### PR TITLE
docs: point tool-response-injection demo at the live pipelock-verify PyPI package

### DIFF
--- a/examples/tool-response-injection/README.md
+++ b/examples/tool-response-injection/README.md
@@ -89,13 +89,22 @@ The receipt format is documented here: <https://pipelab.org/learn/action-receipt
 ## Independent Verification
 `demo.py` verifies every receipt inline with Python and the `cryptography` library. The chain-break subdemo also shells out to the Go CLI so the Python and Go verifiers agree on the same evidence file.
 
-As of 2026-04-10, we did not find a `pipelock-verify` package on PyPI. Use the Go CLI that ships with pipelock:
+Two interchangeable verifiers are available.
+
+The Go CLI ships with pipelock:
 
 ```bash
 pipelock verify-receipt evidence/evidence-proxy-0.jsonl --key <public-key-hex>
 ```
 
-You can also inspect the public key that `demo.py` prints and verify the JSONL file yourself from another implementation.
+The Python reference verifier is on PyPI as [`pipelock-verify`](https://pypi.org/project/pipelock-verify/) and mirrors the Go output byte-for-byte:
+
+```bash
+pip install pipelock-verify
+python -m pipelock_verify evidence/evidence-proxy-0.jsonl --key <public-key-hex>
+```
+
+Both return exit 0 on success, 1 on failure. You can also inspect the public key that `demo.py` prints and verify the JSONL file yourself from any other implementation of the spec.
 
 ## Adapting The Demo For Your Own MCP Server
 Swap `malicious_mcp_server.py` for your own server and keep the same `pipelock.yaml` shape.


### PR DESCRIPTION
## Summary

Updates `examples/tool-response-injection/README.md` to reflect the published `pipelock-verify` Python package. The section was written on 2026-04-10 when no Python package was available; as of 2026-04-19 it is published.

## What changed

Removes the "As of 2026-04-10, we did not find a `pipelock-verify` package on PyPI" qualifier and shows both verifiers side by side:

- Go CLI (ships with pipelock): `pipelock verify-receipt ...`
- Python reference verifier: `pip install pipelock-verify` then `python -m pipelock_verify ...`

Both return exit 0/1, and the cross-language conformance corpus ensures byte-for-byte agreement.

## Links

- PyPI: https://pypi.org/project/pipelock-verify/
- Source: https://github.com/luckyPipewrench/pipelock-verify-python
- Spec: https://pipelab.org/learn/action-receipt-spec/

## Test plan

- [x] Diff is a single file, docs only
- [x] `pipelock-verify` PyPI page returns 200 with 0.1.0 published
- [x] Source repo resolves (previously 404, now live)