### PR TITLE
fix(mcp): drain adopted-descendant zombies during long-lived wraps

### DIFF
--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -951,6 +951,20 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	// no-op, matching the no-op setupChildProcessGroup call above.
 	childPgid := captureChildPgid(cmd.Process.Pid)
 
+	// Drain adopted-descendant zombies live, while the direct child is
+	// still running. Without this, long-running MCP wraps (codex
+	// mcp-server, playwright MCP — multi-hour direct children) accumulate
+	// zombies under pipelock because the post-Wait killAdoptedDescendants
+	// sweep below only fires when the direct child exits. PR_SET_CHILD_SUBREAPER
+	// turned on above causes orphan adoption from minute one; this goroutine
+	// reaps the resulting zombies as they appear. Reaper Wait4's only
+	// PID-specific (never -1) and skips the direct child PID, so
+	// exec.Cmd.Wait()'s ownership of the direct child's exit is preserved.
+	// On non-Linux builds startAdoptedReaper is a no-op.
+	reaperDone := make(chan struct{})
+	defer close(reaperDone)
+	startAdoptedReaper(cmd.Process.Pid, reaperDone)
+
 	// Track child PID for file write attribution.
 	if lineage != nil {
 		lineage.TrackPID(cmd.Process.Pid)

--- a/internal/mcp/reaper_linux.go
+++ b/internal/mcp/reaper_linux.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package mcp
+
+import (
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// startAdoptedReaper drains exited adopted descendants while the direct
+// MCP child is still alive. Without it, long-running wraps (codex
+// mcp-server, playwright MCP) accumulate zombies under pipelock because
+// the post-Wait killAdoptedDescendants sweep only fires when the direct
+// child exits — which can be hours later for those servers.
+//
+// The reaper only Wait4's processes whose PPID is pipelock's own and
+// whose PID is not the direct child. exec.Cmd.Wait()'s ownership of
+// the direct child's exit status is therefore preserved: we never call
+// Wait4(-1, ...) and we never call Wait4(directPID, ...).
+//
+// Why signal.Notify(SIGCHLD) doesn't break exec.Cmd.Wait(): Go's
+// runtime reaps subprocess children with wait4(pid, ..., 0) bound to
+// the specific cmd.Process.Pid, not via SIGCHLD-driven dispatch. The
+// kernel keeps a zombie until SOMEONE waitpids it, regardless of
+// which process catches SIGCHLD. As long as we never wait4(directPID),
+// we cannot consume the direct child's exit status — even with
+// signal.Notify subscribing to SIGCHLD process-wide.
+//
+// Stop the reaper by closing done. The goroutine exits on the next
+// SIGCHLD or when done closes — whichever comes first.
+//
+// Linux-only because PR_SET_CHILD_SUBREAPER (the precondition that
+// causes pipelock to adopt orphans in the first place) is Linux-only.
+// Non-Linux builds use the no-op stub.
+func startAdoptedReaper(directPID int, done <-chan struct{}) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGCHLD)
+	go func() {
+		defer signal.Stop(sigCh)
+		// Initial sweep covers two narrow windows:
+		//   1. A grandchild that exited before cmd.Start finished
+		//      and we got here with the direct PID.
+		//   2. A SIGCHLD that fired before signal.Notify took effect
+		//      above (kernel delivers to the default handler, which
+		//      ignores it — the zombie sits until someone wait4's it).
+		// Without this initial sweep, those zombies would sit until the
+		// direct child exits and the post-Wait sweep runs — exactly
+		// the bug we're fixing.
+		reapAdoptedZombies(directPID)
+		for {
+			select {
+			case <-done:
+				return
+			case <-sigCh:
+				reapAdoptedZombies(directPID)
+			}
+		}
+	}()
+}
+
+// reapAdoptedZombies walks /proc once, finds zombies whose parent PID
+// is pipelock's own and whose PID is not directPID, and Wait4's each
+// one with WNOHANG. Wait4 against a specific PID cannot consume the
+// direct child's exit, which is what makes this safe to run alongside
+// exec.Cmd.Wait().
+//
+// Best-effort throughout — ESRCH on PID-recycle race, EINTR on signal,
+// EPERM on namespace boundary all fall through silently.
+func reapAdoptedZombies(directPID int) {
+	selfPID := os.Getpid()
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		childPID, convErr := strconv.Atoi(name)
+		if convErr != nil {
+			continue
+		}
+		if childPID == selfPID || childPID == directPID {
+			continue
+		}
+		if !isAdoptedZombie(name, selfPID) {
+			continue
+		}
+		var status syscall.WaitStatus
+		_, _ = syscall.Wait4(childPID, &status, syscall.WNOHANG, nil)
+	}
+}
+
+// isAdoptedZombie returns true iff /proc/<name>/stat shows state "Z"
+// and ppid == selfPID. Mirrors the parser in killAdoptedDescendants:
+// field 2 is a parenthesized comm string that may itself contain
+// spaces or close-parens, so we locate the LAST ')' and index from
+// there before whitespace-splitting.
+func isAdoptedZombie(procName string, selfPID int) bool {
+	statPath := filepath.Clean("/proc/" + procName + "/stat")
+	statBytes, readErr := os.ReadFile(statPath)
+	if readErr != nil {
+		return false
+	}
+	stat := string(statBytes)
+	cmdEnd := strings.LastIndex(stat, ")")
+	if cmdEnd < 0 || cmdEnd+2 > len(stat) {
+		return false
+	}
+	// After "<pid> (<comm>) ", fields are: state(1) ppid(2) pgrp(3) ...
+	rest := strings.Fields(stat[cmdEnd+1:])
+	if len(rest) < 2 {
+		return false
+	}
+	if rest[0] != "Z" {
+		return false
+	}
+	ppid, convErr := strconv.Atoi(rest[1])
+	if convErr != nil {
+		return false
+	}
+	return ppid == selfPID
+}

