### PR TITLE
test(proxy): disable rate limiter in reload atomicity soak

### DIFF
--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -2186,6 +2186,11 @@ func TestProxy_Reload_RedactionRuntimePublishedAtomically(t *testing.T) {
 		cfg.ForwardProxy.MaxTunnelSeconds = 10
 		cfg.ForwardProxy.IdleTimeoutSeconds = 2
 		cfg.FetchProxy.TimeoutSeconds = 5
+		// Disable the per-domain rate limit: this soak intentionally
+		// hammers one backend while reloads race with active requests, and
+		// rate-limit blocks would skip the redaction runtime path this test
+		// is meant to exercise.
+		cfg.FetchProxy.Monitoring.MaxReqPerMinute = 0
 		cfg.RequestBodyScanning.Enabled = true
 		cfg.RequestBodyScanning.Action = config.ActionWarn
 		if redactionEnabled {


### PR DESCRIPTION
## Summary

\`TestProxy_Reload_RedactionRuntimePublishedAtomically\` fires concurrent requests while hot-reloading the config to verify active requests see a consistent redaction runtime snapshot. The per-domain rate limiter sits before the redaction runtime path, so under CI concurrency a 429 would skip the exercise this soak is meant to perform while still counting as a well-formed response. Disable the limiter inside this test so every worker request flows through the reload path and the strict 200 OK assertion keeps its stress signal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for reload/redaction soak tests to improve test execution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->