### PR TITLE
Add task boundaries for taint-scoped trust overrides

### DIFF
--- a/internal/cli/runtime/run.go
+++ b/internal/cli/runtime/run.go
@@ -672,6 +672,10 @@ Examples:
 						switch {
 						case killswitch.IsSessionActionPath(path, "airlock"):
 							sessionAPI.HandleAirlock(w, r)
+						case killswitch.IsSessionActionPath(path, "task"):
+							sessionAPI.HandleTask(w, r)
+						case killswitch.IsSessionActionPath(path, "trust"):
+							sessionAPI.HandleTrust(w, r)
 						case killswitch.IsSessionActionPath(path, "reset"):
 							sessionAPI.HandleReset(w, r)
 						default:

--- a/internal/envelope/emitter.go
+++ b/internal/envelope/emitter.go
@@ -47,6 +47,7 @@ type BuildOpts struct {
 	Actor          string
 	ActorAuth      ActorAuth
 	SessionTaint   string
+	TaskID         string
 	AuthorityKind  string
 	AuthorityRef   string
 	RequiresReauth bool
@@ -72,6 +73,7 @@ func (e *Emitter) Build(opts BuildOpts) Envelope {
 		ReceiptID:      opts.ActionID,
 		Timestamp:      time.Now().UTC().Unix(),
 		SessionTaint:   opts.SessionTaint,
+		TaskID:         opts.TaskID,
 		AuthorityKind:  opts.AuthorityKind,
 		AuthorityRef:   opts.AuthorityRef,
 		RequiresReauth: opts.RequiresReauth,

--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -49,6 +49,7 @@ type Envelope struct {
 	ReceiptID      string // UUIDv7 receipt ID for correlation.
 	Timestamp      int64  // Unix timestamp (seconds).
 	SessionTaint   string
+	TaskID         string
 	AuthorityKind  string
 	AuthorityRef   string
 	RequiresReauth bool
@@ -68,6 +69,7 @@ const (
 	keyReceiptID  = "rid"
 	keyTimestamp  = "ts"
 	keyTaint      = "taint"
+	keyTaskID     = "task"
 	keyAuthority  = "auth"
 	keyAuthorityR = "authr"
 	keyReauth     = "reauth"
@@ -87,6 +89,9 @@ func (e Envelope) Serialize() (string, error) {
 	dict.Add(keyTimestamp, httpsfv.NewItem(e.Timestamp))
 	if e.SessionTaint != "" {
 		dict.Add(keyTaint, httpsfv.NewItem(e.SessionTaint))
+	}
+	if e.TaskID != "" {
+		dict.Add(keyTaskID, httpsfv.NewItem(e.TaskID))
 	}
 	if e.AuthorityKind != "" {
 		dict.Add(keyAuthority, httpsfv.NewItem(e.AuthorityKind))
@@ -180,6 +185,13 @@ func Parse(s string) (Envelope, error) {
 			}
 		}
 	}
+	if m, ok := dict.Get(keyTaskID); ok {
+		if item, ok := m.(httpsfv.Item); ok {
+			if v, ok := item.Value.(string); ok {
+				env.TaskID = v
+			}
+		}
+	}
 	if m, ok := dict.Get(keyAuthority); ok {
 		if item, ok := m.(httpsfv.Item); ok {
 			if v, ok := item.Value.(string); ok {
@@ -247,6 +259,9 @@ func (e Envelope) ToMCPMeta() map[string]any {
 	}
 	if e.SessionTaint != "" {
 		meta[keyTaint] = e.SessionTaint
+	}
+	if e.TaskID != "" {
+		meta[keyTaskID] = e.TaskID
 	}
 	if e.AuthorityKind != "" {
 		meta[keyAuthority] = e.AuthorityKind

--- a/internal/killswitch/killswitch.go
+++ b/internal/killswitch/killswitch.go
@@ -163,7 +163,9 @@ func (c *Controller) IsActiveHTTP(r *http.Request) Decision {
 		(path == "/api/v1/killswitch" || path == "/api/v1/killswitch/status" ||
 			path == "/api/v1/sessions" ||
 			IsSessionActionPath(path, "reset") ||
-			IsSessionActionPath(path, "airlock")) {
+			IsSessionActionPath(path, "airlock") ||
+			IsSessionActionPath(path, "task") ||
+			IsSessionActionPath(path, "trust")) {
 		return Decision{}
 	}
 

--- a/internal/killswitch/killswitch_test.go
+++ b/internal/killswitch/killswitch_test.go
@@ -1209,6 +1209,8 @@ func TestIsActiveHTTP_ExemptsSessionAPI(t *testing.T) {
 	}{
 		{"/api/v1/sessions", false},
 		{"/api/v1/sessions/agent%7C10.0.0.1/reset", false},
+		{"/api/v1/sessions/agent%7C10.0.0.1/task", false},
+		{"/api/v1/sessions/agent%7C10.0.0.1/trust", false},
 		{"/fetch", true},
 		{"/api/v1/killswitch", false},
 		{"/api/v1/killswitch/status", false},

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -465,9 +465,12 @@ func ForwardScannedInput(
 				SessionTaintLevel:   taintDecision.Risk.Level.String(),
 				SessionContaminated: taintDecision.Risk.Contaminated,
 				RecentTaintSources:  taintDecision.Risk.Sources,
+				SessionTaskID:       taintDecision.Task.CurrentTaskID,
+				SessionTaskLabel:    taintDecision.Task.CurrentTaskLabel,
 				AuthorityKind:       taintDecision.Authority.String(),
 				TaintDecision:       taintDecision.Result.Decision.String(),
 				TaintDecisionReason: taintDecision.Result.Reason,
+				TaskOverrideApplied: taintDecision.TaskOverrideApplied,
 			})
 		}
 		if verdict.Method == methodToolsCall {
@@ -567,6 +570,7 @@ func ForwardScannedInput(
 					Action:         string(receipt.ClassifyMCPTool(toolCallName, verdict.Method)),
 					Verdict:        config.ActionAllow,
 					SessionTaint:   taintDecision.Risk.Level.String(),
+					TaskID:         taintDecision.Task.CurrentTaskID,
 					AuthorityKind:  taintDecision.Authority.String(),
 					RequiresReauth: taintDecision.RequiresReauth,
 				})
@@ -822,6 +826,7 @@ func ForwardScannedInput(
 					Action:         string(receipt.ClassifyMCPTool(toolCallName, verdict.Method)),
 					Verdict:        config.ActionWarn,
 					SessionTaint:   taintDecision.Risk.Level.String(),
+					TaskID:         taintDecision.Task.CurrentTaskID,
 					AuthorityKind:  taintDecision.Authority.String(),
 					RequiresReauth: taintDecision.RequiresReauth,
 				})

--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -21,16 +21,19 @@ const (
 	taintReasonDisabled = "taint_disabled"
 	taintScopeAction    = "action"
 	taintScopeSource    = "source"
+	taintScopeTask      = "task"
 )
 
 type taintDecision struct {
-	Risk           session.SessionRisk
-	ActionClass    session.ActionClass
-	Sensitivity    session.ActionSensitivity
-	Authority      session.AuthorityKind
-	Result         session.PolicyDecisionResult
-	ActionRef      string
-	RequiresReauth bool
+	Risk                session.SessionRisk
+	Task                session.TaskContext
+	ActionClass         session.ActionClass
+	Sensitivity         session.ActionSensitivity
+	Authority           session.AuthorityKind
+	Result              session.PolicyDecisionResult
+	ActionRef           string
+	RequiresReauth      bool
+	TaskOverrideApplied bool
 }
 
 func observeMCPResponseTaint(opts MCPProxyOpts, promptHit bool) {
@@ -66,6 +69,17 @@ func evaluateMCPTaint(opts MCPProxyOpts, toolName, argsJSON string) taintDecisio
 		opts.TaintCfg.ElevatedPaths,
 	)
 	decision.ActionRef = mcpActionRef(toolName, decision.ActionRef)
+	if tp, ok := opts.Rec.(session.TaskContextProvider); ok {
+		decision.Task = tp.TaskSnapshot()
+		if taintRuntimeTrustOverrideApplies(tp.RuntimeTrustOverrides(), decision.Task, decision.Risk, decision.ActionRef) {
+			decision.Result = session.PolicyDecisionResult{
+				Decision: session.PolicyAllow,
+				Reason:   "taint_runtime_task_override",
+			}
+			decision.TaskOverrideApplied = true
+			return decision
+		}
+	}
 	decision.Result = session.PolicyMatrix{Profile: opts.TaintCfg.Policy}.Evaluate(
 		decision.Risk.Level,
 		decision.ActionClass,
@@ -153,6 +167,29 @@ func taintOverrideMatches(override config.TaintTrustOverride, risk session.Sessi
 	}
 }
 
+func taintRuntimeTrustOverrideApplies(overrides []session.TrustOverride, task session.TaskContext, risk session.SessionRisk, actionRef string) bool {
+	now := time.Now().UTC()
+	for _, override := range overrides {
+		if override.Scope != taintScopeTask {
+			continue
+		}
+		if override.TaskID == "" || override.TaskID != task.CurrentTaskID {
+			continue
+		}
+		if !override.ExpiresAt.IsZero() && override.ExpiresAt.Before(now) {
+			continue
+		}
+		if override.ActionMatch != "" && !taintWildcardMatch(actionRef, override.ActionMatch) {
+			continue
+		}
+		if override.SourceMatch != "" && !taintRiskSourceMatches(risk, override.SourceMatch) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 func taintRiskSourceMatches(risk session.SessionRisk, pattern string) bool {
 	return taintWildcardMatch(risk.LastExternalURL, pattern)
 }
@@ -206,9 +243,12 @@ func emitMCPToolReceipt(opts MCPProxyOpts, actionID, mcpMethod, toolName, receip
 		SessionTaintLevel:   decision.Risk.Level.String(),
 		SessionContaminated: decision.Risk.Contaminated,
 		RecentTaintSources:  decision.Risk.Sources,
+		SessionTaskID:       decision.Task.CurrentTaskID,
+		SessionTaskLabel:    decision.Task.CurrentTaskLabel,
 		AuthorityKind:       decision.Authority.String(),
 		TaintDecision:       decision.Result.Decision.String(),
 		TaintDecisionReason: decision.Result.Reason,
+		TaskOverrideApplied: decision.TaskOverrideApplied,
 	})
 }
 
@@ -221,6 +261,7 @@ func decorateMCPToolMessage(msg []byte, emitter *envelope.Emitter, actionID, mcp
 		Action:         string(receipt.ClassifyMCPTool(toolName, mcpMethod)),
 		Verdict:        receiptVerdict,
 		SessionTaint:   decision.Risk.Level.String(),
+		TaskID:         decision.Task.CurrentTaskID,
 		AuthorityKind:  decision.Authority.String(),
 		RequiresReauth: decision.RequiresReauth,
 	})

--- a/internal/mcp/taint_test.go
+++ b/internal/mcp/taint_test.go
@@ -16,8 +16,10 @@ import (
 )
 
 type taintRecorder struct {
-	level int
-	risk  session.SessionRisk
+	level     int
+	risk      session.SessionRisk
+	task      session.TaskContext
+	overrides []session.TrustOverride
 }
 
 func (r *taintRecorder) RecordSignal(_ session.SignalType, _ float64) (bool, string, string) {
@@ -40,6 +42,17 @@ func (r *taintRecorder) RiskSnapshot() session.SessionRisk {
 
 func (r *taintRecorder) ObserveRisk(observation session.RiskObservation) {
 	r.risk.Observe(observation)
+}
+
+func (r *taintRecorder) TaskSnapshot() session.TaskContext {
+	if r.task.CurrentTaskID == "" {
+		r.task = session.TaskContext{CurrentTaskID: session.NextTaskID()}
+	}
+	return r.task
+}
+
+func (r *taintRecorder) RuntimeTrustOverrides() []session.TrustOverride {
+	return append([]session.TrustOverride(nil), r.overrides...)
 }
 
 func TestForwardScanned_ExternalResponseContaminatesSession(t *testing.T) {
@@ -383,6 +396,44 @@ func TestEvaluateMCPTaint_TrustOverrideUsesActiveSourceOnly(t *testing.T) {
 	}, "write_file", `{"path":"/repo/auth/middleware.go","content":"x"}`)
 	if decision.Result.Decision != session.PolicyAsk {
 		t.Fatalf("decision = %v, want ask when only a historical source matches", decision.Result.Decision)
+	}
+}
+
+func TestEvaluateMCPTaint_RuntimeTaskOverrideHonorsBoundary(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	rec := &taintRecorder{
+		task: session.TaskContext{CurrentTaskID: "task-1"},
+		risk: session.SessionRisk{
+			Level:        session.TaintExternalUntrusted,
+			Contaminated: true,
+			Sources: []session.TaintSourceRef{{
+				URL:   "https://evil.example/issue/123",
+				Kind:  "http_response",
+				Level: session.TaintExternalUntrusted,
+			}},
+		},
+		overrides: []session.TrustOverride{{
+			Scope:       "task",
+			TaskID:      "task-1",
+			ActionMatch: "mcp:write_file:/repo/auth/middleware.go",
+			ExpiresAt:   time.Now().UTC().Add(time.Hour),
+		}},
+	}
+
+	decision := evaluateMCPTaint(MCPProxyOpts{Rec: rec, TaintCfg: &cfg.Taint}, "write_file", `{"path":"/repo/auth/middleware.go","content":"x"}`)
+	if decision.Result.Decision != session.PolicyAllow {
+		t.Fatalf("decision = %v, want allow", decision.Result.Decision)
+	}
+	if !decision.TaskOverrideApplied {
+		t.Fatal("expected runtime task override to be recorded")
+	}
+
+	rec.task = session.TaskContext{CurrentTaskID: "task-2"}
+	decision = evaluateMCPTaint(MCPProxyOpts{Rec: rec, TaintCfg: &cfg.Taint}, "write_file", `{"path":"/repo/auth/middleware.go","content":"x"}`)
+	if decision.Result.Decision != session.PolicyAsk {
+		t.Fatalf("decision after task boundary = %v, want ask", decision.Result.Decision)
 	}
 }
 

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -735,9 +735,12 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			SessionTaintLevel:   forwardTaint.Risk.Level.String(),
 			SessionContaminated: forwardTaint.Risk.Contaminated,
 			RecentTaintSources:  forwardTaint.Risk.Sources,
+			SessionTaskID:       forwardTaint.Task.CurrentTaskID,
+			SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
 			AuthorityKind:       forwardTaint.Authority.String(),
 			TaintDecision:       forwardTaint.Result.Decision.String(),
 			TaintDecisionReason: forwardTaint.Result.Reason,
+			TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
 		})
 		p.metrics.RecordBlocked(r.URL.Hostname(), "taint_policy", time.Since(start), agentLabel)
 		http.Error(w, "blocked: "+forwardTaint.Result.Reason, http.StatusForbidden)
@@ -767,9 +770,12 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 				SessionTaintLevel:   forwardTaint.Risk.Level.String(),
 				SessionContaminated: forwardTaint.Risk.Contaminated,
 				RecentTaintSources:  forwardTaint.Risk.Sources,
+				SessionTaskID:       forwardTaint.Task.CurrentTaskID,
+				SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
 				AuthorityKind:       forwardTaint.Authority.String(),
 				TaintDecision:       forwardTaint.Result.Decision.String(),
 				TaintDecisionReason: forwardTaint.Result.Reason,
+				TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
 			})
 			p.metrics.RecordBlocked(r.URL.Hostname(), "taint_policy", time.Since(start), agentLabel)
 			http.Error(w, "blocked: "+forwardTaint.Result.Reason, http.StatusForbidden)
@@ -1053,6 +1059,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			Actor:          agent,
 			ActorAuth:      id.Auth,
 			SessionTaint:   forwardTaint.Risk.Level.String(),
+			TaskID:         forwardTaint.Task.CurrentTaskID,
 			AuthorityKind:  forwardTaint.Authority.String(),
 			AuthorityRef:   forwardTaint.ActionRef,
 			RequiresReauth: forwardRequiresReauth,
@@ -1124,9 +1131,12 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 				SessionTaintLevel:   forwardTaint.Risk.Level.String(),
 				SessionContaminated: forwardTaint.Risk.Contaminated,
 				RecentTaintSources:  forwardTaint.Risk.Sources,
+				SessionTaskID:       forwardTaint.Task.CurrentTaskID,
+				SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
 				AuthorityKind:       forwardTaint.Authority.String(),
 				TaintDecision:       forwardTaint.Result.Decision.String(),
 				TaintDecisionReason: forwardTaint.Result.Reason,
+				TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
 			})
 			p.logger.LogForwardHTTP(actx, resp.StatusCode, 0, duration)
 			if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
@@ -1395,9 +1405,12 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			SessionTaintLevel:   forwardTaint.Risk.Level.String(),
 			SessionContaminated: forwardTaint.Risk.Contaminated,
 			RecentTaintSources:  forwardTaint.Risk.Sources,
+			SessionTaskID:       forwardTaint.Task.CurrentTaskID,
+			SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
 			AuthorityKind:       forwardTaint.Authority.String(),
 			TaintDecision:       forwardTaint.Result.Decision.String(),
 			TaintDecisionReason: forwardTaint.Result.Reason,
+			TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
 		})
 		p.logger.LogForwardHTTP(actx, resp.StatusCode, int(written), duration)
 		if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
