### PR TITLE
feat: class-preserving redaction library and config schema

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
+	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
@@ -59,6 +60,10 @@ const (
 	ActionStrip    = "strip"
 	ActionForward  = "forward"
 	ActionAllow    = "allow"
+	// ActionRedact replaces the matched value with a typed placeholder
+	// (e.g. "<pl:ipv4:1>"). Irreversible: pipelock holds no mapping.
+	// See the redaction-v1 design spec in ops for the semantic model.
+	ActionRedact = "redact"
 )
 
 // Severity constants for chain detection and emit thresholds.
@@ -393,6 +398,7 @@ type Config struct {
 	A2AScanning              A2AScanning             `yaml:"a2a_scanning"`
 	Taint                    TaintConfig             `yaml:"taint"`
 	MediationEnvelope        MediationEnvelope       `yaml:"mediation_envelope"`
+	Redaction                redact.Config           `yaml:"redaction"`
 	Agents                   map[string]AgentProfile `yaml:"agents,omitempty"`
 	DefaultAgentIdentity     string                  `yaml:"default_agent_identity,omitempty"`      // operator-configured agent name used when no stronger identity source resolves the caller
 	BindDefaultAgentIdentity bool                    `yaml:"bind_default_agent_identity,omitempty"` // when true, ignore self-declared header/query identities and bind requests to default_agent_identity
@@ -2269,11 +2275,22 @@ func (c *Config) Validate() error {
 		c.validateDefaultAgentIdentity,
 		c.validateMediationEnvelope,
 		c.validateMediaPolicy,
+		c.validateRedaction,
 	}
 	for _, v := range validators {
 		if err := v(); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// validateRedaction delegates to the redact package's own validator. Keeps
+// redaction schema ownership inside the redact package while hooking the
+// feature into pipelock's overall config validation chain.
+func (c *Config) validateRedaction() error {
+	if err := c.Redaction.Validate(); err != nil {
+		return fmt.Errorf("redaction: %w", err)
 	}
 	return nil
 }
@@ -5162,6 +5179,9 @@ func Defaults() *Config {
 	for i := range cfg.ResponseScanning.Patterns {
 		cfg.ResponseScanning.Patterns[i].Compiled = true
 	}
+	// Redaction defaults to disabled. Operators opt in via YAML; see the
+	// redact package for the full schema.
+	cfg.Redaction = redact.DefaultConfig()
 	return cfg
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2285,12 +2285,17 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// validateRedaction delegates to the redact package's own validator. Keeps
-// redaction schema ownership inside the redact package while hooking the
-// feature into pipelock's overall config validation chain.
+// validateRedaction delegates to the redact package's own validator and
+// additionally blocks operators from enabling the feature before the
+// request pipeline enforces it. Schema ownership stays inside redact; the
+// pipelock-level gate lives here so library tests can still exercise
+// Enabled=true via the package validator directly.
 func (c *Config) validateRedaction() error {
 	if err := c.Redaction.Validate(); err != nil {
 		return fmt.Errorf("redaction: %w", err)
+	}
+	if c.Redaction.Enabled {
+		return fmt.Errorf("redaction: enabled=true is not supported in this release — the request pipeline does not yet enforce redaction; set redaction.enabled: false until the proxy hook ships")
 	}
 	return nil
 }

--- a/internal/config/redaction_gate_test.go
+++ b/internal/config/redaction_gate_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/redact"
+)
+
+// TestValidate_RedactionEnabledBlockedUntilEnforced guards the startup
+// gate introduced in response to GPT review #1 (2026-04-19). An operator
+// setting redaction.enabled=true must get a loud startup failure until
+// the transport pipeline actually enforces redaction, so nobody believes
+// they are protected by an unwired feature.
+func TestValidate_RedactionEnabledBlockedUntilEnforced(t *testing.T) {
+	t.Parallel()
+	cfg := Defaults()
+	cfg.Redaction = redact.Config{
+		Enabled:        true,
+		DefaultProfile: "p",
+		Profiles: map[string]redact.ProfileSpec{
+			"p": {Classes: []string{"ipv4"}},
+		},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate should reject redaction.enabled=true until enforcement ships")
+	}
+	if !strings.Contains(err.Error(), "enabled=true is not supported") {
+		t.Fatalf("error must explain the gate, got: %v", err)
+	}
+}
+
+// TestValidate_RedactionDisabledPermitted confirms the default-disabled
+// path continues to validate cleanly.
+func TestValidate_RedactionDisabledPermitted(t *testing.T) {
+	t.Parallel()
+	cfg := Defaults()
+	// Redaction defaults to disabled; Validate must succeed.
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("default Validate should pass, got %v", err)
+	}
+}

--- a/internal/redact/classes.go
+++ b/internal/redact/classes.go
@@ -21,145 +21,104 @@ type classPattern struct {
 	priority int
 }
 
+// Shared regex fragments reused across category-specific registries.
+const (
+	hex32    = `[a-fA-F0-9]{32}`
+	hex40    = `[a-fA-F0-9]{40}`
+	hex64    = `[a-fA-F0-9]{64}`
+	hex128   = `[a-fA-F0-9]{128}`
+	octet    = `(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)`
+	ipv4Str  = `\b` + octet + `\.` + octet + `\.` + octet + `\.` + octet
+	cidrMask = `/(?:3[0-2]|[12]?\d)\b`
+)
+
 // classRegistry is the shipped set of structured secret classes.
-// Expressed as a function so compile errors surface at test time rather than
-// process-startup time.
-//
-//nolint:funlen // registry is data; splitting hurts readability.
+// Split across category helpers so no single function trips funlen and the
+// priority story stays scannable category by category.
 func classRegistry() []classPattern {
-	// Shared fragments
-	const (
-		// Generic hex string (any length — refined per hash class below).
-		hex32  = `[a-fA-F0-9]{32}`
-		hex40  = `[a-fA-F0-9]{40}`
-		hex64  = `[a-fA-F0-9]{64}`
-		hex128 = `[a-fA-F0-9]{128}`
-		// IPv4 octet (0-255).
-		octet = `(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)`
-	)
+	out := make([]classPattern, 0, 24)
+	out = append(out, tokenClasses()...)
+	out = append(out, hashClasses()...)
+	out = append(out, networkClasses()...)
+	out = append(out, identityClasses()...)
+	out = append(out, personalClasses()...)
+	return out
+}
 
+// tokenClasses is the API-key / bearer-credential category. High priority
+// so specific token formats win over generic patterns sharing the span.
+func tokenClasses() []classPattern {
 	return []classPattern{
-		// Tokens / API keys — high priority so the most specific span wins.
-		{
-			class:    ClassAWSAccessKey,
-			pattern:  regexp.MustCompile(`\b(?:AKIA|ASIA|AIDA|AGPA|AROA)[A-Z0-9]{16}\b`),
-			priority: 100,
-		},
-		{
-			class:    ClassGoogleAPIKey,
-			pattern:  regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{35}\b`),
-			priority: 100,
-		},
-		{
-			class:    ClassGitHubToken,
-			pattern:  regexp.MustCompile(`\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b`),
-			priority: 100,
-		},
-		{
-			class:    ClassSlackToken,
-			pattern:  regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}\b`),
-			priority: 100,
-		},
-		{
-			class: ClassJWT,
-			// Three base64url segments separated by dots; first segment starts
-			// with `eyJ` (decodes to '{"').
-			pattern:  regexp.MustCompile(`\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b`),
-			priority: 100,
-		},
-		{
-			class:    ClassSSHPrivateKey,
-			pattern:  regexp.MustCompile(`-----BEGIN (?:OPENSSH|RSA|DSA|EC|PGP) PRIVATE KEY(?: BLOCK)?-----`),
-			priority: 100,
-		},
+		{class: ClassAWSAccessKey, pattern: regexp.MustCompile(`\b(?:AKIA|ASIA|AIDA|AGPA|AROA)[A-Z0-9]{16}\b`), priority: 100},
+		{class: ClassGoogleAPIKey, pattern: regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{35}\b`), priority: 100},
+		{class: ClassGitHubToken, pattern: regexp.MustCompile(`\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b`), priority: 100},
+		{class: ClassSlackToken, pattern: regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}\b`), priority: 100},
+		// JWT: three base64url segments separated by dots; first segment
+		// starts with `eyJ` (decodes to '{"').
+		{class: ClassJWT, pattern: regexp.MustCompile(`\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b`), priority: 100},
+		{class: ClassSSHPrivateKey, pattern: regexp.MustCompile(`-----BEGIN (?:OPENSSH|RSA|DSA|EC|PGP) PRIVATE KEY(?: BLOCK)?-----`), priority: 100},
+	}
+}
 
-		// Hashes — medium-high priority. Longer hashes first so they win over
-		// shorter-hash prefixes.
+// hashClasses is the fixed-length hex digest category. Longer digests must
+// win over shorter-hash prefixes, hence the descending priorities. NTLM
+// and MD5 share hex32; disambiguation needs context we don't have at
+// regex time, so we expose MD5 and leave NTLM as a reserved label.
+func hashClasses() []classPattern {
+	return []classPattern{
 		{class: ClassHashSHA512, pattern: regexp.MustCompile(`\b` + hex128 + `\b`), priority: 90},
 		{class: ClassHashSHA256, pattern: regexp.MustCompile(`\b` + hex64 + `\b`), priority: 85},
 		{class: ClassHashSHA1, pattern: regexp.MustCompile(`\b` + hex40 + `\b`), priority: 80},
-		// NTLM is 32 hex chars — same length as MD5 but different context.
-		// We keep a single hex32 class tagged as hash-sha256-like; NTLM-vs-MD5
-		// disambiguation needs context we don't have at regex time. Document
-		// this limitation and let the operator pick a dictionary entry if
-		// they need to distinguish. See redaction-v1 §7 limitations.
 		{class: ClassHashMD5, pattern: regexp.MustCompile(`\b` + hex32 + `\b`), priority: 75},
+	}
+}
 
-		// Network identifiers.
-		{
-			class:    ClassIPv4,
-			pattern:  regexp.MustCompile(`\b` + octet + `\.` + octet + `\.` + octet + `\.` + octet + `\b`),
-			priority: 70,
-		},
-		{
-			class: ClassCIDR,
-			// CIDR is an IPv4 followed by /N — match this BEFORE IPv4 so the
-			// /prefix is included.
-			pattern:  regexp.MustCompile(`\b` + octet + `\.` + octet + `\.` + octet + `\.` + octet + `/(?:3[0-2]|[12]?\d)\b`),
-			priority: 72,
-		},
-		{
-			class: ClassIPv6,
-			// Pragmatic IPv6 pattern: either full 8-group form, OR a run
-			// with `::` zero-compression that has at least one hex digit
-			// adjacent to the `::`. The hex-digit requirement avoids bare
-			// `::` and C++ scope operators like `std::cout` matching while
-			// still catching `::1` (loopback), `fe80::`, `2001:db8::1`,
-			// and full forms. Priority is below MAC so 6-group all-hex
-			// strings ("aa:bb:cc:dd:ee:ff") belong to MAC.
-			pattern:  regexp.MustCompile(`\b(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\b|\b[A-Fa-f0-9]+(?::[A-Fa-f0-9]*)*::(?:[A-Fa-f0-9]*:?)*[A-Fa-f0-9]*\b|::[A-Fa-f0-9]+(?::[A-Fa-f0-9]*)*\b`),
-			priority: 68,
-		},
-		{
-			class:    ClassMAC,
-			pattern:  regexp.MustCompile(`\b(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b`),
-			priority: 65,
-		},
+// networkClasses covers IP addresses (v4/v6), CIDR blocks, and MAC
+// addresses. CIDR priority is above IPv4 so CIDR absorbs the embedded
+// address; IPv6 priority is above MAC so the `::`-compressed form wins
+// over the 6-group hex-with-colons shape.
+func networkClasses() []classPattern {
+	return []classPattern{
+		{class: ClassIPv4, pattern: regexp.MustCompile(ipv4Str + `\b`), priority: 70},
+		// CIDR = IPv4 followed by /N. Match before IPv4 so the /prefix is
+		// included.
+		{class: ClassCIDR, pattern: regexp.MustCompile(ipv4Str + cidrMask), priority: 72},
+		// Pragmatic IPv6: either full 8-group form, OR a run with `::`
+		// zero-compression that has at least one hex digit adjacent. The
+		// hex-digit requirement keeps `std::cout` and bare `::` from
+		// matching while still catching `::1`, `fe80::`, `2001:db8::1`.
+		{class: ClassIPv6, pattern: regexp.MustCompile(`\b(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\b|\b[A-Fa-f0-9]+(?::[A-Fa-f0-9]*)*::(?:[A-Fa-f0-9]*:?)*[A-Fa-f0-9]*\b|::[A-Fa-f0-9]+(?::[A-Fa-f0-9]*)*\b`), priority: 68},
+		{class: ClassMAC, pattern: regexp.MustCompile(`\b(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b`), priority: 65},
+	}
+}
 
-		// Identity / contact.
-		{
-			class:    ClassEmail,
-			pattern:  regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b`),
-			priority: 60,
-		},
-		{
-			class: ClassFQDN,
-			// Conservative FQDN: two-or-more labels, final TLD of 2-24
-			// letters. Avoids matching version strings ("1.2.3") and file
-			// paths ("foo.txt"). Ordered AFTER email so email wins on same
-			// span.
-			pattern:  regexp.MustCompile(`\b(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.){1,}[a-zA-Z]{2,24}\b`),
-			priority: 50,
-		},
-		{
-			class: ClassADUser,
-			// CONTOSO\user or user@contoso.local style. Conservative: DOMAIN
-			// must be uppercase-ish alphanumeric to avoid matching Windows
-			// paths with mixed case.
-			pattern:  regexp.MustCompile(`\b[A-Z][A-Z0-9_-]{1,20}\\[A-Za-z0-9._-]{2,}\b`),
-			priority: 95,
-		},
+// identityClasses covers email, FQDN, and AD user forms. FQDN is last
+// (lowest priority among the three) so email wins on a shared span and a
+// bare FQDN match only fires when no stricter class already claimed it.
+func identityClasses() []classPattern {
+	return []classPattern{
+		{class: ClassEmail, pattern: regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b`), priority: 60},
+		// Conservative FQDN: two-or-more labels, final TLD 2-24 letters.
+		// Avoids version strings ("1.2.3") and most file paths.
+		{class: ClassFQDN, pattern: regexp.MustCompile(`\b(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.){1,}[a-zA-Z]{2,24}\b`), priority: 50},
+		// AD user: CONTOSO\user shape. DOMAIN must be uppercase-ish to
+		// avoid matching Windows paths with mixed case.
+		{class: ClassADUser, pattern: regexp.MustCompile(`\b[A-Z][A-Z0-9_-]{1,20}\\[A-Za-z0-9._-]{2,}\b`), priority: 95},
+	}
+}
 
-		// Personal identifiers (US-centric — operators in other locales
-		// should supplement via dictionaries in v1.1).
-		{
-			class: ClassSSN,
-			// RE2 doesn't support negative lookahead, so the area/group/
-			// serial validity filter cannot be encoded in the regex alone.
-			// We match the SSN shape XXX-XX-XXXX and accept some false
-			// positives on invalid area codes. Redacting a non-SSN that
-			// happens to match the shape is safe; leaking a real SSN is not.
-			pattern:  regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`),
-			priority: 95,
-		},
-		{
-			class: ClassCreditCard,
-			// Major brands with spaces or dashes tolerated. Luhn-verified
-			// class narrowing is deferred; v1 accepts the regex-positive set
-			// and trades some false positives for zero false negatives.
-			pattern:  regexp.MustCompile(`\b(?:4\d{3}|5[1-5]\d{2}|3[47]\d{2}|6011|65\d{2})[ -]?\d{4}[ -]?\d{4}[ -]?\d{4}\b`),
-			priority: 90,
-		},
+// personalClasses is the US-centric PII category. Operators in other
+// locales supplement via dictionaries in v1.1. AmEx is 15 digits
+// (4-6-5 split, 3[47] prefix); other supported brands are 16 digits
+// (4-4-4-4). Folding both under the same template misses AmEx —
+// regression reported in review (2026-04-19).
+func personalClasses() []classPattern {
+	return []classPattern{
+		// SSN shape XXX-XX-XXXX. Matches on invalid area codes too; redacting
+		// a non-SSN that happens to share the shape is safe. RE2 has no
+		// negative lookahead so the area-code filter can't be encoded here.
+		{class: ClassSSN, pattern: regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`), priority: 95},
+		{class: ClassCreditCard, pattern: regexp.MustCompile(`\b(?:3[47]\d{2}[ -]?\d{6}[ -]?\d{5}|(?:4\d{3}|5[1-5]\d{2}|6011|65\d{2})[ -]?\d{4}[ -]?\d{4}[ -]?\d{4})\b`), priority: 90},
 	}
 }
 

