### PR TITLE
Harden DLP and injection scanning against advanced evasion

### DIFF
--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -111,7 +111,11 @@ response_scanning:
     - name: "Output Format Forcing"
       regex: '(?i)(respond\s+with|first\s+(output|write|print|say))\s*[\[\("]?\s*(FILTERED|ERROR|BLOCKED|REFUSED|DECLINED|CENSORED)\s*[\]\)"]?\s*(then|followed\s+by|and\s+then|after\s+(that|which))'
     - name: "System Prompt Extraction"
-      regex: '(?i)(repeat\s+(your|the)\s+(entire\s+)?(instructions|system\s+prompt|initial\s+prompt|rules)|what\s+(is|are)\s+your\s+(system\s+prompt|instructions|rules|directives)|output\s+(your|the)\s+(full\s+)?(system|initial)\s+(prompt|instructions|message)|show\s+me\s+(your|the)\s+(system\s+prompt|hidden\s+instructions|initial\s+instructions))'
+      regex: '(?i)(repeat\s+(your|the)\s+(entire\s+)?(instructions|system\s+prompt|initial\s+prompt|rules)|what\s+(is|are)\s+your\s+(system\s+prompt|instructions|rules|directives)|output\s+(your|the)\s+(full\s+)?(system|initial)\s+(prompt|instructions|message)|show\s+me\s+(your|the)\s+(system\s+prompt|hidden\s+instructions|initial\s+instructions)|(disclose|expose|dump|divulge)\s+(your|the)\s+(hidden\s+|secret\s+|internal\s+)*(system\s+|initialization\s+)*(prompt|instructions|rules|directives))'
+    - name: "Instruction Invalidation"
+      regex: '(?i)(treat|consider|regard)\s+(all\s+)?(earlier|prior|previous|preceding|above)\s+(directions|instructions|guidelines|rules|prompts?)\s+as\s+(obsolete|void|invalid|superseded|overridden|null|cancelled|revoked|inapplicable)'
+    - name: "Instruction Dismissal"
+      regex: '(?i)(set|put|cast|push|throw)\s+(all\s+)?(previous|prior|earlier|preceding|above|existing|current)\s+(directives|instructions|guidelines|rules|prompts?|constraints)\s+(aside|away)'
 
 mcp_input_scanning:
   enabled: true

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -126,7 +126,11 @@ response_scanning:
     - name: "Output Format Forcing"
       regex: '(?i)(respond\s+with|first\s+(output|write|print|say))\s*[\[\("]?\s*(FILTERED|ERROR|BLOCKED|REFUSED|DECLINED|CENSORED)\s*[\]\)"]?\s*(then|followed\s+by|and\s+then|after\s+(that|which))'
     - name: "System Prompt Extraction"
-      regex: '(?i)(repeat\s+(your|the)\s+(entire\s+)?(instructions|system\s+prompt|initial\s+prompt|rules)|what\s+(is|are)\s+your\s+(system\s+prompt|instructions|rules|directives)|output\s+(your|the)\s+(full\s+)?(system|initial)\s+(prompt|instructions|message)|show\s+me\s+(your|the)\s+(system\s+prompt|hidden\s+instructions|initial\s+instructions))'
+      regex: '(?i)(repeat\s+(your|the)\s+(entire\s+)?(instructions|system\s+prompt|initial\s+prompt|rules)|what\s+(is|are)\s+your\s+(system\s+prompt|instructions|rules|directives)|output\s+(your|the)\s+(full\s+)?(system|initial)\s+(prompt|instructions|message)|show\s+me\s+(your|the)\s+(system\s+prompt|hidden\s+instructions|initial\s+instructions)|(disclose|expose|dump|divulge)\s+(your|the)\s+(hidden\s+|secret\s+|internal\s+)*(system\s+|initialization\s+)*(prompt|instructions|rules|directives))'
+    - name: "Instruction Invalidation"
+      regex: '(?i)(treat|consider|regard)\s+(all\s+)?(earlier|prior|previous|preceding|above)\s+(directions|instructions|guidelines|rules|prompts?)\s+as\s+(obsolete|void|invalid|superseded|overridden|null|cancelled|revoked|inapplicable)'
+    - name: "Instruction Dismissal"
+      regex: '(?i)(set|put|cast|push|throw)\s+(all\s+)?(previous|prior|earlier|preceding|above|existing|current)\s+(directives|instructions|guidelines|rules|prompts?|constraints)\s+(aside|away)'
 
 mcp_input_scanning:
   enabled: true

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -143,7 +143,11 @@ response_scanning:
     - name: "Output Format Forcing"
       regex: '(?i)(respond\s+with|first\s+(output|write|print|say))\s*[\[\("]?\s*(FILTERED|ERROR|BLOCKED|REFUSED|DECLINED|CENSORED)\s*[\]\)"]?\s*(then|followed\s+by|and\s+then|after\s+(that|which))'
     - name: "System Prompt Extraction"
