### PR TITLE
Add Homebrew formula to GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,6 +43,25 @@ changelog:
       - '^test:'
       - '^chore:'
 
+brews:
+  - repository:
+      owner: luckyPipewrench
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.GITHUB_TOKEN }}"
+    homepage: "https://github.com/luckyPipewrench/pipelock"
+    description: "Security harness for AI agents"
+    license: "Apache-2.0"
+    folder: Formula
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    install: |
+      bin.install "pipelock"
+    test: |
+      system "#{bin}/pipelock", "version"
+
 dockers:
   - image_templates:
       - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-amd64"


### PR DESCRIPTION
## Summary
- Adds `brews` section to `.goreleaser.yaml` targeting `luckyPipewrench/homebrew-tap`
- Formula auto-publishes on `git tag v*` release
- Requires `homebrew-tap` repo to be created before next release

After setup: `brew tap luckyPipewrench/tap && brew install pipelock`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Homebrew tap support, enabling users to install the project via Homebrew package manager on macOS and Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->