--- a/internal/redact/classes.go
+++ b/internal/redact/classes.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"regexp"
+	"sort"
+	"sync"
+)
+
+// A classPattern associates a secret class with a compiled regex that
+// matches instances of that class in arbitrary text. Patterns must not have
+// anchors (^ / $) because they are applied inside larger string scalars.
+type classPattern struct {
+	class   Class
+	pattern *regexp.Regexp
+	// priority disambiguates overlapping classes: higher wins. Used when the
+	// same substring matches multiple classes (e.g., a CIDR also contains an
+	// IPv4). Kept small integer to make ordering obvious.
+	priority int
+}
+
+// classRegistry is the shipped set of structured secret classes.
+// Expressed as a function so compile errors surface at test time rather than
+// process-startup time.
+//
+//nolint:funlen // registry is data; splitting hurts readability.
+func classRegistry() []classPattern {
+	// Shared fragments
+	const (
+		// Generic hex string (any length — refined per hash class below).
+		hex32  = `[a-fA-F0-9]{32}`
+		hex40  = `[a-fA-F0-9]{40}`
+		hex64  = `[a-fA-F0-9]{64}`
+		hex128 = `[a-fA-F0-9]{128}`
+		// IPv4 octet (0-255).
+		octet = `(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)`
+	)
+
+	return []classPattern{
+		// Tokens / API keys — high priority so the most specific span wins.
+		{
+			class:    ClassAWSAccessKey,
+			pattern:  regexp.MustCompile(`\b(?:AKIA|ASIA|AIDA|AGPA|AROA)[A-Z0-9]{16}\b`),
+			priority: 100,
+		},
+		{
+			class:    ClassGoogleAPIKey,
+			pattern:  regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{35}\b`),
+			priority: 100,
+		},
+		{
+			class:    ClassGitHubToken,
+			pattern:  regexp.MustCompile(`\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b`),
+			priority: 100,
+		},
+		{
+			class:    ClassSlackToken,
+			pattern:  regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}\b`),
+			priority: 100,
+		},
+		{
+			class: ClassJWT,
+			// Three base64url segments separated by dots; first segment starts
+			// with `eyJ` (decodes to '{"').
+			pattern:  regexp.MustCompile(`\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b`),
+			priority: 100,
+		},
+		{
+			class:    ClassSSHPrivateKey,
+			pattern:  regexp.MustCompile(`-----BEGIN (?:OPENSSH|RSA|DSA|EC|PGP) PRIVATE KEY(?: BLOCK)?-----`),
+			priority: 100,
+		},
+
+		// Hashes — medium-high priority. Longer hashes first so they win over
+		// shorter-hash prefixes.
+		{class: ClassHashSHA512, pattern: regexp.MustCompile(`\b` + hex128 + `\b`), priority: 90},
+		{class: ClassHashSHA256, pattern: regexp.MustCompile(`\b` + hex64 + `\b`), priority: 85},
+		{class: ClassHashSHA1, pattern: regexp.MustCompile(`\b` + hex40 + `\b`), priority: 80},
+		// NTLM is 32 hex chars — same length as MD5 but different context.
+		// We keep a single hex32 class tagged as hash-sha256-like; NTLM-vs-MD5
+		// disambiguation needs context we don't have at regex time. Document
+		// this limitation and let the operator pick a dictionary entry if
+		// they need to distinguish. See redaction-v1 §7 limitations.
+		{class: ClassHashMD5, pattern: regexp.MustCompile(`\b` + hex32 + `\b`), priority: 75},
+
+		// Network identifiers.
+		{
+			class:    ClassIPv4,
+			pattern:  regexp.MustCompile(`\b` + octet + `\.` + octet + `\.` + octet + `\.` + octet + `\b`),
+			priority: 70,
+		},
+		{
+			class: ClassCIDR,
+			// CIDR is an IPv4 followed by /N — match this BEFORE IPv4 so the
+			// /prefix is included.
+			pattern:  regexp.MustCompile(`\b` + octet + `\.` + octet + `\.` + octet + `\.` + octet + `/(?:3[0-2]|[12]?\d)\b`),
+			priority: 72,
+		},
+		{
+			class: ClassIPv6,
+			// Pragmatic IPv6 pattern: either full 8-group form, OR a run
+			// with `::` zero-compression that has at least one hex digit
+			// adjacent to the `::`. The hex-digit requirement avoids bare
+			// `::` and C++ scope operators like `std::cout` matching while
+			// still catching `::1` (loopback), `fe80::`, `2001:db8::1`,
+			// and full forms. Priority is below MAC so 6-group all-hex
+			// strings ("aa:bb:cc:dd:ee:ff") belong to MAC.
+			pattern:  regexp.MustCompile(`\b(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\b|\b[A-Fa-f0-9]+(?::[A-Fa-f0-9]*)*::(?:[A-Fa-f0-9]*:?)*[A-Fa-f0-9]*\b|::[A-Fa-f0-9]+(?::[A-Fa-f0-9]*)*\b`),
+			priority: 68,
+		},
+		{
+			class:    ClassMAC,
+			pattern:  regexp.MustCompile(`\b(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b`),
+			priority: 65,
+		},
+
+		// Identity / contact.
+		{
+			class:    ClassEmail,
+			pattern:  regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b`),
+			priority: 60,
+		},
+		{
+			class: ClassFQDN,
+			// Conservative FQDN: two-or-more labels, final TLD of 2-24
+			// letters. Avoids matching version strings ("1.2.3") and file
+			// paths ("foo.txt"). Ordered AFTER email so email wins on same
+			// span.
+			pattern:  regexp.MustCompile(`\b(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.){1,}[a-zA-Z]{2,24}\b`),
+			priority: 50,
+		},
+		{
+			class: ClassADUser,
+			// CONTOSO\user or user@contoso.local style. Conservative: DOMAIN
+			// must be uppercase-ish alphanumeric to avoid matching Windows
+			// paths with mixed case.
+			pattern:  regexp.MustCompile(`\b[A-Z][A-Z0-9_-]{1,20}\\[A-Za-z0-9._-]{2,}\b`),
+			priority: 95,
+		},
+
+		// Personal identifiers (US-centric — operators in other locales
+		// should supplement via dictionaries in v1.1).
+		{
+			class: ClassSSN,
+			// RE2 doesn't support negative lookahead, so the area/group/
+			// serial validity filter cannot be encoded in the regex alone.
+			// We match the SSN shape XXX-XX-XXXX and accept some false
+			// positives on invalid area codes. Redacting a non-SSN that
+			// happens to match the shape is safe; leaking a real SSN is not.
+			pattern:  regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`),
+			priority: 95,
+		},
+		{
+			class: ClassCreditCard,
+			// Major brands with spaces or dashes tolerated. Luhn-verified
+			// class narrowing is deferred; v1 accepts the regex-positive set
+			// and trades some false positives for zero false negatives.
+			pattern:  regexp.MustCompile(`\b(?:4\d{3}|5[1-5]\d{2}|3[47]\d{2}|6011|65\d{2})[ -]?\d{4}[ -]?\d{4}[ -]?\d{4}\b`),
+			priority: 90,
+		},
+	}
+}
+
+// compiledRegistry caches the compiled registry so each call to
+// NewDefaultMatcher doesn't pay the regex compile cost.
+var (
+	compiledRegistryOnce sync.Once
+	compiledRegistryVal  []classPattern
+)
+
+// defaultRegistry returns the shipped registry, compiled once.
+func defaultRegistry() []classPattern {
+	compiledRegistryOnce.Do(func() {
+		compiledRegistryVal = classRegistry()
+		// Sort highest-priority first so span overlap resolution picks the
+		// most specific class first.
+		sort.SliceStable(compiledRegistryVal, func(i, j int) bool {
+			return compiledRegistryVal[i].priority > compiledRegistryVal[j].priority
+		})
+	})
+	return compiledRegistryVal
+}

--- a/internal/redact/classes_test.go
+++ b/internal/redact/classes_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDefaultMatcher_StructuredClasses exercises every built-in matcher class
+// shipped in v1 with at least one positive example and asserts the class +
+// span are correct.
+func TestDefaultMatcher_StructuredClasses(t *testing.T) {
+	t.Parallel()
+	m := NewDefaultMatcher()
+
+	cases := []struct {
+		name  string
+		input string
+		want  Class
+	}{
+		{"ipv4", "connect to 192.0.2.104 now", ClassIPv4},
+		{"ipv4-private", "192.168.1.5", ClassIPv4},
+		{"cidr", "route 10.0.0.0/16 next", ClassCIDR},
+		{"ipv6-compressed", "try 2001:db8::1 now", ClassIPv6},
+		{"ipv6-full", "use 2001:0db8:85a3:0000:0000:8a2e:0370:7334 please", ClassIPv6},
+		{"mac-colon", "mac aa:bb:cc:dd:ee:ff", ClassMAC},
+		{"mac-dash", "mac aa-bb-cc-dd-ee-ff", ClassMAC},
+		{"email", "contact jsmith@contoso.com for info", ClassEmail},
+		{"fqdn", "visit dc01.corp.local for login", ClassFQDN},
+		{"aws-access-key-akia", "key AKIA" + "IOSFODNN7EXAMPLE exposed", ClassAWSAccessKey},
+		{"aws-access-key-asia", "temp " + "ASIA" + "Q5ZABCDEFG1234XY", ClassAWSAccessKey},
+		{"google-api-key", "AIza" + "SyD4mHwK8NQ2J5B1v6xR3L9fP7aW0cZu8kE", ClassGoogleAPIKey},
+		{"github-pat", "token ghp_" + strings.Repeat("A", 36) + " expires", ClassGitHubToken},
+		{"github-new", "token github_pat_" + strings.Repeat("B", 40), ClassGitHubToken},
+		{"slack-bot", "use " + "xox" + "b-12345-67890-abcdefghijklmnopqrstuvwx", ClassSlackToken},
+		{"jwt", "bearer eyJ" + "hbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c", ClassJWT},
+		{"ssh-openssh", "-----BEGIN OPENSSH PRIVATE " + "KEY-----", ClassSSHPrivateKey},
+		{"ssh-rsa", "-----BEGIN RSA PRIVATE " + "KEY-----", ClassSSHPrivateKey},
+		{"ad-user", "CONTOSO\\jsmith logged in", ClassADUser},
+		{"ssn", "SSN " + "123-45-" + "6789 on file", ClassSSN},
+		{"credit-card-visa", "card " + "4111 1111 " + "1111 1111", ClassCreditCard},
+		{"hash-md5", "etag " + strings.Repeat("a", 32), ClassHashMD5},
+		{"hash-sha1", "sha1 " + strings.Repeat("b", 40), ClassHashSHA1},
+		{"hash-sha256", "sha256 " + strings.Repeat("c", 64), ClassHashSHA256},
+		{"hash-sha512", "sha512 " + strings.Repeat("d", 128), ClassHashSHA512},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			matches := m.Scan(tc.input)
+			if len(matches) == 0 {
+				t.Fatalf("Scan(%q) returned no matches; expected class %s", tc.input, tc.want)
+			}
+			// At least one match must be of the expected class.
+			found := false
+			for _, got := range matches {
+				if got.Class == tc.want {
+					found = true
+					// Verify span slices correctly back to the original.
+					if got.Original != tc.input[got.Start:got.End] {
+						t.Errorf("Match span mismatch: original=%q vs s[Start:End]=%q",
+							got.Original, tc.input[got.Start:got.End])
+					}
+					break
+				}
+			}
+			if !found {
+				classesFound := make([]string, 0, len(matches))
+				for _, got := range matches {
+					classesFound = append(classesFound, string(got.Class))
+				}
+				t.Fatalf("no match of class %s in %q; got classes %v", tc.want, tc.input, classesFound)
+			}
+		})
+	}
+}
+
+// TestDefaultMatcher_IPv6DoesNotMatchScopeOperator guards against the
+// false-positive from review finding #4 (2026-04-19): the earlier IPv6
+// regex accepted any `[A-Fa-f0-9:]*::[A-Fa-f0-9:]*` including `::` alone
+// and C++ scope operators like `std::cout`.
+func TestDefaultMatcher_IPv6DoesNotMatchScopeOperator(t *testing.T) {
+	t.Parallel()
+	m := NewDefaultMatcher()
+	shouldNotMatch := []string{
+		"std::cout is the output stream",
+		"call foo::bar(x) to run",
+		"the :: operator is C++",
+	}
+	for _, s := range shouldNotMatch {
+		t.Run(s, func(t *testing.T) {
+			t.Parallel()
+			for _, mv := range m.Scan(s) {
+				if mv.Class == ClassIPv6 {
+					t.Fatalf("IPv6 falsely matched in %q: %+v", s, mv)
+				}
+			}
+		})
+	}
+
+	// Real compressed IPv6 must still match.
+	shouldMatch := []string{"::1", "fe80::1", "2001:db8::1"}
+	for _, s := range shouldMatch {
+		t.Run(s, func(t *testing.T) {
+			t.Parallel()
+			found := false
+			for _, mv := range m.Scan(s) {
+				if mv.Class == ClassIPv6 {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("IPv6 failed to match legitimate address %q: scans=%+v", s, m.Scan(s))
+			}
+		})
+	}
+}
+
+// TestDefaultMatcher_Negative verifies non-secret content does not match.
+func TestDefaultMatcher_Negative(t *testing.T) {
+	t.Parallel()
+	m := NewDefaultMatcher()
+
+	// Note: FQDN detection is class-level best-effort. Common file
+	// extensions (foo.txt, config.yaml) will sometimes match. v1 accepts
+	// this trade-off — operators who need finer control use dictionaries.
+	cases := []string{
+		"", // empty
+		"just a normal sentence about http and https",   // no identifiers
+		"version 1.2.3 shipped yesterday",               // not a FQDN
+		"this is a plain english sentence with no dots", // nothing to match
+	}
+	for _, s := range cases {
+		t.Run(s, func(t *testing.T) {
+			t.Parallel()
+			if got := m.Scan(s); len(got) != 0 {
+				t.Fatalf("Scan(%q) = %+v; wanted no matches", s, got)
+			}
+		})
+	}
+}
+
+// TestDefaultMatcher_OverlapsResolvedByPriority confirms that when a span
+// matches multiple classes, the highest-priority class wins.
+func TestDefaultMatcher_OverlapsResolvedByPriority(t *testing.T) {
+	t.Parallel()
+	m := NewDefaultMatcher()
+
+	// CIDR covers IPv4 + `/N`. Priority table puts CIDR above IPv4.
+	s := "route 10.0.0.0/16 somewhere"
+	matches := m.Scan(s)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match (CIDR absorbs IPv4), got %d: %+v", len(matches), matches)
+	}
+	if matches[0].Class != ClassCIDR {
+		t.Fatalf("expected ClassCIDR, got %s", matches[0].Class)
+	}
+}
+
+// TestDefaultMatcher_SpansAreNonOverlapping sorted and non-overlapping.
+func TestDefaultMatcher_SpansAreNonOverlapping(t *testing.T) {
+	t.Parallel()
+	m := NewDefaultMatcher()
+	s := "a@b.com 10.0.0.1 dc01.corp.local 10.0.0.2 user@domain.org"
+	matches := m.Scan(s)
+	if len(matches) < 2 {
+		t.Fatalf("expected multiple matches, got %d", len(matches))
+	}
+	for i := 1; i < len(matches); i++ {
+		if matches[i-1].End > matches[i].Start {
+			t.Errorf("matches[%d].End=%d overlaps matches[%d].Start=%d",
+				i-1, matches[i-1].End, i, matches[i].Start)
+		}
+	}
+}
+
+// TestDefaultMatcher_NilSafe ensures a nil Matcher returns nil without
+// panicking (defensive).
+func TestDefaultMatcher_NilSafe(t *testing.T) {
+	t.Parallel()
+	var m *Matcher
+	if got := m.Scan("anything"); got != nil {
+		t.Fatalf("nil Matcher Scan returned %+v, want nil", got)
+	}
+}
+
+// TestDefaultRegistry_Cached ensures the compiled registry is stable across
+// calls (same pointer-equal slice entries).
+func TestDefaultRegistry_Cached(t *testing.T) {
+	t.Parallel()
+	a := defaultRegistry()
+	b := defaultRegistry()
+	if len(a) != len(b) {
+		t.Fatalf("registry length changed: %d vs %d", len(a), len(b))
+	}
+	// Cached: first pattern's compiled regex pointer must match.
+	if a[0].pattern != b[0].pattern {
+		t.Fatalf("registry not cached: pointer identity broke")
+	}
+}

