### PR TITLE
feat: add subdomain entropy exclusions for high-entropy cloud domains

### DIFF
--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -26,6 +26,7 @@ fetch_proxy:
       - "*.transfer.sh"
       - "*.file.io"
       - "*.requestbin.com"
+    subdomain_entropy_exclusions: []
 
 forward_proxy:
   enabled: true

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -41,6 +41,7 @@ fetch_proxy:
       - "*.transfer.sh"
       - "*.file.io"
       - "*.requestbin.com"
+    subdomain_entropy_exclusions: []
 
 forward_proxy:
   enabled: true

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -58,6 +58,7 @@ fetch_proxy:
       - "*.requestbin.com"
       - "*.webhook.site"
       - "*.pipedream.net"
+    subdomain_entropy_exclusions: []
 
 forward_proxy:
   enabled: true

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -59,6 +59,7 @@ fetch_proxy:
       - "*.requestbin.com"
       - "*.webhook.site"
       - "*.pipedream.net"
+    subdomain_entropy_exclusions: []
 
 forward_proxy:
   enabled: true

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -66,6 +66,7 @@ fetch_proxy:
       - "*.requestbin.com"
       - "*.webhook.site"
       - "*.pipedream.net"
+    subdomain_entropy_exclusions: []
 
 forward_proxy:
   enabled: true

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -42,6 +42,7 @@ fetch_proxy:
       - "*.beeceptor.com"
       - "*.requestcatcher.com"
       - "*.burpcollaborator.net"
+    subdomain_entropy_exclusions: []
 
 forward_proxy:
   enabled: true

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -39,6 +39,7 @@ fetch_proxy:
       - "*.transfer.sh"
       - "*.file.io"
       - "*.requestbin.com"
+    subdomain_entropy_exclusions: []
 
 forward_proxy:
   enabled: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -343,11 +343,12 @@ type FetchProxy struct {
 
 // Monitoring configures IPC channel anomaly detection.
 type Monitoring struct {
-	MaxURLLength     int      `yaml:"max_url_length"`
-	EntropyThreshold float64  `yaml:"entropy_threshold"`
-	MaxReqPerMinute  int      `yaml:"max_requests_per_minute"`
-	MaxDataPerMinute int      `yaml:"max_data_per_minute"` // bytes per domain per minute (0 = disabled)
-	Blocklist        []string `yaml:"blocklist"`
+	MaxURLLength               int      `yaml:"max_url_length"`
+	EntropyThreshold           float64  `yaml:"entropy_threshold"`
+	MaxReqPerMinute            int      `yaml:"max_requests_per_minute"`
+	MaxDataPerMinute           int      `yaml:"max_data_per_minute"` // bytes per domain per minute (0 = disabled)
+	Blocklist                  []string `yaml:"blocklist"`
+	SubdomainEntropyExclusions []string `yaml:"subdomain_entropy_exclusions"` // domains excluded from subdomain entropy checks (exact or *.example.com wildcard)
 }
 
 // DLP configures data loss prevention scanning.
@@ -1265,6 +1266,29 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// Validate subdomain entropy exclusions are well-formed hostname patterns.
+	// Accepted formats: exact hostnames ("runpod.net") and wildcard prefixes
+	// ("*.runpod.net"). Reject URLs, host:port, and over-broad patterns.
+	for i, raw := range c.FetchProxy.Monitoring.SubdomainEntropyExclusions {
+		d := strings.TrimSpace(strings.ToLower(raw))
+		if d == "" {
+			return fmt.Errorf("subdomain_entropy_exclusions[%d] is empty", i)
+		}
+		if strings.Contains(d, "://") || strings.Contains(d, "/") || strings.Contains(d, ":") {
+			return fmt.Errorf("subdomain_entropy_exclusions[%d] %q: use a hostname pattern, not a URL or host:port", i, raw)
+		}
+		if strings.HasPrefix(d, "*.") {
+			// Wildcard must target a concrete domain (*.com is too broad)
+			if strings.Count(d[2:], ".") < 1 {
+				return fmt.Errorf("subdomain_entropy_exclusions[%d] %q: wildcard must target a concrete domain like *.example.com", i, raw)
+			}
+		} else if strings.ContainsAny(d, "*?[]") {
+			return fmt.Errorf("subdomain_entropy_exclusions[%d] %q: only exact hosts and *.example.com wildcards are supported", i, raw)
+		}
+		// Normalize: store lowercase, trimmed, trailing-dot-stripped version
+		c.FetchProxy.Monitoring.SubdomainEntropyExclusions[i] = strings.TrimSuffix(d, ".")
+	}
+
 	// Validate global rate limits are non-negative
 	if c.FetchProxy.Monitoring.MaxReqPerMinute < 0 {
 		return fmt.Errorf("fetch_proxy.monitoring.max_requests_per_minute must be >= 0")
@@ -1991,6 +2015,17 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 		}
 	}
 
