### PR TITLE
fix: strict posture policy requires MCP server discovery

### DIFF
--- a/internal/cli/posture.go
+++ b/internal/cli/posture.go
@@ -22,8 +22,14 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
-// Exit codes for posture verify. Exit 0 = passed, 1 = integrity failure
-// (bad signature, expired, bad schema), 2 = verified but policy failed.
+// Exit codes for posture verify. These are part of the CLI's stable contract.
+// CI pipelines should key on these values:
+//
+//	0 = Verification passed: signature valid, score meets minimum, all policy gates passed.
+//	1 = Verification could not complete: flag parse error, bad proof file, bad key,
+//	    bad signature, expired capsule, or schema mismatch.
+//	2 = Verified but failed: signature is valid, but policy gates or minimum score not met.
+//	    This means the capsule is authentic but the environment doesn't meet the policy.
 const (
 	exitVerifyIntegrity  = 1
 	exitVerifyPolicyFail = 2
@@ -66,9 +72,10 @@ func postureVerifyCmd() *cobra.Command {
 proof.json capsule.
 
 Exit codes:
-  0  Verified and passed all policy gates
-  1  Integrity/authenticity failure (bad signature, expired, bad schema)
-  2  Verified but policy failed (hard gate violation or score below minimum)`,
+  0  Verification passed: signature valid, score meets minimum, all policy gates passed
+  1  Verification could not complete: flag parse error, bad proof file, bad key,
+     bad signature, expired capsule, or schema mismatch
+  2  Verified but failed: signature is valid, but policy gates or minimum score not met`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			maxAgeDays, err := parseDays(maxAgeStr)
@@ -259,7 +266,7 @@ func exitVerifyIntegrityError(
 			Passed:         false,
 			Error:          err.Error(),
 			Policy:         policy,
-			PolicyVersion:  posturepkg.SchemaVersion,
+			PolicyVersion:  posturepkg.PolicyVersion,
 			ScoringVersion: posturepkg.ScoringVersion,
 		}
 		if capsule != nil {

--- a/internal/cli/posture_verify_test.go
+++ b/internal/cli/posture_verify_test.go
@@ -238,6 +238,12 @@ func TestPostureVerifyJSONOutput(t *testing.T) {
 	if result.Score != 100 {
 		t.Errorf("result.Score = %d, want 100", result.Score)
 	}
+	if result.PolicyVersion != posturepkg.PolicyVersion {
+		t.Errorf("result.PolicyVersion = %q, want %q", result.PolicyVersion, posturepkg.PolicyVersion)
+	}
+	if result.ScoringVersion != posturepkg.ScoringVersion {
+		t.Errorf("result.ScoringVersion = %q, want %q", result.ScoringVersion, posturepkg.ScoringVersion)
+	}
 }
 
 func TestPostureVerifyJSONBadSignature(t *testing.T) {
@@ -277,6 +283,9 @@ func TestPostureVerifyJSONBadSignature(t *testing.T) {
 	}
 	if !strings.Contains(result.Error, "verification failed") {
 		t.Errorf("result.Error = %q, want verification failure", result.Error)
+	}
+	if result.PolicyVersion != posturepkg.PolicyVersion {
+		t.Errorf("result.PolicyVersion = %q, want %q", result.PolicyVersion, posturepkg.PolicyVersion)
 	}
 }
 
@@ -760,7 +769,7 @@ func TestPostureVerifyRequireDiscovery(t *testing.T) {
 	assertExitCode(t, err, exitVerifyPolicyFail)
 }
 
-func TestPostureVerifyRequireDiscoveryIgnoresParseErrors(t *testing.T) {
+func TestPostureVerifyRequireDiscoveryTreatsParseErrorsAsNoServers(t *testing.T) {
 	recent := time.Now().Add(-1 * time.Hour)
 	parseOnly := posturepkg.EvidenceBundle{
 		Discover: posturepkg.DiscoverEvidence{
@@ -803,6 +812,113 @@ func TestPostureVerifyRequireDiscoveryIgnoresParseErrors(t *testing.T) {
 		t.Fatal("cmd.Execute() = nil, want error for parse-errors-only discovery")
 	}
 	assertExitCode(t, err, exitVerifyPolicyFail)
+}
+
+func TestPostureVerifyStrictTreatsParseErrorsAsNoServers(t *testing.T) {
+	recent := time.Now().Add(-1 * time.Hour)
+	parseOnly := posturepkg.EvidenceBundle{
+		Discover: posturepkg.DiscoverEvidence{
+			ParseErrors: 2,
+		},
+		VerifyInstall: posturepkg.VerifyInstallEvidence{
+			FlightRecorderActive: true,
+			ReceiptCount:         10,
+		},
+		Simulate: audit.SimulateResult{
+			Total:      1,
+			Passed:     1,
+			Percentage: 100,
+			Scenarios: []audit.ScenarioResult{
+				{Category: "DLP", Detected: true},
+			},
+		},
+		FlightRecorder: posturepkg.FlightRecorderCounts{
+			ReceiptCount:  10,
+			LastReceiptAt: &recent,
+		},
+	}
+
+	fix := newTestVerifyFixture(t, parseOnly)
+
+	var stdout bytes.Buffer
+	cmd := rootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--policy", testVerifyPolicyStrict,
+		"--min-score", "0",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for strict parse-errors-only discovery")
+	}
+	assertExitCode(t, err, exitVerifyPolicyFail)
+
+	output := stdout.String()
+	if !strings.Contains(output, "FAIL: no_servers_discovered") {
+		t.Fatalf("output missing no_servers_discovered failure, got: %s", output)
+	}
+	if !strings.Contains(output, "FAIL: discovery_parse_errors") {
+		t.Fatalf("output missing discovery_parse_errors failure, got: %s", output)
+	}
+	if strings.Contains(output, "WARN: no_servers_discovered") {
+		t.Fatalf("output should not duplicate no_servers_discovered as warning under strict, got: %s", output)
+	}
+}
+
+func TestPostureVerifyStrictFailsEmptyDiscovery(t *testing.T) {
+	recent := time.Now().Add(-1 * time.Hour)
+	emptyDiscover := posturepkg.EvidenceBundle{
+		Discover: posturepkg.DiscoverEvidence{},
+		VerifyInstall: posturepkg.VerifyInstallEvidence{
+			FlightRecorderActive: true,
+			ReceiptCount:         10,
+		},
+		Simulate: audit.SimulateResult{
+			Total:      1,
+			Passed:     1,
+			Percentage: 100,
+			Scenarios: []audit.ScenarioResult{
+				{Category: "DLP", Detected: true},
+			},
+		},
+		FlightRecorder: posturepkg.FlightRecorderCounts{
+			ReceiptCount:  10,
+			LastReceiptAt: &recent,
+		},
+	}
+
+	fix := newTestVerifyFixture(t, emptyDiscover)
+
+	var stdout bytes.Buffer
+	cmd := rootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"posture", "verify",
+		"--proof", fix.ProofPath,
+		"--key", fix.PubKeyPath,
+		"--policy", testVerifyPolicyStrict,
+		"--min-score", "0",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("cmd.Execute() = nil, want error for strict empty discovery")
+	}
+	assertExitCode(t, err, exitVerifyPolicyFail)
+
+	output := stdout.String()
+	if !strings.Contains(output, "FAIL: no_servers_discovered") {
+		t.Fatalf("output missing no_servers_discovered failure, got: %s", output)
+	}
+	if strings.Contains(output, "WARN: no_servers_discovered") {
+		t.Fatalf("output should not duplicate no_servers_discovered as warning under strict, got: %s", output)
+	}
 }
 
 func TestPostureVerifyPolicyTypo(t *testing.T) {

--- a/internal/posture/score.go
+++ b/internal/posture/score.go
@@ -15,7 +15,7 @@ import (
 const (
 	PolicyNone       = "none"       // score only, no hard gates
 	PolicyEnterprise = "enterprise" // standard hard gates
-	PolicyStrict     = "strict"     // enterprise + unknown/parse_error gates
+	PolicyStrict     = "strict"     // enterprise + no-server/unknown/parse-error gates
 )
 
 // ScoreWeights are the factor weights (must sum to 100).
@@ -25,6 +25,10 @@ const (
 	WeightSimulatePassRate     = 35
 	WeightDiscoveryCleanliness = 25
 )
+
+// PolicyVersion tracks verification policy semantics for reproducibility.
+// Bump this when the same evidence may verify differently under new policy logic.
+const PolicyVersion = "2"
 
 // ScoringVersion tracks the score model for reproducibility.
 const ScoringVersion = "1"
@@ -157,9 +161,9 @@ func evaluatePolicyAt(policy string, evidence EvidenceBundle, opts VerifyOpts, n
 		return failures, warnings
 	}
 
-	// Warning: no servers discovered (vacuous truth, not a failure).
-	totalScannable := evidence.Discover.TotalServers + evidence.Discover.ParseErrors
-	if totalScannable == 0 {
+	// Enterprise warns when discovery produced no usable evidence at all.
+	// Strict upgrades zero successfully discovered servers to a hard failure.
+	if policy != PolicyStrict && noDiscoveryEvidence(evidence.Discover) {
 		warnings = append(warnings, warnNoServersDiscovered)
 	}
 
@@ -212,6 +216,13 @@ func evaluatePolicyAt(policy string, evidence EvidenceBundle, opts VerifyOpts, n
 
 	// Strict gates (superset of enterprise).
 	if policy == PolicyStrict {
+		if noServersDiscovered(evidence.Discover) {
+			failures = append(failures, HardFailure{
+				Rule:   ruleNoServersDiscovered,
+				Detail: "strict policy requires at least one discoverable MCP server",
+			})
+		}
+
 		if evidence.Discover.Unknown > 0 {
 			failures = append(failures, HardFailure{
 				Rule:   ruleUnknownServers,
@@ -247,7 +258,7 @@ func VerifyCapsule(capsule *Capsule, trustedKey ed25519.PublicKey, opts VerifyOp
 	result := &VerifyResult{
 		Verified:       true,
 		Policy:         opts.Policy,
-		PolicyVersion:  SchemaVersion,
+		PolicyVersion:  PolicyVersion,
 		ScoringVersion: ScoringVersion,
 		GeneratedAt:    capsule.GeneratedAt,
 		ExpiresAt:      capsule.ExpiresAt,
@@ -288,9 +299,10 @@ func VerifyCapsule(capsule *Capsule, trustedKey ed25519.PublicKey, opts VerifyOp
 		})
 	}
 
-	// Require discovery gate.
-	if opts.RequireDiscovery {
-		if capsule.Evidence.Discover.TotalServers == 0 {
+	// Require discovery gate. Strict policy already fails on empty discovery,
+	// so only add this for non-strict policies with the explicit flag.
+	if opts.RequireDiscovery && opts.Policy != PolicyStrict {
+		if noServersDiscovered(capsule.Evidence.Discover) {
 			result.HardFailures = append(result.HardFailures, HardFailure{
 				Rule:   ruleNoServersDiscovered,
 				Detail: "0 servers discovered (--require-discovery)",
@@ -345,6 +357,14 @@ func validateCapsuleTimesAt(capsule *Capsule, maxFutureSkew time.Duration, now t
 		return fmt.Errorf("last_receipt_at %s is more than %s in the future", capsule.Evidence.FlightRecorder.LastReceiptAt.Format(time.RFC3339), maxFutureSkew)
 	}
 	return nil
+}
+
+func noServersDiscovered(d DiscoverEvidence) bool {
+	return d.TotalServers == 0
+}
+
+func noDiscoveryEvidence(d DiscoverEvidence) bool {
+	return d.TotalServers == 0 && d.ParseErrors == 0
 }
 
 func computeTransportPct(d DiscoverEvidence) int {

--- a/internal/posture/score_test.go
+++ b/internal/posture/score_test.go
@@ -643,6 +643,97 @@ func TestEvaluatePolicy(t *testing.T) {
 			wantWarnings: []string{warnNoServersDiscovered},
 		},
 		{
+			name:   "strict fails empty discovery",
+			policy: testPolicyStrict,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			opts:         VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+			wantFailures: []string{ruleNoServersDiscovered},
+		},
+		{
+			name:   "strict parse-errors-only also fails no discovery",
+			policy: testPolicyStrict,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					ParseErrors: 2,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			opts:         VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+			wantFailures: []string{ruleNoServersDiscovered, ruleDiscoveryParseError},
+		},
+		{
+			name:   "enterprise allows empty discovery with warning only",
+			policy: testPolicyEnterprise,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			opts:         VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+			wantWarnings: []string{warnNoServersDiscovered},
+		},
+		{
+			name:   "enterprise parse-errors-only no warning",
+			policy: testPolicyEnterprise,
+			evidence: EvidenceBundle{
+				Discover: DiscoverEvidence{
+					ParseErrors: 2,
+				},
+				VerifyInstall: VerifyInstallEvidence{
+					FlightRecorderActive: true,
+					ReceiptCount:         10,
+				},
+				Simulate: audit.SimulateResult{
+					Scenarios: []audit.ScenarioResult{
+						{Category: "DLP", Detected: true},
+					},
+				},
+				FlightRecorder: FlightRecorderCounts{
+					ReceiptCount:  10,
+					LastReceiptAt: &recentReceipt,
+				},
+			},
+			opts: VerifyOpts{MaxReceiptAge: MaxReceiptAgeDays},
+		},
+		{
 			name:   "stale receipt check skipped when max age is 0",
 			policy: testPolicyEnterprise,
 			evidence: EvidenceBundle{
@@ -960,7 +1051,7 @@ func TestVerifyCapsule(t *testing.T) {
 		}
 	})
 
-	t.Run("require discovery ignores parse errors", func(t *testing.T) {
+	t.Run("require discovery treats parse errors as no servers", func(t *testing.T) {
 		parseOnly := EvidenceBundle{
 			Discover: DiscoverEvidence{
 				ParseErrors: 2,
@@ -998,6 +1089,62 @@ func TestVerifyCapsule(t *testing.T) {
 		}
 		if !found {
 			t.Fatalf("missing %s hard failure: %v", ruleNoServersDiscovered, result.HardFailures)
+		}
+	})
+
+	t.Run("strict treats parse errors as no successful discovery", func(t *testing.T) {
+		parseOnly := EvidenceBundle{
+			Discover: DiscoverEvidence{
+				ParseErrors: 2,
+			},
+			VerifyInstall: VerifyInstallEvidence{
+				FlightRecorderActive: true,
+				ReceiptCount:         10,
+			},
+			Simulate: audit.SimulateResult{
+				Percentage: 100,
+				Scenarios: []audit.ScenarioResult{
+					{Category: "DLP", Detected: true},
+				},
+			},
+			FlightRecorder: FlightRecorderCounts{
+				ReceiptCount:  10,
+				LastReceiptAt: &recentReceipt,
+			},
+		}
+		capsule := emitCapsule(t, parseOnly)
+		result, err := VerifyCapsule(capsule, pub, VerifyOpts{
+			Policy:        testPolicyStrict,
+			MinScore:      0,
+			MaxReceiptAge: MaxReceiptAgeDays,
+		})
+		if err != nil {
+			t.Fatalf("VerifyCapsule(): %v", err)
+		}
+		if result.Passed {
+			t.Error("Passed = true, want false (strict parse-errors-only discovery)")
+		}
+
+		foundNoServers := false
+		foundParseErrors := false
+		for _, f := range result.HardFailures {
+			if f.Rule == ruleNoServersDiscovered {
+				foundNoServers = true
+			}
+			if f.Rule == ruleDiscoveryParseError {
+				foundParseErrors = true
+			}
+		}
+		if !foundNoServers {
+			t.Fatalf("missing %s hard failure: %v", ruleNoServersDiscovered, result.HardFailures)
+		}
+		if !foundParseErrors {
+			t.Fatalf("missing %s hard failure: %v", ruleDiscoveryParseError, result.HardFailures)
+		}
+		for _, warn := range result.Warnings {
+			if warn == warnNoServersDiscovered {
+				t.Fatalf("unexpected %s warning under strict policy: %v", warnNoServersDiscovered, result.Warnings)
+			}
 		}
 	})
 
@@ -1236,8 +1383,8 @@ func TestVerifyCapsule(t *testing.T) {
 		if result.ScoringVersion != ScoringVersion {
 			t.Errorf("ScoringVersion = %q, want %q", result.ScoringVersion, ScoringVersion)
 		}
-		if result.PolicyVersion != SchemaVersion {
-			t.Errorf("PolicyVersion = %q, want %q", result.PolicyVersion, SchemaVersion)
+		if result.PolicyVersion != PolicyVersion {
+			t.Errorf("PolicyVersion = %q, want %q", result.PolicyVersion, PolicyVersion)
 		}
 	})
 }

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -669,9 +669,13 @@ func TestWSProxyDLPAuditMode(t *testing.T) {
 	}
 }
 
+// TestWSProxyDLPAuditMode_PropagatesWarnContext verifies that the actual
+// client->upstream relay path preserves DLP warn metadata even though
+// wsRelay.run wraps the request context with context.WithTimeout.
 func TestWSProxyDLPAuditMode_PropagatesWarnContext(t *testing.T) {
 	backendAddr, backendCleanup := wsEchoServer(t)
 	defer backendCleanup()
+	wantURL := "http://" + backendAddr + "/"
 
 	logger := audit.NewNop()
 	cfg := config.Defaults()
@@ -747,8 +751,11 @@ func TestWSProxyDLPAuditMode_PropagatesWarnContext(t *testing.T) {
 	if got.Method != "WS" {
 		t.Fatalf("method = %q, want %q", got.Method, "WS")
 	}
-	if got.URL == "" {
-		t.Fatal("expected websocket warn context to carry URL")
+	if got.URL != wantURL {
+		t.Fatalf("url = %q, want %q", got.URL, wantURL)
+	}
+	if got.ClientIP == "" {
+		t.Fatal("expected websocket warn context to carry client IP")
 	}
 
 	reply, _, err := wsutil.ReadServerData(conn)
@@ -2493,6 +2500,7 @@ func TestWSProxyInjectionStrip(t *testing.T) {
 func TestWSProxyHeaderDLPAuditMode(t *testing.T) {
 	backendAddr, backendCleanup := wsEchoServer(t)
 	defer backendCleanup()
+	wantURL := "http://" + backendAddr + "/"
 
 	// Use a file-backed logger to capture the anomaly log entry.
 	logFile := filepath.Join(t.TempDir(), "audit.log")
@@ -2587,6 +2595,9 @@ func TestWSProxyHeaderDLPAuditMode(t *testing.T) {
 	}
 	if got.Method != "WS" {
 		t.Fatalf("method = %q, want %q", got.Method, "WS")
+	}
+	if got.URL != wantURL {
+		t.Fatalf("url = %q, want %q", got.URL, wantURL)
 	}
 
 	// Verify the connection works (traffic allowed through despite DLP match).


### PR DESCRIPTION
## Summary
- Strict posture policy now hard-fails when zero MCP servers are discovered. Previously an empty discovery bundle could score 100/100 and still pass strict — the score model is unchanged (vacuous truth remains 100%), but the policy gate now rejects it
- Enterprise policy unchanged — empty discovery remains a warning for non-MCP or remote-managed deployments
- PolicyVersion bumped to "2" (decoupled from SchemaVersion) so consumers can distinguish verification results produced under the new policy semantics
- Exit code contract for `posture verify` documented in CLI help text and code comments (0=passed, 1=could not complete, 2=verified but failed)
- WebSocket DLP warn context tests strengthened with exact URL and client IP assertions through the relay timeout context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PolicyVersion field in JSON verification results to correctly represent policy version instead of schema version.

* **Improvements**
  * Enhanced posture verify CLI exit code documentation with explicit definitions for CI automation scenarios.
  * Strict policy mode now enforces additional verification gates for empty discovery and discovery parse errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->