### PR TITLE
chore: update stale pattern and test counts for v2.1.1

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,7 +87,7 @@ Core capabilities available today:
 - Community rule bundles (signed YAML detection patterns)
 
 **Supply Chain**
-- Single static binary (~18 MB), 17 direct dependencies
+- Single static binary (~18 MB), 18 direct dependencies
 - Cosign-signed releases, CycloneDX SBOM, SLSA v1.0 provenance
 - OpenSSF Best Practices Silver, published OWASP and NIST 800-53 coverage mappings
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -10,7 +10,7 @@ Configuration (balanced defaults):
 - SSRF protection disabled (no DNS lookups in benchmarks)
 - Rate limiting disabled (no time-dependent state)
 - Response scanning: 25 prompt injection patterns
-- DLP: 47 patterns + BIP-39 seed phrase detection
+- DLP: 48 patterns + BIP-39 seed phrase detection
 
 Run `make bench` to reproduce on your hardware.
 
@@ -41,7 +41,7 @@ Pattern matching for prompt injection on fetched content. 25 patterns including 
 
 ## Text DLP Scanning (`ScanTextForDLP()`)
 
-DLP pattern matching on arbitrary text (MCP arguments, request bodies). 47 patterns with Aho-Corasick pre-filter.
+DLP pattern matching on arbitrary text (MCP arguments, request bodies). 48 patterns with Aho-Corasick pre-filter.
 
 | Benchmark | ns/op | B/op | allocs/op |
 |-----------|------:|-----:|----------:|
@@ -113,7 +113,7 @@ True concurrent throughput across all available goroutines.
 
 - **Full 11-layer scan on a typical URL: ~32 microseconds.** Slightly higher than v1.5.0 (~21μs) due to expanded DLP patterns and additional scanner layers. Well under 1ms.
 - Blocked URLs short-circuit early: blocklist check is ~2μs.
-- DLP regex matching (47 patterns) with pre-filter: ~8μs. Pre-filter alone: ~497ns with zero allocations on clean text.
+- DLP regex matching (48 patterns) with pre-filter: ~8μs. Pre-filter alone: ~497ns with zero allocations on clean text.
 - Response scanning with 25 patterns on small content: ~76μs. Large content (~10KB): ~8.4ms. State/control patterns add ~133μs on clean text. Injection detected via early exit: ~42μs.
 - MCP scanning (JSON parse + text extraction + pattern match): ~76μs clean, ~33μs injection.
 - Cross-request entropy tracking: ~110μs per record. Fragment buffer append: ~83ns (single alloc).

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -30,7 +30,7 @@ An honest feature matrix and guidance on when to use what.
 | **Config format** | YAML + presets | YAML (agent.yaml) | CLI flags | Code |
 | **Hot-reload** | Yes (fsnotify + SIGHUP) | No | No | No |
 | **CI/CD friendly** | Yes (exit codes, JSON output) | Yes | Limited | Yes |
-| **Testing depth** | 7,500+ tests, 88%+ coverage, private adversarial suite | Public unit tests | Public unit tests | Public unit tests |
+| **Testing depth** | 10,000+ tests, 88%+ coverage, private adversarial suite | Public unit tests | Public unit tests | Public unit tests |
 
 ## When to Use What
 
@@ -72,7 +72,7 @@ An honest feature matrix and guidance on when to use what.
 mcp-scan has two modes: static scanning detects tool poisoning via hash comparison ("has this tool changed?"), while proxy mode monitors MCP traffic with PII/secrets guardrails. Pipelock scans bidirectionally with pattern matching, Unicode normalization, entropy analysis, and covers HTTP fetch traffic in addition to MCP. They're complementary: mcp-scan for MCP-specific auditing and guardrails, Pipelock for deep content inspection across both HTTP and MCP.
 
 ### Pipelock vs Docker MCP Gateway
