### PR TITLE
Return non-zero exit code when check --url blocks a URL

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -9,6 +10,9 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
+
+// ErrURLBlocked is returned when pipelock check --url detects a blocked URL.
+var ErrURLBlocked = errors.New("url blocked")
 
 func checkCmd() *cobra.Command {
 	var configFile string
@@ -59,6 +63,10 @@ Examples:
 					fmt.Printf("  Reason:  %s\n", result.Reason)
 				}
 				fmt.Printf("  Score:   %.2f\n", result.Score)
+
+				if !result.Allowed {
+					return ErrURLBlocked
+				}
 			}
 
 			return nil


### PR DESCRIPTION
## Summary
- `pipelock check --url` now exits 1 when the URL is blocked (previously always exited 0)
- Adds exported `ErrURLBlocked` sentinel error for programmatic detection
- Enables scripts and Claude Code hooks to detect blocks via exit code instead of parsing output

## Test plan
- [x] `TestCheckCmd_URLAllowed` — verifies allowed URLs still exit 0
- [x] `TestCheckCmd_URLBlocked` — verifies blocked URLs return `ErrURLBlocked`
- [x] All existing tests pass with `-race`
- [x] Manual verification: `pipelock check --url https://example.com` exits 0, `pipelock check --url https://pastebin.com/raw/abc` exits 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * URL checking now provides explicit error reporting when a URL is blocked, enabling clearer feedback about validation results.

* **Tests**
  * Added test coverage for URL checking behavior, verifying both allowed and blocked URL scenarios to ensure reliable error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->