### PR TITLE
Fix GoReleaser Docker build context

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,18 +43,20 @@ changelog:
 dockers:
   - image_templates:
       - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-amd64"
+    ids: [pipelock]
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.goreleaser
 
   - image_templates:
       - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-arm64"
+    ids: [pipelock]
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64"
     goarch: arm64
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.goreleaser
 
 docker_manifests:
   - name_template: "ghcr.io/luckypipewrench/pipelock:{{ .Version }}"

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,13 @@
+# Used by GoReleaser — copies the pre-built binary instead of building from source.
+# For local/manual builds, use the main Dockerfile instead.
+FROM alpine:3.21 AS certs
+RUN apk add --no-cache ca-certificates
+
+FROM scratch
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY pipelock /pipelock
+
+EXPOSE 8888
+
+ENTRYPOINT ["/pipelock"]
+CMD ["run"]


### PR DESCRIPTION
## Summary
- GoReleaser only copies the pre-built binary into the Docker context, not source files
- The main Dockerfile builds from source and fails with `go.mod: not found`
- Added `Dockerfile.goreleaser` that copies the pre-built binary directly
- Updated `.goreleaser.yaml` to use it with explicit `ids: [pipelock]`

## Test plan
- [x] v0.1.0 release failed at Docker step — this fixes the root cause
- [ ] Re-tag after merge to verify the release workflow succeeds