### PR TITLE
feat: add hostile-model preset and guardrail-removal detection

### DIFF
--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -1,0 +1,280 @@
+# Pipelock config — hostile model preset
+# For agents running uncensored, abliterated, or jailbroken models.
+# Assumes the model has ZERO safety guardrails and will comply with any instruction.
+#
+# Use this for: red-team testing, self-hosted uncensored models, models with
+# safety refusals removed via weight ablation (e.g. OBLITERATUS), or any agent
+# where you cannot trust the model to refuse harmful requests.
+#
+# This preset enables every defense layer and sets all ambiguous decisions to block.
+# The model won't protect you. The network layer will.
+
+version: 1
+mode: strict
+
+api_allowlist:
+  - "*.anthropic.com"
+  - "*.openai.com"
+
+fetch_proxy:
+  listen: "127.0.0.1:8888"
+  timeout_seconds: 15
+  max_response_mb: 5
+  user_agent: "Pipelock Fetch/1.0"
+  monitoring:
+    max_url_length: 300
+    # 3.0 is aggressive: catches more encoded secrets, more false positives.
+    # Acceptable trade-off when the model is actively hostile.
+    entropy_threshold: 3.0
+    max_requests_per_minute: 15
+    blocklist:
+      - "*.pastebin.com"
+      - "*.hastebin.com"
+      - "*.paste.ee"
+      - "*.transfer.sh"
+      - "*.file.io"
+      - "*.requestbin.com"
+      - "*.ngrok.io"
+      - "*.ngrok-free.app"
+      - "*.pipedream.net"
+      - "*.webhook.site"
+      - "*.hookbin.com"
+      - "*.beeceptor.com"
+      - "*.requestcatcher.com"
+      - "*.burpcollaborator.net"
+
+forward_proxy:
+  enabled: true
+  max_tunnel_seconds: 120
+  idle_timeout_seconds: 30
+
+websocket_proxy:
+  enabled: true
+  max_message_bytes: 524288
+  max_concurrent_connections: 16
+  scan_text_frames: true
+  allow_binary_frames: false
+  forward_cookies: false
+  strip_compression: true
+  max_connection_seconds: 1800
+  idle_timeout_seconds: 120
+  origin_policy: rewrite
+
+dlp:
+  scan_env: true
+  include_defaults: false
+  patterns:
+    # Provider API keys
+    - name: "Anthropic API Key"
+      regex: 'sk-ant-[a-zA-Z0-9\-_]{10,}'
+      severity: critical
+    - name: "OpenAI API Key"
+      regex: 'sk-proj-[a-zA-Z0-9\-_]{10,}'
+      severity: critical
+    - name: "OpenAI Service Key"
+      regex: 'sk-svcacct-[a-zA-Z0-9\-]{10,}'
+      severity: critical
+    - name: "Fireworks API Key"
+      regex: 'fw_[a-zA-Z0-9]{24,}'
+      severity: critical
+    - name: "Google API Key"
+      regex: 'AIza[0-9A-Za-z\-_]{35}'
+      severity: critical
+    - name: "Google OAuth Client Secret"
+      regex: 'GOCSPX-[A-Za-z0-9_\-]{28,}'
+      severity: critical
+    - name: "Stripe Key"
+      regex: '[sr]k_(live|test)_[a-zA-Z0-9]{20,}'
+      severity: critical
+    # Source control tokens
+    - name: "GitHub Token"
+      regex: 'gh[pousr]_[A-Za-z0-9_]{36,}'
+      severity: critical
+    - name: "GitHub Fine-Grained PAT"
+      regex: 'github_pat_[a-zA-Z0-9_]{36,}'
+      severity: critical
+    # Cloud provider credentials
+    - name: "AWS Access ID"
+      regex: '(AKIA|A3T|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16,}'
+      severity: critical
+    - name: "Google OAuth Token"
+      regex: 'ya29\.[a-zA-Z0-9_-]{20,}'
+      severity: critical
+    # Messaging platform tokens
+    - name: "Slack Token"
+      regex: 'xox[bpras]-[0-9a-zA-Z-]{15,}'
+      severity: critical
+    - name: "Slack App Token"
+      regex: 'xapp-[0-9]+-[A-Za-z0-9_]+-[0-9]+-[a-f0-9]+'
+      severity: critical
+    - name: "Discord Bot Token"
+      regex: '[MN][A-Za-z0-9]{23,}\.[A-Za-z0-9\-_]{6}\.[A-Za-z0-9\-_]{27,}'
+      severity: critical
+    # Communication service keys
+    - name: "Twilio API Key"
+      regex: 'SK[a-f0-9]{32}'
+      severity: critical
+    - name: "SendGrid API Key"
+      regex: 'SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}'
+      severity: critical
+    - name: "Mailgun API Key"
+      regex: 'key-[a-zA-Z0-9]{32}'
+      severity: critical
+    # Cryptographic material
+    - name: "Private Key Header"
+      regex: '-----BEGIN\s+(RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----'
+      severity: critical
+    - name: "JWT Token"
+      regex: '(ey[a-zA-Z0-9_\-=]{10,}\.){2}[a-zA-Z0-9_\-=]{10,}'
+      severity: critical
+    # Identity / PII
+    - name: "Google OAuth Client ID"
+      regex: '[0-9]{6,}-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
+      severity: critical
+    # Generic credential patterns
+    - name: "Credential in URL"
+      regex: '\b(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      severity: critical
+
+response_scanning:
+  enabled: true
+  action: block
+  include_defaults: false
+  patterns:
+    - name: "Prompt Injection"
+      regex: '(?i)(ignore|disregard|forget|abandon)[-,;:.\s]+\s*(?:all\s+\w+\s+|\w+\s+all\s+|all\s+|\w+\s+)?(previous|prior|above|earlier)\s+(\w+\s+)?(instructions|prompts|rules|context|directives|constraints|policies|guardrails)'
+    - name: "System Override"
+      regex: '(?im)^\s*system\s*:'
+    - name: "Role Override"
+      regex: '(?i)you\s+are\s+(now\s+)?(a\s+)?((?-i:\bDAN\b)|evil|unrestricted|jailbroken|unfiltered)'
+    - name: "New Instructions"
+      regex: '(?i)(new|updated|revised)\s+(instructions|directives|rules|prompt)'
+    - name: "Jailbreak Attempt"
+      regex: '(?i)((?-i:\bDAN\b)|developer\s+mode|sudo\s+mode|unrestricted\s+mode)'
+    - name: "Hidden Instruction"
+      regex: '(?i)(do\s+not\s+(reveal|tell|show|display|mention)\s+this\s+to\s+the\s+user|hidden\s+instruction|invisible\s+to\s+(the\s+)?user|the\s+user\s+(cannot|must\s+not|should\s+not)\s+see\s+this)'
+    - name: "Behavior Override"
+      regex: '(?i)from\s+now\s+on\s+(you\s+)?(will|must|should|shall)\s+'
+    - name: "Encoded Payload"
+      regex: '(?i)(decode\s+(this|the\s+following)\s+(from\s+)?base64\s+and\s+(execute|run|follow)|eval\s*\(\s*atob\s*\()'
+    - name: "Tool Invocation"
+      regex: '(?i)you\s+must\s+(immediately\s+)?(call|execute|run|invoke)\s+(the|this)\s+(function|tool|command|api|endpoint)'
+    - name: "Authority Escalation"
+      regex: '(?i)you\s+(now\s+)?have\s+(full\s+)?(admin|root|system|superuser|elevated)\s+(access|privileges|permissions|rights)'
+    - name: "Pliny Divider"
+      regex: '(?i)={1,3}/?[A-Z\-]{2,}(/[A-Z\-]{1,4}){3,}=+'
+    - name: "Meta-Command Activation"
+      regex: '(?i)(\{GODMODE\s*:\s*(ENABLED|ON|TRUE)\}|!OMNI\b|RESET_CORTEX|LIBERTAS\s+FACTOR|ENABLE\s+DEV(ELOPER)?\s+MODE|JAILBREAK\s+(ENABLED|ACTIVATED|ON))'
+    - name: "Roleplay Framing"
+      regex: '(?i)(let''?s\s+play\s+a\s+game\s+where\s+you|pretend\s+you\s+are\s+an?\s+(character|person|AI)\s+(who|that)\s+(has\s+no|doesn''?t\s+have|ignores?|bypasses?)|(in\s+this\s+)?(hypothetical|fictional|imaginary)\s+scenario\s+(where\s+)?you\s+(are|have|can|must))'
+    - name: "Instruction Boundary"
+      regex: '(<\|(?:endoftext|im_start|im_end|system|end_header_id|begin_of_text)\|>|\[/?INST\]|<\|(?:user|assistant)\|>|<<SYS>>|</s>)'
+    - name: "Output Format Forcing"
+      regex: '(?i)(respond\s+with|first\s+(output|write|print|say))\s*[\[\("]?\s*(FILTERED|ERROR|BLOCKED|REFUSED|DECLINED|CENSORED)\s*[\]\)"]?\s*(then|followed\s+by|and\s+then|after\s+(that|which))'
+    - name: "System Prompt Extraction"
+      regex: '(?i)(repeat\s+(your|the)\s+(entire\s+)?(instructions|system\s+prompt|initial\s+prompt|rules)|what\s+(is|are)\s+your\s+(system\s+prompt|instructions|rules|directives)|output\s+(your|the)\s+(full\s+)?(system|initial)\s+(prompt|instructions|message)|show\s+me\s+(your|the)\s+(system\s+prompt|hidden\s+instructions|initial\s+instructions)|(disclose|expose|dump|divulge)\s+(your|the)\s+(hidden\s+|secret\s+|internal\s+)*(system\s+|initialization\s+)*(prompt|instructions|rules|directives))'
+    - name: "Instruction Invalidation"
+      regex: '(?i)(treat|consider|regard)\s+(all\s+)?(earlier|prior|previous|preceding|above)\s+(directions|instructions|guidelines|rules|prompts?)\s+as\s+(obsolete|void|invalid|superseded|overridden|null|cancelled|revoked|inapplicable)'
+    - name: "Instruction Dismissal"
+      regex: '(?i)(set|put|cast|push|throw)\s+(all\s+)?(previous|prior|earlier|preceding|above|existing|current)\s+(\w+\s+)?(directives|instructions|guidelines|rules|prompts?|constraints|safeguards|policies|guardrails)\s+(aside|away|to\s+(one|the)\s+side)'
+    - name: "Instruction Downgrade"
+      regex: '(?i)(treat|consider|regard|reinterpret|downgrade)\s+((?:the|all)\s+)?(previous|prior|above|earlier|system|policy|original|existing)\s+(\w+\s+)?(text|instructions?|rules|directives|guidelines|safeguards|constraints|controls|checks|context|prompt|policies|guardrails|parameters)\s+((as|to)\s+)?(historical|outdated|deprecated|optional|background|secondary|non-binding|non-authoritative|informational|advisory)'
+    - name: "Priority Override"
+      regex: '(?i)prioritize\s+(the\s+)?(task|user|current|new|latest)\s+(request|message|input|instructions?|prompt)'
+
+mcp_input_scanning:
+  enabled: true
+  action: block
+  on_parse_error: block
+
+mcp_tool_scanning:
+  enabled: true
+  action: block
+  detect_drift: true
+
+mcp_tool_policy:
+  enabled: true
+  action: block
+  rules:
+    - name: "Destructive File Delete"
+      tool_pattern: '(?i)^(bash|shell|exec|run_command|execute|terminal|bash_exec)$'
+      arg_pattern: '(?i)\brm\s+(--\s+)?(-[a-z]*[rf]\b|--(?:recursive|force)\b)'
+      action: block
+    - name: "Recursive Permission Change"
+      tool_pattern: '(?i)^(bash|shell|exec|run_command|execute|terminal|bash_exec)$'
+      arg_pattern: '(?i)\b(chmod\s+(-R|--recursive)\s+(777|666)|chmod\s+(777|666)\s+(-R|--recursive)|chown\s+(-R|--recursive))\b'
+      action: block
+    - name: "Credential File Access"
+      tool_pattern: '(?i)^(bash|shell|exec|run_command|execute|terminal|bash_exec|read_file|file_read)$'
+      arg_pattern: '(?i)(\.ssh/(id_|authorized)|\.aws/credentials|\.env\b|\.netrc|/etc/shadow|\.kube/config|\.docker/config)'
+      action: block
+    - name: "Network Exfiltration"
+      tool_pattern: '(?i)^(bash|shell|exec|run_command|execute|terminal|bash_exec)$'
+      arg_pattern: '(?i)\b(curl|wget|nc|ncat|socat)\b'
+      action: block
+    - name: "Reverse Shell"
+      tool_pattern: '(?i)^(bash|shell|exec|run_command|execute|terminal|bash_exec)$'
+      arg_pattern: '(?i)(bash\s+-i\s+>&|/dev/tcp/|mkfifo\s+|nc\s+-e|ncat\s+-e)'
+      action: block
+    - name: "Disk Wipe Command"
+      tool_pattern: '(?i)^(bash|shell|exec|run_command|execute|terminal|bash_exec)$'
+      arg_pattern: '(?i)\b(dd\s+if=.*of=/dev/|mkfs\.|fdisk)\b'
+      action: block
+    - name: "Package Install"
+      tool_pattern: '(?i)^(bash|shell|exec|run_command|execute|terminal|bash_exec)$'
+      arg_pattern: '(?i)\b(pip|npm|gem|cargo|go)\s+install\b'
+      action: block
+    - name: "Destructive Git Operation"
+      tool_pattern: '(?i)^(bash|shell|exec|run_command|execute|terminal|bash_exec|git)$'
+      arg_pattern: '(?i)(\bgit\s+)?(push\s+(--force(\s|$)|-f\b)|reset\s+--hard\b|clean\s+-fd\b)'
+      action: block
+    - name: "Encoded Command Execution"
+      tool_pattern: '(?i)^(bash|shell|exec|run_command|execute|terminal|bash_exec)$'
+      arg_pattern: '(?i)(\beval\b.*\bbase64\b|\bbase64\s+(-d|--decode)\b.*\|\s*(ba)?sh\b)'
+      action: block
+    - name: "Environment Dump"
+      tool_pattern: '(?i)^(bash|shell|exec|run_command|execute|terminal|bash_exec)$'
+      arg_pattern: '(?i)\b(printenv|env\b|set\b|export\s+-p)'
+      action: block
+
+# Session binding: pin tool inventory per session. New tools mid-session = block.
+mcp_session_binding:
+  enabled: true
+
+# Session behavioral profiling
+session_profiling:
+  enabled: true
+
+# Adaptive enforcement
+adaptive_enforcement:
+  enabled: true
+
+# Tool chain detection
+tool_chain_detection:
+  enabled: true
+  action: block
+
+# Kill switch preconfigured with sentinel file.
+# Touch /tmp/pipelock-kill to instantly deny all traffic.
+kill_switch:
+  enabled: false
+  sentinel_file: /tmp/pipelock-kill
+  message: "Emergency deny-all active"
+
+logging:
+  format: json
+  output: stdout
+  include_allowed: true
+  include_blocked: true
+
+internal:
+  - "0.0.0.0/8"
+  - "127.0.0.0/8"
+  - "10.0.0.0/8"
+  - "172.16.0.0/12"
+  - "192.168.0.0/16"
+  - "169.254.0.0/16"
+  - "100.64.0.0/10"
+  - "::1/128"
+  - "fc00::/7"
+  - "fe80::/10"

