### PR TITLE
ci: fix deprecated goreleaser format field

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,10 +53,10 @@ builds:
 archives:
   - id: pipelock
     ids: [pipelock]
-    format: tar.gz
+    formats: [tar.gz]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_


### PR DESCRIPTION
GoReleaser v2 renamed `format` to `formats` (plural). Fixes `goreleaser check` deprecation warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated release build configuration for archive format specifications to ensure proper packaging of releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->