### PR TITLE
fix(sentry): drop context.Canceled from CaptureError

### DIFF
--- a/internal/sentry/client.go
+++ b/internal/sentry/client.go
@@ -2,6 +2,8 @@ package plsentry
 
 import (
 	"bufio"
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -98,8 +100,13 @@ func initClient(cfg *config.Config, version string, transport sentry.Transport) 
 }
 
 // CaptureError sends an error event to Sentry (scrubbed by BeforeSend).
+// context.Canceled is dropped because it signals normal shutdown propagation
+// (SIGINT, parent exit, session end), not a failure worth paging on.
 func (c *Client) CaptureError(err error) {
 	if c == nil || !c.enabled {
+		return
+	}
+	if errors.Is(err, context.Canceled) {
 		return
 	}
 	sentry.CaptureException(err)

--- a/internal/sentry/client_test.go
+++ b/internal/sentry/client_test.go
@@ -3,6 +3,7 @@ package plsentry
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -238,6 +239,19 @@ func TestCaptureError_EventIsScrubbed(t *testing.T) {
 				t.Errorf("secret leaked in exception value: %q", exc.Value)
 			}
 		}
+	}
+}
+
+func TestCaptureError_DropsContextCanceled(t *testing.T) {
+	c, transport := initTestClient(t, nil)
+	defer c.Close()
+
+	c.CaptureError(context.Canceled)
+	c.CaptureError(fmt.Errorf("mcp proxy: %w", context.Canceled))
+	_ = c.Flush(2 * time.Second)
+
+	if events := transport.Events(); len(events) != 0 {
+		t.Fatalf("expected no events for context.Canceled, got %d", len(events))
 	}
 }
 


### PR DESCRIPTION
## Summary

`Client.CaptureError` was sending `context.Canceled` to Sentry. That's the normal shutdown signal (SIGINT, parent exit, session end), not a failure worth paging on. Noise in, real signals buried.

Filtering at the `Client` covers every call site (`run.go`, `mcp.go`) with one check instead of sprinkling guards per caller. `errors.Is` catches wrapped cancellations from downstream packages.

## Changes

- `internal/sentry/client.go`: skip Sentry emission when `errors.Is(err, context.Canceled)`.
- `internal/sentry/client_test.go`: regression test covers bare and wrapped cancellation.
- 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Context cancellation errors will no longer be reported to error monitoring, reducing notification noise and helping you focus on actual issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->