### PR TITLE
Add posture capsule emit scaffold

### DIFF
--- a/docs/guides/posture-capsule.md
+++ b/docs/guides/posture-capsule.md
@@ -1,0 +1,128 @@
+<!--
+Copyright 2026 Josh Waldrep
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Posture capsule
+
+A posture capsule is a signed `proof.json` artifact that captures the current
+Pipelock posture at one point in time. It is intended for operators who need a
+portable record of:
+
+- the loaded tool version
+- a hash of the active config
+- discovery counts for local MCP client protection
+- simulated scanner coverage
+- current flight recorder receipt activity
+
+## When to generate one
+
+Generate a capsule when you want a signed snapshot of the current installation,
+for example:
+
+- after enabling or changing the flight recorder
+- before handing an environment to another operator
+- before attaching posture evidence to a ticket or audit trail
+- after config changes that should be reflected in signed evidence
+
+## Emit a capsule
+
+```bash
+pipelock posture emit --config pipelock.yaml --output .pipelock/posture
+```
+
+The command writes:
+
+- `.pipelock/posture/proof.json`
+
+`proof.json` is written with `0o600` permissions.
+
+## Signing model
+
+`pipelock posture emit` reuses the Ed25519 private key configured at
+`flight_recorder.signing_key_path`.
+
+The signature covers canonical JSON for these fields:
+
+- `schema_version`
+- `generated_at`
+- `expires_at`
+- `tool_version`
+- `config_hash`
+- `evidence`
+
+The canonical form sorts object keys and omits extra whitespace so the signed
+payload is deterministic.
+
+## Verification model
+
+Consumers should verify:
+
+1. `schema_version` is supported.
+2. `expires_at` is still in the future.
+3. `signer_key_id` matches the trusted public key they expect.
+4. the Ed25519 signature matches the canonical JSON payload.
+
+The current scaffold exposes verification through the package API:
+
+```go
+err := posture.Verify(capsule, trustedPublicKey)
+```
+
+## Artifact shape
+
+Minimal example:
+
+```json
+{
+  "config_hash":"7d3ec7c0c7d1f2c9d5e44c4f1fbe2fbc08d63fcac2c7248d8c3066cb917d6d0d",
+  "evidence":{
+    "discover":{
+      "high_risk":0,
+      "parse_errors":0,
+      "protected_other":0,
+      "protected_pipelock":2,
+      "total_clients":1,
+      "total_servers":2,
+      "unknown":0,
+      "unprotected":0
+    },
+    "flight_recorder":{
+      "last_receipt_at":"2026-04-11T13:05:12Z",
+      "receipt_count":4,
+      "scanner_verdict":{
+        "dlp":{"allow":0,"block":3,"warn":0},
+        "unknown":{"allow":1,"block":0,"warn":0}
+      }
+    },
+    "simulate":{
+      "config_file":"",
+      "failed":0,
+      "grade":"A",
+      "known_limitations":0,
+      "mode":"balanced",
+      "passed":24,
+      "percentage":100,
+      "scenarios":[],
+      "total":24
+    },
+    "verify_install":{
+      "flight_recorder_active":true,
+      "proxying":true,
+      "receipt_count":4
+    }
+  },
+  "expires_at":"2026-05-11T13:05:12Z",
+  "generated_at":"2026-04-11T13:05:12Z",
+  "schema_version":"1",
+  "signature":"c1b8b9c4f4d2...",
+  "signer_key_id":"9f6b9d7c...",
+  "tool_version":"0.1.0-dev"
+}
+```
+
+## Notes
+
+- The scaffold writes only `proof.json`.
+- Human-readable summaries, CI gates, scores, SARIF, and badges are follow-up
+  work.

