### PR TITLE
Add multi-agent identification and per-request logging

### DIFF
--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -193,6 +193,17 @@ func (l *Logger) LogShutdown(reason string) {
 		Msg("pipelock stopping")
 }
 
+// With returns a sub-logger that includes the given key-value pair in every
+// log entry. The sub-logger shares the parent's file handle and config but
+// does NOT own the file — only the root logger should be Close()'d.
+func (l *Logger) With(key, value string) *Logger {
+	return &Logger{
+		zl:             l.zl.With().Str(key, value).Logger(),
+		includeAllowed: l.includeAllowed,
+		includeBlocked: l.includeBlocked,
+	}
+}
+
 // Close cleans up the logger, flushing and closing any open file handles.
 // Close is idempotent and safe to call multiple times.
 func (l *Logger) Close() {

--- a/internal/proxy/agent.go
+++ b/internal/proxy/agent.go
@@ -1,0 +1,19 @@
+package proxy
+
+import "net/http"
+
+// AgentHeader is the HTTP header used to identify the calling agent.
+const AgentHeader = "X-Pipelock-Agent"
+
+// ExtractAgent reads the agent name from the request. It checks the
+// X-Pipelock-Agent header first, then the "agent" query parameter,
+// falling back to "anonymous".
+func ExtractAgent(r *http.Request) string {
+	if agent := r.Header.Get(AgentHeader); agent != "" {
+		return agent
+	}
+	if agent := r.URL.Query().Get("agent"); agent != "" {
+		return agent
+	}
+	return "anonymous"
+}

--- a/internal/proxy/agent_test.go
+++ b/internal/proxy/agent_test.go
@@ -1,0 +1,45 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestExtractAgent_Header(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/fetch?url=https://example.com", nil)
+	req.Header.Set(AgentHeader, "my-agent")
+
+	got := ExtractAgent(req)
+	if got != "my-agent" {
+		t.Errorf("expected my-agent, got %s", got)
+	}
+}
+
+func TestExtractAgent_QueryParam(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/fetch?url=https://example.com&agent=query-bot", nil)
+
+	got := ExtractAgent(req)
+	if got != "query-bot" {
+		t.Errorf("expected query-bot, got %s", got)
+	}
+}
+
+func TestExtractAgent_HeaderTakesPrecedence(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/fetch?url=https://example.com&agent=query-bot", nil)
+	req.Header.Set(AgentHeader, "header-bot")
+
+	got := ExtractAgent(req)
+	if got != "header-bot" {
+		t.Errorf("expected header-bot (header precedence), got %s", got)
+	}
+}
+
+func TestExtractAgent_DefaultAnonymous(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/fetch?url=https://example.com", nil)
+
+	got := ExtractAgent(req)
+	if got != "anonymous" { //nolint:goconst // test value
+		t.Errorf("expected anonymous, got %s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Agents identify themselves via `X-Pipelock-Agent` header (or `?agent=` query param, defaulting to `"anonymous"`)
- Every audit log entry includes the agent name via `Logger.With()` sub-loggers (zerolog context propagation)
- Agent name returned in `FetchResponse.Agent` JSON field for client visibility
- Agent context propagates through redirect chains via request context

## Files changed
- `internal/proxy/agent.go` — `ExtractAgent()` + `AgentHeader` constant
- `internal/proxy/agent_test.go` — 4 unit tests for extraction logic
- `internal/proxy/proxy.go` — agent wired through handleFetch, redirect chain, FetchResponse
- `internal/proxy/proxy_test.go` — 4 integration tests (header, query param, default, blocked)
- `internal/audit/logger.go` — `With(key, value)` sub-logger method
- `internal/audit/logger_test.go` — 3 tests (With, parent isolation, config inheritance)

## Test plan
- [x] 296 tests passing with `-race`
- [x] 0 lint issues (`golangci-lint run --new-from-rev=HEAD`)
- [x] All 12 pre-commit hooks pass
- [ ] Verify agent field appears in JSON logs when header is set
- [ ] Verify anonymous fallback when no header/param provided