### PR TITLE
chore(release): v2.3.0 pre-tag polish (CHANGELOG, appVersion, docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,59 @@ All notable changes to Pipelock will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.3.0] - 2026-04-24
+
+### Highlights
+
+Two headline features. **Class-preserving redaction v1** lands as a first-party feature: irreversible, typed-placeholder request-side redaction wired into the fetch / forward / TLS-intercepted / reverse HTTP paths, outbound WebSocket client messages, and MCP `tools/call` `params.arguments` across every MCP transport. **Generic SSE streaming**: the existing A2A-gated streaming path is generalized so every `text/event-stream` response (OpenAI chat completions, Anthropic messages, Kilo Gateway, any LLM SSE) streams inline with per-event DLP and injection scanning, preserving token-by-token UX while keeping body scanning on. Plus a substantial tech-debt pass: runtime server lifecycle extraction, runtime policy resolution consolidation, canonical-hash golden-fixture test, `internal/config` mechanical split, and MCP transport pipeline stage extraction (helpers + HTTP + stdio migrations closing the MCP refactor arc). Remaining tech-debt items (metrics reshape, reverse-proxy scanner close-on-reload, `toolBaseline` drift rebuild, reverse-proxy receipt parity) are queued for v2.4 alongside learn-and-lock design.
 
 ### New Features
 
