### PR TITLE
fix: reject unsupported dlp.action and per-pattern action fields (#263)

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -210,6 +210,35 @@ func TestGenerateCmd_AllPresets(t *testing.T) {
 	}
 }
 
+func TestGenerateCmd_OutputPassesValidation(t *testing.T) {
+	// Regression: generated configs must be re-loadable without validation errors.
+	// This catches reserved fields (e.g. dlp.action) being emitted when they shouldn't be.
+	for _, preset := range []string{"strict", "balanced", "audit"} {
+		t.Run(preset, func(t *testing.T) {
+			cmd := rootCmd()
+			cmd.SetArgs([]string{"generate", "config", "--preset", preset})
+
+			buf := &strings.Builder{}
+			cmd.SetOut(buf)
+			cmd.SetErr(&strings.Builder{})
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("generate config --preset %s failed: %v", preset, err)
+			}
+
+			// Write the output to a temp file and reload it.
+			dir := t.TempDir()
+			cfgPath := dir + "/generated.yaml"
+			if err := os.WriteFile(cfgPath, []byte(buf.String()), 0o600); err != nil {
+				t.Fatalf("write generated config: %v", err)
+			}
+			if _, err := config.Load(cfgPath); err != nil {
+				t.Errorf("generated %s config fails validation on reload: %v", preset, err)
+			}
+		})
+	}
+}
+
 func TestGenerateCmd_UnknownPreset(t *testing.T) {
 	cmd := rootCmd()
 	cmd.SetArgs([]string{"generate", "config", "--preset", "nonexistent"})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -408,6 +408,7 @@ type DLP struct {
 	MinEnvSecretLength int          `yaml:"min_env_secret_length"` // minimum env var length for leak detection (default 16)
 	IncludeDefaults    *bool        `yaml:"include_defaults"`      // nil/true: merge user patterns with defaults; false: user patterns only
 	Patterns           []DLPPattern `yaml:"patterns"`
+	Action             string       `yaml:"action,omitempty"` // reserved — not yet implemented; rejected at validation
 }
 
 // DLPPattern is a named regex pattern for detecting secrets in URLs.
@@ -417,6 +418,7 @@ type DLPPattern struct {
 	Severity      string   `yaml:"severity"`            // critical, high, medium, low
 	Validator     string   `yaml:"validator,omitempty"` // post-match checksum: "luhn", "mod97", "aba"
 	ExemptDomains []string `yaml:"exempt_domains"`      // domains where this pattern is not enforced
+	Action        string   `yaml:"action,omitempty"`    // reserved — not yet implemented; rejected at validation
 	Bundle        string   `yaml:"-"`                   // set by rules loader, not from YAML
 	BundleVersion string   `yaml:"-"`                   // set by rules loader, not from YAML
 }
@@ -1437,6 +1439,15 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("logging.file is required when output is %q", c.Logging.Output)
 	}
 
+	// Reject unsupported DLP action fields. Request-side DLP redaction (strip)
+	// is not implemented — DLP matches follow the transport-level action
+	// (request_body_scanning.action, mcp_input_scanning.action, or enforce mode).
+	// These fields exist on the struct so YAML doesn't silently drop them;
+	// validation rejects non-empty values with an explicit error.
+	if c.DLP.Action != "" {
+		return fmt.Errorf("dlp.action %q is not supported; DLP match behavior depends on the calling surface (e.g. request_body_scanning.action for bodies, mcp_input_scanning.action for MCP, enforce/audit mode for URL scanning)", c.DLP.Action)
+	}
+
 	// Validate DLP patterns compile as valid regexes
 	for _, p := range c.DLP.Patterns {
 		if p.Name == "" {
@@ -1447,6 +1458,9 @@ func (c *Config) Validate() error {
 		}
 		if _, err := regexp.Compile(p.Regex); err != nil {
 			return fmt.Errorf("DLP pattern %q has invalid regex: %w", p.Name, err)
+		}
+		if p.Action != "" {
+			return fmt.Errorf("DLP pattern %q has action %q which is not supported; per-pattern DLP actions are not yet implemented", p.Name, p.Action)
 		}
 		if p.Validator != "" {
 			valid := p.Validator == ValidatorLuhn || p.Validator == ValidatorMod97 || p.Validator == ValidatorABA

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -495,6 +495,91 @@ file_sentry:
 	}
 }
 
+func TestValidate_DLPGlobalActionRejected(t *testing.T) {
+	cfg := Defaults()
+	cfg.DLP.Action = ActionStrip
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for unsupported dlp.action")
+	}
+}
+
+func TestValidate_DLPGlobalActionBlock(t *testing.T) {
+	cfg := Defaults()
+	cfg.DLP.Action = ActionBlock
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for unsupported dlp.action (even block)")
+	}
+}
+
+func TestValidate_DLPPatternActionRejected(t *testing.T) {
+	cfg := Defaults()
+	cfg.DLP.Patterns = []DLPPattern{
+		{Name: "test", Regex: `sk-test-[a-z]+`, Severity: "high", Action: ActionStrip},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for unsupported per-pattern action")
+	}
+}
+
+func TestValidate_DLPPatternActionEmpty(t *testing.T) {
+	cfg := Defaults()
+	cfg.DLP.Patterns = []DLPPattern{
+		{Name: "test", Regex: `sk-test-[a-z]+`, Severity: "high"},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("empty action should be valid: %v", err)
+	}
+}
+
+func TestLoad_DLPActionRejectedFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgContent := `
+version: 1
+dlp:
+  action: strip
+  patterns:
+    - name: test
+      regex: 'sk-test-[a-z]+'
+      severity: high
+`
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(cfgPath)
+	if err == nil {
+		t.Fatal("expected error when dlp.action is set in YAML")
+	}
+	if !strings.Contains(err.Error(), "dlp.action") {
+		t.Errorf("error should mention dlp.action, got: %v", err)
+	}
+}
+
+func TestLoad_DLPPatternActionRejectedFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgContent := `
+version: 1
+dlp:
+  include_defaults: false
+  patterns:
+    - name: test
+      regex: 'sk-test-[a-z]+'
+      severity: high
+      action: strip
+`
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(cfgPath)
+	if err == nil {
+		t.Fatal("expected error when pattern action is set in YAML")
+	}
+	if !strings.Contains(err.Error(), "action") {
+		t.Errorf("error should mention action, got: %v", err)
+	}
+}
+
 func TestValidate_InvalidLoggingFormat(t *testing.T) {
 	cfg := Defaults()
 	cfg.Logging.Format = "xml"


### PR DESCRIPTION
## Summary

- `dlp.action` and per-pattern `action` fields were silently dropped by YAML unmarshaling — operators got no error but the settings had no effect
- Fields are now captured on the config structs (with `omitempty` to avoid surfacing in `generate config`) and rejected at validation with an error message pointing to the correct transport-level settings
- Closes #263 (silent-ignore root cause; request-side redaction tracked separately)