### PR TITLE
feat: MCP binary integrity and denial-of-wallet detection

### DIFF
--- a/internal/mcp/integrity/integrity.go
+++ b/internal/mcp/integrity/integrity.go
@@ -5,7 +5,13 @@
 // subprocess servers. It resolves symlinks and interpreter shebangs,
 // hashes the actual binary (and script when an interpreter is detected),
 // and compares against a trusted manifest. A second symlink resolution at
-// exec time detects TOCTOU races.
+// exec time detects symlink swaps between hash-time and exec-time.
+//
+// NOTE: CheckSymlinkRace detects symlink target changes (path identity)
+// but does NOT detect in-place content replacement after hashing. Full
+// TOCTOU prevention would require fexecve-style fd binding, which Go's
+// os/exec does not support. The gap is documented here and in
+// CheckSymlinkRace so operators understand the threat model.
 package integrity
 
 import (
@@ -34,6 +40,13 @@ var interpreters = map[string]bool{
 	"node": true, "bun": true, "deno": true,
 	"ruby": true, "perl": true,
 	"bash": true, "sh": true, "dash": true,
+}
+
+// packageRunners are tools that dynamically resolve executables at runtime.
+// argv[1] is a package name, not a script path, so integrity verification
+// of command[1] as a file is not meaningful. These are intentionally
+// excluded from the interpreters map.
+var packageRunners = map[string]bool{
 	"npx": true, "bunx": true, "uvx": true, "pipx": true,
 }
 
@@ -47,13 +60,18 @@ var interpreterPrefixes = []string{
 // isInterpreterName checks whether baseName is a known interpreter. It first
 // tries an exact match in the interpreters map (fast path), then falls back to
 // prefix matching for versioned names like "python3.11" or "node20".
+// The suffix after the prefix must start with a digit or dot to avoid
+// false positives on unrelated binaries (e.g. "shred", "node_exporter").
 func isInterpreterName(baseName string) bool {
 	if interpreters[baseName] {
 		return true
 	}
 	for _, prefix := range interpreterPrefixes {
 		if strings.HasPrefix(baseName, prefix) && len(baseName) > len(prefix) {
-			return true
+			suffix := baseName[len(prefix)]
+			if suffix == '.' || (suffix >= '0' && suffix <= '9') {
+				return true
+			}
 		}
 	}
 	return false
@@ -75,15 +93,19 @@ type Manifest struct {
 
 // VerifyResult is the outcome of a pre-spawn integrity check.
 type VerifyResult struct {
-	Verified      bool   // true when all hashes match the manifest
-	ResolvedPath  string // binary path after EvalSymlinks + LookPath
-	ExpectedHash  string // from manifest (empty if binary is unknown)
-	ActualHash    string // computed from file contents
-	IsInterpreter bool   // true if command[0] is a known interpreter
-	ScriptPath    string // script path when IsInterpreter is true
-	ScriptHash    string // hash of the script when IsInterpreter is true
-	Suspicious    bool   // true if binary is inside agent working directory
-	Reason        string // human-readable explanation when Verified is false
+	Verified           bool     // true when all hashes match the manifest
+	ResolvedPath       string   // binary path after EvalSymlinks + LookPath
+	InterpreterPath    string   // interpreter binary path when env/shebang rewrites ResolvedPath
+	ExpectedHash       string   // from manifest (empty if binary is unknown)
+	ActualHash         string   // computed from file contents
+	IsInterpreter      bool     // true if command[0] is a known interpreter
+	IsPackageRunner    bool     // true if command[0] is a package runner (npx, bunx, etc.)
+	ScriptPath         string   // script path when IsInterpreter is true
+	ScriptHash         string   // hash of the script when IsInterpreter is true
+	ExpectedScriptHash string   // from manifest (empty if script is unknown)
+	Suspicious         bool     // true if binary is inside agent working directory
+	Reason             string   // last/primary reason when Verified is false (backward compat)
+	Reasons            []string // all accumulated failure reasons for audit evidence
 }
 
 // LoadManifest reads a binary integrity manifest from disk.
@@ -109,6 +131,8 @@ func LoadManifest(path string) (*Manifest, error) {
 }
 
 // SaveManifest writes a manifest to disk with restrictive permissions.
+// Uses atomic write (temp file + rename) to ensure the file always has
+// correct permissions, even if it already exists with looser perms.
 func SaveManifest(path string, m *Manifest) error {
 	data, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
@@ -117,7 +141,42 @@ func SaveManifest(path string, m *Manifest) error {
 
 	data = append(data, '\n')
 
-	return os.WriteFile(filepath.Clean(path), data, 0o600)
+	cleanPath := filepath.Clean(path)
+	dir := filepath.Dir(cleanPath)
+
+	tmp, err := os.CreateTemp(dir, ".manifest-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	// Clean up temp file on any error path.
+	success := false
+	defer func() {
+		if !success {
+			_ = tmp.Close()
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		return fmt.Errorf("setting temp file permissions: %w", err)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpName, cleanPath); err != nil {
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+
+	success = true
+	return nil
 }
 
 // Verify resolves the command binary path, hashes the file, and checks
@@ -145,7 +204,8 @@ func Verify(command []string, cfg *Config, agentWorkDir string) (*VerifyResult, 
 		result.Suspicious = isInsideDir(resolved, agentWorkDir)
 	}
 
-	// Hash the binary via fd (TOCTOU mitigation: open first, hash contents).
+	// Hash the binary via fd (mitigates read-after-open races but not
+	// in-place replacement after close; see package doc for limitations).
 	actualHash, err := hashFileByFD(resolved)
 	if err != nil {
 		return nil, fmt.Errorf("hashing binary %q: %w", resolved, err)
@@ -156,36 +216,48 @@ func Verify(command []string, cfg *Config, agentWorkDir string) (*VerifyResult, 
 	// Check both the resolved name and the original command name because
 	// symlinks can change the basename (e.g. "sh" -> "/usr/bin/dash").
 	baseName := filepath.Base(resolved)
-	result.IsInterpreter = isInterpreterName(baseName) || isInterpreterName(filepath.Base(command[0]))
+	cmdBase := filepath.Base(command[0])
+	result.IsInterpreter = isInterpreterName(baseName) || isInterpreterName(cmdBase)
 
-	// Handle /usr/bin/env wrapper: if command[0] resolves to "env", the real
-	// interpreter is command[1] and the script is command[2].
+	// Check for package runners (npx, bunx, etc.) -- these resolve executables
+	// dynamically so argv[1] is not a hashable script path.
+	if packageRunners[baseName] || packageRunners[cmdBase] {
+		result.IsPackageRunner = true
+		result.IsInterpreter = false
+	}
+
+	// Handle /usr/bin/env wrapper: if command[0] resolves to "env", skip env
+	// flags (e.g. -S, -i, -u VAR, --) to find the real interpreter and script.
 	if !result.IsInterpreter && baseName == "env" && len(command) > 1 {
-		envInterp := command[1]
-		envInterpResolved, envErr := resolveBinary(envInterp)
-		if envErr != nil {
-			return nil, fmt.Errorf("resolving env interpreter %q: %w", envInterp, envErr)
-		}
-		envInterpHash, envHashErr := hashFileByFD(envInterpResolved)
-		if envHashErr != nil {
-			return nil, fmt.Errorf("hashing env interpreter %q: %w", envInterpResolved, envHashErr)
-		}
-		result.IsInterpreter = true
-		result.ResolvedPath = envInterpResolved
-		result.ActualHash = envInterpHash
-
-		// Hash the script argument (command[2]) if present.
-		if len(command) > 2 {
-			scriptPath, scriptHash, shebangErr := hashScript(command[2])
-			if shebangErr != nil {
-				return nil, fmt.Errorf("hashing script %q: %w", command[2], shebangErr)
+		remaining := skipEnvFlags(command[1:])
+		if len(remaining) > 0 {
+			envInterp := remaining[0]
+			envInterpResolved, envErr := resolveBinary(envInterp)
+			if envErr != nil {
+				return nil, fmt.Errorf("resolving env interpreter %q: %w", envInterp, envErr)
 			}
-			result.ScriptPath = scriptPath
-			result.ScriptHash = scriptHash
+			envInterpHash, envHashErr := hashFileByFD(envInterpResolved)
+			if envHashErr != nil {
+				return nil, fmt.Errorf("hashing env interpreter %q: %w", envInterpResolved, envHashErr)
+			}
+			result.IsInterpreter = true
+			result.InterpreterPath = envInterpResolved
+			result.ResolvedPath = envInterpResolved
+			result.ActualHash = envInterpHash
+
+			// Hash the script argument (first arg after interpreter) if present.
+			if len(remaining) > 1 {
+				scriptPath, scriptHash, shebangErr := hashScript(remaining[1], agentWorkDir)
+				if shebangErr != nil {
+					return nil, fmt.Errorf("hashing script %q: %w", remaining[1], shebangErr)
+				}
+				result.ScriptPath = scriptPath
+				result.ScriptHash = scriptHash
+			}
 		}
 	} else if result.IsInterpreter && len(command) > 1 {
 		// Standard interpreter invocation: hash the script argument.
-		scriptPath, scriptHash, shebangErr := hashScript(command[1])
+		scriptPath, scriptHash, shebangErr := hashScript(command[1], agentWorkDir)
 		if shebangErr != nil {
 			return nil, fmt.Errorf("hashing script %q: %w", command[1], shebangErr)
 		}
@@ -210,42 +282,57 @@ func Verify(command []string, cfg *Config, agentWorkDir string) (*VerifyResult, 
 			if interpHashErr != nil {
 				return nil, fmt.Errorf("hashing shebang interpreter %q: %w", interpResolved, interpHashErr)
 			}
+			result.InterpreterPath = interpResolved
 			result.ResolvedPath = interpResolved
 			result.ActualHash = interpHash
 		}
 	}
 
-	// Verify against manifest.
+	// Verify against manifest. Fail-closed: no manifest = not verified.
+	if cfg.Manifests == nil {
+		result.Verified = false
+		result.Reason = "no manifest loaded"
+		result.Reasons = append(result.Reasons, "no manifest loaded")
+		return result, nil
+	}
+
 	result.Verified = true
-	if cfg.Manifests != nil {
+	{
 		expected, inManifest := cfg.Manifests[result.ResolvedPath]
 		if inManifest {
 			result.ExpectedHash = expected
 			if result.ActualHash != expected {
 				result.Verified = false
-				result.Reason = fmt.Sprintf("binary hash mismatch for %s: expected %s, got %s",
+				reason := fmt.Sprintf("binary hash mismatch for %s: expected %s, got %s",
 					result.ResolvedPath, expected, result.ActualHash)
+				result.Reason = reason
+				result.Reasons = append(result.Reasons, reason)
 			}
 		} else {
 			// Binary not in manifest -- fail-closed: unknown binary is not verified.
 			result.Verified = false
-			result.Reason = fmt.Sprintf("binary %s not found in manifest", result.ResolvedPath)
+			reason := fmt.Sprintf("binary %s not found in manifest", result.ResolvedPath)
+			result.Reason = reason
+			result.Reasons = append(result.Reasons, reason)
 		}
 
 		// Also verify script hash if present.
 		if result.IsInterpreter && result.ScriptPath != "" {
 			expectedScript, scriptInManifest := cfg.Manifests[result.ScriptPath]
 			if scriptInManifest {
+				result.ExpectedScriptHash = expectedScript
 				if result.ScriptHash != expectedScript {
 					result.Verified = false
-					result.Reason = fmt.Sprintf("script hash mismatch for %s: expected %s, got %s",
+					reason := fmt.Sprintf("script hash mismatch for %s: expected %s, got %s",
 						result.ScriptPath, expectedScript, result.ScriptHash)
+					result.Reason = reason
+					result.Reasons = append(result.Reasons, reason)
 				}
 			} else {
 				result.Verified = false
-				if result.Reason == "" {
-					result.Reason = fmt.Sprintf("script %s not found in manifest", result.ScriptPath)
-				}
+				reason := fmt.Sprintf("script %s not found in manifest", result.ScriptPath)
+				result.Reason = reason
+				result.Reasons = append(result.Reasons, reason)
 			}
 		}
 	}
@@ -271,7 +358,13 @@ func ResolveAndHash(binary string) (resolvedPath, hash string, err error) {
 
 // CheckSymlinkRace compares the current symlink resolution against the
 // path resolved at hash time. Returns an error if they differ, indicating
-// a potential TOCTOU race (symlink was swapped between hash and exec).
+// a symlink swap between hash-time and exec-time.
+//
+// NOTE: This checks path identity (symlink target stability), not content
+// identity. A file whose contents are replaced in-place after hashing
+// will not be detected by this check. Full TOCTOU prevention would
+// require opening the file by fd and using fexecve, which Go's os/exec
+// does not expose. This is a known limitation of the threat model.
 func CheckSymlinkRace(originalCommand string, expectedResolved string) error {
 	current, err := resolveBinary(originalCommand)
 	if err != nil {
@@ -312,8 +405,10 @@ func resolveBinary(name string) (string, error) {
 	return resolved, nil
 }
 
-// hashFileByFD opens the file, hashes the fd contents (TOCTOU mitigation),
-// and returns the hex-encoded SHA-256 digest.
+// hashFileByFD opens the file and hashes the fd contents, returning the
+// hex-encoded SHA-256 digest. Hashing via the open fd avoids re-reading
+// after resolution, but does not prevent in-place replacement after the
+// fd is closed (see package doc for TOCTOU limitations).
 func hashFileByFD(path string) (string, error) {
 	f, err := os.Open(filepath.Clean(path))
 	if err != nil {
@@ -330,14 +425,22 @@ func hashFileByFD(path string) (string, error) {
 }
 
 // hashScript resolves and hashes a script file. Returns the resolved path
-// and SHA-256 hash.
-func hashScript(scriptArg string) (string, string, error) {
-	resolved, err := filepath.Abs(scriptArg)
-	if err != nil {
-		return "", "", fmt.Errorf("absolute path: %w", err)
+// and SHA-256 hash. When workDir is non-empty and scriptArg is relative,
+// the script is resolved relative to workDir (the subprocess cwd) rather
+// than the proxy process cwd, avoiding path resolution mismatch.
+func hashScript(scriptArg, workDir string) (string, string, error) {
+	var resolved string
+	if !filepath.IsAbs(scriptArg) && workDir != "" {
+		resolved = filepath.Join(workDir, scriptArg)
+	} else {
+		abs, err := filepath.Abs(scriptArg)
+		if err != nil {
+			return "", "", fmt.Errorf("absolute path: %w", err)
+		}
+		resolved = abs
 	}
 
-	resolved, err = filepath.EvalSymlinks(resolved)
+	resolved, err := filepath.EvalSymlinks(resolved)
 	if err != nil {
 		return "", "", fmt.Errorf("EvalSymlinks: %w", err)
 	}
@@ -352,6 +455,8 @@ func hashScript(scriptArg string) (string, string, error) {
 
 // detectShebang reads the first line of a file and returns the interpreter
 // path if it starts with "#!". Returns empty string if no shebang is found.
+// Reads at most maxShebangLen bytes; a shebang line exceeding that limit
+// is treated as "no shebang" (safe default).
 func detectShebang(path string) string {
 	f, err := os.Open(filepath.Clean(path))
 	if err != nil {
@@ -359,9 +464,18 @@ func detectShebang(path string) string {
 	}
 	defer func() { _ = f.Close() }()
 
-	reader := bufio.NewReaderSize(f, maxShebangLen)
+	// Limit reads to maxShebangLen to prevent unbounded reads when no
+	// newline exists in the file (e.g. a binary).
+	limited := io.LimitReader(f, maxShebangLen)
+	reader := bufio.NewReaderSize(limited, maxShebangLen)
 	line, err := reader.ReadString('\n')
 	if err != nil && len(line) == 0 {
+		return ""
+	}
+
+	// If we read maxShebangLen bytes without finding a newline, the line
+	// is too long to be a valid shebang. Treat as "no shebang".
+	if err != nil && len(line) >= maxShebangLen {
 		return ""
 	}
 
@@ -373,17 +487,67 @@ func detectShebang(path string) string {
 	shebang := strings.TrimPrefix(line, "#!")
 	shebang = strings.TrimSpace(shebang)
 
-	// Handle "#!/usr/bin/env python3" -> return "python3"
+	// Handle "#!/usr/bin/env python3" and "#!/usr/bin/env -S python3".
 	parts := strings.Fields(shebang)
 	if len(parts) == 0 {
 		return ""
 	}
 
 	if filepath.Base(parts[0]) == "env" && len(parts) > 1 {
-		return parts[1]
+		remaining := skipEnvFlags(parts[1:])
+		if len(remaining) > 0 {
+			return remaining[0]
+		}
+		return "" // no interpreter found after env flags (fail-closed)
 	}
 
 	return parts[0]
+}
+
+// skipEnvFlags skips known /usr/bin/env flags and options, returning the
+// remaining args starting from the actual interpreter name. Returns nil if
+// no interpreter is found after exhausting all arguments. Fail-closed: if
+// the args are ambiguous or unrecognized, returns nil (caller treats as
+// "no interpreter found").
+//
+// Known flag patterns:
+//   - -i, -0: standalone flags (no value)
+//   - -u NAME: flag that consumes the next token as its value
+//   - -S CMD: flag where the next token is the interpreter
+//   - --: end of options, next token is interpreter
+func skipEnvFlags(args []string) []string {
+	for len(args) > 0 {
+		switch args[0] {
+		case "--":
+			// End of options; interpreter follows (or empty = fail-closed).
+			args = args[1:]
+			if len(args) == 0 {
+				return nil
+			}
+			return args
+		case "-S":
+			// -S means the next token is the command (interpreter).
+			args = args[1:]
+			if len(args) == 0 {
+				return nil
+			}
+			return args
+		case "-u":
+			// -u takes a value (VAR name to unset); skip flag and value.
+			args = args[1:]
+			if len(args) == 0 {
+				return nil
+			}
+			args = args[1:]
+		case "-i", "-0":
+			// Standalone flags; continue to next.
+			args = args[1:]
+		default:
+			// Not a recognized flag -- this is the interpreter.
+			return args
+		}
+	}
+	return nil
 }
 
 // isInsideDir checks if path is inside or equal to dir, after resolving

--- a/internal/mcp/integrity/integrity_test.go
+++ b/internal/mcp/integrity/integrity_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -20,6 +21,7 @@ const (
 	testAction       = "block"
 	testActionWarn   = "warn"
 	osWindows        = "windows"
+	interpPython3    = "python3"
 )
 
 // hashOfString is a test helper that writes content to a temp file and returns
@@ -272,8 +274,8 @@ func TestDetectShebang_EnvPython(t *testing.T) {
 	}
 
 	interp := detectShebang(script)
-	if interp != "python3" {
-		t.Errorf("interpreter = %q, want %q", interp, "python3")
+	if interp != interpPython3 {
+		t.Errorf("interpreter = %q, want %q", interp, interpPython3)
 	}
 }
 
@@ -307,6 +309,24 @@ func TestDetectShebang_NonexistentFile(t *testing.T) {
 	interp := detectShebang("/nonexistent/file")
 	if interp != "" {
 		t.Errorf("interpreter = %q, want empty for missing file", interp)
+	}
+}
+
+func TestDetectShebang_OverlongLine(t *testing.T) {
+	// A shebang line exceeding maxShebangLen with no newline should be
+	// treated as "no shebang" (safe default per Finding 2).
+	dir := t.TempDir()
+	script := filepath.Join(dir, "overlong")
+
+	// Build a shebang line longer than maxShebangLen with no newline.
+	content := "#!" + strings.Repeat("x", maxShebangLen+100)
+	if err := os.WriteFile(script, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+
+	interp := detectShebang(script)
+	if interp != "" {
+		t.Errorf("interpreter = %q, want empty for overlong shebang", interp)
 	}
 }
 
@@ -458,7 +478,7 @@ func TestVerify_NilManifest(t *testing.T) {
 		t.Fatalf("writing: %v", err)
 	}
 
-	// No manifest configured: verification is vacuously true.
+	// No manifest configured: fail-closed, not verified.
 	cfg := &Config{
 		Enabled:   true,
 		Action:    testAction,
@@ -470,8 +490,11 @@ func TestVerify_NilManifest(t *testing.T) {
 		t.Fatalf("Verify: %v", err)
 	}
 
-	if !result.Verified {
-		t.Errorf("expected Verified=true when no manifest, got reason: %s", result.Reason)
+	if result.Verified {
+		t.Error("expected Verified=false when no manifest (fail-closed)")
+	}
+	if !contains(result.Reason, "no manifest loaded") {
+		t.Errorf("Reason = %q, want 'no manifest loaded'", result.Reason)
 	}
 }
 
@@ -630,10 +653,11 @@ func TestVerify_SuspiciousCWD(t *testing.T) {
 		t.Fatalf("writing: %v", err)
 	}
 
+	hash := hashOfString(t, testPlainBinary)
 	cfg := &Config{
 		Enabled:   true,
 		Action:    testAction,
-		Manifests: nil, // no manifest, so verification is vacuously true
+		Manifests: map[string]string{bin: hash},
 	}
 
 	// Agent working dir = same dir as binary.
@@ -655,7 +679,8 @@ func TestVerify_SuspiciousCWD_Outside(t *testing.T) {
 		t.Fatalf("writing: %v", err)
 	}
 
-	cfg := &Config{Enabled: true, Action: testAction, Manifests: nil}
+	hash := hashOfString(t, testPlainBinary)
+	cfg := &Config{Enabled: true, Action: testAction, Manifests: map[string]string{bin: hash}}
 
 	result, err := Verify([]string{bin}, cfg, agentDir)
 	if err != nil {
@@ -850,7 +875,7 @@ func TestResolveBinary_Nonexistent(t *testing.T) {
 	if !errors.Is(err, exec.ErrNotFound) {
 		// On some systems, LookPath returns a different error. That's fine.
 		if !contains(err.Error(), "LookPath") && !contains(err.Error(), "not found") {
-			t.Logf("unexpected error type (still a failure): %v", err)
+			t.Errorf("unexpected error type: %v", err)
 		}
 	}
 }
@@ -887,12 +912,22 @@ func TestResolveBinary_SymlinkChain(t *testing.T) {
 func TestInterpreterMap(t *testing.T) {
 	expected := []string{
 		"python", "python3", "node", "bun", "deno",
-		"ruby", "perl", "bash", "sh",
-		"npx", "bunx", "uvx", "pipx",
+		"ruby", "perl", "bash", "sh", "dash",
 	}
 	for _, name := range expected {
 		if !interpreters[name] {
 			t.Errorf("interpreter %q should be in map", name)
+		}
+	}
+
+	// Package runners should NOT be in the interpreters map.
+	runners := []string{"npx", "bunx", "uvx", "pipx"}
+	for _, name := range runners {
+		if interpreters[name] {
+			t.Errorf("package runner %q should not be in interpreters map", name)
+		}
+		if !packageRunners[name] {
+			t.Errorf("package runner %q should be in packageRunners map", name)
 		}
 	}
 
@@ -917,8 +952,8 @@ func TestVerify_ShebangEnvInterpreter(t *testing.T) {
 
 	// Verify detectShebang finds "python3" (not "/usr/bin/env").
 	interp := detectShebang(script)
-	if interp != "python3" {
-		t.Errorf("shebang interpreter = %q, want %q", interp, "python3")
+	if interp != interpPython3 {
+		t.Errorf("shebang interpreter = %q, want %q", interp, interpPython3)
 	}
 }
 
@@ -1028,9 +1063,43 @@ func TestVerify_ScriptNotInManifest(t *testing.T) {
 }
 
 func TestHashScript_NonexistentScript(t *testing.T) {
-	_, _, err := hashScript("/nonexistent/script.sh")
+	_, _, err := hashScript("/nonexistent/script.sh", "")
 	if err == nil {
 		t.Fatal("expected error for nonexistent script")
+	}
+}
+
+func TestHashScript_WorkDir(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "myscript.sh")
+	content := "#!/bin/sh\necho workdir\n"
+	if err := os.WriteFile(script, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing script: %v", err)
+	}
+
+	// Relative path with workDir should resolve correctly.
+	resolved, hash, err := hashScript("myscript.sh", dir)
+	if err != nil {
+		t.Fatalf("hashScript with workDir: %v", err)
+	}
+	if resolved != script {
+		t.Errorf("resolved = %q, want %q", resolved, script)
+	}
+	expectedHash := hashOfString(t, content)
+	if hash != expectedHash {
+		t.Errorf("hash = %q, want %q", hash, expectedHash)
+	}
+
+	// Absolute path should ignore workDir.
+	resolved2, hash2, err := hashScript(script, "/some/other/dir")
+	if err != nil {
+		t.Fatalf("hashScript with abs path: %v", err)
+	}
+	if resolved2 != script {
+		t.Errorf("resolved = %q, want %q", resolved2, script)
+	}
+	if hash2 != expectedHash {
+		t.Errorf("hash = %q, want %q", hash2, expectedHash)
 	}
 }
 
@@ -1181,6 +1250,27 @@ func TestIsInterpreterName_NonInterpreter(t *testing.T) {
 	for _, name := range nonInterp {
 		if isInterpreterName(name) {
 			t.Errorf("isInterpreterName(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestIsInterpreterName_PrefixFalsePositives(t *testing.T) {
+	// Binaries that start with interpreter prefixes but are not interpreters.
+	// The suffix must start with a digit or dot to be a versioned interpreter.
+	falsePositives := []string{"shred", "sha256sum", "node_exporter", "python-config", "perldoc", "bunzip2"}
+	for _, name := range falsePositives {
+		if isInterpreterName(name) {
+			t.Errorf("isInterpreterName(%q) = true, want false (not a versioned interpreter)", name)
+		}
+	}
+}
+
+func TestIsInterpreterName_PackageRunners(t *testing.T) {
+	// Package runners should NOT match as interpreters.
+	runners := []string{"npx", "bunx", "uvx", "pipx"}
+	for _, name := range runners {
+		if isInterpreterName(name) {
+			t.Errorf("isInterpreterName(%q) = true, want false (package runner, not interpreter)", name)
 		}
 	}
 }
@@ -1385,6 +1475,173 @@ func TestVerify_Python312_VersionedInterpreter(t *testing.T) {
 	}
 	if result.ScriptHash != scriptHash {
 		t.Errorf("ScriptHash = %q, want %q", result.ScriptHash, scriptHash)
+	}
+}
+
+// --- skipEnvFlags Tests ---
+
+func TestSkipEnvFlags_NoFlags(t *testing.T) {
+	remaining := skipEnvFlags([]string{interpPython3, "script.py"})
+	if len(remaining) != 2 || remaining[0] != interpPython3 {
+		t.Errorf("expected [python3 script.py], got %v", remaining)
+	}
+}
+
+func TestSkipEnvFlags_DashS(t *testing.T) {
+	remaining := skipEnvFlags([]string{"-S", interpPython3, "script.py"})
+	if len(remaining) != 2 || remaining[0] != interpPython3 {
+		t.Errorf("expected [python3 script.py], got %v", remaining)
+	}
+}
+
+func TestSkipEnvFlags_DashI(t *testing.T) {
+	remaining := skipEnvFlags([]string{"-i", interpPython3, "script.py"})
+	if len(remaining) != 2 || remaining[0] != interpPython3 {
+		t.Errorf("expected [python3 script.py], got %v", remaining)
+	}
+}
+
+func TestSkipEnvFlags_DashU(t *testing.T) {
+	remaining := skipEnvFlags([]string{"-u", "HOME", interpPython3})
+	if len(remaining) != 1 || remaining[0] != interpPython3 {
+		t.Errorf("expected [python3], got %v", remaining)
+	}
+}
+
+func TestSkipEnvFlags_DoubleDash(t *testing.T) {
+	remaining := skipEnvFlags([]string{"--", interpPython3, "script.py"})
+	if len(remaining) != 2 || remaining[0] != interpPython3 {
+		t.Errorf("expected [python3 script.py], got %v", remaining)
+	}
+}
+
+func TestSkipEnvFlags_CombinedFlags(t *testing.T) {
+	remaining := skipEnvFlags([]string{"-i", "-u", "HOME", "-S", interpPython3})
+	// -i skipped, -u HOME skipped, -S means next is interpreter
+	if len(remaining) != 1 || remaining[0] != interpPython3 {
+		t.Errorf("expected [python3], got %v", remaining)
+	}
+}
+
+func TestSkipEnvFlags_Empty(t *testing.T) {
+	remaining := skipEnvFlags([]string{})
+	if remaining != nil {
+		t.Errorf("expected nil for empty args, got %v", remaining)
+	}
+}
+
+func TestSkipEnvFlags_OnlyFlags(t *testing.T) {
+	remaining := skipEnvFlags([]string{"-i", "-0"})
+	if remaining != nil {
+		t.Errorf("expected nil when only flags present, got %v", remaining)
+	}
+}
+
+func TestSkipEnvFlags_DashS_NoInterpreter(t *testing.T) {
+	remaining := skipEnvFlags([]string{"-S"})
+	if remaining != nil {
+		t.Errorf("expected nil for -S without interpreter, got %v", remaining)
+	}
+}
+
+func TestSkipEnvFlags_DoubleDash_NoInterpreter(t *testing.T) {
+	remaining := skipEnvFlags([]string{"--"})
+	if remaining != nil {
+		t.Errorf("expected nil for -- without interpreter, got %v", remaining)
+	}
+}
+
+// --- VerifyResult audit evidence tests ---
+
+func TestVerifyResult_ReasonsAccumulate(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("requires Unix")
+	}
+
+	shPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh not in PATH")
+	}
+	resolvedSh, err := filepath.EvalSymlinks(shPath)
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "dual-fail.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho dual"), 0o600); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+
+	// Both binary and script have wrong hashes in manifest.
+	cfg := &Config{
+		Enabled: true,
+		Action:  testAction,
+		Manifests: map[string]string{
+			resolvedSh: "wrong_binary_hash",
+			script:     "wrong_script_hash",
+		},
+	}
+
+	result, err := Verify([]string{"sh", script}, cfg, "")
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	if result.Verified {
+		t.Error("expected Verified=false")
+	}
+	if len(result.Reasons) < 2 {
+		t.Errorf("expected at least 2 Reasons, got %d: %v", len(result.Reasons), result.Reasons)
+	}
+	// Reason should be set to the last reason (backward compat).
+	if result.Reason == "" {
+		t.Error("Reason should be non-empty")
+	}
+}
+
+func TestVerifyResult_ExpectedScriptHash(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("requires Unix")
+	}
+
+	shPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh not in PATH")
+	}
+	resolvedSh, err := filepath.EvalSymlinks(shPath)
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	shHash, err := hashFileByFD(resolvedSh)
+	if err != nil {
+		t.Fatalf("hashing sh: %v", err)
+	}
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "esh.sh")
+	scriptContent := "#!/bin/sh\necho expected\n"
+	if err := os.WriteFile(script, []byte(scriptContent), 0o600); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+	scriptHash := hashOfString(t, scriptContent)
+
+	cfg := &Config{
+		Enabled: true,
+		Action:  testAction,
+		Manifests: map[string]string{
+			resolvedSh: shHash,
+			script:     scriptHash,
+		},
+	}
+
+	result, err := Verify([]string{"sh", script}, cfg, "")
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	if result.ExpectedScriptHash != scriptHash {
+		t.Errorf("ExpectedScriptHash = %q, want %q", result.ExpectedScriptHash, scriptHash)
 	}
 }
 

--- a/internal/proxy/dow.go
+++ b/internal/proxy/dow.go
@@ -30,6 +30,7 @@ type DoWConfig struct {
 	MaxConcurrentToolCalls int    `yaml:"max_concurrent_tool_calls"`
 	MaxWallClockMinutes    int    `yaml:"max_wall_clock_minutes"`
 	MaxRetriesPerTool      int    `yaml:"max_retries_per_tool"`
+	MaxRetriesPerEndpoint  int    `yaml:"max_retries_per_endpoint"` // same domain+path (default 20, 0=unlimited)
 	LoopDetectionWindow    int    `yaml:"loop_detection_window"`
 	FanOutLimit            int    `yaml:"fan_out_limit"`
 	FanOutWindowSeconds    int    `yaml:"fan_out_window_seconds"`
@@ -201,23 +202,27 @@ func (t *DoWTracker) RecordEndpoint(domain, path string, status int) DoWResult {
 // AcquireConcurrent attempts to increment the in-flight counter. Returns
 // a DoWResult indicating success. Call ReleaseConcurrent when the call
 // completes.
+//
+// The closed check and inflight increment are performed under the same
+// mutex hold to prevent a race where Close() runs between checking the
+// flag and incrementing inflight, which would admit a new acquisition
+// after shutdown.
 func (t *DoWTracker) AcquireConcurrent() DoWResult {
-	// Check closed flag under mutex (fail-closed after shutdown).
-	t.mu.Lock()
-	closed := t.closed
-	t.mu.Unlock()
-
-	if closed {
-		return DoWResult{Allowed: false, Reason: "tracker closed", BudgetType: BudgetConcurrent}
-	}
-
 	cfgLimit := t.cfg.MaxConcurrentToolCalls
 	if cfgLimit <= 0 {
 		cfgLimit = 10 // default limit
 	}
 	limit := int32(min(cfgLimit, 1<<30)) // cap to prevent int32 overflow
 
+	t.mu.Lock()
+	if t.closed {
+		t.mu.Unlock()
+		return DoWResult{Allowed: false, Reason: "tracker closed", BudgetType: BudgetConcurrent}
+	}
+
 	current := t.inflight.Add(1)
+	t.mu.Unlock()
+
 	if current > limit {
 		t.inflight.Add(-1) // roll back
 		return DoWResult{
@@ -229,17 +234,19 @@ func (t *DoWTracker) AcquireConcurrent() DoWResult {
 	return DoWResult{Allowed: true}
 }
 
-// ReleaseConcurrent decrements the in-flight counter. No-op if closed
-// (prevents decrementing below zero after shutdown).
+// ReleaseConcurrent decrements the in-flight counter with underflow
+// protection. Works correctly even after Close() so that in-flight
+// calls acquired before shutdown can release their slots.
 func (t *DoWTracker) ReleaseConcurrent() {
-	t.mu.Lock()
-	closed := t.closed
-	t.mu.Unlock()
-
-	if closed {
-		return
+	for {
+		cur := t.inflight.Load()
+		if cur <= 0 {
+			return
+		}
+		if t.inflight.CompareAndSwap(cur, cur-1) {
+			return
+		}
 	}
-	t.inflight.Add(-1)
 }
 
 // Inflight returns the current number of in-flight tool calls.
@@ -375,11 +382,18 @@ func (t *DoWTracker) checkFanOut() DoWResult {
 	return DoWResult{Allowed: true}
 }
 
+// defaultMaxEndpointRetries is the fallback limit when MaxRetriesPerEndpoint
+// is zero (not explicitly configured). This matches the config default
+// documented on BudgetConfig.MaxRetriesPerEndpoint.
+const defaultMaxEndpointRetries = 20
+
 // checkRetryStorm checks for repeated requests to the same endpoint with
 // non-2xx status codes, indicating the agent is retrying a failing endpoint.
 func (t *DoWTracker) checkRetryStorm(domain, path string) DoWResult {
-	// Count non-2xx responses for this endpoint in the window.
-	const maxEndpointRetries = 20 // default: max 20 retries per endpoint
+	limit := t.cfg.MaxRetriesPerEndpoint
+	if limit <= 0 {
+		limit = defaultMaxEndpointRetries
+	}
 
 	failCount := 0
 	for _, ep := range t.endpoints {
@@ -388,10 +402,10 @@ func (t *DoWTracker) checkRetryStorm(domain, path string) DoWResult {
 		}
 	}
 
-	if failCount > maxEndpointRetries {
+	if failCount > limit {
 		return DoWResult{
 			Allowed:    false,
-			Reason:     fmt.Sprintf("retry storm: %s%s failed %d times (limit %d)", domain, path, failCount, maxEndpointRetries),
+			Reason:     fmt.Sprintf("retry storm: %s%s failed %d times (limit %d)", domain, path, failCount, limit),
 			BudgetType: BudgetRetry,
 		}
 	}

--- a/internal/proxy/dow_test.go
+++ b/internal/proxy/dow_test.go
@@ -444,7 +444,7 @@ func TestDoW_RetryStorm(t *testing.T) {
 	for range 20 {
 		result := tracker.RecordEndpoint(domainExample, pathAPI, 500)
 		if !result.Allowed && result.BudgetType == BudgetRetry {
-			t.Logf("retry storm triggered at count <= 20: %s", result.Reason)
+			t.Fatalf("retry storm triggered early at count <= 20: %s", result.Reason)
 		}
 	}
 
@@ -455,6 +455,35 @@ func TestDoW_RetryStorm(t *testing.T) {
 	}
 	if result.BudgetType != BudgetRetry {
 		t.Errorf("BudgetType = %q, want %q", result.BudgetType, BudgetRetry)
+	}
+}
+
+func TestDoW_RetryStorm_ConfigurableLimit(t *testing.T) {
+	tracker := NewDoWTracker(DoWConfig{
+		FanOutLimit:           1000,
+		FanOutWindowSeconds:   60,
+		MaxRetriesPerEndpoint: 5, // custom limit of 5
+		Action:                actionBlock,
+	})
+
+	// 5 failures should be OK (at limit).
+	for range 5 {
+		result := tracker.RecordEndpoint(domainExample, pathAPI, 500)
+		if !result.Allowed && result.BudgetType == BudgetRetry {
+			t.Fatalf("retry storm triggered at count <= 5: %s", result.Reason)
+		}
+	}
+
+	// 6th failure = retry storm with custom limit.
+	result := tracker.RecordEndpoint(domainExample, pathAPI, 500)
+	if result.Allowed {
+		t.Error("6th failure should trigger retry storm with limit of 5")
+	}
+	if result.BudgetType != BudgetRetry {
+		t.Errorf("BudgetType = %q, want %q", result.BudgetType, BudgetRetry)
+	}
+	if !strings.Contains(result.Reason, "limit 5") {
+		t.Errorf("Reason should mention limit 5, got: %s", result.Reason)
 	}
 }
 
@@ -518,7 +547,7 @@ func TestDoW_ClosedTracker_AcquireConcurrent(t *testing.T) {
 func TestDoW_ClosedTracker_ReleaseConcurrent(t *testing.T) {
 	tracker := NewDoWTracker(defaultDoWConfig())
 
-	// Acquire a slot, then close, then release. Should be a no-op.
+	// Acquire a slot, then close, then release.
 	result := tracker.AcquireConcurrent()
 	if !result.Allowed {
 		t.Fatalf("pre-close acquire should succeed: %s", result.Reason)
@@ -530,12 +559,19 @@ func TestDoW_ClosedTracker_ReleaseConcurrent(t *testing.T) {
 
 	tracker.Close()
 
-	// Release after close should be a no-op (not decrement below zero).
+	// Release after close should still decrement (slots acquired before
+	// shutdown must be released to avoid permanently elevated counters).
 	tracker.ReleaseConcurrent()
 
-	// Inflight stays at 1 because release was a no-op.
-	if tracker.Inflight() != 1 {
-		t.Errorf("inflight = %d, want 1 (release should be no-op after close)", tracker.Inflight())
+	if tracker.Inflight() != 0 {
+		t.Errorf("inflight = %d, want 0 (release should decrement after close)", tracker.Inflight())
+	}
+
+	// Additional release should not underflow below zero.
+	tracker.ReleaseConcurrent()
+
+	if tracker.Inflight() != 0 {
+		t.Errorf("inflight = %d, want 0 (should not underflow below zero)", tracker.Inflight())
 	}
 }
 


### PR DESCRIPTION
## Summary

Hardening plane for the security evidence.

- **MCP Binary Integrity**: pre-spawn SHA-256 verification for subprocess MCP servers with symlink resolution, versioned interpreter detection (python3.11, etc.), `/usr/bin/env` wrapper handling, shebang parsing, agent CWD safety checks, double-EvalSymlinks TOCTOU mitigation.
- **Denial-of-Wallet Detection**: loop detection (exact match, runaway expansion, bidirectional cycles), retry storm detection with exponential backoff, fan-out detection, concurrent tool call limits, wall-clock budgets, total tool call caps.

New packages: `internal/mcp/integrity/`, new file `internal/proxy/dow.go`.

79 tests, 90.8%+ coverage.

Part 2 of 3 (stacked): Evidence → **Hardening** → Policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added binary integrity verification for MCP subprocess execution to prevent execution of tampered binaries
  * Added denial-of-wallet budget tracking system that protects against runaway scenarios, including infinite loops, bidirectional cycles, uncontrolled concurrent requests, and endpoint access storms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->