### PR TITLE
Update blog links to pipelab.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP JSON-RPC 2.0 response scanning for prompt injection (`pipelock mcp scan`)
 - MCP scanning: text extraction from content blocks, split-injection detection via concatenation
 - MCP scanning: `--json` output mode (one verdict per line) and `--config` flag
-- GitHub Pages blog at luckypipewrench.github.io/pipelock
+- Blog at pipelab.org/blog/
 - 530+ tests passing with `-race`
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,5 +230,5 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. Summary:
 | OWASP Agentic Top 10 mapping | [docs/owasp-mapping.md](docs/owasp-mapping.md) |
 | Competitive comparison | [docs/comparison.md](docs/comparison.md) |
 | Claude Code integration guide | [docs/guides/claude-code.md](docs/guides/claude-code.md) |
-| Blog | [blog/](https://luckypipewrench.github.io/pipelock/blog/) |
+| Blog | [pipelab.org/blog/](https://pipelab.org/blog/) |
 | Changelog | [CHANGELOG.md](CHANGELOG.md) |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 If you run Claude Code, OpenHands, or any AI agent with shell access and API keys, this is for you.
 
-[Blog](https://luckypipewrench.github.io/pipelock/) | [OWASP Coverage](docs/owasp-mapping.md) | [Tool Comparison](docs/comparison.md)
+[Blog](https://pipelab.org/blog/) | [OWASP Coverage](docs/owasp-mapping.md) | [Tool Comparison](docs/comparison.md)
 
 [![demo](https://asciinema.org/a/I1UzzECkeCBx6p42.svg)](https://asciinema.org/a/I1UzzECkeCBx6p42)
 
@@ -199,7 +199,7 @@ pipelock integrity check ./workspace --json  # machine-readable
 pipelock integrity update ./workspace        # re-hash after review
 ```
 
-SHA256 manifests detect modified, added, or removed files. See [lateral movement in multi-agent systems](https://luckypipewrench.github.io/pipelock/blog/2026/02/08/lateral-movement-multi-agent-llm/).
+SHA256 manifests detect modified, added, or removed files. See [lateral movement in multi-agent systems](https://pipelab.org/blog/lateral-movement-multi-agent-llm/).
 
 ### Git Protection
 
@@ -465,7 +465,7 @@ internal/
   hitl/                Human-in-the-loop terminal approval (ask action)
 configs/               Preset config files (strict, balanced, audit, claude-code, cursor, generic-agent)
 docs/                  OWASP mapping, tool comparison
-blog/                  GitHub Pages blog (Jekyll)
+blog/                  Blog posts (mirrored at pipelab.org/blog/)
 ```
 
 ## Credits

--- a/blog/_posts/2026-02-10-securing-claude-code-with-pipelock.md
+++ b/blog/_posts/2026-02-10-securing-claude-code-with-pipelock.md
@@ -19,7 +19,7 @@ Here's what actually goes wrong:
 3. Claude Code processes the response and follows the injected instruction
 4. Your API keys, tokens, and credentials leave through an outbound HTTP request
 
-This isn't theoretical. The [ClawHub skills audit](https://luckypipewrench.github.io/pipelock/blog/2026/02/09/leaky-clawhub-skills-runtime-protection/) found 283 out of 3,984 skills referencing hardcoded credentials. Some of those skills are MCP servers that developers connect to their agents daily.
+This isn't theoretical. The [ClawHub skills audit](https://pipelab.org/blog/leaky-clawhub-skills/) found 283 out of 3,984 skills referencing hardcoded credentials. Some of those skills are MCP servers that developers connect to their agents daily.
 
 ## Setup: wrap your MCP servers
 


### PR DESCRIPTION
## Summary
- Blog migrated from GitHub Pages to pipelab.org/blog/
- Update all references in README, CLAUDE.md, CHANGELOG, and blog cross-links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all blog URL references across changelog, documentation files, and internal blog links to use the new pipelab.org/blog domain, replacing the previous domain.
  * Updated URL patterns to reflect the new domain structure for consistency across all references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->