### PR TITLE
fix: SVG active content bypass — unquoted event handlers and animation injection

### DIFF
--- a/internal/shield/patterns.go
+++ b/internal/shield/patterns.go
@@ -78,8 +78,10 @@ const svgSelfClosingForeignObjectPattern = `(?i)<(?:[\w-]+:)?foreignObject\b[^>]
 // element (onload, onclick, onerror, onmouseover, onfocus, etc.). The
 // pattern captures the leading whitespace so the resulting element tag
 // remains well-formed after removal. Quoted value handling covers both
-// single and double quotes.
-const svgEventHandlerPattern = `(?i)\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*')`
+// single and double quotes. The third alternative catches unquoted values
+// (valid in HTML parsing contexts and some SVG serializers) — the value
+// runs until the next whitespace, >, or />.
+const svgEventHandlerPattern = `(?i)\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>"'/][^\s>"'/]*)`
 
 // svgExternalXlinkHrefPattern matches the namespaced xlink:href attribute
 // when its value is NOT a local fragment reference (#anchor). Split from
@@ -111,6 +113,15 @@ const svgHiddenTextStylePattern = `(?is)<(?:[\w-]+:)?text\b[^>]*style\s*=\s*["']
 // namespace-prefix handling as svgHiddenTextStylePattern.
 const svgHiddenTextAttrPattern = `(?is)<(?:[\w-]+:)?text\b[^>]*(?:\bdisplay\s*=\s*["']none["']|\bvisibility\s*=\s*["']hidden["']|\bopacity\s*=\s*["']0(?:\.0+)?["'])[^>]*>.*?</(?:[\w-]+:)?text>`
 
+// svgAnimationInjectionPattern matches SVG animation elements that target
+// event handler attributes. <set attributeName="onload" to="alert(1)"/> and
+// <animate attributeName="onclick" ...> can inject active content without
+// any direct on* attribute on the target element — the animation engine
+// sets the attribute at runtime. The pattern matches <animate>, <set>,
+// <animateTransform>, and <animateMotion> elements where attributeName
+// points to an event handler (on*). Namespace-prefixed forms included.
+const svgAnimationInjectionPattern = `(?is)<(?:[\w-]+:)?(?:animate|set|animateTransform|animateMotion)\b[^>]*\battributeName\s*=\s*(?:"on[a-z]+"|'on[a-z]+'|on[a-z]+)[^>]*/?>(?:.*?</(?:[\w-]+:)?(?:animate|set|animateTransform|animateMotion)>)?`
+
 // compilePatterns compiles all shield patterns into regexp objects.
 // Called once from NewEngine; panics on invalid regex (programming error).
 func compilePatterns() (
@@ -139,7 +150,8 @@ func compileSVGActivePatterns() (
 	xlinkExternalRe,
 	hrefExternalRe,
 	hiddenTextStyleRe,
-	hiddenTextAttrRe *regexp.Regexp,
+	hiddenTextAttrRe,
+	animationInjectionRe *regexp.Regexp,
 ) {
 	foreignObjectRe = regexp.MustCompile(svgForeignObjectPattern + `|` + svgSelfClosingForeignObjectPattern)
 	eventHandlerRe = regexp.MustCompile(svgEventHandlerPattern)
@@ -147,5 +159,6 @@ func compileSVGActivePatterns() (
 	hrefExternalRe = regexp.MustCompile(svgExternalHrefPattern)
 	hiddenTextStyleRe = regexp.MustCompile(svgHiddenTextStylePattern)
 	hiddenTextAttrRe = regexp.MustCompile(svgHiddenTextAttrPattern)
+	animationInjectionRe = regexp.MustCompile(svgAnimationInjectionPattern)
 	return
 }

--- a/internal/shield/shield.go
+++ b/internal/shield/shield.go
@@ -50,10 +50,11 @@ type Result struct {
 	// SVGXlinkExternalHits counts external xlink:href references rewritten
 	// away from absolute URLs. SVGHiddenTextHits counts hidden <text>
 	// blocks removed (opacity:0 / display:none / visibility:hidden).
-	SVGForeignObjectHits int
-	SVGEventHandlerHits  int
-	SVGXlinkExternalHits int
-	SVGHiddenTextHits    int
+	SVGForeignObjectHits      int
+	SVGEventHandlerHits       int
+	SVGXlinkExternalHits      int
+	SVGHiddenTextHits         int
+	SVGAnimationInjectionHits int
 }
 
 // Engine compiles detection patterns once and reuses them across requests.
@@ -72,12 +73,13 @@ type Engine struct {
 	// so each can be rewritten to its own attribute name (rewriting plain
 	// href to xlink:href in SVG2 without the xmlns:xlink declaration
 	// produces an unbound-prefix XML parse error).
-	svgForeignObjectRe  *regexp.Regexp
-	svgEventHandlerRe   *regexp.Regexp
-	svgXlinkExternalRe  *regexp.Regexp
-	svgHrefExternalRe   *regexp.Regexp
-	svgHiddenTextStyle  *regexp.Regexp
-	svgHiddenTextAttrRe *regexp.Regexp
+	svgForeignObjectRe      *regexp.Regexp
+	svgEventHandlerRe       *regexp.Regexp
+	svgXlinkExternalRe      *regexp.Regexp
+	svgHrefExternalRe       *regexp.Regexp
+	svgHiddenTextStyle      *regexp.Regexp
+	svgHiddenTextAttrRe     *regexp.Regexp
+	svgAnimationInjectionRe *regexp.Regexp
 }
 
 // NewEngine compiles all shield patterns and returns a ready-to-use engine.
@@ -94,20 +96,21 @@ func NewEngine(extraTrackingDomains []string) *Engine {
 		merged := trackRe.String() + `|(?i)` + strings.Join(extra, "|")
 		trackRe = regexp.MustCompile(merged)
 	}
-	svgForeignRe, svgEventRe, svgXlinkRe, svgHrefRe, svgHiddenStyleRe, svgHiddenAttrRe := compileSVGActivePatterns()
+	svgForeignRe, svgEventRe, svgXlinkRe, svgHrefRe, svgHiddenStyleRe, svgHiddenAttrRe, svgAnimRe := compileSVGActivePatterns()
 	return &Engine{
-		extensionRe:         extRe,
-		trackingPixelRe:     trackRe,
-		hiddenTrapRe:        trapRe,
-		commentTrapRe:       commentRe,
-		functionStripRe:     funcRe,
-		svgScriptRe:         regexp.MustCompile(`(?is)<script[^>]*>(.*?)</script>`),
-		svgForeignObjectRe:  svgForeignRe,
-		svgEventHandlerRe:   svgEventRe,
-		svgXlinkExternalRe:  svgXlinkRe,
-		svgHrefExternalRe:   svgHrefRe,
-		svgHiddenTextStyle:  svgHiddenStyleRe,
-		svgHiddenTextAttrRe: svgHiddenAttrRe,
+		extensionRe:             extRe,
+		trackingPixelRe:         trackRe,
+		hiddenTrapRe:            trapRe,
+		commentTrapRe:           commentRe,
+		functionStripRe:         funcRe,
+		svgScriptRe:             regexp.MustCompile(`(?is)<script[^>]*>(.*?)</script>`),
+		svgForeignObjectRe:      svgForeignRe,
+		svgEventHandlerRe:       svgEventRe,
+		svgXlinkExternalRe:      svgXlinkRe,
+		svgHrefExternalRe:       svgHrefRe,
+		svgHiddenTextStyle:      svgHiddenStyleRe,
+		svgHiddenTextAttrRe:     svgHiddenAttrRe,
+		svgAnimationInjectionRe: svgAnimRe,
 	}
 }
 
@@ -267,6 +270,7 @@ func (e *Engine) rewriteSVG(res *Result, cfg *config.BrowserShield) {
 	// caller can see exactly which vector fired.
 	doc, res.SVGForeignObjectHits = countReplace(e.svgForeignObjectRe, doc)
 	doc, res.SVGEventHandlerHits = countReplace(e.svgEventHandlerRe, doc)
+	doc, res.SVGAnimationInjectionHits = countReplace(e.svgAnimationInjectionRe, doc)
 
 	// Rewrite each external ref form back to its own attribute name so the
 	// output stays well-formed XML. Without the split, plain href in an

--- a/internal/shield/svg_active_test.go
+++ b/internal/shield/svg_active_test.go
@@ -310,6 +310,124 @@ func TestRewriteSVG_NamespacePrefixedElements(t *testing.T) {
 	}
 }
 
+func TestRewriteSVG_StripsUnquotedEventHandlers(t *testing.T) {
+	t.Parallel()
+	e := NewEngine(nil)
+	tests := []struct {
+		name string
+		svg  string
+	}{
+		{
+			name: "unquoted_onload",
+			svg:  `<svg><rect onload=alert(1) x="0"/></svg>`,
+		},
+		{
+			name: "unquoted_onerror",
+			svg:  `<svg><image onerror=fetch('https://evil.example') href="#x"/></svg>`,
+		},
+		{
+			name: "unquoted_onmouseover",
+			svg:  `<svg><circle onmouseover=steal() cx="50" cy="50" r="40"/></svg>`,
+		},
+		{
+			name: "mixed_quoted_and_unquoted",
+			svg:  `<svg><rect onclick="ok()" onfocus=bad() x="0"/></svg>`,
+		},
+		{
+			name: "unquoted_self_closing_preserves_slash",
+			svg:  `<svg><rect onload=alert(1)/></svg>`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			res := e.Rewrite(tt.svg, PipelineSVG, svgTestCfg())
+			if res.SVGEventHandlerHits == 0 {
+				t.Fatalf("expected event handler hits, got 0 for input: %s", tt.svg)
+			}
+			for _, needle := range []string{"onload", "onerror", "onmouseover", "onclick", "onfocus"} {
+				if strings.Contains(res.Content, needle+"=") {
+					t.Errorf("unquoted event handler %q= survived strip in: %s", needle, res.Content)
+				}
+			}
+			// Self-closing elements must keep their /> after stripping.
+			if tt.name == "unquoted_self_closing_preserves_slash" {
+				if !strings.Contains(res.Content, "/>") {
+					t.Errorf("self-closing /> lost after strip: %s", res.Content)
+				}
+			}
+		})
+	}
+}
+
+func TestRewriteSVG_StripsAnimationInjection(t *testing.T) {
+	t.Parallel()
+	e := NewEngine(nil)
+	tests := []struct {
+		name string
+		svg  string
+		want int
+	}{
+		{
+			name: "set_onload",
+			svg:  `<svg><set attributeName="onload" to="alert(1)"/></svg>`,
+			want: 1,
+		},
+		{
+			name: "animate_onclick",
+			svg:  `<svg><animate attributeName="onclick" values="steal()" dur="0s" fill="freeze"/></svg>`,
+			want: 1,
+		},
+		{
+			name: "animateTransform_onerror",
+			svg:  `<svg><animateTransform attributeName="onerror" to="evil()"/></svg>`,
+			want: 1,
+		},
+		{
+			name: "animateMotion_safe",
+			svg:  `<svg><animateMotion dur="3s" repeatCount="indefinite"><mpath href="#path1"/></animateMotion></svg>`,
+			want: 0,
+		},
+		{
+			name: "animate_safe_attribute",
+			svg:  `<svg><animate attributeName="opacity" from="0" to="1" dur="1s"/></svg>`,
+			want: 0,
+		},
+		{
+			name: "namespace_prefixed_set",
+			svg:  `<svg><svg:set attributeName="onload" to="alert(1)"/></svg>`,
+			want: 1,
+		},
+		{
+			name: "single_quoted_attributename",
+			svg:  `<svg><set attributeName='onfocus' to='evil()'/></svg>`,
+			want: 1,
+		},
+		{
+			name: "unquoted_attributename",
+			svg:  `<svg><set attributeName=onload to=alert(1)/></svg>`,
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			res := e.Rewrite(tt.svg, PipelineSVG, svgTestCfg())
+			if res.SVGAnimationInjectionHits != tt.want {
+				t.Fatalf("SVGAnimationInjectionHits = %d, want %d for input: %s",
+					res.SVGAnimationInjectionHits, tt.want, tt.svg)
+			}
+			if tt.want > 0 {
+				for _, tag := range []string{"<set", "<animate", "<animateTransform"} {
+					if strings.Contains(res.Content, tag+" attributeName") {
+						t.Errorf("animation injection element survived strip: %s", res.Content)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestRewriteSVG_CleanSVGPassthrough(t *testing.T) {
 	t.Parallel()
 	e := NewEngine(nil)
@@ -319,9 +437,11 @@ func TestRewriteSVG_CleanSVGPassthrough(t *testing.T) {
 </svg>`
 	res := e.Rewrite(svg, PipelineSVG, svgTestCfg())
 	if res.SVGForeignObjectHits != 0 || res.SVGEventHandlerHits != 0 ||
