### PR TITLE
feat: diagnose command, block hints, and v0.3.2 release prep

### DIFF
--- a/.github/workflows/reusable-scan.yml
+++ b/.github/workflows/reusable-scan.yml
@@ -66,13 +66,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0  # Full history needed for PR diff scanning
 
       - name: Run Pipelock
         id: pipelock
-        uses: luckyPipewrench/pipelock@v1
+        uses: luckyPipewrench/pipelock@34667f2146ff5404f31a25d4632b96c94377be12 # v1
         env:
           PIPELOCK_VERSION: ${{ inputs.pipelock-version }}
           PIPELOCK_CONFIG: ${{ inputs.config-path }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,24 @@ All notable changes to Pipelock will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.2] - 2026-03-02
+
+### Added
+- `pipelock diagnose` command: fully local end-to-end configuration verification. Spins up a mock upstream and temp proxy, runs 6 checks (health, fetch allowed/blocked, hint presence, CONNECT allowed/blocked). Exit 0 on pass, 1 on failure, 2 on config error. Supports `--json` and `--config`.
+- `explain_blocks` config field (opt-in, default false): blocked responses include actionable hints explaining why a request was blocked and how to fix it. Fetch proxy gets a JSON `hint` field, CONNECT and WebSocket get an `X-Pipelock-Hint` header. Hints are per-scanner (DLP, blocklist, SSRF, entropy, rate limit, etc.).
+- Scanner label constants (`scanner.ScannerDLP`, `scanner.ScannerBlocklist`, etc.): 12 exported constants matching existing on-wire metric label values
+- `proxy.Handler()` method: returns the composed HTTP handler for use with `httptest.NewServer` or custom listeners
+- Docker Compose quickstart (`examples/quickstart/`): production-ready two-network architecture with `internal: true` isolation, opt-in verification suite (5 tests: network isolation, DLP, response injection, MCP tool poisoning), attacker container for reproducible demos
+
+### Fixed
+- `generate mcporter` now preserves per-server extra fields (`alwaysAllow`, `disabled`, `metadata`, `headers`, etc.) during wrapping. Previously only `command`, `args`, and `env` survived.
+- WebSocket scanner label split: protocol enforcement events now correctly use `ws_protocol` label
+- Grafana dashboard template variable syntax corrected for fleet filtering
+
+### Changed
+- Reusable scan workflow actions pinned to commit SHAs for OpenSSF Scorecard compliance
+
+## [0.3.1] - 2026-03-01
 
 ### Added
 - WebSocket MCP transport: `--upstream ws://` and `wss://` for MCP proxy connections, with the same 6-layer scanning pipeline as stdio and HTTP modes
@@ -23,11 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Grafana dashboard rebuilt from 4-panel overview to 18-panel fleet monitor with per-source kill switch status, chain detection by pattern, session anomaly breakdown, escalation timeseries, and multi-instance `$instance` filter variable
 - `filterAndActOnResponseScan` helper: extracted response scan action handling (suppress, block, ask, strip, warn) to eliminate duplication between raw HTML and extracted text scan paths
 - Demo extended with base64-encoded secret detection, git diff scanning, and config generation steps
-- Docker Compose quickstart (`examples/quickstart/`): production-ready two-network architecture with `internal: true` isolation, opt-in verification suite (5 tests: network isolation, DLP, response injection, MCP tool poisoning), attacker container for reproducible demos
 
 ### Fixed
 - `internal: []` in YAML config now correctly disables SSRF checks. Previously, `ApplyDefaults()` treated explicit empty slices the same as absent fields, filling in default CIDRs. This blocked legitimate Docker container traffic on private IPs (172.x.x.x).
-- `generate mcporter` now preserves per-server extra fields (`alwaysAllow`, `disabled`, `metadata`, `headers`, etc.) during wrapping. Previously only `command`, `args`, and `env` survived.
 - Reject WebSocket compressed frames (RSV1 bit): compressed bytes bypass DLP pattern matching entirely, now closed with StatusProtocolError on both relay directions
 - Scan raw HTML body before go-readability extraction: injection hidden in HTML comments, script/style tags, and hidden elements was stripped before the response scanner could detect it
 - Use Mozilla Public Suffix List for ccTLD-aware domain grouping: `baseDomain()` now correctly groups `evil.co.uk` instead of merging all `.co.uk` domains into one rate limit bucket

--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -4,7 +4,7 @@
 # Usage in a pod spec:
 #   initContainers:
 #     - name: pipelock-init
-#       image: ghcr.io/luckypipewrench/pipelock-init:0.3.1
+#       image: ghcr.io/luckypipewrench/pipelock-init:0.3.2
 #       command: ["cp", "/pipelock", "/shared-bin/pipelock"]
 #       volumeMounts:
 #         - name: shared-bin

--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ See [docs/guides/siem-integration.md](docs/guides/siem-integration.md) for log s
 
 | Feature | What It Does |
 |---------|-------------|
+| **Diagnose** | `pipelock diagnose` runs 6 local checks to verify your config works end-to-end (no network required) |
+| **Block Hints** | Opt-in `explain_blocks: true` adds fix suggestions to blocked responses |
 | **Project Audit** | `pipelock audit ./project` scans for security risks and generates a tailored config |
 | **File Integrity** | SHA256 manifests detect modified, added, or removed workspace files |
 | **Git Protection** | `git diff \| pipelock git scan-diff` catches secrets before they're committed |
@@ -314,7 +316,7 @@ Scan your project for agent security risks on every PR. No Go toolchain needed.
 
 ```yaml
 # .github/workflows/pipelock.yaml
-- uses: luckyPipewrench/pipelock@v0.3.1
+- uses: luckyPipewrench/pipelock@v0.3.2
   with:
     scan-diff: 'true'
     fail-on-findings: 'true'
@@ -480,7 +482,7 @@ Canonical metrics, updated each release.
 
 | Metric | Value |
 |--------|-------|
-| Go tests (with `-race`) | 3,900+ |
+| Go tests (with `-race`) | 3,940+ |
 | Statement coverage | 95%+ |
 | Evasion techniques tested | 230+ |
 | Scanner pipeline overhead | ~25us per URL scan |

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 
 inputs:
   version:
-    description: 'Pipelock version to use (e.g., "0.3.1"). Defaults to latest release.'
+    description: 'Pipelock version to use (e.g., "0.3.2"). Defaults to latest release.'
     required: false
     default: 'latest'
   config:

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -4,7 +4,7 @@
 
 Benchmarks measure the scanner pipeline only, not network I/O. This isolates Pipelock's overhead from the external fetch latency.
 
-Configuration used for these benchmarks (v0.3.1, balanced defaults):
+Configuration used for these benchmarks (v0.3.2, balanced defaults):
 - SSRF protection disabled (no DNS lookups)
 - Rate limiting disabled (no time-dependent state)
 - Response scanning: 20 prompt injection patterns

--- a/docs/compliance/eu-ai-act-mapping.md
+++ b/docs/compliance/eu-ai-act-mapping.md
@@ -6,7 +6,7 @@ How Pipelock's runtime security controls map to the [EU AI Act (Regulation 2024/
 
 **Disclaimer:** This document maps Pipelock's security features to EU AI Act requirements for informational purposes. It does not constitute legal advice or guarantee regulatory compliance. Organizations should consult qualified legal counsel for compliance obligations specific to their AI systems.
 
-**Last updated:** v0.3.1 (March 2026)
+**Last updated:** v0.3.2 (March 2026)
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ If a reload fails validation (invalid regex, security downgrade), the old config
 version: 1                    # Config schema version (currently 1)
 mode: balanced                # "strict", "balanced", or "audit"
 enforce: true                 # false = detect without blocking (warning-only)
+explain_blocks: false         # true = include fix hints in block responses
 ```
 
 | Field | Type | Default | Description |
