### PR TITLE
refactor(mcp): extract EvaluateMCPInputGatesStdio and migrate ForwardScannedInput

### DIFF
--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -461,6 +461,7 @@ func ForwardScannedInput(
 				ErrorCode:      -32600,
 				ErrorMessage:   "pipelock: " + eval.DoWReason,
 			}
+			emitToolReceipt(config.ActionBlock)
 			continue
 		case blockingGateFrozenTool:
 			frozenMsg := fmt.Sprintf("pipelock: input line %d: tools/call %q blocked by frozen tool inventory", lineNum, eval.FrozenToolName)
@@ -479,6 +480,7 @@ func ForwardScannedInput(
 				ErrorCode:      -32600,
 				ErrorMessage:   "pipelock: tool not in frozen inventory",
 			}
+			emitToolReceipt(config.ActionBlock)
 			continue
 		case blockingGateChain:
 			recordAdaptiveSignal(session.SignalBlock)
@@ -489,6 +491,7 @@ func ForwardScannedInput(
 				ErrorCode:      -32004,
 				ErrorMessage:   fmt.Sprintf("tool call blocked: chain pattern %q detected", eval.ChainPatternName),
 			}
+			emitToolReceipt(config.ActionBlock)
 			continue
 		case blockingGateParseError:
 			_, _ = fmt.Fprintf(logW, "pipelock: input line %d: %s\n", lineNum, verdict.Error)
@@ -497,6 +500,7 @@ func ForwardScannedInput(
 				IsNotification: isRPCNotification(verdict.ID),
 				LogMessage:     fmt.Sprintf("pipelock: input line %d: blocked (parse error)", lineNum),
 			}
