### PR TITLE
Prepare v0.2.7: changelog, update version refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.6] - 2026-02-24
+## [0.2.7] - 2026-02-22
+
+### Added
+- MCP HTTP reverse proxy: `--mcp-listen` + `--mcp-upstream` flags on `pipelock run` create an HTTP-to-HTTP scanning proxy with bidirectional JSON-RPC 2.0 validation, Authorization header DLP scanning, and fail-closed parse error handling (PR #127)
+- MCP standalone HTTP listener: `pipelock mcp proxy --listen :8889 --upstream http://host/mcp` for deployments that only need MCP scanning without the fetch/forward proxy (PR #127)
+- JSON-RPC 2.0 structural validation on HTTP listener: rejects non-string method types, wrong/missing jsonrpc version, and missing method field with proper -32600 error codes; batch requests pass through to per-element scanning (PR #127)
+- CI dogfooding: Pipelock's own GitHub Action runs on every PR, scanning diffs for exposed credentials and injection patterns (PR #126)
+
+### Fixed
+- Release workflow: semver-only tag filter (`v*.*.*`) prevents floating tags like `v1` from triggering spurious GoReleaser releases (PR #126)
+- Auto-move `v1` floating tag after each semver release so the GitHub Action always resolves to the latest version (PR #126)
+
+### Changed
+- MCP auto-enable default: `mcp_input_scanning.action` changed from `warn` to `block` when auto-enabled in proxy mode, preventing credential forwarding in balanced configs (PR #127)
+- Default response scanning and DLP patterns auto-populated when MCP listener enables scanning on an unconfigured section (PR #127)
+
+## [0.2.6] - 2026-02-21
 
 ### Added
 - HTTP forward proxy: standard CONNECT tunneling and absolute-URI HTTP forwarding on the same port as the fetch proxy. Set `HTTPS_PROXY=http://localhost:8888` and all agent HTTP traffic flows through the scanner pipeline. Configurable tunnel duration and idle timeout controls (PR #123)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Response scanning adds prompt injection detection on fetched content.
 
 ### MCP Proxy
 
-Wraps any MCP server with bidirectional scanning. Supports two transport modes: stdio subprocess (`-- COMMAND`) and Streamable HTTP (`--upstream URL`). Server responses are scanned for prompt injection. Client requests are scanned for DLP leaks and injection in tool arguments (configurable via `mcp_input_scanning`). Tool descriptions are scanned for poisoned instructions and tracked for rug-pull changes (configurable via `mcp_tool_scanning`). All three scanning modes auto-enable in proxy mode unless explicitly configured.
+Wraps any MCP server with bidirectional scanning. Supports three transport modes: stdio subprocess (`-- COMMAND`), Streamable HTTP stdio-to-HTTP (`--upstream URL`), and HTTP reverse proxy (`--listen ADDR --upstream URL`). The HTTP reverse proxy mode is also available via `pipelock run --mcp-listen --mcp-upstream` for combined fetch/forward + MCP deployments. Server responses are scanned for prompt injection. Client requests are scanned for DLP leaks and injection in tool arguments (configurable via `mcp_input_scanning`). Tool descriptions are scanned for poisoned instructions and tracked for rug-pull changes (configurable via `mcp_tool_scanning`). All three scanning modes auto-enable in proxy mode unless explicitly configured.
 
 ### Key Design Decisions
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ flowchart LR
 | Prompt injection detection | Yes | Yes | No | No |
 | Workspace integrity monitoring | Yes | No | No | Partial |
 | MCP scanning (bidirectional + tool poisoning) | Yes | Yes | No | No |
-| MCP HTTP transport (Streamable HTTP) | Yes | No | No | No |
+| MCP HTTP transport (Streamable HTTP + reverse proxy) | Yes | No | No | No |
 | Single binary, zero deps | Yes | No (Python) | No (npm) | No (kernel-level enforcement) |
 | Audit logging + Prometheus | Yes | No | No | No |
 
@@ -272,6 +272,12 @@ pipelock mcp proxy --config pipelock.yaml -- npx -y @modelcontextprotocol/server
 
 # Proxy a remote MCP server (Streamable HTTP transport)
 pipelock mcp proxy --upstream http://localhost:8080/mcp
+
+# HTTP reverse proxy (MCP-to-MCP, for server deployments)
+pipelock mcp proxy --listen 0.0.0.0:8889 --upstream http://upstream:3000/mcp
+
+# Combined mode (fetch/forward proxy + MCP listener on separate ports)
+pipelock run --config pipelock.yaml --mcp-listen 0.0.0.0:8889 --mcp-upstream http://localhost:3000/mcp
 
 # Batch scan (stdin)
 mcp-server | pipelock mcp scan
@@ -424,7 +430,7 @@ Scan your project for agent security risks on every PR. No Go toolchain needed.
 
 ```yaml
 # .github/workflows/pipelock.yaml
-- uses: luckyPipewrench/pipelock@v0.2.6
+- uses: luckyPipewrench/pipelock@v0.2.7
   with:
     scan-diff: 'true'
     fail-on-findings: 'true'
@@ -435,7 +441,7 @@ The action downloads a pre-built binary, runs `pipelock audit` on your project, 
 **With a config file:**
 
 ```yaml
-- uses: luckyPipewrench/pipelock@v0.2.6
+- uses: luckyPipewrench/pipelock@v0.2.7
   with:
     config: pipelock.yaml
     test-vectors: 'true'
@@ -592,7 +598,7 @@ Canonical metrics — updated each release.
 
 | Metric | Value |
 |--------|-------|
-| Go tests (with `-race`) | 2,600+ |
+| Go tests (with `-race`) | 2,700+ |
 | Statement coverage | 96%+ |
 | Evasion techniques tested | 230+ |
 | Scanner pipeline overhead | ~25μs per URL scan |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -4,7 +4,7 @@
 
 Benchmarks measure the scanner pipeline only, not network I/O. This isolates Pipelock's overhead from the external fetch latency.
 
-Configuration used for these benchmarks (v0.2.6, balanced defaults):
+Configuration used for these benchmarks (v0.2.7, balanced defaults):
 - SSRF protection disabled (no DNS lookups)
 - Rate limiting disabled (no time-dependent state)
 - Response scanning: 20 prompt injection patterns

--- a/docs/compliance/eu-ai-act-mapping.md
+++ b/docs/compliance/eu-ai-act-mapping.md
@@ -6,7 +6,7 @@ How Pipelock's runtime security controls map to the [EU AI Act (Regulation 2024/
 
 **Disclaimer:** This document maps Pipelock's security features to EU AI Act requirements for informational purposes. It does not constitute legal advice or guarantee regulatory compliance. Organizations should consult qualified legal counsel for compliance obligations specific to their AI systems.
 
-**Last updated:** v0.2.6 (February 2026)
+**Last updated:** v0.2.7 (February 2026)
 
 ---
 

--- a/docs/guides/autogen.md
+++ b/docs/guides/autogen.md
@@ -251,7 +251,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.6)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.7)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal

--- a/docs/guides/google-adk.md
+++ b/docs/guides/google-adk.md
@@ -272,7 +272,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.6)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.7)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal

--- a/docs/guides/langgraph.md
+++ b/docs/guides/langgraph.md
@@ -197,7 +197,7 @@ Use `dockerfile_lines` in `langgraph.json` to install Pipelock into the image:
     "env": ".env",
     "dockerfile_lines": [
         "RUN apt-get update && apt-get install -y curl",
-        "RUN PIPELOCK_VERSION=0.2.6 && curl -fsSL https://github.com/luckyPipewrench/pipelock/releases/download/v${PIPELOCK_VERSION}/pipelock_${PIPELOCK_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin/",
+        "RUN PIPELOCK_VERSION=0.2.7 && curl -fsSL https://github.com/luckyPipewrench/pipelock/releases/download/v${PIPELOCK_VERSION}/pipelock_${PIPELOCK_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin/",
         "COPY pipelock-config.yaml /etc/pipelock/config.yaml"
     ]
 }

--- a/docs/guides/openai-agents.md
+++ b/docs/guides/openai-agents.md
@@ -257,7 +257,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.6)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.7)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal

--- a/examples/ci-workflow-advanced.yaml
+++ b/examples/ci-workflow-advanced.yaml
@@ -25,9 +25,9 @@ jobs:
 
       - name: Pipelock Scan
         id: scan
-        uses: luckyPipewrench/pipelock@v0.2.6
+        uses: luckyPipewrench/pipelock@v0.2.7
         with:
-          version: '0.2.6'
+          version: '0.2.7'
           config: pipelock.yaml
           scan-diff: 'true'
           test-vectors: 'true'

--- a/examples/ci-workflow.yaml
+++ b/examples/ci-workflow.yaml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0  # needed for PR diff scanning
 
       - name: Pipelock Scan
-        uses: luckyPipewrench/pipelock@v0.2.6
+        uses: luckyPipewrench/pipelock@v0.2.7
         with:
           # config: pipelock.yaml  # uncomment if you have a config
           scan-diff: 'true'


### PR DESCRIPTION
## Summary
- Add v0.2.7 changelog entry covering PR #126 (CI dogfooding, release workflow fix) and PR #127 (MCP HTTP reverse proxy)
- Bump version references from 0.2.6 to 0.2.7 across README, docs, examples, and CI workflows
- Update test count to 2,700+
- Fix v0.2.6 changelog date (was future-dated as Feb 24, actual tag date was Feb 21)
- Update CLAUDE.md MCP Proxy section to document three transport modes

## Test plan
- [ ] CI passes (doc-only changes, no code)
- [ ] Version refs consistently show 0.2.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP reverse proxy transport mode for MCP deployments.
  * Added combined deployment workflow mode via `pipelock run --mcp-listen --mcp-upstream`.

* **Documentation**
  * Updated all guides and examples with v0.2.7 version references.
  * Added example commands for HTTP reverse proxy and combined mode configurations.

* **Chores**
  * Updated benchmark metrics in canonical test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->