--- a/internal/redact/classes_test.go
+++ b/internal/redact/classes_test.go
@@ -41,6 +41,8 @@ func TestDefaultMatcher_StructuredClasses(t *testing.T) {
 		{"ad-user", "CONTOSO\\jsmith logged in", ClassADUser},
 		{"ssn", "SSN " + "123-45-" + "6789 on file", ClassSSN},
 		{"credit-card-visa", "card " + "4111 1111 " + "1111 1111", ClassCreditCard},
+		{"credit-card-amex-15digit", "card " + "3782 822463 " + "10005", ClassCreditCard},
+		{"credit-card-amex-dashed", "card " + "3714-496353-" + "98431", ClassCreditCard},
 		{"hash-md5", "etag " + strings.Repeat("a", 32), ClassHashMD5},
 		{"hash-sha1", "sha1 " + strings.Repeat("b", 40), ClassHashSHA1},
 		{"hash-sha256", "sha256 " + strings.Repeat("c", 64), ClassHashSHA256},

--- a/internal/redact/config.go
+++ b/internal/redact/config.go
@@ -1,0 +1,218 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Config is the top-level YAML config for redaction. Embedded into the
+// main pipelock Config as the `redaction:` block.
+type Config struct {
+	// Enabled toggles the feature. When false, no other fields have any
+	// effect and the feature is inert.
+	Enabled bool `yaml:"enabled"`
+
+	// DefaultProfile names the profile applied to every request unless a
+	// per-agent override selects a different one. Must be a key in Profiles
+	// when Enabled is true.
+	DefaultProfile string `yaml:"default_profile"`
+
+	// Profiles is the set of named redaction configurations. A profile
+	// composes class names + dictionary names. Operators can ship a
+	// `code` profile that enables only API/token classes, a `business`
+	// profile that adds PII classes and customer dictionaries, etc.
+	Profiles map[string]ProfileSpec `yaml:"profiles"`
+
+	// Dictionaries is the set of named operator-supplied literal lists
+	// that profiles reference. Each key is a dictionary name; the value
+	// describes the class and entries.
+	Dictionaries map[string]DictionarySpec `yaml:"dictionaries"`
+
+	// Limits caps defensive ceilings for fail-closed behavior.
+	Limits LimitsSpec `yaml:"limits"`
+
+	// StrictReload, when true, fails requests closed if a dictionary file
+	// referenced by an active profile cannot be reloaded (disappeared or
+	// corrupted). Default false — retain previous snapshot instead.
+	StrictReload bool `yaml:"strict_reload"`
+
+	// AllowlistUnparseable lists hosts whose request bodies are permitted
+	// to flow through redaction as opaque text when the body is not
+	// parseable JSON. Bodies from hosts not in this list are blocked per
+	// the fail-closed invariant.
+	AllowlistUnparseable []string `yaml:"allowlist_unparseable"`
+}
+
+// ProfileSpec describes a single redaction profile as YAML.
+type ProfileSpec struct {
+	// Classes is the list of built-in redaction class names (e.g.
+	// "ipv4", "aws-access-key") that are enabled for this profile.
+	// Unknown class names are validated against the shipped registry.
+	Classes []string `yaml:"classes"`
+	// Dictionaries is the list of dictionary names (keys in
+	// Config.Dictionaries) that this profile attaches to the matcher.
+	Dictionaries []string `yaml:"dictionaries"`
+}
+
+// DictionarySpec is a YAML-friendly version of Dictionary. Either Entries
+// or EntriesFile must be set; EntriesFile loading is the responsibility of
+// the caller (the redact package does not touch the filesystem).
+type DictionarySpec struct {
+	// Class tags every hit of this dictionary.
+	Class string `yaml:"class"`
+	// Entries lists literal strings to match. Either this or EntriesFile
+	// must be non-empty.
+	Entries []string `yaml:"entries,omitempty"`
+	// EntriesFile points at a YAML/JSON file containing a string list.
+	// Not loaded by this package; resolve before calling BuildMatcher.
+	EntriesFile string `yaml:"entries_file,omitempty"`
+	// CaseInsensitive toggles case-insensitive matching.
+	CaseInsensitive bool `yaml:"case_insensitive"`
+	// WordBoundary requires `\b` surrounding each entry's match span.
+	WordBoundary bool `yaml:"word_boundary"`
+	// Priority positions this dictionary in overlap resolution.
+	Priority int `yaml:"priority"`
+}
+
+// LimitsSpec mirrors Limits but uses YAML-idiomatic zero values. Fields
+// with zero value take the package-level defaults (see walker.go).
+type LimitsSpec struct {
+	MaxBodyBytes            int `yaml:"max_body_bytes"`
+	MaxRedactionsPerRequest int `yaml:"max_redactions_per_request"`
+	MaxDepth                int `yaml:"max_depth"`
+}
+
+// ToLimits converts the YAML form into the internal Limits type.
+// Struct fields match one-for-one so a Go conversion is sufficient.
+func (s LimitsSpec) ToLimits() Limits {
+	return Limits(s)
+}
+
+// Validate returns nil iff cfg is internally consistent. Callers should
+// wire this into the overall config validation so startup fails closed.
+func (c *Config) Validate() error {
+	if !c.Enabled {
+		return nil // inert; no further checks.
+	}
+	if c.DefaultProfile == "" {
+		return errors.New("redact: default_profile required when enabled")
+	}
+	if _, ok := c.Profiles[c.DefaultProfile]; !ok {
+		return fmt.Errorf("redact: default_profile %q not defined in profiles", c.DefaultProfile)
+	}
+
+	validClasses := shippedClassNames()
+	for name, p := range c.Profiles {
+		if len(p.Classes) == 0 && len(p.Dictionaries) == 0 {
+			return fmt.Errorf("redact: profile %q has no classes or dictionaries", name)
+		}
+		for _, cl := range p.Classes {
+			if _, ok := validClasses[cl]; !ok {
+				return fmt.Errorf("redact: profile %q references unknown class %q", name, cl)
+			}
+		}
+		for _, dn := range p.Dictionaries {
+			if _, ok := c.Dictionaries[dn]; !ok {
+				return fmt.Errorf("redact: profile %q references unknown dictionary %q", name, dn)
+			}
+		}
+	}
+
+	for name, d := range c.Dictionaries {
+		if d.Class == "" {
+			return fmt.Errorf("redact: dictionary %q missing class", name)
+		}
+		if len(d.Entries) == 0 && d.EntriesFile == "" {
+			return fmt.Errorf("redact: dictionary %q has no entries or entries_file", name)
+		}
+	}
+	return nil
+}
+
+// BuildMatcher compiles the named profile into a Matcher. Entries from
+// dictionaries referenced by the profile must already be fully resolved
+// (EntriesFile loaded into Entries); the redact package does not perform
+// file I/O.
+func (c *Config) BuildMatcher(profileName string) (*Matcher, error) {
+	if !c.Enabled {
+		return nil, errors.New("redact: cannot build matcher with Enabled=false")
+	}
+	if profileName == "" {
+		profileName = c.DefaultProfile
+	}
+	profile, ok := c.Profiles[profileName]
+	if !ok {
+		return nil, fmt.Errorf("redact: profile %q not found", profileName)
+	}
+
+	m := &Matcher{}
+
+	// Filter the shipped class registry down to the profile's class set.
+	classSet := make(map[string]struct{}, len(profile.Classes))
+	for _, cl := range profile.Classes {
+		classSet[cl] = struct{}{}
+	}
+	for _, cp := range defaultRegistry() {
+		if _, ok := classSet[string(cp.class)]; ok {
+			m.patterns = append(m.patterns, cp)
+		}
+	}
+
+	// Attach each referenced dictionary. The redact package does not read
+	// the filesystem; if EntriesFile is set, the caller must resolve it
+	// into Entries before calling BuildMatcher. A dictionary with only
+	// EntriesFile set will surface here as an empty-entries build error,
+	// which we diagnose explicitly so operators don't think a validated
+	// config somehow failed at matcher build.
+	for _, dn := range profile.Dictionaries {
+		spec := c.Dictionaries[dn]
+		if len(spec.Entries) == 0 && spec.EntriesFile != "" {
+			return nil, fmt.Errorf("redact: build dictionary %q: entries_file %q was not resolved before BuildMatcher (caller must load file contents into Entries)", dn, spec.EntriesFile)
+		}
+		if err := m.AddDictionary(Dictionary{
+			Class:           Class(spec.Class),
+			Entries:         spec.Entries,
+			CaseInsensitive: spec.CaseInsensitive,
+			WordBoundary:    spec.WordBoundary,
+			Priority:        spec.Priority,
+		}); err != nil {
+			return nil, fmt.Errorf("redact: build dictionary %q: %w", dn, err)
+		}
+	}
+
+	return m, nil
+}
+
+// shippedClassNames returns the set of class string values known to the
+// shipped registry. Used for Validate to reject typos in operator profiles.
+func shippedClassNames() map[string]struct{} {
+	reg := defaultRegistry()
+	out := make(map[string]struct{}, len(reg))
+	for _, cp := range reg {
+		out[string(cp.class)] = struct{}{}
+	}
+	return out
+}
+
+// DefaultLimits returns a LimitsSpec populated with the package defaults,
+// suitable for emission in example configs and defaults functions.
+func DefaultLimits() LimitsSpec {
+	return LimitsSpec{
+		MaxBodyBytes:            DefaultMaxBodyBytes,
+		MaxRedactionsPerRequest: DefaultMaxRedactions,
+		MaxDepth:                DefaultMaxDepth,
+	}
+}
+
+// DefaultConfig returns a disabled redaction config suitable as the
+// zero-value embedded in pipelock's main Config. When the operator does
+// not supply a `redaction:` block, this is what they get — inert and safe.
+func DefaultConfig() Config {
+	return Config{
+		Enabled: false,
+		Limits:  DefaultLimits(),
+	}
+}

--- a/internal/redact/config.go
+++ b/internal/redact/config.go
@@ -94,7 +94,28 @@ func (s LimitsSpec) ToLimits() Limits {
 
 // Validate returns nil iff cfg is internally consistent. Callers should
 // wire this into the overall config validation so startup fails closed.
+//
+// Structural checks on allowlist_unparseable host entries and dictionary
+// class names run UNCONDITIONALLY — they are cheap and must not depend on
+// the Enabled gate, because a disabled config with malformed fields can
+// still be loaded, and the fields are security-sensitive once Enabled
+// flips on. Skipping structure checks when disabled would defeat the
+// fail-fast posture (bots already flagged this on 2026-04-19).
 func (c *Config) Validate() error {
+	// Structural: allowlist host entries. Runs before the Enabled gate.
+	for i, host := range c.AllowlistUnparseable {
+		if err := validateHostEntry(host); err != nil {
+			return fmt.Errorf("redact: allowlist_unparseable[%d] %q: %w", i, host, err)
+		}
+	}
+	// Structural: dictionary class names must match the placeholder-safe
+	// shape so a runtime BuildMatcher call doesn't reject a "valid" config.
+	for name, d := range c.Dictionaries {
+		if d.Class != "" && !classNameRe.MatchString(d.Class) {
+			return fmt.Errorf("redact: dictionary %q class %q must match [a-z0-9][a-z0-9_-]*", name, d.Class)
+		}
+	}
+
 	if !c.Enabled {
 		return nil // inert; no further checks.
 	}
@@ -128,12 +149,6 @@ func (c *Config) Validate() error {
 		}
 		if len(d.Entries) == 0 && d.EntriesFile == "" {
 			return fmt.Errorf("redact: dictionary %q has no entries or entries_file", name)
-		}
-	}
-
-	for i, host := range c.AllowlistUnparseable {
-		if err := validateHostEntry(host); err != nil {
-			return fmt.Errorf("redact: allowlist_unparseable[%d] %q: %w", i, host, err)
 		}
 	}
 	return nil

--- a/internal/redact/config.go
+++ b/internal/redact/config.go
@@ -6,6 +6,7 @@ package redact
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // Config is the top-level YAML config for redaction. Embedded into the
@@ -127,6 +128,48 @@ func (c *Config) Validate() error {
 		}
 		if len(d.Entries) == 0 && d.EntriesFile == "" {
 			return fmt.Errorf("redact: dictionary %q has no entries or entries_file", name)
+		}
+	}
+
+	for i, host := range c.AllowlistUnparseable {
+		if err := validateHostEntry(host); err != nil {
+			return fmt.Errorf("redact: allowlist_unparseable[%d] %q: %w", i, host, err)
+		}
+	}
+	return nil
+}
+
+// validateHostEntry rejects ambiguous host-allowlist entries so once v1b
+// enforcement lands the allowlist match semantics are unambiguous. The
+// rules: non-empty, no scheme/path/query, no port, no uppercase, no
+// leading/trailing dot, no consecutive dots, valid label characters only.
+func validateHostEntry(h string) error {
+	if h == "" {
+		return errors.New("empty")
+	}
+	if strings.ContainsAny(h, "/?#@") {
+		return errors.New("must not contain scheme, path, query, or userinfo")
+	}
+	if strings.ContainsRune(h, ':') {
+		return errors.New("must not contain a port (bare hostname only)")
+	}
+	if strings.ToLower(h) != h {
+		return errors.New("must be lowercase")
+	}
+	if strings.HasPrefix(h, ".") || strings.HasSuffix(h, ".") {
+		return errors.New("leading or trailing dot not permitted")
+	}
+	if strings.Contains(h, "..") {
+		return errors.New("consecutive dots not permitted")
+	}
+	for _, r := range h {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= '0' && r <= '9',
+			r == '-', r == '.', r == '*':
+			continue
+		default:
+			return fmt.Errorf("invalid character %q", r)
 		}
 	}
 	return nil

--- a/internal/redact/config_test.go
+++ b/internal/redact/config_test.go
@@ -251,6 +251,62 @@ func TestConfig_BuildMatcherUnresolvedEntriesFile(t *testing.T) {
 	}
 }
 