--- a/internal/mcp/reaper_linux.go
+++ b/internal/mcp/reaper_linux.go
@@ -71,6 +71,14 @@ func startAdoptedReaper(directPID int, done <-chan struct{}) {
 // direct child's exit, which is what makes this safe to run alongside
 // exec.Cmd.Wait().
 //
+// One-wrap-per-process assumption: this helper only protects its own
+// directPID. The MCP CLI today is one `pipelock mcp proxy --` invocation
+// per pipelock process, so directPID uniquely identifies the wrapped
+// child. If RunProxy is ever called concurrently inside one process,
+// a reaper from one call could Wait4 a sibling's direct child. Either
+// keep the one-wrap-per-process invariant or extend this to a shared
+// protected-PID registry before that change lands.
+//
 // Best-effort throughout — ESRCH on PID-recycle race, EINTR on signal,
 // EPERM on namespace boundary all fall through silently.
 func reapAdoptedZombies(directPID int) {

--- a/internal/mcp/reaper_linux_test.go
+++ b/internal/mcp/reaper_linux_test.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package mcp
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestReaper_AdoptedZombieDrained_DirectChildPreserved is the regression
+// test for the MCP proxy zombie accumulation bug. It enables the same
+// PR_SET_CHILD_SUBREAPER bit pipelock sets, spawns a helper whose
+// double-forked grandchild exits while the helper stays alive, asserts
+// the grandchild is reaped by the live reaper (not left as a zombie),
+// then asserts cmd.Wait() still observes the helper's exit normally
+// (i.e. the reaper did not steal the direct child's exit status).
+func TestReaper_AdoptedZombieDrained_DirectChildPreserved(t *testing.T) {
+	if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0); err != nil {
+		t.Skipf("PR_SET_CHILD_SUBREAPER unavailable (need CAP_SYS_RESOURCE in containers): %v", err)
+	}
+
+	// Helper script: double-fork a grandchild that sleeps briefly and
+	// exits. The intermediate shell exits immediately so the grandchild
+	// reparents to whichever ancestor has PR_SET_CHILD_SUBREAPER set —
+	// that's this test process. The outer helper then sleeps so the
+	// direct child stays alive while the grandchild becomes a zombie.
+	helper := `( ( sleep 0.1; exit 0 ) & ) ; sleep 30`
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sh", "-c", helper)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting helper: %v", err)
+	}
+	directPID := cmd.Process.Pid
+
+	// Step 1: WITHOUT the reaper, observe the bug. The double-forked
+	// grandchild sleeps 100 ms then exits and becomes a zombie under
+	// us (via subreaper adoption). Poll until we see it. This proves
+	// the test scenario actually reproduces the leak — without this
+	// gate a no-op reaper would also pass.
+	if !waitForCondition(t, 2*time.Second, func() bool {
+		return countAdoptedZombies(directPID) >= 1
+	}) {
+		t.Fatal("scenario invalid: no adopted zombie ever appeared (helper didn't double-fork as expected)")
+	}
+
+	// Step 2: start the reaper. Initial sweep runs synchronously before
+	// the SIGCHLD listener loop, so the existing zombie should be
+	// drained immediately. Future grandchildren get drained on SIGCHLD.
+	reaperDone := make(chan struct{})
+	startAdoptedReaper(directPID, reaperDone)
+
+	if !waitForCondition(t, 2*time.Second, func() bool {
+		return countAdoptedZombies(directPID) == 0
+	}) {
+		dumpZombies(t, directPID)
+		t.Fatal("live reaper did not drain adopted-descendant zombie")
+	}
+
+	// Direct child must still be running and reapable by cmd.Wait().
+	// If the reaper had stolen its exit status, Wait would return
+	// ECHILD-derived "wait: no child processes" or hang.
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("signaling direct child: %v", err)
+	}
+
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- cmd.Wait() }()
+	select {
+	case err := <-waitDone:
+		// Helper exited via SIGTERM; an *exec.ExitError is expected and
+		// proves Wait observed the direct child's exit. The forbidden
+		// failure mode is err == nil with a stolen-exit symptom or
+		// "no child processes".
+		if err == nil {
+			// Unlikely but acceptable — the helper happened to exit 0.
+			break
+		}
+		if isReaperStoleExitError(err) {
+			t.Fatalf("cmd.Wait() returned a stolen-exit error — reaper consumed the direct child: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("cmd.Wait() hung — reaper likely consumed the direct child's exit status")
+	}
+
+	close(reaperDone)
+}
+
+// waitForCondition polls cond every 25 ms until it returns true or the
+// deadline passes. Returns the final value of cond().
+func waitForCondition(t *testing.T, timeout time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return cond()
+}
+
+// countAdoptedZombies returns the number of zombies under our PID
+// excluding the direct child. Mirrors the reaper's filter.
+func countAdoptedZombies(directPID int) int {
+	selfPID := os.Getpid()
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return 0
+	}
+	var n int
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		childPID, convErr := strconv.Atoi(name)
+		if convErr != nil {
+			continue
+		}
+		if childPID == selfPID || childPID == directPID {
+			continue
+		}
+		if isAdoptedZombie(name, selfPID) {
+			n++
+		}
+	}
+	return n
+}
+
+// dumpZombies logs surviving zombies for diagnostic when the test fails.
+func dumpZombies(t *testing.T, directPID int) {
+	t.Helper()
+	selfPID := os.Getpid()
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		childPID, convErr := strconv.Atoi(name)
+		if convErr != nil {
+			continue
+		}
+		if childPID == selfPID || childPID == directPID {
+			continue
+		}
+		if !isAdoptedZombie(name, selfPID) {
+			continue
+		}
+		statBytes, _ := os.ReadFile(filepath.Clean("/proc/" + name + "/stat"))
+		t.Logf("surviving zombie pid=%d stat=%q", childPID, strings.TrimSpace(string(statBytes)))
+	}
+}
+
+// isReaperStoleExitError detects the symptom of the reaper consuming
+// the direct child's exit status: a syscall.ECHILD wrapped somewhere in
+// the cmd.Wait error chain.
+func isReaperStoleExitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// exec.Cmd.Wait wraps the underlying syscall error in a "wait:
+	// no child processes" string when ECHILD bubbles up.
+	return strings.Contains(err.Error(), "no child processes") ||
+		strings.Contains(err.Error(), "ECHILD")
+}
+
+// TestReaper_DoneChannelStopsGoroutine covers the done-channel teardown
+// branch of startAdoptedReaper and verifies the goroutine actually
+// exits — not merely that the test completes without deadlock. We
+// snapshot runtime.NumGoroutine before and after a batch of
+// start/close cycles; if the done branch failed to fire, leaked
+// goroutines would accumulate and the post-batch count would exceed
+// the pre-batch count by approximately the iteration count.
+func TestReaper_DoneChannelStopsGoroutine(t *testing.T) {
+	const iterations = 10
+	// Drain any pre-existing goroutines (test infra, prior test leftovers)
+	// by sleeping and re-sampling — gives Go's scheduler a chance to
+	// settle.
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	for range iterations {
+		done := make(chan struct{})
+		startAdoptedReaper(0, done) // directPID=0 is impossible — never matches
+		// Let the goroutine reach its select on done/sigCh.
+		time.Sleep(10 * time.Millisecond)
+		// Send a self-SIGCHLD to deterministically exercise the sigCh
+		// branch. The reaper sweep is a no-op (no adopted zombies under
+		// this test process) but the branch is hit, which is the goal.
+		_ = syscall.Kill(os.Getpid(), syscall.SIGCHLD)
+		time.Sleep(10 * time.Millisecond)
+		close(done)
+	}
+	// Give all goroutines a chance to observe close(done) and exit.
+	time.Sleep(100 * time.Millisecond)
+
+	after := runtime.NumGoroutine()
+	// Allow ±2 goroutines for unrelated test infra noise; iterations=10
+	// makes a true leak unmistakable (delta ≥ 10).
+	if delta := after - before; delta > 2 {
+		t.Fatalf("goroutine leak: %d goroutines before, %d after (delta=%d, iterations=%d)",
+			before, after, delta, iterations)
+	}
+}

