### PR TITLE
docs: hedge security claims and add coverage disclaimers

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ What each mode prevents, detects, or logs:
 
 Every request passes through: scheme validation, domain blocklist, DLP pattern matching (36 built-in patterns for API keys, tokens, and credentials), path entropy analysis, subdomain entropy analysis, SSRF protection with DNS rebinding prevention, per-domain rate limiting, URL length limits, and per-domain data budgets.
 
-DLP runs before DNS resolution. Secrets are caught before any DNS query leaves the proxy. See [docs/bypass-resistance.md](docs/bypass-resistance.md) for the full evasion test matrix.
+DLP runs before DNS resolution, designed to catch secrets before any DNS query leaves the proxy. See [docs/bypass-resistance.md](docs/bypass-resistance.md) for the full evasion test matrix.
 
 ### Response Scanning
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Pipelock Agent Security Scan'
-description: 'Scan your project for AI agent security risks. Detects secrets, misconfigurations, and generates a tailored security config.'
+description: 'Scan your project for AI agent security risks. Pattern-based detection of credentials and misconfigurations with tailored config generation. See docs for coverage details.'
 author: 'luckyPipewrench'
 
 branding:
@@ -38,7 +38,7 @@ inputs:
 
 outputs:
   score:
-    description: 'Security score (0-100) for the scanned project.'
+    description: 'Risk score (0-100) based on pattern-matched findings. Higher means more issues detected. Not an absolute security rating.'
     value: ${{ steps.audit.outputs.score }}
   findings-count:
     description: 'Total number of findings.'

--- a/docs/owasp-mapping.md
+++ b/docs/owasp-mapping.md
@@ -2,6 +2,8 @@
 
 How Pipelock addresses the [OWASP Top 10 for Agentic Applications (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/).
 
+> **Note:** Coverage levels reflect architectural capabilities against known attack patterns, not guarantees of threat prevention. "Strong" means the feature addresses the threat effectively for known techniques. "Partial" means it contributes but is not sufficient alone. No security tool prevents all instances of any threat class. This mapping is for informational purposes and does not constitute compliance certification.
+
 | Threat | Coverage | Status |
 |--------|----------|--------|
 | ASI01 Agent Goal Hijack | Strong | Shipped |


### PR DESCRIPTION
## Summary

- Action marketplace description: clarify pattern-based detection, score output is relative risk not absolute security rating
- OWASP mapping: add disclaimer that coverage levels reflect capabilities against known patterns, not guarantees
- README: hedge DLP-before-DNS claim from absolute to design intent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified DLP timing to specify pattern detection occurs before DNS queries leave the proxy.
  * Updated action description to emphasize pattern-based detection and tailored configuration.
  * Refined risk score output to clarify it indicates relative risk, not absolute security rating.
  * Added coverage note explaining levels reflect architectural capabilities against known patterns, not guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->