### PR TITLE
fix: harden log context field routing

### DIFF
--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -263,6 +263,9 @@ func (c LogContext) Agent() string     { return c.agent }
 var (
 	errLogContextMissingClientIP  = errors.New("audit log context: client IP required")
 	errLogContextMissingRequestID = errors.New("audit log context: request ID required")
+	errLogContextMissingURL       = errors.New("audit log context: url required")
+	errLogContextMissingTarget    = errors.New("audit log context: target required")
+	errLogContextMissingResource  = errors.New("audit log context: resource required")
 	errLogContextIdentifierClash  = errors.New("audit log context: url, target, and resource are mutually exclusive")
 )
 
@@ -298,6 +301,9 @@ func newLogContext(method, url, target, resource, clientIP, requestID, agent str
 // (fetch, forward-proxy, WebSocket, response scan). ClientIP and RequestID are
 // required to prevent accidental omission on URL-bearing transport paths.
 func NewHTTPLogContext(method, url, clientIP, requestID, agent string) (LogContext, error) {
+	if url == "" {
+		return LogContext{}, errLogContextMissingURL
+	}
 	if clientIP == "" {
 		return LogContext{}, errLogContextMissingClientIP
 	}
@@ -310,13 +316,18 @@ func NewHTTPLogContext(method, url, clientIP, requestID, agent string) (LogConte
 // NewMCPLogContext creates a LogContext for MCP proxy requests. HTTP-specific
 // fields (ClientIP, RequestID) are omitted by design since MCP stdio has no
 // HTTP transport layer.
-func NewMCPLogContext(method, resource, agent string) LogContext {
-	ctx, _ := newLogContext(method, "", "", resource, "", "", agent)
-	return ctx
+func NewMCPLogContext(method, resource, agent string) (LogContext, error) {
+	if resource == "" {
+		return LogContext{}, errLogContextMissingResource
+	}
+	return newLogContext(method, "", "", resource, "", "", agent)
 }
 
 // NewConnectLogContext creates a LogContext for CONNECT tunnel operations.
 func NewConnectLogContext(target, clientIP, requestID, agent string) (LogContext, error) {
+	if target == "" {
+		return LogContext{}, errLogContextMissingTarget
+	}
 	if clientIP == "" {
 		return LogContext{}, errLogContextMissingClientIP
 	}
@@ -466,7 +477,7 @@ func (l *Logger) LogBlocked(ctx LogContext, scanner, reason string) {
 // LogError logs a fetch error.
 func (l *Logger) LogError(ctx LogContext, err error) {
 	e := newLogEntry(l.zl.Error(), EventError).
-		str("method", ctx.method).
+		optStr("method", ctx.method).
 		optStr("url", ctx.url).
 		optStr("target", ctx.target).
 		optStr("resource", ctx.resource).
@@ -735,6 +746,10 @@ func (l *Logger) LogForwardHTTP(ctx LogContext, statusCode, sizeBytes int, durat
 		intField("size_bytes", sizeBytes).
 		durMS(duration)
 	e.msg("forward proxy request")
+
+	if l.emitter != nil {
+		l.emitter.Emit(context.Background(), string(EventForwardHTTP), e.fields)
+	}
 }
 
 // LogRedirect logs a redirect hop in the chain.

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -6,7 +6,10 @@ package audit
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -240,48 +243,106 @@ type BundleRuleHit struct {
 //   - Target: CONNECT tunnel host:port destinations
 //   - Resource: MCP tool names, config file paths, listen addresses
 type LogContext struct {
-	Method    string
-	URL       string // actual HTTP URL
-	Target    string // CONNECT host:port
-	Resource  string // MCP tool, config path, listen address
-	ClientIP  string
-	RequestID string
-	Agent     string
+	method    string
+	url       string // actual HTTP URL
+	target    string // CONNECT host:port
+	resource  string // MCP tool, config path, listen address
+	clientIP  string
+	requestID string
+	agent     string
 }
 
-// NewHTTPLogContext creates a LogContext for HTTP proxy requests (fetch,
-// forward-proxy). ClientIP and RequestID are required to prevent accidental
-// omission on HTTP paths.
-func NewHTTPLogContext(method, url, clientIP, requestID, agent string) LogContext {
-	return LogContext{
-		Method:    method,
-		URL:       url,
-		ClientIP:  clientIP,
-		RequestID: requestID,
-		Agent:     agent,
+func (c LogContext) Method() string    { return c.method }
+func (c LogContext) URL() string       { return c.url }
+func (c LogContext) Target() string    { return c.target }
+func (c LogContext) Resource() string  { return c.resource }
+func (c LogContext) ClientIP() string  { return c.clientIP }
+func (c LogContext) RequestID() string { return c.requestID }
+func (c LogContext) Agent() string     { return c.agent }
+
+var (
+	errLogContextMissingClientIP  = errors.New("audit log context: client IP required")
+	errLogContextMissingRequestID = errors.New("audit log context: request ID required")
+	errLogContextIdentifierClash  = errors.New("audit log context: url, target, and resource are mutually exclusive")
+)
+
+func newLogContext(method, url, target, resource, clientIP, requestID, agent string) (LogContext, error) {
+	identifierCount := 0
+	if url != "" {
+		identifierCount++
 	}
+	if target != "" {
+		identifierCount++
+	}
+	if resource != "" {
+		identifierCount++
+	}
+	if identifierCount > 1 {
+		return LogContext{}, errLogContextIdentifierClash
+	}
+	if target != "" && method != http.MethodConnect {
+		return LogContext{}, fmt.Errorf("audit log context: target contexts require %q method", http.MethodConnect)
+	}
+	return LogContext{
+		method:    method,
+		url:       url,
+		target:    target,
+		resource:  resource,
+		clientIP:  clientIP,
+		requestID: requestID,
+		agent:     agent,
+	}, nil
+}
+
+// NewHTTPLogContext creates a LogContext for URL-based proxy requests
+// (fetch, forward-proxy, WebSocket, response scan). ClientIP and RequestID are
+// required to prevent accidental omission on URL-bearing transport paths.
+func NewHTTPLogContext(method, url, clientIP, requestID, agent string) (LogContext, error) {
+	if clientIP == "" {
+		return LogContext{}, errLogContextMissingClientIP
+	}
+	if requestID == "" {
+		return LogContext{}, errLogContextMissingRequestID
+	}
+	return newLogContext(method, url, "", "", clientIP, requestID, agent)
 }
 
 // NewMCPLogContext creates a LogContext for MCP proxy requests. HTTP-specific
 // fields (ClientIP, RequestID) are omitted by design since MCP stdio has no
 // HTTP transport layer.
 func NewMCPLogContext(method, resource, agent string) LogContext {
-	return LogContext{
-		Method:   method,
-		Resource: resource,
-		Agent:    agent,
-	}
+	ctx, _ := newLogContext(method, "", "", resource, "", "", agent)
+	return ctx
 }
 
 // NewConnectLogContext creates a LogContext for CONNECT tunnel operations.
-func NewConnectLogContext(target, clientIP, requestID, agent string) LogContext {
-	return LogContext{
-		Method:    "CONNECT",
-		Target:    target,
-		ClientIP:  clientIP,
-		RequestID: requestID,
-		Agent:     agent,
+func NewConnectLogContext(target, clientIP, requestID, agent string) (LogContext, error) {
+	if clientIP == "" {
+		return LogContext{}, errLogContextMissingClientIP
 	}
+	if requestID == "" {
+		return LogContext{}, errLogContextMissingRequestID
+	}
+	return newLogContext(http.MethodConnect, "", target, "", clientIP, requestID, agent)
+}
+
+// NewResourceLogContext creates a LogContext for operational events scoped to a
+// local resource such as a config path or listen address.
+func NewResourceLogContext(method, resource string) LogContext {
+	ctx, _ := newLogContext(method, "", "", resource, "", "", "")
+	return ctx
+}
+
+// NewRequestLogContext creates a LogContext scoped only to a request ID.
+func NewRequestLogContext(requestID string) LogContext {
+	ctx, _ := newLogContext("", "", "", "", "", requestID, "")
+	return ctx
+}
+
+// NewMethodLogContext creates a LogContext scoped only to an operation name.
+func NewMethodLogContext(method string) LogContext {
+	ctx, _ := newLogContext(method, "", "", "", "", "", "")
+	return ctx
 }
 
 // Logger handles structured audit logging using zerolog.
@@ -359,17 +420,21 @@ func (l *Logger) LogAllowed(ctx LogContext, statusCode, sizeBytes int, duration 
 		return
 	}
 	e := newLogEntry(l.zl.Info(), EventAllowed).
-		str("method", ctx.Method).
-		optStr("url", ctx.URL).
-		optStr("target", ctx.Target).
-		optStr("resource", ctx.Resource).
-		optStr("client_ip", ctx.ClientIP).
-		optStr("request_id", ctx.RequestID).
+		str("method", ctx.method).
+		optStr("url", ctx.url).
+		optStr("target", ctx.target).
+		optStr("resource", ctx.resource).
+		optStr("client_ip", ctx.clientIP).
+		optStr("request_id", ctx.requestID).
 		intField("status_code", statusCode).
 		intField("size_bytes", sizeBytes).
 		durMS(duration).
-		optStr("agent", ctx.Agent)
+		optStr("agent", ctx.agent)
 	e.msg("request allowed")
+
+	if l.emitter != nil {
+		l.emitter.Emit(context.Background(), string(EventAllowed), e.fields)
+	}
 }
 
 // LogBlocked logs a blocked request with the reason.
@@ -377,15 +442,15 @@ func (l *Logger) LogBlocked(ctx LogContext, scanner, reason string) {
 	technique := TechniqueForScanner(scanner)
 
 	e := newLogEntry(l.zl.Warn(), EventBlocked).
-		str("method", ctx.Method).
-		optStr("url", ctx.URL).
-		optStr("target", ctx.Target).
-		optStr("resource", ctx.Resource).
-		optStr("client_ip", ctx.ClientIP).
-		optStr("request_id", ctx.RequestID).
+		str("method", ctx.method).
+		optStr("url", ctx.url).
+		optStr("target", ctx.target).
+		optStr("resource", ctx.resource).
+		optStr("client_ip", ctx.clientIP).
+		optStr("request_id", ctx.requestID).
 		str("scanner", scanner).
 		str("reason", reason).
-		optStr("agent", ctx.Agent).
+		optStr("agent", ctx.agent).
 		optStr("mitre_technique", technique)
 
 	// includeBlocked gates local audit log only — external emission always fires
@@ -401,13 +466,13 @@ func (l *Logger) LogBlocked(ctx LogContext, scanner, reason string) {
 // LogError logs a fetch error.
 func (l *Logger) LogError(ctx LogContext, err error) {
 	e := newLogEntry(l.zl.Error(), EventError).
-		str("method", ctx.Method).
-		optStr("url", ctx.URL).
-		optStr("target", ctx.Target).
-		optStr("resource", ctx.Resource).
-		optStr("client_ip", ctx.ClientIP).
-		optStr("request_id", ctx.RequestID).
-		optStr("agent", ctx.Agent).
+		str("method", ctx.method).
+		optStr("url", ctx.url).
+		optStr("target", ctx.target).
+		optStr("resource", ctx.resource).
+		optStr("client_ip", ctx.clientIP).
+		optStr("request_id", ctx.requestID).
+		optStr("agent", ctx.agent).
 		errField(err)
 	e.msg("request error")
 
@@ -424,13 +489,13 @@ func (l *Logger) LogAnomaly(ctx LogContext, scanner, reason string, score float6
 	technique := TechniqueForScanner(scanner)
 
 	e := newLogEntry(l.zl.Warn(), EventAnomaly).
-		str("method", ctx.Method).
-		optStr("url", ctx.URL).
-		optStr("target", ctx.Target).
-		optStr("resource", ctx.Resource).
-		optStr("client_ip", ctx.ClientIP).
-		optStr("request_id", ctx.RequestID).
-		optStr("agent", ctx.Agent).
+		str("method", ctx.method).
+		optStr("url", ctx.url).
+		optStr("target", ctx.target).
+		optStr("resource", ctx.resource).
+		optStr("client_ip", ctx.clientIP).
+		optStr("request_id", ctx.requestID).
+		optStr("agent", ctx.agent).
 		optStr("scanner", scanner).
 		optStr("mitre_technique", technique).
 		str("reason", reason).
@@ -449,55 +514,55 @@ func (l *Logger) LogAnomaly(ctx LogContext, scanner, reason string, score float6
 func (l *Logger) LogResponseScanExempt(ctx LogContext, hostname string) {
 	event := l.zl.Info().
 		Str("event", string(EventResponseScanExempt)).
-		Str("method", ctx.Method)
-	if ctx.URL != "" {
-		event = event.Str("url", sanitizeString(ctx.URL))
+		Str("method", ctx.method)
+	if ctx.url != "" {
+		event = event.Str("url", sanitizeString(ctx.url))
 	}
-	if ctx.Target != "" {
-		event = event.Str("target", sanitizeString(ctx.Target))
+	if ctx.target != "" {
+		event = event.Str("target", sanitizeString(ctx.target))
 	}
-	if ctx.Resource != "" {
-		event = event.Str("resource", sanitizeString(ctx.Resource))
+	if ctx.resource != "" {
+		event = event.Str("resource", sanitizeString(ctx.resource))
 	}
 	event = event.
 		Str("hostname", hostname).
 		Str("enforcement_type", "response_scanning").
 		Str("reason", "exempt_domains match")
-	if ctx.ClientIP != "" {
-		event = event.Str("client_ip", ctx.ClientIP)
+	if ctx.clientIP != "" {
+		event = event.Str("client_ip", ctx.clientIP)
 	}
-	if ctx.RequestID != "" {
-		event = event.Str("request_id", ctx.RequestID)
+	if ctx.requestID != "" {
+		event = event.Str("request_id", ctx.requestID)
 	}
-	if ctx.Agent != "" {
-		event = event.Str("agent", sanitizeString(ctx.Agent))
+	if ctx.agent != "" {
+		event = event.Str("agent", sanitizeString(ctx.agent))
 	}
 	event.Msg("response scan skipped: exempt domain")
 
 	if l.emitter != nil {
 		fields := map[string]any{
-			"method":           ctx.Method,
+			"method":           ctx.method,
 			"hostname":         hostname,
 			"enforcement_type": "response_scanning",
 			"reason":           "exempt_domains match",
 		}
-		if ctx.URL != "" {
-			fields["url"] = sanitizeString(ctx.URL)
+		if ctx.url != "" {
+			fields["url"] = sanitizeString(ctx.url)
 		}
-		if ctx.Target != "" {
-			fields["target"] = sanitizeString(ctx.Target)
+		if ctx.target != "" {
+			fields["target"] = sanitizeString(ctx.target)
 		}
-		if ctx.Resource != "" {
-			fields["resource"] = sanitizeString(ctx.Resource)
+		if ctx.resource != "" {
+			fields["resource"] = sanitizeString(ctx.resource)
 		}
-		if ctx.ClientIP != "" {
-			fields["client_ip"] = ctx.ClientIP
+		if ctx.clientIP != "" {
+			fields["client_ip"] = ctx.clientIP
 		}
-		if ctx.RequestID != "" {
-			fields["request_id"] = ctx.RequestID
+		if ctx.requestID != "" {
+			fields["request_id"] = ctx.requestID
 		}
-		if ctx.Agent != "" {
-			fields["agent"] = sanitizeString(ctx.Agent)
+		if ctx.agent != "" {
+			fields["agent"] = sanitizeString(ctx.agent)
 		}
 		l.emitter.Emit(context.Background(), string(EventResponseScanExempt), fields)
 	}
@@ -535,11 +600,11 @@ type MediaExposureInfo struct {
 // timeline.
 func (l *Logger) LogMediaExposure(ctx LogContext, info MediaExposureInfo) {
 	e := newLogEntry(l.zl.Warn(), EventMediaExposure).
-		optStr("method", ctx.Method).
-		str("url", ctx.URL).
-		optStr("client_ip", ctx.ClientIP).
-		optStr("request_id", ctx.RequestID).
-		optStr("agent", ctx.Agent).
+		optStr("method", ctx.method).
+		str("url", ctx.url).
+		optStr("client_ip", ctx.clientIP).
+		optStr("request_id", ctx.requestID).
+		optStr("agent", ctx.agent).
 		str("transport", info.Transport).
 		str("content_type", info.ContentType).
 		optStr("format", info.Format).
@@ -573,17 +638,17 @@ func (l *Logger) LogResponseScan(ctx LogContext, action string, matchCount int, 
 	technique := TechniqueForScanner("response_scan")
 
 	e := newLogEntry(l.zl.Warn(), EventResponseScan).
-		optStr("method", ctx.Method).
-		optStr("url", ctx.URL).
-		optStr("target", ctx.Target).
-		optStr("resource", ctx.Resource).
-		optStr("client_ip", ctx.ClientIP).
-		optStr("request_id", ctx.RequestID).
+		optStr("method", ctx.method).
+		optStr("url", ctx.url).
+		optStr("target", ctx.target).
+		optStr("resource", ctx.resource).
+		optStr("client_ip", ctx.clientIP).
+		optStr("request_id", ctx.requestID).
 		str("action", action).
 		intField("match_count", matchCount).
 		strs("patterns", patternNames).
 		str("mitre_technique", technique).
-		optStr("agent", ctx.Agent)
+		optStr("agent", ctx.agent)
 	if len(bundleRules) > 0 {
 		e.bundleRulesField(bundleRules)
 	}
@@ -597,11 +662,11 @@ func (l *Logger) LogResponseScan(ctx LogContext, action string, matchCount int, 
 // LogTaintDecision logs a taint-aware policy evaluation for a sensitive action.
 func (l *Logger) LogTaintDecision(ctx LogContext, taintLevel, actionClass, sensitivity, authority, decision, reason, sourceURL, sourceKind string) {
 	e := newLogEntry(l.zl.Warn(), EventTaintDecision).
-		optStr("method", ctx.Method).
-		str("url", ctx.URL).
-		optStr("client_ip", ctx.ClientIP).
-		optStr("request_id", ctx.RequestID).
-		optStr("agent", ctx.Agent).
+		optStr("method", ctx.method).
+		str("url", ctx.url).
+		optStr("client_ip", ctx.clientIP).
+		optStr("request_id", ctx.requestID).
+		optStr("agent", ctx.agent).
 		str("session_taint_level", taintLevel).
 		str("action_class", actionClass).
 		str("action_sensitivity", sensitivity).
@@ -623,11 +688,15 @@ func (l *Logger) LogTunnelOpen(ctx LogContext) {
 		return
 	}
 	e := newLogEntry(l.zl.Info(), EventTunnelOpen).
-		optStr("target", ctx.Target).
-		optStr("client_ip", ctx.ClientIP).
-		optStr("request_id", ctx.RequestID).
-		optStr("agent", ctx.Agent)
+		optStr("target", ctx.target).
+		optStr("client_ip", ctx.clientIP).
+		optStr("request_id", ctx.requestID).
+		optStr("agent", ctx.agent)
 	e.msg("tunnel opened")
+
+	if l.emitter != nil {
+		l.emitter.Emit(context.Background(), string(EventTunnelOpen), e.fields)
+	}
 }
 
 // LogTunnelClose logs a CONNECT tunnel teardown with traffic stats.
@@ -636,13 +705,17 @@ func (l *Logger) LogTunnelClose(ctx LogContext, totalBytes int64, duration time.
 		return
 	}
 	e := newLogEntry(l.zl.Info(), EventTunnelClose).
-		optStr("target", ctx.Target).
-		optStr("client_ip", ctx.ClientIP).
-		optStr("request_id", ctx.RequestID).
-		optStr("agent", ctx.Agent).
+		optStr("target", ctx.target).
+		optStr("client_ip", ctx.clientIP).
+		optStr("request_id", ctx.requestID).
+		optStr("agent", ctx.agent).
 		int64Field("total_bytes", totalBytes).
 		durMS(duration)
 	e.msg("tunnel closed")
+
+	if l.emitter != nil {
+		l.emitter.Emit(context.Background(), string(EventTunnelClose), e.fields)
+	}
 }
 
 // LogForwardHTTP logs a forward proxy HTTP request (absolute-URI).
@@ -651,13 +724,13 @@ func (l *Logger) LogForwardHTTP(ctx LogContext, statusCode, sizeBytes int, durat
 		return
 	}
 	e := newLogEntry(l.zl.Info(), EventForwardHTTP).
-		str("method", ctx.Method).
-		optStr("url", ctx.URL).
-		optStr("target", ctx.Target).
-		optStr("resource", ctx.Resource).
-		optStr("client_ip", ctx.ClientIP).
-		optStr("request_id", ctx.RequestID).
-		optStr("agent", ctx.Agent).
+		str("method", ctx.method).
+		optStr("url", ctx.url).
+		optStr("target", ctx.target).
+		optStr("resource", ctx.resource).
+		optStr("client_ip", ctx.clientIP).
+		optStr("request_id", ctx.requestID).
+		optStr("agent", ctx.agent).
 		intField("status_code", statusCode).
 		intField("size_bytes", sizeBytes).
 		durMS(duration)
@@ -985,14 +1058,14 @@ func (l *Logger) LogBodyDLP(ctx LogContext, action string, matchCount int, patte
 	technique := TechniqueForScanner(ScannerDLP)
 
 	e := newLogEntry(l.zl.Warn(), EventBodyDLP).
-		str("method", ctx.Method).
-		optStr("url", ctx.URL).
-		optStr("target", ctx.Target).
-		optStr("resource", ctx.Resource).
+		str("method", ctx.method).
+		optStr("url", ctx.url).
+		optStr("target", ctx.target).
+		optStr("resource", ctx.resource).
 		str("action", action).
-		optStr("client_ip", ctx.ClientIP).
-		optStr("request_id", ctx.RequestID).
-		optStr("agent", ctx.Agent).
+		optStr("client_ip", ctx.clientIP).
+		optStr("request_id", ctx.requestID).
+		optStr("agent", ctx.agent).
 		intField("match_count", matchCount).
 		strs("patterns", patternNames).
 		str("mitre_technique", technique)
@@ -1010,14 +1083,14 @@ func (l *Logger) LogBodyDLP(ctx LogContext, action string, matchCount int, patte
 // Used to distinguish address_protection from body_dlp in audit output.
 func (l *Logger) LogBodyScan(ctx LogContext, eventType EventType, action string, matchCount int, findingNames []string) {
 	e := newLogEntry(l.zl.Warn(), eventType).
-		str("method", ctx.Method).
-		optStr("url", ctx.URL).
-		optStr("target", ctx.Target).
-		optStr("resource", ctx.Resource).
+		str("method", ctx.method).
+		optStr("url", ctx.url).
+		optStr("target", ctx.target).
+		optStr("resource", ctx.resource).
 		str("action", action).
-		optStr("client_ip", ctx.ClientIP).
-		optStr("request_id", ctx.RequestID).
-		optStr("agent", ctx.Agent).
+		optStr("client_ip", ctx.clientIP).
+		optStr("request_id", ctx.requestID).
+		optStr("agent", ctx.agent).
 		intField("match_count", matchCount).
 		strs("findings", findingNames)
 	e.msg("request body " + string(eventType) + " scan hit")
@@ -1033,15 +1106,15 @@ func (l *Logger) LogHeaderDLP(ctx LogContext, headerName, action string, pattern
 	technique := TechniqueForScanner(ScannerDLP)
 
 	e := newLogEntry(l.zl.Warn(), EventHeaderDLP).
-		str("method", ctx.Method).
-		optStr("url", ctx.URL).
-		optStr("target", ctx.Target).
-		optStr("resource", ctx.Resource).
+		str("method", ctx.method).
+		optStr("url", ctx.url).
+		optStr("target", ctx.target).
+		optStr("resource", ctx.resource).
 		str("header", headerName).
 		str("action", action).
-		optStr("client_ip", ctx.ClientIP).
-		optStr("request_id", ctx.RequestID).
-		optStr("agent", ctx.Agent).
+		optStr("client_ip", ctx.clientIP).
+		optStr("request_id", ctx.requestID).
+		optStr("agent", ctx.agent).
 		strs("patterns", patternNames).
 		str("mitre_technique", technique)
 	if len(bundleRules) > 0 {

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -1637,6 +1637,15 @@ func mustConnectLogContext(t *testing.T, target, clientIP, requestID, agent stri
 	return ctx
 }
 
+func mustMCPLogContext(t *testing.T, method, resource, agent string) LogContext {
+	t.Helper()
+	ctx, err := NewMCPLogContext(method, resource, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ctx
+}
+
 func assertEmitterContextFields(t *testing.T, ev emit.Event, wantKey string, wantValue any, absent ...string) {
 	t.Helper()
 	if got := ev.Fields[wantKey]; got != wantValue {
@@ -1654,17 +1663,19 @@ func TestNewHTTPLogContext_RequiresCorrelationFields(t *testing.T) {
 
 	tests := []struct {
 		name      string
+		url       string
 		clientIP  string
 		requestID string
 		wantErr   error
 	}{
-		{name: "missing_client_ip", clientIP: "", requestID: testReqID, wantErr: errLogContextMissingClientIP},
-		{name: "missing_request_id", clientIP: testClientIP, requestID: "", wantErr: errLogContextMissingRequestID},
+		{name: "missing_url", url: "", clientIP: testClientIP, requestID: testReqID, wantErr: errLogContextMissingURL},
+		{name: "missing_client_ip", url: "https://example.com", clientIP: "", requestID: testReqID, wantErr: errLogContextMissingClientIP},
+		{name: "missing_request_id", url: "https://example.com", clientIP: testClientIP, requestID: "", wantErr: errLogContextMissingRequestID},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewHTTPLogContext(testMethodGet, "https://example.com", tt.clientIP, tt.requestID, "")
+			_, err := NewHTTPLogContext(testMethodGet, tt.url, tt.clientIP, tt.requestID, "")
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("err = %v, want %v", err, tt.wantErr)
 			}
@@ -1677,21 +1688,32 @@ func TestNewConnectLogContext_RequiresCorrelationFields(t *testing.T) {
 
 	tests := []struct {
 		name      string
+		target    string
 		clientIP  string
 		requestID string
 		wantErr   error
 	}{
-		{name: "missing_client_ip", clientIP: "", requestID: testReqID, wantErr: errLogContextMissingClientIP},
-		{name: "missing_request_id", clientIP: testClientIP, requestID: "", wantErr: errLogContextMissingRequestID},
+		{name: "missing_target", target: "", clientIP: testClientIP, requestID: testReqID, wantErr: errLogContextMissingTarget},
+		{name: "missing_client_ip", target: "evil.com:443", clientIP: "", requestID: testReqID, wantErr: errLogContextMissingClientIP},
+		{name: "missing_request_id", target: "evil.com:443", clientIP: testClientIP, requestID: "", wantErr: errLogContextMissingRequestID},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewConnectLogContext("evil.com:443", tt.clientIP, tt.requestID, "")
+			_, err := NewConnectLogContext(tt.target, tt.clientIP, tt.requestID, "")
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("err = %v, want %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestNewMCPLogContext_RequiresResource(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewMCPLogContext("MCP", "", "")
+	if !errors.Is(err, errLogContextMissingResource) {
+		t.Fatalf("err = %v, want %v", err, errLogContextMissingResource)
 	}
 }
 
@@ -1760,8 +1782,8 @@ func TestEmit_LogContextFieldRouting(t *testing.T) {
 		},
 		{
 			name: "mcp_stdio_blocked_uses_resource_only",
-			emitFn: func(_ *testing.T, logger *Logger) {
-				logger.LogBlocked(NewMCPLogContext("MCP", "tools/list", testAgentName), "mcp_tool_scanning", "poisoned description")
+			emitFn: func(t *testing.T, logger *Logger) {
+				logger.LogBlocked(mustMCPLogContext(t, "MCP", "tools/list", testAgentName), "mcp_tool_scanning", "poisoned description")
 			},
 			wantType:  string(EventBlocked),
 			wantKey:   "resource",
@@ -1770,8 +1792,8 @@ func TestEmit_LogContextFieldRouting(t *testing.T) {
 		},
 		{
 			name: "mcp_http_anomaly_uses_resource_only",
-			emitFn: func(_ *testing.T, logger *Logger) {
-				logger.LogAnomaly(NewMCPLogContext("MCP", "resources/read", testAgentName), "prompt_injection", "tool output suspicious", 0.5)
+			emitFn: func(t *testing.T, logger *Logger) {
+				logger.LogAnomaly(mustMCPLogContext(t, "MCP", "resources/read", testAgentName), "prompt_injection", "tool output suspicious", 0.5)
 			},
 			wantType:  string(EventAnomaly),
 			wantKey:   "resource",
@@ -1780,8 +1802,8 @@ func TestEmit_LogContextFieldRouting(t *testing.T) {
 		},
 		{
 			name: "mcp_sse_exempt_uses_resource_only",
-			emitFn: func(_ *testing.T, logger *Logger) {
-				logger.LogResponseScanExempt(NewMCPLogContext("MCP", "prompts/get", testAgentName), "mcp.example")
+			emitFn: func(t *testing.T, logger *Logger) {
+				logger.LogResponseScanExempt(mustMCPLogContext(t, "MCP", "prompts/get", testAgentName), "mcp.example")
 			},
 			wantType:  string(EventResponseScanExempt),
 			wantKey:   "resource",
@@ -1986,6 +2008,27 @@ func TestEmit_LogResponseScan(t *testing.T) {
 	}
 	if ev.Fields["mitre_technique"] != mitreT1059 {
 		t.Errorf("fields[mitre_technique] = %v, want T1059", ev.Fields["mitre_technique"])
+	}
+}
+
+func TestEmit_LogForwardHTTP(t *testing.T) {
+	logger, sink := newLoggerWithEmitter(t)
+	defer logger.Close()
+
+	logger.LogForwardHTTP(LogContext{method: testMethodGet, url: "http://example.com/path", clientIP: testClientIP, requestID: "req-forward-http", agent: testAgentName}, 200, 2048, 100*time.Millisecond)
+
+	ev, ok := sink.lastEvent()
+	if !ok {
+		t.Fatal("expected emitted event")
+	}
+	if ev.Type != string(EventForwardHTTP) {
+		t.Fatalf("type = %q, want %s", ev.Type, EventForwardHTTP)
+	}
+	if ev.Fields["url"] != "http://example.com/path" {
+		t.Errorf("fields[url] = %v, want http://example.com/path", ev.Fields["url"])
+	}
+	if ev.Fields["status_code"] != 200 {
+		t.Errorf("fields[status_code] = %v, want 200", ev.Fields["status_code"])
 	}
 }
 
@@ -3262,7 +3305,10 @@ func TestLogContext_ResourceField_MCP(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := NewMCPLogContext("MCP", "tools/list", testAgentName)
+	ctx, err := NewMCPLogContext("MCP", "tools/list", testAgentName)
+	if err != nil {
+		t.Fatal(err)
+	}
 	logger.LogBlocked(ctx, "mcp_tool_scanning", "poisoned description")
 	logger.Close()
 

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -95,14 +96,14 @@ func TestNew_FileOutputMissingPath(t *testing.T) {
 func TestNewNop(_ *testing.T) {
 	logger := NewNop()
 	// Should not panic
-	logger.LogAllowed(LogContext{Method: testMethodGet, URL: "https://example.com", ClientIP: "127.0.0.1", RequestID: "req-1"}, 200, 1024, time.Second)
-	logger.LogBlocked(LogContext{Method: testMethodGet, URL: "https://evil.com", ClientIP: "127.0.0.1", RequestID: "req-2"}, "blocklist", "domain blocked")
-	logger.LogError(LogContext{Method: testMethodGet, URL: "https://fail.com", ClientIP: "127.0.0.1", RequestID: "req-3"}, os.ErrNotExist)
-	logger.LogAnomaly(LogContext{Method: testMethodGet, URL: "https://sus.com", ClientIP: "127.0.0.1", RequestID: "req-4"}, "entropy", "high entropy", 0.9)
+	logger.LogAllowed(LogContext{method: testMethodGet, url: "https://example.com", clientIP: "127.0.0.1", requestID: "req-1"}, 200, 1024, time.Second)
+	logger.LogBlocked(LogContext{method: testMethodGet, url: "https://evil.com", clientIP: "127.0.0.1", requestID: "req-2"}, "blocklist", "domain blocked")
+	logger.LogError(LogContext{method: testMethodGet, url: "https://fail.com", clientIP: "127.0.0.1", requestID: "req-3"}, os.ErrNotExist)
+	logger.LogAnomaly(LogContext{method: testMethodGet, url: "https://sus.com", clientIP: "127.0.0.1", requestID: "req-4"}, "entropy", "high entropy", 0.9)
 	logger.LogStartup(":8888", "balanced", testVersion, testConfigHash)
 	logger.LogShutdown("test")
 	logger.LogRedirect("https://a.com", "https://b.com", "127.0.0.1", "req-6", "", 1)
-	logger.LogResponseScan(LogContext{URL: "https://example.com", ClientIP: "127.0.0.1", RequestID: "req-8"}, testActionWarn, 2, []string{"Prompt Injection", "Jailbreak Attempt"}, nil)
+	logger.LogResponseScan(LogContext{url: "https://example.com", clientIP: "127.0.0.1", requestID: "req-8"}, testActionWarn, 2, []string{"Prompt Injection", "Jailbreak Attempt"}, nil)
 	logger.Close()
 }
 
@@ -115,7 +116,7 @@ func TestLogAllowed_Filtering(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogAllowed(LogContext{Method: testMethodGet, URL: "https://example.com", ClientIP: "127.0.0.1", RequestID: "req-1"}, 200, 1024, time.Second)
+	logger.LogAllowed(LogContext{method: testMethodGet, url: "https://example.com", clientIP: "127.0.0.1", requestID: "req-1"}, 200, 1024, time.Second)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -133,7 +134,7 @@ func TestLogBlocked_Filtering(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogBlocked(LogContext{Method: testMethodGet, URL: "https://evil.com", ClientIP: "127.0.0.1", RequestID: "req-1"}, "blocklist", "domain blocked")
+	logger.LogBlocked(LogContext{method: testMethodGet, url: "https://evil.com", clientIP: "127.0.0.1", requestID: "req-1"}, "blocklist", "domain blocked")
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -150,7 +151,7 @@ func TestLogAllowed_JSONFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogAllowed(LogContext{Method: testMethodGet, URL: "https://example.com", ClientIP: "10.0.0.5", RequestID: "req-42"}, 200, 1024, time.Second)
+	logger.LogAllowed(LogContext{method: testMethodGet, url: "https://example.com", clientIP: "10.0.0.5", requestID: "req-42"}, 200, 1024, time.Second)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -189,7 +190,7 @@ func TestLogBlocked_JSONFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogBlocked(LogContext{Method: testMethodGet, URL: "https://evil.com", ClientIP: "192.168.1.1", RequestID: testReqID}, "blocklist", "domain in blocklist")
+	logger.LogBlocked(LogContext{method: testMethodGet, url: "https://evil.com", clientIP: "192.168.1.1", requestID: testReqID}, "blocklist", "domain in blocklist")
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -223,7 +224,7 @@ func TestLogError_IncludesError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogError(LogContext{Method: testMethodGet, URL: "https://fail.com", ClientIP: testClientIP, RequestID: "req-9"}, os.ErrNotExist)
+	logger.LogError(LogContext{method: testMethodGet, url: "https://fail.com", clientIP: testClientIP, requestID: "req-9"}, os.ErrNotExist)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -321,7 +322,7 @@ func TestLogAnomaly_JSONFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogAnomaly(LogContext{Method: testMethodGet, URL: "https://sus.com/data", ClientIP: testClientIP, RequestID: "req-5"}, "entropy", "high entropy segment", 0.85)
+	logger.LogAnomaly(LogContext{method: testMethodGet, url: "https://sus.com/data", clientIP: testClientIP, requestID: "req-5"}, "entropy", "high entropy segment", 0.85)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -365,7 +366,7 @@ func TestLogResponseScanExempt_JSONFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogResponseScanExempt(LogContext{Method: testMethodGet, URL: "https://api.openai.com/v1/chat", ClientIP: testClientIP, RequestID: "req-exempt-3", Agent: testAgentName}, "api.openai.com")
+	logger.LogResponseScanExempt(LogContext{method: testMethodGet, url: "https://api.openai.com/v1/chat", clientIP: testClientIP, requestID: "req-exempt-3", agent: testAgentName}, "api.openai.com")
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -442,7 +443,7 @@ func TestLogAllowed_IncludesAllFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogAllowed(LogContext{Method: testMethodGet, URL: "https://example.com/page", ClientIP: "10.0.0.5", RequestID: "req-100"}, 200, 5000, 150*time.Millisecond)
+	logger.LogAllowed(LogContext{method: testMethodGet, url: "https://example.com/page", clientIP: "10.0.0.5", requestID: "req-100"}, 200, 5000, 150*time.Millisecond)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -490,7 +491,7 @@ func TestLogBlocked_IncludesAllFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogBlocked(LogContext{Method: testMethodGet, URL: "https://evil.com/exfil", ClientIP: "192.168.1.1", RequestID: "req-50"}, "blocklist", "domain in blocklist: evil.com")
+	logger.LogBlocked(LogContext{method: testMethodGet, url: "https://evil.com/exfil", clientIP: "192.168.1.1", requestID: "req-50"}, "blocklist", "domain in blocklist: evil.com")
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -525,7 +526,7 @@ func TestLogError_IncludesAllFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogError(LogContext{Method: testMethodGet, URL: "https://fail.com", ClientIP: testClientIP, RequestID: "req-77"}, os.ErrPermission)
+	logger.LogError(LogContext{method: testMethodGet, url: "https://fail.com", clientIP: testClientIP, requestID: "req-77"}, os.ErrPermission)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -584,10 +585,10 @@ func TestLogger_MultipleEvents(t *testing.T) {
 	}
 
 	logger.LogStartup(":8888", "balanced", testVersion, testConfigHash)
-	logger.LogAllowed(LogContext{Method: testMethodGet, URL: "https://a.com", ClientIP: testClientIP, RequestID: "req-1"}, 200, 100, time.Millisecond)
-	logger.LogBlocked(LogContext{Method: testMethodGet, URL: "https://b.com", ClientIP: testClientIP, RequestID: "req-2"}, ScannerDLP, "secret found")
-	logger.LogError(LogContext{Method: testMethodGet, URL: "https://c.com", ClientIP: testClientIP, RequestID: "req-3"}, os.ErrNotExist)
-	logger.LogAnomaly(LogContext{Method: testMethodGet, URL: "https://d.com", ClientIP: testClientIP, RequestID: "req-4"}, "", "weird", 0.5)
+	logger.LogAllowed(LogContext{method: testMethodGet, url: "https://a.com", clientIP: testClientIP, requestID: "req-1"}, 200, 100, time.Millisecond)
+	logger.LogBlocked(LogContext{method: testMethodGet, url: "https://b.com", clientIP: testClientIP, requestID: "req-2"}, ScannerDLP, "secret found")
+	logger.LogError(LogContext{method: testMethodGet, url: "https://c.com", clientIP: testClientIP, requestID: "req-3"}, os.ErrNotExist)
+	logger.LogAnomaly(LogContext{method: testMethodGet, url: "https://d.com", clientIP: testClientIP, requestID: "req-4"}, "", "weird", 0.5)
 	logger.LogShutdown("done")
 	logger.Close()
 
@@ -614,7 +615,7 @@ func TestLogResponseScan_JSONFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogResponseScan(LogContext{URL: "https://example.com/page", ClientIP: testClientIP, RequestID: "req-10"}, testActionWarn, 2, []string{"Prompt Injection", "Jailbreak Attempt"}, nil)
+	logger.LogResponseScan(LogContext{url: "https://example.com/page", clientIP: testClientIP, requestID: "req-10"}, testActionWarn, 2, []string{"Prompt Injection", "Jailbreak Attempt"}, nil)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -659,7 +660,7 @@ func TestLogResponseScan_StripAction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogResponseScan(LogContext{URL: "https://example.com/page", ClientIP: testClientIP, RequestID: "req-11"}, "strip", 1, []string{"System Override"}, nil)
+	logger.LogResponseScan(LogContext{url: "https://example.com/page", clientIP: testClientIP, requestID: "req-11"}, "strip", 1, []string{"System Override"}, nil)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -688,7 +689,7 @@ func TestLogResponseScan_BundleRulesIncluded(t *testing.T) {
 		{RuleID: "owasp-injection-001", Bundle: "owasp-top10", BundleVersion: "1.2.0"},
 		{RuleID: "custom-xss-002", Bundle: "owasp-top10", BundleVersion: "1.2.0"},
 	}
-	logger.LogResponseScan(LogContext{URL: "https://example.com/page", ClientIP: testClientIP, RequestID: "req-12"}, testActionWarn, 2,
+	logger.LogResponseScan(LogContext{url: "https://example.com/page", clientIP: testClientIP, requestID: "req-12"}, testActionWarn, 2,
 		[]string{"owasp-injection-001", "custom-xss-002"}, bundleRules)
 	logger.Close()
 
@@ -728,7 +729,7 @@ func TestLogResponseScan_NilBundleRulesOmitsField(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogResponseScan(LogContext{URL: "https://example.com/page", ClientIP: testClientIP, RequestID: "req-13"}, testActionWarn, 1, []string{"injection"}, nil)
+	logger.LogResponseScan(LogContext{url: "https://example.com/page", clientIP: testClientIP, requestID: "req-13"}, testActionWarn, 1, []string{"injection"}, nil)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -749,7 +750,7 @@ func TestEmit_LogResponseScan_BundleRules(t *testing.T) {
 	bundleRules := []BundleRuleHit{
 		{RuleID: "rule-1", Bundle: "test-bundle", BundleVersion: "0.1.0"},
 	}
-	logger.LogResponseScan(LogContext{URL: "https://example.com", ClientIP: testClientIP, RequestID: "req-14"}, testActionWarn, 1, []string{"rule-1"}, bundleRules)
+	logger.LogResponseScan(LogContext{url: "https://example.com", clientIP: testClientIP, requestID: "req-14"}, testActionWarn, 1, []string{"rule-1"}, bundleRules)
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -774,7 +775,7 @@ func TestEmit_LogResponseScan_NilBundleRulesOmitsField(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogResponseScan(LogContext{URL: "https://example.com", ClientIP: testClientIP, RequestID: "req-15"}, testActionWarn, 1, []string{"injection"}, nil)
+	logger.LogResponseScan(LogContext{url: "https://example.com", clientIP: testClientIP, requestID: "req-15"}, testActionWarn, 1, []string{"injection"}, nil)
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -829,7 +830,7 @@ func TestLogBodyDLP_BundleRulesIncluded(t *testing.T) {
 	bundleRules := []BundleRuleHit{
 		{RuleID: "dlp-rule-1", Bundle: "dlp-bundle", BundleVersion: "3.0.0"},
 	}
-	logger.LogBodyDLP(LogContext{Method: "POST", URL: "https://api.example.com", ClientIP: testClientIP, RequestID: "req-54"}, testActionWarn, 1, []string{"dlp-rule-1"}, bundleRules)
+	logger.LogBodyDLP(LogContext{method: "POST", url: "https://api.example.com", clientIP: testClientIP, requestID: "req-54"}, testActionWarn, 1, []string{"dlp-rule-1"}, bundleRules)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -862,7 +863,7 @@ func TestLogHeaderDLP_BundleRulesIncluded(t *testing.T) {
 	bundleRules := []BundleRuleHit{
 		{RuleID: "hdr-rule-1", Bundle: "hdr-bundle", BundleVersion: "1.0.0"},
 	}
-	logger.LogHeaderDLP(LogContext{Method: testMethodGet, URL: "https://api.example.com", ClientIP: testClientIP, RequestID: "req-55"}, "Authorization", testActionWarn, []string{"hdr-rule-1"}, bundleRules)
+	logger.LogHeaderDLP(LogContext{method: testMethodGet, url: "https://api.example.com", clientIP: testClientIP, requestID: "req-55"}, "Authorization", testActionWarn, []string{"hdr-rule-1"}, bundleRules)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -894,7 +895,7 @@ func TestLogger_With(t *testing.T) {
 	}
 
 	sub := logger.With("agent", "test-bot")
-	sub.LogAllowed(LogContext{Method: testMethodGet, URL: "https://example.com", ClientIP: testClientIP, RequestID: "req-1"}, 200, 100, time.Millisecond)
+	sub.LogAllowed(LogContext{method: testMethodGet, url: "https://example.com", clientIP: testClientIP, requestID: "req-1"}, 200, 100, time.Millisecond)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -924,7 +925,7 @@ func TestLogger_With_DoesNotAffectParent(t *testing.T) {
 	}
 
 	_ = logger.With("agent", "child-bot")
-	logger.LogAllowed(LogContext{Method: testMethodGet, URL: "https://example.com", ClientIP: testClientIP, RequestID: "req-1"}, 200, 100, time.Millisecond)
+	logger.LogAllowed(LogContext{method: testMethodGet, url: "https://example.com", clientIP: testClientIP, requestID: "req-1"}, 200, 100, time.Millisecond)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -949,7 +950,7 @@ func TestLogger_With_InheritsConfig(t *testing.T) {
 	}
 
 	sub := logger.With("agent", "test-bot")
-	sub.LogAllowed(LogContext{Method: testMethodGet, URL: "https://example.com", ClientIP: testClientIP, RequestID: "req-1"}, 200, 100, time.Millisecond)
+	sub.LogAllowed(LogContext{method: testMethodGet, url: "https://example.com", clientIP: testClientIP, requestID: "req-1"}, 200, 100, time.Millisecond)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -1004,7 +1005,7 @@ func TestLogTunnelOpen_JSONFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogTunnelOpen(LogContext{Target: "example.com:443", ClientIP: "10.0.0.5", RequestID: "req-100"})
+	logger.LogTunnelOpen(LogContext{target: "example.com:443", clientIP: "10.0.0.5", requestID: "req-100"})
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -1035,7 +1036,7 @@ func TestLogTunnelOpen_Filtered(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogTunnelOpen(LogContext{Target: "example.com:443", ClientIP: "10.0.0.5", RequestID: "req-100"})
+	logger.LogTunnelOpen(LogContext{target: "example.com:443", clientIP: "10.0.0.5", requestID: "req-100"})
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -1052,7 +1053,7 @@ func TestLogTunnelClose_JSONFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogTunnelClose(LogContext{Target: "example.com:443", ClientIP: "10.0.0.5", RequestID: "req-100"}, 4096, 5*time.Second)
+	logger.LogTunnelClose(LogContext{target: "example.com:443", clientIP: "10.0.0.5", requestID: "req-100"}, 4096, 5*time.Second)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -1084,7 +1085,7 @@ func TestLogTunnelClose_Filtered(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogTunnelClose(LogContext{Target: "example.com:443", ClientIP: "10.0.0.5", RequestID: "req-100"}, 4096, 5*time.Second)
+	logger.LogTunnelClose(LogContext{target: "example.com:443", clientIP: "10.0.0.5", requestID: "req-100"}, 4096, 5*time.Second)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -1101,7 +1102,7 @@ func TestLogForwardHTTP_JSONFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogForwardHTTP(LogContext{Method: testMethodGet, URL: "http://example.com/path", ClientIP: "10.0.0.5", RequestID: "req-200"}, 200, 2048, 100*time.Millisecond)
+	logger.LogForwardHTTP(LogContext{method: testMethodGet, url: "http://example.com/path", clientIP: "10.0.0.5", requestID: "req-200"}, 200, 2048, 100*time.Millisecond)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -1140,7 +1141,7 @@ func TestLogForwardHTTP_Filtered(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogForwardHTTP(LogContext{Method: testMethodGet, URL: "http://example.com/path", ClientIP: "10.0.0.5", RequestID: "req-200"}, 200, 2048, 100*time.Millisecond)
+	logger.LogForwardHTTP(LogContext{method: testMethodGet, url: "http://example.com/path", clientIP: "10.0.0.5", requestID: "req-200"}, 200, 2048, 100*time.Millisecond)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -1585,7 +1586,7 @@ func TestLogTunnelOpen_SanitizesTarget(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogTunnelOpen(LogContext{Target: "evil\x1b[2J.com:443", ClientIP: "10.0.0.5", RequestID: "req-101"})
+	logger.LogTunnelOpen(LogContext{target: "evil\x1b[2J.com:443", clientIP: "10.0.0.5", requestID: "req-101"})
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -1618,11 +1619,231 @@ func newLoggerWithEmitter(t *testing.T) (*Logger, *collectingSink) {
 	return logger, sink
 }
 
+func mustHTTPLogContext(t *testing.T, method, targetURL, requestID string) LogContext {
+	t.Helper()
+	ctx, err := NewHTTPLogContext(method, targetURL, testClientIP, requestID, testAgentName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ctx
+}
+
+func mustConnectLogContext(t *testing.T, target, clientIP, requestID, agent string) LogContext {
+	t.Helper()
+	ctx, err := NewConnectLogContext(target, clientIP, requestID, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ctx
+}
+
+func assertEmitterContextFields(t *testing.T, ev emit.Event, wantKey string, wantValue any, absent ...string) {
+	t.Helper()
+	if got := ev.Fields[wantKey]; got != wantValue {
+		t.Fatalf("fields[%s] = %v, want %v", wantKey, got, wantValue)
+	}
+	for _, key := range absent {
+		if _, exists := ev.Fields[key]; exists {
+			t.Fatalf("expected %q to be absent, got %v", key, ev.Fields[key])
+		}
+	}
+}
+
+func TestNewHTTPLogContext_RequiresCorrelationFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		clientIP  string
+		requestID string
+		wantErr   error
+	}{
+		{name: "missing_client_ip", clientIP: "", requestID: testReqID, wantErr: errLogContextMissingClientIP},
+		{name: "missing_request_id", clientIP: testClientIP, requestID: "", wantErr: errLogContextMissingRequestID},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewHTTPLogContext(testMethodGet, "https://example.com", tt.clientIP, tt.requestID, "")
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewConnectLogContext_RequiresCorrelationFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		clientIP  string
+		requestID string
+		wantErr   error
+	}{
+		{name: "missing_client_ip", clientIP: "", requestID: testReqID, wantErr: errLogContextMissingClientIP},
+		{name: "missing_request_id", clientIP: testClientIP, requestID: "", wantErr: errLogContextMissingRequestID},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewConnectLogContext("evil.com:443", tt.clientIP, tt.requestID, "")
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewLogContext_RejectsInvalidIdentifierCombinations(t *testing.T) {
+	t.Parallel()
+
+	_, err := newLogContext(testMethodGet, "https://example.com", "example.com:443", "", testClientIP, testReqID, "")
+	if !errors.Is(err, errLogContextIdentifierClash) {
+		t.Fatalf("err = %v, want %v", err, errLogContextIdentifierClash)
+	}
+
+	_, err = newLogContext(testMethodGet, "", "example.com:443", "", testClientIP, testReqID, "")
+	if err == nil || !strings.Contains(err.Error(), "target contexts require") {
+		t.Fatalf("err = %v, want target method validation error", err)
+	}
+}
+
+func TestEmit_LogContextFieldRouting(t *testing.T) {
+	tests := []struct {
+		name      string
+		emitFn    func(*testing.T, *Logger)
+		wantType  string
+		wantKey   string
+		wantValue string
+		absent    []string
+	}{
+		{
+			name: "fetch_allowed_uses_url_only",
+			emitFn: func(t *testing.T, logger *Logger) {
+				logger.LogAllowed(mustHTTPLogContext(t, testMethodGet, "https://fetch.example/path", "req-fetch"), 200, 64, time.Millisecond)
+			},
+			wantType:  string(EventAllowed),
+			wantKey:   "url",
+			wantValue: "https://fetch.example/path",
+			absent:    []string{"target", "resource"},
+		},
+		{
+			name: "forward_blocked_uses_url_only",
+			emitFn: func(t *testing.T, logger *Logger) {
+				logger.LogBlocked(mustHTTPLogContext(t, "POST", "http://forward.example/path", "req-forward"), "blocklist", "blocked")
+			},
+			wantType:  string(EventBlocked),
+			wantKey:   "url",
+			wantValue: "http://forward.example/path",
+			absent:    []string{"target", "resource"},
+		},
+		{
+			name: "websocket_response_scan_uses_url_only",
+			emitFn: func(t *testing.T, logger *Logger) {
+				logger.LogResponseScan(mustHTTPLogContext(t, "WS", "wss://socket.example/stream", "req-ws-scan"), testActionWarn, 1, []string{"injection"}, nil)
+			},
+			wantType:  string(EventResponseScan),
+			wantKey:   "url",
+			wantValue: "wss://socket.example/stream",
+			absent:    []string{"target", "resource"},
+		},
+		{
+			name: "websocket_exempt_uses_url_only",
+			emitFn: func(t *testing.T, logger *Logger) {
+				logger.LogResponseScanExempt(mustHTTPLogContext(t, "WS", "ws://socket.example/stream", "req-ws-exempt"), "socket.example")
+			},
+			wantType:  string(EventResponseScanExempt),
+			wantKey:   "url",
+			wantValue: "ws://socket.example/stream",
+			absent:    []string{"target", "resource"},
+		},
+		{
+			name: "mcp_stdio_blocked_uses_resource_only",
+			emitFn: func(_ *testing.T, logger *Logger) {
+				logger.LogBlocked(NewMCPLogContext("MCP", "tools/list", testAgentName), "mcp_tool_scanning", "poisoned description")
+			},
+			wantType:  string(EventBlocked),
+			wantKey:   "resource",
+			wantValue: "tools/list",
+			absent:    []string{"url", "target"},
+		},
+		{
+			name: "mcp_http_anomaly_uses_resource_only",
+			emitFn: func(_ *testing.T, logger *Logger) {
+				logger.LogAnomaly(NewMCPLogContext("MCP", "resources/read", testAgentName), "prompt_injection", "tool output suspicious", 0.5)
+			},
+			wantType:  string(EventAnomaly),
+			wantKey:   "resource",
+			wantValue: "resources/read",
+			absent:    []string{"url", "target"},
+		},
+		{
+			name: "mcp_sse_exempt_uses_resource_only",
+			emitFn: func(_ *testing.T, logger *Logger) {
+				logger.LogResponseScanExempt(NewMCPLogContext("MCP", "prompts/get", testAgentName), "mcp.example")
+			},
+			wantType:  string(EventResponseScanExempt),
+			wantKey:   "resource",
+			wantValue: "prompts/get",
+			absent:    []string{"url", "target"},
+		},
+		{
+			name: "connect_open_uses_target_only",
+			emitFn: func(t *testing.T, logger *Logger) {
+				logger.LogTunnelOpen(mustConnectLogContext(t, "evil.com:443", testClientIP, "req-connect-open", testAgentName))
+			},
+			wantType:  string(EventTunnelOpen),
+			wantKey:   "target",
+			wantValue: "evil.com:443",
+			absent:    []string{"url", "resource"},
+		},
+		{
+			name: "connect_close_uses_target_only",
+			emitFn: func(t *testing.T, logger *Logger) {
+				logger.LogTunnelClose(mustConnectLogContext(t, "evil.com:443", testClientIP, "req-connect-close", testAgentName), 128, time.Second)
+			},
+			wantType:  string(EventTunnelClose),
+			wantKey:   "target",
+			wantValue: "evil.com:443",
+			absent:    []string{"url", "resource"},
+		},
+		{
+			name: "config_reload_error_uses_resource_only",
+			emitFn: func(_ *testing.T, logger *Logger) {
+				logger.LogError(NewResourceLogContext("CONFIG_RELOAD", "/etc/pipelock/config.yaml"), fmt.Errorf("validation failed"))
+			},
+			wantType:  string(EventError),
+			wantKey:   "resource",
+			wantValue: "/etc/pipelock/config.yaml",
+			absent:    []string{"url", "target"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, sink := newLoggerWithEmitter(t)
+			defer logger.Close()
+
+			tt.emitFn(t, logger)
+
+			ev, ok := sink.lastEvent()
+			if !ok {
+				t.Fatal("expected emitted event")
+			}
+			if ev.Type != tt.wantType {
+				t.Fatalf("type = %q, want %q", ev.Type, tt.wantType)
+			}
+			assertEmitterContextFields(t, ev, tt.wantKey, tt.wantValue, tt.absent...)
+		})
+	}
+}
+
 func TestEmit_LogBlocked(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogBlocked(LogContext{Method: testMethodGet, URL: "https://evil.com", ClientIP: testClientIP, RequestID: "req-1"}, ScannerDLP, "secret found")
+	logger.LogBlocked(LogContext{method: testMethodGet, url: "https://evil.com", clientIP: testClientIP, requestID: "req-1"}, ScannerDLP, "secret found")
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -1655,7 +1876,7 @@ func TestEmit_LogBlocked_IncludeBlockedFalse(t *testing.T) {
 	logger.SetEmitter(emitter)
 	t.Cleanup(func() { _ = emitter.Close() })
 
-	logger.LogBlocked(LogContext{Method: testMethodGet, URL: "https://evil.com", ClientIP: testClientIP, RequestID: "req-1"}, ScannerDLP, "secret found")
+	logger.LogBlocked(LogContext{method: testMethodGet, url: "https://evil.com", clientIP: testClientIP, requestID: "req-1"}, ScannerDLP, "secret found")
 
 	// Even with includeBlocked=false, emission should still fire
 	if _, ok := sink.lastEvent(); !ok {
@@ -1667,7 +1888,7 @@ func TestEmit_LogError(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogError(LogContext{Method: testMethodGet, URL: "https://example.com", ClientIP: testClientIP, RequestID: "req-2"}, fmt.Errorf("connection refused"))
+	logger.LogError(LogContext{method: testMethodGet, url: "https://example.com", clientIP: testClientIP, requestID: "req-2"}, fmt.Errorf("connection refused"))
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -1685,7 +1906,7 @@ func TestEmit_LogAnomaly(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogAnomaly(LogContext{Method: testMethodGet, URL: "https://example.com", ClientIP: testClientIP, RequestID: "req-3"}, "entropy", "high entropy", 3.5)
+	logger.LogAnomaly(LogContext{method: testMethodGet, url: "https://example.com", clientIP: testClientIP, requestID: "req-3"}, "entropy", "high entropy", 3.5)
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -1709,7 +1930,7 @@ func TestEmit_LogResponseScanExempt(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogResponseScanExempt(LogContext{Method: testMethodGet, URL: "https://api.openai.com/v1/chat", ClientIP: testClientIP, RequestID: "req-exempt-1", Agent: testAgentName}, "api.openai.com")
+	logger.LogResponseScanExempt(LogContext{method: testMethodGet, url: "https://api.openai.com/v1/chat", clientIP: testClientIP, requestID: "req-exempt-1", agent: testAgentName}, "api.openai.com")
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -1736,7 +1957,7 @@ func TestEmit_LogResponseScanExempt_NoAgent(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogResponseScanExempt(LogContext{Method: testMethodGet, URL: "https://api.openai.com/v1/chat", ClientIP: testClientIP, RequestID: "req-exempt-2"}, "api.openai.com")
+	logger.LogResponseScanExempt(LogContext{method: testMethodGet, url: "https://api.openai.com/v1/chat", clientIP: testClientIP, requestID: "req-exempt-2"}, "api.openai.com")
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -1751,7 +1972,7 @@ func TestEmit_LogResponseScan(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogResponseScan(LogContext{URL: "https://example.com", ClientIP: testClientIP, RequestID: "req-4"}, actionBlock, 2, []string{"injection", "jailbreak"}, nil)
+	logger.LogResponseScan(LogContext{url: "https://example.com", clientIP: testClientIP, requestID: "req-4"}, actionBlock, 2, []string{"injection", "jailbreak"}, nil)
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -1999,7 +2220,7 @@ func TestLogBodyDLP_JSONFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogBodyDLP(LogContext{Method: "POST", URL: "https://api.example.com/v1/chat", ClientIP: testClientIP, RequestID: "req-50"}, testActionWarn, 2, []string{"AWS Access Key", "GitHub PAT"}, nil)
+	logger.LogBodyDLP(LogContext{method: "POST", url: "https://api.example.com/v1/chat", clientIP: testClientIP, requestID: "req-50"}, testActionWarn, 2, []string{"AWS Access Key", "GitHub PAT"}, nil)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -2047,7 +2268,7 @@ func TestLogHeaderDLP_JSONFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogHeaderDLP(LogContext{Method: "POST", URL: "https://api.example.com/v1/chat", ClientIP: testClientIP, RequestID: "req-51"}, "Authorization", actionBlock, []string{"AWS Access Key"}, nil)
+	logger.LogHeaderDLP(LogContext{method: "POST", url: "https://api.example.com/v1/chat", clientIP: testClientIP, requestID: "req-51"}, "Authorization", actionBlock, []string{"AWS Access Key"}, nil)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -2077,7 +2298,7 @@ func TestEmit_LogBodyDLP(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogBodyDLP(LogContext{Method: "POST", URL: "https://api.example.com", ClientIP: testClientIP, RequestID: "req-52"}, actionBlock, 1, []string{"AWS Key"}, nil)
+	logger.LogBodyDLP(LogContext{method: "POST", url: "https://api.example.com", clientIP: testClientIP, requestID: "req-52"}, actionBlock, 1, []string{"AWS Key"}, nil)
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -2098,7 +2319,7 @@ func TestEmit_LogBodyScanAddressProtection(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogBodyScan(LogContext{Method: "POST", URL: "https://api.example.com", ClientIP: testClientIP, RequestID: "req-addr-1", Agent: "trader-bot"}, EventAddressProtection, actionBlock, 1, []string{"ETH lookalike detected"})
+	logger.LogBodyScan(LogContext{method: "POST", url: "https://api.example.com", clientIP: testClientIP, requestID: "req-addr-1", agent: "trader-bot"}, EventAddressProtection, actionBlock, 1, []string{"ETH lookalike detected"})
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -2119,7 +2340,7 @@ func TestEmit_LogHeaderDLP(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogHeaderDLP(LogContext{Method: testMethodGet, URL: "https://api.example.com", ClientIP: testClientIP, RequestID: "req-53"}, "Authorization", actionBlock, []string{"GitHub PAT"}, nil)
+	logger.LogHeaderDLP(LogContext{method: testMethodGet, url: "https://api.example.com", clientIP: testClientIP, requestID: "req-53"}, "Authorization", actionBlock, []string{"GitHub PAT"}, nil)
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -2141,7 +2362,7 @@ func TestEmit_LogAnomaly_NoScanner_NoTechnique(t *testing.T) {
 	defer logger.Close()
 
 	// Operational anomaly with empty scanner should not have mitre_technique.
-	logger.LogAnomaly(LogContext{Method: "STARTUP", URL: "0.0.0.0:8888"}, "", "listen address not loopback", 0.5)
+	logger.LogAnomaly(LogContext{method: "STARTUP", url: "0.0.0.0:8888"}, "", "listen address not loopback", 0.5)
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -2329,7 +2550,7 @@ func TestLogBlockedIncludesAgent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogBlocked(LogContext{Method: testMethodGet, URL: "http://evil.com", ClientIP: testClientIP, RequestID: "req-1", Agent: testAgentName}, "dlp", "secret found")
+	logger.LogBlocked(LogContext{method: testMethodGet, url: "http://evil.com", clientIP: testClientIP, requestID: "req-1", agent: testAgentName}, "dlp", "secret found")
 	logger.Close()
 
 	data, err := os.ReadFile(filepath.Clean(logFile))
@@ -2352,7 +2573,7 @@ func TestLogBlockedOmitsEmptyAgent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogBlocked(LogContext{Method: testMethodGet, URL: "http://evil.com", ClientIP: testClientIP, RequestID: "req-1"}, "dlp", "secret found")
+	logger.LogBlocked(LogContext{method: testMethodGet, url: "http://evil.com", clientIP: testClientIP, requestID: "req-1"}, "dlp", "secret found")
 	logger.Close()
 
 	data, err := os.ReadFile(filepath.Clean(logFile))
@@ -2375,7 +2596,7 @@ func TestLogAllowedIncludesAgent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogAllowed(LogContext{Method: testMethodGet, URL: "http://example.com", ClientIP: testClientIP, RequestID: "req-1", Agent: testAgentName}, 200, 1024, time.Second)
+	logger.LogAllowed(LogContext{method: testMethodGet, url: "http://example.com", clientIP: testClientIP, requestID: "req-1", agent: testAgentName}, 200, 1024, time.Second)
 	logger.Close()
 
 	data, err := os.ReadFile(filepath.Clean(logFile))
@@ -2398,7 +2619,7 @@ func TestLogErrorIncludesAgent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogError(LogContext{Method: testMethodGet, URL: "http://example.com", ClientIP: testClientIP, RequestID: "req-1", Agent: testAgentName}, fmt.Errorf("connection refused"))
+	logger.LogError(LogContext{method: testMethodGet, url: "http://example.com", clientIP: testClientIP, requestID: "req-1", agent: testAgentName}, fmt.Errorf("connection refused"))
 	logger.Close()
 
 	data, err := os.ReadFile(filepath.Clean(logFile))
@@ -2421,7 +2642,7 @@ func TestLogAnomalyIncludesAgent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogAnomaly(LogContext{Method: testMethodGet, URL: "http://example.com", ClientIP: testClientIP, RequestID: "req-1", Agent: testAgentName}, "dlp", "suspicious", 0.5)
+	logger.LogAnomaly(LogContext{method: testMethodGet, url: "http://example.com", clientIP: testClientIP, requestID: "req-1", agent: testAgentName}, "dlp", "suspicious", 0.5)
 	logger.Close()
 
 	data, err := os.ReadFile(filepath.Clean(logFile))
@@ -2444,7 +2665,7 @@ func TestLogTunnelOpenIncludesAgent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogTunnelOpen(LogContext{Target: "example.com:443", ClientIP: testClientIP, RequestID: "req-1", Agent: testAgentName})
+	logger.LogTunnelOpen(LogContext{target: "example.com:443", clientIP: testClientIP, requestID: "req-1", agent: testAgentName})
 	logger.Close()
 
 	data, err := os.ReadFile(filepath.Clean(logFile))
@@ -2464,7 +2685,7 @@ func TestLogBlockedEmitterIncludesAgent(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogBlocked(LogContext{Method: testMethodGet, URL: "http://evil.com", ClientIP: testClientIP, RequestID: "req-1", Agent: testAgentName}, "dlp", "secret found")
+	logger.LogBlocked(LogContext{method: testMethodGet, url: "http://evil.com", clientIP: testClientIP, requestID: "req-1", agent: testAgentName}, "dlp", "secret found")
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -2479,7 +2700,7 @@ func TestLogBlockedEmitterOmitsEmptyAgent(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogBlocked(LogContext{Method: testMethodGet, URL: "http://evil.com", ClientIP: testClientIP, RequestID: "req-1"}, "dlp", "secret found")
+	logger.LogBlocked(LogContext{method: testMethodGet, url: "http://evil.com", clientIP: testClientIP, requestID: "req-1"}, "dlp", "secret found")
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -2494,7 +2715,7 @@ func TestLogResponseScanEmitterIncludesAgent(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogResponseScan(LogContext{URL: "http://example.com", ClientIP: testClientIP, RequestID: "req-1", Agent: testAgentName}, "block", 1, []string{"injection"}, nil)
+	logger.LogResponseScan(LogContext{url: "http://example.com", clientIP: testClientIP, requestID: "req-1", agent: testAgentName}, "block", 1, []string{"injection"}, nil)
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -2509,7 +2730,7 @@ func TestLogAnomalyEmitterIncludesAgent(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogAnomaly(LogContext{Method: testMethodGet, URL: "http://example.com", ClientIP: testClientIP, RequestID: "req-1", Agent: testAgentName}, "dlp", "suspicious", 0.5)
+	logger.LogAnomaly(LogContext{method: testMethodGet, url: "http://example.com", clientIP: testClientIP, requestID: "req-1", agent: testAgentName}, "dlp", "suspicious", 0.5)
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -2524,7 +2745,7 @@ func TestLogErrorEmitterIncludesAgent(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
 
-	logger.LogError(LogContext{Method: testMethodGet, URL: "http://example.com", ClientIP: testClientIP, RequestID: "req-1", Agent: testAgentName}, fmt.Errorf("test"))
+	logger.LogError(LogContext{method: testMethodGet, url: "http://example.com", clientIP: testClientIP, requestID: "req-1", agent: testAgentName}, fmt.Errorf("test"))
 
 	ev, ok := sink.lastEvent()
 	if !ok {
@@ -2586,7 +2807,7 @@ func TestLogResponseScanIncludesAgent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogResponseScan(LogContext{URL: "http://example.com", ClientIP: testClientIP, RequestID: "req-1", Agent: testAgentName}, "block", 1, []string{"injection"}, nil)
+	logger.LogResponseScan(LogContext{url: "http://example.com", clientIP: testClientIP, requestID: "req-1", agent: testAgentName}, "block", 1, []string{"injection"}, nil)
 	logger.Close()
 
 	data, err := os.ReadFile(filepath.Clean(logFile))
@@ -2609,7 +2830,7 @@ func TestLogTunnelCloseIncludesAgent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogTunnelClose(LogContext{Target: "example.com:443", ClientIP: testClientIP, RequestID: "req-1", Agent: testAgentName}, 1024, time.Second)
+	logger.LogTunnelClose(LogContext{target: "example.com:443", clientIP: testClientIP, requestID: "req-1", agent: testAgentName}, 1024, time.Second)
 	logger.Close()
 
 	data, err := os.ReadFile(filepath.Clean(logFile))
@@ -2632,7 +2853,7 @@ func TestLogForwardHTTPIncludesAgent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogForwardHTTP(LogContext{Method: testMethodGet, URL: "http://example.com", ClientIP: testClientIP, RequestID: "req-1", Agent: testAgentName}, 200, 512, time.Second)
+	logger.LogForwardHTTP(LogContext{method: testMethodGet, url: "http://example.com", clientIP: testClientIP, requestID: "req-1", agent: testAgentName}, 200, 512, time.Second)
 	logger.Close()
 
 	data, err := os.ReadFile(filepath.Clean(logFile))
@@ -2678,7 +2899,7 @@ func TestLogBodyDLPIncludesAgent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogBodyDLP(LogContext{Method: "POST", URL: "http://example.com", ClientIP: testClientIP, RequestID: "req-1", Agent: testAgentName}, "block", 1, []string{"aws_key"}, nil)
+	logger.LogBodyDLP(LogContext{method: "POST", url: "http://example.com", clientIP: testClientIP, requestID: "req-1", agent: testAgentName}, "block", 1, []string{"aws_key"}, nil)
 	logger.Close()
 
 	data, err := os.ReadFile(filepath.Clean(logFile))
@@ -2701,7 +2922,7 @@ func TestLogHeaderDLPIncludesAgent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogHeaderDLP(LogContext{Method: testMethodGet, URL: "http://example.com", ClientIP: testClientIP, RequestID: "req-1", Agent: testAgentName}, "Authorization", "warn", []string{"bearer"}, nil)
+	logger.LogHeaderDLP(LogContext{method: testMethodGet, url: "http://example.com", clientIP: testClientIP, requestID: "req-1", agent: testAgentName}, "Authorization", "warn", []string{"bearer"}, nil)
 	logger.Close()
 
 	data, err := os.ReadFile(filepath.Clean(logFile))
@@ -2952,35 +3173,35 @@ func TestLogContext_EmptyFieldsOmitted(t *testing.T) {
 		{
 			name: "LogBlocked_empty_http_fields",
 			logFn: func(l *Logger) {
-				l.LogBlocked(LogContext{Method: "CEE", URL: "mcp-input"}, "cross_request_entropy", "budget exceeded")
+				l.LogBlocked(LogContext{method: "CEE", url: "mcp-input"}, "cross_request_entropy", "budget exceeded")
 			},
 			absent: []string{"client_ip", "request_id", "agent"},
 		},
 		{
 			name: "LogAnomaly_empty_http_fields",
 			logFn: func(l *Logger) {
-				l.LogAnomaly(LogContext{Method: "CEE", URL: "mcp-input"}, "cross_request_entropy", "near miss", 0)
+				l.LogAnomaly(LogContext{method: "CEE", url: "mcp-input"}, "cross_request_entropy", "near miss", 0)
 			},
 			absent: []string{"client_ip", "request_id", "agent"},
 		},
 		{
 			name: "LogError_empty_http_fields",
 			logFn: func(l *Logger) {
-				l.LogError(LogContext{Method: "RELOAD"}, fmt.Errorf("test error"))
+				l.LogError(LogContext{method: "RELOAD"}, fmt.Errorf("test error"))
 			},
 			absent: []string{"client_ip", "request_id", "agent"},
 		},
 		{
 			name: "LogResponseScanExempt_empty_http_fields",
 			logFn: func(l *Logger) {
-				l.LogResponseScanExempt(LogContext{Method: "WS", URL: "ws://example.com"}, "example.com")
+				l.LogResponseScanExempt(LogContext{method: "WS", url: "ws://example.com"}, "example.com")
 			},
 			absent: []string{"client_ip", "request_id", "agent"},
 		},
 		{
 			name: "LogResponseScan_includes_method",
 			logFn: func(l *Logger) {
-				l.LogResponseScan(LogContext{Method: testMethodGet, URL: "https://example.com", ClientIP: testClientIP, RequestID: "req-1"}, testActionWarn, 1, []string{"injection"}, nil)
+				l.LogResponseScan(LogContext{method: testMethodGet, url: "https://example.com", clientIP: testClientIP, requestID: "req-1"}, testActionWarn, 1, []string{"injection"}, nil)
 			},
 			absent: []string{"agent"},
 		},
@@ -3019,7 +3240,7 @@ func TestLogResponseScan_IncludesMethod(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logger.LogResponseScan(LogContext{Method: testMethodGet, URL: "https://example.com", ClientIP: testClientIP, RequestID: "req-method-1"}, testActionWarn, 1, []string{"Prompt Injection"}, nil)
+	logger.LogResponseScan(LogContext{method: testMethodGet, url: "https://example.com", clientIP: testClientIP, requestID: "req-method-1"}, testActionWarn, 1, []string{"Prompt Injection"}, nil)
 	logger.Close()
 
 	data, _ := os.ReadFile(filepath.Clean(path))
@@ -3070,7 +3291,7 @@ func TestLogContext_ResourceField_ConfigReload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := LogContext{Method: "CONFIG_RELOAD", Resource: "/etc/pipelock/config.yaml"}
+	ctx := LogContext{method: "CONFIG_RELOAD", resource: "/etc/pipelock/config.yaml"}
 	logger.LogError(ctx, fmt.Errorf("validation failed"))
 	logger.Close()
 
@@ -3096,7 +3317,10 @@ func TestLogContext_TargetField_Connect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := NewConnectLogContext("evil.com:443", testClientIP, testReqID, testAgentName)
+	ctx, err := NewConnectLogContext("evil.com:443", testClientIP, testReqID, testAgentName)
+	if err != nil {
+		t.Fatal(err)
+	}
 	logger.LogTunnelOpen(ctx)
 	logger.Close()
 

--- a/internal/audit/sanitize_fuzz_test.go
+++ b/internal/audit/sanitize_fuzz_test.go
@@ -68,12 +68,12 @@ func TestSanitizeString(t *testing.T) {
 func TestLogAllowed_SanitizesURL(t *testing.T) {
 	logger := &Logger{zl: zerolog.Nop(), includeAllowed: true}
 	// Should not panic with ANSI in URL.
-	logger.LogAllowed(LogContext{Method: "GET", URL: "https://evil.com/\x1b[2Jclear", ClientIP: "127.0.0.1", RequestID: "req-1"}, 200, 0, 0)
+	logger.LogAllowed(LogContext{method: "GET", url: "https://evil.com/\x1b[2Jclear", clientIP: "127.0.0.1", requestID: "req-1"}, 200, 0, 0)
 }
 
 func TestLogBlocked_SanitizesURLAndReason(t *testing.T) {
 	logger := &Logger{zl: zerolog.Nop(), includeBlocked: true}
-	logger.LogBlocked(LogContext{Method: "GET", URL: "https://\x1b[2Jevil.com", ClientIP: "127.0.0.1", RequestID: "req-1"}, "dlp", "found \x1b[31msecret\x1b[0m")
+	logger.LogBlocked(LogContext{method: "GET", url: "https://\x1b[2Jevil.com", clientIP: "127.0.0.1", requestID: "req-1"}, "dlp", "found \x1b[31msecret\x1b[0m")
 }
 
 func TestSanitizeString_NoAllocation_CleanInput(t *testing.T) {

--- a/internal/cli/runtime/run.go
+++ b/internal/cli/runtime/run.go
@@ -50,6 +50,7 @@ import (
 // metrics, reverse proxy, agent listeners) except the Scan API which uses
 // operator-configured values.
 const (
+	configReloadAuditMethod = "CONFIG_RELOAD"
 	serverReadTimeout       = 10 * time.Second
 	serverReadHeaderTimeout = 5 * time.Second
 	serverWriteTimeout      = 10 * time.Second
@@ -418,7 +419,7 @@ Examples:
 
 				go func() {
 					if err := reloader.Start(ctx); err != nil {
-						logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile), err)
+						logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, configFile), err)
 					}
 				}()
 
@@ -439,7 +440,7 @@ Examples:
 								}
 								// Block downgrades from strict mode (security-critical).
 								if oldCfg.Mode == config.ModeStrict && len(warnings) > 0 {
-									logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile),
+									logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, configFile),
 										fmt.Errorf("rejected: security downgrade from strict mode"))
 									return
 								}
@@ -447,14 +448,14 @@ Examples:
 								// set at server start and cannot change at runtime; tunnels
 								// would be killed prematurely. Restart to enable.
 								if !oldCfg.ForwardProxy.Enabled && newCfg.ForwardProxy.Enabled {
-									logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile),
+									logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, configFile),
 										fmt.Errorf("rejected: forward proxy cannot be enabled via reload (requires restart)"))
 									return
 								}
 								// Block enabling WebSocket proxy via reload for the same
 								// reason: WriteTimeout must be 0 at server start.
 								if !oldCfg.WebSocketProxy.Enabled && newCfg.WebSocketProxy.Enabled {
-									logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile),
+									logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, configFile),
 										fmt.Errorf("rejected: WebSocket proxy cannot be enabled via reload (requires restart)"))
 									return
 								}
@@ -546,7 +547,7 @@ Examples:
 							newSc := scanner.New(newCfg)
 							p.Reload(newCfg, newSc)
 							if reloadErr := p.LoadCertCache(newCfg); reloadErr != nil {
-								logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile),
+								logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, configFile),
 									fmt.Errorf("TLS cert cache reload failed: %w", reloadErr))
 							}
 							ks.Reload(newCfg)
@@ -555,13 +556,13 @@ Examples:
 							// swap into emitter, close old sinks.
 							newSinks, sinkErr := BuildEmitSinks(newCfg)
 							if sinkErr != nil {
-								logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile),
+								logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, configFile),
 									fmt.Errorf("emit sink rebuild failed: %w", sinkErr))
 							} else {
 								oldSinks := emitter.ReloadSinks(newSinks)
 								for _, s := range oldSinks {
 									if closeErr := s.Close(); closeErr != nil {
-										logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile),
+										logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, configFile),
 											fmt.Errorf("closing old emit sink: %w", closeErr))
 									}
 								}
@@ -1239,7 +1240,7 @@ func ReloadPanicHandler(r any, sentryClient *plsentry.Client, logger *audit.Logg
 	if sentryClient != nil {
 		sentryClient.CaptureError(reloadErr)
 	}
-	logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile), reloadErr)
+	logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, configFile), reloadErr)
 }
 
 // PreserveAgentListeners keeps the new config's agent listener state

--- a/internal/cli/runtime/run.go
+++ b/internal/cli/runtime/run.go
@@ -418,7 +418,7 @@ Examples:
 
 				go func() {
 					if err := reloader.Start(ctx); err != nil {
-						logger.LogError(audit.LogContext{Method: "CONFIG_RELOAD", Resource: configFile}, err)
+						logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile), err)
 					}
 				}()
 
@@ -439,7 +439,7 @@ Examples:
 								}
 								// Block downgrades from strict mode (security-critical).
 								if oldCfg.Mode == config.ModeStrict && len(warnings) > 0 {
-									logger.LogError(audit.LogContext{Method: "CONFIG_RELOAD", Resource: configFile},
+									logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile),
 										fmt.Errorf("rejected: security downgrade from strict mode"))
 									return
 								}
@@ -447,14 +447,14 @@ Examples:
 								// set at server start and cannot change at runtime; tunnels
 								// would be killed prematurely. Restart to enable.
 								if !oldCfg.ForwardProxy.Enabled && newCfg.ForwardProxy.Enabled {
-									logger.LogError(audit.LogContext{Method: "CONFIG_RELOAD", Resource: configFile},
+									logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile),
 										fmt.Errorf("rejected: forward proxy cannot be enabled via reload (requires restart)"))
 									return
 								}
 								// Block enabling WebSocket proxy via reload for the same
 								// reason: WriteTimeout must be 0 at server start.
 								if !oldCfg.WebSocketProxy.Enabled && newCfg.WebSocketProxy.Enabled {
-									logger.LogError(audit.LogContext{Method: "CONFIG_RELOAD", Resource: configFile},
+									logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile),
 										fmt.Errorf("rejected: WebSocket proxy cannot be enabled via reload (requires restart)"))
 									return
 								}
@@ -546,7 +546,7 @@ Examples:
 							newSc := scanner.New(newCfg)
 							p.Reload(newCfg, newSc)
 							if reloadErr := p.LoadCertCache(newCfg); reloadErr != nil {
-								logger.LogError(audit.LogContext{Method: "CONFIG_RELOAD", Resource: configFile},
+								logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile),
 									fmt.Errorf("TLS cert cache reload failed: %w", reloadErr))
 							}
 							ks.Reload(newCfg)
@@ -555,13 +555,13 @@ Examples:
 							// swap into emitter, close old sinks.
 							newSinks, sinkErr := BuildEmitSinks(newCfg)
 							if sinkErr != nil {
-								logger.LogError(audit.LogContext{Method: "CONFIG_RELOAD", Resource: configFile},
+								logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile),
 									fmt.Errorf("emit sink rebuild failed: %w", sinkErr))
 							} else {
 								oldSinks := emitter.ReloadSinks(newSinks)
 								for _, s := range oldSinks {
 									if closeErr := s.Close(); closeErr != nil {
-										logger.LogError(audit.LogContext{Method: "CONFIG_RELOAD", Resource: configFile},
+										logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile),
 											fmt.Errorf("closing old emit sink: %w", closeErr))
 									}
 								}
@@ -1239,7 +1239,7 @@ func ReloadPanicHandler(r any, sentryClient *plsentry.Client, logger *audit.Logg
 	if sentryClient != nil {
 		sentryClient.CaptureError(reloadErr)
 	}
-	logger.LogError(audit.LogContext{Method: "CONFIG_RELOAD", Resource: configFile}, reloadErr)
+	logger.LogError(audit.NewResourceLogContext("CONFIG_RELOAD", configFile), reloadErr)
 }
 
 // PreserveAgentListeners keeps the new config's agent listener state

--- a/internal/mcp/audit.go
+++ b/internal/mcp/audit.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import "github.com/luckyPipewrench/pipelock/internal/audit"
+
+func mustMCPAuditContext(logger *audit.Logger, method, resource string) audit.LogContext {
+	ctx, err := audit.NewMCPLogContext(method, resource, "")
+	if err != nil {
+		if logger != nil {
+			logger.LogError(audit.NewMethodLogContext(method), err)
+		}
+		return audit.NewMethodLogContext(method)
+	}
+	return ctx
+}

--- a/internal/mcp/cee.go
+++ b/internal/mcp/cee.go
@@ -61,13 +61,13 @@ func ceeRecordMCP(
 			_, _ = fmt.Fprintf(logW, "pipelock: CEE: %s (session=%s)\n", reason, sessionKey)
 			if cee.Config.EntropyBudget.Action == config.ActionBlock {
 				if logger != nil {
-					logger.LogBlocked(audit.NewMCPLogContext("CEE", "mcp-input", ""), "cross_request_entropy", reason)
+					logger.LogBlocked(mustMCPAuditContext(logger, "CEE", "mcp-input"), "cross_request_entropy", reason)
 				}
 				return reason
 			}
 			// Warn mode: emit structured anomaly event for audit trail.
 			if logger != nil {
-				logger.LogAnomaly(audit.NewMCPLogContext("CEE", "mcp-input", ""), "cross_request_entropy", reason, 0)
+				logger.LogAnomaly(mustMCPAuditContext(logger, "CEE", "mcp-input"), "cross_request_entropy", reason, 0)
 			}
 		}
 	}
@@ -83,13 +83,13 @@ func ceeRecordMCP(
 			_, _ = fmt.Fprintf(logW, "pipelock: CEE: %s (session=%s)\n", reason, sessionKey)
 			if cee.Config.Action == config.ActionBlock {
 				if logger != nil {
-					logger.LogBlocked(audit.NewMCPLogContext("CEE", "mcp-input", ""), "cross_request_fragment", reason)
+					logger.LogBlocked(mustMCPAuditContext(logger, "CEE", "mcp-input"), "cross_request_fragment", reason)
 				}
 				return reason
 			}
 			// Warn mode: emit structured anomaly event for audit trail.
 			if logger != nil {
-				logger.LogAnomaly(audit.NewMCPLogContext("CEE", "mcp-input", ""), "cross_request_fragment", reason, 0)
+				logger.LogAnomaly(mustMCPAuditContext(logger, "CEE", "mcp-input"), "cross_request_fragment", reason, 0)
 			}
 		}
 	}

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -475,7 +475,7 @@ func ForwardScannedInput(
 			if taintDecision.Result.Decision == session.PolicyAsk || taintDecision.Result.Decision == session.PolicyBlock {
 				if auditLogger != nil {
 					auditLogger.LogTaintDecision(
-						audit.LogContext{Method: "MCP", URL: toolCallName},
+						audit.NewMCPLogContext("MCP", toolCallName, ""),
 						taintDecision.Risk.Level.String(),
 						taintDecision.ActionClass.String(),
 						taintDecision.Sensitivity.String(),

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/luckyPipewrench/pipelock/internal/addressprotect"
-	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	decide "github.com/luckyPipewrench/pipelock/internal/decide"
@@ -289,7 +288,7 @@ func ForwardScannedInput(
 				_, _ = fmt.Fprintln(logW, logMsg)
 				if dowAction == config.ActionBlock {
 					if auditLogger != nil {
-						auditLogger.LogBlocked(audit.NewMCPLogContext("MCP", toolCallName, ""), "denial_of_wallet", dowReason)
+						auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", toolCallName), "denial_of_wallet", dowReason)
 					}
 					if m != nil {
 						m.RecordBlocked("mcp", "denial_of_wallet", 0, "")
@@ -306,7 +305,7 @@ func ForwardScannedInput(
 				}
 				// dow_action: warn — log and record near-miss, but forward the request.
 				if auditLogger != nil {
-					auditLogger.LogAnomaly(audit.NewMCPLogContext("MCP", toolCallName, ""), "denial_of_wallet", dowReason, 0)
+					auditLogger.LogAnomaly(mustMCPAuditContext(auditLogger, "MCP", toolCallName), "denial_of_wallet", dowReason, 0)
 				}
 				recordAdaptiveSignal(session.SignalNearMiss)
 			}
@@ -360,7 +359,7 @@ func ForwardScannedInput(
 				frozenMsg := fmt.Sprintf("pipelock: input line %d: tools/call %q blocked by frozen tool inventory", lineNum, toolCallName)
 				_, _ = fmt.Fprintln(logW, frozenMsg)
 				if auditLogger != nil {
-					auditLogger.LogBlocked(audit.NewMCPLogContext("MCP", toolCallName, ""), "frozen_tool", "tool not in frozen inventory")
+					auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", toolCallName), "frozen_tool", "tool not in frozen inventory")
 				}
 				if m != nil {
 					m.RecordBlocked("mcp", "frozen_tool", 0, "")
@@ -475,7 +474,7 @@ func ForwardScannedInput(
 			if taintDecision.Result.Decision == session.PolicyAsk || taintDecision.Result.Decision == session.PolicyBlock {
 				if auditLogger != nil {
 					auditLogger.LogTaintDecision(
-						audit.NewMCPLogContext("MCP", toolCallName, ""),
+						mustMCPAuditContext(auditLogger, "MCP", toolCallName),
 						taintDecision.Risk.Level.String(),
 						taintDecision.ActionClass.String(),
 						taintDecision.Sensitivity.String(),

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	decide "github.com/luckyPipewrench/pipelock/internal/decide"
@@ -249,7 +248,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 				if pv.Block {
 					_, _ = fmt.Fprintf(logW, "pipelock: line %d: tools/list provenance verification failed: %s\n", lineNum, pv.Error)
 					if opts.AuditLogger != nil {
-						opts.AuditLogger.LogBlocked(audit.NewMCPLogContext("MCP", "tools/list", ""), "provenance", pv.Error)
+						opts.AuditLogger.LogBlocked(mustMCPAuditContext(opts.AuditLogger, "MCP", "tools/list"), "provenance", pv.Error)
 					}
 					if m != nil {
 						m.RecordBlocked("mcp", "provenance", 0, "")
@@ -268,7 +267,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 					if r.Status != provenance.StatusVerified {
 						_, _ = fmt.Fprintf(logW, "pipelock: line %d: tool %q unsigned (provenance warn)\n", lineNum, r.ToolName)
 						if opts.AuditLogger != nil {
-							opts.AuditLogger.LogAnomaly(audit.NewMCPLogContext("MCP", r.ToolName, ""), "provenance", "unsigned tool", 0)
+							opts.AuditLogger.LogAnomaly(mustMCPAuditContext(opts.AuditLogger, "MCP", r.ToolName), "provenance", "unsigned tool", 0)
 						}
 					}
 				}

--- a/internal/mcp/proxy_http.go
+++ b/internal/mcp/proxy_http.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/decide"
@@ -373,7 +372,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 					toolName, dowAction, dowReason, dowBudgetType)
 				if dowAction == config.ActionBlock {
 					if auditLogger != nil {
-						auditLogger.LogBlocked(audit.NewMCPLogContext("MCP", toolName, ""), "denial_of_wallet", dowReason)
+						auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", toolName), "denial_of_wallet", dowReason)
 					}
 					if m != nil {
 						m.RecordBlocked("mcp", "denial_of_wallet", 0, "")
@@ -385,7 +384,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 				}
 				// dow_action: warn — log and record near-miss, but allow the request.
 				if auditLogger != nil {
-					auditLogger.LogAnomaly(audit.NewMCPLogContext("MCP", toolName, ""), "denial_of_wallet", dowReason, 0)
+					auditLogger.LogAnomaly(mustMCPAuditContext(auditLogger, "MCP", toolName), "denial_of_wallet", dowReason, 0)
 				}
 				recordAdaptiveSignal(session.SignalNearMiss)
 			}
@@ -446,7 +445,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		if taintEval.Result.Decision == session.PolicyAsk || taintEval.Result.Decision == session.PolicyBlock {
 			if auditLogger != nil {
 				auditLogger.LogTaintDecision(
-					audit.NewMCPLogContext("MCP", toolName, ""),
+					mustMCPAuditContext(auditLogger, "MCP", toolName),
 					taintEval.Risk.Level.String(),
 					taintEval.ActionClass.String(),
 					taintEval.Sensitivity.String(),

--- a/internal/mcp/proxy_http.go
+++ b/internal/mcp/proxy_http.go
@@ -446,7 +446,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		if taintEval.Result.Decision == session.PolicyAsk || taintEval.Result.Decision == session.PolicyBlock {
 			if auditLogger != nil {
 				auditLogger.LogTaintDecision(
-					audit.LogContext{Method: "MCP", URL: toolName},
+					audit.NewMCPLogContext("MCP", toolName, ""),
 					taintEval.Risk.Level.String(),
 					taintEval.ActionClass.String(),
 					taintEval.Sensitivity.String(),

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -556,10 +556,10 @@ func (p *Proxy) evalHeaderDLP(ctx context.Context, headers http.Header, cfg *con
 	bundleRules := dlpBundleRules(headerResult.DLPMatches)
 
 	logger.LogHeaderDLP(actx, headerResult.HeaderName, action, patternNames, bundleRules)
-	p.metrics.RecordHeaderDLP(action, actx.Agent)
+	p.metrics.RecordHeaderDLP(action, actx.Agent())
 
 	if action == config.ActionBlock && cfg.EnforceEnabled() {
-		p.metrics.RecordBlocked(hostname, "header_dlp", time.Since(start), actx.Agent)
+		p.metrics.RecordBlocked(hostname, "header_dlp", time.Since(start), actx.Agent())
 		return true, true
 	}
 	return false, true

--- a/internal/proxy/cee.go
+++ b/internal/proxy/cee.go
@@ -287,7 +287,7 @@ func ceeAdmit(
 			m.RecordCrossRequestEntropyExceeded()
 			detail := fmt.Sprintf("entropy budget exceeded: %.0f/%.0f bits",
 				et.CurrentUsage(sessionKey), et.Budget())
-			actx := audit.LogContext{Method: "CEE", URL: targetURL, ClientIP: clientIP, RequestID: requestID, Agent: agent}
+			actx := newHTTPAuditContext(logger, "CEE", targetURL, clientIP, requestID, agent)
 			if ceeCfg.EntropyBudget.Action == config.ActionBlock {
 				logger.LogBlocked(actx, "cross_request_entropy", detail)
 				result.Blocked = true
@@ -351,7 +351,7 @@ func ceeFragmentScan(
 	}
 	m.RecordCrossRequestDLPMatch()
 	detail := fmt.Sprintf("fragment reassembly DLP match: %s", matches[0].PatternName)
-	actx := audit.LogContext{Method: "CEE", URL: targetURL, ClientIP: clientIP, RequestID: requestID, Agent: agent}
+	actx := newHTTPAuditContext(logger, "CEE", targetURL, clientIP, requestID, agent)
 	if ceeCfg.Action == config.ActionBlock {
 		logger.LogBlocked(actx, "cross_request_fragment", detail)
 		return &ceeResult{

--- a/internal/proxy/closeutil.go
+++ b/internal/proxy/closeutil.go
@@ -21,6 +21,6 @@ func safeClose(c io.Closer, label string, logger *audit.Logger) {
 		return
 	}
 	if err := c.Close(); err != nil && logger != nil {
-		logger.LogError(audit.LogContext{Method: "close"}, fmt.Errorf("%s: %w", label, err))
+		logger.LogError(audit.NewMethodLogContext("close"), fmt.Errorf("%s: %w", label, err))
 	}
 }

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -73,11 +73,6 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 
 	clientIP, requestID := requestMeta(r)
-	baseCtx := audit.LogContext{
-		Method:    http.MethodConnect,
-		ClientIP:  clientIP,
-		RequestID: requestID,
-	}
 
 	// Resolve per-agent config and scanner from a single registry snapshot.
 	// This prevents TOCTOU races during hot-reload where knownProfiles()
@@ -89,7 +84,6 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	if agent == "" {
 		agent = agentAnonymous
 	}
-	baseCtx.Agent = agent
 	agentLabel := id.Profile // bounded cardinality for Prometheus labels
 
 	// Strip inbound mediation envelope headers to prevent forgery.
@@ -120,12 +114,8 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		syntheticHost = "[" + host + "]"
 	}
 	syntheticURL := "https://" + syntheticHost + "/"
-	targetCtx := baseCtx
-	targetCtx.Target = target
-	headerCtx := baseCtx
-	headerCtx.Target = target
-	hostCtx := baseCtx
-	hostCtx.Target = host
+	targetCtx := newConnectAuditContext(p.logger, target, clientIP, requestID, agent)
+	headerCtx := targetCtx
 
 	// Scan through all layers (URL pipeline).
 	result := sc.Scan(r.Context(), syntheticURL)
@@ -433,7 +423,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		if certCache == nil {
 			// Fail-closed: TLS interception is enabled but cert cache is missing.
 			// Connection is already hijacked, so close both sides (deferred).
-			p.logger.LogError(hostCtx, fmt.Errorf("TLS interception enabled but cert cache unavailable"))
+			p.logger.LogError(targetCtx, fmt.Errorf("TLS interception enabled but cert cache unavailable"))
 			p.metrics.RecordTLSIntercept("failed")
 			return
 		}
@@ -442,7 +432,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		safeClose(targetConn, "targetConn", p.logger)
 		targetConn = nil
 		p.metrics.RecordTLSIntercept("intercepted")
-		p.logger.LogAnomaly(hostCtx, "tls_intercept", "TLS MITM interception active", 0) // 0: informational, not anomalous
+		p.logger.LogAnomaly(targetCtx, "tls_intercept", "TLS MITM interception active", 0) // 0: informational, not anomalous
 		// Wrap clientConn with buffered reader so any bytes peeked during
 		// SNI verification (ClientHello) are available to the TLS server.
 		interceptConn := wrapBuffered(clientConn, clientReader)
@@ -484,7 +474,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 			Recorder:       interceptRec,
 			KillSwitch:     p.ks,
 		}); err != nil {
-			p.logger.LogError(hostCtx, err)
+			p.logger.LogError(targetCtx, err)
 		}
 		return
 	}
@@ -564,7 +554,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	agentLabel := id.Profile // bounded cardinality for Prometheus labels
 
 	targetURL := r.URL.String()
-	actx := audit.NewHTTPLogContext(r.Method, targetURL, clientIP, requestID, agent)
+	actx := newHTTPAuditContext(p.logger, r.Method, targetURL, clientIP, requestID, agent)
 
 	// Scan through all layers (URL pipeline)
 	result := sc.Scan(r.Context(), targetURL)

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -134,7 +134,7 @@ func interceptEmitReceipt(ic *InterceptContext, opts receipt.EmitOpts) {
 		return
 	}
 	if err := e.Emit(opts); err != nil && ic.Logger != nil {
-		ic.Logger.LogError(audit.LogContext{RequestID: opts.RequestID}, err)
+		ic.Logger.LogError(audit.NewRequestLogContext(opts.RequestID), err)
 	}
 }
 
@@ -224,7 +224,7 @@ func interceptTunnel(
 		return fmt.Errorf("set handshake deadline: %w", err)
 	}
 
-	ictx := audit.NewConnectLogContext(net.JoinHostPort(ic.TargetHost, ic.TargetPort), ic.ClientIP, ic.RequestID, ic.Agent)
+	ictx := newConnectAuditContext(ic.Logger, net.JoinHostPort(ic.TargetHost, ic.TargetPort), ic.ClientIP, ic.RequestID, ic.Agent)
 
 	tlsConn := tls.Server(clientConn, tlsCfg)
 	handshakeStart := time.Now()
@@ -363,7 +363,8 @@ func newInterceptHandler(
 		}
 		if !strings.EqualFold(reqHost, ic.TargetHost) || reqPort != ic.TargetPort {
 			mismatch := r.Host + " vs " + target
-			ic.Logger.LogBlocked(audit.LogContext{Method: r.Method, Target: net.JoinHostPort(reqHost, reqPort), ClientIP: ic.ClientIP, RequestID: ic.RequestID, Agent: ic.Agent}, "tls_authority_mismatch", "authority mismatch: "+mismatch)
+			mismatchURL := schemeHTTPS + "://" + net.JoinHostPort(reqHost, reqPort) + r.URL.RequestURI()
+			ic.Logger.LogBlocked(newHTTPAuditContext(ic.Logger, r.Method, mismatchURL, ic.ClientIP, ic.RequestID, ic.Agent), "tls_authority_mismatch", "authority mismatch: "+mismatch)
 			ic.Metrics.RecordTLSRequestBlocked("authority_mismatch")
 			interceptEmitReceipt(ic, receipt.EmitOpts{
 				ActionID:  actionID,
@@ -403,7 +404,7 @@ func newInterceptHandler(
 
 		// Build shared audit context AFTER URL reconstruction so actx.URL
 		// contains the full intercepted URL, not just the origin-form path.
-		actx := audit.NewHTTPLogContext(r.Method, r.URL.String(), ic.ClientIP, ic.RequestID, ic.Agent)
+		actx := newHTTPAuditContext(ic.Logger, r.Method, r.URL.String(), ic.ClientIP, ic.RequestID, ic.Agent)
 
 		// Track whether any finding occurred (URL, body DLP, or response scan).
 		// RecordClean is only applied when the request was fully clean so that

--- a/internal/proxy/media_policy_test.go
+++ b/internal/proxy/media_policy_test.go
@@ -481,7 +481,11 @@ func TestLogMediaExposureIfPresent_EmitsWithTransport(t *testing.T) {
 		},
 	}
 	logger := &fakeMediaLogger{}
-	logMediaExposureIfPresent(logger, audit.LogContext{URL: "https://example.com/x.jpg"}, v, "reverse")
+	actx, err := audit.NewHTTPLogContext(http.MethodGet, "https://example.com/x.jpg", "127.0.0.1", "req-media-1", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	logMediaExposureIfPresent(logger, actx, v, "reverse")
 	if len(logger.calls) != 1 {
 		t.Fatalf("calls = %d, want 1", len(logger.calls))
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -118,6 +118,28 @@ func requestMeta(r *http.Request) (clientIP, requestID string) {
 	return
 }
 
+func newHTTPAuditContext(logger *audit.Logger, method, targetURL, clientIP, requestID, agent string) audit.LogContext {
+	ctx, err := audit.NewHTTPLogContext(method, targetURL, clientIP, requestID, agent)
+	if err != nil {
+		if logger != nil {
+			logger.LogError(audit.NewMethodLogContext(method), err)
+		}
+		return audit.NewMethodLogContext(method)
+	}
+	return ctx
+}
+
+func newConnectAuditContext(logger *audit.Logger, target, clientIP, requestID, agent string) audit.LogContext {
+	ctx, err := audit.NewConnectLogContext(target, clientIP, requestID, agent)
+	if err != nil {
+		if logger != nil {
+			logger.LogError(audit.NewMethodLogContext(http.MethodConnect), err)
+		}
+		return audit.NewMethodLogContext(http.MethodConnect)
+	}
+	return ctx
+}
+
 // Version is set at build time via ldflags.
 var Version = "0.1.0-dev"
 
@@ -328,7 +350,7 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 			}
 			result := currentScanner.Scan(req.Context(), redirectURL)
 			if !result.Allowed {
-				actx := audit.NewHTTPLogContext(req.Method, redirectURL, clientIP, requestID, agentName)
+				actx := newHTTPAuditContext(logger, req.Method, redirectURL, clientIP, requestID, agentName)
 				if currentCfg.EnforceEnabled() {
 					logger.LogBlocked(actx, "redirect", fmt.Sprintf("redirect from %s blocked: %s", originalURL, result.Reason))
 					return fmt.Errorf("redirect blocked: %s", result.Reason)
@@ -382,7 +404,7 @@ func (p *Proxy) emitReceipt(opts receipt.EmitOpts) {
 		return
 	}
 	if err := e.Emit(opts); err != nil {
-		p.logger.LogError(audit.LogContext{RequestID: opts.RequestID}, err)
+		p.logger.LogError(audit.NewRequestLogContext(opts.RequestID), err)
 	}
 }
 
@@ -411,7 +433,7 @@ func (p *Proxy) reloadReceiptEmitter(cfg *config.Config) {
 		// Failure is non-fatal: log and keep the prior emitter (if any) so
 		// receipts continue with the old key rather than going dark entirely.
 		if p.logger != nil {
-			p.logger.LogError(audit.LogContext{Method: "RELOAD"}, fmt.Errorf("loading receipt signing key: %w", err))
+			p.logger.LogError(audit.NewMethodLogContext("RELOAD"), fmt.Errorf("loading receipt signing key: %w", err))
 		}
 		return
 	}
@@ -505,7 +527,7 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) {
 	oldSnap := p.editionPtr.Load()
 	newEd, edErr := oldSnap.Reload(cfg, sc)
 	if edErr != nil {
-		p.logger.LogError(audit.LogContext{Method: "RELOAD"}, fmt.Errorf("edition rebuild failed, keeping old config: %w", edErr))
+		p.logger.LogError(audit.NewMethodLogContext("RELOAD"), fmt.Errorf("edition rebuild failed, keeping old config: %w", edErr))
 		sc.Close() // caller-allocated scanner must be closed since we're not using it
 		return
 	}
@@ -941,15 +963,15 @@ func (p *Proxy) runShieldPipeline(body []byte, contentType string, respHeaders h
 		body = []byte(shieldResult.Content)
 		if shieldResult.ExtensionHits > 0 {
 			p.metrics.RecordShieldRewrite("extension", transport)
-			p.logger.LogShieldRewrite("extension", shieldResult.ExtensionHits, transport, actx.URL, clientIP, requestID)
+			p.logger.LogShieldRewrite("extension", shieldResult.ExtensionHits, transport, actx.URL(), clientIP, requestID)
 		}
 		if shieldResult.TrackingHits > 0 {
 			p.metrics.RecordShieldRewrite("tracking", transport)
-			p.logger.LogShieldRewrite("tracking", shieldResult.TrackingHits, transport, actx.URL, clientIP, requestID)
+			p.logger.LogShieldRewrite("tracking", shieldResult.TrackingHits, transport, actx.URL(), clientIP, requestID)
 		}
 		if shieldResult.TrapHits > 0 {
 			p.metrics.RecordShieldRewrite("trap", transport)
-			p.logger.LogShieldRewrite("trap", shieldResult.TrapHits, transport, actx.URL, clientIP, requestID)
+			p.logger.LogShieldRewrite("trap", shieldResult.TrapHits, transport, actx.URL(), clientIP, requestID)
 		}
 		if shieldResult.ShimInjected {
 			p.metrics.RecordShieldShimInjected(transport)
@@ -1212,11 +1234,11 @@ func (p *Proxy) Start(ctx context.Context) error {
 			defer cancel()
 			for _, srv := range p.agentServers {
 				if shutErr := srv.Shutdown(shutdownCtx); shutErr != nil {
-					p.logger.LogError(audit.LogContext{Method: "SHUTDOWN", Resource: srv.Addr}, shutErr)
+					p.logger.LogError(audit.NewResourceLogContext("SHUTDOWN", srv.Addr), shutErr)
 				}
 			}
 			if err := p.server.Shutdown(shutdownCtx); err != nil {
-				p.logger.LogError(audit.LogContext{Method: "SHUTDOWN", Resource: cfg.FetchProxy.Listen}, err)
+				p.logger.LogError(audit.NewResourceLogContext("SHUTDOWN", cfg.FetchProxy.Listen), err)
 			}
 			p.Close()
 		case <-done:
@@ -1229,7 +1251,7 @@ func (p *Proxy) Start(ctx context.Context) error {
 		if host, _, splitErr := net.SplitHostPort(cfg.FetchProxy.Listen); splitErr == nil {
 			ip := net.ParseIP(host)
 			if host == "" || host == "0.0.0.0" || host == "::" || (ip != nil && !ip.IsLoopback()) {
-				p.logger.LogAnomaly(audit.LogContext{Method: "STARTUP", Resource: cfg.FetchProxy.Listen}, "",
+				p.logger.LogAnomaly(audit.NewResourceLogContext("STARTUP", cfg.FetchProxy.Listen), "",
 					"listen address is not loopback — /metrics and /stats endpoints are exposed to the network",
 					0.5)
 			}
@@ -1312,7 +1334,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	// internally decodes for matching, but targetURL retains partial decoding
 	// from Go's query parsing. Operators should see the final resolved URL.
 	displayURL := scanner.IterativeDecode(targetURL)
-	actx := audit.NewHTTPLogContext(http.MethodGet, displayURL, clientIP, requestID, agent)
+	actx := newHTTPAuditContext(p.logger, http.MethodGet, displayURL, clientIP, requestID, agent)
 
 	// Scan URL through all scanners
 	result := sc.Scan(r.Context(), targetURL)
@@ -2097,7 +2119,7 @@ func (p *Proxy) filterAndActOnResponseScan(
 	case config.ActionBlock:
 		recordResponseSignal(session.SignalBlock)
 		reason := fmt.Sprintf("response contains prompt injection: %s", strings.Join(patternNames, ", "))
-		log.LogBlocked(audit.NewHTTPLogContext(http.MethodGet, displayURL, clientIP, requestID, agent), "response_scan", reason)
+		log.LogBlocked(newHTTPAuditContext(p.logger, http.MethodGet, displayURL, clientIP, requestID, agent), "response_scan", reason)
 		p.emitReceipt(receipt.EmitOpts{
 			ActionID:  receipt.NewActionID(),
 			Verdict:   config.ActionBlock,
@@ -2115,7 +2137,7 @@ func (p *Proxy) filterAndActOnResponseScan(
 		if p.approver == nil {
 			recordResponseSignal(session.SignalBlock)
 			reason := fmt.Sprintf("response contains prompt injection: %s (no HITL approver)", strings.Join(patternNames, ", "))
-			log.LogBlocked(audit.NewHTTPLogContext(http.MethodGet, displayURL, clientIP, requestID, agent), "response_scan", reason)
+			log.LogBlocked(newHTTPAuditContext(p.logger, http.MethodGet, displayURL, clientIP, requestID, agent), "response_scan", reason)
 			p.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
@@ -2143,14 +2165,14 @@ func (p *Proxy) filterAndActOnResponseScan(
 		})
 		switch d {
 		case hitl.DecisionAllow:
-			log.LogResponseScan(audit.NewHTTPLogContext("", displayURL, clientIP, requestID, agent), "ask:allow", len(result.Matches), patternNames, bundleRules)
+			log.LogResponseScan(newHTTPAuditContext(log, "", displayURL, clientIP, requestID, agent), "ask:allow", len(result.Matches), patternNames, bundleRules)
 		case hitl.DecisionStrip:
 			out = result.TransformedContent
-			log.LogResponseScan(audit.NewHTTPLogContext("", displayURL, clientIP, requestID, agent), "ask:strip", len(result.Matches), patternNames, bundleRules)
+			log.LogResponseScan(newHTTPAuditContext(log, "", displayURL, clientIP, requestID, agent), "ask:strip", len(result.Matches), patternNames, bundleRules)
 		default:
 			recordResponseSignal(session.SignalBlock)
 			reason := fmt.Sprintf("response blocked by operator: %s", strings.Join(patternNames, ", "))
-			log.LogBlocked(audit.NewHTTPLogContext(http.MethodGet, displayURL, clientIP, requestID, agent), "response_scan", reason)
+			log.LogBlocked(newHTTPAuditContext(p.logger, http.MethodGet, displayURL, clientIP, requestID, agent), "response_scan", reason)
 			p.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
@@ -2168,13 +2190,13 @@ func (p *Proxy) filterAndActOnResponseScan(
 	case config.ActionStrip:
 		recordResponseSignal(session.SignalStrip)
 		out = result.TransformedContent
-		log.LogResponseScan(audit.NewHTTPLogContext("", displayURL, clientIP, requestID, agent), config.ActionStrip, len(result.Matches), patternNames, bundleRules)
+		log.LogResponseScan(newHTTPAuditContext(log, "", displayURL, clientIP, requestID, agent), config.ActionStrip, len(result.Matches), patternNames, bundleRules)
 	case config.ActionWarn:
 		recordResponseSignal(session.SignalNearMiss)
-		log.LogResponseScan(audit.NewHTTPLogContext("", displayURL, clientIP, requestID, agent), config.ActionWarn, len(result.Matches), patternNames, bundleRules)
+		log.LogResponseScan(newHTTPAuditContext(log, "", displayURL, clientIP, requestID, agent), config.ActionWarn, len(result.Matches), patternNames, bundleRules)
 	default:
 		recordResponseSignal(session.SignalNearMiss)
-		log.LogResponseScan(audit.NewHTTPLogContext("", displayURL, clientIP, requestID, agent), action, len(result.Matches), patternNames, bundleRules)
+		log.LogResponseScan(newHTTPAuditContext(log, "", displayURL, clientIP, requestID, agent), action, len(result.Matches), patternNames, bundleRules)
 	}
 	return false, out, true
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2165,10 +2165,10 @@ func (p *Proxy) filterAndActOnResponseScan(
 		})
 		switch d {
 		case hitl.DecisionAllow:
-			log.LogResponseScan(newHTTPAuditContext(log, "", displayURL, clientIP, requestID, agent), "ask:allow", len(result.Matches), patternNames, bundleRules)
+			log.LogResponseScan(newHTTPAuditContext(log, http.MethodGet, displayURL, clientIP, requestID, agent), "ask:allow", len(result.Matches), patternNames, bundleRules)
 		case hitl.DecisionStrip:
 			out = result.TransformedContent
-			log.LogResponseScan(newHTTPAuditContext(log, "", displayURL, clientIP, requestID, agent), "ask:strip", len(result.Matches), patternNames, bundleRules)
+			log.LogResponseScan(newHTTPAuditContext(log, http.MethodGet, displayURL, clientIP, requestID, agent), "ask:strip", len(result.Matches), patternNames, bundleRules)
 		default:
 			recordResponseSignal(session.SignalBlock)
 			reason := fmt.Sprintf("response blocked by operator: %s", strings.Join(patternNames, ", "))
@@ -2190,13 +2190,13 @@ func (p *Proxy) filterAndActOnResponseScan(
 	case config.ActionStrip:
 		recordResponseSignal(session.SignalStrip)
 		out = result.TransformedContent
-		log.LogResponseScan(newHTTPAuditContext(log, "", displayURL, clientIP, requestID, agent), config.ActionStrip, len(result.Matches), patternNames, bundleRules)
+		log.LogResponseScan(newHTTPAuditContext(log, http.MethodGet, displayURL, clientIP, requestID, agent), config.ActionStrip, len(result.Matches), patternNames, bundleRules)
 	case config.ActionWarn:
 		recordResponseSignal(session.SignalNearMiss)
-		log.LogResponseScan(newHTTPAuditContext(log, "", displayURL, clientIP, requestID, agent), config.ActionWarn, len(result.Matches), patternNames, bundleRules)
+		log.LogResponseScan(newHTTPAuditContext(log, http.MethodGet, displayURL, clientIP, requestID, agent), config.ActionWarn, len(result.Matches), patternNames, bundleRules)
 	default:
 		recordResponseSignal(session.SignalNearMiss)
-		log.LogResponseScan(newHTTPAuditContext(log, "", displayURL, clientIP, requestID, agent), action, len(result.Matches), patternNames, bundleRules)
+		log.LogResponseScan(newHTTPAuditContext(log, http.MethodGet, displayURL, clientIP, requestID, agent), action, len(result.Matches), patternNames, bundleRules)
 	}
 	return false, out, true
 }

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -5,6 +5,7 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -127,6 +128,10 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	cfg := rp.cfgPtr.Load()
 	sc := rp.scPtr.Load()
+	clientIP, requestID := requestMeta(r)
+	ctx := context.WithValue(r.Context(), ctxKeyClientIP, clientIP)
+	ctx = context.WithValue(ctx, ctxKeyRequestID, requestID)
+	r = r.WithContext(ctx)
 
 	// Kill switch: deny all traffic when active.
 	if rp.ks != nil && rp.ks.IsActive() {
@@ -173,7 +178,8 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 				action = config.ActionBlock
 			}
 			patternNames := dlpMatchNames(pathDLP.Matches)
-			rp.logger.LogBodyDLP(audit.LogContext{Method: r.Method, URL: r.URL.String()}, action,
+			rp.logger.LogBodyDLP(newHTTPAuditContext(rp.logger, r.Method, r.URL.String(), clientIP, requestID, ""),
+				action,
 				len(patternNames), patternNames, nil)
 
 			if action == config.ActionBlock && cfg.EnforceEnabled() {
@@ -195,7 +201,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 				action = config.ActionBlock
 			}
 			patternNames := dlpMatchNames(headerResult.DLPMatches)
-			rp.logger.LogHeaderDLP(audit.LogContext{Method: r.Method, URL: r.URL.String()}, headerResult.HeaderName,
+			rp.logger.LogHeaderDLP(newHTTPAuditContext(rp.logger, r.Method, r.URL.String(), clientIP, requestID, ""), headerResult.HeaderName,
 				action, patternNames, nil)
 
 			if action == config.ActionBlock && cfg.EnforceEnabled() {
@@ -231,7 +237,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 				Actor:      edition.ExtractAgent(r),
 				ActorAuth:  envelope.ActorAuthSelfDeclared, // Reverse proxy has no per-agent listener binding
 			}); envErr != nil {
-				rp.logger.LogAnomaly(audit.LogContext{Method: r.Method, URL: r.URL.String()}, "", fmt.Sprintf("mediation envelope injection failed: %v", envErr), 0.1)
+				rp.logger.LogAnomaly(newHTTPAuditContext(rp.logger, r.Method, r.URL.String(), clientIP, requestID, ""), "", fmt.Sprintf("mediation envelope injection failed: %v", envErr), 0.1)
 			}
 		}
 	}
@@ -308,10 +314,9 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 	if reason == "" {
 		reason = "request body contains secret patterns"
 	}
-	actx := audit.LogContext{
-		Method: r.Method,
-		URL:    r.URL.String(),
-	}
+	clientIP, _ := r.Context().Value(ctxKeyClientIP).(string)
+	requestID, _ := r.Context().Value(ctxKeyRequestID).(string)
+	actx := newHTTPAuditContext(rp.logger, r.Method, r.URL.String(), clientIP, requestID, "")
 	rp.logger.LogBodyDLP(actx, action, len(patternNames), patternNames, nil)
 
 	// Fail-closed: when bodyBytes is nil the body was consumed but couldn't
@@ -343,6 +348,8 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 	cfg := rp.cfgPtr.Load()
 	sc := rp.scPtr.Load()
+	clientIP, _ := resp.Request.Context().Value(ctxKeyClientIP).(string)
+	requestID, _ := resp.Request.Context().Value(ctxKeyRequestID).(string)
 
 	// Record the final client-visible status at each exit point, not here.
 	// The upstream status may be rewritten to 403 by scanning decisions.
@@ -367,10 +374,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 	mediaCT := resp.Header.Get("Content-Type")
 	mediaCTCanon := canonicalContentType(mediaCT)
 	if (isBinaryMIME(mediaCT) || contentTypeIsGeneric(mediaCTCanon)) && cfg.MediaPolicy.IsEnabled() {
-		actx := audit.LogContext{
-			Method: resp.Request.Method,
-			URL:    resp.Request.URL.String(),
-		}
+		actx := newHTTPAuditContext(rp.logger, resp.Request.Method, resp.Request.URL.String(), clientIP, requestID, "")
 		canonCT := mediaCTCanon
 		isImage := strings.HasPrefix(canonCT, "image/")
 		isDeclaredAudioVideo := !isImage && isBinaryMIME(mediaCT)
@@ -489,10 +493,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		return nil
 	}
 	if revRespExempt {
-		actx := audit.LogContext{
-			Method: resp.Request.Method,
-			URL:    resp.Request.URL.String(),
-		}
+		actx := newHTTPAuditContext(rp.logger, resp.Request.Method, resp.Request.URL.String(), clientIP, requestID, "")
 		rp.logger.LogResponseScanExempt(actx, revHost)
 	}
 
@@ -502,10 +503,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		_ = resp.Body.Close()
 		rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
 		rp.metrics.RecordReverseProxyScanBlocked(scanDirectionResponse, "compressed")
-		actx := audit.LogContext{
-			Method: resp.Request.Method,
-			URL:    resp.Request.URL.String(),
-		}
+		actx := newHTTPAuditContext(rp.logger, resp.Request.Method, resp.Request.URL.String(), clientIP, requestID, "")
 		rp.logger.LogResponseScan(actx, config.ActionBlock, 0, []string{"compressed_response"}, nil)
 		replaceWithBlockResponse(resp, []string{"compressed response cannot be scanned"})
 		return nil
@@ -533,10 +531,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		_ = resp.Body.Close()
 		rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
 		rp.metrics.RecordReverseProxyScanBlocked(scanDirectionResponse, "oversized")
-		actx := audit.LogContext{
-			Method: resp.Request.Method,
-			URL:    resp.Request.URL.String(),
-		}
+		actx := newHTTPAuditContext(rp.logger, resp.Request.Method, resp.Request.URL.String(), clientIP, requestID, "")
 		rp.logger.LogResponseScan(actx, config.ActionBlock, 0, []string{"oversized_response"}, nil)
 		replaceWithBlockResponse(resp, []string{"response exceeds scanning limit"})
 		return nil
@@ -620,10 +615,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 	for _, m := range result.Matches {
 		patternNames = append(patternNames, m.PatternName)
 	}
-	actx := audit.LogContext{
-		Method: resp.Request.Method,
-		URL:    resp.Request.URL.String(),
-	}
+	actx := newHTTPAuditContext(rp.logger, resp.Request.Method, resp.Request.URL.String(), clientIP, requestID, "")
 	rp.logger.LogResponseScan(actx, action, len(patternNames), patternNames, nil)
 
 	// block and ask: unconditional block regardless of enforce mode.
@@ -676,10 +668,9 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 // to avoid leaking internal topology (dial addresses, TLS state, DNS).
 func (rp *ReverseProxyHandler) errorHandler(w http.ResponseWriter, r *http.Request, err error) {
 	rp.metrics.RecordReverseProxyRequest(r.Method, "502")
-	actx := audit.LogContext{
-		Method: r.Method,
-		URL:    r.URL.String(),
-	}
+	clientIP, _ := r.Context().Value(ctxKeyClientIP).(string)
+	requestID, _ := r.Context().Value(ctxKeyRequestID).(string)
+	actx := newHTTPAuditContext(rp.logger, r.Method, r.URL.String(), clientIP, requestID, "")
 	rp.logger.LogError(actx, err)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusBadGateway)

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -151,13 +151,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 	scanURL := scanScheme + "://" + parsed.Host + parsed.RequestURI()
 
-	actx := audit.LogContext{
-		Method:    "WS",
-		URL:       targetURL,
-		ClientIP:  clientIP,
-		RequestID: requestID,
-		Agent:     agent,
-	}
+	actx := newHTTPAuditContext(log, "WS", targetURL, clientIP, requestID, agent)
 
 	// Run through all 9 scanner layers.
 	result := sc.Scan(r.Context(), scanURL)


### PR DESCRIPTION
Closes #380
Closes #381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Hardened audit logging: context creation now validates required fields, enforces mutually exclusive identifiers, and surfaces construction errors; constructors now return errors when invalid.
  * Consolidated audit-context creation with new validated helpers and broader use across logging paths; external event emission extended to additional log paths.

* **Tests**
  * Expanded coverage for context validation, constructor error cases, and emitted-event field routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->