-#### Streaming response scanning
-- **Generic SSE (`text/event-stream`) inline scanning.** Pipelock now scans every Server-Sent Events response, not just A2A. OpenAI chat completions, Anthropic messages, Kilo Gateway streams, and any other LLM SSE traffic flow through the new `ScanGenericSSEStream` scanner: each event's `data:` payload is fed through DLP and prompt-injection detection, clean events flush to the client immediately, and block-mode detection terminates the stream with a block receipt and a `sse_stream` layer label. Warn mode logs findings and continues forwarding. Wired into the forward proxy, TLS-intercept proxy, and reverse proxy paths through a single shared dispatcher (`internal/proxy/sse.go`). Reverse proxy SSE responses are no longer capped by the buffered-body limit. New config block `response_scanning.sse_streaming` with `enabled` (default `true`), `action` (`block` / `warn`, default `block`), and `max_event_bytes` (default `65536`) knobs. Existing `response_scanning.exempt_domains` and global `suppress` rules apply before SSE action selection. When `enabled: false`, SSE responses still stream with per-read flushing instead of silently downgrading to a buffered path. Compressed SSE (gzip, br, zstd) is fail-closed-blocked on every transport, matching A2A behavior. The A2A scanner path is unchanged; the new dispatcher routes A2A traffic to it as before.
+- **Class-preserving redaction (v1).** New `internal/redact/` library. Matched values are replaced in place with typed placeholders such as `<pl:aws-access-key:1>`, one placeholder per `(class, occurrence)`, so downstream tools can reason about field shape without seeing the secret. Irreversible; no vault. Fail-closed on parse errors. Configured via the new `redaction` config section with per-profile class enablement, optional dictionaries, and limits (`max_body_bytes`, `max_redactions_per_request`, `max_depth`). (#413)
+- **Redaction wired into every request-side HTTP transport.** Fetch, forward, reverse, and TLS-intercepted CONNECT paths apply the redaction pipeline to outbound JSON request bodies when enabled. Outbound WebSocket client messages sent through `/ws` go through the same matcher. JSON rewrite uses `json.Decoder.UseNumber()` to preserve numeric fidelity, HTML escaping is disabled on the re-serialized JSON so LLM-bound bodies stay byte-readable, and both keys and values in `map[string]interface{}` are walked to prevent key-smuggling evasion. (#416)
+- **Redaction on MCP `tools/call` arguments.** `params.arguments` is redacted before forwarding on every MCP transport: stdio subprocess, Streamable HTTP upstream, the HTTP listener, and MCP-over-WebSocket. Tool responses are NOT redacted in this release (request-side only); transport parity across the four MCP surfaces is proven by regression tests. (#420)
+- **Generic SSE streaming with inline scanning.** `text/event-stream` responses no longer buffer. Forward proxy, TLS interception, and reverse proxy (previously buffered entirely with a 1 MB cap) all stream events through with per-event DLP and injection scanning. Clean events flush immediately; detection terminates the stream with a `sse_stream` layer label. Warn mode logs findings and continues forwarding. New `response_scanning.sse_streaming` config section: `enabled` (default `true`), `action` (`block` / `warn`, default `block`), `max_event_bytes` (default `65536`). Existing `response_scanning.exempt_domains` and global `suppress` rules apply before SSE action selection. When `enabled: false`, SSE responses still stream with per-read flushing. Compressed SSE streams are rejected fail-closed. Existing A2A-specific scanning is preserved untouched. (#429)
+- **Downstream receipt detection integration guide.** New docs section explaining how SIEMs, audit platforms, and CI workflows verify and chain pipelock action receipts. (#418)
 
 ### Documented limitations
+
 - Generic SSE scanning inspects each event's `data:` payload independently. Cross-event payload splitting (a secret broken across two sequential events) is NOT detected in v1; A2A's rolling-tail scanner still catches that case for A2A traffic. Tracked as a follow-up.
 - Non-`data:` SSE fields (`event:`, `id:`, `retry:`) are not scanned.
+
+### Internal Refactors (tech-debt sprint)
+
+These refactors do not change external behavior but materially improve code health, testability, and coverage ceilings. Shipped as a sprint to clear the TD board before v2.4 / learn-and-lock work opens.
+
+- **TD-1: Frozen config + `ResolveRuntime` clone path.** Runtime policy resolution consolidated into `Config.ResolveRuntime`, eliminating duplicate resolution paths across the CLI and MCP entry points. Loaded config is frozen; runtime policy views are produced by cloning and resolving per-request. (#422)
+- **TD-3: Non-blocking CI debt tracker.** New `hardening-report` job surfaces gocyclo / gocognit / maintidx / dupl metrics per PR without blocking merges, giving contributors visibility into regression trends. (#422)
+- **TD-5: Runtime server lifecycle extraction.** `pipelock run` no longer owns the lifecycle; it delegates to a new `Server` type with `NewServer`, `Start`, `Shutdown`, `Reload`, and `cleanup` methods. Unlocks `internal/cli/runtime/` coverage ceiling. Six spec tests landed. `RegisterKillSwitchSignal` decoupled from Cobra. A Codex polish pass closed two hot-reload gaps: scan API per-request config/scanner/policy resolution, and MCP listener function-pointer-driven per-message snapshotting. (#424)
+- **TD-2a: Canonical-hash golden fixtures (pre-req for TD-2b).** New `canonical_golden_test.go` pins the current `CanonicalPolicyHash` output against a fixed-input config so the mechanical split could not silently invalidate every receipt signed against the current schema. (#425)
+- **TD-2b: `internal/config` mechanical split.** The 5,170-LOC `internal/config/config.go` is split into `schema.go`, `defaults.go`, `normalize.go`, `validate.go`, `reloadwarn.go`, `load.go`, and `schema_receiver_methods.go`. Validators now return `[]Warning` instead of writing to stderr. Callers (CLI + verify_install diagnostics) print the returned warnings. No semantic change; the TD-2a canonical-hash golden fixtures prove byte-equivalent policy output. (#431)
+- **TD-4 groundwork: transport-parity fixtures + stage helpers.** Eight-test transport-parity harness covering stdio, HTTP, and WebSocket MCP transports locks down the per-transport behavior before extraction. New `MCPFrame` and `MCPDecision` helpers are factored out so pipeline stages (parse / policy / decision / relay) become independently testable. (#426, #427)
+- **TD-4 migration: MCP-inbound decision path uses stage helpers (HTTP + stdio).** 34 scattered `extractRPCID` / `extractToolCallName` / `extractToolCallArgs` calls replaced by one `ParseMCPFrame` per message. Six direct receipt/envelope emission sites collapse to one `EmitMCPDecision` helper. New `pipeline_gates.go` holds `EvaluateMCPInputGatesHTTP` and `EvaluateMCPInputGatesStdio` so the gate-evaluation order is identical across transports (policy/taint/redaction/session-binding ordering preserved per the parity fixtures). `ForwardScannedInput` migrated; the MCP refactor arc is closed. Forward / intercept / websocket pipeline migrations deferred to v2.4 per Codex guidance ("don't turn this into abstraction theater"). (#428, #432)
+
+### Fixed
+
+- **Dangerous Capability regex false-positive on runtime-family nouns.** Replaced `(execut|run|launch|spawn)\w*` with explicit verb-form enumeration so `runtime`, `runner`, `launcher`, and `spawner` nouns no longer trigger the tool-poisoning pattern. Seven regression cases added. (#423)
+- **Browser Shield binary media short-circuit.** The `shield.DetectPipeline` classifier now runs before the `max_shield_bytes` ceiling, so image / audio / video / PDF / arbitrary binary responses short-circuit out of shield processing. Fail-closed preserved for HTML / JS / SVG. (#421)
+- **Sentry noise reduction.** `context.Canceled` errors no longer reach `CaptureError`, dropping a class of benign Sentry reports generated during normal shutdown and timeout paths. (#412)
+- **DLP coverage downgrade warning on reload.** `removedOrWeakenedDLPPatterns()` now diffs by `(name, regex)` identity instead of count alone. A reload that replaces a strong regex with a weaker one under the same pattern name was previously silent (count stayed constant). It now surfaces as a reload warning, preserving the "hot reload must preserve security state" invariant. (#433)
+- **SSRF DNS failures stay adaptive-neutral.** DNS resolver failures during SSRF checks were classified like threat blocks, so repeated lookup errors could accumulate adaptive `SignalBlock` points and push sessions into airlock. New `ClassInfrastructureError` + `IsAdaptiveNeutral()` helper unifies protective enforcement and infrastructure errors. Fail-closed semantics preserved: requests still block when DNS cannot be verified, but resolver failures no longer count as threat evidence. Honored on the scanner, adaptive enforcement, TLS intercept, forward, WebSocket, and MCP HTTP A2A paths. Also folds in a CodeRabbit follow-up from #429: `TestScanGenericSSEStream_LargeMaxEventBytes` covers `max_event_bytes` values above `bufio.Scanner`'s 64 KB default in both block and warn modes. (#434)
+
+### Security Hardening
+
+- Redaction library runs fail-closed on parse errors. A malformed JSON body is blocked rather than forwarded.
+- Generic SSE streaming rejects compressed streams fail-closed. Body scanning cannot be bypassed by requesting `Content-Encoding: gzip` on an SSE response.
+- Redaction walks map keys as well as values, so secrets stuffed into JSON keys are caught.
+- Reload-time DLP coverage downgrades (same-length pattern replacements) now surface as warnings instead of being silently accepted.
+
+### Other
+
+- Detection integration guide at `docs/detection-integration/`. (#418)
+- Tool-response-injection demo points at the published `pipelock-verify` PyPI package instead of a vendored copy. (#411)
+- CI composite-action download retry budget hardened. (#410)
+- Dependabot bumps for the `ci-actions` group (3 updates) and `go-deps` group (3 updates). (#414, #415)
+- Helm chart `appVersion` bumped to `2.3.0`.
 
 ## [2.2.0] - 2026-04-17
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ runtime-policy-audit:
 	./scripts/runtime-policy-audit.sh
 
 debt-check:
-	golangci-lint run --disable-all --enable dupl --enable gocyclo --enable gocognit --enable maintidx ./...
+	golangci-lint run --enable-only dupl,gocyclo,gocognit,maintidx ./...
 
 release-check: test lint test-runtime-critical release-audit runtime-policy-audit
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ pipelock mcp proxy --sandbox --config pipelock.yaml -- npx server
 
 Fetched content is scanned for prompt injection and state/control poisoning before reaching the agent. A 6-pass normalization pipeline catches zero-width character evasion, homoglyph substitution, leetspeak encoding, and base64-wrapped payloads. 25 built-in patterns cover jailbreak phrases, instruction manipulation, credential solicitation, memory persistence, preference poisoning, covert action directives, model instruction boundaries, and CJK-language instruction overrides. Actions: `block`, `strip`, `warn`, or `ask` (human-in-the-loop terminal approval).
 
+`text/event-stream` responses (OpenAI chat completions, Anthropic messages, Kilo Gateway, MCP HTTP/SSE) stream through with per-event DLP and injection scanning so token-by-token LLM chat UX is preserved while body scanning stays on. Clean events flush immediately; a detection terminates the stream fail-closed. Compressed SSE streams are rejected since compressed bytes evade regex matching. See [SSE streaming guide](docs/guides/sse-streaming.md).
+
 ### Request Redaction
 
 Optional request-side redaction rewrites matched JSON values before they leave the agent. The same matcher covers HTTP request bodies, outbound WebSocket client messages, and MCP `tools/call` `params.arguments` across stdio, HTTP/SSE, and WebSocket transports. Replacements are typed placeholders such as `<pl:aws-access-key:1>`, and signed action receipts record only the active profile plus per-class counts.

--- a/charts/pipelock/Chart.yaml
+++ b/charts/pipelock/Chart.yaml
@@ -3,7 +3,7 @@ name: pipelock
 description: Agent firewall for AI agents. Network scanning, process containment, and tool policy enforcement.
 type: application
 version: 0.1.0
-appVersion: "2.2.0"
+appVersion: "2.3.0"
 home: https://pipelab.org
 sources:
   - https://github.com/luckyPipewrench/pipelock

--- a/docs/compliance/eu-ai-act-mapping.md
+++ b/docs/compliance/eu-ai-act-mapping.md
@@ -6,7 +6,7 @@ How Pipelock's runtime security controls map to the [EU AI Act (Regulation 2024/
 
 **Disclaimer:** This document maps Pipelock's security features to EU AI Act requirements for informational purposes. It does not constitute legal advice or guarantee regulatory compliance. Organizations should consult qualified legal counsel for compliance obligations specific to their AI systems.
 
-**Last updated:** April 2026 (reviewed against v2.2.0 feature set: mediation envelope, signed action receipts across all transports, taint-aware policy escalation, posture verify CLI, companion-proxy deployment, session operator CLI)
+**Last updated:** April 2026 (reviewed against v2.3.0 feature set; v2.3.0 adds class-preserving request redaction across HTTP/WebSocket/MCP transports contributing to Art. 10 Data Governance and generic SSE streaming with per-event body scanning contributing to Art. 15 Robustness on top of the v2.2.0 baseline: mediation envelope, signed action receipts across all transports, taint-aware policy escalation, posture verify CLI, companion-proxy deployment, session operator CLI)
 
 ---
 

--- a/docs/compliance/nist-800-53.md
+++ b/docs/compliance/nist-800-53.md
@@ -6,7 +6,7 @@ See also: [NIST AI RMF crosswalk](eu-ai-act-mapping.md#nist-ai-rmf-10-crosswalk)
 
 > **Scope:** Pipelock is an application-layer agent firewall with process containment. It covers network egress filtering, content inspection, audit logging, process isolation, and human oversight for AI agent deployments. It does not cover identity management, physical security, personnel security, or full-lifecycle system authorization. This mapping is for informational purposes and does not constitute compliance certification.
 
-**Last updated:** April 2026 (reviewed against v2.2.0 feature set: expanded signed action receipt coverage across all transports for AU-2/AU-10, mediation envelope for AU-3(1), taint-aware policy escalation for SI-10, posture verify CLI + CI gate for CA-2/CA-7, companion-proxy deployment for SC-7)
+**Last updated:** April 2026 (reviewed against v2.3.0 feature set; v2.3.0 adds class-preserving request redaction for SI-12 Information Handling and SC-28 Protection of Information at Rest, and generic SSE streaming with per-event body scanning extending SI-10 Information Input Validation coverage on top of the v2.2.0 baseline: expanded signed action receipt coverage across all transports for AU-2/AU-10, mediation envelope for AU-3(1), taint-aware policy escalation for SI-10, posture verify CLI + CI gate for CA-2/CA-7, companion-proxy deployment for SC-7)
 
 ---
 

--- a/docs/compliance/owasp-mcp-top10.md
+++ b/docs/compliance/owasp-mcp-top10.md
@@ -6,7 +6,7 @@ See also: [OWASP Agentic Top 10 mapping](../owasp-mapping.md) | [OWASP AIVSS cov
 
 > **Note:** Coverage levels reflect architectural capabilities against known attack patterns, not guarantees of threat prevention. Pipelock is a network-layer proxy; some MCP risks require complementary controls at the client, server, or identity layer. This mapping is for informational purposes and does not constitute compliance certification.
 
-**Last updated:** April 2026 (reviewed against v2.2.0 feature set: mediation envelope, signed action receipts across all MCP transports including stdio / HTTP / HTTP reverse proxy, taint-aware policy escalation with task boundaries, media policy and SVG active-content hardening, posture verify CLI, companion-proxy deployment via `pipelock init sidecar`)
+**Last updated:** April 2026 (reviewed against v2.3.0 feature set; v2.3.0 adds class-preserving redaction on MCP `tools/call` `params.arguments` across stdio / HTTP / HTTP reverse proxy / WebSocket transports strengthening MCP01 Token Mismanagement & Secret Exposure coverage, and generic SSE streaming with per-event body scanning on MCP HTTP/SSE responses strengthening MCP03 Tool Poisoning coverage on top of the v2.2.0 baseline: mediation envelope, signed action receipts across all MCP transports, taint-aware policy escalation with task boundaries, media policy and SVG active-content hardening, posture verify CLI, companion-proxy deployment via `pipelock init sidecar`)
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -625,6 +625,8 @@ response_scanning:
 - Cross-event payload splitting (a secret broken across two sequential events) is NOT detected. A2A traffic still gets cross-event scanning via the A2A scanner's rolling tail; generic SSE does not in v1.
 - Non-`data:` SSE fields (`event:`, `id:`, `retry:`) are not scanned. They are forwarded to the client per the SSE spec.
 
+See [`docs/guides/sse-streaming.md`](guides/sse-streaming.md) for the full guide with transport coverage, fail-closed behavior, and adversarial test matrix.
+
 ## MCP Input Scanning
 
 Scans JSON-RPC requests from agent to MCP server for DLP leaks and injection in tool arguments.

--- a/docs/guides/sse-streaming.md
+++ b/docs/guides/sse-streaming.md
@@ -62,7 +62,7 @@ response_scanning:
 |-------|---------|-------------|
 | `enabled` | `true` | Enable generic SSE streaming scan. When disabled, `text/event-stream` responses stream through with flushing but are not body-scanned (CONNECT-level visibility preserved). |
 | `action` | `block` | `block` terminates the stream on a finding and emits a block receipt. `warn` logs the anomaly and forwards the event. |
-| `max_event_bytes` | `65536` | Per-event byte ceiling. Exceeding this is treated as a finding. LLM tokens are small; 64 KiB is well above any legitimate single event. |
+| `max_event_bytes` | `65536` | Per-event byte ceiling. Exceeding this is treated as a finding. LLM token events are typically small; 64 KiB is a conservative default for most streaming providers. Raise it if a provider emits larger single events (batched deltas, full response chunks). |
 
 ## Transport coverage
 

--- a/docs/guides/sse-streaming.md
+++ b/docs/guides/sse-streaming.md
@@ -1,0 +1,98 @@
+# SSE Streaming and Inline Response Scanning
+
+Pipelock streams Server-Sent Event (SSE) responses inline while scanning
+each event for DLP patterns, prompt injection, and other response-layer
+threats. Clean events flush immediately so token-by-token LLM chat UX is
+preserved; a detection terminates the stream fail-closed.
+
+Before v2.3.0, only A2A streams received inline scanning. Generic
+`text/event-stream` responses (OpenAI chat completions, Anthropic
+messages, Kilo Gateway, any MCP HTTP/SSE server) were buffered before
+scanning, which broke streaming UX and capped response size at 1 MB in
+the reverse proxy. v2.3.0 generalizes the streaming scan path to every
+`text/event-stream` response across the forward proxy, TLS interception,
+and reverse proxy.
+
+## What gets scanned
+
+Each SSE event is parsed per the WHATWG Server-Sent Events spec. Scanning
+runs on the concatenated `data:` payload of each event:
+
+- DLP patterns (same set used for non-streaming response scanning)
+- Prompt injection detectors (jailbreak phrases, instruction override,
+  credential solicitation, memory persistence, covert action directives,
+  CJK instruction overrides)
+- Response-address protection and CEE taint propagation when enabled
+
+Event fields other than `data:` (such as `event:`, `id:`, `retry:`) pass
+through unscanned per SSE spec semantics, since those fields are
+metadata and not model output. Unknown fields and lines without a `:`
+delimiter are ignored by the parser rather than terminating the stream,
+matching the WHATWG SSE spec's forgiving parse rules.
+
+Comment lines (`:` prefix) and keepalives are **dropped** before the
+event is forwarded to the client. They are protocol metadata, so the
+scanner neither inspects them nor re-emits them. This is consistent
+with the WHATWG spec and intentional so an upstream cannot smuggle
+bytes through comments.
+
+## What is rejected fail-closed
+
+- Compressed SSE streams. Any `Content-Encoding` other than `identity`
+  is blocked with a receipt before any bytes are forwarded. This
+  prevents scanner bypass by requesting gzip/br/deflate SSE.
+- Events exceeding the configured per-event byte ceiling are treated as
+  a finding and terminate the stream.
+- Invalid UTF-8 in an event's `data:` payload terminates the stream
+  (cannot be safely scanned as text).
+
+## Configuration
+
+SSE streaming scanning lives under `response_scanning.sse_streaming`:
+
+```yaml
+response_scanning:
+  sse_streaming:
+    enabled: true            # default true
+    action: block            # block | warn, default block
+    max_event_bytes: 65536   # 64 KiB per event, default 65536
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `true` | Enable generic SSE streaming scan. When disabled, `text/event-stream` responses stream through with flushing but are not body-scanned (CONNECT-level visibility preserved). |
+| `action` | `block` | `block` terminates the stream on a finding and emits a block receipt. `warn` logs the anomaly and forwards the event. |
+| `max_event_bytes` | `65536` | Per-event byte ceiling. Exceeding this is treated as a finding. LLM tokens are small; 64 KiB is well above any legitimate single event. |
+
+## Transport coverage
+
+| Transport | Before v2.3.0 | From v2.3.0 |
+|-----------|---------------|-------------|
+| Forward proxy + TLS interception | A2A-only streaming; generic SSE buffered | All `text/event-stream` streamed and scanned |
+| TLS-intercepted CONNECT | A2A-only streaming; generic SSE buffered | All `text/event-stream` streamed and scanned |
+| Reverse proxy | No streaming path; all responses buffered at 1 MB | All `text/event-stream` streamed and scanned; non-SSE responses continue to use the buffered path |
+| A2A | Already streamed with field-aware walker + cross-event rolling-tail detection | Unchanged |
+
+## Known limitations
+
+- **Cross-event injection detection applies only to A2A.** Generic SSE
+  streaming scans each event in isolation. An attacker who splits a
+  single injection payload across sequential SSE events can evade the
+  current detector. A2A's rolling-tail detector covers this case for
+  the A2A protocol. Generalizing cross-event detection to any SSE
+  stream is tracked as a follow-up.
+- **Per-account proxy overrides in clients can bypass pipelock.** If an
+  upstream client sets its own proxy (not through `HTTPS_PROXY`), it
+  may route around pipelock entirely. Configure clients to honor the
+  system proxy env vars.
+- **Event fields other than `data:` are not scanned.** Per SSE spec,
+  `event:`, `id:`, and `retry:` fields are protocol metadata. If a
+  malicious upstream stuffs content into `id:` it will not be scanned.
+  The same is true of comment lines.
+
+## See also
+
+- [Response scanning configuration](../configuration.md#response-scanning)
+- [Mediation envelope](./mediation-envelope.md) (signed proof of each
+  scanning decision, including SSE stream terminations)
+- [Receipt transports](./receipt-transports.md)


### PR DESCRIPTION
## Summary

Pre-tag polish for v2.3.0 release. Authors the CHANGELOG section. Bumps Helm chart `appVersion`. Adds SSE streaming guide. Refreshes README and compliance docs. Migrates `debt-check` Makefile target to golangci-lint v2 syntax.

## CHANGELOG

New `[2.3.0] - 2026-04-24` section covering redaction v1 (#413, #416, #420), generic SSE streaming (#429), detection-integration guide (#418), the tech-debt sprint (TD-1/3 #422, TD-5 #424, TD-2a #425, TD-2b #431, TD-4 groundwork #426 #427, TD-4 HTTP migration #428, TD-4 stdio migration #432), and fixes (#412, #421, #423, #433, #434).

TD-6 (metrics reshape), TD-7 (reverse-proxy scanner close-on-reload), TD-8 (`toolBaseline` drift rebuild), and TD-9 (reverse-proxy receipt parity) are held for v2.4.

## Version bumps

`charts/pipelock/Chart.yaml` `appVersion` 2.2.0 to 2.3.0. Chart `version` stays at 0.1.0 (chart structure unchanged).

## Docs

New `docs/guides/sse-streaming.md` covering transport coverage, config, fail-closed behavior, documented limitations. Comment lines and keepalives are dropped (not passed through). Unknown fields ignored per WHATWG SSE spec. Only invalid UTF-8 in `data:` payload terminates the stream.

`docs/configuration.md` gets see-also link to the new guide.

`README.md` gets SSE streaming paragraph in Response Scanning section.

Three compliance docs (`eu-ai-act-mapping`, `nist-800-53`, `owasp-mcp-top10`) get `Last updated` refreshed.

## Redaction wording

Package is `internal/redact`. Placeholders are `<pl:class:n>` format. Coverage is request-side only (fetch, forward, reverse, TLS-intercepted CONNECT, outbound WebSocket client messages, MCP `tools/call` `params.arguments`). Tool responses are NOT redacted in this release.

## Build

`Makefile` `debt-check` target migrated from `--disable-all` (golangci-lint v1) to `--enable-only dupl,gocyclo,gocognit,maintidx` (golangci-lint v2).

## Validation

`make release-audit`, `make test-runtime-critical`, `make runtime-policy-audit`, `go test -race -count=1 ./...`, `golangci-lint run ./...`, and `git diff --check` all pass. `make debt-check` now runs and reports existing debt (per target purpose).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Class-preserving request-side redaction across HTTP, WebSocket, and MCP transports; expanded inline response scanning for SSE with per-event DLP/prompt-injection checks and fail-closed behavior.

* **Documentation**
  * New SSE streaming guide, README and config pointers; updated compliance mappings and docs to reflect v2.3.0 capabilities.

* **Bug Fixes / Security Hardening**
  * Various false-positive and classifier ordering fixes, reduced Sentry noise, SSRF/DNS resilience, and DLP reload warnings.

* **Chores**
  * Version bumped to 2.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->