### PR TITLE
refactor: consolidate runtime config resolution into Config.ResolveRuntime

### DIFF
--- a/.github/workflows/hardening.yaml
+++ b/.github/workflows/hardening.yaml
@@ -1,0 +1,101 @@
+name: Hardening
+
+on:
+  push:
+    branches: [main]
+    tags-ignore: ['v*']
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: hardening-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Workflow and release audit
+        run: make release-audit
+
+  runtime-critical:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: '1.25'
+
+      - name: Verify dependencies
+        run: go mod verify
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run runtime-critical packages
+        run: make test-runtime-critical
+
+  hardening-report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: '1.25'
+
+      - name: Runtime policy audit (warning-only on PRs; blocking in release workflow)
+        id: policy
+        continue-on-error: true
+        run: make runtime-policy-audit
+
+      - name: Debt report (warning-only)
+        id: debt
+        continue-on-error: true
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
+        with:
+          version: v2.10.1
+          skip-cache: true
+          args: --disable-all --enable dupl --enable gocyclo --enable gocognit --enable maintidx ./...
+
+      - name: Summarize hardening report
+        if: always()
+        env:
+          POLICY_OUTCOME: ${{ steps.policy.outcome }}
+          DEBT_OUTCOME: ${{ steps.debt.outcome }}
+        run: |
+          {
+            echo "## Hardening Report"
+            if [ "$POLICY_OUTCOME" = "failure" ]; then
+              echo "- runtime-policy audit: findings present; release workflow will block until they are fixed"
+            else
+              echo "- runtime-policy audit: clean"
+            fi
+            if [ "$DEBT_OUTCOME" = "failure" ]; then
+              echo "- debt report: complexity/duplication debt findings present; review the job log before release"
+            else
+              echo "- debt report: clean for configured linters"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$POLICY_OUTCOME" = "failure" ] || [ "$DEBT_OUTCOME" = "failure" ]; then
+            echo "::warning::Hardening report found follow-up work. See the workflow summary and logs."
+          fi

--- a/.github/workflows/hardening.yaml
+++ b/.github/workflows/hardening.yaml
@@ -24,6 +24,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Workflow and release audit
         run: make release-audit
 
@@ -61,6 +64,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
 
       - name: Runtime policy audit
         run: make runtime-policy-audit

--- a/.github/workflows/hardening.yaml
+++ b/.github/workflows/hardening.yaml
@@ -49,6 +49,22 @@ jobs:
       - name: Run runtime-critical packages
         run: make test-runtime-critical
 
+  runtime-policy:
+    # Blocking on PRs, not just at release-tag time: a runtime package
+    # that re-introduces direct mutation of policy-relevant config would
+    # otherwise land on main and only get caught when someone tags a
+    # release. The release workflow still runs this audit as a defense-
+    # in-depth gate; this job catches regressions earlier.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Runtime policy audit
+        run: make runtime-policy-audit
+
   hardening-report:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -62,11 +78,6 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Runtime policy audit (warning-only on PRs; blocking in release workflow)
-        id: policy
-        continue-on-error: true
-        run: make runtime-policy-audit
-
       - name: Debt report (warning-only)
         id: debt
         continue-on-error: true
@@ -79,16 +90,10 @@ jobs:
       - name: Summarize hardening report
         if: always()
         env:
-          POLICY_OUTCOME: ${{ steps.policy.outcome }}
           DEBT_OUTCOME: ${{ steps.debt.outcome }}
         run: |
           {
             echo "## Hardening Report"
-            if [ "$POLICY_OUTCOME" = "failure" ]; then
-              echo "- runtime-policy audit: findings present; release workflow will block until they are fixed"
-            else
-              echo "- runtime-policy audit: clean"
-            fi
             if [ "$DEBT_OUTCOME" = "failure" ]; then
               echo "- debt report: complexity/duplication debt findings present; review the job log before release"
             else
@@ -96,6 +101,6 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "$POLICY_OUTCOME" = "failure" ] || [ "$DEBT_OUTCOME" = "failure" ]; then
-            echo "::warning::Hardening report found follow-up work. See the workflow summary and logs."
+          if [ "$DEBT_OUTCOME" = "failure" ]; then
+            echo "::warning::Debt report flagged follow-up work. See the workflow summary and logs."
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,15 @@ jobs:
       - name: Verify dependencies
         run: go mod verify
 
+      - name: Run release audit
+        run: make release-audit
+
+      - name: Run runtime-critical packages
+        run: make test-runtime-critical
+
+      - name: Run runtime policy audit
+        run: make runtime-policy-audit
+
       - name: Run tests
         run: go test -race -count=1 ./...
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,9 @@ jobs:
       - name: Verify dependencies
         run: go mod verify
 
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Run release audit
         run: make release-audit
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ LDFLAGS := -ldflags "-s -w \
 	-X $(MODULE)/internal/license.PublicKeyHex=$(LICENSE_PUBLIC_KEY) \
 	-X $(MODULE)/internal/rules.KeyringHex=$(LICENSE_PUBLIC_KEY)"
 
-.PHONY: build test bench lint clean docker install fmt vet tidy-check fuzz stats docs-check
+.PHONY: build test bench lint clean docker install fmt vet tidy-check fuzz stats docs-check \
+	test-runtime-critical release-audit runtime-policy-audit debt-check release-check
 
 build:
 	go build -trimpath $(LDFLAGS) -o $(BINARY) ./cmd/pipelock
@@ -24,6 +25,9 @@ install:
 
 test:
 	go test -race -count=1 ./...
+
+test-runtime-critical:
+	go test -race -count=1 ./internal/config ./internal/cli ./internal/mcp ./internal/proxy
 
 test-cover:
 	go test -race -coverprofile=coverage.out ./...
@@ -41,6 +45,17 @@ vet:
 
 lint: vet
 	golangci-lint run ./...
+
+release-audit:
+	./scripts/release-audit.sh
+
+runtime-policy-audit:
+	./scripts/runtime-policy-audit.sh
+
+debt-check:
+	golangci-lint run --disable-all --enable dupl --enable gocyclo --enable gocognit --enable maintidx ./...
+
+release-check: test lint test-runtime-critical release-audit runtime-policy-audit
 
 tidy-check:
 	go mod tidy

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -15,6 +15,26 @@ tagging a release.
 - Runtime policy changes must be resolved through config-level clone-and-resolve
   logic, not by mutating loaded config inside runtime packages.
 
+### A note on the runtime policy audit
+
+`make runtime-policy-audit` is a coarse regex tripwire: it scans
+`internal/cli/runtime`, `internal/mcp`, and `internal/proxy` for direct
+assignment of a fixed set of policy-relevant config fields outside of test
+files. It catches the common regression class (copy-paste of the pre-refactor
+in-place mutation pattern) but it is not a complete control. Mutation routed
+through a helper, a different field name, or an adjacent package can slip
+past it. Treat its green output as "no obvious regression", not "the
+invariant is proven".
+
+The load-bearing invariants are enforced by Go tests in
+`internal/config/runtime_test.go`: `ResolveRuntime` never mutates its
+receiver, the clone's raw `Hash()` equals the receiver's `Hash()` while
+`CanonicalPolicyHash()` may diverge, deep-clone prevents slice aliasing,
+and the MCP proxy response-scanning fallback runs before the bundle merge.
+A future tightening is an AST analyzer that walks runtime packages and
+asserts every consumer of the loaded config flows through
+`config.ResolveRuntime`; tracked as a follow-up.
+
 ## Required Automated Checks
 
 Run these before tagging locally, and keep the matching GitHub Actions checks

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,69 @@
+# Release Checklist
+
+This checklist is the public, repo-local release gate for Pipelock. It exists
+to catch policy drift, hot-reload regressions, and CI workflow footguns before
+tagging a release.
+
+## Security Model
+
+- PR workflows must use `pull_request`, not `pull_request_target`.
+- PR workflows must not use custom secrets.
+- External GitHub Actions must be pinned to full commit SHAs.
+- PR and CI checkouts must use `persist-credentials: false`.
+- Comment-triggered workflows that use secrets must gate on
+  `author_association` and must check out the PR merge ref, not the head ref.
+- Runtime policy changes must be resolved through config-level clone-and-resolve
+  logic, not by mutating loaded config inside runtime packages.
+
+## Required Automated Checks
+
+Run these before tagging locally, and keep the matching GitHub Actions checks
+required on `main`:
+
+```bash
+make release-audit
+make test-runtime-critical
+make runtime-policy-audit
+go test -race -count=1 ./...
+golangci-lint run ./...
+```
+
+For a one-shot local gate:
+
+```bash
+make release-check
+```
+
+For debt trending that should be reviewed before release even when it does not
+yet block PRs:
+
+```bash
+make debt-check
+```
+
+## Human Sign-Off
+
+- Confirm the release branch is based on the intended commit and that no
+  release-critical PR is waiting to merge.
+- Confirm `Hardening / workflow-audit` and `Hardening / runtime-critical` are
+  green on the candidate commit.
+- Review the `Hardening / hardening-report` summary for policy-drift or debt
+  warnings.
+- Confirm no runtime package is directly mutating policy-relevant config.
+- Confirm receipt and envelope hash call sites still match their intended
+  contracts.
+- Confirm strict-mode hot reload still rejects real downgrades but allows safe
+  operational changes.
+- Confirm degraded rule-bundle behavior is visible in logs and still fail-closed
+  on enforcement paths.
+
+## Repo Settings To Pair With This
+
+These are not enforceable from the repo alone, but they should be configured in
+GitHub:
+
+- Require review before merging changes to `.github/workflows/**`,
+  `scripts/**`, and `Makefile`.
+- Require the `CI` and `Hardening` status checks on `main`.
+- Keep GitHub Actions secrets unavailable to fork PRs.
+- Prefer rulesets or branch protection over manual convention.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1851,6 +1851,280 @@ func TestRunCmd_MCPListenStartupFailure(t *testing.T) {
 	}
 }
 
