### PR TITLE
feat(contract): path normalization with cardinality cap and operator pin/split

### DIFF
--- a/internal/cli/learn/helpers_test.go
+++ b/internal/cli/learn/helpers_test.go
@@ -4,10 +4,23 @@
 package learn
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
 )
+
+// goosWindows is the runtime.GOOS string for Windows. Extracted so the
+// symlink-skip predicate across multiple test files can share the
+// literal (goconst).
+const goosWindows = "windows"
 
 // These tests exercise low-level YAML helper functions directly so we
 // hit the defensive nil/empty branches that the canonical fixture
@@ -398,4 +411,317 @@ rules:
 	if len(pinned) != 3 {
 		t.Errorf("expected 3 entries (bare + existing + users), got %d", len(pinned))
 	}
+}
+
+// TestValidateSegmentLiteral_Grammar pins the closed grammar that both
+// pin --segment input and split-time YAML reads must satisfy. Each row
+// names exactly one rejection class so a future regression points at
+// the offending validator branch.
+func TestValidateSegmentLiteral_Grammar(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		in        string
+		wantOK    bool
+		wantSubst string // substring expected in the error if !wantOK
+	}{
+		{name: "happy_alpha", in: "users", wantOK: true},
+		{name: "happy_alphanumeric", in: "v1abc123", wantOK: true},
+		{name: "happy_dash_underscore_dot", in: "release-2026.04_29", wantOK: true},
+		{name: "rejects_empty", in: "", wantOK: false, wantSubst: "empty"},
+		{name: "rejects_path_separator_leading", in: "/admin", wantOK: false, wantSubst: "path separator"},
+		{name: "rejects_path_separator_embedded", in: "users/me", wantOK: false, wantSubst: "path separator"},
+		{name: "rejects_nul_byte", in: "abc\x00def", wantOK: false, wantSubst: "control"},
+		{name: "rejects_newline", in: "abc\ndef", wantOK: false, wantSubst: "control"},
+		{name: "rejects_carriage_return", in: "abc\rdef", wantOK: false, wantSubst: "control"},
+		{name: "rejects_tab", in: "abc\tdef", wantOK: false, wantSubst: "control"},
+		{name: "rejects_del", in: "abc\x7fdef", wantOK: false, wantSubst: "control"},
+		{name: "rejects_wildcard_star", in: "*", wantOK: false, wantSubst: "wildcard"},
+		{name: "rejects_wildcard_question", in: "ab?", wantOK: false, wantSubst: "wildcard"},
+		{name: "rejects_bracket_open", in: "ab[c", wantOK: false, wantSubst: "bracket"},
+		{name: "rejects_bracket_close", in: "ab]c", wantOK: false, wantSubst: "bracket"},
+		{name: "rejects_overlong", in: strings.Repeat("a", 257), wantOK: false, wantSubst: "exceeds"},
+		{name: "boundary_exactly_max_len", in: strings.Repeat("a", 256), wantOK: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateSegmentLiteral(tc.in)
+			if tc.wantOK {
+				if err != nil {
+					t.Fatalf("validateSegmentLiteral(%q) = %v, want nil", tc.in, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateSegmentLiteral(%q) = nil, want error", tc.in)
+			}
+			if !errors.Is(err, ErrInvalidSegment) {
+				t.Errorf("validateSegmentLiteral(%q): err not ErrInvalidSegment-wrapped: %v", tc.in, err)
+			}
+			if tc.wantSubst != "" && !strings.Contains(err.Error(), tc.wantSubst) {
+				t.Errorf("validateSegmentLiteral(%q): err %q lacks expected substring %q", tc.in, err, tc.wantSubst)
+			}
+		})
+	}
+}
+
+// TestPin_RejectsInvalidSegment proves the pin --segment input boundary
+// applies validateSegmentLiteral so an operator typo cannot poison the
+// candidate.
+func TestPin_RejectsInvalidSegment(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cand := filepath.Join(dir, "cand.yaml")
+	if err := os.WriteFile(cand, []byte(canonicalCandidate), 0o600); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		segment string
+	}{
+		{"path_separator", "/admin"},
+		{"wildcard", "*"},
+		{"control_char", "ab\x00cd"},
+		{"newline", "ab\ncd"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := pinCmd()
+			cmd.SetArgs([]string{"--candidate", cand, "--rule", "r-test-rule-001", "--segment", tc.segment})
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected ErrInvalidSegment for %q, got nil", tc.segment)
+			}
+			if !errors.Is(err, ErrInvalidSegment) {
+				t.Errorf("err not ErrInvalidSegment-wrapped: %v", err)
+			}
+		})
+	}
+}
+
+// TestLoadCandidate_RejectsSymlink proves the trust boundary on
+// candidate input: a symlink at the candidate path is rejected up
+// front rather than chased to its target.
+func TestLoadCandidate_RejectsSymlink(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == goosWindows {
+		t.Skip("symlink semantics differ on Windows; covered by Lstat regular-file branch")
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.yaml")
+	if err := os.WriteFile(target, []byte(canonicalCandidate), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(dir, "link.yaml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, _, err := loadCandidate(link)
+	if err == nil {
+		t.Fatalf("expected ErrInvalidCandidate on symlink, got nil")
+	}
+	if !errors.Is(err, ErrInvalidCandidate) {
+		t.Errorf("err not ErrInvalidCandidate-wrapped: %v", err)
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("err message lacks 'symlink': %v", err)
+	}
+}
+
+// TestLoadCandidate_RejectsNonRegular proves the regular-file gate by
+// pointing at a directory.
+func TestLoadCandidate_RejectsNonRegular(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	_, _, err := loadCandidate(dir)
+	if err == nil {
+		t.Fatalf("expected ErrInvalidCandidate on directory, got nil")
+	}
+	if !errors.Is(err, ErrInvalidCandidate) {
+		t.Errorf("err not ErrInvalidCandidate-wrapped: %v", err)
+	}
+	if !strings.Contains(err.Error(), "regular file") {
+		t.Errorf("err message lacks 'regular file': %v", err)
+	}
+}
+
+// TestResolveOut_RejectsSymlinkOut proves the trust boundary on
+// --out: an existing symlink at the destination is rejected before
+// the atomic rename runs.
+func TestResolveOut_RejectsSymlinkOut(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == goosWindows {
+		t.Skip("symlink semantics differ on Windows")
+	}
+
+	dir := t.TempDir()
+	cand := filepath.Join(dir, "cand.yaml")
+	if err := os.WriteFile(cand, []byte("hi\n"), 0o600); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+	target := filepath.Join(dir, "elsewhere.yaml")
+	if err := os.WriteFile(target, []byte("hi\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	out := filepath.Join(dir, "out.yaml")
+	if err := os.Symlink(target, out); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, err := resolveOut(cand, out)
+	if err == nil {
+		t.Fatalf("expected ErrInvalidCandidate on --out symlink, got nil")
+	}
+	if !errors.Is(err, ErrInvalidCandidate) {
+		t.Errorf("err not ErrInvalidCandidate-wrapped: %v", err)
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("err message lacks 'symlink': %v", err)
+	}
+}
+
+// TestResolveOut_AcceptsNonExistentOut proves the creation case: an
+// --out path that does not exist yet is fine; the atomic-write path
+// will create it without resolving any symlink.
+func TestResolveOut_AcceptsNonExistentOut(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cand := filepath.Join(dir, "cand.yaml")
+	out := filepath.Join(dir, "new.yaml")
+
+	got, err := resolveOut(cand, out)
+	if err != nil {
+		t.Fatalf("expected nil on non-existent --out, got %v", err)
+	}
+	if got != out {
+		t.Errorf("expected returned dest = %q, got %q", out, got)
+	}
+}
+
+// TestValidateRuleSegments_RejectsMaliciousYAML proves the YAML-side
+// boundary: a candidate carrying a path-separator literal in a
+// retained_segments value is rejected before any mutation runs.
+func TestValidateRuleSegments_RejectsMaliciousYAML(t *testing.T) {
+	t.Parallel()
+
+	const malicious = `---
+contract_version: v2.4
+rules:
+  - rule_id: r-test-rule-001
+    selector:
+      paths:
+        - value: /repos/*
+          normalization:
+            algorithm: frequency_weighted_entropy_v1
+            bucket: {host: api.example.com, method: GET, parent_prefix: /repos}
+            retained_segments:
+              - {index: 1, value: "users/me", reason: low_entropy_literal_segment}
+            collapsed_segments: []
+            pinned_segments: []
+`
+
+	dir := t.TempDir()
+	cand := filepath.Join(dir, "evil.yaml")
+	if err := os.WriteFile(cand, []byte(malicious), 0o600); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+
+	cmd := splitCmd()
+	cmd.SetArgs([]string{"--candidate", cand, "--rule", "r-test-rule-001"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected ErrInvalidSegment on malicious YAML, got nil")
+	}
+	if !errors.Is(err, ErrInvalidSegment) {
+		t.Errorf("err not ErrInvalidSegment-wrapped: %v", err)
+	}
+	if !strings.Contains(err.Error(), "path separator") {
+		t.Errorf("err message lacks 'path separator': %v", err)
+	}
+}
+
+// TestEmitAuditEvent_StructuredOnStderr proves both runners write a
+// JSON-formatted audit event to stderr alongside the human-readable
+// stdout summary. Asserts the required fields are present and that
+// the line is parseable JSON.
+func TestEmitAuditEvent_StructuredOnStderr(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cand := filepath.Join(dir, "cand.yaml")
+	if err := os.WriteFile(cand, []byte(canonicalCandidate), 0o600); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+
+	t.Run("split", func(t *testing.T) {
+		t.Parallel()
+		var stdout, stderr bytes.Buffer
+		cmd := splitCmd()
+		cmd.SetArgs([]string{"--candidate", cand, "--rule", "r-test-rule-001"})
+		cmd.SetOut(&stdout)
+		cmd.SetErr(&stderr)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("split: %v", err)
+		}
+		var ev auditEvent
+		if err := json.Unmarshal(bytes.TrimSpace(stderr.Bytes()), &ev); err != nil {
+			t.Fatalf("stderr line is not JSON: %v\n%s", err, stderr.String())
+		}
+		if ev.Event != "learn_split" {
+			t.Errorf("event = %q, want learn_split", ev.Event)
+		}
+		if ev.Rule != "r-test-rule-001" {
+			t.Errorf("rule = %q, want r-test-rule-001", ev.Rule)
+		}
+		if ev.Candidate != cand {
+			t.Errorf("candidate = %q, want %q", ev.Candidate, cand)
+		}
+		if ev.Dest != cand {
+			t.Errorf("dest = %q, want %q (in-place)", ev.Dest, cand)
+		}
+	})
+
+	t.Run("pin", func(t *testing.T) {
+		t.Parallel()
+		// Distinct candidate file so the parallel split test cannot race.
+		c2 := filepath.Join(dir, "cand-pin.yaml")
+		if err := os.WriteFile(c2, []byte(canonicalCandidate), 0o600); err != nil {
+			t.Fatalf("write candidate: %v", err)
+		}
+		var stdout, stderr bytes.Buffer
+		cmd := pinCmd()
+		cmd.SetArgs([]string{"--candidate", c2, "--rule", "r-test-rule-001", "--segment", "production"})
+		cmd.SetOut(&stdout)
+		cmd.SetErr(&stderr)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("pin: %v", err)
+		}
+		var ev auditEvent
+		if err := json.Unmarshal(bytes.TrimSpace(stderr.Bytes()), &ev); err != nil {
+			t.Fatalf("stderr line is not JSON: %v\n%s", err, stderr.String())
+		}
+		if ev.Event != "learn_pin" {
+			t.Errorf("event = %q, want learn_pin", ev.Event)
+		}
+		if ev.Segment != "production" {
+			t.Errorf("segment = %q, want production", ev.Segment)
+		}
+		if ev.NoOp {
+			t.Errorf("noop = true, want false (first pin)")
+		}
+	})
 }

--- a/internal/cli/learn/helpers_test.go
+++ b/internal/cli/learn/helpers_test.go
@@ -1,0 +1,401 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package learn
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// These tests exercise low-level YAML helper functions directly so we
+// hit the defensive nil/empty branches that the canonical fixture
+// can't reach (e.g. nil document, scalar where a mapping is expected).
+// They give the helpers ≥95% coverage without polluting the
+// integration tests with synthetic structural malformations.
+
+func TestDocumentRoot_Nil(t *testing.T) {
+	if got := documentRoot(nil); got != nil {
+		t.Errorf("expected nil for nil doc, got %v", got)
+	}
+}
+
+func TestDocumentRoot_EmptyDocument(t *testing.T) {
+	doc := &yaml.Node{Kind: yaml.DocumentNode}
+	if got := documentRoot(doc); got != nil {
+		t.Errorf("expected nil for empty document, got %v", got)
+	}
+}
+
+func TestDocumentRoot_NonDocumentNode(t *testing.T) {
+	mapping := &yaml.Node{Kind: yaml.MappingNode}
+	if got := documentRoot(mapping); got != mapping {
+		t.Errorf("expected pass-through for non-document node, got %v", got)
+	}
+}
+
+func TestMappingValue_NilNode(t *testing.T) {
+	if got := mappingValue(nil, "any"); got != nil {
+		t.Errorf("expected nil for nil node, got %v", got)
+	}
+}
+
+func TestMappingValue_NonMappingNode(t *testing.T) {
+	scalar := &yaml.Node{Kind: yaml.ScalarNode, Value: "bare"}
+	if got := mappingValue(scalar, "any"); got != nil {
+		t.Errorf("expected nil for scalar node, got %v", got)
+	}
+}
+
+func TestMappingValue_AbsentKey(t *testing.T) {
+	m := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "present"},
+			{Kind: yaml.ScalarNode, Value: "v"},
+		},
+	}
+	if got := mappingValue(m, "absent"); got != nil {
+		t.Errorf("expected nil for absent key, got %v", got)
+	}
+}
+
+func TestMappingScalar_AbsentReturnsEmpty(t *testing.T) {
+	m := &yaml.Node{Kind: yaml.MappingNode}
+	if got := mappingScalar(m, "absent"); got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestMappingScalar_NonScalarReturnsEmpty(t *testing.T) {
+	m := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "k"},
+			{Kind: yaml.SequenceNode}, // non-scalar value
+		},
+	}
+	if got := mappingScalar(m, "k"); got != "" {
+		t.Errorf("expected empty for non-scalar value, got %q", got)
+	}
+}
+
+func TestSetMappingScalar_NilSafe(t *testing.T) {
+	setMappingScalar(nil, "k", "v") // must not panic
+}
+
+func TestSetMappingScalar_NonMappingSafe(t *testing.T) {
+	setMappingScalar(&yaml.Node{Kind: yaml.ScalarNode}, "k", "v") // no-op
+}
+
+func TestSetMappingScalar_ReplacesExisting(t *testing.T) {
+	m := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "k"},
+			{Kind: yaml.ScalarNode, Value: "old"},
+		},
+	}
+	setMappingScalar(m, "k", "new")
+	if m.Content[1].Value != "new" {
+		t.Errorf("expected replaced value 'new', got %q", m.Content[1].Value)
+	}
+}
+
+func TestSetMappingScalar_AppendsNew(t *testing.T) {
+	m := &yaml.Node{Kind: yaml.MappingNode}
+	setMappingScalar(m, "k", "v")
+	if len(m.Content) != 2 {
+		t.Fatalf("expected 2 content entries after append, got %d", len(m.Content))
+	}
+	if m.Content[0].Value != "k" || m.Content[1].Value != "v" {
+		t.Errorf("expected appended k=v, got %q=%q", m.Content[0].Value, m.Content[1].Value)
+	}
+}
+
+func TestEnsureMappingSeq_CreatesWhenAbsent(t *testing.T) {
+	m := &yaml.Node{Kind: yaml.MappingNode}
+	seq := ensureMappingSeq(m, "k")
+	if seq == nil || seq.Kind != yaml.SequenceNode {
+		t.Errorf("expected new sequence node, got %v", seq)
+	}
+	if len(m.Content) != 2 {
+		t.Errorf("expected key+seq appended, got %d entries", len(m.Content))
+	}
+}
+
+func TestEnsureMappingSeq_ReplacesNonSequence(t *testing.T) {
+	m := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "k"},
+			{Kind: yaml.ScalarNode, Value: "scalar-was-here"},
+		},
+	}
+	seq := ensureMappingSeq(m, "k")
+	if seq.Kind != yaml.SequenceNode {
+		t.Errorf("expected upgraded to sequence, got kind=%v", seq.Kind)
+	}
+	if seq.Value != "" {
+		t.Errorf("expected scalar value cleared, got %q", seq.Value)
+	}
+}
+
+func TestEnsureMappingSeq_PassesThroughExistingSeq(t *testing.T) {
+	existing := &yaml.Node{Kind: yaml.SequenceNode}
+	m := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "k"},
+			existing,
+		},
+	}
+	seq := ensureMappingSeq(m, "k")
+	if seq != existing {
+		t.Errorf("expected pass-through of existing seq")
+	}
+}
+
+func TestNodeIntValue_NilReturnsFalse(t *testing.T) {
+	_, ok := nodeIntValue(nil)
+	if ok {
+		t.Errorf("expected ok=false for nil node")
+	}
+}
+
+func TestNodeIntValue_NonScalarReturnsFalse(t *testing.T) {
+	_, ok := nodeIntValue(&yaml.Node{Kind: yaml.SequenceNode})
+	if ok {
+		t.Errorf("expected ok=false for non-scalar")
+	}
+}
+
+func TestNodeIntValue_NonNumericReturnsFalse(t *testing.T) {
+	_, ok := nodeIntValue(&yaml.Node{Kind: yaml.ScalarNode, Value: "not-a-number"})
+	if ok {
+		t.Errorf("expected ok=false for non-numeric scalar")
+	}
+}
+
+func TestNodeIntValue_HappyPath(t *testing.T) {
+	v, ok := nodeIntValue(&yaml.Node{Kind: yaml.ScalarNode, Value: "42"})
+	if !ok || v != 42 {
+		t.Errorf("expected (42,true), got (%d,%v)", v, ok)
+	}
+}
+
+// TestFindRule_NonMappingRuleEntry confirms findRule skips a sequence
+// entry that isn't a mapping (e.g. a stray scalar in `rules:`) without
+// panicking.
+func TestFindRule_NonMappingRuleEntry(t *testing.T) {
+	body := `---
+rules:
+  - just-a-string-not-a-mapping
+  - rule_id: r-test-001
+    selector:
+      paths: []
+`
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(body), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	rule, err := findRule(&doc, "r-test-001")
+	if err != nil {
+		t.Fatalf("expected to find rule despite stray scalar, got %v", err)
+	}
+	if rule == nil {
+		t.Fatal("expected non-nil rule")
+	}
+}
+
+// TestSplitRule_NonMappingPathEntry confirms splitRule skips a stray
+// scalar in `paths:` without panicking.
+func TestSplitRule_NonMappingPathEntry(t *testing.T) {
+	body := `---
+rules:
+  - rule_id: r-test-001
+    selector:
+      paths:
+        - just-a-string
+        - value: /a/*
+          normalization:
+            collapsed_segments:
+              - index: 2
+                reason: high_entropy_identifier_segment
+            retained_segments: []
+`
+	cand := writeTestCandidate(t, body)
+
+	stdout, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", "r-test-001",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if stdout == "" {
+		t.Errorf("expected non-empty stdout")
+	}
+}
+
+// TestSplitNormalization_NonMappingCollapsedEntry confirms a stray
+// scalar inside collapsed_segments is preserved (kept) rather than
+// lost or causing a panic.
+func TestSplitNormalization_NonMappingCollapsedEntry(t *testing.T) {
+	body := `---
+rules:
+  - rule_id: r-test-001
+    selector:
+      paths:
+        - value: /a/*/*
+          normalization:
+            collapsed_segments:
+              - bare-string
+              - index: 2
+                reason: high_entropy_identifier_segment
+            retained_segments: []
+`
+	cand := writeTestCandidate(t, body)
+
+	if _, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", "r-test-001",
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	parsed := loadParsed(t, cand)
+	rule := findRuleNode(parsed, "r-test-001")
+	norm := firstNorm(rule)
+	collapsed, _ := norm["collapsed_segments"].([]interface{})
+	// The bare string survives the demotion; mapping entry got moved.
+	if len(collapsed) != 1 {
+		t.Errorf("expected 1 collapsed entry kept (the bare string), got %d", len(collapsed))
+	}
+}
+
+// TestPinRule_NonMappingPathEntry confirms a stray scalar in paths
+// doesn't cause pin to crash.
+func TestPinRule_NonMappingPathEntry(t *testing.T) {
+	body := `---
+rules:
+  - rule_id: r-test-001
+    selector:
+      paths:
+        - just-a-string
+        - value: /a/*
+          normalization:
+            collapsed_segments: []
+            retained_segments: []
+`
+	cand := writeTestCandidate(t, body)
+
+	if _, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", "r-test-001",
+		"--segment", "users",
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+}
+
+// TestLoadCandidate_EmptyPath exercises the empty-string short
+// circuit in loadCandidate. The cobra MarkFlagRequired catches
+// "missing flag" but a caller passing the empty string directly
+// (or the flag value being explicitly "") should still reject.
+func TestLoadCandidate_EmptyPath(t *testing.T) {
+	_, _, err := loadCandidate("")
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+// TestFindRule_NoTopLevelMapping confirms the document-without-root
+// branch of findRule.
+func TestFindRule_NoTopLevelMapping(t *testing.T) {
+	// Document with a sequence at the root, no mapping.
+	doc := &yaml.Node{
+		Kind:    yaml.DocumentNode,
+		Content: []*yaml.Node{{Kind: yaml.SequenceNode}},
+	}
+	_, err := findRule(doc, "any")
+	if err == nil {
+		t.Fatal("expected error for no top-level mapping")
+	}
+}
+
+// TestRebuildPathValue_NoNormalization confirms the "no
+// normalization block" early return in rebuildPathValue.
+func TestRebuildPathValue_NoNormalization(t *testing.T) {
+	p := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "value"},
+			{Kind: yaml.ScalarNode, Value: "/foo"},
+		},
+	}
+	rebuildPathValue(p) // must not panic
+}
+
+// TestRebuildPathValue_NoIndices confirms the "no indices observed"
+// early return when normalization has only segments without index.
+func TestRebuildPathValue_NoIndices(t *testing.T) {
+	body := `---
+rules:
+  - rule_id: r-no-idx
+    selector:
+      paths:
+        - value: /static
+          normalization:
+            collapsed_segments: []
+            retained_segments:
+              - value: static
+                reason: low_entropy_literal_segment
+`
+	cand := writeTestCandidate(t, body)
+	if _, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", "r-no-idx",
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+}
+
+// TestPinNormalization_NonMappingExistingEntry confirms a stray
+// scalar in pinned_segments is skipped rather than being treated as
+// the matching value.
+func TestPinNormalization_NonMappingExistingEntry(t *testing.T) {
+	body := `---
+rules:
+  - rule_id: r-test-001
+    selector:
+      paths:
+        - value: /a/*
+          normalization:
+            collapsed_segments: []
+            retained_segments: []
+            pinned_segments:
+              - bare-scalar
+              - value: existing
+                reason: operator_pin
+`
+	cand := writeTestCandidate(t, body)
+
+	if _, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", "r-test-001",
+		"--segment", "users",
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	parsed := loadParsed(t, cand)
+	rule := findRuleNode(parsed, "r-test-001")
+	norm := firstNorm(rule)
+	pinned, _ := norm["pinned_segments"].([]interface{})
+	// bare-scalar kept, existing kept, users added.
+	if len(pinned) != 3 {
+		t.Errorf("expected 3 entries (bare + existing + users), got %d", len(pinned))
+	}
+}

--- a/internal/cli/learn/learn.go
+++ b/internal/cli/learn/learn.go
@@ -1,13 +1,21 @@
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0
 
-// Package learn provides the `pipelock learn` command tree for the v2.4
-// learn-and-lock observation pipeline. The `observe` subverb runs the
+// Package learn provides the `pipelock learn` command tree for the
+// contract-compile observation pipeline. The `observe` subverb runs the
 // proxy in capture mode and writes a hash-chained recorder JSONL stream
 // to the configured capture directory; entries carry an event_kind
 // classifier that the downstream compile stage consumes. The privacy
 // enforcer surface lives in internal/contract/privacy and is structural
 // plumbing for the next phase, not active enforcement at observe time.
+//
+// `split` and `pin` are the operator-affordance subverbs that mutate a
+// candidate contract YAML before ratification. `split` demotes a
+// collapsed normalization segment back into its literal values;
+// `pin` adds a per-rule reserved literal so subsequent recompiles
+// cannot collapse it. Both operate at the yaml.Node level to preserve
+// formatting and comments, both write atomically, and both are
+// idempotent.
 //
 // Future commits add `compile`, `review`, `shadow`, `ratify`, `forget`,
 // `promote`, and `rollback` subverbs as the corresponding pipeline
@@ -21,15 +29,21 @@ import "github.com/spf13/cobra"
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "learn",
-		Short: "Run the learn-and-lock observation pipeline",
-		Long: `Learn-and-lock pipeline.
+		Short: "Run the contract-compile observation pipeline",
+		Long: `Contract-compile observation and operator-affordance commands.
 
-Phase 1 (observe): pipelock learn observe --capture-dir <dir>
-  Runs the proxy in capture mode with the learn observation pipeline
+Observe: pipelock learn observe --capture-dir <dir>
+  Runs the proxy in capture mode with the observation pipeline
   enabled. Hash-chained recorder JSONL accumulates in <dir>; later
   pipeline stages compile a behavioral contract from the captured
-  evidence.`,
+  evidence.
+
+Operator affordances (mutate candidate YAML before ratification):
+  pipelock learn split --candidate <path> --rule <rule_id> [--index N] [--out <path>]
+  pipelock learn pin   --candidate <path> --rule <rule_id> --segment <value> [--out <path>]`,
 	}
 	cmd.AddCommand(observeCmd())
+	cmd.AddCommand(splitCmd())
+	cmd.AddCommand(pinCmd())
 	return cmd
 }

--- a/internal/cli/learn/nofollow_unix.go
+++ b/internal/cli/learn/nofollow_unix.go
@@ -1,0 +1,18 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package learn
+
+import "syscall"
+
+// noFollowFlag is OR'd into os.OpenFile flags so the kernel refuses to
+// resolve the final path component if it is a symlink. Closes the
+// stat-then-open TOCTOU window after Lstat has already rejected
+// directory-entry-level symlinks.
+const noFollowFlag = syscall.O_NOFOLLOW
+
+// errELOOP is the sentinel returned by openat(2) when O_NOFOLLOW catches
+// a symlink raced into place between Lstat and Open.
+var errELOOP error = syscall.ELOOP

--- a/internal/cli/learn/nofollow_windows.go
+++ b/internal/cli/learn/nofollow_windows.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package learn
+
+import "errors"
+
+// noFollowFlag is zero on Windows: O_NOFOLLOW is not part of the Win32
+// open API, and the symlink semantics differ (Windows resolves reparse
+// points at a different layer). The Lstat-level rejection in
+// safeReadCandidate still runs and is the primary defense; we accept
+// the loss of the post-open re-check here.
+const noFollowFlag = 0
+
+// errELOOP is an unreachable sentinel on Windows. The Lstat path rejects
+// reparse points before Open is called, so this errors.Is branch never
+// fires. Defined so the Unix and Windows files share an identifier set.
+var errELOOP = errors.New("ELOOP-not-supported-on-windows")

--- a/internal/cli/learn/observe.go
+++ b/internal/cli/learn/observe.go
@@ -65,8 +65,8 @@ func observeCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "observe",
-		Short: "Run the proxy in observation mode for learn-and-lock",
-		Long: `Run the proxy in observation mode for the learn-and-lock pipeline.
+		Short: "Run the proxy in observation mode for contract compile",
+		Long: `Run the proxy in observation mode for the contract-compile pipeline.
 
 The proxy listens for traffic, scans it through the normal pipeline, and
 writes hash-chained recorder JSONL evidence into --capture-dir. Each entry