--- a/internal/cli/posture.go
+++ b/internal/cli/posture.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	posturepkg "github.com/luckyPipewrench/pipelock/internal/posture"
+)
+
+func postureCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "posture",
+		Short: "Generate signed posture evidence",
+	}
+
+	cmd.AddCommand(postureEmitCmd())
+	return cmd
+}
+
+func postureEmitCmd() *cobra.Command {
+	var (
+		configFile     string
+		outputDir      string
+		expirationDays int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "emit",
+		Short: "Emit a signed posture capsule",
+		Long: `Generate a signed posture capsule from the current config, discovery
+state, simulated scanner coverage, and flight recorder receipts.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := cliutil.LoadConfigOrDefault(configFile)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			capsule, err := posturepkg.Emit(cfg, posturepkg.Options{
+				ExpirationDays: expirationDays,
+			})
+			if err != nil {
+				return fmt.Errorf("emit posture capsule: %w", err)
+			}
+
+			path, err := posturepkg.WriteProofJSON(outputDir, capsule)
+			if err != nil {
+				return fmt.Errorf("write posture capsule: %w", err)
+			}
+
+			// TODO: write proof.md once the human-readable posture summary lands.
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s\n", path)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&configFile, "config", "c", "", "config file (default: built-in defaults)")
+	cmd.Flags().StringVarP(&outputDir, "output", "o", posturepkg.DefaultOutputDir, "output directory for posture artifacts")
+	cmd.Flags().IntVar(&expirationDays, "expiration-days", 0, "days until the capsule expires (default 30)")
+	return cmd
+}

--- a/internal/cli/posture_test.go
+++ b/internal/cli/posture_test.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	posturepkg "github.com/luckyPipewrench/pipelock/internal/posture"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestPostureEmitCmdSuccess(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "signing.key")
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("signing.SavePrivateKey(): %v", err)
+	}
+
+	recorderDir := filepath.Join(t.TempDir(), "recorder")
+	writeCLIReceipt(t, recorderDir, priv)
+
+	cfg := config.Defaults()
+	cfg.FlightRecorder.Enabled = true
+	cfg.FlightRecorder.Dir = recorderDir
+	cfg.FlightRecorder.SigningKeyPath = keyPath
+
+	cfgPath := writeCLIConfig(t, cfg)
+	outDir := filepath.Join(t.TempDir(), "out")
+
+	var stdout bytes.Buffer
+	cmd := rootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"posture", "emit", "--config", cfgPath, "--output", outDir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute(): %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "Wrote "+filepath.Join(outDir, posturepkg.ProofFilename)) {
+		t.Fatalf("stdout = %q, want write message", stdout.String())
+	}
+
+	proofPath := filepath.Clean(filepath.Join(outDir, posturepkg.ProofFilename))
+	data, err := os.ReadFile(proofPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(): %v", err)
+	}
+
+	var capsule posturepkg.Capsule
+	if err := json.Unmarshal(data, &capsule); err != nil {
+		t.Fatalf("json.Unmarshal(): %v", err)
+	}
+
+	if err := posturepkg.Verify(&capsule, pub); err != nil {
+		t.Fatalf("posture.Verify(): %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(outDir, "proof.md")); !os.IsNotExist(err) {
+		t.Fatalf("proof.md should not exist, got err=%v", err)
+	}
+}
+
+func TestPostureEmitCmdMissingKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := config.Defaults()
+	cfg.FlightRecorder.Enabled = true
+	cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "recorder")
+
+	cfgPath := writeCLIConfig(t, cfg)
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"posture", "emit", "--config", cfgPath})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "flight_recorder.signing_key_path is required") {
+		t.Fatalf("cmd.Execute() error = %v, want missing signing key path", err)
+	}
+}
+
+func TestPostureEmitCmdBadOutputDir(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "signing.key")
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("signing.SavePrivateKey(): %v", err)
+	}
+
+	recorderDir := filepath.Join(t.TempDir(), "recorder")
+	writeCLIReceipt(t, recorderDir, priv)
+
+	cfg := config.Defaults()
+	cfg.FlightRecorder.Enabled = true
+	cfg.FlightRecorder.Dir = recorderDir
+	cfg.FlightRecorder.SigningKeyPath = keyPath
+
+	cfgPath := writeCLIConfig(t, cfg)
+
+	badOutput := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(badOutput, []byte("x"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"posture", "emit", "--config", cfgPath, "--output", badOutput})
+
+	err = cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "create output directory") {
+		t.Fatalf("cmd.Execute() error = %v, want output dir failure", err)
+	}
+}
+
+func writeCLIConfig(t *testing.T, cfg *config.Config) string {
+	t.Helper()
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("yaml.Marshal(): %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+	return path
+}
+
+func writeCLIReceipt(t *testing.T, dir string, priv ed25519.PrivateKey) {
+	t.Helper()
+
+	rec, err := recorder.New(recorder.Config{
+		Enabled:         true,
+		Dir:             dir,
+		SignCheckpoints: true,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New(): %v", err)
+	}
+	defer func() {
+		if err := rec.Close(); err != nil {
+			t.Fatalf("rec.Close(): %v", err)
+		}
+	}()
+
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: "cfg-hash",
+	})
+	if emitter == nil {
+		t.Fatal("receipt.NewEmitter() returned nil")
+	}
+
+	if err := emitter.Emit(receipt.EmitOpts{
+		ActionID:  "cli-action",
+		Verdict:   config.ActionBlock,
+		Layer:     "dlp",
+		Transport: "forward",
+		Method:    "GET",
+		Target:    "https://example.com",
+		RequestID: "req-cli",
+	}); err != nil {
+		t.Fatalf("emitter.Emit(): %v", err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -69,6 +69,8 @@ Quick start:
 		assess.Cmd(),
 		// Policy capture/replay
 		policy.Cmd(),
+		// Posture capsules
+		postureCmd(),
 		// Audit & reporting
 		audit.Cmd(),
 		// Canary tokens

--- a/internal/posture/posture.go
+++ b/internal/posture/posture.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
@@ -39,6 +40,8 @@ const (
 
 	// ProofFilename is the JSON artifact written by posture emit.
 	ProofFilename = "proof.json"
+
+	evidenceFilePrefix = "evidence-"
 )
 
 var (
@@ -382,7 +385,7 @@ func collectFlightRecorderEvidence(cfg *config.Config) (FlightRecorderCounts, er
 			continue
 		}
 		name := entry.Name()
-		if filepath.Ext(name) == ".jsonl" && len(name) >= len("evidence-") && name[:len("evidence-")] == "evidence-" {
+		if filepath.Ext(name) == ".jsonl" && strings.HasPrefix(name, evidenceFilePrefix) {
 			files = append(files, filepath.Join(dir, name))
 		}
 	}

--- a/internal/posture/posture.go
+++ b/internal/posture/posture.go
@@ -41,6 +41,14 @@ const (
 	ProofFilename = "proof.json"
 )
 
+var (
+	canonicalize     = canonicalJSON
+	jsonMarshal      = json.Marshal
+	userHomeDir      = os.UserHomeDir
+	discoverConfigs  = discover.Discover
+	readRecorderFile = recorder.ReadEntries
+)
+
 // Capsule is the signed posture artifact emitted by pipelock posture emit.
 type Capsule struct {
 	SchemaVersion string         `json:"schema_version"`
@@ -227,7 +235,7 @@ func WriteProofJSON(outputDir string, capsule *Capsule) (string, error) {
 // MarshalJSON emits deterministic canonical JSON for signature stability.
 func (c Capsule) MarshalJSON() ([]byte, error) {
 	type alias Capsule
-	return canonicalJSON(alias(c))
+	return canonicalize(alias(c))
 }
 
 // UnmarshalJSON decodes a posture capsule from JSON.
@@ -270,9 +278,27 @@ func resolveSigningKey(cfg *config.Config, key ed25519.PrivateKey) (ed25519.Priv
 
 func resolveEvidence(cfg *config.Config, preload *EvidenceBundle) (EvidenceBundle, error) {
 	if preload != nil {
-		return *preload, nil
+		return cloneEvidenceBundle(*preload), nil
 	}
 	return collectEvidence(cfg)
+}
+
+func cloneEvidenceBundle(bundle EvidenceBundle) EvidenceBundle {
+	cloned := bundle
+	if bundle.Simulate.Scenarios != nil {
+		cloned.Simulate.Scenarios = append([]audit.ScenarioResult(nil), bundle.Simulate.Scenarios...)
+	}
+	if bundle.FlightRecorder.LastReceiptAt != nil {
+		ts := *bundle.FlightRecorder.LastReceiptAt
+		cloned.FlightRecorder.LastReceiptAt = &ts
+	}
+	if bundle.FlightRecorder.ScannerVerdict != nil {
+		cloned.FlightRecorder.ScannerVerdict = make(map[string]VerdictCount, len(bundle.FlightRecorder.ScannerVerdict))
+		for key, value := range bundle.FlightRecorder.ScannerVerdict {
+			cloned.FlightRecorder.ScannerVerdict[key] = value
+		}
+	}
+	return cloned
 }
 
 func collectEvidence(cfg *config.Config) (EvidenceBundle, error) {
@@ -281,10 +307,7 @@ func collectEvidence(cfg *config.Config) (EvidenceBundle, error) {
 		return EvidenceBundle{}, err
 	}
 
-	simulateEvidence, err := collectSimulateEvidence(cfg)
-	if err != nil {
-		return EvidenceBundle{}, err
-	}
+	simulateEvidence := collectSimulateEvidence(cfg)
 
 	flightRecorderEvidence, err := collectFlightRecorderEvidence(cfg)
 	if err != nil {
@@ -306,12 +329,12 @@ func collectEvidence(cfg *config.Config) (EvidenceBundle, error) {
 }
 
 func collectDiscoverEvidence() (DiscoverEvidence, error) {
-	home, err := os.UserHomeDir()
+	home, err := userHomeDir()
 	if err != nil {
 		return DiscoverEvidence{}, fmt.Errorf("resolve home directory: %w", err)
 	}
 
-	report, err := discover.Discover(home)
+	report, err := discoverConfigs(home)
 	if err != nil {
 		return DiscoverEvidence{}, fmt.Errorf("discover: %w", err)
 	}
@@ -328,12 +351,12 @@ func collectDiscoverEvidence() (DiscoverEvidence, error) {
 	}, nil
 }
 
-func collectSimulateEvidence(cfg *config.Config) (audit.SimulateResult, error) {
+func collectSimulateEvidence(cfg *config.Config) audit.SimulateResult {
 	sc := scanner.New(cfg)
 	defer sc.Close()
 
 	scenarios := audit.BuildSimScenarios(cfg, sc)
-	return audit.RunSimulation(scenarios, "", cfg.Mode), nil
+	return audit.RunSimulation(scenarios, "", cfg.Mode)
 }
 
 func collectFlightRecorderEvidence(cfg *config.Config) (FlightRecorderCounts, error) {
@@ -367,7 +390,7 @@ func collectFlightRecorderEvidence(cfg *config.Config) (FlightRecorderCounts, er
 
 	var lastReceipt time.Time
 	for _, file := range files {
-		records, err := recorder.ReadEntries(file)
+		records, err := readRecorderFile(file)
 		if err != nil {
 			return FlightRecorderCounts{}, fmt.Errorf("read recorder file %s: %w", filepath.Base(file), err)
 		}
@@ -416,7 +439,7 @@ func collectFlightRecorderEvidence(cfg *config.Config) (FlightRecorderCounts, er
 }
 
 func hashConfig(cfg *config.Config) (string, error) {
-	canonical, err := canonicalJSON(cfg)
+	canonical, err := canonicalize(cfg)
 	if err != nil {
 		return "", err
 	}
@@ -425,7 +448,7 @@ func hashConfig(cfg *config.Config) (string, error) {
 }
 
 func (c Capsule) signableJSON() ([]byte, error) {
-	return canonicalJSON(signableCapsule{
+	return canonicalize(signableCapsule{
 		SchemaVersion: c.SchemaVersion,
 		GeneratedAt:   c.GeneratedAt,
 		ExpiresAt:     c.ExpiresAt,
@@ -436,7 +459,7 @@ func (c Capsule) signableJSON() ([]byte, error) {
 }
 
 func canonicalJSON(v any) ([]byte, error) {
-	raw, err := json.Marshal(v)
+	raw, err := jsonMarshal(v)
 	if err != nil {
 		return nil, err
 	}
@@ -467,7 +490,7 @@ func appendCanonical(buf *bytes.Buffer, v any) error {
 			buf.WriteString("false")
 		}
 	case string:
-		data, err := json.Marshal(value)
+		data, err := jsonMarshal(value)
 		if err != nil {
 			return err
 		}
@@ -475,7 +498,7 @@ func appendCanonical(buf *bytes.Buffer, v any) error {
 	case json.Number:
 		buf.WriteString(value.String())
 	case float64:
-		data, err := json.Marshal(value)
+		data, err := jsonMarshal(value)
 		if err != nil {
 			return err
 		}
@@ -502,7 +525,7 @@ func appendCanonical(buf *bytes.Buffer, v any) error {
 			if i > 0 {
 				buf.WriteByte(',')
 			}
-			keyJSON, err := json.Marshal(key)
+			keyJSON, err := jsonMarshal(key)
 			if err != nil {
 				return err
 			}
@@ -514,7 +537,7 @@ func appendCanonical(buf *bytes.Buffer, v any) error {
 		}
 		buf.WriteByte('}')
 	default:
-		data, err := json.Marshal(value)
+		data, err := jsonMarshal(value)
 		if err != nil {
 			return err
 		}

--- a/internal/posture/posture.go
+++ b/internal/posture/posture.go
@@ -246,7 +246,10 @@ func (o Options) withDefaults() Options {
 }
 
 func resolveSigningKey(cfg *config.Config, key ed25519.PrivateKey) (ed25519.PrivateKey, error) {
-	if len(key) == ed25519.PrivateKeySize {
+	if len(key) > 0 {
+		if len(key) != ed25519.PrivateKeySize {
+			return nil, fmt.Errorf("invalid signing key length: got %d, want %d", len(key), ed25519.PrivateKeySize)
+		}
 		return key, nil
 	}
 
@@ -331,9 +334,7 @@ func collectSimulateEvidence(cfg *config.Config) (audit.SimulateResult, error) {
 }
 
 func collectFlightRecorderEvidence(cfg *config.Config) (FlightRecorderCounts, error) {
-	result := FlightRecorderCounts{
-		ScannerVerdict: make(map[string]VerdictCount),
-	}
+	result := FlightRecorderCounts{}
 
 	if cfg.FlightRecorder.Dir == "" {
 		return result, nil
@@ -347,6 +348,7 @@ func collectFlightRecorderEvidence(cfg *config.Config) (FlightRecorderCounts, er
 		}
 		return FlightRecorderCounts{}, fmt.Errorf("read flight recorder dir: %w", err)
 	}
+	result.ScannerVerdict = make(map[string]VerdictCount)
 
 	var files []string
 	for _, entry := range entries {

--- a/internal/posture/posture.go
+++ b/internal/posture/posture.go
@@ -118,6 +118,9 @@ func Emit(cfg *config.Config, opts Options) (*Capsule, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is required")
 	}
+	if opts.ExpirationDays < 0 {
+		return nil, fmt.Errorf("expiration_days must be >= 0")
+	}
 
 	opts = opts.withDefaults()
 
@@ -239,7 +242,7 @@ func (c *Capsule) UnmarshalJSON(data []byte) error {
 }
 
 func (o Options) withDefaults() Options {
-	if o.ExpirationDays <= 0 {
+	if o.ExpirationDays == 0 {
 		o.ExpirationDays = DefaultExpirationDays
 	}
 	return o

--- a/internal/posture/posture.go
+++ b/internal/posture/posture.go
@@ -1,0 +1,519 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package posture emits signed posture capsules for the current pipelock state.
+package posture
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	"github.com/luckyPipewrench/pipelock/internal/cli/audit"
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/discover"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const (
+	// SchemaVersion is the posture capsule schema version.
+	SchemaVersion = "1"
+
+	// DefaultExpirationDays is the default validity period for posture capsules.
+	DefaultExpirationDays = 30
+
+	// DefaultOutputDir is the default output directory for posture artifacts.
+	DefaultOutputDir = ".pipelock/posture"
+
+	// ProofFilename is the JSON artifact written by posture emit.
+	ProofFilename = "proof.json"
+)
+
+// Capsule is the signed posture artifact emitted by pipelock posture emit.
+type Capsule struct {
+	SchemaVersion string         `json:"schema_version"`
+	GeneratedAt   time.Time      `json:"generated_at"`
+	ExpiresAt     time.Time      `json:"expires_at"`
+	ToolVersion   string         `json:"tool_version"`
+	ConfigHash    string         `json:"config_hash"`
+	Evidence      EvidenceBundle `json:"evidence"`
+	Signature     string         `json:"signature"`
+	SignerKeyID   string         `json:"signer_key_id"`
+}
+
+// EvidenceBundle contains the raw posture evidence collected at emit time.
+type EvidenceBundle struct {
+	Discover       DiscoverEvidence      `json:"discover"`
+	VerifyInstall  VerifyInstallEvidence `json:"verify_install"`
+	Simulate       audit.SimulateResult  `json:"simulate"`
+	FlightRecorder FlightRecorderCounts  `json:"flight_recorder"`
+}
+
+// DiscoverEvidence captures high-level MCP protection counts.
+type DiscoverEvidence struct {
+	TotalClients      int `json:"total_clients"`
+	TotalServers      int `json:"total_servers"`
+	ProtectedPipelock int `json:"protected_pipelock"`
+	ProtectedOther    int `json:"protected_other"`
+	Unprotected       int `json:"unprotected"`
+	Unknown           int `json:"unknown"`
+	HighRisk          int `json:"high_risk"`
+	ParseErrors       int `json:"parse_errors"`
+}
+
+// VerifyInstallEvidence captures whether pipelock appears to be actively proxying.
+type VerifyInstallEvidence struct {
+	FlightRecorderActive bool `json:"flight_recorder_active"`
+	ReceiptCount         int  `json:"receipt_count"`
+	Proxying             bool `json:"proxying"`
+}
+
+// FlightRecorderCounts summarizes signed receipt activity.
+type FlightRecorderCounts struct {
+	ReceiptCount   int                     `json:"receipt_count"`
+	LastReceiptAt  *time.Time              `json:"last_receipt_at,omitempty"`
+	ScannerVerdict map[string]VerdictCount `json:"scanner_verdict"`
+}
+
+// VerdictCount tracks allow/block/warn verdicts for one scanner layer.
+type VerdictCount struct {
+	Allow int `json:"allow"`
+	Block int `json:"block"`
+	Warn  int `json:"warn"`
+}
+
+// Options configures posture capsule emission.
+type Options struct {
+	ExpirationDays int
+	SigningKey     ed25519.PrivateKey
+	EvidenceBundle *EvidenceBundle
+}
+
+type signableCapsule struct {
+	SchemaVersion string         `json:"schema_version"`
+	GeneratedAt   time.Time      `json:"generated_at"`
+	ExpiresAt     time.Time      `json:"expires_at"`
+	ToolVersion   string         `json:"tool_version"`
+	ConfigHash    string         `json:"config_hash"`
+	Evidence      EvidenceBundle `json:"evidence"`
+	// SignerKeyID is intentionally excluded: the signature cannot cover its own
+	// verification key identifier. Verify() pins the trusted public key and
+	// separately checks SignerKeyID as a defense-in-depth consistency check.
+}
+
+// Emit builds and signs a posture capsule from the current state.
+func Emit(cfg *config.Config, opts Options) (*Capsule, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+
+	opts = opts.withDefaults()
+
+	privKey, err := resolveSigningKey(cfg, opts.SigningKey)
+	if err != nil {
+		return nil, err
+	}
+
+	evidence, err := resolveEvidence(cfg, opts.EvidenceBundle)
+	if err != nil {
+		return nil, err
+	}
+
+	configHash, err := hashConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("hash config: %w", err)
+	}
+
+	now := time.Now().UTC()
+	capsule := &Capsule{
+		SchemaVersion: SchemaVersion,
+		GeneratedAt:   now,
+		ExpiresAt:     now.AddDate(0, 0, opts.ExpirationDays),
+		ToolVersion:   cliutil.Version,
+		ConfigHash:    configHash,
+		Evidence:      evidence,
+		SignerKeyID:   hex.EncodeToString(privKey.Public().(ed25519.PublicKey)),
+	}
+
+	payload, err := capsule.signableJSON()
+	if err != nil {
+		return nil, fmt.Errorf("marshal signable capsule: %w", err)
+	}
+
+	capsule.Signature = hex.EncodeToString(ed25519.Sign(privKey, payload))
+	return capsule, nil
+}
+
+// Verify validates the capsule signature, expiration, and schema version.
+func Verify(capsule *Capsule, trustedKey ed25519.PublicKey) error {
+	if capsule == nil {
+		return fmt.Errorf("capsule is required")
+	}
+	if capsule.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("unsupported schema_version %q", capsule.SchemaVersion)
+	}
+	if len(trustedKey) != ed25519.PublicKeySize {
+		return fmt.Errorf("invalid trusted key length: got %d, want %d", len(trustedKey), ed25519.PublicKeySize)
+	}
+	if capsule.ExpiresAt.Before(time.Now().UTC()) {
+		return fmt.Errorf("capsule expired at %s", capsule.ExpiresAt.Format(time.RFC3339))
+	}
+	if capsule.Signature == "" {
+		return fmt.Errorf("capsule signature is required")
+	}
+
+	expectedKeyID := hex.EncodeToString(trustedKey)
+	if capsule.SignerKeyID != expectedKeyID {
+		return fmt.Errorf("signer_key_id %q does not match trusted key", capsule.SignerKeyID)
+	}
+
+	sig, err := hex.DecodeString(capsule.Signature)
+	if err != nil {
+		return fmt.Errorf("decode signature: %w", err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return fmt.Errorf("invalid signature length: got %d, want %d", len(sig), ed25519.SignatureSize)
+	}
+
+	payload, err := capsule.signableJSON()
+	if err != nil {
+		return fmt.Errorf("marshal signable capsule: %w", err)
+	}
+	if !ed25519.Verify(trustedKey, payload, sig) {
+		return fmt.Errorf("signature verification failed")
+	}
+	return nil
+}
+
+// WriteProofJSON writes proof.json atomically into the output directory.
+func WriteProofJSON(outputDir string, capsule *Capsule) (string, error) {
+	if capsule == nil {
+		return "", fmt.Errorf("capsule is required")
+	}
+
+	cleanDir := filepath.Clean(outputDir)
+	if err := os.MkdirAll(cleanDir, 0o750); err != nil {
+		return "", fmt.Errorf("create output directory: %w", err)
+	}
+
+	data, err := json.Marshal(capsule)
+	if err != nil {
+		return "", fmt.Errorf("marshal capsule: %w", err)
+	}
+	data = append(data, '\n')
+
+	path := filepath.Join(cleanDir, ProofFilename)
+	if err := atomicfile.Write(path, data, 0o600); err != nil {
+		return "", fmt.Errorf("write %s: %w", ProofFilename, err)
+	}
+	return path, nil
+}
+
+// MarshalJSON emits deterministic canonical JSON for signature stability.
+func (c Capsule) MarshalJSON() ([]byte, error) {
+	type alias Capsule
+	return canonicalJSON(alias(c))
+}
+
+// UnmarshalJSON decodes a posture capsule from JSON.
+func (c *Capsule) UnmarshalJSON(data []byte) error {
+	type alias Capsule
+	var raw alias
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*c = Capsule(raw)
+	return nil
+}
+
+func (o Options) withDefaults() Options {
+	if o.ExpirationDays <= 0 {
+		o.ExpirationDays = DefaultExpirationDays
+	}
+	return o
+}
+
+func resolveSigningKey(cfg *config.Config, key ed25519.PrivateKey) (ed25519.PrivateKey, error) {
+	if len(key) == ed25519.PrivateKeySize {
+		return key, nil
+	}
+
+	keyPath := filepath.Clean(cfg.FlightRecorder.SigningKeyPath)
+	if keyPath == "." || cfg.FlightRecorder.SigningKeyPath == "" {
+		return nil, fmt.Errorf("flight_recorder.signing_key_path is required")
+	}
+
+	privKey, err := signing.LoadPrivateKeyFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("load signing key: %w", err)
+	}
+	return privKey, nil
+}
+
+func resolveEvidence(cfg *config.Config, preload *EvidenceBundle) (EvidenceBundle, error) {
+	if preload != nil {
+		return *preload, nil
+	}
+	return collectEvidence(cfg)
+}
+
+func collectEvidence(cfg *config.Config) (EvidenceBundle, error) {
+	discoverEvidence, err := collectDiscoverEvidence()
+	if err != nil {
+		return EvidenceBundle{}, err
+	}
+
+	simulateEvidence, err := collectSimulateEvidence(cfg)
+	if err != nil {
+		return EvidenceBundle{}, err
+	}
+
+	flightRecorderEvidence, err := collectFlightRecorderEvidence(cfg)
+	if err != nil {
+		return EvidenceBundle{}, err
+	}
+
+	verifyInstallEvidence := VerifyInstallEvidence{
+		FlightRecorderActive: cfg.FlightRecorder.Enabled && cfg.FlightRecorder.Dir != "" && flightRecorderEvidence.ScannerVerdict != nil,
+		ReceiptCount:         flightRecorderEvidence.ReceiptCount,
+		Proxying:             cfg.FlightRecorder.Enabled && flightRecorderEvidence.ReceiptCount > 0,
+	}
+
+	return EvidenceBundle{
+		Discover:       discoverEvidence,
+		VerifyInstall:  verifyInstallEvidence,
+		Simulate:       simulateEvidence,
+		FlightRecorder: flightRecorderEvidence,
+	}, nil
+}
+
+func collectDiscoverEvidence() (DiscoverEvidence, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return DiscoverEvidence{}, fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	report, err := discover.Discover(home)
+	if err != nil {
+		return DiscoverEvidence{}, fmt.Errorf("discover: %w", err)
+	}
+
+	return DiscoverEvidence{
+		TotalClients:      report.Summary.TotalClients,
+		TotalServers:      report.Summary.TotalServers,
+		ProtectedPipelock: report.Summary.ProtectedPipelock,
+		ProtectedOther:    report.Summary.ProtectedOther,
+		Unprotected:       report.Summary.Unprotected,
+		Unknown:           report.Summary.Unknown,
+		HighRisk:          report.Summary.HighRisk,
+		ParseErrors:       report.Summary.ParseErrors,
+	}, nil
+}
+
+func collectSimulateEvidence(cfg *config.Config) (audit.SimulateResult, error) {
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	scenarios := audit.BuildSimScenarios(cfg, sc)
+	return audit.RunSimulation(scenarios, "", cfg.Mode), nil
+}
+
+func collectFlightRecorderEvidence(cfg *config.Config) (FlightRecorderCounts, error) {
+	result := FlightRecorderCounts{
+		ScannerVerdict: make(map[string]VerdictCount),
+	}
+
+	if cfg.FlightRecorder.Dir == "" {
+		return result, nil
+	}
+
+	dir := filepath.Clean(cfg.FlightRecorder.Dir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return result, nil
+		}
+		return FlightRecorderCounts{}, fmt.Errorf("read flight recorder dir: %w", err)
+	}
+
+	var files []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if filepath.Ext(name) == ".jsonl" && len(name) >= len("evidence-") && name[:len("evidence-")] == "evidence-" {
+			files = append(files, filepath.Join(dir, name))
+		}
+	}
+	sort.Strings(files)
+
+	var lastReceipt time.Time
+	for _, file := range files {
+		records, err := recorder.ReadEntries(file)
+		if err != nil {
+			return FlightRecorderCounts{}, fmt.Errorf("read recorder file %s: %w", filepath.Base(file), err)
+		}
+		for _, record := range records {
+			if record.Type != "action_receipt" {
+				continue
+			}
+
+			detailJSON, err := json.Marshal(record.Detail)
+			if err != nil {
+				return FlightRecorderCounts{}, fmt.Errorf("marshal receipt detail: %w", err)
+			}
+			rcpt, err := receipt.Unmarshal(detailJSON)
+			if err != nil {
+				return FlightRecorderCounts{}, fmt.Errorf("decode receipt detail: %w", err)
+			}
+
+			result.ReceiptCount++
+			if rcpt.ActionRecord.Timestamp.After(lastReceipt) {
+				lastReceipt = rcpt.ActionRecord.Timestamp
+			}
+
+			layer := rcpt.ActionRecord.Layer
+			if layer == "" {
+				layer = "unknown"
+			}
+			counts := result.ScannerVerdict[layer]
+			switch rcpt.ActionRecord.Verdict {
+			case config.ActionAllow:
+				counts.Allow++
+			case config.ActionBlock:
+				counts.Block++
+			case config.ActionWarn:
+				counts.Warn++
+			}
+			result.ScannerVerdict[layer] = counts
+		}
+	}
+
+	if !lastReceipt.IsZero() {
+		lastReceipt = lastReceipt.UTC()
+		result.LastReceiptAt = &lastReceipt
+	}
+
+	return result, nil
+}
+
+func hashConfig(cfg *config.Config) (string, error) {
+	canonical, err := canonicalJSON(cfg)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func (c Capsule) signableJSON() ([]byte, error) {
+	return canonicalJSON(signableCapsule{
+		SchemaVersion: c.SchemaVersion,
+		GeneratedAt:   c.GeneratedAt,
+		ExpiresAt:     c.ExpiresAt,
+		ToolVersion:   c.ToolVersion,
+		ConfigHash:    c.ConfigHash,
+		Evidence:      c.Evidence,
+	})
+}
+
+func canonicalJSON(v any) ([]byte, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+
+	var parsed any
+	if err := dec.Decode(&parsed); err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := appendCanonical(&buf, parsed); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func appendCanonical(buf *bytes.Buffer, v any) error {
+	switch value := v.(type) {
+	case nil:
+		buf.WriteString("null")
+	case bool:
+		if value {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+	case string:
+		data, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		buf.Write(data)
+	case json.Number:
+		buf.WriteString(value.String())
+	case float64:
+		data, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		buf.Write(data)
+	case []any:
+		buf.WriteByte('[')
+		for i, item := range value {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := appendCanonical(buf, item); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte(']')
+	case map[string]any:
+		buf.WriteByte('{')
+		keys := make([]string, 0, len(value))
+		for key := range value {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for i, key := range keys {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			keyJSON, err := json.Marshal(key)
+			if err != nil {
+				return err
+			}
+			buf.Write(keyJSON)
+			buf.WriteByte(':')
+			if err := appendCanonical(buf, value[key]); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte('}')
+	default:
+		data, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		buf.Write(data)
+	}
+	return nil
+}

--- a/internal/posture/posture_test.go
+++ b/internal/posture/posture_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestCapsuleMarshalJSONDeterministic(t *testing.T) {
-	t.Parallel()
-
 	expectedCapsule := Capsule{
 		SchemaVersion: "1",
 		GeneratedAt:   time.Date(2026, time.April, 11, 17, 45, 0, 0, time.UTC),
@@ -57,8 +55,6 @@ func TestCapsuleMarshalJSONDeterministic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			var capsule Capsule
 			if err := json.Unmarshal([]byte(tt.input), &capsule); err != nil {
 				t.Fatalf("json.Unmarshal(): %v", err)
@@ -77,8 +73,6 @@ func TestCapsuleMarshalJSONDeterministic(t *testing.T) {
 }
 
 func TestEmitAndVerifyRoundTrip(t *testing.T) {
-	t.Parallel()
-
 	pub, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("ed25519.GenerateKey(): %v", err)
@@ -113,8 +107,6 @@ func TestEmitAndVerifyRoundTrip(t *testing.T) {
 }
 
 func TestVerifyExpiration(t *testing.T) {
-	t.Parallel()
-
 	pub, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("ed25519.GenerateKey(): %v", err)
@@ -142,7 +134,7 @@ func TestVerifyExpiration(t *testing.T) {
 		{
 			name: "near expiration",
 			mutate: func(c *Capsule) {
-				c.ExpiresAt = time.Now().UTC().Add(1 * time.Second)
+				c.ExpiresAt = time.Now().UTC().Add(1 * time.Minute)
 			},
 		},
 		{
@@ -174,8 +166,6 @@ func TestVerifyExpiration(t *testing.T) {
 }
 
 func TestVerifyRejectsSchemaVersionMismatch(t *testing.T) {
-	t.Parallel()
-
 	pub, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("ed25519.GenerateKey(): %v", err)
@@ -199,8 +189,6 @@ func TestVerifyRejectsSchemaVersionMismatch(t *testing.T) {
 }
 
 func TestVerifyDetectsTampering(t *testing.T) {
-	t.Parallel()
-
 	pub, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("ed25519.GenerateKey(): %v", err)
@@ -222,8 +210,6 @@ func TestVerifyDetectsTampering(t *testing.T) {
 }
 
 func TestEmitDefaultsExpirationDays(t *testing.T) {
-	t.Parallel()
-
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("ed25519.GenerateKey(): %v", err)
@@ -243,9 +229,53 @@ func TestEmitDefaultsExpirationDays(t *testing.T) {
 	}
 }
 
-func TestEmitRejectsNegativeExpirationDays(t *testing.T) {
-	t.Parallel()
+func TestEmitReturnsHashConfigError(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
 
+	restore := patchCanonicalize(func(v any) ([]byte, error) {
+		if _, ok := v.(*config.Config); ok {
+			return nil, fmt.Errorf("hash boom")
+		}
+		return canonicalJSON(v)
+	})
+	defer restore()
+
+	_, err = Emit(config.Defaults(), Options{
+		SigningKey:     priv,
+		EvidenceBundle: bundlePtr(testEvidenceBundle()),
+	})
+	if err == nil || !strings.Contains(err.Error(), "hash config: hash boom") {
+		t.Fatalf("Emit() error = %v, want hash config failure", err)
+	}
+}
+
+func TestEmitReturnsSignableMarshalError(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	restore := patchCanonicalize(func(v any) ([]byte, error) {
+		if _, ok := v.(signableCapsule); ok {
+			return nil, fmt.Errorf("signable boom")
+		}
+		return canonicalJSON(v)
+	})
+	defer restore()
+
+	_, err = Emit(config.Defaults(), Options{
+		SigningKey:     priv,
+		EvidenceBundle: bundlePtr(testEvidenceBundle()),
+	})
+	if err == nil || !strings.Contains(err.Error(), "marshal signable capsule: signable boom") {
+		t.Fatalf("Emit() error = %v, want signable marshal failure", err)
+	}
+}
+
+func TestEmitRejectsNegativeExpirationDays(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("ed25519.GenerateKey(): %v", err)
@@ -326,8 +356,6 @@ func TestEmitCollectsEvidenceAndWritesProof(t *testing.T) {
 }
 
 func TestEmitLoadsSigningKeyFromConfigPath(t *testing.T) {
-	t.Parallel()
-
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("ed25519.GenerateKey(): %v", err)
@@ -351,8 +379,6 @@ func TestEmitLoadsSigningKeyFromConfigPath(t *testing.T) {
 }
 
 func TestEmitMissingSigningKeyPath(t *testing.T) {
-	t.Parallel()
-
 	_, err := Emit(config.Defaults(), Options{EvidenceBundle: bundlePtr(testEvidenceBundle())})
 	if err == nil || !strings.Contains(err.Error(), "flight_recorder.signing_key_path is required") {
 		t.Fatalf("Emit() error = %v, want missing signing key path", err)
@@ -382,8 +408,6 @@ func TestEmitReturnsEvidenceCollectionError(t *testing.T) {
 }
 
 func TestEmitNilConfig(t *testing.T) {
-	t.Parallel()
-
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("ed25519.GenerateKey(): %v", err)
@@ -396,8 +420,6 @@ func TestEmitNilConfig(t *testing.T) {
 }
 
 func TestResolveSigningKeyLoadFailure(t *testing.T) {
-	t.Parallel()
-
 	cfg := config.Defaults()
 	cfg.FlightRecorder.SigningKeyPath = filepath.Join(t.TempDir(), "missing.key")
 
@@ -408,8 +430,6 @@ func TestResolveSigningKeyLoadFailure(t *testing.T) {
 }
 
 func TestResolveSigningKeyRejectsMalformedProvidedKey(t *testing.T) {
-	t.Parallel()
-
 	cfg := config.Defaults()
 	cfg.FlightRecorder.SigningKeyPath = filepath.Join(t.TempDir(), "ignored.key")
 
@@ -419,9 +439,29 @@ func TestResolveSigningKeyRejectsMalformedProvidedKey(t *testing.T) {
 	}
 }
 
-func TestVerifyValidationFailures(t *testing.T) {
-	t.Parallel()
+func TestResolveEvidenceClonesPreload(t *testing.T) {
+	preload := testEvidenceBundle()
+	cloned, err := resolveEvidence(config.Defaults(), &preload)
+	if err != nil {
+		t.Fatalf("resolveEvidence(): %v", err)
+	}
 
+	preload.Simulate.Scenarios[0].Name = "mutated"
+	*preload.FlightRecorder.LastReceiptAt = preload.FlightRecorder.LastReceiptAt.Add(24 * time.Hour)
+	preload.FlightRecorder.ScannerVerdict["alpha"] = VerdictCount{Warn: 9}
+
+	if got := cloned.Simulate.Scenarios[0].Name; got != "scenario-a" {
+		t.Fatalf("cloned Simulate.Scenarios[0].Name = %q, want scenario-a", got)
+	}
+	if got := cloned.FlightRecorder.ScannerVerdict["alpha"]; got != (VerdictCount{Allow: 1, Block: 2}) {
+		t.Fatalf("cloned ScannerVerdict[alpha] = %#v, want original counts", got)
+	}
+	if cloned.FlightRecorder.LastReceiptAt == preload.FlightRecorder.LastReceiptAt {
+		t.Fatal("LastReceiptAt pointer was aliased")
+	}
+}
+
+func TestVerifyValidationFailures(t *testing.T) {
 	pub, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("ed25519.GenerateKey(): %v", err)
@@ -508,9 +548,35 @@ func TestVerifyValidationFailures(t *testing.T) {
 	}
 }
 
-func TestWriteProofJSONValidationFailures(t *testing.T) {
-	t.Parallel()
+func TestVerifyReturnsSignableMarshalError(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
 
+	capsule, err := Emit(config.Defaults(), Options{
+		SigningKey:     priv,
+		EvidenceBundle: bundlePtr(testEvidenceBundle()),
+	})
+	if err != nil {
+		t.Fatalf("Emit(): %v", err)
+	}
+
+	restore := patchCanonicalize(func(v any) ([]byte, error) {
+		if _, ok := v.(signableCapsule); ok {
+			return nil, fmt.Errorf("verify boom")
+		}
+		return canonicalJSON(v)
+	})
+	defer restore()
+
+	err = Verify(capsule, pub)
+	if err == nil || !strings.Contains(err.Error(), "marshal signable capsule: verify boom") {
+		t.Fatalf("Verify() error = %v, want signable marshal failure", err)
+	}
+}
+
+func TestWriteProofJSONValidationFailures(t *testing.T) {
 	_, err := WriteProofJSON(t.TempDir(), nil)
 	if err == nil || !strings.Contains(err.Error(), "capsule is required") {
 		t.Fatalf("WriteProofJSON(nil) error = %v, want nil capsule rejection", err)
@@ -556,12 +622,26 @@ func TestWriteProofJSONValidationFailures(t *testing.T) {
 	}
 }
 
-func TestUnmarshalJSONError(t *testing.T) {
-	t.Parallel()
+func TestWriteProofJSONMarshalFailure(t *testing.T) {
+	capsule := &Capsule{
+		SchemaVersion: SchemaVersion,
+	}
 
+	restore := patchCanonicalize(func(v any) ([]byte, error) {
+		return nil, fmt.Errorf("marshal boom")
+	})
+	defer restore()
+
+	_, err := WriteProofJSON(t.TempDir(), capsule)
+	if err == nil || !strings.Contains(err.Error(), "marshal boom") {
+		t.Fatalf("WriteProofJSON() error = %v, want marshal failure", err)
+	}
+}
+
+func TestUnmarshalJSONError(t *testing.T) {
 	var capsule Capsule
-	if err := json.Unmarshal([]byte(`{"schema_version":`), &capsule); err == nil {
-		t.Fatal("json.Unmarshal() error = nil, want invalid JSON error")
+	if err := capsule.UnmarshalJSON([]byte(`{"generated_at":"not-a-time"}`)); err == nil {
+		t.Fatal("UnmarshalJSON() error = nil, want invalid JSON error")
 	}
 }
 
@@ -606,9 +686,19 @@ func TestCollectEvidenceMissingRecorderDirIsInactive(t *testing.T) {
 	}
 }
 
-func TestCollectFlightRecorderEvidence(t *testing.T) {
-	t.Parallel()
+func TestCollectEvidenceDiscoverFailure(t *testing.T) {
+	restoreHome := patchUserHomeDir(func() (string, error) {
+		return "", fmt.Errorf("home boom")
+	})
+	defer restoreHome()
 
+	_, err := collectEvidence(config.Defaults())
+	if err == nil || !strings.Contains(err.Error(), "resolve home directory: home boom") {
+		t.Fatalf("collectEvidence() error = %v, want discover failure", err)
+	}
+}
+
+func TestCollectFlightRecorderEvidence(t *testing.T) {
 	tests := []struct {
 		name    string
 		setup   func(t *testing.T) *config.Config
@@ -663,6 +753,20 @@ func TestCollectFlightRecorderEvidence(t *testing.T) {
 			},
 			wantErr: "decode receipt detail",
 		},
+		{
+			name: "read recorder file error",
+			setup: func(t *testing.T) *config.Config {
+				dir := t.TempDir()
+				path := filepath.Join(dir, "evidence-proxy-0.jsonl")
+				if err := os.WriteFile(path, []byte("{not-json}\n"), 0o600); err != nil {
+					t.Fatalf("os.WriteFile(): %v", err)
+				}
+				cfg := config.Defaults()
+				cfg.FlightRecorder.Dir = dir
+				return cfg
+			},
+			wantErr: "read recorder file",
+		},
 	}
 
 	for _, tt := range tests {
@@ -688,9 +792,79 @@ func TestCollectFlightRecorderEvidence(t *testing.T) {
 	}
 }
 
-func TestCanonicalHelpers(t *testing.T) {
-	t.Parallel()
+func TestCollectFlightRecorderEvidenceAdditionalBranches(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "nested"), 0o750); err != nil {
+		t.Fatalf("os.Mkdir(): %v", err)
+	}
+	path := filepath.Join(dir, "evidence-proxy-0.jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
 
+	baseTime := time.Date(2026, time.April, 11, 17, 40, 0, 0, time.UTC)
+	restore := patchReadRecorderFile(func(string) ([]recorder.Entry, error) {
+		return []recorder.Entry{
+			{Type: "other"},
+			{Type: "action_receipt", Detail: receipt.Receipt{
+				Version: 1,
+				ActionRecord: receipt.ActionRecord{
+					Timestamp: baseTime,
+					Verdict:   config.ActionAllow,
+					Layer:     "",
+				},
+			}},
+			{Type: "action_receipt", Detail: receipt.Receipt{
+				Version: 1,
+				ActionRecord: receipt.ActionRecord{
+					Timestamp: baseTime.Add(time.Minute),
+					Verdict:   config.ActionWarn,
+					Layer:     "custom",
+				},
+			}},
+		}, nil
+	})
+	defer restore()
+
+	cfg := config.Defaults()
+	cfg.FlightRecorder.Dir = dir
+
+	got, err := collectFlightRecorderEvidence(cfg)
+	if err != nil {
+		t.Fatalf("collectFlightRecorderEvidence(): %v", err)
+	}
+	if got.ScannerVerdict["unknown"].Allow != 1 {
+		t.Fatalf("ScannerVerdict[unknown].Allow = %d, want 1", got.ScannerVerdict["unknown"].Allow)
+	}
+	if got.ScannerVerdict["custom"].Warn != 1 {
+		t.Fatalf("ScannerVerdict[custom].Warn = %d, want 1", got.ScannerVerdict["custom"].Warn)
+	}
+}
+
+func TestCollectFlightRecorderEvidenceMarshalReceiptDetailFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence-proxy-0.jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+
+	restore := patchReadRecorderFile(func(string) ([]recorder.Entry, error) {
+		return []recorder.Entry{
+			{Type: "action_receipt", Detail: func() {}},
+		}, nil
+	})
+	defer restore()
+
+	cfg := config.Defaults()
+	cfg.FlightRecorder.Dir = dir
+
+	_, err := collectFlightRecorderEvidence(cfg)
+	if err == nil || !strings.Contains(err.Error(), "marshal receipt detail") {
+		t.Fatalf("collectFlightRecorderEvidence() error = %v, want marshal receipt detail failure", err)
+	}
+}
+
+func TestCanonicalHelpers(t *testing.T) {
 	t.Run("canonical JSON sorts keys", func(t *testing.T) {
 		got, err := canonicalJSON(map[string]any{
 			"b": true,
@@ -749,11 +923,66 @@ func TestCanonicalHelpers(t *testing.T) {
 			t.Fatal("canonicalJSON() error = nil, want decoder failure")
 		}
 	})
+
+	t.Run("canonical JSON propagates append failure", func(t *testing.T) {
+		restore := patchJSONMarshal(func(v any) ([]byte, error) {
+			if s, ok := v.(string); ok && s == "boom-key" {
+				return nil, fmt.Errorf("append boom")
+			}
+			return json.Marshal(v)
+		})
+		defer restore()
+
+		_, err := canonicalJSON(map[string]any{"boom-key": 1})
+		if err == nil || !strings.Contains(err.Error(), "append boom") {
+			t.Fatalf("canonicalJSON() error = %v, want append failure", err)
+		}
+	})
+}
+
+func TestAppendCanonicalMarshalFailures(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		match func(v any) bool
+	}{
+		{
+			name:  "string",
+			value: "boom-string",
+			match: func(v any) bool { s, ok := v.(string); return ok && s == "boom-string" },
+		},
+		{
+			name:  "float64",
+			value: float64(1.5),
+			match: func(v any) bool { f, ok := v.(float64); return ok && f == 1.5 },
+		},
+		{
+			name:  "default",
+			value: 7,
+			match: func(v any) bool { i, ok := v.(int); return ok && i == 7 },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restore := patchJSONMarshal(func(v any) ([]byte, error) {
+				if tt.match(v) {
+					return nil, fmt.Errorf("marshal boom")
+				}
+				return json.Marshal(v)
+			})
+			defer restore()
+
+			var buf bytes.Buffer
+			err := appendCanonical(&buf, tt.value)
+			if err == nil || !strings.Contains(err.Error(), "marshal boom") {
+				t.Fatalf("appendCanonical() error = %v, want marshal failure", err)
+			}
+		})
+	}
 }
 
 func TestHashConfigDeterministic(t *testing.T) {
-	t.Parallel()
-
 	cfgA := config.Defaults()
 	cfgB := config.Defaults()
 
@@ -816,6 +1045,30 @@ func testEvidenceBundle() EvidenceBundle {
 
 func bundlePtr(bundle EvidenceBundle) *EvidenceBundle {
 	return &bundle
+}
+
+func patchCanonicalize(fn func(any) ([]byte, error)) func() {
+	original := canonicalize
+	canonicalize = fn
+	return func() { canonicalize = original }
+}
+
+func patchJSONMarshal(fn func(any) ([]byte, error)) func() {
+	original := jsonMarshal
+	jsonMarshal = fn
+	return func() { jsonMarshal = original }
+}
+
+func patchUserHomeDir(fn func() (string, error)) func() {
+	original := userHomeDir
+	userHomeDir = fn
+	return func() { userHomeDir = original }
+}
+
+func patchReadRecorderFile(fn func(string) ([]recorder.Entry, error)) func() {
+	original := readRecorderFile
+	readRecorderFile = fn
+	return func() { readRecorderFile = original }
 }
 
 func resignCapsule(t *testing.T, capsule *Capsule, priv ed25519.PrivateKey) string {

--- a/internal/posture/posture_test.go
+++ b/internal/posture/posture_test.go
@@ -1,0 +1,834 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package posture
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/cli/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestCapsuleMarshalJSONDeterministic(t *testing.T) {
+	t.Parallel()
+
+	expectedCapsule := Capsule{
+		SchemaVersion: "1",
+		GeneratedAt:   time.Date(2026, time.April, 11, 17, 45, 0, 0, time.UTC),
+		ExpiresAt:     time.Date(2026, time.May, 11, 17, 45, 0, 0, time.UTC),
+		ToolVersion:   "0.1.0-dev",
+		ConfigHash:    "abc123",
+		Evidence:      testEvidenceBundle(),
+		Signature:     "deadbeef",
+		SignerKeyID:   "feedface",
+	}
+
+	expectedJSON, err := json.Marshal(expectedCapsule)
+	if err != nil {
+		t.Fatalf("json.Marshal(expectedCapsule): %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "top-level fields shuffled",
+			input: `{"tool_version":"0.1.0-dev","signature":"deadbeef","schema_version":"1","generated_at":"2026-04-11T17:45:00Z","evidence":{"verify_install":{"proxying":true,"receipt_count":2,"flight_recorder_active":true},"discover":{"unknown":0,"total_servers":2,"protected_other":0,"parse_errors":0,"high_risk":0,"protected_pipelock":1,"total_clients":1,"unprotected":1},"simulate":{"total":2,"passed":2,"failed":0,"known_limitations":0,"percentage":100,"grade":"A","mode":"balanced","scenarios":[{"name":"scenario-a","category":"DLP Exfiltration","detected":true},{"name":"scenario-b","category":"Prompt Injection","detected":true,"detail":"matched"}]},"flight_recorder":{"scanner_verdict":{"zeta":{"warn":1,"allow":0,"block":0},"alpha":{"block":2,"allow":1,"warn":0}},"receipt_count":2,"last_receipt_at":"2026-04-11T17:40:00Z"}},"expires_at":"2026-05-11T17:45:00Z","signer_key_id":"feedface","config_hash":"abc123"}`,
+		},
+		{
+			name:  "nested map fields shuffled",
+			input: `{"schema_version":"1","generated_at":"2026-04-11T17:45:00Z","expires_at":"2026-05-11T17:45:00Z","tool_version":"0.1.0-dev","config_hash":"abc123","evidence":{"discover":{"total_clients":1,"total_servers":2,"protected_pipelock":1,"protected_other":0,"unprotected":1,"unknown":0,"high_risk":0,"parse_errors":0},"verify_install":{"receipt_count":2,"flight_recorder_active":true,"proxying":true},"simulate":{"passed":2,"total":2,"failed":0,"known_limitations":0,"percentage":100,"grade":"A","mode":"balanced","scenarios":[{"category":"DLP Exfiltration","name":"scenario-a","detected":true},{"detail":"matched","detected":true,"category":"Prompt Injection","name":"scenario-b"}]},"flight_recorder":{"last_receipt_at":"2026-04-11T17:40:00Z","receipt_count":2,"scanner_verdict":{"alpha":{"warn":0,"block":2,"allow":1},"zeta":{"allow":0,"warn":1,"block":0}}}},"signature":"deadbeef","signer_key_id":"feedface"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var capsule Capsule
+			if err := json.Unmarshal([]byte(tt.input), &capsule); err != nil {
+				t.Fatalf("json.Unmarshal(): %v", err)
+			}
+
+			got, err := json.Marshal(capsule)
+			if err != nil {
+				t.Fatalf("json.Marshal(): %v", err)
+			}
+
+			if string(got) != string(expectedJSON) {
+				t.Fatalf("canonical JSON mismatch:\n got: %s\nwant: %s", got, expectedJSON)
+			}
+		})
+	}
+}
+
+func TestEmitAndVerifyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	cfg := config.Defaults()
+	capsule, err := Emit(cfg, Options{
+		SigningKey:     priv,
+		EvidenceBundle: bundlePtr(testEvidenceBundle()),
+	})
+	if err != nil {
+		t.Fatalf("Emit(): %v", err)
+	}
+
+	if err := Verify(capsule, pub); err != nil {
+		t.Fatalf("Verify(): %v", err)
+	}
+
+	data, err := json.Marshal(capsule)
+	if err != nil {
+		t.Fatalf("json.Marshal(): %v", err)
+	}
+
+	var decoded Capsule
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(): %v", err)
+	}
+
+	if err := Verify(&decoded, pub); err != nil {
+		t.Fatalf("Verify(decoded): %v", err)
+	}
+}
+
+func TestVerifyExpiration(t *testing.T) {
+	t.Parallel()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	base, err := Emit(config.Defaults(), Options{
+		SigningKey:     priv,
+		EvidenceBundle: bundlePtr(testEvidenceBundle()),
+	})
+	if err != nil {
+		t.Fatalf("Emit(): %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*Capsule)
+		wantErr string
+	}{
+		{
+			name: "fresh",
+			mutate: func(c *Capsule) {
+				c.ExpiresAt = time.Now().UTC().Add(2 * time.Hour)
+			},
+		},
+		{
+			name: "near expiration",
+			mutate: func(c *Capsule) {
+				c.ExpiresAt = time.Now().UTC().Add(1 * time.Second)
+			},
+		},
+		{
+			name: "expired",
+			mutate: func(c *Capsule) {
+				c.ExpiresAt = time.Now().UTC().Add(-1 * time.Second)
+			},
+			wantErr: "expired",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capsule := *base
+			tt.mutate(&capsule)
+			capsule.Signature = resignCapsule(t, &capsule, priv)
+
+			err := Verify(&capsule, pub)
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("Verify(): %v", err)
+			}
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Verify() error = %v, want substring %q", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestVerifyRejectsSchemaVersionMismatch(t *testing.T) {
+	t.Parallel()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	capsule, err := Emit(config.Defaults(), Options{
+		SigningKey:     priv,
+		EvidenceBundle: bundlePtr(testEvidenceBundle()),
+	})
+	if err != nil {
+		t.Fatalf("Emit(): %v", err)
+	}
+
+	capsule.SchemaVersion = "2"
+	capsule.Signature = resignCapsule(t, capsule, priv)
+
+	err = Verify(capsule, pub)
+	if err == nil || !strings.Contains(err.Error(), "unsupported schema_version") {
+		t.Fatalf("Verify() error = %v, want schema version rejection", err)
+	}
+}
+
+func TestVerifyDetectsTampering(t *testing.T) {
+	t.Parallel()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	capsule, err := Emit(config.Defaults(), Options{
+		SigningKey:     priv,
+		EvidenceBundle: bundlePtr(testEvidenceBundle()),
+	})
+	if err != nil {
+		t.Fatalf("Emit(): %v", err)
+	}
+
+	capsule.ConfigHash = "tampered"
+	err = Verify(capsule, pub)
+	if err == nil || !strings.Contains(err.Error(), "signature verification failed") {
+		t.Fatalf("Verify() error = %v, want signature failure", err)
+	}
+}
+
+func TestEmitDefaultsExpirationDays(t *testing.T) {
+	t.Parallel()
+
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	capsule, err := Emit(config.Defaults(), Options{
+		SigningKey:     priv,
+		EvidenceBundle: bundlePtr(testEvidenceBundle()),
+	})
+	if err != nil {
+		t.Fatalf("Emit(): %v", err)
+	}
+
+	want := capsule.GeneratedAt.AddDate(0, 0, DefaultExpirationDays)
+	if !capsule.ExpiresAt.Equal(want) {
+		t.Fatalf("ExpiresAt = %s, want %s", capsule.ExpiresAt, want)
+	}
+}
+
+func TestEmitCollectsEvidenceAndWritesProof(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	recorderDir := filepath.Join(t.TempDir(), "recorder")
+	createTestReceipt(t, recorderDir, priv)
+
+	cfg := config.Defaults()
+	cfg.FlightRecorder.Enabled = true
+	cfg.FlightRecorder.Dir = recorderDir
+
+	capsule, err := Emit(cfg, Options{SigningKey: priv})
+	if err != nil {
+		t.Fatalf("Emit(): %v", err)
+	}
+
+	if capsule.Evidence.VerifyInstall.ReceiptCount != 1 {
+		t.Fatalf("VerifyInstall.ReceiptCount = %d, want 1", capsule.Evidence.VerifyInstall.ReceiptCount)
+	}
+	if !capsule.Evidence.VerifyInstall.Proxying {
+		t.Fatal("VerifyInstall.Proxying = false, want true")
+	}
+	if capsule.Evidence.FlightRecorder.ReceiptCount != 1 {
+		t.Fatalf("FlightRecorder.ReceiptCount = %d, want 1", capsule.Evidence.FlightRecorder.ReceiptCount)
+	}
+	if capsule.Evidence.FlightRecorder.LastReceiptAt == nil {
+		t.Fatal("FlightRecorder.LastReceiptAt = nil, want timestamp")
+	}
+	if got := capsule.Evidence.FlightRecorder.ScannerVerdict["dlp"].Block; got != 1 {
+		t.Fatalf("ScannerVerdict[dlp].Block = %d, want 1", got)
+	}
+	if capsule.Evidence.Discover.TotalClients != 0 {
+		t.Fatalf("Discover.TotalClients = %d, want 0", capsule.Evidence.Discover.TotalClients)
+	}
+	if capsule.Evidence.Simulate.Total == 0 {
+		t.Fatal("Simulate.Total = 0, want non-zero scenarios")
+	}
+	if err := Verify(capsule, pub); err != nil {
+		t.Fatalf("Verify(): %v", err)
+	}
+
+	outDir := filepath.Join(t.TempDir(), "posture")
+	path, err := WriteProofJSON(outDir, capsule)
+	if err != nil {
+		t.Fatalf("WriteProofJSON(): %v", err)
+	}
+	if path != filepath.Join(outDir, ProofFilename) {
+		t.Fatalf("WriteProofJSON path = %s, want %s", path, filepath.Join(outDir, ProofFilename))
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("os.ReadFile(): %v", err)
+	}
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Fatalf("proof.json should end with newline, got %q", data)
+	}
+}
+
+func TestEmitLoadsSigningKeyFromConfigPath(t *testing.T) {
+	t.Parallel()
+
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "signing.key")
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("signing.SavePrivateKey(): %v", err)
+	}
+
+	cfg := config.Defaults()
+	cfg.FlightRecorder.SigningKeyPath = keyPath
+
+	capsule, err := Emit(cfg, Options{EvidenceBundle: bundlePtr(testEvidenceBundle())})
+	if err != nil {
+		t.Fatalf("Emit(): %v", err)
+	}
+	if capsule.SignerKeyID == "" {
+		t.Fatal("SignerKeyID = empty, want populated")
+	}
+}
+
+func TestEmitMissingSigningKeyPath(t *testing.T) {
+	t.Parallel()
+
+	_, err := Emit(config.Defaults(), Options{EvidenceBundle: bundlePtr(testEvidenceBundle())})
+	if err == nil || !strings.Contains(err.Error(), "flight_recorder.signing_key_path is required") {
+		t.Fatalf("Emit() error = %v, want missing signing key path", err)
+	}
+}
+
+func TestEmitReturnsEvidenceCollectionError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	badPath := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(badPath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+
+	cfg := config.Defaults()
+	cfg.FlightRecorder.Dir = badPath
+
+	_, err = Emit(cfg, Options{SigningKey: priv})
+	if err == nil || !strings.Contains(err.Error(), "read flight recorder dir") {
+		t.Fatalf("Emit() error = %v, want flight recorder collection failure", err)
+	}
+}
+
+func TestEmitNilConfig(t *testing.T) {
+	t.Parallel()
+
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	_, err = Emit(nil, Options{SigningKey: priv, EvidenceBundle: bundlePtr(testEvidenceBundle())})
+	if err == nil || !strings.Contains(err.Error(), "config is required") {
+		t.Fatalf("Emit() error = %v, want nil config rejection", err)
+	}
+}
+
+func TestResolveSigningKeyLoadFailure(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.FlightRecorder.SigningKeyPath = filepath.Join(t.TempDir(), "missing.key")
+
+	_, err := resolveSigningKey(cfg, nil)
+	if err == nil || !strings.Contains(err.Error(), "load signing key") {
+		t.Fatalf("resolveSigningKey() error = %v, want load failure", err)
+	}
+}
+
+func TestVerifyValidationFailures(t *testing.T) {
+	t.Parallel()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	base, err := Emit(config.Defaults(), Options{
+		SigningKey:     priv,
+		EvidenceBundle: bundlePtr(testEvidenceBundle()),
+	})
+	if err != nil {
+		t.Fatalf("Emit(): %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		capsule *Capsule
+		key     ed25519.PublicKey
+		wantErr string
+	}{
+		{
+			name:    "nil capsule",
+			capsule: nil,
+			key:     pub,
+			wantErr: "capsule is required",
+		},
+		{
+			name: "invalid key length",
+			capsule: func() *Capsule {
+				c := *base
+				return &c
+			}(),
+			key:     ed25519.PublicKey([]byte("short")),
+			wantErr: "invalid trusted key length",
+		},
+		{
+			name: "missing signature",
+			capsule: func() *Capsule {
+				c := *base
+				c.Signature = ""
+				return &c
+			}(),
+			key:     pub,
+			wantErr: "capsule signature is required",
+		},
+		{
+			name: "signer mismatch",
+			capsule: func() *Capsule {
+				c := *base
+				c.SignerKeyID = "other"
+				return &c
+			}(),
+			key:     pub,
+			wantErr: "does not match trusted key",
+		},
+		{
+			name: "invalid signature hex",
+			capsule: func() *Capsule {
+				c := *base
+				c.Signature = "not-hex"
+				return &c
+			}(),
+			key:     pub,
+			wantErr: "decode signature",
+		},
+		{
+			name: "invalid signature length",
+			capsule: func() *Capsule {
+				c := *base
+				c.Signature = "deadbeef"
+				return &c
+			}(),
+			key:     pub,
+			wantErr: "invalid signature length",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Verify(tt.capsule, tt.key)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Verify() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestWriteProofJSONValidationFailures(t *testing.T) {
+	t.Parallel()
+
+	_, err := WriteProofJSON(t.TempDir(), nil)
+	if err == nil || !strings.Contains(err.Error(), "capsule is required") {
+		t.Fatalf("WriteProofJSON(nil) error = %v, want nil capsule rejection", err)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	capsule, err := Emit(config.Defaults(), Options{
+		SigningKey:     priv,
+		EvidenceBundle: bundlePtr(testEvidenceBundle()),
+	})
+	if err != nil {
+		t.Fatalf("Emit(): %v", err)
+	}
+	if err := Verify(capsule, pub); err != nil {
+		t.Fatalf("Verify(): %v", err)
+	}
+
+	badOutput := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(badOutput, []byte("x"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+
+	_, err = WriteProofJSON(badOutput, capsule)
+	if err == nil || !strings.Contains(err.Error(), "create output directory") {
+		t.Fatalf("WriteProofJSON() error = %v, want output dir failure", err)
+	}
+
+	writeFailDir := filepath.Join(t.TempDir(), "write-fail")
+	if err := os.Mkdir(writeFailDir, 0o750); err != nil {
+		t.Fatalf("os.Mkdir(): %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(writeFailDir, ProofFilename), 0o750); err != nil {
+		t.Fatalf("os.Mkdir(proof dir): %v", err)
+	}
+
+	_, err = WriteProofJSON(writeFailDir, capsule)
+	if err == nil || !strings.Contains(err.Error(), "write proof.json") {
+		t.Fatalf("WriteProofJSON() error = %v, want write failure", err)
+	}
+}
+
+func TestUnmarshalJSONError(t *testing.T) {
+	t.Parallel()
+
+	var capsule Capsule
+	if err := json.Unmarshal([]byte(`{"schema_version":`), &capsule); err == nil {
+		t.Fatal("json.Unmarshal() error = nil, want invalid JSON error")
+	}
+}
+
+func TestCollectEvidenceWithoutRecorder(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	evidence, err := collectEvidence(config.Defaults())
+	if err != nil {
+		t.Fatalf("collectEvidence(): %v", err)
+	}
+
+	if evidence.VerifyInstall.FlightRecorderActive {
+		t.Fatal("VerifyInstall.FlightRecorderActive = true, want false")
+	}
+	if evidence.VerifyInstall.Proxying {
+		t.Fatal("VerifyInstall.Proxying = true, want false")
+	}
+	if evidence.FlightRecorder.ReceiptCount != 0 {
+		t.Fatalf("FlightRecorder.ReceiptCount = %d, want 0", evidence.FlightRecorder.ReceiptCount)
+	}
+}
+
+func TestCollectFlightRecorderEvidence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T) *config.Config
+		wantErr string
+	}{
+		{
+			name: "empty dir",
+			setup: func(t *testing.T) *config.Config {
+				cfg := config.Defaults()
+				cfg.FlightRecorder.Dir = ""
+				return cfg
+			},
+		},
+		{
+			name: "missing dir",
+			setup: func(t *testing.T) *config.Config {
+				cfg := config.Defaults()
+				cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "missing")
+				return cfg
+			},
+		},
+		{
+			name: "malformed receipt detail",
+			setup: func(t *testing.T) *config.Config {
+				dir := t.TempDir()
+				entry := recorder.Entry{
+					Version:   recorder.EntryVersion,
+					Sequence:  0,
+					Timestamp: time.Now().UTC(),
+					SessionID: "proxy",
+					Type:      "action_receipt",
+					Transport: "forward",
+					Summary:   "bad",
+					Detail:    "not-a-receipt",
+					PrevHash:  recorder.GenesisHash,
+					Hash:      "placeholder",
+				}
+				entry.Hash = recorder.ComputeHash(entry)
+
+				data, err := json.Marshal(entry)
+				if err != nil {
+					t.Fatalf("json.Marshal(entry): %v", err)
+				}
+				path := filepath.Join(dir, "evidence-proxy-0.jsonl")
+				if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+					t.Fatalf("os.WriteFile(): %v", err)
+				}
+
+				cfg := config.Defaults()
+				cfg.FlightRecorder.Dir = dir
+				return cfg
+			},
+			wantErr: "decode receipt detail",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setup(t)
+			got, err := collectFlightRecorderEvidence(cfg)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("collectFlightRecorderEvidence() error = %v", err)
+				}
+				if got.ReceiptCount != 0 {
+					t.Fatalf("ReceiptCount = %d, want 0", got.ReceiptCount)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("collectFlightRecorderEvidence() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCanonicalHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("canonical JSON sorts keys", func(t *testing.T) {
+		got, err := canonicalJSON(map[string]any{
+			"b": true,
+			"a": json.Number("2"),
+			"c": []any{"x", float64(1)},
+		})
+		if err != nil {
+			t.Fatalf("canonicalJSON(): %v", err)
+		}
+		want := `{"a":2,"b":true,"c":["x",1]}`
+		if string(got) != want {
+			t.Fatalf("canonicalJSON() = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("appendCanonical handles direct types", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			value any
+			want  string
+		}{
+			{name: "nil", value: nil, want: "null"},
+			{name: "bool true", value: true, want: "true"},
+			{name: "bool false", value: false, want: "false"},
+			{name: "string", value: "hello", want: `"hello"`},
+			{name: "json number", value: json.Number("3"), want: "3"},
+			{name: "float64", value: float64(1.5), want: "1.5"},
+			{name: "slice", value: []any{"a", json.Number("4")}, want: `["a",4]`},
+			{name: "map", value: map[string]any{"b": 2, "a": 1}, want: `{"a":1,"b":2}`},
+			{name: "default", value: 7, want: "7"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				var buf bytes.Buffer
+				if err := appendCanonical(&buf, tc.value); err != nil {
+					t.Fatalf("appendCanonical(): %v", err)
+				}
+				if buf.String() != tc.want {
+					t.Fatalf("appendCanonical() = %s, want %s", buf.String(), tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("canonical JSON propagates marshal errors", func(t *testing.T) {
+		_, err := canonicalJSON(failingJSONMarshaler{})
+		if err == nil || !strings.Contains(err.Error(), "boom") {
+			t.Fatalf("canonicalJSON() error = %v, want marshal error", err)
+		}
+	})
+
+	t.Run("canonical JSON rejects invalid JSON from marshaler", func(t *testing.T) {
+		_, err := canonicalJSON(invalidJSONMarshaler{})
+		if err == nil {
+			t.Fatal("canonicalJSON() error = nil, want decoder failure")
+		}
+	})
+}
+
+func TestHashConfigDeterministic(t *testing.T) {
+	t.Parallel()
+
+	cfgA := config.Defaults()
+	cfgB := config.Defaults()
+
+	hashA, err := hashConfig(cfgA)
+	if err != nil {
+		t.Fatalf("hashConfig(cfgA): %v", err)
+	}
+	hashB, err := hashConfig(cfgB)
+	if err != nil {
+		t.Fatalf("hashConfig(cfgB): %v", err)
+	}
+
+	if hashA != hashB {
+		t.Fatalf("hashConfig mismatch: %s != %s", hashA, hashB)
+	}
+}
+
+func testEvidenceBundle() EvidenceBundle {
+	lastReceipt := time.Date(2026, time.April, 11, 17, 40, 0, 0, time.UTC)
+
+	return EvidenceBundle{
+		Discover: DiscoverEvidence{
+			TotalClients:      1,
+			TotalServers:      2,
+			ProtectedPipelock: 1,
+			ProtectedOther:    0,
+			Unprotected:       1,
+			Unknown:           0,
+			HighRisk:          0,
+			ParseErrors:       0,
+		},
+		VerifyInstall: VerifyInstallEvidence{
+			FlightRecorderActive: true,
+			ReceiptCount:         2,
+			Proxying:             true,
+		},
+		Simulate: audit.SimulateResult{
+			Total:       2,
+			Passed:      2,
+			Failed:      0,
+			KnownLimits: 0,
+			Percentage:  100,
+			Grade:       "A",
+			Mode:        config.ModeBalanced,
+			Scenarios: []audit.ScenarioResult{
+				{Name: "scenario-a", Category: "DLP Exfiltration", Detected: true},
+				{Name: "scenario-b", Category: "Prompt Injection", Detected: true, Detail: "matched"},
+			},
+		},
+		FlightRecorder: FlightRecorderCounts{
+			ReceiptCount:  2,
+			LastReceiptAt: &lastReceipt,
+			ScannerVerdict: map[string]VerdictCount{
+				"zeta":  {Warn: 1},
+				"alpha": {Allow: 1, Block: 2},
+			},
+		},
+	}
+}
+
+func bundlePtr(bundle EvidenceBundle) *EvidenceBundle {
+	return &bundle
+}
+
+func resignCapsule(t *testing.T, capsule *Capsule, priv ed25519.PrivateKey) string {
+	t.Helper()
+
+	payload, err := capsule.signableJSON()
+	if err != nil {
+		t.Fatalf("signableJSON(): %v", err)
+	}
+	return hexEncode(ed25519.Sign(priv, payload))
+}
+
+func createTestReceipt(t *testing.T, dir string, priv ed25519.PrivateKey) {
+	t.Helper()
+
+	rec, err := recorder.New(recorder.Config{
+		Enabled:         true,
+		Dir:             dir,
+		SignCheckpoints: true,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := rec.Close(); err != nil {
+			t.Fatalf("rec.Close(): %v", err)
+		}
+	})
+
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: "cfg-hash",
+	})
+	if emitter == nil {
+		t.Fatal("receipt.NewEmitter() returned nil")
+	}
+
+	if err := emitter.Emit(receipt.EmitOpts{
+		ActionID:  "action-1",
+		Verdict:   config.ActionBlock,
+		Layer:     "dlp",
+		Transport: "forward",
+		Method:    "GET",
+		Target:    "https://example.com",
+		RequestID: "req-1",
+	}); err != nil {
+		t.Fatalf("emitter.Emit(): %v", err)
+	}
+
+	if err := rec.Close(); err != nil {
+		t.Fatalf("rec.Close(): %v", err)
+	}
+}
+
+func hexEncode(b []byte) string {
+	return hex.EncodeToString(b)
+}
+
+type failingJSONMarshaler struct{}
+
+func (failingJSONMarshaler) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("boom")
+}
+
+type invalidJSONMarshaler struct{}
+
+func (invalidJSONMarshaler) MarshalJSON() ([]byte, error) {
+	return []byte("{"), nil
+}

--- a/internal/posture/posture_test.go
+++ b/internal/posture/posture_test.go
@@ -243,6 +243,24 @@ func TestEmitDefaultsExpirationDays(t *testing.T) {
 	}
 }
 
+func TestEmitRejectsNegativeExpirationDays(t *testing.T) {
+	t.Parallel()
+
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	_, err = Emit(config.Defaults(), Options{
+		ExpirationDays: -7,
+		SigningKey:     priv,
+		EvidenceBundle: bundlePtr(testEvidenceBundle()),
+	})
+	if err == nil || !strings.Contains(err.Error(), "expiration_days must be >= 0") {
+		t.Fatalf("Emit() error = %v, want negative expiration rejection", err)
+	}
+}
+
 func TestEmitCollectsEvidenceAndWritesProof(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)

--- a/internal/posture/posture_test.go
+++ b/internal/posture/posture_test.go
@@ -389,6 +389,18 @@ func TestResolveSigningKeyLoadFailure(t *testing.T) {
 	}
 }
 
+func TestResolveSigningKeyRejectsMalformedProvidedKey(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.FlightRecorder.SigningKeyPath = filepath.Join(t.TempDir(), "ignored.key")
+
+	_, err := resolveSigningKey(cfg, ed25519.PrivateKey([]byte("short")))
+	if err == nil || !strings.Contains(err.Error(), "invalid signing key length") {
+		t.Fatalf("resolveSigningKey() error = %v, want malformed key rejection", err)
+	}
+}
+
 func TestVerifyValidationFailures(t *testing.T) {
 	t.Parallel()
 
@@ -555,6 +567,27 @@ func TestCollectEvidenceWithoutRecorder(t *testing.T) {
 	}
 }
 
+func TestCollectEvidenceMissingRecorderDirIsInactive(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	cfg := config.Defaults()
+	cfg.FlightRecorder.Enabled = true
+	cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "missing")
+
+	evidence, err := collectEvidence(cfg)
+	if err != nil {
+		t.Fatalf("collectEvidence(): %v", err)
+	}
+
+	if evidence.VerifyInstall.FlightRecorderActive {
+		t.Fatal("VerifyInstall.FlightRecorderActive = true, want false")
+	}
+	if evidence.FlightRecorder.ScannerVerdict != nil {
+		t.Fatalf("FlightRecorder.ScannerVerdict = %#v, want nil for missing recorder dir", evidence.FlightRecorder.ScannerVerdict)
+	}
+}
+
 func TestCollectFlightRecorderEvidence(t *testing.T) {
 	t.Parallel()
 
@@ -624,6 +657,9 @@ func TestCollectFlightRecorderEvidence(t *testing.T) {
 				}
 				if got.ReceiptCount != 0 {
 					t.Fatalf("ReceiptCount = %d, want 0", got.ReceiptCount)
+				}
+				if tt.name == "missing dir" && got.ScannerVerdict != nil {
+					t.Fatalf("ScannerVerdict = %#v, want nil for missing recorder dir", got.ScannerVerdict)
 				}
 				return
 			}


### PR DESCRIPTION
## Summary
- add a signed `internal/posture` package for posture capsule emission, verification, and `proof.json` writing
- add `pipelock posture emit` and register it on the root CLI
- document the scaffold and cover the new package and CLI path with targeted tests

## Testing
- `env GOCACHE=/tmp/pipelock-go-cache go build ./...`
- `env GOCACHE=/tmp/pipelock-go-cache go test -race -count=1 -v ./internal/posture/...`
- `env GOCACHE=/tmp/pipelock-go-cache go test -race -count=1 -v ./internal/cli -run TestPostureEmitCmd`
- `golangci-lint run ./...`

## Notes
- `proof.md` is intentionally left out of this scaffold; the command currently writes `proof.json` only
- package coverage for `internal/posture` is 88.5%; remaining uncovered branches are failure plumbing that would need fault injection beyond this scaffold
- broader `go test -race -count=1 ./...` coverage is partially socket-blocked in this sandbox, so full-repo local validation reproduced environment failures in packages that open loopback or unix sockets while the new posture command path passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to emit a signed posture capsule (proof.json) snapshot and print the written path.

* **Documentation**
  * New guide describing posture capsules: when/how to emit, output location/permissions, signing model, verification expectations, and example capsule structure.

* **Tests**
  * Added integration and unit tests covering emit/verify flows, deterministic JSON canonicalization, signing/verification edge cases, output writing, and related error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->