### PR TITLE
fix(mcp/tools): strict verb-form regex for Dangerous Capability pattern

### DIFF
--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -344,7 +344,16 @@ var toolPoisonPatterns = []*compiledToolPattern{
 		// Standalone "script"/"file" require a determiner (a/the/any) to avoid
 		// false positives on "Execute the deployment script" or "Run the build
 		// script". Qualified forms (local/shell/arbitrary/system) match directly.
-		re: regexp.MustCompile(`(?i)(execut|run|launch|spawn)\w*\s+.{0,40}(` +
+		//
+		// The leading verb group is strict: it matches only actual verb forms
+		// of execute/run/launch/spawn, not any word that begins with those
+		// stems. `(execut|run|launch|spawn)\w*` accepted `runtime`, `runner`,
+		// `launcher`, `spawner` as noun false positives (PR #348 widening
+		// regressed on `runtime` specifically, blocking agents whose tool
+		// descriptions used it in phrases like "OpenClaw runtime ... local
+		// file"). RE2 has no negative lookahead, so each verb family's
+		// inflections are enumerated explicitly.
+		re: regexp.MustCompile(`(?i)\b(execut(?:e[ds]?|ing)|run(?:s|ning)?|launch(?:e[ds]?|ing)?|spawn(?:s|ed|ing)?)\b\s+.{0,40}(` +
 			`local\s+(?:file|script)|` +
 			`(?:a|the|any)\s+(?:file|script)\b|` +
 			`(?:shell|arbitrary|system)\s+(?:command|script))`,

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -500,6 +500,11 @@ func TestCheckToolPoison_DangerousCapability(t *testing.T) {
 		"Run a shell script on the host system",
 		"Launch arbitrary commands on the server",
 		"Executes a script provided by the user",
+		// Coverage for the spawn* verb-form branch: the strict regex
+		// enumerates each verb family by hand, so each family needs at
+		// least one true-positive case to guard against a future edit
+		// accidentally dropping a branch.
+		"Spawns arbitrary commands on the host system",
 		// Download + execute patterns (MCPHammer download_and_execute style).
 		"Downloads files from HTTP/HTTPS URLs and optionally executes them immediately",
 		"Fetch a remote payload and execute it",
@@ -538,6 +543,17 @@ func TestCheckToolPoison_DangerousCapability_NoFalsePositive(t *testing.T) {
 		// "fetch...run" on different objects must not trigger.
 		"Fetch data from the API and run the analysis pipeline",
 		"Downloads reports and runs the formatter",
+		// Regression: noun forms that start with a verb stem. Before the
+		// strict verb-form regex, `(execut|run|launch|spawn)\w*` matched
+		// `runtime`, `runner`, `launcher`, `spawner` as if they were verbs.
+		// An agent tool description containing "OpenClaw runtime ... local
+		// file" was blocked as a false positive on that basis.
+		"OpenClaw runtime attaches absolute local files for analysis",
+		"The container runtime manages shell scripts per pod",
+		"This tool is a Python runner for a build script",
+		"Launcher process supervises system command execution",
+		"Spawner daemon provides the file watcher",
+		"Runtime environment handles arbitrary command arguments",
 	}
 	for _, text := range benign {
 		name := text


### PR DESCRIPTION
## Summary
PR #348 widened the leading verb group in the Dangerous Capability detector from literal alternations to `(execut|run|launch|spawn)\w*`. The `\w*` unconstrained tail means any word starting with those stems matches: `runtime`, `runner`, `launcher`, `spawner`. Any MCP tool description whose text included a phrase like "runtime ... local file" or "runner ... a script" tripped the block as a false positive.

## Scope
- `internal/mcp/tools/tools.go`: replaces the leading verb group with explicit verb-form enumeration anchored on both sides by word boundaries. RE2 has no negative lookahead, so each verb family's inflections are hand-enumerated: `execut(?:e[ds]?|ing)`, `run(?:s|ning)?`, `launch(?:e[ds]?|ing)?`, `spawn(?:s|ed|ing)?`.
- `internal/mcp/tools/tools_test.go`: adds 7 regression cases to `TestCheckToolPoison_DangerousCapability_NoFalsePositive` covering noun forms that begin with a verb stem (`runtime`, container/language runner, launcher, spawner, and "Runtime environment handles arbitrary command arguments"). Also adds one true-positive case to `TestCheckToolPoison_DangerousCapability` for the `spawn*` verb family so every hand-enumerated branch is exercised against regression.

## Rationale
Fail-closed behavior is preserved for true verb forms (execute/run/launch/spawn and their inflections). Nouns that happen to start with a verb stem no longer match. No config changes. No transport surface changes.