### PR TITLE
refactor: BodyScanRequest struct, server timeout constants, OnClose utility

### DIFF
--- a/internal/cli/runtime/run.go
+++ b/internal/cli/runtime/run.go
@@ -42,6 +42,30 @@ import (
 	plsentry "github.com/luckyPipewrench/pipelock/internal/sentry"
 )
 
+// Standard HTTP server timeouts. Used by all internal servers (kill switch API,
+// metrics, reverse proxy, agent listeners) except the Scan API which uses
+// operator-configured values.
+const (
+	serverReadTimeout       = 10 * time.Second
+	serverReadHeaderTimeout = 5 * time.Second
+	serverWriteTimeout      = 10 * time.Second
+	serverIdleTimeout       = 120 * time.Second
+	serverShutdownTimeout   = 5 * time.Second
+)
+
+// newHTTPServer creates an http.Server with the standard pipelock timeouts.
+// Callers that need non-default values (e.g. reverse proxy WriteTimeout) can
+// override individual fields after creation.
+func newHTTPServer(handler http.Handler) *http.Server {
+	return &http.Server{
+		Handler:           handler,
+		ReadTimeout:       serverReadTimeout,
+		ReadHeaderTimeout: serverReadHeaderTimeout,
+		WriteTimeout:      serverWriteTimeout,
+		IdleTimeout:       serverIdleTimeout,
+	}
+}
+
 // RunCmd returns the run cobra command.
 func RunCmd() *cobra.Command {
 	var configFile string
@@ -591,16 +615,10 @@ Examples:
 					return err
 				}
 
-				apiSrv := &http.Server{
-					Handler:           apiMux,
-					ReadTimeout:       10 * time.Second,
-					ReadHeaderTimeout: 5 * time.Second,
-					WriteTimeout:      10 * time.Second,
-					IdleTimeout:       120 * time.Second,
-				}
+				apiSrv := newHTTPServer(apiMux)
 				go func() {
 					<-ctx.Done()
-					shutdownCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
+					shutdownCtx, shutCancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
 					defer shutCancel()
 					_ = apiSrv.Shutdown(shutdownCtx) //nolint:errcheck // best-effort shutdown
 				}()
@@ -630,16 +648,10 @@ Examples:
 					}
 					return err
 				}
-				metricsSrv := &http.Server{
-					Handler:           metricsMux,
-					ReadTimeout:       10 * time.Second,
-					ReadHeaderTimeout: 5 * time.Second,
-					WriteTimeout:      10 * time.Second,
-					IdleTimeout:       120 * time.Second,
-				}
+				metricsSrv := newHTTPServer(metricsMux)
 				go func() {
 					<-ctx.Done()
-					shutdownCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
+					shutdownCtx, shutCancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
 					defer shutCancel()
 					_ = metricsSrv.Shutdown(shutdownCtx)
 				}()
@@ -685,16 +697,13 @@ Examples:
 					writeTimeout = d
 				}
 
-				scanAPISrv := &http.Server{
-					Handler:           scanAPIMux,
-					ReadTimeout:       readTimeout,
-					ReadHeaderTimeout: readTimeout,
-					WriteTimeout:      writeTimeout,
-					IdleTimeout:       120 * time.Second, // matches main server idle timeout
-				}
+				scanAPISrv := newHTTPServer(scanAPIMux)
+				scanAPISrv.ReadTimeout = readTimeout
+				scanAPISrv.ReadHeaderTimeout = readTimeout
+				scanAPISrv.WriteTimeout = writeTimeout
 				go func() {
 					<-ctx.Done()
-					shutdownCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
+					shutdownCtx, shutCancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
 					defer shutCancel()
 					_ = scanAPISrv.Shutdown(shutdownCtx)
 				}()
@@ -857,16 +866,11 @@ Examples:
 					return err
 				}
 
-				rpSrv := &http.Server{
-					Handler:           rpHandler,
-					ReadTimeout:       10 * time.Second,
-					ReadHeaderTimeout: 5 * time.Second,
-					WriteTimeout:      30 * time.Second,
-					IdleTimeout:       120 * time.Second,
-				}
+				rpSrv := newHTTPServer(rpHandler)
+				rpSrv.WriteTimeout = 30 * time.Second // reverse proxy upstream requests need more time
 				go func() {
 					<-ctx.Done()
-					shutdownCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
+					shutdownCtx, shutCancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
 					defer shutCancel()
 					_ = rpSrv.Shutdown(shutdownCtx)
 				}()
