### PR TITLE
ci: harden composite action download retry budget

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
         VERSION="$PIPELOCK_VERSION"
         if [ "$VERSION" = "latest" ]; then
           # Use GitHub API directly (no gh CLI dependency)
-          VERSION=$(curl -fsSL --connect-timeout 10 --max-time 30 --retry 8 --retry-delay 3 --retry-max-time 120 --retry-all-errors \
+          VERSION=$(curl -fsSL --connect-timeout 10 --max-time 30 --retry 8 --retry-max-time 120 --retry-all-errors \
             -H "Authorization: token $GH_TOKEN" \
             "https://api.github.com/repos/luckyPipewrench/pipelock/releases/latest" \
             | jq -r '.tag_name' | sed 's/^v//')
@@ -106,8 +106,11 @@ runs:
         echo "Downloading pipelock v${VERSION} (${GOOS}/${GOARCH})..."
         # Retry budget ~2 min absorbs transient 504s from the release-assets
         # CDN (Azure Blob behind Fastly) without stalling on real outages.
-        curl -fsSL --connect-timeout 10 --max-time 60 --retry 8 --retry-delay 3 --retry-max-time 120 --retry-all-errors "${BASE_URL}/${ASSET}" -o "${INSTALL_DIR}/pipelock.tar.gz"
-        curl -fsSL --connect-timeout 10 --max-time 30 --retry 8 --retry-delay 3 --retry-max-time 120 --retry-all-errors "${BASE_URL}/checksums.txt" -o "${INSTALL_DIR}/checksums.txt"
+        # Omitting --retry-delay lets curl use exponential backoff inside the
+        # --retry-max-time window, spacing later retries to give the CDN time
+        # to heal rather than hammering a degraded edge.
+        curl -fsSL --connect-timeout 10 --max-time 60 --retry 8 --retry-max-time 120 --retry-all-errors "${BASE_URL}/${ASSET}" -o "${INSTALL_DIR}/pipelock.tar.gz"
+        curl -fsSL --connect-timeout 10 --max-time 30 --retry 8 --retry-max-time 120 --retry-all-errors "${BASE_URL}/checksums.txt" -o "${INSTALL_DIR}/checksums.txt"
 
         # Verify checksum (portable: sha256sum on Linux, shasum on macOS)
         EXPECTED=$(awk -v asset="$ASSET" '$2 == asset || $NF == asset {print $1; exit}' "${INSTALL_DIR}/checksums.txt")
@@ -134,10 +137,11 @@ runs:
         COSIGN_SIG="${INSTALL_DIR}/checksums.txt.sig"
         COSIGN_PEM="${INSTALL_DIR}/checksums.txt.pem"
         # Optional fallback: older releases may 404. No --retry-all-errors so 404
-        # fails fast instead of consuming the full retry window; 5xx still retries.
-        curl -fsSL --connect-timeout 10 --max-time 30 --retry 5 --retry-delay 3 --retry-max-time 60 \
+        # fails fast instead of consuming the full retry window; 5xx still retries
+        # with exponential backoff inside --retry-max-time.
+        curl -fsSL --connect-timeout 10 --max-time 30 --retry 5 --retry-max-time 60 \
           "${BASE_URL}/checksums.txt.sig" -o "$COSIGN_SIG" 2>/dev/null || true
-        curl -fsSL --connect-timeout 10 --max-time 30 --retry 5 --retry-delay 3 --retry-max-time 60 \
+        curl -fsSL --connect-timeout 10 --max-time 30 --retry 5 --retry-max-time 60 \
           "${BASE_URL}/checksums.txt.pem" -o "$COSIGN_PEM" 2>/dev/null || true
 
         if [ -s "$COSIGN_SIG" ] && [ -s "$COSIGN_PEM" ]; then

--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
         VERSION="$PIPELOCK_VERSION"
         if [ "$VERSION" = "latest" ]; then
           # Use GitHub API directly (no gh CLI dependency)
-          VERSION=$(curl -fsSL --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors \
+          VERSION=$(curl -fsSL --connect-timeout 10 --max-time 30 --retry 8 --retry-delay 3 --retry-max-time 120 --retry-all-errors \
             -H "Authorization: token $GH_TOKEN" \
             "https://api.github.com/repos/luckyPipewrench/pipelock/releases/latest" \
             | jq -r '.tag_name' | sed 's/^v//')
@@ -104,8 +104,10 @@ runs:
         mkdir -p "$INSTALL_DIR"
 
         echo "Downloading pipelock v${VERSION} (${GOOS}/${GOARCH})..."
-        curl -fsSL --connect-timeout 10 --max-time 60 --retry 3 --retry-delay 2 --retry-all-errors "${BASE_URL}/${ASSET}" -o "${INSTALL_DIR}/pipelock.tar.gz"
-        curl -fsSL --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors "${BASE_URL}/checksums.txt" -o "${INSTALL_DIR}/checksums.txt"
+        # Retry budget ~2 min absorbs transient 504s from the release-assets
+        # CDN (Azure Blob behind Fastly) without stalling on real outages.
+        curl -fsSL --connect-timeout 10 --max-time 60 --retry 8 --retry-delay 3 --retry-max-time 120 --retry-all-errors "${BASE_URL}/${ASSET}" -o "${INSTALL_DIR}/pipelock.tar.gz"
+        curl -fsSL --connect-timeout 10 --max-time 30 --retry 8 --retry-delay 3 --retry-max-time 120 --retry-all-errors "${BASE_URL}/checksums.txt" -o "${INSTALL_DIR}/checksums.txt"
 
         # Verify checksum (portable: sha256sum on Linux, shasum on macOS)
         EXPECTED=$(awk -v asset="$ASSET" '$2 == asset || $NF == asset {print $1; exit}' "${INSTALL_DIR}/checksums.txt")
@@ -131,9 +133,11 @@ runs:
         # Graceful: warns if cosign unavailable or artifacts missing (older releases).
         COSIGN_SIG="${INSTALL_DIR}/checksums.txt.sig"
         COSIGN_PEM="${INSTALL_DIR}/checksums.txt.pem"
-        curl -fsSL --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors \
+        # Optional fallback: older releases may 404. No --retry-all-errors so 404
+        # fails fast instead of consuming the full retry window; 5xx still retries.
+        curl -fsSL --connect-timeout 10 --max-time 30 --retry 5 --retry-delay 3 --retry-max-time 60 \
           "${BASE_URL}/checksums.txt.sig" -o "$COSIGN_SIG" 2>/dev/null || true
-        curl -fsSL --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors \
+        curl -fsSL --connect-timeout 10 --max-time 30 --retry 5 --retry-delay 3 --retry-max-time 60 \
           "${BASE_URL}/checksums.txt.pem" -o "$COSIGN_PEM" 2>/dev/null || true
 
         if [ -s "$COSIGN_SIG" ] && [ -s "$COSIGN_PEM" ]; then


### PR DESCRIPTION
## Summary

The composite action's 5 download calls previously used `--retry 3 --retry-delay 2`, giving only ~6s of retry patience. When GitHub's release-assets CDN (Azure Blob behind Fastly) returns transient 504s for longer than that window, the action fails with four back-to-back `curl: (22) error: 504` lines and exits 22, producing spurious CI failures for users pulling `pipelock@v2`.

This bumps the retry budget so short CDN blips are absorbed without stalling on real outages.

## Changes

Critical downloads (tarball, `checksums.txt`, version-lookup API):

    --retry 8 --retry-max-time 120 --retry-all-errors

Optional cosign artifacts (`.sig`, `.pem`) drop `--retry-all-errors` so 404 on older pre-sigstore releases fails fast instead of consuming the full retry budget:

    --retry 5 --retry-max-time 60

`--retry-delay` is intentionally omitted so curl uses its default exponential backoff (1s, 2s, 4s, 8s, ...) bounded by `--retry-max-time`. This fully utilizes the retry window, spaces later retries farther apart to give a degraded CDN edge time to heal, and still honors a server `Retry-After` header when present.

## Compatibility

- `--retry-max-time` requires curl >=7.32 (2014)
- `--retry-all-errors` already required curl >=7.71 (2020); pre-existing constraint
- GitHub-hosted runners ship curl >=8.x, no impact
- Self-hosted on ancient LTS images (RHEL 7, Ubuntu 18.04) were already incompatible with the pre-existing `--retry-all-errors` flag, so no regression