### PR TITLE
fix: tolerate subprocess-exit flake in MCP test; dereference v2 tag in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -194,5 +194,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -fa v2 "${TAG_NAME}" -m "Update v2 to ${TAG_NAME}"
+          # The ^{} suffix dereferences TAG_NAME (annotated tag) to its commit.
+          # Without it, git tag -fa v2 "${TAG_NAME}" creates a nested tag
+          # (v2 -> v2.2.0 -> commit) which clutters ls-remote and some tooling rejects it.
+          git tag -fa v2 "${TAG_NAME}^{}" -m "Update v2 to ${TAG_NAME}"
           git push origin v2 --force

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -248,7 +248,15 @@ func TestMcpProxyCmd_EmitsSignedReceipts_StdioSubprocess(t *testing.T) {
 	configPath := writeMCPProxyConfig(t, evidenceDir, keyPath, true)
 
 	stdout, stderr, err := runMCPProxyCommand(t, configPath)
-	if err != nil {
+	// ErrSubprocessExit is an expected outcome when the wrapped Go-test
+	// helper exits non-zero. Under CI load the helper's testing.M
+	// cleanup (which prints "PASS\nok <pkg>" to stdout after the
+	// JSON-RPC scanner loop exits) can race with pipelock's pgid
+	// teardown and surface as "signal: killed". The test assertion is
+	// about receipts being emitted before the child exited, not about
+	// the child's own exit status, so only fail for non-subprocess
+	// errors.
+	if err != nil && !errors.Is(err, mcp.ErrSubprocessExit) {
 		t.Fatalf("run mcp proxy command: %v\nstderr:\n%s", err, stderr)
 	}
 


### PR DESCRIPTION
## Summary

Two small post-v2.2.0 fixes, both surfaced by the release itself.

### TestMcpProxyCmd_EmitsSignedReceipts_StdioSubprocess flake

Under CI load the wrapped Go-test helper's `testing.M` cleanup (which writes `PASS\nok <pkg>` to stdout after the JSON-RPC scanner loop exits) races with pipelock's pgid teardown. The helper can get SIGKILL'd by `exec.CommandContext` during that window, so `cmd.Wait` returns `ErrSubprocessExit` wrapping `signal: killed`. The test previously treated that as a hard fail even though the assertion surface is about receipts being emitted before the child exits, not about the child's exit status.

Fix: `errors.Is(err, mcp.ErrSubprocessExit)` short-circuits the fail; non-subprocess errors still fail. Passes 5/5 locally with `-race -count=1`.

### release.yaml nested v2 tag

`git tag -fa v2 "${TAG_NAME}"` creates a nested tag when `TAG_NAME` is itself an annotated tag (e.g. `v2.2.0`): `v2 → v2.2.0 → commit`. Git resolves nested chains for consumers but they clutter `git ls-remote` output and some tooling rejects them. The v2.2.0 release exhibited this; fixed manually for the live tag.

Fix: dereference with `${TAG_NAME}^{}` so v2 points at the commit directly. Applies to all future releases.

## Test plan

- `go test -race -count=1 -run TestMcpProxyCmd_EmitsSignedReceipts_StdioSubprocess ./internal/cli/runtime/` — passes 5/5 local
- release workflow change is exercised on the next tag push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved subprocess exit error handling validation in test suite

* **Chores**
  * Optimized GitHub Actions release workflow tag management configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->