### PR TITLE
feat(contract): add shadow replay reports

### DIFF
--- a/internal/capture/diff.go
+++ b/internal/capture/diff.go
@@ -3,7 +3,10 @@
 
 package capture
 
-import "sort"
+import (
+	"sort"
+	"time"
+)
 
 // reportVersion is the current DiffReport schema version.
 const reportVersion = 1
@@ -22,6 +25,10 @@ const (
 type ReplayedRecord struct {
 	Summary CaptureSummary
 	Result  ReplayResult
+	// Timestamp is the recorder-envelope timestamp for the captured entry.
+	// It is used by shadow reporting to bucket deltas without trusting
+	// wall-clock time at analysis time.
+	Timestamp time.Time
 }
 
 // DiffReport is the output of ComputeDiff. It summarises how a candidate

--- a/internal/capture/loader.go
+++ b/internal/capture/loader.go
@@ -153,8 +153,9 @@ func LoadAndReplayWithOptions(cfg *config.Config, sessionsDir string, opts Repla
 				replayed := re.ReplayRecord(summary, scannerInput)
 				replayed.SidecarDecrypted = sidecarDecrypted
 				allRecords = append(allRecords, ReplayedRecord{
-					Summary: summary,
-					Result:  replayed,
+					Summary:   summary,
+					Result:    replayed,
+					Timestamp: entry.Timestamp,
 				})
 			}
 		}

