### PR TITLE
feat: add posture verify CLI with score model and CI gate

### DIFF
--- a/internal/cli/posture.go
+++ b/internal/cli/posture.go
@@ -4,22 +4,296 @@
 package cli
 
 import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	posturepkg "github.com/luckyPipewrench/pipelock/internal/posture"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// Exit codes for posture verify. Exit 0 = passed, 1 = integrity failure
+// (bad signature, expired, bad schema), 2 = verified but policy failed.
+const (
+	exitVerifyIntegrity   = 1
+	exitVerifyPolicyFail  = 2
+	verifyDefaultMinScore = 85
+	verifyDefaultMaxAge   = "30d"
+	verifyDefaultReceipt  = "7d"
+
+	// errPolicyFailed is the sentinel message for policy-fail exit code.
+	errPolicyFailed = "posture verification failed: policy gates or minimum score not met"
 )
 
 func postureCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "posture",
-		Short: "Generate signed posture evidence",
+		Short: "Generate and verify signed posture evidence",
 	}
 
 	cmd.AddCommand(postureEmitCmd())
+	cmd.AddCommand(postureVerifyCmd())
 	return cmd
+}
+
+func postureVerifyCmd() *cobra.Command {
+	var (
+		proofFile        string
+		keyFile          string
+		policy           string
+		minScore         int
+		maxAgeStr        string
+		maxReceiptAgeStr string
+		configFile       string
+		jsonOutput       bool
+		requireDiscovery bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Verify a signed posture capsule against policy gates",
+		Long: `Verify the signature, score, and policy compliance of a posture
+proof.json capsule.
+
+Exit codes:
+  0  Verified and passed all policy gates
+  1  Integrity/authenticity failure (bad signature, expired, bad schema)
+  2  Verified but policy failed (hard gate violation or score below minimum)`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			capsule, err := loadProofFile(proofFile)
+			if err != nil {
+				return cliutil.ExitCodeError(exitVerifyIntegrity, fmt.Errorf("loading proof: %w", err))
+			}
+
+			pubKey, err := loadPublicKey(keyFile)
+			if err != nil {
+				return cliutil.ExitCodeError(exitVerifyIntegrity, fmt.Errorf("loading public key: %w", err))
+			}
+
+			maxAgeDays, err := parseDays(maxAgeStr)
+			if err != nil {
+				return fmt.Errorf("parsing --max-age: %w", err)
+			}
+
+			maxReceiptAgeDays, err := parseDays(maxReceiptAgeStr)
+			if err != nil {
+				return fmt.Errorf("parsing --max-receipt-age: %w", err)
+			}
+
+			// Check capsule age before full verification.
+			ageDays := int(time.Since(capsule.GeneratedAt).Hours() / 24)
+			if ageDays > maxAgeDays {
+				return cliutil.ExitCodeError(exitVerifyIntegrity, fmt.Errorf("capsule age %dd exceeds max %dd", ageDays, maxAgeDays))
+			}
+
+			opts := posturepkg.VerifyOpts{
+				Policy:           policy,
+				MinScore:         minScore,
+				MaxReceiptAge:    maxReceiptAgeDays,
+				RequireDiscovery: requireDiscovery,
+			}
+
+			// Compute local config hash for comparison if --config is set.
+			if configFile != "" {
+				cfg, cfgErr := cliutil.LoadConfigOrDefault(configFile)
+				if cfgErr != nil {
+					return fmt.Errorf("loading config for hash comparison: %w", cfgErr)
+				}
+				hash, hashErr := posturepkg.HashConfig(cfg)
+				if hashErr != nil {
+					return fmt.Errorf("hashing local config: %w", hashErr)
+				}
+				opts.ConfigHash = hash
+			}
+
+			result, err := posturepkg.VerifyCapsule(capsule, pubKey, opts)
+			if err != nil {
+				return cliutil.ExitCodeError(exitVerifyIntegrity, fmt.Errorf("verification failed: %w", err))
+			}
+
+			if jsonOutput {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				if encErr := enc.Encode(result); encErr != nil {
+					return fmt.Errorf("encoding JSON output: %w", encErr)
+				}
+				if !result.Passed {
+					return cliutil.ExitCodeError(exitVerifyPolicyFail, fmt.Errorf("%s", errPolicyFailed))
+				}
+				return nil
+			}
+
+			printVerifyResult(cmd, result, capsule, maxAgeDays)
+
+			if !result.Passed {
+				return cliutil.ExitCodeError(exitVerifyPolicyFail, fmt.Errorf("%s", errPolicyFailed))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&proofFile, "proof", "", "path to proof.json (required)")
+	cmd.Flags().StringVar(&keyFile, "key", "", "path to Ed25519 public key file (required)")
+	cmd.Flags().StringVar(&policy, "policy", posturepkg.PolicyEnterprise, "policy level: none, enterprise, strict")
+	cmd.Flags().IntVar(&minScore, "min-score", verifyDefaultMinScore, "minimum passing score (0-100)")
+	cmd.Flags().StringVar(&maxAgeStr, "max-age", verifyDefaultMaxAge, "maximum capsule age (e.g. 30d)")
+	cmd.Flags().StringVar(&maxReceiptAgeStr, "max-receipt-age", verifyDefaultReceipt, "maximum receipt staleness (e.g. 7d)")
+	cmd.Flags().StringVarP(&configFile, "config", "c", "", "local config for hash comparison")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output as JSON")
+	cmd.Flags().BoolVar(&requireDiscovery, "require-discovery", false, "fail if 0 servers discovered")
+
+	_ = cmd.MarkFlagRequired("proof")
+	_ = cmd.MarkFlagRequired("key")
+
+	return cmd
+}
+
+// printVerifyResult formats the human-readable verify output.
+func printVerifyResult(cmd *cobra.Command, result *posturepkg.VerifyResult, capsule *posturepkg.Capsule, maxAgeDays int) {
+	w := cmd.OutOrStdout()
+	verdict := "PASS"
+	if !result.Passed {
+		verdict = "FAIL"
+	}
+
+	_, _ = fmt.Fprintf(w, "Posture Verification: %s (score %d/100)\n\n", verdict, result.Score)
+
+	// Transport coverage detail.
+	disc := capsule.Evidence.Discover
+	protectedAny := disc.ProtectedPipelock + disc.ProtectedOther
+	totalScannable := disc.TotalServers + disc.ParseErrors
+	transportDesc := "no servers"
+	if totalScannable > 0 {
+		transportDesc = fmt.Sprintf("%d/%d protected", protectedAny, totalScannable)
+	}
+	_, _ = fmt.Fprintf(w, "  Transport coverage:    %d%% (%s)%s\n",
+		result.FactorScores.TransportRatio.RawPercent, transportDesc,
+		weightedSuffix(result.FactorScores.TransportRatio))
+
+	// Recorder health detail.
+	recDesc := "inactive"
+	if capsule.Evidence.VerifyInstall.FlightRecorderActive {
+		recDesc = fmt.Sprintf("active, %d receipts", capsule.Evidence.VerifyInstall.ReceiptCount)
+		if result.FactorScores.RecorderHealth.RawPercent == 50 {
+			recDesc += ", stale"
+		}
+	}
+	_, _ = fmt.Fprintf(w, "  Flight recorder:       %d%% (%s)%s\n",
+		result.FactorScores.RecorderHealth.RawPercent, recDesc,
+		weightedSuffix(result.FactorScores.RecorderHealth))
+
+	// Simulate detail.
+	sim := capsule.Evidence.Simulate
+	simDesc := fmt.Sprintf("%d/%d scenarios", sim.Passed, sim.Total)
+	_, _ = fmt.Fprintf(w, "  Simulate pass rate:    %d%% (%s)%s\n",
+		result.FactorScores.SimulatePassRate.RawPercent, simDesc,
+		weightedSuffix(result.FactorScores.SimulatePassRate))
+
+	// Cleanliness detail.
+	cleanDesc := fmt.Sprintf("%d unprotected", disc.Unprotected)
+	_, _ = fmt.Fprintf(w, "  Discovery cleanliness: %d%% (%s)%s\n",
+		result.FactorScores.DiscoveryCleanliness.RawPercent, cleanDesc,
+		weightedSuffix(result.FactorScores.DiscoveryCleanliness))
+
+	_, _ = fmt.Fprintf(w, "\n")
+
+	// Policy summary.
+	_, _ = fmt.Fprintf(w, "  Policy: %s (%d hard failures)\n",
+		result.Policy, len(result.HardFailures))
+
+	for _, f := range result.HardFailures {
+		_, _ = fmt.Fprintf(w, "    FAIL: %s -- %s\n", f.Rule, f.Detail)
+	}
+
+	for _, warn := range result.Warnings {
+		_, _ = fmt.Fprintf(w, "    WARN: %s\n", warn)
+	}
+
+	// Generated line.
+	ageDays := int(time.Since(capsule.GeneratedAt).Hours() / 24)
+	_, _ = fmt.Fprintf(w, "\n  Generated: %s (age: %dd, max: %dd)\n",
+		capsule.GeneratedAt.Format(time.RFC3339), ageDays, maxAgeDays)
+
+	// Config hash.
+	if result.ConfigHashMatch != nil {
+		hashStatus := "match"
+		if !*result.ConfigHashMatch {
+			hashStatus = "mismatch"
+		}
+		_, _ = fmt.Fprintf(w, "  Config hash: %s\n", hashStatus)
+	}
+}
+
+func weightedSuffix(d posturepkg.FactorDetail) string {
+	return fmt.Sprintf(" [%d/%d]", d.Weighted, d.Weight)
+}
+
+func loadProofFile(path string) (*posturepkg.Capsule, error) {
+	cleanPath := filepath.Clean(path)
+	data, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", cleanPath, err)
+	}
+
+	var capsule posturepkg.Capsule
+	if err := json.Unmarshal(data, &capsule); err != nil {
+		return nil, fmt.Errorf("parsing proof JSON: %w", err)
+	}
+	return &capsule, nil
+}
+
+// loadPublicKey reads a public key file, trying the pipelock versioned format
+// first, then falling back to raw hex encoding.
+func loadPublicKey(path string) (ed25519.PublicKey, error) {
+	// Try pipelock versioned format first.
+	key, err := signing.LoadPublicKeyFile(path)
+	if err == nil {
+		return key, nil
+	}
+
+	// Fall back to raw hex encoding.
+	cleanPath := filepath.Clean(path)
+	data, readErr := os.ReadFile(cleanPath)
+	if readErr != nil {
+		return nil, fmt.Errorf("reading key file: %w", readErr)
+	}
+
+	raw, hexErr := hex.DecodeString(strings.TrimSpace(string(data)))
+	if hexErr != nil {
+		// Return the original versioned-format error since it's more informative.
+		return nil, fmt.Errorf("loading public key: %w", err)
+	}
+	if len(raw) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("invalid public key length: got %d, want %d", len(raw), ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(raw), nil
+}
+
+// parseDays parses a duration string like "30d" into days.
+func parseDays(s string) (int, error) {
+	s = strings.TrimSpace(s)
+	if !strings.HasSuffix(s, "d") {
+		return 0, fmt.Errorf("expected format Nd (e.g. 30d), got %q", s)
+	}
+	numStr := strings.TrimSuffix(s, "d")
+	n, err := strconv.Atoi(numStr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid day count %q: %w", numStr, err)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("day count must be non-negative, got %d", n)
+	}
+	return n, nil
 }
 
 func postureEmitCmd() *cobra.Command {

--- a/internal/cli/posture.go
+++ b/internal/cli/posture.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -29,6 +30,7 @@ const (
 	verifyDefaultMinScore = 85
 	verifyDefaultMaxAge   = "30d"
 	verifyDefaultReceipt  = "7d"
+	maxProofJSONBytes     = 8 << 20
 
 	// errPolicyFailed is the sentinel message for policy-fail exit code.
 	errPolicyFailed = "posture verification failed: policy gates or minimum score not met"
@@ -90,17 +92,10 @@ Exit codes:
 				return fmt.Errorf("parsing --max-receipt-age: %w", err)
 			}
 
-			// Check capsule age. A stale capsule is a policy failure (exit 2),
-			// not an integrity failure (exit 1) — the capsule may be perfectly
-			// authentic but too old for the operator's freshness policy.
-			ageDays := int(time.Since(capsule.GeneratedAt).Hours() / 24)
-			if ageDays > maxAgeDays {
-				return cliutil.ExitCodeError(exitVerifyPolicyFail, fmt.Errorf("capsule age %dd exceeds max %dd", ageDays, maxAgeDays))
-			}
-
 			opts := posturepkg.VerifyOpts{
 				Policy:           policy,
 				MinScore:         minScore,
+				MaxAgeDays:       maxAgeDays,
 				MaxReceiptAge:    maxReceiptAgeDays,
 				RequireDiscovery: requireDiscovery,
 			}
@@ -242,9 +237,20 @@ func weightedSuffix(d posturepkg.FactorDetail) string {
 
 func loadProofFile(path string) (*posturepkg.Capsule, error) {
 	cleanPath := filepath.Clean(path)
-	data, err := os.ReadFile(cleanPath)
+	f, err := os.Open(cleanPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", cleanPath, err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	data, err := io.ReadAll(io.LimitReader(f, maxProofJSONBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", cleanPath, err)
+	}
+	if len(data) > maxProofJSONBytes {
+		return nil, fmt.Errorf("proof JSON exceeds %d bytes", maxProofJSONBytes)
 	}
 
 	var capsule posturepkg.Capsule

--- a/internal/cli/posture.go
+++ b/internal/cli/posture.go
@@ -25,12 +25,11 @@ import (
 // Exit codes for posture verify. Exit 0 = passed, 1 = integrity failure
 // (bad signature, expired, bad schema), 2 = verified but policy failed.
 const (
-	exitVerifyIntegrity   = 1
-	exitVerifyPolicyFail  = 2
-	verifyDefaultMinScore = 85
-	verifyDefaultMaxAge   = "30d"
-	verifyDefaultReceipt  = "7d"
-	maxProofJSONBytes     = 8 << 20
+	exitVerifyIntegrity  = 1
+	exitVerifyPolicyFail = 2
+	verifyDefaultMaxAge  = "30d"
+	verifyDefaultReceipt = "7d"
+	maxProofJSONBytes    = 8 << 20
 
 	// errPolicyFailed is the sentinel message for policy-fail exit code.
 	errPolicyFailed = "posture verification failed: policy gates or minimum score not met"
@@ -72,16 +71,6 @@ Exit codes:
   2  Verified but policy failed (hard gate violation or score below minimum)`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			capsule, err := loadProofFile(proofFile)
-			if err != nil {
-				return cliutil.ExitCodeError(exitVerifyIntegrity, fmt.Errorf("loading proof: %w", err))
-			}
-
-			pubKey, err := loadPublicKey(keyFile)
-			if err != nil {
-				return cliutil.ExitCodeError(exitVerifyIntegrity, fmt.Errorf("loading public key: %w", err))
-			}
-
 			maxAgeDays, err := parseDays(maxAgeStr)
 			if err != nil {
 				return fmt.Errorf("parsing --max-age: %w", err)
@@ -91,13 +80,18 @@ Exit codes:
 			if err != nil {
 				return fmt.Errorf("parsing --max-receipt-age: %w", err)
 			}
+			if minScore < 0 || minScore > 100 {
+				return fmt.Errorf("--min-score must be between 0 and 100, got %d", minScore)
+			}
 
 			opts := posturepkg.VerifyOpts{
-				Policy:           policy,
-				MinScore:         minScore,
-				MaxAgeDays:       maxAgeDays,
-				MaxReceiptAge:    maxReceiptAgeDays,
-				RequireDiscovery: requireDiscovery,
+				Policy:               policy,
+				MinScore:             minScore,
+				SkipMinScoreGate:     minScore == 0,
+				MaxAgeDays:           maxAgeDays,
+				MaxReceiptAge:        maxReceiptAgeDays,
+				SkipReceiptFreshness: maxReceiptAgeDays == 0,
+				RequireDiscovery:     requireDiscovery,
 			}
 
 			// Compute local config hash for comparison if --config is set.
@@ -113,15 +107,23 @@ Exit codes:
 				opts.ConfigHash = hash
 			}
 
+			capsule, err := loadProofFile(proofFile)
+			if err != nil {
+				return exitVerifyIntegrityError(cmd, jsonOutput, policy, nil, fmt.Errorf("loading proof: %w", err))
+			}
+
+			pubKey, err := loadPublicKey(keyFile)
+			if err != nil {
+				return exitVerifyIntegrityError(cmd, jsonOutput, policy, capsule, fmt.Errorf("loading public key: %w", err))
+			}
+
 			result, err := posturepkg.VerifyCapsule(capsule, pubKey, opts)
 			if err != nil {
-				return cliutil.ExitCodeError(exitVerifyIntegrity, fmt.Errorf("verification failed: %w", err))
+				return exitVerifyIntegrityError(cmd, jsonOutput, policy, capsule, fmt.Errorf("verification failed: %w", err))
 			}
 
 			if jsonOutput {
-				enc := json.NewEncoder(cmd.OutOrStdout())
-				enc.SetIndent("", "  ")
-				if encErr := enc.Encode(result); encErr != nil {
+				if encErr := writeVerifyJSON(cmd, result); encErr != nil {
 					return fmt.Errorf("encoding JSON output: %w", encErr)
 				}
 				if !result.Passed {
@@ -142,7 +144,7 @@ Exit codes:
 	cmd.Flags().StringVar(&proofFile, "proof", "", "path to proof.json (required)")
 	cmd.Flags().StringVar(&keyFile, "key", "", "path to Ed25519 public key file (required)")
 	cmd.Flags().StringVar(&policy, "policy", posturepkg.PolicyEnterprise, "policy level: none, enterprise, strict")
-	cmd.Flags().IntVar(&minScore, "min-score", verifyDefaultMinScore, "minimum passing score (0-100)")
+	cmd.Flags().IntVar(&minScore, "min-score", posturepkg.DefaultMinScore, "minimum passing score (0-100)")
 	cmd.Flags().StringVar(&maxAgeStr, "max-age", verifyDefaultMaxAge, "maximum capsule age (e.g. 30d)")
 	cmd.Flags().StringVar(&maxReceiptAgeStr, "max-receipt-age", verifyDefaultReceipt, "maximum receipt staleness (e.g. 7d)")
 	cmd.Flags().StringVarP(&configFile, "config", "c", "", "local config for hash comparison")
@@ -217,9 +219,12 @@ func printVerifyResult(cmd *cobra.Command, result *posturepkg.VerifyResult, caps
 	}
 
 	// Generated line.
-	ageDays := int(time.Since(capsule.GeneratedAt).Hours() / 24)
-	_, _ = fmt.Fprintf(w, "\n  Generated: %s (age: %dd, max: %dd)\n",
-		capsule.GeneratedAt.Format(time.RFC3339), ageDays, maxAgeDays)
+	maxAgeLabel := "disabled"
+	if maxAgeDays > 0 {
+		maxAgeLabel = fmt.Sprintf("%dd", maxAgeDays)
+	}
+	_, _ = fmt.Fprintf(w, "\n  Generated: %s (age: %s, max: %s)\n",
+		capsule.GeneratedAt.Format(time.RFC3339), formatVerifyAge(capsule.GeneratedAt), maxAgeLabel)
 
 	// Config hash.
 	if result.ConfigHashMatch != nil {
@@ -233,6 +238,49 @@ func printVerifyResult(cmd *cobra.Command, result *posturepkg.VerifyResult, caps
 
 func weightedSuffix(d posturepkg.FactorDetail) string {
 	return fmt.Sprintf(" [%d/%d]", d.Weighted, d.Weight)
+}
+
+func writeVerifyJSON(cmd *cobra.Command, result *posturepkg.VerifyResult) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+func exitVerifyIntegrityError(
+	cmd *cobra.Command,
+	jsonOutput bool,
+	policy string,
+	capsule *posturepkg.Capsule,
+	err error,
+) error {
+	if jsonOutput {
+		result := &posturepkg.VerifyResult{
+			Verified:       false,
+			Passed:         false,
+			Error:          err.Error(),
+			Policy:         policy,
+			PolicyVersion:  posturepkg.SchemaVersion,
+			ScoringVersion: posturepkg.ScoringVersion,
+		}
+		if capsule != nil {
+			result.GeneratedAt = capsule.GeneratedAt
+			result.ExpiresAt = capsule.ExpiresAt
+			result.LastReceiptAt = capsule.Evidence.FlightRecorder.LastReceiptAt
+		}
+		if jsonErr := writeVerifyJSON(cmd, result); jsonErr != nil {
+			return fmt.Errorf("encoding JSON output: %w", jsonErr)
+		}
+	}
+	return cliutil.ExitCodeError(exitVerifyIntegrity, err)
+}
+
+func formatVerifyAge(ts time.Time) string {
+	elapsed := time.Since(ts)
+	if elapsed <= 0 {
+		return "0d"
+	}
+	days := int((elapsed + (24 * time.Hour) - time.Nanosecond) / (24 * time.Hour))
+	return fmt.Sprintf("%dd", days)
 }
 
 func loadProofFile(path string) (*posturepkg.Capsule, error) {

--- a/internal/cli/posture.go
+++ b/internal/cli/posture.go
@@ -90,10 +90,12 @@ Exit codes:
 				return fmt.Errorf("parsing --max-receipt-age: %w", err)
 			}
 
-			// Check capsule age before full verification.
+			// Check capsule age. A stale capsule is a policy failure (exit 2),
+			// not an integrity failure (exit 1) — the capsule may be perfectly
+			// authentic but too old for the operator's freshness policy.
 			ageDays := int(time.Since(capsule.GeneratedAt).Hours() / 24)
 			if ageDays > maxAgeDays {
-				return cliutil.ExitCodeError(exitVerifyIntegrity, fmt.Errorf("capsule age %dd exceeds max %dd", ageDays, maxAgeDays))
+				return cliutil.ExitCodeError(exitVerifyPolicyFail, fmt.Errorf("capsule age %dd exceeds max %dd", ageDays, maxAgeDays))
 			}
 
 			opts := posturepkg.VerifyOpts{

--- a/internal/cli/posture_verify_test.go
+++ b/internal/cli/posture_verify_test.go
@@ -575,7 +575,8 @@ func TestPostureVerifyOldCapsule(t *testing.T) {
 	if err == nil {
 		t.Fatal("cmd.Execute() = nil, want error for capsule exceeding max age")
 	}
-	assertExitCode(t, err, exitVerifyIntegrity)
+	// Capsule age is a freshness policy failure, not an integrity failure.
+	assertExitCode(t, err, exitVerifyPolicyFail)
 	if !strings.Contains(err.Error(), "capsule age") {
 		t.Errorf("error = %v, want capsule age exceeded message", err)
 	}

--- a/internal/cli/posture_verify_test.go
+++ b/internal/cli/posture_verify_test.go
@@ -240,6 +240,46 @@ func TestPostureVerifyJSONOutput(t *testing.T) {
 	}
 }
 
+func TestPostureVerifyJSONBadSignature(t *testing.T) {
+	fix := newTestVerifyFixture(t, perfectEvidence())
+
+	tamperedCapsule := *fix.Capsule
+	tamperedCapsule.ConfigHash = "tampered"
+	proofDir := filepath.Join(t.TempDir(), "tampered-json")
+	proofPath, err := posturepkg.WriteProofJSON(proofDir, &tamperedCapsule)
+	if err != nil {
+		t.Fatalf("WriteProofJSON(): %v", err)
+	}
+
+	var stdout bytes.Buffer
+	cmd := rootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", proofPath,
+		"--key", fix.PubKeyPath,
+		"--json",
+	})
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error")
+	}
+	assertExitCode(t, err, exitVerifyIntegrity)
+
+	var result posturepkg.VerifyResult
+	if jsonErr := json.Unmarshal(stdout.Bytes(), &result); jsonErr != nil {
+		t.Fatalf("json.Unmarshal(): %v (output: %s)", jsonErr, stdout.String())
+	}
+	if result.Verified {
+		t.Error("result.Verified = true, want false")
+	}
+	if !strings.Contains(result.Error, "verification failed") {
+		t.Errorf("result.Error = %q, want verification failure", result.Error)
+	}
+}
+
 func TestPostureVerifyBadSignature(t *testing.T) {
 	fix := newTestVerifyFixture(t, perfectEvidence())
 
@@ -473,6 +513,42 @@ func TestPostureVerifyMissingProofFile(t *testing.T) {
 	assertExitCode(t, err, exitVerifyIntegrity)
 }
 
+func TestPostureVerifyJSONMissingProofFile(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+	pubKeyPath := writeVersionedPubKey(t, pub)
+
+	var stdout bytes.Buffer
+	cmd := rootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", "/nonexistent/proof.json",
+		"--key", pubKeyPath,
+		"--json",
+	})
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for missing proof")
+	}
+	assertExitCode(t, err, exitVerifyIntegrity)
+
+	var result posturepkg.VerifyResult
+	if jsonErr := json.Unmarshal(stdout.Bytes(), &result); jsonErr != nil {
+		t.Fatalf("json.Unmarshal(): %v (output: %s)", jsonErr, stdout.String())
+	}
+	if result.Verified {
+		t.Error("result.Verified = true, want false")
+	}
+	if !strings.Contains(result.Error, "loading proof") {
+		t.Errorf("result.Error = %q, want loading proof failure", result.Error)
+	}
+}
+
 func TestPostureVerifyBadKeyFile(t *testing.T) {
 	fix := newTestVerifyFixture(t, perfectEvidence())
 
@@ -495,6 +571,43 @@ func TestPostureVerifyBadKeyFile(t *testing.T) {
 		t.Fatal("cmd.Execute() = nil, want error for bad key")
 	}
 	assertExitCode(t, err, exitVerifyIntegrity)
+}
+
+func TestPostureVerifyJSONBadKeyFile(t *testing.T) {
+	fix := newTestVerifyFixture(t, perfectEvidence())
+
+	badKeyPath := filepath.Join(t.TempDir(), "bad-json.key")
+	if err := os.WriteFile(badKeyPath, []byte("not-a-key-at-all"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+
+	var stdout bytes.Buffer
+	cmd := rootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", badKeyPath,
+		"--json",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for bad key")
+	}
+	assertExitCode(t, err, exitVerifyIntegrity)
+
+	var result posturepkg.VerifyResult
+	if jsonErr := json.Unmarshal(stdout.Bytes(), &result); jsonErr != nil {
+		t.Fatalf("json.Unmarshal(): %v (output: %s)", jsonErr, stdout.String())
+	}
+	if result.Verified {
+		t.Error("result.Verified = true, want false")
+	}
+	if !strings.Contains(result.Error, "loading public key") {
+		t.Errorf("result.Error = %q, want loading public key failure", result.Error)
+	}
 }
 
 func TestPostureVerifyBadMaxAge(t *testing.T) {
@@ -538,6 +651,28 @@ func TestPostureVerifyBadMaxReceiptAge(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "parsing --max-receipt-age") {
 		t.Errorf("error = %v, want max-receipt-age parse error", err)
+	}
+}
+
+func TestPostureVerifyBadMinScore(t *testing.T) {
+	fix := newTestVerifyFixture(t, perfectEvidence())
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--min-score", "101",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for bad min-score")
+	}
+	if !strings.Contains(err.Error(), "--min-score must be between 0 and 100") {
+		t.Errorf("error = %v, want min-score validation error", err)
 	}
 }
 
@@ -688,6 +823,28 @@ func TestPostureVerifyPolicyTypo(t *testing.T) {
 		t.Fatal("cmd.Execute() = nil, want error for invalid policy")
 	}
 	assertExitCode(t, err, exitVerifyPolicyFail)
+}
+
+func TestPostureVerifyMaxAgeDisabledLabel(t *testing.T) {
+	fix := newTestVerifyFixture(t, perfectEvidence())
+
+	var stdout bytes.Buffer
+	cmd := rootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--max-age", "0d",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute(): %v", err)
+	}
+	if !strings.Contains(stdout.String(), "max: disabled") {
+		t.Errorf("output missing disabled max-age label, got: %s", stdout.String())
+	}
 }
 
 func TestPostureVerifyOversizeProofFile(t *testing.T) {

--- a/internal/cli/posture_verify_test.go
+++ b/internal/cli/posture_verify_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -290,8 +291,9 @@ func TestPostureVerifyExpiredCapsule(t *testing.T) {
 
 	pubKeyPath := writeVersionedPubKey(t, pub)
 
+	var stdout bytes.Buffer
 	cmd := rootCmd()
-	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetOut(&stdout)
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{
 		"posture", "verify",
@@ -554,15 +556,14 @@ func TestPostureVerifyOldCapsule(t *testing.T) {
 		t.Fatalf("Emit(): %v", err)
 	}
 
-	// Write proof, then patch GeneratedAt to be 35 days ago. The CLI checks
-	// age before calling Verify(), so the signature mismatch doesn't matter.
 	proofDir := filepath.Join(t.TempDir(), "old")
-	oldProof := writeOldProof(t, proofDir, capsule)
+	oldProof := writeOldProof(t, proofDir, capsule, priv)
 
 	pubKeyPath := writeVersionedPubKey(t, pub)
 
+	var stdout bytes.Buffer
 	cmd := rootCmd()
-	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetOut(&stdout)
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{
 		"posture", "verify",
@@ -575,10 +576,9 @@ func TestPostureVerifyOldCapsule(t *testing.T) {
 	if err == nil {
 		t.Fatal("cmd.Execute() = nil, want error for capsule exceeding max age")
 	}
-	// Capsule age is a freshness policy failure, not an integrity failure.
 	assertExitCode(t, err, exitVerifyPolicyFail)
-	if !strings.Contains(err.Error(), "capsule age") {
-		t.Errorf("error = %v, want capsule age exceeded message", err)
+	if !strings.Contains(stdout.String(), "capsule_too_old") {
+		t.Errorf("output missing capsule_too_old failure, got: %s", stdout.String())
 	}
 }
 
@@ -623,6 +623,100 @@ func TestPostureVerifyRequireDiscovery(t *testing.T) {
 		t.Fatal("cmd.Execute() = nil, want error for require-discovery")
 	}
 	assertExitCode(t, err, exitVerifyPolicyFail)
+}
+
+func TestPostureVerifyRequireDiscoveryIgnoresParseErrors(t *testing.T) {
+	recent := time.Now().Add(-1 * time.Hour)
+	parseOnly := posturepkg.EvidenceBundle{
+		Discover: posturepkg.DiscoverEvidence{
+			ParseErrors: 2,
+		},
+		VerifyInstall: posturepkg.VerifyInstallEvidence{
+			FlightRecorderActive: true,
+			ReceiptCount:         10,
+		},
+		Simulate: audit.SimulateResult{
+			Total:      1,
+			Passed:     1,
+			Percentage: 100,
+			Scenarios: []audit.ScenarioResult{
+				{Category: "DLP", Detected: true},
+			},
+		},
+		FlightRecorder: posturepkg.FlightRecorderCounts{
+			ReceiptCount:  10,
+			LastReceiptAt: &recent,
+		},
+	}
+
+	fix := newTestVerifyFixture(t, parseOnly)
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--policy", testVerifyPolicyNone,
+		"--min-score", "0",
+		"--require-discovery",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for parse-errors-only discovery")
+	}
+	assertExitCode(t, err, exitVerifyPolicyFail)
+}
+
+func TestPostureVerifyPolicyTypo(t *testing.T) {
+	fix := newTestVerifyFixture(t, perfectEvidence())
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--policy", "bad-policy",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for invalid policy")
+	}
+	assertExitCode(t, err, exitVerifyPolicyFail)
+}
+
+func TestPostureVerifyOversizeProofFile(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+	pubKeyPath := writeVersionedPubKey(t, pub)
+
+	proofPath := filepath.Join(t.TempDir(), "proof.json")
+	data := bytes.Repeat([]byte("a"), maxProofJSONBytes+1)
+	if err := os.WriteFile(proofPath, data, 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", proofPath,
+		"--key", pubKeyPath,
+	})
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for oversize proof")
+	}
+	assertExitCode(t, err, exitVerifyIntegrity)
 }
 
 func TestParseDays(t *testing.T) {
@@ -779,30 +873,19 @@ func writeExpiredProof(t *testing.T, dir string, capsule *posturepkg.Capsule) st
 	return path
 }
 
-// writeOldProof writes a proof.json with GeneratedAt set to 35 days ago.
-func writeOldProof(t *testing.T, dir string, capsule *posturepkg.Capsule) string {
+// writeOldProof writes a proof.json with GeneratedAt set to 35 days ago and a
+// valid signature so the CLI can classify it as a freshness policy failure.
+func writeOldProof(t *testing.T, dir string, capsule *posturepkg.Capsule, priv ed25519.PrivateKey) string {
 	t.Helper()
 
-	data, err := json.Marshal(capsule)
-	if err != nil {
-		t.Fatalf("json.Marshal(): %v", err)
-	}
+	oldCapsule := *capsule
+	oldCapsule.GeneratedAt = time.Now().Add(-35 * 24 * time.Hour)
+	oldCapsule.ExpiresAt = time.Now().Add(55 * 24 * time.Hour)
+	oldCapsule.Signature = resignCapsuleCLI(t, &oldCapsule, priv)
 
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("json.Unmarshal(): %v", err)
-	}
-
-	oldTime := time.Now().Add(-35 * 24 * time.Hour)
-	oldJSON, err := json.Marshal(oldTime)
+	patched, err := json.Marshal(&oldCapsule)
 	if err != nil {
-		t.Fatalf("json.Marshal(oldTime): %v", err)
-	}
-	raw["generated_at"] = oldJSON
-
-	patched, err := json.Marshal(raw)
-	if err != nil {
-		t.Fatalf("json.Marshal(patched): %v", err)
+		t.Fatalf("json.Marshal(oldCapsule): %v", err)
 	}
 
 	if err := os.MkdirAll(dir, 0o750); err != nil {
@@ -813,6 +896,123 @@ func writeOldProof(t *testing.T, dir string, capsule *posturepkg.Capsule) string
 		t.Fatalf("os.WriteFile(): %v", err)
 	}
 	return path
+}
+
+func resignCapsuleCLI(t *testing.T, capsule *posturepkg.Capsule, priv ed25519.PrivateKey) string {
+	t.Helper()
+
+	payload, err := signableCapsuleJSON(t, capsule)
+	if err != nil {
+		t.Fatalf("signableCapsuleJSON(): %v", err)
+	}
+	return hex.EncodeToString(ed25519.Sign(priv, payload))
+}
+
+func signableCapsuleJSON(t *testing.T, capsule *posturepkg.Capsule) ([]byte, error) {
+	t.Helper()
+
+	type signableCapsule struct {
+		SchemaVersion string                    `json:"schema_version"`
+		GeneratedAt   time.Time                 `json:"generated_at"`
+		ExpiresAt     time.Time                 `json:"expires_at"`
+		ToolVersion   string                    `json:"tool_version"`
+		ConfigHash    string                    `json:"config_hash"`
+		Evidence      posturepkg.EvidenceBundle `json:"evidence"`
+	}
+
+	raw, err := json.Marshal(signableCapsule{
+		SchemaVersion: capsule.SchemaVersion,
+		GeneratedAt:   capsule.GeneratedAt,
+		ExpiresAt:     capsule.ExpiresAt,
+		ToolVersion:   capsule.ToolVersion,
+		ConfigHash:    capsule.ConfigHash,
+		Evidence:      capsule.Evidence,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+
+	var parsed any
+	if err := dec.Decode(&parsed); err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := appendCanonicalJSON(&buf, parsed); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func appendCanonicalJSON(buf *bytes.Buffer, v any) error {
+	switch value := v.(type) {
+	case nil:
+		buf.WriteString("null")
+	case bool:
+		if value {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+	case string:
+		data, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		buf.Write(data)
+	case json.Number:
+		buf.WriteString(value.String())
+	case float64:
+		data, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		buf.Write(data)
+	case []any:
+		buf.WriteByte('[')
+		for i, item := range value {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := appendCanonicalJSON(buf, item); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte(']')
+	case map[string]any:
+		keys := make([]string, 0, len(value))
+		for key := range value {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		buf.WriteByte('{')
+		for i, key := range keys {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			keyJSON, err := json.Marshal(key)
+			if err != nil {
+				return err
+			}
+			buf.Write(keyJSON)
+			buf.WriteByte(':')
+			if err := appendCanonicalJSON(buf, value[key]); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte('}')
+	default:
+		data, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		buf.Write(data)
+	}
+	return nil
 }
 
 func assertExitCode(t *testing.T, err error, wantCode int) {

--- a/internal/cli/posture_verify_test.go
+++ b/internal/cli/posture_verify_test.go
@@ -1,0 +1,829 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/cli/audit"
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	posturepkg "github.com/luckyPipewrench/pipelock/internal/posture"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const (
+	testVerifyPolicyEnterprise = posturepkg.PolicyEnterprise
+	testVerifyPolicyStrict     = posturepkg.PolicyStrict
+	testVerifyPolicyNone       = posturepkg.PolicyNone
+)
+
+// testVerifyFixture creates a signed proof.json and key files for testing.
+type testVerifyFixture struct {
+	ProofPath     string
+	PubKeyPath    string
+	HexPubKeyPath string
+	ConfigPath    string
+	Capsule       *posturepkg.Capsule
+	PublicKey     ed25519.PublicKey
+	PrivateKey    ed25519.PrivateKey
+}
+
+func newTestVerifyFixture(t *testing.T, evidence posturepkg.EvidenceBundle) testVerifyFixture {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	// Write config to YAML first, then load it back. This ensures the config
+	// hash is consistent between emit and verify (YAML round-trip stable).
+	cfgData, err := yaml.Marshal(config.Defaults())
+	if err != nil {
+		t.Fatalf("yaml.Marshal(): %v", err)
+	}
+	configPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(configPath, cfgData, 0o600); err != nil {
+		t.Fatalf("os.WriteFile(config): %v", err)
+	}
+
+	cfg, err := cliutil.LoadConfigOrDefault(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfigOrDefault(): %v", err)
+	}
+
+	capsule, err := posturepkg.Emit(cfg, posturepkg.Options{
+		SigningKey:     priv,
+		EvidenceBundle: &evidence,
+	})
+	if err != nil {
+		t.Fatalf("posture.Emit(): %v", err)
+	}
+
+	// Write proof.json.
+	proofDir := filepath.Join(t.TempDir(), "proof")
+	proofPath, err := posturepkg.WriteProofJSON(proofDir, capsule)
+	if err != nil {
+		t.Fatalf("posture.WriteProofJSON(): %v", err)
+	}
+
+	// Write versioned public key.
+	pubKeyPath := filepath.Join(t.TempDir(), "pub.key")
+	if err := os.WriteFile(pubKeyPath, []byte(signing.EncodePublicKey(pub)), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(pub.key): %v", err)
+	}
+
+	// Write hex-encoded public key.
+	hexPubKeyPath := filepath.Join(t.TempDir(), "pub.hex")
+	if err := os.WriteFile(hexPubKeyPath, []byte(hex.EncodeToString(pub)), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(pub.hex): %v", err)
+	}
+
+	return testVerifyFixture{
+		ProofPath:     proofPath,
+		PubKeyPath:    pubKeyPath,
+		HexPubKeyPath: hexPubKeyPath,
+		ConfigPath:    configPath,
+		Capsule:       capsule,
+		PublicKey:     pub,
+		PrivateKey:    priv,
+	}
+}
+
+func perfectEvidence() posturepkg.EvidenceBundle {
+	recent := time.Now().Add(-1 * time.Hour)
+	return posturepkg.EvidenceBundle{
+		Discover: posturepkg.DiscoverEvidence{
+			TotalServers:      5,
+			ProtectedPipelock: 5,
+		},
+		VerifyInstall: posturepkg.VerifyInstallEvidence{
+			FlightRecorderActive: true,
+			ReceiptCount:         100,
+		},
+		Simulate: audit.SimulateResult{
+			Total:      10,
+			Passed:     10,
+			Percentage: 100,
+			Scenarios: []audit.ScenarioResult{
+				{Category: "DLP", Detected: true},
+				{Category: "Injection", Detected: true},
+			},
+		},
+		FlightRecorder: posturepkg.FlightRecorderCounts{
+			ReceiptCount:  100,
+			LastReceiptAt: &recent,
+		},
+	}
+}
+
+func failEvidence() posturepkg.EvidenceBundle {
+	return posturepkg.EvidenceBundle{
+		Discover: posturepkg.DiscoverEvidence{
+			TotalServers: 5,
+			Unprotected:  5,
+		},
+		VerifyInstall: posturepkg.VerifyInstallEvidence{
+			FlightRecorderActive: false,
+		},
+		Simulate: audit.SimulateResult{
+			Total:      10,
+			Passed:     0,
+			Failed:     10,
+			Percentage: 0,
+			Scenarios: []audit.ScenarioResult{
+				{Category: "DLP", Detected: false},
+			},
+		},
+		FlightRecorder: posturepkg.FlightRecorderCounts{},
+	}
+}
+
+func TestPostureVerifyPass(t *testing.T) {
+	fix := newTestVerifyFixture(t, perfectEvidence())
+
+	var stdout bytes.Buffer
+	cmd := rootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--policy", testVerifyPolicyEnterprise,
+		"--min-score", "85",
+		"--max-age", "30d",
+		"--max-receipt-age", "7d",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute(): %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "PASS") {
+		t.Errorf("output missing PASS, got: %s", output)
+	}
+	if !strings.Contains(output, "score 100/100") {
+		t.Errorf("output missing score, got: %s", output)
+	}
+}
+
+func TestPostureVerifyPassHexKey(t *testing.T) {
+	fix := newTestVerifyFixture(t, perfectEvidence())
+
+	var stdout bytes.Buffer
+	cmd := rootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.HexPubKeyPath,
+		"--policy", testVerifyPolicyNone,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute(): %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "PASS") {
+		t.Errorf("output missing PASS with hex key, got: %s", stdout.String())
+	}
+}
+
+func TestPostureVerifyJSONOutput(t *testing.T) {
+	fix := newTestVerifyFixture(t, perfectEvidence())
+
+	var stdout bytes.Buffer
+	cmd := rootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--policy", testVerifyPolicyNone,
+		"--json",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute(): %v", err)
+	}
+
+	var result posturepkg.VerifyResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("json.Unmarshal(): %v (output: %s)", err, stdout.String())
+	}
+	if !result.Verified {
+		t.Error("result.Verified = false, want true")
+	}
+	if !result.Passed {
+		t.Error("result.Passed = false, want true")
+	}
+	if result.Score != 100 {
+		t.Errorf("result.Score = %d, want 100", result.Score)
+	}
+}
+
+func TestPostureVerifyBadSignature(t *testing.T) {
+	fix := newTestVerifyFixture(t, perfectEvidence())
+
+	// Write a proof with a tampered config hash.
+	tamperedCapsule := *fix.Capsule
+	tamperedCapsule.ConfigHash = "tampered"
+	proofDir := filepath.Join(t.TempDir(), "tampered")
+	proofPath, err := posturepkg.WriteProofJSON(proofDir, &tamperedCapsule)
+	if err != nil {
+		t.Fatalf("WriteProofJSON(): %v", err)
+	}
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", proofPath,
+		"--key", fix.PubKeyPath,
+	})
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error")
+	}
+	assertExitCode(t, err, exitVerifyIntegrity)
+}
+
+func TestPostureVerifyExpiredCapsule(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	capsule, err := posturepkg.Emit(config.Defaults(), posturepkg.Options{
+		SigningKey:     priv,
+		ExpirationDays: 1,
+		EvidenceBundle: &posturepkg.EvidenceBundle{},
+	})
+	if err != nil {
+		t.Fatalf("Emit(): %v", err)
+	}
+
+	// Write the valid capsule as JSON, then patch ExpiresAt to be in the past.
+	// Verify() checks expiry before signature, so the tampered time triggers
+	// an integrity failure without needing a valid signature over it.
+	proofDir := filepath.Join(t.TempDir(), "expired")
+	expiredProof := writeExpiredProof(t, proofDir, capsule)
+
+	pubKeyPath := writeVersionedPubKey(t, pub)
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", expiredProof,
+		"--key", pubKeyPath,
+		"--max-age", "30d",
+	})
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for expired capsule")
+	}
+	assertExitCode(t, err, exitVerifyIntegrity)
+}
+
+func TestPostureVerifyLowScore(t *testing.T) {
+	fix := newTestVerifyFixture(t, failEvidence())
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--policy", testVerifyPolicyNone,
+		"--min-score", "85",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for low score")
+	}
+	assertExitCode(t, err, exitVerifyPolicyFail)
+}
+
+func TestPostureVerifyEnterpriseFailure(t *testing.T) {
+	fix := newTestVerifyFixture(t, failEvidence())
+
+	var stdout bytes.Buffer
+	cmd := rootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--policy", testVerifyPolicyEnterprise,
+		"--min-score", "0",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for enterprise policy failure")
+	}
+	assertExitCode(t, err, exitVerifyPolicyFail)
+
+	output := stdout.String()
+	if !strings.Contains(output, "FAIL") {
+		t.Errorf("output missing FAIL, got: %s", output)
+	}
+	if !strings.Contains(output, "unprotected_servers") {
+		t.Errorf("output missing unprotected_servers failure, got: %s", output)
+	}
+}
+
+func TestPostureVerifyConfigHashMismatch(t *testing.T) {
+	fix := newTestVerifyFixture(t, perfectEvidence())
+
+	// Write a different config that will produce a different hash.
+	differentCfg := config.Defaults()
+	differentCfg.Mode = config.ModeStrict
+	cfgData, err := yaml.Marshal(differentCfg)
+	if err != nil {
+		t.Fatalf("yaml.Marshal(): %v", err)
+	}
+	differentConfigPath := filepath.Join(t.TempDir(), "different.yaml")
+	if err := os.WriteFile(differentConfigPath, cfgData, 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--policy", testVerifyPolicyEnterprise,
+		"--min-score", "0",
+		"--config", differentConfigPath,
+	})
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for config hash mismatch")
+	}
+	assertExitCode(t, err, exitVerifyPolicyFail)
+}
+
+func TestPostureVerifyConfigHashMatch(t *testing.T) {
+	fix := newTestVerifyFixture(t, perfectEvidence())
+
+	var stdout bytes.Buffer
+	cmd := rootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--policy", testVerifyPolicyEnterprise,
+		"--config", fix.ConfigPath,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute(): %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Config hash: match") {
+		t.Errorf("output missing config hash match, got: %s", output)
+	}
+}
+
+func TestPostureVerifyJSONPolicyFail(t *testing.T) {
+	fix := newTestVerifyFixture(t, failEvidence())
+
+	var stdout bytes.Buffer
+	cmd := rootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--policy", testVerifyPolicyEnterprise,
+		"--min-score", "0",
+		"--json",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for policy failure")
+	}
+	assertExitCode(t, err, exitVerifyPolicyFail)
+
+	var result posturepkg.VerifyResult
+	if jsonErr := json.Unmarshal(stdout.Bytes(), &result); jsonErr != nil {
+		t.Fatalf("json.Unmarshal(): %v (output: %s)", jsonErr, stdout.String())
+	}
+	if result.Passed {
+		t.Error("result.Passed = true, want false")
+	}
+}
+
+func TestPostureVerifyMissingProofFile(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+	pubKeyPath := writeVersionedPubKey(t, pub)
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", "/nonexistent/proof.json",
+		"--key", pubKeyPath,
+	})
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for missing proof")
+	}
+	assertExitCode(t, err, exitVerifyIntegrity)
+}
+
+func TestPostureVerifyBadKeyFile(t *testing.T) {
+	fix := newTestVerifyFixture(t, perfectEvidence())
+
+	badKeyPath := filepath.Join(t.TempDir(), "bad.key")
+	if err := os.WriteFile(badKeyPath, []byte("not-a-key-at-all"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", badKeyPath,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for bad key")
+	}
+	assertExitCode(t, err, exitVerifyIntegrity)
+}
+
+func TestPostureVerifyBadMaxAge(t *testing.T) {
+	fix := newTestVerifyFixture(t, perfectEvidence())
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--max-age", "bad",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for bad max-age")
+	}
+	if !strings.Contains(err.Error(), "parsing --max-age") {
+		t.Errorf("error = %v, want max-age parse error", err)
+	}
+}
+
+func TestPostureVerifyBadMaxReceiptAge(t *testing.T) {
+	fix := newTestVerifyFixture(t, perfectEvidence())
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--max-receipt-age", "xyz",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for bad max-receipt-age")
+	}
+	if !strings.Contains(err.Error(), "parsing --max-receipt-age") {
+		t.Errorf("error = %v, want max-receipt-age parse error", err)
+	}
+}
+
+func TestPostureVerifyOldCapsule(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	capsule, err := posturepkg.Emit(config.Defaults(), posturepkg.Options{
+		SigningKey:     priv,
+		ExpirationDays: 90,
+		EvidenceBundle: &posturepkg.EvidenceBundle{},
+	})
+	if err != nil {
+		t.Fatalf("Emit(): %v", err)
+	}
+
+	// Write proof, then patch GeneratedAt to be 35 days ago. The CLI checks
+	// age before calling Verify(), so the signature mismatch doesn't matter.
+	proofDir := filepath.Join(t.TempDir(), "old")
+	oldProof := writeOldProof(t, proofDir, capsule)
+
+	pubKeyPath := writeVersionedPubKey(t, pub)
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", oldProof,
+		"--key", pubKeyPath,
+		"--max-age", "30d",
+	})
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for capsule exceeding max age")
+	}
+	assertExitCode(t, err, exitVerifyIntegrity)
+	if !strings.Contains(err.Error(), "capsule age") {
+		t.Errorf("error = %v, want capsule age exceeded message", err)
+	}
+}
+
+func TestPostureVerifyRequireDiscovery(t *testing.T) {
+	recent := time.Now().Add(-1 * time.Hour)
+	emptyDiscover := posturepkg.EvidenceBundle{
+		Discover: posturepkg.DiscoverEvidence{},
+		VerifyInstall: posturepkg.VerifyInstallEvidence{
+			FlightRecorderActive: true,
+			ReceiptCount:         10,
+		},
+		Simulate: audit.SimulateResult{
+			Total:      1,
+			Passed:     1,
+			Percentage: 100,
+			Scenarios: []audit.ScenarioResult{
+				{Category: "DLP", Detected: true},
+			},
+		},
+		FlightRecorder: posturepkg.FlightRecorderCounts{
+			ReceiptCount:  10,
+			LastReceiptAt: &recent,
+		},
+	}
+
+	fix := newTestVerifyFixture(t, emptyDiscover)
+
+	cmd := rootCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--policy", testVerifyPolicyNone,
+		"--min-score", "0",
+		"--require-discovery",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for require-discovery")
+	}
+	assertExitCode(t, err, exitVerifyPolicyFail)
+}
+
+func TestParseDays(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{input: "30d", want: 30},
+		{input: "7d", want: 7},
+		{input: "0d", want: 0},
+		{input: "365d", want: 365},
+		{input: "bad", wantErr: true},
+		{input: "30", wantErr: true},
+		{input: "-1d", wantErr: true},
+		{input: "abcd", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseDays(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseDays(%q) = %d, want error", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseDays(%q) error = %v", tt.input, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseDays(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadPublicKeyVersionedFormat(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	path := writeVersionedPubKey(t, pub)
+	loaded, err := loadPublicKey(path)
+	if err != nil {
+		t.Fatalf("loadPublicKey(): %v", err)
+	}
+	if !pub.Equal(loaded) {
+		t.Error("loaded key does not match original")
+	}
+}
+
+func TestLoadPublicKeyHexFormat(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "pub.hex")
+	if err := os.WriteFile(path, []byte(hex.EncodeToString(pub)), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+
+	loaded, err := loadPublicKey(path)
+	if err != nil {
+		t.Fatalf("loadPublicKey(): %v", err)
+	}
+	if !pub.Equal(loaded) {
+		t.Error("loaded key does not match original")
+	}
+}
+
+func TestLoadPublicKeyBadFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.key")
+	if err := os.WriteFile(path, []byte("not-a-key"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+
+	_, err := loadPublicKey(path)
+	if err == nil {
+		t.Fatal("loadPublicKey() = nil, want error")
+	}
+}
+
+func TestLoadPublicKeyMissingFile(t *testing.T) {
+	_, err := loadPublicKey(filepath.Join(t.TempDir(), "missing.key"))
+	if err == nil {
+		t.Fatal("loadPublicKey() = nil, want error for missing file")
+	}
+}
+
+func TestLoadPublicKeyWrongHexLength(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "short.hex")
+	if err := os.WriteFile(path, []byte("deadbeef"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+
+	_, err := loadPublicKey(path)
+	if err == nil {
+		t.Fatal("loadPublicKey() = nil, want error for wrong length")
+	}
+	if !strings.Contains(err.Error(), "invalid public key length") {
+		t.Errorf("error = %v, want length error", err)
+	}
+}
+
+// --- helpers ---
+
+func writeVersionedPubKey(t *testing.T, pub ed25519.PublicKey) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pub.key")
+	if err := os.WriteFile(path, []byte(signing.EncodePublicKey(pub)), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+	return path
+}
+
+// writeExpiredProof writes a proof.json with ExpiresAt set to the past.
+func writeExpiredProof(t *testing.T, dir string, capsule *posturepkg.Capsule) string {
+	t.Helper()
+
+	// Marshal, patch expires_at, write.
+	data, err := json.Marshal(capsule)
+	if err != nil {
+		t.Fatalf("json.Marshal(): %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal(): %v", err)
+	}
+
+	expired := time.Now().Add(-1 * time.Hour)
+	expiredJSON, err := json.Marshal(expired)
+	if err != nil {
+		t.Fatalf("json.Marshal(expired): %v", err)
+	}
+	raw["expires_at"] = expiredJSON
+
+	patched, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("json.Marshal(patched): %v", err)
+	}
+
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("os.MkdirAll(): %v", err)
+	}
+	path := filepath.Join(dir, posturepkg.ProofFilename)
+	if err := os.WriteFile(path, patched, 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+	return path
+}
+
+// writeOldProof writes a proof.json with GeneratedAt set to 35 days ago.
+func writeOldProof(t *testing.T, dir string, capsule *posturepkg.Capsule) string {
+	t.Helper()
+
+	data, err := json.Marshal(capsule)
+	if err != nil {
+		t.Fatalf("json.Marshal(): %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal(): %v", err)
+	}
+
+	oldTime := time.Now().Add(-35 * 24 * time.Hour)
+	oldJSON, err := json.Marshal(oldTime)
+	if err != nil {
+		t.Fatalf("json.Marshal(oldTime): %v", err)
+	}
+	raw["generated_at"] = oldJSON
+
+	patched, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("json.Marshal(patched): %v", err)
+	}
+
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("os.MkdirAll(): %v", err)
+	}
+	path := filepath.Join(dir, posturepkg.ProofFilename)
+	if err := os.WriteFile(path, patched, 0o600); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
+	}
+	return path
+}
+
+func assertExitCode(t *testing.T, err error, wantCode int) {
+	t.Helper()
+	gotCode := cliutil.ExitCodeOf(err)
+	if gotCode != wantCode {
+		t.Errorf("exit code = %d, want %d (error: %v)", gotCode, wantCode, err)
+	}
+
+	// Also verify it's an ExitError.
+	var ee *cliutil.ExitError
+	if !errors.As(err, &ee) {
+		t.Errorf("error is not *cliutil.ExitError: %T", err)
+	}
+}

--- a/internal/posture/posture.go
+++ b/internal/posture/posture.go
@@ -441,6 +441,13 @@ func collectFlightRecorderEvidence(cfg *config.Config) (FlightRecorderCounts, er
 	return result, nil
 }
 
+// HashConfig computes the canonical SHA-256 hash of a config. Used by both
+// capsule emission and the verify command (to compare local config against the
+// capsule's config_hash).
+func HashConfig(cfg *config.Config) (string, error) {
+	return hashConfig(cfg)
+}
+
 func hashConfig(cfg *config.Config) (string, error) {
 	canonical, err := canonicalize(cfg)
 	if err != nil {

--- a/internal/posture/score.go
+++ b/internal/posture/score.go
@@ -48,6 +48,7 @@ const (
 	ruleConfigHashMismatch  = "config_hash_mismatch"
 	ruleUnknownServers      = "unknown_servers"
 	ruleDiscoveryParseError = "discovery_parse_errors"
+	ruleNoServersDiscovered = "no_servers_discovered"
 )
 
 // Warning message for no discovered servers.
@@ -107,8 +108,12 @@ type VerifyOpts struct {
 
 // ComputeScore calculates the posture score from an evidence bundle.
 func ComputeScore(evidence EvidenceBundle, maxReceiptAgeDays int) (int, FactorScores) {
+	return computeScoreAt(evidence, maxReceiptAgeDays, time.Now().UTC())
+}
+
+func computeScoreAt(evidence EvidenceBundle, maxReceiptAgeDays int, now time.Time) (int, FactorScores) {
 	transportPct := computeTransportPct(evidence.Discover)
-	recorderPct := computeRecorderPct(evidence.VerifyInstall, evidence.FlightRecorder, maxReceiptAgeDays)
+	recorderPct := computeRecorderPctAt(evidence.VerifyInstall, evidence.FlightRecorder, maxReceiptAgeDays, now)
 	simulatePct := computeSimulatePct(evidence.Simulate)
 	cleanlinessPct := computeCleanlinessPct(evidence.Discover)
 
@@ -132,6 +137,10 @@ func ComputeScore(evidence EvidenceBundle, maxReceiptAgeDays int) (int, FactorSc
 // EvaluatePolicy checks the evidence bundle against the given policy.
 // Returns hard failures and warnings.
 func EvaluatePolicy(policy string, evidence EvidenceBundle, opts VerifyOpts) ([]HardFailure, []string) {
+	return evaluatePolicyAt(policy, evidence, opts, time.Now().UTC())
+}
+
+func evaluatePolicyAt(policy string, evidence EvidenceBundle, opts VerifyOpts, now time.Time) ([]HardFailure, []string) {
 	var failures []HardFailure
 	var warnings []string
 
@@ -150,7 +159,7 @@ func EvaluatePolicy(policy string, evidence EvidenceBundle, opts VerifyOpts) ([]
 
 	// Warning: no servers discovered (vacuous truth, not a failure).
 	totalScannable := evidence.Discover.TotalServers + evidence.Discover.ParseErrors
-	if totalScannable == 0 && evidence.Discover.ParseErrors == 0 {
+	if totalScannable == 0 {
 		warnings = append(warnings, warnNoServersDiscovered)
 	}
 
@@ -191,7 +200,7 @@ func EvaluatePolicy(policy string, evidence EvidenceBundle, opts VerifyOpts) ([]
 				Detail: "last receipt timestamp missing",
 			})
 		} else if evidence.FlightRecorder.LastReceiptAt != nil {
-			elapsed := time.Since(*evidence.FlightRecorder.LastReceiptAt)
+			elapsed := now.Sub(*evidence.FlightRecorder.LastReceiptAt)
 			if elapsed > maxAgeDuration(maxAge) {
 				failures = append(failures, HardFailure{
 					Rule:   ruleStaleReceipts,
@@ -230,7 +239,8 @@ func VerifyCapsule(capsule *Capsule, trustedKey ed25519.PublicKey, opts VerifyOp
 	if err != nil {
 		return nil, err
 	}
-	if err := validateCapsuleTimes(capsule, opts.MaxFutureSkew); err != nil {
+	now := time.Now().UTC()
+	if err := validateCapsuleTimesAt(capsule, opts.MaxFutureSkew, now); err != nil {
 		return nil, err
 	}
 
@@ -252,16 +262,16 @@ func VerifyCapsule(capsule *Capsule, trustedKey ed25519.PublicKey, opts VerifyOp
 
 	// MaxReceiptAge=0 means skip stale-receipt scoring. The CLI sets the
 	// default (7d); callers that want no staleness check pass 0 explicitly.
-	score, factors := ComputeScore(capsule.Evidence, opts.MaxReceiptAge)
+	score, factors := computeScoreAt(capsule.Evidence, opts.MaxReceiptAge, now)
 	result.Score = score
 	result.FactorScores = factors
 
-	failures, warnings := EvaluatePolicy(opts.Policy, capsule.Evidence, opts)
+	failures, warnings := evaluatePolicyAt(opts.Policy, capsule.Evidence, opts, now)
 	result.HardFailures = failures
 	result.Warnings = warnings
 
 	if opts.MaxAgeDays > 0 {
-		elapsed := time.Since(capsule.GeneratedAt)
+		elapsed := now.Sub(capsule.GeneratedAt)
 		if elapsed > maxAgeDuration(opts.MaxAgeDays) {
 			result.HardFailures = append(result.HardFailures, HardFailure{
 				Rule:   ruleCapsuleTooOld,
@@ -282,7 +292,7 @@ func VerifyCapsule(capsule *Capsule, trustedKey ed25519.PublicKey, opts VerifyOp
 	if opts.RequireDiscovery {
 		if capsule.Evidence.Discover.TotalServers == 0 {
 			result.HardFailures = append(result.HardFailures, HardFailure{
-				Rule:   "no_servers_discovered",
+				Rule:   ruleNoServersDiscovered,
 				Detail: "0 servers discovered (--require-discovery)",
 			})
 		}
@@ -310,17 +320,21 @@ func normalizeVerifyOpts(opts VerifyOpts) (VerifyOpts, error) {
 	if opts.MaxReceiptAge < 0 {
 		return opts, fmt.Errorf("max_receipt_age must be >= 0, got %d", opts.MaxReceiptAge)
 	}
-	if opts.MaxReceiptAge == 0 && !opts.SkipReceiptFreshness {
+	if opts.SkipReceiptFreshness {
+		opts.MaxReceiptAge = 0
+	} else if opts.MaxReceiptAge == 0 {
 		opts.MaxReceiptAge = MaxReceiptAgeDays
 	}
-	if opts.MaxFutureSkew <= 0 {
+	if opts.MaxFutureSkew < 0 {
+		return opts, fmt.Errorf("max_future_skew must be >= 0, got %s", opts.MaxFutureSkew)
+	}
+	if opts.MaxFutureSkew == 0 {
 		opts.MaxFutureSkew = defaultMaxFutureSkew
 	}
 	return opts, nil
 }
 
-func validateCapsuleTimes(capsule *Capsule, maxFutureSkew time.Duration) error {
-	now := time.Now().UTC()
+func validateCapsuleTimesAt(capsule *Capsule, maxFutureSkew time.Duration, now time.Time) error {
 	maxAllowed := now.Add(maxFutureSkew)
 
 	if capsule.GeneratedAt.After(maxAllowed) {
@@ -348,7 +362,7 @@ func computeTransportPct(d DiscoverEvidence) int {
 	return clampPercent((100 * protectedAny) / totalScannable)
 }
 
-func computeRecorderPct(vi VerifyInstallEvidence, fr FlightRecorderCounts, maxAgeDays int) int {
+func computeRecorderPctAt(vi VerifyInstallEvidence, fr FlightRecorderCounts, maxAgeDays int, now time.Time) int {
 	if !vi.FlightRecorderActive {
 		return 0
 	}
@@ -359,7 +373,7 @@ func computeRecorderPct(vi VerifyInstallEvidence, fr FlightRecorderCounts, maxAg
 		if fr.LastReceiptAt == nil {
 			return 50
 		}
-		if time.Since(*fr.LastReceiptAt) > maxAgeDuration(maxAgeDays) {
+		if now.Sub(*fr.LastReceiptAt) > maxAgeDuration(maxAgeDays) {
 			return 50
 		}
 	}

--- a/internal/posture/score.go
+++ b/internal/posture/score.go
@@ -184,13 +184,20 @@ func EvaluatePolicy(policy string, evidence EvidenceBundle, opts VerifyOpts) ([]
 	}
 
 	maxAge := opts.MaxReceiptAge
-	if maxAge > 0 && evidence.FlightRecorder.LastReceiptAt != nil {
-		elapsed := time.Since(*evidence.FlightRecorder.LastReceiptAt)
-		if elapsed > maxAgeDuration(maxAge) {
+	if maxAge > 0 {
+		if evidence.VerifyInstall.ReceiptCount > 0 && evidence.FlightRecorder.LastReceiptAt == nil {
 			failures = append(failures, HardFailure{
 				Rule:   ruleStaleReceipts,
-				Detail: fmt.Sprintf("last receipt %s ago (max: %dd)", formatElapsedDays(elapsed), maxAge),
+				Detail: "last receipt timestamp missing",
 			})
+		} else if evidence.FlightRecorder.LastReceiptAt != nil {
+			elapsed := time.Since(*evidence.FlightRecorder.LastReceiptAt)
+			if elapsed > maxAgeDuration(maxAge) {
+				failures = append(failures, HardFailure{
+					Rule:   ruleStaleReceipts,
+					Detail: fmt.Sprintf("last receipt %s ago (max: %dd)", formatElapsedDays(elapsed), maxAge),
+				})
+			}
 		}
 	}
 
@@ -338,7 +345,7 @@ func computeTransportPct(d DiscoverEvidence) int {
 	}
 
 	protectedAny := d.ProtectedPipelock + d.ProtectedOther
-	return (100 * protectedAny) / totalScannable
+	return clampPercent((100 * protectedAny) / totalScannable)
 }
 
 func computeRecorderPct(vi VerifyInstallEvidence, fr FlightRecorderCounts, maxAgeDays int) int {
@@ -348,9 +355,11 @@ func computeRecorderPct(vi VerifyInstallEvidence, fr FlightRecorderCounts, maxAg
 	if vi.ReceiptCount == 0 {
 		return 0
 	}
-	if maxAgeDays > 0 && fr.LastReceiptAt != nil {
+	if maxAgeDays > 0 {
+		if fr.LastReceiptAt == nil {
+			return 50
+		}
 		if time.Since(*fr.LastReceiptAt) > maxAgeDuration(maxAgeDays) {
-			// Active but stale.
 			return 50
 		}
 	}
@@ -371,21 +380,15 @@ func computeSimulatePct(sim audit.SimulateResult) int {
 			}
 		}
 		if scorable > 0 {
-			return (passed * 100) / scorable
+			return clampPercent((passed * 100) / scorable)
 		}
 	}
 
 	scorable := sim.Total - sim.KnownLimits
 	if scorable > 0 {
-		return (sim.Passed * 100) / scorable
+		return clampPercent((sim.Passed * 100) / scorable)
 	}
-	if sim.Percentage < 0 {
-		return 0
-	}
-	if sim.Percentage > 100 {
-		return 100
-	}
-	return sim.Percentage
+	return clampPercent(sim.Percentage)
 }
 
 func computeCleanlinessPct(d DiscoverEvidence) int {
@@ -399,10 +402,22 @@ func computeCleanlinessPct(d DiscoverEvidence) int {
 }
 
 func factor(rawPct, weight int) FactorDetail {
+	rawPct = clampPercent(rawPct)
 	return FactorDetail{
 		RawPercent: rawPct,
 		Weight:     weight,
 		Weighted:   (rawPct * weight) / 100,
+	}
+}
+
+func clampPercent(rawPct int) int {
+	switch {
+	case rawPct < 0:
+		return 0
+	case rawPct > 100:
+		return 100
+	default:
+		return rawPct
 	}
 }
 

--- a/internal/posture/score.go
+++ b/internal/posture/score.go
@@ -29,8 +29,13 @@ const (
 // ScoringVersion tracks the score model for reproducibility.
 const ScoringVersion = "1"
 
+// DefaultMinScore is the default minimum passing score for verification.
+const DefaultMinScore = 85
+
 // MaxReceiptAgeDays is the default max age for the most recent receipt.
 const MaxReceiptAgeDays = 7
+
+const defaultMaxFutureSkew = 5 * time.Minute
 
 // Hard failure rule names.
 const (
@@ -56,6 +61,7 @@ type VerifyResult struct {
 	FactorScores    FactorScores  `json:"factor_scores"`
 	HardFailures    []HardFailure `json:"hard_failures,omitempty"`
 	Warnings        []string      `json:"warnings,omitempty"`
+	Error           string        `json:"error,omitempty"`
 	Policy          string        `json:"policy"`
 	PolicyVersion   string        `json:"policy_version"`
 	ScoringVersion  string        `json:"scoring_version"`
@@ -88,19 +94,22 @@ type HardFailure struct {
 
 // VerifyOpts configures posture verification.
 type VerifyOpts struct {
-	Policy           string // "none", "enterprise", "strict"
-	MinScore         int
-	MaxAgeDays       int
-	MaxReceiptAge    int    // days; 0 = skip
-	ConfigHash       string // from local config; empty = skip
-	RequireDiscovery bool
+	Policy               string // "none", "enterprise", "strict"
+	MinScore             int
+	SkipMinScoreGate     bool // true = allow min score 0 without falling back to DefaultMinScore
+	MaxAgeDays           int
+	MaxReceiptAge        int           // days; defaults to MaxReceiptAgeDays unless SkipReceiptFreshness is true
+	SkipReceiptFreshness bool          // true = skip stale-receipt scoring and policy checks
+	MaxFutureSkew        time.Duration // 0 = default 5m skew allowance
+	ConfigHash           string        // from local config; empty = skip
+	RequireDiscovery     bool
 }
 
 // ComputeScore calculates the posture score from an evidence bundle.
 func ComputeScore(evidence EvidenceBundle, maxReceiptAgeDays int) (int, FactorScores) {
 	transportPct := computeTransportPct(evidence.Discover)
 	recorderPct := computeRecorderPct(evidence.VerifyInstall, evidence.FlightRecorder, maxReceiptAgeDays)
-	simulatePct := evidence.Simulate.Percentage
+	simulatePct := computeSimulatePct(evidence.Simulate)
 	cleanlinessPct := computeCleanlinessPct(evidence.Discover)
 
 	transport := factor(transportPct, WeightTransportRatio)
@@ -210,6 +219,13 @@ func VerifyCapsule(capsule *Capsule, trustedKey ed25519.PublicKey, opts VerifyOp
 	if err := Verify(capsule, trustedKey); err != nil {
 		return nil, err
 	}
+	opts, err := normalizeVerifyOpts(opts)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateCapsuleTimes(capsule, opts.MaxFutureSkew); err != nil {
+		return nil, err
+	}
 
 	result := &VerifyResult{
 		Verified:       true,
@@ -271,6 +287,45 @@ func VerifyCapsule(capsule *Capsule, trustedKey ed25519.PublicKey, opts VerifyOp
 	return result, nil
 }
 
+func normalizeVerifyOpts(opts VerifyOpts) (VerifyOpts, error) {
+	if opts.Policy == "" {
+		opts.Policy = PolicyEnterprise
+	}
+	if opts.MinScore < 0 || opts.MinScore > 100 {
+		return opts, fmt.Errorf("min_score must be between 0 and 100, got %d", opts.MinScore)
+	}
+	if opts.MinScore == 0 && !opts.SkipMinScoreGate {
+		opts.MinScore = DefaultMinScore
+	}
+	if opts.MaxAgeDays < 0 {
+		return opts, fmt.Errorf("max_age_days must be >= 0, got %d", opts.MaxAgeDays)
+	}
+	if opts.MaxReceiptAge < 0 {
+		return opts, fmt.Errorf("max_receipt_age must be >= 0, got %d", opts.MaxReceiptAge)
+	}
+	if opts.MaxReceiptAge == 0 && !opts.SkipReceiptFreshness {
+		opts.MaxReceiptAge = MaxReceiptAgeDays
+	}
+	if opts.MaxFutureSkew <= 0 {
+		opts.MaxFutureSkew = defaultMaxFutureSkew
+	}
+	return opts, nil
+}
+
+func validateCapsuleTimes(capsule *Capsule, maxFutureSkew time.Duration) error {
+	now := time.Now().UTC()
+	maxAllowed := now.Add(maxFutureSkew)
+
+	if capsule.GeneratedAt.After(maxAllowed) {
+		return fmt.Errorf("generated_at %s is more than %s in the future", capsule.GeneratedAt.Format(time.RFC3339), maxFutureSkew)
+	}
+	if capsule.Evidence.FlightRecorder.LastReceiptAt != nil &&
+		capsule.Evidence.FlightRecorder.LastReceiptAt.After(maxAllowed) {
+		return fmt.Errorf("last_receipt_at %s is more than %s in the future", capsule.Evidence.FlightRecorder.LastReceiptAt.Format(time.RFC3339), maxFutureSkew)
+	}
+	return nil
+}
+
 func computeTransportPct(d DiscoverEvidence) int {
 	totalScannable := d.TotalServers + d.ParseErrors
 	if totalScannable == 0 {
@@ -300,6 +355,37 @@ func computeRecorderPct(vi VerifyInstallEvidence, fr FlightRecorderCounts, maxAg
 		}
 	}
 	return 100
+}
+
+func computeSimulatePct(sim audit.SimulateResult) int {
+	if len(sim.Scenarios) > 0 {
+		scorable := 0
+		passed := 0
+		for _, scenario := range sim.Scenarios {
+			if scenario.Limitation {
+				continue
+			}
+			scorable++
+			if scenario.Detected {
+				passed++
+			}
+		}
+		if scorable > 0 {
+			return (passed * 100) / scorable
+		}
+	}
+
+	scorable := sim.Total - sim.KnownLimits
+	if scorable > 0 {
+		return (sim.Passed * 100) / scorable
+	}
+	if sim.Percentage < 0 {
+		return 0
+	}
+	if sim.Percentage > 100 {
+		return 100
+	}
+	return sim.Percentage
 }
 
 func computeCleanlinessPct(d DiscoverEvidence) int {

--- a/internal/posture/score.go
+++ b/internal/posture/score.go
@@ -39,6 +39,7 @@ const (
 	ruleRecorderInactive    = "recorder_inactive"
 	ruleNoReceipts          = "no_receipts"
 	ruleStaleReceipts       = "stale_receipts"
+	ruleCapsuleTooOld       = "capsule_too_old"
 	ruleConfigHashMismatch  = "config_hash_mismatch"
 	ruleUnknownServers      = "unknown_servers"
 	ruleDiscoveryParseError = "discovery_parse_errors"
@@ -175,11 +176,11 @@ func EvaluatePolicy(policy string, evidence EvidenceBundle, opts VerifyOpts) ([]
 
 	maxAge := opts.MaxReceiptAge
 	if maxAge > 0 && evidence.FlightRecorder.LastReceiptAt != nil {
-		ageDays := int(time.Since(*evidence.FlightRecorder.LastReceiptAt).Hours() / 24)
-		if ageDays > maxAge {
+		elapsed := time.Since(*evidence.FlightRecorder.LastReceiptAt)
+		if elapsed > maxAgeDuration(maxAge) {
 			failures = append(failures, HardFailure{
 				Rule:   ruleStaleReceipts,
-				Detail: fmt.Sprintf("last receipt %dd ago (max: %dd)", ageDays, maxAge),
+				Detail: fmt.Sprintf("last receipt %s ago (max: %dd)", formatElapsedDays(elapsed), maxAge),
 			})
 		}
 	}
@@ -236,6 +237,16 @@ func VerifyCapsule(capsule *Capsule, trustedKey ed25519.PublicKey, opts VerifyOp
 	result.HardFailures = failures
 	result.Warnings = warnings
 
+	if opts.MaxAgeDays > 0 {
+		elapsed := time.Since(capsule.GeneratedAt)
+		if elapsed > maxAgeDuration(opts.MaxAgeDays) {
+			result.HardFailures = append(result.HardFailures, HardFailure{
+				Rule:   ruleCapsuleTooOld,
+				Detail: fmt.Sprintf("capsule age %s exceeds max %dd", formatElapsedDays(elapsed), opts.MaxAgeDays),
+			})
+		}
+	}
+
 	// Config hash mismatch as a hard failure.
 	if result.ConfigHashMatch != nil && !*result.ConfigHashMatch {
 		result.HardFailures = append(result.HardFailures, HardFailure{
@@ -246,8 +257,7 @@ func VerifyCapsule(capsule *Capsule, trustedKey ed25519.PublicKey, opts VerifyOp
 
 	// Require discovery gate.
 	if opts.RequireDiscovery {
-		totalScannable := capsule.Evidence.Discover.TotalServers + capsule.Evidence.Discover.ParseErrors
-		if totalScannable == 0 {
+		if capsule.Evidence.Discover.TotalServers == 0 {
 			result.HardFailures = append(result.HardFailures, HardFailure{
 				Rule:   "no_servers_discovered",
 				Detail: "0 servers discovered (--require-discovery)",
@@ -284,8 +294,7 @@ func computeRecorderPct(vi VerifyInstallEvidence, fr FlightRecorderCounts, maxAg
 		return 0
 	}
 	if maxAgeDays > 0 && fr.LastReceiptAt != nil {
-		ageDays := int(time.Since(*fr.LastReceiptAt).Hours() / 24)
-		if ageDays > maxAgeDays {
+		if time.Since(*fr.LastReceiptAt) > maxAgeDuration(maxAgeDays) {
 			// Active but stale.
 			return 50
 		}
@@ -309,6 +318,18 @@ func factor(rawPct, weight int) FactorDetail {
 		Weight:     weight,
 		Weighted:   (rawPct * weight) / 100,
 	}
+}
+
+func maxAgeDuration(days int) time.Duration {
+	return time.Duration(days) * 24 * time.Hour
+}
+
+func formatElapsedDays(elapsed time.Duration) string {
+	if elapsed <= 0 {
+		return "0d"
+	}
+	days := int((elapsed + (24 * time.Hour) - time.Nanosecond) / (24 * time.Hour))
+	return fmt.Sprintf("%dd", days)
 }
 
 // hasZeroDetectionCategory checks if any scenario category has total>0

--- a/internal/posture/score.go
+++ b/internal/posture/score.go
@@ -125,7 +125,16 @@ func EvaluatePolicy(policy string, evidence EvidenceBundle, opts VerifyOpts) ([]
 	var failures []HardFailure
 	var warnings []string
 
-	if policy == PolicyNone {
+	switch policy {
+	case PolicyNone:
+		return failures, warnings
+	case PolicyEnterprise, PolicyStrict:
+		// valid, continue
+	default:
+		failures = append(failures, HardFailure{
+			Rule:   "invalid_policy",
+			Detail: fmt.Sprintf("unknown policy %q; must be none, enterprise, or strict", policy),
+		})
 		return failures, warnings
 	}
 
@@ -217,12 +226,9 @@ func VerifyCapsule(capsule *Capsule, trustedKey ed25519.PublicKey, opts VerifyOp
 		result.ConfigHashMatch = &match
 	}
 
-	maxReceiptAge := opts.MaxReceiptAge
-	if maxReceiptAge == 0 {
-		maxReceiptAge = MaxReceiptAgeDays
-	}
-
-	score, factors := ComputeScore(capsule.Evidence, maxReceiptAge)
+	// MaxReceiptAge=0 means skip stale-receipt scoring. The CLI sets the
+	// default (7d); callers that want no staleness check pass 0 explicitly.
+	score, factors := ComputeScore(capsule.Evidence, opts.MaxReceiptAge)
 	result.Score = score
 	result.FactorScores = factors
 

--- a/internal/posture/score.go
+++ b/internal/posture/score.go
@@ -1,0 +1,338 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package posture
+
+import (
+	"crypto/ed25519"
+	"fmt"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/cli/audit"
+)
+
+// Policy levels for verification gates.
+const (
+	PolicyNone       = "none"       // score only, no hard gates
+	PolicyEnterprise = "enterprise" // standard hard gates
+	PolicyStrict     = "strict"     // enterprise + unknown/parse_error gates
+)
+
+// ScoreWeights are the factor weights (must sum to 100).
+const (
+	WeightTransportRatio       = 25
+	WeightRecorderHealth       = 15
+	WeightSimulatePassRate     = 35
+	WeightDiscoveryCleanliness = 25
+)
+
+// ScoringVersion tracks the score model for reproducibility.
+const ScoringVersion = "1"
+
+// MaxReceiptAgeDays is the default max age for the most recent receipt.
+const MaxReceiptAgeDays = 7
+
+// Hard failure rule names.
+const (
+	ruleUnprotectedServers  = "unprotected_servers"
+	ruleZeroDetection       = "zero_detection_category"
+	ruleRecorderInactive    = "recorder_inactive"
+	ruleNoReceipts          = "no_receipts"
+	ruleStaleReceipts       = "stale_receipts"
+	ruleConfigHashMismatch  = "config_hash_mismatch"
+	ruleUnknownServers      = "unknown_servers"
+	ruleDiscoveryParseError = "discovery_parse_errors"
+)
+
+// Warning message for no discovered servers.
+const warnNoServersDiscovered = "no_servers_discovered"
+
+// VerifyResult is the full verification outcome.
+type VerifyResult struct {
+	Verified        bool          `json:"verified"`
+	Passed          bool          `json:"passed"`
+	Score           int           `json:"score"`
+	FactorScores    FactorScores  `json:"factor_scores"`
+	HardFailures    []HardFailure `json:"hard_failures,omitempty"`
+	Warnings        []string      `json:"warnings,omitempty"`
+	Policy          string        `json:"policy"`
+	PolicyVersion   string        `json:"policy_version"`
+	ScoringVersion  string        `json:"scoring_version"`
+	GeneratedAt     time.Time     `json:"generated_at"`
+	ExpiresAt       time.Time     `json:"expires_at"`
+	LastReceiptAt   *time.Time    `json:"last_receipt_at,omitempty"`
+	ConfigHashMatch *bool         `json:"config_hash_match,omitempty"`
+}
+
+// FactorScores contains the breakdown of each scoring factor.
+type FactorScores struct {
+	TransportRatio       FactorDetail `json:"transport_ratio"`
+	RecorderHealth       FactorDetail `json:"recorder_health"`
+	SimulatePassRate     FactorDetail `json:"simulate_pass_rate"`
+	DiscoveryCleanliness FactorDetail `json:"discovery_cleanliness"`
+}
+
+// FactorDetail is a single scoring factor with raw and weighted values.
+type FactorDetail struct {
+	RawPercent int `json:"raw_percent"` // 0-100
+	Weight     int `json:"weight"`
+	Weighted   int `json:"weighted"` // raw_percent * weight / 100
+}
+
+// HardFailure is a policy gate failure.
+type HardFailure struct {
+	Rule   string `json:"rule"`
+	Detail string `json:"detail"`
+}
+
+// VerifyOpts configures posture verification.
+type VerifyOpts struct {
+	Policy           string // "none", "enterprise", "strict"
+	MinScore         int
+	MaxAgeDays       int
+	MaxReceiptAge    int    // days; 0 = skip
+	ConfigHash       string // from local config; empty = skip
+	RequireDiscovery bool
+}
+
+// ComputeScore calculates the posture score from an evidence bundle.
+func ComputeScore(evidence EvidenceBundle, maxReceiptAgeDays int) (int, FactorScores) {
+	transportPct := computeTransportPct(evidence.Discover)
+	recorderPct := computeRecorderPct(evidence.VerifyInstall, evidence.FlightRecorder, maxReceiptAgeDays)
+	simulatePct := evidence.Simulate.Percentage
+	cleanlinessPct := computeCleanlinessPct(evidence.Discover)
+
+	transport := factor(transportPct, WeightTransportRatio)
+	recorder := factor(recorderPct, WeightRecorderHealth)
+	simulate := factor(simulatePct, WeightSimulatePassRate)
+	cleanliness := factor(cleanlinessPct, WeightDiscoveryCleanliness)
+
+	score := (transport.Weighted + recorder.Weighted + simulate.Weighted + cleanliness.Weighted)
+
+	factors := FactorScores{
+		TransportRatio:       transport,
+		RecorderHealth:       recorder,
+		SimulatePassRate:     simulate,
+		DiscoveryCleanliness: cleanliness,
+	}
+
+	return score, factors
+}
+
+// EvaluatePolicy checks the evidence bundle against the given policy.
+// Returns hard failures and warnings.
+func EvaluatePolicy(policy string, evidence EvidenceBundle, opts VerifyOpts) ([]HardFailure, []string) {
+	var failures []HardFailure
+	var warnings []string
+
+	if policy == PolicyNone {
+		return failures, warnings
+	}
+
+	// Warning: no servers discovered (vacuous truth, not a failure).
+	totalScannable := evidence.Discover.TotalServers + evidence.Discover.ParseErrors
+	if totalScannable == 0 && evidence.Discover.ParseErrors == 0 {
+		warnings = append(warnings, warnNoServersDiscovered)
+	}
+
+	// Enterprise gates.
+	if evidence.Discover.Unprotected > 0 {
+		failures = append(failures, HardFailure{
+			Rule:   ruleUnprotectedServers,
+			Detail: fmt.Sprintf("%d unprotected MCP servers", evidence.Discover.Unprotected),
+		})
+	}
+
+	if hasZeroDetectionCategory(evidence.Simulate.Scenarios) {
+		failures = append(failures, HardFailure{
+			Rule:   ruleZeroDetection,
+			Detail: "at least one category has 0% detection rate",
+		})
+	}
+
+	if !evidence.VerifyInstall.FlightRecorderActive {
+		failures = append(failures, HardFailure{
+			Rule:   ruleRecorderInactive,
+			Detail: "flight recorder is not active",
+		})
+	}
+
+	if evidence.VerifyInstall.ReceiptCount == 0 {
+		failures = append(failures, HardFailure{
+			Rule:   ruleNoReceipts,
+			Detail: "no action receipts recorded",
+		})
+	}
+
+	maxAge := opts.MaxReceiptAge
+	if maxAge > 0 && evidence.FlightRecorder.LastReceiptAt != nil {
+		ageDays := int(time.Since(*evidence.FlightRecorder.LastReceiptAt).Hours() / 24)
+		if ageDays > maxAge {
+			failures = append(failures, HardFailure{
+				Rule:   ruleStaleReceipts,
+				Detail: fmt.Sprintf("last receipt %dd ago (max: %dd)", ageDays, maxAge),
+			})
+		}
+	}
+
+	// Strict gates (superset of enterprise).
+	if policy == PolicyStrict {
+		if evidence.Discover.Unknown > 0 {
+			failures = append(failures, HardFailure{
+				Rule:   ruleUnknownServers,
+				Detail: fmt.Sprintf("%d unknown MCP servers", evidence.Discover.Unknown),
+			})
+		}
+
+		if evidence.Discover.ParseErrors > 0 {
+			failures = append(failures, HardFailure{
+				Rule:   ruleDiscoveryParseError,
+				Detail: fmt.Sprintf("%d discovery parse errors", evidence.Discover.ParseErrors),
+			})
+		}
+	}
+
+	return failures, warnings
+}
+
+// VerifyCapsule performs full verification: signature, score, and policy gates.
+func VerifyCapsule(capsule *Capsule, trustedKey ed25519.PublicKey, opts VerifyOpts) (*VerifyResult, error) {
+	if err := Verify(capsule, trustedKey); err != nil {
+		return nil, err
+	}
+
+	result := &VerifyResult{
+		Verified:       true,
+		Policy:         opts.Policy,
+		PolicyVersion:  SchemaVersion,
+		ScoringVersion: ScoringVersion,
+		GeneratedAt:    capsule.GeneratedAt,
+		ExpiresAt:      capsule.ExpiresAt,
+		LastReceiptAt:  capsule.Evidence.FlightRecorder.LastReceiptAt,
+	}
+
+	// Config hash comparison.
+	if opts.ConfigHash != "" {
+		match := opts.ConfigHash == capsule.ConfigHash
+		result.ConfigHashMatch = &match
+	}
+
+	maxReceiptAge := opts.MaxReceiptAge
+	if maxReceiptAge == 0 {
+		maxReceiptAge = MaxReceiptAgeDays
+	}
+
+	score, factors := ComputeScore(capsule.Evidence, maxReceiptAge)
+	result.Score = score
+	result.FactorScores = factors
+
+	failures, warnings := EvaluatePolicy(opts.Policy, capsule.Evidence, opts)
+	result.HardFailures = failures
+	result.Warnings = warnings
+
+	// Config hash mismatch as a hard failure.
+	if result.ConfigHashMatch != nil && !*result.ConfigHashMatch {
+		result.HardFailures = append(result.HardFailures, HardFailure{
+			Rule:   ruleConfigHashMismatch,
+			Detail: "local config hash does not match capsule",
+		})
+	}
+
+	// Require discovery gate.
+	if opts.RequireDiscovery {
+		totalScannable := capsule.Evidence.Discover.TotalServers + capsule.Evidence.Discover.ParseErrors
+		if totalScannable == 0 {
+			result.HardFailures = append(result.HardFailures, HardFailure{
+				Rule:   "no_servers_discovered",
+				Detail: "0 servers discovered (--require-discovery)",
+			})
+		}
+	}
+
+	// Determine pass/fail.
+	result.Passed = len(result.HardFailures) == 0 && result.Score >= opts.MinScore
+
+	return result, nil
+}
+
+func computeTransportPct(d DiscoverEvidence) int {
+	totalScannable := d.TotalServers + d.ParseErrors
+	if totalScannable == 0 {
+		// Vacuous truth: no servers to protect = 100%.
+		return 100
+	}
+	if d.TotalServers == 0 && d.ParseErrors > 0 {
+		// Parse errors only, no successfully-parsed servers to assess.
+		return 0
+	}
+
+	protectedAny := d.ProtectedPipelock + d.ProtectedOther
+	return (100 * protectedAny) / totalScannable
+}
+
+func computeRecorderPct(vi VerifyInstallEvidence, fr FlightRecorderCounts, maxAgeDays int) int {
+	if !vi.FlightRecorderActive {
+		return 0
+	}
+	if vi.ReceiptCount == 0 {
+		return 0
+	}
+	if maxAgeDays > 0 && fr.LastReceiptAt != nil {
+		ageDays := int(time.Since(*fr.LastReceiptAt).Hours() / 24)
+		if ageDays > maxAgeDays {
+			// Active but stale.
+			return 50
+		}
+	}
+	return 100
+}
+
+func computeCleanlinessPct(d DiscoverEvidence) int {
+	if d.Unprotected > 0 {
+		return 0
+	}
+	if d.Unknown > 0 || d.ParseErrors > 0 {
+		return 50
+	}
+	return 100
+}
+
+func factor(rawPct, weight int) FactorDetail {
+	return FactorDetail{
+		RawPercent: rawPct,
+		Weight:     weight,
+		Weighted:   (rawPct * weight) / 100,
+	}
+}
+
+// hasZeroDetectionCategory checks if any scenario category has total>0
+// but detected==0, excluding limitation scenarios.
+func hasZeroDetectionCategory(scenarios []audit.ScenarioResult) bool {
+	type categoryStats struct {
+		total    int
+		detected int
+	}
+	cats := make(map[string]*categoryStats)
+
+	for _, s := range scenarios {
+		if s.Limitation {
+			continue
+		}
+		stats, ok := cats[s.Category]
+		if !ok {
+			stats = &categoryStats{}
+			cats[s.Category] = stats
+		}
+		stats.total++
+		if s.Detected {
+			stats.detected++
+		}
+	}
+
+	for _, stats := range cats {
+		if stats.total > 0 && stats.detected == 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/posture/score_test.go
+++ b/internal/posture/score_test.go
@@ -128,6 +128,29 @@ func TestComputeScore(t *testing.T) {
 			wantClean:    100,
 		},
 		{
+			name: "missing last receipt timestamp reduces recorder to 50",
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      5,
+					ProtectedPipelock: 5,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         100,
+				},
+				Simulate: audit.SimulateResult{Percentage: 100},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount: 100,
+				},
+			},
+			maxAgeDays:   MaxReceiptAgeDays,
+			wantScore:    92,
+			wantTransp:   100,
+			wantRecorder: 50,
+			wantSim:      100,
+			wantClean:    100,
+		},
+		{
 			name: "no servers discovered vacuous truth",
 			evidence: EvidenceBundle{
 				Discover: DiscoverEvidence{},
@@ -516,6 +539,30 @@ func TestEvaluatePolicy(t *testing.T) {
 				FlightRecorder: FlightRecorderCounts{
 					ReceiptCount:  10,
 					LastReceiptAt: &staleReceipt,
+				},
+			},
+			opts:         VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+			wantFailures: []string{ruleStaleReceipts},
+		},
+		{
+			name:   "enterprise missing last receipt timestamp",
+			policy: testPolicyEnterprise,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      3,
+					ProtectedPipelock: 3,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount: 10,
 				},
 			},
 			opts:         VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
@@ -1198,6 +1245,16 @@ func TestFactorDetail(t *testing.T) {
 	}
 	if d.Weighted != 15 {
 		t.Errorf("Weighted = %d, want 15 (60*25/100)", d.Weighted)
+	}
+
+	high := factor(180, 25)
+	if high.RawPercent != 100 || high.Weighted != 25 {
+		t.Errorf("high clamp = %+v, want raw=100 weighted=25", high)
+	}
+
+	low := factor(-10, 25)
+	if low.RawPercent != 0 || low.Weighted != 0 {
+		t.Errorf("low clamp = %+v, want raw=0 weighted=0", low)
 	}
 }
 

--- a/internal/posture/score_test.go
+++ b/internal/posture/score_test.go
@@ -992,12 +992,12 @@ func TestVerifyCapsule(t *testing.T) {
 		}
 		found := false
 		for _, f := range result.HardFailures {
-			if f.Rule == "no_servers_discovered" {
+			if f.Rule == ruleNoServersDiscovered {
 				found = true
 			}
 		}
 		if !found {
-			t.Fatalf("missing no_servers_discovered hard failure: %v", result.HardFailures)
+			t.Fatalf("missing %s hard failure: %v", ruleNoServersDiscovered, result.HardFailures)
 		}
 	})
 
@@ -1111,6 +1111,32 @@ func TestVerifyCapsule(t *testing.T) {
 		}
 	})
 
+	t.Run("skip receipt freshness overrides explicit max receipt age", func(t *testing.T) {
+		staleEvidence := perfectEvidence
+		staleReceipt := time.Now().Add(-10 * 24 * time.Hour)
+		staleEvidence.FlightRecorder.LastReceiptAt = &staleReceipt
+		capsule := emitCapsule(t, staleEvidence)
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:               testPolicyEnterprise,
+			MaxReceiptAge:        1,
+			SkipReceiptFreshness: true,
+		})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		if !result.Passed {
+			t.Errorf("Passed = false, want true, failures: %v", result.HardFailures)
+		}
+		if result.FactorScores.RecorderHealth.RawPercent != 100 {
+			t.Errorf("RecorderHealth.RawPercent = %d, want 100", result.FactorScores.RecorderHealth.RawPercent)
+		}
+		for _, f := range result.HardFailures {
+			if f.Rule == ruleStaleReceipts {
+				t.Fatalf("unexpected %s hard failure: %v", ruleStaleReceipts, result.HardFailures)
+			}
+		}
+	})
+
 	t.Run("future generated_at rejected", func(t *testing.T) {
 		capsule := emitCapsule(t, perfectEvidence)
 		capsule.GeneratedAt = time.Now().Add(defaultMaxFutureSkew + time.Minute)
@@ -1156,6 +1182,45 @@ func TestVerifyCapsule(t *testing.T) {
 		}
 		if got := err.Error(); got == "" || !containsAll(got, "min_score", "101") {
 			t.Errorf("error = %q, want invalid min score failure", got)
+		}
+	})
+
+	t.Run("negative max future skew rejected", func(t *testing.T) {
+		capsule := emitCapsule(t, perfectEvidence)
+		_, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:        testPolicyEnterprise,
+			MaxReceiptAge: MaxReceiptAgeDays,
+			MaxFutureSkew: -time.Second,
+		})
+		if err == nil {
+			t.Fatal("VerifyCapsule() error = nil, want invalid max future skew failure")
+		}
+		if got := err.Error(); got == "" || !containsAll(got, "max_future_skew", ">=") {
+			t.Errorf("error = %q, want invalid max future skew failure", got)
+		}
+	})
+
+	t.Run("shared clock keeps stale gate and score aligned at threshold", func(t *testing.T) {
+		now := time.Now().UTC()
+		atThreshold := now.Add(-maxAgeDuration(MaxReceiptAgeDays))
+		evidence := perfectEvidence
+		evidence.FlightRecorder.LastReceiptAt = &atThreshold
+
+		score, factors := computeScoreAt(evidence, MaxReceiptAgeDays, now)
+		failures, _ := evaluatePolicyAt(testPolicyEnterprise, evidence, VerifyOpts{
+			MaxReceiptAge: MaxReceiptAgeDays,
+		}, now)
+
+		if score != 100 {
+			t.Errorf("score = %d, want 100", score)
+		}
+		if factors.RecorderHealth.RawPercent != 100 {
+			t.Errorf("RecorderHealth.RawPercent = %d, want 100", factors.RecorderHealth.RawPercent)
+		}
+		for _, f := range failures {
+			if f.Rule == ruleStaleReceipts {
+				t.Fatalf("unexpected %s hard failure at threshold: %v", ruleStaleReceipts, failures)
+			}
 		}
 	})
 

--- a/internal/posture/score_test.go
+++ b/internal/posture/score_test.go
@@ -240,6 +240,30 @@ func TestComputeScore(t *testing.T) {
 			wantSim:      100,
 			wantClean:    100,
 		},
+		{
+			name: "receipt just over threshold is stale",
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      2,
+					ProtectedPipelock: 2,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{Percentage: 100},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: bundleTimePtr(time.Now().Add(-(time.Duration(MaxReceiptAgeDays)*24*time.Hour + time.Hour))),
+				},
+			},
+			maxAgeDays:   MaxReceiptAgeDays,
+			wantScore:    92,
+			wantTransp:   100,
+			wantRecorder: 50,
+			wantSim:      100,
+			wantClean:    100,
+		},
 	}
 
 	for _, tt := range tests {
@@ -532,6 +556,31 @@ func TestEvaluatePolicy(t *testing.T) {
 			},
 			opts: VerifyOpts{MaxReceiptAge: 0},
 		},
+		{
+			name:   "receipt just over threshold fails exactly",
+			policy: testPolicyEnterprise,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      3,
+					ProtectedPipelock: 3,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: bundleTimePtr(time.Now().Add(-(time.Duration(MaxReceiptAgeDays)*24*time.Hour + time.Hour))),
+				},
+			},
+			opts:         VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+			wantFailures: []string{ruleStaleReceipts},
+		},
 	}
 
 	for _, tt := range tests {
@@ -772,6 +821,76 @@ func TestVerifyCapsule(t *testing.T) {
 		}
 	})
 
+	t.Run("max age failure is structured hard failure", func(t *testing.T) {
+		capsule := emitCapsule(t, perfectEvidence)
+		capsule.GeneratedAt = time.Now().Add(-(31 * 24 * time.Hour))
+		capsule.ExpiresAt = time.Now().Add(30 * 24 * time.Hour)
+		capsule.Signature = resignCapsule(t, capsule, priv)
+
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:        testPolicyNone,
+			MinScore:      0,
+			MaxAgeDays:    30,
+			MaxReceiptAge: MaxReceiptAgeDays,
+		})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		if result.Passed {
+			t.Error("Passed = true, want false (max age)")
+		}
+		found := false
+		for _, f := range result.HardFailures {
+			if f.Rule == ruleCapsuleTooOld {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("missing %s hard failure: %v", ruleCapsuleTooOld, result.HardFailures)
+		}
+	})
+
+	t.Run("require discovery ignores parse errors", func(t *testing.T) {
+		parseOnly := EvidenceBundle{
+			Discover: DiscoverEvidence{
+				ParseErrors: 2,
+			},
+			VerifyInstall: VerifyInstallEvidence{
+				FlightRecorderActive: true,
+				ReceiptCount:         10,
+			},
+			Simulate: audit.SimulateResult{
+				Percentage: 100,
+				Scenarios: []audit.ScenarioResult{
+					{Category: "DLP", Detected: true},
+				},
+			},
+			FlightRecorder: FlightRecorderCounts{
+				ReceiptCount:  10,
+				LastReceiptAt: &recentReceipt,
+			},
+		}
+		capsule := emitCapsule(t, parseOnly)
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:           testPolicyNone,
+			MinScore:         0,
+			MaxReceiptAge:    MaxReceiptAgeDays,
+			RequireDiscovery: true,
+		})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		found := false
+		for _, f := range result.HardFailures {
+			if f.Rule == "no_servers_discovered" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("missing no_servers_discovered hard failure: %v", result.HardFailures)
+		}
+	})
+
 	t.Run("default max receipt age applied", func(t *testing.T) {
 		capsule := emitCapsule(t, perfectEvidence)
 		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
@@ -874,4 +993,8 @@ func TestFactorDetail(t *testing.T) {
 	if d.Weighted != 15 {
 		t.Errorf("Weighted = %d, want 15 (60*25/100)", d.Weighted)
 	}
+}
+
+func bundleTimePtr(ts time.Time) *time.Time {
+	return &ts
 }

--- a/internal/posture/score_test.go
+++ b/internal/posture/score_test.go
@@ -5,6 +5,7 @@ package posture
 
 import (
 	"crypto/ed25519"
+	"strings"
 	"testing"
 	"time"
 
@@ -283,6 +284,68 @@ func TestComputeScore(t *testing.T) {
 			}
 			if factors.DiscoveryCleanliness.RawPercent != tt.wantClean {
 				t.Errorf("cleanliness raw = %d, want %d", factors.DiscoveryCleanliness.RawPercent, tt.wantClean)
+			}
+		})
+	}
+}
+
+func TestComputeSimulatePct(t *testing.T) {
+	tests := []struct {
+		name string
+		sim  audit.SimulateResult
+		want int
+	}{
+		{
+			name: "scenarios take precedence over summary percentage",
+			sim: audit.SimulateResult{
+				Total:      2,
+				Passed:     2,
+				Percentage: 100,
+				Scenarios: []audit.ScenarioResult{
+					{Category: "DLP", Detected: true},
+					{Category: "DLP", Detected: false},
+				},
+			},
+			want: 50,
+		},
+		{
+			name: "summary counts used when scenarios absent",
+			sim: audit.SimulateResult{
+				Total:       5,
+				Passed:      3,
+				KnownLimits: 1,
+				Percentage:  100,
+			},
+			want: 75,
+		},
+		{
+			name: "raw percentage fallback without canonical counts",
+			sim: audit.SimulateResult{
+				Percentage: 88,
+			},
+			want: 88,
+		},
+		{
+			name: "raw percentage clamps above 100",
+			sim: audit.SimulateResult{
+				Percentage: 140,
+			},
+			want: 100,
+		},
+		{
+			name: "raw percentage clamps below 0",
+			sim: audit.SimulateResult{
+				Percentage: -5,
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeSimulatePct(tt.sim)
+			if got != tt.want {
+				t.Errorf("computeSimulatePct() = %d, want %d", got, tt.want)
 			}
 		})
 	}
@@ -892,17 +955,160 @@ func TestVerifyCapsule(t *testing.T) {
 	})
 
 	t.Run("default max receipt age applied", func(t *testing.T) {
-		capsule := emitCapsule(t, perfectEvidence)
+		staleEvidence := perfectEvidence
+		staleReceipt := time.Now().Add(-10 * 24 * time.Hour)
+		staleEvidence.FlightRecorder.LastReceiptAt = &staleReceipt
+		capsule := emitCapsule(t, staleEvidence)
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		if result.Passed {
+			t.Error("Passed = true, want false (default stale receipt gate)")
+		}
+		found := false
+		for _, f := range result.HardFailures {
+			if f.Rule == ruleStaleReceipts {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("missing %s hard failure: %v", ruleStaleReceipts, result.HardFailures)
+		}
+	})
+
+	t.Run("zero-value opts default policy and min score", func(t *testing.T) {
+		parseOnly := EvidenceBundle{
+			Discover: DiscoverEvidence{
+				ParseErrors: 2,
+			},
+			VerifyInstall: VerifyInstallEvidence{
+				FlightRecorderActive: true,
+				ReceiptCount:         10,
+			},
+			Simulate: audit.SimulateResult{
+				Percentage: 100,
+				Scenarios: []audit.ScenarioResult{
+					{Category: "DLP", Detected: true},
+				},
+			},
+			FlightRecorder: FlightRecorderCounts{
+				ReceiptCount:  10,
+				LastReceiptAt: &recentReceipt,
+			},
+		}
+		capsule := emitCapsule(t, parseOnly)
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		if result.Policy != PolicyEnterprise {
+			t.Errorf("Policy = %q, want %q", result.Policy, PolicyEnterprise)
+		}
+		if result.Score != 62 {
+			t.Errorf("Score = %d, want 62", result.Score)
+		}
+		if result.Passed {
+			t.Error("Passed = true, want false (default min score)")
+		}
+	})
+
+	t.Run("skip min score gate allows explicit zero threshold", func(t *testing.T) {
+		parseOnly := EvidenceBundle{
+			Discover: DiscoverEvidence{
+				ParseErrors: 2,
+			},
+			VerifyInstall: VerifyInstallEvidence{
+				FlightRecorderActive: true,
+				ReceiptCount:         10,
+			},
+			Simulate: audit.SimulateResult{
+				Percentage: 100,
+				Scenarios: []audit.ScenarioResult{
+					{Category: "DLP", Detected: true},
+				},
+			},
+			FlightRecorder: FlightRecorderCounts{
+				ReceiptCount:  10,
+				LastReceiptAt: &recentReceipt,
+			},
+		}
+		capsule := emitCapsule(t, parseOnly)
 		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
-			Policy:   testPolicyEnterprise,
-			MinScore: 0,
+			Policy:           testPolicyEnterprise,
+			MinScore:         0,
+			SkipMinScoreGate: true,
 		})
 		if err != nil {
 			t.Fatalf("VerifyCapsule(): %v", err)
 		}
-		// With recent receipt and default age, should pass.
-		if !result.Verified {
-			t.Error("Verified = false, want true")
+		if !result.Passed {
+			t.Errorf("Passed = false, want true (explicit zero threshold), failures: %v", result.HardFailures)
+		}
+	})
+
+	t.Run("skip receipt freshness disables default staleness gate", func(t *testing.T) {
+		staleEvidence := perfectEvidence
+		staleReceipt := time.Now().Add(-10 * 24 * time.Hour)
+		staleEvidence.FlightRecorder.LastReceiptAt = &staleReceipt
+		capsule := emitCapsule(t, staleEvidence)
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:               testPolicyEnterprise,
+			SkipReceiptFreshness: true,
+		})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		if !result.Passed {
+			t.Errorf("Passed = false, want true, failures: %v", result.HardFailures)
+		}
+	})
+
+	t.Run("future generated_at rejected", func(t *testing.T) {
+		capsule := emitCapsule(t, perfectEvidence)
+		capsule.GeneratedAt = time.Now().Add(defaultMaxFutureSkew + time.Minute)
+		capsule.ExpiresAt = capsule.GeneratedAt.Add(30 * 24 * time.Hour)
+		capsule.Signature = resignCapsule(t, capsule, priv)
+
+		_, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy: testPolicyEnterprise,
+		})
+		if err == nil {
+			t.Fatal("VerifyCapsule() error = nil, want future generated_at failure")
+		}
+		if got := err.Error(); got == "" || !containsAll(got, "generated_at", "future") {
+			t.Errorf("error = %q, want generated_at future failure", got)
+		}
+	})
+
+	t.Run("future last_receipt_at rejected", func(t *testing.T) {
+		capsule := emitCapsule(t, perfectEvidence)
+		futureReceipt := time.Now().Add(defaultMaxFutureSkew + time.Minute)
+		capsule.Evidence.FlightRecorder.LastReceiptAt = &futureReceipt
+		capsule.Signature = resignCapsule(t, capsule, priv)
+
+		_, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy: testPolicyEnterprise,
+		})
+		if err == nil {
+			t.Fatal("VerifyCapsule() error = nil, want future last_receipt_at failure")
+		}
+		if got := err.Error(); got == "" || !containsAll(got, "last_receipt_at", "future") {
+			t.Errorf("error = %q, want last_receipt_at future failure", got)
+		}
+	})
+
+	t.Run("invalid min score rejected", func(t *testing.T) {
+		capsule := emitCapsule(t, perfectEvidence)
+		_, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:   testPolicyEnterprise,
+			MinScore: 101,
+		})
+		if err == nil {
+			t.Fatal("VerifyCapsule() error = nil, want invalid min score failure")
+		}
+		if got := err.Error(); got == "" || !containsAll(got, "min_score", "101") {
+			t.Errorf("error = %q, want invalid min score failure", got)
 		}
 	})
 
@@ -997,4 +1203,13 @@ func TestFactorDetail(t *testing.T) {
 
 func bundleTimePtr(ts time.Time) *time.Time {
 	return &ts
+}
+
+func containsAll(s string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(s, part) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/posture/score_test.go
+++ b/internal/posture/score_test.go
@@ -1,0 +1,877 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package posture
+
+import (
+	"crypto/ed25519"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/cli/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const (
+	testPolicyEnterprise = PolicyEnterprise
+	testPolicyStrict     = PolicyStrict
+	testPolicyNone       = PolicyNone
+)
+
+func TestComputeScore(t *testing.T) {
+	recentReceipt := time.Now().Add(-1 * time.Hour)
+	staleReceipt := time.Now().Add(-10 * 24 * time.Hour)
+
+	tests := []struct {
+		name         string
+		evidence     EvidenceBundle
+		maxAgeDays   int
+		wantScore    int
+		wantTransp   int
+		wantRecorder int
+		wantSim      int
+		wantClean    int
+	}{
+		{
+			name: "perfect score",
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      5,
+					ProtectedPipelock: 5,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         100,
+				},
+				Simulate: audit.SimulateResult{Percentage: 100},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  100,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			maxAgeDays:   MaxReceiptAgeDays,
+			wantScore:    100,
+			wantTransp:   100,
+			wantRecorder: 100,
+			wantSim:      100,
+			wantClean:    100,
+		},
+		{
+			name: "zero score all bad",
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers: 5,
+					Unprotected:  5,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: false,
+				},
+				Simulate:       audit.SimulateResult{Percentage: 0},
+				FlightRecorder: FlightRecorderCounts{},
+			},
+			maxAgeDays:   MaxReceiptAgeDays,
+			wantScore:    0,
+			wantTransp:   0,
+			wantRecorder: 0,
+			wantSim:      0,
+			wantClean:    0,
+		},
+		{
+			name: "partial transport coverage",
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      10,
+					ProtectedPipelock: 3,
+					ProtectedOther:    3,
+					Unprotected:       4,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         50,
+				},
+				Simulate: audit.SimulateResult{Percentage: 96},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  50,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			maxAgeDays:   MaxReceiptAgeDays,
+			wantScore:    63,
+			wantTransp:   60,
+			wantRecorder: 100,
+			wantSim:      96,
+			wantClean:    0,
+		},
+		{
+			name: "stale receipts reduce recorder to 50",
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      5,
+					ProtectedPipelock: 5,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         100,
+				},
+				Simulate: audit.SimulateResult{Percentage: 100},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  100,
+					LastReceiptAt: &staleReceipt,
+				},
+			},
+			maxAgeDays:   MaxReceiptAgeDays,
+			wantScore:    92,
+			wantTransp:   100,
+			wantRecorder: 50,
+			wantSim:      100,
+			wantClean:    100,
+		},
+		{
+			name: "no servers discovered vacuous truth",
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{Percentage: 100},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			maxAgeDays:   MaxReceiptAgeDays,
+			wantScore:    100,
+			wantTransp:   100,
+			wantRecorder: 100,
+			wantSim:      100,
+			wantClean:    100,
+		},
+		{
+			name: "only parse errors no servers",
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					ParseErrors: 3,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{Percentage: 100},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			maxAgeDays:   MaxReceiptAgeDays,
+			wantScore:    62,
+			wantTransp:   0,
+			wantRecorder: 100,
+			wantSim:      100,
+			wantClean:    50,
+		},
+		{
+			name: "unknown servers reduce cleanliness to 50",
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      3,
+					ProtectedPipelock: 3,
+					Unknown:           1,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{Percentage: 100},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			maxAgeDays:   MaxReceiptAgeDays,
+			wantScore:    87,
+			wantTransp:   100,
+			wantRecorder: 100,
+			wantSim:      100,
+			wantClean:    50,
+		},
+		{
+			name: "recorder active but zero receipts",
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      2,
+					ProtectedPipelock: 2,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         0,
+				},
+				Simulate:       audit.SimulateResult{Percentage: 80},
+				FlightRecorder: FlightRecorderCounts{},
+			},
+			maxAgeDays:   MaxReceiptAgeDays,
+			wantScore:    78,
+			wantTransp:   100,
+			wantRecorder: 0,
+			wantSim:      80,
+			wantClean:    100,
+		},
+		{
+			name: "max receipt age zero skips staleness check",
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      2,
+					ProtectedPipelock: 2,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{Percentage: 100},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &staleReceipt,
+				},
+			},
+			maxAgeDays:   0,
+			wantScore:    100,
+			wantTransp:   100,
+			wantRecorder: 100,
+			wantSim:      100,
+			wantClean:    100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score, factors := ComputeScore(tt.evidence, tt.maxAgeDays)
+			if score != tt.wantScore {
+				t.Errorf("score = %d, want %d", score, tt.wantScore)
+			}
+			if factors.TransportRatio.RawPercent != tt.wantTransp {
+				t.Errorf("transport raw = %d, want %d", factors.TransportRatio.RawPercent, tt.wantTransp)
+			}
+			if factors.RecorderHealth.RawPercent != tt.wantRecorder {
+				t.Errorf("recorder raw = %d, want %d", factors.RecorderHealth.RawPercent, tt.wantRecorder)
+			}
+			if factors.SimulatePassRate.RawPercent != tt.wantSim {
+				t.Errorf("simulate raw = %d, want %d", factors.SimulatePassRate.RawPercent, tt.wantSim)
+			}
+			if factors.DiscoveryCleanliness.RawPercent != tt.wantClean {
+				t.Errorf("cleanliness raw = %d, want %d", factors.DiscoveryCleanliness.RawPercent, tt.wantClean)
+			}
+		})
+	}
+}
+
+func TestEvaluatePolicy(t *testing.T) {
+	recentReceipt := time.Now().Add(-1 * time.Hour)
+	staleReceipt := time.Now().Add(-10 * 24 * time.Hour)
+
+	tests := []struct {
+		name         string
+		policy       string
+		evidence     EvidenceBundle
+		opts         VerifyOpts
+		wantFailures []string // rule names
+		wantWarnings []string
+	}{
+		{
+			name:   "none policy skips all checks",
+			policy: testPolicyNone,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{Unprotected: 5},
+			},
+			opts: VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+		},
+		{
+			name:   "enterprise clean pass",
+			policy: testPolicyEnterprise,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      3,
+					ProtectedPipelock: 3,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+						{Category: "Injection", Detected: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			opts: VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+		},
+		{
+			name:   "enterprise unprotected servers",
+			policy: testPolicyEnterprise,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      5,
+					ProtectedPipelock: 3,
+					Unprotected:       2,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			opts:         VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+			wantFailures: []string{ruleUnprotectedServers},
+		},
+		{
+			name:   "enterprise zero detection category",
+			policy: testPolicyEnterprise,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      3,
+					ProtectedPipelock: 3,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+						{Category: "SSRF", Detected: false},
+						{Category: "SSRF", Detected: false},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			opts:         VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+			wantFailures: []string{ruleZeroDetection},
+		},
+		{
+			name:   "limitation scenarios excluded from zero detection",
+			policy: testPolicyEnterprise,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      3,
+					ProtectedPipelock: 3,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+						{Category: "SSRF", Detected: false, Limitation: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			opts: VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+		},
+		{
+			name:   "enterprise recorder inactive",
+			policy: testPolicyEnterprise,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      3,
+					ProtectedPipelock: 3,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: false,
+					ReceiptCount:         0,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{},
+			},
+			opts:         VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+			wantFailures: []string{ruleRecorderInactive, ruleNoReceipts},
+		},
+		{
+			name:   "enterprise stale receipts",
+			policy: testPolicyEnterprise,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      3,
+					ProtectedPipelock: 3,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &staleReceipt,
+				},
+			},
+			opts:         VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+			wantFailures: []string{ruleStaleReceipts},
+		},
+		{
+			name:   "strict adds unknown servers",
+			policy: testPolicyStrict,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      3,
+					ProtectedPipelock: 3,
+					Unknown:           1,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			opts:         VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+			wantFailures: []string{ruleUnknownServers},
+		},
+		{
+			name:   "strict adds parse errors",
+			policy: testPolicyStrict,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      3,
+					ProtectedPipelock: 3,
+					ParseErrors:       2,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			opts:         VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+			wantFailures: []string{ruleDiscoveryParseError},
+		},
+		{
+			name:   "no servers warning",
+			policy: testPolicyEnterprise,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			opts:         VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+			wantWarnings: []string{warnNoServersDiscovered},
+		},
+		{
+			name:   "stale receipt check skipped when max age is 0",
+			policy: testPolicyEnterprise,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					TotalServers:      3,
+					ProtectedPipelock: 3,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &staleReceipt,
+				},
+			},
+			opts: VerifyOpts{MaxReceiptAge: 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			failures, warnings := EvaluatePolicy(tt.policy, tt.evidence, tt.opts)
+
+			gotRules := make(map[string]bool)
+			for _, f := range failures {
+				gotRules[f.Rule] = true
+			}
+			for _, wantRule := range tt.wantFailures {
+				if !gotRules[wantRule] {
+					t.Errorf("missing expected failure rule %q, got %v", wantRule, failures)
+				}
+			}
+			if len(failures) != len(tt.wantFailures) {
+				t.Errorf("failure count = %d, want %d; got %v", len(failures), len(tt.wantFailures), failures)
+			}
+
+			gotWarns := make(map[string]bool)
+			for _, w := range warnings {
+				gotWarns[w] = true
+			}
+			for _, wantWarn := range tt.wantWarnings {
+				if !gotWarns[wantWarn] {
+					t.Errorf("missing expected warning %q, got %v", wantWarn, warnings)
+				}
+			}
+			if len(warnings) != len(tt.wantWarnings) {
+				t.Errorf("warning count = %d, want %d; got %v", len(warnings), len(tt.wantWarnings), warnings)
+			}
+		})
+	}
+}
+
+func TestVerifyCapsule(t *testing.T) {
+	recentReceipt := time.Now().Add(-1 * time.Hour)
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey(): %v", err)
+	}
+
+	perfectEvidence := EvidenceBundle{
+		Discover: DiscoverEvidence{
+			TotalServers:      5,
+			ProtectedPipelock: 5,
+		},
+		VerifyInstall: VerifyInstallEvidence{
+			FlightRecorderActive: true,
+			ReceiptCount:         100,
+		},
+		Simulate: audit.SimulateResult{
+			Percentage: 100,
+			Scenarios: []audit.ScenarioResult{
+				{Category: "DLP", Detected: true},
+				{Category: "Injection", Detected: true},
+			},
+		},
+		FlightRecorder: FlightRecorderCounts{
+			ReceiptCount:  100,
+			LastReceiptAt: &recentReceipt,
+		},
+	}
+
+	badEvidence := EvidenceBundle{
+		Discover: DiscoverEvidence{
+			TotalServers: 5,
+			Unprotected:  5,
+		},
+		VerifyInstall: VerifyInstallEvidence{
+			FlightRecorderActive: false,
+		},
+		Simulate: audit.SimulateResult{
+			Percentage: 0,
+			Scenarios: []audit.ScenarioResult{
+				{Category: "DLP", Detected: false},
+			},
+		},
+		FlightRecorder: FlightRecorderCounts{},
+	}
+
+	emitCapsule := func(t *testing.T, evidence EvidenceBundle) *Capsule {
+		t.Helper()
+		capsule, err := Emit(config.Defaults(), Options{
+			SigningKey:     priv,
+			EvidenceBundle: bundlePtr(evidence),
+		})
+		if err != nil {
+			t.Fatalf("Emit(): %v", err)
+		}
+		return capsule
+	}
+
+	t.Run("pass with perfect score", func(t *testing.T) {
+		capsule := emitCapsule(t, perfectEvidence)
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:        testPolicyEnterprise,
+			MinScore:      85,
+			MaxReceiptAge: MaxReceiptAgeDays,
+		})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		if !result.Verified {
+			t.Error("Verified = false, want true")
+		}
+		if !result.Passed {
+			t.Error("Passed = false, want true")
+		}
+		if result.Score != 100 {
+			t.Errorf("Score = %d, want 100", result.Score)
+		}
+	})
+
+	t.Run("fail due to low score", func(t *testing.T) {
+		capsule := emitCapsule(t, badEvidence)
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:        testPolicyNone,
+			MinScore:      85,
+			MaxReceiptAge: MaxReceiptAgeDays,
+		})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		if result.Passed {
+			t.Error("Passed = true, want false (low score)")
+		}
+	})
+
+	t.Run("fail due to hard failures", func(t *testing.T) {
+		capsule := emitCapsule(t, badEvidence)
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:        testPolicyEnterprise,
+			MinScore:      0,
+			MaxReceiptAge: MaxReceiptAgeDays,
+		})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		if result.Passed {
+			t.Error("Passed = true, want false (hard failures)")
+		}
+		if len(result.HardFailures) == 0 {
+			t.Error("HardFailures = empty, want at least one")
+		}
+	})
+
+	t.Run("signature failure returns error", func(t *testing.T) {
+		capsule := emitCapsule(t, perfectEvidence)
+		capsule.ConfigHash = "tampered"
+		_, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:   testPolicyEnterprise,
+			MinScore: 85,
+		})
+		if err == nil {
+			t.Fatal("VerifyCapsule() error = nil, want signature failure")
+		}
+	})
+
+	t.Run("config hash match", func(t *testing.T) {
+		capsule := emitCapsule(t, perfectEvidence)
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:        testPolicyEnterprise,
+			MinScore:      85,
+			ConfigHash:    capsule.ConfigHash,
+			MaxReceiptAge: MaxReceiptAgeDays,
+		})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		if result.ConfigHashMatch == nil {
+			t.Fatal("ConfigHashMatch = nil, want non-nil")
+		}
+		if !*result.ConfigHashMatch {
+			t.Error("ConfigHashMatch = false, want true")
+		}
+		if result.Passed != true {
+			t.Error("Passed = false, want true")
+		}
+	})
+
+	t.Run("config hash mismatch adds hard failure", func(t *testing.T) {
+		capsule := emitCapsule(t, perfectEvidence)
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:        testPolicyEnterprise,
+			MinScore:      0,
+			ConfigHash:    "wrong-hash",
+			MaxReceiptAge: MaxReceiptAgeDays,
+		})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		if result.ConfigHashMatch == nil || *result.ConfigHashMatch {
+			t.Error("ConfigHashMatch should be false")
+		}
+		found := false
+		for _, f := range result.HardFailures {
+			if f.Rule == ruleConfigHashMismatch {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing %s hard failure, got %v", ruleConfigHashMismatch, result.HardFailures)
+		}
+	})
+
+	t.Run("require discovery fails when no servers", func(t *testing.T) {
+		emptyDiscovery := EvidenceBundle{
+			Discover: DiscoverEvidence{},
+			VerifyInstall: VerifyInstallEvidence{
+				FlightRecorderActive: true,
+				ReceiptCount:         10,
+			},
+			Simulate: audit.SimulateResult{
+				Percentage: 100,
+				Scenarios: []audit.ScenarioResult{
+					{Category: "DLP", Detected: true},
+				},
+			},
+			FlightRecorder: FlightRecorderCounts{
+				ReceiptCount:  10,
+				LastReceiptAt: &recentReceipt,
+			},
+		}
+		capsule := emitCapsule(t, emptyDiscovery)
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:           testPolicyEnterprise,
+			MinScore:         0,
+			MaxReceiptAge:    MaxReceiptAgeDays,
+			RequireDiscovery: true,
+		})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		if result.Passed {
+			t.Error("Passed = true, want false (require-discovery)")
+		}
+	})
+
+	t.Run("default max receipt age applied", func(t *testing.T) {
+		capsule := emitCapsule(t, perfectEvidence)
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:   testPolicyEnterprise,
+			MinScore: 0,
+		})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		// With recent receipt and default age, should pass.
+		if !result.Verified {
+			t.Error("Verified = false, want true")
+		}
+	})
+
+	t.Run("scoring and policy version populated", func(t *testing.T) {
+		capsule := emitCapsule(t, perfectEvidence)
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:        testPolicyNone,
+			MaxReceiptAge: MaxReceiptAgeDays,
+		})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		if result.ScoringVersion != ScoringVersion {
+			t.Errorf("ScoringVersion = %q, want %q", result.ScoringVersion, ScoringVersion)
+		}
+		if result.PolicyVersion != SchemaVersion {
+			t.Errorf("PolicyVersion = %q, want %q", result.PolicyVersion, SchemaVersion)
+		}
+	})
+}
+
+func TestHasZeroDetectionCategory(t *testing.T) {
+	tests := []struct {
+		name      string
+		scenarios []audit.ScenarioResult
+		want      bool
+	}{
+		{
+			name:      "empty scenarios",
+			scenarios: nil,
+			want:      false,
+		},
+		{
+			name: "all detected",
+			scenarios: []audit.ScenarioResult{
+				{Category: "DLP", Detected: true},
+				{Category: "DLP", Detected: true},
+				{Category: "SSRF", Detected: true},
+			},
+			want: false,
+		},
+		{
+			name: "one category all undetected",
+			scenarios: []audit.ScenarioResult{
+				{Category: "DLP", Detected: true},
+				{Category: "SSRF", Detected: false},
+				{Category: "SSRF", Detected: false},
+			},
+			want: true,
+		},
+		{
+			name: "partial detection in category ok",
+			scenarios: []audit.ScenarioResult{
+				{Category: "DLP", Detected: true},
+				{Category: "SSRF", Detected: true},
+				{Category: "SSRF", Detected: false},
+			},
+			want: false,
+		},
+		{
+			name: "limitation exclusion",
+			scenarios: []audit.ScenarioResult{
+				{Category: "DLP", Detected: true},
+				{Category: "SSRF", Detected: false, Limitation: true},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasZeroDetectionCategory(tt.scenarios)
+			if got != tt.want {
+				t.Errorf("hasZeroDetectionCategory() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFactorDetail(t *testing.T) {
+	d := factor(60, 25)
+	if d.RawPercent != 60 {
+		t.Errorf("RawPercent = %d, want 60", d.RawPercent)
+	}
+	if d.Weight != 25 {
+		t.Errorf("Weight = %d, want 25", d.Weight)
+	}
+	if d.Weighted != 15 {
+		t.Errorf("Weighted = %d, want 15 (60*25/100)", d.Weighted)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `pipelock posture verify` for enterprise posture capsule
verification with deterministic scoring and configurable policy gates.

- **Score model (0-100):** weighted from 4 evidence factors --
  transport coverage (25), flight recorder health (15), simulate
  pass rate (35), discovery cleanliness (25). Deterministic and
  auditable from the evidence bundle.
- **Policy gates** override score with hard pass/fail rules:
  - `enterprise`: unprotected servers, inactive recorder, no/stale
    receipts, 0% simulate category, config hash mismatch
  - `strict`: enterprise + unknown servers, parse errors
  - `none`: score only, no hard gates
- **Exit codes:** 0 (verified + passed), 1 (integrity/authenticity
  failure), 2 (verified but policy failed)
- **CLI flags:** `--proof`, `--key`, `--policy`, `--min-score`,
  `--max-age`, `--max-receipt-age`, `--config`, `--json`,
  `--require-discovery`
- **Human-readable output** shows per-factor scores with weighted
  contributions, hard failures, and warnings
- **JSON output** via `--json` for CI/CD pipeline integration

Score weights and policy gates align with the existing `pipelock
assess` philosophy: weighted score for trending, non-compensating
caps for procurement and audit.

Completes the verification half of the posture capsule system
started in #391.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a verify command to validate signed posture capsules across policy modes (none, enterprise, strict). Introduces deterministic scoring with weighted factor breakdowns, configurable minimum score, capsule age and receipt-freshness checks, optional config-hash comparison, JSON or human-readable output, discovery enforcement, and distinct exit codes for policy vs integrity failures.
  * Exposed config hashing for external verification workflows.

* **Tests**
  * Comprehensive unit and end-to-end tests covering verification flows, scoring, policy gates, flags, output formats, and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->