### PR TITLE
Fix GitHub Pages workflow configuration

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
-        with:
-          source: blog
 
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1


### PR DESCRIPTION
## Summary

- Remove invalid `source` input from `configure-pages@v5` action (the blog source path is already handled by `jekyll-build-pages`)
- The original deploy (PR #32) failed because GitHub Pages was not yet enabled in repo settings — now it is

Merging this will trigger a re-deploy of the Jekyll blog from `blog/`.