+			emitToolReceipt(config.ActionBlock)
 			continue
 		case blockingGateTaintBlock, blockingGateTaintAskDenied:
 			logTaintDecision()

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -163,7 +163,6 @@ func ForwardScannedInput(
 	sc := opts.scanner()
 	policyCfg := opts.policyCfg()
 	ks := opts.KillSwitch
-	chainMatcher := opts.chainMatcher()
 	auditLogger := opts.AuditLogger
 	cee := opts.cee()
 	rec := opts.Rec
@@ -174,9 +173,6 @@ func ForwardScannedInput(
 	receiptEmitter := opts.receiptEmitter()
 	envelopeEmitter := opts.envelopeEmitter()
 	redirectRT := opts.redirectRT()
-	taintOpts := opts
-	taintOpts.TaintCfg = opts.taintCfg()
-	taintOpts.TaintCfgFn = nil
 
 	defer close(blockedCh)
 
@@ -314,86 +310,42 @@ func ForwardScannedInput(
 		warnCtx := scanner.DLPWarnContextFromCtx(opts.warnContext())
 		warnCtx.Transport = transportMCPStdio
 		stdioInputCtx := scanner.WithDLPWarnContext(opts.warnContext(), warnCtx)
-		verdict := ScanRequest(stdioInputCtx, line, sc, action, onParseError)
 
-		// Tool call policy check — independent of content scanning.
-		policyVerdict := policy.Verdict{}
-		if policyCfg != nil {
-			policyVerdict = policyCfg.CheckRequest(line)
-		}
+		// Evaluate every configured gate in one pass. The helper returns
+		// a composite verdict and the first gate that short-circuited,
+		// preserving per-gate block semantics and stdio's gate ordering
+		// (policy before DoW, two-phase binding around DoW, frozen tool
+		// between DoW and chain, taint last).
+		eval := EvaluateMCPInputGatesStdio(stdioInputCtx, frame, line, trimmedLine, bindingCfg, opts, action, onParseError)
+		verdict := eval.ContentVerdict
+		policyVerdict := eval.PolicyVerdict
+		taintDecision := eval.TaintDecision
+		bindingAction := eval.BindingAction
+		bindingReason := eval.BindingReason
+		chainAction := eval.ChainAction
+		chainReason := eval.ChainReason
 
-		// Session binding: validate tools/call against baseline.
-		bindingAction := ""
-		bindingReason := ""
-
-		// Defense-in-depth: session binding also rejects batches. The
-		// unconditional batch reject above makes this unreachable, but
-		// it stays as a safety net if the early check is ever removed.
-		if bindingCfg != nil && bindingCfg.Baseline != nil && len(trimmedLine) > 0 && trimmedLine[0] == '[' {
-			_, _ = fmt.Fprintf(logW, "pipelock: input line %d: batch request with session binding active\n", lineNum)
-			bindingAction = bindingCfg.UnknownToolAction
-			bindingReason = "session_binding:batch_request"
-		}
-
-		// Extract tool name once for binding, chain detection, and DoW tracking.
 		var toolCallName string
 		if verdict.Method == methodToolsCall {
 			toolCallName = frame.ToolCallName
 		}
 
-		// Denial-of-wallet: check tool call budget before forwarding.
-		if opts.DoWCheck != nil && verdict.Method == methodToolsCall && toolCallName != "" {
-			argsJSON := string(frame.Args)
-			allowed, dowAction, dowReason, dowBudgetType := opts.DoWCheck(toolCallName, argsJSON)
-			if !allowed {
-				logMsg := fmt.Sprintf("pipelock: input line %d: tools/call %q DoW %s: %s (%s)",
-					lineNum, toolCallName, dowAction, dowReason, dowBudgetType)
-				_, _ = fmt.Fprintln(logW, logMsg)
-				if dowAction == config.ActionBlock {
-					if auditLogger != nil {
-						auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", toolCallName), "denial_of_wallet", dowReason)
-					}
-					if m != nil {
-						m.RecordBlocked("mcp", "denial_of_wallet", 0, "")
-					}
-					recordAdaptiveSignal(session.SignalBlock)
-					blockedCh <- BlockedRequest{
-						ID:             verdict.ID,
-						IsNotification: isRPCNotification(verdict.ID),
-						LogMessage:     logMsg,
-						ErrorCode:      -32600,
-						ErrorMessage:   "pipelock: " + dowReason,
-					}
-					continue
-				}
-				// dow_action: warn — log and record near-miss, but forward the request.
-				if auditLogger != nil {
-					auditLogger.LogAnomaly(mustMCPAuditContext(auditLogger, "MCP", toolCallName), "denial_of_wallet", dowReason, 0)
-				}
-				recordAdaptiveSignal(session.SignalNearMiss)
-			}
-		}
-
-		if bindingCfg != nil && bindingCfg.Baseline != nil && verdict.Method == methodToolsCall {
-			if toolCallName == "" {
-				// Fail closed: tools/call without a name is a binding violation.
-				_, _ = fmt.Fprintf(logW, "pipelock: input line %d: tools/call missing params.name\n", lineNum)
-				bindingAction = bindingCfg.UnknownToolAction
-				bindingReason = "session_binding:missing_tool_name"
-			} else if !bindingCfg.Baseline.HasBaseline() {
-				_, _ = fmt.Fprintf(logW, "pipelock: input line %d: tools/call %q before baseline established\n",
-					lineNum, toolCallName)
-				bindingAction = bindingCfg.NoBaselineAction
-				bindingReason = "session_binding:no_baseline"
-			} else if !bindingCfg.Baseline.IsKnownTool(toolCallName) {
-				_, _ = fmt.Fprintf(logW, "pipelock: input line %d: tools/call %q not in session baseline\n",
-					lineNum, toolCallName)
-				bindingAction = bindingCfg.UnknownToolAction
-				bindingReason = "session_binding:unknown_tool"
-			}
-		}
-		// Capture: record session binding verdict when a violation occurred.
+		// Session binding side effects. Fire the diagnostic log and
+		// capture observe for every binding violation regardless of
+		// which gate short-circuits later, preserving the pre-refactor
+		// ordering where binding observes run before frozen/chain/
+		// parse-error/taint have had a chance to fire.
 		if bindingReason != "" {
+			switch bindingReason {
+			case bindingReasonBatchRequest:
+				_, _ = fmt.Fprintf(logW, "pipelock: input line %d: batch request with session binding active\n", lineNum)
+			case bindingReasonMissingToolName:
+				_, _ = fmt.Fprintf(logW, "pipelock: input line %d: tools/call missing params.name\n", lineNum)
+			case bindingReasonNoBaseline:
+				_, _ = fmt.Fprintf(logW, "pipelock: input line %d: tools/call %q before baseline established\n", lineNum, toolCallName)
+			case bindingReasonUnknownTool:
+				_, _ = fmt.Fprintf(logW, "pipelock: input line %d: tools/call %q not in session baseline\n", lineNum, toolCallName)
+			}
 			obs.ObserveToolPolicyVerdict(context.Background(), &capture.ToolPolicyRecord{
 				Subsurface: "session_binding",
 				Transport:  opts.Transport,
@@ -412,94 +364,33 @@ func ForwardScannedInput(
 			})
 		}
 
-		// Frozen tool enforcement: when a session is in airlock hard tier,
-		// only tools in the frozen snapshot are permitted. This prevents
-		// tool injection after quarantine begins.
-		if opts.ToolFreezer != nil && opts.FrozenToolStableKey != "" &&
-			opts.ToolFreezer.IsFrozen(opts.FrozenToolStableKey) {
-			// Fail-closed: block when tool name is empty (unparseable) or not in frozen set.
-			if toolCallName == "" || !opts.ToolFreezer.IsToolAllowed(opts.FrozenToolStableKey, toolCallName) {
-				frozenMsg := fmt.Sprintf("pipelock: input line %d: tools/call %q blocked by frozen tool inventory", lineNum, toolCallName)
-				_, _ = fmt.Fprintln(logW, frozenMsg)
-				if auditLogger != nil {
-					auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", toolCallName), "frozen_tool", "tool not in frozen inventory")
-				}
-				if m != nil {
-					m.RecordBlocked("mcp", "frozen_tool", 0, "")
-				}
-				recordAdaptiveSignal(session.SignalBlock)
-				blockedCh <- BlockedRequest{
-					ID:             verdict.ID,
-					IsNotification: isRPCNotification(verdict.ID),
-					LogMessage:     frozenMsg,
-					ErrorCode:      -32600,
-					ErrorMessage:   "pipelock: tool not in frozen inventory",
-				}
-				continue
+		// Chain side effects. Log, audit, and capture observe on every
+		// match, block and warn alike. The block-dispatch switch below
+		// handles the block-specific adaptive signal + BlockedRequest;
+		// warn matches fall through into the effective-action merge
+		// below with chainAction / chainReason populated.
+		if eval.ChainMatched {
+			_, _ = fmt.Fprintf(logW, "pipelock: chain detected: %s (severity=%s, action=%s)\n",
+				eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction)
+			if auditLogger != nil {
+				auditLogger.LogChainDetection(eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction, toolCallName, "default")
 			}
-		}
-
-		// Chain detection: check if this tool call matches an attack pattern.
-		// Runs on every tools/call regardless of content scan results.
-		chainAction := ""
-		chainReason := ""
-		// Stdio proxy has exactly one client session per process instance.
-		// "default" is the correct session key for this 1:1 architecture.
-		if chainMatcher != nil && toolCallName != "" {
-			cv := chainMatcher.Record("default", toolCallName, string(line))
-			if cv.Matched {
-				_, _ = fmt.Fprintf(logW, "pipelock: chain detected: %s (severity=%s, action=%s)\n",
-					cv.PatternName, cv.Severity, cv.Action)
-				if auditLogger != nil {
-					auditLogger.LogChainDetection(cv.PatternName, cv.Severity, cv.Action, toolCallName, "default")
-				}
-				// Capture: record chain detection verdict.
-				obs.ObserveToolPolicyVerdict(context.Background(), &capture.ToolPolicyRecord{
-					Subsurface: "chain_detection",
-					Transport:  opts.Transport,
-					Request: capture.CaptureRequest{
-						ToolName:  toolCallName,
-						MCPMethod: methodToolsCall,
-					},
-					RawFindings: []capture.Finding{{
-						Kind:     capture.KindChainDetection,
-						Chain:    cv.PatternName,
-						Severity: cv.Severity,
-						Action:   cv.Action,
-					}},
-					EffectiveAction: cv.Action,
-					Outcome:         captureOutcome(cv.Action, false),
-				})
-				if cv.Action == config.ActionBlock {
-					// Use verdict.ID from the already-parsed ScanRequest result
-					// rather than re-parsing via extractRPCID. A tools/call always
-					// has an ID; using the parsed value avoids a silent-drop bug
-					// if re-parsing fails on unusual ID shapes.
-					recordAdaptiveSignal(session.SignalBlock)
-					blockedCh <- BlockedRequest{
-						ID:             verdict.ID,
-						IsNotification: isRPCNotification(verdict.ID),
-						LogMessage:     fmt.Sprintf("pipelock: input line %d: chain pattern %q blocked", lineNum, cv.PatternName),
-						ErrorCode:      -32004,
-						ErrorMessage:   fmt.Sprintf("tool call blocked: chain pattern %q detected", cv.PatternName),
-					}
-					continue
-				}
-				// warn action: record reason for inclusion in combined verdict.
-				chainAction = cv.Action
-				chainReason = "chain:" + cv.PatternName
-			}
-		}
-
-		// Parse error — block by default (policy doesn't override parse errors).
-		if verdict.Error != "" {
-			_, _ = fmt.Fprintf(logW, "pipelock: input line %d: %s\n", lineNum, verdict.Error)
-			blockedCh <- BlockedRequest{
-				ID:             verdict.ID,
-				IsNotification: isRPCNotification(verdict.ID),
-				LogMessage:     fmt.Sprintf("pipelock: input line %d: blocked (parse error)", lineNum),
-			}
-			continue
+			obs.ObserveToolPolicyVerdict(context.Background(), &capture.ToolPolicyRecord{
+				Subsurface: "chain_detection",
+				Transport:  opts.Transport,
+				Request: capture.CaptureRequest{
+					ToolName:  toolCallName,
+					MCPMethod: methodToolsCall,
+				},
+				RawFindings: []capture.Finding{{
+					Kind:     capture.KindChainDetection,
+					Chain:    eval.ChainPatternName,
+					Severity: eval.ChainSeverity,
+					Action:   eval.ChainAction,
+				}},
+				EffectiveAction: eval.ChainAction,
+				Outcome:         captureOutcome(eval.ChainAction, false),
+			})
 		}
 
 		// Pre-generate actionID for tools/call only — metadata methods
@@ -513,59 +404,126 @@ func ForwardScannedInput(
 			}
 		}
 
-		taintDecision := taintDecision{
-			Authority: session.AuthorityUserBroad,
-			Result:    session.PolicyDecisionResult{Decision: session.PolicyAllow, Reason: taintReasonDisabled},
-		}
 		emitToolReceipt := func(receiptVerdict string) {
 			// Delegate to the shared helper so stdio and HTTP/WS emit
 			// tool receipts through the same EmitMCPDecision entry.
 			emitMCPToolReceipt(receiptEmitter, opts.Transport, redactionCfg.Profile, actionID, verdict.Method, toolCallName, receiptVerdict, taintDecision, redactionReport)
 		}
-		if verdict.Method == methodToolsCall {
-			taintDecision = evaluateMCPTaint(taintOpts, toolCallName, string(frame.Args))
-			if taintDecision.Result.Decision == session.PolicyAsk || taintDecision.Result.Decision == session.PolicyBlock {
-				if auditLogger != nil {
-					auditLogger.LogTaintDecision(
-						mustMCPAuditContext(auditLogger, "MCP", toolCallName),
-						taintDecision.Risk.Level.String(),
-						taintDecision.ActionClass.String(),
-						taintDecision.Sensitivity.String(),
-						taintDecision.Authority.String(),
-						taintDecision.Result.Decision.String(),
-						taintDecision.Result.Reason,
-						taintDecision.Risk.LastExternalURL,
-						taintDecision.Risk.LastExternalKind,
-					)
-				}
-				switch taintDecision.Result.Decision {
-				case session.PolicyBlock:
-					blockedCh <- BlockedRequest{
-						ID:             verdict.ID,
-						IsNotification: isRPCNotification(verdict.ID),
-						LogMessage:     fmt.Sprintf("pipelock: input line %d: blocked by taint policy", lineNum),
-						ErrorCode:      -32002,
-						ErrorMessage:   "pipelock: " + taintDecision.Result.Reason,
-					}
-					emitToolReceipt(config.ActionBlock)
-					continue
-				case session.PolicyAsk:
-					preview := strings.TrimSpace(fmt.Sprintf("%s %s", toolCallName, taintDecision.ActionRef))
-					approved, hasApprover := taintDecisionRequiresApproval(opts, toolCallName, taintApprovalReason(taintDecision), preview)
-					if !hasApprover || !approved {
-						blockedCh <- BlockedRequest{
-							ID:             verdict.ID,
-							IsNotification: isRPCNotification(verdict.ID),
-							LogMessage:     fmt.Sprintf("pipelock: input line %d: blocked by taint policy", lineNum),
-							ErrorCode:      -32002,
-							ErrorMessage:   "pipelock: " + taintDecision.Result.Reason,
-						}
-						emitToolReceipt(config.ActionBlock)
-						continue
-					}
-					approveTaintDecision(&taintDecision)
-				}
+
+		logTaintDecision := func() {
+			if auditLogger == nil {
+				return
 			}
+			decision := taintDecision
+			if eval.TaintAuditDecisionSet {
+				decision = eval.TaintAuditDecision
+			}
+			auditLogger.LogTaintDecision(
+				mustMCPAuditContext(auditLogger, "MCP", toolCallName),
+				decision.Risk.Level.String(),
+				decision.ActionClass.String(),
+				decision.Sensitivity.String(),
+				decision.Authority.String(),
+				decision.Result.Decision.String(),
+				decision.Result.Reason,
+				decision.Risk.LastExternalURL,
+				decision.Risk.LastExternalKind,
+			)
+		}
+
+		// DoW diagnostic log. Runs on any !allowed outcome (block or
+		// warn). Held in a local so the block-dispatch case below can
+		// reuse it verbatim as the BlockedRequest.LogMessage.
+		var dowLogMsg string
+		if !eval.DoWAllowed && eval.DoWAction != "" {
+			dowLogMsg = fmt.Sprintf("pipelock: input line %d: tools/call %q DoW %s: %s (%s)",
+				lineNum, toolCallName, eval.DoWAction, eval.DoWReason, eval.DoWBudgetType)
+			_, _ = fmt.Fprintln(logW, dowLogMsg)
+		}
+
+		// Block dispatch on the first gate that short-circuited. Per
+		// gate: audit + metrics + adaptive-signal + BlockedRequest.
+		// The response shape (JSON-RPC error code, LogMessage) stays
+		// here because it is transport-specific.
+		switch eval.BlockingGate {
+		case blockingGateDoW:
+			if auditLogger != nil {
+				auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", toolCallName), "denial_of_wallet", eval.DoWReason)
+			}
+			if m != nil {
+				m.RecordBlocked("mcp", "denial_of_wallet", 0, "")
+			}
+			recordAdaptiveSignal(session.SignalBlock)
+			blockedCh <- BlockedRequest{
+				ID:             verdict.ID,
+				IsNotification: isRPCNotification(verdict.ID),
+				LogMessage:     dowLogMsg,
+				ErrorCode:      -32600,
+				ErrorMessage:   "pipelock: " + eval.DoWReason,
+			}
+			continue
+		case blockingGateFrozenTool:
+			frozenMsg := fmt.Sprintf("pipelock: input line %d: tools/call %q blocked by frozen tool inventory", lineNum, eval.FrozenToolName)
+			_, _ = fmt.Fprintln(logW, frozenMsg)
+			if auditLogger != nil {
+				auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", eval.FrozenToolName), "frozen_tool", "tool not in frozen inventory")
+			}
+			if m != nil {
+				m.RecordBlocked("mcp", "frozen_tool", 0, "")
+			}
+			recordAdaptiveSignal(session.SignalBlock)
+			blockedCh <- BlockedRequest{
+				ID:             verdict.ID,
+				IsNotification: isRPCNotification(verdict.ID),
+				LogMessage:     frozenMsg,
+				ErrorCode:      -32600,
+				ErrorMessage:   "pipelock: tool not in frozen inventory",
+			}
+			continue
+		case blockingGateChain:
+			recordAdaptiveSignal(session.SignalBlock)
+			blockedCh <- BlockedRequest{
+				ID:             verdict.ID,
+				IsNotification: isRPCNotification(verdict.ID),
+				LogMessage:     fmt.Sprintf("pipelock: input line %d: chain pattern %q blocked", lineNum, eval.ChainPatternName),
+				ErrorCode:      -32004,
+				ErrorMessage:   fmt.Sprintf("tool call blocked: chain pattern %q detected", eval.ChainPatternName),
+			}
+			continue
+		case blockingGateParseError:
+			_, _ = fmt.Fprintf(logW, "pipelock: input line %d: %s\n", lineNum, verdict.Error)
+			blockedCh <- BlockedRequest{
+				ID:             verdict.ID,
+				IsNotification: isRPCNotification(verdict.ID),
+				LogMessage:     fmt.Sprintf("pipelock: input line %d: blocked (parse error)", lineNum),
+			}
+			continue
+		case blockingGateTaintBlock, blockingGateTaintAskDenied:
+			logTaintDecision()
+			blockedCh <- BlockedRequest{
+				ID:             verdict.ID,
+				IsNotification: isRPCNotification(verdict.ID),
+				LogMessage:     fmt.Sprintf("pipelock: input line %d: blocked by taint policy", lineNum),
+				ErrorCode:      -32002,
+				ErrorMessage:   "pipelock: " + taintDecision.Result.Reason,
+			}
+			emitToolReceipt(config.ActionBlock)
+			continue
+		}
+
+		// Non-blocking warn-level side effects from gates that did not
+		// short-circuit. DoW warn: audit anomaly + near-miss signal
+		// (the diagnostic log already ran above). Taint approved:
+		// audit the pre-approval decision so the operator sees the
+		// approval happened.
+		if !eval.DoWAllowed && eval.DoWAction != "" {
+			if auditLogger != nil {
+				auditLogger.LogAnomaly(mustMCPAuditContext(auditLogger, "MCP", toolCallName), "denial_of_wallet", eval.DoWReason, 0)
+			}
+			recordAdaptiveSignal(session.SignalNearMiss)
+		}
+		if eval.TaintApproved {
+			logTaintDecision()
 		}
 
 		// All clean — forward (with block_all and CEE checks).

--- a/internal/mcp/input_test.go
+++ b/internal/mcp/input_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/transport"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	"github.com/luckyPipewrench/pipelock/internal/session"
@@ -388,6 +389,63 @@ func TestForwardScannedInput_BlocksToolCallRedactionFailure(t *testing.T) {
 	}
 	if blocked.ErrorMessage != "pipelock: request blocked by MCP redaction" {
 		t.Fatalf("error message = %q", blocked.ErrorMessage)
+	}
+}
+
+// TestForwardScannedInput_FrozenToolBlockEmitsReceipt pins the audit
+// parity fix on the stdio block paths. Previously only the taint
+// branch called emitToolReceipt; DoW, FrozenTool, Chain, and
+// ParseError skipped it, leaving signed-receipt chain gaps on four
+// tools/call block verdicts. Exercising the FrozenTool path here is
+// representative: all four use the same emitToolReceipt closure.
+func TestForwardScannedInput_FrozenToolBlockEmitsReceipt(t *testing.T) {
+	sc := testInputScanner(t)
+	msg := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"exec_command","arguments":{"cmd":"ls"}}}`
+
+	emitter, rec, dir, pubHex := newReceiptTestHarness(t)
+
+	var serverBuf, logBuf bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 1)
+	opts := MCPProxyOpts{
+		Scanner:             sc,
+		Transport:           "mcp_stdio",
+		ReceiptEmitter:      emitter,
+		ToolFreezer:         &stubToolFreezer{frozen: true, allowed: map[string]bool{"read_file": true}},
+		FrozenToolStableKey: testFrozenSessionKey,
+	}
+
+	ForwardScannedInput(
+		transport.NewStdioReader(strings.NewReader(msg)),
+		transport.NewStdioWriter(&serverBuf),
+		&logBuf,
+		config.ActionWarn,
+		config.ActionBlock,
+		blockedCh,
+		nil,
+		nil,
+		opts,
+	)
+
+	blocked, ok := <-blockedCh
+	if !ok {
+		t.Fatal("expected blocked request on frozen-tool path")
+	}
+	if !strings.Contains(blocked.LogMessage, "frozen tool inventory") {
+		t.Errorf("block log message = %q, want frozen-tool reason", blocked.LogMessage)
+	}
+
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	blockReceipts := receiptsByVerdict(readActionReceipts(t, dir), config.ActionBlock)
+	if len(blockReceipts) == 0 {
+		t.Fatal("expected block receipt for frozen-tool block; emitToolReceipt was skipped on this gate before the parity fix")
+	}
+	for _, r := range blockReceipts {
+		if err := receipt.VerifyWithKey(r, pubHex); err != nil {
+			t.Fatalf("VerifyWithKey: %v", err)
+		}
 	}
 }
 

--- a/internal/mcp/pipeline_gates.go
+++ b/internal/mcp/pipeline_gates.go
@@ -448,9 +448,14 @@ func EvaluateMCPInputGatesStdio(
 		}
 	}
 
-	// Gate 7: frozen tool. Fail-closed: block when the tool name
-	// is empty (unparseable) or not in the frozen set.
+	// Gate 7: frozen tool. Scoped to tools/call messages; methods like
+	// tools/list, initialize, and notifications/* carry no tool name and
+	// must flow through a frozen session so MCP protocol state
+	// (handshake, discovery, recovery) keeps working. Within tools/call
+	// the gate is fail-closed: block when the tool name is empty or not
+	// in the frozen set. Mirrors the method-scoping on gates 5 and 6.
 	if opts.ToolFreezer != nil && opts.FrozenToolStableKey != "" &&
+		eval.ContentVerdict.Method == methodToolsCall &&
 		opts.ToolFreezer.IsFrozen(opts.FrozenToolStableKey) {
 		if toolCallName == "" || !opts.ToolFreezer.IsToolAllowed(opts.FrozenToolStableKey, toolCallName) {
 			eval.FrozenToolName = toolCallName

--- a/internal/mcp/pipeline_gates.go
+++ b/internal/mcp/pipeline_gates.go
@@ -6,10 +6,34 @@ package mcp
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/policy"
 	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+// BlockingGate values identifying which inbound gate short-circuited.
+// Callers switch on these to build per-gate block dispatch responses.
+const (
+	blockingGateA2ABody        = "a2a_body"
+	blockingGateDoW            = "dow"
+	blockingGateFrozenTool     = "frozen_tool"
+	blockingGateChain          = "chain"
+	blockingGateParseError     = "parse_error"
+	blockingGateTaintBlock     = "taint_block"
+	blockingGateTaintAskDenied = "taint_ask_denied"
+)
+
+// BindingReason values populated by the stdio gate helper when a
+// session binding violation fires. Callers switch on these to emit
+// the right per-reason diagnostic log.
+const (
+	bindingReasonBatchRequest    = "session_binding:batch_request"
+	bindingReasonMissingToolName = "session_binding:missing_tool_name"
+	bindingReasonNoBaseline      = "session_binding:no_baseline"
+	bindingReasonUnknownTool     = "session_binding:unknown_tool"
 )
 
 // MCPInputEvaluation aggregates the outputs of the configured inbound
@@ -93,6 +117,24 @@ type MCPInputEvaluation struct {
 	// PolicyAsk decision, and an approver allowed the call. False
 	// in every other case including when the gate did not run.
 	TaintApproved bool
+
+	// BindingAction is the session-binding action ("block" or "warn")
+	// when a stdio binding violation was detected. Empty when binding
+	// did not fire. Stdio-only; the HTTP helper leaves this empty.
+	BindingAction string
+
+	// BindingReason names the stdio binding violation:
+	// "session_binding:batch_request" (batch with binding active),
+	// "session_binding:missing_tool_name" (tools/call without
+	// params.name), "session_binding:no_baseline" (tools/call before
+	// the first tools/list response established a baseline),
+	// "session_binding:unknown_tool" (tools/call for a tool not in
+	// the session baseline). Empty when binding did not fire.
+	BindingReason string
+
+	// FrozenToolName is the tool name that tripped the stdio frozen
+	// tool gate. Empty when the gate did not run or did not block.
+	FrozenToolName string
 }
 
 // EvaluateMCPInputGates runs the configured inbound gates for one
@@ -183,7 +225,7 @@ func EvaluateMCPInputGates(
 				}
 				eval.A2AEffectiveAction = action
 				if action == config.ActionBlock {
-					eval.BlockingGate = "a2a_body"
+					eval.BlockingGate = blockingGateA2ABody
 					return eval
 				}
 			}
@@ -198,7 +240,7 @@ func EvaluateMCPInputGates(
 		eval.DoWReason = reason
 		eval.DoWBudgetType = budgetType
 		if !allowed && action == config.ActionBlock {
-			eval.BlockingGate = "dow"
+			eval.BlockingGate = blockingGateDoW
 			return eval
 		}
 	}
@@ -220,7 +262,7 @@ func EvaluateMCPInputGates(
 			eval.ChainAction = cv.Action
 			eval.ChainReason = "chain:" + cv.PatternName
 			if cv.Action == config.ActionBlock {
-				eval.BlockingGate = "chain"
+				eval.BlockingGate = blockingGateChain
 				return eval
 			}
 		}
@@ -231,7 +273,7 @@ func EvaluateMCPInputGates(
 	// before the block verdict is emitted. Matches the pre-refactor
 	// ordering in scanHTTPInputDecision and ForwardScannedInput.
 	if eval.ContentVerdict.Error != "" {
-		eval.BlockingGate = "parse_error"
+		eval.BlockingGate = blockingGateParseError
 		return eval
 	}
 
@@ -247,7 +289,7 @@ func EvaluateMCPInputGates(
 		case session.PolicyBlock:
 			eval.TaintAuditDecision = eval.TaintDecision
 			eval.TaintAuditDecisionSet = true
-			eval.BlockingGate = "taint_block"
+			eval.BlockingGate = blockingGateTaintBlock
 			return eval
 		case session.PolicyAsk:
 			eval.TaintAuditDecision = eval.TaintDecision
@@ -255,7 +297,212 @@ func EvaluateMCPInputGates(
 			preview := frame.ToolCallName + " " + eval.TaintDecision.ActionRef
 			approved, hasApprover := taintDecisionRequiresApproval(opts, frame.ToolCallName, taintApprovalReason(eval.TaintDecision), preview)
 			if !hasApprover || !approved {
-				eval.BlockingGate = "taint_ask_denied"
+				eval.BlockingGate = blockingGateTaintAskDenied
+				return eval
+			}
+			approveTaintDecision(&eval.TaintDecision)
+			eval.TaintApproved = true
+		}
+	}
+
+	return eval
+}
+
+// EvaluateMCPInputGatesStdio is the stdio counterpart to
+// EvaluateMCPInputGates. The stdio path preserves gate ordering that
+// diverges from the HTTP helper in three ways, all intentional and
+// captured here so a single shared helper does not have to flip
+// behavior on a transport switch:
+//
+//  1. Policy runs before DoW. HTTP runs policy after DoW; stdio's
+//     pre-refactor order placed the policy check ahead of the
+//     tools/call-scoped gates, so the policy verdict is materialized
+//     before any tools/call-scoped gate can short-circuit.
+//  2. Session binding is two-phase, wrapping DoW. The batch
+//     pre-check fires before DoW; the tool-name check fires after.
+//     Batches are rejected earlier in the caller, so the pre-check
+//     is defense-in-depth -- the helper still populates it so the
+//     caller's capture-observe side effect runs identically.
+//  3. A frozen-tool gate sits between DoW and chain detection.
+//     HTTP has no frozen-tool gate; it lives only on the stdio
+//     transport to enforce airlock-hard-tier tool snapshots.
+//
+// Unlike HTTP, stdio does not have an A2A body gate; A2A methods
+// flow through a separate path. The helper omits the a2a_body
+// gate entirely.
+//
+// Gate execution order (semantic, not cosmetic):
+//
+//  1. Content scan via ScanRequest. Always runs. Establishes
+//     ContentVerdict.ID / Method used by later short-circuit paths.
+//  2. Policy check. Populates PolicyVerdict without short-circuit;
+//     the caller folds matched policy into the effective action.
+//  3. Session binding batch pre-check. Populates BindingAction /
+//     BindingReason when a batch request is seen with binding
+//     active. No short-circuit -- batches are rejected earlier in
+//     the caller path.
+//  4. Tool name extraction from the frame for the tools/call gates.
+//  5. Denial-of-wallet check for tools/call with a non-empty tool
+//     name. Blocks short-circuit; warns populate DoWAction.
+//  6. Session binding tool check for tools/call. Overrides the
+//     batch pre-check when it fires (missing tool name, no
+//     baseline, unknown tool). No short-circuit -- the caller
+//     folds BindingAction into the effective action merge.
+//  7. Frozen tool enforcement. Short-circuits on a block verdict
+//     when the session has a frozen snapshot and the tool is
+//     either unparseable or not in the snapshot.
+//  8. Chain detection for tools/call. Mutates chain-matcher
+//     session state; the 1:1 stdio architecture uses the literal
+//     "default" session key. Matched patterns populate chain
+//     fields; Block-action matches short-circuit.
+//  9. Parse-error short-circuit from ContentVerdict.Error. Runs
+//     after the stateful gates so audit signals are recorded
+//     before the block verdict is emitted.
+//  10. Taint evaluation for tools/call. Reads session state the
+//     earlier gates may have updated. PolicyAsk triggers the
+//     inline approver dialog; approved sets TaintApproved.
+//
+// The helper populates MCPInputEvaluation without writing to
+// logW, emitting audit logs, recording metrics, or firing
+// capture observes. Those side effects stay in the caller at
+// the block-dispatch site so the transport-specific response
+// shape (JSON-RPC error codes, LogMessage strings) stays in
+// the transport layer.
+//
+// trimmedLine is the caller's bytes.TrimSpace(msg) result,
+// threaded through so the helper does not re-trim. The caller
+// already computes it for the batch reject earlier in the loop.
+func EvaluateMCPInputGatesStdio(
+	ctx context.Context,
+	frame MCPFrame,
+	msg []byte,
+	trimmedLine []byte,
+	bindingCfg *SessionBindingConfig,
+	opts MCPProxyOpts,
+	scanAction, onParseError string,
+) MCPInputEvaluation {
+	eval := MCPInputEvaluation{}
+
+	sc := opts.scanner()
+	policyCfg := opts.policyCfg()
+	chainMatcher := opts.chainMatcher()
+
+	// Gate 1: content scan. Always runs on stdio (inputCfg is not
+	// consulted at this layer -- the caller gates enablement via
+	// the scanAction / onParseError it passes in).
+	eval.ContentVerdict = ScanRequest(ctx, msg, sc, scanAction, onParseError)
+	if errors.Is(frame.ParseErr, ErrInvalidMethodType) {
+		eval.ContentVerdict.ID = frame.ID
+		eval.ContentVerdict.Method = frame.Method
+		eval.ContentVerdict.Clean = false
+		eval.ContentVerdict.Error = frame.ParseErr.Error()
+	}
+
+	// Gate 2: policy. No short-circuit; policy participates in the
+	// effective-action merge alongside content scan and binding.
+	if policyCfg != nil {
+		eval.PolicyVerdict = policyCfg.CheckRequest(msg)
+	}
+
+	// Gate 3: session binding batch pre-check. Unreachable in
+	// practice because the caller rejects batches before calling
+	// the helper, but kept as a defense-in-depth signal so the
+	// capture observe fires when the early reject is ever removed.
+	if bindingCfg != nil && bindingCfg.Baseline != nil && len(trimmedLine) > 0 && trimmedLine[0] == '[' {
+		eval.BindingAction = bindingCfg.UnknownToolAction
+		eval.BindingReason = bindingReasonBatchRequest
+	}
+
+	// Gate 4: tool name extraction.
+	toolCallName := ""
+	if eval.ContentVerdict.Method == methodToolsCall {
+		toolCallName = frame.ToolCallName
+	}
+
+	// Gate 5: DoW. Only for tools/call with a tool name.
+	if opts.DoWCheck != nil && eval.ContentVerdict.Method == methodToolsCall && toolCallName != "" {
+		allowed, action, reason, budgetType := opts.DoWCheck(toolCallName, string(frame.Args))
+		eval.DoWAllowed = allowed
+		eval.DoWAction = action
+		eval.DoWReason = reason
+		eval.DoWBudgetType = budgetType
+		if !allowed && action == config.ActionBlock {
+			eval.BlockingGate = blockingGateDoW
+			return eval
+		}
+	}
+
+	// Gate 6: session binding tool check. Overrides the batch
+	// pre-check when it fires. No short-circuit.
+	if bindingCfg != nil && bindingCfg.Baseline != nil && eval.ContentVerdict.Method == methodToolsCall {
+		switch {
+		case toolCallName == "":
+			eval.BindingAction = bindingCfg.UnknownToolAction
+			eval.BindingReason = bindingReasonMissingToolName
+		case !bindingCfg.Baseline.HasBaseline():
+			eval.BindingAction = bindingCfg.NoBaselineAction
+			eval.BindingReason = bindingReasonNoBaseline
+		case !bindingCfg.Baseline.IsKnownTool(toolCallName):
+			eval.BindingAction = bindingCfg.UnknownToolAction
+			eval.BindingReason = bindingReasonUnknownTool
+		}
+	}
+
+	// Gate 7: frozen tool. Fail-closed: block when the tool name
+	// is empty (unparseable) or not in the frozen set.
+	if opts.ToolFreezer != nil && opts.FrozenToolStableKey != "" &&
+		opts.ToolFreezer.IsFrozen(opts.FrozenToolStableKey) {
+		if toolCallName == "" || !opts.ToolFreezer.IsToolAllowed(opts.FrozenToolStableKey, toolCallName) {
+			eval.FrozenToolName = toolCallName
+			eval.BlockingGate = blockingGateFrozenTool
+			return eval
+		}
+	}
+
+	// Gate 8: chain detection. Stdio is 1:1 session-per-process;
+	// the literal "default" session key is correct.
+	if chainMatcher != nil && toolCallName != "" {
+		cv := chainMatcher.Record("default", toolCallName, string(msg))
+		if cv.Matched {
+			eval.ChainMatched = true
+			eval.ChainPatternName = cv.PatternName
+			eval.ChainSeverity = cv.Severity
+			eval.ChainAction = cv.Action
+			eval.ChainReason = "chain:" + cv.PatternName
+			if cv.Action == config.ActionBlock {
+				eval.BlockingGate = blockingGateChain
+				return eval
+			}
+		}
+	}
+
+	// Gate 9: parse-error short-circuit.
+	if eval.ContentVerdict.Error != "" {
+		eval.BlockingGate = blockingGateParseError
+		return eval
+	}
+
+	// Gate 10: taint. Only for tools/call. PolicyAsk triggers the
+	// inline approver dialog so HITL runs in the request-processing
+	// goroutine, matching the pre-refactor call site.
+	if eval.ContentVerdict.Method == methodToolsCall {
+		taintOpts := opts
+		taintOpts.TaintCfg = opts.taintCfg()
+		taintOpts.TaintCfgFn = nil
+		eval.TaintDecision = evaluateMCPTaint(taintOpts, toolCallName, string(frame.Args))
+		switch eval.TaintDecision.Result.Decision {
+		case session.PolicyBlock:
+			eval.TaintAuditDecision = eval.TaintDecision
+			eval.TaintAuditDecisionSet = true
+			eval.BlockingGate = blockingGateTaintBlock
+			return eval
+		case session.PolicyAsk:
+			eval.TaintAuditDecision = eval.TaintDecision
+			eval.TaintAuditDecisionSet = true
+			preview := strings.TrimSpace(fmt.Sprintf("%s %s", toolCallName, eval.TaintDecision.ActionRef))
+			approved, hasApprover := taintDecisionRequiresApproval(opts, toolCallName, taintApprovalReason(eval.TaintDecision), preview)
+			if !hasApprover || !approved {
+				eval.BlockingGate = blockingGateTaintAskDenied
 				return eval
 			}
 			approveTaintDecision(&eval.TaintDecision)

--- a/internal/mcp/pipeline_gates.go
+++ b/internal/mcp/pipeline_gates.go
@@ -142,26 +142,25 @@ type MCPInputEvaluation struct {
 // nil-safe: the helper skips gates whose config is nil or whose
 // preconditions are not met (e.g., DoW is tools/call-only).
 //
-// Gate execution order (semantic, not cosmetic):
+// Gate execution order (semantic, not cosmetic). Sequence is fixed by
+// the code below; see per-gate comments for placement rationale:
 //
-//  1. Content scan via ScanRequest. Always runs. Establishes
+//   - content scan via ScanRequest. Always runs. Establishes
 //     ContentVerdict.ID / Method used by later short-circuit paths.
-//  2. A2A body scan when a2aCfg is enabled and the method matches
+//   - A2A body scan when a2aCfg is enabled and the method matches
 //     IsA2AMethod. A block verdict short-circuits the remaining
 //     tools/call-scoped gates.
-//  3. Denial-of-wallet check for tools/call with a non-empty tool
-//     name.
-//  4. Policy check against the full message bytes.
-//  5. Chain detection for tools/call. Mutates chain-matcher session
+//   - denial-of-wallet check for tools/call with a non-empty tool name.
+//   - policy check against the full message bytes.
+//   - chain detection for tools/call. Mutates chain-matcher session
 //     state; running after DoW preserves the contract that DoW-block
 //     messages do not leave a chain trace.
-//  6. Parse-error short-circuit from ContentVerdict.Error. Runs
-//     after the stateful gates above so every configured gate
-//     contributes its audit signals before the block verdict is
-//     emitted.
-//  7. Taint evaluation for tools/call. Reads session state the
-//     earlier gates may have updated. PolicyAsk triggers the inline
-//     approver dialog (HITL); approved sets TaintApproved.
+//   - parse-error short-circuit from ContentVerdict.Error. Runs after
+//     the stateful gates above so every configured gate contributes
+//     its audit signals before the block verdict is emitted.
+//   - taint evaluation for tools/call. Reads session state the earlier
+//     gates may have updated. PolicyAsk triggers the inline approver
+//     dialog (HITL); approved sets TaintApproved.
 //
 // Adaptive signal recording, audit logging, and receipt emission
 // stay in the caller because those side effects happen at the
@@ -187,7 +186,7 @@ func EvaluateMCPInputGates(
 	chainMatcher := opts.chainMatcher()
 	a2aCfg := opts.a2aCfg()
 
-	// Gate 1: content scan.
+	// content scan.
 	if scanEnabled {
 		eval.ContentVerdict = ScanRequest(ctx, msg, sc, scanAction, onParseError)
 	} else {
@@ -206,7 +205,7 @@ func EvaluateMCPInputGates(
 		eval.ContentVerdict.Error = frame.ParseErr.Error()
 	}
 
-	// Gate 2: A2A body scan. Runs before the tools/call-scoped
+	// A2A body scan. Runs before the tools/call-scoped
 	// gates so an A2A body block short-circuits them.
 	if a2aCfg != nil && a2aCfg.Enabled {
 		method := eval.ContentVerdict.Method
@@ -232,7 +231,7 @@ func EvaluateMCPInputGates(
 		}
 	}
 
-	// Gate 3: DoW. Only for tools/call with a tool name.
+	// DoW. Only for tools/call with a tool name.
 	if opts.DoWCheck != nil && frame.IsToolsCall() && frame.ToolCallName != "" {
 		allowed, action, reason, budgetType := opts.DoWCheck(frame.ToolCallName, string(frame.Args))
 		eval.DoWAllowed = allowed
@@ -245,12 +244,12 @@ func EvaluateMCPInputGates(
 		}
 	}
 
-	// Gate 4: policy.
+	// policy.
 	if policyCfg != nil {
 		eval.PolicyVerdict = policyCfg.CheckRequest(msg)
 	}
 
-	// Gate 5: chain. Mutates chain-matcher session state; ordering
+	// chain. Mutates chain-matcher session state; ordering
 	// after DoW preserves the pre-refactor contract that DoW-block
 	// messages do not leave a chain trace.
 	if chainMatcher != nil && frame.IsToolsCall() && frame.ToolCallName != "" {
@@ -268,7 +267,7 @@ func EvaluateMCPInputGates(
 		}
 	}
 
-	// Gate 6: parse-error short-circuit. Runs after the stateful
+	// parse-error short-circuit. Runs after the stateful
 	// gates so every configured gate contributes its audit signals
 	// before the block verdict is emitted. Matches the pre-refactor
 	// ordering in scanHTTPInputDecision and ForwardScannedInput.
@@ -277,7 +276,7 @@ func EvaluateMCPInputGates(
 		return eval
 	}
 
-	// Gate 7: taint. Only for tools/call. PolicyAsk triggers the
+	// taint. Only for tools/call. PolicyAsk triggers the
 	// inline approver dialog so HITL runs in the request-processing
 	// goroutine, matching the pre-refactor call site.
 	if frame.IsToolsCall() {
@@ -310,57 +309,58 @@ func EvaluateMCPInputGates(
 
 // EvaluateMCPInputGatesStdio is the stdio counterpart to
 // EvaluateMCPInputGates. The stdio path preserves gate ordering that
-// diverges from the HTTP helper in three ways, all intentional and
-// captured here so a single shared helper does not have to flip
-// behavior on a transport switch:
+// diverges from the HTTP helper in three intentional ways, captured
+// here so a single shared helper does not have to flip behavior on a
+// transport switch:
 //
-//  1. Policy runs before DoW. HTTP runs policy after DoW; stdio's
+//   - policy runs before DoW. HTTP runs policy after DoW; stdio's
 //     pre-refactor order placed the policy check ahead of the
 //     tools/call-scoped gates, so the policy verdict is materialized
 //     before any tools/call-scoped gate can short-circuit.
-//  2. Session binding is two-phase, wrapping DoW. The batch
-//     pre-check fires before DoW; the tool-name check fires after.
-//     Batches are rejected earlier in the caller, so the pre-check
-//     is defense-in-depth -- the helper still populates it so the
+//   - session binding is two-phase, wrapping DoW. The batch pre-check
+//     fires before DoW; the tool-name check fires after. Batches are
+//     rejected earlier in the caller, so the pre-check is
+//     defense-in-depth -- the helper still populates it so the
 //     caller's capture-observe side effect runs identically.
-//  3. A frozen-tool gate sits between DoW and chain detection.
-//     HTTP has no frozen-tool gate; it lives only on the stdio
-//     transport to enforce airlock-hard-tier tool snapshots.
+//   - a frozen-tool gate sits between DoW and chain detection. HTTP
+//     has no frozen-tool gate; it lives only on the stdio transport
+//     to enforce airlock-hard-tier tool snapshots.
 //
-// Unlike HTTP, stdio does not have an A2A body gate; A2A methods
-// flow through a separate path. The helper omits the a2a_body
-// gate entirely.
+// Unlike HTTP, stdio does not have an A2A body gate; A2A methods flow
+// through a separate path. The helper omits the a2a_body gate
+// entirely.
 //
-// Gate execution order (semantic, not cosmetic):
+// Gate execution order (semantic, not cosmetic). Sequence is fixed
+// by the code below; see per-gate comments for placement rationale:
 //
-//  1. Content scan via ScanRequest. Always runs. Establishes
+//   - content scan via ScanRequest. Always runs. Establishes
 //     ContentVerdict.ID / Method used by later short-circuit paths.
-//  2. Policy check. Populates PolicyVerdict without short-circuit;
+//   - policy check. Populates PolicyVerdict without short-circuit;
 //     the caller folds matched policy into the effective action.
-//  3. Session binding batch pre-check. Populates BindingAction /
+//   - session binding batch pre-check. Populates BindingAction /
 //     BindingReason when a batch request is seen with binding
 //     active. No short-circuit -- batches are rejected earlier in
 //     the caller path.
-//  4. Tool name extraction from the frame for the tools/call gates.
-//  5. Denial-of-wallet check for tools/call with a non-empty tool
+//   - tool name extraction from the frame for the tools/call gates.
+//   - denial-of-wallet check for tools/call with a non-empty tool
 //     name. Blocks short-circuit; warns populate DoWAction.
-//  6. Session binding tool check for tools/call. Overrides the
-//     batch pre-check when it fires (missing tool name, no
-//     baseline, unknown tool). No short-circuit -- the caller
-//     folds BindingAction into the effective action merge.
-//  7. Frozen tool enforcement. Short-circuits on a block verdict
-//     when the session has a frozen snapshot and the tool is
-//     either unparseable or not in the snapshot.
-//  8. Chain detection for tools/call. Mutates chain-matcher
-//     session state; the 1:1 stdio architecture uses the literal
-//     "default" session key. Matched patterns populate chain
-//     fields; Block-action matches short-circuit.
-//  9. Parse-error short-circuit from ContentVerdict.Error. Runs
-//     after the stateful gates so audit signals are recorded
-//     before the block verdict is emitted.
-//  10. Taint evaluation for tools/call. Reads session state the
-//     earlier gates may have updated. PolicyAsk triggers the
-//     inline approver dialog; approved sets TaintApproved.
+//   - session binding tool check for tools/call. Overrides the
+//     batch pre-check when it fires (missing tool name, no baseline,
+//     unknown tool). No short-circuit -- the caller folds
+//     BindingAction into the effective action merge.
+//   - frozen tool enforcement. Short-circuits on a block verdict
+//     when the session has a frozen snapshot and the tool is either
+//     unparseable or not in the snapshot.
+//   - chain detection for tools/call. Mutates chain-matcher session
+//     state; the 1:1 stdio architecture uses the literal "default"
+//     session key. Matched patterns populate chain fields;
+//     Block-action matches short-circuit.
+//   - parse-error short-circuit from ContentVerdict.Error. Runs
+//     after the stateful gates so audit signals are recorded before
+//     the block verdict is emitted.
+//   - taint evaluation for tools/call. Reads session state the
+//     earlier gates may have updated. PolicyAsk triggers the inline
+//     approver dialog; approved sets TaintApproved.
 //
 // The helper populates MCPInputEvaluation without writing to
 // logW, emitting audit logs, recording metrics, or firing
@@ -387,7 +387,7 @@ func EvaluateMCPInputGatesStdio(
 	policyCfg := opts.policyCfg()
 	chainMatcher := opts.chainMatcher()
 
-	// Gate 1: content scan. Always runs on stdio (inputCfg is not
+	// content scan. Always runs on stdio (inputCfg is not
 	// consulted at this layer -- the caller gates enablement via
 	// the scanAction / onParseError it passes in).
 	eval.ContentVerdict = ScanRequest(ctx, msg, sc, scanAction, onParseError)
@@ -398,13 +398,13 @@ func EvaluateMCPInputGatesStdio(
 		eval.ContentVerdict.Error = frame.ParseErr.Error()
 	}
 
-	// Gate 2: policy. No short-circuit; policy participates in the
+	// policy. No short-circuit; policy participates in the
 	// effective-action merge alongside content scan and binding.
 	if policyCfg != nil {
 		eval.PolicyVerdict = policyCfg.CheckRequest(msg)
 	}
 
-	// Gate 3: session binding batch pre-check. Unreachable in
+	// session binding batch pre-check. Unreachable in
 	// practice because the caller rejects batches before calling
 	// the helper, but kept as a defense-in-depth signal so the
 	// capture observe fires when the early reject is ever removed.
@@ -413,13 +413,13 @@ func EvaluateMCPInputGatesStdio(
 		eval.BindingReason = bindingReasonBatchRequest
 	}
 
-	// Gate 4: tool name extraction.
+	// tool name extraction.
 	toolCallName := ""
 	if eval.ContentVerdict.Method == methodToolsCall {
 		toolCallName = frame.ToolCallName
 	}
 
-	// Gate 5: DoW. Only for tools/call with a tool name.
+	// DoW. Only for tools/call with a tool name.
 	if opts.DoWCheck != nil && eval.ContentVerdict.Method == methodToolsCall && toolCallName != "" {
 		allowed, action, reason, budgetType := opts.DoWCheck(toolCallName, string(frame.Args))
 		eval.DoWAllowed = allowed
@@ -432,7 +432,7 @@ func EvaluateMCPInputGatesStdio(
 		}
 	}
 
-	// Gate 6: session binding tool check. Overrides the batch
+	// session binding tool check. Overrides the batch
 	// pre-check when it fires. No short-circuit.
 	if bindingCfg != nil && bindingCfg.Baseline != nil && eval.ContentVerdict.Method == methodToolsCall {
 		switch {
@@ -448,7 +448,7 @@ func EvaluateMCPInputGatesStdio(
 		}
 	}
 
-	// Gate 7: frozen tool. Scoped to tools/call messages; methods like
+	// frozen tool. Scoped to tools/call messages; methods like
 	// tools/list, initialize, and notifications/* carry no tool name and
 	// must flow through a frozen session so MCP protocol state
 	// (handshake, discovery, recovery) keeps working. Within tools/call
@@ -464,7 +464,7 @@ func EvaluateMCPInputGatesStdio(
 		}
 	}
 
-	// Gate 8: chain detection. Stdio is 1:1 session-per-process;
+	// chain detection. Stdio is 1:1 session-per-process;
 	// the literal "default" session key is correct.
 	if chainMatcher != nil && toolCallName != "" {
 		cv := chainMatcher.Record("default", toolCallName, string(msg))
@@ -481,13 +481,13 @@ func EvaluateMCPInputGatesStdio(
 		}
 	}
 
-	// Gate 9: parse-error short-circuit.
+	// parse-error short-circuit.
 	if eval.ContentVerdict.Error != "" {
 		eval.BlockingGate = blockingGateParseError
 		return eval
 	}
 
-	// Gate 10: taint. Only for tools/call. PolicyAsk triggers the
+	// taint. Only for tools/call. PolicyAsk triggers the
 	// inline approver dialog so HITL runs in the request-processing
 	// goroutine, matching the pre-refactor call site.
 	if eval.ContentVerdict.Method == methodToolsCall {

--- a/internal/mcp/pipeline_gates_stdio_test.go
+++ b/internal/mcp/pipeline_gates_stdio_test.go
@@ -1,0 +1,322 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/tools"
+	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+// stubToolFreezer is a session.ToolFreezer test double. Allowed names
+// are treated as permitted; anything else fails the IsToolAllowed
+// check. When frozen is false IsFrozen returns false so the gate is
+// a no-op.
+type stubToolFreezer struct {
+	frozen  bool
+	allowed map[string]bool
+}
+
+func (s *stubToolFreezer) IsFrozen(_ string) bool { return s.frozen }
+func (s *stubToolFreezer) IsToolAllowed(_ string, tool string) bool {
+	return s.allowed[tool]
+}
+
+func TestEvaluateMCPInputGatesStdio_BatchBindingPreCheck(t *testing.T) {
+	// Even though the stdio caller rejects batches before calling the
+	// helper, the defense-in-depth gate populates BindingAction/Reason
+	// so the caller's capture-observe side effect survives if the
+	// early reject is ever removed.
+	t.Parallel()
+
+	sc := testInputScanner(t)
+	tb := tools.NewToolBaseline()
+	tb.SetKnownTools([]string{"read_file"})
+
+	bindingCfg := &SessionBindingConfig{
+		Baseline:          tb,
+		UnknownToolAction: config.ActionBlock,
+		NoBaselineAction:  config.ActionBlock,
+	}
+
+	batch := []byte(`[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]`)
+	frame := ParseMCPFrame(batch)
+
+	eval := EvaluateMCPInputGatesStdio(
+		context.Background(),
+		frame,
+		batch,
+		batch, // trimmedLine starts with '['
+		bindingCfg,
+		testOpts(sc),
+		config.ActionWarn,
+		config.ActionBlock,
+	)
+
+	if eval.BindingReason != bindingReasonBatchRequest {
+		t.Errorf("BindingReason = %q, want %s", eval.BindingReason, bindingReasonBatchRequest)
+	}
+	if eval.BindingAction != config.ActionBlock {
+		t.Errorf("BindingAction = %q, want block", eval.BindingAction)
+	}
+	if eval.BlockingGate != "" {
+		t.Errorf("BlockingGate = %q, want empty (pre-check never short-circuits)", eval.BlockingGate)
+	}
+}
+
+func TestEvaluateMCPInputGatesStdio_FrozenToolBlocksUnknownTool(t *testing.T) {
+	t.Parallel()
+
+	sc := testInputScanner(t)
+	opts := testOpts(sc)
+	opts.ToolFreezer = &stubToolFreezer{frozen: true, allowed: map[string]bool{"read_file": true}}
+	opts.FrozenToolStableKey = "test-session"
+
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"exec_command","arguments":{"cmd":"ls"}}}`)
+	frame := ParseMCPFrame(msg)
+
+	eval := EvaluateMCPInputGatesStdio(
+		context.Background(),
+		frame,
+		msg,
+		msg,
+		nil,
+		opts,
+		config.ActionWarn,
+		config.ActionBlock,
+	)
+
+	if eval.BlockingGate != blockingGateFrozenTool {
+		t.Errorf("BlockingGate = %q, want %s", eval.BlockingGate, blockingGateFrozenTool)
+	}
+	if eval.FrozenToolName != "exec_command" {
+		t.Errorf("FrozenToolName = %q, want exec_command", eval.FrozenToolName)
+	}
+}
+
+func TestEvaluateMCPInputGatesStdio_FrozenToolAllowsKnownTool(t *testing.T) {
+	t.Parallel()
+
+	sc := testInputScanner(t)
+	opts := testOpts(sc)
+	opts.ToolFreezer = &stubToolFreezer{frozen: true, allowed: map[string]bool{"read_file": true}}
+	opts.FrozenToolStableKey = "test-session"
+
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"/tmp/x"}}}`)
+	frame := ParseMCPFrame(msg)
+
+	eval := EvaluateMCPInputGatesStdio(
+		context.Background(),
+		frame,
+		msg,
+		msg,
+		nil,
+		opts,
+		config.ActionWarn,
+		config.ActionBlock,
+	)
+
+	if eval.BlockingGate != "" {
+		t.Errorf("BlockingGate = %q, want empty for allowed tool", eval.BlockingGate)
+	}
+}
+
+func TestEvaluateMCPInputGatesStdio_TaintBlock(t *testing.T) {
+	// Hostile external taint + sensitive write resolves to PolicyBlock
+	// directly (no approval dialog). Short-circuits on "taint_block".
+	t.Parallel()
+
+	sc := testScannerWithAction(t, config.ActionWarn)
+	cfg := config.Defaults()
+	rec := &taintRecorder{}
+	rec.ObserveRisk(session.RiskObservation{
+		Source: session.TaintSourceRef{
+			URL:   "https://evil.example/issue/123",
+			Kind:  "http_response",
+			Level: session.TaintExternalHostile,
+		},
+	})
+
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"write_file","arguments":{"path":"/repo/auth/middleware.go","content":"x"}}}`)
+	frame := ParseMCPFrame(msg)
+
+	eval := EvaluateMCPInputGatesStdio(
+		context.Background(),
+		frame,
+		msg,
+		msg,
+		nil,
+		MCPProxyOpts{
+			Scanner:  sc,
+			Rec:      rec,
+			TaintCfg: &cfg.Taint,
+		},
+		config.ActionWarn,
+		config.ActionBlock,
+	)
+
+	if eval.BlockingGate != blockingGateTaintBlock {
+		t.Errorf("BlockingGate = %q, want %s", eval.BlockingGate, blockingGateTaintBlock)
+	}
+	if !eval.TaintAuditDecisionSet {
+		t.Error("TaintAuditDecisionSet = false, want true (pre-approval snapshot)")
+	}
+}
+
+func TestEvaluateMCPInputGatesStdio_TaintAskDeniedWithoutApprover(t *testing.T) {
+	// Untrusted external taint + protected write resolves to PolicyAsk.
+	// Without an Approver configured, taintDecisionRequiresApproval
+	// returns false, so the helper short-circuits on taint_ask_denied.
+	t.Parallel()
+
+	sc := testScannerWithAction(t, config.ActionWarn)
+	cfg := config.Defaults()
+	rec := &taintRecorder{}
+	rec.ObserveRisk(session.RiskObservation{
+		Source: session.TaintSourceRef{
+			URL:   "https://evil.example/issue/123",
+			Kind:  "http_response",
+			Level: session.TaintExternalUntrusted,
+		},
+	})
+
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"write_file","arguments":{"path":"/repo/auth/middleware.go","content":"x"}}}`)
+	frame := ParseMCPFrame(msg)
+
+	eval := EvaluateMCPInputGatesStdio(
+		context.Background(),
+		frame,
+		msg,
+		msg,
+		nil,
+		MCPProxyOpts{
+			Scanner:  sc,
+			Rec:      rec,
+			TaintCfg: &cfg.Taint,
+		},
+		config.ActionWarn,
+		config.ActionBlock,
+	)
+
+	if eval.BlockingGate != blockingGateTaintAskDenied {
+		t.Errorf("BlockingGate = %q, want %s", eval.BlockingGate, blockingGateTaintAskDenied)
+	}
+}
+
+func TestEvaluateMCPInputGatesStdio_TaintAskApproved(t *testing.T) {
+	t.Parallel()
+
+	sc := testScannerWithAction(t, config.ActionWarn)
+	cfg := config.Defaults()
+	rec := &taintRecorder{}
+	rec.ObserveRisk(session.RiskObservation{
+		Source: session.TaintSourceRef{
+			URL:   "https://evil.example/issue/123",
+			Kind:  "http_response",
+			Level: session.TaintExternalUntrusted,
+		},
+	})
+
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"write_file","arguments":{"path":"/repo/auth/middleware.go","content":"x"}}}`)
+	frame := ParseMCPFrame(msg)
+
+	eval := EvaluateMCPInputGatesStdio(
+		context.Background(),
+		frame,
+		msg,
+		msg,
+		nil,
+		MCPProxyOpts{
+			Scanner:   sc,
+			Rec:       rec,
+			TaintCfg:  &cfg.Taint,
+			Approver:  testApproverForMCP(t, "y\n"),
+			Transport: "mcp_stdio",
+		},
+		config.ActionWarn,
+		config.ActionBlock,
+	)
+
+	if eval.BlockingGate != "" {
+		t.Errorf("BlockingGate = %q, want empty after approval", eval.BlockingGate)
+	}
+	if !eval.TaintApproved {
+		t.Error("TaintApproved = false, want true")
+	}
+	if !eval.TaintAuditDecisionSet {
+		t.Error("TaintAuditDecisionSet = false, want true (snapshot captured pre-approval)")
+	}
+}
+
+func TestEvaluateMCPInputGatesStdio_DoWWarnDoesNotShortCircuit(t *testing.T) {
+	// DoW with warn action populates DoWAction/DoWReason/DoWBudgetType
+	// but does NOT set BlockingGate, leaving the caller to log the
+	// diagnostic + anomaly + near-miss signal before forwarding.
+	t.Parallel()
+
+	sc := testInputScanner(t)
+	opts := testOpts(sc)
+	opts.DoWCheck = func(_ string, _ string) (bool, string, string, string) {
+		return false, config.ActionWarn, testDoWBudgetReason, "per_tool"
+	}
+
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"/tmp/x"}}}`)
+	frame := ParseMCPFrame(msg)
+
+	eval := EvaluateMCPInputGatesStdio(
+		context.Background(),
+		frame,
+		msg,
+		msg,
+		nil,
+		opts,
+		config.ActionWarn,
+		config.ActionBlock,
+	)
+
+	if eval.BlockingGate != "" {
+		t.Errorf("BlockingGate = %q, want empty (warn does not short-circuit)", eval.BlockingGate)
+	}
+	if eval.DoWAllowed {
+		t.Error("DoWAllowed = true, want false")
+	}
+	if eval.DoWAction != config.ActionWarn {
+		t.Errorf("DoWAction = %q, want warn", eval.DoWAction)
+	}
+	if eval.DoWReason != testDoWBudgetReason {
+		t.Errorf("DoWReason = %q, want %s", eval.DoWReason, testDoWBudgetReason)
+	}
+}
+
+func TestEvaluateMCPInputGatesStdio_ParseErrorShortCircuit(t *testing.T) {
+	// Force ContentVerdict.Error via invalid JSON. The frame will
+	// have ParseErr set and ScanRequest returns a parse-error verdict.
+	t.Parallel()
+
+	sc := testInputScanner(t)
+
+	msg := []byte(`not json at all`)
+	frame := ParseMCPFrame(msg)
+
+	eval := EvaluateMCPInputGatesStdio(
+		context.Background(),
+		frame,
+		msg,
+		msg,
+		nil,
+		testOpts(sc),
+		config.ActionWarn,
+		config.ActionBlock,
+	)
+
+	if eval.BlockingGate != blockingGateParseError {
+		t.Errorf("BlockingGate = %q, want %s", eval.BlockingGate, blockingGateParseError)
+	}
+	if eval.ContentVerdict.Error == "" {
+		t.Error("ContentVerdict.Error is empty, expected parse-error reason")
+	}
+}

--- a/internal/mcp/pipeline_gates_stdio_test.go
+++ b/internal/mcp/pipeline_gates_stdio_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/session"
 )
 
+const testFrozenSessionKey = "test-session"
+
 // stubToolFreezer is a session.ToolFreezer test double. Allowed names
 // are treated as permitted; anything else fails the IsToolAllowed
 // check. When frozen is false IsFrozen returns false so the gate is
@@ -74,7 +76,7 @@ func TestEvaluateMCPInputGatesStdio_FrozenToolBlocksUnknownTool(t *testing.T) {
 	sc := testInputScanner(t)
 	opts := testOpts(sc)
 	opts.ToolFreezer = &stubToolFreezer{frozen: true, allowed: map[string]bool{"read_file": true}}
-	opts.FrozenToolStableKey = "test-session"
+	opts.FrozenToolStableKey = testFrozenSessionKey
 
 	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"exec_command","arguments":{"cmd":"ls"}}}`)
 	frame := ParseMCPFrame(msg)