@@ -34,6 +35,17 @@ enforce: true                 # false = detect without blocking (warning-only)
 | `version` | int | `1` | Config schema version |
 | `mode` | string | `"balanced"` | Operating mode (see [Modes](#modes)) |
 | `enforce` | bool | `true` | When false, all blocks become warnings |
+| `explain_blocks` | bool | `false` | Include actionable hints in block responses |
+
+### Block Hints (`explain_blocks`)
+
+When enabled, blocked responses include a hint explaining why the request was blocked and how to fix it. Fetch proxy responses get a `hint` field in the JSON body. CONNECT and WebSocket rejections get an `X-Pipelock-Hint` response header.
+
+```yaml
+explain_blocks: true
+```
+
+**Security note:** Hints expose scanner names and config field names (e.g., "Add to api_allowlist", "Add a suppress entry"). This is useful for debugging but reveals your security policy to the agent. **Default: false (opt-in).** Enable when you trust your agent or need easier debugging. Leave disabled in production where untrusted agents could use hints to craft bypasses.
 
 ### Modes
 

--- a/docs/guides/autogen.md
+++ b/docs/guides/autogen.md
@@ -251,7 +251,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.3.1)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.3.2)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal

--- a/docs/guides/deployment-recipes.md
+++ b/docs/guides/deployment-recipes.md
@@ -128,7 +128,7 @@ spec:
       # Init container: copy pipelock binary for MCP stdio wrapping
       initContainers:
         - name: pipelock-init
-          image: ghcr.io/luckypipewrench/pipelock-init:0.3.1
+          image: ghcr.io/luckypipewrench/pipelock-init:0.3.2
           command: ["cp", "/pipelock", "/shared-bin/pipelock"]
           volumeMounts:
             - name: shared-bin
@@ -137,7 +137,7 @@ spec:
       containers:
         # Pipelock sidecar
         - name: pipelock
-          image: ghcr.io/luckypipewrench/pipelock:0.3.1
+          image: ghcr.io/luckypipewrench/pipelock:0.3.2
           args:
             - run
             - --config

--- a/docs/guides/google-adk.md
+++ b/docs/guides/google-adk.md
@@ -272,7 +272,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.3.1)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.3.2)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal

--- a/docs/guides/langgraph.md
+++ b/docs/guides/langgraph.md
@@ -197,7 +197,7 @@ Use `dockerfile_lines` in `langgraph.json` to install Pipelock into the image:
     "env": ".env",
     "dockerfile_lines": [
         "RUN apt-get update && apt-get install -y curl",
-        "RUN PIPELOCK_VERSION=0.3.1 && curl -fsSL https://github.com/luckyPipewrench/pipelock/releases/download/v${PIPELOCK_VERSION}/pipelock_${PIPELOCK_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin/",
+        "RUN PIPELOCK_VERSION=0.3.2 && curl -fsSL https://github.com/luckyPipewrench/pipelock/releases/download/v${PIPELOCK_VERSION}/pipelock_${PIPELOCK_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin/",
         "COPY pipelock-config.yaml /etc/pipelock/config.yaml"
     ]
 }

--- a/docs/guides/openai-agents.md
+++ b/docs/guides/openai-agents.md
@@ -257,7 +257,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.3.1)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:v0.3.2)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal

--- a/docs/guides/openclaw.md
+++ b/docs/guides/openclaw.md
@@ -166,7 +166,7 @@ spec:
     spec:
       initContainers:
         - name: pipelock-init
-          image: ghcr.io/luckypipewrench/pipelock-init:0.3.1
+          image: ghcr.io/luckypipewrench/pipelock-init:0.3.2
           command: ["cp", "/pipelock", "/shared-bin/pipelock"]
           volumeMounts:
             - name: shared-bin
@@ -187,7 +187,7 @@ spec:
               readOnly: true
 
         - name: pipelock
-          image: ghcr.io/luckypipewrench/pipelock:0.3.1
+          image: ghcr.io/luckypipewrench/pipelock:0.3.2
           args: ["run", "--listen", "0.0.0.0:8888"]
           ports:
             - containerPort: 8888