-      regex: '(?i)(repeat\s+(your|the)\s+(entire\s+)?(instructions|system\s+prompt|initial\s+prompt|rules)|what\s+(is|are)\s+your\s+(system\s+prompt|instructions|rules|directives)|output\s+(your|the)\s+(full\s+)?(system|initial)\s+(prompt|instructions|message)|show\s+me\s+(your|the)\s+(system\s+prompt|hidden\s+instructions|initial\s+instructions))'
+      regex: '(?i)(repeat\s+(your|the)\s+(entire\s+)?(instructions|system\s+prompt|initial\s+prompt|rules)|what\s+(is|are)\s+your\s+(system\s+prompt|instructions|rules|directives)|output\s+(your|the)\s+(full\s+)?(system|initial)\s+(prompt|instructions|message)|show\s+me\s+(your|the)\s+(system\s+prompt|hidden\s+instructions|initial\s+instructions)|(disclose|expose|dump|divulge)\s+(your|the)\s+(hidden\s+|secret\s+|internal\s+)*(system\s+|initialization\s+)*(prompt|instructions|rules|directives))'
+    - name: "Instruction Invalidation"
+      regex: '(?i)(treat|consider|regard)\s+(all\s+)?(earlier|prior|previous|preceding|above)\s+(directions|instructions|guidelines|rules|prompts?)\s+as\s+(obsolete|void|invalid|superseded|overridden|null|cancelled|revoked|inapplicable)'
+    - name: "Instruction Dismissal"
+      regex: '(?i)(set|put|cast|push|throw)\s+(all\s+)?(previous|prior|earlier|preceding|above|existing|current)\s+(directives|instructions|guidelines|rules|prompts?|constraints)\s+(aside|away)'
 
 mcp_input_scanning:
   enabled: true

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -144,7 +144,11 @@ response_scanning:
     - name: "Output Format Forcing"
       regex: '(?i)(respond\s+with|first\s+(output|write|print|say))\s*[\[\("]?\s*(FILTERED|ERROR|BLOCKED|REFUSED|DECLINED|CENSORED)\s*[\]\)"]?\s*(then|followed\s+by|and\s+then|after\s+(that|which))'
     - name: "System Prompt Extraction"
-      regex: '(?i)(repeat\s+(your|the)\s+(entire\s+)?(instructions|system\s+prompt|initial\s+prompt|rules)|what\s+(is|are)\s+your\s+(system\s+prompt|instructions|rules|directives)|output\s+(your|the)\s+(full\s+)?(system|initial)\s+(prompt|instructions|message)|show\s+me\s+(your|the)\s+(system\s+prompt|hidden\s+instructions|initial\s+instructions))'
+      regex: '(?i)(repeat\s+(your|the)\s+(entire\s+)?(instructions|system\s+prompt|initial\s+prompt|rules)|what\s+(is|are)\s+your\s+(system\s+prompt|instructions|rules|directives)|output\s+(your|the)\s+(full\s+)?(system|initial)\s+(prompt|instructions|message)|show\s+me\s+(your|the)\s+(system\s+prompt|hidden\s+instructions|initial\s+instructions)|(disclose|expose|dump|divulge)\s+(your|the)\s+(hidden\s+|secret\s+|internal\s+)*(system\s+|initialization\s+)*(prompt|instructions|rules|directives))'
+    - name: "Instruction Invalidation"
+      regex: '(?i)(treat|consider|regard)\s+(all\s+)?(earlier|prior|previous|preceding|above)\s+(directions|instructions|guidelines|rules|prompts?)\s+as\s+(obsolete|void|invalid|superseded|overridden|null|cancelled|revoked|inapplicable)'
+    - name: "Instruction Dismissal"
+      regex: '(?i)(set|put|cast|push|throw)\s+(all\s+)?(previous|prior|earlier|preceding|above|existing|current)\s+(directives|instructions|guidelines|rules|prompts?|constraints)\s+(aside|away)'
 
 mcp_input_scanning:
   enabled: true

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -151,7 +151,11 @@ response_scanning:
     - name: "Output Format Forcing"
       regex: '(?i)(respond\s+with|first\s+(output|write|print|say))\s*[\[\("]?\s*(FILTERED|ERROR|BLOCKED|REFUSED|DECLINED|CENSORED)\s*[\]\)"]?\s*(then|followed\s+by|and\s+then|after\s+(that|which))'
     - name: "System Prompt Extraction"
