### PR TITLE
Fix SBOM generation for Go 1.24 compatibility

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Generate SBOM
         run: |
-          go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.10.0
+          go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.9.0
           cyclonedx-gomod mod -json -output sbom.cdx.json
 
       - name: Upload SBOM to release


### PR DESCRIPTION
## Summary
- Downgrade `cyclonedx-gomod` from v1.10.0 to v1.9.0 in release workflow (v1.10.0 requires Go 1.25)

## Test plan
- [ ] Release workflow SBOM step completes on Go 1.24 runner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow tooling to improve build reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->