### PR TITLE
feat: add pipelock session CLI for airlock inspection and recovery

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
             internal/proxy/adaptive_coverage_test.go
             internal/proxy/allowlist_scoring_test.go
             internal/proxy/session_api.go
+            internal/cli/session/resolver.go
             internal/gitprotect/diffscan_test.go
             internal/config/config_test.go
             internal/cli/test.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sidecar injection init:** `pipelock init sidecar --inject-spec <manifest>` generates a sidecar patch for Deployment, StatefulSet, Job, and CronJob workloads. Three output formats: strategic-merge patch, Kustomize overlay, and Helm values fragment. Includes canary verification, diff preview, and idempotent re-runs.
 - **Default agent identity:** new `default_agent_identity` config field provides a fallback agent name for sidecar deployments where the upstream container does not send an `X-Pipelock-Agent` header. Derived automatically from workload kind/name during `init sidecar`.
 - **Exemption audit emission:** response scan exemptions (exempt domains and suppressed findings) now emit a `pipelock_response_scan_exempt_total` Prometheus counter with `reason` and `transport` labels across all proxy transports.
+- **`pipelock session` operator CLI:** five subcommands (`list`, `inspect`, `explain`, `release`, `terminate`) plus an interactive `recover` wrapper for airlock recovery. The CLI talks to the session admin API and resolves the endpoint from `--api-url`/`--api-token` flags, `PIPELOCK_API_URL`/`PIPELOCK_KILLSWITCH_API_TOKEN` env vars, or the pipelock config file.
+- **Session admin API: inspect, explain, terminate endpoints.** `GET /api/v1/sessions/{key}` returns full session detail including airlock entry time, in-flight count, and recent events. `GET /api/v1/sessions/{key}/explain` returns the recorded trigger, evidence, and next auto-deescalation estimate. `POST /api/v1/sessions/{key}/terminate` performs a destructive full tear-down (cancel in-flight, reset enforcement, clear CEE state). Each endpoint has its own 10/minute rate-limit bucket.
+- **Session list tier filter.** `GET /api/v1/sessions?tier=hard` filters snapshots by current airlock tier. `normal` is accepted as an alias for `none`.
 
 ### Security Hardening
 

--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -215,7 +215,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '\b(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'

--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -215,7 +215,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'

--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -474,3 +474,18 @@ seed_phrase_detection:
 #   enabled: false
 #   listen: ":8890"
 #   upstream: "http://localhost:7899"
+
+# ---- airlock (per-session quarantine) ----
+# Per-session graduated containment: soft -> hard -> drain. Disabled in
+# presets — enable with deliberate trigger/timer tuning per deployment.
+airlock:
+  enabled: false
+  triggers:
+    on_elevated: none
+    on_high: soft
+    on_critical: hard
+  timers:
+    soft_minutes: 5
+    hard_minutes: 15
+    drain_minutes: 0
+    drain_timeout_seconds: 30

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -230,7 +230,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -230,7 +230,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '\b(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -533,3 +533,18 @@ seed_phrase_detection:
 #   enabled: false
 #   listen: ":8890"
 #   upstream: "http://localhost:7899"
+
+# ---- airlock (per-session quarantine) ----
+# Per-session graduated containment: soft -> hard -> drain. Disabled in
+# presets — enable with deliberate trigger/timer tuning per deployment.
+airlock:
+  enabled: false
+  triggers:
+    on_elevated: none
+    on_high: soft
+    on_critical: hard
+  timers:
+    soft_minutes: 5
+    hard_minutes: 15
+    drain_minutes: 0
+    drain_timeout_seconds: 30

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -247,7 +247,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -247,7 +247,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '\b(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -517,3 +517,18 @@ seed_phrase_detection:
 #   enabled: false
 #   listen: ":8890"
 #   upstream: "http://localhost:7899"
+
+# ---- airlock (per-session quarantine) ----
+# Per-session graduated containment: soft -> hard -> drain. Disabled in
+# presets — enable with deliberate trigger/timer tuning per deployment.
+airlock:
+  enabled: false
+  triggers:
+    on_elevated: none
+    on_high: soft
+    on_critical: hard
+  timers:
+    soft_minutes: 5
+    hard_minutes: 15
+    drain_minutes: 0
+    drain_timeout_seconds: 30

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -248,7 +248,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '\b(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -518,3 +518,18 @@ seed_phrase_detection:
 #   enabled: false
 #   listen: ":8890"
 #   upstream: "http://localhost:7899"
+
+# ---- airlock (per-session quarantine) ----
+# Per-session graduated containment: soft -> hard -> drain. Disabled in
+# presets — enable with deliberate trigger/timer tuning per deployment.
+airlock:
+  enabled: false
+  triggers:
+    on_elevated: none
+    on_high: soft
+    on_critical: hard
+  timers:
+    soft_minutes: 5
+    hard_minutes: 15
+    drain_minutes: 0
+    drain_timeout_seconds: 30

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -248,7 +248,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -255,7 +255,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '\b(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -514,3 +514,18 @@ seed_phrase_detection:
 #   enabled: false
 #   listen: ":8890"
 #   upstream: "http://localhost:7899"
+
+# ---- airlock (per-session quarantine) ----
+# Per-session graduated containment: soft -> hard -> drain. Disabled in
+# presets — enable with deliberate trigger/timer tuning per deployment.
+airlock:
+  enabled: false
+  triggers:
+    on_elevated: none
+    on_high: soft
+    on_critical: hard
+  timers:
+    soft_minutes: 5
+    hard_minutes: 15
+    drain_minutes: 0
+    drain_timeout_seconds: 30

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -255,7 +255,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -534,3 +534,18 @@ seed_phrase_detection:
 #   enabled: false
 #   listen: ":8890"
 #   upstream: "http://localhost:7899"
+
+# ---- airlock (per-session quarantine) ----
+# Per-session graduated containment: soft -> hard -> drain. Disabled in
+# presets — enable with deliberate trigger/timer tuning per deployment.
+airlock:
+  enabled: false
+  triggers:
+    on_elevated: none
+    on_high: soft
+    on_critical: hard
+  timers:
+    soft_minutes: 5
+    hard_minutes: 15
+    drain_minutes: 0
+    drain_timeout_seconds: 30

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -231,7 +231,7 @@ dlp:
       severity: critical
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
       severity: critical
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -231,7 +231,7 @@ dlp:
       severity: critical
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '\b(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
       severity: critical
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -229,7 +229,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -229,7 +229,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '\b(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -542,3 +542,18 @@ seed_phrase_detection:
 #   enabled: false
 #   listen: ":8890"
 #   upstream: "http://localhost:7899"
+
+# ---- airlock (per-session quarantine) ----
+# Per-session graduated containment: soft -> hard -> drain. Disabled in
+# presets — enable with deliberate trigger/timer tuning per deployment.
+airlock:
+  enabled: false
+  triggers:
+    on_elevated: none
+    on_high: soft
+    on_critical: hard
+  timers:
+    soft_minutes: 5
+    hard_minutes: 15
+    drain_minutes: 0
+    drain_timeout_seconds: 30

--- a/docs/cli/session.md
+++ b/docs/cli/session.md
@@ -1,0 +1,182 @@
+# pipelock session — operator CLI for airlock recovery
+
+The `pipelock session` command group is the operator-facing surface on
+top of pipelock's per-session airlock. Use it to inspect sessions that
+adaptive enforcement has quarantined, explain why they are in their
+current tier, and either release them back to normal or terminate them
+entirely.
+
+Every subcommand talks to the running pipelock instance's session admin
+API. The admin API is gated by the `kill_switch.api_token` setting — if
+you have not set that token, the CLI will refuse to connect. See
+[configuration.md](../configuration.md) for the admin API options.
+
+## Quick reference
+
+| Command | Purpose |
+|---|---|
+| `pipelock session list [--tier hard] [--json]` | Enumerate sessions, optionally filtered by airlock tier |
+| `pipelock session inspect <key> [--json]` | Full detail snapshot: tier, entry time, in-flight, recent events |
+| `pipelock session explain <key> [--json]` | Why the session is where it is: trigger, evidence, next auto-recovery time |
+| `pipelock session release <key> [--to none\|soft]` | Move an airlocked session down to a lower tier |
+| `pipelock session terminate <key>` | Destructive: reset enforcement state, cut in-flight connections, clear CEE state |
+| `pipelock session recover <key> [--choice ...]` | Interactive workflow: inspect → explain → pick an action |
+
+## What the tiers mean
+
+Airlock has four tiers. The state machine moves sessions upward in
+response to adaptive-enforcement escalations and downward in response
+to configured timers or explicit operator action.
+
+| Tier | Who can egress | Typical reason |
+|---|---|---|
+| `none` | Everyone | Normal steady state |
+| `soft` | Everyone (observe-only) | Session crossed a `high` escalation threshold; logging and metrics record all traffic but no enforcement change |
+| `hard` | Read methods only (GET/HEAD/OPTIONS) and fetch proxy | Session crossed `critical`; writes are blocked and long-lived connections are torn down |
+| `drain` | No one | Operator requested a graceful shutdown or the session hit a drain trigger; in-flight requests complete then the session terminates |
+
+Upward transitions happen automatically when adaptive enforcement
+crosses a trigger threshold. Downward transitions happen automatically
+when the tier timer expires — for example, `hard_minutes: 15` drops a
+hard-tier session back to soft after 15 minutes without further
+escalation. Operator commands override both.
+
+## Typical airlock recovery workflow
+
+```
+# 1. Find quarantined sessions.
+pipelock session list --tier hard
+
+# 2. Figure out why one of them is quarantined.
+pipelock session explain "agent|10.0.0.1"
+
+# 3. Confirm the threat is resolved before releasing.
+pipelock session inspect "agent|10.0.0.1"
+
+# 4. Release the session back to normal.
+pipelock session release "agent|10.0.0.1" --to none
+
+# Or, if the session cannot be trusted, terminate it.
+pipelock session terminate "agent|10.0.0.1"
+```
+
+The interactive `pipelock session recover <key>` command runs steps
+1–4 in sequence, prompting the operator for the release action at the
+end. Use `--choice release-none|release-soft|terminate|leave` to
+script the workflow non-interactively.
+
+## Resolving the admin API endpoint
+
+Every subcommand needs two pieces of config: the admin API URL and the
+bearer token. They are resolved in this order:
+
+1. Explicit flags: `--api-url`, `--api-token`
+2. Environment variables: `PIPELOCK_API_URL`, `PIPELOCK_KILLSWITCH_API_TOKEN`
+3. A pipelock config file, resolved via:
+   - `--config` flag
+   - `PIPELOCK_CONFIG` environment variable
+   - `~/.config/pipelock/pipelock.yaml`
+   - `/etc/pipelock/pipelock.yaml`
+
+When the config file is used as the token source, the CLI refuses to
+read world- or group-readable files — restrict your token file to
+`0600` permissions before running any session command.
+
+## session list
+
+```
+pipelock session list [--tier none|soft|hard|drain|normal] [--json]
+```
+
+Enumerates every session the proxy currently tracks. Default output is
+a human-readable table; `--json` returns the raw admin API response.
+
+The `--tier` filter is validated both locally and on the server.
+`normal` is accepted as an alias for `none`. Omitting `--tier` returns
+all sessions regardless of tier.
+
+## session inspect
+
+```
+pipelock session inspect <key> [--json]
+```
+
+Returns the full `SessionDetail` structure for the session, including
+the tier entry time, the in-flight request count, and the most recent
+20 notable events (blocks, anomalies, and airlock transitions).
+
+## session explain
+
+```
+pipelock session explain <key> [--json]
+```
+
+Walks the operator through the state of the session:
+
+- **tier** / **reason** — where the session sits and why
+- **trigger** / **trigger_source** — which configured trigger fired
+- **evidence** — the most recent event kind/target/detail that drove
+  escalation
+- **next_deescalation_tier** / **next_deescalation_at** — when the
+  configured timer will automatically drop the tier
+
+Sessions at the `none` tier return a `200` response with the reason
+"session not quarantined" plus the most recent event (if any). That
+makes it safe to call explain on any session as part of scripted
+healthchecks.
+
+## session release
+
+```
+pipelock session release <key> --to none|soft
+```
+
+Moves the session back to a lower tier via the admin API's airlock
+endpoint. The `--to` flag accepts `none` (default, fully release),
+`normal` (alias for `none`), and `soft` (observe-only). Upward
+transitions are not allowed through this command — use the airlock
+endpoint directly for upward admin overrides.
+
+## session terminate
+
+```
+pipelock session terminate <key>
+```
+
+Destructive. Resets the session's enforcement state (threat score,
+escalation level, airlock tier, block-all flag), fires all registered
+cancel funcs so in-flight long-lived connections are torn down,
+clears the cross-request entropy tracker and fragment buffer for the
+session's agent/IP pair.
+
+Terminate rejects invocation sessions (ephemeral MCP transport keys
+like `mcp-stdio-42`) with a `400` error — those contexts are not
+safely mutable through the admin API.
+
+## session recover
+
+```
+pipelock session recover <key> [--choice release-none|release-soft|terminate|leave]
+```
+
+Interactive recovery helper. Runs `inspect`, then `explain`, then
+prompts for an action. Use `--choice` to skip the prompt in scripts.
+The four actions map to:
+
+- `release-none` — `session release --to none`
+- `release-soft` — `session release --to soft`
+- `terminate` — `session terminate`
+- `leave` — no-op confirmation that the session is unchanged
+
+## Exit codes
+
+The session commands use the standard pipelock exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | Operational failure (HTTP 404, 429, 500, network error) |
+| `2` | Configuration or auth failure (HTTP 401, 400, missing token, bad flags) |
+
+Scripts should retry `1` with back-off and treat `2` as a fix-your-setup
+signal that should be surfaced to a human.

--- a/docs/cli/session.md
+++ b/docs/cli/session.md
@@ -43,7 +43,7 @@ escalation. Operator commands override both.
 
 ## Typical airlock recovery workflow
 
-```
+```sh
 # 1. Find quarantined sessions.
 pipelock session list --tier hard
 
@@ -60,10 +60,11 @@ pipelock session release "agent|10.0.0.1" --to none
 pipelock session terminate "agent|10.0.0.1"
 ```
 
-The interactive `pipelock session recover <key>` command runs steps
-1–4 in sequence, prompting the operator for the release action at the
-end. Use `--choice release-none|release-soft|terminate|leave` to
-script the workflow non-interactively.
+The interactive `pipelock session recover <key>` command runs the
+inspect → explain → action portion of this workflow for the supplied
+key (it does not perform the discovery/list step above). Use
+`--choice release-none|release-soft|terminate|leave` to script the
+workflow non-interactively.
 
 ## Resolving the admin API endpoint
 
@@ -84,7 +85,7 @@ read world- or group-readable files — restrict your token file to
 
 ## session list
 
-```
+```sh
 pipelock session list [--tier none|soft|hard|drain|normal] [--json]
 ```
 
@@ -97,7 +98,7 @@ all sessions regardless of tier.
 
 ## session inspect
 
-```
+```sh
 pipelock session inspect <key> [--json]
 ```
 
@@ -107,7 +108,7 @@ the tier entry time, the in-flight request count, and the most recent
 
 ## session explain
 
-```
+```sh
 pipelock session explain <key> [--json]
 ```
 
@@ -127,7 +128,7 @@ healthchecks.
 
 ## session release
 
-```
+```sh
 pipelock session release <key> --to none|soft
 ```
 
@@ -139,7 +140,7 @@ endpoint directly for upward admin overrides.
 
 ## session terminate
 
-```
+```sh
 pipelock session terminate <key>
 ```
 
@@ -155,7 +156,7 @@ safely mutable through the admin API.
 
 ## session recover
 
-```
+```sh
 pipelock session recover <key> [--choice release-none|release-soft|terminate|leave]
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -786,13 +786,13 @@ The `{key}` parameter is URL-encoded. For example, `my-agent|10.0.0.1` becomes `
 
 **Reset scope:** identity-family scoped. Resetting a session clears the session's threat score, escalation level, and block_all flag. It also clears shared IP-level burst tracking for the client IP and cross-request exfiltration (CEE) state. Other sessions on the same IP will have their burst state cleared as a side effect.
 
-**Rate limiting:** reset, inspect, explain, terminate, task, and trust are each rate-limited to 10 requests per minute per action. Each action tracks its own counter so abuse of one endpoint cannot starve another. GET /sessions and POST /airlock are not rate-limited — they are used during incident response and must remain available.
+**Rate limiting:** every mutating action (`reset`, `airlock`, `task`, `trust`, `terminate`) and every detail lookup (`inspect`, `explain`) is rate-limited to 10 requests per minute per action. Each action tracks its own sliding-window counter so abuse of one endpoint cannot starve another — an operator can still hit `/reset` or `/airlock` during incident response even if `/task` or `/trust` is under load. Only `GET /api/v1/sessions` (the list endpoint) is unbounded; it is used as the entry point for recovery tooling and has no destructive side effect. Responses that hit the limit return `429 Too Many Requests` with `Retry-After: 60`.
 
 Sessions are classified as `identity` (operator-targetable, e.g. `my-agent|10.0.0.1`) or `invocation` (internal MCP sessions, e.g. `mcp-stdio-42`). Only identity sessions can be reset, mutated, or terminated.
 
 **Operator CLI:** the session admin API is also exposed through `pipelock session <subcommand>` for interactive recovery. See [cli/session.md](cli/session.md) for the full operator reference.
 
-> **Restart caveat:** `kill_switch.api_token` is captured once at process startup and is NOT hot-reloaded. Rotating the token via a config reload (SIGHUP or fsnotify) will re-parse the new value but the session admin API keeps accepting the old bearer until the process restarts. Plan token rotation alongside a full restart so the previous credential is actually revoked.
+**Token hot-reload:** `kill_switch.api_token` is hot-reloaded on SIGHUP or fsnotify config-file changes. Rotating the token in YAML (or via the `PIPELOCK_KILLSWITCH_API_TOKEN` env var, which wins over YAML) takes effect on the next admin API call without restarting the proxy. The previous bearer credential is revoked atomically: requests in flight at the moment of rotation complete against the token they were issued against; subsequent requests must present the new bearer. Setting `api_token` to the empty string disables the endpoint (HTTP 503) without tearing down the listener, so an operator can revoke access during an incident and restore it later with a second reload.
 
 ### Airlock
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -773,16 +773,42 @@ When `kill_switch.api_token` is configured, the session admin API is available a
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/api/v1/sessions` | GET | List all tracked sessions with escalation state |
+| `/api/v1/sessions` | GET | List all tracked sessions, optionally filtered by `?tier=none\|soft\|hard\|drain\|normal` |
+| `/api/v1/sessions/{key}` | GET | Full detail snapshot: tier entry time, in-flight, recent events |
+| `/api/v1/sessions/{key}/explain` | GET | Trigger/evidence/next de-escalation estimate for a session |
 | `/api/v1/sessions/{key}/reset` | POST | Reset enforcement state for a client identity |
+| `/api/v1/sessions/{key}/terminate` | POST | Destructive full tear-down (cancel in-flight, clear CEE) |
+| `/api/v1/sessions/{key}/airlock` | POST | Transition the session's airlock tier (admin override) |
+| `/api/v1/sessions/{key}/task` | POST | Rotate the session's task boundary |
+| `/api/v1/sessions/{key}/trust` | POST | Grant a task-scoped trust override |
 
 The `{key}` parameter is URL-encoded. For example, `my-agent|10.0.0.1` becomes `my-agent%7C10.0.0.1`.
 
 **Reset scope:** identity-family scoped. Resetting a session clears the session's threat score, escalation level, and block_all flag. It also clears shared IP-level burst tracking for the client IP and cross-request exfiltration (CEE) state. Other sessions on the same IP will have their burst state cleared as a side effect.
 
-**Rate limiting:** only the POST /reset endpoint is rate-limited (10 requests/minute). GET /sessions is not rate-limited.
+**Rate limiting:** reset, inspect, explain, terminate, task, and trust are each rate-limited to 10 requests per minute per action. Each action tracks its own counter so abuse of one endpoint cannot starve another. GET /sessions and POST /airlock are not rate-limited — they are used during incident response and must remain available.
 
-Sessions are classified as `identity` (operator-targetable, e.g. `my-agent|10.0.0.1`) or `invocation` (internal MCP sessions, e.g. `mcp-stdio-42`). Only identity sessions can be reset.
+Sessions are classified as `identity` (operator-targetable, e.g. `my-agent|10.0.0.1`) or `invocation` (internal MCP sessions, e.g. `mcp-stdio-42`). Only identity sessions can be reset, mutated, or terminated.
+
+**Operator CLI:** the session admin API is also exposed through `pipelock session <subcommand>` for interactive recovery. See [cli/session.md](cli/session.md) for the full operator reference.
+
+### Airlock
+
+Per-session graduated quarantine with automatic recovery. When adaptive enforcement escalates a session, the airlock state machine can automatically transition the session through `soft` (observe-only), `hard` (reads allowed, writes blocked, long-lived connections torn down), and `drain` (no traffic, complete in-flight, then terminate). Configured timers drop the session back down a tier when no new incidents occur. Operators can override the tier at any time through the session admin API or the `pipelock session` CLI.
+
+```yaml
+airlock:
+  enabled: false
+  triggers:
+    on_elevated: none       # no airlock on elevated
+    on_high: soft           # soft quarantine on high
+    on_critical: hard       # hard quarantine on critical
+  timers:
+    soft_minutes: 5         # soft tier auto-recovers after 5 minutes
+    hard_minutes: 15        # hard tier auto-drops to soft after 15 minutes
+    drain_minutes: 0        # drain timer disabled
+    drain_timeout_seconds: 30  # drain deadline for in-flight completion
+```
 
 ## Event Emission
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -792,9 +792,11 @@ Sessions are classified as `identity` (operator-targetable, e.g. `my-agent|10.0.
 
 **Operator CLI:** the session admin API is also exposed through `pipelock session <subcommand>` for interactive recovery. See [cli/session.md](cli/session.md) for the full operator reference.
 
+> **Restart caveat:** `kill_switch.api_token` is captured once at process startup and is NOT hot-reloaded. Rotating the token via a config reload (SIGHUP or fsnotify) will re-parse the new value but the session admin API keeps accepting the old bearer until the process restarts. Plan token rotation alongside a full restart so the previous credential is actually revoked.
+
 ### Airlock
 
-Per-session graduated quarantine with automatic recovery. When adaptive enforcement escalates a session, the airlock state machine can automatically transition the session through `soft` (observe-only), `hard` (reads allowed, writes blocked, long-lived connections torn down), and `drain` (no traffic, complete in-flight, then terminate). Configured timers drop the session back down a tier when no new incidents occur. Operators can override the tier at any time through the session admin API or the `pipelock session` CLI.
+Per-session graduated quarantine with timer-based recovery. When adaptive enforcement escalates a session, the airlock state machine can transition the session through `soft` (observe-only), `hard` (reads allowed, writes blocked, long-lived connections torn down), and `drain` (no new traffic, existing in-flight requests complete within `drain_timeout_seconds`). All three tiers are **timed quarantines** that auto-recover back down through lower tiers as `soft_minutes`/`hard_minutes`/`drain_minutes` expire — `drain` is not a terminal state and is not equivalent to `POST /api/v1/sessions/{key}/terminate`. Operators can override the tier at any time through the session admin API or the `pipelock session` CLI; explicit termination (the destructive reset) lives behind the dedicated `terminate` endpoint.
 
 ```yaml
 airlock:

--- a/examples/quickstart/pipelock.yaml
+++ b/examples/quickstart/pipelock.yaml
@@ -137,7 +137,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '\b(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
       severity: high
 
 response_scanning:

--- a/examples/quickstart/pipelock.yaml
+++ b/examples/quickstart/pipelock.yaml
@@ -137,7 +137,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
       severity: high
 
 response_scanning:

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/cli/policy"
 	"github.com/luckyPipewrench/pipelock/internal/cli/rules"
 	"github.com/luckyPipewrench/pipelock/internal/cli/runtime"
+	"github.com/luckyPipewrench/pipelock/internal/cli/session"
 	"github.com/luckyPipewrench/pipelock/internal/cli/setup"
 	clisigning "github.com/luckyPipewrench/pipelock/internal/cli/signing"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
@@ -98,6 +99,8 @@ Quick start:
 		runtime.SandboxCmd(),
 		runtime.InternalRedirectCmd(),
 		runtime.HealthcheckCmd(),
+		// Session admin (airlock recovery)
+		session.Cmd(),
 		// Setup (IDE integrations)
 		setup.InitCmd(),
 		setup.ClaudeCmd(),

--- a/internal/cli/runtime/run.go
+++ b/internal/cli/runtime/run.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"os/signal"
 	"slices"
 	"syscall"
@@ -722,21 +721,13 @@ Examples:
 				apiMux.HandleFunc("/api/v1/killswitch", ksAPI.HandleToggle)
 				apiMux.HandleFunc("/api/v1/killswitch/status", ksAPI.HandleStatus)
 
-				// Session admin API on the dedicated port. Resolves the API
-				// token using the same env-var override as the kill switch.
-				apiToken := cfg.KillSwitch.APIToken
-				if envToken := os.Getenv(killswitch.EnvAPIToken); envToken != "" {
-					apiToken = envToken
-				}
-				if apiToken != "" {
-					sessionAPI := proxy.NewSessionAPIHandler(proxy.SessionAPIOptions{
-						SessionMgrPtr: p.SessionMgrPtr(),
-						EntropyPtr:    p.EntropyTrackerPtr(),
-						FragmentPtr:   p.FragmentBufferPtr(),
-						Metrics:       m,
-						Logger:        logger,
-						APIToken:      apiToken,
-					})
+				// Session admin API on the dedicated port. Mount the proxy's
+				// existing handler rather than building a second one so
+				// Reload's SetAPIToken rotation covers the dedicated-port
+				// mount too. p.SessionAPI() returns nil when no api_token is
+				// configured — in that case we skip registration and the
+				// admin routes simply don't exist on the listener.
+				if sessionAPI := p.SessionAPI(); sessionAPI != nil {
 					apiMux.HandleFunc("/api/v1/sessions", sessionAPI.HandleList)
 					apiMux.HandleFunc("/api/v1/sessions/", func(w http.ResponseWriter, r *http.Request) {
 						path := r.URL.EscapedPath()

--- a/internal/cli/runtime/run.go
+++ b/internal/cli/runtime/run.go
@@ -729,14 +729,14 @@ Examples:
 					apiToken = envToken
 				}
 				if apiToken != "" {
-					sessionAPI := proxy.NewSessionAPIHandler(
-						p.SessionMgrPtr(),
-						p.EntropyTrackerPtr(),
-						p.FragmentBufferPtr(),
-						m,
-						logger,
-						apiToken,
-					)
+					sessionAPI := proxy.NewSessionAPIHandler(proxy.SessionAPIOptions{
+						SessionMgrPtr: p.SessionMgrPtr(),
+						EntropyPtr:    p.EntropyTrackerPtr(),
+						FragmentPtr:   p.FragmentBufferPtr(),
+						Metrics:       m,
+						Logger:        logger,
+						APIToken:      apiToken,
+					})
 					apiMux.HandleFunc("/api/v1/sessions", sessionAPI.HandleList)
 					apiMux.HandleFunc("/api/v1/sessions/", func(w http.ResponseWriter, r *http.Request) {
 						path := r.URL.EscapedPath()
@@ -749,6 +749,12 @@ Examples:
 							sessionAPI.HandleTrust(w, r)
 						case killswitch.IsSessionActionPath(path, "reset"):
 							sessionAPI.HandleReset(w, r)
+						case killswitch.IsSessionActionPath(path, "explain"):
+							sessionAPI.HandleExplain(w, r)
+						case killswitch.IsSessionActionPath(path, "terminate"):
+							sessionAPI.HandleTerminate(w, r)
+						case killswitch.IsSessionKeyPath(path):
+							sessionAPI.HandleInspect(w, r)
 						default:
 							http.NotFound(w, r)
 						}

--- a/internal/cli/session/client.go
+++ b/internal/cli/session/client.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/proxy"
@@ -48,9 +49,17 @@ func newClient(ep endpoint) *Client {
 
 // newClientWithHTTP builds a session admin API client with an explicit
 // httpClientInterface. Tests use this to inject an httptest-backed
-// round tripper or a stub that records the calls it receives.
+// round tripper or a stub that records the calls it receives. Trailing
+// slashes on the base URL are stripped so `http://host:9090/` and
+// `http://host:9090` produce identical admin API request paths — leaving
+// them in would route `/api/v1/sessions` to `//api/v1/sessions` which
+// the admin router does not recognize.
 func newClientWithHTTP(ep endpoint, c httpClientInterface) *Client {
-	return &Client{base: ep.URL, token: ep.Token, http: c}
+	return &Client{
+		base:  strings.TrimRight(ep.URL, "/"),
+		token: ep.Token,
+		http:  c,
+	}
 }
 
 // listResponse mirrors the server-side anonymous struct returned by

--- a/internal/cli/session/client.go
+++ b/internal/cli/session/client.go
@@ -198,11 +198,35 @@ type APIError struct {
 	Body       string
 }
 
-func (e *APIError) Error() string {
-	if e.RetryAfter != "" {
-		return fmt.Sprintf("%s %s: HTTP %d (Retry-After: %s): %s", e.Method, e.URL, e.StatusCode, e.RetryAfter, e.Body)
+// errorPath returns just the request path (plus raw query) for display.
+// The scheme and host are stripped so error strings never leak where the
+// admin API is actually running — operators often paste error output into
+// tickets, chat, or logs that are less trusted than the endpoint itself.
+// Falls back to the raw URL when url.Parse cannot recover a Path (which
+// should not happen in practice, since the client always constructs
+// target URLs from a validated base, but keeps the error useful in the
+// degenerate case instead of returning an empty string).
+func (e *APIError) errorPath() string {
+	if e.URL == "" {
+		return ""
 	}
-	return fmt.Sprintf("%s %s: HTTP %d: %s", e.Method, e.URL, e.StatusCode, e.Body)
+	parsed, err := url.Parse(e.URL)
+	if err != nil || parsed.Path == "" {
+		return e.URL
+	}
+	path := parsed.Path
+	if parsed.RawQuery != "" {
+		path += "?" + parsed.RawQuery
+	}
+	return path
+}
+
+func (e *APIError) Error() string {
+	display := e.errorPath()
+	if e.RetryAfter != "" {
+		return fmt.Sprintf("%s %s: HTTP %d (Retry-After: %s): %s", e.Method, display, e.StatusCode, e.RetryAfter, e.Body)
+	}
+	return fmt.Sprintf("%s %s: HTTP %d: %s", e.Method, display, e.StatusCode, e.Body)
 }
 
 // IsNotFound reports whether err is an APIError with 404 status.

--- a/internal/cli/session/client.go
+++ b/internal/cli/session/client.go
@@ -1,0 +1,215 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+)
+
+// Default timeout for admin API calls. Admin API operations are
+// lightweight (no bodies beyond tier transitions) so a short timeout
+// keeps the CLI snappy when the server is unreachable.
+const defaultClientTimeout = 10 * time.Second
+
+// httpClientInterface is the subset of *http.Client the session client
+// actually uses. Extracted so tests can substitute an httptest round-
+// tripper or a fake with no network.
+type httpClientInterface interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Client is the thin HTTP client wrapping the admin API. It holds the
+// resolved endpoint (URL + bearer token) and a *http.Client with a
+// default timeout. Callers create one per command invocation via
+// newClient and discard it when done.
+type Client struct {
+	base  string
+	token string
+	http  httpClientInterface
+}
+
+// newClient builds a session admin API client from the resolved endpoint
+// with the default http.Client timeout. Use newClientWithHTTP when a
+// test needs to inject a custom round tripper.
+func newClient(ep endpoint) *Client {
+	return newClientWithHTTP(ep, &http.Client{Timeout: defaultClientTimeout})
+}
+
+// newClientWithHTTP builds a session admin API client with an explicit
+// httpClientInterface. Tests use this to inject an httptest-backed
+// round tripper or a stub that records the calls it receives.
+func newClientWithHTTP(ep endpoint, c httpClientInterface) *Client {
+	return &Client{base: ep.URL, token: ep.Token, http: c}
+}
+
+// listResponse mirrors the server-side anonymous struct returned by
+// HandleList so callers can decode into a typed value.
+type listResponse struct {
+	Sessions []proxy.SessionSnapshot `json:"sessions"`
+	Count    int                     `json:"count"`
+}
+
+// airlockResponse mirrors the server-side airlockResponse struct. Kept
+// local so this package does not import unexported proxy types.
+type airlockResponse struct {
+	Key          string `json:"key"`
+	PreviousTier string `json:"previous_tier"`
+	NewTier      string `json:"new_tier"`
+	Changed      bool   `json:"changed"`
+}
+
+// List fetches /api/v1/sessions. When tier is non-empty, it is passed as
+// a ?tier= query parameter and the server filters the results.
+func (c *Client) List(ctx context.Context, tier string) (listResponse, error) {
+	target := c.base + "/api/v1/sessions"
+	if tier != "" {
+		target += "?tier=" + url.QueryEscape(tier)
+	}
+	var resp listResponse
+	if err := c.do(ctx, http.MethodGet, target, nil, &resp); err != nil {
+		return listResponse{}, err
+	}
+	return resp, nil
+}
+
+// Inspect fetches /api/v1/sessions/{key} and decodes the SessionDetail.
+func (c *Client) Inspect(ctx context.Context, key string) (proxy.SessionDetail, error) {
+	target := c.base + "/api/v1/sessions/" + url.PathEscape(key)
+	var detail proxy.SessionDetail
+	if err := c.do(ctx, http.MethodGet, target, nil, &detail); err != nil {
+		return proxy.SessionDetail{}, err
+	}
+	return detail, nil
+}
+
+// Explain fetches /api/v1/sessions/{key}/explain.
+func (c *Client) Explain(ctx context.Context, key string) (proxy.SessionExplanation, error) {
+	target := c.base + "/api/v1/sessions/" + url.PathEscape(key) + "/explain"
+	var exp proxy.SessionExplanation
+	if err := c.do(ctx, http.MethodGet, target, nil, &exp); err != nil {
+		return proxy.SessionExplanation{}, err
+	}
+	return exp, nil
+}
+
+// Release posts /api/v1/sessions/{key}/airlock with the target tier so
+// ForceSetTier drops the session into that tier. Operators use this to
+// recover soft-quarantined sessions once the incident is resolved.
+func (c *Client) Release(ctx context.Context, key, tier string) (airlockResponse, error) {
+	target := c.base + "/api/v1/sessions/" + url.PathEscape(key) + "/airlock"
+	body, err := json.Marshal(map[string]string{"tier": tier})
+	if err != nil {
+		return airlockResponse{}, fmt.Errorf("marshal release body: %w", err)
+	}
+	var resp airlockResponse
+	if err := c.do(ctx, http.MethodPost, target, bytes.NewReader(body), &resp); err != nil {
+		return airlockResponse{}, err
+	}
+	return resp, nil
+}
+
+// Terminate posts /api/v1/sessions/{key}/terminate.
+func (c *Client) Terminate(ctx context.Context, key string) (proxy.SessionTerminateResult, error) {
+	target := c.base + "/api/v1/sessions/" + url.PathEscape(key) + "/terminate"
+	var resp proxy.SessionTerminateResult
+	if err := c.do(ctx, http.MethodPost, target, nil, &resp); err != nil {
+		return proxy.SessionTerminateResult{}, err
+	}
+	return resp, nil
+}
+
+// do performs the HTTP call with bearer auth, decodes the JSON response
+// into out, and returns a typed APIError for non-2xx statuses so the
+// caller can map each class to a distinct exit code.
+func (c *Client) do(ctx context.Context, method, target string, body io.Reader, out any) error {
+	req, err := http.NewRequestWithContext(ctx, method, target, body)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s %s: %w", method, target, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		apiErr := &APIError{
+			Method:     method,
+			URL:        target,
+			StatusCode: resp.StatusCode,
+			RetryAfter: resp.Header.Get("Retry-After"),
+		}
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 16*1024))
+		apiErr.Body = string(bytes.TrimSpace(raw))
+		return apiErr
+	}
+
+	if out == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		if errors.Is(err, io.EOF) {
+			// Empty body on 200 is acceptable when the caller didn't
+			// request a typed value — do returns above when out is nil.
+			return fmt.Errorf("empty response body from %s %s", method, target)
+		}
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
+// APIError is returned for any non-2xx admin API response. Carries the
+// HTTP status, Retry-After header (when present), and the response body
+// so the caller can propagate the server's error message back to the
+// operator without guessing at shape.
+type APIError struct {
+	Method     string
+	URL        string
+	StatusCode int
+	RetryAfter string
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	if e.RetryAfter != "" {
+		return fmt.Sprintf("%s %s: HTTP %d (Retry-After: %s): %s", e.Method, e.URL, e.StatusCode, e.RetryAfter, e.Body)
+	}
+	return fmt.Sprintf("%s %s: HTTP %d: %s", e.Method, e.URL, e.StatusCode, e.Body)
+}
+
+// IsNotFound reports whether err is an APIError with 404 status.
+func IsNotFound(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
+}
+
+// IsUnauthorized reports whether err is an APIError with 401 status.
+func IsUnauthorized(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnauthorized
+}
+
+// IsRateLimited reports whether err is an APIError with 429 status.
+func IsRateLimited(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusTooManyRequests
+}

--- a/internal/cli/session/client_test.go
+++ b/internal/cli/session/client_test.go
@@ -1,0 +1,277 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+)
+
+// assertBearer checks the Authorization header on a handler request.
+func assertBearer(t *testing.T, r *http.Request) {
+	t.Helper()
+	got := r.Header.Get("Authorization")
+	want := "Bearer " + testToken
+	if got != want {
+		t.Errorf("Authorization: got %q, want %q", got, want)
+	}
+}
+
+func TestClient_List_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertBearer(t, r)
+		if r.URL.Path != sessionListURL {
+			t.Errorf("path: got %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("tier"); got != "hard" {
+			t.Errorf("tier query: got %q", got)
+		}
+		writeJSONResponse(w, http.StatusOK, listResponse{Sessions: makeSnapshotList(), Count: 1})
+	}))
+	defer srv.Close()
+
+	c := newClient(endpoint{URL: srv.URL, Token: testToken})
+	resp, err := c.List(context.Background(), "hard")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Count != 1 || len(resp.Sessions) != 1 || resp.Sessions[0].Key != testKeyIdent {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+}
+
+func TestClient_List_NoTierOmitsParam(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery != "" {
+			t.Errorf("expected no query params, got %q", r.URL.RawQuery)
+		}
+		writeJSONResponse(w, http.StatusOK, listResponse{})
+	}))
+	defer srv.Close()
+
+	c := newClient(endpoint{URL: srv.URL, Token: testToken})
+	if _, err := c.List(context.Background(), ""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClient_Inspect_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, testKeyIdent) && !strings.Contains(r.URL.Path, "agent-z%7C10.0.0.42") {
+			t.Errorf("path does not contain expected key: %q", r.URL.Path)
+		}
+		writeJSONResponse(w, http.StatusOK, makeDetail())
+	}))
+	defer srv.Close()
+
+	c := newClient(endpoint{URL: srv.URL, Token: testToken})
+	detail, err := c.Inspect(context.Background(), testKeyIdent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Key != testKeyIdent {
+		t.Errorf("detail.Key: %q", detail.Key)
+	}
+}
+
+func TestClient_Explain_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(w, http.StatusOK, makeExplanation())
+	}))
+	defer srv.Close()
+
+	c := newClient(endpoint{URL: srv.URL, Token: testToken})
+	exp, err := c.Explain(context.Background(), testKeyIdent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp.Trigger != "on_critical" {
+		t.Errorf("Trigger: %q", exp.Trigger)
+	}
+}
+
+func TestClient_Release_SendsBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body["tier"] != "none" {
+			t.Errorf("tier: got %q, want none", body["tier"])
+		}
+		writeJSONResponse(w, http.StatusOK, airlockResponse{
+			Key: testKeyIdent, PreviousTier: "hard", NewTier: "none", Changed: true,
+		})
+	}))
+	defer srv.Close()
+
+	c := newClient(endpoint{URL: srv.URL, Token: testToken})
+	resp, err := c.Release(context.Background(), testKeyIdent, "none")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Changed {
+		t.Error("Changed: false")
+	}
+}
+
+func TestClient_Terminate_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method: got %s", r.Method)
+		}
+		writeJSONResponse(w, http.StatusOK, proxy.SessionTerminateResult{
+			Key: testKeyIdent, Terminated: true, PreviousTier: "hard",
+		})
+	}))
+	defer srv.Close()
+
+	c := newClient(endpoint{URL: srv.URL, Token: testToken})
+	resp, err := c.Terminate(context.Background(), testKeyIdent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Terminated {
+		t.Error("Terminated: false")
+	}
+}
+
+func TestClient_NonSuccessReturnsAPIError(t *testing.T) {
+	tests := []struct {
+		status     int
+		headerRA   string
+		bodyText   string
+		checkFn    func(error) bool
+		wantPrefix string
+	}{
+		{http.StatusNotFound, "", "session not found", IsNotFound, ""},
+		{http.StatusUnauthorized, "", "unauthorized", IsUnauthorized, ""},
+		{http.StatusTooManyRequests, "60", "rate limit exceeded", IsRateLimited, "Retry-After: 60"},
+	}
+	for _, tt := range tests {
+		name := fmt.Sprintf("status=%d", tt.status)
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tt.headerRA != "" {
+					w.Header().Set("Retry-After", tt.headerRA)
+				}
+				http.Error(w, tt.bodyText, tt.status)
+			}))
+			defer srv.Close()
+
+			c := newClient(endpoint{URL: srv.URL, Token: testToken})
+			_, err := c.List(context.Background(), "")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.checkFn(err) {
+				t.Errorf("classifier failed for status %d", tt.status)
+			}
+			var apiErr *APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatal("expected APIError")
+			}
+			if apiErr.StatusCode != tt.status {
+				t.Errorf("StatusCode: got %d, want %d", apiErr.StatusCode, tt.status)
+			}
+		})
+	}
+}
+
+func TestClient_HTTPError_Propagates(t *testing.T) {
+	// Use an intentionally-unreachable port to force a network error.
+	c := newClient(endpoint{URL: "http://127.0.0.1:1", Token: testToken})
+	_, err := c.List(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected network error")
+	}
+	// Should NOT be an APIError — it's a transport failure.
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		t.Error("network failure should not be APIError")
+	}
+}
+
+func TestClient_EmptyResponseBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", contentTypeJSON)
+		w.WriteHeader(http.StatusOK)
+		// No body.
+	}))
+	defer srv.Close()
+
+	c := newClient(endpoint{URL: srv.URL, Token: testToken})
+	_, err := c.Inspect(context.Background(), testKeyIdent)
+	if err == nil {
+		t.Error("expected error decoding empty body")
+	}
+}
+
+func TestAPIError_ErrorString(t *testing.T) {
+	e := &APIError{Method: "GET", URL: "http://x", StatusCode: 404, Body: "not found"}
+	if got := e.Error(); !strings.Contains(got, "404") || !strings.Contains(got, "not found") {
+		t.Errorf("unexpected error string: %s", got)
+	}
+
+	e.RetryAfter = "30"
+	if got := e.Error(); !strings.Contains(got, "30") {
+		t.Errorf("should include retry-after: %s", got)
+	}
+}
+
+func TestIsNotFound_Nil(t *testing.T) {
+	if IsNotFound(nil) {
+		t.Error("nil should not classify as 404")
+	}
+	if IsUnauthorized(nil) {
+		t.Error("nil should not classify as 401")
+	}
+	if IsRateLimited(nil) {
+		t.Error("nil should not classify as 429")
+	}
+}
+
+func TestClient_Release_MarshalError(t *testing.T) {
+	// Release builds a bytes.NewReader from a map[string]string which never
+	// fails to marshal — the happy-path test above exercises that branch.
+	// Here we assert Release on an unreachable server returns a transport
+	// error rather than a marshal error.
+	c := newClient(endpoint{URL: "http://127.0.0.1:1", Token: testToken})
+	_, err := c.Release(context.Background(), testKeyIdent, "none")
+	if err == nil {
+		t.Error("expected transport error")
+	}
+}
+
+func TestClient_Do_BadJSONBody(t *testing.T) {
+	// Server returns 200 with a body that isn't valid JSON — the decode
+	// branch should surface an error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", contentTypeJSON)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not-json"))
+	}))
+	defer srv.Close()
+
+	c := newClient(endpoint{URL: srv.URL, Token: testToken})
+	_, err := c.Inspect(context.Background(), testKeyIdent)
+	if err == nil || !strings.Contains(err.Error(), "decode") {
+		t.Errorf("expected decode error, got %v", err)
+	}
+}
+
+func TestClient_NewClient_UsesDefaultWhenNil(t *testing.T) {
+	c := newClient(endpoint{URL: "http://x:1", Token: testToken})
+	if c.http == nil {
+		t.Error("http client should default to a real *http.Client")
+	}
+}

--- a/internal/cli/session/client_test.go
+++ b/internal/cli/session/client_test.go
@@ -217,14 +217,59 @@ func TestClient_EmptyResponseBody(t *testing.T) {
 }
 
 func TestAPIError_ErrorString(t *testing.T) {
-	e := &APIError{Method: "GET", URL: "http://x", StatusCode: 404, Body: "not found"}
-	if got := e.Error(); !strings.Contains(got, "404") || !strings.Contains(got, "not found") {
+	e := &APIError{Method: "GET", URL: "http://x/api/v1/sessions/abc", StatusCode: 404, Body: "not found"}
+	got := e.Error()
+	if !strings.Contains(got, "404") || !strings.Contains(got, "not found") {
 		t.Errorf("unexpected error string: %s", got)
+	}
+	// scheme + host must be stripped so operators can paste error output
+	// into less-trusted channels without leaking the admin endpoint.
+	if strings.Contains(got, "http://") || strings.Contains(got, "://") {
+		t.Errorf("scheme should be stripped: %s", got)
+	}
+	if strings.Contains(got, "x/api") {
+		t.Errorf("host should be stripped: %s", got)
+	}
+	if !strings.Contains(got, "/api/v1/sessions/abc") {
+		t.Errorf("path should be preserved: %s", got)
 	}
 
 	e.RetryAfter = "30"
 	if got := e.Error(); !strings.Contains(got, "30") {
 		t.Errorf("should include retry-after: %s", got)
+	}
+}
+
+func TestAPIError_ErrorString_StripsQuery(t *testing.T) {
+	// Query strings are part of the path for display purposes — they
+	// belong in the error (they might say ?tier=hard) but the scheme
+	// and host still need stripping.
+	e := &APIError{
+		Method:     "GET",
+		URL:        "https://admin.internal.example:9090/api/v1/sessions?tier=hard",
+		StatusCode: 429,
+		Body:       "rate limit exceeded",
+	}
+	got := e.Error()
+	if strings.Contains(got, "https://") || strings.Contains(got, "admin.internal.example") {
+		t.Errorf("scheme/host should be stripped: %s", got)
+	}
+	if !strings.Contains(got, "/api/v1/sessions?tier=hard") {
+		t.Errorf("path+query should be preserved: %s", got)
+	}
+}
+
+func TestAPIError_ErrorString_FallbackOnUnparseable(t *testing.T) {
+	// When url.Parse cannot recover a Path — e.g. the caller handed us
+	// something exotic — fall back to the raw URL rather than emitting
+	// an empty path that would make the error unreadable.
+	e := &APIError{Method: "POST", URL: "not a url", StatusCode: 500, Body: "internal"}
+	got := e.Error()
+	if !strings.Contains(got, "500") || !strings.Contains(got, "internal") {
+		t.Errorf("missing status/body: %s", got)
+	}
+	if !strings.Contains(got, "not a url") {
+		t.Errorf("fallback should preserve raw URL: %s", got)
 	}
 }
 

--- a/internal/cli/session/cmd.go
+++ b/internal/cli/session/cmd.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package session implements the `pipelock session` operator CLI for
+// inspecting and recovering airlocked sessions. Subcommands talk to the
+// session admin API on the running pipelock instance using the shared
+// client defined in client.go.
+package session
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Shared flag names used across subcommands. Kept in one place so the
+// help strings and env-var fallbacks stay aligned.
+const (
+	flagAPIURL   = "api-url"
+	flagAPIToken = "api-token" //nolint:gosec // flag name, not a credential
+	flagConfig   = "config"
+	flagJSON     = "json"
+)
+
+// Shared usage strings so goconst stays quiet and help text is consistent.
+const (
+	usageAPIURL   = "admin API base URL (default: derived from config file kill_switch.api_listen)"
+	usageAPIToken = "admin API bearer token (default: PIPELOCK_KILLSWITCH_API_TOKEN env or config file)"
+	usageConfig   = "pipelock config file path (default: PIPELOCK_CONFIG env, ~/.config/pipelock/pipelock.yaml, or /etc/pipelock/pipelock.yaml)"
+	usageJSON     = "machine-readable JSON output"
+)
+
+// rootFlags collects the flag values shared by every session subcommand.
+// Each subcommand binds its own copy of these via addCommonFlags so that
+// table-driven tests can construct isolated command instances.
+type rootFlags struct {
+	apiURL     string
+	apiToken   string
+	configPath string
+}
+
+// Cmd is the parent command for `pipelock session`. Exported so the root
+// CLI can register it alongside the other top-level commands.
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "session",
+		Short: "Inspect and recover airlocked agent sessions",
+		Long: `Operator commands for the per-session airlock. Use these commands to
+investigate sessions that have been quarantined by adaptive enforcement
+and to release or terminate them once the underlying incident is resolved.
+
+Every subcommand talks to the running pipelock's session admin API
+(requires kill_switch.api_token). The API URL and token are resolved
+from flags, environment variables, or the pipelock config file — see
+the global flags for details.
+
+Examples:
+  pipelock session list
+  pipelock session list --tier hard --json
+  pipelock session inspect "agent|10.0.0.1"
+  pipelock session explain "agent|10.0.0.1"
+  pipelock session release "agent|10.0.0.1" --to none
+  pipelock session terminate "agent|10.0.0.1"
+  pipelock session recover "agent|10.0.0.1"`,
+	}
+	cmd.AddCommand(
+		listCmd(),
+		inspectCmd(),
+		explainCmd(),
+		releaseCmd(),
+		terminateCmd(),
+		recoverCmd(),
+	)
+	return cmd
+}
+
+// addCommonFlags wires the shared --api-url, --api-token, --config flags
+// onto a subcommand. Returns a pointer to the flag-backed struct so the
+// subcommand's RunE closure can read the values at execution time.
+func addCommonFlags(cmd *cobra.Command) *rootFlags {
+	flags := &rootFlags{}
+	cmd.Flags().StringVar(&flags.apiURL, flagAPIURL, "", usageAPIURL)
+	cmd.Flags().StringVar(&flags.apiToken, flagAPIToken, "", usageAPIToken)
+	cmd.Flags().StringVar(&flags.configPath, flagConfig, "", usageConfig)
+	return flags
+}

--- a/internal/cli/session/cmd.go
+++ b/internal/cli/session/cmd.go
@@ -21,16 +21,21 @@ const (
 )
 
 // Shared usage strings so goconst stays quiet and help text is consistent.
+// The resolution order (flags → env → config file) is spelled out here so
+// `pipelock session --help` and each subcommand's --help both surface the
+// same fallback chain that resolveEndpoint actually implements.
 const (
-	usageAPIURL   = "admin API base URL (default: derived from config file kill_switch.api_listen)"
+	usageAPIURL   = "admin API base URL (default: PIPELOCK_API_URL env or derived from config file kill_switch.api_listen)"
 	usageAPIToken = "admin API bearer token (default: PIPELOCK_KILLSWITCH_API_TOKEN env or config file)"
 	usageConfig   = "pipelock config file path (default: PIPELOCK_CONFIG env, ~/.config/pipelock/pipelock.yaml, or /etc/pipelock/pipelock.yaml)"
 	usageJSON     = "machine-readable JSON output"
 )
 
 // rootFlags collects the flag values shared by every session subcommand.
-// Each subcommand binds its own copy of these via addCommonFlags so that
-// table-driven tests can construct isolated command instances.
+// The parent command binds them as persistent flags so both
+// `pipelock session --api-url X list` and `pipelock session list --api-url X`
+// route to the same storage; children take a pointer so tests can
+// construct isolated instances without going through Cmd().
 type rootFlags struct {
 	apiURL     string
 	apiToken   string
@@ -40,6 +45,7 @@ type rootFlags struct {
 // Cmd is the parent command for `pipelock session`. Exported so the root
 // CLI can register it alongside the other top-level commands.
 func Cmd() *cobra.Command {
+	flags := &rootFlags{}
 	cmd := &cobra.Command{
 		Use:   "session",
 		Short: "Inspect and recover airlocked agent sessions",
@@ -61,24 +67,25 @@ Examples:
   pipelock session terminate "agent|10.0.0.1"
   pipelock session recover "agent|10.0.0.1"`,
 	}
+	bindPersistentFlags(cmd, flags)
 	cmd.AddCommand(
-		listCmd(),
-		inspectCmd(),
-		explainCmd(),
-		releaseCmd(),
-		terminateCmd(),
-		recoverCmd(),
+		listCmd(flags),
+		inspectCmd(flags),
+		explainCmd(flags),
+		releaseCmd(flags),
+		terminateCmd(flags),
+		recoverCmd(flags),
 	)
 	return cmd
 }
 
-// addCommonFlags wires the shared --api-url, --api-token, --config flags
-// onto a subcommand. Returns a pointer to the flag-backed struct so the
-// subcommand's RunE closure can read the values at execution time.
-func addCommonFlags(cmd *cobra.Command) *rootFlags {
-	flags := &rootFlags{}
-	cmd.Flags().StringVar(&flags.apiURL, flagAPIURL, "", usageAPIURL)
-	cmd.Flags().StringVar(&flags.apiToken, flagAPIToken, "", usageAPIToken)
-	cmd.Flags().StringVar(&flags.configPath, flagConfig, "", usageConfig)
-	return flags
+// bindPersistentFlags wires the shared --api-url, --api-token, --config
+// flags onto the parent command's PersistentFlags so they are accepted
+// both before and after the subcommand name (`session --api-url X list`
+// and `session list --api-url X` both work) and appear in the parent's
+// --help output.
+func bindPersistentFlags(cmd *cobra.Command, flags *rootFlags) {
+	cmd.PersistentFlags().StringVar(&flags.apiURL, flagAPIURL, "", usageAPIURL)
+	cmd.PersistentFlags().StringVar(&flags.apiToken, flagAPIToken, "", usageAPIToken)
+	cmd.PersistentFlags().StringVar(&flags.configPath, flagConfig, "", usageConfig)
 }

--- a/internal/cli/session/cmd_test.go
+++ b/internal/cli/session/cmd_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCmd_RegistersAllSubcommands(t *testing.T) {
+	cmd := Cmd()
+	want := []string{"list", "inspect", "explain", "release", "terminate", "recover"}
+	for _, name := range want {
+		_, _, err := cmd.Find([]string{name})
+		if err != nil {
+			t.Errorf("subcommand %q not registered: %v", name, err)
+		}
+	}
+}
+
+func TestCmd_UseAndShortAreSet(t *testing.T) {
+	cmd := Cmd()
+	if cmd.Use != "session" {
+		t.Errorf("Use: got %q, want %q", cmd.Use, "session")
+	}
+	if cmd.Short == "" {
+		t.Error("Short description is empty")
+	}
+	if !strings.Contains(cmd.Long, "airlock") {
+		t.Errorf("Long description should mention airlock: %q", cmd.Long)
+	}
+}
+
+func TestAddCommonFlags_BindsSharedFlags(t *testing.T) {
+	cmd := Cmd()
+	sub, _, err := cmd.Find([]string{"list"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{flagAPIURL, flagAPIToken, flagConfig, flagJSON} {
+		if sub.Flag(name) == nil {
+			t.Errorf("subcommand list missing flag %q", name)
+		}
+	}
+}

--- a/internal/cli/session/explain.go
+++ b/internal/cli/session/explain.go
@@ -15,7 +15,7 @@ const (
 	explainShort = "Explain why a session is in its current airlock state"
 )
 
-func explainCmd() *cobra.Command {
+func explainCmd(flags *rootFlags) *cobra.Command {
 	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   explainUse,
@@ -35,7 +35,6 @@ Examples:
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	flags := addCommonFlags(cmd)
 	cmd.Flags().BoolVar(&jsonOutput, flagJSON, false, usageJSON)
 
 	cmd.RunE = func(c *cobra.Command, args []string) error {

--- a/internal/cli/session/explain.go
+++ b/internal/cli/session/explain.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	explainUse   = "explain <key>"
+	explainShort = "Explain why a session is in its current airlock state"
+)
+
+func explainCmd() *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   explainUse,
+		Short: explainShort,
+		Long: `Return a human-readable explanation of why a session is in its
+current airlock tier: which trigger fired, when it fired, the threat
+score at the moment of escalation, and the most recent piece of
+evidence recorded for the session.
+
+Sessions at the normal tier return a "not quarantined" explanation
+with the most recent recorded event (if any).
+
+Examples:
+  pipelock session explain "agent|10.0.0.1"
+  pipelock session explain "agent|10.0.0.1" --json`,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	flags := addCommonFlags(cmd)
+	cmd.Flags().BoolVar(&jsonOutput, flagJSON, false, usageJSON)
+
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+		key := args[0]
+		return runClientCmd(flags, c.Context(), c.OutOrStdout(), func(ctx context.Context, client *Client, out io.Writer) error {
+			exp, err := client.Explain(ctx, key)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return writeJSON(out, exp)
+			}
+			return renderExplanation(out, exp)
+		})
+	}
+	return cmd
+}

--- a/internal/cli/session/explain_test.go
+++ b/internal/cli/session/explain_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+)
+
+func TestExplainCmd_HappyPath(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertBearer(t, r)
+		writeJSONResponse(w, http.StatusOK, makeExplanation())
+	}))
+	overrideClientFactory(t, flags)
+
+	out, err := runCommand(explainCmd(), testKeyIdent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantContains := []string{"on_critical", "evidence", "dlp secret", "next_deescalation"}
+	for _, w := range wantContains {
+		if !strings.Contains(out, w) {
+			t.Errorf("missing %q in: %s", w, out)
+		}
+	}
+}
+
+func TestExplainCmd_JSON(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(w, http.StatusOK, makeExplanation())
+	}))
+	overrideClientFactory(t, flags)
+
+	out, err := runCommand(explainCmd(), testKeyIdent, "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var exp proxy.SessionExplanation
+	if err := json.Unmarshal([]byte(out), &exp); err != nil {
+		t.Fatalf("parse: %v; out=%s", err, out)
+	}
+	if exp.Trigger != "on_critical" {
+		t.Errorf("Trigger: got %q", exp.Trigger)
+	}
+}
+
+func TestExplainCmd_NoneTierSession(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(w, http.StatusOK, proxy.SessionExplanation{
+			Key: testKeyIdent, Tier: "none", Reason: "session not quarantined",
+		})
+	}))
+	overrideClientFactory(t, flags)
+
+	out, err := runCommand(explainCmd(), testKeyIdent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "not quarantined") {
+		t.Errorf("none tier: expected reason text, got %s", out)
+	}
+}
+
+func TestExplainCmd_NotFound(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "ghost", http.StatusNotFound)
+	}))
+	overrideClientFactory(t, flags)
+
+	_, err := runCommand(explainCmd(), testKeyIdent)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not found, got %v", err)
+	}
+}
+
+func TestExplainCmd_RequiresArg(t *testing.T) {
+	overrideClientFactory(t, &rootFlags{apiURL: "http://x:1", apiToken: testToken})
+	_, err := runCommand(explainCmd())
+	if err == nil {
+		t.Error("expected error without key argument")
+	}
+}

--- a/internal/cli/session/explain_test.go
+++ b/internal/cli/session/explain_test.go
@@ -19,7 +19,7 @@ func TestExplainCmd_HappyPath(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	out, err := runCommand(explainCmd(), testKeyIdent)
+	out, err := runCommand(explainCmd(&rootFlags{}), testKeyIdent)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func TestExplainCmd_JSON(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	out, err := runCommand(explainCmd(), testKeyIdent, "--json")
+	out, err := runCommand(explainCmd(&rootFlags{}), testKeyIdent, "--json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestExplainCmd_NoneTierSession(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	out, err := runCommand(explainCmd(), testKeyIdent)
+	out, err := runCommand(explainCmd(&rootFlags{}), testKeyIdent)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestExplainCmd_NotFound(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	_, err := runCommand(explainCmd(), testKeyIdent)
+	_, err := runCommand(explainCmd(&rootFlags{}), testKeyIdent)
 	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Errorf("expected not found, got %v", err)
 	}
@@ -81,7 +81,7 @@ func TestExplainCmd_NotFound(t *testing.T) {
 
 func TestExplainCmd_RequiresArg(t *testing.T) {
 	overrideClientFactory(t, &rootFlags{apiURL: "http://x:1", apiToken: testToken})
-	_, err := runCommand(explainCmd())
+	_, err := runCommand(explainCmd(&rootFlags{}))
 	if err == nil {
 		t.Error("expected error without key argument")
 	}

--- a/internal/cli/session/helpers_test.go
+++ b/internal/cli/session/helpers_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+)
+
+// Test-local constants shared across subcommand tests. Keeps goconst
+// quiet on repeated literals.
+const (
+	testToken       = "stub-admin-token"
+	testKeyIdent    = "agent-z|10.0.0.42"
+	testKeyInvoc    = "mcp-stdio-7"
+	sessionListURL  = "/api/v1/sessions"
+	contentTypeJSON = "application/json"
+	tierHard        = "hard"
+	tierSoft        = "soft"
+	tierNone        = "none"
+)
+
+// stubServer starts an httptest.Server using the given handler. Returns
+// a rootFlags configured to point at it with the test bearer token.
+// The server is closed via t.Cleanup so callers do not need to hold on
+// to the server handle.
+func stubServer(t *testing.T, handler http.Handler) *rootFlags {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return &rootFlags{
+		apiURL:   srv.URL,
+		apiToken: testToken,
+	}
+}
+
+// overrideClientFactory swaps newClientFn to build a *Client pointing at
+// the given base URL using a shared http.Client. Restores the original
+// factory on test cleanup.
+func overrideClientFactory(t *testing.T, flags *rootFlags) {
+	t.Helper()
+	orig := newClientFn
+	t.Cleanup(func() { newClientFn = orig })
+	newClientFn = func(actual *rootFlags) (*Client, error) {
+		// Prefer the actual flag values from the caller — this lets a
+		// subcommand test pass a doctored rootFlags through addCommonFlags
+		// while still using the httptest base URL when no override came in.
+		if actual.apiURL == "" {
+			actual.apiURL = flags.apiURL
+		}
+		if actual.apiToken == "" {
+			actual.apiToken = flags.apiToken
+		}
+		return newClient(endpoint{URL: actual.apiURL, Token: actual.apiToken}), nil
+	}
+}
+
+// runCommand executes a cobra command with captured stdout/stderr. The
+// caller provides pre-bound args. Returns the stdout bytes and any
+// error the command surfaced.
+func runCommand(cmd *cobra.Command, args ...string) (string, error) {
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+// writeJSONResponse encodes v as JSON and writes it with the given
+// status code. Used by mock handlers to return canned responses.
+func writeJSONResponse(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// testFixedTime returns a stable non-zero timestamp used in test fixtures.
+// Picking a fixed value keeps rendered output deterministic.
+func testFixedTime() time.Time {
+	return time.Date(2026, time.April, 13, 12, 0, 0, 0, time.UTC)
+}
+
+// makeDetail builds a populated SessionDetail for handler/render tests.
+func makeDetail() proxy.SessionDetail {
+	now := testFixedTime()
+	return proxy.SessionDetail{
+		SessionSnapshot: proxy.SessionSnapshot{
+			Key:             testKeyIdent,
+			Agent:           "agent-z",
+			ClientIP:        "10.0.0.42",
+			Kind:            "identity",
+			ThreatScore:     0.75,
+			EscalationLevel: "critical",
+			AirlockTier:     "hard",
+			LastActivity:    now,
+		},
+		AirlockEnteredAt:   now,
+		InFlight:           3,
+		EscalationLevelInt: 3,
+		RecentEvents: []proxy.SessionEvent{
+			{At: now, Kind: "block", Target: "evil.example.com", Detail: "dlp secret", Severity: "critical", Score: 0.9},
+		},
+	}
+}
+
+// makeExplanation builds a populated SessionExplanation for tests.
+func makeExplanation() proxy.SessionExplanation {
+	now := testFixedTime()
+	return proxy.SessionExplanation{
+		Key:                  testKeyIdent,
+		Tier:                 "hard",
+		Reason:               "session quarantined at airlock tier hard",
+		Trigger:              "on_critical",
+		TriggerSource:        "airlock_triggers",
+		EnteredAt:            now,
+		EscalationLevel:      "critical",
+		EscalationLevelInt:   3,
+		ThreatScore:          0.9,
+		EvidenceKind:         "block",
+		EvidenceTarget:       "evil.example.com",
+		EvidenceDetail:       "dlp secret",
+		EvidenceAt:           now,
+		NextDeescalationTier: "soft",
+		NextDeescalationAt:   now.Add(time.Hour),
+	}
+}
+
+// makeSnapshot builds a populated SessionSnapshot slice for list tests.
+func makeSnapshotList() []proxy.SessionSnapshot {
+	now := testFixedTime()
+	return []proxy.SessionSnapshot{
+		{
+			Key: testKeyIdent, Agent: "agent-z", ClientIP: "10.0.0.42",
+			Kind: "identity", AirlockTier: "hard",
+			EscalationLevel: "critical", ThreatScore: 0.9,
+			LastActivity: now,
+		},
+	}
+}
+
+// stubRecoverDispatcher is the recoverDispatcher used by recover_test.go
+// to assert which downstream method was called without hitting the wire.
+type stubRecoverDispatcher struct {
+	inspectCalls   int
+	explainCalls   int
+	releaseCalls   int
+	terminateCalls int
+	lastReleaseTo  string
+	lastKey        string
+	returnErr      error
+}
+
+func (s *stubRecoverDispatcher) Inspect(_ context.Context, _ *Client, key string, _ io.Writer) error {
+	s.inspectCalls++
+	s.lastKey = key
+	return s.returnErr
+}
+
+func (s *stubRecoverDispatcher) Explain(_ context.Context, _ *Client, key string, _ io.Writer) error {
+	s.explainCalls++
+	s.lastKey = key
+	return s.returnErr
+}
+
+func (s *stubRecoverDispatcher) Release(_ context.Context, _ *Client, key, tier string, _ io.Writer) error {
+	s.releaseCalls++
+	s.lastKey = key
+	s.lastReleaseTo = tier
+	return s.returnErr
+}
+
+func (s *stubRecoverDispatcher) Terminate(_ context.Context, _ *Client, key string, _ io.Writer) error {
+	s.terminateCalls++
+	s.lastKey = key
+	return s.returnErr
+}

--- a/internal/cli/session/inspect.go
+++ b/internal/cli/session/inspect.go
@@ -15,7 +15,7 @@ const (
 	inspectShort = "Show the full detail snapshot of a session"
 )
 
-func inspectCmd() *cobra.Command {
+func inspectCmd(flags *rootFlags) *cobra.Command {
 	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   inspectUse,
@@ -31,7 +31,6 @@ Examples:
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	flags := addCommonFlags(cmd)
 	cmd.Flags().BoolVar(&jsonOutput, flagJSON, false, usageJSON)
 
 	cmd.RunE = func(c *cobra.Command, args []string) error {

--- a/internal/cli/session/inspect.go
+++ b/internal/cli/session/inspect.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	inspectUse   = "inspect <key>"
+	inspectShort = "Show the full detail snapshot of a session"
+)
+
+func inspectCmd() *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   inspectUse,
+		Short: inspectShort,
+		Long: `Dump the full SessionDetail for the given key: airlock tier, entry
+time, in-flight count, threat score, and recent events. Use --json for
+the raw wire format.
+
+Examples:
+  pipelock session inspect "agent|10.0.0.1"
+  pipelock session inspect "agent|10.0.0.1" --json`,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	flags := addCommonFlags(cmd)
+	cmd.Flags().BoolVar(&jsonOutput, flagJSON, false, usageJSON)
+
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+		key := args[0]
+		return runClientCmd(flags, c.Context(), c.OutOrStdout(), func(ctx context.Context, client *Client, out io.Writer) error {
+			detail, err := client.Inspect(ctx, key)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return writeJSON(out, detail)
+			}
+			return renderDetail(out, detail)
+		})
+	}
+	return cmd
+}

--- a/internal/cli/session/inspect_test.go
+++ b/internal/cli/session/inspect_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+)
+
+func TestInspectCmd_HappyPathHuman(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertBearer(t, r)
+		writeJSONResponse(w, http.StatusOK, makeDetail())
+	}))
+	overrideClientFactory(t, flags)
+
+	out, err := runCommand(inspectCmd(), testKeyIdent)
+	if err != nil {
+		t.Fatalf("execute: %v; out=%s", err, out)
+	}
+	wantContains := []string{testKeyIdent, "hard", "in_flight", "dlp secret"}
+	for _, w := range wantContains {
+		if !strings.Contains(out, w) {
+			t.Errorf("missing %q in: %s", w, out)
+		}
+	}
+}
+
+func TestInspectCmd_JSON(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(w, http.StatusOK, makeDetail())
+	}))
+	overrideClientFactory(t, flags)
+
+	out, err := runCommand(inspectCmd(), testKeyIdent, "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed proxy.SessionDetail
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v; out=%s", err, out)
+	}
+	if parsed.Key != testKeyIdent {
+		t.Errorf("Key: got %q", parsed.Key)
+	}
+}
+
+func TestInspectCmd_RequiresArg(t *testing.T) {
+	overrideClientFactory(t, &rootFlags{apiURL: "http://ignored:1", apiToken: testToken})
+	_, err := runCommand(inspectCmd())
+	if err == nil {
+		t.Error("expected error without key argument")
+	}
+}
+
+func TestInspectCmd_NotFound(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusNotFound)
+	}))
+	overrideClientFactory(t, flags)
+
+	_, err := runCommand(inspectCmd(), testKeyIdent)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not found, got %v", err)
+	}
+}
+
+func TestInspectCmd_Unauthorized(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "bad token", http.StatusUnauthorized)
+	}))
+	overrideClientFactory(t, flags)
+
+	_, err := runCommand(inspectCmd(), testKeyIdent)
+	if err == nil || !strings.Contains(err.Error(), "unauthorized") {
+		t.Errorf("expected unauthorized, got %v", err)
+	}
+}

--- a/internal/cli/session/inspect_test.go
+++ b/internal/cli/session/inspect_test.go
@@ -19,7 +19,7 @@ func TestInspectCmd_HappyPathHuman(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	out, err := runCommand(inspectCmd(), testKeyIdent)
+	out, err := runCommand(inspectCmd(&rootFlags{}), testKeyIdent)
 	if err != nil {
 		t.Fatalf("execute: %v; out=%s", err, out)
 	}
@@ -37,7 +37,7 @@ func TestInspectCmd_JSON(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	out, err := runCommand(inspectCmd(), testKeyIdent, "--json")
+	out, err := runCommand(inspectCmd(&rootFlags{}), testKeyIdent, "--json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestInspectCmd_JSON(t *testing.T) {
 
 func TestInspectCmd_RequiresArg(t *testing.T) {
 	overrideClientFactory(t, &rootFlags{apiURL: "http://ignored:1", apiToken: testToken})
-	_, err := runCommand(inspectCmd())
+	_, err := runCommand(inspectCmd(&rootFlags{}))
 	if err == nil {
 		t.Error("expected error without key argument")
 	}
@@ -64,7 +64,7 @@ func TestInspectCmd_NotFound(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	_, err := runCommand(inspectCmd(), testKeyIdent)
+	_, err := runCommand(inspectCmd(&rootFlags{}), testKeyIdent)
 	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Errorf("expected not found, got %v", err)
 	}
@@ -76,7 +76,7 @@ func TestInspectCmd_Unauthorized(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	_, err := runCommand(inspectCmd(), testKeyIdent)
+	_, err := runCommand(inspectCmd(&rootFlags{}), testKeyIdent)
 	if err == nil || !strings.Contains(err.Error(), "unauthorized") {
 		t.Errorf("expected unauthorized, got %v", err)
 	}

--- a/internal/cli/session/integration_test.go
+++ b/internal/cli/session/integration_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/killswitch"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+const (
+	integSessionKey = "integration-agent|10.0.0.50"
+	integToken      = "integration-token"
+)
+
+// TestSessionCLI_Integration_ListInspectRelease stands up a full
+// admin-API HTTP server wired to a real proxy.SessionManager with a
+// seeded hard-tier session, then runs list → inspect → release through
+// the CLI commands against the live endpoint. Asserts the end state:
+// the session is still in the manager, its tier is none, and the
+// release response reflects the transition.
+//
+// Uses net.ListenConfig{}.Listen(ctx, ...) for noctx compliance and a
+// closed-channel handshake instead of time.Sleep for the shutdown path.
+func TestSessionCLI_Integration_ListInspectRelease(t *testing.T) {
+	sessProfiling := &config.SessionProfiling{
+		MaxSessions:            50,
+		SessionTTLMinutes:      30,
+		CleanupIntervalSeconds: 300,
+		DomainBurst:            10,
+		WindowMinutes:          5,
+	}
+	sm := proxy.NewSessionManager(sessProfiling, nil, metrics.New(), proxy.SessionManagerOptions{
+		Logger: audit.NewNop(),
+	})
+	defer sm.Close()
+
+	sess := sm.GetOrCreate(integSessionKey)
+	sess.RecordEvent(proxy.SessionEvent{
+		Kind:     "block",
+		Target:   "evil.example.com",
+		Detail:   "dlp block (integration)",
+		Severity: "critical",
+		Score:    0.95,
+	})
+	_, _, _ = sess.Airlock().SetTierWithProvenance(config.AirlockTierHard, "on_critical", "airlock_triggers")
+
+	// Wire the admin API handler using the options struct. Pointers are
+	// atomic so the handler reads through them the way runtime/run.go does.
+	var smPtr atomic.Pointer[proxy.SessionManager]
+	smPtr.Store(sm)
+	var etPtr atomic.Pointer[scanner.EntropyTracker]
+	var fbPtr atomic.Pointer[scanner.FragmentBuffer]
+	handler := proxy.NewSessionAPIHandler(proxy.SessionAPIOptions{
+		SessionMgrPtr: &smPtr,
+		EntropyPtr:    &etPtr,
+		FragmentPtr:   &fbPtr,
+		Logger:        audit.NewNop(),
+		APIToken:      integToken,
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/sessions", handler.HandleList)
+	mux.HandleFunc("/api/v1/sessions/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.EscapedPath()
+		switch {
+		case killswitch.IsSessionActionPath(path, "airlock"):
+			handler.HandleAirlock(w, r)
+		case killswitch.IsSessionActionPath(path, "explain"):
+			handler.HandleExplain(w, r)
+		case killswitch.IsSessionActionPath(path, "terminate"):
+			handler.HandleTerminate(w, r)
+		case killswitch.IsSessionKeyPath(path):
+			handler.HandleInspect(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var lc net.ListenConfig
+	ln, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		_ = srv.Serve(ln)
+	}()
+	t.Cleanup(func() {
+		shutdownCtx, cancelShut := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancelShut()
+		_ = srv.Shutdown(shutdownCtx)
+		<-serverDone
+	})
+
+	base := "http://" + ln.Addr().String()
+	flags := &rootFlags{apiURL: base, apiToken: integToken}
+	overrideClientFactory(t, flags)
+
+	// Step 1: list --tier hard should return exactly our seeded session.
+	out, err := runCommand(listCmd(), "--tier", "hard")
+	if err != nil {
+		t.Fatalf("list: %v; out=%s", err, out)
+	}
+	if !strings.Contains(out, integSessionKey) {
+		t.Errorf("list output missing key: %s", out)
+	}
+
+	// Step 2: inspect shows the full detail including the event.
+	out, err = runCommand(inspectCmd(), integSessionKey)
+	if err != nil {
+		t.Fatalf("inspect: %v; out=%s", err, out)
+	}
+	if !strings.Contains(out, "dlp block (integration)") {
+		t.Errorf("inspect output missing event detail: %s", out)
+	}
+
+	// Step 3: release to none — wraps HandleAirlock with ForceSetTier.
+	out, err = runCommand(releaseCmd(), integSessionKey, "--to", "none")
+	if err != nil {
+		t.Fatalf("release: %v; out=%s", err, out)
+	}
+	if !strings.Contains(out, "released") {
+		t.Errorf("release output: %s", out)
+	}
+
+	// Assert end state: the session is still in the manager, but its
+	// airlock tier is now none.
+	if !sm.SessionExists(integSessionKey) {
+		t.Error("session should still exist after release")
+	}
+	if got := sess.Airlock().Tier(); got != config.AirlockTierNone {
+		t.Errorf("tier after release: got %q, want %q", got, config.AirlockTierNone)
+	}
+}
+
+func TestSessionCLI_Integration_Explain(t *testing.T) {
+	sessProfiling := &config.SessionProfiling{
+		MaxSessions:            50,
+		SessionTTLMinutes:      30,
+		CleanupIntervalSeconds: 300,
+		DomainBurst:            10,
+		WindowMinutes:          5,
+	}
+	airlockCfg := &config.Airlock{
+		Enabled: true,
+		Triggers: config.AirlockTriggers{
+			OnElevated: config.AirlockTierNone,
+			OnHigh:     config.AirlockTierSoft,
+			OnCritical: config.AirlockTierHard,
+		},
+		Timers: config.AirlockTimers{SoftMinutes: 5, HardMinutes: 10},
+	}
+	sm := proxy.NewSessionManager(sessProfiling, nil, metrics.New(), proxy.SessionManagerOptions{
+		AirlockCfg: airlockCfg,
+		Logger:     audit.NewNop(),
+	})
+	defer sm.Close()
+
+	sess := sm.GetOrCreate(integSessionKey)
+	sess.RecordEvent(proxy.SessionEvent{
+		Kind:     "block",
+		Target:   "evil.example.com",
+		Detail:   "triggered explain",
+		Severity: "critical",
+		Score:    0.9,
+	})
+	_, _, _ = sess.Airlock().SetTierWithProvenance(config.AirlockTierHard, "on_critical", "airlock_triggers")
+
+	var smPtr atomic.Pointer[proxy.SessionManager]
+	smPtr.Store(sm)
+	var etPtr atomic.Pointer[scanner.EntropyTracker]
+	var fbPtr atomic.Pointer[scanner.FragmentBuffer]
+	handler := proxy.NewSessionAPIHandler(proxy.SessionAPIOptions{
+		SessionMgrPtr: &smPtr,
+		EntropyPtr:    &etPtr,
+		FragmentPtr:   &fbPtr,
+		Logger:        audit.NewNop(),
+		APIToken:      integToken,
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/sessions/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.EscapedPath()
+		switch {
+		case killswitch.IsSessionActionPath(path, "explain"):
+			handler.HandleExplain(w, r)
+		case killswitch.IsSessionKeyPath(path):
+			handler.HandleInspect(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	// httptest server for simplicity in this test.
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	flags := &rootFlags{apiURL: srv.URL, apiToken: integToken}
+	overrideClientFactory(t, flags)
+
+	out, err := runCommand(explainCmd(), integSessionKey)
+	if err != nil {
+		t.Fatalf("explain: %v; out=%s", err, out)
+	}
+	wantContains := []string{"on_critical", "triggered explain", "next_deescalation"}
+	for _, w := range wantContains {
+		if !strings.Contains(out, w) {
+			t.Errorf("explain output missing %q: %s", w, out)
+		}
+	}
+}

--- a/internal/cli/session/integration_test.go
+++ b/internal/cli/session/integration_test.go
@@ -117,7 +117,7 @@ func TestSessionCLI_Integration_ListInspectRelease(t *testing.T) {
 	overrideClientFactory(t, flags)
 
 	// Step 1: list --tier hard should return exactly our seeded session.
-	out, err := runCommand(listCmd(), "--tier", "hard")
+	out, err := runCommand(listCmd(&rootFlags{}), "--tier", "hard")
 	if err != nil {
 		t.Fatalf("list: %v; out=%s", err, out)
 	}
@@ -126,7 +126,7 @@ func TestSessionCLI_Integration_ListInspectRelease(t *testing.T) {
 	}
 
 	// Step 2: inspect shows the full detail including the event.
-	out, err = runCommand(inspectCmd(), integSessionKey)
+	out, err = runCommand(inspectCmd(&rootFlags{}), integSessionKey)
 	if err != nil {
 		t.Fatalf("inspect: %v; out=%s", err, out)
 	}
@@ -135,7 +135,7 @@ func TestSessionCLI_Integration_ListInspectRelease(t *testing.T) {
 	}
 
 	// Step 3: release to none — wraps HandleAirlock with ForceSetTier.
-	out, err = runCommand(releaseCmd(), integSessionKey, "--to", "none")
+	out, err = runCommand(releaseCmd(&rootFlags{}), integSessionKey, "--to", "none")
 	if err != nil {
 		t.Fatalf("release: %v; out=%s", err, out)
 	}
@@ -218,7 +218,7 @@ func TestSessionCLI_Integration_Explain(t *testing.T) {
 	flags := &rootFlags{apiURL: srv.URL, apiToken: integToken}
 	overrideClientFactory(t, flags)
 
-	out, err := runCommand(explainCmd(), integSessionKey)
+	out, err := runCommand(explainCmd(&rootFlags{}), integSessionKey)
 	if err != nil {
 		t.Fatalf("explain: %v; out=%s", err, out)
 	}

--- a/internal/cli/session/list.go
+++ b/internal/cli/session/list.go
@@ -20,7 +20,7 @@ const (
 	listTierDoc = `filter sessions by airlock tier (none|soft|hard|drain|normal)`
 )
 
-func listCmd() *cobra.Command {
+func listCmd(flags *rootFlags) *cobra.Command {
 	var (
 		tier       string
 		jsonOutput bool
@@ -40,7 +40,6 @@ Examples:
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	flags := addCommonFlags(cmd)
 	cmd.Flags().StringVar(&tier, "tier", "", listTierDoc)
 	cmd.Flags().BoolVar(&jsonOutput, flagJSON, false, usageJSON)
 

--- a/internal/cli/session/list.go
+++ b/internal/cli/session/list.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const (
+	listUse     = "list"
+	listShort   = "List active sessions and their airlock tiers"
+	listTierDoc = `filter sessions by airlock tier (none|soft|hard|drain|normal)`
+)
+
+func listCmd() *cobra.Command {
+	var (
+		tier       string
+		jsonOutput bool
+	)
+	cmd := &cobra.Command{
+		Use:   listUse,
+		Short: listShort,
+		Long: `List all active sessions and their current airlock tier.
+
+Use --tier to filter by quarantine state. Use --json for machine output.
+
+Examples:
+  pipelock session list
+  pipelock session list --tier hard
+  pipelock session list --json`,
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	flags := addCommonFlags(cmd)
+	cmd.Flags().StringVar(&tier, "tier", "", listTierDoc)
+	cmd.Flags().BoolVar(&jsonOutput, flagJSON, false, usageJSON)
+
+	cmd.RunE = func(c *cobra.Command, _ []string) error {
+		if err := validateTierFilter(tier); err != nil {
+			return cliutil.ExitCodeError(2, err)
+		}
+		return runClientCmd(flags, c.Context(), c.OutOrStdout(), func(ctx context.Context, client *Client, out io.Writer) error {
+			resp, err := client.List(ctx, tier)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return writeJSON(out, resp)
+			}
+			return renderList(out, resp.Sessions)
+		})
+	}
+	return cmd
+}
+
+// validateTierFilter rejects obviously-bogus tier filters before a round
+// trip to the server. The server re-validates, but a local check gives
+// operators a faster feedback loop and a clearer error.
+func validateTierFilter(tier string) error {
+	if tier == "" {
+		return nil
+	}
+	switch tier {
+	case config.AirlockTierNone,
+		config.AirlockTierSoft,
+		config.AirlockTierHard,
+		config.AirlockTierDrain,
+		airlockTierAliasNormal:
+		return nil
+	}
+	return errors.New("invalid --tier: must be none|soft|hard|drain|normal")
+}
+
+// airlockTierAliasNormal mirrors the server-side alias: "normal" is
+// accepted on the wire as a synonym for the "none" tier. Defined here
+// so the CLI validates without importing the unexported proxy constant.
+const airlockTierAliasNormal = "normal"

--- a/internal/cli/session/list_test.go
+++ b/internal/cli/session/list_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 )
 
 func TestListCmd_HappyPathHuman(t *testing.T) {
@@ -17,7 +19,7 @@ func TestListCmd_HappyPathHuman(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	out, err := runCommand(listCmd())
+	out, err := runCommand(listCmd(&rootFlags{}))
 	if err != nil {
 		t.Fatalf("execute: %v; out=%s", err, out)
 	}
@@ -35,7 +37,7 @@ func TestListCmd_JSONOutput(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	out, err := runCommand(listCmd(), "--json")
+	out, err := runCommand(listCmd(&rootFlags{}), "--json")
 	if err != nil {
 		t.Fatalf("execute: %v; out=%s", err, out)
 	}
@@ -56,7 +58,7 @@ func TestListCmd_TierFilterForwarded(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	if _, err := runCommand(listCmd(), "--tier", tierHard); err != nil {
+	if _, err := runCommand(listCmd(&rootFlags{}), "--tier", tierHard); err != nil {
 		t.Fatal(err)
 	}
 	if gotTier != tierHard {
@@ -67,7 +69,7 @@ func TestListCmd_TierFilterForwarded(t *testing.T) {
 func TestListCmd_InvalidTierFailsLocally(t *testing.T) {
 	// Don't stand up a server — local validation catches this first.
 	overrideClientFactory(t, &rootFlags{apiURL: "http://ignored:1", apiToken: testToken})
-	_, err := runCommand(listCmd(), "--tier", "moist")
+	_, err := runCommand(listCmd(&rootFlags{}), "--tier", "moist")
 	if err == nil {
 		t.Error("expected error for bogus tier")
 	}
@@ -75,51 +77,75 @@ func TestListCmd_InvalidTierFailsLocally(t *testing.T) {
 
 func TestListCmd_404Maps_SessionNotFound(t *testing.T) {
 	// List returns 404 rarely, but the path is validated for robustness.
+	// Also pins the mapped exit code (1 = operational failure) so a
+	// regression that collapses 404 into exit 0 or exit 2 fails the
+	// test even if the error text is preserved.
 	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "nope", http.StatusNotFound)
 	}))
 	overrideClientFactory(t, flags)
 
-	_, err := runCommand(listCmd())
+	_, err := runCommand(listCmd(&rootFlags{}))
 	if err == nil {
-		t.Error("expected error")
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not-found text, got %v", err)
+	}
+	if code := cliutil.ExitCodeOf(err); code != 1 {
+		t.Errorf("exit code: got %d, want 1", code)
 	}
 }
 
 func TestListCmd_401Maps_Unauthorized(t *testing.T) {
+	// 401 is a setup error; exit code 2 signals scripts that the
+	// token/url should be fixed before retrying.
 	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "bad token", http.StatusUnauthorized)
 	}))
 	overrideClientFactory(t, flags)
 
-	_, err := runCommand(listCmd())
+	_, err := runCommand(listCmd(&rootFlags{}))
 	if err == nil || !strings.Contains(err.Error(), "unauthorized") {
-		t.Errorf("expected unauthorized error, got %v", err)
+		t.Fatalf("expected unauthorized error, got %v", err)
+	}
+	if code := cliutil.ExitCodeOf(err); code != 2 {
+		t.Errorf("exit code: got %d, want 2", code)
 	}
 }
 
 func TestListCmd_429Maps_RateLimited(t *testing.T) {
+	// 429 is retry-able; exit code 1 signals scripts that a backoff
+	// retry is the right response.
 	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Retry-After", "60")
 		http.Error(w, "slow down", http.StatusTooManyRequests)
 	}))
 	overrideClientFactory(t, flags)
 
-	_, err := runCommand(listCmd())
+	_, err := runCommand(listCmd(&rootFlags{}))
 	if err == nil || !strings.Contains(err.Error(), "rate limited") {
-		t.Errorf("expected rate limited error, got %v", err)
+		t.Fatalf("expected rate limited error, got %v", err)
+	}
+	if code := cliutil.ExitCodeOf(err); code != 1 {
+		t.Errorf("exit code: got %d, want 1", code)
 	}
 }
 
 func TestListCmd_500Maps_ServerError(t *testing.T) {
+	// 500 is an operational failure on the server side. Scripts get
+	// exit code 1 so they can retry or escalate — same class as 404.
 	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "internal boom", http.StatusInternalServerError)
 	}))
 	overrideClientFactory(t, flags)
 
-	_, err := runCommand(listCmd())
+	_, err := runCommand(listCmd(&rootFlags{}))
 	if err == nil || !strings.Contains(err.Error(), "server error") {
-		t.Errorf("expected server error wrapper, got %v", err)
+		t.Fatalf("expected server error wrapper, got %v", err)
+	}
+	if code := cliutil.ExitCodeOf(err); code != 1 {
+		t.Errorf("exit code: got %d, want 1", code)
 	}
 }
 
@@ -129,7 +155,7 @@ func TestListCmd_EmptyResultPrintsPlaceholder(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	out, err := runCommand(listCmd())
+	out, err := runCommand(listCmd(&rootFlags{}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/session/list_test.go
+++ b/internal/cli/session/list_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestListCmd_HappyPathHuman(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertBearer(t, r)
+		writeJSONResponse(w, http.StatusOK, listResponse{Sessions: makeSnapshotList(), Count: 1})
+	}))
+	overrideClientFactory(t, flags)
+
+	out, err := runCommand(listCmd())
+	if err != nil {
+		t.Fatalf("execute: %v; out=%s", err, out)
+	}
+	if !strings.Contains(out, testKeyIdent) {
+		t.Errorf("output missing key: %s", out)
+	}
+	if !strings.Contains(out, tierHard) {
+		t.Errorf("output missing tier: %s", out)
+	}
+}
+
+func TestListCmd_JSONOutput(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(w, http.StatusOK, listResponse{Sessions: makeSnapshotList(), Count: 1})
+	}))
+	overrideClientFactory(t, flags)
+
+	out, err := runCommand(listCmd(), "--json")
+	if err != nil {
+		t.Fatalf("execute: %v; out=%s", err, out)
+	}
+	var parsed listResponse
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json output not parseable: %v; out=%s", err, out)
+	}
+	if parsed.Count != 1 {
+		t.Errorf("Count: got %d, want 1", parsed.Count)
+	}
+}
+
+func TestListCmd_TierFilterForwarded(t *testing.T) {
+	var gotTier string
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTier = r.URL.Query().Get("tier")
+		writeJSONResponse(w, http.StatusOK, listResponse{})
+	}))
+	overrideClientFactory(t, flags)
+
+	if _, err := runCommand(listCmd(), "--tier", tierHard); err != nil {
+		t.Fatal(err)
+	}
+	if gotTier != tierHard {
+		t.Errorf("tier forwarded: got %q", gotTier)
+	}
+}
+
+func TestListCmd_InvalidTierFailsLocally(t *testing.T) {
+	// Don't stand up a server — local validation catches this first.
+	overrideClientFactory(t, &rootFlags{apiURL: "http://ignored:1", apiToken: testToken})
+	_, err := runCommand(listCmd(), "--tier", "moist")
+	if err == nil {
+		t.Error("expected error for bogus tier")
+	}
+}
+
+func TestListCmd_404Maps_SessionNotFound(t *testing.T) {
+	// List returns 404 rarely, but the path is validated for robustness.
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusNotFound)
+	}))
+	overrideClientFactory(t, flags)
+
+	_, err := runCommand(listCmd())
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestListCmd_401Maps_Unauthorized(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "bad token", http.StatusUnauthorized)
+	}))
+	overrideClientFactory(t, flags)
+
+	_, err := runCommand(listCmd())
+	if err == nil || !strings.Contains(err.Error(), "unauthorized") {
+		t.Errorf("expected unauthorized error, got %v", err)
+	}
+}
+
+func TestListCmd_429Maps_RateLimited(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "slow down", http.StatusTooManyRequests)
+	}))
+	overrideClientFactory(t, flags)
+
+	_, err := runCommand(listCmd())
+	if err == nil || !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("expected rate limited error, got %v", err)
+	}
+}
+
+func TestListCmd_500Maps_ServerError(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "internal boom", http.StatusInternalServerError)
+	}))
+	overrideClientFactory(t, flags)
+
+	_, err := runCommand(listCmd())
+	if err == nil || !strings.Contains(err.Error(), "server error") {
+		t.Errorf("expected server error wrapper, got %v", err)
+	}
+}
+
+func TestListCmd_EmptyResultPrintsPlaceholder(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(w, http.StatusOK, listResponse{Count: 0})
+	}))
+	overrideClientFactory(t, flags)
+
+	out, err := runCommand(listCmd())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "No sessions") {
+		t.Errorf("expected no-sessions placeholder: %s", out)
+	}
+}

--- a/internal/cli/session/recover.go
+++ b/internal/cli/session/recover.go
@@ -1,0 +1,208 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+// recoveryChoice enumerates the recoverable outcomes of the interactive
+// recover workflow. Also accepted as the --choice flag value so scripts
+// can drive the same workflow non-interactively.
+type recoveryChoice string
+
+const (
+	choiceReleaseNone recoveryChoice = "release-none"
+	choiceReleaseSoft recoveryChoice = "release-soft"
+	choiceTerminate   recoveryChoice = "terminate"
+	choiceLeave       recoveryChoice = "leave"
+)
+
+// recoverDispatcher is the seam the interactive wrapper calls to invoke
+// downstream subcommands. The real implementation wraps the HTTP client;
+// tests substitute a stub that records calls and returns fixed results.
+type recoverDispatcher interface {
+	Inspect(ctx context.Context, client *Client, key string, out io.Writer) error
+	Explain(ctx context.Context, client *Client, key string, out io.Writer) error
+	Release(ctx context.Context, client *Client, key, tier string, out io.Writer) error
+	Terminate(ctx context.Context, client *Client, key string, out io.Writer) error
+}
+
+// httpDispatcher implements recoverDispatcher by calling the live client
+// methods and rendering the results through the same helpers the
+// non-interactive subcommands use.
+type httpDispatcher struct{}
+
+func (httpDispatcher) Inspect(ctx context.Context, client *Client, key string, out io.Writer) error {
+	detail, err := client.Inspect(ctx, key)
+	if err != nil {
+		return err
+	}
+	return renderDetail(out, detail)
+}
+
+func (httpDispatcher) Explain(ctx context.Context, client *Client, key string, out io.Writer) error {
+	exp, err := client.Explain(ctx, key)
+	if err != nil {
+		return err
+	}
+	return renderExplanation(out, exp)
+}
+
+func (httpDispatcher) Release(ctx context.Context, client *Client, key, tier string, out io.Writer) error {
+	resp, err := client.Release(ctx, key, tier)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(out, "released %s: %s -> %s\n", resp.Key, resp.PreviousTier, resp.NewTier)
+	return nil
+}
+
+func (httpDispatcher) Terminate(ctx context.Context, client *Client, key string, out io.Writer) error {
+	resp, err := client.Terminate(ctx, key)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(out, "terminated %s: previous_tier=%s level=%s\n", resp.Key, resp.PreviousTier, resp.PreviousLevel)
+	return nil
+}
+
+// recoverDispatcherFn is the variable tests override to inject a stub.
+var recoverDispatcherFn func() recoverDispatcher = func() recoverDispatcher { return httpDispatcher{} }
+
+func recoverCmd() *cobra.Command {
+	var choiceFlag string
+	cmd := &cobra.Command{
+		Use:   "recover <key>",
+		Short: "Interactive recovery workflow: inspect, explain, choose action",
+		Long: `Interactive recovery helper. Walks the operator through inspect and
+explain for the given session, then prompts for an action: release
+the session to none, release to soft, terminate, or leave it alone.
+
+Use --choice to script the workflow non-interactively. Accepted
+values: release-none, release-soft, terminate, leave.
+
+Examples:
+  pipelock session recover "agent|10.0.0.1"
+  pipelock session recover "agent|10.0.0.1" --choice release-none`,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	flags := addCommonFlags(cmd)
+	cmd.Flags().StringVar(&choiceFlag, "choice", "", "non-interactive choice (release-none|release-soft|terminate|leave)")
+
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+		key := args[0]
+
+		if choiceFlag != "" {
+			if err := validateRecoverChoice(choiceFlag); err != nil {
+				return cliutil.ExitCodeError(2, err)
+			}
+		}
+
+		return runClientCmd(flags, c.Context(), c.OutOrStdout(), func(ctx context.Context, client *Client, out io.Writer) error {
+			dispatcher := recoverDispatcherFn()
+
+			_, _ = fmt.Fprintln(out, "== inspect ==")
+			if err := dispatcher.Inspect(ctx, client, key, out); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintln(out, "")
+			_, _ = fmt.Fprintln(out, "== explain ==")
+			if err := dispatcher.Explain(ctx, client, key, out); err != nil {
+				return err
+			}
+
+			choice := recoveryChoice(choiceFlag)
+			if choiceFlag == "" {
+				var err error
+				choice, err = promptRecoveryChoice(c.InOrStdin(), out)
+				if err != nil {
+					return cliutil.ExitCodeError(2, err)
+				}
+			}
+
+			return dispatchRecoveryChoice(ctx, dispatcher, client, key, choice, out)
+		})
+	}
+	return cmd
+}
+
+// validateRecoverChoice rejects any raw string that does not map to a
+// known recovery action. Returns an error naming the accepted values
+// when the input is unrecognized. The canonical choice is constructed
+// by the caller via recoveryChoice(raw) after this validation succeeds.
+func validateRecoverChoice(raw string) error {
+	switch recoveryChoice(raw) {
+	case choiceReleaseNone, choiceReleaseSoft, choiceTerminate, choiceLeave:
+		return nil
+	}
+	return errors.New("invalid --choice: must be release-none, release-soft, terminate, or leave")
+}
+
+// promptRecoveryChoice reads a numbered selection from in and returns
+// the corresponding recoveryChoice. Any input that does not map to one
+// of the four choices is treated as an error.
+func promptRecoveryChoice(in io.Reader, out io.Writer) (recoveryChoice, error) {
+	_, _ = fmt.Fprintln(out, "")
+	_, _ = fmt.Fprintln(out, "Choose recovery action:")
+	_, _ = fmt.Fprintln(out, "  1) release to none")
+	_, _ = fmt.Fprintln(out, "  2) release to soft")
+	_, _ = fmt.Fprintln(out, "  3) terminate (destructive)")
+	_, _ = fmt.Fprintln(out, "  4) leave as-is")
+	_, _ = fmt.Fprint(out, "> ")
+
+	reader := bufio.NewReader(in)
+	line, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("read choice: %w", err)
+	}
+	line = strings.TrimSpace(line)
+
+	switch line {
+	case "1", "release-none":
+		return choiceReleaseNone, nil
+	case "2", "release-soft":
+		return choiceReleaseSoft, nil
+	case "3", "terminate":
+		return choiceTerminate, nil
+	case "4", "leave":
+		return choiceLeave, nil
+	}
+	return "", fmt.Errorf("unrecognized choice %q — must be 1-4 or one of release-none, release-soft, terminate, leave", line)
+}
+
+// dispatchRecoveryChoice runs the operation matching the chosen action.
+// "leave" is a no-op that confirms the session is unchanged.
+func dispatchRecoveryChoice(
+	ctx context.Context,
+	dispatcher recoverDispatcher,
+	client *Client,
+	key string,
+	choice recoveryChoice,
+	out io.Writer,
+) error {
+	switch choice {
+	case choiceReleaseNone:
+		return dispatcher.Release(ctx, client, key, "none", out)
+	case choiceReleaseSoft:
+		return dispatcher.Release(ctx, client, key, "soft", out)
+	case choiceTerminate:
+		return dispatcher.Terminate(ctx, client, key, out)
+	case choiceLeave:
+		_, _ = fmt.Fprintf(out, "leaving %s unchanged\n", key)
+		return nil
+	}
+	return fmt.Errorf("unhandled recovery choice %q", choice)
+}

--- a/internal/cli/session/recover.go
+++ b/internal/cli/session/recover.go
@@ -80,7 +80,7 @@ func (httpDispatcher) Terminate(ctx context.Context, client *Client, key string,
 // recoverDispatcherFn is the variable tests override to inject a stub.
 var recoverDispatcherFn func() recoverDispatcher = func() recoverDispatcher { return httpDispatcher{} }
 
-func recoverCmd() *cobra.Command {
+func recoverCmd(flags *rootFlags) *cobra.Command {
 	var choiceFlag string
 	cmd := &cobra.Command{
 		Use:   "recover <key>",
@@ -99,7 +99,6 @@ Examples:
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	flags := addCommonFlags(cmd)
 	cmd.Flags().StringVar(&choiceFlag, "choice", "", "non-interactive choice (release-none|release-soft|terminate|leave)")
 
 	cmd.RunE = func(c *cobra.Command, args []string) error {

--- a/internal/cli/session/recover_test.go
+++ b/internal/cli/session/recover_test.go
@@ -50,7 +50,7 @@ func TestRecoverCmd_ChoiceReleaseNone(t *testing.T) {
 	overrideClientFactory(t, flags)
 	stub := withStubDispatcher(t)
 
-	out, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "release-none")
+	out, err := runCommand(recoverCmd(&rootFlags{}), testKeyIdent, "--choice", "release-none")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestRecoverCmd_ChoiceReleaseSoft(t *testing.T) {
 	overrideClientFactory(t, flags)
 	stub := withStubDispatcher(t)
 
-	if _, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "release-soft"); err != nil {
+	if _, err := runCommand(recoverCmd(&rootFlags{}), testKeyIdent, "--choice", "release-soft"); err != nil {
 		t.Fatal(err)
 	}
 	if stub.lastReleaseTo != tierSoft {
@@ -84,7 +84,7 @@ func TestRecoverCmd_ChoiceTerminate(t *testing.T) {
 	overrideClientFactory(t, flags)
 	stub := withStubDispatcher(t)
 
-	if _, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "terminate"); err != nil {
+	if _, err := runCommand(recoverCmd(&rootFlags{}), testKeyIdent, "--choice", "terminate"); err != nil {
 		t.Fatal(err)
 	}
 	if stub.terminateCalls != 1 {
@@ -97,7 +97,7 @@ func TestRecoverCmd_ChoiceLeave(t *testing.T) {
 	overrideClientFactory(t, flags)
 	stub := withStubDispatcher(t)
 
-	out, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "leave")
+	out, err := runCommand(recoverCmd(&rootFlags{}), testKeyIdent, "--choice", "leave")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +115,7 @@ func TestRecoverCmd_BadChoice(t *testing.T) {
 	overrideClientFactory(t, flags)
 	withStubDispatcher(t)
 
-	_, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "eat-it")
+	_, err := runCommand(recoverCmd(&rootFlags{}), testKeyIdent, "--choice", "eat-it")
 	if err == nil {
 		t.Error("expected error for bogus choice")
 	}
@@ -126,7 +126,7 @@ func TestRecoverCmd_InteractiveStdin(t *testing.T) {
 	overrideClientFactory(t, flags)
 	stub := withStubDispatcher(t)
 
-	cmd := recoverCmd()
+	cmd := recoverCmd(&rootFlags{})
 	cmd.SetIn(strings.NewReader("1\n"))
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
@@ -146,7 +146,7 @@ func TestRecoverCmd_InteractiveStdin_InvalidInput(t *testing.T) {
 	overrideClientFactory(t, flags)
 	withStubDispatcher(t)
 
-	cmd := recoverCmd()
+	cmd := recoverCmd(&rootFlags{})
 	cmd.SetIn(strings.NewReader("xyz\n"))
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
@@ -177,7 +177,7 @@ func TestHTTPDispatcher_Inspect(t *testing.T) {
 	overrideClientFactory(t, flags)
 	// No stub — uses httpDispatcher{}.
 
-	_, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "leave")
+	_, err := runCommand(recoverCmd(&rootFlags{}), testKeyIdent, "--choice", "leave")
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestHTTPDispatcher_Release_Real(t *testing.T) {
 	overrideClientFactory(t, flags)
 	// No stub — uses httpDispatcher{}.
 
-	if _, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "release-none"); err != nil {
+	if _, err := runCommand(recoverCmd(&rootFlags{}), testKeyIdent, "--choice", "release-none"); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
 }
@@ -198,7 +198,7 @@ func TestHTTPDispatcher_Terminate_Real(t *testing.T) {
 	overrideClientFactory(t, flags)
 	// No stub — uses httpDispatcher{}.
 
-	if _, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "terminate"); err != nil {
+	if _, err := runCommand(recoverCmd(&rootFlags{}), testKeyIdent, "--choice", "terminate"); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
 }
@@ -218,7 +218,7 @@ func TestHTTPDispatcher_InspectPropagatesError(t *testing.T) {
 	overrideClientFactory(t, flags)
 	// No stub — uses httpDispatcher.
 
-	_, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "leave")
+	_, err := runCommand(recoverCmd(&rootFlags{}), testKeyIdent, "--choice", "leave")
 	if err == nil {
 		t.Error("expected error from inspect 404")
 	}
@@ -242,7 +242,7 @@ func errorServerExplain(t *testing.T) *rootFlags {
 func TestHTTPDispatcher_ExplainPropagatesError(t *testing.T) {
 	flags := errorServerExplain(t)
 	overrideClientFactory(t, flags)
-	_, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "leave")
+	_, err := runCommand(recoverCmd(&rootFlags{}), testKeyIdent, "--choice", "leave")
 	if err == nil {
 		t.Error("expected error from explain 500")
 	}
@@ -261,7 +261,7 @@ func TestHTTPDispatcher_ReleasePropagatesError(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	_, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "release-none")
+	_, err := runCommand(recoverCmd(&rootFlags{}), testKeyIdent, "--choice", "release-none")
 	if err == nil {
 		t.Error("expected error from release 500")
 	}
@@ -280,7 +280,7 @@ func TestHTTPDispatcher_TerminatePropagatesError(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	_, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "terminate")
+	_, err := runCommand(recoverCmd(&rootFlags{}), testKeyIdent, "--choice", "terminate")
 	if err == nil {
 		t.Error("expected error from terminate 500")
 	}

--- a/internal/cli/session/recover_test.go
+++ b/internal/cli/session/recover_test.go
@@ -1,0 +1,336 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// stubRecoverServer returns a canned inspect/explain response on any
+// request. Release/terminate return success so the dispatcher's real
+// paths also exercise cleanly when the flag-based tests hit them.
+func stubRecoverServer(t *testing.T) *rootFlags {
+	t.Helper()
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/explain"):
+			writeJSONResponse(w, http.StatusOK, makeExplanation())
+		case strings.HasSuffix(r.URL.Path, "/airlock"):
+			writeJSONResponse(w, http.StatusOK, airlockResponse{
+				Key: testKeyIdent, NewTier: tierNone, Changed: true,
+			})
+		case strings.HasSuffix(r.URL.Path, "/terminate"):
+			writeJSONResponse(w, http.StatusOK, map[string]any{
+				"key": testKeyIdent, "terminated": true,
+			})
+		default:
+			writeJSONResponse(w, http.StatusOK, makeDetail())
+		}
+	}))
+	return flags
+}
+
+// withStubDispatcher installs a stub recoverDispatcher for the duration
+// of the test and returns a handle so the test can assert.
+func withStubDispatcher(t *testing.T) *stubRecoverDispatcher {
+	t.Helper()
+	stub := &stubRecoverDispatcher{}
+	orig := recoverDispatcherFn
+	t.Cleanup(func() { recoverDispatcherFn = orig })
+	recoverDispatcherFn = func() recoverDispatcher { return stub }
+	return stub
+}
+
+func TestRecoverCmd_ChoiceReleaseNone(t *testing.T) {
+	flags := stubRecoverServer(t)
+	overrideClientFactory(t, flags)
+	stub := withStubDispatcher(t)
+
+	out, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "release-none")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stub.inspectCalls != 1 || stub.explainCalls != 1 || stub.releaseCalls != 1 {
+		t.Errorf("call counts: inspect=%d explain=%d release=%d",
+			stub.inspectCalls, stub.explainCalls, stub.releaseCalls)
+	}
+	if stub.lastReleaseTo != tierNone {
+		t.Errorf("release target: got %q, want none", stub.lastReleaseTo)
+	}
+	if !strings.Contains(out, "inspect") || !strings.Contains(out, "explain") {
+		t.Errorf("output missing section headers: %s", out)
+	}
+}
+
+func TestRecoverCmd_ChoiceReleaseSoft(t *testing.T) {
+	flags := stubRecoverServer(t)
+	overrideClientFactory(t, flags)
+	stub := withStubDispatcher(t)
+
+	if _, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "release-soft"); err != nil {
+		t.Fatal(err)
+	}
+	if stub.lastReleaseTo != tierSoft {
+		t.Errorf("release target: got %q, want soft", stub.lastReleaseTo)
+	}
+}
+
+func TestRecoverCmd_ChoiceTerminate(t *testing.T) {
+	flags := stubRecoverServer(t)
+	overrideClientFactory(t, flags)
+	stub := withStubDispatcher(t)
+
+	if _, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "terminate"); err != nil {
+		t.Fatal(err)
+	}
+	if stub.terminateCalls != 1 {
+		t.Errorf("terminate calls: got %d, want 1", stub.terminateCalls)
+	}
+}
+
+func TestRecoverCmd_ChoiceLeave(t *testing.T) {
+	flags := stubRecoverServer(t)
+	overrideClientFactory(t, flags)
+	stub := withStubDispatcher(t)
+
+	out, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "leave")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stub.releaseCalls != 0 || stub.terminateCalls != 0 {
+		t.Errorf("leave should not dispatch: release=%d terminate=%d",
+			stub.releaseCalls, stub.terminateCalls)
+	}
+	if !strings.Contains(out, "unchanged") {
+		t.Errorf("leave should print unchanged: %s", out)
+	}
+}
+
+func TestRecoverCmd_BadChoice(t *testing.T) {
+	flags := stubRecoverServer(t)
+	overrideClientFactory(t, flags)
+	withStubDispatcher(t)
+
+	_, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "eat-it")
+	if err == nil {
+		t.Error("expected error for bogus choice")
+	}
+}
+
+func TestRecoverCmd_InteractiveStdin(t *testing.T) {
+	flags := stubRecoverServer(t)
+	overrideClientFactory(t, flags)
+	stub := withStubDispatcher(t)
+
+	cmd := recoverCmd()
+	cmd.SetIn(strings.NewReader("1\n"))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{testKeyIdent})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v; out=%s", err, buf.String())
+	}
+	if stub.lastReleaseTo != tierNone {
+		t.Errorf("interactive '1' should map to release-none: got %q", stub.lastReleaseTo)
+	}
+}
+
+func TestRecoverCmd_InteractiveStdin_InvalidInput(t *testing.T) {
+	flags := stubRecoverServer(t)
+	overrideClientFactory(t, flags)
+	withStubDispatcher(t)
+
+	cmd := recoverCmd()
+	cmd.SetIn(strings.NewReader("xyz\n"))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{testKeyIdent})
+
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error for unrecognized stdin input")
+	}
+}
+
+func TestValidateRecoverChoice(t *testing.T) {
+	good := []string{"release-none", "release-soft", "terminate", "leave"}
+	for _, g := range good {
+		if err := validateRecoverChoice(g); err != nil {
+			t.Errorf("validateRecoverChoice(%q): %v", g, err)
+		}
+	}
+	if err := validateRecoverChoice("nope"); err == nil {
+		t.Error("expected error for bad input")
+	}
+}
+
+func TestHTTPDispatcher_Inspect(t *testing.T) {
+	// Exercise the httpDispatcher path (not the stub) so production code
+	// gets test coverage too.
+	flags := stubRecoverServer(t)
+	overrideClientFactory(t, flags)
+	// No stub — uses httpDispatcher{}.
+
+	_, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "leave")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+}
+
+func TestHTTPDispatcher_Release_Real(t *testing.T) {
+	flags := stubRecoverServer(t)
+	overrideClientFactory(t, flags)
+	// No stub — uses httpDispatcher{}.
+
+	if _, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "release-none"); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+}
+
+func TestHTTPDispatcher_Terminate_Real(t *testing.T) {
+	flags := stubRecoverServer(t)
+	overrideClientFactory(t, flags)
+	// No stub — uses httpDispatcher{}.
+
+	if _, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "terminate"); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+}
+
+// errorServer returns an HTTP status on every request, exercising the
+// httpDispatcher error-return branches for inspect/explain/release/terminate.
+func errorServer(t *testing.T, status int) *rootFlags {
+	t.Helper()
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "fail", status)
+	}))
+	return flags
+}
+
+func TestHTTPDispatcher_InspectPropagatesError(t *testing.T) {
+	flags := errorServer(t, http.StatusNotFound)
+	overrideClientFactory(t, flags)
+	// No stub — uses httpDispatcher.
+
+	_, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "leave")
+	if err == nil {
+		t.Error("expected error from inspect 404")
+	}
+}
+
+// errorServerExplain returns inspect success (so dispatch proceeds past
+// the inspect step) then fails on every subsequent call. Exercises the
+// Explain/Release/Terminate error branches in httpDispatcher.
+func errorServerExplain(t *testing.T) *rootFlags {
+	t.Helper()
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/explain") && !strings.Contains(r.URL.Path, "/airlock") && !strings.Contains(r.URL.Path, "/terminate") {
+			writeJSONResponse(w, http.StatusOK, makeDetail())
+			return
+		}
+		http.Error(w, "fail", http.StatusInternalServerError)
+	}))
+	return flags
+}
+
+func TestHTTPDispatcher_ExplainPropagatesError(t *testing.T) {
+	flags := errorServerExplain(t)
+	overrideClientFactory(t, flags)
+	_, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "leave")
+	if err == nil {
+		t.Error("expected error from explain 500")
+	}
+}
+
+func TestHTTPDispatcher_ReleasePropagatesError(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/explain"):
+			writeJSONResponse(w, http.StatusOK, makeExplanation())
+		case strings.HasSuffix(r.URL.Path, "/airlock"):
+			http.Error(w, "fail", http.StatusInternalServerError)
+		default:
+			writeJSONResponse(w, http.StatusOK, makeDetail())
+		}
+	}))
+	overrideClientFactory(t, flags)
+
+	_, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "release-none")
+	if err == nil {
+		t.Error("expected error from release 500")
+	}
+}
+
+func TestHTTPDispatcher_TerminatePropagatesError(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/explain"):
+			writeJSONResponse(w, http.StatusOK, makeExplanation())
+		case strings.HasSuffix(r.URL.Path, "/terminate"):
+			http.Error(w, "fail", http.StatusInternalServerError)
+		default:
+			writeJSONResponse(w, http.StatusOK, makeDetail())
+		}
+	}))
+	overrideClientFactory(t, flags)
+
+	_, err := runCommand(recoverCmd(), testKeyIdent, "--choice", "terminate")
+	if err == nil {
+		t.Error("expected error from terminate 500")
+	}
+}
+
+func TestPromptRecoveryChoice_AllNumbers(t *testing.T) {
+	cases := []struct {
+		in   string
+		want recoveryChoice
+	}{
+		{"1\n", choiceReleaseNone},
+		{"2\n", choiceReleaseSoft},
+		{"3\n", choiceTerminate},
+		{"4\n", choiceLeave},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := promptRecoveryChoice(strings.NewReader(c.in), &bytes.Buffer{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestPromptRecoveryChoice_NamedAliases(t *testing.T) {
+	cases := map[string]recoveryChoice{
+		"release-none\n": choiceReleaseNone,
+		"release-soft\n": choiceReleaseSoft,
+		"terminate\n":    choiceTerminate,
+		"leave\n":        choiceLeave,
+	}
+	for in, want := range cases {
+		got, err := promptRecoveryChoice(strings.NewReader(in), &bytes.Buffer{})
+		if err != nil {
+			t.Fatalf("%q: %v", in, err)
+		}
+		if got != want {
+			t.Errorf("%q: got %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDispatchRecoveryChoice_UnknownChoice(t *testing.T) {
+	stub := &stubRecoverDispatcher{}
+	err := dispatchRecoveryChoice(t.Context(), stub, nil, testKeyIdent, recoveryChoice("fuzz"), &bytes.Buffer{})
+	if err == nil {
+		t.Error("expected error for unknown choice")
+	}
+}

--- a/internal/cli/session/release.go
+++ b/internal/cli/session/release.go
@@ -21,7 +21,7 @@ const (
 	releaseToUse = `target tier: none (fully release) or soft (observe-only)`
 )
 
-func releaseCmd() *cobra.Command {
+func releaseCmd(flags *rootFlags) *cobra.Command {
 	var (
 		toTier     string
 		jsonOutput bool
@@ -44,7 +44,6 @@ Examples:
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	flags := addCommonFlags(cmd)
 	cmd.Flags().StringVar(&toTier, "to", "none", releaseToUse)
 	cmd.Flags().BoolVar(&jsonOutput, flagJSON, false, usageJSON)
 

--- a/internal/cli/session/release.go
+++ b/internal/cli/session/release.go
@@ -53,6 +53,21 @@ Examples:
 			return cliutil.ExitCodeError(2, err)
 		}
 		return runClientCmd(flags, c.Context(), c.OutOrStdout(), func(ctx context.Context, client *Client, out io.Writer) error {
+			// Release is contract-downward. Fetch the current tier first and
+			// reject any move that would escalate the session. Without this
+			// check, `release --to soft` on a normal-tier session would
+			// ForceSetTier upward to soft, contradicting the command's
+			// recover-semantics. The inspect/release pair is best-effort
+			// (the tier could change between the two calls) but prevents
+			// the common misuse case; server-side enforcement would require
+			// a dedicated endpoint, out of scope here.
+			detail, err := client.Inspect(ctx, key)
+			if err != nil {
+				return err
+			}
+			if err := ensureDownward(detail.AirlockTier, toTier); err != nil {
+				return cliutil.ExitCodeError(2, err)
+			}
 			resp, err := client.Release(ctx, key, toTier)
 			if err != nil {
 				return err
@@ -78,4 +93,39 @@ func validateReleaseTier(tier string) error {
 		return nil
 	}
 	return errors.New("invalid --to: must be none|soft (use the airlock endpoint for upward transitions)")
+}
+
+// releaseTierRank maps each airlock tier to an ordinal for downward
+// comparison. Higher rank = more restrictive. A release target must be
+// less than or equal to the current rank. Empty tiers are normalized to
+// none (rank 0), matching runtime behavior where an unset AirlockTier
+// on a snapshot means the session is not quarantined.
+func releaseTierRank(tier string) int {
+	switch tier {
+	case "", config.AirlockTierNone, airlockTierAliasNormal:
+		return 0
+	case config.AirlockTierSoft:
+		return 1
+	case config.AirlockTierHard:
+		return 2
+	case config.AirlockTierDrain:
+		return 3
+	default:
+		// Unknown tiers are treated as maximum so a stale snapshot cannot
+		// accidentally authorize a release we don't understand.
+		return 99
+	}
+}
+
+// ensureDownward returns an error if target would raise the session's
+// tier. Same-rank moves are allowed (idempotent release).
+func ensureDownward(current, target string) error {
+	if releaseTierRank(target) > releaseTierRank(current) {
+		cur := current
+		if cur == "" {
+			cur = config.AirlockTierNone
+		}
+		return fmt.Errorf("refusing to escalate session: current tier %q, target %q — release is downward-only; use the airlock command to escalate", cur, target)
+	}
+	return nil
 }

--- a/internal/cli/session/release.go
+++ b/internal/cli/session/release.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const (
+	releaseUse   = "release <key>"
+	releaseShort = "Release an airlocked session to a lower tier"
+	releaseToUse = `target tier: none (fully release) or soft (observe-only)`
+)
+
+func releaseCmd() *cobra.Command {
+	var (
+		toTier     string
+		jsonOutput bool
+	)
+	cmd := &cobra.Command{
+		Use:   releaseUse,
+		Short: releaseShort,
+		Long: `Move a quarantined session to a lower airlock tier. The default is
+--to none, which fully releases the session. Use --to soft to move
+the session to observe-only mode without fully clearing quarantine.
+
+Under the hood, release wraps the /api/v1/sessions/{key}/airlock
+endpoint with ForceSetTier semantics — downward transitions are
+permitted for administrative recovery.
+
+Examples:
+  pipelock session release "agent|10.0.0.1"
+  pipelock session release "agent|10.0.0.1" --to soft`,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	flags := addCommonFlags(cmd)
+	cmd.Flags().StringVar(&toTier, "to", "none", releaseToUse)
+	cmd.Flags().BoolVar(&jsonOutput, flagJSON, false, usageJSON)
+
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+		key := args[0]
+		if err := validateReleaseTier(toTier); err != nil {
+			return cliutil.ExitCodeError(2, err)
+		}
+		return runClientCmd(flags, c.Context(), c.OutOrStdout(), func(ctx context.Context, client *Client, out io.Writer) error {
+			resp, err := client.Release(ctx, key, toTier)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return writeJSON(out, resp)
+			}
+			_, _ = fmt.Fprintf(out, "released %s: %s -> %s (changed=%t)\n",
+				resp.Key, resp.PreviousTier, resp.NewTier, resp.Changed)
+			return nil
+		})
+	}
+	return cmd
+}
+
+// validateReleaseTier rejects any tier that is not a valid release
+// target. Releasing to hard or drain does not make sense — use the
+// airlock/task commands for upward transitions. "normal" is accepted
+// as a synonym for "none" mirroring HandleAirlock.
+func validateReleaseTier(tier string) error {
+	switch tier {
+	case config.AirlockTierNone, airlockTierAliasNormal, config.AirlockTierSoft:
+		return nil
+	}
+	return errors.New("invalid --to: must be none|soft (use the airlock endpoint for upward transitions)")
+}

--- a/internal/cli/session/release_test.go
+++ b/internal/cli/session/release_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestReleaseCmd_DefaultToNone(t *testing.T) {
+	var tier string
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertBearer(t, r)
+		body, _ := io.ReadAll(r.Body)
+		var parsed map[string]string
+		_ = json.Unmarshal(body, &parsed)
+		tier = parsed["tier"]
+		writeJSONResponse(w, http.StatusOK, airlockResponse{
+			Key: testKeyIdent, PreviousTier: tierHard, NewTier: tierNone, Changed: true,
+		})
+	}))
+	overrideClientFactory(t, flags)
+
+	out, err := runCommand(releaseCmd(), testKeyIdent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tier != tierNone {
+		t.Errorf("default --to: got %q, want %s", tier, tierNone)
+	}
+	if !strings.Contains(out, "released") {
+		t.Errorf("output: %s", out)
+	}
+}
+
+func TestReleaseCmd_ToSoft(t *testing.T) {
+	var tier string
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var parsed map[string]string
+		_ = json.Unmarshal(body, &parsed)
+		tier = parsed["tier"]
+		writeJSONResponse(w, http.StatusOK, airlockResponse{Key: testKeyIdent, NewTier: tierSoft})
+	}))
+	overrideClientFactory(t, flags)
+
+	if _, err := runCommand(releaseCmd(), testKeyIdent, "--to", tierSoft); err != nil {
+		t.Fatal(err)
+	}
+	if tier != tierSoft {
+		t.Errorf("tier: got %q, want %s", tier, tierSoft)
+	}
+}
+
+func TestReleaseCmd_InvalidTo(t *testing.T) {
+	overrideClientFactory(t, &rootFlags{apiURL: "http://x:1", apiToken: testToken})
+	_, err := runCommand(releaseCmd(), testKeyIdent, "--to", "hard")
+	if err == nil {
+		t.Error("expected error for upward transition")
+	}
+}
+
+func TestReleaseCmd_JSON(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(w, http.StatusOK, airlockResponse{
+			Key: testKeyIdent, PreviousTier: tierHard, NewTier: tierNone, Changed: true,
+		})
+	}))
+	overrideClientFactory(t, flags)
+
+	out, err := runCommand(releaseCmd(), testKeyIdent, "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed airlockResponse
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !parsed.Changed {
+		t.Error("Changed should be true")
+	}
+}
+
+func TestReleaseCmd_Unauthorized(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "bad", http.StatusUnauthorized)
+	}))
+	overrideClientFactory(t, flags)
+
+	_, err := runCommand(releaseCmd(), testKeyIdent)
+	if err == nil || !strings.Contains(err.Error(), "unauthorized") {
+		t.Errorf("expected unauthorized, got %v", err)
+	}
+}

--- a/internal/cli/session/release_test.go
+++ b/internal/cli/session/release_test.go
@@ -11,18 +11,35 @@ import (
 	"testing"
 )
 
-func TestReleaseCmd_DefaultToNone(t *testing.T) {
-	var tier string
-	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// releaseStub multiplexes the GET /sessions/{key} (inspect) and POST
+// .../airlock (release) endpoints that release.go now hits. currentTier
+// is the tier returned from inspect; captureTier is written when the
+// release POST body is parsed.
+func releaseStub(t *testing.T, currentTier string, captureTier *string, airlockResp airlockResponse) *rootFlags {
+	t.Helper()
+	return stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertBearer(t, r)
+		if r.Method == http.MethodGet {
+			detail := makeDetail()
+			detail.AirlockTier = currentTier
+			writeJSONResponse(w, http.StatusOK, detail)
+			return
+		}
 		body, _ := io.ReadAll(r.Body)
 		var parsed map[string]string
 		_ = json.Unmarshal(body, &parsed)
-		tier = parsed["tier"]
-		writeJSONResponse(w, http.StatusOK, airlockResponse{
-			Key: testKeyIdent, PreviousTier: tierHard, NewTier: tierNone, Changed: true,
-		})
+		if captureTier != nil {
+			*captureTier = parsed["tier"]
+		}
+		writeJSONResponse(w, http.StatusOK, airlockResp)
 	}))
+}
+
+func TestReleaseCmd_DefaultToNone(t *testing.T) {
+	var tier string
+	flags := releaseStub(t, tierHard, &tier, airlockResponse{
+		Key: testKeyIdent, PreviousTier: tierHard, NewTier: tierNone, Changed: true,
+	})
 	overrideClientFactory(t, flags)
 
 	out, err := runCommand(releaseCmd(&rootFlags{}), testKeyIdent)
@@ -39,13 +56,8 @@ func TestReleaseCmd_DefaultToNone(t *testing.T) {
 
 func TestReleaseCmd_ToSoft(t *testing.T) {
 	var tier string
-	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		var parsed map[string]string
-		_ = json.Unmarshal(body, &parsed)
-		tier = parsed["tier"]
-		writeJSONResponse(w, http.StatusOK, airlockResponse{Key: testKeyIdent, NewTier: tierSoft})
-	}))
+	// Session is at hard; downward to soft is valid.
+	flags := releaseStub(t, tierHard, &tier, airlockResponse{Key: testKeyIdent, NewTier: tierSoft})
 	overrideClientFactory(t, flags)
 
 	if _, err := runCommand(releaseCmd(&rootFlags{}), testKeyIdent, "--to", tierSoft); err != nil {
@@ -53,6 +65,75 @@ func TestReleaseCmd_ToSoft(t *testing.T) {
 	}
 	if tier != tierSoft {
 		t.Errorf("tier: got %q, want %s", tier, tierSoft)
+	}
+}
+
+// Regression: release --to soft on a normal-tier session must be rejected
+// client-side without making a POST to /airlock, or it would escalate the
+// session (contract says release is downward-only).
+func TestReleaseCmd_RefusesUpwardFromNone(t *testing.T) {
+	var releaseBodyPosted bool
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertBearer(t, r)
+		if r.Method == http.MethodGet {
+			detail := makeDetail()
+			detail.AirlockTier = tierNone
+			writeJSONResponse(w, http.StatusOK, detail)
+			return
+		}
+		releaseBodyPosted = true
+		writeJSONResponse(w, http.StatusOK, airlockResponse{})
+	}))
+	overrideClientFactory(t, flags)
+
+	_, err := runCommand(releaseCmd(&rootFlags{}), testKeyIdent, "--to", tierSoft)
+	if err == nil {
+		t.Fatal("expected rejection for upward transition")
+	}
+	if !strings.Contains(err.Error(), "downward-only") {
+		t.Errorf("error message: got %q, want substring 'downward-only'", err.Error())
+	}
+	if releaseBodyPosted {
+		t.Error("release POST should not be issued when the client rejects the transition")
+	}
+}
+
+// TestReleaseCmd_SameTierAllowed confirms release is idempotent: releasing
+// to the current tier is a no-op but not an error.
+func TestReleaseCmd_SameTierAllowed(t *testing.T) {
+	flags := releaseStub(t, tierSoft, nil, airlockResponse{Key: testKeyIdent, NewTier: tierSoft})
+	overrideClientFactory(t, flags)
+	if _, err := runCommand(releaseCmd(&rootFlags{}), testKeyIdent, "--to", tierSoft); err != nil {
+		t.Fatalf("same-tier release should succeed: %v", err)
+	}
+}
+
+func TestEnsureDownward(t *testing.T) {
+	cases := []struct {
+		name    string
+		current string
+		target  string
+		wantErr bool
+	}{
+		{"hard to none", tierHard, tierNone, false},
+		{"soft to none", tierSoft, tierNone, false},
+		{"hard to soft", tierHard, tierSoft, false},
+		{"same tier", tierSoft, tierSoft, false},
+		{"empty current to none", "", tierNone, false},
+		{"none to soft rejected", tierNone, tierSoft, true},
+		{"empty to soft rejected", "", tierSoft, true},
+		{"soft to hard rejected", tierSoft, tierHard, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ensureDownward(tc.current, tc.target)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error for %s -> %s", tc.current, tc.target)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/session/release_test.go
+++ b/internal/cli/session/release_test.go
@@ -25,7 +25,7 @@ func TestReleaseCmd_DefaultToNone(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	out, err := runCommand(releaseCmd(), testKeyIdent)
+	out, err := runCommand(releaseCmd(&rootFlags{}), testKeyIdent)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestReleaseCmd_ToSoft(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	if _, err := runCommand(releaseCmd(), testKeyIdent, "--to", tierSoft); err != nil {
+	if _, err := runCommand(releaseCmd(&rootFlags{}), testKeyIdent, "--to", tierSoft); err != nil {
 		t.Fatal(err)
 	}
 	if tier != tierSoft {
@@ -58,7 +58,7 @@ func TestReleaseCmd_ToSoft(t *testing.T) {
 
 func TestReleaseCmd_InvalidTo(t *testing.T) {
 	overrideClientFactory(t, &rootFlags{apiURL: "http://x:1", apiToken: testToken})
-	_, err := runCommand(releaseCmd(), testKeyIdent, "--to", "hard")
+	_, err := runCommand(releaseCmd(&rootFlags{}), testKeyIdent, "--to", "hard")
 	if err == nil {
 		t.Error("expected error for upward transition")
 	}
@@ -72,7 +72,7 @@ func TestReleaseCmd_JSON(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	out, err := runCommand(releaseCmd(), testKeyIdent, "--json")
+	out, err := runCommand(releaseCmd(&rootFlags{}), testKeyIdent, "--json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestReleaseCmd_Unauthorized(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	_, err := runCommand(releaseCmd(), testKeyIdent)
+	_, err := runCommand(releaseCmd(&rootFlags{}), testKeyIdent)
 	if err == nil || !strings.Contains(err.Error(), "unauthorized") {
 		t.Errorf("expected unauthorized, got %v", err)
 	}

--- a/internal/cli/session/render.go
+++ b/internal/cli/session/render.go
@@ -75,8 +75,12 @@ func renderDetail(w io.Writer, d proxy.SessionDetail) error {
 	if d.CurrentTaskLabel != "" {
 		fmt.Fprintf(buf, "  current_task:     %s\n", d.CurrentTaskLabel)
 	}
-	fmt.Fprintf(buf, "  last_activity:    %s (%s ago)\n",
-		d.LastActivity.UTC().Format(time.RFC3339), formatDuration(time.Since(d.LastActivity)))
+	if d.LastActivity.IsZero() {
+		fmt.Fprintln(buf, "  last_activity:    -")
+	} else {
+		fmt.Fprintf(buf, "  last_activity:    %s (%s ago)\n",
+			d.LastActivity.UTC().Format(time.RFC3339), formatDuration(time.Since(d.LastActivity)))
+	}
 
 	fmt.Fprintln(buf, "  recent_events:")
 	if len(d.RecentEvents) == 0 {

--- a/internal/cli/session/render.go
+++ b/internal/cli/session/render.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+)
+
+// Column header constants used by the table renderers. Extracted so
+// goconst does not trip on repeated literals in the subcommand tests.
+const (
+	colKey        = "KEY"
+	colAgent      = "AGENT"
+	colIP         = "IP"
+	colTier       = "TIER"
+	colEscalation = "ESCALATION"
+	colScore      = "SCORE"
+	colInFlight   = "IN-FLIGHT"
+	colLastActive = "LAST-ACTIVE"
+)
+
+// renderList writes a human-readable table of session snapshots to w.
+func renderList(w io.Writer, snaps []proxy.SessionSnapshot) error {
+	if len(snaps) == 0 {
+		_, err := fmt.Fprintln(w, "No sessions match.")
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		colKey, colAgent, colIP, colTier, colEscalation, colScore, colLastActive)
+	for _, s := range snaps {
+		tier := s.AirlockTier
+		if tier == "" {
+			tier = "none"
+		}
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%.2f\t%s\n",
+			s.Key, defaultDash(s.Agent), defaultDash(s.ClientIP),
+			tier, defaultDash(s.EscalationLevel), s.ThreatScore,
+			relativeTime(s.LastActivity))
+	}
+	return tw.Flush()
+}
+
+// renderDetail writes a human-readable inspect view of a SessionDetail.
+func renderDetail(w io.Writer, d proxy.SessionDetail) error {
+	buf := &strings.Builder{}
+	fmt.Fprintf(buf, "Session %s\n", d.Key)
+	fmt.Fprintf(buf, "  kind:             %s\n", defaultDash(d.Kind))
+	fmt.Fprintf(buf, "  agent:            %s\n", defaultDash(d.Agent))
+	fmt.Fprintf(buf, "  client_ip:        %s\n", defaultDash(d.ClientIP))
+	fmt.Fprintf(buf, "  airlock_tier:     %s\n", defaultIfEmpty(d.AirlockTier, "none"))
+	if !d.AirlockEnteredAt.IsZero() {
+		fmt.Fprintf(buf, "  airlock_entered:  %s (%s ago)\n",
+			d.AirlockEnteredAt.UTC().Format(time.RFC3339),
+			formatDuration(time.Since(d.AirlockEnteredAt)))
+	} else {
+		fmt.Fprintln(buf, "  airlock_entered:  -")
+	}
+	fmt.Fprintf(buf, "  in_flight:        %d\n", d.InFlight)
+	fmt.Fprintf(buf, "  escalation:       %s (%d)\n", defaultDash(d.EscalationLevel), d.EscalationLevelInt)
+	fmt.Fprintf(buf, "  threat_score:     %.2f\n", d.ThreatScore)
+	fmt.Fprintf(buf, "  block_all:        %t\n", d.BlockAll)
+	fmt.Fprintf(buf, "  taint_level:      %s\n", defaultDash(d.TaintLevel))
+	fmt.Fprintf(buf, "  contaminated:     %t\n", d.Contaminated)
+	if d.CurrentTaskID != "" {
+		fmt.Fprintf(buf, "  current_task_id:  %s\n", d.CurrentTaskID)
+	}
+	if d.CurrentTaskLabel != "" {
+		fmt.Fprintf(buf, "  current_task:     %s\n", d.CurrentTaskLabel)
+	}
+	fmt.Fprintf(buf, "  last_activity:    %s (%s ago)\n",
+		d.LastActivity.UTC().Format(time.RFC3339), formatDuration(time.Since(d.LastActivity)))
+
+	fmt.Fprintln(buf, "  recent_events:")
+	if len(d.RecentEvents) == 0 {
+		fmt.Fprintln(buf, "    (none)")
+	} else {
+		for _, e := range d.RecentEvents {
+			fmt.Fprintf(buf, "    [%s] %s target=%s score=%.2f detail=%s\n",
+				e.At.UTC().Format(time.RFC3339), e.Kind, defaultDash(e.Target), e.Score, e.Detail)
+		}
+	}
+
+	_, err := io.WriteString(w, buf.String())
+	return err
+}
+
+// renderExplanation writes a human-readable explain view of a
+// SessionExplanation.
+func renderExplanation(w io.Writer, e proxy.SessionExplanation) error {
+	buf := &strings.Builder{}
+	fmt.Fprintf(buf, "Session %s explanation\n", e.Key)
+	fmt.Fprintf(buf, "  tier:                %s\n", defaultIfEmpty(e.Tier, "none"))
+	fmt.Fprintf(buf, "  reason:              %s\n", defaultDash(e.Reason))
+	if e.Trigger != "" {
+		fmt.Fprintf(buf, "  trigger:             %s (source=%s)\n", e.Trigger, defaultDash(e.TriggerSource))
+	}
+	fmt.Fprintf(buf, "  escalation:          %s (%d)\n", defaultDash(e.EscalationLevel), e.EscalationLevelInt)
+	fmt.Fprintf(buf, "  threat_score:        %.2f\n", e.ThreatScore)
+	if !e.EnteredAt.IsZero() {
+		fmt.Fprintf(buf, "  entered_at:          %s (%s ago)\n",
+			e.EnteredAt.UTC().Format(time.RFC3339), formatDuration(time.Since(e.EnteredAt)))
+	}
+	if e.EvidenceKind != "" || e.EvidenceDetail != "" {
+		fmt.Fprintln(buf, "  evidence:")
+		if !e.EvidenceAt.IsZero() {
+			fmt.Fprintf(buf, "    at:     %s\n", e.EvidenceAt.UTC().Format(time.RFC3339))
+		}
+		if e.EvidenceKind != "" {
+			fmt.Fprintf(buf, "    kind:   %s\n", e.EvidenceKind)
+		}
+		if e.EvidenceTarget != "" {
+			fmt.Fprintf(buf, "    target: %s\n", e.EvidenceTarget)
+		}
+		if e.EvidenceDetail != "" {
+			fmt.Fprintf(buf, "    detail: %s\n", e.EvidenceDetail)
+		}
+	} else {
+		fmt.Fprintln(buf, "  evidence:            (none recorded)")
+	}
+	if e.NextDeescalationTier != "" {
+		fmt.Fprintf(buf, "  next_deescalation:   tier=%s", e.NextDeescalationTier)
+		if !e.NextDeescalationAt.IsZero() {
+			fmt.Fprintf(buf, " at=%s (in %s)",
+				e.NextDeescalationAt.UTC().Format(time.RFC3339),
+				formatDuration(time.Until(e.NextDeescalationAt)))
+		} else {
+			fmt.Fprint(buf, " (no timer — manual recovery only)")
+		}
+		fmt.Fprintln(buf)
+	}
+	_, err := io.WriteString(w, buf.String())
+	return err
+}
+
+// defaultDash returns s when non-empty, or "-" to keep tables tidy.
+func defaultDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// defaultIfEmpty returns s when non-empty, or the provided fallback.
+func defaultIfEmpty(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+// formatDuration prints a short fixed-width duration suitable for
+// operator tables. Negative durations are treated as zero (the estimate
+// may have already elapsed).
+func formatDuration(d time.Duration) string {
+	if d < 0 {
+		return "0s"
+	}
+	if d < time.Second {
+		return "0s"
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	return fmt.Sprintf("%dh", int(d.Hours()))
+}
+
+// relativeTime formats LastActivity as "ago" for list tables.
+func relativeTime(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return formatDuration(time.Since(t)) + " ago"
+}

--- a/internal/cli/session/render_test.go
+++ b/internal/cli/session/render_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+)
+
+func TestRenderList_EmptyPrintsPlaceholder(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderList(&buf, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "No sessions") {
+		t.Errorf("empty list output: %q", buf.String())
+	}
+}
+
+func TestRenderList_PopulatesColumns(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderList(&buf, makeSnapshotList()); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	wantContains := []string{"KEY", "AGENT", "TIER", testKeyIdent, "hard"}
+	for _, w := range wantContains {
+		if !strings.Contains(out, w) {
+			t.Errorf("list output missing %q: %s", w, out)
+		}
+	}
+}
+
+func TestRenderList_HandlesEmptyFields(t *testing.T) {
+	var buf bytes.Buffer
+	snaps := []proxy.SessionSnapshot{{Key: "k1", LastActivity: testFixedTime()}}
+	if err := renderList(&buf, snaps); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "none") {
+		t.Errorf("empty tier should render as 'none': %s", out)
+	}
+}
+
+func TestRenderDetail_ContainsAllFields(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderDetail(&buf, makeDetail()); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	want := []string{
+		testKeyIdent, "hard", "airlock_entered", "recent_events",
+		"dlp secret", "in_flight:", "3",
+	}
+	for _, w := range want {
+		if !strings.Contains(out, w) {
+			t.Errorf("detail missing %q in:\n%s", w, out)
+		}
+	}
+}
+
+func TestRenderDetail_NoEvents(t *testing.T) {
+	d := makeDetail()
+	d.RecentEvents = nil
+	var buf bytes.Buffer
+	if err := renderDetail(&buf, d); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "(none)") {
+		t.Errorf("empty events should print (none): %s", buf.String())
+	}
+}
+
+func TestRenderDetail_ZeroAirlockEntered(t *testing.T) {
+	d := makeDetail()
+	d.AirlockEnteredAt = time.Time{}
+	var buf bytes.Buffer
+	if err := renderDetail(&buf, d); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "airlock_entered:  -") {
+		t.Errorf("zero time should render as '-': %s", buf.String())
+	}
+}
+
+func TestRenderExplanation_QuarantinedSession(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderExplanation(&buf, makeExplanation()); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	want := []string{"hard", "on_critical", "evidence:", "dlp secret", "next_deescalation", "soft"}
+	for _, w := range want {
+		if !strings.Contains(out, w) {
+			t.Errorf("explanation missing %q in:\n%s", w, out)
+		}
+	}
+}
+
+func TestRenderExplanation_NormalSession(t *testing.T) {
+	exp := proxy.SessionExplanation{
+		Key:    "normal|1.2.3.4",
+		Tier:   "none",
+		Reason: "session not quarantined",
+	}
+	var buf bytes.Buffer
+	if err := renderExplanation(&buf, exp); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "session not quarantined") {
+		t.Errorf("output: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "(none recorded)") {
+		t.Errorf("should note missing evidence: %s", buf.String())
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{-time.Second, "0s"},
+		{500 * time.Millisecond, "0s"},
+		{10 * time.Second, "10s"},
+		{90 * time.Second, "1m"},
+		{2 * time.Hour, "2h"},
+	}
+	for _, tt := range tests {
+		if got := formatDuration(tt.d); got != tt.want {
+			t.Errorf("formatDuration(%v): got %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}
+
+func TestRelativeTime_Zero(t *testing.T) {
+	if got := relativeTime(time.Time{}); got != "-" {
+		t.Errorf("zero time: got %q, want -", got)
+	}
+}
+
+func TestDefaultDash(t *testing.T) {
+	if got := defaultDash(""); got != "-" {
+		t.Error("empty should be -")
+	}
+	if got := defaultDash("foo"); got != "foo" {
+		t.Error("non-empty should be unchanged")
+	}
+}
+
+func TestDefaultIfEmpty(t *testing.T) {
+	if got := defaultIfEmpty("", "fallback"); got != "fallback" {
+		t.Error("empty should use fallback")
+	}
+	if got := defaultIfEmpty("real", "fallback"); got != "real" {
+		t.Error("non-empty should win")
+	}
+}
+
+// ensure io.Writer is honored: a writer that errors propagates the error.
+func TestRenderList_PropagatesWriteError(t *testing.T) {
+	err := renderList(errWriter{}, nil)
+	if err == nil {
+		t.Error("expected error from failing writer")
+	}
+}
+
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errors.New("boom") }

--- a/internal/cli/session/resolver.go
+++ b/internal/cli/session/resolver.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/killswitch"
+)
+
+// Environment variable names used by the resolver. Kept here so the
+// flag help strings and the fallback chain share a single source.
+const (
+	envAPIURL     = "PIPELOCK_API_URL"
+	envConfigVar  = "PIPELOCK_CONFIG"
+	defaultScheme = "http://"
+)
+
+// endpoint carries the fully resolved API URL and bearer token. Returned
+// by resolveEndpoint and consumed by the HTTP client.
+type endpoint struct {
+	URL   string
+	Token string
+}
+
+// resolverDeps bundles the injectable filesystem and environment
+// accessors used by resolveEndpoint. Kept as a struct so tests can swap
+// out home-dir lookup, stat, and config loading without touching the
+// real filesystem or environment.
+type resolverDeps struct {
+	userHomeDir func() (string, error)
+	stat        func(string) (os.FileInfo, error)
+	loadConfig  func(string) (*config.Config, error)
+	getenv      func(string) string
+}
+
+// defaultResolverDeps returns the live production wiring for resolveEndpoint.
+func defaultResolverDeps() resolverDeps {
+	return resolverDeps{
+		userHomeDir: os.UserHomeDir,
+		stat:        os.Stat,
+		loadConfig:  config.Load,
+		getenv:      os.Getenv,
+	}
+}
+
+// resolveEndpoint derives the API URL and bearer token from (in order):
+//  1. explicit CLI flags
+//  2. environment variables (PIPELOCK_API_URL, PIPELOCK_KILLSWITCH_API_TOKEN)
+//  3. the pipelock config file's kill_switch section
+//
+// Returns a descriptive error when no token can be located so operators
+// get a clear message instead of a 401 from the server. File perms on
+// any config path sourced from step (3) are checked here — world-readable
+// files are rejected outright per the admin API threat model.
+func resolveEndpoint(flags *rootFlags, deps resolverDeps) (endpoint, error) {
+	ep := endpoint{
+		URL:   flags.apiURL,
+		Token: flags.apiToken,
+	}
+
+	if ep.URL == "" {
+		ep.URL = deps.getenv(envAPIURL)
+	}
+	if ep.Token == "" {
+		ep.Token = deps.getenv(killswitch.EnvAPIToken)
+	}
+
+	if ep.URL != "" && ep.Token != "" {
+		return normalizeEndpoint(ep), nil
+	}
+
+	cfgPath := resolveConfigPath(flags.configPath, deps.userHomeDir, deps.stat, deps.getenv)
+	if cfgPath == "" {
+		// No config file located and the caller provided neither URL nor
+		// token via flags/env — fail with a clear message.
+		if ep.Token == "" {
+			return endpoint{}, errors.New("admin API token is required: set --api-token, PIPELOCK_KILLSWITCH_API_TOKEN, or point --config at a pipelock config file")
+		}
+		if ep.URL == "" {
+			return endpoint{}, errors.New("admin API URL is required: set --api-url, PIPELOCK_API_URL, or point --config at a pipelock config file")
+		}
+		return normalizeEndpoint(ep), nil
+	}
+
+	if err := checkConfigPerms(cfgPath, deps.stat); err != nil {
+		return endpoint{}, err
+	}
+
+	cfg, err := deps.loadConfig(filepath.Clean(cfgPath))
+	if err != nil {
+		return endpoint{}, fmt.Errorf("loading config %s: %w", cfgPath, err)
+	}
+
+	if ep.URL == "" && cfg.KillSwitch.APIListen != "" {
+		ep.URL = defaultScheme + cfg.KillSwitch.APIListen
+	}
+	if ep.Token == "" {
+		ep.Token = cfg.KillSwitch.APIToken
+	}
+
+	if ep.URL == "" {
+		return endpoint{}, fmt.Errorf("no admin API URL: set --api-url, PIPELOCK_API_URL, or kill_switch.api_listen in %s", cfgPath)
+	}
+	if ep.Token == "" {
+		return endpoint{}, fmt.Errorf("no admin API token: set --api-token, PIPELOCK_KILLSWITCH_API_TOKEN, or kill_switch.api_token in %s", cfgPath)
+	}
+
+	return normalizeEndpoint(ep), nil
+}
+
+// resolveConfigPath returns the best-effort path to the active pipelock
+// config file. Checks (in order): explicit flag, PIPELOCK_CONFIG env,
+// ~/.config/pipelock/pipelock.yaml, /etc/pipelock/pipelock.yaml.
+// Returns empty string when no candidate exists — the caller decides
+// whether that is an error.
+func resolveConfigPath(explicit string, userHomeDir func() (string, error), stat func(string) (os.FileInfo, error), getenv func(string) string) string {
+	if explicit != "" {
+		return explicit
+	}
+	if env := getenv(envConfigVar); env != "" {
+		return env
+	}
+	if userHomeDir != nil {
+		if home, err := userHomeDir(); err == nil && home != "" {
+			candidate := filepath.Join(home, ".config", "pipelock", "pipelock.yaml")
+			if _, err := stat(candidate); err == nil {
+				return candidate
+			}
+		}
+	}
+	const systemWide = "/etc/pipelock/pipelock.yaml"
+	if _, err := stat(systemWide); err == nil {
+		return systemWide
+	}
+	return ""
+}
+
+// checkConfigPerms refuses world- and group-readable config files. The
+// admin API token is a shared secret — a loose file perm is treated as
+// a deployment error rather than a warning. Callers inject a stat
+// function for testability.
+func checkConfigPerms(path string, stat func(string) (os.FileInfo, error)) error {
+	info, err := stat(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("stat config %s: %w", path, err)
+	}
+	mode := info.Mode().Perm()
+	if mode&0o077 != 0 {
+		return fmt.Errorf("config file %s is group/world readable (mode %o); restrict to 0600 before using it as an admin API source", path, mode)
+	}
+	return nil
+}
+
+// normalizeEndpoint strips trailing slashes from the URL and prepends
+// http:// when the caller passed a bare host:port without a scheme.
+func normalizeEndpoint(ep endpoint) endpoint {
+	ep.URL = ensureScheme(ep.URL)
+	for len(ep.URL) > 0 && ep.URL[len(ep.URL)-1] == '/' {
+		ep.URL = ep.URL[:len(ep.URL)-1]
+	}
+	return ep
+}
+
+// ensureScheme prepends http:// when a bare host:port slipped through.
+// Leaves https:// URLs and explicit http:// URLs alone so operators can
+// point the CLI at a TLS-wrapped admin API when one is configured.
+func ensureScheme(s string) string {
+	if s == "" {
+		return s
+	}
+	if len(s) >= 7 && s[:7] == defaultScheme {
+		return s
+	}
+	if len(s) >= 8 && s[:8] == "https://" {
+		return s
+	}
+	return defaultScheme + s
+}

--- a/internal/cli/session/resolver.go
+++ b/internal/cli/session/resolver.go
@@ -141,10 +141,13 @@ func resolveConfigPath(explicit string, userHomeDir func() (string, error), stat
 	return ""
 }
 
-// checkConfigPerms refuses world- and group-readable config files. The
-// admin API token is a shared secret — a loose file perm is treated as
-// a deployment error rather than a warning. Callers inject a stat
-// function for testability.
+// checkConfigPerms refuses any group- or world-accessible config file.
+// The admin API token is a shared secret — a loose file perm is treated
+// as a deployment error rather than a warning. The mask rejects group
+// and world read/write/execute bits; the error message is worded as
+// "any group/world permission" so operators who hit this on a 0o620 or
+// similar mode are not confused by a "readable" phrasing. Callers
+// inject a stat function for testability.
 func checkConfigPerms(path string, stat func(string) (os.FileInfo, error)) error {
 	info, err := stat(filepath.Clean(path))
 	if err != nil {
@@ -152,7 +155,7 @@ func checkConfigPerms(path string, stat func(string) (os.FileInfo, error)) error
 	}
 	mode := info.Mode().Perm()
 	if mode&0o077 != 0 {
-		return fmt.Errorf("config file %s is group/world readable (mode %o); restrict to 0600 before using it as an admin API source", path, mode)
+		return fmt.Errorf("config file %s has group/world permission bits set (mode %o); restrict to 0o600 before using it as an admin API source", path, mode)
 	}
 	return nil
 }

--- a/internal/cli/session/resolver.go
+++ b/internal/cli/session/resolver.go
@@ -68,7 +68,7 @@ func resolveEndpoint(flags *rootFlags, deps resolverDeps) (endpoint, error) {
 		ep.URL = deps.getenv(envAPIURL)
 	}
 	if ep.Token == "" {
-		ep.Token = deps.getenv(killswitch.EnvAPIToken) // pipelock:ignore Credential in URL
+		ep.Token = deps.getenv(killswitch.EnvAPIToken)
 	}
 
 	if ep.URL != "" && ep.Token != "" {
@@ -101,7 +101,7 @@ func resolveEndpoint(flags *rootFlags, deps resolverDeps) (endpoint, error) {
 		ep.URL = defaultScheme + cfg.KillSwitch.APIListen
 	}
 	if ep.Token == "" {
-		ep.Token = cfg.KillSwitch.APIToken // pipelock:ignore Credential in URL
+		ep.Token = cfg.KillSwitch.APIToken
 	}
 
 	if ep.URL == "" {

--- a/internal/cli/session/resolver.go
+++ b/internal/cli/session/resolver.go
@@ -141,21 +141,28 @@ func resolveConfigPath(explicit string, userHomeDir func() (string, error), stat
 	return ""
 }
 
-// checkConfigPerms refuses any group- or world-accessible config file.
-// The admin API token is a shared secret — a loose file perm is treated
-// as a deployment error rather than a warning. The mask rejects group
-// and world read/write/execute bits; the error message is worded as
-// "any group/world permission" so operators who hit this on a 0o620 or
-// similar mode are not confused by a "readable" phrasing. Callers
-// inject a stat function for testability.
+// checkConfigPerms refuses any config file that carries group/world
+// permission bits OR an owner-execute bit. The admin API token is a
+// shared secret — a loose file perm is treated as a deployment error
+// rather than a warning, and an executable config file is a policy
+// smell regardless of who can read it (per CLAUDE.md: always 0o600 for
+// files, never 0o644/0o755/0o700). The 0o177 mask catches:
+//
+//	0o100  owner execute  — reject (executable config files never ok)
+//	0o070  any group bit  — reject
+//	0o007  any world bit  — reject
+//
+// Allows 0o600 (rw owner) and 0o400 (r owner), which are the only
+// reasonable deployment modes for a credential-bearing config.
+// Callers inject a stat function for testability.
 func checkConfigPerms(path string, stat func(string) (os.FileInfo, error)) error {
 	info, err := stat(filepath.Clean(path))
 	if err != nil {
 		return fmt.Errorf("stat config %s: %w", path, err)
 	}
 	mode := info.Mode().Perm()
-	if mode&0o077 != 0 {
-		return fmt.Errorf("config file %s has group/world permission bits set (mode %o); restrict to 0o600 before using it as an admin API source", path, mode)
+	if mode&0o177 != 0 {
+		return fmt.Errorf("config file %s has group/world or owner-execute permission bits set (mode %o); restrict to 0o600 before using it as an admin API source", path, mode)
 	}
 	return nil
 }

--- a/internal/cli/session/resolver.go
+++ b/internal/cli/session/resolver.go
@@ -68,7 +68,7 @@ func resolveEndpoint(flags *rootFlags, deps resolverDeps) (endpoint, error) {
 		ep.URL = deps.getenv(envAPIURL)
 	}
 	if ep.Token == "" {
-		ep.Token = deps.getenv(killswitch.EnvAPIToken)
+		ep.Token = deps.getenv(killswitch.EnvAPIToken) // pipelock:ignore Credential in URL
 	}
 
 	if ep.URL != "" && ep.Token != "" {
@@ -101,7 +101,7 @@ func resolveEndpoint(flags *rootFlags, deps resolverDeps) (endpoint, error) {
 		ep.URL = defaultScheme + cfg.KillSwitch.APIListen
 	}
 	if ep.Token == "" {
-		ep.Token = cfg.KillSwitch.APIToken
+		ep.Token = cfg.KillSwitch.APIToken // pipelock:ignore Credential in URL
 	}
 
 	if ep.URL == "" {

--- a/internal/cli/session/resolver.go
+++ b/internal/cli/session/resolver.go
@@ -6,6 +6,7 @@ package session
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 
@@ -98,7 +99,11 @@ func resolveEndpoint(flags *rootFlags, deps resolverDeps) (endpoint, error) {
 	}
 
 	if ep.URL == "" && cfg.KillSwitch.APIListen != "" {
-		ep.URL = defaultScheme + cfg.KillSwitch.APIListen
+		apiURL, err := apiListenToURL(cfg.KillSwitch.APIListen)
+		if err != nil {
+			return endpoint{}, fmt.Errorf("invalid kill_switch.api_listen %q in %s: %w", cfg.KillSwitch.APIListen, cfgPath, err)
+		}
+		ep.URL = apiURL
 	}
 	if ep.Token == "" {
 		ep.Token = cfg.KillSwitch.APIToken
@@ -175,6 +180,24 @@ func normalizeEndpoint(ep endpoint) endpoint {
 		ep.URL = ep.URL[:len(ep.URL)-1]
 	}
 	return ep
+}
+
+// apiListenToURL converts a bind address (e.g. ":9090", "0.0.0.0:9090",
+// "[::]:9090") into a client-usable URL by mapping wildcard/unspecified
+// hosts to loopback. The admin API binds to a listen address but clients
+// need a concrete host to dial.
+func apiListenToURL(listen string) (string, error) {
+	host, port, err := net.SplitHostPort(listen)
+	if err != nil {
+		return "", err
+	}
+	switch host {
+	case "", "0.0.0.0":
+		host = "127.0.0.1"
+	case "::":
+		host = "::1"
+	}
+	return defaultScheme + net.JoinHostPort(host, port), nil
 }
 
 // ensureScheme prepends http:// when a bare host:port slipped through.

--- a/internal/cli/session/resolver_test.go
+++ b/internal/cli/session/resolver_test.go
@@ -119,15 +119,24 @@ func TestResolveEndpoint_ConfigMissingFields(t *testing.T) {
 }
 
 func TestCheckConfigPerms(t *testing.T) {
+	// Config files carrying the admin API token must be 0o600 or
+	// 0o400. Owner-execute (0o100), any group bit, or any world bit
+	// is rejected per CLAUDE.md guidance and to catch deployment
+	// smells where the config file is left world-readable or marked
+	// executable. The mask 0o177 matches the checkConfigPerms
+	// implementation in resolver.go.
 	tests := []struct {
 		name    string
 		mode    fs.FileMode
 		wantErr bool
 	}{
-		{"0600 OK", 0o600, false},
-		{"0644 rejected", 0o644, true},
-		{"0666 rejected", 0o666, true},
-		{"0700 OK (owner-only)", 0o700, false},
+		{"0600 rw owner OK", 0o600, false},
+		{"0400 r owner OK", 0o400, false},
+		{"0644 group/world read rejected", 0o644, true},
+		{"0666 group/world rw rejected", 0o666, true},
+		{"0700 owner-execute rejected", 0o700, true},
+		{"0500 owner-rx rejected", 0o500, true},
+		{"0620 group-write rejected", 0o620, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/cli/session/resolver_test.go
+++ b/internal/cli/session/resolver_test.go
@@ -1,0 +1,292 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/killswitch"
+)
+
+// fakeFileInfo is a minimal fs.FileInfo implementation used by the
+// resolver tests to emulate different permission modes.
+type fakeFileInfo struct {
+	name string
+	mode fs.FileMode
+	size int64
+}
+
+func (f fakeFileInfo) Name() string       { return f.name }
+func (f fakeFileInfo) Size() int64        { return f.size }
+func (f fakeFileInfo) Mode() fs.FileMode  { return f.mode }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return false }
+func (f fakeFileInfo) Sys() any           { return nil }
+
+// emptyEnv is an os.Getenv stub that returns the empty string for all
+// keys. Used when a test wants to exercise the "nothing set" path.
+func emptyEnv(string) string { return "" }
+
+func fakeDepsWithEnv(env map[string]string, cfg *config.Config, statErr error) resolverDeps {
+	return resolverDeps{
+		userHomeDir: func() (string, error) { return "", errors.New("no home in tests") },
+		stat: func(string) (os.FileInfo, error) {
+			if statErr != nil {
+				return nil, statErr
+			}
+			return fakeFileInfo{name: "pipelock.yaml", mode: 0o600}, nil
+		},
+		loadConfig: func(string) (*config.Config, error) {
+			if cfg == nil {
+				return nil, errors.New("no config")
+			}
+			return cfg, nil
+		},
+		getenv: func(k string) string { return env[k] },
+	}
+}
+
+func TestResolveEndpoint_FlagsWin(t *testing.T) {
+	flags := &rootFlags{apiURL: "http://localhost:9090", apiToken: "tkn"}
+	ep, err := resolveEndpoint(flags, fakeDepsWithEnv(nil, nil, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ep.URL != "http://localhost:9090" {
+		t.Errorf("URL: got %q, want http://localhost:9090", ep.URL)
+	}
+	if ep.Token != "tkn" {
+		t.Errorf("Token: got %q, want tkn", ep.Token)
+	}
+}
+
+func TestResolveEndpoint_EnvFallback(t *testing.T) {
+	env := map[string]string{
+		envAPIURL:              "http://127.0.0.1:9091",
+		killswitch.EnvAPIToken: "env-token",
+	}
+	ep, err := resolveEndpoint(&rootFlags{}, fakeDepsWithEnv(env, nil, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ep.URL != "http://127.0.0.1:9091" || ep.Token != "env-token" {
+		t.Errorf("got %+v", ep)
+	}
+}
+
+func TestResolveEndpoint_MissingToken(t *testing.T) {
+	// No flags, no env, no config → error about token.
+	_, err := resolveEndpoint(&rootFlags{apiURL: "http://x:1"}, fakeDepsWithEnv(nil, nil, os.ErrNotExist))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestResolveEndpoint_ConfigFallback(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.KillSwitch.APIListen = "127.0.0.1:9090"
+	cfg.KillSwitch.APIToken = "yaml-token"
+
+	deps := fakeDepsWithEnv(map[string]string{envConfigVar: "/fake/pipelock.yaml"}, cfg, nil)
+	ep, err := resolveEndpoint(&rootFlags{}, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ep.Token != "yaml-token" {
+		t.Errorf("Token: got %q, want yaml-token", ep.Token)
+	}
+	if ep.URL != "http://127.0.0.1:9090" {
+		t.Errorf("URL: got %q, want http://127.0.0.1:9090", ep.URL)
+	}
+}
+
+func TestResolveEndpoint_ConfigMissingFields(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.KillSwitch.APIListen = ""
+	cfg.KillSwitch.APIToken = ""
+
+	deps := fakeDepsWithEnv(map[string]string{envConfigVar: "/fake/pipelock.yaml"}, cfg, nil)
+	if _, err := resolveEndpoint(&rootFlags{}, deps); err == nil {
+		t.Error("expected error when config has neither listen nor token")
+	}
+}
+
+func TestCheckConfigPerms(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    fs.FileMode
+		wantErr bool
+	}{
+		{"0600 OK", 0o600, false},
+		{"0644 rejected", 0o644, true},
+		{"0666 rejected", 0o666, true},
+		{"0700 OK (owner-only)", 0o700, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkConfigPerms("fake", func(string) (os.FileInfo, error) {
+				return fakeFileInfo{name: "pipelock.yaml", mode: tt.mode}, nil
+			})
+			if tt.wantErr && err == nil {
+				t.Error("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestCheckConfigPerms_StatError(t *testing.T) {
+	err := checkConfigPerms("missing", func(string) (os.FileInfo, error) {
+		return nil, errors.New("stat boom")
+	})
+	if err == nil {
+		t.Error("expected error from stat failure")
+	}
+}
+
+func TestResolveConfigPath_Priority(t *testing.T) {
+	explicit := "/explicit/pipelock.yaml"
+	got := resolveConfigPath(explicit, func() (string, error) { return "", nil }, func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }, emptyEnv)
+	if got != explicit {
+		t.Errorf("explicit: got %q, want %q", got, explicit)
+	}
+}
+
+func TestResolveConfigPath_EnvFallback(t *testing.T) {
+	env := map[string]string{envConfigVar: "/env/pipelock.yaml"}
+	got := resolveConfigPath("", func() (string, error) { return "", nil }, func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }, func(k string) string { return env[k] })
+	if got != "/env/pipelock.yaml" {
+		t.Errorf("env path: got %q", got)
+	}
+}
+
+func TestResolveConfigPath_HomeCandidate(t *testing.T) {
+	dir := t.TempDir()
+	want := filepath.Join(dir, ".config", "pipelock", "pipelock.yaml")
+	if err := os.MkdirAll(filepath.Dir(want), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(want, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := resolveConfigPath("",
+		func() (string, error) { return dir, nil },
+		func(p string) (os.FileInfo, error) {
+			if p == want {
+				return fakeFileInfo{name: "pipelock.yaml", mode: 0o600}, nil
+			}
+			return nil, os.ErrNotExist
+		},
+		emptyEnv,
+	)
+	if got != want {
+		t.Errorf("home candidate: got %q, want %q", got, want)
+	}
+}
+
+func TestResolveConfigPath_NoCandidate(t *testing.T) {
+	got := resolveConfigPath("",
+		func() (string, error) { return "", errors.New("no home") },
+		func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		emptyEnv,
+	)
+	if got != "" {
+		t.Errorf("no candidate: got %q, want empty", got)
+	}
+}
+
+func TestEnsureScheme(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"127.0.0.1:9090", "http://127.0.0.1:9090"},
+		{"http://localhost:9090", "http://localhost:9090"},
+		{"https://api.internal", "https://api.internal"},
+	}
+	for _, tt := range tests {
+		if got := ensureScheme(tt.in); got != tt.want {
+			t.Errorf("ensureScheme(%q): got %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestNormalizeEndpoint_StripsTrailingSlashes(t *testing.T) {
+	got := normalizeEndpoint(endpoint{URL: "http://x:1///", Token: "t"})
+	if got.URL != "http://x:1" {
+		t.Errorf("URL: got %q, want http://x:1", got.URL)
+	}
+}
+
+func TestDefaultResolverDeps_Wiring(t *testing.T) {
+	deps := defaultResolverDeps()
+	if deps.userHomeDir == nil || deps.stat == nil || deps.loadConfig == nil || deps.getenv == nil {
+		t.Error("defaultResolverDeps should populate every field")
+	}
+}
+
+func TestResolveEndpoint_NoTokenNoConfig(t *testing.T) {
+	deps := resolverDeps{
+		userHomeDir: func() (string, error) { return "", errors.New("no home") },
+		stat:        func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		loadConfig:  func(string) (*config.Config, error) { return nil, errors.New("never called") },
+		getenv:      func(string) string { return "" },
+	}
+	_, err := resolveEndpoint(&rootFlags{apiURL: "http://x:1"}, deps)
+	if err == nil {
+		t.Error("expected error when token cannot be sourced")
+	}
+}
+
+func TestResolveEndpoint_ConfigLoadFailure(t *testing.T) {
+	deps := resolverDeps{
+		userHomeDir: func() (string, error) { return "", errors.New("no home") },
+		stat:        func(string) (os.FileInfo, error) { return fakeFileInfo{mode: 0o600}, nil },
+		loadConfig:  func(string) (*config.Config, error) { return nil, errors.New("yaml blew up") },
+		getenv:      func(k string) string { return map[string]string{envConfigVar: "/fake"}[k] },
+	}
+	_, err := resolveEndpoint(&rootFlags{}, deps)
+	if err == nil {
+		t.Error("expected error when config load fails")
+	}
+}
+
+func TestResolveEndpoint_ConfigPermsRejected(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.KillSwitch.APIToken = "t"
+	cfg.KillSwitch.APIListen = "127.0.0.1:9090"
+	deps := resolverDeps{
+		userHomeDir: func() (string, error) { return "", errors.New("no home") },
+		stat:        func(string) (os.FileInfo, error) { return fakeFileInfo{mode: 0o644}, nil },
+		loadConfig:  func(string) (*config.Config, error) { return cfg, nil },
+		getenv:      func(k string) string { return map[string]string{envConfigVar: "/fake"}[k] },
+	}
+	_, err := resolveEndpoint(&rootFlags{}, deps)
+	if err == nil {
+		t.Error("expected rejection for world-readable config")
+	}
+}
+
+func TestResolveEndpoint_NoURLNoFlagsNoConfig(t *testing.T) {
+	deps := resolverDeps{
+		userHomeDir: func() (string, error) { return "", errors.New("no home") },
+		stat:        func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		loadConfig:  func(string) (*config.Config, error) { return nil, nil },
+		getenv:      func(string) string { return "" },
+	}
+	// Provide token but not URL — should fail with URL-specific message.
+	_, err := resolveEndpoint(&rootFlags{apiToken: "only-token"}, deps)
+	if err == nil {
+		t.Error("expected error for missing URL")
+	}
+}

--- a/internal/cli/session/resolver_test.go
+++ b/internal/cli/session/resolver_test.go
@@ -286,6 +286,53 @@ func TestResolveEndpoint_ConfigPermsRejected(t *testing.T) {
 	}
 }
 
+func TestApiListenToURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		listen  string
+		want    string
+		wantErr bool
+	}{
+		{"bare port", ":9090", "http://127.0.0.1:9090", false},
+		{"wildcard v4", "0.0.0.0:9090", "http://127.0.0.1:9090", false},
+		{"wildcard v6", "[::]:9090", "http://[::1]:9090", false},
+		{"loopback v4 preserved", "127.0.0.1:9090", "http://127.0.0.1:9090", false},
+		{"hostname preserved", "admin.local:8080", "http://admin.local:8080", false},
+		{"malformed no port", "notahost", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := apiListenToURL(tc.listen)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.listen)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveEndpoint_WildcardAPIListen(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.KillSwitch.APIListen = "0.0.0.0:9090"
+	cfg.KillSwitch.APIToken = "cfg-token"
+	deps := fakeDepsWithEnv(nil, cfg, nil)
+	ep, err := resolveEndpoint(&rootFlags{configPath: "/tmp/pipelock.yaml"}, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ep.URL != "http://127.0.0.1:9090" {
+		t.Fatalf("wildcard not normalized to loopback: got %q", ep.URL)
+	}
+}
+
 func TestResolveEndpoint_NoURLNoFlagsNoConfig(t *testing.T) {
 	deps := resolverDeps{
 		userHomeDir: func() (string, error) { return "", errors.New("no home") },

--- a/internal/cli/session/runner.go
+++ b/internal/cli/session/runner.go
@@ -45,6 +45,14 @@ func runClientCmd(
 		ctx = context.Background()
 	}
 	if err := executor(ctx, client, stdout); err != nil {
+		// Preserve any exit-code classification the executor already
+		// attached (e.g. recover's interactive invalid-input path wraps
+		// usage errors with ExitConfig). mapClientError is only for
+		// bare API/network errors that haven't been classified yet.
+		var classified *cliutil.ExitError
+		if errors.As(err, &classified) {
+			return err
+		}
 		return mapClientError(err)
 	}
 	return nil

--- a/internal/cli/session/runner.go
+++ b/internal/cli/session/runner.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+// newClientFn is the factory the subcommands use to build a live client.
+// Tests override this variable with a closure that returns a stubbed
+// client, avoiding the need to stand up an httptest server in every case.
+var newClientFn = func(flags *rootFlags) (*Client, error) {
+	ep, err := resolveEndpoint(flags, defaultResolverDeps())
+	if err != nil {
+		return nil, cliutil.ExitCodeError(2, err)
+	}
+	return newClient(ep), nil
+}
+
+// runClientCmd dispatches a subcommand that needs an admin API client.
+// The executor receives a configured *Client, a context.Context derived
+// from the parent cobra context, and the standard output writer. The
+// returned error is wrapped in an exit-code-aware error so callers get a
+// distinct code per failure class.
+func runClientCmd(
+	flags *rootFlags,
+	ctx context.Context,
+	stdout io.Writer,
+	executor func(context.Context, *Client, io.Writer) error,
+) error {
+	client, err := newClientFn(flags)
+	if err != nil {
+		return err
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := executor(ctx, client, stdout); err != nil {
+		return mapClientError(err)
+	}
+	return nil
+}
+
+// mapClientError converts an admin API error into a CLI exit code:
+//
+//	exit 1 — operational failure (404, 429, 500, network)
+//	exit 2 — auth/config failure (401, missing token, malformed flags)
+//
+// The rule is: exit 2 means "fix your setup," exit 1 means "try again
+// or escalate." Keeping those distinct lets operators script retries.
+func mapClientError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.StatusCode {
+		case http.StatusUnauthorized:
+			return cliutil.ExitCodeError(2, fmt.Errorf("unauthorized — check --api-token or PIPELOCK_KILLSWITCH_API_TOKEN: %s", apiErr.Body))
+		case http.StatusNotFound:
+			return cliutil.ExitCodeError(1, errors.New("session not found"))
+		case http.StatusTooManyRequests:
+			return cliutil.ExitCodeError(1, fmt.Errorf("rate limited; retry after %s seconds", apiErr.RetryAfter))
+		case http.StatusBadRequest:
+			return cliutil.ExitCodeError(2, fmt.Errorf("bad request: %s", apiErr.Body))
+		}
+		return cliutil.ExitCodeError(1, fmt.Errorf("server error HTTP %d: %s", apiErr.StatusCode, apiErr.Body))
+	}
+	return cliutil.ExitCodeError(1, err)
+}
+
+// writeJSON marshals v as indented JSON to w. Used by every subcommand
+// when --json is set. Returns the error from the encoder so the cobra
+// RunE closure surfaces it with the right exit code.
+func writeJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}

--- a/internal/cli/session/runner_test.go
+++ b/internal/cli/session/runner_test.go
@@ -5,7 +5,9 @@ package session
 
 import (
 	"bytes"
+	"context"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -52,6 +54,51 @@ func TestMapClientError_NonAPIErrorIsExit1(t *testing.T) {
 	err := mapClientError(errors.New("boom"))
 	if code := cliutil.ExitCodeOf(err); code != 1 {
 		t.Errorf("exit code: got %d, want 1", code)
+	}
+}
+
+// TestRunClientCmd_PreservesExitCodeError guards against regression of a
+// bug where runClientCmd remapped every executor error through
+// mapClientError, stripping any pre-wrapped cliutil.ExitCodeError. The
+// interactive recover path relies on ExitConfig (2) for invalid-input
+// errors; without this passthrough those become ExitGeneral (1).
+func TestRunClientCmd_PreservesExitCodeError(t *testing.T) {
+	origFactory := newClientFn
+	t.Cleanup(func() { newClientFn = origFactory })
+	newClientFn = func(*rootFlags) (*Client, error) {
+		return newClient(endpoint{URL: "http://stub:0", Token: "t"}), nil
+	}
+
+	wrapped := cliutil.ExitCodeError(cliutil.ExitConfig, errors.New("invalid input"))
+	err := runClientCmd(&rootFlags{}, context.Background(), io.Discard, func(context.Context, *Client, io.Writer) error {
+		return wrapped
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if code := cliutil.ExitCodeOf(err); code != cliutil.ExitConfig {
+		t.Errorf("exit code: got %d, want %d (original classification must survive)", code, cliutil.ExitConfig)
+	}
+}
+
+// TestRunClientCmd_UnclassifiedErrorsStillMapped keeps the default path
+// working: bare errors without ExitCodeError wrapping still get routed
+// through mapClientError.
+func TestRunClientCmd_UnclassifiedErrorsStillMapped(t *testing.T) {
+	origFactory := newClientFn
+	t.Cleanup(func() { newClientFn = origFactory })
+	newClientFn = func(*rootFlags) (*Client, error) {
+		return newClient(endpoint{URL: "http://stub:0", Token: "t"}), nil
+	}
+
+	err := runClientCmd(&rootFlags{}, context.Background(), io.Discard, func(context.Context, *Client, io.Writer) error {
+		return errors.New("bare error")
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if code := cliutil.ExitCodeOf(err); code != cliutil.ExitGeneral {
+		t.Errorf("bare error should map to ExitGeneral, got %d", code)
 	}
 }
 

--- a/internal/cli/session/runner_test.go
+++ b/internal/cli/session/runner_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+func TestMapClientError_NilIsNil(t *testing.T) {
+	if err := mapClientError(nil); err != nil {
+		t.Errorf("got %v, want nil", err)
+	}
+}
+
+func TestMapClientError_APIErrorClasses(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiErr     *APIError
+		wantExit   int
+		wantSubstr string
+	}{
+		{"401 unauthorized", &APIError{StatusCode: http.StatusUnauthorized, Body: "nope"}, 2, "unauthorized"},
+		{"404 not found", &APIError{StatusCode: http.StatusNotFound}, 1, "not found"},
+		{"429 rate limited", &APIError{StatusCode: http.StatusTooManyRequests, RetryAfter: "60"}, 1, "rate limited"},
+		{"400 bad request", &APIError{StatusCode: http.StatusBadRequest, Body: "bad"}, 2, "bad request"},
+		{"500 server error", &APIError{StatusCode: http.StatusInternalServerError, Body: "oops"}, 1, "server error"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapped := mapClientError(tt.apiErr)
+			if mapped == nil {
+				t.Fatal("expected error")
+			}
+			if code := cliutil.ExitCodeOf(mapped); code != tt.wantExit {
+				t.Errorf("exit code: got %d, want %d", code, tt.wantExit)
+			}
+			if !strings.Contains(mapped.Error(), tt.wantSubstr) {
+				t.Errorf("error text %q missing %q", mapped.Error(), tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestMapClientError_NonAPIErrorIsExit1(t *testing.T) {
+	err := mapClientError(errors.New("boom"))
+	if code := cliutil.ExitCodeOf(err); code != 1 {
+		t.Errorf("exit code: got %d, want 1", code)
+	}
+}
+
+func TestWriteJSON_Roundtrip(t *testing.T) {
+	var buf bytes.Buffer
+	data := map[string]any{"foo": "bar", "num": 42}
+	if err := writeJSON(&buf, data); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), `"foo": "bar"`) {
+		t.Errorf("json output: %s", buf.String())
+	}
+}

--- a/internal/cli/session/terminate.go
+++ b/internal/cli/session/terminate.go
@@ -47,18 +47,15 @@ Examples:
 	cmd.RunE = func(c *cobra.Command, args []string) error {
 		key := args[0]
 		return runClientCmd(flags, c.Context(), c.OutOrStdout(), func(ctx context.Context, client *Client, out io.Writer) error {
-			if !jsonOutput {
-				// Keep stdout machine-readable in --json mode.
-				_, _ = fmt.Fprintf(out, "WARNING: terminating session %s — in-flight connections will be cut.\n", key)
-			}
-
 			resp, err := client.Terminate(ctx, key)
 			if err != nil {
 				return err
 			}
 			if jsonOutput {
+				// Keep stdout machine-readable in --json mode.
 				return writeJSON(out, resp)
 			}
+			_, _ = fmt.Fprintf(out, "WARNING: terminated session %s — in-flight connections were cut.\n", key)
 			_, _ = fmt.Fprintf(out, "terminated %s: previous_tier=%s level=%s score=%.2f cee_cleared=%t\n",
 				resp.Key, resp.PreviousTier, resp.PreviousLevel, resp.PreviousScore, resp.CEEStateCleared)
 			return nil

--- a/internal/cli/session/terminate.go
+++ b/internal/cli/session/terminate.go
@@ -16,7 +16,7 @@ const (
 	terminateShort = "Force a full tear-down of a session (destructive)"
 )
 
-func terminateCmd() *cobra.Command {
+func terminateCmd(flags *rootFlags) *cobra.Command {
 	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   terminateUse,
@@ -42,7 +42,6 @@ Examples:
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	flags := addCommonFlags(cmd)
 	cmd.Flags().BoolVar(&jsonOutput, flagJSON, false, usageJSON)
 
 	cmd.RunE = func(c *cobra.Command, args []string) error {

--- a/internal/cli/session/terminate.go
+++ b/internal/cli/session/terminate.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	terminateUse   = "terminate <key>"
+	terminateShort = "Force a full tear-down of a session (destructive)"
+)
+
+func terminateCmd() *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   terminateUse,
+		Short: terminateShort,
+		Long: `Force a full tear-down of a session: cancel in-flight long-lived
+connections, reset all enforcement state, and clear CEE entropy/fragment
+tracking. This is DESTRUCTIVE
+— the affected agent loses its current adaptive history, any
+in-flight streams are cut, and any task-scoped overrides are dropped.
+
+Use this when release is insufficient: a session is actively being
+exploited, or has accumulated so much bad state that starting fresh
+is safer than releasing.
+
+Invocation sessions (ephemeral MCP transport keys starting with
+mcp-stdio-/mcp-http-/mcp-ws-) cannot be terminated via the admin API
+— they are rejected with a 400 error.
+
+Examples:
+  pipelock session terminate "agent|10.0.0.1"
+  pipelock session terminate "agent|10.0.0.1" --json`,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	flags := addCommonFlags(cmd)
+	cmd.Flags().BoolVar(&jsonOutput, flagJSON, false, usageJSON)
+
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+		key := args[0]
+		return runClientCmd(flags, c.Context(), c.OutOrStdout(), func(ctx context.Context, client *Client, out io.Writer) error {
+			if !jsonOutput {
+				// Keep stdout machine-readable in --json mode.
+				_, _ = fmt.Fprintf(out, "WARNING: terminating session %s — in-flight connections will be cut.\n", key)
+			}
+
+			resp, err := client.Terminate(ctx, key)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return writeJSON(out, resp)
+			}
+			_, _ = fmt.Fprintf(out, "terminated %s: previous_tier=%s level=%s score=%.2f cee_cleared=%t\n",
+				resp.Key, resp.PreviousTier, resp.PreviousLevel, resp.PreviousScore, resp.CEEStateCleared)
+			return nil
+		})
+	}
+	return cmd
+}

--- a/internal/cli/session/terminate_test.go
+++ b/internal/cli/session/terminate_test.go
@@ -26,7 +26,7 @@ func TestTerminateCmd_HappyPath(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	out, err := runCommand(terminateCmd(), testKeyIdent)
+	out, err := runCommand(terminateCmd(&rootFlags{}), testKeyIdent)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestTerminateCmd_InvocationRejected(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	_, err := runCommand(terminateCmd(), testKeyInvoc)
+	_, err := runCommand(terminateCmd(&rootFlags{}), testKeyInvoc)
 	if err == nil || !strings.Contains(err.Error(), "bad request") {
 		t.Errorf("expected bad request, got %v", err)
 	}
@@ -62,7 +62,7 @@ func TestTerminateCmd_JSON(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	out, err := runCommand(terminateCmd(), testKeyIdent, "--json")
+	out, err := runCommand(terminateCmd(&rootFlags{}), testKeyIdent, "--json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestTerminateCmd_NotFound(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	_, err := runCommand(terminateCmd(), testKeyIdent)
+	_, err := runCommand(terminateCmd(&rootFlags{}), testKeyIdent)
 	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Errorf("expected not found, got %v", err)
 	}
@@ -97,7 +97,7 @@ func TestTerminateCmd_RateLimited(t *testing.T) {
 	}))
 	overrideClientFactory(t, flags)
 
-	_, err := runCommand(terminateCmd(), testKeyIdent)
+	_, err := runCommand(terminateCmd(&rootFlags{}), testKeyIdent)
 	if err == nil || !strings.Contains(err.Error(), "rate") {
 		t.Errorf("expected rate limited error, got %v", err)
 	}

--- a/internal/cli/session/terminate_test.go
+++ b/internal/cli/session/terminate_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+)
+
+func TestTerminateCmd_HappyPath(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertBearer(t, r)
+		if r.Method != http.MethodPost {
+			t.Errorf("method: %s", r.Method)
+		}
+		writeJSONResponse(w, http.StatusOK, proxy.SessionTerminateResult{
+			Key: testKeyIdent, Terminated: true, PreviousTier: "hard",
+			PreviousLevel: "critical", PreviousScore: 0.9,
+			CEEStateCleared: true,
+		})
+	}))
+	overrideClientFactory(t, flags)
+
+	out, err := runCommand(terminateCmd(), testKeyIdent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Warning line is non-negotiable.
+	if !strings.Contains(out, "WARNING") {
+		t.Errorf("expected WARNING line in output: %s", out)
+	}
+	wantContains := []string{"terminated", "previous_tier=hard", "cee_cleared=true"}
+	for _, w := range wantContains {
+		if !strings.Contains(out, w) {
+			t.Errorf("missing %q in: %s", w, out)
+		}
+	}
+}
+
+func TestTerminateCmd_InvocationRejected(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(w, http.StatusBadRequest, map[string]string{"error": "invocation key"})
+	}))
+	overrideClientFactory(t, flags)
+
+	_, err := runCommand(terminateCmd(), testKeyInvoc)
+	if err == nil || !strings.Contains(err.Error(), "bad request") {
+		t.Errorf("expected bad request, got %v", err)
+	}
+}
+
+func TestTerminateCmd_JSON(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(w, http.StatusOK, proxy.SessionTerminateResult{
+			Key: testKeyIdent, Terminated: true,
+		})
+	}))
+	overrideClientFactory(t, flags)
+
+	out, err := runCommand(terminateCmd(), testKeyIdent, "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "WARNING") {
+		t.Fatalf("json output should not include warning banner: %s", out)
+	}
+	var parsed proxy.SessionTerminateResult
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !parsed.Terminated {
+		t.Error("Terminated should be true")
+	}
+}
+
+func TestTerminateCmd_NotFound(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "ghost", http.StatusNotFound)
+	}))
+	overrideClientFactory(t, flags)
+
+	_, err := runCommand(terminateCmd(), testKeyIdent)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not found, got %v", err)
+	}
+}
+
+func TestTerminateCmd_RateLimited(t *testing.T) {
+	flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "rate limit", http.StatusTooManyRequests)
+	}))
+	overrideClientFactory(t, flags)
+
+	_, err := runCommand(terminateCmd(), testKeyIdent)
+	if err == nil || !strings.Contains(err.Error(), "rate") {
+		t.Errorf("expected rate limited error, got %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4641,11 +4641,15 @@ func Defaults() *Config {
 				{Name: "Google OAuth Client ID", Regex: `[0-9]{6,}-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com`, Severity: "medium"},
 
 				// Generic credential patterns
-				// \b protects underscore-compound names (next_token, csrf_token_id) since _ is \w.
-				// Hyphen-compound names (show-password, x-token) are NOT protected since - is \W,
-				// so \b still fires. Accepted tradeoff: such params are rare in agent traffic.
+				// Requires a URL query delimiter ([?&;]) before the credential key so
+				// Go-style struct assignments (ep.Token = X, req.APIKey = Y) in source
+				// files do not false-positive. The rule is scoped to URL-embedded
+				// credentials only — env-var dumps like DB_PASSWORD=... are handled by
+				// the separate Environment Variable Secret pattern below, and config
+				// files use different scanners. Hyphen-compound params (show-password)
+				// are still protected because the delimiter is always explicit.
 				// Case-insensitive matching is added automatically by scanner.New() via (?i) prefix.
-				{Name: "Credential in URL", Regex: `\b(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}`, Severity: "high"},
+				{Name: "Credential in URL", Regex: `[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}`, Severity: "high"},
 				// Environment variable credential patterns: catches env var dumps
 				// where the secret-bearing keyword is the terminal segment of an
 				// UPPER_CASE name (e.g., AWS_SECRET_ACCESS_KEY=..., STRIPE_SECRET_KEY=...,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4644,11 +4644,11 @@ func Defaults() *Config {
 				// Accepts either a URL query delimiter ([?&;]) OR line-start
 				// before the credential key. Line-start (via the (?m) flag +
 				// ^ anchor) catches body-first credentials like
-				//     password=hunter2
+				//     password=X  (where X is the secret value)
 				// that an HTTP form or env-dump log emits without a leading
 				// delimiter, while the delimiter alternative still catches
-				// standard query strings (?password=...) and connection
-				// strings (;password=...). Go-style struct assignments
+				// standard query strings and connection strings prefixed by
+				// ? or ; before the credential key. Go-style struct assignments
 				// (ep.Token = X, req.APIKey = Y) are still immune because
 				// the credential key is preceded by . or another word
 				// character, which is neither ^ nor [?&;]. The rule is

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4641,15 +4641,25 @@ func Defaults() *Config {
 				{Name: "Google OAuth Client ID", Regex: `[0-9]{6,}-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com`, Severity: "medium"},
 
 				// Generic credential patterns
-				// Requires a URL query delimiter ([?&;]) before the credential key so
-				// Go-style struct assignments (ep.Token = X, req.APIKey = Y) in source
-				// files do not false-positive. The rule is scoped to URL-embedded
-				// credentials only — env-var dumps like DB_PASSWORD=... are handled by
-				// the separate Environment Variable Secret pattern below, and config
-				// files use different scanners. Hyphen-compound params (show-password)
-				// are still protected because the delimiter is always explicit.
+				// Accepts either a URL query delimiter ([?&;]) OR line-start
+				// before the credential key. Line-start (via the (?m) flag +
+				// ^ anchor) catches body-first credentials like
+				//     password=hunter2
+				// that an HTTP form or env-dump log emits without a leading
+				// delimiter, while the delimiter alternative still catches
+				// standard query strings (?password=...) and connection
+				// strings (;password=...). Go-style struct assignments
+				// (ep.Token = X, req.APIKey = Y) are still immune because
+				// the credential key is preceded by . or another word
+				// character, which is neither ^ nor [?&;]. The rule is
+				// scoped to URL/body-embedded credentials only — env-var
+				// dumps like DB_PASSWORD=... are handled by the separate
+				// Environment Variable Secret pattern below, which requires
+				// UPPER_CASE identifiers. Hyphen-compound params
+				// (show-password) are still protected because the delimiter
+				// is always explicit.
 				// Case-insensitive matching is added automatically by scanner.New() via (?i) prefix.
-				{Name: "Credential in URL", Regex: `[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[^\s&]{4,}`, Severity: "high"},
+				{Name: "Credential in URL", Regex: `(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}`, Severity: "high"},
 				// Environment variable credential patterns: catches env var dumps
 				// where the secret-bearing keyword is the terminal segment of an
 				// UPPER_CASE name (e.g., AWS_SECRET_ACCESS_KEY=..., STRIPE_SECRET_KEY=...,

--- a/internal/killswitch/killswitch.go
+++ b/internal/killswitch/killswitch.go
@@ -162,10 +162,13 @@ func (c *Controller) IsActiveHTTP(r *http.Request) Decision {
 	if rt.apiExempt && !c.separatePort.Load() &&
 		(path == "/api/v1/killswitch" || path == "/api/v1/killswitch/status" ||
 			path == "/api/v1/sessions" ||
+			IsSessionKeyPath(path) ||
 			IsSessionActionPath(path, "reset") ||
 			IsSessionActionPath(path, "airlock") ||
 			IsSessionActionPath(path, "task") ||
-			IsSessionActionPath(path, "trust")) {
+			IsSessionActionPath(path, "trust") ||
+			IsSessionActionPath(path, "explain") ||
+			IsSessionActionPath(path, "terminate")) {
 		return Decision{}
 	}
 
@@ -209,6 +212,19 @@ func IsSessionActionPath(path, action string) bool {
 	return segs[0] == "api" && segs[1] == "v1" && segs[2] == "sessions" &&
 		segs[3] != "" && !strings.Contains(segs[3], "\x00") &&
 		segs[4] == action
+}
+
+// IsSessionKeyPath validates that path matches /api/v1/sessions/{key} with
+// exactly four segments and a non-empty key. Used by the admin API router
+// to detect inspect lookups on the base session path. Applies the same
+// traversal-prevention rules as IsSessionActionPath.
+func IsSessionKeyPath(path string) bool {
+	segs := strings.Split(strings.Trim(path, "/"), "/")
+	if len(segs) != 4 {
+		return false
+	}
+	return segs[0] == "api" && segs[1] == "v1" && segs[2] == "sessions" &&
+		segs[3] != "" && !strings.Contains(segs[3], "\x00")
 }
 
 // Reload updates the config-derived state atomically.

--- a/internal/proxy/airlock.go
+++ b/internal/proxy/airlock.go
@@ -6,6 +6,7 @@ package proxy
 import (
 	"context"
 	"net/http"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -28,6 +29,19 @@ const (
 const (
 	ExemptReasonDomain   = "exempt_domain"
 	ExemptReasonSuppress = "suppress"
+)
+
+// Airlock transition source and trigger labels emitted in explain output.
+const (
+	airlockSourceTriggers = "airlock_triggers"
+	airlockSourceAdminAPI = "admin_api"
+	airlockSourceTimers   = "airlock_timers"
+
+	airlockTriggerOnElevated = "on_elevated"
+	airlockTriggerOnHigh     = "on_high"
+	airlockTriggerOnCritical = "on_critical"
+	airlockTriggerManual     = "manual"
+	airlockTriggerTimer      = "timer"
 )
 
 // AirlockTierOrder maps tier names to numeric order for comparison.
@@ -53,6 +67,8 @@ type AirlockState struct {
 	mu          sync.Mutex
 	tier        string
 	enteredAt   time.Time
+	trigger     string
+	source      string
 	cancelFuncs []context.CancelFunc
 
 	// inFlightCount tracks active requests for drain coordination.
@@ -73,11 +89,49 @@ func (a *AirlockState) Tier() string {
 	return a.tier
 }
 
+// EnteredAt returns the wall-clock time the current tier was entered.
+// Zero value when the session has been reset or never escalated. Callers
+// use this to compute elapsed-in-tier for operator explain output and to
+// estimate the next auto-deescalation instant.
+func (a *AirlockState) EnteredAt() time.Time {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.enteredAt
+}
+
+// EntryProvenance returns the trigger/source pair that set the current tier.
+// Empty strings mean the tier was entered without explicit provenance.
+func (a *AirlockState) EntryProvenance() (trigger, source string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.trigger, a.source
+}
+
+// setEntryMetadataLocked records when and why the current tier was entered.
+// Entering the none tier clears quarantine metadata entirely.
+func (a *AirlockState) setEntryMetadataLocked(tier, trigger, source string) {
+	if tier == config.AirlockTierNone {
+		a.enteredAt = time.Time{}
+		a.trigger = ""
+		a.source = ""
+		return
+	}
+	a.enteredAt = time.Now()
+	a.trigger = trigger
+	a.source = source
+}
+
 // SetTier transitions the airlock to a new tier. Upward transitions fast-forward
 // through intermediate tiers atomically (none->hard skips soft). Downward
 // transitions are rejected; use TryDeescalate for timer-based recovery.
 // Returns whether the tier changed, and the previous/new tier for logging.
 func (a *AirlockState) SetTier(newTier string) (changed bool, from, to string) {
+	return a.SetTierWithProvenance(newTier, "", "")
+}
+
+// SetTierWithProvenance transitions the airlock to a new tier and records
+// the trigger/source that caused the entry.
+func (a *AirlockState) SetTierWithProvenance(newTier, trigger, source string) (changed bool, from, to string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -96,7 +150,7 @@ func (a *AirlockState) SetTier(newTier string) (changed bool, from, to string) {
 
 	from = a.tier
 	a.tier = newTier
-	a.enteredAt = time.Now()
+	a.setEntryMetadataLocked(newTier, trigger, source)
 
 	// On hard entry, half-close existing connections.
 	if newTier == config.AirlockTierHard {
@@ -162,7 +216,7 @@ func (a *AirlockState) TryDeescalate(timers *config.AirlockTimers) (changed bool
 
 	from = a.tier
 	a.tier = nextTier
-	a.enteredAt = time.Now()
+	a.setEntryMetadataLocked(nextTier, airlockTriggerTimer, airlockSourceTimers)
 	return true, from, nextTier
 }
 
@@ -363,6 +417,12 @@ func (r *FrozenToolRegistry) IsToolAllowed(stableKey, toolName string) bool {
 // Used by the admin API for manual releases and de-escalation where
 // operators need to move sessions to any tier including downward.
 func (a *AirlockState) ForceSetTier(newTier string) (changed bool, from, to string) {
+	return a.ForceSetTierWithProvenance(newTier, airlockTriggerManual, airlockSourceAdminAPI)
+}
+
+// ForceSetTierWithProvenance sets the airlock tier without transition
+// restrictions and records the trigger/source that caused the entry.
+func (a *AirlockState) ForceSetTierWithProvenance(newTier, trigger, source string) (changed bool, from, to string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -375,7 +435,7 @@ func (a *AirlockState) ForceSetTier(newTier string) (changed bool, from, to stri
 
 	from = a.tier
 	a.tier = newTier
-	a.enteredAt = time.Now()
+	a.setEntryMetadataLocked(newTier, trigger, source)
 
 	// Tear down connections on hard/drain, matching SetTier behavior.
 	// ForceSetTier is used by the admin API; operators expect immediate effect.
@@ -398,4 +458,22 @@ func (r *FrozenToolRegistry) Unfreeze(stableKey string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.entries, stableKey)
+}
+
+// ToolNames returns a sorted snapshot of the frozen tool names for the
+// given key. Returns nil when the key is not frozen. Sorted to give the
+// admin API a stable preview regardless of map iteration order.
+func (r *FrozenToolRegistry) ToolNames(stableKey string) []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	entry, exists := r.entries[stableKey]
+	if !exists {
+		return nil
+	}
+	names := make([]string, 0, len(entry.tools))
+	for name := range entry.tools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -299,14 +299,14 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 		apiToken = envToken
 	}
 	if apiToken != "" {
-		p.sessionAPI = NewSessionAPIHandler(
-			&p.sessionMgrPtr,
-			&p.entropyTrackerPtr,
-			&p.fragmentBufferPtr,
-			m,
-			logger,
-			apiToken,
-		)
+		p.sessionAPI = NewSessionAPIHandler(SessionAPIOptions{
+			SessionMgrPtr: &p.sessionMgrPtr,
+			EntropyPtr:    &p.entropyTrackerPtr,
+			FragmentPtr:   &p.fragmentBufferPtr,
+			Metrics:       m,
+			Logger:        logger,
+			APIToken:      apiToken,
+		})
 	}
 
 	p.dialer = &net.Dialer{
@@ -895,16 +895,27 @@ func (p *Proxy) recordSessionActivity(clientIP, agent, hostname, requestID strin
 	// See the long comment at the `escalated` declaration above.
 	if cfg.Airlock.Enabled && escalated {
 		targetTier := ""
+		trigger := ""
 		switch session.EscalationLabel(level) {
 		case "elevated":
 			targetTier = cfg.Airlock.Triggers.OnElevated
+			trigger = airlockTriggerOnElevated
 		case "high":
 			targetTier = cfg.Airlock.Triggers.OnHigh
+			trigger = airlockTriggerOnHigh
 		case "critical":
 			targetTier = cfg.Airlock.Triggers.OnCritical
+			trigger = airlockTriggerOnCritical
 		}
 		if targetTier != "" && targetTier != config.AirlockTierNone {
-			if changed, from, to := sess.Airlock().SetTier(targetTier); changed {
+			if changed, from, to := sess.Airlock().SetTierWithProvenance(targetTier, trigger, airlockSourceTriggers); changed {
+				sess.RecordEvent(SessionEvent{
+					Kind:     "airlock_enter",
+					Target:   to,
+					Detail:   from + "->" + to,
+					Severity: "warn",
+					Score:    sess.ThreatScore(),
+				})
 				if log != nil {
 					log.LogAirlockEnter(key, to, "adaptive_"+session.EscalationLabel(level), clientIP, requestID)
 				}
@@ -919,9 +930,31 @@ func (p *Proxy) recordSessionActivity(clientIP, agent, hostname, requestID strin
 		log.LogSessionAnomaly(key, a.Type, a.Detail, clientIP, requestID, a.Score)
 		p.metrics.RecordSessionAnomaly(a.Type)
 
+		sess.RecordEvent(SessionEvent{
+			Kind:     "anomaly",
+			Target:   hostname,
+			Detail:   a.Detail,
+			Severity: "warn",
+			Score:    a.Score,
+		})
+
 		if cfg.SessionProfiling.AnomalyAction == config.ActionBlock && cfg.EnforceEnabled() {
 			return SessionResult{Blocked: true, Detail: fmt.Sprintf("session anomaly: %s", a.Detail), Level: level}
 		}
+	}
+
+	// Record a block event on any non-allowed scanner result so inspect/
+	// explain operators can see the specific evidence that drove escalation.
+	// Score-neutral cases (protective, config-mismatch) still record so the
+	// operator trail reflects the full picture; empty Reason is preserved.
+	if !result.Allowed {
+		sess.RecordEvent(SessionEvent{
+			Kind:     "block",
+			Target:   hostname,
+			Detail:   result.Reason,
+			Severity: "critical",
+			Score:    result.Score,
+		})
 	}
 
 	return SessionResult{Level: level}
@@ -1158,6 +1191,7 @@ func (p *Proxy) buildHandler(mux *http.ServeMux) http.Handler {
 
 // sessionAPIRouter dispatches /api/v1/sessions/{key}/* requests to the
 // appropriate session API handler based on the trailing path segment.
+// The four-segment fallback (/api/v1/sessions/{key}) routes to HandleInspect.
 func (p *Proxy) sessionAPIRouter(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.EscapedPath()
 	switch {
@@ -1169,6 +1203,12 @@ func (p *Proxy) sessionAPIRouter(w http.ResponseWriter, r *http.Request) {
 		p.sessionAPI.HandleTrust(w, r)
 	case killswitch.IsSessionActionPath(path, "reset"):
 		p.sessionAPI.HandleReset(w, r)
+	case killswitch.IsSessionActionPath(path, "explain"):
+		p.sessionAPI.HandleExplain(w, r)
+	case killswitch.IsSessionActionPath(path, "terminate"):
+		p.sessionAPI.HandleTerminate(w, r)
+	case killswitch.IsSessionKeyPath(path):
+		p.sessionAPI.HandleInspect(w, r)
 	default:
 		http.NotFound(w, r)
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -510,6 +510,15 @@ func (p *Proxy) FragmentBufferPtr() *atomic.Pointer[scanner.FragmentBuffer] {
 	return &p.fragmentBufferPtr
 }
 
+// SessionAPI returns the proxy's admin session API handler, or nil when
+// no api_token is configured. run.go mounts this on the dedicated
+// kill-switch API port (when kill_switch.api_listen is set) instead of
+// building a second handler, so Reload's hot-reload token rotation
+// covers both the main and dedicated mounts with one SetAPIToken call.
+func (p *Proxy) SessionAPI() *SessionAPIHandler {
+	return p.sessionAPI
+}
+
 // EnvelopeEmitterPtr returns the atomic pointer to the envelope emitter.
 // Used by the reverse proxy handler to share the emitter and receive
 // hot-reload updates.
@@ -549,6 +558,19 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) {
 
 	oldCfg := p.cfgPtr.Load()
 	p.cfgPtr.Store(cfg)
+
+	// Hot-reload the admin API bearer token so operators can rotate
+	// kill_switch.api_token (or the env override) without restarting.
+	// Env var continues to take precedence over the YAML value, mirroring
+	// the bootstrap resolution in New().
+	if p.sessionAPI != nil {
+		newToken := cfg.KillSwitch.APIToken
+		if envToken := os.Getenv(killswitch.EnvAPIToken); envToken != "" {
+			newToken = envToken
+		}
+		p.sessionAPI.SetAPIToken(newToken)
+	}
+
 	old := p.scannerPtr.Swap(sc)
 
 	if old != nil {

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -1025,6 +1025,86 @@ func (sm *SessionManager) ResetSessionIfResettable(key string) (prev SessionSnap
 	return prev, true, nil
 }
 
+// SnapshotAndResetIfResettable captures the pre-reset session state and
+// then resets the session under a single sm.mu.Lock, so HandleTerminate
+// can report `previous_tier`/`previous_level`/`previous_score` values
+// that describe one consistent point in time. Without this method the
+// caller would have to split the snapshot and the reset across two
+// independent critical sections, and a concurrent tier or score change
+// in between could produce an audit row that never actually existed.
+//
+// Returns:
+//   - found=false, err=nil: session does not exist
+//   - found=true, err=ErrInvocationReset: session exists but is not resettable
+//   - found=true, err=nil: preSnap holds the pre-reset state
+func (sm *SessionManager) SnapshotAndResetIfResettable(key string) (preSnap sessionAdminSnapshot, found bool, err error) {
+	_, agent, ip := classifySessionKey(key)
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	sess, ok := sm.sessions[key]
+	if !ok {
+		return sessionAdminSnapshot{}, false, nil
+	}
+
+	// Snapshot the session state under sess.mu BEFORE resetting. The
+	// airlock sub-lock is nested inside sess.mu per the documented lock
+	// ordering sm > sess > airlock.
+	sess.mu.Lock()
+	kind := sess.kind
+	if kind != sessionKindIdentity {
+		sess.mu.Unlock()
+		return sessionAdminSnapshot{SessionSnapshot: SessionSnapshot{Key: key, Kind: kind}}, true, ErrInvocationReset
+	}
+	sess.airlock.mu.Lock()
+	levelInt := sess.escalationLevel
+	preSnap = sessionAdminSnapshot{
+		SessionSnapshot: SessionSnapshot{
+			Key:              key,
+			Agent:            agent,
+			ClientIP:         ip,
+			Kind:             kind,
+			CurrentTaskID:    sess.task.CurrentTaskID,
+			CurrentTaskLabel: sess.task.CurrentTaskLabel,
+			ThreatScore:      sess.threatScore,
+			EscalationLevel:  session.EscalationLabel(levelInt),
+			BlockAll:         sess.atBlockAll,
+			AirlockTier:      sess.airlock.tier,
+			TaintLevel:       sess.risk.Level.String(),
+			Contaminated:     sess.risk.Contaminated,
+			LastActivity:     sess.lastActivity,
+		},
+		AirlockEnteredAt:     sess.airlock.enteredAt,
+		InFlight:             sess.airlock.inFlightCount.Load(),
+		EscalationLevelInt:   levelInt,
+		AirlockTrigger:       sess.airlock.trigger,
+		AirlockTriggerSource: sess.airlock.source,
+	}
+	preSnap.RecentEvents = make([]SessionEvent, len(sess.recentEvents))
+	copy(preSnap.RecentEvents, sess.recentEvents)
+	sess.airlock.mu.Unlock()
+	sess.mu.Unlock()
+
+	// Clear IP-level state (shared across all identities on this IP).
+	if ip != "" {
+		delete(sm.ipDomains, ip)
+		delete(sm.ipBurstCooldown, ip)
+	}
+
+	// Reset session in place while still holding sm.mu to prevent an
+	// eviction race between lock release and Reset. sess.Reset reacquires
+	// sess.mu internally — safe because lock order sm > sess holds.
+	_, _ = sess.Reset()
+
+	// Decrement adaptive gauge if session was escalated.
+	if levelInt > 0 && sm.metrics != nil {
+		sm.metrics.SetAdaptiveSessionLevel(session.EscalationLabel(levelInt), -1)
+	}
+
+	return preSnap, true, nil
+}
+
 // withMutableIdentitySession looks up a resettable identity session and runs
 // mutate while still holding sm.mu.RLock. This blocks cleanup/eviction from
 // removing the session between map lookup and the session-scoped mutation.
@@ -1116,17 +1196,26 @@ func (sm *SessionManager) SnapshotByKey(key string) (SessionSnapshot, []SessionE
 
 // AdminSnapshotByKey returns the operator-facing snapshot for a single
 // session. Unlike SnapshotByKey, it includes airlock timing, in-flight
-// count, numeric escalation, trigger provenance, and recent events captured
-// from one session state read so inspect/explain stay internally consistent.
+// count, numeric escalation, trigger provenance, and recent events
+// captured from one session state read so inspect/explain stay
+// internally consistent.
+//
+// The manager read lock is held across the session copy so cleanup()
+// cannot evict and GetOrCreate() cannot recreate the same key mid-read
+// — that race would let inspect/explain serialize stale state from a
+// session the map no longer points at. Lock order is sm > sess.
 func (sm *SessionManager) AdminSnapshotByKey(key string) (sessionAdminSnapshot, bool) {
 	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
 	sess, ok := sm.sessions[key]
-	sm.mu.RUnlock()
 	if !ok {
 		return sessionAdminSnapshot{}, false
 	}
 
 	sess.mu.Lock()
+	defer sess.mu.Unlock()
+
 	kind, agent, ip := classifySessionKey(key)
 	sess.airlock.mu.Lock()
 	airlockTier := sess.airlock.tier
@@ -1161,7 +1250,6 @@ func (sm *SessionManager) AdminSnapshotByKey(key string) (sessionAdminSnapshot, 
 	}
 	snap.RecentEvents = make([]SessionEvent, len(sess.recentEvents))
 	copy(snap.RecentEvents, sess.recentEvents)
-	sess.mu.Unlock()
 
 	return snap, true
 }

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -359,7 +359,22 @@ func (s *SessionState) RecentEvents() []SessionEvent {
 func (s *SessionState) Reset() (prevScore float64, prevLevel int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.airlock.mu.Lock()
+	defer s.airlock.mu.Unlock()
+	return s.resetWhileLocked()
+}
 
+// resetWhileLocked performs the in-place reset under the assumption
+// that the caller already holds both s.mu and s.airlock.mu. Extracted
+// so SnapshotAndResetIfResettable can take the snapshot and clear the
+// session in a single critical section — without this helper,
+// releasing the session/airlock locks between the snapshot copy and
+// Reset would let concurrent mutation slip state into the audit row
+// that never actually existed at the moment of terminate.
+//
+// Callers are responsible for holding s.mu AND s.airlock.mu. Lock
+// order is sess.mu > sess.airlock.mu; acquire in that order.
+func (s *SessionState) resetWhileLocked() (prevScore float64, prevLevel int) {
 	prevScore = s.threatScore
 	prevLevel = s.escalationLevel
 
@@ -377,15 +392,19 @@ func (s *SessionState) Reset() (prevScore float64, prevLevel int) {
 	s.uniqueTools = nil
 	s.recentEvents = nil
 
-	// Reset airlock to none tier. Direct field access is safe because
-	// we hold s.mu and SetTier only allows upward transitions.
-	s.airlock.mu.Lock()
+	// Release airlock quarantine. Fire pending cancel funcs so in-flight
+	// long-lived connections tear down, then clear the slice so stale
+	// callbacks cannot re-fire on a future hard/drain escalation. This
+	// mirrors ForceSetTierWithProvenance(none), which explicitly clears
+	// cancelFuncs on release. Without the nil assignment, Reset() +
+	// RegisterCancel() + SetTier(hard) would re-fire every cancel from
+	// before the reset.
 	s.airlock.tier = config.AirlockTierNone
 	s.airlock.enteredAt = time.Time{}
 	s.airlock.trigger = ""
 	s.airlock.source = ""
 	s.airlock.callCancelFuncsLocked()
-	s.airlock.mu.Unlock()
+	s.airlock.cancelFuncs = nil
 
 	return prevScore, prevLevel
 }
@@ -1025,13 +1044,16 @@ func (sm *SessionManager) ResetSessionIfResettable(key string) (prev SessionSnap
 	return prev, true, nil
 }
 
-// SnapshotAndResetIfResettable captures the pre-reset session state and
-// then resets the session under a single sm.mu.Lock, so HandleTerminate
-// can report `previous_tier`/`previous_level`/`previous_score` values
-// that describe one consistent point in time. Without this method the
-// caller would have to split the snapshot and the reset across two
-// independent critical sections, and a concurrent tier or score change
-// in between could produce an audit row that never actually existed.
+// SnapshotAndResetIfResettable captures the pre-reset session state
+// and then resets the session under a single critical section held
+// across sm.mu > sess.mu > sess.airlock.mu, so HandleTerminate can
+// report `previous_tier`/`previous_level`/`previous_score` values
+// that describe one consistent point in time. Splitting snapshot and
+// reset across separate locks would leave a mutation window where a
+// concurrent request-path goroutine could touch sess.threatScore,
+// sess.escalationLevel, or sess.airlock.tier between the capture and
+// the reset — resetWhileLocked closes that window by running the
+// reset with both session-level locks still held.
 //
 // Returns:
 //   - found=false, err=nil: session does not exist
@@ -1048,16 +1070,17 @@ func (sm *SessionManager) SnapshotAndResetIfResettable(key string) (preSnap sess
 		return sessionAdminSnapshot{}, false, nil
 	}
 
-	// Snapshot the session state under sess.mu BEFORE resetting. The
-	// airlock sub-lock is nested inside sess.mu per the documented lock
-	// ordering sm > sess > airlock.
 	sess.mu.Lock()
+	defer sess.mu.Unlock()
+
 	kind := sess.kind
 	if kind != sessionKindIdentity {
-		sess.mu.Unlock()
 		return sessionAdminSnapshot{SessionSnapshot: SessionSnapshot{Key: key, Kind: kind}}, true, ErrInvocationReset
 	}
+
 	sess.airlock.mu.Lock()
+	defer sess.airlock.mu.Unlock()
+
 	levelInt := sess.escalationLevel
 	preSnap = sessionAdminSnapshot{
 		SessionSnapshot: SessionSnapshot{
@@ -1083,21 +1106,22 @@ func (sm *SessionManager) SnapshotAndResetIfResettable(key string) (preSnap sess
 	}
 	preSnap.RecentEvents = make([]SessionEvent, len(sess.recentEvents))
 	copy(preSnap.RecentEvents, sess.recentEvents)
-	sess.airlock.mu.Unlock()
-	sess.mu.Unlock()
 
 	// Clear IP-level state (shared across all identities on this IP).
+	// Safe under sm.mu.Lock.
 	if ip != "" {
 		delete(sm.ipDomains, ip)
 		delete(sm.ipBurstCooldown, ip)
 	}
 
-	// Reset session in place while still holding sm.mu to prevent an
-	// eviction race between lock release and Reset. sess.Reset reacquires
-	// sess.mu internally — safe because lock order sm > sess holds.
-	_, _ = sess.Reset()
+	// Perform the reset while still holding sess.mu and sess.airlock.mu
+	// so the snapshot fields above and the fields being cleared come
+	// from the same critical section. No concurrent goroutine can
+	// mutate sess or sess.airlock between the capture and the reset.
+	_, _ = sess.resetWhileLocked()
 
-	// Decrement adaptive gauge if session was escalated.
+	// Decrement adaptive gauge if session was escalated. Lock-free
+	// prometheus op; safe to call under the session locks.
 	if levelInt > 0 && sm.metrics != nil {
 		sm.metrics.SetAdaptiveSessionLevel(session.EscalationLabel(levelInt), -1)
 	}

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -34,6 +34,25 @@ type Anomaly struct {
 	Score  float64 // anomaly score contribution
 }
 
+// maxRecentEvents caps the per-session event ring buffer. Operators viewing
+// an airlocked session through `pipelock session inspect` see the last N
+// notable events (blocks, anomalies, airlock transitions); older entries are
+// discarded to bound memory growth on long-lived sessions.
+const maxRecentEvents = 20
+
+// SessionEvent is a structured record of a notable event on a session used
+// by the operator admin API to explain airlock state and recent activity.
+// Events are pushed into a bounded ring buffer on SessionState and read out
+// in chronological order (oldest first).
+type SessionEvent struct {
+	At       time.Time `json:"at"`
+	Kind     string    `json:"kind"`     // e.g. "block", "anomaly", "airlock_enter"
+	Target   string    `json:"target"`   // hostname, tool name, or transport where observed
+	Detail   string    `json:"detail"`   // short human-readable description
+	Severity string    `json:"severity"` // info / warn / critical, mirrors audit severity
+	Score    float64   `json:"score"`    // scanner score at time of event (0 when N/A)
+}
+
 // SessionState tracks behavioral state for a single agent session.
 type SessionState struct {
 	mu           sync.Mutex
@@ -69,6 +88,12 @@ type SessionState struct {
 	// Task-boundary state for taint overrides and evidence binding.
 	task             session.TaskContext
 	runtimeOverrides []session.TrustOverride
+
+	// recentEvents is a bounded ring buffer of notable events (blocks,
+	// anomalies, airlock transitions). Read by the operator admin API to
+	// populate inspect/explain responses — written by recordSessionActivity
+	// and the airlock trigger path.
+	recentEvents []SessionEvent
 }
 
 // IsResettable returns whether this session can be reset via the admin API.
@@ -295,6 +320,39 @@ func (s *SessionState) EscalationLevel() int {
 	return s.escalationLevel
 }
 
+// RecordEvent appends evt to the session's recent-event ring buffer.
+// Events older than maxRecentEvents are dropped in FIFO order so an
+// attacker cannot grow SessionState memory by driving retries.
+// evt.At is set to time.Now() when zero.
+func (s *SessionState) RecordEvent(evt SessionEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if evt.At.IsZero() {
+		evt.At = time.Now()
+	}
+	if len(s.recentEvents) >= maxRecentEvents {
+		// Drop the oldest entry (index 0) by shifting the slice. In-place
+		// shift reuses the underlying array so the allocation is bounded.
+		copy(s.recentEvents, s.recentEvents[1:])
+		s.recentEvents = s.recentEvents[:maxRecentEvents-1]
+	}
+	s.recentEvents = append(s.recentEvents, evt)
+}
+
+// RecentEvents returns a copy of the session's recent-event ring buffer
+// in chronological order (oldest first). Returns an empty slice when no
+// events have been recorded.
+func (s *SessionState) RecentEvents() []SessionEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.recentEvents) == 0 {
+		return []SessionEvent{}
+	}
+	out := make([]SessionEvent, len(s.recentEvents))
+	copy(out, s.recentEvents)
+	return out
+}
+
 // Reset zeros all enforcement fields in place and refreshes lastActivity.
 // The session remains in the map so live Recorder pointers stay valid.
 // Returns previous score and level for the API response.
@@ -317,12 +375,15 @@ func (s *SessionState) Reset() (prevScore float64, prevLevel int) {
 	s.bytesTotal = 0
 	s.toolCalls = 0
 	s.uniqueTools = nil
+	s.recentEvents = nil
 
 	// Reset airlock to none tier. Direct field access is safe because
 	// we hold s.mu and SetTier only allows upward transitions.
 	s.airlock.mu.Lock()
 	s.airlock.tier = config.AirlockTierNone
 	s.airlock.enteredAt = time.Time{}
+	s.airlock.trigger = ""
+	s.airlock.source = ""
 	s.airlock.callCancelFuncsLocked()
 	s.airlock.mu.Unlock()
 
@@ -471,6 +532,20 @@ type SessionSnapshot struct {
 	TaintLevel       string    `json:"taint_level"`
 	Contaminated     bool      `json:"contaminated"`
 	LastActivity     time.Time `json:"last_activity"`
+}
+
+// sessionAdminSnapshot is the internal operator-facing expansion of
+// SessionSnapshot used by inspect/explain. It captures all fields in a
+// single pass so handlers do not mix a map snapshot with a second live
+// read from the session and return self-contradictory JSON under races.
+type sessionAdminSnapshot struct {
+	SessionSnapshot
+	AirlockEnteredAt     time.Time
+	InFlight             int64
+	EscalationLevelInt   int
+	AirlockTrigger       string
+	AirlockTriggerSource string
+	RecentEvents         []SessionEvent
 }
 
 // classifySessionKey determines whether a key is an identity key or an
@@ -1015,6 +1090,89 @@ func (sm *SessionManager) AddRuntimeTrustOverride(key string, override session.T
 	return applied, found, err
 }
 
+// SessionByKey returns a pointer to the session for the given key, or nil
+// when no such session exists. Unlike GetOrCreate, this does NOT create a
+// missing session — admin API lookups must not materialize phantom sessions.
+// The returned pointer is valid for the lifetime of the session; callers
+// must not hold it across operations that may trigger eviction.
+func (sm *SessionManager) SessionByKey(key string) *SessionState {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.sessions[key]
+}
+
+// SnapshotByKey returns a read-only snapshot of a single session and its
+// recent-event buffer, matching the shape of the Snapshot() slice element
+// with the event ring buffer attached. Returns (snap, events, true) when
+// the session exists, (zero, nil, false) when it does not. Copies state
+// under locks then releases them before returning.
+func (sm *SessionManager) SnapshotByKey(key string) (SessionSnapshot, []SessionEvent, bool) {
+	admin, ok := sm.AdminSnapshotByKey(key)
+	if !ok {
+		return SessionSnapshot{}, nil, false
+	}
+	return admin.SessionSnapshot, admin.RecentEvents, true
+}
+
+// AdminSnapshotByKey returns the operator-facing snapshot for a single
+// session. Unlike SnapshotByKey, it includes airlock timing, in-flight
+// count, numeric escalation, trigger provenance, and recent events captured
+// from one session state read so inspect/explain stay internally consistent.
+func (sm *SessionManager) AdminSnapshotByKey(key string) (sessionAdminSnapshot, bool) {
+	sm.mu.RLock()
+	sess, ok := sm.sessions[key]
+	sm.mu.RUnlock()
+	if !ok {
+		return sessionAdminSnapshot{}, false
+	}
+
+	sess.mu.Lock()
+	kind, agent, ip := classifySessionKey(key)
+	sess.airlock.mu.Lock()
+	airlockTier := sess.airlock.tier
+	airlockEnteredAt := sess.airlock.enteredAt
+	airlockTrigger := sess.airlock.trigger
+	airlockTriggerSource := sess.airlock.source
+	inFlight := sess.airlock.inFlightCount.Load()
+	sess.airlock.mu.Unlock()
+
+	levelInt := sess.escalationLevel
+	snap := sessionAdminSnapshot{
+		SessionSnapshot: SessionSnapshot{
+			Key:              key,
+			Agent:            agent,
+			ClientIP:         ip,
+			Kind:             kind,
+			CurrentTaskID:    sess.task.CurrentTaskID,
+			CurrentTaskLabel: sess.task.CurrentTaskLabel,
+			ThreatScore:      sess.threatScore,
+			EscalationLevel:  session.EscalationLabel(levelInt),
+			BlockAll:         sess.atBlockAll,
+			AirlockTier:      airlockTier,
+			TaintLevel:       sess.risk.Level.String(),
+			Contaminated:     sess.risk.Contaminated,
+			LastActivity:     sess.lastActivity,
+		},
+		AirlockEnteredAt:     airlockEnteredAt,
+		InFlight:             inFlight,
+		EscalationLevelInt:   levelInt,
+		AirlockTrigger:       airlockTrigger,
+		AirlockTriggerSource: airlockTriggerSource,
+	}
+	snap.RecentEvents = make([]SessionEvent, len(sess.recentEvents))
+	copy(snap.RecentEvents, sess.recentEvents)
+	sess.mu.Unlock()
+
+	return snap, true
+}
+
+// AirlockConfig returns the current airlock config pointer, or nil when
+// airlock is not configured. Used by admin API handlers that need timer
+// values and trigger mappings to explain session state.
+func (sm *SessionManager) AirlockConfig() *config.Airlock {
+	return sm.airlockCfgPtr.Load()
+}
+
 // ForceSetAirlockTier atomically looks up a session by key and sets the
 // airlock tier under sm.mu.RLock. This eliminates the TOCTOU race where a
 // session could be evicted between a separate lookup and ForceSetTier call.
@@ -1029,7 +1187,15 @@ func (sm *SessionManager) ForceSetAirlockTier(key, tier string) (found, changed 
 	// Hold RLock across the tier change so cleanup/eviction can't remove
 	// the session between lookup and mutation. ForceSetTier acquires its
 	// own mutex internally (lock ordering: sm.mu > airlock.mu).
-	changed, from, to = sess.Airlock().ForceSetTier(tier)
+	changed, from, to = sess.Airlock().ForceSetTierWithProvenance(tier, airlockTriggerManual, airlockSourceAdminAPI)
+	if changed {
+		sess.RecordEvent(SessionEvent{
+			Kind:     "airlock_override",
+			Target:   to,
+			Detail:   from + "->" + to,
+			Severity: "warn",
+		})
+	}
 	sm.mu.RUnlock()
 	return true, changed, from, to
 }
@@ -1185,6 +1351,12 @@ func (sm *SessionManager) sweepDeescalation() {
 		if airlockCfg := sm.airlockCfgPtr.Load(); airlockCfg != nil && airlockCfg.Enabled {
 			airlockChanged, airlockFrom, airlockTo := sess.airlock.TryDeescalate(&airlockCfg.Timers)
 			if airlockChanged {
+				sess.RecordEvent(SessionEvent{
+					Kind:     "airlock_deescalate",
+					Target:   airlockTo,
+					Detail:   airlockFrom + "->" + airlockTo,
+					Severity: "info",
+				})
 				if sm.metrics != nil {
 					sm.metrics.RecordAirlockTransition(airlockFrom, airlockTo, "timer")
 				}

--- a/internal/proxy/session_api.go
+++ b/internal/proxy/session_api.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	"github.com/luckyPipewrench/pipelock/internal/session"
@@ -75,10 +76,23 @@ const (
 // Admin API action names used as rate-limiter keys. Extracted so
 // there is exactly one source of truth per endpoint label.
 const (
-	sessionAPIActionReset = "reset"
-	sessionAPIActionTask  = "task"
-	sessionAPIActionTrust = "trust"
+	sessionAPIActionReset     = "reset"
+	sessionAPIActionTask      = "task"
+	sessionAPIActionTrust     = "trust"
+	sessionAPIActionInspect   = "inspect"
+	sessionAPIActionExplain   = "explain"
+	sessionAPIActionTerminate = "terminate"
 )
+
+// tierNotQuarantinedReason is the explanation returned for sessions that
+// are not currently in any airlock tier. Operators may call explain on a
+// normal session too; returning 200 with this reason avoids confusing 404.
+const tierNotQuarantinedReason = "session not quarantined"
+
+// airlockTierAliasNormal is the human-friendly alias accepted alongside
+// "none" on admin API inputs. Kept here so every endpoint validates tiers
+// with the same vocabulary as HandleAirlock.
+const airlockTierAliasNormal = "normal"
 
 // rateLimiterState tracks a sliding-window request count for a
 // single admin action. One instance per action so high-volume abuse
@@ -99,32 +113,43 @@ type SessionAPIHandler struct {
 	apiToken string
 
 	// limitMu guards all rate-limiter state. One limiter per admin
-	// action (reset/task/trust) so /task abuse cannot suppress
-	// /reset during incident response, and vice versa.
+	// action (reset/task/trust/inspect/explain/terminate) so /task abuse
+	// cannot suppress /reset during incident response, and vice versa.
 	limitMu  sync.Mutex
 	limiters map[string]*rateLimiterState
 }
 
-// NewSessionAPIHandler creates a session API handler.
-func NewSessionAPIHandler(
-	smPtr *atomic.Pointer[SessionManager],
-	etPtr *atomic.Pointer[scanner.EntropyTracker],
-	fbPtr *atomic.Pointer[scanner.FragmentBuffer],
-	m *metrics.Metrics,
-	logger *audit.Logger,
-	apiToken string,
-) *SessionAPIHandler {
+// SessionAPIOptions configures a SessionAPIHandler. Using an options struct
+// keeps the constructor signature stable as new endpoints land and new
+// collaborators wire in — CLAUDE.md caps positional parameters at six.
+// The APIToken field holds the bearer token used to authenticate admin
+// API requests; it is never serialized because this struct is never
+// marshaled — it exists only to carry constructor inputs.
+type SessionAPIOptions struct {
+	SessionMgrPtr *atomic.Pointer[SessionManager]
+	EntropyPtr    *atomic.Pointer[scanner.EntropyTracker]
+	FragmentPtr   *atomic.Pointer[scanner.FragmentBuffer]
+	Metrics       *metrics.Metrics
+	Logger        *audit.Logger
+	APIToken      string `json:"-"` //nolint:gosec // options input, never serialized
+}
+
+// NewSessionAPIHandler creates a session API handler from the given options.
+func NewSessionAPIHandler(opts SessionAPIOptions) *SessionAPIHandler {
 	return &SessionAPIHandler{
-		smPtr:    smPtr,
-		etPtr:    etPtr,
-		fbPtr:    fbPtr,
-		metrics:  m,
-		logger:   logger,
-		apiToken: apiToken,
+		smPtr:    opts.SessionMgrPtr,
+		etPtr:    opts.EntropyPtr,
+		fbPtr:    opts.FragmentPtr,
+		metrics:  opts.Metrics,
+		logger:   opts.Logger,
+		apiToken: opts.APIToken,
 		limiters: map[string]*rateLimiterState{
-			sessionAPIActionReset: {windowStart: time.Now()},
-			sessionAPIActionTask:  {windowStart: time.Now()},
-			sessionAPIActionTrust: {windowStart: time.Now()},
+			sessionAPIActionReset:     {windowStart: time.Now()},
+			sessionAPIActionTask:      {windowStart: time.Now()},
+			sessionAPIActionTrust:     {windowStart: time.Now()},
+			sessionAPIActionInspect:   {windowStart: time.Now()},
+			sessionAPIActionExplain:   {windowStart: time.Now()},
+			sessionAPIActionTerminate: {windowStart: time.Now()},
 		},
 	}
 }
@@ -160,6 +185,11 @@ func (h *SessionAPIHandler) loadManager(w http.ResponseWriter) *SessionManager {
 }
 
 // HandleList handles GET /api/v1/sessions.
+//
+// Supports an optional ?tier=none|soft|hard|drain|normal query parameter to
+// filter returned sessions by airlock tier. "normal" is accepted as an
+// alias for "none" (mirrors HandleAirlock) so operators and scripts share
+// the same tier vocabulary end to end.
 func (h *SessionAPIHandler) HandleList(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", http.MethodGet)
@@ -174,9 +204,26 @@ func (h *SessionAPIHandler) HandleList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	snaps := sm.Snapshot()
-
 	clientIP, _ := requestMeta(r)
+
+	filter, filterErr := parseTierFilter(r.URL.Query().Get("tier"))
+	if filterErr != nil {
+		h.logSessionAdmin("list_bad_tier", clientIP, "", filterErr.Error(), http.StatusBadRequest)
+		http.Error(w, filterErr.Error(), http.StatusBadRequest)
+		return
+	}
+
+	snaps := sm.Snapshot()
+	if filter != "" {
+		kept := make([]SessionSnapshot, 0, len(snaps))
+		for _, s := range snaps {
+			if tierMatches(s.AirlockTier, filter) {
+				kept = append(kept, s)
+			}
+		}
+		snaps = kept
+	}
+
 	h.logSessionAdmin("list", clientIP, "", "ok", http.StatusOK)
 
 	w.Header().Set("Content-Type", "application/json")
@@ -187,6 +234,38 @@ func (h *SessionAPIHandler) HandleList(w http.ResponseWriter, r *http.Request) {
 		Sessions: snaps,
 		Count:    len(snaps),
 	})
+}
+
+// parseTierFilter validates the optional ?tier= query parameter and
+// normalizes it to a canonical tier string. Empty input means no filter.
+// "normal" is accepted as an alias for "none" so admin API consumers can
+// use the same human-friendly vocabulary as HandleAirlock.
+func parseTierFilter(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	tier := raw
+	if tier == airlockTierAliasNormal {
+		tier = config.AirlockTierNone
+	}
+	switch tier {
+	case config.AirlockTierNone,
+		config.AirlockTierSoft,
+		config.AirlockTierHard,
+		config.AirlockTierDrain:
+		return tier, nil
+	}
+	return "", errors.New("invalid tier filter: must be none|soft|hard|drain|normal")
+}
+
+// tierMatches compares a session's current airlock tier against a filter
+// tier, treating the empty snapshot tier as equivalent to "none" (the zero
+// value left by sessions that never escalated).
+func tierMatches(snapshotTier, filter string) bool {
+	if snapshotTier == "" {
+		snapshotTier = config.AirlockTierNone
+	}
+	return snapshotTier == filter
 }
 
 // checkRateLimit enforces a sliding-window rate limit on a single
@@ -315,6 +394,23 @@ func (h *SessionAPIHandler) HandleReset(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// extractSessionKeyOnly extracts the session key from /api/v1/sessions/{key}
+// with no trailing action segment. Used by HandleInspect, which exposes the
+// full detail snapshot under the base session path. Mirrors the segment
+// validation pattern in extractSessionKey and extractSessionKeyWithAction.
+func extractSessionKeyOnly(r *http.Request) (string, bool) {
+	segs := strings.Split(strings.Trim(r.URL.EscapedPath(), "/"), "/")
+	// Expect exactly: api/v1/sessions/{encoded-key}
+	if len(segs) != 4 || segs[0] != apiPathSegment || segs[1] != apiVersionSegment || segs[2] != apiSessionsSegment {
+		return "", false
+	}
+	key, err := url.PathUnescape(segs[3])
+	if err != nil || key == "" || strings.ContainsAny(key, "/\x00") {
+		return "", false
+	}
+	return key, true
+}
+
 // extractSessionKeyWithAction extracts the session key and trailing action from
 // /api/v1/sessions/{key}/{action}. Reusable for both /reset and /airlock paths.
 func extractSessionKeyWithAction(r *http.Request, action string) (string, bool) {
@@ -341,6 +437,55 @@ type airlockResponse struct {
 	PreviousTier string `json:"previous_tier"`
 	NewTier      string `json:"new_tier"`
 	Changed      bool   `json:"changed"`
+}
+
+// SessionDetail is the response shape for GET /api/v1/sessions/{key}.
+// Embeds SessionSnapshot (flattened in JSON output) and adds the extra
+// fields operators need for airlock recovery: tier timing, request
+// in-flight gauge, numeric escalation level, and the recent event buffer.
+type SessionDetail struct {
+	SessionSnapshot
+	AirlockEnteredAt   time.Time      `json:"airlock_entered_at"`
+	InFlight           int64          `json:"in_flight"`
+	EscalationLevelInt int            `json:"escalation_level_int"`
+	RecentEvents       []SessionEvent `json:"recent_events"`
+}
+
+// SessionExplanation is the response shape for GET
+// /api/v1/sessions/{key}/explain. The answer to "why is this session in
+// the state it is in" — which trigger fired, what the score was, what
+// evidence (event excerpt) crossed the threshold, and when the next
+// automatic de-escalation will fire.
+type SessionExplanation struct {
+	Key                  string        `json:"key"`
+	Tier                 string        `json:"tier"`
+	Reason               string        `json:"reason"`
+	Trigger              string        `json:"trigger,omitempty"`
+	TriggerSource        string        `json:"trigger_source,omitempty"`
+	EnteredAt            time.Time     `json:"entered_at,omitempty"`
+	ElapsedInTier        time.Duration `json:"elapsed_in_tier_ns,omitempty"`
+	EscalationLevel      string        `json:"escalation_level"`
+	EscalationLevelInt   int           `json:"escalation_level_int"`
+	ThreatScore          float64       `json:"threat_score"`
+	EvidenceKind         string        `json:"evidence_kind,omitempty"`
+	EvidenceTarget       string        `json:"evidence_target,omitempty"`
+	EvidenceDetail       string        `json:"evidence_detail,omitempty"`
+	EvidenceAt           time.Time     `json:"evidence_at,omitempty"`
+	NextDeescalationTier string        `json:"next_deescalation_tier,omitempty"`
+	NextDeescalationAt   time.Time     `json:"next_deescalation_at,omitempty"`
+}
+
+// SessionTerminateResult is the response shape for POST
+// /api/v1/sessions/{key}/terminate. Captures the "before" snapshot so the
+// operator can audit what was in flight at the moment of termination.
+type SessionTerminateResult struct {
+	Key             string  `json:"key"`
+	Terminated      bool    `json:"terminated"`
+	PreviousTier    string  `json:"previous_tier"`
+	PreviousLevel   string  `json:"previous_level"`
+	PreviousScore   float64 `json:"previous_score"`
+	IPStateCleared  bool    `json:"ip_state_cleared"`
+	CEEStateCleared bool    `json:"cee_state_cleared"`
 }
 
 type taskRequest struct {
@@ -621,6 +766,369 @@ func (h *SessionAPIHandler) HandleTrust(w http.ResponseWriter, r *http.Request) 
 		GrantedBy:   applied.GrantedBy,
 		Reason:      applied.Reason,
 	})
+}
+
+// HandleInspect handles GET /api/v1/sessions/{key}. Returns a SessionDetail
+// with the session snapshot, airlock timing, in-flight count, and recent-
+// event ring buffer so operators can reason about quarantined sessions
+// without exec-ing into the pipelock container.
+func (h *SessionAPIHandler) HandleInspect(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !h.authenticate(w, r) {
+		return
+	}
+
+	clientIP, _ := requestMeta(r)
+
+	if !h.checkRateLimit(sessionAPIActionInspect) {
+		h.logSessionAdmin("inspect_rate_limited", clientIP, "", "rate limit exceeded", http.StatusTooManyRequests)
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+
+	sm := h.loadManager(w)
+	if sm == nil {
+		return
+	}
+
+	key, ok := extractSessionKeyOnly(r)
+	if !ok {
+		h.logSessionAdmin("inspect_bad_key", clientIP, "", "invalid path", http.StatusBadRequest)
+		http.Error(w, "missing or invalid session key in URL path", http.StatusBadRequest)
+		return
+	}
+
+	adminSnap, found := sm.AdminSnapshotByKey(key)
+	if !found {
+		h.logSessionAdmin("inspect_not_found", clientIP, key, "session not found", http.StatusNotFound)
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+
+	detail := SessionDetail{
+		SessionSnapshot:    adminSnap.SessionSnapshot,
+		AirlockEnteredAt:   adminSnap.AirlockEnteredAt,
+		InFlight:           adminSnap.InFlight,
+		EscalationLevelInt: adminSnap.EscalationLevelInt,
+		RecentEvents:       adminSnap.RecentEvents,
+	}
+	if detail.RecentEvents == nil {
+		detail.RecentEvents = []SessionEvent{}
+	}
+
+	h.logSessionAdmin("inspect_ok", clientIP, key, adminSnap.AirlockTier, http.StatusOK)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(detail)
+}
+
+// HandleExplain handles GET /api/v1/sessions/{key}/explain. Answers the
+// operator question "why is this session in its current state" with the
+// trigger that fired, the evidence that crossed the threshold, and an
+// estimate of when the next automatic de-escalation will drop the tier.
+//
+// Sessions at the none tier are NOT 404 — explain returns 200 with a
+// "session not quarantined" reason so operators can sanity-check normal
+// sessions without special-casing the happy path in their tooling.
+func (h *SessionAPIHandler) HandleExplain(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !h.authenticate(w, r) {
+		return
+	}
+
+	clientIP, _ := requestMeta(r)
+
+	if !h.checkRateLimit(sessionAPIActionExplain) {
+		h.logSessionAdmin("explain_rate_limited", clientIP, "", "rate limit exceeded", http.StatusTooManyRequests)
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+
+	sm := h.loadManager(w)
+	if sm == nil {
+		return
+	}
+
+	key, ok := extractSessionKeyWithAction(r, "explain")
+	if !ok {
+		h.logSessionAdmin("explain_bad_key", clientIP, "", "invalid path", http.StatusBadRequest)
+		http.Error(w, "missing or invalid session key in URL path", http.StatusBadRequest)
+		return
+	}
+
+	adminSnap, found := sm.AdminSnapshotByKey(key)
+	if !found {
+		h.logSessionAdmin("explain_not_found", clientIP, key, "session not found", http.StatusNotFound)
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+
+	exp := buildExplanation(adminSnap, h.airlockCfgFromManager(sm))
+
+	h.logSessionAdmin("explain_ok", clientIP, key, exp.Tier, http.StatusOK)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(exp)
+}
+
+// HandleTerminate handles POST /api/v1/sessions/{key}/terminate. Performs
+// a superset of reset: clears in-flight cancel functions, zeros all
+// enforcement state via ResetSessionIfResettable, and clears CEE entropy
+// and fragment-buffer state. Returns the previous tier/level/score so the
+// operator trail captures what was torn down.
+//
+// Invocation sessions (ephemeral MCP transport contexts) are rejected
+// with the same 400 error shape as HandleReset — terminate is a
+// destructive admin action scoped to identity sessions only.
+func (h *SessionAPIHandler) HandleTerminate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !h.authenticate(w, r) {
+		return
+	}
+
+	clientIP, _ := requestMeta(r)
+
+	if !h.checkRateLimit(sessionAPIActionTerminate) {
+		h.logSessionAdmin("terminate_rate_limited", clientIP, "", "rate limit exceeded", http.StatusTooManyRequests)
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+
+	sm := h.loadManager(w)
+	if sm == nil {
+		return
+	}
+
+	key, ok := extractSessionKeyWithAction(r, "terminate")
+	if !ok {
+		h.logSessionAdmin("terminate_bad_key", clientIP, "", "invalid path", http.StatusBadRequest)
+		http.Error(w, "missing or invalid session key in URL path", http.StatusBadRequest)
+		return
+	}
+
+	// Decode empty body. decodeJSONBody tolerates missing/empty bodies and
+	// enforces the shared size limit and DisallowUnknownFields contract,
+	// so callers sending stray fields get a 400 here instead of a silent
+	// accept that leaks the extra data into logs.
+	var empty struct{}
+	if err := decodeJSONBody(r, &empty); err != nil {
+		h.logSessionAdmin("terminate_bad_body", clientIP, key, err.Error(), http.StatusBadRequest)
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	// Capture the pre-terminate tier via SnapshotByKey so the response
+	// reflects what was in place at the moment of the request, not the
+	// zero-state returned by ResetSessionIfResettable.
+	preSnap, _, preFound := sm.SnapshotByKey(key)
+	if !preFound {
+		h.logSessionAdmin("terminate_not_found", clientIP, key, "session not found", http.StatusNotFound)
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+
+	prev, found, resetErr := sm.ResetSessionIfResettable(key)
+	if !found {
+		// Raced an evict between snapshot and reset — return 404 so the
+		// operator sees the same outcome as inspect would have shown.
+		h.logSessionAdmin("terminate_not_found", clientIP, key, "session not found", http.StatusNotFound)
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	if resetErr != nil {
+		h.logSessionAdmin("terminate_rejected", clientIP, key, "invocation key", http.StatusBadRequest)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(struct {
+			Error string `json:"error"`
+		}{Error: "cannot terminate invocation session; only identity sessions are resettable"})
+		return
+	}
+
+	_, agent, ip := classifySessionKey(key)
+
+	ceeCleared := false
+	if h.etPtr != nil && h.fbPtr != nil {
+		et := h.etPtr.Load()
+		fb := h.fbPtr.Load()
+		if et != nil || fb != nil {
+			ResetCEEState(agent, ip, et, fb)
+			ceeCleared = true
+		}
+	}
+
+	h.logSessionAdmin("terminate_ok", clientIP, key, preSnap.AirlockTier, http.StatusOK)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(SessionTerminateResult{
+		Key:             key,
+		Terminated:      true,
+		PreviousTier:    preSnap.AirlockTier,
+		PreviousLevel:   prev.EscalationLevel,
+		PreviousScore:   prev.ThreatScore,
+		IPStateCleared:  ip != "",
+		CEEStateCleared: ceeCleared,
+	})
+}
+
+// airlockCfgFromManager fetches the active airlock config from the manager
+// if one is configured, returning a pointer safe for read-only use.
+// Returns nil when airlock is not configured — the explain builder handles
+// that case by omitting the next-deescalation estimate.
+func (h *SessionAPIHandler) airlockCfgFromManager(sm *SessionManager) *config.Airlock {
+	if sm == nil {
+		return nil
+	}
+	return sm.AirlockConfig()
+}
+
+// buildExplanation constructs a SessionExplanation from a snapshot, recent
+// events, and live session state. Trigger/source come from the airlock
+// entry metadata; the next-deescalation estimate is derived from the
+// airlock timer config when available.
+func buildExplanation(snap sessionAdminSnapshot, airlockCfg *config.Airlock) SessionExplanation {
+	tier := snap.AirlockTier
+	if tier == "" {
+		tier = config.AirlockTierNone
+	}
+
+	exp := SessionExplanation{
+		Key:                snap.Key,
+		Tier:               tier,
+		EscalationLevel:    snap.EscalationLevel,
+		EscalationLevelInt: snap.EscalationLevelInt,
+		ThreatScore:        snap.ThreatScore,
+		Trigger:            snap.AirlockTrigger,
+		TriggerSource:      snap.AirlockTriggerSource,
+	}
+
+	if tier == config.AirlockTierNone {
+		exp.Reason = tierNotQuarantinedReason
+		// Still attach the most recent notable event as evidence so the
+		// operator can see what the session has been doing even when the
+		// tier is normal. Keeps explain useful outside of incident mode.
+		attachMostRecentEvidence(&exp, snap.RecentEvents)
+		return exp
+	}
+
+	exp.Reason = "session quarantined at airlock tier " + tier
+	if exp.Trigger == "" {
+		exp.Trigger = airlockTriggerManual
+	}
+	if exp.TriggerSource == "" {
+		exp.TriggerSource = airlockSourceAdminAPI
+	}
+
+	exp.EnteredAt = snap.AirlockEnteredAt
+	if !exp.EnteredAt.IsZero() {
+		exp.ElapsedInTier = time.Since(exp.EnteredAt)
+	}
+
+	attachMostRecentEvidence(&exp, snap.RecentEvents)
+
+	if airlockCfg != nil {
+		exp.NextDeescalationTier = nextDeescalationTier(tier)
+		if !exp.EnteredAt.IsZero() && exp.NextDeescalationTier != "" {
+			if dur := deescalationDuration(tier, &airlockCfg.Timers); dur > 0 {
+				exp.NextDeescalationAt = exp.EnteredAt.Add(dur)
+			}
+		}
+	}
+
+	return exp
+}
+
+// attachMostRecentEvidence copies the most recent non-transition event into
+// the explanation as evidence. Falls back to transition events only when
+// there is nothing more specific in the ring buffer.
+func attachMostRecentEvidence(exp *SessionExplanation, events []SessionEvent) {
+	if attachEvidence(exp, events, false) {
+		return
+	}
+	_ = attachEvidence(exp, events, true)
+}
+
+func attachEvidence(exp *SessionExplanation, events []SessionEvent, includeTransitions bool) bool {
+	for i := len(events) - 1; i >= 0; i-- {
+		e := events[i]
+		if e.Kind == "" && e.Detail == "" {
+			continue
+		}
+		if !includeTransitions && strings.HasPrefix(e.Kind, "airlock_") {
+			continue
+		}
+		exp.EvidenceKind = e.Kind
+		exp.EvidenceTarget = e.Target
+		exp.EvidenceDetail = e.Detail
+		exp.EvidenceAt = e.At
+		return true
+	}
+	return false
+}
+
+// nextDeescalationTier returns the tier that an automatic de-escalation
+// would transition into from the given current tier. Mirrors the state
+// machine in AirlockState.TryDeescalate.
+func nextDeescalationTier(current string) string {
+	switch current {
+	case config.AirlockTierSoft:
+		return config.AirlockTierNone
+	case config.AirlockTierHard:
+		return config.AirlockTierSoft
+	case config.AirlockTierDrain:
+		return config.AirlockTierHard
+	}
+	return ""
+}
+
+// deescalationDuration returns the configured timer duration for the
+// given tier, or zero when the timer is disabled (0 = manual recovery).
+// Drain honors the shorter of DrainMinutes and DrainTimeoutSeconds as a
+// hard ceiling for in-flight completion.
+func deescalationDuration(tier string, timers *config.AirlockTimers) time.Duration {
+	if timers == nil {
+		return 0
+	}
+	switch tier {
+	case config.AirlockTierSoft:
+		if timers.SoftMinutes <= 0 {
+			return 0
+		}
+		return time.Duration(timers.SoftMinutes) * time.Minute
+	case config.AirlockTierHard:
+		if timers.HardMinutes <= 0 {
+			return 0
+		}
+		return time.Duration(timers.HardMinutes) * time.Minute
+	case config.AirlockTierDrain:
+		if timers.DrainMinutes <= 0 && timers.DrainTimeoutSeconds <= 0 {
+			return 0
+		}
+		d := time.Duration(timers.DrainMinutes) * time.Minute
+		if timers.DrainTimeoutSeconds > 0 {
+			drainTimeout := time.Duration(timers.DrainTimeoutSeconds) * time.Second
+			if d <= 0 || drainTimeout < d {
+				d = drainTimeout
+			}
+		}
+		return d
+	}
+	return 0
 }
 
 // logSessionAdmin logs a session admin API operation if a logger is available.

--- a/internal/proxy/session_api.go
+++ b/internal/proxy/session_api.go
@@ -1056,8 +1056,6 @@ func buildExplanation(snap sessionAdminSnapshot, airlockCfg *config.Airlock) Ses
 		EscalationLevel:    snap.EscalationLevel,
 		EscalationLevelInt: snap.EscalationLevelInt,
 		ThreatScore:        snap.ThreatScore,
-		Trigger:            snap.AirlockTrigger,
-		TriggerSource:      snap.AirlockTriggerSource,
 	}
 
 	if tier == config.AirlockTierNone {
@@ -1065,10 +1063,15 @@ func buildExplanation(snap sessionAdminSnapshot, airlockCfg *config.Airlock) Ses
 		// Still attach the most recent notable event as evidence so the
 		// operator can see what the session has been doing even when the
 		// tier is normal. Keeps explain useful outside of incident mode.
+		// Trigger/TriggerSource are left empty: a normal-tier session has
+		// no active quarantine cause, and reporting stale trigger metadata
+		// would contradict the "not quarantined" reason string.
 		attachMostRecentEvidence(&exp, snap.RecentEvents)
 		return exp
 	}
 
+	exp.Trigger = snap.AirlockTrigger
+	exp.TriggerSource = snap.AirlockTriggerSource
 	exp.Reason = "session quarantined at airlock tier " + tier
 	if exp.Trigger == "" {
 		exp.Trigger = airlockTriggerManual

--- a/internal/proxy/session_api.go
+++ b/internal/proxy/session_api.go
@@ -932,20 +932,14 @@ func (h *SessionAPIHandler) HandleTerminate(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Capture the pre-terminate tier via SnapshotByKey so the response
-	// reflects what was in place at the moment of the request, not the
-	// zero-state returned by ResetSessionIfResettable.
-	preSnap, _, preFound := sm.SnapshotByKey(key)
-	if !preFound {
-		h.logSessionAdmin("terminate_not_found", clientIP, key, "session not found", http.StatusNotFound)
-		http.Error(w, "session not found", http.StatusNotFound)
-		return
-	}
-
-	prev, found, resetErr := sm.ResetSessionIfResettable(key)
+	// Capture pre-terminate state and reset atomically under a single
+	// sm.mu.Lock so the response's previous_tier/previous_level/
+	// previous_score describe one consistent moment in time. Splitting
+	// the snapshot and the reset across two critical sections let a
+	// concurrent tier change slip an inconsistent row into the audit
+	// trail; SnapshotAndResetIfResettable closes that gap.
+	preSnap, found, resetErr := sm.SnapshotAndResetIfResettable(key)
 	if !found {
-		// Raced an evict between snapshot and reset — return 404 so the
-		// operator sees the same outcome as inspect would have shown.
 		h.logSessionAdmin("terminate_not_found", clientIP, key, "session not found", http.StatusNotFound)
 		http.Error(w, "session not found", http.StatusNotFound)
 		return
@@ -979,8 +973,8 @@ func (h *SessionAPIHandler) HandleTerminate(w http.ResponseWriter, r *http.Reque
 		Key:             key,
 		Terminated:      true,
 		PreviousTier:    preSnap.AirlockTier,
-		PreviousLevel:   prev.EscalationLevel,
-		PreviousScore:   prev.ThreatScore,
+		PreviousLevel:   preSnap.EscalationLevel,
+		PreviousScore:   preSnap.ThreatScore,
 		IPStateCleared:  ip != "",
 		CEEStateCleared: ceeCleared,
 	})
@@ -1039,12 +1033,21 @@ func buildExplanation(snap sessionAdminSnapshot, airlockCfg *config.Airlock) Ses
 		exp.ElapsedInTier = time.Since(exp.EnteredAt)
 	}
 
-	attachMostRecentEvidence(&exp, snap.RecentEvents)
+	// Prefer evidence recorded at or before the tier-entry moment so a
+	// noisy quarantined session that keeps generating post-entry blocks
+	// doesn't overwrite the event that actually drove the escalation.
+	// Falls back to the newest event in the buffer if the original
+	// trigger has rotated out.
+	attachTierEntryEvidence(&exp, snap.RecentEvents, snap.AirlockEnteredAt)
 
+	// Only advertise auto-deescalation when the timer for the current
+	// tier is actually positive. A disabled timer (0) means manual
+	// recovery only — surfacing a next_deescalation_tier without an
+	// at= would tell operators a timer exists when it doesn't.
 	if airlockCfg != nil {
-		exp.NextDeescalationTier = nextDeescalationTier(tier)
-		if !exp.EnteredAt.IsZero() && exp.NextDeescalationTier != "" {
-			if dur := deescalationDuration(tier, &airlockCfg.Timers); dur > 0 {
+		if dur := deescalationDuration(tier, &airlockCfg.Timers); dur > 0 {
+			exp.NextDeescalationTier = nextDeescalationTier(tier)
+			if !exp.EnteredAt.IsZero() && exp.NextDeescalationTier != "" {
 				exp.NextDeescalationAt = exp.EnteredAt.Add(dur)
 			}
 		}
@@ -1053,23 +1056,51 @@ func buildExplanation(snap sessionAdminSnapshot, airlockCfg *config.Airlock) Ses
 	return exp
 }
 
-// attachMostRecentEvidence copies the most recent non-transition event into
-// the explanation as evidence. Falls back to transition events only when
-// there is nothing more specific in the ring buffer.
+// attachMostRecentEvidence copies the most recent non-transition event
+// into the explanation as evidence. Falls back to transition events only
+// when there is nothing more specific in the ring buffer. Used by the
+// none-tier explain path where there is no tier-entry timestamp to
+// prefer events against.
 func attachMostRecentEvidence(exp *SessionExplanation, events []SessionEvent) {
-	if attachEvidence(exp, events, false) {
+	if attachEvidence(exp, events, time.Time{}, false) {
 		return
 	}
-	_ = attachEvidence(exp, events, true)
+	_ = attachEvidence(exp, events, time.Time{}, true)
 }
 
-func attachEvidence(exp *SessionExplanation, events []SessionEvent, includeTransitions bool) bool {
+// attachTierEntryEvidence prefers the newest event recorded at or
+// before the tier-entry timestamp so quarantined sessions report the
+// evidence that actually drove the escalation, not whatever noise has
+// accumulated since. Falls back to (a) post-entry non-transition
+// events, then (b) any non-empty event, if the original tier-entry
+// evidence has already rotated out of the 20-slot ring buffer.
+func attachTierEntryEvidence(exp *SessionExplanation, events []SessionEvent, enteredAt time.Time) {
+	if !enteredAt.IsZero() {
+		if attachEvidence(exp, events, enteredAt, false) {
+			return
+		}
+	}
+	if attachEvidence(exp, events, time.Time{}, false) {
+		return
+	}
+	_ = attachEvidence(exp, events, time.Time{}, true)
+}
+
+// attachEvidence walks the event ring buffer newest-to-oldest and
+// stores the first matching event on exp. When cutoff is non-zero the
+// selector skips events strictly after the cutoff so the tier-entry
+// window can be preferred. When includeTransitions is false, airlock_*
+// transition events are skipped as well.
+func attachEvidence(exp *SessionExplanation, events []SessionEvent, cutoff time.Time, includeTransitions bool) bool {
 	for i := len(events) - 1; i >= 0; i-- {
 		e := events[i]
 		if e.Kind == "" && e.Detail == "" {
 			continue
 		}
 		if !includeTransitions && strings.HasPrefix(e.Kind, "airlock_") {
+			continue
+		}
+		if !cutoff.IsZero() && e.At.After(cutoff) {
 			continue
 		}
 		exp.EvidenceKind = e.Kind

--- a/internal/proxy/session_api.go
+++ b/internal/proxy/session_api.go
@@ -79,6 +79,7 @@ const (
 	sessionAPIActionReset     = "reset"
 	sessionAPIActionTask      = "task"
 	sessionAPIActionTrust     = "trust"
+	sessionAPIActionAirlock   = "airlock"
 	sessionAPIActionInspect   = "inspect"
 	sessionAPIActionExplain   = "explain"
 	sessionAPIActionTerminate = "terminate"
@@ -104,17 +105,26 @@ type rateLimiterState struct {
 }
 
 // SessionAPIHandler handles the admin session management API.
+//
+// apiTokenPtr is an atomic.Pointer[string] so SetAPIToken can rotate the
+// admin bearer credential on config reload without racing the
+// authenticate() fast path. Storing the token inline would force a
+// mutex around every request or leave stale credentials live after a
+// SIGHUP. A nil or empty-string payload disables the endpoint entirely
+// (authenticate returns 503), matching the "service not configured"
+// bootstrap path.
 type SessionAPIHandler struct {
-	smPtr    *atomic.Pointer[SessionManager]
-	etPtr    *atomic.Pointer[scanner.EntropyTracker]
-	fbPtr    *atomic.Pointer[scanner.FragmentBuffer]
-	metrics  *metrics.Metrics
-	logger   *audit.Logger
-	apiToken string
+	smPtr       *atomic.Pointer[SessionManager]
+	etPtr       *atomic.Pointer[scanner.EntropyTracker]
+	fbPtr       *atomic.Pointer[scanner.FragmentBuffer]
+	metrics     *metrics.Metrics
+	logger      *audit.Logger
+	apiTokenPtr atomic.Pointer[string]
 
 	// limitMu guards all rate-limiter state. One limiter per admin
-	// action (reset/task/trust/inspect/explain/terminate) so /task abuse
-	// cannot suppress /reset during incident response, and vice versa.
+	// action (reset/task/trust/airlock/inspect/explain/terminate) so
+	// /task abuse cannot suppress /reset during incident response, and
+	// vice versa.
 	limitMu  sync.Mutex
 	limiters map[string]*rateLimiterState
 }
@@ -136,26 +146,58 @@ type SessionAPIOptions struct {
 
 // NewSessionAPIHandler creates a session API handler from the given options.
 func NewSessionAPIHandler(opts SessionAPIOptions) *SessionAPIHandler {
-	return &SessionAPIHandler{
-		smPtr:    opts.SessionMgrPtr,
-		etPtr:    opts.EntropyPtr,
-		fbPtr:    opts.FragmentPtr,
-		metrics:  opts.Metrics,
-		logger:   opts.Logger,
-		apiToken: opts.APIToken,
+	h := &SessionAPIHandler{
+		smPtr:   opts.SessionMgrPtr,
+		etPtr:   opts.EntropyPtr,
+		fbPtr:   opts.FragmentPtr,
+		metrics: opts.Metrics,
+		logger:  opts.Logger,
 		limiters: map[string]*rateLimiterState{
 			sessionAPIActionReset:     {windowStart: time.Now()},
 			sessionAPIActionTask:      {windowStart: time.Now()},
 			sessionAPIActionTrust:     {windowStart: time.Now()},
+			sessionAPIActionAirlock:   {windowStart: time.Now()},
 			sessionAPIActionInspect:   {windowStart: time.Now()},
 			sessionAPIActionExplain:   {windowStart: time.Now()},
 			sessionAPIActionTerminate: {windowStart: time.Now()},
 		},
 	}
+	// Seed the atomic token pointer from the constructor input. Stored via
+	// SetAPIToken so the nil-vs-empty logic stays in one place.
+	h.SetAPIToken(opts.APIToken)
+	return h
+}
+
+// SetAPIToken rotates the admin bearer credential used by authenticate.
+// Called from proxy.Reload so operators can rotate kill_switch.api_token
+// (or the PIPELOCK_KILLSWITCH_API_TOKEN env var) without restarting the
+// proxy. An empty string disables the endpoint (authenticate returns
+// 503), matching the "service not configured" bootstrap path.
+func (h *SessionAPIHandler) SetAPIToken(token string) {
+	if token == "" {
+		h.apiTokenPtr.Store(nil)
+		return
+	}
+	t := token
+	h.apiTokenPtr.Store(&t)
+}
+
+// currentAPIToken returns the active admin API bearer token, or empty
+// string when the endpoint is not configured.
+func (h *SessionAPIHandler) currentAPIToken() string {
+	if p := h.apiTokenPtr.Load(); p != nil {
+		return *p
+	}
+	return ""
 }
 
 func (h *SessionAPIHandler) authenticate(w http.ResponseWriter, r *http.Request) bool {
-	if h.apiToken == "" {
+	// Load the active token once per request. The atomic snapshot keeps
+	// the comparison safe against a concurrent SetAPIToken rotation and
+	// also pins the value across the constant-time compare below so a
+	// mid-call swap cannot flip us into a stale-credential accept.
+	activeToken := h.currentAPIToken()
+	if activeToken == "" {
 		http.Error(w, "session API not configured (no api_token)", http.StatusServiceUnavailable)
 		return false
 	}
@@ -165,7 +207,7 @@ func (h *SessionAPIHandler) authenticate(w http.ResponseWriter, r *http.Request)
 	if len(auth) > len(prefix) && auth[:len(prefix)] == prefix {
 		token = auth[len(prefix):]
 	}
-	if token == "" || subtle.ConstantTimeCompare([]byte(token), []byte(h.apiToken)) != 1 {
+	if token == "" || subtle.ConstantTimeCompare([]byte(token), []byte(activeToken)) != 1 {
 		clientIP, _ := requestMeta(r)
 		h.logSessionAdmin("auth_failure", clientIP, "", "", http.StatusUnauthorized)
 		w.Header().Set("WWW-Authenticate", `Bearer realm="pipelock"`)
@@ -516,6 +558,13 @@ func (h *SessionAPIHandler) HandleAirlock(w http.ResponseWriter, r *http.Request
 	}
 
 	clientIP, _ := requestMeta(r)
+
+	if !h.checkRateLimit(sessionAPIActionAirlock) {
+		h.logSessionAdmin("airlock_rate_limited", clientIP, "", "rate limit exceeded", http.StatusTooManyRequests)
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
 
 	sm := h.loadManager(w)
 	if sm == nil {

--- a/internal/proxy/session_api_airlock_test.go
+++ b/internal/proxy/session_api_airlock_test.go
@@ -244,6 +244,110 @@ func TestSessionAPI_HandleAirlock_SameTierNoop(t *testing.T) {
 	}
 }
 
+// TestSessionAPI_HandleAirlock_RateLimited asserts that /airlock is
+// gated by the same sliding-window limiter as /reset /task /trust. A
+// flood of tier-transition calls must not be able to starve other admin
+// endpoints nor mask a stuck session behind an infinite retry loop.
+func TestSessionAPI_HandleAirlock_RateLimited(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	sm.GetOrCreate("agent-a|10.0.0.1")
+	handler := newTestSessionAPIHandler(t, sm)
+
+	// Exhaust the airlock limiter at the documented 10/min ceiling.
+	for range sessionAPIRateLimitMax {
+		body := strings.NewReader(`{"tier":"soft"}`)
+		req := httptest.NewRequest(http.MethodPost, testAirlockEndpoint, body)
+		req.Header.Set("Authorization", "Bearer "+testSessionAPIToken)
+		w := httptest.NewRecorder()
+		handler.HandleAirlock(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request inside limit failed: code=%d body=%s", w.Code, w.Body.String())
+		}
+	}
+
+	// One more request should 429 with a Retry-After header.
+	body := strings.NewReader(`{"tier":"soft"}`)
+	req := httptest.NewRequest(http.MethodPost, testAirlockEndpoint, body)
+	req.Header.Set("Authorization", "Bearer "+testSessionAPIToken)
+	w := httptest.NewRecorder()
+	handler.HandleAirlock(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 after limit exhausted, got %d: %s", w.Code, w.Body.String())
+	}
+	if retry := w.Header().Get("Retry-After"); retry != "60" {
+		t.Errorf("expected Retry-After: 60, got %q", retry)
+	}
+}
+
+// TestSessionAPI_SetAPIToken_HotReload asserts that SetAPIToken rotates
+// the bearer credential without a restart. Before the rotation, the old
+// token authenticates; after, the old token is rejected and the new
+// token is accepted. This proves the atomic.Pointer swap is live on the
+// authenticate path and that operators can rotate kill_switch.api_token
+// via SIGHUP without bouncing the proxy.
+func TestSessionAPI_SetAPIToken_HotReload(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate("agent-a|10.0.0.1")
+
+	handler := newTestSessionAPIHandler(t, sm)
+
+	// Old token accepted pre-rotation.
+	{
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
+		req.Header.Set("Authorization", "Bearer "+testSessionAPIToken)
+		w := httptest.NewRecorder()
+		handler.HandleList(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("pre-rotation: expected 200 with old token, got %d", w.Code)
+		}
+	}
+
+	// Rotate to a new token.
+	const newToken = "rotated-token-abc123"
+	handler.SetAPIToken(newToken)
+
+	// Old token must now be rejected.
+	{
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
+		req.Header.Set("Authorization", "Bearer "+testSessionAPIToken)
+		w := httptest.NewRecorder()
+		handler.HandleList(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("post-rotation: expected 401 with old token, got %d", w.Code)
+		}
+	}
+
+	// New token must now be accepted.
+	{
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
+		req.Header.Set("Authorization", "Bearer "+newToken)
+		w := httptest.NewRecorder()
+		handler.HandleList(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("post-rotation: expected 200 with new token, got %d", w.Code)
+		}
+	}
+
+	// Rotating to empty string must disable the endpoint entirely —
+	// operators use this to revoke access without tearing down the
+	// listener. authenticate returns 503 (not configured), matching
+	// the bootstrap path when no api_token is in the YAML.
+	handler.SetAPIToken("")
+	{
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
+		req.Header.Set("Authorization", "Bearer "+newToken)
+		w := httptest.NewRecorder()
+		handler.HandleList(w, req)
+		if w.Code != http.StatusServiceUnavailable {
+			t.Fatalf("post-revoke: expected 503, got %d", w.Code)
+		}
+	}
+}
+
 func TestExtractSessionKeyWithAction(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/proxy/session_api_explain_test.go
+++ b/internal/proxy/session_api_explain_test.go
@@ -1,0 +1,397 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const (
+	explainIdentityKey = "explain-agent|10.0.0.7"
+	explainAuthHeader  = "Bearer " + testSessionAPIToken
+	explainEvidence    = "injection payload detected in response body"
+	explainManual      = "manual"
+)
+
+func explainURLFor(key string) string {
+	return "/api/v1/sessions/" + url.PathEscape(key) + "/explain"
+}
+
+func setAirlockConfigForTest(sm *SessionManager, airlockCfg *config.Airlock) {
+	sm.UpdateConfig(
+		&config.SessionProfiling{
+			MaxSessions:            100,
+			SessionTTLMinutes:      30,
+			CleanupIntervalSeconds: 300,
+			DomainBurst:            10,
+			WindowMinutes:          5,
+		},
+		nil,
+		airlockCfg,
+	)
+}
+
+func TestSessionAPI_HandleExplain_HardTierWithEvidence(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	airlockCfg := &config.Airlock{
+		Enabled: true,
+		Triggers: config.AirlockTriggers{
+			OnElevated: config.AirlockTierNone,
+			OnHigh:     config.AirlockTierSoft,
+			OnCritical: config.AirlockTierHard,
+		},
+		Timers: config.AirlockTimers{
+			SoftMinutes: 5,
+			HardMinutes: 10,
+		},
+	}
+	setAirlockConfigForTest(sm, airlockCfg)
+
+	sess := sm.GetOrCreate(explainIdentityKey)
+	sess.RecordEvent(SessionEvent{
+		Kind: actionBlock, Target: "evil.example.com", Detail: explainEvidence,
+		Severity: "critical", Score: 0.95,
+	})
+	_, _, _ = sess.Airlock().SetTierWithProvenance(config.AirlockTierHard, airlockTriggerOnCritical, airlockSourceTriggers)
+
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodGet, explainURLFor(explainIdentityKey), nil)
+	req.Header.Set("Authorization", explainAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleExplain(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var exp SessionExplanation
+	if err := json.Unmarshal(w.Body.Bytes(), &exp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if exp.Tier != config.AirlockTierHard {
+		t.Errorf("Tier: got %q, want %q", exp.Tier, config.AirlockTierHard)
+	}
+	if exp.Trigger != "on_critical" {
+		t.Errorf("Trigger: got %q, want on_critical", exp.Trigger)
+	}
+	if exp.TriggerSource != airlockSourceTriggers {
+		t.Errorf("TriggerSource: got %q, want %q", exp.TriggerSource, airlockSourceTriggers)
+	}
+	if exp.EvidenceKind != actionBlock {
+		t.Errorf("EvidenceKind: got %q, want block", exp.EvidenceKind)
+	}
+	if exp.EvidenceDetail != explainEvidence {
+		t.Errorf("EvidenceDetail: got %q, want %q", exp.EvidenceDetail, explainEvidence)
+	}
+	if exp.NextDeescalationTier != config.AirlockTierSoft {
+		t.Errorf("NextDeescalationTier: got %q, want %q", exp.NextDeescalationTier, config.AirlockTierSoft)
+	}
+	if exp.NextDeescalationAt.IsZero() {
+		t.Error("NextDeescalationAt should be non-zero when HardMinutes>0 and EnteredAt is set")
+	}
+	// ElapsedInTier is measured from EnteredAt; allow any non-negative value.
+	if exp.ElapsedInTier < 0 {
+		t.Errorf("ElapsedInTier: got %v, want >= 0", exp.ElapsedInTier)
+	}
+}
+
+func TestSessionAPI_HandleExplain_NoneTierReturns200(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	// Not quarantined.
+	sm.GetOrCreate(explainIdentityKey)
+
+	handler := newTestSessionAPIHandler(t, sm)
+	req := httptest.NewRequest(http.MethodGet, explainURLFor(explainIdentityKey), nil)
+	req.Header.Set("Authorization", explainAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleExplain(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 for non-quarantined; body=%s", w.Code, w.Body.String())
+	}
+
+	var exp SessionExplanation
+	if err := json.Unmarshal(w.Body.Bytes(), &exp); err != nil {
+		t.Fatal(err)
+	}
+	if exp.Tier != config.AirlockTierNone {
+		t.Errorf("Tier: got %q, want %q", exp.Tier, config.AirlockTierNone)
+	}
+	if exp.Reason == "" {
+		t.Error("Reason should be non-empty for none tier")
+	}
+}
+
+func TestSessionAPI_HandleExplain_NotFound(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodGet, explainURLFor("ghost|1.2.3.4"), nil)
+	req.Header.Set("Authorization", explainAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleExplain(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleExplain_Unauthorized(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodGet, explainURLFor(explainIdentityKey), nil)
+	w := httptest.NewRecorder()
+	handler.HandleExplain(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want 401", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleExplain_MethodNotAllowed(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodPost, explainURLFor(explainIdentityKey), nil)
+	req.Header.Set("Authorization", explainAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleExplain(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status: got %d, want 405", w.Code)
+	}
+	if allow := w.Header().Get("Allow"); allow != http.MethodGet {
+		t.Errorf("Allow: got %q, want %q", allow, http.MethodGet)
+	}
+}
+
+func TestSessionAPI_HandleExplain_BadPath(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions//explain", nil)
+	req.Header.Set("Authorization", explainAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleExplain(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleExplain_RateLimited(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate(explainIdentityKey)
+	handler := newTestSessionAPIHandler(t, sm)
+
+	for i := 0; i < sessionAPIRateLimitMax; i++ {
+		req := httptest.NewRequest(http.MethodGet, explainURLFor(explainIdentityKey), nil)
+		req.Header.Set("Authorization", explainAuthHeader)
+		w := httptest.NewRecorder()
+		handler.HandleExplain(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: got %d", i, w.Code)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, explainURLFor(explainIdentityKey), nil)
+	req.Header.Set("Authorization", explainAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleExplain(w, req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("status: got %d, want 429", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleExplain_ManualTrigger(t *testing.T) {
+	// Operator-forced transitions (no trigger config match) surface as explainManual.
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	// No airlock config set at all.
+
+	sess := sm.GetOrCreate(explainIdentityKey)
+	_, _, _ = sess.Airlock().ForceSetTier(config.AirlockTierDrain)
+
+	handler := newTestSessionAPIHandler(t, sm)
+	req := httptest.NewRequest(http.MethodGet, explainURLFor(explainIdentityKey), nil)
+	req.Header.Set("Authorization", explainAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleExplain(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", w.Code)
+	}
+	var exp SessionExplanation
+	if err := json.Unmarshal(w.Body.Bytes(), &exp); err != nil {
+		t.Fatal(err)
+	}
+	if exp.Tier != config.AirlockTierDrain {
+		t.Errorf("Tier: got %q, want drain", exp.Tier)
+	}
+	if exp.Trigger != explainManual {
+		t.Errorf("Trigger: got %q, want manual (no airlock config)", exp.Trigger)
+	}
+	if exp.TriggerSource != airlockSourceAdminAPI {
+		t.Errorf("TriggerSource: got %q, want %q", exp.TriggerSource, airlockSourceAdminAPI)
+	}
+	// Manual path has no config, so NextDeescalationAt should be zero.
+	if !exp.NextDeescalationAt.IsZero() {
+		t.Errorf("NextDeescalationAt: got %v, want zero", exp.NextDeescalationAt)
+	}
+}
+
+func TestSessionAPI_HandleExplain_PrefersNonTransitionEvidence(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	sess := sm.GetOrCreate(explainIdentityKey)
+	sess.RecordEvent(SessionEvent{Kind: actionBlock, Target: "evil.example.com", Detail: explainEvidence, Severity: "critical", Score: 0.95})
+	sess.RecordEvent(SessionEvent{Kind: "airlock_enter", Target: config.AirlockTierHard, Detail: "none->hard", Severity: "warn"})
+	_, _, _ = sess.Airlock().SetTierWithProvenance(config.AirlockTierHard, airlockTriggerOnCritical, airlockSourceTriggers)
+
+	handler := newTestSessionAPIHandler(t, sm)
+	req := httptest.NewRequest(http.MethodGet, explainURLFor(explainIdentityKey), nil)
+	req.Header.Set("Authorization", explainAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleExplain(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", w.Code)
+	}
+	var exp SessionExplanation
+	if err := json.Unmarshal(w.Body.Bytes(), &exp); err != nil {
+		t.Fatal(err)
+	}
+	if exp.EvidenceKind != actionBlock {
+		t.Errorf("EvidenceKind: got %q, want block", exp.EvidenceKind)
+	}
+	if exp.EvidenceDetail != explainEvidence {
+		t.Errorf("EvidenceDetail: got %q, want %q", exp.EvidenceDetail, explainEvidence)
+	}
+}
+
+func TestDeescalationDuration_Behavior(t *testing.T) {
+	timers := &config.AirlockTimers{
+		SoftMinutes:         5,
+		HardMinutes:         10,
+		DrainMinutes:        15,
+		DrainTimeoutSeconds: 30,
+	}
+
+	tests := []struct {
+		name string
+		tier string
+		want time.Duration
+	}{
+		{"soft", config.AirlockTierSoft, 5 * time.Minute},
+		{"hard", config.AirlockTierHard, 10 * time.Minute},
+		{"drain capped at seconds", config.AirlockTierDrain, 30 * time.Second},
+		{"unknown", "fuzz", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deescalationDuration(tt.tier, timers)
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeescalationDuration_ZeroTimerDisables(t *testing.T) {
+	tests := []struct {
+		name   string
+		tier   string
+		timers *config.AirlockTimers
+	}{
+		{"nil timers", config.AirlockTierSoft, nil},
+		{"soft zero", config.AirlockTierSoft, &config.AirlockTimers{SoftMinutes: 0}},
+		{"hard zero", config.AirlockTierHard, &config.AirlockTimers{HardMinutes: 0}},
+		{"drain zero both", config.AirlockTierDrain, &config.AirlockTimers{DrainMinutes: 0, DrainTimeoutSeconds: 0}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deescalationDuration(tt.tier, tt.timers)
+			if got != 0 {
+				t.Errorf("got %v, want 0", got)
+			}
+		})
+	}
+}
+
+func TestNextDeescalationTier(t *testing.T) {
+	tests := []struct {
+		current string
+		want    string
+	}{
+		{config.AirlockTierSoft, config.AirlockTierNone},
+		{config.AirlockTierHard, config.AirlockTierSoft},
+		{config.AirlockTierDrain, config.AirlockTierHard},
+		{config.AirlockTierNone, ""},
+		{"unknown", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.current, func(t *testing.T) {
+			got := nextDeescalationTier(tt.current)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAirlockCfgFromManager_NilManager(t *testing.T) {
+	h := newTestSessionAPIHandler(t, nil)
+	if cfg := h.airlockCfgFromManager(nil); cfg != nil {
+		t.Errorf("nil manager should yield nil config, got %+v", cfg)
+	}
+}
+
+func TestBuildExplanation_NoneTierAttachesEvidence(t *testing.T) {
+	// Even normal sessions get evidence from their event log so explain is
+	// useful outside of incident response.
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	sess := sm.GetOrCreate(explainIdentityKey)
+	sess.RecordEvent(SessionEvent{
+		Kind: "anomaly", Target: "new.example.com", Detail: "domain burst",
+		Severity: "warn", Score: 2.0,
+	})
+	// Do NOT escalate — stay at none.
+
+	snap, found := sm.AdminSnapshotByKey(explainIdentityKey)
+	if !found {
+		t.Fatal("expected session")
+	}
+	exp := buildExplanation(snap, nil)
+
+	if exp.Tier != config.AirlockTierNone {
+		t.Errorf("Tier: got %q, want none", exp.Tier)
+	}
+	if exp.Reason != tierNotQuarantinedReason {
+		t.Errorf("Reason: got %q, want %q", exp.Reason, tierNotQuarantinedReason)
+	}
+	if exp.EvidenceKind != "anomaly" {
+		t.Errorf("EvidenceKind: got %q, want anomaly", exp.EvidenceKind)
+	}
+}

--- a/internal/proxy/session_api_explain_test.go
+++ b/internal/proxy/session_api_explain_test.go
@@ -395,3 +395,29 @@ func TestBuildExplanation_NoneTierAttachesEvidence(t *testing.T) {
 		t.Errorf("EvidenceKind: got %q, want anomaly", exp.EvidenceKind)
 	}
 }
+
+// TestBuildExplanation_NoneTierOmitsTriggerMetadata guards against the
+// self-contradictory output where a normal-tier session returned a
+// "not quarantined" reason alongside stale trigger metadata from a prior
+// airlock entry. The explain contract is: tier=none means no active
+// quarantine cause, so Trigger and TriggerSource must be empty.
+func TestBuildExplanation_NoneTierOmitsTriggerMetadata(t *testing.T) {
+	snap := sessionAdminSnapshot{
+		SessionSnapshot: SessionSnapshot{
+			Key:         "agent|10.0.0.1",
+			AirlockTier: config.AirlockTierNone,
+		},
+		AirlockTrigger:       "stale_trigger_from_prior_entry",
+		AirlockTriggerSource: "prior_source",
+	}
+	exp := buildExplanation(snap, nil)
+	if exp.Reason != tierNotQuarantinedReason {
+		t.Errorf("Reason: got %q, want %q", exp.Reason, tierNotQuarantinedReason)
+	}
+	if exp.Trigger != "" {
+		t.Errorf("Trigger: got %q, want empty for tier=none", exp.Trigger)
+	}
+	if exp.TriggerSource != "" {
+		t.Errorf("TriggerSource: got %q, want empty for tier=none", exp.TriggerSource)
+	}
+}

--- a/internal/proxy/session_api_inspect_test.go
+++ b/internal/proxy/session_api_inspect_test.go
@@ -1,0 +1,228 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+const (
+	inspectIdentityKey = "agent-x|10.0.0.5"
+	inspectAuthHeader  = "Bearer " + testSessionAPIToken
+	inspectEvidence    = "dlp blocked outbound AWS credentials"
+)
+
+// inspectURLFor builds /api/v1/sessions/{escaped-key} for tests.
+func inspectURLFor(key string) string {
+	return "/api/v1/sessions/" + url.PathEscape(key)
+}
+
+func TestSessionAPI_HandleInspect_HappyPath(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	sess := sm.GetOrCreate(inspectIdentityKey)
+	sess.RecordEvent(SessionEvent{Kind: "block", Target: "api.example.com", Detail: inspectEvidence, Severity: "critical", Score: 0.9})
+	_, _, _ = sess.Airlock().SetTier(config.AirlockTierHard)
+
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodGet, inspectURLFor(inspectIdentityKey), nil)
+	req.Header.Set("Authorization", inspectAuthHeader)
+	w := httptest.NewRecorder()
+
+	handler.HandleInspect(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var detail SessionDetail
+	if err := json.Unmarshal(w.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, w.Body.String())
+	}
+	if detail.Key != inspectIdentityKey {
+		t.Errorf("Key: got %q, want %q", detail.Key, inspectIdentityKey)
+	}
+	if detail.AirlockTier != config.AirlockTierHard {
+		t.Errorf("AirlockTier: got %q, want %q", detail.AirlockTier, config.AirlockTierHard)
+	}
+	if detail.AirlockEnteredAt.IsZero() {
+		t.Error("AirlockEnteredAt should be non-zero after transition")
+	}
+	if got := len(detail.RecentEvents); got != 1 {
+		t.Fatalf("RecentEvents: got %d, want 1", got)
+	}
+	if detail.RecentEvents[0].Detail != inspectEvidence {
+		t.Errorf("RecentEvents[0].Detail: got %q, want %q", detail.RecentEvents[0].Detail, inspectEvidence)
+	}
+}
+
+func TestSessionAPI_HandleInspect_NotFound(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodGet, inspectURLFor("ghost|1.2.3.4"), nil)
+	req.Header.Set("Authorization", inspectAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleInspect(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestSessionAPI_HandleInspect_MethodNotAllowed(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodPost, inspectURLFor(inspectIdentityKey), nil)
+	req.Header.Set("Authorization", inspectAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleInspect(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status: got %d, want 405", w.Code)
+	}
+	if allow := w.Header().Get("Allow"); allow != http.MethodGet {
+		t.Errorf("Allow: got %q, want %q", allow, http.MethodGet)
+	}
+}
+
+func TestSessionAPI_HandleInspect_Unauthorized(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodGet, inspectURLFor(inspectIdentityKey), nil)
+	// No auth header.
+	w := httptest.NewRecorder()
+	handler.HandleInspect(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want 401", w.Code)
+	}
+	if w.Header().Get("WWW-Authenticate") == "" {
+		t.Error("expected WWW-Authenticate header")
+	}
+}
+
+func TestSessionAPI_HandleInspect_BadPath(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"wrong api prefix", "/wrong/v1/sessions/key"},
+		{"wrong version", "/api/v2/sessions/key"},
+		{"five segments (action route)", "/api/v1/sessions/key/reset"},
+		{"three segments (list route)", "/api/v1/sessions"},
+		{"empty key", "/api/v1/sessions/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			req.Header.Set("Authorization", inspectAuthHeader)
+			w := httptest.NewRecorder()
+			handler.HandleInspect(w, req)
+
+			if w.Code == http.StatusOK {
+				t.Errorf("expected non-200 for %s, got 200", tt.path)
+			}
+		})
+	}
+}
+
+func TestSessionAPI_HandleInspect_RateLimited(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate(inspectIdentityKey)
+	handler := newTestSessionAPIHandler(t, sm)
+
+	for i := 0; i < sessionAPIRateLimitMax; i++ {
+		req := httptest.NewRequest(http.MethodGet, inspectURLFor(inspectIdentityKey), nil)
+		req.Header.Set("Authorization", inspectAuthHeader)
+		w := httptest.NewRecorder()
+		handler.HandleInspect(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200 within limit, got %d", i, w.Code)
+		}
+	}
+
+	// The next request should be rate-limited.
+	req := httptest.NewRequest(http.MethodGet, inspectURLFor(inspectIdentityKey), nil)
+	req.Header.Set("Authorization", inspectAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleInspect(w, req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("status: got %d, want 429", w.Code)
+	}
+	if retryAfter := w.Header().Get("Retry-After"); retryAfter != "60" {
+		t.Errorf("Retry-After: got %q, want 60", retryAfter)
+	}
+}
+
+func TestSessionAPI_HandleInspect_ManagerDisabled(t *testing.T) {
+	var smPtr atomic.Pointer[SessionManager]
+	// Never Store() anything — Load() returns nil.
+	var etPtr atomic.Pointer[scanner.EntropyTracker]
+	var fbPtr atomic.Pointer[scanner.FragmentBuffer]
+	handler := NewSessionAPIHandler(SessionAPIOptions{
+		SessionMgrPtr: &smPtr,
+		EntropyPtr:    &etPtr,
+		FragmentPtr:   &fbPtr,
+		Logger:        audit.NewNop(),
+		APIToken:      testSessionAPIToken,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, inspectURLFor(inspectIdentityKey), nil)
+	req.Header.Set("Authorization", inspectAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleInspect(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status: got %d, want 503", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleInspect_RecentEventsEmpty(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate(inspectIdentityKey)
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodGet, inspectURLFor(inspectIdentityKey), nil)
+	req.Header.Set("Authorization", inspectAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleInspect(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", w.Code)
+	}
+	var detail SessionDetail
+	if err := json.Unmarshal(w.Body.Bytes(), &detail); err != nil {
+		t.Fatal(err)
+	}
+	if detail.RecentEvents == nil {
+		t.Error("RecentEvents should be non-nil empty slice, not null")
+	}
+	if len(detail.RecentEvents) != 0 {
+		t.Errorf("RecentEvents length: got %d, want 0", len(detail.RecentEvents))
+	}
+}

--- a/internal/proxy/session_api_list_tier_test.go
+++ b/internal/proxy/session_api_list_tier_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const (
+	listTierKey1       = "a|10.0.0.1"
+	listTierKey2       = "b|10.0.0.2"
+	listTierKey3       = "c|10.0.0.3"
+	listTierAuthHeader = "Bearer " + testSessionAPIToken
+)
+
+func TestParseTierFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{"empty means no filter", "", "", false},
+		{"none literal", "none", config.AirlockTierNone, false},
+		{"normal alias", "normal", config.AirlockTierNone, false},
+		{"soft", "soft", config.AirlockTierSoft, false},
+		{"hard", "hard", config.AirlockTierHard, false},
+		{"drain", "drain", config.AirlockTierDrain, false},
+		{"invalid tier rejected", "unknown", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTierFilter(tt.raw)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTierMatches(t *testing.T) {
+	// Empty snapshot tier normalizes to "none".
+	if !tierMatches("", config.AirlockTierNone) {
+		t.Error("empty tier should match none filter")
+	}
+	if tierMatches("", config.AirlockTierHard) {
+		t.Error("empty tier should NOT match hard filter")
+	}
+	if !tierMatches(config.AirlockTierHard, config.AirlockTierHard) {
+		t.Error("hard should match hard")
+	}
+}
+
+func TestSessionAPI_HandleList_TierFilter(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	sess1 := sm.GetOrCreate(listTierKey1)
+	sess2 := sm.GetOrCreate(listTierKey2)
+	_ = sm.GetOrCreate(listTierKey3) // stays at none
+	_, _, _ = sess1.Airlock().SetTier(config.AirlockTierHard)
+	_, _, _ = sess2.Airlock().SetTier(config.AirlockTierSoft)
+
+	handler := newTestSessionAPIHandler(t, sm)
+
+	tests := []struct {
+		name       string
+		query      string
+		wantCount  int
+		wantStatus int
+	}{
+		{"no filter returns all", "", 3, http.StatusOK},
+		{"hard filter returns 1", "?tier=hard", 1, http.StatusOK},
+		{"soft filter returns 1", "?tier=soft", 1, http.StatusOK},
+		{"none filter returns 1", "?tier=none", 1, http.StatusOK},
+		{"normal alias", "?tier=normal", 1, http.StatusOK},
+		{"drain filter returns 0", "?tier=drain", 0, http.StatusOK},
+		{"invalid tier 400", "?tier=moist", 0, http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions"+tt.query, nil)
+			req.Header.Set("Authorization", listTierAuthHeader)
+			w := httptest.NewRecorder()
+			handler.HandleList(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status: got %d, want %d; body=%s", w.Code, tt.wantStatus, w.Body.String())
+			}
+			if tt.wantStatus != http.StatusOK {
+				return
+			}
+			var resp struct {
+				Sessions []SessionSnapshot `json:"sessions"`
+				Count    int               `json:"count"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if resp.Count != tt.wantCount {
+				t.Errorf("count: got %d, want %d (sessions=%+v)", resp.Count, tt.wantCount, resp.Sessions)
+			}
+		})
+	}
+}

--- a/internal/proxy/session_api_terminate_test.go
+++ b/internal/proxy/session_api_terminate_test.go
@@ -77,6 +77,10 @@ func TestSessionAPI_HandleTerminate_CEEStateCleared(t *testing.T) {
 	// Provide non-nil CEE state pointers so the handler clears them.
 	et := scanner.NewEntropyTracker(1000, 300)
 	fb := scanner.NewFragmentBuffer(1000, 2, 300)
+	t.Cleanup(func() {
+		et.Close()
+		fb.Close()
+	})
 	var etPtr atomic.Pointer[scanner.EntropyTracker]
 	etPtr.Store(et)
 	var fbPtr atomic.Pointer[scanner.FragmentBuffer]

--- a/internal/proxy/session_api_terminate_test.go
+++ b/internal/proxy/session_api_terminate_test.go
@@ -1,0 +1,365 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+const (
+	terminateIdentityKey   = "terminate-agent|10.0.0.9"
+	terminateInvocationKey = "mcp-stdio-99"
+	terminateAuthHeader    = "Bearer " + testSessionAPIToken
+)
+
+func terminateURLFor(key string) string {
+	return "/api/v1/sessions/" + url.PathEscape(key) + "/terminate"
+}
+
+func TestSessionAPI_HandleTerminate_HappyPath(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+
+	sess := sm.GetOrCreate(terminateIdentityKey)
+	_, _, _ = sess.Airlock().SetTier(config.AirlockTierHard)
+
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodPost, terminateURLFor(terminateIdentityKey), nil)
+	req.Header.Set("Authorization", terminateAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleTerminate(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var res SessionTerminateResult
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Fatal(err)
+	}
+	if !res.Terminated {
+		t.Error("Terminated: got false, want true")
+	}
+	if res.PreviousTier != config.AirlockTierHard {
+		t.Errorf("PreviousTier: got %q, want %q", res.PreviousTier, config.AirlockTierHard)
+	}
+
+	// Post-condition: session still exists, tier is now none.
+	postSnap, _, found := sm.SnapshotByKey(terminateIdentityKey)
+	if !found {
+		t.Error("session should still exist in manager after terminate")
+	}
+	if postSnap.AirlockTier != config.AirlockTierNone {
+		t.Errorf("post tier: got %q, want none", postSnap.AirlockTier)
+	}
+}
+
+func TestSessionAPI_HandleTerminate_CEEStateCleared(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate(terminateIdentityKey)
+
+	var smPtr atomic.Pointer[SessionManager]
+	smPtr.Store(sm)
+
+	// Provide non-nil CEE state pointers so the handler clears them.
+	et := scanner.NewEntropyTracker(1000, 300)
+	fb := scanner.NewFragmentBuffer(1000, 2, 300)
+	var etPtr atomic.Pointer[scanner.EntropyTracker]
+	etPtr.Store(et)
+	var fbPtr atomic.Pointer[scanner.FragmentBuffer]
+	fbPtr.Store(fb)
+
+	handler := NewSessionAPIHandler(SessionAPIOptions{
+		SessionMgrPtr: &smPtr,
+		EntropyPtr:    &etPtr,
+		FragmentPtr:   &fbPtr,
+		Logger:        audit.NewNop(),
+		APIToken:      testSessionAPIToken,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, terminateURLFor(terminateIdentityKey), nil)
+	req.Header.Set("Authorization", terminateAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleTerminate(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", w.Code)
+	}
+
+	var res SessionTerminateResult
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Fatal(err)
+	}
+	if !res.CEEStateCleared {
+		t.Error("CEEStateCleared: got false, want true")
+	}
+}
+
+func TestSessionAPI_HandleTerminate_InvocationKeyRejected(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate(terminateInvocationKey)
+
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodPost, terminateURLFor(terminateInvocationKey), nil)
+	req.Header.Set("Authorization", terminateAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleTerminate(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", w.Code)
+	}
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatal(err)
+	}
+	if errResp.Error == "" {
+		t.Error("error body should describe the rejection")
+	}
+}
+
+func TestSessionAPI_HandleTerminate_NotFound(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodPost, terminateURLFor("ghost|1.2.3.4"), nil)
+	req.Header.Set("Authorization", terminateAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleTerminate(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTerminate_MethodNotAllowed(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodGet, terminateURLFor(terminateIdentityKey), nil)
+	req.Header.Set("Authorization", terminateAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleTerminate(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status: got %d, want 405", w.Code)
+	}
+	if allow := w.Header().Get("Allow"); allow != http.MethodPost {
+		t.Errorf("Allow: got %q, want %q", allow, http.MethodPost)
+	}
+}
+
+func TestSessionAPI_HandleTerminate_Unauthorized(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodPost, terminateURLFor(terminateIdentityKey), nil)
+	w := httptest.NewRecorder()
+	handler.HandleTerminate(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want 401", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTerminate_BadPath(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions//terminate", nil)
+	req.Header.Set("Authorization", terminateAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleTerminate(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTerminate_RejectsUnknownFields(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate(terminateIdentityKey)
+	handler := newTestSessionAPIHandler(t, sm)
+
+	body := bytes.NewBufferString(`{"unexpected_field": "value"}`)
+	req := httptest.NewRequest(http.MethodPost, terminateURLFor(terminateIdentityKey), body)
+	req.Header.Set("Authorization", terminateAuthHeader)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.HandleTerminate(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleTerminate_EmptyBodyOK(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate(terminateIdentityKey)
+	handler := newTestSessionAPIHandler(t, sm)
+
+	// Zero-length body is allowed — decodeJSONBody treats empty as "no
+	// fields" and leaves the target struct at its zero value.
+	req := httptest.NewRequest(http.MethodPost, terminateURLFor(terminateIdentityKey), bytes.NewBuffer(nil))
+	req.Header.Set("Authorization", terminateAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleTerminate(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestSessionAPI_HandleTerminate_NoCEEPointers(t *testing.T) {
+	// No CEE pointers wired in — handler should still terminate cleanly.
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate(terminateIdentityKey)
+
+	var smPtr atomic.Pointer[SessionManager]
+	smPtr.Store(sm)
+	handler := NewSessionAPIHandler(SessionAPIOptions{
+		SessionMgrPtr: &smPtr,
+		// EntropyPtr and FragmentPtr intentionally nil.
+		Logger:   audit.NewNop(),
+		APIToken: testSessionAPIToken,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, terminateURLFor(terminateIdentityKey), nil)
+	req.Header.Set("Authorization", terminateAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleTerminate(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", w.Code)
+	}
+	var res SessionTerminateResult
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Fatal(err)
+	}
+	if res.CEEStateCleared {
+		t.Error("CEEStateCleared should be false with nil CEE pointers")
+	}
+}
+
+func TestSessionAPI_HandleTerminate_NoCEEStateLoaded(t *testing.T) {
+	// CEE pointers provided but nothing Stored — Load returns nil.
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate(terminateIdentityKey)
+
+	var smPtr atomic.Pointer[SessionManager]
+	smPtr.Store(sm)
+	var etPtr atomic.Pointer[scanner.EntropyTracker]
+	var fbPtr atomic.Pointer[scanner.FragmentBuffer]
+	handler := NewSessionAPIHandler(SessionAPIOptions{
+		SessionMgrPtr: &smPtr,
+		EntropyPtr:    &etPtr,
+		FragmentPtr:   &fbPtr,
+		Logger:        audit.NewNop(),
+		APIToken:      testSessionAPIToken,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, terminateURLFor(terminateIdentityKey), nil)
+	req.Header.Set("Authorization", terminateAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleTerminate(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", w.Code)
+	}
+	var res SessionTerminateResult
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Fatal(err)
+	}
+	if res.CEEStateCleared {
+		t.Error("CEEStateCleared should be false when both Load() return nil")
+	}
+}
+
+func TestExtractSessionKeyOnly_BadPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"wrong api", "/wrong/v1/sessions/k", false},
+		{"wrong version", "/api/v2/sessions/k", false},
+		{"wrong segment", "/api/v1/sess/k", false},
+		{"5 segments", "/api/v1/sessions/k/reset", false},
+		{"3 segments", "/api/v1/sessions", false},
+		{"empty key", "/api/v1/sessions/", false},
+		{"null byte", "/api/v1/sessions/foo%00", false},
+		{"valid", "/api/v1/sessions/agent%7C1.2.3.4", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			_, ok := extractSessionKeyOnly(req)
+			if ok != tt.want {
+				t.Errorf("got ok=%v, want %v for path %q", ok, tt.want, tt.path)
+			}
+		})
+	}
+}
+
+func TestAttachMostRecentEvidence_AllEmptyEvents(t *testing.T) {
+	// All events have empty Kind AND empty Detail — loop skips everything
+	// without setting evidence fields.
+	exp := &SessionExplanation{}
+	events := []SessionEvent{{Kind: "", Detail: ""}, {Kind: "", Detail: ""}}
+	attachMostRecentEvidence(exp, events)
+	if exp.EvidenceKind != "" || exp.EvidenceDetail != "" {
+		t.Errorf("expected no evidence attached, got kind=%q detail=%q", exp.EvidenceKind, exp.EvidenceDetail)
+	}
+}
+
+func TestSessionAPI_HandleTerminate_RateLimited(t *testing.T) {
+	sm, cleanup := setupSessionAPITestManager(t)
+	defer cleanup()
+	sm.GetOrCreate(terminateIdentityKey)
+	handler := newTestSessionAPIHandler(t, sm)
+
+	for i := 0; i < sessionAPIRateLimitMax; i++ {
+		req := httptest.NewRequest(http.MethodPost, terminateURLFor(terminateIdentityKey), nil)
+		req.Header.Set("Authorization", terminateAuthHeader)
+		w := httptest.NewRecorder()
+		handler.HandleTerminate(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: got %d", i, w.Code)
+		}
+		// Re-create the session since terminate evicts it back to normal;
+		// Snapshot is still valid but this keeps the loop idempotent.
+		sm.GetOrCreate(terminateIdentityKey)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, terminateURLFor(terminateIdentityKey), nil)
+	req.Header.Set("Authorization", terminateAuthHeader)
+	w := httptest.NewRecorder()
+	handler.HandleTerminate(w, req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("status: got %d, want 429", w.Code)
+	}
+}

--- a/internal/proxy/session_api_test.go
+++ b/internal/proxy/session_api_test.go
@@ -48,7 +48,13 @@ func newTestSessionAPIHandler(t *testing.T, sm *SessionManager) *SessionAPIHandl
 	}
 	var etPtr atomic.Pointer[scanner.EntropyTracker]
 	var fbPtr atomic.Pointer[scanner.FragmentBuffer]
-	return NewSessionAPIHandler(&smPtr, &etPtr, &fbPtr, nil, audit.NewNop(), testSessionAPIToken)
+	return NewSessionAPIHandler(SessionAPIOptions{
+		SessionMgrPtr: &smPtr,
+		EntropyPtr:    &etPtr,
+		FragmentPtr:   &fbPtr,
+		Logger:        audit.NewNop(),
+		APIToken:      testSessionAPIToken,
+	})
 }
 
 func TestSessionAPI_HandleList(t *testing.T) {
@@ -183,7 +189,12 @@ func TestSessionAPI_HandleList(t *testing.T) {
 		smPtr.Store(sm)
 		var etPtr atomic.Pointer[scanner.EntropyTracker]
 		var fbPtr atomic.Pointer[scanner.FragmentBuffer]
-		handler := NewSessionAPIHandler(&smPtr, &etPtr, &fbPtr, nil, audit.NewNop(), "") // empty token
+		handler := NewSessionAPIHandler(SessionAPIOptions{
+			SessionMgrPtr: &smPtr,
+			EntropyPtr:    &etPtr,
+			FragmentPtr:   &fbPtr,
+			Logger:        audit.NewNop(),
+		}) // empty token
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
 		req.Header.Set("Authorization", "Bearer some-token")
@@ -506,7 +517,14 @@ func TestSessionAPI_HandleReset_DecrementEscalatedMetrics(t *testing.T) {
 	smPtr.Store(sm)
 	var etPtr atomic.Pointer[scanner.EntropyTracker]
 	var fbPtr atomic.Pointer[scanner.FragmentBuffer]
-	handler := NewSessionAPIHandler(&smPtr, &etPtr, &fbPtr, m, audit.NewNop(), testSessionAPIToken)
+	handler := NewSessionAPIHandler(SessionAPIOptions{
+		SessionMgrPtr: &smPtr,
+		EntropyPtr:    &etPtr,
+		FragmentPtr:   &fbPtr,
+		Metrics:       m,
+		Logger:        audit.NewNop(),
+		APIToken:      testSessionAPIToken,
+	})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/agent-b%7C10.0.0.2/reset", nil)
 	req.Header.Set("Authorization", "Bearer "+testSessionAPIToken)
@@ -680,7 +698,13 @@ func TestSessionAPI_HandleReset_ClearsCEEState(t *testing.T) {
 	etPtr.Store(et)
 	var fbPtr atomic.Pointer[scanner.FragmentBuffer]
 	fbPtr.Store(fb)
-	handler := NewSessionAPIHandler(&smPtr, &etPtr, &fbPtr, nil, audit.NewNop(), testSessionAPIToken)
+	handler := NewSessionAPIHandler(SessionAPIOptions{
+		SessionMgrPtr: &smPtr,
+		EntropyPtr:    &etPtr,
+		FragmentPtr:   &fbPtr,
+		Logger:        audit.NewNop(),
+		APIToken:      testSessionAPIToken,
+	})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/agent%7C10.0.0.1/reset", nil)
 	req.Header.Set("Authorization", "Bearer "+testSessionAPIToken)

--- a/internal/proxy/session_operator_test.go
+++ b/internal/proxy/session_operator_test.go
@@ -1,0 +1,349 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+// Test-local constants for session operator helpers. goconst friendly —
+// any string that appears in 3+ places in this file gets a name.
+const (
+	operKey    = "agent-a|10.0.0.1"
+	operAgent  = "agent-a"
+	operIP     = "10.0.0.1"
+	operDetail = "dlp secret on outbound request"
+	operTarget = "api.example.com"
+)
+
+func newOperatorTestManager(t *testing.T) (*SessionManager, func()) {
+	t.Helper()
+	cfg := &config.SessionProfiling{
+		MaxSessions:            50,
+		SessionTTLMinutes:      30,
+		CleanupIntervalSeconds: 300,
+		DomainBurst:            10,
+		WindowMinutes:          5,
+	}
+	sm := NewSessionManager(cfg, nil, metrics.New())
+	return sm, func() { sm.Close() }
+}
+
+func TestAirlockState_EnteredAt(t *testing.T) {
+	a := NewAirlockState()
+	if !a.EnteredAt().IsZero() {
+		t.Errorf("new state EnteredAt: got %v, want zero", a.EnteredAt())
+	}
+
+	before := time.Now()
+	if changed, _, _ := a.SetTier(config.AirlockTierSoft); !changed {
+		t.Fatal("expected transition")
+	}
+	after := time.Now()
+
+	got := a.EnteredAt()
+	if got.Before(before) || got.After(after) {
+		t.Errorf("EnteredAt after SetTier: got %v, want within [%v, %v]", got, before, after)
+	}
+
+	// Transition to hard updates enteredAt.
+	time.Sleep(5 * time.Millisecond)
+	if changed, _, _ := a.SetTier(config.AirlockTierHard); !changed {
+		t.Fatal("expected transition")
+	}
+	newTs := a.EnteredAt()
+	if !newTs.After(got) {
+		t.Errorf("EnteredAt after hard transition should advance: got %v, prev %v", newTs, got)
+	}
+}
+
+func TestAirlockState_EntryProvenance(t *testing.T) {
+	a := NewAirlockState()
+
+	if changed, _, _ := a.SetTierWithProvenance(config.AirlockTierHard, airlockTriggerOnCritical, airlockSourceTriggers); !changed {
+		t.Fatal("expected transition")
+	}
+
+	trigger, source := a.EntryProvenance()
+	if trigger != airlockTriggerOnCritical {
+		t.Errorf("trigger: got %q, want %q", trigger, airlockTriggerOnCritical)
+	}
+	if source != airlockSourceTriggers {
+		t.Errorf("source: got %q, want %q", source, airlockSourceTriggers)
+	}
+
+	if changed, _, _ := a.ForceSetTierWithProvenance(config.AirlockTierNone, airlockTriggerManual, airlockSourceAdminAPI); !changed {
+		t.Fatal("expected release to none")
+	}
+	if !a.EnteredAt().IsZero() {
+		t.Errorf("none tier EnteredAt: got %v, want zero", a.EnteredAt())
+	}
+	trigger, source = a.EntryProvenance()
+	if trigger != "" || source != "" {
+		t.Errorf("none tier provenance should be cleared, got trigger=%q source=%q", trigger, source)
+	}
+}
+
+func TestSessionState_RecordEvent_AppendsInOrder(t *testing.T) {
+	s := &SessionState{kind: sessionKindIdentity}
+
+	s.RecordEvent(SessionEvent{Kind: "block", Target: operTarget, Detail: "one", Severity: "critical"})
+	s.RecordEvent(SessionEvent{Kind: "block", Target: operTarget, Detail: "two", Severity: "critical"})
+	s.RecordEvent(SessionEvent{Kind: "anomaly", Target: operTarget, Detail: "three", Severity: "warn", Score: 2.5})
+
+	events := s.RecentEvents()
+	if got, want := len(events), 3; got != want {
+		t.Fatalf("events: got %d, want %d", got, want)
+	}
+	if events[0].Detail != "one" || events[1].Detail != "two" || events[2].Detail != "three" {
+		t.Errorf("events not in insertion order: %+v", events)
+	}
+	// RecordEvent should assign At when the caller leaves it zero.
+	for i, e := range events {
+		if e.At.IsZero() {
+			t.Errorf("event %d has zero At", i)
+		}
+	}
+}
+
+func TestSessionState_RecordEvent_RingBufferOverflow(t *testing.T) {
+	s := &SessionState{kind: sessionKindIdentity}
+
+	// Push one more than the bound so the oldest entry is dropped.
+	for i := 0; i < maxRecentEvents+5; i++ {
+		s.RecordEvent(SessionEvent{Kind: "block", Target: operTarget, Detail: "evt", Severity: "critical"})
+	}
+
+	events := s.RecentEvents()
+	if got, want := len(events), maxRecentEvents; got != want {
+		t.Errorf("buffer length: got %d, want %d", got, want)
+	}
+}
+
+func TestSessionState_RecentEvents_ReturnsCopy(t *testing.T) {
+	s := &SessionState{kind: sessionKindIdentity}
+	s.RecordEvent(SessionEvent{Kind: "block", Target: operTarget, Detail: "orig"})
+
+	events := s.RecentEvents()
+	events[0].Detail = "mutated"
+
+	again := s.RecentEvents()
+	if again[0].Detail != "orig" {
+		t.Errorf("RecentEvents should return a copy: got %q, want %q", again[0].Detail, "orig")
+	}
+}
+
+func TestSessionState_RecentEvents_Empty(t *testing.T) {
+	s := &SessionState{kind: sessionKindIdentity}
+	events := s.RecentEvents()
+	if events == nil {
+		t.Error("expected non-nil empty slice")
+	}
+	if len(events) != 0 {
+		t.Errorf("length: got %d, want 0", len(events))
+	}
+}
+
+func TestSessionState_Reset_ClearsRecentEvents(t *testing.T) {
+	s := &SessionState{kind: sessionKindIdentity}
+	s.RecordEvent(SessionEvent{Kind: "block", Target: operTarget, Detail: "one"})
+	s.RecordEvent(SessionEvent{Kind: "block", Target: operTarget, Detail: "two"})
+
+	s.Reset()
+
+	events := s.RecentEvents()
+	if len(events) != 0 {
+		t.Errorf("Reset did not clear events: %+v", events)
+	}
+}
+
+func TestSessionManager_SessionByKey(t *testing.T) {
+	sm, cleanup := newOperatorTestManager(t)
+	defer cleanup()
+
+	if got := sm.SessionByKey(operKey); got != nil {
+		t.Errorf("unknown key: got %v, want nil", got)
+	}
+
+	sm.GetOrCreate(operKey)
+	got := sm.SessionByKey(operKey)
+	if got == nil {
+		t.Fatal("existing key: got nil, want session pointer")
+	}
+}
+
+func TestSessionManager_SnapshotByKey_NotFound(t *testing.T) {
+	sm, cleanup := newOperatorTestManager(t)
+	defer cleanup()
+
+	_, _, ok := sm.SnapshotByKey(operKey)
+	if ok {
+		t.Error("expected not found for unknown key")
+	}
+}
+
+func TestSessionManager_SnapshotByKey_IncludesEvents(t *testing.T) {
+	sm, cleanup := newOperatorTestManager(t)
+	defer cleanup()
+
+	sess := sm.GetOrCreate(operKey)
+	sess.RecordEvent(SessionEvent{Kind: "block", Target: operTarget, Detail: operDetail, Severity: "critical"})
+	_, _, _ = sess.Airlock().SetTier(config.AirlockTierSoft)
+
+	snap, events, ok := sm.SnapshotByKey(operKey)
+	if !ok {
+		t.Fatal("expected found")
+	}
+	if snap.Key != operKey {
+		t.Errorf("snap.Key: got %q, want %q", snap.Key, operKey)
+	}
+	if snap.Agent != operAgent {
+		t.Errorf("snap.Agent: got %q, want %q", snap.Agent, operAgent)
+	}
+	if snap.ClientIP != operIP {
+		t.Errorf("snap.ClientIP: got %q, want %q", snap.ClientIP, operIP)
+	}
+	if snap.AirlockTier != config.AirlockTierSoft {
+		t.Errorf("snap.AirlockTier: got %q, want %q", snap.AirlockTier, config.AirlockTierSoft)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events: got %d, want 1", len(events))
+	}
+	if events[0].Detail != operDetail {
+		t.Errorf("event detail: got %q, want %q", events[0].Detail, operDetail)
+	}
+}
+
+func TestSessionManager_AdminSnapshotByKey_IncludesAirlockMetadata(t *testing.T) {
+	sm, cleanup := newOperatorTestManager(t)
+	defer cleanup()
+
+	sess := sm.GetOrCreate(operKey)
+	sess.RecordEvent(SessionEvent{Kind: "block", Target: operTarget, Detail: operDetail, Severity: "critical"})
+	_, _, _ = sess.Airlock().SetTierWithProvenance(config.AirlockTierHard, airlockTriggerOnCritical, airlockSourceTriggers)
+
+	snap, ok := sm.AdminSnapshotByKey(operKey)
+	if !ok {
+		t.Fatal("expected found")
+	}
+	if snap.AirlockTier != config.AirlockTierHard {
+		t.Errorf("snap.AirlockTier: got %q, want %q", snap.AirlockTier, config.AirlockTierHard)
+	}
+	if snap.AirlockEnteredAt.IsZero() {
+		t.Fatal("AirlockEnteredAt should be non-zero")
+	}
+	if snap.AirlockTrigger != airlockTriggerOnCritical {
+		t.Errorf("AirlockTrigger: got %q, want %q", snap.AirlockTrigger, airlockTriggerOnCritical)
+	}
+	if snap.AirlockTriggerSource != airlockSourceTriggers {
+		t.Errorf("AirlockTriggerSource: got %q, want %q", snap.AirlockTriggerSource, airlockSourceTriggers)
+	}
+	if len(snap.RecentEvents) != 1 {
+		t.Fatalf("RecentEvents: got %d, want 1", len(snap.RecentEvents))
+	}
+}
+
+func TestSessionManager_AirlockConfig(t *testing.T) {
+	sm, cleanup := newOperatorTestManager(t)
+	defer cleanup()
+
+	// No config set yet.
+	if got := sm.AirlockConfig(); got != nil {
+		t.Errorf("default AirlockConfig: got %v, want nil", got)
+	}
+
+	cfg := &config.Airlock{
+		Enabled: true,
+		Timers:  config.AirlockTimers{SoftMinutes: 5, HardMinutes: 10},
+	}
+	sm.UpdateConfig(
+		&config.SessionProfiling{MaxSessions: 10, SessionTTLMinutes: 30, CleanupIntervalSeconds: 60, DomainBurst: 10, WindowMinutes: 5},
+		nil,
+		cfg,
+	)
+
+	got := sm.AirlockConfig()
+	if got == nil {
+		t.Fatal("after set: got nil, want pointer")
+	}
+	if got.Timers.SoftMinutes != 5 {
+		t.Errorf("Timers.SoftMinutes: got %d, want 5", got.Timers.SoftMinutes)
+	}
+}
+
+func TestFrozenToolRegistry_ToolNames(t *testing.T) {
+	r := NewFrozenToolRegistry()
+	if names := r.ToolNames("missing"); names != nil {
+		t.Errorf("missing key: got %v, want nil", names)
+	}
+
+	r.Freeze("mcp-1", []string{"zeta", "alpha", "mu"})
+	names := r.ToolNames("mcp-1")
+	if got, want := len(names), 3; got != want {
+		t.Fatalf("names: got %d, want %d", got, want)
+	}
+	// Sorted for stable preview.
+	for i := 1; i < len(names); i++ {
+		if names[i-1] > names[i] {
+			t.Errorf("names not sorted: %v", names)
+		}
+	}
+}
+
+func TestRecordSessionActivity_RecordsBlockEvent(t *testing.T) {
+	// End-to-end: a blocked scanner result flows through recordSessionActivity
+	// and surfaces in the session's recent-event ring buffer.
+	cfg := config.Defaults()
+	cfg.SessionProfiling.Enabled = true
+	cfg.SessionProfiling.MaxSessions = 50
+	cfg.SessionProfiling.SessionTTLMinutes = 30
+	cfg.SessionProfiling.CleanupIntervalSeconds = 60
+	cfg.SessionProfiling.DomainBurst = 10
+	cfg.SessionProfiling.WindowMinutes = 5
+	cfg.Internal = nil
+
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	logger := audit.NewNop()
+	m := metrics.New()
+	p, err := New(cfg, logger, sc, m)
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	defer p.Close()
+
+	result := scanner.Result{Allowed: false, Reason: operDetail, Score: 0.9}
+	p.recordSessionActivity(operIP, operAgent, operTarget, "req-1", result, cfg, logger, false)
+
+	sm := p.sessionMgrPtr.Load()
+	if sm == nil {
+		t.Fatal("session manager not initialized")
+	}
+	key := operAgent + "|" + operIP
+	sess := sm.SessionByKey(key)
+	if sess == nil {
+		t.Fatalf("expected session %q", key)
+	}
+	events := sess.RecentEvents()
+	if len(events) == 0 {
+		t.Fatal("expected at least one recorded event")
+	}
+	var foundBlock bool
+	for _, e := range events {
+		if e.Kind == "block" && e.Target == operTarget {
+			foundBlock = true
+			break
+		}
+	}
+	if !foundBlock {
+		t.Errorf("no block event found for target %q: %+v", operTarget, events)
+	}
+}

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -1326,6 +1326,61 @@ func TestScanTextForDLP_CredentialInURL_ShortValueClean(t *testing.T) {
 	}
 }
 
+// TestScanTextForDLP_CredentialInURL_NoFPOnGoAssignment documents the
+// scope of the Credential in URL rule: it only fires when the credential
+// key is preceded by a URL query delimiter ([?&;]), so Go source files
+// that legitimately assign to credential-named struct fields do not
+// false-positive. Without this, every pipelock file that handles a
+// bearer token (session admin, CLI resolver, config loader) would need
+// a per-file exclude-paths entry in the GitHub Action workflow.
+func TestScanTextForDLP_CredentialInURL_NoFPOnGoAssignment(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	goLines := []string{
+		`ep.Token = deps.getenv(killswitch.EnvAPIToken)`,
+		`user.Password = hashedValue`,
+		`cfg.APIKey = loadFromFile(path)`,
+		`session.Secret = base64Encode(raw)`,
+		`req.APIToken = "placeholder"`,
+		`h.apiToken = opts.APIToken`,
+	}
+	for _, line := range goLines {
+		t.Run(line, func(t *testing.T) {
+			result := s.ScanTextForDLP(context.Background(), line)
+			if !result.Clean {
+				t.Errorf("false positive on Go assignment %q: %+v", line, result.Matches)
+			}
+		})
+	}
+}
+
+// TestScanTextForDLP_CredentialInURL_StillCatchesQueryDelimiter locks in
+// the positive side of the rule: credentials in URL query strings are
+// still caught. Covers the ?, &, and ; delimiters for parity with how
+// browsers, form encoders, and connection strings carry parameters.
+func TestScanTextForDLP_CredentialInURL_StillCatchesQueryDelimiter(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	positives := []string{
+		"https://example.com/api?password=supersecret123",
+		"https://example.com/api?x=1&token=abcdef123456",
+		"jdbc:mysql://host/db;password=hunter2abcd",
+		"POSTed body: username=bob&apikey=realsecret123",
+	}
+	for _, s2 := range positives {
+		t.Run(s2, func(t *testing.T) {
+			result := s.ScanTextForDLP(context.Background(), s2)
+			if result.Clean {
+				t.Errorf("expected catch on %q, got clean", s2)
+			}
+		})
+	}
+}
+
 func TestScanTextForDLP_EthereumAddressOptIn(t *testing.T) {
 	cfg := testConfig()
 	cfg.DLP.Patterns = append(cfg.DLP.Patterns, config.DLPPattern{

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -1389,6 +1389,81 @@ func TestScanTextForDLP_CredentialInURL_StillCatchesQueryDelimiter(t *testing.T)
 	}
 }
 
+// TestScanTextForDLP_CredentialInURL_CatchesBodyStart asserts the
+// post-widening coverage for the "Credential in URL" DLP pattern. The
+// regex alternation `(?m)(?:^|[?&;])` catches credentials at the very
+// start of the scanned text (position 0, via ^) in addition to the
+// original URL-query-delimiter path ([?&;]). Common sources: env-var
+// dumps, log lines, cURL -d bodies where the first field has no
+// leading & or ?.
+//
+// Note on whitespace: ForDLP strips ASCII control chars (including \n)
+// before the regex runs, so embedded newlines collapse adjacent text.
+// The positive cases below are limited to inputs that stay caught
+// after that normalization. The mid-text-after-random-prose case is
+// a known FN that this PR deliberately does not close (it would
+// re-trigger the Go struct-assignment FP the narrowing originally
+// fixed). Split literals keep GitGuardian quiet on the fixtures.
+func TestScanTextForDLP_CredentialInURL_CatchesBodyStart(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	longVal := "hunter" + "x" + "abcd"
+	tokenVal := "abc" + "def" + "1234"
+
+	positives := []string{
+		"password=" + longVal,          // body-start, no leading anything
+		"token=" + tokenVal,            // body-start, different key
+		"?foo=bar&password=" + longVal, // classic URL query (original path)
+		"; password=" + longVal,        // semicolon delimiter (cookie-style)
+	}
+	for _, s2 := range positives {
+		t.Run(s2, func(t *testing.T) {
+			result := s.ScanTextForDLP(context.Background(), s2)
+			if result.Clean {
+				t.Errorf("expected catch on %q, got clean", s2)
+			}
+		})
+	}
+}
+
+// TestScanTextForDLP_CredentialInURL_SkipsStructAssignment asserts the
+// narrowing from the earlier round is still in effect: Go struct-style
+// assignments where the credential key is preceded by a word-char or
+// dot must NOT trigger the pattern. Without this assertion a future
+// widening could accidentally re-introduce the tree-wide FP that the
+// narrowing closed.
+func TestScanTextForDLP_CredentialInURL_SkipsStructAssignment(t *testing.T) {
+	cfg := testConfig()
+	s := New(cfg)
+	defer s.Close()
+
+	longVal := "hunter" + "x" + "abcd"
+
+	// Go struct assignments — the credential key is preceded by `.` or
+	// another word char, not ^ or [?&;]. These must stay clean.
+	negatives := []string{
+		"ep.Token = " + longVal,
+		"req.APIKey = " + longVal,
+		"MyStruct{Password: " + longVal + "}",
+	}
+	for _, s2 := range negatives {
+		t.Run(s2, func(t *testing.T) {
+			result := s.ScanTextForDLP(context.Background(), s2)
+			// Accept either cleanly missed OR caught by a different
+			// pattern (e.g., entropy); just ensure the test name
+			// captures the intent rather than asserting the wrong
+			// pattern name.
+			for _, m := range result.Matches {
+				if m.PatternName == "Credential in URL" {
+					t.Errorf("expected Credential-in-URL to skip %q, but it matched", s2)
+				}
+			}
+		})
+	}
+}
+
 func TestScanTextForDLP_EthereumAddressOptIn(t *testing.T) {
 	cfg := testConfig()
 	cfg.DLP.Patterns = append(cfg.DLP.Patterns, config.DLPPattern{

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -1360,16 +1360,24 @@ func TestScanTextForDLP_CredentialInURL_NoFPOnGoAssignment(t *testing.T) {
 // the positive side of the rule: credentials in URL query strings are
 // still caught. Covers the ?, &, and ; delimiters for parity with how
 // browsers, form encoders, and connection strings carry parameters.
+// Fake-secret values are concatenated from split literals at runtime so
+// GitGuardian's hardcoded-password heuristic doesn't flag the fixtures
+// themselves as a leak (see also CLAUDE.md G101 guidance for gosec).
 func TestScanTextForDLP_CredentialInURL_StillCatchesQueryDelimiter(t *testing.T) {
 	cfg := testConfig()
 	s := New(cfg)
 	defer s.Close()
 
+	longVal := "super" + "secret" + "123"
+	tokenVal := "abc" + "def" + "123456"
+	dbPass := "hunter" + "x" + "abcd"
+	apiVal := "real" + "secret" + "123"
+
 	positives := []string{
-		"https://example.com/api?password=supersecret123",
-		"https://example.com/api?x=1&token=abcdef123456",
-		"jdbc:mysql://host/db;password=hunter2abcd",
-		"POSTed body: username=bob&apikey=realsecret123",
+		"https://example.com/api?password=" + longVal,
+		"https://example.com/api?x=1&token=" + tokenVal,
+		"jdbc:mysql://host/db;password=" + dbPass,
+		"POSTed body: username=bob&apikey=" + apiVal,
 	}
 	for _, s2 := range positives {
 		t.Run(s2, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `pipelock session` top-level command with `list`, `inspect`, `explain`, `release`, `terminate`, and interactive `recover` subcommands for operator-driven airlock recovery. Shared `--api-url`/`--api-token`/`--config` flags with a built-in resolver that falls through flag → env → pipelock config file (`kill_switch.api_listen` / `kill_switch.api_token`).
- Adds three new session admin API endpoints: `GET /api/v1/sessions/{key}` (full `SessionDetail` with tier entry time, in-flight count, and the most recent 20 notable events), `GET /api/v1/sessions/{key}/explain` (trigger, evidence, next auto-deescalation estimate; returns 200 for normal-tier sessions with a `session not quarantined` reason), and `POST /api/v1/sessions/{key}/terminate` (destructive full tear-down: fires cancel funcs, resets enforcement, clears CEE state). Each new endpoint has its own 10/minute rate-limit bucket.
- Adds an optional `?tier=` filter on `GET /api/v1/sessions` so operators can narrow list output to a specific airlock tier; `normal` is accepted as an alias for `none`.
- Stores airlock trigger and source on `AirlockState` at the moment of entry (`airlock_triggers`/`admin_api`/`airlock_timers` × `on_elevated`/`on_high`/`on_critical`/`manual`/`timer`) via new `SetTierWithProvenance`/`ForceSetTierWithProvenance` wrappers, so explain reports what actually happened instead of reverse-mapping from the current config. `SessionState` grows a bounded 20-event ring buffer that records scanner blocks, anomalies, and airlock transitions; inspect/explain read through a single `AdminSnapshotByKey` pass so they never return self-contradictory JSON under concurrent release or deescalation.
- Registers the new routes on both same-port and separate-port admin paths, extends the kill-switch exemption list, adds an `airlock:` section (disabled) to every preset config, and ships `docs/cli/session.md` with a recovery walkthrough plus an Airlock section in `docs/configuration.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pipelock session` CLI (list, inspect, explain, release, terminate, recover) and new Session Admin API endpoints; list supports tier filtering with `normal` alias and per-action rate limiting.

* **Documentation**
  * Expanded CLI and config docs for Session Admin API, Airlock tiers, token resolution, and recovery workflows.

* **Chores**
  * Added disabled-by-default Airlock config across presets; tightened DLP “Credential in URL” regex.

* **Tests**
  * Extensive unit and integration tests covering CLI, API, resolver, rendering, and airlock behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->