--- a/internal/capture/replay.go
+++ b/internal/capture/replay.go
@@ -113,6 +113,7 @@ func (re *ReplayEngine) replayContractURL(summary CaptureSummary, scannerInput s
 
 	hostHasEnforceRule := false
 	hasComparableEvidence := false
+	var hostRuleIDs []string
 	for _, rule := range re.contract.Rules {
 		if rule.LifecycleState != "enforce" || (rule.RuleKind != "http_destination" && rule.RuleKind != "http_action") {
 			continue
@@ -121,6 +122,7 @@ func (re *ReplayEngine) replayContractURL(summary CaptureSummary, scannerInput s
 			continue
 		}
 		hostHasEnforceRule = true
+		hostRuleIDs = append(hostRuleIDs, rule.RuleID)
 		matches, canCompare := contractRuleMatchesURL(rule, u, summary)
 		if !canCompare {
 			return re.replayURL(summary, scannerInput)
@@ -134,6 +136,12 @@ func (re *ReplayEngine) replayContractURL(summary CaptureSummary, scannerInput s
 				OriginalAction:  summary.EffectiveAction,
 				CandidateAction: config.ActionAllow,
 				Changed:         summary.EffectiveAction != config.ActionAllow,
+				CandidateFindings: []Finding{{
+					Kind:       KindContract,
+					Action:     config.ActionAllow,
+					PolicyRule: rule.RuleID,
+					MatchText:  target,
+				}},
 			}
 		}
 	}
@@ -144,15 +152,31 @@ func (re *ReplayEngine) replayContractURL(summary CaptureSummary, scannerInput s
 		return re.replayURL(summary, scannerInput)
 	}
 	return ReplayResult{
-		OriginalAction:  summary.EffectiveAction,
-		CandidateAction: config.ActionBlock,
-		Changed:         summary.EffectiveAction != config.ActionBlock,
-		CandidateFindings: []Finding{{
+		OriginalAction:    summary.EffectiveAction,
+		CandidateAction:   config.ActionBlock,
+		Changed:           summary.EffectiveAction != config.ActionBlock,
+		CandidateFindings: contractDenyFindings(hostRuleIDs, target),
+	}
+}
+
+func contractDenyFindings(ruleIDs []string, target string) []Finding {
+	if len(ruleIDs) == 0 {
+		return []Finding{{
 			Kind:      KindContract,
 			Action:    config.ActionBlock,
 			MatchText: target,
-		}},
+		}}
 	}
+	out := make([]Finding, 0, len(ruleIDs))
+	for _, ruleID := range ruleIDs {
+		out = append(out, Finding{
+			Kind:       KindContract,
+			Action:     config.ActionBlock,
+			PolicyRule: ruleID,
+			MatchText:  target,
+		})
+	}
+	return out
 }
 
 func contractRuleHostMatches(rule contract.Rule, host string) bool {

--- a/internal/capture/replay.go
+++ b/internal/capture/replay.go
@@ -114,6 +114,7 @@ func (re *ReplayEngine) replayContractURL(summary CaptureSummary, scannerInput s
 	hostHasEnforceRule := false
 	hasComparableEvidence := false
 	var hostRuleIDs []string
+	seenHostRuleIDs := map[string]struct{}{}
 	for _, rule := range re.contract.Rules {
 		if rule.LifecycleState != "enforce" || (rule.RuleKind != "http_destination" && rule.RuleKind != "http_action") {
 			continue
@@ -122,7 +123,7 @@ func (re *ReplayEngine) replayContractURL(summary CaptureSummary, scannerInput s
 			continue
 		}
 		hostHasEnforceRule = true
-		hostRuleIDs = append(hostRuleIDs, rule.RuleID)
+		hostRuleIDs = appendContractRuleID(hostRuleIDs, seenHostRuleIDs, rule.RuleID)
 		matches, canCompare := contractRuleMatchesURL(rule, u, summary)
 		if !canCompare {
 			return re.replayURL(summary, scannerInput)
@@ -159,16 +160,33 @@ func (re *ReplayEngine) replayContractURL(summary CaptureSummary, scannerInput s
 	}
 }
 
+func appendContractRuleID(ruleIDs []string, seen map[string]struct{}, ruleID string) []string {
+	ruleID = strings.TrimSpace(ruleID)
+	if ruleID == "" {
+		return ruleIDs
+	}
+	if _, ok := seen[ruleID]; ok {
+		return ruleIDs
+	}
+	seen[ruleID] = struct{}{}
+	return append(ruleIDs, ruleID)
+}
+
 func contractDenyFindings(ruleIDs []string, target string) []Finding {
-	if len(ruleIDs) == 0 {
+	seen := map[string]struct{}{}
+	unique := make([]string, 0, len(ruleIDs))
+	for _, ruleID := range ruleIDs {
+		unique = appendContractRuleID(unique, seen, ruleID)
+	}
+	if len(unique) == 0 {
 		return []Finding{{
 			Kind:      KindContract,
 			Action:    config.ActionBlock,
 			MatchText: target,
 		}}
 	}
-	out := make([]Finding, 0, len(ruleIDs))
-	for _, ruleID := range ruleIDs {
+	out := make([]Finding, 0, len(unique))
+	for _, ruleID := range unique {
 		out = append(out, Finding{
 			Kind:       KindContract,
 			Action:     config.ActionBlock,

--- a/internal/capture/replay_test.go
+++ b/internal/capture/replay_test.go
@@ -27,6 +27,8 @@ const loadReplayOriginalHash = "sha256:original"
 // fakeAWSKey is split to avoid gosec G101.
 const fakeAWSKey = "AKIA" + "IOSFODNN7EXAMPLE"
 
+const testContractRuleIDAPI = "r-api"
+
 func newTestScanner(t *testing.T, mutate func(*config.Config)) *scanner.Scanner {
 	t.Helper()
 	cfg := config.Defaults()
@@ -112,7 +114,7 @@ func TestReplayContractURL(t *testing.T) {
 	sc := newTestScanner(t, nil)
 	re := NewContractReplayEngine(cfg, sc, contract.Contract{
 		Rules: []contract.Rule{{
-			RuleID:               "r-api",
+			RuleID:               testContractRuleIDAPI,
 			RuleKind:             "http_destination",
 			LifecycleState:       "enforce",
 			RequiredCaptureGrade: contract.CaptureGradeFull,
@@ -138,7 +140,7 @@ func TestReplayContractURL(t *testing.T) {
 	if allowed.Changed || allowed.CandidateAction != config.ActionAllow {
 		t.Fatalf("allowed result = changed %v action %q, want false/allow", allowed.Changed, allowed.CandidateAction)
 	}
-	if len(allowed.CandidateFindings) != 1 || allowed.CandidateFindings[0].PolicyRule != "r-api" {
+	if len(allowed.CandidateFindings) != 1 || allowed.CandidateFindings[0].PolicyRule != testContractRuleIDAPI {
 		t.Fatalf("allowed contract findings = %#v, want rule id", allowed.CandidateFindings)
 	}
 
@@ -154,7 +156,7 @@ func TestReplayContractURL(t *testing.T) {
 		t.Fatalf("blocked result = changed %v action %q, want true/block", blocked.Changed, blocked.CandidateAction)
 	}
 	if len(blocked.CandidateFindings) != 1 || blocked.CandidateFindings[0].Kind != KindContract ||
-		blocked.CandidateFindings[0].PolicyRule != "r-api" {
+		blocked.CandidateFindings[0].PolicyRule != testContractRuleIDAPI {
 		t.Fatalf("contract findings = %#v, want one contract finding", blocked.CandidateFindings)
 	}
 
@@ -185,6 +187,72 @@ func TestReplayContractURL(t *testing.T) {
 		if result.Changed || result.CandidateAction != config.ActionAllow {
 			t.Fatalf("%s result = changed %v action %q, want non-canonical scanner fallback allow", rawURL, result.Changed, result.CandidateAction)
 		}
+	}
+}
+
+func TestReplayContractURL_DeduplicatesDenyRuleIDs(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.DLP.ScanEnv = false
+	sc := newTestScanner(t, nil)
+	re := NewContractReplayEngine(cfg, sc, contract.Contract{
+		Rules: []contract.Rule{
+			{
+				RuleID:               " r-api ",
+				RuleKind:             "http_destination",
+				LifecycleState:       "enforce",
+				RequiredCaptureGrade: contract.CaptureGradeFull,
+				ObservedCaptureGrade: contract.CaptureGradeFull,
+				Selector: map[string]any{
+					"host": map[string]any{"value": "api.example.com"},
+					"paths": []any{
+						map[string]any{"value": "/repos/foo"},
+					},
+				},
+			},
+			{
+				RuleID:               testContractRuleIDAPI,
+				RuleKind:             "http_destination",
+				LifecycleState:       "enforce",
+				RequiredCaptureGrade: contract.CaptureGradeFull,
+				ObservedCaptureGrade: contract.CaptureGradeFull,
+				Selector: map[string]any{
+					"host": map[string]any{"value": "api.example.com"},
+					"paths": []any{
+						map[string]any{"value": "/repos/baz"},
+					},
+				},
+			},
+			{
+				RuleID:               "",
+				RuleKind:             "http_destination",
+				LifecycleState:       "enforce",
+				RequiredCaptureGrade: contract.CaptureGradeFull,
+				ObservedCaptureGrade: contract.CaptureGradeFull,
+				Selector: map[string]any{
+					"host": map[string]any{"value": "api.example.com"},
+					"paths": []any{
+						map[string]any{"value": "/repos/qux"},
+					},
+				},
+			},
+		},
+	})
+
+	result := re.ReplayRecord(CaptureSummary{
+		Surface:         SurfaceURL,
+		EffectiveAction: config.ActionAllow,
+		Request: CaptureRequest{
+			Method: "GET",
+			URL:    "https://api.example.com/repos/bar",
+		},
+	}, "")
+	if result.CandidateAction != config.ActionBlock || len(result.CandidateFindings) != 1 {
+		t.Fatalf("result findings = %+v, want one contract deny finding", result.CandidateFindings)
+	}
+	if got := result.CandidateFindings[0].PolicyRule; got != testContractRuleIDAPI {
+		t.Fatalf("PolicyRule = %q, want trimmed unique rule id", got)
 	}
 }
 

--- a/internal/capture/replay_test.go
+++ b/internal/capture/replay_test.go
@@ -138,6 +138,9 @@ func TestReplayContractURL(t *testing.T) {
 	if allowed.Changed || allowed.CandidateAction != config.ActionAllow {
 		t.Fatalf("allowed result = changed %v action %q, want false/allow", allowed.Changed, allowed.CandidateAction)
 	}
+	if len(allowed.CandidateFindings) != 1 || allowed.CandidateFindings[0].PolicyRule != "r-api" {
+		t.Fatalf("allowed contract findings = %#v, want rule id", allowed.CandidateFindings)
+	}
 
 	blocked := re.ReplayRecord(CaptureSummary{
 		Surface:         SurfaceURL,
@@ -150,7 +153,8 @@ func TestReplayContractURL(t *testing.T) {
 	if !blocked.Changed || blocked.CandidateAction != config.ActionBlock {
 		t.Fatalf("blocked result = changed %v action %q, want true/block", blocked.Changed, blocked.CandidateAction)
 	}
-	if len(blocked.CandidateFindings) != 1 || blocked.CandidateFindings[0].Kind != KindContract {
+	if len(blocked.CandidateFindings) != 1 || blocked.CandidateFindings[0].Kind != KindContract ||
+		blocked.CandidateFindings[0].PolicyRule != "r-api" {
 		t.Fatalf("contract findings = %#v, want one contract finding", blocked.CandidateFindings)
 	}
 

--- a/internal/cli/learn/diff.go
+++ b/internal/cli/learn/diff.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package learn
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	"github.com/luckyPipewrench/pipelock/internal/contract/shadow"
+)
+
+func diffCmd() *cobra.Command {
+	var outPath string
+	cmd := &cobra.Command{
+		Use:   "diff <shadow-a.json> <shadow-b.json>",
+		Short: "Compare two shadow JSON reports",
+		Long: `Compare two JSON reports written by 'pipelock learn shadow --out-json'.
+
+The output is deterministic markdown summarizing per-rule changes in evaluation
+volume and new-block rates between the two shadow runs.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDiff(cmd, args[0], args[1], outPath)
+		},
+	}
+	cmd.Flags().StringVar(&outPath, "out", "", "write markdown to path instead of stdout")
+	return cmd
+}
+
+func runDiff(cmd *cobra.Command, firstPath, secondPath, outPath string) error {
+	first, err := readShadowReport(firstPath)
+	if err != nil {
+		return err
+	}
+	second, err := readShadowReport(secondPath)
+	if err != nil {
+		return err
+	}
+	rows := shadow.DiffReports(first, second)
+	markdown := renderShadowDiff(first, second, rows)
+	if outPath == "" {
+		emitAuditEvent(cmd, auditEvent{
+			Event:     "learn_diff",
+			Candidate: filepath.Clean(firstPath),
+			Dest:      filepath.Clean(secondPath),
+			NoOp:      len(rows) == 0,
+		})
+		_, _ = fmt.Fprint(cmd.OutOrStdout(), markdown)
+		return nil
+	}
+	dest, err := checkedWritePath(filepath.Clean(outPath))
+	if err != nil {
+		return err
+	}
+	if err := atomicfile.Write(dest, []byte(markdown), 0o600); err != nil {
+		return fmt.Errorf("learn diff: write markdown: %w", err)
+	}
+	emitAuditEvent(cmd, auditEvent{
+		Event:     "learn_diff",
+		Candidate: filepath.Clean(firstPath),
+		Dest:      dest,
+		NoOp:      len(rows) == 0,
+	})
+	return nil
+}
+
+func renderShadowDiff(first, second shadow.Report, rows []shadow.RuleStats) string {
+	out := "# Shadow Diff\n\n"
+	out += fmt.Sprintf("- first_contract_hash: `%s`\n", first.ContractHash)
+	out += fmt.Sprintf("- second_contract_hash: `%s`\n", second.ContractHash)
+	out += fmt.Sprintf("- records_delta: %+d\n", second.TotalRecords-first.TotalRecords)
+	out += fmt.Sprintf("- new_blocks_delta: %+d\n", second.NewBlocks-first.NewBlocks)
+	out += fmt.Sprintf("- quarantine_delta: %+d\n\n", len(second.Quarantines)-len(first.Quarantines))
+	out += "| rule | evals_delta | new_blocks_delta | new_allows_delta | rate_delta |\n"
+	out += "|---|---:|---:|---:|---:|\n"
+	for _, row := range rows {
+		out += fmt.Sprintf("| `%s` | %+d | %+d | %+d | %+.2f%% |\n",
+			row.RuleID, row.Evaluations, row.NewBlocks, row.NewAllows, row.NewBlockRatePct)
+	}
+	return out
+}

--- a/internal/cli/learn/diff.go
+++ b/internal/cli/learn/diff.go
@@ -46,8 +46,11 @@ func runDiff(cmd *cobra.Command, firstPath, secondPath, outPath string) error {
 		emitAuditEvent(cmd, auditEvent{
 			Event:     "learn_diff",
 			Candidate: filepath.Clean(firstPath),
-			Dest:      filepath.Clean(secondPath),
-			NoOp:      len(rows) == 0,
+			Inputs: []string{
+				filepath.Clean(firstPath),
+				filepath.Clean(secondPath),
+			},
+			NoOp: len(rows) == 0,
 		})
 		_, _ = fmt.Fprint(cmd.OutOrStdout(), markdown)
 		return nil
@@ -62,8 +65,12 @@ func runDiff(cmd *cobra.Command, firstPath, secondPath, outPath string) error {
 	emitAuditEvent(cmd, auditEvent{
 		Event:     "learn_diff",
 		Candidate: filepath.Clean(firstPath),
-		Dest:      dest,
-		NoOp:      len(rows) == 0,
+		Inputs: []string{
+			filepath.Clean(firstPath),
+			filepath.Clean(secondPath),
+		},
+		Dest: dest,
+		NoOp: len(rows) == 0,
 	})
 	return nil
 }

--- a/internal/cli/learn/learn.go
+++ b/internal/cli/learn/learn.go
@@ -41,6 +41,8 @@ Observe: pipelock learn observe --capture-dir <dir>
 Compile and review:
   pipelock learn compile --agent <name> [--input <glob>]
   pipelock learn review <candidate.yaml>
+  pipelock learn shadow --contract <candidate.yaml> --sessions <dir>
+  pipelock learn diff <shadow-a.json> <shadow-b.json>
 
 Operator affordances (mutate candidate YAML before ratification):
   pipelock learn split --candidate <path> --rule <rule_id> [--index N] [--out <path>]
@@ -49,6 +51,8 @@ Operator affordances (mutate candidate YAML before ratification):
 	cmd.AddCommand(observeCmd())
 	cmd.AddCommand(compileCmd())
 	cmd.AddCommand(reviewCmd())
+	cmd.AddCommand(shadowCmd())
+	cmd.AddCommand(diffCmd())
 	cmd.AddCommand(splitCmd())
 	cmd.AddCommand(pinCmd())
 	return cmd

--- a/internal/cli/learn/shadow.go
+++ b/internal/cli/learn/shadow.go
@@ -128,11 +128,11 @@ func runShadow(cmd *cobra.Command, flags shadowFlags) error {
 	if err != nil {
 		return err
 	}
-	receiptsEmitted, err := emitShadowReceipts(flags, env.Body, report, now)
-	if err != nil {
+	if err := writeShadowReports(cmd, report, flags); err != nil {
 		return err
 	}
-	if err := writeShadowReports(cmd, report, flags); err != nil {
+	receiptsEmitted, err := emitShadowReceipts(flags, env.Body, report, now)
+	if err != nil {
 		return err
 	}
 

--- a/internal/cli/learn/shadow.go
+++ b/internal/cli/learn/shadow.go
@@ -1,0 +1,399 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package learn
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	"github.com/luckyPipewrench/pipelock/internal/capture"
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/contract/shadow"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const defaultReceiptKeyAgent = "receipt-signing"
+
+type shadowFlags struct {
+	contractPath  string
+	contractKey   string
+	allowUnsigned bool
+	configPath    string
+	sessionsDir   string
+	agent         string
+	duration      time.Duration
+	outPath       string
+	outJSONPath   string
+	recorderDir   string
+	escrowKeyHex  string
+	keystore      string
+	receiptKey    string
+	deterministic bool
+}
+
+func shadowCmd() *cobra.Command {
+	var flags shadowFlags
+	flags.duration = 7 * 24 * time.Hour
+	cmd := &cobra.Command{
+		Use:   "shadow",
+		Short: "Replay observations against a candidate contract and emit shadow deltas",
+		Long: `Replay captured observations against a signed candidate contract, summarize
+candidate-vs-original verdict deltas, and optionally persist signed shadow_delta
+receipts into a recorder chain.
+
+Use --sessions for an explicit capture sessions directory. Without --sessions,
+provide --agent and configure learn.capture_dir; the command reads
+<capture_dir>/<agent>.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runShadow(cmd, flags)
+		},
+	}
+	cmd.Flags().StringVar(&flags.contractPath, "contract", "", "signed candidate contract YAML (required, absolute)")
+	cmd.Flags().StringVar(&flags.contractKey, "contract-key", "", "trusted Ed25519 public key (hex or file) used to verify --contract")
+	cmd.Flags().BoolVar(&flags.allowUnsigned, "allow-unsigned-contract-for-diagnostics", false, "allow unverified --contract input for diagnostics only (unsafe)")
+	cmd.Flags().StringVar(&flags.configPath, "config", "", "path to pipelock config file")
+	cmd.Flags().StringVar(&flags.sessionsDir, "sessions", "", "capture sessions directory (absolute)")
+	cmd.Flags().StringVar(&flags.agent, "agent", "", "agent name used with learn.capture_dir when --sessions is omitted")
+	cmd.Flags().DurationVar(&flags.duration, "duration", flags.duration, "lookback duration for captured observations")
+	cmd.Flags().StringVar(&flags.outPath, "out", "", "markdown report output path; empty writes markdown to stdout")
+	cmd.Flags().StringVar(&flags.outJSONPath, "out-json", "", "JSON report output path")
+	cmd.Flags().StringVar(&flags.recorderDir, "recorder-dir", "", "recorder directory for signed shadow_delta receipts")
+	cmd.Flags().StringVar(&flags.escrowKeyHex, "escrow-private-key", "", "X25519 hex private key for sidecar decryption")
+	cmd.Flags().StringVar(&flags.keystore, "keystore", "", "keystore directory for receipt signing")
+	cmd.Flags().StringVar(&flags.receiptKey, "receipt-key-agent", defaultReceiptKeyAgent, "keystore agent name for receipt signing")
+	cmd.Flags().BoolVar(&flags.deterministic, "deterministic", false, "use deterministic fixtures for reproducible reports")
+	_ = cmd.MarkFlagRequired("contract")
+	return cmd
+}
+
+func runShadow(cmd *cobra.Command, flags shadowFlags) error {
+	if flags.duration <= 0 {
+		return fmt.Errorf("learn shadow: --duration must be positive")
+	}
+	cfg, err := loadConfig(flags.configPath)
+	if err != nil {
+		return err
+	}
+	cfg.Internal = nil
+	cfg.DLP.ScanEnv = false
+
+	env, contractPath, verified, err := loadShadowContract(flags.contractPath, flags.contractKey, flags.allowUnsigned)
+	if err != nil {
+		return err
+	}
+	if !verified {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning: unverified contract accepted because --allow-unsigned-contract-for-diagnostics is set; shadow replay is diagnostic only")
+	}
+	sessionsDir, err := resolveShadowSessions(cfg, flags)
+	if err != nil {
+		return err
+	}
+	escrow, err := decodeOptionalHex(flags.escrowKeyHex)
+	if err != nil {
+		return err
+	}
+	records, _, _, _, err := capture.LoadAndReplayWithOptions(cfg, sessionsDir, capture.ReplayOptions{
+		EscrowPrivateKey: escrow,
+		Contract:         &env.Body,
+	})
+	if err != nil {
+		return fmt.Errorf("learn shadow: replay captures: %w", err)
+	}
+	now := time.Now().UTC()
+	if flags.deterministic {
+		now = time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	}
+	records = filterShadowDuration(records, now, flags.duration)
+	report, err := shadow.Analyze(records, shadow.AnalyzeOptions{
+		ContractHash: contractHash(env.Body),
+		GeneratedAt:  now,
+		Aggregation:  shadow.DefaultAggregateConfig(),
+		Quarantine:   shadow.DefaultQuarantineConfig(),
+	})
+	if err != nil {
+		return err
+	}
+	receiptsEmitted, err := emitShadowReceipts(flags, env.Body, report, now)
+	if err != nil {
+		return err
+	}
+	if err := writeShadowReports(cmd, report, flags); err != nil {
+		return err
+	}
+
+	emitAuditEvent(cmd, auditEvent{
+		Event:           "learn_shadow",
+		Candidate:       contractPath,
+		Agent:           flags.agent,
+		Sessions:        sessionsDir,
+		Output:          flags.outPath,
+		Review:          flags.outJSONPath,
+		RecorderDir:     flags.recorderDir,
+		EventsIngested:  report.TotalRecords,
+		RulesEmitted:    len(report.Batches),
+		Quarantines:     len(report.Quarantines),
+		ReceiptsEmitted: receiptsEmitted,
+		NoOp:            report.Changed == 0,
+	})
+	return nil
+}
+
+func loadShadowContract(path, publicKey string, allowUnsigned bool) (contract.ContractEnvelope, string, bool, error) {
+	clean, doc, err := loadCandidate(path)
+	if err != nil {
+		return contract.ContractEnvelope{}, "", false, err
+	}
+	raw, err := yamlBytes(doc)
+	if err != nil {
+		return contract.ContractEnvelope{}, "", false, err
+	}
+	var env contract.ContractEnvelope
+	if err := contract.DecodeStrictYAML(raw, &env); err != nil {
+		return contract.ContractEnvelope{}, "", false, fmt.Errorf("learn shadow: decode contract: %w", err)
+	}
+	if err := env.Body.Validate(); err != nil {
+		return contract.ContractEnvelope{}, "", false, fmt.Errorf("learn shadow: validate contract: %w", err)
+	}
+	if publicKey == "" {
+		if !allowUnsigned {
+			return contract.ContractEnvelope{}, "", false,
+				fmt.Errorf("learn shadow: --contract-key is required for --contract (or use --allow-unsigned-contract-for-diagnostics)")
+		}
+		return env, clean, false, nil
+	}
+	pubKey, err := signing.LoadPublicKey(publicKey)
+	if err != nil {
+		return contract.ContractEnvelope{}, "", false, fmt.Errorf("learn shadow: load contract verification key: %w", err)
+	}
+	if err := verifyShadowContractEnvelope(env, pubKey); err != nil {
+		return contract.ContractEnvelope{}, "", false, fmt.Errorf("learn shadow: verify contract: %w", err)
+	}
+	return env, clean, true, nil
+}
+
+func verifyShadowContractEnvelope(env contract.ContractEnvelope, pubKey ed25519.PublicKey) error {
+	if env.Body.KeyPurpose != signing.PurposeContractCompileSigning.String() {
+		return fmt.Errorf("key_purpose must be %q, got %q", signing.PurposeContractCompileSigning.String(), env.Body.KeyPurpose)
+	}
+	if !strings.HasPrefix(env.Signature, "ed25519:") {
+		return fmt.Errorf("signature must use ed25519:<hex>")
+	}
+	sig, err := hex.DecodeString(strings.TrimPrefix(env.Signature, "ed25519:"))
+	if err != nil {
+		return fmt.Errorf("decode signature: %w", err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return fmt.Errorf("signature length=%d, want %d", len(sig), ed25519.SignatureSize)
+	}
+	preimage, err := env.Body.SignablePreimage()
+	if err != nil {
+		return fmt.Errorf("build preimage: %w", err)
+	}
+	if !ed25519.Verify(pubKey, preimage, sig) {
+		return fmt.Errorf("signature verification failed")
+	}
+	return nil
+}
+
+func resolveShadowSessions(cfg *config.Config, flags shadowFlags) (string, error) {
+	if flags.sessionsDir != "" {
+		return checkedReadDir(flags.sessionsDir)
+	}
+	if err := validateCompileAgent(flags.agent); err != nil {
+		return "", err
+	}
+	if cfg.Learn.CaptureDir == "" {
+		return "", errNoCaptureDir
+	}
+	if !filepath.IsAbs(filepath.Clean(cfg.Learn.CaptureDir)) {
+		return "", errRelativeCaptureDir
+	}
+	return checkedReadDir(filepath.Join(cfg.Learn.CaptureDir, flags.agent))
+}
+
+func checkedReadDir(path string) (string, error) {
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) {
+		return "", fmt.Errorf("%w: sessions dir must be absolute: %s", ErrInvalidCandidate, path)
+	}
+	info, err := os.Lstat(clean)
+	if err != nil {
+		return "", fmt.Errorf("%w: inspect sessions dir: %w", ErrInvalidCandidate, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("%w: sessions dir must not be a symlink: %s", ErrInvalidCandidate, clean)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%w: sessions dir must be a directory: %s", ErrInvalidCandidate, clean)
+	}
+	return clean, nil
+}
+
+func filterShadowDuration(records []capture.ReplayedRecord, now time.Time, duration time.Duration) []capture.ReplayedRecord {
+	cutoff := now.Add(-duration)
+	filtered := records[:0]
+	for _, record := range records {
+		if record.Timestamp.IsZero() || !record.Timestamp.Before(cutoff) {
+			filtered = append(filtered, record)
+		}
+	}
+	return filtered
+}
+
+func emitShadowReceipts(flags shadowFlags, body contract.Contract, report shadow.Report, now time.Time) (int, error) {
+	if flags.recorderDir == "" || len(report.Batches) == 0 {
+		return 0, nil
+	}
+	recorderDir, err := checkedWriteDir(flags.recorderDir)
+	if err != nil {
+		return 0, err
+	}
+	signer, err := resolveShadowSigner(flags)
+	if err != nil {
+		return 0, err
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                recorderDir,
+		CheckpointInterval: 1000,
+		MaxEntriesPerFile:  10000,
+		Redact:             true,
+	}, nil, nil)
+	if err != nil {
+		return 0, fmt.Errorf("learn shadow: open recorder: %w", err)
+	}
+	defer func() { _ = rec.Close() }()
+	emitter := shadow.NewEmitter(shadow.EmitterConfig{
+		Recorder:           rec,
+		Signer:             signer,
+		Principal:          "learn",
+		Actor:              "shadow",
+		ActiveManifestHash: body.ContractHash,
+		SelectorID:         body.Selector.SelectorID,
+		Clock: func() time.Time {
+			return now
+		},
+	})
+	for i, batch := range report.Batches {
+		if err := emitter.EmitBatch(batch); err != nil {
+			return i, err
+		}
+	}
+	return len(report.Batches), nil
+}
+
+func checkedWriteDir(path string) (string, error) {
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) {
+		return "", fmt.Errorf("%w: recorder dir must be absolute: %s", ErrInvalidCandidate, path)
+	}
+	if err := os.MkdirAll(clean, 0o750); err != nil {
+		return "", fmt.Errorf("learn shadow: mkdir recorder dir: %w", err)
+	}
+	info, err := os.Lstat(clean)
+	if err != nil {
+		return "", fmt.Errorf("%w: inspect recorder dir: %w", ErrInvalidCandidate, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("%w: recorder dir must not be a symlink: %s", ErrInvalidCandidate, clean)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%w: recorder dir must be a directory: %s", ErrInvalidCandidate, clean)
+	}
+	return clean, nil
+}
+
+func resolveShadowSigner(flags shadowFlags) (privateKeySigner, error) {
+	if flags.deterministic {
+		seed := sha256.Sum256([]byte("pipelock deterministic shadow receipt signer"))
+		return privateKeySigner{keyID: "deterministic-receipt-signing", key: ed25519.NewKeyFromSeed(seed[:])}, nil
+	}
+	keyAgent := flags.receiptKey
+	if keyAgent == "" {
+		keyAgent = defaultReceiptKeyAgent
+	}
+	dir, err := cliutil.ResolveKeystoreDir(flags.keystore)
+	if err != nil {
+		return privateKeySigner{}, err
+	}
+	priv, err := signing.NewKeystore(dir).LoadPrivateKey(keyAgent)
+	if err != nil {
+		return privateKeySigner{}, fmt.Errorf("load receipt signing key for %q: %w", keyAgent, err)
+	}
+	return privateKeySigner{keyID: keyAgent, key: priv}, nil
+}
+
+func writeShadowReports(cmd *cobra.Command, report shadow.Report, flags shadowFlags) error {
+	var markdown strings.Builder
+	if err := shadow.RenderMarkdown(&markdown, report); err != nil {
+		return err
+	}
+	if flags.outPath == "" {
+		_, _ = fmt.Fprint(cmd.OutOrStdout(), markdown.String())
+	} else {
+		dest, err := checkedWritePath(filepath.Clean(flags.outPath))
+		if err != nil {
+			return err
+		}
+		if err := atomicfile.Write(dest, []byte(markdown.String()), 0o600); err != nil {
+			return fmt.Errorf("learn shadow: write markdown report: %w", err)
+		}
+	}
+	if flags.outJSONPath != "" {
+		var data strings.Builder
+		if err := shadow.RenderJSON(&data, report); err != nil {
+			return err
+		}
+		dest, err := checkedWritePath(filepath.Clean(flags.outJSONPath))
+		if err != nil {
+			return err
+		}
+		if err := atomicfile.Write(dest, []byte(data.String()), 0o600); err != nil {
+			return fmt.Errorf("learn shadow: write JSON report: %w", err)
+		}
+	}
+	return nil
+}
+
+func contractHash(body contract.Contract) string {
+	if body.ContractHash != "" {
+		return body.ContractHash
+	}
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		return "sha256:unknown"
+	}
+	sum := sha256.Sum256(preimage)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func readShadowReport(path string) (shadow.Report, error) {
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) {
+		return shadow.Report{}, fmt.Errorf("%w: report path must be absolute: %s", ErrInvalidCandidate, path)
+	}
+	data, err := safeReadCandidate(clean)
+	if err != nil {
+		return shadow.Report{}, err
+	}
+	var report shadow.Report
+	if err := json.Unmarshal(data, &report); err != nil {
+		return shadow.Report{}, fmt.Errorf("learn diff: decode report: %w", err)
+	}
+	return report, nil
+}

--- a/internal/cli/learn/shadow_test.go
+++ b/internal/cli/learn/shadow_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package learn
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/capture"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract/shadow"
+)
+
+func TestResolveShadowSessionsUsesExplicitDirAndRejectsSymlink(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	got, err := resolveShadowSessions(config.Defaults(), shadowFlags{sessionsDir: dir})
+	if err != nil {
+		t.Fatalf("resolveShadowSessions: %v", err)
+	}
+	if got != dir {
+		t.Fatalf("sessions dir = %q, want %q", got, dir)
+	}
+
+	link := filepath.Join(t.TempDir(), "sessions-link")
+	if err := os.Symlink(dir, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if _, err := resolveShadowSessions(config.Defaults(), shadowFlags{sessionsDir: link}); err == nil ||
+		!strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("resolve symlink error = %v, want symlink rejection", err)
+	}
+}
+
+func TestFilterShadowDurationKeepsZeroTimestampAndRecentRecords(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	records := []capture.ReplayedRecord{
+		{},
+		{Timestamp: now.Add(-30 * time.Minute)},
+		{Timestamp: now.Add(-2 * time.Hour)},
+	}
+	got := filterShadowDuration(records, now, time.Hour)
+	if len(got) != 2 {
+		t.Fatalf("filtered records = %d, want zero timestamp + recent", len(got))
+	}
+}
+
+func TestRunDiffPrintsAndWritesMarkdown(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.json")
+	second := filepath.Join(dir, "second.json")
+	writeShadowReport(t, first, shadow.Report{
+		ReportVersion: 1,
+		ContractHash:  "sha256:a",
+		TotalRecords:  10,
+		NewBlocks:     1,
+		Rules: []shadow.RuleStats{{
+			RuleID:      "rule-a",
+			Evaluations: 10,
+			NewBlocks:   1,
+		}},
+	})
+	writeShadowReport(t, second, shadow.Report{
+		ReportVersion: 1,
+		ContractHash:  "sha256:b",
+		TotalRecords:  12,
+		NewBlocks:     3,
+		Rules: []shadow.RuleStats{{
+			RuleID:      "rule-a",
+			Evaluations: 12,
+			NewBlocks:   3,
+		}},
+	})
+
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if err := runDiff(cmd, first, second, ""); err != nil {
+		t.Fatalf("runDiff stdout: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Shadow Diff") || !strings.Contains(stdout.String(), "+2") {
+		t.Fatalf("stdout diff =\n%s", stdout.String())
+	}
+
+	out := filepath.Join(dir, "diff.md")
+	if err := runDiff(cmd, first, second, out); err != nil {
+		t.Fatalf("runDiff out: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Clean(out))
+	if err != nil {
+		t.Fatalf("ReadFile diff: %v", err)
+	}
+	if !bytes.Contains(data, []byte("new_blocks_delta")) {
+		t.Fatalf("written diff =\n%s", data)
+	}
+}
+
+func writeShadowReport(t *testing.T, path string, report shadow.Report) {
+	t.Helper()
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("Marshal report: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile report: %v", err)
+	}
+}

--- a/internal/cli/learn/shadow_test.go
+++ b/internal/cli/learn/shadow_test.go
@@ -5,7 +5,12 @@ package learn
 
 import (
 	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,8 +21,13 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
 	"github.com/luckyPipewrench/pipelock/internal/contract/shadow"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
+
+const testUnknownContractHash = "sha256:unknown"
 
 func TestResolveShadowSessionsUsesExplicitDirAndRejectsSymlink(t *testing.T) {
 	t.Parallel()
@@ -93,8 +103,16 @@ func TestRunDiffPrintsAndWritesMarkdown(t *testing.T) {
 	if !strings.Contains(stdout.String(), "Shadow Diff") || !strings.Contains(stdout.String(), "+2") {
 		t.Fatalf("stdout diff =\n%s", stdout.String())
 	}
+	var stdoutAudit auditEvent
+	if err := json.Unmarshal(bytes.TrimSpace(stderr.Bytes()), &stdoutAudit); err != nil {
+		t.Fatalf("Unmarshal stdout audit: %v", err)
+	}
+	if stdoutAudit.Dest != "" || len(stdoutAudit.Inputs) != 2 || stdoutAudit.Inputs[1] != filepath.Clean(second) {
+		t.Fatalf("stdout audit = %+v, want both inputs and no dest", stdoutAudit)
+	}
 
 	out := filepath.Join(dir, "diff.md")
+	stderr.Reset()
 	if err := runDiff(cmd, first, second, out); err != nil {
 		t.Fatalf("runDiff out: %v", err)
 	}
@@ -104,6 +122,54 @@ func TestRunDiffPrintsAndWritesMarkdown(t *testing.T) {
 	}
 	if !bytes.Contains(data, []byte("new_blocks_delta")) {
 		t.Fatalf("written diff =\n%s", data)
+	}
+	var fileAudit auditEvent
+	if err := json.Unmarshal(bytes.TrimSpace(stderr.Bytes()), &fileAudit); err != nil {
+		t.Fatalf("Unmarshal file audit: %v", err)
+	}
+	if fileAudit.Dest != filepath.Clean(out) || len(fileAudit.Inputs) != 2 || fileAudit.Inputs[0] != filepath.Clean(first) {
+		t.Fatalf("file audit = %+v, want inputs plus output dest", fileAudit)
+	}
+}
+
+func TestDiffCmdRunEAndErrorBranches(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.json")
+	second := filepath.Join(dir, "second.json")
+	writeShadowReport(t, first, shadow.Report{ReportVersion: 1, ContractHash: "sha256:a"})
+	writeShadowReport(t, second, shadow.Report{ReportVersion: 1, ContractHash: "sha256:b"})
+
+	cmd := diffCmd()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{first, second})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("diff command Execute: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Shadow Diff") {
+		t.Fatalf("diff stdout =\n%s", stdout.String())
+	}
+
+	for _, tc := range []struct {
+		name       string
+		firstPath  string
+		secondPath string
+		outPath    string
+		want       string
+	}{
+		{name: "first", firstPath: "relative.json", secondPath: second, want: "absolute"},
+		{name: "second", firstPath: first, secondPath: "relative.json", want: "absolute"},
+		{name: "out", firstPath: first, secondPath: second, outPath: dir, want: "regular file"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := runDiff(&cobra.Command{}, tc.firstPath, tc.secondPath, tc.outPath)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("runDiff error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 
@@ -116,4 +182,693 @@ func writeShadowReport(t *testing.T, path string, report shadow.Report) {
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatalf("WriteFile report: %v", err)
 	}
+}
+
+func TestRunShadowWritesReportsThenReceipts(t *testing.T) {
+	dir := t.TempDir()
+	sessionsDir := writeShadowCaptureSession(t, filepath.Join(dir, "sessions"))
+	contractPath, _ := writeSignedShadowContract(t, dir)
+	recorderDir := filepath.Join(dir, "receipts")
+	outPath := filepath.Join(dir, "shadow.md")
+	jsonPath := filepath.Join(dir, "shadow.json")
+
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	withTestShadowConfig(t)
+
+	err := runShadow(cmd, shadowFlags{
+		contractPath:  contractPath,
+		allowUnsigned: true,
+		sessionsDir:   sessionsDir,
+		duration:      365 * 24 * time.Hour,
+		outPath:       outPath,
+		outJSONPath:   jsonPath,
+		recorderDir:   recorderDir,
+		deterministic: true,
+	})
+	if err != nil {
+		t.Fatalf("runShadow: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want report written to files", stdout.String())
+	}
+	for _, path := range []string{outPath, jsonPath} {
+		if _, err := os.Stat(filepath.Clean(path)); err != nil {
+			t.Fatalf("Stat(%s): %v", path, err)
+		}
+	}
+	var report shadow.Report
+	rawJSON, err := os.ReadFile(filepath.Clean(jsonPath))
+	if err != nil {
+		t.Fatalf("ReadFile json report: %v", err)
+	}
+	if err := json.Unmarshal(rawJSON, &report); err != nil {
+		t.Fatalf("Unmarshal json report: %v", err)
+	}
+	if report.Changed != 1 || len(report.Batches) != 1 {
+		t.Fatalf("report changed/batches = %d/%d, want one changed batch", report.Changed, len(report.Batches))
+	}
+	entries := readRecorderEntries(t, recorderDir)
+	if countEntries(entries, "evidence_receipt") != 1 {
+		t.Fatalf("receipt entries = %d, want 1", countEntries(entries, "evidence_receipt"))
+	}
+	var audit auditEvent
+	if err := json.Unmarshal(lastJSONLine(stderr.Bytes()), &audit); err != nil {
+		t.Fatalf("Unmarshal audit: %v\nstderr:\n%s", err, stderr.String())
+	}
+	if audit.ReceiptsEmitted != 1 || audit.Output != outPath || audit.Review != jsonPath {
+		t.Fatalf("audit = %+v, want receipt and output fields", audit)
+	}
+}
+
+func TestRunShadowDoesNotEmitReceiptsWhenReportWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	sessionsDir := writeShadowCaptureSession(t, filepath.Join(dir, "sessions"))
+	contractPath, _ := writeSignedShadowContract(t, dir)
+	recorderDir := filepath.Join(dir, "receipts")
+	withTestShadowConfig(t)
+
+	err := runShadow(&cobra.Command{}, shadowFlags{
+		contractPath:  contractPath,
+		allowUnsigned: true,
+		sessionsDir:   sessionsDir,
+		duration:      365 * 24 * time.Hour,
+		outPath:       dir,
+		recorderDir:   recorderDir,
+		deterministic: true,
+	})
+	if err == nil {
+		t.Fatal("runShadow succeeded, want report write error")
+	}
+	if _, statErr := os.Stat(filepath.Clean(recorderDir)); !os.IsNotExist(statErr) {
+		t.Fatalf("recorder dir stat = %v, want no receipt side effect", statErr)
+	}
+}
+
+func TestLoadShadowContractRequiresKeyAndVerifiesSignature(t *testing.T) {
+	dir := t.TempDir()
+	contractPath, publicKey := writeSignedShadowContract(t, dir)
+	if _, _, _, err := loadShadowContract(contractPath, "", false); err == nil ||
+		!strings.Contains(err.Error(), "--contract-key is required") {
+		t.Fatalf("load without key error = %v, want required key", err)
+	}
+	env, clean, verified, err := loadShadowContract(contractPath, publicKey, false)
+	if err != nil {
+		t.Fatalf("load verified contract: %v", err)
+	}
+	if clean != contractPath || !verified || env.Body.Selector.SelectorID == "" {
+		t.Fatalf("load result clean=%q verified=%v env=%+v", clean, verified, env.Body.Selector)
+	}
+	if _, _, _, err := loadShadowContract(contractPath, strings.Repeat("0", ed25519.PublicKeySize*2), false); err == nil ||
+		!strings.Contains(err.Error(), "signature verification failed") {
+		t.Fatalf("load wrong key error = %v, want verification failure", err)
+	}
+}
+
+func TestWriteShadowReportsStdoutAndCheckedWriteDir(t *testing.T) {
+	t.Parallel()
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	report := shadow.Report{
+		ReportVersion: 1,
+		GeneratedAt:   time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC),
+		ContractHash:  "sha256:contract",
+	}
+	if err := writeShadowReports(cmd, report, shadowFlags{}); err != nil {
+		t.Fatalf("write stdout report: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Shadow Report") {
+		t.Fatalf("stdout report =\n%s", stdout.String())
+	}
+
+	relDir := filepath.Join("relative", "recorder")
+	if _, err := checkedWriteDir(relDir); err == nil || !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("checkedWriteDir relative error = %v, want absolute rejection", err)
+	}
+	link := filepath.Join(t.TempDir(), "recorder-link")
+	if err := os.Symlink(t.TempDir(), link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if _, err := checkedWriteDir(link); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("checkedWriteDir symlink error = %v, want symlink rejection", err)
+	}
+}
+
+func TestReadShadowReportRejectsBadInputs(t *testing.T) {
+	t.Parallel()
+	if _, err := readShadowReport("relative.json"); err == nil || !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("read relative error = %v, want absolute rejection", err)
+	}
+	path := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := readShadowReport(path); err == nil || !strings.Contains(err.Error(), "decode report") {
+		t.Fatalf("read bad json error = %v, want decode error", err)
+	}
+	if _, err := readShadowReport(filepath.Join(t.TempDir(), "missing.json")); err == nil {
+		t.Fatal("read missing report succeeded, want error")
+	}
+}
+
+func TestRunShadowErrorBranches(t *testing.T) {
+	dir := t.TempDir()
+	contractPath, _ := writeSignedShadowContract(t, dir)
+	sessionsDir := writeShadowCaptureSession(t, filepath.Join(dir, "sessions"))
+	corruptSessionsDir := filepath.Join(dir, "corrupt-sessions")
+	corruptSession := filepath.Join(corruptSessionsDir, "session-a")
+	if err := os.MkdirAll(corruptSession, 0o750); err != nil {
+		t.Fatalf("MkdirAll corrupt session: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(corruptSession, "evidence-session-a-0.jsonl"), []byte("{\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile corrupt session: %v", err)
+	}
+	withTestShadowConfig(t)
+
+	tests := []struct {
+		name  string
+		flags shadowFlags
+		want  string
+	}{
+		{
+			name: "duration",
+			flags: shadowFlags{
+				contractPath:  contractPath,
+				allowUnsigned: true,
+				sessionsDir:   sessionsDir,
+			},
+			want: "--duration must be positive",
+		},
+		{
+			name: "contract",
+			flags: shadowFlags{
+				contractPath:  filepath.Join(dir, "missing.json"),
+				allowUnsigned: true,
+				sessionsDir:   sessionsDir,
+				duration:      time.Hour,
+			},
+			want: "read candidate",
+		},
+		{
+			name: "sessions",
+			flags: shadowFlags{
+				contractPath:  contractPath,
+				allowUnsigned: true,
+				sessionsDir:   filepath.Join(dir, "missing-sessions"),
+				duration:      time.Hour,
+			},
+			want: "inspect sessions dir",
+		},
+		{
+			name: "escrow",
+			flags: shadowFlags{
+				contractPath:  contractPath,
+				allowUnsigned: true,
+				sessionsDir:   sessionsDir,
+				duration:      time.Hour,
+				escrowKeyHex:  "not-hex",
+			},
+			want: "must be hex",
+		},
+		{
+			name: "replay",
+			flags: shadowFlags{
+				contractPath:  contractPath,
+				allowUnsigned: true,
+				sessionsDir:   corruptSessionsDir,
+				duration:      time.Hour,
+			},
+			want: "replay captures",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := runShadow(&cobra.Command{}, tc.flags)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("runShadow error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+
+	original := loadConfig
+	loadConfig = func(string) (*config.Config, error) {
+		return nil, errors.New("config boom")
+	}
+	err := runShadow(&cobra.Command{}, shadowFlags{
+		contractPath:  contractPath,
+		allowUnsigned: true,
+		sessionsDir:   sessionsDir,
+		duration:      time.Hour,
+	})
+	loadConfig = original
+	if err == nil || !strings.Contains(err.Error(), "config boom") {
+		t.Fatalf("runShadow config error = %v, want config boom", err)
+	}
+}
+
+func TestRunShadowReceiptErrorAfterSuccessfulReportWrite(t *testing.T) {
+	dir := t.TempDir()
+	contractPath, _ := writeSignedShadowContract(t, dir)
+	sessionsDir := writeShadowCaptureSession(t, filepath.Join(dir, "sessions"))
+	outPath := filepath.Join(dir, "shadow.md")
+	withTestShadowConfig(t)
+
+	err := runShadow(&cobra.Command{}, shadowFlags{
+		contractPath:  contractPath,
+		allowUnsigned: true,
+		sessionsDir:   sessionsDir,
+		duration:      365 * 24 * time.Hour,
+		outPath:       outPath,
+		recorderDir:   filepath.Join(dir, "receipts"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "load receipt signing key") {
+		t.Fatalf("runShadow receipt error = %v, want missing signing key", err)
+	}
+	if _, statErr := os.Stat(filepath.Clean(outPath)); statErr != nil {
+		t.Fatalf("report stat = %v, want report written before receipt failure", statErr)
+	}
+}
+
+func TestLoadShadowContractRejectsMalformedInputs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	badJSON := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(badJSON, []byte(`{"body":{"unknown":true},"signature":"ed25519:00"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile bad json: %v", err)
+	}
+	if _, _, _, err := loadShadowContract(badJSON, "", true); err == nil || !strings.Contains(err.Error(), "decode contract") {
+		t.Fatalf("bad json error = %v, want decode contract", err)
+	}
+
+	invalidContract := filepath.Join(dir, "invalid-contract.json")
+	data, err := json.Marshal(contract.ContractEnvelope{
+		Body: contract.Contract{
+			SchemaVersion:    contract.SchemaVersionContract,
+			ContractKind:     contract.ContractKind,
+			DataClassRoot:    string(contract.DataClassInternal),
+			FieldDataClasses: map[string]string{},
+			Rules: []contract.Rule{{
+				RuleKind:       "http_destination",
+				LifecycleState: "enforce",
+			}},
+		},
+		Signature: "ed25519:00",
+	})
+	if err != nil {
+		t.Fatalf("Marshal invalid contract: %v", err)
+	}
+	if err := os.WriteFile(invalidContract, data, 0o600); err != nil {
+		t.Fatalf("WriteFile invalid contract: %v", err)
+	}
+	if _, _, _, err := loadShadowContract(invalidContract, "", true); err == nil || !strings.Contains(err.Error(), "validate contract") {
+		t.Fatalf("invalid contract error = %v, want validate contract", err)
+	}
+
+	contractPath, _ := writeSignedShadowContract(t, dir)
+	if _, _, _, err := loadShadowContract(contractPath, "zz", false); err == nil || !strings.Contains(err.Error(), "load contract verification key") {
+		t.Fatalf("bad public key error = %v, want load key error", err)
+	}
+}
+
+func TestVerifyShadowContractEnvelopeRejectsMalformedSignature(t *testing.T) {
+	t.Parallel()
+	contractPath, publicKey := writeSignedShadowContract(t, t.TempDir())
+	env, _, _, err := loadShadowContract(contractPath, publicKey, false)
+	if err != nil {
+		t.Fatalf("load verified contract: %v", err)
+	}
+	pub, err := hex.DecodeString(publicKey)
+	if err != nil {
+		t.Fatalf("DecodeString public key: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		mut  func(*contract.ContractEnvelope)
+		want string
+	}{
+		{
+			name: "purpose",
+			mut:  func(env *contract.ContractEnvelope) { env.Body.KeyPurpose = "wrong" },
+			want: "key_purpose",
+		},
+		{
+			name: "prefix",
+			mut:  func(env *contract.ContractEnvelope) { env.Signature = "sha256:00" },
+			want: "signature must use",
+		},
+		{
+			name: "hex",
+			mut:  func(env *contract.ContractEnvelope) { env.Signature = "ed25519:zz" },
+			want: "decode signature",
+		},
+		{
+			name: "length",
+			mut:  func(env *contract.ContractEnvelope) { env.Signature = "ed25519:00" },
+			want: "signature length",
+		},
+		{
+			name: "preimage",
+			mut: func(env *contract.ContractEnvelope) {
+				env.Body.Defaults.Confidence = map[string]any{"bad": make(chan int)}
+			},
+			want: "build preimage",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			next := env
+			tc.mut(&next)
+			err := verifyShadowContractEnvelope(next, ed25519.PublicKey(pub))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("verify error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveShadowSessionsAgentConfigBranches(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agent-a")
+	if err := os.Mkdir(agentDir, 0o750); err != nil {
+		t.Fatalf("Mkdir agent dir: %v", err)
+	}
+	cfg := config.Defaults()
+	cfg.Learn.CaptureDir = root
+	got, err := resolveShadowSessions(cfg, shadowFlags{agent: "agent-a"})
+	if err != nil {
+		t.Fatalf("resolve by agent: %v", err)
+	}
+	if got != agentDir {
+		t.Fatalf("agent sessions = %q, want %q", got, agentDir)
+	}
+	if _, err := resolveShadowSessions(cfg, shadowFlags{}); err == nil {
+		t.Fatal("resolve empty agent succeeded, want validation error")
+	}
+	cfg.Learn.CaptureDir = ""
+	if _, err := resolveShadowSessions(cfg, shadowFlags{agent: "agent-a"}); !errors.Is(err, errNoCaptureDir) {
+		t.Fatalf("resolve no capture dir error = %v, want errNoCaptureDir", err)
+	}
+	cfg.Learn.CaptureDir = "relative"
+	if _, err := resolveShadowSessions(cfg, shadowFlags{agent: "agent-a"}); !errors.Is(err, errRelativeCaptureDir) {
+		t.Fatalf("resolve relative capture dir error = %v, want errRelativeCaptureDir", err)
+	}
+}
+
+func TestCheckedReadDirRejectsRelativeMissingAndFile(t *testing.T) {
+	t.Parallel()
+	if _, err := checkedReadDir("relative"); err == nil || !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("checkedReadDir relative error = %v, want absolute", err)
+	}
+	if _, err := checkedReadDir(filepath.Join(t.TempDir(), "missing")); err == nil || !strings.Contains(err.Error(), "inspect sessions dir") {
+		t.Fatalf("checkedReadDir missing error = %v, want inspect failure", err)
+	}
+	file := filepath.Join(t.TempDir(), "sessions-file")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := checkedReadDir(file); err == nil || !strings.Contains(err.Error(), "must be a directory") {
+		t.Fatalf("checkedReadDir file error = %v, want directory rejection", err)
+	}
+}
+
+func TestEmitShadowReceiptsBranches(t *testing.T) {
+	t.Parallel()
+	body := validShadowContractBody()
+	report := shadow.Report{Batches: []shadow.Batch{{
+		ContractHash:     body.ContractHash,
+		RuleID:           "rule-api",
+		OriginalVerdict:  config.ActionAllow,
+		CandidateVerdict: config.ActionBlock,
+		WindowStart:      time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC),
+		WindowEnd:        time.Date(2026, 4, 30, 13, 0, 0, 0, time.UTC),
+		LosslessCount:    1,
+		ExemplarIDs:      []string{"ex-1"},
+	}}}
+	if got, err := emitShadowReceipts(shadowFlags{}, body, report, time.Now()); err != nil || got != 0 {
+		t.Fatalf("emit no recorder = %d/%v, want 0 nil", got, err)
+	}
+	empty := report
+	empty.Batches = nil
+	if got, err := emitShadowReceipts(shadowFlags{recorderDir: t.TempDir()}, body, empty, time.Now()); err != nil || got != 0 {
+		t.Fatalf("emit no batches = %d/%v, want 0 nil", got, err)
+	}
+	if _, err := emitShadowReceipts(shadowFlags{recorderDir: "relative", deterministic: true}, body, report, time.Now()); err == nil ||
+		!strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("emit relative recorder error = %v, want absolute", err)
+	}
+	if _, err := emitShadowReceipts(shadowFlags{recorderDir: t.TempDir()}, body, report, time.Now()); err == nil ||
+		!strings.Contains(err.Error(), "load receipt signing key") {
+		t.Fatalf("emit signer error = %v, want missing key", err)
+	}
+	bad := report
+	bad.Batches = append([]shadow.Batch(nil), report.Batches...)
+	bad.Batches[0].ContractHash = ""
+	if got, err := emitShadowReceipts(shadowFlags{recorderDir: t.TempDir(), deterministic: true}, body, bad, time.Now()); err == nil || got != 0 {
+		t.Fatalf("emit invalid batch = %d/%v, want index 0 error", got, err)
+	}
+}
+
+func TestCheckedWriteDirRejectsFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "recorder-file")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := checkedWriteDir(path); err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("checkedWriteDir file error = %v, want directory rejection", err)
+	}
+}
+
+func TestResolveShadowSignerDefaultAgentMissingKey(t *testing.T) {
+	t.Parallel()
+	signer, err := resolveShadowSigner(shadowFlags{deterministic: true})
+	if err != nil {
+		t.Fatalf("resolve deterministic signer: %v", err)
+	}
+	if signer.KeyID() != "deterministic-receipt-signing" {
+		t.Fatalf("deterministic signer key id = %q", signer.KeyID())
+	}
+	if _, err := resolveShadowSigner(shadowFlags{keystore: t.TempDir()}); err == nil ||
+		!strings.Contains(err.Error(), defaultReceiptKeyAgent) {
+		t.Fatalf("resolve default signer error = %v, want missing default agent", err)
+	}
+	keyDir := t.TempDir()
+	if _, err := signing.NewKeystore(keyDir).GenerateAgent(defaultReceiptKeyAgent); err != nil {
+		t.Fatalf("GenerateAgent: %v", err)
+	}
+	signer, err = resolveShadowSigner(shadowFlags{keystore: keyDir})
+	if err != nil {
+		t.Fatalf("resolve default signer: %v", err)
+	}
+	if signer.KeyID() != defaultReceiptKeyAgent {
+		t.Fatalf("signer key id = %q, want default", signer.KeyID())
+	}
+}
+
+func TestWriteShadowReportsRejectsInvalidJSONPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	report := shadow.Report{
+		ReportVersion: 1,
+		GeneratedAt:   time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC),
+		ContractHash:  "sha256:contract",
+	}
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	err := writeShadowReports(cmd, report, shadowFlags{
+		outJSONPath: dir,
+	})
+	if err == nil || !strings.Contains(err.Error(), "must be a regular file") {
+		t.Fatalf("writeShadowReports JSON dir error = %v, want non-regular rejection", err)
+	}
+}
+
+func TestContractHashFallbacks(t *testing.T) {
+	t.Parallel()
+	body := validShadowContractBody()
+	if got := contractHash(body); got != body.ContractHash {
+		t.Fatalf("contractHash = %q, want existing hash", got)
+	}
+	body.ContractHash = ""
+	if got := contractHash(body); !strings.HasPrefix(got, "sha256:") || got == testUnknownContractHash {
+		t.Fatalf("contractHash derived = %q, want derived sha256", got)
+	}
+	body.Defaults.Confidence = map[string]any{"bad": make(chan int)}
+	if got := contractHash(body); got != testUnknownContractHash {
+		t.Fatalf("contractHash error = %q, want unknown", got)
+	}
+}
+
+func writeShadowCaptureSession(t *testing.T, dir string) string {
+	t.Helper()
+	w, err := capture.NewWriter(capture.WriterConfig{
+		RecorderConfig: recorder.Config{
+			Enabled:            true,
+			Dir:                dir,
+			CheckpointInterval: 1000,
+		},
+		QueueSize:    8,
+		BuildVersion: "test",
+		BuildSHA:     "test",
+	})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	w.ObserveURLVerdict(context.Background(), &capture.URLVerdictRecord{
+		Subsurface:      "url",
+		Transport:       "http",
+		SessionID:       "session-a",
+		RequestID:       "req-1",
+		ConfigHash:      "sha256:old",
+		Agent:           "agent-a",
+		Profile:         "test",
+		Request:         capture.CaptureRequest{Method: "GET", URL: "https://api.example.com/repos/bar"},
+		EffectiveAction: config.ActionAllow,
+		Outcome:         capture.OutcomeClean,
+	})
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+	return dir
+}
+
+func writeSignedShadowContract(t *testing.T, dir string) (string, string) {
+	t.Helper()
+	seed := sha256.Sum256([]byte("learn shadow contract verification test"))
+	priv := ed25519.NewKeyFromSeed(seed[:])
+	body := validShadowContractBody()
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage: %v", err)
+	}
+	env := contract.ContractEnvelope{
+		Body:      body,
+		Signature: "ed25519:" + hex.EncodeToString(ed25519.Sign(priv, preimage)),
+	}
+	data, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("Marshal contract: %v", err)
+	}
+	path := filepath.Join(dir, "contract.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile contract: %v", err)
+	}
+	return path, hex.EncodeToString(priv.Public().(ed25519.PublicKey))
+}
+
+func validShadowContractBody() contract.Contract {
+	return contract.Contract{
+		SchemaVersion:    contract.SchemaVersionContract,
+		ContractKind:     contract.ContractKind,
+		ContractHash:     "sha256:test-contract",
+		SignerKeyID:      "test",
+		KeyPurpose:       signing.PurposeContractCompileSigning.String(),
+		DataClassRoot:    string(contract.DataClassInternal),
+		FieldDataClasses: map[string]string{},
+		Selector:         contract.Selector{Agent: "agent-a", SelectorID: "selector-a"},
+		ObservationWindow: contract.ObservationWindow{
+			Start:                 time.Date(2026, 4, 30, 11, 0, 0, 0, time.UTC),
+			End:                   time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC),
+			EventCount:            1,
+			SessionCount:          1,
+			ObservationWindowRoot: "sha256:window",
+		},
+		Compile: contract.ContractCompile{
+			PipelockVersion:        "test",
+			PipelockBuildSHA:       "test",
+			GoVersion:              "test",
+			ModuleDigestRoot:       "sha256:modules",
+			CompileConfigHash:      "sha256:config",
+			InferenceAlgorithm:     "test",
+			NormalizationAlgorithm: "test",
+		},
+		Defaults: contract.ContractDefaults{
+			Fidelity:   "full",
+			Confidence: map[string]any{},
+			Privacy: contract.ContractDefaultsPrivacy{
+				DefaultDataClass: contract.DataClassInternal,
+				ForbidClasses:    []contract.DataClass{},
+			},
+		},
+		Rules: []contract.Rule{{
+			RuleID:               "rule-api",
+			DisplayName:          "API rule",
+			RuleKind:             "http_destination",
+			LifecycleState:       "enforce",
+			RequiredCaptureGrade: contract.CaptureGradeFull,
+			ObservedCaptureGrade: contract.CaptureGradeFull,
+			Confidence:           "stable",
+			WilsonLower:          "0.99",
+			Observation:          map[string]any{},
+			Selector: map[string]any{
+				"host": map[string]any{"value": "api.example.com"},
+				"paths": []any{
+					map[string]any{"value": "/repos/foo"},
+				},
+			},
+			Rationale:         map[string]any{},
+			RecurringSupport:  map[string]any{},
+			OpportunityHealth: map[string]any{},
+		}},
+	}
+}
+
+func withTestShadowConfig(t *testing.T) {
+	t.Helper()
+	original := loadConfig
+	loadConfig = func(string) (*config.Config, error) {
+		cfg := config.Defaults()
+		cfg.Internal = nil
+		cfg.DLP.ScanEnv = false
+		return cfg, nil
+	}
+	t.Cleanup(func() {
+		loadConfig = original
+	})
+}
+
+func readRecorderEntries(t *testing.T, dir string) []recorder.Entry {
+	t.Helper()
+	var entries []recorder.Entry
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		if !strings.HasSuffix(d.Name(), ".jsonl") {
+			return nil
+		}
+		chunk, err := recorder.ReadEntries(path)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, chunk...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir recorder entries: %v", err)
+	}
+	return entries
+}
+
+func countEntries(entries []recorder.Entry, entryType string) int {
+	count := 0
+	for _, entry := range entries {
+		if entry.Type == entryType {
+			count++
+		}
+	}
+	return count
+}
+
+func lastJSONLine(data []byte) []byte {
+	lines := bytes.Split(bytes.TrimSpace(data), []byte("\n"))
+	if len(lines) == 0 {
+		return nil
+	}
+	return lines[len(lines)-1]
 }

--- a/internal/cli/learn/split.go
+++ b/internal/cli/learn/split.go
@@ -741,9 +741,13 @@ type auditEvent struct {
 	Output            string   `json:"output,omitempty"`
 	Review            string   `json:"review,omitempty"`
 	Manifest          string   `json:"manifest,omitempty"`
+	Sessions          string   `json:"sessions,omitempty"`
+	RecorderDir       string   `json:"recorder_dir,omitempty"`
 	EventsIngested    int      `json:"events_ingested,omitempty"`
 	EventsDropped     int      `json:"events_dropped,omitempty"`
 	RulesEmitted      int      `json:"rules_emitted,omitempty"`
+	Quarantines       int      `json:"quarantines,omitempty"`
+	ReceiptsEmitted   int      `json:"receipts_emitted,omitempty"`
 	CrossAgentSigning bool     `json:"cross_agent_signing,omitempty"`
 	NoOp              bool     `json:"noop"`
 }

--- a/internal/contract/shadow/report.go
+++ b/internal/contract/shadow/report.go
@@ -1,0 +1,462 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package shadow
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/capture"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const (
+	reportVersion = 1
+
+	defaultQuarantineCeilingPct = 5.0
+	defaultQuarantineReleasePct = 1.0
+	defaultQuarantineMinEval    = 50
+	defaultQuarantineCooldown   = time.Hour
+	defaultQuarantinePageLimit  = 5
+	defaultShadowReportTitle    = "Shadow Report"
+	quarantineStateClear        = "clear"
+	quarantineStateCandidate    = "candidate"
+	quarantineStateHeld         = "held"
+	quarantineStateReleased     = "released"
+	quarantineReasonRate        = "new_block_rate_above_ceiling"
+	quarantineReasonCooldown    = "cooldown_active"
+	quarantineReasonPageLimit   = "page_rate_limited"
+	quarantineReasonHeld        = "above_release_floor"
+	quarantineReasonReleased    = "below_release_floor"
+	quarantineReasonThinSample  = "below_denominator_floor"
+)
+
+// ErrInvalidQuarantineConfig rejects unusable quarantine thresholds.
+var ErrInvalidQuarantineConfig = errors.New("shadow: invalid quarantine config")
+
+// QuarantineConfig controls flap-resistant quarantine decisions.
+type QuarantineConfig struct {
+	CeilingPct        float64
+	ReleaseFloorPct   float64
+	MinEvaluations    int
+	Cooldown          time.Duration
+	PageLimitPerHour  int
+	ActiveRules       map[string]bool
+	LastQuarantinedAt map[string]time.Time
+	RecentPageTimes   []time.Time
+}
+
+// DefaultQuarantineConfig returns the standard shadow quarantine thresholds.
+func DefaultQuarantineConfig() QuarantineConfig {
+	return QuarantineConfig{
+		CeilingPct:       defaultQuarantineCeilingPct,
+		ReleaseFloorPct:  defaultQuarantineReleasePct,
+		MinEvaluations:   defaultQuarantineMinEval,
+		Cooldown:         defaultQuarantineCooldown,
+		PageLimitPerHour: defaultQuarantinePageLimit,
+	}
+}
+
+// Validate reports invalid quarantine settings.
+func (cfg QuarantineConfig) Validate() error {
+	if cfg.CeilingPct <= 0 || cfg.CeilingPct > 100 {
+		return fmt.Errorf("%w: ceiling_pct=%v", ErrInvalidQuarantineConfig, cfg.CeilingPct)
+	}
+	if cfg.ReleaseFloorPct < 0 || cfg.ReleaseFloorPct >= cfg.CeilingPct {
+		return fmt.Errorf("%w: release_floor_pct=%v ceiling_pct=%v", ErrInvalidQuarantineConfig, cfg.ReleaseFloorPct, cfg.CeilingPct)
+	}
+	if cfg.MinEvaluations <= 0 {
+		return fmt.Errorf("%w: min_evaluations=%d", ErrInvalidQuarantineConfig, cfg.MinEvaluations)
+	}
+	if cfg.Cooldown <= 0 {
+		return fmt.Errorf("%w: cooldown=%s", ErrInvalidQuarantineConfig, cfg.Cooldown)
+	}
+	if cfg.PageLimitPerHour <= 0 {
+		return fmt.Errorf("%w: page_limit_per_hour=%d", ErrInvalidQuarantineConfig, cfg.PageLimitPerHour)
+	}
+	return nil
+}
+
+// AnalyzeOptions controls conversion of replayed records into shadow output.
+type AnalyzeOptions struct {
+	ContractHash string
+	GeneratedAt  time.Time
+	Aggregation  AggregateConfig
+	Quarantine   QuarantineConfig
+}
+
+// RuleStats summarizes one contract rule in a shadow run.
+type RuleStats struct {
+	RuleID          string  `json:"rule_id"`
+	Evaluations     int     `json:"evaluations"`
+	NewBlocks       int     `json:"new_blocks"`
+	NewAllows       int     `json:"new_allows"`
+	Unchanged       int     `json:"unchanged"`
+	NewBlockRatePct float64 `json:"new_block_rate_pct"`
+	State           string  `json:"state"`
+	Reason          string  `json:"reason,omitempty"`
+}
+
+// QuarantineEvent records one rule quarantine recommendation.
+type QuarantineEvent struct {
+	RuleID          string    `json:"rule_id"`
+	Reason          string    `json:"reason"`
+	Evaluations     int       `json:"evaluations"`
+	NewBlocks       int       `json:"new_blocks"`
+	NewBlockRatePct float64   `json:"new_block_rate_pct"`
+	CooldownUntil   time.Time `json:"cooldown_until"`
+}
+
+// Report is the JSON and markdown surface for a shadow run.
+type Report struct {
+	ReportVersion   int                              `json:"report_version"`
+	GeneratedAt     time.Time                        `json:"generated_at"`
+	ContractHash    string                           `json:"contract_hash"`
+	TotalRecords    int                              `json:"total_records"`
+	Replayed        int                              `json:"replayed"`
+	Changed         int                              `json:"changed"`
+	NewBlocks       int                              `json:"new_blocks"`
+	NewAllows       int                              `json:"new_allows"`
+	EvidenceOnly    int                              `json:"evidence_only"`
+	SummaryOnly     int                              `json:"summary_only"`
+	Rules           []RuleStats                      `json:"rules"`
+	Quarantines     []QuarantineEvent                `json:"quarantines,omitempty"`
+	Batches         []Batch                          `json:"batches,omitempty"`
+	CaptureSurfaces map[string]capture.SurfaceStatus `json:"capture_surfaces,omitempty"`
+}
+
+type mutableRuleStats struct {
+	RuleStats
+}
+
+// Analyze converts replay output into shadow deltas, aggregate batches, and
+// quarantine recommendations.
+func Analyze(records []capture.ReplayedRecord, opts AnalyzeOptions) (Report, error) {
+	if opts.ContractHash == "" {
+		return Report{}, fmt.Errorf("%w: contract_hash", ErrInvalidConfig)
+	}
+	if opts.Aggregation.WindowDuration == 0 && opts.Aggregation.SampleCount == 0 {
+		opts.Aggregation = DefaultAggregateConfig()
+	}
+	if err := opts.Aggregation.Validate(); err != nil {
+		return Report{}, err
+	}
+	if opts.Quarantine.CeilingPct == 0 && opts.Quarantine.ReleaseFloorPct == 0 &&
+		opts.Quarantine.MinEvaluations == 0 && opts.Quarantine.Cooldown == 0 &&
+		opts.Quarantine.PageLimitPerHour == 0 {
+		opts.Quarantine = DefaultQuarantineConfig()
+	}
+	if err := opts.Quarantine.Validate(); err != nil {
+		return Report{}, err
+	}
+	now := opts.GeneratedAt
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	report := Report{
+		ReportVersion:   reportVersion,
+		GeneratedAt:     now.UTC(),
+		ContractHash:    opts.ContractHash,
+		TotalRecords:    len(records),
+		CaptureSurfaces: map[string]capture.SurfaceStatus{},
+	}
+	stats := map[string]*mutableRuleStats{}
+	var deltas []Delta
+	for _, record := range records {
+		report.recordSurface(record)
+		if record.Result.EvidenceOnly {
+			report.EvidenceOnly++
+			continue
+		}
+		if record.Result.SummaryOnly {
+			report.SummaryOnly++
+			continue
+		}
+		report.Replayed++
+		if record.Result.Changed {
+			report.Changed++
+		}
+		if isNewBlock(record.Result.OriginalAction, record.Result.CandidateAction) {
+			report.NewBlocks++
+		} else if record.Result.Changed {
+			report.NewAllows++
+		}
+		ruleIDs := contractRuleIDs(record.Result.CandidateFindings)
+		if len(ruleIDs) == 0 {
+			continue
+		}
+		for _, ruleID := range ruleIDs {
+			s := statsForRule(stats, ruleID)
+			s.Evaluations++
+			switch {
+			case isNewBlock(record.Result.OriginalAction, record.Result.CandidateAction):
+				s.NewBlocks++
+			case record.Result.Changed:
+				s.NewAllows++
+			default:
+				s.Unchanged++
+			}
+			if record.Result.Changed {
+				observedAt := record.Timestamp
+				if observedAt.IsZero() {
+					observedAt = now
+				}
+				deltas = append(deltas, Delta{
+					ContractHash:     opts.ContractHash,
+					RuleID:           ruleID,
+					OriginalVerdict:  record.Result.OriginalAction,
+					CandidateVerdict: record.Result.CandidateAction,
+					ExemplarID:       exemplarID(record),
+					ObservedAt:       observedAt,
+				})
+			}
+		}
+	}
+	if len(report.CaptureSurfaces) == 0 {
+		report.CaptureSurfaces = nil
+	}
+
+	batches, err := Aggregate(deltas, opts.Aggregation)
+	if err != nil {
+		return Report{}, err
+	}
+	report.Batches = batches
+	report.Rules, report.Quarantines = finalizeRuleStats(stats, opts.Quarantine, now)
+	return report, nil
+}
+
+func (r *Report) recordSurface(record capture.ReplayedRecord) {
+	if record.Summary.Surface == "" || record.Result.CaptureGrade == "" {
+		return
+	}
+	current := r.CaptureSurfaces[record.Summary.Surface]
+	if captureGradeRank(record.Result.CaptureGrade) > captureGradeRank(current.Grade) {
+		current.Grade = record.Result.CaptureGrade
+	}
+	current.Sidecar = current.Sidecar || record.Result.SidecarDecrypted
+	r.CaptureSurfaces[record.Summary.Surface] = current
+}
+
+func statsForRule(stats map[string]*mutableRuleStats, ruleID string) *mutableRuleStats {
+	s := stats[ruleID]
+	if s == nil {
+		s = &mutableRuleStats{RuleStats: RuleStats{RuleID: ruleID}}
+		stats[ruleID] = s
+	}
+	return s
+}
+
+func finalizeRuleStats(stats map[string]*mutableRuleStats, cfg QuarantineConfig, now time.Time) ([]RuleStats, []QuarantineEvent) {
+	rules := make([]RuleStats, 0, len(stats))
+	for _, s := range stats {
+		if s.Evaluations > 0 {
+			s.NewBlockRatePct = float64(s.NewBlocks) * 100 / float64(s.Evaluations)
+		}
+		rules = append(rules, s.RuleStats)
+	}
+	sort.SliceStable(rules, func(i, j int) bool { return rules[i].RuleID < rules[j].RuleID })
+
+	events := make([]QuarantineEvent, 0)
+	recent := append([]time.Time(nil), cfg.RecentPageTimes...)
+	for i, rule := range rules {
+		effectiveCfg := cfg
+		effectiveCfg.RecentPageTimes = recent
+		state, reason, event := quarantineDecision(rule, effectiveCfg, now)
+		rules[i].State = state
+		rules[i].Reason = reason
+		if event != nil {
+			events = append(events, *event)
+			recent = append(recent, now)
+		}
+	}
+	return rules, events
+}
+
+func quarantineDecision(s RuleStats, cfg QuarantineConfig, now time.Time) (string, string, *QuarantineEvent) {
+	active := cfg.ActiveRules != nil && cfg.ActiveRules[s.RuleID]
+	if s.Evaluations < cfg.MinEvaluations {
+		if active {
+			return quarantineStateHeld, quarantineReasonThinSample, nil
+		}
+		return quarantineStateClear, quarantineReasonThinSample, nil
+	}
+	if active {
+		if s.NewBlockRatePct > cfg.ReleaseFloorPct {
+			return quarantineStateHeld, quarantineReasonHeld, nil
+		}
+		return quarantineStateReleased, quarantineReasonReleased, nil
+	}
+	if s.NewBlockRatePct <= cfg.CeilingPct {
+		return quarantineStateClear, "", nil
+	}
+	if last, ok := cfg.LastQuarantinedAt[s.RuleID]; ok && now.Sub(last) < cfg.Cooldown {
+		return quarantineStateClear, quarantineReasonCooldown, nil
+	}
+	if recentPages(now, cfg.RecentPageTimes) >= cfg.PageLimitPerHour {
+		return quarantineStateClear, quarantineReasonPageLimit, nil
+	}
+	return quarantineStateCandidate, quarantineReasonRate, &QuarantineEvent{
+		RuleID:          s.RuleID,
+		Reason:          quarantineReasonRate,
+		Evaluations:     s.Evaluations,
+		NewBlocks:       s.NewBlocks,
+		NewBlockRatePct: s.NewBlockRatePct,
+		CooldownUntil:   now.Add(cfg.Cooldown).UTC(),
+	}
+}
+
+func recentPages(now time.Time, pages []time.Time) int {
+	cutoff := now.Add(-time.Hour)
+	count := 0
+	for _, ts := range pages {
+		if !ts.Before(cutoff) && !ts.After(now) {
+			count++
+		}
+	}
+	return count
+}
+
+func contractRuleIDs(findings []capture.Finding) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, finding := range findings {
+		if finding.Kind != capture.KindContract || finding.PolicyRule == "" {
+			continue
+		}
+		for _, ruleID := range strings.Split(finding.PolicyRule, ",") {
+			ruleID = strings.TrimSpace(ruleID)
+			if ruleID == "" {
+				continue
+			}
+			if _, ok := seen[ruleID]; ok {
+				continue
+			}
+			seen[ruleID] = struct{}{}
+			out = append(out, ruleID)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func isNewBlock(original, candidate string) bool {
+	return !isBlockAction(original) && isBlockAction(candidate)
+}
+
+func isBlockAction(action string) bool {
+	return action == config.ActionBlock || action == "fail_closed"
+}
+
+func captureGradeRank(grade string) int {
+	switch grade {
+	case capture.CaptureGradeNone:
+		return 0
+	case capture.CaptureGradeSummary:
+		return 1
+	case capture.CaptureGradePartial:
+		return 2
+	case capture.CaptureGradeFull:
+		return 3
+	default:
+		return -1
+	}
+}
+
+func exemplarID(record capture.ReplayedRecord) string {
+	h := sha256.New()
+	_, _ = io.WriteString(h, record.Summary.Surface)
+	_, _ = io.WriteString(h, "\x00")
+	_, _ = io.WriteString(h, record.Summary.Request.Method)
+	_, _ = io.WriteString(h, "\x00")
+	_, _ = io.WriteString(h, record.Summary.Request.URL)
+	_, _ = io.WriteString(h, "\x00")
+	_, _ = io.WriteString(h, record.Summary.Request.ToolName)
+	_, _ = io.WriteString(h, "\x00")
+	_, _ = io.WriteString(h, record.Summary.Request.MCPMethod)
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// RenderJSON writes a deterministic JSON report.
+func RenderJSON(w io.Writer, report Report) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
+}
+
+// RenderMarkdown writes a deterministic human-readable shadow report.
+func RenderMarkdown(w io.Writer, report Report) error {
+	_, _ = fmt.Fprintf(w, "# %s\n\n", defaultShadowReportTitle)
+	_, _ = fmt.Fprintf(w, "- contract_hash: `%s`\n", report.ContractHash)
+	_, _ = fmt.Fprintf(w, "- generated_at: `%s`\n", report.GeneratedAt.UTC().Format(time.RFC3339Nano))
+	_, _ = fmt.Fprintf(w, "- records: %d total, %d replayed, %d changed\n", report.TotalRecords, report.Replayed, report.Changed)
+	_, _ = fmt.Fprintf(w, "- deltas: %d new blocks, %d new allows, %d batches\n\n", report.NewBlocks, report.NewAllows, len(report.Batches))
+
+	_, _ = fmt.Fprintln(w, "## Quarantine")
+	if len(report.Quarantines) == 0 {
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w, "No quarantine candidates.")
+		_, _ = fmt.Fprintln(w)
+	} else {
+		_, _ = fmt.Fprintln(w)
+		for _, q := range report.Quarantines {
+			_, _ = fmt.Fprintf(w, "- `%s`: %.2f%% new-block rate (%d/%d), cooldown until `%s`\n",
+				q.RuleID, q.NewBlockRatePct, q.NewBlocks, q.Evaluations, q.CooldownUntil.UTC().Format(time.RFC3339Nano))
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+
+	_, _ = fmt.Fprintln(w, "## Rules")
+	if len(report.Rules) == 0 {
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w, "No contract rule evaluations.")
+		_, _ = fmt.Fprintln(w)
+		return nil
+	}
+	_, _ = fmt.Fprintln(w, "\n| rule | evals | new_blocks | new_allows | rate | state | reason |")
+	_, _ = fmt.Fprintln(w, "|---|---:|---:|---:|---:|---|---|")
+	for _, rule := range report.Rules {
+		_, _ = fmt.Fprintf(w, "| `%s` | %d | %d | %d | %.2f%% | %s | %s |\n",
+			rule.RuleID, rule.Evaluations, rule.NewBlocks, rule.NewAllows, rule.NewBlockRatePct, rule.State, rule.Reason)
+	}
+	return nil
+}
+
+// DiffReports returns a deterministic summary comparing two shadow reports.
+func DiffReports(a, b Report) []RuleStats {
+	byRule := map[string]RuleStats{}
+	for _, rule := range a.Rules {
+		byRule[rule.RuleID] = RuleStats{
+			RuleID:          rule.RuleID,
+			Evaluations:     -rule.Evaluations,
+			NewBlocks:       -rule.NewBlocks,
+			NewAllows:       -rule.NewAllows,
+			Unchanged:       -rule.Unchanged,
+			NewBlockRatePct: -rule.NewBlockRatePct,
+		}
+	}
+	for _, rule := range b.Rules {
+		prev := byRule[rule.RuleID]
+		prev.RuleID = rule.RuleID
+		prev.Evaluations += rule.Evaluations
+		prev.NewBlocks += rule.NewBlocks
+		prev.NewAllows += rule.NewAllows
+		prev.Unchanged += rule.Unchanged
+		prev.NewBlockRatePct += rule.NewBlockRatePct
+		byRule[rule.RuleID] = prev
+	}
+	out := make([]RuleStats, 0, len(byRule))
+	for _, rule := range byRule {
+		out = append(out, rule)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].RuleID < out[j].RuleID })
+	return out
+}

--- a/internal/contract/shadow/report.go
+++ b/internal/contract/shadow/report.go
@@ -152,7 +152,12 @@ func Analyze(records []capture.ReplayedRecord, opts AnalyzeOptions) (Report, err
 	if opts.Quarantine.CeilingPct == 0 && opts.Quarantine.ReleaseFloorPct == 0 &&
 		opts.Quarantine.MinEvaluations == 0 && opts.Quarantine.Cooldown == 0 &&
 		opts.Quarantine.PageLimitPerHour == 0 {
-		opts.Quarantine = DefaultQuarantineConfig()
+		defaults := DefaultQuarantineConfig()
+		opts.Quarantine.CeilingPct = defaults.CeilingPct
+		opts.Quarantine.ReleaseFloorPct = defaults.ReleaseFloorPct
+		opts.Quarantine.MinEvaluations = defaults.MinEvaluations
+		opts.Quarantine.Cooldown = defaults.Cooldown
+		opts.Quarantine.PageLimitPerHour = defaults.PageLimitPerHour
 	}
 	if err := opts.Quarantine.Validate(); err != nil {
 		return Report{}, err

--- a/internal/contract/shadow/report_test.go
+++ b/internal/contract/shadow/report_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
+const (
+	testRuleIDA = "rule-a"
+	testRuleIDB = "rule-b"
+)
+
 func TestAnalyze_BuildsBatchesAndQuarantineCandidate(t *testing.T) {
 	t.Parallel()
 	base := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
@@ -37,7 +42,7 @@ func TestAnalyze_BuildsBatchesAndQuarantineCandidate(t *testing.T) {
 	if report.Batches[0].LosslessCount != 4 || len(report.Batches[0].ExemplarIDs) != 3 {
 		t.Fatalf("batch = %+v, want four lossless and three exemplars", report.Batches[0])
 	}
-	if len(report.Quarantines) != 1 || report.Quarantines[0].RuleID != "rule-a" {
+	if len(report.Quarantines) != 1 || report.Quarantines[0].RuleID != testRuleIDA {
 		t.Fatalf("quarantines = %+v, want rule-a", report.Quarantines)
 	}
 	if got := report.Rules[0].State; got != quarantineStateCandidate {
@@ -51,7 +56,7 @@ func TestAnalyze_QuarantineCooldownAndHysteresis(t *testing.T) {
 	now := base.Add(2 * time.Hour)
 
 	cooldownCfg := DefaultQuarantineConfig()
-	cooldownCfg.LastQuarantinedAt = map[string]time.Time{"rule-a": now.Add(-30 * time.Minute)}
+	cooldownCfg.LastQuarantinedAt = map[string]time.Time{testRuleIDA: now.Add(-30 * time.Minute)}
 	report, err := Analyze(shadowRecords(base, 4), AnalyzeOptions{
 		ContractHash: "sha256:contract",
 		GeneratedAt:  now,
@@ -66,7 +71,7 @@ func TestAnalyze_QuarantineCooldownAndHysteresis(t *testing.T) {
 	}
 
 	heldCfg := DefaultQuarantineConfig()
-	heldCfg.ActiveRules = map[string]bool{"rule-a": true}
+	heldCfg.ActiveRules = map[string]bool{testRuleIDA: true}
 	held, err := Analyze(shadowRecords(base, 2), AnalyzeOptions{
 		ContractHash: "sha256:contract",
 		GeneratedAt:  now,
@@ -94,6 +99,27 @@ func TestAnalyze_QuarantineCooldownAndHysteresis(t *testing.T) {
 	}
 }
 
+func TestAnalyze_DefaultQuarantineThresholdsPreserveState(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	cfg := QuarantineConfig{
+		LastQuarantinedAt: map[string]time.Time{testRuleIDA: base.Add(-30 * time.Minute)},
+		RecentPageTimes:   []time.Time{base.Add(-time.Minute)},
+	}
+	report, err := Analyze(shadowRecords(base, 4), AnalyzeOptions{
+		ContractHash: "sha256:contract",
+		GeneratedAt:  base,
+		Aggregation:  AggregateConfig{WindowDuration: time.Hour, SampleCount: 1},
+		Quarantine:   cfg,
+	})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if report.Rules[0].Reason != quarantineReasonCooldown {
+		t.Fatalf("rule reason = %q, want preserved cooldown state", report.Rules[0].Reason)
+	}
+}
+
 func TestRenderJSONMarkdownAndDiffReports(t *testing.T) {
 	t.Parallel()
 	report := Report{
@@ -103,7 +129,7 @@ func TestRenderJSONMarkdownAndDiffReports(t *testing.T) {
 		TotalRecords:  10,
 		NewBlocks:     1,
 		Rules: []RuleStats{{
-			RuleID:          "rule-a",
+			RuleID:          testRuleIDA,
 			Evaluations:     10,
 			NewBlocks:       1,
 			NewBlockRatePct: 10,
@@ -159,6 +185,13 @@ func TestAnalyze_DefaultsSkipsAndValidation(t *testing.T) {
 	}
 	if _, err := Analyze(nil, AnalyzeOptions{
 		ContractHash: "sha256:contract",
+		Aggregation:  AggregateConfig{WindowDuration: -time.Minute, SampleCount: 1},
+		Quarantine:   DefaultQuarantineConfig(),
+	}); !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("Analyze invalid aggregation error = %v, want ErrInvalidConfig", err)
+	}
+	if _, err := Analyze(nil, AnalyzeOptions{
+		ContractHash: "sha256:contract",
 		Aggregation:  AggregateConfig{WindowDuration: time.Minute, SampleCount: 1},
 		Quarantine: QuarantineConfig{
 			CeilingPct:       -1,
@@ -197,8 +230,8 @@ func TestAnalyze_DefaultsSkipsAndValidation(t *testing.T) {
 				Changed:         true,
 				CaptureGrade:    capture.CaptureGradeFull,
 				CandidateFindings: []capture.Finding{
-					{Kind: capture.KindContract, PolicyRule: "rule-b"},
-					{Kind: capture.KindContract, PolicyRule: "rule-b"},
+					{Kind: capture.KindContract, PolicyRule: testRuleIDB},
+					{Kind: capture.KindContract, PolicyRule: testRuleIDB},
 					{Kind: capture.KindDLP, PolicyRule: "ignored"},
 				},
 			},
@@ -211,11 +244,35 @@ func TestAnalyze_DefaultsSkipsAndValidation(t *testing.T) {
 	if report.EvidenceOnly != 1 || report.SummaryOnly != 1 || report.Replayed != 2 || report.NewAllows != 1 {
 		t.Fatalf("report skip counts = %+v", report)
 	}
-	if len(report.Rules) != 1 || report.Rules[0].RuleID != "rule-b" || report.Rules[0].NewAllows != 1 {
+	if len(report.Rules) != 1 || report.Rules[0].RuleID != testRuleIDB || report.Rules[0].NewAllows != 1 {
 		t.Fatalf("rule stats = %+v", report.Rules)
 	}
 	if got := report.CaptureSurfaces[capture.SurfaceDLP].Grade; got != capture.CaptureGradePartial {
 		t.Fatalf("surface grade = %q, want partial", got)
+	}
+
+	empty, err := Analyze(nil, AnalyzeOptions{ContractHash: "sha256:contract"})
+	if err != nil {
+		t.Fatalf("Analyze empty defaults: %v", err)
+	}
+	if empty.CaptureSurfaces != nil || empty.GeneratedAt.IsZero() {
+		t.Fatalf("empty report surfaces/time = %#v/%s, want nil surfaces and generated time", empty.CaptureSurfaces, empty.GeneratedAt)
+	}
+	if _, err := Analyze([]capture.ReplayedRecord{{
+		Result: capture.ReplayResult{
+			Changed: true,
+			CandidateFindings: []capture.Finding{{
+				Kind:       capture.KindContract,
+				PolicyRule: testRuleIDB,
+			}},
+		},
+	}}, AnalyzeOptions{
+		ContractHash: "sha256:contract",
+		GeneratedAt:  base,
+		Aggregation:  AggregateConfig{WindowDuration: time.Minute, SampleCount: 1},
+		Quarantine:   DefaultQuarantineConfig(),
+	}); !errors.Is(err, ErrInvalidDelta) {
+		t.Fatalf("Analyze invalid delta error = %v, want ErrInvalidDelta", err)
 	}
 }
 
@@ -224,10 +281,12 @@ func TestQuarantineDecisionPageLimitThinSampleAndClear(t *testing.T) {
 	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
 	cfg := DefaultQuarantineConfig()
 	cfg.MinEvaluations = 10
+	cfg.ActiveRules = map[string]bool{"thin": true}
 	state, reason, event := quarantineDecision(RuleStats{RuleID: "thin", Evaluations: 9}, cfg, now)
-	if state != quarantineStateClear || reason != quarantineReasonThinSample || event != nil {
+	if state != quarantineStateHeld || reason != quarantineReasonThinSample || event != nil {
 		t.Fatalf("thin decision = %s/%s/%+v", state, reason, event)
 	}
+	cfg.ActiveRules = nil
 	state, reason, event = quarantineDecision(RuleStats{RuleID: "clear", Evaluations: 10, NewBlocks: 0}, cfg, now)
 	if state != quarantineStateClear || reason != "" || event != nil {
 		t.Fatalf("clear decision = %s/%s/%+v", state, reason, event)
@@ -246,6 +305,13 @@ func TestQuarantineDecisionPageLimitThinSampleAndClear(t *testing.T) {
 	if recentPages(now, []time.Time{now.Add(-2 * time.Hour), now.Add(-30 * time.Minute), now.Add(time.Minute)}) != 1 {
 		t.Fatal("recentPages did not count only timestamps in the last hour and not in the future")
 	}
+	ids := contractRuleIDs([]capture.Finding{{
+		Kind:       capture.KindContract,
+		PolicyRule: " rule-a, ,rule-b,rule-a ",
+	}})
+	if len(ids) != 2 || ids[0] != testRuleIDA || ids[1] != testRuleIDB {
+		t.Fatalf("contractRuleIDs = %#v, want trimmed unique ids", ids)
+	}
 }
 
 func TestRenderMarkdownNoRulesAndRankFallbacks(t *testing.T) {
@@ -256,6 +322,22 @@ func TestRenderMarkdownNoRulesAndRankFallbacks(t *testing.T) {
 	}
 	if !bytes.Contains(md.Bytes(), []byte("No contract rule evaluations.")) {
 		t.Fatalf("markdown =\n%s", md.String())
+	}
+	md.Reset()
+	if err := RenderMarkdown(&md, Report{
+		GeneratedAt: time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC),
+		Quarantines: []QuarantineEvent{{
+			RuleID:          testRuleIDA,
+			Evaluations:     60,
+			NewBlocks:       4,
+			NewBlockRatePct: 6.67,
+			CooldownUntil:   time.Date(2026, 4, 30, 13, 0, 0, 0, time.UTC),
+		}},
+	}); err != nil {
+		t.Fatalf("RenderMarkdown quarantine: %v", err)
+	}
+	if !bytes.Contains(md.Bytes(), []byte("cooldown until")) {
+		t.Fatalf("markdown missing quarantine entry:\n%s", md.String())
 	}
 	for _, grade := range []string{
 		capture.CaptureGradeNone,
@@ -294,7 +376,7 @@ func shadowRecords(base time.Time, newBlocks int) []capture.ReplayedRecord {
 				CandidateFindings: []capture.Finding{{
 					Kind:       capture.KindContract,
 					Action:     candidate,
-					PolicyRule: "rule-a",
+					PolicyRule: testRuleIDA,
 				}},
 			},
 		})

--- a/internal/contract/shadow/report_test.go
+++ b/internal/contract/shadow/report_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package shadow
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/capture"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestAnalyze_BuildsBatchesAndQuarantineCandidate(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	records := shadowRecords(base, 4)
+
+	report, err := Analyze(records, AnalyzeOptions{
+		ContractHash: "sha256:contract",
+		GeneratedAt:  base.Add(time.Hour),
+		Aggregation:  AggregateConfig{WindowDuration: time.Hour, SampleCount: 3},
+		Quarantine:   DefaultQuarantineConfig(),
+	})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if report.TotalRecords != 60 || report.Replayed != 60 || report.Changed != 4 || report.NewBlocks != 4 {
+		t.Fatalf("report counts = %+v", report)
+	}
+	if len(report.Batches) != 1 {
+		t.Fatalf("batches = %d, want 1", len(report.Batches))
+	}
+	if report.Batches[0].LosslessCount != 4 || len(report.Batches[0].ExemplarIDs) != 3 {
+		t.Fatalf("batch = %+v, want four lossless and three exemplars", report.Batches[0])
+	}
+	if len(report.Quarantines) != 1 || report.Quarantines[0].RuleID != "rule-a" {
+		t.Fatalf("quarantines = %+v, want rule-a", report.Quarantines)
+	}
+	if got := report.Rules[0].State; got != quarantineStateCandidate {
+		t.Fatalf("rule state = %q, want %q", got, quarantineStateCandidate)
+	}
+}
+
+func TestAnalyze_QuarantineCooldownAndHysteresis(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	now := base.Add(2 * time.Hour)
+
+	cooldownCfg := DefaultQuarantineConfig()
+	cooldownCfg.LastQuarantinedAt = map[string]time.Time{"rule-a": now.Add(-30 * time.Minute)}
+	report, err := Analyze(shadowRecords(base, 4), AnalyzeOptions{
+		ContractHash: "sha256:contract",
+		GeneratedAt:  now,
+		Aggregation:  AggregateConfig{WindowDuration: time.Hour, SampleCount: 1},
+		Quarantine:   cooldownCfg,
+	})
+	if err != nil {
+		t.Fatalf("Analyze cooldown: %v", err)
+	}
+	if len(report.Quarantines) != 0 || report.Rules[0].Reason != quarantineReasonCooldown {
+		t.Fatalf("cooldown report = %+v", report)
+	}
+
+	heldCfg := DefaultQuarantineConfig()
+	heldCfg.ActiveRules = map[string]bool{"rule-a": true}
+	held, err := Analyze(shadowRecords(base, 2), AnalyzeOptions{
+		ContractHash: "sha256:contract",
+		GeneratedAt:  now,
+		Aggregation:  AggregateConfig{WindowDuration: time.Hour, SampleCount: 1},
+		Quarantine:   heldCfg,
+	})
+	if err != nil {
+		t.Fatalf("Analyze held: %v", err)
+	}
+	if held.Rules[0].State != quarantineStateHeld || held.Rules[0].Reason != quarantineReasonHeld {
+		t.Fatalf("held rule = %+v", held.Rules[0])
+	}
+
+	released, err := Analyze(shadowRecords(base, 0), AnalyzeOptions{
+		ContractHash: "sha256:contract",
+		GeneratedAt:  now,
+		Aggregation:  AggregateConfig{WindowDuration: time.Hour, SampleCount: 1},
+		Quarantine:   heldCfg,
+	})
+	if err != nil {
+		t.Fatalf("Analyze released: %v", err)
+	}
+	if released.Rules[0].State != quarantineStateReleased || released.Rules[0].Reason != quarantineReasonReleased {
+		t.Fatalf("released rule = %+v", released.Rules[0])
+	}
+}
+
+func TestRenderJSONMarkdownAndDiffReports(t *testing.T) {
+	t.Parallel()
+	report := Report{
+		ReportVersion: reportVersion,
+		GeneratedAt:   time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC),
+		ContractHash:  "sha256:contract",
+		TotalRecords:  10,
+		NewBlocks:     1,
+		Rules: []RuleStats{{
+			RuleID:          "rule-a",
+			Evaluations:     10,
+			NewBlocks:       1,
+			NewBlockRatePct: 10,
+			State:           quarantineStateCandidate,
+		}},
+	}
+	var jsonBuf bytes.Buffer
+	if err := RenderJSON(&jsonBuf, report); err != nil {
+		t.Fatalf("RenderJSON: %v", err)
+	}
+	var decoded Report
+	if err := json.Unmarshal(jsonBuf.Bytes(), &decoded); err != nil {
+		t.Fatalf("Unmarshal rendered JSON: %v", err)
+	}
+	var md bytes.Buffer
+	if err := RenderMarkdown(&md, report); err != nil {
+		t.Fatalf("RenderMarkdown: %v", err)
+	}
+	if !bytes.Contains(md.Bytes(), []byte("Shadow Report")) {
+		t.Fatalf("markdown missing title:\n%s", md.String())
+	}
+
+	next := report
+	next.Rules = append([]RuleStats(nil), report.Rules...)
+	next.TotalRecords = 12
+	next.Rules[0].NewBlocks = 3
+	diff := DiffReports(report, next)
+	if len(diff) != 1 || diff[0].NewBlocks != 2 {
+		t.Fatalf("DiffReports = %+v, want +2 new blocks", diff)
+	}
+}
+
+func TestQuarantineConfigValidateRejectsInvalidValues(t *testing.T) {
+	t.Parallel()
+	for _, cfg := range []QuarantineConfig{
+		{CeilingPct: 0, ReleaseFloorPct: 0, MinEvaluations: 50, Cooldown: time.Hour, PageLimitPerHour: 5},
+		{CeilingPct: 5, ReleaseFloorPct: 5, MinEvaluations: 50, Cooldown: time.Hour, PageLimitPerHour: 5},
+		{CeilingPct: 5, ReleaseFloorPct: 1, MinEvaluations: 0, Cooldown: time.Hour, PageLimitPerHour: 5},
+		{CeilingPct: 5, ReleaseFloorPct: 1, MinEvaluations: 50, Cooldown: 0, PageLimitPerHour: 5},
+		{CeilingPct: 5, ReleaseFloorPct: 1, MinEvaluations: 50, Cooldown: time.Hour, PageLimitPerHour: 0},
+	} {
+		if err := cfg.Validate(); !errors.Is(err, ErrInvalidQuarantineConfig) {
+			t.Fatalf("Validate(%+v) error = %v, want ErrInvalidQuarantineConfig", cfg, err)
+		}
+	}
+}
+
+func TestAnalyze_DefaultsSkipsAndValidation(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	if _, err := Analyze(nil, AnalyzeOptions{}); !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("Analyze empty hash error = %v, want ErrInvalidConfig", err)
+	}
+	if _, err := Analyze(nil, AnalyzeOptions{
+		ContractHash: "sha256:contract",
+		Aggregation:  AggregateConfig{WindowDuration: time.Minute, SampleCount: 1},
+		Quarantine: QuarantineConfig{
+			CeilingPct:       -1,
+			ReleaseFloorPct:  0,
+			MinEvaluations:   1,
+			Cooldown:         time.Hour,
+			PageLimitPerHour: 1,
+		},
+	}); !errors.Is(err, ErrInvalidQuarantineConfig) {
+		t.Fatalf("Analyze invalid quarantine error = %v, want ErrInvalidQuarantineConfig", err)
+	}
+
+	records := []capture.ReplayedRecord{
+		{
+			Summary: capture.CaptureSummary{Surface: capture.SurfaceCEE},
+			Result:  capture.ReplayResult{EvidenceOnly: true, CaptureGrade: capture.CaptureGradeNone},
+		},
+		{
+			Summary: capture.CaptureSummary{Surface: capture.SurfaceResponse},
+			Result:  capture.ReplayResult{SummaryOnly: true, CaptureGrade: capture.CaptureGradeSummary},
+		},
+		{
+			Summary: capture.CaptureSummary{Surface: capture.SurfaceDLP},
+			Result: capture.ReplayResult{
+				OriginalAction:  config.ActionAllow,
+				CandidateAction: config.ActionAllow,
+				CaptureGrade:    capture.CaptureGradePartial,
+			},
+		},
+		{
+			Timestamp: base,
+			Summary:   capture.CaptureSummary{Surface: capture.SurfaceURL, Request: capture.CaptureRequest{URL: "https://api.example.com"}},
+			Result: capture.ReplayResult{
+				OriginalAction:  config.ActionBlock,
+				CandidateAction: config.ActionAllow,
+				Changed:         true,
+				CaptureGrade:    capture.CaptureGradeFull,
+				CandidateFindings: []capture.Finding{
+					{Kind: capture.KindContract, PolicyRule: "rule-b"},
+					{Kind: capture.KindContract, PolicyRule: "rule-b"},
+					{Kind: capture.KindDLP, PolicyRule: "ignored"},
+				},
+			},
+		},
+	}
+	report, err := Analyze(records, AnalyzeOptions{ContractHash: "sha256:contract", GeneratedAt: base})
+	if err != nil {
+		t.Fatalf("Analyze defaults: %v", err)
+	}
+	if report.EvidenceOnly != 1 || report.SummaryOnly != 1 || report.Replayed != 2 || report.NewAllows != 1 {
+		t.Fatalf("report skip counts = %+v", report)
+	}
+	if len(report.Rules) != 1 || report.Rules[0].RuleID != "rule-b" || report.Rules[0].NewAllows != 1 {
+		t.Fatalf("rule stats = %+v", report.Rules)
+	}
+	if got := report.CaptureSurfaces[capture.SurfaceDLP].Grade; got != capture.CaptureGradePartial {
+		t.Fatalf("surface grade = %q, want partial", got)
+	}
+}
+
+func TestQuarantineDecisionPageLimitThinSampleAndClear(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	cfg := DefaultQuarantineConfig()
+	cfg.MinEvaluations = 10
+	state, reason, event := quarantineDecision(RuleStats{RuleID: "thin", Evaluations: 9}, cfg, now)
+	if state != quarantineStateClear || reason != quarantineReasonThinSample || event != nil {
+		t.Fatalf("thin decision = %s/%s/%+v", state, reason, event)
+	}
+	state, reason, event = quarantineDecision(RuleStats{RuleID: "clear", Evaluations: 10, NewBlocks: 0}, cfg, now)
+	if state != quarantineStateClear || reason != "" || event != nil {
+		t.Fatalf("clear decision = %s/%s/%+v", state, reason, event)
+	}
+	cfg.RecentPageTimes = []time.Time{now.Add(-time.Minute)}
+	cfg.PageLimitPerHour = 1
+	state, reason, event = quarantineDecision(RuleStats{
+		RuleID:          "limited",
+		Evaluations:     10,
+		NewBlocks:       2,
+		NewBlockRatePct: 20,
+	}, cfg, now)
+	if state != quarantineStateClear || reason != quarantineReasonPageLimit || event != nil {
+		t.Fatalf("page limited decision = %s/%s/%+v", state, reason, event)
+	}
+	if recentPages(now, []time.Time{now.Add(-2 * time.Hour), now.Add(-30 * time.Minute), now.Add(time.Minute)}) != 1 {
+		t.Fatal("recentPages did not count only timestamps in the last hour and not in the future")
+	}
+}
+
+func TestRenderMarkdownNoRulesAndRankFallbacks(t *testing.T) {
+	t.Parallel()
+	var md bytes.Buffer
+	if err := RenderMarkdown(&md, Report{GeneratedAt: time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)}); err != nil {
+		t.Fatalf("RenderMarkdown: %v", err)
+	}
+	if !bytes.Contains(md.Bytes(), []byte("No contract rule evaluations.")) {
+		t.Fatalf("markdown =\n%s", md.String())
+	}
+	for _, grade := range []string{
+		capture.CaptureGradeNone,
+		capture.CaptureGradeSummary,
+		capture.CaptureGradePartial,
+		capture.CaptureGradeFull,
+		"bogus",
+	} {
+		_ = captureGradeRank(grade)
+	}
+}
+
+func shadowRecords(base time.Time, newBlocks int) []capture.ReplayedRecord {
+	const total = 60
+	records := make([]capture.ReplayedRecord, 0, total)
+	for i := 0; i < total; i++ {
+		changed := i < newBlocks
+		candidate := config.ActionAllow
+		if changed {
+			candidate = config.ActionBlock
+		}
+		records = append(records, capture.ReplayedRecord{
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+			Summary: capture.CaptureSummary{
+				Surface: capture.SurfaceURL,
+				Request: capture.CaptureRequest{
+					Method: "GET",
+					URL:    "https://api.example.com/repos/foo",
+				},
+			},
+			Result: capture.ReplayResult{
+				OriginalAction:  config.ActionAllow,
+				CandidateAction: candidate,
+				Changed:         changed,
+				CaptureGrade:    capture.CaptureGradeFull,
+				CandidateFindings: []capture.Finding{{
+					Kind:       capture.KindContract,
+					Action:     candidate,
+					PolicyRule: "rule-a",
+				}},
+			},
+		})
+	}
+	return records
+}


### PR DESCRIPTION
## Summary

- add `pipelock learn shadow` for contract-aware replay reports over captured sessions
- optionally persist signed `shadow_delta` receipt batches into a recorder chain
- add `pipelock learn diff` for comparing shadow JSON reports
- attribute replay findings to contract rule IDs for per-rule shadow analysis
- add quarantine analysis with denominator floor, hysteresis, cooldown, and page-rate limiting

## Validation

- full race test suite passed
- lint clean
- coverage gate green
- `pipelock git scan-diff` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `learn shadow` command to analyze policy contracts against recorded sessions with optional cryptographic verification and configurable time-based filtering
  * Added `learn diff` command to compare two compliance reports with formatted markdown output

* **Improvements**
  * Enhanced contract enforcement findings with specific policy rule identification for better traceability
  * Improved audit tracking with timestamp records for all captured entries

* **Tests**
  * Added comprehensive test coverage for shadow analysis and compliance reporting functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->