### PR TITLE
feat: per-pattern warn mode for DLP rollout safety

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -324,7 +324,7 @@ dlp:
 | `patterns` | 46 built-in | DLP credential detection patterns |
 | `patterns[].validator` | `""` | Post-match checksum validator: `luhn`, `mod97`, `aba`, or `wif` |
 | `patterns[].exempt_domains` | `[]` | Domains where this pattern is not enforced (wildcard supported) |
-| `patterns[].action` | `""` | Per-pattern action override. Only `warn` is supported. When set to `warn`, matches produce an audit event (`dlp_warn`) without blocking. See the [false positive tuning guide](guides/false-positive-tuning.md) for the rollout workflow. Built-in default patterns cannot be set to warn. |
+| `patterns[].action` | `""` | Per-pattern action override. Only `warn` is supported. When set to `warn`, matches allow traffic through without enforcement. See the [false positive tuning guide](guides/false-positive-tuning.md) for the rollout workflow. Built-in default patterns cannot be set to warn. |
 
 There is no top-level `dlp.action` setting. DLP enforcement is transport-specific:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -324,6 +324,7 @@ dlp:
 | `patterns` | 46 built-in | DLP credential detection patterns |
 | `patterns[].validator` | `""` | Post-match checksum validator: `luhn`, `mod97`, `aba`, or `wif` |
 | `patterns[].exempt_domains` | `[]` | Domains where this pattern is not enforced (wildcard supported) |
+| `patterns[].action` | `""` | Per-pattern action override. Only `warn` is supported. When set to `warn`, matches produce an audit event (`dlp_warn`) without blocking. See the [false positive tuning guide](guides/false-positive-tuning.md) for the rollout workflow. Built-in default patterns cannot be set to warn. |
 
 There is no top-level `dlp.action` setting. DLP enforcement is transport-specific:
 

--- a/docs/guides/false-positive-tuning.md
+++ b/docs/guides/false-positive-tuning.md
@@ -24,8 +24,8 @@ dlp:
 
 2. **Deploy and observe.** The pattern matches traffic but requests are not
    blocked. When the runtime warn hook is configured (see below), matches
-   emit `dlp_warn` audit events. Without the hook, you can observe matches
-   through `InformationalMatches` in the scan API response or flight recorder.
+   emit `dlp_warn` audit events. Without the hook, warn matches are still
+   tracked in the scanner result's `InformationalMatches` field.
 
 3. **Review matches.** Check the `pattern`, `severity`, and `transport` fields
    in the audit event (when the warn hook is active) or the scan API response

--- a/docs/guides/false-positive-tuning.md
+++ b/docs/guides/false-positive-tuning.md
@@ -1,0 +1,117 @@
+# False Positive Tuning
+
+This guide covers techniques for managing DLP pattern false positives
+in pipelock, including the per-pattern warn mode for safe rollout of new patterns.
+
+## Staging new DLP patterns with warn mode
+
+When deploying a new DLP pattern to production, there is always a risk of
+false positives blocking legitimate traffic. Warn mode lets you observe what
+a pattern would match in production without taking enforcement action.
+
+### The rollout workflow
+
+1. **Add the pattern with `action: warn`:**
+
+```yaml
+dlp:
+  patterns:
+    - name: my-new-pattern
+      regex: 'my-prefix-[A-Za-z0-9]{20,}'
+      severity: high
+      action: warn
+```
+
+2. **Deploy and observe.** The pattern matches traffic and emits `dlp_warn`
+   audit events, but requests are not blocked. Monitor the audit log or
+   flight recorder for `event: dlp_warn` entries.
+
+3. **Review matches.** Check the `pattern`, `severity`, and `transport` fields
+   in the audit event to determine if the matches are true positives or false
+   positives. Adjust the regex if needed.
+
+4. **Promote to enforce.** When confident the pattern has an acceptable
+   false positive rate, remove the `action: warn` line (or delete the field
+   entirely). The pattern defaults to enforce mode on the next config reload.
+
+```yaml
+dlp:
+  patterns:
+    - name: my-new-pattern
+      regex: 'my-prefix-[A-Za-z0-9]{20,}'
+      severity: high
+      # action removed — pattern now enforces
+```
+
+### How warn mode works
+
+Warn-mode patterns are evaluated through the same scanning pipeline as
+enforced patterns (URL DLP, text DLP, encoded variants, cross-request
+detection). The difference is purely in how the match result is handled:
+
+- **Enforced patterns** produce a block/strip action on the applicable transport.
+- **Warn patterns** produce an informational audit event (`dlp_warn`) and
+  the request proceeds as if the pattern had not matched.
+
+Warn mode applies to all DLP scanning surfaces: fetch proxy, forward proxy,
+CONNECT, WebSocket, MCP input scanning, and request body scanning.
+
+### Interpreting `dlp_warn` audit events
+
+Each warn-mode match emits an event with these fields:
+
+| Field | Description |
+|-------|-------------|
+| `event` | `dlp_warn` |
+| `mode` | `warn` |
+| `pattern` | Pattern name from config |
+| `severity` | Pattern severity (`critical`, `high`, `medium`, `low`) |
+| `transport` | Scanning surface that triggered the match |
+| `url` / `target` / `resource` | The scanned destination |
+
+To find warn matches in the flight recorder:
+
+```bash
+pipelock logs --event dlp_warn
+```
+
+Or filter the JSON audit log:
+
+```bash
+jq 'select(.event == "dlp_warn")' /var/log/pipelock/audit.json
+```
+
+### Restrictions
+
+- **Built-in default patterns cannot be set to warn.** These are the
+  immutable safety floor and always enforce.
+- **Only `warn` is accepted as a per-pattern action.** Other actions
+  (`block`, `strip`, `redirect`, `ask`) are not valid at the pattern level.
+  Transport-level action configuration (`request_body_scanning.action`,
+  `mcp_input_scanning.action`, etc.) controls enforcement for enforced matches.
+- **Warn mode applies to DLP patterns only.** Blocklist entries, response
+  scanning patterns, and chain detection rules do not support per-rule warn
+  mode in this release.
+
+## Other false positive tuning techniques
+
+### Exempt domains
+
+Use `exempt_domains` on a DLP pattern to skip enforcement for specific
+trusted destinations:
+
+```yaml
+dlp:
+  patterns:
+    - name: github-token
+      regex: 'ghp_[A-Za-z0-9]{36}'
+      severity: critical
+      exempt_domains:
+        - "api.github.com"
+        - "*.github.com"
+```
+
+### Suppression rules
+
+The `suppress` configuration section lets you suppress specific scanner
+findings by scanner name and pattern. See the [suppression guide](suppression.md).

--- a/docs/guides/false-positive-tuning.md
+++ b/docs/guides/false-positive-tuning.md
@@ -25,7 +25,8 @@ dlp:
 2. **Deploy and observe.** The pattern matches traffic but requests are not
    blocked. When the runtime warn hook is configured (see below), matches
    emit `dlp_warn` audit events. Without the hook, warn matches are still
-   tracked in the scanner result's `InformationalMatches` field.
+   tracked in the scanner result (`InformationalMatches` for text DLP,
+   `WarnMatches` for URL DLP).
 
 3. **Review matches.** Check the `pattern`, `severity`, and `transport` fields
    in the audit event (when the warn hook is active) or the scan API response
@@ -80,8 +81,8 @@ fields, but no audit event is emitted.
   Transport-level action configuration (`request_body_scanning.action`,
   `mcp_input_scanning.action`, etc.) controls enforcement for enforced matches.
 - **Warn mode applies to DLP patterns only.** Blocklist entries, response
-  scanning patterns, and chain detection rules do not support per-rule warn
-  mode in this release.
+  scanning patterns, and chain detection rules. Per-rule warn for those
+  rule types may be added in a future release.
 
 ## Other false positive tuning techniques
 

