### PR TITLE
chore: fix Grafana dashboard template, document missing metrics

### DIFF
--- a/configs/grafana-dashboard.json
+++ b/configs/grafana-dashboard.json
@@ -660,22 +660,22 @@
               "uid": true,
               "prometheus": true,
               "Value #F": true,
-              "Value #A": true
+              "Value #A": true,
+              "Value #G": true
             },
             "renameByName": {
               "instance": "Agent",
               "namespace": "Namespace",
-              "Value #A": "Status",
               "Value #B": "Tunnels",
               "Value #C": "Data",
               "Value #D": "Avg Duration",
               "Value #E": "Evicted",
-              "Value #F": "(ns)"
+              "version": "Version"
             },
             "indexByName": {
               "instance": 0,
               "namespace": 1,
-              "Value #A": 2,
+              "version": 2,
               "Value #B": 3,
               "Value #C": 4,
               "Value #D": 5,
@@ -1219,7 +1219,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (scanner) (pipelock_scanner_hits_total{instance=~\"$instance\"}) or vector(0)",
+          "expr": "sum by (scanner) (pipelock_scanner_hits_total{instance=~\"$instance\"})",
           "refId": "A",
           "legendFormat": "{{scanner}}",
           "format": "time_series",
@@ -2300,5 +2300,5 @@
       ]
     }
   ],
-  "description": "Security monitoring for the Pipelock agent firewall. Tracks all 20 metric families: CONNECT tunnels, HTTP requests, scanner activity, session profiling, kill switch events, chain detection, and WebSocket proxy."
+  "description": "Security monitoring for the Pipelock agent firewall. Tracks all 22 metric families: CONNECT tunnels, HTTP requests, scanner activity, session profiling, kill switch events, chain detection, and WebSocket proxy."
 }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -71,6 +71,13 @@ inspect WebSocket frames for DLP and prompt injection.
 | `pipelock_ws_scan_hits_total` | counter | `scanner` | WebSocket frame scan detections by scanner. |
 | `pipelock_forward_ws_redirect_hint_total` | counter | (none) | CONNECT requests to known WebSocket API hosts (potential upgrade candidates). |
 
+## Build Information
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `pipelock_info` | gauge | `version` | Build information. Always 1. The `version` label identifies the running release (e.g. `0.3.1`). |
+| `pipelock_kill_switch_active` | gauge | `source` | Whether each kill switch source is active (1) or inactive (0). `source` is `config`, `api`, `signal`, or `sentinel`. Reported fresh on every scrape. |
+
 ## Security Event Metrics
 
 These counters track enforcement actions. In a healthy deployment, all of
@@ -144,7 +151,7 @@ An importable Grafana dashboard is included at
 [`configs/grafana-dashboard.json`](../configs/grafana-dashboard.json).
 Import it via **Dashboards → Import → Upload JSON file** in Grafana.
 
-The dashboard covers all 20 metric families across six sections: fleet
+The dashboard covers all 22 metric families across six sections: fleet
 overview, agent status table, traffic, connection details, security events,
 and WebSocket proxy.
 


### PR DESCRIPTION
## Summary
- Fix Fleet Status table: hide raw pipelock_info column, add Version column
- Fix Scanner Hit Distribution pie chart: remove `or vector(0)` that created phantom unlabeled slice
- Document `pipelock_info` and `pipelock_kill_switch_active` metrics (added in v0.3.1, missing from docs)
- Update metric family count from 20 to 22

Closes #151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added build information metric to track application version.
  * Added kill switch status metric to monitor system state activation sources.

* **Documentation**
  * Updated metrics docs to include the new metrics and reflect 22 metric families.
  * Updated Grafana dashboard to add a Version column and reorganize fields.

* **Bug Fixes**
  * Simplified a dashboard query expression for scanner hit aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->