### PR TITLE
fix: WS scanner label split, mcporter field preservation, OpenClaw README link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Demo extended with base64-encoded secret detection, git diff scanning, and config generation steps
 
 ### Fixed
+- `generate mcporter` now preserves per-server extra fields (`alwaysAllow`, `disabled`, `metadata`, `headers`, etc.) during wrapping. Previously only `command`, `args`, and `env` survived.
 - Reject WebSocket compressed frames (RSV1 bit): compressed bytes bypass DLP pattern matching entirely, now closed with StatusProtocolError on both relay directions
 - Scan raw HTML body before go-readability extraction: injection hidden in HTML comments, script/style tags, and hidden elements was stripped before the response scanner could detect it
 - Use Mozilla Public Suffix List for ccTLD-aware domain grouping: `baseDomain()` now correctly groups `evil.co.uk` instead of merging all `.co.uk` domains into one rate limit bucket
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RFC 6455 compliance: WebSocket proxy now sends masked close frames to upstream connections (previously sent unmasked server-style frames)
 
 ### Changed
+- **Telemetry label split:** WebSocket protocol enforcement events (binary frame rejection, fragment errors) now emit scanner label `ws_protocol` instead of `policy`. The `policy` label is now exclusively for MCP tool policy violations. MITRE mapping: `ws_protocol` maps to T1071 (Application Layer Protocol), `policy` remains T1059 (Command and Scripting Interpreter). Update any dashboards or alert rules that filter on `scanner="policy"` for WebSocket-specific events.
 - `internal/wsutil` package extracted: shared WebSocket utilities (fragment reassembly, close frames, error classification) used by both the HTTP WS proxy and MCP WS transport
 - Anomaly audit events now include `scanner` as a structured field with MITRE technique mapping (previously embedded in reason string)
 - README slimmed from 829 to ~490 lines; full configuration YAML replaced with link to `docs/configuration.md`, forward proxy quick start moved to collapsible section

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Full reference with all fields, defaults, and hot-reload behavior: **[docs/confi
 - **[CrewAI](docs/guides/crewai.md):** `MCPServerStdio` wrapping, `MCPServerAdapter`
 - **[LangGraph](docs/guides/langgraph.md):** `MultiServerMCPClient`, `StateGraph`
 - **Cursor:** use `configs/cursor.yaml` with the same MCP proxy pattern as [Claude Code](docs/guides/claude-code.md)
+- **[OpenClaw](docs/guides/openclaw.md):** Gateway sidecar, init container, `generate mcporter` config wrapping
 
 ## CI Integration
 
@@ -446,6 +447,7 @@ Details, config examples, and gap analysis: [docs/owasp-mapping.md](docs/owasp-m
 | [OWASP Mapping](docs/owasp-mapping.md) | Coverage against OWASP Agentic AI Top 10 |
 | [Comparison](docs/comparison.md) | How pipelock compares to agent-scan, srt, agentsh, MCP Gateway |
 | [Finding Suppression](docs/guides/suppression.md) | Rule names, path matching, inline comments, CI integration |
+| [OpenClaw Guide](docs/guides/openclaw.md) | Gateway sidecar, init container, `generate mcporter` wrapping |
 | [Security Assurance](docs/security-assurance.md) | Security model, trust boundaries, supply chain |
 | [EU AI Act Mapping](docs/compliance/eu-ai-act-mapping.md) | Article-by-article compliance mapping |
 

--- a/internal/audit/technique.go
+++ b/internal/audit/technique.go
@@ -29,7 +29,10 @@ var techniqueMap = map[string]string{
 
 	// Command and scripting interpreter (response-side / MCP)
 	"response_scan": "T1059", // Command and Scripting Interpreter (prompt injection)
-	"policy":        "T1059", // Tool policy violation
+	"policy":        "T1059", // MCP tool policy violation
+
+	// WebSocket transport protocol enforcement
+	"ws_protocol": "T1071", // Application Layer Protocol (binary frame / fragment violation)
 
 	// Exploitation / parsing
 	"parser": "T1190", // Exploit Public-Facing Application

--- a/internal/audit/technique_test.go
+++ b/internal/audit/technique_test.go
@@ -38,6 +38,9 @@ func TestTechniqueForScanner_AllMappedEntries(t *testing.T) {
 		{"response_scan", "T1059"},
 		{"policy", "T1059"},
 
+		// WebSocket transport
+		{"ws_protocol", "T1071"},
+
 		// Exploitation
 		{"parser", "T1190"},
 
@@ -93,7 +96,7 @@ func TestTechniqueMap_NoDuplicateKeys(t *testing.T) {
 	// This test is a compile-time guarantee in Go (duplicate map keys are a
 	// compile error), but we verify the map has the expected number of entries
 	// to catch accidental deletions during refactoring.
-	const expectedEntries = 18
+	const expectedEntries = 19
 	if len(techniqueMap) != expectedEntries {
 		t.Errorf("techniqueMap has %d entries, expected %d (was an entry added or removed?)", len(techniqueMap), expectedEntries)
 	}

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -441,8 +441,8 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 		if hdr.OpCode == ws.OpBinary || (hdr.OpCode == ws.OpContinuation && frag.Active && frag.Opcode == ws.OpBinary) {
 			binaryFrames++
 			if !r.allowBinary {
-				log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, "policy", "binary frames not allowed", r.clientIP, r.requestID)
-				r.proxy.metrics.RecordWSScanHit("policy")
+				log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, "ws_protocol", "binary frames not allowed", r.clientIP, r.requestID)
+				r.proxy.metrics.RecordWSScanHit("ws_protocol")
 				plwsutil.WriteCloseFrame(r.clientConn, ws.StatusPolicyViolation, "binary frames not allowed")
 				plwsutil.WriteClientCloseFrame(r.upstreamConn, ws.StatusPolicyViolation, "binary frames not allowed")
 				blocked = true
@@ -453,7 +453,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 		// Fragment reassembly for text frames.
 		complete, msg, closeCode, closeReason := frag.Process(hdr, payload)
 		if closeCode != 0 {
-			log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, "policy", closeReason, r.clientIP, r.requestID)
+			log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, "ws_protocol", closeReason, r.clientIP, r.requestID)
 			plwsutil.WriteCloseFrame(r.clientConn, closeCode, closeReason)
 			plwsutil.WriteClientCloseFrame(r.upstreamConn, closeCode, closeReason)
 			blocked = true
@@ -614,8 +614,8 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 		if hdr.OpCode == ws.OpBinary || (hdr.OpCode == ws.OpContinuation && frag.Active && frag.Opcode == ws.OpBinary) {
 			binaryFrames++
 			if !r.allowBinary {
-				log.LogWSBlocked(r.targetURL, audit.DirectionServerToClient, "policy", "binary frames not allowed", r.clientIP, r.requestID)
-				r.proxy.metrics.RecordWSScanHit("policy")
+				log.LogWSBlocked(r.targetURL, audit.DirectionServerToClient, "ws_protocol", "binary frames not allowed", r.clientIP, r.requestID)
+				r.proxy.metrics.RecordWSScanHit("ws_protocol")
 				plwsutil.WriteCloseFrame(r.clientConn, ws.StatusPolicyViolation, "binary frames not allowed")
 				plwsutil.WriteClientCloseFrame(r.upstreamConn, ws.StatusPolicyViolation, "binary frames not allowed")
 				blocked = true
@@ -626,7 +626,7 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 		// Fragment reassembly.
 		complete, msg, closeCode, closeReason := frag.Process(hdr, payload)
 		if closeCode != 0 {
-			log.LogWSBlocked(r.targetURL, audit.DirectionServerToClient, "policy", closeReason, r.clientIP, r.requestID)
+			log.LogWSBlocked(r.targetURL, audit.DirectionServerToClient, "ws_protocol", closeReason, r.clientIP, r.requestID)
 			plwsutil.WriteCloseFrame(r.clientConn, closeCode, closeReason)
 			plwsutil.WriteClientCloseFrame(r.upstreamConn, closeCode, closeReason)
 			blocked = true


### PR DESCRIPTION
## Summary

- Decouple WebSocket protocol enforcement scanner label from MCP tool policy: binary frame rejection and fragment errors now emit `ws_protocol` (T1071) instead of overloading `policy` (T1059)
- Fix `generate mcporter` dropping per-server extra fields (`alwaysAllow`, `disabled`, `metadata`, `headers`) during wrapping
- Link OpenClaw deployment guide in README integration guides section and docs table

## Telemetry migration

The `policy` scanner label previously covered both MCP tool policy violations and WebSocket transport enforcement. This PR splits them:

| Event | Before | After |
|-------|--------|-------|
| MCP tool policy violation | `policy` (T1059) | `policy` (T1059) — unchanged |
| WS binary frame block | `policy` (T1059) | `ws_protocol` (T1071) |
| WS fragment error | `policy` (T1059) | `ws_protocol` (T1071) |

Update dashboards/alerts filtering on `scanner="policy"` for WebSocket events.

## Test plan

- [x] `TestGenerateMcporter_PreservesPerServerExtraFields` — stdio + URL entries preserve extra fields
- [x] `TestTechniqueForScanner_AllMappedEntries` — includes `ws_protocol` -> T1071
- [x] `TestTechniqueMap_NoDuplicateKeys` — expected count bumped to 19
- [x] Idempotency verified with extra fields (wrap twice, diff outputs)
- [x] Full test suite passes with race detector
- [x] golangci-lint clean (0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Generate mcporter now preserves per-server configuration fields (metadata, headers, disabled, alwaysAllow) during server wrapping.

* **Documentation**
  * Added OpenClaw integration reference for gateway sidecar deployment scenarios.

* **Other Changes**
  * Improved telemetry categorization for WebSocket protocol enforcement events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->