### PR TITLE
Improve OpenSSF Scorecard: pin images, fix token perms, harden branch rules

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,15 +5,16 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write
-  attestations: write
+permissions: {}
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -9,12 +9,14 @@ on:
     - cron: '0 3 * * 0' # Weekly Sunday 3AM UTC
 
 permissions:
-  security-events: write
   contents: read
 
 jobs:
   codeql:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release attestation steps use `continue-on-error` with final verification (prevents cascading failures)
 - Container digest resolution uses `::warning` annotation instead of silent fallback
 - `govulncheck`, `cyclonedx-gomod`, and `crane` pinned to specific versions (not `@latest`)
+- Docker base images pinned by SHA256 digest (Scorecard Pinned-Dependencies)
+- Write permissions moved from workflow-level to job-level (Scorecard Token-Permissions)
+- Branch protection: added PR requirement, lint as required check, strict status policy, review thread resolution
 
 ### Fixed
 - Fetch proxy DNS subdomain exfiltration: dot-collapse scanning now applied to hostnames in `checkDLP` (was only on MCP text scanning side)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for minimal image size
-FROM golang:1.24-alpine AS builder
+FROM golang:1.24-alpine@sha256:8bee1901f1e530bfb4a7850aa7a479d17ae3a18beb6e09064ed54cfd245b7191 AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,6 +1,6 @@
 # Used by GoReleaser — copies the pre-built binary instead of building from source.
 # For local/manual builds, use the main Dockerfile instead.
-FROM alpine:3.21 AS certs
+FROM alpine:3.21@sha256:c3f8e73fdb79deaebaa2037150150191b9dcbfba68b4a46d70103204c53f4709 AS certs
 RUN apk add --no-cache ca-certificates
 
 FROM scratch


### PR DESCRIPTION
## Summary
- Pin Docker base images by SHA256 digest (Pinned-Dependencies 8 → 10)
- Move write permissions to job-level in release and security workflows (Token-Permissions 0 → 10)
- Branch ruleset updated: added PR requirement, lint as required check, strict status policy, review thread resolution

## Test plan
- [x] All tests pass
- [x] Lint clean
- [ ] Verify scorecard re-runs after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned Docker base images with SHA256 digests for enhanced supply chain security and reproducibility
  * Scoped workflow permissions to job-level configuration, restricting write access for improved security isolation
  * Strengthened branch protection with PR requirements, mandatory lint checks, and strict status enforcement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->