-      regex: '(?i)(repeat\s+(your|the)\s+(entire\s+)?(instructions|system\s+prompt|initial\s+prompt|rules)|what\s+(is|are)\s+your\s+(system\s+prompt|instructions|rules|directives)|output\s+(your|the)\s+(full\s+)?(system|initial)\s+(prompt|instructions|message)|show\s+me\s+(your|the)\s+(system\s+prompt|hidden\s+instructions|initial\s+instructions))'
+      regex: '(?i)(repeat\s+(your|the)\s+(entire\s+)?(instructions|system\s+prompt|initial\s+prompt|rules)|what\s+(is|are)\s+your\s+(system\s+prompt|instructions|rules|directives)|output\s+(your|the)\s+(full\s+)?(system|initial)\s+(prompt|instructions|message)|show\s+me\s+(your|the)\s+(system\s+prompt|hidden\s+instructions|initial\s+instructions)|(disclose|expose|dump|divulge)\s+(your|the)\s+(hidden\s+|secret\s+|internal\s+)*(system\s+|initialization\s+)*(prompt|instructions|rules|directives))'
+    - name: "Instruction Invalidation"
+      regex: '(?i)(treat|consider|regard)\s+(all\s+)?(earlier|prior|previous|preceding|above)\s+(directions|instructions|guidelines|rules|prompts?)\s+as\s+(obsolete|void|invalid|superseded|overridden|null|cancelled|revoked|inapplicable)'
+    - name: "Instruction Dismissal"
+      regex: '(?i)(set|put|cast|push|throw)\s+(all\s+)?(previous|prior|earlier|preceding|above|existing|current)\s+(directives|instructions|guidelines|rules|prompts?|constraints)\s+(aside|away)'
 
 mcp_input_scanning:
   enabled: true

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -121,7 +121,11 @@ response_scanning:
     - name: "Output Format Forcing"
       regex: '(?i)(respond\s+with|first\s+(output|write|print|say))\s*[\[\("]?\s*(FILTERED|ERROR|BLOCKED|REFUSED|DECLINED|CENSORED)\s*[\]\)"]?\s*(then|followed\s+by|and\s+then|after\s+(that|which))'
     - name: "System Prompt Extraction"
