### PR TITLE
test(proxy): raise reload-soak rate limit above stress, guard against regression

### DIFF
--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -2177,6 +2177,12 @@ func TestProxy_Reload_RedactionRuntimePublishedAtomically(t *testing.T) {
 	}))
 	defer backend.Close()
 
+	const (
+		workers           = 6
+		requestsPerWorker = 40
+		soakRateLimit     = workers * requestsPerWorker * 10
+	)
+
 	buildCfg := func(redactionEnabled bool) *config.Config {
 		cfg := config.Defaults()
 		cfg.Internal = nil
@@ -2186,11 +2192,6 @@ func TestProxy_Reload_RedactionRuntimePublishedAtomically(t *testing.T) {
 		cfg.ForwardProxy.MaxTunnelSeconds = 10
 		cfg.ForwardProxy.IdleTimeoutSeconds = 2
 		cfg.FetchProxy.TimeoutSeconds = 5
-		// Disable the per-domain rate limit: this soak intentionally
-		// hammers one backend while reloads race with active requests, and
-		// rate-limit blocks would skip the redaction runtime path this test
-		// is meant to exercise.
-		cfg.FetchProxy.Monitoring.MaxReqPerMinute = 0
 		cfg.RequestBodyScanning.Enabled = true
 		cfg.RequestBodyScanning.Action = config.ActionWarn
 		if redactionEnabled {
@@ -2200,6 +2201,15 @@ func TestProxy_Reload_RedactionRuntimePublishedAtomically(t *testing.T) {
 		}
 		cfg.ApplyDefaults()
 		cfg.Internal = nil
+		// Raise the per-domain rate limit far above the soak's worst case.
+		// This soak intentionally hammers one backend (6 workers * 40 requests)
+		// while reloads race with active requests, and rate-limit blocks would
+		// skip the redaction runtime path this test is meant to exercise.
+		// Set AFTER ApplyDefaults because the normalizer clamps <= 0 back to 60.
+		cfg.FetchProxy.Monitoring.MaxReqPerMinute = soakRateLimit
+		if cfg.FetchProxy.Monitoring.MaxReqPerMinute <= workers*requestsPerWorker {
+			t.Fatalf("reload soak rate limit = %d, want > %d", cfg.FetchProxy.Monitoring.MaxReqPerMinute, workers*requestsPerWorker)
+		}
 		return cfg
 	}
 
@@ -2217,8 +2227,6 @@ func TestProxy_Reload_RedactionRuntimePublishedAtomically(t *testing.T) {
 	client := proxyClient(strings.TrimPrefix(proxySrv.URL, "http://"))
 	targetURL := backend.URL + "/upload"
 
-	const workers = 6
-	const requestsPerWorker = 40
 	errCh := make(chan string, workers*requestsPerWorker+16)
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Summary

PR #437 tried to disable \`FetchProxy.Monitoring.MaxReqPerMinute\` by setting it to 0, but \`config.ApplyDefaults()\` normalizes \`<= 0\` back to 60 in \`normalize.go\`, so the override was dead code. Six workers firing 40 requests each against one backend still hit that 60/min cap under CI load, returning HTTP 429 and failing \`TestProxy_Reload_RedactionRuntimePublishedAtomically\`.

Set \`MaxReqPerMinute\` AFTER \`ApplyDefaults\` to a named \`soakRateLimit\` constant (\`workers * requestsPerWorker * 10\` = 2400) so the limit is proportional to the stress the test actually generates, not a magic number. Add a defensive check in \`buildCfg\` that fails the test loudly if anything future-clamps the value below the stress level, so the next time a normalizer or reload path quietly rewrites this field we see it as a clear test failure instead of a CI-only 429 storm.

Promote \`workers\` and \`requestsPerWorker\` to a single \`const\` block at the top of the test so the new \`soakRateLimit\` derivation is colocated with its inputs.