### PR TITLE
feat: community rules rollout — build wiring and docs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,7 @@ builds:
       - -X github.com/luckyPipewrench/pipelock/internal/cli.GoVersion={{.Env.GOVERSION}}
       - -X github.com/luckyPipewrench/pipelock/internal/proxy.Version={{.Version}}
       - -X github.com/luckyPipewrench/pipelock/internal/license.PublicKeyHex={{.Env.LICENSE_PUBLIC_KEY}}
+      - -X github.com/luckyPipewrench/pipelock/internal/rules.KeyringHex={{.Env.LICENSE_PUBLIC_KEY}}
 
   # License service: cluster-only webhook handler for Polar subscription events.
   # Linux-only (runs in k8s), not distributed via Homebrew or public archives.

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
       -X github.com/luckyPipewrench/pipelock/internal/cli.GitCommit=${GIT_COMMIT} \
       -X github.com/luckyPipewrench/pipelock/internal/cli.GoVersion=$(go version | awk '{print $3}') \
       -X github.com/luckyPipewrench/pipelock/internal/proxy.Version=${VERSION} \
-      -X github.com/luckyPipewrench/pipelock/internal/license.PublicKeyHex=${LICENSE_PUBLIC_KEY}" \
+      -X github.com/luckyPipewrench/pipelock/internal/license.PublicKeyHex=${LICENSE_PUBLIC_KEY} \
+      -X github.com/luckyPipewrench/pipelock/internal/rules.KeyringHex=${LICENSE_PUBLIC_KEY}" \
     -o /pipelock ./cmd/pipelock
 
 # Scratch-based final image (~15MB)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ LDFLAGS := -ldflags "-s -w \
 	-X $(MODULE)/internal/cli.GitCommit=$(GIT_COMMIT) \
 	-X $(MODULE)/internal/cli.GoVersion=$(GO_VERSION) \
 	-X $(MODULE)/internal/proxy.Version=$(VERSION) \
-	-X $(MODULE)/internal/license.PublicKeyHex=$(LICENSE_PUBLIC_KEY)"
+	-X $(MODULE)/internal/license.PublicKeyHex=$(LICENSE_PUBLIC_KEY) \
+	-X $(MODULE)/internal/rules.KeyringHex=$(LICENSE_PUBLIC_KEY)"
 
 .PHONY: build test bench lint clean docker install fmt vet tidy-check
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ gh attestation verify oci://ghcr.io/luckypipewrench/pipelock:<version> --owner l
 
 </details>
 