-		res.SVGXlinkExternalHits != 0 || res.SVGHiddenTextHits != 0 {
-		t.Errorf("clean SVG triggered strip: foreign=%d event=%d xlink=%d hidden=%d",
+		res.SVGXlinkExternalHits != 0 || res.SVGHiddenTextHits != 0 ||
+		res.SVGAnimationInjectionHits != 0 {
+		t.Errorf("clean SVG triggered strip: foreign=%d event=%d xlink=%d hidden=%d anim=%d",
 			res.SVGForeignObjectHits, res.SVGEventHandlerHits,
-			res.SVGXlinkExternalHits, res.SVGHiddenTextHits)
+			res.SVGXlinkExternalHits, res.SVGHiddenTextHits,
+			res.SVGAnimationInjectionHits)
 	}
 }


### PR DESCRIPTION
## Summary

- Extends `svgEventHandlerPattern` to match unquoted attribute values
  (`<rect onload=alert(1)>`), which are valid in HTML-parsed SVG contexts.
  Previous regex only matched quoted `"..."` and `'...'` values.
- Adds `svgAnimationInjectionPattern` to strip `<animate>`, `<set>`,
  `<animateTransform>`, and `<animateMotion>` elements that target event
  handler attributes via `attributeName="on*"`. These inject active content
  at runtime without any direct `on*` attribute on the target element.
- Both patterns handle namespace-prefixed element forms and unquoted
  `attributeName` values.
- Self-closing element `/>` is preserved after event handler stripping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced SVG injection protection to detect and remove unquoted event handler attributes in SVG elements.
  * Added detection for SVG animation-based injection attacks that target event handlers.

* **Tests**
  * Added comprehensive test coverage for unquoted event handler stripping in SVG content.
  * Added test cases validating animation injection detection and removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->