### PR TITLE
Add target audience one-liner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 **Security harness for AI agents.** Controls what your agent can access on the network, preventing credential exfiltration while preserving web browsing capability.
 
+If you run Claude Code, OpenHands, or any AI agent with shell access and API keys, this is for you.
+
 [Blog](https://luckypipewrench.github.io/pipelock/) | [GitHub](https://github.com/luckyPipewrench/pipelock)
 
 ## The Problem


### PR DESCRIPTION
Adds a one-liner after the tagline so first-time visitors immediately know if pipelock is relevant to them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with improved contextual guidance for users running AI agents with shell access and API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->