### PR TITLE
feat(signing): deployment-level key roster, recovery authorization, and root transition primitive

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,7 @@ jobs:
             examples/quickstart/
             internal/contract/testdata/golden/
             internal/contract/testdata/invalid/
+            internal/signing/testdata/
 
   test:
     needs: [security-scan]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
             examples/quickstart/
             internal/contract/testdata/golden/
             internal/contract/testdata/invalid/
-            internal/signing/testdata/
+            internal/signing/testdata/golden/
 
   test:
     needs: [security-scan]

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -116,6 +116,7 @@ Quick start:
 		clisigning.TlsCmd(),
 		clisigning.VerifyReceiptCmd(),
 		clisigning.TranscriptRootCmd(),
+		clisigning.SigningSubtreeCmd(),
 		// Binary install helper for sidecar init containers.
 		installCmd(),
 		// Version

--- a/internal/cli/signing/signing_subtree.go
+++ b/internal/cli/signing/signing_subtree.go
@@ -1,0 +1,245 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	domsigning "github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// ed25519PubKeyHexLen is the expected hex-encoded length of a 32-byte
+// Ed25519 public key: 32 bytes = 64 hex characters.
+const ed25519PubKeyHexLen = 64
+
+// SigningSubtreeCmd returns the "signing" parent cobra command hosting
+// offline ceremony verification subcommands: roster show, roster verify,
+// recovery verify, and transition verify.
+func SigningSubtreeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "signing",
+		Short: "Offline ceremony verification for key rosters and trust roots",
+		Long: `Verify signed key rosters, recovery authorizations, and root
+transition documents offline. These commands are used during key
+ceremonies to confirm that signed artifacts are authentic before
+trusting them in production.
+
+Subcommand groups:
+  roster      Show and verify key rosters
+  recovery    Verify recovery authorizations
+  transition  Verify root transition documents`,
+	}
+
+	roster := &cobra.Command{
+		Use:   "roster",
+		Short: "Show and verify key rosters",
+	}
+	roster.AddCommand(rosterShowCmd())
+	roster.AddCommand(rosterVerifyCmd())
+
+	recovery := &cobra.Command{
+		Use:   "recovery",
+		Short: "Verify recovery authorizations",
+	}
+	recovery.AddCommand(recoveryVerifyCmd())
+
+	transition := &cobra.Command{
+		Use:   "transition",
+		Short: "Verify root transition documents",
+	}
+	transition.AddCommand(transitionVerifyCmd())
+
+	cmd.AddCommand(roster, recovery, transition)
+	return cmd
+}
+
+func rosterShowCmd() *cobra.Command {
+	var path string
+	var rootFingerprint string
+
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Load and verify a key roster, then pretty-print its body",
+		Long: `Loads a signed key roster from disk, verifies the signature
+against the pinned root fingerprint, and prints the roster body as
+indented JSON.
+
+Examples:
+  pipelock signing roster show --path roster.json --root-fingerprint sha256:abc123...`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			loaded, err := domsigning.LoadRoster(filepath.Clean(path), rootFingerprint)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "load failed: %v\n", err)
+				return err
+			}
+
+			data, err := json.MarshalIndent(loaded.Body, "", "  ")
+			if err != nil {
+				return fmt.Errorf("marshal roster body: %w", err)
+			}
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "path to roster file (.json/.yaml/.yml)")
+	cmd.Flags().StringVar(&rootFingerprint, "root-fingerprint", "", "pinned root fingerprint (sha256:...)")
+	_ = cmd.MarkFlagRequired("path")
+	_ = cmd.MarkFlagRequired("root-fingerprint")
+	return cmd
+}
+
+func rosterVerifyCmd() *cobra.Command {
+	var path string
+	var rootFingerprint string
+
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Verify a key roster's signature and print a summary",
+		Long: `Loads and verifies a signed key roster against the pinned root
+fingerprint. On success prints the key count and signing key ID.
+Exit 0 on success, non-zero on failure.
+
+Examples:
+  pipelock signing roster verify --path roster.json --root-fingerprint sha256:abc123...`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			loaded, err := domsigning.LoadRoster(filepath.Clean(path), rootFingerprint)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: %v\n", err)
+				return err
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+				"roster verified: %d keys, root_signed_by=%s\n",
+				len(loaded.Body.Keys), loaded.Body.RosterSignedBy)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "path to roster file (.json/.yaml/.yml)")
+	cmd.Flags().StringVar(&rootFingerprint, "root-fingerprint", "", "pinned root fingerprint (sha256:...)")
+	_ = cmd.MarkFlagRequired("path")
+	_ = cmd.MarkFlagRequired("root-fingerprint")
+	return cmd
+}
+
+func recoveryVerifyCmd() *cobra.Command {
+	var path string
+	var recoveryPubkeyHex string
+	var pinnedFingerprint string
+
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Verify a recovery authorization file",
+		Long: `Loads and verifies a recovery authorization against the
+specified recovery-root public key and pinned fingerprint. Checks
+the signature, time window, and structural validity.
+Exit 0 on success, non-zero on failure.
+
+Examples:
+  pipelock signing recovery verify --path recovery.json --recovery-pubkey <64-char-hex> --pinned-fingerprint sha256:abc123...`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			pubBytes, err := decodeHexPubkey(recoveryPubkeyHex)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: %v\n", err)
+				return err
+			}
+
+			loaded, err := domsigning.LoadRecoveryAuthorization(
+				filepath.Clean(path), pubBytes, pinnedFingerprint, time.Now())
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: %v\n", err)
+				return err
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+				"recovery authorization verified: reason=%s, expires_at=%s, operator=%s\n",
+				loaded.Body.Reason, loaded.Body.ExpiresAt, loaded.Body.OperatorIdentity)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "path to recovery authorization file")
+	cmd.Flags().StringVar(&recoveryPubkeyHex, "recovery-pubkey", "", "recovery-root public key (64-char hex)")
+	cmd.Flags().StringVar(&pinnedFingerprint, "pinned-fingerprint", "", "operator-pinned recovery-root fingerprint (sha256:...)")
+	_ = cmd.MarkFlagRequired("path")
+	_ = cmd.MarkFlagRequired("recovery-pubkey")
+	_ = cmd.MarkFlagRequired("pinned-fingerprint")
+	return cmd
+}
+
+func transitionVerifyCmd() *cobra.Command {
+	var path string
+	var oldPubkeyHex string
+	var newPubkeyHex string
+	var pinnedFingerprint string
+
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Verify a root transition document's dual signatures",
+		Long: `Loads and verifies a root transition document against both
+the old and new public keys. Both signatures must be valid. When
+--pinned is supplied, the old fingerprint in the document must
+match it.
+Exit 0 on success, non-zero on failure.
+
+Examples:
+  pipelock signing transition verify --path transition.json --old-pubkey <hex> --new-pubkey <hex>
+  pipelock signing transition verify --path transition.json --old-pubkey <hex> --new-pubkey <hex> --pinned sha256:abc123...`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			oldPub, err := decodeHexPubkey(oldPubkeyHex)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: invalid old-pubkey: %v\n", err)
+				return fmt.Errorf("invalid old-pubkey: %w", err)
+			}
+
+			newPub, err := decodeHexPubkey(newPubkeyHex)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: invalid new-pubkey: %v\n", err)
+				return fmt.Errorf("invalid new-pubkey: %w", err)
+			}
+
+			loaded, err := domsigning.LoadRootTransition(
+				filepath.Clean(path), oldPub, newPub, pinnedFingerprint)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: %v\n", err)
+				return err
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+				"transition verified: kind=%s, old=%s, new=%s, effective_at=%s\n",
+				loaded.Body.RootKind, loaded.Body.OldFingerprint,
+				loaded.Body.NewFingerprint, loaded.Body.EffectiveAt)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "path to root transition file")
+	cmd.Flags().StringVar(&oldPubkeyHex, "old-pubkey", "", "old root public key (64-char hex)")
+	cmd.Flags().StringVar(&newPubkeyHex, "new-pubkey", "", "new root public key (64-char hex)")
+	cmd.Flags().StringVar(&pinnedFingerprint, "pinned", "", "operator-pinned old fingerprint (sha256:..., optional)")
+	_ = cmd.MarkFlagRequired("path")
+	_ = cmd.MarkFlagRequired("old-pubkey")
+	_ = cmd.MarkFlagRequired("new-pubkey")
+	return cmd
+}
+
+// decodeHexPubkey decodes a 64-character hex string into a 32-byte Ed25519
+// public key. Returns a descriptive error on invalid input.
+func decodeHexPubkey(hexStr string) ([]byte, error) {
+	if len(hexStr) != ed25519PubKeyHexLen {
+		return nil, fmt.Errorf("hex public key must be %d characters, got %d", ed25519PubKeyHexLen, len(hexStr))
+	}
+	b, err := hex.DecodeString(hexStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid hex in public key: %w", err)
+	}
+	return b, nil
+}

--- a/internal/cli/signing/signing_subtree.go
+++ b/internal/cli/signing/signing_subtree.go
@@ -146,7 +146,7 @@ the signature, time window, lifetime ceiling, and structural validity.
 The optional --expected-target-roster-hash binds the authorization to a
 specific roster body. Empty (the default) skips the binding check, which
 is appropriate for offline ceremony review when the target hash is not yet
-known. Runtime callers SHOULD pass a non-empty value.
+known. Runtime callers MUST pass a non-empty value.
 Exit 0 on success, non-zero on failure.
 
 Examples:
@@ -171,7 +171,7 @@ Examples:
 				loaded.Body.Reason, loaded.Body.ExpiresAt, loaded.Body.OperatorIdentity)
 			if expectedTargetRosterHash == "" {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(),
-					"NOTE: target_roster_hash binding NOT verified (offline mode). Runtime callers must pass --expected-target-roster-hash.")
+					"NOTE: target_roster_hash binding NOT verified (offline mode). Runtime callers MUST pass --expected-target-roster-hash.")
 			}
 			return nil
 		},

--- a/internal/cli/signing/signing_subtree.go
+++ b/internal/cli/signing/signing_subtree.go
@@ -134,17 +134,24 @@ func recoveryVerifyCmd() *cobra.Command {
 	var path string
 	var recoveryPubkeyHex string
 	var pinnedFingerprint string
+	var expectedTargetRosterHash string
 
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "Verify a recovery authorization file",
 		Long: `Loads and verifies a recovery authorization against the
 specified recovery-root public key and pinned fingerprint. Checks
-the signature, time window, and structural validity.
+the signature, time window, lifetime ceiling, and structural validity.
+
+The optional --expected-target-roster-hash binds the authorization to a
+specific roster body. Empty (the default) skips the binding check, which
+is appropriate for offline ceremony review when the target hash is not yet
+known. Runtime callers SHOULD pass a non-empty value.
 Exit 0 on success, non-zero on failure.
 
 Examples:
-  pipelock signing recovery verify --path recovery.json --recovery-pubkey <64-char-hex> --pinned-fingerprint sha256:abc123...`,
+  pipelock signing recovery verify --path recovery.json --recovery-pubkey <64-char-hex> --pinned-fingerprint sha256:abc123...
+  pipelock signing recovery verify --path recovery.json --recovery-pubkey <hex> --pinned-fingerprint sha256:abc... --expected-target-roster-hash sha256:def...`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			pubBytes, err := decodeHexPubkey(recoveryPubkeyHex)
 			if err != nil {
@@ -153,7 +160,7 @@ Examples:
 			}
 
 			loaded, err := domsigning.LoadRecoveryAuthorization(
-				filepath.Clean(path), pubBytes, pinnedFingerprint, time.Now())
+				filepath.Clean(path), pubBytes, pinnedFingerprint, expectedTargetRosterHash, time.Now())
 			if err != nil {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: %v\n", err)
 				return err
@@ -162,6 +169,10 @@ Examples:
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 				"recovery authorization verified: reason=%s, expires_at=%s, operator=%s\n",
 				loaded.Body.Reason, loaded.Body.ExpiresAt, loaded.Body.OperatorIdentity)
+			if expectedTargetRosterHash == "" {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(),
+					"NOTE: target_roster_hash binding NOT verified (offline mode). Runtime callers must pass --expected-target-roster-hash.")
+			}
 			return nil
 		},
 	}
@@ -169,6 +180,7 @@ Examples:
 	cmd.Flags().StringVar(&path, "path", "", "path to recovery authorization file")
 	cmd.Flags().StringVar(&recoveryPubkeyHex, "recovery-pubkey", "", "recovery-root public key (64-char hex)")
 	cmd.Flags().StringVar(&pinnedFingerprint, "pinned-fingerprint", "", "operator-pinned recovery-root fingerprint (sha256:...)")
+	cmd.Flags().StringVar(&expectedTargetRosterHash, "expected-target-roster-hash", "", "expected target roster hash (sha256:...); empty = skip binding check (offline only)")
 	_ = cmd.MarkFlagRequired("path")
 	_ = cmd.MarkFlagRequired("recovery-pubkey")
 	_ = cmd.MarkFlagRequired("pinned-fingerprint")

--- a/internal/cli/signing/signing_subtree.go
+++ b/internal/cli/signing/signing_subtree.go
@@ -6,8 +6,11 @@ package signing
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -18,6 +21,15 @@ import (
 // ed25519PubKeyHexLen is the expected hex-encoded length of a 32-byte
 // Ed25519 public key: 32 bytes = 64 hex characters.
 const ed25519PubKeyHexLen = 64
+
+// pubkeyFileMaxSize caps the size of a public-key file. A 64-hex-char key
+// plus newline is 65 bytes; allow a small margin for whitespace or BOMs but
+// reject pathologically large inputs that might be a misconfiguration or an
+// adversary trying to exhaust the loader on a non-key file.
+const pubkeyFileMaxSize = 4096
+
+// errPubkeyFileTooLarge surfaces when a --*-pubkey-file exceeds the cap.
+var errPubkeyFileTooLarge = errors.New("public key file exceeds size cap")
 
 // SigningSubtreeCmd returns the "signing" parent cobra command hosting
 // offline ceremony verification subcommands: roster show, roster verify,
@@ -116,9 +128,12 @@ Examples:
 				return err
 			}
 
+			// RosterSignedBy is the operator-supplied roster signing key id
+			// from the YAML; it is attacker-controlled before the roster
+			// is signed, so quote it for terminal-injection safety.
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 				"roster verified: %d keys, root_signed_by=%s\n",
-				len(loaded.Body.Keys), loaded.Body.RosterSignedBy)
+				len(loaded.Body.Keys), sanitizeForTerminal(loaded.Body.RosterSignedBy))
 			return nil
 		},
 	}
@@ -133,6 +148,7 @@ Examples:
 func recoveryVerifyCmd() *cobra.Command {
 	var path string
 	var recoveryPubkeyHex string
+	var recoveryPubkeyFile string
 	var pinnedFingerprint string
 	var expectedTargetRosterHash string
 
@@ -144,31 +160,66 @@ specified recovery-root public key and pinned fingerprint. Checks
 the signature, time window, lifetime ceiling, and structural validity.
 
 The optional --expected-target-roster-hash binds the authorization to a
-specific roster body. Empty (the default) skips the binding check, which
-is appropriate for offline ceremony review when the target hash is not yet
-known. Runtime callers MUST pass a non-empty value.
+specific roster body. Empty invokes the offline-inspection path
+(InspectRecoveryAuthorizationOffline) which skips the binding check; this
+is appropriate for ceremony review when the target hash is not yet known.
+The runtime LoadRecoveryAuthorization API in internal/signing rejects an
+empty value at the boundary so a forgotten parameter cannot bypass the
+binding silently in production code.
+
+Pass the recovery-root public key via --recovery-pubkey-file (preferred for
+ceremony durability; the file path stays in audit trail) or via
+--recovery-pubkey for ad-hoc/test usage. Exactly one must be set.
 Exit 0 on success, non-zero on failure.
 
 Examples:
-  pipelock signing recovery verify --path recovery.json --recovery-pubkey <64-char-hex> --pinned-fingerprint sha256:abc123...
-  pipelock signing recovery verify --path recovery.json --recovery-pubkey <hex> --pinned-fingerprint sha256:abc... --expected-target-roster-hash sha256:def...`,
+  pipelock signing recovery verify --path recovery.json --recovery-pubkey-file pub.hex --pinned-fingerprint sha256:abc123...
+  pipelock signing recovery verify --path recovery.json --recovery-pubkey <64-char-hex> --pinned-fingerprint sha256:abc...
+  pipelock signing recovery verify --path recovery.json --recovery-pubkey-file pub.hex --pinned-fingerprint sha256:abc... --expected-target-roster-hash sha256:def...`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			pubBytes, err := decodeHexPubkey(recoveryPubkeyHex)
+			pubBytes, err := resolvePubkey("recovery-pubkey", recoveryPubkeyHex, recoveryPubkeyFile)
 			if err != nil {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: %v\n", err)
 				return err
 			}
 
-			loaded, err := domsigning.LoadRecoveryAuthorization(
-				filepath.Clean(path), pubBytes, pinnedFingerprint, expectedTargetRosterHash, time.Now())
+			// Compute and surface the fingerprint of the key we ACTUALLY
+			// loaded so the operator can confirm the trust anchor before
+			// trusting any verdict line below it. Mismatch with the pinned
+			// expectation would be caught by the loader, but printing the
+			// computed value first gives a visible cross-check.
+			computedFP, fpErr := domsigning.Fingerprint(pubBytes)
+			if fpErr != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: %v\n", fpErr)
+				return fpErr
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+				"loaded recovery-root: fingerprint=%s\n", computedFP)
+
+			var loaded *domsigning.LoadedRecoveryAuthorization
+			if expectedTargetRosterHash == "" {
+				loaded, err = domsigning.InspectRecoveryAuthorizationOffline(
+					filepath.Clean(path), pubBytes, pinnedFingerprint, time.Now())
+			} else {
+				loaded, err = domsigning.LoadRecoveryAuthorization(
+					filepath.Clean(path), pubBytes, pinnedFingerprint,
+					expectedTargetRosterHash, time.Now())
+			}
 			if err != nil {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: %v\n", err)
 				return err
 			}
 
+			// Quote attacker-controlled fields before printing so a hostile
+			// signed file with control characters in reason/operator_identity
+			// cannot repaint the operator's terminal during ceremony review.
+			// expires_at is RFC 3339 validated by the loader so it does not
+			// need quoting; reason and operator_identity are free-form.
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 				"recovery authorization verified: reason=%s, expires_at=%s, operator=%s\n",
-				loaded.Body.Reason, loaded.Body.ExpiresAt, loaded.Body.OperatorIdentity)
+				sanitizeForTerminal(loaded.Body.Reason),
+				loaded.Body.ExpiresAt,
+				sanitizeForTerminal(loaded.Body.OperatorIdentity))
 			if expectedTargetRosterHash == "" {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(),
 					"NOTE: target_roster_hash binding NOT verified (offline mode). Runtime callers MUST pass --expected-target-roster-hash.")
@@ -178,19 +229,23 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&path, "path", "", "path to recovery authorization file")
-	cmd.Flags().StringVar(&recoveryPubkeyHex, "recovery-pubkey", "", "recovery-root public key (64-char hex)")
+	cmd.Flags().StringVar(&recoveryPubkeyHex, "recovery-pubkey", "", "recovery-root public key (64-char hex; for ad-hoc/test use)")
+	cmd.Flags().StringVar(&recoveryPubkeyFile, "recovery-pubkey-file", "", "path to file containing the recovery-root public key as 64-char hex")
 	cmd.Flags().StringVar(&pinnedFingerprint, "pinned-fingerprint", "", "operator-pinned recovery-root fingerprint (sha256:...)")
 	cmd.Flags().StringVar(&expectedTargetRosterHash, "expected-target-roster-hash", "", "expected target roster hash (sha256:...); empty = skip binding check (offline only)")
 	_ = cmd.MarkFlagRequired("path")
-	_ = cmd.MarkFlagRequired("recovery-pubkey")
 	_ = cmd.MarkFlagRequired("pinned-fingerprint")
+	cmd.MarkFlagsOneRequired("recovery-pubkey", "recovery-pubkey-file")
+	cmd.MarkFlagsMutuallyExclusive("recovery-pubkey", "recovery-pubkey-file")
 	return cmd
 }
 
 func transitionVerifyCmd() *cobra.Command {
 	var path string
 	var oldPubkeyHex string
+	var oldPubkeyFile string
 	var newPubkeyHex string
+	var newPubkeyFile string
 	var pinnedFingerprint string
 
 	cmd := &cobra.Command{
@@ -200,23 +255,43 @@ func transitionVerifyCmd() *cobra.Command {
 the old and new public keys. Both signatures must be valid. When
 --pinned is supplied, the old fingerprint in the document must
 match it.
+
+Pass each public key via --*-pubkey-file (preferred for ceremony durability;
+the file path stays in audit trail) or via --*-pubkey for ad-hoc/test
+usage. Exactly one of each pair must be set.
 Exit 0 on success, non-zero on failure.
 
 Examples:
-  pipelock signing transition verify --path transition.json --old-pubkey <hex> --new-pubkey <hex>
+  pipelock signing transition verify --path transition.json --old-pubkey-file old.hex --new-pubkey-file new.hex
   pipelock signing transition verify --path transition.json --old-pubkey <hex> --new-pubkey <hex> --pinned sha256:abc123...`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			oldPub, err := decodeHexPubkey(oldPubkeyHex)
+			oldPub, err := resolvePubkey("old-pubkey", oldPubkeyHex, oldPubkeyFile)
 			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: invalid old-pubkey: %v\n", err)
-				return fmt.Errorf("invalid old-pubkey: %w", err)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: %v\n", err)
+				return err
+			}
+			newPub, err := resolvePubkey("new-pubkey", newPubkeyHex, newPubkeyFile)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: %v\n", err)
+				return err
 			}
 
-			newPub, err := decodeHexPubkey(newPubkeyHex)
-			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: invalid new-pubkey: %v\n", err)
-				return fmt.Errorf("invalid new-pubkey: %w", err)
+			// Echo the fingerprints of the two keys we ACTUALLY loaded so
+			// the operator confirms the trust anchors before trusting any
+			// verdict line below them.
+			oldFP, fpErr := domsigning.Fingerprint(oldPub)
+			if fpErr != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: %v\n", fpErr)
+				return fpErr
 			}
+			newFP, fpErr := domsigning.Fingerprint(newPub)
+			if fpErr != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "verify failed: %v\n", fpErr)
+				return fpErr
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+				"loaded transition keys: old_fingerprint=%s, new_fingerprint=%s\n",
+				oldFP, newFP)
 
 			loaded, err := domsigning.LoadRootTransition(
 				filepath.Clean(path), oldPub, newPub, pinnedFingerprint)
@@ -225,6 +300,10 @@ Examples:
 				return err
 			}
 
+			// RootKind is enum-validated and OldFingerprint/NewFingerprint
+			// match the sha256:<hex> pattern, so they don't carry control
+			// characters; effective_at is RFC 3339 validated by the loader.
+			// No quoting needed for these — they're constrained.
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 				"transition verified: kind=%s, old=%s, new=%s, effective_at=%s\n",
 				loaded.Body.RootKind, loaded.Body.OldFingerprint,
@@ -234,12 +313,16 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&path, "path", "", "path to root transition file")
-	cmd.Flags().StringVar(&oldPubkeyHex, "old-pubkey", "", "old root public key (64-char hex)")
-	cmd.Flags().StringVar(&newPubkeyHex, "new-pubkey", "", "new root public key (64-char hex)")
+	cmd.Flags().StringVar(&oldPubkeyHex, "old-pubkey", "", "old root public key (64-char hex; for ad-hoc/test use)")
+	cmd.Flags().StringVar(&oldPubkeyFile, "old-pubkey-file", "", "path to file containing the old root public key as 64-char hex")
+	cmd.Flags().StringVar(&newPubkeyHex, "new-pubkey", "", "new root public key (64-char hex; for ad-hoc/test use)")
+	cmd.Flags().StringVar(&newPubkeyFile, "new-pubkey-file", "", "path to file containing the new root public key as 64-char hex")
 	cmd.Flags().StringVar(&pinnedFingerprint, "pinned", "", "operator-pinned old fingerprint (sha256:..., optional)")
 	_ = cmd.MarkFlagRequired("path")
-	_ = cmd.MarkFlagRequired("old-pubkey")
-	_ = cmd.MarkFlagRequired("new-pubkey")
+	cmd.MarkFlagsOneRequired("old-pubkey", "old-pubkey-file")
+	cmd.MarkFlagsMutuallyExclusive("old-pubkey", "old-pubkey-file")
+	cmd.MarkFlagsOneRequired("new-pubkey", "new-pubkey-file")
+	cmd.MarkFlagsMutuallyExclusive("new-pubkey", "new-pubkey-file")
 	return cmd
 }
 
@@ -254,4 +337,70 @@ func decodeHexPubkey(hexStr string) ([]byte, error) {
 		return nil, fmt.Errorf("invalid hex in public key: %w", err)
 	}
 	return b, nil
+}
+
+// readPubkeyFile reads a hex-encoded Ed25519 public key from disk. The file
+// is expected to contain exactly the 64-hex-character form, optionally with
+// surrounding whitespace (newline trailing, etc.). Decodes and returns the
+// 32-byte raw key.
+//
+// Why files: ceremony commands previously took --*-pubkey as raw CLI args.
+// On multi-user systems those values appear in process listings and shell
+// history. Public keys are not secret, but durable provenance of which trust
+// anchor was used during a key ceremony belongs in a file, not on argv.
+func readPubkeyFile(path string) ([]byte, error) {
+	cleanPath := filepath.Clean(path)
+	info, err := os.Stat(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat public key file %q: %w", cleanPath, err)
+	}
+	if info.Size() > pubkeyFileMaxSize {
+		return nil, fmt.Errorf("%w: %d bytes (cap %d): %q",
+			errPubkeyFileTooLarge, info.Size(), pubkeyFileMaxSize, cleanPath)
+	}
+	raw, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("read public key file %q: %w", cleanPath, err)
+	}
+	hexStr := strings.TrimSpace(string(raw))
+	return decodeHexPubkey(hexStr)
+}
+
+// resolvePubkey returns the raw key bytes from either an inline hex flag or
+// a file flag. Exactly one must be non-empty; cobra's MarkFlagsOneRequired +
+// MarkFlagsMutuallyExclusive enforce this at parse time, so the empty/dual
+// cases are defense in depth.
+//
+// Errors are wrapped with "invalid <label>: ..." so the CLI's stderr message
+// makes the offending flag obvious.
+func resolvePubkey(label, hexFlag, fileFlag string) ([]byte, error) {
+	if hexFlag != "" && fileFlag != "" {
+		return nil, fmt.Errorf("invalid %s: pass either --%s or --%s-file, not both", label, label, label)
+	}
+	if fileFlag != "" {
+		key, err := readPubkeyFile(fileFlag)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s: %w", label, err)
+		}
+		return key, nil
+	}
+	if hexFlag != "" {
+		key, err := decodeHexPubkey(hexFlag)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s: %w", label, err)
+		}
+		return key, nil
+	}
+	return nil, fmt.Errorf("invalid %s: --%s or --%s-file is required", label, label, label)
+}
+
+// sanitizeForTerminal returns a Go-quoted form of s suitable for printing to
+// a terminal without risking control-character or newline injection. Even
+// signed artifact fields like reason and operator_identity are
+// attacker-controlled before signing — an operator tricked into verifying a
+// hostile signed file should not have their terminal repainted by the
+// printed output. %q escapes control bytes and quotes the result so the
+// boundary between operator-supplied content and CLI chrome stays visible.
+func sanitizeForTerminal(s string) string {
+	return fmt.Sprintf("%q", s)
 }

--- a/internal/cli/signing/signing_subtree_test.go
+++ b/internal/cli/signing/signing_subtree_test.go
@@ -1,0 +1,744 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	domsigning "github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// Deterministic ed25519 seeds for roster test fixtures, split per G101 lint.
+const (
+	testSubtreeRosterSeedHex = "" +
+		"9d61b19d" + "effd5a60" + "ba844af4" + "92ec2cc4" +
+		"4449c569" + "7b326919" + "703bac03" + "1cae7f60"
+	testSubtreeRosterPubHex = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+	testSubtreeRosterKeyID  = "roster-root-test"
+	testSubtreeReceiptKeyID = "receipt-signing-test"
+	testSubtreeDataClass    = "internal"
+	testSubtreeValidFrom    = "2026-04-01T00:00:00Z"
+)
+
+// Deterministic seeds for recovery test fixtures, different from roster.
+const (
+	testSubtreeRecoverySeedHex = "" +
+		"4ccd089b" + "28ff96da" + "9db6c346" + "ec114e0f" +
+		"5b8a319f" + "35aba624" + "da8cf6ed" + "4fb8a6fb"
+
+	testSubtreeRecoveryReason     = "roster root key compromised"
+	testSubtreeRecoveryOperator   = "ops@example.com"
+	testSubtreeRecoveryTargetHash = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+// Deterministic seeds for root transition test fixtures (two independent keys).
+const (
+	testSubtreeRTOldSeedHex = "" +
+		"9d61b19d" + "effd5a60" + "ba844af4" + "92ec2cc4" +
+		"4449c569" + "8b64e70e" + "1b6ff1ae" + "1b6ff1ae"
+
+	testSubtreeRTNewSeedHex = "" +
+		"9d61b19d" + "effd5a60" + "ba844af4" + "92ec2cc4" +
+		"4449c569" + "8b64e70e" + "ae1bff6b" + "ae1bff6b"
+
+	testSubtreeRTReason    = "scheduled annual key rotation"
+	testSubtreeRTEffective = "2026-04-26T15:00:00Z"
+)
+
+// buildRosterFixture creates a signed roster JSON file in a temp dir and
+// returns (filePath, pinnedFingerprint).
+func buildRosterFixture(t *testing.T) (string, string) {
+	t.Helper()
+
+	seed, err := hex.DecodeString(testSubtreeRosterSeedHex)
+	if err != nil {
+		t.Fatalf("decode seed: %v", err)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+
+	envelope := contract.RosterEnvelope{
+		Body: contract.KeyRoster{
+			SchemaVersion:  1,
+			RosterSignedBy: testSubtreeRosterKeyID,
+			Keys: []contract.KeyInfo{
+				{
+					KeyID:        testSubtreeRosterKeyID,
+					KeyPurpose:   string(domsigning.PurposeRosterRoot),
+					PublicKeyHex: testSubtreeRosterPubHex,
+					ValidFrom:    testSubtreeValidFrom,
+					Status:       contract.KeyStatusRoot,
+				},
+				{
+					KeyID:        testSubtreeReceiptKeyID,
+					KeyPurpose:   string(domsigning.PurposeReceiptSigning),
+					PublicKeyHex: testSubtreeRosterPubHex,
+					ValidFrom:    testSubtreeValidFrom,
+					Status:       contract.KeyStatusActive,
+				},
+			},
+			DataClassRoot: testSubtreeDataClass,
+		},
+	}
+
+	preimage, err := envelope.Body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("roster preimage: %v", err)
+	}
+	sig := ed25519.Sign(priv, preimage)
+	envelope.Signature = "ed25519:" + hex.EncodeToString(sig)
+
+	data, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "key_roster.json")
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	digest := sha256.Sum256(pub)
+	fingerprint := "sha256:" + hex.EncodeToString(digest[:])
+
+	return fp, fingerprint
+}
+
+// buildRecoveryFixture creates a signed recovery authorization JSON file.
+// Returns (filePath, pubkeyHex, pinnedFingerprint).
+func buildRecoveryFixture(t *testing.T, now time.Time) (string, string, string) {
+	t.Helper()
+
+	seed, err := hex.DecodeString(testSubtreeRecoverySeedHex)
+	if err != nil {
+		t.Fatalf("decode seed: %v", err)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+
+	envelope := domsigning.RecoveryAuthorizationEnvelope{
+		Body: domsigning.RecoveryAuthorizationBody{
+			SchemaVersion:    1,
+			Reason:           testSubtreeRecoveryReason,
+			ExpiresAt:        now.Add(30 * time.Minute).UTC().Format(time.RFC3339),
+			TargetRosterHash: testSubtreeRecoveryTargetHash,
+			OperatorIdentity: testSubtreeRecoveryOperator,
+			IssuedAt:         now.Add(-10 * time.Minute).UTC().Format(time.RFC3339),
+		},
+	}
+
+	preimage, err := envelope.Body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("recovery preimage: %v", err)
+	}
+	sig := ed25519.Sign(priv, preimage)
+	envelope.Signature = "ed25519:" + hex.EncodeToString(sig)
+
+	data, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "recovery_authorization.json")
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	pubHex := hex.EncodeToString(pub)
+	digest := sha256.Sum256(pub)
+	fingerprint := "sha256:" + hex.EncodeToString(digest[:])
+
+	return fp, pubHex, fingerprint
+}
+
+// buildExpiredRecoveryFixture creates a recovery authorization that expired
+// 10 minutes ago.
+func buildExpiredRecoveryFixture(t *testing.T, now time.Time) (string, string, string) {
+	t.Helper()
+
+	seed, err := hex.DecodeString(testSubtreeRecoverySeedHex)
+	if err != nil {
+		t.Fatalf("decode seed: %v", err)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+
+	envelope := domsigning.RecoveryAuthorizationEnvelope{
+		Body: domsigning.RecoveryAuthorizationBody{
+			SchemaVersion:    1,
+			Reason:           testSubtreeRecoveryReason,
+			ExpiresAt:        now.Add(-10 * time.Minute).UTC().Format(time.RFC3339),
+			TargetRosterHash: testSubtreeRecoveryTargetHash,
+			OperatorIdentity: testSubtreeRecoveryOperator,
+			IssuedAt:         now.Add(-60 * time.Minute).UTC().Format(time.RFC3339),
+		},
+	}
+
+	preimage, err := envelope.Body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("recovery preimage: %v", err)
+	}
+	sig := ed25519.Sign(priv, preimage)
+	envelope.Signature = "ed25519:" + hex.EncodeToString(sig)
+
+	data, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "recovery_expired.json")
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	pubHex := hex.EncodeToString(pub)
+	digest := sha256.Sum256(pub)
+	fingerprint := "sha256:" + hex.EncodeToString(digest[:])
+
+	return fp, pubHex, fingerprint
+}
+
+// buildTransitionFixture creates a dual-signed root transition JSON file.
+// Returns (filePath, oldPubHex, newPubHex, oldFingerprint).
+func buildTransitionFixture(t *testing.T) (string, string, string, string) {
+	t.Helper()
+
+	oldSeed, err := hex.DecodeString(testSubtreeRTOldSeedHex)
+	if err != nil {
+		t.Fatalf("decode old seed: %v", err)
+	}
+	oldPriv := ed25519.NewKeyFromSeed(oldSeed)
+	oldPub := oldPriv.Public().(ed25519.PublicKey)
+
+	newSeed, err := hex.DecodeString(testSubtreeRTNewSeedHex)
+	if err != nil {
+		t.Fatalf("decode new seed: %v", err)
+	}
+	newPriv := ed25519.NewKeyFromSeed(newSeed)
+	newPub := newPriv.Public().(ed25519.PublicKey)
+
+	oldDigest := sha256.Sum256(oldPub)
+	oldFP := "sha256:" + hex.EncodeToString(oldDigest[:])
+	newDigest := sha256.Sum256(newPub)
+	newFP := "sha256:" + hex.EncodeToString(newDigest[:])
+
+	envelope := domsigning.RootTransitionEnvelope{
+		Body: domsigning.RootTransitionBody{
+			SchemaVersion:  1,
+			RootKind:       domsigning.RootKindRoster,
+			OldFingerprint: oldFP,
+			NewFingerprint: newFP,
+			EffectiveAt:    testSubtreeRTEffective,
+			Reason:         testSubtreeRTReason,
+		},
+	}
+
+	preimage, err := envelope.Body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("transition preimage: %v", err)
+	}
+	oldSig := ed25519.Sign(oldPriv, preimage)
+	envelope.OldSignature = "ed25519:" + hex.EncodeToString(oldSig)
+	newSig := ed25519.Sign(newPriv, preimage)
+	envelope.NewSignature = "ed25519:" + hex.EncodeToString(newSig)
+
+	data, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "root_transition.json")
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	return fp, hex.EncodeToString(oldPub), hex.EncodeToString(newPub), oldFP
+}
+
+// --- Roster Show tests ---
+
+func TestRosterShow_HappyPath(t *testing.T) {
+	t.Parallel()
+	rosterPath, fingerprint := buildRosterFixture(t)
+
+	root := testRoot()
+	root.AddCommand(SigningSubtreeCmd())
+	root.SetArgs([]string{
+		"signing", "roster", "show",
+		"--path", rosterPath,
+		"--root-fingerprint", fingerprint,
+	})
+
+	var stdout strings.Builder
+	root.SetOut(&stdout)
+	root.SetErr(&strings.Builder{})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "roster_signed_by") {
+		t.Errorf("output should contain roster_signed_by, got:\n%s", output)
+	}
+	if !strings.Contains(output, testSubtreeRosterKeyID) {
+		t.Errorf("output should contain key ID %q, got:\n%s", testSubtreeRosterKeyID, output)
+	}
+}
+
+func TestRosterShow_RejectMissingFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "no path",
+			args: []string{"signing", "roster", "show", "--root-fingerprint", "sha256:abc"},
+		},
+		{
+			name: "no root-fingerprint",
+			args: []string{"signing", "roster", "show", "--path", "/tmp/nonexistent.json"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := testRoot()
+			root.AddCommand(SigningSubtreeCmd())
+			root.SetArgs(tc.args)
+			root.SetOut(&strings.Builder{})
+			root.SetErr(&strings.Builder{})
+
+			if err := root.Execute(); err == nil {
+				t.Fatal("expected error for missing required flag")
+			}
+		})
+	}
+}
+
+func TestRosterShow_FileMissing(t *testing.T) {
+	t.Parallel()
+
+	root := testRoot()
+	root.AddCommand(SigningSubtreeCmd())
+	root.SetArgs([]string{
+		"signing", "roster", "show",
+		"--path", "/tmp/nonexistent-roster-file-2026.json",
+		"--root-fingerprint", "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+	})
+
+	var stderr strings.Builder
+	root.SetOut(&strings.Builder{})
+	root.SetErr(&stderr)
+
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+
+	errOutput := stderr.String()
+	if !strings.Contains(errOutput, "load failed") {
+		t.Errorf("stderr should contain 'load failed', got:\n%s", errOutput)
+	}
+}
+
+// --- Roster Verify tests ---
+
+func TestRosterVerify_HappyPath(t *testing.T) {
+	t.Parallel()
+	rosterPath, fingerprint := buildRosterFixture(t)
+
+	root := testRoot()
+	root.AddCommand(SigningSubtreeCmd())
+	root.SetArgs([]string{
+		"signing", "roster", "verify",
+		"--path", rosterPath,
+		"--root-fingerprint", fingerprint,
+	})
+
+	var stdout strings.Builder
+	root.SetOut(&stdout)
+	root.SetErr(&strings.Builder{})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "roster verified") {
+		t.Errorf("output should contain 'roster verified', got:\n%s", output)
+	}
+	if !strings.Contains(output, "2 keys") {
+		t.Errorf("output should contain '2 keys', got:\n%s", output)
+	}
+	if !strings.Contains(output, testSubtreeRosterKeyID) {
+		t.Errorf("output should contain root_signed_by key ID, got:\n%s", output)
+	}
+}
+
+func TestRosterVerify_FingerprintMismatch(t *testing.T) {
+	t.Parallel()
+	rosterPath, _ := buildRosterFixture(t)
+
+	// Use a wrong fingerprint.
+	wrongFP := "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+	root := testRoot()
+	root.AddCommand(SigningSubtreeCmd())
+	root.SetArgs([]string{
+		"signing", "roster", "verify",
+		"--path", rosterPath,
+		"--root-fingerprint", wrongFP,
+	})
+
+	var stderr strings.Builder
+	root.SetOut(&strings.Builder{})
+	root.SetErr(&stderr)
+
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected error for fingerprint mismatch")
+	}
+
+	errOutput := stderr.String()
+	if !strings.Contains(errOutput, "verify failed") {
+		t.Errorf("stderr should contain 'verify failed', got:\n%s", errOutput)
+	}
+}
+
+// --- Recovery Verify tests ---
+
+func TestRecoveryVerify_HappyPath(t *testing.T) {
+	t.Parallel()
+	// Use real time.Now() since the CLI calls time.Now() internally.
+	now := time.Now()
+	path, pubHex, fingerprint := buildRecoveryFixture(t, now)
+
+	root := testRoot()
+	root.AddCommand(SigningSubtreeCmd())
+	root.SetArgs([]string{
+		"signing", "recovery", "verify",
+		"--path", path,
+		"--recovery-pubkey", pubHex,
+		"--pinned-fingerprint", fingerprint,
+	})
+
+	var stdout strings.Builder
+	root.SetOut(&stdout)
+	root.SetErr(&strings.Builder{})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "recovery authorization verified") {
+		t.Errorf("output should contain success message, got:\n%s", output)
+	}
+	if !strings.Contains(output, testSubtreeRecoveryReason) {
+		t.Errorf("output should contain reason, got:\n%s", output)
+	}
+	if !strings.Contains(output, testSubtreeRecoveryOperator) {
+		t.Errorf("output should contain operator, got:\n%s", output)
+	}
+}
+
+func TestRecoveryVerify_RejectExpired(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	path, pubHex, fingerprint := buildExpiredRecoveryFixture(t, now)
+
+	root := testRoot()
+	root.AddCommand(SigningSubtreeCmd())
+	root.SetArgs([]string{
+		"signing", "recovery", "verify",
+		"--path", path,
+		"--recovery-pubkey", pubHex,
+		"--pinned-fingerprint", fingerprint,
+	})
+
+	var stderr strings.Builder
+	root.SetOut(&strings.Builder{})
+	root.SetErr(&stderr)
+
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected error for expired recovery authorization")
+	}
+
+	errOutput := stderr.String()
+	if !strings.Contains(errOutput, "verify failed") {
+		t.Errorf("stderr should contain 'verify failed', got:\n%s", errOutput)
+	}
+}
+
+func TestRecoveryVerify_RejectMalformedPubkey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		pubkey string
+	}{
+		{name: "too short", pubkey: "abcdef"},
+		{name: "non-hex chars", pubkey: "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"},
+		{name: "too long", pubkey: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789aa"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := testRoot()
+			root.AddCommand(SigningSubtreeCmd())
+			root.SetArgs([]string{
+				"signing", "recovery", "verify",
+				"--path", "/tmp/dummy.json",
+				"--recovery-pubkey", tc.pubkey,
+				"--pinned-fingerprint", "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			})
+
+			var stderr strings.Builder
+			root.SetOut(&strings.Builder{})
+			root.SetErr(&stderr)
+
+			if err := root.Execute(); err == nil {
+				t.Fatal("expected error for malformed pubkey")
+			}
+
+			errOutput := stderr.String()
+			if !strings.Contains(errOutput, "verify failed") {
+				t.Errorf("stderr should contain 'verify failed', got:\n%s", errOutput)
+			}
+		})
+	}
+}
+
+// --- Transition Verify tests ---
+
+func TestTransitionVerify_HappyPath_WithPin(t *testing.T) {
+	t.Parallel()
+	path, oldPubHex, newPubHex, oldFP := buildTransitionFixture(t)
+
+	root := testRoot()
+	root.AddCommand(SigningSubtreeCmd())
+	root.SetArgs([]string{
+		"signing", "transition", "verify",
+		"--path", path,
+		"--old-pubkey", oldPubHex,
+		"--new-pubkey", newPubHex,
+		"--pinned", oldFP,
+	})
+
+	var stdout strings.Builder
+	root.SetOut(&stdout)
+	root.SetErr(&strings.Builder{})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "transition verified") {
+		t.Errorf("output should contain 'transition verified', got:\n%s", output)
+	}
+	if !strings.Contains(output, string(domsigning.RootKindRoster)) {
+		t.Errorf("output should contain root kind, got:\n%s", output)
+	}
+	if !strings.Contains(output, testSubtreeRTEffective) {
+		t.Errorf("output should contain effective_at, got:\n%s", output)
+	}
+}
+
+func TestTransitionVerify_HappyPath_EmptyPin(t *testing.T) {
+	t.Parallel()
+	path, oldPubHex, newPubHex, _ := buildTransitionFixture(t)
+
+	root := testRoot()
+	root.AddCommand(SigningSubtreeCmd())
+	root.SetArgs([]string{
+		"signing", "transition", "verify",
+		"--path", path,
+		"--old-pubkey", oldPubHex,
+		"--new-pubkey", newPubHex,
+	})
+
+	var stdout strings.Builder
+	root.SetOut(&stdout)
+	root.SetErr(&strings.Builder{})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "transition verified") {
+		t.Errorf("output should contain 'transition verified', got:\n%s", output)
+	}
+}
+
+func TestTransitionVerify_RejectFingerprintMismatch(t *testing.T) {
+	t.Parallel()
+	path, oldPubHex, newPubHex, _ := buildTransitionFixture(t)
+
+	// Use a wrong pinned fingerprint.
+	wrongFP := "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+	root := testRoot()
+	root.AddCommand(SigningSubtreeCmd())
+	root.SetArgs([]string{
+		"signing", "transition", "verify",
+		"--path", path,
+		"--old-pubkey", oldPubHex,
+		"--new-pubkey", newPubHex,
+		"--pinned", wrongFP,
+	})
+
+	var stderr strings.Builder
+	root.SetOut(&strings.Builder{})
+	root.SetErr(&stderr)
+
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected error for fingerprint mismatch")
+	}
+
+	errOutput := stderr.String()
+	if !strings.Contains(errOutput, "verify failed") {
+		t.Errorf("stderr should contain 'verify failed', got:\n%s", errOutput)
+	}
+}
+
+func TestTransitionVerify_RejectMalformedPubkey(t *testing.T) {
+	t.Parallel()
+
+	// Valid 64-char hex key for the side that's not being tested.
+	validHex := "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+
+	tests := []struct {
+		name      string
+		oldPubkey string
+		newPubkey string
+		errText   string
+	}{
+		{
+			name:      "old too short",
+			oldPubkey: "abcdef",
+			newPubkey: validHex,
+			errText:   "invalid old-pubkey",
+		},
+		{
+			name:      "new too short",
+			oldPubkey: validHex,
+			newPubkey: "abcdef",
+			errText:   "invalid new-pubkey",
+		},
+		{
+			name:      "old non-hex",
+			oldPubkey: "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+			newPubkey: validHex,
+			errText:   "invalid old-pubkey",
+		},
+		{
+			name:      "new non-hex",
+			oldPubkey: validHex,
+			newPubkey: "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+			errText:   "invalid new-pubkey",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := testRoot()
+			root.AddCommand(SigningSubtreeCmd())
+			root.SetArgs([]string{
+				"signing", "transition", "verify",
+				"--path", "/tmp/dummy.json",
+				"--old-pubkey", tc.oldPubkey,
+				"--new-pubkey", tc.newPubkey,
+			})
+
+			var stderr strings.Builder
+			root.SetOut(&strings.Builder{})
+			root.SetErr(&stderr)
+
+			if err := root.Execute(); err == nil {
+				t.Fatal("expected error for malformed pubkey")
+			}
+
+			errOutput := stderr.String()
+			if !strings.Contains(errOutput, tc.errText) {
+				t.Errorf("stderr should contain %q, got:\n%s", tc.errText, errOutput)
+			}
+		})
+	}
+}
+
+// --- decodeHexPubkey unit tests ---
+
+func TestDecodeHexPubkey_Valid(t *testing.T) {
+	t.Parallel()
+	b, err := decodeHexPubkey(testSubtreeRosterPubHex)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(b) != ed25519.PublicKeySize {
+		t.Errorf("decoded length = %d, want %d", len(b), ed25519.PublicKeySize)
+	}
+}
+
+func TestDecodeHexPubkey_WrongLength(t *testing.T) {
+	t.Parallel()
+	_, err := decodeHexPubkey("abcdef")
+	if err == nil {
+		t.Fatal("expected error for wrong length")
+	}
+	if !strings.Contains(err.Error(), "64 characters") {
+		t.Errorf("error should mention 64 characters, got: %v", err)
+	}
+}
+
+func TestDecodeHexPubkey_InvalidHex(t *testing.T) {
+	t.Parallel()
+	_, err := decodeHexPubkey("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz")
+	if err == nil {
+		t.Fatal("expected error for invalid hex")
+	}
+	if !strings.Contains(err.Error(), "invalid hex") {
+		t.Errorf("error should mention invalid hex, got: %v", err)
+	}
+}
+
+// --- Help output test ---
+
+func TestSigningSubtree_Help(t *testing.T) {
+	t.Parallel()
+
+	root := testRoot()
+	root.AddCommand(SigningSubtreeCmd())
+	root.SetArgs([]string{"signing", "--help"})
+
+	var stdout strings.Builder
+	root.SetOut(&stdout)
+
+	_ = root.Execute()
+	output := stdout.String()
+
+	for _, sub := range []string{"roster", "recovery", "transition"} {
+		if !strings.Contains(output, sub) {
+			t.Errorf("signing help should list %q subcommand", sub)
+		}
+	}
+}

