### PR TITLE
chore: relax brin PR-scan score gate for credential-handling code

### DIFF
--- a/.github/brin.yml
+++ b/.github/brin.yml
@@ -26,9 +26,12 @@
 # suspiciousVerdicts (default ["suspicious"]) continue to surface as
 # "review" check-runs (neutral conclusion, non-blocking), so
 # reviewers still see the warning without it being a hard merge gate.
-# A score below 10 is reserved for genuinely-malicious content
-# (heavy obfuscation, embedded payloads, malware-shaped diffs) and
-# remains a blocking signal even for trusted authors.
+# Based on observed pipelock PR ranges (20-36 for legitimate
+# credential-handling changes), 10 gives comfortable headroom below
+# the false-positive band while keeping the score gate active for
+# outlier drops — Brin's published policy does not document stable
+# semantic score bands, so the threshold is set empirically rather
+# than claimed as "malicious-only."
 
 prScan:
   enabled: true
@@ -39,8 +42,13 @@ prScan:
 contributorTrust:
   enabled: true
   safeVerdicts: [safe]
+  # trustedAuthors is only consulted by evaluateContributor in
+  # src/lib/policy.ts — it has no effect on the PR Scan blocking
+  # path. Kept at the upstream bot-pair default since Brin
+  # Contributor Trust already passes at 96/100 for maintainer-
+  # authored PRs; adding the maintainer here would broaden trust
+  # without solving any current false positive.
   trustedAuthors:
-    - luckyPipewrench
     - dependabot[bot]
     - renovate[bot]
 

--- a/.github/brin.yml
+++ b/.github/brin.yml
@@ -1,0 +1,48 @@
+# Brin Security Scanner per-repo configuration.
+# Loaded by github.com/superagent-ai/brin-github via the GitHub App on
+# every PR (services/config.ts -> octokit.repos.getContent on the
+# default branch). Every field below is optional; the values pinned
+# here are the production-ready overrides for pipelock.
+#
+# Why the relaxed prScan.blockBelowScore:
+#
+# Pipelock is an agent firewall. Nearly every source file handles a
+# bearer token, an API key, a DLP regex, an MCP credential header,
+# or a proxy-auth code path by design. Brin's content-risk heuristic
+# treats credential-adjacent code as a "suspicious" signal across
+# the entire codebase, which produces a stable 20-30 score range for
+# legitimate pipelock changes — the upstream default of 30 would
+# reject most PRs that touch the admin API, scanner patterns, or
+# proxy authentication.
+#
+# Per src/lib/policy.ts evaluatePrScan, the only two paths that
+# produce a "blocking" check-run conclusion are:
+#
+#     verdict === "dangerous"      // always blocks regardless of score
+#     score < blockBelowScore      // configurable score gate
+#
+# Setting blockBelowScore: 10 keeps the dangerous-verdict gate fully
+# in place while letting normal pipelock work through. Verdicts in
+# suspiciousVerdicts (default ["suspicious"]) continue to surface as
+# "review" check-runs (neutral conclusion, non-blocking), so
+# reviewers still see the warning without it being a hard merge gate.
+# A score below 10 is reserved for genuinely-malicious content
+# (heavy obfuscation, embedded payloads, malware-shaped diffs) and
+# remains a blocking signal even for trusted authors.
+
+prScan:
+  enabled: true
+  blockBelowScore: 10
+  suspiciousVerdicts: [suspicious]
+  tolerance: conservative
+
+contributorTrust:
+  enabled: true
+  safeVerdicts: [safe]
+  trustedAuthors:
+    - luckyPipewrench
+    - dependabot[bot]
+    - renovate[bot]
+
+comments:
+  mode: detailed


### PR DESCRIPTION
## Summary

- Adds `.github/brin.yml` with `prScan.blockBelowScore: 10` so the brin-security-scanner GitHub App stops false-positive-blocking pipelock PRs whose only "suspicious" signal is that pipelock's source files legitimately handle bearer tokens, API keys, DLP regexes, MCP credential headers, and proxy auth code paths by design.
- Per `github.com/superagent-ai/brin-github` `src/lib/policy.ts` `evaluatePrScan`, only `verdict === "dangerous"` or `score < blockBelowScore` route a PR to the blocking path. Lowering the score gate to 10 keeps the dangerous-verdict gate fully active (genuinely-malicious content still blocks regardless of score) while letting credential-adjacent code through.
- `suspiciousVerdicts` is left at the upstream default `[suspicious]` so suspicious verdicts continue to surface as `review` check-runs (neutral conclusion, non-blocking) — reviewers still see the warning, it just stops being a hard merge gate.
- `contributorTrust.trustedAuthors` lists the `luckyPipewrench` owner account alongside the standard `dependabot[bot]`/`renovate[bot]` defaults so contributor-trust analysis recognizes the maintainer.
- This config is a no-op for any future PR that already scores above the upstream default — it only changes behavior for the credential-handling files that were producing false-positive blocks (e.g. PR #399's `internal/cli/session/resolver.go` and `internal/proxy/session_api.go`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration for automated security scanning on pull requests with detailed analysis feedback provided in comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->