+	// Subdomain entropy exclusions expanded (reduces detection coverage)
+	if added := passthroughDomainsAdded(
+		old.FetchProxy.Monitoring.SubdomainEntropyExclusions,
+		updated.FetchProxy.Monitoring.SubdomainEntropyExclusions,
+	); len(added) > 0 {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "fetch_proxy.monitoring.subdomain_entropy_exclusions",
+			Message: fmt.Sprintf("subdomain entropy exclusions added: %s — entropy detection coverage reduced", strings.Join(added, ", ")),
+		})
+	}
+
 	// Request body scanning disabled
 	if old.RequestBodyScanning.Enabled && !updated.RequestBodyScanning.Enabled {
 		warnings = append(warnings, ReloadWarning{
@@ -2173,6 +2208,7 @@ func Defaults() *Config {
 					"*.file.io",
 					"*.requestbin.com",
 				},
+				SubdomainEntropyExclusions: []string{},
 			},
 		},
 		ForwardProxy: ForwardProxy{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -29,6 +29,7 @@ const (
 	fieldKSAPIListen    = "kill_switch.api_listen"
 	fieldTLSPassthrough = "tls_interception.passthrough_domains"
 	fieldSentry         = "sentry"
+	fieldSubEntExcl     = "fetch_proxy.monitoring.subdomain_entropy_exclusions"
 
 	// testLicenseFileCfg is a minimal config with license_file pointing to a
 	// relative file name. Used in multiple license loading tests.
@@ -278,6 +279,147 @@ func TestValidate_EmptyBlocklistEntry(t *testing.T) {
 	cfg.FetchProxy.Monitoring.Blocklist = []string{"*.pastebin.com", ""}
 	if err := cfg.Validate(); err == nil {
 		t.Error("expected error for empty blocklist entry")
+	}
+}
+
+func TestValidate_SubdomainEntropyExclusions_Valid(t *testing.T) {
+	cfg := Defaults()
+	cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{
+		"*.runpod.net",
+		"trusted.example.com",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("expected validation to pass, got: %v", err)
+	}
+}
+
+func TestValidate_SubdomainEntropyExclusions_Empty(t *testing.T) {
+	cfg := Defaults()
+	cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"*.example.com", ""}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for empty subdomain_entropy_exclusions entry")
+	}
+}
+
+func TestValidate_SubdomainEntropyExclusions_URL(t *testing.T) {
+	cfg := Defaults()
+	cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"https://example.com"}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for URL in subdomain_entropy_exclusions")
+	}
+	if !strings.Contains(err.Error(), "not a URL") {
+		t.Errorf("error should mention URL, got: %v", err)
+	}
+}
+
+func TestValidate_SubdomainEntropyExclusions_HostPort(t *testing.T) {
+	cfg := Defaults()
+	cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"example.com:8080"}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for host:port in subdomain_entropy_exclusions")
+	}
+	if !strings.Contains(err.Error(), "not a URL or host:port") {
+		t.Errorf("error should mention host:port, got: %v", err)
+	}
+}
+
+func TestValidate_SubdomainEntropyExclusions_OverBroad(t *testing.T) {
+	cfg := Defaults()
+	cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"*.com"}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for over-broad wildcard *.com")
+	}
+	if !strings.Contains(err.Error(), "concrete domain") {
+		t.Errorf("error should mention concrete domain, got: %v", err)
+	}
+}
+
+func TestValidate_SubdomainEntropyExclusions_BadWildcard(t *testing.T) {
+	cfg := Defaults()
+	cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"example.*.com"}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for non-prefix wildcard")
+	}
+	if !strings.Contains(err.Error(), "only exact hosts") {
+		t.Errorf("error should mention supported formats, got: %v", err)
+	}
+}
+
+func TestValidate_SubdomainEntropyExclusions_Normalized(t *testing.T) {
+	cfg := Defaults()
+	cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"  *.RunPod.NET  "}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected validation to pass, got: %v", err)
+	}
+	// After validation, entry should be lowercase and trimmed
+	if cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions[0] != "*.runpod.net" {
+		t.Errorf("expected normalized entry, got %q", cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions[0])
+	}
+}
+
+func TestValidate_SubdomainEntropyExclusions_TrailingDot(t *testing.T) {
+	cfg := Defaults()
+	cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"*.runpod.net."}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected validation to pass, got: %v", err)
+	}
+	// After validation, trailing dot should be stripped
+	if cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions[0] != "*.runpod.net" {
+		t.Errorf("expected trailing dot stripped, got %q", cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions[0])
+	}
+}
+
+func TestValidateReload_SubdomainExclusionsExpanded(t *testing.T) {
+	old := Defaults()
+	old.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"*.runpod.net"}
+	updated := Defaults()
+	updated.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"*.runpod.net", "*.modal.run"}
+
+	warnings := ValidateReload(old, updated)
+	found := false
+	for _, w := range warnings {
+		if w.Field == fieldSubEntExcl {
+			found = true
+			if !strings.Contains(w.Message, "*.modal.run") {
+				t.Errorf("warning should name the added domain, got: %s", w.Message)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected warning when subdomain entropy exclusions are expanded")
+	}
+}
+
+func TestValidateReload_SubdomainExclusionsUnchanged_NoWarning(t *testing.T) {
+	old := Defaults()
+	old.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"*.runpod.net"}
+	updated := Defaults()
+	updated.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"*.runpod.net"}
+
+	warnings := ValidateReload(old, updated)
+	for _, w := range warnings {
+		if w.Field == fieldSubEntExcl {
+			t.Errorf("unexpected warning for unchanged exclusions: %s", w.Message)
+		}
+	}
+}
+
+func TestValidateReload_SubdomainExclusionsReduced_NoWarning(t *testing.T) {
+	old := Defaults()
+	old.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"*.runpod.net", "*.modal.run"}
+	updated := Defaults()
+	updated.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"*.runpod.net"}
+
+	warnings := ValidateReload(old, updated)
+	for _, w := range warnings {
+		if w.Field == fieldSubEntExcl {
+			t.Errorf("unexpected warning when exclusions are reduced: %s", w.Message)
+		}
 	}
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -76,6 +76,7 @@ type Scanner struct {
 	responseVowelFoldPatterns []*compiledPattern // vowel-folded variants for confusable vowel attacks
 	responseAction            string
 	responseEnabled           bool
+	subdomainExclusions       []string // domains excluded from subdomain entropy checks
 }
 
 type compiledPattern struct {
@@ -96,11 +97,12 @@ func New(cfg *config.Config) *Scanner {
 	}
 
 	s := &Scanner{
-		allowlist:        allowlist,
-		blocklist:        cfg.FetchProxy.Monitoring.Blocklist,
-		entropyThreshold: cfg.FetchProxy.Monitoring.EntropyThreshold,
-		entropyMinLen:    20,
-		maxURLLength:     cfg.FetchProxy.Monitoring.MaxURLLength,
+		allowlist:           allowlist,
+		blocklist:           cfg.FetchProxy.Monitoring.Blocklist,
+		entropyThreshold:    cfg.FetchProxy.Monitoring.EntropyThreshold,
+		entropyMinLen:       20,
+		maxURLLength:        cfg.FetchProxy.Monitoring.MaxURLLength,
+		subdomainExclusions: cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions,
 	}
 
 	// Initialize rate limiter if enabled
@@ -1211,6 +1213,8 @@ const subdomainMinLabelLen = 8
 // checkSubdomainEntropy flags hostnames where subdomain labels contain
 // high-entropy data, indicating base64/hex exfiltration via DNS queries.
 // Only checks hostnames with 3+ labels (at least one subdomain beyond base domain).
+// Excludes domains listed in subdomainExclusions (e.g., RunPod, cloud services
+// that use high-entropy subdomains for legitimate purposes).
 func (s *Scanner) checkSubdomainEntropy(hostname string) Result {
 	if s.entropyThreshold <= 0 {
 		return Result{Allowed: true}
@@ -1218,6 +1222,11 @@ func (s *Scanner) checkSubdomainEntropy(hostname string) Result {
 
 	// Skip IP addresses
 	if net.ParseIP(hostname) != nil {
+		return Result{Allowed: true}
+	}
+
+	// Skip domains on the exclusion list (exact match or wildcard suffix)
+	if s.isExcludedFromSubdomainEntropy(hostname) {
 		return Result{Allowed: true}
 	}
 
@@ -1243,6 +1252,36 @@ func (s *Scanner) checkSubdomainEntropy(hostname string) Result {
 	}
 
 	return Result{Allowed: true}
+}
+
+// isExcludedFromSubdomainEntropy checks if the hostname matches any exclusion
+// rule. Supports exact hostnames and wildcard prefixes (*.example.com matches
+// any subdomain of example.com, including example.com itself).
+// All comparisons are case-insensitive with trailing-dot normalization.
+func (s *Scanner) isExcludedFromSubdomainEntropy(hostname string) bool {
+	host := strings.ToLower(strings.TrimSuffix(hostname, "."))
+	for _, pattern := range s.subdomainExclusions {
+		// Defensive: patterns should already be normalized by config.Validate(),
+		// but we re-normalize here as defense-in-depth for security-sensitive matching.
+		p := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(pattern), "."))
+		if p == "" {
+			continue
+		}
+		// Wildcard prefix: *.example.com matches sub.example.com and example.com
+		if strings.HasPrefix(p, "*.") {
+			suffix := p[1:] // ".example.com"
+			base := p[2:]   // "example.com"
+			if host == base || strings.HasSuffix(host, suffix) {
+				return true
+			}
+			continue
+		}
+		// Exact match
+		if host == p {
+			return true
+		}
+	}
+	return false
 }
 
 // baseDomain returns the registrable domain (eTLD+1) for budget tracking,

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -3464,3 +3464,113 @@ func TestScanHintEmptyOnAllowed(t *testing.T) {
 		t.Errorf("expected empty hint on allowed result, got %q", result.Hint)
 	}
 }
