### PR TITLE
Prepare v0.2.4: changelog, update version refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-02-19
+
 ### Added
-- MCP Streamable HTTP transport: `pipelock mcp proxy --upstream <url>` bridges stdio clients to remote MCP servers over HTTP
-- SSE reader for parsing Server-Sent Events responses from HTTP MCP servers
-- GET SSE stream support for server-initiated messages (notifications, requests)
-- Session lifecycle management (Mcp-Session-Id tracking, DELETE on exit)
-- Full bidirectional scanning on HTTP transport (response injection, input DLP, tool poisoning, tool call policy)
+- MCP Streamable HTTP transport: `pipelock mcp proxy --upstream <url>` bridges stdio clients to remote MCP servers over HTTP with SSE stream support and session lifecycle management (PR #112)
+- Pre-execution tool call policy: configurable `mcp_tool_policy` blocks dangerous commands (rm -rf, curl to external, chmod 777) before MCP tools execute, with pairwise token matching and whitespace normalization (PR #107)
+- Known secret scanning: `dlp.secrets_file` config loads explicit secrets from file, scans URLs and MCP tool arguments for raw + base64/hex/base32 encoded variants including unpadded forms (PR #111)
+- `pipelock test` CLI command: validates scanner coverage against loaded config with structured pass/fail output per scanner layer (PR #109)
+- Framework integration guides: OpenAI Agents SDK, Google ADK, AutoGen (PR #110)
+- GOVERNANCE.md, ROADMAP.md, and security assurance documentation for OpenSSF Silver (PR #108)
+- OpenSSF Best Practices Silver badge (PR #114)
+
+### Fixed
+- Unicode bypass in injection and DLP scanning: full homoglyph normalization (Cyrillic, Greek, Armenian, Cherokee), combining mark stripping, leetspeak normalization, 6 new injection patterns (PR #105)
+- govulncheck CI flake: pinned Go version to 1.24.13 to prevent runner cache inconsistency (PR #113)
+- Codecov targets raised to 95% project / 90% patch (PR #113)
+
+### Changed
+- README Quick Start reordered: `pipelock check` before `pipelock run` since check doesn't need a running proxy (PR #113)
+- CONTRIBUTING.md updated with complete CLI command list and project structure (PR #113)
+- Demo script uses `DEMO_TMPDIR` instead of `TMPDIR` to avoid shadowing POSIX env var (PR #113)
+- CI matrix tests Go 1.24 + 1.25 (PR #113)
 
 ## [0.2.3] - 2026-02-16
 

--- a/docs/compliance/eu-ai-act-mapping.md
+++ b/docs/compliance/eu-ai-act-mapping.md
@@ -6,7 +6,7 @@ How Pipelock's runtime security controls map to the [EU AI Act (Regulation 2024/
 
 **Disclaimer:** This document maps Pipelock's security features to EU AI Act requirements for informational purposes. It does not constitute legal advice or guarantee regulatory compliance. Organizations should consult qualified legal counsel for compliance obligations specific to their AI systems.
 
-**Last updated:** v0.2.3 (February 2026)
+**Last updated:** v0.2.4 (February 2026)
 
 ---
 

--- a/docs/guides/autogen.md
+++ b/docs/guides/autogen.md
@@ -251,7 +251,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.3)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.4)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal

--- a/docs/guides/google-adk.md
+++ b/docs/guides/google-adk.md
@@ -272,7 +272,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.3)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.4)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal

--- a/docs/guides/langgraph.md
+++ b/docs/guides/langgraph.md
@@ -197,7 +197,7 @@ Use `dockerfile_lines` in `langgraph.json` to install Pipelock into the image:
     "env": ".env",
     "dockerfile_lines": [
         "RUN apt-get update && apt-get install -y curl",
-        "RUN PIPELOCK_VERSION=0.2.3 && curl -fsSL https://github.com/luckyPipewrench/pipelock/releases/download/v${PIPELOCK_VERSION}/pipelock_${PIPELOCK_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin/",
+        "RUN PIPELOCK_VERSION=0.2.4 && curl -fsSL https://github.com/luckyPipewrench/pipelock/releases/download/v${PIPELOCK_VERSION}/pipelock_${PIPELOCK_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin/",
         "COPY pipelock-config.yaml /etc/pipelock/config.yaml"
     ]
 }

--- a/docs/guides/openai-agents.md
+++ b/docs/guides/openai-agents.md
@@ -257,7 +257,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.3)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.4)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal


### PR DESCRIPTION
## Summary
- Add v0.2.4 changelog entry covering PRs #105–#114
- Update version references from v0.2.3 to v0.2.4 in docs (EU AI Act mapping, framework integration guides)

## Test plan
- [x] `golangci-lint run ./...` — zero issues
- [x] `go test -race -count=1 ./...` — all tests pass
- [x] Binary builds with v0.2.4 ldflags, `pipelock version` confirms
- [x] Full security suite (232/232 pen test cases pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with version 0.2.4 release information
  * Updated documentation guides and compliance mappings to reflect version 0.2.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->