+func TestRunCmd_MCPListenReloadUsesResolvedConfigForWarnings(t *testing.T) {
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fetchAddr := ln.Addr().String()
+	_ = ln.Close()
+
+	ln2, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mcpAddr := ln2.Addr().String()
+	_ = ln2.Close()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "test.yaml")
+	cfgContent := fmt.Sprintf(`version: 1
+mode: balanced
+fetch_proxy:
+  listen: "%s"
+  timeout_seconds: 5
+`, fetchAddr)
+	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := rootCmd()
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{
+		"run",
+		"--config", cfgPath,
+		"--mcp-listen", mcpAddr,
+		"--mcp-upstream", "http://localhost:19999",
+	})
+	cmd.SetOut(io.Discard)
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- cmd.Execute()
+	}()
+
+	client := &http.Client{Timeout: time.Second}
+	healthURL := "http://" + fetchAddr + "/health"
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case cmdErr := <-errCh:
+			cancel()
+			t.Fatalf("run exited early: %v", cmdErr)
+		default:
+		}
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		if rerr == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	updatedCfg := fmt.Sprintf(`version: 1
+mode: strict
+api_allowlist:
+  - "api.example.com"
+fetch_proxy:
+  listen: "%s"
+  timeout_seconds: 5
+`, fetchAddr)
+	if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	reloadDeadline := time.Now().Add(5 * time.Second)
+	reloaded := false
+	for time.Now().Before(reloadDeadline) {
+		select {
+		case cmdErr := <-errCh:
+			cancel()
+			t.Fatalf("run exited early during reload: %v", cmdErr)
+		default:
+		}
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		if rerr == nil {
+			var health map[string]any
+			_ = json.NewDecoder(resp.Body).Decode(&health)
+			_ = resp.Body.Close()
+			if health["mode"] == config.ModeStrict {
+				reloaded = true
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !reloaded {
+		t.Fatal("hot reload did not apply strict mode before timeout")
+	}
+
+	cancel()
+	select {
+	case cmdErr := <-errCh:
+		if cmdErr != nil {
+			t.Errorf("unexpected error: %v", cmdErr)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("run did not shut down")
+	}
+
+	output := stderr.String()
+	for _, field := range []string{
+		"mcp_input_scanning.enabled",
+		"mcp_tool_scanning.enabled",
+		"mcp_tool_policy.enabled",
+	} {
+		if strings.Contains(output, field) {
+			t.Errorf("unexpected false-positive reload warning for %s:\n%s", field, output)
+		}
+	}
+}
+
+func TestRunCmd_MCPListenReloadStrictAllowsKillSwitchAPIToken(t *testing.T) {
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fetchAddr := ln.Addr().String()
+	_ = ln.Close()
+
+	ln2, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mcpAddr := ln2.Addr().String()
+	_ = ln2.Close()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "test.yaml")
+	cfgContent := fmt.Sprintf(`version: 1
+mode: strict
+api_allowlist:
+  - "api.example.com"
+fetch_proxy:
+  listen: "%s"
+  timeout_seconds: 5
+`, fetchAddr)
+	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := rootCmd()
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{
+		"run",
+		"--config", cfgPath,
+		"--mcp-listen", mcpAddr,
+		"--mcp-upstream", "http://localhost:19999",
+	})
+	cmd.SetOut(io.Discard)
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- cmd.Execute()
+	}()
+
+	client := &http.Client{Timeout: time.Second}
+	healthURL := "http://" + fetchAddr + "/health"
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case cmdErr := <-errCh:
+			cancel()
+			t.Fatalf("run exited early: %v", cmdErr)
+		default:
+		}
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		if rerr == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	statusURL := "http://" + fetchAddr + "/api/v1/killswitch/status"
+	statusReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
+	statusReq.Header.Set("Authorization", "Bearer reload-token")
+	resp, err := client.Do(statusReq) //nolint:gosec // test-only
+	if err != nil {
+		cancel()
+		t.Fatalf("kill switch status request failed before reload: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 before reload, got %d", resp.StatusCode)
+	}
+
+	updatedCfg := fmt.Sprintf(`version: 1
+mode: strict
+api_allowlist:
+  - "api.example.com"
+fetch_proxy:
+  listen: "%s"
+  timeout_seconds: 5
+kill_switch:
+  api_token: "reload-token"
+`, fetchAddr)
+	if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	reloadDeadline := time.Now().Add(5 * time.Second)
+	reloaded := false
+	for time.Now().Before(reloadDeadline) {
+		select {
+		case cmdErr := <-errCh:
+			cancel()
+			t.Fatalf("run exited early during reload: %v", cmdErr)
+		default:
+		}
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
+		req.Header.Set("Authorization", "Bearer reload-token")
+		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		if rerr == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				reloaded = true
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !reloaded {
+		t.Fatal("kill switch API token did not become active after strict-mode reload")
+	}
+
+	cancel()
+	select {
+	case cmdErr := <-errCh:
+		if cmdErr != nil {
+			t.Errorf("unexpected error: %v", cmdErr)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("run did not shut down")
+	}
+
+	output := stderr.String()
+	for _, field := range []string{
+		"mcp_input_scanning.enabled",
+		"mcp_tool_scanning.enabled",
+		"mcp_tool_policy.enabled",
+	} {
+		if strings.Contains(output, field) {
+			t.Errorf("unexpected false-positive reload warning for %s:\n%s", field, output)
+		}
+	}
+}
+
 func TestGenerateCmd_WriteError(t *testing.T) {
 	// Generate config with -o pointing to a read-only directory.
 	dir := t.TempDir()

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1510,7 +1510,7 @@ forward_proxy:
 		default:
 		}
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		resp, rerr := client.Do(req)
 		if rerr == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -1522,7 +1522,7 @@ forward_proxy:
 
 	// Verify health shows forward_proxy_enabled=true
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-	resp, err := client.Do(req) //nolint:gosec // test-only
+	resp, err := client.Do(req)
 	if err != nil {
 		cancel()
 		t.Fatalf("health request failed: %v", err)
@@ -1600,7 +1600,7 @@ forward_proxy:
 		default:
 		}
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		resp, rerr := client.Do(req)
 		if rerr == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -1630,7 +1630,7 @@ forward_proxy:
 
 	// Verify forward_proxy is still disabled (reload was rejected)
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-	resp, err := client.Do(req) //nolint:gosec // test-only
+	resp, err := client.Do(req)
 	if err != nil {
 		cancel()
 		t.Fatalf("health request failed: %v", err)
@@ -1775,7 +1775,7 @@ func TestRunCmd_MCPListenBanner(t *testing.T) {
 		default:
 		}
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		resp, rerr := client.Do(req)
 		if rerr == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -1788,7 +1788,7 @@ func TestRunCmd_MCPListenBanner(t *testing.T) {
 	// Verify MCP listener health endpoint.
 	mcpHealthURL := "http://" + mcpAddr + "/health"
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, mcpHealthURL, nil)
-	resp, err := client.Do(req) //nolint:gosec // test-only
+	resp, err := client.Do(req)
 	if err != nil {
 		cancel()
 		t.Fatalf("MCP health request failed: %v", err)
@@ -1910,7 +1910,7 @@ fetch_proxy:
 		default:
 		}
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		resp, rerr := client.Do(req)
 		if rerr == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -1942,7 +1942,7 @@ fetch_proxy:
 		default:
 		}
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		resp, rerr := client.Do(req)
 		if rerr == nil {
 			var health map[string]any
 			_ = json.NewDecoder(resp.Body).Decode(&health)
@@ -2041,7 +2041,7 @@ fetch_proxy:
 		default:
 		}
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		resp, rerr := client.Do(req)
 		if rerr == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -2054,7 +2054,7 @@ fetch_proxy:
 	statusURL := "http://" + fetchAddr + "/api/v1/killswitch/status"
 	statusReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
 	statusReq.Header.Set("Authorization", "Bearer reload-token")
-	resp, err := client.Do(statusReq) //nolint:gosec // test-only
+	resp, err := client.Do(statusReq)
 	if err != nil {
 		cancel()
 		t.Fatalf("kill switch status request failed before reload: %v", err)
@@ -2089,7 +2089,7 @@ kill_switch:
 		}
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
 		req.Header.Set("Authorization", "Bearer reload-token")
-		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		resp, rerr := client.Do(req)
 		if rerr == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -2240,7 +2240,7 @@ fetch_proxy:
 		default:
 		}
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		resp, rerr := client.Do(req)
 		if rerr == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -2330,7 +2330,7 @@ fetch_proxy:
 		default:
 		}
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		resp, rerr := client.Do(req)
 		if rerr == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -2420,7 +2420,7 @@ fetch_proxy:
 		default:
 		}
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		resp, rerr := client.Do(req)
 		if rerr == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -2509,7 +2509,7 @@ fetch_proxy:
 		default:
 		}
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		resp, rerr := client.Do(req)
 		if rerr == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -2607,7 +2607,7 @@ websocket_proxy:
 		default:
 		}
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // test-only
+		resp, rerr := client.Do(req)
 		if rerr == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -358,6 +358,12 @@ signed action receipts for MCP decisions.`,
 			for _, e := range bundleResult.Errors {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: warning: bundle %s: %s\n", e.Name, e.Reason)
 			}
+			for _, w := range bundleResult.Warnings {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: %s\n", w)
+			}
+			if bundleResult.Degraded {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: DEGRADED — standard pack failed, running core patterns only\n")
+			}
 			emitResolveInfoLogs(cmd.ErrOrStderr(), resolveInfo, "proxy")
 			extraPoison := rules.ConvertToolPoison(bundleResult.ToolPoison)
 

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -144,13 +144,19 @@ Examples:
 				return err
 			}
 
-			// Ensure response scanning is enabled -- that's the command's purpose.
-			if !cfg.ResponseScanning.Enabled {
-				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning: response scanning was disabled in config, enabling with defaults")
-				cfg.ResponseScanning = config.Defaults().ResponseScanning
-			}
-
-			bundleResult := rules.MergeIntoConfig(cfg, cliutil.Version)
+			// Resolve effective policy for scan mode: response-scanning
+			// fallback + bundle merge on a cloned config. The scan
+			// command does not auto-enable MCP scanning because it never
+			// wraps an upstream server; RuntimeMCPProxy mode supplies the
+			// response-scanning fallback behavior the command needs.
+			var bundleResult *rules.LoadResult
+			var resolveInfo config.ResolveRuntimeInfo
+			cfg, resolveInfo = cfg.ResolveRuntime(config.RuntimeResolveOpts{
+				Mode: config.RuntimeMCPScan,
+				MergeBundles: func(c *config.Config) {
+					bundleResult = rules.MergeIntoConfig(c, cliutil.Version)
+				},
+			})
 			for _, e := range bundleResult.Errors {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: warning: bundle %s: %s\n", e.Name, e.Reason)
 			}
@@ -160,6 +166,7 @@ Examples:
 			if bundleResult.Degraded {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: DEGRADED — standard pack failed, running core patterns only\n")
 			}
+			emitResolveInfoLogs(cmd.ErrOrStderr(), resolveInfo, "scan")
 			sc := scanner.New(cfg)
 			defer sc.Close()
 
@@ -351,18 +358,7 @@ signed action receipts for MCP decisions.`,
 			for _, e := range bundleResult.Errors {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: warning: bundle %s: %s\n", e.Name, e.Reason)
 			}
-			if resolveInfo.ResponseScanningFallback {
-				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning: response scanning was disabled in config, enabling with defaults")
-			}
-			if resolveInfo.MCPInputScanningAutoEnabled {
-				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "pipelock: auto-enabling MCP input scanning for proxy mode")
-			}
-			if resolveInfo.MCPToolScanningAutoEnabled {
-				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "pipelock: auto-enabling MCP tool scanning for proxy mode")
-			}
-			if resolveInfo.MCPToolPolicyAutoEnabled {
-				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "pipelock: auto-enabling MCP tool call policy for proxy mode")
-			}
+			emitResolveInfoLogs(cmd.ErrOrStderr(), resolveInfo, "proxy")
 			extraPoison := rules.ConvertToolPoison(bundleResult.ToolPoison)
 
 			// Rebuild scanner with the (possibly modified) resolved config.

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -333,25 +333,35 @@ signed action receipts for MCP decisions.`,
 				defer sentryClient.Close()
 			}
 
-			if !cfg.ResponseScanning.Enabled {
-				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning: response scanning was disabled in config, enabling with defaults")
-				cfg.ResponseScanning = config.Defaults().ResponseScanning
-			}
-
-			// Auto-enable MCP input scanning for proxy mode unless the user explicitly
-			// configured the section. Action is only set by ApplyDefaults when Enabled
-			// is true, so Action=="" with Enabled=false means unconfigured. OnParseError
-			// is always defaulted by ApplyDefaults, so we don't check it here.
-			if !cfg.MCPInputScanning.Enabled && cfg.MCPInputScanning.Action == "" {
-				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "pipelock: auto-enabling MCP input scanning for proxy mode")
-				cfg.MCPInputScanning.Enabled = true
-				cfg.MCPInputScanning.Action = config.ActionBlock
-			}
-
-			// Merge community rule bundles before building the scanner.
-			bundleResult := rules.MergeIntoConfig(cfg, cliutil.Version)
+			// Resolve effective runtime policy on a clone. The MCP proxy
+			// mode response-scanning fallback, MCP scanning auto-enable,
+			// and bundle merges all run inside ResolveRuntime so the
+			// loaded cfg is never mutated and the clone's CanonicalPolicyHash
+			// reflects the effective policy every downstream emitter,
+			// scanner, and receipt stamp consumes.
+			var bundleResult *rules.LoadResult
+			var resolveInfo config.ResolveRuntimeInfo
+			cfg, resolveInfo = cfg.ResolveRuntime(config.RuntimeResolveOpts{
+				Mode: config.RuntimeMCPProxy,
+				MergeBundles: func(c *config.Config) {
+					bundleResult = rules.MergeIntoConfig(c, cliutil.Version)
+				},
+				DefaultToolPolicyRules: policy.DefaultToolPolicyRules,
+			})
 			for _, e := range bundleResult.Errors {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: warning: bundle %s: %s\n", e.Name, e.Reason)
+			}
+			if resolveInfo.ResponseScanningFallback {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning: response scanning was disabled in config, enabling with defaults")
+			}
+			if resolveInfo.MCPInputScanningAutoEnabled {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "pipelock: auto-enabling MCP input scanning for proxy mode")
+			}
+			if resolveInfo.MCPToolScanningAutoEnabled {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "pipelock: auto-enabling MCP tool scanning for proxy mode")
+			}
+			if resolveInfo.MCPToolPolicyAutoEnabled {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "pipelock: auto-enabling MCP tool call policy for proxy mode")
 			}
 			extraPoison := rules.ConvertToolPoison(bundleResult.ToolPoison)
 
@@ -383,14 +393,6 @@ signed action receipts for MCP decisions.`,
 				}
 			}
 
