### PR TITLE
fix: close WebSocket cross-message DLP bypass

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strconv"
 
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
 	"github.com/spf13/cobra"
 )
 
@@ -51,6 +52,7 @@ var (
 
 // Execute runs the root command.
 func Execute() error {
+	proxy.Version = Version // sync so /health reports the same version as CLI
 	return rootCmd().Execute()
 }
 


### PR DESCRIPTION
## Summary

- Add 512-byte rolling tail buffer in `clientToUpstream()` to catch secrets split across separate complete WebSocket messages
- Each text message is now scanned with the tail of the previous message prepended
- Closes the gap where splitting a secret across two FIN=1 messages evaded per-message DLP scanning

## Test plan

- [x] 6 new tests: two-way split, three-way split, clean sequence (no FP), tail eviction, Anthropic key split, fragment+split interaction
- [x] Full test suite passes with race detector
- [x] golangci-lint clean (0 issues)
- [x] All 3 security test layers pass (350/350)
- [x] Dev build deployed to red team sidecar and verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced WebSocket DLP scanning to detect sensitive content split across consecutive messages in both directions.

* **Tests**
  * Added comprehensive cross-message DLP tests covering split secrets, multi-part keys, fragment reassembly, tail eviction, and clean sequences.

* **Chores**
  * CLI now synchronizes the reported service version with the health endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->