### PR TITLE
Add GoReleaser for automated releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.24'
+
+      - name: Run tests
+        run: go test -race -count=1 ./...
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,68 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: pipelock
+    main: ./cmd/pipelock
+    binary: pipelock
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/luckyPipewrench/pipelock/internal/cli.Version={{.Version}}
+      - -X github.com/luckyPipewrench/pipelock/internal/proxy.Version={{.Version}}
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- .Arch }}
+
+checksum:
+  name_template: 'checksums.txt'
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+
+dockers:
+  - image_templates:
+      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-amd64"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+    dockerfile: Dockerfile
+
+  - image_templates:
+      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-arm64"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+    goarch: arm64
+    dockerfile: Dockerfile
+
+docker_manifests:
+  - name_template: "ghcr.io/luckypipewrench/pipelock:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-amd64"
+      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-arm64"
+
+  - name_template: "ghcr.io/luckypipewrench/pipelock:latest"
+    image_templates:
+      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-amd64"
+      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-arm64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN go mod download
 
 COPY . .
 ARG VERSION=0.1.0-dev
-RUN CGO_ENABLED=0 GOOS=linux go build \
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags "-s -w -X github.com/luckyPipewrench/pipelock/internal/cli.Version=${VERSION} \
               -X github.com/luckyPipewrench/pipelock/internal/proxy.Version=${VERSION}" \
     -o /pipelock ./cmd/pipelock


### PR DESCRIPTION
## Summary
- Add `.goreleaser.yaml` for multi-arch binary and Docker image builds
- Add `.github/workflows/release.yaml` triggered on version tags (`v*`)
- Update `Dockerfile` with `TARGETOS`/`TARGETARCH` args for multi-arch support

## How it works
```bash
git tag -a v0.3.0 -m "Release v0.3.0"
git push origin v0.3.0
```
This automatically:
- Runs tests
- Builds binaries for linux/darwin x amd64/arm64
- Builds multi-arch Docker images to `ghcr.io/luckypipewrench/pipelock`
- Creates a GitHub Release with checksums and changelog

## Test plan
- [x] Pre-commit hooks pass (yaml validation, gitleaks)
- [x] Dockerfile still builds locally with existing `docker build` command
- [ ] Tag-triggered release (will verify after merge)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Automated release builds now available across multiple platforms and architectures.
  * Docker images are automatically created and published with each release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->