### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-02-08
+
 ### Changed
 - CLI commands write to `cmd.OutOrStdout()` instead of `os.Stdout` (cobra-idiomatic)
 - `run` command uses `cmd.Context()` as signal parent for testability
@@ -17,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Base64url environment variable leak detection test
 - Rate limiter window rollover test
 - Healthcheck command test against running server
+- 363 tests passing with `-race`
 
 ## [0.1.0] - 2026-02-08
 


### PR DESCRIPTION
## Summary
- Bumps CHANGELOG for v0.1.1 release
- Covers PRs #24 (medium test coverage) and #25 (CLI refactor + run integration test)
- 363 tests passing with `-race`

## After merge
Tag `v0.1.1` on the merge commit to trigger GoReleaser → GHCR image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * CLI now correctly writes output to standard output
  * Command execution improvements for better reliability

* **Tests**
  * Added comprehensive test coverage for configuration loading, Docker Compose validation, base64url security, rate limiting, and health checks with 363 tests passing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->