### PR TITLE
Fix Docker container reachability and add healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,8 @@ COPY --from=builder /pipelock /pipelock
 
 EXPOSE 8888
 
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+  CMD ["/pipelock", "healthcheck"]
+
 ENTRYPOINT ["/pipelock"]
-CMD ["run"]
+CMD ["run", "--listen", "0.0.0.0:8888"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -9,5 +9,8 @@ COPY pipelock /pipelock
 
 EXPOSE 8888
 
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+  CMD ["/pipelock", "healthcheck"]
+
 ENTRYPOINT ["/pipelock"]
-CMD ["run"]
+CMD ["run", "--listen", "0.0.0.0:8888"]

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -394,3 +394,45 @@ func TestMatchFilter_NonJSON(t *testing.T) {
 		t.Error("expected no match when substring not present")
 	}
 }
+
+func TestHealthcheckCmd_NoServer(t *testing.T) {
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"healthcheck", "--addr", "127.0.0.1:19999"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error when no server is running")
+	}
+}
+
+func TestHealthcheckCmd_RegisteredInHelp(t *testing.T) {
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"--help"})
+
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "healthcheck") {
+		t.Error("expected help output to list 'healthcheck' command")
+	}
+}
+
+func TestRunCmd_ListenFlag(t *testing.T) {
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"run", "--help"})
+
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "--listen") {
+		t.Error("expected run --help to show --listen flag")
+	}
+}

--- a/internal/cli/healthcheck.go
+++ b/internal/cli/healthcheck.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func healthcheckCmd() *cobra.Command {
+	var addr string
+
+	cmd := &cobra.Command{
+		Use:   "healthcheck",
+		Short: "Check if the proxy is healthy (for Docker HEALTHCHECK)",
+		Long: `Sends a GET request to the proxy's /health endpoint and exits
+with code 0 if healthy, 1 otherwise. Designed for use as a Docker HEALTHCHECK command.
+
+Examples:
+  pipelock healthcheck
+  pipelock healthcheck --addr 0.0.0.0:8888`,
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://%s/health", addr), nil)
+			if err != nil {
+				return fmt.Errorf("health check failed: %w", err)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return fmt.Errorf("health check failed: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("unhealthy: status %d", resp.StatusCode)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&addr, "addr", "127.0.0.1:8888", "proxy address to check")
+
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -47,6 +47,7 @@ Quick start:
 		generateCmd(),
 		gitCmd(),
 		versionCmd(),
+		healthcheckCmd(),
 	)
 
 	return cmd

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -19,6 +19,7 @@ import (
 func runCmd() *cobra.Command {
 	var configFile string
 	var mode string
+	var listen string
 
 	cmd := &cobra.Command{
 		Use:   "run [flags] [-- <command> [args...]]",
@@ -47,13 +48,17 @@ Examples:
 				cfg = config.Defaults()
 			}
 
-			// Override mode from flag if provided
+			// Override flags if provided
 			if cmd.Flags().Changed("mode") {
 				cfg.Mode = mode
-				cfg.ApplyDefaults()
-				if err := cfg.Validate(); err != nil {
-					return fmt.Errorf("invalid config: %w", err)
-				}
+			}
+			if cmd.Flags().Changed("listen") {
+				cfg.FetchProxy.Listen = listen
+			}
+
+			cfg.ApplyDefaults()
+			if err := cfg.Validate(); err != nil {
+				return fmt.Errorf("invalid config: %w", err)
 			}
 
 			// Set up audit logger
@@ -136,6 +141,7 @@ Examples:
 
 	cmd.Flags().StringVarP(&configFile, "config", "c", "", "config file path")
 	cmd.Flags().StringVarP(&mode, "mode", "m", "balanced", "operating mode: strict, balanced, audit")
+	cmd.Flags().StringVarP(&listen, "listen", "l", "", "listen address (default 127.0.0.1:8888)")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

- **`--listen` flag on `run` command** — Override listen address without a config file, useful for Docker CMD overrides
- **`healthcheck` subcommand** — Hits `/health` endpoint and exits 0/1, needed for Docker HEALTHCHECK since scratch images have no curl/wget
- **Docker listen address fixed** — CMD now uses `0.0.0.0:8888` instead of the default `127.0.0.1:8888`, which is unreachable from other containers in a compose stack
- **HEALTHCHECK directive** in both Dockerfiles — Enables `depends_on: condition: service_healthy` in Docker Compose

## Why

The default `127.0.0.1` listen address silently breaks Docker Compose deployments. Other containers resolve the `pipelock` service name to the container's bridge IP, but the proxy only listens on loopback. This is the most common "it works locally but not in Docker" issue.

## Test plan

- [x] `TestHealthcheckCmd_NoServer` — verifies error when no proxy running
- [x] `TestHealthcheckCmd_RegisteredInHelp` — verifies command appears in help
- [x] `TestRunCmd_ListenFlag` — verifies `--listen` flag exists
- [x] Full suite passing (~300 tests with `-race`)
- [x] golangci-lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a healthcheck command to verify service availability.
  * Added a --listen flag to the run command for configurable network address binding.

* **Tests**
  * Added test coverage for the healthcheck command and listen flag.

* **Chores**
  * Updated Docker configurations with built-in health checks and explicit listen address configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->