--- a/internal/mcp/reaper_linux_test.go
+++ b/internal/mcp/reaper_linux_test.go
@@ -7,6 +7,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -169,15 +170,14 @@ func dumpZombies(t *testing.T, directPID int) {
 
 // isReaperStoleExitError detects the symptom of the reaper consuming
 // the direct child's exit status: a syscall.ECHILD wrapped somewhere in
-// the cmd.Wait error chain.
+// the cmd.Wait error chain. Match through errors.Is so any wrapper
+// preserving the chain (exec.Cmd.Wait, os.SyscallError, etc.) resolves
+// to the same verdict regardless of the surrounding message text.
 func isReaperStoleExitError(err error) bool {
 	if err == nil {
 		return false
 	}
-	// exec.Cmd.Wait wraps the underlying syscall error in a "wait:
-	// no child processes" string when ECHILD bubbles up.
-	return strings.Contains(err.Error(), "no child processes") ||
-		strings.Contains(err.Error(), "ECHILD")
+	return errors.Is(err, syscall.ECHILD)
 }
 
 // TestReaper_DoneChannelStopsGoroutine covers the done-channel teardown

--- a/internal/mcp/reaper_linux_test.go
+++ b/internal/mcp/reaper_linux_test.go
@@ -57,9 +57,10 @@ func TestReaper_AdoptedZombieDrained_DirectChildPreserved(t *testing.T) {
 		t.Fatal("scenario invalid: no adopted zombie ever appeared (helper didn't double-fork as expected)")
 	}
 
-	// Step 2: start the reaper. Initial sweep runs synchronously before
-	// the SIGCHLD listener loop, so the existing zombie should be
-	// drained immediately. Future grandchildren get drained on SIGCHLD.
+	// Step 2: start the reaper. Initial sweep runs first inside the
+	// goroutine (before it blocks on the select), so the existing
+	// zombie should be drained within the next scheduling tick.
+	// Future grandchildren get drained on SIGCHLD.
 	reaperDone := make(chan struct{})
 	startAdoptedReaper(directPID, reaperDone)
 

--- a/internal/mcp/reaper_other.go
+++ b/internal/mcp/reaper_other.go
@@ -1,0 +1,13 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package mcp
+
+// startAdoptedReaper is a no-op on non-Linux builds. The reaper exists
+// to drain descendants pipelock has adopted via PR_SET_CHILD_SUBREAPER,
+// which is itself Linux-only (see subtree_other.go's enableSubreaper
+// no-op). Without subreaper adoption there are no orphaned descendants
+// to reap.
+func startAdoptedReaper(_ int, _ <-chan struct{}) {}


### PR DESCRIPTION
## Summary

Pipelock's MCP proxy already calls `PR_SET_CHILD_SUBREAPER` before spawning each direct child (`internal/mcp/subtree_linux.go`), so any grandchild that escapes the direct child's process group via `setsid` or double-fork reparents to pipelock instead of PID 1. The post-Wait `killAdoptedDescendants` sweep then SIGKILLs everything left.

That sweep only fires after the direct child exits, which can be hours later for long-running MCP wraps (codex mcp-server, playwright MCP). During that window, adopted-descendant grandchildren exit and become zombies under pipelock with no live reaper to drain them. Observed: 100+ zombies under two long-lived MCP proxy parents (about 22h uptime each).

## Fix

Add a SIGCHLD-driven goroutine that walks `/proc` on each notification, finds processes with `PPID==pipelock` in zombie state, and `Wait4`'s only PID-specific (never `-1`) and only those whose PID is not the direct child. `exec.Cmd.Wait()`'s ownership of the direct child's exit status is therefore preserved: the reaper cannot accidentally consume it.

Linux-only. Non-Linux builds use a no-op stub since `PR_SET_CHILD_SUBREAPER` (the precondition for adoption) is itself Linux-only.

## Tests

Regression test double-forks a grandchild that sleeps briefly then exits:

1. Observe the zombie appears (proves the scenario reproduces the leak).
2. Start the reaper.
3. Observe the zombie is drained.
4. SIGTERM the helper, verify `cmd.Wait()` still observes the direct child exit normally (proves the reaper did not steal the direct child's exit).

Plus a goroutine-leak test using `runtime.NumGoroutine()` to verify `close(done)` actually stops the reaper.

Per-function coverage on new code: `startAdoptedReaper` 100%, `reapAdoptedZombies` 94.1%, `isAdoptedZombie` 76.5%. Remaining uncovered lines are defensive guards for malformed `/proc` data, same structural ceiling class as the filesystem-fault-injection branches already acknowledged in `CLAUDE.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process cleanup on Linux systems through automatic and continuous removal of zombie processes in the background. The proxy now includes a dedicated monitoring mechanism that identifies and safely reaps orphaned child processes during operation, preventing the gradual resource accumulation and performance degradation that could occur during extended or high-volume proxy operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->