+## Community Rules
+
+Pipelock supports signed rule bundles for distributable detection patterns. Install the official community bundle for additional DLP, injection, and tool-poison patterns beyond the built-in defaults:
+
+```bash
+pipelock rules install pipelock-community
+```
+
+Rules are loaded at startup and merged with built-in patterns. Bundles are Ed25519-signed and verified against the embedded keyring, which is present in release binaries (Homebrew, GitHub Releases, Docker). Source builds via `go install` must add the official public key to `trusted_keys` in their config. See [docs/rules.md](docs/rules.md) for details.
+
 ## How It Works
 
 Pipelock is an [agent firewall](https://pipelab.org/agent-firewall/): like a WAF for web apps, it sits inline between your AI agent and the internet. It uses **capability separation**: the agent process (which has secrets) is network-restricted, while Pipelock (which holds no agent secrets) inspects all traffic through an 11-layer scanner pipeline. Deployment (Docker network isolation, Kubernetes NetworkPolicy, etc.) enforces the separation boundary.
@@ -478,6 +488,7 @@ Details, config examples, and gap analysis: [docs/owasp-mapping.md](docs/owasp-m
 | [Security Assurance](docs/security-assurance.md) | Security model, trust boundaries, supply chain |
 | [Transport Modes](docs/guides/transport-modes.md) | Comparison of all proxy modes and their scanning capabilities |
 | [EU AI Act Mapping](docs/compliance/eu-ai-act-mapping.md) | Article-by-article compliance mapping |
+| [Community Rules](docs/rules.md) | Install, configure, and create signed rule bundles |
 
 ## Project Structure
 

--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -425,3 +425,8 @@ seed_phrase_detection:
 #       window_minutes: 60
 #   _default:
 #     mode: balanced
+
+# Community rule bundles — install with: pipelock rules install pipelock-community
+# rules:
+#   min_confidence: medium
+#   include_experimental: false

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -475,3 +475,8 @@ seed_phrase_detection:
 #       window_minutes: 60
 #   _default:
 #     mode: balanced
+
+# Community rule bundles — install with: pipelock rules install pipelock-community
+# rules:
+#   min_confidence: medium
+#   include_experimental: false

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -468,3 +468,8 @@ seed_phrase_detection:
 #       window_minutes: 60
 #   _default:
 #     mode: balanced
+
+# Community rule bundles — install with: pipelock rules install pipelock-community
+# rules:
+#   min_confidence: medium
+#   include_experimental: false

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -469,3 +469,8 @@ seed_phrase_detection:
 #       window_minutes: 60
 #   _default:
 #     mode: balanced
+
+# Community rule bundles — install with: pipelock rules install pipelock-community
+# rules:
+#   min_confidence: medium
+#   include_experimental: false

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -465,3 +465,8 @@ seed_phrase_detection:
 #       window_minutes: 60
 #   _default:
 #     mode: balanced
+
+# Community rule bundles — install with: pipelock rules install pipelock-community
+# rules:
+#   min_confidence: medium
+#   include_experimental: false

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -484,3 +484,8 @@ seed_phrase_detection:
 #       window_minutes: 60
 #   _default:
 #     mode: balanced
+
+# Community rule bundles — install with: pipelock rules install pipelock-community
+# rules:
+#   min_confidence: medium
+#   include_experimental: false

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -485,3 +485,8 @@ seed_phrase_detection:
 #       window_minutes: 60
 #   _default:
 #     mode: balanced
+
+# Community rule bundles — install with: pipelock rules install pipelock-community
+# rules:
+#   min_confidence: medium
+#   include_experimental: false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1232,6 +1232,29 @@ At least one chain must be enabled when `address_protection.enabled` is `true`. 
 
 **Hot reload:** disabling address protection triggers a reload warning. Re-enabling takes effect immediately.
 
+## Community Rules
+
+Optional signed rule bundles that extend built-in detection patterns. See [docs/rules.md](rules.md) for the full user guide.
+
+```yaml
+rules:
+  rules_dir: ~/.pipelock/rules    # default location for installed bundles
+  min_confidence: medium          # skip low-confidence (experimental) rules
+  include_experimental: false     # only load stable rules by default
+  trusted_keys:                   # additional signing keys (beyond embedded keyring)
+    - name: "acme-security"
+      public_key: "64-char-hex-encoded-ed25519-public-key"
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `rules_dir` | `~/.pipelock/rules` | Directory for installed bundles |
+| `min_confidence` | `""` (all) | Skip rules below this confidence level |
+| `include_experimental` | `false` | Include experimental rules from bundles |
+| `trusted_keys` | `[]` | Additional Ed25519 public keys to trust for signature verification |
+
+**Hot reload:** rule directory changes are not detected via hot-reload. Restart pipelock after installing or updating bundles.
+
 ## Validation Rules
 
 The following are enforced at startup:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,130 @@
+# Community Rules
+
+Pipelock ships with built-in DLP patterns, injection detection, and tool-poison scanners. Community rule bundles extend these defaults with additional detections that ship on a faster cadence than the core binary.
+
+## Installing a Bundle
+
+```bash
+# Install the official community bundle (requires network access)
+pipelock rules install pipelock-community
+
+# Install from a third-party HTTPS source
+pipelock rules install --source https://example.com/my-bundle/bundle.yaml my-bundle
+
+# Install from a local path (signature verification skipped)
+pipelock rules install --path /path/to/bundle/ --allow-unsigned
+```
+
+Bundles are stored in `~/.pipelock/rules/` by default. Override with the `--rules-dir` flag or the `rules_dir` config field.
+
+> **Note:** Official bundle verification requires the embedded keyring, which is present in release binaries (Homebrew, GitHub Releases, Docker). Source builds via `go install` do not include the keyring unless built with the release ldflags. Source-build users must add the official public key to `trusted_keys` in their config for remote installs, or download the bundle manually and use `--path` with `--allow-unsigned`.
+
+## Updating and Removing
+
+```bash
+# Update to the latest version
+pipelock rules update pipelock-community
+
+# List installed bundles
+pipelock rules list
+
+# Show diff between installed and available versions
+pipelock rules diff pipelock-community
+
+# Remove a bundle
+pipelock rules remove pipelock-community
+```
+
+## How Rules Are Loaded
+
+At startup, pipelock scans the rules directory for installed bundles. Each bundle's rules are merged with the built-in patterns:
+
+- **DLP rules** are added to the DLP pattern list alongside built-in patterns
+- **Injection rules** are added to the response scanning pattern list
+- **Tool-poison rules** are added to the tool description scanner
+
+Bundle rules cannot override or disable built-in patterns. They are additive only.
+
+## Configuration
+
+```yaml
+# pipelock.yaml
+rules:
+  rules_dir: ~/.pipelock/rules    # default
+  min_confidence: medium          # skip experimental rules (low confidence)
+  include_experimental: false     # default: only stable rules are active
+  # trusted_keys:                 # additional trusted public keys (beyond embedded keyring)
+  #   - name: "acme-security"
+  #     public_key: "64-char-hex-encoded-ed25519-public-key"
+```
+
+## Trust Model
+
+Bundles are Ed25519-signed YAML files. Pipelock verifies signatures against a keyring before loading rules.
+
+### Official bundles
+
+Official bundles (like `pipelock-community`) are signed with the production key embedded in the binary at build time. No additional configuration is needed.
+
+### Third-party bundles
+
+Organizations can create and sign their own bundles. Add their public key to `trusted_keys` in your config. Pipelock verifies third-party signatures the same way it verifies official ones.
+
+### Unsigned bundles
+
+The `--allow-unsigned` flag skips signature verification during install. Use this only for local testing. Unsigned bundles log a warning at startup.
+
+## Verifying Signatures
+
+```bash
+# Re-verify all installed bundles against the embedded keyring
+pipelock rules verify
+```
+
+## Creating Your Own Bundle
+
+A bundle is a single YAML file with a header and a list of rules:
+
+```yaml
+name: my-company-rules
+version: "2026.03.1"
+min_pipelock: "1.4.0"
+description: Internal detection patterns for Acme Corp
+rules:
+  - id: dlp-internal-api-key
+    type: dlp
+    name: "Acme Internal API Key"
+    regex: 'acme_[a-zA-Z0-9]{32}'
+    severity: critical
+    confidence: high
+```
+
+### Rule types
+
+| Type | `type` value | Merged with |
+|------|-------------|-------------|
+| DLP pattern | `dlp` | `dlp.patterns` |
+| Injection pattern | `injection` | `response_scanning.patterns` |
+| Tool poison pattern | `tool_poison` | `mcp_tool_scanning` descriptions |
+
+### Signing your bundle
+
+```bash
+# Generate a keypair for your organization
+pipelock keygen my-org
+
+# Sign the bundle (uses the keystore at ~/.pipelock/)
+pipelock sign bundle.yaml --agent my-org
+
+# Distribute: bundle.yaml + bundle.yaml.sig + your public key hex
+```
+
+Users add your public key to their `trusted_keys` config to verify your bundles.
+
+## Hosting
+
+The official community bundle is hosted at `pipelab.org/rules/`. The `pipelock rules install` command fetches from this URL by default. Self-hosted bundles can be served from any HTTPS endpoint using the `--source` flag.
+
+## Version Format
+
+Bundles use CalVer: `YYYY.MM.patch` (e.g., `2026.03.1`). The `min_pipelock` field ensures compatibility with the installed binary version.

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -25,8 +25,9 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
-// Official bundle registry base URL.
-const officialRegistryURL = "https://rules.pipelab.org"
+// Official bundle registry base URL. Bundles are served as static files
+// from the pipelab.org Hugo site via Cloudflare Pages.
+const officialRegistryURL = "https://pipelab.org/rules"
 
 // loadRulesConfig loads the pipelock config for trusted key resolution.
 // When configFile is explicitly set (--config flag), load failures are fatal


### PR DESCRIPTION
## Summary

- Wire `rules.KeyringHex` into build ldflags (Makefile, GoReleaser, Dockerfile) so release binaries verify official bundle signatures
- Reuses existing `LICENSE_PUBLIC_KEY` secret — no new GitHub Actions secret needed
- Add `docs/rules.md` user guide: install, update, config, trust model, creating third-party bundles
- Add Community Rules section to README with source-build caveat
- Add commented `rules:` config section to all 7 preset YAMLs

Unblocks the community rules launch sequence: after this merges and a new tag is cut, the binary has the keyring baked in. DNS CNAME, bundle signing, repo flip, and Pages enablement can follow independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Community Rules support: users can install, load, verify, and manage signed rule bundles.

* **Documentation**
  * Added comprehensive Community Rules docs and updated configuration examples across presets.

* **Chores**
  * Updated the official bundle registry URL to the new pipelab.org rules host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->