### PR TITLE
fix(proxy)+docs: browser-shield media bypass + README receipt-positioning sharpen

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@
   <a href="https://github.com/luckyPipewrench/pipelock/blob/main/.github/workflows/ci.yaml#L21-L35"><img alt="pipelock self-scanned" src="https://img.shields.io/badge/pipelock-self--scanned-00FFC8?style=flat&labelColor=1A1A2E&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNCAxNCI+PHBhdGggZmlsbD0iIzAwRkZDOCIgZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik03IDAuNWMtMS45MyAwLTMuNSAxLjY2LTMuNSAzLjd2MS4zSDNjLS44MyAwLTEuNSAuNjctMS41IDEuNXY2YzAgLjgzLjY3IDEuNSAxLjUgMS41aDhjLjgzIDAgMS41LS42NyAxLjUtMS41VjdjMC0uODMtLjY3LTEuNS0xLjUtMS41aC0uNVY0LjJjMC0yLjA0LTEuNTctMy43LTMuNS0zLjdabS0yIDVWNC4yYzAtMS40OSAxLjEyLTIuNyAyLjUtMi43czIuNSAxLjIxIDIuNSAyLjd2MS4zSDVaTTIuNSA1aDJ2MS4yaC0yVjVabTcgMGgydjEuMmgtMlY1Wk03IDguMmMtLjY5IDAtMS4yNS41Ni0xLjI1IDEuMjUgMCAuNDQuMjMuODMuNTcgMS4wNXYxLjVoMS4zNnYtMS41Yy4zNC0uMjIuNTctLjYxLjU3LTEuMDUgMC0uNjktLjU2LTEuMjUtMS4yNS0xLjI1WiIvPjwvc3ZnPgo="></a>
 </p>
 
