### PR TITLE
Add public CLAUDE.md and fix stale OWASP URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ cmd/pipelock/          Entry point (main.go)
 internal/
   cli/                 Cobra commands (run, check, generate, logs, git, integrity, mcp, keygen, sign, verify, trust, version, healthcheck)
   proxy/               HTTP fetch proxy (/fetch, /health, /metrics, /stats)
-  scanner/             URL + response scanning pipeline (6 layers)
+  scanner/             URL + response scanning pipeline (7 layers)
   config/              YAML config loading, validation, hot-reload (fsnotify + SIGHUP)
   audit/               Structured JSON logging (zerolog)
   mcp/                 MCP stdio proxy + JSON-RPC 2.0 response scanning
@@ -65,14 +65,15 @@ Pipelock uses **capability separation**: the agent process (which has secrets an
 Agent (secrets, no network) → Pipelock Proxy (no secrets, full network) → Internet
 ```
 
-### Scanner Pipeline (6 layers)
+### Scanner Pipeline (7 layers)
 
 1. **SSRF** — Block private IPs, link-local, metadata endpoints. DNS rebinding protection.
 2. **Domain blocklist** — Configurable deny/allow lists per mode.
 3. **Rate limiting** — Per-domain sliding window.
-4. **DLP** — Regex patterns for API keys, tokens, credentials (8 built-in patterns, extensible via config). Includes env leak sub-check for raw + base64-encoded environment variable values.
-5. **Entropy** — Flag high-entropy URL segments that may be exfiltrated data (Shannon entropy > 3.0).
-6. **URL length** — Configurable max URL length.
+4. **DLP** — Regex patterns for API keys, tokens, credentials (8 built-in patterns, extensible via config).
+5. **Env leak** — Detect raw + base64-encoded environment variable values (Shannon entropy > 3.0).
+6. **Entropy** — Flag high-entropy URL segments that may be exfiltrated data.
+7. **URL length** — Configurable max URL length.
 
 Response scanning adds prompt injection detection on fetched content.
 

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ blog/                  GitHub Pages blog (Jekyll)
 ## Credits
 
 - Architecture influenced by [Anthropic's Claude Code sandboxing](https://www.anthropic.com/engineering/claude-code-sandboxing) and [sandbox-runtime](https://github.com/anthropic-experimental/sandbox-runtime)
-- Threat model informed by [OWASP Agentic AI Top 10](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/)
+- Threat model informed by [OWASP Agentic AI Top 10](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)
 - See [docs/comparison.md](docs/comparison.md) for how Pipelock relates to [AIP](https://github.com/ArangoGutierrez/agent-identity-protocol), [agentsh](https://github.com/canyonroad/agentsh), and [srt](https://github.com/anthropic-experimental/sandbox-runtime)
 - Security review contributions from Dylan Corrales
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -8,7 +8,7 @@ An honest feature matrix and guidance on when to use what.
 |---------|----------|-----|---------|-----|
 | **Layer** | HTTP proxy + CLI | MCP proxy | Kernel (seccomp/eBPF/FUSE) | OS sandbox |
 | **Language** | Go | Go | Go | TypeScript |
-| **Binary** | Single, ~17MB | Single | Single + kernel modules | npm package |
+| **Binary** | Single, ~12MB | Single | Single + kernel modules | npm package |
 | **Domain allowlist** | Yes | Yes (MCP-level) | Yes (LLM proxy) | Yes |
 | **DLP (secret detection)** | Regex + entropy + env scan | Regex (per-argument) | Regex (LLM proxy) | No |
 | **SSRF protection** | Yes (DNS pinning) | No | N/A (kernel-level) | N/A |
@@ -101,4 +101,4 @@ Defense in depth: use tools at multiple layers. A compromised agent must bypass 
 - [AIP](https://github.com/ArangoGutierrez/agent-identity-protocol)
 - [agentsh](https://github.com/canyonroad/agentsh)
 - [srt](https://github.com/anthropic-experimental/sandbox-runtime)
-- [OWASP Agentic Top 10](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/)
+- [OWASP Agentic Top 10](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)


### PR DESCRIPTION
## Summary
- Add production CLAUDE.md contributor guide (build/test/lint, architecture, CLI commands, testing patterns, common dev tasks)
- Fix OWASP 404 URLs in README.md and docs/comparison.md (same fix as PR #61 for owasp-mapping.md)

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Verify OWASP links resolve (not 404)
- [ ] Lint + tests pass (no code changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a comprehensive development guide covering architecture, scanner pipeline, CLI, testing, release/process, and contribution guidelines.
  * Updated threat-model reference links to the GenAI OWASP resource.
  * Adjusted feature matrix details to reflect an updated binary size (~17MB → ~12MB).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->