### PR TITLE
refactor(mcp): migrate parse + emission sites to Frame/Decision helpers

### DIFF
--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -283,14 +283,16 @@ func ForwardScannedInput(
 			_, _ = fmt.Fprintf(logW, "pipelock: input line %d: %s\n", lineNum, reason)
 			recordAdaptiveSignal(session.SignalBlock)
 			if pendingActionID != "" && receiptEmitter != nil {
-				_ = receiptEmitter.Emit(receipt.EmitOpts{
-					ActionID:         pendingActionID,
-					Verdict:          config.ActionBlock,
-					RedactionProfile: redactionCfg.Profile,
-					Transport:        opts.Transport,
-					Target:           pendingToolCallName,
-					MCPMethod:        methodToolsCall,
-					ToolName:         pendingToolCallName,
+				_, _ = EmitMCPDecision(receiptEmitter, nil, MCPDecision{
+					Receipt: receipt.EmitOpts{
+						ActionID:         pendingActionID,
+						Verdict:          config.ActionBlock,
+						RedactionProfile: redactionCfg.Profile,
+						Transport:        opts.Transport,
+						Target:           pendingToolCallName,
+						MCPMethod:        methodToolsCall,
+						ToolName:         pendingToolCallName,
+					},
 				})
 			}
 			blockedCh <- BlockedRequest{
@@ -516,28 +518,9 @@ func ForwardScannedInput(
 			Result:    session.PolicyDecisionResult{Decision: session.PolicyAllow, Reason: taintReasonDisabled},
 		}
 		emitToolReceipt := func(receiptVerdict string) {
-			if actionID == "" || receiptEmitter == nil {
-				return
-			}
-			_ = receiptEmitter.Emit(receipt.EmitOpts{
-				ActionID:            actionID,
-				Verdict:             receiptVerdict,
-				RedactionProfile:    redactionCfg.Profile,
-				RedactionReport:     redactionReport,
-				Transport:           opts.Transport,
-				Target:              toolCallName,
-				MCPMethod:           verdict.Method,
-				ToolName:            toolCallName,
-				SessionTaintLevel:   taintDecision.Risk.Level.String(),
-				SessionContaminated: taintDecision.Risk.Contaminated,
-				RecentTaintSources:  taintDecision.Risk.Sources,
-				SessionTaskID:       taintDecision.Task.CurrentTaskID,
-				SessionTaskLabel:    taintDecision.Task.CurrentTaskLabel,
-				AuthorityKind:       taintDecision.Authority.String(),
-				TaintDecision:       taintDecision.Result.Decision.String(),
-				TaintDecisionReason: taintDecision.Result.Reason,
-				TaskOverrideApplied: taintDecision.TaskOverrideApplied,
-			})
+			// Delegate to the shared helper so stdio and HTTP/WS emit
+			// tool receipts through the same EmitMCPDecision entry.
+			emitMCPToolReceipt(receiptEmitter, opts.Transport, redactionCfg.Profile, actionID, verdict.Method, toolCallName, receiptVerdict, taintDecision, redactionReport)
 		}
 		if verdict.Method == methodToolsCall {
 			taintDecision = evaluateMCPTaint(taintOpts, toolCallName, string(frame.Args))
@@ -631,7 +614,7 @@ func ForwardScannedInput(
 			tracker.Track(verdict.ID)
 			fwdLine := line
 			if verdict.Method == methodToolsCall {
-				fwdLine = injectMCPEnvelope(line, envelopeEmitter, envelope.BuildOpts{
+				buildOpts := envelope.BuildOpts{
 					ActionID:       actionID,
 					Action:         string(receipt.ClassifyMCPTool(toolCallName, verdict.Method)),
 					Verdict:        config.ActionAllow,
@@ -639,6 +622,10 @@ func ForwardScannedInput(
 					TaskID:         taintDecision.Task.CurrentTaskID,
 					AuthorityKind:  taintDecision.Authority.String(),
 					RequiresReauth: taintDecision.RequiresReauth,
+				}
+				fwdLine, _ = EmitMCPDecision(nil, envelopeEmitter, MCPDecision{
+					Envelope:   &buildOpts,
+					InboundMsg: line,
 				})
 			}
 			if err := writer.WriteMessage(fwdLine); err != nil {
@@ -891,7 +878,7 @@ func ForwardScannedInput(
 			// Inject envelope for warn-mode tool calls before forwarding.
 			fwdLine := line
 			if verdict.Method == methodToolsCall {
-				fwdLine = injectMCPEnvelope(line, envelopeEmitter, envelope.BuildOpts{
+				buildOpts := envelope.BuildOpts{
 					ActionID:       actionID,
 					Action:         string(receipt.ClassifyMCPTool(toolCallName, verdict.Method)),
 					Verdict:        config.ActionWarn,
@@ -899,6 +886,10 @@ func ForwardScannedInput(
 					TaskID:         taintDecision.Task.CurrentTaskID,
 					AuthorityKind:  taintDecision.Authority.String(),
 					RequiresReauth: taintDecision.RequiresReauth,
+				}
+				fwdLine, _ = EmitMCPDecision(nil, envelopeEmitter, MCPDecision{
+					Envelope:   &buildOpts,
+					InboundMsg: line,
 				})
 			}
 			// Forward anyway (warn mode).

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -213,6 +213,14 @@ func ForwardScannedInput(
 		// or upstream from passing through to the MCP server.
 		line = stripInboundMCPMeta(line)
 
+		// Parse the inbound frame once per message. Every gate below
+		// reads ID / Method / tool fields from this frame instead of
+		// re-parsing the bytes. Redaction may rewrite the argument
+		// values later in the loop; the frame is re-parsed after the
+		// redaction step so downstream gates (DoW, taint) see the
+		// redacted args while ID / Method / ToolCallName stay stable.
+		frame := ParseMCPFrame(line)
+
 		// Kill switch: deny all messages when active.
 		if ks != nil {
 			if d := ks.IsActiveMCP(line); d.Active {
@@ -222,7 +230,7 @@ func ForwardScannedInput(
 						lineNum, d.Source)
 				} else {
 					// Request with ID — send JSON-RPC error response.
-					rpcID := extractRPCID(line)
+					rpcID := frame.ID
 					blockedCh <- BlockedRequest{
 						ID:             rpcID,
 						IsNotification: false,
@@ -252,19 +260,19 @@ func ForwardScannedInput(
 			_, _ = fmt.Fprintf(logW, "pipelock: input line %d: blocked batch request (not supported by MCP)\n", lineNum)
 			recordAdaptiveSignal(session.SignalBlock)
 			blockedCh <- BlockedRequest{
-				ID:           extractRPCID(line),
+				ID:           frame.ID,
 				ErrorCode:    -32600,
 				ErrorMessage: "pipelock: batch requests are not supported by MCP",
 			}
 			continue
 		}
 
-		pendingToolCallName := extractToolCallName(line)
+		pendingToolCallName := frame.ToolCallName
 		pendingActionID := ""
 		if pendingToolCallName != "" {
 			pendingActionID = receipt.NewActionID()
 		}
-		rpcID := extractRPCID(line)
+		rpcID := frame.ID
 		rewrittenLine, redactionReport, redactErr := applyMCPToolCallRedactionWithConfig(line, redactionCfg)
 		if redactErr != nil {
 			reason := redactErr.Error()
@@ -295,6 +303,11 @@ func ForwardScannedInput(
 			continue
 		}
 		line = rewrittenLine
+		// Redaction may have rewritten argument values; re-parse so
+		// downstream gates (DoW, taint) see the redacted args. ID,
+		// Method, and ToolCallName are invariant under redaction but
+		// re-parsing keeps the frame the single source of truth.
+		frame = ParseMCPFrame(line)
 
 		warnCtx := scanner.DLPWarnContextFromCtx(opts.warnContext())
 		warnCtx.Transport = transportMCPStdio
@@ -323,12 +336,12 @@ func ForwardScannedInput(
 		// Extract tool name once for binding, chain detection, and DoW tracking.
 		var toolCallName string
 		if verdict.Method == methodToolsCall {
-			toolCallName = extractToolCallName(line)
+			toolCallName = frame.ToolCallName
 		}
 
 		// Denial-of-wallet: check tool call budget before forwarding.
 		if opts.DoWCheck != nil && verdict.Method == methodToolsCall && toolCallName != "" {
-			argsJSON := extractToolCallArgs(line)
+			argsJSON := string(frame.Args)
 			allowed, dowAction, dowReason, dowBudgetType := opts.DoWCheck(toolCallName, argsJSON)
 			if !allowed {
 				logMsg := fmt.Sprintf("pipelock: input line %d: tools/call %q DoW %s: %s (%s)",
@@ -527,7 +540,7 @@ func ForwardScannedInput(
 			})
 		}
 		if verdict.Method == methodToolsCall {
-			taintDecision = evaluateMCPTaint(taintOpts, toolCallName, extractToolCallArgs(line))
+			taintDecision = evaluateMCPTaint(taintOpts, toolCallName, string(frame.Args))
 			if taintDecision.Result.Decision == session.PolicyAsk || taintDecision.Result.Decision == session.PolicyBlock {
 				if auditLogger != nil {
 					auditLogger.LogTaintDecision(

--- a/internal/mcp/pipeline_frame.go
+++ b/internal/mcp/pipeline_frame.go
@@ -10,11 +10,10 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/mcp/jsonrpc"
 )
 
-// MCPFrame is a single-pass structural parse of a JSON-RPC 2.0 message
+// MCPFrame is a structural parse of a JSON-RPC 2.0 message
 // received on an MCP transport. Callers that previously invoked
 // extractRPCID, extractToolCallName, and extractToolCallArgs separately
-// (each re-running json.Unmarshal on the same bytes) can parse once and
-// read every field from the Frame.
+// can read every field from the Frame instead.
 //
 // The zero value is a valid "nothing-parsed-yet" frame. Downstream
 // callers must check ParseErr before trusting Method or ToolCallName:
@@ -34,9 +33,7 @@ type MCPFrame struct {
 
 	// ID is the JSON-RPC "id" field, verbatim from the wire.
 	//
-	//  - nil when the "id" key is absent (a notification).
-	//  - json.RawMessage("null") for explicit-null IDs (also treated
-	//    as notification per isRPCNotification).
+	//  - nil when the "id" key is absent or explicitly null.
 	//  - the raw numeric or string form otherwise (do not coerce; the
 	//    wire format must flow through untouched for response
 	//    correlation).
@@ -73,8 +70,8 @@ type MCPFrame struct {
 
 // IsRequest reports whether the frame carries a JSON-RPC request ID
 // (numeric or string). Notifications (missing or null ID) return false.
-// Responses (no Method) also return false — callers should check Method
-// separately when they need to distinguish request from response.
+// Responses with an ID also return true, so callers that need to
+// distinguish requests from responses must check Method separately.
 func (f MCPFrame) IsRequest() bool {
 	return !isRPCNotification(f.ID)
 }
@@ -86,9 +83,10 @@ func (f MCPFrame) IsToolsCall() bool {
 	return f.Method == methodToolsCall
 }
 
-// ParseMCPFrame decodes msg in a single pass. The returned Frame is
-// always usable: even on parse failure the caller gets back a populated
-// Raw and a set ParseErr so fail-closed handling can run.
+// ParseMCPFrame decodes msg into the fields needed by the MCP pipeline.
+// The returned Frame is always usable: even on parse failure the caller
+// gets back a populated Raw and a set ParseErr so fail-closed handling
+// can run.
 //
 // This function is intentionally tolerant: it does not enforce the
 // jsonrpc 2.0 marker or any other validation. Those are policy
@@ -104,39 +102,52 @@ func ParseMCPFrame(msg []byte) MCPFrame {
 		return frame
 	}
 
-	// Single struct captures every field any MCP call path needs.
-	// Keeping this layout stable matters: adding optional fields here
-	// is safe, removing or renaming them breaks every caller.
+	// First pass: extract the ID only. This succeeds for any valid
+	// JSON object even if method or params are the wrong type. Keeping
+	// ID extraction resilient matters because the HTTP listener returns
+	// an invalid-request response that must include the client's id
+	// verbatim, even when the structural validator rejects the rest of
+	// the message (e.g., non-string method).
+	var idOnly struct {
+		ID json.RawMessage `json:"id"`
+	}
+	if err := json.Unmarshal(msg, &idOnly); err != nil {
+		frame.ParseErr = err
+		return frame
+	}
+	// Normalise the ID to match the legacy extractRPCID semantics: an
+	// explicit "null" literal or an empty RawMessage becomes nil.
+	if len(idOnly.ID) > 0 && string(idOnly.ID) != jsonrpc.Null {
+		frame.ID = idOnly.ID
+	}
+
+	// Second pass: extract method and raw params. May fail when method is a
+	// non-string; in that case the frame keeps the ID from the first pass
+	// and surfaces ParseErr so downstream validators still fail closed.
 	var decoded struct {
 		Method string          `json:"method"`
-		ID     json.RawMessage `json:"id"`
-		Params struct {
-			Name      string          `json:"name"`
-			Arguments json.RawMessage `json:"arguments"`
-		} `json:"params"`
+		Params json.RawMessage `json:"params"`
 	}
 	if err := json.Unmarshal(msg, &decoded); err != nil {
 		frame.ParseErr = err
 		return frame
 	}
-
-	// Normalise the ID to match the legacy extractRPCID semantics: an
-	// explicit "null" literal or an empty RawMessage becomes nil. This
-	// keeps downstream notification checks and direct ID comparisons
-	// behaving identically during the migration off the legacy
-	// extractors.
-	if len(decoded.ID) > 0 && string(decoded.ID) != jsonrpc.Null {
-		frame.ID = decoded.ID
-	}
 	frame.Method = decoded.Method
 	if decoded.Method == methodToolsCall {
-		frame.ToolCallName = decoded.Params.Name
+		var params struct {
+			Name      string          `json:"name"`
+			Arguments json.RawMessage `json:"arguments"`
+		}
+		if err := json.Unmarshal(decoded.Params, &params); err != nil {
+			return frame
+		}
+		frame.ToolCallName = params.Name
 		// Only retain a non-null, non-empty Arguments slice. A
 		// json.RawMessage of "null" is non-nil in Go but semantically
 		// absent; normalising to nil here lets callers rely on a plain
 		// len() == 0 check without the jsonrpc.Null-literal dance.
-		if len(decoded.Params.Arguments) > 0 && string(decoded.Params.Arguments) != jsonrpc.Null {
-			frame.Args = decoded.Params.Arguments
+		if len(params.Arguments) > 0 && string(params.Arguments) != jsonrpc.Null {
+			frame.Args = params.Arguments
 		}
 	}
 	return frame

--- a/internal/mcp/pipeline_frame.go
+++ b/internal/mcp/pipeline_frame.go
@@ -6,9 +6,19 @@ package mcp
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 
 	"github.com/luckyPipewrench/pipelock/internal/mcp/jsonrpc"
 )
+
+// ErrInvalidMethodType is surfaced via MCPFrame.ParseErr when a
+// JSON-RPC message has a non-string "method" field (including the
+// explicit JSON null literal). The HTTP listener's validateRPCStructure
+// already rejects these before they reach the frame parser on that
+// transport; the explicit error here fails closed on the stdio and
+// HTTP upstream paths where no pre-validator runs.
+var ErrInvalidMethodType = errors.New("mcp: method must be a string")
 
 // MCPFrame is a structural parse of a JSON-RPC 2.0 message
 // received on an MCP transport. Callers that previously invoked
@@ -124,16 +134,29 @@ func ParseMCPFrame(msg []byte) MCPFrame {
 	// Second pass: extract method and raw params. May fail when method is a
 	// non-string; in that case the frame keeps the ID from the first pass
 	// and surfaces ParseErr so downstream validators still fail closed.
+	// Method is read as json.RawMessage so we can distinguish three cases
+	// the Go json package would otherwise conflate: absent (zero len),
+	// explicit null literal (surfaces ErrInvalidMethodType per the
+	// fail-closed default), and a real string.
 	var decoded struct {
-		Method string          `json:"method"`
+		Method json.RawMessage `json:"method"`
 		Params json.RawMessage `json:"params"`
 	}
 	if err := json.Unmarshal(msg, &decoded); err != nil {
 		frame.ParseErr = err
 		return frame
 	}
-	frame.Method = decoded.Method
-	if decoded.Method == methodToolsCall {
+	if len(decoded.Method) > 0 {
+		if string(decoded.Method) == jsonrpc.Null {
+			frame.ParseErr = ErrInvalidMethodType
+			return frame
+		}
+		if err := json.Unmarshal(decoded.Method, &frame.Method); err != nil {
+			frame.ParseErr = fmt.Errorf("%w: %w", ErrInvalidMethodType, err)
+			return frame
+		}
+	}
+	if frame.Method == methodToolsCall {
 		var params struct {
 			Name      string          `json:"name"`
 			Arguments json.RawMessage `json:"arguments"`

--- a/internal/mcp/pipeline_frame_test.go
+++ b/internal/mcp/pipeline_frame_test.go
@@ -5,6 +5,7 @@ package mcp
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 )
 
@@ -167,16 +168,47 @@ func TestParseMCPFrame_ToolsCallMalformedParamsKeepsMethodAndID(t *testing.T) {
 }
 
 func TestParseMCPFrame_InvalidMethodPreservesID(t *testing.T) {
-	msg := `{"jsonrpc":"2.0","id":"client-id","method":42}`
-	frame := ParseMCPFrame([]byte(msg))
-	if frame.ParseErr == nil {
-		t.Fatal("ParseErr = nil, want error for non-string method")
+	tests := []struct {
+		name       string
+		msg        string
+		wantErrIs  error
+		matchExact bool
+	}{
+		{
+			name: "numeric method",
+			msg:  `{"jsonrpc":"2.0","id":"client-id","method":42}`,
+		},
+		{
+			name:       "null method",
+			msg:        `{"jsonrpc":"2.0","id":"client-id","method":null}`,
+			wantErrIs:  ErrInvalidMethodType,
+			matchExact: true,
+		},
+		{
+			name: "boolean method",
+			msg:  `{"jsonrpc":"2.0","id":"client-id","method":true}`,
+		},
+		{
+			name: "array method",
+			msg:  `{"jsonrpc":"2.0","id":"client-id","method":["a","b"]}`,
+		},
 	}
-	if string(frame.ID) != `"client-id"` {
-		t.Fatalf("ID = %q, want client ID preserved after second-pass failure", string(frame.ID))
-	}
-	if frame.Method != "" {
-		t.Fatalf("Method = %q, want empty after invalid method", frame.Method)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			frame := ParseMCPFrame([]byte(tt.msg))
+			if frame.ParseErr == nil {
+				t.Fatal("ParseErr = nil, want error for non-string method")
+			}
+			if tt.matchExact && !errors.Is(frame.ParseErr, tt.wantErrIs) {
+				t.Fatalf("ParseErr = %v, want errors.Is(%v)", frame.ParseErr, tt.wantErrIs)
+			}
+			if string(frame.ID) != `"client-id"` {
+				t.Fatalf("ID = %q, want client ID preserved after second-pass failure", string(frame.ID))
+			}
+			if frame.Method != "" {
+				t.Fatalf("Method = %q, want empty after invalid method", frame.Method)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/pipeline_frame_test.go
+++ b/internal/mcp/pipeline_frame_test.go
@@ -126,6 +126,60 @@ func TestParseMCPFrame_ToolsCallNullArgs(t *testing.T) {
 	}
 }
 
+func TestParseMCPFrame_ToolsCallMalformedParamsKeepsMethodAndID(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+	}{
+		{
+			name: "params array",
+			msg:  `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":["not","object"]}`,
+		},
+		{
+			name: "params string",
+			msg:  `{"jsonrpc":"2.0","id":8,"method":"tools/call","params":"not-object"}`,
+		},
+		{
+			name: "non-string tool name",
+			msg:  `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":42,"arguments":{"q":"x"}}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			frame := ParseMCPFrame([]byte(tt.msg))
+			if frame.ParseErr != nil {
+				t.Fatalf("ParseErr = %v, want nil", frame.ParseErr)
+			}
+			if frame.ID == nil {
+				t.Fatal("ID = nil, want preserved request ID")
+			}
+			if frame.Method != methodToolsCall {
+				t.Fatalf("Method = %q, want %q", frame.Method, methodToolsCall)
+			}
+			if frame.ToolCallName != "" {
+				t.Errorf("ToolCallName = %q, want empty for malformed params", frame.ToolCallName)
+			}
+			if frame.Args != nil {
+				t.Errorf("Args = %q, want nil for malformed params", string(frame.Args))
+			}
+		})
+	}
+}
+
+func TestParseMCPFrame_InvalidMethodPreservesID(t *testing.T) {
+	msg := `{"jsonrpc":"2.0","id":"client-id","method":42}`
+	frame := ParseMCPFrame([]byte(msg))
+	if frame.ParseErr == nil {
+		t.Fatal("ParseErr = nil, want error for non-string method")
+	}
+	if string(frame.ID) != `"client-id"` {
+		t.Fatalf("ID = %q, want client ID preserved after second-pass failure", string(frame.ID))
+	}
+	if frame.Method != "" {
+		t.Fatalf("Method = %q, want empty after invalid method", frame.Method)
+	}
+}
+
 func TestParseMCPFrame_NonToolsCallLeavesToolFieldsEmpty(t *testing.T) {
 	// tools/list and friends: ToolCallName and Args must stay zero so
 	// callers can use empty-ness as the "not a tools/call" gate.

--- a/internal/mcp/pipeline_gates.go
+++ b/internal/mcp/pipeline_gates.go
@@ -1,0 +1,267 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"errors"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/policy"
+	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+// MCPInputEvaluation aggregates the outputs of the configured inbound
+// gates for one MCP request. EvaluateMCPInputGates populates the
+// struct in a single pass; callers consume it to merge per-gate
+// actions into an effective verdict, dispatch block / warn / forward,
+// record adaptive signals, and emit receipts.
+//
+// Zero-value fields mean the gate did not run (its config was nil or
+// an earlier gate short-circuited). BlockingGate names the first gate
+// that issued a block-level verdict; empty means every configured
+// gate ran through. An empty BlockingGate does not mean "clean" -- the
+// caller may still find reasons to warn or merge non-clean content
+// with matched policy.
+//
+// Short-circuit semantics mirror the pre-refactor callers exactly.
+// On the first block verdict EvaluateMCPInputGates returns and the
+// remaining gates do not run. This preserves the stateful-gate
+// ordering contract: chain detection reads session state mutated by
+// DoW; taint reads session state potentially mutated by chain.
+type MCPInputEvaluation struct {
+	// BlockingGate names the first gate that returned a block-level
+	// verdict, or empty when every configured gate ran through.
+	// Values: "a2a_body", "dow", "chain", "parse_error",
+	// "taint_block", "taint_ask_denied". Callers use this as a
+	// log-framing key; block dispatch reads the per-gate fields
+	// below for the specific reason / code / message shape.
+	BlockingGate string
+
+	// ContentVerdict is the ScanRequest output. Always populated
+	// because content scan is the first gate.
+	ContentVerdict InputVerdict
+
+	// A2AResult is populated when a2aCfg is non-nil and enabled and
+	// the method matches IsA2AMethod. A2AResult.Clean is true when
+	// no findings were produced.
+	A2AResult A2AScanResult
+
+	// A2AEffectiveAction is the action A2AResult resolved to (empty
+	// when A2A did not run or the result was clean). Held separately
+	// so the caller can fold an A2A warn into the effective action
+	// merge alongside content and policy verdicts when no gate
+	// blocked.
+	A2AEffectiveAction string
+
+	// DoW fields are populated when DoWCheck is non-nil and the
+	// message is a tools/call with a non-empty ToolCallName.
+	DoWAllowed    bool
+	DoWAction     string
+	DoWReason     string
+	DoWBudgetType string
+
+	// PolicyVerdict is populated when policyCfg is non-nil.
+	PolicyVerdict policy.Verdict
+
+	// Chain fields are populated when chainMatcher is non-nil and
+	// the message is a tools/call with a non-empty ToolCallName.
+	// Note that chainMatcher.Record mutates session chain state on
+	// every call; the gate ordering after DoW preserves the
+	// pre-refactor contract that DoW-block messages do not leave a
+	// chain trace.
+	ChainMatched     bool
+	ChainPatternName string
+	ChainSeverity    string
+	ChainAction      string
+	ChainReason      string
+
+	// TaintDecision is populated when the message is a tools/call.
+	// The taint evaluator reads session state potentially mutated
+	// by earlier gates which is why it runs last.
+	TaintDecision taintDecision
+
+	// TaintAuditDecision preserves the raw policy result before any
+	// HITL approval mutates authority / reauth fields for envelope
+	// emission. TaintAuditDecisionSet is true when the decision should
+	// be logged by the caller.
+	TaintAuditDecision    taintDecision
+	TaintAuditDecisionSet bool
+
+	// TaintApproved is true iff the taint gate ran, produced a
+	// PolicyAsk decision, and an approver allowed the call. False
+	// in every other case including when the gate did not run.
+	TaintApproved bool
+}
+
+// EvaluateMCPInputGates runs the configured inbound gates for one
+// MCP request and returns their aggregated verdict. Each gate is
+// nil-safe: the helper skips gates whose config is nil or whose
+// preconditions are not met (e.g., DoW is tools/call-only).
+//
+// Gate execution order (semantic, not cosmetic):
+//
+//  1. Content scan via ScanRequest. Always runs. Establishes
+//     ContentVerdict.ID / Method used by later short-circuit paths.
+//  2. A2A body scan when a2aCfg is enabled and the method matches
+//     IsA2AMethod. A block verdict short-circuits the remaining
+//     tools/call-scoped gates.
+//  3. Denial-of-wallet check for tools/call with a non-empty tool
+//     name.
+//  4. Policy check against the full message bytes.
+//  5. Chain detection for tools/call. Mutates chain-matcher session
+//     state; running after DoW preserves the contract that DoW-block
+//     messages do not leave a chain trace.
+//  6. Parse-error short-circuit from ContentVerdict.Error. Runs
+//     after the stateful gates above so every configured gate
+//     contributes its audit signals before the block verdict is
+//     emitted.
+//  7. Taint evaluation for tools/call. Reads session state the
+//     earlier gates may have updated. PolicyAsk triggers the inline
+//     approver dialog (HITL); approved sets TaintApproved.
+//
+// Adaptive signal recording, audit logging, and receipt emission
+// stay in the caller because those side effects happen at the
+// block-dispatch site where the transport-specific response shape
+// is built. Lifting them here would hide the transport intent.
+//
+// scanAction, onParseError, and scanEnabled come from the caller's
+// inputCfg; they are parameters rather than opts-derived so the
+// helper does not have to duplicate the caller's scan-enable guard.
+func EvaluateMCPInputGates(
+	ctx context.Context,
+	frame MCPFrame,
+	msg []byte,
+	sessionKey string,
+	opts MCPProxyOpts,
+	scanAction, onParseError string,
+	scanEnabled bool,
+) MCPInputEvaluation {
+	eval := MCPInputEvaluation{}
+
+	sc := opts.scanner()
+	policyCfg := opts.policyCfg()
+	chainMatcher := opts.chainMatcher()
+	a2aCfg := opts.a2aCfg()
+
+	// Gate 1: content scan.
+	if scanEnabled {
+		eval.ContentVerdict = ScanRequest(ctx, msg, sc, scanAction, onParseError)
+	} else {
+		eval.ContentVerdict = InputVerdict{Clean: true}
+		// Always backfill ID / Method from the frame so downstream
+		// block paths (adaptive block_all, CEE) can return correct
+		// JSON-RPC error responses even when content scanning is
+		// disabled.
+		eval.ContentVerdict.ID = frame.ID
+		eval.ContentVerdict.Method = frame.Method
+	}
+	if errors.Is(frame.ParseErr, ErrInvalidMethodType) {
+		eval.ContentVerdict.ID = frame.ID
+		eval.ContentVerdict.Method = frame.Method
+		eval.ContentVerdict.Clean = false
+		eval.ContentVerdict.Error = frame.ParseErr.Error()
+	}
+
+	// Gate 2: A2A body scan. Runs before the tools/call-scoped
+	// gates so an A2A body block short-circuits them.
+	if a2aCfg != nil && a2aCfg.Enabled {
+		method := eval.ContentVerdict.Method
+		if method == "" {
+			method = frame.Method
+			if eval.ContentVerdict.ID == nil {
+				eval.ContentVerdict.ID = frame.ID
+			}
+		}
+		if IsA2AMethod(method) {
+			eval.A2AResult = ScanA2ARequestBody(ctx, msg, sc, a2aCfg)
+			if !eval.A2AResult.Clean {
+				action := eval.A2AResult.Action
+				if action == "" {
+					action = a2aCfg.Action
+				}
+				eval.A2AEffectiveAction = action
+				if action == config.ActionBlock {
+					eval.BlockingGate = "a2a_body"
+					return eval
+				}
+			}
+		}
+	}
+
+	// Gate 3: DoW. Only for tools/call with a tool name.
+	if opts.DoWCheck != nil && frame.IsToolsCall() && frame.ToolCallName != "" {
+		allowed, action, reason, budgetType := opts.DoWCheck(frame.ToolCallName, string(frame.Args))
+		eval.DoWAllowed = allowed
+		eval.DoWAction = action
+		eval.DoWReason = reason
+		eval.DoWBudgetType = budgetType
+		if !allowed && action == config.ActionBlock {
+			eval.BlockingGate = "dow"
+			return eval
+		}
+	}
+
+	// Gate 4: policy.
+	if policyCfg != nil {
+		eval.PolicyVerdict = policyCfg.CheckRequest(msg)
+	}
+
+	// Gate 5: chain. Mutates chain-matcher session state; ordering
+	// after DoW preserves the pre-refactor contract that DoW-block
+	// messages do not leave a chain trace.
+	if chainMatcher != nil && frame.IsToolsCall() && frame.ToolCallName != "" {
+		cv := chainMatcher.Record(sessionKey, frame.ToolCallName, string(msg))
+		if cv.Matched {
+			eval.ChainMatched = true
+			eval.ChainPatternName = cv.PatternName
+			eval.ChainSeverity = cv.Severity
+			eval.ChainAction = cv.Action
+			eval.ChainReason = "chain:" + cv.PatternName
+			if cv.Action == config.ActionBlock {
+				eval.BlockingGate = "chain"
+				return eval
+			}
+		}
+	}
+
+	// Gate 6: parse-error short-circuit. Runs after the stateful
+	// gates so every configured gate contributes its audit signals
+	// before the block verdict is emitted. Matches the pre-refactor
+	// ordering in scanHTTPInputDecision and ForwardScannedInput.
+	if eval.ContentVerdict.Error != "" {
+		eval.BlockingGate = "parse_error"
+		return eval
+	}
+
+	// Gate 7: taint. Only for tools/call. PolicyAsk triggers the
+	// inline approver dialog so HITL runs in the request-processing
+	// goroutine, matching the pre-refactor call site.
+	if frame.IsToolsCall() {
+		taintOpts := opts
+		taintOpts.TaintCfg = opts.taintCfg()
+		taintOpts.TaintCfgFn = nil
+		eval.TaintDecision = evaluateMCPTaint(taintOpts, frame.ToolCallName, string(frame.Args))
+		switch eval.TaintDecision.Result.Decision {
+		case session.PolicyBlock:
+			eval.TaintAuditDecision = eval.TaintDecision
+			eval.TaintAuditDecisionSet = true
+			eval.BlockingGate = "taint_block"
+			return eval
+		case session.PolicyAsk:
+			eval.TaintAuditDecision = eval.TaintDecision
+			eval.TaintAuditDecisionSet = true
+			preview := frame.ToolCallName + " " + eval.TaintDecision.ActionRef
+			approved, hasApprover := taintDecisionRequiresApproval(opts, frame.ToolCallName, taintApprovalReason(eval.TaintDecision), preview)
+			if !hasApprover || !approved {
+				eval.BlockingGate = "taint_ask_denied"
+				return eval
+			}
+			approveTaintDecision(&eval.TaintDecision)
+			eval.TaintApproved = true
+		}
+	}
+
+	return eval
+}

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -154,12 +154,16 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 		}
 		lineNum++
 
+		// Parse the inbound frame once per message; every gate below reads
+		// ID / Method / tool fields from this frame instead of re-parsing.
+		frame := ParseMCPFrame(line)
+
 		// Kill switch: deny all responses when activated mid-stream.
 		// Checked per message so activation after session start takes effect
 		// immediately on already-open MCP sessions.
 		if ks != nil {
 			if d := ks.IsActiveMCP(line); d.Active {
-				rpcID := extractRPCID(line)
+				rpcID := frame.ID
 				if rpcID == nil {
 					// Notification: drop silently (no response possible).
 					_, _ = fmt.Fprintf(logW, "pipelock: response line %d: kill switch dropped notification (source=%s)\n",
@@ -192,7 +196,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 			}
 		}
 		if blockAll {
-			rpcID := extractRPCID(line)
+			rpcID := frame.ID
 			// Notifications (no ID) must not receive a response per JSON-RPC spec.
 			// Drop them silently instead of writing an error.
 			if rpcID == nil {
@@ -222,7 +226,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 		// (concurrent goroutines). The window is not exploitable: before any
 		// client request, no valid request ID exists to hijack.
 		if tracker != nil && tracker.Seeded() && isResponse(line) {
-			rpcID := extractRPCID(line)
+			rpcID := frame.ID
 			if rpcID != nil && !tracker.Validate(rpcID) {
 				_, _ = fmt.Fprintf(logW, "pipelock: line %d: confused deputy: unsolicited response ID %s\n",
 					lineNum, string(rpcID))
@@ -236,7 +240,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 
 		mediaResult := applyMCPResponseMediaPolicy(line, mediaPolicy, opts.Transport)
 		if len(mediaResult.Exposures) > 0 && opts.AuditLogger != nil {
-			rpcID := extractRPCID(line)
+			rpcID := frame.ID
 			target := mcpServerResponse
 			if requestID := canonicalID(rpcID); requestID != "" {
 				target = "response:" + requestID
@@ -247,7 +251,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 			}
 		}
 		if mediaResult.Blocked {
-			rpcID := extractRPCID(line)
+			rpcID := frame.ID
 			requestID := canonicalID(rpcID)
 			target := mcpServerResponse
 			if requestID != "" {

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -266,14 +266,16 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 				m.RecordBlocked("mcp", "media_policy", 0, "")
 			}
 			if receiptEmitter != nil {
-				if emitErr := receiptEmitter.Emit(receipt.EmitOpts{
-					ActionID:  receipt.NewActionID(),
-					Verdict:   config.ActionBlock,
-					Transport: opts.Transport,
-					Target:    target,
-					RequestID: requestID,
-					Layer:     "media_policy",
-					Pattern:   mediaResult.BlockReason,
+				if _, emitErr := EmitMCPDecision(receiptEmitter, nil, MCPDecision{
+					Receipt: receipt.EmitOpts{
+						ActionID:  receipt.NewActionID(),
+						Verdict:   config.ActionBlock,
+						Transport: opts.Transport,
+						Target:    target,
+						RequestID: requestID,
+						Layer:     "media_policy",
+						Pattern:   mediaResult.BlockReason,
+					},
 				}); emitErr != nil {
 					_, _ = fmt.Fprintf(logW, "pipelock: receipt emission failed: %v\n", emitErr)
 				}
@@ -551,14 +553,16 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 			if len(names) > 0 {
 				pattern = names[0]
 			}
-			if emitErr := receiptEmitter.Emit(receipt.EmitOpts{
-				ActionID:  receipt.NewActionID(),
-				Verdict:   effectiveAction,
-				Transport: opts.Transport,
-				Target:    target,
-				RequestID: requestID,
-				Layer:     "mcp_response_scan",
-				Pattern:   pattern,
+			if _, emitErr := EmitMCPDecision(receiptEmitter, nil, MCPDecision{
+				Receipt: receipt.EmitOpts{
+					ActionID:  receipt.NewActionID(),
+					Verdict:   effectiveAction,
+					Transport: opts.Transport,
+					Target:    target,
+					RequestID: requestID,
+					Layer:     "mcp_response_scan",
+					Pattern:   pattern,
+				},
 			}); emitErr != nil {
 				_, _ = fmt.Fprintf(logW, "pipelock: receipt emission failed: %v\n", emitErr)
 			}

--- a/internal/mcp/proxy_http.go
+++ b/internal/mcp/proxy_http.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -225,7 +224,6 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	sc := opts.scanner()
 	inputCfg := opts.inputCfg()
 	policyCfg := opts.policyCfg()
-	chainMatcher := opts.chainMatcher()
 	auditLogger := opts.AuditLogger
 	cee := opts.cee()
 	rec := opts.Rec
@@ -235,11 +233,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	redactionCfg := opts.redactionConfig()
 	receiptEmitter := opts.receiptEmitter()
 	envelopeEmitter := opts.envelopeEmitter()
-	a2aCfg := opts.a2aCfg()
 	redirectRT := opts.redirectRT()
-	taintOpts := opts
-	taintOpts.TaintCfg = opts.taintCfg()
-	taintOpts.TaintCfgFn = nil
 	result := httpInputDecision{ForwardMessage: msg}
 	mcpMethod := ""
 	toolName := ""
@@ -338,28 +332,23 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		action = inputCfg.Action
 		onParseError = inputCfg.OnParseError
 	}
-
-	// Content scan.
-	var verdict InputVerdict
 	scanEnabled := inputCfg != nil && inputCfg.Enabled
+
+	// Build the scan context once so the helper sees the same
+	// DLPWarnContext the inline content scan would have seen.
 	inputScanCtx := opts.warnContext()
 	wc := scanner.DLPWarnContextFromCtx(inputScanCtx)
 	if wc.Transport == "" {
 		wc.Transport = transportMCPHTTP
 		inputScanCtx = scanner.WithDLPWarnContext(inputScanCtx, wc)
 	}
-	if scanEnabled {
-		verdict = ScanRequest(inputScanCtx, msg, sc, action, onParseError)
-	} else {
-		verdict = InputVerdict{Clean: true}
-		// When input scanning is disabled, backfill enough metadata from
-		// the parsed frame so policy, taint gating, chain detection, and
-		// DoW still work.
-		if policyCfg != nil || chainMatcher != nil || opts.DoWCheck != nil || taintOpts.TaintCfg != nil || receiptEmitter != nil || envelopeEmitter != nil {
-			verdict.ID = frame.ID
-			verdict.Method = frame.Method
-		}
-	}
+
+	// Evaluate every configured gate in one pass. The helper returns
+	// a composite verdict and the first gate that short-circuited,
+	// preserving per-gate block semantics and ordering.
+	eval := EvaluateMCPInputGates(inputScanCtx, frame, msg, sessionKey, opts, action, onParseError, scanEnabled)
+	verdict := eval.ContentVerdict
+	policyVerdict := eval.PolicyVerdict
 
 	mcpMethod = verdict.Method
 	if verdict.Method == methodToolsCall {
@@ -368,122 +357,78 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		}
 		toolName = frame.ToolCallName
 	}
-
-	// A2A request body scanning: field-aware analysis for A2A protocol methods.
-	// Runs after content scanning so both pipelines contribute findings.
-	// When the method is unknown (input scanning disabled, no policy/chain),
-	// backfill it from the parsed frame for A2A detection.
-	if a2aCfg != nil && a2aCfg.Enabled {
-		method := verdict.Method
-		if method == "" {
-			method = frame.Method
-			// Backfill verdict.ID so IsNotification works correctly
-			// when input scanning is disabled and no policy/chain config
-			// triggered the earlier backfill.
-			if verdict.ID == nil {
-				verdict.ID = frame.ID
-			}
+	logTaintDecision := func() {
+		if auditLogger == nil {
+			return
 		}
-		if IsA2AMethod(method) {
-			a2aResult := ScanA2ARequestBody(inputScanCtx, msg, sc, a2aCfg)
-			if !a2aResult.Clean {
-				a2aAction := a2aResult.Action
-				if a2aAction == "" {
-					a2aAction = a2aCfg.Action
-				}
-				if a2aAction == config.ActionBlock {
-					_, _ = fmt.Fprintf(logW, "pipelock: a2a input: blocked (%s)\n", a2aResult.Reason)
-					if a2aResult.IsConfigMismatch() {
-						recordAdaptiveSignal(session.SignalNearMiss)
-					} else {
-						recordAdaptiveSignal(session.SignalBlock)
-					}
-					receiptVerdict = config.ActionBlock
-					result.Blocked = &BlockedRequest{
-						ID:             verdict.ID,
-						IsNotification: isRPCNotification(verdict.ID),
-						LogMessage:     "blocked (a2a input scanning)",
-						ErrorCode:      -32001,
-						ErrorMessage:   "pipelock: request blocked by A2A input scanning",
-					}
-					return result
-				}
-				// warn mode: log and continue.
-				_, _ = fmt.Fprintf(logW, "pipelock: a2a input: warning (%s)\n", a2aResult.Reason)
-				recordAdaptiveSignal(session.SignalNearMiss)
-			}
+		decision := eval.TaintDecision
+		if eval.TaintAuditDecisionSet {
+			decision = eval.TaintAuditDecision
 		}
+		auditLogger.LogTaintDecision(
+			mustMCPAuditContext(auditLogger, "MCP", toolName),
+			decision.Risk.Level.String(),
+			decision.ActionClass.String(),
+			decision.Sensitivity.String(),
+			decision.Authority.String(),
+			decision.Result.Decision.String(),
+			decision.Result.Reason,
+			decision.Risk.LastExternalURL,
+			decision.Risk.LastExternalKind,
+		)
 	}
 
-	// Denial-of-wallet: check tool call budget before forwarding.
-	if opts.DoWCheck != nil && verdict.Method == methodToolsCall {
-		toolName := frame.ToolCallName
-		if toolName != "" {
-			argsJSON := string(frame.Args)
-			allowed, dowAction, dowReason, dowBudgetType := opts.DoWCheck(toolName, argsJSON)
-			if !allowed {
-				_, _ = fmt.Fprintf(logW, "pipelock: tools/call %q DoW %s: %s (%s)\n",
-					toolName, dowAction, dowReason, dowBudgetType)
-				if dowAction == config.ActionBlock {
-					if auditLogger != nil {
-						auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", toolName), "denial_of_wallet", dowReason)
-					}
-					if m != nil {
-						m.RecordBlocked("mcp", "denial_of_wallet", 0, "")
-					}
-					recordAdaptiveSignal(session.SignalBlock)
-					receiptVerdict = config.ActionBlock
-					result.Blocked = &BlockedRequest{ID: verdict.ID, IsNotification: isRPCNotification(verdict.ID), ErrorCode: -32600, ErrorMessage: "pipelock: " + dowReason}
-					return result
-				}
-				// dow_action: warn — log and record near-miss, but allow the request.
-				if auditLogger != nil {
-					auditLogger.LogAnomaly(mustMCPAuditContext(auditLogger, "MCP", toolName), "denial_of_wallet", dowReason, 0)
-				}
-				recordAdaptiveSignal(session.SignalNearMiss)
-			}
+	// Dispatch block-level gate verdicts. Per-gate log / audit /
+	// metrics / adaptive-signal side effects live here so the
+	// transport-specific response shape (JSON-RPC error codes,
+	// LogMessage strings) stays in the transport layer.
+	switch eval.BlockingGate {
+	case "a2a_body":
+		_, _ = fmt.Fprintf(logW, "pipelock: a2a input: blocked (%s)\n", eval.A2AResult.Reason)
+		if eval.A2AResult.IsConfigMismatch() {
+			recordAdaptiveSignal(session.SignalNearMiss)
+		} else {
+			recordAdaptiveSignal(session.SignalBlock)
 		}
-	}
-
-	// Policy check.
-	policyVerdict := policy.Verdict{}
-	if policyCfg != nil {
-		policyVerdict = policyCfg.CheckRequest(msg)
-	}
-
-	// Chain detection: check if this tool call matches an attack pattern.
-	chainAction := ""
-	chainReason := ""
-	if chainMatcher != nil && verdict.Method == methodToolsCall {
-		toolName := frame.ToolCallName
-		if toolName != "" {
-			cv := chainMatcher.Record(sessionKey, toolName, string(msg))
-			if cv.Matched {
-				_, _ = fmt.Fprintf(logW, "pipelock: chain detected: %s (severity=%s, action=%s)\n",
-					cv.PatternName, cv.Severity, cv.Action)
-				if auditLogger != nil {
-					auditLogger.LogChainDetection(cv.PatternName, cv.Severity, cv.Action, toolName, auditSessionKey)
-				}
-				if cv.Action == config.ActionBlock {
-					recordAdaptiveSignal(session.SignalBlock)
-					receiptVerdict = config.ActionBlock
-					result.Blocked = &BlockedRequest{
-						ID:             verdict.ID,
-						IsNotification: isRPCNotification(verdict.ID),
-						LogMessage:     fmt.Sprintf("chain pattern %q blocked", cv.PatternName),
-						ErrorCode:      -32004,
-						ErrorMessage:   fmt.Sprintf("tool call blocked: chain pattern %q detected", cv.PatternName),
-					}
-					return result
-				}
-				chainAction = cv.Action
-				chainReason = "chain:" + cv.PatternName
-			}
+		receiptVerdict = config.ActionBlock
+		result.Blocked = &BlockedRequest{
+			ID:             verdict.ID,
+			IsNotification: isRPCNotification(verdict.ID),
+			LogMessage:     "blocked (a2a input scanning)",
+			ErrorCode:      -32001,
+			ErrorMessage:   "pipelock: request blocked by A2A input scanning",
 		}
-	}
-
-	// Parse error — always block.
-	if verdict.Error != "" {
+		return result
+	case "dow":
+		_, _ = fmt.Fprintf(logW, "pipelock: tools/call %q DoW %s: %s (%s)\n",
+			toolName, eval.DoWAction, eval.DoWReason, eval.DoWBudgetType)
+		if auditLogger != nil {
+			auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", toolName), "denial_of_wallet", eval.DoWReason)
+		}
+		if m != nil {
+			m.RecordBlocked("mcp", "denial_of_wallet", 0, "")
+		}
+		recordAdaptiveSignal(session.SignalBlock)
+		receiptVerdict = config.ActionBlock
+		result.Blocked = &BlockedRequest{ID: verdict.ID, IsNotification: isRPCNotification(verdict.ID), ErrorCode: -32600, ErrorMessage: "pipelock: " + eval.DoWReason}
+		return result
+	case "chain":
+		_, _ = fmt.Fprintf(logW, "pipelock: chain detected: %s (severity=%s, action=%s)\n",
+			eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction)
+		if auditLogger != nil {
+			auditLogger.LogChainDetection(eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction, toolName, auditSessionKey)
+		}
+		recordAdaptiveSignal(session.SignalBlock)
+		receiptVerdict = config.ActionBlock
+		result.Blocked = &BlockedRequest{
+			ID:             verdict.ID,
+			IsNotification: isRPCNotification(verdict.ID),
+			LogMessage:     fmt.Sprintf("chain pattern %q blocked", eval.ChainPatternName),
+			ErrorCode:      -32004,
+			ErrorMessage:   fmt.Sprintf("tool call blocked: chain pattern %q detected", eval.ChainPatternName),
+		}
+		return result
+	case "parse_error":
 		_, _ = fmt.Fprintf(logW, "pipelock: input: %s\n", verdict.Error)
 		receiptVerdict = config.ActionBlock
 		result.Blocked = &BlockedRequest{
@@ -492,53 +437,51 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			LogMessage:     "blocked (parse error)",
 		}
 		return result
+	case "taint_block", "taint_ask_denied":
+		logTaintDecision()
+		receiptVerdict = config.ActionBlock
+		result.Blocked = &BlockedRequest{
+			ID:             verdict.ID,
+			IsNotification: isRPCNotification(verdict.ID),
+			LogMessage:     "blocked by taint policy",
+			ErrorCode:      -32002,
+			ErrorMessage:   "pipelock: " + eval.TaintDecision.Result.Reason,
+		}
+		return result
 	}
 
-	if verdict.Method == methodToolsCall {
-		taintEval = evaluateMCPTaint(taintOpts, toolName, string(frame.Args))
-		if taintEval.Result.Decision == session.PolicyAsk || taintEval.Result.Decision == session.PolicyBlock {
-			if auditLogger != nil {
-				auditLogger.LogTaintDecision(
-					mustMCPAuditContext(auditLogger, "MCP", toolName),
-					taintEval.Risk.Level.String(),
-					taintEval.ActionClass.String(),
-					taintEval.Sensitivity.String(),
-					taintEval.Authority.String(),
-					taintEval.Result.Decision.String(),
-					taintEval.Result.Reason,
-					taintEval.Risk.LastExternalURL,
-					taintEval.Risk.LastExternalKind,
-				)
-			}
-			switch taintEval.Result.Decision {
-			case session.PolicyBlock:
-				receiptVerdict = config.ActionBlock
-				result.Blocked = &BlockedRequest{
-					ID:             verdict.ID,
-					IsNotification: isRPCNotification(verdict.ID),
-					LogMessage:     "blocked by taint policy",
-					ErrorCode:      -32002,
-					ErrorMessage:   "pipelock: " + taintEval.Result.Reason,
-				}
-				return result
-			case session.PolicyAsk:
-				preview := strings.TrimSpace(fmt.Sprintf("%s %s", toolName, taintEval.ActionRef))
-				approved, hasApprover := taintDecisionRequiresApproval(opts, toolName, taintApprovalReason(taintEval), preview)
-				if !hasApprover || !approved {
-					receiptVerdict = config.ActionBlock
-					result.Blocked = &BlockedRequest{
-						ID:             verdict.ID,
-						IsNotification: isRPCNotification(verdict.ID),
-						LogMessage:     "blocked by taint policy",
-						ErrorCode:      -32002,
-						ErrorMessage:   "pipelock: " + taintEval.Result.Reason,
-					}
-					return result
-				}
-				approveTaintDecision(&taintEval)
-			}
+	// Non-blocking warn-level side effects from gates that did not
+	// short-circuit. A2A warn logs and records a near-miss; DoW warn
+	// logs, records an anomaly, and records a near-miss. These
+	// happen after the switch so block dispatches skip them.
+	if eval.TaintApproved {
+		logTaintDecision()
+	}
+	if !eval.A2AResult.Clean && eval.A2AEffectiveAction != "" && eval.A2AEffectiveAction != config.ActionBlock {
+		_, _ = fmt.Fprintf(logW, "pipelock: a2a input: warning (%s)\n", eval.A2AResult.Reason)
+		recordAdaptiveSignal(session.SignalNearMiss)
+	}
+	if eval.DoWAction != "" && !eval.DoWAllowed && eval.DoWAction != config.ActionBlock {
+		_, _ = fmt.Fprintf(logW, "pipelock: tools/call %q DoW %s: %s (%s)\n",
+			toolName, eval.DoWAction, eval.DoWReason, eval.DoWBudgetType)
+		if auditLogger != nil {
+			auditLogger.LogAnomaly(mustMCPAuditContext(auditLogger, "MCP", toolName), "denial_of_wallet", eval.DoWReason, 0)
+		}
+		recordAdaptiveSignal(session.SignalNearMiss)
+	}
+	// Chain warn has already been recorded as ChainAction on eval;
+	// log it here so the action-merge section below can fold it in.
+	if eval.ChainMatched && eval.ChainAction != config.ActionBlock {
+		_, _ = fmt.Fprintf(logW, "pipelock: chain detected: %s (severity=%s, action=%s)\n",
+			eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction)
+		if auditLogger != nil {
+			auditLogger.LogChainDetection(eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction, toolName, auditSessionKey)
 		}
 	}
+
+	taintEval = eval.TaintDecision
+	chainAction := eval.ChainAction
+	chainReason := eval.ChainReason
 
 	// All clean — proceed (with block_all and CEE checks).
 	if verdict.Clean && !policyVerdict.Matched && chainAction == "" {

--- a/internal/mcp/proxy_http.go
+++ b/internal/mcp/proxy_http.go
@@ -107,6 +107,11 @@ func RunHTTPProxy(
 			return fmt.Errorf("reading stdin: %w", err)
 		}
 
+		// Parse the inbound frame once per message. Kill switch, request
+		// tracking, and upstream-error responses all read frame.ID
+		// instead of re-parsing.
+		frame := ParseMCPFrame(msg)
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -120,7 +125,7 @@ func RunHTTPProxy(
 					_, _ = fmt.Fprintf(safeLogW, "pipelock: kill switch dropped notification (source=%s)\n", d.Source)
 					continue
 				}
-				rpcID := extractRPCID(msg)
+				rpcID := frame.ID
 				resp := killswitch.ErrorResponse(rpcID, d.Message)
 				if wErr := safeClientOut.WriteMessage(resp); wErr != nil {
 					_, _ = fmt.Fprintf(safeLogW, "pipelock: failed to send kill switch response: %v\n", wErr)
@@ -151,7 +156,7 @@ func RunHTTPProxy(
 		// Only track requests (have "method"), not client responses to
 		// server-initiated calls, to prevent tracker pollution.
 		if isRequest(msg) {
-			tracker.Track(extractRPCID(msg))
+			tracker.Track(frame.ID)
 		}
 
 		// POST to upstream.
@@ -161,7 +166,7 @@ func RunHTTPProxy(
 			_, _ = fmt.Fprintf(safeLogW, "pipelock: upstream error: %v\n", err)
 			// Send sanitized error to client — don't include upstream body content
 			// which could contain prompt injection payloads.
-			rpcID := extractRPCID(msg)
+			rpcID := frame.ID
 			errResp := upstreamErrorResponse(rpcID, fmt.Errorf("upstream HTTP request failed"))
 			if wErr := safeClientOut.WriteMessage(errResp); wErr != nil {
 				_, _ = fmt.Fprintf(safeLogW, "pipelock: failed to send error response: %v\n", wErr)
@@ -249,6 +254,13 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		emitMCPToolReceipt(receiptEmitter, opts.Transport, redactionCfg.Profile, actionID, mcpMethod, toolName, receiptVerdict, taintEval, redactionReport)
 	}()
 
+	// Parse the inbound frame once. Every gate below reads ID / Method /
+	// tool fields from this frame instead of re-parsing. Redaction may
+	// rewrite argument values; the frame is re-parsed after redaction so
+	// downstream gates (DoW, taint) see the redacted args while
+	// ID / Method / ToolCallName stay stable.
+	frame := ParseMCPFrame(msg)
+
 	// Helper: record an adaptive signal and handle escalation side-effects.
 	// Eliminates repeated nil/enabled guards at every call site.
 	recordAdaptiveSignal := func(sig session.SignalType) {
@@ -281,14 +293,14 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		recordAdaptiveSignal(session.SignalBlock)
 		receiptVerdict = config.ActionBlock
 		result.Blocked = &BlockedRequest{
-			ID:           extractRPCID(msg),
+			ID:           frame.ID,
 			ErrorCode:    -32600,
 			ErrorMessage: "pipelock: batch requests are not supported by MCP",
 		}
 		return result
 	}
 
-	if pendingToolName := extractToolCallName(msg); pendingToolName != "" {
+	if pendingToolName := frame.ToolCallName; pendingToolName != "" {
 		toolName = pendingToolName
 		mcpMethod = methodToolsCall
 		actionID = receipt.NewActionID()
@@ -304,8 +316,8 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		recordAdaptiveSignal(session.SignalBlock)
 		receiptVerdict = config.ActionBlock
 		result.Blocked = &BlockedRequest{
-			ID:             extractRPCID(msg),
-			IsNotification: isRPCNotification(extractRPCID(msg)),
+			ID:             frame.ID,
+			IsNotification: isRPCNotification(frame.ID),
 			LogMessage:     "blocked (redaction)",
 			ErrorCode:      -32001,
 			ErrorMessage:   "pipelock: request blocked by MCP redaction",
@@ -315,6 +327,9 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	msg = rewrittenMsg
 	result.ForwardMessage = rewrittenMsg
 	redactionReport = report
+	// Redaction may have rewritten argument values; re-parse so
+	// downstream gates (DoW, taint) see the redacted args.
+	frame = ParseMCPFrame(msg)
 
 	// Determine input scanning parameters.
 	action := config.ActionWarn
@@ -337,17 +352,12 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		verdict = ScanRequest(inputScanCtx, msg, sc, action, onParseError)
 	} else {
 		verdict = InputVerdict{Clean: true}
-		// When input scanning is disabled, extract enough metadata from the
-		// raw message so policy, taint gating, chain detection, and DoW still work.
+		// When input scanning is disabled, backfill enough metadata from
+		// the parsed frame so policy, taint gating, chain detection, and
+		// DoW still work.
 		if policyCfg != nil || chainMatcher != nil || opts.DoWCheck != nil || taintOpts.TaintCfg != nil || receiptEmitter != nil || envelopeEmitter != nil {
-			verdict.ID = extractRPCID(msg)
-			// Extract method for chain detection even when content scanning is off.
-			var env struct {
-				Method string `json:"method"`
-			}
-			if json.Unmarshal(msg, &env) == nil {
-				verdict.Method = env.Method
-			}
+			verdict.ID = frame.ID
+			verdict.Method = frame.Method
 		}
 	}
 
@@ -356,28 +366,22 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		if actionID == "" {
 			actionID = receipt.NewActionID()
 		}
-		toolName = extractToolCallName(msg)
+		toolName = frame.ToolCallName
 	}
 
 	// A2A request body scanning: field-aware analysis for A2A protocol methods.
 	// Runs after content scanning so both pipelines contribute findings.
 	// When the method is unknown (input scanning disabled, no policy/chain),
-	// extract it for A2A detection.
+	// backfill it from the parsed frame for A2A detection.
 	if a2aCfg != nil && a2aCfg.Enabled {
 		method := verdict.Method
 		if method == "" {
-			var env struct {
-				Method string          `json:"method"`
-				ID     json.RawMessage `json:"id"`
-			}
-			if json.Unmarshal(msg, &env) == nil {
-				method = env.Method
-				// Backfill verdict.ID so IsNotification works correctly
-				// when input scanning is disabled and no policy/chain config
-				// triggered the earlier extraction.
-				if verdict.ID == nil && len(env.ID) > 0 && string(env.ID) != jsonrpc.Null {
-					verdict.ID = env.ID
-				}
+			method = frame.Method
+			// Backfill verdict.ID so IsNotification works correctly
+			// when input scanning is disabled and no policy/chain config
+			// triggered the earlier backfill.
+			if verdict.ID == nil {
+				verdict.ID = frame.ID
 			}
 		}
 		if IsA2AMethod(method) {
@@ -413,9 +417,9 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 
 	// Denial-of-wallet: check tool call budget before forwarding.
 	if opts.DoWCheck != nil && verdict.Method == methodToolsCall {
-		toolName := extractToolCallName(msg)
+		toolName := frame.ToolCallName
 		if toolName != "" {
-			argsJSON := extractToolCallArgs(msg)
+			argsJSON := string(frame.Args)
 			allowed, dowAction, dowReason, dowBudgetType := opts.DoWCheck(toolName, argsJSON)
 			if !allowed {
 				_, _ = fmt.Fprintf(logW, "pipelock: tools/call %q DoW %s: %s (%s)\n",
@@ -451,7 +455,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	chainAction := ""
 	chainReason := ""
 	if chainMatcher != nil && verdict.Method == methodToolsCall {
-		toolName := extractToolCallName(msg)
+		toolName := frame.ToolCallName
 		if toolName != "" {
 			cv := chainMatcher.Record(sessionKey, toolName, string(msg))
 			if cv.Matched {
@@ -491,7 +495,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	}
 
 	if verdict.Method == methodToolsCall {
-		taintEval = evaluateMCPTaint(taintOpts, toolName, extractToolCallArgs(msg))
+		taintEval = evaluateMCPTaint(taintOpts, toolName, string(frame.Args))
 		if taintEval.Result.Decision == session.PolicyAsk || taintEval.Result.Decision == session.PolicyBlock {
 			if auditLogger != nil {
 				auditLogger.LogTaintDecision(
@@ -1149,6 +1153,11 @@ func RunHTTPListenerProxy(
 			return
 		}
 
+		// Parse the inbound frame once per request. Every rpcID lookup
+		// and upstream-error response below reads frame.ID instead of
+		// re-parsing the body bytes.
+		frame := ParseMCPFrame(body)
+
 		// Validate JSON-RPC 2.0 structure for single requests: version
 		// must be "2.0", method must be present and a string. Batch
 		// requests (JSON arrays) are validated per-element by scanHTTPInput.
@@ -1157,7 +1166,7 @@ func RunHTTPListenerProxy(
 			if reason := validateRPCStructure(body); reason != "" {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
-				rpcID := extractRPCID(body)
+				rpcID := frame.ID
 				invalidReq, _ := json.Marshal(rpcError{
 					JSONRPC: jsonrpc.Version,
 					ID:      rpcID,
@@ -1177,7 +1186,7 @@ func RunHTTPListenerProxy(
 					_, _ = fmt.Fprintf(safeLogW, "pipelock: kill switch dropped notification (source=%s)\n", d.Source)
 					return
 				}
-				rpcID := extractRPCID(body)
+				rpcID := frame.ID
 				_, _ = w.Write(killswitch.ErrorResponse(rpcID, d.Message))
 				return
 			}
@@ -1251,7 +1260,7 @@ func RunHTTPListenerProxy(
 					})
 				}
 				w.Header().Set("Content-Type", "application/json")
-				rpcID := extractRPCID(body)
+				rpcID := frame.ID
 				resp, _ := json.Marshal(rpcError{
 					JSONRPC: jsonrpc.Version,
 					ID:      rpcID,
@@ -1284,7 +1293,7 @@ func RunHTTPListenerProxy(
 					}
 				}
 				w.Header().Set("Content-Type", "application/json")
-				rpcID := extractRPCID(body)
+				rpcID := frame.ID
 				resp, _ := json.Marshal(rpcError{
 					JSONRPC: jsonrpc.Version,
 					ID:      rpcID,
@@ -1321,7 +1330,7 @@ func RunHTTPListenerProxy(
 		if err != nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadGateway)
-			_, _ = w.Write(upstreamErrorResponse(extractRPCID(body), fmt.Errorf("upstream HTTP request failed")))
+			_, _ = w.Write(upstreamErrorResponse(frame.ID, fmt.Errorf("upstream HTTP request failed")))
 			return
 		}
 		upReq.Header.Set("Content-Type", "application/json")
@@ -1349,7 +1358,7 @@ func RunHTTPListenerProxy(
 			_, _ = fmt.Fprintf(safeLogW, "pipelock: upstream error: %v\n", err)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadGateway)
-			_, _ = w.Write(upstreamErrorResponse(extractRPCID(body), fmt.Errorf("upstream HTTP request failed")))
+			_, _ = w.Write(upstreamErrorResponse(frame.ID, fmt.Errorf("upstream HTTP request failed")))
 			return
 		}
 		defer upResp.Body.Close() //nolint:errcheck // best-effort cleanup
@@ -1366,7 +1375,7 @@ func RunHTTPListenerProxy(
 			_, _ = fmt.Fprintf(safeLogW, "pipelock: upstream HTTP %d\n", upResp.StatusCode)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadGateway)
-			_, _ = w.Write(upstreamErrorResponse(extractRPCID(body), fmt.Errorf("upstream HTTP request failed")))
+			_, _ = w.Write(upstreamErrorResponse(frame.ID, fmt.Errorf("upstream HTTP request failed")))
 			return
 		}
 

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/emit"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/chains"
@@ -50,6 +51,19 @@ const (
 )
 
 func intPtrHTTP(v int) *int { return &v }
+
+type recordingEmitSinkHTTP struct {
+	events []emit.Event
+}
+
+func (s *recordingEmitSinkHTTP) Emit(_ context.Context, ev emit.Event) error {
+	s.events = append(s.events, ev)
+	return nil
+}
+
+func (s *recordingEmitSinkHTTP) Close() error {
+	return nil
+}
 
 func testHTTPRedactionMatcher() *redact.Matcher {
 	return redact.NewDefaultMatcher()
@@ -4739,6 +4753,62 @@ func TestScanHTTPInputDecision_ReceiptBackfillWhenInputScanningDisabledAndBlocke
 	}
 	if record.Target != "expensive_tool" {
 		t.Fatalf("receipt target = %q, want %q", record.Target, "expensive_tool")
+	}
+}
+
+func TestScanHTTPInputDecision_InvalidMethodTypeBlocks(t *testing.T) {
+	sc := testScannerForHTTP(t)
+
+	tests := []struct {
+		name     string
+		msg      []byte
+		inputCfg *InputScanConfig
+	}{
+		{
+			name: "input scanning enabled",
+			msg:  []byte(`{"jsonrpc":"2.0","id":5,"method":null}`),
+			inputCfg: &InputScanConfig{
+				Enabled:      true,
+				Action:       config.ActionWarn,
+				OnParseError: config.ActionBlock,
+			},
+		},
+		{
+			name: "input scanning disabled",
+			msg:  []byte(`{"jsonrpc":"2.0","id":6,"method":42}`),
+		},
+		{
+			name: "boolean method",
+			msg:  []byte(`{"jsonrpc":"2.0","id":7,"method":true}`),
+			inputCfg: &InputScanConfig{
+				Enabled:      true,
+				Action:       config.ActionWarn,
+				OnParseError: config.ActionBlock,
+			},
+		},
+		{
+			name: "array method",
+			msg:  []byte(`{"jsonrpc":"2.0","id":8,"method":["tools/call"]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision := scanHTTPInputDecision(tt.msg, io.Discard, "sess", "sess", MCPProxyOpts{
+				Scanner:  sc,
+				InputCfg: tt.inputCfg,
+			})
+			if decision.Blocked == nil {
+				t.Fatal("expected invalid method type to block")
+			}
+			if decision.Blocked.LogMessage != "blocked (parse error)" {
+				t.Fatalf("LogMessage = %q, want %q", decision.Blocked.LogMessage, "blocked (parse error)")
+			}
+			frame := ParseMCPFrame(tt.msg)
+			if string(decision.Blocked.ID) != string(frame.ID) {
+				t.Fatalf("blocked ID = %s, want %s", decision.Blocked.ID, frame.ID)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/proxy_ws.go
+++ b/internal/mcp/proxy_ws.go
@@ -126,6 +126,10 @@ func RunWSProxy(
 			break
 		}
 
+		// Parse the inbound frame once per message; every gate below reads
+		// ID / Method / tool fields from this frame instead of re-parsing.
+		frame := ParseMCPFrame(msg)
+
 		select {
 		case <-innerCtx.Done():
 			// Upstream closed or external cancellation.
@@ -151,8 +155,7 @@ func RunWSProxy(
 					_, _ = fmt.Fprintf(safeLogW, "pipelock: kill switch dropped notification (source=%s)\n", d.Source)
 					continue
 				}
-				rpcID := extractRPCID(msg)
-				resp := killswitch.ErrorResponse(rpcID, d.Message)
+				resp := killswitch.ErrorResponse(frame.ID, d.Message)
 				if wErr := safeClientOut.WriteMessage(resp); wErr != nil {
 					_, _ = fmt.Fprintf(safeLogW, "pipelock: stdout write error: %v\n", wErr)
 				}
@@ -182,7 +185,7 @@ func RunWSProxy(
 		// Only track requests (have "method"), not client responses to
 		// server-initiated calls, to prevent tracker pollution.
 		if isRequest(msg) {
-			tracker.Track(extractRPCID(msg))
+			tracker.Track(frame.ID)
 		}
 
 		// Forward to upstream.

--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -232,6 +232,11 @@ func taintApprovalReason(decision taintDecision) string {
 	return fmt.Sprintf("%s after %s", decision.ActionClass.String(), decision.Result.Reason)
 }
 
+// emitMCPToolReceipt emits the post-decision tool receipt for an MCP
+// tools/call message. The receipt payload bundles redaction context,
+// transport, and the full taint snapshot. Routed through
+// EmitMCPDecision so every tool receipt in the MCP inbound pipeline
+// goes through a single emission entry point.
 func emitMCPToolReceipt(
 	receiptEmitter *receipt.Emitter,
 	transport, redactionProfile string,
@@ -242,32 +247,38 @@ func emitMCPToolReceipt(
 	if actionID == "" || receiptEmitter == nil {
 		return
 	}
-	_ = receiptEmitter.Emit(receipt.EmitOpts{
-		ActionID:            actionID,
-		Verdict:             receiptVerdict,
-		RedactionProfile:    redactionProfile,
-		RedactionReport:     report,
-		Transport:           transport,
-		Target:              toolName,
-		MCPMethod:           mcpMethod,
-		ToolName:            toolName,
-		SessionTaintLevel:   decision.Risk.Level.String(),
-		SessionContaminated: decision.Risk.Contaminated,
-		RecentTaintSources:  decision.Risk.Sources,
-		SessionTaskID:       decision.Task.CurrentTaskID,
-		SessionTaskLabel:    decision.Task.CurrentTaskLabel,
-		AuthorityKind:       decision.Authority.String(),
-		TaintDecision:       decision.Result.Decision.String(),
-		TaintDecisionReason: decision.Result.Reason,
-		TaskOverrideApplied: decision.TaskOverrideApplied,
+	_, _ = EmitMCPDecision(receiptEmitter, nil, MCPDecision{
+		Receipt: receipt.EmitOpts{
+			ActionID:            actionID,
+			Verdict:             receiptVerdict,
+			RedactionProfile:    redactionProfile,
+			RedactionReport:     report,
+			Transport:           transport,
+			Target:              toolName,
+			MCPMethod:           mcpMethod,
+			ToolName:            toolName,
+			SessionTaintLevel:   decision.Risk.Level.String(),
+			SessionContaminated: decision.Risk.Contaminated,
+			RecentTaintSources:  decision.Risk.Sources,
+			SessionTaskID:       decision.Task.CurrentTaskID,
+			SessionTaskLabel:    decision.Task.CurrentTaskLabel,
+			AuthorityKind:       decision.Authority.String(),
+			TaintDecision:       decision.Result.Decision.String(),
+			TaintDecisionReason: decision.Result.Reason,
+			TaskOverrideApplied: decision.TaskOverrideApplied,
+		},
 	})
 }
 
+// decorateMCPToolMessage injects the mediation envelope for a clean or
+// warn-mode tools/call that is about to be forwarded upstream. Routed
+// through EmitMCPDecision so envelope injection shares the same
+// emission entry point as receipt emission.
 func decorateMCPToolMessage(msg []byte, emitter *envelope.Emitter, actionID, mcpMethod, toolName, receiptVerdict string, decision taintDecision) []byte {
 	if actionID == "" {
 		return msg
 	}
-	return injectMCPEnvelope(msg, emitter, envelope.BuildOpts{
+	buildOpts := envelope.BuildOpts{
 		ActionID:       actionID,
 		Action:         string(receipt.ClassifyMCPTool(toolName, mcpMethod)),
 		Verdict:        receiptVerdict,
@@ -275,5 +286,10 @@ func decorateMCPToolMessage(msg []byte, emitter *envelope.Emitter, actionID, mcp
 		TaskID:         decision.Task.CurrentTaskID,
 		AuthorityKind:  decision.Authority.String(),
 		RequiresReauth: decision.RequiresReauth,
+	}
+	out, _ := EmitMCPDecision(nil, emitter, MCPDecision{
+		Envelope:   &buildOpts,
+		InboundMsg: msg,
 	})
+	return out
 }

--- a/internal/mcp/taint_test.go
+++ b/internal/mcp/taint_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/emit"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/transport"
 	"github.com/luckyPipewrench/pipelock/internal/session"
@@ -304,6 +306,51 @@ func TestScanHTTPInputDecision_ApprovedToolCarriesEnvelope(t *testing.T) {
 	if meta["reauth"] != true {
 		t.Fatalf("reauth = %v, want true", meta["reauth"])
 	}
+}
+
+func TestScanHTTPInputDecision_ApprovedTaintAskEmitsAudit(t *testing.T) {
+	sc := testScannerWithAction(t, config.ActionWarn)
+	cfg := config.Defaults()
+	rec := &taintRecorder{}
+	rec.ObserveRisk(session.RiskObservation{
+		Source: session.TaintSourceRef{
+			URL:   "https://evil.example/issue/123",
+			Kind:  "http_response",
+			Level: session.TaintExternalUntrusted,
+		},
+	})
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"write_file","arguments":{"path":"/repo/auth/middleware.go","content":"x"}}}`)
+
+	sink := &recordingEmitSinkHTTP{}
+	logger := audit.NewNop()
+	emitter := emit.NewEmitter("test", sink)
+	logger.SetEmitter(emitter)
+	t.Cleanup(func() { _ = emitter.Close() })
+
+	decision := scanHTTPInputDecision(msg, &bytes.Buffer{}, "sess", "sess", MCPProxyOpts{
+		Scanner:     sc,
+		Approver:    testApproverForMCP(t, "y\n"),
+		Rec:         rec,
+		TaintCfg:    &cfg.Taint,
+		AuditLogger: logger,
+	})
+	if decision.Blocked != nil {
+		t.Fatalf("expected approved request to pass, got block: %+v", decision.Blocked)
+	}
+
+	for _, ev := range sink.events {
+		if ev.Type != string(audit.EventTaintDecision) {
+			continue
+		}
+		if ev.Fields["decision"] != session.PolicyAsk.String() {
+			t.Fatalf("decision = %v, want %q", ev.Fields["decision"], session.PolicyAsk.String())
+		}
+		if ev.Fields["authority_kind"] != session.AuthorityUserBroad.String() {
+			t.Fatalf("authority_kind = %v, want %q", ev.Fields["authority_kind"], session.AuthorityUserBroad.String())
+		}
+		return
+	}
+	t.Fatal("expected approved taint ask to emit taint_decision audit event")
 }
 
 func TestEvaluateMCPTaint_TrustOverrideHonorsScope(t *testing.T) {


### PR DESCRIPTION
## Summary

Migrates the inbound MCP pipeline to read ID / Method / ToolCallName / Args from a single ParseMCPFrame per message (replacing 34 scattered extractRPCID / extractToolCallName / extractToolCallArgs calls across input.go, proxy.go, proxy_http.go, proxy_ws.go) and routes every receipt + envelope emission through EmitMCPDecision so the inbound pipeline has one emission entry point.

## Scope

- ForwardScannedInput and scanHTTPInputDecision re-parse the frame after applyMCPToolCallRedactionWithConfig so DoW and taint see redacted args while ID / Method / ToolCallName stay stable.
- ParseMCPFrame hardened to a layered decode. First pass extracts ID alone, so the HTTP listener still returns the client id verbatim on invalid-request responses when the structural validator rejects a non-string method. Second pass extracts Method + raw params, so Method stays populated even when params are malformed (array, string, non-string tool name); ToolCallName and Args only populate on an object-shaped params. Matches legacy extraction behavior byte-for-byte.
- emitMCPToolReceipt and decorateMCPToolMessage now delegate to EmitMCPDecision. The stdio emitToolReceipt closure collapses to a single call to the shared helper.
- The 12 audit-log sites stay as-is (gate-specific signatures).
- scan.go and input_scan.go retain their extract calls intentionally; both are auxiliary scan contexts out of the inbound-pipeline migration scope.

## Rationale

Parity fixtures from #426 are the before/after oracle. Pre-refactor 7 parses per tools/call drop to 2 (frame computed once pre-redaction, once post-redaction). Receipt and envelope emissions previously scattered across six direct call sites now share one entry point, which makes the follow-up gate-evaluator extraction mechanical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to the MCP protocol message handling system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->