### PR TITLE
Add OpenSSF Best Practices passing badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `govulncheck` CI job scanning Go dependencies for known vulnerabilities
 - `go mod verify` step in CI and release pipelines
 - OpenSSF Scorecard badge in README
+- OpenSSF Best Practices passing badge in README
 - Release verification instructions in README (`gh attestation verify`)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/luckyPipewrench/pipelock)](https://goreportcard.com/report/github.com/luckyPipewrench/pipelock)
 [![CodeQL](https://github.com/luckyPipewrench/pipelock/actions/workflows/security.yaml/badge.svg)](https://github.com/luckyPipewrench/pipelock/actions/workflows/security.yaml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/luckyPipewrench/pipelock/badge)](https://scorecard.dev/viewer/?uri=github.com/luckyPipewrench/pipelock)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11948/badge)](https://www.bestpractices.dev/projects/11948)
 [![codecov](https://codecov.io/gh/luckyPipewrench/pipelock/graph/badge.svg)](https://codecov.io/gh/luckyPipewrench/pipelock)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 


### PR DESCRIPTION
## Summary
- Add OpenSSF Best Practices passing badge to README (project ID 11948)
- Badge placed between Scorecard and Codecov badges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OpenSSF Best Practices passing badge to project documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->