### PR TITLE
Mark Phase 1.5 planning doc as complete

### DIFF
--- a/docs/planning/phase-1.5-codeql-lint-coverage.md
+++ b/docs/planning/phase-1.5-codeql-lint-coverage.md
@@ -1,8 +1,8 @@
 # Phase 1.5: CodeQL, Lint Cleanup, Code Coverage
 
 **Date:** 2026-02-08
-**Status:** In progress
-**PRs:** #28 (lint cleanup), #29 (CodeQL + Codecov)
+**Status:** Complete (v0.1.2)
+**PRs:** #28 (lint cleanup), #29 (CodeQL + Codecov) — both merged
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Update `docs/planning/phase-1.5-codeql-lint-coverage.md` status from "In progress" to "Complete (v0.1.2)"

Docs-only change, no code impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Phase 1.5 planning documentation to reflect completion status (v0.1.2), confirming the integration of CodeQL lint coverage improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->