+// TestConfig_ValidateAllowlistUnparseable enforces strict host-entry
+// canonicalisation. GPT review #4 (2026-04-19): fuzzy entries would
+// produce ambiguous match semantics once v1b enforcement lands.
+func TestConfig_ValidateAllowlistUnparseable(t *testing.T) {
+	t.Parallel()
+	mkCfg := func(hosts ...string) *Config {
+		return &Config{
+			Enabled:              true,
+			DefaultProfile:       "p",
+			Profiles:             map[string]ProfileSpec{"p": {Classes: []string{"ipv4"}}},
+			AllowlistUnparseable: hosts,
+		}
+	}
+
+	rejectCases := []struct {
+		name string
+		host string
+	}{
+		{"empty", ""},
+		{"has-scheme", "https://api.example.com"},
+		{"has-path", "api.example.com/v1"},
+		{"has-query", "api.example.com?x=1"},
+		{"has-port", "api.example.com:443"},
+		{"uppercase", "API.example.com"},
+		{"leading-dot", ".api.example.com"},
+		{"trailing-dot", "api.example.com."},
+		{"double-dot", "api..example.com"},
+		{"invalid-char", "api_example.com"},
+	}
+	for _, tc := range rejectCases {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := mkCfg(tc.host).Validate()
+			if err == nil || !strings.Contains(err.Error(), "allowlist_unparseable") {
+				t.Fatalf("host %q should be rejected, got %v", tc.host, err)
+			}
+		})
+	}
+
+	acceptCases := []string{
+		"api.anthropic.com",
+		"api.openai.com",
+		"generativelanguage.googleapis.com",
+		"*.internal.example",
+		"my-host-42.example.com",
+	}
+	for _, h := range acceptCases {
+		t.Run("accept/"+h, func(t *testing.T) {
+			t.Parallel()
+			if err := mkCfg(h).Validate(); err != nil {
+				t.Fatalf("host %q should validate, got %v", h, err)
+			}
+		})
+	}
+}
+
 func TestConfig_LimitsSpecToLimitsPassthrough(t *testing.T) {
 	t.Parallel()
 	s := LimitsSpec{MaxBodyBytes: 1024, MaxRedactionsPerRequest: 42, MaxDepth: 5}

--- a/internal/redact/config_test.go
+++ b/internal/redact/config_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfig_ValidateDisabledInert(t *testing.T) {
+	t.Parallel()
+	c := Config{}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("disabled Config should validate, got %v", err)
+	}
+}
+
+func TestConfig_ValidateRequiresDefaultProfile(t *testing.T) {
+	t.Parallel()
+	c := Config{Enabled: true}
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "default_profile required") {
+		t.Fatalf("expected default_profile error, got %v", err)
+	}
+}
+
+func TestConfig_ValidateUnknownDefaultProfile(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Enabled:        true,
+		DefaultProfile: "does-not-exist",
+		Profiles:       map[string]ProfileSpec{"code": {Classes: []string{"aws-access-key"}}},
+	}
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "not defined in profiles") {
+		t.Fatalf("expected unknown-default error, got %v", err)
+	}
+}
+
+func TestConfig_ValidateUnknownClass(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Enabled:        true,
+		DefaultProfile: "p",
+		Profiles:       map[string]ProfileSpec{"p": {Classes: []string{"not-a-real-class"}}},
+	}
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "unknown class") {
+		t.Fatalf("expected unknown-class error, got %v", err)
+	}
+}
+
+func TestConfig_ValidateEmptyProfile(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Enabled:        true,
+		DefaultProfile: "p",
+		Profiles:       map[string]ProfileSpec{"p": {}},
+	}
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "no classes or dictionaries") {
+		t.Fatalf("expected empty-profile error, got %v", err)
+	}
+}
+
+func TestConfig_ValidateUnknownDictionaryRef(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Enabled:        true,
+		DefaultProfile: "p",
+		Profiles:       map[string]ProfileSpec{"p": {Dictionaries: []string{"missing"}}},
+	}
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "unknown dictionary") {
+		t.Fatalf("expected unknown-dict error, got %v", err)
+	}
+}
+
+func TestConfig_ValidateDictionaryMissingClass(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Enabled:        true,
+		DefaultProfile: "p",
+		Profiles: map[string]ProfileSpec{
+			"p": {Classes: []string{"ipv4"}, Dictionaries: []string{"d"}},
+		},
+		Dictionaries: map[string]DictionarySpec{"d": {Entries: []string{"x"}}},
+	}
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "missing class") {
+		t.Fatalf("expected missing-class error, got %v", err)
+	}
+}
+
+func TestConfig_ValidateDictionaryNoEntries(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Enabled:        true,
+		DefaultProfile: "p",
+		Profiles: map[string]ProfileSpec{
+			"p": {Classes: []string{"ipv4"}, Dictionaries: []string{"d"}},
+		},
+		Dictionaries: map[string]DictionarySpec{"d": {Class: "customer"}},
+	}
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "no entries") {
+		t.Fatalf("expected no-entries error, got %v", err)
+	}
+}
+
+func TestConfig_ValidatePassesForCompleteConfig(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Enabled:        true,
+		DefaultProfile: "code",
+		Profiles: map[string]ProfileSpec{
+			"code":     {Classes: []string{"aws-access-key", "github-token"}},
+			"business": {Classes: []string{"email", "ipv4"}, Dictionaries: []string{"customer"}},
+		},
+		Dictionaries: map[string]DictionarySpec{
+			"customer": {
+				Class:           "customer",
+				Entries:         []string{"AcmeCorp", "Contoso"},
+				CaseInsensitive: true,
+				WordBoundary:    true,
+				Priority:        75,
+			},
+		},
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("expected valid, got %v", err)
+	}
+}
+
+func TestConfig_BuildMatcherDefaultProfile(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Enabled:        true,
+		DefaultProfile: "code",
+		Profiles: map[string]ProfileSpec{
+			"code": {Classes: []string{"aws-access-key"}},
+		},
+	}
+	m, err := c.BuildMatcher("")
+	if err != nil {
+		t.Fatalf("BuildMatcher: %v", err)
+	}
+	matches := m.Scan("hit " + "AKIA" + "IOSFODNN7EXAMPLE yes")
+	if len(matches) != 1 || matches[0].Class != ClassAWSAccessKey {
+		t.Fatalf("expected 1 aws-access-key match, got %+v", matches)
+	}
+	// Code profile does NOT enable IPv4 — it shouldn't match.
+	ipMatches := m.Scan("ip 10.0.0.1 here")
+	for _, mv := range ipMatches {
+		if mv.Class == ClassIPv4 {
+			t.Fatalf("code profile leaked ipv4 match: %+v", ipMatches)
+		}
+	}
+}
+
+func TestConfig_BuildMatcherWithDictionary(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Enabled:        true,
+		DefaultProfile: "biz",
+		Profiles: map[string]ProfileSpec{
+			"biz": {Classes: []string{"ipv4"}, Dictionaries: []string{"customer"}},
+		},
+		Dictionaries: map[string]DictionarySpec{
+			"customer": {
+				Class:        "customer",
+				Entries:      []string{"AcmeCorp"},
+				WordBoundary: true,
+				Priority:     80,
+			},
+		},
+	}
+	m, err := c.BuildMatcher("biz")
+	if err != nil {
+		t.Fatalf("BuildMatcher: %v", err)
+	}
+	matches := m.Scan("sold AcmeCorp licenses for 10.0.0.1")
+	var foundCustomer, foundIP bool
+	for _, mv := range matches {
+		if mv.Class == Class("customer") {
+			foundCustomer = true
+		}
+		if mv.Class == ClassIPv4 {
+			foundIP = true
+		}
+	}
+	if !foundCustomer || !foundIP {
+		t.Fatalf("missing matches: customer=%v ipv4=%v; got %+v", foundCustomer, foundIP, matches)
+	}
+}
+
+func TestConfig_BuildMatcherRejectsDisabled(t *testing.T) {
+	t.Parallel()
+	c := DefaultConfig()
+	_, err := c.BuildMatcher("")
+	if err == nil || !strings.Contains(err.Error(), "Enabled=false") {
+		t.Fatalf("expected disabled error, got %v", err)
+	}
+}
+
+func TestConfig_BuildMatcherUnknownProfile(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Enabled:        true,
+		DefaultProfile: "code",
+		Profiles:       map[string]ProfileSpec{"code": {Classes: []string{"email"}}},
+	}
+	_, err := c.BuildMatcher("does-not-exist")
+	if err == nil || !strings.Contains(err.Error(), "profile \"does-not-exist\" not found") {
+		t.Fatalf("expected profile-not-found error, got %v", err)
+	}
+}
+
+// TestConfig_BuildMatcherUnresolvedEntriesFile diagnoses the footgun from
+// review finding #2 (2026-04-19): Validate passes when only entries_file
+// is set, but BuildMatcher needs Entries resolved. The error message must
+// name entries_file so operators understand what the caller needs to do.
+func TestConfig_BuildMatcherUnresolvedEntriesFile(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Enabled:        true,
+		DefaultProfile: "p",
+		Profiles: map[string]ProfileSpec{
+			"p": {Classes: []string{"ipv4"}, Dictionaries: []string{"d"}},
+		},
+		Dictionaries: map[string]DictionarySpec{
+			"d": {
+				Class:       "customer",
+				EntriesFile: "/etc/pipelock/dicts/customers.yaml",
+			},
+		},
+	}
+	// Validate must accept this (entries_file is caller responsibility).
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil (caller resolves entries_file)", err)
+	}
+	// BuildMatcher must fail-closed with a diagnostic error naming
+	// entries_file.
+	_, err := c.BuildMatcher("p")
+	if err == nil {
+		t.Fatalf("BuildMatcher must fail when entries_file is unresolved")
+	}
+	if !strings.Contains(err.Error(), "entries_file") {
+		t.Fatalf("error must mention entries_file, got: %v", err)
+	}
+}
+
+func TestConfig_LimitsSpecToLimitsPassthrough(t *testing.T) {
+	t.Parallel()
+	s := LimitsSpec{MaxBodyBytes: 1024, MaxRedactionsPerRequest: 42, MaxDepth: 5}
+	l := s.ToLimits()
+	if l.MaxBodyBytes != 1024 || l.MaxRedactionsPerRequest != 42 || l.MaxDepth != 5 {
+		t.Fatalf("pass-through broke: %+v", l)
+	}
+}
+
+func TestConfig_DefaultsInert(t *testing.T) {
+	t.Parallel()
+	d := DefaultConfig()
+	if d.Enabled {
+		t.Fatal("DefaultConfig must be disabled")
+	}
+	if d.Limits.MaxBodyBytes != DefaultMaxBodyBytes {
+		t.Fatalf("MaxBodyBytes = %d, want %d", d.Limits.MaxBodyBytes, DefaultMaxBodyBytes)
+	}
+	if err := d.Validate(); err != nil {
+		t.Fatalf("DefaultConfig should validate, got %v", err)
+	}
+}

--- a/internal/redact/config_test.go
+++ b/internal/redact/config_test.go
@@ -254,6 +254,37 @@ func TestConfig_BuildMatcherUnresolvedEntriesFile(t *testing.T) {
 // TestConfig_ValidateAllowlistUnparseable enforces strict host-entry
 // canonicalisation. GPT review #4 (2026-04-19): fuzzy entries would
 // produce ambiguous match semantics once v1b enforcement lands.
+// TestConfig_ValidateStructureWhenDisabled enforces the CodeRabbit finding
+// (2026-04-19) that structural fields must be checked even when the
+// feature is inert. Loading a malformed allowlist or dictionary class
+// now must fail at startup regardless of Enabled so the fail-fast
+// posture is consistent.
+func TestConfig_ValidateStructureWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	// Malformed allowlist entry, feature disabled — must still reject.
+	c := Config{
+		Enabled:              false,
+		AllowlistUnparseable: []string{"UPPERCASE.example.com"},
+	}
+	if err := c.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "allowlist_unparseable") {
+		t.Fatalf("disabled-with-bad-allowlist should still fail, got %v", err)
+	}
+
+	// Malformed dictionary class, feature disabled — must still reject.
+	c = Config{
+		Enabled: false,
+		Dictionaries: map[string]DictionarySpec{
+			"d": {Class: "Upper", Entries: []string{"x"}},
+		},
+	}
+	if err := c.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "must match") {
+		t.Fatalf("disabled-with-bad-dict-class should still fail, got %v", err)
+	}
+}
+
 func TestConfig_ValidateAllowlistUnparseable(t *testing.T) {
 	t.Parallel()
 	mkCfg := func(hosts ...string) *Config {

--- a/internal/redact/doc.go
+++ b/internal/redact/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package redact implements class-preserving, irreversible secret redaction
+// for pipelock request bodies bound for upstream LLM providers.
+//
+// The package holds no mapping from placeholder back to original; redaction
+// is one-way by design. See the redaction-v1 design spec for the full
+// semantic model and threat analysis.
+//
+// Invariants enforced by this package:
+//
+//   - No vault, no reversibility: the placeholder is terminal.
+//   - Whole-body scan: every string scalar in a parsed request body is
+//     scanned, regardless of field position. No cache-safe exemption.
+//   - Fail-closed: if redaction is configured and cannot be applied safely
+//     (unparseable body, overflow, unsupported transport), the request is
+//     blocked rather than forwarded.
+//   - Class-preserving placeholders: `<pl:CLASS:N>` retains semantic class
+//     so the upstream model can reason about type without seeing the value.
+package redact

--- a/internal/redact/doc.go
+++ b/internal/redact/doc.go
@@ -11,8 +11,10 @@
 // Invariants enforced by this package:
 //
 //   - No vault, no reversibility: the placeholder is terminal.
-//   - Whole-body scan: every string scalar in a parsed request body is
-//     scanned, regardless of field position. No cache-safe exemption.
+//   - Whole-body scan: every string scalar and every object key in a
+//     parsed request body is scanned at every nesting depth, regardless
+//     of field position. Numeric JSON scalars matching a redaction
+//     pattern fail closed. No cache-safe exemption.
 //   - Fail-closed: if redaction is configured and cannot be applied safely
 //     (unparseable body, overflow, unsupported transport), the request is
 //     blocked rather than forwarded.

--- a/internal/redact/errors.go
+++ b/internal/redact/errors.go
@@ -37,6 +37,16 @@ const (
 	// the same placeholder. Silently letting one key overwrite another
 	// changes the forwarded object's structure, so we fail closed.
 	ReasonKeyCollision BlockReason = "key_collision"
+	// ReasonSecretInNumericScalar — a numeric JSON scalar (json.Number)
+	// matched a redaction pattern. Rewriting to a string placeholder would
+	// change the JSON type and likely break the upstream; redacting is
+	// impossible without type-coercion risk, so we fail closed. Legitimate
+	// bodies should not carry secrets as bare numbers.
+	ReasonSecretInNumericScalar BlockReason = "secret_in_numeric_scalar"
+	// ReasonRemarshalFailed — the redacted tree could not be re-encoded
+	// to JSON. Distinguished from ReasonBodyUnparseable so telemetry can
+	// separate attacker-malformed input from an implementation bug.
+	ReasonRemarshalFailed BlockReason = "remarshal_failed"
 )
 
 // BlockError is returned by Rewrite when redaction cannot safely proceed.

--- a/internal/redact/errors.go
+++ b/internal/redact/errors.go
@@ -33,6 +33,10 @@ const (
 	// ReasonDepthExceeded — JSON structure exceeded the configured nesting
 	// depth cap (defensive against resource-exhaustion JSON).
 	ReasonDepthExceeded BlockReason = "json_depth_exceeded"
+	// ReasonKeyCollision — rewriting two different object keys produced
+	// the same placeholder. Silently letting one key overwrite another
+	// changes the forwarded object's structure, so we fail closed.
+	ReasonKeyCollision BlockReason = "key_collision"
 )
 
 // BlockError is returned by Rewrite when redaction cannot safely proceed.

--- a/internal/redact/errors.go
+++ b/internal/redact/errors.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import "errors"
+
+// BlockReason classifies a fail-closed outcome. Every redaction failure
+// mode is a separate constant so operators and telemetry can distinguish
+// them without parsing error messages.
+type BlockReason string
+
+const (
+	// ReasonBodyTooLarge — the request body exceeds the configured byte cap.
+	ReasonBodyTooLarge BlockReason = "body_too_large"
+	// ReasonBodyUnparseable — the body was expected to be JSON but did not
+	// parse.
+	ReasonBodyUnparseable BlockReason = "body_unparseable"
+	// ReasonNonJSONBody — Content-Type signaled non-JSON and the host is not
+	// on the operator's `allowlist_unparseable` list.
+	ReasonNonJSONBody BlockReason = "non_json_body"
+	// ReasonStreamingRequest — request used chunked or streaming transfer
+	// encoding which cannot be buffered safely.
+	ReasonStreamingRequest BlockReason = "streaming_request_unsupported"
+	// ReasonMultipart — request was multipart/form-data which v1 does not
+	// scan.
+	ReasonMultipart BlockReason = "multipart_unsupported"
+	// ReasonWebSocketFragmented — WebSocket message arrived with
+	// continuation frames.
+	ReasonWebSocketFragmented BlockReason = "ws_message_fragmented"
+	// ReasonOverflow — match count exceeded the per-request cap.
+	ReasonOverflow BlockReason = "redaction_overflow"
+	// ReasonDepthExceeded — JSON structure exceeded the configured nesting
+	// depth cap (defensive against resource-exhaustion JSON).
+	ReasonDepthExceeded BlockReason = "json_depth_exceeded"
+)
+
+// BlockError is returned by Rewrite when redaction cannot safely proceed.
+// Callers should treat it as a signal to refuse the request upstream.
+type BlockError struct {
+	Reason BlockReason
+	// MatchesBeforeBlock reports how many unique redactions were applied
+	// before the failure (0 when the failure prevents any scanning).
+	MatchesBeforeBlock int
+	// Detail is an optional human-readable hint. Not stable API — telemetry
+	// and receipts should key off Reason.
+	Detail string
+}
+
+// Error implements the error interface. The format is compact and safe for
+// logs: it never includes originals, only the block reason and count.
+func (e *BlockError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Detail != "" {
+		return "redact: blocked (" + string(e.Reason) + "): " + e.Detail
+	}
+	return "redact: blocked (" + string(e.Reason) + ")"
+}
+
+// Is makes BlockError comparable with errors.Is for a specific reason.
+// Callers can check `errors.Is(err, &redact.BlockError{Reason: ...})`.
+func (e *BlockError) Is(target error) bool {
+	if e == nil {
+		return false
+	}
+	var other *BlockError
+	if !errors.As(target, &other) {
+		return false
+	}
+	// Match on reason; empty reason in target matches any reason.
+	return other.Reason == "" || e.Reason == other.Reason
+}
+
+// newBlock is a shorthand for constructing a BlockError.
+func newBlock(reason BlockReason, matches int, detail string) *BlockError {
+	return &BlockError{Reason: reason, MatchesBeforeBlock: matches, Detail: detail}
+}

--- a/internal/redact/errors_test.go
+++ b/internal/redact/errors_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestBlockError_ErrorMessage(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		err        *BlockError
+		wantSubstr []string
+	}{
+		{
+			name: "with detail",
+			err:  &BlockError{Reason: ReasonOverflow, Detail: "10k cap"},
+			wantSubstr: []string{
+				"redact: blocked",
+				string(ReasonOverflow),
+				"10k cap",
+			},
+		},
+		{
+			name:       "reason only",
+			err:        &BlockError{Reason: ReasonBodyUnparseable},
+			wantSubstr: []string{"redact: blocked", string(ReasonBodyUnparseable)},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			msg := tc.err.Error()
+			for _, want := range tc.wantSubstr {
+				if !strings.Contains(msg, want) {
+					t.Errorf("message %q missing %q", msg, want)
+				}
+			}
+		})
+	}
+}
+
+func TestBlockError_NilSafe(t *testing.T) {
+	t.Parallel()
+	var e *BlockError
+	if got := e.Error(); got != "" {
+		t.Fatalf("nil error should produce empty string, got %q", got)
+	}
+	if e.Is(&BlockError{Reason: ReasonBodyTooLarge}) {
+		t.Fatal("nil Is should return false")
+	}
+}
+
+func TestBlockError_IsByReason(t *testing.T) {
+	t.Parallel()
+	err := newBlock(ReasonOverflow, 100, "")
+	if !errors.Is(err, &BlockError{Reason: ReasonOverflow}) {
+		t.Fatal("errors.Is should match on same reason")
+	}
+	if errors.Is(err, &BlockError{Reason: ReasonBodyTooLarge}) {
+		t.Fatal("errors.Is should not match on different reason")
+	}
+	// Empty-reason target matches any BlockError (sentinel).
+	if !errors.Is(err, &BlockError{}) {
+		t.Fatal("empty-reason target should match any BlockError")
+	}
+	// Non-BlockError target does not match.
+	if errors.Is(err, errors.New("unrelated")) {
+		t.Fatal("errors.Is should not match non-BlockError target")
+	}
+}
+
+func TestBlockError_ExposesMatchesBeforeBlock(t *testing.T) {
+	t.Parallel()
+	err := newBlock(ReasonOverflow, 42, "")
+	var be *BlockError
+	if !errors.As(err, &be) {
+		t.Fatal("errors.As failed")
+	}
+	if be.MatchesBeforeBlock != 42 {
+		t.Fatalf("MatchesBeforeBlock = %d, want 42", be.MatchesBeforeBlock)
+	}
+}