+
+// TestCheckSubdomainEntropy_Exclusions tests the subdomain entropy exclusion
+// feature, which allows users to whitelist domains that legitimately use
+// high-entropy subdomains (e.g., RunPod GPU instances, cloud preview URLs).
+func TestCheckSubdomainEntropy_Exclusions(t *testing.T) {
+	// 21-char label with entropy well above the 4.0 threshold used by
+	// checkSubdomainEntropy (hardcoded constant, not the config threshold).
+	const highEntropyLabel = "r7km2np9qw4xb5vy8za3b"
+
+	tests := []struct {
+		name           string
+		exclusions     []string
+		url            string
+		shouldAllow    bool
+		expectedReason string
+	}{
+		{
+			name:           "no exclusions blocks high entropy",
+			exclusions:     []string{},
+			url:            fmt.Sprintf("https://%s.evil.com/", highEntropyLabel),
+			shouldAllow:    false,
+			expectedReason: ScannerSubdomainEntropy,
+		},
+		{
+			name:        "wildcard exclusion allows matching domain",
+			exclusions:  []string{"*.evil.com"},
+			url:         fmt.Sprintf("https://%s.evil.com/", highEntropyLabel),
+			shouldAllow: true,
+		},
+		{
+			name:           "wildcard exclusion does not match different domain",
+			exclusions:     []string{"*.evil.com"},
+			url:            fmt.Sprintf("https://%s.different.com/", highEntropyLabel),
+			shouldAllow:    false,
+			expectedReason: ScannerSubdomainEntropy,
+		},
+		{
+			name:        "exact match exclusion allows",
+			exclusions:  []string{fmt.Sprintf("%s.trusted.example.com", highEntropyLabel)},
+			url:         fmt.Sprintf("https://%s.trusted.example.com/", highEntropyLabel),
+			shouldAllow: true,
+		},
+		{
+			name:           "exact match exclusion does not match other subdomains",
+			exclusions:     []string{"other.trusted.example.com"},
+			url:            fmt.Sprintf("https://%s.trusted.example.com/", highEntropyLabel),
+			shouldAllow:    false,
+			expectedReason: ScannerSubdomainEntropy,
+		},
+		{
+			name:        "wildcard matches multi-level subdomains",
+			exclusions:  []string{"*.example.com"},
+			url:         fmt.Sprintf("https://%s.deep.sub.example.com/", highEntropyLabel),
+			shouldAllow: true,
+		},
+		{
+			name:        "wildcard matches base domain itself",
+			exclusions:  []string{"*.runpod.net"},
+			url:         fmt.Sprintf("https://%s.runpod.net/", highEntropyLabel),
+			shouldAllow: true,
+		},
+		{
+			name:        "case insensitive matching",
+			exclusions:  []string{"*.RunPod.NET"},
+			url:         fmt.Sprintf("https://%s.runpod.net/", highEntropyLabel),
+			shouldAllow: true,
+		},
+		{
+			name:        "trailing dot normalization",
+			exclusions:  []string{"*.runpod.net."},
+			url:         fmt.Sprintf("https://%s.runpod.net/", highEntropyLabel),
+			shouldAllow: true,
+		},
+		{
+			name:        "multiple exclusions first match",
+			exclusions:  []string{"*.evil.com", "*.trusted.com"},
+			url:         fmt.Sprintf("https://%s.evil.com/", highEntropyLabel),
+			shouldAllow: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.DLP.Patterns = nil
+			cfg.Internal = nil
+			cfg.APIAllowlist = nil
+			cfg.FetchProxy.Monitoring.Blocklist = nil
+			cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions = tt.exclusions
+			s := New(cfg)
+			defer s.Close()
+
+			result := s.Scan(context.Background(), tt.url)
+
+			if result.Allowed != tt.shouldAllow {
+				if tt.shouldAllow {
+					t.Errorf("expected allowed, got blocked by %s: %s", result.Scanner, result.Reason)
+				} else {
+					t.Errorf("expected blocked by %s, got allowed", tt.expectedReason)
+				}
+			}
+			if !tt.shouldAllow && result.Scanner != tt.expectedReason {
+				t.Errorf("expected scanner=%s, got %s", tt.expectedReason, result.Scanner)
+			}
+			if tt.shouldAllow && result.Scanner != ScannerAll {
+				t.Errorf("expected scanner=all for allowed URL, got %s", result.Scanner)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `subdomain_entropy_exclusions` config field under `fetch_proxy.monitoring` to whitelist domains with legitimately high-entropy subdomains (e.g., RunPod GPU instances)
- Wildcard matching (`*.runpod.net`) covers all subdomain depths
- Validation rejects malformed patterns, normalizes to lowercase with trailing-dot stripping
- All 7 config presets updated with the new field

Closes #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subdomain entropy exclusion configuration support across all profiles. Users can now specify domain patterns, including exact matches and wildcard patterns (e.g., *.example.com), to exclude from subdomain entropy monitoring. This enables more granular control over detection sensitivity and helps reduce false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->