### PR TITLE
Fix fetch proxy DNS subdomain exfiltration bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Pipelock will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fetch proxy DNS subdomain exfiltration: dot-collapse scanning now applied to hostnames in `checkDLP` (was only on MCP text scanning side)
+
 ## [0.2.0] - 2026-02-13
 
 ### Added

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -365,6 +365,13 @@ func (s *Scanner) checkDLP(parsed *url.URL) Result {
 		targets = append(targets, decodedPath)
 	}
 
+	// Dot-collapse the hostname to catch secrets split across DNS subdomains
+	// (e.g. "sk-ant-api03-.AABBCCDD.EEFFGGHH.evil.com" → "sk-ant-api03-AABBCCDDEEFFGGHHevilcom").
+	// Dots break regex character classes, so individual labels pass DLP checks.
+	if hostname := parsed.Hostname(); strings.Contains(hostname, ".") {
+		targets = append(targets, strings.ReplaceAll(hostname, ".", ""))
+	}
+
 	for _, target := range targets {
 		if target == "" {
 			continue


### PR DESCRIPTION
## Summary
- Dot-collapse scanning now applied to hostnames in `checkDLP` (fetch proxy side)
- Was already present on MCP text scanning side (`ScanTextForDLP`) but missing from fetch proxy path
- Catches secrets split across DNS subdomains (e.g. `sk-ant-api03-.AABB.CCDD.evil.com`)

## Test plan
- [x] 5 new test cases in `TestScan_DLPSubdomainDotCollapse` (3 blocked, 2 no-FP)
- [x] All existing tests pass with `-race`
- [x] Lint clean (`golangci-lint run ./...`)
- [x] Red team tested against live proxy build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* DLP scanning now detects secrets split across DNS subdomains through dot-collapse technique.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->