--- a/internal/redact/matcher.go
+++ b/internal/redact/matcher.go
@@ -1,0 +1,251 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var (
+	errNilMatcher      = errors.New("redact: nil matcher")
+	errEmptyDictionary = errors.New("redact: dictionary has no entries")
+	errInvalidClass    = errors.New("redact: class must match [a-z0-9][a-z0-9_-]*")
+)
+
+// classNameRe enforces the placeholder-safe shape for operator-supplied
+// class names. Shipped const classes already satisfy this. The constraint
+// exists so `<pl:CLASS:N>` cannot be perturbed by adversarial class names
+// (e.g. "foo>bar" produces `<pl:foo>bar:1>` which confuses downstream
+// parsers that split on `>`).
+var classNameRe = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
+
+// Match is a single redactable span inside a string scalar. Start and End
+// are byte offsets into the scalar (half-open, [Start, End)). Original is
+// the matched substring.
+type Match struct {
+	Class    Class
+	Start    int
+	End      int
+	Original string
+}
+
+// Matcher scans a string for redactable spans using a fixed set of class
+// patterns plus optional operator-supplied dictionaries. A Matcher is
+// immutable after construction and safe for concurrent use across
+// goroutines; each scan builds its own match list.
+type Matcher struct {
+	patterns []classPattern
+	// dictionaries compiled into a single alternation regex per class.
+	// Separate from patterns so dictionary matches can be disambiguated
+	// from regex matches in telemetry and tests.
+	dicts []dictPattern
+}
+
+// dictPattern is a compiled operator dictionary: one alternation regex
+// across all entries for a single class, with a per-pattern priority so
+// dictionary hits can dominate or defer to regex hits depending on operator
+// preference.
+type dictPattern struct {
+	class    Class
+	pattern  *regexp.Regexp
+	priority int
+}
+
+// NewDefaultMatcher returns a Matcher configured with the shipped class
+// registry and no operator dictionaries. Equivalent to a profile that
+// enables every structured class but no contextual entities.
+func NewDefaultMatcher() *Matcher {
+	return &Matcher{patterns: defaultRegistry()}
+}
+
+// Dictionary is an operator-supplied named list of literal strings that
+// should be redacted as a single semantic class. Each entry is escaped and
+// compiled into one alternation regex; all matches for the dictionary are
+// tagged with Class.
+type Dictionary struct {
+	// Class is the redaction class that dictionary hits are tagged with.
+	// Callers typically use a domain-specific class string like "customer"
+	// or "hostname" rather than a shipped const.
+	Class Class
+	// Entries is the literal set of strings to match. Empty entries are
+	// ignored silently.
+	Entries []string
+	// CaseInsensitive toggles case-insensitive matching via the `(?i)`
+	// regex flag. Defaults to false.
+	CaseInsensitive bool
+	// WordBoundary wraps the alternation in `\b...\b` so "corp" does not
+	// match inside "incorporation". Defaults to false.
+	WordBoundary bool
+	// Priority places dictionary hits in the overlap-resolution order
+	// relative to class regexes. A dictionary for "customer" that should
+	// win over the generic FQDN class sets priority above 50. Zero = lowest.
+	Priority int
+}
+
+// AddDictionary compiles d into a dictionary pattern and attaches it to
+// the matcher. Returns an error if the entries list is empty or if the
+// compiled regex would exceed RE2's implementation limits.
+//
+// Matcher is intended to be constructed once and then scanned against many
+// inputs; AddDictionary is not safe to call concurrently with Scan. Build
+// all dictionaries before handing the matcher to request handlers.
+func (m *Matcher) AddDictionary(d Dictionary) error {
+	if m == nil {
+		return errNilMatcher
+	}
+	if !classNameRe.MatchString(string(d.Class)) {
+		return fmt.Errorf("%w: got %q", errInvalidClass, string(d.Class))
+	}
+	// Strip empties and deduplicate while preserving order of first
+	// occurrence for deterministic regex output (helps testing).
+	seen := make(map[string]struct{}, len(d.Entries))
+	pruned := make([]string, 0, len(d.Entries))
+	for _, e := range d.Entries {
+		if e == "" {
+			continue
+		}
+		if _, ok := seen[e]; ok {
+			continue
+		}
+		seen[e] = struct{}{}
+		pruned = append(pruned, e)
+	}
+	if len(pruned) == 0 {
+		return errEmptyDictionary
+	}
+
+	// Longest literals first prevents prefix entries from shadowing a longer
+	// secret in the same alternation (e.g. "dc01" before "dc01.corp.local").
+	sort.SliceStable(pruned, func(i, j int) bool {
+		return len(pruned[i]) > len(pruned[j])
+	})
+
+	// Escape regex metachars in each entry, join with `|`.
+	escaped := make([]string, len(pruned))
+	for i, e := range pruned {
+		escaped[i] = regexp.QuoteMeta(e)
+	}
+	body := strings.Join(escaped, "|")
+
+	pattern := "(?:" + body + ")"
+	if d.WordBoundary {
+		pattern = `\b` + pattern + `\b`
+	}
+	if d.CaseInsensitive {
+		pattern = "(?i)" + pattern
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return err
+	}
+	m.dicts = append(m.dicts, dictPattern{
+		class:    d.Class,
+		pattern:  re,
+		priority: d.Priority,
+	})
+	return nil
+}
+
+// Scan returns all redactable matches in s, with overlapping spans resolved
+// by priority (highest wins) then by leftmost-longest. Returned matches are
+// sorted by Start ascending and do not overlap.
+func (m *Matcher) Scan(s string) []Match {
+	if s == "" || m == nil {
+		return nil
+	}
+
+	var raw []Match
+	for _, cp := range m.patterns {
+		for _, loc := range cp.pattern.FindAllStringIndex(s, -1) {
+			raw = append(raw, Match{
+				Class:    cp.class,
+				Start:    loc[0],
+				End:      loc[1],
+				Original: s[loc[0]:loc[1]],
+			})
+		}
+	}
+	for _, dp := range m.dicts {
+		for _, loc := range dp.pattern.FindAllStringIndex(s, -1) {
+			raw = append(raw, Match{
+				Class:    dp.class,
+				Start:    loc[0],
+				End:      loc[1],
+				Original: s[loc[0]:loc[1]],
+			})
+		}
+	}
+
+	return resolveOverlaps(raw, m.priorityLookup())
+}
+
+// priorityLookup returns a map from Class to priority for overlap
+// resolution. Called per Scan so dictionaries added after construction (not
+// supported in v1, but defensive) still resolve correctly.
+func (m *Matcher) priorityLookup() map[Class]int {
+	out := make(map[Class]int, len(m.patterns)+len(m.dicts))
+	for _, cp := range m.patterns {
+		// Keep the max priority seen for a class (same class can have
+		// multiple underlying regexes in theory; use the strongest).
+		if p, ok := out[cp.class]; !ok || cp.priority > p {
+			out[cp.class] = cp.priority
+		}
+	}
+	for _, dp := range m.dicts {
+		if p, ok := out[dp.class]; !ok || dp.priority > p {
+			out[dp.class] = dp.priority
+		}
+	}
+	return out
+}
+
+// resolveOverlaps picks a non-overlapping subset of raw matches. The rule:
+//  1. Sort by (priority desc, start asc, length desc).
+//  2. Walk in that order, admitting a match if its span is free; otherwise
+//     drop it.
+//  3. Re-sort the admitted set by Start ascending so callers can rewrite
+//     the string in a single left-to-right pass.
+func resolveOverlaps(raw []Match, priorityOf map[Class]int) []Match {
+	if len(raw) <= 1 {
+		// Even a single match benefits from the Start-ascending sort.
+		sort.SliceStable(raw, func(i, j int) bool { return raw[i].Start < raw[j].Start })
+		return raw
+	}
+	sort.SliceStable(raw, func(i, j int) bool {
+		pi, pj := priorityOf[raw[i].Class], priorityOf[raw[j].Class]
+		if pi != pj {
+			return pi > pj
+		}
+		if raw[i].Start != raw[j].Start {
+			return raw[i].Start < raw[j].Start
+		}
+		return (raw[i].End - raw[i].Start) > (raw[j].End - raw[j].Start)
+	})
+
+	admitted := make([]Match, 0, len(raw))
+	// Interval tree would be faster but overkill for this size; a simple
+	// sorted list with linear check is fine for typical request bodies.
+	for _, cand := range raw {
+		if overlapsAny(cand, admitted) {
+			continue
+		}
+		admitted = append(admitted, cand)
+	}
+	sort.SliceStable(admitted, func(i, j int) bool { return admitted[i].Start < admitted[j].Start })
+	return admitted
+}
+
+func overlapsAny(c Match, adm []Match) bool {
+	for _, a := range adm {
+		if c.Start < a.End && a.Start < c.End {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/redact/matcher_test.go
+++ b/internal/redact/matcher_test.go
@@ -1,0 +1,274 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestMatcher_AddDictionaryBasic(t *testing.T) {
+	t.Parallel()
+	m := NewDefaultMatcher()
+	if err := m.AddDictionary(Dictionary{
+		Class:        Class("customer"),
+		Entries:      []string{"AcmeCorp", "Contoso"},
+		WordBoundary: true,
+		Priority:     55,
+	}); err != nil {
+		t.Fatalf("AddDictionary: %v", err)
+	}
+
+	matches := m.Scan("AcmeCorp was acquired by Contoso last year")
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 dictionary matches, got %d: %+v", len(matches), matches)
+	}
+	for _, mv := range matches {
+		if mv.Class != Class("customer") {
+			t.Errorf("unexpected class %s for %q", mv.Class, mv.Original)
+		}
+	}
+}
+
+func TestMatcher_DictionaryCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	m := NewDefaultMatcher()
+	if err := m.AddDictionary(Dictionary{
+		Class:           Class("hostname"),
+		Entries:         []string{"dc01"},
+		CaseInsensitive: true,
+		WordBoundary:    true,
+	}); err != nil {
+		t.Fatalf("AddDictionary: %v", err)
+	}
+
+	cases := []string{"DC01 is down", "dc01 is down", "Dc01 is down"}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			t.Parallel()
+			matches := m.Scan(c)
+			found := false
+			for _, mv := range matches {
+				if mv.Class == Class("hostname") {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("case-insensitive dict did not match %q", c)
+			}
+		})
+	}
+}
+
+func TestMatcher_DictionaryWordBoundary(t *testing.T) {
+	t.Parallel()
+	m := NewDefaultMatcher()
+	if err := m.AddDictionary(Dictionary{
+		Class:        Class("codename"),
+		Entries:      []string{"Phoenix"},
+		WordBoundary: true,
+	}); err != nil {
+		t.Fatalf("AddDictionary: %v", err)
+	}
+
+	// "Phoenixville" should NOT match (word-boundary).
+	matches := m.Scan("I grew up in Phoenixville PA")
+	for _, mv := range matches {
+		if mv.Class == Class("codename") {
+			t.Fatalf("word-boundary should have prevented match, got %+v", mv)
+		}
+	}
+	// "Project Phoenix" MUST match.
+	matches = m.Scan("Operation Phoenix launches Tuesday")
+	found := false
+	for _, mv := range matches {
+		if mv.Class == Class("codename") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected dictionary match on word-bounded 'Phoenix'")
+	}
+}
+
+func TestMatcher_DictionaryLongestLiteralWins(t *testing.T) {
+	t.Parallel()
+	m := NewDefaultMatcher()
+	if err := m.AddDictionary(Dictionary{
+		Class:        Class("hostname"),
+		Entries:      []string{"dc01", "dc01.corp.local"},
+		WordBoundary: true,
+	}); err != nil {
+		t.Fatalf("AddDictionary: %v", err)
+	}
+
+	matches := m.Scan("ssh dc01.corp.local now")
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 dictionary match, got %d: %+v", len(matches), matches)
+	}
+	if got := matches[0].Original; got != "dc01.corp.local" {
+		t.Fatalf("dictionary matched prefix %q, want full literal %q", got, "dc01.corp.local")
+	}
+}
+
+func TestMatcher_DictionaryDedupAndEscape(t *testing.T) {
+	t.Parallel()
+	m := NewDefaultMatcher()
+	// Duplicates and regex metachars in entries must be handled safely.
+	err := m.AddDictionary(Dictionary{
+		Class:   Class("label"),
+		Entries: []string{"foo", "foo", "", "a.b.c", `x[y]`},
+	})
+	if err != nil {
+		t.Fatalf("AddDictionary escape/dedup: %v", err)
+	}
+
+	// "a.b.c" is a regex meta-containing literal; escape must work.
+	matches := m.Scan(`the literal a.b.c and x[y] are here`)
+	if len(matches) < 2 {
+		t.Fatalf("expected dictionary hits on escaped literals, got %d", len(matches))
+	}
+}
+
+func TestMatcher_AddDictionaryEmpty(t *testing.T) {
+	t.Parallel()
+	m := NewDefaultMatcher()
+	err := m.AddDictionary(Dictionary{Class: Class("empty")})
+	if !errors.Is(err, errEmptyDictionary) {
+		t.Fatalf("expected errEmptyDictionary, got %v", err)
+	}
+	// All-empty entries is equivalent to no entries.
+	err = m.AddDictionary(Dictionary{Class: Class("empty"), Entries: []string{"", ""}})
+	if !errors.Is(err, errEmptyDictionary) {
+		t.Fatalf("all-empty entries: expected errEmptyDictionary, got %v", err)
+	}
+}
+
+func TestMatcher_AddDictionaryNil(t *testing.T) {
+	t.Parallel()
+	var m *Matcher
+	err := m.AddDictionary(Dictionary{Class: Class("x"), Entries: []string{"a"}})
+	if !errors.Is(err, errNilMatcher) {
+		t.Fatalf("expected errNilMatcher, got %v", err)
+	}
+}
+
+// TestMatcher_AddDictionaryInvalidClassName enforces that operator-supplied
+// class names cannot perturb the `<pl:CLASS:N>` placeholder by containing
+// reserved syntax characters. Review finding #3 (2026-04-19).
+func TestMatcher_AddDictionaryInvalidClassName(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"",              // empty
+		"Upper",         // uppercase banned for determinism
+		"with space",    // whitespace
+		"with:colon",    // colon would confuse placeholder parser
+		"with<angle",    // angle brackets break placeholder syntax
+		"with>angle",    // same
+		"_starts-under", // must start with alphanumeric
+		"-starts-dash",  // same
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			t.Parallel()
+			m := NewDefaultMatcher()
+			err := m.AddDictionary(Dictionary{
+				Class:   Class(c),
+				Entries: []string{"foo"},
+			})
+			if !errors.Is(err, errInvalidClass) {
+				t.Fatalf("AddDictionary(%q) = %v, want errInvalidClass", c, err)
+			}
+		})
+	}
+}
+
+func TestMatcher_DictionaryPriorityDominates(t *testing.T) {
+	t.Parallel()
+	m := NewDefaultMatcher()
+	// FQDN has priority 50. Give our customer-name dict priority 75 so the
+	// operator-supplied label wins over generic FQDN for "corp.local".
+	if err := m.AddDictionary(Dictionary{
+		Class:    Class("customer"),
+		Entries:  []string{"corp.local"},
+		Priority: 75,
+	}); err != nil {
+		t.Fatalf("AddDictionary: %v", err)
+	}
+	matches := m.Scan("visit corp.local for the dashboard")
+	classes := make([]string, 0, len(matches))
+	for _, mv := range matches {
+		classes = append(classes, string(mv.Class))
+	}
+	found := false
+	for _, c := range classes {
+		if c == "customer" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("dictionary-priority expected 'customer' class, got %v", classes)
+	}
+	for _, c := range classes {
+		if c == string(ClassFQDN) {
+			t.Fatalf("generic FQDN should have been suppressed by customer dict, got %v", classes)
+		}
+	}
+}
+
+func TestMatcher_DictionaryScanInJSON(t *testing.T) {
+	t.Parallel()
+	m := NewDefaultMatcher()
+	if err := m.AddDictionary(Dictionary{
+		Class:        Class("codename"),
+		Entries:      []string{"Bluebird"},
+		WordBoundary: true,
+	}); err != nil {
+		t.Fatalf("AddDictionary: %v", err)
+	}
+	body := []byte(`{"note": "Project Bluebird is red."}`)
+	out, report, err := RewriteJSON(body, m, NewRedactor(), Limits{})
+	if err != nil {
+		t.Fatalf("RewriteJSON: %v", err)
+	}
+	if report.TotalRedactions != 1 {
+		t.Fatalf("expected 1 redaction, got %d", report.TotalRedactions)
+	}
+	if strings.Contains(string(out), "Bluebird") {
+		t.Fatalf("codename leaked: %s", out)
+	}
+	if !strings.Contains(string(out), "<pl:codename:1>") {
+		t.Fatalf("codename placeholder missing: %s", out)
+	}
+}
+
+func TestMatcher_DictionaryPrefixShadowDoesNotLeakTail(t *testing.T) {
+	t.Parallel()
+	m := &Matcher{}
+	if err := m.AddDictionary(Dictionary{
+		Class:        Class("hostname"),
+		Entries:      []string{"dc01", "dc01.corp.local"},
+		WordBoundary: true,
+	}); err != nil {
+		t.Fatalf("AddDictionary: %v", err)
+	}
+
+	body := []byte(`{"cmd":"ssh dc01.corp.local now"}`)
+	out, report, err := RewriteJSON(body, m, NewRedactor(), Limits{})
+	if err != nil {
+		t.Fatalf("RewriteJSON: %v", err)
+	}
+	if report.TotalRedactions != 1 {
+		t.Fatalf("expected 1 redaction, got %d", report.TotalRedactions)
+	}
+	outStr := string(out)
+	if strings.Contains(outStr, ".corp.local") {
+		t.Fatalf("dictionary prefix-shadow leaked tail: %s", outStr)
+	}
+	if !strings.Contains(outStr, "<pl:hostname:1>") {
+		t.Fatalf("hostname placeholder missing: %s", outStr)
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import "fmt"
+
+// Class identifies a semantic class for a redacted value.
+// Placeholders preserve the class so the upstream model retains type
+// information ("<pl:aws-access-key:1>" rather than an opaque token).
+type Class string
+
+// Standard redaction classes. Callers may use any string. The first block is
+// the built-in matcher surface shipped with v1. The second block reserves
+// stable class labels for future profiles that are not matched by the v1
+// built-in regex registry yet.
+const (
+	ClassIPv4          Class = "ipv4"
+	ClassIPv6          Class = "ipv6"
+	ClassCIDR          Class = "cidr"
+	ClassFQDN          Class = "fqdn"
+	ClassEmail         Class = "email"
+	ClassAWSAccessKey  Class = "aws-access-key"
+	ClassGoogleAPIKey  Class = "google-api-key"
+	ClassGitHubToken   Class = "github-token"
+	ClassSlackToken    Class = "slack-token"
+	ClassJWT           Class = "jwt"
+	ClassHashMD5       Class = "hash-md5"
+	ClassHashSHA1      Class = "hash-sha1"
+	ClassHashSHA256    Class = "hash-sha256"
+	ClassHashSHA512    Class = "hash-sha512"
+	ClassMAC           Class = "mac"
+	ClassSSN           Class = "ssn"
+	ClassCreditCard    Class = "credit-card"
+	ClassSSHPrivateKey Class = "ssh-private-key"
+	ClassADUser        Class = "ad-user"
+)
+
+// Reserved class labels for future profiles or operator-defined use.
+const (
+	ClassAWSSecretKey Class = "aws-secret-key"
+	ClassBearer       Class = "bearer"
+	ClassHashNTLM     Class = "hash-ntlm"
+	ClassCredential   Class = "credential"
+)
+
+// Redactor manages per-request redaction state: sequence numbering per class
+// and value-level deduplication. A fresh Redactor must be created per request.
+// Across requests, placeholder numbers restart from 1 per class — no
+// cross-request correlation is exposed upstream (redaction-v1 spec §5.3).
+//
+// Not goroutine-safe. DLP scans a request body on a single goroutine and the
+// Redactor is scoped to that scan. Callers that need concurrent use must wrap
+// externally.
+type Redactor struct {
+	counters map[Class]int
+	dedup    map[Class]map[string]string
+	total    int
+}
+
+// NewRedactor returns a fresh per-request Redactor.
+func NewRedactor() *Redactor {
+	return &Redactor{
+		counters: make(map[Class]int),
+		dedup:    make(map[Class]map[string]string),
+	}
+}
+
+// Placeholder returns the typed placeholder for (class, original). First call
+// for a (class, original) pair generates a new numbered placeholder of the
+// form "<pl:CLASS:N>". Subsequent calls for the same pair return the same
+// placeholder (per-request dedup). Sequence numbers are per-class, starting
+// at 1.
+func (r *Redactor) Placeholder(class Class, original string) string {
+	bucket, ok := r.dedup[class]
+	if !ok {
+		bucket = make(map[string]string)
+		r.dedup[class] = bucket
+	}
+	if existing, found := bucket[original]; found {
+		return existing
+	}
+	r.counters[class]++
+	ph := fmt.Sprintf("<pl:%s:%d>", string(class), r.counters[class])
+	bucket[original] = ph
+	r.total++
+	return ph
+}
+
+// Total returns the count of unique redactions applied so far — every dedup
+// hit counts once, regardless of how many times the same value appeared.
+func (r *Redactor) Total() int {
+	return r.total
+}
+
+func (r *Redactor) seen(class Class, original string) bool {
+	if r == nil {
+		return false
+	}
+	bucket, ok := r.dedup[class]
+	if !ok {
+		return false
+	}
+	_, ok = bucket[original]
+	return ok
+}
+
+// ByClass returns a copy of per-class unique-redaction counts. Safe for the
+// caller to retain: mutating the returned map does not affect internal state.
+func (r *Redactor) ByClass() map[Class]int {
+	out := make(map[Class]int, len(r.counters))
+	for k, v := range r.counters {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -71,7 +71,16 @@ func NewRedactor() *Redactor {
 // form "<pl:CLASS:N>". Subsequent calls for the same pair return the same
 // placeholder (per-request dedup). Sequence numbers are per-class, starting
 // at 1.
+//
+// If class does not match the safe placeholder shape (lowercase, digits,
+// hyphens, underscores, starting with alphanumeric) the call coerces class
+// to the sentinel "invalid" so downstream parsers never see a perturbed
+// placeholder. AddDictionary rejects malformed class names up front; this
+// defensive check catches any direct caller that bypasses that API.
 func (r *Redactor) Placeholder(class Class, original string) string {
+	if !safePlaceholderClass(class) {
+		class = Class("invalid")
+	}
 	bucket, ok := r.dedup[class]
 	if !ok {
 		bucket = make(map[string]string)
@@ -85,6 +94,31 @@ func (r *Redactor) Placeholder(class Class, original string) string {
 	bucket[original] = ph
 	r.total++
 	return ph
+}
+
+// safePlaceholderClass reports whether c matches the placeholder-safe
+// shape `[a-z0-9][a-z0-9_-]*`. Checked by hand (not via regex) so this
+// runs in Placeholder's hot path without regex-compile amortisation
+// surprises during the first call.
+func safePlaceholderClass(c Class) bool {
+	s := string(c)
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			continue
+		case r == '-' || r == '_':
+			if i == 0 {
+				return false
+			}
+			continue
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // Total returns the count of unique redactions applied so far — every dedup

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Common expected placeholder values. Extracted to satisfy goconst.
+const (
+	wantIPv4First = "<pl:ipv4:1>"
+)
+
+func TestRedactor_SingleMatchFirstPlaceholder(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor()
+	got := r.Placeholder(ClassIPv4, "192.0.2.104")
+	if got != wantIPv4First {
+		t.Fatalf("first placeholder = %q, want %q", got, wantIPv4First)
+	}
+	if r.Total() != 1 {
+		t.Fatalf("total = %d, want 1", r.Total())
+	}
+}
+
+func TestRedactor_MultipleDistinctSameClass(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor()
+	cases := []struct {
+		original string
+		want     string
+	}{
+		{"192.0.2.104", wantIPv4First},
+		{"192.168.1.5", "<pl:ipv4:2>"},
+		{"127.0.0.1", "<pl:ipv4:3>"},
+	}
+	for _, tc := range cases {
+		if got := r.Placeholder(ClassIPv4, tc.original); got != tc.want {
+			t.Errorf("Placeholder(%q) = %q, want %q", tc.original, got, tc.want)
+		}
+	}
+	if r.Total() != 3 {
+		t.Fatalf("total = %d, want 3", r.Total())
+	}
+}
+
+func TestRedactor_SameValueDeduplicated(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor()
+	first := r.Placeholder(ClassFQDN, "dc01.corp.local")
+	second := r.Placeholder(ClassFQDN, "dc01.corp.local")
+	third := r.Placeholder(ClassFQDN, "dc01.corp.local")
+	if first != "<pl:fqdn:1>" {
+		t.Fatalf("first = %q, want <pl:fqdn:1>", first)
+	}
+	if second != first || third != first {
+		t.Fatalf("dedup broke: first=%q second=%q third=%q", first, second, third)
+	}
+	if r.Total() != 1 {
+		t.Fatalf("total = %d after 3 lookups of same value, want 1", r.Total())
+	}
+}
+
+func TestRedactor_DifferentClassesHaveIndependentCounters(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor()
+	cases := []struct {
+		class    Class
+		original string
+		want     string
+	}{
+		{ClassIPv4, "10.0.0.1", "<pl:ipv4:1>"},
+		{ClassFQDN, "one.example", "<pl:fqdn:1>"},
+		{ClassIPv4, "10.0.0.2", "<pl:ipv4:2>"},
+		{ClassEmail, "a@b", "<pl:email:1>"},
+		{ClassFQDN, "two.example", "<pl:fqdn:2>"},
+		{ClassIPv4, "10.0.0.3", "<pl:ipv4:3>"},
+	}
+	for _, tc := range cases {
+		if got := r.Placeholder(tc.class, tc.original); got != tc.want {
+			t.Errorf("Placeholder(%s, %q) = %q, want %q", tc.class, tc.original, got, tc.want)
+		}
+	}
+}
+
+func TestRedactor_SequenceResetsAcrossInstances(t *testing.T) {
+	t.Parallel()
+	// Request 1
+	r1 := NewRedactor()
+	r1.Placeholder(ClassIPv4, "10.0.0.1")
+	r1.Placeholder(ClassIPv4, "10.0.0.2")
+	// Request 2: fresh Redactor starts numbering at 1 even for the same value.
+	r2 := NewRedactor()
+	got := r2.Placeholder(ClassIPv4, "10.0.0.1")
+	if got != wantIPv4First {
+		t.Fatalf("second-instance placeholder = %q, want %q", got, wantIPv4First)
+	}
+}
+
+func TestRedactor_ByClassAndTotalReport(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor()
+	r.Placeholder(ClassIPv4, "10.0.0.1")
+	r.Placeholder(ClassIPv4, "10.0.0.2")
+	r.Placeholder(ClassIPv4, "10.0.0.1") // dedup, does not increment
+	r.Placeholder(ClassFQDN, "one.example")
+	r.Placeholder(ClassAWSAccessKey, "AKIA"+"IOSFODNN7EXAMPLE")
+
+	if r.Total() != 4 {
+		t.Fatalf("total = %d, want 4", r.Total())
+	}
+	wantByClass := map[Class]int{
+		ClassIPv4:         2,
+		ClassFQDN:         1,
+		ClassAWSAccessKey: 1,
+	}
+	if got := r.ByClass(); !reflect.DeepEqual(got, wantByClass) {
+		t.Fatalf("ByClass() = %v, want %v", got, wantByClass)
+	}
+}
+
+func TestRedactor_ByClassReturnsCopy(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor()
+	r.Placeholder(ClassIPv4, "10.0.0.1")
+	snapshot := r.ByClass()
+	snapshot[ClassIPv4] = 99
+	if r.ByClass()[ClassIPv4] != 1 {
+		t.Fatalf("mutating ByClass() result affected internal state")
+	}
+}
+
+func TestRedactor_BuiltInClassesFormatCorrectly(t *testing.T) {
+	t.Parallel()
+	classes := []Class{
+		ClassIPv4, ClassIPv6, ClassCIDR, ClassFQDN, ClassEmail,
+		ClassAWSAccessKey, ClassGoogleAPIKey,
+		ClassGitHubToken, ClassSlackToken, ClassJWT,
+		ClassHashMD5, ClassHashSHA1, ClassHashSHA256, ClassHashSHA512,
+		ClassMAC, ClassSSN, ClassCreditCard,
+		ClassSSHPrivateKey, ClassADUser,
+	}
+	for _, c := range classes {
+		t.Run(string(c), func(t *testing.T) {
+			t.Parallel()
+			r := NewRedactor()
+			got := r.Placeholder(c, "value")
+			want := "<pl:" + string(c) + ":1>"
+			if got != want {
+				t.Fatalf("Placeholder(%s) = %q, want %q", c, got, want)
+			}
+		})
+	}
+}
+
+func TestRedactor_ReservedClassesFormatCorrectly(t *testing.T) {
+	t.Parallel()
+	classes := []Class{
+		ClassAWSSecretKey,
+		ClassBearer,
+		ClassHashNTLM,
+		ClassCredential,
+	}
+	for _, c := range classes {
+		t.Run(string(c), func(t *testing.T) {
+			t.Parallel()
+			r := NewRedactor()
+			got := r.Placeholder(c, "value")
+			want := "<pl:" + string(c) + ":1>"
+			if got != want {
+				t.Fatalf("Placeholder(%s) = %q, want %q", c, got, want)
+			}
+		})
+	}
+}
+
+func TestRedactor_CustomClassAccepted(t *testing.T) {
+	t.Parallel()
+	// Operator-dictionary classes (e.g. "customer", "hostname", "codename") are
+	// not in the shipped constants but must work end-to-end.
+	r := NewRedactor()
+	if got, want := r.Placeholder(Class("customer"), "AcmeCorp"), "<pl:customer:1>"; got != want {
+		t.Fatalf("custom class = %q, want %q", got, want)
+	}
+}
+
+func TestRedactor_EmptyOriginalStillPlaceholders(t *testing.T) {
+	t.Parallel()
+	// Defensive: DLP generally matches non-empty, but an empty original must
+	// not panic and must still number deterministically.
+	r := NewRedactor()
+	first := r.Placeholder(ClassIPv4, "")
+	second := r.Placeholder(ClassIPv4, "")
+	if first != wantIPv4First {
+		t.Fatalf("empty original first = %q, want %q", first, wantIPv4First)
+	}
+	if second != first {
+		t.Fatalf("empty original not deduped: first=%q second=%q", first, second)
+	}
+	if r.Total() != 1 {
+		t.Fatalf("total = %d, want 1", r.Total())
+	}
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -186,6 +186,40 @@ func TestRedactor_CustomClassAccepted(t *testing.T) {
 	}
 }
 
+// TestRedactor_PlaceholderCoercesInvalidClass guards against direct callers
+// that bypass AddDictionary validation. GPT review #3 (2026-04-19): a
+// malformed class with `:`, `>`, whitespace, or control characters could
+// perturb `<pl:CLASS:N>` for downstream parsers. Placeholder coerces any
+// malformed class to the sentinel "invalid".
+func TestRedactor_PlaceholderCoercesInvalidClass(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		class Class
+	}{
+		{"empty", Class("")},
+		{"uppercase", Class("Upper")},
+		{"colon", Class("with:colon")},
+		{"angle-open", Class("with<angle")},
+		{"angle-close", Class("with>angle")},
+		{"space", Class("with space")},
+		{"leading-hyphen", Class("-lead")},
+		{"leading-underscore", Class("_lead")},
+		{"control-char", Class("a\x00b")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := NewRedactor()
+			got := r.Placeholder(tc.class, "value")
+			want := "<pl:invalid:1>"
+			if got != want {
+				t.Fatalf("Placeholder(%q) = %q, want %q", tc.class, got, want)
+			}
+		})
+	}
+}
+
 func TestRedactor_EmptyOriginalStillPlaceholders(t *testing.T) {
 	t.Parallel()
 	// Defensive: DLP generally matches non-empty, but an empty original must

--- a/internal/redact/rewrite.go
+++ b/internal/redact/rewrite.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import "strings"
+
+// RewriteString applies matches (pre-sorted by Start ascending, non-
+// overlapping) to s, replacing each match with a typed placeholder from r.
+// Returns the rewritten string. Matches are consumed in order; any match
+// whose Start < previous.End is silently skipped (defensive — Scan should
+// not emit overlapping matches).
+func RewriteString(s string, matches []Match, r *Redactor) string {
+	if len(matches) == 0 || s == "" {
+		return s
+	}
+	var b strings.Builder
+	// Rough capacity hint: original length plus slack for placeholders.
+	b.Grow(len(s) + len(matches)*16)
+	cursor := 0
+	for _, m := range matches {
+		if m.Start < cursor || m.Start < 0 || m.End > len(s) || m.End <= m.Start {
+			continue
+		}
+		b.WriteString(s[cursor:m.Start])
+		b.WriteString(r.Placeholder(m.Class, m.Original))
+		cursor = m.End
+	}
+	b.WriteString(s[cursor:])
+	return b.String()
+}

--- a/internal/redact/rewrite_test.go
+++ b/internal/redact/rewrite_test.go
@@ -273,6 +273,24 @@ func TestRewriteJSON_JSONKeyBypassClosed(t *testing.T) {
 	}
 }
 
+// TestRewriteJSON_KeyCollisionBlocks guards against silent sibling-field
+// drop when the rewritten version of one key equals the literal value of
+// another key in the same object. GPT review #2 (2026-04-19).
+func TestRewriteJSON_KeyCollisionBlocks(t *testing.T) {
+	t.Parallel()
+	// First key is a literal placeholder-shaped string (untouched).
+	// Second key contains an IPv4 that rewrites to the same string.
+	body := []byte(`{"<pl:ipv4:1>": "one", "10.0.0.1": "two"}`)
+	_, _, err := RewriteJSON(body, NewDefaultMatcher(), NewRedactor(), Limits{})
+	be, ok := asBlockError(err)
+	if !ok {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+	if be.Reason != ReasonKeyCollision {
+		t.Fatalf("reason = %q, want %q", be.Reason, ReasonKeyCollision)
+	}
+}
+
 func TestRewriteJSON_JSONKeyRedactionDedupesWithValue(t *testing.T) {
 	t.Parallel()
 	// Same secret appearing as both a key and a value should dedup to one

--- a/internal/redact/rewrite_test.go
+++ b/internal/redact/rewrite_test.go
@@ -306,6 +306,42 @@ func TestRewriteJSON_JSONKeyRedactionDedupesWithValue(t *testing.T) {
 	}
 }
 
+// TestRewriteJSON_NumericScalarBypassBlocked guards the bypass reported
+// in CodeRabbit review (2026-04-19): a credit card stuffed into a bare
+// JSON number used to fall through the walker untouched because
+// json.Number wasn't scanned. Must block now.
+func TestRewriteJSON_NumericScalarBypassBlocked(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"visa-16", `{"cc": ` + "4111111111" + "111111}"},
+		{"mastercard-16", `{"cc": ` + "5555555555" + "554444}"},
+		{"amex-15", `{"cc": ` + "37828224" + "6310005}"},
+		{"ssn-shaped-would-not-match", `{"ssn_numeric": 123456789}`}, // SSN needs dashes, won't match — sanity check
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := RewriteJSON([]byte(tc.body), NewDefaultMatcher(), NewRedactor(), Limits{})
+			if tc.name == "ssn-shaped-would-not-match" {
+				if err != nil {
+					t.Fatalf("bare 9-digit number should NOT match SSN (needs dashes), got %v", err)
+				}
+				return
+			}
+			be, ok := asBlockError(err)
+			if !ok {
+				t.Fatalf("expected BlockError, got %v", err)
+			}
+			if be.Reason != ReasonSecretInNumericScalar {
+				t.Fatalf("reason = %q, want %q", be.Reason, ReasonSecretInNumericScalar)
+			}
+		})
+	}
+}
+
 func TestRewriteJSON_NonStringScalarsUntouched(t *testing.T) {
 	t.Parallel()
 	// A JSON array of numbers — no scalars to scan, no redactions.

--- a/internal/redact/rewrite_test.go
+++ b/internal/redact/rewrite_test.go
@@ -1,0 +1,347 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRewriteString_SingleMatch(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor()
+	// "connect to " is 11 chars; "192.0.2.104" occupies [11, 22).
+	matches := []Match{
+		{Class: ClassIPv4, Start: 11, End: 22, Original: "192.0.2.104"},
+	}
+	got := RewriteString("connect to 192.0.2.104 now", matches, r)
+	want := "connect to <pl:ipv4:1> now"
+	if got != want {
+		t.Fatalf("RewriteString = %q, want %q", got, want)
+	}
+}
+
+func TestRewriteString_MultipleMatches(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor()
+	in := "from 10.0.0.1 to 10.0.0.2 via dc01.corp.local"
+	matches := []Match{
+		{Class: ClassIPv4, Start: 5, End: 13, Original: "10.0.0.1"},
+		{Class: ClassIPv4, Start: 17, End: 25, Original: "10.0.0.2"},
+		{Class: ClassFQDN, Start: 30, End: 45, Original: "dc01.corp.local"},
+	}
+	got := RewriteString(in, matches, r)
+	want := "from <pl:ipv4:1> to <pl:ipv4:2> via <pl:fqdn:1>"
+	if got != want {
+		t.Fatalf("RewriteString = %q, want %q", got, want)
+	}
+}
+
+func TestRewriteString_EmptyNoop(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor()
+	if got := RewriteString("", nil, r); got != "" {
+		t.Fatalf("empty input should return empty, got %q", got)
+	}
+	if got := RewriteString("unchanged", nil, r); got != "unchanged" {
+		t.Fatalf("no matches should return input verbatim, got %q", got)
+	}
+}
+
+func TestRewriteString_OverlappingSkipped(t *testing.T) {
+	t.Parallel()
+	// Malformed caller input: overlapping matches. Rewriter must defensively
+	// skip the overlapper instead of producing garbled output.
+	r := NewRedactor()
+	in := "10.0.0.1"
+	matches := []Match{
+		{Class: ClassIPv4, Start: 0, End: 8, Original: "10.0.0.1"},
+		{Class: ClassFQDN, Start: 3, End: 8, Original: "0.0.1"}, // overlaps with IPv4
+	}
+	got := RewriteString(in, matches, r)
+	// First match applied; second skipped because Start < cursor.
+	if got != "<pl:ipv4:1>" {
+		t.Fatalf("RewriteString with overlapping = %q, want %q", got, "<pl:ipv4:1>")
+	}
+}
+
+func TestRewriteJSON_WholeBodyScan(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{
+        "system": "Use AKIA` + `IOSFODNN7EXAMPLE against dc01.corp.local",
+        "tools": [{"description": "call 10.0.0.5"}],
+        "messages": [
+          {"role": "user", "content": "please scan 192.168.1.1 for me"}
+        ]
+    }`)
+
+	out, report, err := RewriteJSON(body, NewDefaultMatcher(), NewRedactor(), Limits{})
+	if err != nil {
+		t.Fatalf("RewriteJSON error: %v", err)
+	}
+	if report == nil || !report.Applied {
+		t.Fatalf("report = %+v, want Applied=true", report)
+	}
+	if report.TotalRedactions < 4 {
+		t.Fatalf("expected at least 4 redactions (system AWS key + system FQDN + tool IPv4 + message IPv4), got %d", report.TotalRedactions)
+	}
+	outStr := string(out)
+	// Whole-body scan — the AWS key in `system` MUST be redacted (round-3
+	// bypass fix).
+	if strings.Contains(outStr, "AKIA"+"IOSFODNN7EXAMPLE") {
+		t.Fatalf("AWS access key leaked through system field: %s", outStr)
+	}
+	// FQDN in system must be redacted too.
+	if strings.Contains(outStr, "dc01.corp.local") {
+		t.Fatalf("FQDN leaked through system field: %s", outStr)
+	}
+	// IPv4 in tools description must be redacted.
+	if strings.Contains(outStr, "10.0.0.5") {
+		t.Fatalf("IPv4 leaked through tools field: %s", outStr)
+	}
+	// IPv4 in user message must be redacted.
+	if strings.Contains(outStr, "192.168.1.1") {
+		t.Fatalf("IPv4 leaked through user message: %s", outStr)
+	}
+}
+
+func TestRewriteJSON_DeepNestingRedacted(t *testing.T) {
+	t.Parallel()
+	// Secret buried several levels deep must still be scanned.
+	body := []byte(`{
+        "outer": {
+            "middle": {
+                "inner": [
+                    {"deep": "hit AKIA` + `IOSFODNN7EXAMPLE now"}
+                ]
+            }
+        }
+    }`)
+	out, report, err := RewriteJSON(body, NewDefaultMatcher(), NewRedactor(), Limits{})
+	if err != nil {
+		t.Fatalf("RewriteJSON error: %v", err)
+	}
+	if report.TotalRedactions != 1 {
+		t.Fatalf("expected 1 redaction, got %d", report.TotalRedactions)
+	}
+	if strings.Contains(string(out), "AKIA"+"IOSFODNN7EXAMPLE") {
+		t.Fatalf("deep-nested secret leaked: %s", out)
+	}
+}
+
+func TestRewriteJSON_DedupAcrossFields(t *testing.T) {
+	t.Parallel()
+	// Same original value in two different fields must get the same
+	// placeholder (per-request dedup).
+	body := []byte(`{"a": "see 10.0.0.1 here", "b": "and 10.0.0.1 there"}`)
+	out, report, err := RewriteJSON(body, NewDefaultMatcher(), NewRedactor(), Limits{})
+	if err != nil {
+		t.Fatalf("RewriteJSON error: %v", err)
+	}
+	if report.TotalRedactions != 1 {
+		t.Fatalf("same value in two fields should dedup to 1, got %d", report.TotalRedactions)
+	}
+	// Both occurrences should become <pl:ipv4:1>.
+	if c := strings.Count(string(out), "<pl:ipv4:1>"); c != 2 {
+		t.Fatalf("expected 2 placeholder occurrences, got %d; out=%s", c, out)
+	}
+}
+
+func TestRewriteJSON_OverflowDedupCountsUniquePairsOnly(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"a":"10.0.0.1 10.0.0.1","b":"10.0.0.1"}`)
+	out, report, err := RewriteJSON(body, NewDefaultMatcher(), NewRedactor(), Limits{MaxRedactionsPerRequest: 1})
+	if err != nil {
+		t.Fatalf("duplicate values should fit under unique-count cap, got %v", err)
+	}
+	if report.TotalRedactions != 1 {
+		t.Fatalf("expected 1 unique redaction, got %d", report.TotalRedactions)
+	}
+	if c := strings.Count(string(out), "<pl:ipv4:1>"); c != 3 {
+		t.Fatalf("expected 3 placeholder occurrences, got %d; out=%s", c, out)
+	}
+}
+
+func TestRewriteJSON_BodyTooLargeBlocks(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"x":"` + strings.Repeat("a", 2048) + `"}`)
+	_, _, err := RewriteJSON(body, NewDefaultMatcher(), NewRedactor(), Limits{MaxBodyBytes: 512})
+	be, ok := asBlockError(err)
+	if !ok {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+	if be.Reason != ReasonBodyTooLarge {
+		t.Fatalf("reason = %q, want %q", be.Reason, ReasonBodyTooLarge)
+	}
+}
+
+func TestRewriteJSON_UnparseableBodyBlocks(t *testing.T) {
+	t.Parallel()
+	_, _, err := RewriteJSON([]byte(`{not json`), NewDefaultMatcher(), NewRedactor(), Limits{})
+	be, ok := asBlockError(err)
+	if !ok {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+	if be.Reason != ReasonBodyUnparseable {
+		t.Fatalf("reason = %q, want %q", be.Reason, ReasonBodyUnparseable)
+	}
+}
+
+func TestRewriteJSON_OverflowBlocks(t *testing.T) {
+	t.Parallel()
+	// Attacker crafts a body with many distinct IPs; cap at 3 forces
+	// overflow on the fourth.
+	body := []byte(`{"x":"10.0.0.1 10.0.0.2 10.0.0.3 10.0.0.4"}`)
+	_, _, err := RewriteJSON(body, NewDefaultMatcher(), NewRedactor(), Limits{MaxRedactionsPerRequest: 3})
+	be, ok := asBlockError(err)
+	if !ok {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+	if be.Reason != ReasonOverflow {
+		t.Fatalf("reason = %q, want %q", be.Reason, ReasonOverflow)
+	}
+}
+
+func TestRewriteJSON_DepthLimitBlocks(t *testing.T) {
+	t.Parallel()
+	// 6 levels of nesting, cap at 2 — should block.
+	body := []byte(`{"a":{"b":{"c":{"d":{"e":{"f":"x"}}}}}}`)
+	_, _, err := RewriteJSON(body, NewDefaultMatcher(), NewRedactor(), Limits{MaxDepth: 2})
+	be, ok := asBlockError(err)
+	if !ok {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+	if be.Reason != ReasonDepthExceeded {
+		t.Fatalf("reason = %q, want %q", be.Reason, ReasonDepthExceeded)
+	}
+}
+
+func TestRewriteJSON_EmptyBodyClean(t *testing.T) {
+	t.Parallel()
+	out, report, err := RewriteJSON([]byte(`{}`), NewDefaultMatcher(), NewRedactor(), Limits{})
+	if err != nil {
+		t.Fatalf("empty object should not error: %v", err)
+	}
+	if string(out) != `{}` {
+		t.Fatalf("empty object = %q, want %q", out, `{}`)
+	}
+	if report.TotalRedactions != 0 {
+		t.Fatalf("no redactions expected, got %d", report.TotalRedactions)
+	}
+}
+
+func TestRewriteJSON_PreservesNumbersAndBools(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"n": 42, "pi": 3.14, "ok": true, "v": null, "text": "10.0.0.1"}`)
+	out, report, err := RewriteJSON(body, NewDefaultMatcher(), NewRedactor(), Limits{})
+	if err != nil {
+		t.Fatalf("RewriteJSON error: %v", err)
+	}
+	if report.TotalRedactions != 1 {
+		t.Fatalf("expected 1 redaction, got %d", report.TotalRedactions)
+	}
+	outStr := string(out)
+	for _, needle := range []string{`"n":42`, `"pi":3.14`, `"ok":true`, `"v":null`} {
+		if !strings.Contains(outStr, needle) {
+			t.Errorf("expected %s in output, got %s", needle, outStr)
+		}
+	}
+}
+
+// TestRewriteJSON_JSONKeyBypassClosed confirms that secrets placed in
+// JSON object KEYS are scanned and redacted. Review finding #1
+// (2026-04-19): an agent could stuff a secret into a key name and evade
+// value-only scanning.
+func TestRewriteJSON_JSONKeyBypassClosed(t *testing.T) {
+	t.Parallel()
+	awsKey := "AKIA" + "IOSFODNN7EXAMPLE"
+	body := []byte(`{"` + awsKey + `": "value"}`)
+	out, report, err := RewriteJSON(body, NewDefaultMatcher(), NewRedactor(), Limits{})
+	if err != nil {
+		t.Fatalf("RewriteJSON: %v", err)
+	}
+	if report.TotalRedactions != 1 {
+		t.Fatalf("expected 1 redaction, got %d", report.TotalRedactions)
+	}
+	if strings.Contains(string(out), awsKey) {
+		t.Fatalf("secret in JSON key leaked: %s", out)
+	}
+	if !strings.Contains(string(out), "<pl:aws-access-key:1>") {
+		t.Fatalf("expected placeholder-as-key in output, got %s", out)
+	}
+}
+
+func TestRewriteJSON_JSONKeyRedactionDedupesWithValue(t *testing.T) {
+	t.Parallel()
+	// Same secret appearing as both a key and a value should dedup to one
+	// placeholder per the Redactor's (class, original) contract.
+	ip := "10.0.0.1"
+	body := []byte(`{"` + ip + `": "mirrored here: ` + ip + `"}`)
+	_, report, err := RewriteJSON(body, NewDefaultMatcher(), NewRedactor(), Limits{})
+	if err != nil {
+		t.Fatalf("RewriteJSON: %v", err)
+	}
+	if report.TotalRedactions != 1 {
+		t.Fatalf("key+value of same original should dedup to 1, got %d", report.TotalRedactions)
+	}
+}
+
+func TestRewriteJSON_NonStringScalarsUntouched(t *testing.T) {
+	t.Parallel()
+	// A JSON array of numbers — no scalars to scan, no redactions.
+	body := []byte(`[1, 2, 3, 4]`)
+	out, report, err := RewriteJSON(body, NewDefaultMatcher(), NewRedactor(), Limits{})
+	if err != nil {
+		t.Fatalf("array input error: %v", err)
+	}
+	if report.TotalRedactions != 0 {
+		t.Fatalf("expected no redactions, got %d", report.TotalRedactions)
+	}
+	if string(out) != `[1,2,3,4]` {
+		t.Fatalf("array output = %q, want %q", out, `[1,2,3,4]`)
+	}
+}
+
+func TestNormaliseLimits_DefaultsAndClamps(t *testing.T) {
+	t.Parallel()
+	// Zero input → defaults.
+	l := normaliseLimits(Limits{})
+	if l.MaxBodyBytes != DefaultMaxBodyBytes {
+		t.Errorf("MaxBodyBytes default = %d, want %d", l.MaxBodyBytes, DefaultMaxBodyBytes)
+	}
+	if l.MaxRedactionsPerRequest != DefaultMaxRedactions {
+		t.Errorf("MaxRedactions default = %d, want %d", l.MaxRedactionsPerRequest, DefaultMaxRedactions)
+	}
+	if l.MaxDepth != DefaultMaxDepth {
+		t.Errorf("MaxDepth default = %d, want %d", l.MaxDepth, DefaultMaxDepth)
+	}
+	// Over-the-limit input → clamped.
+	l = normaliseLimits(Limits{
+		MaxBodyBytes:            absoluteBodyCapBytes * 10,
+		MaxRedactionsPerRequest: absoluteRedactionCap * 10,
+		MaxDepth:                absoluteDepthCap * 10,
+	})
+	if l.MaxBodyBytes != absoluteBodyCapBytes {
+		t.Errorf("MaxBodyBytes clamp = %d, want %d", l.MaxBodyBytes, absoluteBodyCapBytes)
+	}
+	if l.MaxRedactionsPerRequest != absoluteRedactionCap {
+		t.Errorf("MaxRedactions clamp = %d, want %d", l.MaxRedactionsPerRequest, absoluteRedactionCap)
+	}
+	if l.MaxDepth != absoluteDepthCap {
+		t.Errorf("MaxDepth clamp = %d, want %d", l.MaxDepth, absoluteDepthCap)
+	}
+}
+
+// asBlockError unwraps an error to a *BlockError if one is present.
+func asBlockError(err error) (*BlockError, bool) {
+	if err == nil {
+		return nil, false
+	}
+	var be *BlockError
+	if errors.As(err, &be) {
+		return be, true
+	}
+	return nil, false
+}

--- a/internal/redact/walker.go
+++ b/internal/redact/walker.go
@@ -84,9 +84,10 @@ func RewriteJSON(body []byte, m *Matcher, r *Redactor, lim Limits) ([]byte, *Rep
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
 	if err := enc.Encode(rewritten); err != nil {
-		// Should not happen for inputs decoded via encoding/json, but
-		// fail-closed if it does.
-		return nil, nil, newBlock(ReasonBodyUnparseable, r.Total(), "remarshal: "+err.Error())
+		// Input was parseable (we already decoded it above); only the
+		// rewritten tree failed to re-encode. Distinct reason so telemetry
+		// separates attacker-malformed input from an implementation bug.
+		return nil, nil, newBlock(ReasonRemarshalFailed, r.Total(), err.Error())
 	}
 	// Encoder appends a trailing newline; trim it so the output is a bare
 	// JSON value, matching what callers get from json.Marshal.
@@ -146,8 +147,26 @@ func (w *walker) walk(node interface{}, depth int) (interface{}, error) {
 			out[i] = rewritten
 		}
 		return out, nil
+	case json.Number:
+		// Numeric scalars are textually preserved by json.Decoder.UseNumber,
+		// so the digit string passes unredacted if we do not scan it. A
+		// credit card, SSN, or hash placed as a bare JSON number would
+		// therefore bypass pattern-based redaction. Scan the textual form
+		// and, on any pattern hit, fail closed: rewriting the number to a
+		// string placeholder would change the JSON type and almost always
+		// break the upstream API. Bodies that legitimately carry secrets
+		// as bare numbers should use string encoding instead.
+		if matches := w.matcher.Scan(string(v)); len(matches) > 0 {
+			return nil, newBlock(ReasonSecretInNumericScalar, w.redactor.Total(),
+				"secret pattern matched a numeric JSON scalar; encode sensitive values as strings")
+		}
+		return v, nil
+	case bool, nil:
+		// Booleans and JSON null carry no scannable content.
+		return v, nil
 	default:
-		// Numbers (json.Number), bools, nil, etc. Pass through untouched.
+		// Any other concrete Go type produced by encoding/json (none of
+		// them in practice with UseNumber enabled) passes through.
 		return v, nil
 	}
 }

--- a/internal/redact/walker.go
+++ b/internal/redact/walker.go
@@ -116,11 +116,8 @@ func (w *walker) walk(node interface{}, depth int) (interface{}, error) {
 	case map[string]interface{}:
 		out := make(map[string]interface{}, len(v))
 		for k, child := range v {
-			// Scan and redact the key too. An adversarial agent can stuff
-			// a secret into a JSON key name (e.g. {"AKIA...": "safe"}); if
-			// we only scanned values, that path would bypass redaction.
-			// Rewriting the key preserves the fail-closed invariant that
-			// every string scalar at any position is scanned.
+			// Scan and redact the key. A secret stuffed into a JSON key
+			// name would otherwise bypass value-only scanning.
 			rewrittenKey, err := w.rewriteScalar(k)
 			if err != nil {
 				return nil, err
@@ -128,6 +125,13 @@ func (w *walker) walk(node interface{}, depth int) (interface{}, error) {
 			rewritten, err := w.walk(child, depth+1)
 			if err != nil {
 				return nil, err
+			}
+			// Detect key-rewrite collisions: if two distinct originals
+			// produce the same output key, silently overwriting the
+			// earlier sibling changes forwarded object structure and
+			// could be abused to drop fields. Fail closed.
+			if _, exists := out[rewrittenKey]; exists {
+				return nil, newBlock(ReasonKeyCollision, w.redactor.Total(), "two keys redact to the same placeholder")
 			}
 			out[rewrittenKey] = rewritten
 		}

--- a/internal/redact/walker.go
+++ b/internal/redact/walker.go
@@ -1,0 +1,212 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// Report summarises the outcome of a Rewrite call.
+type Report struct {
+	// Applied is true when redaction ran to completion. False when the
+	// request was blocked; in that case the accompanying error is a
+	// *BlockError and Body is nil.
+	Applied bool
+	// TotalRedactions is the count of unique redactions applied.
+	TotalRedactions int
+	// ByClass is the per-class count of unique redactions.
+	ByClass map[Class]int
+}
+
+// Limits configures the defensive caps Rewrite enforces.
+type Limits struct {
+	// MaxBodyBytes is the largest request body Rewrite will process. Zero
+	// disables the check (not recommended outside tests).
+	MaxBodyBytes int
+	// MaxRedactionsPerRequest caps the number of unique redactions. Zero
+	// defaults to DefaultMaxRedactions.
+	MaxRedactionsPerRequest int
+	// MaxDepth bounds JSON nesting depth to prevent stack exhaustion on
+	// pathological input. Zero defaults to DefaultMaxDepth.
+	MaxDepth int
+}
+
+// Default limits tuned to typical LLM request sizes.
+const (
+	DefaultMaxBodyBytes  = 10 * 1024 * 1024 // 10 MB
+	DefaultMaxRedactions = 10_000
+	DefaultMaxDepth      = 64
+	absoluteBodyCapBytes = 64 * 1024 * 1024 // hard ceiling, never exceeded
+	absoluteRedactionCap = 1_000_000        // safety net above operator config
+	absoluteDepthCap     = 256              // safety net above operator config
+)
+
+// RewriteJSON parses body as JSON, walks every string scalar, applies m +
+// r, and returns a rewritten JSON body. Fail-closed: any error during
+// parsing, any scalar that cannot be decoded/re-encoded, or any cap
+// exceeded results in a *BlockError with the matched originals left in r.
+//
+// The Redactor r is mutated: its counters and dedup state reflect every
+// placeholder generated during this call. Callers should pass a fresh
+// Redactor per request.
+func RewriteJSON(body []byte, m *Matcher, r *Redactor, lim Limits) ([]byte, *Report, error) {
+	lim = normaliseLimits(lim)
+
+	if lim.MaxBodyBytes > 0 && len(body) > lim.MaxBodyBytes {
+		return nil, nil, newBlock(ReasonBodyTooLarge, 0, "")
+	}
+	if !json.Valid(body) {
+		return nil, nil, newBlock(ReasonBodyUnparseable, 0, "")
+	}
+
+	var root interface{}
+	dec := json.NewDecoder(bytes.NewReader(body))
+	// UseNumber to preserve numeric fidelity on re-encode.
+	dec.UseNumber()
+	if err := dec.Decode(&root); err != nil {
+		return nil, nil, newBlock(ReasonBodyUnparseable, 0, err.Error())
+	}
+
+	w := walker{matcher: m, redactor: r, limits: lim}
+	rewritten, err := w.walk(root, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Disable HTML escaping so `<pl:CLASS:N>` placeholders appear as
+	// literal characters in the output bytes, not `\u003cpl:...\u003e`.
+	// This is API traffic, not HTML; the upstream provider parses the
+	// JSON and sees the same string either way, but literal form keeps
+	// byte-level inspection and telemetry readable.
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(rewritten); err != nil {
+		// Should not happen for inputs decoded via encoding/json, but
+		// fail-closed if it does.
+		return nil, nil, newBlock(ReasonBodyUnparseable, r.Total(), "remarshal: "+err.Error())
+	}
+	// Encoder appends a trailing newline; trim it so the output is a bare
+	// JSON value, matching what callers get from json.Marshal.
+	out := bytes.TrimRight(buf.Bytes(), "\n")
+
+	return out, &Report{
+		Applied:         true,
+		TotalRedactions: r.Total(),
+		ByClass:         r.ByClass(),
+	}, nil
+}
+
+// walker carries scan state across recursive calls.
+type walker struct {
+	matcher  *Matcher
+	redactor *Redactor
+	limits   Limits
+}
+
+func (w *walker) walk(node interface{}, depth int) (interface{}, error) {
+	if depth > w.limits.MaxDepth {
+		return nil, newBlock(ReasonDepthExceeded, w.redactor.Total(), "")
+	}
+	switch v := node.(type) {
+	case string:
+		return w.rewriteScalar(v)
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(v))
+		for k, child := range v {
+			// Scan and redact the key too. An adversarial agent can stuff
+			// a secret into a JSON key name (e.g. {"AKIA...": "safe"}); if
+			// we only scanned values, that path would bypass redaction.
+			// Rewriting the key preserves the fail-closed invariant that
+			// every string scalar at any position is scanned.
+			rewrittenKey, err := w.rewriteScalar(k)
+			if err != nil {
+				return nil, err
+			}
+			rewritten, err := w.walk(child, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			out[rewrittenKey] = rewritten
+		}
+		return out, nil
+	case []interface{}:
+		out := make([]interface{}, len(v))
+		for i, child := range v {
+			rewritten, err := w.walk(child, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = rewritten
+		}
+		return out, nil
+	default:
+		// Numbers (json.Number), bools, nil, etc. Pass through untouched.
+		return v, nil
+	}
+}
+
+func (w *walker) rewriteScalar(s string) (string, error) {
+	matches := w.matcher.Scan(s)
+	if len(matches) == 0 {
+		return s, nil
+	}
+	// Overflow check counts only net-new (class, original) pairs after dedup
+	// against both earlier fields and repeated values within this scalar.
+	if w.limits.MaxRedactionsPerRequest > 0 {
+		projected := w.redactor.Total() + countNewPairs(matches, w.redactor)
+		if projected > w.limits.MaxRedactionsPerRequest {
+			return "", newBlock(ReasonOverflow, w.redactor.Total(), "")
+		}
+	}
+	return RewriteString(s, matches, w.redactor), nil
+}
+
+func countNewPairs(matches []Match, r *Redactor) int {
+	if len(matches) == 0 {
+		return 0
+	}
+	seen := make(map[Class]map[string]struct{})
+	newPairs := 0
+	for _, m := range matches {
+		if r.seen(m.Class, m.Original) {
+			continue
+		}
+		bucket, ok := seen[m.Class]
+		if !ok {
+			bucket = make(map[string]struct{})
+			seen[m.Class] = bucket
+		}
+		if _, ok := bucket[m.Original]; ok {
+			continue
+		}
+		bucket[m.Original] = struct{}{}
+		newPairs++
+	}
+	return newPairs
+}
+
+// normaliseLimits applies defaults and clamps to safety ceilings.
+func normaliseLimits(lim Limits) Limits {
+	if lim.MaxBodyBytes <= 0 {
+		lim.MaxBodyBytes = DefaultMaxBodyBytes
+	}
+	if lim.MaxBodyBytes > absoluteBodyCapBytes {
+		lim.MaxBodyBytes = absoluteBodyCapBytes
+	}
+	if lim.MaxRedactionsPerRequest <= 0 {
+		lim.MaxRedactionsPerRequest = DefaultMaxRedactions
+	}
+	if lim.MaxRedactionsPerRequest > absoluteRedactionCap {
+		lim.MaxRedactionsPerRequest = absoluteRedactionCap
+	}
+	if lim.MaxDepth <= 0 {
+		lim.MaxDepth = DefaultMaxDepth
+	}
+	if lim.MaxDepth > absoluteDepthCap {
+		lim.MaxDepth = absoluteDepthCap
+	}
+	return lim
+}


### PR DESCRIPTION
## Summary

New `internal/redact` package provides class-preserving, irreversible redaction of secrets in JSON request bodies bound for upstream providers. Typed placeholders `<pl:CLASS:N>` preserve semantic class without exposing originals.

19 built-in classes (IPs, FQDN, email, AWS/Google/GitHub/Slack tokens, JWT, hashes, SSH key header, AD user, SSN, credit card) plus operator YAML dictionaries. Whole-body JSON walk — every string scalar and every object key at any depth, no field-position exemption. Fail-closed on oversize, unparseable, overflow, depth-exceeded with typed `*BlockError` reasons.

Adds `ActionRedact = "redact"` and a `Redaction` config block plumbed into `Config`. Library ships disabled.

## Scope

Library-only. No transport calls it yet — forward-proxy hook and receipt integration land in a follow-up.

## Rationale

Whole-body scan (no `system`/`tools` exemption) is deliberate: the caller controls field placement, so any field-position exemption is a bypass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added redaction framework to secure sensitive data in request bodies. The feature is currently disabled and enforced as disabled in this release. Configuration now supports profiles, dictionaries, and limits to detect and replace secrets (API keys, tokens, credentials, hashes, etc.) with safe placeholders.

* **Tests**
  * Added comprehensive test coverage for redaction functionality including configuration validation, secret detection, and JSON processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->