### PR TITLE
chore: prepare v2.2.0 release and version bumps + preset sync

### DIFF
--- a/charts/pipelock/Chart.yaml
+++ b/charts/pipelock/Chart.yaml
@@ -3,7 +3,7 @@ name: pipelock
 description: Agent firewall for AI agents. Network scanning, process containment, and tool policy enforcement.
 type: application
 version: 0.1.0
-appVersion: "2.1.2"
+appVersion: "2.2.0"
 home: https://pipelab.org
 sources:
   - https://github.com/luckyPipewrench/pipelock

--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -489,3 +489,9 @@ airlock:
     hard_minutes: 15
     drain_minutes: 0
     drain_timeout_seconds: 30
+
+# Exposure-based policy escalation (v2.2.0)
+# Permissive policy: observe and log taint events without enforcement.
+taint:
+  enabled: true
+  policy: permissive

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -549,3 +549,15 @@ airlock:
     hard_minutes: 15
     drain_minutes: 0
     drain_timeout_seconds: 30
+
+# Exposure-based policy escalation (v2.2.0)
+# Strict policy: tainted sessions are blocked on protected paths immediately.
+taint:
+  enabled: true
+  policy: strict
+
+# Media policy: strip everything. Hostile model may embed instructions in media.
+media_policy:
+  strip_images: true
+  strip_audio: true
+  strip_video: true

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -557,3 +557,8 @@ airlock:
     hard_minutes: 15
     drain_minutes: 0
     drain_timeout_seconds: 30
+
+# Exposure-based policy escalation (v2.2.0)
+taint:
+  enabled: true
+  policy: strict

--- a/docs/guides/autogen.md
+++ b/docs/guides/autogen.md
@@ -251,7 +251,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:2.1.2)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:2.2.0)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal

--- a/docs/guides/google-adk.md
+++ b/docs/guides/google-adk.md
@@ -272,7 +272,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:2.1.2)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:2.2.0)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal

--- a/docs/guides/openai-agents.md
+++ b/docs/guides/openai-agents.md
@@ -257,7 +257,7 @@ networks:
 
 services:
   pipelock:
-    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:2.1.2)
+    # Pin to a specific version for production (e.g., ghcr.io/luckypipewrench/pipelock:2.2.0)
     image: ghcr.io/luckypipewrench/pipelock:latest
     networks:
       - pipelock-internal

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -100,7 +100,7 @@ inspect WebSocket frames for DLP and prompt injection.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `pipelock_info` | gauge | `version` | Build information. Always 1. The `version` label identifies the running release (e.g. `2.1.2`). |
+| `pipelock_info` | gauge | `version` | Build information. Always 1. The `version` label identifies the running release (e.g. `2.2.0`). |
 | `pipelock_kill_switch_active` | gauge | `source` | Whether each kill switch source is active (1) or inactive (0). `source` is `config`, `api`, `signal`, or `sentinel`. Reported fresh on every scrape. |
 
 ## Security Event Metrics


### PR DESCRIPTION
Bumps the Helm chart appVersion, the "pin to a specific version for production" examples in the three deployment guides, and the `pipelock_info` version-label example in the metrics doc to `2.2.0`. Adds a preset-appropriate `taint.*` block to the three bundled configs.

- `charts/pipelock/Chart.yaml`: `appVersion` → `2.2.0`.
- `configs/audit.yaml`: `taint.policy: permissive` (observe and log).
- `configs/strict.yaml`: `taint.policy: strict` (block tainted sessions on protected paths).
- `configs/hostile-model.yaml`: `taint.policy: strict` plus `media_policy.strip_*: true` for every media type.
- Deployment guides + `docs/metrics.md`: version pin examples → `2.2.0`.