### PR TITLE
Add Ed25519 signing for file and manifest verification

### DIFF
--- a/internal/cli/keygen.go
+++ b/internal/cli/keygen.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func keygenCmd() *cobra.Command {
+	var keystoreDir string
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "keygen <agent-name>",
+		Short: "Generate an Ed25519 key pair for an agent",
+		Long: `Generates an Ed25519 signing key pair and stores it in the pipelock
+keystore (~/.pipelock/agents/<name>/). The public key can be shared with other
+agents via 'pipelock trust'.
+
+Examples:
+  pipelock keygen claude-code
+  pipelock keygen buster --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			out := cmd.OutOrStdout()
+
+			dir, err := resolveKeystoreDir(keystoreDir)
+			if err != nil {
+				return err
+			}
+			ks := signing.NewKeystore(dir)
+
+			var pub []byte
+			if force {
+				pub, err = ks.ForceGenerateAgent(name)
+			} else {
+				pub, err = ks.GenerateAgent(name)
+			}
+			if err != nil {
+				return err
+			}
+
+			pubPath := ks.PublicKeyPath(name)
+			_, _ = fmt.Fprintf(out, "Key pair generated for agent %q\n", name)
+			_, _ = fmt.Fprintf(out, "Public key: %s\n", pubPath)
+			_, _ = fmt.Fprintf(out, "Share with: pipelock trust %s %s\n", name, pubPath)
+
+			_ = pub // key returned for programmatic use
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&keystoreDir, "dir", "", "keystore directory (default ~/.pipelock)")
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite existing keys")
+	return cmd
+}
+
+func resolveKeystoreDir(explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	return signing.DefaultKeystorePath()
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -47,6 +47,10 @@ Quick start:
 		generateCmd(),
 		gitCmd(),
 		integrityCmd(),
+		keygenCmd(),
+		signCmd(),
+		verifyCmd(),
+		trustCmd(),
 		versionCmd(),
 		healthcheckCmd(),
 	)

--- a/internal/cli/sign.go
+++ b/internal/cli/sign.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func signCmd() *cobra.Command {
+	var keystoreDir string
+	var agent string
+
+	cmd := &cobra.Command{
+		Use:   "sign <file>",
+		Short: "Sign a file with an agent's Ed25519 key",
+		Long: `Creates a detached Ed25519 signature (<file>.sig) using the specified
+agent's private key.
+
+Agent resolution order: --agent flag, PIPELOCK_AGENT env var.
+
+Examples:
+  pipelock sign manifest.json --agent claude-code
+  PIPELOCK_AGENT=buster pipelock sign handoff.md`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := args[0]
+			out := cmd.OutOrStdout()
+
+			agentName, err := resolveAgentName(agent)
+			if err != nil {
+				return err
+			}
+
+			dir, err := resolveKeystoreDir(keystoreDir)
+			if err != nil {
+				return err
+			}
+			ks := signing.NewKeystore(dir)
+
+			privKey, err := ks.LoadPrivateKey(agentName)
+			if err != nil {
+				return fmt.Errorf("loading key for agent %q: %w", agentName, err)
+			}
+
+			sig, err := signing.SignFile(path, privKey)
+			if err != nil {
+				return err
+			}
+
+			sigPath := path + signing.SigExtension
+			if err := signing.SaveSignature(sig, sigPath); err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(out, "Signed %s (agent: %s)\n", path, agentName)
+			_, _ = fmt.Fprintf(out, "Signature: %s\n", sigPath)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&keystoreDir, "dir", "", "keystore directory (default ~/.pipelock)")
+	cmd.Flags().StringVar(&agent, "agent", "", "agent name (or set PIPELOCK_AGENT)")
+	return cmd
+}
+
+func verifyCmd() *cobra.Command {
+	var keystoreDir string
+	var agent string
+	var sigPath string
+
+	cmd := &cobra.Command{
+		Use:   "verify <file>",
+		Short: "Verify a file's Ed25519 signature",
+		Long: `Verifies a file against its detached signature (<file>.sig or --sig path)
+using the specified agent's public key. Checks both the agent's own keys and
+trusted keys.
+
+Exit 0 = valid signature, exit 1 = invalid or missing.
+
+Examples:
+  pipelock verify manifest.json --agent claude-code
+  pipelock verify handoff.md --agent buster --sig handoff.md.sig`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := args[0]
+			out := cmd.OutOrStdout()
+
+			agentName, err := resolveAgentName(agent)
+			if err != nil {
+				return err
+			}
+
+			dir, err := resolveKeystoreDir(keystoreDir)
+			if err != nil {
+				return err
+			}
+			ks := signing.NewKeystore(dir)
+
+			pubKey, err := ks.ResolvePublicKey(agentName)
+			if err != nil {
+				return fmt.Errorf("loading key for agent %q: %w", agentName, err)
+			}
+
+			if err := signing.VerifyFile(path, sigPath, pubKey); err != nil {
+				_, _ = fmt.Fprintf(out, "FAILED: %s (agent: %s): %v\n", path, agentName, err)
+				return fmt.Errorf("verification failed")
+			}
+
+			_, _ = fmt.Fprintf(out, "OK: %s (agent: %s)\n", path, agentName)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&keystoreDir, "dir", "", "keystore directory (default ~/.pipelock)")
+	cmd.Flags().StringVar(&agent, "agent", "", "agent name (or set PIPELOCK_AGENT)")
+	cmd.Flags().StringVar(&sigPath, "sig", "", "signature file path (default <file>.sig)")
+	return cmd
+}
+
+func resolveAgentName(explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	if env := os.Getenv("PIPELOCK_AGENT"); env != "" {
+		return env, nil
+	}
+	return "", fmt.Errorf("agent name required: use --agent or set PIPELOCK_AGENT")
+}

--- a/internal/cli/signing_test.go
+++ b/internal/cli/signing_test.go
@@ -1,0 +1,406 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestKeygenCmd_Basic(t *testing.T) {
+	dir := t.TempDir()
+
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"keygen", "alice", "--dir", dir})
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("keygen error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "alice") {
+		t.Errorf("output should mention agent name, got: %s", output)
+	}
+
+	// Verify key files exist.
+	privPath := filepath.Join(dir, "agents", "alice", "id_ed25519")
+	if _, err := os.Stat(privPath); err != nil {
+		t.Errorf("private key not created: %v", err)
+	}
+}
+
+func TestKeygenCmd_AlreadyExists(t *testing.T) {
+	dir := t.TempDir()
+
+	cmd1 := rootCmd()
+	cmd1.SetArgs([]string{"keygen", "alice", "--dir", dir})
+	cmd1.SetOut(&strings.Builder{})
+	if err := cmd1.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd2 := rootCmd()
+	cmd2.SetArgs([]string{"keygen", "alice", "--dir", dir})
+	cmd2.SetOut(&strings.Builder{})
+	if err := cmd2.Execute(); err == nil {
+		t.Fatal("expected error for duplicate keygen")
+	}
+}
+
+func TestKeygenCmd_Force(t *testing.T) {
+	dir := t.TempDir()
+
+	cmd1 := rootCmd()
+	cmd1.SetArgs([]string{"keygen", "alice", "--dir", dir})
+	cmd1.SetOut(&strings.Builder{})
+	if err := cmd1.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd2 := rootCmd()
+	cmd2.SetArgs([]string{"keygen", "alice", "--dir", dir, "--force"})
+	buf := &strings.Builder{}
+	cmd2.SetOut(buf)
+	if err := cmd2.Execute(); err != nil {
+		t.Fatalf("keygen --force error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "alice") {
+		t.Errorf("expected output mentioning alice, got: %s", buf.String())
+	}
+}
+
+func TestKeygenCmd_NoArgs(t *testing.T) {
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"keygen"})
+	cmd.SetOut(&strings.Builder{})
+	cmd.SetErr(&strings.Builder{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for missing agent name")
+	}
+}
+
+func TestSignCmd_Basic(t *testing.T) {
+	dir := t.TempDir()
+
+	// Generate key.
+	ks := signing.NewKeystore(dir)
+	if _, err := ks.GenerateAgent("alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a file to sign.
+	testFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(testFile, []byte("hello world\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"sign", testFile, "--agent", "alice", "--dir", dir})
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("sign error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Signed") {
+		t.Errorf("expected 'Signed' in output, got: %s", output)
+	}
+
+	// Verify .sig file was created.
+	sigPath := testFile + ".sig"
+	if _, err := os.Stat(sigPath); err != nil {
+		t.Errorf("signature file not created: %v", err)
+	}
+}
+
+func TestSignCmd_NoAgent(t *testing.T) {
+	testFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(testFile, []byte("content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure env is not set.
+	t.Setenv("PIPELOCK_AGENT", "")
+
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"sign", testFile})
+	cmd.SetOut(&strings.Builder{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when no agent specified")
+	}
+}
+
+func TestSignCmd_EnvAgent(t *testing.T) {
+	dir := t.TempDir()
+
+	ks := signing.NewKeystore(dir)
+	if _, err := ks.GenerateAgent("envbot"); err != nil {
+		t.Fatal(err)
+	}
+
+	testFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(testFile, []byte("env test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PIPELOCK_AGENT", "envbot")
+
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"sign", testFile, "--dir", dir})
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("sign with env agent error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "envbot") {
+		t.Errorf("expected 'envbot' in output, got: %s", buf.String())
+	}
+}
+
+func TestVerifyCmd_Valid(t *testing.T) {
+	dir := t.TempDir()
+
+	ks := signing.NewKeystore(dir)
+	if _, err := ks.GenerateAgent("alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	testFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(testFile, []byte("verified content\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign.
+	signC := rootCmd()
+	signC.SetArgs([]string{"sign", testFile, "--agent", "alice", "--dir", dir})
+	signC.SetOut(&strings.Builder{})
+	if err := signC.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify.
+	verifyC := rootCmd()
+	verifyC.SetArgs([]string{"verify", testFile, "--agent", "alice", "--dir", dir})
+	buf := &strings.Builder{}
+	verifyC.SetOut(buf)
+
+	if err := verifyC.Execute(); err != nil {
+		t.Fatalf("verify error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "OK") {
+		t.Errorf("expected 'OK' in output, got: %s", buf.String())
+	}
+}
+
+func TestVerifyCmd_TamperedFile(t *testing.T) {
+	dir := t.TempDir()
+
+	ks := signing.NewKeystore(dir)
+	if _, err := ks.GenerateAgent("alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	testFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(testFile, []byte("original\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign.
+	signC := rootCmd()
+	signC.SetArgs([]string{"sign", testFile, "--agent", "alice", "--dir", dir})
+	signC.SetOut(&strings.Builder{})
+	if err := signC.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Tamper.
+	if err := os.WriteFile(testFile, []byte("tampered\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify should fail.
+	verifyC := rootCmd()
+	verifyC.SetArgs([]string{"verify", testFile, "--agent", "alice", "--dir", dir})
+	buf := &strings.Builder{}
+	verifyC.SetOut(buf)
+
+	if err := verifyC.Execute(); err == nil {
+		t.Fatal("expected error for tampered file")
+	}
+	if !strings.Contains(buf.String(), "FAILED") {
+		t.Errorf("expected 'FAILED' in output, got: %s", buf.String())
+	}
+}
+
+func TestVerifyCmd_MissingSig(t *testing.T) {
+	dir := t.TempDir()
+
+	ks := signing.NewKeystore(dir)
+	if _, err := ks.GenerateAgent("alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	testFile := filepath.Join(t.TempDir(), "nosig.txt")
+	if err := os.WriteFile(testFile, []byte("no sig\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"verify", testFile, "--agent", "alice", "--dir", dir})
+	cmd.SetOut(&strings.Builder{})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for missing signature")
+	}
+}
+
+func TestVerifyCmd_WrongAgent(t *testing.T) {
+	dir := t.TempDir()
+
+	ks := signing.NewKeystore(dir)
+	if _, err := ks.GenerateAgent("alice"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ks.GenerateAgent("bob"); err != nil {
+		t.Fatal(err)
+	}
+
+	testFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(testFile, []byte("alice signed this\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign as alice.
+	signC := rootCmd()
+	signC.SetArgs([]string{"sign", testFile, "--agent", "alice", "--dir", dir})
+	signC.SetOut(&strings.Builder{})
+	if err := signC.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify as bob should fail.
+	verifyC := rootCmd()
+	verifyC.SetArgs([]string{"verify", testFile, "--agent", "bob", "--dir", dir})
+	verifyC.SetOut(&strings.Builder{})
+
+	if err := verifyC.Execute(); err == nil {
+		t.Fatal("expected error when verifying with wrong agent's key")
+	}
+}
+
+func TestTrustCmd_Basic(t *testing.T) {
+	dir := t.TempDir()
+
+	ks := signing.NewKeystore(dir)
+	if _, err := ks.GenerateAgent("remote"); err != nil {
+		t.Fatal(err)
+	}
+	pubKeyPath := ks.PublicKeyPath("remote")
+
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"trust", "remote", pubKeyPath, "--dir", dir})
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("trust error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Trusted") {
+		t.Errorf("expected 'Trusted' in output, got: %s", buf.String())
+	}
+
+	// Verify trusted key can be loaded.
+	_, err := ks.LoadTrustedKey("remote")
+	if err != nil {
+		t.Fatalf("trusted key not loadable: %v", err)
+	}
+}
+
+func TestTrustCmd_InvalidKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	badFile := filepath.Join(t.TempDir(), "bad.pub")
+	if err := os.WriteFile(badFile, []byte("not a key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"trust", "bad-agent", badFile, "--dir", dir})
+	cmd.SetOut(&strings.Builder{})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for invalid key file")
+	}
+}
+
+func TestSignVerify_EndToEnd(t *testing.T) {
+	ksDir := t.TempDir()
+	workspace := t.TempDir()
+
+	// Generate key pair.
+	keygenC := rootCmd()
+	keygenC.SetArgs([]string{"keygen", "test-agent", "--dir", ksDir})
+	keygenC.SetOut(&strings.Builder{})
+	if err := keygenC.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create workspace file.
+	testFile := filepath.Join(workspace, "config.yaml")
+	if err := os.WriteFile(testFile, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign.
+	signC := rootCmd()
+	signC.SetArgs([]string{"sign", testFile, "--agent", "test-agent", "--dir", ksDir})
+	signC.SetOut(&strings.Builder{})
+	if err := signC.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify (should pass).
+	verifyC := rootCmd()
+	verifyC.SetArgs([]string{"verify", testFile, "--agent", "test-agent", "--dir", ksDir})
+	verifyBuf := &strings.Builder{}
+	verifyC.SetOut(verifyBuf)
+	if err := verifyC.Execute(); err != nil {
+		t.Fatalf("end-to-end verify failed: %v", err)
+	}
+	if !strings.Contains(verifyBuf.String(), "OK") {
+		t.Errorf("expected OK, got: %s", verifyBuf.String())
+	}
+
+	// Tamper and re-verify (should fail).
+	if err := os.WriteFile(testFile, []byte("mode: strict\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	verifyC2 := rootCmd()
+	verifyC2.SetArgs([]string{"verify", testFile, "--agent", "test-agent", "--dir", ksDir})
+	verifyC2.SetOut(&strings.Builder{})
+	if err := verifyC2.Execute(); err == nil {
+		t.Fatal("expected verification failure after tampering")
+	}
+}
+
+func TestKeygenCmd_RegisteredInHelp(t *testing.T) {
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"--help"})
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+
+	_ = cmd.Execute()
+	output := buf.String()
+
+	for _, sub := range []string{"keygen", "sign", "verify", "trust"} {
+		if !strings.Contains(output, sub) {
+			t.Errorf("root help should list %q command", sub)
+		}
+	}
+}

--- a/internal/cli/trust.go
+++ b/internal/cli/trust.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func trustCmd() *cobra.Command {
+	var keystoreDir string
+
+	cmd := &cobra.Command{
+		Use:   "trust <agent-name> <pubkey-file>",
+		Short: "Add an agent's public key to the trusted keystore",
+		Long: `Copies an agent's Ed25519 public key into the trusted keystore
+(~/.pipelock/trusted_keys/<name>.pub). The key is validated before storing.
+
+After trusting, you can verify that agent's signatures with 'pipelock verify'.
+
+Examples:
+  pipelock trust buster /path/to/buster.pub
+  pipelock trust claude-code ~/.pipelock/agents/claude-code/id_ed25519.pub`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			pubKeyPath := args[1]
+			out := cmd.OutOrStdout()
+
+			dir, err := resolveKeystoreDir(keystoreDir)
+			if err != nil {
+				return err
+			}
+			ks := signing.NewKeystore(dir)
+
+			if err := ks.TrustKey(name, pubKeyPath); err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(out, "Trusted agent %q\n", name)
+			_, _ = fmt.Fprintf(out, "Verify with: pipelock verify <file> --agent %s\n", name)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&keystoreDir, "dir", "", "keystore directory (default ~/.pipelock)")
+	return cmd
+}

--- a/internal/integrity/check.go
+++ b/internal/integrity/check.go
@@ -27,7 +27,7 @@ type Violation struct {
 }
 
 // alwaysExcluded are basenames that are always skipped during directory walks.
-var alwaysExcluded = []string{".git", DefaultManifestFile}
+var alwaysExcluded = []string{".git", DefaultManifestFile, DefaultManifestFile + ".sig"}
 
 // Generate walks a directory tree and produces a new manifest.
 func Generate(dir string, excludes []string) (*Manifest, error) {

--- a/internal/signing/keystore.go
+++ b/internal/signing/keystore.go
@@ -1,0 +1,244 @@
+package signing
+
+import (
+	"crypto/ed25519"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+)
+
+// DefaultPipelockDir is the directory name for pipelock key storage.
+const DefaultPipelockDir = ".pipelock"
+
+const (
+	agentsSubdir     = "agents"
+	trustedSubdir    = "trusted_keys"
+	privateKeyFile   = "id_ed25519"
+	publicKeyFile    = "id_ed25519.pub"
+	maxAgentNameLen  = 64
+	dirPermission    = 0o700
+	trustedPubSuffix = ".pub"
+)
+
+// agentNameRe matches characters NOT allowed in agent names.
+// Same rule as internal/proxy/agent.go for consistency.
+var agentNameRe = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
+
+// Keystore manages Ed25519 keys on disk under a base directory.
+type Keystore struct {
+	baseDir string
+}
+
+// NewKeystore creates a Keystore rooted at baseDir.
+func NewKeystore(baseDir string) *Keystore {
+	return &Keystore{baseDir: baseDir}
+}
+
+// DefaultKeystorePath returns ~/.pipelock, resolving the home directory.
+func DefaultKeystorePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, DefaultPipelockDir), nil
+}
+
+// SanitizeAgentName cleans an agent name to safe characters.
+func SanitizeAgentName(name string) string {
+	name = agentNameRe.ReplaceAllString(name, "_")
+	if len(name) > maxAgentNameLen {
+		name = name[:maxAgentNameLen]
+	}
+	return name
+}
+
+// ValidateAgentName checks that a name is non-empty and already clean.
+func ValidateAgentName(name string) error {
+	if name == "" {
+		return fmt.Errorf("agent name cannot be empty")
+	}
+	if sanitized := SanitizeAgentName(name); sanitized != name {
+		return fmt.Errorf("agent name %q contains invalid characters (use %q)", name, sanitized)
+	}
+	return nil
+}
+
+// GenerateAgent creates a new Ed25519 key pair for an agent.
+// Returns an error if keys already exist (caller should check AgentExists first
+// or pass force=true through the CLI).
+func (k *Keystore) GenerateAgent(name string) (ed25519.PublicKey, error) {
+	if err := ValidateAgentName(name); err != nil {
+		return nil, err
+	}
+
+	dir := k.agentDir(name)
+	if k.AgentExists(name) {
+		return nil, fmt.Errorf("keys already exist for agent %q (use --force to overwrite)", name)
+	}
+
+	if err := os.MkdirAll(dir, dirPermission); err != nil {
+		return nil, fmt.Errorf("creating agent directory: %w", err)
+	}
+
+	pub, priv, err := GenerateKeyPair()
+	if err != nil {
+		return nil, err
+	}
+
+	privPath := filepath.Join(dir, privateKeyFile)
+	pubPath := filepath.Join(dir, publicKeyFile)
+
+	if err := SavePrivateKey(priv, privPath); err != nil {
+		return nil, fmt.Errorf("saving private key: %w", err)
+	}
+	if err := SavePublicKey(pub, pubPath); err != nil {
+		return nil, fmt.Errorf("saving public key: %w", err)
+	}
+
+	return pub, nil
+}
+
+// ForceGenerateAgent creates a new key pair, overwriting any existing keys.
+func (k *Keystore) ForceGenerateAgent(name string) (ed25519.PublicKey, error) {
+	if err := ValidateAgentName(name); err != nil {
+		return nil, err
+	}
+
+	dir := k.agentDir(name)
+	if err := os.MkdirAll(dir, dirPermission); err != nil {
+		return nil, fmt.Errorf("creating agent directory: %w", err)
+	}
+
+	pub, priv, err := GenerateKeyPair()
+	if err != nil {
+		return nil, err
+	}
+
+	privPath := filepath.Join(dir, privateKeyFile)
+	pubPath := filepath.Join(dir, publicKeyFile)
+
+	if err := SavePrivateKey(priv, privPath); err != nil {
+		return nil, fmt.Errorf("saving private key: %w", err)
+	}
+	if err := SavePublicKey(pub, pubPath); err != nil {
+		return nil, fmt.Errorf("saving public key: %w", err)
+	}
+
+	return pub, nil
+}
+
+// LoadPrivateKey loads an agent's private key from the keystore.
+func (k *Keystore) LoadPrivateKey(name string) (ed25519.PrivateKey, error) {
+	path := filepath.Join(k.agentDir(name), privateKeyFile)
+	return LoadPrivateKeyFile(path)
+}
+
+// LoadPublicKey loads an agent's own public key from the keystore.
+func (k *Keystore) LoadPublicKey(name string) (ed25519.PublicKey, error) {
+	path := filepath.Join(k.agentDir(name), publicKeyFile)
+	return LoadPublicKeyFile(path)
+}
+
+// TrustKey copies a public key file into trusted_keys/<name>.pub.
+func (k *Keystore) TrustKey(name, pubKeyPath string) error {
+	if err := ValidateAgentName(name); err != nil {
+		return err
+	}
+
+	// Validate the key file before copying.
+	if _, err := LoadPublicKeyFile(pubKeyPath); err != nil {
+		return fmt.Errorf("invalid public key file: %w", err)
+	}
+
+	dir := filepath.Join(k.baseDir, trustedSubdir)
+	if err := os.MkdirAll(dir, dirPermission); err != nil {
+		return fmt.Errorf("creating trusted keys directory: %w", err)
+	}
+
+	data, err := os.ReadFile(pubKeyPath) //nolint:gosec // G304: caller controls path
+	if err != nil {
+		return fmt.Errorf("reading public key: %w", err)
+	}
+
+	dest := k.trustedKeyPath(name)
+	return atomicWrite(dest, data, 0o644)
+}
+
+// LoadTrustedKey loads a trusted agent's public key.
+func (k *Keystore) LoadTrustedKey(name string) (ed25519.PublicKey, error) {
+	return LoadPublicKeyFile(k.trustedKeyPath(name))
+}
+
+// ResolvePublicKey looks up a public key by agent name, checking the agent's
+// own keys first, then trusted keys.
+func (k *Keystore) ResolvePublicKey(name string) (ed25519.PublicKey, error) {
+	if pub, err := k.LoadPublicKey(name); err == nil {
+		return pub, nil
+	}
+	return k.LoadTrustedKey(name)
+}
+
+// AgentExists returns whether keys exist for the given agent.
+func (k *Keystore) AgentExists(name string) bool {
+	privPath := filepath.Join(k.agentDir(name), privateKeyFile)
+	_, err := os.Stat(privPath)
+	return err == nil
+}
+
+// ListAgents returns all agent names with generated keys.
+func (k *Keystore) ListAgents() ([]string, error) {
+	dir := filepath.Join(k.baseDir, agentsSubdir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("listing agents: %w", err)
+	}
+
+	var agents []string
+	for _, e := range entries {
+		if e.IsDir() {
+			agents = append(agents, e.Name())
+		}
+	}
+	sort.Strings(agents)
+	return agents, nil
+}
+
+// ListTrusted returns all trusted agent names.
+func (k *Keystore) ListTrusted() ([]string, error) {
+	dir := filepath.Join(k.baseDir, trustedSubdir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("listing trusted keys: %w", err)
+	}
+
+	var trusted []string
+	for _, e := range entries {
+		name := e.Name()
+		if !e.IsDir() && filepath.Ext(name) == trustedPubSuffix {
+			trusted = append(trusted, name[:len(name)-len(trustedPubSuffix)])
+		}
+	}
+	sort.Strings(trusted)
+	return trusted, nil
+}
+
+func (k *Keystore) agentDir(name string) string {
+	return filepath.Join(k.baseDir, agentsSubdir, name)
+}
+
+func (k *Keystore) trustedKeyPath(name string) string {
+	return filepath.Join(k.baseDir, trustedSubdir, name+trustedPubSuffix)
+}
+
+// PublicKeyPath returns the path to an agent's public key file.
+func (k *Keystore) PublicKeyPath(name string) string {
+	return filepath.Join(k.agentDir(name), publicKeyFile)
+}

--- a/internal/signing/keystore_test.go
+++ b/internal/signing/keystore_test.go
@@ -1,0 +1,320 @@
+package signing
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestKeystoreGenerateAgent(t *testing.T) {
+	ks := NewKeystore(t.TempDir())
+
+	pub, err := ks.GenerateAgent("alice")
+	if err != nil {
+		t.Fatalf("GenerateAgent() error: %v", err)
+	}
+	if pub == nil {
+		t.Fatal("expected non-nil public key")
+	}
+
+	// Check files were created.
+	dir := ks.agentDir("alice")
+	if _, err := os.Stat(filepath.Join(dir, privateKeyFile)); err != nil {
+		t.Errorf("private key file missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, publicKeyFile)); err != nil {
+		t.Errorf("public key file missing: %v", err)
+	}
+}
+
+func TestKeystoreGenerateAgent_AlreadyExists(t *testing.T) {
+	ks := NewKeystore(t.TempDir())
+
+	if _, err := ks.GenerateAgent("alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ks.GenerateAgent("alice")
+	if err == nil {
+		t.Fatal("expected error for duplicate agent")
+	}
+}
+
+func TestKeystoreForceGenerateAgent(t *testing.T) {
+	ks := NewKeystore(t.TempDir())
+
+	pub1, err := ks.GenerateAgent("alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pub2, err := ks.ForceGenerateAgent("alice")
+	if err != nil {
+		t.Fatalf("ForceGenerateAgent() error: %v", err)
+	}
+
+	// Keys should be different (crypto/rand).
+	if equal(pub1, pub2) {
+		t.Fatal("forced regeneration produced identical key")
+	}
+}
+
+func TestKeystoreLoadKeys(t *testing.T) {
+	ks := NewKeystore(t.TempDir())
+
+	pub, err := ks.GenerateAgent("bob")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loadedPub, err := ks.LoadPublicKey("bob")
+	if err != nil {
+		t.Fatalf("LoadPublicKey() error: %v", err)
+	}
+	if !equal(pub, loadedPub) {
+		t.Fatal("loaded public key does not match generated key")
+	}
+
+	priv, err := ks.LoadPrivateKey("bob")
+	if err != nil {
+		t.Fatalf("LoadPrivateKey() error: %v", err)
+	}
+	if priv == nil {
+		t.Fatal("expected non-nil private key")
+	}
+}
+
+func TestKeystoreLoadPrivateKey_NotFound(t *testing.T) {
+	ks := NewKeystore(t.TempDir())
+
+	_, err := ks.LoadPrivateKey("nobody")
+	if err == nil {
+		t.Fatal("expected error for nonexistent agent")
+	}
+}
+
+func TestKeystoreTrustKey(t *testing.T) {
+	ks := NewKeystore(t.TempDir())
+
+	// Generate a key to trust.
+	if _, err := ks.GenerateAgent("remote-agent"); err != nil {
+		t.Fatal(err)
+	}
+	pubKeyPath := ks.PublicKeyPath("remote-agent")
+
+	// Trust it under a different name.
+	if err := ks.TrustKey("remote-agent", pubKeyPath); err != nil {
+		t.Fatalf("TrustKey() error: %v", err)
+	}
+
+	trusted, err := ks.LoadTrustedKey("remote-agent")
+	if err != nil {
+		t.Fatalf("LoadTrustedKey() error: %v", err)
+	}
+
+	original, _ := ks.LoadPublicKey("remote-agent")
+	if !equal(trusted, original) {
+		t.Fatal("trusted key does not match original")
+	}
+}
+
+func TestKeystoreTrustKey_InvalidFile(t *testing.T) {
+	ks := NewKeystore(t.TempDir())
+
+	// Write garbage to a file.
+	bad := filepath.Join(t.TempDir(), "bad.pub")
+	if err := os.WriteFile(bad, []byte("not a key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ks.TrustKey("bad-agent", bad)
+	if err == nil {
+		t.Fatal("expected error for invalid key file")
+	}
+}
+
+func TestKeystoreLoadTrustedKey_NotFound(t *testing.T) {
+	ks := NewKeystore(t.TempDir())
+
+	_, err := ks.LoadTrustedKey("nobody")
+	if err == nil {
+		t.Fatal("expected error for nonexistent trusted key")
+	}
+}
+
+func TestKeystoreResolvePublicKey_OwnKey(t *testing.T) {
+	ks := NewKeystore(t.TempDir())
+
+	pub, err := ks.GenerateAgent("self")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := ks.ResolvePublicKey("self")
+	if err != nil {
+		t.Fatalf("ResolvePublicKey() error: %v", err)
+	}
+	if !equal(pub, resolved) {
+		t.Fatal("resolved key does not match own key")
+	}
+}
+
+func TestKeystoreResolvePublicKey_TrustedKey(t *testing.T) {
+	ks := NewKeystore(t.TempDir())
+
+	if _, err := ks.GenerateAgent("remote"); err != nil {
+		t.Fatal(err)
+	}
+	pubPath := ks.PublicKeyPath("remote")
+
+	// Trust the key, then remove the agent directory so only trusted remains.
+	if err := ks.TrustKey("remote", pubPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(ks.agentDir("remote")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ks.ResolvePublicKey("remote")
+	if err != nil {
+		t.Fatalf("ResolvePublicKey() should find trusted key: %v", err)
+	}
+}
+
+func TestKeystoreAgentExists(t *testing.T) {
+	ks := NewKeystore(t.TempDir())
+
+	if ks.AgentExists("ghost") {
+		t.Fatal("expected false for nonexistent agent")
+	}
+
+	if _, err := ks.GenerateAgent("exists"); err != nil {
+		t.Fatal(err)
+	}
+	if !ks.AgentExists("exists") {
+		t.Fatal("expected true for existing agent")
+	}
+}
+
+func TestKeystoreListAgents(t *testing.T) {
+	ks := NewKeystore(t.TempDir())
+
+	// Empty at first.
+	agents, err := ks.ListAgents()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(agents) != 0 {
+		t.Fatalf("expected 0 agents, got %d", len(agents))
+	}
+
+	// Generate two agents.
+	if _, err := ks.GenerateAgent("bob"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ks.GenerateAgent("alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	agents, err = ks.ListAgents()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should be sorted.
+	if len(agents) != 2 || agents[0] != "alice" || agents[1] != "bob" {
+		t.Fatalf("expected [alice bob], got %v", agents)
+	}
+}
+
+func TestKeystoreListTrusted(t *testing.T) {
+	ks := NewKeystore(t.TempDir())
+
+	// Empty at first.
+	trusted, err := ks.ListTrusted()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(trusted) != 0 {
+		t.Fatalf("expected 0 trusted, got %d", len(trusted))
+	}
+
+	// Generate and trust.
+	if _, err := ks.GenerateAgent("peer"); err != nil {
+		t.Fatal(err)
+	}
+	if err := ks.TrustKey("peer", ks.PublicKeyPath("peer")); err != nil {
+		t.Fatal(err)
+	}
+
+	trusted, err = ks.ListTrusted()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(trusted) != 1 || trusted[0] != "peer" {
+		t.Fatalf("expected [peer], got %v", trusted)
+	}
+}
+
+func TestKeystoreDirectoryPermissions(t *testing.T) {
+	base := t.TempDir()
+	ks := NewKeystore(base)
+
+	if _, err := ks.GenerateAgent("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Agent directory should be 0700.
+	info, err := os.Stat(ks.agentDir("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != dirPermission {
+		t.Errorf("agent dir permissions = %04o, want %04o", info.Mode().Perm(), dirPermission)
+	}
+}
+
+func TestValidateAgentName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"alice", false},
+		{"bob-123", false},
+		{"agent.v2", false},
+		{"under_score", false},
+		{"", true},
+		{"has spaces", true},
+		{"has/slash", true},
+		{"special@char", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAgentName(tt.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateAgentName(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSanitizeAgentName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"alice", "alice"},
+		{"has spaces", "has_spaces"},
+		{"special@char!", "special_char_"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := SanitizeAgentName(tt.input)
+			if got != tt.want {
+				t.Errorf("SanitizeAgentName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/signing/signing.go
+++ b/internal/signing/signing.go
@@ -1,0 +1,199 @@
+// Package signing provides Ed25519 key generation, file signing, and
+// signature verification for securing inter-agent communication.
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SigExtension is the file extension for detached signature files.
+const SigExtension = ".sig"
+
+// Key file header lines identify the format version.
+const (
+	publicKeyHeader  = "pipelock-ed25519-public-v1"
+	privateKeyHeader = "pipelock-ed25519-private-v1"
+)
+
+// GenerateKeyPair creates a new Ed25519 key pair using crypto/rand.
+func GenerateKeyPair() (ed25519.PublicKey, ed25519.PrivateKey, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generating ed25519 key pair: %w", err)
+	}
+	return pub, priv, nil
+}
+
+// SignFile reads a file and produces a detached Ed25519 signature.
+func SignFile(path string, privKey ed25519.PrivateKey) ([]byte, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: caller controls path
+	if err != nil {
+		return nil, fmt.Errorf("reading file to sign: %w", err)
+	}
+	return ed25519.Sign(privKey, data), nil
+}
+
+// VerifyFile reads a file and its detached signature, verifying against pubKey.
+// If sigPath is empty, it defaults to path + SigExtension.
+func VerifyFile(path, sigPath string, pubKey ed25519.PublicKey) error {
+	if sigPath == "" {
+		sigPath = path + SigExtension
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // G304: caller controls path
+	if err != nil {
+		return fmt.Errorf("reading file to verify: %w", err)
+	}
+
+	sig, err := LoadSignature(sigPath)
+	if err != nil {
+		return err
+	}
+
+	if !ed25519.Verify(pubKey, data, sig) {
+		return fmt.Errorf("signature verification failed")
+	}
+	return nil
+}
+
+// SaveSignature writes a base64-encoded signature to a .sig file.
+// Uses atomic temp+rename to prevent corruption.
+func SaveSignature(sig []byte, path string) error {
+	encoded := base64.StdEncoding.EncodeToString(sig) + "\n"
+	return atomicWrite(path, []byte(encoded), 0o600)
+}
+
+// LoadSignature reads and decodes a base64-encoded .sig file.
+func LoadSignature(path string) ([]byte, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: caller controls path
+	if err != nil {
+		return nil, fmt.Errorf("reading signature: %w", err)
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(data)))
+	if err != nil {
+		return nil, fmt.Errorf("decoding signature: %w", err)
+	}
+	return sig, nil
+}
+
+// EncodePublicKey serializes a public key with a versioned header.
+func EncodePublicKey(key ed25519.PublicKey) string {
+	return publicKeyHeader + "\n" + base64.StdEncoding.EncodeToString(key) + "\n"
+}
+
+// DecodePublicKey deserializes a public key from the versioned format.
+func DecodePublicKey(encoded string) (ed25519.PublicKey, error) {
+	lines := strings.SplitN(strings.TrimSpace(encoded), "\n", 2)
+	if len(lines) != 2 || lines[0] != publicKeyHeader {
+		return nil, fmt.Errorf("invalid public key format (expected %s header)", publicKeyHeader)
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(lines[1]))
+	if err != nil {
+		return nil, fmt.Errorf("decoding public key: %w", err)
+	}
+	if len(raw) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("invalid public key length: got %d, want %d", len(raw), ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(raw), nil
+}
+
+// EncodePrivateKey serializes a private key with a versioned header.
+func EncodePrivateKey(key ed25519.PrivateKey) string {
+	return privateKeyHeader + "\n" + base64.StdEncoding.EncodeToString(key) + "\n"
+}
+
+// DecodePrivateKey deserializes a private key from the versioned format.
+func DecodePrivateKey(encoded string) (ed25519.PrivateKey, error) {
+	lines := strings.SplitN(strings.TrimSpace(encoded), "\n", 2)
+	if len(lines) != 2 || lines[0] != privateKeyHeader {
+		return nil, fmt.Errorf("invalid private key format (expected %s header)", privateKeyHeader)
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(lines[1]))
+	if err != nil {
+		return nil, fmt.Errorf("decoding private key: %w", err)
+	}
+	if len(raw) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("invalid private key length: got %d, want %d", len(raw), ed25519.PrivateKeySize)
+	}
+	return ed25519.PrivateKey(raw), nil
+}
+
+// atomicWrite writes data to path via a temporary file and rename.
+func atomicWrite(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".pipelock-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	cleanup := func() {
+		tmp.Close()        //nolint:errcheck,gosec // best-effort cleanup
+		os.Remove(tmpName) //nolint:errcheck,gosec // best-effort cleanup
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return fmt.Errorf("writing file: %w", err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		cleanup()
+		return fmt.Errorf("setting permissions: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName) //nolint:errcheck,gosec // best-effort cleanup
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName) //nolint:errcheck,gosec // best-effort cleanup
+		return fmt.Errorf("renaming file: %w", err)
+	}
+	return nil
+}
+
+// SavePublicKey writes an encoded public key to path with 0o644 permissions.
+func SavePublicKey(key ed25519.PublicKey, path string) error {
+	return atomicWrite(path, []byte(EncodePublicKey(key)), 0o644)
+}
+
+// SavePrivateKey writes an encoded private key to path with 0o600 permissions.
+func SavePrivateKey(key ed25519.PrivateKey, path string) error {
+	return atomicWrite(path, []byte(EncodePrivateKey(key)), 0o600)
+}
+
+// LoadPublicKeyFile reads and decodes a public key from a file.
+func LoadPublicKeyFile(path string) (ed25519.PublicKey, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: caller controls path
+	if err != nil {
+		return nil, fmt.Errorf("reading public key: %w", err)
+	}
+	return DecodePublicKey(string(data))
+}
+
+// LoadPrivateKeyFile reads and decodes a private key from a file.
+func LoadPrivateKeyFile(path string) (ed25519.PrivateKey, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: caller controls path
+	if err != nil {
+		return nil, fmt.Errorf("reading private key: %w", err)
+	}
+	return DecodePrivateKey(string(data))
+}
+
+// SignReader reads all data from r and produces an Ed25519 signature.
+func SignReader(r io.Reader, privKey ed25519.PrivateKey) ([]byte, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading data to sign: %w", err)
+	}
+	return ed25519.Sign(privKey, data), nil
+}


### PR DESCRIPTION
## Summary

- New `internal/signing/` package — Ed25519 key generation, file signing with detached `.sig` files, and signature verification using Go stdlib only (zero new dependencies)
- Keystore at `~/.pipelock/` manages per-agent key pairs and a `trusted_keys/` directory for cross-agent verification
- Four new CLI commands: `keygen`, `sign`, `verify`, `trust`
- Integrity commands (`init`, `check`, `update`) gain `--sign` and `--verify` flags for manifest signing
- Signature companion files (`.sig`) are automatically excluded from integrity directory walks

## New Commands

```bash
pipelock keygen <agent-name>                    # Generate Ed25519 key pair
pipelock sign <file> --agent <name>             # Create detached signature
pipelock verify <file> --agent <name>           # Verify signature
pipelock trust <name> <pubkey-file>             # Add trusted public key

pipelock integrity init . --sign --agent alice  # Init + sign manifest
pipelock integrity check . --verify --agent alice  # Verify sig + check
```

## Test plan

- [x] 33 signing package unit tests (key gen, sign/verify round-trips, tamper detection, key encoding, permissions)
- [x] 15 keystore tests (agent lifecycle, trust workflow, key resolution, name validation)
- [x] 16 CLI integration tests (all commands, end-to-end flows, error cases)
- [x] 6 integrity signing tests (init+sign, check+verify, tampered manifest, update+sign, wrong agent)
- [x] All ~420 tests pass with `-race`
- [x] Zero lint warnings
- [x] All pre-commit hooks pass (gitleaks, golangci-lint, go vet, go test)