### PR TITLE
docs: clarify hypothetical attack scenario in OpenClaw guide

### DIFF
--- a/docs/guides/openclaw.md
+++ b/docs/guides/openclaw.md
@@ -4,7 +4,9 @@ Pipelock sits between your AI agent and the OpenClaw gateway, scanning all MCP t
 
 ## Why
 
-CVE-2026-25253 (CVSS 8.8) is a cross-site WebSocket hijacking attack against OpenClaw gateways. The attack chain:
+> **Note:** The following describes a hypothetical attack scenario for illustration purposes.
+
+A cross-site WebSocket hijacking attack (similar to CSRF but for WebSockets) against OpenClaw gateways could work as follows. The attack chain:
 
 1. Victim clicks a malicious link
 2. Attacker's page opens a WebSocket to the victim's localhost gateway (no origin validation)


### PR DESCRIPTION
This PR improves the clarity of the OpenClaw integration guide by clarifying that the attack scenario described is hypothetical and for illustration purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation with hypothetical scenario examples for illustration purposes, replacing specific threat references with generic attack descriptions for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->