--- a/docs/guides/suppression.md
+++ b/docs/guides/suppression.md
@@ -88,7 +88,7 @@ Path patterns use the same matching rules as config suppress entries (exact, dir
 Use the `exclude-paths` input (one pattern per line):
 
 ```yaml
-- uses: luckyPipewrench/pipelock@v0.3.1
+- uses: luckyPipewrench/pipelock@v0.3.2
   with:
     exclude-paths: |
       vendor/
@@ -101,7 +101,7 @@ Use the `exclude-paths` input (one pattern per line):
 Use the `config` input to provide inline YAML config with suppress entries:
 
 ```yaml
-- uses: luckyPipewrench/pipelock@v0.3.1
+- uses: luckyPipewrench/pipelock@v0.3.2
   with:
     config: |
       suppress:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -75,7 +75,7 @@ inspect WebSocket frames for DLP and prompt injection.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `pipelock_info` | gauge | `version` | Build information. Always 1. The `version` label identifies the running release (e.g. `0.3.1`). |
+| `pipelock_info` | gauge | `version` | Build information. Always 1. The `version` label identifies the running release (e.g. `0.3.2`). |
 | `pipelock_kill_switch_active` | gauge | `source` | Whether each kill switch source is active (1) or inactive (0). `source` is `config`, `api`, `signal`, or `sentinel`. Reported fresh on every scrape. |
 
 ## Security Event Metrics

--- a/examples/ci-workflow-advanced.yaml
+++ b/examples/ci-workflow-advanced.yaml
@@ -25,9 +25,9 @@ jobs:
 
       - name: Pipelock Scan
         id: scan
-        uses: luckyPipewrench/pipelock@v0.3.1
+        uses: luckyPipewrench/pipelock@v0.3.2
         with:
-          version: '0.3.1'
+          version: '0.3.2'
           config: pipelock.yaml
           scan-diff: 'true'
           test-vectors: 'true'

--- a/examples/ci-workflow.yaml
+++ b/examples/ci-workflow.yaml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0  # needed for PR diff scanning
 
       - name: Pipelock Scan
-        uses: luckyPipewrench/pipelock@v0.3.1
+        uses: luckyPipewrench/pipelock@v0.3.2
         with:
           # config: pipelock.yaml  # uncomment if you have a config
           scan-diff: 'true'

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -15,7 +15,7 @@ This starts two containers:
 
 Set your agent's `HTTP_PROXY` and `HTTPS_PROXY` to `http://pipelock:8888`. The agent container already has these configured.
 
-Pin a specific version with `PIPELOCK_VERSION=0.3.1 docker compose up`.
+Pin a specific version with `PIPELOCK_VERSION=0.3.2 docker compose up`.
 
 ## Verify
 

--- a/internal/cli/diagnose.go
+++ b/internal/cli/diagnose.go
@@ -1,0 +1,386 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+const diagnoseTimeout = 5 * time.Second
+
+var diagnoseClient = &http.Client{Timeout: diagnoseTimeout}
+
+// diagnoseGet performs a GET request with a background context so noctx is satisfied.
+func diagnoseGet(url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return diagnoseClient.Do(req)
+}
+
+type diagnoseCheck struct {
+	Name string
+	Run  func(proxyURL, mockURL string, cfg *config.Config) diagnoseResult
+}
+
+type diagnoseResult struct {
+	Status string `json:"status"` // pass, fail, skip
+	Detail string `json:"detail,omitempty"`
+}
+
+type diagnoseReport struct {
+	ConfigFile string                `json:"config_file"`
+	Mode       string                `json:"mode"`
+	Total      int                   `json:"total"`
+	Passed     int                   `json:"passed"`
+	Failed     int                   `json:"failed"`
+	Skipped    int                   `json:"skipped"`
+	Checks     []diagnoseReportCheck `json:"checks"`
+}
+
+type diagnoseReportCheck struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+func diagnoseCmd() *cobra.Command {
+	var configFile string
+	var jsonOutput bool
+	var noColor bool
+
+	cmd := &cobra.Command{
+		Use:   "diagnose",
+		Short: "Run end-to-end diagnostic checks against a local proxy",
+		Long: `Spin up a temporary proxy with a local mock upstream and run diagnostic
+checks to verify your configuration works correctly. No network access required.
+
+Checks:
+  health           /health endpoint responds 200
+  fetch_allowed    Allowed fetch succeeds and returns content
+  fetch_blocked    DLP-triggering fetch is blocked correctly
+  fetch_hint       Blocked response includes actionable hint (requires explain_blocks)
+  forward_allowed  CONNECT tunnel to allowed host succeeds
+  forward_blocked  CONNECT tunnel to blocklisted host is rejected
+
+Exit codes:
+  0  All checks passed (skipped checks are OK)
+  1  One or more checks failed
+  2  Config load error`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, cfgLabel, err := loadTestConfig(configFile)
+			if err != nil {
+				return ExitCodeError(2, err)
+			}
+
+			// Disable SSRF so mock upstream at 127.0.0.1 is reachable.
+			cfg.Internal = nil
+			// Disable env scanning for self-test.
+			cfg.DLP.ScanEnv = false
+			// Enable forward proxy for CONNECT checks.
+			cfg.ForwardProxy.Enabled = true
+
+			color := !noColor && useColor()
+
+			return runDiagnose(cmd, cfg, cfgLabel, jsonOutput, color)
+		},
+	}
+
+	cmd.Flags().StringVarP(&configFile, "config", "c", "", "config file (default: built-in defaults)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output results as JSON")
+	cmd.Flags().BoolVar(&noColor, "no-color", false, "disable color output")
+
+	return cmd
+}
+
+func runDiagnose(cmd *cobra.Command, cfg *config.Config, cfgLabel string, jsonOut, color bool) error {
+	// Start mock upstream that responds 200 to everything.
+	// Use explicit listener to return an error instead of panicking.
+	var lc net.ListenConfig
+	mockLn, err := lc.Listen(cmd.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("mock upstream listener: %w", err)
+	}
+	mock := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("mock upstream OK"))
+	}))
+	mock.Listener = mockLn
+	mock.Start()
+	defer mock.Close()
+
+	// Add mock hostname (without port) to allowlist so fetch_allowed passes.
+	// MatchDomain compares against parsed.Hostname() which strips port.
+	mockHostPort := strings.TrimPrefix(mock.URL, "http://")
+	mockHost, _, _ := net.SplitHostPort(mockHostPort)
+	cfg.APIAllowlist = append(cfg.APIAllowlist, mockHost)
+
+	// Add a known blocklist entry for forward_blocked check.
+	cfg.FetchProxy.Monitoring.Blocklist = append(cfg.FetchProxy.Monitoring.Blocklist, "malware.example.com")
+
+	// Nop logger avoids writing to stdout, which would corrupt --json output.
+	sc := scanner.New(cfg)
+	defer sc.Close()
+	logger := audit.NewNop()
+	defer logger.Close()
+	m := metrics.New()
+
+	p := proxy.New(cfg, logger, sc, m)
+
+	// Start temp proxy using the composed handler.
+	proxyLn, err := lc.Listen(cmd.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("proxy listener: %w", err)
+	}
+	ts := httptest.NewUnstartedServer(p.Handler())
+	ts.Listener = proxyLn
+	ts.Start()
+	defer ts.Close()
+
+	checks := buildDiagnoseChecks()
+
+	report := diagnoseReport{
+		ConfigFile: cfgLabel,
+		Mode:       cfg.Mode,
+		Total:      len(checks),
+	}
+
+	for _, c := range checks {
+		result := c.Run(ts.URL, mock.URL, cfg)
+		switch result.Status {
+		case statusPass:
+			report.Passed++
+		case statusFail:
+			report.Failed++
+		case statusSkip:
+			report.Skipped++
+		}
+		report.Checks = append(report.Checks, diagnoseReportCheck{
+			Name:   c.Name,
+			Status: result.Status,
+			Detail: result.Detail,
+		})
+	}
+
+	if jsonOut {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			return fmt.Errorf("JSON encode: %w", err)
+		}
+	} else {
+		printDiagnoseTable(cmd.OutOrStdout(), report, color)
+	}
+
+	if report.Failed > 0 {
+		return ExitCodeError(1, fmt.Errorf("%d check(s) failed", report.Failed))
+	}
+	return nil
+}
+
+func buildDiagnoseChecks() []diagnoseCheck {
+	return []diagnoseCheck{
+		{Name: "health", Run: checkHealth},
+		{Name: "fetch_allowed", Run: checkFetchAllowed},
+		{Name: "fetch_blocked", Run: checkFetchBlocked},
+		{Name: "fetch_hint", Run: checkFetchHint},
+		{Name: "forward_allowed", Run: checkForwardAllowed},
+		{Name: "forward_blocked", Run: checkForwardBlocked},
+	}
+}
+
+func checkHealth(proxyURL, _ string, _ *config.Config) diagnoseResult {
+	resp, err := diagnoseGet(proxyURL + "/health") //nolint:gosec // diagnostic one-shot to local httptest
+	if err != nil {
+		return diagnoseResult{Status: statusFail, Detail: fmt.Sprintf("health request failed: %v", err)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return diagnoseResult{Status: statusFail, Detail: fmt.Sprintf("expected 200, got %d", resp.StatusCode)}
+	}
+	return diagnoseResult{Status: statusPass}
+}
+
+func checkFetchAllowed(proxyURL, mockURL string, _ *config.Config) diagnoseResult {
+	resp, err := diagnoseGet(proxyURL + "/fetch?url=" + mockURL) //nolint:gosec // diagnostic one-shot to local httptest
+	if err != nil {
+		return diagnoseResult{Status: statusFail, Detail: fmt.Sprintf("fetch request failed: %v", err)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var fr proxy.FetchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&fr); err != nil {
+		return diagnoseResult{Status: statusFail, Detail: fmt.Sprintf("decode error: %v", err)}
+	}
+	if fr.Blocked {
+		return diagnoseResult{Status: statusFail, Detail: fmt.Sprintf("expected allowed, got blocked: %s", fr.BlockReason)}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return diagnoseResult{Status: statusFail, Detail: fmt.Sprintf("expected 200, got %d", resp.StatusCode)}
+	}
+	if fr.Error != "" {
+		return diagnoseResult{Status: statusFail, Detail: fmt.Sprintf("fetch error: %s", fr.Error)}
+	}
+	return diagnoseResult{Status: statusPass}
+}
+
+func checkFetchBlocked(proxyURL, mockURL string, _ *config.Config) diagnoseResult {
+	// Split credential at runtime to avoid gosec G101 (hardcoded credentials).
+	fakeKey := "AKIA" + "IOSFODNN7EXAMPLE" //nolint:goconst // diagnostic test value
+	url := proxyURL + "/fetch?url=" + mockURL + "%3Ftoken%3D" + fakeKey
+
+	resp, err := diagnoseGet(url) //nolint:gosec // diagnostic one-shot to local httptest
+	if err != nil {
+		return diagnoseResult{Status: statusFail, Detail: fmt.Sprintf("fetch request failed: %v", err)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var fr proxy.FetchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&fr); err != nil {
+		return diagnoseResult{Status: statusFail, Detail: fmt.Sprintf("decode error: %v", err)}
+	}
+	if !fr.Blocked {
+		return diagnoseResult{Status: statusFail, Detail: "expected blocked by DLP, but request was allowed"}
+	}
+	if !strings.HasPrefix(fr.BlockReason, "DLP") {
+		return diagnoseResult{Status: statusFail, Detail: fmt.Sprintf("blocked by %q, expected DLP scanner", fr.BlockReason)}
+	}
+	return diagnoseResult{Status: statusPass, Detail: fmt.Sprintf("reason=%s", fr.BlockReason)}
+}
+
+func checkFetchHint(proxyURL, mockURL string, cfg *config.Config) diagnoseResult {
+	if !cfg.ExplainBlocksEnabled() {
+		return diagnoseResult{
+			Status: statusSkip,
+			Detail: "explain_blocks not enabled; set explain_blocks: true in config to test",
+		}
+	}
+
+	fakeKey := "AKIA" + "IOSFODNN7EXAMPLE" //nolint:goconst // diagnostic test value
+	url := proxyURL + "/fetch?url=" + mockURL + "%3Ftoken%3D" + fakeKey
+
+	resp, err := diagnoseGet(url) //nolint:gosec // diagnostic one-shot to local httptest
+	if err != nil {
+		return diagnoseResult{Status: statusFail, Detail: fmt.Sprintf("fetch request failed: %v", err)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var fr proxy.FetchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&fr); err != nil {
+		return diagnoseResult{Status: statusFail, Detail: fmt.Sprintf("decode error: %v", err)}
+	}
+	if !fr.Blocked {
+		return diagnoseResult{Status: statusFail, Detail: "expected blocked, but request was allowed"}
+	}
+	if fr.Hint == "" {
+		return diagnoseResult{Status: statusFail, Detail: "expected non-empty hint in blocked response"}
+	}
+	return diagnoseResult{Status: statusPass, Detail: fmt.Sprintf("hint=%q", fr.Hint)}
+}
+
+func checkForwardAllowed(proxyURL, mockURL string, _ *config.Config) diagnoseResult {
+	// CONNECT to the mock upstream's host:port.
+	mockHost := strings.TrimPrefix(mockURL, "http://")
+
+	conn, err := connectThroughProxy(proxyURL, mockHost)
+	if err != nil {
+		return diagnoseResult{Status: statusFail, Detail: fmt.Sprintf("CONNECT failed: %v", err)}
+	}
+	_ = conn.Close()
+	return diagnoseResult{Status: statusPass}
+}
+
+func checkForwardBlocked(proxyURL, _ string, _ *config.Config) diagnoseResult {
+	_, err := connectThroughProxy(proxyURL, "malware.example.com:443")
+	if err == nil {
+		return diagnoseResult{Status: statusFail, Detail: "expected CONNECT to be blocked, but it succeeded"}
+	}
+	// The error should indicate a 403.
+	if strings.Contains(err.Error(), "403") {
+		return diagnoseResult{Status: statusPass}
+	}
+	return diagnoseResult{Status: statusFail, Detail: fmt.Sprintf("unexpected error (expected 403): %v", err)}
+}
+
+// connectThroughProxy issues a CONNECT request through the proxy and returns
+// the hijacked connection on success, or an error if blocked/failed.
+func connectThroughProxy(proxyURL, target string) (net.Conn, error) {
+	proxyHost := strings.TrimPrefix(proxyURL, "http://")
+
+	ctx, cancel := context.WithTimeout(context.Background(), diagnoseTimeout)
+	defer cancel()
+
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "tcp", proxyHost)
+	if err != nil {
+		return nil, fmt.Errorf("dial proxy: %w", err)
+	}
+	_ = conn.SetDeadline(time.Now().Add(diagnoseTimeout))
+
+	req := fmt.Sprintf("%s %s HTTP/1.1\r\nHost: %s\r\n\r\n", http.MethodConnect, target, target)
+	if _, err := conn.Write([]byte(req)); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("write CONNECT: %w", err)
+	}
+
+	//nolint:bodyclose // CONNECT 200 has no body; resp.Body wraps the tunneled conn we return.
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		_ = conn.Close()
+		return nil, fmt.Errorf("CONNECT rejected: %s", resp.Status)
+	}
+
+	// Clear deadline for caller use.
+	_ = conn.SetDeadline(time.Time{})
+	return conn, nil
+}
+
+func printDiagnoseTable(w io.Writer, report diagnoseReport, color bool) {
+	_, _ = fmt.Fprintf(w, "Pipelock Diagnostics\n")
+	_, _ = fmt.Fprintf(w, "Config: %s  Mode: %s\n\n", report.ConfigFile, report.Mode)
+
+	for _, c := range report.Checks {
+		icon := statusIcon(c.Status, color)
+		line := fmt.Sprintf("  %s  %-20s", icon, c.Name)
+		if c.Detail != "" {
+			line += "  " + c.Detail
+		}
+		_, _ = fmt.Fprintln(w, line)
+	}
+
+	_, _ = fmt.Fprintf(w, "\n%d passed, %d failed, %d skipped\n", report.Passed, report.Failed, report.Skipped)
+}
+
+func statusIcon(status string, color bool) string {
+	if color {
+		switch status {
+		case statusPass:
+			return "\033[32mPASS\033[0m"
+		case statusFail:
+			return "\033[31mFAIL\033[0m"
+		case statusSkip:
+			return "\033[33mSKIP\033[0m"
+		}
+	}
+	return strings.ToUpper(status)
+}

--- a/internal/cli/diagnose_test.go
+++ b/internal/cli/diagnose_test.go
@@ -1,0 +1,139 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiagnoseDefault(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := diagnoseCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--no-color"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("diagnose failed: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "PASS") {
+		t.Error("expected PASS in output")
+	}
+	if strings.Contains(out, "FAIL") {
+		t.Errorf("unexpected FAIL in output: %s", out)
+	}
+	// fetch_hint should be skipped by default (explain_blocks not set).
+	if !strings.Contains(out, "SKIP") {
+		t.Error("expected SKIP for fetch_hint check")
+	}
+}
+
+func TestDiagnoseJSON(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := diagnoseCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("diagnose --json failed: %v", err)
+	}
+	var report diagnoseReport
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, buf.String())
+	}
+	if report.Total != 6 {
+		t.Errorf("expected 6 checks, got %d", report.Total)
+	}
+	if report.Failed != 0 {
+		t.Errorf("expected 0 failures, got %d", report.Failed)
+	}
+	if report.Skipped != 1 {
+		t.Errorf("expected 1 skip (fetch_hint), got %d", report.Skipped)
+	}
+	// Verify check names.
+	names := make(map[string]bool)
+	for _, c := range report.Checks {
+		names[c.Name] = true
+	}
+	for _, expected := range []string{"health", "fetch_allowed", "fetch_blocked", "fetch_hint", "forward_allowed", "forward_blocked"} {
+		if !names[expected] {
+			t.Errorf("missing check %q in report", expected)
+		}
+	}
+}
+
+func TestDiagnoseConfigError(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := diagnoseCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--config", filepath.Join(t.TempDir(), "nonexistent.yaml")})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent config")
+	}
+	if ExitCodeOf(err) != 2 {
+		t.Errorf("expected exit code 2, got %d", ExitCodeOf(err))
+	}
+}
+
+func TestDiagnoseHintSkipMessage(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := diagnoseCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("diagnose failed: %v", err)
+	}
+	var report diagnoseReport
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	for _, c := range report.Checks {
+		if c.Name == "fetch_hint" {
+			if c.Status != "skip" {
+				t.Errorf("expected fetch_hint to be skip, got %s", c.Status)
+			}
+			if !strings.Contains(c.Detail, "explain_blocks") {
+				t.Errorf("skip detail should mention explain_blocks, got: %s", c.Detail)
+			}
+			return
+		}
+	}
+	t.Error("fetch_hint check not found in report")
+}
+
+func TestDiagnoseHintEnabled(t *testing.T) {
+	// Write temp config with explain_blocks enabled.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte("explain_blocks: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	cmd := diagnoseCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--json", "--config", cfgPath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("diagnose with explain_blocks=true failed: %v", err)
+	}
+
+	var report diagnoseReport
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+
+	for _, c := range report.Checks {
+		if c.Name == "fetch_hint" {
+			if c.Status != "pass" {
+				t.Errorf("expected fetch_hint to pass with explain_blocks=true, got %s: %s", c.Status, c.Detail)
+			}
+			if !strings.Contains(c.Detail, "hint=") {
+				t.Errorf("expected hint detail, got: %s", c.Detail)
+			}
+			return
+		}
+	}
+	t.Error("fetch_hint check not found in report")
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -81,6 +81,7 @@ Quick start:
 	cmd.AddCommand(
 		auditCmd(),
 		demoCmd(),
+		diagnoseCmd(),
 		runCmd(),
 		logsCmd(),
 		checkCmd(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,8 +115,9 @@ func toSlash(s string) string {
 // Config is the top-level Pipelock configuration.
 type Config struct {
 	Version             int                 `yaml:"version"`
-	Mode                string              `yaml:"mode"`    // strict, balanced, audit
-	Enforce             *bool               `yaml:"enforce"` // nil = true (default); false = detect & log without blocking
+	Mode                string              `yaml:"mode"`           // strict, balanced, audit
+	Enforce             *bool               `yaml:"enforce"`        // nil = true (default); false = detect & log without blocking
+	ExplainBlocks       *bool               `yaml:"explain_blocks"` // nil = false (default); true = include hints in block responses
 	APIAllowlist        []string            `yaml:"api_allowlist"`
 	Suppress            []SuppressEntry     `yaml:"suppress"`
 	FetchProxy          FetchProxy          `yaml:"fetch_proxy"`
@@ -231,6 +232,14 @@ type GitProtection struct {
 // Defaults to true when Enforce is nil (not set in config).
 func (c *Config) EnforceEnabled() bool {
 	return c.Enforce == nil || *c.Enforce
+}
+
+// ExplainBlocksEnabled returns whether block responses include hints.
+// Defaults to false when ExplainBlocks is nil (opt-in only).
+// Enabling this exposes scanner names and config field names in responses,
+// which is useful for debugging but constitutes information disclosure.
+func (c *Config) ExplainBlocksEnabled() bool {
+	return c.ExplainBlocks != nil && *c.ExplainBlocks
 }
 
 // FetchProxy configures the unprivileged fetch proxy.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -966,6 +966,31 @@ func TestEnforceEnabled_ExplicitFalse(t *testing.T) {
 	}
 }
 
+// --- ExplainBlocksEnabled Tests ---
+
+func TestExplainBlocksEnabled_NilDefaultsFalse(t *testing.T) {
+	cfg := &Config{} // ExplainBlocks is nil by default
+	if cfg.ExplainBlocksEnabled() {
+		t.Error("expected ExplainBlocksEnabled() == false when ExplainBlocks is nil")
+	}
+}
+
+func TestExplainBlocksEnabled_ExplicitTrue(t *testing.T) {
+	v := true
+	cfg := &Config{ExplainBlocks: &v}
+	if !cfg.ExplainBlocksEnabled() {
+		t.Error("expected ExplainBlocksEnabled() == true when ExplainBlocks is explicitly true")
+	}
+}
+
+func TestExplainBlocksEnabled_ExplicitFalse(t *testing.T) {
+	v := false
+	cfg := &Config{ExplainBlocks: &v}
+	if cfg.ExplainBlocksEnabled() {
+		t.Error("expected ExplainBlocksEnabled() == false when ExplainBlocks is explicitly false")
+	}
+}
+
 // --- Git Protection Validation Tests ---
 
 func TestValidate_GitProtectionEnabled(t *testing.T) {

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -110,6 +110,9 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		if cfg.EnforceEnabled() {
 			p.logger.LogBlocked(http.MethodConnect, target, result.Scanner, result.Reason, clientIP, requestID)
 			p.metrics.RecordTunnelBlocked()
+			if cfg.ExplainBlocksEnabled() && result.Hint != "" {
+				w.Header().Set("X-Pipelock-Hint", result.Hint)
+			}
 			http.Error(w, "CONNECT blocked: "+result.Reason, http.StatusForbidden)
 			return
 		}
@@ -281,6 +284,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		if cfg.EnforceEnabled() {
 			p.logger.LogBlocked(r.Method, targetURL, result.Scanner, result.Reason, clientIP, requestID)
 			p.metrics.RecordBlocked(r.URL.Hostname(), result.Scanner, time.Since(start))
+			if cfg.ExplainBlocksEnabled() && result.Hint != "" {
+				w.Header().Set("X-Pipelock-Hint", result.Hint)
+			}
 			http.Error(w, "blocked: "+result.Reason, http.StatusForbidden)
 			return
 		}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -138,6 +138,7 @@ type FetchResponse struct {
 	Error       string `json:"error,omitempty"`
 	Blocked     bool   `json:"blocked"`
 	BlockReason string `json:"block_reason,omitempty"`
+	Hint        string `json:"hint,omitempty"`
 }
 
 // New creates a new fetch proxy from config.
@@ -406,9 +407,9 @@ func (p *Proxy) buildHandler(mux *http.ServeMux) http.Handler {
 	})
 }
 
-// Start starts the fetch proxy HTTP server. It blocks until the context
-// is cancelled or the server encounters a fatal error.
-func (p *Proxy) Start(ctx context.Context) error {
+// buildMux constructs the route multiplexer for the proxy. Used by both
+// Start() and Handler() to ensure route registration is not duplicated.
+func (p *Proxy) buildMux() *http.ServeMux {
 	cfg := p.cfgPtr.Load()
 
 	mux := http.NewServeMux()
@@ -416,23 +417,32 @@ func (p *Proxy) Start(ctx context.Context) error {
 	mux.HandleFunc("/ws", p.handleWebSocket)
 	mux.HandleFunc("/health", p.handleHealth)
 	// Register metrics/stats only when NOT running on a separate port.
-	// When metrics_listen is configured, these routes are served by a
-	// dedicated metrics server — the main port returns 404, preventing
-	// the agent from scraping operational metadata.
 	if cfg.MetricsListen == "" {
 		mux.Handle("/metrics", p.metrics.PrometheusHandler())
 		mux.HandleFunc("/stats", p.metrics.StatsHandler())
 	}
 	// Register kill switch API routes only when the API is NOT running on a
-	// separate port. When api_listen is configured, these routes are served
-	// by the dedicated API server — the main port returns 404, preventing
-	// the agent from reaching the API to self-deactivate.
+	// separate port.
 	if p.ksAPI != nil && cfg.KillSwitch.APIListen == "" {
 		mux.HandleFunc("/api/v1/killswitch", p.ksAPI.HandleToggle)
 		mux.HandleFunc("/api/v1/killswitch/status", p.ksAPI.HandleStatus)
 	}
+	return mux
+}
 
-	handler := p.buildHandler(mux)
+// Handler returns the composed HTTP handler for the proxy, including
+// CONNECT interception and kill switch checks. Useful for testing with
+// httptest.NewServer and for embedding the proxy in other servers.
+func (p *Proxy) Handler() http.Handler {
+	return p.buildHandler(p.buildMux())
+}
+
+// Start starts the fetch proxy HTTP server. It blocks until the context
+// is cancelled or the server encounters a fatal error.
+func (p *Proxy) Start(ctx context.Context) error {
+	cfg := p.cfgPtr.Load()
+
+	handler := p.buildHandler(p.buildMux())
 
 	// CONNECT tunnels and WebSocket connections need to live beyond any single
 	// write timeout. When forward proxy or WebSocket proxy is enabled,
@@ -565,15 +575,19 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			log.LogBlocked("GET", displayURL, result.Scanner, result.Reason, clientIP, requestID)
 			p.metrics.RecordBlocked(parsed.Hostname(), result.Scanner, time.Since(start))
 			status := http.StatusForbidden
-			if result.Scanner == "ratelimit" {
+			if result.Scanner == scanner.ScannerRateLimit {
 				status = http.StatusTooManyRequests
 			}
-			writeJSON(w, status, FetchResponse{
+			resp := FetchResponse{
 				URL:         displayURL,
 				Agent:       agent,
 				Blocked:     true,
 				BlockReason: result.Reason,
-			})
+			}
+			if cfg.ExplainBlocksEnabled() {
+				resp.Hint = result.Hint
+			}
+			writeJSON(w, status, resp)
 			return
 		}
 		// Audit mode: log anomaly but allow through
@@ -615,12 +629,16 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			reason := err.Error()
 			log.LogBlocked("GET", displayURL, "redirect", reason, clientIP, requestID)
 			p.metrics.RecordBlocked(parsed.Hostname(), "redirect", time.Since(start))
-			writeJSON(w, http.StatusForbidden, FetchResponse{
+			resp := FetchResponse{
 				URL:         displayURL,
 				Agent:       agent,
 				Blocked:     true,
 				BlockReason: reason,
-			})
+			}
+			if cfg.ExplainBlocksEnabled() {
+				resp.Hint = "Request was redirected to a different origin. Cross-origin redirects are blocked to prevent open redirect attacks."
+			}
+			writeJSON(w, http.StatusForbidden, resp)
 			return
 		}
 		log.LogError("GET", displayURL, clientIP, requestID, err)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -3423,3 +3423,100 @@ func TestExtractHiddenContent(t *testing.T) {
 		})
 	}
 }
+
+func TestHandler_ServesEndpoints(t *testing.T) {
+	p, backend := setupTestProxy(t)
+	defer backend.Close()
+
+	ts := httptest.NewServer(p.Handler())
+	defer ts.Close()
+
+	endpoints := []struct {
+		path   string
+		status int
+	}{
+		{"/health", http.StatusOK},
+		{"/metrics", http.StatusOK},
+		{"/stats", http.StatusOK},
+	}
+	for _, ep := range endpoints {
+		t.Run(ep.path, func(t *testing.T) {
+			resp, err := http.Get(ts.URL + ep.path) //nolint:noctx // test one-shot
+			if err != nil {
+				t.Fatalf("GET %s: %v", ep.path, err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != ep.status {
+				t.Errorf("GET %s: expected %d, got %d", ep.path, ep.status, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestFetchResponseHint_Enabled(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.APIAllowlist = nil
+	v := true
+	cfg.ExplainBlocks = &v
+
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	m := metrics.New()
+	p := New(cfg, logger, sc, m)
+
+	ts := httptest.NewServer(p.Handler())
+	defer ts.Close()
+
+	// Trigger a DLP block with a fake AWS key (split for gosec).
+	fakeKey := "AKIA" + "IOSFODNN7EXAMPLE"                                             //nolint:goconst // test value
+	resp, err := http.Get(ts.URL + "/fetch?url=https://example.com/?token=" + fakeKey) //nolint:noctx,gosec // test one-shot
+	if err != nil {
+		t.Fatalf("fetch request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var fr FetchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&fr); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !fr.Blocked {
+		t.Fatal("expected blocked response")
+	}
+	if fr.Hint == "" {
+		t.Error("expected non-empty hint when explain_blocks is enabled")
+	}
+}
+
+func TestFetchResponseHint_Disabled(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.APIAllowlist = nil
+	// ExplainBlocks is nil (defaults to false).
+
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	m := metrics.New()
+	p := New(cfg, logger, sc, m)
+
+	ts := httptest.NewServer(p.Handler())
+	defer ts.Close()
+
+	fakeKey := "AKIA" + "IOSFODNN7EXAMPLE"                                             //nolint:goconst // test value
+	resp, err := http.Get(ts.URL + "/fetch?url=https://example.com/?token=" + fakeKey) //nolint:noctx,gosec // test one-shot
+	if err != nil {
+		t.Fatalf("fetch request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var fr FetchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&fr); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !fr.Blocked {
+		t.Fatal("expected blocked response")
+	}
+	if fr.Hint != "" {
+		t.Errorf("expected empty hint when explain_blocks is disabled, got %q", fr.Hint)
+	}
+}

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -111,6 +111,9 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		if cfg.EnforceEnabled() {
 			log.LogBlocked("WS", targetURL, result.Scanner, result.Reason, clientIP, requestID)
 			p.metrics.RecordWSBlocked()
+			if cfg.ExplainBlocksEnabled() && result.Hint != "" {
+				w.Header().Set("X-Pipelock-Hint", result.Hint)
+			}
 			http.Error(w, "WebSocket blocked: "+result.Reason, http.StatusForbidden)
 			return
 		}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -24,11 +24,30 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/normalize"
 )
 
+// Scanner label constants. These values flow into Prometheus metrics
+// (pipelock_scanner_hits_total{scanner="..."}), suppression rules, and audit
+// logs. Changing a value is a breaking change for dashboards and alerts.
+const (
+	ScannerParser           = "parser"
+	ScannerScheme           = "scheme"
+	ScannerLength           = "length"
+	ScannerSSRF             = "ssrf"
+	ScannerAllowlist        = "allowlist"
+	ScannerBlocklist        = "blocklist"
+	ScannerRateLimit        = "ratelimit"
+	ScannerDLP              = "dlp"
+	ScannerEntropy          = "entropy"
+	ScannerSubdomainEntropy = "subdomain_entropy"
+	ScannerDataBudget       = "databudget"
+	ScannerAll              = "all"
+)
+
 // Result describes the outcome of scanning a URL.
 type Result struct {
 	Allowed bool    `json:"allowed"`
 	Reason  string  `json:"reason,omitempty"`
 	Scanner string  `json:"scanner,omitempty"` // which scanner triggered
+	Hint    string  `json:"hint,omitempty"`    // actionable guidance when blocked
 	Score   float64 `json:"score"`             // anomaly score 0.0-1.0
 }
 
@@ -241,13 +260,48 @@ func (s *Scanner) RecordRequest(hostname string, dataBytes int) {
 	}
 }
 
+// scannerHints maps scanner labels to actionable guidance for operators.
+// Keyed by scanner constants; TestHintForBlock covers all entries.
+var scannerHints = map[string]string{
+	ScannerBlocklist:        "Domain is on the blocklist. Remove from fetch_proxy.monitoring.blocklist if legitimate.",
+	ScannerDLP:              "A DLP pattern matched this URL. If false positive, add a suppress entry for this rule.",
+	ScannerEntropy:          "High-entropy content detected. Review the URL for data exfiltration attempts.",
+	ScannerSubdomainEntropy: "High-entropy content detected in subdomain. Review for data exfiltration via DNS.",
+	ScannerSSRF:             "SSRF protection blocked this URL. It may resolve to a private IP or DNS resolution failed.",
+	ScannerRateLimit:        "Rate limit exceeded. Retry later or adjust fetch_proxy.monitoring.max_requests_per_minute.",
+	ScannerLength:           "URL exceeds maximum length. Check for data stuffing in query parameters.",
+	ScannerDataBudget:       "Session data budget exceeded.",
+	ScannerScheme:           "Only http and https schemes are allowed.",
+	ScannerAllowlist:        "Domain not on the allowlist. In strict mode, only allowlisted domains are reachable.",
+	ScannerParser:           "The URL could not be parsed.",
+}
+
+// HintForBlock returns actionable guidance for a blocked scan result.
+// Returns empty string for unknown scanner labels (fail-safe).
+func HintForBlock(r *Result) string {
+	if r == nil || r.Allowed {
+		return ""
+	}
+	return scannerHints[r.Scanner]
+}
+
 // Scan checks a URL against all scanners and returns the result.
+// Blocked results include a Hint field with actionable guidance.
+func (s *Scanner) Scan(rawURL string) Result {
+	r := s.scan(rawURL)
+	if !r.Allowed {
+		r.Hint = HintForBlock(&r)
+	}
+	return r
+}
+
+// scan checks a URL against all scanners and returns the result.
 // DLP runs on the hostname BEFORE DNS resolution to prevent secret exfiltration
 // via DNS queries (e.g., "sk-ant-xxx.evil.com" leaks the key during resolution).
-func (s *Scanner) Scan(rawURL string) Result {
+func (s *Scanner) scan(rawURL string) Result {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
-		return Result{Allowed: false, Reason: "invalid URL", Scanner: "parser", Score: 1.0}
+		return Result{Allowed: false, Reason: "invalid URL", Scanner: ScannerParser, Score: 1.0}
 	}
 
 	// Normalize hostname for consistent matching
@@ -258,7 +312,7 @@ func (s *Scanner) Scan(rawURL string) Result {
 		return Result{
 			Allowed: false,
 			Reason:  fmt.Sprintf("scheme %q not allowed: only http and https", parsed.Scheme),
-			Scanner: "scheme",
+			Scanner: ScannerScheme,
 			Score:   1.0,
 		}
 	}
@@ -305,7 +359,7 @@ func (s *Scanner) Scan(rawURL string) Result {
 		return Result{
 			Allowed: false,
 			Reason:  fmt.Sprintf("URL length %d exceeds maximum %d", len(rawURL), s.maxURLLength),
-			Scanner: "length",
+			Scanner: ScannerLength,
 			Score:   0.8,
 		}
 	}
@@ -315,7 +369,7 @@ func (s *Scanner) Scan(rawURL string) Result {
 		return result
 	}
 
-	return Result{Allowed: true, Scanner: "all", Score: 0.0}
+	return Result{Allowed: true, Scanner: ScannerAll, Score: 0.0}
 }
 
 // checkSSRF blocks requests to internal/private IP ranges.
@@ -335,7 +389,7 @@ func (s *Scanner) checkSSRF(hostname string) Result {
 		return Result{
 			Allowed: false,
 			Reason:  fmt.Sprintf("SSRF check failed: DNS resolution error for %s: %v", hostname, err),
-			Scanner: "ssrf",
+			Scanner: ScannerSSRF,
 			Score:   1.0,
 		}
 	}
@@ -356,7 +410,7 @@ func (s *Scanner) checkSSRF(hostname string) Result {
 				return Result{
 					Allowed: false,
 					Reason:  fmt.Sprintf("SSRF blocked: %s resolves to internal IP %s", hostname, ipStr),
-					Scanner: "ssrf",
+					Scanner: ScannerSSRF,
 					Score:   1.0,
 				}
 			}
@@ -382,7 +436,7 @@ func (s *Scanner) checkAllowlist(hostname string) Result {
 	return Result{
 		Allowed: false,
 		Reason:  fmt.Sprintf("domain not in allowlist: %s", hostname),
-		Scanner: "allowlist",
+		Scanner: ScannerAllowlist,
 		Score:   1.0,
 	}
 }
@@ -394,7 +448,7 @@ func (s *Scanner) checkBlocklist(hostname string) Result {
 			return Result{
 				Allowed: false,
 				Reason:  fmt.Sprintf("domain blocked: %s matches %s", hostname, pattern),
-				Scanner: "blocklist",
+				Scanner: ScannerBlocklist,
 				Score:   1.0,
 			}
 		}
@@ -416,7 +470,7 @@ func (s *Scanner) checkRateLimit(hostname string) Result {
 		return Result{
 			Allowed: false,
 			Reason:  fmt.Sprintf("rate limit exceeded for %s", hostname),
-			Scanner: "ratelimit",
+			Scanner: ScannerRateLimit,
 			Score:   0.7,
 		}
 	}
@@ -607,7 +661,7 @@ func (s *Scanner) checkDLP(parsed *url.URL) Result {
 				return Result{
 					Allowed: false,
 					Reason:  fmt.Sprintf("DLP match: %s (%s)", p.name, p.severity),
-					Scanner: "dlp",
+					Scanner: ScannerDLP,
 					Score:   1.0,
 				}
 			}
@@ -694,7 +748,7 @@ func (s *Scanner) checkDLPCombinations(values []string, n, size int) Result {
 				return Result{
 					Allowed: false,
 					Reason:  fmt.Sprintf("DLP match: %s (%s)", p.name, p.severity),
-					Scanner: "dlp",
+					Scanner: ScannerDLP,
 					Score:   1.0,
 				}
 			}
@@ -742,7 +796,7 @@ func (s *Scanner) checkSecretsInURL(secrets []string, parsed *url.URL, reasonPre
 			if enc != "" {
 				reason += " (" + enc + "-encoded)"
 			}
-			return Result{Allowed: false, Reason: reason, Scanner: "dlp", Score: 1.0}
+			return Result{Allowed: false, Reason: reason, Scanner: ScannerDLP, Score: 1.0}
 		}
 	}
 	return Result{Allowed: true}
@@ -945,7 +999,7 @@ func (s *Scanner) checkEntropy(parsed *url.URL) Result {
 				return Result{
 					Allowed: false,
 					Reason:  fmt.Sprintf("high entropy path segment (%.2f > %.2f threshold)", entropy, s.entropyThreshold),
-					Scanner: "entropy",
+					Scanner: ScannerEntropy,
 					Score:   math.Min(entropy/8.0, 1.0), // normalize to 0-1
 				}
 			}
@@ -961,7 +1015,7 @@ func (s *Scanner) checkEntropy(parsed *url.URL) Result {
 				return Result{
 					Allowed: false,
 					Reason:  fmt.Sprintf("high entropy query key %q (%.2f > %.2f threshold)", key, entropy, s.entropyThreshold),
-					Scanner: "entropy",
+					Scanner: ScannerEntropy,
 					Score:   math.Min(entropy/8.0, 1.0),
 				}
 			}
@@ -973,7 +1027,7 @@ func (s *Scanner) checkEntropy(parsed *url.URL) Result {
 					return Result{
 						Allowed: false,
 						Reason:  fmt.Sprintf("high entropy query param %q (%.2f > %.2f threshold)", key, entropy, s.entropyThreshold),
-						Scanner: "entropy",
+						Scanner: ScannerEntropy,
 						Score:   math.Min(entropy/8.0, 1.0),
 					}
 				}
@@ -1021,7 +1075,7 @@ func (s *Scanner) checkDataBudget(hostname string) Result {
 		return Result{
 			Allowed: false,
 			Reason:  fmt.Sprintf("data budget exceeded for %s", hostname),
-			Scanner: "databudget",
+			Scanner: ScannerDataBudget,
 			Score:   0.8,
 		}
 	}
@@ -1064,7 +1118,7 @@ func (s *Scanner) checkSubdomainEntropy(hostname string) Result {
 			return Result{
 				Allowed: false,
 				Reason:  fmt.Sprintf("high entropy subdomain label %q (%.2f bits)", label, entropy),
-				Scanner: "subdomain_entropy",
+				Scanner: ScannerSubdomainEntropy,
 				Score:   math.Min(entropy/8.0, 1.0),
 			}
 		}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -3035,3 +3035,78 @@ func TestBaseDomain(t *testing.T) {
 		})
 	}
 }
+
+func TestHintForBlock(t *testing.T) {
+	tests := []struct {
+		scanner string
+		want    string
+	}{
+		{ScannerBlocklist, "Domain is on the blocklist. Remove from fetch_proxy.monitoring.blocklist if legitimate."},
+		{ScannerDLP, "A DLP pattern matched this URL. If false positive, add a suppress entry for this rule."},
+		{ScannerEntropy, "High-entropy content detected. Review the URL for data exfiltration attempts."},
+		{ScannerSubdomainEntropy, "High-entropy content detected in subdomain. Review for data exfiltration via DNS."},
+		{ScannerSSRF, "SSRF protection blocked this URL. It may resolve to a private IP or DNS resolution failed."},
+		{ScannerRateLimit, "Rate limit exceeded. Retry later or adjust fetch_proxy.monitoring.max_requests_per_minute."},
+		{ScannerLength, "URL exceeds maximum length. Check for data stuffing in query parameters."},
+		{ScannerDataBudget, "Session data budget exceeded."},
+		{ScannerScheme, "Only http and https schemes are allowed."},
+		{ScannerAllowlist, "Domain not on the allowlist. In strict mode, only allowlisted domains are reachable."},
+		{ScannerParser, "The URL could not be parsed."},
+		{"unknown_scanner", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.scanner, func(t *testing.T) {
+			r := &Result{Allowed: false, Scanner: tt.scanner}
+			got := HintForBlock(r)
+			if got != tt.want {
+				t.Errorf("HintForBlock(scanner=%q) = %q, want %q", tt.scanner, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHintForBlockAllowed(t *testing.T) {
+	r := &Result{Allowed: true, Scanner: ScannerAll}
+	if hint := HintForBlock(r); hint != "" {
+		t.Errorf("expected empty hint for allowed result, got %q", hint)
+	}
+}
+
+func TestHintForBlockNil(t *testing.T) {
+	if hint := HintForBlock(nil); hint != "" {
+		t.Errorf("expected empty hint for nil result, got %q", hint)
+	}
+}
+
+func TestScanPopulatesHintOnBlock(t *testing.T) {
+	cfg := testConfig()
+	sc := New(cfg)
+	defer sc.Close()
+
+	// This URL should be blocked by DLP (AWS key pattern).
+	fakeKey := "AKIA" + "IOSFODNN7EXAMPLE" //nolint:goconst // test value
+	result := sc.Scan("https://example.com/?token=" + fakeKey)
+	if result.Allowed {
+		t.Fatal("expected URL to be blocked by DLP")
+	}
+	if result.Hint == "" {
+		t.Error("expected non-empty hint on blocked result")
+	}
+	if result.Scanner != "dlp" {
+		t.Errorf("expected scanner=dlp, got %q", result.Scanner)
+	}
+}
+
+func TestScanHintEmptyOnAllowed(t *testing.T) {
+	cfg := testConfig()
+	sc := New(cfg)
+	defer sc.Close()
+
+	result := sc.Scan("https://example.com/")
+	if !result.Allowed {
+		t.Fatalf("expected URL to be allowed, got blocked: %s", result.Reason)
+	}
+	if result.Hint != "" {
+		t.Errorf("expected empty hint on allowed result, got %q", result.Hint)
+	}
+}


### PR DESCRIPTION
## Summary
- `pipelock diagnose`: fully local end-to-end configuration verification (6 checks, --json, exit 0/1/2)
- `explain_blocks` config (opt-in): actionable hints on blocked responses (fetch JSON `hint` field, CONNECT/WS `X-Pipelock-Hint` header)
- CHANGELOG finalized for v0.3.2, version references bumped across 14 files, missing v0.3.1 section added

## Test plan
- `go test -race -count=1 ./...` (3,943 tests pass)
- Lint clean, 94.9% statement coverage
- Pen tested via sidecar deployment (6/6 checks pass, hints verified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a diagnoser command to verify proxy/upstream health, connectivity, and enforcement checks
  * Added explain_blocks to surface actionable hints when requests are blocked; hints appear in responses/headers when enabled
  * Standardized scanner labels and populated user-facing hint messages on blocks

* **Documentation**
  * Updated configuration and guides with explain_blocks usage, examples, security note, and new release references

* **Tests**
  * Added tests for diagnostics and block-hint behavior

* **Infrastructure**
  * CI actions pinned to exact commits for supply-chain robustness
<!-- end of auto-generated comment: release notes by coderabbit.ai -->