-      regex: '(?i)(repeat\s+(your|the)\s+(entire\s+)?(instructions|system\s+prompt|initial\s+prompt|rules)|what\s+(is|are)\s+your\s+(system\s+prompt|instructions|rules|directives)|output\s+(your|the)\s+(full\s+)?(system|initial)\s+(prompt|instructions|message)|show\s+me\s+(your|the)\s+(system\s+prompt|hidden\s+instructions|initial\s+instructions))'
+      regex: '(?i)(repeat\s+(your|the)\s+(entire\s+)?(instructions|system\s+prompt|initial\s+prompt|rules)|what\s+(is|are)\s+your\s+(system\s+prompt|instructions|rules|directives)|output\s+(your|the)\s+(full\s+)?(system|initial)\s+(prompt|instructions|message)|show\s+me\s+(your|the)\s+(system\s+prompt|hidden\s+instructions|initial\s+instructions)|(disclose|expose|dump|divulge)\s+(your|the)\s+(hidden\s+|secret\s+|internal\s+)*(system\s+|initialization\s+)*(prompt|instructions|rules|directives))'
+    - name: "Instruction Invalidation"
+      regex: '(?i)(treat|consider|regard)\s+(all\s+)?(earlier|prior|previous|preceding|above)\s+(directions|instructions|guidelines|rules|prompts?)\s+as\s+(obsolete|void|invalid|superseded|overridden|null|cancelled|revoked|inapplicable)'
+    - name: "Instruction Dismissal"
+      regex: '(?i)(set|put|cast|push|throw)\s+(all\s+)?(previous|prior|earlier|preceding|above|existing|current)\s+(directives|instructions|guidelines|rules|prompts?|constraints)\s+(aside|away)'
 
 mcp_input_scanning:
   enabled: true

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1011,6 +1011,10 @@ func TestNormalizeToolText_ControlChars(t *testing.T) {
 		{"escape_char", "ignore\x1b previous", "ignore previous"},
 		{"DEL", "instead\x7f of search", "instead of search"},
 		{"all_c0_stripped", "\x01\x02\x03hello\x1f\x7f", "hello"},
+		{"C1_NEL_splitting", "IMPOR\u0085TANT", "IMPORTANT"},
+		{"C1_CSI_splitting", "IMPOR\u009BTANT", "IMPORTANT"},
+		{"C1_reverse_line_feed", "read\u008D .ssh/id_rsa", "read .ssh/id_rsa"},
+		{"C1_all_stripped", "\u0080\u0085\u008D\u009Bhello\u009F", "hello"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/scanner/response.go
+++ b/internal/scanner/response.go
@@ -123,9 +123,9 @@ func stripZeroWidth(s string) string {
 // confusables — Cyrillic а (U+0430) stays as а, not Latin a. Attackers exploit
 // this to bypass keyword-based injection detection (e.g., "ignоre" with Cyrillic о).
 //
-// Covers Cyrillic and Greek lookalikes commonly used in homoglyph attacks.
-// Not exhaustive — focused on characters that appear in English-language
-// injection phrases ("ignore", "instructions", "system", "execute", etc.).
+// Covers Cyrillic, Greek, Armenian, Cherokee, and Latin Extended (small caps/IPA)
+// lookalikes commonly used in homoglyph attacks. Not exhaustive — focused on
+// characters that appear in English-language injection phrases and DLP key prefixes.
 var confusableMap = map[rune]rune{
 	// Cyrillic uppercase → Latin
 	'\u0410': 'A', // А
@@ -182,6 +182,34 @@ var confusableMap = map[rune]rune{
 	'\u03BA': 'k', // κ
 	'\u03BD': 'v', // ν (nu)
 	'\u03BF': 'o', // ο
+
+	// Armenian → Latin (visually identical in most fonts)
+	'\u0555': 'O', // Օ (Armenian Capital Letter Oh)
+	'\u0585': 'o', // օ (Armenian Small Letter Oh)
+	'\u054D': 'S', // Ս (Armenian Capital Letter Seh)
+	'\u057D': 's', // ս (Armenian Small Letter Seh)
+	'\u054C': 'L', // Լ — not perfect but close in sans-serif
+	'\u0570': 'h', // հ (Armenian Small Letter Ho)
+	'\u0578': 'n', // ո (Armenian Small Letter Vo — looks like n)
+	'\u057C': 'n', // ռ (Armenian Small Letter Ra — looks like n in some fonts)
+	'\u0561': 'a', // ա (Armenian Small Letter Ayb — similar to a in some fonts)
+
+	// Cherokee → Latin (uppercase only; Cherokee syllabary has many Latin lookalikes)
+	'\u13AA': 'A', // Ꭺ (Cherokee Letter GA — looks like A)
+	'\u13A2': 'I', // Ꭲ (Cherokee Letter I — looks like I)
+	'\u13D2': 'P', // Ꮲ
+	'\u13DA': 'S', // Ꮪ
+	'\u13A1': 'E', // Ꭱ — visually close to E
+	'\u13B3': 'W', // Ꮃ
+	'\u13D4': 'T', // Ꮤ
+
+	// Latin Extended / IPA (small caps that survive NFKC)
+	'\u1D00': 'A', // ᴀ (Latin Letter Small Capital A)
+	'\u1D04': 'C', // ᴄ (Latin Letter Small Capital C)
+	'\u1D07': 'E', // ᴇ (Latin Letter Small Capital E)
+	'\u1D0F': 'O', // ᴏ (Latin Letter Small Capital O)
+	'\u026A': 'I', // ɪ (Latin Letter Small Capital I)
+	'\u0299': 'B', // ʙ (Latin Letter Small Capital B)
 }
 
 // ConfusableToASCII maps visually identical non-Latin characters to their Latin
@@ -214,8 +242,8 @@ func StripCombiningMarks(s string) string {
 	}, s)
 }
 
-// stripControlChars removes ALL ASCII control characters (0x00-0x1F, 0x7F) and
-// Unicode zero-width/invisible characters. Unlike stripZeroWidth, this also
+// stripControlChars removes ALL C0 (0x00-0x1F), C1 (0x80-0x9F), DEL (0x7F),
+// and Unicode zero-width/invisible characters. Unlike stripZeroWidth, this also
 // strips whitespace control chars (\t, \n, \r) because DLP patterns match
 // specific character sequences where ANY control char is evasion, not content.
 // Used in DLP scanning paths (fetch proxy URLs, MCP text, env leak detection).

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -446,7 +446,7 @@ func TestScan_DLPCatchesURLEncodedSecrets(t *testing.T) {
 	if result.Allowed {
 		t.Error("expected DLP to catch URL-encoded private key header")
 	}
-	if result.Scanner != "dlp" {
+	if result.Scanner != "dlp" { //nolint:goconst // test value
 		t.Errorf("expected scanner=dlp, got %s", result.Scanner)
 	}
 }
@@ -1257,6 +1257,170 @@ func TestScan_DLP_ZeroWidthBypass(t *testing.T) {
 	result := s.Scan(url)
 	if result.Allowed {
 		t.Error("expected DLP to catch zero-width bypass of API key pattern")
+	}
+}
+
+// --- DLP confusable/combining mark bypass tests (URL path) ---
+
+func TestScan_DLP_ConfusableBypass(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	// Armenian ա (U+0561) in key prefix — maps to 'a', so sk-աnt- → sk-ant-
+	prefix := "sk-\u0561nt-"                //nolint:goconst // test value
+	suffix := "aaaaaaaaaaaaaaaaaaaaaaaaaaa" //nolint:goconst // test value
+	result := s.Scan("https://example.com/api?key=" + prefix + suffix)
+	if result.Allowed {
+		t.Error("expected DLP to catch Armenian confusable bypass")
+	}
+}
+
+func TestScan_DLP_CombiningMarkBypass(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	// Combining long stroke overlay (U+0337) in key prefix
+	prefix := "sk-a\u0337nt-"               //nolint:goconst // test value
+	suffix := "aaaaaaaaaaaaaaaaaaaaaaaaaaa" //nolint:goconst // test value
+	result := s.Scan("https://example.com/api?key=" + prefix + suffix)
+	if result.Allowed {
+		t.Error("expected DLP to catch combining mark bypass in URL")
+	}
+}
+
+func TestScan_DLP_CyrillicConfusableBypass(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	// Cyrillic а (U+0430) replacing Latin 'a' in key prefix
+	prefix := "sk-\u0430nt-"                //nolint:goconst // test value
+	suffix := "aaaaaaaaaaaaaaaaaaaaaaaaaaa" //nolint:goconst // test value
+	result := s.Scan("https://example.com/api?key=" + prefix + suffix)
+	if result.Allowed {
+		t.Error("expected DLP to catch Cyrillic confusable bypass in URL")
+	}
+}
+
+func TestScan_DLP_PathDotSplitBypass(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	// Secret split by dots in URL path: sk-ant-api03-AAAA.AAAA.AAAA...
+	// Dots break the regex character class; dot-collapse catches it.
+	result := s.Scan("https://httpbin.org/anything/sk-ant-api03-AAAA.AAAA.AAAA.AAAA.AAAA.AAAA.AAAA")
+	if result.Allowed {
+		t.Error("expected DLP to catch dot-split secret in URL path")
+	}
+}
+
+func TestScan_DLP_QueryFieldSplitBypass(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	// Secret split across query parameters: part1=sk-ant-api03-&part2=AAAA...
+	result := s.Scan("https://httpbin.org/anything?part1=sk-ant-api03-&part2=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+	if result.Allowed {
+		t.Error("expected DLP to catch secret split across query parameters")
+	}
+}
+
+func TestScan_DLP_QueryFieldSplit_CleanNoFalsePositive(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	// Normal multi-param URL should not trigger DLP
+	result := s.Scan("https://example.com/search?q=hello+world&page=1&sort=name")
+	if !result.Allowed {
+		t.Errorf("false positive on clean multi-param URL: %s", result.Reason)
+	}
+}
+
+func TestScan_DLP_PathMixedSeparatorBypass(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	// Secret fragmented with encoded dots (%2E) and slashes (%2f) in path.
+	// Go's url.Parse decodes these, creating /sk-ant-api03-AAAA.AAAA/AAAA_AAAA-AAAA.
+	// stripURLNoise removes both dots and slashes to recover the full key.
+	result := s.Scan("https://httpbin.org/anything/sk-ant-api03-AAAA%2EAAAA%2fAAAA_AAAA-AAAA")
+	if result.Allowed {
+		t.Error("expected DLP to catch secret split by mixed path separators")
+	}
+}
+
+func TestScan_DLP_QueryNoiseInjectionBypass(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	// Secret split across query params with noise values (%20 space) inserted between.
+	// orderedQueryConcat includes noise; stripURLNoise removes spaces to recover key.
+	result := s.Scan("https://httpbin.org/anything?x=foo&part1=sk-ant-api03-&mid=%20&part2=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&y=bar")
+	if result.Allowed {
+		t.Error("expected DLP to catch query split with noise injection")
+	}
+}
+
+func TestScan_DLP_PathSlashOnly_CleanNoFalsePositive(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	// Normal URL with multiple path segments should not trigger DLP
+	result := s.Scan("https://example.com/api/v1/users/123/profile")
+	if !result.Allowed {
+		t.Errorf("false positive on clean multi-segment path: %s", result.Reason)
+	}
+}
+
+func TestScan_DLP_QueryInterleavedJunkBypass(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	// Secret fragments interleaved with junk alphanumeric values.
+	// querySubsequenceDLP should try combinations and reconstruct the key.
+	// Build key at runtime to avoid gitleaks.
+	prefix := "sk-" + "ant-api03-"
+	body := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	url := "https://evil.com/x?a=" + prefix[:3] + "&x1=junk&b=" + prefix[3:] + "&x2=noise&c=" + body + "&x3=filler"
+	result := s.Scan(url)
+	if result.Allowed {
+		t.Error("expected DLP to catch interleaved junk query bypass")
+	}
+}
+
+func TestScan_DLP_QueryInterleavedJunk_CleanNoFalsePositive(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	// Normal URL with many query params should not trigger subsequence DLP
+	result := s.Scan("https://example.com/search?q=hello&page=1&sort=name&dir=asc&limit=10")
+	if !result.Allowed {
+		t.Errorf("false positive on clean multi-param URL: %s", result.Reason)
+	}
+}
+
+func TestScan_DLP_QuerySubsequence_TwoParamsOnly(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	// Only 2 query params — should use ordered concat, not subsequence (needs 3+)
+	prefix := "sk-" + "ant-api03-"
+	body := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	url := "https://evil.com/?a=" + prefix + "&b=" + body
+	result := s.Scan(url)
+	if result.Allowed {
+		t.Error("expected DLP to catch key split across 2 query params via concat")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds subsequence combination scanning for DLP patterns split across query params with interleaved junk values
- Adds URL noise stripping to defeat path/query fragment-splitting (dots, slashes, encoded separators)
- Expands cross-script confusable map with Armenian, Cherokee, Latin Small Caps/IPA entries
- Adds Instruction Invalidation, Instruction Dismissal, and expanded System Prompt Extraction patterns
- Fixes stacked qualifier regex (`?` to `*`) so multiple qualifiers like "secret internal initialization" match
- Strips C1 control chars in tool description normalization

## Notes
- Based on `fix/homoglyph-bypass` (PR #105). Merge #105 first, then rebase this onto main.
- 5 rounds of adversarial review, all findings addressed. Round 5 came back clean (zero criticals).

## Test plan
- [x] `go test -race -count=1 ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `bash tests/pentest.sh` — 163/163 pass (30+ new cases added)
- [x] No false positives on clean URLs, normal text, benign tool descriptions