### PR TITLE
fix: set explicit archive ID for Homebrew formula matching

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,7 +50,8 @@ builds:
       - -s -w
 
 archives:
-  - ids: [pipelock]
+  - id: pipelock
+    ids: [pipelock]
     format: tar.gz
     format_overrides:
       - goos: windows


### PR DESCRIPTION
When the license-service build was added in #226, the archives section gained a build filter (`ids: [pipelock]`) but not an explicit archive `id`. The archive ID defaulted to `"default"` while `brews.ids` looked for `"pipelock"`, causing a no-match failure in GoReleaser during the v1.3.0 release.

Adds `id: pipelock` to the archive entry so the brew formula can find it.