@@ -911,13 +915,8 @@ Examples:
 						}
 						return err
 					}
-					srv := &http.Server{
-						Handler:           AgentHandler(name, handler),
-						ReadTimeout:       10 * time.Second,
-						ReadHeaderTimeout: 5 * time.Second,
-						WriteTimeout:      agentWriteTimeout,
-						IdleTimeout:       120 * time.Second, // matches main server idle timeout
-					}
+					srv := newHTTPServer(AgentHandler(name, handler))
+					srv.WriteTimeout = agentWriteTimeout
 					// Register with proxy so its shutdown goroutine
 					// gracefully stops agent servers alongside the main server.
 					p.RegisterAgentServer(srv)

--- a/internal/proxy/address_bodyscan_test.go
+++ b/internal/proxy/address_bodyscan_test.go
@@ -42,10 +42,12 @@ func TestScanRequestBody_AddressPoisoningBlocked(t *testing.T) {
 
 	// JSON body with a poisoned ETH address (lookalike of allowlisted).
 	body := `{"to": "0x742daaaaaaaaaaaaaaaaaaaaaaaaaaaaaaf2bd3e", "amount": "1.0"}`
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"application/json", "", 1024*1024, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		MaxBytes:    1024 * 1024,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("poisoned address in body should not be clean")
 	}
@@ -65,10 +67,12 @@ func TestScanRequestBody_AddressExactMatchClean(t *testing.T) {
 
 	// Exact allowlisted address — should pass clean.
 	body := `{"to": "0x742d35cc6634c0532925a3b844bc9e7595f2bd3e", "amount": "1.0"}`
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"application/json", "", 1024*1024, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		MaxBytes:    1024 * 1024,
+		Scanner:     sc,
+	})
 	if !result.Clean {
 		t.Error("exact allowlisted address should be clean")
 	}
@@ -79,10 +83,12 @@ func TestScanRequestBody_AddressUnknownAllowed(t *testing.T) {
 
 	// Unknown address with unknown_action=allow — should pass clean.
 	body := `{"to": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}`
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"application/json", "", 1024*1024, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		MaxBytes:    1024 * 1024,
+		Scanner:     sc,
+	})
 	if !result.Clean {
 		t.Error("unknown address with allow action should be clean")
 	}
@@ -98,10 +104,12 @@ func TestScanRequestBody_NoAddressProtection(t *testing.T) {
 
 	// No address protection enabled — should not crash.
 	body := `{"to": "0x742daaaaaaaaaaaaaaaaaaaaaaaaaaaaaaf2bd3e"}`
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"application/json", "", 1024*1024, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		MaxBytes:    1024 * 1024,
+		Scanner:     sc,
+	})
 	if !result.Clean {
 		t.Error("no address protection: should be clean")
 	}
@@ -136,10 +144,13 @@ func TestScanRequestBody_AddressWithAgentID(t *testing.T) {
 
 	// Poisoned address with agent ID "trader" — agent's allowlist should be consulted.
 	body := `{"to": "0x742daaaaaaaaaaaaaaaaaaaaaaaaaaaaaaf2bd3e"}`
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"application/json", "", 1024*1024, sc, "trader",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		MaxBytes:    1024 * 1024,
+		Scanner:     sc,
+		AgentID:     "trader",
+	})
 	if result.Clean {
 		t.Fatal("poisoned address should be caught with agent allowlist")
 	}

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -80,22 +80,33 @@ type BodyScanResult struct {
 	Reason          string                   // human-readable block reason
 }
 
+// BodyScanRequest groups the parameters for scanRequestBody, keeping the
+// function signature under the 6-parameter guideline (ctx is passed separately).
+type BodyScanRequest struct {
+	Body            io.Reader
+	ContentType     string
+	ContentEncoding string
+	MaxBytes        int
+	Scanner         *scanner.Scanner
+	AgentID         string
+}
+
 // scanRequestBody reads, buffers, and DLP-scans an HTTP request body.
 // Returns the buffered body bytes (for re-wrapping) and the scan result.
 // Fail-closed: oversized bodies and compressed bodies are always blocked.