--- a/internal/cli/learn/pin.go
+++ b/internal/cli/learn/pin.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package learn
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// pinCmd returns the `pipelock learn pin` subcommand. It rewrites a
+// candidate contract YAML to add a per-rule pinned segment, ensuring
+// that subsequent recompile passes treat the literal value as
+// reserved-equivalent for that rule. Idempotent: pinning the same
+// (rule, segment) twice has no effect after the first.
+//
+// Trust model and atomic-write semantics are identical to splitCmd:
+// see split.go loadCandidate / writeCandidate.
+//
+// Usage:
+//
+//	pipelock learn pin --candidate <path> --rule <rule_id> --segment <value> [--out <path>]
+func pinCmd() *cobra.Command {
+	var (
+		candidatePath string
+		ruleID        string
+		segment       string
+		outPath       string
+	)
+	cmd := &cobra.Command{
+		Use:   "pin",
+		Short: "Pin a literal segment value as reserved for a candidate rule",
+		Long: `Operator affordance: add a pinned segment to a candidate
+contract rule. Pinned segments behave like the canonical reserved
+blocklist (admin/auth/...) but are scoped to the rule. Subsequent
+compile passes will not collapse a pinned literal regardless of
+entropy. Use this to lock in a path family the algorithm should keep
+distinct on every recompile.
+
+The command is idempotent and writes atomically (temp file + rename).
+Pinning is value-keyed: the same literal applies to any segment
+position where it occurs in the rule's paths.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runPin(cmd, candidatePath, ruleID, segment, outPath)
+		},
+	}
+	cmd.Flags().StringVar(&candidatePath, "candidate", "", "path to candidate YAML (required, absolute)")
+	cmd.Flags().StringVar(&ruleID, "rule", "", "rule_id to pin within (required)")
+	cmd.Flags().StringVar(&segment, "segment", "", "literal segment value to pin (required)")
+	cmd.Flags().StringVar(&outPath, "out", "", "output path; empty = rewrite candidate in place")
+	_ = cmd.MarkFlagRequired("candidate")
+	_ = cmd.MarkFlagRequired("rule")
+	_ = cmd.MarkFlagRequired("segment")
+	return cmd
+}
+
+// runPin reads the candidate YAML at candidatePath, finds the rule
+// matching ruleID, appends a pinned segment with reason=operator_pin
+// across every path's normalization block (idempotent per path), and
+// writes the result back atomically. If outPath is non-empty, the
+// result is written there and candidatePath is left untouched.
+//
+// Pinning is value-keyed (no `index:` field on the entry) so the
+// compile pipeline can reserve the literal regardless of which
+// position it appears in. This matches how the canonical reserved
+// list (admin/auth/login/...) is consulted.
+func runPin(cmd *cobra.Command, candidatePath, ruleID, segment, outPath string) error {
+	trimmed := strings.TrimSpace(segment)
+	if trimmed == "" {
+		return fmt.Errorf("learn pin: %w", ErrEmptySegment)
+	}
+
+	cleanCandidate, doc, err := loadCandidate(candidatePath)
+	if err != nil {
+		return err
+	}
+
+	rule, err := findRule(doc, ruleID)
+	if err != nil {
+		return fmt.Errorf("learn pin: %w", err)
+	}
+
+	added := pinRule(rule, trimmed)
+
+	dest, err := resolveOut(cleanCandidate, outPath)
+	if err != nil {
+		return err
+	}
+	if err := writeCandidate(dest, doc); err != nil {
+		return err
+	}
+
+	if added == 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"pin: rule %s, segment %q already pinned, no-op (written to %s)\n",
+			ruleID, trimmed, dest)
+		return nil
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+		"pin: rule %s, segment %q pinned, written to %s\n",
+		ruleID, trimmed, dest)
+	return nil
+}
+
+// pinRule appends a pinned-segments entry per path normalization
+// block, skipping blocks where the segment value already exists in
+// pinned_segments. Returns the number of normalization blocks that
+// received a new pin (0 when fully idempotent across the rule).
+func pinRule(rule *yaml.Node, segment string) int {
+	selector := mappingValue(rule, "selector")
+	if selector == nil {
+		return 0
+	}
+	paths := mappingValue(selector, "paths")
+	if paths == nil || paths.Kind != yaml.SequenceNode {
+		return 0
+	}
+
+	added := 0
+	for _, p := range paths.Content {
+		if p.Kind != yaml.MappingNode {
+			continue
+		}
+		norm := mappingValue(p, "normalization")
+		if norm == nil {
+			continue
+		}
+		if pinNormalization(norm, segment) {
+			added++
+		}
+	}
+	return added
+}
+
+// pinNormalization appends {value, reason} to pinned_segments unless
+// segment is already present. Returns true if a new entry was added.
+//
+// Existing entries are matched by their `value:` scalar, so adding a
+// pin twice with the same segment is a no-op even if the previous
+// entry's other fields differ.
+func pinNormalization(norm *yaml.Node, segment string) bool {
+	pinned := ensureMappingSeq(norm, "pinned_segments")
+	for _, entry := range pinned.Content {
+		if entry.Kind != yaml.MappingNode {
+			continue
+		}
+		if mappingScalar(entry, "value") == segment {
+			return false
+		}
+	}
+	entry := newPinEntry(segment)
+	pinned.Content = append(pinned.Content, entry)
+	return true
+}
+
+// newPinEntry constructs a pinned_segments YAML entry for the given
+// literal value. The entry has no `index` field on purpose: pin is
+// value-keyed and reserves the literal across any segment position.
+func newPinEntry(segment string) *yaml.Node {
+	return &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "value"},
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: segment},
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "reason"},
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: reasonOperatorPin},
+		},
+	}
+}

--- a/internal/cli/learn/pin.go
+++ b/internal/cli/learn/pin.go
@@ -73,6 +73,13 @@ func runPin(cmd *cobra.Command, candidatePath, ruleID, segment, outPath string) 
 	if trimmed == "" {
 		return fmt.Errorf("learn pin: %w", ErrEmptySegment)
 	}
+	// Apply the same grammar that split-side validateRuleSegments
+	// enforces on YAML literals so CLI input and YAML-carried values
+	// share one rejection surface. Catches operator typos like passing
+	// "/admin" or "*" before the value reaches the candidate file.
+	if err := validateSegmentLiteral(trimmed); err != nil {
+		return fmt.Errorf("learn pin: %w", err)
+	}
 
 	cleanCandidate, doc, err := loadCandidate(candidatePath)
 	if err != nil {
@@ -81,6 +88,10 @@ func runPin(cmd *cobra.Command, candidatePath, ruleID, segment, outPath string) 
 
 	rule, err := findRule(doc, ruleID)
 	if err != nil {
+		return fmt.Errorf("learn pin: %w", err)
+	}
+
+	if err := validateRuleSegments(rule); err != nil {
 		return fmt.Errorf("learn pin: %w", err)
 	}
 
@@ -93,6 +104,16 @@ func runPin(cmd *cobra.Command, candidatePath, ruleID, segment, outPath string) 
 	if err := writeCandidate(dest, doc); err != nil {
 		return err
 	}
+
+	emitAuditEvent(cmd, auditEvent{
+		Event:           "learn_pin",
+		Candidate:       cleanCandidate,
+		Dest:            dest,
+		Rule:            ruleID,
+		Segment:         trimmed,
+		SegmentsChanged: added,
+		NoOp:            added == 0,
+	})
 
 	if added == 0 {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(),

--- a/internal/cli/learn/pin_test.go
+++ b/internal/cli/learn/pin_test.go
@@ -155,7 +155,7 @@ func TestPin_RejectsMissingRule(t *testing.T) {
 }
 
 func TestPin_AtomicWrite_OnFailure(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		t.Skip("read-only directory semantics differ on Windows")
 	}
 	if os.Geteuid() == 0 {

--- a/internal/cli/learn/pin_test.go
+++ b/internal/cli/learn/pin_test.go
@@ -1,0 +1,459 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package learn
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// testPinSegment is the canonical literal used for pinning across the
+// pin tests. Extracted to satisfy goconst.
+const testPinSegment = "users"
+
+// runPinCobra executes the pin subcommand with the given args against
+// fresh in-memory stdout/stderr buffers and returns (stdout, err).
+func runPinCobra(t *testing.T, args []string) (string, error) {
+	t.Helper()
+	cmd := pinCmd()
+	var stdout strings.Builder
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&strings.Builder{})
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return stdout.String(), err
+}
+
+// pinnedValues returns the list of pinned segment values on the first
+// path of the rule.
+func pinnedValues(t *testing.T, parsed map[string]interface{}, ruleID string) []string {
+	t.Helper()
+	rule := findRuleNode(parsed, ruleID)
+	if rule == nil {
+		return nil
+	}
+	norm := firstNorm(rule)
+	if norm == nil {
+		return nil
+	}
+	pinned, ok := norm["pinned_segments"].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(pinned))
+	for _, e := range pinned {
+		em, _ := e.(map[string]interface{})
+		v, _ := em["value"].(string)
+		out = append(out, v)
+	}
+	return out
+}
+
+func TestPin_HappyPath_AddsPin(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	stdout, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--segment", testPinSegment,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stdout, "pinned") {
+		t.Errorf("expected 'pinned' in stdout, got %q", stdout)
+	}
+
+	parsed := loadParsed(t, cand)
+	got := pinnedValues(t, parsed, testRuleID)
+	if len(got) != 1 || got[0] != testPinSegment {
+		t.Errorf("expected pinned_segments=[users], got %v", got)
+	}
+}
+
+func TestPin_Idempotent(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	if _, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--segment", testPinSegment,
+	}); err != nil {
+		t.Fatalf("first pin: %v", err)
+	}
+
+	stdout, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--segment", testPinSegment,
+	})
+	if err != nil {
+		t.Fatalf("second pin: %v", err)
+	}
+	if !strings.Contains(stdout, "already pinned") {
+		t.Errorf("expected 'already pinned' note, got %q", stdout)
+	}
+
+	parsed := loadParsed(t, cand)
+	got := pinnedValues(t, parsed, testRuleID)
+	if len(got) != 1 {
+		t.Errorf("expected 1 pinned entry after duplicate pin, got %v", got)
+	}
+}
+
+func TestPin_PreservesExistingPins(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	if _, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testOtherRule,
+		"--segment", "auth",
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	parsed := loadParsed(t, cand)
+	got := pinnedValues(t, parsed, testOtherRule)
+	// Original fixture has "existing-pin"; we added "auth".
+	if len(got) != 2 {
+		t.Fatalf("expected 2 pinned entries, got %d (%v)", len(got), got)
+	}
+	hasExisting := false
+	hasAuth := false
+	for _, v := range got {
+		switch v {
+		case "existing-pin":
+			hasExisting = true
+		case "auth":
+			hasAuth = true
+		}
+	}
+	if !hasExisting || !hasAuth {
+		t.Errorf("expected both existing-pin and auth, got %v", got)
+	}
+}
+
+func TestPin_RejectsMissingRule(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	_, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", "r-does-not-exist",
+		"--segment", testPinSegment,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing rule")
+	}
+	if !errors.Is(err, ErrRuleNotFound) {
+		t.Errorf("expected ErrRuleNotFound, got %v", err)
+	}
+}
+
+func TestPin_AtomicWrite_OnFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("read-only directory semantics differ on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 0o500 doesn't restrict writes")
+	}
+
+	cand := writeTestCandidate(t, canonicalCandidate)
+	original, err := os.ReadFile(filepath.Clean(cand))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	dir := filepath.Dir(cand)
+	if err := os.Chmod(dir, 0o500); err != nil { //nolint:gosec // test: intentionally restrictive perms
+		t.Fatalf("chmod dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) }) //nolint:gosec // test: restore dir permissions for cleanup
+
+	_, err = runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--segment", testPinSegment,
+	})
+	if err == nil {
+		t.Fatal("expected error when write target is read-only")
+	}
+
+	if err := os.Chmod(dir, 0o700); err != nil { //nolint:gosec // test: restore dir permissions
+		t.Fatalf("chmod back: %v", err)
+	}
+	after, err := os.ReadFile(filepath.Clean(cand))
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if string(original) != string(after) {
+		t.Errorf("candidate was mutated despite write failure")
+	}
+}
+
+func TestPin_OutFlag_WritesElsewhere(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+	original, err := os.ReadFile(filepath.Clean(cand))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	outDir := t.TempDir()
+	outPath := filepath.Join(outDir, "pin-output.yaml")
+
+	_, err = runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--segment", testPinSegment,
+		"--out", outPath,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if _, err := os.Stat(outPath); err != nil {
+		t.Errorf("expected --out file to exist: %v", err)
+	}
+
+	after, err := os.ReadFile(filepath.Clean(cand))
+	if err != nil {
+		t.Fatalf("read original: %v", err)
+	}
+	if string(original) != string(after) {
+		t.Errorf("candidate file should be unchanged when --out is set")
+	}
+
+	parsed := loadParsed(t, outPath)
+	got := pinnedValues(t, parsed, testRuleID)
+	if len(got) != 1 || got[0] != testPinSegment {
+		t.Errorf("expected pinned_segments=[users] in --out file, got %v", got)
+	}
+}
+
+func TestPin_InvalidYAML_Rejects(t *testing.T) {
+	dir := t.TempDir()
+	cand := filepath.Join(dir, testFile)
+	if err := os.WriteFile(cand, []byte("not: valid: yaml: nope:::"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--segment", testPinSegment,
+	})
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !errors.Is(err, ErrInvalidCandidate) {
+		t.Errorf("expected ErrInvalidCandidate, got %v", err)
+	}
+}
+
+func TestPin_EmptySegmentRejects(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	_, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--segment", "   ",
+	})
+	if err == nil {
+		t.Fatal("expected error for whitespace-only segment")
+	}
+	if !errors.Is(err, ErrEmptySegment) {
+		t.Errorf("expected ErrEmptySegment, got %v", err)
+	}
+}
+
+func TestPin_RejectsRelativeCandidate(t *testing.T) {
+	_, err := runPinCobra(t, []string{
+		"--candidate", "relative/path.yaml",
+		"--rule", testRuleID,
+		"--segment", testPinSegment,
+	})
+	if err == nil {
+		t.Fatal("expected error for relative candidate path")
+	}
+	if !errors.Is(err, ErrInvalidCandidate) {
+		t.Errorf("expected ErrInvalidCandidate for relative path, got %v", err)
+	}
+}
+
+func TestPin_RejectsRelativeOut(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	_, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--segment", testPinSegment,
+		"--out", "relative.yaml",
+	})
+	if err == nil {
+		t.Fatal("expected error for relative --out")
+	}
+	if !errors.Is(err, ErrInvalidCandidate) {
+		t.Errorf("expected ErrInvalidCandidate for relative --out, got %v", err)
+	}
+}
+
+func TestPin_HelpText(t *testing.T) {
+	cmd := pinCmd()
+	if !strings.Contains(cmd.Long, "Pinned segments") {
+		t.Errorf("pin Long should describe pinned semantics; got %q", cmd.Long)
+	}
+	if !strings.Contains(cmd.Long, "atomic") {
+		t.Errorf("pin Long should mention atomic write; got %q", cmd.Long)
+	}
+}
+
+func TestPin_RejectsPositionalArgs(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	_, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--segment", testPinSegment,
+		"stray",
+	})
+	if err == nil {
+		t.Fatal("expected error for stray positional argument")
+	}
+}
+
+func TestPin_NoRulesSection(t *testing.T) {
+	dir := t.TempDir()
+	cand := filepath.Join(dir, testFile)
+	if err := os.WriteFile(cand, []byte("contract_version: v2.4\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--segment", testPinSegment,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing rules section")
+	}
+	if !errors.Is(err, ErrInvalidCandidate) {
+		t.Errorf("expected ErrInvalidCandidate, got %v", err)
+	}
+}
+
+func TestPin_RuleWithoutSelector(t *testing.T) {
+	body := `---
+rules:
+  - rule_id: r-test-noselector
+`
+	cand := writeTestCandidate(t, body)
+
+	stdout, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", "r-test-noselector",
+		"--segment", testPinSegment,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stdout, "already pinned") {
+		t.Errorf("expected idempotent no-op note for no-selector rule, got %q", stdout)
+	}
+}
+
+func TestPin_RejectsNonexistentCandidate(t *testing.T) {
+	_, err := runPinCobra(t, []string{
+		"--candidate", "/nonexistent/path/candidate.yaml",
+		"--rule", testRuleID,
+		"--segment", testPinSegment,
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent candidate")
+	}
+	if !errors.Is(err, ErrInvalidCandidate) {
+		t.Errorf("expected ErrInvalidCandidate, got %v", err)
+	}
+}
+
+func TestPin_NormalizationWithoutPinnedSegments(t *testing.T) {
+	body := `---
+rules:
+  - rule_id: r-test-no-pinned
+    selector:
+      paths:
+        - value: /a/*
+          normalization:
+            collapsed_segments:
+              - index: 2
+                reason: high_entropy_identifier_segment
+            retained_segments:
+              - index: 1
+                value: a
+                reason: low_entropy_literal_segment
+`
+	cand := writeTestCandidate(t, body)
+
+	if _, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", "r-test-no-pinned",
+		"--segment", testPinSegment,
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	parsed := loadParsed(t, cand)
+	got := pinnedValues(t, parsed, "r-test-no-pinned")
+	if len(got) != 1 || got[0] != testPinSegment {
+		t.Errorf("expected new pinned_segments=[users], got %v", got)
+	}
+}
+
+func TestPin_RequiredFlagsEnforced(t *testing.T) {
+	// Missing all required flags: cobra should fail.
+	_, err := runPinCobra(t, []string{})
+	if err == nil {
+		t.Fatal("expected error for missing required flags")
+	}
+}
+
+func TestPin_OutputPermissionsSecure(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+	if _, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--segment", testPinSegment,
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	st, err := os.Stat(cand)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	mode := st.Mode().Perm()
+	if mode&0o077 != 0 {
+		t.Errorf("output perms %#o leak group/other access; expected 0o600 floor", mode)
+	}
+}
+
+func TestPin_TrimWhitespaceFromSegment(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	if _, err := runPinCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--segment", "  users  ",
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	parsed := loadParsed(t, cand)
+	got := pinnedValues(t, parsed, testRuleID)
+	if len(got) != 1 || got[0] != testPinSegment {
+		t.Errorf("expected trimmed segment 'users', got %v", got)
+	}
+}

--- a/internal/cli/learn/split.go
+++ b/internal/cli/learn/split.go
@@ -1,0 +1,526 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package learn
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+)
+
+// Sentinel errors returned by the split / pin operator-affordance
+// commands. Tests assert via errors.Is.
+var (
+	// ErrRuleNotFound is returned when the requested rule_id is absent
+	// from the candidate document.
+	ErrRuleNotFound = errors.New("learn: rule not found in candidate")
+
+	// ErrCollapsedSegmentNotFound is returned when --index targets a
+	// segment that is not present in the rule's collapsed_segments
+	// list. Returned by split only.
+	ErrCollapsedSegmentNotFound = errors.New("learn: collapsed segment not found")
+
+	// ErrInvalidCandidate is returned when the candidate file cannot be
+	// read or parsed as YAML, or has no rules to mutate.
+	ErrInvalidCandidate = errors.New("learn: invalid candidate file")
+
+	// ErrEmptySegment is returned when --segment is empty after
+	// trimming. Cobra's MarkFlagRequired only catches "flag missing",
+	// not "flag value is empty string", so we enforce non-empty
+	// explicitly.
+	ErrEmptySegment = errors.New("learn: pin segment must be non-empty")
+)
+
+// reasonOperatorSplit / reasonOperatorPin label segments that an
+// operator manually demoted or pinned. The future compile pipeline
+// treats these as authoritative: a segment with reason=operator_split
+// is retained even if its entropy would otherwise collapse it; a
+// segment in pinned_segments is reserved-equivalent for the rule.
+const (
+	reasonOperatorSplit = "operator_split"
+	reasonOperatorPin   = "operator_pin"
+)
+
+// splitCmd returns the `pipelock learn split` subcommand. It rewrites
+// a candidate contract YAML to demote one or more collapsed segments
+// back into their constituent literal values, so the operator can
+// preserve a path family the algorithm wanted to wildcard. The command
+// is idempotent: splitting an already-literal segment is a no-op with
+// a clear stdout note.
+//
+// Trust model: candidate paths are operator-controlled. We require an
+// absolute path and `filepath.Clean` every input. The candidate file
+// is rewritten in place via atomic temp-file-then-rename, preserving
+// 0o600 permission floor.
+//
+// Usage:
+//
+//	pipelock learn split --candidate <path> --rule <rule_id> [--index N] [--out <path>]
+//
+// If --index is omitted (or 0), all collapsed segments for the rule
+// are split. If --out is omitted, the candidate file is rewritten in
+// place via atomic rename.
+func splitCmd() *cobra.Command {
+	var (
+		candidatePath string
+		ruleID        string
+		index         int
+		outPath       string
+	)
+	cmd := &cobra.Command{
+		Use:   "split",
+		Short: "Demote collapsed path segments back to literals before contract ratification",
+		Long: `Operator affordance: rewrite a candidate contract YAML so a
+collapsed normalization segment is restored as a literal value. Use this
+when the path-normalization algorithm collapsed a segment you wanted to
+keep distinct (e.g., a path that should stay /api/v1/users instead of
+collapsing to /api/v1/*).
+
+The command is idempotent and writes atomically (temp file + rename).
+The candidate is not signed or activated by this command; that is the
+job of pipelock learn ratify (future PR).`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSplit(cmd, candidatePath, ruleID, index, outPath)
+		},
+	}
+	cmd.Flags().StringVar(&candidatePath, "candidate", "", "path to candidate YAML (required, absolute)")
+	cmd.Flags().StringVar(&ruleID, "rule", "", "rule_id to split (required)")
+	cmd.Flags().IntVar(&index, "index", 0, "specific segment index to split; 0 = split all collapsed")
+	cmd.Flags().StringVar(&outPath, "out", "", "output path; empty = rewrite candidate in place")
+	_ = cmd.MarkFlagRequired("candidate")
+	_ = cmd.MarkFlagRequired("rule")
+	return cmd
+}
+
+// runSplit reads the candidate YAML at candidatePath, finds the rule
+// matching ruleID, demotes one or all collapsed segments back to
+// retained_segments with reason=operator_split, rebuilds the path
+// value strings, and writes back atomically. If outPath is non-empty,
+// the result is written there and candidatePath is left untouched.
+//
+// The rebuilt path value reflects the segment ledger after the split:
+// retained-by-index becomes the literal at that position, and any
+// segment still in collapsed_segments is rendered as `*`. Pinned
+// segments are joined by their (input-position) index when present,
+// otherwise treated as supplemental and not assigned a slot.
+func runSplit(cmd *cobra.Command, candidatePath, ruleID string, index int, outPath string) error {
+	cleanCandidate, doc, err := loadCandidate(candidatePath)
+	if err != nil {
+		return err
+	}
+
+	rule, err := findRule(doc, ruleID)
+	if err != nil {
+		return fmt.Errorf("learn split: %w", err)
+	}
+
+	moved, err := splitRule(rule, index)
+	if err != nil {
+		return fmt.Errorf("learn split: %w", err)
+	}
+
+	dest, err := resolveOut(cleanCandidate, outPath)
+	if err != nil {
+		return err
+	}
+	if err := writeCandidate(dest, doc); err != nil {
+		return err
+	}
+
+	if moved == 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"split: rule %s, no collapsed segments to demote, written to %s\n",
+			ruleID, dest)
+		return nil
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+		"split: rule %s, %d segments demoted, written to %s\n",
+		ruleID, moved, dest)
+	return nil
+}
+
+// loadCandidate cleans the path, validates it is absolute, reads the
+// file, and parses it as YAML. Returns the cleaned path and the parsed
+// document.
+//
+// Absolute-path validation is part of the trust boundary. A relative
+// candidate path is operator-controlled and could be interpreted
+// against a surprising cwd; reject up front rather than guess.
+func loadCandidate(path string) (string, *yaml.Node, error) {
+	if path == "" {
+		return "", nil, fmt.Errorf("%w: empty candidate path", ErrInvalidCandidate)
+	}
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) {
+		return "", nil, fmt.Errorf("%w: candidate path must be absolute, got %q",
+			ErrInvalidCandidate, path)
+	}
+
+	// G304: clean is filepath.Clean'd above. Operator-supplied path is
+	// the trust boundary; absolute-path requirement plus YAML parse
+	// failure-mode covers traversal: even if a symlink were chased, we
+	// only ever read+rewrite the linked file, never escape to anything
+	// the caller couldn't already write to.
+	data, err := os.ReadFile(clean)
+	if err != nil {
+		return "", nil, fmt.Errorf("read candidate: %w: %w", ErrInvalidCandidate, err)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return "", nil, fmt.Errorf("yaml parse: %w: %w", ErrInvalidCandidate, err)
+	}
+	if doc.Kind == 0 || (doc.Kind == yaml.DocumentNode && len(doc.Content) == 0) {
+		return "", nil, fmt.Errorf("%w: candidate is empty", ErrInvalidCandidate)
+	}
+	return clean, &doc, nil
+}
+
+// resolveOut returns the destination path for the rewrite. If outPath
+// is empty, the candidate is rewritten in place. Both paths are
+// cleaned and required to be absolute.
+func resolveOut(candidatePath, outPath string) (string, error) {
+	if outPath == "" {
+		return candidatePath, nil
+	}
+	clean := filepath.Clean(outPath)
+	if !filepath.IsAbs(clean) {
+		return "", fmt.Errorf("%w: --out must be absolute, got %q",
+			ErrInvalidCandidate, outPath)
+	}
+	return clean, nil
+}
+
+// writeCandidate marshals doc back to YAML and writes it to dest
+// atomically with 0o600 permission floor. Marshal failure is rare
+// (would mean the in-memory tree was corrupted); we surface it as
+// ErrInvalidCandidate.
+func writeCandidate(dest string, doc *yaml.Node) error {
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("yaml marshal: %w: %w", ErrInvalidCandidate, err)
+	}
+	if err := atomicfile.Write(dest, out, 0o600); err != nil {
+		return fmt.Errorf("learn: writing candidate: %w", err)
+	}
+	return nil
+}
+
+// findRule walks the candidate document looking for a rule with the
+// given rule_id. Returns the rule's mapping node so callers can mutate
+// in place. Returns ErrRuleNotFound if absent.
+//
+// Schema (subset of the candidate-contract YAML emitted by the future
+// compile pipeline):
+//
+//	rules:
+//	  - rule_id: r-...
+//	    selector:
+//	      paths: [...]
+func findRule(doc *yaml.Node, ruleID string) (*yaml.Node, error) {
+	root := documentRoot(doc)
+	if root == nil {
+		return nil, fmt.Errorf("%w: candidate has no top-level mapping", ErrInvalidCandidate)
+	}
+	rules := mappingValue(root, "rules")
+	if rules == nil || rules.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("%w: candidate has no rules sequence", ErrInvalidCandidate)
+	}
+	for _, rule := range rules.Content {
+		if rule.Kind != yaml.MappingNode {
+			continue
+		}
+		idNode := mappingValue(rule, "rule_id")
+		if idNode != nil && idNode.Value == ruleID {
+			return rule, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: %q", ErrRuleNotFound, ruleID)
+}
+
+// splitRule moves collapsed segments to retained for every path in
+// the rule. If index is 0, all collapsed segments move; otherwise
+// only the entry whose `index:` field matches. Returns the count of
+// segments moved across all paths, and ErrCollapsedSegmentNotFound if
+// a specific index was requested but not found anywhere.
+func splitRule(rule *yaml.Node, index int) (int, error) {
+	selector := mappingValue(rule, "selector")
+	if selector == nil {
+		return 0, nil
+	}
+	paths := mappingValue(selector, "paths")
+	if paths == nil || paths.Kind != yaml.SequenceNode {
+		return 0, nil
+	}
+
+	moved := 0
+	specificFound := false
+	for _, p := range paths.Content {
+		if p.Kind != yaml.MappingNode {
+			continue
+		}
+		norm := mappingValue(p, "normalization")
+		if norm == nil {
+			continue
+		}
+		n, found := splitNormalization(norm, index)
+		moved += n
+		if found {
+			specificFound = true
+		}
+		// Rebuild the path's `value:` to mirror the new segment
+		// ledger, keeping wildcards for whatever stays collapsed.
+		rebuildPathValue(p)
+	}
+	if index > 0 && !specificFound {
+		return moved, fmt.Errorf("%w: index=%d", ErrCollapsedSegmentNotFound, index)
+	}
+	return moved, nil
+}
+
+// splitNormalization moves matching collapsed entries to the retained
+// list with reason=operator_split. Returns (movedCount, foundSpecific).
+// foundSpecific is true if a specific index was requested AND matched
+// in this normalization block.
+func splitNormalization(norm *yaml.Node, index int) (int, bool) {
+	collapsed := mappingValue(norm, "collapsed_segments")
+	if collapsed == nil || collapsed.Kind != yaml.SequenceNode {
+		return 0, false
+	}
+
+	keep := make([]*yaml.Node, 0, len(collapsed.Content))
+	move := make([]*yaml.Node, 0, len(collapsed.Content))
+	specificFound := false
+	for _, entry := range collapsed.Content {
+		if entry.Kind != yaml.MappingNode {
+			keep = append(keep, entry)
+			continue
+		}
+		idxNode := mappingValue(entry, "index")
+		idxVal, ok := nodeIntValue(idxNode)
+		if index == 0 || (ok && idxVal == index) {
+			move = append(move, entry)
+			if index > 0 {
+				specificFound = true
+			}
+			continue
+		}
+		keep = append(keep, entry)
+	}
+	if len(move) == 0 {
+		return 0, specificFound
+	}
+
+	collapsed.Content = keep
+
+	// Demote the moved entries: reason -> operator_split. Other
+	// fields (index, value, distinct_values, ...) are preserved as
+	// audit context.
+	for _, entry := range move {
+		setMappingScalar(entry, "reason", reasonOperatorSplit)
+	}
+
+	retained := ensureMappingSeq(norm, "retained_segments")
+	retained.Content = append(retained.Content, move...)
+
+	return len(move), specificFound
+}
+
+// rebuildPathValue regenerates the path's `value` from the ordered
+// union of retained_segments + pinned_segments (by index) plus `*`
+// for whatever indices remain collapsed.
+//
+// Index discovery is bounded: we read every segment list, take the
+// max index seen, and walk 1..max emitting either the retained
+// literal, the pinned literal, or `*`. Segments without an index
+// (e.g. value-only pins) are skipped at this stage; they affect the
+// pinned ledger but not the rendered path.
+func rebuildPathValue(p *yaml.Node) {
+	norm := mappingValue(p, "normalization")
+	if norm == nil {
+		return
+	}
+
+	type slot struct {
+		value     string
+		wildcard  bool
+		hasLitVal bool
+	}
+	slots := make(map[int]slot)
+	maxIdx := 0
+
+	addLit := func(seg *yaml.Node) {
+		idxNode := mappingValue(seg, "index")
+		idx, ok := nodeIntValue(idxNode)
+		if !ok || idx <= 0 {
+			return
+		}
+		val := mappingScalar(seg, "value")
+		if idx > maxIdx {
+			maxIdx = idx
+		}
+		// Retained beats pinned beats nothing for the rendered slot,
+		// but in practice retained-by-index and pinned-by-index don't
+		// collide because pin is value-keyed. Use first-write-wins.
+		if _, exists := slots[idx]; !exists {
+			slots[idx] = slot{value: val, hasLitVal: true}
+		}
+	}
+	addWild := func(seg *yaml.Node) {
+		idxNode := mappingValue(seg, "index")
+		idx, ok := nodeIntValue(idxNode)
+		if !ok || idx <= 0 {
+			return
+		}
+		if idx > maxIdx {
+			maxIdx = idx
+		}
+		if _, exists := slots[idx]; !exists {
+			slots[idx] = slot{wildcard: true}
+		}
+	}
+
+	if retained := mappingValue(norm, "retained_segments"); retained != nil && retained.Kind == yaml.SequenceNode {
+		for _, seg := range retained.Content {
+			addLit(seg)
+		}
+	}
+	if pinned := mappingValue(norm, "pinned_segments"); pinned != nil && pinned.Kind == yaml.SequenceNode {
+		for _, seg := range pinned.Content {
+			addLit(seg)
+		}
+	}
+	if collapsed := mappingValue(norm, "collapsed_segments"); collapsed != nil && collapsed.Kind == yaml.SequenceNode {
+		for _, seg := range collapsed.Content {
+			addWild(seg)
+		}
+	}
+
+	if maxIdx == 0 {
+		return
+	}
+
+	// Rebuild "/seg1/seg2/...". Missing indices in [1..maxIdx] are
+	// rendered as wildcards so the path string stays well-formed even
+	// if a segment was removed from every list.
+	rebuilt := ""
+	for i := 1; i <= maxIdx; i++ {
+		s, present := slots[i]
+		switch {
+		case !present:
+			rebuilt += "/*"
+		case s.hasLitVal:
+			rebuilt += "/" + s.value
+		case s.wildcard:
+			rebuilt += "/*"
+		default:
+			rebuilt += "/*"
+		}
+	}
+	setMappingScalar(p, "value", rebuilt)
+}
+
+// documentRoot returns the top-level mapping node of a yaml.Node
+// document, or nil if the document is malformed.
+func documentRoot(doc *yaml.Node) *yaml.Node {
+	if doc == nil {
+		return nil
+	}
+	if doc.Kind == yaml.DocumentNode {
+		if len(doc.Content) == 0 {
+			return nil
+		}
+		return doc.Content[0]
+	}
+	return doc
+}
+
+// mappingValue returns the value node for a given key on a mapping
+// node, or nil if absent / non-mapping.
+func mappingValue(m *yaml.Node, key string) *yaml.Node {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// mappingScalar returns the string value of a scalar field on a
+// mapping, or "" if absent / non-scalar.
+func mappingScalar(m *yaml.Node, key string) string {
+	v := mappingValue(m, key)
+	if v == nil || v.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return v.Value
+}
+
+// setMappingScalar sets or replaces a scalar field on a mapping node.
+// Adds the key if absent.
+func setMappingScalar(m *yaml.Node, key, value string) {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			m.Content[i+1].Kind = yaml.ScalarNode
+			m.Content[i+1].Tag = "!!str"
+			m.Content[i+1].Value = value
+			return
+		}
+	}
+	m.Content = append(m.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value},
+	)
+}
+
+// ensureMappingSeq returns the existing sequence node at key on m, or
+// creates an empty one and appends it before returning.
+func ensureMappingSeq(m *yaml.Node, key string) *yaml.Node {
+	existing := mappingValue(m, key)
+	if existing != nil && existing.Kind == yaml.SequenceNode {
+		return existing
+	}
+	if existing != nil {
+		// Field exists but is not a sequence (e.g. !!null). Replace
+		// in place.
+		existing.Kind = yaml.SequenceNode
+		existing.Tag = "!!seq"
+		existing.Value = ""
+		existing.Content = nil
+		return existing
+	}
+	seq := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+	m.Content = append(m.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		seq,
+	)
+	return seq
+}
+
+// nodeIntValue parses a scalar yaml.Node as an int. Returns (val, true)
+// on success, (0, false) on absent / non-scalar / parse error.
+func nodeIntValue(n *yaml.Node) (int, bool) {
+	if n == nil || n.Kind != yaml.ScalarNode {
+		return 0, false
+	}
+	v, err := strconv.Atoi(n.Value)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}

--- a/internal/cli/learn/split.go
+++ b/internal/cli/learn/split.go
@@ -4,8 +4,10 @@
 package learn
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -37,7 +39,23 @@ var (
 	// not "flag value is empty string", so we enforce non-empty
 	// explicitly.
 	ErrEmptySegment = errors.New("learn: pin segment must be non-empty")
+
+	// ErrInvalidSegment is returned when a segment literal (whether
+	// from --segment input on pin or from a YAML retained/pinned entry
+	// on split) fails the segment grammar: empty after trim, contains
+	// a path separator, control character, wildcard glyph, or exceeds
+	// the bounded length. Both code paths share the validator so CLI
+	// input and YAML-carried values are constrained identically.
+	ErrInvalidSegment = errors.New("learn: invalid segment literal")
 )
+
+// maxSegmentLiteralLen bounds the length of a path segment literal.
+// 256 bytes is generous for real-world API segments (usernames, repo
+// names, IDs) while keeping a malicious YAML from blowing up the
+// rebuilt path string. Aligns with the 2048-char path-canonical cap in
+// internal/contract/inference/normalize: a 2048-char path with 256-char
+// segments is at most 8 segments, comfortably realistic.
+const maxSegmentLiteralLen = 256
 
 // reasonOperatorSplit / reasonOperatorPin label segments that an
 // operator manually demoted or pinned. The future compile pipeline
@@ -123,6 +141,10 @@ func runSplit(cmd *cobra.Command, candidatePath, ruleID string, index int, outPa
 		return fmt.Errorf("learn split: %w", err)
 	}
 
+	if err := validateRuleSegments(rule); err != nil {
+		return fmt.Errorf("learn split: %w", err)
+	}
+
 	moved, err := splitRule(rule, index)
 	if err != nil {
 		return fmt.Errorf("learn split: %w", err)
@@ -135,6 +157,16 @@ func runSplit(cmd *cobra.Command, candidatePath, ruleID string, index int, outPa
 	if err := writeCandidate(dest, doc); err != nil {
 		return err
 	}
+
+	emitAuditEvent(cmd, auditEvent{
+		Event:           "learn_split",
+		Candidate:       cleanCandidate,
+		Dest:            dest,
+		Rule:            ruleID,
+		Index:           index,
+		SegmentsChanged: moved,
+		NoOp:            moved == 0,
+	})
 
 	if moved == 0 {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
@@ -152,9 +184,13 @@ func runSplit(cmd *cobra.Command, candidatePath, ruleID string, index int, outPa
 // file, and parses it as YAML. Returns the cleaned path and the parsed
 // document.
 //
-// Absolute-path validation is part of the trust boundary. A relative
-// candidate path is operator-controlled and could be interpreted
-// against a surprising cwd; reject up front rather than guess.
+// Absolute-path validation, symlink rejection, and regular-file
+// confirmation form the trust boundary on the candidate input. A
+// relative path is operator-controlled and could be interpreted
+// against a surprising cwd; a symlink could redirect reads to a file
+// outside the intended candidate area; a non-regular file is a sign of
+// pipe / device confusion that the rewrite path cannot handle safely.
+// All three reject up front rather than guess.
 func loadCandidate(path string) (string, *yaml.Node, error) {
 	if path == "" {
 		return "", nil, fmt.Errorf("%w: empty candidate path", ErrInvalidCandidate)
@@ -165,14 +201,9 @@ func loadCandidate(path string) (string, *yaml.Node, error) {
 			ErrInvalidCandidate, path)
 	}
 
-	// G304: clean is filepath.Clean'd above. Operator-supplied path is
-	// the trust boundary; absolute-path requirement plus YAML parse
-	// failure-mode covers traversal: even if a symlink were chased, we
-	// only ever read+rewrite the linked file, never escape to anything
-	// the caller couldn't already write to.
-	data, err := os.ReadFile(clean)
+	data, err := safeReadCandidate(clean)
 	if err != nil {
-		return "", nil, fmt.Errorf("read candidate: %w: %w", ErrInvalidCandidate, err)
+		return "", nil, err
 	}
 
 	var doc yaml.Node
@@ -185,9 +216,49 @@ func loadCandidate(path string) (string, *yaml.Node, error) {
 	return clean, &doc, nil
 }
 
+// safeReadCandidate reads the file at clean (already filepath.Clean'd
+// and absolute) with two-step symlink protection:
+//
+//   - Lstat rejects symlinks and non-regular files at the directory
+//     entry level.
+//   - Open with O_RDONLY|O_NOFOLLOW so a between-stat-and-open swap
+//     also fails closed on Unix. Windows lacks O_NOFOLLOW (noFollowFlag
+//     is zero); the Lstat regular-file check still runs and is the
+//     primary defense, since Go's os.Lstat maps Windows reparse points
+//     to ModeSymlink.
+//
+// Errors wrap ErrInvalidCandidate so callers detect the trust-boundary
+// failure with errors.Is.
+func safeReadCandidate(clean string) ([]byte, error) {
+	li, err := os.Lstat(clean)
+	if err != nil {
+		return nil, fmt.Errorf("read candidate: %w: %w", ErrInvalidCandidate, err)
+	}
+	if li.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%w: candidate must not be a symlink: %s", ErrInvalidCandidate, clean)
+	}
+	if !li.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: candidate must be a regular file: %s", ErrInvalidCandidate, clean)
+	}
+	// G304: clean is filepath.Clean'd by the caller and Lstat-validated
+	// above; symlinks and non-regular files are already rejected.
+	f, err := os.OpenFile(filepath.Clean(clean), os.O_RDONLY|noFollowFlag, 0) //nolint:gosec // path is operator-supplied and validated
+	if err != nil {
+		if errors.Is(err, errELOOP) {
+			return nil, fmt.Errorf("%w: symlink raced into place: %s", ErrInvalidCandidate, clean)
+		}
+		return nil, fmt.Errorf("read candidate: %w: %w", ErrInvalidCandidate, err)
+	}
+	defer func() { _ = f.Close() }()
+	return io.ReadAll(f)
+}
+
 // resolveOut returns the destination path for the rewrite. If outPath
-// is empty, the candidate is rewritten in place. Both paths are
-// cleaned and required to be absolute.
+// is empty, the candidate is rewritten in place. Both paths must be
+// absolute. If outPath points to an existing file, it must already be
+// a regular file (not a symlink, device, or directory) so the atomic
+// rename does not redirect through a symlink to write outside the
+// intended directory.
 func resolveOut(candidatePath, outPath string) (string, error) {
 	if outPath == "" {
 		return candidatePath, nil
@@ -196,6 +267,22 @@ func resolveOut(candidatePath, outPath string) (string, error) {
 	if !filepath.IsAbs(clean) {
 		return "", fmt.Errorf("%w: --out must be absolute, got %q",
 			ErrInvalidCandidate, outPath)
+	}
+	li, err := os.Lstat(clean)
+	switch {
+	case err == nil:
+		if li.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("%w: --out must not be a symlink: %s", ErrInvalidCandidate, clean)
+		}
+		if !li.Mode().IsRegular() {
+			return "", fmt.Errorf("%w: --out must be a regular file when it exists: %s", ErrInvalidCandidate, clean)
+		}
+	case os.IsNotExist(err):
+		// Creation case is fine; atomicfile.Write creates a sibling
+		// temp file in the parent directory and renames over the
+		// target name, never resolving a symlink at the dest position.
+	default:
+		return "", fmt.Errorf("%w: --out lstat: %w", ErrInvalidCandidate, err)
 	}
 	return clean, nil
 }
@@ -365,6 +452,22 @@ func rebuildPathValue(p *yaml.Node) {
 			return
 		}
 		val := mappingScalar(seg, "value")
+		// Defense-in-depth: validateRuleSegments runs before mutation
+		// and rejects malformed literals at the entry boundary, but if
+		// a future caller invokes rebuildPathValue on a tree that did
+		// not pass through that gate we want the slot to render as a
+		// wildcard rather than embed a path-corrupting value. Empty
+		// values are common (operator-split entries with no original
+		// literal recorded) and intentionally render as wildcards.
+		if val == "" || validateSegmentLiteral(val) != nil {
+			if idx > maxIdx {
+				maxIdx = idx
+			}
+			if _, exists := slots[idx]; !exists {
+				slots[idx] = slot{wildcard: true}
+			}
+			return
+		}
 		if idx > maxIdx {
 			maxIdx = idx
 		}
@@ -523,4 +626,126 @@ func nodeIntValue(n *yaml.Node) (int, bool) {
 		return 0, false
 	}
 	return v, true
+}
+
+// validateSegmentLiteral enforces the segment grammar that both
+// CLI-side --segment input on `pin` and YAML-side retained/pinned
+// values on `split` must satisfy. Used to keep policy artifacts
+// well-formed against operator typos and against YAML smuggled in
+// from a less-trusted source.
+//
+// Rejected:
+//   - empty after TrimSpace (pin enforces this separately as
+//     ErrEmptySegment for the precise CLI error; here it folds in)
+//   - any byte 0x00-0x1F or 0x7F (control characters)
+//   - the path separator '/' (would smuggle one segment as multiple)
+//   - the wildcard glyphs '*' and '?' (have meaning in the contract
+//     grammar; an operator pinning literal "*" is almost certainly a
+//     mistake and would silently broaden compile-time matching)
+//   - bracket glyphs '[' and ']' (set / range characters in path
+//     globs; same hazard)
+//   - more than maxSegmentLiteralLen bytes
+func validateSegmentLiteral(s string) error {
+	if s == "" {
+		return fmt.Errorf("%w: empty", ErrInvalidSegment)
+	}
+	if len(s) > maxSegmentLiteralLen {
+		return fmt.Errorf("%w: length %d exceeds %d", ErrInvalidSegment, len(s), maxSegmentLiteralLen)
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c < 0x20 || c == 0x7F:
+			return fmt.Errorf("%w: control character at offset %d", ErrInvalidSegment, i)
+		case c == '/':
+			return fmt.Errorf("%w: path separator '/' at offset %d", ErrInvalidSegment, i)
+		case c == '*' || c == '?':
+			return fmt.Errorf("%w: wildcard glyph %q at offset %d", ErrInvalidSegment, c, i)
+		case c == '[' || c == ']':
+			return fmt.Errorf("%w: bracket glyph %q at offset %d", ErrInvalidSegment, c, i)
+		}
+	}
+	return nil
+}
+
+// validateRuleSegments walks every selector.paths[].normalization on
+// the rule and validates retained_segments[].value and
+// pinned_segments[].value against validateSegmentLiteral. Empty
+// values, missing values, or absent normalization blocks are skipped
+// (the rebuilder handles those cases). Returns the first failure as
+// an ErrInvalidSegment-wrapped error so the operator sees a precise
+// path-and-offset message.
+//
+// Run before mutation in both runSplit and runPin so an operator
+// invocation against a candidate carrying an attacker-supplied
+// segment literal fails closed without rewriting the file.
+func validateRuleSegments(rule *yaml.Node) error {
+	selector := mappingValue(rule, "selector")
+	if selector == nil {
+		return nil
+	}
+	paths := mappingValue(selector, "paths")
+	if paths == nil || paths.Kind != yaml.SequenceNode {
+		return nil
+	}
+	for pi, p := range paths.Content {
+		if p.Kind != yaml.MappingNode {
+			continue
+		}
+		norm := mappingValue(p, "normalization")
+		if norm == nil {
+			continue
+		}
+		for _, listKey := range []string{"retained_segments", "pinned_segments"} {
+			lst := mappingValue(norm, listKey)
+			if lst == nil || lst.Kind != yaml.SequenceNode {
+				continue
+			}
+			for ei, entry := range lst.Content {
+				if entry.Kind != yaml.MappingNode {
+					continue
+				}
+				val := mappingScalar(entry, "value")
+				if val == "" {
+					continue
+				}
+				if err := validateSegmentLiteral(val); err != nil {
+					return fmt.Errorf("%w (path %d, %s[%d])", err, pi, listKey, ei)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// auditEvent is the structured audit-log payload emitted on stderr by
+// learn split / learn pin. It is JSON-encoded one event per line so
+// log shippers can parse it without buffering. Fields mirror the
+// minimum information needed for incident reconstruction: the command
+// name, the candidate path (input), the destination path (output,
+// which differs from candidate when --out is set), the rule_id, the
+// segment-or-index target, the count of entries actually changed,
+// and whether the call was a no-op.
+type auditEvent struct {
+	Event           string `json:"event"`
+	Candidate       string `json:"candidate"`
+	Dest            string `json:"dest"`
+	Rule            string `json:"rule"`
+	Segment         string `json:"segment,omitempty"`
+	Index           int    `json:"index,omitempty"`
+	SegmentsChanged int    `json:"segments_changed"`
+	NoOp            bool   `json:"noop"`
+}
+
+// emitAuditEvent writes an auditEvent as a single JSON line to stderr.
+// Marshal failures are swallowed: an audit-log emit failing must never
+// block the operator command, and json.Marshal of a fully-typed struct
+// only fails on programming errors (channels, functions, cycles)
+// which the auditEvent shape cannot produce.
+func emitAuditEvent(cmd *cobra.Command, ev auditEvent) {
+	out, err := json.Marshal(ev)
+	if err != nil {
+		return
+	}
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), string(out))
 }

--- a/internal/cli/learn/split_test.go
+++ b/internal/cli/learn/split_test.go
@@ -282,7 +282,7 @@ func TestSplit_RejectsMissingIndex(t *testing.T) {
 }
 
 func TestSplit_AtomicWrite_OnFailure(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		t.Skip("read-only directory semantics differ on Windows")
 	}
 	if os.Geteuid() == 0 {

--- a/internal/cli/learn/split_test.go
+++ b/internal/cli/learn/split_test.go
@@ -1,0 +1,672 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package learn
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Shared test constants. Extracted to satisfy goconst.
+const (
+	testRuleID    = "r-test-rule-001"
+	testOtherRule = "r-test-rule-002"
+	testFile      = "candidate.yaml"
+)
+
+// canonicalCandidate is the synthetic candidate YAML used across the
+// split + pin test suites. Two paths, both with two collapsed
+// segments and one retained segment. The shape mirrors the
+// candidate-contract YAML emitted by the future compile pipeline
+// without committing to the full schema.
+const canonicalCandidate = `---
+contract_version: v2.4
+rules:
+  - rule_id: r-test-rule-001
+    selector:
+      paths:
+        - value: /repos/*/*
+          normalization:
+            algorithm: frequency_weighted_entropy_v1
+            collapsed_segments:
+              - index: 2
+                distinct_values: 87
+                event_count: 412
+                reason: high_entropy_identifier_segment
+              - index: 3
+                distinct_values: 14
+                event_count: 412
+                reason: high_entropy_identifier_segment
+            retained_segments:
+              - index: 1
+                value: repos
+                reason: low_entropy_literal_segment
+            pinned_segments: []
+  - rule_id: r-test-rule-002
+    selector:
+      paths:
+        - value: /api/*
+          normalization:
+            algorithm: frequency_weighted_entropy_v1
+            collapsed_segments:
+              - index: 2
+                distinct_values: 50
+                event_count: 100
+                reason: high_entropy_identifier_segment
+            retained_segments:
+              - index: 1
+                value: api
+                reason: low_entropy_literal_segment
+            pinned_segments:
+              - value: existing-pin
+                reason: operator_pin
+`
+
+// writeCandidate drops the canonical YAML to a tempdir and returns
+// its absolute path.
+func writeTestCandidate(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, testFile)
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	return abs
+}
+
+// loadParsed reads and parses a YAML file as a map for assertions.
+// Walking with yaml.Node would mirror the production code under test;
+// using map[string]interface{} keeps the assertion code orthogonal to
+// the production parser.
+func loadParsed(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var out map[string]interface{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return out
+}
+
+// findRuleNode returns the parsed map for a rule by id, or nil if
+// absent.
+func findRuleNode(parsed map[string]interface{}, ruleID string) map[string]interface{} {
+	rules, ok := parsed["rules"].([]interface{})
+	if !ok {
+		return nil
+	}
+	for _, r := range rules {
+		m, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if m["rule_id"] == ruleID {
+			return m
+		}
+	}
+	return nil
+}
+
+// firstNorm returns the normalization map from the first path of a
+// rule, or nil if absent.
+func firstNorm(rule map[string]interface{}) map[string]interface{} {
+	selector, ok := rule["selector"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	paths, ok := selector["paths"].([]interface{})
+	if !ok || len(paths) == 0 {
+		return nil
+	}
+	pmap, ok := paths[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	norm, _ := pmap["normalization"].(map[string]interface{})
+	return norm
+}
+
+// firstPathValue returns the rendered path value from the first path
+// of a rule.
+func firstPathValue(rule map[string]interface{}) string {
+	selector, ok := rule["selector"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	paths, ok := selector["paths"].([]interface{})
+	if !ok || len(paths) == 0 {
+		return ""
+	}
+	pmap, ok := paths[0].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	v, _ := pmap["value"].(string)
+	return v
+}
+
+// runSplitCobra executes the split subcommand with the given args
+// against fresh in-memory stdout/stderr buffers and returns
+// (stdout, err).
+func runSplitCobra(t *testing.T, args []string) (string, error) {
+	t.Helper()
+	cmd := splitCmd()
+	var stdout strings.Builder
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&strings.Builder{})
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return stdout.String(), err
+}
+
+func TestSplit_HappyPath_AllSegments(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	stdout, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stdout, "2 segments demoted") {
+		t.Errorf("expected '2 segments demoted' in stdout, got %q", stdout)
+	}
+
+	parsed := loadParsed(t, cand)
+	rule := findRuleNode(parsed, testRuleID)
+	if rule == nil {
+		t.Fatal("rule disappeared after split")
+	}
+	norm := firstNorm(rule)
+	if norm == nil {
+		t.Fatal("normalization disappeared")
+	}
+
+	collapsed, _ := norm["collapsed_segments"].([]interface{})
+	if len(collapsed) != 0 {
+		t.Errorf("expected empty collapsed_segments, got %d entries", len(collapsed))
+	}
+	retained, _ := norm["retained_segments"].([]interface{})
+	// Original retained had 1 entry (index=1). Both demoted entries
+	// (index 2 and 3) should now be present with reason=operator_split.
+	if len(retained) != 3 {
+		t.Errorf("expected 3 retained entries (1 original + 2 demoted), got %d", len(retained))
+	}
+	demotedCount := 0
+	for _, e := range retained {
+		em, _ := e.(map[string]interface{})
+		if em["reason"] == reasonOperatorSplit {
+			demotedCount++
+		}
+	}
+	if demotedCount != 2 {
+		t.Errorf("expected 2 entries with reason=%s, got %d", reasonOperatorSplit, demotedCount)
+	}
+}
+
+func TestSplit_HappyPath_SpecificIndex(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	stdout, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--index", "2",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stdout, "1 segments demoted") {
+		t.Errorf("expected '1 segments demoted', got %q", stdout)
+	}
+
+	parsed := loadParsed(t, cand)
+	rule := findRuleNode(parsed, testRuleID)
+	norm := firstNorm(rule)
+
+	collapsed, _ := norm["collapsed_segments"].([]interface{})
+	if len(collapsed) != 1 {
+		t.Errorf("expected 1 remaining collapsed entry, got %d", len(collapsed))
+	}
+	if len(collapsed) == 1 {
+		em, _ := collapsed[0].(map[string]interface{})
+		if idx, _ := em["index"].(int); idx != 3 {
+			t.Errorf("expected remaining collapsed index=3, got %v", em["index"])
+		}
+	}
+}
+
+func TestSplit_RejectsMissingRule(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	_, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", "r-does-not-exist",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing rule")
+	}
+	if !errors.Is(err, ErrRuleNotFound) {
+		t.Errorf("expected ErrRuleNotFound, got %v", err)
+	}
+}
+
+func TestSplit_RejectsMissingIndex(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	_, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--index", "99",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing index")
+	}
+	if !errors.Is(err, ErrCollapsedSegmentNotFound) {
+		t.Errorf("expected ErrCollapsedSegmentNotFound, got %v", err)
+	}
+}
+
+func TestSplit_AtomicWrite_OnFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("read-only directory semantics differ on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 0o500 doesn't restrict writes")
+	}
+
+	cand := writeTestCandidate(t, canonicalCandidate)
+	original, err := os.ReadFile(filepath.Clean(cand))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	// Make the directory read-only so atomicfile.Write's CreateTemp
+	// fails. The candidate file itself stays readable.
+	dir := filepath.Dir(cand)
+	if err := os.Chmod(dir, 0o500); err != nil { //nolint:gosec // test: intentionally restrictive perms
+		t.Fatalf("chmod dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) }) //nolint:gosec // test: restore dir permissions for cleanup
+
+	_, err = runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+	})
+	if err == nil {
+		t.Fatal("expected error when write target is read-only")
+	}
+
+	// Restore to read so we can verify the original is untouched.
+	if err := os.Chmod(dir, 0o700); err != nil { //nolint:gosec // test: restore dir permissions
+		t.Fatalf("chmod dir back: %v", err)
+	}
+	after, err := os.ReadFile(filepath.Clean(cand))
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if string(original) != string(after) {
+		t.Errorf("candidate was mutated despite write failure")
+	}
+}
+
+func TestSplit_OutFlag_WritesElsewhere(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+	original, err := os.ReadFile(filepath.Clean(cand))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	outDir := t.TempDir()
+	outPath := filepath.Join(outDir, "split-output.yaml")
+
+	_, err = runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--out", outPath,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if _, err := os.Stat(outPath); err != nil {
+		t.Errorf("expected --out file to exist: %v", err)
+	}
+
+	after, err := os.ReadFile(filepath.Clean(cand))
+	if err != nil {
+		t.Fatalf("read original: %v", err)
+	}
+	if string(original) != string(after) {
+		t.Errorf("candidate file should be unchanged when --out is set")
+	}
+}
+
+func TestSplit_Idempotent(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	if _, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+	}); err != nil {
+		t.Fatalf("first split: %v", err)
+	}
+
+	stdout, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+	})
+	if err != nil {
+		t.Fatalf("second split: %v", err)
+	}
+	if !strings.Contains(stdout, "no collapsed segments to demote") {
+		t.Errorf("expected idempotent no-op note, got %q", stdout)
+	}
+}
+
+func TestSplit_InvalidYAML_Rejects(t *testing.T) {
+	dir := t.TempDir()
+	cand := filepath.Join(dir, testFile)
+	if err := os.WriteFile(cand, []byte("not: valid: yaml: nope:::"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+	})
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !errors.Is(err, ErrInvalidCandidate) {
+		t.Errorf("expected ErrInvalidCandidate, got %v", err)
+	}
+}
+
+func TestSplit_RejectsRelativeCandidate(t *testing.T) {
+	_, err := runSplitCobra(t, []string{
+		"--candidate", "relative/path.yaml",
+		"--rule", testRuleID,
+	})
+	if err == nil {
+		t.Fatal("expected error for relative candidate path")
+	}
+	if !errors.Is(err, ErrInvalidCandidate) {
+		t.Errorf("expected ErrInvalidCandidate for relative path, got %v", err)
+	}
+}
+
+func TestSplit_RejectsNonexistentCandidate(t *testing.T) {
+	_, err := runSplitCobra(t, []string{
+		"--candidate", "/nonexistent/path/candidate.yaml",
+		"--rule", testRuleID,
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent candidate")
+	}
+	if !errors.Is(err, ErrInvalidCandidate) {
+		t.Errorf("expected ErrInvalidCandidate, got %v", err)
+	}
+}
+
+func TestSplit_RejectsRelativeOut(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	_, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"--out", "relative.yaml",
+	})
+	if err == nil {
+		t.Fatal("expected error for relative --out")
+	}
+	if !errors.Is(err, ErrInvalidCandidate) {
+		t.Errorf("expected ErrInvalidCandidate for relative --out, got %v", err)
+	}
+}
+
+func TestSplit_PathValueRebuilt(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	if _, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	parsed := loadParsed(t, cand)
+	rule := findRuleNode(parsed, testRuleID)
+	got := firstPathValue(rule)
+	// After splitting both collapsed segments (index 2 and 3) back to
+	// retained, the path slot for index 2 and 3 has no literal value
+	// (the demoted entries don't carry a `value` field in the
+	// fixture), so they render as wildcards.
+	if got == "" {
+		t.Errorf("expected non-empty rebuilt path value")
+	}
+}
+
+func TestSplit_HelpText(t *testing.T) {
+	cmd := splitCmd()
+	if !strings.Contains(cmd.Long, "collapsed") {
+		t.Errorf("split Long should mention 'collapsed'; got %q", cmd.Long)
+	}
+	if !strings.Contains(cmd.Long, "atomic") {
+		t.Errorf("split Long should mention 'atomic' write semantics; got %q", cmd.Long)
+	}
+}
+
+func TestSplit_RejectsPositionalArgs(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+
+	_, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+		"stray",
+	})
+	if err == nil {
+		t.Fatal("expected error for stray positional argument")
+	}
+}
+
+// TestCmd_HasSplitAndPinSubcommands confirms learn.go wired both new
+// subcommands under the parent.
+func TestCmd_HasSplitAndPinSubcommands(t *testing.T) {
+	parent := Cmd()
+	want := map[string]bool{"split": false, "pin": false, "observe": false}
+	for _, sub := range parent.Commands() {
+		if _, ok := want[sub.Name()]; ok {
+			want[sub.Name()] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("expected %q subcommand wired into `learn`", name)
+		}
+	}
+}
+
+func TestSplit_EmptyCandidateContent(t *testing.T) {
+	dir := t.TempDir()
+	cand := filepath.Join(dir, testFile)
+	if err := os.WriteFile(cand, []byte(""), 0o600); err != nil {
+		t.Fatalf("write empty: %v", err)
+	}
+
+	_, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+	})
+	if err == nil {
+		t.Fatal("expected error for empty candidate")
+	}
+	if !errors.Is(err, ErrInvalidCandidate) {
+		t.Errorf("expected ErrInvalidCandidate, got %v", err)
+	}
+}
+
+func TestSplit_NoRulesSection(t *testing.T) {
+	dir := t.TempDir()
+	cand := filepath.Join(dir, testFile)
+	if err := os.WriteFile(cand, []byte("contract_version: v2.4\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing rules section")
+	}
+	if !errors.Is(err, ErrInvalidCandidate) {
+		t.Errorf("expected ErrInvalidCandidate, got %v", err)
+	}
+}
+
+// TestSplit_RuleWithoutNormalization confirms a rule that has no
+// normalization metadata produces a 0-segment-demoted no-op rather
+// than an error.
+func TestSplit_RuleWithoutNormalization(t *testing.T) {
+	body := `---
+rules:
+  - rule_id: r-test-bare
+    selector:
+      paths:
+        - value: /static
+`
+	cand := writeTestCandidate(t, body)
+
+	stdout, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", "r-test-bare",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stdout, "no collapsed segments") {
+		t.Errorf("expected no-op message, got %q", stdout)
+	}
+}
+
+func TestSplit_RuleWithoutSelector(t *testing.T) {
+	body := `---
+rules:
+  - rule_id: r-test-noselector
+`
+	cand := writeTestCandidate(t, body)
+
+	stdout, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", "r-test-noselector",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stdout, "no collapsed segments") {
+		t.Errorf("expected no-op for no-selector rule, got %q", stdout)
+	}
+}
+
+// TestSplit_PinnedSegmentsNullPreserved exercises the `null` pinned
+// list path through ensureMappingSeq's "exists but not seq" branch.
+// It is structural: pin won't crash if pinned_segments was written as
+// `~` rather than `[]`.
+func TestSplit_PinnedSegmentsNullPreserved(t *testing.T) {
+	body := `---
+rules:
+  - rule_id: r-test-null-pinned
+    selector:
+      paths:
+        - value: /a/*
+          normalization:
+            collapsed_segments:
+              - index: 2
+                reason: high_entropy_identifier_segment
+            retained_segments:
+              - index: 1
+                value: a
+                reason: low_entropy_literal_segment
+            pinned_segments: ~
+`
+	cand := writeTestCandidate(t, body)
+
+	if _, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", "r-test-null-pinned",
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+}
+
+// TestSplit_NormalizationWithoutCollapsed exercises the "norm exists,
+// collapsed_segments absent" branch in splitNormalization.
+func TestSplit_NormalizationWithoutCollapsed(t *testing.T) {
+	body := `---
+rules:
+  - rule_id: r-test-no-collapsed
+    selector:
+      paths:
+        - value: /static
+          normalization:
+            algorithm: frequency_weighted_entropy_v1
+            retained_segments:
+              - index: 1
+                value: static
+                reason: low_entropy_literal_segment
+`
+	cand := writeTestCandidate(t, body)
+
+	stdout, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", "r-test-no-collapsed",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stdout, "no collapsed segments") {
+		t.Errorf("expected no-op message, got %q", stdout)
+	}
+}
+
+func TestSplit_RequiredFlagsEnforced(t *testing.T) {
+	// Missing both --candidate and --rule: cobra should fail.
+	_, err := runSplitCobra(t, []string{})
+	if err == nil {
+		t.Fatal("expected error for missing required flags")
+	}
+}
+
+func TestSplit_OutputPermissionsSecure(t *testing.T) {
+	cand := writeTestCandidate(t, canonicalCandidate)
+	if _, err := runSplitCobra(t, []string{
+		"--candidate", cand,
+		"--rule", testRuleID,
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	st, err := os.Stat(cand)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	mode := st.Mode().Perm()
+	if mode&0o077 != 0 {
+		t.Errorf("output perms %#o leak group/other access; expected 0o600 floor", mode)
+	}
+}

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -175,6 +175,16 @@ func (c *Config) policySemanticView() Config {
 	view.Internal = sortedCopy(view.Internal)
 	view.TrustedDomains = sortedCopy(view.TrustedDomains)
 
+	// Resolve omitted-or-zero learn-inference fields to their effective
+	// defaults so the policy hash reflects the runtime-effective policy,
+	// not the literal YAML representation. Without this, a YAML omitting
+	// learn.inference.floors.* and a YAML setting them explicitly to
+	// 5/20/3 would produce different hashes despite describing the same
+	// effective policy. The drift would surface as spurious verifier
+	// rejections on merge requests that just clarify defaults.
+	view.Learn.Inference.Floors = view.Learn.Inference.Floors.Resolved()
+	view.Learn.Inference.Normalization = view.Learn.Inference.Normalization.Resolved()
+
 	return view
 }
 

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -33,7 +33,7 @@ const (
 	// constructed Defaults() config, post-ApplyDefaults + Validate.
 	// This is the "out of the box" hash a user gets from `pipelock
 	// run` with no --config flag.
-	// Bumped for the v2.4 learn-and-lock observation pipeline schema:
+	// Bumped for the contract-compile observation pipeline schema:
 	// Defaults() now includes the Learn top-level block (enabled=false,
 	// privacy.public_allowlist_default=true). New policy surface → ph
 	// must shift so verifiers detect the schema change.
@@ -42,13 +42,29 @@ const (
 	// Floors are detection-relevant (they decide stable vs
 	// never_confirmed at compile time), so they must flow into ph so
 	// verifiers detect deployments that loosen the exposure gates.
-	goldenHashDefaults = "2fc2087f2baaf55caeff6aea778760eee3f2e16a36687473ab29e338c95ea624"
+	// Re-bumped on the path-normalization wiring PR: Learn now also
+	// carries an inference.normalization substruct (algorithm,
+	// min_events, min_distinct_values, entropy_threshold_bits,
+	// reserved_segments_extra, cardinality_cap_per_host,
+	// tail_promotion_block_pct). Normalization knobs are
+	// policy-relevant because they decide which path segments collapse
+	// to wildcards at compile time. An operator who lowers the entropy
+	// threshold or raises the cardinality cap silently widens the
+	// wildcard surface of every emitted contract; the verifier must
+	// observe the schema change through ph.
+	// Re-bumped on the same PR after policySemanticView started
+	// resolving zero-valued floors and normalization fields to their
+	// effective defaults before hashing. The change closes a verifier-
+	// drift hole: a YAML omitting learn.inference.floors and a YAML
+	// setting them explicitly to 5/20/3 now hash identically because
+	// they describe the same effective policy.
+	goldenHashDefaults = "3991ac9dbd84ba3683c0b855c979c4bd0bf422362a12ea85354ef90c58da3a31"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
 	// representative policy-semantic fixture with emphasis on the
 	// sections most likely to drift during TD-2b.
-	// Bumped for the v2.4 learn-and-lock observation pipeline schema:
+	// Bumped for the contract-compile observation pipeline schema:
 	// the rich fixture now carries a Learn block with enabled=false +
 	// privacy.public_allowlist_default=true defaults, so ph must shift
 	// in lockstep with the Defaults() bump above.
@@ -56,7 +72,16 @@ const (
 	// note above. Floors decode as zero in the rich fixture (which does
 	// not set them) and Resolved() supplies defaults at runtime, so the
 	// rich-config hash shifts in lockstep with Defaults().
-	goldenHashRichConfig = "19acd838ef7d36ed467077dd56a545e60808a5155fa61715aa5f889ee5f7aac7"
+	// Re-bumped on the path-normalization wiring PR: see goldenHashDefaults
+	// note above. Normalization knobs decode as zero in the rich fixture
+	// (which does not set them) and Resolved() supplies defaults at
+	// runtime, so the rich-config hash shifts in lockstep with Defaults().
+	// Re-bumped on the same PR after policySemanticView started
+	// resolving zero-valued floors and normalization fields to their
+	// effective defaults before hashing. See goldenHashDefaults note
+	// above. The rich fixture omits the inference substruct, so
+	// resolved-default values flow into ph identically to Defaults().
+	goldenHashRichConfig = "8584aecb9ff688cc0062249fa24581cda8fb8883d94d73a1aaa559ca13d494ce"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/learn_test.go
+++ b/internal/config/learn_test.go
@@ -6,11 +6,17 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
 )
+
+// reservedExtraInternal is the operator-supplied reserved-segment
+// extension used in normalization round-trip fixtures. Extracted as a
+// const to satisfy goconst across the round-trip and load tests.
+const reservedExtraInternal = "internal"
 
 const (
 	// learnYAMLOmittedPrivacy is a YAML fragment with learn enabled and a
@@ -552,6 +558,13 @@ func TestLearn_YAMLRoundTrip(t *testing.T) {
 	cfg.Learn.Inference.Floors.MinSessions = 7
 	cfg.Learn.Inference.Floors.MinEvents = 30
 	cfg.Learn.Inference.Floors.MinWindows = 4
+	cfg.Learn.Inference.Normalization.Algorithm = LearnNormalizationAlgorithmV1
+	cfg.Learn.Inference.Normalization.MinEvents = 12
+	cfg.Learn.Inference.Normalization.MinDistinctValues = 6
+	cfg.Learn.Inference.Normalization.EntropyThresholdBits = 3.5
+	cfg.Learn.Inference.Normalization.ReservedSegmentsExtra = []string{"corp", reservedExtraInternal}
+	cfg.Learn.Inference.Normalization.CardinalityCapPerHost = 2000
+	cfg.Learn.Inference.Normalization.TailPromotionBlockPct = 7.5
 
 	out, err := yaml.Marshal(cfg)
 	if err != nil {
@@ -581,6 +594,29 @@ func TestLearn_YAMLRoundTrip(t *testing.T) {
 	}
 	if got.Learn.Inference.Floors.MinWindows != 4 {
 		t.Errorf("Inference.Floors.MinWindows=%d lost on round-trip", got.Learn.Inference.Floors.MinWindows)
+	}
+	if got.Learn.Inference.Normalization.Algorithm != LearnNormalizationAlgorithmV1 {
+		t.Errorf("Normalization.Algorithm=%q lost on round-trip", got.Learn.Inference.Normalization.Algorithm)
+	}
+	if got.Learn.Inference.Normalization.MinEvents != 12 {
+		t.Errorf("Normalization.MinEvents=%d lost on round-trip", got.Learn.Inference.Normalization.MinEvents)
+	}
+	if got.Learn.Inference.Normalization.MinDistinctValues != 6 {
+		t.Errorf("Normalization.MinDistinctValues=%d lost on round-trip", got.Learn.Inference.Normalization.MinDistinctValues)
+	}
+	if got.Learn.Inference.Normalization.EntropyThresholdBits != 3.5 {
+		t.Errorf("Normalization.EntropyThresholdBits=%v lost on round-trip", got.Learn.Inference.Normalization.EntropyThresholdBits)
+	}
+	if len(got.Learn.Inference.Normalization.ReservedSegmentsExtra) != 2 ||
+		got.Learn.Inference.Normalization.ReservedSegmentsExtra[0] != "corp" ||
+		got.Learn.Inference.Normalization.ReservedSegmentsExtra[1] != reservedExtraInternal {
+		t.Errorf("Normalization.ReservedSegmentsExtra=%v lost on round-trip", got.Learn.Inference.Normalization.ReservedSegmentsExtra)
+	}
+	if got.Learn.Inference.Normalization.CardinalityCapPerHost != 2000 {
+		t.Errorf("Normalization.CardinalityCapPerHost=%d lost on round-trip", got.Learn.Inference.Normalization.CardinalityCapPerHost)
+	}
+	if got.Learn.Inference.Normalization.TailPromotionBlockPct != 7.5 {
+		t.Errorf("Normalization.TailPromotionBlockPct=%v lost on round-trip", got.Learn.Inference.Normalization.TailPromotionBlockPct)
 	}
 }
 
@@ -756,5 +792,554 @@ func TestLoad_LearnInferenceFloors_NegativeRejected(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "learn.inference.floors.min_sessions") {
 		t.Errorf("error %q missing operator-facing YAML path", err)
+	}
+}
+
+// TestValidateLearnInferenceNormalization_Algorithm pins the algorithm
+// gate. Empty is accepted (defaults flow through Resolved at runtime),
+// the canonical algorithm value is accepted, and any other value
+// rejects with the operator-facing YAML path. A future algorithm bump
+// must extend this test, never weaken it.
+func TestValidateLearnInferenceNormalization_Algorithm(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		algorithm  string
+		wantErr    bool
+		wantInPath string
+	}{
+		{"empty_accepted", "", false, ""},
+		{"canonical_v1_accepted", LearnNormalizationAlgorithmV1, false, ""},
+		{"unknown_rejected", "frequency_weighted_entropy_v2", true, "learn.inference.normalization.algorithm"},
+		{"misspelled_rejected", "frequency-weighted-entropy-v1", true, "learn.inference.normalization.algorithm"},
+		{"random_string_rejected", "naive", true, "learn.inference.normalization.algorithm"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n := LearnInferenceNormalization{Algorithm: tt.algorithm}
+			err := validateLearnInferenceNormalization(n)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for algorithm=%q", tt.algorithm)
+				}
+				if !strings.Contains(err.Error(), tt.wantInPath) {
+					t.Errorf("error %q missing YAML path %q", err, tt.wantInPath)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error for algorithm=%q: %v", tt.algorithm, err)
+			}
+		})
+	}
+}
+
+// TestValidateLearnInferenceNormalization_NumericFields_RejectNegative
+// exercises one row per numeric knob, each row setting exactly one field
+// to -1. The error message must surface the YAML path the operator sees
+// in pipelock.yaml plus the numeric value.
+func TestValidateLearnInferenceNormalization_NumericFields_RejectNegative(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		mut       func(*LearnInferenceNormalization)
+		wantPath  string
+		wantValue string
+	}{
+		{
+			name:      "min_events_negative",
+			mut:       func(n *LearnInferenceNormalization) { n.MinEvents = -1 },
+			wantPath:  "learn.inference.normalization.min_events",
+			wantValue: "-1",
+		},
+		{
+			name:      "min_distinct_values_negative",
+			mut:       func(n *LearnInferenceNormalization) { n.MinDistinctValues = -1 },
+			wantPath:  "learn.inference.normalization.min_distinct_values",
+			wantValue: "-1",
+		},
+		{
+			name:      "entropy_threshold_bits_negative",
+			mut:       func(n *LearnInferenceNormalization) { n.EntropyThresholdBits = -1 },
+			wantPath:  "learn.inference.normalization.entropy_threshold_bits",
+			wantValue: "-1",
+		},
+		{
+			name:      "cardinality_cap_per_host_negative",
+			mut:       func(n *LearnInferenceNormalization) { n.CardinalityCapPerHost = -1 },
+			wantPath:  "learn.inference.normalization.cardinality_cap_per_host",
+			wantValue: "-1",
+		},
+		{
+			name:      "tail_promotion_block_pct_negative",
+			mut:       func(n *LearnInferenceNormalization) { n.TailPromotionBlockPct = -1 },
+			wantPath:  "learn.inference.normalization.tail_promotion_block_pct",
+			wantValue: "-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var n LearnInferenceNormalization
+			tt.mut(&n)
+			err := validateLearnInferenceNormalization(n)
+			if err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+			if !strings.Contains(err.Error(), tt.wantPath) {
+				t.Errorf("error %q missing YAML path %q", err, tt.wantPath)
+			}
+			if !strings.Contains(err.Error(), tt.wantValue) {
+				t.Errorf("error %q missing numeric value %q", err, tt.wantValue)
+			}
+			if !strings.Contains(err.Error(), "non-negative") {
+				t.Errorf("error %q missing constraint phrasing", err)
+			}
+		})
+	}
+}
+
+// TestValidateLearnInferenceNormalization_EntropyThresholdBitsBand pins
+// the [0, 8.0] band for entropy_threshold_bits. Boundary cases at 0 and
+// 8.0 accept; anything outside rejects.
+func TestValidateLearnInferenceNormalization_EntropyThresholdBitsBand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		bits    float64
+		wantErr bool
+	}{
+		{"at_zero_accepted", 0, false},
+		{"just_above_zero_accepted", 0.001, false},
+		{"at_eight_accepted", 8.0, false},
+		{"just_above_eight_rejected", 8.0001, true},
+		{"just_below_zero_rejected", -0.001, true},
+		{"way_too_high_rejected", 1000.0, true},
+		{"way_too_low_rejected", -100.0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n := LearnInferenceNormalization{EntropyThresholdBits: tt.bits}
+			err := validateLearnInferenceNormalization(n)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for bits=%v", tt.bits)
+				}
+				if !strings.Contains(err.Error(), "learn.inference.normalization.entropy_threshold_bits") {
+					t.Errorf("error %q missing YAML path", err)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error for bits=%v: %v", tt.bits, err)
+			}
+		})
+	}
+}
+
+// TestValidateLearnInferenceNormalization_TailPctBand pins the [0, 100]
+// band for tail_promotion_block_pct. 0 and 100 both accept (defaults
+// land at 5.0, but operators may dial to either extreme).
+func TestValidateLearnInferenceNormalization_TailPctBand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pct     float64
+		wantErr bool
+	}{
+		{"at_zero_accepted", 0, false},
+		{"at_hundred_accepted", 100.0, false},
+		{"just_above_hundred_rejected", 100.0001, true},
+		{"just_below_zero_rejected", -0.001, true},
+		{"middle_default_accepted", 5.0, false},
+		{"way_too_high_rejected", 1000.0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n := LearnInferenceNormalization{TailPromotionBlockPct: tt.pct}
+			err := validateLearnInferenceNormalization(n)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for pct=%v", tt.pct)
+				}
+				if !strings.Contains(err.Error(), "learn.inference.normalization.tail_promotion_block_pct") {
+					t.Errorf("error %q missing YAML path", err)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error for pct=%v: %v", tt.pct, err)
+			}
+		})
+	}
+}
+
+// TestValidateLearnInferenceNormalization_ReservedExtras_RejectsEmpty
+// confirms an empty string anywhere in reserved_segments_extra trips
+// the validator with the index in the error so the operator can find
+// the offending entry without counting list items by hand.
+func TestValidateLearnInferenceNormalization_ReservedExtras_RejectsEmpty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		extras    []string
+		wantErr   bool
+		wantIndex string
+	}{
+		{"all_valid_accepted", []string{"valid", "also-valid", "third"}, false, ""},
+		{"empty_at_zero_rejected", []string{"", "valid"}, true, "[0]"},
+		{"empty_at_one_rejected", []string{"valid", "", "also-valid"}, true, "[1]"},
+		{"empty_at_two_rejected", []string{"valid", "also-valid", ""}, true, "[2]"},
+		{"nil_accepted", nil, false, ""},
+		{"empty_slice_accepted", []string{}, false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n := LearnInferenceNormalization{ReservedSegmentsExtra: tt.extras}
+			err := validateLearnInferenceNormalization(n)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for extras=%v", tt.extras)
+				}
+				if !strings.Contains(err.Error(), "learn.inference.normalization.reserved_segments_extra") {
+					t.Errorf("error %q missing YAML path", err)
+				}
+				if !strings.Contains(err.Error(), tt.wantIndex) {
+					t.Errorf("error %q missing index %q", err, tt.wantIndex)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error for extras=%v: %v", tt.extras, err)
+			}
+		})
+	}
+}
+
+// TestValidateLearnInferenceNormalization_AllZeroAccepted confirms a
+// fully-zero struct (operator omitted the entire normalization block)
+// validates clean. Zero is the "use default" sentinel: the runtime
+// applies normalize.DefaultDecideConfig / DefaultCapConfig at use time
+// via Resolved().
+func TestValidateLearnInferenceNormalization_AllZeroAccepted(t *testing.T) {
+	t.Parallel()
+
+	if err := validateLearnInferenceNormalization(LearnInferenceNormalization{}); err != nil {
+		t.Errorf("unexpected error on zero-value struct: %v", err)
+	}
+}
+
+// TestValidateLearnInferenceNormalization_FieldOrder pins the sequential
+// validation contract: when multiple fields are bad, the validator
+// returns the first error in declaration order. Operators read the
+// first error in their logs and fix it before re-running — non-
+// deterministic ordering would force multiple round-trips. Algorithm
+// is checked first; numeric fields follow in struct declaration order.
+func TestValidateLearnInferenceNormalization_FieldOrder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("algorithm_before_numeric", func(t *testing.T) {
+		t.Parallel()
+		// Bad algorithm + multiple bad numerics: algorithm error wins.
+		n := LearnInferenceNormalization{
+			Algorithm:             "bogus",
+			MinEvents:             -1,
+			MinDistinctValues:     -1,
+			EntropyThresholdBits:  -1,
+			CardinalityCapPerHost: -1,
+			TailPromotionBlockPct: -1,
+		}
+		err := validateLearnInferenceNormalization(n)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "algorithm") {
+			t.Errorf("expected algorithm error first, got: %v", err)
+		}
+	})
+
+	t.Run("min_events_before_other_numerics", func(t *testing.T) {
+		t.Parallel()
+		// Algorithm clean: first bad numeric (min_events) wins.
+		n := LearnInferenceNormalization{
+			MinEvents:             -1,
+			MinDistinctValues:     -2,
+			EntropyThresholdBits:  -3,
+			CardinalityCapPerHost: -4,
+			TailPromotionBlockPct: -5,
+		}
+		err := validateLearnInferenceNormalization(n)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "min_events") {
+			t.Errorf("expected min_events error first, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "min_distinct_values") ||
+			strings.Contains(err.Error(), "entropy_threshold_bits") ||
+			strings.Contains(err.Error(), "cardinality_cap_per_host") ||
+			strings.Contains(err.Error(), "tail_promotion_block_pct") {
+			t.Errorf("first error must report only min_events, got: %v", err)
+		}
+	})
+}
+
+// TestValidateLearn_PropagatesNormalizationError walks the full
+// Validate() pipeline with a bad Normalization sub-block so the
+// validateLearn → return-err branch is exercised end-to-end (mirrors
+// the salt-source and floor propagation tests already in this file).
+func TestValidateLearn_PropagatesNormalizationError(t *testing.T) {
+	cfg := Defaults()
+	cfg.Learn.Inference.Normalization.CardinalityCapPerHost = -1
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error from validateLearn through full Validate() chain")
+	}
+	if !strings.Contains(err.Error(), "learn.inference.normalization.cardinality_cap_per_host") {
+		t.Errorf("error %q does not propagate normalization detail", err)
+	}
+}
+
+// TestLoad_LearnInferenceNormalization_RoundTrip confirms YAML decoding
+// routes the normalization knobs into the right struct. The Load()
+// round-trip is the layer most likely to drift if the yaml tags get
+// mistyped, so we exercise it explicitly through the public API.
+func TestLoad_LearnInferenceNormalization_RoundTrip(t *testing.T) {
+	body := "" +
+		"mode: balanced\n" +
+		"learn:\n" +
+		"  enabled: true\n" +
+		"  capture_dir: /tmp/c\n" +
+		"  inference:\n" +
+		"    normalization:\n" +
+		"      algorithm: frequency_weighted_entropy_v1\n" +
+		"      min_events: 25\n" +
+		"      min_distinct_values: 8\n" +
+		"      entropy_threshold_bits: 4.2\n" +
+		"      reserved_segments_extra:\n" +
+		"        - corp\n" +
+		"        - tenant\n" +
+		"      cardinality_cap_per_host: 1500\n" +
+		"      tail_promotion_block_pct: 8.0\n"
+	p := writeLearnConfig(t, body)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	n := cfg.Learn.Inference.Normalization
+	if n.Algorithm != LearnNormalizationAlgorithmV1 {
+		t.Errorf("Algorithm=%q lost on Load", n.Algorithm)
+	}
+	if n.MinEvents != 25 {
+		t.Errorf("MinEvents=%d, want 25", n.MinEvents)
+	}
+	if n.MinDistinctValues != 8 {
+		t.Errorf("MinDistinctValues=%d, want 8", n.MinDistinctValues)
+	}
+	if n.EntropyThresholdBits != 4.2 {
+		t.Errorf("EntropyThresholdBits=%v, want 4.2", n.EntropyThresholdBits)
+	}
+	if len(n.ReservedSegmentsExtra) != 2 ||
+		n.ReservedSegmentsExtra[0] != "corp" ||
+		n.ReservedSegmentsExtra[1] != "tenant" {
+		t.Errorf("ReservedSegmentsExtra=%v lost on Load", n.ReservedSegmentsExtra)
+	}
+	if n.CardinalityCapPerHost != 1500 {
+		t.Errorf("CardinalityCapPerHost=%d, want 1500", n.CardinalityCapPerHost)
+	}
+	if n.TailPromotionBlockPct != 8.0 {
+		t.Errorf("TailPromotionBlockPct=%v, want 8.0", n.TailPromotionBlockPct)
+	}
+}
+
+// TestLoad_LearnInferenceNormalization_Negative_Rejected confirms a YAML
+// doc with a negative normalization knob fails Load() — the YAML
+// decode must reach Validate() and the validator must reject it with
+// the operator-facing YAML path so a misconfigured deployment cannot
+// silently widen the wildcard surface.
+func TestLoad_LearnInferenceNormalization_Negative_Rejected(t *testing.T) {
+	body := "" +
+		"mode: balanced\n" +
+		"learn:\n" +
+		"  enabled: true\n" +
+		"  capture_dir: /tmp/c\n" +
+		"  inference:\n" +
+		"    normalization:\n" +
+		"      cardinality_cap_per_host: -1\n"
+	p := writeLearnConfig(t, body)
+	_, err := Load(p)
+	if err == nil {
+		t.Fatal("expected Load error for negative cardinality_cap_per_host")
+	}
+	if !strings.Contains(err.Error(), "learn.inference.normalization.cardinality_cap_per_host") {
+		t.Errorf("error %q missing operator-facing YAML path", err)
+	}
+}
+
+// TestCanonicalPolicyHash_OmittedFloorsHashAsExplicitDefaults proves the
+// hash invariant policySemanticView promises: a config with omitted
+// learn.inference.floors and a config with explicit 5/20/3 must produce
+// identical canonical policy hashes. Without the Resolved() pre-pass,
+// these would diverge despite describing the same effective policy,
+// causing spurious verifier rejections on PRs that just clarify
+// defaults.
+func TestCanonicalPolicyHash_OmittedFloorsHashAsExplicitDefaults(t *testing.T) {
+	t.Parallel()
+
+	omitted := Defaults()
+	if got := omitted.Learn.Inference.Floors; (got != LearnInferenceFloors{}) {
+		t.Fatalf("Defaults() should leave inference.floors at zero, got %+v", got)
+	}
+
+	explicit := Defaults()
+	explicit.Learn.Inference.Floors = LearnInferenceFloors{
+		MinSessions: defaultLearnFloorMinSessions,
+		MinEvents:   defaultLearnFloorMinEvents,
+		MinWindows:  defaultLearnFloorMinWindows,
+	}
+
+	if h1, h2 := omitted.CanonicalPolicyHash(), explicit.CanonicalPolicyHash(); h1 != h2 {
+		t.Errorf("omitted floors and explicit defaults produced different hashes; the Resolved() pre-pass should make them identical\n  omitted:  %s\n  explicit: %s", h1, h2)
+	}
+}
+
+// TestCanonicalPolicyHash_OmittedNormalizationHashAsExplicitDefaults is
+// the parallel invariant for the normalization substruct.
+func TestCanonicalPolicyHash_OmittedNormalizationHashAsExplicitDefaults(t *testing.T) {
+	t.Parallel()
+
+	omitted := Defaults()
+	if got := omitted.Learn.Inference.Normalization; !reflect.DeepEqual(got, LearnInferenceNormalization{}) {
+		t.Fatalf("Defaults() should leave inference.normalization at zero, got %+v", got)
+	}
+
+	explicit := Defaults()
+	explicit.Learn.Inference.Normalization = LearnInferenceNormalization{
+		Algorithm:             LearnNormalizationAlgorithmV1,
+		MinEvents:             defaultLearnNormMinEvents,
+		MinDistinctValues:     defaultLearnNormMinDistinctValues,
+		EntropyThresholdBits:  defaultLearnNormEntropyThresholdBits,
+		CardinalityCapPerHost: defaultLearnNormCardinalityCapPerHost,
+		TailPromotionBlockPct: defaultLearnNormTailPromotionBlockPct,
+	}
+
+	if h1, h2 := omitted.CanonicalPolicyHash(), explicit.CanonicalPolicyHash(); h1 != h2 {
+		t.Errorf("omitted normalization and explicit defaults produced different hashes; the Resolved() pre-pass should make them identical\n  omitted:  %s\n  explicit: %s", h1, h2)
+	}
+}
+
+// TestLearnInferenceFloors_Resolved exercises the Resolved() canonical
+// pre-pass directly. Each row pins one input/output expectation so a
+// future regression in the zero-fill logic surfaces with a precise
+// failure message.
+func TestLearnInferenceFloors_Resolved(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   LearnInferenceFloors
+		want LearnInferenceFloors
+	}{
+		{
+			name: "all_zero_resolves_to_defaults",
+			in:   LearnInferenceFloors{},
+			want: LearnInferenceFloors{MinSessions: 5, MinEvents: 20, MinWindows: 3},
+		},
+		{
+			name: "partial_zero_only_zero_fields_default",
+			in:   LearnInferenceFloors{MinSessions: 0, MinEvents: 50, MinWindows: 0},
+			want: LearnInferenceFloors{MinSessions: 5, MinEvents: 50, MinWindows: 3},
+		},
+		{
+			name: "all_set_passes_through",
+			in:   LearnInferenceFloors{MinSessions: 99, MinEvents: 999, MinWindows: 9},
+			want: LearnInferenceFloors{MinSessions: 99, MinEvents: 999, MinWindows: 9},
+		},
+		{
+			name: "explicit_defaults_pass_through",
+			in:   LearnInferenceFloors{MinSessions: 5, MinEvents: 20, MinWindows: 3},
+			want: LearnInferenceFloors{MinSessions: 5, MinEvents: 20, MinWindows: 3},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.in.Resolved(); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Resolved(%+v) = %+v, want %+v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLearnInferenceNormalization_Resolved is the parallel test for the
+// normalization substruct.
+func TestLearnInferenceNormalization_Resolved(t *testing.T) {
+	t.Parallel()
+
+	defaults := LearnInferenceNormalization{
+		Algorithm:             LearnNormalizationAlgorithmV1,
+		MinEvents:             10,
+		MinDistinctValues:     5,
+		EntropyThresholdBits:  3.0,
+		CardinalityCapPerHost: 1000,
+		TailPromotionBlockPct: 5.0,
+	}
+
+	tests := []struct {
+		name string
+		in   LearnInferenceNormalization
+		want LearnInferenceNormalization
+	}{
+		{name: "all_zero_resolves_to_defaults", in: LearnInferenceNormalization{}, want: defaults},
+		{
+			name: "partial_set_only_zero_fields_default",
+			in: LearnInferenceNormalization{
+				MinEvents:             100,
+				CardinalityCapPerHost: 5000,
+			},
+			want: LearnInferenceNormalization{
+				Algorithm:             LearnNormalizationAlgorithmV1,
+				MinEvents:             100,
+				MinDistinctValues:     5,
+				EntropyThresholdBits:  3.0,
+				CardinalityCapPerHost: 5000,
+				TailPromotionBlockPct: 5.0,
+			},
+		},
+		{
+			name: "all_set_passes_through",
+			in: LearnInferenceNormalization{
+				Algorithm:             LearnNormalizationAlgorithmV1,
+				MinEvents:             50,
+				MinDistinctValues:     8,
+				EntropyThresholdBits:  4.0,
+				CardinalityCapPerHost: 2000,
+				TailPromotionBlockPct: 2.5,
+			},
+			want: LearnInferenceNormalization{
+				Algorithm:             LearnNormalizationAlgorithmV1,
+				MinEvents:             50,
+				MinDistinctValues:     8,
+				EntropyThresholdBits:  4.0,
+				CardinalityCapPerHost: 2000,
+				TailPromotionBlockPct: 2.5,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.in.Resolved(); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Resolved(%+v) = %+v, want %+v", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1104,10 +1104,10 @@ type ScanAPIKinds struct {
 	ToolCall        bool `yaml:"tool_call"`
 }
 
-// Learn governs the v2.4 learn-and-lock observation pipeline. When Enabled,
-// the proxy emits classification metadata into the recorder JSONL stream so
-// that pipelock learn compile (PR 2.x) can build a behavioral contract.
-// All fields are reload-safe.
+// Learn governs the contract-compile observation pipeline. When Enabled,
+// the proxy emits classification metadata into the recorder JSONL stream
+// so the future compile pipeline can build a behavioral contract from
+// it. All fields are reload-safe.
 type Learn struct {
 	Enabled    bool           `yaml:"enabled"`
 	CaptureDir string         `yaml:"capture_dir"`
@@ -1145,7 +1145,75 @@ type LearnPrivacy struct {
 // volumes differ across deployments, and the floors are exposure gates
 // rather than confidence thresholds.
 type LearnInference struct {
-	Floors LearnInferenceFloors `yaml:"floors"`
+	Floors        LearnInferenceFloors        `yaml:"floors"`
+	Normalization LearnInferenceNormalization `yaml:"normalization"`
+}
+
+// Default values for the LearnInferenceFloors substruct. Mirrors the
+// inference package's DefaultMinSessions / DefaultMinEvents /
+// DefaultMinWindows so the config layer can resolve omitted floors to
+// their effective values without importing the domain package.
+// TestLearnInferenceFloorsDefaults_MatchInferencePackage in the test
+// file imports inference and asserts the values agree.
+const (
+	defaultLearnFloorMinSessions = 5
+	defaultLearnFloorMinEvents   = 20
+	defaultLearnFloorMinWindows  = 3
+)
+
+// Default values for the LearnInferenceNormalization substruct. Mirrors
+// the normalize package's DefaultDecideConfig / DefaultCapConfig
+// values; sync test asserts they agree.
+const (
+	defaultLearnNormMinEvents             = 10
+	defaultLearnNormMinDistinctValues     = 5
+	defaultLearnNormEntropyThresholdBits  = 3.0
+	defaultLearnNormCardinalityCapPerHost = 1000
+	defaultLearnNormTailPromotionBlockPct = 5.0
+)
+
+// Resolved returns a copy of the floors substruct with any zero field
+// replaced by its corresponding default. Used by policySemanticView so
+// the canonical policy hash reflects effective floors, not literal
+// YAML zeros: a YAML omitting the floors and a YAML setting them
+// explicitly to 5/20/3 must hash identically because they describe the
+// same effective policy.
+func (f LearnInferenceFloors) Resolved() LearnInferenceFloors {
+	if f.MinSessions == 0 {
+		f.MinSessions = defaultLearnFloorMinSessions
+	}
+	if f.MinEvents == 0 {
+		f.MinEvents = defaultLearnFloorMinEvents
+	}
+	if f.MinWindows == 0 {
+		f.MinWindows = defaultLearnFloorMinWindows
+	}
+	return f
+}
+
+// Resolved returns a copy of the normalization substruct with any zero
+// field replaced by its corresponding default. Same canonicalization
+// contract as LearnInferenceFloors.Resolved.
+func (n LearnInferenceNormalization) Resolved() LearnInferenceNormalization {
+	if n.Algorithm == "" {
+		n.Algorithm = LearnNormalizationAlgorithmV1
+	}
+	if n.MinEvents == 0 {
+		n.MinEvents = defaultLearnNormMinEvents
+	}
+	if n.MinDistinctValues == 0 {
+		n.MinDistinctValues = defaultLearnNormMinDistinctValues
+	}
+	if n.EntropyThresholdBits == 0 {
+		n.EntropyThresholdBits = defaultLearnNormEntropyThresholdBits
+	}
+	if n.CardinalityCapPerHost == 0 {
+		n.CardinalityCapPerHost = defaultLearnNormCardinalityCapPerHost
+	}
+	if n.TailPromotionBlockPct == 0 {
+		n.TailPromotionBlockPct = defaultLearnNormTailPromotionBlockPct
+	}
+	return n
 }
 
 // LearnInferenceFloors mirrors inference.Floors at the YAML wire layer.
@@ -1158,4 +1226,62 @@ type LearnInferenceFloors struct {
 	MinSessions int `yaml:"min_sessions"`
 	MinEvents   int `yaml:"min_events"`
 	MinWindows  int `yaml:"min_windows"`
+}
+
+// LearnNormalizationAlgorithmV1 is the canonical path-normalization
+// algorithm name. Operators set learn.inference.normalization.algorithm
+// to this string (or omit it, which means "use default at runtime").
+// Anything else is rejected at config validation. A future algorithm
+// bump adds a new constant and a version-gated dispatch in the
+// inference package, never by relaxing the validator to accept
+// arbitrary names.
+const LearnNormalizationAlgorithmV1 = "frequency_weighted_entropy_v1"
+
+// LearnInferenceNormalization mirrors normalize.DecideConfig and
+// normalize.CapConfig at the YAML wire layer. Algorithm is locked to
+// LearnNormalizationAlgorithmV1 today; future algorithm bumps go
+// through a new constant + version-gated dispatch in the inference
+// package, not by accepting arbitrary algorithm strings here. The
+// numeric knobs are deployment-configurable (traffic volumes vary)
+// but bounded so a misconfiguration cannot disable safety properties.
+type LearnInferenceNormalization struct {
+	// Algorithm names the normalization algorithm. The only accepted
+	// value is LearnNormalizationAlgorithmV1 today; a future algorithm
+	// bump will require schema changes in the inference package itself.
+	Algorithm string `yaml:"algorithm"`
+
+	// MinEvents is the minimum number of events that must be observed
+	// in a (host, method, parent_prefix) bucket before any segment
+	// position in that bucket is eligible for collapse. Default 10.
+	MinEvents int `yaml:"min_events"`
+
+	// MinDistinctValues is the minimum number of distinct segment
+	// values at a given index before that position is eligible for
+	// collapse. Default 5.
+	MinDistinctValues int `yaml:"min_distinct_values"`
+
+	// EntropyThresholdBits is the minimum frequency-weighted Shannon
+	// entropy (in bits) at a given index for that position to be
+	// collapsed. Below this threshold the segment retains as a
+	// literal. Default 3.0.
+	EntropyThresholdBits float64 `yaml:"entropy_threshold_bits"`
+
+	// ReservedSegmentsExtra is the operator-supplied extension to the
+	// canonical reserved-segment blocklist (admin/auth/... in
+	// normalize.CanonicalReservedSegments()). Empty by default.
+	// Operators may extend but cannot remove from the canonical list.
+	ReservedSegmentsExtra []string `yaml:"reserved_segments_extra"`
+
+	// CardinalityCapPerHost is the maximum number of distinct
+	// path-families per host before overflow is bucketed into the
+	// _other tail. Default 1000.
+	CardinalityCapPerHost int `yaml:"cardinality_cap_per_host"`
+
+	// TailPromotionBlockPct is the percentage of host-event traffic
+	// that, if represented in the _other tail bucket, blocks
+	// promotion of the contract without explicit accept_tail: true.
+	// Default 5.0 (i.e., a contract with > 5% of events in tail
+	// requires operator acknowledgement). Strict greater-than: a
+	// tail at exactly the threshold does not block.
+	TailPromotionBlockPct float64 `yaml:"tail_promotion_block_pct"`
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -274,6 +274,57 @@ func (c *Config) validateLearn() error {
 	if err := validateLearnInferenceFloors(c.Learn.Inference.Floors); err != nil {
 		return err
 	}
+	if err := validateLearnInferenceNormalization(c.Learn.Inference.Normalization); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateLearnInferenceNormalization rejects malformed normalization
+// configuration on the YAML wire layer. Algorithm must be the v2.4
+// canonical value; numeric fields must be non-negative; the entropy
+// threshold must fit the [0, 8.0] band that path inference can
+// reasonably operate in (>8 bits per single segment is a typo);
+// the tail-promotion threshold is a percentage in [0, 100]. Errors
+// emit the full YAML path the operator sees in pipelock.yaml.
+//
+// Mirrors validateLearnInferenceFloors's layering choice: no import on
+// internal/contract/inference/normalize; the validator inlines the
+// rules that the normalize package's CapConfig.Validate and
+// DecideConfig.Validate also enforce, because operator-facing error
+// messages must use the YAML field path.
+func validateLearnInferenceNormalization(n LearnInferenceNormalization) error {
+	if n.Algorithm != "" && n.Algorithm != LearnNormalizationAlgorithmV1 {
+		return fmt.Errorf("learn.inference.normalization.algorithm: %q: must be %q (only supported algorithm in v2.4)", n.Algorithm, LearnNormalizationAlgorithmV1)
+	}
+	if n.MinEvents < 0 {
+		return fmt.Errorf("learn.inference.normalization.min_events: %d: must be non-negative", n.MinEvents)
+	}
+	if n.MinDistinctValues < 0 {
+		return fmt.Errorf("learn.inference.normalization.min_distinct_values: %d: must be non-negative", n.MinDistinctValues)
+	}
+	if n.EntropyThresholdBits < 0 {
+		return fmt.Errorf("learn.inference.normalization.entropy_threshold_bits: %v: must be non-negative", n.EntropyThresholdBits)
+	}
+	if n.EntropyThresholdBits > 8.0 {
+		return fmt.Errorf("learn.inference.normalization.entropy_threshold_bits: %v: must not exceed 8.0 (more than 8 bits per single segment is implausible)", n.EntropyThresholdBits)
+	}
+	if n.CardinalityCapPerHost < 0 {
+		return fmt.Errorf("learn.inference.normalization.cardinality_cap_per_host: %d: must be non-negative", n.CardinalityCapPerHost)
+	}
+	if n.TailPromotionBlockPct < 0 {
+		return fmt.Errorf("learn.inference.normalization.tail_promotion_block_pct: %v: must be non-negative", n.TailPromotionBlockPct)
+	}
+	if n.TailPromotionBlockPct > 100.0 {
+		return fmt.Errorf("learn.inference.normalization.tail_promotion_block_pct: %v: must not exceed 100", n.TailPromotionBlockPct)
+	}
+	// Reserved-segments-extra must not contain empty strings (would shadow
+	// the canonical list lookup ambiguously).
+	for i, s := range n.ReservedSegmentsExtra {
+		if s == "" {
+			return fmt.Errorf("learn.inference.normalization.reserved_segments_extra[%d]: empty string not permitted", i)
+		}
+	}
 	return nil
 }
 

--- a/internal/contract/inference/budgets.go
+++ b/internal/contract/inference/budgets.go
@@ -3,7 +3,10 @@
 
 package inference
 
-import "slices"
+import (
+	"math"
+	"slices"
+)
 
 // DefaultHeadroomRate is the default multiplicative headroom applied to
 // the observed P99 of a rate-dimensioned numeric budget (events per unit
@@ -14,8 +17,8 @@ import "slices"
 // part of the statistical contract and is NOT exposed as a config field.
 // Making it deployment-configurable would let two installs derive
 // different enforced ceilings from identical recorder data, which is
-// audit drift rather than flexibility. The value comes from the v2.4
-// learn-and-lock design (Round 5 spec).
+// audit drift rather than flexibility. The value comes from the
+// contract inference engine design baseline.
 //
 // The Budget type itself is dimension-agnostic; the caller picks
 // DefaultHeadroomRate vs DefaultHeadroomSize when invoking
@@ -31,14 +34,15 @@ const DefaultHeadroomRate = 0.20
 // without admitting noise.
 //
 // Same contract logic as DefaultHeadroomRate: locked, not deployment-
-// configurable, sourced from the v2.4 learn-and-lock design (Round 5
-// spec). The value is 0.50, meaning "allow 50% above the observed tail".
+// configurable, sourced from the contract inference engine design
+// baseline. The value is 0.50, meaning "allow 50% above the observed
+// tail".
 const DefaultHeadroomSize = 0.50
 
 // Budget is the inference package's pure value type for the persisted
 // statistics of a numeric-budget rule. The four observed statistics
 // (P99, P95, Median, Max) plus SampleCount are the canonical record-level
-// shape from the Round 5 design: review UX renders all of them, the
+// shape from the design baseline: review UX renders all of them, the
 // "thin-sample" badge is driven by SampleCount vs the rule's MinEvents
 // floor, and the property test pack uses Median to prove the
 // percentile-monotonicity invariant.
@@ -93,19 +97,28 @@ type Budget struct {
 // The caller's slice is NOT mutated: BudgetStats works on a clone made
 // via slices.Clone.
 //
-// Caller responsibility: NaN or Inf values in the input produce
-// undefined sort ordering and NaN-tainted percentile outputs. Recorder
-// inputs are non-NaN by construction (counts and sizes), so adding
-// defensive NaN/Inf filtering here would expand the API surface
-// without an attacker model. Callers that ingest untrusted floats must
-// filter at their boundary, not here.
+// Non-finite samples (NaN, +Inf, -Inf) are filtered out before
+// computing statistics so the inference path cannot persist nonsensical
+// budgets that downstream JSON encoding or enforcement comparisons
+// might handle inconsistently. SampleCount reflects the count after
+// filtering. A window that contains only non-finite values returns a
+// zero-valued Budget (same shape as an empty input window).
 func BudgetStats(window []float64) Budget {
-	n := len(window)
-	if n == 0 {
+	if len(window) == 0 {
 		return Budget{}
 	}
 
-	sorted := slices.Clone(window)
+	sorted := make([]float64, 0, len(window))
+	for _, v := range window {
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			continue
+		}
+		sorted = append(sorted, v)
+	}
+	n := len(sorted)
+	if n == 0 {
+		return Budget{}
+	}
 	slices.Sort(sorted)
 
 	return Budget{

--- a/internal/contract/inference/budgets_test.go
+++ b/internal/contract/inference/budgets_test.go
@@ -66,6 +66,69 @@ func TestBudgetStats_EmptyWindow(t *testing.T) {
 	}
 }
 
+// TestBudgetStats_FiltersNonFinite asserts that NaN and +/-Inf values
+// in the input window are filtered out before percentile computation,
+// so the resulting Budget never persists non-finite floats. SampleCount
+// reflects the count after filtering. A window containing only
+// non-finite values returns a zero-valued Budget. This is the
+// fail-closed-but-valid contract on the budget math: a future caller
+// that pipes a divide-by-zero result into BudgetStats cannot poison
+// the persisted contract or the policy hash with NaN/Inf.
+func TestBudgetStats_FiltersNonFinite(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []float64
+		want Budget
+	}{
+		{
+			name: "interleaved_finite_and_nan",
+			in:   []float64{10, math.NaN(), 20, 30, math.NaN(), 40},
+			// After filtering: [10, 20, 30, 40]. Nearest-rank median:
+			// ceil(50*4/100) = 2, sorted[1] = 20.
+			want: Budget{P99: 40, P95: 40, Median: 20, Max: 40, SampleCount: 4},
+		},
+		{
+			name: "interleaved_finite_and_inf",
+			in:   []float64{10, math.Inf(1), 20, math.Inf(-1), 30},
+			want: Budget{P99: 30, P95: 30, Median: 20, Max: 30, SampleCount: 3},
+		},
+		{
+			name: "all_nan_returns_zero_budget",
+			in:   []float64{math.NaN(), math.NaN(), math.NaN()},
+			want: Budget{},
+		},
+		{
+			name: "all_inf_returns_zero_budget",
+			in:   []float64{math.Inf(1), math.Inf(-1)},
+			want: Budget{},
+		},
+		{
+			name: "mixed_inf_nan_returns_zero_budget",
+			in:   []float64{math.NaN(), math.Inf(1), math.Inf(-1)},
+			want: Budget{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := BudgetStats(tc.in)
+			if got != tc.want {
+				t.Fatalf("BudgetStats(%v) = %+v, want %+v", tc.in, got, tc.want)
+			}
+			if math.IsNaN(got.P99) || math.IsInf(got.P99, 0) ||
+				math.IsNaN(got.P95) || math.IsInf(got.P95, 0) ||
+				math.IsNaN(got.Median) || math.IsInf(got.Median, 0) ||
+				math.IsNaN(got.Max) || math.IsInf(got.Max, 0) {
+				t.Fatalf("Budget contains non-finite value: %+v", got)
+			}
+		})
+	}
+}
+
 // TestBudgetStats_SingleElement verifies that a one-element window
 // collapses to a Budget where all four percentile/max values equal the
 // single sample.

--- a/internal/contract/inference/floors.go
+++ b/internal/contract/inference/floors.go
@@ -15,8 +15,8 @@ import (
 // contract and is NOT exposed as a config field. Making the threshold
 // deployment-configurable would let two installs infer different
 // classifications from identical recorder data, which is audit drift
-// rather than flexibility. The value comes from the v2.4 learn-and-lock
-// design (Round 5 spec).
+// rather than flexibility. The value comes from the contract inference
+// engine design baseline.
 const TauStable = 0.85
 
 // TauBrittle is the Wilson lower-bound threshold a rule must clear (in
@@ -24,7 +24,7 @@ const TauStable = 0.85
 // rather than ConfidenceNeverConfirmed.
 //
 // Same contract logic as TauStable: locked, not deployment-configurable,
-// sourced from the Round 5 spec.
+// sourced from the design baseline.
 const TauBrittle = 0.50
 
 // Default exposure floors. A rule cannot be classified ConfidenceStable
@@ -32,7 +32,7 @@ const TauBrittle = 0.50
 // how high the Wilson lower bound climbs. Floors are AND-composed with
 // Wilson — never OR — so a low-volume signal cannot promote itself to
 // stable just by being lucky on a handful of trials. Values come from
-// the v2.4 learn-and-lock design (Round 5 spec).
+// the contract inference engine design baseline.
 const (
 	// DefaultMinSessions is the minimum number of distinct sessions in
 	// which a rule must have been observed before it can be classified

--- a/internal/contract/inference/normalize/cardinality.go
+++ b/internal/contract/inference/normalize/cardinality.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package normalize
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// tailBucketPattern is the canonical wire form for the aggregated
+// tail bucket emitted when a host's distinct path-family count
+// exceeds the cap. The review UX renders this verbatim; downstream
+// metrics emit a `learn_normalize_tail_events_total` counter keyed
+// by this label.
+const tailBucketPattern = "_other"
+
+// PathFamily is a (post-collapse) path-family entry contributed by
+// the caller after Decide has run on each bucket. Cardinality cap
+// operates at the host level: PathFamily.Host is the bucket's host,
+// the canonical pattern is the segment-collapsed form, and
+// EventCount is the total events observed against this family
+// during the window.
+type PathFamily struct {
+	Host       string
+	Pattern    string // post-collapse path pattern, e.g. "/repos/*"
+	EventCount int
+}
+
+// CapResult is what CapPerHost returns: the kept top-N families
+// plus an aggregated _other tail entry (if overflow occurred), plus
+// the promotion-block decision. The struct is the wire-form
+// contract for the review UX and the policy hash.
+type CapResult struct {
+	Kept            []PathFamily // top-N by EventCount, deterministically sorted
+	Tail            PathFamily   // _other bucket; Pattern == "_other"; EventCount == sum of dropped
+	HostTotalEvents int          // sum of all input EventCount for this host (kept + tail)
+	Overflowed      bool         // true iff input had > N families for this host
+	PromotionBlock  bool         // true iff Tail.EventCount / HostTotalEvents > tail_promotion_block_pct AND !acceptTail
+}
+
+// ShouldBlockPromotion returns the PromotionBlock field. Callers
+// can write `if result.ShouldBlockPromotion() { ... }` for
+// readability.
+func (c CapResult) ShouldBlockPromotion() bool {
+	return c.PromotionBlock
+}
+
+// CapConfig carries the algorithm knobs for CapPerHost. Mirrors the
+// YAML knobs at
+// learn.inference.normalization.{cardinality_cap_per_host,
+// tail_promotion_block_pct}.
+type CapConfig struct {
+	CardinalityCapPerHost int     // max distinct families per host before tail bucketing
+	TailPromotionBlockPct float64 // tail-event% threshold above which promotion is blocked
+}
+
+// Default cap-config values mirror the design doc
+// (learn-and-lock-design.md, lines 1100-1106). 1000 distinct
+// families per host is the per-host ceiling; >5% tail coverage
+// blocks promotion unless the operator opts in via accept_tail.
+const (
+	defaultCardinalityCapPerHost = 1000
+	defaultTailPromotionBlockPct = 5.0
+	maxTailPromotionBlockPct     = 100.0
+)
+
+// DefaultCapConfig returns the canonical defaults baked into the
+// design. Tested by TestDefaultCapConfig_Locked as a drift guard.
+func DefaultCapConfig() CapConfig {
+	return CapConfig{
+		CardinalityCapPerHost: defaultCardinalityCapPerHost,
+		TailPromotionBlockPct: defaultTailPromotionBlockPct,
+	}
+}
+
+// Resolved returns a CapConfig with missing/zero fields filled from
+// DefaultCapConfig(). Negative values pass through unchanged so
+// Validate can flag them; Resolved deliberately does not silently
+// repair invalid input.
+func (c CapConfig) Resolved() CapConfig {
+	out := c
+	if out.CardinalityCapPerHost == 0 {
+		out.CardinalityCapPerHost = defaultCardinalityCapPerHost
+	}
+	if out.TailPromotionBlockPct == 0 {
+		out.TailPromotionBlockPct = defaultTailPromotionBlockPct
+	}
+	return out
+}
+
+// ErrInvalidCapConfig is the sentinel returned (wrapped) when a
+// CapConfig fails Validate. Callers use errors.Is.
+var ErrInvalidCapConfig = errors.New("normalize: invalid cap config")
+
+// Validate enforces the documented ranges:
+//   - CardinalityCapPerHost must be >= 0 (zero means "use default" via Resolved).
+//   - TailPromotionBlockPct must be in [0, 100].
+//
+// Pure: no I/O.
+func (c CapConfig) Validate() error {
+	if c.CardinalityCapPerHost < 0 {
+		return fmt.Errorf("normalize: %w (field=cardinality_cap_per_host, value=%d)", ErrInvalidCapConfig, c.CardinalityCapPerHost)
+	}
+	if c.TailPromotionBlockPct < 0 {
+		return fmt.Errorf("normalize: %w (field=tail_promotion_block_pct, value=%v)", ErrInvalidCapConfig, c.TailPromotionBlockPct)
+	}
+	if c.TailPromotionBlockPct > maxTailPromotionBlockPct {
+		return fmt.Errorf("normalize: %w (field=tail_promotion_block_pct, value=%v)", ErrInvalidCapConfig, c.TailPromotionBlockPct)
+	}
+	return nil
+}
+
+// ErrCapInvalidInput is the sentinel returned (wrapped) when
+// CapPerHost is called with an empty host or with an input
+// PathFamily that has a negative EventCount. These are programmer
+// errors caught at the boundary; the runtime never produces them.
+var ErrCapInvalidInput = errors.New("normalize: invalid cap input")
+
+// CapPerHost applies the per-host cardinality cap to `families`,
+// emitting the top-N kept entries and aggregating any overflow into
+// a single `_other` tail bucket. The function is pure: no I/O, no
+// goroutines, no allocations beyond the result.
+//
+// Algorithm (deterministic across calls and Go versions):
+//  1. Stable-filter to entries whose Host == host.
+//  2. Sort survivors by EventCount DESC, then Pattern ASC.
+//  3. If len(filtered) <= cap, all are kept; tail is empty (Pattern
+//     stays "_other" with EventCount == 0).
+//  4. Otherwise top-N becomes Kept and the rest is summed into Tail.
+//  5. PromotionBlock is set when Tail event% strictly exceeds the
+//     threshold and acceptTail is false. Equality at the threshold
+//     does NOT block (strict-greater-than semantic, pinned by test).
+//
+// Defensive checks reject host == "" and any input with
+// EventCount < 0 with a wrapped ErrCapInvalidInput.
+func CapPerHost(host string, families []PathFamily, cfg CapConfig, acceptTail bool) (CapResult, error) {
+	if host == "" {
+		return CapResult{}, fmt.Errorf("normalize: %w (field=host, value=\"\")", ErrCapInvalidInput)
+	}
+	for i, f := range families {
+		if f.EventCount < 0 {
+			return CapResult{}, fmt.Errorf("normalize: %w (field=families[%d].event_count, value=%d)", ErrCapInvalidInput, i, f.EventCount)
+		}
+	}
+
+	resolved := cfg.Resolved()
+	limit := resolved.CardinalityCapPerHost
+
+	// Stable filter for entries that belong to this host.
+	filtered := make([]PathFamily, 0, len(families))
+	for _, f := range families {
+		if f.Host == host {
+			filtered = append(filtered, f)
+		}
+	}
+
+	// Deterministic sort: EventCount DESC, Pattern ASC for ties.
+	sort.SliceStable(filtered, func(i, j int) bool {
+		if filtered[i].EventCount != filtered[j].EventCount {
+			return filtered[i].EventCount > filtered[j].EventCount
+		}
+		return filtered[i].Pattern < filtered[j].Pattern
+	})
+
+	result := CapResult{
+		Tail: PathFamily{
+			Host:       host,
+			Pattern:    tailBucketPattern,
+			EventCount: 0,
+		},
+	}
+
+	if len(filtered) <= limit {
+		result.Kept = filtered
+		for _, f := range filtered {
+			result.HostTotalEvents += f.EventCount
+		}
+		return result, nil
+	}
+
+	// Overflow: top-N kept, rest aggregated into tail.
+	result.Overflowed = true
+	result.Kept = filtered[:limit]
+	tailSum := 0
+	for _, f := range filtered[limit:] {
+		tailSum += f.EventCount
+	}
+	result.Tail.EventCount = tailSum
+
+	for _, f := range result.Kept {
+		result.HostTotalEvents += f.EventCount
+	}
+	result.HostTotalEvents += tailSum
+
+	// Tail-coverage promotion block: strict-greater-than threshold.
+	// HostTotalEvents > 0 here because overflow implies at least
+	// (cap+1) entries; if every one were zero EventCount we still
+	// wouldn't trip the threshold (0/0-style: tailSum == 0).
+	if result.HostTotalEvents > 0 {
+		tailPct := 100.0 * float64(tailSum) / float64(result.HostTotalEvents)
+		if tailPct > resolved.TailPromotionBlockPct && !acceptTail {
+			result.PromotionBlock = true
+		}
+	}
+
+	return result, nil
+}

--- a/internal/contract/inference/normalize/cardinality_test.go
+++ b/internal/contract/inference/normalize/cardinality_test.go
@@ -1,0 +1,554 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package normalize
+
+import (
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"reflect"
+	"testing"
+)
+
+const (
+	testHostA       = "api.example.com"
+	testHostB       = "other.example.com"
+	testHostVictim  = "victim.example"
+	testTailPattern = "_other"
+)
+
+func TestDefaultCapConfig_Locked(t *testing.T) {
+	t.Parallel()
+	got := DefaultCapConfig()
+	want := CapConfig{
+		CardinalityCapPerHost: 1000,
+		TailPromotionBlockPct: 5.0,
+	}
+	if got != want {
+		t.Fatalf("DefaultCapConfig() drift: got=%+v want=%+v", got, want)
+	}
+}
+
+func TestCapConfig_Resolved(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   CapConfig
+		want CapConfig
+	}{
+		{
+			name: "all_zero_uses_defaults",
+			in:   CapConfig{},
+			want: CapConfig{CardinalityCapPerHost: 1000, TailPromotionBlockPct: 5.0},
+		},
+		{
+			name: "partial_zero_cap_only",
+			in:   CapConfig{TailPromotionBlockPct: 10.0},
+			want: CapConfig{CardinalityCapPerHost: 1000, TailPromotionBlockPct: 10.0},
+		},
+		{
+			name: "partial_zero_pct_only",
+			in:   CapConfig{CardinalityCapPerHost: 500},
+			want: CapConfig{CardinalityCapPerHost: 500, TailPromotionBlockPct: 5.0},
+		},
+		{
+			name: "all_set_passes_through",
+			in:   CapConfig{CardinalityCapPerHost: 250, TailPromotionBlockPct: 2.5},
+			want: CapConfig{CardinalityCapPerHost: 250, TailPromotionBlockPct: 2.5},
+		},
+		{
+			name: "negative_passes_through_unchanged",
+			in:   CapConfig{CardinalityCapPerHost: -1, TailPromotionBlockPct: -2.0},
+			want: CapConfig{CardinalityCapPerHost: -1, TailPromotionBlockPct: -2.0},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.in.Resolved()
+			if got != tc.want {
+				t.Fatalf("Resolved(%+v) = %+v want %+v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCapConfig_Validate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		in      CapConfig
+		wantErr bool
+	}{
+		{name: "defaults_pass", in: DefaultCapConfig(), wantErr: false},
+		{name: "zero_pass", in: CapConfig{}, wantErr: false},
+		{name: "valid_low_threshold", in: CapConfig{CardinalityCapPerHost: 1, TailPromotionBlockPct: 0}, wantErr: false},
+		{name: "valid_max_threshold", in: CapConfig{CardinalityCapPerHost: 100, TailPromotionBlockPct: 100.0}, wantErr: false},
+		{name: "negative_cap_rejects", in: CapConfig{CardinalityCapPerHost: -1, TailPromotionBlockPct: 5.0}, wantErr: true},
+		{name: "negative_pct_rejects", in: CapConfig{CardinalityCapPerHost: 1000, TailPromotionBlockPct: -0.1}, wantErr: true},
+		{name: "pct_above_100_rejects", in: CapConfig{CardinalityCapPerHost: 1000, TailPromotionBlockPct: 100.0001}, wantErr: true},
+		{name: "pct_far_above_100_rejects", in: CapConfig{CardinalityCapPerHost: 1000, TailPromotionBlockPct: 1000.0}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.in.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Validate(%+v) = nil want error", tc.in)
+				}
+				if !errors.Is(err, ErrInvalidCapConfig) {
+					t.Fatalf("Validate(%+v) error not wrapping ErrInvalidCapConfig: %v", tc.in, err)
+				}
+			} else if err != nil {
+				t.Fatalf("Validate(%+v) = %v want nil", tc.in, err)
+			}
+		})
+	}
+}
+
+func TestCapPerHost_NoOverflow(t *testing.T) {
+	t.Parallel()
+	families := []PathFamily{
+		{Host: testHostA, Pattern: "/a", EventCount: 50},
+		{Host: testHostA, Pattern: "/b", EventCount: 25},
+		{Host: testHostA, Pattern: "/c", EventCount: 10},
+		{Host: testHostA, Pattern: "/d", EventCount: 5},
+		{Host: testHostA, Pattern: "/e", EventCount: 2},
+	}
+	cfg := CapConfig{CardinalityCapPerHost: 10, TailPromotionBlockPct: 5.0}
+	got, err := CapPerHost(testHostA, families, cfg, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Overflowed {
+		t.Fatalf("expected Overflowed=false")
+	}
+	if got.PromotionBlock {
+		t.Fatalf("expected PromotionBlock=false")
+	}
+	if len(got.Kept) != 5 {
+		t.Fatalf("expected 5 kept, got %d", len(got.Kept))
+	}
+	if got.Tail.EventCount != 0 {
+		t.Fatalf("expected empty tail, got EventCount=%d", got.Tail.EventCount)
+	}
+	if got.Tail.Pattern != testTailPattern {
+		t.Fatalf("tail pattern = %q want %q", got.Tail.Pattern, testTailPattern)
+	}
+	if got.Tail.Host != testHostA {
+		t.Fatalf("tail host = %q want %q", got.Tail.Host, testHostA)
+	}
+	if got.HostTotalEvents != 92 {
+		t.Fatalf("HostTotalEvents = %d want 92", got.HostTotalEvents)
+	}
+}
+
+func TestCapPerHost_ExactBoundary(t *testing.T) {
+	t.Parallel()
+	// N families, cap=N → all kept, no overflow. Off-by-one trap.
+	cfg := CapConfig{CardinalityCapPerHost: 5, TailPromotionBlockPct: 5.0}
+	families := []PathFamily{
+		{Host: testHostA, Pattern: "/a", EventCount: 10},
+		{Host: testHostA, Pattern: "/b", EventCount: 10},
+		{Host: testHostA, Pattern: "/c", EventCount: 10},
+		{Host: testHostA, Pattern: "/d", EventCount: 10},
+		{Host: testHostA, Pattern: "/e", EventCount: 10},
+	}
+	got, err := CapPerHost(testHostA, families, cfg, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Overflowed {
+		t.Fatalf("expected Overflowed=false at boundary")
+	}
+	if len(got.Kept) != 5 {
+		t.Fatalf("expected 5 kept, got %d", len(got.Kept))
+	}
+	if got.Tail.EventCount != 0 {
+		t.Fatalf("expected empty tail")
+	}
+	if got.HostTotalEvents != 50 {
+		t.Fatalf("HostTotalEvents = %d want 50", got.HostTotalEvents)
+	}
+}
+
+func TestCapPerHost_Overflow_PromotionAllowed(t *testing.T) {
+	t.Parallel()
+	// 12 families, cap=10. Top 10 dominate. Tail is ~1% → no block.
+	families := make([]PathFamily, 0, 12)
+	for i := range 10 {
+		families = append(families, PathFamily{
+			Host:       testHostA,
+			Pattern:    fmt.Sprintf("/big-%02d", i),
+			EventCount: 1000,
+		})
+	}
+	families = append(families,
+		PathFamily{Host: testHostA, Pattern: "/tail-1", EventCount: 50},
+		PathFamily{Host: testHostA, Pattern: "/tail-2", EventCount: 50},
+	)
+	cfg := CapConfig{CardinalityCapPerHost: 10, TailPromotionBlockPct: 5.0}
+	got, err := CapPerHost(testHostA, families, cfg, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Overflowed {
+		t.Fatalf("expected Overflowed=true")
+	}
+	if got.PromotionBlock {
+		t.Fatalf("expected PromotionBlock=false (tail ~1%%)")
+	}
+	if len(got.Kept) != 10 {
+		t.Fatalf("expected 10 kept, got %d", len(got.Kept))
+	}
+	if got.Tail.EventCount != 100 {
+		t.Fatalf("Tail.EventCount = %d want 100", got.Tail.EventCount)
+	}
+	if got.HostTotalEvents != 10100 {
+		t.Fatalf("HostTotalEvents = %d want 10100", got.HostTotalEvents)
+	}
+}
+
+func TestCapPerHost_Overflow_PromotionBlocked(t *testing.T) {
+	t.Parallel()
+	// Tail = 30% of total → blocks promotion.
+	// The kept entries must dominate (top-N by EventCount DESC), so
+	// they get the larger counts. The dropped entries make up the
+	// tail — with EventCount that totals 30% of all events.
+	// 10 kept × 70 = 700 events. 2 dropped × 150 = 300 events. Total = 1000.
+	// 300/1000 = 30% > 5% threshold → block.
+	families := make([]PathFamily, 0, 12)
+	for i := range 10 {
+		families = append(families, PathFamily{
+			Host:       testHostA,
+			Pattern:    fmt.Sprintf("/kept-%02d", i),
+			EventCount: 70,
+		})
+	}
+	// Make these have LOWER per-entry EventCount than kept entries
+	// so the sort places them after the kept ones. But we want their
+	// TOTAL to be 30% of events. 10 entries × 30 events = 300 events.
+	for i := range 10 {
+		families = append(families, PathFamily{
+			Host:       testHostA,
+			Pattern:    fmt.Sprintf("/dropped-%02d", i),
+			EventCount: 30,
+		})
+	}
+	cfg := CapConfig{CardinalityCapPerHost: 10, TailPromotionBlockPct: 5.0}
+	got, err := CapPerHost(testHostA, families, cfg, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Overflowed {
+		t.Fatalf("expected Overflowed=true")
+	}
+	if !got.PromotionBlock {
+		t.Fatalf("expected PromotionBlock=true (tail=300/1000=30%%)")
+	}
+	if !got.ShouldBlockPromotion() {
+		t.Fatalf("ShouldBlockPromotion() should mirror PromotionBlock")
+	}
+	if got.Tail.EventCount != 300 {
+		t.Fatalf("Tail.EventCount = %d want 300", got.Tail.EventCount)
+	}
+	if got.HostTotalEvents != 1000 {
+		t.Fatalf("HostTotalEvents = %d want 1000", got.HostTotalEvents)
+	}
+	if len(got.Kept) != 10 {
+		t.Fatalf("expected 10 kept, got %d", len(got.Kept))
+	}
+}
+
+func TestCapPerHost_AcceptTailOverridesBlock(t *testing.T) {
+	t.Parallel()
+	// Same shape as TestCapPerHost_Overflow_PromotionBlocked: tail
+	// would be 30% of total events without acceptTail. acceptTail=true
+	// must override the block.
+	families := make([]PathFamily, 0, 20)
+	for i := range 10 {
+		families = append(families, PathFamily{
+			Host:       testHostA,
+			Pattern:    fmt.Sprintf("/kept-%02d", i),
+			EventCount: 70,
+		})
+	}
+	for i := range 10 {
+		families = append(families, PathFamily{
+			Host:       testHostA,
+			Pattern:    fmt.Sprintf("/dropped-%02d", i),
+			EventCount: 30,
+		})
+	}
+	cfg := CapConfig{CardinalityCapPerHost: 10, TailPromotionBlockPct: 5.0}
+	got, err := CapPerHost(testHostA, families, cfg, true) // acceptTail=true
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Overflowed {
+		t.Fatalf("expected Overflowed=true")
+	}
+	if got.PromotionBlock {
+		t.Fatalf("expected PromotionBlock=false when acceptTail=true")
+	}
+	if got.Tail.EventCount != 300 {
+		t.Fatalf("Tail.EventCount = %d want 300", got.Tail.EventCount)
+	}
+}
+
+func TestCapPerHost_TailExactlyAtThreshold(t *testing.T) {
+	t.Parallel()
+	// Build families where the tail is exactly 5% of total events.
+	// 11 families, cap=10. Kept gets 950 events; tail (one entry)
+	// gets 50 events. 50/1000 = 5.0% — strict-greater-than means
+	// PromotionBlock is FALSE.
+	families := make([]PathFamily, 0, 11)
+	for i := range 10 {
+		families = append(families, PathFamily{
+			Host:       testHostA,
+			Pattern:    fmt.Sprintf("/kept-%02d", i),
+			EventCount: 95,
+		})
+	}
+	families = append(families, PathFamily{
+		Host:       testHostA,
+		Pattern:    "/tail-only",
+		EventCount: 50,
+	})
+	cfg := CapConfig{CardinalityCapPerHost: 10, TailPromotionBlockPct: 5.0}
+	got, err := CapPerHost(testHostA, families, cfg, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Overflowed {
+		t.Fatalf("expected Overflowed=true")
+	}
+	if got.Tail.EventCount != 50 {
+		t.Fatalf("Tail.EventCount = %d want 50", got.Tail.EventCount)
+	}
+	if got.HostTotalEvents != 1000 {
+		t.Fatalf("HostTotalEvents = %d want 1000", got.HostTotalEvents)
+	}
+	// 50.0 / 1000.0 == 5.0; threshold 5.0; strict greater-than means
+	// no block. Pin this boundary semantic.
+	if got.PromotionBlock {
+		t.Fatalf("PromotionBlock=true at exact threshold; semantic should be strict-greater-than")
+	}
+}
+
+func TestCapPerHost_StableTieBreaking(t *testing.T) {
+	t.Parallel()
+	// Two families with identical EventCount but different patterns;
+	// cap=1 → the one with Pattern lexicographically lower wins.
+	families := []PathFamily{
+		{Host: testHostA, Pattern: "/zebra", EventCount: 100},
+		{Host: testHostA, Pattern: "/apple", EventCount: 100},
+	}
+	cfg := CapConfig{CardinalityCapPerHost: 1, TailPromotionBlockPct: 5.0}
+	got, err := CapPerHost(testHostA, families, cfg, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Kept) != 1 {
+		t.Fatalf("expected 1 kept, got %d", len(got.Kept))
+	}
+	if got.Kept[0].Pattern != "/apple" {
+		t.Fatalf("tie-break failed: kept %q want %q", got.Kept[0].Pattern, "/apple")
+	}
+	if got.Tail.EventCount != 100 {
+		t.Fatalf("Tail.EventCount = %d want 100", got.Tail.EventCount)
+	}
+}
+
+func TestCapPerHost_DeterministicAcross1000Calls(t *testing.T) {
+	t.Parallel()
+	// Build 100 random-ish families. Using a seeded RNG for the test
+	// itself doesn't matter — we just need a fixed corpus that
+	// exercises ties + ordering.
+	rng := rand.New(rand.NewPCG(0xCAFE, 0xBEEF)) //nolint:gosec // G404: deterministic test corpus, not security-sensitive
+	families := make([]PathFamily, 100)
+	for i := range families {
+		families[i] = PathFamily{
+			Host:       testHostA,
+			Pattern:    fmt.Sprintf("/p-%03d", i),
+			EventCount: rng.IntN(50), // ties guaranteed in [0, 50)
+		}
+	}
+	cfg := CapConfig{CardinalityCapPerHost: 25, TailPromotionBlockPct: 5.0}
+
+	first, err := CapPerHost(testHostA, families, cfg, false)
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	for i := range 1000 {
+		got, err := CapPerHost(testHostA, families, cfg, false)
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("non-deterministic at call %d:\n first=%+v\n got=  %+v", i, first, got)
+		}
+	}
+}
+
+func TestCapPerHost_RejectsEmptyHost(t *testing.T) {
+	t.Parallel()
+	_, err := CapPerHost("", []PathFamily{{Host: testHostA, Pattern: "/x", EventCount: 1}}, DefaultCapConfig(), false)
+	if err == nil {
+		t.Fatalf("expected error for empty host")
+	}
+	if !errors.Is(err, ErrCapInvalidInput) {
+		t.Fatalf("error not wrapping ErrCapInvalidInput: %v", err)
+	}
+}
+
+func TestCapPerHost_RejectsNegativeEventCount(t *testing.T) {
+	t.Parallel()
+	families := []PathFamily{
+		{Host: testHostA, Pattern: "/a", EventCount: 5},
+		{Host: testHostA, Pattern: "/b", EventCount: -1},
+	}
+	_, err := CapPerHost(testHostA, families, DefaultCapConfig(), false)
+	if err == nil {
+		t.Fatalf("expected error for negative EventCount")
+	}
+	if !errors.Is(err, ErrCapInvalidInput) {
+		t.Fatalf("error not wrapping ErrCapInvalidInput: %v", err)
+	}
+}
+
+func TestCapPerHost_FiltersForeignHosts(t *testing.T) {
+	t.Parallel()
+	// Mixed input. CapPerHost("A", ...) must only see host-A entries.
+	families := []PathFamily{
+		{Host: testHostA, Pattern: "/a1", EventCount: 50},
+		{Host: testHostB, Pattern: "/b1", EventCount: 999},
+		{Host: testHostA, Pattern: "/a2", EventCount: 25},
+		{Host: testHostB, Pattern: "/b2", EventCount: 999},
+	}
+	cfg := CapConfig{CardinalityCapPerHost: 10, TailPromotionBlockPct: 5.0}
+	got, err := CapPerHost(testHostA, families, cfg, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Kept) != 2 {
+		t.Fatalf("expected 2 kept (only host A), got %d", len(got.Kept))
+	}
+	if got.HostTotalEvents != 75 {
+		t.Fatalf("HostTotalEvents = %d want 75 (foreign hosts excluded)", got.HostTotalEvents)
+	}
+	// Verify only host-A patterns made it through.
+	for _, f := range got.Kept {
+		if f.Host != testHostA {
+			t.Fatalf("foreign host leaked into Kept: %+v", f)
+		}
+	}
+}
+
+func TestCapPerHost_EmptyFamilies(t *testing.T) {
+	t.Parallel()
+	got, err := CapPerHost(testHostA, nil, DefaultCapConfig(), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Kept) != 0 {
+		t.Fatalf("expected empty Kept")
+	}
+	if got.Overflowed {
+		t.Fatalf("expected Overflowed=false")
+	}
+	if got.PromotionBlock {
+		t.Fatalf("expected PromotionBlock=false")
+	}
+	if got.HostTotalEvents != 0 {
+		t.Fatalf("expected HostTotalEvents=0")
+	}
+	if got.Tail.Pattern != testTailPattern {
+		t.Fatalf("Tail.Pattern = %q want %q (tail bucket label is constant)", got.Tail.Pattern, testTailPattern)
+	}
+	if got.Tail.Host != testHostA {
+		t.Fatalf("Tail.Host = %q want %q", got.Tail.Host, testHostA)
+	}
+}
+
+func TestCapPerHost_DefaultsAppliedWhenZero(t *testing.T) {
+	t.Parallel()
+	// CapConfig{} → Resolved → 1000 cap, 5% threshold. With only
+	// 3 families nothing overflows.
+	families := []PathFamily{
+		{Host: testHostA, Pattern: "/a", EventCount: 1},
+		{Host: testHostA, Pattern: "/b", EventCount: 1},
+		{Host: testHostA, Pattern: "/c", EventCount: 1},
+	}
+	got, err := CapPerHost(testHostA, families, CapConfig{}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Overflowed {
+		t.Fatalf("expected Overflowed=false")
+	}
+	if len(got.Kept) != 3 {
+		t.Fatalf("expected 3 kept, got %d", len(got.Kept))
+	}
+}
+
+func TestCapPerHost_AdversarialCorpus_100k_Distinct(t *testing.T) {
+	t.Parallel()
+	const total = 100_000
+	const capLimit = 1000
+	rng := rand.New(rand.NewPCG(0xDEADBEEF, 0xCAFEBABE)) //nolint:gosec // G404: deterministic test corpus, not security-sensitive
+	families := make([]PathFamily, total)
+	totalEvents := 0
+	for i := range families {
+		ec := 1 + rng.IntN(10) // [1, 10]
+		families[i] = PathFamily{
+			Host:       testHostVictim,
+			Pattern:    fmt.Sprintf("/path-%06d", i),
+			EventCount: ec,
+		}
+		totalEvents += ec
+	}
+	cfg := CapConfig{CardinalityCapPerHost: capLimit, TailPromotionBlockPct: 5.0}
+	got, err := CapPerHost(testHostVictim, families, cfg, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Overflowed {
+		t.Fatalf("expected Overflowed=true")
+	}
+	if len(got.Kept) != capLimit {
+		t.Fatalf("expected len(Kept)=%d, got %d", capLimit, len(got.Kept))
+	}
+	if got.Tail.Pattern != testTailPattern {
+		t.Fatalf("Tail.Pattern = %q want %q", got.Tail.Pattern, testTailPattern)
+	}
+	if got.HostTotalEvents != totalEvents {
+		t.Fatalf("HostTotalEvents = %d want %d", got.HostTotalEvents, totalEvents)
+	}
+	// Tail.EventCount = total - kept events.
+	keptSum := 0
+	for _, f := range got.Kept {
+		keptSum += f.EventCount
+	}
+	if got.Tail.EventCount != totalEvents-keptSum {
+		t.Fatalf("Tail.EventCount mismatch: tail=%d, total=%d, kept=%d, expected_tail=%d",
+			got.Tail.EventCount, totalEvents, keptSum, totalEvents-keptSum)
+	}
+	// With ~99k of 100k entries dropped the tail will dominate.
+	if !got.PromotionBlock {
+		tailPct := 100.0 * float64(got.Tail.EventCount) / float64(got.HostTotalEvents)
+		t.Fatalf("expected PromotionBlock=true (tail %v%% of total)", tailPct)
+	}
+}
+
+func TestShouldBlockPromotion_DelegatesField(t *testing.T) {
+	t.Parallel()
+	c1 := CapResult{PromotionBlock: false}
+	if c1.ShouldBlockPromotion() {
+		t.Fatalf("ShouldBlockPromotion() = true want false")
+	}
+	c2 := CapResult{PromotionBlock: true}
+	if !c2.ShouldBlockPromotion() {
+		t.Fatalf("ShouldBlockPromotion() = false want true")
+	}
+}

--- a/internal/contract/inference/normalize/doc.go
+++ b/internal/contract/inference/normalize/doc.go
@@ -1,0 +1,10 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package normalize implements the path-normalization layer of the
+// contract-compile inference engine: frequency-weighted entropy
+// bucketing, the 5-gate collapse decision, the reserved-segment
+// blocklist, and per-host cardinality capping with tail-coverage. Pure
+// functions, no I/O. Consumed by the future compile pipeline at
+// compile-time only; the runtime proxy never invokes this package.
+package normalize

--- a/internal/contract/inference/normalize/evidence.go
+++ b/internal/contract/inference/normalize/evidence.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package normalize
+
+import (
+	"errors"
+	"fmt"
+)
+
+// NormalizationEvidence is the per-rule artifact emitted by the
+// path-normalization layer. It is attached to every rule in the
+// compiled contract YAML and to the signed JCS preimage so verifiers
+// can reconstruct the bucket and reason about why a segment was
+// collapsed or retained. The struct is the wire-form contract; the
+// runtime proxy never reads it (consumed only at compile time and by
+// the review UX).
+type NormalizationEvidence struct {
+	Algorithm         string             `json:"algorithm" yaml:"algorithm"`
+	Bucket            Bucket             `json:"bucket" yaml:"bucket"`
+	CollapsedSegments []CollapsedSegment `json:"collapsed_segments,omitempty" yaml:"collapsed_segments,omitempty"`
+	RetainedSegments  []RetainedSegment  `json:"retained_segments,omitempty" yaml:"retained_segments,omitempty"`
+}
+
+// Bucket is the (host, method, parent-prefix) triple that scopes
+// frequency-weighted entropy. Path-family inference is per-bucket;
+// global path-family inference is forbidden by design (W7 in the
+// W-list at the bottom of the design doc).
+type Bucket struct {
+	Host         string `json:"host" yaml:"host"`
+	Method       string `json:"method" yaml:"method"`
+	ParentPrefix string `json:"parent_prefix" yaml:"parent_prefix"`
+}
+
+// CollapsedSegment records a path segment position that the algorithm
+// merged into a wildcard. It carries enough audit data for the review
+// UX to render the decision: how many distinct values were observed,
+// how many events those values covered, the entropy that triggered
+// the collapse, and the reason code.
+type CollapsedSegment struct {
+	Index          int     `json:"index" yaml:"index"` // 1-indexed segment position
+	DistinctValues int     `json:"distinct_values" yaml:"distinct_values"`
+	EventCount     int     `json:"event_count" yaml:"event_count"`
+	Entropy        float64 `json:"entropy" yaml:"entropy"`
+	Reason         string  `json:"reason" yaml:"reason"` // collapse-reason wire form (see Reason* constants)
+}
+
+// RetainedSegment records a path segment position that the algorithm
+// kept as a literal because it failed at least one collapse gate.
+type RetainedSegment struct {
+	Index  int    `json:"index" yaml:"index"`
+	Value  string `json:"value" yaml:"value"`
+	Reason string `json:"reason" yaml:"reason"` // retain-reason wire form
+}
+
+// Collapse-reason wire forms emitted on CollapsedSegment.Reason. The
+// review UX groups by these values; downstream tooling alerts on
+// specific reasons.
+const (
+	ReasonHighEntropyIdentifierSegment = "high_entropy_identifier_segment"
+)
+
+// Retain-reason wire forms emitted on RetainedSegment.Reason. Each
+// reason corresponds to one of the 5 collapse gates failing in a way
+// that means the segment must be kept as a literal.
+const (
+	ReasonLowEntropyLiteralSegment = "low_entropy_literal_segment"
+	ReasonInsufficientEvents       = "insufficient_events"
+	ReasonInsufficientDistinct     = "insufficient_distinct_values"
+	ReasonReservedSegment          = "reserved_segment"
+	ReasonNoMergeRule              = "no_merge_rule_high_risk_sibling"
+)
+
+// ErrInvalidNormalizationEvidence is the sentinel returned (wrapped)
+// by Validate when an evidence struct fails any of its invariants.
+// Callers use errors.Is for matching.
+var ErrInvalidNormalizationEvidence = errors.New("normalize: invalid normalization evidence")
+
+// Validate reports whether the evidence struct is internally
+// consistent. It enforces the wire-form invariants documented on each
+// field. An evidence struct with both CollapsedSegments and
+// RetainedSegments empty is accepted (rare but valid: a rule on a
+// host where every path was a constant literal already and no
+// collapse decision was reached).
+func (e NormalizationEvidence) Validate() error {
+	if e.Algorithm == "" {
+		return fmt.Errorf("normalize: %w (field=algorithm, value=\"\")", ErrInvalidNormalizationEvidence)
+	}
+	if e.Bucket.Host == "" {
+		return fmt.Errorf("normalize: %w (field=bucket.host, value=\"\")", ErrInvalidNormalizationEvidence)
+	}
+	if e.Bucket.Method == "" {
+		return fmt.Errorf("normalize: %w (field=bucket.method, value=\"\")", ErrInvalidNormalizationEvidence)
+	}
+	for i, seg := range e.CollapsedSegments {
+		if seg.Index < 1 {
+			return fmt.Errorf("normalize: %w (field=collapsed_segments[%d].index, value=%d)", ErrInvalidNormalizationEvidence, i, seg.Index)
+		}
+		if seg.DistinctValues < 0 {
+			return fmt.Errorf("normalize: %w (field=collapsed_segments[%d].distinct_values, value=%d)", ErrInvalidNormalizationEvidence, i, seg.DistinctValues)
+		}
+		if seg.EventCount < 0 {
+			return fmt.Errorf("normalize: %w (field=collapsed_segments[%d].event_count, value=%d)", ErrInvalidNormalizationEvidence, i, seg.EventCount)
+		}
+		if seg.Reason == "" {
+			return fmt.Errorf("normalize: %w (field=collapsed_segments[%d].reason, value=\"\")", ErrInvalidNormalizationEvidence, i)
+		}
+	}
+	for i, seg := range e.RetainedSegments {
+		if seg.Index < 1 {
+			return fmt.Errorf("normalize: %w (field=retained_segments[%d].index, value=%d)", ErrInvalidNormalizationEvidence, i, seg.Index)
+		}
+		if seg.Reason == "" {
+			return fmt.Errorf("normalize: %w (field=retained_segments[%d].reason, value=\"\")", ErrInvalidNormalizationEvidence, i)
+		}
+	}
+	return nil
+}

--- a/internal/contract/inference/normalize/evidence_test.go
+++ b/internal/contract/inference/normalize/evidence_test.go
@@ -1,0 +1,253 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package normalize
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+const (
+	testAlgorithm    = "frequency_weighted_entropy_v1"
+	testHost         = "api.example.com"
+	testMethod       = "GET"
+	testParentPrefix = "/v1"
+)
+
+// validEvidence returns a fully populated NormalizationEvidence that
+// passes Validate. Tests mutate one field to assert each invariant.
+func validEvidence() NormalizationEvidence {
+	return NormalizationEvidence{
+		Algorithm: testAlgorithm,
+		Bucket: Bucket{
+			Host:         testHost,
+			Method:       testMethod,
+			ParentPrefix: testParentPrefix,
+		},
+		CollapsedSegments: []CollapsedSegment{
+			{
+				Index:          3,
+				DistinctValues: 47,
+				EventCount:     211,
+				Entropy:        4.92,
+				Reason:         ReasonHighEntropyIdentifierSegment,
+			},
+		},
+		RetainedSegments: []RetainedSegment{
+			{
+				Index:  2,
+				Value:  "users",
+				Reason: ReasonReservedSegment,
+			},
+		},
+	}
+}
+
+func TestNormalizationEvidence_Validate_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	if err := validEvidence().Validate(); err != nil {
+		t.Fatalf("validEvidence().Validate() = %v, want nil", err)
+	}
+}
+
+func TestNormalizationEvidence_Validate_RejectsEmptyAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	e := validEvidence()
+	e.Algorithm = ""
+	err := e.Validate()
+	if !errors.Is(err, ErrInvalidNormalizationEvidence) {
+		t.Fatalf("Validate() = %v, want wrapped ErrInvalidNormalizationEvidence", err)
+	}
+	if !strings.Contains(err.Error(), "algorithm") {
+		t.Fatalf("error message = %q, want field=algorithm reference", err.Error())
+	}
+}
+
+func TestNormalizationEvidence_Validate_RejectsEmptyBucketHost(t *testing.T) {
+	t.Parallel()
+
+	e := validEvidence()
+	e.Bucket.Host = ""
+	err := e.Validate()
+	if !errors.Is(err, ErrInvalidNormalizationEvidence) {
+		t.Fatalf("Validate() = %v, want wrapped ErrInvalidNormalizationEvidence", err)
+	}
+	if !strings.Contains(err.Error(), "bucket.host") {
+		t.Fatalf("error message = %q, want field=bucket.host reference", err.Error())
+	}
+}
+
+func TestNormalizationEvidence_Validate_RejectsEmptyBucketMethod(t *testing.T) {
+	t.Parallel()
+
+	e := validEvidence()
+	e.Bucket.Method = ""
+	err := e.Validate()
+	if !errors.Is(err, ErrInvalidNormalizationEvidence) {
+		t.Fatalf("Validate() = %v, want wrapped ErrInvalidNormalizationEvidence", err)
+	}
+	if !strings.Contains(err.Error(), "bucket.method") {
+		t.Fatalf("error message = %q, want field=bucket.method reference", err.Error())
+	}
+}
+
+func TestNormalizationEvidence_Validate_AcceptsEmptyParentPrefix(t *testing.T) {
+	t.Parallel()
+
+	e := validEvidence()
+	e.Bucket.ParentPrefix = ""
+	if err := e.Validate(); err != nil {
+		t.Fatalf("Validate() with empty ParentPrefix = %v, want nil (root-level paths are valid)", err)
+	}
+}
+
+func TestNormalizationEvidence_Validate_RejectsBadCollapsedSegment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		mutate    func(*CollapsedSegment)
+		fieldHint string
+	}{
+		{
+			name:      "negative event count",
+			mutate:    func(c *CollapsedSegment) { c.EventCount = -1 },
+			fieldHint: "event_count",
+		},
+		{
+			name:      "negative distinct values",
+			mutate:    func(c *CollapsedSegment) { c.DistinctValues = -1 },
+			fieldHint: "distinct_values",
+		},
+		{
+			name:      "zero index",
+			mutate:    func(c *CollapsedSegment) { c.Index = 0 },
+			fieldHint: "index",
+		},
+		{
+			name:      "negative index",
+			mutate:    func(c *CollapsedSegment) { c.Index = -3 },
+			fieldHint: "index",
+		},
+		{
+			name:      "empty reason",
+			mutate:    func(c *CollapsedSegment) { c.Reason = "" },
+			fieldHint: "reason",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := validEvidence()
+			tc.mutate(&e.CollapsedSegments[0])
+			err := e.Validate()
+			if !errors.Is(err, ErrInvalidNormalizationEvidence) {
+				t.Fatalf("Validate() = %v, want wrapped ErrInvalidNormalizationEvidence", err)
+			}
+			if !strings.Contains(err.Error(), tc.fieldHint) {
+				t.Fatalf("error message = %q, want %q reference", err.Error(), tc.fieldHint)
+			}
+			if !strings.Contains(err.Error(), "collapsed_segments") {
+				t.Fatalf("error message = %q, want collapsed_segments path", err.Error())
+			}
+		})
+	}
+}
+
+func TestNormalizationEvidence_Validate_RejectsBadRetainedSegment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		mutate    func(*RetainedSegment)
+		fieldHint string
+	}{
+		{
+			name:      "zero index",
+			mutate:    func(r *RetainedSegment) { r.Index = 0 },
+			fieldHint: "index",
+		},
+		{
+			name:      "negative index",
+			mutate:    func(r *RetainedSegment) { r.Index = -1 },
+			fieldHint: "index",
+		},
+		{
+			name:      "empty reason",
+			mutate:    func(r *RetainedSegment) { r.Reason = "" },
+			fieldHint: "reason",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := validEvidence()
+			tc.mutate(&e.RetainedSegments[0])
+			err := e.Validate()
+			if !errors.Is(err, ErrInvalidNormalizationEvidence) {
+				t.Fatalf("Validate() = %v, want wrapped ErrInvalidNormalizationEvidence", err)
+			}
+			if !strings.Contains(err.Error(), tc.fieldHint) {
+				t.Fatalf("error message = %q, want %q reference", err.Error(), tc.fieldHint)
+			}
+			if !strings.Contains(err.Error(), "retained_segments") {
+				t.Fatalf("error message = %q, want retained_segments path", err.Error())
+			}
+		})
+	}
+}
+
+func TestNormalizationEvidence_Validate_AcceptsAllSegmentLiterals(t *testing.T) {
+	t.Parallel()
+
+	// Rare but valid: a rule on a host where every path was already a
+	// constant literal so no collapse decision was reached and no
+	// retain decision was emitted either. The Validate contract
+	// permits this.
+	e := NormalizationEvidence{
+		Algorithm: testAlgorithm,
+		Bucket: Bucket{
+			Host:         testHost,
+			Method:       testMethod,
+			ParentPrefix: "",
+		},
+	}
+	if err := e.Validate(); err != nil {
+		t.Fatalf("Validate() with empty Collapsed and Retained = %v, want nil", err)
+	}
+}
+
+func TestReasonConstants_WireForms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"ReasonHighEntropyIdentifierSegment", ReasonHighEntropyIdentifierSegment, "high_entropy_identifier_segment"},
+		{"ReasonLowEntropyLiteralSegment", ReasonLowEntropyLiteralSegment, "low_entropy_literal_segment"},
+		{"ReasonInsufficientEvents", ReasonInsufficientEvents, "insufficient_events"},
+		{"ReasonInsufficientDistinct", ReasonInsufficientDistinct, "insufficient_distinct_values"},
+		{"ReasonReservedSegment", ReasonReservedSegment, "reserved_segment"},
+		{"ReasonNoMergeRule", ReasonNoMergeRule, "no_merge_rule_high_risk_sibling"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.got != tc.want {
+				t.Fatalf("%s = %q, want %q (drift guard: don't change the wire form without bumping the algorithm version)", tc.name, tc.got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/contract/inference/normalize/path.go
+++ b/internal/contract/inference/normalize/path.go
@@ -1,0 +1,594 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package normalize
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"net/url"
+	"sort"
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// AlgorithmFrequencyWeightedEntropyV1 is the wire-form algorithm name
+// emitted on every NormalizationEvidence struct produced by Decide.
+// The version suffix exists so future changes to the gate matrix or
+// entropy definition can ship under v2/v3 without breaking
+// signature-verification on contracts compiled against v1.
+const AlgorithmFrequencyWeightedEntropyV1 = "frequency_weighted_entropy_v1"
+
+// Path-length ceiling. 2048 chars is the design's stated cap and is a
+// generous bound: real-world recorder paths above 2048 are almost
+// always pathological (encoded payload smuggling, fuzz noise, or
+// mis-decoded binary). We reject these at the boundary rather than try
+// to normalize them — a normalize step that succeeds on a 100 KB path
+// is a DoS amplifier on the compile pipeline.
+const maxPathBytes = 2048
+
+// EntropyThresholdMaxBits is the upper bound for
+// DecideConfig.EntropyThresholdBits accepted by Validate. A single
+// segment can carry at most log2(N_distinct) bits of entropy, and
+// requiring more than 8 bits before we collapse means even 256
+// distinct values per segment wouldn't be enough — almost certainly a
+// config typo (e.g. someone wrote "30" thinking percent).
+const EntropyThresholdMaxBits = 8.0
+
+// Sentinel errors returned (wrapped) from Canonicalize. Callers MUST
+// match with errors.Is, never raw equality, because every return
+// wraps with fmt.Errorf("%w (...detail)") so the operator sees the
+// offending input without breaking the errors.Is chain.
+var (
+	// ErrPathEmpty signals the raw input was the empty string.
+	ErrPathEmpty = errors.New("normalize: path is empty")
+
+	// ErrPathTooLong signals the raw input exceeded maxPathBytes
+	// after no normalization. The byte length, not the rune count,
+	// is the gate — a multi-byte UTF-8 sequence still costs bytes
+	// downstream.
+	ErrPathTooLong = errors.New("normalize: path exceeds 2048 chars")
+
+	// ErrPathNonCanonical signals the path contains structural noise
+	// the canonicalizer refuses to silently rewrite: dot-segments
+	// (".", ".."), double slashes, trailing slash on a non-root
+	// path, control characters, or a percent-encoded slash that
+	// would change topology after decoding.
+	ErrPathNonCanonical = errors.New("normalize: path is non-canonical")
+
+	// ErrPathDecodeFailure signals a malformed percent-escape
+	// (truncated %xy, non-hex digits) inside a segment.
+	ErrPathDecodeFailure = errors.New("normalize: percent-decode failed")
+)
+
+// ErrInvalidDecideConfig is returned (wrapped) by DecideConfig.Validate
+// when any knob is out of range. Matches with errors.Is.
+var ErrInvalidDecideConfig = errors.New("normalize: invalid decide config")
+
+// Canonicalize transforms a raw path from a recorder event into the
+// form Decide consumes. The pipeline is:
+//
+//  1. Reject empty or > maxPathBytes inputs.
+//  2. Apply Unicode NFC normalization.
+//  3. Lowercase via strings.ToLower (full-Unicode, not just ASCII).
+//  4. Split on '/' and percent-decode each segment with
+//     url.PathUnescape.
+//  5. Reject any non-canonical structure: ".", "..", "//",
+//     trailing-slash-on-non-root, control characters, percent-encoded
+//     slashes, segments containing literal '/' after decode.
+//
+// Only path topology is validated here. Host, query, and fragment are
+// the caller's responsibility — Bucket.Host comes from a separate
+// host-normalization pass at the recorder boundary.
+//
+// Pure: no I/O, no allocations beyond the result strings, no panics.
+// Returns the canonical path string, the segment slice (1-indexed by
+// the algorithm but Go-0-indexed in the slice), and a wrapped
+// sentinel on failure.
+func Canonicalize(rawPath string) (string, []string, error) {
+	if rawPath == "" {
+		return "", nil, fmt.Errorf("%w", ErrPathEmpty)
+	}
+	if len(rawPath) > maxPathBytes {
+		return "", nil, fmt.Errorf("%w (length=%d)", ErrPathTooLong, len(rawPath))
+	}
+
+	// NFC normalization first so any combining-character form
+	// folds into the composed code points before we lowercase or
+	// split. Note: NFC, not NFKC. NFKC is a different security
+	// surface (compat decomposition) and is not what the design
+	// asks for here; the path-level canonicalization is conservative
+	// and only normalizes form, not visual confusables.
+	canonical := norm.NFC.String(rawPath)
+
+	// Full-Unicode lowercase. Many ID strings reach pipelock via
+	// agents that uppercase casually; the bucket is per-host
+	// per-method, so case folding the path keeps "/Repos/Foo" and
+	// "/repos/foo" in the same bucket.
+	canonical = strings.ToLower(canonical)
+
+	// Reject control characters anywhere in the path before we
+	// touch percent-decoding. A %00 in a path is a strong signal
+	// the agent is probing a parser differential, and accepting it
+	// would let attackers embed null bytes in collapsed segments
+	// downstream.
+	if hasControlChar(canonical) {
+		return "", nil, fmt.Errorf("%w (reason=control_char)", ErrPathNonCanonical)
+	}
+
+	// A leading '/' is required for a recorder path. Bare "foo"
+	// would split into [""] which is misleading — reject up front.
+	if !strings.HasPrefix(canonical, "/") {
+		return "", nil, fmt.Errorf("%w (reason=missing_leading_slash)", ErrPathNonCanonical)
+	}
+
+	// Special case: root path "/". Splitting on "/" yields ["", ""]
+	// which is two empty segments, but the algorithm wants
+	// segments=[].
+	if canonical == "/" {
+		return "/", []string{}, nil
+	}
+
+	// Trailing slash on a non-root path is non-canonical: it
+	// changes the bucket parent_prefix for the same logical
+	// resource. Reject so the caller fixes it upstream.
+	if strings.HasSuffix(canonical, "/") {
+		return "", nil, fmt.Errorf("%w (reason=trailing_slash)", ErrPathNonCanonical)
+	}
+
+	// Split on '/'. Drop the leading empty element from the leading
+	// '/'. We've already rejected trailing slash on non-root, so no
+	// trailing empty element here.
+	rawSegments := strings.Split(canonical[1:], "/")
+
+	// Percent-decode each segment, rejecting double slashes,
+	// dot-segments, decode failures, and decoded-segments
+	// containing literal '/' (which would indicate a percent-encoded
+	// slash, a topology-changing bypass).
+	segments := make([]string, 0, len(rawSegments))
+	decodedSegments := make([]string, 0, len(rawSegments))
+	for _, seg := range rawSegments {
+		if seg == "" {
+			return "", nil, fmt.Errorf("%w (reason=double_slash)", ErrPathNonCanonical)
+		}
+		if seg == "." || seg == ".." {
+			return "", nil, fmt.Errorf("%w (reason=dot_segment, segment=%q)", ErrPathNonCanonical, seg)
+		}
+		decoded, err := url.PathUnescape(seg)
+		if err != nil {
+			return "", nil, fmt.Errorf("%w (segment=%q): %w", ErrPathDecodeFailure, seg, err)
+		}
+		// Decoded segment containing a literal '/' means the input
+		// had %2F, which would silently change the path topology
+		// (one segment becomes multiple). Treat as a bypass and
+		// reject.
+		if strings.ContainsRune(decoded, '/') {
+			return "", nil, fmt.Errorf("%w (reason=percent_encoded_slash, segment=%q)", ErrPathNonCanonical, seg)
+		}
+		// Defense-in-depth: decoded value should not contain any
+		// control char either. Without this, a %01 inside a
+		// segment would slip through (we only checked the raw
+		// input's control chars before decoding).
+		if hasControlChar(decoded) {
+			return "", nil, fmt.Errorf("%w (reason=decoded_control_char)", ErrPathNonCanonical)
+		}
+		// Note: a non-empty seg cannot decode to "" because
+		// url.PathUnescape never strips bytes without erroring,
+		// so no explicit empty-decoded check is needed here.
+		segments = append(segments, decoded)
+		decodedSegments = append(decodedSegments, decoded)
+	}
+
+	// Re-emit the canonical form from the decoded segments so the
+	// returned string matches the segment slice byte-for-byte. This
+	// guarantees a caller that splits the canonical path on '/' will
+	// recover the same slice.
+	canonicalOut := "/" + strings.Join(decodedSegments, "/")
+	return canonicalOut, segments, nil
+}
+
+// hasControlChar reports whether s contains any byte in the C0
+// (\x00-\x1F) or DEL (\x7F) ranges. Operates on bytes, not runes,
+// because control bytes embedded in UTF-8 mid-sequence are still
+// dangerous regardless of how the surrounding rune is counted.
+func hasControlChar(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c <= 0x1F || c == 0x7F {
+			return true
+		}
+	}
+	return false
+}
+
+// Entropy returns the frequency-weighted Shannon entropy in bits of
+// the value distribution described by counts. counts maps each
+// distinct value at a single segment position to the number of
+// recorder events that produced it. The formula is:
+//
+//	H = -Σ p_i * log2(p_i)   where p_i = counts[v_i] / total
+//
+// Edge cases:
+//   - Empty map or total <= 0 returns 0.0 (no entropy).
+//   - A single distinct value returns 0.0 (perfect predictability).
+//   - Any non-positive count is skipped so log2(0) never appears.
+//
+// Pure: no I/O, never panics, never returns NaN or Inf.
+func Entropy(counts map[string]int) float64 {
+	if len(counts) == 0 {
+		return 0.0
+	}
+	total := 0
+	for _, c := range counts {
+		if c <= 0 {
+			continue
+		}
+		total += c
+	}
+	if total <= 0 {
+		return 0.0
+	}
+	var h float64
+	denom := float64(total)
+	for _, c := range counts {
+		if c <= 0 {
+			continue
+		}
+		p := float64(c) / denom
+		// p is strictly positive here because c > 0 and denom > 0.
+		h -= p * math.Log2(p)
+	}
+	// Guard against any residual numerical noise. A pure
+	// computation should not produce NaN or Inf, but a defensive
+	// clamp protects downstream code that hashes evidence into a
+	// policy hash.
+	if math.IsNaN(h) || math.IsInf(h, 0) {
+		return 0.0
+	}
+	return h
+}
+
+// DecideConfig carries the algorithm knobs for Decide. Every field
+// maps 1:1 to a YAML field on
+// learn.inference.normalization in the deployment config; the YAML
+// loader is responsible for translating between snake_case YAML and
+// these typed Go fields.
+type DecideConfig struct {
+	// MinEvents is gate 1: the bucket must contain at least this
+	// many total events at the position before any collapse is
+	// considered.
+	MinEvents int
+
+	// MinDistinctValues is gate 2: the position must show at least
+	// this many distinct value strings. With min=5 and 4 distinct
+	// values we retain.
+	MinDistinctValues int
+
+	// EntropyThresholdBits is gate 3: the position's
+	// frequency-weighted Shannon entropy must equal or exceed this
+	// many bits before we collapse.
+	EntropyThresholdBits float64
+
+	// ReservedExtras is appended to the package's canonical
+	// reserved-segment list when running gate 4. Operator-supplied
+	// extras can extend the security floor but cannot remove
+	// canonical entries.
+	ReservedExtras []string
+
+	// HighRiskSiblings drives gate 5: if any value at the position
+	// matches one of these names, the entire position retains. The
+	// caller decides which siblings count as "high risk"; this
+	// package only enforces the rule.
+	HighRiskSiblings []string
+}
+
+// Default knob values, matching the design baseline. The
+// constants are unexported so callers must go through
+// DefaultDecideConfig — that pattern makes the drift guard test
+// trivial (TestDefaultDecideConfig_Locked) and keeps the values out
+// of unrelated import sets.
+const (
+	defaultDecideMinEvents            = 10
+	defaultDecideMinDistinctValues    = 5
+	defaultDecideEntropyThresholdBits = 3.0
+)
+
+// DefaultDecideConfig returns the design's canonical defaults:
+// MinEvents=10, MinDistinctValues=5, EntropyThresholdBits=3.0,
+// ReservedExtras=nil, HighRiskSiblings=nil. The drift-guard test
+// asserts exact equality so these values cannot move silently.
+func DefaultDecideConfig() DecideConfig {
+	return DecideConfig{
+		MinEvents:            defaultDecideMinEvents,
+		MinDistinctValues:    defaultDecideMinDistinctValues,
+		EntropyThresholdBits: defaultDecideEntropyThresholdBits,
+		ReservedExtras:       nil,
+		HighRiskSiblings:     nil,
+	}
+}
+
+// Resolved returns a DecideConfig with each zero-valued numeric field
+// replaced by its default. Negative values pass through unchanged so
+// Validate (which the caller is expected to run first or after) can
+// surface them as configuration errors instead of silently rewriting
+// them to a default.
+//
+// The slice fields ReservedExtras and HighRiskSiblings are passed
+// through; nil slices are valid inputs and stay nil.
+func (c DecideConfig) Resolved() DecideConfig {
+	out := c
+	if out.MinEvents == 0 {
+		out.MinEvents = defaultDecideMinEvents
+	}
+	if out.MinDistinctValues == 0 {
+		out.MinDistinctValues = defaultDecideMinDistinctValues
+	}
+	if out.EntropyThresholdBits == 0 {
+		out.EntropyThresholdBits = defaultDecideEntropyThresholdBits
+	}
+	return out
+}
+
+// Validate reports whether the config is internally consistent.
+// Negative integer thresholds, negative entropy, or entropy above
+// EntropyThresholdMaxBits are all rejected with a wrapped sentinel.
+// Slice fields are not validated here; the caller validates segment
+// content at the boundary where it has type info.
+func (c DecideConfig) Validate() error {
+	if c.MinEvents < 0 {
+		return fmt.Errorf("%w (field=min_events, value=%d)", ErrInvalidDecideConfig, c.MinEvents)
+	}
+	if c.MinDistinctValues < 0 {
+		return fmt.Errorf("%w (field=min_distinct_values, value=%d)", ErrInvalidDecideConfig, c.MinDistinctValues)
+	}
+	if c.EntropyThresholdBits < 0 {
+		return fmt.Errorf("%w (field=entropy_threshold_bits, value=%g)", ErrInvalidDecideConfig, c.EntropyThresholdBits)
+	}
+	if c.EntropyThresholdBits > EntropyThresholdMaxBits {
+		return fmt.Errorf("%w (field=entropy_threshold_bits, value=%g, max=%g)", ErrInvalidDecideConfig, c.EntropyThresholdBits, EntropyThresholdMaxBits)
+	}
+	return nil
+}
+
+// SegmentObservation is one observed (value-at-position, event-weight)
+// pair from a single bucket. The future compile pipeline will flatten
+// recorder events into a slice of these per (host, method,
+// parent_prefix) bucket and per segment position.
+//
+// Index is 1-indexed to match the wire-form Index field on
+// CollapsedSegment / RetainedSegment. Decide preserves that 1-indexed
+// convention end-to-end.
+type SegmentObservation struct {
+	// Index is the 1-indexed segment position. Index 1 is the
+	// segment immediately after the leading '/'.
+	Index int
+
+	// Value is the already-canonicalized literal segment text. The
+	// caller is responsible for running Canonicalize and pulling
+	// the matching slice element before constructing this struct.
+	Value string
+
+	// EventCount is how many recorder events observed this Value
+	// at this Index. Non-positive counts are treated as zero by
+	// Decide.
+	EventCount int
+}
+
+// Decide composes the bucket's observations into a NormalizationEvidence,
+// running the 5-gate test per segment position and emitting one entry
+// per position into either CollapsedSegments or RetainedSegments.
+//
+// Gates (in order, first-failure-wins for retain reasons):
+//
+//  1. min_events: total event count at the position >= cfg.MinEvents.
+//     Failure → ReasonInsufficientEvents.
+//  2. min_distinct_values: count of distinct values at the position
+//     >= cfg.MinDistinctValues. Single-distinct-value positions retain
+//     with ReasonLowEntropyLiteralSegment (covers "/repos always
+//     appears at index 1"); 2..(min-1) distinct retain with
+//     ReasonInsufficientDistinct.
+//  3. entropy: frequency-weighted Shannon entropy >= cfg.EntropyThresholdBits.
+//     Failure → ReasonLowEntropyLiteralSegment.
+//  4. reserved: any value at the position matches IsReserved with
+//     cfg.ReservedExtras. Failure → ReasonReservedSegment.
+//  5. no-merge: any value at the position matches cfg.HighRiskSiblings.
+//     Failure → ReasonNoMergeRule.
+//
+// Gates 4 and 5 are evaluated AFTER 1/2/3 in the listing above, but
+// the reserved/no-merge checks are position-level: they apply
+// regardless of how high entropy climbs. The implementation evaluates
+// gates 4 and 5 BEFORE gates 2 and 3 so that even a position with
+// only one distinct value still surfaces "reserved_segment" if that
+// value is reserved — that's the security floor.
+//
+// Determinism: positions are emitted in ascending Index order. The
+// caller hashes this evidence into the policy hash, so non-deterministic
+// map iteration would break audit reproducibility.
+func Decide(observations []SegmentObservation, cfg DecideConfig) NormalizationEvidence {
+	resolved := cfg.Resolved()
+	evidence := NormalizationEvidence{
+		Algorithm: AlgorithmFrequencyWeightedEntropyV1,
+	}
+	if len(observations) == 0 {
+		return evidence
+	}
+
+	// Aggregate: per-index map of value -> count.
+	type positionAgg struct {
+		counts map[string]int
+		total  int
+	}
+	byIndex := make(map[int]*positionAgg)
+	for _, obs := range observations {
+		if obs.Index < 1 {
+			// Defensive: skip malformed input. The caller is
+			// supposed to use 1-indexed positions; a 0 or
+			// negative index is a programming error upstream
+			// but Decide must not panic on it.
+			continue
+		}
+		count := obs.EventCount
+		if count <= 0 {
+			continue
+		}
+		agg, ok := byIndex[obs.Index]
+		if !ok {
+			agg = &positionAgg{counts: make(map[string]int)}
+			byIndex[obs.Index] = agg
+		}
+		agg.counts[obs.Value] += count
+		agg.total += count
+	}
+
+	// Sort indices ascending so emission order is deterministic.
+	// Map iteration in Go is randomized; without this sort the
+	// signed contract hash would change run-to-run on identical
+	// input.
+	indices := make([]int, 0, len(byIndex))
+	for i := range byIndex {
+		indices = append(indices, i)
+	}
+	sort.Ints(indices)
+
+	for _, idx := range indices {
+		agg := byIndex[idx]
+
+		// Gate 4 first: reserved-segment presence. A reserved
+		// value at this index forces retain regardless of
+		// entropy, distinct count, or event count. We retain a
+		// stable representative value for the wire form (the
+		// first reserved value in sorted order, so the evidence
+		// is reproducible).
+		if reservedHit := firstReservedValue(agg.counts, resolved.ReservedExtras); reservedHit != "" {
+			evidence.RetainedSegments = append(evidence.RetainedSegments, RetainedSegment{
+				Index:  idx,
+				Value:  reservedHit,
+				Reason: ReasonReservedSegment,
+			})
+			continue
+		}
+
+		// Gate 5: high-risk sibling presence. Same logic as
+		// reserved but with the operator-supplied list.
+		if siblingHit := firstSiblingValue(agg.counts, resolved.HighRiskSiblings); siblingHit != "" {
+			evidence.RetainedSegments = append(evidence.RetainedSegments, RetainedSegment{
+				Index:  idx,
+				Value:  siblingHit,
+				Reason: ReasonNoMergeRule,
+			})
+			continue
+		}
+
+		// Gate 1: min_events.
+		if agg.total < resolved.MinEvents {
+			evidence.RetainedSegments = append(evidence.RetainedSegments, RetainedSegment{
+				Index:  idx,
+				Value:  representativeValue(agg.counts),
+				Reason: ReasonInsufficientEvents,
+			})
+			continue
+		}
+
+		// Gate 2: min_distinct_values. Single-distinct-value
+		// positions get a more specific reason because the most
+		// common case is a literal path component like "/repos"
+		// that should never collapse — calling that
+		// "insufficient_distinct" would be misleading in audit.
+		distinct := len(agg.counts)
+		if distinct < resolved.MinDistinctValues {
+			reason := ReasonInsufficientDistinct
+			if distinct <= 1 {
+				reason = ReasonLowEntropyLiteralSegment
+			}
+			evidence.RetainedSegments = append(evidence.RetainedSegments, RetainedSegment{
+				Index:  idx,
+				Value:  representativeValue(agg.counts),
+				Reason: reason,
+			})
+			continue
+		}
+
+		// Gate 3: entropy.
+		entropy := Entropy(agg.counts)
+		if entropy < resolved.EntropyThresholdBits {
+			evidence.RetainedSegments = append(evidence.RetainedSegments, RetainedSegment{
+				Index:  idx,
+				Value:  representativeValue(agg.counts),
+				Reason: ReasonLowEntropyLiteralSegment,
+			})
+			continue
+		}
+
+		// All 5 gates passed — collapse.
+		evidence.CollapsedSegments = append(evidence.CollapsedSegments, CollapsedSegment{
+			Index:          idx,
+			DistinctValues: distinct,
+			EventCount:     agg.total,
+			Entropy:        entropy,
+			Reason:         ReasonHighEntropyIdentifierSegment,
+		})
+	}
+
+	return evidence
+}
+
+// firstReservedValue returns the lexicographically-first value in
+// counts that matches IsReserved. Sorting first guarantees a
+// deterministic representative value for the audit record;
+// non-deterministic order would break the signed contract hash.
+// Returns "" when no value matches.
+func firstReservedValue(counts map[string]int, extras []string) string {
+	keys := sortedKeys(counts)
+	for _, k := range keys {
+		if IsReserved(k, extras) {
+			return k
+		}
+	}
+	return ""
+}
+
+// firstSiblingValue returns the lexicographically-first value in
+// counts that matches any name in siblings. Same determinism
+// rationale as firstReservedValue.
+func firstSiblingValue(counts map[string]int, siblings []string) string {
+	if len(siblings) == 0 {
+		return ""
+	}
+	keys := sortedKeys(counts)
+	for _, k := range keys {
+		for _, s := range siblings {
+			if k == s {
+				return k
+			}
+		}
+	}
+	return ""
+}
+
+// representativeValue returns the lexicographically-first value in
+// counts. Used for the RetainedSegment.Value field on retain reasons
+// that are not tied to a specific value (insufficient_events,
+// insufficient_distinct, low_entropy_literal_segment). Stable across
+// runs; never panics; "" only when counts is empty (which Decide
+// already filters out before reaching this path).
+func representativeValue(counts map[string]int) string {
+	keys := sortedKeys(counts)
+	if len(keys) == 0 {
+		return ""
+	}
+	return keys[0]
+}
+
+// sortedKeys returns the keys of counts in ascending byte order.
+// Centralized so all three helper functions share the same
+// determinism contract; callers must not mutate the result.
+func sortedKeys(counts map[string]int) []string {
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/contract/inference/normalize/path_test.go
+++ b/internal/contract/inference/normalize/path_test.go
@@ -1,0 +1,792 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package normalize
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+)
+
+const (
+	testValRepos = "repos"
+	testValAdmin = "admin"
+	testValUsers = "users"
+	testValAuth  = "auth"
+	testValDebug = "debug"
+)
+
+// ---------- Canonicalize ----------
+
+func TestCanonicalize_HappyPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantPath string
+		wantSegs []string
+	}{
+		{"simple ascii", "/foo/bar", "/foo/bar", []string{"foo", "bar"}},
+		{"root", "/", "/", []string{}},
+		{"case folding", "/FOO/Bar", "/foo/bar", []string{"foo", "bar"}},
+		{"percent decoded", "/foo%20bar", "/foo bar", []string{"foo bar"}},
+		{"multi segment", "/repos/octocat/hello-world", "/repos/octocat/hello-world", []string{"repos", "octocat", "hello-world"}},
+		{"unicode path lowercased", "/Repos/ÉClair", "/repos/éclair", []string{"repos", "éclair"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath, gotSegs, err := Canonicalize(tt.in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotPath != tt.wantPath {
+				t.Errorf("path: got %q, want %q", gotPath, tt.wantPath)
+			}
+			if len(gotSegs) != len(tt.wantSegs) {
+				t.Fatalf("segs len: got %d, want %d (got=%v)", len(gotSegs), len(tt.wantSegs), gotSegs)
+			}
+			for i := range gotSegs {
+				if gotSegs[i] != tt.wantSegs[i] {
+					t.Errorf("seg[%d]: got %q, want %q", i, gotSegs[i], tt.wantSegs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCanonicalize_RejectsEmpty(t *testing.T) {
+	_, _, err := Canonicalize("")
+	if !errors.Is(err, ErrPathEmpty) {
+		t.Fatalf("got %v, want ErrPathEmpty", err)
+	}
+}
+
+func TestCanonicalize_RejectsTooLong(t *testing.T) {
+	// 2049-char path rejects.
+	long := "/" + strings.Repeat("a", maxPathBytes)
+	_, _, err := Canonicalize(long)
+	if !errors.Is(err, ErrPathTooLong) {
+		t.Fatalf("got %v, want ErrPathTooLong", err)
+	}
+	// 2048-char path accepts.
+	exact := "/" + strings.Repeat("a", maxPathBytes-1)
+	if len(exact) != maxPathBytes {
+		t.Fatalf("test setup: exact path length %d != %d", len(exact), maxPathBytes)
+	}
+	if _, _, err := Canonicalize(exact); err != nil {
+		t.Fatalf("2048-char path should accept, got %v", err)
+	}
+}
+
+func TestCanonicalize_RejectsNonCanonical(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"dot dot", "/foo/../bar"},
+		{"dot", "/foo/./bar"},
+		{"double slash", "/foo//bar"},
+		{"trailing slash", "/foo/bar/"},
+		{"null byte", "/foo\x00bar"},
+		{"control 0x1f", "/foo\x1fbar"},
+		{"control 0x7f", "/foo\x7fbar"},
+		{"missing leading slash", "foo/bar"},
+		{"leading dot dot", "/../etc/passwd"},
+		{"trailing dot", "/foo/."},
+		{"trailing slash root extension", "/foo/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := Canonicalize(tt.in)
+			if !errors.Is(err, ErrPathNonCanonical) {
+				t.Fatalf("got %v, want ErrPathNonCanonical", err)
+			}
+		})
+	}
+}
+
+func TestCanonicalize_RejectsBadPercentDecode(t *testing.T) {
+	tests := []string{
+		"/foo%2",
+		"/foo%XX",
+		"/foo%G0",
+	}
+	for _, in := range tests {
+		t.Run(in, func(t *testing.T) {
+			_, _, err := Canonicalize(in)
+			if !errors.Is(err, ErrPathDecodeFailure) {
+				t.Fatalf("got %v, want ErrPathDecodeFailure", err)
+			}
+		})
+	}
+}
+
+func TestCanonicalize_RejectsPercentEncodedSlash(t *testing.T) {
+	// %2F decodes to '/', which would split one segment into two.
+	_, _, err := Canonicalize("/foo%2Fbar")
+	if !errors.Is(err, ErrPathNonCanonical) {
+		t.Fatalf("got %v, want ErrPathNonCanonical", err)
+	}
+}
+
+func TestCanonicalize_RejectsDecodedControlChar(t *testing.T) {
+	// %01 decodes to a C0 control char that wasn't visible pre-decode.
+	_, _, err := Canonicalize("/foo%01bar")
+	if !errors.Is(err, ErrPathNonCanonical) {
+		t.Fatalf("got %v, want ErrPathNonCanonical", err)
+	}
+}
+
+func TestCanonicalize_NFCApplied(t *testing.T) {
+	// "é" (decomposed) and "é" (composed) must fold to the
+	// same canonical form via NFC.
+	decomposed := "/café" // /cafe + combining acute
+	composed := "/café"    // /café composed
+	gotDec, _, err := Canonicalize(decomposed)
+	if err != nil {
+		t.Fatalf("decomposed: %v", err)
+	}
+	gotComp, _, err := Canonicalize(composed)
+	if err != nil {
+		t.Fatalf("composed: %v", err)
+	}
+	if gotDec != gotComp {
+		t.Fatalf("NFC fold mismatch: decomposed=%q composed=%q", gotDec, gotComp)
+	}
+}
+
+func TestCanonicalize_RootPath(t *testing.T) {
+	gotPath, gotSegs, err := Canonicalize("/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/" {
+		t.Errorf("path: got %q, want /", gotPath)
+	}
+	if len(gotSegs) != 0 {
+		t.Errorf("segs: got %v, want empty", gotSegs)
+	}
+}
+
+func TestCanonicalize_DeterministicAcross1000Calls(t *testing.T) {
+	in := "/Repos/Octocat/Hello-World%20Test"
+	wantPath, wantSegs, err := Canonicalize(in)
+	if err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	for i := 0; i < 1000; i++ {
+		gotPath, gotSegs, err := Canonicalize(in)
+		if err != nil {
+			t.Fatalf("iter %d: %v", i, err)
+		}
+		if gotPath != wantPath {
+			t.Fatalf("iter %d: path drift got %q want %q", i, gotPath, wantPath)
+		}
+		if len(gotSegs) != len(wantSegs) {
+			t.Fatalf("iter %d: seg-count drift", i)
+		}
+		for j := range gotSegs {
+			if gotSegs[j] != wantSegs[j] {
+				t.Fatalf("iter %d seg[%d]: drift got %q want %q", i, j, gotSegs[j], wantSegs[j])
+			}
+		}
+	}
+}
+
+// ---------- Entropy ----------
+
+func TestEntropy_EmptyReturnsZero(t *testing.T) {
+	if got := Entropy(map[string]int{}); got != 0.0 {
+		t.Errorf("got %v, want 0", got)
+	}
+	if got := Entropy(nil); got != 0.0 {
+		t.Errorf("nil: got %v, want 0", got)
+	}
+}
+
+func TestEntropy_SingleValueReturnsZero(t *testing.T) {
+	got := Entropy(map[string]int{"foo": 100})
+	if got != 0.0 {
+		t.Errorf("got %v, want 0", got)
+	}
+}
+
+func TestEntropy_FiftyFifty(t *testing.T) {
+	got := Entropy(map[string]int{"a": 50, "b": 50})
+	if math.Abs(got-1.0) > 1e-9 {
+		t.Errorf("got %v, want 1.0", got)
+	}
+}
+
+func TestEntropy_UniformN(t *testing.T) {
+	// 4 equal-count values => log2(4) = 2.
+	got := Entropy(map[string]int{"a": 1, "b": 1, "c": 1, "d": 1})
+	if math.Abs(got-2.0) > 1e-9 {
+		t.Errorf("got %v, want 2.0", got)
+	}
+}
+
+func TestEntropy_DesignTableRow(t *testing.T) {
+	// Design example: 87 distinct values, 412 events, entropy ~5.9.
+	// We construct a near-uniform distribution: 87 values, total 412
+	// events (412/87 ≈ 4.74). Allocate 4 events to most values and 5
+	// to the first 412-87*4 = 64 values to use up the total.
+	counts := make(map[string]int)
+	const distinct = 87
+	const total = 412
+	base := total / distinct
+	extras := total - base*distinct
+	for i := 0; i < distinct; i++ {
+		k := fmt.Sprintf("v%03d", i)
+		c := base
+		if i < extras {
+			c++
+		}
+		counts[k] = c
+	}
+	got := Entropy(counts)
+	// Upper bound is log2(87) ~= 6.44; near-uniform should land in
+	// roughly [5.8, 6.5] per the design's "5.9" stated value.
+	if got < 5.5 || got > 6.5 {
+		t.Errorf("got %v, want in [5.5, 6.5] (design row says ~5.9)", got)
+	}
+	// Tighter assertion: within 0.1 of 6.44 (uniform limit) since
+	// our distribution is nearly uniform.
+	uniformLimit := math.Log2(distinct)
+	if math.Abs(got-uniformLimit) > 0.1 {
+		t.Errorf("near-uniform should approach log2(87)=%v, got %v", uniformLimit, got)
+	}
+}
+
+func TestEntropy_NeverNaN(t *testing.T) {
+	// Synthetic mixes: zero counts, large counts, one-offs, and a
+	// deterministic pseudo-random pattern. None should produce NaN
+	// or Inf. We use a stateful linear-congruential mixer rather
+	// than math/rand so the test is fully deterministic without
+	// pulling in a weak-RNG dependency.
+	state := uint64(0xDEADBEEFCAFEBABE)
+	mix := func() uint64 {
+		state = state*6364136223846793005 + 1442695040888963407
+		return state
+	}
+	for i := 0; i < 100; i++ {
+		counts := make(map[string]int)
+		n := int(mix() % 20)
+		for j := 0; j < n; j++ {
+			counts[fmt.Sprintf("k%d", j)] = int(mix() % 1_000_000)
+		}
+		got := Entropy(counts)
+		if math.IsNaN(got) || math.IsInf(got, 0) {
+			t.Fatalf("iter %d: got %v from %v", i, got, counts)
+		}
+		if got < 0 {
+			t.Fatalf("iter %d: negative entropy %v", i, got)
+		}
+	}
+}
+
+func TestEntropy_DeterministicAcross1000Calls(t *testing.T) {
+	counts := map[string]int{"a": 11, "b": 22, "c": 33, "d": 44}
+	want := Entropy(counts)
+	for i := 0; i < 1000; i++ {
+		if got := Entropy(counts); got != want {
+			t.Fatalf("iter %d: drift got %v want %v", i, got, want)
+		}
+	}
+}
+
+func TestEntropy_HandlesNonPositiveCounts(t *testing.T) {
+	// Zero/negative counts must be skipped without panic.
+	got := Entropy(map[string]int{"a": 50, "b": 50, "skipped-zero": 0, "skipped-neg": -5})
+	if math.Abs(got-1.0) > 1e-9 {
+		t.Errorf("got %v, want 1.0 (non-positive entries skipped)", got)
+	}
+}
+
+func TestEntropy_AllNonPositiveCountsReturnsZero(t *testing.T) {
+	// Map is non-empty (so len-zero guard skipped) but every count is
+	// non-positive. Exercises the "total <= 0" defensive guard.
+	got := Entropy(map[string]int{"a": 0, "b": -1, "c": -100})
+	if got != 0.0 {
+		t.Errorf("got %v, want 0", got)
+	}
+}
+
+// ---------- DecideConfig ----------
+
+func TestDefaultDecideConfig_Locked(t *testing.T) {
+	got := DefaultDecideConfig()
+	want := DecideConfig{
+		MinEvents:            10,
+		MinDistinctValues:    5,
+		EntropyThresholdBits: 3.0,
+		ReservedExtras:       nil,
+		HighRiskSiblings:     nil,
+	}
+	if got.MinEvents != want.MinEvents ||
+		got.MinDistinctValues != want.MinDistinctValues ||
+		got.EntropyThresholdBits != want.EntropyThresholdBits ||
+		got.ReservedExtras != nil ||
+		got.HighRiskSiblings != nil {
+		t.Fatalf("default drifted: got %+v, want %+v", got, want)
+	}
+}
+
+func TestDecideConfig_Resolved(t *testing.T) {
+	tests := []struct {
+		name string
+		in   DecideConfig
+		want DecideConfig
+	}{
+		{
+			"all zero",
+			DecideConfig{},
+			DefaultDecideConfig(),
+		},
+		{
+			"min_events set, others default",
+			DecideConfig{MinEvents: 25},
+			DecideConfig{MinEvents: 25, MinDistinctValues: 5, EntropyThresholdBits: 3.0},
+		},
+		{
+			"min_distinct set, others default",
+			DecideConfig{MinDistinctValues: 8},
+			DecideConfig{MinEvents: 10, MinDistinctValues: 8, EntropyThresholdBits: 3.0},
+		},
+		{
+			"entropy set, others default",
+			DecideConfig{EntropyThresholdBits: 4.5},
+			DecideConfig{MinEvents: 10, MinDistinctValues: 5, EntropyThresholdBits: 4.5},
+		},
+		{
+			"all set",
+			DecideConfig{MinEvents: 20, MinDistinctValues: 6, EntropyThresholdBits: 2.5},
+			DecideConfig{MinEvents: 20, MinDistinctValues: 6, EntropyThresholdBits: 2.5},
+		},
+		{
+			"negatives pass through",
+			DecideConfig{MinEvents: -1, MinDistinctValues: -2, EntropyThresholdBits: -3},
+			DecideConfig{MinEvents: -1, MinDistinctValues: -2, EntropyThresholdBits: -3},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.in.Resolved()
+			if got.MinEvents != tt.want.MinEvents ||
+				got.MinDistinctValues != tt.want.MinDistinctValues ||
+				got.EntropyThresholdBits != tt.want.EntropyThresholdBits {
+				t.Fatalf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecideConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     DecideConfig
+		wantErr bool
+	}{
+		{"defaults ok", DefaultDecideConfig(), false},
+		{"zeroes ok (treated as defaults at apply-time)", DecideConfig{}, false},
+		{"max entropy ok", DecideConfig{EntropyThresholdBits: EntropyThresholdMaxBits}, false},
+		{"high entropy reasonable", DecideConfig{EntropyThresholdBits: 5.5}, false},
+		{"neg min_events", DecideConfig{MinEvents: -1}, true},
+		{"neg min_distinct", DecideConfig{MinDistinctValues: -1}, true},
+		{"neg entropy", DecideConfig{EntropyThresholdBits: -0.1}, true},
+		{"entropy above max", DecideConfig{EntropyThresholdBits: 8.1}, true},
+		{"entropy way above max", DecideConfig{EntropyThresholdBits: 30}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("got err=%v, wantErr=%v", err, tt.wantErr)
+			}
+			if tt.wantErr && !errors.Is(err, ErrInvalidDecideConfig) {
+				t.Fatalf("got %v, want errors.Is ErrInvalidDecideConfig", err)
+			}
+		})
+	}
+}
+
+// ---------- Decide: gate matrix ----------
+
+// makeUniformObs builds a SegmentObservation list at a given index,
+// distinct count, and per-value event count. Values are numbered
+// "v000", "v001", ... so they don't collide with reserved or sibling
+// names.
+func makeUniformObs(index, distinct, perValue int) []SegmentObservation {
+	out := make([]SegmentObservation, 0, distinct)
+	for i := 0; i < distinct; i++ {
+		out = append(out, SegmentObservation{
+			Index:      index,
+			Value:      fmt.Sprintf("v%03d", i),
+			EventCount: perValue,
+		})
+	}
+	return out
+}
+
+func TestDecide_AllFiveGatesPassYieldsCollapse(t *testing.T) {
+	// Index 1 = "/repos" everywhere (single distinct value -> retain).
+	// Index 2 = 87 random IDs (high entropy -> collapse).
+	obs := []SegmentObservation{}
+	for i := 0; i < 100; i++ {
+		obs = append(obs, SegmentObservation{Index: 1, Value: testValRepos, EventCount: 1})
+	}
+	obs = append(obs, makeUniformObs(2, 87, 5)...)
+
+	ev := Decide(obs, DefaultDecideConfig())
+	if ev.Algorithm != AlgorithmFrequencyWeightedEntropyV1 {
+		t.Errorf("algorithm: got %q, want %q", ev.Algorithm, AlgorithmFrequencyWeightedEntropyV1)
+	}
+	if len(ev.CollapsedSegments) != 1 {
+		t.Fatalf("collapsed: got %d, want 1", len(ev.CollapsedSegments))
+	}
+	if ev.CollapsedSegments[0].Index != 2 {
+		t.Errorf("collapsed index: got %d, want 2", ev.CollapsedSegments[0].Index)
+	}
+	if ev.CollapsedSegments[0].DistinctValues != 87 {
+		t.Errorf("collapsed distinct: got %d, want 87", ev.CollapsedSegments[0].DistinctValues)
+	}
+	if ev.CollapsedSegments[0].EventCount != 87*5 {
+		t.Errorf("collapsed events: got %d, want %d", ev.CollapsedSegments[0].EventCount, 87*5)
+	}
+	if ev.CollapsedSegments[0].Reason != ReasonHighEntropyIdentifierSegment {
+		t.Errorf("collapsed reason: got %q, want %q", ev.CollapsedSegments[0].Reason, ReasonHighEntropyIdentifierSegment)
+	}
+	if len(ev.RetainedSegments) != 1 {
+		t.Fatalf("retained: got %d, want 1", len(ev.RetainedSegments))
+	}
+	if ev.RetainedSegments[0].Index != 1 {
+		t.Errorf("retained index: got %d, want 1", ev.RetainedSegments[0].Index)
+	}
+	if ev.RetainedSegments[0].Reason != ReasonLowEntropyLiteralSegment {
+		t.Errorf("retained reason: got %q, want %q", ev.RetainedSegments[0].Reason, ReasonLowEntropyLiteralSegment)
+	}
+}
+
+func TestDecide_Gate1_FailsWhenInsufficientEvents(t *testing.T) {
+	// 5 distinct values, 1 event each, total 5 < min_events=10.
+	obs := makeUniformObs(2, 5, 1)
+	ev := Decide(obs, DefaultDecideConfig())
+	if len(ev.RetainedSegments) != 1 || ev.RetainedSegments[0].Reason != ReasonInsufficientEvents {
+		t.Fatalf("got retained=%v, want one with ReasonInsufficientEvents", ev.RetainedSegments)
+	}
+	if len(ev.CollapsedSegments) != 0 {
+		t.Errorf("collapsed: want 0, got %d", len(ev.CollapsedSegments))
+	}
+}
+
+func TestDecide_Gate2_FailsWhenInsufficientDistinct(t *testing.T) {
+	// 4 distinct values, 10 events each (total=40, passes gate 1), but
+	// distinct=4 < min_distinct=5.
+	obs := makeUniformObs(2, 4, 10)
+	ev := Decide(obs, DefaultDecideConfig())
+	if len(ev.RetainedSegments) != 1 || ev.RetainedSegments[0].Reason != ReasonInsufficientDistinct {
+		t.Fatalf("got retained=%v, want one with ReasonInsufficientDistinct", ev.RetainedSegments)
+	}
+}
+
+func TestDecide_Gate2_FailsWithSingleValue(t *testing.T) {
+	// 1 distinct value, 1000 events. Should retain with
+	// LowEntropyLiteralSegment, not InsufficientDistinct, because
+	// "single literal" is the audit-friendly framing.
+	obs := []SegmentObservation{{Index: 1, Value: testValRepos, EventCount: 1000}}
+	ev := Decide(obs, DefaultDecideConfig())
+	if len(ev.RetainedSegments) != 1 {
+		t.Fatalf("retained: got %d, want 1", len(ev.RetainedSegments))
+	}
+	if ev.RetainedSegments[0].Reason != ReasonLowEntropyLiteralSegment {
+		t.Errorf("reason: got %q, want %q", ev.RetainedSegments[0].Reason, ReasonLowEntropyLiteralSegment)
+	}
+	if ev.RetainedSegments[0].Value != testValRepos {
+		t.Errorf("value: got %q, want %q", ev.RetainedSegments[0].Value, testValRepos)
+	}
+}
+
+func TestDecide_Gate3_FailsWhenLowEntropy(t *testing.T) {
+	// 6 distinct values: 5 of them "foo*" copies (highly skewed) and
+	// one outlier. Total events = 5*100 + 1 = 501. Distinct = 6 >= 5.
+	// Entropy is dominated by the heavy class, well below 3 bits.
+	obs := []SegmentObservation{
+		{Index: 2, Value: "foo1", EventCount: 100},
+		{Index: 2, Value: "foo2", EventCount: 100},
+		{Index: 2, Value: "foo3", EventCount: 100},
+		{Index: 2, Value: "foo4", EventCount: 100},
+		{Index: 2, Value: "foo5", EventCount: 100},
+		{Index: 2, Value: "outlier", EventCount: 1},
+	}
+	ev := Decide(obs, DefaultDecideConfig())
+	if len(ev.CollapsedSegments) != 0 {
+		t.Errorf("collapsed: want 0, got %d", len(ev.CollapsedSegments))
+	}
+	if len(ev.RetainedSegments) != 1 || ev.RetainedSegments[0].Reason != ReasonLowEntropyLiteralSegment {
+		t.Fatalf("retained=%v, want LowEntropyLiteralSegment", ev.RetainedSegments)
+	}
+}
+
+func TestDecide_Gate4_ReservedSegmentBlocksCollapse(t *testing.T) {
+	// 87 high-entropy values at index 2 PLUS one reserved "admin"
+	// value. The whole position must retain because the reserved
+	// floor wins.
+	obs := makeUniformObs(2, 87, 5)
+	obs = append(obs, SegmentObservation{Index: 2, Value: testValAdmin, EventCount: 5})
+	ev := Decide(obs, DefaultDecideConfig())
+	if len(ev.CollapsedSegments) != 0 {
+		t.Errorf("collapsed: want 0, got %d", len(ev.CollapsedSegments))
+	}
+	if len(ev.RetainedSegments) != 1 || ev.RetainedSegments[0].Reason != ReasonReservedSegment {
+		t.Fatalf("retained=%v, want ReservedSegment", ev.RetainedSegments)
+	}
+	if ev.RetainedSegments[0].Value != testValAdmin {
+		t.Errorf("value: got %q, want %q", ev.RetainedSegments[0].Value, testValAdmin)
+	}
+}
+
+func TestDecide_Gate4_ExtrasReservedAlsoBlocks(t *testing.T) {
+	// 87 high-entropy values + "debug" at index 2. "debug" is not in
+	// the canonical list, but the extras list should catch it.
+	obs := makeUniformObs(2, 87, 5)
+	obs = append(obs, SegmentObservation{Index: 2, Value: testValDebug, EventCount: 5})
+	cfg := DefaultDecideConfig()
+	cfg.ReservedExtras = []string{testValDebug}
+	ev := Decide(obs, cfg)
+	if len(ev.CollapsedSegments) != 0 {
+		t.Errorf("collapsed: want 0, got %d", len(ev.CollapsedSegments))
+	}
+	if len(ev.RetainedSegments) != 1 || ev.RetainedSegments[0].Reason != ReasonReservedSegment {
+		t.Fatalf("retained=%v, want ReservedSegment", ev.RetainedSegments)
+	}
+	if ev.RetainedSegments[0].Value != testValDebug {
+		t.Errorf("value: got %q, want %q", ev.RetainedSegments[0].Value, testValDebug)
+	}
+}
+
+func TestDecide_Gate5_HighRiskSiblingBlocksCollapse(t *testing.T) {
+	// "users" and "admin" at the same index. Both are reserved AND
+	// sibling, but reserved is checked first; we use a non-reserved
+	// sibling list here to isolate gate 5.
+	obs := []SegmentObservation{
+		{Index: 2, Value: "alpha", EventCount: 50},
+		{Index: 2, Value: "beta", EventCount: 50},
+		{Index: 2, Value: "gamma", EventCount: 50},
+		{Index: 2, Value: "delta", EventCount: 50},
+		{Index: 2, Value: "epsilon", EventCount: 50},
+		{Index: 2, Value: "premium", EventCount: 50}, // sibling
+	}
+	cfg := DefaultDecideConfig()
+	cfg.HighRiskSiblings = []string{"premium", "vip"}
+	ev := Decide(obs, cfg)
+	if len(ev.CollapsedSegments) != 0 {
+		t.Errorf("collapsed: want 0, got %d", len(ev.CollapsedSegments))
+	}
+	if len(ev.RetainedSegments) != 1 || ev.RetainedSegments[0].Reason != ReasonNoMergeRule {
+		t.Fatalf("retained=%v, want NoMergeRule", ev.RetainedSegments)
+	}
+	if ev.RetainedSegments[0].Value != "premium" {
+		t.Errorf("value: got %q, want premium", ev.RetainedSegments[0].Value)
+	}
+}
+
+func TestDecide_DeterministicEvidenceOrder(t *testing.T) {
+	// Build observations with two collapsable positions (3 and 5) and
+	// two retainable positions (1 and 4). Expect ascending Index in
+	// each output slice on every call.
+	obs := []SegmentObservation{}
+	// idx 5 first in the slice — but emission must still be sorted.
+	obs = append(obs, makeUniformObs(5, 87, 5)...)
+	for i := 0; i < 100; i++ {
+		obs = append(obs, SegmentObservation{Index: 1, Value: "v1", EventCount: 1})
+	}
+	obs = append(obs, makeUniformObs(3, 87, 5)...)
+	for i := 0; i < 100; i++ {
+		obs = append(obs, SegmentObservation{Index: 4, Value: "v4", EventCount: 1})
+	}
+
+	ev1 := Decide(obs, DefaultDecideConfig())
+	ev2 := Decide(obs, DefaultDecideConfig())
+
+	// Compare slice-by-slice: we want the Decide output to be byte-
+	// identical for identical input.
+	if len(ev1.CollapsedSegments) != len(ev2.CollapsedSegments) {
+		t.Fatalf("collapsed len drift: %d vs %d", len(ev1.CollapsedSegments), len(ev2.CollapsedSegments))
+	}
+	for i := range ev1.CollapsedSegments {
+		if ev1.CollapsedSegments[i] != ev2.CollapsedSegments[i] {
+			t.Errorf("collapsed[%d]: %+v vs %+v", i, ev1.CollapsedSegments[i], ev2.CollapsedSegments[i])
+		}
+	}
+	if len(ev1.RetainedSegments) != len(ev2.RetainedSegments) {
+		t.Fatalf("retained len drift")
+	}
+	for i := range ev1.RetainedSegments {
+		if ev1.RetainedSegments[i] != ev2.RetainedSegments[i] {
+			t.Errorf("retained[%d]: %+v vs %+v", i, ev1.RetainedSegments[i], ev2.RetainedSegments[i])
+		}
+	}
+
+	// And ascending order assertions.
+	for i := 1; i < len(ev1.CollapsedSegments); i++ {
+		if ev1.CollapsedSegments[i].Index <= ev1.CollapsedSegments[i-1].Index {
+			t.Errorf("collapsed not ascending at %d", i)
+		}
+	}
+	for i := 1; i < len(ev1.RetainedSegments); i++ {
+		if ev1.RetainedSegments[i].Index <= ev1.RetainedSegments[i-1].Index {
+			t.Errorf("retained not ascending at %d", i)
+		}
+	}
+}
+
+func TestDecide_EmptyInputReturnsEmptyEvidence(t *testing.T) {
+	ev := Decide(nil, DefaultDecideConfig())
+	if ev.Algorithm != AlgorithmFrequencyWeightedEntropyV1 {
+		t.Errorf("algorithm: got %q", ev.Algorithm)
+	}
+	if len(ev.CollapsedSegments) != 0 || len(ev.RetainedSegments) != 0 {
+		t.Errorf("non-empty evidence on nil input: %+v", ev)
+	}
+	ev2 := Decide([]SegmentObservation{}, DefaultDecideConfig())
+	if ev2.Algorithm != AlgorithmFrequencyWeightedEntropyV1 {
+		t.Errorf("algorithm: got %q", ev2.Algorithm)
+	}
+	if len(ev2.CollapsedSegments) != 0 || len(ev2.RetainedSegments) != 0 {
+		t.Errorf("non-empty evidence on empty slice: %+v", ev2)
+	}
+}
+
+func TestDecide_NonPositiveCountsIgnored(t *testing.T) {
+	// Zero-count and negative-count observations should be skipped
+	// without panic and without polluting the aggregate.
+	obs := []SegmentObservation{
+		{Index: 1, Value: "real", EventCount: 100},
+		{Index: 1, Value: "ghost", EventCount: 0},
+		{Index: 1, Value: "neg", EventCount: -50},
+	}
+	ev := Decide(obs, DefaultDecideConfig())
+	// Only one real value at index 1 -> retain low-entropy.
+	if len(ev.RetainedSegments) != 1 {
+		t.Fatalf("retained: got %d, want 1", len(ev.RetainedSegments))
+	}
+	if ev.RetainedSegments[0].Value != "real" {
+		t.Errorf("value: got %q, want real", ev.RetainedSegments[0].Value)
+	}
+}
+
+func TestDecide_NegativeIndexIgnored(t *testing.T) {
+	// Defensive: caller's bug shouldn't crash us, but should also
+	// not produce evidence for the bad position.
+	obs := []SegmentObservation{
+		{Index: 0, Value: "bad", EventCount: 100},
+		{Index: -1, Value: "worse", EventCount: 100},
+	}
+	ev := Decide(obs, DefaultDecideConfig())
+	if len(ev.RetainedSegments) != 0 || len(ev.CollapsedSegments) != 0 {
+		t.Errorf("non-empty evidence on bad-index input: %+v", ev)
+	}
+}
+
+func TestDecide_ResolvesZeroConfig(t *testing.T) {
+	// A zero-value DecideConfig should behave like the defaults.
+	obs := makeUniformObs(2, 87, 5)
+	ev := Decide(obs, DecideConfig{})
+	if len(ev.CollapsedSegments) != 1 {
+		t.Fatalf("zero cfg should collapse high-entropy: got %+v", ev)
+	}
+}
+
+// ---------- Adversarial corpus ----------
+
+func TestDecide_AdversarialCorpus_AdminCannotCollapse(t *testing.T) {
+	// 100 random siblings + one "admin". Even with overwhelming
+	// random entropy, the reserved floor must hold.
+	obs := makeUniformObs(2, 100, 5)
+	obs = append(obs, SegmentObservation{Index: 2, Value: testValAdmin, EventCount: 1})
+	ev := Decide(obs, DefaultDecideConfig())
+	if len(ev.CollapsedSegments) != 0 {
+		t.Errorf("collapsed: want 0, got %d", len(ev.CollapsedSegments))
+	}
+	if len(ev.RetainedSegments) != 1 || ev.RetainedSegments[0].Reason != ReasonReservedSegment {
+		t.Fatalf("retained=%v, want ReservedSegment", ev.RetainedSegments)
+	}
+	if ev.RetainedSegments[0].Value != testValAdmin {
+		t.Errorf("value: got %q, want %q", ev.RetainedSegments[0].Value, testValAdmin)
+	}
+}
+
+func TestDecide_AdversarialCorpus_HighEntropyDoesNotForceCollapse(t *testing.T) {
+	// 1000 distinct values + "auth". Reserved-segment-presence is
+	// position-level, so the entire position retains.
+	obs := makeUniformObs(2, 1000, 2)
+	obs = append(obs, SegmentObservation{Index: 2, Value: testValAuth, EventCount: 2})
+	ev := Decide(obs, DefaultDecideConfig())
+	if len(ev.CollapsedSegments) != 0 {
+		t.Errorf("collapsed: want 0, got %d", len(ev.CollapsedSegments))
+	}
+	if len(ev.RetainedSegments) != 1 || ev.RetainedSegments[0].Reason != ReasonReservedSegment {
+		t.Fatalf("retained=%v, want ReservedSegment", ev.RetainedSegments)
+	}
+	if ev.RetainedSegments[0].Value != testValAuth {
+		t.Errorf("value: got %q, want %q", ev.RetainedSegments[0].Value, testValAuth)
+	}
+}
+
+func TestRepresentativeValue_EmptyCountsReturnsEmpty(t *testing.T) {
+	// White-box: representativeValue is unreachable from the public
+	// API with empty counts (Decide filters), but the defensive
+	// guard exists to protect downstream code from a panic on
+	// empty slices. Test it directly.
+	if got := representativeValue(map[string]int{}); got != "" {
+		t.Errorf("got %q, want \"\"", got)
+	}
+}
+
+func TestFirstReservedValue_NoMatchReturnsEmpty(t *testing.T) {
+	// White-box: a non-empty counts map with no reserved hits.
+	got := firstReservedValue(map[string]int{"alpha": 1, "beta": 2}, nil)
+	if got != "" {
+		t.Errorf("got %q, want \"\"", got)
+	}
+}
+
+func TestDecide_HighRiskSiblings_NoMatchAllowsCollapse(t *testing.T) {
+	// HighRiskSiblings is set but none of the values match.
+	// Decide should still collapse because gate 5 doesn't fire.
+	// Exercises the firstSiblingValue branch where siblings is
+	// non-empty but no match is found.
+	obs := makeUniformObs(2, 87, 5)
+	cfg := DefaultDecideConfig()
+	cfg.HighRiskSiblings = []string{"unicorn", "phoenix"}
+	ev := Decide(obs, cfg)
+	if len(ev.CollapsedSegments) != 1 {
+		t.Fatalf("collapsed: got %d, want 1 (siblings list is non-empty but none match)", len(ev.CollapsedSegments))
+	}
+}
+
+func TestDecide_AdversarialCorpus_UsersAndAdminCannotMerge(t *testing.T) {
+	// /v1/admin and /v1/users at index 2: the design's high-risk
+	// sibling case. With both as siblings, the position retains.
+	// Note: both are also in the canonical reserved list, so this
+	// passes via the reserved path. We assert that retain happens
+	// regardless of which gate fires first.
+	obs := []SegmentObservation{
+		{Index: 2, Value: testValAdmin, EventCount: 100},
+		{Index: 2, Value: testValUsers, EventCount: 100},
+	}
+	cfg := DefaultDecideConfig()
+	cfg.HighRiskSiblings = []string{testValAdmin, testValUsers}
+	ev := Decide(obs, cfg)
+	if len(ev.CollapsedSegments) != 0 {
+		t.Errorf("collapsed: want 0, got %d", len(ev.CollapsedSegments))
+	}
+	if len(ev.RetainedSegments) != 1 {
+		t.Fatalf("retained: got %d, want 1", len(ev.RetainedSegments))
+	}
+	if ev.RetainedSegments[0].Reason != ReasonReservedSegment && ev.RetainedSegments[0].Reason != ReasonNoMergeRule {
+		t.Errorf("reason: got %q, want one of {%q, %q}", ev.RetainedSegments[0].Reason, ReasonReservedSegment, ReasonNoMergeRule)
+	}
+}

--- a/internal/contract/inference/normalize/reserved.go
+++ b/internal/contract/inference/normalize/reserved.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package normalize
+
+// reservedSegmentsCanonical is the security-floor list of path
+// segments that cannot be collapsed to a wildcard at any entropy.
+// Hardcoded by design — operators may extend via
+// learn.inference.normalization.reserved_segments_extra but cannot
+// remove. Order is the design's emission order; tests assert no
+// duplicates and no empty entries.
+var reservedSegmentsCanonical = []string{
+	"admin", "auth", "login", "oauth", "token",
+	"billing", "settings", "users", "me", "orgs",
+	"sso", "saml", "mfa", "kms", "vault",
+	"secret", "key", "password", "payment", "refund",
+	"transfer", "withdraw", "ssh", "ssl", "cert",
+	"ca", "auth0",
+}
+
+// CanonicalReservedSegments returns a defensive copy of the canonical
+// reserved-segment list. Defense-in-depth: callers cannot mutate the
+// package-level slice. Returned in deterministic order so callers can
+// emit it as documentation or audit evidence.
+func CanonicalReservedSegments() []string {
+	out := make([]string, len(reservedSegmentsCanonical))
+	copy(out, reservedSegmentsCanonical)
+	return out
+}
+
+// IsReserved reports whether `segment` matches the canonical list or
+// any operator-supplied extra. Comparison is byte-exact against the
+// already-normalized form (NFC + lowercase + percent-decoded — the
+// caller is responsible for normalizing first; this function does NOT
+// re-normalize). Empty `segment` returns false.
+//
+// Performance: the canonical list is small (~27 entries) and the
+// extras are bounded by config. Linear scan is fine; we do not bother
+// with a map because the linear-scan constant factor is faster on
+// slices this short and avoids pointer-chasing.
+func IsReserved(segment string, extras []string) bool {
+	if segment == "" {
+		return false
+	}
+	for _, r := range reservedSegmentsCanonical {
+		if segment == r {
+			return true
+		}
+	}
+	for _, e := range extras {
+		if segment == e {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/contract/inference/normalize/reserved_test.go
+++ b/internal/contract/inference/normalize/reserved_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package normalize
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestCanonicalReservedSegments_NoDuplicatesNoEmpty(t *testing.T) {
+	t.Parallel()
+
+	got := CanonicalReservedSegments()
+	if len(got) == 0 {
+		t.Fatalf("CanonicalReservedSegments() returned empty list")
+	}
+
+	seen := make(map[string]bool, len(got))
+	for i, s := range got {
+		if s == "" {
+			t.Errorf("entry %d is empty", i)
+		}
+		if seen[s] {
+			t.Errorf("duplicate entry %q at index %d", s, i)
+		}
+		seen[s] = true
+	}
+}
+
+func TestCanonicalReservedSegments_MatchesDesign(t *testing.T) {
+	t.Parallel()
+
+	// Design-drift guard. The reserved-segment list in the contract
+	// inference engine design is the source of truth. If it bumps,
+	// this test fails and forces an update with audit trail rather
+	// than a silent change.
+	want := []string{
+		"admin", "auth", "auth0", "billing", "ca",
+		"cert", "key", "kms", "login", "me",
+		"mfa", "oauth", "orgs", "password", "payment",
+		"refund", "saml", "secret", "settings", "ssh",
+		"ssl", "sso", "token", "transfer", "users",
+		"vault", "withdraw",
+	}
+
+	got := CanonicalReservedSegments()
+	if len(got) != len(want) {
+		t.Fatalf("CanonicalReservedSegments() returned %d entries, want %d", len(got), len(want))
+	}
+
+	gotSorted := append([]string(nil), got...)
+	sort.Strings(gotSorted)
+
+	for i, w := range want {
+		if gotSorted[i] != w {
+			t.Errorf("sorted entry %d = %q, want %q", i, gotSorted[i], w)
+		}
+	}
+}
+
+func TestCanonicalReservedSegments_ReturnsDefensiveCopy(t *testing.T) {
+	t.Parallel()
+
+	first := CanonicalReservedSegments()
+	if len(first) == 0 {
+		t.Fatalf("CanonicalReservedSegments() returned empty list")
+	}
+	original := first[0]
+	first[0] = "MUTATED"
+
+	second := CanonicalReservedSegments()
+	if second[0] != original {
+		t.Fatalf("second call returned %q at index 0, want %q — package-level slice was mutated through returned reference (security regression)", second[0], original)
+	}
+}
+
+func TestIsReserved_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	canonical := CanonicalReservedSegments()
+	for _, c := range canonical {
+		t.Run("canonical/"+c, func(t *testing.T) {
+			t.Parallel()
+			if !IsReserved(c, nil) {
+				t.Fatalf("IsReserved(%q, nil) = false, want true", c)
+			}
+		})
+	}
+
+	notReserved := []string{"foo", "v1", "repos", "search", "items", "data"}
+	for _, n := range notReserved {
+		t.Run("non-canonical/"+n, func(t *testing.T) {
+			t.Parallel()
+			if IsReserved(n, nil) {
+				t.Fatalf("IsReserved(%q, nil) = true, want false", n)
+			}
+		})
+	}
+}
+
+func TestIsReserved_EmptyReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	if IsReserved("", nil) {
+		t.Fatalf("IsReserved(\"\", nil) = true, want false (empty is not reserved)")
+	}
+	if IsReserved("", []string{"admin"}) {
+		t.Fatalf("IsReserved(\"\", extras) = true, want false (empty is not reserved even with extras)")
+	}
+}
+
+func TestIsReserved_ExtrasMatched(t *testing.T) {
+	t.Parallel()
+
+	extras := []string{"debug", "internal"}
+	if !IsReserved("debug", extras) {
+		t.Fatalf("IsReserved(\"debug\", %v) = false, want true (extras must be honored)", extras)
+	}
+	if !IsReserved("internal", extras) {
+		t.Fatalf("IsReserved(\"internal\", %v) = false, want true (extras must be honored)", extras)
+	}
+	if IsReserved("staging", extras) {
+		t.Fatalf("IsReserved(\"staging\", %v) = true, want false (not in extras or canonical)", extras)
+	}
+}
+
+func TestIsReserved_ExtrasDoNotShadowCanonical(t *testing.T) {
+	t.Parallel()
+
+	// Empty/nil extras must not stop the canonical floor from
+	// matching. Operators ADD to the floor; they cannot subtract.
+	if !IsReserved("admin", nil) {
+		t.Fatalf("IsReserved(\"admin\", nil) = false, want true")
+	}
+	if !IsReserved("admin", []string{}) {
+		t.Fatalf("IsReserved(\"admin\", []) = false, want true")
+	}
+	if !IsReserved("admin", []string{"unrelated"}) {
+		t.Fatalf("IsReserved(\"admin\", [\"unrelated\"]) = false, want true (canonical still applies)")
+	}
+}
+
+func TestIsReserved_CaseSensitive(t *testing.T) {
+	t.Parallel()
+
+	// The function trusts the caller has normalized the input. Path.go
+	// (next wave) lowercases before calling. Passing a non-normalized
+	// form is the caller's bug, not the predicate's job to fix.
+	if IsReserved("ADMIN", nil) {
+		t.Fatalf("IsReserved(\"ADMIN\", nil) = true, want false (predicate is byte-exact, no folding)")
+	}
+	if IsReserved("Admin", nil) {
+		t.Fatalf("IsReserved(\"Admin\", nil) = true, want false (predicate is byte-exact, no folding)")
+	}
+}
+
+func TestIsReserved_ExactMatchOnly(t *testing.T) {
+	t.Parallel()
+
+	// Substring is not match: prefixes, suffixes, and embedded
+	// occurrences must not match.
+	notMatches := []string{"administrator", "admins", "myadmin", "auths", "uauth", "tokens"}
+	for _, s := range notMatches {
+		t.Run(s, func(t *testing.T) {
+			t.Parallel()
+			if IsReserved(s, nil) {
+				t.Fatalf("IsReserved(%q, nil) = true, want false (substring is not match)", s)
+			}
+		})
+	}
+}

--- a/internal/contract/inference/opportunity.go
+++ b/internal/contract/inference/opportunity.go
@@ -108,8 +108,8 @@ func (l OpportunityLevel) Valid() bool {
 
 // OpportunityContext holds the precomputed counts the inference engine needs
 // to pick a denominator for any rule level. Each field documents which level
-// reads it. The upstream aggregator (PR 2.3 territory) populates these counts
-// from the recorder; Denominator just selects the right field and validates.
+// reads it. The upstream aggregator populates these counts from the recorder;
+// Denominator just selects the right field and validates.
 //
 // Passed by value: the struct is small, value semantics make accidental
 // mutation impossible, and the cost is below measurement noise.
@@ -153,9 +153,9 @@ var (
 
 	// ErrNegativeOpportunityCount is returned by Denominator when the
 	// selected count is negative. Negative counts indicate an aggregator
-	// bug, not adversarial input — but the inference engine is no-panic
-	// per CLAUDE.md hard rules, so we return the error and let the caller
-	// decide. Callers can detect this with
+	// bug, not adversarial input, but the inference engine never panics
+	// on runtime input, so we return the error and let the caller decide.
+	// Callers can detect this with
 	// errors.Is(err, ErrNegativeOpportunityCount).
 	ErrNegativeOpportunityCount = errors.New("inference: negative opportunity count")
 )
@@ -171,8 +171,8 @@ var (
 //   - Negative selected count: returns (0, wrapped
 //     ErrNegativeOpportunityCount with level + count context).
 //   - Zero selected count: returns (0, nil). Zero is a valid "no
-//     opportunity yet" state; the floor gates downstream (PR 2.2) handle
-//     the implication.
+//     opportunity yet" state; the downstream floor gates handle the
+//     implication.
 func Denominator(level OpportunityLevel, ctx OpportunityContext) (int, error) {
 	var count int
 	switch level {

--- a/internal/contract/inference/opportunity_test.go
+++ b/internal/contract/inference/opportunity_test.go
@@ -147,7 +147,7 @@ func TestDenominator_HappyPath(t *testing.T) {
 
 // TestDenominator_RejectsUnknownLevel asserts the zero value and any
 // out-of-range int both return ErrUnknownOpportunityLevel. The error MUST
-// be detectable via errors.Is — never raw equality (PR 1.3 lesson).
+// be detectable via errors.Is, never raw equality.
 func TestDenominator_RejectsUnknownLevel(t *testing.T) {
 	t.Parallel()
 
@@ -260,9 +260,9 @@ func TestDenominator_RejectsNegativeCount(t *testing.T) {
 }
 
 // TestDenominator_ZeroCountAllowed asserts that an opportunity count of
-// zero is a valid state, not an error. Floor gates downstream (PR 2.2)
-// turn zero into a "not enough evidence yet" classification; Denominator
-// just reports the count.
+// zero is a valid state, not an error. The downstream floor gates turn
+// zero into a "not enough evidence yet" classification; Denominator just
+// reports the count.
 func TestDenominator_ZeroCountAllowed(t *testing.T) {
 	t.Parallel()
 

--- a/internal/contract/inference/wilson.go
+++ b/internal/contract/inference/wilson.go
@@ -1,7 +1,7 @@
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0
 
-// Package inference implements the v2.4 contract-compile inference engine:
+// Package inference implements the contract-compile inference engine:
 // Wilson lower-bound confidence, conditional opportunity denominators,
 // exposure-floor gates, and numeric-budget statistics. Pure functions —
 // no I/O, no transports, no logging. Inputs are recorder.Entry events that
@@ -119,9 +119,20 @@ func wilsonZ(alpha float64) float64 {
 // within the test tolerance of 3 decimal places for any non-default alpha
 // the engine would realistically encounter.
 //
-// p in (0, 1) is guaranteed by the caller (WilsonLowerBound /
-// WilsonUpperBound validate alpha before reaching this path).
+// Caller validates 0 < alpha < 1 before reaching this path, but very
+// small alpha (e.g. 1e-16) can round 1 - alpha/2 to exactly 1.0 in
+// IEEE-754 double, which would otherwise drive the rational
+// approximation toward +Inf. The clamp pulls p back into a safely
+// representable open interval (1e-15, 1 - 1e-15) so the function never
+// returns NaN or Inf even for degenerate alpha. The supported alpha
+// range for accurate output is roughly [1e-12, 1 - 1e-12]; outside that
+// band the result remains finite but accuracy degrades.
 func invNormalCDF(p float64) float64 {
+	if p < 1e-15 {
+		p = 1e-15
+	} else if p > 1-1e-15 {
+		p = 1 - 1e-15
+	}
 	// Beasley-Springer central region coefficients.
 	a := [...]float64{
 		-3.969683028665376e+01,

--- a/internal/metrics/learn.go
+++ b/internal/metrics/learn.go
@@ -5,18 +5,57 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
-// learnNamespace is the Prometheus namespace for all learn-and-lock metrics.
-// Per the v2.4 design, the observation pipeline emits under pipelock_learn_*;
-// the rest of pipelock emits under pipelock_* directly. Keeping the
-// namespaces separate makes alerting on observation-pipeline health
-// independent of proxy/scanner alerts.
+// learnNamespace is the Prometheus namespace for the contract-compile
+// observation-pipeline metrics. The pipeline emits under
+// pipelock_learn_*; the rest of pipelock emits under pipelock_*
+// directly. Keeping the namespaces separate makes alerting on
+// observation-pipeline health independent of proxy/scanner alerts.
 const learnNamespace = "pipelock_learn"
 
-// learnActionClassUnclassified is the canonical wire-form label for
-// observation events whose action class could not be resolved by the
-// classifier. Kept as a const so the bookkeeping in RecordObservationEvent
-// agrees with the upstream emitters byte-for-byte.
-const learnActionClassUnclassified = "unclassified"
+// ActionClass is the closed wire-form domain for the
+// observation_events_total counter's action_class label. The string
+// values come from the action-class taxonomy in the contract-compile
+// design baseline; the capture pipeline produces these and only these.
+// Any value outside the canonical set is dropped at record time to
+// prevent label-cardinality drift on a security-relevant counter.
+//
+// The metrics package owns the enum locally to avoid a layering import
+// on internal/contract/inference (or any other domain package).
+// Cross-package alignment is asserted by the metrics test pack.
+type ActionClass string
+
+// Canonical ActionClass values per the action-class taxonomy.
+// Wire form (snake_case lowercase verb) — must agree with the recorder
+// emitter's wire output byte-for-byte. Add a new constant here when
+// the taxonomy gains a verb; never widen the closed set silently.
+const (
+	ActionRead         ActionClass = "read"
+	ActionDerive       ActionClass = "derive"
+	ActionWrite        ActionClass = "write"
+	ActionDelegate     ActionClass = "delegate"
+	ActionAuthorize    ActionClass = "authorize"
+	ActionSpend        ActionClass = "spend"
+	ActionCommit       ActionClass = "commit"
+	ActionActuate      ActionClass = "actuate"
+	ActionUnclassified ActionClass = "unclassified"
+)
+
+// BlockReason is the closed wire-form domain for the
+// regulated_data_blocked_total counter's reason label. Values mirror
+// the privacy enforcer's classifier-rule names (snake_case). Any value
+// outside the canonical set is dropped at record time to prevent
+// label-cardinality drift.
+type BlockReason string
+
+// Canonical BlockReason values. Add new values here when the privacy
+// enforcer (internal/contract/privacy) gains additional rules. The
+// three values below mirror the godoc on RecordRegulatedDataBlocked
+// and the privacy-enforcer rule set in the design baseline.
+const (
+	BlockReasonFieldClassRegulated BlockReason = "field_class_regulated"
+	BlockReasonRootClassRegulated  BlockReason = "root_class_regulated"
+	BlockReasonExplicitBlock       BlockReason = "explicit_block"
+)
 
 // registerLearnMetrics builds and registers the observation-pipeline counters
 // (events emitted by event_kind, regulated data blocked by reason,
@@ -69,37 +108,64 @@ func (m *Metrics) registerLearnMetrics(reg *prometheus.Registry) {
 	)
 }
 
-// RecordObservationEvent increments the observation events counter for the
-// given action class. The capture writer (and receipt emitter) call this
-// on every recorder.Entry write for capture/action_receipt entries.
+// RecordObservationEvent increments the observation_events_total
+// counter for the given action class. The capture writer (and receipt
+// emitter) call this on every recorder.Entry write for
+// capture/action_receipt entries.
 //
-// actionClass is the wire-form label string (lower-case verb: read, derive,
-// write, delegate, authorize, spend, commit, actuate, unclassified). The
-// caller must pass the canonical form; this helper does NOT normalize.
-func (m *Metrics) RecordObservationEvent(actionClass string) {
+// Non-canonical values are dropped silently: Prometheus creates a new
+// time series for every distinct label value, so accepting arbitrary
+// strings would let a future caller bug expand cardinality on a
+// security-relevant telemetry counter without an obvious failure mode.
+// The closed allowlist (ActionRead / Derive / Write / Delegate /
+// Authorize / Spend / Commit / Actuate / Unclassified) is enforced at
+// runtime; the typed parameter steers callers toward the constants but
+// untyped string literals still convert per Go's constant rules.
+//
+// When actionClass is ActionUnclassified, also increments the
+// unclassified-actions total (the v2.4 done-state classification-debt
+// gate watches that counter).
+func (m *Metrics) RecordObservationEvent(actionClass ActionClass) {
 	if m == nil {
 		return
 	}
-	m.learnObservationEvents.WithLabelValues(actionClass).Inc()
-	if actionClass == learnActionClassUnclassified {
-		m.learnUnclassifiedActions.Inc()
+	switch actionClass {
+	case ActionRead, ActionDerive, ActionWrite, ActionDelegate,
+		ActionAuthorize, ActionSpend, ActionCommit, ActionActuate,
+		ActionUnclassified:
+		m.learnObservationEvents.WithLabelValues(string(actionClass)).Inc()
+		if actionClass == ActionUnclassified {
+			m.learnUnclassifiedActions.Inc()
+		}
+	default:
+		// Drop non-canonical: future caller drift cannot expand the
+		// cardinality of pipelock_learn_observation_events_total
+		// beyond the nine legitimate action classes.
 	}
 }
 
-// RecordRegulatedDataBlocked increments the regulated-data-blocked counter
-// with the given reason label. The privacy enforcer calls this when an
-// observation event's data class resolves to regulated and is dropped
-// before reaching the recorder.
+// RecordRegulatedDataBlocked increments the regulated_data_blocked_total
+// counter with the given reason label. The privacy enforcer calls this
+// when an observation event's data class resolves to regulated and is
+// dropped before reaching the recorder.
 //
-// reason should be a stable, low-cardinality string identifying which
-// classifier rule fired (e.g., "field_class_regulated", "root_class_regulated",
-// "explicit_block"). The caller is responsible for keeping the cardinality
-// bounded; do not pass user-supplied or unbounded values.
-func (m *Metrics) RecordRegulatedDataBlocked(reason string) {
+// Same closed-allowlist contract as RecordObservationEvent:
+// non-canonical values drop silently to prevent cardinality drift on a
+// security-relevant counter. The typed parameter steers callers toward
+// the BlockReason constants but untyped string literals still convert
+// per Go's constant rules.
+func (m *Metrics) RecordRegulatedDataBlocked(reason BlockReason) {
 	if m == nil {
 		return
 	}
-	m.learnRegulatedDataBlocked.WithLabelValues(reason).Inc()
+	switch reason {
+	case BlockReasonFieldClassRegulated,
+		BlockReasonRootClassRegulated,
+		BlockReasonExplicitBlock:
+		m.learnRegulatedDataBlocked.WithLabelValues(string(reason)).Inc()
+	default:
+		// Drop non-canonical (see RecordObservationEvent).
+	}
 }
 
 // SetUnclassifiedRate updates the unclassified-rate gauge. The observation

--- a/internal/metrics/learn_test.go
+++ b/internal/metrics/learn_test.go
@@ -21,20 +21,21 @@ var expectedLearnMetricNames = []string{
 	"pipelock_learn_inference_floor_failures_total",
 }
 
-func TestRegisterLearnMetrics_RegistersAllFour(t *testing.T) {
+func TestRegisterLearnMetrics_RegistersAllSix(t *testing.T) {
 	t.Parallel()
 	m := New()
 
 	// Touch the CounterVec metrics so Gather() emits them. CounterVec/
 	// GaugeVec are lazy: descriptors are registered at New() time, but
 	// no MetricFamily appears in Gather output until at least one
-	// labeled child is observed. The new inference helpers enforce a
-	// closed allowlist on their labels (cardinality protection), so we
-	// touch them with canonical values rather than a synthetic probe;
-	// the pre-existing helpers retain the probe label because their
-	// behavior is out of scope for this PR.
-	m.RecordObservationEvent("registration_probe")
-	m.RecordRegulatedDataBlocked("registration_probe")
+	// labeled child is observed. All four CounterVec helpers enforce a
+	// closed allowlist on their labels (cardinality protection), so the
+	// registration probe must use canonical values for every helper.
+	// A non-canonical "registration_probe" would be silently dropped
+	// and the CounterVec wouldn't appear in Gather output, hiding
+	// registration regressions.
+	m.RecordObservationEvent(ActionRead)
+	m.RecordRegulatedDataBlocked(BlockReasonFieldClassRegulated)
 	m.RecordInferenceClassification(OutcomeStable)
 	m.RecordInferenceFloorFailure(FloorSessions)
 
@@ -59,10 +60,10 @@ func TestRecordObservationEvent_IncrementsByActionClass(t *testing.T) {
 	t.Parallel()
 	m := New()
 
-	m.RecordObservationEvent("read")
-	m.RecordObservationEvent("read")
-	m.RecordObservationEvent("read")
-	m.RecordObservationEvent("write")
+	m.RecordObservationEvent(ActionRead)
+	m.RecordObservationEvent(ActionRead)
+	m.RecordObservationEvent(ActionRead)
+	m.RecordObservationEvent(ActionWrite)
 
 	if got := testutil.ToFloat64(m.learnObservationEvents.WithLabelValues("read")); got != 3 {
 		t.Errorf("read counter = %v, want 3", got)
@@ -76,7 +77,7 @@ func TestRecordObservationEvent_UnclassifiedAlsoBumpsUnclassifiedTotal(t *testin
 	t.Parallel()
 	m := New()
 
-	m.RecordObservationEvent("unclassified")
+	m.RecordObservationEvent(ActionUnclassified)
 
 	if got := testutil.ToFloat64(m.learnObservationEvents.WithLabelValues("unclassified")); got != 1 {
 		t.Errorf("unclassified label counter = %v, want 1", got)
@@ -86,7 +87,7 @@ func TestRecordObservationEvent_UnclassifiedAlsoBumpsUnclassifiedTotal(t *testin
 	}
 
 	// A non-unclassified increment must not bump the unclassified total.
-	m.RecordObservationEvent("read")
+	m.RecordObservationEvent(ActionRead)
 	if got := testutil.ToFloat64(m.learnUnclassifiedActions); got != 1 {
 		t.Errorf("unclassified total after read = %v, want still 1", got)
 	}
@@ -96,9 +97,9 @@ func TestRecordRegulatedDataBlocked_IncrementsByReason(t *testing.T) {
 	t.Parallel()
 	m := New()
 
-	m.RecordRegulatedDataBlocked("field_class_regulated")
-	m.RecordRegulatedDataBlocked("field_class_regulated")
-	m.RecordRegulatedDataBlocked("root_class_regulated")
+	m.RecordRegulatedDataBlocked(BlockReasonFieldClassRegulated)
+	m.RecordRegulatedDataBlocked(BlockReasonFieldClassRegulated)
+	m.RecordRegulatedDataBlocked(BlockReasonRootClassRegulated)
 
 	if got := testutil.ToFloat64(m.learnRegulatedDataBlocked.WithLabelValues("field_class_regulated")); got != 2 {
 		t.Errorf("field_class_regulated counter = %v, want 2", got)
@@ -146,14 +147,14 @@ func TestSetUnclassifiedRate_OverwritesPreviousValue(t *testing.T) {
 func TestRecordObservationEvent_NilSafe(t *testing.T) {
 	t.Parallel()
 	var m *Metrics
-	m.RecordObservationEvent("read")         // no panic
-	m.RecordObservationEvent("unclassified") // unclassified branch, also nil-safe
+	m.RecordObservationEvent(ActionRead)         // no panic
+	m.RecordObservationEvent(ActionUnclassified) // unclassified branch, also nil-safe
 }
 
 func TestRecordRegulatedDataBlocked_NilSafe(t *testing.T) {
 	t.Parallel()
 	var m *Metrics
-	m.RecordRegulatedDataBlocked("field_class_regulated") // no panic
+	m.RecordRegulatedDataBlocked(BlockReasonFieldClassRegulated) // no panic
 }
 
 func TestSetUnclassifiedRate_NilSafe(t *testing.T) {
@@ -297,6 +298,109 @@ func TestInferenceOutcome_AlignsWithConfidenceString(t *testing.T) {
 	for got, want := range cases {
 		if string(got) != want {
 			t.Errorf("InferenceOutcome %q wire form = %q, want %q (must match inference.Confidence.String())", want, string(got), want)
+		}
+	}
+}
+
+// TestRecordObservationEvent_DropsNonCanonical confirms the
+// closed-allowlist contract on the observation-event counter. A label
+// value outside the v2.4 action-class taxonomy is dropped silently,
+// never increments any series, and cannot expand cardinality on
+// pipelock_learn_observation_events_total. The unclassified-actions
+// total must also stay 0 — the helper never reaches the unclassified
+// branch when the input is non-canonical.
+func TestRecordObservationEvent_DropsNonCanonical(t *testing.T) {
+	t.Parallel()
+	m := New()
+
+	m.RecordObservationEvent(ActionClass("malicious_action"))
+	m.RecordObservationEvent(ActionClass(""))
+	m.RecordObservationEvent(ActionClass("READ")) // case-sensitive
+
+	if got := testutil.ToFloat64(m.learnObservationEvents.WithLabelValues("malicious_action")); got != 0 {
+		t.Errorf("non-canonical action leaked into counter: got %v", got)
+	}
+	if got := testutil.ToFloat64(m.learnObservationEvents.WithLabelValues("READ")); got != 0 {
+		t.Errorf("case-variant action leaked into counter: got %v", got)
+	}
+	for _, canonical := range []string{
+		"read", "derive", "write", "delegate", "authorize",
+		"spend", "commit", "actuate", "unclassified",
+	} {
+		if got := testutil.ToFloat64(m.learnObservationEvents.WithLabelValues(canonical)); got != 0 {
+			t.Errorf("canonical %q counter = %v, want 0 after non-canonical-only inputs", canonical, got)
+		}
+	}
+	// The unclassified total must also stay 0: a non-canonical input
+	// that LOOKS like the unclassified branch (e.g. uppercase "READ")
+	// must not slip through and bump the classification-debt counter.
+	if got := testutil.ToFloat64(m.learnUnclassifiedActions); got != 0 {
+		t.Errorf("unclassified total = %v, want 0", got)
+	}
+}
+
+// TestRecordRegulatedDataBlocked_DropsNonCanonical mirrors the
+// classification drop test for the regulated-data-blocked counter.
+func TestRecordRegulatedDataBlocked_DropsNonCanonical(t *testing.T) {
+	t.Parallel()
+	m := New()
+
+	m.RecordRegulatedDataBlocked(BlockReason("evil_reason"))
+	m.RecordRegulatedDataBlocked(BlockReason(""))
+	m.RecordRegulatedDataBlocked(BlockReason("Field_Class_Regulated")) // case-sensitive
+
+	if got := testutil.ToFloat64(m.learnRegulatedDataBlocked.WithLabelValues("evil_reason")); got != 0 {
+		t.Errorf("non-canonical reason leaked into counter: got %v", got)
+	}
+	if got := testutil.ToFloat64(m.learnRegulatedDataBlocked.WithLabelValues("Field_Class_Regulated")); got != 0 {
+		t.Errorf("case-variant reason leaked into counter: got %v", got)
+	}
+	for _, canonical := range []string{
+		"field_class_regulated", "root_class_regulated", "explicit_block",
+	} {
+		if got := testutil.ToFloat64(m.learnRegulatedDataBlocked.WithLabelValues(canonical)); got != 0 {
+			t.Errorf("canonical %q counter = %v, want 0 after non-canonical-only inputs", canonical, got)
+		}
+	}
+}
+
+// TestActionClass_WireForms_Locked drift-guards the v2.4 action-class
+// taxonomy wire form. If anyone changes a constant, the test fails
+// loudly — these strings are part of the recorder/metrics contract and
+// flow into signed contracts; bumping them silently would break wire
+// compatibility with dashboards, alerts, and downstream verifiers.
+func TestActionClass_WireForms_Locked(t *testing.T) {
+	t.Parallel()
+	cases := map[ActionClass]string{
+		ActionRead:         "read",
+		ActionDerive:       "derive",
+		ActionWrite:        "write",
+		ActionDelegate:     "delegate",
+		ActionAuthorize:    "authorize",
+		ActionSpend:        "spend",
+		ActionCommit:       "commit",
+		ActionActuate:      "actuate",
+		ActionUnclassified: "unclassified",
+	}
+	for got, want := range cases {
+		if string(got) != want {
+			t.Errorf("ActionClass %q wire form = %q, want %q", want, string(got), want)
+		}
+	}
+}
+
+// TestBlockReason_WireForms_Locked drift-guards the privacy-enforcer
+// reason wire form. Same contract as TestActionClass_WireForms_Locked.
+func TestBlockReason_WireForms_Locked(t *testing.T) {
+	t.Parallel()
+	cases := map[BlockReason]string{
+		BlockReasonFieldClassRegulated: "field_class_regulated",
+		BlockReasonRootClassRegulated:  "root_class_regulated",
+		BlockReasonExplicitBlock:       "explicit_block",
+	}
+	for got, want := range cases {
+		if string(got) != want {
+			t.Errorf("BlockReason %q wire form = %q, want %q", want, string(got), want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds the `internal/contract/inference/normalize` package implementing the path-normalization layer of the contract-compile inference engine: per-bucket frequency-weighted Shannon entropy with the 5-gate collapse decision, the canonical reserved-segment blocklist, and per-host cardinality capping with `_other` tail coverage. Wires the operator-affordance commands `pipelock learn split` and `pipelock learn pin` for pre-ratification adjustments. Also folds the cardinality-trust hardening onto the two pre-existing learn helpers (`RecordObservationEvent`, `RecordRegulatedDataBlocked`) so all four learn counters share the closed-allowlist contract. Addresses the four follow-up findings on the prior PR.

## What's in the new package

- **`evidence.go`**: value types matching the rule emission shape (NormalizationEvidence, Bucket, CollapsedSegment, RetainedSegment) plus collapse and retain reason wire constants. Validate method rejects malformed instances with a wrapped sentinel.

- **`reserved.go`**: the canonical reserved-segment blocklist (admin, auth, login, oauth, token, billing, settings, users, me, orgs, sso, saml, mfa, kms, vault, secret, key, password, payment, refund, transfer, withdraw, ssh, ssl, cert, ca, auth0). IsReserved accepts an operator-supplied `extras` slice; operators may extend but cannot remove from the canonical floor.

- **`path.go`**: Canonicalize applies NFC plus Unicode lowercasing plus per-segment percent-decoding and rejects non-canonical inputs (`..`, standalone `.`, double slashes, trailing slash on non-root, control chars, percent-encoded slashes, paths over 2048 chars). Frequency-weighted Shannon entropy. Decide composer runs the 5-gate test per segment position: minimum events (default 10), minimum distinct values (default 5), entropy threshold (default 3.0 bits), reserved blocklist match, and high-risk-sibling no-merge rule. Emitted evidence is deterministic across runs (segment positions sorted ascending) so the policy hash stays stable.

- **`cardinality.go`**: per-host cap (default 1000) with `_other` tail bucketing. Top-N selection by event count with stable lexicographic tie-breaking. `ShouldBlockPromotion` engages when tail event count strictly exceeds the configured percentage of host total (default 5.0) without explicit `accept_tail`. Adversarial corpus test exercises a 100K-distinct-path host bucketing into top-1000 plus tail in roughly 0.7 seconds.

## Pen-test gates the test pack pins

- `/admin` cannot collapse: even surrounded by 1000 high-entropy random siblings at the same parent, the position retains as a literal because the reserved blocklist is a position-level decision.
- `/v1/admin` and `/v1/users` cannot merge: when both are present at the same parent and either appears in the high-risk-sibling list, the no-merge gate fires.
- 100K distinct synthetic paths bucket into top-1000 plus a single `_other` tail with the correct event count sum, and the promotion-block correctly engages because tail is roughly 99% of events.
- Non-canonical paths hard-fail at Canonicalize before reaching Decide.

## Config surface

Adds `learn.inference.normalization.{algorithm, min_events, min_distinct_values, entropy_threshold_bits, reserved_segments_extra, cardinality_cap_per_host, tail_promotion_block_pct}` to the existing `learn:` block. Algorithm is locked to `frequency_weighted_entropy_v1`; numeric fields validate to non-negative; entropy threshold is bounded to `[0, 8.0]` bits; tail percent is bounded to `[0, 100]`; the reserved-segments-extra list rejects empty entries with a precise YAML index in the error message.

The config validator deliberately duplicates the inference package's `DecideConfig.Validate()` and `CapConfig.Validate()` so operators see `learn.inference.normalization.cardinality_cap_per_host: -1: must be non-negative` instead of an API-level field name.

## CLI handlers

`pipelock learn split --candidate <path> --rule <rule_id> [--index N] [--out <path>]` rewrites a candidate contract YAML to demote one or more collapsed segments back into literal values. With `--index 0` (default) all collapsed segments for the rule are split; with a specific index only that one moves. Writes atomically via temp file plus rename. Idempotent.

`pipelock learn pin --candidate <path> --rule <rule_id> --segment <value> [--out <path>]` adds a per-rule `pinned_segments` entry for a literal value, ensuring subsequent recompile passes treat it as reserved-equivalent for that rule. Operates at the YAML node level via `gopkg.in/yaml.v3` so comments and ordering are preserved across rewrite. Idempotent.

Neither command signs or activates the candidate; that lands with the compile pipeline in a follow-up.

## Metrics fold-in

`RecordObservationEvent` and `RecordRegulatedDataBlocked` now match the closed-allowlist contract the inference helpers got in the prior PR. New typed aliases `ActionClass` (read, derive, write, delegate, authorize, spend, commit, actuate, unclassified) and `BlockReason` (field_class_regulated, root_class_regulated, explicit_block) with exported canonical constants. Non-canonical values drop silently to prevent cardinality drift on the security-relevant counters. The `unclassified` side-effect on `learnUnclassifiedActions` is preserved when reached via the canonical `ActionUnclassified` branch.

No production callers exist yet for either helper (the prior PR shipped them without runtime wiring; that lands later), so the fold-in is contained to `internal/metrics/learn.go` plus its tests.

## Prior-PR review fixes folded in

- **BudgetStats finite contract**: filters NaN and infinite values from the input window before computing statistics so the contract math layer cannot persist non-finite values into a signed envelope. SampleCount reflects post-filter count. New `TestBudgetStats_FiltersNonFinite` covers 5 boundary rows.
- **Hash drift on omitted floors**: `policySemanticView` now resolves omitted `learn.inference.floors.*` and `learn.inference.normalization.*` to their effective defaults before hashing so a YAML omitting these and a YAML setting them explicitly to the design defaults hash identically. New regression tests `TestCanonicalPolicyHash_OmittedFloorsHashAsExplicitDefaults` and `..._OmittedNormalizationHashAsExplicitDefaults` prove the invariant.
- **Wilson extreme-alpha boundary**: `invNormalCDF` clamps `p` to `(1e-15, 1 - 1e-15)` so extreme alpha values cannot drive the rational approximation toward NaN or infinity. Documented supported alpha range.
- **Source-comment OPSEC**: scrubbed internal-tracker phrasing across every reviewer-flagged file plus follow-on touched files (`budgets.go`, `floors.go`, `opportunity.go`, `wilson.go`, `schema.go`, `metrics/learn.go`, the CLI files, the new normalize files, and the canonical golden test). Replaced with product-neutral language.

## Policy-hash impact

Adding the normalization substruct plus the Resolved pre-pass shifts the canonical policy hash twice in this cycle. Both `goldenHashDefaults` and `goldenHashRichConfig` are updated with explanatory test-file comments extending the prior bumps. The Resolved pre-pass closes a verifier-drift hole: omitted YAML and explicit defaults now hash identically.

## Coverage

- 100% line coverage on every new function in the normalize package except `Entropy` (94.7%, with one intentionally uncovered defensive `IsNaN || IsInf` clamp documented inline as a defense-in-depth on the signed-policy-hash path).
- 100% on every new CLI helper top-level function (runSplit, runPin, splitCmd, pinCmd, splitNormalization, pinNormalization). A few internal yaml.Node helpers sit at 87 to 95% on defensive nil branches that yaml.v3 cannot produce on parse; documented inline.
- 100% on every new config validator and on every metrics helper (the four hardened helpers plus the two from the prior PR).
- 1300+ config-package PASS subtests, 200+ normalize-package PASS subtests, 175+ metrics-package PASS subtests, 85+ CLI-package PASS subtests.

## Cross-build

Linux and Windows builds, default and enterprise tags, all four green. The new package is pure Go math plus stdlib (`slices`, `strings`, `unicode`, `unicode/norm`, `net/url`, `errors`, `fmt`, `sort`, `math`) and `golang.org/x/text/unicode/norm` which pipelock already depends on. No syscall surface.

## Out of scope

- The full `pipelock learn compile` end-to-end pipeline (streaming JSONL ingest, deterministic recompile, signed candidate emission) lands in a later PR. This PR ships the building blocks but not the wiring that produces candidate files.
- Runtime wiring of the metrics helpers is still future work; the helpers stand ready with the closed-allowlist contract in place.
- The verifier `verify.py` is not extended; this PR does not emit signed artifacts.
- Pre-existing source-comment phrasing in `internal/contract/contract.go` and sibling files from earlier PRs is intentionally not scrubbed here; that would explode the diff into files this PR does not otherwise touch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `split` and `pin` subcommands to the `learn` command for managing path segments in contract rules.
  * Introduced path normalization configuration with entropy-based bucketing and cardinality capping for improved contract inference.

* **Documentation**
  * Updated pipeline terminology from "learn-and-lock" to "contract-compile" observation pipeline throughout documentation.

* **Bug Fixes**
  * Improved handling of non-finite values in budget statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->