### PR TITLE
Add --json flag to git scan-diff

### DIFF
--- a/internal/gitprotect/diffscan.go
+++ b/internal/gitprotect/diffscan.go
@@ -3,6 +3,7 @@
 package gitprotect
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -14,11 +15,11 @@ import (
 
 // Finding represents a secret detected in a git diff.
 type Finding struct {
-	File     string // source file path
-	Line     int    // line number in the new file
-	Content  string // sanitized line — actual secret replaced with [REDACTED]
-	Pattern  string // DLP pattern name that matched
-	Severity string // severity level from the DLP pattern
+	File     string `json:"file"`
+	Line     int    `json:"line"`
+	Content  string `json:"content"`
+	Pattern  string `json:"pattern"`
+	Severity string `json:"severity"`
 }
 
 // addedLine represents a line that was added in a diff hunk.
@@ -165,6 +166,15 @@ func ScanDiff(diffText string, patterns []CompiledDLPPattern) []Finding {
 	})
 
 	return findings
+}
+
+// FindingsJSON returns the findings as a JSON-encoded byte slice.
+// An empty or nil slice is encoded as "[]" (not "null").
+func FindingsJSON(findings []Finding) ([]byte, error) {
+	if findings == nil {
+		findings = []Finding{}
+	}
+	return json.Marshal(findings)
 }
 
 // FormatFindings returns a human-readable summary of findings.

--- a/internal/gitprotect/diffscan_test.go
+++ b/internal/gitprotect/diffscan_test.go
@@ -1,6 +1,7 @@
 package gitprotect
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -318,5 +319,52 @@ func TestFormatFindings_WithFindings(t *testing.T) {
 	}
 	if !strings.Contains(result, "main.go:10") {
 		t.Errorf("expected file:line in output, got %q", result)
+	}
+}
+
+func TestFindingsJSON_WithFindings(t *testing.T) {
+	findings := []Finding{
+		{File: "main.go", Line: 42, Pattern: "AWS Key", Severity: "critical", Content: "[REDACTED]"},
+	}
+	data, err := FindingsJSON(findings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var decoded []Finding
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(decoded) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(decoded))
+	}
+	if decoded[0].File != "main.go" {
+		t.Errorf("expected file main.go, got %q", decoded[0].File)
+	}
+	if decoded[0].Line != 42 {
+		t.Errorf("expected line 42, got %d", decoded[0].Line)
+	}
+	if decoded[0].Pattern != "AWS Key" {
+		t.Errorf("expected pattern 'AWS Key', got %q", decoded[0].Pattern)
+	}
+}
+
+func TestFindingsJSON_Empty(t *testing.T) {
+	data, err := FindingsJSON(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != "[]" {
+		t.Errorf("expected [], got %q", string(data))
+	}
+}
+
+func TestFindingsJSON_EmptySlice(t *testing.T) {
+	data, err := FindingsJSON([]Finding{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != "[]" {
+		t.Errorf("expected [], got %q", string(data))
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `--json` flag to `pipelock git scan-diff` for machine-readable output
- JSON struct tags on `Finding` type
- `FindingsJSON()` helper marshals findings to JSON array
- Empty findings produce `[]` (not null)

## Test plan
- [ ] `git scan-diff --json` outputs valid JSON array
- [ ] `git scan-diff --json` with no findings outputs `[]`
- [ ] Existing human-readable output unchanged without `--json`
- [ ] CI passes (lint + test + build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--json` flag to scan-diff command to enable JSON-formatted output of findings for programmatic consumption.
  * When no diff content is detected, outputs an empty JSON array when JSON mode is enabled.
  * Findings now include file location, line number, content, pattern match, and severity information in JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->