### PR TITLE
Prepare v0.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,25 @@ All notable changes to Pipelock will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.2] - 2026-02-15
 
 ### Added
 - MCP tool description scanning: detects poisoned tool descriptions containing hidden instructions (`<IMPORTANT>` tags, file exfiltration directives, cross-tool manipulation)
 - MCP tool rug-pull detection: SHA256 baseline tracks tool definitions per session, alerts when descriptions change mid-session
 - `mcp_tool_scanning` config section (action: warn/block, detect_drift: true/false)
 - Auto-enabled in `mcp proxy` mode unless explicitly configured
+- Unicode normalization (NFKC) and C0 control character stripping in tool description scanning
+- Recursive schema extraction: scans `description` and `title` fields from nested `inputSchema` objects
+- JSON-RPC batch response handling for tool scanning
 - `CODEOWNERS` file for automatic review assignment
 - Cosign keyless signing for release checksums (Sigstore transparency log)
 - Manual trigger (`workflow_dispatch`) for OpenSSF Scorecard workflow
+
+### Fixed
+- Fetch proxy URL parameter truncation: unencoded `&` in target URLs silently truncated secrets from DLP scanner
+- Fetch proxy control character bypass: `%00`, `%08`, `%09`, `%0a` in target URLs broke DLP regex matching
+- Empty-name tool bypass: tools with no `name` field bypassed `tools/list` scanning entirely
+- Baseline capacity DoS: malicious servers could force hash computation on unlimited unique tool names (added capacity cap with `ShouldSkip()`)
 
 ### Changed
 - Branch protection: squash-only merges, stale review dismissal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Wraps any MCP server as a stdio proxy with bidirectional scanning. Server respon
 
 - **Race detector mandatory**: All tests run with `-race -count=1`
 - **90% coverage target** across all packages
-- **1,300+ tests** currently passing
+- **1,500+ tests** currently passing
 
 ### Patterns
 

--- a/blog/_posts/2026-02-09-leaky-clawhub-skills-runtime-protection.md
+++ b/blog/_posts/2026-02-09-leaky-clawhub-skills-runtime-protection.md
@@ -100,4 +100,4 @@ Repo: [github.com/luckyPipewrench/pipelock](https://github.com/luckyPipewrench/p
 
 ---
 
-*Pipelock is open source (Apache 2.0). 1,300+ tests, 94%+ coverage. Single static binary.*
+*Pipelock is open source (Apache 2.0). 1,500+ tests, 95%+ coverage. Single static binary.*

--- a/docs/compliance/eu-ai-act-mapping.md
+++ b/docs/compliance/eu-ai-act-mapping.md
@@ -6,7 +6,7 @@ How Pipelock's runtime security controls map to the [EU AI Act (Regulation 2024/
 
 **Disclaimer:** This document maps Pipelock's security features to EU AI Act requirements for informational purposes. It does not constitute legal advice or guarantee regulatory compliance. Organizations should consult qualified legal counsel for compliance obligations specific to their AI systems.
 
-**Last updated:** v0.2.0 (February 2026)
+**Last updated:** v0.2.2 (February 2026)
 
 ---
 
@@ -176,7 +176,7 @@ How Pipelock maps to NIST AI Risk Management Framework functions, with EU AI Act
 | NIST Subcategory | Description | Pipelock Feature | EU AI Act |
 |-----------------|-------------|-----------------|-----------|
 | MEASURE 1.1 | Metrics selected and documented | Prometheus: `pipelock_requests_total`, `pipelock_scanner_hits_total`, `pipelock_request_duration_seconds` | Art. 12 |
-| MEASURE 2.5 | System demonstrated valid and reliable | CI: 3 required checks (test, lint, build), CodeQL analysis, 1,300+ tests with race detector | Art. 15 |
+| MEASURE 2.5 | System demonstrated valid and reliable | CI: 3 required checks (test, lint, build), CodeQL analysis, 1,500+ tests with race detector | Art. 15 |
 | MEASURE 2.6 | Evaluated for misuse and abuse | Scanning layers target misuse: DLP catches exfiltration, SSRF catches internal probing, injection detection catches hijacking | Art. 9, 15 |
 | MEASURE 2.7 | Security and resilience evaluated | Security audit completed (26 of 32 items fixed); DNS rebinding protection; fail-closed architecture | Art. 15 |
 | MEASURE 3.1 | Risks tracked on ongoing basis | Prometheus real-time tracking; zerolog persistent timeline; both queryable and alertable | Art. 12 |

--- a/docs/owasp-mapping.md
+++ b/docs/owasp-mapping.md
@@ -157,7 +157,7 @@ Use `pipelock generate config --preset balanced` for the complete default patter
 - **Audit logging** — every request and scanner detection is logged, giving humans a verifiable record to review.
 - **Prometheus metrics** — `/metrics` and `/stats` endpoints surface block rates, scanner hits, and top domains for human oversight dashboards.
 
-**Gap:** No user-facing UI for non-terminal environments. HITL is terminal-only in v0.1.4.
+**Gap:** No user-facing UI for non-terminal environments. HITL is terminal-only.
 
 ---
 


### PR DESCRIPTION
## Summary
- Promote changelog Unreleased section to v0.2.2
- Fix stale test counts and version references across docs
- Remove stale v0.1.4 reference from OWASP mapping

## Changes
- CHANGELOG.md: Unreleased → [0.2.2] with complete Added/Fixed/Changed sections
- docs/compliance/eu-ai-act-mapping.md: version v0.2.0 → v0.2.2
- docs/owasp-mapping.md: remove stale version from HITL gap note
- Dev guide and blog post: update test count figures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.2.2

* **New Features**
  * Added Unicode normalization and control character filtering for tool descriptions.
  * Implemented recursive schema extraction and JSON-RPC batch response handling.
  * Introduced `mcp_tool_scanning` configuration section for enhanced governance.

* **Bug Fixes**
  * Fixed URL parameter truncation in fetch proxy preventing credential leakage.
  * Resolved control character bypass affecting DLP matching.
  * Fixed bypass of unnamed tools during scanning.
  * Added capacity safeguards against DoS attacks.

* **Documentation**
  * Updated test metrics to 1,500+ tests with 95%+ coverage.
  * Updated compliance documentation to v0.2.2 standards.

* **Chores**
  * Enhanced security practices with keyless code signing and review automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->