--- a/docs/guides/false-positive-tuning.md
+++ b/docs/guides/false-positive-tuning.md
@@ -22,13 +22,15 @@ dlp:
       action: warn
 ```
 
-2. **Deploy and observe.** The pattern matches traffic and emits `dlp_warn`
-   audit events, but requests are not blocked. Monitor the audit log or
-   flight recorder for `event: dlp_warn` entries.
+2. **Deploy and observe.** The pattern matches traffic but requests are not
+   blocked. When the runtime warn hook is configured (see below), matches
+   emit `dlp_warn` audit events. Without the hook, you can observe matches
+   through `InformationalMatches` in the scan API response or flight recorder.
 
 3. **Review matches.** Check the `pattern`, `severity`, and `transport` fields
-   in the audit event to determine if the matches are true positives or false
-   positives. Adjust the regex if needed.
+   in the audit event (when the warn hook is active) or the scan API response
+   to determine if the matches are true positives or false positives.
+   Adjust the regex if needed.
 
 4. **Promote to enforce.** When confident the pattern has an acceptable
    false positive rate, remove the `action: warn` line (or delete the field
@@ -50,36 +52,24 @@ enforced patterns (URL DLP, text DLP, encoded variants, cross-request
 detection). The difference is purely in how the match result is handled:
 
 - **Enforced patterns** produce a block/strip action on the applicable transport.
-- **Warn patterns** produce an informational audit event (`dlp_warn`) and
-  the request proceeds as if the pattern had not matched.
+- **Warn patterns** allow the request to proceed. When the warn hook is
+  active, they also emit `dlp_warn` audit events.
 
 Warn mode applies to all DLP scanning surfaces: fetch proxy, forward proxy,
-CONNECT, WebSocket, MCP input scanning, and request body scanning.
+CONNECT, WebSocket, MCP input scanning, request body scanning, and
+cross-request fragment detection.
 
-### Interpreting `dlp_warn` audit events
+### Warn hook
 
-Each warn-mode match emits an event with these fields:
+The scanner provides a package-level hook (`scanner.DLPWarnHook`) that the
+runtime can set to route warn events to the audit logger. When the hook is
+wired, each warn-mode match emits a `dlp_warn` event with `pattern`,
+`severity`, and `transport` fields. The `LogDLPWarn` method on the audit
+logger provides the canonical event format.
 
-| Field | Description |
-|-------|-------------|
-| `event` | `dlp_warn` |
-| `mode` | `warn` |
-| `pattern` | Pattern name from config |
-| `severity` | Pattern severity (`critical`, `high`, `medium`, `low`) |
-| `transport` | Scanning surface that triggered the match |
-| `url` / `target` / `resource` | The scanned destination |
-
-To find warn matches in the flight recorder:
-
-```bash
-pipelock logs --event dlp_warn
-```
-
-Or filter the JSON audit log:
-
-```bash
-jq 'select(.event == "dlp_warn")' /var/log/pipelock/audit.json
-```
+When the hook is not configured, warn matches still allow traffic through
+and are reported in the scan result's `InformationalMatches` / `WarnMatches`
+fields, but no audit event is emitted.
 
 ### Restrictions
 

--- a/internal/audit/dlp_warn.go
+++ b/internal/audit/dlp_warn.go
@@ -20,13 +20,13 @@ func (l *Logger) LogDLPWarn(ctx LogContext, patternName, severity, transport str
 		str("severity", severity).
 		str("transport", transport).
 		str("mitre_technique", technique).
-		str("method", ctx.Method).
-		optStr("url", ctx.URL).
-		optStr("target", ctx.Target).
-		optStr("resource", ctx.Resource).
-		optStr("client_ip", ctx.ClientIP).
-		optStr("request_id", ctx.RequestID).
-		optStr("agent", ctx.Agent)
+		str("method", ctx.Method()).
+		optStr("url", ctx.URL()).
+		optStr("target", ctx.Target()).
+		optStr("resource", ctx.Resource()).
+		optStr("client_ip", ctx.ClientIP()).
+		optStr("request_id", ctx.RequestID()).
+		optStr("agent", ctx.Agent())
 	e.msg("DLP warn-mode match (informational)")
 
 	if l.emitter != nil {

--- a/internal/audit/dlp_warn.go
+++ b/internal/audit/dlp_warn.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import "context"
+
+// EventDLPWarn is emitted when a warn-mode DLP pattern matches.
+// The match is informational only — no enforcement action is taken.
+const EventDLPWarn EventType = "dlp_warn"
+
+// LogDLPWarn emits an audit event for a DLP pattern match in warn mode.
+// Transport identifies the scanning surface (e.g., "fetch", "forward", "mcp_input", "body").
+func (l *Logger) LogDLPWarn(ctx LogContext, patternName, severity, transport string) {
+	technique := TechniqueForScanner(ScannerDLP)
+
+	e := newLogEntry(l.zl.Warn(), EventDLPWarn).
+		str("mode", "warn").
+		str("pattern", patternName).
+		str("severity", severity).
+		str("transport", transport).
+		str("mitre_technique", technique).
+		str("method", ctx.Method).
+		optStr("url", ctx.URL).
+		optStr("target", ctx.Target).
+		optStr("resource", ctx.Resource).
+		optStr("client_ip", ctx.ClientIP).
+		optStr("request_id", ctx.RequestID).
+		optStr("agent", ctx.Agent)
+	e.msg("DLP warn-mode match (informational)")
+
+	if l.emitter != nil {
+		l.emitter.Emit(context.Background(), string(EventDLPWarn), e.fields)
+	}
+}

--- a/internal/audit/dlp_warn_test.go
+++ b/internal/audit/dlp_warn_test.go
@@ -30,7 +30,10 @@ func TestLogDLPWarn_EmitsCorrectFields(t *testing.T) {
 	}
 	logger.zl = logger.zl.Output(&buf)
 
-	ctx := NewHTTPLogContext("GET", "https://example.com/api", "10.0.0.1", "req-42", "test-agent")
+	ctx, ctxErr := NewHTTPLogContext("GET", "https://example.com/api", "10.0.0.1", "req-42", "test-agent")
+	if ctxErr != nil {
+		t.Fatalf("NewHTTPLogContext: %v", ctxErr)
+	}
 	logger.LogDLPWarn(ctx, wantPatternStagedKey, wantSeverityHigh, wantTransportFetch)
 
 	output := buf.String()
@@ -84,7 +87,10 @@ func TestLogDLPWarn_EmitterReceivesEvent(t *testing.T) {
 	logger.SetEmitter(emitter)
 	t.Cleanup(func() { _ = emitter.Close() })
 
-	ctx := NewHTTPLogContext("POST", "https://api.example.com/v1", "10.0.0.2", "req-99", "my-agent")
+	ctx, ctxErr := NewHTTPLogContext("POST", "https://api.example.com/v1", "10.0.0.2", "req-99", "my-agent")
+	if ctxErr != nil {
+		t.Fatalf("NewHTTPLogContext: %v", ctxErr)
+	}
 	logger.LogDLPWarn(ctx, wantPatternStagedTok, wantSeverityMedium, wantTransportBody)
 
 	_ = emitter.Close() // flush

--- a/internal/audit/dlp_warn_test.go
+++ b/internal/audit/dlp_warn_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/emit"
+)
+
+func TestLogDLPWarn_EmitsCorrectFields(t *testing.T) {
+	var buf bytes.Buffer
+	logger, err := New("json", "custom", "", true, true)
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+	logger.zl = logger.zl.Output(&buf)
+
+	ctx := NewHTTPLogContext("GET", "https://example.com/api", "10.0.0.1", "req-42", "test-agent")
+	logger.LogDLPWarn(ctx, "staged-key", "high", "fetch")
+
+	output := buf.String()
+	if output == "" {
+		t.Fatal("expected log output, got empty")
+	}
+
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &entry); err != nil {
+		t.Fatalf("failed to parse log entry: %v\nraw: %s", err, output)
+	}
+
+	checks := map[string]string{
+		"event":     string(EventDLPWarn),
+		"mode":      "warn",
+		"pattern":   "staged-key",
+		"severity":  "high",
+		"transport": "fetch",
+		"method":    "GET",
+		"url":       "https://example.com/api",
+		"client_ip": "10.0.0.1",
+	}
+	for key, want := range checks {
+		got, ok := entry[key]
+		if !ok {
+			t.Errorf("missing field %q in log entry", key)
+			continue
+		}
+		if gotStr, ok := got.(string); !ok || gotStr != want {
+			t.Errorf("field %q: want %q, got %v", key, want, got)
+		}
+	}
+}
+
+func TestLogDLPWarn_EventTypeConstant(t *testing.T) {
+	if EventDLPWarn != "dlp_warn" {
+		t.Errorf("EventDLPWarn should be %q, got %q", "dlp_warn", EventDLPWarn)
+	}
+}
+
+func TestLogDLPWarn_EmitterReceivesEvent(t *testing.T) {
+	var buf bytes.Buffer
+	logger, err := New("json", "custom", "", true, true)
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+	logger.zl = logger.zl.Output(&buf)
+
+	sink := &collectingSink{}
+	emitter := emit.NewEmitter("test-dlp-warn", sink)
+	logger.SetEmitter(emitter)
+	t.Cleanup(func() { _ = emitter.Close() })
+
+	ctx := NewHTTPLogContext("POST", "https://api.example.com/v1", "10.0.0.2", "req-99", "my-agent")
+	logger.LogDLPWarn(ctx, "staged-token", "medium", "body")
+
+	_ = emitter.Close() // flush
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+
+	if len(sink.events) == 0 {
+		t.Fatal("emitter should have received an event")
+	}
+	ev := sink.events[0]
+	if ev.Type != string(EventDLPWarn) {
+		t.Errorf("emitted event type: want %q, got %q", EventDLPWarn, ev.Type)
+	}
+	if ev.Fields["mode"] != "warn" {
+		t.Errorf("emitted mode: want %q, got %v", "warn", ev.Fields["mode"])
+	}
+	if ev.Fields["pattern"] != "staged-token" {
+		t.Errorf("emitted pattern: want %q, got %v", "staged-token", ev.Fields["pattern"])
+	}
+	if ev.Fields["transport"] != "body" {
+		t.Errorf("emitted transport: want %q, got %v", "body", ev.Fields["transport"])
+	}
+}

--- a/internal/audit/dlp_warn_test.go
+++ b/internal/audit/dlp_warn_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/emit"
 )
 
+const (
+	wantMode             = "warn"
+	wantTransportFetch   = "fetch"
+	wantTransportBody    = "body"
+	wantPatternStagedKey = "staged-key"
+	wantPatternStagedTok = "staged-token"
+	wantSeverityHigh     = "high"
+	wantSeverityMedium   = "medium"
+)
+
 func TestLogDLPWarn_EmitsCorrectFields(t *testing.T) {
 	var buf bytes.Buffer
 	logger, err := New("json", "custom", "", true, true)
@@ -21,7 +31,7 @@ func TestLogDLPWarn_EmitsCorrectFields(t *testing.T) {
 	logger.zl = logger.zl.Output(&buf)
 
 	ctx := NewHTTPLogContext("GET", "https://example.com/api", "10.0.0.1", "req-42", "test-agent")
-	logger.LogDLPWarn(ctx, "staged-key", "high", "fetch")
+	logger.LogDLPWarn(ctx, wantPatternStagedKey, wantSeverityHigh, wantTransportFetch)
 
 	output := buf.String()
 	if output == "" {
@@ -35,10 +45,10 @@ func TestLogDLPWarn_EmitsCorrectFields(t *testing.T) {
 
 	checks := map[string]string{
 		"event":     string(EventDLPWarn),
-		"mode":      "warn",
-		"pattern":   "staged-key",
-		"severity":  "high",
-		"transport": "fetch",
+		"mode":      wantMode,
+		"pattern":   wantPatternStagedKey,
+		"severity":  wantSeverityHigh,
+		"transport": wantTransportFetch,
 		"method":    "GET",
 		"url":       "https://example.com/api",
 		"client_ip": "10.0.0.1",
@@ -75,7 +85,7 @@ func TestLogDLPWarn_EmitterReceivesEvent(t *testing.T) {
 	t.Cleanup(func() { _ = emitter.Close() })
 
 	ctx := NewHTTPLogContext("POST", "https://api.example.com/v1", "10.0.0.2", "req-99", "my-agent")
-	logger.LogDLPWarn(ctx, "staged-token", "medium", "body")
+	logger.LogDLPWarn(ctx, wantPatternStagedTok, wantSeverityMedium, wantTransportBody)
 
 	_ = emitter.Close() // flush
 
@@ -89,13 +99,13 @@ func TestLogDLPWarn_EmitterReceivesEvent(t *testing.T) {
 	if ev.Type != string(EventDLPWarn) {
 		t.Errorf("emitted event type: want %q, got %q", EventDLPWarn, ev.Type)
 	}
-	if ev.Fields["mode"] != "warn" {
-		t.Errorf("emitted mode: want %q, got %v", "warn", ev.Fields["mode"])
+	if ev.Fields["mode"] != wantMode {
+		t.Errorf("emitted mode: want %q, got %v", wantMode, ev.Fields["mode"])
 	}
-	if ev.Fields["pattern"] != "staged-token" {
-		t.Errorf("emitted pattern: want %q, got %v", "staged-token", ev.Fields["pattern"])
+	if ev.Fields["pattern"] != wantPatternStagedTok {
+		t.Errorf("emitted pattern: want %q, got %v", wantPatternStagedTok, ev.Fields["pattern"])
 	}
-	if ev.Fields["transport"] != "body" {
-		t.Errorf("emitted transport: want %q, got %v", "body", ev.Fields["transport"])
+	if ev.Fields["transport"] != wantTransportBody {
+		t.Errorf("emitted transport: want %q, got %v", wantTransportBody, ev.Fields["transport"])
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2243,7 +2243,12 @@ func (c *Config) validateDLP() error {
 			return fmt.Errorf("DLP pattern %q has invalid regex: %w", p.Name, err)
 		}
 		if p.Action != "" {
-			return fmt.Errorf("DLP pattern %q has action %q which is not supported; per-pattern DLP actions are not yet implemented", p.Name, p.Action)
+			if p.Action != ActionWarn {
+				return fmt.Errorf("DLP pattern %q has unsupported action %q; only %q is allowed as a per-pattern action", p.Name, p.Action, ActionWarn)
+			}
+			if p.Compiled {
+				return fmt.Errorf("DLP pattern %q is a built-in default and cannot be set to warn mode; built-in patterns always enforce", p.Name)
+			}
 		}
 		if p.Validator != "" {
 			valid := p.Validator == ValidatorLuhn || p.Validator == ValidatorMod97 || p.Validator == ValidatorABA || p.Validator == ValidatorWIF

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,6 +43,7 @@ const (
 	fieldFileSentry      = "file_sentry"
 	fieldSubEntExcl      = "fetch_proxy.monitoring.subdomain_entropy_exclusions"
 	testExemptDomain     = "api.openai.com"
+	testStagedPattern    = "staged-pattern"
 
 	testProfileDir  = "/tmp/profiles"
 	testRecorderDir = "/tmp/recorder"
@@ -897,6 +898,255 @@ dlp:
 	if !strings.Contains(err.Error(), "action") {
 		t.Errorf("error should mention action, got: %v", err)
 	}
+}
+
+func TestValidate_DLPPatternActionWarn(t *testing.T) {
+	// 6-state boolean test for the action: warn field per Security Invariants.
+	tests := []struct {
+		name    string
+		action  string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "omitted (empty string) — valid",
+			action:  "",
+			wantErr: false,
+		},
+		{
+			name:    "explicit warn — valid",
+			action:  ActionWarn,
+			wantErr: false,
+		},
+		{
+			name:    "explicit block — rejected",
+			action:  ActionBlock,
+			wantErr: true,
+			errMsg:  "unsupported action",
+		},
+		{
+			name:    "explicit strip — rejected",
+			action:  ActionStrip,
+			wantErr: true,
+			errMsg:  "unsupported action",
+		},
+		{
+			name:    "explicit redirect — rejected",
+			action:  ActionRedirect,
+			wantErr: true,
+			errMsg:  "unsupported action",
+		},
+		{
+			name:    "explicit ask — rejected",
+			action:  ActionAsk,
+			wantErr: true,
+			errMsg:  "unsupported action",
+		},
+		{
+			name:    "arbitrary string — rejected",
+			action:  "foobar",
+			wantErr: true,
+			errMsg:  "unsupported action",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Defaults()
+			cfg.DLP.Patterns = []DLPPattern{
+				{Name: "test-warn", Regex: `sk-test-[a-z]+`, Severity: "high", Action: tt.action},
+			}
+			err := cfg.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for action %q", tt.action)
+				} else if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error containing %q, got: %v", tt.errMsg, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("action %q should be valid: %v", tt.action, err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidate_DLPPatternActionWarnOnBuiltin(t *testing.T) {
+	cfg := Defaults()
+	// Built-in default patterns have Compiled=true. Setting warn on them
+	// must be rejected — the immutable safety floor is never warnable.
+	for i := range cfg.DLP.Patterns {
+		if cfg.DLP.Patterns[i].Compiled {
+			cfg.DLP.Patterns[i].Action = ActionWarn
+			break
+		}
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error when setting warn on built-in pattern")
+	}
+	if !strings.Contains(err.Error(), "built-in default") {
+		t.Errorf("error should mention built-in default, got: %v", err)
+	}
+}
+
+func TestLoad_DLPPatternActionWarnFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgContent := `
+version: 1
+dlp:
+  include_defaults: false
+  patterns:
+    - name: test-warn-pattern
+      regex: 'sk-test-[a-z]+'
+      severity: high
+      action: warn
+`
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("action: warn should be accepted: %v", err)
+	}
+	found := false
+	for _, p := range cfg.DLP.Patterns {
+		if p.Name == "test-warn-pattern" && p.Action == ActionWarn {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("loaded config should contain pattern with action: warn")
+	}
+}
+
+func TestLoad_DLPPatternActionNullFromYAML(t *testing.T) {
+	// YAML null for the action field should be treated as omitted (empty string).
+	dir := t.TempDir()
+	cfgContent := `
+version: 1
+dlp:
+  include_defaults: false
+  patterns:
+    - name: test-null
+      regex: 'sk-test-[a-z]+'
+      severity: high
+      action: null
+`
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("action: null should be valid (treated as omitted): %v", err)
+	}
+	for _, p := range cfg.DLP.Patterns {
+		if p.Name == "test-null" {
+			if p.Action != "" {
+				t.Errorf("YAML null action should parse as empty string, got %q", p.Action)
+			}
+			return
+		}
+	}
+	t.Error("test-null pattern not found in loaded config")
+}
+
+func TestReload_DLPPatternActionWarnPersists(t *testing.T) {
+	dir := t.TempDir()
+	// First config: pattern with warn.
+	cfgContent1 := `
+version: 1
+dlp:
+  include_defaults: false
+  patterns:
+    - name: staged-pattern
+      regex: 'staged-[a-z]+'
+      severity: medium
+      action: warn
+`
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfgContent1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg1, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+
+	// Second config: same pattern, still warn (reload without change).
+	cfg2, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	_ = cfg1
+	for _, p := range cfg2.DLP.Patterns {
+		if p.Name == testStagedPattern {
+			if p.Action != ActionWarn {
+				t.Errorf("reload without change: action should be %q, got %q", ActionWarn, p.Action)
+			}
+			return
+		}
+	}
+	t.Error("staged-pattern not found after reload")
+}
+
+func TestReload_DLPPatternActionWarnRemoved(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+
+	// First: pattern with warn.
+	cfgContent1 := `
+version: 1
+dlp:
+  include_defaults: false
+  patterns:
+    - name: staged-pattern
+      regex: 'staged-[a-z]+'
+      severity: medium
+      action: warn
+`
+	if err := os.WriteFile(cfgPath, []byte(cfgContent1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg1, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	for _, p := range cfg1.DLP.Patterns {
+		if p.Name == testStagedPattern && p.Action != ActionWarn {
+			t.Fatalf("first load: expected action warn, got %q", p.Action)
+		}
+	}
+
+	// Second: same pattern, warn removed (promoted to enforce).
+	cfgContent2 := `
+version: 1
+dlp:
+  include_defaults: false
+  patterns:
+    - name: staged-pattern
+      regex: 'staged-[a-z]+'
+      severity: medium
+`
+	if err := os.WriteFile(cfgPath, []byte(cfgContent2), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg2, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	for _, p := range cfg2.DLP.Patterns {
+		if p.Name == testStagedPattern {
+			if p.Action != "" {
+				t.Errorf("reload with warn removed: action should be empty, got %q", p.Action)
+			}
+			return
+		}
+	}
+	t.Error("staged-pattern not found after reload with warn removed")
 }
 
 func TestValidate_InvalidLoggingFormat(t *testing.T) {

--- a/internal/scanner/dlp_warn_test.go
+++ b/internal/scanner/dlp_warn_test.go
@@ -287,7 +287,7 @@ func TestDeduplicateWarnMatches_NilAndSingle(t *testing.T) {
 	}
 }
 
-func TestFragmentBuffer_WarnPatternReportedNotEnforced(t *testing.T) {
+func TestFragmentBuffer_WarnPatternNotEnforced(t *testing.T) {
 	cfg := testDLPConfig("staged-frag", `staged-frag-[A-Za-z0-9]{20,}`, true)
 	s := New(cfg)
 
@@ -299,15 +299,11 @@ func TestFragmentBuffer_WarnPatternReportedNotEnforced(t *testing.T) {
 	fb.Append("session-1", []byte("AABBCCDDEEFFGGHHIIJJ"))
 
 	matches := fb.ScanForSecrets(context.Background(), "session-1", s)
-	// Warn-only cross-request matches should be reported with Warn=true.
-	// The caller uses the Warn field to decide enforcement vs. audit-only.
-	if len(matches) == 0 {
-		t.Fatal("expected warn-mode cross-request match to be reported")
-	}
-	for _, m := range matches {
-		if !m.Warn {
-			t.Errorf("cross-request warn match should have Warn=true, got %q", m.PatternName)
-		}
+	// Warn-only cross-request matches must NOT appear in the enforcement
+	// return — CEE callers treat len(matches) > 0 as an enforcement signal.
+	// The DLPWarnHook inside ScanTextForDLP handles audit emission.
+	if len(matches) != 0 {
+		t.Errorf("warn-only pattern should not produce enforcement matches, got %d", len(matches))
 	}
 }
 

--- a/internal/scanner/dlp_warn_test.go
+++ b/internal/scanner/dlp_warn_test.go
@@ -269,7 +269,7 @@ func TestDeduplicateWarnMatches_NilAndSingle(t *testing.T) {
 	}
 }
 
-func TestFragmentBuffer_WarnPatternNotBlocked(t *testing.T) {
+func TestFragmentBuffer_WarnPatternReportedNotEnforced(t *testing.T) {
 	cfg := testDLPConfig("staged-frag", `staged-frag-[A-Za-z0-9]{20,}`, true)
 	s := New(cfg)
 
@@ -281,8 +281,69 @@ func TestFragmentBuffer_WarnPatternNotBlocked(t *testing.T) {
 	fb.Append("session-1", []byte("AABBCCDDEEFFGGHHIIJJ"))
 
 	matches := fb.ScanForSecrets(context.Background(), "session-1", s)
-	// Warn-only matches should NOT trigger cross-request enforcement.
-	if len(matches) != 0 {
-		t.Errorf("warn-only pattern should not produce cross-request DLP matches, got %d", len(matches))
+	// Warn-only cross-request matches should be reported with Warn=true.
+	// The caller uses the Warn field to decide enforcement vs. audit-only.
+	if len(matches) == 0 {
+		t.Fatal("expected warn-mode cross-request match to be reported")
 	}
+	for _, m := range matches {
+		if !m.Warn {
+			t.Errorf("cross-request warn match should have Warn=true, got %q", m.PatternName)
+		}
+	}
+}
+
+func TestDLPWarnHook_TextDLP(t *testing.T) {
+	cfg := testDLPConfig("hook-text", `hook-text-[A-Za-z0-9]{10,}`, true)
+	s := New(cfg)
+
+	var called []string
+	old := DLPWarnHook
+	DLPWarnHook = func(patternName, severity, transport string) {
+		called = append(called, patternName+":"+transport)
+	}
+	defer func() { DLPWarnHook = old }()
+
+	s.ScanTextForDLP(context.Background(), "hook-text-ABCDEFGHIJ1234")
+
+	if len(called) == 0 {
+		t.Fatal("DLPWarnHook should have been called for text DLP warn match")
+	}
+	if called[0] != "hook-text:text" {
+		t.Errorf("expected hook-text:text, got %q", called[0])
+	}
+}
+
+func TestDLPWarnHook_URLDLP(t *testing.T) {
+	cfg := testDLPConfig("hook-url", `hook-url-[A-Za-z0-9]{10,}`, true)
+	s := New(cfg)
+
+	var called []string
+	old := DLPWarnHook
+	DLPWarnHook = func(patternName, severity, transport string) {
+		called = append(called, patternName+":"+transport)
+	}
+	defer func() { DLPWarnHook = old }()
+
+	s.Scan(context.Background(), "https://example.com/?key=hook-url-ABCDEFGHIJ1234")
+
+	if len(called) == 0 {
+		t.Fatal("DLPWarnHook should have been called for URL DLP warn match")
+	}
+	if called[0] != "hook-url:url" {
+		t.Errorf("expected hook-url:url, got %q", called[0])
+	}
+}
+
+func TestDLPWarnHook_NilDoesNotPanic(t *testing.T) {
+	cfg := testDLPConfig("hook-nil", `hook-nil-[A-Za-z0-9]{10,}`, true)
+	s := New(cfg)
+
+	old := DLPWarnHook
+	DLPWarnHook = nil
+	defer func() { DLPWarnHook = old }()
+
+	// Should not panic with nil hook.
+	s.ScanTextForDLP(context.Background(), "hook-nil-ABCDEFGHIJ1234")
+	s.Scan(context.Background(), "https://example.com/?key=hook-nil-ABCDEFGHIJ1234")
 }

--- a/internal/scanner/dlp_warn_test.go
+++ b/internal/scanner/dlp_warn_test.go
@@ -1,0 +1,288 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// testDLPConfig returns a minimal config with SSRF disabled and one pattern.
+// If warn is true, the pattern gets action: warn.
+func testDLPConfig(patternName, regex string, warn bool) *config.Config {
+	cfg := config.Defaults()
+	cfg.Internal = nil // disable SSRF for unit tests
+
+	action := ""
+	if warn {
+		action = config.ActionWarn
+	}
+	cfg.DLP.Patterns = append(cfg.DLP.Patterns, config.DLPPattern{
+		Name:     patternName,
+		Regex:    regex,
+		Severity: "high",
+		Action:   action,
+	})
+	return cfg
+}
+
+func TestTextDLP_WarnPatternRoutesToInformational(t *testing.T) {
+	cfg := testDLPConfig("staged-key", `staged-[A-Za-z0-9]{10,}`, true)
+	s := New(cfg)
+
+	result := s.ScanTextForDLP(context.Background(), "here is staged-ABCDEFGHIJ1234")
+
+	// Warn-only: Clean should be true (no enforcement), Matches empty.
+	if !result.Clean {
+		t.Error("warn-only match should produce Clean=true")
+	}
+	if len(result.Matches) != 0 {
+		t.Errorf("warn-only match should not appear in Matches, got %d", len(result.Matches))
+	}
+	if len(result.InformationalMatches) == 0 {
+		t.Fatal("warn-only match should appear in InformationalMatches")
+	}
+	m := result.InformationalMatches[0]
+	if m.PatternName != "staged-key" {
+		t.Errorf("expected pattern name staged-key, got %q", m.PatternName)
+	}
+	if !m.Warn {
+		t.Error("InformationalMatches entry should have Warn=true")
+	}
+}
+
+func TestTextDLP_EnforcePatternRoutesToMatches(t *testing.T) {
+	cfg := testDLPConfig("enforced-key", `enforced-[A-Za-z0-9]{10,}`, false)
+	s := New(cfg)
+
+	result := s.ScanTextForDLP(context.Background(), "here is enforced-ABCDEFGHIJ1234")
+
+	if result.Clean {
+		t.Error("enforced match should produce Clean=false")
+	}
+	if len(result.Matches) == 0 {
+		t.Fatal("enforced match should appear in Matches")
+	}
+	if result.Matches[0].Warn {
+		t.Error("enforced match should have Warn=false")
+	}
+	if len(result.InformationalMatches) != 0 {
+		t.Errorf("enforced match should not appear in InformationalMatches, got %d",
+			len(result.InformationalMatches))
+	}
+}
+
+func TestTextDLP_MixedWarnAndEnforce(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.DLP.Patterns = append(cfg.DLP.Patterns,
+		config.DLPPattern{
+			Name:     "warn-pattern",
+			Regex:    `warn-[A-Za-z0-9]{10,}`,
+			Severity: "medium",
+			Action:   config.ActionWarn,
+		},
+		config.DLPPattern{
+			Name:     "enforce-pattern",
+			Regex:    `enforce-[A-Za-z0-9]{10,}`,
+			Severity: "high",
+		},
+	)
+	s := New(cfg)
+
+	text := "warn-AAAAAAAAAA plus enforce-BBBBBBBBBB"
+	result := s.ScanTextForDLP(context.Background(), text)
+
+	// Should NOT be clean (enforced match exists).
+	if result.Clean {
+		t.Error("mixed result should not be clean when enforced match exists")
+	}
+
+	// Enforced match in Matches.
+	foundEnforce := false
+	for _, m := range result.Matches {
+		if m.PatternName == "enforce-pattern" {
+			foundEnforce = true
+			if m.Warn {
+				t.Error("enforce-pattern should not have Warn=true")
+			}
+		}
+		if m.PatternName == "warn-pattern" {
+			t.Error("warn-pattern should NOT appear in Matches")
+		}
+	}
+	if !foundEnforce {
+		t.Error("enforce-pattern not found in Matches")
+	}
+
+	// Warn match in InformationalMatches.
+	foundWarn := false
+	for _, m := range result.InformationalMatches {
+		if m.PatternName == "warn-pattern" {
+			foundWarn = true
+			if !m.Warn {
+				t.Error("warn-pattern should have Warn=true")
+			}
+		}
+		if m.PatternName == "enforce-pattern" {
+			t.Error("enforce-pattern should NOT appear in InformationalMatches")
+		}
+	}
+	if !foundWarn {
+		t.Error("warn-pattern not found in InformationalMatches")
+	}
+}
+
+func TestURLDLP_WarnPatternAllowsRequest(t *testing.T) {
+	cfg := testDLPConfig("staged-url-key", `staged-[A-Za-z0-9]{10,}`, true)
+	s := New(cfg)
+
+	result := s.Scan(context.Background(), "https://example.com/?key=staged-ABCDEFGHIJ1234")
+
+	if !result.Allowed {
+		t.Error("warn-mode URL DLP match should allow the request")
+	}
+	if len(result.WarnMatches) == 0 {
+		t.Fatal("warn-mode URL DLP match should populate WarnMatches")
+	}
+	if result.WarnMatches[0].PatternName != "staged-url-key" {
+		t.Errorf("expected pattern name staged-url-key, got %q", result.WarnMatches[0].PatternName)
+	}
+}
+
+func TestURLDLP_EnforcePatternBlocksRequest(t *testing.T) {
+	cfg := testDLPConfig("enforced-url-key", `enforced-[A-Za-z0-9]{10,}`, false)
+	s := New(cfg)
+
+	result := s.Scan(context.Background(), "https://example.com/?key=enforced-ABCDEFGHIJ1234")
+
+	if result.Allowed {
+		t.Error("enforced URL DLP match should block the request")
+	}
+	if result.Scanner != ScannerDLP {
+		t.Errorf("expected scanner %q, got %q", ScannerDLP, result.Scanner)
+	}
+}
+
+func TestURLDLP_WarnDoesNotPreventEnforceBlock(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.DLP.Patterns = append(cfg.DLP.Patterns,
+		config.DLPPattern{
+			Name:     "warn-url",
+			Regex:    `warnurl-[A-Za-z0-9]{10,}`,
+			Severity: "medium",
+			Action:   config.ActionWarn,
+		},
+		config.DLPPattern{
+			Name:     "enforce-url",
+			Regex:    `enforceurl-[A-Za-z0-9]{10,}`,
+			Severity: "critical",
+		},
+	)
+	s := New(cfg)
+
+	// URL with both warn and enforce matches — should be blocked by enforce.
+	url := "https://example.com/?a=warnurl-AAAAAAAAAA&b=enforceurl-BBBBBBBBBB"
+	result := s.Scan(context.Background(), url)
+
+	if result.Allowed {
+		t.Error("should be blocked when enforce pattern matches")
+	}
+	// Warn matches should still be reported even when blocked by another pattern.
+	if len(result.WarnMatches) == 0 {
+		t.Error("warn matches should be reported even when request is blocked by enforce pattern")
+	}
+}
+
+func TestURLDLP_WarnMatchFromSubsequenceCombination(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.DLP.Patterns = append(cfg.DLP.Patterns, config.DLPPattern{
+		Name:     "staged-subseq",
+		Regex:    `staged-subseq-[A-Za-z0-9]{20,}`,
+		Severity: "high",
+		Action:   config.ActionWarn,
+	})
+	s := New(cfg)
+
+	// Secret split across 3 query params — subsequence recombination should
+	// produce a warn match instead of blocking.
+	url := "https://example.com/?a=staged-subseq-&x=junk&b=AABBCCDDEE&y=junk&c=FFEEDDCCBBAA"
+	result := s.Scan(context.Background(), url)
+
+	if !result.Allowed {
+		t.Error("warn-mode subsequence match should not block")
+	}
+	// The pattern may or may not fire depending on concatenation order,
+	// but the request MUST be allowed regardless.
+}
+
+func TestTextDLP_WarnPatternEncodedVariants(t *testing.T) {
+	cfg := testDLPConfig("staged-encoded", `staged-encoded-[A-Za-z0-9]{10,}`, true)
+	s := New(cfg)
+
+	tests := []struct {
+		name string
+		text string
+	}{
+		{"raw", "staged-encoded-ABCDEFGHIJ1234"},
+		{"url-encoded", "staged-encoded-%41%42%43%44%45%46%47%48%49%4a1234"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.ScanTextForDLP(context.Background(), tt.text)
+			if !result.Clean {
+				t.Error("warn-only match should produce Clean=true")
+			}
+			if len(result.InformationalMatches) == 0 {
+				t.Error("expected informational match for encoded variant")
+			}
+		})
+	}
+}
+
+func TestDeduplicateWarnMatches(t *testing.T) {
+	matches := []WarnMatch{
+		{PatternName: "a", Severity: "high"},
+		{PatternName: "b", Severity: "medium"},
+		{PatternName: "a", Severity: "high"}, // duplicate
+		{PatternName: "c", Severity: "low"},
+		{PatternName: "b", Severity: "medium"}, // duplicate
+	}
+	deduped := deduplicateWarnMatches(matches)
+	if len(deduped) != 3 {
+		t.Errorf("expected 3 unique matches, got %d", len(deduped))
+	}
+}
+
+func TestDeduplicateWarnMatches_NilAndSingle(t *testing.T) {
+	if got := deduplicateWarnMatches(nil); got != nil {
+		t.Errorf("nil input should return nil, got %v", got)
+	}
+	single := []WarnMatch{{PatternName: "x", Severity: "high"}}
+	if got := deduplicateWarnMatches(single); len(got) != 1 {
+		t.Errorf("single input should return as-is, got %d", len(got))
+	}
+}
+
+func TestFragmentBuffer_WarnPatternNotBlocked(t *testing.T) {
+	cfg := testDLPConfig("staged-frag", `staged-frag-[A-Za-z0-9]{20,}`, true)
+	s := New(cfg)
+
+	fb := NewFragmentBuffer(4096, 10, 60)
+	defer fb.Close()
+
+	// Split a staged secret across two fragments.
+	fb.Append("session-1", []byte("staged-frag-"))
+	fb.Append("session-1", []byte("AABBCCDDEEFFGGHHIIJJ"))
+
+	matches := fb.ScanForSecrets(context.Background(), "session-1", s)
+	// Warn-only matches should NOT trigger cross-request enforcement.
+	if len(matches) != 0 {
+		t.Errorf("warn-only pattern should not produce cross-request DLP matches, got %d", len(matches))
+	}
+}

--- a/internal/scanner/dlp_warn_test.go
+++ b/internal/scanner/dlp_warn_test.go
@@ -185,6 +185,14 @@ func TestURLDLP_WarnDoesNotPreventEnforceBlock(t *testing.T) {
 	)
 	s := New(cfg)
 
+	// Install hook to verify warn emission even on blocked requests.
+	var hookCalled []string
+	old := DLPWarnHook
+	DLPWarnHook = func(patternName, _, _ string) {
+		hookCalled = append(hookCalled, patternName)
+	}
+	defer func() { DLPWarnHook = old }()
+
 	// URL with both warn and enforce matches — should be blocked by enforce.
 	url := "https://example.com/?a=warnurl-AAAAAAAAAA&b=enforceurl-BBBBBBBBBB"
 	result := s.Scan(context.Background(), url)
@@ -195,6 +203,16 @@ func TestURLDLP_WarnDoesNotPreventEnforceBlock(t *testing.T) {
 	// Warn matches should still be reported even when blocked by another pattern.
 	if len(result.WarnMatches) == 0 {
 		t.Error("warn matches should be reported even when request is blocked by enforce pattern")
+	}
+	// Hook should fire for the warn pattern even though the request was blocked.
+	foundWarnHook := false
+	for _, name := range hookCalled {
+		if name == "warn-url" {
+			foundWarnHook = true
+		}
+	}
+	if !foundWarnHook {
+		t.Error("DLPWarnHook should fire for warn-url even when request is blocked by enforce pattern")
 	}
 }
 

--- a/internal/scanner/fragment_buffer.go
+++ b/internal/scanner/fragment_buffer.go
@@ -145,7 +145,7 @@ func (fb *FragmentBuffer) ScanForSecrets(ctx context.Context, sessionKey string,
 
 	// Scan the concatenated buffer.
 	result := sc.ScanTextForDLP(ctx, string(buf))
-	if result.Clean {
+	if result.Clean && len(result.InformationalMatches) == 0 {
 		return nil
 	}
 
@@ -159,6 +159,9 @@ func (fb *FragmentBuffer) ScanForSecrets(ctx context.Context, sessionKey string,
 			for _, m := range fragResult.Matches {
 				singleFragment[m.PatternName] = true
 			}
+			for _, m := range fragResult.InformationalMatches {
+				singleFragment[m.PatternName] = true
+			}
 		}
 	}
 
@@ -169,6 +172,15 @@ func (fb *FragmentBuffer) ScanForSecrets(ctx context.Context, sessionKey string,
 		if !singleFragment[m.PatternName] {
 			matches = append(matches, DLPMatch{
 				PatternName: m.PatternName,
+			})
+		}
+	}
+	// Warn-mode cross-request matches: emit via hook but don't enforce.
+	for _, m := range result.InformationalMatches {
+		if !singleFragment[m.PatternName] {
+			matches = append(matches, DLPMatch{
+				PatternName: m.PatternName,
+				Warn:        true,
 			})
 		}
 	}

--- a/internal/scanner/fragment_buffer.go
+++ b/internal/scanner/fragment_buffer.go
@@ -167,20 +167,14 @@ func (fb *FragmentBuffer) ScanForSecrets(ctx context.Context, sessionKey string,
 
 	// Only report matches NOT found in any individual fragment.
 	// These are true cross-request matches (secret spans fragment boundaries).
+	// Warn-mode matches are NOT included here — they are already emitted
+	// via DLPWarnHook inside ScanTextForDLP. Including them would cause
+	// CEE callers to treat informational warn matches as enforcement signals.
 	var matches []DLPMatch
 	for _, m := range result.Matches {
 		if !singleFragment[m.PatternName] {
 			matches = append(matches, DLPMatch{
 				PatternName: m.PatternName,
-			})
-		}
-	}
-	// Warn-mode cross-request matches: emit via hook but don't enforce.
-	for _, m := range result.InformationalMatches {
-		if !singleFragment[m.PatternName] {
-			matches = append(matches, DLPMatch{
-				PatternName: m.PatternName,
-				Warn:        true,
 			})
 		}
 	}

--- a/internal/scanner/fragment_buffer.go
+++ b/internal/scanner/fragment_buffer.go
@@ -13,6 +13,7 @@ import (
 type DLPMatch struct {
 	PatternName string
 	Matched     string
+	Warn        bool // true for warn-mode patterns (informational only)
 }
 
 // fragment holds a single outbound payload chunk with its arrival time.

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -615,17 +615,14 @@ func (s *Scanner) scan(ctx context.Context, rawURL string) (result Result) {
 	dlpResult, dlpWarns := s.checkDLP(parsed)
 	if !dlpResult.Allowed {
 		dlpResult.WarnMatches = dlpWarns
+		emitDLPWarns(dlpWarns)
 		return dlpResult
 	}
 	// Attach DLP warn matches to whatever result is returned from here on.
 	// The defer fires on every return path, including blocks by later scanners.
 	defer func() {
 		result.WarnMatches = dlpWarns
-		if len(dlpWarns) > 0 && DLPWarnHook != nil {
-			for _, m := range dlpWarns {
-				DLPWarnHook(m.PatternName, m.Severity, "url")
-			}
-		}
+		emitDLPWarns(dlpWarns)
 	}()
 	if result := s.checkEntropy(parsed); !result.Allowed {
 		return result
@@ -1509,6 +1506,16 @@ func nextCombination(indices []int, n int) bool {
 		}
 	}
 	return false
+}
+
+// emitDLPWarns calls DLPWarnHook for each warn match if the hook is set.
+func emitDLPWarns(matches []WarnMatch) {
+	if len(matches) == 0 || DLPWarnHook == nil {
+		return
+	}
+	for _, m := range matches {
+		DLPWarnHook(m.PatternName, m.Severity, "url")
+	}
 }
 
 // deduplicateWarnMatches removes duplicate warn matches by pattern name.

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -70,14 +70,22 @@ const (
 	ClassConfigMismatch
 )
 
+// WarnMatch describes a DLP pattern match from a warn-mode pattern.
+// These are informational only — they do not block or alter the request.
+type WarnMatch struct {
+	PatternName string `json:"pattern_name"`
+	Severity    string `json:"severity"`
+}
+
 // Result describes the outcome of scanning a URL.
 type Result struct {
-	Allowed bool        `json:"allowed"`
-	Reason  string      `json:"reason,omitempty"`
-	Scanner string      `json:"scanner,omitempty"` // which scanner triggered
-	Hint    string      `json:"hint,omitempty"`    // actionable guidance when blocked
-	Score   float64     `json:"score"`             // anomaly score 0.0-1.0
-	Class   ResultClass `json:"-"`                 // internal: threat vs protective classification
+	Allowed     bool        `json:"allowed"`
+	Reason      string      `json:"reason,omitempty"`
+	Scanner     string      `json:"scanner,omitempty"` // which scanner triggered
+	Hint        string      `json:"hint,omitempty"`    // actionable guidance when blocked
+	Score       float64     `json:"score"`             // anomaly score 0.0-1.0
+	Class       ResultClass `json:"-"`                 // internal: threat vs protective classification
+	WarnMatches []WarnMatch `json:"warn_matches,omitempty"`
 }
 
 // IsProtective reports whether this result represents protective enforcement
@@ -136,6 +144,7 @@ type compiledPattern struct {
 	exemptDomains []string          // domains where this pattern is skipped (wildcard supported)
 	bundle        string            // empty for built-in/config patterns
 	bundleVersion string
+	warn          bool // true when pattern action is "warn" — matches are informational only
 }
 
 // matches returns true if text matches the regex AND passes the post-match
@@ -206,6 +215,7 @@ func New(cfg *config.Config) *Scanner {
 			exemptDomains: p.ExemptDomains,
 			bundle:        p.Bundle,
 			bundleVersion: p.BundleVersion,
+			warn:          p.Action == config.ActionWarn,
 		}
 		if p.Validator != "" {
 			fn, ok := DLPValidators[p.Validator]
@@ -523,7 +533,7 @@ func (s *Scanner) Scan(ctx context.Context, rawURL string) Result {
 // scan checks a URL against all scanners and returns the result.
 // DLP runs on the hostname BEFORE DNS resolution to prevent secret exfiltration
 // via DNS queries (e.g., "sk-ant-xxx.evil.com" leaks the key during resolution).
-func (s *Scanner) scan(ctx context.Context, rawURL string) Result {
+func (s *Scanner) scan(ctx context.Context, rawURL string) (result Result) {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return Result{Allowed: false, Reason: "invalid URL", Scanner: ScannerParser, Score: 1.0}
@@ -596,9 +606,14 @@ func (s *Scanner) scan(ctx context.Context, rawURL string) Result {
 	// DLP + entropy on hostname BEFORE DNS resolution.
 	// Prevents secret exfiltration via DNS queries for domains like
 	// "sk-ant-xxxx.evil.com" where the subdomain encodes a secret.
-	if result := s.checkDLP(parsed); !result.Allowed {
-		return result
+	dlpResult, dlpWarns := s.checkDLP(parsed)
+	if !dlpResult.Allowed {
+		dlpResult.WarnMatches = dlpWarns
+		return dlpResult
 	}
+	// Attach DLP warn matches to whatever result is returned from here on.
+	// The defer fires on every return path, including blocks by later scanners.
+	defer func() { result.WarnMatches = dlpWarns }()
 	if result := s.checkEntropy(parsed); !result.Allowed {
 		return result
 	}
@@ -1168,11 +1183,13 @@ func decodeEncodings(s string) []decodedResult {
 // Scanning the full URL catches secrets encoded in subdomains (e.g., sk-proj-xxx.evil.com)
 // and secrets split across query parameters. Iterative URL decoding
 // prevents multi-layer encoding bypass.
-func (s *Scanner) checkDLP(parsed *url.URL) Result {
+func (s *Scanner) checkDLP(parsed *url.URL) (Result, []WarnMatch) {
 	// Canary check is deferred to after DLP pattern evaluation (below).
 	// DLP patterns provide more specific attribution ("aws_access_key" vs
 	// "Canary Token"). Canary is the safety net for synthetic tokens that
 	// DLP patterns don't cover. Both are evaluated — DLP wins if it matches.
+
+	var warnMatches []WarnMatch
 
 	// parsed.Path is already URL-decoded by Go's url.Parse.
 	// For query strings, iteratively decode to catch multi-layer encoding.
@@ -1269,12 +1286,19 @@ func (s *Scanner) checkDLP(parsed *url.URL) Result {
 				if len(p.exemptDomains) > 0 && matchesDomainList(parsed.Hostname(), p.exemptDomains) {
 					continue
 				}
+				if p.warn {
+					warnMatches = append(warnMatches, WarnMatch{
+						PatternName: p.name,
+						Severity:    p.severity,
+					})
+					continue
+				}
 				return Result{
 					Allowed: false,
 					Reason:  fmt.Sprintf("DLP match: %s (%s)", p.name, p.severity),
 					Scanner: ScannerDLP,
 					Score:   1.0,
-				}
+				}, warnMatches
 			}
 		}
 	}
@@ -1283,8 +1307,10 @@ func (s *Scanner) checkDLP(parsed *url.URL) Result {
 	// to catch secrets split across params with junk values interleaved.
 	// E.g., "?a=sk-&x=junk&b=ant-&y=junk&c=api03-&z=junk&d=AAAA..." —
 	// combination (0,2,4,6) reconstructs "sk-ant-api03-AAAA...".
-	if result := s.querySubsequenceDLP(parsed.RawQuery, parsed.Hostname()); !result.Allowed {
-		return result
+	subResult, subWarns := s.querySubsequenceDLP(parsed.RawQuery, parsed.Hostname())
+	warnMatches = append(warnMatches, subWarns...)
+	if !subResult.Allowed {
+		return subResult, warnMatches
 	}
 
 	// Seed phrase detection on seed-safe candidates only.
@@ -1350,22 +1376,22 @@ func (s *Scanner) checkDLP(parsed *url.URL) Result {
 					Reason:  "DLP match: BIP-39 Seed Phrase (critical)",
 					Scanner: ScannerDLP,
 					Score:   1.0,
-				}
+				}, warnMatches
 			}
 		}
 	}
 
 	// Check for environment variable leaks
 	if result := s.checkSecretsInURL(s.envSecrets, parsed, "environment variable leak detected"); !result.Allowed {
-		return result
+		return result, warnMatches
 	}
 
 	// Check for known file secret leaks
 	if result := s.checkSecretsInURL(s.fileSecrets, parsed, "known secret leak detected"); !result.Allowed {
-		return result
+		return result, warnMatches
 	}
 
-	return Result{Allowed: true}
+	return Result{Allowed: true}, deduplicateWarnMatches(warnMatches)
 }
 
 // querySubsequenceDLP checks ordered subsequences (combinations) of query
@@ -1373,9 +1399,9 @@ func (s *Scanner) checkDLP(parsed *url.URL) Result {
 // multiple parameters with arbitrary junk values interleaved between fragments.
 // Tries subsequences of size 2-4 for URLs with 3-20 query params.
 // Cost: O(n^4) worst case, bounded at ~6k combinations for n=20.
-func (s *Scanner) querySubsequenceDLP(rawQuery, hostname string) Result {
+func (s *Scanner) querySubsequenceDLP(rawQuery, hostname string) (Result, []WarnMatch) {
 	if rawQuery == "" || !strings.Contains(rawQuery, "&") {
-		return Result{Allowed: true}
+		return Result{Allowed: true}, nil
 	}
 
 	var values []string
@@ -1388,7 +1414,7 @@ func (s *Scanner) querySubsequenceDLP(rawQuery, hostname string) Result {
 
 	n := len(values)
 	if n < 3 {
-		return Result{Allowed: true}
+		return Result{Allowed: true}, nil
 	}
 	// Cap to first 20 values to bound combinatorial cost (O(n^4)).
 	if n > 20 {
@@ -1396,18 +1422,22 @@ func (s *Scanner) querySubsequenceDLP(rawQuery, hostname string) Result {
 		n = 20
 	}
 
+	var warnMatches []WarnMatch
 	for size := 2; size <= 4 && size <= n; size++ {
-		if result := s.checkDLPCombinations(values, n, size, hostname); !result.Allowed {
-			return result
+		result, warns := s.checkDLPCombinations(values, n, size, hostname)
+		warnMatches = append(warnMatches, warns...)
+		if !result.Allowed {
+			return result, warnMatches
 		}
 	}
 
-	return Result{Allowed: true}
+	return Result{Allowed: true}, warnMatches
 }
 
 // checkDLPCombinations generates all ordered combinations of the given size
 // from the values slice and checks each concatenation against DLP patterns.
-func (s *Scanner) checkDLPCombinations(values []string, n, size int, hostname string) Result {
+func (s *Scanner) checkDLPCombinations(values []string, n, size int, hostname string) (Result, []WarnMatch) {
+	var warnMatches []WarnMatch
 	indices := make([]int, size)
 	for i := range indices {
 		indices[i] = i
@@ -1428,12 +1458,19 @@ func (s *Scanner) checkDLPCombinations(values []string, n, size int, hostname st
 				if len(p.exemptDomains) > 0 && matchesDomainList(hostname, p.exemptDomains) {
 					continue
 				}
+				if p.warn {
+					warnMatches = append(warnMatches, WarnMatch{
+						PatternName: p.name,
+						Severity:    p.severity,
+					})
+					continue
+				}
 				return Result{
 					Allowed: false,
 					Reason:  fmt.Sprintf("DLP match: %s (%s)", p.name, p.severity),
 					Scanner: ScannerDLP,
 					Score:   1.0,
-				}
+				}, warnMatches
 			}
 		}
 
@@ -1442,7 +1479,7 @@ func (s *Scanner) checkDLPCombinations(values []string, n, size int, hostname st
 		}
 	}
 
-	return Result{Allowed: true}
+	return Result{Allowed: true}, warnMatches
 }
 
 // nextCombination advances indices to the next lexicographic combination.
@@ -1459,6 +1496,22 @@ func nextCombination(indices []int, n int) bool {
 		}
 	}
 	return false
+}
+
+// deduplicateWarnMatches removes duplicate warn matches by pattern name.
+func deduplicateWarnMatches(matches []WarnMatch) []WarnMatch {
+	if len(matches) <= 1 {
+		return matches
+	}
+	seen := make(map[string]struct{}, len(matches))
+	out := make([]WarnMatch, 0, len(matches))
+	for _, m := range matches {
+		if _, ok := seen[m.PatternName]; !ok {
+			seen[m.PatternName] = struct{}{}
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 // checkSecretsInURL scans a URL for leaked secrets (env vars or file-based).

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -100,6 +100,12 @@ func (r Result) IsConfigMismatch() bool {
 	return r.Class == ClassConfigMismatch
 }
 
+// DLPWarnHook is called whenever a warn-mode DLP pattern matches.
+// The runtime sets this to route warn events to the audit logger.
+// When nil, warn matches still allow traffic but are not emitted.
+// Parameters: patternName, severity, transport ("url" or "text").
+var DLPWarnHook func(patternName, severity, transport string)
+
 // Scanner checks URLs for suspicious content before fetching.
 type Scanner struct {
 	core                       *compiledCoreScanner // immutable safety floor — always runs, no config knobs
@@ -613,7 +619,14 @@ func (s *Scanner) scan(ctx context.Context, rawURL string) (result Result) {
 	}
 	// Attach DLP warn matches to whatever result is returned from here on.
 	// The defer fires on every return path, including blocks by later scanners.
-	defer func() { result.WarnMatches = dlpWarns }()
+	defer func() {
+		result.WarnMatches = dlpWarns
+		if len(dlpWarns) > 0 && DLPWarnHook != nil {
+			for _, m := range dlpWarns {
+				DLPWarnHook(m.PatternName, m.Severity, "url")
+			}
+		}
+	}()
 	if result := s.checkEntropy(parsed); !result.Allowed {
 		return result
 	}

--- a/internal/scanner/text_dlp.go
+++ b/internal/scanner/text_dlp.go
@@ -21,12 +21,14 @@ type TextDLPMatch struct {
 	Encoded       string `json:"encoded,omitempty"` // "", "base64", "hex", "base32", "env", "url", "subdomain"
 	Bundle        string `json:"bundle,omitempty"`
 	BundleVersion string `json:"bundle_version,omitempty"`
+	Warn          bool   `json:"warn,omitempty"` // true for warn-mode patterns (informational only)
 }
 
 // TextDLPResult describes the outcome of scanning text for DLP patterns.
 type TextDLPResult struct {
-	Clean   bool           `json:"clean"`
-	Matches []TextDLPMatch `json:"matches,omitempty"`
+	Clean                bool           `json:"clean"`
+	Matches              []TextDLPMatch `json:"matches,omitempty"`
+	InformationalMatches []TextDLPMatch `json:"informational_matches,omitempty"` // warn-mode matches (non-blocking)
 }
 
 // ScanTextForDLP checks arbitrary text for DLP pattern matches and env secret leaks.
@@ -129,6 +131,7 @@ func (s *Scanner) ScanTextForDLP(_ context.Context, text string) TextDLPResult {
 				Severity:      p.severity,
 				Bundle:        p.bundle,
 				BundleVersion: p.bundleVersion,
+				Warn:          p.warn,
 			})
 		}
 	}
@@ -180,7 +183,23 @@ func (s *Scanner) ScanTextForDLP(_ context.Context, text string) TextDLPResult {
 	if len(matches) == 0 {
 		return TextDLPResult{Clean: true}
 	}
-	return TextDLPResult{Clean: false, Matches: matches}
+
+	// Partition matches: warn-mode patterns go to InformationalMatches,
+	// enforced patterns go to Matches. Warn-only results are Clean=true
+	// so transports take no enforcement action.
+	var enforced, informational []TextDLPMatch
+	for _, m := range matches {
+		if m.Warn {
+			informational = append(informational, m)
+		} else {
+			enforced = append(enforced, m)
+		}
+	}
+	return TextDLPResult{
+		Clean:                len(enforced) == 0,
+		Matches:              enforced,
+		InformationalMatches: informational,
+	}
 }
 
 // maxDecodeDepth bounds recursive encoding decode to prevent CPU exhaustion.
@@ -257,6 +276,7 @@ func (s *Scanner) matchDLPPatterns(text, encoding string) []TextDLPMatch {
 				Encoded:       encoding,
 				Bundle:        p.bundle,
 				BundleVersion: p.bundleVersion,
+				Warn:          p.warn,
 			})
 		}
 	}

--- a/internal/scanner/text_dlp.go
+++ b/internal/scanner/text_dlp.go
@@ -161,7 +161,10 @@ func (s *Scanner) ScanTextForDLP(_ context.Context, text string) TextDLPResult {
 	// try decoding each segment individually. Catches encoded secrets embedded
 	// in URLs within MCP tool arguments (e.g., "https://evil.com/<hex-key>/data")
 	// where whole-string decode fails because the text isn't pure hex/base64.
-	if len(matches) == 0 {
+	// Only skip segment decoding when enforced matches already exist.
+	// Warn-only matches must not gate off further scanning — an enforced
+	// match might hide in a decoded segment.
+	if !hasEnforcedMatch(matches) {
 		matches = append(matches, s.decodeTextSegments(cleaned)...)
 	}
 
@@ -336,6 +339,16 @@ func deduplicateMatches(matches []TextDLPMatch) []TextDLPMatch {
 		}
 	}
 	return result
+}
+
+// hasEnforcedMatch reports whether any match in the slice is non-warn (enforced).
+func hasEnforcedMatch(matches []TextDLPMatch) bool {
+	for _, m := range matches {
+		if !m.Warn {
+			return true
+		}
+	}
+	return false
 }
 
 // decodeTextSegments splits text on common URL/path delimiters and tries

--- a/internal/scanner/text_dlp.go
+++ b/internal/scanner/text_dlp.go
@@ -195,6 +195,14 @@ func (s *Scanner) ScanTextForDLP(_ context.Context, text string) TextDLPResult {
 			enforced = append(enforced, m)
 		}
 	}
+
+	// Emit warn events through the hook so callers don't need individual wiring.
+	if len(informational) > 0 && DLPWarnHook != nil {
+		for _, m := range informational {
+			DLPWarnHook(m.PatternName, m.Severity, "text")
+		}
+	}
+
 	return TextDLPResult{
 		Clean:                len(enforced) == 0,
 		Matches:              enforced,


### PR DESCRIPTION
## Summary

- Operators can annotate DLP patterns with `action: warn` to observe matches in production without blocking traffic. Warn-mode patterns run through the full scanning pipeline (URL DLP, text DLP, encoded variants, cross-request fragment detection) but produce informational results instead of enforcement actions.
- The warn filter is handled at the scanner output layer: text DLP partitions into `Matches` (enforced) and `InformationalMatches` (warn-only); URL DLP collects warn matches in `Result.WarnMatches`. Transports check only `Matches`/`Allowed` and require no changes.
- Built-in default patterns reject warn mode at config validation — the immutable safety floor always enforces.
- A `DLPWarnHook` callback on the scanner package enables audit event emission (`dlp_warn`) from within `ScanTextForDLP` and `Scan` automatically, without per-transport wiring. Runtime hook assignment is deferred to a follow-up once `run.go` is available (#384).

## Design notes

**Scanner-output-layer routing** was chosen over threading warn checks through transports because 5 of 8 transport files are reserved by open PRs (#384, #385, #388, #389). The scanner partitions enforced vs. informational; transports see only enforced matches and need zero changes.

**Named return + defer in `scan()`** propagates warn matches through 7 return paths after the DLP check (entropy, SSRF, rate limit, URL length, data budget, context, final pass) without touching each return statement.

**Audit emission scope:** `DLPWarnHook` is called from within the scanner whenever warn matches are produced. The runtime wires it to `audit.Logger.LogDLPWarn` — that wiring is out of scope for this PR because `internal/cli/runtime/run.go` is reserved by #384. The hook mechanism is tested and ready; wiring is a one-liner once #384 lands.

## Test plan

New test functions cover all warn-mode paths:
- 6-state config validation (omitted, null, warn, non-warn rejected, built-in rejected, reload)
- Text DLP routing (warn → InformationalMatches, enforce → Matches, mixed, encoded variants)
- URL DLP routing (warn allows, enforce blocks, mixed, subsequence)
- Fragment buffer cross-request warn propagation
- DLPWarnHook callback for text and URL paths, nil safety
- Audit event structure and emitter integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-pattern DLP action "warn": treats matches as informational, allows traffic, and reports them separately from enforced matches.
  * Warn-mode emits distinct audit/log events for monitoring and provides hook points for integrations.

* **Documentation**
  * New guide for tuning DLP false positives using warn mode.
  * Configuration docs updated; built-in default patterns cannot be set to warn.

* **Tests**
  * Expanded coverage for warn vs enforce behavior, reload semantics, and hook/emission paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->