### PR TITLE
Prepare v0.2.3: changelog, fix stale version refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-02-16
+
 ### Added
+- MCP transport abstraction: `MessageReader`/`MessageWriter` interfaces decouple scanning from stdio framing, preparing for HTTP transport
 - Demo command: 7 attack scenarios (was 5), adding MCP input secret leak and tool description poisoning demos
 - Demo ANSI color output with `NO_COLOR` env var support and TTY detection
 - Demo `--interactive` flag for live presentations (pauses between scenarios)
+- CrewAI integration guide (`docs/guides/crewai.md`)
+- LangGraph integration guide (`docs/guides/langgraph.md`)
+- `WriteMessage` size guard (10 MB limit) prevents unbounded memory allocation on malformed input
+- `maxLineSize` guard on stdio message reader for consistency with write path
+
+### Fixed
+- Strict-mode API allowlist enforcement: requests to non-allowlisted domains now blocked in strict mode (was warn-only)
+- MCP no-params DLP bypass: requests with missing `params` field bypassed input scanning entirely
+- Encoded secret bypass in MCP input: multi-layer percent-encoding could evade DLP patterns
+- Display URL normalization: audit log URLs now consistently decoded for readability
+- Three static analysis findings: `ViolationPermissions` field visibility, HITL reload-to-ask warning, stale comment
 
 ### Changed
 - Demo "MCP Tool Poisoning" scenario renamed to "MCP Response Injection" for clarity
+- `iterativeDecode` consolidated into single exported function (was duplicated across scanner paths)
+- Write errors in `syncWriter` and `StdioWriter` now wrapped with context
+- Bumped `sigstore/cosign-installer` from 3.10.1 to 4.0.0
 
 ## [0.2.2] - 2026-02-15
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Wraps any MCP server as a stdio proxy with bidirectional scanning. Server respon
 
 - **Race detector mandatory**: All tests run with `-race -count=1`
 - **90% coverage target** across all packages
-- **1,500+ tests** currently passing
+- **1,580+ tests** currently passing
 
 ### Patterns
 

--- a/docs/compliance/eu-ai-act-mapping.md
+++ b/docs/compliance/eu-ai-act-mapping.md
@@ -6,7 +6,7 @@ How Pipelock's runtime security controls map to the [EU AI Act (Regulation 2024/
 
 **Disclaimer:** This document maps Pipelock's security features to EU AI Act requirements for informational purposes. It does not constitute legal advice or guarantee regulatory compliance. Organizations should consult qualified legal counsel for compliance obligations specific to their AI systems.
 
-**Last updated:** v0.2.2 (February 2026)
+**Last updated:** v0.2.3 (February 2026)
 
 ---
 
@@ -176,7 +176,7 @@ How Pipelock maps to NIST AI Risk Management Framework functions, with EU AI Act
 | NIST Subcategory | Description | Pipelock Feature | EU AI Act |
 |-----------------|-------------|-----------------|-----------|
 | MEASURE 1.1 | Metrics selected and documented | Prometheus: `pipelock_requests_total`, `pipelock_scanner_hits_total`, `pipelock_request_duration_seconds` | Art. 12 |
-| MEASURE 2.5 | System demonstrated valid and reliable | CI: 3 required checks (test, lint, build), CodeQL analysis, 1,500+ tests with race detector | Art. 15 |
+| MEASURE 2.5 | System demonstrated valid and reliable | CI: 3 required checks (test, lint, build), CodeQL analysis, 1,580+ tests with race detector | Art. 15 |
 | MEASURE 2.6 | Evaluated for misuse and abuse | Scanning layers target misuse: DLP catches exfiltration, SSRF catches internal probing, injection detection catches hijacking | Art. 9, 15 |
 | MEASURE 2.7 | Security and resilience evaluated | Security audit completed (26 of 32 items fixed); DNS rebinding protection; fail-closed architecture | Art. 15 |
 | MEASURE 3.1 | Risks tracked on ongoing basis | Prometheus real-time tracking; zerolog persistent timeline; both queryable and alertable | Art. 12 |

--- a/docs/guides/langgraph.md
+++ b/docs/guides/langgraph.md
@@ -197,7 +197,7 @@ Use `dockerfile_lines` in `langgraph.json` to install Pipelock into the image:
     "env": ".env",
     "dockerfile_lines": [
         "RUN apt-get update && apt-get install -y curl",
-        "RUN PIPELOCK_VERSION=0.2.2 && curl -fsSL https://github.com/luckyPipewrench/pipelock/releases/download/v${PIPELOCK_VERSION}/pipelock_${PIPELOCK_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin/",
+        "RUN PIPELOCK_VERSION=0.2.3 && curl -fsSL https://github.com/luckyPipewrench/pipelock/releases/download/v${PIPELOCK_VERSION}/pipelock_${PIPELOCK_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin/",
         "COPY pipelock-config.yaml /etc/pipelock/config.yaml"
     ]
 }


### PR DESCRIPTION
## Summary
- Update CHANGELOG with all changes since v0.2.2 (PRs #99-#103)
- Update test count (1,580+) in CLAUDE.md and compliance mapping
- Update version refs in EU AI Act mapping and LangGraph guide

## Changes
- **CHANGELOG.md** — 7 Added, 5 Fixed, 4 Changed entries for v0.2.3
- **CLAUDE.md** — test count 1,500+ → 1,580+
- **docs/compliance/eu-ai-act-mapping.md** — version and test count
- **docs/guides/langgraph.md** — Dockerfile version 0.2.2 → 0.2.3

## Test plan
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race -count=1 ./...` — 1,580 tests passing
- [x] Doc-only changes, no code modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integration documentation guides for CrewAI and LangGraph.

* **Bug Fixes**
  * Fixed strict-mode API allowlist to properly block non-allowed domain requests.
  * Fixed DLP bypass vulnerabilities in MCP request scanning and encoded secret handling.
  * Fixed audit log URL display normalization for consistency.

* **Tests**
  * Increased test coverage to 1,580+ tests.

* **Chores**
  * Updated dependency versions and documentation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->