-**Open-source AI agent firewall with signed action receipts.** Network scanning, process containment, MCP-aware policy enforcement, and independently verifiable proof of what your agent did in a single binary. Learn more: [Open-source AI firewall](https://pipelab.org/learn/open-source-ai-firewall/).
+**Open-source AI agent firewall with mediator-signed [action receipts](https://pipelab.org/learn/action-receipt-spec/) from outside the agent trust boundary.** Network scanning, process containment, MCP-aware policy enforcement, and independently verifiable proof of what your agent did in a single binary. Learn more: [Open-source AI firewall](https://pipelab.org/learn/open-source-ai-firewall/).
+
+**Agent-external attestation built in.** Receipts are signed by the mediator, outside the agent process and outside its credentials, so evidence does not depend on the agent attesting to itself.
 
 **Works with:** Claude Code · Cursor · VS Code · JetBrains · OpenAI Agents SDK · Google ADK · AutoGen · CrewAI · LangGraph
 

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -2933,3 +2933,89 @@ func TestSSRFSafeDialContext_MalysScenario_AllowlistAndTrusted(t *testing.T) {
 	}
 	_ = conn.Close()
 }
+
+// TestForwardHTTP_ShieldOversizeTransportParity exercises the full
+// absolute-URI forward proxy request/response path so the applyShield
+// call at forward.go (TransportForward) is reached in a real HTTP
+// round-trip, not just a direct helper call. Complements the direct
+// TestProxy_ApplyShield_* regressions in shield_integration_test.go per
+// the "transport parity must be proven, not claimed" invariant.
+func TestForwardHTTP_ShieldOversizeTransportParity(t *testing.T) {
+	t.Run("non-shieldable oversized passes through", func(t *testing.T) {
+		// application/pdf is non-shieldable (DetectPipeline returns
+		// PipelineNone) and is not parsed by media_policy (which only
+		// validates image formats it knows how to inspect), so this
+		// content reaches applyShield with no other scanner intercepting.
+		body := make([]byte, 1024)
+		copy(body, []byte("%PDF-1.4\n"))
+		backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/pdf")
+			_, _ = w.Write(body)
+		}))
+		defer backend.Close()
+
+		cfg := config.Defaults()
+		cfg.Internal = nil
+		cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+		cfg.APIAllowlist = nil
+		cfg.ForwardProxy.Enabled = true
+		// Isolate the shield-oversize path: disable DLP + response scanning
+		// so the body reaches applyShield without being flagged by unrelated
+		// scanners. media_policy only validates known image formats and
+		// leaves application/pdf alone.
+		cfg.DLP.Patterns = nil
+		cfg.ResponseScanning.Enabled = false
+		cfg.BrowserShield.Enabled = true
+		cfg.BrowserShield.MaxShieldBytes = 100
+		cfg.BrowserShield.OversizeAction = config.ShieldOversizeBlock
+
+		proxyAddr, cleanup := startProxyOnFreePort(t, cfg)
+		defer cleanup()
+
+		resp := doGet(t, proxyClient(proxyAddr), backend.URL+"/doc.pdf")
+		defer resp.Body.Close() //nolint:errcheck // test
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("non-shieldable PDF over MaxShieldBytes must pass through forward proxy; got status %d", resp.StatusCode)
+		}
+		got, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if len(got) != len(body) {
+			t.Errorf("forward proxy truncated non-shieldable body (got %d bytes, want %d); shield oversize must not rewrite media responses", len(got), len(body))
+		}
+	})
+
+	t.Run("shieldable oversized still blocks", func(t *testing.T) {
+		body := make([]byte, 1024)
+		copy(body, []byte("<!DOCTYPE html><html><body>"))
+		backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write(body)
+		}))
+		defer backend.Close()
+
+		cfg := config.Defaults()
+		cfg.Internal = nil
+		cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+		cfg.APIAllowlist = nil
+		cfg.ForwardProxy.Enabled = true
+		// Isolate the shield-oversize path: disable DLP + response scanning
+		// so the body reaches applyShield without being flagged by unrelated
+		// scanners (the PNG magic-prefix pad can otherwise trip pattern checks).
+		cfg.DLP.Patterns = nil
+		cfg.ResponseScanning.Enabled = false
+		cfg.BrowserShield.Enabled = true
+		cfg.BrowserShield.MaxShieldBytes = 100
+		cfg.BrowserShield.OversizeAction = config.ShieldOversizeBlock
+
+		proxyAddr, cleanup := startProxyOnFreePort(t, cfg)
+		defer cleanup()
+
+		resp := doGet(t, proxyClient(proxyAddr), backend.URL+"/large.html")
+		defer resp.Body.Close() //nolint:errcheck // test
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("shieldable HTML over MaxShieldBytes must still block via forward proxy (fail-closed); got status %d", resp.StatusCode)
+		}
+	})
+}

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -2930,3 +2930,86 @@ func TestInterceptTunnel_CanaryBodyBlocked(t *testing.T) {
 		t.Error("upstream received the canary body, want blocked at pipelock")
 	}
 }
