### PR TITLE
feat: pipelock init sidecar + agent identity default + exemption audit emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Features
 
 - Extend signed receipt emission to fetch handler error paths (audit-mode escalation, session profiling, header DLP, budget, CEE), WebSocket transport (handshake blocks, frame-level DLP/injection/address/CEE blocks, session close), and A2A transport in the forward proxy (header scan, stream scan, response body scan).
+- **Sidecar injection init:** `pipelock init sidecar --inject-spec <manifest>` generates a sidecar patch for Deployment, StatefulSet, Job, and CronJob workloads. Three output formats: strategic-merge patch, Kustomize overlay, and Helm values fragment. Includes canary verification, diff preview, and idempotent re-runs.
+- **Default agent identity:** new `default_agent_identity` config field provides a fallback agent name for sidecar deployments where the upstream container does not send an `X-Pipelock-Agent` header. Derived automatically from workload kind/name during `init sidecar`.
+- **Exemption audit emission:** response scan exemptions (exempt domains and suppressed findings) now emit a `pipelock_response_scan_exempt_total` Prometheus counter with `reason` and `transport` labels across all proxy transports.
 
 ### Security Hardening
 

--- a/charts/pipelock/templates/deployment.yaml
+++ b/charts/pipelock/templates/deployment.yaml
@@ -31,7 +31,11 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - run

--- a/charts/pipelock/templates/deployment.yaml
+++ b/charts/pipelock/templates/deployment.yaml
@@ -73,8 +73,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: /etc/pipelock/pipelock.yaml
-              subPath: pipelock.yaml
+              mountPath: /etc/pipelock
       volumes:
         - name: config
           configMap:

--- a/charts/pipelock/values.yaml
+++ b/charts/pipelock/values.yaml
@@ -3,6 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/luckypipewrench/pipelock
   tag: ""  # defaults to .Chart.AppVersion
+  digest: ""  # optional sha256 digest; when set, repository@digest is used
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/docs/cli/init-sidecar.md
+++ b/docs/cli/init-sidecar.md
@@ -1,0 +1,137 @@
+# pipelock init sidecar
+
+Inject a pipelock sidecar proxy into a Kubernetes workload manifest.
+
+## Synopsis
+
+```
+pipelock init sidecar --inject-spec <manifest>
+  [--emit patch|kustomize|helm-values]
+  [--output <path>]
+  [--dry-run]
+  [--force]
+  [--image <ref>]
+  [--preset strict|balanced|audit]
+  [--skip-canary]
+  [--skip-verify]
+  [--json]
+  [--agent-identity <name>]
+```
+
+## Description
+
+Reads a Kubernetes workload manifest (Deployment, StatefulSet, Job, or CronJob), detects the pod spec, and generates a sidecar injection patch that routes all container egress through pipelock.
+
+The patched manifest includes:
+
+- A `pipelock` sidecar container with health probes, resource limits, and a read-only security context
+- `HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY` environment variables on existing containers
+- A shared `pipelock-config` volume backed by a ConfigMap
+- A pod-scoped `NetworkPolicy` that allows DNS and standard web egress for the injected sidecar
+
+The command runs 7 phases: detect, generate, preview, emit, verify, canary, and summary.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--inject-spec` | (required) | Path to the Kubernetes workload manifest |
+| `--emit` | `patch` | Output format: `patch`, `kustomize`, or `helm-values` |
+| `--output`, `-o` | stdout | Output path (file or directory for kustomize) |
+| `--dry-run` | false | Show diff without writing files or running canary |
+| `--force` | false | Overwrite existing output files |
+| `--image` | `ghcr.io/luckypipewrench/pipelock:<version>` | Sidecar container image (tag or digest ref) |
+| `--preset` | `balanced` | Config preset: `strict`, `balanced`, `audit` |
+| `--skip-canary` | false | Skip the canary detection test |
+| `--skip-verify` | false | Skip post-apply sidecar verification |
+| `--json` | false | Machine-readable JSON output (`--output` required unless `--dry-run`) |
+| `--agent-identity` | `<kind>/<name>` | Default agent identity for attribution |
+
+## Supported Workload Kinds
+
+| Kind | Pod spec location |
+|------|-------------------|
+| Deployment | `spec.template.spec` |
+| StatefulSet | `spec.template.spec` |
+| Job | `spec.template.spec` |
+| CronJob | `spec.jobTemplate.spec.template.spec` |
+
+## Output Formats
+
+### patch (default)
+
+Writes the full patched manifest as multi-document YAML: the workload, a ConfigMap, and a NetworkPolicy.
+
+```bash
+pipelock init sidecar --inject-spec deployment.yaml --output patched.yaml
+kubectl apply -f patched.yaml
+```
+
+### kustomize
+
+Writes a standalone directory containing the original workload manifest, the sidecar patch, ConfigMap, NetworkPolicy, and `kustomization.yaml`.
+
+```bash
+pipelock init sidecar --inject-spec deployment.yaml --emit kustomize --output ./pipelock-overlay
+kubectl apply -k ./pipelock-overlay
+```
+
+### helm-values
+
+Writes a `values.yaml` fragment targeting the pipelock Helm chart.
+
+```bash
+pipelock init sidecar --inject-spec deployment.yaml --emit helm-values --output values-pipelock.yaml
+helm upgrade --install pipelock pipelock/pipelock -f values-pipelock.yaml
+```
+
+## Examples
+
+### Deployment (dry run)
+
+```bash
+pipelock init sidecar --inject-spec deployment.yaml --dry-run
+```
+
+### StatefulSet with strict preset
+
+```bash
+pipelock init sidecar --inject-spec statefulset.yaml --preset strict --output patched.yaml
+```
+
+### Job with custom agent identity
+
+```bash
+pipelock init sidecar --inject-spec job.yaml --agent-identity ci-team/nightly-scan
+```
+
+### CronJob with kustomize output
+
+```bash
+pipelock init sidecar --inject-spec cronjob.yaml --emit kustomize --output ./overlay
+```
+
+### Machine-readable output
+
+```bash
+pipelock init sidecar --inject-spec deployment.yaml --dry-run --json
+```
+
+## Agent Identity
+
+In sidecar mode, requests are attributed to a default agent identity derived from the workload:
+
+- `deployment/my-agent` for a Deployment named `my-agent`
+- `statefulset/my-db` for a StatefulSet named `my-db`
+
+Override with `--agent-identity`. The identity is written to the generated ConfigMap as `default_agent_identity` and appears in audit logs, receipts, and metrics instead of `anonymous`.
+
+Resolution precedence: `X-Pipelock-Agent` header > `?agent=` query param > `default_agent_identity` config > `anonymous`.
+
+## NetworkPolicy Semantics
+
+The generated `NetworkPolicy` is pod-scoped because Kubernetes policies apply to pods, not individual containers. That means it cannot enforce "app container may only talk to the sidecar" inside the same pod. Instead, the generated policy keeps sidecar mode functional by allowing DNS plus standard web egress for the selected workload pods.
+
+## Idempotency
+
+Running `pipelock init sidecar` against a manifest that already has a `pipelock` sidecar container produces no changes. The command detects the existing container and reports "already patched".

--- a/docs/cli/init-sidecar.md
+++ b/docs/cli/init-sidecar.md
@@ -1,10 +1,10 @@
 # pipelock init sidecar
 
-Inject a pipelock sidecar proxy into a Kubernetes workload manifest.
+Generate an enforced pipelock companion proxy for a Kubernetes workload.
 
 ## Synopsis
 
-```
+```bash
 pipelock init sidecar --inject-spec <manifest>
   [--emit patch|kustomize|helm-values]
   [--output <path>]
@@ -20,14 +20,19 @@ pipelock init sidecar --inject-spec <manifest>
 
 ## Description
 
-Reads a Kubernetes workload manifest (Deployment, StatefulSet, Job, or CronJob), detects the pod spec, and generates a sidecar injection patch that routes all container egress through pipelock.
+`pipelock init sidecar` reads a Kubernetes workload manifest (Deployment, StatefulSet, Job, or CronJob), patches the workload to use a companion pipelock proxy Service, and emits the extra Kubernetes resources needed to enforce that topology.
 
-The patched manifest includes:
+The generated bundle includes:
 
-- A `pipelock` sidecar container with health probes, resource limits, and a read-only security context
-- `HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY` environment variables on existing containers
-- A shared `pipelock-config` volume backed by a ConfigMap
-- A pod-scoped `NetworkPolicy` that allows DNS and standard web egress for the injected sidecar
+- The patched agent workload with `HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY` pointing at the companion Service
+- A pipelock ConfigMap with forward proxy mode enabled
+- A companion pipelock Deployment with two replicas, anti-affinity, and production-oriented resource defaults
+- A companion pipelock Service
+- An agent NetworkPolicy that limits agent pod egress to DNS plus the pipelock proxy
+- A proxy NetworkPolicy that allows agent ingress and standard web egress for the pipelock proxy pods
+- A PodDisruptionBudget that keeps at least one proxy replica available during voluntary disruptions
+
+This is not same-pod sidecar injection. The enforcement boundary comes from pod-scoped NetworkPolicies plus a separate pipelock proxy workload, not from trusting application containers to honor proxy environment variables on their own.
 
 The command runs 7 phases: detect, generate, preview, emit, verify, canary, and summary.
 
@@ -37,13 +42,13 @@ The command runs 7 phases: detect, generate, preview, emit, verify, canary, and 
 |------|---------|-------------|
 | `--inject-spec` | (required) | Path to the Kubernetes workload manifest |
 | `--emit` | `patch` | Output format: `patch`, `kustomize`, or `helm-values` |
-| `--output`, `-o` | stdout | Output path (file or directory for kustomize) |
-| `--dry-run` | false | Show diff without writing files or running canary |
+| `--output`, `-o` | stdout for `patch`; directory required for `kustomize` and `helm-values` | Output path |
+| `--dry-run` | false | Show the generated topology without writing files or running canary |
 | `--force` | false | Overwrite existing output files |
-| `--image` | `ghcr.io/luckypipewrench/pipelock:<version>` | Sidecar container image (tag or digest ref) |
+| `--image` | `ghcr.io/luckypipewrench/pipelock:<version>` | Companion proxy image (tag or digest ref) |
 | `--preset` | `balanced` | Config preset: `strict`, `balanced`, `audit` |
 | `--skip-canary` | false | Skip the canary detection test |
-| `--skip-verify` | false | Skip post-apply sidecar verification |
+| `--skip-verify` | false | Skip static topology verification |
 | `--json` | false | Machine-readable JSON output (`--output` required unless `--dry-run`) |
 | `--agent-identity` | `<kind>/<name>` | Default agent identity for attribution |
 
@@ -60,16 +65,35 @@ The command runs 7 phases: detect, generate, preview, emit, verify, canary, and 
 
 ### patch (default)
 
-Writes the full patched manifest as multi-document YAML: the workload, a ConfigMap, and a NetworkPolicy.
+Writes the full enforced topology as multi-document YAML:
+
+1. Patched agent workload
+2. Pipelock ConfigMap
+3. Pipelock Deployment
+4. Pipelock Service
+5. Agent NetworkPolicy
+6. Pipelock NetworkPolicy
+7. Pipelock PodDisruptionBudget
 
 ```bash
-pipelock init sidecar --inject-spec deployment.yaml --output patched.yaml
-kubectl apply -f patched.yaml
+pipelock init sidecar --inject-spec deployment.yaml --output enforced.yaml
+kubectl apply -f enforced.yaml
 ```
 
 ### kustomize
 
-Writes a standalone directory containing the original workload manifest, the sidecar patch, ConfigMap, NetworkPolicy, and `kustomization.yaml`.
+Writes a standalone directory with the emitted resources and `kustomization.yaml`.
+
+Generated files:
+
+- `agent-workload.yaml`
+- `pipelock-configmap.yaml`
+- `pipelock-deployment.yaml`
+- `pipelock-service.yaml`
+- `agent-networkpolicy.yaml`
+- `pipelock-networkpolicy.yaml`
+- `pipelock-pdb.yaml`
+- `kustomization.yaml`
 
 ```bash
 pipelock init sidecar --inject-spec deployment.yaml --emit kustomize --output ./pipelock-overlay
@@ -78,11 +102,25 @@ kubectl apply -k ./pipelock-overlay
 
 ### helm-values
 
-Writes a `values.yaml` fragment targeting the pipelock Helm chart.
+Writes a Helm bundle directory for the pipelock chart plus the agent workload and NetworkPolicies that stay outside the chart.
+
+Generated files:
+
+- `values.yaml`
+- `agent-workload.yaml`
+- `agent-networkpolicy.yaml`
+- `pipelock-networkpolicy.yaml`
+- `pipelock-pdb.yaml`
+- `README.txt`
 
 ```bash
-pipelock init sidecar --inject-spec deployment.yaml --emit helm-values --output values-pipelock.yaml
-helm upgrade --install pipelock pipelock/pipelock -f values-pipelock.yaml
+pipelock init sidecar --inject-spec deployment.yaml --emit helm-values --output ./pipelock-bundle
+helm upgrade --install my-agent-pipelock pipelock/pipelock -f ./pipelock-bundle/values.yaml
+kubectl rollout status deployment/my-agent-pipelock
+kubectl apply -f ./pipelock-bundle/pipelock-networkpolicy.yaml \
+  -f ./pipelock-bundle/pipelock-pdb.yaml
+kubectl apply -f ./pipelock-bundle/agent-networkpolicy.yaml
+kubectl apply -f ./pipelock-bundle/agent-workload.yaml
 ```
 
 ## Examples
@@ -96,7 +134,7 @@ pipelock init sidecar --inject-spec deployment.yaml --dry-run
 ### StatefulSet with strict preset
 
 ```bash
-pipelock init sidecar --inject-spec statefulset.yaml --preset strict --output patched.yaml
+pipelock init sidecar --inject-spec statefulset.yaml --preset strict --output enforced.yaml
 ```
 
 ### Job with custom agent identity
@@ -119,19 +157,43 @@ pipelock init sidecar --inject-spec deployment.yaml --dry-run --json
 
 ## Agent Identity
 
-In sidecar mode, requests are attributed to a default agent identity derived from the workload:
+Requests are attributed to a default agent identity derived from the workload:
 
 - `deployment/my-agent` for a Deployment named `my-agent`
 - `statefulset/my-db` for a StatefulSet named `my-db`
 
-Override with `--agent-identity`. The identity is written to the generated ConfigMap as `default_agent_identity` and appears in audit logs, receipts, and metrics instead of `anonymous`.
+Override with `--agent-identity`. The identity is written into the generated pipelock config as `default_agent_identity` and appears in audit logs, receipts, and metrics instead of `anonymous`.
 
-Resolution precedence: `X-Pipelock-Agent` header > `?agent=` query param > `default_agent_identity` config > `anonymous`.
+The generated companion config also sets `bind_default_agent_identity: true`, which makes the deployment single-workload and operator-bound: caller-supplied `X-Pipelock-Agent` headers and `?agent=` query parameters are ignored.
+
+Companion-mode precedence: context override (unused in this topology) > `default_agent_identity` config > `anonymous`.
+
+## Verification
+
+The verify phase is static. It confirms the generated topology has the expected companion resources and boundary settings:
+
+- forward proxy mode enabled
+- cluster-reachable proxy listeners
+- agent NetworkPolicy allows DNS plus the pipelock proxy port only
+- proxy NetworkPolicy allows agent ingress and standard web egress
+
+The canary phase runs locally against the generated config to confirm DLP blocks a synthetic secret. It validates generated policy coverage, not the live cluster deployment.
 
 ## NetworkPolicy Semantics
 
-The generated `NetworkPolicy` is pod-scoped because Kubernetes policies apply to pods, not individual containers. That means it cannot enforce "app container may only talk to the sidecar" inside the same pod. Instead, the generated policy keeps sidecar mode functional by allowing DNS plus standard web egress for the selected workload pods.
+The enforcement claim for this command depends on Kubernetes NetworkPolicy egress enforcement being active in your cluster. If your CNI does not enforce egress policies, the generated manifests still configure the companion proxy correctly, but the cluster will not provide the intended direct-egress boundary.
+
+For existing workloads, roll the companion proxy out first and wait for ready endpoints before patching the agent workload. The Helm bundle output includes that order explicitly to avoid a fail-closed brownout while the proxy Deployment is still starting.
+
+Within a cluster that enforces egress NetworkPolicies, the agent pods are limited to:
+
+- DNS
+- The pipelock companion Service on port `8888`
+
+Direct `80/443` web egress is reserved for the pipelock companion pods, not the agent workload.
+
+DNS egress is intentionally left unrestricted at the NetworkPolicy layer for cluster portability. This command does not block DNS tunneling by policy alone.
 
 ## Idempotency
 
-Running `pipelock init sidecar` against a manifest that already has a `pipelock` sidecar container produces no changes. The command detects the existing container and reports "already patched".
+Running `pipelock init sidecar` against a manifest already managed by this command is safe. The workload annotations preserve the generated proxy identity, the command reports the manifest as already patched, and verification can still be rerun against the derived topology.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1097,19 +1097,24 @@ The core principle: the model won't protect you, so the network layer must.
 
 ## Default Agent Identity
 
-When pipelock runs as a sidecar, incoming requests typically lack the `X-Pipelock-Agent` header because the upstream container sends traffic through `HTTPS_PROXY` without identity headers. Set `default_agent_identity` so sidecar traffic is attributed to the workload rather than showing as `anonymous` in logs, receipts, and metrics.
+When pipelock runs behind a workload-local proxy configuration, incoming requests typically lack the `X-Pipelock-Agent` header because the upstream container sends traffic through `HTTPS_PROXY` without identity headers. Set `default_agent_identity` so that traffic is attributed to the workload rather than showing as `anonymous` in logs, receipts, and metrics.
 
 ```yaml
 default_agent_identity: "deployment/my-agent"
 ```
 
-Resolution precedence: `X-Pipelock-Agent` header > `?agent=` query param > `default_agent_identity` > `anonymous`.
+If you also set `bind_default_agent_identity: true`, pipelock ignores caller-supplied `X-Pipelock-Agent` headers and `?agent=` query params and binds all traffic on that listener to the configured default identity. This is the recommended mode for the generated `pipelock init sidecar` companion topology.
 
-`pipelock init sidecar` sets this automatically from the workload kind and name (e.g., `deployment/my-agent`). Override with `--agent-identity`.
+Resolution precedence with binding disabled: `X-Pipelock-Agent` header > `default_agent_identity` > `?agent=` query param > `anonymous`.
+
+Resolution precedence with binding enabled: context override > `default_agent_identity` > `anonymous`.
+
+`pipelock init sidecar` sets both fields automatically from the workload kind and name (e.g., `deployment/my-agent`). Override the identity with `--agent-identity`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `default_agent_identity` | `string` | `""` (anonymous) | Fallback agent name when no header or query param is present |
+| `default_agent_identity` | `string` | `""` (anonymous) | Operator-configured agent name used when no stronger identity source resolves the caller |
+| `bind_default_agent_identity` | `bool` | `false` | Ignore caller-supplied `X-Pipelock-Agent` and `?agent=` values and bind requests to `default_agent_identity` |
 
 ## Agent Profiles
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1105,7 +1105,9 @@ default_agent_identity: "deployment/my-agent"
 
 If you also set `bind_default_agent_identity: true`, pipelock ignores caller-supplied `X-Pipelock-Agent` headers and `?agent=` query params and binds all traffic on that listener to the configured default identity. This is the recommended mode for the generated `pipelock init sidecar` companion topology.
 
-Resolution precedence with binding disabled: `X-Pipelock-Agent` header > `default_agent_identity` > `?agent=` query param > `anonymous`.
+These precedences apply to default-identity resolution after listener-level and source-CIDR resolution have been evaluated. They do not override an agent profile that matched on listener address or source CIDR.
+
+Resolution precedence with binding disabled: context override > `X-Pipelock-Agent` header > `default_agent_identity` > `?agent=` query param > `anonymous`.
 
 Resolution precedence with binding enabled: context override > `default_agent_identity` > `anonymous`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1095,6 +1095,22 @@ What it enables beyond `strict`:
 
 The core principle: the model won't protect you, so the network layer must.
 
+## Default Agent Identity
+
+When pipelock runs as a sidecar, incoming requests typically lack the `X-Pipelock-Agent` header because the upstream container sends traffic through `HTTPS_PROXY` without identity headers. Set `default_agent_identity` so sidecar traffic is attributed to the workload rather than showing as `anonymous` in logs, receipts, and metrics.
+
+```yaml
+default_agent_identity: "deployment/my-agent"
+```
+
+Resolution precedence: `X-Pipelock-Agent` header > `?agent=` query param > `default_agent_identity` > `anonymous`.
+
+`pipelock init sidecar` sets this automatically from the workload kind and name (e.g., `deployment/my-agent`). Override with `--agent-identity`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `default_agent_identity` | `string` | `""` (anonymous) | Fallback agent name when no header or query param is present |
+
 ## Agent Profiles
 
 Per-agent policy overrides. When multiple agents share one pipelock instance, each agent can have its own mode, allowlist, DLP patterns, rate limits, and request budgets. Scalar fields (mode, enforce) inherit from the base config when unset. `mcp_tool_policy` replaces the base section entirely when set on an agent profile (no deep merge). `session_profiling` replaces the per-agent fields (`domain_burst`, `anomaly_action`, `volume_spike_ratio`) unconditionally while preserving global-only fields (`max_sessions`, `session_ttl_minutes`, `cleanup_interval_seconds`). `rate_limit` overrides individual rate limit fields (non-zero values win). DLP merging follows separate rules (see below).

--- a/enterprise/registry.go
+++ b/enterprise/registry.go
@@ -174,7 +174,7 @@ func (r *AgentRegistry) ResolveFromRequest(ctx context.Context, req *http.Reques
 	for _, name := range profiles {
 		known[name] = true
 	}
-	id := edition.ResolveAgentIdentity(req, known)
+	id := edition.ResolveAgentIdentity(req, known, defaultCfg.DefaultAgentIdentity)
 	return r.Lookup(id.Profile), id
 }
 

--- a/enterprise/registry.go
+++ b/enterprise/registry.go
@@ -174,7 +174,7 @@ func (r *AgentRegistry) ResolveFromRequest(ctx context.Context, req *http.Reques
 	for _, name := range profiles {
 		known[name] = true
 	}
-	id := edition.ResolveAgentIdentity(req, known, defaultCfg.DefaultAgentIdentity)
+	id := edition.ResolveAgentIdentity(req, known, defaultCfg.DefaultAgentIdentity, defaultCfg.BindDefaultAgentIdentity)
 	return r.Lookup(id.Profile), id
 }
 

--- a/internal/cli/runtime/run_test.go
+++ b/internal/cli/runtime/run_test.go
@@ -587,7 +587,7 @@ func TestAgentHandler(t *testing.T) {
 	var resolved edition.AgentIdentity
 
 	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		resolved = edition.ResolveAgentIdentity(r, map[string]bool{testProfile: true}, "")
+		resolved = edition.ResolveAgentIdentity(r, map[string]bool{testProfile: true}, "", false)
 	})
 
 	handler := AgentHandler(testProfile, inner)

--- a/internal/cli/runtime/run_test.go
+++ b/internal/cli/runtime/run_test.go
@@ -587,7 +587,7 @@ func TestAgentHandler(t *testing.T) {
 	var resolved edition.AgentIdentity
 
 	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		resolved = edition.ResolveAgentIdentity(r, map[string]bool{testProfile: true})
+		resolved = edition.ResolveAgentIdentity(r, map[string]bool{testProfile: true}, "")
 	})
 
 	handler := AgentHandler(testProfile, inner)

--- a/internal/cli/setup/init.go
+++ b/internal/cli/setup/init.go
@@ -122,6 +122,8 @@ Examples:
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "machine-readable JSON output")
 	cmd.Flags().StringVar(&scanHome, "scan-home", "", "override home directory for discovery (default: $HOME)")
 
+	cmd.AddCommand(SidecarCmd())
+
 	return cmd
 }
 
@@ -346,7 +348,7 @@ func buildConfig(preset string, report *discover.Report) *config.Config {
 	}
 
 	// Enable MCP scanning if MCP servers were discovered.
