### PR TITLE
Pass build metadata through Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,17 @@ RUN go mod download
 
 COPY . .
 ARG VERSION=0.1.0-dev
+ARG BUILD_DATE=unknown
+ARG GIT_COMMIT=unknown
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-    -ldflags "-s -w -X github.com/luckyPipewrench/pipelock/internal/cli.Version=${VERSION} \
-              -X github.com/luckyPipewrench/pipelock/internal/proxy.Version=${VERSION}" \
+    -ldflags "-s -w \
+      -X github.com/luckyPipewrench/pipelock/internal/cli.Version=${VERSION} \
+      -X github.com/luckyPipewrench/pipelock/internal/cli.BuildDate=${BUILD_DATE} \
+      -X github.com/luckyPipewrench/pipelock/internal/cli.GitCommit=${GIT_COMMIT} \
+      -X github.com/luckyPipewrench/pipelock/internal/cli.GoVersion=$(go version | awk '{print $3}') \
+      -X github.com/luckyPipewrench/pipelock/internal/proxy.Version=${VERSION}" \
     -o /pipelock ./cmd/pipelock
 
 # Scratch-based final image (~15MB)

--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,8 @@ clean:
 	rm -f $(BINARY) coverage.out coverage.html
 
 docker:
-	docker build -t $(BINARY):$(VERSION) -t $(BINARY):latest .
+	docker build \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg BUILD_DATE=$(BUILD_DATE) \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		-t $(BINARY):$(VERSION) -t $(BINARY):latest .


### PR DESCRIPTION
## Summary
- Dockerfile now accepts BUILD_DATE and GIT_COMMIT build args alongside VERSION
- Makefile docker target passes all build metadata args
- GoVersion is computed inside the build container for accuracy

## Test plan
- [x] `make docker` builds with correct version metadata
- [x] Container `pipelock version` shows build date and commit