+
+// TestInterceptTunnel_ShieldOversizeTransportParity exercises the TLS
+// intercept response-handling path so applyShield is reached through the
+// CONNECT tunnel (TransportConnect), not just via the direct helper in
+// shield_integration_test.go. Pairs with TestForwardHTTP_ShieldOversize-
+// TransportParity to prove the transport parity invariant. Uses
+// interceptAndRequestWithProxy because the shield block inside
+// interceptTunnel is gated on ic.Proxy being non-nil.
+func TestInterceptTunnel_ShieldOversizeTransportParity(t *testing.T) {
+	t.Run("non-shieldable oversized passes through", func(t *testing.T) {
+		// application/pdf is non-shieldable (DetectPipeline returns
+		// PipelineNone) and is not parsed by media_policy, so this
+		// content reaches applyShield unimpeded by other scanners.
+		body := make([]byte, 1024)
+		copy(body, []byte("%PDF-1.4\n"))
+		upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/pdf")
+			_, _ = w.Write(body)
+		}))
+		defer upstream.Close()
+
+		cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+		cfg.DLP.Patterns = nil
+		cfg.ResponseScanning.Enabled = false
+		cfg.BrowserShield.Enabled = true
+		cfg.BrowserShield.MaxShieldBytes = 100
+		cfg.BrowserShield.OversizeAction = config.ShieldOversizeBlock
+		testLogger, _ := audit.New("json", "stdout", "", false, false)
+		p, err := New(cfg, testLogger, sc, m)
+		if err != nil {
+			t.Fatalf("proxy.New: %v", err)
+		}
+		t.Cleanup(func() { p.Close() })
+
+		addr := upstream.Listener.Addr().String()
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://"+addr+"/doc.pdf", nil)
+
+		resp := interceptAndRequestWithProxy(t, upstream, cache, pool, cfg, sc, logger, m, req, p)
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("non-shieldable PDF over MaxShieldBytes must pass through TLS intercept; got status %d", resp.StatusCode)
+		}
+		got, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if len(got) != len(body) {
+			t.Errorf("TLS intercept truncated non-shieldable body (got %d bytes, want %d); shield oversize must not rewrite media responses", len(got), len(body))
+		}
+	})
+
+	t.Run("shieldable oversized still blocks", func(t *testing.T) {
+		body := make([]byte, 1024)
+		copy(body, []byte("<!DOCTYPE html><html><body>"))
+		upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write(body)
+		}))
+		defer upstream.Close()
+
+		cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+		cfg.BrowserShield.Enabled = true
+		cfg.BrowserShield.MaxShieldBytes = 100
+		cfg.BrowserShield.OversizeAction = config.ShieldOversizeBlock
+		testLogger, _ := audit.New("json", "stdout", "", false, false)
+		p, err := New(cfg, testLogger, sc, m)
+		if err != nil {
+			t.Fatalf("proxy.New: %v", err)
+		}
+		t.Cleanup(func() { p.Close() })
+
+		addr := upstream.Listener.Addr().String()
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://"+addr+"/large.html", nil)
+
+		resp := interceptAndRequestWithProxy(t, upstream, cache, pool, cfg, sc, logger, m, req, p)
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("shieldable HTML over MaxShieldBytes must still block via TLS intercept (fail-closed); got status %d", resp.StatusCode)
+		}
+	})
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1560,7 +1560,26 @@ func (p *Proxy) applyShield(body []byte, contentType, hostname string, respHeade
 		return body, false
 	}
 
