### PR TITLE
Update docs for Phase 2b, improve test coverage to 90%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom manifest path support (`--manifest` flag)
 - Atomic manifest writes (temp file + rename) to prevent corruption
 - Manifest version validation and nil-files guard on load
+- Ed25519 signing for file and manifest verification (`pipelock keygen|sign|verify|trust`)
+- Key storage under `~/.pipelock/` with versioned format headers
+- Trusted key management for inter-agent signature verification
+- Path traversal protection in keystore operations
+- MCP JSON-RPC 2.0 response scanning for prompt injection (`pipelock mcp scan`)
+- MCP scanning: text extraction from content blocks, split-injection detection via concatenation
+- MCP scanning: `--json` output mode (one verdict per line) and `--config` flag
+- Security fix: `json.RawMessage` null bypass prevention (result always scanned regardless of error field)
+- JSON tags on `scanner.ResponseMatch` for consistent snake_case output
 - GitHub Pages blog at luckypipewrench.github.io/pipelock
+- ~500 tests passing with `-race`
 
 ### Removed
 - Stale Phase 1.5 planning doc (planning docs live outside the repo)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,9 @@ Include:
 The following are in scope:
 - Bypass of URL scanning (blocklist, DLP, entropy)
 - SSRF vulnerabilities in the fetch proxy
+- Bypass of MCP response scanning (prompt injection evasion)
+- Ed25519 signature forgery or verification bypass
+- Integrity monitoring bypass (undetected file modification)
 - Audit log injection or tampering
 - Config parsing vulnerabilities
 - Privilege escalation in network restriction mode

--- a/blog/_posts/2026-02-08-lateral-movement-multi-agent-llm.md
+++ b/blog/_posts/2026-02-08-lateral-movement-multi-agent-llm.md
@@ -91,11 +91,15 @@ The manifest stores SHA256 hashes for every protected file. When an agent starts
 
 This doesn't stop every lateral movement attack. A compromised agent can still write to files that aren't in the manifest, and we need signing (coming next) to verify who actually made a change. But it catches the most dangerous thing: someone (or something) quietly editing the files that control how your agents behave.
 
+### Now available
+
+- **Ed25519 signing** — verify which agent or person changed each file (`pipelock keygen|sign|verify|trust`)
+- **MCP response scanning** — scan MCP tool responses for prompt injection before they reach the agent (`pipelock mcp scan`)
+
 ### Coming next
 
-- Ed25519 signing, so you can verify which agent or person changed each file
 - Communication policies, so you can define which agents are allowed to modify which files
-- Content scanning to catch prompt injection patterns in shared files before they get loaded
+- Content scanning for shared workspace files (extending MCP scanning to file-based communication)
 
 ## What you can do right now
 


### PR DESCRIPTION
## Summary
- Update README, CHANGELOG, SECURITY.md, and blog post for shipped Phase 2b features (Ed25519 signing + MCP scanning)
- Improve test coverage: signing 83.7%→90.4%, integrity 82.7%→90.6%, overall 88.9%→90.3%
- 526 tests passing with `-race`, zero lint warnings

## Test plan
- [x] `go test -race -count=1 ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] Coverage verified per-package above 90% for signing and integrity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Ed25519 signing and verification for file and manifest integrity
  * MCP response scanning to detect prompt injection attempts
  * Secure keystore management with enhanced protection against path traversal
  * JSON output mode for scanning results

* **Bug Fixes**
  * Security fix for null value handling in JSON responses

* **Tests**
  * Comprehensive test coverage additions, including ~500 tests with race condition detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->