--- a/internal/cli/signing/signing_subtree_test.go
+++ b/internal/cli/signing/signing_subtree_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -718,6 +719,150 @@ func TestDecodeHexPubkey_InvalidHex(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid hex") {
 		t.Errorf("error should mention invalid hex, got: %v", err)
+	}
+}
+
+// --- Pubkey-file resolution tests ---
+
+// TestReadPubkeyFile_HappyPath confirms a file containing a valid 64-char
+// hex Ed25519 key (with or without trailing whitespace) decodes to 32 raw
+// bytes.
+func TestReadPubkeyFile_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	const validHex = "1111111111111111111111111111111111111111111111111111111111111111"
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"no_trailing_newline", validHex},
+		{"trailing_newline", validHex + "\n"},
+		{"crlf_trailing", validHex + "\r\n"},
+		{"leading_whitespace", "  " + validHex + "\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			p := filepath.Join(dir, "pub.hex")
+			if err := os.WriteFile(p, []byte(tc.content), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			got, err := readPubkeyFile(p)
+			if err != nil {
+				t.Fatalf("readPubkeyFile: %v", err)
+			}
+			if len(got) != 32 {
+				t.Errorf("got %d bytes, want 32", len(got))
+			}
+		})
+	}
+}
+
+// TestReadPubkeyFile_RejectsOversize confirms the size cap fires on any
+// pathologically large input. A 5KB file should not be a public key.
+func TestReadPubkeyFile_RejectsOversize(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "pub.hex")
+	if err := os.WriteFile(p, make([]byte, pubkeyFileMaxSize+1), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := readPubkeyFile(p)
+	if err == nil {
+		t.Fatal("expected size-cap rejection")
+	}
+	if !errors.Is(err, errPubkeyFileTooLarge) {
+		t.Errorf("got %v, want errPubkeyFileTooLarge", err)
+	}
+}
+
+// TestResolvePubkey_FileWinsWhenInlineEmpty proves the file flag is consulted
+// and decoded when the inline flag is empty.
+func TestResolvePubkey_FileWinsWhenInlineEmpty(t *testing.T) {
+	t.Parallel()
+	const validHex = "2222222222222222222222222222222222222222222222222222222222222222"
+	dir := t.TempDir()
+	p := filepath.Join(dir, "pub.hex")
+	if err := os.WriteFile(p, []byte(validHex), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := resolvePubkey("recovery-pubkey", "", p)
+	if err != nil {
+		t.Fatalf("resolvePubkey: %v", err)
+	}
+	if len(got) != 32 {
+		t.Errorf("got %d bytes, want 32", len(got))
+	}
+}
+
+// TestResolvePubkey_BothFlagsSet covers the defense-in-depth rejection of
+// passing both inline + file. cobra's MarkFlagsMutuallyExclusive should catch
+// this at parse time, but the helper is also called from tests that bypass
+// cobra.
+func TestResolvePubkey_BothFlagsSet(t *testing.T) {
+	t.Parallel()
+	const validHex = "3333333333333333333333333333333333333333333333333333333333333333"
+	dir := t.TempDir()
+	p := filepath.Join(dir, "pub.hex")
+	if err := os.WriteFile(p, []byte(validHex), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := resolvePubkey("recovery-pubkey", validHex, p)
+	if err == nil {
+		t.Fatal("expected rejection when both flags are set")
+	}
+	if !strings.Contains(err.Error(), "not both") {
+		t.Errorf("error should mention not both, got: %v", err)
+	}
+}
+
+// TestResolvePubkey_NeitherFlagSet covers the same defense-in-depth case from
+// the empty side. Cobra's MarkFlagsOneRequired should catch this at parse
+// time.
+func TestResolvePubkey_NeitherFlagSet(t *testing.T) {
+	t.Parallel()
+	_, err := resolvePubkey("recovery-pubkey", "", "")
+	if err == nil {
+		t.Fatal("expected rejection when neither flag is set")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Errorf("error should mention required, got: %v", err)
+	}
+}
+
+// --- sanitizeForTerminal tests ---
+
+// TestSanitizeForTerminal_QuotesControlCharacters proves attacker-controlled
+// fields with newlines, escape sequences, and ANSI control bytes render as a
+// quoted Go literal rather than landing raw on stdout.
+func TestSanitizeForTerminal_QuotesControlCharacters(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		in           string
+		mustNotEqual string
+	}{
+		{"newline_injection", "line1\nFAKE: verified", "line1\nFAKE: verified"},
+		{"ansi_escape", "\x1b[31mred", "\x1b[31mred"},
+		{"carriage_return", "before\rafter", "before\rafter"},
+		{"null_byte", "before\x00after", "before\x00after"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := sanitizeForTerminal(tc.in)
+			if got == tc.mustNotEqual {
+				t.Errorf("sanitizeForTerminal returned raw input %q", got)
+			}
+			if !strings.HasPrefix(got, `"`) || !strings.HasSuffix(got, `"`) {
+				t.Errorf("expected quoted form, got %q", got)
+			}
+			if strings.ContainsAny(got, "\n\r\x00\x1b") {
+				t.Errorf("sanitized output still contains control chars: %q", got)
+			}
+		})
 	}
 }
 

--- a/internal/contract/load_yaml.go
+++ b/internal/contract/load_yaml.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contract
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DecodeStrictYAML decodes raw YAML into target with the same strictness as
+// DecodeStrictJSON. The pipeline is YAML -> generic tree -> JSON -> typed struct,
+// intentionally reusing DecodeStrictJSON so that JSON and YAML transports share
+// one typed-boundary bug surface.
+//
+// YAML-layer rejections come from [ParseYAMLStrict]:
+//   - [ErrYAMLDuplicateKey]: duplicate mapping keys
+//   - [ErrYAMLAliasOrAnchor]: anchors or aliases
+//   - [ErrYAMLMergeKey]: merge keys (<<:)
+//   - [ErrYAMLCustomTag]: non-core tags
+//   - [ErrYAMLMultiDoc]: multi-document streams
+//
+// Typed-layer rejections come from [DecodeStrictJSON]:
+//   - [ErrUnknownField]: fields not in the target struct
+//   - [ErrEmptyPayload]: empty or null input
+//   - [ErrTrailingTokens]: trailing tokens after the JSON value (should not
+//     occur through this pipeline since json.Marshal produces clean output,
+//     but the check is inherited from DecodeStrictJSON for defense in depth)
+func DecodeStrictYAML(raw []byte, target any) error {
+	if len(raw) == 0 {
+		return ErrEmptyPayload
+	}
+
+	tree, err := ParseYAMLStrict(raw)
+	if err != nil {
+		return fmt.Errorf("yaml strict decode: %w", err)
+	}
+	if tree == nil {
+		return ErrEmptyPayload
+	}
+
+	jsonBytes, err := json.Marshal(tree)
+	if err != nil {
+		return fmt.Errorf("yaml strict decode: marshal to JSON: %w", err)
+	}
+
+	if err := DecodeStrictJSON(jsonBytes, target); err != nil {
+		return fmt.Errorf("yaml strict decode: %w", err)
+	}
+	return nil
+}
+
+// LoadContractYAML parses raw YAML into a Contract using DecodeStrictYAML.
+// Unknown fields, YAML-layer violations, and empty/null payloads reject.
+func LoadContractYAML(raw []byte) (Contract, error) {
+	var c Contract
+	if err := DecodeStrictYAML(raw, &c); err != nil {
+		return Contract{}, fmt.Errorf("load contract yaml: %w", err)
+	}
+	return c, nil
+}
+
+// LoadKeyRosterYAML parses raw YAML into a KeyRoster using DecodeStrictYAML.
+// Unknown fields, YAML-layer violations, and empty/null payloads reject.
+func LoadKeyRosterYAML(raw []byte) (KeyRoster, error) {
+	var r KeyRoster
+	if err := DecodeStrictYAML(raw, &r); err != nil {
+		return KeyRoster{}, fmt.Errorf("load key_roster yaml: %w", err)
+	}
+	return r, nil
+}
+
+// LoadTombstoneYAML parses raw YAML into a Tombstone using DecodeStrictYAML.
+// Unknown fields, YAML-layer violations, and empty/null payloads reject.
+func LoadTombstoneYAML(raw []byte) (Tombstone, error) {
+	var t Tombstone
+	if err := DecodeStrictYAML(raw, &t); err != nil {
+		return Tombstone{}, fmt.Errorf("load tombstone yaml: %w", err)
+	}
+	return t, nil
+}

