### PR TITLE
feat: sandbox --best-effort for container environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Sandbox `--best-effort` flag: gracefully degrades when user namespace creation is blocked (e.g. k8s containers with default seccomp). Landlock and seccomp containment layers still apply. Network scanning uses proxy-based routing instead of kernel-enforced namespace isolation.
+- Sandbox `--env` flag: pass environment variables to sandboxed processes (KEY or KEY=VALUE, repeatable). Validates against dangerous keys (LD_PRELOAD, NODE_OPTIONS, etc.) that could subvert containment.
+- MCP proxy `--sandbox-best-effort` flag: parity with `pipelock sandbox --best-effort` for MCP stdio wrapping mode.
+- Pure Go netlink loopback: sandbox uses raw netlink syscalls to bring up loopback inside network namespaces. No `ip` binary required. Works in minimal container images without iproute2.
+
+### Fixed
+- Seccomp io_uring handling: changed from KILL_PROCESS to EPERM so runtimes like Node.js 22 that probe io_uring at startup can gracefully fall back to epoll instead of crashing.
+- Seccomp `readlink` syscall: added `SYS_READLINK` (nr 89) to the allowlist. Node.js/libuv uses the legacy readlink syscall directly, not readlinkat.
+- Sandbox secret dir validation: `secretDirs()` now only protects directories that actually exist. Prevents false validation errors in containers.
+- Sandbox bridge proxy dynamic port: in best-effort mode, uses dynamic port instead of hardcoded 8888.
+- Config reload detection: `sandbox.best_effort` changes detected during hot reload. Per-agent `best_effort` propagated through enterprise merge.
+- Config validation: `sandbox.best_effort` and `sandbox.strict` mutually exclusive.
+
 ## [2.0.0] - 2026-03-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 [![CI](https://github.com/luckyPipewrench/pipelock/actions/workflows/ci.yaml/badge.svg)](https://github.com/luckyPipewrench/pipelock/actions/workflows/ci.yaml)
 [![Security](https://github.com/luckyPipewrench/pipelock/actions/workflows/security.yaml/badge.svg)](https://github.com/luckyPipewrench/pipelock/actions/workflows/security.yaml)
-[![Pipelock Security Scan](https://github.com/luckyPipewrench/pipelock/actions/workflows/pipelock.yaml/badge.svg)](https://github.com/luckyPipewrench/pipelock/actions/workflows/pipelock.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/luckyPipewrench/pipelock)](https://goreportcard.com/report/github.com/luckyPipewrench/pipelock)
 [![GitHub Release](https://img.shields.io/github/v/release/luckyPipewrench/pipelock)](https://github.com/luckyPipewrench/pipelock/releases)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/luckyPipewrench/pipelock/badge)](https://scorecard.dev/viewer/?uri=github.com/luckyPipewrench/pipelock)
@@ -233,12 +232,13 @@ DLP runs before DNS resolution, designed to catch secrets before any DNS query l
 
 See [docs/bypass-resistance.md](docs/bypass-resistance.md) for the full evasion test matrix.
 
-### Process Sandbox (Linux)
+### Process Sandbox
 
-Unprivileged process containment using Landlock LSM, network namespaces, and seccomp. No root, no Docker, no containers. The agent runs in an isolated environment with controlled filesystem access, no direct network egress, and a filtered syscall set. Works with any command — MCP servers, standalone agents, or arbitrary processes.
+Unprivileged process containment using OS-native kernel primitives. On Linux: Landlock LSM restricts filesystem access, seccomp filters dangerous syscalls, and network namespaces force all traffic through pipelock's scanner (no direct egress). On macOS: sandbox-exec profiles restrict filesystem and network. In containers, use `--best-effort` for Landlock + seccomp containment when namespace creation is restricted (network scanning uses proxy-based routing instead of kernel enforcement).
 
 ```bash
 pipelock sandbox --config pipelock.yaml -- python agent.py
+pipelock sandbox --best-effort -- python agent.py  # containers
 pipelock mcp proxy --sandbox --config pipelock.yaml -- npx server
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1405,15 +1405,18 @@ rules:
 
 ## Sandbox
 
-Process containment for agent commands using Linux kernel primitives. The agent runs in a restricted namespace with controlled filesystem access, no direct network, and a filtered syscall set.
+Process containment for agent commands using Linux kernel primitives. The agent runs in a restricted environment with controlled filesystem access, no direct network, and a filtered syscall set.
 
 ```yaml
 sandbox:
   enabled: true
+  best_effort: false              # degrade gracefully when namespace isolation unavailable
+  strict: false                   # error if any layer unavailable (mutually exclusive with best_effort)
   workspace: /home/user/project   # agent working directory (default: CWD)
   filesystem:                     # optional Landlock overrides (default policy works for most agents)
     allow_read:
       - /usr/share/data
+      - /app/                     # application code in containers
     allow_write:
       - /tmp/agent-work
 ```
@@ -1421,6 +1424,8 @@ sandbox:
 | Field | Default | Description |
 |-------|---------|-------------|
 | `enabled` | `false` | Enable sandbox containment |
+| `best_effort` | `false` | Skip namespace isolation when unavailable (e.g. containers). Landlock + seccomp still apply. |
+| `strict` | `false` | Error if any containment layer is unavailable. Mutually exclusive with `best_effort`. |
 | `workspace` | CWD | Agent working directory (resolved to absolute at startup) |
 | `filesystem.allow_read` | `[]` | Additional read-only filesystem paths |
 | `filesystem.allow_write` | `[]` | Additional writable paths (workspace is always writable) |
@@ -1428,9 +1433,9 @@ sandbox:
 If `filesystem` is omitted, the default Landlock policy is used (safe for Python/Node/Go agents without config). Read access grants execute (Landlock bundling). Write paths are also executable.
 
 **Containment layers:**
-- **Landlock LSM:** Restricts filesystem access to declared paths. Read-only and read-write grants are explicit. Allowlist model.
-- **Network namespaces:** Agent runs in an isolated network namespace. For MCP (stdio), no network is needed. For standalone agents, traffic routes through pipelock's bridge proxy.
-- **Seccomp BPF:** Syscall allowlist blocks dangerous operations (ptrace, mount, io_uring, module loading, kexec). Clone flags are filtered to prevent namespace escape.
+- **Landlock LSM:** Restricts filesystem access to declared paths. Allowlist model. Protected directories (`~/.ssh`, `~/.aws`, `~/.kube`, etc.) are denied. Only dirs that exist on the system are checked.
+- **Network namespaces:** Agent runs in an isolated network namespace. All traffic is kernel-forced through pipelock's bridge proxy. Raw socket bypass is impossible. For MCP (stdio), no network is needed.
+- **Seccomp BPF:** Syscall allowlist (~130 safe syscalls for Go/Python/Node.js). Blocks ptrace, mount, module loading, kexec (KILL). io_uring returns EPERM (allows runtimes like Node.js 22 to fall back to epoll). Clone flags filtered to prevent namespace escape.
 
 **Usage:**
 ```bash
@@ -1439,9 +1444,26 @@ pipelock mcp proxy --sandbox --config pipelock.yaml -- npx server
 
 # Sandbox a standalone command
 pipelock sandbox --config pipelock.yaml -- python agent.py
+
+# Pass environment variables to sandboxed process
+pipelock sandbox --env API_KEY --env HOME=/app -- node server.js
+
+# Best-effort mode for containers (Landlock + seccomp, no namespace)
+pipelock sandbox --best-effort -- python agent.py
+
+# Check sandbox capabilities without launching
+pipelock sandbox --dry-run --json -- python agent.py
 ```
 
-**Requirements:** Linux 5.13+ (Landlock ABI v1). Unprivileged — no root, no Docker, no special capabilities. Not available on macOS or Windows (hard error with explanation).
+**Environments:**
+
+| Environment | Layers | Notes |
+|-------------|--------|-------|
+| Bare metal / VM (Linux) | 3/3 | Full containment: Landlock + seccomp + network namespace |
+| Containers (`--best-effort`) | 2/3 | Landlock + seccomp. Network via HTTP_PROXY + NetworkPolicy. |
+| macOS | sandbox-exec | Apple SBPL profiles for filesystem + network restriction |
+
+**Requirements:** Linux 5.13+ (Landlock ABI v1). Unprivileged on bare metal. macOS 13+ for sandbox-exec. Containers may need `--best-effort` if default seccomp blocks `CLONE_NEWUSER`.
 
 ## Config Audit Scoring (v2.0)
 

--- a/enterprise/config.go
+++ b/enterprise/config.go
@@ -385,6 +385,9 @@ func MergeAgentProfile(base *config.Config, profile *config.AgentProfile) (*conf
 		if profile.Sandbox.Strict != nil {
 			merged.Sandbox.Strict = *profile.Sandbox.Strict
 		}
+		if profile.Sandbox.BestEffort != nil {
+			merged.Sandbox.BestEffort = *profile.Sandbox.BestEffort
+		}
 		if profile.Sandbox.Workspace != "" {
 			merged.Sandbox.Workspace = profile.Sandbox.Workspace
 		}

--- a/enterprise/config_test.go
+++ b/enterprise/config_test.go
@@ -911,6 +911,42 @@ func TestMergeAgentProfile_SandboxFSAppendToNilBase(t *testing.T) {
 	}
 }
 
+func TestMergeAgentProfile_SandboxBestEffortOverride(t *testing.T) {
+	cfg := testConfig()
+	cfg.Sandbox.BestEffort = false
+
+	bestEffort := true
+	profile := &config.AgentProfile{
+		Sandbox: &config.AgentSandboxOverride{
+			BestEffort: &bestEffort,
+		},
+	}
+	merged, err := MergeAgentProfile(cfg, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !merged.Sandbox.BestEffort {
+		t.Error("expected sandbox.best_effort=true (explicit override)")
+	}
+}
+
+func TestMergeAgentProfile_SandboxBestEffortInherits(t *testing.T) {
+	cfg := testConfig()
+	cfg.Sandbox.BestEffort = true
+
+	// Profile with nil BestEffort — should inherit from base.
+	profile := &config.AgentProfile{
+		Sandbox: &config.AgentSandboxOverride{},
+	}
+	merged, err := MergeAgentProfile(cfg, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !merged.Sandbox.BestEffort {
+		t.Error("expected sandbox.best_effort=true (inherited from base)")
+	}
+}
+
 func TestResolvePublicKey_InvalidHex(t *testing.T) {
 	cfg := testConfig()
 	cfg.LicensePublicKey = "not-valid-hex"

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -128,6 +128,7 @@ func mcpProxyCmd() *cobra.Command {
 	var agentName string
 	var sandboxEnabled bool
 	var sandboxStrict bool
+	var sandboxBestEffort bool
 	var sandboxWorkspace string
 
 	cmd := &cobra.Command{
@@ -496,15 +497,15 @@ Environment passthrough (subprocess mode only):
 
 			// Subprocess mode.
 			serverCmd := args[dashIdx:]
-			// --sandbox-strict implies --sandbox.
-			if sandboxStrict {
+			// --sandbox-strict and --sandbox-best-effort imply --sandbox.
+			if sandboxStrict || sandboxBestEffort {
 				sandboxEnabled = true
 			}
 			useSandbox := sandboxEnabled || cfg.Sandbox.Enabled
 
-			// Reject config-enabled sandbox with remote modes.
-			if cfg.Sandbox.Enabled && (hasUpstream || hasListen) {
-				return errors.New("sandbox.enabled cannot be used with --upstream or --listen (cannot sandbox a remote server)")
+			// Reject sandbox with remote modes.
+			if useSandbox && (hasUpstream || hasListen) {
+				return errors.New("sandbox cannot be used with --upstream or --listen (cannot sandbox a remote server)")
 			}
 
 			// Sandboxed MCP proxy: child in isolated namespace.
@@ -532,13 +533,19 @@ Environment passthrough (subprocess mode only):
 				defer cancel()
 
 				mcpStrict := sandboxStrict || cfg.Sandbox.Strict
+				mcpBestEffort := sandboxBestEffort || cfg.Sandbox.BestEffort
+
+				if mcpStrict && mcpBestEffort {
+					return errors.New("--sandbox-strict and --sandbox-best-effort are mutually exclusive")
+				}
 
 				launchCfg := sandbox.LaunchConfig{
-					Ctx:       ctx,
-					Command:   serverCmd,
-					Workspace: workspace,
-					Strict:    mcpStrict,
-					ExtraEnv:  extraEnv,
+					Ctx:        ctx,
+					Command:    serverCmd,
+					Workspace:  workspace,
+					Strict:     mcpStrict,
+					BestEffort: mcpBestEffort,
+					ExtraEnv:   extraEnv,
 				}
 				if cfg.Sandbox.FS != nil {
 					p := sandbox.DefaultPolicy(workspace)
@@ -652,6 +659,7 @@ Environment passthrough (subprocess mode only):
 	cmd.Flags().StringVar(&agentName, "agent", "", "agent profile name (resolves to config profile for policy/scanner)")
 	cmd.Flags().BoolVar(&sandboxEnabled, "sandbox", false, "run child in sandbox (Landlock + seccomp + network namespace, Linux only)")
 	cmd.Flags().BoolVar(&sandboxStrict, "sandbox-strict", false, "strict sandbox: error on missing layers, private /dev/shm, block clone3 (implies --sandbox)")
+	cmd.Flags().BoolVar(&sandboxBestEffort, "sandbox-best-effort", false, "degrade gracefully when namespace isolation is unavailable (implies --sandbox)")
 	cmd.Flags().StringVar(&sandboxWorkspace, "workspace", "", "sandbox workspace directory (default: current directory)")
 	return cmd
 }

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -30,8 +30,10 @@ func sandboxCmd() *cobra.Command {
 	var workspace string
 	var configFile string
 	var strict bool
+	var bestEffort bool
 	var dryRun bool
 	var jsonOutput bool
+	var envVars []string
 
 	cmd := &cobra.Command{
 		Use:   "sandbox [flags] -- COMMAND [ARGS...]",
@@ -45,9 +47,14 @@ func sandboxCmd() *cobra.Command {
 Agent HTTP/HTTPS traffic is routed through pipelock's full scanner pipeline
 (DLP, SSRF, blocklist, rate limiting, entropy analysis) via a bridge proxy.
 
+Use --best-effort inside containers where user namespace creation is blocked
+(e.g. Kubernetes with default seccomp). Landlock and seccomp are still applied;
+network scanning uses proxy-based routing instead of kernel-enforced isolation.
+
 Examples:
   pipelock sandbox -- python agent.py
   pipelock sandbox --workspace /home/user/project -- node server.js
+  pipelock sandbox --best-effort -- python agent.py  # inside containers
   pipelock sandbox --config pipelock.yaml -- bash -c "curl https://example.com"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dashIdx := cmd.ArgsLenAtDash()
@@ -75,6 +82,11 @@ Examples:
 			workspace, _ = filepath.Abs(workspace)
 
 			useStrict := strict || cfg.Sandbox.Strict
+			useBestEffort := bestEffort || cfg.Sandbox.BestEffort
+
+			if useStrict && useBestEffort {
+				return errors.New("--strict and --best-effort are mutually exclusive")
+			}
 
 			// Dry-run: preflight check without launching.
 			if dryRun {
@@ -141,11 +153,30 @@ Examples:
 				_ = srv.Serve(&singleConnListener{conn: conn})
 			}
 
+			// Resolve --env flags: KEY=VALUE passes as-is, bare KEY inherits from parent.
+			var extraEnv []string
+			for _, e := range envVars {
+				key, _, hasValue := strings.Cut(e, "=")
+				if key == "" {
+					return errors.New("--env requires a non-empty variable name")
+				}
+				if sandbox.IsDangerousEnvKey(key) {
+					return fmt.Errorf("--env %s is blocked: this variable can subvert sandbox containment", key)
+				}
+				if hasValue {
+					extraEnv = append(extraEnv, e)
+				} else if val, found := os.LookupEnv(e); found {
+					extraEnv = append(extraEnv, e+"="+val)
+				}
+			}
+
 			launchCfg := sandbox.StandaloneLaunchConfig{
 				Ctx:          ctx,
 				Command:      command,
 				Workspace:    workspace,
 				Strict:       useStrict,
+				BestEffort:   useBestEffort,
+				ExtraEnv:     extraEnv,
 				ProxyHandler: proxyHandler,
 			}
 
@@ -164,6 +195,8 @@ Examples:
 	cmd.Flags().StringVar(&workspace, "workspace", "", "sandbox workspace directory (default: current directory)")
 	cmd.Flags().StringVarP(&configFile, "config", "c", "", "config file path")
 	cmd.Flags().BoolVar(&strict, "strict", false, "strict mode: error if any containment layer is unavailable, mount private /dev/shm, block clone3")
+	cmd.Flags().BoolVar(&bestEffort, "best-effort", false, "degrade gracefully when namespace isolation is unavailable (e.g. inside containers)")
+	cmd.Flags().StringArrayVar(&envVars, "env", nil, "pass environment variable to sandboxed process (KEY or KEY=VALUE, repeatable)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "check sandbox capabilities without launching (exit 0=capabilities ok, 1=degraded, 2=error)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output dry-run result as JSON")
 	return cmd

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -216,10 +216,11 @@ type FileSentry struct {
 // Sandbox config is startup-only and reload-immutable: changing these
 // values in a config reload has no effect on an already-running sandbox.
 type Sandbox struct {
-	Enabled   bool               `yaml:"enabled"`
-	Strict    bool               `yaml:"strict"`    // error if any containment layer is unavailable
-	Workspace string             `yaml:"workspace"` // agent working dir; resolved to absolute at startup
-	FS        *SandboxFilesystem `yaml:"filesystem"`
+	Enabled    bool               `yaml:"enabled"`
+	Strict     bool               `yaml:"strict"`      // error if any containment layer is unavailable
+	BestEffort bool               `yaml:"best_effort"` // degrade gracefully when namespace isolation unavailable (e.g. containers)
+	Workspace  string             `yaml:"workspace"`   // agent working dir; resolved to absolute at startup
+	FS         *SandboxFilesystem `yaml:"filesystem"`
 }
 
 // AgentSandboxOverride controls per-agent sandbox settings.
@@ -227,10 +228,11 @@ type Sandbox struct {
 // Scoped to mcp proxy --agent and agent listeners. pipelock sandbox
 // CLI does not support per-agent resolution.
 type AgentSandboxOverride struct {
-	Enabled   *bool              `yaml:"enabled,omitempty"`
-	Strict    *bool              `yaml:"strict,omitempty"`
-	Workspace string             `yaml:"workspace,omitempty"`
-	FS        *SandboxFilesystem `yaml:"filesystem,omitempty"`
+	Enabled    *bool              `yaml:"enabled,omitempty"`
+	Strict     *bool              `yaml:"strict,omitempty"`
+	BestEffort *bool              `yaml:"best_effort,omitempty"`
+	Workspace  string             `yaml:"workspace,omitempty"`
+	FS         *SandboxFilesystem `yaml:"filesystem,omitempty"`
 }
 
 // SandboxFilesystem overrides the default Landlock policy. If nil, the
@@ -2408,6 +2410,11 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// Sandbox: best_effort and strict are mutually exclusive.
+	if c.Sandbox.BestEffort && c.Sandbox.Strict {
+		return fmt.Errorf("sandbox: best_effort and strict are mutually exclusive")
+	}
+
 	// Sandbox: validate filesystem paths even when disabled (CLI can override enabled).
 	if c.Sandbox.FS != nil {
 		for _, p := range c.Sandbox.FS.AllowRead {
@@ -2804,6 +2811,9 @@ func sandboxChanged(old, updated *Config) bool {
 	if old.Sandbox.Strict != updated.Sandbox.Strict {
 		return true
 	}
+	if old.Sandbox.BestEffort != updated.Sandbox.BestEffort {
+		return true
+	}
 	if old.Sandbox.Workspace != updated.Sandbox.Workspace {
 		return true
 	}
@@ -2855,7 +2865,7 @@ func agentSandboxChanged(old, updated *AgentSandboxOverride) bool {
 	if old == nil {
 		return false
 	}
-	if !boolPtrEqual(old.Enabled, updated.Enabled) || !boolPtrEqual(old.Strict, updated.Strict) {
+	if !boolPtrEqual(old.Enabled, updated.Enabled) || !boolPtrEqual(old.Strict, updated.Strict) || !boolPtrEqual(old.BestEffort, updated.BestEffort) {
 		return true
 	}
 	if old.Workspace != updated.Workspace {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7515,6 +7515,25 @@ func TestValidateReload_SandboxStrictChanged(t *testing.T) {
 	}
 }
 
+func TestValidateReload_SandboxBestEffortChanged(t *testing.T) {
+	old := Defaults()
+	old.Sandbox.Enabled = true
+	updated := Defaults()
+	updated.Sandbox.Enabled = true
+	updated.Sandbox.BestEffort = true
+	warnings := ValidateReload(old, updated)
+	found := false
+	for _, w := range warnings {
+		if w.Field == fieldSandbox {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected sandbox reload warning when sandbox.best_effort changes")
+	}
+}
+
 func TestValidateReload_SandboxUnchanged_NoWarning(t *testing.T) {
 	old := Defaults()
 	old.Sandbox.Enabled = true
@@ -7720,6 +7739,29 @@ func TestValidateReload_SandboxAgentChanged(t *testing.T) {
 	}
 }
 
+func TestValidateReload_SandboxAgentBestEffortChanged(t *testing.T) {
+	bestEffortTrue := true
+	bestEffortFalse := false
+	old := Defaults()
+	old.Agents = map[string]AgentProfile{
+		"test-agent": {Sandbox: &AgentSandboxOverride{BestEffort: &bestEffortFalse}},
+	}
+	updated := Defaults()
+	updated.Agents = map[string]AgentProfile{
+		"test-agent": {Sandbox: &AgentSandboxOverride{BestEffort: &bestEffortTrue}},
+	}
+	warnings := ValidateReload(old, updated)
+	found := false
+	for _, w := range warnings {
+		if w.Field == fieldSandbox {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected sandbox warning when agent sandbox.best_effort changes")
+	}
+}
+
 func TestSandboxFSChanged(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -7739,6 +7781,36 @@ func TestSandboxFSChanged(t *testing.T) {
 				t.Errorf("sandboxFSChanged = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestValidate_SandboxBestEffortAndStrictMutuallyExclusive(t *testing.T) {
+	cfg := Defaults()
+	cfg.Internal = nil
+	cfg.Sandbox.BestEffort = true
+	cfg.Sandbox.Strict = true
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error when both best_effort and strict are set")
+	}
+}
+
+func TestValidate_SandboxBestEffortAlone(t *testing.T) {
+	cfg := Defaults()
+	cfg.Internal = nil
+	cfg.Sandbox.BestEffort = true
+	cfg.Sandbox.Strict = false
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("best_effort alone should be valid: %v", err)
+	}
+}
+
+func TestValidate_SandboxStrictAlone(t *testing.T) {
+	cfg := Defaults()
+	cfg.Internal = nil
+	cfg.Sandbox.Strict = true
+	cfg.Sandbox.BestEffort = false
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("strict alone should be valid: %v", err)
 	}
 }
 

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -161,13 +161,18 @@ func setupWSProxy(t *testing.T, cfgMod func(*config.Config)) (string, func()) {
 }
 
 // dialWS connects to the proxy /ws endpoint and returns the raw connection.
+// Compression is disabled to avoid "compressed frames not supported" errors
+// when the proxy relays frames without per-message deflate negotiation.
 func dialWS(t *testing.T, proxyAddr, backendAddr string) net.Conn {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	wsURL := fmt.Sprintf("ws://%s/ws?url=ws://%s", proxyAddr, backendAddr)
-	conn, _, _, err := ws.Dial(ctx, wsURL)
+	dialer := ws.Dialer{
+		Extensions: nil, // disable per-message deflate compression
+	}
+	conn, _, _, err := dialer.Dial(ctx, wsURL)
 	if err != nil {
 		t.Fatalf("ws dial: %v", err)
 	}
@@ -2596,9 +2601,10 @@ func TestWSRelay_KillSwitch_UpstreamToClient(t *testing.T) {
 	cfg.WebSocketProxy.Enabled = true
 	cfg.WebSocketProxy.MaxMessageBytes = 1048576
 	cfg.WebSocketProxy.MaxConcurrentConnections = 128
-	cfg.WebSocketProxy.MaxConnectionSeconds = 10
-	cfg.WebSocketProxy.IdleTimeoutSeconds = 5
-	cfg.FetchProxy.TimeoutSeconds = 5
+	// Generous timeouts to avoid CI flakes under load.
+	cfg.WebSocketProxy.MaxConnectionSeconds = 30
+	cfg.WebSocketProxy.IdleTimeoutSeconds = 15
+	cfg.FetchProxy.TimeoutSeconds = 10
 
 	logger := audit.NewNop()
 	sc := scanner.New(cfg)

--- a/internal/sandbox/child_init.go
+++ b/internal/sandbox/child_init.go
@@ -87,12 +87,19 @@ func RunInit() {
 	reportLayer(os.Stderr, scStatus, scErr)
 
 	// Report network namespace status (set at fork time by parent).
-	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] network: ACTIVE (isolated namespace)\n")
+	noNetNS := IsNoNetNS()
+	if noNetNS {
+		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] network: DEGRADED (no namespace, best-effort mode)\n")
+	} else {
+		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] network: ACTIVE (isolated namespace)\n")
+	}
 
 	// Report summary.
 	active := countActive(llStatus, scStatus)
 	const totalLayers = 3
-	active++ // count netns
+	if !noNetNS {
+		active++ // count netns only when namespace isolation is active
+	}
 	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] containment: %d/%d layers active\n", active, totalLayers)
 
 	// Strict mode: fail-closed if any layer is inactive.
@@ -105,6 +112,7 @@ func RunInit() {
 	for _, key := range []string{
 		initEnvKey, "__PIPELOCK_SANDBOX_WORKSPACE", "__PIPELOCK_SANDBOX_COMMAND",
 		"__PIPELOCK_SANDBOX_EXTRA_ENV", "__PIPELOCK_SANDBOX_POLICY",
+		noNetNSEnvKey,
 	} {
 		env = removeEnvKey(env, key)
 	}

--- a/internal/sandbox/child_standalone_init.go
+++ b/internal/sandbox/child_standalone_init.go
@@ -87,17 +87,33 @@ func RunStandaloneInit() {
 	scStatus, scErr := ApplySeccomp(strict)
 	reportLayer(os.Stderr, scStatus, scErr)
 
-	// Network namespace is active (set at fork time).
-	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] network: ACTIVE (isolated namespace)\n")
-
-	// Bring up loopback for the bridge proxy.
-	if err := bringUpLoopback(); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] loopback: %v\n", err)
-		os.Exit(1)
+	// Network namespace status depends on whether parent created one.
+	noNetNS := IsNoNetNS()
+	if noNetNS {
+		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] network: DEGRADED (no namespace, proxy-based routing only)\n")
+	} else {
+		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] network: ACTIVE (isolated namespace)\n")
+		// Bring up loopback only in a new network namespace.
+		// In best-effort mode without netns, loopback is already up.
+		if err := bringUpLoopback(); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] loopback: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
-	// Start bridge proxy.
-	bridge, err := NewBridgeProxy(socketPath)
+	// Start bridge proxy. In best-effort mode without netns, the bridge
+	// still works — HTTP_PROXY routes cooperative agents through pipelock.
+	// Network isolation is not kernel-enforced in this mode.
+	//
+	// Without a network namespace, the default port (8888) may conflict
+	// with a pipelock sidecar already running in the same pod. Use port 0
+	// (OS-assigned) to avoid the conflict — the agent gets the actual
+	// address via HTTP_PROXY env var.
+	var bridgeAddr string
+	if noNetNS {
+		bridgeAddr = "127.0.0.1:0" // dynamic port to avoid sidecar conflict
+	}
+	bridge, err := NewBridgeProxy(socketPath, bridgeAddr)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] bridge proxy: %v\n", err)
 		os.Exit(1)
@@ -111,8 +127,10 @@ func RunStandaloneInit() {
 
 	// Report summary.
 	active := countActive(llStatus, scStatus)
-	active++ // network namespace
 	const totalLayers = 3
+	if !noNetNS {
+		active++ // count netns only when namespace isolation is active
+	}
 	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] containment: %d/%d layers active\n", active, totalLayers)
 
 	// Strict mode: fail-closed if any layer is inactive.
@@ -136,7 +154,7 @@ func RunStandaloneInit() {
 		standaloneInitEnv, initEnvKey,
 		"__PIPELOCK_SANDBOX_WORKSPACE", "__PIPELOCK_SANDBOX_COMMAND",
 		"__PIPELOCK_SANDBOX_SOCKET", "__PIPELOCK_SANDBOX_EXTRA_ENV",
-		"__PIPELOCK_SANDBOX_POLICY",
+		"__PIPELOCK_SANDBOX_POLICY", noNetNSEnvKey,
 	} {
 		env = removeEnvKey(env, key)
 	}

--- a/internal/sandbox/env.go
+++ b/internal/sandbox/env.go
@@ -25,6 +25,11 @@ var safePassthroughKeys = []string{
 // dangerousEnvKeys are environment variable keys that must NOT be passed
 // into the sandbox via --env flags. These can subvert containment by
 // injecting code before the agent process starts.
+// IsDangerousEnvKey returns true if the key could subvert sandbox containment.
+func IsDangerousEnvKey(key string) bool {
+	return dangerousEnvKeys[key]
+}
+
 var dangerousEnvKeys = map[string]bool{
 	"LD_PRELOAD":      true, // shared library injection
 	"LD_LIBRARY_PATH": true, // library search path hijack

--- a/internal/sandbox/helpers.go
+++ b/internal/sandbox/helpers.go
@@ -27,10 +27,20 @@ func IsInitMode() bool {
 // strictEnvKey signals the child that strict mode is active.
 const strictEnvKey = "__PIPELOCK_SANDBOX_STRICT"
 
+// noNetNSEnvKey signals the child that network namespace was NOT created
+// (best-effort mode where CLONE_NEWUSER is blocked, e.g. inside containers).
+const noNetNSEnvKey = "__PIPELOCK_SANDBOX_NO_NETNS"
+
 // IsStrictMode returns true if the child process should enforce strict
 // sandbox containment (error on missing layers, private /dev/shm, etc.).
 func IsStrictMode() bool {
 	return os.Getenv(strictEnvKey) == "1"
+}
+
+// IsNoNetNS returns true if the child was launched without network namespace
+// isolation (best-effort fallback when CLONE_NEWUSER is unavailable).
+func IsNoNetNS() bool {
+	return os.Getenv(noNetNSEnvKey) == "1"
 }
 
 // reportLayer prints a sandbox layer status line to stderr.

--- a/internal/sandbox/launcher.go
+++ b/internal/sandbox/launcher.go
@@ -37,6 +37,11 @@ type LaunchConfig struct {
 	// private /dev/shm mount, clone3 blocked.
 	Strict bool
 
+	// BestEffort skips namespace isolation when unavailable (e.g. inside
+	// containers where CLONE_NEWUSER is blocked by seccomp). Landlock and
+	// seccomp are still applied. Mutually exclusive with Strict.
+	BestEffort bool
+
 	// ExtraEnv contains additional KEY=VALUE pairs to pass to the child.
 	ExtraEnv []string
 
@@ -50,6 +55,10 @@ type LaunchConfig struct {
 // sandbox-init mode with user + network namespace isolation. The returned
 // cmd is NOT started — the caller can set up pipes (StdinPipe, StdoutPipe)
 // before calling cmd.Start().
+//
+// When BestEffort is true and user namespaces are unavailable (e.g. inside
+// containers), the child is launched without namespace isolation. Landlock
+// and seccomp containment are still applied.
 //
 // For simple cases, use LaunchSandboxed which calls Start automatically.
 func PrepareSandboxCmd(cfg LaunchConfig) (*exec.Cmd, error) {
@@ -68,6 +77,20 @@ func PrepareSandboxCmd(cfg LaunchConfig) (*exec.Cmd, error) {
 	}
 	if err := ValidatePolicy(policy); err != nil {
 		return nil, err
+	}
+
+	// Strict and BestEffort are mutually exclusive — catch misuse by callers.
+	if cfg.Strict && cfg.BestEffort {
+		return nil, fmt.Errorf("sandbox: strict and best_effort are mutually exclusive")
+	}
+
+	// Probe namespace support before setting clone flags.
+	// Only CLONE_NEWUSER is probed because CLONE_NEWNET requires CLONE_NEWUSER
+	// on unprivileged processes — if user namespaces work, network namespaces
+	// will too (created inside the user namespace with CAP_SYS_ADMIN).
+	hasNamespaces := probeUserNamespace()
+	if !hasNamespaces && !cfg.BestEffort {
+		return nil, fmt.Errorf("%w: user namespaces unavailable (blocked by seccomp or sysctl? enable best_effort for degraded mode)", ErrUnavailable)
 	}
 
 	// Re-exec ourselves as sandbox-init. Using /proc/self/exe ensures we
@@ -108,24 +131,33 @@ func PrepareSandboxCmd(cfg LaunchConfig) (*exec.Cmd, error) {
 		cmd.Env = append(cmd.Env, "__PIPELOCK_SANDBOX_POLICY="+policyJSON)
 	}
 
-	// Create child in new user + network namespace.
-	// Strict mode adds CLONE_NEWNS (mount namespace) for private /dev/shm.
-	cloneFlags := uintptr(syscall.CLONE_NEWUSER | syscall.CLONE_NEWNET)
-	if cfg.Strict {
-		cloneFlags |= syscall.CLONE_NEWNS
-	}
-	uid := os.Getuid()
-	gid := os.Getgid()
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Cloneflags: cloneFlags,
-		UidMappings: []syscall.SysProcIDMap{
-			{ContainerID: 0, HostID: uid, Size: 1},
-		},
-		GidMappings: []syscall.SysProcIDMap{
-			{ContainerID: 0, HostID: gid, Size: 1},
-		},
-		Pdeathsig: syscall.SIGTERM, // kill child if parent dies
-		Setpgid:   true,            // own process group for cleanup
+	if hasNamespaces {
+		// Full isolation: user + network namespace.
+		// Strict mode adds CLONE_NEWNS (mount namespace) for private /dev/shm.
+		cloneFlags := uintptr(syscall.CLONE_NEWUSER | syscall.CLONE_NEWNET)
+		if cfg.Strict {
+			cloneFlags |= syscall.CLONE_NEWNS
+		}
+		uid := os.Getuid()
+		gid := os.Getgid()
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Cloneflags: cloneFlags,
+			UidMappings: []syscall.SysProcIDMap{
+				{ContainerID: 0, HostID: uid, Size: 1},
+			},
+			GidMappings: []syscall.SysProcIDMap{
+				{ContainerID: 0, HostID: gid, Size: 1},
+			},
+			Pdeathsig: syscall.SIGTERM, // kill child if parent dies
+			Setpgid:   true,            // own process group for cleanup
+		}
+	} else {
+		// Best-effort: no namespace isolation. Child still gets Landlock + seccomp.
+		cmd.Env = append(cmd.Env, noNetNSEnvKey+"=1")
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Pdeathsig: syscall.SIGTERM,
+			Setpgid:   true,
+		}
 	}
 
 	return cmd, nil

--- a/internal/sandbox/launcher_darwin.go
+++ b/internal/sandbox/launcher_darwin.go
@@ -28,6 +28,10 @@ type LaunchConfig struct {
 	// seccomp or mount namespace isolation.
 	Strict bool
 
+	// BestEffort is accepted for API compatibility with Linux but has
+	// no effect on macOS (sandbox-exec doesn't use namespaces).
+	BestEffort bool
+
 	ExtraEnv []string
 	Stdin    io.Reader
 	Stdout   io.Writer
@@ -41,6 +45,7 @@ type StandaloneLaunchConfig struct {
 	Workspace    string
 	Policy       *Policy
 	Strict       bool
+	BestEffort   bool
 	ExtraEnv     []string
 	ProxyHandler func(conn net.Conn)
 }

--- a/internal/sandbox/launcher_helpers_test.go
+++ b/internal/sandbox/launcher_helpers_test.go
@@ -187,6 +187,29 @@ func TestIsInitMode_False(t *testing.T) {
 	}
 }
 
+func TestIsNoNetNS_False(t *testing.T) {
+	// Default: no env var means network namespace IS active.
+	t.Setenv(noNetNSEnvKey, "")
+	if IsNoNetNS() {
+		t.Error("should not report no-netns when env var is not set")
+	}
+}
+
+func TestIsNoNetNS_True(t *testing.T) {
+	t.Setenv(noNetNSEnvKey, "1")
+	if !IsNoNetNS() {
+		t.Error("should report no-netns when env var is set")
+	}
+}
+
+func TestNoNetNSEnvKey_CleanedByRemoveEnvKey(t *testing.T) {
+	env := []string{noNetNSEnvKey + "=1", "OTHER=value"}
+	result := removeEnvKey(env, noNetNSEnvKey)
+	if len(result) != 1 || result[0] != "OTHER=value" {
+		t.Errorf("expected only OTHER=value, got %v", result)
+	}
+}
+
 func TestReportLayer_UnavailableWithError(t *testing.T) {
 	var buf bytes.Buffer
 	status := LayerStatus{Name: LayerLandlock} // no reason set

--- a/internal/sandbox/launcher_other.go
+++ b/internal/sandbox/launcher_other.go
@@ -16,15 +16,16 @@ import (
 // LaunchConfig configures how the sandbox launcher forks the child process.
 // On non-Linux platforms, all launcher functions return ErrUnavailable.
 type LaunchConfig struct {
-	Ctx       context.Context
-	Command   []string
-	Workspace string
-	Policy    *Policy
-	Strict    bool
-	ExtraEnv  []string
-	Stdin     io.Reader
-	Stdout    io.Writer
-	Stderr    io.Writer
+	Ctx        context.Context
+	Command    []string
+	Workspace  string
+	Policy     *Policy
+	Strict     bool
+	BestEffort bool
+	ExtraEnv   []string
+	Stdin      io.Reader
+	Stdout     io.Writer
+	Stderr     io.Writer
 }
 
 // StandaloneLaunchConfig configures the standalone sandbox launcher.
@@ -34,6 +35,7 @@ type StandaloneLaunchConfig struct {
 	Workspace    string
 	Policy       *Policy
 	Strict       bool
+	BestEffort   bool
 	ExtraEnv     []string
 	ProxyHandler func(conn net.Conn)
 }

--- a/internal/sandbox/loopback_linux.go
+++ b/internal/sandbox/loopback_linux.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package sandbox
+
+import (
+	"encoding/binary"
+	"fmt"
+	"syscall"
+)
+
+// Netlink message types and flags for RTM_NEWLINK.
+const (
+	nlmsgHdrLen  = 16 // sizeof(nlmsghdr)
+	ifInfoMsgLen = 16 // sizeof(ifinfomsg)
+)
+
+// loopbackUp brings up the loopback interface using raw netlink syscalls.
+// This avoids requiring the `ip` binary in minimal container images.
+func loopbackUp() error {
+	fd, err := syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW, syscall.NETLINK_ROUTE)
+	if err != nil {
+		return fmt.Errorf("netlink socket: %w", err)
+	}
+	defer func() { _ = syscall.Close(fd) }()
+
+	if err := syscall.Bind(fd, &syscall.SockaddrNetlink{Family: syscall.AF_NETLINK}); err != nil {
+		return fmt.Errorf("netlink bind: %w", err)
+	}
+
+	// Build RTM_NEWLINK message to set IFF_UP on loopback (index 1).
+	msgLen := nlmsgHdrLen + ifInfoMsgLen
+	buf := make([]byte, msgLen)
+
+	// nlmsghdr
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(msgLen))                          // nlmsg_len
+	binary.LittleEndian.PutUint16(buf[4:6], syscall.RTM_NEWLINK)                     // nlmsg_type
+	binary.LittleEndian.PutUint16(buf[6:8], syscall.NLM_F_REQUEST|syscall.NLM_F_ACK) // nlmsg_flags
+	binary.LittleEndian.PutUint32(buf[8:12], 1)                                      // nlmsg_seq
+	binary.LittleEndian.PutUint32(buf[12:16], 0)                                     // nlmsg_pid
+
+	// ifinfomsg
+	buf[nlmsgHdrLen+0] = syscall.AF_UNSPEC                                            // ifi_family
+	binary.LittleEndian.PutUint16(buf[nlmsgHdrLen+2:nlmsgHdrLen+4], 0)                // pad / ifi_type
+	binary.LittleEndian.PutUint32(buf[nlmsgHdrLen+4:nlmsgHdrLen+8], 1)                // ifi_index (lo = 1)
+	binary.LittleEndian.PutUint32(buf[nlmsgHdrLen+8:nlmsgHdrLen+12], syscall.IFF_UP)  // ifi_flags
+	binary.LittleEndian.PutUint32(buf[nlmsgHdrLen+12:nlmsgHdrLen+16], syscall.IFF_UP) // ifi_change
+
+	if err := syscall.Sendto(fd, buf, 0, &syscall.SockaddrNetlink{Family: syscall.AF_NETLINK}); err != nil {
+		return fmt.Errorf("netlink send: %w", err)
+	}
+
+	// Read ACK.
+	ack := make([]byte, 1024)
+	n, _, err := syscall.Recvfrom(fd, ack, 0)
+	if err != nil {
+		return fmt.Errorf("netlink recv: %w", err)
+	}
+
+	// Parse the nlmsghdr to check for NLMSG_ERROR.
+	if n >= nlmsgHdrLen {
+		msgType := binary.LittleEndian.Uint16(ack[4:6])
+		if msgType == syscall.NLMSG_ERROR {
+			// Error code is a negative errno (int32) at offset 16 (after nlmsghdr).
+			if n >= nlmsgHdrLen+4 {
+				errInt := int32(binary.LittleEndian.Uint32(ack[nlmsgHdrLen : nlmsgHdrLen+4])) //nolint:gosec // G115: reinterpreting uint32 as int32 for netlink signed errno
+				if errInt < 0 {
+					return fmt.Errorf("netlink error: %w", syscall.Errno(-errInt)) //nolint:gosec // G115: negated int32 fits in syscall.Errno
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/sandbox/loopback_linux_test.go
+++ b/internal/sandbox/loopback_linux_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package sandbox
+
+import (
+	"errors"
+	"runtime"
+	"syscall"
+	"testing"
+)
+
+func TestLoopbackUp_ReturnsError(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux only")
+	}
+	// On the host without CAP_NET_ADMIN, loopbackUp returns EPERM.
+	// Inside a sandbox namespace (as root), it succeeds.
+	// Either outcome is valid — we just verify it doesn't panic.
+	err := loopbackUp()
+	if err != nil {
+		// Expected on host: EPERM because we lack CAP_NET_ADMIN.
+		if !errors.Is(err, syscall.EPERM) {
+			t.Logf("loopbackUp returned non-EPERM error: %v", err)
+		}
+	}
+	// If err == nil, loopback was already up and we had permission (CI as root).
+}
+
+func TestBringUpLoopback_DoesNotPanic(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux only")
+	}
+	// bringUpLoopback uses raw netlink syscalls.
+	// On unprivileged host, returns EPERM — we just verify no panic.
+	_ = bringUpLoopback()
+}
+
+func TestLoopbackUp_NetlinkMessageFormat(t *testing.T) {
+	// Verify the netlink constants are correct sizes.
+	if nlmsgHdrLen != 16 {
+		t.Errorf("nlmsgHdrLen = %d, want 16", nlmsgHdrLen)
+	}
+	if ifInfoMsgLen != 16 {
+		t.Errorf("ifInfoMsgLen = %d, want 16", ifInfoMsgLen)
+	}
+}

--- a/internal/sandbox/loopback_other.go
+++ b/internal/sandbox/loopback_other.go
@@ -1,0 +1,14 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package sandbox
+
+import "fmt"
+
+// loopbackUp is a no-op on non-Linux platforms.
+// Linux uses raw netlink syscalls to bring up loopback.
+func loopbackUp() error {
+	return fmt.Errorf("loopback setup not supported on this platform")
+}

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -206,12 +206,14 @@ func DefaultPolicy(workspace string) Policy {
 }
 
 // secretDirs returns paths that should never be readable inside the sandbox.
+// Only includes directories that actually exist — in containers, most of
+// these won't be present and shouldn't block policy validation.
 func secretDirs() []string {
 	home := os.Getenv("HOME")
 	if home == "" {
 		return nil
 	}
-	return []string{
+	candidates := []string{
 		filepath.Join(home, ".ssh"),
 		filepath.Join(home, ".aws"),
 		filepath.Join(home, ".config", "pipelock"),
@@ -219,6 +221,13 @@ func secretDirs() []string {
 		filepath.Join(home, ".kube"),
 		filepath.Join(home, ".docker"),
 	}
+	var dirs []string
+	for _, d := range candidates {
+		if _, err := os.Stat(d); err == nil {
+			dirs = append(dirs, d)
+		}
+	}
+	return dirs
 }
 
 // ValidatePolicy checks that a sandbox policy does not accidentally

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -129,14 +129,16 @@ func TestDefaultPolicy_DeniesSecretDirs(t *testing.T) {
 	if home == "" {
 		t.Skip("HOME not set")
 	}
+	requireSecretDirs(t)
 	dir := t.TempDir()
 	p := DefaultPolicy(dir)
 
 	if len(p.DenyReadDirs) == 0 {
 		t.Fatal("expected deny_read dirs, got empty")
 	}
-	assertContains(t, "DenyReadDirs", p.DenyReadDirs, filepath.Join(home, ".ssh"))
-	assertContains(t, "DenyReadDirs", p.DenyReadDirs, filepath.Join(home, ".aws"))
+	// Verify at least one secret dir is in the deny list.
+	protected := secretDirs()
+	assertContains(t, "DenyReadDirs", p.DenyReadDirs, protected[0])
 }
 
 func TestResult_ActiveCount(t *testing.T) {
@@ -196,11 +198,19 @@ func TestValidateWorkspace_RejectsSymlinkResolveError(t *testing.T) {
 	}
 }
 
+func requireSecretDirs(t *testing.T) {
+	t.Helper()
+	if len(secretDirs()) == 0 {
+		t.Skip("no secret dirs exist (CI env without ~/.ssh, ~/.aws, etc.)")
+	}
+}
+
 func TestValidatePolicy_RejectsHomeOverlap(t *testing.T) {
 	home := os.Getenv("HOME")
 	if home == "" {
 		t.Skip("HOME not set")
 	}
+	requireSecretDirs(t)
 	p := DefaultPolicy(t.TempDir())
 	p.AllowReadDirs = append(p.AllowReadDirs, home)
 	if err := ValidatePolicy(p); err == nil {
@@ -213,6 +223,7 @@ func TestValidatePolicy_RejectsParentOfSecret(t *testing.T) {
 	if home == "" {
 		t.Skip("HOME not set")
 	}
+	requireSecretDirs(t)
 	p := DefaultPolicy(t.TempDir())
 	p.AllowReadDirs = append(p.AllowReadDirs, home+"/")
 	if err := ValidatePolicy(p); err == nil {
@@ -225,6 +236,7 @@ func TestValidatePolicy_RejectsWriteOverlap(t *testing.T) {
 	if home == "" {
 		t.Skip("HOME not set")
 	}
+	requireSecretDirs(t)
 	p := DefaultPolicy(t.TempDir())
 	p.AllowRWDirs = append(p.AllowRWDirs, home)
 	if err := ValidatePolicy(p); err == nil {
@@ -272,6 +284,7 @@ func TestValidatePolicy_RejectsSymlinkToHome(t *testing.T) {
 	if home == "" {
 		t.Skip("HOME not set")
 	}
+	requireSecretDirs(t)
 	// Create a symlink that points to HOME. Landlock would resolve this
 	// and grant access to the real home directory.
 	dir := t.TempDir()
@@ -292,6 +305,7 @@ func TestValidatePolicy_RejectsSymlinkToHomeInWrite(t *testing.T) {
 	if home == "" {
 		t.Skip("HOME not set")
 	}
+	requireSecretDirs(t)
 	dir := t.TempDir()
 	link := filepath.Join(dir, "home-link-rw")
 	if err := os.Symlink(home, link); err != nil {
@@ -310,10 +324,13 @@ func TestValidatePolicy_RejectsFileInsideProtectedDir(t *testing.T) {
 	if home == "" {
 		t.Skip("HOME not set")
 	}
+	requireSecretDirs(t)
+	// Use the first existing protected dir for the test.
+	protected := secretDirs()
 	p := DefaultPolicy(t.TempDir())
-	p.AllowReadFiles = append(p.AllowReadFiles, filepath.Join(home, ".ssh", "known_hosts"))
+	p.AllowReadFiles = append(p.AllowReadFiles, filepath.Join(protected[0], "test_file"))
 	if err := ValidatePolicy(p); err == nil {
-		t.Error("expected error for file inside protected .ssh directory")
+		t.Errorf("expected error for file inside protected directory %s", protected[0])
 	}
 }
 

--- a/internal/sandbox/seccomp_linux.go
+++ b/internal/sandbox/seccomp_linux.go
@@ -82,10 +82,15 @@ func SetNoNewPrivs() error {
 func buildSeccompFilter(strict bool) []unix.SockFilter {
 	allow := allowedSyscalls()
 	kill := killSyscalls()
+	deny := denySyscalls()
 
 	killSet := make(map[uint32]bool, len(kill))
 	for _, nr := range kill {
 		killSet[nr] = true
+	}
+	denySet := make(map[uint32]bool, len(deny))
+	for _, nr := range deny {
+		denySet[nr] = true
 	}
 
 	// Syscalls handled by argument-level conditional blocks (not the flat allowlist).
@@ -112,6 +117,14 @@ func buildSeccompFilter(strict bool) []unix.SockFilter {
 		prog = append(prog, bpfRet(unix.SECCOMP_RET_KILL_PROCESS))
 	}
 
+	// Step 3b: Deny-on-match (EPERM, not KILL). For syscalls that are
+	// dangerous but where KILL would crash runtimes that probe and
+	// gracefully fall back (e.g. Node.js probes io_uring at startup).
+	for _, nr := range deny {
+		prog = append(prog, bpfJumpEq(nr, 0, 1))
+		prog = append(prog, bpfRet(unix.SECCOMP_RET_ERRNO|uint32(unix.EPERM)))
+	}
+
 	// Step 4: Conditional argument filtering.
 	// Each block is self-contained: if the syscall matches, it inspects args
 	// and returns ALLOW or EPERM. If the syscall doesn't match, it skips
@@ -127,7 +140,7 @@ func buildSeccompFilter(strict bool) []unix.SockFilter {
 
 	// Step 5: Allow-on-match for safe syscalls (flat allowlist).
 	for _, nr := range allow {
-		if killSet[nr] || conditionalSet[nr] {
+		if killSet[nr] || denySet[nr] || conditionalSet[nr] {
 			continue // already handled above
 		}
 		prog = append(prog, bpfJumpEq(nr, 0, 1))
@@ -268,7 +281,7 @@ func allowedSyscalls() []uint32 {
 		unix.SYS_PREADV2, unix.SYS_PWRITEV2,
 		unix.SYS_FSTAT, unix.SYS_NEWFSTATAT, unix.SYS_STATX,
 		unix.SYS_FSTATFS, unix.SYS_STATFS,
-		unix.SYS_READLINKAT, unix.SYS_FACCESSAT, unix.SYS_FACCESSAT2,
+		unix.SYS_READLINK, unix.SYS_READLINKAT, unix.SYS_FACCESSAT, unix.SYS_FACCESSAT2,
 		unix.SYS_FTRUNCATE, unix.SYS_TRUNCATE, unix.SYS_FALLOCATE,
 		unix.SYS_FADVISE64, unix.SYS_FCNTL, unix.SYS_FLOCK,
 		unix.SYS_IOCTL, unix.SYS_DUP, unix.SYS_DUP2, unix.SYS_DUP3,
@@ -368,10 +381,19 @@ func killSyscalls() []uint32 {
 		unix.SYS_KEXEC_LOAD, unix.SYS_KEXEC_FILE_LOAD,
 		unix.SYS_INIT_MODULE, unix.SYS_FINIT_MODULE, unix.SYS_DELETE_MODULE,
 
-		// io_uring (bypasses seccomp entirely — 60% of Google's 2022 kernel bugs)
-		unix.SYS_IO_URING_SETUP, unix.SYS_IO_URING_ENTER, unix.SYS_IO_URING_REGISTER,
-
 		// Reboot
 		unix.SYS_REBOOT,
+	}
+}
+
+// denySyscalls returns syscall numbers that return EPERM (not KILL).
+// These are dangerous but the process should be able to recover from
+// EPERM and fall back to alternatives. KILL would crash runtimes like
+// Node.js 22 that probe io_uring at startup and expect ENOSYS/EPERM.
+func denySyscalls() []uint32 {
+	return []uint32{
+		// io_uring (bypasses seccomp — 60% of Google's 2022 kernel bugs)
+		// Returns EPERM instead of KILL so runtimes can fall back to epoll.
+		unix.SYS_IO_URING_SETUP, unix.SYS_IO_URING_ENTER, unix.SYS_IO_URING_REGISTER,
 	}
 }

--- a/internal/sandbox/seccomp_test.go
+++ b/internal/sandbox/seccomp_test.go
@@ -405,14 +405,33 @@ func TestKillSyscalls_ContainsCritical(t *testing.T) {
 
 	// These MUST be in the kill list.
 	critical := map[string]uint32{
-		"io_uring_setup": unix.SYS_IO_URING_SETUP,
-		"kexec_load":     unix.SYS_KEXEC_LOAD,
-		"init_module":    unix.SYS_INIT_MODULE,
-		"reboot":         unix.SYS_REBOOT,
+		"kexec_load":  unix.SYS_KEXEC_LOAD,
+		"init_module": unix.SYS_INIT_MODULE,
+		"reboot":      unix.SYS_REBOOT,
 	}
 	for name, nr := range critical {
 		if !set[nr] {
 			t.Errorf("missing critical kill syscall: %s (%d)", name, nr)
+		}
+	}
+}
+
+func TestDenySyscalls_ContainsIOUring(t *testing.T) {
+	deny := denySyscalls()
+	set := make(map[uint32]bool, len(deny))
+	for _, nr := range deny {
+		set[nr] = true
+	}
+
+	// io_uring returns EPERM (not KILL) so runtimes like Node.js can fall back to epoll.
+	iouring := map[string]uint32{
+		"io_uring_setup":    unix.SYS_IO_URING_SETUP,
+		"io_uring_enter":    unix.SYS_IO_URING_ENTER,
+		"io_uring_register": unix.SYS_IO_URING_REGISTER,
+	}
+	for name, nr := range iouring {
+		if !set[nr] {
+			t.Errorf("missing deny syscall: %s (%d)", name, nr)
 		}
 	}
 }

--- a/internal/sandbox/standalone.go
+++ b/internal/sandbox/standalone.go
@@ -4,10 +4,7 @@
 package sandbox
 
 import (
-	"context"
-	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 )
 
@@ -21,19 +18,11 @@ func IsStandaloneInitMode() bool {
 	return os.Getenv(standaloneInitEnv) == "1"
 }
 
-// bringUpLoopback runs `ip link set lo up` inside the current namespace.
+// bringUpLoopback brings up the loopback interface inside a new network
+// namespace using raw netlink syscalls. No external tools required — works
+// in minimal containers without iproute2.
 func bringUpLoopback() error {
-	// Use absolute path because synthetic env PATH may not include /usr/sbin
-	// (where ip lives on Fedora/RHEL). Fall back to PATH lookup.
-	ipBin := "/usr/sbin/ip"
-	if _, err := os.Stat(ipBin); err != nil {
-		ipBin = "ip" // fall back to PATH lookup
-	}
-	cmd := exec.CommandContext(context.Background(), ipBin, "link", "set", "lo", "up") //nolint:gosec // G204: fixed command
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("ip link set lo up: %w (%s)", err, string(out))
-	}
-	return nil
+	return loopbackUp()
 }
 
 // ProxySocketPath returns the Unix socket path for the parent's proxy,

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -37,6 +37,12 @@ type StandaloneLaunchConfig struct {
 	// private /dev/shm mount, clone3 blocked, subreaper enabled.
 	Strict bool
 
+	// BestEffort skips namespace isolation when unavailable (e.g. inside
+	// containers where CLONE_NEWUSER is blocked by seccomp). Landlock and
+	// seccomp are still applied. Network scanning uses proxy-based routing
+	// instead of kernel-enforced isolation. Mutually exclusive with Strict.
+	BestEffort bool
+
 	// ExtraEnv contains additional KEY=VALUE pairs to pass to the child.
 	ExtraEnv []string
 
@@ -58,9 +64,13 @@ type StandaloneLaunchConfig struct {
 //  5. Child runs agent command with HTTP_PROXY pointing to bridge
 //  6. Agent traffic: loopback → bridge → Unix socket → parent proxy → scanner → internet
 //
+// When BestEffort is true and namespaces are unavailable, step 2 skips
+// namespace creation. Network scanning still works via HTTP_PROXY routing
+// but is not kernel-enforced (cooperative, not mandatory).
+//
 // Returns when the agent command exits.
 func LaunchStandalone(cfg StandaloneLaunchConfig) error {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != osLinux {
 		return fmt.Errorf("%w: sandbox requires Linux", ErrUnavailable)
 	}
 
@@ -75,6 +85,20 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	}
 	if err := ValidatePolicy(policy); err != nil {
 		return err
+	}
+
+	// Strict and BestEffort are mutually exclusive — catch misuse by callers.
+	if cfg.Strict && cfg.BestEffort {
+		return fmt.Errorf("sandbox: strict and best_effort are mutually exclusive")
+	}
+
+	// Probe namespace support before forking.
+	// Only CLONE_NEWUSER is probed because CLONE_NEWNET requires CLONE_NEWUSER
+	// on unprivileged processes — if user namespaces work, network namespaces
+	// will too (created inside the user namespace with CAP_SYS_ADMIN).
+	hasNamespaces := probeUserNamespace()
+	if !hasNamespaces && !cfg.BestEffort {
+		return fmt.Errorf("%w: user namespaces unavailable (blocked by seccomp or sysctl? use --best-effort for degraded mode)", ErrUnavailable)
 	}
 
 	ctx := cfg.Ctx
@@ -156,22 +180,31 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 		cmd.Env = append(cmd.Env, "__PIPELOCK_SANDBOX_POLICY="+policyJSON)
 	}
 
-	cloneFlags := uintptr(syscall.CLONE_NEWUSER | syscall.CLONE_NEWNET)
-	if cfg.Strict {
-		cloneFlags |= syscall.CLONE_NEWNS // mount namespace for private /dev/shm
-	}
-	uid := os.Getuid()
-	gid := os.Getgid()
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Cloneflags: cloneFlags,
-		UidMappings: []syscall.SysProcIDMap{
-			{ContainerID: 0, HostID: uid, Size: 1},
-		},
-		GidMappings: []syscall.SysProcIDMap{
-			{ContainerID: 0, HostID: gid, Size: 1},
-		},
-		Pdeathsig: syscall.SIGTERM,
-		Setpgid:   true,
+	if hasNamespaces {
+		cloneFlags := uintptr(syscall.CLONE_NEWUSER | syscall.CLONE_NEWNET)
+		if cfg.Strict {
+			cloneFlags |= syscall.CLONE_NEWNS // mount namespace for private /dev/shm
+		}
+		uid := os.Getuid()
+		gid := os.Getgid()
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Cloneflags: cloneFlags,
+			UidMappings: []syscall.SysProcIDMap{
+				{ContainerID: 0, HostID: uid, Size: 1},
+			},
+			GidMappings: []syscall.SysProcIDMap{
+				{ContainerID: 0, HostID: gid, Size: 1},
+			},
+			Pdeathsig: syscall.SIGTERM,
+			Setpgid:   true,
+		}
+	} else {
+		// Best-effort: no namespace isolation. Tell child to skip loopback setup.
+		cmd.Env = append(cmd.Env, noNetNSEnvKey+"=1")
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Pdeathsig: syscall.SIGTERM,
+			Setpgid:   true,
+		}
 	}
 
 	// Strict mode: become subreaper so orphaned grandchildren are

--- a/scripts/pr-review.py
+++ b/scripts/pr-review.py
@@ -15,8 +15,8 @@ LLM configuration (one of):
   OPENAI_API_KEY                       - Direct OpenAI API
 
 Model selection:
-  PR_REVIEW_MODEL_FAST  - Model for /review and /review fast (default: gpt-4.1-mini)
-  PR_REVIEW_MODEL_DEEP  - Model for /review deep (default: gpt-4.1)
+  PR_REVIEW_MODEL_FAST  - Model for /review and /review fast (default: gpt-5.4-mini)
+  PR_REVIEW_MODEL_DEEP  - Model for /review deep (default: gpt-5.4)
 """
 
 import json
@@ -112,7 +112,8 @@ def call_llm(diff: str, mode: str) -> str:
             },
         ],
         "temperature": 0.2,
-        "max_tokens": 4096,
+        # gpt-5.x and o-series require max_completion_tokens, not max_tokens.
+        "max_completion_tokens": 4096,
     }
 
     resp = requests.post(api_url, headers=headers, json=payload, timeout=120)


### PR DESCRIPTION
## Summary

- **`--best-effort` flag** on `pipelock sandbox` and `pipelock mcp proxy --sandbox-best-effort`: gracefully degrades when user namespace creation is blocked (k8s containers with default seccomp). Landlock and seccomp still apply.
- **`--env` flag** on `pipelock sandbox`: pass environment variables to sandboxed processes with dangerous-key validation.
- **Pure Go netlink loopback**: no `ip` binary dependency. Works in minimal container images.
- **Seccomp fixes**: io_uring returns EPERM (not KILL) for Node.js 22 compatibility. Added `SYS_READLINK` to allowlist.
- **Container compatibility**: `secretDirs()` checks path existence. Dynamic bridge proxy port avoids sidecar conflicts.
- **Config**: `sandbox.best_effort` field with hot-reload detection, enterprise per-agent merge, mutual exclusion with `strict`.
- **Docs**: updated sandbox section in configuration.md with deployment environments table.

## Test plan

Verified on k8s cluster:
- `pipelock sandbox -- echo test` with 3/3 layers on bare metal
- `pipelock sandbox --best-effort -- echo test` with 2/3 in containers
- `node --version` runs successfully inside full sandbox
- All in-repo tests pass with race detector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --best-effort sandbox mode, repeatable --env with validation, and MCP --sandbox-best-effort flag; pure-Go loopback bring-up replaces external ip usage.

* **Bug Fixes**
  * io_uring now degrades to EPERM instead of killing processes; seccomp allowlist includes legacy readlink; secret-dir checks ignore non-existent paths; best-effort proxy uses dynamic ports.

* **Validation**
  * Hot-reload detects best_effort changes; config validation enforces mutual exclusivity between best_effort and strict; dangerous env keys are rejected.

* **Documentation**
  * README and sandbox docs updated with examples and platform-agnostic sandbox guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->