@@ -1437,9 +1450,12 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		SessionTaintLevel:   forwardTaint.Risk.Level.String(),
 		SessionContaminated: forwardTaint.Risk.Contaminated,
 		RecentTaintSources:  forwardTaint.Risk.Sources,
+		SessionTaskID:       forwardTaint.Task.CurrentTaskID,
+		SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
 		AuthorityKind:       forwardTaint.Authority.String(),
 		TaintDecision:       forwardTaint.Result.Decision.String(),
 		TaintDecisionReason: forwardTaint.Result.Reason,
+		TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
 	})
 	p.logger.LogForwardHTTP(actx, resp.StatusCode, int(written), duration)
 	if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1121,6 +1121,10 @@ func (p *Proxy) sessionAPIRouter(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case killswitch.IsSessionActionPath(path, "airlock"):
 		p.sessionAPI.HandleAirlock(w, r)
+	case killswitch.IsSessionActionPath(path, "task"):
+		p.sessionAPI.HandleTask(w, r)
+	case killswitch.IsSessionActionPath(path, "trust"):
+		p.sessionAPI.HandleTrust(w, r)
 	case killswitch.IsSessionActionPath(path, "reset"):
 		p.sessionAPI.HandleReset(w, r)
 	default:
@@ -1394,9 +1398,12 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 				SessionTaintLevel:   fetchTaint.Risk.Level.String(),
 				SessionContaminated: fetchTaint.Risk.Contaminated,
 				RecentTaintSources:  fetchTaint.Risk.Sources,
+				SessionTaskID:       fetchTaint.Task.CurrentTaskID,
+				SessionTaskLabel:    fetchTaint.Task.CurrentTaskLabel,
 				AuthorityKind:       fetchTaint.Authority.String(),
 				TaintDecision:       fetchTaint.Result.Decision.String(),
 				TaintDecisionReason: fetchTaint.Result.Reason,
+				TaskOverrideApplied: fetchTaint.TaskOverrideApplied,
 			})
 			p.metrics.RecordBlocked(parsed.Hostname(), result.Scanner, time.Since(start), agentLabel)
 			status := http.StatusForbidden
@@ -1651,6 +1658,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			Actor:         agent,
 			ActorAuth:     id.Auth,
 			SessionTaint:  fetchTaint.Risk.Level.String(),
+			TaskID:        fetchTaint.Task.CurrentTaskID,
 			AuthorityKind: fetchTaint.Authority.String(),
 		}); envErr != nil {
 			log.LogAnomaly(actx, "", fmt.Sprintf("mediation envelope injection failed: %v", envErr), 0.1)
@@ -1990,9 +1998,12 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		SessionTaintLevel:   fetchTaint.Risk.Level.String(),
 		SessionContaminated: fetchTaint.Risk.Contaminated,
 		RecentTaintSources:  fetchTaint.Risk.Sources,
+		SessionTaskID:       fetchTaint.Task.CurrentTaskID,
+		SessionTaskLabel:    fetchTaint.Task.CurrentTaskLabel,
 		AuthorityKind:       fetchTaint.Authority.String(),
 		TaintDecision:       fetchTaint.Result.Decision.String(),
 		TaintDecisionReason: fetchTaint.Result.Reason,
+		TaskOverrideApplied: fetchTaint.TaskOverrideApplied,
 	})
 	log.LogAllowed(actx, resp.StatusCode, len(body), duration)
 

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -386,6 +386,10 @@ func (s *SessionState) BeginNewTask(label string) (prev, current session.TaskCon
 		s.runtimeOverrides = kept
 	}
 
+	// Refresh activity so cleanup doesn't evict a session that just had
+	// its task boundary rotated via the admin API.
+	s.lastActivity = now
+
 	return prev, s.task, clearedOverrides
 }
 
@@ -402,6 +406,9 @@ func (s *SessionState) AddRuntimeTrustOverride(override session.TrustOverride) s
 		override.TaskID = s.task.CurrentTaskID
 	}
 	s.runtimeOverrides = append(s.runtimeOverrides, override)