-	// Max shield bytes: enforce oversize action.
+	// Content-type gate: skip shield entirely for non-shieldable media
+	// (image/*, audio/*, video/*, application/pdf, arbitrary octet-stream
+	// that does not sniff as HTML/JS/SVG, etc.). This MUST run before the
+	// max_shield_bytes ceiling so a large binary payload from a legitimate
+	// media API is not blocked as "oversize" when the shield would return
+	// PipelineNone anyway. runShieldPipeline performs the same detection
+	// on the rewrite path; we short-circuit here for binary bodies so the
+	// oversize ceiling only applies to content the shield would actually
+	// rewrite (HTML, JS, SVG).
+	prefixLen := len(body)
+	if prefixLen > 512 {
+		prefixLen = 512
+	}
+	if shield.DetectPipeline(contentType, body[:prefixLen]) == shield.PipelineNone {
+		p.metrics.RecordShieldSkipped("non_shieldable_content")
+		return body, false
+	}
+
+	// Max shield bytes: enforce oversize action. Only runs for content the
+	// shield would rewrite (HTML/JS/SVG) per the gate above.
 	if cfg.BrowserShield.MaxShieldBytes > 0 && len(body) > cfg.BrowserShield.MaxShieldBytes {
 		p.metrics.RecordShieldSkipped("oversize")
 		switch cfg.BrowserShield.OversizeAction {

--- a/internal/proxy/shield_integration_test.go
+++ b/internal/proxy/shield_integration_test.go
@@ -180,9 +180,12 @@ func TestProxy_ApplyShield_NonShieldableContentBypassesOversize(t *testing.T) {
 			cfg.BrowserShield.MaxShieldBytes = 100
 			cfg.BrowserShield.OversizeAction = config.ShieldOversizeBlock
 
-			// Pad the head with plausible magic bytes, then fill to 500 bytes
-			// so the total exceeds MaxShieldBytes by a clear margin.
-			body := make([]byte, 500)
+			// Pad the head with plausible magic bytes, then fill to 1024
+			// bytes so the total exceeds both MaxShieldBytes and the 512-byte
+			// prefix cap used by DetectPipeline. Exercising the >512 path
+			// is part of the regression; a smaller body would leave the
+			// prefix-truncation branch in applyShield uncovered.
+			body := make([]byte, 1024)
 			copy(body, tc.bodyHead)
 
 			result, blocked := p.applyShield(body, tc.contentType, "example.com", nil, cfg, audit.LogContext{}, "127.0.0.1", "req1", TransportFetch)
@@ -220,7 +223,10 @@ func TestProxy_ApplyShield_ShieldableContentStillBlockedWhenOversize(t *testing.
 			cfg.BrowserShield.MaxShieldBytes = 100
 			cfg.BrowserShield.OversizeAction = config.ShieldOversizeBlock
 
-			body := make([]byte, 500)
+			// 1024 bytes exceeds both MaxShieldBytes and the 512-byte
+			// prefix cap, exercising the prefix-truncation branch on the
+			// shieldable path too.
+			body := make([]byte, 1024)
 			copy(body, tc.bodyHead)
 			for i := len(tc.bodyHead); i < len(body); i++ {
 				body[i] = 'A'

--- a/internal/proxy/shield_integration_test.go
+++ b/internal/proxy/shield_integration_test.go
@@ -151,6 +151,92 @@ func TestProxy_ApplyShield_OversizeWarn(t *testing.T) {
 	}
 }
 
+func TestProxy_ApplyShield_NonShieldableContentBypassesOversize(t *testing.T) {
+	// Regression: v2.2.0 blocked legitimate binary responses (image/audio/
+	// video) from media generation APIs when the payload exceeded
+	// max_shield_bytes, even though DetectPipeline would have returned
+	// PipelineNone and the shield would not have rewritten anything. The
+	// Content-Type gate in applyShield must short-circuit before the
+	// oversize ceiling for non-shieldable media.
+	t.Parallel()
+
+	nonShieldable := []struct {
+		name        string
+		contentType string
+		bodyHead    []byte
+	}{
+		{"png", "image/png", []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}},
+		{"jpeg", "image/jpeg", []byte{0xff, 0xd8, 0xff, 0xe0}},
+		{"webp", "image/webp", []byte("RIFF\x00\x00\x00\x00WEBP")},
+		{"mp4", "video/mp4", []byte{0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70}},
+		{"mpeg", "audio/mpeg", []byte{0x49, 0x44, 0x33, 0x04}},
+		{"pdf", "application/pdf", []byte("%PDF-1.4")},
+	}
+	for _, tc := range nonShieldable {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newTestProxy(t)
+			cfg := config.Defaults()
+			cfg.BrowserShield.Enabled = true
+			cfg.BrowserShield.MaxShieldBytes = 100
+			cfg.BrowserShield.OversizeAction = config.ShieldOversizeBlock
+
+			// Pad the head with plausible magic bytes, then fill to 500 bytes
+			// so the total exceeds MaxShieldBytes by a clear margin.
+			body := make([]byte, 500)
+			copy(body, tc.bodyHead)
+
+			result, blocked := p.applyShield(body, tc.contentType, "example.com", nil, cfg, audit.LogContext{}, "127.0.0.1", "req1", TransportFetch)
+			if blocked {
+				t.Fatalf("%s: non-shieldable media must not be blocked as shield_oversize", tc.contentType)
+			}
+			if len(result) != len(body) {
+				t.Fatalf("%s: body length changed (got %d, want %d); shield should pass non-shieldable content through unchanged", tc.contentType, len(result), len(body))
+			}
+		})
+	}
+}
+
+func TestProxy_ApplyShield_ShieldableContentStillBlockedWhenOversize(t *testing.T) {
+	// Complement to the non-shieldable bypass test: verify the oversize
+	// ceiling still fires for content the shield would rewrite. Ensures
+	// the Content-Type gate did not accidentally disable fail-closed
+	// behavior on HTML, JS, or SVG.
+	t.Parallel()
+
+	shieldable := []struct {
+		name        string
+		contentType string
+		bodyHead    []byte
+	}{
+		{"html", "text/html", []byte("<!DOCTYPE html><html>")},
+		{"js", "application/javascript", []byte("function run() {")},
+		{"svg", "image/svg+xml", []byte("<svg xmlns='http://www.w3.org/2000/svg'>")},
+	}
+	for _, tc := range shieldable {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newTestProxy(t)
+			cfg := config.Defaults()
+			cfg.BrowserShield.Enabled = true
+			cfg.BrowserShield.MaxShieldBytes = 100
+			cfg.BrowserShield.OversizeAction = config.ShieldOversizeBlock
+
+			body := make([]byte, 500)
+			copy(body, tc.bodyHead)
+			for i := len(tc.bodyHead); i < len(body); i++ {
+				body[i] = 'A'
+			}
+
+			result, blocked := p.applyShield(body, tc.contentType, "example.com", nil, cfg, audit.LogContext{}, "127.0.0.1", "req1", TransportFetch)
+			if !blocked {
+				t.Fatalf("%s: shieldable content over MaxShieldBytes must still block (fail-closed invariant)", tc.contentType)
+			}
+			if result != nil {
+				t.Fatalf("%s: blocked body must be nil, got %d bytes", tc.contentType, len(result))
+			}
+		})
+	}
+}
+
 func TestProxy_ApplyShield_OversizeScanHead(t *testing.T) {
 	t.Parallel()
 	p := newTestProxy(t)


### PR DESCRIPTION
Two related changes in one PR. Both touch how Pipelock presents and enforces its mediator-signed receipt model.

## 1. `fix(proxy)`: browser-shield no longer blocks non-shieldable media responses

`applyShield` now runs `shield.DetectPipeline` *before* the `max_shield_bytes` ceiling. Image, audio, video, PDF, and arbitrary binary responses short-circuit, because the shield's rewrite surface is HTML / JS / SVG only — it would return `PipelineNone` for non-shieldable media anyway.

### Why
Media-generation APIs (image-generation endpoints in particular) return response bodies that exceed the default shield ceiling. Before this fix, the ceiling's `block` action tripped before the pipeline classifier ran, so legitimate image responses were rejected as `shield_oversize` even though the shield would not have rewritten them. Users worked around it with per-domain `browser_shield.exempt_domains` entries — this fix removes that need.

### Fail-closed preserved
Shieldable content (HTML / JS / SVG) still hits `max_shield_bytes` with the configured `OversizeAction`. The new Content-Type gate is additive: it only short-circuits content the shield would not rewrite.

### Transport parity
`applyShield` is the shared helper called by both the forward-proxy response path (`internal/proxy/forward.go`) and the CONNECT/TLS intercept path (`internal/proxy/intercept.go`). One fix, both transports.

### Tests
- 6 non-shieldable subtests (png, jpeg, webp, mp4, mpeg, pdf): verify oversize payloads pass through unchanged.
- 3 shieldable subtests (html, js, svg): verify oversize payloads still block under `ShieldOversizeBlock` (fail-closed invariant).

## 2. `docs(readme)`: sharpen tagline with agent-external attestation framing

Qualifies the existing "signed action receipts" phrase in the README tagline as "**mediator-signed** action receipts **from outside the agent trust boundary**" and links to the receipt spec. Adds one short follow-up paragraph introducing **agent-external attestation** as the category noun.

"Signed action receipts" as an unqualified phrase is the same phrase used by attestation tooling that signs receipts from inside the agent process. Pipelock's differentiator is the signer's location, not the signature itself. Qualifying the phrase on first use prevents readers from flattening Pipelock's out-of-process signer model into "just another tool that signs receipts."

Wire format and binary behavior unchanged on both fronts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to clarify that action receipts are mediator-signed from outside the agent trust boundary with details on agent-external attestation.

* **Improvements**
  * BrowserShield now detects content type before enforcing size limits, intelligently skipping protection for non-shieldable media like images and videos while maintaining enforcement for web content.

* **Tests**
  * Added integration tests for content-type-aware oversize handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->