@@ -98,13 +100,62 @@ func TestEvaluateMCPInputGatesStdio_FrozenToolBlocksUnknownTool(t *testing.T) {
 	}
 }
 
+// TestEvaluateMCPInputGatesStdio_FrozenSessionAllowsNonToolCallMethods
+// pins the Gate 7 scoping fix: when a session is frozen, MCP protocol
+// messages that carry no tool name (tools/list, initialize,
+// notifications/*) must continue to flow. Without the method filter
+// they would hit the fail-closed branch (toolCallName == "") and
+// block, breaking handshake, discovery, and session recovery.
+func TestEvaluateMCPInputGatesStdio_FrozenSessionAllowsNonToolCallMethods(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		msg  []byte
+	}{
+		{"tools/list", []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)},
+		{"initialize", []byte(`{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`)},
+		{"notification", []byte(`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1}}`)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sc := testInputScanner(t)
+			opts := testOpts(sc)
+			// Freeze the session to only one tool. Non-tools/call
+			// methods carry no tool name; they must NOT be blocked.
+			opts.ToolFreezer = &stubToolFreezer{frozen: true, allowed: map[string]bool{"read_file": true}}
+			opts.FrozenToolStableKey = testFrozenSessionKey
+
+			frame := ParseMCPFrame(tc.msg)
+			eval := EvaluateMCPInputGatesStdio(
+				context.Background(),
+				frame,
+				tc.msg,
+				tc.msg,
+				nil,
+				opts,
+				config.ActionWarn,
+				config.ActionBlock,
+			)
+
+			if eval.BlockingGate == blockingGateFrozenTool {
+				t.Errorf("frozen session must not block non-tools/call method %q; "+
+					"Gate 7 should scope to methodToolsCall (breaks MCP handshake/discovery/recovery otherwise)", tc.name)
+			}
+		})
+	}
+}
+
 func TestEvaluateMCPInputGatesStdio_FrozenToolAllowsKnownTool(t *testing.T) {
 	t.Parallel()
 
 	sc := testInputScanner(t)
 	opts := testOpts(sc)
 	opts.ToolFreezer = &stubToolFreezer{frozen: true, allowed: map[string]bool{"read_file": true}}
-	opts.FrozenToolStableKey = "test-session"
+	opts.FrozenToolStableKey = testFrozenSessionKey
 
 	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"/tmp/x"}}}`)
 	frame := ParseMCPFrame(msg)

--- a/internal/mcp/proxy_http.go
+++ b/internal/mcp/proxy_http.go
@@ -383,7 +383,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	// transport-specific response shape (JSON-RPC error codes,
 	// LogMessage strings) stays in the transport layer.
 	switch eval.BlockingGate {
-	case "a2a_body":
+	case blockingGateA2ABody:
 		_, _ = fmt.Fprintf(logW, "pipelock: a2a input: blocked (%s)\n", eval.A2AResult.Reason)
 		if eval.A2AResult.IsConfigMismatch() {
 			recordAdaptiveSignal(session.SignalNearMiss)
@@ -399,7 +399,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			ErrorMessage:   "pipelock: request blocked by A2A input scanning",
 		}
 		return result
-	case "dow":
+	case blockingGateDoW:
 		_, _ = fmt.Fprintf(logW, "pipelock: tools/call %q DoW %s: %s (%s)\n",
 			toolName, eval.DoWAction, eval.DoWReason, eval.DoWBudgetType)
 		if auditLogger != nil {
@@ -412,7 +412,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		receiptVerdict = config.ActionBlock
 		result.Blocked = &BlockedRequest{ID: verdict.ID, IsNotification: isRPCNotification(verdict.ID), ErrorCode: -32600, ErrorMessage: "pipelock: " + eval.DoWReason}
 		return result
-	case "chain":
+	case blockingGateChain:
 		_, _ = fmt.Fprintf(logW, "pipelock: chain detected: %s (severity=%s, action=%s)\n",
 			eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction)
 		if auditLogger != nil {
@@ -428,7 +428,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			ErrorMessage:   fmt.Sprintf("tool call blocked: chain pattern %q detected", eval.ChainPatternName),
 		}
 		return result
-	case "parse_error":
+	case blockingGateParseError:
 		_, _ = fmt.Fprintf(logW, "pipelock: input: %s\n", verdict.Error)
 		receiptVerdict = config.ActionBlock
 		result.Blocked = &BlockedRequest{
@@ -437,7 +437,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			LogMessage:     "blocked (parse error)",
 		}
 		return result
-	case "taint_block", "taint_ask_denied":
+	case blockingGateTaintBlock, blockingGateTaintAskDenied:
 		logTaintDecision()
 		receiptVerdict = config.ActionBlock
 		result.Blocked = &BlockedRequest{


### PR DESCRIPTION
## Summary

Closes the MCP pipeline refactor arc by migrating `ForwardScannedInput` to a new `EvaluateMCPInputGatesStdio` helper that mirrors the HTTP gate evaluator from #428 but preserves stdio's divergent gate order (policy before DoW), two-phase session binding around DoW, frozen-tool gate, and stdio-only capture-observe side effects.

## Scope

- New `EvaluateMCPInputGatesStdio` in `internal/mcp/pipeline_gates.go` sharing `MCPInputEvaluation` with the HTTP helper.
- `MCPInputEvaluation` extended with `BindingAction`, `BindingReason`, `FrozenToolName`.
- `ForwardScannedInput` migrated to one helper call plus per-gate block dispatch. Capture-observe side effects (session binding, chain detection) stay in the caller.
- `BlockingGate` and `BindingReason` string literals consolidated into shared `blockingGate*` / `bindingReason*` constants.
- Zero behavior change; parity fixtures from #426 catch drift.

## Rationale

Stdio's gate order differs from HTTP (policy runs before DoW; session binding is two-phase around DoW; frozen tool between DoW and chain). A single evaluator would require either a transport switch or a reorder, both worse than two sibling helpers sharing the same output struct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved input validation and enforcement for content/policy checks, sensitive-call approval flows, restricted-tool blocking, chain detection, and DoW warnings—yielding more consistent blocking, diagnostics, and logging.
* **Tests**
  * Added end-to-end tests covering validation, frozen-tool handling, taint/approval outcomes, DoW warn behavior, and parse-error blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->