+	// Refresh activity so cleanup doesn't evict a session that just
+	// received a trust override via the admin API.
+	s.lastActivity = time.Now()
 	return override
 }
 

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -945,19 +945,34 @@ func (sm *SessionManager) ResetSessionIfResettable(key string) (prev SessionSnap
 
 // BeginNewTask rotates the task boundary for an active session and clears
 // taint-only state while preserving adaptive profiling state.
-func (sm *SessionManager) BeginNewTask(key, label string) (prev, current session.TaskContext, clearedOverrides int, found bool) {
+//
+// Only identity sessions are valid targets. Invocation sessions (ephemeral
+// per-request MCP session keys) cannot be mutated via the admin API — they
+// represent the exact execution context the caller should NOT be allowed to
+// alter, and mirror the guardrail established by ResetSessionIfResettable.
+//
+// Returns:
+//   - found=false, err=nil: session does not exist
+//   - found=true, err=ErrInvocationReset: session exists but is not resettable
+//   - found=true, err=nil: rotation succeeded
+func (sm *SessionManager) BeginNewTask(key, label string) (prev, current session.TaskContext, clearedOverrides int, found bool, err error) {
 	sm.mu.RLock()
 	sess, ok := sm.sessions[key]
 	sm.mu.RUnlock()
 	if !ok {
-		return session.TaskContext{}, session.TaskContext{}, 0, false
+		return session.TaskContext{}, session.TaskContext{}, 0, false, nil
+	}
+	if !sess.IsResettable() {
+		return session.TaskContext{}, session.TaskContext{}, 0, true, ErrInvocationReset
 	}
 	prev, current, clearedOverrides = sess.BeginNewTask(label)
-	return prev, current, clearedOverrides, true
+	return prev, current, clearedOverrides, true, nil
 }
 
 // AddRuntimeTrustOverride binds and stores a task-scoped trust override on an
-// active session.
+// active session. Same identity-session guardrail as BeginNewTask applies:
+// invocation sessions cannot receive runtime trust overrides via the admin
+// API.
 func (sm *SessionManager) AddRuntimeTrustOverride(key string, override session.TrustOverride) (applied session.TrustOverride, task session.TaskContext, found bool, err error) {
 	if override.Scope != "task" {
 		return session.TrustOverride{}, session.TaskContext{}, false, ErrTaskScopeOnly
@@ -968,6 +983,9 @@ func (sm *SessionManager) AddRuntimeTrustOverride(key string, override session.T
 	sm.mu.RUnlock()
 	if !ok {
 		return session.TrustOverride{}, session.TaskContext{}, false, nil
+	}
+	if !sess.IsResettable() {
+		return session.TrustOverride{}, session.TaskContext{}, true, ErrInvocationReset
 	}
 
 	applied = sess.AddRuntimeTrustOverride(override)

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -943,6 +943,32 @@ func (sm *SessionManager) ResetSessionIfResettable(key string) (prev SessionSnap
 	return prev, true, nil
 }
 
+// withMutableIdentitySession looks up a resettable identity session and runs
+// mutate while still holding sm.mu.RLock. This blocks cleanup/eviction from
+// removing the session between map lookup and the session-scoped mutation.
+//
+// Returns:
+//   - found=false, err=nil: session does not exist
+//   - found=true, err=ErrInvocationReset: session exists but is not resettable
+//   - found=true, err=nil: mutate completed
+func (sm *SessionManager) withMutableIdentitySession(key string, mutate func(*SessionState)) (found bool, err error) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	sess, ok := sm.sessions[key]
+	if !ok {
+		return false, nil
+	}
+	// Hold RLock across the kind check and mutation so cleanup/eviction
+	// can't remove the session between lookup and mutate. IsResettable and
+	// the callback both acquire sess.mu internally (lock ordering: sm.mu > sess.mu).
+	if !sess.IsResettable() {
+		return true, ErrInvocationReset
+	}
+	mutate(sess)
+	return true, nil
+}
+
 // BeginNewTask rotates the task boundary for an active session and clears
 // taint-only state while preserving adaptive profiling state.
 //
@@ -956,17 +982,10 @@ func (sm *SessionManager) ResetSessionIfResettable(key string) (prev SessionSnap
 //   - found=true, err=ErrInvocationReset: session exists but is not resettable
 //   - found=true, err=nil: rotation succeeded
 func (sm *SessionManager) BeginNewTask(key, label string) (prev, current session.TaskContext, clearedOverrides int, found bool, err error) {
-	sm.mu.RLock()
-	sess, ok := sm.sessions[key]
-	sm.mu.RUnlock()
-	if !ok {
-		return session.TaskContext{}, session.TaskContext{}, 0, false, nil
-	}
-	if !sess.IsResettable() {
-		return session.TaskContext{}, session.TaskContext{}, 0, true, ErrInvocationReset
-	}
-	prev, current, clearedOverrides = sess.BeginNewTask(label)
-	return prev, current, clearedOverrides, true, nil
+	found, err = sm.withMutableIdentitySession(key, func(sess *SessionState) {
+		prev, current, clearedOverrides = sess.BeginNewTask(label)
+	})
+	return prev, current, clearedOverrides, found, err
 }
 
 // AddRuntimeTrustOverride binds and stores a task-scoped trust override on an
@@ -983,18 +1002,10 @@ func (sm *SessionManager) AddRuntimeTrustOverride(key string, override session.T
 		return session.TrustOverride{}, false, ErrTaskScopeOnly
 	}
 
-	sm.mu.RLock()
-	sess, ok := sm.sessions[key]
-	sm.mu.RUnlock()
-	if !ok {
-		return session.TrustOverride{}, false, nil
-	}
-	if !sess.IsResettable() {
-		return session.TrustOverride{}, true, ErrInvocationReset
-	}
-
-	applied = sess.AddRuntimeTrustOverride(override)
-	return applied, true, nil
+	found, err = sm.withMutableIdentitySession(key, func(sess *SessionState) {
+		applied = sess.AddRuntimeTrustOverride(override)
+	})
+	return applied, found, err
 }
 
 // ForceSetAirlockTier atomically looks up a session by key and sets the

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -65,6 +65,10 @@ type SessionState struct {
 
 	// Sticky taint state used for exposure-based policy escalation.
 	risk session.SessionRisk
+
+	// Task-boundary state for taint overrides and evidence binding.
+	task             session.TaskContext
+	runtimeOverrides []session.TrustOverride
 }
 
 // IsResettable returns whether this session can be reset via the admin API.
@@ -332,11 +336,73 @@ func (s *SessionState) RiskSnapshot() session.SessionRisk {
 	return s.risk.Snapshot()
 }
 
+// TaskSnapshot returns a copy of the session's current task context.
+func (s *SessionState) TaskSnapshot() session.TaskContext {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.task.CurrentTaskID == "" {
+		s.task = newTaskContext("", time.Now())
+	}
+	return s.task
+}
+
+// RuntimeTrustOverrides returns a copy of the session's runtime overrides.
+func (s *SessionState) RuntimeTrustOverrides() []session.TrustOverride {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]session.TrustOverride(nil), s.runtimeOverrides...)
+}
+
 // ObserveRisk folds a new taint observation into the session's sticky risk state.
 func (s *SessionState) ObserveRisk(observation session.RiskObservation) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.risk.Observe(observation)
+}
+
+// BeginNewTask rotates the current task boundary and clears taint-only state.
+// Adaptive enforcement state remains intact.
+func (s *SessionState) BeginNewTask(label string) (prev, current session.TaskContext, clearedOverrides int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	if s.task.CurrentTaskID == "" {
+		s.task = newTaskContext("", now)
+	}
+	prev = s.task
+	s.task = newTaskContext(label, now)
+	s.risk = session.SessionRisk{}
+
+	if len(s.runtimeOverrides) > 0 {
+		kept := s.runtimeOverrides[:0]
+		for _, override := range s.runtimeOverrides {
+			if override.TaskID != "" && override.TaskID == prev.CurrentTaskID {
+				clearedOverrides++
+				continue
+			}
+			kept = append(kept, override)
+		}
+		s.runtimeOverrides = kept
+	}
+
+	return prev, s.task, clearedOverrides
+}
+
+// AddRuntimeTrustOverride stores a session-scoped trust override. Task-scoped
+// overrides are automatically bound to the current task ID.
+func (s *SessionState) AddRuntimeTrustOverride(override session.TrustOverride) session.TrustOverride {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.task.CurrentTaskID == "" {
+		s.task = newTaskContext("", time.Now())
+	}
+	if override.Scope == "task" && override.TaskID == "" {
+		override.TaskID = s.task.CurrentTaskID
+	}
+	s.runtimeOverrides = append(s.runtimeOverrides, override)
+	return override
 }
 
 // RecordBytes adds to the session's cumulative byte count.
@@ -385,17 +451,19 @@ var invocationPrefixes = []string{"mcp-stdio-", "mcp-http-", "mcp-ws-"}
 
 // SessionSnapshot is a read-only DTO for the admin API.
 type SessionSnapshot struct {
-	Key             string    `json:"key"`
-	Agent           string    `json:"agent"`
-	ClientIP        string    `json:"client_ip"`
-	Kind            string    `json:"kind"`
-	ThreatScore     float64   `json:"threat_score"`
-	EscalationLevel string    `json:"escalation_level"`
-	BlockAll        bool      `json:"block_all"`
-	AirlockTier     string    `json:"airlock_tier"`
-	TaintLevel      string    `json:"taint_level"`
-	Contaminated    bool      `json:"contaminated"`
-	LastActivity    time.Time `json:"last_activity"`
+	Key              string    `json:"key"`
+	Agent            string    `json:"agent"`
+	ClientIP         string    `json:"client_ip"`
+	Kind             string    `json:"kind"`
+	CurrentTaskID    string    `json:"current_task_id,omitempty"`
+	CurrentTaskLabel string    `json:"current_task_label,omitempty"`
+	ThreatScore      float64   `json:"threat_score"`
+	EscalationLevel  string    `json:"escalation_level"`
+	BlockAll         bool      `json:"block_all"`
+	AirlockTier      string    `json:"airlock_tier"`
+	TaintLevel       string    `json:"taint_level"`
+	Contaminated     bool      `json:"contaminated"`
+	LastActivity     time.Time `json:"last_activity"`
 }
 
 // classifySessionKey determines whether a key is an identity key or an
@@ -410,6 +478,15 @@ func classifySessionKey(key string) (kind, agent, clientIP string) {
 		return sessionKindIdentity, key[:idx], key[idx+1:]
 	}
 	return sessionKindIdentity, "", key
+}
+
+func newTaskContext(label string, now time.Time) session.TaskContext {
+	return session.TaskContext{
+		CurrentTaskID:    session.NextTaskID(),
+		CurrentTaskLabel: label,
+		StartedAt:        now.UTC(),
+		LastBoundaryAt:   now.UTC(),
+	}
 }
 
 // BaselineResult holds the outcome of a behavioral baseline deviation check.
