### PR TITLE
docs: deployment recipes by enforcement tier + misc housekeeping

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Pipelock Scan
         uses: luckyPipewrench/pipelock@39bd56ed252f2f8ce89b30bd5caa7e36d70e6678 # v2
@@ -72,6 +73,8 @@ jobs:
         go-version: ['1.25', '1.26']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -103,6 +106,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -123,6 +128,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -144,6 +150,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -164,6 +172,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6

--- a/.github/workflows/clusterfuzzlite.yaml
+++ b/.github/workflows/clusterfuzzlite.yaml
@@ -2,10 +2,12 @@ name: ClusterFuzzLite
 on:
   pull_request:
     branches: [ main ]
-permissions: read-all
+permissions:
+  contents: read
 jobs:
   PR:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -14,6 +16,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Build Fuzzers
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -14,6 +14,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,9 +20,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
@@ -41,6 +44,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.issue.number }}/merge
+          persist-credentials: false
 
       - name: Set up Go
         if: contains(github.event.comment.body, 'stats')

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -10,7 +10,14 @@ permissions:
 
 jobs:
   review:
+    # Restrict to repo members. Some /review modes execute code from the
+    # PR's merge ref in this workflow's secret scope, so the trigger needs
+    # a permission gate beyond the comment body check (the body is
+    # user-controlled, author_association is not).
     if: >-
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR') &&
       github.event.issue.pull_request &&
       (github.event.comment.body == '/review' ||
        github.event.comment.body == '/review fast' ||
@@ -56,11 +63,7 @@ jobs:
       - name: Run PR review
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
-          LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          PR_REVIEW_MODEL_FAST: ${{ secrets.PR_REVIEW_MODEL_FAST }}
-          PR_REVIEW_MODEL_DEEP: ${{ secrets.PR_REVIEW_MODEL_DEEP }}
           REVIEW_MODE: ${{ steps.mode.outputs.mode }}
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/reusable-scan.yml
+++ b/.github/workflows/reusable-scan.yml
@@ -59,6 +59,7 @@ jobs:
   scan:
     name: Pipelock Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       score: ${{ steps.pipelock.outputs.score }}
       findings-count: ${{ steps.pipelock.outputs.findings-count }}
@@ -69,6 +70,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Full history needed for PR diff scanning
+          persist-credentials: false
 
       - name: Run Pipelock
         id: pipelock

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -14,11 +14,14 @@ permissions:
 jobs:
   codeql:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       security-events: write
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ These are Pipelock's three pillars. Weight findings in these areas highest.
 ## Code Conventions
 
 - **Go 1.25+**, module: `github.com/luckyPipewrench/pipelock`
-- **18 direct dependencies.** Don't suggest adding deps without strong justification.
+- **20 direct dependencies.** Don't suggest adding deps without strong justification.
 - **golangci-lint v2** with 19 linters + gofumpt formatter (see `.golangci.yml`)
 - **`cmd.OutOrStdout()`** for output, never raw `fmt.Print`
 - **`0o600`** not `0600` for file permissions (gosec)

--- a/docs/guides/deployment-recipes.md
+++ b/docs/guides/deployment-recipes.md
@@ -4,6 +4,26 @@ Pipelock blocks bad traffic, but only if traffic actually goes through it. Setti
 
 The pattern is always the same: agent can only reach pipelock, pipelock can reach the internet.
 
+## Enforcement Tiers
+
+Pipelock supports three enforcement tiers. Pick the one that matches your threat model, then follow the recipe that implements it.
+
+| Tier | Name | What enforces it | Bypass surface | Recommended when |
+|------|------|------------------|----------------|------------------|
+| 1 | **Soft** (`HTTPS_PROXY`, K8s sidecar) | Agent cooperation | Raw sockets, tools that ignore proxy env vars, any container sharing the pod network namespace | Local dev, trusted agents, quick start |
+| 2 | **Enforced** (kernel network boundary) | Container runtime network namespace or kernel per-UID packet filter | Container escape or kernel-level bypass | Most production workloads on a single host |
+| 3 | **Transparent** (separate proxy pod + NetworkPolicy egress lock) | Cluster CNI enforces that the agent pod can only reach the pipelock Service IP | CNI misconfiguration or a CNI vulnerability | Zero-trust deployments, untrusted agents, fleet scale |
+
+Each tier is strictly stronger than the previous one. Tier 1 assumes the agent cooperates with `HTTPS_PROXY`. Tier 2 makes cooperation irrelevant because a kernel-enforced boundary drops direct egress from the agent. Tier 3 moves pipelock to its own pod so the agent's container has no network path except the pipelock Service endpoint — even a compromised agent binary can't bypass it without escaping the CNI.
+
+**Picking a tier:**
+
+- **Tier 1 (Soft):** `HTTPS_PROXY` env var, or [Kubernetes sidecar](#sidecar-deployment) where pipelock runs in the same pod as the agent. Fast to set up, no isolation guarantees — the agent must cooperate. The K8s sidecar is in this tier because the agent container shares the pod's network namespace with pipelock and can reach the internet directly without going through pipelock; NetworkPolicy filters the pod's egress, not the container-to-container traffic within the pod. Good for local development, CI where the agent is trusted, and K8s quickstart.
+- **Tier 2 (Enforced):** [Docker Compose with `internal: true` network](#docker-compose-recommended-for-local-development) on a single host (Docker creates an isolated network namespace with no gateway, so pipelock is the agent's only route out), [Linux host firewall rules](#iptables--nftables-linux) (iptables/nftables `--uid-owner` filtering drops packets from the agent user unless destined for pipelock), or [macOS PF per-user filtering](#macos-pf) (PF drops packets from the agent user unless destined for pipelock). In all three, a kernel-enforced boundary drops direct agent egress; raw sockets don't help because the kernel drops the packets before they leave the host.
+- **Tier 3 (Transparent):** [Kubernetes separate-pod pattern with NetworkPolicy](#kubernetes-with-networkpolicy) restricting the agent pod's egress to only the pipelock Service IP. Pipelock runs as its own Deployment, not as a sidecar. The agent pod has no route to the internet; it can only reach the pipelock Service endpoint. This is the strongest tier pipelock supports today with zero agent cooperation required.
+
+> **Future work: kernel-level transparent interception.** TPROXY / `IP_TRANSPARENT`-based interception that redirects packets at the kernel before they leave the host would let pipelock transparently capture agent traffic without any agent cooperation or per-UID filtering. Pipelock does not currently set `IP_TRANSPARENT` on its listen socket, so a TPROXY recipe requires pipelock code changes, not just documentation. This is on the roadmap.
+
 ## Docker Compose (Recommended for Local Development)
 
 The quickest way to get full network isolation. Pipelock generates this for you:


### PR DESCRIPTION
## Summary

Three small housekeeping changes bundled together. The deployment recipe refresh is the main change; the other two are minor tidying.

- **`docs:` lead deployment recipes with named enforcement tiers.** Reorganizes `docs/guides/deployment-recipes.md` to introduce a three-tier framing (Soft / Enforced / Transparent) for the existing recipes. Readers pick a tier that matches their threat model and then follow the recipe that implements it. The existing recipes are unchanged — this only adds the tier overview at the top plus a short "future work" note on kernel-level transparent interception.

- **`docs:` refresh stale dependency count in AGENTS.md.** Direct dep count drifted from 18 to 20. Verified via `make stats`.

- **`ci:` tidy the pr-review workflow.** Restricts the `/review` slash command to repo members (OWNER / MEMBER / COLLABORATOR) and removes several unused env var references for a LiteLLM fallback path that was never configured as a secret.

### Tier categorization notes

- **Tier 1 Soft:** `HTTPS_PROXY` env var and the Kubernetes sidecar pattern. Both rely on agent cooperation. The K8s sidecar is in Tier 1 (not Tier 2) because the agent container shares the pod's network namespace with pipelock and can reach the internet directly; NetworkPolicy filters pod egress, not container-to-container traffic within the pod.
- **Tier 2 Enforced:** kernel-enforced network boundary. Docker Compose \`internal: true\` network, Linux \`--uid-owner\` firewall rules, macOS PF per-user filtering. In all three, the kernel drops direct agent egress unless destined for pipelock.
- **Tier 3 Transparent:** separate pipelock pod + NetworkPolicy egress lock on the agent pod. CNI enforces with zero agent cooperation required.

A \`> Future work\` note explains that TPROXY-based kernel interception would let pipelock transparently capture traffic without per-UID filtering but requires pipelock code changes and is not documented yet.

## Diff stat

\`\`\`
.github/workflows/pr-review.yaml  | 11 +++++++----
AGENTS.md                         |  2 +-
docs/guides/deployment-recipes.md | 20 ++++++++++++++++++++
3 files changed, 28 insertions(+), 5 deletions(-)
\`\`\`

No Go code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security in GitHub workflows with stricter credential handling across checkout steps.
  * Restricted PR review workflow access to authorized contributors only.
  * Added execution timeout configurations across multiple workflows to prevent runaway jobs.
  * Updated project dependency count to 20.

* **Documentation**
  * Added "Enforcement Tiers" section to deployment guides, defining three network-enforcement modes with tier-specific bypass prevention strategies and recommended deployment contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->