-func scanRequestBody(ctx context.Context, body io.Reader, contentType, contentEncoding string, maxBytes int, sc *scanner.Scanner, agentID string) ([]byte, BodyScanResult) {
+func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScanResult) {
 	// Content-Encoding check: compressed bodies evade DLP regex matching.
 	// Parse as comma-separated tokens (RFC 7231 section 3.1.2.2).
-	if hasNonIdentityEncoding(contentEncoding) {
+	if hasNonIdentityEncoding(req.ContentEncoding) {
 		return nil, BodyScanResult{
 			Clean:  false,
 			Action: config.ActionBlock,
-			Reason: fmt.Sprintf("request body uses Content-Encoding %q; compressed bodies cannot be scanned for secrets", contentEncoding),
+			Reason: fmt.Sprintf("request body uses Content-Encoding %q; compressed bodies cannot be scanned for secrets", req.ContentEncoding),
 		}
 	}
 
 	// Read body with +1 byte to detect overflow.
-	buf, err := io.ReadAll(io.LimitReader(body, int64(maxBytes)+1))
+	buf, err := io.ReadAll(io.LimitReader(req.Body, int64(req.MaxBytes)+1))
 	if err != nil {
 		return nil, BodyScanResult{
 			Clean:  false,
@@ -105,11 +116,11 @@ func scanRequestBody(ctx context.Context, body io.Reader, contentType, contentEn
 	}
 
 	// Overflow: fail-closed block regardless of configured action.
-	if len(buf) > maxBytes {
+	if len(buf) > req.MaxBytes {
 		return nil, BodyScanResult{
 			Clean:  false,
 			Action: config.ActionBlock,
-			Reason: fmt.Sprintf("request body exceeds max_body_bytes (%d)", maxBytes),
+			Reason: fmt.Sprintf("request body exceeds max_body_bytes (%d)", req.MaxBytes),
 		}
 	}
 
@@ -119,7 +130,7 @@ func scanRequestBody(ctx context.Context, body io.Reader, contentType, contentEn
 	}
 
 	// Extract text strings from body based on content type.
-	texts, parseErr := extractBodyText(buf, contentType, maxBytes)
+	texts, parseErr := extractBodyText(buf, req.ContentType, req.MaxBytes)
 	if parseErr != "" {
 		// Multipart limit exceeded: fail-closed block.
 		return nil, BodyScanResult{
@@ -135,7 +146,7 @@ func scanRequestBody(ctx context.Context, body io.Reader, contentType, contentEn
 
 	// Scan each extracted string individually (catches per-field encoded secrets).
 	for _, text := range texts {
-		result := sc.ScanTextForDLP(ctx, text)
+		result := req.Scanner.ScanTextForDLP(ctx, text)
 		if !result.Clean {
 			return buf, BodyScanResult{
 				Clean:      false,
@@ -150,7 +161,7 @@ func scanRequestBody(ctx context.Context, body io.Reader, contentType, contentEn
 	copy(sorted, texts)
 	sort.Strings(sorted)
 	joined := strings.Join(sorted, "\n")
-	result := sc.ScanTextForDLP(ctx, joined)
+	result := req.Scanner.ScanTextForDLP(ctx, joined)
 	if !result.Clean {
 		return buf, BodyScanResult{
 			Clean:      false,
@@ -162,8 +173,8 @@ func scanRequestBody(ctx context.Context, body io.Reader, contentType, contentEn
 	// Note: body address findings are currently emitted/counted as body_dlp
 	// by callers (forward.go, intercept.go). Dedicated address_protection
 	// log/metric path deferred to v2.
-	if checker := sc.AddressChecker(); checker != nil {
-		addrResult := checker.CheckText(joined, agentID)
+	if checker := req.Scanner.AddressChecker(); checker != nil {
+		addrResult := checker.CheckText(joined, req.AgentID)
 		if len(addrResult.Findings) > 0 {
 			return buf, BodyScanResult{
 				Clean:           false,

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -49,10 +49,12 @@ func TestScanRequestBody_JSONWithSecret(t *testing.T) {
 	defer sc.Close()
 
 	body := `{"key": "` + fakeAPIKey() + `"}`
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"application/json", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected DLP match in JSON body with API key")
 	}
@@ -68,10 +70,12 @@ func TestScanRequestBody_JSONKeyExfil(t *testing.T) {
 
 	// Secret encoded as a JSON object key
 	body := `{"` + fakeAPIKey() + `": "value"}`
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"application/json", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected DLP match in JSON key")
 	}
@@ -83,10 +87,12 @@ func TestScanRequestBody_FormURLEncoded(t *testing.T) {
 	defer sc.Close()
 
 	body := "secret=" + fakeAPIKey() + "&name=test"
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"application/x-www-form-urlencoded", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/x-www-form-urlencoded",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected DLP match in form body")
 	}
@@ -98,10 +104,12 @@ func TestScanRequestBody_PlainText(t *testing.T) {
 	defer sc.Close()
 
 	body := "my secret key is " + fakeAPIKey()
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"text/plain", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "text/plain",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected DLP match in plain text body")
 	}
@@ -114,10 +122,12 @@ func TestScanRequestBody_ContentTypeBypass_OctetStream(t *testing.T) {
 
 	// JSON secret sent as application/octet-stream: fallback raw scan catches it
 	body := `{"key": "` + fakeAPIKey() + `"}`
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"application/octet-stream", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/octet-stream",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected DLP match via fallback raw scan on octet-stream")
 	}
@@ -130,10 +140,12 @@ func TestScanRequestBody_ContentTypeBypass_ImagePNG(t *testing.T) {
 
 	// JSON secret sent as image/png: fallback raw scan catches it
 	body := `{"key": "` + fakeAPIKey() + `"}`
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"image/png", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "image/png",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected DLP match via fallback raw scan on image/png")
 	}
@@ -144,10 +156,13 @@ func TestScanRequestBody_CompressedGzip(t *testing.T) {
 	sc := scanner.New(cfg)
 	defer sc.Close()
 
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader("compressed data"),
-		"application/json", "gzip", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:            strings.NewReader("compressed data"),
+		ContentType:     "application/json",
+		ContentEncoding: "gzip",
+		MaxBytes:        cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:         sc,
+	})
 	if result.Clean {
 		t.Fatal("expected fail-closed block on gzip Content-Encoding")
 	}
@@ -161,10 +176,13 @@ func TestScanRequestBody_CompressedDeflate(t *testing.T) {
 	sc := scanner.New(cfg)
 	defer sc.Close()
 
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader("compressed data"),
-		"application/json", "deflate", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:            strings.NewReader("compressed data"),
+		ContentType:     "application/json",
+		ContentEncoding: "deflate",
+		MaxBytes:        cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:         sc,
+	})
 	if result.Clean {
 		t.Fatal("expected fail-closed block on deflate")
 	}
@@ -175,10 +193,13 @@ func TestScanRequestBody_CompressedCaseMismatch(t *testing.T) {
 	sc := scanner.New(cfg)
 	defer sc.Close()
 
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader("data"),
-		"application/json", "GZip", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:            strings.NewReader("data"),
+		ContentType:     "application/json",
+		ContentEncoding: "GZip",
+		MaxBytes:        cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:         sc,
+	})
 	if result.Clean {
 		t.Fatal("expected fail-closed block on case-insensitive gzip")
 	}
@@ -189,10 +210,13 @@ func TestScanRequestBody_CompressedCommaSeparated(t *testing.T) {
 	sc := scanner.New(cfg)
 	defer sc.Close()
 
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader("data"),
-		"application/json", "gzip, identity", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:            strings.NewReader("data"),
+		ContentType:     "application/json",
+		ContentEncoding: "gzip, identity",
+		MaxBytes:        cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:         sc,
+	})
 	if result.Clean {
 		t.Fatal("expected fail-closed block on comma-separated with gzip")
 	}
@@ -203,10 +227,13 @@ func TestScanRequestBody_IdentityEncodingAllowed(t *testing.T) {
 	sc := scanner.New(cfg)
 	defer sc.Close()
 
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader("clean body text"),
-		"text/plain", "identity", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:            strings.NewReader("clean body text"),
+		ContentType:     "text/plain",
+		ContentEncoding: "identity",
+		MaxBytes:        cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:         sc,
+	})
 	if !result.Clean {
 		t.Fatal("identity encoding should be allowed")
 	}
@@ -217,10 +244,12 @@ func TestScanRequestBody_EmptyBody(t *testing.T) {
 	sc := scanner.New(cfg)
 	defer sc.Close()
 
-	buf, result := scanRequestBody(
-		context.Background(), strings.NewReader(""),
-		"application/json", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	buf, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(""),
+		ContentType: "application/json",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if !result.Clean {
 		t.Fatal("empty body should be clean")
 	}
@@ -236,10 +265,12 @@ func TestScanRequestBody_OversizedBody(t *testing.T) {
 
 	// Create body larger than 1MB max
 	body := strings.Repeat("x", cfg.RequestBodyScanning.MaxBodyBytes+1)
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"text/plain", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "text/plain",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected fail-closed block on oversized body")
 	}
@@ -258,10 +289,12 @@ func TestScanRequestBody_SplitSecretAcrossFields(t *testing.T) {
 	half1 := key[:len(key)/2]
 	half2 := key[len(key)/2:]
 	body := `{"part1": "` + half1 + `", "part2": "` + half2 + `"}`
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"application/json", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected DLP match from joined scan of split secret")
 	}
@@ -273,10 +306,12 @@ func TestScanRequestBody_CleanJSON(t *testing.T) {
 	defer sc.Close()
 
 	body := `{"name": "test", "value": 42}`
-	buf, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"application/json", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	buf, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if !result.Clean {
 		t.Fatal("clean JSON body should not trigger DLP")
 	}
@@ -291,10 +326,12 @@ func TestScanRequestBody_XMLWithSecret(t *testing.T) {
 	defer sc.Close()
 
 	body := `<root><key>` + fakeAPIKey() + `</key></root>`
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"application/xml", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/xml",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected DLP match in XML body")
 	}
@@ -311,10 +348,12 @@ func TestScanRequestBody_MultipartText(t *testing.T) {
 		fakeAPIKey() + "\r\n" +
 		"--" + boundary + "--\r\n"
 
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"multipart/form-data; boundary="+boundary, "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "multipart/form-data; boundary=" + boundary,
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected DLP match in multipart text field")
 	}
@@ -332,10 +371,12 @@ func TestScanRequestBody_MultipartBinarySkipped(t *testing.T) {
 		"\x89PNG\r\n\x1a\n" + "\r\n" +
 		"--" + boundary + "--\r\n"
 
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"multipart/form-data; boundary="+boundary, "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "multipart/form-data; boundary=" + boundary,
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if !result.Clean {
 		t.Fatal("binary multipart part should be skipped")
 	}
@@ -356,10 +397,12 @@ func TestScanRequestBody_MultipartBinaryMetadataExfil(t *testing.T) {
 		"\x89PNG\r\n\x1a\n" + "\r\n" +
 		"--" + boundary + "--\r\n"
 
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"multipart/form-data; boundary="+boundary, "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "multipart/form-data; boundary=" + boundary,
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected DLP match for secret in binary part filename")
 	}
@@ -556,7 +599,12 @@ func TestScanRequestBody_ChunkedTransfer(t *testing.T) {
 	// Simulate chunked encoding by using a reader without known length.
 	reader := strings.NewReader(body)
 
-	buf, result := scanRequestBody(context.Background(), reader, "application/json", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "")
+	buf, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        reader,
+		ContentType: "application/json",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected DLP match in chunked JSON body")
 	}
@@ -1007,10 +1055,12 @@ func TestScanRequestBody_InvalidJSON_FailClosed(t *testing.T) {
 	defer sc.Close()
 
 	// Invalid JSON declared as application/json must fail-closed (not pass as clean).
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(`{invalid json`),
-		"application/json", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(`{invalid json`),
+		ContentType: "application/json",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected fail-closed block for invalid JSON body")
 	}
@@ -1029,10 +1079,12 @@ func TestScanRequestBody_FormURLEncoded_ParseFailure(t *testing.T) {
 	// Malformed query string that url.ParseQuery rejects: bare % without hex digits.
 	// Fail-closed: parse error blocks regardless of body content.
 	malformed := "field=%zz&value=clean"
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(malformed),
-		"application/x-www-form-urlencoded", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(malformed),
+		ContentType: "application/x-www-form-urlencoded",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected fail-closed block for malformed form body")
 	}
@@ -1047,10 +1099,12 @@ func TestScanRequestBody_MultipartMissingBoundary(t *testing.T) {
 	defer sc.Close()
 
 	// multipart/form-data without boundary parameter: fail-closed block.
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader("some body content"),
-		"multipart/form-data", "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader("some body content"),
+		ContentType: "multipart/form-data",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected fail-closed block for multipart missing boundary")
 	}
@@ -1073,10 +1127,12 @@ func TestScanRequestBody_MultipartOversizedFilename(t *testing.T) {
 		"clean content\r\n" +
 		"--" + boundary + "--\r\n"
 
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"multipart/form-data; boundary="+boundary, "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "multipart/form-data; boundary=" + boundary,
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected fail-closed block for oversized multipart filename")
 	}
@@ -1101,10 +1157,12 @@ func TestScanRequestBody_MultipartOversizedPart(t *testing.T) {
 		bigValue + "\r\n" +
 		"--" + boundary + "--\r\n"
 
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"multipart/form-data; boundary="+boundary, "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "multipart/form-data; boundary=" + boundary,
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected fail-closed block for oversized multipart part")
 	}
@@ -1126,10 +1184,12 @@ func TestScanRequestBody_MultipartFilename(t *testing.T) {
 		"clean content\r\n" +
 		"--" + boundary + "--\r\n"
 
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"multipart/form-data; boundary="+boundary, "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "multipart/form-data; boundary=" + boundary,
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected DLP match for secret in multipart filename")
 	}
@@ -1148,10 +1208,12 @@ func TestScanRequestBody_MultipartBinaryWithMetadata(t *testing.T) {
 		"\x89PNG\r\n\x1a\n\r\n" +
 		"--" + boundary + "--\r\n"
 
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(body),
-		"multipart/form-data; boundary="+boundary, "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "multipart/form-data; boundary=" + boundary,
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected DLP match for secret in binary part form name")
 	}
@@ -1204,10 +1266,12 @@ func TestScanRequestBody_MultipartTooManyParts(t *testing.T) {
 	}
 	sb.WriteString("--" + boundary + "--\r\n")
 
-	_, result := scanRequestBody(
-		context.Background(), strings.NewReader(sb.String()),
-		"multipart/form-data; boundary="+boundary, "", cfg.RequestBodyScanning.MaxBodyBytes, sc, "",
-	)
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(sb.String()),
+		ContentType: "multipart/form-data; boundary=" + boundary,
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
 	if result.Clean {
 		t.Fatal("expected fail-closed block when multipart part limit exceeded")
 	}

--- a/internal/proxy/closeutil.go
+++ b/internal/proxy/closeutil.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+)
+
+// safeClose calls Close on c and logs any error via the audit logger.
+// The label identifies the resource in log messages (e.g. "targetConn",
+// "resp.Body"). If logger is nil, errors are silently discarded.
+//
+// Use this instead of bare close-and-ignore patterns in proxy code so close
+// failures are observable in audit logs.
+func safeClose(c io.Closer, label string, logger *audit.Logger) {
+	if c == nil {
+		return
+	}
+	if err := c.Close(); err != nil && logger != nil {
+		logger.LogError(audit.LogContext{Method: "close"}, fmt.Errorf("%s: %w", label, err))
+	}
+}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -364,7 +364,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	}
 	defer func() {
 		if targetConn != nil {
-			_ = targetConn.Close()
+			safeClose(targetConn, "targetConn", p.logger)
 		}
 	}()
 
@@ -382,7 +382,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		p.logger.LogError(targetCtx, err)
 		return
 	}
-	defer clientConn.Close() //nolint:errcheck // best effort
+	defer safeClose(clientConn, "clientConn", p.logger)
 
 	// Send 200 Connection Established
 	_, _ = clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
@@ -418,7 +418,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		}
 		// Close the pre-established upstream TCP connection since interceptTunnel
 		// creates its own via the SSRF-safe dialer. This prevents a dangling connection.
-		_ = targetConn.Close()
+		safeClose(targetConn, "targetConn", p.logger)
 		targetConn = nil
 		p.metrics.RecordTLSIntercept("intercepted")
 		p.logger.LogAnomaly(hostCtx, "tls_intercept", "TLS MITM interception active", 0) // 0: informational, not anomalous
@@ -710,8 +710,14 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	// Request body DLP scanning: read and scan body before Clone so the
 	// cloned request gets the re-wrapped buffered bytes.
 	if cfg.RequestBodyScanning.Enabled && r.Body != nil && r.Body != http.NoBody {
-		buf, bodyResult := scanRequestBody(r.Context(), r.Body, r.Header.Get("Content-Type"),
-			r.Header.Get("Content-Encoding"), cfg.RequestBodyScanning.MaxBodyBytes, sc, agent)
+		buf, bodyResult := scanRequestBody(r.Context(), BodyScanRequest{
+			Body:            r.Body,
+			ContentType:     r.Header.Get("Content-Type"),
+			ContentEncoding: r.Header.Get("Content-Encoding"),
+			MaxBytes:        cfg.RequestBodyScanning.MaxBodyBytes,
+			Scanner:         sc,
+			AgentID:         agent,
+		})
 
 		// Capture observer: record forward body DLP verdict for policy replay.
 		{
@@ -965,7 +971,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "forward proxy fetch failed", http.StatusBadGateway)
 		return
 	}
-	defer resp.Body.Close() //nolint:errcheck // response body
+	defer safeClose(resp.Body, "resp.Body", p.logger)
 
 	// Size limit: tighter of max_response_mb and remaining byte budget.
 	maxBytes := int64(cfg.FetchProxy.MaxResponseMB) * 1024 * 1024

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -466,15 +466,14 @@ func newInterceptHandler(
 
 		// Request body DLP scanning.
 		if ic.Config.RequestBodyScanning.Enabled && r.Body != nil && r.Body != http.NoBody {
-			bodyBytes, result := scanRequestBody(
-				r.Context(),
-				r.Body,
-				r.Header.Get("Content-Type"),
-				r.Header.Get("Content-Encoding"),
-				ic.Config.RequestBodyScanning.MaxBodyBytes,
-				ic.Scanner,
-				ic.Agent,
-			)
+			bodyBytes, result := scanRequestBody(r.Context(), BodyScanRequest{
+				Body:            r.Body,
+				ContentType:     r.Header.Get("Content-Type"),
+				ContentEncoding: r.Header.Get("Content-Encoding"),
+				MaxBytes:        ic.Config.RequestBodyScanning.MaxBodyBytes,
+				Scanner:         ic.Scanner,
+				AgentID:         ic.Agent,
+			})
 
 			// Capture observer: record intercept body DLP verdict for policy replay.
 			if ic.Proxy != nil {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1339,7 +1339,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	defer resp.Body.Close() //nolint:errcheck // response body
+	defer safeClose(resp.Body, "resp.Body", p.logger)
 
 	// Limit response body size: use the tighter of max_response_mb and the
 	// remaining per-agent byte budget, so oversized responses are blocked

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -215,10 +215,13 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 		maxBytes = reverseProxyMaxBodyBytes
 	}
 
-	bodyBytes, result := scanRequestBody(
-		r.Context(), r.Body, r.Header.Get("Content-Type"),
-		r.Header.Get("Content-Encoding"), maxBytes, sc, "",
-	)
+	bodyBytes, result := scanRequestBody(r.Context(), BodyScanRequest{
+		Body:            r.Body,
+		ContentType:     r.Header.Get("Content-Type"),
+		ContentEncoding: r.Header.Get("Content-Encoding"),
+		MaxBytes:        maxBytes,
+		Scanner:         sc,
+	})
 
 	// Capture observer: record reverse proxy request DLP verdict for policy replay.
 	{

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -305,7 +305,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		// If Upgrade fails, it already wrote the HTTP error response.
 		return
 	}
-	defer clientConn.Close() //nolint:errcheck // best effort
+	defer safeClose(clientConn, "ws.clientConn", log)
 
 	// Dial upstream via SSRF-safe dialer.
 	upstreamConn, dialErr := p.wsDialUpstream(r.Context(), targetURL, fwdHeaders, cfg)
@@ -314,7 +314,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		plwsutil.WriteCloseFrame(clientConn, ws.StatusInternalServerError, "upstream dial failed")
 		return
 	}
-	defer upstreamConn.Close() //nolint:errcheck // best effort
+	defer safeClose(upstreamConn, "ws.upstreamConn", log)
 
 	p.metrics.IncrActiveWS()
 	log.LogWSOpen(targetURL, clientIP, requestID, agent)


### PR DESCRIPTION
## Summary

- Extract `BodyScanRequest` struct replacing 7-param `scanRequestBody` (H8)
- Extract HTTP server timeout constants and `newHTTPServer` helper (H6)
- Add `safeClose` utility for observable close error logging (H7)
- Update all `scanRequestBody` callers across proxy package

## Motivation

Tech debt audit items H8, H6, H7. Reduces parameter proliferation, eliminates magic timeout numbers, and provides a path to replace 198 bare close-and-ignore patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified server timeout configuration across HTTP components for consistent behavior.
  * Restructured request body scanning to use a single request object for clarity.
  * Centralized resource-closure handling to surface and log closure errors.

* **Tests**
  * Updated body-scan tests to exercise the new request-style API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->