@@ -597,6 +674,7 @@ func (sm *SessionManager) GetOrCreate(key string) *SessionState {
 		lastActivity:     now,
 		currentThreshold: 0, // set by adaptive enforcement when enabled
 		airlock:          AirlockState{tier: config.AirlockTierNone},
+		task:             newTaskContext("", now),
 	}
 	sm.sessions[key] = sess
 	if sm.metrics != nil {
@@ -708,17 +786,19 @@ func (sm *SessionManager) Snapshot() []SessionSnapshot {
 		s.mu.Lock()
 		kind, agent, ip := classifySessionKey(keys[i])
 		snaps[i] = SessionSnapshot{
-			Key:             keys[i],
-			Agent:           agent,
-			ClientIP:        ip,
-			Kind:            kind,
-			ThreatScore:     s.threatScore,
-			EscalationLevel: session.EscalationLabel(s.escalationLevel),
-			BlockAll:        s.atBlockAll,
-			AirlockTier:     s.airlock.Tier(),
-			TaintLevel:      s.risk.Level.String(),
-			Contaminated:    s.risk.Contaminated,
-			LastActivity:    s.lastActivity,
+			Key:              keys[i],
+			Agent:            agent,
+			ClientIP:         ip,
+			Kind:             kind,
+			CurrentTaskID:    s.task.CurrentTaskID,
+			CurrentTaskLabel: s.task.CurrentTaskLabel,
+			ThreatScore:      s.threatScore,
+			EscalationLevel:  session.EscalationLabel(s.escalationLevel),
+			BlockAll:         s.atBlockAll,
+			AirlockTier:      s.airlock.Tier(),
+			TaintLevel:       s.risk.Level.String(),
+			Contaminated:     s.risk.Contaminated,
+			LastActivity:     s.lastActivity,
 		}
 		s.mu.Unlock()
 	}
@@ -776,16 +856,18 @@ func (sm *SessionManager) ResetSession(key string) (prev SessionSnapshot, found 
 
 	riskSnapshot := sess.RiskSnapshot()
 	prev = SessionSnapshot{
-		Key:             key,
-		Agent:           agent,
-		ClientIP:        ip,
-		Kind:            sessionKindIdentity,
-		ThreatScore:     prevScore,
-		EscalationLevel: session.EscalationLabel(prevLevel),
-		BlockAll:        false,
-		TaintLevel:      riskSnapshot.Level.String(),
-		Contaminated:    riskSnapshot.Contaminated,
-		LastActivity:    time.Now(),
+		Key:              key,
+		Agent:            agent,
+		ClientIP:         ip,
+		Kind:             sessionKindIdentity,
+		CurrentTaskID:    sess.TaskSnapshot().CurrentTaskID,
+		CurrentTaskLabel: sess.TaskSnapshot().CurrentTaskLabel,
+		ThreatScore:      prevScore,
+		EscalationLevel:  session.EscalationLabel(prevLevel),
+		BlockAll:         false,
+		TaintLevel:       riskSnapshot.Level.String(),
+		Contaminated:     riskSnapshot.Contaminated,
+		LastActivity:     time.Now(),
 	}
 	return prev, true
 }
@@ -794,6 +876,9 @@ func (sm *SessionManager) ResetSession(key string) (prev SessionSnapshot, found 
 // invocation (MCP transport) session, which is ephemeral and not meaningful
 // to reset.
 var ErrInvocationReset = errors.New("cannot reset invocation session")
+
+// ErrTaskScopeOnly is returned when a runtime trust grant uses an unsupported scope.
+var ErrTaskScopeOnly = errors.New("runtime trust grants only support task scope")
 
 // ResetSessionIfResettable atomically looks up a session, verifies it is an
 // identity session (not invocation), and resets it under a single sm.mu.Lock.
@@ -842,18 +927,52 @@ func (sm *SessionManager) ResetSessionIfResettable(key string) (prev SessionSnap
 
 	riskSnapshot := sess.RiskSnapshot()
 	prev = SessionSnapshot{
-		Key:             key,
-		Agent:           agent,
-		ClientIP:        ip,
-		Kind:            sessionKindIdentity,
-		ThreatScore:     prevScore,
-		EscalationLevel: session.EscalationLabel(prevLevel),
-		BlockAll:        false,
-		TaintLevel:      riskSnapshot.Level.String(),
-		Contaminated:    riskSnapshot.Contaminated,
-		LastActivity:    time.Now(),
+		Key:              key,
+		Agent:            agent,
+		ClientIP:         ip,
+		Kind:             sessionKindIdentity,
+		CurrentTaskID:    sess.TaskSnapshot().CurrentTaskID,
+		CurrentTaskLabel: sess.TaskSnapshot().CurrentTaskLabel,
+		ThreatScore:      prevScore,
+		EscalationLevel:  session.EscalationLabel(prevLevel),
+		BlockAll:         false,
+		TaintLevel:       riskSnapshot.Level.String(),
+		Contaminated:     riskSnapshot.Contaminated,
+		LastActivity:     time.Now(),
 	}
 	return prev, true, nil
+}
+
+// BeginNewTask rotates the task boundary for an active session and clears
+// taint-only state while preserving adaptive profiling state.
+func (sm *SessionManager) BeginNewTask(key, label string) (prev, current session.TaskContext, clearedOverrides int, found bool) {
+	sm.mu.RLock()
+	sess, ok := sm.sessions[key]
+	sm.mu.RUnlock()
+	if !ok {
+		return session.TaskContext{}, session.TaskContext{}, 0, false
+	}
+	prev, current, clearedOverrides = sess.BeginNewTask(label)
+	return prev, current, clearedOverrides, true
+}
+
+// AddRuntimeTrustOverride binds and stores a task-scoped trust override on an
+// active session.
+func (sm *SessionManager) AddRuntimeTrustOverride(key string, override session.TrustOverride) (applied session.TrustOverride, task session.TaskContext, found bool, err error) {
+	if override.Scope != "task" {
+		return session.TrustOverride{}, session.TaskContext{}, false, ErrTaskScopeOnly
+	}
+
+	sm.mu.RLock()
+	sess, ok := sm.sessions[key]
+	sm.mu.RUnlock()
+	if !ok {
+		return session.TrustOverride{}, session.TaskContext{}, false, nil
+	}
+
+	applied = sess.AddRuntimeTrustOverride(override)
+	task = sess.TaskSnapshot()
+	return applied, task, true, nil
 }
 
 // ForceSetAirlockTier atomically looks up a session by key and sets the

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -973,24 +973,28 @@ func (sm *SessionManager) BeginNewTask(key, label string) (prev, current session
 // active session. Same identity-session guardrail as BeginNewTask applies:
 // invocation sessions cannot receive runtime trust overrides via the admin
 // API.
-func (sm *SessionManager) AddRuntimeTrustOverride(key string, override session.TrustOverride) (applied session.TrustOverride, task session.TaskContext, found bool, err error) {
+//
+// The returned “applied“ override carries the task ID that was bound under
+// the session mutex. Callers must use “applied.TaskID“ for response bodies
+// or logs — a second TaskSnapshot call outside the mutex would race against
+// concurrent BeginNewTask rotations.
+func (sm *SessionManager) AddRuntimeTrustOverride(key string, override session.TrustOverride) (applied session.TrustOverride, found bool, err error) {
 	if override.Scope != "task" {
-		return session.TrustOverride{}, session.TaskContext{}, false, ErrTaskScopeOnly
+		return session.TrustOverride{}, false, ErrTaskScopeOnly
 	}
 
 	sm.mu.RLock()
 	sess, ok := sm.sessions[key]
 	sm.mu.RUnlock()
 	if !ok {
-		return session.TrustOverride{}, session.TaskContext{}, false, nil
+		return session.TrustOverride{}, false, nil
 	}
 	if !sess.IsResettable() {
-		return session.TrustOverride{}, session.TaskContext{}, true, ErrInvocationReset
+		return session.TrustOverride{}, true, ErrInvocationReset
 	}
 
 	applied = sess.AddRuntimeTrustOverride(override)
-	task = sess.TaskSnapshot()
-	return applied, task, true, nil
+	return applied, true, nil
 }
 
 // ForceSetAirlockTier atomically looks up a session by key and sets the

--- a/internal/proxy/session_api.go
+++ b/internal/proxy/session_api.go
@@ -16,6 +16,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/session"
 )
 
 // Rate limiting constants for the session reset endpoint.
@@ -269,6 +270,20 @@ type airlockResponse struct {
 	Changed      bool   `json:"changed"`
 }
 
+type taskRequest struct {
+	Label  string `json:"label"`
+	Reason string `json:"reason"`
+}
+
+type trustOverrideRequest struct {
+	Scope       string    `json:"scope"`
+	SourceMatch string    `json:"source_match"`
+	ActionMatch string    `json:"action_match"`
+	ExpiresAt   time.Time `json:"expires_at"`
+	GrantedBy   string    `json:"granted_by"`
+	Reason      string    `json:"reason"`
+}
+
 // HandleAirlock handles POST /api/v1/sessions/{key}/airlock.
 // Accepts {"tier": "soft|hard|drain|normal"} and transitions the session's
 // airlock state. "normal" is an alias for "none" (human-friendly).
@@ -341,6 +356,166 @@ func (h *SessionAPIHandler) HandleAirlock(w http.ResponseWriter, r *http.Request
 		PreviousTier: from,
 		NewTier:      to,
 		Changed:      changed,
+	})
+}
+
+// HandleTask starts a new task boundary for an active session.
+func (h *SessionAPIHandler) HandleTask(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !h.authenticate(w, r) {
+		return
+	}
+
+	clientIP, _ := requestMeta(r)
+	if !h.checkResetRateLimit() {
+		h.logSessionAdmin("task_rate_limited", clientIP, "", "rate limit exceeded", http.StatusTooManyRequests)
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+	sm := h.loadManager(w)
+	if sm == nil {
+		return
+	}
+
+	key, ok := extractSessionKeyWithAction(r, "task")
+	if !ok {
+		h.logSessionAdmin("task_bad_key", clientIP, "", "invalid path", http.StatusBadRequest)
+		http.Error(w, "missing or invalid session key in URL path", http.StatusBadRequest)
+		return
+	}
+
+	var req taskRequest
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			h.logSessionAdmin("task_bad_body", clientIP, key, "invalid JSON", http.StatusBadRequest)
+			http.Error(w, "invalid JSON body", http.StatusBadRequest)
+			return
+		}
+	}
+
+	prev, current, cleared, found := sm.BeginNewTask(key, req.Label)
+	if !found {
+		h.logSessionAdmin("task_not_found", clientIP, key, "session not found", http.StatusNotFound)
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+
+	h.logSessionAdmin("task_ok", clientIP, key, req.Reason, http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(struct {
+		Key                     string `json:"key"`
+		PreviousTaskID          string `json:"previous_task_id"`
+		CurrentTaskID           string `json:"current_task_id"`
+		CurrentTaskLabel        string `json:"current_task_label,omitempty"`
+		TaintCleared            bool   `json:"taint_cleared"`
+		RuntimeOverridesCleared int    `json:"runtime_overrides_cleared"`
+	}{
+		Key:                     key,
+		PreviousTaskID:          prev.CurrentTaskID,
+		CurrentTaskID:           current.CurrentTaskID,
+		CurrentTaskLabel:        current.CurrentTaskLabel,
+		TaintCleared:            true,
+		RuntimeOverridesCleared: cleared,
+	})
+}
+
+// HandleTrust grants a runtime trust override bound to the current task.
+func (h *SessionAPIHandler) HandleTrust(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !h.authenticate(w, r) {
+		return
+	}
+
+	clientIP, _ := requestMeta(r)
+	if !h.checkResetRateLimit() {
+		h.logSessionAdmin("trust_rate_limited", clientIP, "", "rate limit exceeded", http.StatusTooManyRequests)
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+	sm := h.loadManager(w)
+	if sm == nil {
+		return
+	}
+
+	key, ok := extractSessionKeyWithAction(r, "trust")
+	if !ok {
+		h.logSessionAdmin("trust_bad_key", clientIP, "", "invalid path", http.StatusBadRequest)
+		http.Error(w, "missing or invalid session key in URL path", http.StatusBadRequest)
+		return
+	}
+
+	var req trustOverrideRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.logSessionAdmin("trust_bad_body", clientIP, key, "invalid JSON", http.StatusBadRequest)
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	if req.Scope != taintScopeTask {
+		h.logSessionAdmin("trust_bad_scope", clientIP, key, "invalid scope", http.StatusBadRequest)
+		http.Error(w, "invalid scope: must be task", http.StatusBadRequest)
+		return
+	}
+	if req.SourceMatch == "" && req.ActionMatch == "" {
+		h.logSessionAdmin("trust_bad_match", clientIP, key, "missing match pattern", http.StatusBadRequest)
+		http.Error(w, "source_match or action_match is required", http.StatusBadRequest)
+		return
+	}
+	if req.ExpiresAt.IsZero() || !req.ExpiresAt.After(time.Now().UTC()) {
+		h.logSessionAdmin("trust_bad_expiry", clientIP, key, "invalid expiry", http.StatusBadRequest)
+		http.Error(w, "expires_at must be in the future", http.StatusBadRequest)
+		return
+	}
+
+	override := session.TrustOverride{
+		Scope:       taintScopeTask,
+		SourceMatch: req.SourceMatch,
+		ActionMatch: req.ActionMatch,
+		ExpiresAt:   req.ExpiresAt.UTC(),
+		GrantedBy:   req.GrantedBy,
+		Reason:      req.Reason,
+	}
+	applied, task, found, err := sm.AddRuntimeTrustOverride(key, override)
+	if err != nil {
+		h.logSessionAdmin("trust_rejected", clientIP, key, err.Error(), http.StatusBadRequest)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !found {
+		h.logSessionAdmin("trust_not_found", clientIP, key, "session not found", http.StatusNotFound)
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+
+	h.logSessionAdmin("trust_ok", clientIP, key, applied.Reason, http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(struct {
+		Key         string    `json:"key"`
+		Scope       string    `json:"scope"`
+		TaskID      string    `json:"task_id"`
+		SourceMatch string    `json:"source_match,omitempty"`
+		ActionMatch string    `json:"action_match,omitempty"`
+		ExpiresAt   time.Time `json:"expires_at"`
+		GrantedBy   string    `json:"granted_by,omitempty"`
+		Reason      string    `json:"reason,omitempty"`
+	}{
+		Key:         key,
+		Scope:       applied.Scope,
+		TaskID:      task.CurrentTaskID,
+		SourceMatch: applied.SourceMatch,
+		ActionMatch: applied.ActionMatch,
+		ExpiresAt:   applied.ExpiresAt,
+		GrantedBy:   applied.GrantedBy,
+		Reason:      applied.Reason,
 	})
 }
 

--- a/internal/proxy/session_api.go
+++ b/internal/proxy/session_api.go
@@ -72,6 +72,23 @@ const (
 	apiSessionsSegment = "sessions"
 )
 
+// Admin API action names used as rate-limiter keys. Extracted so
+// there is exactly one source of truth per endpoint label.
+const (
+	sessionAPIActionReset = "reset"
+	sessionAPIActionTask  = "task"
+	sessionAPIActionTrust = "trust"
+)
+
+// rateLimiterState tracks a sliding-window request count for a
+// single admin action. One instance per action so high-volume abuse
+// of one endpoint cannot starve legitimate traffic on another during
+// incident response.
+type rateLimiterState struct {
+	reqCount    int
+	windowStart time.Time
+}
+
 // SessionAPIHandler handles the admin session management API.
 type SessionAPIHandler struct {
 	smPtr    *atomic.Pointer[SessionManager]
@@ -81,9 +98,11 @@ type SessionAPIHandler struct {
 	logger   *audit.Logger
 	apiToken string
 
-	mu          sync.Mutex
-	reqCount    int
-	windowStart time.Time
+	// limitMu guards all rate-limiter state. One limiter per admin
+	// action (reset/task/trust) so /task abuse cannot suppress
+	// /reset during incident response, and vice versa.
+	limitMu  sync.Mutex
+	limiters map[string]*rateLimiterState
 }
 
 // NewSessionAPIHandler creates a session API handler.
@@ -96,13 +115,17 @@ func NewSessionAPIHandler(
 	apiToken string,
 ) *SessionAPIHandler {
 	return &SessionAPIHandler{
-		smPtr:       smPtr,
-		etPtr:       etPtr,
-		fbPtr:       fbPtr,
-		metrics:     m,
-		logger:      logger,
-		apiToken:    apiToken,
-		windowStart: time.Now(),
+		smPtr:    smPtr,
+		etPtr:    etPtr,
+		fbPtr:    fbPtr,
+		metrics:  m,
+		logger:   logger,
+		apiToken: apiToken,
+		limiters: map[string]*rateLimiterState{
+			sessionAPIActionReset: {windowStart: time.Now()},
+			sessionAPIActionTask:  {windowStart: time.Now()},
+			sessionAPIActionTrust: {windowStart: time.Now()},
+		},
 	}
 }
 
@@ -166,19 +189,29 @@ func (h *SessionAPIHandler) HandleList(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// checkResetRateLimit enforces a sliding-window rate limit on reset requests.
-// Returns true if the request is within the limit.
-func (h *SessionAPIHandler) checkResetRateLimit() bool {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+// checkRateLimit enforces a sliding-window rate limit on a single
+// admin action (reset/task/trust). Returns true if the request is
+// within the limit. Each action has its own counter so a flood on one
+// endpoint cannot starve another during incident response — the
+// operator can hit /reset even while /task or /trust is being abused.
+func (h *SessionAPIHandler) checkRateLimit(action string) bool {
+	h.limitMu.Lock()
+	defer h.limitMu.Unlock()
 
-	now := time.Now()
-	if now.Sub(h.windowStart) > sessionAPIRateLimitWindow {
-		h.reqCount = 0
-		h.windowStart = now
+	st, ok := h.limiters[action]
+	if !ok {
+		// Defensive: if a new admin action is added without
+		// registering a limiter, fail-closed (deny) rather than
+		// silently bypass rate limiting.
+		return false
 	}
-	h.reqCount++
-	return h.reqCount <= sessionAPIRateLimitMax
+	now := time.Now()
+	if now.Sub(st.windowStart) > sessionAPIRateLimitWindow {
+		st.reqCount = 0
+		st.windowStart = now
+	}
+	st.reqCount++
+	return st.reqCount <= sessionAPIRateLimitMax
 }
 
 // extractSessionKey extracts the session key from /api/v1/sessions/{key}/reset.
@@ -210,7 +243,7 @@ func (h *SessionAPIHandler) HandleReset(w http.ResponseWriter, r *http.Request) 
 
 	clientIP, _ := requestMeta(r)
 
-	if !h.checkResetRateLimit() {
+	if !h.checkRateLimit(sessionAPIActionReset) {
 		h.logSessionAdmin("reset_rate_limited", clientIP, "", "rate limit exceeded", http.StatusTooManyRequests)
 		w.Header().Set("Retry-After", "60")
 		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
@@ -411,7 +444,7 @@ func (h *SessionAPIHandler) HandleTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	clientIP, _ := requestMeta(r)
-	if !h.checkResetRateLimit() {
+	if !h.checkRateLimit(sessionAPIActionTask) {
 		h.logSessionAdmin("task_rate_limited", clientIP, "", "rate limit exceeded", http.StatusTooManyRequests)
 		w.Header().Set("Retry-After", "60")
 		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
@@ -491,7 +524,7 @@ func (h *SessionAPIHandler) HandleTrust(w http.ResponseWriter, r *http.Request) 
 	}
 
 	clientIP, _ := requestMeta(r)
-	if !h.checkResetRateLimit() {
+	if !h.checkRateLimit(sessionAPIActionTrust) {
 		h.logSessionAdmin("trust_rate_limited", clientIP, "", "rate limit exceeded", http.StatusTooManyRequests)
 		w.Header().Set("Retry-After", "60")
 		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)

--- a/internal/proxy/session_api.go
+++ b/internal/proxy/session_api.go
@@ -6,6 +6,9 @@ package proxy
 import (
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -24,6 +27,43 @@ const (
 	sessionAPIRateLimitWindow = time.Minute
 	sessionAPIRateLimitMax    = 10
 )
+
+// sessionAPIMaxBodyBytes caps the size of admin API request bodies. These
+// endpoints accept small JSON (tier, label, trust override) and have no
+// reason to read more. The limit defends against slow-body DoS and
+// accidental large uploads.
+const sessionAPIMaxBodyBytes = 64 * 1024 // 64 KiB
+
+// decodeJSONBody is the shared strict decoder for admin API endpoints.
+// It enforces:
+//   - a hard size limit via io.LimitReader (defends against large bodies)
+//   - DisallowUnknownFields (rejects typos and field injection attempts)
+//   - exactly-one-JSON-value (rejects trailing garbage after the object)
+//
+// An empty body is treated as "no fields" (v is left at its zero value and
+// nil is returned). Callers that require a body must validate fields after
+// decoding.
+func decodeJSONBody(r *http.Request, v any) error {
+	if r.Body == nil {
+		return nil
+	}
+	dec := json.NewDecoder(io.LimitReader(r.Body, sessionAPIMaxBodyBytes))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		if errors.Is(err, io.EOF) {
+			// Empty body — acceptable for optional-body endpoints.
+			return nil
+		}
+		return fmt.Errorf("decode body: %w", err)
+	}
+	// Reject bodies with trailing data after the first JSON value. This
+	// catches multi-object smuggling and trailing garbage.
+	var trailing json.RawMessage
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return errors.New("decode body: unexpected trailing data")
+	}
+	return nil
+}
 
 // API path segment constants used in URL validation.
 const (
@@ -312,8 +352,8 @@ func (h *SessionAPIHandler) HandleAirlock(w http.ResponseWriter, r *http.Request
 	}
 
 	var req airlockRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		h.logSessionAdmin("airlock_bad_body", clientIP, key, "invalid JSON", http.StatusBadRequest)
+	if err := decodeJSONBody(r, &req); err != nil {
+		h.logSessionAdmin("airlock_bad_body", clientIP, key, err.Error(), http.StatusBadRequest)
 		http.Error(w, "invalid JSON body", http.StatusBadRequest)
 		return
 	}
@@ -389,19 +429,34 @@ func (h *SessionAPIHandler) HandleTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Body is optional for HandleTask — callers may POST with no body to
+	// rotate the task without a label/reason. decodeJSONBody treats an
+	// empty body as "no fields" and leaves req at its zero value, so a
+	// missing Content-Length or chunked transfer encoding is handled
+	// correctly without skipping the decode.
 	var req taskRequest
-	if r.Body != nil && r.ContentLength != 0 {
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			h.logSessionAdmin("task_bad_body", clientIP, key, "invalid JSON", http.StatusBadRequest)
-			http.Error(w, "invalid JSON body", http.StatusBadRequest)
-			return
-		}
+	if err := decodeJSONBody(r, &req); err != nil {
+		h.logSessionAdmin("task_bad_body", clientIP, key, err.Error(), http.StatusBadRequest)
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
 	}
 
-	prev, current, cleared, found := sm.BeginNewTask(key, req.Label)
+	prev, current, cleared, found, taskErr := sm.BeginNewTask(key, req.Label)
 	if !found {
 		h.logSessionAdmin("task_not_found", clientIP, key, "session not found", http.StatusNotFound)
 		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	if taskErr != nil {
+		// Invocation sessions are ephemeral per-request contexts and
+		// cannot be mutated via the admin API. Mirrors the guardrail on
+		// HandleReset.
+		h.logSessionAdmin("task_rejected", clientIP, key, "invocation key", http.StatusBadRequest)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(struct {
+			Error string `json:"error"`
+		}{Error: "cannot begin new task on invocation session; only identity sessions are mutable"})
 		return
 	}
 
@@ -455,8 +510,8 @@ func (h *SessionAPIHandler) HandleTrust(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var req trustOverrideRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		h.logSessionAdmin("trust_bad_body", clientIP, key, "invalid JSON", http.StatusBadRequest)
+	if err := decodeJSONBody(r, &req); err != nil {
+		h.logSessionAdmin("trust_bad_body", clientIP, key, err.Error(), http.StatusBadRequest)
 		http.Error(w, "invalid JSON body", http.StatusBadRequest)
 		return
 	}
@@ -485,14 +540,26 @@ func (h *SessionAPIHandler) HandleTrust(w http.ResponseWriter, r *http.Request) 
 		Reason:      req.Reason,
 	}
 	applied, task, found, err := sm.AddRuntimeTrustOverride(key, override)
-	if err != nil {
-		h.logSessionAdmin("trust_rejected", clientIP, key, err.Error(), http.StatusBadRequest)
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	if !found {
+	if !found && err == nil {
 		h.logSessionAdmin("trust_not_found", clientIP, key, "session not found", http.StatusNotFound)
 		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		// Distinguish invocation-session rejection from other errors so
+		// the audit trail mirrors HandleReset. Both return 400; only the
+		// error string + log tag differ.
+		if errors.Is(err, ErrInvocationReset) {
+			h.logSessionAdmin("trust_rejected", clientIP, key, "invocation key", http.StatusBadRequest)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(struct {
+				Error string `json:"error"`
+			}{Error: "cannot grant runtime trust override on invocation session; only identity sessions are mutable"})
+			return
+		}
+		h.logSessionAdmin("trust_rejected", clientIP, key, err.Error(), http.StatusBadRequest)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/internal/proxy/session_api.go
+++ b/internal/proxy/session_api.go
@@ -539,7 +539,7 @@ func (h *SessionAPIHandler) HandleTrust(w http.ResponseWriter, r *http.Request) 
 		GrantedBy:   req.GrantedBy,
 		Reason:      req.Reason,
 	}
-	applied, task, found, err := sm.AddRuntimeTrustOverride(key, override)
+	applied, found, err := sm.AddRuntimeTrustOverride(key, override)
 	if !found && err == nil {
 		h.logSessionAdmin("trust_not_found", clientIP, key, "session not found", http.StatusNotFound)
 		http.Error(w, "session not found", http.StatusNotFound)
@@ -575,9 +575,13 @@ func (h *SessionAPIHandler) HandleTrust(w http.ResponseWriter, r *http.Request) 
 		GrantedBy   string    `json:"granted_by,omitempty"`
 		Reason      string    `json:"reason,omitempty"`
 	}{
-		Key:         key,
-		Scope:       applied.Scope,
-		TaskID:      task.CurrentTaskID,
+		Key:   key,
+		Scope: applied.Scope,
+		// applied.TaskID was bound under the session mutex by
+		// SessionState.AddRuntimeTrustOverride — use it directly instead
+		// of taking a second TaskSnapshot that could race a concurrent
+		// BeginNewTask rotation.
+		TaskID:      applied.TaskID,
 		SourceMatch: applied.SourceMatch,
 		ActionMatch: applied.ActionMatch,
 		ExpiresAt:   applied.ExpiresAt,

--- a/internal/proxy/session_api_test.go
+++ b/internal/proxy/session_api_test.go
@@ -1387,3 +1387,190 @@ func TestSessionManager_AddRuntimeTrustOverride_WrongScope(t *testing.T) {
 		t.Fatalf("err = %v, want ErrTaskScopeOnly", err)
 	}
 }
+
+// TestSessionManager_WithMutableIdentitySession_BlocksConcurrentWriteLock
+// proves the helper keeps sm.mu.RLock held for the full callback duration.
+// A concurrent writer must stay blocked until the mutation callback returns.
+func TestSessionManager_WithMutableIdentitySession_BlocksConcurrentWriteLock(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	const targetKey = "agent|10.0.0.1"
+	sm.GetOrCreate(targetKey)
+
+	entered := make(chan struct{})
+	releaseMutation := make(chan struct{})
+	resultCh := make(chan struct {
+		found bool
+		err   error
+	}, 1)
+
+	go func() {
+		found, err := sm.withMutableIdentitySession(targetKey, func(_ *SessionState) {
+			close(entered)
+			<-releaseMutation
+		})
+		resultCh <- struct {
+			found bool
+			err   error
+		}{found: found, err: err}
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("mutation callback did not start")
+	}
+
+	writerAcquired := make(chan struct{})
+	writerRelease := make(chan struct{})
+	go func() {
+		sm.mu.Lock()
+		close(writerAcquired)
+		<-writerRelease
+		sm.mu.Unlock()
+	}()
+
+	select {
+	case <-writerAcquired:
+		t.Fatal("concurrent writer acquired sm.mu while mutation callback was active")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseMutation)
+
+	select {
+	case res := <-resultCh:
+		if !res.found {
+			t.Fatal("expected found=true for existing identity session")
+		}
+		if res.err != nil {
+			t.Fatalf("unexpected mutation err: %v", res.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("mutation did not complete after release")
+	}
+
+	select {
+	case <-writerAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent writer did not acquire sm.mu after mutation completed")
+	}
+	close(writerRelease)
+}
+
+// TestSessionManager_WithMutableIdentitySession_BlocksEvictionDuringMutation
+// proves that eviction-triggering writes stay blocked until the mutation
+// callback returns. This is the stale-pointer race that BeginNewTask and
+// AddRuntimeTrustOverride rely on withMutableIdentitySession to prevent.
+func TestSessionManager_WithMutableIdentitySession_BlocksEvictionDuringMutation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*SessionState) string
+	}{
+		{
+			name: "begin new task",
+			mutate: func(sess *SessionState) string {
+				_, current, _ := sess.BeginNewTask("coordinated-task")
+				return current.CurrentTaskID
+			},
+		},
+		{
+			name: "runtime trust override",
+			mutate: func(sess *SessionState) string {
+				applied := sess.AddRuntimeTrustOverride(session.TrustOverride{
+					Scope:       "task",
+					ActionMatch: "publish:*",
+					ExpiresAt:   time.Now().UTC().Add(time.Hour),
+					Reason:      "lock-span regression",
+				})
+				return applied.TaskID
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sm := NewSessionManager(&config.SessionProfiling{
+				MaxSessions:            1,
+				SessionTTLMinutes:      30,
+				CleanupIntervalSeconds: 300,
+				DomainBurst:            10,
+				WindowMinutes:          5,
+			}, nil, nil)
+			defer sm.Close()
+
+			const targetKey = "agent|10.0.0.1"
+			sm.GetOrCreate(targetKey)
+
+			entered := make(chan struct{})
+			releaseMutation := make(chan struct{})
+			resultCh := make(chan struct {
+				found     bool
+				err       error
+				mutatedID string
+			}, 1)
+
+			go func() {
+				var mutatedID string
+				found, err := sm.withMutableIdentitySession(targetKey, func(sess *SessionState) {
+					close(entered)
+					<-releaseMutation
+					mutatedID = tt.mutate(sess)
+				})
+				resultCh <- struct {
+					found     bool
+					err       error
+					mutatedID string
+				}{found: found, err: err, mutatedID: mutatedID}
+			}()
+
+			select {
+			case <-entered:
+			case <-time.After(time.Second):
+				t.Fatal("mutation callback did not start")
+			}
+
+			evictDone := make(chan struct{})
+			go func() {
+				sm.GetOrCreate("evictor|10.0.0.2")
+				close(evictDone)
+			}()
+
+			select {
+			case <-evictDone:
+				t.Fatal("GetOrCreate completed before mutation released sm.mu.RLock")
+			case <-time.After(50 * time.Millisecond):
+			}
+
+			close(releaseMutation)
+
+			var mutatedID string
+			select {
+			case res := <-resultCh:
+				if !res.found {
+					t.Fatal("expected found=true for existing identity session")
+				}
+				if res.err != nil {
+					t.Fatalf("unexpected mutation err: %v", res.err)
+				}
+				if res.mutatedID == "" {
+					t.Fatal("mutation did not produce a task ID")
+				}
+				mutatedID = res.mutatedID
+			case <-time.After(time.Second):
+				t.Fatal("mutation did not complete after release")
+			}
+
+			select {
+			case <-evictDone:
+			case <-time.After(time.Second):
+				t.Fatal("eviction-triggering GetOrCreate did not resume after mutation completed")
+			}
+
+			if got := sm.GetOrCreate(targetKey).TaskSnapshot().CurrentTaskID; got == mutatedID {
+				t.Fatalf("expected target session to be replaced after eviction, but live task ID %s still matches the pre-eviction mutation", got)
+			}
+		})
+	}
+}

--- a/internal/proxy/session_api_test.go
+++ b/internal/proxy/session_api_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -233,6 +234,90 @@ func TestSessionAPI_HandleReset_Success(t *testing.T) {
 	}
 	if sess.BlockAll() {
 		t.Error("blockAll should be cleared")
+	}
+}
+
+func TestSessionAPI_HandleTask_Success(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	sess := sm.GetOrCreate("agent-a|10.0.0.1")
+	sess.ObserveRisk(session.RiskObservation{
+		Source: session.TaintSourceRef{
+			URL:   "https://evil.example/issue/123",
+			Kind:  "http_response",
+			Level: session.TaintExternalUntrusted,
+		},
+	})
+	before := sess.TaskSnapshot()
+
+	handler := newTestSessionAPIHandler(t, sm)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/agent-a%7C10.0.0.1/task", strings.NewReader(`{"label":"new task","reason":"user started a new task"}`))
+	req.Header.Set("Authorization", "Bearer "+testSessionAPIToken)
+	w := httptest.NewRecorder()
+
+	handler.HandleTask(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		PreviousTaskID          string `json:"previous_task_id"`
+		CurrentTaskID           string `json:"current_task_id"`
+		RuntimeOverridesCleared int    `json:"runtime_overrides_cleared"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.PreviousTaskID != before.CurrentTaskID {
+		t.Fatalf("previous_task_id = %q, want %q", resp.PreviousTaskID, before.CurrentTaskID)
+	}
+	if resp.CurrentTaskID == "" || resp.CurrentTaskID == resp.PreviousTaskID {
+		t.Fatalf("expected rotated task id, got %q", resp.CurrentTaskID)
+	}
+	if sess.RiskSnapshot().Contaminated {
+		t.Fatal("task boundary should clear taint contamination")
+	}
+}
+
+func TestSessionAPI_HandleTrust_Success(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	sess := sm.GetOrCreate("agent-a|10.0.0.1")
+	task := sess.TaskSnapshot()
+
+	handler := newTestSessionAPIHandler(t, sm)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/agent-a%7C10.0.0.1/trust", strings.NewReader(fmt.Sprintf(`{"scope":"task","action_match":"publish:post:https://api.example.com/auth/update","expires_at":"%s","granted_by":"operator","reason":"same-task follow-up"}`, time.Now().UTC().Add(time.Hour).Format(time.RFC3339))))
+	req.Header.Set("Authorization", "Bearer "+testSessionAPIToken)
+	w := httptest.NewRecorder()
+
+	handler.HandleTrust(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		TaskID      string `json:"task_id"`
+		ActionMatch string `json:"action_match"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.TaskID != task.CurrentTaskID {
+		t.Fatalf("task_id = %q, want %q", resp.TaskID, task.CurrentTaskID)
+	}
+	overrides := sess.RuntimeTrustOverrides()
+	if len(overrides) != 1 {
+		t.Fatalf("runtime overrides = %d, want 1", len(overrides))
+	}
+	if overrides[0].TaskID != task.CurrentTaskID {
+		t.Fatalf("override task_id = %q, want %q", overrides[0].TaskID, task.CurrentTaskID)
+	}
+	if overrides[0].ActionMatch != resp.ActionMatch {
+		t.Fatalf("override action_match = %q, want %q", overrides[0].ActionMatch, resp.ActionMatch)
 	}
 }
 

--- a/internal/proxy/session_api_test.go
+++ b/internal/proxy/session_api_test.go
@@ -406,6 +406,72 @@ func TestSessionAPI_HandleList_NotRateLimited(t *testing.T) {
 	}
 }
 
+// TestSessionAPI_RateLimiters_Independent asserts that flooding one
+// admin endpoint does not starve another. Each mutating endpoint
+// has its own sliding-window limiter so an attacker (or a runaway
+// script) exhausting /task cannot prevent a legitimate operator
+// from hitting /reset during incident response.
+func TestSessionAPI_RateLimiters_Independent(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("agent|10.0.0.1")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	// Exhaust the /task limiter.
+	for range sessionAPIRateLimitMax {
+		req := newTaskRequest(http.MethodPost, "agent|10.0.0.1", "")
+		w := httptest.NewRecorder()
+		handler.HandleTask(w, req)
+	}
+	// One more /task request should 429 — the limiter is exhausted.
+	{
+		req := newTaskRequest(http.MethodPost, "agent|10.0.0.1", "")
+		w := httptest.NewRecorder()
+		handler.HandleTask(w, req)
+		if w.Code != http.StatusTooManyRequests {
+			t.Fatalf("exhausted /task should 429, got %d", w.Code)
+		}
+	}
+	// /reset on the same handler must still succeed — its limiter
+	// has not been touched.
+	{
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/agent%7C10.0.0.1/reset", nil)
+		req.Header.Set("Authorization", "Bearer "+testSessionAPIToken)
+		w := httptest.NewRecorder()
+		handler.HandleReset(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			t.Fatal("/task flood should not starve /reset; got 429")
+		}
+		if w.Code != http.StatusOK {
+			t.Fatalf("/reset expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	}
+	// /trust also has its own limiter and should still be fresh.
+	{
+		req := newTrustRequest(http.MethodPost, "agent|10.0.0.1",
+			`{"scope":"task","action_match":"x","expires_at":"`+futureTimestamp()+`"}`)
+		w := httptest.NewRecorder()
+		handler.HandleTrust(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			t.Fatal("/task flood should not starve /trust; got 429")
+		}
+	}
+}
+
+// TestSessionAPI_CheckRateLimit_UnknownActionDenies covers the
+// defensive fail-closed path when a bug asks the limiter about an
+// action that was never registered. The code must NOT silently
+// bypass limiting — it must deny.
+func TestSessionAPI_CheckRateLimit_UnknownActionDenies(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	if handler.checkRateLimit("nonexistent-action") {
+		t.Fatal("unknown action should fail-closed, got allowed")
+	}
+}
+
 func TestSessionAPI_HandleReset_MethodNotAllowed(t *testing.T) {
 	sm, cleanup := setupSessionAPITestManager(t)
 	defer cleanup()

--- a/internal/proxy/session_api_test.go
+++ b/internal/proxy/session_api_test.go
@@ -1422,14 +1422,25 @@ func TestSessionManager_WithMutableIdentitySession_BlocksConcurrentWriteLock(t *
 		t.Fatal("mutation callback did not start")
 	}
 
+	writerStarted := make(chan struct{})
 	writerAcquired := make(chan struct{})
 	writerRelease := make(chan struct{})
 	go func() {
+		close(writerStarted)
 		sm.mu.Lock()
 		close(writerAcquired)
 		<-writerRelease
 		sm.mu.Unlock()
 	}()
+
+	// Wait for the writer goroutine to be scheduled before checking it
+	// stays blocked. Without this handshake, a slow scheduler could make
+	// the 50ms window pass before the goroutine even reaches sm.mu.Lock().
+	select {
+	case <-writerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("writer goroutine did not start")
+	}
 
 	select {
 	case <-writerAcquired:
@@ -1531,11 +1542,19 @@ func TestSessionManager_WithMutableIdentitySession_BlocksEvictionDuringMutation(
 				t.Fatal("mutation callback did not start")
 			}
 
+			evictStarted := make(chan struct{})
 			evictDone := make(chan struct{})
 			go func() {
+				close(evictStarted)
 				sm.GetOrCreate("evictor|10.0.0.2")
 				close(evictDone)
 			}()
+
+			select {
+			case <-evictStarted:
+			case <-time.After(time.Second):
+				t.Fatal("evictor goroutine did not start")
+			}
 
 			select {
 			case <-evictDone:

--- a/internal/proxy/session_api_test.go
+++ b/internal/proxy/session_api_test.go
@@ -1258,7 +1258,7 @@ func TestSessionManager_AddRuntimeTrustOverride_InvocationRejected(t *testing.T)
 		ActionMatch: "x",
 		ExpiresAt:   time.Now().UTC().Add(time.Hour),
 	}
-	_, _, found, err := sm.AddRuntimeTrustOverride("mcp-stdio-101", override)
+	_, found, err := sm.AddRuntimeTrustOverride("mcp-stdio-101", override)
 	if !found {
 		t.Fatal("expected found=true for existing invocation session")
 	}
@@ -1292,7 +1292,7 @@ func TestSessionManager_AddRuntimeTrustOverride_NotFound(t *testing.T) {
 		ActionMatch: "x",
 		ExpiresAt:   time.Now().UTC().Add(time.Hour),
 	}
-	_, _, found, err := sm.AddRuntimeTrustOverride("no-such-session", override)
+	_, found, err := sm.AddRuntimeTrustOverride("no-such-session", override)
 	if found {
 		t.Fatal("expected found=false for nonexistent session")
 	}
@@ -1313,7 +1313,7 @@ func TestSessionManager_AddRuntimeTrustOverride_WrongScope(t *testing.T) {
 		SourceMatch: "https://docs.example",
 		ExpiresAt:   time.Now().UTC().Add(time.Hour),
 	}
-	_, _, found, err := sm.AddRuntimeTrustOverride("agent|10.0.0.1", override)
+	_, found, err := sm.AddRuntimeTrustOverride("agent|10.0.0.1", override)
 	if found {
 		t.Errorf("expected found=false when scope is wrong, got true")
 	}

--- a/internal/proxy/session_api_test.go
+++ b/internal/proxy/session_api_test.go
@@ -6,9 +6,12 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -726,5 +729,595 @@ func TestSessionAPI_ResetUnderConcurrentTraffic(t *testing.T) {
 		// Success — completed without deadlock.
 	case <-ctx.Done():
 		t.Fatal("deadlock detected: test did not complete within timeout")
+	}
+}
+
+// --- HandleTask coverage: error and guard paths ---
+
+// futureTimestamp builds a valid expires_at string one hour in the future
+// for trust-override request bodies. Extracted to avoid reading time.RFC3339
+// in every test literal.
+func futureTimestamp() string {
+	return time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+}
+
+// newTaskRequest constructs a POST /task request with the given body reader
+// and standard auth header. Returns the request ready for ServeHTTP.
+func newTaskRequest(method, key, body string) *http.Request {
+	path := "/api/v1/sessions/" + url.PathEscape(key) + "/task"
+	var r io.Reader
+	if body != "" {
+		r = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, path, r)
+	req.Header.Set("Authorization", "Bearer "+testSessionAPIToken)
+	return req
+}
+
+// newTrustRequest constructs a POST /trust request with the given body and
+// auth header.
+func newTrustRequest(method, key, body string) *http.Request {
+	path := "/api/v1/sessions/" + url.PathEscape(key) + "/trust"
+	var r io.Reader
+	if body != "" {
+		r = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, path, r)
+	req.Header.Set("Authorization", "Bearer "+testSessionAPIToken)
+	return req
+}
+
+func TestSessionAPI_HandleTask_MethodNotAllowed(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := newTaskRequest(http.MethodGet, "agent|10.0.0.1", "")
+	w := httptest.NewRecorder()
+	handler.HandleTask(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+	if allow := w.Header().Get("Allow"); allow != http.MethodPost {
+		t.Errorf("expected Allow: POST, got %q", allow)
+	}
+}
+
+func TestSessionAPI_HandleTask_Unauthorized(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/agent%7C10.0.0.1/task", nil)
+	// No Authorization header.
+	w := httptest.NewRecorder()
+	handler.HandleTask(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTask_RateLimited(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("agent|10.0.0.1")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	// Task and reset share the same limiter — exhaust it via /task.
+	for range sessionAPIRateLimitMax {
+		req := newTaskRequest(http.MethodPost, "agent|10.0.0.1", "")
+		w := httptest.NewRecorder()
+		handler.HandleTask(w, req)
+	}
+	req := newTaskRequest(http.MethodPost, "agent|10.0.0.1", "")
+	w := httptest.NewRecorder()
+	handler.HandleTask(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", w.Code)
+	}
+	if retry := w.Header().Get("Retry-After"); retry != "60" {
+		t.Errorf("expected Retry-After: 60, got %q", retry)
+	}
+}
+
+func TestSessionAPI_HandleTask_ProfilingDisabled(t *testing.T) {
+	handler := newTestSessionAPIHandler(t, nil) // nil SessionManager
+	req := newTaskRequest(http.MethodPost, "agent|10.0.0.1", "")
+	w := httptest.NewRecorder()
+	handler.HandleTask(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTask_BadKey(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	// Path missing the session key entirely.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions//task", nil)
+	req.Header.Set("Authorization", "Bearer "+testSessionAPIToken)
+	w := httptest.NewRecorder()
+	handler.HandleTask(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTask_BadBody(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("agent|10.0.0.1")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := newTaskRequest(http.MethodPost, "agent|10.0.0.1", `{"label":`) // truncated JSON
+	w := httptest.NewRecorder()
+	handler.HandleTask(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSessionAPI_HandleTask_UnknownField(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("agent|10.0.0.1")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := newTaskRequest(http.MethodPost, "agent|10.0.0.1", `{"label":"x","unknown_field":true}`)
+	w := httptest.NewRecorder()
+	handler.HandleTask(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown field, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSessionAPI_HandleTask_TrailingData(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("agent|10.0.0.1")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	// Two JSON objects back-to-back should be rejected.
+	req := newTaskRequest(http.MethodPost, "agent|10.0.0.1", `{"label":"a"}{"label":"b"}`)
+	w := httptest.NewRecorder()
+	handler.HandleTask(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for trailing data, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSessionAPI_HandleTask_EmptyBodyOK(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("agent|10.0.0.1")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	// Empty body is allowed for HandleTask — rotates the task with no
+	// label/reason. This was the chunked-body case CodeRabbit flagged.
+	req := newTaskRequest(http.MethodPost, "agent|10.0.0.1", "")
+	w := httptest.NewRecorder()
+	handler.HandleTask(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for empty body, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSessionAPI_HandleTask_NotFound(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := newTaskRequest(http.MethodPost, "ghost|10.0.0.1", `{}`)
+	w := httptest.NewRecorder()
+	handler.HandleTask(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+// TestSessionAPI_HandleTask_InvocationKeyRejected is the GPT-flagged
+// privilege-boundary bypass regression. Invocation sessions (ephemeral
+// per-request MCP keys) must not be mutable via /task, mirroring the
+// HandleReset guardrail.
+func TestSessionAPI_HandleTask_InvocationKeyRejected(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("mcp-stdio-42") // classifies as invocation (no pipe)
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := newTaskRequest(http.MethodPost, "mcp-stdio-42", `{"label":"attempt"}`)
+	w := httptest.NewRecorder()
+	handler.HandleTask(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invocation key, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "invocation session") {
+		t.Errorf("expected invocation-session error, got %q", w.Body.String())
+	}
+}
+
+// --- HandleTrust coverage: error and guard paths ---
+
+func TestSessionAPI_HandleTrust_MethodNotAllowed(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := newTrustRequest(http.MethodGet, "agent|10.0.0.1", "")
+	w := httptest.NewRecorder()
+	handler.HandleTrust(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTrust_Unauthorized(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/agent%7C10.0.0.1/trust", nil)
+	w := httptest.NewRecorder()
+	handler.HandleTrust(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTrust_RateLimited(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("agent|10.0.0.1")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	for range sessionAPIRateLimitMax {
+		req := newTrustRequest(http.MethodPost, "agent|10.0.0.1",
+			`{"scope":"task","action_match":"x","expires_at":"`+futureTimestamp()+`"}`)
+		w := httptest.NewRecorder()
+		handler.HandleTrust(w, req)
+	}
+	req := newTrustRequest(http.MethodPost, "agent|10.0.0.1",
+		`{"scope":"task","action_match":"x","expires_at":"`+futureTimestamp()+`"}`)
+	w := httptest.NewRecorder()
+	handler.HandleTrust(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTrust_ProfilingDisabled(t *testing.T) {
+	handler := newTestSessionAPIHandler(t, nil)
+	req := newTrustRequest(http.MethodPost, "agent|10.0.0.1",
+		`{"scope":"task","action_match":"x","expires_at":"`+futureTimestamp()+`"}`)
+	w := httptest.NewRecorder()
+	handler.HandleTrust(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTrust_BadKey(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions//trust", nil)
+	req.Header.Set("Authorization", "Bearer "+testSessionAPIToken)
+	w := httptest.NewRecorder()
+	handler.HandleTrust(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTrust_BadBody(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("agent|10.0.0.1")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := newTrustRequest(http.MethodPost, "agent|10.0.0.1", `{not-json`)
+	w := httptest.NewRecorder()
+	handler.HandleTrust(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTrust_UnknownField(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("agent|10.0.0.1")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := newTrustRequest(http.MethodPost, "agent|10.0.0.1",
+		`{"scope":"task","action_match":"x","expires_at":"`+futureTimestamp()+`","wildcard":true}`)
+	w := httptest.NewRecorder()
+	handler.HandleTrust(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown field, got %d", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTrust_BadScope(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("agent|10.0.0.1")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := newTrustRequest(http.MethodPost, "agent|10.0.0.1",
+		`{"scope":"source","source_match":"https://x","expires_at":"`+futureTimestamp()+`"}`)
+	w := httptest.NewRecorder()
+	handler.HandleTrust(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for non-task scope, got %d", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTrust_NoMatchPattern(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("agent|10.0.0.1")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := newTrustRequest(http.MethodPost, "agent|10.0.0.1",
+		`{"scope":"task","expires_at":"`+futureTimestamp()+`"}`)
+	w := httptest.NewRecorder()
+	handler.HandleTrust(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing match, got %d", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTrust_ExpiredOrMissing(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("agent|10.0.0.1")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	// Past expiry.
+	req := newTrustRequest(http.MethodPost, "agent|10.0.0.1",
+		`{"scope":"task","action_match":"x","expires_at":"`+time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)+`"}`)
+	w := httptest.NewRecorder()
+	handler.HandleTrust(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for past expiry, got %d", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTrust_NotFound(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := newTrustRequest(http.MethodPost, "ghost|10.0.0.1",
+		`{"scope":"task","action_match":"x","expires_at":"`+futureTimestamp()+`"}`)
+	w := httptest.NewRecorder()
+	handler.HandleTrust(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+// TestSessionAPI_HandleTrust_InvocationKeyRejected is the GPT-flagged
+// privilege-boundary bypass regression for HandleTrust.
+func TestSessionAPI_HandleTrust_InvocationKeyRejected(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("mcp-stdio-7")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := newTrustRequest(http.MethodPost, "mcp-stdio-7",
+		`{"scope":"task","action_match":"publish:*","expires_at":"`+futureTimestamp()+`"}`)
+	w := httptest.NewRecorder()
+	handler.HandleTrust(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invocation key, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "invocation session") {
+		t.Errorf("expected invocation-session error, got %q", w.Body.String())
+	}
+}
+
+func TestSessionAPI_HandleTrust_SourceMatchOnly(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("agent|10.0.0.1")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := newTrustRequest(http.MethodPost, "agent|10.0.0.1",
+		`{"scope":"task","source_match":"https://docs.example","expires_at":"`+futureTimestamp()+`"}`)
+	w := httptest.NewRecorder()
+	handler.HandleTrust(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- decodeJSONBody unit coverage ---
+
+func TestDecodeJSONBody(t *testing.T) {
+	type payload struct {
+		Name string `json:"name"`
+	}
+
+	cases := []struct {
+		name    string
+		body    string
+		wantErr bool
+		wantVal string
+	}{
+		{name: "valid", body: `{"name":"alice"}`, wantErr: false, wantVal: "alice"},
+		{name: "empty_body", body: "", wantErr: false, wantVal: ""},
+		{name: "unknown_field", body: `{"name":"x","extra":1}`, wantErr: true},
+		{name: "trailing_data", body: `{"name":"a"}garbage`, wantErr: true},
+		{name: "malformed", body: `{bad`, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var r io.Reader
+			if tc.body != "" {
+				r = strings.NewReader(tc.body)
+			}
+			req := httptest.NewRequest(http.MethodPost, "/x", r)
+			var v payload
+			err := decodeJSONBody(req, &v)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !tc.wantErr && v.Name != tc.wantVal {
+				t.Fatalf("Name = %q, want %q", v.Name, tc.wantVal)
+			}
+		})
+	}
+}
+
+// TestDecodeJSONBody_NilBody confirms the nil-body early return path.
+func TestDecodeJSONBody_NilBody(t *testing.T) {
+	var v struct {
+		Name string `json:"name"`
+	}
+	r := &http.Request{Body: nil}
+	if err := decodeJSONBody(r, &v); err != nil {
+		t.Fatalf("nil body should return nil error, got %v", err)
+	}
+}
+
+// TestDecodeJSONBody_SizeLimit confirms the size limit truncates input and
+// causes a decode error for oversized payloads.
+func TestDecodeJSONBody_SizeLimit(t *testing.T) {
+	// Build a body larger than sessionAPIMaxBodyBytes with a valid opening.
+	big := `{"name":"` + strings.Repeat("a", sessionAPIMaxBodyBytes+1) + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(big))
+	var v struct {
+		Name string `json:"name"`
+	}
+	err := decodeJSONBody(req, &v)
+	if err == nil {
+		t.Fatal("expected decode error on oversized body, got nil")
+	}
+}
+
+// --- SessionManager guard coverage ---
+
+// TestSessionManager_BeginNewTask_InvocationRejected asserts the guard at
+// the SessionManager layer rejects invocation sessions directly (not just
+// via the HTTP handler).
+func TestSessionManager_BeginNewTask_InvocationRejected(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	sm.GetOrCreate("mcp-stdio-99")
+	_, _, _, found, err := sm.BeginNewTask("mcp-stdio-99", "label")
+	if !found {
+		t.Fatal("expected found=true for existing invocation session")
+	}
+	if !errors.Is(err, ErrInvocationReset) {
+		t.Fatalf("err = %v, want ErrInvocationReset", err)
+	}
+}
+
+// TestSessionManager_AddRuntimeTrustOverride_InvocationRejected asserts
+// the guard at the SessionManager layer for AddRuntimeTrustOverride.
+func TestSessionManager_AddRuntimeTrustOverride_InvocationRejected(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	sm.GetOrCreate("mcp-stdio-101")
+	override := session.TrustOverride{
+		Scope:       "task",
+		ActionMatch: "x",
+		ExpiresAt:   time.Now().UTC().Add(time.Hour),
+	}
+	_, _, found, err := sm.AddRuntimeTrustOverride("mcp-stdio-101", override)
+	if !found {
+		t.Fatal("expected found=true for existing invocation session")
+	}
+	if !errors.Is(err, ErrInvocationReset) {
+		t.Fatalf("err = %v, want ErrInvocationReset", err)
+	}
+}
+
+// TestSessionManager_BeginNewTask_NotFound covers the no-session path.
+func TestSessionManager_BeginNewTask_NotFound(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	_, _, _, found, err := sm.BeginNewTask("no-such-session", "")
+	if found {
+		t.Fatal("expected found=false for nonexistent session")
+	}
+	if err != nil {
+		t.Fatalf("expected nil err for not-found, got %v", err)
+	}
+}
+
+// TestSessionManager_AddRuntimeTrustOverride_NotFound covers the
+// no-session path for the trust override API.
+func TestSessionManager_AddRuntimeTrustOverride_NotFound(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	override := session.TrustOverride{
+		Scope:       "task",
+		ActionMatch: "x",
+		ExpiresAt:   time.Now().UTC().Add(time.Hour),
+	}
+	_, _, found, err := sm.AddRuntimeTrustOverride("no-such-session", override)
+	if found {
+		t.Fatal("expected found=false for nonexistent session")
+	}
+	if err != nil {
+		t.Fatalf("expected nil err for not-found, got %v", err)
+	}
+}
+
+// TestSessionManager_AddRuntimeTrustOverride_WrongScope covers the
+// ErrTaskScopeOnly branch.
+func TestSessionManager_AddRuntimeTrustOverride_WrongScope(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	sm.GetOrCreate("agent|10.0.0.1")
+	override := session.TrustOverride{
+		Scope:       "source",
+		SourceMatch: "https://docs.example",
+		ExpiresAt:   time.Now().UTC().Add(time.Hour),
+	}
+	_, _, found, err := sm.AddRuntimeTrustOverride("agent|10.0.0.1", override)
+	if found {
+		t.Errorf("expected found=false when scope is wrong, got true")
+	}
+	if !errors.Is(err, ErrTaskScopeOnly) {
+		t.Fatalf("err = %v, want ErrTaskScopeOnly", err)
 	}
 }

--- a/internal/proxy/session_api_test.go
+++ b/internal/proxy/session_api_test.go
@@ -871,7 +871,7 @@ func TestSessionAPI_HandleTask_RateLimited(t *testing.T) {
 	sm.GetOrCreate("agent|10.0.0.1")
 	handler := newTestSessionAPIHandler(t, sm)
 
-	// Task and reset share the same limiter — exhaust it via /task.
+	// Exhaust the /task limiter via /task requests.
 	for range sessionAPIRateLimitMax {
 		req := newTaskRequest(http.MethodPost, "agent|10.0.0.1", "")
 		w := httptest.NewRecorder()

--- a/internal/proxy/session_taint_test.go
+++ b/internal/proxy/session_taint_test.go
@@ -62,6 +62,35 @@ func TestSessionManagerSnapshotIncludesTaint(t *testing.T) {
 	if !snaps[0].Contaminated {
 		t.Fatal("expected contaminated snapshot")
 	}
+	if snaps[0].CurrentTaskID == "" {
+		t.Fatal("expected snapshot to include current task id")
+	}
+}
+
+func TestSessionStateBeginNewTaskClearsTaintButKeepsAdaptiveState(t *testing.T) {
+	sess := &SessionState{}
+	sess.RecordSignal(session.SignalBlock, 1.0)
+	sess.ObserveRisk(session.RiskObservation{
+		Source: session.TaintSourceRef{
+			URL:   "https://evil.example/backdoor",
+			Kind:  "http_response",
+			Level: session.TaintExternalUntrusted,
+		},
+	})
+	prevTask, currentTask, _ := sess.BeginNewTask("fresh task")
+
+	if prevTask.CurrentTaskID == "" || currentTask.CurrentTaskID == "" {
+		t.Fatal("expected task ids before and after boundary")
+	}
+	if prevTask.CurrentTaskID == currentTask.CurrentTaskID {
+		t.Fatal("expected task boundary to rotate task id")
+	}
+	if sess.RiskSnapshot().Contaminated {
+		t.Fatal("new task boundary should clear taint contamination")
+	}
+	if sess.ThreatScore() == 0 {
+		t.Fatal("new task boundary should not clear adaptive threat score")
+	}
 }
 
 func TestEvaluateHTTPTaint_ExternalPublishAfterUntrustedExposureAsks(t *testing.T) {
@@ -135,5 +164,37 @@ func TestEvaluateHTTPTaint_TrustOverrideUsesActiveSourceOnly(t *testing.T) {
 	decision := evaluateHTTPTaint(cfg, sess, http.MethodPost, targetURL)
 	if decision.Result.Decision != session.PolicyAsk {
 		t.Fatalf("decision = %v, want ask when only a historical source matches", decision.Result.Decision)
+	}
+}
+
+func TestEvaluateHTTPTaint_RuntimeTaskOverrideHonorsBoundary(t *testing.T) {
+	cfg := config.Defaults()
+	sess := &SessionState{}
+
+	observeHTTPResponseTaint(sess, cfg, "https://evil.example/issue/123", "text/html", "fetch_response", false)
+	sess.AddRuntimeTrustOverride(session.TrustOverride{
+		Scope:       "task",
+		ActionMatch: "publish:post:https://api.example.com/auth/update",
+		ExpiresAt:   time.Now().UTC().Add(time.Hour),
+	})
+
+	targetURL, err := url.Parse("https://api.example.com/auth/update")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+
+	decision := evaluateHTTPTaint(cfg, sess, http.MethodPost, targetURL)
+	if decision.Result.Decision != session.PolicyAllow {
+		t.Fatalf("decision = %v, want allow", decision.Result.Decision)
+	}
+	if !decision.TaskOverrideApplied {
+		t.Fatal("expected runtime task override to be applied")
+	}
+
+	sess.BeginNewTask("next task")
+	observeHTTPResponseTaint(sess, cfg, "https://evil.example/issue/123", "text/html", "fetch_response", false)
+	decision = evaluateHTTPTaint(cfg, sess, http.MethodPost, targetURL)
+	if decision.Result.Decision != session.PolicyAsk {
+		t.Fatalf("decision after task boundary = %v, want ask", decision.Result.Decision)
 	}
 }

--- a/internal/proxy/taint.go
+++ b/internal/proxy/taint.go
@@ -17,15 +17,18 @@ import (
 const (
 	taintScopeAction = "action"
 	taintScopeSource = "source"
+	taintScopeTask   = "task"
 )
 
 type taintDecision struct {
-	Risk        session.SessionRisk
-	ActionClass session.ActionClass
-	Sensitivity session.ActionSensitivity
-	Authority   session.AuthorityKind
-	Result      session.PolicyDecisionResult
-	ActionRef   string
+	Risk                session.SessionRisk
+	Task                session.TaskContext
+	ActionClass         session.ActionClass
+	Sensitivity         session.ActionSensitivity
+	Authority           session.AuthorityKind
+	Result              session.PolicyDecisionResult
+	ActionRef           string
+	TaskOverrideApplied bool
 }
 
 func observeHTTPResponseTaint(rec session.Recorder, cfg *config.Config, rawURL, contentType, kind string, promptHit bool) {
@@ -55,6 +58,14 @@ func evaluateHTTPTaint(cfg *config.Config, rec session.Recorder, method string, 
 	}
 	decision.ActionClass, decision.Sensitivity = session.ClassifyHTTPAction(method, parsedURL.Path, cfg.Taint.ProtectedPaths, cfg.Taint.ElevatedPaths)
 	decision.ActionRef = httpActionRef(decision.ActionClass, method, parsedURL)
+	if tp, ok := rec.(session.TaskContextProvider); ok {
+		decision.Task = tp.TaskSnapshot()
+		if runtimeTrustOverrideApplies(tp.RuntimeTrustOverrides(), decision.Task, decision.Risk, decision.ActionRef) {
+			decision.Result = session.PolicyDecisionResult{Decision: session.PolicyAllow, Reason: "taint_runtime_task_override"}
+			decision.TaskOverrideApplied = true
+			return decision
+		}
+	}
 	decision.Result = session.PolicyMatrix{Profile: cfg.Taint.Policy}.Evaluate(
 		decision.Risk.Level,
 		decision.ActionClass,
@@ -122,6 +133,29 @@ func overrideMatches(override config.TaintTrustOverride, risk session.SessionRis
 	default:
 		return false
 	}
+}
+
+func runtimeTrustOverrideApplies(overrides []session.TrustOverride, task session.TaskContext, risk session.SessionRisk, actionRef string) bool {
+	now := time.Now().UTC()
+	for _, override := range overrides {
+		if override.Scope != taintScopeTask {
+			continue
+		}
+		if override.TaskID == "" || override.TaskID != task.CurrentTaskID {
+			continue
+		}
+		if !override.ExpiresAt.IsZero() && override.ExpiresAt.Before(now) {
+			continue
+		}
+		if override.ActionMatch != "" && !wildcardMatch(actionRef, override.ActionMatch) {
+			continue
+		}
+		if override.SourceMatch != "" && !riskSourceMatches(risk, override.SourceMatch) {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func riskSourceMatches(risk session.SessionRisk, pattern string) bool {

--- a/internal/receipt/action.go
+++ b/internal/receipt/action.go
@@ -135,9 +135,12 @@ type ActionRecord struct {
 	SessionTaintLevel   string                   `json:"session_taint_level,omitempty"`
 	SessionContaminated bool                     `json:"session_contaminated,omitempty"`
 	RecentTaintSources  []session.TaintSourceRef `json:"recent_taint_sources,omitempty"`
+	SessionTaskID       string                   `json:"session_task_id,omitempty"`
+	SessionTaskLabel    string                   `json:"session_task_label,omitempty"`
 	AuthorityKind       string                   `json:"authority_kind,omitempty"`
 	TaintDecision       string                   `json:"taint_decision,omitempty"`
 	TaintDecisionReason string                   `json:"taint_decision_reason,omitempty"`
+	TaskOverrideApplied bool                     `json:"task_override_applied,omitempty"`
 
 	// Transport context
 	Transport string `json:"transport"`

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -83,9 +83,12 @@ type EmitOpts struct {
 	SessionTaintLevel   string
 	SessionContaminated bool
 	RecentTaintSources  []session.TaintSourceRef
+	SessionTaskID       string
+	SessionTaskLabel    string
 	AuthorityKind       string
 	TaintDecision       string
 	TaintDecisionReason string
+	TaskOverrideApplied bool
 
 	// MCP-specific fields
 	ToolName  string
@@ -139,9 +142,12 @@ func (e *Emitter) Emit(opts EmitOpts) error {
 		SessionTaintLevel:   opts.SessionTaintLevel,
 		SessionContaminated: opts.SessionContaminated,
 		RecentTaintSources:  append([]session.TaintSourceRef(nil), opts.RecentTaintSources...),
+		SessionTaskID:       opts.SessionTaskID,
+		SessionTaskLabel:    opts.SessionTaskLabel,
 		AuthorityKind:       opts.AuthorityKind,
 		TaintDecision:       opts.TaintDecision,
 		TaintDecisionReason: opts.TaintDecisionReason,
+		TaskOverrideApplied: opts.TaskOverrideApplied,
 		Transport:           opts.Transport,
 		Method:              opts.Method,
 		Layer:               opts.Layer,

--- a/internal/receipt/emitter_test.go
+++ b/internal/receipt/emitter_test.go
@@ -199,9 +199,12 @@ func TestEmitter_Emit_TaintFields(t *testing.T) {
 		SessionTaintLevel:   session.TaintExternalUntrusted.String(),
 		SessionContaminated: true,
 		RecentTaintSources:  []session.TaintSourceRef{source},
+		SessionTaskID:       "task-123",
+		SessionTaskLabel:    "review auth fix",
 		AuthorityKind:       session.AuthorityOperatorOverride.String(),
 		TaintDecision:       "ask",
 		TaintDecisionReason: "protected_write_after_untrusted_external_exposure",
+		TaskOverrideApplied: true,
 	})
 	if err != nil {
 		t.Fatalf("Emit() error: %v", err)
@@ -220,6 +223,12 @@ func TestEmitter_Emit_TaintFields(t *testing.T) {
 	if len(got.ActionRecord.RecentTaintSources) != 1 {
 		t.Fatalf("recent_taint_sources length = %d, want 1", len(got.ActionRecord.RecentTaintSources))
 	}
+	if got.ActionRecord.SessionTaskID != "task-123" {
+		t.Fatalf("session_task_id = %q", got.ActionRecord.SessionTaskID)
+	}
+	if got.ActionRecord.SessionTaskLabel != "review auth fix" {
+		t.Fatalf("session_task_label = %q", got.ActionRecord.SessionTaskLabel)
+	}
 	if got.ActionRecord.AuthorityKind != session.AuthorityOperatorOverride.String() {
 		t.Fatalf("authority_kind = %q", got.ActionRecord.AuthorityKind)
 	}
@@ -228,6 +237,9 @@ func TestEmitter_Emit_TaintFields(t *testing.T) {
 	}
 	if got.ActionRecord.TaintDecisionReason != "protected_write_after_untrusted_external_exposure" {
 		t.Fatalf("taint_decision_reason = %q", got.ActionRecord.TaintDecisionReason)
+	}
+	if !got.ActionRecord.TaskOverrideApplied {
+		t.Fatal("expected task_override_applied to be true")
 	}
 }
 

--- a/internal/session/risk.go
+++ b/internal/session/risk.go
@@ -159,6 +159,7 @@ type RiskObservation struct {
 // TrustOverride grants a narrow, expiring trust exemption.
 type TrustOverride struct {
 	Scope       string
+	TaskID      string
 	SourceMatch string
 	ActionMatch string
 	ExpiresAt   time.Time

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -9,6 +9,7 @@ package session
 import (
 	"fmt"
 	"sync/atomic"
+	"time"
 )
 
 // SignalType identifies a threat signal for adaptive enforcement.
@@ -63,6 +64,21 @@ type Store interface {
 	GetOrCreate(key string) Recorder
 }
 
+// TaskContext describes the current task boundary attached to a live session.
+type TaskContext struct {
+	CurrentTaskID    string
+	CurrentTaskLabel string
+	StartedAt        time.Time
+	LastBoundaryAt   time.Time
+}
+
+// TaskContextProvider exposes task-boundary context and runtime trust
+// overrides without coupling callers to the proxy package.
+type TaskContextProvider interface {
+	TaskSnapshot() TaskContext
+	RuntimeTrustOverrides() []TrustOverride
+}
+
 // ToolFreezer checks whether a tool call is permitted under a frozen tool
 // inventory. Used by MCP proxy paths to enforce airlock hard-tier restrictions
 // without importing the proxy package (which would create a circular dep).
@@ -76,9 +92,17 @@ type ToolFreezer interface {
 // subprocesses start concurrently.
 var invocationCounter atomic.Uint64
 
+// taskCounter provides unique task identifiers scoped to the current process.
+var taskCounter atomic.Uint64
+
 // NextInvocationKey returns a unique session key with the given prefix.
 // Format: "<prefix>-<n>" where n is a monotonically increasing integer.
 // Safe for concurrent use.
 func NextInvocationKey(prefix string) string {
 	return fmt.Sprintf("%s-%d", prefix, invocationCounter.Add(1))
+}
+
+// NextTaskID returns a unique pipelock-owned task identifier.
+func NextTaskID() string {
+	return fmt.Sprintf("task-%d", taskCounter.Add(1))
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"sync/atomic"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // SignalType identifies a threat signal for adaptive enforcement.
@@ -92,9 +94,6 @@ type ToolFreezer interface {
 // subprocesses start concurrently.
 var invocationCounter atomic.Uint64
 
-// taskCounter provides unique task identifiers scoped to the current process.
-var taskCounter atomic.Uint64
-
 // NextInvocationKey returns a unique session key with the given prefix.
 // Format: "<prefix>-<n>" where n is a monotonically increasing integer.
 // Safe for concurrent use.
@@ -103,6 +102,22 @@ func NextInvocationKey(prefix string) string {
 }
 
 // NextTaskID returns a unique pipelock-owned task identifier.
+//
+// Task IDs are emitted in envelopes, MCP _meta, action receipts, and
+// session snapshots. They are correlation identifiers, not auth
+// tokens — but they leave the trust boundary, so using opaque
+// high-entropy UUIDv7 values prevents downstream components from
+// treating a monotonically-predictable "task-N" sequence as
+// meaningful context. Matches the UUIDv7 pattern already used for
+// action IDs in internal/receipt/action.go.
 func NextTaskID() string {
-	return fmt.Sprintf("task-%d", taskCounter.Add(1))
+	id, err := uuid.NewV7()
+	if err != nil {
+		// UUIDv7 generation fails only when crypto/rand or the
+		// clock is broken — neither happens in practice. Emit a
+		// sentinel that is clearly non-colliding and easy to
+		// grep for if it ever appears in a receipt.
+		return "task-00000000-0000-7000-8000-000000000000"
+	}
+	return "task-" + id.String()
 }


### PR DESCRIPTION
## Summary

This follow-up adds a real task boundary model for taint-aware policy escalation.

- adds session task state and explicit task boundary rotation
- adds runtime task-scoped trust grants through the session admin API
- evaluates task-scoped taint overrides against the active session task
- carries task context into receipts and mediation envelopes for auditability

## Notes

- task-scoped trust is runtime-bound to the current pipelock session task, not to agent-declared task IDs
- this PR keeps config-backed trust scopes conservative and uses the admin API for narrow task-scoped grants


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin endpoints to create/rotate session tasks and to add task-scoped runtime trust overrides.

* **Enhancements**
  * Session state now tracks task context; task IDs/labels and override flags are included in receipts, envelopes and action records.
  * Policy evaluation honors temporary task-scoped grants.
  * Kill-switch now exempts task/trust admin endpoints when API exemption is enabled.
  * Strict admin JSON parsing and per-action rate limiting with clearer admin responses.

* **Tests**
  * Expanded coverage for task lifecycle, task-scoped overrides, strict JSON decoding, rate limiting, and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->