### PR TITLE
fix: edge-trigger airlock from adaptive escalation

### DIFF
--- a/internal/proxy/airlock.go
+++ b/internal/proxy/airlock.go
@@ -159,14 +159,6 @@ func (a *AirlockState) TryDeescalate(timers *config.AirlockTimers) (changed bool
 	return true, from, nextTier
 }
 
-// ExtendTimer resets enteredAt to now, preventing auto-deescalation while
-// the session continues to trigger airlock denials.
-func (a *AirlockState) ExtendTimer() {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.enteredAt = time.Now()
-}
-
 // RegisterCancel adds a cancel function for a long-lived connection.
 // Called when new connections are established so they can be torn down
 // on tier escalation. Stale entries (from normally-closed connections)

--- a/internal/proxy/airlock_edge_trigger_test.go
+++ b/internal/proxy/airlock_edge_trigger_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+// TestAirlockEdgeTrigger_NoPlateauReentry is the core regression test for the
+// drain -> hard -> drain deadlock that a busy retrying client could cause.
+//
+// Before the fix, recordSessionActivity mapped the session's CURRENT adaptive
+// level to an airlock tier on every request. After a drain session timer-
+// recovered to hard, the very next allowed request would observe the session
+// still sitting at "critical" adaptively and shove airlock back into drain
+// — 3 seconds after leaving it — even though no new threat had appeared.
+//
+// After the fix, airlock activation is edge-triggered: it fires only on the
+// request that actually crossed an adaptive escalation threshold.
+func TestAirlockEdgeTrigger_NoPlateauReentry(t *testing.T) {
+	cfg := adaptiveConfig()
+	cfg.Airlock.Enabled = true
+	cfg.Airlock.Triggers.OnCritical = config.AirlockTierDrain
+	cfg.Airlock.Timers.DrainMinutes = 15
+	cfg.Airlock.Timers.DrainTimeoutSeconds = 30
+
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+	m := metrics.New()
+	p, err := New(cfg, logger, sc, m)
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	defer p.Close()
+
+	// Drive the session to critical through the actual adaptive→airlock
+	// bridge (recordSessionActivity), not by reaching into raw signals.
+	// With threshold 5.0 doubling each step and SignalBlock worth 3 points,
+	// reaching level 3 (critical) takes 7 blocked-result calls.
+	blocked := scanner.Result{Allowed: false}
+	for i := 0; i < 12; i++ {
+		p.recordSessionActivity(testClientIP, agentAnonymous, "evil.example", "req-escalate", blocked, cfg, logger, false)
+		sm := p.sessionMgrPtr.Load()
+		if sm == nil {
+			t.Fatal("session manager not initialized")
+		}
+		sess := sm.GetOrCreate(testClientIP)
+		if sess.EscalationLevel() >= 3 {
+			break
+		}
+	}
+
+	sm := p.sessionMgrPtr.Load()
+	sess := sm.GetOrCreate(testClientIP)
+	if got := sess.EscalationLevel(); got < 3 {
+		t.Fatalf("pre-condition failed: expected session to reach critical (level >= 3), got level %d", got)
+	}
+	if got := sess.Airlock().Tier(); got != config.AirlockTierDrain {
+		t.Fatalf("pre-condition failed: expected airlock at %q after escalation to critical, got %q",
+			config.AirlockTierDrain, got)
+	}
+
+	// Simulate timer-based recovery drain -> hard. ForceSetTier bypasses the
+	// upward-only SetTier rule; it exists for exactly this kind of admin /
+	// timer path. The production timer path in sweepDeescalation ends up in
+	// the same state, so this is a faithful proxy for it.
+	if changed, _, _ := sess.Airlock().ForceSetTier(config.AirlockTierHard); !changed {
+		t.Fatal("ForceSetTier(hard) unexpectedly returned changed=false")
+	}
+	if got := sess.Airlock().Tier(); got != config.AirlockTierHard {
+		t.Fatalf("post-ForceSetTier state wrong: expected %q, got %q", config.AirlockTierHard, got)
+	}
+	// Adaptive level is still at critical — that's the plateau condition
+	// the bug exploited. Sanity-check it explicitly.
+	if got := sess.EscalationLevel(); got < 3 {
+		t.Fatalf("plateau precondition failed: expected level still >= 3 (critical), got %d", got)
+	}
+
+	// The next request is CLEAN. It does not cross any escalation threshold
+	// (escalated=false). Under the fix, edge-triggered airlock must NOT
+	// re-arm drain even though the session is still at critical level.
+	clean := scanner.Result{Allowed: true}
+	p.recordSessionActivity(testClientIP, agentAnonymous, "docs.example", "req-post-recovery-clean", clean, cfg, logger, false)
+
+	if got := sess.Airlock().Tier(); got != config.AirlockTierHard {
+		t.Fatalf("edge-trigger regression: expected airlock to STAY at %q after a clean plateau request, got %q (drain->hard->drain loop returned)",
+			config.AirlockTierHard, got)
+	}
+
+	// Control: a NEW blocked result that fires a fresh escalation (level
+	// will tick past the doubled threshold at this point) must still be
+	// able to re-arm drain. Edge-triggering narrows the trigger, it does
+	// not disable it.
+	for i := 0; i < 20; i++ {
+		p.recordSessionActivity(testClientIP, agentAnonymous, "evil2.example", "req-post-recovery-bad", blocked, cfg, logger, false)
+		if sess.Airlock().Tier() == config.AirlockTierDrain {
+			return
+		}
+	}
+	t.Fatalf("control case failed: blocked-result retries should eventually escalate and re-arm drain, ended at tier %q level %d",
+		sess.Airlock().Tier(), sess.EscalationLevel())
+}
+
+// TestSessionManager_SweepDeescalation_DrainToHardAfterTimeout verifies that
+// sweepDeescalation drops a drained session back to hard once wall clock has
+// advanced past the drain timeout, with adaptive enforcement enabled and
+// without any external touches to the airlock timer.
+//
+// This is the fix-direction assertion for Bug #2. Before the fix, every deny
+// path called AirlockState.ExtendTimer(), which reset enteredAt on every
+// blocked retry. The deny paths no longer reference ExtendTimer (the
+// function itself has been deleted), so a session's drain enteredAt is only
+// ever set once — at drain entry — and sweepDeescalation can observe a
+// real elapsed interval. This test locks that invariant in place.
+//
+// Regression guard: if a future refactor reintroduces a timer-extension
+// mechanism that fires on denies, this test by itself will not catch it
+// (it does not drive the HTTP handler). That surface is guarded by the
+// absence of any ExtendTimer-equivalent public method on AirlockState and
+// by the source-level fact that the four deny paths touch only the logger,
+// metrics, and response writer — see forward.go, intercept.go, websocket.go.
+func TestSessionManager_SweepDeescalation_DrainToHardAfterTimeout(t *testing.T) {
+	sessCfg := testSessionConfig()
+	adaptiveCfg := &config.AdaptiveEnforcement{
+		Enabled:              true,
+		EscalationThreshold:  adaptiveTestThreshold,
+		DecayPerCleanRequest: 0.5,
+	}
+	airlockCfg := &config.Airlock{
+		Enabled: true,
+		Timers: config.AirlockTimers{
+			// DrainTimeoutSeconds is the shorter ceiling TryDeescalate checks
+			// (it takes min(DrainMinutes*60, DrainTimeoutSeconds) as the
+			// drain duration). Keep DrainMinutes realistic and use a 1s
+			// timeout that the test crosses via enteredAt manipulation.
+			DrainMinutes:        15,
+			DrainTimeoutSeconds: 1,
+		},
+	}
+
+	sm := NewSessionManager(sessCfg, adaptiveCfg, nil, SessionManagerOptions{
+		AirlockCfg: airlockCfg,
+		Logger:     audit.NewNop(),
+	})
+	defer sm.Close()
+
+	sess := sm.GetOrCreate(testClientIP)
+
+	// Match the real-world bug state: session has reached critical on the
+	// adaptive ladder before being shoved into airlock drain.
+	escalateRec(sess, 3)
+
+	if changed, _, _ := sess.Airlock().SetTier(config.AirlockTierDrain); !changed {
+		t.Fatal("SetTier(drain) unexpectedly returned changed=false")
+	}
+
+	// Age enteredAt past the 1s drain timeout so TryDeescalate fires. This
+	// is the same technique used by TestAirlockState_TryDeescalate elsewhere
+	// in the file — avoids wall-clock sleeps and keeps the test fast and
+	// deterministic.
+	sess.Airlock().mu.Lock()
+	sess.Airlock().enteredAt = time.Now().Add(-2 * time.Second)
+	sess.Airlock().mu.Unlock()
+
+	// sweepDeescalation short-circuits when adaptive is nil/disabled, which
+	// is why airlockCfg alone is not enough — adaptiveCfg MUST be enabled
+	// for the sweep to reach the airlock-recovery block. This wiring is
+	// exercised explicitly so a future refactor cannot silently bypass it.
+	sm.sweepDeescalation()
+
+	if got := sess.Airlock().Tier(); got != config.AirlockTierHard {
+		t.Fatalf("expected sweepDeescalation to drop drain -> hard after timeout; got tier %q", got)
+	}
+}