-Docker MCP Gateway aggregates MCP servers and provides basic secret scanning. Pipelock provides deep content inspection (47 DLP patterns, BIP-39 seed phrase detection, 25 injection detection patterns, entropy analysis, tool poisoning). They're complementary: Pipelock could run as a Gateway interceptor for content inspection while Gateway handles routing and Docker-native lifecycle management.
+Docker MCP Gateway aggregates MCP servers and provides basic secret scanning. Pipelock provides deep content inspection (48 DLP patterns, BIP-39 seed phrase detection, 25 injection detection patterns, entropy analysis, tool poisoning). They're complementary: Pipelock could run as a Gateway interceptor for content inspection while Gateway handles routing and Docker-native lifecycle management.
 
 ## Using Tools Together
 

--- a/docs/compliance/owasp-mcp-top10.md
+++ b/docs/compliance/owasp-mcp-top10.md
@@ -33,7 +33,7 @@ See also: [OWASP Agentic Top 10 mapping](../owasp-mapping.md) | [OWASP AIVSS cov
 
 **Pipelock coverage:**
 
-- **DLP scanning:** 47 regex patterns with 4 checksum validators (Luhn, mod97, ABA, WIF) detect secrets in tool arguments, URLs, headers, and request bodies. Patterns cover AWS, GitHub, Slack, Stripe, Anthropic, OpenAI, and 30+ other provider key formats.
+- **DLP scanning:** 48 regex patterns with 4 checksum validators (Luhn, mod97, ABA, WIF) detect secrets in tool arguments, URLs, headers, and request bodies. Patterns cover AWS, GitHub, Slack, Stripe, Anthropic, OpenAI, and 30+ other provider key formats.
 - **Environment leak detection:** `dlp.scan_env` reads the local environment and flags any outbound request containing env var values above a minimum length threshold.
 - **MCP input scanning:** scans tool call arguments (client-to-server) for secrets before they reach the MCP server. Catches agents forwarding credentials to untrusted tools.
 - **Encoding resistance:** 6-pass normalization decodes base64, hex, and URL encoding before pattern matching. Secrets encoded to evade detection are decoded and caught.

--- a/test/secureiqlab/README.md
+++ b/test/secureiqlab/README.md
@@ -116,8 +116,8 @@ Pipelock applies these scanning layers to all traffic:
 | Layer | What it does | Applies to |
 |-------|-------------|------------|
 | **URL Scanner** | 11-layer pipeline: scheme, blocklist, DLP, path entropy, subdomain entropy, SSRF, rate limit, URL length, data budget | Forward proxy, fetch |
-| **DLP** | 46 credential patterns with checksum validators (Luhn, Mod97, ABA, WIF). Env variable leak detection. Case-insensitive with `(?i)` prefix. | All transports |
-| **Response Scanning** | 23 prompt injection / jailbreak patterns with 6-pass normalization (NFKC, invisible chars, leetspeak, optional whitespace, vowel folding, base64/hex decode) | Fetch responses, MCP tool results |
+| **DLP** | 48 credential patterns with checksum validators (Luhn, Mod97, ABA, WIF). Env variable leak detection. Case-insensitive with `(?i)` prefix. | All transports |
+| **Response Scanning** | 25 prompt injection / jailbreak patterns with 6-pass normalization (NFKC, invisible chars, leetspeak, optional whitespace, vowel folding, base64/hex decode) | Fetch responses, MCP tool results |
 | **Request Body** | DLP + injection scanning on outbound request bodies and headers | Forward proxy, fetch |
 | **Canary Tokens** | Synthetic secret detection — exact match, zero false positives by definition | All transports |
 | **MCP Tool Scanning** | Poisoned tool description detection with recursive schema walking. Rug-pull drift detection between sessions. | MCP proxy |


### PR DESCRIPTION
## Summary

Post-release stat sweep. DLP 47→48, response 23→25, tests 7,500→10,000+, deps 17→18 across docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Data Loss Prevention (DLP) scanning coverage documentation to reflect expanded pattern detection (47 to 48 patterns)
  * Enhanced test coverage metrics across compliance and validation documentation (7,500+ to 10,000+ tests)
  * Updated supply chain documentation with current dependency specifications (17 to 18 direct dependencies)
  * Improved Response Scanning pattern coverage in validation documentation (23 to 25 patterns)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->