--- a/internal/projectscan/detect.go
+++ b/internal/projectscan/detect.go
@@ -2,6 +2,7 @@ package projectscan
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -210,9 +211,9 @@ func parsePythonRequirements(content string) []string {
 		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "-") {
 			continue
 		}
-		// Extract package name before version specifier
+		// Extract package name before version specifier or inline comment
 		for i, ch := range line {
-			if ch == '=' || ch == '>' || ch == '<' || ch == '!' || ch == '[' || ch == ';' {
+			if ch == '=' || ch == '>' || ch == '<' || ch == '!' || ch == '[' || ch == ';' || ch == '#' {
 				line = line[:i]
 				break
 			}
@@ -257,6 +258,112 @@ func hasDependency(path, pkg string) bool {
 	}
 	_, ok := pj.DevDependencies[pkg]
 	return ok
+}
+
+// hostileToolingPackages are Python packages associated with guardrail removal,
+// model ablation, or safety bypass toolchains.
+var hostileToolingPackages = []string{
+	"obliteratus",
+	"abliterator",
+	"refusal-ablation",
+	"llm-abliterator",
+}
+
+// detectHostileTooling checks project dependencies for guardrail-removal toolchains.
+// Returns findings for each detected package.
+func detectHostileTooling(dir string) []Finding {
+	var findings []Finding
+
+	// Check requirements.txt (parsed line-by-line, exact match)
+	deps := readPythonDeps(dir)
+	for _, dep := range deps {
+		for _, hostile := range hostileToolingPackages {
+			if dep == hostile {
+				findings = append(findings, Finding{
+					Severity: "warning",
+					Category: "tooling",
+					Message:  fmt.Sprintf("Guardrail-removal toolchain detected: %s. Consider using the hostile-model config preset.", dep),
+					Pattern:  hostile,
+				})
+			}
+		}
+	}
+
+	// Also check pyproject.toml directly for hostile packages.
+	// readPythonDeps/parsePyprojectDeps only looks for agent frameworks,
+	// so we do a separate check. Two dependency formats exist:
+	//   PEP 621:  dependencies = ["obliteratus>=0.1"]  (quoted in array)
+	//   Poetry:   obliteratus = "^0.1"                 (TOML key = value)
+	// We match both while avoiding false positives from prose descriptions.
+	pyprojectPath := filepath.Join(dir, "pyproject.toml")
+	if data, err := os.ReadFile(filepath.Clean(pyprojectPath)); err == nil {
+		lower := strings.ToLower(string(data))
+		for _, hostile := range hostileToolingPackages {
+			if pyprojectHasHostileDep(lower, hostile) {
+				if !hasHostileFinding(findings, hostile) {
+					findings = append(findings, Finding{
+						Severity: "warning",
+						Category: "tooling",
+						Message:  fmt.Sprintf("Guardrail-removal toolchain detected: %s. Consider using the hostile-model config preset.", hostile),
+						Pattern:  hostile,
+					})
+				}
+			}
+		}
+	}
+
+	// Check for HuggingFace ablation configs
+	ablationFiles := []string{
+		"abliterate.py",
+		"abliteration.py",
+		"remove_refusals.py",
+		"uncensor.py",
+	}
+	for _, name := range ablationFiles {
+		if fileExists(filepath.Join(dir, name)) {
+			findings = append(findings, Finding{
+				Severity: "warning",
+				Category: "tooling",
+				File:     name,
+				Message:  fmt.Sprintf("Ablation script detected: %s. The model in this project may have safety guardrails removed.", name),
+			})
+		}
+	}
+
+	return findings
+}
+
+// pyprojectHasHostileDep checks if a lowercased pyproject.toml contains a
+// hostile package as an actual dependency (not in prose). Matches per-line:
+//   - PEP 621 array entries: line starts with "pkg or 'pkg (indented items)
+//   - Poetry table keys: line starts with pkg followed by space or = sign
+func pyprojectHasHostileDep(lower, pkg string) bool {
+	for _, line := range strings.Split(lower, "\n") {
+		trimmed := strings.TrimSpace(line)
+		// PEP 621: dependency array entry starts with quoted package name
+		//   e.g. "obliteratus>=0.1",
+		if strings.HasPrefix(trimmed, `"`+pkg) || strings.HasPrefix(trimmed, `'`+pkg) {
+			return true
+		}
+		// Poetry: package name as a TOML key at the start of a line
+		//   e.g. obliteratus = "^0.1"
+		if strings.HasPrefix(trimmed, pkg) {
+			rest := trimmed[len(pkg):]
+			if len(rest) > 0 && (rest[0] == ' ' || rest[0] == '=') {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasHostileFinding(findings []Finding, pattern string) bool {
+	for _, f := range findings {
+		if f.Category == "tooling" && f.Pattern == pattern {
+			return true
+		}
+	}
+	return false
 }
 
 func fileExists(path string) bool {

--- a/internal/projectscan/detect_test.go
+++ b/internal/projectscan/detect_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 )
 
+const testHostilePkg = "obliteratus"
+
 func TestDetectAgent_ClaudeCode_DotClaude(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.Mkdir(filepath.Join(dir, ".claude"), 0o750); err != nil {
@@ -396,5 +398,172 @@ crewai = "^0.1"
 	}
 	if got := detectAgent(dir); got != AgentCrewAI {
 		t.Errorf("detectAgent = %q, want %q", got, AgentCrewAI)
+	}
+}
+
+func TestDetectHostileTooling_PythonPackage(t *testing.T) {
+	tests := []struct {
+		name    string
+		deps    string
+		wantLen int
+	}{
+		{"obliteratus", "obliteratus\ntorch\n", 1},
+		{"abliterator", "transformers\nabliterator>=1.0\n", 1},
+		{"refusal-ablation", "refusal-ablation\n", 1},
+		{"llm-abliterator", "llm-abliterator\nopenai\n", 1},
+		{"inline comment", "obliteratus # guardrail removal\n", 1},
+		{"clean project", "torch\ntransformers\nopenai\n", 0},
+		{"empty", "", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.deps != "" {
+				if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte(tt.deps), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			findings := detectHostileTooling(dir)
+			if len(findings) != tt.wantLen {
+				t.Errorf("detectHostileTooling() returned %d findings, want %d: %v", len(findings), tt.wantLen, findings)
+			}
+			for _, f := range findings {
+				if f.Severity != "warning" {
+					t.Errorf("expected severity warning, got %q", f.Severity)
+				}
+				if f.Category != "tooling" {
+					t.Errorf("expected category tooling, got %q", f.Category)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectHostileTooling_AblationScript(t *testing.T) {
+	scripts := []string{"abliterate.py", "abliteration.py", "remove_refusals.py", "uncensor.py"}
+
+	for _, script := range scripts {
+		t.Run(script, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, script), []byte("# ablation script"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			findings := detectHostileTooling(dir)
+			if len(findings) != 1 {
+				t.Fatalf("expected 1 finding for %s, got %d", script, len(findings))
+			}
+			if findings[0].File != script {
+				t.Errorf("expected file %q, got %q", script, findings[0].File)
+			}
+		})
+	}
+}
+
+func TestDetectHostileTooling_PyprojectToml(t *testing.T) {
+	dir := t.TempDir()
+	pyproject := `[project]
+name = "my-project"
+dependencies = [
+    "torch>=2.0",
+    "obliteratus>=0.1",
+    "transformers",
+]
+`
+	if err := os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte(pyproject), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	findings := detectHostileTooling(dir)
+	if len(findings) != 1 {
+		t.Errorf("expected 1 finding for obliteratus in pyproject.toml, got %d", len(findings))
+	}
+	if len(findings) > 0 && findings[0].Pattern != testHostilePkg {
+		t.Errorf("expected pattern obliteratus, got %q", findings[0].Pattern)
+	}
+}
+
+func TestDetectHostileTooling_PyprojectNoDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	// Both requirements.txt and pyproject.toml have obliteratus; should produce 1 finding, not 2
+	if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("obliteratus\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pyproject := `[project]
+dependencies = ["obliteratus"]
+`
+	if err := os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte(pyproject), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	findings := detectHostileTooling(dir)
+	count := 0
+	for _, f := range findings {
+		if f.Pattern == testHostilePkg {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 obliteratus finding (deduplicated), got %d", count)
+	}
+}
+
+func TestDetectHostileTooling_PyprojectPoetryStyle(t *testing.T) {
+	dir := t.TempDir()
+	pyproject := `[tool.poetry.dependencies]
+python = "^3.11"
+obliteratus = "^0.1"
+torch = "^2.0"
+`
+	if err := os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte(pyproject), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	findings := detectHostileTooling(dir)
+	if len(findings) != 1 {
+		t.Errorf("expected 1 finding for Poetry-style obliteratus dep, got %d", len(findings))
+	}
+	if len(findings) > 0 && findings[0].Pattern != testHostilePkg {
+		t.Errorf("expected pattern obliteratus, got %q", findings[0].Pattern)
+	}
+}
+
+func TestDetectHostileTooling_PyprojectDescriptionFalsePositive(t *testing.T) {
+	dir := t.TempDir()
+	// Package name in description (not as a dependency) should NOT trigger
+	pyproject := `[project]
+name = "safe-project"
+description = "research notes about obliteratus and model ablation"
+dependencies = ["numpy", "torch"]
+`
+	if err := os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte(pyproject), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	findings := detectHostileTooling(dir)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for mention in description, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestDetectHostileTooling_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+	// Normal Python file should not trigger
+	if err := os.WriteFile(filepath.Join(dir, "train.py"), []byte("import torch"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	findings := detectHostileTooling(dir)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for clean project, got %d", len(findings))
+	}
+}
+
+func TestDetectHostileTooling_BothPackageAndScript(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("obliteratus\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "abliterate.py"), []byte("# script"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	findings := detectHostileTooling(dir)
+	if len(findings) != 2 {
+		t.Errorf("expected 2 findings (package + script), got %d", len(findings))
 	}
 }

--- a/internal/projectscan/scan.go
+++ b/internal/projectscan/scan.go
@@ -144,6 +144,10 @@ func Scan(dir string) (*Report, error) {
 		})
 	}
 
+	// Check for hostile tooling (ablation/uncensor packages)
+	hostileFindings := detectHostileTooling(dir)
+	r.Findings = append(r.Findings, hostileFindings...)
+
 	// Compile DLP patterns once for both scans
 	patterns := compileDLPPatterns()
 


### PR DESCRIPTION
## Summary

- Add `configs/hostile-model.yaml` preset for agents running uncensored or abliterated models. Enables maximum defense layers with aggressive thresholds (entropy 3.0, 15 req/min, expanded exfiltration blocklist, session binding, kill switch preconfigured).
- Add guardrail-removal toolchain detection to `pipelock audit`. Detects hostile Python packages (obliteratus, abliterator, etc.) in requirements.txt and pyproject.toml (PEP 621 + Poetry formats), and ablation script files. Surfaces warnings recommending the hostile-model preset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a strict security configuration preset with comprehensive defenses against data exposure, prompt manipulation attacks, and malicious tool execution.
  * Enhanced project scanning to detect hostile tooling and suspicious dependency packages.

* **Tests**
  * Added extensive test coverage for hostile tooling detection capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->