--- a/internal/proxy/airlock_test.go
+++ b/internal/proxy/airlock_test.go
@@ -220,32 +220,6 @@ func TestAirlockState_TryDeescalate_ZeroTimerDisables(t *testing.T) {
 	}
 }
 
-func TestAirlockState_ExtendTimer(t *testing.T) {
-	a := NewAirlockState()
-	a.mu.Lock()
-	a.tier = config.AirlockTierHard
-	a.enteredAt = time.Now().Add(-10 * time.Minute)
-	a.mu.Unlock()
-
-	before := time.Now()
-	a.ExtendTimer()
-
-	a.mu.Lock()
-	entered := a.enteredAt
-	a.mu.Unlock()
-
-	if entered.Before(before) {
-		t.Error("ExtendTimer should reset enteredAt to now")
-	}
-
-	// After extension, deescalation should NOT fire (timer was 5 min default).
-	timers := &config.AirlockTimers{HardMinutes: 5}
-	changed, _, _ := a.TryDeescalate(timers)
-	if changed {
-		t.Error("deescalation should not fire after timer extension")
-	}
-}
-
 func TestAirlockState_HalfClose(t *testing.T) {
 	a := NewAirlockState()
 	called := 0

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -360,7 +360,6 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		if connectSess, ok := connectRec.(*SessionState); ok && connectSess != nil {
 			tier := connectSess.Airlock().Tier()
 			if tier == config.AirlockTierHard || tier == config.AirlockTierDrain {
-				connectSess.Airlock().ExtendTimer()
 				p.logger.LogAirlockDeny(connectSess.key, tier, TransportConnect, http.MethodConnect, clientIP, requestID)
 				p.metrics.RecordAirlockDenial(tier, TransportConnect, http.MethodConnect)
 				p.metrics.RecordTunnelBlocked(agentLabel)
@@ -633,7 +632,6 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		if tier != config.AirlockTierNone {
 			allowed, reason := ClassifyAction(tier, r.Method, TransportForward, false)
 			if !allowed {
-				forwardSess.Airlock().ExtendTimer()
 				p.logger.LogAirlockDeny(forwardSess.key, tier, TransportForward, r.Method, clientIP, requestID)
 				p.metrics.RecordAirlockDenial(tier, TransportForward, r.Method)
 				http.Error(w, "airlock: "+reason, http.StatusForbidden)

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -386,7 +386,6 @@ func newInterceptHandler(
 			if tier != config.AirlockTierNone {
 				allowed, reason := ClassifyAction(tier, r.Method, TransportConnect, true)
 				if !allowed {
-					interceptSess.Airlock().ExtendTimer()
 					ic.Logger.LogAirlockDeny(interceptSess.key, tier, TransportConnect, r.Method, ic.ClientIP, ic.RequestID)
 					ic.Metrics.RecordAirlockDenial(tier, TransportConnect, r.Method)
 					ic.Metrics.RecordTLSRequestBlocked("airlock")

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -808,6 +808,16 @@ func (p *Proxy) recordSessionActivity(clientIP, agent, hostname, requestID strin
 	anomalies = append(anomalies, ipAnomalies...)
 
 	// Record adaptive signals (only when adaptive enforcement is enabled).
+	// escalated tracks whether the current request actually crossed an
+	// adaptive escalation threshold. Downstream airlock triggering is
+	// edge-bound on this flag so a session that merely sits at a trigger
+	// level (plateau) does not repeatedly re-arm airlock on every request.
+	// Plateau triggering produced a drain -> hard -> drain deadlock under
+	// retrying clients: timer-based de-escalation would recover to hard,
+	// the next allowed request would observe the still-elevated level,
+	// slam SetTier(drain) again, and the loop never broke. See
+	// TestAirlockEdgeTrigger_NoPlateauReentry.
+	escalated := false
 	if cfg.AdaptiveEnforcement.Enabled {
 		adaptiveCfg := cfg.AdaptiveEnforcement
 		ep := decide.EscalationParams{
@@ -827,15 +837,18 @@ func (p *Proxy) recordSessionActivity(clientIP, agent, hostname, requestID strin
 			// probing should still accumulate a weak signal so the
 			// session isn't completely invisible to adaptive scoring.
 			if decide.RecordSignal(sess, session.SignalNearMiss, ep) {
+				escalated = true
 				sess.SetBlockAll(decide.UpgradeAction("", sess.EscalationLevel(), &adaptiveCfg) == config.ActionBlock)
 			}
 		} else if !result.Allowed {
 			if decide.RecordSignal(sess, session.SignalBlock, ep) {
+				escalated = true
 				// Update block_all flag so RecordRequest stops refreshing lastActivity.
 				sess.SetBlockAll(decide.UpgradeAction("", sess.EscalationLevel(), &adaptiveCfg) == config.ActionBlock)
 			}
 		} else if result.Score > 0 {
 			if decide.RecordSignal(sess, session.SignalNearMiss, ep) {
+				escalated = true
 				sess.SetBlockAll(decide.UpgradeAction("", sess.EscalationLevel(), &adaptiveCfg) == config.ActionBlock)
 			}
 		} else if !deferClean {
@@ -848,10 +861,10 @@ func (p *Proxy) recordSessionActivity(clientIP, agent, hostname, requestID strin
 
 	level := sess.EscalationLevel()
 
-	// Airlock auto-triggers: map adaptive escalation levels to airlock tiers.
-	// Only fires when airlock is enabled. sess is already *SessionState from
-	// SessionManager.GetOrCreate, so Airlock() is directly accessible.
-	if cfg.Airlock.Enabled {
+	// Airlock auto-triggers fire on adaptive escalation EDGES only, not on
+	// every request that happens to observe a session at a trigger level.
+	// See the long comment at the `escalated` declaration above.
+	if cfg.Airlock.Enabled && escalated {
 		targetTier := ""
 		switch session.EscalationLabel(level) {
 		case "elevated":

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -330,7 +330,6 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	if wsSess, ok := wsRec.(*SessionState); ok && wsSess != nil {
 		tier := wsSess.Airlock().Tier()
 		if tier == config.AirlockTierHard || tier == config.AirlockTierDrain {
-			wsSess.Airlock().ExtendTimer()
 			log.LogAirlockDeny(wsSess.key, tier, TransportWS, http.MethodGet, clientIP, requestID)
 			p.metrics.RecordAirlockDenial(tier, TransportWS, http.MethodGet)
 			p.metrics.RecordWSBlocked()


### PR DESCRIPTION
## Summary

Airlock activation from adaptive enforcement was level-polled on every request. After timer-based drain→hard recovery, the next allowed request could observe the still-critical adaptive level and re-enter drain without a new escalation, creating a drain→hard→drain loop under retrying clients. Compounded by deny paths that reset the airlock timer on every blocked retry.

- edge-trigger airlock activation: only fire `SetTier` on the request that actually crosses an adaptive escalation threshold
- remove `ExtendTimer` from the four deny paths (forward opaque CONNECT, forward absolute-URI, TLS-intercepted CONNECT, WebSocket); delete the method
- add regression tests for plateau non-reentry and drain→hard recovery during sweep deescalation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Airlock quarantine timer no longer refreshes when requests are denied.
  * Airlock tier changes now occur only on new escalation events, not on steady-state observations.

* **Tests**
  * Added tests covering airlock edge conditions and time-based tier transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->