--- a/internal/contract/load_yaml_test.go
+++ b/internal/contract/load_yaml_test.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contract
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDecodeStrictYAML_HappyPath(t *testing.T) {
+	t.Parallel()
+	raw := []byte("schema_version: 1\nroster_signed_by: root-key\nkeys: []\ndata_class_root: internal\n")
+	var r KeyRoster
+	if err := DecodeStrictYAML(raw, &r); err != nil {
+		t.Fatalf("DecodeStrictYAML: %v", err)
+	}
+	if r.SchemaVersion != 1 {
+		t.Errorf("SchemaVersion = %d, want 1", r.SchemaVersion)
+	}
+	if r.RosterSignedBy != "root-key" {
+		t.Errorf("RosterSignedBy = %q, want %q", r.RosterSignedBy, "root-key")
+	}
+}
+
+func TestDecodeStrictYAML_RejectsNilAndEmpty(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		raw  []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var r KeyRoster
+			if err := DecodeStrictYAML(tc.raw, &r); !errors.Is(err, ErrEmptyPayload) {
+				t.Errorf("got %v, want ErrEmptyPayload", err)
+			}
+		})
+	}
+}
+
+func TestDecodeStrictYAML_RejectsNullTree(t *testing.T) {
+	t.Parallel()
+	// ParseYAMLStrict returns nil for empty YAML documents (just whitespace/comments).
+	// DecodeStrictYAML treats a nil tree as ErrEmptyPayload.
+	raw := []byte("# just a comment\n")
+	var r KeyRoster
+	if err := DecodeStrictYAML(raw, &r); !errors.Is(err, ErrEmptyPayload) {
+		t.Errorf("got %v, want ErrEmptyPayload", err)
+	}
+}
+
+func TestDecodeStrictYAML_RejectsUnknownField(t *testing.T) {
+	t.Parallel()
+	raw := []byte("schema_version: 1\nroster_signed_by: root-key\nkeys: []\ndata_class_root: internal\nextra_field: sneaky\n")
+	var r KeyRoster
+	if err := DecodeStrictYAML(raw, &r); !errors.Is(err, ErrUnknownField) {
+		t.Errorf("got %v, want ErrUnknownField", err)
+	}
+}
+
+func TestDecodeStrictYAML_RejectsYAMLLayerViolations(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		fixture string
+		wantErr error
+	}{
+		{"duplicate key", "duplicate_key.yaml", ErrYAMLDuplicateKey},
+		{"anchor", "yaml_anchor.yaml", ErrYAMLAliasOrAnchor},
+		{"alias", "yaml_alias.yaml", ErrYAMLAliasOrAnchor},
+		{"merge key", "yaml_merge_key.yaml", ErrYAMLMergeKey},
+		{"custom tag", "yaml_custom_tag.yaml", ErrYAMLCustomTag},
+		{"multi-doc", "yaml_multi_doc.yaml", ErrYAMLMultiDoc},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join("testdata", "invalid", tc.fixture)
+			b, err := os.ReadFile(filepath.Clean(path))
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+			var r KeyRoster
+			if err := DecodeStrictYAML(b, &r); !errors.Is(err, tc.wantErr) {
+				t.Errorf("got %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadContractYAML_HappyPath(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`schema_version: 1
+contract_kind: behavioral_contract
+contract_hash: ""
+signer_key_id: ""
+key_purpose: ""
+data_class_root: internal
+field_data_classes: {}
+selector:
+  selector_id: ""
+observation_window:
+  start: "0001-01-01T00:00:00Z"
+  end: "0001-01-01T00:00:00Z"
+  event_count: 0
+  session_count: 0
+  observation_window_root: ""
+compile:
+  pipelock_version: ""
+  pipelock_build_sha: ""
+  go_version: ""
+  module_digest_root: ""
+  compile_config_hash: ""
+  inference_algorithm: ""
+  normalization_algorithm: ""
+defaults:
+  fidelity: ""
+  confidence: null
+  privacy:
+    default_data_class: ""
+    salt_epoch: 0
+    forbid_classes: null
+rules: null
+`)
+	c, err := LoadContractYAML(raw)
+	if err != nil {
+		t.Fatalf("LoadContractYAML: %v", err)
+	}
+	if c.SchemaVersion != 1 {
+		t.Errorf("SchemaVersion = %d, want 1", c.SchemaVersion)
+	}
+	if c.ContractKind != "behavioral_contract" {
+		t.Errorf("ContractKind = %q, want %q", c.ContractKind, "behavioral_contract")
+	}
+}
+
+func TestLoadContractYAML_RejectsUnknownField(t *testing.T) {
+	t.Parallel()
+	raw := []byte("schema_version: 1\ncontract_kind: behavioral_contract\nfuture_field: sneaky\n")
+	_, err := LoadContractYAML(raw)
+	if !errors.Is(err, ErrUnknownField) {
+		t.Errorf("got %v, want ErrUnknownField wrapped", err)
+	}
+}
+
+func TestLoadKeyRosterYAML_HappyPath(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`schema_version: 1
+roster_signed_by: root-key
+keys:
+  - key_id: root-key
+    key_purpose: roster-signing
+    public_key_hex: deadbeef
+    valid_from: "2026-01-01T00:00:00Z"
+    status: root
+data_class_root: internal
+`)
+	r, err := LoadKeyRosterYAML(raw)
+	if err != nil {
+		t.Fatalf("LoadKeyRosterYAML: %v", err)
+	}
+	if r.SchemaVersion != 1 {
+		t.Errorf("SchemaVersion = %d, want 1", r.SchemaVersion)
+	}
+	if r.RosterSignedBy != "root-key" {
+		t.Errorf("RosterSignedBy = %q, want %q", r.RosterSignedBy, "root-key")
+	}
+	if len(r.Keys) != 1 {
+		t.Errorf("len(Keys) = %d, want 1", len(r.Keys))
+	}
+}
+
+func TestLoadKeyRosterYAML_RejectsUnknownField(t *testing.T) {
+	t.Parallel()
+	raw := []byte("schema_version: 1\nroster_signed_by: root-key\nkeys: []\ndata_class_root: internal\nextra: x\n")
+	_, err := LoadKeyRosterYAML(raw)
+	if !errors.Is(err, ErrUnknownField) {
+		t.Errorf("got %v, want ErrUnknownField wrapped", err)
+	}
+}
+
+func TestLoadTombstoneYAML_HappyPath(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`schema_version: 1
+tombstone: true
+prior_contract_hash: abc123
+redacted_at: "2026-04-26T00:00:00Z"
+redaction_authorization_id: auth-1
+signer_key_id: key-1
+key_purpose: contract-activation-signing
+data_class_root: internal
+`)
+	ts, err := LoadTombstoneYAML(raw)
+	if err != nil {
+		t.Fatalf("LoadTombstoneYAML: %v", err)
+	}
+	if ts.SchemaVersion != 1 {
+		t.Errorf("SchemaVersion = %d, want 1", ts.SchemaVersion)
+	}
+	if !ts.Tombstone {
+		t.Error("Tombstone = false, want true")
+	}
+	if ts.PriorContractHash != "abc123" {
+		t.Errorf("PriorContractHash = %q, want %q", ts.PriorContractHash, "abc123")
+	}
+}
+
+func TestLoadTombstoneYAML_RejectsUnknownField(t *testing.T) {
+	t.Parallel()
+	raw := []byte("schema_version: 1\ntombstone: true\nsurplus: yes\n")
+	_, err := LoadTombstoneYAML(raw)
+	if !errors.Is(err, ErrUnknownField) {
+		t.Errorf("got %v, want ErrUnknownField wrapped", err)
+	}
+}

--- a/internal/signing/fingerprint.go
+++ b/internal/signing/fingerprint.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// FingerprintAlgorithm is the prefix used for all key fingerprints in
+// pipelock signed artifacts.
+const FingerprintAlgorithm = "sha256"
+
+// fingerprintAlgorithmPrefix is the canonical wire prefix for fingerprint
+// strings: "sha256:".
+const fingerprintAlgorithmPrefix = FingerprintAlgorithm + ":"
+
+// sha256DigestHexLen is the expected length of a SHA-256 digest in lowercase
+// hex encoding: 32 bytes = 64 hex characters.
+const sha256DigestHexLen = 64
+
+// Sentinel errors for fingerprint operations.
+var (
+	// ErrFingerprintMismatch indicates that a fingerprint comparison failed.
+	ErrFingerprintMismatch = errors.New("fingerprint mismatch")
+
+	// ErrFingerprintFormat indicates that a fingerprint string is malformed:
+	// missing prefix, wrong algorithm, bad hex, or wrong digest length.
+	ErrFingerprintFormat = errors.New("malformed fingerprint")
+
+	// ErrFingerprintLength indicates that the public key input has the wrong
+	// byte length (expected exactly ed25519.PublicKeySize = 32 bytes).
+	ErrFingerprintLength = errors.New("invalid public key length for fingerprint")
+)
+
+// Fingerprint returns the canonical pipelock key fingerprint for an Ed25519
+// public key.
+//
+// Format (locked):
+//
+//	"sha256:" + lowercase hex of sha256 over the raw 32-byte public key
+//
+// The preimage is the raw 32-byte Ed25519 public key. NEVER hash hex text.
+// NEVER hash an encoded form.
+//
+// Cross-implementation: the Python verifier computes the same value byte for
+// byte. Changing this format requires a roster schema_version bump.
+//
+// Returns ErrFingerprintLength if pubKey is not exactly ed25519.PublicKeySize
+// (32) bytes long. The function does not panic on malformed input.
+func Fingerprint(pubKey []byte) (string, error) {
+	if len(pubKey) != ed25519.PublicKeySize {
+		return "", fmt.Errorf("%w: got %d bytes, want %d",
+			ErrFingerprintLength, len(pubKey), ed25519.PublicKeySize)
+	}
+	digest := sha256.Sum256(pubKey)
+	return fingerprintAlgorithmPrefix + hex.EncodeToString(digest[:]), nil
+}
+
+// ParseFingerprint splits a fingerprint string into algorithm and lowercase
+// hex digest.
+//
+// Returns ErrFingerprintFormat for:
+//   - missing ":" separator
+//   - empty algorithm or empty digest
+//   - unknown algorithm (only "sha256" is accepted)
+//   - non-hex characters in the digest
+//   - wrong digest length (sha256 = 32 bytes = 64 hex chars)
+//
+// Uppercase hex is accepted on input but the returned hex is always lowercase.
+func ParseFingerprint(s string) (algorithm, hexDigest string, err error) {
+	idx := strings.IndexByte(s, ':')
+	if idx < 0 {
+		return "", "", fmt.Errorf("%w: missing algorithm prefix", ErrFingerprintFormat)
+	}
+
+	algorithm = s[:idx]
+	hexDigest = s[idx+1:]
+
+	if algorithm == "" {
+		return "", "", fmt.Errorf("%w: empty algorithm", ErrFingerprintFormat)
+	}
+	if hexDigest == "" {
+		return "", "", fmt.Errorf("%w: empty digest", ErrFingerprintFormat)
+	}
+	if algorithm != FingerprintAlgorithm {
+		return "", "", fmt.Errorf("%w: unsupported algorithm %q", ErrFingerprintFormat, algorithm)
+	}
+
+	// Validate hex encoding by attempting decode.
+	digestBytes, decErr := hex.DecodeString(hexDigest)
+	if decErr != nil {
+		return "", "", fmt.Errorf("%w: invalid hex in digest: %w", ErrFingerprintFormat, decErr)
+	}
+
+	if len(digestBytes) != sha256.Size {
+		return "", "", fmt.Errorf("%w: digest length %d hex chars, want %d",
+			ErrFingerprintFormat, len(hexDigest), sha256DigestHexLen)
+	}
+
+	// Normalize to lowercase (hex.EncodeToString always returns lowercase).
+	hexDigest = hex.EncodeToString(digestBytes)
+
+	return algorithm, hexDigest, nil
+}
+
+// VerifyFingerprint computes Fingerprint(pubKey) and compares it to expected
+// in constant time on the digest bytes. Returns nil on match.
+//
+// On mismatch returns ErrFingerprintMismatch. On invalid input (bad expected
+// format or wrong pubKey length) returns the underlying ErrFingerprintFormat /
+// ErrFingerprintLength.
+//
+// Constant-time comparison (crypto/subtle.ConstantTimeCompare) defends against
+// fingerprint-oracle timing attacks when expected is operator-controlled. An
+// attacker with repeated verify attempts could otherwise learn the fingerprint
+// byte-by-byte from early-exit comparison timing.
+func VerifyFingerprint(pubKey []byte, expected string) error {
+	_, expectedHex, err := ParseFingerprint(expected)
+	if err != nil {
+		return err
+	}
+
+	computed, err := Fingerprint(pubKey)
+	if err != nil {
+		return err
+	}
+
+	// Extract the hex portion of the computed fingerprint for comparison.
+	// We know the format is valid because Fingerprint succeeded.
+	computedHex := computed[len(fingerprintAlgorithmPrefix):]
+
+	// Decode both hex strings to raw bytes for constant-time comparison.
+	// Both are validated hex at this point, so errors are impossible.
+	expectedBytes, _ := hex.DecodeString(expectedHex)
+	computedBytes, _ := hex.DecodeString(computedHex)
+
+	if subtle.ConstantTimeCompare(expectedBytes, computedBytes) != 1 {
+		return fmt.Errorf("%w: got %s, want %s", ErrFingerprintMismatch, computed, expected)
+	}
+	return nil
+}

--- a/internal/signing/fingerprint_test.go
+++ b/internal/signing/fingerprint_test.go
@@ -1,0 +1,235 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// RFC 8032 section 7.1 test vector 1 seed (split for G101 lint).
+const rfcTestSeedHex = "9d61b19d" + "effd5a60" + "ba844af4" + "92ec2cc4" +
+	"4449c569" + "7b326919" + "703bac03" + "1cae7f60"
+
+// rfcTestPubKeyHex is the public key derived from the RFC 8032 test seed.
+const rfcTestPubKeyHex = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+
+// rfcTestPubFingerprint is the expected fingerprint of the RFC 8032 test
+// public key. Computed: sha256 over the raw 32-byte public key bytes.
+// Cross-impl pinning: if the Python verifier disagrees, this test fails first.
+const rfcTestPubFingerprint = "sha256:21fe31dfa154a261626bf854046fd2271b7bed4b6abe45aa58877ef47f9721b9"
+
+func rfcTestPubKey(t *testing.T) ed25519.PublicKey {
+	t.Helper()
+	seed, err := hex.DecodeString(rfcTestSeedHex)
+	if err != nil {
+		t.Fatalf("decoding RFC test seed: %v", err)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	return priv.Public().(ed25519.PublicKey)
+}
+
+func TestFingerprint_HappyPath(t *testing.T) {
+	pub := rfcTestPubKey(t)
+
+	// Sanity: the public key matches the known hex.
+	if got := hex.EncodeToString(pub); got != rfcTestPubKeyHex {
+		t.Fatalf("RFC test pubkey mismatch: got %s, want %s", got, rfcTestPubKeyHex)
+	}
+
+	fp, err := Fingerprint(pub)
+	if err != nil {
+		t.Fatalf("Fingerprint() error: %v", err)
+	}
+
+	// Primary assertion: computed fingerprint matches hardcoded golden vector.
+	if fp != rfcTestPubFingerprint {
+		t.Fatalf("Fingerprint() = %q, want %q", fp, rfcTestPubFingerprint)
+	}
+
+	// Secondary assertion: deterministic — calling again yields same result.
+	fp2, err := Fingerprint(pub)
+	if err != nil {
+		t.Fatalf("Fingerprint() second call error: %v", err)
+	}
+	if fp != fp2 {
+		t.Fatalf("Fingerprint() not deterministic: %q != %q", fp, fp2)
+	}
+}
+
+func TestFingerprint_RejectsWrongLength(t *testing.T) {
+	tests := []struct {
+		name string
+		key  []byte
+	}{
+		{name: "empty", key: []byte{}},
+		{name: "31_bytes", key: make([]byte, 31)},
+		{name: "33_bytes", key: make([]byte, 33)},
+		{name: "64_bytes_private_key_sized", key: make([]byte, 64)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fp, err := Fingerprint(tt.key)
+			if !errors.Is(err, ErrFingerprintLength) {
+				t.Fatalf("Fingerprint(%d bytes) error = %v, want ErrFingerprintLength", len(tt.key), err)
+			}
+			if fp != "" {
+				t.Fatalf("Fingerprint(%d bytes) = %q, want empty string", len(tt.key), fp)
+			}
+		})
+	}
+}
+
+func TestParseFingerprint_HappyPath(t *testing.T) {
+	algo, hexDigest, err := ParseFingerprint(rfcTestPubFingerprint)
+	if err != nil {
+		t.Fatalf("ParseFingerprint() error: %v", err)
+	}
+	if algo != FingerprintAlgorithm {
+		t.Errorf("algorithm = %q, want %q", algo, FingerprintAlgorithm)
+	}
+
+	// Extract expected hex from the golden constant.
+	wantHex := rfcTestPubFingerprint[len(fingerprintAlgorithmPrefix):]
+	if hexDigest != wantHex {
+		t.Errorf("hexDigest = %q, want %q", hexDigest, wantHex)
+	}
+}
+
+func TestParseFingerprint_Rejects(t *testing.T) {
+	// Valid 64-char hex digest for reuse in test cases.
+	validHex := "21fe31dfa154a261626bf854046fd2271b7bed4b6abe45aa58877ef47f9721b9"
+	// Uppercase variant of the same digest.
+	upperHex := strings.ToUpper(validHex)
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "missing_prefix", input: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},
+		{name: "wrong_algorithm", input: "sha512:" + validHex},
+		{name: "empty_algorithm", input: ":" + validHex},
+		{name: "empty_digest", input: "sha256:"},
+		{name: "non_hex_digest", input: "sha256:gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg"},
+		{name: "truncated_digest", input: "sha256:21fe31dfa154a261"},
+		{name: "extended_digest", input: "sha256:" + validHex + "deadbeef"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := ParseFingerprint(tt.input)
+			if !errors.Is(err, ErrFingerprintFormat) {
+				t.Fatalf("ParseFingerprint(%q) error = %v, want ErrFingerprintFormat", tt.input, err)
+			}
+		})
+	}
+
+	// Special case: uppercase hex IS accepted and normalized to lowercase.
+	t.Run("uppercase_hex_normalized", func(t *testing.T) {
+		algo, hexDigest, err := ParseFingerprint("sha256:" + upperHex)
+		if err != nil {
+			t.Fatalf("ParseFingerprint(uppercase) error: %v", err)
+		}
+		if algo != FingerprintAlgorithm {
+			t.Errorf("algorithm = %q, want %q", algo, FingerprintAlgorithm)
+		}
+		if hexDigest != validHex {
+			t.Errorf("hexDigest = %q, want normalized lowercase %q", hexDigest, validHex)
+		}
+		if hexDigest == upperHex {
+			t.Error("uppercase hex was not normalized to lowercase")
+		}
+	})
+}
+
+func TestVerifyFingerprint(t *testing.T) {
+	pub := rfcTestPubKey(t)
+
+	// Build a one-byte-different public key for the mismatch test.
+	diffPub := make([]byte, ed25519.PublicKeySize)
+	copy(diffPub, pub)
+	diffPub[0] ^= 0xff
+
+	tests := []struct {
+		name      string
+		pubKey    []byte
+		expected  string
+		wantErr   error
+		wantNilOK bool
+	}{
+		{
+			name:      "happy_path_matches",
+			pubKey:    pub,
+			expected:  rfcTestPubFingerprint,
+			wantNilOK: true,
+		},
+		{
+			name:     "one_byte_different_pubkey",
+			pubKey:   diffPub,
+			expected: rfcTestPubFingerprint,
+			wantErr:  ErrFingerprintMismatch,
+		},
+		{
+			name:     "wrong_format_expected",
+			pubKey:   pub,
+			expected: "not-a-fingerprint",
+			wantErr:  ErrFingerprintFormat,
+		},
+		{
+			name:     "wrong_length_pubkey",
+			pubKey:   []byte("short"),
+			expected: rfcTestPubFingerprint,
+			wantErr:  ErrFingerprintLength,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := VerifyFingerprint(tt.pubKey, tt.expected)
+			if tt.wantNilOK {
+				if err != nil {
+					t.Fatalf("VerifyFingerprint() error = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("VerifyFingerprint() error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFingerprint_DocumentedFormat(t *testing.T) {
+	pub := rfcTestPubKey(t)
+	fp, err := Fingerprint(pub)
+	if err != nil {
+		t.Fatalf("Fingerprint() error: %v", err)
+	}
+
+	// Must start with "sha256:" prefix.
+	if !strings.HasPrefix(fp, fingerprintAlgorithmPrefix) {
+		t.Fatalf("fingerprint %q missing prefix %q", fp, fingerprintAlgorithmPrefix)
+	}
+
+	hexPart := fp[len(fingerprintAlgorithmPrefix):]
+
+	// Hex part must be exactly 64 characters (sha256 = 32 bytes = 64 hex chars).
+	if len(hexPart) != sha256DigestHexLen {
+		t.Fatalf("hex part length = %d, want %d", len(hexPart), sha256DigestHexLen)
+	}
+
+	// Must be all lowercase hex.
+	if hexPart != strings.ToLower(hexPart) {
+		t.Fatalf("hex part contains uppercase characters: %q", hexPart)
+	}
+
+	// Must decode as valid hex.
+	if _, err := hex.DecodeString(hexPart); err != nil {
+		t.Fatalf("hex part is not valid hex: %v", err)
+	}
+}

--- a/internal/signing/golden_vectors_test.go
+++ b/internal/signing/golden_vectors_test.go
@@ -115,11 +115,16 @@ func goldenFingerprint(t *testing.T, pub ed25519.PublicKey) string {
 // --- Golden fixture constants ---
 
 const (
-	goldenRecoveryIssuedAt   = "2026-04-26T13:00:00Z"
-	goldenRecoveryExpiresAt  = "2026-04-26T13:30:00Z"
-	goldenRecoveryReason     = "roster root key compromised"
-	goldenRecoveryOperator   = "ops@example.com"
-	goldenRecoveryTargetHash = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	goldenRecoveryIssuedAt  = "2026-04-26T13:00:00Z"
+	goldenRecoveryExpiresAt = "2026-04-26T13:30:00Z"
+	goldenRecoveryReason    = "roster root key compromised"
+	goldenRecoveryOperator  = "ops@example.com"
+	// Deterministic stand-in for a real roster body hash, fixed at the
+	// digest of a constant string. Conformance fixtures need a non-zero
+	// value so the target-roster-hash binding gate exercises a real
+	// comparison instead of trivially matching the all-zero default.
+	// Computed from sha256("pipelock-test-recovery-target-roster-body-fixture").
+	goldenRecoveryTargetHash = "sha256:d0936185ee07c30a681e5beb49ef01899744df04bef122596467d9aa8ef24f7d"
 
 	goldenRTReason      = "scheduled annual key rotation"
 	goldenRTEffectiveAt = "2026-04-26T15:00:00Z"
@@ -281,7 +286,7 @@ func TestGolden_AllFixturesParseAndValidate(t *testing.T) {
 		}
 
 		path := filepath.Join(goldenDirRel, "valid_recovery_authorization.json")
-		loaded, loadErr := LoadRecoveryAuthorization(path, pub, fp, now)
+		loaded, loadErr := LoadRecoveryAuthorization(path, pub, fp, "", now)
 		if loadErr != nil {
 			t.Fatalf("LoadRecoveryAuthorization: %v", loadErr)
 		}

--- a/internal/signing/golden_vectors_test.go
+++ b/internal/signing/golden_vectors_test.go
@@ -285,10 +285,14 @@ func TestGolden_AllFixturesParseAndValidate(t *testing.T) {
 			t.Fatalf("parse now: %v", err)
 		}
 
+		// Use the offline-inspection entry point: this golden test verifies
+		// the envelope's signature and structural validity without binding
+		// to a particular target roster body, which mirrors the offline
+		// ceremony review use case.
 		path := filepath.Join(goldenDirRel, "valid_recovery_authorization.json")
-		loaded, loadErr := LoadRecoveryAuthorization(path, pub, fp, "", now)
+		loaded, loadErr := InspectRecoveryAuthorizationOffline(path, pub, fp, now)
 		if loadErr != nil {
-			t.Fatalf("LoadRecoveryAuthorization: %v", loadErr)
+			t.Fatalf("InspectRecoveryAuthorizationOffline: %v", loadErr)
 		}
 		if loaded.Body.Reason != goldenRecoveryReason {
 			t.Errorf("reason = %q, want %q", loaded.Body.Reason, goldenRecoveryReason)

--- a/internal/signing/golden_vectors_test.go
+++ b/internal/signing/golden_vectors_test.go
@@ -1,0 +1,323 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// --- Golden test infrastructure ---
+
+// goldenUpdateMode returns true when golden fixture files should be
+// (re)written to disk rather than compared. Set via UPDATE_GOLDEN=1.
+func goldenUpdateMode() bool {
+	return os.Getenv("UPDATE_GOLDEN") == "1"
+}
+
+// goldenWriteOrAssert either writes body to path (UPDATE_GOLDEN=1) or
+// reads the file at path and asserts byte-identical content.
+func goldenWriteOrAssert(t *testing.T, path string, body []byte) {
+	t.Helper()
+	if goldenUpdateMode() {
+		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(path, body, 0o600); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		return
+	}
+	got, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read golden %s: %v", path, err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("%s drift\n--- expected\n%s\n--- got\n%s", path, got, body)
+	}
+}
+
+// --- Deterministic keypairs ---
+
+// goldenRecoveryRootSeedHex is a deterministic Ed25519 seed for the
+// recovery-root keypair used in golden fixtures. Split per G101 lint rule.
+const goldenRecoveryRootSeedHex = "" +
+	"4ccd089b" + "28ff96da" + "9db6c346" + "ec114e0f" +
+	"5b8a319f" + "35aba624" + "da8cf6ed" + "4fb8a6fb"
+
+// goldenNewRootSeedHex is a deterministic Ed25519 seed for the new-root
+// keypair in root-transition fixtures. One byte flipped vs the recovery
+// seed to produce an independent key. Split per G101 lint rule.
+const goldenNewRootSeedHex = "" +
+	"4ccd089b" + "28ff96da" + "9db6c346" + "ec114e0f" +
+	"5b8a319f" + "35aba624" + "da8cf6ed" + "4fb8a6fc"
+
+// goldenOldRootSeedHex is a deterministic Ed25519 seed for the old-root
+// keypair in root-transition fixtures. Uses the RFC 8032 section 7.1 test 1
+// vector seed (same as the contract package golden tests). Split per G101.
+const goldenOldRootSeedHex = "" +
+	"9d61b19d" + "effd5a60" + "ba844af4" + "92ec2cc4" +
+	"4449c569" + "7b326919" + "703bac03" + "1cae7f60"
+
+// goldenKeyFromSeed derives an Ed25519 private key from a hex-encoded seed.
+func goldenKeyFromSeed(t *testing.T, seedHex string) ed25519.PrivateKey {
+	t.Helper()
+	seed, err := hex.DecodeString(seedHex)
+	if err != nil {
+		t.Fatalf("decode seed: %v", err)
+	}
+	if len(seed) != ed25519.SeedSize {
+		t.Fatalf("seed length: got %d want %d", len(seed), ed25519.SeedSize)
+	}
+	return ed25519.NewKeyFromSeed(seed)
+}
+
+// goldenRecoveryRootKey returns the deterministic recovery-root keypair.
+func goldenRecoveryRootKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	return goldenKeyFromSeed(t, goldenRecoveryRootSeedHex)
+}
+
+// goldenNewRootKey returns the deterministic new-root keypair for
+// root-transition fixtures.
+func goldenNewRootKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	return goldenKeyFromSeed(t, goldenNewRootSeedHex)
+}
+
+// goldenOldRootKey returns the deterministic old-root keypair for
+// root-transition fixtures (RFC 8032 test 1 seed).
+func goldenOldRootKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	return goldenKeyFromSeed(t, goldenOldRootSeedHex)
+}
+
+// signEd25519Hex signs preimage with key and returns "ed25519:" + hex(sig).
+func goldenSignEd25519Hex(key ed25519.PrivateKey, preimage []byte) string {
+	sig := ed25519.Sign(key, preimage)
+	return "ed25519:" + hex.EncodeToString(sig)
+}
+
+// goldenFingerprint computes the canonical fingerprint for an Ed25519 public key.
+func goldenFingerprint(t *testing.T, pub ed25519.PublicKey) string {
+	t.Helper()
+	digest := sha256.Sum256(pub)
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+// --- Golden fixture constants ---
+
+const (
+	goldenRecoveryIssuedAt   = "2026-04-26T13:00:00Z"
+	goldenRecoveryExpiresAt  = "2026-04-26T13:30:00Z"
+	goldenRecoveryReason     = "roster root key compromised"
+	goldenRecoveryOperator   = "ops@example.com"
+	goldenRecoveryTargetHash = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+	goldenRTReason      = "scheduled annual key rotation"
+	goldenRTEffectiveAt = "2026-04-26T15:00:00Z"
+
+	goldenDirRel = "testdata/golden"
+)
+
+// --- Per-artifact golden round-trip tests ---
+
+func TestGolden_RecoveryAuthorization(t *testing.T) {
+	t.Parallel()
+	priv := goldenRecoveryRootKey(t)
+	pub := priv.Public().(ed25519.PublicKey)
+
+	body := RecoveryAuthorizationBody{
+		SchemaVersion:    1,
+		Reason:           goldenRecoveryReason,
+		ExpiresAt:        goldenRecoveryExpiresAt,
+		TargetRosterHash: goldenRecoveryTargetHash,
+		OperatorIdentity: goldenRecoveryOperator,
+		IssuedAt:         goldenRecoveryIssuedAt,
+	}
+
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("preimage: %v", err)
+	}
+
+	envelope := RecoveryAuthorizationEnvelope{
+		Body:      body,
+		Signature: goldenSignEd25519Hex(priv, preimage),
+	}
+
+	data, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	data = append(data, '\n')
+
+	outPath := filepath.Join(goldenDirRel, "valid_recovery_authorization.json")
+	goldenWriteOrAssert(t, outPath, data)
+
+	// Read-back verification: decode, recompute preimage, verify signature.
+	raw, err := os.ReadFile(filepath.Clean(outPath))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var got RecoveryAuthorizationEnvelope
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	gotPre, err := got.Body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("verify preimage: %v", err)
+	}
+	if string(gotPre) != string(preimage) {
+		t.Error("preimage drift on read-back")
+	}
+
+	sigBytes, sigErr := parseSignature(got.Signature)
+	if sigErr != nil {
+		t.Fatalf("parse signature: %v", sigErr)
+	}
+	if !ed25519.Verify(pub, gotPre, sigBytes) {
+		t.Error("signature verify failed on golden recovery_authorization")
+	}
+}
+
+func TestGolden_RootTransition(t *testing.T) {
+	t.Parallel()
+	oldPriv := goldenOldRootKey(t)
+	oldPub := oldPriv.Public().(ed25519.PublicKey)
+	newPriv := goldenNewRootKey(t)
+	newPub := newPriv.Public().(ed25519.PublicKey)
+
+	oldFP := goldenFingerprint(t, oldPub)
+	newFP := goldenFingerprint(t, newPub)
+
+	body := RootTransitionBody{
+		SchemaVersion:  1,
+		RootKind:       RootKindRoster,
+		OldFingerprint: oldFP,
+		NewFingerprint: newFP,
+		EffectiveAt:    goldenRTEffectiveAt,
+		Reason:         goldenRTReason,
+	}
+
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("preimage: %v", err)
+	}
+
+	envelope := RootTransitionEnvelope{
+		Body:         body,
+		OldSignature: goldenSignEd25519Hex(oldPriv, preimage),
+		NewSignature: goldenSignEd25519Hex(newPriv, preimage),
+	}
+
+	data, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	data = append(data, '\n')
+
+	outPath := filepath.Join(goldenDirRel, "valid_root_transition.json")
+	goldenWriteOrAssert(t, outPath, data)
+
+	// Read-back verification: decode, recompute preimage, verify both sigs.
+	raw, err := os.ReadFile(filepath.Clean(outPath))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var got RootTransitionEnvelope
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	gotPre, err := got.Body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("verify preimage: %v", err)
+	}
+	if string(gotPre) != string(preimage) {
+		t.Error("preimage drift on read-back")
+	}
+
+	oldSigBytes, err := parseSignature(got.OldSignature)
+	if err != nil {
+		t.Fatalf("parse old_signature: %v", err)
+	}
+	if !ed25519.Verify(oldPub, gotPre, oldSigBytes) {
+		t.Error("old_signature verify failed on golden root_transition")
+	}
+
+	newSigBytes, err := parseSignature(got.NewSignature)
+	if err != nil {
+		t.Fatalf("parse new_signature: %v", err)
+	}
+	if !ed25519.Verify(newPub, gotPre, newSigBytes) {
+		t.Error("new_signature verify failed on golden root_transition")
+	}
+}
+
+func TestGolden_AllFixturesParseAndValidate(t *testing.T) {
+	if goldenUpdateMode() {
+		t.Skip("skipped in UPDATE_GOLDEN mode; individual tests write and verify")
+	}
+
+	// Recovery authorization: load via the public API with deterministic
+	// time inside the validity window.
+	t.Run("recovery_authorization", func(t *testing.T) {
+		priv := goldenRecoveryRootKey(t)
+		pub := priv.Public().(ed25519.PublicKey)
+		fp := goldenFingerprint(t, pub)
+
+		// now must be after issued_at and before expires_at, with
+		// expires_at - now <= 1 hour.
+		now, err := time.Parse(time.RFC3339, "2026-04-26T13:10:00Z")
+		if err != nil {
+			t.Fatalf("parse now: %v", err)
+		}
+
+		path := filepath.Join(goldenDirRel, "valid_recovery_authorization.json")
+		loaded, loadErr := LoadRecoveryAuthorization(path, pub, fp, now)
+		if loadErr != nil {
+			t.Fatalf("LoadRecoveryAuthorization: %v", loadErr)
+		}
+		if loaded.Body.Reason != goldenRecoveryReason {
+			t.Errorf("reason = %q, want %q", loaded.Body.Reason, goldenRecoveryReason)
+		}
+	})
+
+	// Root transition: load via the public API.
+	t.Run("root_transition", func(t *testing.T) {
+		oldPriv := goldenOldRootKey(t)
+		oldPub := oldPriv.Public().(ed25519.PublicKey)
+		newPriv := goldenNewRootKey(t)
+		newPub := newPriv.Public().(ed25519.PublicKey)
+
+		oldFP := goldenFingerprint(t, oldPub)
+
+		path := filepath.Join(goldenDirRel, "valid_root_transition.json")
+		loaded, loadErr := LoadRootTransition(path, oldPub, newPub, oldFP)
+		if loadErr != nil {
+			t.Fatalf("LoadRootTransition: %v", loadErr)
+		}
+		if loaded.Body.Reason != goldenRTReason {
+			t.Errorf("reason = %q, want %q", loaded.Body.Reason, goldenRTReason)
+		}
+	})
+
+	// Existence check for both fixtures.
+	expected := []string{
+		"valid_recovery_authorization.json",
+		"valid_root_transition.json",
+	}
+	for _, name := range expected {
+		path := filepath.Join(goldenDirRel, name)
+		if _, err := os.Stat(filepath.Clean(path)); err != nil {
+			t.Errorf("missing golden fixture %s: %v", name, err)
+		}
+	}
+}

--- a/internal/signing/key_purpose.go
+++ b/internal/signing/key_purpose.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+)
+
+// KeyPurpose is the typed form of the wire-string key_purpose attribute on
+// every signed-artifact key entry. The wire form is the lowercase hyphenated
+// string representation; this typed wrapper centralises validation and helpers.
+//
+// Six values are defined, drawn from the design doc Key Management section
+// (lines 758-870):
+//
+//   - PurposeReceiptSigning:            runtime receipt keys (hot-loadable)
+//   - PurposeContractCompileSigning:    compile-time contract keys (warm, operator-only)
+//   - PurposeContractActivationSigning: activation/promotion authority keys
+//   - PurposeRulesOfficialSigning:      official rules package signing keys
+//   - PurposeRosterRoot:                deployment-local trust root for key rosters
+//   - PurposeRecoveryRoot:              deployment-local trust root for recovery operations
+//
+// Wire stability: these strings are part of the signed-artifact wire format
+// and will not change without a schema_version bump.
+//
+// Why this lives in signing, not contract: the contract package owns the
+// payload-kind authority matrix; the signing package owns deployment-side key
+// handling. Both reference the same wire strings.
+type KeyPurpose string
+
+const (
+	// PurposeReceiptSigning identifies keys used to sign runtime receipts
+	// (proxy_decision, contract lifecycle events, shadow deltas, etc.).
+	PurposeReceiptSigning KeyPurpose = "receipt-signing"
+
+	// PurposeContractCompileSigning identifies keys used to sign compiled
+	// contract artifacts. These are warm/operator-only keys, not hot-loaded.
+	PurposeContractCompileSigning KeyPurpose = "contract-compile-signing"
+
+	// PurposeContractActivationSigning identifies keys used to authorise
+	// contract promotion, rollback, key rotation, and redaction requests.
+	PurposeContractActivationSigning KeyPurpose = "contract-activation-signing"
+
+	// PurposeRulesOfficialSigning identifies keys used to sign official
+	// rules packages distributed by the project.
+	PurposeRulesOfficialSigning KeyPurpose = "rules-official-signing"
+
+	// PurposeRosterRoot identifies the deployment-local trust root key
+	// that signs the key roster itself.
+	PurposeRosterRoot KeyPurpose = "roster-root"
+
+	// PurposeRecoveryRoot identifies the deployment-local trust root key
+	// used for recovery operations (root transition, emergency rotation).
+	PurposeRecoveryRoot KeyPurpose = "recovery-root"
+)
+
+// ErrUnknownKeyPurpose indicates a key_purpose value is not one of the six
+// recognised purposes.
+var ErrUnknownKeyPurpose = errors.New("unknown key_purpose")
+
+// knownPurposes is the canonical ordered list. KnownPurposes returns a copy.
+var knownPurposes = [...]KeyPurpose{
+	PurposeReceiptSigning,
+	PurposeContractCompileSigning,
+	PurposeContractActivationSigning,
+	PurposeRulesOfficialSigning,
+	PurposeRosterRoot,
+	PurposeRecoveryRoot,
+}
+
+// knownSet provides O(1) validation lookup.
+var knownSet = func() map[KeyPurpose]struct{} {
+	m := make(map[KeyPurpose]struct{}, len(knownPurposes))
+	for _, p := range knownPurposes {
+		m[p] = struct{}{}
+	}
+	return m
+}()
+
+// String returns the wire-format string of the key purpose. Satisfies
+// fmt.Stringer.
+func (p KeyPurpose) String() string {
+	return string(p)
+}
+
+// Validate returns nil if p is one of the six known purposes. Otherwise it
+// returns an error wrapping ErrUnknownKeyPurpose with the offending value.
+func (p KeyPurpose) Validate() error {
+	if _, ok := knownSet[p]; ok {
+		return nil
+	}
+	return fmt.Errorf("%w: %q", ErrUnknownKeyPurpose, string(p))
+}
+
+// IsRoot returns true for the two deployment-local trust root purposes:
+// PurposeRosterRoot and PurposeRecoveryRoot.
+func (p KeyPurpose) IsRoot() bool {
+	return p == PurposeRosterRoot || p == PurposeRecoveryRoot
+}
+
+// IsActivationAuthority returns true for PurposeContractActivationSigning.
+// Used by future dual-control logic to identify keys that can authorise
+// contract promotion, rollback, rotation, and redaction.
+func (p KeyPurpose) IsActivationAuthority() bool {
+	return p == PurposeContractActivationSigning
+}
+
+// IsRuntimeReceipt returns true for PurposeReceiptSigning. Used to gate
+// hot-loaded keys that sign runtime proxy decisions and lifecycle events.
+func (p KeyPurpose) IsRuntimeReceipt() bool {
+	return p == PurposeReceiptSigning
+}
+
+// IsCompileTime returns true for PurposeContractCompileSigning. Used to gate
+// warm/operator-only keys that sign compiled contract artifacts.
+func (p KeyPurpose) IsCompileTime() bool {
+	return p == PurposeContractCompileSigning
+}
+
+// KnownPurposes returns a freshly-allocated slice of all six recognised key
+// purposes in stable order:
+//
+//  1. PurposeReceiptSigning
+//  2. PurposeContractCompileSigning
+//  3. PurposeContractActivationSigning
+//  4. PurposeRulesOfficialSigning
+//  5. PurposeRosterRoot
+//  6. PurposeRecoveryRoot
+//
+// Tests rely on this order; it will not change without a major version bump.
+func KnownPurposes() []KeyPurpose {
+	out := make([]KeyPurpose, len(knownPurposes))
+	copy(out, knownPurposes[:])
+	return out
+}
+
+// AuthorizePayload checks that signedWith is the required key purpose for the
+// given payloadKind according to the EvidenceReceipt v2 authority matrix in
+// contract.AuthorizeKeyPurpose. Returns nil on success. On failure, the
+// returned error preserves errors.Is compatibility with
+// contract.ErrWrongKeyPurpose and contract.ErrUnknownPayloadKind.
+func AuthorizePayload(payloadKind string, signedWith KeyPurpose) error {
+	return contract.AuthorizeKeyPurpose(payloadKind, signedWith.String())
+}

--- a/internal/signing/key_purpose_test.go
+++ b/internal/signing/key_purpose_test.go
@@ -1,0 +1,247 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+)
+
+func TestKeyPurpose_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		purpose  KeyPurpose
+		expected string
+	}{
+		{"receipt-signing", PurposeReceiptSigning, "receipt-signing"},
+		{"contract-compile-signing", PurposeContractCompileSigning, "contract-compile-signing"},
+		{"contract-activation-signing", PurposeContractActivationSigning, "contract-activation-signing"},
+		{"rules-official-signing", PurposeRulesOfficialSigning, "rules-official-signing"},
+		{"roster-root", PurposeRosterRoot, "roster-root"},
+		{"recovery-root", PurposeRecoveryRoot, "recovery-root"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.purpose.String(); got != tt.expected {
+				t.Errorf("String() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestKeyPurpose_Validate(t *testing.T) {
+	t.Run("valid_purposes", func(t *testing.T) {
+		for _, p := range KnownPurposes() {
+			t.Run(string(p), func(t *testing.T) {
+				if err := p.Validate(); err != nil {
+					t.Errorf("Validate() returned error for valid purpose %q: %v", p, err)
+				}
+			})
+		}
+	})
+
+	t.Run("invalid_purposes", func(t *testing.T) {
+		invalid := []struct {
+			name  string
+			value KeyPurpose
+		}{
+			{"empty", KeyPurpose("")},
+			{"partial", KeyPurpose("signing")},
+			{"wrong_case", KeyPurpose("RECEIPT-SIGNING")},
+			{"typo", KeyPurpose("receipt_signing")},
+			{"unknown", KeyPurpose("audit-signing")},
+		}
+		for _, tt := range invalid {
+			t.Run(tt.name, func(t *testing.T) {
+				err := tt.value.Validate()
+				if err == nil {
+					t.Fatalf("Validate() returned nil for invalid purpose %q", tt.value)
+				}
+				if !errors.Is(err, ErrUnknownKeyPurpose) {
+					t.Errorf("error does not wrap ErrUnknownKeyPurpose: %v", err)
+				}
+			})
+		}
+	})
+}
+
+func TestKeyPurpose_IsRoot(t *testing.T) {
+	tests := []struct {
+		purpose  KeyPurpose
+		expected bool
+	}{
+		{PurposeReceiptSigning, false},
+		{PurposeContractCompileSigning, false},
+		{PurposeContractActivationSigning, false},
+		{PurposeRulesOfficialSigning, false},
+		{PurposeRosterRoot, true},
+		{PurposeRecoveryRoot, true},
+		{KeyPurpose("unknown"), false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.purpose), func(t *testing.T) {
+			if got := tt.purpose.IsRoot(); got != tt.expected {
+				t.Errorf("IsRoot() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestKeyPurpose_IsActivationAuthority(t *testing.T) {
+	tests := []struct {
+		purpose  KeyPurpose
+		expected bool
+	}{
+		{PurposeReceiptSigning, false},
+		{PurposeContractCompileSigning, false},
+		{PurposeContractActivationSigning, true},
+		{PurposeRulesOfficialSigning, false},
+		{PurposeRosterRoot, false},
+		{PurposeRecoveryRoot, false},
+		{KeyPurpose("unknown"), false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.purpose), func(t *testing.T) {
+			if got := tt.purpose.IsActivationAuthority(); got != tt.expected {
+				t.Errorf("IsActivationAuthority() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestKeyPurpose_IsRuntimeReceipt(t *testing.T) {
+	tests := []struct {
+		purpose  KeyPurpose
+		expected bool
+	}{
+		{PurposeReceiptSigning, true},
+		{PurposeContractCompileSigning, false},
+		{PurposeContractActivationSigning, false},
+		{PurposeRulesOfficialSigning, false},
+		{PurposeRosterRoot, false},
+		{PurposeRecoveryRoot, false},
+		{KeyPurpose("unknown"), false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.purpose), func(t *testing.T) {
+			if got := tt.purpose.IsRuntimeReceipt(); got != tt.expected {
+				t.Errorf("IsRuntimeReceipt() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestKeyPurpose_IsCompileTime(t *testing.T) {
+	tests := []struct {
+		purpose  KeyPurpose
+		expected bool
+	}{
+		{PurposeReceiptSigning, false},
+		{PurposeContractCompileSigning, true},
+		{PurposeContractActivationSigning, false},
+		{PurposeRulesOfficialSigning, false},
+		{PurposeRosterRoot, false},
+		{PurposeRecoveryRoot, false},
+		{KeyPurpose("unknown"), false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.purpose), func(t *testing.T) {
+			if got := tt.purpose.IsCompileTime(); got != tt.expected {
+				t.Errorf("IsCompileTime() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestKnownPurposes(t *testing.T) {
+	purposes := KnownPurposes()
+
+	t.Run("length", func(t *testing.T) {
+		if len(purposes) != 6 {
+			t.Fatalf("KnownPurposes() returned %d elements, want 6", len(purposes))
+		}
+	})
+
+	t.Run("order", func(t *testing.T) {
+		expected := []KeyPurpose{
+			PurposeReceiptSigning,
+			PurposeContractCompileSigning,
+			PurposeContractActivationSigning,
+			PurposeRulesOfficialSigning,
+			PurposeRosterRoot,
+			PurposeRecoveryRoot,
+		}
+		for i, p := range purposes {
+			if p != expected[i] {
+				t.Errorf("index %d: got %q, want %q", i, p, expected[i])
+			}
+		}
+	})
+
+	t.Run("fresh_slice", func(t *testing.T) {
+		a := KnownPurposes()
+		b := KnownPurposes()
+		// Mutating one must not affect the other.
+		a[0] = KeyPurpose("mutated")
+		if b[0] == KeyPurpose("mutated") {
+			t.Fatal("KnownPurposes() returns shared backing array; expected independent slices")
+		}
+	})
+}
+
+func TestAuthorizePayload(t *testing.T) {
+	// Happy paths: each payload kind from the authority matrix paired with its
+	// required purpose. These are exhaustively listed from
+	// internal/contract/verify.go payloadAuthority map.
+	t.Run("happy_paths", func(t *testing.T) {
+		tests := []struct {
+			payloadKind string
+			signedWith  KeyPurpose
+		}{
+			{"proxy_decision", PurposeReceiptSigning},
+			{"contract_ratified", PurposeReceiptSigning},
+			{"contract_promote_intent", PurposeContractActivationSigning},
+			{"contract_promote_committed", PurposeReceiptSigning},
+			{"contract_rollback_authorized", PurposeContractActivationSigning},
+			{"contract_rollback_committed", PurposeReceiptSigning},
+			{"contract_demoted", PurposeReceiptSigning},
+			{"contract_expired", PurposeReceiptSigning},
+			{"contract_drift", PurposeReceiptSigning},
+			{"shadow_delta", PurposeReceiptSigning},
+			{"opportunity_missing", PurposeReceiptSigning},
+			{"key_rotation", PurposeContractActivationSigning},
+			{"contract_redaction_request", PurposeContractActivationSigning},
+		}
+		for _, tt := range tests {
+			t.Run(tt.payloadKind, func(t *testing.T) {
+				if err := AuthorizePayload(tt.payloadKind, tt.signedWith); err != nil {
+					t.Errorf("AuthorizePayload(%q, %q) = %v, want nil", tt.payloadKind, tt.signedWith, err)
+				}
+			})
+		}
+	})
+
+	t.Run("wrong_purpose", func(t *testing.T) {
+		// proxy_decision requires receipt-signing; use activation instead.
+		err := AuthorizePayload("proxy_decision", PurposeContractActivationSigning)
+		if err == nil {
+			t.Fatal("expected error for wrong purpose, got nil")
+		}
+		if !errors.Is(err, contract.ErrWrongKeyPurpose) {
+			t.Errorf("error does not wrap contract.ErrWrongKeyPurpose: %v", err)
+		}
+	})
+
+	t.Run("unknown_payload_kind", func(t *testing.T) {
+		err := AuthorizePayload("made_up_kind", PurposeReceiptSigning)
+		if err == nil {
+			t.Fatal("expected error for unknown payload kind, got nil")
+		}
+		if !errors.Is(err, contract.ErrUnknownPayloadKind) {
+			t.Errorf("error does not wrap contract.ErrUnknownPayloadKind: %v", err)
+		}
+	})
+}

--- a/internal/signing/recovery.go
+++ b/internal/signing/recovery.go
@@ -1,0 +1,240 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+)
+
+// recoveryExpiryCeiling is the maximum allowed gap between now and expires_at.
+// Per the design doc, recovery authorizations must expire within 1 hour.
+const recoveryExpiryCeiling = time.Hour
+
+// recoverySchemaVersion is the expected schema version for recovery
+// authorization envelopes.
+const recoverySchemaVersion = 1
+
+// Envelope file extension constants. These are also used by roster.go's
+// LoadRoster switch; a shared extraction is appropriate once both call sites
+// are editable in the same PR.
+const (
+	envelopeExtJSON = ".json"
+	envelopeExtYAML = ".yaml"
+	envelopeExtYML  = ".yml"
+)
+
+// targetRosterHashPattern validates "sha256:" followed by exactly 64 lowercase
+// hex characters.
+var targetRosterHashPattern = regexp.MustCompile(
+	`^sha256:[0-9a-f]{64}$`,
+)
+
+// Sentinel errors for recovery authorization loading and validation.
+var (
+	ErrRecoveryRead                 = errors.New("recovery authorization read failed")
+	ErrRecoveryDecode               = errors.New("recovery authorization decode failed")
+	ErrRecoveryUnsupportedExtension = errors.New("unsupported recovery authorization file extension")
+	ErrRecoverySchemaVersion        = errors.New("unsupported recovery authorization schema_version; expected 1")
+	ErrRecoveryReasonRequired       = errors.New("recovery authorization reason is required")
+	ErrRecoveryOperatorRequired     = errors.New("recovery authorization operator_identity is required")
+	ErrRecoveryExpiryFormat         = errors.New("recovery authorization expires_at must be RFC 3339")
+	ErrRecoveryIssuedAtFormat       = errors.New("recovery authorization issued_at must be RFC 3339")
+	ErrRecoveryTargetHashFormat     = errors.New("recovery authorization target_roster_hash must be sha256:<64 hex>")
+	ErrRecoveryNotYetValid          = errors.New("recovery authorization issued_at is in the future")
+	ErrRecoveryExpired              = errors.New("recovery authorization is expired")
+	ErrRecoveryExpiryTooFar         = errors.New("recovery authorization expires more than 1h in the future")
+	ErrRecoverySignatureFormat      = errors.New("recovery authorization signature format invalid")
+	ErrRecoverySignatureInvalid     = errors.New("recovery authorization signature does not verify")
+	ErrRecoveryFingerprintMismatch  = errors.New("recovery authorization signing key fingerprint does not match pinned")
+)
+
+// RecoveryAuthorizationBody is the typed signable body of a roster recovery
+// authorization. The recovery-root signs the body's canonical preimage.
+type RecoveryAuthorizationBody struct {
+	SchemaVersion    int    `json:"schema_version"`
+	Reason           string `json:"reason"`
+	ExpiresAt        string `json:"expires_at"`
+	TargetRosterHash string `json:"target_roster_hash"`
+	OperatorIdentity string `json:"operator_identity"`
+	IssuedAt         string `json:"issued_at"`
+}
+
+// RecoveryAuthorizationEnvelope is the on-disk wire format.
+type RecoveryAuthorizationEnvelope struct {
+	Body      RecoveryAuthorizationBody `json:"body"`
+	Signature string                    `json:"signature"`
+}
+
+// LoadedRecoveryAuthorization is a verified recovery authorization bound to
+// the pinned recovery-root fingerprint that was used to verify it.
+type LoadedRecoveryAuthorization struct {
+	Body                    RecoveryAuthorizationBody
+	Signature               string
+	RecoveryRootFingerprint string
+	LoadedAt                time.Time
+	SourcePath              string
+}
+
+// SignablePreimage returns the JCS-canonical bytes of the body for signing
+// and verification. Mirrors the KeyRoster preimage pattern in the contract
+// package: marshal -> ParseJSONStrict -> Canonicalize.
+func (b RecoveryAuthorizationBody) SignablePreimage() ([]byte, error) {
+	raw, err := json.Marshal(b)
+	if err != nil {
+		return nil, fmt.Errorf("marshal recovery_authorization body: %w", err)
+	}
+	tree, err := contract.ParseJSONStrict(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse recovery_authorization for canonicalization: %w", err)
+	}
+	return contract.Canonicalize(tree)
+}
+
+// Validate runs structural checks on the body (no signature verification,
+// no time-window enforcement):
+//   - SchemaVersion == 1
+//   - Reason non-empty
+//   - ExpiresAt parses as RFC 3339
+//   - IssuedAt parses as RFC 3339
+//   - TargetRosterHash matches "sha256:<64 hex>"
+//   - OperatorIdentity non-empty
+//
+// Time-window enforcement happens in LoadRecoveryAuthorization, not here,
+// because Validate must be deterministic for canonicalization purposes.
+func (b RecoveryAuthorizationBody) Validate() error {
+	if b.SchemaVersion != recoverySchemaVersion {
+		return fmt.Errorf("%w: got %d", ErrRecoverySchemaVersion, b.SchemaVersion)
+	}
+	if b.Reason == "" {
+		return ErrRecoveryReasonRequired
+	}
+	if _, err := time.Parse(time.RFC3339, b.ExpiresAt); err != nil {
+		return fmt.Errorf("%w: %w", ErrRecoveryExpiryFormat, err)
+	}
+	if _, err := time.Parse(time.RFC3339, b.IssuedAt); err != nil {
+		return fmt.Errorf("%w: %w", ErrRecoveryIssuedAtFormat, err)
+	}
+	// TODO: caller must match TargetRosterHash against the actual loaded roster body in a future PR.
+	if !targetRosterHashPattern.MatchString(b.TargetRosterHash) {
+		return fmt.Errorf("%w: got %q", ErrRecoveryTargetHashFormat, b.TargetRosterHash)
+	}
+	if b.OperatorIdentity == "" {
+		return ErrRecoveryOperatorRequired
+	}
+	return nil
+}
+
+// LoadRecoveryAuthorization reads a recovery_authorization file from disk,
+// decodes it strictly, runs structural validation, then cryptographically
+// verifies the detached signature against the operator-pinned recovery-root
+// public key.
+//
+// The recoveryRootPublicKey must be the raw 32-byte Ed25519 public key of the
+// recovery-root. Pinning by fingerprint is enforced via VerifyFingerprint
+// against pinnedRecoveryRootFingerprint before the signature check, so that
+// passing the wrong key surfaces a fingerprint-mismatch error rather than a
+// signature-mismatch error (more diagnostic).
+//
+// Time-window checks (clock-skew bounded, against the now parameter):
+//   - now < IssuedAt       -> ErrRecoveryNotYetValid (issued in the future)
+//   - now > ExpiresAt      -> ErrRecoveryExpired
+//   - ExpiresAt - now > 1h -> ErrRecoveryExpiryTooFar
+//
+// The 1-hour ceiling is hard-coded per the design doc. There is no unsigned
+// recovery path: callers must pass a valid signed envelope or get an error.
+func LoadRecoveryAuthorization(
+	path string,
+	recoveryRootPublicKey []byte,
+	pinnedRecoveryRootFingerprint string,
+	now time.Time,
+) (*LoadedRecoveryAuthorization, error) {
+	// Step 1: Read file from disk.
+	cleanPath := filepath.Clean(path)
+	raw, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRecoveryRead, err)
+	}
+
+	// Step 2: Decode based on file extension.
+	var envelope RecoveryAuthorizationEnvelope
+	if decErr := decodeRecoveryEnvelope(cleanPath, raw, &envelope); decErr != nil {
+		return nil, decErr
+	}
+
+	// Step 3: Structural validation of the body.
+	if valErr := envelope.Body.Validate(); valErr != nil {
+		return nil, valErr
+	}
+
+	// Step 4: Validate signature format (reuse the parse helper).
+	sigBytes, sigErr := parseSignature(envelope.Signature)
+	if sigErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRecoverySignatureFormat, sigErr)
+	}
+
+	// Step 5: Time-window checks.
+	issuedAt, _ := time.Parse(time.RFC3339, envelope.Body.IssuedAt)
+	if now.Before(issuedAt) {
+		return nil, fmt.Errorf("%w: issued_at=%s, now=%s",
+			ErrRecoveryNotYetValid, envelope.Body.IssuedAt, now.Format(time.RFC3339))
+	}
+	expiresAt, _ := time.Parse(time.RFC3339, envelope.Body.ExpiresAt)
+	if now.After(expiresAt) {
+		return nil, fmt.Errorf("%w: expires_at=%s, now=%s",
+			ErrRecoveryExpired, envelope.Body.ExpiresAt, now.Format(time.RFC3339))
+	}
+	if expiresAt.Sub(now) > recoveryExpiryCeiling {
+		return nil, fmt.Errorf("%w: expires_at=%s, now=%s, delta=%s",
+			ErrRecoveryExpiryTooFar, envelope.Body.ExpiresAt, now.Format(time.RFC3339), expiresAt.Sub(now))
+	}
+
+	// Step 6: Verify recovery-root fingerprint pinning.
+	if fpErr := VerifyFingerprint(recoveryRootPublicKey, pinnedRecoveryRootFingerprint); fpErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRecoveryFingerprintMismatch, fpErr)
+	}
+
+	// Step 7: Compute preimage and verify signature.
+	preimage, err := envelope.Body.SignablePreimage()
+	if err != nil {
+		return nil, fmt.Errorf("%w: preimage: %w", ErrRecoverySignatureInvalid, err)
+	}
+	if !contract.VerifyEd25519PureEdDSA(recoveryRootPublicKey, preimage, sigBytes) {
+		return nil, fmt.Errorf("%w", ErrRecoverySignatureInvalid)
+	}
+
+	return &LoadedRecoveryAuthorization{
+		Body:                    envelope.Body,
+		Signature:               envelope.Signature,
+		RecoveryRootFingerprint: pinnedRecoveryRootFingerprint,
+		LoadedAt:                now,
+		SourcePath:              cleanPath,
+	}, nil
+}
+
+// decodeRecoveryEnvelope dispatches file-extension-based strict decoding.
+func decodeRecoveryEnvelope(cleanPath string, raw []byte, envelope *RecoveryAuthorizationEnvelope) error {
+	ext := strings.ToLower(filepath.Ext(cleanPath))
+	switch ext {
+	case envelopeExtJSON:
+		if decErr := contract.DecodeStrictJSON(raw, envelope); decErr != nil {
+			return fmt.Errorf("%w: %w", ErrRecoveryDecode, decErr)
+		}
+	case envelopeExtYAML, envelopeExtYML:
+		if decErr := contract.DecodeStrictYAML(raw, envelope); decErr != nil {
+			return fmt.Errorf("%w: %w", ErrRecoveryDecode, decErr)
+		}
+	default:
+		return fmt.Errorf("%w: %q", ErrRecoveryUnsupportedExtension, ext)
+	}
+	return nil
+}

--- a/internal/signing/recovery.go
+++ b/internal/signing/recovery.go
@@ -56,6 +56,9 @@ var (
 	ErrRecoverySignatureFormat      = errors.New("recovery authorization signature format invalid")
 	ErrRecoverySignatureInvalid     = errors.New("recovery authorization signature does not verify")
 	ErrRecoveryFingerprintMismatch  = errors.New("recovery authorization signing key fingerprint does not match pinned")
+	ErrRecoveryLifetimeTooLong      = errors.New("recovery authorization lifetime (expires_at - issued_at) exceeds 1h ceiling")
+	ErrRecoveryExpiresBeforeIssued  = errors.New("recovery authorization expires_at is before issued_at")
+	ErrRecoveryTargetHashMismatch   = errors.New("recovery authorization target_roster_hash does not match expected")
 )
 
 // RecoveryAuthorizationBody is the typed signable body of a roster recovery
@@ -145,17 +148,36 @@ func (b RecoveryAuthorizationBody) Validate() error {
 // passing the wrong key surfaces a fingerprint-mismatch error rather than a
 // signature-mismatch error (more diagnostic).
 //
-// Time-window checks (clock-skew bounded, against the now parameter):
-//   - now < IssuedAt       -> ErrRecoveryNotYetValid (issued in the future)
-//   - now > ExpiresAt      -> ErrRecoveryExpired
-//   - ExpiresAt - now > 1h -> ErrRecoveryExpiryTooFar
+// expectedTargetRosterHash binds the authorization to a specific roster body
+// the runtime is about to recover into. When non-empty, body.TargetRosterHash
+// must equal it (string compare on the canonical "sha256:<hex>" form). When
+// empty, the binding check is skipped and the loader returns a verified
+// envelope without proving it authorises any particular roster — used by
+// the offline ceremony CLI to inspect a file before a target hash is known.
+// Runtime callers MUST pass a non-empty expected hash; mirroring the
+// pinned-fingerprint convention used by LoadRootTransition keeps the
+// distinction visible in source.
 //
-// The 1-hour ceiling is hard-coded per the design doc. There is no unsigned
-// recovery path: callers must pass a valid signed envelope or get an error.
+// Time-window checks (clock-skew bounded, against the now parameter):
+//   - now < IssuedAt              -> ErrRecoveryNotYetValid (issued in future)
+//   - now > ExpiresAt             -> ErrRecoveryExpired
+//   - ExpiresAt - now > 1h        -> ErrRecoveryExpiryTooFar (replay guard)
+//   - ExpiresAt <= IssuedAt       -> ErrRecoveryExpiresBeforeIssued
+//   - ExpiresAt - IssuedAt > 1h   -> ErrRecoveryLifetimeTooLong (lifetime cap)
+//
+// The 1-hour ceiling is enforced both on the LIFETIME (issued -> expired)
+// and the REMAINING WINDOW (now -> expired). Without the lifetime cap, an
+// authorization issued days ago but with expires_at = now + 30m would slip
+// past the replay guard while having an effective lifetime of days, which
+// violates the design's bounded blast-radius requirement.
+//
+// There is no unsigned recovery path: callers must pass a valid signed
+// envelope or get an error.
 func LoadRecoveryAuthorization(
 	path string,
 	recoveryRootPublicKey []byte,
 	pinnedRecoveryRootFingerprint string,
+	expectedTargetRosterHash string,
 	now time.Time,
 ) (*LoadedRecoveryAuthorization, error) {
 	// Step 1: Read file from disk.
@@ -184,18 +206,39 @@ func LoadRecoveryAuthorization(
 
 	// Step 5: Time-window checks.
 	issuedAt, _ := time.Parse(time.RFC3339, envelope.Body.IssuedAt)
+	expiresAt, _ := time.Parse(time.RFC3339, envelope.Body.ExpiresAt)
+
+	// Lifetime cap: expires must be after issued, and the gap must not
+	// exceed the 1h ceiling. Without these, a stale authorization with a
+	// short remaining window slips past the replay guard.
+	if !expiresAt.After(issuedAt) {
+		return nil, fmt.Errorf("%w: issued_at=%s, expires_at=%s",
+			ErrRecoveryExpiresBeforeIssued, envelope.Body.IssuedAt, envelope.Body.ExpiresAt)
+	}
+	if expiresAt.Sub(issuedAt) > recoveryExpiryCeiling {
+		return nil, fmt.Errorf("%w: lifetime=%s, ceiling=%s",
+			ErrRecoveryLifetimeTooLong, expiresAt.Sub(issuedAt), recoveryExpiryCeiling)
+	}
+
 	if now.Before(issuedAt) {
 		return nil, fmt.Errorf("%w: issued_at=%s, now=%s",
 			ErrRecoveryNotYetValid, envelope.Body.IssuedAt, now.Format(time.RFC3339))
 	}
-	expiresAt, _ := time.Parse(time.RFC3339, envelope.Body.ExpiresAt)
 	if now.After(expiresAt) {
 		return nil, fmt.Errorf("%w: expires_at=%s, now=%s",
 			ErrRecoveryExpired, envelope.Body.ExpiresAt, now.Format(time.RFC3339))
 	}
+	// Replay guard: even with a lawful 1h lifetime, the remaining window
+	// must also be no more than 1h. Cheap to enforce; same ceiling.
 	if expiresAt.Sub(now) > recoveryExpiryCeiling {
 		return nil, fmt.Errorf("%w: expires_at=%s, now=%s, delta=%s",
 			ErrRecoveryExpiryTooFar, envelope.Body.ExpiresAt, now.Format(time.RFC3339), expiresAt.Sub(now))
+	}
+
+	// Step 5b: Bind to expected target roster, when caller supplied one.
+	if expectedTargetRosterHash != "" && envelope.Body.TargetRosterHash != expectedTargetRosterHash {
+		return nil, fmt.Errorf("%w: got %q, want %q",
+			ErrRecoveryTargetHashMismatch, envelope.Body.TargetRosterHash, expectedTargetRosterHash)
 	}
 
 	// Step 6: Verify recovery-root fingerprint pinning.

--- a/internal/signing/recovery.go
+++ b/internal/signing/recovery.go
@@ -59,6 +59,12 @@ var (
 	ErrRecoveryLifetimeTooLong      = errors.New("recovery authorization lifetime (expires_at - issued_at) exceeds 1h ceiling")
 	ErrRecoveryExpiresBeforeIssued  = errors.New("recovery authorization expires_at is before issued_at")
 	ErrRecoveryTargetHashMismatch   = errors.New("recovery authorization target_roster_hash does not match expected")
+	// ErrRecoveryTargetHashRequired is returned by LoadRecoveryAuthorization when
+	// expectedTargetRosterHash is empty. The runtime entry point fails closed on
+	// missing target binding so a forgotten argument never silently accepts a
+	// valid authorization for an arbitrary roster body. Offline ceremony tooling
+	// uses InspectRecoveryAuthorizationOffline instead.
+	ErrRecoveryTargetHashRequired = errors.New("recovery authorization expectedTargetRosterHash is required at runtime; use InspectRecoveryAuthorizationOffline for ceremony review")
 )
 
 // RecoveryAuthorizationBody is the typed signable body of a roster recovery
@@ -140,26 +146,23 @@ func (b RecoveryAuthorizationBody) Validate() error {
 	return nil
 }
 
-// LoadRecoveryAuthorization reads a recovery_authorization file from disk,
-// decodes it strictly, runs structural validation, then cryptographically
-// verifies the detached signature against the operator-pinned recovery-root
-// public key.
+// LoadRecoveryAuthorization is the runtime entry point for verifying a
+// recovery authorization before applying it to a live roster. It reads,
+// decodes, structurally validates, fingerprint-pins, time-window-checks,
+// and signature-verifies the envelope, then enforces the target-roster
+// binding against expectedTargetRosterHash.
 //
-// The recoveryRootPublicKey must be the raw 32-byte Ed25519 public key of the
-// recovery-root. Pinning by fingerprint is enforced via VerifyFingerprint
-// against pinnedRecoveryRootFingerprint before the signature check, so that
-// passing the wrong key surfaces a fingerprint-mismatch error rather than a
-// signature-mismatch error (more diagnostic).
+// Empty expectedTargetRosterHash is rejected with ErrRecoveryTargetHashRequired:
+// at runtime, an authorization that is not bound to a specific roster body is
+// an authorization for ANY roster body, which is an authorization-bypass
+// footgun in a security-boundary product. Ceremony tooling that needs to
+// inspect a file before the target hash is known calls
+// InspectRecoveryAuthorizationOffline instead.
 //
-// expectedTargetRosterHash binds the authorization to a specific roster body
-// the runtime is about to recover into. When non-empty, body.TargetRosterHash
-// must equal it (string compare on the canonical "sha256:<hex>" form). When
-// empty, the binding check is skipped and the loader returns a verified
-// envelope without proving it authorises any particular roster — used by
-// the offline ceremony CLI to inspect a file before a target hash is known.
-// Runtime callers MUST pass a non-empty expected hash; mirroring the
-// pinned-fingerprint convention used by LoadRootTransition keeps the
-// distinction visible in source.
+// recoveryRootPublicKey is the raw 32-byte Ed25519 key. Pinning by fingerprint
+// runs via VerifyFingerprint against pinnedRecoveryRootFingerprint before the
+// signature check, so that passing the wrong key surfaces a fingerprint
+// mismatch (more diagnostic) rather than a signature mismatch.
 //
 // Time-window checks (clock-skew bounded, against the now parameter):
 //   - now < IssuedAt              -> ErrRecoveryNotYetValid (issued in future)
@@ -177,6 +180,46 @@ func (b RecoveryAuthorizationBody) Validate() error {
 // There is no unsigned recovery path: callers must pass a valid signed
 // envelope or get an error.
 func LoadRecoveryAuthorization(
+	path string,
+	recoveryRootPublicKey []byte,
+	pinnedRecoveryRootFingerprint string,
+	expectedTargetRosterHash string,
+	now time.Time,
+) (*LoadedRecoveryAuthorization, error) {
+	if expectedTargetRosterHash == "" {
+		return nil, ErrRecoveryTargetHashRequired
+	}
+	return loadRecoveryAuthorizationCore(
+		path, recoveryRootPublicKey, pinnedRecoveryRootFingerprint,
+		expectedTargetRosterHash, now)
+}
+
+// InspectRecoveryAuthorizationOffline is the offline-ceremony entry point. It
+// runs every check LoadRecoveryAuthorization performs except the target-roster
+// binding, returning a verified envelope when the file is structurally and
+// cryptographically valid against the pinned recovery-root.
+//
+// Use this only from offline ceremony tooling (the pipelock signing recovery
+// verify CLI) where the operator is reviewing an authorization before a target
+// roster body exists. Runtime callers must use LoadRecoveryAuthorization so the
+// target binding is enforced.
+func InspectRecoveryAuthorizationOffline(
+	path string,
+	recoveryRootPublicKey []byte,
+	pinnedRecoveryRootFingerprint string,
+	now time.Time,
+) (*LoadedRecoveryAuthorization, error) {
+	return loadRecoveryAuthorizationCore(
+		path, recoveryRootPublicKey, pinnedRecoveryRootFingerprint,
+		"", now)
+}
+
+// loadRecoveryAuthorizationCore is the shared verification path. It is
+// unexported so callers must pick the runtime (LoadRecoveryAuthorization) or
+// offline-ceremony (InspectRecoveryAuthorizationOffline) entry point and the
+// target-binding policy is visible in the API surface, not buried in an
+// argument default.
+func loadRecoveryAuthorizationCore(
 	path string,
 	recoveryRootPublicKey []byte,
 	pinnedRecoveryRootFingerprint string,
@@ -239,6 +282,9 @@ func LoadRecoveryAuthorization(
 	}
 
 	// Step 5b: Bind to expected target roster, when caller supplied one.
+	// LoadRecoveryAuthorization rejects the empty case at the entry point;
+	// only InspectRecoveryAuthorizationOffline reaches here with empty
+	// expectedTargetRosterHash.
 	if expectedTargetRosterHash != "" && envelope.Body.TargetRosterHash != expectedTargetRosterHash {
 		return nil, fmt.Errorf("%w: got %q, want %q",
 			ErrRecoveryTargetHashMismatch, envelope.Body.TargetRosterHash, expectedTargetRosterHash)
@@ -258,10 +304,23 @@ func LoadRecoveryAuthorization(
 		return nil, fmt.Errorf("%w", ErrRecoverySignatureInvalid)
 	}
 
+	// Step 8: Compute the canonical fingerprint from the verified key
+	// rather than echoing back the operator-supplied input. ParseFingerprint
+	// accepts uppercase hex and normalizes; persisting the canonical form
+	// keeps audit records consistent across systems regardless of how the
+	// operator typed the pin in.
+	canonicalFP, fpErr := Fingerprint(recoveryRootPublicKey)
+	if fpErr != nil {
+		// Unreachable: VerifyFingerprint above already proved key length is
+		// 32 bytes, which is the only way Fingerprint fails. Preserve the
+		// fail-closed invariant explicitly anyway.
+		return nil, fmt.Errorf("%w: canonical fingerprint: %w", ErrRecoveryFingerprintMismatch, fpErr)
+	}
+
 	return &LoadedRecoveryAuthorization{
 		Body:                    envelope.Body,
 		Signature:               envelope.Signature,
-		RecoveryRootFingerprint: pinnedRecoveryRootFingerprint,
+		RecoveryRootFingerprint: canonicalFP,
 		LoadedAt:                now,
 		SourcePath:              cleanPath,
 	}, nil

--- a/internal/signing/recovery.go
+++ b/internal/signing/recovery.go
@@ -127,7 +127,10 @@ func (b RecoveryAuthorizationBody) Validate() error {
 	if _, err := time.Parse(time.RFC3339, b.IssuedAt); err != nil {
 		return fmt.Errorf("%w: %w", ErrRecoveryIssuedAtFormat, err)
 	}
-	// TODO: caller must match TargetRosterHash against the actual loaded roster body in a future PR.
+	// Format-only check here. The binding to a specific roster body is
+	// enforced by LoadRecoveryAuthorization's expectedTargetRosterHash
+	// argument; runtime callers must pass a non-empty value to make that
+	// gate fire. Validate must stay deterministic for canonicalization.
 	if !targetRosterHashPattern.MatchString(b.TargetRosterHash) {
 		return fmt.Errorf("%w: got %q", ErrRecoveryTargetHashFormat, b.TargetRosterHash)
 	}

--- a/internal/signing/recovery_test.go
+++ b/internal/signing/recovery_test.go
@@ -1,0 +1,633 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// RFC 8032 section 7.1 test 2 private seed, split per G101 lint rule.
+// This is a DIFFERENT seed from the roster tests so the two keypairs are
+// independent.
+const testRecoverySeedHex = "" +
+	"4ccd089b" + "28ff96da" + "9db6c346" + "ec114e0f" +
+	"5b8a319f" + "35aba624" + "da8cf6ed" + "4fb8a6fb"
+
+// testRecoveryReason is the operator reason used in test fixtures.
+const testRecoveryReason = "roster root key compromised"
+
+// testRecoveryOperator is the operator identity used in test fixtures.
+const testRecoveryOperator = "ops@example.com"
+
+// testRecoveryTargetHash is a well-formed target roster hash for fixtures.
+const testRecoveryTargetHash = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+// testRecoveryBadDate is reused for RFC 3339 parse-failure tests.
+const testRecoveryBadDate = "not-a-date"
+
+// recoveryPreSignOpt mutates the envelope body before the signature is computed.
+type recoveryPreSignOpt func(env *RecoveryAuthorizationEnvelope)
+
+// recoveryPostSignOpt mutates the envelope after the signature is computed,
+// useful for corrupting signature or body post-signing.
+type recoveryPostSignOpt func(env *RecoveryAuthorizationEnvelope)
+
+// recoveryFixture builds a known-good recovery authorization, signs it with
+// a deterministic recovery-root keypair, writes the envelope to a temp file,
+// and returns (path, recoveryRootPublicKey, recoveryRootFingerprint).
+//
+// The default fixture has:
+//   - issued_at  = now - 10 minutes
+//   - expires_at = now + 30 minutes
+//
+// so that time-window checks pass with the returned "now" (also returned).
+//
+// Pass recoveryPreSignOpt to mutate the body before signing, or
+// recoveryPostSignOpt to tamper with the envelope after signing.
+func recoveryFixture(t *testing.T, now time.Time, ext string, opts ...any) (path string, pub []byte, fingerprint string) {
+	t.Helper()
+
+	seed, err := hex.DecodeString(testRecoverySeedHex)
+	if err != nil {
+		t.Fatalf("decode seed: %v", err)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub = priv.Public().(ed25519.PublicKey)
+
+	envelope := RecoveryAuthorizationEnvelope{
+		Body: RecoveryAuthorizationBody{
+			SchemaVersion:    1,
+			Reason:           testRecoveryReason,
+			ExpiresAt:        now.Add(30 * time.Minute).UTC().Format(time.RFC3339),
+			TargetRosterHash: testRecoveryTargetHash,
+			OperatorIdentity: testRecoveryOperator,
+			IssuedAt:         now.Add(-10 * time.Minute).UTC().Format(time.RFC3339),
+		},
+	}
+
+	// Apply pre-sign mutations.
+	for _, o := range opts {
+		if fn, ok := o.(recoveryPreSignOpt); ok {
+			fn(&envelope)
+		}
+	}
+
+	// Sign the body.
+	preimage, pErr := envelope.Body.SignablePreimage()
+	if pErr != nil {
+		// For tests that deliberately break the body, produce a dummy sig.
+		envelope.Signature = "ed25519:" + hex.EncodeToString(make([]byte, ed25519.SignatureSize))
+	} else {
+		sig := ed25519.Sign(priv, preimage)
+		envelope.Signature = "ed25519:" + hex.EncodeToString(sig)
+	}
+
+	// Apply post-sign mutations (signature tampering, etc.).
+	for _, o := range opts {
+		if fn, ok := o.(recoveryPostSignOpt); ok {
+			fn(&envelope)
+		}
+	}
+
+	// Serialize.
+	var data []byte
+	switch ext {
+	case envelopeExtYAML, envelopeExtYML:
+		// JSON is valid YAML; DecodeStrictYAML handles it.
+		data, err = json.Marshal(envelope)
+		if err != nil {
+			t.Fatalf("json marshal for yaml: %v", err)
+		}
+	default:
+		data, err = json.MarshalIndent(envelope, "", "  ")
+		if err != nil {
+			t.Fatalf("json marshal: %v", err)
+		}
+		data = append(data, '\n')
+	}
+
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "recovery_authorization"+ext)
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	// Compute fingerprint.
+	digest := sha256.Sum256(pub)
+	fpStr := "sha256:" + hex.EncodeToString(digest[:])
+
+	return fp, pub, fpStr
+}
+
+// --- LoadRecoveryAuthorization tests ---
+
+func TestLoadRecoveryAuthorization_HappyPath_JSON(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json")
+
+	loaded, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err != nil {
+		t.Fatalf("LoadRecoveryAuthorization: %v", err)
+	}
+	if loaded.Body.Reason != testRecoveryReason {
+		t.Errorf("Reason = %q, want %q", loaded.Body.Reason, testRecoveryReason)
+	}
+	if loaded.Body.OperatorIdentity != testRecoveryOperator {
+		t.Errorf("OperatorIdentity = %q, want %q", loaded.Body.OperatorIdentity, testRecoveryOperator)
+	}
+	if loaded.RecoveryRootFingerprint != fp {
+		t.Errorf("RecoveryRootFingerprint = %q, want %q", loaded.RecoveryRootFingerprint, fp)
+	}
+	if loaded.SourcePath == "" {
+		t.Error("SourcePath is empty")
+	}
+	if loaded.LoadedAt.IsZero() {
+		t.Error("LoadedAt is zero")
+	}
+}
+
+func TestLoadRecoveryAuthorization_HappyPath_YAML(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".yaml")
+
+	loaded, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err != nil {
+		t.Fatalf("LoadRecoveryAuthorization YAML: %v", err)
+	}
+	if loaded.Body.Reason != testRecoveryReason {
+		t.Errorf("Reason = %q, want %q", loaded.Body.Reason, testRecoveryReason)
+	}
+}
+
+func TestLoadRecoveryAuthorization_HappyPath_YML(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".yml")
+
+	loaded, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err != nil {
+		t.Fatalf("LoadRecoveryAuthorization YML: %v", err)
+	}
+	if loaded.Body.Reason != testRecoveryReason {
+		t.Errorf("Reason = %q, want %q", loaded.Body.Reason, testRecoveryReason)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectFileMissing(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	_, pub, fp := recoveryFixture(t, now, ".json")
+
+	_, err := LoadRecoveryAuthorization("/nonexistent/path/recovery.json", pub, fp, now)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !errors.Is(err, ErrRecoveryRead) {
+		t.Errorf("got %v, want ErrRecoveryRead", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectUnsupportedExtension(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	_, pub, fp := recoveryFixture(t, now, ".json")
+
+	dir := t.TempDir()
+	badPath := filepath.Join(dir, "recovery.txt")
+	if err := os.WriteFile(badPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadRecoveryAuthorization(badPath, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected error for unsupported extension")
+	}
+	if !errors.Is(err, ErrRecoveryUnsupportedExtension) {
+		t.Errorf("got %v, want ErrRecoveryUnsupportedExtension", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectMalformedJSON(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	_, pub, fp := recoveryFixture(t, now, ".json")
+
+	dir := t.TempDir()
+	badPath := filepath.Join(dir, "recovery.json")
+	if err := os.WriteFile(badPath, []byte("{bad json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadRecoveryAuthorization(badPath, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+	if !errors.Is(err, ErrRecoveryDecode) {
+		t.Errorf("got %v, want ErrRecoveryDecode", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectSchemaVersionWrong(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.SchemaVersion = 99
+	}))
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected ErrRecoverySchemaVersion")
+	}
+	if !errors.Is(err, ErrRecoverySchemaVersion) {
+		t.Errorf("got %v, want ErrRecoverySchemaVersion", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectMissingReason(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.Reason = ""
+	}))
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected ErrRecoveryReasonRequired")
+	}
+	if !errors.Is(err, ErrRecoveryReasonRequired) {
+		t.Errorf("got %v, want ErrRecoveryReasonRequired", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectMissingOperator(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.OperatorIdentity = ""
+	}))
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected ErrRecoveryOperatorRequired")
+	}
+	if !errors.Is(err, ErrRecoveryOperatorRequired) {
+		t.Errorf("got %v, want ErrRecoveryOperatorRequired", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectExpiresAtNotRFC3339(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.ExpiresAt = testRecoveryBadDate
+	}))
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected ErrRecoveryExpiryFormat")
+	}
+	if !errors.Is(err, ErrRecoveryExpiryFormat) {
+		t.Errorf("got %v, want ErrRecoveryExpiryFormat", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectIssuedAtNotRFC3339(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.IssuedAt = testRecoveryBadDate
+	}))
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected ErrRecoveryIssuedAtFormat")
+	}
+	if !errors.Is(err, ErrRecoveryIssuedAtFormat) {
+		t.Errorf("got %v, want ErrRecoveryIssuedAtFormat", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectTargetHashWrongPrefix(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.TargetRosterHash = "md5:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	}))
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected ErrRecoveryTargetHashFormat")
+	}
+	if !errors.Is(err, ErrRecoveryTargetHashFormat) {
+		t.Errorf("got %v, want ErrRecoveryTargetHashFormat", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectTargetHashWrongLength(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.TargetRosterHash = "sha256:aabb"
+	}))
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected ErrRecoveryTargetHashFormat")
+	}
+	if !errors.Is(err, ErrRecoveryTargetHashFormat) {
+		t.Errorf("got %v, want ErrRecoveryTargetHashFormat", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectTargetHashNonHex(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	// 64 chars but with non-hex 'g'.
+	badHash := "sha256:g3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.TargetRosterHash = badHash
+	}))
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected ErrRecoveryTargetHashFormat")
+	}
+	if !errors.Is(err, ErrRecoveryTargetHashFormat) {
+		t.Errorf("got %v, want ErrRecoveryTargetHashFormat", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectIssuedInTheFuture(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	// Set issued_at to 1 hour in the future.
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.IssuedAt = now.Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	}))
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected ErrRecoveryNotYetValid")
+	}
+	if !errors.Is(err, ErrRecoveryNotYetValid) {
+		t.Errorf("got %v, want ErrRecoveryNotYetValid", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectExpired(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	// Set expires_at to 1 minute ago.
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.ExpiresAt = now.Add(-1 * time.Minute).UTC().Format(time.RFC3339)
+	}))
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected ErrRecoveryExpired")
+	}
+	if !errors.Is(err, ErrRecoveryExpired) {
+		t.Errorf("got %v, want ErrRecoveryExpired", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectExpiryMoreThan1HourOut(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	// Set expires_at to 2 hours in the future.
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.ExpiresAt = now.Add(2 * time.Hour).UTC().Format(time.RFC3339)
+	}))
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected ErrRecoveryExpiryTooFar")
+	}
+	if !errors.Is(err, ErrRecoveryExpiryTooFar) {
+		t.Errorf("got %v, want ErrRecoveryExpiryTooFar", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_AcceptsExpiryExactly1Hour(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	// Set expires_at to exactly now + 1h. The check is > 1h, so exactly 1h passes.
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.ExpiresAt = now.Add(recoveryExpiryCeiling).UTC().Format(time.RFC3339)
+	}))
+
+	loaded, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err != nil {
+		t.Fatalf("expected exactly 1h expiry to be accepted, got: %v", err)
+	}
+	if loaded.Body.Reason != testRecoveryReason {
+		t.Errorf("Reason = %q, want %q", loaded.Body.Reason, testRecoveryReason)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectFingerprintMismatch(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, _ := recoveryFixture(t, now, ".json")
+
+	// Use a wrong pinned fingerprint (valid format but different digest).
+	wrongFP := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	_, err := LoadRecoveryAuthorization(path, pub, wrongFP, now)
+	if err == nil {
+		t.Fatal("expected ErrRecoveryFingerprintMismatch")
+	}
+	if !errors.Is(err, ErrRecoveryFingerprintMismatch) {
+		t.Errorf("got %v, want ErrRecoveryFingerprintMismatch", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectSignatureFormatBad(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sig  string
+	}{
+		{name: "empty", sig: ""},
+		{name: "wrong_prefix", sig: "sha256:aabb"},
+		{name: "wrong_length", sig: "ed25519:aabb"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+			path, pub, fp := recoveryFixture(t, now, ".json", recoveryPostSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+				env.Signature = tc.sig
+			}))
+
+			_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+			if err == nil {
+				t.Fatalf("expected ErrRecoverySignatureFormat for %q", tc.name)
+			}
+			if !errors.Is(err, ErrRecoverySignatureFormat) {
+				t.Errorf("got %v, want ErrRecoverySignatureFormat", err)
+			}
+		})
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectSignatureInvalid(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	// Flip last hex char in the signature to make it cryptographically invalid.
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPostSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		sig := env.Signature
+		lastChar := sig[len(sig)-1]
+		var replacement byte
+		if lastChar == '0' {
+			replacement = '1'
+		} else {
+			replacement = '0'
+		}
+		env.Signature = sig[:len(sig)-1] + string(replacement)
+	}))
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected ErrRecoverySignatureInvalid")
+	}
+	if !errors.Is(err, ErrRecoverySignatureInvalid) {
+		t.Errorf("got %v, want ErrRecoverySignatureInvalid", err)
+	}
+}
+
+// --- SignablePreimage tests ---
+
+func TestRecoveryAuthorizationBody_SignablePreimage_Stable(t *testing.T) {
+	t.Parallel()
+	body := RecoveryAuthorizationBody{
+		SchemaVersion:    1,
+		Reason:           testRecoveryReason,
+		ExpiresAt:        "2026-04-26T15:00:00Z",
+		TargetRosterHash: testRecoveryTargetHash,
+		OperatorIdentity: testRecoveryOperator,
+		IssuedAt:         "2026-04-26T13:00:00Z",
+	}
+
+	p1, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	p2, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if string(p1) != string(p2) {
+		t.Errorf("preimage not stable:\n  first:  %s\n  second: %s", p1, p2)
+	}
+	if len(p1) == 0 {
+		t.Error("preimage is empty")
+	}
+}
+
+// --- Validate tests (table-driven, isolated from time-window checks) ---
+
+func TestRecoveryAuthorizationBody_Validate_HappyPath(t *testing.T) {
+	t.Parallel()
+	body := RecoveryAuthorizationBody{
+		SchemaVersion:    1,
+		Reason:           testRecoveryReason,
+		ExpiresAt:        "2026-04-26T15:00:00Z",
+		TargetRosterHash: testRecoveryTargetHash,
+		OperatorIdentity: testRecoveryOperator,
+		IssuedAt:         "2026-04-26T13:00:00Z",
+	}
+	if err := body.Validate(); err != nil {
+		t.Fatalf("Validate happy path: %v", err)
+	}
+}
+
+func TestRecoveryAuthorizationBody_Validate_Errors(t *testing.T) {
+	t.Parallel()
+
+	validBody := RecoveryAuthorizationBody{
+		SchemaVersion:    1,
+		Reason:           testRecoveryReason,
+		ExpiresAt:        "2026-04-26T15:00:00Z",
+		TargetRosterHash: testRecoveryTargetHash,
+		OperatorIdentity: testRecoveryOperator,
+		IssuedAt:         "2026-04-26T13:00:00Z",
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*RecoveryAuthorizationBody)
+		wantErr error
+	}{
+		{
+			name:    "wrong_schema_version",
+			mutate:  func(b *RecoveryAuthorizationBody) { b.SchemaVersion = 0 },
+			wantErr: ErrRecoverySchemaVersion,
+		},
+		{
+			name:    "empty_reason",
+			mutate:  func(b *RecoveryAuthorizationBody) { b.Reason = "" },
+			wantErr: ErrRecoveryReasonRequired,
+		},
+		{
+			name:    "bad_expires_at",
+			mutate:  func(b *RecoveryAuthorizationBody) { b.ExpiresAt = "nope" },
+			wantErr: ErrRecoveryExpiryFormat,
+		},
+		{
+			name:    "bad_issued_at",
+			mutate:  func(b *RecoveryAuthorizationBody) { b.IssuedAt = "nope" },
+			wantErr: ErrRecoveryIssuedAtFormat,
+		},
+		{
+			name:    "target_hash_wrong_prefix",
+			mutate:  func(b *RecoveryAuthorizationBody) { b.TargetRosterHash = "md5:abcd" },
+			wantErr: ErrRecoveryTargetHashFormat,
+		},
+		{
+			name:    "target_hash_wrong_length",
+			mutate:  func(b *RecoveryAuthorizationBody) { b.TargetRosterHash = "sha256:abcd" },
+			wantErr: ErrRecoveryTargetHashFormat,
+		},
+		{
+			name: "target_hash_uppercase_hex",
+			mutate: func(b *RecoveryAuthorizationBody) {
+				b.TargetRosterHash = "sha256:E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855"
+			},
+			wantErr: ErrRecoveryTargetHashFormat,
+		},
+		{
+			name:    "empty_operator",
+			mutate:  func(b *RecoveryAuthorizationBody) { b.OperatorIdentity = "" },
+			wantErr: ErrRecoveryOperatorRequired,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := validBody
+			tc.mutate(&b)
+			err := b.Validate()
+			if err == nil {
+				t.Fatalf("expected %v, got nil", tc.wantErr)
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("got %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/signing/recovery_test.go
+++ b/internal/signing/recovery_test.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	goyaml "github.com/goccy/go-yaml"
 )
 
 // RFC 8032 section 7.1 test 2 private seed, split per G101 lint rule.
@@ -98,14 +100,17 @@ func recoveryFixture(t *testing.T, now time.Time, ext string, opts ...any) (path
 		}
 	}
 
-	// Serialize.
+	// Serialize. YAML extensions emit a native YAML document so the
+	// happy-path test exercises the YAML parser, not just the
+	// JSON-as-YAML compatibility surface (CodeRabbit thread on PR #444).
 	var data []byte
 	switch ext {
 	case envelopeExtYAML, envelopeExtYML:
-		// JSON is valid YAML; DecodeStrictYAML handles it.
-		data, err = json.Marshal(envelope)
+		data, err = goyaml.MarshalWithOptions(envelope,
+			goyaml.UseLiteralStyleIfMultiline(true),
+			goyaml.IndentSequence(true))
 		if err != nil {
-			t.Fatalf("json marshal for yaml: %v", err)
+			t.Fatalf("yaml marshal: %v", err)
 		}
 	default:
 		data, err = json.MarshalIndent(envelope, "", "  ")

--- a/internal/signing/recovery_test.go
+++ b/internal/signing/recovery_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -140,7 +141,7 @@ func TestLoadRecoveryAuthorization_HappyPath_JSON(t *testing.T) {
 	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
 	path, pub, fp := recoveryFixture(t, now, ".json")
 
-	loaded, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	loaded, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err != nil {
 		t.Fatalf("LoadRecoveryAuthorization: %v", err)
 	}
@@ -166,7 +167,7 @@ func TestLoadRecoveryAuthorization_HappyPath_YAML(t *testing.T) {
 	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
 	path, pub, fp := recoveryFixture(t, now, ".yaml")
 
-	loaded, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	loaded, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err != nil {
 		t.Fatalf("LoadRecoveryAuthorization YAML: %v", err)
 	}
@@ -180,7 +181,7 @@ func TestLoadRecoveryAuthorization_HappyPath_YML(t *testing.T) {
 	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
 	path, pub, fp := recoveryFixture(t, now, ".yml")
 
-	loaded, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	loaded, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err != nil {
 		t.Fatalf("LoadRecoveryAuthorization YML: %v", err)
 	}
@@ -194,7 +195,7 @@ func TestLoadRecoveryAuthorization_RejectFileMissing(t *testing.T) {
 	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
 	_, pub, fp := recoveryFixture(t, now, ".json")
 
-	_, err := LoadRecoveryAuthorization("/nonexistent/path/recovery.json", pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization("/nonexistent/path/recovery.json", pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}
@@ -214,7 +215,7 @@ func TestLoadRecoveryAuthorization_RejectUnsupportedExtension(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := LoadRecoveryAuthorization(badPath, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(badPath, pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected error for unsupported extension")
 	}
@@ -234,7 +235,7 @@ func TestLoadRecoveryAuthorization_RejectMalformedJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := LoadRecoveryAuthorization(badPath, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(badPath, pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected error for malformed JSON")
 	}
@@ -250,7 +251,7 @@ func TestLoadRecoveryAuthorization_RejectSchemaVersionWrong(t *testing.T) {
 		env.Body.SchemaVersion = 99
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected ErrRecoverySchemaVersion")
 	}
@@ -266,7 +267,7 @@ func TestLoadRecoveryAuthorization_RejectMissingReason(t *testing.T) {
 		env.Body.Reason = ""
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryReasonRequired")
 	}
@@ -282,7 +283,7 @@ func TestLoadRecoveryAuthorization_RejectMissingOperator(t *testing.T) {
 		env.Body.OperatorIdentity = ""
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryOperatorRequired")
 	}
@@ -298,7 +299,7 @@ func TestLoadRecoveryAuthorization_RejectExpiresAtNotRFC3339(t *testing.T) {
 		env.Body.ExpiresAt = testRecoveryBadDate
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryExpiryFormat")
 	}
@@ -314,7 +315,7 @@ func TestLoadRecoveryAuthorization_RejectIssuedAtNotRFC3339(t *testing.T) {
 		env.Body.IssuedAt = testRecoveryBadDate
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryIssuedAtFormat")
 	}
@@ -330,7 +331,7 @@ func TestLoadRecoveryAuthorization_RejectTargetHashWrongPrefix(t *testing.T) {
 		env.Body.TargetRosterHash = "md5:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryTargetHashFormat")
 	}
@@ -346,7 +347,7 @@ func TestLoadRecoveryAuthorization_RejectTargetHashWrongLength(t *testing.T) {
 		env.Body.TargetRosterHash = "sha256:aabb"
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryTargetHashFormat")
 	}
@@ -364,7 +365,7 @@ func TestLoadRecoveryAuthorization_RejectTargetHashNonHex(t *testing.T) {
 		env.Body.TargetRosterHash = badHash
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryTargetHashFormat")
 	}
@@ -383,7 +384,7 @@ func TestLoadRecoveryAuthorization_RejectIssuedInTheFuture(t *testing.T) {
 		env.Body.ExpiresAt = now.Add(1*time.Hour + 30*time.Minute).UTC().Format(time.RFC3339)
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryNotYetValid")
 	}
@@ -400,7 +401,7 @@ func TestLoadRecoveryAuthorization_RejectExpired(t *testing.T) {
 		env.Body.ExpiresAt = now.Add(-1 * time.Minute).UTC().Format(time.RFC3339)
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryExpired")
 	}
@@ -420,7 +421,7 @@ func TestLoadRecoveryAuthorization_RejectsLifetimeTooLong(t *testing.T) {
 		env.Body.ExpiresAt = now.Add(2 * time.Hour).UTC().Format(time.RFC3339)
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryLifetimeTooLong")
 	}
@@ -443,7 +444,7 @@ func TestLoadRecoveryAuthorization_RejectsStaleAuthShortRemaining(t *testing.T) 
 		env.Body.ExpiresAt = now.Add(30 * time.Minute).UTC().Format(time.RFC3339)
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if !errors.Is(err, ErrRecoveryLifetimeTooLong) {
 		t.Errorf("got %v, want ErrRecoveryLifetimeTooLong", err)
 	}
@@ -457,7 +458,7 @@ func TestLoadRecoveryAuthorization_RejectsExpiresBeforeIssued(t *testing.T) {
 		env.Body.ExpiresAt = now.Add(-30 * time.Minute).UTC().Format(time.RFC3339)
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if !errors.Is(err, ErrRecoveryExpiresBeforeIssued) {
 		t.Errorf("got %v, want ErrRecoveryExpiresBeforeIssued", err)
 	}
@@ -473,7 +474,7 @@ func TestLoadRecoveryAuthorization_AcceptsExpiryExactly1Hour(t *testing.T) {
 		env.Body.ExpiresAt = now.Add(recoveryExpiryCeiling).UTC().Format(time.RFC3339)
 	}))
 
-	loaded, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	loaded, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err != nil {
 		t.Fatalf("expected exactly 1h lifetime to be accepted, got: %v", err)
 	}
@@ -513,7 +514,7 @@ func TestLoadRecoveryAuthorization_RejectFingerprintMismatch(t *testing.T) {
 	// Use a wrong pinned fingerprint (valid format but different digest).
 	wrongFP := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
-	_, err := LoadRecoveryAuthorization(path, pub, wrongFP, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, wrongFP, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryFingerprintMismatch")
 	}
@@ -542,7 +543,7 @@ func TestLoadRecoveryAuthorization_RejectSignatureFormatBad(t *testing.T) {
 				env.Signature = tc.sig
 			}))
 
-			_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+			_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 			if err == nil {
 				t.Fatalf("expected ErrRecoverySignatureFormat for %q", tc.name)
 			}
@@ -569,7 +570,7 @@ func TestLoadRecoveryAuthorization_RejectSignatureInvalid(t *testing.T) {
 		env.Signature = sig[:len(sig)-1] + string(replacement)
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now)
 	if err == nil {
 		t.Fatal("expected ErrRecoverySignatureInvalid")
 	}
@@ -698,5 +699,102 @@ func TestRecoveryAuthorizationBody_Validate_Errors(t *testing.T) {
 				t.Errorf("got %v, want %v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+// TestLoadRecoveryAuthorization_RejectsEmptyTargetHash proves the runtime
+// entry point fails closed when expectedTargetRosterHash is empty, even when
+// every other input is valid. Matches the deep-review HIGH finding: a runtime
+// caller that forgets the parameter must not silently accept an
+// authorization for any roster.
+func TestLoadRecoveryAuthorization_RejectsEmptyTargetHash(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json")
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	if err == nil {
+		t.Fatal("expected ErrRecoveryTargetHashRequired, got nil")
+	}
+	if !errors.Is(err, ErrRecoveryTargetHashRequired) {
+		t.Errorf("got %v, want ErrRecoveryTargetHashRequired", err)
+	}
+}
+
+// TestInspectRecoveryAuthorizationOffline_HappyPath proves the offline entry
+// point loads a valid envelope without enforcing target binding, returning the
+// same envelope content the runtime path would.
+func TestInspectRecoveryAuthorizationOffline_HappyPath(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json")
+
+	loaded, err := InspectRecoveryAuthorizationOffline(path, pub, fp, now)
+	if err != nil {
+		t.Fatalf("InspectRecoveryAuthorizationOffline: %v", err)
+	}
+	if loaded.Body.Reason != testRecoveryReason {
+		t.Errorf("Reason = %q, want %q", loaded.Body.Reason, testRecoveryReason)
+	}
+	if loaded.Body.TargetRosterHash != testRecoveryTargetHash {
+		t.Errorf("TargetRosterHash = %q, want %q",
+			loaded.Body.TargetRosterHash, testRecoveryTargetHash)
+	}
+}
+
+// TestInspectRecoveryAuthorizationOffline_StillVerifiesSignature proves the
+// offline entry point only relaxes the target-binding check; signature
+// verification is still mandatory.
+func TestInspectRecoveryAuthorizationOffline_StillVerifiesSignature(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+
+	// Mutate the signature post-sign so verification fails. 64 bytes = 128 hex.
+	const badSig = "ed25519:" +
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPostSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Signature = badSig
+	}))
+
+	_, err := InspectRecoveryAuthorizationOffline(path, pub, fp, now)
+	if err == nil {
+		t.Fatal("expected signature verification failure, got nil")
+	}
+	if !errors.Is(err, ErrRecoverySignatureInvalid) {
+		t.Errorf("got %v, want ErrRecoverySignatureInvalid", err)
+	}
+}
+
+// TestLoadRecoveryAuthorization_StoresCanonicalFingerprint proves the
+// returned LoadedRecoveryAuthorization records the canonical lowercase-hex
+// fingerprint computed from the verified key, NOT the operator-supplied
+// string (which ParseFingerprint accepts in mixed case). Matches the
+// deep-review LOW finding: audit records must reflect the actual trust
+// anchor identity, not the keystroke that produced the pin.
+func TestLoadRecoveryAuthorization_StoresCanonicalFingerprint(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json")
+
+	// Operator typed the fingerprint with uppercase hex digits. ParseFingerprint
+	// accepts that, but the loaded record must store the canonical lowercase
+	// form computed from the public key directly.
+	upperFP := "sha256:" + strings.ToUpper(strings.TrimPrefix(fp, "sha256:"))
+	if upperFP == fp {
+		t.Fatalf("test setup: uppercase form is identical to lowercase, fp=%q", fp)
+	}
+
+	loaded, err := LoadRecoveryAuthorization(path, pub, upperFP, testRecoveryTargetHash, now)
+	if err != nil {
+		t.Fatalf("LoadRecoveryAuthorization: %v", err)
+	}
+	if loaded.RecoveryRootFingerprint != fp {
+		t.Errorf("RecoveryRootFingerprint = %q, want canonical %q (operator passed %q)",
+			loaded.RecoveryRootFingerprint, fp, upperFP)
+	}
+	if strings.ContainsAny(loaded.RecoveryRootFingerprint, "ABCDEF") {
+		t.Errorf("RecoveryRootFingerprint contains uppercase hex: %q",
+			loaded.RecoveryRootFingerprint)
 	}
 }

--- a/internal/signing/recovery_test.go
+++ b/internal/signing/recovery_test.go
@@ -135,7 +135,7 @@ func TestLoadRecoveryAuthorization_HappyPath_JSON(t *testing.T) {
 	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
 	path, pub, fp := recoveryFixture(t, now, ".json")
 
-	loaded, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	loaded, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err != nil {
 		t.Fatalf("LoadRecoveryAuthorization: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestLoadRecoveryAuthorization_HappyPath_YAML(t *testing.T) {
 	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
 	path, pub, fp := recoveryFixture(t, now, ".yaml")
 
-	loaded, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	loaded, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err != nil {
 		t.Fatalf("LoadRecoveryAuthorization YAML: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestLoadRecoveryAuthorization_HappyPath_YML(t *testing.T) {
 	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
 	path, pub, fp := recoveryFixture(t, now, ".yml")
 
-	loaded, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	loaded, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err != nil {
 		t.Fatalf("LoadRecoveryAuthorization YML: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestLoadRecoveryAuthorization_RejectFileMissing(t *testing.T) {
 	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
 	_, pub, fp := recoveryFixture(t, now, ".json")
 
-	_, err := LoadRecoveryAuthorization("/nonexistent/path/recovery.json", pub, fp, now)
+	_, err := LoadRecoveryAuthorization("/nonexistent/path/recovery.json", pub, fp, "", now)
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}
@@ -209,7 +209,7 @@ func TestLoadRecoveryAuthorization_RejectUnsupportedExtension(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := LoadRecoveryAuthorization(badPath, pub, fp, now)
+	_, err := LoadRecoveryAuthorization(badPath, pub, fp, "", now)
 	if err == nil {
 		t.Fatal("expected error for unsupported extension")
 	}
@@ -229,7 +229,7 @@ func TestLoadRecoveryAuthorization_RejectMalformedJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := LoadRecoveryAuthorization(badPath, pub, fp, now)
+	_, err := LoadRecoveryAuthorization(badPath, pub, fp, "", now)
 	if err == nil {
 		t.Fatal("expected error for malformed JSON")
 	}
@@ -245,7 +245,7 @@ func TestLoadRecoveryAuthorization_RejectSchemaVersionWrong(t *testing.T) {
 		env.Body.SchemaVersion = 99
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err == nil {
 		t.Fatal("expected ErrRecoverySchemaVersion")
 	}
@@ -261,7 +261,7 @@ func TestLoadRecoveryAuthorization_RejectMissingReason(t *testing.T) {
 		env.Body.Reason = ""
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryReasonRequired")
 	}
@@ -277,7 +277,7 @@ func TestLoadRecoveryAuthorization_RejectMissingOperator(t *testing.T) {
 		env.Body.OperatorIdentity = ""
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryOperatorRequired")
 	}
@@ -293,7 +293,7 @@ func TestLoadRecoveryAuthorization_RejectExpiresAtNotRFC3339(t *testing.T) {
 		env.Body.ExpiresAt = testRecoveryBadDate
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryExpiryFormat")
 	}
@@ -309,7 +309,7 @@ func TestLoadRecoveryAuthorization_RejectIssuedAtNotRFC3339(t *testing.T) {
 		env.Body.IssuedAt = testRecoveryBadDate
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryIssuedAtFormat")
 	}
@@ -325,7 +325,7 @@ func TestLoadRecoveryAuthorization_RejectTargetHashWrongPrefix(t *testing.T) {
 		env.Body.TargetRosterHash = "md5:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryTargetHashFormat")
 	}
@@ -341,7 +341,7 @@ func TestLoadRecoveryAuthorization_RejectTargetHashWrongLength(t *testing.T) {
 		env.Body.TargetRosterHash = "sha256:aabb"
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryTargetHashFormat")
 	}
@@ -359,7 +359,7 @@ func TestLoadRecoveryAuthorization_RejectTargetHashNonHex(t *testing.T) {
 		env.Body.TargetRosterHash = badHash
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryTargetHashFormat")
 	}
@@ -371,12 +371,14 @@ func TestLoadRecoveryAuthorization_RejectTargetHashNonHex(t *testing.T) {
 func TestLoadRecoveryAuthorization_RejectIssuedInTheFuture(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
-	// Set issued_at to 1 hour in the future.
+	// Set issued_at to 1 hour in the future, expires_at to 1h30m to keep the
+	// lifetime under the ceiling so we can test the issued-in-future gate.
 	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
 		env.Body.IssuedAt = now.Add(1 * time.Hour).UTC().Format(time.RFC3339)
+		env.Body.ExpiresAt = now.Add(1*time.Hour + 30*time.Minute).UTC().Format(time.RFC3339)
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryNotYetValid")
 	}
@@ -393,7 +395,7 @@ func TestLoadRecoveryAuthorization_RejectExpired(t *testing.T) {
 		env.Body.ExpiresAt = now.Add(-1 * time.Minute).UTC().Format(time.RFC3339)
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryExpired")
 	}
@@ -402,37 +404,99 @@ func TestLoadRecoveryAuthorization_RejectExpired(t *testing.T) {
 	}
 }
 
-func TestLoadRecoveryAuthorization_RejectExpiryMoreThan1HourOut(t *testing.T) {
+func TestLoadRecoveryAuthorization_RejectsLifetimeTooLong(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
-	// Set expires_at to 2 hours in the future.
+	// Lifetime = 2h10m (issued -10m, expires +2h) violates the lifetime cap
+	// regardless of where now sits inside the window. This is the cap that
+	// closes the "stale auth, short remaining" attack: a 30-day-old auth
+	// expiring in 30 minutes would slip past a remaining-only check.
 	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
 		env.Body.ExpiresAt = now.Add(2 * time.Hour).UTC().Format(time.RFC3339)
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err == nil {
-		t.Fatal("expected ErrRecoveryExpiryTooFar")
+		t.Fatal("expected ErrRecoveryLifetimeTooLong")
 	}
-	if !errors.Is(err, ErrRecoveryExpiryTooFar) {
-		t.Errorf("got %v, want ErrRecoveryExpiryTooFar", err)
+	if !errors.Is(err, ErrRecoveryLifetimeTooLong) {
+		t.Errorf("got %v, want ErrRecoveryLifetimeTooLong", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectsStaleAuthShortRemaining(t *testing.T) {
+	t.Parallel()
+	// The exact attack the lifetime cap closes: an authorization issued 30
+	// days ago but with expires_at 30 minutes from now. The remaining
+	// window (30m) passes the replay check, but the lifetime (30 days)
+	// blows past the ceiling. Without the lifetime cap this would be
+	// accepted and an attacker who stole the auth weeks ago could still use
+	// it.
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.IssuedAt = now.Add(-30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+		env.Body.ExpiresAt = now.Add(30 * time.Minute).UTC().Format(time.RFC3339)
+	}))
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	if !errors.Is(err, ErrRecoveryLifetimeTooLong) {
+		t.Errorf("got %v, want ErrRecoveryLifetimeTooLong", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectsExpiresBeforeIssued(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.IssuedAt = now.UTC().Format(time.RFC3339)
+		env.Body.ExpiresAt = now.Add(-30 * time.Minute).UTC().Format(time.RFC3339)
+	}))
+
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
+	if !errors.Is(err, ErrRecoveryExpiresBeforeIssued) {
+		t.Errorf("got %v, want ErrRecoveryExpiresBeforeIssued", err)
 	}
 }
 
 func TestLoadRecoveryAuthorization_AcceptsExpiryExactly1Hour(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
-	// Set expires_at to exactly now + 1h. The check is > 1h, so exactly 1h passes.
+	// Lifetime = exactly 1h (issued = now, expires = now + 1h). The
+	// lifetime cap allows equality, so this should be accepted.
 	path, pub, fp := recoveryFixture(t, now, ".json", recoveryPreSignOpt(func(env *RecoveryAuthorizationEnvelope) {
+		env.Body.IssuedAt = now.UTC().Format(time.RFC3339)
 		env.Body.ExpiresAt = now.Add(recoveryExpiryCeiling).UTC().Format(time.RFC3339)
 	}))
 
-	loaded, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	loaded, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err != nil {
-		t.Fatalf("expected exactly 1h expiry to be accepted, got: %v", err)
+		t.Fatalf("expected exactly 1h lifetime to be accepted, got: %v", err)
 	}
 	if loaded.Body.Reason != testRecoveryReason {
 		t.Errorf("Reason = %q, want %q", loaded.Body.Reason, testRecoveryReason)
+	}
+}
+
+func TestLoadRecoveryAuthorization_RejectsTargetRosterHashMismatch(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json")
+
+	const expected = "sha256:" + "0123456789abcdef0123456789abcdef" + "0123456789abcdef0123456789abcdef"
+	_, err := LoadRecoveryAuthorization(path, pub, fp, expected, now)
+	if !errors.Is(err, ErrRecoveryTargetHashMismatch) {
+		t.Errorf("got %v, want ErrRecoveryTargetHashMismatch", err)
+	}
+}
+
+func TestLoadRecoveryAuthorization_AcceptsMatchingTargetRosterHash(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 26, 14, 0, 0, 0, time.UTC)
+	path, pub, fp := recoveryFixture(t, now, ".json")
+
+	// recoveryFixture uses testRecoveryTargetHash for the body's TargetRosterHash.
+	if _, err := LoadRecoveryAuthorization(path, pub, fp, testRecoveryTargetHash, now); err != nil {
+		t.Errorf("expected matching target hash to be accepted, got: %v", err)
 	}
 }
 
@@ -444,7 +508,7 @@ func TestLoadRecoveryAuthorization_RejectFingerprintMismatch(t *testing.T) {
 	// Use a wrong pinned fingerprint (valid format but different digest).
 	wrongFP := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
-	_, err := LoadRecoveryAuthorization(path, pub, wrongFP, now)
+	_, err := LoadRecoveryAuthorization(path, pub, wrongFP, "", now)
 	if err == nil {
 		t.Fatal("expected ErrRecoveryFingerprintMismatch")
 	}
@@ -473,7 +537,7 @@ func TestLoadRecoveryAuthorization_RejectSignatureFormatBad(t *testing.T) {
 				env.Signature = tc.sig
 			}))
 
-			_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+			_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 			if err == nil {
 				t.Fatalf("expected ErrRecoverySignatureFormat for %q", tc.name)
 			}
@@ -500,7 +564,7 @@ func TestLoadRecoveryAuthorization_RejectSignatureInvalid(t *testing.T) {
 		env.Signature = sig[:len(sig)-1] + string(replacement)
 	}))
 
-	_, err := LoadRecoveryAuthorization(path, pub, fp, now)
+	_, err := LoadRecoveryAuthorization(path, pub, fp, "", now)
 	if err == nil {
 		t.Fatal("expected ErrRecoverySignatureInvalid")
 	}

--- a/internal/signing/root_transition.go
+++ b/internal/signing/root_transition.go
@@ -1,0 +1,279 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+)
+
+// rootTransitionSchemaVersion is the expected schema version for root
+// transition envelopes.
+const rootTransitionSchemaVersion = 1
+
+// rootTransitionFingerprintPattern validates "sha256:" followed by exactly 64
+// lowercase hex characters. Same format as targetRosterHashPattern in
+// recovery.go; own constant avoids cross-file coupling.
+var rootTransitionFingerprintPattern = regexp.MustCompile(
+	`^sha256:[0-9a-f]{64}$`,
+)
+
+// RootKind identifies which trust anchor a transition rotates.
+type RootKind string
+
+const (
+	// RootKindRoster identifies a roster-root key transition.
+	RootKindRoster RootKind = "roster-root"
+
+	// RootKindRecovery identifies a recovery-root key transition.
+	RootKindRecovery RootKind = "recovery-root"
+)
+
+// Validate returns nil if k is one of the two known kinds.
+func (k RootKind) Validate() error {
+	switch k {
+	case RootKindRoster, RootKindRecovery:
+		return nil
+	default:
+		return fmt.Errorf("%w: %q", ErrRootTransitionUnknownKind, string(k))
+	}
+}
+
+// Sentinel errors for root transition loading and validation.
+var (
+	ErrRootTransitionRead                   = errors.New("root transition read failed")
+	ErrRootTransitionDecode                 = errors.New("root transition decode failed")
+	ErrRootTransitionUnsupportedExtension   = errors.New("unsupported root transition file extension")
+	ErrRootTransitionInvalid                = errors.New("root transition body validation failed")
+	ErrRootTransitionUnknownKind            = errors.New("root_kind must be roster-root or recovery-root")
+	ErrRootTransitionFingerprintFormat      = errors.New("fingerprint must be sha256:<64 hex>")
+	ErrRootTransitionIdentityRotation       = errors.New("old_fingerprint and new_fingerprint must differ")
+	ErrRootTransitionEffectiveAtFormat      = errors.New("effective_at must be RFC 3339")
+	ErrRootTransitionReasonRequired         = errors.New("root transition reason is required")
+	ErrRootTransitionKeyLength              = errors.New("public key wrong length for ed25519")
+	ErrRootTransitionOldFingerprintMismatch = errors.New("provided oldPubKey does not match body.old_fingerprint")
+	ErrRootTransitionNewFingerprintMismatch = errors.New("provided newPubKey does not match body.new_fingerprint")
+	ErrRootTransitionPinMismatch            = errors.New("body.old_fingerprint does not match operator-pinned fingerprint")
+	ErrRootTransitionOldSignatureFormat     = errors.New("old_signature format invalid")
+	ErrRootTransitionNewSignatureFormat     = errors.New("new_signature format invalid")
+	ErrRootTransitionOldSignatureInvalid    = errors.New("old_signature does not verify")
+	ErrRootTransitionNewSignatureInvalid    = errors.New("new_signature does not verify")
+)
+
+// RootTransitionBody is the typed signable body of a root rotation document.
+type RootTransitionBody struct {
+	SchemaVersion  int      `json:"schema_version"`
+	RootKind       RootKind `json:"root_kind"`
+	OldFingerprint string   `json:"old_fingerprint"`
+	NewFingerprint string   `json:"new_fingerprint"`
+	EffectiveAt    string   `json:"effective_at"`
+	Reason         string   `json:"reason"`
+}
+
+// RootTransitionEnvelope is the on-disk wire format with TWO detached
+// signatures: one from the OLD root, one from the NEW root.
+type RootTransitionEnvelope struct {
+	Body         RootTransitionBody `json:"body"`
+	OldSignature string             `json:"old_signature"`
+	NewSignature string             `json:"new_signature"`
+}
+
+// LoadedRootTransition is a verified root transition bound to both the old
+// and new fingerprints that were used to verify it.
+type LoadedRootTransition struct {
+	Body         RootTransitionBody
+	OldSignature string
+	NewSignature string
+	LoadedAt     time.Time
+	SourcePath   string
+}
+
+// SignablePreimage returns JCS-canonical bytes of the body for signing
+// and verification. Both old and new signatures cover this preimage.
+func (b RootTransitionBody) SignablePreimage() ([]byte, error) {
+	raw, err := json.Marshal(b)
+	if err != nil {
+		return nil, fmt.Errorf("marshal root_transition body: %w", err)
+	}
+	tree, err := contract.ParseJSONStrict(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse root_transition for canonicalization: %w", err)
+	}
+	return contract.Canonicalize(tree)
+}
+
+// Validate runs structural checks on the body (no signature verification,
+// no fingerprint pinning):
+//   - SchemaVersion == 1
+//   - RootKind is roster-root or recovery-root
+//   - OldFingerprint matches "sha256:<64 lowercase hex>"
+//   - NewFingerprint matches "sha256:<64 lowercase hex>"
+//   - OldFingerprint != NewFingerprint (must actually rotate; identity reject)
+//   - EffectiveAt parses as RFC 3339
+//   - Reason non-empty
+func (b RootTransitionBody) Validate() error {
+	if b.SchemaVersion != rootTransitionSchemaVersion {
+		return fmt.Errorf("%w: schema_version=%d, want %d",
+			ErrRootTransitionInvalid, b.SchemaVersion, rootTransitionSchemaVersion)
+	}
+	if err := b.RootKind.Validate(); err != nil {
+		return err
+	}
+	if !rootTransitionFingerprintPattern.MatchString(b.OldFingerprint) {
+		return fmt.Errorf("%w: old_fingerprint=%q", ErrRootTransitionFingerprintFormat, b.OldFingerprint)
+	}
+	if !rootTransitionFingerprintPattern.MatchString(b.NewFingerprint) {
+		return fmt.Errorf("%w: new_fingerprint=%q", ErrRootTransitionFingerprintFormat, b.NewFingerprint)
+	}
+	if b.OldFingerprint == b.NewFingerprint {
+		return fmt.Errorf("%w: %s", ErrRootTransitionIdentityRotation, b.OldFingerprint)
+	}
+	if _, err := time.Parse(time.RFC3339, b.EffectiveAt); err != nil {
+		return fmt.Errorf("%w: %w", ErrRootTransitionEffectiveAtFormat, err)
+	}
+	if b.Reason == "" {
+		return ErrRootTransitionReasonRequired
+	}
+	return nil
+}
+
+// LoadRootTransition reads a root transition file from disk, decodes it
+// strictly, runs structural validation, then verifies BOTH detached
+// signatures (old AND new) against the supplied public keys. Both
+// signatures cover the same canonical preimage.
+//
+// Pinning by fingerprint:
+//   - Fingerprint(oldPubKey) MUST equal body.old_fingerprint AND
+//     equal pinnedOldFingerprint (the operator's currently-pinned root).
+//   - Fingerprint(newPubKey) MUST equal body.new_fingerprint.
+//
+// If pinnedOldFingerprint is empty string, the body.old_fingerprint check
+// against the supplied oldPubKey still runs but the operator-pin check
+// is skipped (used for offline ceremony verification before runtime pin
+// is updated).
+//
+// On success returns *LoadedRootTransition. The runtime applies the
+// transition by updating the operator-pinned fingerprint to NewFingerprint.
+func LoadRootTransition(
+	path string,
+	oldPubKey, newPubKey []byte,
+	pinnedOldFingerprint string,
+) (*LoadedRootTransition, error) {
+	// Step 1: Read file from disk.
+	cleanPath := filepath.Clean(path)
+	raw, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRootTransitionRead, err)
+	}
+
+	// Step 2: Decode based on file extension.
+	var envelope RootTransitionEnvelope
+	if decErr := decodeRootTransitionEnvelope(cleanPath, raw, &envelope); decErr != nil {
+		return nil, decErr
+	}
+
+	// Step 3: Structural validation of the body.
+	if valErr := envelope.Body.Validate(); valErr != nil {
+		return nil, valErr
+	}
+
+	// Step 4: Validate key lengths before fingerprinting.
+	if len(oldPubKey) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("%w: oldPubKey is %d bytes, want %d",
+			ErrRootTransitionKeyLength, len(oldPubKey), ed25519.PublicKeySize)
+	}
+	if len(newPubKey) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("%w: newPubKey is %d bytes, want %d",
+			ErrRootTransitionKeyLength, len(newPubKey), ed25519.PublicKeySize)
+	}
+
+	// Step 5: Verify oldPubKey fingerprint matches body.old_fingerprint.
+	oldFP, err := Fingerprint(oldPubKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRootTransitionOldFingerprintMismatch, err)
+	}
+	if oldFP != envelope.Body.OldFingerprint {
+		return nil, fmt.Errorf("%w: computed %s, body has %s",
+			ErrRootTransitionOldFingerprintMismatch, oldFP, envelope.Body.OldFingerprint)
+	}
+
+	// Step 6: Verify newPubKey fingerprint matches body.new_fingerprint.
+	newFP, err := Fingerprint(newPubKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRootTransitionNewFingerprintMismatch, err)
+	}
+	if newFP != envelope.Body.NewFingerprint {
+		return nil, fmt.Errorf("%w: computed %s, body has %s",
+			ErrRootTransitionNewFingerprintMismatch, newFP, envelope.Body.NewFingerprint)
+	}
+
+	// Step 7: If an operator pin is supplied, verify body.old_fingerprint matches it.
+	if pinnedOldFingerprint != "" && envelope.Body.OldFingerprint != pinnedOldFingerprint {
+		return nil, fmt.Errorf("%w: body=%s, pinned=%s",
+			ErrRootTransitionPinMismatch, envelope.Body.OldFingerprint, pinnedOldFingerprint)
+	}
+
+	// Step 8: Validate old_signature format.
+	oldSigBytes, sigErr := parseSignature(envelope.OldSignature)
+	if sigErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRootTransitionOldSignatureFormat, sigErr)
+	}
+
+	// Step 9: Validate new_signature format.
+	newSigBytes, sigErr := parseSignature(envelope.NewSignature)
+	if sigErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRootTransitionNewSignatureFormat, sigErr)
+	}
+
+	// Step 10: Compute preimage.
+	preimage, err := envelope.Body.SignablePreimage()
+	if err != nil {
+		return nil, fmt.Errorf("%w: preimage: %w", ErrRootTransitionOldSignatureInvalid, err)
+	}
+
+	// Step 11: Verify old signature.
+	if !contract.VerifyEd25519PureEdDSA(oldPubKey, preimage, oldSigBytes) {
+		return nil, fmt.Errorf("%w", ErrRootTransitionOldSignatureInvalid)
+	}
+
+	// Step 12: Verify new signature.
+	if !contract.VerifyEd25519PureEdDSA(newPubKey, preimage, newSigBytes) {
+		return nil, fmt.Errorf("%w", ErrRootTransitionNewSignatureInvalid)
+	}
+
+	return &LoadedRootTransition{
+		Body:         envelope.Body,
+		OldSignature: envelope.OldSignature,
+		NewSignature: envelope.NewSignature,
+		LoadedAt:     time.Now(),
+		SourcePath:   cleanPath,
+	}, nil
+}
+
+// decodeRootTransitionEnvelope dispatches file-extension-based strict decoding.
+func decodeRootTransitionEnvelope(cleanPath string, raw []byte, envelope *RootTransitionEnvelope) error {
+	ext := strings.ToLower(filepath.Ext(cleanPath))
+	switch ext {
+	case envelopeExtJSON:
+		if decErr := contract.DecodeStrictJSON(raw, envelope); decErr != nil {
+			return fmt.Errorf("%w: %w", ErrRootTransitionDecode, decErr)
+		}
+	case envelopeExtYAML, envelopeExtYML:
+		if decErr := contract.DecodeStrictYAML(raw, envelope); decErr != nil {
+			return fmt.Errorf("%w: %w", ErrRootTransitionDecode, decErr)
+		}
+	default:
+		return fmt.Errorf("%w: %q", ErrRootTransitionUnsupportedExtension, ext)
+	}
+	return nil
+}

--- a/internal/signing/root_transition_test.go
+++ b/internal/signing/root_transition_test.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	goyaml "github.com/goccy/go-yaml"
 )
 
 // Deterministic test seed for the OLD keypair (RFC 8032 section 7.1
@@ -122,14 +124,17 @@ func rootTransitionFixture(
 		}
 	}
 
-	// Serialize.
+	// Serialize. YAML extensions emit a native YAML document so the
+	// happy-path test exercises the YAML parser, not just the
+	// JSON-as-YAML compatibility surface (CodeRabbit thread on PR #444).
 	var data []byte
 	switch ext {
 	case envelopeExtYAML, envelopeExtYML:
-		// JSON is valid YAML; DecodeStrictYAML handles it.
-		data, err = json.Marshal(envelope)
+		data, err = goyaml.MarshalWithOptions(envelope,
+			goyaml.UseLiteralStyleIfMultiline(true),
+			goyaml.IndentSequence(true))
 		if err != nil {
-			t.Fatalf("json marshal for yaml: %v", err)
+			t.Fatalf("yaml marshal: %v", err)
 		}
 	default:
 		data, err = json.MarshalIndent(envelope, "", "  ")

--- a/internal/signing/root_transition_test.go
+++ b/internal/signing/root_transition_test.go
@@ -1,0 +1,733 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// RFC 8032 section 7.1 test 2 private seed for the OLD keypair, split per
+// G101 lint rule.
+const testRTOldSeedHex = "" +
+	"9d61b19d" + "effd5a60" + "ba844af4" + "92ec2cc4" +
+	"4449c569" + "8b64e70e" + "1b6ff1ae" + "1b6ff1ae"
+
+// Different seed for the NEW keypair (last 4 bytes flipped relative to old).
+const testRTNewSeedHex = "" +
+	"9d61b19d" + "effd5a60" + "ba844af4" + "92ec2cc4" +
+	"4449c569" + "8b64e70e" + "ae1bff6b" + "ae1bff6b"
+
+// testRTReason is the operator reason used in test fixtures.
+const testRTReason = "scheduled annual key rotation"
+
+// testRTEffectiveAt is a well-formed RFC 3339 timestamp for fixtures.
+const testRTEffectiveAt = "2026-04-26T15:00:00Z"
+
+// testRTBadDate is reused for RFC 3339 parse-failure tests.
+const testRTBadDate = "not-a-date"
+
+// testRTBadPrefixFP is a fingerprint with the wrong algorithm prefix.
+const testRTBadPrefixFP = "md5:abcd"
+
+// testRTShortFP is a fingerprint with valid prefix but wrong digest length.
+const testRTShortFP = "sha256:abcd"
+
+// rtPreSignOpt mutates the envelope body before the signatures are computed.
+type rtPreSignOpt func(env *RootTransitionEnvelope)
+
+// rtPostSignOpt mutates the envelope after the signatures are computed,
+// useful for corrupting signatures or fields post-signing.
+type rtPostSignOpt func(env *RootTransitionEnvelope)
+
+// rootTransitionFixture builds a known-good transition envelope, signs it
+// with deterministic old/new keypairs, writes to a temp file, and returns
+// (path, oldPub, newPub, oldFingerprint, newFingerprint).
+func rootTransitionFixture(
+	t *testing.T,
+	ext string,
+	kind RootKind,
+	opts ...any,
+) (path string, oldPub, newPub []byte, oldFP, newFP string) {
+	t.Helper()
+
+	oldSeed, err := hex.DecodeString(testRTOldSeedHex)
+	if err != nil {
+		t.Fatalf("decode old seed: %v", err)
+	}
+	oldPriv := ed25519.NewKeyFromSeed(oldSeed)
+	oldPub = oldPriv.Public().(ed25519.PublicKey)
+
+	newSeed, err := hex.DecodeString(testRTNewSeedHex)
+	if err != nil {
+		t.Fatalf("decode new seed: %v", err)
+	}
+	newPriv := ed25519.NewKeyFromSeed(newSeed)
+	newPub = newPriv.Public().(ed25519.PublicKey)
+
+	oldDigest := sha256.Sum256(oldPub)
+	oldFP = "sha256:" + hex.EncodeToString(oldDigest[:])
+
+	newDigest := sha256.Sum256(newPub)
+	newFP = "sha256:" + hex.EncodeToString(newDigest[:])
+
+	envelope := RootTransitionEnvelope{
+		Body: RootTransitionBody{
+			SchemaVersion:  1,
+			RootKind:       kind,
+			OldFingerprint: oldFP,
+			NewFingerprint: newFP,
+			EffectiveAt:    testRTEffectiveAt,
+			Reason:         testRTReason,
+		},
+	}
+
+	// Apply pre-sign mutations.
+	for _, o := range opts {
+		if fn, ok := o.(rtPreSignOpt); ok {
+			fn(&envelope)
+		}
+	}
+
+	// Sign the body with both keys.
+	preimage, pErr := envelope.Body.SignablePreimage()
+	if pErr != nil {
+		// For tests that deliberately break the body, produce dummy sigs.
+		dummySig := "ed25519:" + hex.EncodeToString(make([]byte, ed25519.SignatureSize))
+		envelope.OldSignature = dummySig
+		envelope.NewSignature = dummySig
+	} else {
+		oldSig := ed25519.Sign(oldPriv, preimage)
+		envelope.OldSignature = "ed25519:" + hex.EncodeToString(oldSig)
+		newSig := ed25519.Sign(newPriv, preimage)
+		envelope.NewSignature = "ed25519:" + hex.EncodeToString(newSig)
+	}
+
+	// Apply post-sign mutations (signature tampering, etc.).
+	for _, o := range opts {
+		if fn, ok := o.(rtPostSignOpt); ok {
+			fn(&envelope)
+		}
+	}
+
+	// Serialize.
+	var data []byte
+	switch ext {
+	case envelopeExtYAML, envelopeExtYML:
+		// JSON is valid YAML; DecodeStrictYAML handles it.
+		data, err = json.Marshal(envelope)
+		if err != nil {
+			t.Fatalf("json marshal for yaml: %v", err)
+		}
+	default:
+		data, err = json.MarshalIndent(envelope, "", "  ")
+		if err != nil {
+			t.Fatalf("json marshal: %v", err)
+		}
+		data = append(data, '\n')
+	}
+
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "root_transition"+ext)
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	return fp, oldPub, newPub, oldFP, newFP
+}
+
+// --- RootKind.Validate tests ---
+
+func TestRootKind_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		kind    RootKind
+		wantErr bool
+	}{
+		{name: "roster-root", kind: RootKindRoster, wantErr: false},
+		{name: "recovery-root", kind: RootKindRecovery, wantErr: false},
+		{name: "empty", kind: "", wantErr: true},
+		{name: "foo", kind: "foo", wantErr: true},
+		{name: "ROSTER-ROOT", kind: "ROSTER-ROOT", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.kind.Validate()
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr && !errors.Is(err, ErrRootTransitionUnknownKind) {
+				t.Errorf("got %v, want ErrRootTransitionUnknownKind", err)
+			}
+		})
+	}
+}
+
+// --- RootTransitionBody.Validate tests ---
+
+func TestRootTransitionBody_Validate_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	// Use distinct well-formed fingerprints.
+	body := RootTransitionBody{
+		SchemaVersion:  1,
+		RootKind:       RootKindRoster,
+		OldFingerprint: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		NewFingerprint: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		EffectiveAt:    testRTEffectiveAt,
+		Reason:         testRTReason,
+	}
+	if err := body.Validate(); err != nil {
+		t.Fatalf("Validate happy path: %v", err)
+	}
+}
+
+func TestRootTransitionBody_Validate_Errors(t *testing.T) {
+	t.Parallel()
+
+	validBody := RootTransitionBody{
+		SchemaVersion:  1,
+		RootKind:       RootKindRoster,
+		OldFingerprint: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		NewFingerprint: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		EffectiveAt:    testRTEffectiveAt,
+		Reason:         testRTReason,
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*RootTransitionBody)
+		wantErr error
+	}{
+		{
+			name:    "wrong_schema_version",
+			mutate:  func(b *RootTransitionBody) { b.SchemaVersion = 0 },
+			wantErr: ErrRootTransitionInvalid,
+		},
+		{
+			name:    "unknown_root_kind",
+			mutate:  func(b *RootTransitionBody) { b.RootKind = "bad-kind" },
+			wantErr: ErrRootTransitionUnknownKind,
+		},
+		{
+			name:    "empty_root_kind",
+			mutate:  func(b *RootTransitionBody) { b.RootKind = "" },
+			wantErr: ErrRootTransitionUnknownKind,
+		},
+		{
+			name:    "old_fingerprint_wrong_prefix",
+			mutate:  func(b *RootTransitionBody) { b.OldFingerprint = testRTBadPrefixFP },
+			wantErr: ErrRootTransitionFingerprintFormat,
+		},
+		{
+			name:    "old_fingerprint_wrong_length",
+			mutate:  func(b *RootTransitionBody) { b.OldFingerprint = testRTShortFP },
+			wantErr: ErrRootTransitionFingerprintFormat,
+		},
+		{
+			name: "old_fingerprint_uppercase_hex",
+			mutate: func(b *RootTransitionBody) {
+				b.OldFingerprint = "sha256:E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855"
+			},
+			wantErr: ErrRootTransitionFingerprintFormat,
+		},
+		{
+			name:    "new_fingerprint_wrong_prefix",
+			mutate:  func(b *RootTransitionBody) { b.NewFingerprint = testRTBadPrefixFP },
+			wantErr: ErrRootTransitionFingerprintFormat,
+		},
+		{
+			name:    "new_fingerprint_wrong_length",
+			mutate:  func(b *RootTransitionBody) { b.NewFingerprint = testRTShortFP },
+			wantErr: ErrRootTransitionFingerprintFormat,
+		},
+		{
+			name: "identity_rotation",
+			mutate: func(b *RootTransitionBody) {
+				b.NewFingerprint = b.OldFingerprint
+			},
+			wantErr: ErrRootTransitionIdentityRotation,
+		},
+		{
+			name:    "bad_effective_at",
+			mutate:  func(b *RootTransitionBody) { b.EffectiveAt = testRTBadDate },
+			wantErr: ErrRootTransitionEffectiveAtFormat,
+		},
+		{
+			name:    "empty_reason",
+			mutate:  func(b *RootTransitionBody) { b.Reason = "" },
+			wantErr: ErrRootTransitionReasonRequired,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := validBody
+			tc.mutate(&b)
+			err := b.Validate()
+			if err == nil {
+				t.Fatalf("expected %v, got nil", tc.wantErr)
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("got %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// --- SignablePreimage tests ---
+
+func TestRootTransitionBody_SignablePreimage_Stable(t *testing.T) {
+	t.Parallel()
+	body := RootTransitionBody{
+		SchemaVersion:  1,
+		RootKind:       RootKindRoster,
+		OldFingerprint: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		NewFingerprint: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		EffectiveAt:    testRTEffectiveAt,
+		Reason:         testRTReason,
+	}
+
+	p1, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	p2, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if string(p1) != string(p2) {
+		t.Errorf("preimage not stable:\n  first:  %s\n  second: %s", p1, p2)
+	}
+	if len(p1) == 0 {
+		t.Error("preimage is empty")
+	}
+}
+
+// --- LoadRootTransition tests ---
+
+func TestLoadRootTransition_HappyPath_JSON(t *testing.T) {
+	t.Parallel()
+	path, oldPub, newPub, oldFP, newFP := rootTransitionFixture(t, ".json", RootKindRoster)
+
+	loaded, err := LoadRootTransition(path, oldPub, newPub, oldFP)
+	if err != nil {
+		t.Fatalf("LoadRootTransition: %v", err)
+	}
+	if loaded.Body.RootKind != RootKindRoster {
+		t.Errorf("RootKind = %q, want %q", loaded.Body.RootKind, RootKindRoster)
+	}
+	if loaded.Body.Reason != testRTReason {
+		t.Errorf("Reason = %q, want %q", loaded.Body.Reason, testRTReason)
+	}
+	if loaded.Body.OldFingerprint != oldFP {
+		t.Errorf("OldFingerprint = %q, want %q", loaded.Body.OldFingerprint, oldFP)
+	}
+	if loaded.Body.NewFingerprint != newFP {
+		t.Errorf("NewFingerprint = %q, want %q", loaded.Body.NewFingerprint, newFP)
+	}
+	if loaded.SourcePath == "" {
+		t.Error("SourcePath is empty")
+	}
+	if loaded.LoadedAt.IsZero() {
+		t.Error("LoadedAt is zero")
+	}
+	if loaded.OldSignature == "" {
+		t.Error("OldSignature is empty")
+	}
+	if loaded.NewSignature == "" {
+		t.Error("NewSignature is empty")
+	}
+}
+
+func TestLoadRootTransition_HappyPath_YAML(t *testing.T) {
+	t.Parallel()
+	path, oldPub, newPub, oldFP, _ := rootTransitionFixture(t, ".yaml", RootKindRecovery)
+
+	loaded, err := LoadRootTransition(path, oldPub, newPub, oldFP)
+	if err != nil {
+		t.Fatalf("LoadRootTransition YAML: %v", err)
+	}
+	if loaded.Body.RootKind != RootKindRecovery {
+		t.Errorf("RootKind = %q, want %q", loaded.Body.RootKind, RootKindRecovery)
+	}
+}
+
+func TestLoadRootTransition_RejectFileMissing(t *testing.T) {
+	t.Parallel()
+	_, oldPub, newPub, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster)
+
+	_, err := LoadRootTransition("/nonexistent/path/transition.json", oldPub, newPub, oldFP)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !errors.Is(err, ErrRootTransitionRead) {
+		t.Errorf("got %v, want ErrRootTransitionRead", err)
+	}
+}
+
+func TestLoadRootTransition_RejectUnsupportedExtension(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	badPath := filepath.Join(dir, "transition.txt")
+	if err := os.WriteFile(badPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, oldPub, newPub, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster)
+
+	_, err := LoadRootTransition(badPath, oldPub, newPub, oldFP)
+	if err == nil {
+		t.Fatal("expected error for unsupported extension")
+	}
+	if !errors.Is(err, ErrRootTransitionUnsupportedExtension) {
+		t.Errorf("got %v, want ErrRootTransitionUnsupportedExtension", err)
+	}
+}
+
+func TestLoadRootTransition_RejectMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	badPath := filepath.Join(dir, "transition.json")
+	if err := os.WriteFile(badPath, []byte("{bad json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, oldPub, newPub, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster)
+
+	_, err := LoadRootTransition(badPath, oldPub, newPub, oldFP)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+	if !errors.Is(err, ErrRootTransitionDecode) {
+		t.Errorf("got %v, want ErrRootTransitionDecode", err)
+	}
+}
+
+func TestLoadRootTransition_RejectStructuralValidation(t *testing.T) {
+	t.Parallel()
+	// schema_version != 1 triggers structural validation failure.
+	path, oldPub, newPub, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster,
+		rtPreSignOpt(func(env *RootTransitionEnvelope) {
+			env.Body.SchemaVersion = 99
+		}))
+
+	_, err := LoadRootTransition(path, oldPub, newPub, oldFP)
+	if err == nil {
+		t.Fatal("expected ErrRootTransitionInvalid")
+	}
+	if !errors.Is(err, ErrRootTransitionInvalid) {
+		t.Errorf("got %v, want ErrRootTransitionInvalid", err)
+	}
+}
+
+func TestLoadRootTransition_RejectOldKeyWrongLength(t *testing.T) {
+	t.Parallel()
+	path, _, newPub, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster)
+
+	// 31-byte key: wrong length.
+	shortKey := make([]byte, 31)
+	_, err := LoadRootTransition(path, shortKey, newPub, oldFP)
+	if err == nil {
+		t.Fatal("expected ErrRootTransitionKeyLength")
+	}
+	if !errors.Is(err, ErrRootTransitionKeyLength) {
+		t.Errorf("got %v, want ErrRootTransitionKeyLength", err)
+	}
+}
+
+func TestLoadRootTransition_RejectNewKeyWrongLength(t *testing.T) {
+	t.Parallel()
+	path, oldPub, _, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster)
+
+	// 31-byte key: wrong length.
+	shortKey := make([]byte, 31)
+	_, err := LoadRootTransition(path, oldPub, shortKey, oldFP)
+	if err == nil {
+		t.Fatal("expected ErrRootTransitionKeyLength")
+	}
+	if !errors.Is(err, ErrRootTransitionKeyLength) {
+		t.Errorf("got %v, want ErrRootTransitionKeyLength", err)
+	}
+}
+
+func TestLoadRootTransition_RejectOldKeyFingerprintMismatch(t *testing.T) {
+	t.Parallel()
+	path, _, newPub, _, _ := rootTransitionFixture(t, ".json", RootKindRoster)
+
+	// Generate a different 32-byte key that does not match the body's old_fingerprint.
+	differentKey := make([]byte, ed25519.PublicKeySize)
+	differentKey[0] = 0xff
+	differentKey[1] = 0xfe
+
+	_, err := LoadRootTransition(path, differentKey, newPub, "")
+	if err == nil {
+		t.Fatal("expected ErrRootTransitionOldFingerprintMismatch")
+	}
+	if !errors.Is(err, ErrRootTransitionOldFingerprintMismatch) {
+		t.Errorf("got %v, want ErrRootTransitionOldFingerprintMismatch", err)
+	}
+}
+
+func TestLoadRootTransition_RejectNewKeyFingerprintMismatch(t *testing.T) {
+	t.Parallel()
+	path, oldPub, _, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster)
+
+	// Generate a different 32-byte key that does not match the body's new_fingerprint.
+	differentKey := make([]byte, ed25519.PublicKeySize)
+	differentKey[0] = 0xff
+	differentKey[1] = 0xfd
+
+	_, err := LoadRootTransition(path, oldPub, differentKey, oldFP)
+	if err == nil {
+		t.Fatal("expected ErrRootTransitionNewFingerprintMismatch")
+	}
+	if !errors.Is(err, ErrRootTransitionNewFingerprintMismatch) {
+		t.Errorf("got %v, want ErrRootTransitionNewFingerprintMismatch", err)
+	}
+}
+
+func TestLoadRootTransition_RejectPinnedFingerprintMismatch(t *testing.T) {
+	t.Parallel()
+	path, oldPub, newPub, _, _ := rootTransitionFixture(t, ".json", RootKindRoster)
+
+	// Valid format but different digest.
+	wrongPin := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	_, err := LoadRootTransition(path, oldPub, newPub, wrongPin)
+	if err == nil {
+		t.Fatal("expected ErrRootTransitionPinMismatch")
+	}
+	if !errors.Is(err, ErrRootTransitionPinMismatch) {
+		t.Errorf("got %v, want ErrRootTransitionPinMismatch", err)
+	}
+}
+
+func TestLoadRootTransition_AcceptsEmptyPin(t *testing.T) {
+	t.Parallel()
+	path, oldPub, newPub, _, _ := rootTransitionFixture(t, ".json", RootKindRoster)
+
+	// Empty pinnedOldFingerprint skips the pin check.
+	loaded, err := LoadRootTransition(path, oldPub, newPub, "")
+	if err != nil {
+		t.Fatalf("expected empty pin to be accepted, got: %v", err)
+	}
+	if loaded.Body.Reason != testRTReason {
+		t.Errorf("Reason = %q, want %q", loaded.Body.Reason, testRTReason)
+	}
+}
+
+func TestLoadRootTransition_RejectOldSignatureMissing(t *testing.T) {
+	t.Parallel()
+	path, oldPub, newPub, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster,
+		rtPostSignOpt(func(env *RootTransitionEnvelope) {
+			env.OldSignature = ""
+		}))
+
+	_, err := LoadRootTransition(path, oldPub, newPub, oldFP)
+	if err == nil {
+		t.Fatal("expected ErrRootTransitionOldSignatureFormat")
+	}
+	if !errors.Is(err, ErrRootTransitionOldSignatureFormat) {
+		t.Errorf("got %v, want ErrRootTransitionOldSignatureFormat", err)
+	}
+}
+
+func TestLoadRootTransition_RejectOldSignatureWrongFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sig  string
+	}{
+		{name: "wrong_prefix", sig: "sha256:aabb"},
+		{name: "wrong_length", sig: "ed25519:aabb"},
+		{name: "non_hex", sig: "ed25519:" + "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path, oldPub, newPub, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster,
+				rtPostSignOpt(func(env *RootTransitionEnvelope) {
+					env.OldSignature = tc.sig
+				}))
+
+			_, err := LoadRootTransition(path, oldPub, newPub, oldFP)
+			if err == nil {
+				t.Fatalf("expected ErrRootTransitionOldSignatureFormat for %q", tc.name)
+			}
+			if !errors.Is(err, ErrRootTransitionOldSignatureFormat) {
+				t.Errorf("got %v, want ErrRootTransitionOldSignatureFormat", err)
+			}
+		})
+	}
+}
+
+func TestLoadRootTransition_RejectNewSignatureMissing(t *testing.T) {
+	t.Parallel()
+	path, oldPub, newPub, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster,
+		rtPostSignOpt(func(env *RootTransitionEnvelope) {
+			env.NewSignature = ""
+		}))
+
+	_, err := LoadRootTransition(path, oldPub, newPub, oldFP)
+	if err == nil {
+		t.Fatal("expected ErrRootTransitionNewSignatureFormat")
+	}
+	if !errors.Is(err, ErrRootTransitionNewSignatureFormat) {
+		t.Errorf("got %v, want ErrRootTransitionNewSignatureFormat", err)
+	}
+}
+
+func TestLoadRootTransition_RejectNewSignatureWrongFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sig  string
+	}{
+		{name: "wrong_prefix", sig: "sha256:aabb"},
+		{name: "wrong_length", sig: "ed25519:aabb"},
+		{name: "non_hex", sig: "ed25519:" + "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path, oldPub, newPub, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster,
+				rtPostSignOpt(func(env *RootTransitionEnvelope) {
+					env.NewSignature = tc.sig
+				}))
+
+			_, err := LoadRootTransition(path, oldPub, newPub, oldFP)
+			if err == nil {
+				t.Fatalf("expected ErrRootTransitionNewSignatureFormat for %q", tc.name)
+			}
+			if !errors.Is(err, ErrRootTransitionNewSignatureFormat) {
+				t.Errorf("got %v, want ErrRootTransitionNewSignatureFormat", err)
+			}
+		})
+	}
+}
+
+func TestLoadRootTransition_RejectOldSignatureInvalid(t *testing.T) {
+	t.Parallel()
+	// Sign old_signature with a third-party key (not oldPub).
+	thirdPartySeedHex := "" +
+		"11111111" + "22222222" + "33333333" + "44444444" +
+		"55555555" + "66666666" + "77777777" + "88888888"
+
+	path, oldPub, newPub, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster,
+		rtPostSignOpt(func(env *RootTransitionEnvelope) {
+			thirdSeed, _ := hex.DecodeString(thirdPartySeedHex)
+			thirdPriv := ed25519.NewKeyFromSeed(thirdSeed)
+			preimage, err := env.Body.SignablePreimage()
+			if err != nil {
+				return
+			}
+			badSig := ed25519.Sign(thirdPriv, preimage)
+			env.OldSignature = "ed25519:" + hex.EncodeToString(badSig)
+		}))
+
+	_, err := LoadRootTransition(path, oldPub, newPub, oldFP)
+	if err == nil {
+		t.Fatal("expected ErrRootTransitionOldSignatureInvalid")
+	}
+	if !errors.Is(err, ErrRootTransitionOldSignatureInvalid) {
+		t.Errorf("got %v, want ErrRootTransitionOldSignatureInvalid", err)
+	}
+}
+
+func TestLoadRootTransition_RejectNewSignatureInvalid(t *testing.T) {
+	t.Parallel()
+	// Sign new_signature with oldPub's key instead of newPub's key (swap test).
+	path, oldPub, newPub, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster,
+		rtPostSignOpt(func(env *RootTransitionEnvelope) {
+			oldSeed, _ := hex.DecodeString(testRTOldSeedHex)
+			oldPriv := ed25519.NewKeyFromSeed(oldSeed)
+			preimage, err := env.Body.SignablePreimage()
+			if err != nil {
+				return
+			}
+			// Sign with old key instead of new key.
+			badSig := ed25519.Sign(oldPriv, preimage)
+			env.NewSignature = "ed25519:" + hex.EncodeToString(badSig)
+		}))
+
+	_, err := LoadRootTransition(path, oldPub, newPub, oldFP)
+	if err == nil {
+		t.Fatal("expected ErrRootTransitionNewSignatureInvalid")
+	}
+	if !errors.Is(err, ErrRootTransitionNewSignatureInvalid) {
+		t.Errorf("got %v, want ErrRootTransitionNewSignatureInvalid", err)
+	}
+}
+
+func TestLoadRootTransition_BothSignaturesPresentAndVerify(t *testing.T) {
+	t.Parallel()
+	// Positive sanity: a correctly dual-signed envelope loads fine.
+	// This is the counter-example to the swap test above.
+	path, oldPub, newPub, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster)
+
+	loaded, err := LoadRootTransition(path, oldPub, newPub, oldFP)
+	if err != nil {
+		t.Fatalf("expected both signatures to verify, got: %v", err)
+	}
+	if loaded.Body.Reason != testRTReason {
+		t.Errorf("Reason = %q, want %q", loaded.Body.Reason, testRTReason)
+	}
+	if loaded.OldSignature == loaded.NewSignature {
+		t.Error("old and new signatures should differ (different keys)")
+	}
+}
+
+func TestLoadRootTransition_HappyPath_YML(t *testing.T) {
+	t.Parallel()
+	path, oldPub, newPub, oldFP, _ := rootTransitionFixture(t, ".yml", RootKindRoster)
+
+	loaded, err := LoadRootTransition(path, oldPub, newPub, oldFP)
+	if err != nil {
+		t.Fatalf("LoadRootTransition YML: %v", err)
+	}
+	if loaded.Body.RootKind != RootKindRoster {
+		t.Errorf("RootKind = %q, want %q", loaded.Body.RootKind, RootKindRoster)
+	}
+}
+
+func TestLoadRootTransition_RejectMalformedYAML(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	badPath := filepath.Join(dir, "transition.yaml")
+	if err := os.WriteFile(badPath, []byte("{bad yaml: ["), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, oldPub, newPub, oldFP, _ := rootTransitionFixture(t, ".json", RootKindRoster)
+
+	_, err := LoadRootTransition(badPath, oldPub, newPub, oldFP)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML")
+	}
+	if !errors.Is(err, ErrRootTransitionDecode) {
+		t.Errorf("got %v, want ErrRootTransitionDecode", err)
+	}
+}

--- a/internal/signing/root_transition_test.go
+++ b/internal/signing/root_transition_test.go
@@ -14,13 +14,18 @@ import (
 	"testing"
 )
 
-// RFC 8032 section 7.1 test 2 private seed for the OLD keypair, split per
-// G101 lint rule.
+// Deterministic test seed for the OLD keypair (RFC 8032 section 7.1
+// test 1's first 24 bytes, with the trailing 8 bytes replaced by a
+// duplicated 1b6ff1ae block so the OLD and NEW seeds below differ in
+// their suffix without colliding with any published vector). Split
+// across string concatenations per G101 lint rule.
 const testRTOldSeedHex = "" +
 	"9d61b19d" + "effd5a60" + "ba844af4" + "92ec2cc4" +
 	"4449c569" + "8b64e70e" + "1b6ff1ae" + "1b6ff1ae"
 
-// Different seed for the NEW keypair (last 4 bytes flipped relative to old).
+// NEW keypair seed: same first 24 bytes as OLD, with the trailing 8
+// bytes replaced by ae1bff6b ae1bff6b so the two seeds produce
+// distinct keypairs without colliding with any RFC 8032 vector.
 const testRTNewSeedHex = "" +
 	"9d61b19d" + "effd5a60" + "ba844af4" + "92ec2cc4" +
 	"4449c569" + "8b64e70e" + "ae1bff6b" + "ae1bff6b"

--- a/internal/signing/roster.go
+++ b/internal/signing/roster.go
@@ -84,11 +84,11 @@ func LoadRoster(path string, pinnedRootFingerprint string) (*LoadedRoster, error
 	var envelope contract.RosterEnvelope
 	ext := strings.ToLower(filepath.Ext(cleanPath))
 	switch ext {
-	case ".json":
+	case envelopeExtJSON:
 		if decErr := contract.DecodeStrictJSON(raw, &envelope); decErr != nil {
 			return nil, fmt.Errorf("%w: %w", ErrRosterDecode, decErr)
 		}
-	case ".yaml", ".yml":
+	case envelopeExtYAML, envelopeExtYML:
 		if decErr := contract.DecodeStrictYAML(raw, &envelope); decErr != nil {
 			return nil, fmt.Errorf("%w: %w", ErrRosterDecode, decErr)
 		}
@@ -104,7 +104,7 @@ func LoadRoster(path string, pinnedRootFingerprint string) (*LoadedRoster, error
 	// Step 4: Validate signature format.
 	sigBytes, err := parseSignature(envelope.Signature)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrRosterSignatureFormat, err)
 	}
 
 	// Step 5: Locate the root key referenced by roster_signed_by.
@@ -152,21 +152,23 @@ func LoadRoster(path string, pinnedRootFingerprint string) (*LoadedRoster, error
 }
 
 // parseSignature validates and decodes the "ed25519:<hex>" wire format.
+// Returns descriptive errors WITHOUT a package-level sentinel; callers wrap
+// with their own ErrXxxSignatureFormat sentinel so that errors.Is works for
+// the right scope.
 func parseSignature(sig string) ([]byte, error) {
 	if sig == "" {
-		return nil, fmt.Errorf("%w: empty signature", ErrRosterSignatureFormat)
+		return nil, errors.New("empty signature")
 	}
 	if !strings.HasPrefix(sig, ed25519SignaturePrefix) {
-		return nil, fmt.Errorf("%w: missing %q prefix", ErrRosterSignatureFormat, ed25519SignaturePrefix)
+		return nil, fmt.Errorf("missing %q prefix", ed25519SignaturePrefix)
 	}
 	hexPart := sig[len(ed25519SignaturePrefix):]
 	if len(hexPart) != ed25519SignatureHexLen {
-		return nil, fmt.Errorf("%w: hex length %d, want %d",
-			ErrRosterSignatureFormat, len(hexPart), ed25519SignatureHexLen)
+		return nil, fmt.Errorf("hex length %d, want %d", len(hexPart), ed25519SignatureHexLen)
 	}
 	sigBytes, err := hex.DecodeString(hexPart)
 	if err != nil {
-		return nil, fmt.Errorf("%w: invalid hex: %w", ErrRosterSignatureFormat, err)
+		return nil, fmt.Errorf("invalid hex: %w", err)
 	}
 	return sigBytes, nil
 }

--- a/internal/signing/roster.go
+++ b/internal/signing/roster.go
@@ -4,6 +4,7 @@
 package signing
 
 import (
+	"crypto/ed25519"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -30,6 +31,10 @@ var (
 	ErrRosterKeyRevoked              = errors.New("key is revoked")
 	ErrRosterKeyNotYetValid          = errors.New("key is not yet valid")
 	ErrRosterKeyExpired              = errors.New("key is expired")
+	ErrRosterKeyInvalidStatus        = errors.New("key has unknown status")
+	ErrRosterKeyNotActive            = errors.New("key is not active")
+	ErrRosterKeyMissingPublicKey     = errors.New("key has missing or malformed public_key_hex")
+	ErrRosterKeyInvalidPurpose       = errors.New("key has unknown key_purpose")
 )
 
 // ed25519SignaturePrefix is the wire-format prefix for Ed25519 detached signatures.
@@ -98,6 +103,15 @@ func LoadRoster(path string, pinnedRootFingerprint string) (*LoadedRoster, error
 
 	// Step 3: Structural validation of the body.
 	if valErr := envelope.Body.Validate(); valErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRosterInvalid, valErr)
+	}
+
+	// Step 3b: Strict per-key validation. The contract package's Validate()
+	// only checks duplicate IDs, root presence, and data class root. The
+	// signing package owns runtime trust decisions, so it tightens the gate:
+	// every key MUST have a known status, a known purpose, and a parseable
+	// 32-byte ed25519 public key.
+	if valErr := validateKeyInfos(envelope.Body.Keys); valErr != nil {
 		return nil, fmt.Errorf("%w: %w", ErrRosterInvalid, valErr)
 	}
 
@@ -173,6 +187,38 @@ func parseSignature(sig string) ([]byte, error) {
 	return sigBytes, nil
 }
 
+// validateKeyInfos runs strict per-key checks on every entry in a roster
+// body. It is the runtime-trust gate that catches values the contract
+// package's structural Validate() intentionally lets through (the contract
+// package validates SCHEMA; the signing package validates TRUST).
+//
+// Reject cases:
+//   - Status not in {active, revoked, root}              -> ErrRosterKeyInvalidStatus
+//   - KeyPurpose is not one of the six known purposes     -> ErrRosterKeyInvalidPurpose
+//   - PublicKeyHex is empty, non-hex, or wrong length     -> ErrRosterKeyMissingPublicKey
+func validateKeyInfos(keys []contract.KeyInfo) error {
+	for _, k := range keys {
+		switch k.Status {
+		case contract.KeyStatusActive, contract.KeyStatusRevoked, contract.KeyStatusRoot:
+			// known
+		default:
+			return fmt.Errorf("%w: key_id=%q status=%q", ErrRosterKeyInvalidStatus, k.KeyID, k.Status)
+		}
+		if err := KeyPurpose(k.KeyPurpose).Validate(); err != nil {
+			return fmt.Errorf("%w: key_id=%q: %w", ErrRosterKeyInvalidPurpose, k.KeyID, err)
+		}
+		pub, err := hex.DecodeString(k.PublicKeyHex)
+		if err != nil {
+			return fmt.Errorf("%w: key_id=%q hex decode: %w", ErrRosterKeyMissingPublicKey, k.KeyID, err)
+		}
+		if len(pub) != ed25519.PublicKeySize {
+			return fmt.Errorf("%w: key_id=%q got %d bytes, want %d",
+				ErrRosterKeyMissingPublicKey, k.KeyID, len(pub), ed25519.PublicKeySize)
+		}
+	}
+	return nil
+}
+
 // findRootKey locates the key in body.Keys whose key_id matches
 // body.RosterSignedBy AND whose status is "root".
 func findRootKey(body contract.KeyRoster) (contract.KeyInfo, error) {
@@ -189,11 +235,22 @@ func findRootKey(body contract.KeyRoster) (contract.KeyInfo, error) {
 }
 
 // ResolveKey returns the active, in-window key info for the given key_id.
+// Only keys with status="active" are resolvable; revoked, root, and any
+// unrecognised status reject. Root keys are intentionally not resolvable
+// here because they sign rosters and root transitions, never runtime
+// payloads — the loader uses findRootKey internally for that lookup.
+//
 // Reject cases (typed sentinels):
 //   - key_id not in roster                        -> ErrRosterKeyUnknown
 //   - key status is revoked                       -> ErrRosterKeyRevoked
+//   - key status is root                          -> ErrRosterKeyNotActive
+//   - key status is anything else                 -> ErrRosterKeyInvalidStatus
 //   - now < valid_from                            -> ErrRosterKeyNotYetValid
 //   - now > valid_until (when valid_until is set) -> ErrRosterKeyExpired
+//
+// LoadRoster runs validateKeyInfos before this method is reachable, so
+// unknown statuses are normally rejected at load time. The defense-in-depth
+// check here is for callers who construct a LoadedRoster by other means.
 //
 // The now parameter is for testability; pass time.Now() in production.
 // valid_from / valid_until on the wire are RFC 3339 UTC strings.
@@ -203,9 +260,16 @@ func (r *LoadedRoster) ResolveKey(keyID string, now time.Time) (contract.KeyInfo
 			continue
 		}
 
-		// Status check.
-		if k.Status == contract.KeyStatusRevoked {
+		// Status check: only active keys are resolvable.
+		switch k.Status {
+		case contract.KeyStatusActive:
+			// proceed to window check
+		case contract.KeyStatusRevoked:
 			return contract.KeyInfo{}, fmt.Errorf("%w: %q", ErrRosterKeyRevoked, keyID)
+		case contract.KeyStatusRoot:
+			return contract.KeyInfo{}, fmt.Errorf("%w: key_id=%q has status=root", ErrRosterKeyNotActive, keyID)
+		default:
+			return contract.KeyInfo{}, fmt.Errorf("%w: key_id=%q status=%q", ErrRosterKeyInvalidStatus, keyID, k.Status)
 		}
 
 		// Window check: valid_from.
@@ -235,10 +299,12 @@ func (r *LoadedRoster) ResolveKey(keyID string, now time.Time) (contract.KeyInfo
 	return contract.KeyInfo{}, fmt.Errorf("%w: %q", ErrRosterKeyUnknown, keyID)
 }
 
-// AuthorizeSignature combines roster lifecycle checks with the contract
-// package's payload-kind authority matrix. It is the canonical "is this
-// signature legitimate for this payload kind, by this key, right now"
-// gate.
+// AuthorizeSignerForPayload checks that signerKeyID is allowed to author the
+// given payload kind RIGHT NOW. It is the lifecycle-and-purpose gate, NOT a
+// cryptographic signature verifier — the actual Ed25519 verification happens
+// at the call site using the resolved key's public key. The name reflects
+// that distinction: this function answers "is this signer permitted?", not
+// "is this signature valid?".
 //
 // Steps (all must pass; first failure returns):
 //  1. Resolve the key via ResolveKey (active + in-window).
@@ -248,7 +314,7 @@ func (r *LoadedRoster) ResolveKey(keyID string, now time.Time) (contract.KeyInfo
 // Returns nil iff all three pass. Errors preserve errors.Is on every
 // underlying sentinel (ResolveKey's, contract.ErrWrongKeyPurpose,
 // contract.ErrUnknownPayloadKind, ErrUnknownKeyPurpose).
-func (r *LoadedRoster) AuthorizeSignature(payloadKind, signerKeyID string, now time.Time) error {
+func (r *LoadedRoster) AuthorizeSignerForPayload(payloadKind, signerKeyID string, now time.Time) error {
 	key, err := r.ResolveKey(signerKeyID, now)
 	if err != nil {
 		return err

--- a/internal/signing/roster.go
+++ b/internal/signing/roster.go
@@ -1,0 +1,261 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+)
+
+// Sentinel errors for roster loading and key resolution.
+var (
+	ErrRosterRead                    = errors.New("roster read failed")
+	ErrRosterDecode                  = errors.New("roster decode failed")
+	ErrRosterUnsupportedExtension    = errors.New("unsupported roster file extension")
+	ErrRosterInvalid                 = errors.New("roster body validation failed")
+	ErrRosterSignatureFormat         = errors.New("roster signature format invalid")
+	ErrRosterSignatureInvalid        = errors.New("roster signature does not verify")
+	ErrRosterRootMissing             = errors.New("roster root key missing or wrong status")
+	ErrRosterRootWrongPurpose        = errors.New("roster root key has wrong key_purpose")
+	ErrRosterRootFingerprintMismatch = errors.New("roster root key fingerprint does not match pinned")
+	ErrRosterKeyUnknown              = errors.New("key_id not in roster")
+	ErrRosterKeyRevoked              = errors.New("key is revoked")
+	ErrRosterKeyNotYetValid          = errors.New("key is not yet valid")
+	ErrRosterKeyExpired              = errors.New("key is expired")
+)
+
+// ed25519SignaturePrefix is the wire-format prefix for Ed25519 detached signatures.
+const ed25519SignaturePrefix = "ed25519:"
+
+// ed25519SignatureHexLen is the expected hex-encoded length of an Ed25519
+// signature: 64 bytes = 128 hex characters.
+const ed25519SignatureHexLen = 128
+
+// LoadedRoster is a verified deployment-local key roster bound to the
+// pinned roster-root fingerprint that was used to verify it.
+type LoadedRoster struct {
+	Body                  contract.KeyRoster
+	Signature             string    // "ed25519:<hex>" form, kept for audit traces
+	RosterRootFingerprint string    // pinned fingerprint that authenticated this roster
+	LoadedAt              time.Time // wall-clock at successful verify
+	SourcePath            string    // file path it came from, for diagnostic logs
+}
+
+// LoadRoster reads a roster file from disk, decodes it strictly, runs
+// structural validation, then cryptographically verifies the detached
+// signature against the key inside the roster body whose key_id matches
+// roster_signed_by AND whose fingerprint matches the operator-pinned
+// rosterRootFingerprint.
+//
+// Format: file extension determines decoder (.yaml/.yml -> DecodeStrictYAML,
+// .json -> DecodeStrictJSON). Other extensions reject with a typed error.
+//
+// Reject cases (each gets a typed sentinel that errors.Is can match):
+//
+//   - File missing or unreadable                  -> ErrRosterRead
+//   - Decoder failure                             -> ErrRosterDecode (wraps the underlying err)
+//   - Body fails contract.KeyRoster.Validate()    -> ErrRosterInvalid
+//   - signature missing or wrong prefix           -> ErrRosterSignatureFormat
+//   - signature hex malformed or wrong length      -> ErrRosterSignatureFormat
+//   - roster_signed_by key_id not in body.Keys    -> ErrRosterRootMissing
+//   - referenced root key has wrong purpose       -> ErrRosterRootWrongPurpose
+//   - referenced root key has wrong status         -> ErrRosterRootMissing
+//   - referenced root key fingerprint != pinned   -> ErrRosterRootFingerprintMismatch
+//   - signature does not verify                   -> ErrRosterSignatureInvalid
+//
+// On success returns *LoadedRoster bound to the pinned fingerprint.
+func LoadRoster(path string, pinnedRootFingerprint string) (*LoadedRoster, error) {
+	// Step 1: Read file from disk.
+	cleanPath := filepath.Clean(path)
+	raw, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRosterRead, err)
+	}
+
+	// Step 2: Decode based on file extension.
+	var envelope contract.RosterEnvelope
+	ext := strings.ToLower(filepath.Ext(cleanPath))
+	switch ext {
+	case ".json":
+		if decErr := contract.DecodeStrictJSON(raw, &envelope); decErr != nil {
+			return nil, fmt.Errorf("%w: %w", ErrRosterDecode, decErr)
+		}
+	case ".yaml", ".yml":
+		if decErr := contract.DecodeStrictYAML(raw, &envelope); decErr != nil {
+			return nil, fmt.Errorf("%w: %w", ErrRosterDecode, decErr)
+		}
+	default:
+		return nil, fmt.Errorf("%w: %q", ErrRosterUnsupportedExtension, ext)
+	}
+
+	// Step 3: Structural validation of the body.
+	if valErr := envelope.Body.Validate(); valErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRosterInvalid, valErr)
+	}
+
+	// Step 4: Validate signature format.
+	sigBytes, err := parseSignature(envelope.Signature)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 5: Locate the root key referenced by roster_signed_by.
+	rootKey, err := findRootKey(envelope.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 6: Verify root key purpose.
+	rootPurpose := KeyPurpose(rootKey.KeyPurpose)
+	if rootPurpose != PurposeRosterRoot {
+		return nil, fmt.Errorf("%w: got %q, want %q",
+			ErrRosterRootWrongPurpose, rootKey.KeyPurpose, PurposeRosterRoot)
+	}
+
+	// Step 7: Decode root public key and verify fingerprint against pinned.
+	rootPubBytes, err := hex.DecodeString(rootKey.PublicKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid root public key hex: %w", ErrRosterRootMissing, err)
+	}
+	if fpErr := VerifyFingerprint(rootPubBytes, pinnedRootFingerprint); fpErr != nil {
+		if errors.Is(fpErr, ErrFingerprintMismatch) {
+			return nil, fmt.Errorf("%w: %w", ErrRosterRootFingerprintMismatch, fpErr)
+		}
+		// Format errors in the pinned fingerprint also reject.
+		return nil, fmt.Errorf("%w: %w", ErrRosterRootFingerprintMismatch, fpErr)
+	}
+
+	// Step 8: Compute preimage and verify signature.
+	preimage, err := envelope.Body.SignablePreimage()
+	if err != nil {
+		return nil, fmt.Errorf("%w: preimage: %w", ErrRosterSignatureInvalid, err)
+	}
+	if !contract.VerifyEd25519PureEdDSA(rootPubBytes, preimage, sigBytes) {
+		return nil, fmt.Errorf("%w", ErrRosterSignatureInvalid)
+	}
+
+	return &LoadedRoster{
+		Body:                  envelope.Body,
+		Signature:             envelope.Signature,
+		RosterRootFingerprint: pinnedRootFingerprint,
+		LoadedAt:              time.Now(),
+		SourcePath:            cleanPath,
+	}, nil
+}
+
+// parseSignature validates and decodes the "ed25519:<hex>" wire format.
+func parseSignature(sig string) ([]byte, error) {
+	if sig == "" {
+		return nil, fmt.Errorf("%w: empty signature", ErrRosterSignatureFormat)
+	}
+	if !strings.HasPrefix(sig, ed25519SignaturePrefix) {
+		return nil, fmt.Errorf("%w: missing %q prefix", ErrRosterSignatureFormat, ed25519SignaturePrefix)
+	}
+	hexPart := sig[len(ed25519SignaturePrefix):]
+	if len(hexPart) != ed25519SignatureHexLen {
+		return nil, fmt.Errorf("%w: hex length %d, want %d",
+			ErrRosterSignatureFormat, len(hexPart), ed25519SignatureHexLen)
+	}
+	sigBytes, err := hex.DecodeString(hexPart)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid hex: %w", ErrRosterSignatureFormat, err)
+	}
+	return sigBytes, nil
+}
+
+// findRootKey locates the key in body.Keys whose key_id matches
+// body.RosterSignedBy AND whose status is "root".
+func findRootKey(body contract.KeyRoster) (contract.KeyInfo, error) {
+	for _, k := range body.Keys {
+		if k.KeyID == body.RosterSignedBy {
+			if k.Status != contract.KeyStatusRoot {
+				return contract.KeyInfo{}, fmt.Errorf("%w: key %q has status %q, want %q",
+					ErrRosterRootMissing, k.KeyID, k.Status, contract.KeyStatusRoot)
+			}
+			return k, nil
+		}
+	}
+	return contract.KeyInfo{}, fmt.Errorf("%w: key_id %q not found", ErrRosterRootMissing, body.RosterSignedBy)
+}
+
+// ResolveKey returns the active, in-window key info for the given key_id.
+// Reject cases (typed sentinels):
+//   - key_id not in roster                        -> ErrRosterKeyUnknown
+//   - key status is revoked                       -> ErrRosterKeyRevoked
+//   - now < valid_from                            -> ErrRosterKeyNotYetValid
+//   - now > valid_until (when valid_until is set) -> ErrRosterKeyExpired
+//
+// The now parameter is for testability; pass time.Now() in production.
+// valid_from / valid_until on the wire are RFC 3339 UTC strings.
+func (r *LoadedRoster) ResolveKey(keyID string, now time.Time) (contract.KeyInfo, error) {
+	for _, k := range r.Body.Keys {
+		if k.KeyID != keyID {
+			continue
+		}
+
+		// Status check.
+		if k.Status == contract.KeyStatusRevoked {
+			return contract.KeyInfo{}, fmt.Errorf("%w: %q", ErrRosterKeyRevoked, keyID)
+		}
+
+		// Window check: valid_from.
+		validFrom, err := time.Parse(time.RFC3339, k.ValidFrom)
+		if err != nil {
+			return contract.KeyInfo{}, fmt.Errorf("%w: invalid valid_from: %w", ErrRosterKeyNotYetValid, err)
+		}
+		if now.Before(validFrom) {
+			return contract.KeyInfo{}, fmt.Errorf("%w: %q valid_from=%s, now=%s",
+				ErrRosterKeyNotYetValid, keyID, k.ValidFrom, now.Format(time.RFC3339))
+		}
+
+		// Window check: valid_until (optional).
+		if k.ValidUntil != nil {
+			validUntil, err := time.Parse(time.RFC3339, *k.ValidUntil)
+			if err != nil {
+				return contract.KeyInfo{}, fmt.Errorf("%w: invalid valid_until: %w", ErrRosterKeyExpired, err)
+			}
+			if now.After(validUntil) {
+				return contract.KeyInfo{}, fmt.Errorf("%w: %q valid_until=%s, now=%s",
+					ErrRosterKeyExpired, keyID, *k.ValidUntil, now.Format(time.RFC3339))
+			}
+		}
+
+		return k, nil
+	}
+	return contract.KeyInfo{}, fmt.Errorf("%w: %q", ErrRosterKeyUnknown, keyID)
+}
+
+// AuthorizeSignature combines roster lifecycle checks with the contract
+// package's payload-kind authority matrix. It is the canonical "is this
+// signature legitimate for this payload kind, by this key, right now"
+// gate.
+//
+// Steps (all must pass; first failure returns):
+//  1. Resolve the key via ResolveKey (active + in-window).
+//  2. Validate the key's purpose enum (KeyPurpose.Validate).
+//  3. Run AuthorizePayload(payloadKind, KeyPurpose(key.KeyPurpose)).
+//
+// Returns nil iff all three pass. Errors preserve errors.Is on every
+// underlying sentinel (ResolveKey's, contract.ErrWrongKeyPurpose,
+// contract.ErrUnknownPayloadKind, ErrUnknownKeyPurpose).
+func (r *LoadedRoster) AuthorizeSignature(payloadKind, signerKeyID string, now time.Time) error {
+	key, err := r.ResolveKey(signerKeyID, now)
+	if err != nil {
+		return err
+	}
+
+	purpose := KeyPurpose(key.KeyPurpose)
+	if err := purpose.Validate(); err != nil {
+		return err
+	}
+
+	return AuthorizePayload(payloadKind, purpose)
+}

--- a/internal/signing/roster_test.go
+++ b/internal/signing/roster_test.go
@@ -1,0 +1,1044 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+)
+
+// RFC 8032 section 7.1 test 1 private seed, split per G101 lint rule.
+const testRosterSeedHex = "" +
+	"9d61b19d" + "effd5a60" + "ba844af4" + "92ec2cc4" +
+	"4449c569" + "7b326919" + "703bac03" + "1cae7f60"
+
+// testRosterPubHex is the corresponding public key hex.
+const testRosterPubHex = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+
+// testRosterValidFrom is the validity start used in test fixtures.
+const testRosterValidFrom = "2026-04-01T00:00:00Z"
+
+// testRosterKeyIDRoot is the key_id for the root key in test fixtures.
+const testRosterKeyIDRoot = "roster-root-test"
+
+// testRosterKeyIDReceipt is the key_id for the receipt-signing key in test fixtures.
+const testRosterKeyIDReceipt = "receipt-signing-test"
+
+// testRosterDataClass is the data_class_root used in test fixtures.
+const testRosterDataClass = "internal"
+
+// preSignOpt mutates the envelope body before the signature is computed.
+type preSignOpt func(env *contract.RosterEnvelope)
+
+// postSignOpt mutates the envelope after the signature is computed, useful
+// for corrupting signature or body post-signing.
+type postSignOpt func(env *contract.RosterEnvelope)
+
+// withExtension controls the file extension written by rosterFixture.
+type withExtension struct {
+	ext string
+}
+
+// rosterFixture generates a known-good roster with a deterministic
+// roster-root keypair. Returns the temp file path and pinned fingerprint.
+func rosterFixture(t *testing.T, opts ...any) (path, fingerprint string) {
+	t.Helper()
+
+	seed, err := hex.DecodeString(testRosterSeedHex)
+	if err != nil {
+		t.Fatalf("decode seed: %v", err)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+
+	envelope := contract.RosterEnvelope{
+		Body: contract.KeyRoster{
+			SchemaVersion:  1,
+			RosterSignedBy: testRosterKeyIDRoot,
+			Keys: []contract.KeyInfo{
+				{
+					KeyID:        testRosterKeyIDRoot,
+					KeyPurpose:   string(PurposeRosterRoot),
+					PublicKeyHex: testRosterPubHex,
+					ValidFrom:    testRosterValidFrom,
+					Status:       contract.KeyStatusRoot,
+				},
+				{
+					KeyID:        testRosterKeyIDReceipt,
+					KeyPurpose:   string(PurposeReceiptSigning),
+					PublicKeyHex: testRosterPubHex,
+					ValidFrom:    testRosterValidFrom,
+					Status:       contract.KeyStatusActive,
+				},
+			},
+			DataClassRoot: testRosterDataClass,
+		},
+	}
+
+	// Determine file extension and apply pre-sign mutations.
+	ext := ".json"
+	for _, o := range opts {
+		switch v := o.(type) {
+		case preSignOpt:
+			v(&envelope)
+		case withExtension:
+			ext = v.ext
+		case postSignOpt:
+			// applied after signing
+		}
+	}
+
+	// Sign the body (even if mutations made it invalid — the test checks that).
+	preimage, err := envelope.Body.SignablePreimage()
+	if err != nil {
+		// For tests that deliberately break the body, produce a dummy sig.
+		envelope.Signature = "ed25519:" + hex.EncodeToString(make([]byte, ed25519.SignatureSize))
+	} else {
+		sig := ed25519.Sign(priv, preimage)
+		envelope.Signature = "ed25519:" + hex.EncodeToString(sig)
+	}
+
+	// Apply post-sign mutations (signature tampering, etc.).
+	for _, o := range opts {
+		if fn, ok := o.(postSignOpt); ok {
+			fn(&envelope)
+		}
+	}
+
+	// Serialize based on extension.
+	var data []byte
+	switch ext {
+	case ".yaml", ".yml":
+		// Build a map that serialises cleanly to YAML-compatible JSON keys.
+		// DecodeStrictYAML goes YAML -> generic tree -> JSON -> struct,
+		// so the YAML keys must match JSON tags.
+		m := map[string]any{
+			"body":      envelopeBodyToMap(envelope.Body),
+			"signature": envelope.Signature,
+		}
+		data, err = yamlMarshal(m)
+		if err != nil {
+			t.Fatalf("yaml marshal: %v", err)
+		}
+	default:
+		data, err = json.MarshalIndent(envelope, "", "  ")
+		if err != nil {
+			t.Fatalf("json marshal: %v", err)
+		}
+		data = append(data, '\n')
+	}
+
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "key_roster"+ext)
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	// Compute pinned fingerprint from the public key.
+	pubBytes, err := hex.DecodeString(testRosterPubHex)
+	if err != nil {
+		t.Fatalf("decode pub: %v", err)
+	}
+	fp2, err := Fingerprint(pubBytes)
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+
+	return fp, fp2
+}
+
+// envelopeBodyToMap converts a KeyRoster to a map for YAML serialisation.
+func envelopeBodyToMap(body contract.KeyRoster) map[string]any {
+	keys := make([]map[string]any, len(body.Keys))
+	for i, k := range body.Keys {
+		km := map[string]any{
+			"key_id":         k.KeyID,
+			"key_purpose":    k.KeyPurpose,
+			"public_key_hex": k.PublicKeyHex,
+			"valid_from":     k.ValidFrom,
+			"valid_until":    nil,
+			"status":         k.Status,
+		}
+		if k.ValidUntil != nil {
+			km["valid_until"] = *k.ValidUntil
+		}
+		if k.Principal != "" {
+			km["principal"] = k.Principal
+		}
+		keys[i] = km
+	}
+	return map[string]any{
+		"schema_version":   body.SchemaVersion,
+		"roster_signed_by": body.RosterSignedBy,
+		"keys":             keys,
+		"data_class_root":  body.DataClassRoot,
+	}
+}
+
+// yamlMarshal produces YAML text. We use a simple hand-rolled approach
+// to avoid importing gopkg.in/yaml.v3 in test code; the YAML is simple
+// enough that json.Marshal -> contract.DecodeStrictYAML works because
+// DecodeStrictYAML parses YAML that happens to look like JSON. Instead,
+// we produce actual YAML text.
+func yamlMarshal(m map[string]any) ([]byte, error) {
+	// Use the gopkg.in/yaml.v3 encoder that's already a transitive dep.
+	// Import is via the contract package's own YAML support.
+	// Actually, we can just produce JSON and rename the file — DecodeStrictYAML
+	// handles JSON-like YAML. But for a proper YAML test, let's produce
+	// flow-style via json.Marshal which is valid YAML.
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// computeTestFingerprint computes sha256 fingerprint of the test public key.
+func computeTestFingerprint(t *testing.T) string {
+	t.Helper()
+	pubBytes, err := hex.DecodeString(testRosterPubHex)
+	if err != nil {
+		t.Fatalf("decode pub: %v", err)
+	}
+	digest := sha256.Sum256(pubBytes)
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+// --- LoadRoster tests ---
+
+func TestLoadRoster_HappyPath_JSON(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t)
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+	if roster.Body.RosterSignedBy != testRosterKeyIDRoot {
+		t.Errorf("RosterSignedBy = %q, want %q", roster.Body.RosterSignedBy, testRosterKeyIDRoot)
+	}
+	if roster.RosterRootFingerprint != fp {
+		t.Errorf("RosterRootFingerprint = %q, want %q", roster.RosterRootFingerprint, fp)
+	}
+	if roster.SourcePath == "" {
+		t.Error("SourcePath is empty")
+	}
+	if roster.LoadedAt.IsZero() {
+		t.Error("LoadedAt is zero")
+	}
+	if len(roster.Body.Keys) != 2 {
+		t.Errorf("Keys count = %d, want 2", len(roster.Body.Keys))
+	}
+}
+
+func TestLoadRoster_HappyPath_YAML(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t, withExtension{ext: ".yaml"})
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster YAML: %v", err)
+	}
+	if roster.Body.RosterSignedBy != testRosterKeyIDRoot {
+		t.Errorf("RosterSignedBy = %q, want %q", roster.Body.RosterSignedBy, testRosterKeyIDRoot)
+	}
+}
+
+func TestLoadRoster_HappyPath_YML(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t, withExtension{ext: ".yml"})
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster YML: %v", err)
+	}
+	if roster.Body.RosterSignedBy != testRosterKeyIDRoot {
+		t.Errorf("RosterSignedBy = %q, want %q", roster.Body.RosterSignedBy, testRosterKeyIDRoot)
+	}
+}
+
+func TestLoadRoster_RejectFileMissing(t *testing.T) {
+	t.Parallel()
+	_, err := LoadRoster("/nonexistent/path/roster.json", computeTestFingerprint(t))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !errors.Is(err, ErrRosterRead) {
+		t.Errorf("got %v, want ErrRosterRead", err)
+	}
+}
+
+func TestLoadRoster_RejectUnsupportedExtension(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "roster.txt")
+	if err := os.WriteFile(fp, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadRoster(fp, computeTestFingerprint(t))
+	if err == nil {
+		t.Fatal("expected error for unsupported extension")
+	}
+	if !errors.Is(err, ErrRosterUnsupportedExtension) {
+		t.Errorf("got %v, want ErrRosterUnsupportedExtension", err)
+	}
+}
+
+func TestLoadRoster_RejectMalformedJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "roster.json")
+	if err := os.WriteFile(fp, []byte("{bad json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadRoster(fp, computeTestFingerprint(t))
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+	if !errors.Is(err, ErrRosterDecode) {
+		t.Errorf("got %v, want ErrRosterDecode", err)
+	}
+}
+
+func TestLoadRoster_RejectMalformedYAML(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "roster.yaml")
+	// Produce invalid YAML: tab indentation is fine, but unmatched braces aren't.
+	if err := os.WriteFile(fp, []byte("body:\n  - [unclosed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadRoster(fp, computeTestFingerprint(t))
+	if err == nil {
+		t.Fatal("expected error for malformed YAML")
+	}
+	if !errors.Is(err, ErrRosterDecode) {
+		t.Errorf("got %v, want ErrRosterDecode", err)
+	}
+}
+
+func TestLoadRoster_RejectBodyValidationFails(t *testing.T) {
+	t.Parallel()
+	// Remove the root key so Validate() fails (no key with status=root).
+	path, fp := rosterFixture(t, preSignOpt(func(env *contract.RosterEnvelope) {
+		// Keep only the receipt-signing key, remove root.
+		env.Body.Keys = []contract.KeyInfo{
+			{
+				KeyID:        testRosterKeyIDReceipt,
+				KeyPurpose:   string(PurposeReceiptSigning),
+				PublicKeyHex: testRosterPubHex,
+				ValidFrom:    testRosterValidFrom,
+				Status:       contract.KeyStatusActive,
+			},
+		}
+	}))
+	_, err := LoadRoster(path, fp)
+	if err == nil {
+		t.Fatal("expected ErrRosterInvalid")
+	}
+	if !errors.Is(err, ErrRosterInvalid) {
+		t.Errorf("got %v, want ErrRosterInvalid", err)
+	}
+}
+
+func TestLoadRoster_RejectMissingSignature(t *testing.T) {
+	t.Parallel()
+	// Write a fixture where the signature is empty.
+	path, fp := rosterFixture(t, postSignOpt(func(env *contract.RosterEnvelope) {
+		env.Signature = ""
+	}))
+	_, err := LoadRoster(path, fp)
+	if err == nil {
+		t.Fatal("expected ErrRosterSignatureFormat")
+	}
+	if !errors.Is(err, ErrRosterSignatureFormat) {
+		t.Errorf("got %v, want ErrRosterSignatureFormat", err)
+	}
+}
+
+func TestLoadRoster_RejectSignatureBadPrefix(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t, postSignOpt(func(env *contract.RosterEnvelope) {
+		env.Signature = "sha256:" + env.Signature[len("ed25519:"):]
+	}))
+	_, err := LoadRoster(path, fp)
+	if err == nil {
+		t.Fatal("expected ErrRosterSignatureFormat")
+	}
+	if !errors.Is(err, ErrRosterSignatureFormat) {
+		t.Errorf("got %v, want ErrRosterSignatureFormat", err)
+	}
+}
+
+func TestLoadRoster_RejectSignatureWrongLength(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t, postSignOpt(func(env *contract.RosterEnvelope) {
+		// Truncate the hex part.
+		env.Signature = "ed25519:aabb"
+	}))
+	_, err := LoadRoster(path, fp)
+	if err == nil {
+		t.Fatal("expected ErrRosterSignatureFormat")
+	}
+	if !errors.Is(err, ErrRosterSignatureFormat) {
+		t.Errorf("got %v, want ErrRosterSignatureFormat", err)
+	}
+}
+
+func TestLoadRoster_RejectSignedByKeyNotInRoster(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t, postSignOpt(func(env *contract.RosterEnvelope) {
+		env.Body.RosterSignedBy = "nonexistent-key"
+		// Also add a root key to keep Validate() happy.
+		env.Body.Keys = append(env.Body.Keys, contract.KeyInfo{
+			KeyID:        "nonexistent-key",
+			KeyPurpose:   string(PurposeRosterRoot),
+			PublicKeyHex: testRosterPubHex,
+			ValidFrom:    testRosterValidFrom,
+			Status:       contract.KeyStatusRoot,
+		})
+	}))
+
+	// The fixture was signed with the original body, but then we mutated
+	// RosterSignedBy. The body now has "nonexistent-key" as RosterSignedBy,
+	// and there IS a key with that ID and root status (we added it), so
+	// Validate() passes. But the signature won't verify because the body
+	// was mutated after signing.
+	_, err := LoadRoster(path, fp)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Should fail at signature verification since body was mutated.
+	if !errors.Is(err, ErrRosterSignatureInvalid) {
+		t.Errorf("got %v, want ErrRosterSignatureInvalid", err)
+	}
+}
+
+func TestLoadRoster_RejectSignedByWrongPurpose(t *testing.T) {
+	t.Parallel()
+	// Build a roster where the signing key has purpose=receipt-signing.
+	seed, _ := hex.DecodeString(testRosterSeedHex)
+	priv := ed25519.NewKeyFromSeed(seed)
+
+	envelope := contract.RosterEnvelope{
+		Body: contract.KeyRoster{
+			SchemaVersion:  1,
+			RosterSignedBy: testRosterKeyIDRoot,
+			Keys: []contract.KeyInfo{
+				{
+					KeyID:        testRosterKeyIDRoot,
+					KeyPurpose:   string(PurposeReceiptSigning),
+					PublicKeyHex: testRosterPubHex,
+					ValidFrom:    testRosterValidFrom,
+					Status:       contract.KeyStatusRoot,
+				},
+			},
+			DataClassRoot: testRosterDataClass,
+		},
+	}
+
+	preimage, err := envelope.Body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("preimage: %v", err)
+	}
+	sig := ed25519.Sign(priv, preimage)
+	envelope.Signature = "ed25519:" + hex.EncodeToString(sig)
+
+	data, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "roster.json")
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = LoadRoster(fp, computeTestFingerprint(t))
+	if err == nil {
+		t.Fatal("expected ErrRosterRootWrongPurpose")
+	}
+	if !errors.Is(err, ErrRosterRootWrongPurpose) {
+		t.Errorf("got %v, want ErrRosterRootWrongPurpose", err)
+	}
+}
+
+func TestLoadRoster_RejectRulesOfficialSigningPurpose(t *testing.T) {
+	t.Parallel()
+	// Design doc line 861: roster signed by rules-official-signing is rejected.
+	seed, _ := hex.DecodeString(testRosterSeedHex)
+	priv := ed25519.NewKeyFromSeed(seed)
+
+	envelope := contract.RosterEnvelope{
+		Body: contract.KeyRoster{
+			SchemaVersion:  1,
+			RosterSignedBy: testRosterKeyIDRoot,
+			Keys: []contract.KeyInfo{
+				{
+					KeyID:        testRosterKeyIDRoot,
+					KeyPurpose:   string(PurposeRulesOfficialSigning),
+					PublicKeyHex: testRosterPubHex,
+					ValidFrom:    testRosterValidFrom,
+					Status:       contract.KeyStatusRoot,
+				},
+			},
+			DataClassRoot: testRosterDataClass,
+		},
+	}
+
+	preimage, err := envelope.Body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("preimage: %v", err)
+	}
+	sig := ed25519.Sign(priv, preimage)
+	envelope.Signature = "ed25519:" + hex.EncodeToString(sig)
+
+	data, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "roster.json")
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = LoadRoster(fp, computeTestFingerprint(t))
+	if err == nil {
+		t.Fatal("expected ErrRosterRootWrongPurpose")
+	}
+	if !errors.Is(err, ErrRosterRootWrongPurpose) {
+		t.Errorf("got %v, want ErrRosterRootWrongPurpose", err)
+	}
+}
+
+func TestLoadRoster_RejectFingerprintMismatch(t *testing.T) {
+	t.Parallel()
+	path, _ := rosterFixture(t)
+	// Use a different pinned fingerprint.
+	wrongFP := "sha256:" + "aa" + testRosterPubHex[2:]
+	// Ensure it's a valid length. We just need it to differ.
+	_, err := LoadRoster(path, wrongFP)
+	if err == nil {
+		t.Fatal("expected ErrRosterRootFingerprintMismatch")
+	}
+	if !errors.Is(err, ErrRosterRootFingerprintMismatch) {
+		t.Errorf("got %v, want ErrRosterRootFingerprintMismatch", err)
+	}
+}
+
+func TestLoadRoster_RejectSignatureInvalid(t *testing.T) {
+	t.Parallel()
+	// Flip a bit in the signature.
+	path, fp := rosterFixture(t, postSignOpt(func(env *contract.RosterEnvelope) {
+		// Swap last hex char to corrupt signature.
+		sig := env.Signature
+		lastChar := sig[len(sig)-1]
+		var replacement byte
+		if lastChar == '0' {
+			replacement = '1'
+		} else {
+			replacement = '0'
+		}
+		env.Signature = sig[:len(sig)-1] + string(replacement)
+	}))
+	_, err := LoadRoster(path, fp)
+	if err == nil {
+		t.Fatal("expected ErrRosterSignatureInvalid")
+	}
+	if !errors.Is(err, ErrRosterSignatureInvalid) {
+		t.Errorf("got %v, want ErrRosterSignatureInvalid", err)
+	}
+}
+
+// --- ResolveKey tests ---
+
+func TestResolveKey_HappyPath(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t)
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
+	key, err := roster.ResolveKey(testRosterKeyIDReceipt, now)
+	if err != nil {
+		t.Fatalf("ResolveKey: %v", err)
+	}
+	if key.KeyID != testRosterKeyIDReceipt {
+		t.Errorf("KeyID = %q, want %q", key.KeyID, testRosterKeyIDReceipt)
+	}
+	if key.Status != contract.KeyStatusActive {
+		t.Errorf("Status = %q, want %q", key.Status, contract.KeyStatusActive)
+	}
+}
+
+func TestResolveKey_HappyPath_RootKey(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t)
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
+	key, err := roster.ResolveKey(testRosterKeyIDRoot, now)
+	if err != nil {
+		t.Fatalf("ResolveKey root: %v", err)
+	}
+	if key.KeyID != testRosterKeyIDRoot {
+		t.Errorf("KeyID = %q, want %q", key.KeyID, testRosterKeyIDRoot)
+	}
+}
+
+func TestResolveKey_RejectUnknown(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t)
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
+	_, err = roster.ResolveKey("nonexistent", now)
+	if err == nil {
+		t.Fatal("expected ErrRosterKeyUnknown")
+	}
+	if !errors.Is(err, ErrRosterKeyUnknown) {
+		t.Errorf("got %v, want ErrRosterKeyUnknown", err)
+	}
+}
+
+func TestResolveKey_RejectRevoked(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t, preSignOpt(func(env *contract.RosterEnvelope) {
+		for i := range env.Body.Keys {
+			if env.Body.Keys[i].KeyID == testRosterKeyIDReceipt {
+				env.Body.Keys[i].Status = contract.KeyStatusRevoked
+			}
+		}
+	}))
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
+	_, err = roster.ResolveKey(testRosterKeyIDReceipt, now)
+	if err == nil {
+		t.Fatal("expected ErrRosterKeyRevoked")
+	}
+	if !errors.Is(err, ErrRosterKeyRevoked) {
+		t.Errorf("got %v, want ErrRosterKeyRevoked", err)
+	}
+}
+
+func TestResolveKey_RejectNotYetValid(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t)
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	// Use a time before the valid_from.
+	now, _ := time.Parse(time.RFC3339, "2025-01-01T00:00:00Z")
+	_, err = roster.ResolveKey(testRosterKeyIDReceipt, now)
+	if err == nil {
+		t.Fatal("expected ErrRosterKeyNotYetValid")
+	}
+	if !errors.Is(err, ErrRosterKeyNotYetValid) {
+		t.Errorf("got %v, want ErrRosterKeyNotYetValid", err)
+	}
+}
+
+func TestResolveKey_RejectExpired(t *testing.T) {
+	t.Parallel()
+	validUntil := "2026-06-01T00:00:00Z"
+	path, fp := rosterFixture(t, preSignOpt(func(env *contract.RosterEnvelope) {
+		for i := range env.Body.Keys {
+			if env.Body.Keys[i].KeyID == testRosterKeyIDReceipt {
+				env.Body.Keys[i].ValidUntil = &validUntil
+			}
+		}
+	}))
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	// Use a time after the valid_until.
+	now, _ := time.Parse(time.RFC3339, "2026-07-01T00:00:00Z")
+	_, err = roster.ResolveKey(testRosterKeyIDReceipt, now)
+	if err == nil {
+		t.Fatal("expected ErrRosterKeyExpired")
+	}
+	if !errors.Is(err, ErrRosterKeyExpired) {
+		t.Errorf("got %v, want ErrRosterKeyExpired", err)
+	}
+}
+
+func TestResolveKey_ValidUntilBoundary(t *testing.T) {
+	t.Parallel()
+	// When now == valid_until, key should still be valid (not expired).
+	validUntil := "2026-06-01T00:00:00Z"
+	path, fp := rosterFixture(t, preSignOpt(func(env *contract.RosterEnvelope) {
+		for i := range env.Body.Keys {
+			if env.Body.Keys[i].KeyID == testRosterKeyIDReceipt {
+				env.Body.Keys[i].ValidUntil = &validUntil
+			}
+		}
+	}))
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, validUntil)
+	_, err = roster.ResolveKey(testRosterKeyIDReceipt, now)
+	if err != nil {
+		t.Errorf("key at exact valid_until should be valid, got: %v", err)
+	}
+}
+
+// --- AuthorizeSignature tests ---
+
+func TestAuthorizeSignature_HappyPath(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t)
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
+	// receipt-signing key should be authorised for proxy_decision.
+	if err := roster.AuthorizeSignature("proxy_decision", testRosterKeyIDReceipt, now); err != nil {
+		t.Errorf("AuthorizeSignature proxy_decision: %v", err)
+	}
+}
+
+func TestAuthorizeSignature_RejectWrongPurpose(t *testing.T) {
+	t.Parallel()
+	// Add a contract-activation-signing key to test purpose mismatch.
+	path, fp := rosterFixture(t, preSignOpt(func(env *contract.RosterEnvelope) {
+		env.Body.Keys = append(env.Body.Keys, contract.KeyInfo{
+			KeyID:        "activation-test",
+			KeyPurpose:   string(PurposeContractActivationSigning),
+			PublicKeyHex: testRosterPubHex,
+			ValidFrom:    testRosterValidFrom,
+			Status:       contract.KeyStatusActive,
+		})
+	}))
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
+	// proxy_decision requires receipt-signing, not contract-activation-signing.
+	err = roster.AuthorizeSignature("proxy_decision", "activation-test", now)
+	if err == nil {
+		t.Fatal("expected ErrWrongKeyPurpose")
+	}
+	if !errors.Is(err, contract.ErrWrongKeyPurpose) {
+		t.Errorf("got %v, want contract.ErrWrongKeyPurpose", err)
+	}
+}
+
+func TestAuthorizeSignature_RejectUnknownPayloadKind(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t)
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
+	err = roster.AuthorizeSignature("nonexistent_payload", testRosterKeyIDReceipt, now)
+	if err == nil {
+		t.Fatal("expected ErrUnknownPayloadKind")
+	}
+	if !errors.Is(err, contract.ErrUnknownPayloadKind) {
+		t.Errorf("got %v, want contract.ErrUnknownPayloadKind", err)
+	}
+}
+
+func TestAuthorizeSignature_RejectKeyNotResolved_Revoked(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t, preSignOpt(func(env *contract.RosterEnvelope) {
+		for i := range env.Body.Keys {
+			if env.Body.Keys[i].KeyID == testRosterKeyIDReceipt {
+				env.Body.Keys[i].Status = contract.KeyStatusRevoked
+			}
+		}
+	}))
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
+	err = roster.AuthorizeSignature("proxy_decision", testRosterKeyIDReceipt, now)
+	if err == nil {
+		t.Fatal("expected ErrRosterKeyRevoked")
+	}
+	if !errors.Is(err, ErrRosterKeyRevoked) {
+		t.Errorf("got %v, want ErrRosterKeyRevoked", err)
+	}
+}
+
+func TestAuthorizeSignature_RejectKeyNotResolved_Expired(t *testing.T) {
+	t.Parallel()
+	validUntil := "2026-04-15T00:00:00Z"
+	path, fp := rosterFixture(t, preSignOpt(func(env *contract.RosterEnvelope) {
+		for i := range env.Body.Keys {
+			if env.Body.Keys[i].KeyID == testRosterKeyIDReceipt {
+				env.Body.Keys[i].ValidUntil = &validUntil
+			}
+		}
+	}))
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
+	err = roster.AuthorizeSignature("proxy_decision", testRosterKeyIDReceipt, now)
+	if err == nil {
+		t.Fatal("expected ErrRosterKeyExpired")
+	}
+	if !errors.Is(err, ErrRosterKeyExpired) {
+		t.Errorf("got %v, want ErrRosterKeyExpired", err)
+	}
+}
+
+func TestAuthorizeSignature_RejectKeyNotResolved_Unknown(t *testing.T) {
+	t.Parallel()
+	path, fp := rosterFixture(t)
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
+	err = roster.AuthorizeSignature("proxy_decision", "nonexistent", now)
+	if err == nil {
+		t.Fatal("expected ErrRosterKeyUnknown")
+	}
+	if !errors.Is(err, ErrRosterKeyUnknown) {
+		t.Errorf("got %v, want ErrRosterKeyUnknown", err)
+	}
+}
+
+func TestAuthorizeSignature_ContractPromoteIntent(t *testing.T) {
+	t.Parallel()
+	// contract_promote_intent requires contract-activation-signing.
+	path, fp := rosterFixture(t, preSignOpt(func(env *contract.RosterEnvelope) {
+		env.Body.Keys = append(env.Body.Keys, contract.KeyInfo{
+			KeyID:        "activation-test",
+			KeyPurpose:   string(PurposeContractActivationSigning),
+			PublicKeyHex: testRosterPubHex,
+			ValidFrom:    testRosterValidFrom,
+			Status:       contract.KeyStatusActive,
+		})
+	}))
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
+	if err := roster.AuthorizeSignature("contract_promote_intent", "activation-test", now); err != nil {
+		t.Errorf("AuthorizeSignature contract_promote_intent: %v", err)
+	}
+}
+
+// --- Coverage boost tests for edge cases ---
+
+func TestLoadRoster_RejectSignatureHexInvalidChars(t *testing.T) {
+	t.Parallel()
+	// 128-char hex but with invalid hex chars (gg is not hex).
+	badHex := "gg" + testRosterPubHex[2:] + testRosterPubHex
+	path, fp := rosterFixture(t, postSignOpt(func(env *contract.RosterEnvelope) {
+		env.Signature = "ed25519:" + badHex
+	}))
+	_, err := LoadRoster(path, fp)
+	if err == nil {
+		t.Fatal("expected ErrRosterSignatureFormat")
+	}
+	if !errors.Is(err, ErrRosterSignatureFormat) {
+		t.Errorf("got %v, want ErrRosterSignatureFormat", err)
+	}
+}
+
+func TestAuthorizeSignature_RejectUnknownPurpose(t *testing.T) {
+	t.Parallel()
+	// A key with an unrecognised purpose should fail at purpose.Validate().
+	path, fp := rosterFixture(t, preSignOpt(func(env *contract.RosterEnvelope) {
+		env.Body.Keys = append(env.Body.Keys, contract.KeyInfo{
+			KeyID:        "bogus-purpose-key",
+			KeyPurpose:   "bogus-purpose",
+			PublicKeyHex: testRosterPubHex,
+			ValidFrom:    testRosterValidFrom,
+			Status:       contract.KeyStatusActive,
+		})
+	}))
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
+	err = roster.AuthorizeSignature("proxy_decision", "bogus-purpose-key", now)
+	if err == nil {
+		t.Fatal("expected ErrUnknownKeyPurpose")
+	}
+	if !errors.Is(err, ErrUnknownKeyPurpose) {
+		t.Errorf("got %v, want ErrUnknownKeyPurpose", err)
+	}
+}
+
+func TestResolveKey_InvalidValidFromFormat(t *testing.T) {
+	t.Parallel()
+	// Key with invalid valid_from string.
+	path, fp := rosterFixture(t, preSignOpt(func(env *contract.RosterEnvelope) {
+		env.Body.Keys = append(env.Body.Keys, contract.KeyInfo{
+			KeyID:        "bad-from-key",
+			KeyPurpose:   string(PurposeReceiptSigning),
+			PublicKeyHex: testRosterPubHex,
+			ValidFrom:    "not-a-date",
+			Status:       contract.KeyStatusActive,
+		})
+	}))
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
+	_, err = roster.ResolveKey("bad-from-key", now)
+	if err == nil {
+		t.Fatal("expected ErrRosterKeyNotYetValid")
+	}
+	if !errors.Is(err, ErrRosterKeyNotYetValid) {
+		t.Errorf("got %v, want ErrRosterKeyNotYetValid", err)
+	}
+}
+
+func TestResolveKey_InvalidValidUntilFormat(t *testing.T) {
+	t.Parallel()
+	// Key with invalid valid_until string.
+	badUntil := "not-a-date"
+	path, fp := rosterFixture(t, preSignOpt(func(env *contract.RosterEnvelope) {
+		for i := range env.Body.Keys {
+			if env.Body.Keys[i].KeyID == testRosterKeyIDReceipt {
+				env.Body.Keys[i].ValidUntil = &badUntil
+			}
+		}
+	}))
+	roster, err := LoadRoster(path, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+
+	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
+	_, err = roster.ResolveKey(testRosterKeyIDReceipt, now)
+	if err == nil {
+		t.Fatal("expected ErrRosterKeyExpired")
+	}
+	if !errors.Is(err, ErrRosterKeyExpired) {
+		t.Errorf("got %v, want ErrRosterKeyExpired", err)
+	}
+}
+
+func TestLoadRoster_GoldenJSON(t *testing.T) {
+	t.Parallel()
+	// Load the existing golden fixture from PR 1.1 to verify cross-compat.
+	goldenPath := filepath.Join("..", "contract", "testdata", "golden", "valid_key_roster.json")
+	fp := computeTestFingerprint(t)
+	roster, err := LoadRoster(goldenPath, fp)
+	if err != nil {
+		t.Fatalf("LoadRoster golden: %v", err)
+	}
+	if roster.Body.RosterSignedBy != testRosterKeyIDRoot {
+		t.Errorf("RosterSignedBy = %q, want %q", roster.Body.RosterSignedBy, testRosterKeyIDRoot)
+	}
+	if len(roster.Body.Keys) != 2 {
+		t.Errorf("Keys count = %d, want 2", len(roster.Body.Keys))
+	}
+}
+
+func TestLoadRoster_RejectBadPinnedFingerprintFormat(t *testing.T) {
+	t.Parallel()
+	path, _ := rosterFixture(t)
+	// Pass a malformed pinned fingerprint (wrong algorithm, not wrong digest).
+	_, err := LoadRoster(path, "md5:aabbccdd")
+	if err == nil {
+		t.Fatal("expected ErrRosterRootFingerprintMismatch")
+	}
+	if !errors.Is(err, ErrRosterRootFingerprintMismatch) {
+		t.Errorf("got %v, want ErrRosterRootFingerprintMismatch", err)
+	}
+}
+
+func TestLoadRoster_RejectRootKeyBadHex(t *testing.T) {
+	t.Parallel()
+	// Root key with invalid hex in public_key_hex.
+	seed, _ := hex.DecodeString(testRosterSeedHex)
+	priv := ed25519.NewKeyFromSeed(seed)
+
+	// Pad with 'zz' to get 64-char hex that won't decode.
+	badHex := "zz" + testRosterPubHex[2:]
+	envelope := contract.RosterEnvelope{
+		Body: contract.KeyRoster{
+			SchemaVersion:  1,
+			RosterSignedBy: testRosterKeyIDRoot,
+			Keys: []contract.KeyInfo{
+				{
+					KeyID:        testRosterKeyIDRoot,
+					KeyPurpose:   string(PurposeRosterRoot),
+					PublicKeyHex: badHex,
+					ValidFrom:    testRosterValidFrom,
+					Status:       contract.KeyStatusRoot,
+				},
+			},
+			DataClassRoot: testRosterDataClass,
+		},
+	}
+
+	preimage, err := envelope.Body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("preimage: %v", err)
+	}
+	sig := ed25519.Sign(priv, preimage)
+	envelope.Signature = "ed25519:" + hex.EncodeToString(sig)
+
+	data, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "roster.json")
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = LoadRoster(fp, computeTestFingerprint(t))
+	if err == nil {
+		t.Fatal("expected ErrRosterRootMissing")
+	}
+	if !errors.Is(err, ErrRosterRootMissing) {
+		t.Errorf("got %v, want ErrRosterRootMissing", err)
+	}
+}

--- a/internal/signing/roster_test.go
+++ b/internal/signing/roster_test.go
@@ -582,8 +582,10 @@ func TestResolveKey_HappyPath(t *testing.T) {
 	}
 }
 
-func TestResolveKey_HappyPath_RootKey(t *testing.T) {
+func TestResolveKey_RejectRootStatus(t *testing.T) {
 	t.Parallel()
+	// Root keys sign rosters and root transitions, never runtime payloads,
+	// so ResolveKey must reject them even though they are otherwise valid.
 	path, fp := rosterFixture(t)
 	roster, err := LoadRoster(path, fp)
 	if err != nil {
@@ -591,12 +593,8 @@ func TestResolveKey_HappyPath_RootKey(t *testing.T) {
 	}
 
 	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
-	key, err := roster.ResolveKey(testRosterKeyIDRoot, now)
-	if err != nil {
-		t.Fatalf("ResolveKey root: %v", err)
-	}
-	if key.KeyID != testRosterKeyIDRoot {
-		t.Errorf("KeyID = %q, want %q", key.KeyID, testRosterKeyIDRoot)
+	if _, err := roster.ResolveKey(testRosterKeyIDRoot, now); !errors.Is(err, ErrRosterKeyNotActive) {
+		t.Errorf("got %v, want ErrRosterKeyNotActive", err)
 	}
 }
 
@@ -710,7 +708,7 @@ func TestResolveKey_ValidUntilBoundary(t *testing.T) {
 	}
 }
 
-// --- AuthorizeSignature tests ---
+// --- AuthorizeSignerForPayload tests ---
 
 func TestAuthorizeSignature_HappyPath(t *testing.T) {
 	t.Parallel()
@@ -722,7 +720,7 @@ func TestAuthorizeSignature_HappyPath(t *testing.T) {
 
 	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
 	// receipt-signing key should be authorised for proxy_decision.
-	if err := roster.AuthorizeSignature("proxy_decision", testRosterKeyIDReceipt, now); err != nil {
+	if err := roster.AuthorizeSignerForPayload("proxy_decision", testRosterKeyIDReceipt, now); err != nil {
 		t.Errorf("AuthorizeSignature proxy_decision: %v", err)
 	}
 }
@@ -746,7 +744,7 @@ func TestAuthorizeSignature_RejectWrongPurpose(t *testing.T) {
 
 	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
 	// proxy_decision requires receipt-signing, not contract-activation-signing.
-	err = roster.AuthorizeSignature("proxy_decision", "activation-test", now)
+	err = roster.AuthorizeSignerForPayload("proxy_decision", "activation-test", now)
 	if err == nil {
 		t.Fatal("expected ErrWrongKeyPurpose")
 	}
@@ -764,7 +762,7 @@ func TestAuthorizeSignature_RejectUnknownPayloadKind(t *testing.T) {
 	}
 
 	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
-	err = roster.AuthorizeSignature("nonexistent_payload", testRosterKeyIDReceipt, now)
+	err = roster.AuthorizeSignerForPayload("nonexistent_payload", testRosterKeyIDReceipt, now)
 	if err == nil {
 		t.Fatal("expected ErrUnknownPayloadKind")
 	}
@@ -788,7 +786,7 @@ func TestAuthorizeSignature_RejectKeyNotResolved_Revoked(t *testing.T) {
 	}
 
 	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
-	err = roster.AuthorizeSignature("proxy_decision", testRosterKeyIDReceipt, now)
+	err = roster.AuthorizeSignerForPayload("proxy_decision", testRosterKeyIDReceipt, now)
 	if err == nil {
 		t.Fatal("expected ErrRosterKeyRevoked")
 	}
@@ -813,7 +811,7 @@ func TestAuthorizeSignature_RejectKeyNotResolved_Expired(t *testing.T) {
 	}
 
 	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
-	err = roster.AuthorizeSignature("proxy_decision", testRosterKeyIDReceipt, now)
+	err = roster.AuthorizeSignerForPayload("proxy_decision", testRosterKeyIDReceipt, now)
 	if err == nil {
 		t.Fatal("expected ErrRosterKeyExpired")
 	}
@@ -831,7 +829,7 @@ func TestAuthorizeSignature_RejectKeyNotResolved_Unknown(t *testing.T) {
 	}
 
 	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
-	err = roster.AuthorizeSignature("proxy_decision", "nonexistent", now)
+	err = roster.AuthorizeSignerForPayload("proxy_decision", "nonexistent", now)
 	if err == nil {
 		t.Fatal("expected ErrRosterKeyUnknown")
 	}
@@ -858,7 +856,7 @@ func TestAuthorizeSignature_ContractPromoteIntent(t *testing.T) {
 	}
 
 	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
-	if err := roster.AuthorizeSignature("contract_promote_intent", "activation-test", now); err != nil {
+	if err := roster.AuthorizeSignerForPayload("contract_promote_intent", "activation-test", now); err != nil {
 		t.Errorf("AuthorizeSignature contract_promote_intent: %v", err)
 	}
 }
@@ -881,9 +879,58 @@ func TestLoadRoster_RejectSignatureHexInvalidChars(t *testing.T) {
 	}
 }
 
-func TestAuthorizeSignature_RejectUnknownPurpose(t *testing.T) {
+func TestLoadRoster_RejectsUnknownKeyStatus(t *testing.T) {
 	t.Parallel()
-	// A key with an unrecognised purpose should fail at purpose.Validate().
+	// A signed roster entry with status="disabled" must reject at LoadRoster
+	// even though the rest of the entry is well-formed. Fail-open on unknown
+	// status would let an attacker smuggle a key that ResolveKey treats as
+	// active because the only explicit reject historically was "revoked".
+	path, fp := rosterFixture(t, preSignOpt(func(env *contract.RosterEnvelope) {
+		env.Body.Keys = append(env.Body.Keys, contract.KeyInfo{
+			KeyID:        "disabled-key",
+			KeyPurpose:   string(PurposeReceiptSigning),
+			PublicKeyHex: testRosterPubHex,
+			ValidFrom:    testRosterValidFrom,
+			Status:       "disabled",
+		})
+	}))
+
+	_, err := LoadRoster(path, fp)
+	if err == nil {
+		t.Fatal("expected ErrRosterKeyInvalidStatus")
+	}
+	if !errors.Is(err, ErrRosterKeyInvalidStatus) {
+		t.Errorf("got %v, want ErrRosterKeyInvalidStatus", err)
+	}
+}
+
+func TestLoadRoster_RejectsBadPublicKeyHex(t *testing.T) {
+	t.Parallel()
+	// Strict per-key validation must reject a non-32-byte public key even
+	// when the rest of the roster is otherwise valid.
+	path, fp := rosterFixture(t, preSignOpt(func(env *contract.RosterEnvelope) {
+		env.Body.Keys = append(env.Body.Keys, contract.KeyInfo{
+			KeyID:        "short-key",
+			KeyPurpose:   string(PurposeReceiptSigning),
+			PublicKeyHex: "deadbeef", // 4 bytes, not 32
+			ValidFrom:    testRosterValidFrom,
+			Status:       contract.KeyStatusActive,
+		})
+	}))
+
+	_, err := LoadRoster(path, fp)
+	if err == nil {
+		t.Fatal("expected ErrRosterKeyMissingPublicKey")
+	}
+	if !errors.Is(err, ErrRosterKeyMissingPublicKey) {
+		t.Errorf("got %v, want ErrRosterKeyMissingPublicKey", err)
+	}
+}
+
+func TestLoadRoster_RejectsUnknownKeyPurpose(t *testing.T) {
+	t.Parallel()
+	// A key with an unrecognised purpose must reject at LoadRoster (strict
+	// per-key validation runs before any signature lookup).
 	path, fp := rosterFixture(t, preSignOpt(func(env *contract.RosterEnvelope) {
 		env.Body.Keys = append(env.Body.Keys, contract.KeyInfo{
 			KeyID:        "bogus-purpose-key",
@@ -893,18 +940,13 @@ func TestAuthorizeSignature_RejectUnknownPurpose(t *testing.T) {
 			Status:       contract.KeyStatusActive,
 		})
 	}))
-	roster, err := LoadRoster(path, fp)
-	if err != nil {
-		t.Fatalf("LoadRoster: %v", err)
-	}
 
-	now, _ := time.Parse(time.RFC3339, "2026-05-01T00:00:00Z")
-	err = roster.AuthorizeSignature("proxy_decision", "bogus-purpose-key", now)
+	_, err := LoadRoster(path, fp)
 	if err == nil {
-		t.Fatal("expected ErrUnknownKeyPurpose")
+		t.Fatal("expected ErrRosterKeyInvalidPurpose")
 	}
-	if !errors.Is(err, ErrUnknownKeyPurpose) {
-		t.Errorf("got %v, want ErrUnknownKeyPurpose", err)
+	if !errors.Is(err, ErrRosterKeyInvalidPurpose) {
+		t.Errorf("got %v, want ErrRosterKeyInvalidPurpose", err)
 	}
 }
 
@@ -1036,9 +1078,12 @@ func TestLoadRoster_RejectRootKeyBadHex(t *testing.T) {
 
 	_, err = LoadRoster(fp, computeTestFingerprint(t))
 	if err == nil {
-		t.Fatal("expected ErrRosterRootMissing")
+		t.Fatal("expected ErrRosterKeyMissingPublicKey")
 	}
-	if !errors.Is(err, ErrRosterRootMissing) {
-		t.Errorf("got %v, want ErrRosterRootMissing", err)
+	// Strict per-key validation in LoadRoster catches the bad hex before any
+	// root-specific lookup runs, so the surfaced sentinel is the missing /
+	// malformed public-key sentinel.
+	if !errors.Is(err, ErrRosterKeyMissingPublicKey) {
+		t.Errorf("got %v, want ErrRosterKeyMissingPublicKey", err)
 	}
 }

--- a/internal/signing/testdata/golden/valid_recovery_authorization.json
+++ b/internal/signing/testdata/golden/valid_recovery_authorization.json
@@ -3,9 +3,9 @@
     "schema_version": 1,
     "reason": "roster root key compromised",
     "expires_at": "2026-04-26T13:30:00Z",
-    "target_roster_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "target_roster_hash": "sha256:d0936185ee07c30a681e5beb49ef01899744df04bef122596467d9aa8ef24f7d",
     "operator_identity": "ops@example.com",
     "issued_at": "2026-04-26T13:00:00Z"
   },
-  "signature": "ed25519:87f9600b25ebde8975fea0e6177093c261edbeac7a8d8835c05b08ed630c9ce6c75fb3ee68dc1bdd1fbf02b1760acca53a72c5542a14f13a7f0e29b06c7b2b0a"
+  "signature": "ed25519:12f5e5867a8dcc8777cdbe38e666794e152bf0820e4b15849702305860c2d823901bc5e911f285d4a1a06a49918bdae9d8b6bfa7940cb4bfc70e29b3c56f530a"
 }

--- a/internal/signing/testdata/golden/valid_recovery_authorization.json
+++ b/internal/signing/testdata/golden/valid_recovery_authorization.json
@@ -1,0 +1,11 @@
+{
+  "body": {
+    "schema_version": 1,
+    "reason": "roster root key compromised",
+    "expires_at": "2026-04-26T13:30:00Z",
+    "target_roster_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "operator_identity": "ops@example.com",
+    "issued_at": "2026-04-26T13:00:00Z"
+  },
+  "signature": "ed25519:87f9600b25ebde8975fea0e6177093c261edbeac7a8d8835c05b08ed630c9ce6c75fb3ee68dc1bdd1fbf02b1760acca53a72c5542a14f13a7f0e29b06c7b2b0a"
+}

--- a/internal/signing/testdata/golden/valid_root_transition.json
+++ b/internal/signing/testdata/golden/valid_root_transition.json
@@ -1,0 +1,12 @@
+{
+  "body": {
+    "schema_version": 1,
+    "root_kind": "roster-root",
+    "old_fingerprint": "sha256:21fe31dfa154a261626bf854046fd2271b7bed4b6abe45aa58877ef47f9721b9",
+    "new_fingerprint": "sha256:82b554bd0ac856758d29d195d8a3c1d633086f8df6cd1b19318d15967ff66450",
+    "effective_at": "2026-04-26T15:00:00Z",
+    "reason": "scheduled annual key rotation"
+  },
+  "old_signature": "ed25519:e1e1a93198d95cf85a8b9921693dc88dec9eec20fba139cec99e1086c013e78726ad357e1405926f12b0c2300407a70bf53eb2339094d8fca997b75790841c00",
+  "new_signature": "ed25519:8df1082c41ad17133b23ac6a8aeb482c93064cbf10d7ec7921cc6503e3f6948c9945c7561deba771986bf1a0ce45f760c7eeda708d3a5ee9e2a19a8ee2c9f409"
+}

--- a/testdata/python_verifier_fixture/verify.py
+++ b/testdata/python_verifier_fixture/verify.py
@@ -161,30 +161,68 @@ def _parse_rfc3339(s: str) -> datetime:
     return datetime.fromisoformat(s)
 
 
+# Allowed top-level fields in a recovery_authorization envelope. Strict
+# schema parity with the Go DecodeStrictJSON path: unknown fields reject.
+_RECOVERY_ENVELOPE_FIELDS = frozenset({"body", "signature"})
+# Allowed fields inside the recovery_authorization body. Same strictness
+# rule as the envelope.
+_RECOVERY_BODY_FIELDS = frozenset(
+    {
+        "schema_version",
+        "reason",
+        "expires_at",
+        "target_roster_hash",
+        "operator_identity",
+        "issued_at",
+    }
+)
+
+
+def _reject_unknown_fields(name: str, obj: dict, allowed: frozenset) -> None:
+    """Mirror Go's json.Decoder.DisallowUnknownFields by raising on extras."""
+    extras = set(obj.keys()) - allowed
+    if extras:
+        raise ValueError(
+            f"{name} contains unknown fields: {sorted(extras)}"
+        )
+
+
 def verify_recovery_authorization(
     envelope_json_bytes: bytes,
     recovery_root_pubkey_bytes: bytes,
     pinned_recovery_root_fingerprint: str,
     now_iso: str,
+    expected_target_roster_hash: str = "",
 ) -> dict:
     """Verify a recovery_authorization envelope.
 
     Performs:
+      - Strict schema parity with Go (unknown envelope or body fields reject)
       - Structural validation matching Go RecoveryAuthorizationBody.Validate()
+      - Lifetime cap (expires_at - issued_at <= 1h) AND replay guard
+        (expires_at - now <= 1h) AND expires_at > issued_at
       - Time-window check using now_iso
       - Fingerprint pinning
+      - Optional target_roster_hash binding when expected_target_roster_hash
+        is non-empty (mirrors Go LoadRecoveryAuthorization)
       - Ed25519 signature verification over JCS-canonicalized body
 
     Returns the parsed body dict on success; raises ValueError on failure.
     """
     envelope = json.loads(envelope_json_bytes)
 
+    if not isinstance(envelope, dict):
+        raise ValueError("recovery authorization envelope must be a JSON object")
+    _reject_unknown_fields("recovery authorization envelope", envelope, _RECOVERY_ENVELOPE_FIELDS)
     if "body" not in envelope:
         raise ValueError("missing body field")
     if "signature" not in envelope:
         raise ValueError("missing signature field")
 
     body = envelope["body"]
+    if not isinstance(body, dict):
+        raise ValueError("recovery authorization body must be a JSON object")
+    _reject_unknown_fields("recovery authorization body", body, _RECOVERY_BODY_FIELDS)
 
     # Structural validation.
     if body.get("schema_version") != 1:
@@ -205,6 +243,21 @@ def verify_recovery_authorization(
     expires_at = _parse_rfc3339(body["expires_at"])
     now = _parse_rfc3339(now_iso)
 
+    # Lifetime cap and ordering: expires must follow issued, and the
+    # absolute lifetime must not exceed 1h. Without this, a stale auth
+    # with a short remaining window slips past the replay guard.
+    if expires_at <= issued_at:
+        raise ValueError(
+            f"recovery authorization expires_at is before issued_at: "
+            f"issued_at={body['issued_at']}, expires_at={body['expires_at']}"
+        )
+    lifetime = expires_at - issued_at
+    if lifetime.total_seconds() > 3600:
+        raise ValueError(
+            f"recovery authorization lifetime exceeds 1h ceiling: "
+            f"lifetime={lifetime}"
+        )
+
     # Time-window checks.
     if now < issued_at:
         raise ValueError(
@@ -216,11 +269,20 @@ def verify_recovery_authorization(
             f"recovery authorization is expired: "
             f"now={now_iso}, expires_at={body['expires_at']}"
         )
+    # Replay guard (defense in depth; redundant with lifetime cap when
+    # now >= issued_at, kept explicit so the gate is visible in code).
     delta = expires_at - now
     if delta.total_seconds() > 3600:
         raise ValueError(
             f"recovery authorization expires more than 1h in the future: "
             f"delta={delta}"
+        )
+
+    # Target roster binding.
+    if expected_target_roster_hash and target_hash != expected_target_roster_hash:
+        raise ValueError(
+            f"target_roster_hash mismatch: got {target_hash}, "
+            f"want {expected_target_roster_hash}"
         )
 
     # Fingerprint pinning.
@@ -243,6 +305,21 @@ def verify_recovery_authorization(
     return body
 
 
+# Allowed top-level fields in a root_transition envelope and body. Strict
+# schema parity with the Go DecodeStrictJSON path: unknown fields reject.
+_ROOT_TRANSITION_ENVELOPE_FIELDS = frozenset({"body", "old_signature", "new_signature"})
+_ROOT_TRANSITION_BODY_FIELDS = frozenset(
+    {
+        "schema_version",
+        "root_kind",
+        "old_fingerprint",
+        "new_fingerprint",
+        "effective_at",
+        "reason",
+    }
+)
+
+
 def verify_root_transition(
     envelope_json_bytes: bytes,
     old_pubkey_bytes: bytes,
@@ -252,6 +329,7 @@ def verify_root_transition(
     """Verify a root_transition envelope with dual signatures.
 
     Performs:
+      - Strict schema parity with Go (unknown envelope or body fields reject)
       - Structural validation matching Go RootTransitionBody.Validate()
       - Fingerprint matching for both old and new keys
       - Optional operator-pin check (if pinned_old_fingerprint is non-empty)
@@ -261,6 +339,9 @@ def verify_root_transition(
     """
     envelope = json.loads(envelope_json_bytes)
 
+    if not isinstance(envelope, dict):
+        raise ValueError("root transition envelope must be a JSON object")
+    _reject_unknown_fields("root transition envelope", envelope, _ROOT_TRANSITION_ENVELOPE_FIELDS)
     if "body" not in envelope:
         raise ValueError("missing body field")
     if "old_signature" not in envelope:
@@ -269,6 +350,9 @@ def verify_root_transition(
         raise ValueError("missing new_signature field")
 
     body = envelope["body"]
+    if not isinstance(body, dict):
+        raise ValueError("root transition body must be a JSON object")
+    _reject_unknown_fields("root transition body", body, _ROOT_TRANSITION_BODY_FIELDS)
 
     # Structural validation.
     if body.get("schema_version") != 1:
@@ -430,6 +514,15 @@ def _pubkey_from_seed_hex(seed_hex: str) -> bytes:
     return priv.public_key().public_bytes_raw()
 
 
+# Deterministic stand-in for the roster body hash the recovery
+# authorization is bound to. Must match goldenRecoveryTargetHash on the Go
+# side so cross-implementation parity is exercised end-to-end.
+# sha256("pipelock-test-recovery-target-roster-body-fixture")
+_GOLDEN_RECOVERY_TARGET_ROSTER_HASH = (
+    "sha256:d0936185ee07c30a681e5beb49ef01899744df04bef122596467d9aa8ef24f7d"
+)
+
+
 def smoke_test_recovery_authorization(fixture_path: str) -> int:
     """Verify a recovery_authorization golden fixture from the signing package."""
     pubkey = _pubkey_from_seed_hex(_GOLDEN_RECOVERY_ROOT_SEED_HEX)
@@ -437,11 +530,15 @@ def smoke_test_recovery_authorization(fixture_path: str) -> int:
     data = Path(fixture_path).read_bytes()
     try:
         body = verify_recovery_authorization(
-            data, pubkey, fp, "2026-04-26T13:10:00Z"
+            data,
+            pubkey,
+            fp,
+            "2026-04-26T13:10:00Z",
+            expected_target_roster_hash=_GOLDEN_RECOVERY_TARGET_ROSTER_HASH,
         )
         print(
             f"OK recovery_authorization: reason={body['reason']!r}, "
-            f"fingerprint={fp}"
+            f"fingerprint={fp}, target_roster_hash bound"
         )
         return 0
     except ValueError as e:

--- a/testdata/python_verifier_fixture/verify.py
+++ b/testdata/python_verifier_fixture/verify.py
@@ -140,16 +140,51 @@ def fingerprint(pubkey_bytes: bytes) -> str:
     return FINGERPRINT_ALGORITHM + ":" + hashlib.sha256(pubkey_bytes).hexdigest()
 
 
+def parse_fingerprint(s: str) -> str:
+    """Validate and normalize a sha256:<hex> fingerprint string.
+
+    Returns the canonical lowercase form. Raises ValueError on a missing
+    algorithm prefix, an unknown algorithm, a non-hex digest, or a digest
+    of the wrong length. Mirrors the Go ParseFingerprint behavior so that
+    a pin typed with uppercase hex on either side compares equal to its
+    canonical form.
+    """
+    idx = s.find(":")
+    if idx < 0:
+        raise ValueError(f"fingerprint missing algorithm prefix: {s!r}")
+    algorithm = s[:idx]
+    digest = s[idx + 1 :]
+    if algorithm != FINGERPRINT_ALGORITHM:
+        raise ValueError(
+            f"fingerprint algorithm {algorithm!r} not supported "
+            f"(expected {FINGERPRINT_ALGORITHM!r})"
+        )
+    # 32 bytes = 64 hex chars for sha256.
+    if len(digest) != 64:
+        raise ValueError(
+            f"fingerprint digest must be 64 hex chars, got {len(digest)}"
+        )
+    try:
+        bytes.fromhex(digest)
+    except ValueError as e:
+        raise ValueError(f"fingerprint digest is not hex: {digest!r}") from e
+    return FINGERPRINT_ALGORITHM + ":" + digest.lower()
+
+
 def verify_fingerprint(pubkey_hex: str, expected_fingerprint: str) -> None:
     """Decode a hex public key, compute its fingerprint, and compare to expected.
 
-    Raises ValueError on mismatch or invalid input.
+    The expected_fingerprint is parsed and normalized via parse_fingerprint
+    so a mixed-case pin compares equal to its canonical form (Go's
+    ParseFingerprint accepts uppercase hex; this verifier must stay
+    wire-compatible). Raises ValueError on mismatch or invalid input.
     """
     pubkey_bytes = bytes.fromhex(pubkey_hex)
     computed = fingerprint(pubkey_bytes)
-    if computed != expected_fingerprint:
+    expected_canonical = parse_fingerprint(expected_fingerprint)
+    if computed != expected_canonical:
         raise ValueError(
-            f"fingerprint mismatch: computed {computed}, expected {expected_fingerprint}"
+            f"fingerprint mismatch: computed {computed}, expected {expected_canonical}"
         )
 
 
@@ -312,12 +347,15 @@ def verify_recovery_authorization(
             f"want {expected_target_roster_hash}"
         )
 
-    # Fingerprint pinning.
+    # Fingerprint pinning. Normalize the operator-supplied pin via
+    # parse_fingerprint so a mixed-case input compares equal to its
+    # canonical form, matching Go's ParseFingerprint behavior.
     computed_fp = fingerprint(recovery_root_pubkey_bytes)
-    if computed_fp != pinned_recovery_root_fingerprint:
+    pinned_canonical = parse_fingerprint(pinned_recovery_root_fingerprint)
+    if computed_fp != pinned_canonical:
         raise ValueError(
             f"fingerprint mismatch: computed {computed_fp}, "
-            f"pinned {pinned_recovery_root_fingerprint}"
+            f"pinned {pinned_canonical}"
         )
 
     # Signature verification.
@@ -400,12 +438,19 @@ def verify_root_transition(
     if old_fp == new_fp:
         raise ValueError("old_fingerprint and new_fingerprint must differ")
 
+    # Explicit presence check so a missing effective_at surfaces as
+    # ValueError rather than KeyError on the subscript below.
+    if "effective_at" not in body:
+        raise ValueError("effective_at is required")
     _parse_rfc3339(body["effective_at"])  # validates format
 
     if not body.get("reason"):
         raise ValueError("reason is required")
 
-    # Fingerprint matching.
+    # Fingerprint matching. Body fields are already validated against
+    # _SHA256_HASH_RE which only admits lowercase hex, so they are
+    # canonical by construction; computed fingerprints are also
+    # canonical. Operator-supplied pin must be normalized.
     computed_old_fp = fingerprint(old_pubkey_bytes)
     if computed_old_fp != old_fp:
         raise ValueError(
@@ -419,12 +464,15 @@ def verify_root_transition(
             f"body has {new_fp}"
         )
 
-    # Optional operator-pin check.
-    if pinned_old_fingerprint and old_fp != pinned_old_fingerprint:
-        raise ValueError(
-            f"old_fingerprint does not match operator-pinned fingerprint: "
-            f"body={old_fp}, pinned={pinned_old_fingerprint}"
-        )
+    # Optional operator-pin check. Normalize via parse_fingerprint so a
+    # mixed-case input compares equal to the canonical body value.
+    if pinned_old_fingerprint:
+        pinned_old_canonical = parse_fingerprint(pinned_old_fingerprint)
+        if old_fp != pinned_old_canonical:
+            raise ValueError(
+                f"old_fingerprint does not match operator-pinned fingerprint: "
+                f"body={old_fp}, pinned={pinned_old_canonical}"
+            )
 
     # Dual signature verification.
     preimage = jcs.canonicalize(body)

--- a/testdata/python_verifier_fixture/verify.py
+++ b/testdata/python_verifier_fixture/verify.py
@@ -162,10 +162,22 @@ def _parse_rfc3339(s: str) -> datetime:
     Python 3.11; the repo targets earlier interpreters too, so normalize
     'Z' to '+00:00' before delegating. Other valid offsets pass through
     untouched.
+
+    RFC 3339 mandates a UTC offset on every timestamp. fromisoformat
+    happily produces a naive datetime for an offset-less input, which
+    later trips the timezone-aware comparisons with TypeError instead
+    of the documented ValueError. Reject naive results explicitly so
+    the error class matches the docstring and matches the Go side
+    parity (Go's time.Parse with RFC 3339 fails fast on missing zone).
     """
     if s.endswith("Z"):
         s = s[:-1] + "+00:00"
-    return datetime.fromisoformat(s)
+    dt = datetime.fromisoformat(s)
+    if dt.tzinfo is None or dt.utcoffset() is None:
+        raise ValueError(
+            f"RFC 3339 timestamp must include a UTC offset: {s!r}"
+        )
+    return dt
 
 
 # Allowed top-level fields in a recovery_authorization envelope. Strict
@@ -619,10 +631,23 @@ if __name__ == "__main__":
         sys.exit(smoke_test_signing_goldens())
 
     # Default: verify contract-package golden-dir.
-    # Also verify signing-package goldens if the directory exists.
+    # Also verify signing-package goldens, but only when the signing
+    # directory actually exists. Without this gate, an explicit
+    # `python3 verify.py <golden-dir>` invocation outside the repo tree
+    # would fail solely because the script's relative path to
+    # internal/signing/testdata/golden does not resolve there. Explicit
+    # `--signing-goldens` keeps its hard-fail-on-missing semantics.
     exit_code = main(sys.argv)
     if exit_code == 0:
-        signing_result = smoke_test_signing_goldens()
-        if signing_result > 0:
-            exit_code = 1
+        signing_golden = (
+            Path(__file__).resolve().parent.parent.parent
+            / "internal"
+            / "signing"
+            / "testdata"
+            / "golden"
+        )
+        if signing_golden.is_dir():
+            signing_result = smoke_test_signing_goldens()
+            if signing_result > 0:
+                exit_code = 1
     sys.exit(exit_code)

--- a/testdata/python_verifier_fixture/verify.py
+++ b/testdata/python_verifier_fixture/verify.py
@@ -8,13 +8,18 @@ between the Go and Python implementations.
 
 Usage:
     python3 verify.py <golden-dir>
+    python3 verify.py --fingerprint
+    python3 verify.py --recovery-authorization <path>
+    python3 verify.py --root-transition <path>
 
 Exits 0 on success, 1 on any verification failure.
 """
 
 import json
 import os
+import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import jcs
@@ -24,6 +29,9 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
 SIG_PREFIX = "ed25519:"
 FINGERPRINT_ALGORITHM = "sha256"
+
+# sha256:<64 lowercase hex chars>
+_SHA256_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 def load_test_pubkey(golden_dir: Path) -> bytes:
@@ -145,6 +153,188 @@ def verify_fingerprint(pubkey_hex: str, expected_fingerprint: str) -> None:
         )
 
 
+def _parse_rfc3339(s: str) -> datetime:
+    """Parse an RFC 3339 timestamp string into a timezone-aware datetime.
+
+    Raises ValueError on malformed input.
+    """
+    return datetime.fromisoformat(s)
+
+
+def verify_recovery_authorization(
+    envelope_json_bytes: bytes,
+    recovery_root_pubkey_bytes: bytes,
+    pinned_recovery_root_fingerprint: str,
+    now_iso: str,
+) -> dict:
+    """Verify a recovery_authorization envelope.
+
+    Performs:
+      - Structural validation matching Go RecoveryAuthorizationBody.Validate()
+      - Time-window check using now_iso
+      - Fingerprint pinning
+      - Ed25519 signature verification over JCS-canonicalized body
+
+    Returns the parsed body dict on success; raises ValueError on failure.
+    """
+    envelope = json.loads(envelope_json_bytes)
+
+    if "body" not in envelope:
+        raise ValueError("missing body field")
+    if "signature" not in envelope:
+        raise ValueError("missing signature field")
+
+    body = envelope["body"]
+
+    # Structural validation.
+    if body.get("schema_version") != 1:
+        raise ValueError(
+            f"unsupported schema_version: {body.get('schema_version')}"
+        )
+    if not body.get("reason"):
+        raise ValueError("reason is required")
+    if not body.get("operator_identity"):
+        raise ValueError("operator_identity is required")
+
+    target_hash = body.get("target_roster_hash", "")
+    if not _SHA256_HASH_RE.match(target_hash):
+        raise ValueError(f"target_roster_hash format invalid: {target_hash!r}")
+
+    # Parse timestamps (raises ValueError on bad format).
+    issued_at = _parse_rfc3339(body["issued_at"])
+    expires_at = _parse_rfc3339(body["expires_at"])
+    now = _parse_rfc3339(now_iso)
+
+    # Time-window checks.
+    if now < issued_at:
+        raise ValueError(
+            f"recovery authorization issued_at is in the future: "
+            f"now={now_iso}, issued_at={body['issued_at']}"
+        )
+    if now > expires_at:
+        raise ValueError(
+            f"recovery authorization is expired: "
+            f"now={now_iso}, expires_at={body['expires_at']}"
+        )
+    delta = expires_at - now
+    if delta.total_seconds() > 3600:
+        raise ValueError(
+            f"recovery authorization expires more than 1h in the future: "
+            f"delta={delta}"
+        )
+
+    # Fingerprint pinning.
+    computed_fp = fingerprint(recovery_root_pubkey_bytes)
+    if computed_fp != pinned_recovery_root_fingerprint:
+        raise ValueError(
+            f"fingerprint mismatch: computed {computed_fp}, "
+            f"pinned {pinned_recovery_root_fingerprint}"
+        )
+
+    # Signature verification.
+    preimage = jcs.canonicalize(body)
+    sig = strip_sig_prefix(envelope["signature"])
+    pk = Ed25519PublicKey.from_public_bytes(recovery_root_pubkey_bytes)
+    try:
+        pk.verify(sig, preimage)
+    except InvalidSignature as e:
+        raise ValueError(f"signature verify failed: {e}") from e
+
+    return body
+
+
+def verify_root_transition(
+    envelope_json_bytes: bytes,
+    old_pubkey_bytes: bytes,
+    new_pubkey_bytes: bytes,
+    pinned_old_fingerprint: str = "",
+) -> dict:
+    """Verify a root_transition envelope with dual signatures.
+
+    Performs:
+      - Structural validation matching Go RootTransitionBody.Validate()
+      - Fingerprint matching for both old and new keys
+      - Optional operator-pin check (if pinned_old_fingerprint is non-empty)
+      - Dual Ed25519 signature verification over JCS-canonicalized body
+
+    Returns the parsed body dict on success; raises ValueError on failure.
+    """
+    envelope = json.loads(envelope_json_bytes)
+
+    if "body" not in envelope:
+        raise ValueError("missing body field")
+    if "old_signature" not in envelope:
+        raise ValueError("missing old_signature field")
+    if "new_signature" not in envelope:
+        raise ValueError("missing new_signature field")
+
+    body = envelope["body"]
+
+    # Structural validation.
+    if body.get("schema_version") != 1:
+        raise ValueError(
+            f"unsupported schema_version: {body.get('schema_version')}"
+        )
+
+    root_kind = body.get("root_kind", "")
+    if root_kind not in ("roster-root", "recovery-root"):
+        raise ValueError(f"root_kind must be roster-root or recovery-root: {root_kind!r}")
+
+    old_fp = body.get("old_fingerprint", "")
+    new_fp = body.get("new_fingerprint", "")
+    if not _SHA256_HASH_RE.match(old_fp):
+        raise ValueError(f"old_fingerprint format invalid: {old_fp!r}")
+    if not _SHA256_HASH_RE.match(new_fp):
+        raise ValueError(f"new_fingerprint format invalid: {new_fp!r}")
+    if old_fp == new_fp:
+        raise ValueError("old_fingerprint and new_fingerprint must differ")
+
+    _parse_rfc3339(body["effective_at"])  # validates format
+
+    if not body.get("reason"):
+        raise ValueError("reason is required")
+
+    # Fingerprint matching.
+    computed_old_fp = fingerprint(old_pubkey_bytes)
+    if computed_old_fp != old_fp:
+        raise ValueError(
+            f"old key fingerprint mismatch: computed {computed_old_fp}, "
+            f"body has {old_fp}"
+        )
+    computed_new_fp = fingerprint(new_pubkey_bytes)
+    if computed_new_fp != new_fp:
+        raise ValueError(
+            f"new key fingerprint mismatch: computed {computed_new_fp}, "
+            f"body has {new_fp}"
+        )
+
+    # Optional operator-pin check.
+    if pinned_old_fingerprint and old_fp != pinned_old_fingerprint:
+        raise ValueError(
+            f"old_fingerprint does not match operator-pinned fingerprint: "
+            f"body={old_fp}, pinned={pinned_old_fingerprint}"
+        )
+
+    # Dual signature verification.
+    preimage = jcs.canonicalize(body)
+
+    old_sig = strip_sig_prefix(envelope["old_signature"])
+    old_pk = Ed25519PublicKey.from_public_bytes(old_pubkey_bytes)
+    try:
+        old_pk.verify(old_sig, preimage)
+    except InvalidSignature as e:
+        raise ValueError(f"old_signature verify failed: {e}") from e
+
+    new_sig = strip_sig_prefix(envelope["new_signature"])
+    new_pk = Ed25519PublicKey.from_public_bytes(new_pubkey_bytes)
+    try:
+        new_pk.verify(new_sig, preimage)
+    except InvalidSignature as e:
+        raise ValueError(f"new_signature verify failed: {e}") from e
+
+    return body
+
+
 # Map fixture filename -> verifier function.
 VERIFIERS = {
     "valid_contract.json": verify_envelope,
@@ -211,7 +401,116 @@ def smoke_test_fingerprint() -> int:
         return 1
 
 
+# --- Deterministic key seeds (must match Go golden_vectors_test.go) ---
+
+# Recovery-root seed (same as Go goldenRecoveryRootSeedHex).
+_GOLDEN_RECOVERY_ROOT_SEED_HEX = (
+    "4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb"
+)
+
+# New-root seed for root-transition (same as Go goldenNewRootSeedHex).
+_GOLDEN_NEW_ROOT_SEED_HEX = (
+    "4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fc"
+)
+
+# Old-root seed (RFC 8032 test 1 seed, same as Go goldenOldRootSeedHex).
+_GOLDEN_OLD_ROOT_SEED_HEX = (
+    "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"
+)
+
+
+def _pubkey_from_seed_hex(seed_hex: str) -> bytes:
+    """Derive the Ed25519 public key from a hex-encoded 32-byte seed."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+    )
+
+    seed = bytes.fromhex(seed_hex)
+    priv = Ed25519PrivateKey.from_private_bytes(seed)
+    return priv.public_key().public_bytes_raw()
+
+
+def smoke_test_recovery_authorization(fixture_path: str) -> int:
+    """Verify a recovery_authorization golden fixture from the signing package."""
+    pubkey = _pubkey_from_seed_hex(_GOLDEN_RECOVERY_ROOT_SEED_HEX)
+    fp = fingerprint(pubkey)
+    data = Path(fixture_path).read_bytes()
+    try:
+        body = verify_recovery_authorization(
+            data, pubkey, fp, "2026-04-26T13:10:00Z"
+        )
+        print(
+            f"OK recovery_authorization: reason={body['reason']!r}, "
+            f"fingerprint={fp}"
+        )
+        return 0
+    except ValueError as e:
+        print(f"FAIL recovery_authorization: {e}")
+        return 1
+
+
+def smoke_test_root_transition(fixture_path: str) -> int:
+    """Verify a root_transition golden fixture from the signing package."""
+    old_pubkey = _pubkey_from_seed_hex(_GOLDEN_OLD_ROOT_SEED_HEX)
+    new_pubkey = _pubkey_from_seed_hex(_GOLDEN_NEW_ROOT_SEED_HEX)
+    old_fp = fingerprint(old_pubkey)
+    data = Path(fixture_path).read_bytes()
+    try:
+        body = verify_root_transition(data, old_pubkey, new_pubkey, old_fp)
+        print(
+            f"OK root_transition: reason={body['reason']!r}, "
+            f"old_fingerprint={body['old_fingerprint']}, "
+            f"new_fingerprint={body['new_fingerprint']}"
+        )
+        return 0
+    except ValueError as e:
+        print(f"FAIL root_transition: {e}")
+        return 1
+
+
+def smoke_test_signing_goldens() -> int:
+    """Auto-locate and verify both signing-package golden fixtures.
+
+    Looks relative to this script's location:
+      ../../internal/signing/testdata/golden/
+    """
+    script_dir = Path(__file__).resolve().parent
+    signing_golden = script_dir.parent.parent / "internal" / "signing" / "testdata" / "golden"
+
+    failures = 0
+
+    recovery_path = signing_golden / "valid_recovery_authorization.json"
+    if recovery_path.exists():
+        failures += smoke_test_recovery_authorization(str(recovery_path))
+    else:
+        print(f"FAIL recovery_authorization: file missing at {recovery_path}")
+        failures += 1
+
+    transition_path = signing_golden / "valid_root_transition.json"
+    if transition_path.exists():
+        failures += smoke_test_root_transition(str(transition_path))
+    else:
+        print(f"FAIL root_transition: file missing at {transition_path}")
+        failures += 1
+
+    return failures
+
+
 if __name__ == "__main__":
     if len(sys.argv) == 2 and sys.argv[1] == "--fingerprint":
         sys.exit(smoke_test_fingerprint())
-    sys.exit(main(sys.argv))
+    if len(sys.argv) == 3 and sys.argv[1] == "--recovery-authorization":
+        sys.exit(smoke_test_recovery_authorization(sys.argv[2]))
+    if len(sys.argv) == 3 and sys.argv[1] == "--root-transition":
+        sys.exit(smoke_test_root_transition(sys.argv[2]))
+    if len(sys.argv) == 2 and sys.argv[1] == "--signing-goldens":
+        sys.exit(smoke_test_signing_goldens())
+
+    # Default: verify contract-package golden-dir.
+    # Also verify signing-package goldens if the directory exists.
+    exit_code = main(sys.argv)
+    if exit_code == 0:
+        signing_result = smoke_test_signing_goldens()
+        if signing_result > 0:
+            exit_code = 1
+    sys.exit(exit_code)

--- a/testdata/python_verifier_fixture/verify.py
+++ b/testdata/python_verifier_fixture/verify.py
@@ -23,6 +23,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
 
 SIG_PREFIX = "ed25519:"
+FINGERPRINT_ALGORITHM = "sha256"
 
 
 def load_test_pubkey(golden_dir: Path) -> bytes:
@@ -114,6 +115,36 @@ def verify_evidence_receipt(fixture: Path, pubkey: bytes) -> tuple[bool, str]:
         return False, f"verify failed: {e}"
 
 
+def fingerprint(pubkey_bytes: bytes) -> str:
+    """Pipelock canonical key fingerprint: "sha256:" + lowercase hex of
+    sha256 over the raw 32-byte ed25519 public key.
+
+    Cross-implementation: the Go Fingerprint() function computes the same
+    value byte for byte. Changing this format requires a roster
+    schema_version bump.
+    """
+    if len(pubkey_bytes) != 32:
+        raise ValueError(
+            f"expected 32-byte ed25519 public key, got {len(pubkey_bytes)}"
+        )
+    import hashlib
+
+    return FINGERPRINT_ALGORITHM + ":" + hashlib.sha256(pubkey_bytes).hexdigest()
+
+
+def verify_fingerprint(pubkey_hex: str, expected_fingerprint: str) -> None:
+    """Decode a hex public key, compute its fingerprint, and compare to expected.
+
+    Raises ValueError on mismatch or invalid input.
+    """
+    pubkey_bytes = bytes.fromhex(pubkey_hex)
+    computed = fingerprint(pubkey_bytes)
+    if computed != expected_fingerprint:
+        raise ValueError(
+            f"fingerprint mismatch: computed {computed}, expected {expected_fingerprint}"
+        )
+
+
 # Map fixture filename -> verifier function.
 VERIFIERS = {
     "valid_contract.json": verify_envelope,
@@ -159,5 +190,28 @@ def main(argv: list[str]) -> int:
     return 0
 
 
+def smoke_test_fingerprint() -> int:
+    """Standalone smoke test for the fingerprint function.
+
+    Uses the RFC 8032 section 7.1 test vector 1 public key.
+    The expected value must match the Go rfcTestPubFingerprint constant.
+    """
+    rfc_pubkey_hex = (
+        "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+    )
+    expected = (
+        "sha256:21fe31dfa154a261626bf854046fd2271b7bed4b6abe45aa58877ef47f9721b9"
+    )
+    try:
+        verify_fingerprint(rfc_pubkey_hex, expected)
+        print(f"OK fingerprint: {expected}")
+        return 0
+    except ValueError as e:
+        print(f"FAIL fingerprint: {e}")
+        return 1
+
+
 if __name__ == "__main__":
+    if len(sys.argv) == 2 and sys.argv[1] == "--fingerprint":
+        sys.exit(smoke_test_fingerprint())
     sys.exit(main(sys.argv))

--- a/testdata/python_verifier_fixture/verify.py
+++ b/testdata/python_verifier_fixture/verify.py
@@ -157,7 +157,14 @@ def _parse_rfc3339(s: str) -> datetime:
     """Parse an RFC 3339 timestamp string into a timezone-aware datetime.
 
     Raises ValueError on malformed input.
+
+    datetime.fromisoformat does not accept a trailing 'Z' suffix until
+    Python 3.11; the repo targets earlier interpreters too, so normalize
+    'Z' to '+00:00' before delegating. Other valid offsets pass through
+    untouched.
     """
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
     return datetime.fromisoformat(s)
 
 
@@ -233,6 +240,14 @@ def verify_recovery_authorization(
         raise ValueError("reason is required")
     if not body.get("operator_identity"):
         raise ValueError("operator_identity is required")
+    # Explicit presence checks so missing required body fields surface
+    # as ValueError rather than KeyError on the subscript below; matches
+    # the Go side's ErrRecoveryIssuedAtFormat / ErrRecoveryExpiryFormat
+    # behavior when the JSON decoder yields a zero-value empty string.
+    if "issued_at" not in body:
+        raise ValueError("issued_at is required")
+    if "expires_at" not in body:
+        raise ValueError("expires_at is required")
 
     target_hash = body.get("target_roster_hash", "")
     if not _SHA256_HASH_RE.match(target_hash):


### PR DESCRIPTION
## Summary

Ships the deployment-side signing extension for v2.4 learn-and-lock:

- **`signing.KeyPurpose`** typed enum mirroring the wire-format `key_purpose` strings from the design (six values: receipt, contract-compile, contract-activation, rules-official, roster-root, recovery-root). Authorisation wraps `contract.AuthorizeKeyPurpose` so callers operate on typed values without losing `errors.Is` on the underlying sentinels.
- **`signing.Fingerprint`** canonical key fingerprint helpers. Format is locked at `"sha256:" + lowercase hex(sha256(rawPubKey))` over the 32-byte ed25519 public key. Hashing the encoded form (hex text or versioned envelope) is documented as forbidden. `VerifyFingerprint` runs constant-time on the decoded digest bytes.
- **`signing.LoadedRoster`** loads `key_roster.yaml`/`.json` envelopes, runs strict per-key validation (status, purpose, public-key length), verifies the roster-root fingerprint matches the operator-pinned value, and verifies the detached Ed25519 signature against the body's canonical preimage. `ResolveKey` requires explicit `status=active`. `AuthorizeSignerForPayload` is the lifecycle-and-purpose gate (the name reflects that it does not itself verify signatures).
- **`signing.RecoveryAuthorization`** break-glass primitive. Enforces lifetime ceiling (`expires_at - issued_at <= 1h`), replay guard (`expires_at - now <= 1h`), expiry ordering, and an optional `expectedTargetRosterHash` binding that runtime callers must use to bind an authorisation to a specific roster body. There is no unsigned recovery path.
- **`signing.RootTransition`** rotation primitive for both roster-root and recovery-root keys. Body is signed by BOTH the OLD and NEW roots over the same canonical preimage; the loader requires both signatures to verify. Identity rotations (old fingerprint == new fingerprint) reject so the primitive cannot be used to launder audit trails.
- **`pipelock signing`** CLI subtree: `roster show`, `roster verify`, `recovery verify`, `transition verify`. Verify-focused offline-ceremony commands. No `rotate` command in this PR; rotation requires runtime/config wiring that lands in a later change.
- **`contract.DecodeStrictYAML`** + `LoadContractYAML`/`LoadKeyRosterYAML`/`LoadTombstoneYAML` so YAML-distributed signed artifacts share the typed-boundary discipline already used for JSON. Pipeline is YAML → strict-parsed tree → JSON marshal → `DecodeStrictJSON`, so JSON and YAML transports converge on one bug surface.

The existing per-agent `signing.Keystore` is intentionally untouched: this machinery is for the deployment-level key roster, not agent message signing. Zero migration for existing on-disk agent keys.

## Cross-implementation conformance

The Python verifier fixture grows matching `fingerprint`, `verify_recovery_authorization`, and `verify_root_transition` functions, plus strict-schema rejection of unknown envelope/body fields so the cross-implementation boundary is byte-identical with Go's strict decoder. New Go-emitted golden vectors round-trip byte-identically through Python under `jcs` + `cryptography>=46`. `internal/signing/testdata/golden/` is added to the Pipelock self-scan exclude list (Ed25519 hex strings trip the Bitcoin WIF / generic API key heuristics).

## Stacked on PR #442

Base is `feat/learn-and-lock-pr-1.1`. The diff shown here is only this PR's 12 commits; PR #442's content is part of the base and will rebase cleanly onto main when #442 merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline CLI subtree for signing operations (roster, recovery, transition) and related verification/inspect commands
  * Roster, recovery-authorization, and root-transition loading + strict verification flows
  * SHA-256 fingerprinting and strict fingerprint format checks
  * Strict YAML/JSON decoding helpers for contract artifacts
  * Standalone verifier script now supports signing artifact smoke tests

* **Tests**
  * Extensive deterministic and golden test suites for signing, recovery, transitions, rosters, and loaders

* **Chores**
  * CI security scan excludes additional testdata path
<!-- end of auto-generated comment: release notes by coderabbit.ai -->