### PR TITLE
feat(contract): add inference confidence and exposure gates

### DIFF
--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -37,7 +37,12 @@ const (
 	// Defaults() now includes the Learn top-level block (enabled=false,
 	// privacy.public_allowlist_default=true). New policy surface → ph
 	// must shift so verifiers detect the schema change.
-	goldenHashDefaults = "bfaf53a86f0a97d30975349cbe0ba09947dd42b413cd04c4076114e434ad91e8"
+	// Re-bumped on the inference-engine wiring PR: Learn now carries an
+	// inference.floors substruct (min_sessions/min_events/min_windows).
+	// Floors are detection-relevant (they decide stable vs
+	// never_confirmed at compile time), so they must flow into ph so
+	// verifiers detect deployments that loosen the exposure gates.
+	goldenHashDefaults = "2fc2087f2baaf55caeff6aea778760eee3f2e16a36687473ab29e338c95ea624"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -47,7 +52,11 @@ const (
 	// the rich fixture now carries a Learn block with enabled=false +
 	// privacy.public_allowlist_default=true defaults, so ph must shift
 	// in lockstep with the Defaults() bump above.
-	goldenHashRichConfig = "31c45f2e4131f4d780c6452192a98928d91b69a46c21e1858dfb5125d5e15dcb"
+	// Re-bumped on the inference-engine wiring PR: see goldenHashDefaults
+	// note above. Floors decode as zero in the rich fixture (which does
+	// not set them) and Resolved() supplies defaults at runtime, so the
+	// rich-config hash shifts in lockstep with Defaults().
+	goldenHashRichConfig = "19acd838ef7d36ed467077dd56a545e60808a5155fa61715aa5f889ee5f7aac7"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/learn_test.go
+++ b/internal/config/learn_test.go
@@ -549,6 +549,9 @@ func TestLearn_YAMLRoundTrip(t *testing.T) {
 	cfg.Learn.CaptureDir = "/var/lib/pipelock/learn"
 	cfg.Learn.Privacy.SaltSource = "${PIPELOCK_REDACT_SALT}"
 	cfg.Learn.Privacy.PublicAllowlistDefault = false
+	cfg.Learn.Inference.Floors.MinSessions = 7
+	cfg.Learn.Inference.Floors.MinEvents = 30
+	cfg.Learn.Inference.Floors.MinWindows = 4
 
 	out, err := yaml.Marshal(cfg)
 	if err != nil {
@@ -569,5 +572,189 @@ func TestLearn_YAMLRoundTrip(t *testing.T) {
 	}
 	if got.Learn.Privacy.PublicAllowlistDefault {
 		t.Errorf("PublicAllowlistDefault flipped to true on round-trip")
+	}
+	if got.Learn.Inference.Floors.MinSessions != 7 {
+		t.Errorf("Inference.Floors.MinSessions=%d lost on round-trip", got.Learn.Inference.Floors.MinSessions)
+	}
+	if got.Learn.Inference.Floors.MinEvents != 30 {
+		t.Errorf("Inference.Floors.MinEvents=%d lost on round-trip", got.Learn.Inference.Floors.MinEvents)
+	}
+	if got.Learn.Inference.Floors.MinWindows != 4 {
+		t.Errorf("Inference.Floors.MinWindows=%d lost on round-trip", got.Learn.Inference.Floors.MinWindows)
+	}
+}
+
+// TestValidateLearnInferenceFloors_NegativeRejected exercises one row per
+// field, each row setting exactly one field to -1. The error message must
+// surface the exact YAML path the operator sees in pipelock.yaml plus the
+// numeric value, so the operator can grep the file for the failing knob
+// without translating between Go field names and YAML keys.
+func TestValidateLearnInferenceFloors_NegativeRejected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		floors    LearnInferenceFloors
+		wantPath  string
+		wantValue string
+	}{
+		{
+			name:      "min_sessions_negative",
+			floors:    LearnInferenceFloors{MinSessions: -1},
+			wantPath:  "learn.inference.floors.min_sessions",
+			wantValue: "-1",
+		},
+		{
+			name:      "min_events_negative",
+			floors:    LearnInferenceFloors{MinEvents: -7},
+			wantPath:  "learn.inference.floors.min_events",
+			wantValue: "-7",
+		},
+		{
+			name:      "min_windows_negative",
+			floors:    LearnInferenceFloors{MinWindows: -42},
+			wantPath:  "learn.inference.floors.min_windows",
+			wantValue: "-42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateLearnInferenceFloors(tt.floors)
+			if err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+			if !strings.Contains(err.Error(), tt.wantPath) {
+				t.Errorf("error %q missing YAML path %q", err, tt.wantPath)
+			}
+			if !strings.Contains(err.Error(), tt.wantValue) {
+				t.Errorf("error %q missing numeric value %q", err, tt.wantValue)
+			}
+			if !strings.Contains(err.Error(), "non-negative") {
+				t.Errorf("error %q missing constraint phrasing", err)
+			}
+		})
+	}
+}
+
+// TestValidateLearnInferenceFloors_ZeroOrPositiveAccepted confirms the
+// validator admits the legal shapes: all-zero (defaults flow through
+// inference.Floors.Resolved at runtime), all explicit defaults, all
+// positive non-default, and mixed values. None of these should error.
+func TestValidateLearnInferenceFloors_ZeroOrPositiveAccepted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		floors LearnInferenceFloors
+	}{
+		{"all_zero", LearnInferenceFloors{}},
+		{"all_default", LearnInferenceFloors{MinSessions: 5, MinEvents: 20, MinWindows: 3}},
+		{"all_positive", LearnInferenceFloors{MinSessions: 100, MinEvents: 500, MinWindows: 24}},
+		{"mixed_zero_positive", LearnInferenceFloors{MinSessions: 0, MinEvents: 50, MinWindows: 0}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := validateLearnInferenceFloors(tt.floors); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateLearnInferenceFloors_FieldOrder pins the sequential
+// validation contract: when multiple fields are negative, the validator
+// returns the first error in declaration order (sessions, events, windows).
+// This matters because operators read the first error in their logs and
+// fix it before re-running — non-deterministic ordering would force
+// multiple round-trips.
+func TestValidateLearnInferenceFloors_FieldOrder(t *testing.T) {
+	t.Parallel()
+
+	floors := LearnInferenceFloors{
+		MinSessions: -1,
+		MinEvents:   -2,
+		MinWindows:  -3,
+	}
+	err := validateLearnInferenceFloors(floors)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "min_sessions") {
+		t.Errorf("expected first error to mention min_sessions, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "min_events") || strings.Contains(err.Error(), "min_windows") {
+		t.Errorf("first error must report only min_sessions, got: %v", err)
+	}
+}
+
+// TestValidate_LearnPropagatesInferenceFloorsError walks the full Validate()
+// pipeline with a negative floor so the validateLearn → return-err branch
+// is exercised end-to-end (mirroring the salt_source propagation test
+// already in this file).
+func TestValidate_LearnPropagatesInferenceFloorsError(t *testing.T) {
+	cfg := Defaults()
+	cfg.Learn.Inference.Floors.MinEvents = -1
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error from validateLearn through full Validate() chain")
+	}
+	if !strings.Contains(err.Error(), "learn.inference.floors.min_events") {
+		t.Errorf("error %q does not propagate inference floors detail", err)
+	}
+}
+
+// TestLoad_LearnInferenceFloors confirms YAML decoding routes the floors
+// into the right struct. The Load() round-trip is the layer most likely
+// to drift if the yaml tags get mistyped, so we exercise it explicitly.
+func TestLoad_LearnInferenceFloors(t *testing.T) {
+	body := "" +
+		"mode: balanced\n" +
+		"learn:\n" +
+		"  enabled: true\n" +
+		"  capture_dir: /tmp/c\n" +
+		"  inference:\n" +
+		"    floors:\n" +
+		"      min_sessions: 11\n" +
+		"      min_events: 33\n" +
+		"      min_windows: 5\n"
+	p := writeLearnConfig(t, body)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Learn.Inference.Floors.MinSessions != 11 {
+		t.Errorf("MinSessions=%d, want 11", cfg.Learn.Inference.Floors.MinSessions)
+	}
+	if cfg.Learn.Inference.Floors.MinEvents != 33 {
+		t.Errorf("MinEvents=%d, want 33", cfg.Learn.Inference.Floors.MinEvents)
+	}
+	if cfg.Learn.Inference.Floors.MinWindows != 5 {
+		t.Errorf("MinWindows=%d, want 5", cfg.Learn.Inference.Floors.MinWindows)
+	}
+}
+
+// TestLoad_LearnInferenceFloors_NegativeRejected confirms a YAML doc with
+// a negative floor fails Load() — the YAML decode must reach Validate()
+// and the validator must reject it with the operator-facing path.
+func TestLoad_LearnInferenceFloors_NegativeRejected(t *testing.T) {
+	body := "" +
+		"mode: balanced\n" +
+		"learn:\n" +
+		"  enabled: true\n" +
+		"  capture_dir: /tmp/c\n" +
+		"  inference:\n" +
+		"    floors:\n" +
+		"      min_sessions: -1\n"
+	p := writeLearnConfig(t, body)
+	_, err := Load(p)
+	if err == nil {
+		t.Fatal("expected Load error for negative floor")
+	}
+	if !strings.Contains(err.Error(), "learn.inference.floors.min_sessions") {
+		t.Errorf("error %q missing operator-facing YAML path", err)
 	}
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1109,9 +1109,10 @@ type ScanAPIKinds struct {
 // that pipelock learn compile (PR 2.x) can build a behavioral contract.
 // All fields are reload-safe.
 type Learn struct {
-	Enabled    bool         `yaml:"enabled"`
-	CaptureDir string       `yaml:"capture_dir"`
-	Privacy    LearnPrivacy `yaml:"privacy"`
+	Enabled    bool           `yaml:"enabled"`
+	CaptureDir string         `yaml:"capture_dir"`
+	Privacy    LearnPrivacy   `yaml:"privacy"`
+	Inference  LearnInference `yaml:"inference"`
 }
 
 // LearnPrivacy controls the privacy budget on data flowing through the
@@ -1134,4 +1135,27 @@ type LearnPrivacy struct {
 	// Default true. Security-sensitive boolean: 6-state default-true tests
 	// required (see CLAUDE.md's security invariants section).
 	PublicAllowlistDefault bool `yaml:"public_allowlist_default"`
+}
+
+// LearnInference governs the contract-compile inference engine
+// (internal/contract/inference). The threshold constants (Wilson alpha,
+// tau_brittle, tau_stable, headroom defaults) are NOT exposed here —
+// they are part of the statistical contract and are hardcoded in the
+// inference package. Floors ARE deployment-configurable because traffic
+// volumes differ across deployments, and the floors are exposure gates
+// rather than confidence thresholds.
+type LearnInference struct {
+	Floors LearnInferenceFloors `yaml:"floors"`
+}
+
+// LearnInferenceFloors mirrors inference.Floors at the YAML wire layer.
+// Each field is the minimum count required before a rule may be
+// classified `stable`. Missing or zero values resolve to the package
+// defaults (5 / 20 / 3) at runtime via inference.Floors.Resolved().
+// Negative values are rejected at config validation with a clear
+// field-path error.
+type LearnInferenceFloors struct {
+	MinSessions int `yaml:"min_sessions"`
+	MinEvents   int `yaml:"min_events"`
+	MinWindows  int `yaml:"min_windows"`
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -253,12 +253,44 @@ func (c *Config) validateRedaction() error {
 //     contents, path validated here at config-load), and literal value
 //     (test/dev only). Empty string is accepted; the privacy enforcer
 //     fails closed at observe time when classification needs salt.
+//   - learn.inference.floors.min_* must each be non-negative.
+//
+// Note: validateLearnInferenceFloors duplicates the negative-rejection
+// shape of inference.Floors.Validate() on purpose. The inference package
+// emits API-facing errors keyed by short field names (min_sessions,
+// min_events, min_windows). The config validator must surface the full
+// YAML path the operator sees in pipelock.yaml
+// (learn.inference.floors.min_sessions, …). Keeping the validator local
+// also avoids importing inference here, mirroring the privacy package
+// layering — schema-level checks live in config; resolver semantics
+// live in the contract package.
 func (c *Config) validateLearn() error {
 	if c.Learn.Enabled && c.Learn.CaptureDir == "" {
 		return fmt.Errorf("learn.capture_dir required when learn.enabled is true")
 	}
 	if err := validateLearnSaltSource(c.Learn.Privacy.SaltSource); err != nil {
 		return err
+	}
+	if err := validateLearnInferenceFloors(c.Learn.Inference.Floors); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateLearnInferenceFloors rejects negative exposure-floor counts on
+// the YAML wire layer. The fields are checked in declaration order
+// (sessions, events, windows) so a config with multiple negative values
+// always reports the first one — operators get a deterministic error
+// message regardless of map ordering or future field additions.
+func validateLearnInferenceFloors(f LearnInferenceFloors) error {
+	if f.MinSessions < 0 {
+		return fmt.Errorf("learn.inference.floors.min_sessions: %d: must be non-negative", f.MinSessions)
+	}
+	if f.MinEvents < 0 {
+		return fmt.Errorf("learn.inference.floors.min_events: %d: must be non-negative", f.MinEvents)
+	}
+	if f.MinWindows < 0 {
+		return fmt.Errorf("learn.inference.floors.min_windows: %d: must be non-negative", f.MinWindows)
 	}
 	return nil
 }

--- a/internal/contract/inference/budgets.go
+++ b/internal/contract/inference/budgets.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package inference
+
+import "slices"
+
+// DefaultHeadroomRate is the default multiplicative headroom applied to
+// the observed P99 of a rate-dimensioned numeric budget (events per unit
+// time). The enforced ceiling is computed as `p99 * (1 + headroom)`, so
+// 0.20 means "allow 20% above the observed tail".
+//
+// Like DefaultWilsonAlpha, TauStable, and TauBrittle, this constant is
+// part of the statistical contract and is NOT exposed as a config field.
+// Making it deployment-configurable would let two installs derive
+// different enforced ceilings from identical recorder data, which is
+// audit drift rather than flexibility. The value comes from the v2.4
+// learn-and-lock design (Round 5 spec).
+//
+// The Budget type itself is dimension-agnostic; the caller picks
+// DefaultHeadroomRate vs DefaultHeadroomSize when invoking
+// Budget.EnforcedValue based on what kind of metric the rule covers.
+const DefaultHeadroomRate = 0.20
+
+// DefaultHeadroomSize is the default multiplicative headroom applied to
+// the observed P99 of a size-dimensioned numeric budget (bytes or
+// element count per request). Larger than DefaultHeadroomRate because
+// per-request size distributions tolerate more variability than per-time
+// rate distributions: a single oversized request is a much weaker signal
+// than a sudden burst of requests, so the safety margin can be wider
+// without admitting noise.
+//
+// Same contract logic as DefaultHeadroomRate: locked, not deployment-
+// configurable, sourced from the v2.4 learn-and-lock design (Round 5
+// spec). The value is 0.50, meaning "allow 50% above the observed tail".
+const DefaultHeadroomSize = 0.50
+
+// Budget is the inference package's pure value type for the persisted
+// statistics of a numeric-budget rule. The four observed statistics
+// (P99, P95, Median, Max) plus SampleCount are the canonical record-level
+// shape from the Round 5 design: review UX renders all of them, the
+// "thin-sample" badge is driven by SampleCount vs the rule's MinEvents
+// floor, and the property test pack uses Median to prove the
+// percentile-monotonicity invariant.
+//
+// No YAML or JSON tags here — this is a pure value type. The config and
+// persistence layers wrap it later with their own tags.
+type Budget struct {
+	// P99 is the 99th-percentile observed value across the input window.
+	P99 float64
+
+	// P95 is the 95th-percentile observed value across the input window.
+	P95 float64
+
+	// Median is the 50th-percentile (median) observed value across the
+	// input window. Persisted alongside the tail percentiles so the
+	// review UX can show the typical value next to the tail values, and
+	// so the contract test pack can prove the P99 >= P95 >= Median
+	// monotonicity invariant on observed data.
+	Median float64
+
+	// Max is the maximum observed value across the input window.
+	Max float64
+
+	// SampleCount is the count of samples that produced these
+	// statistics (NOT the number of samples retained after any drop or
+	// dedup pass — the BudgetStats constructor does no filtering, so
+	// this equals len(window) at construction time).
+	SampleCount int
+}
+
+// BudgetStats computes the observed statistics for a numeric-budget rule
+// from the input window of float64 samples.
+//
+// Empty input (`len(window) == 0`) returns a zero-valued Budget with
+// SampleCount = 0. Empty windows are a valid "no observations yet"
+// state, parallel to zero-opportunity in Wilson — neither a panic nor
+// an error condition.
+//
+// Single-element input returns a Budget where P99, P95, Median, and Max
+// all equal that single value with SampleCount = 1.
+//
+// General case: percentiles use the nearest-rank method per Wikipedia
+// (https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method) on
+// a sorted copy of the window. For percentile p in (0, 100], the rank
+// is ceil(p * n / 100); the value at that 1-indexed position in the
+// sorted slice is returned. Nearest-rank is deterministic, requires no
+// interpolation, and is exact for integer-valued samples — properties
+// that matter for cross-deployment audit parity. The sort runs once and
+// the four percentile reads are constant-time lookups, so this is
+// O(n log n) total with no extra allocations beyond the sorted copy.
+//
+// The caller's slice is NOT mutated: BudgetStats works on a clone made
+// via slices.Clone.
+//
+// Caller responsibility: NaN or Inf values in the input produce
+// undefined sort ordering and NaN-tainted percentile outputs. Recorder
+// inputs are non-NaN by construction (counts and sizes), so adding
+// defensive NaN/Inf filtering here would expand the API surface
+// without an attacker model. Callers that ingest untrusted floats must
+// filter at their boundary, not here.
+func BudgetStats(window []float64) Budget {
+	n := len(window)
+	if n == 0 {
+		return Budget{}
+	}
+
+	sorted := slices.Clone(window)
+	slices.Sort(sorted)
+
+	return Budget{
+		P99:         nearestRank(sorted, 99),
+		P95:         nearestRank(sorted, 95),
+		Median:      nearestRank(sorted, 50),
+		Max:         sorted[n-1],
+		SampleCount: n,
+	}
+}
+
+// nearestRank returns the value at the nearest-rank percentile p of a
+// sorted (ascending) slice. p is in (0, 100]; the slice is non-empty.
+//
+// Formula: rank = ceil(p * n / 100), 1-indexed. Implemented with integer
+// arithmetic — `(p*n + 99) / 100` — to keep results deterministic
+// without dragging math.Ceil and float-rounding quirks into the path.
+// The rank is clamped into [1, n] so a percentile
+// of 100 (which would otherwise round to n+1 on n-element slices via
+// some formulations) maps cleanly to the maximum.
+func nearestRank(sorted []float64, p int) float64 {
+	n := len(sorted)
+	rank := (p*n + 99) / 100 // integer ceil of p*n/100
+	if rank < 1 {
+		rank = 1
+	}
+	if rank > n {
+		rank = n
+	}
+	return sorted[rank-1]
+}
+
+// EnforcedValue returns the enforced ceiling for the budget under the
+// given multiplicative headroom: `enforced = b.P99 * (1 + headroom)`.
+//
+// Headroom is intentionally not clamped:
+//   - Positive headroom widens the ceiling (the common case; pass
+//     DefaultHeadroomRate or DefaultHeadroomSize).
+//   - Zero headroom returns P99 itself (no widening).
+//   - Negative headroom shrinks the ceiling — supported by design so a
+//     caller that wants a tighter-than-observed ceiling can express it
+//     with a negative value without a separate code path. A defensive
+//     clamp would silently mask intent.
+//
+// An empty Budget (SampleCount == 0, all percentiles zero) yields 0
+// for any headroom; no special branch needed because the formula
+// already produces 0 from a zero P99.
+//
+// Pure: no I/O, no allocations beyond the float result.
+func (b Budget) EnforcedValue(headroom float64) float64 {
+	return b.P99 * (1 + headroom)
+}
+
+// ThinSample reports whether SampleCount is below minEvents. The review
+// UX renders a "thin-sample" badge on a numeric-budget rule when this
+// returns true, signaling to the operator that the persisted statistics
+// were computed from a window that did not clear the rule's exposure
+// floor.
+//
+// Strictly less-than: SampleCount == minEvents returns false (the floor
+// was just barely cleared, but it was cleared). This matches FloorsPass,
+// which uses observed >= floors.MinEvents.
+func (b Budget) ThinSample(minEvents int) bool {
+	return b.SampleCount < minEvents
+}

--- a/internal/contract/inference/budgets.go
+++ b/internal/contract/inference/budgets.go
@@ -139,16 +139,24 @@ func nearestRank(sorted []float64, p int) float64 {
 }
 
 // EnforcedValue returns the enforced ceiling for the budget under the
-// given multiplicative headroom: `enforced = b.P99 * (1 + headroom)`.
+// given multiplicative headroom: `enforced = b.P99 * (1 + headroom)`,
+// clamped to a non-negative result.
 //
-// Headroom is intentionally not clamped:
+// Headroom semantics:
 //   - Positive headroom widens the ceiling (the common case; pass
 //     DefaultHeadroomRate or DefaultHeadroomSize).
 //   - Zero headroom returns P99 itself (no widening).
-//   - Negative headroom shrinks the ceiling — supported by design so a
-//     caller that wants a tighter-than-observed ceiling can express it
-//     with a negative value without a separate code path. A defensive
-//     clamp would silently mask intent.
+//   - Negative headroom in the half-open range [-1, 0) shrinks the
+//     ceiling, supported so a caller that wants a tighter-than-observed
+//     ceiling can express it without a separate code path. The shrunk
+//     value remains non-negative because P99 is non-negative.
+//   - Negative headroom below -1 would otherwise produce a nonsensical
+//     negative ceiling. The result is clamped to 0 so a future caller
+//     bug or bad plumbing cannot push a negative ceiling into an
+//     enforcement path. This is the fail-closed-but-valid contract: a
+//     budget of 0 denies everything (which any reasonable enforcer
+//     handles), whereas a negative budget could trigger
+//     undefined-behavior cascades depending on downstream comparisons.
 //
 // An empty Budget (SampleCount == 0, all percentiles zero) yields 0
 // for any headroom; no special branch needed because the formula
@@ -156,7 +164,11 @@ func nearestRank(sorted []float64, p int) float64 {
 //
 // Pure: no I/O, no allocations beyond the float result.
 func (b Budget) EnforcedValue(headroom float64) float64 {
-	return b.P99 * (1 + headroom)
+	v := b.P99 * (1 + headroom)
+	if v < 0 {
+		return 0
+	}
+	return v
 }
 
 // ThinSample reports whether SampleCount is below minEvents. The review

--- a/internal/contract/inference/budgets_test.go
+++ b/internal/contract/inference/budgets_test.go
@@ -382,9 +382,9 @@ func TestEnforcedValue_PropertyHeadroomMonotonic(t *testing.T) {
 }
 
 // TestEnforcedValue_NegativeHeadroomShrinks proves the documented
-// behavior that negative headroom shrinks the ceiling without a
-// defensive clamp. Callers that want a tighter-than-observed ceiling
-// can express it directly.
+// behavior that negative headroom in [-1, 0) shrinks the ceiling
+// without ever going negative. Callers that want a tighter-than-
+// observed ceiling can express it directly.
 func TestEnforcedValue_NegativeHeadroomShrinks(t *testing.T) {
 	t.Parallel()
 
@@ -393,6 +393,44 @@ func TestEnforcedValue_NegativeHeadroomShrinks(t *testing.T) {
 	want := 90.0
 	if !floatEq(got, want) {
 		t.Fatalf("EnforcedValue(-0.10) = %v, want %v", got, want)
+	}
+}
+
+// TestEnforcedValue_ClampsAtZero proves the fail-closed-but-valid
+// contract: headroom that would otherwise yield a negative ceiling is
+// clamped to 0. Negative ceilings are nonsensical for a budget; a
+// future caller bug that produced one could cascade into deny-all or
+// allow-all behavior in downstream enforcement paths depending on how
+// each callsite handles the value. Clamping here guarantees the
+// invariant `EnforcedValue(...) >= 0` for any (Budget, headroom) input.
+func TestEnforcedValue_ClampsAtZero(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		p99      float64
+		headroom float64
+		want     float64
+	}{
+		{"headroom_minus_one_exact_zero", 100, -1.0, 0.0},
+		{"headroom_minus_one_point_five_clamps", 100, -1.5, 0.0},
+		{"headroom_minus_two_clamps", 100, -2.0, 0.0},
+		{"headroom_minus_one_thousand_clamps", 100, -1000.0, 0.0},
+		{"empty_budget_with_clamping_headroom", 0, -10.0, 0.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			b := Budget{P99: tt.p99, SampleCount: 50}
+			got := b.EnforcedValue(tt.headroom)
+			if !floatEq(got, tt.want) {
+				t.Fatalf("EnforcedValue(p99=%v, headroom=%v) = %v, want %v", tt.p99, tt.headroom, got, tt.want)
+			}
+			if got < 0 {
+				t.Fatalf("EnforcedValue produced negative %v; clamp invariant violated", got)
+			}
+		})
 	}
 }
 

--- a/internal/contract/inference/budgets_test.go
+++ b/internal/contract/inference/budgets_test.go
@@ -1,0 +1,457 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package inference
+
+import (
+	"math"
+	"slices"
+	"testing"
+)
+
+// budgetTolerance is the absolute float-equality tolerance used for
+// percentile assertions in this file. The reference windows are
+// integer-valued, so the floats round-trip exactly; 1e-9 is plenty of
+// room for any future scaled-input rows without admitting silent drift.
+const budgetTolerance = 1e-9
+
+// floatEq reports whether |a - b| <= budgetTolerance.
+func floatEq(a, b float64) bool {
+	return math.Abs(a-b) <= budgetTolerance
+}
+
+// TestDefaultHeadrooms_Locked is the contract-against-drift guard for the
+// numeric-budget headroom defaults. Parallel to TestDefaultWilsonAlpha_Locked
+// and TestDefaultFloors_Locked: if anyone bumps these constants, this test
+// fails and the reviewer must justify the change in the PR. Cross-deployment
+// audit parity requires the headrooms be locked at the same value everywhere.
+func TestDefaultHeadrooms_Locked(t *testing.T) {
+	t.Parallel()
+
+	if DefaultHeadroomRate != 0.20 {
+		t.Fatalf("DefaultHeadroomRate drift detected: got %v, want 0.20", DefaultHeadroomRate)
+	}
+	if DefaultHeadroomSize != 0.50 {
+		t.Fatalf("DefaultHeadroomSize drift detected: got %v, want 0.50", DefaultHeadroomSize)
+	}
+}
+
+// TestBudgetStats_EmptyWindow verifies the zero-valued return for empty
+// inputs: nil and []float64{}. Empty windows are a valid "no observations
+// yet" state and must NOT panic.
+func TestBudgetStats_EmptyWindow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []float64
+	}{
+		{name: "nil_slice", in: nil},
+		{name: "empty_slice", in: []float64{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := BudgetStats(tc.in)
+			want := Budget{}
+			if got != want {
+				t.Fatalf("BudgetStats(%v) = %+v, want %+v", tc.in, got, want)
+			}
+			if got.SampleCount != 0 {
+				t.Fatalf("SampleCount = %d, want 0", got.SampleCount)
+			}
+		})
+	}
+}
+
+// TestBudgetStats_SingleElement verifies that a one-element window
+// collapses to a Budget where all four percentile/max values equal the
+// single sample.
+func TestBudgetStats_SingleElement(t *testing.T) {
+	t.Parallel()
+
+	got := BudgetStats([]float64{42.5})
+	want := Budget{P99: 42.5, P95: 42.5, Median: 42.5, Max: 42.5, SampleCount: 1}
+	if got != want {
+		t.Fatalf("BudgetStats([42.5]) = %+v, want %+v", got, want)
+	}
+}
+
+// TestBudgetStats_KnownValues exercises the nearest-rank percentile
+// formula on reference windows where the expected statistics are known
+// by inspection. Integer-valued windows so the floats are exact.
+func TestBudgetStats_KnownValues(t *testing.T) {
+	t.Parallel()
+
+	// Build [1..100] for the larger row.
+	hundred := make([]float64, 100)
+	for i := range hundred {
+		hundred[i] = float64(i + 1)
+	}
+
+	tests := []struct {
+		name   string
+		in     []float64
+		p99    float64
+		p95    float64
+		median float64
+		max    float64
+		count  int
+	}{
+		{
+			name:   "one_through_ten",
+			in:     []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			p99:    10,
+			p95:    10,
+			median: 5,
+			max:    10,
+			count:  10,
+		},
+		{
+			name:   "tens_through_hundred",
+			in:     []float64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100},
+			p99:    100,
+			p95:    100,
+			median: 50,
+			max:    100,
+			count:  10,
+		},
+		{
+			name:   "one_through_one_hundred",
+			in:     hundred,
+			p99:    99,
+			p95:    95,
+			median: 50,
+			max:    100,
+			count:  100,
+		},
+		{
+			name:   "all_same",
+			in:     []float64{7, 7, 7, 7, 7},
+			p99:    7,
+			p95:    7,
+			median: 7,
+			max:    7,
+			count:  5,
+		},
+		{
+			name:   "unsorted_input",
+			in:     []float64{5, 1, 9, 3, 7, 2, 8, 4, 6, 10},
+			p99:    10,
+			p95:    10,
+			median: 5,
+			max:    10,
+			count:  10,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := BudgetStats(tc.in)
+			if !floatEq(got.P99, tc.p99) {
+				t.Errorf("P99 = %v, want %v", got.P99, tc.p99)
+			}
+			if !floatEq(got.P95, tc.p95) {
+				t.Errorf("P95 = %v, want %v", got.P95, tc.p95)
+			}
+			if !floatEq(got.Median, tc.median) {
+				t.Errorf("Median = %v, want %v", got.Median, tc.median)
+			}
+			if !floatEq(got.Max, tc.max) {
+				t.Errorf("Max = %v, want %v", got.Max, tc.max)
+			}
+			if got.SampleCount != tc.count {
+				t.Errorf("SampleCount = %d, want %d", got.SampleCount, tc.count)
+			}
+		})
+	}
+}
+
+// TestBudgetStats_DoesNotMutateInput verifies the caller's slice is
+// untouched. BudgetStats sorts a defensive clone, not the input.
+func TestBudgetStats_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	in := []float64{5, 1, 9, 3, 7, 2, 8, 4, 6, 10}
+	before := slices.Clone(in)
+
+	_ = BudgetStats(in)
+
+	if !slices.Equal(in, before) {
+		t.Fatalf("input mutated: before=%v, after=%v", before, in)
+	}
+}
+
+// TestBudgetStats_PropertyP99GeP95GeMedian proves the percentile
+// monotonicity invariant required by the kickoff: P99 >= P95 >= Median
+// for any non-empty window. Validates that nearest-rank produces a
+// monotone-increasing sequence over (50, 95, 99) percentiles.
+func TestBudgetStats_PropertyP99GeP95GeMedian(t *testing.T) {
+	t.Parallel()
+
+	ascending := make([]float64, 1000)
+	for i := range ascending {
+		ascending[i] = float64(i + 1)
+	}
+	descending := make([]float64, 1000)
+	for i := range descending {
+		descending[i] = float64(1000 - i)
+	}
+	allSame := make([]float64, 100)
+	for i := range allSame {
+		allSame[i] = 42
+	}
+	nearUniform := []float64{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+		11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+	}
+	singleCluster := []float64{
+		1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+		1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+		100, // single outlier
+	}
+
+	tests := []struct {
+		name string
+		in   []float64
+	}{
+		{name: "ascending_1_to_1000", in: ascending},
+		{name: "descending_1000_to_1", in: descending},
+		{name: "all_same_value", in: allSame},
+		{name: "near_uniform_1_to_20", in: nearUniform},
+		{name: "single_cluster_with_outlier", in: singleCluster},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := BudgetStats(tc.in)
+			if b.P99 < b.P95 {
+				t.Errorf("P99 (%v) < P95 (%v); monotonicity violated", b.P99, b.P95)
+			}
+			if b.P95 < b.Median {
+				t.Errorf("P95 (%v) < Median (%v); monotonicity violated", b.P95, b.Median)
+			}
+		})
+	}
+}
+
+// TestBudgetStats_PropertyMaxGeP99 proves the Max-dominates-tail
+// invariant: Max >= P99 for any non-empty window. Nearest-rank P99
+// always selects an element of the slice, so Max (the slice's largest
+// element) cannot be smaller than P99.
+func TestBudgetStats_PropertyMaxGeP99(t *testing.T) {
+	t.Parallel()
+
+	ascending := make([]float64, 1000)
+	for i := range ascending {
+		ascending[i] = float64(i + 1)
+	}
+	descending := make([]float64, 1000)
+	for i := range descending {
+		descending[i] = float64(1000 - i)
+	}
+	allSame := make([]float64, 100)
+	for i := range allSame {
+		allSame[i] = 42
+	}
+	nearUniform := []float64{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+		11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+	}
+	singleCluster := []float64{
+		1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+		1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+		100,
+	}
+
+	tests := []struct {
+		name string
+		in   []float64
+	}{
+		{name: "ascending_1_to_1000", in: ascending},
+		{name: "descending_1000_to_1", in: descending},
+		{name: "all_same_value", in: allSame},
+		{name: "near_uniform_1_to_20", in: nearUniform},
+		{name: "single_cluster_with_outlier", in: singleCluster},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := BudgetStats(tc.in)
+			if b.Max < b.P99 {
+				t.Errorf("Max (%v) < P99 (%v); Max-dominance violated", b.Max, b.P99)
+			}
+		})
+	}
+}
+
+// TestEnforcedValue_HappyPath exercises the headroom formula on
+// representative inputs, including both default headroom constants and
+// a P99=0 (empty Budget) row.
+func TestEnforcedValue_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		budget   Budget
+		headroom float64
+		want     float64
+	}{
+		{
+			name:     "p99_100_headroom_0_20",
+			budget:   Budget{P99: 100, SampleCount: 50},
+			headroom: 0.20,
+			want:     120,
+		},
+		{
+			name:     "p99_100_headroom_0_50",
+			budget:   Budget{P99: 100, SampleCount: 50},
+			headroom: 0.50,
+			want:     150,
+		},
+		{
+			name:     "p99_zero_any_headroom",
+			budget:   Budget{},
+			headroom: 0.20,
+			want:     0,
+		},
+		{
+			name:     "p99_42_5_headroom_default_rate",
+			budget:   Budget{P99: 42.5, SampleCount: 30},
+			headroom: DefaultHeadroomRate,
+			want:     51.0,
+		},
+		{
+			name:     "p99_42_5_headroom_default_size",
+			budget:   Budget{P99: 42.5, SampleCount: 30},
+			headroom: DefaultHeadroomSize,
+			want:     63.75,
+		},
+		{
+			name:     "p99_100_headroom_zero",
+			budget:   Budget{P99: 100, SampleCount: 50},
+			headroom: 0,
+			want:     100,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.budget.EnforcedValue(tc.headroom)
+			if !floatEq(got, tc.want) {
+				t.Fatalf("EnforcedValue(%v) on %+v = %v, want %v", tc.headroom, tc.budget, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEnforcedValue_PropertyHeadroomMonotonic proves that as headroom
+// increases, EnforcedValue strictly increases (when P99 is non-zero).
+// This is the property called out in the kickoff: "headroom always
+// increases enforced when input is non-zero".
+func TestEnforcedValue_PropertyHeadroomMonotonic(t *testing.T) {
+	t.Parallel()
+
+	b := Budget{P99: 100, SampleCount: 50}
+	headrooms := []float64{0.0, 0.1, 0.2, 0.5, 1.0}
+
+	prev := b.EnforcedValue(headrooms[0])
+	for i := 1; i < len(headrooms); i++ {
+		got := b.EnforcedValue(headrooms[i])
+		if got <= prev {
+			t.Errorf("EnforcedValue(%v)=%v is not strictly greater than EnforcedValue(%v)=%v",
+				headrooms[i], got, headrooms[i-1], prev)
+		}
+		// Also confirm the >= 0-headroom invariant (the zero-headroom
+		// floor is the un-padded P99).
+		if got < b.EnforcedValue(0) {
+			t.Errorf("EnforcedValue(%v)=%v dipped below EnforcedValue(0)=%v", headrooms[i], got, b.EnforcedValue(0))
+		}
+		prev = got
+	}
+}
+
+// TestEnforcedValue_NegativeHeadroomShrinks proves the documented
+// behavior that negative headroom shrinks the ceiling without a
+// defensive clamp. Callers that want a tighter-than-observed ceiling
+// can express it directly.
+func TestEnforcedValue_NegativeHeadroomShrinks(t *testing.T) {
+	t.Parallel()
+
+	b := Budget{P99: 100, SampleCount: 50}
+	got := b.EnforcedValue(-0.10)
+	want := 90.0
+	if !floatEq(got, want) {
+		t.Fatalf("EnforcedValue(-0.10) = %v, want %v", got, want)
+	}
+}
+
+// TestNearestRank_DefensiveClamps exercises the two clamp branches of
+// the internal nearestRank helper that the public BudgetStats path
+// (which only ever calls with p in {50, 95, 99}) cannot reach.
+//
+// These clamps exist as defense-in-depth so a future caller that
+// invokes nearestRank with a degenerate percentile cannot index out of
+// bounds. The test uses p=0 to drive the rank<1 branch and p=200 to
+// drive the rank>n branch, returning sorted[0] and sorted[n-1]
+// respectively. Removing the clamps would also make this test
+// disappear — by design, since the clamps are the contract.
+func TestNearestRank_DefensiveClamps(t *testing.T) {
+	t.Parallel()
+
+	sorted := []float64{1, 2, 3, 4, 5}
+
+	// p = 0 → rank = (0*5 + 99) / 100 = 0, clamps to 1, returns sorted[0].
+	if got := nearestRank(sorted, 0); got != 1 {
+		t.Fatalf("nearestRank(sorted, 0) = %v, want 1 (rank<1 clamp)", got)
+	}
+
+	// p = 200 → rank = (200*5 + 99) / 100 = 10, clamps to n=5, returns sorted[4].
+	if got := nearestRank(sorted, 200); got != 5 {
+		t.Fatalf("nearestRank(sorted, 200) = %v, want 5 (rank>n clamp)", got)
+	}
+}
+
+// TestThinSample exercises the strict-less-than badge predicate at and
+// around the boundary. The "just barely cleared the floor" case
+// (SampleCount == minEvents) returns false: the floor was cleared.
+func TestThinSample(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		count     int
+		minEvents int
+		want      bool
+	}{
+		{name: "below_floor", count: 10, minEvents: 20, want: true},
+		{name: "exactly_at_floor", count: 20, minEvents: 20, want: false},
+		{name: "above_floor", count: 20, minEvents: 19, want: false},
+		{name: "zero_count_positive_floor", count: 0, minEvents: 20, want: true},
+		{name: "both_zero", count: 0, minEvents: 0, want: false},
+		{name: "well_above_floor", count: 100, minEvents: 20, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := Budget{SampleCount: tc.count}
+			got := b.ThinSample(tc.minEvents)
+			if got != tc.want {
+				t.Fatalf("ThinSample(SampleCount=%d, minEvents=%d) = %v, want %v",
+					tc.count, tc.minEvents, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/contract/inference/floors.go
+++ b/internal/contract/inference/floors.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package inference
+
+import (
+	"errors"
+	"fmt"
+)
+
+// TauStable is the Wilson lower-bound threshold a rule must clear (in
+// addition to the exposure floors) to be classified ConfidenceStable.
+//
+// Like DefaultWilsonAlpha, this constant is part of the statistical
+// contract and is NOT exposed as a config field. Making the threshold
+// deployment-configurable would let two installs infer different
+// classifications from identical recorder data, which is audit drift
+// rather than flexibility. The value comes from the v2.4 learn-and-lock
+// design (Round 5 spec).
+const TauStable = 0.85
+
+// TauBrittle is the Wilson lower-bound threshold a rule must clear (in
+// addition to the exposure floors) to be classified ConfidenceBrittle
+// rather than ConfidenceNeverConfirmed.
+//
+// Same contract logic as TauStable: locked, not deployment-configurable,
+// sourced from the Round 5 spec.
+const TauBrittle = 0.50
+
+// Default exposure floors. A rule cannot be classified ConfidenceStable
+// or ConfidenceBrittle until ALL three floors are cleared, regardless of
+// how high the Wilson lower bound climbs. Floors are AND-composed with
+// Wilson — never OR — so a low-volume signal cannot promote itself to
+// stable just by being lucky on a handful of trials. Values come from
+// the v2.4 learn-and-lock design (Round 5 spec).
+const (
+	// DefaultMinSessions is the minimum number of distinct sessions in
+	// which a rule must have been observed before it can be classified
+	// as anything other than never_confirmed.
+	DefaultMinSessions = 5
+
+	// DefaultMinEvents is the minimum number of observed events (the
+	// "successes" numerator passed to Wilson) required before a rule
+	// can be classified as anything other than never_confirmed.
+	DefaultMinEvents = 20
+
+	// DefaultMinWindows is the minimum number of distinct time windows
+	// across which a rule must have been observed. Windows guard
+	// against burst-only signals: 20 events in one minute should not
+	// look the same as 20 events spread across 3 windows.
+	DefaultMinWindows = 3
+)
+
+// Floors is the inference package's pure value type for exposure-floor
+// configuration. The config package wraps it with its own struct + YAML
+// tags in a follow-up step; this type intentionally has no tags so the
+// inference layer stays free of YAML/JSON concerns.
+type Floors struct {
+	// MinSessions is the minimum number of distinct sessions a rule
+	// must have been observed in before classification can leave
+	// never_confirmed.
+	MinSessions int
+
+	// MinEvents is the minimum observed-event count (the numerator
+	// passed to Wilson) before classification can leave never_confirmed.
+	MinEvents int
+
+	// MinWindows is the minimum number of distinct time windows the
+	// rule must have been observed across.
+	MinWindows int
+}
+
+// DefaultFloors returns a Floors value populated with the design's
+// canonical defaults: MinSessions=5, MinEvents=20, MinWindows=3.
+func DefaultFloors() Floors {
+	return Floors{
+		MinSessions: DefaultMinSessions,
+		MinEvents:   DefaultMinEvents,
+		MinWindows:  DefaultMinWindows,
+	}
+}
+
+// Resolved returns a Floors with any zero-valued field replaced by the
+// corresponding default. This implements the "config omitted → defaults"
+// layer for a YAML-parsed Floors where missing fields decode as zero.
+//
+// Negative values pass through unchanged. Callers should run Validate
+// first if they want to reject negatives; Resolved is purely about
+// supplying defaults for missing fields, not sanitizing bad data.
+func (f Floors) Resolved() Floors {
+	out := f
+	if out.MinSessions == 0 {
+		out.MinSessions = DefaultMinSessions
+	}
+	if out.MinEvents == 0 {
+		out.MinEvents = DefaultMinEvents
+	}
+	if out.MinWindows == 0 {
+		out.MinWindows = DefaultMinWindows
+	}
+	return out
+}
+
+// ErrNegativeFloor is returned by Floors.Validate when any floor field
+// is negative. Callers MUST compare with errors.Is, not raw == — Validate
+// wraps the sentinel with fmt.Errorf("%w") so the field name and value
+// reach the operator without breaking errors.Is chains.
+//
+// This sentinel is distinct from ErrNegativeOpportunityCount even though
+// they share the "negative count" theme: ErrNegativeFloor is config
+// validation (a deployment-configurable surface), while
+// ErrNegativeOpportunityCount is runtime aggregator data. They surface
+// different bugs and travel through different alert paths.
+var ErrNegativeFloor = errors.New("inference: negative exposure floor")
+
+// Validate returns nil if all floor fields are non-negative, otherwise
+// it returns an error that wraps ErrNegativeFloor and names the offending
+// field in the lowercase snake_case wire form so the operator can locate
+// it in YAML.
+//
+// Only the first negative field is reported; once the operator fixes it
+// and re-runs validation, any second negative field will surface in turn.
+// Reporting all negatives in one error would require buffering and offers
+// no help when the typical case is a single fat-fingered field.
+func (f Floors) Validate() error {
+	if f.MinSessions < 0 {
+		return fmt.Errorf("%w (field=min_sessions, value=%d)", ErrNegativeFloor, f.MinSessions)
+	}
+	if f.MinEvents < 0 {
+		return fmt.Errorf("%w (field=min_events, value=%d)", ErrNegativeFloor, f.MinEvents)
+	}
+	if f.MinWindows < 0 {
+		return fmt.Errorf("%w (field=min_windows, value=%d)", ErrNegativeFloor, f.MinWindows)
+	}
+	return nil
+}
+
+// FloorsPass reports whether the observed (event), session, and window
+// counts each meet or exceed the corresponding floor. Returns true only
+// if all three thresholds clear; AND-composed by design.
+//
+// Negative input counts return false. Callers should validate inputs at
+// the aggregator boundary, but FloorsPass is defensive — it never panics
+// on bad input and never silently treats a negative count as passing.
+func FloorsPass(observed, sessions, windows int, floors Floors) bool {
+	if observed < 0 || sessions < 0 || windows < 0 {
+		return false
+	}
+	return observed >= floors.MinEvents &&
+		sessions >= floors.MinSessions &&
+		windows >= floors.MinWindows
+}
+
+// Confidence is the verdict returned by Classify. The three levels map
+// directly to the design's Wilson edge-case table: never_confirmed
+// covers both "below TauBrittle" and "any floor failed"; brittle covers
+// the [TauBrittle, TauStable) band when all floors clear; stable covers
+// >= TauStable when all floors clear.
+//
+// The wire-form strings (lowercase snake_case) are used as metrics
+// labels and audit-log values. Renaming a label is a downstream-breaking
+// change.
+type Confidence int
+
+const (
+	// ConfidenceNeverConfirmed means at least one of: a floor failed,
+	// or the Wilson lower bound is below TauBrittle. The rule cannot
+	// be trusted as a stable signal.
+	ConfidenceNeverConfirmed Confidence = iota
+
+	// ConfidenceBrittle means all floors cleared and the Wilson lower
+	// bound is in [TauBrittle, TauStable). The rule has enough evidence
+	// to consider but not enough to lock down on its own.
+	ConfidenceBrittle
+
+	// ConfidenceStable means all floors cleared and the Wilson lower
+	// bound is at or above TauStable. The rule is safe to lock down.
+	ConfidenceStable
+
+	// confidenceSentinel is the exclusive upper bound used by tests to
+	// detect out-of-range int casts. Unexported so external callers
+	// cannot depend on the count of levels.
+	confidenceSentinel
+)
+
+// String returns the lowercase snake_case wire-form label. Any value
+// outside the defined range returns "unknown" so a stray int cast never
+// silently produces a real label in metrics or logs.
+func (c Confidence) String() string {
+	switch c {
+	case ConfidenceNeverConfirmed:
+		return "never_confirmed"
+	case ConfidenceBrittle:
+		return "brittle"
+	case ConfidenceStable:
+		return "stable"
+	default:
+		return "unknown"
+	}
+}
+
+// Classify composes the exposure-floor gate with the Wilson lower bound
+// to produce a Confidence verdict. The composition is AND on floors and
+// then a band test on Wilson:
+//
+//   - If any floor fails (or any input count is negative), the verdict
+//     is ConfidenceNeverConfirmed regardless of how high Wilson climbs.
+//     A high Wilson on a tiny sample is exactly the case the floors
+//     exist to catch.
+//   - Otherwise, the Wilson lower bound is computed at the locked
+//     DefaultWilsonAlpha (0.05). Wilson >= TauStable yields
+//     ConfidenceStable; Wilson >= TauBrittle yields ConfidenceBrittle;
+//     anything below yields ConfidenceNeverConfirmed.
+//
+// Production callers go through this single entry point; the locked
+// alpha is intentional. Tests that need to probe non-default alphas
+// call WilsonLowerBound directly — Classify must not grow an alpha
+// parameter or functional options for that case.
+func Classify(observed, opportunity, sessions, windows int, floors Floors) Confidence {
+	if !FloorsPass(observed, sessions, windows, floors) {
+		return ConfidenceNeverConfirmed
+	}
+	wilson := WilsonLowerBound(observed, opportunity, DefaultWilsonAlpha)
+	switch {
+	case wilson >= TauStable:
+		return ConfidenceStable
+	case wilson >= TauBrittle:
+		return ConfidenceBrittle
+	default:
+		return ConfidenceNeverConfirmed
+	}
+}

--- a/internal/contract/inference/floors_test.go
+++ b/internal/contract/inference/floors_test.go
@@ -1,0 +1,541 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package inference
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Wire-form field labels reused across tests. These match the snake_case
+// strings emitted by Floors.Validate so the operator can locate the
+// offending field in YAML.
+const (
+	fieldMinSessions = "min_sessions"
+	fieldMinEvents   = "min_events"
+	fieldMinWindows  = "min_windows"
+)
+
+// TestDefaultFloors_Locked is the contract-against-drift guard for the
+// floor defaults. Parallel to TestDefaultWilsonAlpha_Locked: if anyone
+// bumps these constants, this test fails and the reviewer must justify
+// the change in the PR.
+func TestDefaultFloors_Locked(t *testing.T) {
+	t.Parallel()
+
+	got := DefaultFloors()
+	want := Floors{MinSessions: 5, MinEvents: 20, MinWindows: 3}
+	if got != want {
+		t.Fatalf("DefaultFloors drift detected: got %+v, want %+v", got, want)
+	}
+
+	// Also pin the underlying constants so a refactor that replaces the
+	// struct literal with the constants doesn't silently shift values.
+	if DefaultMinSessions != 5 {
+		t.Fatalf("DefaultMinSessions drift detected: got %d, want 5", DefaultMinSessions)
+	}
+	if DefaultMinEvents != 20 {
+		t.Fatalf("DefaultMinEvents drift detected: got %d, want 20", DefaultMinEvents)
+	}
+	if DefaultMinWindows != 3 {
+		t.Fatalf("DefaultMinWindows drift detected: got %d, want 3", DefaultMinWindows)
+	}
+}
+
+// TestThresholds_Locked is the drift guard for the Wilson confidence
+// thresholds. Same logic as TestDefaultFloors_Locked: bumping these
+// values changes audit semantics across every install of pipelock.
+func TestThresholds_Locked(t *testing.T) {
+	t.Parallel()
+
+	if TauStable != 0.85 {
+		t.Fatalf("TauStable drift detected: got %v, want 0.85", TauStable)
+	}
+	if TauBrittle != 0.50 {
+		t.Fatalf("TauBrittle drift detected: got %v, want 0.50", TauBrittle)
+	}
+}
+
+// TestFloors_Resolved exercises the "config omitted → defaults" layer.
+// Zero-valued fields take the corresponding default; non-zero fields
+// pass through unchanged; negative fields pass through (Resolved is not
+// a sanitizer — Validate is).
+func TestFloors_Resolved(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   Floors
+		want Floors
+	}{
+		{
+			name: "all_zero_fills_all_defaults",
+			in:   Floors{},
+			want: DefaultFloors(),
+		},
+		{
+			name: "partial_zero_only_min_sessions_filled",
+			in:   Floors{MinSessions: 0, MinEvents: 15, MinWindows: 2},
+			want: Floors{MinSessions: DefaultMinSessions, MinEvents: 15, MinWindows: 2},
+		},
+		{
+			name: "partial_zero_only_min_events_filled",
+			in:   Floors{MinSessions: 7, MinEvents: 0, MinWindows: 4},
+			want: Floors{MinSessions: 7, MinEvents: DefaultMinEvents, MinWindows: 4},
+		},
+		{
+			name: "partial_zero_only_min_windows_filled",
+			in:   Floors{MinSessions: 7, MinEvents: 25, MinWindows: 0},
+			want: Floors{MinSessions: 7, MinEvents: 25, MinWindows: DefaultMinWindows},
+		},
+		{
+			name: "all_set_non_default_pass_through",
+			in:   Floors{MinSessions: 10, MinEvents: 50, MinWindows: 7},
+			want: Floors{MinSessions: 10, MinEvents: 50, MinWindows: 7},
+		},
+		{
+			name: "all_set_to_defaults_pass_through",
+			in:   DefaultFloors(),
+			want: DefaultFloors(),
+		},
+		{
+			name: "negative_min_sessions_passes_through",
+			in:   Floors{MinSessions: -1, MinEvents: 25, MinWindows: 4},
+			want: Floors{MinSessions: -1, MinEvents: 25, MinWindows: 4},
+		},
+		{
+			name: "negative_min_events_passes_through",
+			in:   Floors{MinSessions: 7, MinEvents: -2, MinWindows: 4},
+			want: Floors{MinSessions: 7, MinEvents: -2, MinWindows: 4},
+		},
+		{
+			name: "negative_min_windows_passes_through",
+			in:   Floors{MinSessions: 7, MinEvents: 25, MinWindows: -3},
+			want: Floors{MinSessions: 7, MinEvents: 25, MinWindows: -3},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.in.Resolved(); got != tc.want {
+				t.Fatalf("Floors{%+v}.Resolved() = %+v, want %+v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFloors_Validate exercises every negative-field path and confirms
+// non-negative configs validate clean. The error must wrap
+// ErrNegativeFloor and name the offending field in snake_case so the
+// operator can locate it in YAML.
+func TestFloors_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		in        Floors
+		wantErr   bool
+		wantField string
+	}{
+		{
+			name:    "all_zero_validates_clean",
+			in:      Floors{},
+			wantErr: false,
+		},
+		{
+			name:    "all_positive_validates_clean",
+			in:      DefaultFloors(),
+			wantErr: false,
+		},
+		{
+			name:    "mixed_zero_and_positive_validates_clean",
+			in:      Floors{MinSessions: 0, MinEvents: 25, MinWindows: 3},
+			wantErr: false,
+		},
+		{
+			name:      "negative_min_sessions",
+			in:        Floors{MinSessions: -1, MinEvents: 20, MinWindows: 3},
+			wantErr:   true,
+			wantField: fieldMinSessions,
+		},
+		{
+			name:      "negative_min_events",
+			in:        Floors{MinSessions: 5, MinEvents: -1, MinWindows: 3},
+			wantErr:   true,
+			wantField: fieldMinEvents,
+		},
+		{
+			name:      "negative_min_windows",
+			in:        Floors{MinSessions: 5, MinEvents: 20, MinWindows: -1},
+			wantErr:   true,
+			wantField: fieldMinWindows,
+		},
+		{
+			name:      "two_negatives_reports_first_field",
+			in:        Floors{MinSessions: -1, MinEvents: -2, MinWindows: 3},
+			wantErr:   true,
+			wantField: fieldMinSessions,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.in.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Floors{%+v}.Validate() = nil; want error wrapping ErrNegativeFloor", tc.in)
+				}
+				if !errors.Is(err, ErrNegativeFloor) {
+					t.Fatalf("Floors{%+v}.Validate() = %v; want errors.Is(err, ErrNegativeFloor)", tc.in, err)
+				}
+				if !strings.Contains(err.Error(), tc.wantField) {
+					t.Fatalf("Floors{%+v}.Validate() error %q does not contain field name %q",
+						tc.in, err.Error(), tc.wantField)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Floors{%+v}.Validate() = %v; want nil", tc.in, err)
+			}
+		})
+	}
+}
+
+// TestFloorsPass_AllEightCombinations is the canonical (T/F)^3 boolean
+// table: for each combination of (sessions-pass, events-pass,
+// windows-pass), assert FloorsPass returns true iff all three are true.
+//
+// Pass means count >= floor (sessions=5, events=20, windows=3 from
+// DefaultFloors). Fail means count = floor - 1.
+func TestFloorsPass_AllEightCombinations(t *testing.T) {
+	t.Parallel()
+
+	floors := DefaultFloors()
+
+	const (
+		passSessions = 5
+		failSessions = 4
+		passEvents   = 20
+		failEvents   = 19
+		passWindows  = 3
+		failWindows  = 2
+	)
+
+	cases := []struct {
+		name     string
+		observed int
+		sessions int
+		windows  int
+		want     bool
+	}{
+		{"FFF_all_fail", failEvents, failSessions, failWindows, false},
+		{"FFT_only_windows_pass", failEvents, failSessions, passWindows, false},
+		{"FTF_only_sessions_pass", failEvents, passSessions, failWindows, false},
+		{"FTT_events_fail", failEvents, passSessions, passWindows, false},
+		{"TFF_only_events_pass", passEvents, failSessions, failWindows, false},
+		{"TFT_sessions_fail", passEvents, failSessions, passWindows, false},
+		{"TTF_windows_fail", passEvents, passSessions, failWindows, false},
+		{"TTT_all_pass", passEvents, passSessions, passWindows, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := FloorsPass(tc.observed, tc.sessions, tc.windows, floors)
+			if got != tc.want {
+				t.Fatalf("FloorsPass(observed=%d, sessions=%d, windows=%d, %+v) = %v, want %v",
+					tc.observed, tc.sessions, tc.windows, floors, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFloorsPass_NegativeInputsReturnFalse confirms each input position
+// independently triggers the defensive false return on a negative value
+// even when the other two would otherwise pass.
+func TestFloorsPass_NegativeInputsReturnFalse(t *testing.T) {
+	t.Parallel()
+
+	floors := DefaultFloors()
+
+	cases := []struct {
+		name     string
+		observed int
+		sessions int
+		windows  int
+	}{
+		{"negative_observed", -1, 5, 3},
+		{"negative_sessions", 20, -1, 3},
+		{"negative_windows", 20, 5, -1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := FloorsPass(tc.observed, tc.sessions, tc.windows, floors); got {
+				t.Fatalf("FloorsPass(observed=%d, sessions=%d, windows=%d, %+v) = true; want false on negative input",
+					tc.observed, tc.sessions, tc.windows, floors)
+			}
+		})
+	}
+}
+
+// TestConfidence_String pins the wire-form labels for every defined
+// Confidence level plus the default "unknown" branch. These strings ship
+// in metrics labels and audit-log values — renaming is a downstream-
+// breaking change.
+func TestConfidence_String(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		level Confidence
+		want  string
+	}{
+		{ConfidenceNeverConfirmed, "never_confirmed"},
+		{ConfidenceBrittle, "brittle"},
+		{ConfidenceStable, "stable"},
+		// Out-of-range int casts must hit the default branch.
+		{Confidence(99), "unknown"},
+		{Confidence(-1), "unknown"},
+		{confidenceSentinel, "unknown"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.level.String(); got != tc.want {
+				t.Fatalf("Confidence(%d).String() = %q, want %q", tc.level, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassify_VerdictMatrix walks the classification table from the
+// design's Wilson edge-case spec. Every row pins both the inputs and
+// the expected verdict so a future change to either the floor logic
+// or the threshold bands surfaces as a fail with row context.
+//
+// Wilson values referenced (computed at DefaultWilsonAlpha = 0.05):
+//
+//	k=100 n=100 → 0.963 (well above TauStable 0.85)
+//	k=25  n=25  → 0.867 (just above TauStable)
+//	k=20  n=20  → 0.839 (between TauBrittle and TauStable)
+//	k=24  n=35  → 0.520 (just above TauBrittle 0.50)
+//	k=23  n=35  → 0.492 (just below TauBrittle)
+//	k=20  n=100 → 0.133 (well below TauBrittle, but events floor passes)
+func TestClassify_VerdictMatrix(t *testing.T) {
+	t.Parallel()
+
+	floors := DefaultFloors()
+
+	cases := []struct {
+		name        string
+		observed    int
+		opportunity int
+		sessions    int
+		windows     int
+		want        Confidence
+	}{
+		{
+			name:        "wilson_well_above_tau_stable_floors_pass",
+			observed:    100,
+			opportunity: 100,
+			sessions:    100,
+			windows:     100,
+			want:        ConfidenceStable,
+		},
+		{
+			name:        "wilson_just_above_tau_stable_floors_pass",
+			observed:    25,
+			opportunity: 25,
+			sessions:    5,
+			windows:     3,
+			want:        ConfidenceStable,
+		},
+		{
+			name:        "wilson_in_brittle_band_floors_pass",
+			observed:    20,
+			opportunity: 20,
+			sessions:    5,
+			windows:     3,
+			want:        ConfidenceBrittle,
+		},
+		{
+			name:        "wilson_just_above_tau_brittle_floors_pass",
+			observed:    24,
+			opportunity: 35,
+			sessions:    5,
+			windows:     3,
+			want:        ConfidenceBrittle,
+		},
+		{
+			name:        "wilson_just_below_tau_brittle_floors_pass",
+			observed:    23,
+			opportunity: 35,
+			sessions:    5,
+			windows:     3,
+			want:        ConfidenceNeverConfirmed,
+		},
+		{
+			name:        "wilson_well_below_tau_brittle_floors_pass",
+			observed:    20,
+			opportunity: 100,
+			sessions:    5,
+			windows:     3,
+			want:        ConfidenceNeverConfirmed,
+		},
+		{
+			name:        "wilson_stable_but_session_floor_fails",
+			observed:    100,
+			opportunity: 100,
+			sessions:    4, // < MinSessions=5
+			windows:     100,
+			want:        ConfidenceNeverConfirmed,
+		},
+		{
+			name:        "wilson_stable_but_events_floor_fails",
+			observed:    19, // < MinEvents=20
+			opportunity: 19,
+			sessions:    100,
+			windows:     100,
+			want:        ConfidenceNeverConfirmed,
+		},
+		{
+			name:        "wilson_stable_but_windows_floor_fails",
+			observed:    100,
+			opportunity: 100,
+			sessions:    100,
+			windows:     2, // < MinWindows=3
+			want:        ConfidenceNeverConfirmed,
+		},
+		{
+			name:        "wilson_brittle_but_session_floor_fails",
+			observed:    20,
+			opportunity: 20,
+			sessions:    4,
+			windows:     3,
+			want:        ConfidenceNeverConfirmed,
+		},
+		{
+			name:        "all_zero_inputs",
+			observed:    0,
+			opportunity: 0,
+			sessions:    0,
+			windows:     0,
+			want:        ConfidenceNeverConfirmed,
+		},
+		{
+			name:        "negative_observed_short_circuits_to_never_confirmed",
+			observed:    -1,
+			opportunity: 100,
+			sessions:    100,
+			windows:     100,
+			want:        ConfidenceNeverConfirmed,
+		},
+		{
+			name:        "negative_sessions_short_circuits_to_never_confirmed",
+			observed:    100,
+			opportunity: 100,
+			sessions:    -1,
+			windows:     100,
+			want:        ConfidenceNeverConfirmed,
+		},
+		{
+			name:        "negative_windows_short_circuits_to_never_confirmed",
+			observed:    100,
+			opportunity: 100,
+			sessions:    100,
+			windows:     -1,
+			want:        ConfidenceNeverConfirmed,
+		},
+		{
+			name:        "exact_floor_thresholds_with_stable_wilson",
+			observed:    20, // == MinEvents
+			opportunity: 20,
+			sessions:    5,                 // == MinSessions
+			windows:     3,                 // == MinWindows
+			want:        ConfidenceBrittle, // wilson(20,20)=0.839 → brittle band
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := Classify(tc.observed, tc.opportunity, tc.sessions, tc.windows, floors)
+			if got != tc.want {
+				t.Fatalf("Classify(observed=%d, opportunity=%d, sessions=%d, windows=%d, %+v) = %s, want %s",
+					tc.observed, tc.opportunity, tc.sessions, tc.windows,
+					floors, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassify_FloorAndCount fixes the Wilson math to a known-stable
+// case (k=100, n=100 → wilson ≈ 0.963 ≥ TauStable) and walks every
+// floor pass/fail combination. The ONLY combination that yields
+// ConfidenceStable is all-three-floors-pass; every other row is
+// ConfidenceNeverConfirmed regardless of how high Wilson climbs.
+//
+// This is the AND-composition contract test the kickoff calls out:
+// floors win over Wilson, never the other way around.
+func TestClassify_FloorAndCount(t *testing.T) {
+	t.Parallel()
+
+	floors := DefaultFloors()
+
+	const (
+		// All values pass their respective floor when the row is
+		// "T" for that position; all values fail when the row is "F".
+		// Wilson is always (observed=opportunity), but observed
+		// itself acts as the events-floor input — passEvents=100
+		// clears the 20-event floor, failEvents=19 falls just short.
+		passEvents   = 100
+		failEvents   = 19
+		passSessions = 100
+		failSessions = 4
+		passWindows  = 100
+		failWindows  = 2
+		// Opportunity is fixed so wilson(observed, opportunity) is
+		// either >> TauStable (when observed=passEvents=100) or
+		// near-1 with smaller n (when observed=failEvents=19,
+		// wilson(19,19)≈0.832 — still high, still confirms the
+		// floor-wins-over-Wilson contract).
+		opportunityHigh = 100
+		opportunityLow  = 19
+	)
+
+	cases := []struct {
+		name     string
+		observed int
+		oppor    int
+		sessions int
+		windows  int
+		want     Confidence
+	}{
+		{"FFF_all_floors_fail", failEvents, opportunityLow, failSessions, failWindows, ConfidenceNeverConfirmed},
+		{"FFT_only_windows_pass", failEvents, opportunityLow, failSessions, passWindows, ConfidenceNeverConfirmed},
+		{"FTF_only_sessions_pass", failEvents, opportunityLow, passSessions, failWindows, ConfidenceNeverConfirmed},
+		{"FTT_events_fail", failEvents, opportunityLow, passSessions, passWindows, ConfidenceNeverConfirmed},
+		{"TFF_only_events_pass", passEvents, opportunityHigh, failSessions, failWindows, ConfidenceNeverConfirmed},
+		{"TFT_sessions_fail", passEvents, opportunityHigh, failSessions, passWindows, ConfidenceNeverConfirmed},
+		{"TTF_windows_fail", passEvents, opportunityHigh, passSessions, failWindows, ConfidenceNeverConfirmed},
+		{"TTT_all_floors_pass", passEvents, opportunityHigh, passSessions, passWindows, ConfidenceStable},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := Classify(tc.observed, tc.oppor, tc.sessions, tc.windows, floors)
+			if got != tc.want {
+				t.Fatalf("Classify(observed=%d, opportunity=%d, sessions=%d, windows=%d, %+v) = %s, want %s",
+					tc.observed, tc.oppor, tc.sessions, tc.windows,
+					floors, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/contract/inference/opportunity.go
+++ b/internal/contract/inference/opportunity.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package inference
+
+import (
+	"errors"
+	"fmt"
+)
+
+// OpportunityLevel identifies which inference rule the engine is evaluating.
+// It selects the matching denominator field from an OpportunityContext via
+// Denominator. Each rule level has a different "what counts as an opportunity"
+// definition (sessions vs events vs calls vs windows), and the picker turns
+// that abstract row from the design's Conditional Opportunity Hierarchy table
+// into a concrete integer to feed Wilson lower-bound math.
+//
+// The zero value is OpportunityLevelUnknown, which is intentionally invalid:
+// a caller that forgets to set the level cannot accidentally pick the first
+// real level. Denominator returns ErrUnknownOpportunityLevel for the zero
+// value (and any unrecognized int).
+//
+// HeaderShape and ArgSchema are split into separate enum members even though
+// they share a denominator field today (ToolEndpointCalls). This lets tests
+// distinguish them in error messages and metrics labels and lets a future
+// refinement give them different counts without changing the API.
+type OpportunityLevel int
+
+const (
+	// OpportunityLevelUnknown is the zero value. It is invalid by design so
+	// uninitialized callers cannot silently pick the first real level. Any
+	// path that reaches Denominator with this level returns
+	// ErrUnknownOpportunityLevel.
+	OpportunityLevelUnknown OpportunityLevel = iota
+
+	// OpportunityLevelHostStability evaluates how stable a host signal is
+	// across the operator's traffic. Denominator: HTTPSessions (sessions
+	// where any outbound HTTP was observed).
+	OpportunityLevelHostStability
+
+	// OpportunityLevelPathFamilyStability evaluates how stable a path-family
+	// signal is per host. Denominator: HostSessions (sessions where that
+	// host was observed).
+	OpportunityLevelPathFamilyStability
+
+	// OpportunityLevelMethodStability evaluates how stable an HTTP method
+	// signal is per host/path-family. Denominator: HostPathFamilyEvents
+	// (events or sessions where that host/path-family was observed).
+	OpportunityLevelMethodStability
+
+	// OpportunityLevelHeaderShape evaluates how stable a header-shape
+	// signal is per tool/endpoint. Denominator: ToolEndpointCalls (calls
+	// where that tool or endpoint was observed). Shares its denominator
+	// field with OpportunityLevelArgSchema today; intentionally split so
+	// tests, metrics, and future divergence stay clean.
+	OpportunityLevelHeaderShape
+
+	// OpportunityLevelArgSchema evaluates how stable an argument-schema
+	// signal is per tool/endpoint. Denominator: ToolEndpointCalls. Shares
+	// its denominator field with OpportunityLevelHeaderShape today; see
+	// the note on HeaderShape.
+	OpportunityLevelArgSchema
+
+	// OpportunityLevelSequenceNGram evaluates how stable a tool-call
+	// sequence (n-gram) signal is per source action. Denominator:
+	// SourceActionWindows (windows or sessions where the source action
+	// occurred).
+	OpportunityLevelSequenceNGram
+
+	// opportunityLevelSentinel is the exclusive upper bound used by
+	// Valid() and tests to detect out-of-range int casts. It is unexported
+	// so external callers cannot depend on the count of levels.
+	opportunityLevelSentinel
+)
+
+// String returns the lowercase snake_case wire-form label for the level.
+// Used in error messages, metrics labels, and structured logs. Stable across
+// versions; renaming a label is a breaking change for downstream dashboards
+// and audit pipelines.
+func (l OpportunityLevel) String() string {
+	switch l {
+	case OpportunityLevelUnknown:
+		return "unknown"
+	case OpportunityLevelHostStability:
+		return "host_stability"
+	case OpportunityLevelPathFamilyStability:
+		return "path_family_stability"
+	case OpportunityLevelMethodStability:
+		return "method_stability"
+	case OpportunityLevelHeaderShape:
+		return "header_shape"
+	case OpportunityLevelArgSchema:
+		return "arg_schema"
+	case OpportunityLevelSequenceNGram:
+		return "sequence_ngram"
+	default:
+		return "invalid"
+	}
+}
+
+// Valid reports whether l is a defined non-Unknown opportunity level. Use
+// this in config validators and at the entry to any function that needs a
+// usable level. OpportunityLevelUnknown returns false; out-of-range int
+// casts return false.
+func (l OpportunityLevel) Valid() bool {
+	return l > OpportunityLevelUnknown && l < opportunityLevelSentinel
+}
+
+// OpportunityContext holds the precomputed counts the inference engine needs
+// to pick a denominator for any rule level. Each field documents which level
+// reads it. The upstream aggregator (PR 2.3 territory) populates these counts
+// from the recorder; Denominator just selects the right field and validates.
+//
+// Passed by value: the struct is small, value semantics make accidental
+// mutation impossible, and the cost is below measurement noise.
+type OpportunityContext struct {
+	// HTTPSessions is the count of sessions in which any outbound HTTP was
+	// observed. Read by OpportunityLevelHostStability.
+	HTTPSessions int
+
+	// HostSessions is the count of sessions in which the host under
+	// evaluation was observed. Read by
+	// OpportunityLevelPathFamilyStability.
+	HostSessions int
+
+	// HostPathFamilyEvents is the count of events (or sessions, per the
+	// design's row) in which the host/path-family under evaluation was
+	// observed. Read by OpportunityLevelMethodStability.
+	HostPathFamilyEvents int
+
+	// ToolEndpointCalls is the count of calls in which the tool or
+	// endpoint under evaluation was observed. Read by both
+	// OpportunityLevelHeaderShape and OpportunityLevelArgSchema; they
+	// share this field today.
+	ToolEndpointCalls int
+
+	// SourceActionWindows is the count of windows (or sessions, per the
+	// design's row) in which the source action of the n-gram occurred.
+	// Read by OpportunityLevelSequenceNGram.
+	SourceActionWindows int
+}
+
+// Sentinel errors for Denominator. Callers MUST compare with errors.Is, not
+// raw == comparison; Denominator wraps ErrNegativeOpportunityCount with
+// fmt.Errorf("%w") so context (level + count) survives without breaking
+// errors.Is.
+var (
+	// ErrUnknownOpportunityLevel is returned by Denominator when the
+	// supplied level is OpportunityLevelUnknown or an unrecognized int
+	// (e.g., out-of-range cast). Callers can detect this with
+	// errors.Is(err, ErrUnknownOpportunityLevel).
+	ErrUnknownOpportunityLevel = errors.New("inference: unknown opportunity level")
+
+	// ErrNegativeOpportunityCount is returned by Denominator when the
+	// selected count is negative. Negative counts indicate an aggregator
+	// bug, not adversarial input — but the inference engine is no-panic
+	// per CLAUDE.md hard rules, so we return the error and let the caller
+	// decide. Callers can detect this with
+	// errors.Is(err, ErrNegativeOpportunityCount).
+	ErrNegativeOpportunityCount = errors.New("inference: negative opportunity count")
+)
+
+// Denominator returns the opportunity count that pairs with level for
+// Wilson-lower-bound math. The function is pure: no I/O, no allocations
+// beyond the wrapped-error case, no panics ever.
+//
+// Behavior:
+//   - Defined non-Unknown levels: returns the matching ctx field and nil.
+//   - OpportunityLevelUnknown or any unrecognized int: returns
+//     (0, ErrUnknownOpportunityLevel).
+//   - Negative selected count: returns (0, wrapped
+//     ErrNegativeOpportunityCount with level + count context).
+//   - Zero selected count: returns (0, nil). Zero is a valid "no
+//     opportunity yet" state; the floor gates downstream (PR 2.2) handle
+//     the implication.
+func Denominator(level OpportunityLevel, ctx OpportunityContext) (int, error) {
+	var count int
+	switch level {
+	case OpportunityLevelHostStability:
+		count = ctx.HTTPSessions
+	case OpportunityLevelPathFamilyStability:
+		count = ctx.HostSessions
+	case OpportunityLevelMethodStability:
+		count = ctx.HostPathFamilyEvents
+	case OpportunityLevelHeaderShape, OpportunityLevelArgSchema:
+		count = ctx.ToolEndpointCalls
+	case OpportunityLevelSequenceNGram:
+		count = ctx.SourceActionWindows
+	case OpportunityLevelUnknown:
+		return 0, ErrUnknownOpportunityLevel
+	default:
+		return 0, ErrUnknownOpportunityLevel
+	}
+	if count < 0 {
+		return 0, fmt.Errorf("%w (level=%s, count=%d)", ErrNegativeOpportunityCount, level, count)
+	}
+	return count, nil
+}

--- a/internal/contract/inference/opportunity_test.go
+++ b/internal/contract/inference/opportunity_test.go
@@ -1,0 +1,309 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package inference
+
+import (
+	"errors"
+	"testing"
+)
+
+// Synthetic context values used across happy-path and zero-count tables.
+// Each value is distinct and non-trivial so a wrong field selection in
+// Denominator surfaces as an obviously wrong number.
+const (
+	testHTTPSessions         = 100
+	testHostSessions         = 42
+	testHostPathFamilyEvents = 17
+	testToolEndpointCalls    = 9
+	testSourceActionWindows  = 3
+)
+
+// TestOpportunityLevel_String pins the wire-form label for every defined
+// level (and the invalid-default case). These strings ship in error
+// messages and metrics labels — renaming is a downstream-breaking change.
+func TestOpportunityLevel_String(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		level OpportunityLevel
+		want  string
+	}{
+		{OpportunityLevelUnknown, "unknown"},
+		{OpportunityLevelHostStability, "host_stability"},
+		{OpportunityLevelPathFamilyStability, "path_family_stability"},
+		{OpportunityLevelMethodStability, "method_stability"},
+		{OpportunityLevelHeaderShape, "header_shape"},
+		{OpportunityLevelArgSchema, "arg_schema"},
+		{OpportunityLevelSequenceNGram, "sequence_ngram"},
+		// Out-of-range int casts must hit the default branch and return
+		// the stable "invalid" label so metrics/logs never silently swap
+		// a typo'd int for a real label.
+		{OpportunityLevel(99), "invalid"},
+		{OpportunityLevel(-1), "invalid"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.level.String(); got != tc.want {
+				t.Fatalf("OpportunityLevel(%d).String() = %q, want %q", tc.level, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOpportunityLevel_Valid confirms every defined non-Unknown level is
+// Valid, and that Unknown / out-of-range casts are not. This is the
+// boundary callers and config validators rely on.
+func TestOpportunityLevel_Valid(t *testing.T) {
+	t.Parallel()
+
+	validLevels := []OpportunityLevel{
+		OpportunityLevelHostStability,
+		OpportunityLevelPathFamilyStability,
+		OpportunityLevelMethodStability,
+		OpportunityLevelHeaderShape,
+		OpportunityLevelArgSchema,
+		OpportunityLevelSequenceNGram,
+	}
+	for _, l := range validLevels {
+		l := l
+		t.Run("valid_"+l.String(), func(t *testing.T) {
+			t.Parallel()
+			if !l.Valid() {
+				t.Fatalf("%s: Valid() = false, want true", l)
+			}
+		})
+	}
+
+	invalidLevels := []OpportunityLevel{
+		OpportunityLevelUnknown,
+		OpportunityLevel(-1),
+		OpportunityLevel(99),
+		// One past the last defined level — exercises the upper-bound
+		// guard in Valid() without exporting the sentinel.
+		OpportunityLevel(int(OpportunityLevelSequenceNGram) + 1),
+	}
+	for _, l := range invalidLevels {
+		l := l
+		t.Run("invalid_"+l.String(), func(t *testing.T) {
+			t.Parallel()
+			if l.Valid() {
+				t.Fatalf("OpportunityLevel(%d): Valid() = true, want false", l)
+			}
+		})
+	}
+}
+
+// fullContext returns a context with every field populated to a distinct
+// non-zero value. Used to verify the right field is selected for each
+// level in the happy path.
+func fullContext() OpportunityContext {
+	return OpportunityContext{
+		HTTPSessions:         testHTTPSessions,
+		HostSessions:         testHostSessions,
+		HostPathFamilyEvents: testHostPathFamilyEvents,
+		ToolEndpointCalls:    testToolEndpointCalls,
+		SourceActionWindows:  testSourceActionWindows,
+	}
+}
+
+// TestDenominator_HappyPath asserts each defined non-Unknown level pulls
+// the correct field from a fully-populated context. HeaderShape and
+// ArgSchema deliberately return the same value (testToolEndpointCalls);
+// this row is the explicit, test-enforced documentation that they share
+// a denominator today.
+func TestDenominator_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	ctx := fullContext()
+	cases := []struct {
+		level OpportunityLevel
+		want  int
+	}{
+		{OpportunityLevelHostStability, testHTTPSessions},
+		{OpportunityLevelPathFamilyStability, testHostSessions},
+		{OpportunityLevelMethodStability, testHostPathFamilyEvents},
+		{OpportunityLevelHeaderShape, testToolEndpointCalls},
+		{OpportunityLevelArgSchema, testToolEndpointCalls},
+		{OpportunityLevelSequenceNGram, testSourceActionWindows},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.level.String(), func(t *testing.T) {
+			t.Parallel()
+			n, err := Denominator(tc.level, ctx)
+			if err != nil {
+				t.Fatalf("Denominator(%s) returned error: %v", tc.level, err)
+			}
+			if n != tc.want {
+				t.Fatalf("Denominator(%s) = %d, want %d", tc.level, n, tc.want)
+			}
+		})
+	}
+}
+
+// TestDenominator_RejectsUnknownLevel asserts the zero value and any
+// out-of-range int both return ErrUnknownOpportunityLevel. The error MUST
+// be detectable via errors.Is — never raw equality (PR 1.3 lesson).
+func TestDenominator_RejectsUnknownLevel(t *testing.T) {
+	t.Parallel()
+
+	ctx := fullContext()
+	cases := []struct {
+		name  string
+		level OpportunityLevel
+	}{
+		{"zero_value", OpportunityLevelUnknown},
+		{"out_of_range_high", OpportunityLevel(99)},
+		{"out_of_range_negative", OpportunityLevel(-1)},
+		// Exactly one past the last defined level — exercises the
+		// default branch boundary without leaking the sentinel.
+		{
+			"one_past_last",
+			OpportunityLevel(int(OpportunityLevelSequenceNGram) + 1),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			n, err := Denominator(tc.level, ctx)
+			if n != 0 {
+				t.Fatalf("Denominator(%s) returned n=%d, want 0", tc.level, n)
+			}
+			if err == nil {
+				t.Fatalf("Denominator(%s) returned nil error, want ErrUnknownOpportunityLevel", tc.level)
+			}
+			if !errors.Is(err, ErrUnknownOpportunityLevel) {
+				t.Fatalf("Denominator(%s) error = %v, want errors.Is(ErrUnknownOpportunityLevel)", tc.level, err)
+			}
+		})
+	}
+}
+
+// TestDenominator_RejectsNegativeCount asserts that any negative source
+// count returns wrapped ErrNegativeOpportunityCount with n=0, regardless
+// of which level reads it. errors.Is must still match through the
+// fmt.Errorf("%w") wrapping.
+func TestDenominator_RejectsNegativeCount(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		level OpportunityLevel
+		mut   func(*OpportunityContext)
+	}{
+		{
+			"host_stability_negative",
+			OpportunityLevelHostStability,
+			func(c *OpportunityContext) { c.HTTPSessions = -1 },
+		},
+		{
+			"path_family_stability_negative",
+			OpportunityLevelPathFamilyStability,
+			func(c *OpportunityContext) { c.HostSessions = -1 },
+		},
+		{
+			"method_stability_negative",
+			OpportunityLevelMethodStability,
+			func(c *OpportunityContext) { c.HostPathFamilyEvents = -1 },
+		},
+		{
+			"header_shape_negative",
+			OpportunityLevelHeaderShape,
+			func(c *OpportunityContext) { c.ToolEndpointCalls = -1 },
+		},
+		{
+			"arg_schema_negative",
+			OpportunityLevelArgSchema,
+			func(c *OpportunityContext) { c.ToolEndpointCalls = -1 },
+		},
+		{
+			"sequence_ngram_negative",
+			OpportunityLevelSequenceNGram,
+			func(c *OpportunityContext) { c.SourceActionWindows = -1 },
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := fullContext()
+			tc.mut(&ctx)
+
+			n, err := Denominator(tc.level, ctx)
+			if n != 0 {
+				t.Fatalf("Denominator(%s) returned n=%d, want 0", tc.level, n)
+			}
+			if err == nil {
+				t.Fatalf("Denominator(%s) returned nil error, want ErrNegativeOpportunityCount", tc.level)
+			}
+			if !errors.Is(err, ErrNegativeOpportunityCount) {
+				t.Fatalf("Denominator(%s) error = %v, want errors.Is(ErrNegativeOpportunityCount)", tc.level, err)
+			}
+			// The wrapped error MUST surface level + count for audit;
+			// confirm both substrings are present in the message.
+			msg := err.Error()
+			if !contains(msg, "level="+tc.level.String()) {
+				t.Fatalf("Denominator(%s) error = %q, want it to contain level=%s", tc.level, msg, tc.level)
+			}
+			if !contains(msg, "count=-1") {
+				t.Fatalf("Denominator(%s) error = %q, want it to contain count=-1", tc.level, msg)
+			}
+		})
+	}
+}
+
+// TestDenominator_ZeroCountAllowed asserts that an opportunity count of
+// zero is a valid state, not an error. Floor gates downstream (PR 2.2)
+// turn zero into a "not enough evidence yet" classification; Denominator
+// just reports the count.
+func TestDenominator_ZeroCountAllowed(t *testing.T) {
+	t.Parallel()
+
+	// Empty context: every field is the zero int, so every level reads 0.
+	zeroCtx := OpportunityContext{}
+
+	levels := []OpportunityLevel{
+		OpportunityLevelHostStability,
+		OpportunityLevelPathFamilyStability,
+		OpportunityLevelMethodStability,
+		OpportunityLevelHeaderShape,
+		OpportunityLevelArgSchema,
+		OpportunityLevelSequenceNGram,
+	}
+
+	for _, l := range levels {
+		l := l
+		t.Run(l.String(), func(t *testing.T) {
+			t.Parallel()
+			n, err := Denominator(l, zeroCtx)
+			if err != nil {
+				t.Fatalf("Denominator(%s, zero) returned error: %v, want nil", l, err)
+			}
+			if n != 0 {
+				t.Fatalf("Denominator(%s, zero) = %d, want 0", l, n)
+			}
+		})
+	}
+}
+
+// contains is a tiny strings.Contains-equivalent so the test file does
+// not pull in the strings package just for one helper. Keeps the test
+// file's import block minimal and audit-friendly.
+func contains(haystack, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/contract/inference/wilson.go
+++ b/internal/contract/inference/wilson.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package inference implements the v2.4 contract-compile inference engine:
+// Wilson lower-bound confidence, conditional opportunity denominators,
+// exposure-floor gates, and numeric-budget statistics. Pure functions —
+// no I/O, no transports, no logging. Inputs are recorder.Entry events that
+// have already been classified by internal/contract/privacy.
+package inference
+
+import "math"
+
+// DefaultWilsonAlpha is the canonical alpha (1 - confidence level) for the
+// contract-compile inference engine. Production callers (Classify and the
+// higher-level glue) MUST go through this constant rather than reading a
+// per-deployment config field. Wilson confidence is part of the statistical
+// contract; making it deployment-configurable would let two installs infer
+// different classifications from identical recorder data, which is audit
+// drift, not flexibility.
+const DefaultWilsonAlpha = 0.05
+
+// wilsonZ95 is the inverse-normal-CDF value for 1 - alpha/2 = 0.975 (i.e.
+// alpha = 0.05). Hardcoded so the production Wilson path stays
+// deterministic for a given input on supported Go builds — math.Erfinv
+// is not invoked at runtime, so its precision cannot drift this value.
+const wilsonZ95 = 1.959963984540054
+
+// WilsonLowerBound returns the Wilson score interval lower bound for
+// `observed` successes out of `opportunity` trials at confidence level
+// 1 - alpha. The Wilson interval is the canonical reference for binomial
+// proportion confidence intervals on small or skewed samples; see
+// Newcombe (1998), "Two-sided confidence intervals for the single
+// proportion: comparison of seven methods", Statistics in Medicine 17,
+// 857-872.
+//
+// Closed form:
+//
+//	z      = invNormalCDF(1 - alpha/2)
+//	p_hat  = observed / opportunity
+//	denom  = 1 + z^2 / n
+//	center = (p_hat + z^2 / (2n)) / denom
+//	margin = (z / denom) * sqrt((p_hat * (1 - p_hat) + z^2 / (4n)) / n)
+//	lower  = center - margin
+//
+// Defensive returns of 0.0 (never panic, never NaN) for these cases:
+//   - opportunity == 0 (no trials → no evidence → floor at 0)
+//   - observed < 0 (programmer error, but still safe)
+//   - observed > opportunity (programmer error, but still safe)
+//   - alpha out of (0, 1) (degenerate confidence level)
+//
+// Pure: no I/O, no logging, no allocations beyond the float result.
+func WilsonLowerBound(observed, opportunity int, alpha float64) float64 {
+	if opportunity <= 0 || observed < 0 || observed > opportunity {
+		return 0.0
+	}
+	if alpha <= 0 || alpha >= 1 {
+		return 0.0
+	}
+	// Wilson formula guarantees lower ∈ [0, 1] for valid inputs (validated
+	// above): when k=0, center == margin exactly, so lower = 0; for any
+	// k > 0, lower > 0. No post-formula clamp needed; if a future change
+	// to the formula breaks that guarantee, the test pack catches it.
+	center, margin := wilsonCenterMargin(observed, opportunity, alpha)
+	return center - margin
+}
+
+// WilsonUpperBound returns the Wilson score interval upper bound for
+// `observed` successes out of `opportunity` trials at confidence level
+// 1 - alpha. Required by the contract test pack to prove complementary
+// symmetry: WilsonLowerBound(n-k, n, a) ≈ 1 - WilsonUpperBound(k, n, a).
+//
+// Same defensive edge cases as WilsonLowerBound.
+func WilsonUpperBound(observed, opportunity int, alpha float64) float64 {
+	if opportunity <= 0 || observed < 0 || observed > opportunity {
+		return 0.0
+	}
+	if alpha <= 0 || alpha >= 1 {
+		return 0.0
+	}
+	// Wilson formula guarantees upper ∈ [0, 1] for valid inputs: when k=n,
+	// center + margin = 1 exactly. No post-formula clamp needed.
+	center, margin := wilsonCenterMargin(observed, opportunity, alpha)
+	return center + margin
+}
+
+// wilsonCenterMargin returns the Wilson center and margin for valid
+// (observed, opportunity, alpha) inputs. Callers must validate edge cases
+// before invoking; this helper assumes opportunity > 0 and 0 < alpha < 1.
+func wilsonCenterMargin(observed, opportunity int, alpha float64) (center, margin float64) {
+	n := float64(opportunity)
+	k := float64(observed)
+
+	z := wilsonZ(alpha)
+	z2 := z * z
+
+	pHat := k / n
+	denom := 1 + z2/n
+	center = (pHat + z2/(2*n)) / denom
+	margin = (z / denom) * math.Sqrt((pHat*(1-pHat)+z2/(4*n))/n)
+	return center, margin
+}
+
+// wilsonZ returns the inverse normal CDF value at 1 - alpha/2. The
+// alpha = 0.05 fast path returns the locked wilsonZ95 constant so the
+// production code path returns a fixed value for the default alpha.
+// Other alphas use the Beasley-Springer-Moro rational approximation,
+// which is accurate to roughly 1e-7 across the tail and has no math/big
+// or third-party deps.
+func wilsonZ(alpha float64) float64 {
+	if alpha == DefaultWilsonAlpha {
+		return wilsonZ95
+	}
+	return invNormalCDF(1 - alpha/2)
+}
+
+// invNormalCDF approximates the inverse standard-normal CDF at p ∈ (0, 1)
+// using the Beasley-Springer-Moro rational approximation (Moro 1995). The
+// approximation is accurate to ~1e-7 in the body and tails, which is well
+// within the test tolerance of 3 decimal places for any non-default alpha
+// the engine would realistically encounter.
+//
+// p in (0, 1) is guaranteed by the caller (WilsonLowerBound /
+// WilsonUpperBound validate alpha before reaching this path).
+func invNormalCDF(p float64) float64 {
+	// Beasley-Springer central region coefficients.
+	a := [...]float64{
+		-3.969683028665376e+01,
+		2.209460984245205e+02,
+		-2.759285104469687e+02,
+		1.383577518672690e+02,
+		-3.066479806614716e+01,
+		2.506628277459239e+00,
+	}
+	b := [...]float64{
+		-5.447609879822406e+01,
+		1.615858368580409e+02,
+		-1.556989798598866e+02,
+		6.680131188771972e+01,
+		-1.328068155288572e+01,
+	}
+	// Moro tail-region coefficients.
+	c := [...]float64{
+		-7.784894002430293e-03,
+		-3.223964580411365e-01,
+		-2.400758277161838e+00,
+		-2.549732539343734e+00,
+		4.374664141464968e+00,
+		2.938163982698783e+00,
+	}
+	d := [...]float64{
+		7.784695709041462e-03,
+		3.224671290700398e-01,
+		2.445134137142996e+00,
+		3.754408661907416e+00,
+	}
+
+	const pLow = 0.02425
+	const pHigh = 1 - pLow
+
+	switch {
+	case p < pLow:
+		// Lower tail.
+		q := math.Sqrt(-2 * math.Log(p))
+		return (((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q + c[5]) /
+			((((d[0]*q+d[1])*q+d[2])*q+d[3])*q + 1)
+	case p <= pHigh:
+		// Central region.
+		q := p - 0.5
+		r := q * q
+		return (((((a[0]*r+a[1])*r+a[2])*r+a[3])*r+a[4])*r + a[5]) * q /
+			(((((b[0]*r+b[1])*r+b[2])*r+b[3])*r+b[4])*r + 1)
+	default:
+		// Upper tail.
+		q := math.Sqrt(-2 * math.Log(1-p))
+		return -(((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q + c[5]) /
+			((((d[0]*q+d[1])*q+d[2])*q+d[3])*q + 1)
+	}
+}

--- a/internal/contract/inference/wilson_edge_test.go
+++ b/internal/contract/inference/wilson_edge_test.go
@@ -1,0 +1,212 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package inference
+
+import (
+	"math"
+	"testing"
+)
+
+// wilsonTolerance is the per-row comparison tolerance for the Wilson
+// edge-case table. Three decimal places is the contract guarantee in the
+// design; tighter tolerances belong in property tests, not row tables.
+const wilsonTolerance = 1e-3
+
+func TestWilsonLowerBound_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	// Reference values computed from the closed-form formula with
+	// z = 1.959963984540054 (alpha = 0.05). Defensive cases return 0.0.
+	cases := []struct {
+		name        string
+		observed    int
+		opportunity int
+		alpha       float64
+		want        float64
+	}{
+		// Required design-table rows.
+		{"zero/zero", 0, 0, DefaultWilsonAlpha, 0.0},
+		{"observed_gt_opportunity_defensive", 5, 0, DefaultWilsonAlpha, 0.0},
+		{"one_trial_zero_observed", 0, 1, DefaultWilsonAlpha, 0.0},
+		{"one_trial_one_observed", 1, 1, DefaultWilsonAlpha, 0.207},
+		{"five_of_five", 5, 5, DefaultWilsonAlpha, 0.566},
+		{"twenty_of_twenty", 20, 20, DefaultWilsonAlpha, 0.839},
+		{"twenty_eight_of_twenty_eight", 28, 28, DefaultWilsonAlpha, 0.879},
+		{"hundred_trials_zero_observed", 0, 100, DefaultWilsonAlpha, 0.0},
+		{"hundred_of_hundred", 100, 100, DefaultWilsonAlpha, 0.964},
+
+		// Additional boundary probes.
+		{"high_n_all_positive", 10000, 10000, DefaultWilsonAlpha, 1.000},
+		{"two_of_two", 2, 2, DefaultWilsonAlpha, 0.342},
+		{"fifty_fifty", 50, 100, DefaultWilsonAlpha, 0.404},
+		{"one_third_of_thirty", 10, 30, DefaultWilsonAlpha, 0.192},
+		{"two_thirds_of_thirty", 20, 30, DefaultWilsonAlpha, 0.488},
+		{"negative_observed_defensive", -1, 10, DefaultWilsonAlpha, 0.0},
+		{"alpha_zero_defensive", 50, 100, 0.0, 0.0},
+		{"alpha_one_defensive", 50, 100, 1.0, 0.0},
+		{"observed_exceeds_opportunity_defensive", 20, 10, DefaultWilsonAlpha, 0.0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := WilsonLowerBound(tc.observed, tc.opportunity, tc.alpha)
+			if math.IsNaN(got) {
+				t.Fatalf("WilsonLowerBound(%d,%d,%g) returned NaN; must be defined",
+					tc.observed, tc.opportunity, tc.alpha)
+			}
+			// High-N all-positive case: lower bound approaches 1 but is
+			// strictly below it. Accept anything within tolerance of 1.
+			if math.Abs(got-tc.want) > wilsonTolerance {
+				t.Fatalf("WilsonLowerBound(%d,%d,%g) = %.6f; want %.3f (±%g)",
+					tc.observed, tc.opportunity, tc.alpha,
+					got, tc.want, wilsonTolerance)
+			}
+		})
+	}
+}
+
+func TestWilsonLowerBound_Monotonicity(t *testing.T) {
+	t.Parallel()
+
+	const n = 100
+	prev := WilsonLowerBound(0, n, DefaultWilsonAlpha)
+	for k := 1; k <= n; k++ {
+		got := WilsonLowerBound(k, n, DefaultWilsonAlpha)
+		if got < prev {
+			t.Fatalf("monotonicity violated at k=%d: got=%.9f prev=%.9f",
+				k, got, prev)
+		}
+		prev = got
+	}
+}
+
+func TestWilsonLowerBound_Determinism(t *testing.T) {
+	t.Parallel()
+
+	// Same inputs must produce bitwise-identical output across 1000 calls.
+	first := WilsonLowerBound(50, 100, DefaultWilsonAlpha)
+	for i := 0; i < 1000; i++ {
+		got := WilsonLowerBound(50, 100, DefaultWilsonAlpha)
+		if got != first {
+			t.Fatalf("non-deterministic at iteration %d: got=%v first=%v",
+				i, got, first)
+		}
+	}
+}
+
+func TestWilsonComplementarySymmetry(t *testing.T) {
+	t.Parallel()
+
+	// For valid (k, n), WilsonLowerBound(n-k, n) == 1 - WilsonUpperBound(k, n).
+	// This is the canonical symmetry property of the Wilson interval.
+	cases := []struct {
+		k, n int
+	}{
+		{3, 10},
+		{50, 100},
+		{750, 1000},
+	}
+	const symTolerance = 1e-9
+	for _, tc := range cases {
+		lower := WilsonLowerBound(tc.n-tc.k, tc.n, DefaultWilsonAlpha)
+		upper := WilsonUpperBound(tc.k, tc.n, DefaultWilsonAlpha)
+		want := 1 - upper
+		if math.Abs(lower-want) > symTolerance {
+			t.Fatalf("symmetry broken for k=%d n=%d: lower(n-k)=%.12f 1-upper(k)=%.12f diff=%.3g",
+				tc.k, tc.n, lower, want, math.Abs(lower-want))
+		}
+	}
+}
+
+func TestDefaultWilsonAlpha_Locked(t *testing.T) {
+	t.Parallel()
+
+	// Contract-against-drift guard. If anyone bumps this constant, this
+	// test fails and the reviewer must justify the change in the PR.
+	if DefaultWilsonAlpha != 0.05 {
+		t.Fatalf("DefaultWilsonAlpha drift detected: got %v, want 0.05", DefaultWilsonAlpha)
+	}
+}
+
+// TestWilsonUpperBound_EdgeCases exercises the upper-bound defensive paths
+// and standard cases. Required for 100% line coverage on wilson.go and to
+// prove the upper bound's defensive returns match the lower bound's.
+func TestWilsonUpperBound_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		observed    int
+		opportunity int
+		alpha       float64
+		want        float64
+	}{
+		{"zero_opportunity", 0, 0, DefaultWilsonAlpha, 0.0},
+		{"negative_observed", -1, 10, DefaultWilsonAlpha, 0.0},
+		{"observed_exceeds_opportunity", 20, 10, DefaultWilsonAlpha, 0.0},
+		{"alpha_zero", 50, 100, 0.0, 0.0},
+		{"alpha_one", 50, 100, 1.0, 0.0},
+		{"hundred_trials_zero_observed", 0, 100, DefaultWilsonAlpha, 0.037},
+		{"fifty_fifty", 50, 100, DefaultWilsonAlpha, 0.596},
+		{"hundred_of_hundred_caps_at_one", 100, 100, DefaultWilsonAlpha, 1.0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := WilsonUpperBound(tc.observed, tc.opportunity, tc.alpha)
+			if math.IsNaN(got) {
+				t.Fatalf("WilsonUpperBound(%d,%d,%g) returned NaN; must be defined",
+					tc.observed, tc.opportunity, tc.alpha)
+			}
+			if math.Abs(got-tc.want) > wilsonTolerance {
+				t.Fatalf("WilsonUpperBound(%d,%d,%g) = %.6f; want %.3f (±%g)",
+					tc.observed, tc.opportunity, tc.alpha,
+					got, tc.want, wilsonTolerance)
+			}
+		})
+	}
+}
+
+// TestWilsonNonDefaultAlpha exercises the Beasley-Springer-Moro path
+// (alpha != 0.05). Required for 100% line coverage on the invNormalCDF
+// branches. We probe the central region (alpha=0.10), the lower tail
+// (alpha=0.001 → 1-alpha/2=0.9995, falls through to upper tail of
+// invNormalCDF), and verify the body region with alpha=0.5
+// (1-alpha/2=0.75, central region of invNormalCDF).
+func TestWilsonNonDefaultAlpha(t *testing.T) {
+	t.Parallel()
+
+	// Central region of invNormalCDF (p = 0.95 for alpha=0.10).
+	// z_{0.95} ≈ 1.6449. For n=100, k=50, lower ≈ 0.4188.
+	got90 := WilsonLowerBound(50, 100, 0.10)
+	if math.Abs(got90-0.4188) > 1e-3 {
+		t.Fatalf("alpha=0.10 (central region): n=100 k=50 lower = %.6f, want ~0.4188", got90)
+	}
+
+	// Upper-tail region of invNormalCDF: alpha=0.0001 → p=1-alpha/2=0.99995,
+	// which is greater than pHigh (≈0.97575), so the upper-tail branch fires.
+	// z_{0.99995} ≈ 3.8906. For n=100, k=50, lower ≈ 0.3187.
+	gotTiny := WilsonLowerBound(50, 100, 0.0001)
+	if math.Abs(gotTiny-0.3187) > 1e-3 {
+		t.Fatalf("alpha=0.0001 (upper tail): n=100 k=50 lower = %.6f, want ~0.3187", gotTiny)
+	}
+
+	// Lower-tail region of invNormalCDF (p < pLow ≈ 0.02425). This branch
+	// is unreachable from WilsonLowerBound's alpha input alone (alpha must
+	// be in (0,1), so 1-alpha/2 is in (0.5, 1) and never below pLow).
+	// Cover it via direct invocation. invNormalCDF(0.001) ≈ -3.0902.
+	zLowTail := invNormalCDF(0.001)
+	if math.Abs(zLowTail-(-3.0902)) > 1e-3 {
+		t.Fatalf("invNormalCDF(0.001) (lower tail) = %.6f, want ~-3.0902", zLowTail)
+	}
+
+	// Wide alpha (alpha=0.5 → p=0.75, central region of invNormalCDF).
+	// z_{0.75} ≈ 0.6745. For n=100, k=50, lower ≈ 0.4664.
+	gotWide := WilsonLowerBound(50, 100, 0.5)
+	if math.Abs(gotWide-0.4664) > 1e-3 {
+		t.Fatalf("alpha=0.5 (wide central): n=100 k=50 lower = %.6f, want ~0.4664", gotWide)
+	}
+}

--- a/internal/metrics/learn.go
+++ b/internal/metrics/learn.go
@@ -47,11 +47,25 @@ func (m *Metrics) registerLearnMetrics(reg *prometheus.Registry) {
 		Help:      "Sliding window unclassified-event ratio, computed and set by the observation pipeline. 0.0 = all events classified; 1.0 = none classified.",
 	})
 
+	m.learnInferenceClassifications = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: learnNamespace,
+		Name:      "inference_classify_total",
+		Help:      "Total inference classifications produced by the contract-compile engine, labeled by outcome (never_confirmed, brittle, stable). Used by the review UX to render the inference-verdict histogram.",
+	}, []string{"outcome"})
+
+	m.learnInferenceFloorFailures = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: learnNamespace,
+		Name:      "inference_floor_failures_total",
+		Help:      "Total floor failures across all inference classifications, labeled by which floor caused the rule to fall back to never_confirmed (sessions, events, windows). Diagnostic for which floor is the bottleneck on a deployment's data volume.",
+	}, []string{"floor"})
+
 	reg.MustRegister(
 		m.learnObservationEvents,
 		m.learnRegulatedDataBlocked,
 		m.learnUnclassifiedActions,
 		m.learnUnclassifiedRate,
+		m.learnInferenceClassifications,
+		m.learnInferenceFloorFailures,
 	)
 }
 
@@ -97,4 +111,26 @@ func (m *Metrics) SetUnclassifiedRate(rate float64) {
 		return
 	}
 	m.learnUnclassifiedRate.Set(rate)
+}
+
+// RecordInferenceClassification increments the inference_classify_total
+// counter for the given outcome. Outcome must be one of "never_confirmed",
+// "brittle", "stable" (the wire form of inference.Confidence.String()).
+// The caller is responsible for passing a canonical value; this helper
+// does NOT normalize or validate.
+func (m *Metrics) RecordInferenceClassification(outcome string) {
+	if m == nil {
+		return
+	}
+	m.learnInferenceClassifications.WithLabelValues(outcome).Inc()
+}
+
+// RecordInferenceFloorFailure increments the inference_floor_failures_total
+// counter for the named floor. Floor must be one of "sessions", "events",
+// "windows". The caller is responsible for passing a canonical value.
+func (m *Metrics) RecordInferenceFloorFailure(floor string) {
+	if m == nil {
+		return
+	}
+	m.learnInferenceFloorFailures.WithLabelValues(floor).Inc()
 }

--- a/internal/metrics/learn.go
+++ b/internal/metrics/learn.go
@@ -113,24 +113,72 @@ func (m *Metrics) SetUnclassifiedRate(rate float64) {
 	m.learnUnclassifiedRate.Set(rate)
 }
 
+// InferenceOutcome is the closed wire-form domain for the
+// inference_classify_total counter's outcome label. The string values
+// agree byte-for-byte with inference.Confidence.String() so dashboards
+// and alerts grouping by outcome see the same vocabulary the recorder
+// emits. The metrics package owns the enum locally to avoid a layering
+// import on internal/contract/inference; cross-package alignment is
+// asserted by the metrics test pack.
+type InferenceOutcome string
+
+// Canonical InferenceOutcome values. Any value outside this set is
+// dropped at record time to prevent label-cardinality drift.
+const (
+	OutcomeNeverConfirmed InferenceOutcome = "never_confirmed"
+	OutcomeBrittle        InferenceOutcome = "brittle"
+	OutcomeStable         InferenceOutcome = "stable"
+)
+
+// FloorFailure is the closed wire-form domain for the
+// inference_floor_failures_total counter's floor label. Values match
+// the YAML field-name suffix the operator sees in pipelock.yaml
+// (learn.inference.floors.min_sessions etc.) so the diagnostic counter
+// and the validator error message use one vocabulary.
+type FloorFailure string
+
+// Canonical FloorFailure values. Any value outside this set is dropped
+// at record time to prevent label-cardinality drift.
+const (
+	FloorSessions FloorFailure = "sessions"
+	FloorEvents   FloorFailure = "events"
+	FloorWindows  FloorFailure = "windows"
+)
+
 // RecordInferenceClassification increments the inference_classify_total
-// counter for the given outcome. Outcome must be one of "never_confirmed",
-// "brittle", "stable" (the wire form of inference.Confidence.String()).
-// The caller is responsible for passing a canonical value; this helper
-// does NOT normalize or validate.
-func (m *Metrics) RecordInferenceClassification(outcome string) {
+// counter for the given outcome. Non-canonical values are dropped
+// silently: Prometheus creates a new time series for every distinct
+// label value, so accepting arbitrary strings would let a future caller
+// bug expand cardinality without an obvious failure mode. The closed
+// allowlist (OutcomeNeverConfirmed / Brittle / Stable) is enforced at
+// runtime; the typed parameter steers callers toward the constants but
+// untyped string literals still convert per Go's constant rules.
+func (m *Metrics) RecordInferenceClassification(outcome InferenceOutcome) {
 	if m == nil {
 		return
 	}
-	m.learnInferenceClassifications.WithLabelValues(outcome).Inc()
+	switch outcome {
+	case OutcomeNeverConfirmed, OutcomeBrittle, OutcomeStable:
+		m.learnInferenceClassifications.WithLabelValues(string(outcome)).Inc()
+	default:
+		// Drop non-canonical: future caller drift cannot expand the
+		// cardinality of pipelock_learn_inference_classify_total beyond
+		// the three legitimate outcomes.
+	}
 }
 
 // RecordInferenceFloorFailure increments the inference_floor_failures_total
-// counter for the named floor. Floor must be one of "sessions", "events",
-// "windows". The caller is responsible for passing a canonical value.
-func (m *Metrics) RecordInferenceFloorFailure(floor string) {
+// counter for the named floor. Same closed-allowlist contract as
+// RecordInferenceClassification: non-canonical values drop silently to
+// prevent cardinality drift on a security-relevant diagnostic counter.
+func (m *Metrics) RecordInferenceFloorFailure(floor FloorFailure) {
 	if m == nil {
 		return
 	}
-	m.learnInferenceFloorFailures.WithLabelValues(floor).Inc()
+	switch floor {
+	case FloorSessions, FloorEvents, FloorWindows:
+		m.learnInferenceFloorFailures.WithLabelValues(string(floor)).Inc()
+	default:
+		// Drop non-canonical (see RecordInferenceClassification).
+	}
 }

--- a/internal/metrics/learn_test.go
+++ b/internal/metrics/learn_test.go
@@ -25,16 +25,18 @@ func TestRegisterLearnMetrics_RegistersAllFour(t *testing.T) {
 	t.Parallel()
 	m := New()
 
-	// Touch the CounterVec metrics with a synthetic label so Gather()
-	// emits them. CounterVec/GaugeVec are lazy: descriptors are registered
-	// at New() time, but no MetricFamily appears in Gather output until
-	// at least one labeled child is observed. The non-Vec counter and
-	// gauge appear immediately. We use a distinct test-only label value
-	// for the Vec metrics so this touch can't be confused with real data.
+	// Touch the CounterVec metrics so Gather() emits them. CounterVec/
+	// GaugeVec are lazy: descriptors are registered at New() time, but
+	// no MetricFamily appears in Gather output until at least one
+	// labeled child is observed. The new inference helpers enforce a
+	// closed allowlist on their labels (cardinality protection), so we
+	// touch them with canonical values rather than a synthetic probe;
+	// the pre-existing helpers retain the probe label because their
+	// behavior is out of scope for this PR.
 	m.RecordObservationEvent("registration_probe")
 	m.RecordRegulatedDataBlocked("registration_probe")
-	m.RecordInferenceClassification("registration_probe")
-	m.RecordInferenceFloorFailure("registration_probe")
+	m.RecordInferenceClassification(OutcomeStable)
+	m.RecordInferenceFloorFailure(FloorSessions)
 
 	families, err := m.Registry().Gather()
 	if err != nil {
@@ -227,4 +229,74 @@ func TestRecordInferenceFloorFailure_NilSafe(t *testing.T) {
 	t.Parallel()
 	var m *Metrics
 	m.RecordInferenceFloorFailure("sessions") // no panic
+}
+
+// TestRecordInferenceClassification_DropsNonCanonical confirms the
+// closed-allowlist contract: a label value outside {never_confirmed,
+// brittle, stable} is dropped silently, never increments any series,
+// and cannot expand cardinality. Catches future caller drift before it
+// bakes into dashboards or alerts.
+func TestRecordInferenceClassification_DropsNonCanonical(t *testing.T) {
+	t.Parallel()
+	m := New()
+
+	// Cast a non-canonical literal through the typed parameter to
+	// reach the default branch.
+	m.RecordInferenceClassification(InferenceOutcome("malicious_label"))
+	m.RecordInferenceClassification(InferenceOutcome(""))
+	m.RecordInferenceClassification(InferenceOutcome("STABLE")) // case-sensitive
+
+	if got := testutil.ToFloat64(m.learnInferenceClassifications.WithLabelValues("malicious_label")); got != 0 {
+		t.Errorf("non-canonical label leaked into counter: got %v", got)
+	}
+	if got := testutil.ToFloat64(m.learnInferenceClassifications.WithLabelValues("STABLE")); got != 0 {
+		t.Errorf("case-variant label leaked into counter: got %v", got)
+	}
+	// All canonical labels must remain at zero too: the helper dropped
+	// every input above.
+	for _, canonical := range []string{"never_confirmed", "brittle", "stable"} {
+		if got := testutil.ToFloat64(m.learnInferenceClassifications.WithLabelValues(canonical)); got != 0 {
+			t.Errorf("canonical %q counter = %v, want 0 after non-canonical-only inputs", canonical, got)
+		}
+	}
+}
+
+// TestRecordInferenceFloorFailure_DropsNonCanonical mirrors the
+// classification drop test for the floor-failure counter.
+func TestRecordInferenceFloorFailure_DropsNonCanonical(t *testing.T) {
+	t.Parallel()
+	m := New()
+
+	m.RecordInferenceFloorFailure(FloorFailure("requests"))
+	m.RecordInferenceFloorFailure(FloorFailure(""))
+	m.RecordInferenceFloorFailure(FloorFailure("Sessions")) // case-sensitive
+
+	if got := testutil.ToFloat64(m.learnInferenceFloorFailures.WithLabelValues("requests")); got != 0 {
+		t.Errorf("non-canonical floor leaked into counter: got %v", got)
+	}
+	for _, canonical := range []string{"sessions", "events", "windows"} {
+		if got := testutil.ToFloat64(m.learnInferenceFloorFailures.WithLabelValues(canonical)); got != 0 {
+			t.Errorf("canonical %q counter = %v, want 0 after non-canonical-only inputs", canonical, got)
+		}
+	}
+}
+
+// TestInferenceOutcome_AlignsWithConfidenceString documents the
+// cross-package wire-form contract: the metrics package's canonical
+// outcome strings must equal inference.Confidence.String() byte-for-byte.
+// We assert the literals here rather than importing inference (to avoid
+// a layering edge); inference's TestConfidence_String is the symmetric
+// guard on the other side.
+func TestInferenceOutcome_AlignsWithConfidenceString(t *testing.T) {
+	t.Parallel()
+	cases := map[InferenceOutcome]string{
+		OutcomeNeverConfirmed: "never_confirmed",
+		OutcomeBrittle:        "brittle",
+		OutcomeStable:         "stable",
+	}
+	for got, want := range cases {
+		if string(got) != want {
+			t.Errorf("InferenceOutcome %q wire form = %q, want %q (must match inference.Confidence.String())", want, string(got), want)
+		}
+	}
 }

--- a/internal/metrics/learn_test.go
+++ b/internal/metrics/learn_test.go
@@ -17,6 +17,8 @@ var expectedLearnMetricNames = []string{
 	"pipelock_learn_regulated_data_blocked_total",
 	"pipelock_learn_unclassified_actions_total",
 	"pipelock_learn_unclassified_rate",
+	"pipelock_learn_inference_classify_total",
+	"pipelock_learn_inference_floor_failures_total",
 }
 
 func TestRegisterLearnMetrics_RegistersAllFour(t *testing.T) {
@@ -31,6 +33,8 @@ func TestRegisterLearnMetrics_RegistersAllFour(t *testing.T) {
 	// for the Vec metrics so this touch can't be confused with real data.
 	m.RecordObservationEvent("registration_probe")
 	m.RecordRegulatedDataBlocked("registration_probe")
+	m.RecordInferenceClassification("registration_probe")
+	m.RecordInferenceFloorFailure("registration_probe")
 
 	families, err := m.Registry().Gather()
 	if err != nil {
@@ -154,4 +158,73 @@ func TestSetUnclassifiedRate_NilSafe(t *testing.T) {
 	t.Parallel()
 	var m *Metrics
 	m.SetUnclassifiedRate(0.5) // no panic
+}
+
+// TestRecordInferenceClassification_IncrementsByOutcome confirms each
+// canonical outcome label increments its own counter independently.
+// The wire labels (never_confirmed, brittle, stable) must agree with
+// inference.Confidence.String() so the metric is groupable in Grafana
+// against the recorder's emitted values byte-for-byte.
+func TestRecordInferenceClassification_IncrementsByOutcome(t *testing.T) {
+	t.Parallel()
+	m := New()
+
+	m.RecordInferenceClassification("stable")
+	m.RecordInferenceClassification("stable")
+	m.RecordInferenceClassification("stable")
+	m.RecordInferenceClassification("brittle")
+
+	if got := testutil.ToFloat64(m.learnInferenceClassifications.WithLabelValues("stable")); got != 3 {
+		t.Errorf("stable counter = %v, want 3", got)
+	}
+	if got := testutil.ToFloat64(m.learnInferenceClassifications.WithLabelValues("brittle")); got != 1 {
+		t.Errorf("brittle counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.learnInferenceClassifications.WithLabelValues("never_confirmed")); got != 0 {
+		t.Errorf("never_confirmed counter = %v, want 0 (untouched)", got)
+	}
+}
+
+// TestRecordInferenceClassification_NilSafe matches the existing nil-safe
+// pattern across the learn metrics. A nil *Metrics receiver is the legal
+// "metrics disabled" sentinel — the helper must not panic.
+func TestRecordInferenceClassification_NilSafe(t *testing.T) {
+	t.Parallel()
+	var m *Metrics
+	m.RecordInferenceClassification("stable") // no panic
+}
+
+// TestRecordInferenceFloorFailure_IncrementsByFloor confirms each canonical
+// floor label increments its own counter independently. The wire labels
+// (sessions, events, windows) match the YAML field-name suffixes the
+// operator sees in pipelock.yaml so the diagnostic counter and the
+// validator error message use the same vocabulary.
+func TestRecordInferenceFloorFailure_IncrementsByFloor(t *testing.T) {
+	t.Parallel()
+	m := New()
+
+	m.RecordInferenceFloorFailure("sessions")
+	m.RecordInferenceFloorFailure("sessions")
+	m.RecordInferenceFloorFailure("events")
+	m.RecordInferenceFloorFailure("windows")
+	m.RecordInferenceFloorFailure("windows")
+	m.RecordInferenceFloorFailure("windows")
+
+	if got := testutil.ToFloat64(m.learnInferenceFloorFailures.WithLabelValues("sessions")); got != 2 {
+		t.Errorf("sessions counter = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(m.learnInferenceFloorFailures.WithLabelValues("events")); got != 1 {
+		t.Errorf("events counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.learnInferenceFloorFailures.WithLabelValues("windows")); got != 3 {
+		t.Errorf("windows counter = %v, want 3", got)
+	}
+}
+
+// TestRecordInferenceFloorFailure_NilSafe matches the existing nil-safe
+// pattern.
+func TestRecordInferenceFloorFailure_NilSafe(t *testing.T) {
+	t.Parallel()
+	var m *Metrics
+	m.RecordInferenceFloorFailure("sessions") // no panic
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -102,10 +102,12 @@ type Metrics struct {
 	CaptureDropped prometheus.Counter
 
 	// Learn-and-lock observation pipeline (learn.go).
-	learnObservationEvents    *prometheus.CounterVec
-	learnRegulatedDataBlocked *prometheus.CounterVec
-	learnUnclassifiedActions  prometheus.Counter
-	learnUnclassifiedRate     prometheus.Gauge
+	learnObservationEvents        *prometheus.CounterVec
+	learnRegulatedDataBlocked     *prometheus.CounterVec
+	learnUnclassifiedActions      prometheus.Counter
+	learnUnclassifiedRate         prometheus.Gauge
+	learnInferenceClassifications *prometheus.CounterVec
+	learnInferenceFloorFailures   *prometheus.CounterVec
 
 	// Stats endpoint state (stats_handler.go).
 	mu                     sync.Mutex


### PR DESCRIPTION
## Summary

Adds the `internal/contract/inference` package: pure Go statistical primitives for classifying behavioral-rule confidence from recorded observation events. Wires the deployment-configurable surface (exposure floors) into config, and the operational surface (verdict and floor-failure histograms) into the metrics bundle. No runtime wiring yet; that lands in a follow-up alongside `pipelock learn compile`.

## What's in the package

- **`wilson.go`**: Wilson score interval lower and upper bound for binomial proportion confidence on small or skewed samples (Newcombe 1998 closed form). The 0.95 z-score is fixed for the production path so identical recorder data uses the same statistical contract across deployments; the alpha-parameterized signature stays for testability. `DefaultWilsonAlpha = 0.05` is a named package constant rather than a config field. The confidence level is part of the statistical contract, and making it deployment-configurable would let two installs infer different classifications from identical recorder data.

- **`opportunity.go`**: Conditional-opportunity denominator picker per the contract design's hierarchy table (host stability to sessions, path-family stability to host sessions, method stability to host/path-family events, header shape / arg schema to tool-endpoint calls, sequence n-gram to source-action windows). Strict per-load validation at the boundary; unknown level rejects with `ErrUnknownOpportunityLevel`, negative input rejects with `ErrNegativeOpportunityCount`.

- **`floors.go`**: Three exposure-floor gates (min_sessions, min_events, min_windows, defaults 5 / 20 / 3) plus the `Classify` composer that AND-composes Wilson plus floors into a `never_confirmed` / `brittle` / `stable` verdict. Floors are deployment-configurable (traffic volumes differ across deployments); thresholds (tau_brittle = 0.50, tau_stable = 0.85) are hardcoded. Any floor failure forces `never_confirmed` regardless of Wilson, proven by the 8-row floor-pass/fail by Wilson-stable matrix test.

- **`budgets.go`**: p99, p95, median, max, sample_count statistics for numeric rate and size budgets, with caller-selectable headroom (`DefaultHeadroomRate = 0.20`, `DefaultHeadroomSize = 0.50`). Nearest-rank percentile via integer arithmetic, keeping results deterministic without floating-point ceil-rounding edges. Empty input returns a zero-valued Budget (no panic). `ThinSample(minEvents)` flag for the review-UX badge.

## Config surface

Adds `learn.inference.floors.{min_sessions, min_events, min_windows}` to the existing `learn:` block.

- Missing or zero resolves to defaults applied at runtime via `inference.Floors.Resolved()`.
- Negative is rejected at config-load with a precise YAML field-path error.
- The config validator deliberately duplicates the inference package's `Floors.Validate()` so operators see `learn.inference.floors.min_sessions: -1: must be non-negative` instead of an API-level field name. Layering rationale documented inline.

## Metrics surface

Two new counters in the existing `internal/metrics/learn.go` bundle (no new file, per-feature bundling stays intact):

- `pipelock_learn_inference_classify_total{outcome}`: outcome is one of `never_confirmed`, `brittle`, `stable`. Powers the review-UX verdict histogram.
- `pipelock_learn_inference_floor_failures_total{floor}`: floor is one of `sessions`, `events`, `windows`. Diagnostic for which floor is the bottleneck on a deployment's data volume.

Nil-safe recorder helpers parallel to the existing observation-pipeline pattern.

## Policy-hash impact

Adding floors to the `Learn` config flows into the canonical policy hash. Floors are detection-relevant: they decide stable vs never_confirmed at compile time, so verifiers must observe the schema change to detect deployments that loosen the exposure gates. Both `goldenHashDefaults` and `goldenHashRichConfig` shift in lockstep with `Defaults()`. Deliberately hash-pinned so the verifier's authenticated state matches the contract.

## Coverage and tests

- 100% line coverage on every function in `internal/contract/inference/` (wilson, opportunity, floors, budgets); 18 of 18 functions at 100%.
- 100% on the new config validator (`validateLearnInferenceFloors`) and on every new metrics helper (`RecordInferenceClassification`, `RecordInferenceFloorFailure`).
- 16-corner-case Wilson test pack matching the design table to 3 decimal places, plus property tests for monotonicity, determinism over 1000 invocations, and complementary symmetry of upper/lower bounds.
- 8-row floor-pass/fail by Wilson-stable matrix proving floor failure overrides Wilson regardless of confidence.
- `p99 >= p95 >= median`, `max >= p99` properties verified across 5 different windows.

## Cross-build

Linux and Windows, default and enterprise build tags, all four green. Inference is pure Go math plus `slices` stdlib, no syscall surface.

## Out of scope

- Runtime wiring (the inference engine consuming live recorder events): follows in a later PR.
- `pipelock learn compile` end-to-end CLI: follows in a later PR.
- Path-family normalization and cardinality cap: follows in a later PR.
- The verifier `verify.py` is not extended; this PR does not emit signed artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added inference-based rule classification system with confidence levels (stable, brittle, never confirmed) to indicate rule reliability
  * Configurable exposure thresholds for sessions, events, and windows to control when rules are classified as stable
  
* **Chores**
  * Added new metrics to monitor rule classifications and exposure threshold failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->