### PR TITLE
Fix GoReleaser GOVERSION env for ldflag template

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,9 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
+      - name: Set GOVERSION
+        run: echo "GOVERSION=$(go env GOVERSION)" >> "$GITHUB_ENV"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -45,3 +48,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOVERSION: ${{ env.GOVERSION }}


### PR DESCRIPTION
## Summary
- GoReleaser release failed because `{{.Env.GOVERSION}}` was not set in CI
- Added a step to export `GOVERSION` from `go env` before running GoReleaser

## Context
The `.goreleaser.yaml` ldflag `-X ...GoVersion={{.Env.GOVERSION}}` was added in PR #42 but the release workflow didn't set the env var.

Generated with [Claude Code](https://claude.com/claude-code)