### PR TITLE
Fix Homebrew formula auto-push on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,4 +48,5 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           GOVERSION: ${{ env.GOVERSION }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,7 +48,7 @@ brews:
       owner: luckyPipewrench
       name: homebrew-tap
       branch: main
-      token: "{{ .Env.GITHUB_TOKEN }}"
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     homepage: "https://github.com/luckyPipewrench/pipelock"
     description: "Security harness for AI agents"
     license: "Apache-2.0"


### PR DESCRIPTION
## Summary
- Use `HOMEBREW_TAP_TOKEN` secret instead of `GITHUB_TOKEN` for cross-repo Homebrew tap push
- Pass the secret as env var to GoReleaser in the release workflow

Fixes the 403 on every release since v0.1.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release and deployment configuration for improved build process management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->