-			// Auto-enable MCP tool scanning for proxy mode unless explicitly configured.
-			if !cfg.MCPToolScanning.Enabled && cfg.MCPToolScanning.Action == "" {
-				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "pipelock: auto-enabling MCP tool scanning for proxy mode")
-				cfg.MCPToolScanning.Enabled = true
-				cfg.MCPToolScanning.Action = config.ActionWarn
-				cfg.MCPToolScanning.DetectDrift = true
-			}
-
 			var toolCfg *tools.ToolScanConfig
 			if cfg.MCPToolScanning.Enabled {
 				toolCfg = &tools.ToolScanConfig{
@@ -403,15 +405,6 @@ signed action receipts for MCP decisions.`,
 					toolCfg.BindingUnknownAction = cfg.MCPSessionBinding.UnknownToolAction
 					toolCfg.BindingNoBaselineAction = cfg.MCPSessionBinding.NoBaselineAction
 				}
-			}
-
-			// Auto-enable MCP tool call policy for proxy mode unless explicitly configured.
-			// Action=="" with Enabled=false and no rules means unconfigured.
-			if !cfg.MCPToolPolicy.Enabled && cfg.MCPToolPolicy.Action == "" && len(cfg.MCPToolPolicy.Rules) == 0 {
-				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "pipelock: auto-enabling MCP tool call policy for proxy mode")
-				cfg.MCPToolPolicy.Enabled = true
-				cfg.MCPToolPolicy.Action = config.ActionWarn
-				cfg.MCPToolPolicy.Rules = policy.DefaultToolPolicyRules()
 			}
 
 			var policyCfg *policy.Config
@@ -541,6 +534,15 @@ signed action receipts for MCP decisions.`,
 				}
 				defer func() { _ = rec.Close() }()
 
+				// ConfigHash here uses cfg.Hash() (raw YAML bytes) — the
+				// receipt is a point-in-time audit fingerprint of the
+				// loaded configuration file. The envelope emitter below
+				// uses cfg.CanonicalPolicyHash() because its contract is
+				// about effective policy equivalence, not file identity.
+				// Intentional split, preserved across the runtime-resolve
+				// refactor: the resolved cfg carries the original rawBytes
+				// so Hash() still reflects the on-disk YAML even after
+				// bundle merge and auto-enable.
 				receiptEmitter = receipt.NewEmitter(receipt.EmitterConfig{
 					Recorder:   rec,
 					PrivKey:    recPrivKey,

--- a/internal/cli/runtime/resolve_logs.go
+++ b/internal/cli/runtime/resolve_logs.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// emitResolveInfoLogs writes the operator-facing notices that correspond
+// to the auto-enable and fallback branches a config.ResolveRuntime call
+// reported as having fired. modeLabel is interpolated into the
+// "auto-enabling … for X mode" message so `pipelock run --mcp-listen`
+// and `pipelock mcp proxy` remain distinguishable in logs.
+//
+// The helper exists so the runtime commands can share one source of
+// truth for these messages and so the branches are trivially
+// unit-testable without spinning up a full proxy process.
+func emitResolveInfoLogs(w io.Writer, info config.ResolveRuntimeInfo, modeLabel string) {
+	if info.ResponseScanningFallback {
+		_, _ = fmt.Fprintln(w, "warning: response scanning was disabled in config, enabling with defaults")
+	}
+	if info.MCPInputScanningAutoEnabled {
+		_, _ = fmt.Fprintf(w, "pipelock: auto-enabling MCP input scanning for %s mode\n", modeLabel)
+	}
+	if info.MCPToolScanningAutoEnabled {
+		_, _ = fmt.Fprintf(w, "pipelock: auto-enabling MCP tool scanning for %s mode\n", modeLabel)
+	}
+	if info.MCPToolPolicyAutoEnabled {
+		_, _ = fmt.Fprintf(w, "pipelock: auto-enabling MCP tool call policy for %s mode\n", modeLabel)
+	}
+}

--- a/internal/cli/runtime/resolve_logs_test.go
+++ b/internal/cli/runtime/resolve_logs_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestEmitResolveInfoLogs(t *testing.T) {
+	t.Run("all branches fired", func(t *testing.T) {
+		var buf bytes.Buffer
+		emitResolveInfoLogs(&buf, config.ResolveRuntimeInfo{
+			ResponseScanningFallback:    true,
+			MCPInputScanningAutoEnabled: true,
+			MCPToolScanningAutoEnabled:  true,
+			MCPToolPolicyAutoEnabled:    true,
+		}, "proxy")
+
+		want := []string{
+			"warning: response scanning was disabled in config, enabling with defaults",
+			"pipelock: auto-enabling MCP input scanning for proxy mode",
+			"pipelock: auto-enabling MCP tool scanning for proxy mode",
+			"pipelock: auto-enabling MCP tool call policy for proxy mode",
+		}
+		got := buf.String()
+		for _, line := range want {
+			if !strings.Contains(got, line) {
+				t.Errorf("missing log line %q in output:\n%s", line, got)
+			}
+		}
+	})
+
+	t.Run("no branches fired", func(t *testing.T) {
+		var buf bytes.Buffer
+		emitResolveInfoLogs(&buf, config.ResolveRuntimeInfo{}, "proxy")
+		if buf.Len() != 0 {
+			t.Errorf("expected empty output, got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("mode label interpolated", func(t *testing.T) {
+		var buf bytes.Buffer
+		emitResolveInfoLogs(&buf, config.ResolveRuntimeInfo{
+			MCPInputScanningAutoEnabled: true,
+		}, "listener")
+		if !strings.Contains(buf.String(), "for listener mode") {
+			t.Errorf("mode label not interpolated; got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("only response fallback fires", func(t *testing.T) {
+		var buf bytes.Buffer
+		emitResolveInfoLogs(&buf, config.ResolveRuntimeInfo{
+			ResponseScanningFallback: true,
+		}, "proxy")
+		out := buf.String()
+		if !strings.Contains(out, "warning: response scanning was disabled") {
+			t.Errorf("expected response-fallback line, got:\n%s", out)
+		}
+		if strings.Contains(out, "auto-enabling MCP") {
+			t.Errorf("unexpected auto-enable line when only fallback fired; got:\n%s", out)
+		}
+	})
+
+	t.Run("only tool scanning fires", func(t *testing.T) {
+		var buf bytes.Buffer
+		emitResolveInfoLogs(&buf, config.ResolveRuntimeInfo{
+			MCPToolScanningAutoEnabled: true,
+		}, "proxy")
+		out := buf.String()
+		if !strings.Contains(out, "auto-enabling MCP tool scanning for proxy mode") {
+			t.Errorf("expected tool-scanning line, got:\n%s", out)
+		}
+		if strings.Contains(out, "tool call policy") || strings.Contains(out, "input scanning") {
+			t.Errorf("unexpected additional branches fired; got:\n%s", out)
+		}
+	})
+}

--- a/internal/cli/runtime/run.go
+++ b/internal/cli/runtime/run.go
@@ -256,8 +256,26 @@ Examples:
 			defer func() { _ = emitter.Close() }()
 			logger.SetEmitter(emitter)
 
-			// Merge community rule bundles before building the scanner.
-			bundleResult := rules.MergeIntoConfig(cfg, cliutil.Version)
+			// Resolve effective runtime policy on a clone. Bundle merges
+			// and MCP auto-enable run inside ResolveRuntime against the
+			// clone, so the loaded cfg stays frozen and the resolved
+			// clone's CanonicalPolicyHash reflects the policy the proxy
+			// actually enforces. Every downstream consumer (scanner,
+			// emitter, proxy, hot-reload diff) reads from the resolved
+			// clone.
+			runtimeMode := config.RuntimeForward
+			if hasMCPListen {
+				runtimeMode = config.RuntimeForwardWithMCPListener
+			}
+			var bundleResult *rules.LoadResult
+			var resolveInfo config.ResolveRuntimeInfo
+			cfg, resolveInfo = cfg.ResolveRuntime(config.RuntimeResolveOpts{
+				Mode: runtimeMode,
+				MergeBundles: func(c *config.Config) {
+					bundleResult = rules.MergeIntoConfig(c, cliutil.Version)
+				},
+				DefaultToolPolicyRules: policy.DefaultToolPolicyRules,
+			})
 			for _, e := range bundleResult.Errors {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: warning: bundle %s: %s\n", e.Name, e.Reason)
 			}
@@ -266,6 +284,15 @@ Examples:
 			}
 			if bundleResult.Degraded {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: DEGRADED — standard pack failed, running core patterns only\n")
+			}
+			if resolveInfo.MCPInputScanningAutoEnabled {
+				cmd.PrintErrln("pipelock: auto-enabling MCP input scanning for listener mode")
+			}
+			if resolveInfo.MCPToolScanningAutoEnabled {
+				cmd.PrintErrln("pipelock: auto-enabling MCP tool scanning for listener mode")
+			}
+			if resolveInfo.MCPToolPolicyAutoEnabled {
+				cmd.PrintErrln("pipelock: auto-enabling MCP tool call policy for listener mode")
 			}
 
 			// Shared runtime components referenced by hooks and reload paths.
@@ -391,6 +418,17 @@ Examples:
 				// Action receipt emitter: signs every proxy decision with
 				// Ed25519 and writes to the flight recorder. Requires a
 				// signing key — nil emitter means receipts are disabled.
+				//
+				// ConfigHash here uses cfg.Hash() (raw YAML bytes) rather
+				// than cfg.CanonicalPolicyHash() because the receipt is a
+				// point-in-time audit fingerprint of the loaded
+				// configuration file: two deployments that happened to
+				// produce the same effective policy through different
+				// YAML should still be distinguishable in a forensic
+				// trail. Envelope attestation (below) uses the
+				// policy-semantic hash because its contract is the
+				// opposite — identical effective policy should produce
+				// identical envelope ph regardless of YAML formatting.
 				receiptEmitter = receipt.NewEmitter(receipt.EmitterConfig{
 					Recorder:   rec,
 					PrivKey:    recPrivKey,
@@ -482,19 +520,8 @@ Examples:
 									ReloadPanicHandler(r, sentryClient, logger, configFile)
 								}
 							}()
-							// Check for security downgrades before applying
 							oldCfg := p.CurrentConfig()
 							if oldCfg != nil {
-								warnings := config.ValidateReload(oldCfg, newCfg)
-								for _, w := range warnings {
-									cmd.PrintErrf("WARNING: config reload: %s - %s\n", w.Field, w.Message)
-								}
-								// Block downgrades from strict mode (security-critical).
-								if oldCfg.Mode == config.ModeStrict && len(warnings) > 0 {
-									logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, configFile),
-										fmt.Errorf("rejected: security downgrade from strict mode"))
-									return
-								}
 								// Block enabling forward proxy via reload. WriteTimeout is
 								// set at server start and cannot change at runtime; tunnels
 								// would be killed prematurely. Restart to enable.
@@ -618,7 +645,22 @@ Examples:
 								// old value until restart.
 								newCfg.LicenseExpiresAt = oldCfg.LicenseExpiresAt
 							}
-							reloadBundleResult := rules.MergeIntoConfig(newCfg, cliutil.Version)
+							// Resolve runtime policy on a clone of the newly
+							// loaded config so the reloaded cfg stored in
+							// the proxy reflects the same bundle-merge +
+							// auto-enable pipeline startup uses and its
+							// canonical hash is computed fresh. The live
+							// runtime mode tracks the startup flags:
+							// reload cannot toggle MCP listener or forward
+							// proxy enablement (both gated above).
+							var reloadBundleResult *rules.LoadResult
+							newCfg, _ = newCfg.ResolveRuntime(config.RuntimeResolveOpts{
+								Mode: runtimeMode,
+								MergeBundles: func(c *config.Config) {
+									reloadBundleResult = rules.MergeIntoConfig(c, cliutil.Version)
+								},
+								DefaultToolPolicyRules: policy.DefaultToolPolicyRules,
+							})
 							for _, e := range reloadBundleResult.Errors {
 								cmd.PrintErrf("WARNING: config reload: bundle %s: %s\n", e.Name, e.Reason)
 							}
@@ -627,6 +669,21 @@ Examples:
 							}
 							if reloadBundleResult.Degraded {
 								cmd.PrintErrf("WARNING: DEGRADED — standard pack failed after reload, running core patterns only\n")
+							}
+							if oldCfg != nil {
+								// Compare resolved-vs-resolved configs so bundle merges
+								// and MCP listener auto-enable do not look like policy
+								// downgrades during hot reload.
+								warnings := config.ValidateReload(oldCfg, newCfg)
+								for _, w := range warnings {
+									cmd.PrintErrf("WARNING: config reload: %s - %s\n", w.Field, w.Message)
+								}
+								// Block downgrades from strict mode (security-critical).
+								if oldCfg.Mode == config.ModeStrict && len(warnings) > 0 {
+									logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, configFile),
+										fmt.Errorf("rejected: security downgrade from strict mode"))
+									return
+								}
 							}
 							newSc := scanner.New(newCfg)
 							newSc.SetDLPWarnHook(func(ctx context.Context, patternName, severity string) {
@@ -888,24 +945,9 @@ Examples:
 			// Start MCP HTTP listener in background if configured.
 			var mcpErr chan error
 			if hasMCPListen {
-				// Auto-enable MCP scanning features for listener mode.
-				if !cfg.MCPInputScanning.Enabled && cfg.MCPInputScanning.Action == "" {
-					cmd.PrintErrln("pipelock: auto-enabling MCP input scanning for listener mode")
-					cfg.MCPInputScanning.Enabled = true
-					cfg.MCPInputScanning.Action = config.ActionBlock
-				}
-				if !cfg.MCPToolScanning.Enabled && cfg.MCPToolScanning.Action == "" {
-					cmd.PrintErrln("pipelock: auto-enabling MCP tool scanning for listener mode")
-					cfg.MCPToolScanning.Enabled = true
-					cfg.MCPToolScanning.Action = config.ActionWarn
-					cfg.MCPToolScanning.DetectDrift = true
-				}
-				if !cfg.MCPToolPolicy.Enabled && cfg.MCPToolPolicy.Action == "" && len(cfg.MCPToolPolicy.Rules) == 0 {
-					cmd.PrintErrln("pipelock: auto-enabling MCP tool call policy for listener mode")
-					cfg.MCPToolPolicy.Enabled = true
-					cfg.MCPToolPolicy.Action = config.ActionWarn
-					cfg.MCPToolPolicy.Rules = policy.DefaultToolPolicyRules()
-				}
+				// MCP scanning sections auto-enable inside ResolveRuntime
+				// above when the operator did not configure them; the
+				// effective cfg already reflects those defaults.
 
 				inputCfg := &mcp.InputScanConfig{
 					Enabled:      cfg.MCPInputScanning.Enabled,

--- a/internal/cli/runtime/run.go
+++ b/internal/cli/runtime/run.go
@@ -285,15 +285,7 @@ Examples:
 			if bundleResult.Degraded {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: DEGRADED — standard pack failed, running core patterns only\n")
 			}
-			if resolveInfo.MCPInputScanningAutoEnabled {
-				cmd.PrintErrln("pipelock: auto-enabling MCP input scanning for listener mode")
-			}
-			if resolveInfo.MCPToolScanningAutoEnabled {
-				cmd.PrintErrln("pipelock: auto-enabling MCP tool scanning for listener mode")
-			}
-			if resolveInfo.MCPToolPolicyAutoEnabled {
-				cmd.PrintErrln("pipelock: auto-enabling MCP tool call policy for listener mode")
-			}
+			emitResolveInfoLogs(cmd.ErrOrStderr(), resolveInfo, "listener")
 
 			// Shared runtime components referenced by hooks and reload paths.
 			var receiptEmitter *receipt.Emitter

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -56,6 +56,13 @@ import (
 // Config after a canonical hash has been computed will silently return
 // a stale hash. Tests must use fresh Config values for sensitivity.
 func (c *Config) CanonicalPolicyHash() string {
+	if c.canonicalHashCache == nil {
+		// Lazy-init for *Config values constructed outside Load() /
+		// Clone() (tests using Defaults() directly). Load-time callers
+		// drive a single serial init via Load()'s eager warm; concurrent
+		// first-touch on a Defaults() value is not a supported pattern.
+		c.canonicalHashCache = &canonicalHashCacheHolder{}
+	}
 	if cached := c.canonicalHashCache.Load(); cached != nil {
 		if s, ok := cached.(string); ok {
 			return s

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -421,10 +421,15 @@ type Config struct {
 	// canonicalHashCache memoises CanonicalPolicyHash() so repeated calls
 	// on the same *Config value do not re-walk and re-marshal the struct.
 	// Unexported — json.Marshal skips it, yaml does not see it, and test
-	// helpers that build fresh Config values always start with an empty
-	// atomic. Config instances are treated as immutable after Load(); any
-	// mutation after a hash has been computed will return a stale value.
-	canonicalHashCache canonicalHashCacheHolder `yaml:"-"`
+	// helpers that build fresh Config values always start with a nil
+	// pointer (lazy-initialised on first hash read). The field is a
+	// pointer rather than an embedded atomic.Value so that struct copies
+	// (e.g., Config.Clone's `clone := *c`) duplicate the pointer only —
+	// atomic.Value forbids copying after first use, and every caller that
+	// wants a fresh cache explicitly reassigns the pointer. Config
+	// instances are treated as immutable after Load(); any mutation after
+	// a hash has been computed will return a stale value.
+	canonicalHashCache *canonicalHashCacheHolder `yaml:"-"`
 }
 
 // MCPInputScanning configures scanning of MCP JSON-RPC requests going from

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -207,6 +207,15 @@ func (c *Config) Clone() *Config {
 
 	clone.DLP.Patterns = cloneDLPPatterns(c.DLP.Patterns)
 	clone.ResponseScanning.Patterns = cloneResponseScanPatterns(c.ResponseScanning.Patterns)
+	// ExemptDomains is a reload-sensitive exemption surface: operators
+	// remove entries via hot-reload and ValidateReload warns when the
+	// list is cleared. Without deep-copying the slice here, a runtime
+	// caller that appends to clone.ResponseScanning.ExemptDomains would
+	// alias back into the loaded config, breaking the frozen-after-Load
+	// guarantee for this field.
+	if c.ResponseScanning.ExemptDomains != nil {
+		clone.ResponseScanning.ExemptDomains = append([]string(nil), c.ResponseScanning.ExemptDomains...)
+	}
 	clone.MCPToolPolicy.Rules = cloneToolPolicyRules(c.MCPToolPolicy.Rules)
 
 	return &clone

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -27,12 +27,28 @@ const (
 	// response scanning (response scanning is the MCP proxy's primary
 	// injection surface).
 	RuntimeMCPProxy
+
+	// RuntimeMCPScan runs `pipelock mcp scan`, the one-shot stdin-driven
+	// scanner for MCP responses. Response scanning is the command's sole
+	// purpose so the fallback still fires, but the command does not wrap
+	// an upstream server and therefore skips MCP input / tool / policy
+	// auto-enable.
+	RuntimeMCPScan
 )
 
 // WrapsMCP reports whether the mode routes MCP traffic through pipelock and
-// therefore needs MCP scanning auto-enable defaults.
+// therefore needs MCP scanning auto-enable defaults. Scan mode is
+// excluded: it consumes responses from stdin without ever proxying.
 func (m RuntimeMode) WrapsMCP() bool {
 	return m == RuntimeForwardWithMCPListener || m == RuntimeMCPProxy
+}
+
+// NeedsResponseScanningFallback reports whether the mode requires the
+// response-scanning defaults to be re-enabled when the operator disabled
+// them. Both `mcp proxy` and `mcp scan` process MCP responses and rely on
+// response scanning for injection detection.
+func (m RuntimeMode) NeedsResponseScanningFallback() bool {
+	return m == RuntimeMCPProxy || m == RuntimeMCPScan
 }
 
 // RuntimeResolveOpts controls how ResolveRuntime assembles the effective
@@ -99,7 +115,7 @@ func (c *Config) ResolveRuntime(opts RuntimeResolveOpts) (*Config, ResolveRuntim
 	clone := c.Clone()
 	var info ResolveRuntimeInfo
 
-	if opts.Mode == RuntimeMCPProxy && !clone.ResponseScanning.Enabled {
+	if opts.Mode.NeedsResponseScanningFallback() && !clone.ResponseScanning.Enabled {
 		// MCP proxy mode re-enables default response scanning if the
 		// operator disabled it. Response scanning is the primary injection
 		// defence on the MCP response path; silently running without it
@@ -173,10 +189,12 @@ func (c *Config) Clone() *Config {
 	}
 	clone := *c
 
-	// atomic.Value must not be copied after first use. Replace with a
-	// fresh zero value so the clone starts with an empty canonical hash
-	// cache and computes against its own post-resolve state.
-	clone.canonicalHashCache = canonicalHashCacheHolder{}
+	// The field is a *canonicalHashCacheHolder so the struct copy above
+	// duplicated the pointer, not the atomic.Value (atomic.Value forbids
+	// copying after first use). Allocate a fresh holder so the clone
+	// starts with an empty cache and computes against its own
+	// post-resolve state.
+	clone.canonicalHashCache = &canonicalHashCacheHolder{}
 
 	// Copy rawBytes so mutations to the clone's byte buffer do not alias
 	// back to the receiver. Hash() on the clone continues to reflect the

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -1,0 +1,235 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+// RuntimeMode selects which runtime-time defaults ResolveRuntime applies.
+// It is an explicit CLI-surface value: the same loaded Config can produce
+// different effective policies depending on which command path consumes it
+// (forward proxy alone, forward proxy with an MCP listener, or `mcp proxy`
+// wrapper), and canonical policy hashes stamped on receipts/envelopes must
+// reflect the mode-specific defaults that actually ran.
+type RuntimeMode uint8
+
+const (
+	// RuntimeForward runs the forward / fetch proxy without an MCP listener.
+	RuntimeForward RuntimeMode = iota + 1
+
+	// RuntimeForwardWithMCPListener runs the forward / fetch proxy alongside
+	// an MCP HTTP listener (run --mcp-listen). MCP input scanning, tool
+	// scanning, and tool policy auto-enable with safe defaults when the
+	// operator did not configure them.
+	RuntimeForwardWithMCPListener
+
+	// RuntimeMCPProxy runs `pipelock mcp proxy` in stdio or HTTP wrapping
+	// mode. Same MCP auto-enable as the listener mode, plus a response
+	// scanning fallback that re-enables defaults if the operator disabled
+	// response scanning (response scanning is the MCP proxy's primary
+	// injection surface).
+	RuntimeMCPProxy
+)
+
+// WrapsMCP reports whether the mode routes MCP traffic through pipelock and
+// therefore needs MCP scanning auto-enable defaults.
+func (m RuntimeMode) WrapsMCP() bool {
+	return m == RuntimeForwardWithMCPListener || m == RuntimeMCPProxy
+}
+
+// RuntimeResolveOpts controls how ResolveRuntime assembles the effective
+// runtime policy. Each field is independently optional; zero-value opts
+// still produce a valid clone (no bundle merge, no auto-enable, no
+// fallback).
+type RuntimeResolveOpts struct {
+	// Mode selects the runtime profile. A zero value skips mode-specific
+	// auto-enable and the MCP proxy response-scanning fallback.
+	Mode RuntimeMode
+
+	// MergeBundles, if non-nil, is invoked on the freshly cloned config
+	// before any mode-specific auto-enable runs. Callers use it to merge
+	// rule bundles into DLP and response scanning pattern lists without
+	// creating an import cycle on the rules package.
+	MergeBundles func(*Config)
+
+	// DefaultToolPolicyRules, if non-nil, is invoked when MCP tool policy
+	// auto-enables to populate MCPToolPolicy.Rules. Passed as a function
+	// (rather than a slice) so it is only evaluated when auto-enable
+	// actually fires, and so the config package does not import the
+	// mcp/policy package that owns the defaults.
+	DefaultToolPolicyRules func() []ToolPolicyRule
+}
+
+// ResolveRuntimeInfo captures which auto-enable and fallback branches
+// fired during ResolveRuntime. Callers log operator-facing messages based
+// on these flags: the config package does not print directly so it stays
+// free of an io.Writer dependency and so tests can verify the resolution
+// decisions without parsing stderr.
+type ResolveRuntimeInfo struct {
+	// ResponseScanningFallback is true when MCP proxy mode re-enabled
+	// default response scanning because the operator had disabled it.
+	ResponseScanningFallback bool
+
+	// MCPInputScanningAutoEnabled is true when input scanning was
+	// unconfigured and the runtime default was applied.
+	MCPInputScanningAutoEnabled bool
+
+	// MCPToolScanningAutoEnabled is true when tool scanning was
+	// unconfigured and the runtime default was applied.
+	MCPToolScanningAutoEnabled bool
+
+	// MCPToolPolicyAutoEnabled is true when tool policy was
+	// unconfigured and the runtime default was applied.
+	MCPToolPolicyAutoEnabled bool
+}
+
+// ResolveRuntime returns a cloned *Config with runtime-mode policy
+// resolution applied, plus a ResolveRuntimeInfo describing which defaults
+// fired. The receiver is never mutated; downstream runtime wiring
+// (scanner construction, emitters, proxy) must consume the returned
+// clone so any canonical policy hash stamped on receipts or envelopes
+// reflects the effective policy that was actually enforced.
+//
+// The resolution order is intentional: (1) deep clone, (2) MCP proxy
+// response-scanning fallback, (3) caller-supplied bundle merge,
+// (4) mode-aware MCP scanning auto-enable. The fallback runs before the
+// bundle merge because it replaces the entire ResponseScanning struct
+// with defaults; any bundle-appended ResponseScanning.Patterns applied
+// before the fallback would be wiped. Running the fallback first lets
+// the merge append its patterns on top of the default set.
+func (c *Config) ResolveRuntime(opts RuntimeResolveOpts) (*Config, ResolveRuntimeInfo) {
+	clone := c.Clone()
+	var info ResolveRuntimeInfo
+
+	if opts.Mode == RuntimeMCPProxy && !clone.ResponseScanning.Enabled {
+		// MCP proxy mode re-enables default response scanning if the
+		// operator disabled it. Response scanning is the primary injection
+		// defence on the MCP response path; silently running without it
+		// would leave tool responses unscanned. Runs before MergeBundles
+		// because this replaces the entire struct, which would otherwise
+		// wipe bundle-appended patterns.
+		clone.ResponseScanning = Defaults().ResponseScanning
+		info.ResponseScanningFallback = true
+	}
+
+	if opts.MergeBundles != nil {
+		opts.MergeBundles(clone)
+	}
+
+	if opts.Mode.WrapsMCP() {
+		applyMCPAutoEnable(clone, opts.DefaultToolPolicyRules, &info)
+	}
+
+	return clone, info
+}
+
+// applyMCPAutoEnable flips MCP scanning sections on when the operator did
+// not explicitly configure them. A section counts as unconfigured when
+// Enabled is false AND Action is empty (ApplyDefaults sets Action only
+// when Enabled is true, so an empty Action with Enabled false indicates
+// an unset YAML section rather than an explicit disable). Tool policy also
+// requires len(Rules)==0 for the same reason. Each auto-enable branch
+// records its decision on info so callers can print operator-facing
+// log messages without replicating the predicate.
+func applyMCPAutoEnable(c *Config, defaultToolPolicyRules func() []ToolPolicyRule, info *ResolveRuntimeInfo) {
+	if !c.MCPInputScanning.Enabled && c.MCPInputScanning.Action == "" {
+		c.MCPInputScanning.Enabled = true
+		c.MCPInputScanning.Action = ActionBlock
+		info.MCPInputScanningAutoEnabled = true
+	}
+	if !c.MCPToolScanning.Enabled && c.MCPToolScanning.Action == "" {
+		c.MCPToolScanning.Enabled = true
+		c.MCPToolScanning.Action = ActionWarn
+		c.MCPToolScanning.DetectDrift = true
+		info.MCPToolScanningAutoEnabled = true
+	}
+	if !c.MCPToolPolicy.Enabled && c.MCPToolPolicy.Action == "" && len(c.MCPToolPolicy.Rules) == 0 {
+		c.MCPToolPolicy.Enabled = true
+		c.MCPToolPolicy.Action = ActionWarn
+		if defaultToolPolicyRules != nil {
+			c.MCPToolPolicy.Rules = defaultToolPolicyRules()
+		}
+		info.MCPToolPolicyAutoEnabled = true
+	}
+}
+
+// Clone returns a deep copy of c suitable for runtime mutation. The clone
+// has a fresh canonical hash cache, and policy-semantic slices (DLP
+// patterns, response scan patterns, tool policy rules) are independently
+// allocated so mutations to the clone never alias back into the receiver.
+//
+// rawBytes is copied verbatim so Hash() on the clone still reflects the
+// on-disk YAML bytes that were loaded — the receipt-audit fingerprint is
+// about "what YAML file was loaded", which does not change under bundle
+// merge or auto-enable. CanonicalPolicyHash recomputes from the clone's
+// current state the first time it is called.
+//
+// Nested slices inside DLPPattern (ExemptDomains) and other mutable
+// collections touched by ResolveRuntime are copied as well. Unmodified
+// nested collections (map fields in MCPToolPolicy, AgentProfile maps, and
+// similar) are shallow-copied; callers that mutate those directly outside
+// the ResolveRuntime pipeline are responsible for their own aliasing.
+func (c *Config) Clone() *Config {
+	if c == nil {
+		return nil
+	}
+	clone := *c
+
+	// atomic.Value must not be copied after first use. Replace with a
+	// fresh zero value so the clone starts with an empty canonical hash
+	// cache and computes against its own post-resolve state.
+	clone.canonicalHashCache = canonicalHashCacheHolder{}
+
+	// Copy rawBytes so mutations to the clone's byte buffer do not alias
+	// back to the receiver. Hash() on the clone continues to reflect the
+	// original on-disk YAML bytes.
+	if c.rawBytes != nil {
+		buf := make([]byte, len(c.rawBytes))
+		copy(buf, c.rawBytes)
+		clone.rawBytes = buf
+	}
+
+	clone.DLP.Patterns = cloneDLPPatterns(c.DLP.Patterns)
+	clone.ResponseScanning.Patterns = cloneResponseScanPatterns(c.ResponseScanning.Patterns)
+	clone.MCPToolPolicy.Rules = cloneToolPolicyRules(c.MCPToolPolicy.Rules)
+
+	return &clone
+}
+
+// cloneDLPPatterns returns a deep copy of src. Each pattern's ExemptDomains
+// slice is copied so mutating the clone never leaks back into src.
+func cloneDLPPatterns(src []DLPPattern) []DLPPattern {
+	if src == nil {
+		return nil
+	}
+	dst := make([]DLPPattern, len(src))
+	for i := range src {
+		dst[i] = src[i]
+		if src[i].ExemptDomains != nil {
+			dst[i].ExemptDomains = append([]string(nil), src[i].ExemptDomains...)
+		}
+	}
+	return dst
+}
+
+// cloneResponseScanPatterns returns a deep copy of src. ResponseScanPattern
+// has no nested slices today; the helper exists so future additions pick up
+// deep-copy behavior without caller churn.
+func cloneResponseScanPatterns(src []ResponseScanPattern) []ResponseScanPattern {
+	if src == nil {
+		return nil
+	}
+	dst := make([]ResponseScanPattern, len(src))
+	copy(dst, src)
+	return dst
+}
+
+// cloneToolPolicyRules returns a deep copy of src. ToolPolicyRule has only
+// scalar fields today; the helper keeps the pattern consistent with the
+// other clone helpers and gives future nested-slice additions a clear home.
+func cloneToolPolicyRules(src []ToolPolicyRule) []ToolPolicyRule {
+	if src == nil {
+		return nil
+	}
+	dst := make([]ToolPolicyRule, len(src))
+	copy(dst, src)
+	return dst
+}

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -1,0 +1,555 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+const mutatedSentinel = "mutated"
+
+// TestResolveRuntime_LoadedConfigNotMutated is the core immutability
+// invariant: ResolveRuntime must not mutate its receiver. The loaded
+// *Config is treated as immutable after Load() returns, and its
+// canonical hash cache is warmed against that post-Load snapshot.
+// Runtime-mode defaults (bundle merges, MCP auto-enable) apply to the
+// returned clone only.
+func TestResolveRuntime_LoadedConfigNotMutated(t *testing.T) {
+	cfg := Defaults()
+	cfg.rawBytes = []byte("mode: balanced\n")
+	beforeHash := cfg.CanonicalPolicyHash()
+	beforeRawHash := cfg.Hash()
+	beforeInput := cfg.MCPInputScanning
+	beforeTool := cfg.MCPToolScanning
+	beforePolicy := cfg.MCPToolPolicy
+	beforeResponse := cfg.ResponseScanning
+
+	resolved, _ := cfg.ResolveRuntime(RuntimeResolveOpts{
+		Mode: RuntimeForwardWithMCPListener,
+		MergeBundles: func(c *Config) {
+			c.DLP.Patterns = append(c.DLP.Patterns, DLPPattern{Name: "bundle", Regex: "."})
+		},
+	})
+
+	if got := cfg.CanonicalPolicyHash(); got != beforeHash {
+		t.Errorf("CanonicalPolicyHash on loaded config changed after resolve: before=%s after=%s", beforeHash, got)
+	}
+	if got := cfg.Hash(); got != beforeRawHash {
+		t.Errorf("Hash on loaded config changed after resolve: before=%s after=%s", beforeRawHash, got)
+	}
+	if !reflect.DeepEqual(cfg.MCPInputScanning, beforeInput) {
+		t.Errorf("MCPInputScanning mutated on loaded config: got %+v want %+v", cfg.MCPInputScanning, beforeInput)
+	}
+	if !reflect.DeepEqual(cfg.MCPToolScanning, beforeTool) {
+		t.Errorf("MCPToolScanning mutated on loaded config: got %+v want %+v", cfg.MCPToolScanning, beforeTool)
+	}
+	if !reflect.DeepEqual(cfg.MCPToolPolicy, beforePolicy) {
+		t.Errorf("MCPToolPolicy mutated on loaded config: got %+v want %+v", cfg.MCPToolPolicy, beforePolicy)
+	}
+	if !reflect.DeepEqual(cfg.ResponseScanning, beforeResponse) {
+		t.Errorf("ResponseScanning mutated on loaded config: got %+v want %+v", cfg.ResponseScanning, beforeResponse)
+	}
+	if resolved == cfg {
+		t.Error("ResolveRuntime returned the same *Config; expected a clone")
+	}
+}
+
+// TestResolveRuntime_HashReflectsAutoEnable verifies that when a runtime
+// mode triggers auto-enable, the clone's CanonicalPolicyHash differs from
+// the loaded config's — receipts and envelopes stamped with the clone's
+// hash will therefore match the policy the proxy enforces, not the
+// pre-resolve state.
+func TestResolveRuntime_HashReflectsAutoEnable(t *testing.T) {
+	cfg := Defaults()
+	cfg.rawBytes = []byte("mode: balanced\n")
+	cfg.MCPInputScanning = MCPInputScanning{}
+	cfg.MCPToolScanning = MCPToolScanning{}
+	cfg.MCPToolPolicy = MCPToolPolicy{}
+	loadedHash := cfg.CanonicalPolicyHash()
+
+	resolved, _ := cfg.ResolveRuntime(RuntimeResolveOpts{Mode: RuntimeMCPProxy})
+
+	if got := resolved.CanonicalPolicyHash(); got == loadedHash {
+		t.Errorf("resolved CanonicalPolicyHash matches loaded; auto-enable not reflected (both %s)", got)
+	}
+	if !resolved.MCPInputScanning.Enabled {
+		t.Error("MCPInputScanning not auto-enabled on resolved clone")
+	}
+	if resolved.MCPInputScanning.Action != ActionBlock {
+		t.Errorf("MCPInputScanning.Action = %q, want %q", resolved.MCPInputScanning.Action, ActionBlock)
+	}
+}
+
+// TestResolveRuntime_Deterministic: identical inputs produce identical
+// canonical hashes. Without this, a verifier that caches policy hashes
+// across restarts would see spurious divergence on reload.
+func TestResolveRuntime_Deterministic(t *testing.T) {
+	cfg := Defaults()
+	cfg.rawBytes = []byte("mode: balanced\n")
+	opts := RuntimeResolveOpts{Mode: RuntimeForwardWithMCPListener}
+
+	r1, _ := cfg.ResolveRuntime(opts)
+	r2, _ := cfg.ResolveRuntime(opts)
+
+	if got, want := r1.CanonicalPolicyHash(), r2.CanonicalPolicyHash(); got != want {
+		t.Errorf("non-deterministic canonical hash: %s vs %s", got, want)
+	}
+	if got, want := r1.Hash(), r2.Hash(); got != want {
+		t.Errorf("non-deterministic raw hash: %s vs %s", got, want)
+	}
+}
+
+// TestResolveRuntime_SliceAliasingPrevented: mutating slices on the
+// resolved clone must not leak into the loaded config. Without deep clone
+// of the mutable policy surface, runtime auto-enable or bundle merge
+// could retroactively change the policy the loaded config represents.
+func TestResolveRuntime_SliceAliasingPrevented(t *testing.T) {
+	cfg := Defaults()
+	cfg.rawBytes = []byte("mode: balanced\n")
+	cfg.DLP.Patterns = []DLPPattern{{Name: "seed", Regex: ".", ExemptDomains: []string{"example.com"}}}
+	cfg.ResponseScanning.Patterns = []ResponseScanPattern{{Name: "seed", Regex: "."}}
+	cfg.MCPToolPolicy.Rules = []ToolPolicyRule{{Name: "seed", ToolPattern: "."}}
+
+	resolved, _ := cfg.ResolveRuntime(RuntimeResolveOpts{Mode: RuntimeForward})
+
+	resolved.DLP.Patterns[0].Name = mutatedSentinel
+	resolved.DLP.Patterns[0].ExemptDomains[0] = "mutated.example"
+	resolved.ResponseScanning.Patterns[0].Name = mutatedSentinel
+	resolved.MCPToolPolicy.Rules[0].Name = mutatedSentinel
+
+	if cfg.DLP.Patterns[0].Name == mutatedSentinel {
+		t.Error("DLP.Patterns aliased — mutation on clone leaked into loaded config")
+	}
+	if cfg.DLP.Patterns[0].ExemptDomains[0] == "mutated.example" {
+		t.Error("DLPPattern.ExemptDomains aliased — nested mutation leaked")
+	}
+	if cfg.ResponseScanning.Patterns[0].Name == mutatedSentinel {
+		t.Error("ResponseScanning.Patterns aliased")
+	}
+	if cfg.MCPToolPolicy.Rules[0].Name == mutatedSentinel {
+		t.Error("MCPToolPolicy.Rules aliased")
+	}
+}
+
+// TestResolveRuntime_BundleMergeOnClone: the MergeBundles hook receives
+// the clone, not the receiver. Callers that mutate patterns in the hook
+// must see those changes on the resolved clone but never on the loaded
+// config.
+func TestResolveRuntime_BundleMergeOnClone(t *testing.T) {
+	cfg := Defaults()
+	cfg.DLP.Patterns = []DLPPattern{{Name: "seed", Regex: "."}}
+	before := len(cfg.DLP.Patterns)
+
+	resolved, _ := cfg.ResolveRuntime(RuntimeResolveOpts{
+		Mode: RuntimeForward,
+		MergeBundles: func(c *Config) {
+			c.DLP.Patterns = append(c.DLP.Patterns, DLPPattern{Name: "bundle", Regex: "."})
+		},
+	})
+
+	if got := len(cfg.DLP.Patterns); got != before {
+		t.Errorf("loaded DLP.Patterns mutated by merge hook: got %d want %d", got, before)
+	}
+	if got := len(resolved.DLP.Patterns); got != before+1 {
+		t.Errorf("resolved DLP.Patterns missing bundle pattern: got %d want %d", got, before+1)
+	}
+}
+
+// TestResolveRuntime_RespectsExplicitConfig: auto-enable must not override
+// explicit operator configuration. An operator who set action=warn must
+// get action=warn, not action=block.
+func TestResolveRuntime_RespectsExplicitConfig(t *testing.T) {
+	cfg := Defaults()
+	cfg.MCPInputScanning = MCPInputScanning{Enabled: true, Action: ActionWarn}
+
+	resolved, _ := cfg.ResolveRuntime(RuntimeResolveOpts{Mode: RuntimeMCPProxy})
+
+	if resolved.MCPInputScanning.Action != ActionWarn {
+		t.Errorf("auto-enable clobbered explicit action: got %q want %q", resolved.MCPInputScanning.Action, ActionWarn)
+	}
+	if !resolved.MCPInputScanning.Enabled {
+		t.Error("auto-enable disabled an explicitly enabled section")
+	}
+}
+
+// TestResolveRuntime_ForwardModeSkipsMCPAutoEnable: plain forward proxy
+// mode (no MCP listener) must not auto-enable MCP scanning. Enabling it
+// would waste cycles scanning non-MCP traffic and potentially produce
+// spurious blocks.
+func TestResolveRuntime_ForwardModeSkipsMCPAutoEnable(t *testing.T) {
+	cfg := Defaults()
+	cfg.MCPInputScanning = MCPInputScanning{}
+	cfg.MCPToolScanning = MCPToolScanning{}
+	cfg.MCPToolPolicy = MCPToolPolicy{}
+
+	resolved, _ := cfg.ResolveRuntime(RuntimeResolveOpts{Mode: RuntimeForward})
+
+	if resolved.MCPInputScanning.Enabled {
+		t.Error("RuntimeForward should not auto-enable MCPInputScanning")
+	}
+	if resolved.MCPToolScanning.Enabled {
+		t.Error("RuntimeForward should not auto-enable MCPToolScanning")
+	}
+	if resolved.MCPToolPolicy.Enabled {
+		t.Error("RuntimeForward should not auto-enable MCPToolPolicy")
+	}
+}
+
+// TestResolveRuntime_MCPProxyResponseScanningFallback: when the operator
+// disables response scanning, RuntimeMCPProxy falls back to defaults so
+// tool responses still get scanned for injection. The fallback only
+// applies in MCP proxy mode.
+func TestResolveRuntime_MCPProxyResponseScanningFallback(t *testing.T) {
+	cfg := Defaults()
+	cfg.ResponseScanning.Enabled = false
+
+	resolved, _ := cfg.ResolveRuntime(RuntimeResolveOpts{Mode: RuntimeMCPProxy})
+
+	if !resolved.ResponseScanning.Enabled {
+		t.Error("RuntimeMCPProxy should fall back to default response scanning when disabled")
+	}
+	if cfg.ResponseScanning.Enabled {
+		t.Error("loaded config mutated by response scanning fallback")
+	}
+}
+
+// TestResolveRuntime_MCPProxyFallbackPreservesBundlePatterns ensures the
+// response-scanning fallback runs BEFORE the caller-supplied bundle merge.
+// The fallback replaces the entire ResponseScanning struct with defaults,
+// so if it ran after MergeBundles the bundle-appended patterns would be
+// silently discarded. Original mcp.go ordering was fallback-then-merge;
+// this test pins that ordering inside ResolveRuntime.
+func TestResolveRuntime_MCPProxyFallbackPreservesBundlePatterns(t *testing.T) {
+	cfg := Defaults()
+	cfg.ResponseScanning.Enabled = false
+
+	resolved, info := cfg.ResolveRuntime(RuntimeResolveOpts{
+		Mode: RuntimeMCPProxy,
+		MergeBundles: func(c *Config) {
+			c.ResponseScanning.Patterns = append(c.ResponseScanning.Patterns, ResponseScanPattern{
+				Name:  "bundle-added",
+				Regex: "bundle-only-regex",
+			})
+		},
+	})
+
+	if !info.ResponseScanningFallback {
+		t.Fatal("expected response-scanning fallback to fire")
+	}
+	found := false
+	for _, p := range resolved.ResponseScanning.Patterns {
+		if p.Name == "bundle-added" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("bundle-added pattern missing from resolved ResponseScanning.Patterns; fallback ran after merge and wiped bundle appends")
+	}
+}
+
+// TestResolveRuntime_MCPProxyFallbackSkippedWhenEnabled: the fallback
+// does not clobber an explicitly enabled response-scanning config.
+func TestResolveRuntime_MCPProxyFallbackSkippedWhenEnabled(t *testing.T) {
+	cfg := Defaults()
+	cfg.ResponseScanning.Enabled = true
+	cfg.ResponseScanning.Action = ActionWarn
+
+	resolved, _ := cfg.ResolveRuntime(RuntimeResolveOpts{Mode: RuntimeMCPProxy})
+
+	if resolved.ResponseScanning.Action != ActionWarn {
+		t.Errorf("fallback clobbered explicit response scanning action: got %q want %q", resolved.ResponseScanning.Action, ActionWarn)
+	}
+}
+
+// TestResolveRuntime_DefaultToolPolicyRulesCalledOnAutoEnable: when tool
+// policy auto-enables, DefaultToolPolicyRules is invoked exactly once and
+// its result populates Rules.
+func TestResolveRuntime_DefaultToolPolicyRulesCalledOnAutoEnable(t *testing.T) {
+	cfg := Defaults()
+	cfg.MCPToolPolicy = MCPToolPolicy{}
+
+	callCount := 0
+	defaults := []ToolPolicyRule{{Name: "rule-a", ToolPattern: "."}}
+	resolved, _ := cfg.ResolveRuntime(RuntimeResolveOpts{
+		Mode: RuntimeMCPProxy,
+		DefaultToolPolicyRules: func() []ToolPolicyRule {
+			callCount++
+			return defaults
+		},
+	})
+
+	if callCount != 1 {
+		t.Errorf("DefaultToolPolicyRules called %d times, want 1", callCount)
+	}
+	if got, want := len(resolved.MCPToolPolicy.Rules), 1; got != want {
+		t.Fatalf("resolved.MCPToolPolicy.Rules len = %d, want %d", got, want)
+	}
+	if resolved.MCPToolPolicy.Rules[0].Name != "rule-a" {
+		t.Errorf("auto-enable did not populate default rule: got %q", resolved.MCPToolPolicy.Rules[0].Name)
+	}
+}
+
+// TestResolveRuntime_DefaultToolPolicyRulesNotCalledWhenRulesPresent:
+// when the operator supplied rules explicitly, auto-enable leaves them
+// alone and DefaultToolPolicyRules is not invoked.
+func TestResolveRuntime_DefaultToolPolicyRulesNotCalledWhenRulesPresent(t *testing.T) {
+	cfg := Defaults()
+	cfg.MCPToolPolicy = MCPToolPolicy{
+		Rules: []ToolPolicyRule{{Name: "operator", ToolPattern: "."}},
+	}
+
+	callCount := 0
+	resolved, _ := cfg.ResolveRuntime(RuntimeResolveOpts{
+		Mode: RuntimeMCPProxy,
+		DefaultToolPolicyRules: func() []ToolPolicyRule {
+			callCount++
+			return nil
+		},
+	})
+
+	if callCount != 0 {
+		t.Errorf("DefaultToolPolicyRules called %d times, want 0", callCount)
+	}
+	if got, want := len(resolved.MCPToolPolicy.Rules), 1; got != want {
+		t.Fatalf("operator rules overwritten: got %d rules, want %d", got, want)
+	}
+	if resolved.MCPToolPolicy.Rules[0].Name != "operator" {
+		t.Errorf("operator rules clobbered: got %q", resolved.MCPToolPolicy.Rules[0].Name)
+	}
+}
+
+// TestClone_FreshCanonicalHashCache: cloning must produce a *Config whose
+// canonical hash cache starts empty. Without this, mutations on the clone
+// would silently return the receiver's cached hash.
+func TestClone_FreshCanonicalHashCache(t *testing.T) {
+	cfg := Defaults()
+	cfg.rawBytes = []byte("mode: balanced\n")
+	// Warm source cache.
+	_ = cfg.CanonicalPolicyHash()
+
+	clone := cfg.Clone()
+	if clone.canonicalHashCache.Load() != nil {
+		t.Error("Clone returned a *Config with a pre-warmed canonical hash cache")
+	}
+
+	// Clone computes its own hash.
+	got := clone.CanonicalPolicyHash()
+	if want := clone.computeCanonicalPolicyHash(); got != want {
+		t.Errorf("cloned canonical hash mismatch: got %s want %s", got, want)
+	}
+}
+
+// TestClone_RawBytesCopiedNotAliased: editing the clone's rawBytes must
+// not mutate the receiver's rawBytes. Without the copy, receipt Hash()
+// could be retroactively invalidated by downstream code that edits raw
+// bytes (e.g., canary injection or serialization helpers).
+func TestClone_RawBytesCopiedNotAliased(t *testing.T) {
+	cfg := Defaults()
+	cfg.rawBytes = []byte("mode: balanced\n")
+	srcHash := cfg.Hash()
+
+	clone := cfg.Clone()
+	clone.rawBytes[0] = 'Z'
+
+	if got := cfg.Hash(); got != srcHash {
+		t.Errorf("Clone aliased rawBytes; src Hash changed from %s to %s after clone edit", srcHash, got)
+	}
+}
+
+// TestClone_NilSafe: Clone on a nil receiver returns nil without panicking.
+// Defensive: some test paths pass optional configs as *Config.
+func TestClone_NilSafe(t *testing.T) {
+	var c *Config
+	if got := c.Clone(); got != nil {
+		t.Errorf("Clone(nil) = %v, want nil", got)
+	}
+}
+
+// TestResolveRuntime_HashSemanticsStable pins the intentional split
+// between Hash() (raw YAML audit fingerprint) and CanonicalPolicyHash()
+// (effective policy attestation). After resolve, the clone's raw Hash()
+// must equal the receiver's Hash() — both refer to the on-disk YAML that
+// was loaded. The clone's CanonicalPolicyHash() may differ because bundle
+// merge and auto-enable shift effective policy. This split is the reason
+// receipts (point-in-time audit) use Hash() and envelopes (policy
+// attestation) use CanonicalPolicyHash(). A future refactor that unifies
+// them must explicitly update this test.
+func TestResolveRuntime_HashSemanticsStable(t *testing.T) {
+	cfg := Defaults()
+	cfg.rawBytes = []byte("mode: balanced\n")
+	cfg.MCPInputScanning = MCPInputScanning{}
+	cfg.MCPToolScanning = MCPToolScanning{}
+	cfg.MCPToolPolicy = MCPToolPolicy{}
+
+	resolved, _ := cfg.ResolveRuntime(RuntimeResolveOpts{Mode: RuntimeMCPProxy})
+
+	if got, want := resolved.Hash(), cfg.Hash(); got != want {
+		t.Errorf("resolved Hash() diverged from loaded: got %s want %s (rawBytes should be preserved)", got, want)
+	}
+	if resolved.CanonicalPolicyHash() == cfg.CanonicalPolicyHash() {
+		t.Error("resolved CanonicalPolicyHash() matched loaded; expected divergence once auto-enable fired")
+	}
+}
+
+// TestResolveRuntime_InfoReportsFiredBranches pins the operator-visible
+// side of ResolveRuntime: the returned ResolveRuntimeInfo must flag every
+// auto-enable or fallback branch that fired so CLI callers can emit a
+// matching log line. Without this contract, moving the auto-enable
+// predicates into the config package silently removes the "auto-enabling
+// MCP ..." operator messages and any tooling that grep-parses those
+// lines silently breaks.
+func TestResolveRuntime_InfoReportsFiredBranches(t *testing.T) {
+	t.Run("all unconfigured fire", func(t *testing.T) {
+		cfg := Defaults()
+		cfg.ResponseScanning.Enabled = false
+		cfg.MCPInputScanning = MCPInputScanning{}
+		cfg.MCPToolScanning = MCPToolScanning{}
+		cfg.MCPToolPolicy = MCPToolPolicy{}
+
+		_, info := cfg.ResolveRuntime(RuntimeResolveOpts{Mode: RuntimeMCPProxy})
+
+		if !info.ResponseScanningFallback {
+			t.Error("ResponseScanningFallback not flagged")
+		}
+		if !info.MCPInputScanningAutoEnabled {
+			t.Error("MCPInputScanningAutoEnabled not flagged")
+		}
+		if !info.MCPToolScanningAutoEnabled {
+			t.Error("MCPToolScanningAutoEnabled not flagged")
+		}
+		if !info.MCPToolPolicyAutoEnabled {
+			t.Error("MCPToolPolicyAutoEnabled not flagged")
+		}
+	})
+
+	t.Run("all explicit: no flags fire", func(t *testing.T) {
+		cfg := Defaults()
+		cfg.ResponseScanning.Enabled = true
+		cfg.ResponseScanning.Action = ActionBlock
+		cfg.MCPInputScanning = MCPInputScanning{Enabled: true, Action: ActionBlock}
+		cfg.MCPToolScanning = MCPToolScanning{Enabled: true, Action: ActionBlock}
+		cfg.MCPToolPolicy = MCPToolPolicy{Enabled: true, Action: ActionBlock}
+
+		_, info := cfg.ResolveRuntime(RuntimeResolveOpts{Mode: RuntimeMCPProxy})
+
+		if info.ResponseScanningFallback {
+			t.Error("ResponseScanningFallback should not fire on explicit config")
+		}
+		if info.MCPInputScanningAutoEnabled {
+			t.Error("MCPInputScanningAutoEnabled should not fire on explicit config")
+		}
+		if info.MCPToolScanningAutoEnabled {
+			t.Error("MCPToolScanningAutoEnabled should not fire on explicit config")
+		}
+		if info.MCPToolPolicyAutoEnabled {
+			t.Error("MCPToolPolicyAutoEnabled should not fire on explicit config")
+		}
+	})
+
+	t.Run("forward mode skips all MCP flags", func(t *testing.T) {
+		cfg := Defaults()
+		cfg.MCPInputScanning = MCPInputScanning{}
+		cfg.MCPToolScanning = MCPToolScanning{}
+		cfg.MCPToolPolicy = MCPToolPolicy{}
+
+		_, info := cfg.ResolveRuntime(RuntimeResolveOpts{Mode: RuntimeForward})
+
+		if info.MCPInputScanningAutoEnabled || info.MCPToolScanningAutoEnabled || info.MCPToolPolicyAutoEnabled {
+			t.Errorf("RuntimeForward should not fire any MCP auto-enable flags: %+v", info)
+		}
+	})
+}
+
+// TestResolveRuntime_ResolvedComparisonAvoidsFalseReloadWarnings pins the
+// hot-reload contract behind run.go: ValidateReload must compare two
+// resolved runtime configs, not a resolved live config against a freshly
+// loaded unresolved one. Otherwise bundle merges and MCP listener
+// auto-enable look like operator downgrades.
+func TestResolveRuntime_ResolvedComparisonAvoidsFalseReloadWarnings(t *testing.T) {
+	base := Defaults()
+	base.DLP.Patterns = []DLPPattern{{Name: "seed", Regex: "."}}
+	base.MCPInputScanning = MCPInputScanning{}
+	base.MCPToolScanning = MCPToolScanning{}
+	base.MCPToolPolicy = MCPToolPolicy{}
+
+	opts := RuntimeResolveOpts{
+		Mode: RuntimeForwardWithMCPListener,
+		MergeBundles: func(c *Config) {
+			c.DLP.Patterns = append(c.DLP.Patterns, DLPPattern{Name: "bundle", Regex: "."})
+		},
+		DefaultToolPolicyRules: func() []ToolPolicyRule {
+			return []ToolPolicyRule{{Name: "default-rule", ToolPattern: "."}}
+		},
+	}
+
+	oldResolved, _ := base.ResolveRuntime(opts)
+	unresolvedNext := base.Clone()
+
+	unresolvedWarnings := ValidateReload(oldResolved, unresolvedNext)
+	if len(unresolvedWarnings) == 0 {
+		t.Fatal("ValidateReload(resolved, unresolved) returned no warnings; test setup is not exercising the hot-reload bug")
+	}
+
+	expectedFalsePositives := map[string]bool{
+		"dlp.patterns":               false,
+		"mcp_input_scanning.enabled": false,
+		"mcp_tool_scanning.enabled":  false,
+		"mcp_tool_policy.enabled":    false,
+		"mcp_tool_policy.rules":      false,
+	}
+	for _, w := range unresolvedWarnings {
+		if _, ok := expectedFalsePositives[w.Field]; ok {
+			expectedFalsePositives[w.Field] = true
+		}
+	}
+	for field, seen := range expectedFalsePositives {
+		if !seen {
+			t.Errorf("ValidateReload(resolved, unresolved) missing expected false-positive warning for %s", field)
+		}
+	}
+
+	newResolved, _ := unresolvedNext.ResolveRuntime(opts)
+	if warnings := ValidateReload(oldResolved, newResolved); len(warnings) != 0 {
+		t.Fatalf("ValidateReload(resolved, resolved) returned unexpected warnings: %+v", warnings)
+	}
+}
+
+// TestCloneHelpers_NilAndEmpty covers the nil/empty slice paths in the
+// internal clone helpers. Explicit so goconst + coverage stay honest:
+// the clone helpers must produce nil when given nil (not an empty slice)
+// so canonical-hash stability is preserved across the omitted-field vs
+// empty-slice distinction.
+func TestCloneHelpers_NilAndEmpty(t *testing.T) {
+	if got := cloneDLPPatterns(nil); got != nil {
+		t.Errorf("cloneDLPPatterns(nil) = %v, want nil", got)
+	}
+	if got := cloneResponseScanPatterns(nil); got != nil {
+		t.Errorf("cloneResponseScanPatterns(nil) = %v, want nil", got)
+	}
+	if got := cloneToolPolicyRules(nil); got != nil {
+		t.Errorf("cloneToolPolicyRules(nil) = %v, want nil", got)
+	}
+}
+
+// TestRuntimeMode_WrapsMCP exercises the mode helper used across the
+// resolve pipeline. Exported so runtime code can branch on it without
+// replicating the set membership test.
+func TestRuntimeMode_WrapsMCP(t *testing.T) {
+	cases := []struct {
+		mode RuntimeMode
+		want bool
+	}{
+		{RuntimeForward, false},
+		{RuntimeForwardWithMCPListener, true},
+		{RuntimeMCPProxy, true},
+		{RuntimeMode(0), false}, // zero value
+	}
+	for _, tc := range cases {
+		if got := tc.mode.WrapsMCP(); got != tc.want {
+			t.Errorf("RuntimeMode(%d).WrapsMCP() = %v, want %v", tc.mode, got, tc.want)
+		}
+	}
+}

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -331,8 +331,14 @@ func TestClone_FreshCanonicalHashCache(t *testing.T) {
 	_ = cfg.CanonicalPolicyHash()
 
 	clone := cfg.Clone()
-	if clone.canonicalHashCache.Load() != nil {
-		t.Error("Clone returned a *Config with a pre-warmed canonical hash cache")
+	if clone.canonicalHashCache == nil {
+		t.Fatal("Clone returned a *Config with a nil canonical hash cache holder; expected a fresh allocation")
+	}
+	if clone.canonicalHashCache == cfg.canonicalHashCache {
+		t.Error("Clone aliased the receiver's canonical hash cache pointer; expected a separate holder")
+	}
+	if cached := clone.canonicalHashCache.Load(); cached != nil {
+		t.Errorf("Clone returned a *Config with a pre-warmed canonical hash cache: %v", cached)
 	}
 
 	// Clone computes its own hash.
@@ -545,11 +551,59 @@ func TestRuntimeMode_WrapsMCP(t *testing.T) {
 		{RuntimeForward, false},
 		{RuntimeForwardWithMCPListener, true},
 		{RuntimeMCPProxy, true},
+		{RuntimeMCPScan, false}, // scan consumes stdin, not a proxy
 		{RuntimeMode(0), false}, // zero value
 	}
 	for _, tc := range cases {
 		if got := tc.mode.WrapsMCP(); got != tc.want {
 			t.Errorf("RuntimeMode(%d).WrapsMCP() = %v, want %v", tc.mode, got, tc.want)
 		}
+	}
+}
+
+// TestRuntimeMode_NeedsResponseScanningFallback: both proxy and scan
+// modes process MCP responses and need the response-scanning fallback
+// to fire; forward-only modes do not.
+func TestRuntimeMode_NeedsResponseScanningFallback(t *testing.T) {
+	cases := []struct {
+		mode RuntimeMode
+		want bool
+	}{
+		{RuntimeForward, false},
+		{RuntimeForwardWithMCPListener, false},
+		{RuntimeMCPProxy, true},
+		{RuntimeMCPScan, true},
+		{RuntimeMode(0), false},
+	}
+	for _, tc := range cases {
+		if got := tc.mode.NeedsResponseScanningFallback(); got != tc.want {
+			t.Errorf("RuntimeMode(%d).NeedsResponseScanningFallback() = %v, want %v", tc.mode, got, tc.want)
+		}
+	}
+}
+
+// TestResolveRuntime_MCPScanFallbackNoAutoEnable: RuntimeMCPScan should
+// enable the response-scanning fallback but leave MCP input / tool /
+// policy sections alone (scan mode never wraps an upstream server).
+func TestResolveRuntime_MCPScanFallbackNoAutoEnable(t *testing.T) {
+	cfg := Defaults()
+	cfg.ResponseScanning.Enabled = false
+	cfg.MCPInputScanning = MCPInputScanning{}
+	cfg.MCPToolScanning = MCPToolScanning{}
+	cfg.MCPToolPolicy = MCPToolPolicy{}
+
+	resolved, info := cfg.ResolveRuntime(RuntimeResolveOpts{Mode: RuntimeMCPScan})
+
+	if !info.ResponseScanningFallback {
+		t.Error("RuntimeMCPScan should fire the response-scanning fallback when operator disabled it")
+	}
+	if !resolved.ResponseScanning.Enabled {
+		t.Error("resolved ResponseScanning.Enabled = false; fallback didn't take effect")
+	}
+	if info.MCPInputScanningAutoEnabled || info.MCPToolScanningAutoEnabled || info.MCPToolPolicyAutoEnabled {
+		t.Errorf("RuntimeMCPScan should not fire any MCP auto-enable flags: %+v", info)
+	}
+	if resolved.MCPInputScanning.Enabled || resolved.MCPToolScanning.Enabled || resolved.MCPToolPolicy.Enabled {
+		t.Error("MCP scanning sections auto-enabled under RuntimeMCPScan; expected to stay off")
 	}
 }

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -110,6 +110,7 @@ func TestResolveRuntime_SliceAliasingPrevented(t *testing.T) {
 	cfg.rawBytes = []byte("mode: balanced\n")
 	cfg.DLP.Patterns = []DLPPattern{{Name: "seed", Regex: ".", ExemptDomains: []string{"example.com"}}}
 	cfg.ResponseScanning.Patterns = []ResponseScanPattern{{Name: "seed", Regex: "."}}
+	cfg.ResponseScanning.ExemptDomains = []string{"seed.example.com"}
 	cfg.MCPToolPolicy.Rules = []ToolPolicyRule{{Name: "seed", ToolPattern: "."}}
 
 	resolved, _ := cfg.ResolveRuntime(RuntimeResolveOpts{Mode: RuntimeForward})
@@ -117,6 +118,7 @@ func TestResolveRuntime_SliceAliasingPrevented(t *testing.T) {
 	resolved.DLP.Patterns[0].Name = mutatedSentinel
 	resolved.DLP.Patterns[0].ExemptDomains[0] = "mutated.example"
 	resolved.ResponseScanning.Patterns[0].Name = mutatedSentinel
+	resolved.ResponseScanning.ExemptDomains[0] = "mutated.example.com"
 	resolved.MCPToolPolicy.Rules[0].Name = mutatedSentinel
 
 	if cfg.DLP.Patterns[0].Name == mutatedSentinel {
@@ -127,6 +129,9 @@ func TestResolveRuntime_SliceAliasingPrevented(t *testing.T) {
 	}
 	if cfg.ResponseScanning.Patterns[0].Name == mutatedSentinel {
 		t.Error("ResponseScanning.Patterns aliased")
+	}
+	if cfg.ResponseScanning.ExemptDomains[0] == "mutated.example.com" {
+		t.Error("ResponseScanning.ExemptDomains aliased — mutation on clone leaked into loaded config")
 	}
 	if cfg.MCPToolPolicy.Rules[0].Name == mutatedSentinel {
 		t.Error("MCPToolPolicy.Rules aliased")

--- a/scripts/release-audit.sh
+++ b/scripts/release-audit.sh
@@ -40,7 +40,9 @@ while IFS= read -r match; do
 	rest="${match#*:}"
 	line="${rest%%:*}"
 	uses="${rest#*:}"
-	ref="$(printf '%s\n' "$uses" | sed -E 's/^[[:space:]]*-[[:space:]]*uses:[[:space:]]*//; s/[[:space:]]+#.*$//')"
+	# Strip either step-level (leading dash) or job-level (no dash)
+	# `uses:` prefix so reusable-workflow calls are audited too.
+	ref="$(printf '%s\n' "$uses" | sed -E 's/^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*//; s/[[:space:]]+#.*$//')"
 
 	case "$ref" in
 		./*|docker://*)
@@ -57,7 +59,7 @@ while IFS= read -r match; do
 	if [[ ! "$version" =~ ^[0-9a-f]{40}$ ]]; then
 		fail "${file}:${line} action is not pinned to a full commit SHA (${ref})"
 	fi
-done < <(rg -n '^[[:space:]]*-[[:space:]]*uses:[[:space:]]*[^[:space:]]+' .github/workflows/*.y*ml || true)
+done < <(rg -n '^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*[^[:space:]]+' .github/workflows/*.y*ml || true)
 
 note "release audit: checking pull_request workflows stay secret-light"
 
@@ -66,8 +68,40 @@ while IFS= read -r workflow; do
 		continue
 	fi
 
-	if ! rg -q 'persist-credentials:[[:space:]]*false' "$workflow"; then
-		fail "${workflow} handles pull_request but does not disable checkout credential persistence"
+	# Per-step validation: every actions/checkout invocation must have
+	# persist-credentials: false within its own step block. Checking the
+	# workflow as a whole (the previous behavior) lets a second
+	# actions/checkout without the flag piggy-back on the first step's
+	# setting and evade the audit.
+	#
+	# Step boundaries in GitHub Actions workflows are `-` list items
+	# under `steps:` whose first key is `uses:`, `name:`, `run:`, `id:`,
+	# `if:`, `with:`, `env:`, `continue-on-error:`, or `timeout-minutes:`.
+	# We walk each file, track whether the current step is a checkout,
+	# and emit the checkout line number when its step ends without
+	# persist-credentials: false.
+	missing_checkouts="$(awk '
+		function flush() {
+			if (in_checkout && !found_persist) {
+				printf "%s:%d\n", FILENAME, checkout_line
+			}
+			in_checkout = 0
+			found_persist = 0
+		}
+		/^[[:space:]]*-[[:space:]]+(uses|name|run|id|if|env|with|continue-on-error|timeout-minutes):/ {
+			flush()
+			if ($0 ~ /uses:[[:space:]]*actions\/checkout(@|[[:space:]]|$)/) {
+				in_checkout = 1
+				checkout_line = NR
+			}
+			next
+		}
+		in_checkout && /persist-credentials:[[:space:]]*false/ { found_persist = 1 }
+		END { flush() }
+	' "$workflow")"
+	if [[ -n "$missing_checkouts" ]]; then
+		fail "${workflow} has actions/checkout step(s) without persist-credentials: false:"
+		note "$missing_checkouts"
 	fi
 
 	secrets_matches="$(rg -n 'secrets\.[A-Za-z0-9_]+' "$workflow" || true)"

--- a/scripts/release-audit.sh
+++ b/scripts/release-audit.sh
@@ -111,22 +111,29 @@ while IFS= read -r workflow; do
 	# and emit the checkout line number when its step ends without
 	# persist-credentials: false.
 	missing_checkouts="$(awk '
+		# Track each step window independently of which key the step
+		# starts with. A step that begins with `- name: Checkout` and
+		# has `uses: actions/checkout` on a later indented line is
+		# still one step; scanning the whole window catches it.
 		function flush() {
-			if (in_checkout && !found_persist) {
+			if (in_step && is_checkout && !found_persist) {
 				printf "%s:%d\n", FILENAME, checkout_line
 			}
-			in_checkout = 0
+			in_step = 0
+			is_checkout = 0
 			found_persist = 0
+			checkout_line = 0
 		}
-		/^[[:space:]]*-[[:space:]]+(uses|name|run|id|if|env|with|continue-on-error|timeout-minutes):/ {
+		# A new step begins on any `- <key>:` list item under steps:.
+		/^[[:space:]]*-[[:space:]]+[A-Za-z_-]+:/ {
 			flush()
-			if ($0 ~ /uses:[[:space:]]*actions\/checkout(@|[[:space:]]|$)/) {
-				in_checkout = 1
-				checkout_line = NR
-			}
-			next
+			in_step = 1
 		}
-		in_checkout && /persist-credentials:[[:space:]]*false/ { found_persist = 1 }
+		in_step && /uses:[[:space:]]*actions\/checkout(@|[[:space:]]|$)/ {
+			is_checkout = 1
+			if (!checkout_line) checkout_line = NR
+		}
+		in_step && /persist-credentials:[[:space:]]*false/ { found_persist = 1 }
 		END { flush() }
 	' "$workflow")"
 	if [[ -n "$missing_checkouts" ]]; then

--- a/scripts/release-audit.sh
+++ b/scripts/release-audit.sh
@@ -4,6 +4,16 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+# Fail closed if ripgrep is missing. Several of the checks below use
+# `rg -q ... || true`, which would otherwise silently pass (exit 127
+# gets swallowed and the branch behaves as if "no match"). Runners
+# without ripgrep must fail loudly, not scan nothing and report OK.
+if ! command -v rg >/dev/null 2>&1; then
+	printf '%s\n' "ERROR: ripgrep (rg) is required for the release audit and is not on PATH." >&2
+	printf '%s\n' "Install ripgrep (e.g., apt-get install -y ripgrep) before running this script." >&2
+	exit 127
+fi
+
 errors=0
 
 note() {
@@ -15,15 +25,35 @@ fail() {
 	errors=1
 }
 
+# rg_search runs ripgrep and distinguishes "no matches" (exit 1, clean)
+# from a search error (exit >=2, which `|| true` would otherwise mask
+# and let the audit pass with zero scans — exactly what happened on
+# runners that lack ripgrep before this fix).
+rg_search() {
+	local status
+	set +e
+	rg_output="$(rg "$@")"
+	status=$?
+	set -e
+	if [[ "$status" -gt 1 ]]; then
+		note "ERROR: ripgrep exited with $status while running: rg $*"
+		note "The release audit is a release-blocking tripwire and must fail closed on scan errors."
+		errors=1
+		return 2
+	fi
+	return 0
+}
+
 check_no_matches() {
 	local pattern="$1"
 	local message="$2"
-	local matches
 
-	matches="$(rg -n "$pattern" .github/workflows || true)"
-	if [[ -n "$matches" ]]; then
+	if ! rg_search -n "$pattern" .github/workflows; then
+		return
+	fi
+	if [[ -n "$rg_output" ]]; then
 		fail "$message"
-		note "$matches"
+		note "$rg_output"
 	fi
 }
 

--- a/scripts/release-audit.sh
+++ b/scripts/release-audit.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+errors=0
+
+note() {
+	printf '%s\n' "$*" >&2
+}
+
+fail() {
+	note "ERROR: $*"
+	errors=1
+}
+
+check_no_matches() {
+	local pattern="$1"
+	local message="$2"
+	local matches
+
+	matches="$(rg -n "$pattern" .github/workflows || true)"
+	if [[ -n "$matches" ]]; then
+		fail "$message"
+		note "$matches"
+	fi
+}
+
+note "release audit: checking workflow trigger and token hygiene"
+
+check_no_matches '^[[:space:]]*pull_request_target:' "pull_request_target is banned for this repo; use pull_request plus read-only permissions"
+check_no_matches 'permissions:[[:space:]]*write-all' "write-all workflow permissions are banned"
+check_no_matches 'persist-credentials:[[:space:]]*true' "persist-credentials: true is banned; PR and CI jobs must not retain checkout credentials"
+
+note "release audit: checking action pinning"
+
+while IFS= read -r match; do
+	file="${match%%:*}"
+	rest="${match#*:}"
+	line="${rest%%:*}"
+	uses="${rest#*:}"
+	ref="$(printf '%s\n' "$uses" | sed -E 's/^[[:space:]]*-[[:space:]]*uses:[[:space:]]*//; s/[[:space:]]+#.*$//')"
+
+	case "$ref" in
+		./*|docker://*)
+			continue
+			;;
+	esac
+
+	if [[ "$ref" != *@* ]]; then
+		fail "${file}:${line} uses an unpinned action (${ref}); pin every external action to a full commit SHA"
+		continue
+	fi
+
+	version="${ref##*@}"
+	if [[ ! "$version" =~ ^[0-9a-f]{40}$ ]]; then
+		fail "${file}:${line} action is not pinned to a full commit SHA (${ref})"
+	fi
+done < <(rg -n '^[[:space:]]*-[[:space:]]*uses:[[:space:]]*[^[:space:]]+' .github/workflows/*.y*ml || true)
+
+note "release audit: checking pull_request workflows stay secret-light"
+
+while IFS= read -r workflow; do
+	if ! rg -q '^[[:space:]]*pull_request:' "$workflow"; then
+		continue
+	fi
+
+	if ! rg -q 'persist-credentials:[[:space:]]*false' "$workflow"; then
+		fail "${workflow} handles pull_request but does not disable checkout credential persistence"
+	fi
+
+	secrets_matches="$(rg -n 'secrets\.[A-Za-z0-9_]+' "$workflow" || true)"
+	if [[ -n "$secrets_matches" ]]; then
+		custom_secret_matches="$(printf '%s\n' "$secrets_matches" | rg -v 'secrets\.GITHUB_TOKEN\b' || true)"
+		if [[ -n "$custom_secret_matches" ]]; then
+			fail "${workflow} is pull_request-triggered and references custom secrets; keep PR workflows secretless"
+			note "$custom_secret_matches"
+		fi
+	fi
+done < <(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+
+note "release audit: checking secret-bearing comment workflows"
+
+while IFS= read -r workflow; do
+	if ! rg -q '^[[:space:]]*issue_comment:' "$workflow"; then
+		continue
+	fi
+	if ! rg -q 'secrets\.' "$workflow"; then
+		continue
+	fi
+	if ! rg -q 'author_association' "$workflow"; then
+		fail "${workflow} uses secrets on issue_comment without an author_association gate"
+	fi
+	if rg -q 'refs/pull/\$\{\{[[:space:]]*github\.event\.issue\.number[[:space:]]*\}\}/head' "$workflow"; then
+		fail "${workflow} checks out the PR head ref in a secret-bearing comment workflow; use the merge ref instead"
+	fi
+done < <(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+
+if [[ "$errors" -ne 0 ]]; then
+	exit 1
+fi
+
+note "release audit: OK"

--- a/scripts/runtime-policy-audit.sh
+++ b/scripts/runtime-policy-audit.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+pattern='MCPInputScanning\.(Enabled|Action)\s*=|MCPToolScanning\.(Enabled|Action|DetectDrift)\s*=|MCPToolPolicy\.(Enabled|Action|Rules)\s*=|ResponseScanning\s*=|ResponseScanning\.(Enabled|Patterns)\s*=|DLP\.Patterns\s*=|Internal\s*='
+
+matches="$(rg -n "$pattern" internal/cli/runtime internal/mcp internal/proxy --glob '!**/*_test.go' || true)"
+
+if [[ -n "$matches" ]]; then
+	printf '%s\n' "ERROR: runtime packages still mutate policy-relevant config directly." >&2
+	printf '%s\n' "Move runtime defaults and bundle-driven policy changes into config-level clone-and-resolve logic before release." >&2
+	printf '%s\n' "$matches" >&2
+	exit 1
+fi
+
+printf '%s\n' "runtime policy audit: OK"

--- a/scripts/runtime-policy-audit.sh
+++ b/scripts/runtime-policy-audit.sh
@@ -6,9 +6,27 @@ cd "$ROOT_DIR"
 
 pattern='MCPInputScanning\.(Enabled|Action)\s*=|MCPToolScanning\.(Enabled|Action|DetectDrift)\s*=|MCPToolPolicy\.(Enabled|Action|Rules)\s*=|ResponseScanning\s*=|ResponseScanning\.(Enabled|Patterns)\s*=|DLP\.Patterns\s*=|Internal\s*='
 
-matches="$(rg -n "$pattern" internal/cli/runtime internal/mcp internal/proxy --glob '!**/*_test.go' || true)"
+# Capture rg's exit code explicitly. ripgrep returns:
+#   0 — match(es) found (policy mutation detected — fail release)
+#   1 — no matches (clean — pass)
+#   2 or higher — search error (unreadable paths, invalid regex, etc.)
+#
+# The previous `|| true` swallowed exit 2, letting a misconfigured repo
+# (missing directory, permission denied) silently pass the audit. A
+# release-blocking tripwire must fail closed on scan failures.
+set +e
+matches="$(rg -n "$pattern" internal/cli/runtime internal/mcp internal/proxy --glob '!**/*_test.go')"
+status=$?
+set -e
 
-if [[ -n "$matches" ]]; then
+if [[ "$status" -gt 1 ]]; then
+	printf '%s\n' "ERROR: runtime policy audit could not complete (ripgrep exit $status)." >&2
+	printf '%s\n' "The audit is a release-blocking tripwire; a scan failure must not pass silently." >&2
+	printf '%s\n' "$matches" >&2
+	exit "$status"
+fi
+
+if [[ "$status" -eq 0 ]]; then
 	printf '%s\n' "ERROR: runtime packages still mutate policy-relevant config directly." >&2
 	printf '%s\n' "Move runtime defaults and bundle-driven policy changes into config-level clone-and-resolve logic before release." >&2
 	printf '%s\n' "$matches" >&2

--- a/scripts/runtime-policy-audit.sh
+++ b/scripts/runtime-policy-audit.sh
@@ -4,6 +4,14 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+# Fail closed if ripgrep is missing. The release-blocking tripwire must
+# not silently pass when its only scan tool is unavailable.
+if ! command -v rg >/dev/null 2>&1; then
+	printf '%s\n' "ERROR: ripgrep (rg) is required for the runtime policy audit and is not on PATH." >&2
+	printf '%s\n' "Install ripgrep (e.g., apt-get install -y ripgrep) before running this script." >&2
+	exit 127
+fi
+
 pattern='MCPInputScanning\.(Enabled|Action)\s*=|MCPToolScanning\.(Enabled|Action|DetectDrift)\s*=|MCPToolPolicy\.(Enabled|Action|Rules)\s*=|ResponseScanning\s*=|ResponseScanning\.(Enabled|Patterns)\s*=|DLP\.Patterns\s*=|Internal\s*='
 
 # Capture rg's exit code explicitly. ripgrep returns:


### PR DESCRIPTION
Adds `config.ResolveRuntime` as the single entrypoint that produces a runtime `*Config` from a loaded one: deep clone, MCP proxy response-scanning fallback, caller-supplied bundle merge, and mode-aware MCP scanning auto-enable. `pipelock run`, `pipelock mcp proxy`, `pipelock mcp scan`, and the hot-reload goroutine all call it once and feed the resolved clone to every downstream consumer (scanner, emitters, proxy, reload diff). Also adds repo-local hardening audits so the new invariants cannot regress.

## Motivation

- MCP input scanning, tool scanning, and tool policy auto-enable lived in three places with the same semantic rule.
- Bundle merging, response-scanning fallback, and auto-enable mutated the loaded config in separate blocks scattered through the runtime. One builder keeps the order explicit.
- Per-agent effective configs and reload diffing both benefit from a resolved-config abstraction.
- Hot reload previously compared pre-resolve `newCfg` against post-resolve `oldCfg`, which produced false downgrade warnings on no-op reloads. Reload now resolves first, then compares resolved-vs-resolved.

## Hash split

Receipt `ConfigHash` continues to use `cfg.Hash()` (raw YAML audit fingerprint). Envelope `ConfigHash` uses `cfg.CanonicalPolicyHash()` (policy-semantic attestation fingerprint). Call-site comments document the intentional split: receipts are a point-in-time audit fingerprint of the loaded file, while envelope `ph` is the effective-policy fingerprint that verifiers care about.

The canonical hash cache is now stored as `*canonicalHashCacheHolder` (pointer to `atomic.Value`) rather than an embedded value, so `Config.Clone`'s shallow struct copy duplicates the pointer rather than the atomic. `CanonicalPolicyHash` lazily allocates a fresh holder if none exists and `Clone` explicitly reassigns a fresh one — both paths avoid Go's atomic-copy-after-first-use rule.

## Modes

| Mode | Auto-enable MCP sections | Response-scanning fallback |
|------|--------------------------|----------------------------|
| `RuntimeForward` | no | no |
| `RuntimeForwardWithMCPListener` | yes | no |
| `RuntimeMCPProxy` | yes | yes |
| `RuntimeMCPScan` | no | yes |

`WrapsMCP()` and `NeedsResponseScanningFallback()` capture the predicates so both the resolve builder and any future caller stay in sync.

## Release hardening

Adds repo-local checks so release and high-risk runtime paths have explicit, repeatable gates:

- `.github/workflows/hardening.yaml` runs `make release-audit` and `make test-runtime-critical` as blocking checks and `make runtime-policy-audit` plus a complexity/duplication debt lint as warning-only reports summarised in the step summary.
- `scripts/release-audit.sh` blocks `pull_request_target`, `permissions: write-all`, unpinned actions, `persist-credentials: true`, PR-triggered workflows that reference non-`GITHUB_TOKEN` secrets, and `issue_comment` workflows that either use secrets without an `author_association` gate or check out the PR head ref instead of the merge ref.
- `scripts/runtime-policy-audit.sh` scans `internal/cli/runtime`, `internal/mcp`, and `internal/proxy` for direct assignment of policy-relevant config fields (`MCPInputScanning`, `MCPToolScanning`, `MCPToolPolicy`, `ResponseScanning`, `DLP.Patterns`, `Internal`) outside of tests. Locks in the resolve builder so the mutation pattern cannot regress.
- Makefile targets: `test-runtime-critical` (race detector on `config`, `cli`, `mcp`, `proxy`), `release-audit`, `runtime-policy-audit`, `debt-check`, `release-check` (aggregate gate).
- The tag release workflow now runs the audits before tagging.
- `docs/release-checklist.md` captures the release gate explicitly.

## Tests

`internal/config/runtime_test.go` covers immutability, deep-clone aliasing, hash semantics, resolve-info reporting, response-scanning fallback ordering, mode helpers, and the resolved-vs-resolved reload comparison. `internal/cli/cli_test.go` adds two end-to-end reload tests (MCP-listener reload warnings, strict-mode reload with a non-policy change). `internal/cli/runtime/resolve_logs_test.go` covers the operator-facing log helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hot-reload validation to prevent security downgrades during strict-mode config changes.
  * Fixed kill-switch token behavior so API status follows updated config after reloads.

* **Improvements**
  * Emit clearer notices when runtime defaults are auto-enabled (distinguished by runtime mode).
  * Runtime config handling made immutable for safer, deterministic reloads and receipt fingerprints.

* **Tests & Hardening**
  * Added comprehensive unit/integration tests for runtime resolution and reloads.
  * New CI hardening workflow, release audit scripts, Make targets, and a release checklist document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->