### PR TITLE
Fix GoReleaser v2 Homebrew config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,7 +52,7 @@ brews:
     homepage: "https://github.com/luckyPipewrench/pipelock"
     description: "Security harness for AI agents"
     license: "Apache-2.0"
-    folder: Formula
+    directory: Formula
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com


### PR DESCRIPTION
Rename `folder` to `directory` per GoReleaser v2 schema. Fixes the v0.1.4 release workflow failure.