### PR TITLE
Prepare v0.2.9: changelog, version refs, action retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-02-23
+
 ### Added
 - WebSocket proxy: `/ws?url=ws://...` endpoint with bidirectional frame relay, DLP + injection scanning on text frames, fragment reassembly, message size limits, SSRF-safe upstream dialer, auth header forwarding with DLP scanning, concurrency limits, connection lifetime and idle timeout controls, and Prometheus metrics
 - WebSocket configuration: `websocket_proxy` section in config with `max_message_bytes`, `scan_text_frames`, `allow_binary_frames`, `strip_compression`, `max_connection_seconds`, `idle_timeout_seconds`, `origin_policy`, and `max_concurrent_connections`

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ Scan your project for agent security risks on every PR. No Go toolchain needed.
 
 ```yaml
 # .github/workflows/pipelock.yaml
-- uses: luckyPipewrench/pipelock@v0.2.8
+- uses: luckyPipewrench/pipelock@v0.2.9
   with:
     scan-diff: 'true'
     fail-on-findings: 'true'
@@ -491,7 +491,7 @@ The action downloads a pre-built binary, runs `pipelock audit` on your project, 
 **With a config file:**
 
 ```yaml
-- uses: luckyPipewrench/pipelock@v0.2.8
+- uses: luckyPipewrench/pipelock@v0.2.9
   with:
     config: pipelock.yaml
     test-vectors: 'true'

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 
 inputs:
   version:
-    description: 'Pipelock version to use (e.g., "0.2.8"). Defaults to latest release.'
+    description: 'Pipelock version to use (e.g., "0.2.9"). Defaults to latest release.'
     required: false
     default: 'latest'
   config:
@@ -68,7 +68,7 @@ runs:
         VERSION="$PIPELOCK_VERSION"
         if [ "$VERSION" = "latest" ]; then
           # Use GitHub API directly (no gh CLI dependency)
-          VERSION=$(curl -fsSL --connect-timeout 10 --max-time 30 \
+          VERSION=$(curl -fsSL --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors \
             -H "Authorization: token $GH_TOKEN" \
             "https://api.github.com/repos/luckyPipewrench/pipelock/releases/latest" \
             | jq -r '.tag_name' | sed 's/^v//')
@@ -104,8 +104,8 @@ runs:
         mkdir -p "$INSTALL_DIR"
 
         echo "Downloading pipelock v${VERSION} (${GOOS}/${GOARCH})..."
-        curl -fsSL --connect-timeout 10 --max-time 60 "${BASE_URL}/${ASSET}" -o "${INSTALL_DIR}/pipelock.tar.gz"
-        curl -fsSL --connect-timeout 10 --max-time 30 "${BASE_URL}/checksums.txt" -o "${INSTALL_DIR}/checksums.txt"
+        curl -fsSL --connect-timeout 10 --max-time 60 --retry 3 --retry-delay 2 --retry-all-errors "${BASE_URL}/${ASSET}" -o "${INSTALL_DIR}/pipelock.tar.gz"
+        curl -fsSL --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors "${BASE_URL}/checksums.txt" -o "${INSTALL_DIR}/checksums.txt"
 
         # Verify checksum (portable: sha256sum on Linux, shasum on macOS)
         EXPECTED=$(awk -v asset="$ASSET" '$2 == asset || $NF == asset {print $1; exit}' "${INSTALL_DIR}/checksums.txt")

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -4,7 +4,7 @@
 
 Benchmarks measure the scanner pipeline only, not network I/O. This isolates Pipelock's overhead from the external fetch latency.
 
-Configuration used for these benchmarks (v0.2.8, balanced defaults):
+Configuration used for these benchmarks (v0.2.9, balanced defaults):
 - SSRF protection disabled (no DNS lookups)
 - Rate limiting disabled (no time-dependent state)
 - Response scanning: 20 prompt injection patterns

--- a/docs/compliance/eu-ai-act-mapping.md
+++ b/docs/compliance/eu-ai-act-mapping.md
@@ -6,7 +6,7 @@ How Pipelock's runtime security controls map to the [EU AI Act (Regulation 2024/
 
 **Disclaimer:** This document maps Pipelock's security features to EU AI Act requirements for informational purposes. It does not constitute legal advice or guarantee regulatory compliance. Organizations should consult qualified legal counsel for compliance obligations specific to their AI systems.
 
-**Last updated:** v0.2.8 (February 2026)
+**Last updated:** v0.2.9 (February 2026)
 
 ---
 

--- a/docs/guides/autogen.md
+++ b/docs/guides/autogen.md
@@ -251,7 +251,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.8)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.9)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal

--- a/docs/guides/google-adk.md
+++ b/docs/guides/google-adk.md
@@ -272,7 +272,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.8)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.9)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal

--- a/docs/guides/langgraph.md
+++ b/docs/guides/langgraph.md
@@ -197,7 +197,7 @@ Use `dockerfile_lines` in `langgraph.json` to install Pipelock into the image:
     "env": ".env",
     "dockerfile_lines": [
         "RUN apt-get update && apt-get install -y curl",
-        "RUN PIPELOCK_VERSION=0.2.8 && curl -fsSL https://github.com/luckyPipewrench/pipelock/releases/download/v${PIPELOCK_VERSION}/pipelock_${PIPELOCK_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin/",
+        "RUN PIPELOCK_VERSION=0.2.9 && curl -fsSL https://github.com/luckyPipewrench/pipelock/releases/download/v${PIPELOCK_VERSION}/pipelock_${PIPELOCK_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin/",
         "COPY pipelock-config.yaml /etc/pipelock/config.yaml"
     ]
 }

--- a/docs/guides/openai-agents.md
+++ b/docs/guides/openai-agents.md
@@ -257,7 +257,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.8)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.2.9)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal

--- a/examples/ci-workflow-advanced.yaml
+++ b/examples/ci-workflow-advanced.yaml
@@ -25,9 +25,9 @@ jobs:
 
       - name: Pipelock Scan
         id: scan
-        uses: luckyPipewrench/pipelock@v0.2.8
+        uses: luckyPipewrench/pipelock@v0.2.9
         with:
-          version: '0.2.8'
+          version: '0.2.9'
           config: pipelock.yaml
           scan-diff: 'true'
           test-vectors: 'true'

--- a/examples/ci-workflow.yaml
+++ b/examples/ci-workflow.yaml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0  # needed for PR diff scanning
 
       - name: Pipelock Scan
-        uses: luckyPipewrench/pipelock@v0.2.8
+        uses: luckyPipewrench/pipelock@v0.2.9
         with:
           # config: pipelock.yaml  # uncomment if you have a config
           scan-diff: 'true'


### PR DESCRIPTION
## Summary
- Move Unreleased changelog entries to v0.2.9 section
- Bump version references across docs, examples, and action.yml (0.2.8 to 0.2.9)
- Add curl retry logic to GitHub Action download step (--retry 3 --retry-delay 2 --retry-all-errors) to survive transient 502s

Merge, then tag `v0.2.9` to trigger GoReleaser.