-	if report.Summary.TotalServers > 0 {
+	if report != nil && report.Summary.TotalServers > 0 {
 		cfg.MCPInputScanning.Enabled = true
 		cfg.MCPInputScanning.Action = config.ActionWarn
 		cfg.MCPToolScanning.Enabled = true
@@ -355,7 +357,7 @@ func buildConfig(preset string, report *discover.Report) *config.Config {
 	}
 
 	// Enable tool chain detection for larger MCP installations.
-	if report.Summary.TotalServers > 3 {
+	if report != nil && report.Summary.TotalServers > 3 {
 		cfg.ToolChainDetection.Enabled = true
 		cfg.ToolChainDetection.Action = config.ActionWarn
 		cfg.ToolChainDetection.WindowSize = 20

--- a/internal/cli/setup/sidecar.go
+++ b/internal/cli/setup/sidecar.go
@@ -5,6 +5,7 @@ package setup
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -59,24 +60,24 @@ func SidecarCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "sidecar",
-		Short: "Inject a pipelock sidecar into a Kubernetes workload manifest",
-		Long: `Generate a pipelock sidecar injection patch for Kubernetes workloads.
+		Short: "Generate an enforced pipelock companion proxy for a Kubernetes workload",
+		Long: `Generate an enforced companion-proxy topology for Kubernetes workloads.
 
 Supported workload kinds: Deployment, StatefulSet, Job, CronJob.
 
 Phases:
   1. Detect:   parse the input manifest, identify workload kind
-  2. Generate: build the sidecar patch (container, volumes, env, probes)
-  3. Preview:  show a unified diff of changes
-  4. Apply:    write the patched manifest (or emit kustomize/helm-values)
-  5. Verify:   check sidecar health via port-forward (skippable)
+  2. Generate: patch the agent workload and build companion proxy resources
+  3. Preview:  show the workload diff plus generated companion resources
+  4. Apply:    write the enforced topology bundle
+  5. Verify:   statically verify proxy config and network policy boundaries
   6. Canary:   inject a synthetic secret and confirm DLP catches it
   7. Summary:  show results
 
 Examples:
   pipelock init sidecar --inject-spec deployment.yaml --dry-run
   pipelock init sidecar --inject-spec deployment.yaml --emit kustomize --output ./pipelock-overlay
-  pipelock init sidecar --inject-spec statefulset.yaml --emit helm-values --output values-override.yaml
+  pipelock init sidecar --inject-spec statefulset.yaml --emit helm-values --output ./pipelock-helm-bundle
   pipelock init sidecar --inject-spec cronjob.yaml --preset strict --agent-identity my-team/bot`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -90,10 +91,10 @@ Examples:
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "", "output path (default: stdout)")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "show diff without writing files or running canary")
 	cmd.Flags().BoolVar(&opts.force, "force", false, "overwrite existing output files")
-	cmd.Flags().StringVar(&opts.image, "image", "", "sidecar image (default: ghcr.io/luckypipewrench/pipelock:<version>)")
+	cmd.Flags().StringVar(&opts.image, "image", "", "companion proxy image (default: ghcr.io/luckypipewrench/pipelock:<version>)")
 	cmd.Flags().StringVar(&opts.preset, "preset", config.ModeBalanced, "config preset: strict, balanced, audit")
 	cmd.Flags().BoolVar(&opts.skipCanary, "skip-canary", false, "skip the canary detection test")
-	cmd.Flags().BoolVar(&opts.skipVerify, "skip-verify", false, "skip post-apply verification")
+	cmd.Flags().BoolVar(&opts.skipVerify, "skip-verify", false, "skip static topology verification")
 	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "machine-readable JSON output")
 	cmd.Flags().StringVar(&opts.agentIdentity, "agent-identity", "", "default agent identity (default: <kind>/<name>)")
 
@@ -138,11 +139,7 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 		return cliutil.ExitCodeError(initExitError, err)
 	}
 
-	podSpec, err := getPodSpec(manifest.Raw, manifest.Kind)
-	if err != nil {
-		return cliutil.ExitCodeError(initExitError, err)
-	}
-	alreadyPatched := hasPipelockContainer(podSpec)
+	alreadyPatched := hasPipelockTopology(manifest.Raw)
 
 	result.Detect = &sidecarDetectResult{
 		Kind:           manifest.Kind,
@@ -154,14 +151,14 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 		_, _ = fmt.Fprintf(w, "  Kind: %s\n", manifest.Kind)
 		_, _ = fmt.Fprintf(w, "  Name: %s\n", manifest.Name)
 		if alreadyPatched {
-			_, _ = fmt.Fprintln(w, "  Status: already patched (pipelock container found)")
+			_, _ = fmt.Fprintln(w, "  Status: already patched (companion proxy annotations found)")
 		}
 		_, _ = fmt.Fprintln(w)
 	}
 
 	// Phase 2: Generate
 	if !opts.jsonOutput {
-		_, _ = fmt.Fprintln(w, "[2/7] Generating sidecar patch...")
+		_, _ = fmt.Fprintln(w, "[2/7] Generating companion proxy topology...")
 	}
 
 	patchResult, err := generateSidecarPatch(manifest, opts)
@@ -171,6 +168,8 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 
 	if !opts.jsonOutput {
 		_, _ = fmt.Fprintf(w, "  Agent identity: %s\n", patchResult.AgentIdentity)
+		_, _ = fmt.Fprintf(w, "  Proxy name: %s\n", patchResult.ProxyName)
+		_, _ = fmt.Fprintf(w, "  Proxy URL: %s\n", patchResult.ProxyURL)
 		_, _ = fmt.Fprintf(w, "  Image: %s\n", resolveImage(opts))
 		_, _ = fmt.Fprintf(w, "  Preset: %s\n\n", opts.preset)
 	}
@@ -235,7 +234,7 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 
 	// Phase 5: Verify (skipped in dry-run)
 	if !opts.jsonOutput {
-		_, _ = fmt.Fprintln(w, "[5/7] Verifying sidecar...")
+		_, _ = fmt.Fprintln(w, "[5/7] Verifying enforced topology...")
 	}
 	if opts.dryRun {
 		result.Verify = &sidecarVerifyResult{Skipped: true, Detail: "skipped (--dry-run)"}
@@ -243,7 +242,7 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 			_, _ = fmt.Fprintln(w, "  Skipped (--dry-run)")
 		}
 	} else {
-		result.Verify = runSidecarVerify(w, opts, opts.jsonOutput)
+		result.Verify = runSidecarVerify(w, patchResult, opts, opts.jsonOutput)
 		if !opts.jsonOutput {
 			_, _ = fmt.Fprintln(w)
 		}
@@ -259,14 +258,20 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 			_, _ = fmt.Fprintln(w, "  Skipped (--dry-run)")
 		}
 	} else {
-		cfg := buildConfig(opts.preset, nil)
-		result.Canary = runSidecarCanary(w, cfg, opts, opts.jsonOutput)
+		result.Canary = runSidecarCanary(w, patchResult.Config, opts, opts.jsonOutput)
 		if !opts.jsonOutput {
 			if result.Canary.Detected {
 				_, _ = fmt.Fprintln(w, "  Canary secret detected in URL scan. DLP is working.")
 			}
 			_, _ = fmt.Fprintln(w)
 		}
+	}
+
+	if result.Verify != nil && !result.Verify.Skipped && !result.Verify.Healthy {
+		return &cliutil.ExitError{Err: errors.New(result.Verify.Detail), Code: initExitFailure}
+	}
+	if result.Canary != nil && !result.Canary.Skipped && !result.Canary.Detected {
+		return &cliutil.ExitError{Err: fmt.Errorf("canary secret was not detected by DLP"), Code: initExitFailure}
 	}
 
 	// Phase 7: Summary
@@ -312,6 +317,14 @@ func renderDiff(manifest *workloadManifest, patchResult *sidecarPatchResult) (st
 		}
 	}
 
+	if patchResult.ProxyName != "" {
+		_, _ = fmt.Fprintf(&sb, "  + companion Deployment: %s\n", patchResult.ProxyName)
+		_, _ = fmt.Fprintf(&sb, "  + companion Service: %s\n", patchResult.ProxyName)
+		_, _ = fmt.Fprintln(&sb, "  + agent NetworkPolicy: DNS + proxy-only egress")
+		_, _ = fmt.Fprintln(&sb, "  + proxy NetworkPolicy: agent ingress + web-only egress")
+		_, _ = fmt.Fprintln(&sb, "  + companion PodDisruptionBudget: minAvailable=1")
+	}
+
 	if sb.Len() == 0 {
 		return "  (no changes)", nil
 	}
@@ -344,6 +357,8 @@ func printSidecarSummary(w io.Writer, result *sidecarResult, opts sidecarOptions
 			_, _ = fmt.Fprintln(w, "  Verify:          skipped")
 		} else if result.Verify.Healthy {
 			_, _ = fmt.Fprintln(w, "  Verify:          healthy")
+		} else {
+			_, _ = fmt.Fprintf(w, "  Verify:          %s\n", result.Verify.Detail)
 		}
 	}
 
@@ -371,14 +386,18 @@ func printSidecarSummary(w io.Writer, result *sidecarResult, opts sidecarOptions
 		}
 	case emitHelmValues:
 		if result.Patch.OutputPath != "" {
-			_, _ = fmt.Fprintf(w, "  helm upgrade --install pipelock pipelock/pipelock -f %s\n", result.Patch.OutputPath)
+			_, _ = fmt.Fprintf(w, "  helm upgrade --install <release-name> pipelock/pipelock -f %s/values.yaml\n", result.Patch.OutputPath)
+			_, _ = fmt.Fprintln(w, "  kubectl rollout status deployment/<release-name>")
+			_, _ = fmt.Fprintf(w, "  kubectl apply -f %s/pipelock-networkpolicy.yaml -f %s/pipelock-pdb.yaml\n", result.Patch.OutputPath, result.Patch.OutputPath)
+			_, _ = fmt.Fprintf(w, "  kubectl apply -f %s/agent-networkpolicy.yaml\n", result.Patch.OutputPath)
+			_, _ = fmt.Fprintf(w, "  kubectl apply -f %s/agent-workload.yaml\n", result.Patch.OutputPath)
 		} else {
-			_, _ = fmt.Fprintln(w, "  helm upgrade --install pipelock pipelock/pipelock -f <values-file>")
+			_, _ = fmt.Fprintln(w, "  helm upgrade --install <release-name> pipelock/pipelock -f <bundle-dir>/values.yaml")
 		}
 	default:
 		_, _ = fmt.Fprintln(w, "  kubectl apply -f <patched-manifest>")
 	}
-	_, _ = fmt.Fprintln(w, "  kubectl port-forward <pod> 8888:8888")
-	_, _ = fmt.Fprintln(w, "  curl http://localhost:8888/health")
+	_, _ = fmt.Fprintln(w, "  kubectl get networkpolicy")
+	_, _ = fmt.Fprintln(w, "  kubectl port-forward deploy/<proxy-name> 8888:8888")
 	_, _ = fmt.Fprintln(w)
 }

--- a/internal/cli/setup/sidecar.go
+++ b/internal/cli/setup/sidecar.go
@@ -1,0 +1,384 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// sidecarOptions holds all flags for the sidecar subcommand.
+type sidecarOptions struct {
+	injectSpec    string
+	emit          string
+	output        string
+	dryRun        bool
+	force         bool
+	image         string
+	preset        string
+	skipCanary    bool
+	skipVerify    bool
+	jsonOutput    bool
+	agentIdentity string
+}
+
+// sidecarResult holds the outcome of each phase for JSON reporting.
+type sidecarResult struct {
+	Detect *sidecarDetectResult `json:"detect"`
+	Patch  *sidecarPatchSummary `json:"patch"`
+	Verify *sidecarVerifyResult `json:"verify,omitempty"`
+	Canary *sidecarCanaryResult `json:"canary,omitempty"`
+}
+
+type sidecarDetectResult struct {
+	Kind           string `json:"kind"`
+	Name           string `json:"name"`
+	AlreadyPatched bool   `json:"already_patched"`
+}
+
+type sidecarPatchSummary struct {
+	EmitFormat    string `json:"emit_format"`
+	OutputPath    string `json:"output_path,omitempty"`
+	AgentIdentity string `json:"agent_identity"`
+	Written       bool   `json:"written"`
+	DryRun        bool   `json:"dry_run"`
+}
+
+// SidecarCmd returns the "pipelock init sidecar" subcommand.
+func SidecarCmd() *cobra.Command {
+	var opts sidecarOptions
+
+	cmd := &cobra.Command{
+		Use:   "sidecar",
+		Short: "Inject a pipelock sidecar into a Kubernetes workload manifest",
+		Long: `Generate a pipelock sidecar injection patch for Kubernetes workloads.
+
+Supported workload kinds: Deployment, StatefulSet, Job, CronJob.
+
+Phases:
+  1. Detect:   parse the input manifest, identify workload kind
+  2. Generate: build the sidecar patch (container, volumes, env, probes)
+  3. Preview:  show a unified diff of changes
+  4. Apply:    write the patched manifest (or emit kustomize/helm-values)
+  5. Verify:   check sidecar health via port-forward (skippable)
+  6. Canary:   inject a synthetic secret and confirm DLP catches it
+  7. Summary:  show results
+
+Examples:
+  pipelock init sidecar --inject-spec deployment.yaml --dry-run
+  pipelock init sidecar --inject-spec deployment.yaml --emit kustomize --output ./pipelock-overlay
+  pipelock init sidecar --inject-spec statefulset.yaml --emit helm-values --output values-override.yaml
+  pipelock init sidecar --inject-spec cronjob.yaml --preset strict --agent-identity my-team/bot`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSidecar(cmd, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.injectSpec, "inject-spec", "", "path to the Kubernetes workload manifest (required)")
+	cmd.Flags().StringVar(&opts.emit, "emit", emitPatch, "output format: patch, kustomize, helm-values")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "", "output path (default: stdout)")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "show diff without writing files or running canary")
+	cmd.Flags().BoolVar(&opts.force, "force", false, "overwrite existing output files")
+	cmd.Flags().StringVar(&opts.image, "image", "", "sidecar image (default: ghcr.io/luckypipewrench/pipelock:<version>)")
+	cmd.Flags().StringVar(&opts.preset, "preset", config.ModeBalanced, "config preset: strict, balanced, audit")
+	cmd.Flags().BoolVar(&opts.skipCanary, "skip-canary", false, "skip the canary detection test")
+	cmd.Flags().BoolVar(&opts.skipVerify, "skip-verify", false, "skip post-apply verification")
+	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "machine-readable JSON output")
+	cmd.Flags().StringVar(&opts.agentIdentity, "agent-identity", "", "default agent identity (default: <kind>/<name>)")
+
+	_ = cmd.MarkFlagRequired("inject-spec")
+
+	return cmd
+}
+
+func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
+	w := cmd.OutOrStdout()
+
+	// Validate preset.
+	switch opts.preset {
+	case config.ModeStrict, config.ModeBalanced, config.ModeAudit:
+		// valid
+	default:
+		return cliutil.ExitCodeError(initExitError,
+			fmt.Errorf("unknown preset %q: choose strict, balanced, or audit", opts.preset))
+	}
+
+	// Validate emit format.
+	switch opts.emit {
+	case emitPatch, emitKustomize, emitHelmValues:
+		// valid
+	default:
+		return cliutil.ExitCodeError(initExitError,
+			fmt.Errorf("unknown emit format %q: choose patch, kustomize, or helm-values", opts.emit))
+	}
+
+	result := &sidecarResult{}
+
+	// Phase 1: Detect
+	if !opts.jsonOutput {
+		_, _ = fmt.Fprintln(w, "Pipelock Sidecar Init")
+		_, _ = fmt.Fprintln(w, "=====================")
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w, "[1/7] Detecting workload type...")
+	}
+
+	manifest, err := detectWorkload(opts.injectSpec)
+	if err != nil {
+		return cliutil.ExitCodeError(initExitError, err)
+	}
+
+	podSpec, err := getPodSpec(manifest.Raw, manifest.Kind)
+	if err != nil {
+		return cliutil.ExitCodeError(initExitError, err)
+	}
+	alreadyPatched := hasPipelockContainer(podSpec)
+
+	result.Detect = &sidecarDetectResult{
+		Kind:           manifest.Kind,
+		Name:           manifest.Name,
+		AlreadyPatched: alreadyPatched,
+	}
+
+	if !opts.jsonOutput {
+		_, _ = fmt.Fprintf(w, "  Kind: %s\n", manifest.Kind)
+		_, _ = fmt.Fprintf(w, "  Name: %s\n", manifest.Name)
+		if alreadyPatched {
+			_, _ = fmt.Fprintln(w, "  Status: already patched (pipelock container found)")
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+
+	// Phase 2: Generate
+	if !opts.jsonOutput {
+		_, _ = fmt.Fprintln(w, "[2/7] Generating sidecar patch...")
+	}
+
+	patchResult, err := generateSidecarPatch(manifest, opts)
+	if err != nil {
+		return cliutil.ExitCodeError(initExitError, err)
+	}
+
+	if !opts.jsonOutput {
+		_, _ = fmt.Fprintf(w, "  Agent identity: %s\n", patchResult.AgentIdentity)
+		_, _ = fmt.Fprintf(w, "  Image: %s\n", resolveImage(opts))
+		_, _ = fmt.Fprintf(w, "  Preset: %s\n\n", opts.preset)
+	}
+
+	// Phase 3: Preview
+	if !opts.jsonOutput {
+		_, _ = fmt.Fprintln(w, "[3/7] Diff preview:")
+		if alreadyPatched {
+			_, _ = fmt.Fprintln(w, "  No changes (manifest already patched).")
+		} else {
+			diff, err := renderDiff(manifest, patchResult)
+			if err != nil {
+				_, _ = fmt.Fprintf(w, "  (diff generation failed: %v)\n", err)
+			} else {
+				_, _ = fmt.Fprintln(w, diff)
+			}
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+
+	// Phase 4: Apply or Emit
+	if !opts.jsonOutput {
+		_, _ = fmt.Fprintln(w, "[4/7] Emitting output...")
+	}
+
+	patchSummary := &sidecarPatchSummary{
+		EmitFormat:    opts.emit,
+		OutputPath:    opts.output,
+		AgentIdentity: patchResult.AgentIdentity,
+		DryRun:        opts.dryRun,
+	}
+
+	if opts.dryRun {
+		patchSummary.Written = false
+		if !opts.jsonOutput {
+			_, _ = fmt.Fprintf(w, "  Dry run: would emit %s format\n\n", opts.emit)
+		}
+	} else if alreadyPatched {
+		patchSummary.Written = false
+		if !opts.jsonOutput {
+			_, _ = fmt.Fprintln(w, "  Skipped: manifest already patched.")
+		}
+	} else {
+		if opts.jsonOutput && opts.output == "" {
+			return cliutil.ExitCodeError(initExitError,
+				fmt.Errorf("--json requires --output when emitting %s content", opts.emit))
+		}
+		if err := emitPatched(w, patchResult, opts); err != nil {
+			return cliutil.ExitCodeError(initExitError, fmt.Errorf("emit: %w", err))
+		}
+		patchSummary.Written = true
+		if !opts.jsonOutput {
+			if opts.output != "" {
+				_, _ = fmt.Fprintf(w, "  Written to: %s\n\n", opts.output)
+			} else {
+				// Output was written to stdout in emitPatched.
+				_, _ = fmt.Fprintln(w)
+			}
+		}
+	}
+	result.Patch = patchSummary
+
+	// Phase 5: Verify (skipped in dry-run)
+	if !opts.jsonOutput {
+		_, _ = fmt.Fprintln(w, "[5/7] Verifying sidecar...")
+	}
+	if opts.dryRun {
+		result.Verify = &sidecarVerifyResult{Skipped: true, Detail: "skipped (--dry-run)"}
+		if !opts.jsonOutput {
+			_, _ = fmt.Fprintln(w, "  Skipped (--dry-run)")
+		}
+	} else {
+		result.Verify = runSidecarVerify(w, opts, opts.jsonOutput)
+		if !opts.jsonOutput {
+			_, _ = fmt.Fprintln(w)
+		}
+	}
+
+	// Phase 6: Canary (skipped in dry-run)
+	if !opts.jsonOutput {
+		_, _ = fmt.Fprintln(w, "[6/7] Testing canary detection...")
+	}
+	if opts.dryRun {
+		result.Canary = &sidecarCanaryResult{Skipped: true, Detail: "skipped (--dry-run)"}
+		if !opts.jsonOutput {
+			_, _ = fmt.Fprintln(w, "  Skipped (--dry-run)")
+		}
+	} else {
+		cfg := buildConfig(opts.preset, nil)
+		result.Canary = runSidecarCanary(w, cfg, opts, opts.jsonOutput)
+		if !opts.jsonOutput {
+			if result.Canary.Detected {
+				_, _ = fmt.Fprintln(w, "  Canary secret detected in URL scan. DLP is working.")
+			}
+			_, _ = fmt.Fprintln(w)
+		}
+	}
+
+	// Phase 7: Summary
+	if opts.jsonOutput {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	printSidecarSummary(w, result, opts)
+	return nil
+}
+
+// renderDiff produces a simple before/after comparison.
+func renderDiff(manifest *workloadManifest, patchResult *sidecarPatchResult) (string, error) {
+	patched, err := yaml.Marshal(patchResult.PatchedManifest)
+	if err != nil {
+		return "", err
+	}
+
+	original := string(manifest.RawBytes)
+	patchedStr := string(patched)
+
+	// Simple line-by-line diff indicator (not a full unified diff).
+	origLines := strings.Split(original, "\n")
+	patchLines := strings.Split(patchedStr, "\n")
+
+	var sb strings.Builder
+
+	// Show additions (lines in patched but not in original).
+	origSet := make(map[string]bool, len(origLines))
+	for _, l := range origLines {
+		origSet[strings.TrimSpace(l)] = true
+	}
+
+	for _, l := range patchLines {
+		trimmed := strings.TrimSpace(l)
+		if trimmed == "" {
+			continue
+		}
+		if !origSet[trimmed] {
+			_, _ = fmt.Fprintf(&sb, "  + %s\n", l)
+		}
+	}
+
+	if sb.Len() == 0 {
+		return "  (no changes)", nil
+	}
+	return sb.String(), nil
+}
+
+func printSidecarSummary(w io.Writer, result *sidecarResult, opts sidecarOptions) {
+	_, _ = fmt.Fprintln(w, "[7/7] Summary")
+	_, _ = fmt.Fprintln(w, "=============")
+	_, _ = fmt.Fprintln(w)
+
+	_, _ = fmt.Fprintf(w, "  Workload:        %s/%s\n", result.Detect.Kind, result.Detect.Name)
+	_, _ = fmt.Fprintf(w, "  Agent identity:  %s\n", result.Patch.AgentIdentity)
+	_, _ = fmt.Fprintf(w, "  Emit format:     %s\n", result.Patch.EmitFormat)
+
+	if result.Patch.DryRun {
+		_, _ = fmt.Fprintln(w, "  Mode:            dry-run")
+	} else if result.Patch.Written {
+		if result.Patch.OutputPath != "" {
+			_, _ = fmt.Fprintf(w, "  Output:          %s\n", result.Patch.OutputPath)
+		} else {
+			_, _ = fmt.Fprintln(w, "  Output:          stdout")
+		}
+	} else if result.Detect.AlreadyPatched {
+		_, _ = fmt.Fprintln(w, "  Status:          already patched (no changes)")
+	}
+
+	if result.Verify != nil {
+		if result.Verify.Skipped {
+			_, _ = fmt.Fprintln(w, "  Verify:          skipped")
+		} else if result.Verify.Healthy {
+			_, _ = fmt.Fprintln(w, "  Verify:          healthy")
+		}
+	}
+
+	if result.Canary != nil {
+		if result.Canary.Skipped {
+			_, _ = fmt.Fprintln(w, "  Canary:          skipped")
+		} else if result.Canary.Detected {
+			_, _ = fmt.Fprintln(w, "  Canary:          detected (DLP working)")
+		} else {
+			_, _ = fmt.Fprintln(w, "  Canary:          not detected (check config)")
+		}
+	}
+
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "Next steps:")
+	if !result.Patch.Written && !result.Detect.AlreadyPatched {
+		_, _ = fmt.Fprintf(w, "  pipelock init sidecar --inject-spec %s\n", opts.injectSpec)
+	}
+	switch result.Patch.EmitFormat {
+	case emitKustomize:
+		if result.Patch.OutputPath != "" {
+			_, _ = fmt.Fprintf(w, "  kubectl apply -k %s\n", result.Patch.OutputPath)
+		} else {
+			_, _ = fmt.Fprintln(w, "  kubectl apply -k <overlay-dir>")
+		}
+	case emitHelmValues:
+		if result.Patch.OutputPath != "" {
+			_, _ = fmt.Fprintf(w, "  helm upgrade --install pipelock pipelock/pipelock -f %s\n", result.Patch.OutputPath)
+		} else {
+			_, _ = fmt.Fprintln(w, "  helm upgrade --install pipelock pipelock/pipelock -f <values-file>")
+		}
+	default:
+		_, _ = fmt.Fprintln(w, "  kubectl apply -f <patched-manifest>")
+	}
+	_, _ = fmt.Fprintln(w, "  kubectl port-forward <pod> 8888:8888")
+	_, _ = fmt.Fprintln(w, "  curl http://localhost:8888/health")
+	_, _ = fmt.Fprintln(w)
+}

--- a/internal/cli/setup/sidecar_canary.go
+++ b/internal/cli/setup/sidecar_canary.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// sidecarCanaryResult holds the outcome of the in-cluster canary phase.
+type sidecarCanaryResult struct {
+	Detected bool   `json:"detected"`
+	Skipped  bool   `json:"skipped"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+// runSidecarCanary runs the synthetic secret injection canary against the
+// generated config. Reuses the same canary logic as the IDE init flow.
+func runSidecarCanary(w io.Writer, cfg *config.Config, opts sidecarOptions, jsonOutput bool) *sidecarCanaryResult {
+	if opts.skipCanary {
+		return &sidecarCanaryResult{Skipped: true, Detail: "skipped (--skip-canary)"}
+	}
+
+	// Use the same canary URL and scanner as the IDE init flow.
+	canaryURL := "https://github.com/test?key=" + canaryToken()
+	detected := scanCanaryURL(cfg, canaryURL)
+
+	if detected {
+		return &sidecarCanaryResult{
+			Detected: true,
+			Detail:   "Canary secret detected in URL scan. DLP is working.",
+		}
+	}
+
+	if !jsonOutput {
+		_, _ = fmt.Fprintln(w, "  Canary was not detected. Check the generated config.")
+	}
+
+	return &sidecarCanaryResult{
+		Detected: false,
+		Detail:   "Canary was not detected. Run 'pipelock check --url \"" + canaryURL + "\"' to debug.",
+	}
+}

--- a/internal/cli/setup/sidecar_detect.go
+++ b/internal/cli/setup/sidecar_detect.go
@@ -97,6 +97,7 @@ func getPodSpec(raw map[string]interface{}, kind string) (map[string]interface{}
 }
 
 // hasPipelockContainer returns true if a pipelock sidecar container already exists.
+// This remains as a legacy detector for pre-enforced same-pod patches.
 func hasPipelockContainer(podSpec map[string]interface{}) bool {
 	containers, ok := podSpec["containers"].([]interface{})
 	if !ok {

--- a/internal/cli/setup/sidecar_detect.go
+++ b/internal/cli/setup/sidecar_detect.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Supported workload kinds for sidecar injection.
+const (
+	kindDeployment  = "Deployment"
+	kindStatefulSet = "StatefulSet"
+	kindJob         = "Job"
+	kindCronJob     = "CronJob"
+)
+
+// supportedKinds lists the 4 accepted workload types.
+var supportedKinds = []string{kindDeployment, kindStatefulSet, kindJob, kindCronJob}
+
+// workloadManifest holds the parsed workload metadata and raw YAML.
+type workloadManifest struct {
+	Kind     string
+	Name     string
+	Raw      map[string]interface{}
+	RawBytes []byte
+}
+
+// detectWorkload reads a YAML file and identifies the workload kind and pod spec path.
+// Returns an error for unsupported kinds with a clear message listing supported types.
+func detectWorkload(path string) (*workloadManifest, error) {
+	cleanPath := filepath.Clean(path)
+	data, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading manifest %s: %w", cleanPath, err)
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing manifest %s: %w", cleanPath, err)
+	}
+
+	kind, _ := raw["kind"].(string)
+	if kind == "" {
+		return nil, fmt.Errorf("manifest %s: missing or empty 'kind' field", cleanPath)
+	}
+
+	if !isSupportedKind(kind) {
+		return nil, fmt.Errorf("unsupported workload kind %q; supported: %v", kind, supportedKinds)
+	}
+
+	// Extract the workload name from metadata.
+	name := extractWorkloadName(raw)
+
+	return &workloadManifest{
+		Kind:     kind,
+		Name:     name,
+		Raw:      raw,
+		RawBytes: data,
+	}, nil
+}
+
+// podSpecPath returns the YAML path segments to the pod spec for each workload kind.
+// Deployment/StatefulSet: spec.template.spec
+// Job: spec.template.spec
+// CronJob: spec.jobTemplate.spec.template.spec.
+func podSpecPath(kind string) []string {
+	switch kind {
+	case kindCronJob:
+		return []string{"spec", "jobTemplate", "spec", "template", "spec"}
+	default:
+		// Deployment, StatefulSet, Job all use spec.template.spec
+		return []string{"spec", "template", "spec"}
+	}
+}
+
+// getPodSpec navigates the raw YAML tree to the pod spec using the kind-specific path.
+func getPodSpec(raw map[string]interface{}, kind string) (map[string]interface{}, error) {
+	path := podSpecPath(kind)
+	current := raw
+	for i, key := range path {
+		next, ok := current[key]
+		if !ok {
+			return nil, fmt.Errorf("missing %s in manifest (expected path: %s)", key, pathString(path[:i+1]))
+		}
+		nextMap, ok := next.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("%s is not a mapping in manifest", pathString(path[:i+1]))
+		}
+		current = nextMap
+	}
+	return current, nil
+}
+
+// hasPipelockContainer returns true if a pipelock sidecar container already exists.
+func hasPipelockContainer(podSpec map[string]interface{}) bool {
+	containers, ok := podSpec["containers"].([]interface{})
+	if !ok {
+		return false
+	}
+	for _, c := range containers {
+		cMap, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := cMap["name"].(string)
+		if name == sidecarContainerName {
+			return true
+		}
+	}
+	return false
+}
+
+// isSupportedKind checks if a workload kind is in the supported list.
+func isSupportedKind(kind string) bool {
+	for _, k := range supportedKinds {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// extractWorkloadName gets the name from metadata.name.
+func extractWorkloadName(raw map[string]interface{}) string {
+	meta, ok := raw["metadata"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	name, _ := meta["name"].(string)
+	return name
+}
+
+func pathString(path []string) string {
+	result := ""
+	for i, p := range path {
+		if i > 0 {
+			result += "."
+		}
+		result += p
+	}
+	return result
+}

--- a/internal/cli/setup/sidecar_detect_test.go
+++ b/internal/cli/setup/sidecar_detect_test.go
@@ -1,0 +1,337 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	testdataSidecarDir = "testdata/sidecar"
+)
+
+func testdataPath(t *testing.T, filename string) string {
+	t.Helper()
+	return filepath.Join(testdataSidecarDir, filename)
+}
+
+func TestDetectWorkload(t *testing.T) {
+	tests := []struct {
+		name     string
+		file     string
+		wantKind string
+		wantName string
+	}{
+		{
+			name:     "deployment",
+			file:     "deployment.yaml",
+			wantKind: kindDeployment,
+			wantName: "my-agent",
+		},
+		{
+			name:     "statefulset",
+			file:     "statefulset.yaml",
+			wantKind: kindStatefulSet,
+			wantName: "my-db-agent",
+		},
+		{
+			name:     "job",
+			file:     "job.yaml",
+			wantKind: kindJob,
+			wantName: "batch-runner",
+		},
+		{
+			name:     "cronjob",
+			file:     "cronjob.yaml",
+			wantKind: kindCronJob,
+			wantName: "scheduled-scan",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest, err := detectWorkload(testdataPath(t, tc.file))
+			if err != nil {
+				t.Fatalf("detectWorkload(%s): %v", tc.file, err)
+			}
+			if manifest.Kind != tc.wantKind {
+				t.Errorf("Kind = %q, want %q", manifest.Kind, tc.wantKind)
+			}
+			if manifest.Name != tc.wantName {
+				t.Errorf("Name = %q, want %q", manifest.Name, tc.wantName)
+			}
+			if manifest.Raw == nil {
+				t.Error("Raw should not be nil")
+			}
+			if len(manifest.RawBytes) == 0 {
+				t.Error("RawBytes should not be empty")
+			}
+		})
+	}
+}
+
+func TestDetectWorkload_UnsupportedKind(t *testing.T) {
+	dir := t.TempDir()
+	daemonsetYAML := `apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: log-collector
+spec:
+  selector:
+    matchLabels:
+      app: log-collector
+  template:
+    spec:
+      containers:
+        - name: collector
+          image: fluentd:latest
+`
+	path := filepath.Join(dir, "daemonset.yaml")
+	if err := os.WriteFile(path, []byte(daemonsetYAML), 0o600); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	_, err := detectWorkload(path)
+	if err == nil {
+		t.Fatal("expected error for unsupported kind DaemonSet")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "unsupported") {
+		t.Errorf("error should contain 'unsupported', got: %s", errMsg)
+	}
+	// Verify the error lists supported kinds.
+	for _, kind := range supportedKinds {
+		if !strings.Contains(errMsg, kind) {
+			t.Errorf("error should list supported kind %q, got: %s", kind, errMsg)
+		}
+	}
+}
+
+func TestDetectWorkload_MissingKind(t *testing.T) {
+	dir := t.TempDir()
+	noKindYAML := `apiVersion: v1
+metadata:
+  name: something
+spec:
+  replicas: 1
+`
+	path := filepath.Join(dir, "nokind.yaml")
+	if err := os.WriteFile(path, []byte(noKindYAML), 0o600); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	_, err := detectWorkload(path)
+	if err == nil {
+		t.Fatal("expected error for missing kind field")
+	}
+	if !strings.Contains(err.Error(), "kind") {
+		t.Errorf("error should mention 'kind', got: %s", err.Error())
+	}
+}
+
+func TestDetectWorkload_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(path, []byte("{{not: valid: yaml::: ["), 0o600); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	_, err := detectWorkload(path)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+	if !strings.Contains(err.Error(), "parsing") {
+		t.Errorf("error should mention 'parsing', got: %s", err.Error())
+	}
+}
+
+func TestDetectWorkload_NotFound(t *testing.T) {
+	_, err := detectWorkload(filepath.Clean("/tmp/nonexistent-pipelock-test-file-404.yaml"))
+	if err == nil {
+		t.Fatal("expected error for non-existent file")
+	}
+	if !strings.Contains(err.Error(), "reading") {
+		t.Errorf("error should mention 'reading', got: %s", err.Error())
+	}
+}
+
+func TestPodSpecPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     string
+		wantPath []string
+	}{
+		{
+			name:     "deployment",
+			kind:     kindDeployment,
+			wantPath: []string{"spec", "template", "spec"},
+		},
+		{
+			name:     "statefulset",
+			kind:     kindStatefulSet,
+			wantPath: []string{"spec", "template", "spec"},
+		},
+		{
+			name:     "job",
+			kind:     kindJob,
+			wantPath: []string{"spec", "template", "spec"},
+		},
+		{
+			name:     "cronjob",
+			kind:     kindCronJob,
+			wantPath: []string{"spec", "jobTemplate", "spec", "template", "spec"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := podSpecPath(tc.kind)
+			if len(got) != len(tc.wantPath) {
+				t.Fatalf("podSpecPath(%s) length = %d, want %d", tc.kind, len(got), len(tc.wantPath))
+			}
+			for i := range got {
+				if got[i] != tc.wantPath[i] {
+					t.Errorf("podSpecPath(%s)[%d] = %q, want %q", tc.kind, i, got[i], tc.wantPath[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetPodSpec(t *testing.T) {
+	tests := []struct {
+		name     string
+		file     string
+		wantKind string
+	}{
+		{name: "deployment", file: "deployment.yaml", wantKind: kindDeployment},
+		{name: "statefulset", file: "statefulset.yaml", wantKind: kindStatefulSet},
+		{name: "job", file: "job.yaml", wantKind: kindJob},
+		{name: "cronjob", file: "cronjob.yaml", wantKind: kindCronJob},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest, err := detectWorkload(testdataPath(t, tc.file))
+			if err != nil {
+				t.Fatalf("detectWorkload: %v", err)
+			}
+
+			podSpec, err := getPodSpec(manifest.Raw, manifest.Kind)
+			if err != nil {
+				t.Fatalf("getPodSpec(%s): %v", tc.wantKind, err)
+			}
+
+			// Every testdata file has a containers list in the pod spec.
+			containers, ok := podSpec["containers"].([]interface{})
+			if !ok {
+				t.Fatal("pod spec missing containers list")
+			}
+			if len(containers) == 0 {
+				t.Fatal("containers list is empty")
+			}
+		})
+	}
+}
+
+func TestGetPodSpec_MissingPath(t *testing.T) {
+	raw := map[string]interface{}{
+		"kind": kindDeployment,
+		"spec": map[string]interface{}{},
+	}
+
+	_, err := getPodSpec(raw, kindDeployment)
+	if err == nil {
+		t.Fatal("expected error for missing pod spec path")
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Errorf("error should contain 'missing', got: %s", err.Error())
+	}
+}
+
+func TestGetPodSpec_NotAMapping(t *testing.T) {
+	raw := map[string]interface{}{
+		"kind": kindDeployment,
+		"spec": map[string]interface{}{
+			"template": "not-a-map",
+		},
+	}
+
+	_, err := getPodSpec(raw, kindDeployment)
+	if err == nil {
+		t.Fatal("expected error for non-mapping node")
+	}
+	if !strings.Contains(err.Error(), "not a mapping") {
+		t.Errorf("error should contain 'not a mapping', got: %s", err.Error())
+	}
+}
+
+func TestHasPipelockContainer(t *testing.T) {
+	tests := []struct {
+		name    string
+		podSpec map[string]interface{}
+		want    bool
+	}{
+		{
+			name: "has pipelock container",
+			podSpec: map[string]interface{}{
+				"containers": []interface{}{
+					map[string]interface{}{"name": "agent"},
+					map[string]interface{}{"name": sidecarContainerName},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no pipelock container",
+			podSpec: map[string]interface{}{
+				"containers": []interface{}{
+					map[string]interface{}{"name": "agent"},
+					map[string]interface{}{"name": "other-sidecar"},
+				},
+			},
+			want: false,
+		},
+		{
+			name:    "no containers key",
+			podSpec: map[string]interface{}{},
+			want:    false,
+		},
+		{
+			name: "empty containers list",
+			podSpec: map[string]interface{}{
+				"containers": []interface{}{},
+			},
+			want: false,
+		},
+		{
+			name: "containers is wrong type",
+			podSpec: map[string]interface{}{
+				"containers": "not-a-list",
+			},
+			want: false,
+		},
+		{
+			name: "container entry is wrong type",
+			podSpec: map[string]interface{}{
+				"containers": []interface{}{
+					"not-a-map",
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasPipelockContainer(tc.podSpec)
+			if got != tc.want {
+				t.Errorf("hasPipelockContainer() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/setup/sidecar_emit.go
+++ b/internal/cli/setup/sidecar_emit.go
@@ -1,0 +1,208 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+// Emit format constants.
+const (
+	emitPatch      = "patch"
+	emitKustomize  = "kustomize"
+	emitHelmValues = "helm-values"
+)
+
+type imageRef struct {
+	Repository string
+	Tag        string
+	Digest     string
+}
+
+// emitPatched writes the patched manifest in the requested format.
+func emitPatched(w io.Writer, result *sidecarPatchResult, opts sidecarOptions) error {
+	switch opts.emit {
+	case emitPatch:
+		return emitPatchFormat(w, result, opts)
+	case emitKustomize:
+		return emitKustomizeFormat(result, opts)
+	case emitHelmValues:
+		return emitHelmValuesFormat(w, result, opts)
+	default:
+		return fmt.Errorf("unknown emit format %q; supported: patch, kustomize, helm-values", opts.emit)
+	}
+}
+
+// emitPatchFormat writes the fully patched manifest YAML as a standalone applyable file.
+func emitPatchFormat(w io.Writer, result *sidecarPatchResult, opts sidecarOptions) error {
+	data, err := yaml.Marshal(result.PatchedManifest)
+	if err != nil {
+		return fmt.Errorf("marshaling patched manifest: %w", err)
+	}
+
+	// Append ConfigMap and NetworkPolicy as multi-document YAML.
+	output := string(data) + "---\n" + result.ConfigMapYAML + "---\n" + result.NetworkPolicyYAML
+
+	return writeOutput(w, []byte(output), opts.output, opts.force)
+}
+
+// emitKustomizeFormat writes a standalone kustomize overlay directory.
+func emitKustomizeFormat(result *sidecarPatchResult, opts sidecarOptions) error {
+	outDir := opts.output
+	if outDir == "" {
+		return fmt.Errorf("--output directory required for kustomize format")
+	}
+
+	cleanDir := filepath.Clean(outDir)
+	if err := os.MkdirAll(cleanDir, 0o750); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+	if strings.TrimSpace(result.OriginalManifestYAML) == "" {
+		return fmt.Errorf("original workload manifest is required for kustomize format")
+	}
+
+	// Write the original workload so the overlay builds standalone.
+	workloadPath := filepath.Join(cleanDir, "workload.yaml")
+	if err := writeOutput(nil, []byte(result.OriginalManifestYAML), workloadPath, opts.force); err != nil {
+		return fmt.Errorf("writing %s: %w", workloadPath, err)
+	}
+
+	// Write the sidecar patch.
+	patchData, err := yaml.Marshal(result.PatchedManifest)
+	if err != nil {
+		return fmt.Errorf("marshaling patch: %w", err)
+	}
+	patchPath := filepath.Join(cleanDir, "pipelock-sidecar-patch.yaml")
+	if err := writeOutput(nil, patchData, patchPath, opts.force); err != nil {
+		return fmt.Errorf("writing %s: %w", patchPath, err)
+	}
+
+	// Write the ConfigMap.
+	cmPath := filepath.Join(cleanDir, "pipelock-configmap.yaml")
+	if err := writeOutput(nil, []byte(result.ConfigMapYAML), cmPath, opts.force); err != nil {
+		return fmt.Errorf("writing %s: %w", cmPath, err)
+	}
+
+	// Write the NetworkPolicy.
+	npPath := filepath.Join(cleanDir, "pipelock-networkpolicy.yaml")
+	if err := writeOutput(nil, []byte(result.NetworkPolicyYAML), npPath, opts.force); err != nil {
+		return fmt.Errorf("writing %s: %w", npPath, err)
+	}
+
+	// Write the kustomization.yaml.
+	kustomization := map[string]interface{}{
+		"apiVersion": "kustomize.config.k8s.io/v1beta1",
+		"kind":       "Kustomization",
+		"resources": []interface{}{
+			"workload.yaml",
+			"pipelock-configmap.yaml",
+			"pipelock-networkpolicy.yaml",
+		},
+		"patches": []interface{}{
+			map[string]interface{}{
+				"path": "pipelock-sidecar-patch.yaml",
+			},
+		},
+	}
+	kustomizationData, err := yaml.Marshal(kustomization)
+	if err != nil {
+		return fmt.Errorf("marshaling kustomization.yaml: %w", err)
+	}
+	kustomizationPath := filepath.Join(cleanDir, "kustomization.yaml")
+	if err := writeOutput(nil, kustomizationData, kustomizationPath, opts.force); err != nil {
+		return fmt.Errorf("writing %s: %w", kustomizationPath, err)
+	}
+
+	return nil
+}
+
+// emitHelmValuesFormat writes a values.yaml fragment targeting the pipelock Helm chart.
+func emitHelmValuesFormat(w io.Writer, result *sidecarPatchResult, opts sidecarOptions) error {
+	values := map[string]interface{}{
+		"image": map[string]interface{}{
+			"repository": defaultImageRepo,
+			"tag":        cliutil.Version,
+			"digest":     "",
+		},
+		"pipelock": map[string]interface{}{
+			"mode":                   opts.preset,
+			"default_agent_identity": result.AgentIdentity,
+		},
+		"networkPolicy": map[string]interface{}{
+			"enabled": true,
+		},
+	}
+
+	if opts.image != "" {
+		parsed := parseImageRef(opts.image)
+		img := values["image"].(map[string]interface{})
+		img["repository"] = parsed.Repository
+		img["tag"] = parsed.Tag
+		img["digest"] = parsed.Digest
+	}
+
+	data, err := yaml.Marshal(values)
+	if err != nil {
+		return fmt.Errorf("marshaling helm values: %w", err)
+	}
+
+	header := "# Pipelock Helm chart values fragment\n# Generated by: pipelock init sidecar --emit helm-values\n# Apply with: helm upgrade --install pipelock pipelock/pipelock -f <this-file>\n\n"
+
+	return writeOutput(w, []byte(header+string(data)), opts.output, opts.force)
+}
+
+// writeOutput writes data to a file or stdout.
+func writeOutput(w io.Writer, data []byte, outputPath string, force bool) error {
+	if outputPath == "" {
+		if w == nil {
+			w = os.Stdout
+		}
+		_, err := w.Write(data)
+		return err
+	}
+
+	cleanPath := filepath.Clean(outputPath)
+
+	// Refuse to overwrite without --force.
+	if _, err := os.Stat(cleanPath); err == nil && !force {
+		return fmt.Errorf("output file %s already exists; use --force to overwrite", cleanPath)
+	}
+
+	dir := filepath.Dir(cleanPath)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("creating directory %s: %w", dir, err)
+	}
+
+	if err := os.WriteFile(cleanPath, data, 0o600); err != nil {
+		return fmt.Errorf("writing %s: %w", cleanPath, err)
+	}
+
+	return nil
+}
+
+// parseImageRef splits a container image reference into repository, tag, and digest.
+func parseImageRef(ref string) imageRef {
+	if repo, digest, ok := strings.Cut(ref, "@"); ok {
+		return imageRef{Repository: repo, Digest: digest}
+	}
+
+	lastSlash := strings.LastIndex(ref, "/")
+	lastColon := strings.LastIndex(ref, ":")
+	if lastColon > lastSlash {
+		return imageRef{
+			Repository: ref[:lastColon],
+			Tag:        ref[lastColon+1:],
+		}
+	}
+
+	return imageRef{Repository: ref, Tag: "latest"}
+}

--- a/internal/cli/setup/sidecar_emit.go
+++ b/internal/cli/setup/sidecar_emit.go
@@ -42,20 +42,25 @@ func emitPatched(w io.Writer, result *sidecarPatchResult, opts sidecarOptions) e
 	}
 }
 
-// emitPatchFormat writes the fully patched manifest YAML as a standalone applyable file.
+// emitPatchFormat writes the full enforced topology bundle as standalone YAML.
 func emitPatchFormat(w io.Writer, result *sidecarPatchResult, opts sidecarOptions) error {
 	data, err := yaml.Marshal(result.PatchedManifest)
 	if err != nil {
 		return fmt.Errorf("marshaling patched manifest: %w", err)
 	}
 
-	// Append ConfigMap and NetworkPolicy as multi-document YAML.
-	output := string(data) + "---\n" + result.ConfigMapYAML + "---\n" + result.NetworkPolicyYAML
+	output := string(data) +
+		"---\n" + result.ConfigMapYAML +
+		"---\n" + result.DeploymentYAML +
+		"---\n" + result.ServiceYAML +
+		"---\n" + result.AgentNetworkPolicyYAML +
+		"---\n" + result.ProxyNetworkPolicyYAML +
+		"---\n" + result.PodDisruptionBudgetYAML
 
 	return writeOutput(w, []byte(output), opts.output, opts.force)
 }
 
-// emitKustomizeFormat writes a standalone kustomize overlay directory.
+// emitKustomizeFormat writes a standalone kustomize bundle directory.
 func emitKustomizeFormat(result *sidecarPatchResult, opts sidecarOptions) error {
 	outDir := opts.output
 	if outDir == "" {
@@ -66,24 +71,13 @@ func emitKustomizeFormat(result *sidecarPatchResult, opts sidecarOptions) error 
 	if err := os.MkdirAll(cleanDir, 0o750); err != nil {
 		return fmt.Errorf("creating output directory: %w", err)
 	}
-	if strings.TrimSpace(result.OriginalManifestYAML) == "" {
-		return fmt.Errorf("original workload manifest is required for kustomize format")
-	}
-
-	// Write the original workload so the overlay builds standalone.
-	workloadPath := filepath.Join(cleanDir, "workload.yaml")
-	if err := writeOutput(nil, []byte(result.OriginalManifestYAML), workloadPath, opts.force); err != nil {
-		return fmt.Errorf("writing %s: %w", workloadPath, err)
-	}
-
-	// Write the sidecar patch.
-	patchData, err := yaml.Marshal(result.PatchedManifest)
+	agentData, err := yaml.Marshal(result.PatchedManifest)
 	if err != nil {
-		return fmt.Errorf("marshaling patch: %w", err)
+		return fmt.Errorf("marshaling agent manifest: %w", err)
 	}
-	patchPath := filepath.Join(cleanDir, "pipelock-sidecar-patch.yaml")
-	if err := writeOutput(nil, patchData, patchPath, opts.force); err != nil {
-		return fmt.Errorf("writing %s: %w", patchPath, err)
+	workloadPath := filepath.Join(cleanDir, "agent-workload.yaml")
+	if err := writeOutput(nil, agentData, workloadPath, opts.force); err != nil {
+		return fmt.Errorf("writing %s: %w", workloadPath, err)
 	}
 
 	// Write the ConfigMap.
@@ -92,25 +86,42 @@ func emitKustomizeFormat(result *sidecarPatchResult, opts sidecarOptions) error 
 		return fmt.Errorf("writing %s: %w", cmPath, err)
 	}
 
-	// Write the NetworkPolicy.
-	npPath := filepath.Join(cleanDir, "pipelock-networkpolicy.yaml")
-	if err := writeOutput(nil, []byte(result.NetworkPolicyYAML), npPath, opts.force); err != nil {
-		return fmt.Errorf("writing %s: %w", npPath, err)
+	deployPath := filepath.Join(cleanDir, "pipelock-deployment.yaml")
+	if err := writeOutput(nil, []byte(result.DeploymentYAML), deployPath, opts.force); err != nil {
+		return fmt.Errorf("writing %s: %w", deployPath, err)
 	}
 
-	// Write the kustomization.yaml.
+	servicePath := filepath.Join(cleanDir, "pipelock-service.yaml")
+	if err := writeOutput(nil, []byte(result.ServiceYAML), servicePath, opts.force); err != nil {
+		return fmt.Errorf("writing %s: %w", servicePath, err)
+	}
+
+	agentPolicyPath := filepath.Join(cleanDir, "agent-networkpolicy.yaml")
+	if err := writeOutput(nil, []byte(result.AgentNetworkPolicyYAML), agentPolicyPath, opts.force); err != nil {
+		return fmt.Errorf("writing %s: %w", agentPolicyPath, err)
+	}
+
+	proxyPolicyPath := filepath.Join(cleanDir, "pipelock-networkpolicy.yaml")
+	if err := writeOutput(nil, []byte(result.ProxyNetworkPolicyYAML), proxyPolicyPath, opts.force); err != nil {
+		return fmt.Errorf("writing %s: %w", proxyPolicyPath, err)
+	}
+
+	pdbPath := filepath.Join(cleanDir, "pipelock-pdb.yaml")
+	if err := writeOutput(nil, []byte(result.PodDisruptionBudgetYAML), pdbPath, opts.force); err != nil {
+		return fmt.Errorf("writing %s: %w", pdbPath, err)
+	}
+
 	kustomization := map[string]interface{}{
 		"apiVersion": "kustomize.config.k8s.io/v1beta1",
 		"kind":       "Kustomization",
 		"resources": []interface{}{
-			"workload.yaml",
+			"agent-workload.yaml",
 			"pipelock-configmap.yaml",
+			"pipelock-deployment.yaml",
+			"pipelock-service.yaml",
+			"agent-networkpolicy.yaml",
 			"pipelock-networkpolicy.yaml",
-		},
-		"patches": []interface{}{
-			map[string]interface{}{
-				"path": "pipelock-sidecar-patch.yaml",
-			},
+			"pipelock-pdb.yaml",
 		},
 	}
 	kustomizationData, err := yaml.Marshal(kustomization)
@@ -125,20 +136,62 @@ func emitKustomizeFormat(result *sidecarPatchResult, opts sidecarOptions) error 
 	return nil
 }
 
-// emitHelmValuesFormat writes a values.yaml fragment targeting the pipelock Helm chart.
+// emitHelmValuesFormat writes a Helm bundle directory: chart values plus the
+// patched agent workload and the companion NetworkPolicies.
 func emitHelmValuesFormat(w io.Writer, result *sidecarPatchResult, opts sidecarOptions) error {
+	_ = w
+	outDir := opts.output
+	if outDir == "" {
+		return fmt.Errorf("--output directory required for helm-values format")
+	}
+
 	values := map[string]interface{}{
+		"replicaCount":     proxyReplicaCount,
+		"fullnameOverride": result.ProxyName,
 		"image": map[string]interface{}{
 			"repository": defaultImageRepo,
 			"tag":        cliutil.Version,
 			"digest":     "",
+			"pullPolicy": "IfNotPresent",
+		},
+		"resources": map[string]interface{}{
+			"requests": map[string]interface{}{"cpu": proxyCPURequest, "memory": proxyMemoryRequest},
+			"limits":   map[string]interface{}{"cpu": proxyCPULimit, "memory": proxyMemoryLimit},
+		},
+		"podLabels": map[string]interface{}{
+			"app.kubernetes.io/component": "proxy",
+		},
+		"affinity": map[string]interface{}{
+			"podAntiAffinity": map[string]interface{}{
+				"preferredDuringSchedulingIgnoredDuringExecution": []interface{}{
+					map[string]interface{}{
+						"weight": 100,
+						"podAffinityTerm": map[string]interface{}{
+							"labelSelector": map[string]interface{}{
+								"matchExpressions": []interface{}{
+									map[string]interface{}{
+										"key":      "app.kubernetes.io/instance",
+										"operator": "In",
+										"values":   []interface{}{result.ProxyName},
+									},
+								},
+							},
+							"topologyKey": "kubernetes.io/hostname",
+						},
+					},
+				},
+			},
 		},
 		"pipelock": map[string]interface{}{
-			"mode":                   opts.preset,
-			"default_agent_identity": result.AgentIdentity,
+			"mode": opts.preset,
+			"forward_proxy": map[string]interface{}{
+				"enabled": true,
+			},
+			"default_agent_identity":      result.AgentIdentity,
+			"bind_default_agent_identity": true,
 		},
 		"networkPolicy": map[string]interface{}{
-			"enabled": true,
+			"enabled": false,
 		},
 	}
 
@@ -155,9 +208,43 @@ func emitHelmValuesFormat(w io.Writer, result *sidecarPatchResult, opts sidecarO
 		return fmt.Errorf("marshaling helm values: %w", err)
 	}
 
-	header := "# Pipelock Helm chart values fragment\n# Generated by: pipelock init sidecar --emit helm-values\n# Apply with: helm upgrade --install pipelock pipelock/pipelock -f <this-file>\n\n"
+	cleanDir := filepath.Clean(outDir)
+	if err := os.MkdirAll(cleanDir, 0o750); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
 
-	return writeOutput(w, []byte(header+string(data)), opts.output, opts.force)
+	header := "# Pipelock Helm bundle values\n# Generated by: pipelock init sidecar --emit helm-values\n# Use release name: " + result.ProxyName + "\n\n"
+	if err := writeOutput(nil, []byte(header+string(data)), filepath.Join(cleanDir, "values.yaml"), opts.force); err != nil {
+		return err
+	}
+
+	agentData, err := yaml.Marshal(result.PatchedManifest)
+	if err != nil {
+		return fmt.Errorf("marshaling agent manifest: %w", err)
+	}
+	if err := writeOutput(nil, agentData, filepath.Join(cleanDir, "agent-workload.yaml"), opts.force); err != nil {
+		return err
+	}
+	if err := writeOutput(nil, []byte(result.AgentNetworkPolicyYAML), filepath.Join(cleanDir, "agent-networkpolicy.yaml"), opts.force); err != nil {
+		return err
+	}
+	if err := writeOutput(nil, []byte(result.ProxyNetworkPolicyYAML), filepath.Join(cleanDir, "pipelock-networkpolicy.yaml"), opts.force); err != nil {
+		return err
+	}
+	if err := writeOutput(nil, []byte(result.PodDisruptionBudgetYAML), filepath.Join(cleanDir, "pipelock-pdb.yaml"), opts.force); err != nil {
+		return err
+	}
+
+	readme := fmt.Sprintf("helm upgrade --install %s pipelock/pipelock -f %s\nkubectl rollout status deployment/%s\nkubectl apply -f %s -f %s\nkubectl apply -f %s\nkubectl apply -f %s\n",
+		result.ProxyName,
+		filepath.Join(cleanDir, "values.yaml"),
+		result.ProxyName,
+		filepath.Join(cleanDir, "pipelock-networkpolicy.yaml"),
+		filepath.Join(cleanDir, "pipelock-pdb.yaml"),
+		filepath.Join(cleanDir, "agent-networkpolicy.yaml"),
+		filepath.Join(cleanDir, "agent-workload.yaml"),
+	)
+	return writeOutput(nil, []byte(readme), filepath.Join(cleanDir, "README.txt"), opts.force)
 }
 
 // writeOutput writes data to a file or stdout.

--- a/internal/cli/setup/sidecar_emit_test.go
+++ b/internal/cli/setup/sidecar_emit_test.go
@@ -1,0 +1,606 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestParseImageRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ref     string
+		wantRep string
+		wantTag string
+		wantDig string
+	}{
+		{
+			name:    "ghcr with version tag",
+			ref:     "ghcr.io/luckypipewrench/pipelock:v2.1.2",
+			wantRep: "ghcr.io/luckypipewrench/pipelock",
+			wantTag: "v2.1.2",
+		},
+		{
+			name:    "custom registry with latest",
+			ref:     "myregistry.com/pipelock:latest",
+			wantRep: "myregistry.com/pipelock",
+			wantTag: "latest",
+		},
+		{
+			name:    "bare image no tag",
+			ref:     "pipelock",
+			wantRep: "pipelock",
+			wantTag: "latest",
+		},
+		{
+			name:    "custom registry with sha256 tag",
+			ref:     "myregistry.com/pipelock:sha256-abc",
+			wantRep: "myregistry.com/pipelock",
+			wantTag: "sha256-abc",
+		},
+		{
+			name:    "nested path with tag",
+			ref:     "registry.example.com/org/sub/pipelock:v1.0.0",
+			wantRep: "registry.example.com/org/sub/pipelock",
+			wantTag: "v1.0.0",
+		},
+		{
+			name:    "port in registry with tag",
+			ref:     "localhost:5000/pipelock:dev",
+			wantRep: "localhost:5000/pipelock",
+			wantTag: "dev",
+		},
+		{
+			name:    "image with only registry no tag",
+			ref:     "myregistry.com/pipelock",
+			wantRep: "myregistry.com/pipelock",
+			wantTag: "latest",
+		},
+		{
+			name:    "digest reference",
+			ref:     "ghcr.io/luckypipewrench/pipelock@sha256:deadbeef",
+			wantRep: "ghcr.io/luckypipewrench/pipelock",
+			wantDig: "sha256:deadbeef",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseImageRef(tc.ref)
+			if got.Repository != tc.wantRep {
+				t.Errorf("parseImageRef(%q) repo = %q, want %q", tc.ref, got.Repository, tc.wantRep)
+			}
+			if got.Tag != tc.wantTag {
+				t.Errorf("parseImageRef(%q) tag = %q, want %q", tc.ref, got.Tag, tc.wantTag)
+			}
+			if got.Digest != tc.wantDig {
+				t.Errorf("parseImageRef(%q) digest = %q, want %q", tc.ref, got.Digest, tc.wantDig)
+			}
+		})
+	}
+}
+
+func TestWriteOutput_File(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "output.yaml")
+	content := []byte("test-content\n")
+
+	if err := writeOutput(nil, content, outPath, false); err != nil {
+		t.Fatalf("writeOutput: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(outPath))
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	if string(data) != string(content) {
+		t.Errorf("file content = %q, want %q", string(data), string(content))
+	}
+
+	info, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file permission = %o, want 600", perm)
+	}
+}
+
+func TestWriteOutput_Stdout(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	content := []byte("stdout-content\n")
+	err := writeOutput(&buf, content, "", false)
+	if err != nil {
+		t.Fatalf("writeOutput to stdout: %v", err)
+	}
+	if buf.String() != string(content) {
+		t.Fatalf("stdout content = %q, want %q", buf.String(), string(content))
+	}
+}
+
+func TestWriteOutput_NoOverwrite(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "existing.yaml")
+
+	// Create an existing file.
+	if err := os.WriteFile(outPath, []byte("original"), 0o600); err != nil {
+		t.Fatalf("writing seed file: %v", err)
+	}
+
+	err := writeOutput(nil, []byte("new-content"), outPath, false)
+	if err == nil {
+		t.Fatal("expected error when file exists and force=false")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error should contain 'already exists', got: %s", err.Error())
+	}
+
+	// Verify original content is preserved.
+	data, err := os.ReadFile(filepath.Clean(outPath))
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+	if string(data) != "original" {
+		t.Errorf("original file was modified: got %q", string(data))
+	}
+}
+
+func TestWriteOutput_ForceOverwrite(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "existing.yaml")
+
+	// Create an existing file.
+	if err := os.WriteFile(outPath, []byte("original"), 0o600); err != nil {
+		t.Fatalf("writing seed file: %v", err)
+	}
+
+	newContent := []byte("overwritten-content")
+	if err := writeOutput(nil, newContent, outPath, true); err != nil {
+		t.Fatalf("writeOutput with force: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(outPath))
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+	if string(data) != string(newContent) {
+		t.Errorf("file content = %q, want %q", string(data), string(newContent))
+	}
+}
+
+func TestWriteOutput_CreatesParentDirs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "nested", "deep", "output.yaml")
+
+	if err := writeOutput(nil, []byte("nested"), outPath, false); err != nil {
+		t.Fatalf("writeOutput: %v", err)
+	}
+
+	if _, err := os.Stat(outPath); os.IsNotExist(err) {
+		t.Error("output file was not created")
+	}
+}
+
+func TestEmitPatchFormat(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "patch-output.yaml")
+
+	result := &sidecarPatchResult{
+		PatchedManifest: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name": "test-agent",
+			},
+			"spec": map[string]interface{}{
+				"replicas": 1,
+			},
+		},
+		ConfigMapYAML:     "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: pipelock-config\n",
+		NetworkPolicyYAML: "apiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\nmetadata:\n  name: test-np\n",
+		AgentIdentity:     "deployment/test-agent",
+	}
+
+	opts := sidecarOptions{
+		output: outPath,
+		emit:   emitPatch,
+	}
+
+	if err := emitPatchFormat(nil, result, opts); err != nil {
+		t.Fatalf("emitPatchFormat: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(outPath))
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+
+	content := string(data)
+
+	// Verify the output contains the three YAML documents separated by "---".
+	docSeparatorCount := strings.Count(content, "---")
+	if docSeparatorCount < 2 {
+		t.Errorf("expected at least 2 document separators, got %d", docSeparatorCount)
+	}
+
+	// Verify the patched manifest is present.
+	if !strings.Contains(content, "Deployment") {
+		t.Error("output should contain the Deployment kind")
+	}
+
+	// Verify ConfigMap YAML is present.
+	if !strings.Contains(content, "ConfigMap") {
+		t.Error("output should contain the ConfigMap")
+	}
+
+	// Verify NetworkPolicy YAML is present.
+	if !strings.Contains(content, "NetworkPolicy") {
+		t.Error("output should contain the NetworkPolicy")
+	}
+}
+
+func TestEmitKustomizeFormat(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outDir := filepath.Join(dir, "kustomize-output")
+
+	result := &sidecarPatchResult{
+		OriginalManifestYAML: "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: test-agent\n",
+		PatchedManifest: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name": "test-agent",
+			},
+		},
+		ConfigMapYAML:     "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: pipelock-config\n",
+		NetworkPolicyYAML: "apiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\nmetadata:\n  name: test-np\n",
+		AgentIdentity:     "deployment/test-agent",
+	}
+
+	opts := sidecarOptions{
+		output: outDir,
+		emit:   emitKustomize,
+	}
+
+	if err := emitKustomizeFormat(result, opts); err != nil {
+		t.Fatalf("emitKustomizeFormat: %v", err)
+	}
+
+	// Verify all 5 expected files were created.
+	expectedFiles := []string{
+		"kustomization.yaml",
+		"workload.yaml",
+		"pipelock-sidecar-patch.yaml",
+		"pipelock-configmap.yaml",
+		"pipelock-networkpolicy.yaml",
+	}
+
+	for _, name := range expectedFiles {
+		path := filepath.Join(outDir, name)
+		info, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			t.Errorf("expected file %s not created", name)
+			continue
+		}
+		if err != nil {
+			t.Errorf("stat %s: %v", name, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("file %s is empty", name)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("file %s permission = %o, want 600", name, perm)
+		}
+	}
+
+	// Verify kustomization.yaml has expected structure.
+	kustomData, err := os.ReadFile(filepath.Clean(filepath.Join(outDir, "kustomization.yaml")))
+	if err != nil {
+		t.Fatalf("reading kustomization.yaml: %v", err)
+	}
+
+	var kustomization map[string]interface{}
+	if err := yaml.Unmarshal(kustomData, &kustomization); err != nil {
+		t.Fatalf("parsing kustomization.yaml: %v", err)
+	}
+
+	if kustomization["apiVersion"] != "kustomize.config.k8s.io/v1beta1" {
+		t.Errorf("kustomization apiVersion = %v, want kustomize.config.k8s.io/v1beta1",
+			kustomization["apiVersion"])
+	}
+	if kustomization["kind"] != "Kustomization" {
+		t.Errorf("kustomization kind = %v, want Kustomization", kustomization["kind"])
+	}
+
+	resources, ok := kustomization["resources"].([]interface{})
+	if !ok {
+		t.Fatal("kustomization resources should be a list")
+	}
+	foundWorkload := false
+	for _, resource := range resources {
+		if resource == "workload.yaml" {
+			foundWorkload = true
+			break
+		}
+	}
+	if !foundWorkload {
+		t.Fatal("kustomization resources should include workload.yaml")
+	}
+}
+
+func TestEmitKustomizeFormat_EmptyOutputDir(t *testing.T) {
+	t.Parallel()
+
+	result := &sidecarPatchResult{
+		OriginalManifestYAML: "kind: Deployment\n",
+		PatchedManifest:      map[string]interface{}{"kind": "Deployment"},
+	}
+
+	opts := sidecarOptions{
+		output: "",
+		emit:   emitKustomize,
+	}
+
+	err := emitKustomizeFormat(result, opts)
+	if err == nil {
+		t.Fatal("expected error for empty output directory")
+	}
+	if !strings.Contains(err.Error(), "--output directory required") {
+		t.Errorf("error should mention required output, got: %s", err.Error())
+	}
+}
+
+func TestEmitKustomizeFormat_NoOverwriteWithoutForce(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outDir := filepath.Join(dir, "kustomize-output")
+	result := &sidecarPatchResult{
+		OriginalManifestYAML: "kind: Deployment\n",
+		PatchedManifest:      map[string]interface{}{"kind": "Deployment"},
+		ConfigMapYAML:        "kind: ConfigMap\n",
+		NetworkPolicyYAML:    "kind: NetworkPolicy\n",
+	}
+	opts := sidecarOptions{
+		output: outDir,
+		emit:   emitKustomize,
+	}
+
+	if err := emitKustomizeFormat(result, opts); err != nil {
+		t.Fatalf("first emitKustomizeFormat: %v", err)
+	}
+
+	err := emitKustomizeFormat(result, opts)
+	if err == nil {
+		t.Fatal("expected overwrite error on second emit without --force")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected already exists error, got: %v", err)
+	}
+}
+
+func TestEmitHelmValuesFormat(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "values.yaml")
+
+	result := &sidecarPatchResult{
+		PatchedManifest: map[string]interface{}{
+			"kind": "Deployment",
+		},
+		AgentIdentity: "deployment/test-agent",
+	}
+
+	opts := sidecarOptions{
+		output: outPath,
+		emit:   emitHelmValues,
+		preset: config.ModeBalanced,
+	}
+
+	if err := emitHelmValuesFormat(nil, result, opts); err != nil {
+		t.Fatalf("emitHelmValuesFormat: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(outPath))
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+
+	content := string(data)
+
+	// Verify the header comment is present.
+	if !strings.Contains(content, "Pipelock Helm chart values") {
+		t.Error("output should contain the Helm header comment")
+	}
+
+	// Parse the YAML (skip comment header lines).
+	var values map[string]interface{}
+	if err := yaml.Unmarshal(data, &values); err != nil {
+		t.Fatalf("parsing helm values: %v", err)
+	}
+
+	// Verify expected top-level keys.
+	if _, ok := values["image"]; !ok {
+		t.Error("helm values should contain 'image' key")
+	}
+	if _, ok := values["pipelock"]; !ok {
+		t.Error("helm values should contain 'pipelock' key")
+	}
+	if _, ok := values["networkPolicy"]; !ok {
+		t.Error("helm values should contain 'networkPolicy' key")
+	}
+
+	// Verify image defaults.
+	imgMap, ok := values["image"].(map[string]interface{})
+	if !ok {
+		t.Fatal("image value should be a map")
+	}
+	if imgMap["repository"] != defaultImageRepo {
+		t.Errorf("image.repository = %v, want %s", imgMap["repository"], defaultImageRepo)
+	}
+	if imgMap["tag"] != cliutil.Version {
+		t.Errorf("image.tag = %v, want %s", imgMap["tag"], cliutil.Version)
+	}
+	if imgMap["digest"] != "" {
+		t.Errorf("image.digest = %v, want empty string", imgMap["digest"])
+	}
+
+	// Verify pipelock section.
+	plMap, ok := values["pipelock"].(map[string]interface{})
+	if !ok {
+		t.Fatal("pipelock value should be a map")
+	}
+	if plMap["mode"] != config.ModeBalanced {
+		t.Errorf("pipelock.mode = %v, want %s", plMap["mode"], config.ModeBalanced)
+	}
+	if plMap["default_agent_identity"] != "deployment/test-agent" {
+		t.Errorf("pipelock.default_agent_identity = %v, want deployment/test-agent",
+			plMap["default_agent_identity"])
+	}
+}
+
+func TestEmitHelmValuesFormat_CustomImage(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "values-custom.yaml")
+
+	result := &sidecarPatchResult{
+		PatchedManifest: map[string]interface{}{
+			"kind": "Deployment",
+		},
+		AgentIdentity: "deployment/agent",
+	}
+
+	opts := sidecarOptions{
+		output: outPath,
+		emit:   emitHelmValues,
+		preset: config.ModeStrict,
+		image:  "registry.example.com/pipelock:v1.2.3",
+	}
+
+	if err := emitHelmValuesFormat(nil, result, opts); err != nil {
+		t.Fatalf("emitHelmValuesFormat: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(outPath))
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+
+	var values map[string]interface{}
+	if err := yaml.Unmarshal(data, &values); err != nil {
+		t.Fatalf("parsing helm values: %v", err)
+	}
+
+	imgMap, ok := values["image"].(map[string]interface{})
+	if !ok {
+		t.Fatal("image value should be a map")
+	}
+	if imgMap["repository"] != "registry.example.com/pipelock" {
+		t.Errorf("image.repository = %v, want registry.example.com/pipelock",
+			imgMap["repository"])
+	}
+	if imgMap["tag"] != "v1.2.3" {
+		t.Errorf("image.tag = %v, want v1.2.3", imgMap["tag"])
+	}
+	if imgMap["digest"] != "" {
+		t.Errorf("image.digest = %v, want empty string", imgMap["digest"])
+	}
+}
+
+func TestEmitHelmValuesFormat_DigestImage(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "values-digest.yaml")
+
+	result := &sidecarPatchResult{
+		PatchedManifest: map[string]interface{}{"kind": "Deployment"},
+		AgentIdentity:   "deployment/agent",
+	}
+
+	opts := sidecarOptions{
+		output: outPath,
+		emit:   emitHelmValues,
+		preset: config.ModeStrict,
+		image:  "ghcr.io/luckypipewrench/pipelock@sha256:deadbeef",
+	}
+
+	if err := emitHelmValuesFormat(nil, result, opts); err != nil {
+		t.Fatalf("emitHelmValuesFormat: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(outPath))
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+
+	var values map[string]interface{}
+	if err := yaml.Unmarshal(data, &values); err != nil {
+		t.Fatalf("parsing helm values: %v", err)
+	}
+
+	imgMap, ok := values["image"].(map[string]interface{})
+	if !ok {
+		t.Fatal("image value should be a map")
+	}
+	if imgMap["repository"] != "ghcr.io/luckypipewrench/pipelock" {
+		t.Errorf("image.repository = %v, want ghcr.io/luckypipewrench/pipelock", imgMap["repository"])
+	}
+	if imgMap["digest"] != "sha256:deadbeef" {
+		t.Errorf("image.digest = %v, want sha256:deadbeef", imgMap["digest"])
+	}
+	if imgMap["tag"] != "" {
+		t.Errorf("image.tag = %v, want empty string", imgMap["tag"])
+	}
+}
+
+func TestEmitPatched_UnknownFormat(t *testing.T) {
+	t.Parallel()
+
+	result := &sidecarPatchResult{
+		PatchedManifest: map[string]interface{}{"kind": "Deployment"},
+	}
+
+	opts := sidecarOptions{
+		emit: "unknown-format",
+	}
+
+	err := emitPatched(nil, result, opts)
+	if err == nil {
+		t.Fatal("expected error for unknown emit format")
+	}
+	if !strings.Contains(err.Error(), "unknown emit format") {
+		t.Errorf("error should mention unknown format, got: %s", err.Error())
+	}
+}

--- a/internal/cli/setup/sidecar_emit_test.go
+++ b/internal/cli/setup/sidecar_emit_test.go
@@ -16,6 +16,20 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
+func mustPatchResult(t *testing.T, opts sidecarOptions) *sidecarPatchResult {
+	t.Helper()
+
+	manifest, err := detectWorkload(testdataPath(t, "deployment.yaml"))
+	if err != nil {
+		t.Fatalf("detectWorkload: %v", err)
+	}
+	result, err := generateSidecarPatch(manifest, opts)
+	if err != nil {
+		t.Fatalf("generateSidecarPatch: %v", err)
+	}
+	return result
+}
+
 func TestParseImageRef(t *testing.T) {
 	t.Parallel()
 
@@ -26,54 +40,14 @@ func TestParseImageRef(t *testing.T) {
 		wantTag string
 		wantDig string
 	}{
-		{
-			name:    "ghcr with version tag",
-			ref:     "ghcr.io/luckypipewrench/pipelock:v2.1.2",
-			wantRep: "ghcr.io/luckypipewrench/pipelock",
-			wantTag: "v2.1.2",
-		},
-		{
-			name:    "custom registry with latest",
-			ref:     "myregistry.com/pipelock:latest",
-			wantRep: "myregistry.com/pipelock",
-			wantTag: "latest",
-		},
-		{
-			name:    "bare image no tag",
-			ref:     "pipelock",
-			wantRep: "pipelock",
-			wantTag: "latest",
-		},
-		{
-			name:    "custom registry with sha256 tag",
-			ref:     "myregistry.com/pipelock:sha256-abc",
-			wantRep: "myregistry.com/pipelock",
-			wantTag: "sha256-abc",
-		},
-		{
-			name:    "nested path with tag",
-			ref:     "registry.example.com/org/sub/pipelock:v1.0.0",
-			wantRep: "registry.example.com/org/sub/pipelock",
-			wantTag: "v1.0.0",
-		},
-		{
-			name:    "port in registry with tag",
-			ref:     "localhost:5000/pipelock:dev",
-			wantRep: "localhost:5000/pipelock",
-			wantTag: "dev",
-		},
-		{
-			name:    "image with only registry no tag",
-			ref:     "myregistry.com/pipelock",
-			wantRep: "myregistry.com/pipelock",
-			wantTag: "latest",
-		},
-		{
-			name:    "digest reference",
-			ref:     "ghcr.io/luckypipewrench/pipelock@sha256:deadbeef",
-			wantRep: "ghcr.io/luckypipewrench/pipelock",
-			wantDig: "sha256:deadbeef",
-		},
+		{name: "ghcr with version tag", ref: "ghcr.io/luckypipewrench/pipelock:v2.1.2", wantRep: "ghcr.io/luckypipewrench/pipelock", wantTag: "v2.1.2"},
+		{name: "custom registry with latest", ref: "myregistry.com/pipelock:latest", wantRep: "myregistry.com/pipelock", wantTag: "latest"},
+		{name: "bare image no tag", ref: "pipelock", wantRep: "pipelock", wantTag: "latest"},
+		{name: "custom registry with sha256 tag", ref: "myregistry.com/pipelock:sha256-abc", wantRep: "myregistry.com/pipelock", wantTag: "sha256-abc"},
+		{name: "nested path with tag", ref: "registry.example.com/org/sub/pipelock:v1.0.0", wantRep: "registry.example.com/org/sub/pipelock", wantTag: "v1.0.0"},
+		{name: "port in registry with tag", ref: "localhost:5000/pipelock:dev", wantRep: "localhost:5000/pipelock", wantTag: "dev"},
+		{name: "image with only registry no tag", ref: "myregistry.com/pipelock", wantRep: "myregistry.com/pipelock", wantTag: "latest"},
+		{name: "digest reference", ref: "ghcr.io/luckypipewrench/pipelock@sha256:deadbeef", wantRep: "ghcr.io/luckypipewrench/pipelock", wantDig: "sha256:deadbeef"},
 	}
 
 	for _, tc := range tests {
@@ -81,13 +55,13 @@ func TestParseImageRef(t *testing.T) {
 			t.Parallel()
 			got := parseImageRef(tc.ref)
 			if got.Repository != tc.wantRep {
-				t.Errorf("parseImageRef(%q) repo = %q, want %q", tc.ref, got.Repository, tc.wantRep)
+				t.Fatalf("parseImageRef(%q) repo = %q, want %q", tc.ref, got.Repository, tc.wantRep)
 			}
 			if got.Tag != tc.wantTag {
-				t.Errorf("parseImageRef(%q) tag = %q, want %q", tc.ref, got.Tag, tc.wantTag)
+				t.Fatalf("parseImageRef(%q) tag = %q, want %q", tc.ref, got.Tag, tc.wantTag)
 			}
 			if got.Digest != tc.wantDig {
-				t.Errorf("parseImageRef(%q) digest = %q, want %q", tc.ref, got.Digest, tc.wantDig)
+				t.Fatalf("parseImageRef(%q) digest = %q, want %q", tc.ref, got.Digest, tc.wantDig)
 			}
 		})
 	}
@@ -109,7 +83,7 @@ func TestWriteOutput_File(t *testing.T) {
 		t.Fatalf("reading output: %v", err)
 	}
 	if string(data) != string(content) {
-		t.Errorf("file content = %q, want %q", string(data), string(content))
+		t.Fatalf("file content = %q, want %q", string(data), string(content))
 	}
 
 	info, err := os.Stat(outPath)
@@ -117,7 +91,7 @@ func TestWriteOutput_File(t *testing.T) {
 		t.Fatalf("stat: %v", err)
 	}
 	if perm := info.Mode().Perm(); perm != 0o600 {
-		t.Errorf("file permission = %o, want 600", perm)
+		t.Fatalf("file permission = %o, want 600", perm)
 	}
 }
 
@@ -126,8 +100,7 @@ func TestWriteOutput_Stdout(t *testing.T) {
 
 	var buf bytes.Buffer
 	content := []byte("stdout-content\n")
-	err := writeOutput(&buf, content, "", false)
-	if err != nil {
+	if err := writeOutput(&buf, content, "", false); err != nil {
 		t.Fatalf("writeOutput to stdout: %v", err)
 	}
 	if buf.String() != string(content) {
@@ -140,8 +113,6 @@ func TestWriteOutput_NoOverwrite(t *testing.T) {
 
 	dir := t.TempDir()
 	outPath := filepath.Join(dir, "existing.yaml")
-
-	// Create an existing file.
 	if err := os.WriteFile(outPath, []byte("original"), 0o600); err != nil {
 		t.Fatalf("writing seed file: %v", err)
 	}
@@ -151,16 +122,7 @@ func TestWriteOutput_NoOverwrite(t *testing.T) {
 		t.Fatal("expected error when file exists and force=false")
 	}
 	if !strings.Contains(err.Error(), "already exists") {
-		t.Errorf("error should contain 'already exists', got: %s", err.Error())
-	}
-
-	// Verify original content is preserved.
-	data, err := os.ReadFile(filepath.Clean(outPath))
-	if err != nil {
-		t.Fatalf("reading file: %v", err)
-	}
-	if string(data) != "original" {
-		t.Errorf("original file was modified: got %q", string(data))
+		t.Fatalf("error should contain 'already exists', got: %s", err.Error())
 	}
 }
 
@@ -169,23 +131,19 @@ func TestWriteOutput_ForceOverwrite(t *testing.T) {
 
 	dir := t.TempDir()
 	outPath := filepath.Join(dir, "existing.yaml")
-
-	// Create an existing file.
 	if err := os.WriteFile(outPath, []byte("original"), 0o600); err != nil {
 		t.Fatalf("writing seed file: %v", err)
 	}
 
-	newContent := []byte("overwritten-content")
-	if err := writeOutput(nil, newContent, outPath, true); err != nil {
+	if err := writeOutput(nil, []byte("overwritten-content"), outPath, true); err != nil {
 		t.Fatalf("writeOutput with force: %v", err)
 	}
-
 	data, err := os.ReadFile(filepath.Clean(outPath))
 	if err != nil {
 		t.Fatalf("reading file: %v", err)
 	}
-	if string(data) != string(newContent) {
-		t.Errorf("file content = %q, want %q", string(data), string(newContent))
+	if string(data) != "overwritten-content" {
+		t.Fatalf("file content = %q, want overwritten-content", string(data))
 	}
 }
 
@@ -194,13 +152,11 @@ func TestWriteOutput_CreatesParentDirs(t *testing.T) {
 
 	dir := t.TempDir()
 	outPath := filepath.Join(dir, "nested", "deep", "output.yaml")
-
 	if err := writeOutput(nil, []byte("nested"), outPath, false); err != nil {
 		t.Fatalf("writeOutput: %v", err)
 	}
-
 	if _, err := os.Stat(outPath); os.IsNotExist(err) {
-		t.Error("output file was not created")
+		t.Fatal("output file was not created")
 	}
 }
 
@@ -209,29 +165,9 @@ func TestEmitPatchFormat(t *testing.T) {
 
 	dir := t.TempDir()
 	outPath := filepath.Join(dir, "patch-output.yaml")
+	result := mustPatchResult(t, sidecarOptions{preset: config.ModeBalanced})
 
-	result := &sidecarPatchResult{
-		PatchedManifest: map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "test-agent",
-			},
-			"spec": map[string]interface{}{
-				"replicas": 1,
-			},
-		},
-		ConfigMapYAML:     "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: pipelock-config\n",
-		NetworkPolicyYAML: "apiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\nmetadata:\n  name: test-np\n",
-		AgentIdentity:     "deployment/test-agent",
-	}
-
-	opts := sidecarOptions{
-		output: outPath,
-		emit:   emitPatch,
-	}
-
-	if err := emitPatchFormat(nil, result, opts); err != nil {
+	if err := emitPatchFormat(nil, result, sidecarOptions{output: outPath, emit: emitPatch}); err != nil {
 		t.Fatalf("emitPatchFormat: %v", err)
 	}
 
@@ -239,28 +175,15 @@ func TestEmitPatchFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading output: %v", err)
 	}
-
 	content := string(data)
 
-	// Verify the output contains the three YAML documents separated by "---".
-	docSeparatorCount := strings.Count(content, "---")
-	if docSeparatorCount < 2 {
-		t.Errorf("expected at least 2 document separators, got %d", docSeparatorCount)
+	if docSeparatorCount := strings.Count(content, "---"); docSeparatorCount < 6 {
+		t.Fatalf("expected at least 6 document separators, got %d", docSeparatorCount)
 	}
-
-	// Verify the patched manifest is present.
-	if !strings.Contains(content, "Deployment") {
-		t.Error("output should contain the Deployment kind")
-	}
-
-	// Verify ConfigMap YAML is present.
-	if !strings.Contains(content, "ConfigMap") {
-		t.Error("output should contain the ConfigMap")
-	}
-
-	// Verify NetworkPolicy YAML is present.
-	if !strings.Contains(content, "NetworkPolicy") {
-		t.Error("output should contain the NetworkPolicy")
+	for _, needle := range []string{"kind: Deployment", "kind: ConfigMap", "kind: Service", "kind: NetworkPolicy", "kind: PodDisruptionBudget"} {
+		if !strings.Contains(content, needle) {
+			t.Fatalf("output should contain %q", needle)
+		}
 	}
 }
 
@@ -269,112 +192,80 @@ func TestEmitKustomizeFormat(t *testing.T) {
 
 	dir := t.TempDir()
 	outDir := filepath.Join(dir, "kustomize-output")
+	result := mustPatchResult(t, sidecarOptions{preset: config.ModeBalanced})
 
-	result := &sidecarPatchResult{
-		OriginalManifestYAML: "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: test-agent\n",
-		PatchedManifest: map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "test-agent",
-			},
-		},
-		ConfigMapYAML:     "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: pipelock-config\n",
-		NetworkPolicyYAML: "apiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\nmetadata:\n  name: test-np\n",
-		AgentIdentity:     "deployment/test-agent",
-	}
-
-	opts := sidecarOptions{
-		output: outDir,
-		emit:   emitKustomize,
-	}
-
-	if err := emitKustomizeFormat(result, opts); err != nil {
+	if err := emitKustomizeFormat(result, sidecarOptions{output: outDir, emit: emitKustomize}); err != nil {
 		t.Fatalf("emitKustomizeFormat: %v", err)
 	}
 
-	// Verify all 5 expected files were created.
 	expectedFiles := []string{
 		"kustomization.yaml",
-		"workload.yaml",
-		"pipelock-sidecar-patch.yaml",
+		"agent-workload.yaml",
 		"pipelock-configmap.yaml",
+		"pipelock-deployment.yaml",
+		"pipelock-service.yaml",
+		"agent-networkpolicy.yaml",
 		"pipelock-networkpolicy.yaml",
+		"pipelock-pdb.yaml",
 	}
-
 	for _, name := range expectedFiles {
 		path := filepath.Join(outDir, name)
 		info, err := os.Stat(path)
-		if os.IsNotExist(err) {
-			t.Errorf("expected file %s not created", name)
-			continue
-		}
 		if err != nil {
-			t.Errorf("stat %s: %v", name, err)
-			continue
+			t.Fatalf("stat %s: %v", name, err)
 		}
 		if info.Size() == 0 {
-			t.Errorf("file %s is empty", name)
+			t.Fatalf("file %s is empty", name)
 		}
 		if perm := info.Mode().Perm(); perm != 0o600 {
-			t.Errorf("file %s permission = %o, want 600", name, perm)
+			t.Fatalf("file %s permission = %o, want 600", name, perm)
 		}
 	}
 
-	// Verify kustomization.yaml has expected structure.
 	kustomData, err := os.ReadFile(filepath.Clean(filepath.Join(outDir, "kustomization.yaml")))
 	if err != nil {
 		t.Fatalf("reading kustomization.yaml: %v", err)
 	}
-
 	var kustomization map[string]interface{}
 	if err := yaml.Unmarshal(kustomData, &kustomization); err != nil {
 		t.Fatalf("parsing kustomization.yaml: %v", err)
 	}
-
-	if kustomization["apiVersion"] != "kustomize.config.k8s.io/v1beta1" {
-		t.Errorf("kustomization apiVersion = %v, want kustomize.config.k8s.io/v1beta1",
-			kustomization["apiVersion"])
-	}
-	if kustomization["kind"] != "Kustomization" {
-		t.Errorf("kustomization kind = %v, want Kustomization", kustomization["kind"])
-	}
-
 	resources, ok := kustomization["resources"].([]interface{})
 	if !ok {
 		t.Fatal("kustomization resources should be a list")
 	}
-	foundWorkload := false
+	wantResources := map[string]bool{
+		"agent-workload.yaml":         false,
+		"pipelock-configmap.yaml":     false,
+		"pipelock-deployment.yaml":    false,
+		"pipelock-service.yaml":       false,
+		"agent-networkpolicy.yaml":    false,
+		"pipelock-networkpolicy.yaml": false,
+		"pipelock-pdb.yaml":           false,
+	}
 	for _, resource := range resources {
-		if resource == "workload.yaml" {
-			foundWorkload = true
-			break
+		name, _ := resource.(string)
+		if _, ok := wantResources[name]; ok {
+			wantResources[name] = true
 		}
 	}
-	if !foundWorkload {
-		t.Fatal("kustomization resources should include workload.yaml")
+	for name, found := range wantResources {
+		if !found {
+			t.Fatalf("kustomization resources missing %s", name)
+		}
 	}
 }
 
 func TestEmitKustomizeFormat_EmptyOutputDir(t *testing.T) {
 	t.Parallel()
 
-	result := &sidecarPatchResult{
-		OriginalManifestYAML: "kind: Deployment\n",
-		PatchedManifest:      map[string]interface{}{"kind": "Deployment"},
-	}
-
-	opts := sidecarOptions{
-		output: "",
-		emit:   emitKustomize,
-	}
-
-	err := emitKustomizeFormat(result, opts)
+	result := mustPatchResult(t, sidecarOptions{preset: config.ModeBalanced})
+	err := emitKustomizeFormat(result, sidecarOptions{output: "", emit: emitKustomize})
 	if err == nil {
 		t.Fatal("expected error for empty output directory")
 	}
 	if !strings.Contains(err.Error(), "--output directory required") {
-		t.Errorf("error should mention required output, got: %s", err.Error())
+		t.Fatalf("error should mention required output, got: %s", err.Error())
 	}
 }
 
@@ -383,22 +274,12 @@ func TestEmitKustomizeFormat_NoOverwriteWithoutForce(t *testing.T) {
 
 	dir := t.TempDir()
 	outDir := filepath.Join(dir, "kustomize-output")
-	result := &sidecarPatchResult{
-		OriginalManifestYAML: "kind: Deployment\n",
-		PatchedManifest:      map[string]interface{}{"kind": "Deployment"},
-		ConfigMapYAML:        "kind: ConfigMap\n",
-		NetworkPolicyYAML:    "kind: NetworkPolicy\n",
-	}
-	opts := sidecarOptions{
-		output: outDir,
-		emit:   emitKustomize,
-	}
+	result := mustPatchResult(t, sidecarOptions{preset: config.ModeBalanced})
 
-	if err := emitKustomizeFormat(result, opts); err != nil {
+	if err := emitKustomizeFormat(result, sidecarOptions{output: outDir, emit: emitKustomize}); err != nil {
 		t.Fatalf("first emitKustomizeFormat: %v", err)
 	}
-
-	err := emitKustomizeFormat(result, opts)
+	err := emitKustomizeFormat(result, sidecarOptions{output: outDir, emit: emitKustomize})
 	if err == nil {
 		t.Fatal("expected overwrite error on second emit without --force")
 	}
@@ -411,80 +292,96 @@ func TestEmitHelmValuesFormat(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	outPath := filepath.Join(dir, "values.yaml")
+	outDir := filepath.Join(dir, "helm-bundle")
+	result := mustPatchResult(t, sidecarOptions{preset: config.ModeBalanced})
 
-	result := &sidecarPatchResult{
-		PatchedManifest: map[string]interface{}{
-			"kind": "Deployment",
-		},
-		AgentIdentity: "deployment/test-agent",
-	}
-
-	opts := sidecarOptions{
-		output: outPath,
-		emit:   emitHelmValues,
-		preset: config.ModeBalanced,
-	}
-
-	if err := emitHelmValuesFormat(nil, result, opts); err != nil {
+	if err := emitHelmValuesFormat(nil, result, sidecarOptions{output: outDir, emit: emitHelmValues, preset: config.ModeBalanced}); err != nil {
 		t.Fatalf("emitHelmValuesFormat: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Clean(outPath))
+	for _, name := range []string{"values.yaml", "agent-workload.yaml", "agent-networkpolicy.yaml", "pipelock-networkpolicy.yaml", "pipelock-pdb.yaml", "README.txt"} {
+		if _, err := os.Stat(filepath.Join(outDir, name)); err != nil {
+			t.Fatalf("expected file %s: %v", name, err)
+		}
+	}
+
+	data, err := os.ReadFile(filepath.Clean(filepath.Join(outDir, "values.yaml")))
 	if err != nil {
-		t.Fatalf("reading output: %v", err)
+		t.Fatalf("reading values.yaml: %v", err)
+	}
+	if !strings.Contains(string(data), "Pipelock Helm bundle values") {
+		t.Fatal("values.yaml should contain the bundle header comment")
 	}
 
-	content := string(data)
-
-	// Verify the header comment is present.
-	if !strings.Contains(content, "Pipelock Helm chart values") {
-		t.Error("output should contain the Helm header comment")
-	}
-
-	// Parse the YAML (skip comment header lines).
 	var values map[string]interface{}
 	if err := yaml.Unmarshal(data, &values); err != nil {
 		t.Fatalf("parsing helm values: %v", err)
 	}
-
-	// Verify expected top-level keys.
-	if _, ok := values["image"]; !ok {
-		t.Error("helm values should contain 'image' key")
+	if values["fullnameOverride"] != result.ProxyName {
+		t.Fatalf("fullnameOverride = %v, want %q", values["fullnameOverride"], result.ProxyName)
 	}
-	if _, ok := values["pipelock"]; !ok {
-		t.Error("helm values should contain 'pipelock' key")
-	}
-	if _, ok := values["networkPolicy"]; !ok {
-		t.Error("helm values should contain 'networkPolicy' key")
+	if values["replicaCount"] != proxyReplicaCount {
+		t.Fatalf("replicaCount = %v, want %d", values["replicaCount"], proxyReplicaCount)
 	}
 
-	// Verify image defaults.
-	imgMap, ok := values["image"].(map[string]interface{})
-	if !ok {
-		t.Fatal("image value should be a map")
-	}
+	imgMap := values["image"].(map[string]interface{})
 	if imgMap["repository"] != defaultImageRepo {
-		t.Errorf("image.repository = %v, want %s", imgMap["repository"], defaultImageRepo)
+		t.Fatalf("image.repository = %v, want %s", imgMap["repository"], defaultImageRepo)
 	}
 	if imgMap["tag"] != cliutil.Version {
-		t.Errorf("image.tag = %v, want %s", imgMap["tag"], cliutil.Version)
+		t.Fatalf("image.tag = %v, want %s", imgMap["tag"], cliutil.Version)
 	}
 	if imgMap["digest"] != "" {
-		t.Errorf("image.digest = %v, want empty string", imgMap["digest"])
+		t.Fatalf("image.digest = %v, want empty string", imgMap["digest"])
+	}
+	if imgMap["pullPolicy"] != "IfNotPresent" {
+		t.Fatalf("image.pullPolicy = %v, want IfNotPresent", imgMap["pullPolicy"])
 	}
 
-	// Verify pipelock section.
-	plMap, ok := values["pipelock"].(map[string]interface{})
-	if !ok {
-		t.Fatal("pipelock value should be a map")
+	resources := values["resources"].(map[string]interface{})
+	requests := resources["requests"].(map[string]interface{})
+	limits := resources["limits"].(map[string]interface{})
+	if requests["cpu"] != proxyCPURequest || requests["memory"] != proxyMemoryRequest {
+		t.Fatalf("requests = %v, want cpu=%s memory=%s", requests, proxyCPURequest, proxyMemoryRequest)
 	}
+	if limits["cpu"] != proxyCPULimit || limits["memory"] != proxyMemoryLimit {
+		t.Fatalf("limits = %v, want cpu=%s memory=%s", limits, proxyCPULimit, proxyMemoryLimit)
+	}
+	if _, ok := values["affinity"].(map[string]interface{}); !ok {
+		t.Fatal("values.yaml should include affinity")
+	}
+	podLabels := values["podLabels"].(map[string]interface{})
+	if podLabels["app.kubernetes.io/component"] != "proxy" {
+		t.Fatalf("podLabels.component = %v, want proxy", podLabels["app.kubernetes.io/component"])
+	}
+
+	plMap := values["pipelock"].(map[string]interface{})
 	if plMap["mode"] != config.ModeBalanced {
-		t.Errorf("pipelock.mode = %v, want %s", plMap["mode"], config.ModeBalanced)
+		t.Fatalf("pipelock.mode = %v, want %s", plMap["mode"], config.ModeBalanced)
 	}
-	if plMap["default_agent_identity"] != "deployment/test-agent" {
-		t.Errorf("pipelock.default_agent_identity = %v, want deployment/test-agent",
-			plMap["default_agent_identity"])
+	if plMap["default_agent_identity"] != result.AgentIdentity {
+		t.Fatalf("pipelock.default_agent_identity = %v, want %q", plMap["default_agent_identity"], result.AgentIdentity)
+	}
+	if bind, _ := plMap["bind_default_agent_identity"].(bool); !bind {
+		t.Fatalf("pipelock.bind_default_agent_identity = %v, want true", plMap["bind_default_agent_identity"])
+	}
+	forwardProxy := plMap["forward_proxy"].(map[string]interface{})
+	if enabled, _ := forwardProxy["enabled"].(bool); !enabled {
+		t.Fatal("pipelock.forward_proxy.enabled should be true")
+	}
+
+	readme, err := os.ReadFile(filepath.Clean(filepath.Join(outDir, "README.txt")))
+	if err != nil {
+		t.Fatalf("reading README.txt: %v", err)
+	}
+	if !strings.Contains(string(readme), "helm upgrade --install") {
+		t.Fatal("README.txt should contain install instructions")
+	}
+	if !strings.Contains(string(readme), "kubectl rollout status deployment/") {
+		t.Fatal("README.txt should include rollout status guidance")
+	}
+	if !strings.Contains(string(readme), "pipelock-pdb.yaml") {
+		t.Fatal("README.txt should include the PDB apply command")
 	}
 }
 
@@ -492,49 +389,38 @@ func TestEmitHelmValuesFormat_CustomImage(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	outPath := filepath.Join(dir, "values-custom.yaml")
+	outDir := filepath.Join(dir, "helm-custom")
+	result := mustPatchResult(t, sidecarOptions{
+		preset: config.ModeStrict,
+		image:  "registry.example.com/pipelock:v1.2.3",
+	})
 
-	result := &sidecarPatchResult{
-		PatchedManifest: map[string]interface{}{
-			"kind": "Deployment",
-		},
-		AgentIdentity: "deployment/agent",
-	}
-
-	opts := sidecarOptions{
-		output: outPath,
+	if err := emitHelmValuesFormat(nil, result, sidecarOptions{
+		output: outDir,
 		emit:   emitHelmValues,
 		preset: config.ModeStrict,
 		image:  "registry.example.com/pipelock:v1.2.3",
-	}
-
-	if err := emitHelmValuesFormat(nil, result, opts); err != nil {
+	}); err != nil {
 		t.Fatalf("emitHelmValuesFormat: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Clean(outPath))
+	data, err := os.ReadFile(filepath.Clean(filepath.Join(outDir, "values.yaml")))
 	if err != nil {
-		t.Fatalf("reading output: %v", err)
+		t.Fatalf("reading values.yaml: %v", err)
 	}
-
 	var values map[string]interface{}
 	if err := yaml.Unmarshal(data, &values); err != nil {
 		t.Fatalf("parsing helm values: %v", err)
 	}
-
-	imgMap, ok := values["image"].(map[string]interface{})
-	if !ok {
-		t.Fatal("image value should be a map")
-	}
+	imgMap := values["image"].(map[string]interface{})
 	if imgMap["repository"] != "registry.example.com/pipelock" {
-		t.Errorf("image.repository = %v, want registry.example.com/pipelock",
-			imgMap["repository"])
+		t.Fatalf("image.repository = %v, want registry.example.com/pipelock", imgMap["repository"])
 	}
 	if imgMap["tag"] != "v1.2.3" {
-		t.Errorf("image.tag = %v, want v1.2.3", imgMap["tag"])
+		t.Fatalf("image.tag = %v, want v1.2.3", imgMap["tag"])
 	}
 	if imgMap["digest"] != "" {
-		t.Errorf("image.digest = %v, want empty string", imgMap["digest"])
+		t.Fatalf("image.digest = %v, want empty string", imgMap["digest"])
 	}
 }
 
@@ -542,65 +428,49 @@ func TestEmitHelmValuesFormat_DigestImage(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	outPath := filepath.Join(dir, "values-digest.yaml")
+	outDir := filepath.Join(dir, "helm-digest")
+	result := mustPatchResult(t, sidecarOptions{
+		preset: config.ModeStrict,
+		image:  "ghcr.io/luckypipewrench/pipelock@sha256:deadbeef",
+	})
 
-	result := &sidecarPatchResult{
-		PatchedManifest: map[string]interface{}{"kind": "Deployment"},
-		AgentIdentity:   "deployment/agent",
-	}
-
-	opts := sidecarOptions{
-		output: outPath,
+	if err := emitHelmValuesFormat(nil, result, sidecarOptions{
+		output: outDir,
 		emit:   emitHelmValues,
 		preset: config.ModeStrict,
 		image:  "ghcr.io/luckypipewrench/pipelock@sha256:deadbeef",
-	}
-
-	if err := emitHelmValuesFormat(nil, result, opts); err != nil {
+	}); err != nil {
 		t.Fatalf("emitHelmValuesFormat: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Clean(outPath))
+	data, err := os.ReadFile(filepath.Clean(filepath.Join(outDir, "values.yaml")))
 	if err != nil {
-		t.Fatalf("reading output: %v", err)
+		t.Fatalf("reading values.yaml: %v", err)
 	}
-
 	var values map[string]interface{}
 	if err := yaml.Unmarshal(data, &values); err != nil {
 		t.Fatalf("parsing helm values: %v", err)
 	}
-
-	imgMap, ok := values["image"].(map[string]interface{})
-	if !ok {
-		t.Fatal("image value should be a map")
-	}
+	imgMap := values["image"].(map[string]interface{})
 	if imgMap["repository"] != "ghcr.io/luckypipewrench/pipelock" {
-		t.Errorf("image.repository = %v, want ghcr.io/luckypipewrench/pipelock", imgMap["repository"])
+		t.Fatalf("image.repository = %v, want ghcr.io/luckypipewrench/pipelock", imgMap["repository"])
 	}
 	if imgMap["digest"] != "sha256:deadbeef" {
-		t.Errorf("image.digest = %v, want sha256:deadbeef", imgMap["digest"])
+		t.Fatalf("image.digest = %v, want sha256:deadbeef", imgMap["digest"])
 	}
 	if imgMap["tag"] != "" {
-		t.Errorf("image.tag = %v, want empty string", imgMap["tag"])
+		t.Fatalf("image.tag = %v, want empty string", imgMap["tag"])
 	}
 }
 
 func TestEmitPatched_UnknownFormat(t *testing.T) {
 	t.Parallel()
 
-	result := &sidecarPatchResult{
-		PatchedManifest: map[string]interface{}{"kind": "Deployment"},
-	}
-
-	opts := sidecarOptions{
-		emit: "unknown-format",
-	}
-
-	err := emitPatched(nil, result, opts)
+	err := emitPatched(nil, mustPatchResult(t, sidecarOptions{preset: config.ModeBalanced}), sidecarOptions{emit: "unknown-format"})
 	if err == nil {
 		t.Fatal("expected error for unknown emit format")
 	}
 	if !strings.Contains(err.Error(), "unknown emit format") {
-		t.Errorf("error should mention unknown format, got: %s", err.Error())
+		t.Fatalf("error should mention unknown format, got: %s", err.Error())
 	}
 }

--- a/internal/cli/setup/sidecar_patch.go
+++ b/internal/cli/setup/sidecar_patch.go
@@ -1,10 +1,10 @@
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0
 
-// Package setup implements init flows. This file generates a strategic-merge
-// patch that injects a pipelock sidecar into Kubernetes workload manifests.
-// Strategic merge is used for container-level mutations (container additions,
-// env additions) because kubectl apply handles list-merge on container name.
+// Package setup implements init flows. This file generates an enforced
+// companion-proxy topology for Kubernetes workloads: the agent workload is
+// patched to talk to a separate pipelock proxy Service, and matching
+// NetworkPolicies keep direct agent egress off the wire.
 package setup
 
 import (
@@ -17,14 +17,16 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
-// Fixed names and values for the sidecar injection.
+// Fixed names and values for companion-proxy generation.
 const (
-	sidecarContainerName = "pipelock"
+	proxyContainerName   = "pipelock"
+	sidecarContainerName = proxyContainerName // legacy alias for pre-companion tests/helpers
 	sidecarConfigVolume  = "pipelock-config"
 	sidecarConfigMount   = "/etc/pipelock"
 	sidecarConfigFile    = "pipelock.yaml"
 	sidecarHealthPath    = "/health"
 	sidecarHealthPort    = 8888
+	sidecarMetricsPort   = 9091
 
 	// defaultImage is the GHCR image with the current version tag.
 	// Overridden by --image flag.
@@ -35,200 +37,191 @@ const (
 	envHTTPProxy  = "HTTP_PROXY"
 	envNoProxy    = "NO_PROXY"
 	noProxyValue  = "localhost,127.0.0.1,.svc,.cluster.local"
+
+	proxyReplicaCount = 2
+
+	proxyCPURequest    = "100m"
+	proxyMemoryRequest = "128Mi"
+	proxyCPULimit      = "500m"
+	proxyMemoryLimit   = "512Mi"
+
+	managedTopologyAnnotation     = "pipelock.dev/topology"
+	managedProxyNameAnnotation    = "pipelock.dev/proxy-name"
+	managedProxyServiceAnnotation = "pipelock.dev/proxy-service"
+	managedTopologyCompanion      = "companion-proxy"
+	managedByLabelValue           = "pipelock-init-sidecar"
 )
 
 // sidecarPatchResult holds the generated patch and related artifacts.
 type sidecarPatchResult struct {
 	// OriginalManifestYAML is the source workload manifest used for kustomize output.
 	OriginalManifestYAML string
-	// PatchedManifest is the full manifest with the sidecar injected.
+	// PatchedManifest is the full agent workload manifest with proxy env routing.
 	PatchedManifest map[string]interface{}
-	// ConfigMapYAML is the standalone ConfigMap for the pipelock config.
+	// Config is the rendered proxy config used for canary and topology verification.
+	Config *config.Config
+	// ConfigMapYAML is the standalone ConfigMap for the companion proxy.
 	ConfigMapYAML string
-	// NetworkPolicyYAML is a deny-all NetworkPolicy with explicit egress to the sidecar.
-	NetworkPolicyYAML string
+	// DeploymentYAML is the companion proxy Deployment.
+	DeploymentYAML string
+	// ServiceYAML is the companion proxy Service.
+	ServiceYAML string
+	// AgentNetworkPolicyYAML constrains the agent pods to DNS + pipelock proxy.
+	AgentNetworkPolicyYAML string
+	// ProxyNetworkPolicyYAML constrains the proxy pods to trusted ingress + web egress.
+	ProxyNetworkPolicyYAML string
+	// PodDisruptionBudgetYAML protects the proxy deployment during voluntary disruptions.
+	PodDisruptionBudgetYAML string
 	// AgentIdentity is the derived default_agent_identity value.
 	AgentIdentity string
+	// ProxyName is the generated name of the companion proxy resources.
+	ProxyName string
+	// ProxyURL is the Service URL injected into the agent workload.
+	ProxyURL string
+	// AgentSelectorLabels identify the protected agent pods.
+	AgentSelectorLabels map[string]string
+	// ProxySelectorLabels identify the companion proxy pods.
+	ProxySelectorLabels map[string]string
 }
 
-// generateSidecarPatch creates the patched manifest with the pipelock sidecar injected.
-// The patch is idempotent: if a pipelock container already exists, no changes are made.
+// generateSidecarPatch creates an enforced companion-proxy topology for the workload.
+// The patched manifest is the agent workload only; the companion proxy resources are
+// emitted separately.
 func generateSidecarPatch(manifest *workloadManifest, opts sidecarOptions) (*sidecarPatchResult, error) {
-	// Deep copy the raw manifest to avoid mutating the original.
 	patched, err := deepCopyMap(manifest.Raw)
 	if err != nil {
 		return nil, fmt.Errorf("deep copy manifest: %w", err)
 	}
-
 	podSpec, err := getPodSpec(patched, manifest.Kind)
 	if err != nil {
 		return nil, fmt.Errorf("locating pod spec: %w", err)
 	}
-
-	// Idempotency: if pipelock container already exists, return as-is.
-	if hasPipelockContainer(podSpec) {
-		return &sidecarPatchResult{
-			OriginalManifestYAML: string(manifest.RawBytes),
-			PatchedManifest:      patched,
-			AgentIdentity:        resolveAgentIdentity(manifest, opts),
-		}, nil
-	}
-
-	image := resolveImage(opts)
 	agentIdentity := resolveAgentIdentity(manifest, opts)
-
-	// Build the sidecar container spec.
-	sidecar := buildSidecarContainer(image, opts.preset)
-
-	// Add the sidecar container.
-	containers, _ := podSpec["containers"].([]interface{})
-	podSpec["containers"] = append(containers, sidecar)
-
-	// Add the config volume.
-	volumes, _ := podSpec["volumes"].([]interface{})
-	podSpec["volumes"] = append(volumes, map[string]interface{}{
-		"name": sidecarConfigVolume,
-		"configMap": map[string]interface{}{
-			"name": sidecarConfigVolume,
-		},
-	})
-
-	// Inject proxy env vars into existing primary container(s).
-	injectProxyEnvs(podSpec)
-
-	// Build the ConfigMap YAML.
-	pipelockCfg := buildConfig(opts.preset, nil)
-	pipelockCfg.DefaultAgentIdentity = agentIdentity
-	configMapYAML, err := renderConfigMap(pipelockCfg, opts.preset)
-	if err != nil {
-		return nil, fmt.Errorf("rendering ConfigMap: %w", err)
-	}
-
-	// Build the NetworkPolicy YAML.
 	namespace := extractNamespace(manifest.Raw)
 	selectorLabels, err := networkPolicySelectorLabels(manifest.Raw, manifest.Kind)
 	if err != nil {
 		return nil, fmt.Errorf("building NetworkPolicy selector: %w", err)
 	}
-	networkPolicyYAML, err := renderNetworkPolicy(namespace, manifest.Name, selectorLabels)
+
+	proxyName := resolveProxyName(manifest.Raw, manifest.Name)
+	proxyURL := proxyServiceURL(proxyName)
+	proxyLabels := proxySelectorLabels(proxyName)
+
+	if err := annotateManagedWorkload(patched, manifest.Kind, proxyName); err != nil {
+		return nil, fmt.Errorf("annotating workload: %w", err)
+	}
+	if err := injectProxyEnvs(podSpec, proxyURL); err != nil {
+		return nil, fmt.Errorf("injecting proxy env: %w", err)
+	}
+
+	proxyCfg := buildProxyConfig(opts.preset, agentIdentity)
+	configMapYAML, err := renderConfigMap(proxyCfg, opts.preset, namespace, proxyName, proxyLabels)
 	if err != nil {
-		return nil, fmt.Errorf("rendering NetworkPolicy: %w", err)
+		return nil, fmt.Errorf("rendering ConfigMap: %w", err)
+	}
+	deploymentYAML, err := renderProxyDeployment(namespace, proxyName, resolveImage(opts), proxyLabels)
+	if err != nil {
+		return nil, fmt.Errorf("rendering Deployment: %w", err)
+	}
+	serviceYAML, err := renderProxyService(namespace, proxyName, proxyLabels)
+	if err != nil {
+		return nil, fmt.Errorf("rendering Service: %w", err)
+	}
+	agentNetworkPolicyYAML, err := renderAgentNetworkPolicy(namespace, manifest.Name, selectorLabels, proxyLabels)
+	if err != nil {
+		return nil, fmt.Errorf("rendering agent NetworkPolicy: %w", err)
+	}
+	proxyNetworkPolicyYAML, err := renderProxyNetworkPolicy(namespace, proxyName, proxyLabels, selectorLabels)
+	if err != nil {
+		return nil, fmt.Errorf("rendering proxy NetworkPolicy: %w", err)
+	}
+	pdbYAML, err := renderProxyPodDisruptionBudget(namespace, proxyName, proxyLabels)
+	if err != nil {
+		return nil, fmt.Errorf("rendering PodDisruptionBudget: %w", err)
 	}
 
 	return &sidecarPatchResult{
-		OriginalManifestYAML: string(manifest.RawBytes),
-		PatchedManifest:      patched,
-		ConfigMapYAML:        configMapYAML,
-		NetworkPolicyYAML:    networkPolicyYAML,
-		AgentIdentity:        agentIdentity,
+		OriginalManifestYAML:    string(manifest.RawBytes),
+		PatchedManifest:         patched,
+		Config:                  proxyCfg,
+		ConfigMapYAML:           configMapYAML,
+		DeploymentYAML:          deploymentYAML,
+		ServiceYAML:             serviceYAML,
+		AgentNetworkPolicyYAML:  agentNetworkPolicyYAML,
+		ProxyNetworkPolicyYAML:  proxyNetworkPolicyYAML,
+		PodDisruptionBudgetYAML: pdbYAML,
+		AgentIdentity:           agentIdentity,
+		ProxyName:               proxyName,
+		ProxyURL:                proxyURL,
+		AgentSelectorLabels:     selectorLabels,
+		ProxySelectorLabels:     proxyLabels,
 	}, nil
 }
 
-// buildSidecarContainer creates the pipelock sidecar container spec.
-func buildSidecarContainer(image, preset string) map[string]interface{} {
-	return map[string]interface{}{
-		"name":  sidecarContainerName,
-		"image": image,
-		"args":  []interface{}{"run", "--config", sidecarConfigMount + "/" + sidecarConfigFile},
-		"ports": []interface{}{
-			map[string]interface{}{
-				"name":          "proxy",
-				"containerPort": sidecarHealthPort,
-				"protocol":      "TCP",
-			},
-		},
-		"env": []interface{}{
-			map[string]interface{}{"name": "PIPELOCK_MODE", "value": preset},
-			map[string]interface{}{"name": "PIPELOCK_CONFIG_PATH", "value": sidecarConfigMount + "/" + sidecarConfigFile},
-		},
-		"volumeMounts": []interface{}{
-			map[string]interface{}{
-				"name":      sidecarConfigVolume,
-				"mountPath": sidecarConfigMount,
-				"readOnly":  true,
-			},
-		},
-		"resources": map[string]interface{}{
-			"requests": map[string]interface{}{
-				"cpu":    "25m",
-				"memory": "32Mi",
-			},
-			"limits": map[string]interface{}{
-				"cpu":    "200m",
-				"memory": "128Mi",
-			},
-		},
-		"readinessProbe": map[string]interface{}{
-			"httpGet": map[string]interface{}{
-				"path": sidecarHealthPath,
-				"port": sidecarHealthPort,
-			},
-			"initialDelaySeconds": 2,
-			"periodSeconds":       10,
-		},
-		"livenessProbe": map[string]interface{}{
-			"httpGet": map[string]interface{}{
-				"path": sidecarHealthPath,
-				"port": sidecarHealthPort,
-			},
-			"initialDelaySeconds": 5,
-			"periodSeconds":       30,
-		},
-		"securityContext": map[string]interface{}{
-			"readOnlyRootFilesystem":   true,
-			"allowPrivilegeEscalation": false,
-			"runAsNonRoot":             true,
-			"runAsUser":                65534,
-			"capabilities": map[string]interface{}{
-				"drop": []interface{}{"ALL"},
-			},
-		},
-	}
+func buildProxyConfig(preset, agentIdentity string) *config.Config {
+	cfg := buildConfig(preset, nil)
+	cfg.DefaultAgentIdentity = agentIdentity
+	cfg.BindDefaultAgentIdentity = true
+	cfg.FetchProxy.Listen = fmt.Sprintf("0.0.0.0:%d", sidecarHealthPort)
+	cfg.MetricsListen = fmt.Sprintf("0.0.0.0:%d", sidecarMetricsPort)
+	cfg.ForwardProxy.Enabled = true
+	return cfg
 }
 
-// injectProxyEnvs adds HTTPS_PROXY, HTTP_PROXY, NO_PROXY to existing non-pipelock containers.
-func injectProxyEnvs(podSpec map[string]interface{}) {
+// injectProxyEnvs adds HTTPS_PROXY, HTTP_PROXY, NO_PROXY to agent containers.
+// Existing conflicting proxy env vars are rejected instead of silently preserved.
+func injectProxyEnvs(podSpec map[string]interface{}, proxyURL string) error {
 	containers, ok := podSpec["containers"].([]interface{})
 	if !ok {
-		return
+		return nil
 	}
-	proxyURL := fmt.Sprintf("http://localhost:%d", sidecarHealthPort)
-	proxyEnvs := []interface{}{
-		map[string]interface{}{"name": envHTTPSProxy, "value": proxyURL},
-		map[string]interface{}{"name": envHTTPProxy, "value": proxyURL},
-		map[string]interface{}{"name": envNoProxy, "value": noProxyValue},
-	}
-
 	for _, c := range containers {
 		cMap, ok := c.(map[string]interface{})
 		if !ok {
 			continue
 		}
-		name, _ := cMap["name"].(string)
-		if name == sidecarContainerName {
+		containerName, _ := cMap["name"].(string)
+		if containerName == proxyContainerName {
 			continue
 		}
 		existing, _ := cMap["env"].([]interface{})
-		// Skip if proxy env already set (idempotency).
-		if hasEnvVar(existing, envHTTPSProxy) {
-			continue
+		existing, err := upsertProxyEnv(existing, envHTTPSProxy, proxyURL)
+		if err != nil {
+			return fmt.Errorf("container %q: %w", containerName, err)
 		}
-		cMap["env"] = append(existing, proxyEnvs...)
+		existing, err = upsertProxyEnv(existing, envHTTPProxy, proxyURL)
+		if err != nil {
+			return fmt.Errorf("container %q: %w", containerName, err)
+		}
+		existing, err = upsertProxyEnv(existing, envNoProxy, noProxyValue)
+		if err != nil {
+			return fmt.Errorf("container %q: %w", containerName, err)
+		}
+		cMap["env"] = existing
 	}
+	return nil
 }
 
-// hasEnvVar checks if a named env var exists in the list.
-func hasEnvVar(envList []interface{}, name string) bool {
-	for _, e := range envList {
+func upsertProxyEnv(envList []interface{}, name, value string) ([]interface{}, error) {
+	for i, e := range envList {
 		eMap, ok := e.(map[string]interface{})
 		if !ok {
 			continue
 		}
-		if n, _ := eMap["name"].(string); n == name {
-			return true
+		if n, _ := eMap["name"].(string); n != name {
+			continue
 		}
+		existingValue, ok := eMap["value"].(string)
+		if !ok {
+			return nil, fmt.Errorf("%s already defined via valueFrom; patch it manually", name)
+		}
+		if existingValue != value {
+			return nil, fmt.Errorf("%s already defined as %q, want %q", name, existingValue, value)
+		}
+		envList[i] = eMap
+		return envList, nil
 	}
-	return false
+	return append(envList, map[string]interface{}{"name": name, "value": value}), nil
 }
 
 // resolveImage determines the sidecar container image.
@@ -252,25 +245,23 @@ func resolveAgentIdentity(manifest *workloadManifest, opts sidecarOptions) strin
 	return ""
 }
 
-// renderConfigMap builds a Kubernetes ConfigMap YAML string for the pipelock config.
-func renderConfigMap(cfg *config.Config, preset string) (string, error) {
+// renderConfigMap builds the ConfigMap consumed by the companion proxy Deployment.
+func renderConfigMap(cfg *config.Config, preset, namespace, proxyName string, proxyLabels map[string]string) (string, error) {
 	configData, err := yaml.Marshal(cfg)
 	if err != nil {
 		return "", fmt.Errorf("marshaling config: %w", err)
 	}
 
-	header := fmt.Sprintf("# Pipelock sidecar config (%s preset)\n# Generated by: pipelock init sidecar\n\n", preset)
+	header := fmt.Sprintf("# Pipelock companion proxy config (%s preset)\n# Generated by: pipelock init sidecar\n\n", preset)
+	labels := managedProxyResourceLabels(proxyLabels, "config")
 
-	cmName := sidecarConfigVolume
 	cm := map[string]interface{}{
 		"apiVersion": "v1",
 		"kind":       "ConfigMap",
 		"metadata": map[string]interface{}{
-			"name": cmName,
-			"labels": map[string]interface{}{
-				"app.kubernetes.io/managed-by": "pipelock",
-				"app.kubernetes.io/component":  "sidecar-config",
-			},
+			"name":      proxyName,
+			"namespace": namespace,
+			"labels":    labelsToInterfaceMap(labels),
 		},
 		"data": map[string]interface{}{
 			sidecarConfigFile: header + string(configData),
@@ -284,73 +275,429 @@ func renderConfigMap(cfg *config.Config, preset string) (string, error) {
 	return string(out), nil
 }
 
-// renderNetworkPolicy builds a pod-scoped egress policy for sidecar mode.
-//
-// Kubernetes NetworkPolicy is pod-scoped, not container-scoped: it cannot force
-// app->sidecar routing inside a multi-container pod. The generated policy keeps
-// the injected sidecar functional by allowing DNS plus standard web egress while
-// still constraining the selected workload pods to that pod boundary.
-func renderNetworkPolicy(namespace, workloadName string, selectorLabels map[string]string) (string, error) {
-	if len(selectorLabels) == 0 {
-		return "", fmt.Errorf("selector labels must not be empty")
+func renderProxyDeployment(namespace, proxyName, image string, proxyLabels map[string]string) (string, error) {
+	deploy := map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      proxyName,
+			"namespace": namespace,
+			"labels":    labelsToInterfaceMap(managedProxyResourceLabels(proxyLabels, "proxy")),
+		},
+		"spec": map[string]interface{}{
+			"replicas": proxyReplicaCount,
+			"selector": map[string]interface{}{
+				"matchLabels": labelsToInterfaceMap(proxyLabels),
+			},
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": labelsToInterfaceMap(managedProxyResourceLabels(proxyLabels, "proxy")),
+				},
+				"spec": map[string]interface{}{
+					"automountServiceAccountToken": false,
+					"securityContext": map[string]interface{}{
+						"seccompProfile": map[string]interface{}{
+							"type": "RuntimeDefault",
+						},
+					},
+					"affinity": map[string]interface{}{
+						"podAntiAffinity": map[string]interface{}{
+							"preferredDuringSchedulingIgnoredDuringExecution": []interface{}{
+								map[string]interface{}{
+									"weight": 100,
+									"podAffinityTerm": map[string]interface{}{
+										"labelSelector": map[string]interface{}{
+											"matchLabels": labelsToInterfaceMap(proxyLabels),
+										},
+										"topologyKey": "kubernetes.io/hostname",
+									},
+								},
+							},
+						},
+					},
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":            proxyContainerName,
+							"image":           image,
+							"args":            []interface{}{"run", "--config", sidecarConfigMount + "/" + sidecarConfigFile},
+							"imagePullPolicy": "IfNotPresent",
+							"ports": []interface{}{
+								map[string]interface{}{"name": "http", "containerPort": sidecarHealthPort, "protocol": "TCP"},
+								map[string]interface{}{"name": "metrics", "containerPort": sidecarMetricsPort, "protocol": "TCP"},
+							},
+							"volumeMounts": []interface{}{
+								map[string]interface{}{
+									"name":      sidecarConfigVolume,
+									"mountPath": sidecarConfigMount,
+									"readOnly":  true,
+								},
+							},
+							"resources": map[string]interface{}{
+								"requests": map[string]interface{}{"cpu": proxyCPURequest, "memory": proxyMemoryRequest},
+								"limits":   map[string]interface{}{"cpu": proxyCPULimit, "memory": proxyMemoryLimit},
+							},
+							"readinessProbe": map[string]interface{}{
+								"httpGet":             map[string]interface{}{"path": sidecarHealthPath, "port": "http"},
+								"initialDelaySeconds": 2,
+								"periodSeconds":       10,
+							},
+							"livenessProbe": map[string]interface{}{
+								"httpGet":             map[string]interface{}{"path": sidecarHealthPath, "port": "http"},
+								"initialDelaySeconds": 5,
+								"periodSeconds":       30,
+							},
+							"securityContext": map[string]interface{}{
+								"readOnlyRootFilesystem":   true,
+								"allowPrivilegeEscalation": false,
+								"runAsNonRoot":             true,
+								"runAsUser":                65534,
+								"capabilities": map[string]interface{}{
+									"drop": []interface{}{"ALL"},
+								},
+							},
+						},
+					},
+					"volumes": []interface{}{
+						map[string]interface{}{
+							"name": sidecarConfigVolume,
+							"configMap": map[string]interface{}{
+								"name": proxyName,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
-
-	matchLabels := make(map[string]interface{}, len(selectorLabels))
-	for key, value := range selectorLabels {
-		matchLabels[key] = value
+	out, err := yaml.Marshal(deploy)
+	if err != nil {
+		return "", fmt.Errorf("marshaling Deployment: %w", err)
 	}
+	return string(out), nil
+}
 
+func renderProxyService(namespace, proxyName string, proxyLabels map[string]string) (string, error) {
+	svc := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata": map[string]interface{}{
+			"name":      proxyName,
+			"namespace": namespace,
+			"labels":    labelsToInterfaceMap(managedProxyResourceLabels(proxyLabels, "proxy")),
+		},
+		"spec": map[string]interface{}{
+			"type":     "ClusterIP",
+			"selector": labelsToInterfaceMap(proxyLabels),
+			"ports": []interface{}{
+				map[string]interface{}{"name": "http", "port": sidecarHealthPort, "targetPort": "http", "protocol": "TCP"},
+				map[string]interface{}{"name": "metrics", "port": sidecarMetricsPort, "targetPort": "metrics", "protocol": "TCP"},
+			},
+		},
+	}
+	out, err := yaml.Marshal(svc)
+	if err != nil {
+		return "", fmt.Errorf("marshaling Service: %w", err)
+	}
+	return string(out), nil
+}
+
+func renderAgentNetworkPolicy(namespace, workloadName string, agentLabels, proxyLabels map[string]string) (string, error) {
+	if len(agentLabels) == 0 || len(proxyLabels) == 0 {
+		return "", fmt.Errorf("agent and proxy selector labels must not be empty")
+	}
 	np := map[string]interface{}{
 		"apiVersion": "networking.k8s.io/v1",
 		"kind":       "NetworkPolicy",
 		"metadata": map[string]interface{}{
-			"name":      workloadName + "-pipelock-egress",
+			"name":      kubeResourceName(workloadName, "pipelock-egress"),
 			"namespace": namespace,
-			"labels": map[string]interface{}{
-				"app.kubernetes.io/managed-by": "pipelock",
-			},
+			"labels":    labelsToInterfaceMap(managedComponentLabels("agent-network-policy")),
 		},
 		"spec": map[string]interface{}{
 			"podSelector": map[string]interface{}{
-				"matchLabels": matchLabels,
+				"matchLabels": labelsToInterfaceMap(agentLabels),
 			},
 			"policyTypes": []interface{}{"Egress"},
 			"egress": []interface{}{
-				// Allow DNS.
 				map[string]interface{}{
 					"ports": []interface{}{
-						map[string]interface{}{
-							"port":     53,
-							"protocol": "UDP",
-						},
-						map[string]interface{}{
-							"port":     53,
-							"protocol": "TCP",
-						},
+						map[string]interface{}{"port": 53, "protocol": "UDP"},
+						map[string]interface{}{"port": 53, "protocol": "TCP"},
 					},
 				},
-				// Allow standard web egress so the sidecar can reach upstream HTTP(S)/WS APIs.
 				map[string]interface{}{
+					"to": []interface{}{
+						map[string]interface{}{
+							"podSelector": map[string]interface{}{
+								"matchLabels": labelsToInterfaceMap(proxyLabels),
+							},
+						},
+					},
 					"ports": []interface{}{
-						map[string]interface{}{
-							"port":     80,
-							"protocol": "TCP",
-						},
-						map[string]interface{}{
-							"port":     443,
-							"protocol": "TCP",
-						},
+						map[string]interface{}{"port": sidecarHealthPort, "protocol": "TCP"},
 					},
 				},
 			},
 		},
 	}
-
 	out, err := yaml.Marshal(np)
 	if err != nil {
-		return "", fmt.Errorf("marshaling NetworkPolicy: %w", err)
+		return "", fmt.Errorf("marshaling agent NetworkPolicy: %w", err)
 	}
 	return string(out), nil
+}
+
+func renderProxyNetworkPolicy(namespace, proxyName string, proxyLabels, agentLabels map[string]string) (string, error) {
+	if len(agentLabels) == 0 || len(proxyLabels) == 0 {
+		return "", fmt.Errorf("agent and proxy selector labels must not be empty")
+	}
+	np := map[string]interface{}{
+		"apiVersion": "networking.k8s.io/v1",
+		"kind":       "NetworkPolicy",
+		"metadata": map[string]interface{}{
+			"name":      kubeResourceName(proxyName, "policy"),
+			"namespace": namespace,
+			"labels":    labelsToInterfaceMap(managedProxyResourceLabels(proxyLabels, "network-policy")),
+		},
+		"spec": map[string]interface{}{
+			"podSelector": map[string]interface{}{
+				"matchLabels": labelsToInterfaceMap(proxyLabels),
+			},
+			"policyTypes": []interface{}{"Ingress", "Egress"},
+			"ingress": []interface{}{
+				map[string]interface{}{
+					"from": []interface{}{
+						map[string]interface{}{
+							"podSelector": map[string]interface{}{
+								"matchLabels": labelsToInterfaceMap(agentLabels),
+							},
+						},
+					},
+					"ports": []interface{}{
+						map[string]interface{}{"port": sidecarHealthPort, "protocol": "TCP"},
+					},
+				},
+			},
+			"egress": []interface{}{
+				map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{"port": 53, "protocol": "UDP"},
+						map[string]interface{}{"port": 53, "protocol": "TCP"},
+					},
+				},
+				map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{"port": 80, "protocol": "TCP"},
+						map[string]interface{}{"port": 443, "protocol": "TCP"},
+					},
+				},
+			},
+		},
+	}
+	out, err := yaml.Marshal(np)
+	if err != nil {
+		return "", fmt.Errorf("marshaling proxy NetworkPolicy: %w", err)
+	}
+	return string(out), nil
+}
+
+func renderProxyPodDisruptionBudget(namespace, proxyName string, proxyLabels map[string]string) (string, error) {
+	pdb := map[string]interface{}{
+		"apiVersion": "policy/v1",
+		"kind":       "PodDisruptionBudget",
+		"metadata": map[string]interface{}{
+			"name":      kubeResourceName(proxyName, "pdb"),
+			"namespace": namespace,
+			"labels":    labelsToInterfaceMap(managedProxyResourceLabels(proxyLabels, "pdb")),
+		},
+		"spec": map[string]interface{}{
+			"minAvailable": 1,
+			"selector": map[string]interface{}{
+				"matchLabels": labelsToInterfaceMap(proxyLabels),
+			},
+		},
+	}
+	out, err := yaml.Marshal(pdb)
+	if err != nil {
+		return "", fmt.Errorf("marshaling PodDisruptionBudget: %w", err)
+	}
+	return string(out), nil
+}
+
+func hasPipelockTopology(raw map[string]interface{}) bool {
+	return extractAnnotation(raw, managedTopologyAnnotation) == managedTopologyCompanion
+}
+
+func resolveProxyName(raw map[string]interface{}, workloadName string) string {
+	if existing := extractAnnotation(raw, managedProxyNameAnnotation); existing != "" {
+		return existing
+	}
+	return kubeResourceName(workloadName, "pipelock")
+}
+
+func extractAnnotation(raw map[string]interface{}, key string) string {
+	meta, ok := raw["metadata"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	annotations, ok := meta["annotations"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	value, _ := annotations[key].(string)
+	return value
+}
+
+func proxyServiceURL(proxyName string) string {
+	return fmt.Sprintf("http://%s:%d", proxyName, sidecarHealthPort)
+}
+
+func proxySelectorLabels(proxyName string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":      "pipelock",
+		"app.kubernetes.io/instance":  proxyName,
+		"app.kubernetes.io/component": "proxy",
+	}
+}
+
+func managedProxyResourceLabels(proxyLabels map[string]string, component string) map[string]string {
+	labels := cloneStringMap(proxyLabels)
+	labels["app.kubernetes.io/component"] = component
+	labels["app.kubernetes.io/managed-by"] = managedByLabelValue
+	labels["app.kubernetes.io/version"] = cliutil.Version
+	return labels
+}
+
+func managedComponentLabels(component string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":       "pipelock",
+		"app.kubernetes.io/component":  component,
+		"app.kubernetes.io/managed-by": managedByLabelValue,
+		"app.kubernetes.io/version":    cliutil.Version,
+	}
+}
+
+func annotateManagedWorkload(raw map[string]interface{}, kind, proxyName string) error {
+	annotations := map[string]string{
+		managedTopologyAnnotation:     managedTopologyCompanion,
+		managedProxyNameAnnotation:    proxyName,
+		managedProxyServiceAnnotation: proxyServiceURL(proxyName),
+	}
+	if err := setAnnotationsAtPath(raw, []string{"metadata", "annotations"}, annotations); err != nil {
+		return err
+	}
+	templatePath := []string{"spec", "template", "metadata", "annotations"}
+	if kind == kindCronJob {
+		templatePath = []string{"spec", "jobTemplate", "spec", "template", "metadata", "annotations"}
+	}
+	return setAnnotationsAtPath(raw, templatePath, annotations)
+}
+
+func setAnnotationsAtPath(raw map[string]interface{}, path []string, annotations map[string]string) error {
+	current, err := ensureMapAtPath(raw, path)
+	if err != nil {
+		return err
+	}
+	for key, value := range annotations {
+		current[key] = value
+	}
+	return nil
+}
+
+func ensureMapAtPath(raw map[string]interface{}, path []string) (map[string]interface{}, error) {
+	current := raw
+	for i, key := range path {
+		if i == len(path)-1 {
+			next, ok := current[key]
+			if !ok {
+				nextMap := map[string]interface{}{}
+				current[key] = nextMap
+				return nextMap, nil
+			}
+			nextMap, ok := next.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("%s is not a mapping in manifest", pathString(path[:i+1]))
+			}
+			return nextMap, nil
+		}
+
+		next, ok := current[key]
+		if !ok {
+			nextMap := map[string]interface{}{}
+			current[key] = nextMap
+			current = nextMap
+			continue
+		}
+		nextMap, ok := next.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("%s is not a mapping in manifest", pathString(path[:i+1]))
+		}
+		current = nextMap
+	}
+	return current, nil
+}
+
+func labelsToInterfaceMap(labels map[string]string) map[string]interface{} {
+	out := make(map[string]interface{}, len(labels))
+	for key, value := range labels {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneStringMap(src map[string]string) map[string]string {
+	out := make(map[string]string, len(src))
+	for key, value := range src {
+		out[key] = value
+	}
+	return out
+}
+
+func kubeResourceName(base, suffix string) string {
+	base = sanitizeDNSLabel(base)
+	suffix = sanitizeDNSLabel(suffix)
+	switch {
+	case base == "" && suffix == "":
+		return "pipelock"
+	case base == "":
+		return suffix
+	case suffix == "":
+		return base
+	}
+
+	maxBaseLen := 63 - len(suffix) - 1
+	if maxBaseLen > 0 && len(base) > maxBaseLen {
+		base = strings.Trim(base[:maxBaseLen], "-")
+	}
+	name := strings.Trim(base+"-"+suffix, "-")
+	if len(name) > 63 {
+		name = strings.Trim(name[:63], "-")
+	}
+	if name == "" {
+		return "pipelock"
+	}
+	return name
+}
+
+func sanitizeDNSLabel(input string) string {
+	lower := strings.ToLower(input)
+	var sb strings.Builder
+	lastDash := false
+	for _, r := range lower {
+		isAlpha := r >= 'a' && r <= 'z'
+		isDigit := r >= '0' && r <= '9'
+		if isAlpha || isDigit {
+			sb.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if sb.Len() == 0 || lastDash {
+			continue
+		}
+		sb.WriteByte('-')
+		lastDash = true
+	}
+	return strings.Trim(sb.String(), "-")
 }
 
 // extractNamespace gets the namespace from metadata, defaulting to "default".

--- a/internal/cli/setup/sidecar_patch.go
+++ b/internal/cli/setup/sidecar_patch.go
@@ -1,0 +1,442 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package setup implements init flows. This file generates a strategic-merge
+// patch that injects a pipelock sidecar into Kubernetes workload manifests.
+// Strategic merge is used for container-level mutations (container additions,
+// env additions) because kubectl apply handles list-merge on container name.
+package setup
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// Fixed names and values for the sidecar injection.
+const (
+	sidecarContainerName = "pipelock"
+	sidecarConfigVolume  = "pipelock-config"
+	sidecarConfigMount   = "/etc/pipelock"
+	sidecarConfigFile    = "pipelock.yaml"
+	sidecarHealthPath    = "/health"
+	sidecarHealthPort    = 8888
+
+	// defaultImage is the GHCR image with the current version tag.
+	// Overridden by --image flag.
+	defaultImageRepo = "ghcr.io/luckypipewrench/pipelock"
+
+	// Proxy env vars injected into the primary container.
+	envHTTPSProxy = "HTTPS_PROXY"
+	envHTTPProxy  = "HTTP_PROXY"
+	envNoProxy    = "NO_PROXY"
+	noProxyValue  = "localhost,127.0.0.1,.svc,.cluster.local"
+)
+
+// sidecarPatchResult holds the generated patch and related artifacts.
+type sidecarPatchResult struct {
+	// OriginalManifestYAML is the source workload manifest used for kustomize output.
+	OriginalManifestYAML string
+	// PatchedManifest is the full manifest with the sidecar injected.
+	PatchedManifest map[string]interface{}
+	// ConfigMapYAML is the standalone ConfigMap for the pipelock config.
+	ConfigMapYAML string
+	// NetworkPolicyYAML is a deny-all NetworkPolicy with explicit egress to the sidecar.
+	NetworkPolicyYAML string
+	// AgentIdentity is the derived default_agent_identity value.
+	AgentIdentity string
+}
+
+// generateSidecarPatch creates the patched manifest with the pipelock sidecar injected.
+// The patch is idempotent: if a pipelock container already exists, no changes are made.
+func generateSidecarPatch(manifest *workloadManifest, opts sidecarOptions) (*sidecarPatchResult, error) {
+	// Deep copy the raw manifest to avoid mutating the original.
+	patched, err := deepCopyMap(manifest.Raw)
+	if err != nil {
+		return nil, fmt.Errorf("deep copy manifest: %w", err)
+	}
+
+	podSpec, err := getPodSpec(patched, manifest.Kind)
+	if err != nil {
+		return nil, fmt.Errorf("locating pod spec: %w", err)
+	}
+
+	// Idempotency: if pipelock container already exists, return as-is.
+	if hasPipelockContainer(podSpec) {
+		return &sidecarPatchResult{
+			OriginalManifestYAML: string(manifest.RawBytes),
+			PatchedManifest:      patched,
+			AgentIdentity:        resolveAgentIdentity(manifest, opts),
+		}, nil
+	}
+
+	image := resolveImage(opts)
+	agentIdentity := resolveAgentIdentity(manifest, opts)
+
+	// Build the sidecar container spec.
+	sidecar := buildSidecarContainer(image, opts.preset)
+
+	// Add the sidecar container.
+	containers, _ := podSpec["containers"].([]interface{})
+	podSpec["containers"] = append(containers, sidecar)
+
+	// Add the config volume.
+	volumes, _ := podSpec["volumes"].([]interface{})
+	podSpec["volumes"] = append(volumes, map[string]interface{}{
+		"name": sidecarConfigVolume,
+		"configMap": map[string]interface{}{
+			"name": sidecarConfigVolume,
+		},
+	})
+
+	// Inject proxy env vars into existing primary container(s).
+	injectProxyEnvs(podSpec)
+
+	// Build the ConfigMap YAML.
+	pipelockCfg := buildConfig(opts.preset, nil)
+	pipelockCfg.DefaultAgentIdentity = agentIdentity
+	configMapYAML, err := renderConfigMap(pipelockCfg, opts.preset)
+	if err != nil {
+		return nil, fmt.Errorf("rendering ConfigMap: %w", err)
+	}
+
+	// Build the NetworkPolicy YAML.
+	namespace := extractNamespace(manifest.Raw)
+	selectorLabels, err := networkPolicySelectorLabels(manifest.Raw, manifest.Kind)
+	if err != nil {
+		return nil, fmt.Errorf("building NetworkPolicy selector: %w", err)
+	}
+	networkPolicyYAML, err := renderNetworkPolicy(namespace, manifest.Name, selectorLabels)
+	if err != nil {
+		return nil, fmt.Errorf("rendering NetworkPolicy: %w", err)
+	}
+
+	return &sidecarPatchResult{
+		OriginalManifestYAML: string(manifest.RawBytes),
+		PatchedManifest:      patched,
+		ConfigMapYAML:        configMapYAML,
+		NetworkPolicyYAML:    networkPolicyYAML,
+		AgentIdentity:        agentIdentity,
+	}, nil
+}
+
+// buildSidecarContainer creates the pipelock sidecar container spec.
+func buildSidecarContainer(image, preset string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":  sidecarContainerName,
+		"image": image,
+		"args":  []interface{}{"run", "--config", sidecarConfigMount + "/" + sidecarConfigFile},
+		"ports": []interface{}{
+			map[string]interface{}{
+				"name":          "proxy",
+				"containerPort": sidecarHealthPort,
+				"protocol":      "TCP",
+			},
+		},
+		"env": []interface{}{
+			map[string]interface{}{"name": "PIPELOCK_MODE", "value": preset},
+			map[string]interface{}{"name": "PIPELOCK_CONFIG_PATH", "value": sidecarConfigMount + "/" + sidecarConfigFile},
+		},
+		"volumeMounts": []interface{}{
+			map[string]interface{}{
+				"name":      sidecarConfigVolume,
+				"mountPath": sidecarConfigMount,
+				"readOnly":  true,
+			},
+		},
+		"resources": map[string]interface{}{
+			"requests": map[string]interface{}{
+				"cpu":    "25m",
+				"memory": "32Mi",
+			},
+			"limits": map[string]interface{}{
+				"cpu":    "200m",
+				"memory": "128Mi",
+			},
+		},
+		"readinessProbe": map[string]interface{}{
+			"httpGet": map[string]interface{}{
+				"path": sidecarHealthPath,
+				"port": sidecarHealthPort,
+			},
+			"initialDelaySeconds": 2,
+			"periodSeconds":       10,
+		},
+		"livenessProbe": map[string]interface{}{
+			"httpGet": map[string]interface{}{
+				"path": sidecarHealthPath,
+				"port": sidecarHealthPort,
+			},
+			"initialDelaySeconds": 5,
+			"periodSeconds":       30,
+		},
+		"securityContext": map[string]interface{}{
+			"readOnlyRootFilesystem":   true,
+			"allowPrivilegeEscalation": false,
+			"runAsNonRoot":             true,
+			"runAsUser":                65534,
+			"capabilities": map[string]interface{}{
+				"drop": []interface{}{"ALL"},
+			},
+		},
+	}
+}
+
+// injectProxyEnvs adds HTTPS_PROXY, HTTP_PROXY, NO_PROXY to existing non-pipelock containers.
+func injectProxyEnvs(podSpec map[string]interface{}) {
+	containers, ok := podSpec["containers"].([]interface{})
+	if !ok {
+		return
+	}
+	proxyURL := fmt.Sprintf("http://localhost:%d", sidecarHealthPort)
+	proxyEnvs := []interface{}{
+		map[string]interface{}{"name": envHTTPSProxy, "value": proxyURL},
+		map[string]interface{}{"name": envHTTPProxy, "value": proxyURL},
+		map[string]interface{}{"name": envNoProxy, "value": noProxyValue},
+	}
+
+	for _, c := range containers {
+		cMap, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := cMap["name"].(string)
+		if name == sidecarContainerName {
+			continue
+		}
+		existing, _ := cMap["env"].([]interface{})
+		// Skip if proxy env already set (idempotency).
+		if hasEnvVar(existing, envHTTPSProxy) {
+			continue
+		}
+		cMap["env"] = append(existing, proxyEnvs...)
+	}
+}
+
+// hasEnvVar checks if a named env var exists in the list.
+func hasEnvVar(envList []interface{}, name string) bool {
+	for _, e := range envList {
+		eMap, ok := e.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if n, _ := eMap["name"].(string); n == name {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveImage determines the sidecar container image.
+func resolveImage(opts sidecarOptions) string {
+	if opts.image != "" {
+		return opts.image
+	}
+	version := cliutil.Version
+	return fmt.Sprintf("%s:%s", defaultImageRepo, version)
+}
+
+// resolveAgentIdentity determines the default agent identity for the sidecar config.
+// Uses --agent-identity flag if set, otherwise derives from workload kind/name.
+func resolveAgentIdentity(manifest *workloadManifest, opts sidecarOptions) string {
+	if opts.agentIdentity != "" {
+		return opts.agentIdentity
+	}
+	if manifest.Name != "" {
+		return strings.ToLower(manifest.Kind) + "/" + manifest.Name
+	}
+	return ""
+}
+
+// renderConfigMap builds a Kubernetes ConfigMap YAML string for the pipelock config.
+func renderConfigMap(cfg *config.Config, preset string) (string, error) {
+	configData, err := yaml.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("marshaling config: %w", err)
+	}
+
+	header := fmt.Sprintf("# Pipelock sidecar config (%s preset)\n# Generated by: pipelock init sidecar\n\n", preset)
+
+	cmName := sidecarConfigVolume
+	cm := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name": cmName,
+			"labels": map[string]interface{}{
+				"app.kubernetes.io/managed-by": "pipelock",
+				"app.kubernetes.io/component":  "sidecar-config",
+			},
+		},
+		"data": map[string]interface{}{
+			sidecarConfigFile: header + string(configData),
+		},
+	}
+
+	out, err := yaml.Marshal(cm)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// renderNetworkPolicy builds a pod-scoped egress policy for sidecar mode.
+//
+// Kubernetes NetworkPolicy is pod-scoped, not container-scoped: it cannot force
+// app->sidecar routing inside a multi-container pod. The generated policy keeps
+// the injected sidecar functional by allowing DNS plus standard web egress while
+// still constraining the selected workload pods to that pod boundary.
+func renderNetworkPolicy(namespace, workloadName string, selectorLabels map[string]string) (string, error) {
+	if len(selectorLabels) == 0 {
+		return "", fmt.Errorf("selector labels must not be empty")
+	}
+
+	matchLabels := make(map[string]interface{}, len(selectorLabels))
+	for key, value := range selectorLabels {
+		matchLabels[key] = value
+	}
+
+	np := map[string]interface{}{
+		"apiVersion": "networking.k8s.io/v1",
+		"kind":       "NetworkPolicy",
+		"metadata": map[string]interface{}{
+			"name":      workloadName + "-pipelock-egress",
+			"namespace": namespace,
+			"labels": map[string]interface{}{
+				"app.kubernetes.io/managed-by": "pipelock",
+			},
+		},
+		"spec": map[string]interface{}{
+			"podSelector": map[string]interface{}{
+				"matchLabels": matchLabels,
+			},
+			"policyTypes": []interface{}{"Egress"},
+			"egress": []interface{}{
+				// Allow DNS.
+				map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{
+							"port":     53,
+							"protocol": "UDP",
+						},
+						map[string]interface{}{
+							"port":     53,
+							"protocol": "TCP",
+						},
+					},
+				},
+				// Allow standard web egress so the sidecar can reach upstream HTTP(S)/WS APIs.
+				map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{
+							"port":     80,
+							"protocol": "TCP",
+						},
+						map[string]interface{}{
+							"port":     443,
+							"protocol": "TCP",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := yaml.Marshal(np)
+	if err != nil {
+		return "", fmt.Errorf("marshaling NetworkPolicy: %w", err)
+	}
+	return string(out), nil
+}
+
+// extractNamespace gets the namespace from metadata, defaulting to "default".
+func extractNamespace(raw map[string]interface{}) string {
+	meta, ok := raw["metadata"].(map[string]interface{})
+	if !ok {
+		return "default"
+	}
+	ns, _ := meta["namespace"].(string)
+	if ns == "" {
+		return "default"
+	}
+	return ns
+}
+
+func networkPolicySelectorLabels(raw map[string]interface{}, kind string) (map[string]string, error) {
+	selectorPath := []string{"spec", "selector", "matchLabels"}
+	if kind == kindCronJob {
+		selectorPath = []string{"spec", "jobTemplate", "spec", "selector", "matchLabels"}
+	}
+	labels, err := extractStringMapAtPath(raw, selectorPath)
+	if err != nil {
+		return nil, fmt.Errorf("selector.matchLabels: %w", err)
+	}
+	if len(labels) > 0 {
+		return labels, nil
+	}
+
+	templatePath := []string{"spec", "template", "metadata", "labels"}
+	if kind == kindCronJob {
+		templatePath = []string{"spec", "jobTemplate", "spec", "template", "metadata", "labels"}
+	}
+	labels, err = extractStringMapAtPath(raw, templatePath)
+	if err != nil {
+		return nil, fmt.Errorf("pod template labels: %w", err)
+	}
+	if len(labels) > 0 {
+		return labels, nil
+	}
+
+	return nil, fmt.Errorf("no selector.matchLabels or pod template labels found")
+}
+
+func extractStringMapAtPath(raw map[string]interface{}, path []string) (map[string]string, error) {
+	current := raw
+	for i, key := range path {
+		next, ok := current[key]
+		if !ok {
+			return nil, nil
+		}
+		if i == len(path)-1 {
+			nextMap, ok := next.(map[string]interface{})
+			if !ok {
+				return nil, nil
+			}
+			out := make(map[string]string, len(nextMap))
+			for labelKey, labelValue := range nextMap {
+				value, ok := labelValue.(string)
+				if !ok {
+					return nil, fmt.Errorf("label %q has non-string value %T", labelKey, labelValue)
+				}
+				if value == "" {
+					continue
+				}
+				out[labelKey] = value
+			}
+			return out, nil
+		}
+		nextMap, ok := next.(map[string]interface{})
+		if !ok {
+			return nil, nil
+		}
+		current = nextMap
+	}
+	return nil, nil
+}
+
+// deepCopyMap performs a deep copy via YAML marshal/unmarshal.
+func deepCopyMap(src map[string]interface{}) (map[string]interface{}, error) {
+	data, err := yaml.Marshal(src)
+	if err != nil {
+		return nil, err
+	}
+	var dst map[string]interface{}
+	if err := yaml.Unmarshal(data, &dst); err != nil {
+		return nil, err
+	}
+	return dst, nil
+}

--- a/internal/cli/setup/sidecar_patch_test.go
+++ b/internal/cli/setup/sidecar_patch_test.go
@@ -5,6 +5,7 @@ package setup
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -13,22 +14,57 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
+func envValue(t *testing.T, envList []interface{}, name string) string {
+	t.Helper()
+
+	for _, entry := range envList {
+		envMap, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if envName, _ := envMap["name"].(string); envName == name {
+			value, _ := envMap["value"].(string)
+			return value
+		}
+	}
+
+	t.Fatalf("env var %q not found", name)
+	return ""
+}
+
+func envCount(envList []interface{}, name string) int {
+	count := 0
+	for _, entry := range envList {
+		envMap, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if envName, _ := envMap["name"].(string); envName == name {
+			count++
+		}
+	}
+	return count
+}
+
 func TestGenerateSidecarPatch_Deployment(t *testing.T) {
 	manifest, err := detectWorkload(testdataPath(t, "deployment.yaml"))
 	if err != nil {
 		t.Fatalf("detectWorkload: %v", err)
 	}
 
-	opts := sidecarOptions{
-		preset: config.ModeBalanced,
-	}
-
+	opts := sidecarOptions{preset: config.ModeBalanced}
 	result, err := generateSidecarPatch(manifest, opts)
 	if err != nil {
 		t.Fatalf("generateSidecarPatch: %v", err)
 	}
 
-	// Verify 2 containers in patched manifest.
+	if result.ProxyName != "my-agent-pipelock" {
+		t.Fatalf("ProxyName = %q, want %q", result.ProxyName, "my-agent-pipelock")
+	}
+	if result.ProxyURL != "http://my-agent-pipelock:8888" {
+		t.Fatalf("ProxyURL = %q, want %q", result.ProxyURL, "http://my-agent-pipelock:8888")
+	}
+
 	podSpec, err := getPodSpec(result.PatchedManifest, kindDeployment)
 	if err != nil {
 		t.Fatalf("getPodSpec on patched: %v", err)
@@ -38,93 +74,155 @@ func TestGenerateSidecarPatch_Deployment(t *testing.T) {
 	if !ok {
 		t.Fatal("containers not found in patched pod spec")
 	}
-	if len(containers) != 2 {
-		t.Fatalf("expected 2 containers, got %d", len(containers))
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 agent container, got %d", len(containers))
+	}
+	if hasPipelockContainer(podSpec) {
+		t.Fatal("patched workload should not inject a same-pod pipelock container")
 	}
 
-	// Second container should be named "pipelock".
-	second, ok := containers[1].(map[string]interface{})
-	if !ok {
-		t.Fatal("second container is not a map")
-	}
-	if name, _ := second["name"].(string); name != sidecarContainerName {
-		t.Errorf("second container name = %q, want %q", name, sidecarContainerName)
-	}
-
-	// First container should have proxy env vars.
 	first, ok := containers[0].(map[string]interface{})
 	if !ok {
-		t.Fatal("first container is not a map")
+		t.Fatal("agent container is not a map")
 	}
 	envList, ok := first["env"].([]interface{})
 	if !ok {
-		t.Fatal("first container has no env list")
+		t.Fatal("agent container has no env list")
+	}
+	if got := envValue(t, envList, envHTTPSProxy); got != result.ProxyURL {
+		t.Fatalf("%s = %q, want %q", envHTTPSProxy, got, result.ProxyURL)
+	}
+	if got := envValue(t, envList, envHTTPProxy); got != result.ProxyURL {
+		t.Fatalf("%s = %q, want %q", envHTTPProxy, got, result.ProxyURL)
+	}
+	if got := envValue(t, envList, envNoProxy); got != noProxyValue {
+		t.Fatalf("%s = %q, want %q", envNoProxy, got, noProxyValue)
 	}
 
-	wantEnvNames := []string{envHTTPSProxy, envHTTPProxy, envNoProxy}
-	for _, wantName := range wantEnvNames {
-		if !hasEnvVar(envList, wantName) {
-			t.Errorf("first container missing env var %s", wantName)
+	metadata, ok := result.PatchedManifest["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatal("metadata missing from patched manifest")
+	}
+	annotations, ok := metadata["annotations"].(map[string]interface{})
+	if !ok {
+		t.Fatal("metadata.annotations missing from patched manifest")
+	}
+	if annotations[managedTopologyAnnotation] != managedTopologyCompanion {
+		t.Fatalf("metadata.annotations[%q] = %v, want %q", managedTopologyAnnotation, annotations[managedTopologyAnnotation], managedTopologyCompanion)
+	}
+	if annotations[managedProxyNameAnnotation] != result.ProxyName {
+		t.Fatalf("metadata.annotations[%q] = %v, want %q", managedProxyNameAnnotation, annotations[managedProxyNameAnnotation], result.ProxyName)
+	}
+	if annotations[managedProxyServiceAnnotation] != result.ProxyURL {
+		t.Fatalf("metadata.annotations[%q] = %v, want %q", managedProxyServiceAnnotation, annotations[managedProxyServiceAnnotation], result.ProxyURL)
+	}
+
+	for _, artifact := range []string{
+		result.ConfigMapYAML,
+		result.DeploymentYAML,
+		result.ServiceYAML,
+		result.AgentNetworkPolicyYAML,
+		result.ProxyNetworkPolicyYAML,
+		result.PodDisruptionBudgetYAML,
+	} {
+		if artifact == "" {
+			t.Fatal("expected all companion artifacts to be non-empty")
 		}
 	}
 
-	// Volumes should include pipelock-config.
-	volumes, ok := podSpec["volumes"].([]interface{})
-	if !ok {
-		t.Fatal("volumes not found in patched pod spec")
+	var deployment map[string]interface{}
+	if err := yaml.Unmarshal([]byte(result.DeploymentYAML), &deployment); err != nil {
+		t.Fatalf("parsing DeploymentYAML: %v", err)
 	}
-	foundVol := false
-	for _, v := range volumes {
-		vMap, ok := v.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if n, _ := vMap["name"].(string); n == sidecarConfigVolume {
-			foundVol = true
-			break
-		}
+	if deployment["kind"] != kindDeployment {
+		t.Fatalf("deployment kind = %v, want %s", deployment["kind"], kindDeployment)
 	}
-	if !foundVol {
-		t.Errorf("expected volume %q in patched manifest", sidecarConfigVolume)
+	deployMeta := deployment["metadata"].(map[string]interface{})
+	if deployMeta["name"] != result.ProxyName {
+		t.Fatalf("deployment metadata.name = %v, want %q", deployMeta["name"], result.ProxyName)
+	}
+	deploySpec := deployment["spec"].(map[string]interface{})
+	if deploySpec["replicas"] != proxyReplicaCount {
+		t.Fatalf("deployment replicas = %v, want %d", deploySpec["replicas"], proxyReplicaCount)
+	}
+	template := deploySpec["template"].(map[string]interface{})
+	templateSpec := template["spec"].(map[string]interface{})
+	if _, ok := templateSpec["affinity"].(map[string]interface{}); !ok {
+		t.Fatal("proxy deployment should define affinity")
+	}
+	proxyContainers := templateSpec["containers"].([]interface{})
+	if len(proxyContainers) != 1 {
+		t.Fatalf("proxy deployment should have 1 container, got %d", len(proxyContainers))
+	}
+	proxyContainer := proxyContainers[0].(map[string]interface{})
+	if proxyContainer["name"] != proxyContainerName {
+		t.Fatalf("proxy container name = %v, want %q", proxyContainer["name"], proxyContainerName)
+	}
+	if proxyContainer["image"] != fmt.Sprintf("%s:%s", defaultImageRepo, cliutil.Version) {
+		t.Fatalf("proxy image = %v", proxyContainer["image"])
+	}
+	if proxyContainer["imagePullPolicy"] != "IfNotPresent" {
+		t.Fatalf("proxy imagePullPolicy = %v, want IfNotPresent", proxyContainer["imagePullPolicy"])
+	}
+	volumeMounts := proxyContainer["volumeMounts"].([]interface{})
+	volumeMount := volumeMounts[0].(map[string]interface{})
+	if volumeMount["mountPath"] != sidecarConfigMount {
+		t.Fatalf("config mountPath = %v, want %q", volumeMount["mountPath"], sidecarConfigMount)
+	}
+	if _, ok := volumeMount["subPath"]; ok {
+		t.Fatal("config mount should not use subPath")
+	}
+	resources := proxyContainer["resources"].(map[string]interface{})
+	requests := resources["requests"].(map[string]interface{})
+	limits := resources["limits"].(map[string]interface{})
+	if requests["cpu"] != proxyCPURequest || requests["memory"] != proxyMemoryRequest {
+		t.Fatalf("requests = %v, want cpu=%s memory=%s", requests, proxyCPURequest, proxyMemoryRequest)
+	}
+	if limits["cpu"] != proxyCPULimit || limits["memory"] != proxyMemoryLimit {
+		t.Fatalf("limits = %v, want cpu=%s memory=%s", limits, proxyCPULimit, proxyMemoryLimit)
 	}
 
-	// ConfigMapYAML should be non-empty.
-	if result.ConfigMapYAML == "" {
-		t.Error("ConfigMapYAML should not be empty")
+	var agentPolicy map[string]interface{}
+	if err := yaml.Unmarshal([]byte(result.AgentNetworkPolicyYAML), &agentPolicy); err != nil {
+		t.Fatalf("parsing AgentNetworkPolicyYAML: %v", err)
 	}
-
-	// NetworkPolicyYAML should be non-empty.
-	if result.NetworkPolicyYAML == "" {
-		t.Error("NetworkPolicyYAML should not be empty")
-	}
-	var networkPolicy map[string]interface{}
-	if err := yaml.Unmarshal([]byte(result.NetworkPolicyYAML), &networkPolicy); err != nil {
-		t.Fatalf("parsing NetworkPolicyYAML: %v", err)
-	}
-	spec, ok := networkPolicy["spec"].(map[string]interface{})
-	if !ok {
-		t.Fatal("network policy spec should be a map")
-	}
-	podSelector, ok := spec["podSelector"].(map[string]interface{})
-	if !ok {
-		t.Fatal("network policy podSelector should be a map")
-	}
-	matchLabels, ok := podSelector["matchLabels"].(map[string]interface{})
-	if !ok {
-		t.Fatal("network policy matchLabels should be a map")
-	}
+	agentSpec := agentPolicy["spec"].(map[string]interface{})
+	podSelector := agentSpec["podSelector"].(map[string]interface{})
+	matchLabels := podSelector["matchLabels"].(map[string]interface{})
 	if matchLabels["app"] != "my-agent" {
-		t.Fatalf("network policy selector = %v, want app=my-agent", matchLabels)
+		t.Fatalf("agent policy selector = %v, want app=my-agent", matchLabels)
 	}
-	egress, ok := spec["egress"].([]interface{})
-	if !ok || len(egress) != 2 {
-		t.Fatalf("network policy egress = %v, want 2 rules", spec["egress"])
+	if strings.Contains(result.AgentNetworkPolicyYAML, "port: 80") || strings.Contains(result.AgentNetworkPolicyYAML, "port: 443") {
+		t.Fatal("agent NetworkPolicy should not allow direct web egress")
 	}
 
-	// AgentIdentity should be "deployment/my-agent".
+	var proxyPolicy map[string]interface{}
+	if err := yaml.Unmarshal([]byte(result.ProxyNetworkPolicyYAML), &proxyPolicy); err != nil {
+		t.Fatalf("parsing ProxyNetworkPolicyYAML: %v", err)
+	}
+	proxySpec := proxyPolicy["spec"].(map[string]interface{})
+	if _, ok := proxySpec["ingress"].([]interface{}); !ok {
+		t.Fatal("proxy NetworkPolicy should define ingress rules")
+	}
+	if _, ok := proxySpec["egress"].([]interface{}); !ok {
+		t.Fatal("proxy NetworkPolicy should define egress rules")
+	}
+
+	var pdb map[string]interface{}
+	if err := yaml.Unmarshal([]byte(result.PodDisruptionBudgetYAML), &pdb); err != nil {
+		t.Fatalf("parsing PodDisruptionBudgetYAML: %v", err)
+	}
+	if pdb["kind"] != "PodDisruptionBudget" {
+		t.Fatalf("pdb kind = %v, want PodDisruptionBudget", pdb["kind"])
+	}
+	pdbSpec := pdb["spec"].(map[string]interface{})
+	if pdbSpec["minAvailable"] != 1 {
+		t.Fatalf("pdb minAvailable = %v, want 1", pdbSpec["minAvailable"])
+	}
+
 	wantIdentity := "deployment/my-agent"
 	if result.AgentIdentity != wantIdentity {
-		t.Errorf("AgentIdentity = %q, want %q", result.AgentIdentity, wantIdentity)
+		t.Fatalf("AgentIdentity = %q, want %q", result.AgentIdentity, wantIdentity)
 	}
 }
 
@@ -134,48 +232,47 @@ func TestGenerateSidecarPatch_Idempotent(t *testing.T) {
 		t.Fatalf("detectWorkload: %v", err)
 	}
 
-	opts := sidecarOptions{
-		preset: config.ModeBalanced,
-	}
-
-	// First patch.
+	opts := sidecarOptions{preset: config.ModeBalanced}
 	first, err := generateSidecarPatch(manifest, opts)
 	if err != nil {
 		t.Fatalf("first generateSidecarPatch: %v", err)
 	}
 
-	// Build a new workloadManifest from the patched result.
+	patchedBytes, err := yaml.Marshal(first.PatchedManifest)
+	if err != nil {
+		t.Fatalf("marshal patched manifest: %v", err)
+	}
 	patchedManifest := &workloadManifest{
-		Kind: manifest.Kind,
-		Name: manifest.Name,
-		Raw:  first.PatchedManifest,
+		Kind:     manifest.Kind,
+		Name:     manifest.Name,
+		Raw:      first.PatchedManifest,
+		RawBytes: patchedBytes,
 	}
 
-	// Second patch on already-patched manifest.
 	second, err := generateSidecarPatch(patchedManifest, opts)
 	if err != nil {
 		t.Fatalf("second generateSidecarPatch: %v", err)
 	}
 
-	// Second run should not add duplicate containers.
 	podSpec, err := getPodSpec(second.PatchedManifest, kindDeployment)
 	if err != nil {
 		t.Fatalf("getPodSpec on second patch: %v", err)
 	}
-
-	containers, ok := podSpec["containers"].([]interface{})
-	if !ok {
-		t.Fatal("containers not found")
+	containers := podSpec["containers"].([]interface{})
+	firstContainer := containers[0].(map[string]interface{})
+	envList := firstContainer["env"].([]interface{})
+	if envCount(envList, envHTTPSProxy) != 1 || envCount(envList, envHTTPProxy) != 1 || envCount(envList, envNoProxy) != 1 {
+		t.Fatalf("expected proxy env vars to remain singletons, got env=%v", envList)
 	}
 
-	// Should still be 2 containers, not 3.
-	if len(containers) != 2 {
-		t.Errorf("expected 2 containers after second patch, got %d", len(containers))
+	if second.ProxyName != first.ProxyName {
+		t.Fatalf("ProxyName changed across idempotent run: %q vs %q", second.ProxyName, first.ProxyName)
 	}
-
-	// ConfigMapYAML should be empty on idempotent run (no new artifacts).
-	if second.ConfigMapYAML != "" {
-		t.Error("expected empty ConfigMapYAML on idempotent patch")
+	if second.ProxyURL != first.ProxyURL {
+		t.Fatalf("ProxyURL changed across idempotent run: %q vs %q", second.ProxyURL, first.ProxyURL)
+	}
+	if second.Config == nil || second.DeploymentYAML == "" || second.ServiceYAML == "" || second.PodDisruptionBudgetYAML == "" {
+		t.Fatal("idempotent generation should still render companion artifacts for verification")
 	}
 }
 
@@ -186,30 +283,10 @@ func TestGenerateSidecarPatch_AllKinds(t *testing.T) {
 		kind         string
 		wantIdentity string
 	}{
-		{
-			name:         "deployment",
-			file:         "deployment.yaml",
-			kind:         kindDeployment,
-			wantIdentity: "deployment/my-agent",
-		},
-		{
-			name:         "statefulset",
-			file:         "statefulset.yaml",
-			kind:         kindStatefulSet,
-			wantIdentity: "statefulset/my-db-agent",
-		},
-		{
-			name:         "job",
-			file:         "job.yaml",
-			kind:         kindJob,
-			wantIdentity: "job/batch-runner",
-		},
-		{
-			name:         "cronjob",
-			file:         "cronjob.yaml",
-			kind:         kindCronJob,
-			wantIdentity: "cronjob/scheduled-scan",
-		},
+		{name: "deployment", file: "deployment.yaml", kind: kindDeployment, wantIdentity: "deployment/my-agent"},
+		{name: "statefulset", file: "statefulset.yaml", kind: kindStatefulSet, wantIdentity: "statefulset/my-db-agent"},
+		{name: "job", file: "job.yaml", kind: kindJob, wantIdentity: "job/batch-runner"},
+		{name: "cronjob", file: "cronjob.yaml", kind: kindCronJob, wantIdentity: "cronjob/scheduled-scan"},
 	}
 
 	for _, tc := range tests {
@@ -219,35 +296,30 @@ func TestGenerateSidecarPatch_AllKinds(t *testing.T) {
 				t.Fatalf("detectWorkload: %v", err)
 			}
 
-			opts := sidecarOptions{
-				preset: config.ModeBalanced,
-			}
-
-			result, err := generateSidecarPatch(manifest, opts)
+			result, err := generateSidecarPatch(manifest, sidecarOptions{preset: config.ModeBalanced})
 			if err != nil {
 				t.Fatalf("generateSidecarPatch: %v", err)
 			}
 
-			// Verify sidecar container was added.
 			podSpec, err := getPodSpec(result.PatchedManifest, tc.kind)
 			if err != nil {
 				t.Fatalf("getPodSpec: %v", err)
 			}
-			if !hasPipelockContainer(podSpec) {
-				t.Error("patched manifest should have pipelock container")
+			if hasPipelockContainer(podSpec) {
+				t.Fatal("patched manifest should not have a same-pod pipelock container")
 			}
 
-			// Verify identity derivation.
+			containers := podSpec["containers"].([]interface{})
+			agentContainer := containers[0].(map[string]interface{})
+			envList := agentContainer["env"].([]interface{})
+			if envValue(t, envList, envHTTPSProxy) != result.ProxyURL {
+				t.Fatalf("%s should point to proxy URL", envHTTPSProxy)
+			}
 			if result.AgentIdentity != tc.wantIdentity {
-				t.Errorf("AgentIdentity = %q, want %q", result.AgentIdentity, tc.wantIdentity)
+				t.Fatalf("AgentIdentity = %q, want %q", result.AgentIdentity, tc.wantIdentity)
 			}
-
-			// Verify artifacts were generated.
-			if result.ConfigMapYAML == "" {
-				t.Error("ConfigMapYAML should not be empty")
-			}
-			if result.NetworkPolicyYAML == "" {
-				t.Error("NetworkPolicyYAML should not be empty")
+			if result.ConfigMapYAML == "" || result.DeploymentYAML == "" || result.ServiceYAML == "" || result.PodDisruptionBudgetYAML == "" {
+				t.Fatal("expected companion resources for every workload kind")
 			}
 		})
 	}
@@ -260,42 +332,26 @@ func TestGenerateSidecarPatch_CustomImage(t *testing.T) {
 	}
 
 	const customImage = "registry.example.com/pipelock:v1.2.3"
-	opts := sidecarOptions{
+	result, err := generateSidecarPatch(manifest, sidecarOptions{
 		preset: config.ModeBalanced,
 		image:  customImage,
-	}
-
-	result, err := generateSidecarPatch(manifest, opts)
+	})
 	if err != nil {
 		t.Fatalf("generateSidecarPatch: %v", err)
 	}
 
-	podSpec, err := getPodSpec(result.PatchedManifest, kindDeployment)
-	if err != nil {
-		t.Fatalf("getPodSpec: %v", err)
+	var deployment map[string]interface{}
+	if err := yaml.Unmarshal([]byte(result.DeploymentYAML), &deployment); err != nil {
+		t.Fatalf("parsing DeploymentYAML: %v", err)
 	}
-
-	containers, ok := podSpec["containers"].([]interface{})
-	if !ok {
-		t.Fatal("containers not found")
+	spec := deployment["spec"].(map[string]interface{})
+	template := spec["template"].(map[string]interface{})
+	templateSpec := template["spec"].(map[string]interface{})
+	containers := templateSpec["containers"].([]interface{})
+	proxyContainer := containers[0].(map[string]interface{})
+	if proxyContainer["image"] != customImage {
+		t.Fatalf("proxy image = %v, want %q", proxyContainer["image"], customImage)
 	}
-
-	// Find the pipelock container and check its image.
-	for _, c := range containers {
-		cMap, ok := c.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		name, _ := cMap["name"].(string)
-		if name == sidecarContainerName {
-			img, _ := cMap["image"].(string)
-			if img != customImage {
-				t.Errorf("sidecar image = %q, want %q", img, customImage)
-			}
-			return
-		}
-	}
-	t.Fatal("pipelock sidecar container not found in patched manifest")
 }
 
 func TestGenerateSidecarPatch_CustomIdentity(t *testing.T) {
@@ -305,18 +361,37 @@ func TestGenerateSidecarPatch_CustomIdentity(t *testing.T) {
 	}
 
 	const customIdentity = "team-alpha/my-custom-agent"
-	opts := sidecarOptions{
+	result, err := generateSidecarPatch(manifest, sidecarOptions{
 		preset:        config.ModeBalanced,
 		agentIdentity: customIdentity,
-	}
-
-	result, err := generateSidecarPatch(manifest, opts)
+	})
 	if err != nil {
 		t.Fatalf("generateSidecarPatch: %v", err)
 	}
 
 	if result.AgentIdentity != customIdentity {
-		t.Errorf("AgentIdentity = %q, want %q", result.AgentIdentity, customIdentity)
+		t.Fatalf("AgentIdentity = %q, want %q", result.AgentIdentity, customIdentity)
+	}
+}
+
+func TestInjectProxyEnvs_RejectsConflictingProxy(t *testing.T) {
+	podSpec := map[string]interface{}{
+		"containers": []interface{}{
+			map[string]interface{}{
+				"name": "agent",
+				"env": []interface{}{
+					map[string]interface{}{"name": envHTTPSProxy, "value": "http://wrong-proxy:8888"},
+				},
+			},
+		},
+	}
+
+	err := injectProxyEnvs(podSpec, "http://expected-proxy:8888")
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if !strings.Contains(err.Error(), envHTTPSProxy) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -326,24 +401,15 @@ func TestResolveImage(t *testing.T) {
 		image     string
 		wantImage string
 	}{
-		{
-			name:      "default image uses version",
-			image:     "",
-			wantImage: fmt.Sprintf("%s:%s", defaultImageRepo, cliutil.Version),
-		},
-		{
-			name:      "custom image override",
-			image:     "my-registry.io/pipelock:custom",
-			wantImage: "my-registry.io/pipelock:custom",
-		},
+		{name: "default image uses version", image: "", wantImage: fmt.Sprintf("%s:%s", defaultImageRepo, cliutil.Version)},
+		{name: "custom image override", image: "my-registry.io/pipelock:custom", wantImage: "my-registry.io/pipelock:custom"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			opts := sidecarOptions{image: tc.image}
-			got := resolveImage(opts)
+			got := resolveImage(sidecarOptions{image: tc.image})
 			if got != tc.wantImage {
-				t.Errorf("resolveImage() = %q, want %q", got, tc.wantImage)
+				t.Fatalf("resolveImage() = %q, want %q", got, tc.wantImage)
 			}
 		})
 	}
@@ -357,57 +423,20 @@ func TestResolveAgentIdentity_Sidecar(t *testing.T) {
 		agentIdentity string
 		want          string
 	}{
-		{
-			name:         "derived from deployment",
-			kind:         kindDeployment,
-			workloadName: "my-agent",
-			want:         "deployment/my-agent",
-		},
-		{
-			name:         "derived from statefulset",
-			kind:         kindStatefulSet,
-			workloadName: "my-db",
-			want:         "statefulset/my-db",
-		},
-		{
-			name:         "derived from job",
-			kind:         kindJob,
-			workloadName: "runner",
-			want:         "job/runner",
-		},
-		{
-			name:         "derived from cronjob",
-			kind:         kindCronJob,
-			workloadName: "scanner",
-			want:         "cronjob/scanner",
-		},
-		{
-			name:          "custom identity overrides derivation",
-			kind:          kindDeployment,
-			workloadName:  "my-agent",
-			agentIdentity: "custom/override",
-			want:          "custom/override",
-		},
-		{
-			name:         "empty workload name",
-			kind:         kindDeployment,
-			workloadName: "",
-			want:         "",
-		},
+		{name: "derived from deployment", kind: kindDeployment, workloadName: "my-agent", want: "deployment/my-agent"},
+		{name: "derived from statefulset", kind: kindStatefulSet, workloadName: "my-db", want: "statefulset/my-db"},
+		{name: "derived from job", kind: kindJob, workloadName: "runner", want: "job/runner"},
+		{name: "derived from cronjob", kind: kindCronJob, workloadName: "scanner", want: "cronjob/scanner"},
+		{name: "custom identity overrides derivation", kind: kindDeployment, workloadName: "my-agent", agentIdentity: "custom/override", want: "custom/override"},
+		{name: "empty workload name", kind: kindDeployment, workloadName: "", want: ""},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			manifest := &workloadManifest{
-				Kind: tc.kind,
-				Name: tc.workloadName,
-			}
-			opts := sidecarOptions{
-				agentIdentity: tc.agentIdentity,
-			}
-			got := resolveAgentIdentity(manifest, opts)
+			manifest := &workloadManifest{Kind: tc.kind, Name: tc.workloadName}
+			got := resolveAgentIdentity(manifest, sidecarOptions{agentIdentity: tc.agentIdentity})
 			if got != tc.want {
-				t.Errorf("resolveAgentIdentity() = %q, want %q", got, tc.want)
+				t.Fatalf("resolveAgentIdentity() = %q, want %q", got, tc.want)
 			}
 		})
 	}
@@ -463,8 +492,14 @@ func TestNetworkPolicySelectorLabels_FallsBackToTemplateLabels(t *testing.T) {
 	}
 }
 
-func TestRenderNetworkPolicy_EmptySelectorError(t *testing.T) {
-	if _, err := renderNetworkPolicy("default", "agent", nil); err == nil {
-		t.Fatal("expected error for empty selector labels")
+func TestRenderAgentNetworkPolicy_EmptySelectorError(t *testing.T) {
+	if _, err := renderAgentNetworkPolicy("default", "agent", nil, map[string]string{"app": "proxy"}); err == nil {
+		t.Fatal("expected error for empty agent selector labels")
+	}
+}
+
+func TestRenderProxyNetworkPolicy_EmptySelectorError(t *testing.T) {
+	if _, err := renderProxyNetworkPolicy("default", "proxy", map[string]string{"app": "proxy"}, nil); err == nil {
+		t.Fatal("expected error for empty agent selector labels")
 	}
 }

--- a/internal/cli/setup/sidecar_patch_test.go
+++ b/internal/cli/setup/sidecar_patch_test.go
@@ -1,0 +1,470 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"fmt"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestGenerateSidecarPatch_Deployment(t *testing.T) {
+	manifest, err := detectWorkload(testdataPath(t, "deployment.yaml"))
+	if err != nil {
+		t.Fatalf("detectWorkload: %v", err)
+	}
+
+	opts := sidecarOptions{
+		preset: config.ModeBalanced,
+	}
+
+	result, err := generateSidecarPatch(manifest, opts)
+	if err != nil {
+		t.Fatalf("generateSidecarPatch: %v", err)
+	}
+
+	// Verify 2 containers in patched manifest.
+	podSpec, err := getPodSpec(result.PatchedManifest, kindDeployment)
+	if err != nil {
+		t.Fatalf("getPodSpec on patched: %v", err)
+	}
+
+	containers, ok := podSpec["containers"].([]interface{})
+	if !ok {
+		t.Fatal("containers not found in patched pod spec")
+	}
+	if len(containers) != 2 {
+		t.Fatalf("expected 2 containers, got %d", len(containers))
+	}
+
+	// Second container should be named "pipelock".
+	second, ok := containers[1].(map[string]interface{})
+	if !ok {
+		t.Fatal("second container is not a map")
+	}
+	if name, _ := second["name"].(string); name != sidecarContainerName {
+		t.Errorf("second container name = %q, want %q", name, sidecarContainerName)
+	}
+
+	// First container should have proxy env vars.
+	first, ok := containers[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("first container is not a map")
+	}
+	envList, ok := first["env"].([]interface{})
+	if !ok {
+		t.Fatal("first container has no env list")
+	}
+
+	wantEnvNames := []string{envHTTPSProxy, envHTTPProxy, envNoProxy}
+	for _, wantName := range wantEnvNames {
+		if !hasEnvVar(envList, wantName) {
+			t.Errorf("first container missing env var %s", wantName)
+		}
+	}
+
+	// Volumes should include pipelock-config.
+	volumes, ok := podSpec["volumes"].([]interface{})
+	if !ok {
+		t.Fatal("volumes not found in patched pod spec")
+	}
+	foundVol := false
+	for _, v := range volumes {
+		vMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if n, _ := vMap["name"].(string); n == sidecarConfigVolume {
+			foundVol = true
+			break
+		}
+	}
+	if !foundVol {
+		t.Errorf("expected volume %q in patched manifest", sidecarConfigVolume)
+	}
+
+	// ConfigMapYAML should be non-empty.
+	if result.ConfigMapYAML == "" {
+		t.Error("ConfigMapYAML should not be empty")
+	}
+
+	// NetworkPolicyYAML should be non-empty.
+	if result.NetworkPolicyYAML == "" {
+		t.Error("NetworkPolicyYAML should not be empty")
+	}
+	var networkPolicy map[string]interface{}
+	if err := yaml.Unmarshal([]byte(result.NetworkPolicyYAML), &networkPolicy); err != nil {
+		t.Fatalf("parsing NetworkPolicyYAML: %v", err)
+	}
+	spec, ok := networkPolicy["spec"].(map[string]interface{})
+	if !ok {
+		t.Fatal("network policy spec should be a map")
+	}
+	podSelector, ok := spec["podSelector"].(map[string]interface{})
+	if !ok {
+		t.Fatal("network policy podSelector should be a map")
+	}
+	matchLabels, ok := podSelector["matchLabels"].(map[string]interface{})
+	if !ok {
+		t.Fatal("network policy matchLabels should be a map")
+	}
+	if matchLabels["app"] != "my-agent" {
+		t.Fatalf("network policy selector = %v, want app=my-agent", matchLabels)
+	}
+	egress, ok := spec["egress"].([]interface{})
+	if !ok || len(egress) != 2 {
+		t.Fatalf("network policy egress = %v, want 2 rules", spec["egress"])
+	}
+
+	// AgentIdentity should be "deployment/my-agent".
+	wantIdentity := "deployment/my-agent"
+	if result.AgentIdentity != wantIdentity {
+		t.Errorf("AgentIdentity = %q, want %q", result.AgentIdentity, wantIdentity)
+	}
+}
+
+func TestGenerateSidecarPatch_Idempotent(t *testing.T) {
+	manifest, err := detectWorkload(testdataPath(t, "deployment.yaml"))
+	if err != nil {
+		t.Fatalf("detectWorkload: %v", err)
+	}
+
+	opts := sidecarOptions{
+		preset: config.ModeBalanced,
+	}
+
+	// First patch.
+	first, err := generateSidecarPatch(manifest, opts)
+	if err != nil {
+		t.Fatalf("first generateSidecarPatch: %v", err)
+	}
+
+	// Build a new workloadManifest from the patched result.
+	patchedManifest := &workloadManifest{
+		Kind: manifest.Kind,
+		Name: manifest.Name,
+		Raw:  first.PatchedManifest,
+	}
+
+	// Second patch on already-patched manifest.
+	second, err := generateSidecarPatch(patchedManifest, opts)
+	if err != nil {
+		t.Fatalf("second generateSidecarPatch: %v", err)
+	}
+
+	// Second run should not add duplicate containers.
+	podSpec, err := getPodSpec(second.PatchedManifest, kindDeployment)
+	if err != nil {
+		t.Fatalf("getPodSpec on second patch: %v", err)
+	}
+
+	containers, ok := podSpec["containers"].([]interface{})
+	if !ok {
+		t.Fatal("containers not found")
+	}
+
+	// Should still be 2 containers, not 3.
+	if len(containers) != 2 {
+		t.Errorf("expected 2 containers after second patch, got %d", len(containers))
+	}
+
+	// ConfigMapYAML should be empty on idempotent run (no new artifacts).
+	if second.ConfigMapYAML != "" {
+		t.Error("expected empty ConfigMapYAML on idempotent patch")
+	}
+}
+
+func TestGenerateSidecarPatch_AllKinds(t *testing.T) {
+	tests := []struct {
+		name         string
+		file         string
+		kind         string
+		wantIdentity string
+	}{
+		{
+			name:         "deployment",
+			file:         "deployment.yaml",
+			kind:         kindDeployment,
+			wantIdentity: "deployment/my-agent",
+		},
+		{
+			name:         "statefulset",
+			file:         "statefulset.yaml",
+			kind:         kindStatefulSet,
+			wantIdentity: "statefulset/my-db-agent",
+		},
+		{
+			name:         "job",
+			file:         "job.yaml",
+			kind:         kindJob,
+			wantIdentity: "job/batch-runner",
+		},
+		{
+			name:         "cronjob",
+			file:         "cronjob.yaml",
+			kind:         kindCronJob,
+			wantIdentity: "cronjob/scheduled-scan",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest, err := detectWorkload(testdataPath(t, tc.file))
+			if err != nil {
+				t.Fatalf("detectWorkload: %v", err)
+			}
+
+			opts := sidecarOptions{
+				preset: config.ModeBalanced,
+			}
+
+			result, err := generateSidecarPatch(manifest, opts)
+			if err != nil {
+				t.Fatalf("generateSidecarPatch: %v", err)
+			}
+
+			// Verify sidecar container was added.
+			podSpec, err := getPodSpec(result.PatchedManifest, tc.kind)
+			if err != nil {
+				t.Fatalf("getPodSpec: %v", err)
+			}
+			if !hasPipelockContainer(podSpec) {
+				t.Error("patched manifest should have pipelock container")
+			}
+
+			// Verify identity derivation.
+			if result.AgentIdentity != tc.wantIdentity {
+				t.Errorf("AgentIdentity = %q, want %q", result.AgentIdentity, tc.wantIdentity)
+			}
+
+			// Verify artifacts were generated.
+			if result.ConfigMapYAML == "" {
+				t.Error("ConfigMapYAML should not be empty")
+			}
+			if result.NetworkPolicyYAML == "" {
+				t.Error("NetworkPolicyYAML should not be empty")
+			}
+		})
+	}
+}
+
+func TestGenerateSidecarPatch_CustomImage(t *testing.T) {
+	manifest, err := detectWorkload(testdataPath(t, "deployment.yaml"))
+	if err != nil {
+		t.Fatalf("detectWorkload: %v", err)
+	}
+
+	const customImage = "registry.example.com/pipelock:v1.2.3"
+	opts := sidecarOptions{
+		preset: config.ModeBalanced,
+		image:  customImage,
+	}
+
+	result, err := generateSidecarPatch(manifest, opts)
+	if err != nil {
+		t.Fatalf("generateSidecarPatch: %v", err)
+	}
+
+	podSpec, err := getPodSpec(result.PatchedManifest, kindDeployment)
+	if err != nil {
+		t.Fatalf("getPodSpec: %v", err)
+	}
+
+	containers, ok := podSpec["containers"].([]interface{})
+	if !ok {
+		t.Fatal("containers not found")
+	}
+
+	// Find the pipelock container and check its image.
+	for _, c := range containers {
+		cMap, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := cMap["name"].(string)
+		if name == sidecarContainerName {
+			img, _ := cMap["image"].(string)
+			if img != customImage {
+				t.Errorf("sidecar image = %q, want %q", img, customImage)
+			}
+			return
+		}
+	}
+	t.Fatal("pipelock sidecar container not found in patched manifest")
+}
+
+func TestGenerateSidecarPatch_CustomIdentity(t *testing.T) {
+	manifest, err := detectWorkload(testdataPath(t, "deployment.yaml"))
+	if err != nil {
+		t.Fatalf("detectWorkload: %v", err)
+	}
+
+	const customIdentity = "team-alpha/my-custom-agent"
+	opts := sidecarOptions{
+		preset:        config.ModeBalanced,
+		agentIdentity: customIdentity,
+	}
+
+	result, err := generateSidecarPatch(manifest, opts)
+	if err != nil {
+		t.Fatalf("generateSidecarPatch: %v", err)
+	}
+
+	if result.AgentIdentity != customIdentity {
+		t.Errorf("AgentIdentity = %q, want %q", result.AgentIdentity, customIdentity)
+	}
+}
+
+func TestResolveImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		image     string
+		wantImage string
+	}{
+		{
+			name:      "default image uses version",
+			image:     "",
+			wantImage: fmt.Sprintf("%s:%s", defaultImageRepo, cliutil.Version),
+		},
+		{
+			name:      "custom image override",
+			image:     "my-registry.io/pipelock:custom",
+			wantImage: "my-registry.io/pipelock:custom",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := sidecarOptions{image: tc.image}
+			got := resolveImage(opts)
+			if got != tc.wantImage {
+				t.Errorf("resolveImage() = %q, want %q", got, tc.wantImage)
+			}
+		})
+	}
+}
+
+func TestResolveAgentIdentity_Sidecar(t *testing.T) {
+	tests := []struct {
+		name          string
+		kind          string
+		workloadName  string
+		agentIdentity string
+		want          string
+	}{
+		{
+			name:         "derived from deployment",
+			kind:         kindDeployment,
+			workloadName: "my-agent",
+			want:         "deployment/my-agent",
+		},
+		{
+			name:         "derived from statefulset",
+			kind:         kindStatefulSet,
+			workloadName: "my-db",
+			want:         "statefulset/my-db",
+		},
+		{
+			name:         "derived from job",
+			kind:         kindJob,
+			workloadName: "runner",
+			want:         "job/runner",
+		},
+		{
+			name:         "derived from cronjob",
+			kind:         kindCronJob,
+			workloadName: "scanner",
+			want:         "cronjob/scanner",
+		},
+		{
+			name:          "custom identity overrides derivation",
+			kind:          kindDeployment,
+			workloadName:  "my-agent",
+			agentIdentity: "custom/override",
+			want:          "custom/override",
+		},
+		{
+			name:         "empty workload name",
+			kind:         kindDeployment,
+			workloadName: "",
+			want:         "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := &workloadManifest{
+				Kind: tc.kind,
+				Name: tc.workloadName,
+			}
+			opts := sidecarOptions{
+				agentIdentity: tc.agentIdentity,
+			}
+			got := resolveAgentIdentity(manifest, opts)
+			if got != tc.want {
+				t.Errorf("resolveAgentIdentity() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNetworkPolicySelectorLabels_UsesSelectorMatchLabels(t *testing.T) {
+	raw := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{
+					"app.kubernetes.io/name": "agent",
+					"tier":                   "prod",
+				},
+			},
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"ignored": "value",
+					},
+				},
+			},
+		},
+	}
+
+	got, err := networkPolicySelectorLabels(raw, kindDeployment)
+	if err != nil {
+		t.Fatalf("networkPolicySelectorLabels: %v", err)
+	}
+	if got["app.kubernetes.io/name"] != "agent" || got["tier"] != "prod" {
+		t.Fatalf("selector labels = %v, want selector.matchLabels", got)
+	}
+}
+
+func TestNetworkPolicySelectorLabels_FallsBackToTemplateLabels(t *testing.T) {
+	raw := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"job-name": "nightly",
+					},
+				},
+			},
+		},
+	}
+
+	got, err := networkPolicySelectorLabels(raw, kindJob)
+	if err != nil {
+		t.Fatalf("networkPolicySelectorLabels: %v", err)
+	}
+	if got["job-name"] != "nightly" {
+		t.Fatalf("selector labels = %v, want template labels", got)
+	}
+}
+
+func TestRenderNetworkPolicy_EmptySelectorError(t *testing.T) {
+	if _, err := renderNetworkPolicy("default", "agent", nil); err == nil {
+		t.Fatal("expected error for empty selector labels")
+	}
+}

--- a/internal/cli/setup/sidecar_test.go
+++ b/internal/cli/setup/sidecar_test.go
@@ -199,9 +199,8 @@ func TestRunSidecar_EmitPatch(t *testing.T) {
 func TestRunSidecar_Idempotent(t *testing.T) {
 	t.Parallel()
 
-	// First pass: generate a patched manifest.
 	dir := t.TempDir()
-	patchedPath := filepath.Join(dir, "patched.yaml")
+	outDir := filepath.Join(dir, "kustomize-out")
 
 	var buf1 bytes.Buffer
 	cmd1 := SidecarCmd()
@@ -209,7 +208,8 @@ func TestRunSidecar_Idempotent(t *testing.T) {
 	cmd1.SetErr(&buf1)
 	cmd1.SetArgs([]string{
 		"--inject-spec", testdataPath(t, "deployment.yaml"),
-		"--output", patchedPath,
+		"--emit", "kustomize",
+		"--output", outDir,
 		"--skip-canary",
 		"--skip-verify",
 	})
@@ -218,13 +218,14 @@ func TestRunSidecar_Idempotent(t *testing.T) {
 		t.Fatalf("first run: %v", err)
 	}
 
-	// Second pass: run against the already-patched manifest with JSON output.
+	agentWorkloadPath := filepath.Join(outDir, "agent-workload.yaml")
+
 	var buf2 bytes.Buffer
 	cmd2 := SidecarCmd()
 	cmd2.SetOut(&buf2)
 	cmd2.SetErr(&buf2)
 	cmd2.SetArgs([]string{
-		"--inject-spec", patchedPath,
+		"--inject-spec", agentWorkloadPath,
 		"--dry-run",
 		"--json",
 	})
@@ -352,10 +353,13 @@ func TestRunSidecar_EmitKustomize(t *testing.T) {
 	// Verify kustomize files exist.
 	for _, name := range []string{
 		"kustomization.yaml",
-		"workload.yaml",
-		"pipelock-sidecar-patch.yaml",
+		"agent-workload.yaml",
 		"pipelock-configmap.yaml",
+		"pipelock-deployment.yaml",
+		"pipelock-service.yaml",
+		"agent-networkpolicy.yaml",
 		"pipelock-networkpolicy.yaml",
+		"pipelock-pdb.yaml",
 	} {
 		path := filepath.Join(outDir, name)
 		if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -391,7 +395,7 @@ func TestRunSidecar_EmitHelmValues(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	outPath := filepath.Join(dir, "values.yaml")
+	outDir := filepath.Join(dir, "helm-bundle")
 
 	var buf bytes.Buffer
 	cmd := SidecarCmd()
@@ -400,7 +404,7 @@ func TestRunSidecar_EmitHelmValues(t *testing.T) {
 	cmd.SetArgs([]string{
 		"--inject-spec", testdataPath(t, "deployment.yaml"),
 		"--emit", "helm-values",
-		"--output", outPath,
+		"--output", outDir,
 		"--skip-canary",
 		"--skip-verify",
 	})
@@ -409,13 +413,55 @@ func TestRunSidecar_EmitHelmValues(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Clean(outPath))
+	data, err := os.ReadFile(filepath.Clean(filepath.Join(outDir, "values.yaml")))
 	if err != nil {
 		t.Fatalf("reading output: %v", err)
 	}
 
-	if !strings.Contains(string(data), "Helm chart values") {
+	if !strings.Contains(string(data), "Helm bundle values") {
 		t.Error("output should contain Helm header comment")
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "README.txt")); err != nil {
+		t.Fatalf("expected README.txt in helm bundle: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "pipelock-pdb.yaml")); err != nil {
+		t.Fatalf("expected pipelock-pdb.yaml in helm bundle: %v", err)
+	}
+}
+
+func TestRunSidecar_VerifyHealthy(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "patched.yaml")
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--output", outPath,
+		"--skip-canary",
+		"--json",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result sidecarResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if result.Verify == nil {
+		t.Fatal("verify field should not be nil")
+	}
+	if result.Verify.Skipped {
+		t.Fatal("verify should not be skipped")
+	}
+	if !result.Verify.Healthy {
+		t.Fatalf("verify should be healthy, got: %+v", result.Verify)
 	}
 }
 

--- a/internal/cli/setup/sidecar_test.go
+++ b/internal/cli/setup/sidecar_test.go
@@ -1,0 +1,490 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunSidecar_DryRun(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--dry-run",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+
+	// Verify all 7 phase markers appear.
+	for i := 1; i <= 7; i++ {
+		marker := "[" + itoa(i) + "/7]"
+		if !strings.Contains(output, marker) {
+			t.Errorf("output should contain phase marker %s", marker)
+		}
+	}
+
+	// Verify dry-run message.
+	if !strings.Contains(output, "Dry run") {
+		t.Errorf("output should contain 'Dry run', got:\n%s", output)
+	}
+
+	// Verify diff preview section is present.
+	if !strings.Contains(output, "Diff preview") {
+		t.Errorf("output should contain 'Diff preview', got:\n%s", output)
+	}
+}
+
+func TestRunSidecar_JSON(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--dry-run",
+		"--json",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result sidecarResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, buf.String())
+	}
+
+	if result.Detect == nil {
+		t.Fatal("detect field should not be nil")
+	}
+	if result.Detect.Kind != kindDeployment {
+		t.Errorf("detect.kind = %q, want %q", result.Detect.Kind, kindDeployment)
+	}
+	if result.Detect.Name != "my-agent" {
+		t.Errorf("detect.name = %q, want %q", result.Detect.Name, "my-agent")
+	}
+
+	if result.Patch == nil {
+		t.Fatal("patch field should not be nil")
+	}
+	if !result.Patch.DryRun {
+		t.Error("patch.dry_run should be true")
+	}
+	if result.Patch.EmitFormat != emitPatch {
+		t.Errorf("patch.emit_format = %q, want %q", result.Patch.EmitFormat, emitPatch)
+	}
+}
+
+func TestRunSidecar_AllKinds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		file     string
+		wantKind string
+		wantName string
+	}{
+		{
+			name:     "deployment",
+			file:     "deployment.yaml",
+			wantKind: kindDeployment,
+			wantName: "my-agent",
+		},
+		{
+			name:     "statefulset",
+			file:     "statefulset.yaml",
+			wantKind: kindStatefulSet,
+			wantName: "my-db-agent",
+		},
+		{
+			name:     "job",
+			file:     "job.yaml",
+			wantKind: kindJob,
+			wantName: "batch-runner",
+		},
+		{
+			name:     "cronjob",
+			file:     "cronjob.yaml",
+			wantKind: kindCronJob,
+			wantName: "scheduled-scan",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			cmd := SidecarCmd()
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs([]string{
+				"--inject-spec", testdataPath(t, tc.file),
+				"--dry-run",
+				"--json",
+			})
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var result sidecarResult
+			if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+				t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+			}
+
+			if result.Detect.Kind != tc.wantKind {
+				t.Errorf("detect.kind = %q, want %q", result.Detect.Kind, tc.wantKind)
+			}
+			if result.Detect.Name != tc.wantName {
+				t.Errorf("detect.name = %q, want %q", result.Detect.Name, tc.wantName)
+			}
+		})
+	}
+}
+
+func TestRunSidecar_EmitPatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "patched.yaml")
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--output", outPath,
+		"--skip-canary",
+		"--skip-verify",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify file was written.
+	data, err := os.ReadFile(filepath.Clean(outPath))
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("output file is empty")
+	}
+
+	// Verify it contains multi-document YAML.
+	if !strings.Contains(string(data), "---") {
+		t.Error("output should contain YAML document separator")
+	}
+}
+
+func TestRunSidecar_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	// First pass: generate a patched manifest.
+	dir := t.TempDir()
+	patchedPath := filepath.Join(dir, "patched.yaml")
+
+	var buf1 bytes.Buffer
+	cmd1 := SidecarCmd()
+	cmd1.SetOut(&buf1)
+	cmd1.SetErr(&buf1)
+	cmd1.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--output", patchedPath,
+		"--skip-canary",
+		"--skip-verify",
+	})
+
+	if err := cmd1.Execute(); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+
+	// Second pass: run against the already-patched manifest with JSON output.
+	var buf2 bytes.Buffer
+	cmd2 := SidecarCmd()
+	cmd2.SetOut(&buf2)
+	cmd2.SetErr(&buf2)
+	cmd2.SetArgs([]string{
+		"--inject-spec", patchedPath,
+		"--dry-run",
+		"--json",
+	})
+
+	if err := cmd2.Execute(); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	var result sidecarResult
+	if err := json.Unmarshal(buf2.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf2.String())
+	}
+
+	if !result.Detect.AlreadyPatched {
+		t.Error("second run should detect already_patched=true")
+	}
+}
+
+func TestRunSidecar_CanaryDetection(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--output", filepath.Join(t.TempDir(), "out.yaml"),
+		"--skip-verify",
+		"--json",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result sidecarResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+
+	if result.Canary == nil {
+		t.Fatal("canary field should not be nil")
+	}
+	if !result.Canary.Detected {
+		t.Error("canary.detected should be true (DLP should catch the synthetic secret)")
+	}
+}
+
+func TestRunSidecar_InvalidPreset(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--preset", "bogus",
+		"--dry-run",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid preset")
+	}
+}
+
+func TestRunSidecar_InvalidEmitFormat(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--emit", "bad-format",
+		"--dry-run",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid emit format")
+	}
+}
+
+func TestRunSidecar_MissingInjectSpec(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--dry-run"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing --inject-spec")
+	}
+}
+
+func TestRunSidecar_EmitKustomize(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outDir := filepath.Join(dir, "kustomize-out")
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--emit", "kustomize",
+		"--output", outDir,
+		"--skip-canary",
+		"--skip-verify",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify kustomize files exist.
+	for _, name := range []string{
+		"kustomization.yaml",
+		"workload.yaml",
+		"pipelock-sidecar-patch.yaml",
+		"pipelock-configmap.yaml",
+		"pipelock-networkpolicy.yaml",
+	} {
+		path := filepath.Join(outDir, name)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("expected file %s not created", name)
+		}
+	}
+}
+
+func TestRunSidecar_JSONRequiresOutputWhenEmitting(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--json",
+		"--skip-canary",
+		"--skip-verify",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --json emits to stdout without --output")
+	}
+	if !strings.Contains(err.Error(), "--json requires --output") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunSidecar_EmitHelmValues(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "values.yaml")
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--emit", "helm-values",
+		"--output", outPath,
+		"--skip-canary",
+		"--skip-verify",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(outPath))
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+
+	if !strings.Contains(string(data), "Helm chart values") {
+		t.Error("output should contain Helm header comment")
+	}
+}
+
+func TestRunSidecar_SkipCanary(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--dry-run",
+		"--skip-canary",
+		"--json",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result sidecarResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+
+	if result.Canary == nil {
+		t.Fatal("canary field should not be nil")
+	}
+	if !result.Canary.Skipped {
+		t.Error("canary.skipped should be true with --skip-canary")
+	}
+}
+
+func TestRunSidecar_CustomAgentIdentity(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--dry-run",
+		"--json",
+		"--agent-identity", "team/custom-bot",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result sidecarResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+
+	if result.Patch.AgentIdentity != "team/custom-bot" {
+		t.Errorf("agent_identity = %q, want %q", result.Patch.AgentIdentity, "team/custom-bot")
+	}
+}
+
+// itoa is a minimal int-to-string without importing strconv (keeps imports lean).
+func itoa(n int) string {
+	if n < 0 {
+		return "-" + itoa(-n)
+	}
+	if n < 10 {
+		return string(rune('0' + n))
+	}
+	return itoa(n/10) + string(rune('0'+n%10))
+}

--- a/internal/cli/setup/sidecar_verify.go
+++ b/internal/cli/setup/sidecar_verify.go
@@ -6,6 +6,7 @@ package setup
 import (
 	"fmt"
 	"io"
+	"strings"
 )
 
 // sidecarVerifyResult holds the outcome of the sidecar verify phase.
@@ -16,25 +17,86 @@ type sidecarVerifyResult struct {
 	Detail    string `json:"detail,omitempty"`
 }
 
-// runSidecarVerify attempts to reach the sidecar's health endpoint via port-forward.
-// Fails open on kubeconfig absence — prints a clear message and skips.
-// Uses a 5-second deadline to prevent indefinite blocking.
-func runSidecarVerify(w io.Writer, opts sidecarOptions, jsonOutput bool) *sidecarVerifyResult {
+// runSidecarVerify performs static verification of the generated enforced topology.
+func runSidecarVerify(w io.Writer, result *sidecarPatchResult, opts sidecarOptions, jsonOutput bool) *sidecarVerifyResult {
 	if opts.skipVerify {
 		return &sidecarVerifyResult{Skipped: true, Detail: "skipped (--skip-verify)"}
 	}
 
-	// Port-forward verification requires a real cluster connection.
-	// For the initial implementation, we skip gracefully when not connected.
-	// Future: use kubeconfig to port-forward and probe /health.
-	if !jsonOutput {
-		_, _ = fmt.Fprintln(w, "  Cluster verification requires a running pod.")
-		_, _ = fmt.Fprintln(w, "  Apply the manifest and run: kubectl port-forward <pod> 8888:8888")
-		_, _ = fmt.Fprintln(w, "  Then: curl http://localhost:8888/health")
+	if result == nil || result.Config == nil {
+		return &sidecarVerifyResult{Healthy: false, Detail: "generated topology is missing proxy config"}
 	}
 
+	var failed []string
+	if result.ProxyName == "" || result.ProxyURL == "" {
+		failed = append(failed, "proxy identity metadata is incomplete")
+	}
+	if result.DeploymentYAML == "" {
+		failed = append(failed, "proxy Deployment YAML is empty")
+	}
+	if result.ServiceYAML == "" {
+		failed = append(failed, "proxy Service YAML is empty")
+	}
+	if result.PodDisruptionBudgetYAML == "" {
+		failed = append(failed, "proxy PodDisruptionBudget YAML is empty")
+	}
+	if !strings.Contains(result.DeploymentYAML, fmt.Sprintf("replicas: %d", proxyReplicaCount)) {
+		failed = append(failed, fmt.Sprintf("proxy Deployment does not set replicas=%d", proxyReplicaCount))
+	}
+	if strings.Contains(result.DeploymentYAML, "subPath:") {
+		failed = append(failed, "proxy Deployment still uses subPath ConfigMap mount")
+	}
+	if !strings.Contains(result.DeploymentYAML, "mountPath: /etc/pipelock") {
+		failed = append(failed, "proxy Deployment does not mount the config directory")
+	}
+	if !strings.Contains(result.DeploymentYAML, "imagePullPolicy: IfNotPresent") {
+		failed = append(failed, "proxy Deployment does not set imagePullPolicy=IfNotPresent")
+	}
+	if !result.Config.ForwardProxy.Enabled {
+		failed = append(failed, "forward_proxy.enabled is false")
+	}
+	if got := result.Config.FetchProxy.Listen; got != fmt.Sprintf("0.0.0.0:%d", sidecarHealthPort) {
+		failed = append(failed, fmt.Sprintf("fetch_proxy.listen = %q", got))
+	}
+	if got := result.Config.MetricsListen; got != fmt.Sprintf("0.0.0.0:%d", sidecarMetricsPort) {
+		failed = append(failed, fmt.Sprintf("metrics_listen = %q", got))
+	}
+	if !strings.Contains(result.AgentNetworkPolicyYAML, "matchLabels") || !strings.Contains(result.AgentNetworkPolicyYAML, "podSelector") {
+		failed = append(failed, "agent NetworkPolicy missing selectors")
+	}
+	if strings.Contains(result.AgentNetworkPolicyYAML, "port: 80") || strings.Contains(result.AgentNetworkPolicyYAML, "port: 443") {
+		failed = append(failed, "agent NetworkPolicy still allows direct web egress")
+	}
+	if !strings.Contains(result.AgentNetworkPolicyYAML, fmt.Sprintf("port: %d", sidecarHealthPort)) {
+		failed = append(failed, "agent NetworkPolicy does not allow proxy port")
+	}
+	if !strings.Contains(result.ProxyNetworkPolicyYAML, fmt.Sprintf("port: %d", sidecarHealthPort)) {
+		failed = append(failed, "proxy NetworkPolicy does not allow agent ingress on proxy port")
+	}
+	if !strings.Contains(result.ProxyNetworkPolicyYAML, "port: 80") || !strings.Contains(result.ProxyNetworkPolicyYAML, "port: 443") {
+		failed = append(failed, "proxy NetworkPolicy does not allow web egress")
+	}
+
+	if len(failed) == 0 {
+		if !jsonOutput {
+			_, _ = fmt.Fprintln(w, "  Static topology checks passed.")
+			_, _ = fmt.Fprintf(w, "  Agent egress is limited to DNS + %s.\n", result.ProxyName)
+			_, _ = fmt.Fprintln(w, "  Proxy config is cluster-reachable with forward proxy enabled.")
+		}
+		return &sidecarVerifyResult{
+			Reachable: true,
+			Healthy:   true,
+			Detail:    "static topology verification passed",
+		}
+	}
+
+	detail := "static topology verification failed: " + strings.Join(failed, "; ")
+	if !jsonOutput {
+		_, _ = fmt.Fprintln(w, "  Static topology verification failed.")
+		_, _ = fmt.Fprintf(w, "  %s\n", detail)
+	}
 	return &sidecarVerifyResult{
-		Skipped: true,
-		Detail:  "cluster verification deferred; apply the manifest and verify manually",
+		Healthy: false,
+		Detail:  detail,
 	}
 }

--- a/internal/cli/setup/sidecar_verify.go
+++ b/internal/cli/setup/sidecar_verify.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"fmt"
+	"io"
+)
+
+// sidecarVerifyResult holds the outcome of the sidecar verify phase.
+type sidecarVerifyResult struct {
+	Reachable bool   `json:"reachable"`
+	Healthy   bool   `json:"healthy"`
+	Skipped   bool   `json:"skipped"`
+	Detail    string `json:"detail,omitempty"`
+}
+
+// runSidecarVerify attempts to reach the sidecar's health endpoint via port-forward.
+// Fails open on kubeconfig absence — prints a clear message and skips.
+// Uses a 5-second deadline to prevent indefinite blocking.
+func runSidecarVerify(w io.Writer, opts sidecarOptions, jsonOutput bool) *sidecarVerifyResult {
+	if opts.skipVerify {
+		return &sidecarVerifyResult{Skipped: true, Detail: "skipped (--skip-verify)"}
+	}
+
+	// Port-forward verification requires a real cluster connection.
+	// For the initial implementation, we skip gracefully when not connected.
+	// Future: use kubeconfig to port-forward and probe /health.
+	if !jsonOutput {
+		_, _ = fmt.Fprintln(w, "  Cluster verification requires a running pod.")
+		_, _ = fmt.Fprintln(w, "  Apply the manifest and run: kubectl port-forward <pod> 8888:8888")
+		_, _ = fmt.Fprintln(w, "  Then: curl http://localhost:8888/health")
+	}
+
+	return &sidecarVerifyResult{
+		Skipped: true,
+		Detail:  "cluster verification deferred; apply the manifest and verify manually",
+	}
+}

--- a/internal/cli/setup/testdata/sidecar/cronjob.yaml
+++ b/internal/cli/setup/testdata/sidecar/cronjob.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: scheduled-scan
+  namespace: cron
+spec:
+  schedule: "0 */6 * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: scheduled-scan
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: scanner
+              image: scheduled-scan:latest

--- a/internal/cli/setup/testdata/sidecar/deployment.yaml
+++ b/internal/cli/setup/testdata/sidecar/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-agent
+  namespace: agents
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-agent
+  template:
+    metadata:
+      labels:
+        app: my-agent
+    spec:
+      containers:
+        - name: agent
+          image: my-agent:latest
+          ports:
+            - containerPort: 8080

--- a/internal/cli/setup/testdata/sidecar/job.yaml
+++ b/internal/cli/setup/testdata/sidecar/job.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: batch-runner
+  namespace: jobs
+spec:
+  template:
+    metadata:
+      labels:
+        app: batch-runner
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: runner
+          image: batch-runner:latest

--- a/internal/cli/setup/testdata/sidecar/statefulset.yaml
+++ b/internal/cli/setup/testdata/sidecar/statefulset.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: my-db-agent
+  namespace: data
+spec:
+  serviceName: my-db-agent
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-db-agent
+  template:
+    metadata:
+      labels:
+        app: my-db-agent
+    spec:
+      containers:
+        - name: agent
+          image: my-db-agent:latest
+          ports:
+            - containerPort: 5432

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -391,9 +391,10 @@ type Config struct {
 	Taint                 TaintConfig             `yaml:"taint"`
 	MediationEnvelope     MediationEnvelope       `yaml:"mediation_envelope"`
 	Agents                map[string]AgentProfile `yaml:"agents,omitempty"`
-	LicenseKey            string                  `yaml:"license_key,omitempty"`        // signed license token (from pipelock license issue)
-	LicenseFile           string                  `yaml:"license_file,omitempty"`       // path to file containing the license token (read at startup)
-	LicensePublicKey      string                  `yaml:"license_public_key,omitempty"` // hex-encoded Ed25519 public key for license verification (dev builds only)
+	DefaultAgentIdentity  string                  `yaml:"default_agent_identity,omitempty"` // fallback agent name when no header/query identifies the caller
+	LicenseKey            string                  `yaml:"license_key,omitempty"`            // signed license token (from pipelock license issue)
+	LicenseFile           string                  `yaml:"license_file,omitempty"`           // path to file containing the license token (read at startup)
+	LicensePublicKey      string                  `yaml:"license_public_key,omitempty"`     // hex-encoded Ed25519 public key for license verification (dev builds only)
 	Internal              []string                `yaml:"internal"`
 	TrustedDomains        []string                `yaml:"trusted_domains"` // domains exempt from SSRF internal-IP check (wildcard supported)
 	SSRF                  SSRF                    `yaml:"ssrf"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -344,60 +344,61 @@ type SandboxFilesystem struct {
 
 // Config is the top-level Pipelock configuration.
 type Config struct {
-	Version               int                     `yaml:"version"`
-	Mode                  string                  `yaml:"mode"`           // strict, balanced, audit
-	Enforce               *bool                   `yaml:"enforce"`        // nil = true (default); false = detect & log without blocking
-	ExplainBlocks         *bool                   `yaml:"explain_blocks"` // nil = false (default); true = include hints in block responses
-	APIAllowlist          []string                `yaml:"api_allowlist"`
-	Suppress              []SuppressEntry         `yaml:"suppress"`
-	FetchProxy            FetchProxy              `yaml:"fetch_proxy"`
-	ForwardProxy          ForwardProxy            `yaml:"forward_proxy"`
-	WebSocketProxy        WebSocketProxy          `yaml:"websocket_proxy"`
-	DLP                   DLP                     `yaml:"dlp"`
-	CanaryTokens          CanaryTokens            `yaml:"canary_tokens"`
-	ResponseScanning      ResponseScanning        `yaml:"response_scanning"`
-	MCPInputScanning      MCPInputScanning        `yaml:"mcp_input_scanning"`
-	MCPToolScanning       MCPToolScanning         `yaml:"mcp_tool_scanning"`
-	MCPToolPolicy         MCPToolPolicy           `yaml:"mcp_tool_policy"`
-	GitProtection         GitProtection           `yaml:"git_protection"`
-	Logging               LoggingConfig           `yaml:"logging"`
-	SessionProfiling      SessionProfiling        `yaml:"session_profiling"`
-	AdaptiveEnforcement   AdaptiveEnforcement     `yaml:"adaptive_enforcement"`
-	MCPSessionBinding     MCPSessionBinding       `yaml:"mcp_session_binding"`
-	RequestBodyScanning   RequestBodyScanning     `yaml:"request_body_scanning"`
-	KillSwitch            KillSwitch              `yaml:"kill_switch"`
-	Sentry                SentryConfig            `yaml:"sentry"`
-	MetricsListen         string                  `yaml:"metrics_listen"` // separate listen address for /metrics and /stats
-	Emit                  EmitConfig              `yaml:"emit"`
-	ToolChainDetection    ToolChainDetection      `yaml:"tool_chain_detection"`
-	MCPWSListener         MCPWSListener           `yaml:"mcp_ws_listener"`
-	TLSInterception       TLSInterception         `yaml:"tls_interception"`
-	CrossRequestDetection CrossRequestDetection   `yaml:"cross_request_detection"`
-	ReverseProxy          ReverseProxy            `yaml:"reverse_proxy"`
-	ScanAPI               ScanAPI                 `yaml:"scan_api"`
-	AddressProtection     AddressProtection       `yaml:"address_protection"`
-	SeedPhraseDetection   SeedPhraseDetection     `yaml:"seed_phrase_detection"`
-	Rules                 Rules                   `yaml:"rules"`
-	FileSentry            FileSentry              `yaml:"file_sentry"`
-	Sandbox               Sandbox                 `yaml:"sandbox"`
-	FlightRecorder        FlightRecorder          `yaml:"flight_recorder"`
-	MCPBinaryIntegrity    MCPBinaryIntegrity      `yaml:"mcp_binary_integrity"`
-	MCPToolProvenance     MCPToolProvenance       `yaml:"mcp_tool_provenance"`
-	BehavioralBaseline    BehavioralBaseline      `yaml:"behavioral_baseline"`
-	Airlock               Airlock                 `yaml:"airlock"`
-	BrowserShield         BrowserShield           `yaml:"browser_shield"`
-	MediaPolicy           MediaPolicy             `yaml:"media_policy"`
-	A2AScanning           A2AScanning             `yaml:"a2a_scanning"`
-	Taint                 TaintConfig             `yaml:"taint"`
-	MediationEnvelope     MediationEnvelope       `yaml:"mediation_envelope"`
-	Agents                map[string]AgentProfile `yaml:"agents,omitempty"`
-	DefaultAgentIdentity  string                  `yaml:"default_agent_identity,omitempty"` // fallback agent name when no header/query identifies the caller
-	LicenseKey            string                  `yaml:"license_key,omitempty"`            // signed license token (from pipelock license issue)
-	LicenseFile           string                  `yaml:"license_file,omitempty"`           // path to file containing the license token (read at startup)
-	LicensePublicKey      string                  `yaml:"license_public_key,omitempty"`     // hex-encoded Ed25519 public key for license verification (dev builds only)
-	Internal              []string                `yaml:"internal"`
-	TrustedDomains        []string                `yaml:"trusted_domains"` // domains exempt from SSRF internal-IP check (wildcard supported)
-	SSRF                  SSRF                    `yaml:"ssrf"`
+	Version                  int                     `yaml:"version"`
+	Mode                     string                  `yaml:"mode"`           // strict, balanced, audit
+	Enforce                  *bool                   `yaml:"enforce"`        // nil = true (default); false = detect & log without blocking
+	ExplainBlocks            *bool                   `yaml:"explain_blocks"` // nil = false (default); true = include hints in block responses
+	APIAllowlist             []string                `yaml:"api_allowlist"`
+	Suppress                 []SuppressEntry         `yaml:"suppress"`
+	FetchProxy               FetchProxy              `yaml:"fetch_proxy"`
+	ForwardProxy             ForwardProxy            `yaml:"forward_proxy"`
+	WebSocketProxy           WebSocketProxy          `yaml:"websocket_proxy"`
+	DLP                      DLP                     `yaml:"dlp"`
+	CanaryTokens             CanaryTokens            `yaml:"canary_tokens"`
+	ResponseScanning         ResponseScanning        `yaml:"response_scanning"`
+	MCPInputScanning         MCPInputScanning        `yaml:"mcp_input_scanning"`
+	MCPToolScanning          MCPToolScanning         `yaml:"mcp_tool_scanning"`
+	MCPToolPolicy            MCPToolPolicy           `yaml:"mcp_tool_policy"`
+	GitProtection            GitProtection           `yaml:"git_protection"`
+	Logging                  LoggingConfig           `yaml:"logging"`
+	SessionProfiling         SessionProfiling        `yaml:"session_profiling"`
+	AdaptiveEnforcement      AdaptiveEnforcement     `yaml:"adaptive_enforcement"`
+	MCPSessionBinding        MCPSessionBinding       `yaml:"mcp_session_binding"`
+	RequestBodyScanning      RequestBodyScanning     `yaml:"request_body_scanning"`
+	KillSwitch               KillSwitch              `yaml:"kill_switch"`
+	Sentry                   SentryConfig            `yaml:"sentry"`
+	MetricsListen            string                  `yaml:"metrics_listen"` // separate listen address for /metrics and /stats
+	Emit                     EmitConfig              `yaml:"emit"`
+	ToolChainDetection       ToolChainDetection      `yaml:"tool_chain_detection"`
+	MCPWSListener            MCPWSListener           `yaml:"mcp_ws_listener"`
+	TLSInterception          TLSInterception         `yaml:"tls_interception"`
+	CrossRequestDetection    CrossRequestDetection   `yaml:"cross_request_detection"`
+	ReverseProxy             ReverseProxy            `yaml:"reverse_proxy"`
+	ScanAPI                  ScanAPI                 `yaml:"scan_api"`
+	AddressProtection        AddressProtection       `yaml:"address_protection"`
+	SeedPhraseDetection      SeedPhraseDetection     `yaml:"seed_phrase_detection"`
+	Rules                    Rules                   `yaml:"rules"`
+	FileSentry               FileSentry              `yaml:"file_sentry"`
+	Sandbox                  Sandbox                 `yaml:"sandbox"`
+	FlightRecorder           FlightRecorder          `yaml:"flight_recorder"`
+	MCPBinaryIntegrity       MCPBinaryIntegrity      `yaml:"mcp_binary_integrity"`
+	MCPToolProvenance        MCPToolProvenance       `yaml:"mcp_tool_provenance"`
+	BehavioralBaseline       BehavioralBaseline      `yaml:"behavioral_baseline"`
+	Airlock                  Airlock                 `yaml:"airlock"`
+	BrowserShield            BrowserShield           `yaml:"browser_shield"`
+	MediaPolicy              MediaPolicy             `yaml:"media_policy"`
+	A2AScanning              A2AScanning             `yaml:"a2a_scanning"`
+	Taint                    TaintConfig             `yaml:"taint"`
+	MediationEnvelope        MediationEnvelope       `yaml:"mediation_envelope"`
+	Agents                   map[string]AgentProfile `yaml:"agents,omitempty"`
+	DefaultAgentIdentity     string                  `yaml:"default_agent_identity,omitempty"`      // operator-configured agent name used when no stronger identity source resolves the caller
+	BindDefaultAgentIdentity bool                    `yaml:"bind_default_agent_identity,omitempty"` // when true, ignore self-declared header/query identities and bind requests to default_agent_identity
+	LicenseKey               string                  `yaml:"license_key,omitempty"`                 // signed license token (from pipelock license issue)
+	LicenseFile              string                  `yaml:"license_file,omitempty"`                // path to file containing the license token (read at startup)
+	LicensePublicKey         string                  `yaml:"license_public_key,omitempty"`          // hex-encoded Ed25519 public key for license verification (dev builds only)
+	Internal                 []string                `yaml:"internal"`
+	TrustedDomains           []string                `yaml:"trusted_domains"` // domains exempt from SSRF internal-IP check (wildcard supported)
+	SSRF                     SSRF                    `yaml:"ssrf"`
 
 	// LicenseExpiresAt is the Unix timestamp of the license expiry, populated
 	// by EnforceLicenseGate(). Zero means perpetual. Used for runtime expiry
@@ -2196,6 +2197,7 @@ func (c *Config) Validate() error {
 		c.validateAirlock,
 		c.validateBrowserShield,
 		c.validateTaint,
+		c.validateDefaultAgentIdentity,
 		c.validateMediationEnvelope,
 		c.validateMediaPolicy,
 	}
@@ -3466,6 +3468,13 @@ func (c *Config) validateBrowserShield() error {
 func (c *Config) validateMediationEnvelope() error {
 	// Only field today is Enabled (bool). Signing, SPIFFE actor format,
 	// and key management will add validation when they ship.
+	return nil
+}
+
+func (c *Config) validateDefaultAgentIdentity() error {
+	if c.BindDefaultAgentIdentity && c.DefaultAgentIdentity == "" {
+		return fmt.Errorf("bind_default_agent_identity requires default_agent_identity")
+	}
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3472,8 +3472,12 @@ func (c *Config) validateMediationEnvelope() error {
 }
 
 func (c *Config) validateDefaultAgentIdentity() error {
-	if c.BindDefaultAgentIdentity && c.DefaultAgentIdentity == "" {
+	identity := strings.TrimSpace(c.DefaultAgentIdentity)
+	if c.BindDefaultAgentIdentity && identity == "" {
 		return fmt.Errorf("bind_default_agent_identity requires default_agent_identity")
+	}
+	if c.DefaultAgentIdentity != "" && identity != c.DefaultAgentIdentity {
+		return fmt.Errorf("default_agent_identity must not contain leading or trailing whitespace")
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -85,6 +85,9 @@ func TestDefaults(t *testing.T) {
 	if len(cfg.Internal) == 0 {
 		t.Error("expected non-empty internal CIDRs")
 	}
+	if cfg.BindDefaultAgentIdentity {
+		t.Error("expected bind_default_agent_identity to default false")
+	}
 }
 
 func TestDefaults_QuarantineDir(t *testing.T) {
@@ -126,6 +129,15 @@ func TestValidate_StrictModeRequiresAllowlist(t *testing.T) {
 	cfg.APIAllowlist = nil
 	if err := cfg.Validate(); err == nil {
 		t.Error("expected error for strict mode with empty allowlist")
+	}
+}
+
+func TestValidate_BindDefaultAgentIdentityRequiresDefault(t *testing.T) {
+	cfg := Defaults()
+	cfg.BindDefaultAgentIdentity = true
+	cfg.DefaultAgentIdentity = ""
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error when bind_default_agent_identity is true without default_agent_identity")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -141,6 +141,23 @@ func TestValidate_BindDefaultAgentIdentityRequiresDefault(t *testing.T) {
 	}
 }
 
+func TestValidate_BindDefaultAgentIdentityRejectsWhitespaceOnly(t *testing.T) {
+	cfg := Defaults()
+	cfg.BindDefaultAgentIdentity = true
+	cfg.DefaultAgentIdentity = "   \t  "
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error when bind_default_agent_identity is true and identity is whitespace-only")
+	}
+}
+
+func TestValidate_DefaultAgentIdentityRejectsLeadingTrailingWhitespace(t *testing.T) {
+	cfg := Defaults()
+	cfg.DefaultAgentIdentity = "  deployment/my-agent  "
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error when default_agent_identity has leading or trailing whitespace")
+	}
+}
+
 func TestValidate_InvalidDLPRegex(t *testing.T) {
 	cfg := Defaults()
 	cfg.DLP.Patterns = []DLPPattern{

--- a/internal/edition/edition.go
+++ b/internal/edition/edition.go
@@ -155,13 +155,29 @@ func ValidateAgentName(name string) error {
 // Returns "anonymous" when no agent is specified.
 // Names are sanitized to prevent log injection.
 func ExtractAgent(r *http.Request) string {
+	return ExtractAgentWithDefault(r, "")
+}
+
+// ExtractAgentWithDefault reads the agent name from the request header or
+// query param, falling back to defaultIdentity before "anonymous".
+// Priority: header > query param > defaultIdentity > "anonymous".
+// Names are sanitized to prevent log injection.
+func ExtractAgentWithDefault(r *http.Request, defaultIdentity string) string {
 	agent := r.Header.Get(AgentHeader)
 	if agent == "" {
 		agent = r.URL.Query().Get("agent")
 	}
 	if agent == "" {
+		if defaultIdentity != "" {
+			return sanitizeAgentName(defaultIdentity)
+		}
 		return agentAnonymous
 	}
+	return sanitizeAgentName(agent)
+}
+
+// sanitizeAgentName strips disallowed characters and truncates.
+func sanitizeAgentName(agent string) string {
 	agent = agentNameRe.ReplaceAllString(agent, "_")
 	if len(agent) > maxAgentNameLen {
 		agent = agent[:maxAgentNameLen]
@@ -173,15 +189,25 @@ func ExtractAgent(r *http.Request) string {
 }
 
 // ResolveAgentIdentity determines agent identity from a request.
-// Priority: context override > header > query param > fallback.
+// Priority: context override > header > query param > defaultIdentity > fallback.
 // knownProfiles contains profile names that exist in the registry.
 // Unrecognized names get Profile=ProfileDefault (bounded cardinality).
-func ResolveAgentIdentity(r *http.Request, knownProfiles map[string]bool) AgentIdentity {
+func ResolveAgentIdentity(r *http.Request, knownProfiles map[string]bool, defaultIdentity string) AgentIdentity {
 	if profile, ok := AgentOverrideFromContext(r.Context()); ok {
 		return AgentIdentity{Name: profile, Profile: profile, Auth: envelope.ActorAuthBound}
 	}
 
+	// Check header/query first (agent-declared).
 	name := ExtractAgent(r)
+	if name == agentAnonymous && defaultIdentity != "" {
+		// Config-provided default: operator-configured, not agent-declared.
+		resolved := sanitizeAgentName(defaultIdentity)
+		if knownProfiles[resolved] {
+			return AgentIdentity{Name: resolved, Profile: resolved, Auth: envelope.ActorAuthConfigDefault}
+		}
+		return AgentIdentity{Name: resolved, Profile: ProfileDefault, Auth: envelope.ActorAuthConfigDefault}
+	}
+
 	if name == agentAnonymous {
 		return AgentIdentity{Name: "", Profile: ProfileDefault, Auth: envelope.ActorAuthSelfDeclared}
 	}

--- a/internal/edition/edition.go
+++ b/internal/edition/edition.go
@@ -155,22 +155,46 @@ func ValidateAgentName(name string) error {
 // Returns "anonymous" when no agent is specified.
 // Names are sanitized to prevent log injection.
 func ExtractAgent(r *http.Request) string {
-	return ExtractAgentWithDefault(r, "")
+	return ExtractAgentWithDefault(r, "", false)
 }
 
-// ExtractAgentWithDefault reads the agent name from the request header or
-// query param, falling back to defaultIdentity before "anonymous".
-// Priority: header > query param > defaultIdentity > "anonymous".
-// Names are sanitized to prevent log injection.
-func ExtractAgentWithDefault(r *http.Request, defaultIdentity string) string {
-	agent := r.Header.Get(AgentHeader)
-	if agent == "" {
-		agent = r.URL.Query().Get("agent")
+func boundDefaultIdentity(defaultIdentity string, bindDefaultIdentity bool) (string, bool) {
+	if !bindDefaultIdentity || defaultIdentity == "" {
+		return "", false
 	}
+	return sanitizeAgentName(defaultIdentity), true
+}
+
+func configDefaultIdentity(knownProfiles map[string]bool, defaultIdentity string) AgentIdentity {
+	resolved := sanitizeAgentName(defaultIdentity)
+	if knownProfiles[resolved] {
+		return AgentIdentity{Name: resolved, Profile: resolved, Auth: envelope.ActorAuthConfigDefault}
+	}
+	return AgentIdentity{Name: resolved, Profile: ProfileDefault, Auth: envelope.ActorAuthConfigDefault}
+}
+
+// ExtractAgentWithDefault reads the agent name from the request header,
+// default identity, or query param before "anonymous".
+// Priority:
+//   - when bindDefaultIdentity=true and defaultIdentity is set:
+//     defaultIdentity > "anonymous" (header/query ignored)
+//   - otherwise:
+//     header > defaultIdentity > query param > "anonymous"
+//
+// Names are sanitized to prevent log injection.
+func ExtractAgentWithDefault(r *http.Request, defaultIdentity string, bindDefaultIdentity bool) string {
+	if boundName, ok := boundDefaultIdentity(defaultIdentity, bindDefaultIdentity); ok {
+		return boundName
+	}
+	agent := r.Header.Get(AgentHeader)
+	if agent != "" {
+		return sanitizeAgentName(agent)
+	}
+	if defaultIdentity != "" {
+		return sanitizeAgentName(defaultIdentity)
+	}
+	agent = r.URL.Query().Get("agent")
 	if agent == "" {
-		if defaultIdentity != "" {
-			return sanitizeAgentName(defaultIdentity)
-		}
 		return agentAnonymous
 	}
 	return sanitizeAgentName(agent)
@@ -189,25 +213,35 @@ func sanitizeAgentName(agent string) string {
 }
 
 // ResolveAgentIdentity determines agent identity from a request.
-// Priority: context override > header > query param > defaultIdentity > fallback.
+// Priority:
+//   - context override
+//   - bound defaultIdentity when bindDefaultIdentity=true
+//   - header > defaultIdentity > query param > fallback otherwise
+//
 // knownProfiles contains profile names that exist in the registry.
 // Unrecognized names get Profile=ProfileDefault (bounded cardinality).
-func ResolveAgentIdentity(r *http.Request, knownProfiles map[string]bool, defaultIdentity string) AgentIdentity {
+func ResolveAgentIdentity(r *http.Request, knownProfiles map[string]bool, defaultIdentity string, bindDefaultIdentity bool) AgentIdentity {
 	if profile, ok := AgentOverrideFromContext(r.Context()); ok {
 		return AgentIdentity{Name: profile, Profile: profile, Auth: envelope.ActorAuthBound}
 	}
 
-	// Check header/query first (agent-declared).
-	name := ExtractAgent(r)
-	if name == agentAnonymous && defaultIdentity != "" {
-		// Config-provided default: operator-configured, not agent-declared.
-		resolved := sanitizeAgentName(defaultIdentity)
-		if knownProfiles[resolved] {
-			return AgentIdentity{Name: resolved, Profile: resolved, Auth: envelope.ActorAuthConfigDefault}
-		}
-		return AgentIdentity{Name: resolved, Profile: ProfileDefault, Auth: envelope.ActorAuthConfigDefault}
+	if _, ok := boundDefaultIdentity(defaultIdentity, bindDefaultIdentity); ok {
+		return configDefaultIdentity(knownProfiles, defaultIdentity)
 	}
 
+	headerName := sanitizeAgentName(r.Header.Get(AgentHeader))
+	if headerName != agentAnonymous {
+		if knownProfiles[headerName] {
+			return AgentIdentity{Name: headerName, Profile: headerName, Auth: envelope.ActorAuthMatched}
+		}
+		return AgentIdentity{Name: headerName, Profile: ProfileDefault, Auth: envelope.ActorAuthSelfDeclared}
+	}
+
+	if defaultIdentity != "" {
+		return configDefaultIdentity(knownProfiles, defaultIdentity)
+	}
+
+	name := sanitizeAgentName(r.URL.Query().Get("agent"))
 	if name == agentAnonymous {
 		return AgentIdentity{Name: "", Profile: ProfileDefault, Auth: envelope.ActorAuthSelfDeclared}
 	}

--- a/internal/edition/edition_test.go
+++ b/internal/edition/edition_test.go
@@ -52,6 +52,45 @@ func TestNoopEdition_ResolveAgent(t *testing.T) {
 	}
 }
 
+func TestNoopEdition_ResolveAgent_DefaultIdentity(t *testing.T) {
+	cfg := testConfig()
+	cfg.DefaultAgentIdentity = "deployment/my-sidecar"
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	ed, err := newNoopEdition(cfg, sc)
+	if err != nil {
+		t.Fatalf("newNoopEdition: %v", err)
+	}
+
+	// No header — should resolve to config default identity with config-default auth.
+	r := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	_, id := ed.ResolveAgent(context.Background(), r)
+
+	if id.Name != "deployment_my-sidecar" {
+		t.Errorf("id.Name = %q, want %q", id.Name, "deployment_my-sidecar")
+	}
+	if id.Profile != ProfileDefault {
+		t.Errorf("id.Profile = %q, want %q", id.Profile, ProfileDefault)
+	}
+	if id.Auth != envelope.ActorAuthConfigDefault {
+		t.Errorf("id.Auth = %q, want %q (config-provided default should not be self-declared)",
+			id.Auth, envelope.ActorAuthConfigDefault)
+	}
+
+	// Header should override config default with self-declared auth.
+	r2 := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	r2.Header.Set(AgentHeader, "explicit-agent")
+	_, id2 := ed.ResolveAgent(context.Background(), r2)
+
+	if id2.Name != "explicit-agent" {
+		t.Errorf("id2.Name = %q, want %q", id2.Name, "explicit-agent")
+	}
+	if id2.Auth != envelope.ActorAuthSelfDeclared {
+		t.Errorf("id2.Auth = %q, want %q", id2.Auth, envelope.ActorAuthSelfDeclared)
+	}
+}
+
 func TestNoopEdition_LookupProfile(t *testing.T) {
 	cfg := testConfig()
 	sc := scanner.New(cfg)
@@ -266,7 +305,7 @@ func TestResolveAgentIdentity(t *testing.T) {
 				profiles = nil
 			}
 
-			id := ResolveAgentIdentity(r, profiles)
+			id := ResolveAgentIdentity(r, profiles, "")
 			if id.Name != tt.wantName {
 				t.Errorf("Name = %q, want %q", id.Name, tt.wantName)
 			}
@@ -324,9 +363,99 @@ func TestResolveAgentIdentity_ActorAuth(t *testing.T) {
 			t.Parallel()
 			r := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
 			r = tt.setup(r)
-			id := ResolveAgentIdentity(r, knownProfiles)
+			id := ResolveAgentIdentity(r, knownProfiles, "")
 			if id.Auth != tt.wantAuth {
 				t.Errorf("Auth = %q, want %q", id.Auth, tt.wantAuth)
+			}
+		})
+	}
+}
+
+func TestExtractAgentWithDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		header          string
+		query           string
+		defaultIdentity string
+		want            string
+	}{
+		{"no agent no default", "", "", "", "anonymous"},
+		{"no agent with default", "", "", "deployment/my-app", "deployment_my-app"},
+		{"header overrides default", "from-header", "", "deployment/my-app", "from-header"},
+		{"query overrides default", "", "from-query", "deployment/my-app", "from-query"},
+		{"header overrides query and default", "from-header", "from-query", "deployment/my-app", "from-header"},
+		{"default sanitized", "", "", "bad agent!@#", "bad_agent___"},
+		{"empty default same as anonymous", "", "", "", "anonymous"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+			if tt.header != "" {
+				r.Header.Set(AgentHeader, tt.header)
+			}
+			if tt.query != "" {
+				q := r.URL.Query()
+				q.Set("agent", tt.query)
+				r.URL.RawQuery = q.Encode()
+			}
+			got := ExtractAgentWithDefault(r, tt.defaultIdentity)
+			if got != tt.want {
+				t.Errorf("ExtractAgentWithDefault = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveAgentIdentity_DefaultIdentity(t *testing.T) {
+	t.Parallel()
+
+	known := map[string]bool{"agent-a": true}
+
+	tests := []struct {
+		name            string
+		header          string
+		defaultIdentity string
+		wantName        string
+		wantProfile     string
+	}{
+		{
+			name:            "no header, no default falls to anonymous",
+			defaultIdentity: "",
+			wantName:        "",
+			wantProfile:     ProfileDefault,
+		},
+		{
+			name:            "no header, default identity used",
+			defaultIdentity: "deployment/my-app",
+			wantName:        "deployment_my-app",
+			wantProfile:     ProfileDefault,
+		},
+		{
+			name:            "header overrides default identity",
+			header:          "agent-a",
+			defaultIdentity: "deployment/my-app",
+			wantName:        "agent-a",
+			wantProfile:     "agent-a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+			if tt.header != "" {
+				r.Header.Set(AgentHeader, tt.header)
+			}
+			id := ResolveAgentIdentity(r, known, tt.defaultIdentity)
+			if id.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", id.Name, tt.wantName)
+			}
+			if id.Profile != tt.wantProfile {
+				t.Errorf("Profile = %q, want %q", id.Profile, tt.wantProfile)
 			}
 		})
 	}

--- a/internal/edition/edition_test.go
+++ b/internal/edition/edition_test.go
@@ -305,7 +305,7 @@ func TestResolveAgentIdentity(t *testing.T) {
 				profiles = nil
 			}
 
-			id := ResolveAgentIdentity(r, profiles, "")
+			id := ResolveAgentIdentity(r, profiles, "", false)
 			if id.Name != tt.wantName {
 				t.Errorf("Name = %q, want %q", id.Name, tt.wantName)
 			}
@@ -363,7 +363,7 @@ func TestResolveAgentIdentity_ActorAuth(t *testing.T) {
 			t.Parallel()
 			r := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
 			r = tt.setup(r)
-			id := ResolveAgentIdentity(r, knownProfiles, "")
+			id := ResolveAgentIdentity(r, knownProfiles, "", false)
 			if id.Auth != tt.wantAuth {
 				t.Errorf("Auth = %q, want %q", id.Auth, tt.wantAuth)
 			}
@@ -379,15 +379,17 @@ func TestExtractAgentWithDefault(t *testing.T) {
 		header          string
 		query           string
 		defaultIdentity string
+		bind            bool
 		want            string
 	}{
-		{"no agent no default", "", "", "", "anonymous"},
-		{"no agent with default", "", "", "deployment/my-app", "deployment_my-app"},
-		{"header overrides default", "from-header", "", "deployment/my-app", "from-header"},
-		{"query overrides default", "", "from-query", "deployment/my-app", "from-query"},
-		{"header overrides query and default", "from-header", "from-query", "deployment/my-app", "from-header"},
-		{"default sanitized", "", "", "bad agent!@#", "bad_agent___"},
-		{"empty default same as anonymous", "", "", "", "anonymous"},
+		{"no agent no default", "", "", "", false, "anonymous"},
+		{"no agent with default", "", "", "deployment/my-app", false, "deployment_my-app"},
+		{"header overrides default", "from-header", "", "deployment/my-app", false, "from-header"},
+		{"default overrides query", "", "from-query", "deployment/my-app", false, "deployment_my-app"},
+		{"header overrides query and default", "from-header", "from-query", "deployment/my-app", false, "from-header"},
+		{"default sanitized", "", "", "bad agent!@#", false, "bad_agent___"},
+		{"empty default same as anonymous", "", "", "", false, "anonymous"},
+		{"bind ignores header and query", "from-header", "from-query", "deployment/my-app", true, "deployment_my-app"},
 	}
 
 	for _, tt := range tests {
@@ -402,7 +404,7 @@ func TestExtractAgentWithDefault(t *testing.T) {
 				q.Set("agent", tt.query)
 				r.URL.RawQuery = q.Encode()
 			}
-			got := ExtractAgentWithDefault(r, tt.defaultIdentity)
+			got := ExtractAgentWithDefault(r, tt.defaultIdentity, tt.bind)
 			if got != tt.want {
 				t.Errorf("ExtractAgentWithDefault = %q, want %q", got, tt.want)
 			}
@@ -418,6 +420,7 @@ func TestResolveAgentIdentity_DefaultIdentity(t *testing.T) {
 	tests := []struct {
 		name            string
 		header          string
+		query           string
 		defaultIdentity string
 		wantName        string
 		wantProfile     string
@@ -441,6 +444,13 @@ func TestResolveAgentIdentity_DefaultIdentity(t *testing.T) {
 			wantName:        "agent-a",
 			wantProfile:     "agent-a",
 		},
+		{
+			name:            "default identity overrides query param",
+			query:           "agent-a",
+			defaultIdentity: "deployment/my-app",
+			wantName:        "deployment_my-app",
+			wantProfile:     ProfileDefault,
+		},
 	}
 
 	for _, tt := range tests {
@@ -450,7 +460,12 @@ func TestResolveAgentIdentity_DefaultIdentity(t *testing.T) {
 			if tt.header != "" {
 				r.Header.Set(AgentHeader, tt.header)
 			}
-			id := ResolveAgentIdentity(r, known, tt.defaultIdentity)
+			if tt.query != "" {
+				q := r.URL.Query()
+				q.Set("agent", tt.query)
+				r.URL.RawQuery = q.Encode()
+			}
+			id := ResolveAgentIdentity(r, known, tt.defaultIdentity, false)
 			if id.Name != tt.wantName {
 				t.Errorf("Name = %q, want %q", id.Name, tt.wantName)
 			}
@@ -458,6 +473,52 @@ func TestResolveAgentIdentity_DefaultIdentity(t *testing.T) {
 				t.Errorf("Profile = %q, want %q", id.Profile, tt.wantProfile)
 			}
 		})
+	}
+}
+
+func TestResolveAgentIdentity_BindDefaultIdentity(t *testing.T) {
+	t.Parallel()
+
+	known := map[string]bool{"agent-a": true}
+	r := httptest.NewRequest(http.MethodGet, "http://example.com?agent=agent-a", nil)
+	r.Header.Set(AgentHeader, "spoofed-header")
+
+	id := ResolveAgentIdentity(r, known, "deployment/my-app", true)
+	if id.Name != "deployment_my-app" {
+		t.Errorf("Name = %q, want %q", id.Name, "deployment_my-app")
+	}
+	if id.Profile != ProfileDefault {
+		t.Errorf("Profile = %q, want %q", id.Profile, ProfileDefault)
+	}
+	if id.Auth != envelope.ActorAuthConfigDefault {
+		t.Errorf("Auth = %q, want %q", id.Auth, envelope.ActorAuthConfigDefault)
+	}
+}
+
+func TestNoopEdition_ResolveAgent_BindDefaultIdentity(t *testing.T) {
+	cfg := testConfig()
+	cfg.DefaultAgentIdentity = "deployment/my-sidecar"
+	cfg.BindDefaultAgentIdentity = true
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	ed, err := newNoopEdition(cfg, sc)
+	if err != nil {
+		t.Fatalf("newNoopEdition: %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "http://example.com?agent=query-agent", nil)
+	r.Header.Set(AgentHeader, "header-agent")
+	_, id := ed.ResolveAgent(context.Background(), r)
+
+	if id.Name != "deployment_my-sidecar" {
+		t.Errorf("id.Name = %q, want %q", id.Name, "deployment_my-sidecar")
+	}
+	if id.Profile != ProfileDefault {
+		t.Errorf("id.Profile = %q, want %q", id.Profile, ProfileDefault)
+	}
+	if id.Auth != envelope.ActorAuthConfigDefault {
+		t.Errorf("id.Auth = %q, want %q", id.Auth, envelope.ActorAuthConfigDefault)
 	}
 }
 

--- a/internal/edition/noop.go
+++ b/internal/edition/noop.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
-	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
@@ -24,18 +23,7 @@ func newNoopEdition(cfg *config.Config, sc *scanner.Scanner) (Edition, error) {
 }
 
 func (e *noopEdition) ResolveAgent(_ context.Context, r *http.Request) (*ResolvedAgent, AgentIdentity) {
-	identity := AgentIdentity{Profile: ProfileDefault}
-
-	// Check header/query first (agent-declared).
-	name := ExtractAgent(r)
-	if name != agentAnonymous {
-		identity.Name = name
-		identity.Auth = envelope.ActorAuthSelfDeclared
-	} else if e.cfg.DefaultAgentIdentity != "" {
-		// Config-provided default: operator-configured, not agent-declared.
-		identity.Name = sanitizeAgentName(e.cfg.DefaultAgentIdentity)
-		identity.Auth = envelope.ActorAuthConfigDefault
-	}
+	identity := ResolveAgentIdentity(r, nil, e.cfg.DefaultAgentIdentity, e.cfg.BindDefaultAgentIdentity)
 
 	return &ResolvedAgent{
 		Name:    ProfileDefault,

--- a/internal/edition/noop.go
+++ b/internal/edition/noop.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
@@ -22,13 +23,26 @@ func newNoopEdition(cfg *config.Config, sc *scanner.Scanner) (Edition, error) {
 	return &noopEdition{cfg: cfg, sc: sc}, nil
 }
 
-func (e *noopEdition) ResolveAgent(_ context.Context, _ *http.Request) (*ResolvedAgent, AgentIdentity) {
+func (e *noopEdition) ResolveAgent(_ context.Context, r *http.Request) (*ResolvedAgent, AgentIdentity) {
+	identity := AgentIdentity{Profile: ProfileDefault}
+
+	// Check header/query first (agent-declared).
+	name := ExtractAgent(r)
+	if name != agentAnonymous {
+		identity.Name = name
+		identity.Auth = envelope.ActorAuthSelfDeclared
+	} else if e.cfg.DefaultAgentIdentity != "" {
+		// Config-provided default: operator-configured, not agent-declared.
+		identity.Name = sanitizeAgentName(e.cfg.DefaultAgentIdentity)
+		identity.Auth = envelope.ActorAuthConfigDefault
+	}
+
 	return &ResolvedAgent{
 		Name:    ProfileDefault,
 		Config:  e.cfg,
 		Scanner: e.sc,
 		Budget:  NoopBudget,
-	}, AgentIdentity{Name: "", Profile: ProfileDefault}
+	}, identity
 }
 
 func (e *noopEdition) LookupProfile(name string) (*ResolvedAgent, bool) {

--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -32,6 +32,10 @@ const (
 	// but was self-declared via header or query param.
 	ActorAuthMatched ActorAuth = "matched"
 
+	// ActorAuthConfigDefault means the actor identity was resolved from the
+	// config default_agent_identity field. Operator-configured, not agent-declared.
+	ActorAuthConfigDefault ActorAuth = "config-default"
+
 	// ActorAuthSelfDeclared means the actor name is unknown or from the
 	// fallback path. Attacker-controllable. Informational only.
 	ActorAuthSelfDeclared ActorAuth = "self-declared"
@@ -235,7 +239,7 @@ func Parse(s string) (Envelope, error) {
 
 	// Validate ActorAuth against allowed values.
 	switch env.ActorAuth {
-	case ActorAuthBound, ActorAuthMatched, ActorAuthSelfDeclared, "":
+	case ActorAuthBound, ActorAuthMatched, ActorAuthConfigDefault, ActorAuthSelfDeclared, "":
 		// valid
 	default:
 		return Envelope{}, fmt.Errorf("unknown actor_auth value %q", env.ActorAuth)

--- a/internal/envelope/envelope_test.go
+++ b/internal/envelope/envelope_test.go
@@ -150,7 +150,7 @@ func TestEnvelope_ToMCPMeta_OmitsOptionalEmptyFields(t *testing.T) {
 func TestActorAuth_Constants(t *testing.T) {
 	t.Parallel()
 
-	levels := []ActorAuth{ActorAuthBound, ActorAuthMatched, ActorAuthSelfDeclared}
+	levels := []ActorAuth{ActorAuthBound, ActorAuthMatched, ActorAuthConfigDefault, ActorAuthSelfDeclared}
 	seen := make(map[ActorAuth]bool)
 	for _, l := range levels {
 		if seen[l] {
@@ -203,7 +203,7 @@ func TestParse_RejectsUnknownActorAuth(t *testing.T) {
 func TestParse_AcceptsValidActorAuth(t *testing.T) {
 	t.Parallel()
 
-	for _, aa := range []string{"bound", "matched", "self-declared", ""} {
+	for _, aa := range []string{"bound", "matched", "config-default", "self-declared", ""} {
 		input := `v=1, act="read", vd="allow", rid="id-1", ts=1712345678`
 		if aa != "" {
 			input += `, aa="` + aa + `"`

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -109,6 +109,9 @@ type Metrics struct {
 	shieldSkipped       *prometheus.CounterVec   // reason label
 	shieldLatency       *prometheus.HistogramVec // transport label
 
+	// Response scan exemption: tracks every response-scan skip for operator visibility.
+	responseScanExemptTotal *prometheus.CounterVec // reason, transport labels
+
 	wsConnectionCount int64
 
 	mu                sync.Mutex
@@ -456,6 +459,12 @@ func New() *Metrics {
 		Buckets:   []float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1},
 	}, []string{"transport"})
 
+	responseScanExemptTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "pipelock",
+		Name:      "response_scan_exempt_total",
+		Help:      "Total response scan exemption skips by reason and transport.",
+	}, []string{"reason", "transport"})
+
 	reg.MustRegister(requestsTotal, scannerHits, requestLatency,
 		tunnelsTotal, tunnelDuration, tunnelBytes, activeTunnels,
 		wsConnectionsTotal, wsDuration, wsBytes, activeWS, wsFrames, wsScanHits, wsRedirectHints,
@@ -474,7 +483,8 @@ func New() *Metrics {
 		airlockSessions, airlockTransitions, airlockDenials,
 		airlockDrainCompleted, airlockDrainTimeout,
 		shieldRewrites, shieldBytesStripped, shieldShimsInjected,
-		shieldSkipped, shieldLatency)
+		shieldSkipped, shieldLatency,
+		responseScanExemptTotal)
 
 	return &Metrics{
 		registry:                    reg,
@@ -532,6 +542,7 @@ func New() *Metrics {
 		shieldShimsInjected:         shieldShimsInjected,
 		shieldSkipped:               shieldSkipped,
 		shieldLatency:               shieldLatency,
+		responseScanExemptTotal:     responseScanExemptTotal,
 		startTime:                   time.Now(),
 		topBlockedDomains:           make(map[string]int64),
 		topScannerHits:              make(map[string]int64),
@@ -1131,4 +1142,14 @@ func (m *Metrics) RecordShieldLatency(transport string, d time.Duration) {
 		return
 	}
 	m.shieldLatency.WithLabelValues(transport).Observe(d.Seconds())
+}
+
+// RecordResponseScanExempt increments the response scan exemption counter.
+// reason: "exempt_domain" (config exempt_domains match) or "suppress" (config suppress match).
+// transport: "fetch", "forward", "connect", "websocket", "reverse".
+func (m *Metrics) RecordResponseScanExempt(reason, transport string) {
+	if m == nil {
+		return
+	}
+	m.responseScanExemptTotal.WithLabelValues(reason, transport).Inc()
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1715,3 +1715,38 @@ func TestRecordSessionAutoDeescalation_NilSafe(t *testing.T) {
 	var m *Metrics
 	m.RecordSessionAutoDeescalation("critical", "high") // must not panic
 }
+
+func TestRecordResponseScanExempt(t *testing.T) {
+	m := New()
+	m.RecordResponseScanExempt("exempt_domain", "fetch")
+	m.RecordResponseScanExempt("exempt_domain", "forward")
+	m.RecordResponseScanExempt("suppress", "connect")
+
+	body := scrapeMetrics(t, m)
+	if !strings.Contains(body, `pipelock_response_scan_exempt_total{reason="exempt_domain",transport="fetch"} 1`) {
+		t.Error("expected exempt_domain/fetch counter = 1")
+	}
+	if !strings.Contains(body, `pipelock_response_scan_exempt_total{reason="exempt_domain",transport="forward"} 1`) {
+		t.Error("expected exempt_domain/forward counter = 1")
+	}
+	if !strings.Contains(body, `pipelock_response_scan_exempt_total{reason="suppress",transport="connect"} 1`) {
+		t.Error("expected suppress/connect counter = 1")
+	}
+}
+
+func TestRecordResponseScanExempt_NilSafe(t *testing.T) {
+	var m *Metrics
+	m.RecordResponseScanExempt("exempt_domain", "fetch") // must not panic
+}
+
+func scrapeMetrics(t *testing.T, m *Metrics) string {
+	t.Helper()
+	handler := m.PrometheusHandler()
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body, err := io.ReadAll(rec.Body)
+	if err != nil {
+		t.Fatalf("reading metrics: %v", err)
+	}
+	return string(body)
+}

--- a/internal/proxy/airlock.go
+++ b/internal/proxy/airlock.go
@@ -21,6 +21,13 @@ const (
 	TransportWS      = "websocket"
 	TransportMCP     = "mcp"
 	TransportScanAPI = "scan_api"
+	TransportReverse = "reverse"
+)
+
+// Exemption reason constants for the response_scan_exempt_total metric.
+const (
+	ExemptReasonDomain   = "exempt_domain"
+	ExemptReasonSuppress = "suppress"
 )
 
 // AirlockTierOrder maps tier names to numeric order for comparison.

--- a/internal/proxy/envelope_test.go
+++ b/internal/proxy/envelope_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/edition"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
@@ -685,6 +686,83 @@ func TestEnvelope_ReverseProxyInjectsHeader(t *testing.T) {
 	}
 	if env.ActorAuth != envelope.ActorAuthSelfDeclared {
 		t.Errorf("ActorAuth = %q, want %q", env.ActorAuth, envelope.ActorAuthSelfDeclared)
+	}
+}
+
+func TestEnvelope_ReverseProxyBindDefaultAgentIdentity(t *testing.T) {
+	t.Parallel()
+
+	var gotHeader headerCapture
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader.Set(r.Header.Get(envelope.HeaderName))
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+
+	cfg := reverseTestConfig()
+	cfg.DefaultAgentIdentity = "deployment/my-sidecar"
+	cfg.BindDefaultAgentIdentity = true
+
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	var cfgPtr atomic.Pointer[config.Config]
+	var scPtr atomic.Pointer[scanner.Scanner]
+	cfgPtr.Store(cfg)
+	scPtr.Store(sc)
+
+	logger, _ := audit.New("json", "stdout", "", false, false)
+	t.Cleanup(logger.Close)
+
+	m := metrics.New()
+	ks := killswitch.New(cfg)
+
+	handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, logger, m, ks, nil, nil)
+
+	em := envelope.NewEmitter(envelope.EmitterConfig{ConfigHash: testEnvelopeConfigHash})
+	var emPtr atomic.Pointer[envelope.Emitter]
+	emPtr.Store(em)
+	handler.SetEnvelopeEmitter(&emPtr)
+
+	proxy := httptest.NewServer(handler)
+	t.Cleanup(proxy.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, proxy.URL+"/test?agent=query-agent", nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set(edition.AgentHeader, "header-agent")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d; body: %s", resp.StatusCode, body)
+	}
+
+	header := gotHeader.Get()
+	if header == "" {
+		t.Fatal("upstream did not receive Pipelock-Mediation header via reverse proxy")
+	}
+
+	env, parseErr := envelope.Parse(header)
+	if parseErr != nil {
+		t.Fatalf("parse envelope: %v", parseErr)
+	}
+	if env.Actor != "deployment_my-sidecar" {
+		t.Errorf("Actor = %q, want %q", env.Actor, "deployment_my-sidecar")
+	}
+	if env.ActorAuth != envelope.ActorAuthConfigDefault {
+		t.Errorf("ActorAuth = %q, want %q", env.ActorAuth, envelope.ActorAuthConfigDefault)
 	}
 }
 

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1205,6 +1205,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	fwdRespExempt := isResponseScanExempt(fwdRespHost, cfg.ResponseScanning.ExemptDomains)
 	if sc.ResponseScanningEnabled() && fwdRespExempt {
 		p.logger.LogResponseScanExempt(actx, fwdRespHost)
+		p.metrics.RecordResponseScanExempt(ExemptReasonDomain, TransportForward)
 	}
 	// Buffer the response when ANY of response scanning, browser shield, or
 	// media policy is enabled. Media policy cannot be gated behind the
@@ -1343,6 +1344,8 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 				for _, m := range scanResult.Matches {
 					if !config.IsSuppressed(m.PatternName, targetURL, cfg.Suppress) {
 						kept = append(kept, m)
+					} else {
+						p.metrics.RecordResponseScanExempt(ExemptReasonSuppress, TransportForward)
 					}
 				}
 				scanResult.Matches = kept

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -1189,6 +1189,7 @@ func newInterceptHandler(
 		interceptRespExempt := isResponseScanExempt(r.URL.Hostname(), ic.Config.ResponseScanning.ExemptDomains)
 		if ic.Scanner.ResponseScanningEnabled() && interceptRespExempt {
 			ic.Logger.LogResponseScanExempt(actx, r.URL.Hostname())
+			ic.Metrics.RecordResponseScanExempt(ExemptReasonDomain, TransportConnect)
 		}
 		if ic.Scanner.ResponseScanningEnabled() {
 			scanResult := ic.Scanner.ScanResponse(r.Context(), string(respBody))
@@ -1223,6 +1224,8 @@ func newInterceptHandler(
 				for _, m := range scanResult.Matches {
 					if !config.IsSuppressed(m.PatternName, r.URL.String(), ic.Config.Suppress) {
 						kept = append(kept, m)
+					} else {
+						ic.Metrics.RecordResponseScanExempt(ExemptReasonSuppress, TransportConnect)
 					}
 				}
 				scanResult.Matches = kept

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2064,6 +2064,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	responseScanExempt := isResponseScanExempt(finalHost, cfg.ResponseScanning.ExemptDomains)
 	if sc.ResponseScanningEnabled() && responseScanExempt {
 		log.LogResponseScanExempt(actx, finalHost)
+		p.metrics.RecordResponseScanExempt(ExemptReasonDomain, TransportFetch)
 	}
 	var hiddenInjectionFound bool
 	if sc.ResponseScanningEnabled() && isHTML {
@@ -2134,6 +2135,8 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			for _, m := range scanResult.Matches {
 				if !config.IsSuppressed(m.PatternName, displayURL, cfg.Suppress) {
 					kept = append(kept, m)
+				} else {
+					p.metrics.RecordResponseScanExempt(ExemptReasonSuppress, TransportFetch)
 				}
 			}
 			scanResult.Matches = kept
@@ -2245,12 +2248,18 @@ func (p *Proxy) filterAndActOnResponseScan(
 ) (blocked bool, out string, found bool) {
 	out = content
 
-	// Filter out suppressed findings.
+	// Suppress filter: serves both the main response scan path (where the caller's
+	// inline loop already stripped suppressed matches before the capture observer) and
+	// the hidden content scan path (where this is the only suppress point). For the
+	// main path, no suppressed matches remain so this loop is a no-op. For the hidden
+	// content path, this loop filters and emits the metric correctly.
 	if !result.Clean && len(cfg.Suppress) > 0 {
 		var kept []scanner.ResponseMatch
 		for _, m := range result.Matches {
 			if !config.IsSuppressed(m.PatternName, displayURL, cfg.Suppress) {
 				kept = append(kept, m)
+			} else {
+				p.metrics.RecordResponseScanExempt(ExemptReasonSuppress, TransportFetch)
 			}
 		}
 		result.Matches = kept

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1371,6 +1371,49 @@ func TestFetchEndpoint_AgentDefaultAnonymous(t *testing.T) {
 	}
 }
 
+func TestFetchEndpoint_BindDefaultAgentIdentityIgnoresHeaderAndQuery(t *testing.T) {
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = fmt.Fprint(w, "Hello world")
+	}))
+	defer backend.Close()
+
+	cfg := config.Defaults()
+	cfg.FetchProxy.TimeoutSeconds = 5
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.APIAllowlist = nil
+	cfg.DefaultAgentIdentity = "deployment/my-sidecar"
+	cfg.BindDefaultAgentIdentity = true
+
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/fetch?url="+backend.URL+"/text&agent=query-agent", nil)
+	req.Header.Set(AgentHeader, "header-agent")
+	w := httptest.NewRecorder()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fetch", p.handleFetch)
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp FetchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("expected valid JSON: %v", err)
+	}
+	if resp.Agent != "deployment_my-sidecar" {
+		t.Errorf("expected agent=deployment_my-sidecar, got %q", resp.Agent)
+	}
+}
+
 // --- Redirect Scanning Tests ---
 
 func TestFetchEndpoint_RedirectToBlockedDomain(t *testing.T) {

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -234,13 +234,18 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	// Inject mediation envelope before forwarding on allow path.
 	if rp.envelopeEmitterPtr != nil {
 		if envEmitter := rp.envelopeEmitterPtr.Load(); envEmitter != nil {
+			actorIdentity := edition.ResolveAgentIdentity(r, nil, cfg.DefaultAgentIdentity, cfg.BindDefaultAgentIdentity)
+			actor := actorIdentity.Name
+			if actor == "" {
+				actor = "anonymous"
+			}
 			if envErr := envEmitter.InjectHTTPEnvelope(r.Header, envelope.BuildOpts{
 				ActionID:   receipt.NewActionID(),
 				Action:     string(receipt.ClassifyHTTP(r.Method)),
 				Verdict:    forwardedVerdict,
 				SideEffect: string(receipt.SideEffectFromMethod(r.Method)),
-				Actor:      edition.ExtractAgentWithDefault(r, cfg.DefaultAgentIdentity),
-				ActorAuth:  envelope.ActorAuthSelfDeclared, // Reverse proxy has no per-agent listener binding
+				Actor:      actor,
+				ActorAuth:  actorIdentity.Auth,
 			}); envErr != nil {
 				rp.logger.LogAnomaly(newHTTPAuditContext(rp.logger, r.Method, r.URL.String(), clientIP, requestID, ""), "", fmt.Sprintf("mediation envelope injection failed: %v", envErr), 0.1)
 			}

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -239,7 +239,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 				Action:     string(receipt.ClassifyHTTP(r.Method)),
 				Verdict:    forwardedVerdict,
 				SideEffect: string(receipt.SideEffectFromMethod(r.Method)),
-				Actor:      edition.ExtractAgent(r),
+				Actor:      edition.ExtractAgentWithDefault(r, cfg.DefaultAgentIdentity),
 				ActorAuth:  envelope.ActorAuthSelfDeclared, // Reverse proxy has no per-agent listener binding
 			}); envErr != nil {
 				rp.logger.LogAnomaly(newHTTPAuditContext(rp.logger, r.Method, r.URL.String(), clientIP, requestID, ""), "", fmt.Sprintf("mediation envelope injection failed: %v", envErr), 0.1)
@@ -500,6 +500,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 	if revRespExempt {
 		actx := newHTTPAuditContext(rp.logger, resp.Request.Method, resp.Request.URL.String(), clientIP, requestID, "")
 		rp.logger.LogResponseScanExempt(actx, revHost)
+		rp.metrics.RecordResponseScanExempt(ExemptReasonDomain, TransportReverse)
 	}
 
 	// Fail-closed on compressed responses: regex can't match gzipped content.
@@ -596,6 +597,8 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		for _, m := range result.Matches {
 			if !config.IsSuppressed(m.PatternName, resp.Request.URL.String(), cfg.Suppress) {
 				kept = append(kept, m)
+			} else {
+				rp.metrics.RecordResponseScanExempt(ExemptReasonSuppress, TransportReverse)
 			}
 		}
 		result.Matches = kept

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -493,6 +493,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	if scanTextFrames && sc.ResponseScanningEnabled() && isResponseScanExempt(relay.hostname, cfg.ResponseScanning.ExemptDomains) {
 		log.LogResponseScanExempt(actx, relay.hostname)
+		p.metrics.RecordResponseScanExempt(ExemptReasonDomain, TransportWS)
 	}
 
 	stats := relay.run(r.Context())

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -493,7 +493,6 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	if scanTextFrames && sc.ResponseScanningEnabled() && isResponseScanExempt(relay.hostname, cfg.ResponseScanning.ExemptDomains) {
 		log.LogResponseScanExempt(actx, relay.hostname)
-		p.metrics.RecordResponseScanExempt(ExemptReasonDomain, TransportWS)
 	}
 
 	stats := relay.run(r.Context())
@@ -1341,6 +1340,9 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 			if r.scanText && r.scanner.ResponseScanningEnabled() {
 				scanResult := r.scanner.ScanResponse(ctx, string(msg))
 				if !scanResult.Clean {
+					if wsRespExempt {
+						r.proxy.metrics.RecordResponseScanExempt(ExemptReasonDomain, TransportWS)
+					}
 					patternNames := make([]string, len(scanResult.Matches))
 					for i, m := range scanResult.Matches {
 						patternNames[i] = m.PatternName


### PR DESCRIPTION
## Summary

- **Sidecar injection init:** `pipelock init sidecar --inject-spec <manifest>` generates a sidecar patch for Deployment, StatefulSet, Job, and CronJob workloads with three output formats (strategic-merge patch, Kustomize overlay, Helm values fragment), diff preview, canary verification, and idempotent re-runs.
- **Default agent identity:** new `default_agent_identity` config field and `ActorAuthConfigDefault` envelope auth level provide operator-configured fallback attribution for sidecar deployments where the upstream container does not send an `X-Pipelock-Agent` header.
- **Exemption audit emission:** response scan exemptions (exempt domains and suppressed findings) now increment a `pipelock_response_scan_exempt_total` Prometheus counter with `reason` and `transport` labels across all five proxy transports.
- **Helm digest support:** `image.digest` field added to the Helm chart values, rendering as `repository@digest` in the deployment template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `pipelock init sidecar` CLI command to generate and inject sidecar proxy configurations for Kubernetes workloads (Deployment, StatefulSet, Job, CronJob) with patch, kustomize, and helm-values output formats.
  * Added `default_agent_identity` configuration field to specify a fallback agent name for sidecar deployments.
  * Added `pipelock_response_scan_exempt_total` Prometheus counter to track exempted response scans by reason and transport.

* **Documentation**
  * Added CLI reference documentation for sidecar initialization command.
  * Updated configuration documentation for agent identity resolution.

* **Chores**
  * Updated Helm chart to support container image selection by digest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->