### PR TITLE
feat(contract): add active manifest store

### DIFF
--- a/internal/contract/store/lock_unix.go
+++ b/internal/contract/store/lock_unix.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func (s Store) withLock(fn func() error) error {
+	if err := os.MkdirAll(s.root, 0o700); err != nil {
+		return fmt.Errorf("create contract store root: %w", err)
+	}
+	f, err := os.OpenFile(filepath.Join(s.root, ".lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("open contract store lock: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	fd := int(f.Fd()) //nolint:gosec // file descriptors fit in int on supported Unix targets.
+	if err := syscall.Flock(fd, syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("acquire contract store lock: %w", err)
+	}
+	defer func() { _ = syscall.Flock(fd, syscall.LOCK_UN) }()
+	return fn()
+}

--- a/internal/contract/store/lock_unix.go
+++ b/internal/contract/store/lock_unix.go
@@ -13,10 +13,10 @@ import (
 )
 
 func (s Store) withLock(fn func() error) error {
-	if err := os.MkdirAll(s.root, 0o700); err != nil {
+	if err := os.MkdirAll(s.root, dirPerm); err != nil {
 		return fmt.Errorf("create contract store root: %w", err)
 	}
-	f, err := os.OpenFile(filepath.Join(s.root, ".lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	f, err := os.OpenFile(filepath.Join(s.root, ".lock"), os.O_CREATE|os.O_RDWR, filePerm)
 	if err != nil {
 		return fmt.Errorf("open contract store lock: %w", err)
 	}

--- a/internal/contract/store/lock_windows.go
+++ b/internal/contract/store/lock_windows.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func (s Store) withLock(fn func() error) error {
+	if err := os.MkdirAll(s.root, 0o700); err != nil {
+		return fmt.Errorf("create contract store root: %w", err)
+	}
+	lockPath := filepath.Join(s.root, ".lock")
+	pathp, err := syscall.UTF16PtrFromString(lockPath)
+	if err != nil {
+		return fmt.Errorf("encode contract store lock path: %w", err)
+	}
+	handle, err := syscall.CreateFile(
+		pathp,
+		syscall.GENERIC_READ|syscall.GENERIC_WRITE,
+		0,
+		nil,
+		syscall.OPEN_ALWAYS,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("open contract store lock: %w", err)
+	}
+	f := os.NewFile(uintptr(handle), lockPath)
+	if f == nil {
+		_ = syscall.CloseHandle(handle)
+		return fmt.Errorf("create contract store lock handle: %s", lockPath)
+	}
+	defer func() { _ = f.Close() }()
+	return fn()
+}

--- a/internal/contract/store/lock_windows.go
+++ b/internal/contract/store/lock_windows.go
@@ -10,10 +10,19 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+	"unsafe"
+)
+
+const lockfileExclusiveLock = 0x00000002
+
+var (
+	kernel32Proc     = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = kernel32Proc.NewProc("LockFileEx")
+	procUnlockFileEx = kernel32Proc.NewProc("UnlockFileEx")
 )
 
 func (s Store) withLock(fn func() error) error {
-	if err := os.MkdirAll(s.root, 0o700); err != nil {
+	if err := os.MkdirAll(s.root, dirPerm); err != nil {
 		return fmt.Errorf("create contract store root: %w", err)
 	}
 	lockPath := filepath.Join(s.root, ".lock")
@@ -24,7 +33,7 @@ func (s Store) withLock(fn func() error) error {
 	handle, err := syscall.CreateFile(
 		pathp,
 		syscall.GENERIC_READ|syscall.GENERIC_WRITE,
-		0,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE,
 		nil,
 		syscall.OPEN_ALWAYS,
 		syscall.FILE_ATTRIBUTE_NORMAL,
@@ -39,5 +48,39 @@ func (s Store) withLock(fn func() error) error {
 		return fmt.Errorf("create contract store lock handle: %s", lockPath)
 	}
 	defer func() { _ = f.Close() }()
+	var overlapped syscall.Overlapped
+	if err := lockFileEx(handle, lockfileExclusiveLock, 0xffffffff, 0xffffffff, &overlapped); err != nil {
+		return fmt.Errorf("acquire contract store lock: %w", err)
+	}
+	defer func() { _ = unlockFileEx(handle, 0xffffffff, 0xffffffff, &overlapped) }()
 	return fn()
+}
+
+func lockFileEx(handle syscall.Handle, flags, lowBytes, highBytes uint32, overlapped *syscall.Overlapped) error {
+	r1, _, err := procLockFileEx.Call(
+		uintptr(handle),
+		uintptr(flags),
+		0,
+		uintptr(lowBytes),
+		uintptr(highBytes),
+		uintptr(unsafe.Pointer(overlapped)),
+	)
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}
+
+func unlockFileEx(handle syscall.Handle, lowBytes, highBytes uint32, overlapped *syscall.Overlapped) error {
+	r1, _, err := procUnlockFileEx.Call(
+		uintptr(handle),
+		0,
+		uintptr(lowBytes),
+		uintptr(highBytes),
+		uintptr(unsafe.Pointer(overlapped)),
+	)
+	if r1 == 0 {
+		return err
+	}
+	return nil
 }

--- a/internal/contract/store/store.go
+++ b/internal/contract/store/store.go
@@ -1,0 +1,520 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package store loads and persists signed active contract manifests.
+package store
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+var (
+	readFile = os.ReadFile
+	readDir  = os.ReadDir
+	mkdirAll = os.MkdirAll
+	openFile = func(name string, flag int, perm os.FileMode) (writableFile, error) {
+		return os.OpenFile(name, flag, perm) //nolint:gosec // Store callers provide paths rooted in the configured contracts directory.
+	}
+	atomicWrite = atomicfile.Write
+	marshalJSON = json.Marshal
+)
+
+type writableFile interface {
+	Write([]byte) (int, error)
+	Close() error
+}
+
+const (
+	defaultMinSignatures = 1
+
+	activeFilename  = "active.json"
+	historyDirname  = "history"
+	manifestDirname = "manifests"
+	journalFilename = ".activation_journal.jsonl"
+
+	hashPrefix      = "sha256:"
+	hashFilePrefix  = "sha256-"
+	jsonExt         = ".json"
+	yamlExt         = ".yaml"
+	signaturePrefix = "ed25519:"
+)
+
+var (
+	ErrDecode              = errors.New("contract store: decode failed")
+	ErrStructural          = errors.New("contract store: structural validation failed")
+	ErrSignature           = errors.New("contract store: manifest signature invalid")
+	ErrDualControl         = errors.New("contract store: dual control requirement not met")
+	ErrEnvironmentMismatch = errors.New("contract store: manifest environment mismatch")
+	ErrGeneration          = errors.New("contract store: manifest generation is not monotonic")
+	ErrPriorManifest       = errors.New("contract store: prior manifest hash mismatch")
+	ErrContractHistory     = errors.New("contract store: contract history invalid")
+	ErrWriteOnceConflict   = errors.New("contract store: write-once object already exists with different bytes")
+	ErrNoActiveManifest    = errors.New("contract store: active manifest does not exist")
+)
+
+// Store is rooted at the contracts directory.
+type Store struct {
+	root string
+}
+
+// New returns a Store rooted at dir.
+func New(dir string) Store {
+	return Store{root: filepath.Clean(dir)}
+}
+
+// Options controls manifest reload validation.
+type Options struct {
+	Environment        contract.Environment
+	Roster             *signing.LoadedRoster
+	PreviousHash       string
+	PreviousGeneration uint64
+	MinSignatures      int
+	ReadOnly           bool
+	Now                func() time.Time
+}
+
+// State is the accepted manifest and resolved contract set.
+type State struct {
+	Envelope       contract.ActiveManifestEnvelope
+	ManifestHash   string
+	Contracts      map[string]contract.ContractEnvelope
+	AcceptedPath   string
+	JournalOutcome string
+}
+
+// JournalEntry is appended for accepted and rejected reload attempts.
+type JournalEntry struct {
+	Timestamp         time.Time `json:"ts"`
+	Outcome           string    `json:"outcome"`
+	ManifestHash      string    `json:"manifest_hash,omitempty"`
+	Generation        uint64    `json:"generation,omitempty"`
+	PriorManifestHash string    `json:"prior_manifest_hash,omitempty"`
+	Reason            string    `json:"reason,omitempty"`
+	SignerKeyIDs      []string  `json:"signer_key_ids,omitempty"`
+}
+
+// Reload validates active.json and returns the accepted state. If validation
+// fails, the caller keeps its previous in-memory state.
+func (s Store) Reload(opts Options) (State, error) {
+	raw, err := readFile(s.activePath())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return State{}, fmt.Errorf("%w: %w", ErrNoActiveManifest, err)
+		}
+		return State{}, fmt.Errorf("%w: read active manifest: %w", ErrDecode, err)
+	}
+	state, err := s.ValidateEnvelope(raw, opts)
+	if err != nil {
+		// Rejections are audit events even when accepted-manifest persistence is
+		// disabled. Audit write failures do not hide the validation failure.
+		_ = s.appendJournal(JournalEntry{
+			Timestamp: now(opts),
+			Outcome:   "rejected",
+			Reason:    err.Error(),
+		})
+		return State{}, err
+	}
+	if !opts.ReadOnly {
+		encoded, encErr := encodeForStorage(state.Envelope)
+		if encErr != nil {
+			return State{}, encErr
+		}
+		path := s.manifestPath(state.ManifestHash)
+		if err := s.withLock(func() error {
+			if journalErr := s.appendJournalLocked(JournalEntry{
+				Timestamp:         now(opts),
+				Outcome:           "accepted",
+				ManifestHash:      state.ManifestHash,
+				Generation:        state.Envelope.Body.Generation,
+				PriorManifestHash: state.Envelope.Body.PriorManifestHash,
+				SignerKeyIDs:      signerKeyIDs(state.Envelope.Signatures),
+			}); journalErr != nil {
+				return journalErr
+			}
+			if writeErr := writeOnce(path, encoded); writeErr != nil {
+				return writeErr
+			}
+			return nil
+		}); err != nil {
+			return State{}, err
+		}
+		state.AcceptedPath = path
+	}
+	state.JournalOutcome = "accepted"
+	return state, nil
+}
+
+// ValidateEnvelope runs strict decode, signature checks, CAS checks, and
+// contract-history resolution without mutating store files.
+func (s Store) ValidateEnvelope(raw []byte, opts Options) (State, error) {
+	var env contract.ActiveManifestEnvelope
+	if err := contract.DecodeStrictJSON(raw, &env); err != nil {
+		return State{}, fmt.Errorf("%w: active manifest: %w", ErrDecode, err)
+	}
+	if err := env.Body.Validate(); err != nil {
+		return State{}, fmt.Errorf("%w: active manifest: %w", ErrStructural, err)
+	}
+	hash, err := ActiveManifestHash(env.Body)
+	if err != nil {
+		return State{}, err
+	}
+	if err := verifyEnvironment(env.Body.Environment, opts.Environment); err != nil {
+		return State{}, err
+	}
+	if env.Body.Generation <= opts.PreviousGeneration {
+		return State{}, fmt.Errorf("%w: got %d, previous %d", ErrGeneration, env.Body.Generation, opts.PreviousGeneration)
+	}
+	if opts.PreviousHash != "" && env.Body.PriorManifestHash != opts.PreviousHash {
+		return State{}, fmt.Errorf("%w: got %q, want %q", ErrPriorManifest, env.Body.PriorManifestHash, opts.PreviousHash)
+	}
+	if err := verifyManifestSignatures(env, opts); err != nil {
+		return State{}, err
+	}
+	contracts, err := s.loadContracts(env.Body.Selectors)
+	if err != nil {
+		return State{}, err
+	}
+	return State{Envelope: env, ManifestHash: hash, Contracts: contracts}, nil
+}
+
+// WriteActive validates and atomically writes active.json. The advisory lock
+// serializes local same-host writers so the prior-manifest check is not stale.
+func (s Store) WriteActive(raw []byte, opts Options) (string, error) {
+	var manifestHash string
+	err := s.withLock(func() error {
+		state, err := s.ValidateEnvelope(raw, opts)
+		if err != nil {
+			return err
+		}
+		manifestHash = state.ManifestHash
+		if err := mkdirAll(s.root, 0o700); err != nil {
+			return fmt.Errorf("create contract store root: %w", err)
+		}
+		if err := atomicWrite(s.activePath(), append(bytes.TrimSpace(raw), '\n'), 0o600); err != nil {
+			return fmt.Errorf("write active manifest: %w", err)
+		}
+		return nil
+	})
+	return manifestHash, err
+}
+
+// PutHistoryContract stores a signed contract envelope by its contract_hash.
+func (s Store) PutHistoryContract(raw []byte) (string, error) {
+	var env contract.ContractEnvelope
+	if err := contract.DecodeStrictYAML(raw, &env); err != nil {
+		return "", fmt.Errorf("%w: contract history: %w", ErrDecode, err)
+	}
+	hash, err := ContractHash(env.Body)
+	if err != nil {
+		return "", err
+	}
+	if env.Body.ContractHash != hash {
+		return "", fmt.Errorf("%w: contract_hash got %q, computed %q", ErrContractHistory, env.Body.ContractHash, hash)
+	}
+	if err := env.Body.Validate(); err != nil {
+		return "", fmt.Errorf("%w: contract: %w", ErrStructural, err)
+	}
+	if err := s.withLock(func() error {
+		return writeOnce(s.historyPath(hash), append(bytes.TrimSpace(raw), '\n'))
+	}); err != nil {
+		return "", err
+	}
+	return hash, nil
+}
+
+// LatestAccepted returns the highest-generation immutable accepted manifest.
+func (s Store) LatestAccepted(opts Options) (State, error) {
+	entries, err := readDir(s.manifestDir())
+	if err != nil {
+		return State{}, fmt.Errorf("read accepted manifests: %w", err)
+	}
+	var latest State
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), hashFilePrefix) || !strings.HasSuffix(entry.Name(), jsonExt) {
+			continue
+		}
+		raw, err := readFile(filepath.Join(s.manifestDir(), entry.Name()))
+		if err != nil {
+			return State{}, fmt.Errorf("read accepted manifest: %w", err)
+		}
+		var env contract.ActiveManifestEnvelope
+		if err := contract.DecodeStrictJSON(raw, &env); err != nil {
+			return State{}, fmt.Errorf("%w: accepted manifest: %w", ErrDecode, err)
+		}
+		if err := env.Body.Validate(); err != nil {
+			return State{}, fmt.Errorf("%w: accepted manifest: %w", ErrStructural, err)
+		}
+		hash, err := ActiveManifestHash(env.Body)
+		if err != nil {
+			return State{}, err
+		}
+		if hashFilePrefix+strings.TrimPrefix(hash, hashPrefix)+jsonExt != entry.Name() {
+			return State{}, fmt.Errorf("%w: accepted manifest filename/hash mismatch", ErrContractHistory)
+		}
+		if err := verifyEnvironment(env.Body.Environment, opts.Environment); err != nil {
+			return State{}, err
+		}
+		if err := verifyManifestSignatures(env, opts); err != nil {
+			return State{}, err
+		}
+		if env.Body.Generation > latest.Envelope.Body.Generation {
+			latest = State{
+				Envelope:     env,
+				ManifestHash: hash,
+				AcceptedPath: filepath.Join(s.manifestDir(), entry.Name()),
+			}
+		}
+	}
+	if latest.ManifestHash == "" {
+		return State{}, os.ErrNotExist
+	}
+	return latest, nil
+}
+
+// ActiveManifestHash returns sha256 over the manifest body's canonical preimage.
+func ActiveManifestHash(m contract.ActiveManifest) (string, error) {
+	preimage, err := m.SignablePreimage()
+	if err != nil {
+		return "", fmt.Errorf("manifest preimage: %w", err)
+	}
+	sum := sha256.Sum256(preimage)
+	return hashPrefix + hex.EncodeToString(sum[:]), nil
+}
+
+// ContractHash returns sha256 over the canonical contract body with
+// contract_hash cleared, matching the compiler's signed body hash.
+func ContractHash(c contract.Contract) (string, error) {
+	c.ContractHash = ""
+	preimage, err := c.SignablePreimage()
+	if err != nil {
+		return "", fmt.Errorf("contract preimage: %w", err)
+	}
+	sum := sha256.Sum256(preimage)
+	return hashPrefix + hex.EncodeToString(sum[:]), nil
+}
+
+func (s Store) loadContracts(selectors []contract.ManifestSelector) (map[string]contract.ContractEnvelope, error) {
+	out := make(map[string]contract.ContractEnvelope, len(selectors))
+	for _, selector := range selectors {
+		raw, err := readFile(s.historyPath(selector.ContractHash))
+		if err != nil {
+			return nil, fmt.Errorf("%w: read %s: %w", ErrContractHistory, selector.ContractHash, err)
+		}
+		var env contract.ContractEnvelope
+		if err := contract.DecodeStrictYAML(raw, &env); err != nil {
+			return nil, fmt.Errorf("%w: decode %s: %w", ErrDecode, selector.ContractHash, err)
+		}
+		hash, err := ContractHash(env.Body)
+		if err != nil {
+			return nil, err
+		}
+		if env.Body.ContractHash != selector.ContractHash || hash != selector.ContractHash {
+			return nil, fmt.Errorf("%w: selector %q points to %q, body has %q computed %q",
+				ErrContractHistory, selector.SelectorID, selector.ContractHash, env.Body.ContractHash, hash)
+		}
+		if err := env.Body.Validate(); err != nil {
+			return nil, fmt.Errorf("%w: contract %s: %w", ErrStructural, selector.ContractHash, err)
+		}
+		out[selector.SelectorID] = env
+	}
+	return out, nil
+}
+
+func verifyManifestSignatures(env contract.ActiveManifestEnvelope, opts Options) error {
+	if opts.Roster == nil {
+		return fmt.Errorf("%w: roster is required", ErrSignature)
+	}
+	required := opts.MinSignatures
+	if required <= 0 {
+		required = defaultMinSignatures
+	}
+	preimage, err := env.Body.SignablePreimage()
+	if err != nil {
+		return fmt.Errorf("manifest preimage: %w", err)
+	}
+	nowTime := now(opts)
+	seenPrincipals := map[string]struct{}{}
+	seenKeys := map[string]struct{}{}
+	valid := 0
+	for _, sig := range env.Signatures {
+		if sig.KeyPurpose != signing.PurposeContractActivationSigning.String() {
+			return fmt.Errorf("%w: key_id=%q purpose=%q", ErrSignature, sig.KeyID, sig.KeyPurpose)
+		}
+		if sig.Algorithm != "ed25519" {
+			return fmt.Errorf("%w: key_id=%q algorithm=%q", ErrSignature, sig.KeyID, sig.Algorithm)
+		}
+		key, err := opts.Roster.ResolveKey(sig.KeyID, nowTime)
+		if err != nil {
+			return fmt.Errorf("%w: key_id=%q: %w", ErrSignature, sig.KeyID, err)
+		}
+		if key.KeyPurpose != signing.PurposeContractActivationSigning.String() {
+			return fmt.Errorf("%w: key_id=%q roster purpose=%q", ErrSignature, sig.KeyID, key.KeyPurpose)
+		}
+		if key.Principal == "" {
+			return fmt.Errorf("%w: key_id=%q missing activation principal", ErrSignature, sig.KeyID)
+		}
+		if sig.Principal != "" && key.Principal != "" && sig.Principal != key.Principal {
+			return fmt.Errorf("%w: key_id=%q principal mismatch", ErrSignature, sig.KeyID)
+		}
+		sigBytes, err := parseSignature(sig.Signature)
+		if err != nil {
+			return fmt.Errorf("%w: key_id=%q: %w", ErrSignature, sig.KeyID, err)
+		}
+		pub, err := hex.DecodeString(key.PublicKeyHex)
+		if err != nil {
+			return fmt.Errorf("%w: key_id=%q public key: %w", ErrSignature, sig.KeyID, err)
+		}
+		if !contract.VerifyEd25519PureEdDSA(pub, preimage, sigBytes) {
+			return fmt.Errorf("%w: key_id=%q", ErrSignature, sig.KeyID)
+		}
+		if _, dup := seenKeys[sig.KeyID]; dup {
+			continue
+		}
+		principal := key.Principal
+		if _, dup := seenPrincipals[principal]; dup {
+			continue
+		}
+		seenKeys[sig.KeyID] = struct{}{}
+		seenPrincipals[principal] = struct{}{}
+		valid++
+	}
+	if valid < required {
+		return fmt.Errorf("%w: got %d valid distinct signatures, want %d", ErrDualControl, valid, required)
+	}
+	return nil
+}
+
+func verifyEnvironment(got, want contract.Environment) error {
+	if want == (contract.Environment{}) {
+		return nil
+	}
+	if got != want {
+		return fmt.Errorf("%w: got %+v want %+v", ErrEnvironmentMismatch, got, want)
+	}
+	return nil
+}
+
+func writeOnce(path string, data []byte) error {
+	path = filepath.Clean(path)
+	if err := mkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create store directory: %w", err)
+	}
+	existing, err := readFile(path)
+	if err == nil {
+		if bytes.Equal(existing, data) {
+			return nil
+		}
+		return fmt.Errorf("%w: %s", ErrWriteOnceConflict, path)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read write-once object: %w", err)
+	}
+	if err := atomicWrite(path, data, 0o600); err != nil {
+		return fmt.Errorf("write write-once object: %w", err)
+	}
+	return nil
+}
+
+func (s Store) appendJournal(entry JournalEntry) error {
+	return s.withLock(func() error {
+		return s.appendJournalLocked(entry)
+	})
+}
+
+func (s Store) appendJournalLocked(entry JournalEntry) error {
+	if err := mkdirAll(s.root, 0o700); err != nil {
+		return fmt.Errorf("create contract store root: %w", err)
+	}
+	raw, err := marshalJSON(entry)
+	if err != nil {
+		return fmt.Errorf("marshal activation journal entry: %w", err)
+	}
+	raw = append(raw, '\n')
+	f, err := openFile(s.journalPath(), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open activation journal: %w", err)
+	}
+	if _, err := f.Write(raw); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write activation journal: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close activation journal: %w", err)
+	}
+	return nil
+}
+
+func encodeForStorage(v any) ([]byte, error) {
+	raw, err := marshalJSON(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshal json: %w", err)
+	}
+	return append(raw, '\n'), nil
+}
+
+func parseSignature(sig string) ([]byte, error) {
+	if !strings.HasPrefix(sig, signaturePrefix) {
+		return nil, fmt.Errorf("missing %q prefix", signaturePrefix)
+	}
+	hexPart := strings.TrimPrefix(sig, signaturePrefix)
+	if len(hexPart) != 128 {
+		return nil, fmt.Errorf("signature hex length %d, want 128", len(hexPart))
+	}
+	out, err := hex.DecodeString(hexPart)
+	if err != nil {
+		return nil, fmt.Errorf("signature hex decode: %w", err)
+	}
+	return out, nil
+}
+
+func (s Store) activePath() string {
+	return filepath.Join(s.root, activeFilename)
+}
+
+func (s Store) manifestDir() string {
+	return filepath.Join(s.root, manifestDirname)
+}
+
+func (s Store) manifestPath(hash string) string {
+	return filepath.Join(s.manifestDir(), hashFilename(hash, jsonExt))
+}
+
+func (s Store) historyPath(hash string) string {
+	return filepath.Join(s.root, historyDirname, hashFilename(hash, yamlExt))
+}
+
+func (s Store) journalPath() string {
+	return filepath.Join(s.root, journalFilename)
+}
+
+func hashFilename(hash, ext string) string {
+	return hashFilePrefix + strings.TrimPrefix(hash, hashPrefix) + ext
+}
+
+func signerKeyIDs(sigs []contract.ManifestSignature) []string {
+	out := make([]string, 0, len(sigs))
+	for _, sig := range sigs {
+		out = append(out, sig.KeyID)
+	}
+	return out
+}
+
+func now(opts Options) time.Time {
+	if opts.Now != nil {
+		return opts.Now().UTC()
+	}
+	return time.Now().UTC()
+}

--- a/internal/contract/store/store.go
+++ b/internal/contract/store/store.go
@@ -58,6 +58,7 @@ var (
 	ErrDecode              = errors.New("contract store: decode failed")
 	ErrStructural          = errors.New("contract store: structural validation failed")
 	ErrSignature           = errors.New("contract store: manifest signature invalid")
+	ErrContractSignature   = errors.New("contract store: contract signature invalid")
 	ErrDualControl         = errors.New("contract store: dual control requirement not met")
 	ErrEnvironmentMismatch = errors.New("contract store: manifest environment mismatch")
 	ErrGeneration          = errors.New("contract store: manifest generation is not monotonic")
@@ -121,13 +122,14 @@ func (s Store) Reload(opts Options) (State, error) {
 		}
 		accepted, err := s.ValidateEnvelope(raw, opts)
 		if err != nil {
-			// Rejections are audit events even when accepted-manifest persistence is
-			// disabled. Audit write failures do not hide the validation failure.
-			_ = s.appendJournalLocked(JournalEntry{
-				Timestamp: now(opts),
-				Outcome:   "rejected",
-				Reason:    err.Error(),
-			})
+			if !opts.ReadOnly {
+				// Audit write failures do not hide the validation failure.
+				_ = s.appendJournalLocked(JournalEntry{
+					Timestamp: now(opts),
+					Outcome:   "rejected",
+					Reason:    err.Error(),
+				})
+			}
 			return err
 		}
 		acceptedPath := ""
@@ -136,7 +138,10 @@ func (s Store) Reload(opts Options) (State, error) {
 			if encErr != nil {
 				return encErr
 			}
-			path := s.manifestPath(accepted.ManifestHash)
+			path, pathErr := s.manifestPath(accepted.ManifestHash)
+			if pathErr != nil {
+				return pathErr
+			}
 			if journalErr := s.appendJournalLocked(JournalEntry{
 				Timestamp:         now(opts),
 				Outcome:           "accepted",
@@ -192,7 +197,7 @@ func (s Store) ValidateEnvelope(raw []byte, opts Options) (State, error) {
 	if err := verifyManifestSignatures(env, opts); err != nil {
 		return State{}, err
 	}
-	contracts, err := s.loadContracts(env.Body.Selectors)
+	contracts, err := s.loadContracts(env.Body.Selectors, opts)
 	if err != nil {
 		return State{}, err
 	}
@@ -204,7 +209,16 @@ func (s Store) ValidateEnvelope(raw []byte, opts Options) (State, error) {
 func (s Store) WriteActive(raw []byte, opts Options) (string, error) {
 	var manifestHash string
 	err := s.withLock(func() error {
-		state, err := s.ValidateEnvelope(raw, opts)
+		lockedOpts := opts
+		current, err := s.currentActiveLocked(opts)
+		if err != nil && !errors.Is(err, ErrNoActiveManifest) {
+			return err
+		}
+		if err == nil {
+			lockedOpts.PreviousHash = current.ManifestHash
+			lockedOpts.PreviousGeneration = current.Envelope.Body.Generation
+		}
+		state, err := s.ValidateEnvelope(raw, lockedOpts)
 		if err != nil {
 			return err
 		}
@@ -221,7 +235,7 @@ func (s Store) WriteActive(raw []byte, opts Options) (string, error) {
 }
 
 // PutHistoryContract stores a signed contract envelope by its contract_hash.
-func (s Store) PutHistoryContract(raw []byte) (string, error) {
+func (s Store) PutHistoryContract(raw []byte, opts Options) (string, error) {
 	var env contract.ContractEnvelope
 	if err := contract.DecodeStrictYAML(raw, &env); err != nil {
 		return "", fmt.Errorf("%w: contract history: %w", ErrDecode, err)
@@ -236,8 +250,15 @@ func (s Store) PutHistoryContract(raw []byte) (string, error) {
 	if err := env.Body.Validate(); err != nil {
 		return "", fmt.Errorf("%w: contract: %w", ErrStructural, err)
 	}
+	if err := verifyContractSignature(env, opts); err != nil {
+		return "", err
+	}
+	path, err := s.historyPath(hash)
+	if err != nil {
+		return "", err
+	}
 	if err := s.withLock(func() error {
-		return writeOnce(s.historyPath(hash), append(bytes.TrimSpace(raw), '\n'))
+		return writeOnce(path, append(bytes.TrimSpace(raw), '\n'))
 	}); err != nil {
 		return "", err
 	}
@@ -270,7 +291,11 @@ func (s Store) LatestAccepted(opts Options) (State, error) {
 		if err != nil {
 			return State{}, err
 		}
-		if hashFilePrefix+strings.TrimPrefix(hash, hashPrefix)+jsonExt != entry.Name() {
+		expectedName, err := hashFilename(hash, jsonExt)
+		if err != nil {
+			return State{}, err
+		}
+		if expectedName != entry.Name() {
 			return State{}, fmt.Errorf("%w: accepted manifest filename/hash mismatch", ErrContractHistory)
 		}
 		if err := verifyEnvironment(env.Body.Environment, opts.Environment); err != nil {
@@ -279,7 +304,11 @@ func (s Store) LatestAccepted(opts Options) (State, error) {
 		if err := verifyManifestSignatures(env, opts); err != nil {
 			return State{}, err
 		}
-		contracts, err := s.loadContracts(env.Body.Selectors)
+		contracts, err := s.loadContracts(env.Body.Selectors, opts)
+		if err != nil {
+			return State{}, err
+		}
+		acceptedPath, err := s.manifestPath(hash)
 		if err != nil {
 			return State{}, err
 		}
@@ -288,7 +317,7 @@ func (s Store) LatestAccepted(opts Options) (State, error) {
 				Envelope:     env,
 				ManifestHash: hash,
 				Contracts:    contracts,
-				AcceptedPath: filepath.Join(s.manifestDir(), entry.Name()),
+				AcceptedPath: acceptedPath,
 			}
 		}
 	}
@@ -320,10 +349,14 @@ func ContractHash(c contract.Contract) (string, error) {
 	return hashPrefix + hex.EncodeToString(sum[:]), nil
 }
 
-func (s Store) loadContracts(selectors []contract.ManifestSelector) (map[string]contract.ContractEnvelope, error) {
+func (s Store) loadContracts(selectors []contract.ManifestSelector, opts Options) (map[string]contract.ContractEnvelope, error) {
 	out := make(map[string]contract.ContractEnvelope, len(selectors))
 	for _, selector := range selectors {
-		raw, err := readFile(s.historyPath(selector.ContractHash))
+		path, err := s.historyPath(selector.ContractHash)
+		if err != nil {
+			return nil, err
+		}
+		raw, err := readFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("%w: read %s: %w", ErrContractHistory, selector.ContractHash, err)
 		}
@@ -342,9 +375,26 @@ func (s Store) loadContracts(selectors []contract.ManifestSelector) (map[string]
 		if err := env.Body.Validate(); err != nil {
 			return nil, fmt.Errorf("%w: contract %s: %w", ErrStructural, selector.ContractHash, err)
 		}
+		if err := verifyContractSignature(env, opts); err != nil {
+			return nil, err
+		}
 		out[selector.SelectorID] = env
 	}
 	return out, nil
+}
+
+func (s Store) currentActiveLocked(opts Options) (State, error) {
+	raw, err := readFile(s.activePath())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return State{}, fmt.Errorf("%w: %w", ErrNoActiveManifest, err)
+		}
+		return State{}, fmt.Errorf("%w: read active manifest: %w", ErrDecode, err)
+	}
+	currentOpts := opts
+	currentOpts.PreviousHash = ""
+	currentOpts.PreviousGeneration = 0
+	return s.ValidateEnvelope(raw, currentOpts)
 }
 
 func verifyManifestSignatures(env contract.ActiveManifestEnvelope, opts Options) error {
@@ -407,6 +457,38 @@ func verifyManifestSignatures(env contract.ActiveManifestEnvelope, opts Options)
 	}
 	if valid < required {
 		return fmt.Errorf("%w: got %d valid distinct signatures, want %d", ErrDualControl, valid, required)
+	}
+	return nil
+}
+
+func verifyContractSignature(env contract.ContractEnvelope, opts Options) error {
+	if opts.Roster == nil {
+		return fmt.Errorf("%w: roster is required", ErrContractSignature)
+	}
+	if env.Body.KeyPurpose != signing.PurposeContractCompileSigning.String() {
+		return fmt.Errorf("%w: key_id=%q purpose=%q", ErrContractSignature, env.Body.SignerKeyID, env.Body.KeyPurpose)
+	}
+	key, err := opts.Roster.ResolveKey(env.Body.SignerKeyID, now(opts))
+	if err != nil {
+		return fmt.Errorf("%w: key_id=%q: %w", ErrContractSignature, env.Body.SignerKeyID, err)
+	}
+	if key.KeyPurpose != signing.PurposeContractCompileSigning.String() {
+		return fmt.Errorf("%w: key_id=%q roster purpose=%q", ErrContractSignature, env.Body.SignerKeyID, key.KeyPurpose)
+	}
+	sigBytes, err := parseSignature(env.Signature)
+	if err != nil {
+		return fmt.Errorf("%w: key_id=%q: %w", ErrContractSignature, env.Body.SignerKeyID, err)
+	}
+	pub, err := hex.DecodeString(key.PublicKeyHex)
+	if err != nil {
+		return fmt.Errorf("%w: key_id=%q public key: %w", ErrContractSignature, env.Body.SignerKeyID, err)
+	}
+	preimage, err := env.Body.SignablePreimage()
+	if err != nil {
+		return fmt.Errorf("%w: contract preimage: %w", ErrContractSignature, err)
+	}
+	if !contract.VerifyEd25519PureEdDSA(pub, preimage, sigBytes) {
+		return fmt.Errorf("%w: key_id=%q", ErrContractSignature, env.Body.SignerKeyID)
 	}
 	return nil
 }
@@ -496,20 +578,56 @@ func (s Store) manifestDir() string {
 	return filepath.Join(s.root, manifestDirname)
 }
 
-func (s Store) manifestPath(hash string) string {
-	return filepath.Join(s.manifestDir(), hashFilename(hash, jsonExt))
+func (s Store) manifestPath(hash string) (string, error) {
+	return objectPath(s.manifestDir(), hash, jsonExt)
 }
 
-func (s Store) historyPath(hash string) string {
-	return filepath.Join(s.root, historyDirname, hashFilename(hash, yamlExt))
+func (s Store) historyPath(hash string) (string, error) {
+	return objectPath(filepath.Join(s.root, historyDirname), hash, yamlExt)
 }
 
 func (s Store) journalPath() string {
 	return filepath.Join(s.root, journalFilename)
 }
 
-func hashFilename(hash, ext string) string {
-	return hashFilePrefix + strings.TrimPrefix(hash, hashPrefix) + ext
+func objectPath(dir, hash, ext string) (string, error) {
+	name, err := hashFilename(hash, ext)
+	if err != nil {
+		return "", err
+	}
+	cleanDir := filepath.Clean(dir)
+	path := filepath.Join(cleanDir, name)
+	rel, err := filepath.Rel(cleanDir, path)
+	if err != nil {
+		return "", fmt.Errorf("%w: object path: %w", ErrContractHistory, err)
+	}
+	if rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("%w: object path escapes store root", ErrContractHistory)
+	}
+	return path, nil
+}
+
+func hashFilename(hash, ext string) (string, error) {
+	if err := validateHash(hash); err != nil {
+		return "", err
+	}
+	return hashFilePrefix + strings.TrimPrefix(hash, hashPrefix) + ext, nil
+}
+
+func validateHash(hash string) error {
+	if !strings.HasPrefix(hash, hashPrefix) {
+		return fmt.Errorf("%w: hash %q missing %q prefix", ErrContractHistory, hash, hashPrefix)
+	}
+	hexPart := strings.TrimPrefix(hash, hashPrefix)
+	if len(hexPart) != 64 {
+		return fmt.Errorf("%w: hash %q length %d, want 64 hex chars", ErrContractHistory, hash, len(hexPart))
+	}
+	for _, r := range hexPart {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return fmt.Errorf("%w: hash %q is not lowercase hex", ErrContractHistory, hash)
+		}
+	}
+	return nil
 }
 
 func signerKeyIDs(sigs []contract.ManifestSignature) []string {

--- a/internal/contract/store/store.go
+++ b/internal/contract/store/store.go
@@ -26,7 +26,7 @@ var (
 	readDir  = os.ReadDir
 	mkdirAll = os.MkdirAll
 	openFile = func(name string, flag int, perm os.FileMode) (writableFile, error) {
-		return os.OpenFile(name, flag, perm) //nolint:gosec // Store callers provide paths rooted in the configured contracts directory.
+		return os.OpenFile(filepath.Clean(name), flag, perm)
 	}
 	atomicWrite = atomicfile.Write
 	marshalJSON = json.Marshal

--- a/internal/contract/store/store.go
+++ b/internal/contract/store/store.go
@@ -90,11 +90,10 @@ type Options struct {
 
 // State is the accepted manifest and resolved contract set.
 type State struct {
-	Envelope       contract.ActiveManifestEnvelope
-	ManifestHash   string
-	Contracts      map[string]contract.ContractEnvelope
-	AcceptedPath   string
-	JournalOutcome string
+	Envelope     contract.ActiveManifestEnvelope
+	ManifestHash string
+	Contracts    map[string]contract.ContractEnvelope
+	AcceptedPath string
 }
 
 // JournalEntry is appended for accepted and rejected reload attempts.
@@ -131,6 +130,7 @@ func (s Store) Reload(opts Options) (State, error) {
 			})
 			return err
 		}
+		acceptedPath := ""
 		if !opts.ReadOnly {
 			encoded, encErr := encodeForStorage(accepted.Envelope)
 			if encErr != nil {
@@ -150,10 +150,14 @@ func (s Store) Reload(opts Options) (State, error) {
 			if writeErr := writeOnce(path, encoded); writeErr != nil {
 				return writeErr
 			}
-			accepted.AcceptedPath = path
+			acceptedPath = path
 		}
-		accepted.JournalOutcome = "accepted"
-		state = accepted
+		state = State{
+			Envelope:     accepted.Envelope,
+			ManifestHash: accepted.ManifestHash,
+			Contracts:    accepted.Contracts,
+			AcceptedPath: acceptedPath,
+		}
 		return nil
 	})
 	if err != nil {

--- a/internal/contract/store/store.go
+++ b/internal/contract/store/store.go
@@ -39,6 +39,8 @@ type writableFile interface {
 
 const (
 	defaultMinSignatures = 1
+	dirPerm              = 0o750
+	filePerm             = 0o600
 
 	activeFilename  = "active.json"
 	historyDirname  = "history"
@@ -109,51 +111,54 @@ type JournalEntry struct {
 // Reload validates active.json and returns the accepted state. If validation
 // fails, the caller keeps its previous in-memory state.
 func (s Store) Reload(opts Options) (State, error) {
-	raw, err := readFile(s.activePath())
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return State{}, fmt.Errorf("%w: %w", ErrNoActiveManifest, err)
+	var state State
+	err := s.withLock(func() error {
+		raw, err := readFile(s.activePath())
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("%w: %w", ErrNoActiveManifest, err)
+			}
+			return fmt.Errorf("%w: read active manifest: %w", ErrDecode, err)
 		}
-		return State{}, fmt.Errorf("%w: read active manifest: %w", ErrDecode, err)
-	}
-	state, err := s.ValidateEnvelope(raw, opts)
-	if err != nil {
-		// Rejections are audit events even when accepted-manifest persistence is
-		// disabled. Audit write failures do not hide the validation failure.
-		_ = s.appendJournal(JournalEntry{
-			Timestamp: now(opts),
-			Outcome:   "rejected",
-			Reason:    err.Error(),
-		})
-		return State{}, err
-	}
-	if !opts.ReadOnly {
-		encoded, encErr := encodeForStorage(state.Envelope)
-		if encErr != nil {
-			return State{}, encErr
+		accepted, err := s.ValidateEnvelope(raw, opts)
+		if err != nil {
+			// Rejections are audit events even when accepted-manifest persistence is
+			// disabled. Audit write failures do not hide the validation failure.
+			_ = s.appendJournalLocked(JournalEntry{
+				Timestamp: now(opts),
+				Outcome:   "rejected",
+				Reason:    err.Error(),
+			})
+			return err
 		}
-		path := s.manifestPath(state.ManifestHash)
-		if err := s.withLock(func() error {
+		if !opts.ReadOnly {
+			encoded, encErr := encodeForStorage(accepted.Envelope)
+			if encErr != nil {
+				return encErr
+			}
+			path := s.manifestPath(accepted.ManifestHash)
 			if journalErr := s.appendJournalLocked(JournalEntry{
 				Timestamp:         now(opts),
 				Outcome:           "accepted",
-				ManifestHash:      state.ManifestHash,
-				Generation:        state.Envelope.Body.Generation,
-				PriorManifestHash: state.Envelope.Body.PriorManifestHash,
-				SignerKeyIDs:      signerKeyIDs(state.Envelope.Signatures),
+				ManifestHash:      accepted.ManifestHash,
+				Generation:        accepted.Envelope.Body.Generation,
+				PriorManifestHash: accepted.Envelope.Body.PriorManifestHash,
+				SignerKeyIDs:      signerKeyIDs(accepted.Envelope.Signatures),
 			}); journalErr != nil {
 				return journalErr
 			}
 			if writeErr := writeOnce(path, encoded); writeErr != nil {
 				return writeErr
 			}
-			return nil
-		}); err != nil {
-			return State{}, err
+			accepted.AcceptedPath = path
 		}
-		state.AcceptedPath = path
+		accepted.JournalOutcome = "accepted"
+		state = accepted
+		return nil
+	})
+	if err != nil {
+		return State{}, err
 	}
-	state.JournalOutcome = "accepted"
 	return state, nil
 }
 
@@ -200,10 +205,10 @@ func (s Store) WriteActive(raw []byte, opts Options) (string, error) {
 			return err
 		}
 		manifestHash = state.ManifestHash
-		if err := mkdirAll(s.root, 0o700); err != nil {
+		if err := mkdirAll(s.root, dirPerm); err != nil {
 			return fmt.Errorf("create contract store root: %w", err)
 		}
-		if err := atomicWrite(s.activePath(), append(bytes.TrimSpace(raw), '\n'), 0o600); err != nil {
+		if err := atomicWrite(s.activePath(), append(bytes.TrimSpace(raw), '\n'), filePerm); err != nil {
 			return fmt.Errorf("write active manifest: %w", err)
 		}
 		return nil
@@ -270,10 +275,15 @@ func (s Store) LatestAccepted(opts Options) (State, error) {
 		if err := verifyManifestSignatures(env, opts); err != nil {
 			return State{}, err
 		}
+		contracts, err := s.loadContracts(env.Body.Selectors)
+		if err != nil {
+			return State{}, err
+		}
 		if env.Body.Generation > latest.Envelope.Body.Generation {
 			latest = State{
 				Envelope:     env,
 				ManifestHash: hash,
+				Contracts:    contracts,
 				AcceptedPath: filepath.Join(s.manifestDir(), entry.Name()),
 			}
 		}
@@ -409,7 +419,7 @@ func verifyEnvironment(got, want contract.Environment) error {
 
 func writeOnce(path string, data []byte) error {
 	path = filepath.Clean(path)
-	if err := mkdirAll(filepath.Dir(path), 0o700); err != nil {
+	if err := mkdirAll(filepath.Dir(path), dirPerm); err != nil {
 		return fmt.Errorf("create store directory: %w", err)
 	}
 	existing, err := readFile(path)
@@ -422,20 +432,14 @@ func writeOnce(path string, data []byte) error {
 	if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("read write-once object: %w", err)
 	}
-	if err := atomicWrite(path, data, 0o600); err != nil {
+	if err := atomicWrite(path, data, filePerm); err != nil {
 		return fmt.Errorf("write write-once object: %w", err)
 	}
 	return nil
 }
 
-func (s Store) appendJournal(entry JournalEntry) error {
-	return s.withLock(func() error {
-		return s.appendJournalLocked(entry)
-	})
-}
-
 func (s Store) appendJournalLocked(entry JournalEntry) error {
-	if err := mkdirAll(s.root, 0o700); err != nil {
+	if err := mkdirAll(s.root, dirPerm); err != nil {
 		return fmt.Errorf("create contract store root: %w", err)
 	}
 	raw, err := marshalJSON(entry)
@@ -443,7 +447,7 @@ func (s Store) appendJournalLocked(entry JournalEntry) error {
 		return fmt.Errorf("marshal activation journal entry: %w", err)
 	}
 	raw = append(raw, '\n')
-	f, err := openFile(s.journalPath(), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	f, err := openFile(s.journalPath(), os.O_CREATE|os.O_APPEND|os.O_WRONLY, filePerm)
 	if err != nil {
 		return fmt.Errorf("open activation journal: %w", err)
 	}

--- a/internal/contract/store/store.go
+++ b/internal/contract/store/store.go
@@ -142,6 +142,9 @@ func (s Store) Reload(opts Options) (State, error) {
 			if pathErr != nil {
 				return pathErr
 			}
+			if writeErr := writeOnce(path, encoded); writeErr != nil {
+				return writeErr
+			}
 			if journalErr := s.appendJournalLocked(JournalEntry{
 				Timestamp:         now(opts),
 				Outcome:           "accepted",
@@ -151,9 +154,6 @@ func (s Store) Reload(opts Options) (State, error) {
 				SignerKeyIDs:      signerKeyIDs(accepted.Envelope.Signatures),
 			}); journalErr != nil {
 				return journalErr
-			}
-			if writeErr := writeOnce(path, encoded); writeErr != nil {
-				return writeErr
 			}
 			acceptedPath = path
 		}
@@ -271,60 +271,133 @@ func (s Store) LatestAccepted(opts Options) (State, error) {
 	if err != nil {
 		return State{}, fmt.Errorf("read accepted manifests: %w", err)
 	}
-	var latest State
+	candidates := map[string]acceptedManifest{}
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasPrefix(entry.Name(), hashFilePrefix) || !strings.HasSuffix(entry.Name(), jsonExt) {
 			continue
 		}
-		raw, err := readFile(filepath.Join(s.manifestDir(), entry.Name()))
-		if err != nil {
-			return State{}, fmt.Errorf("read accepted manifest: %w", err)
-		}
-		var env contract.ActiveManifestEnvelope
-		if err := contract.DecodeStrictJSON(raw, &env); err != nil {
-			return State{}, fmt.Errorf("%w: accepted manifest: %w", ErrDecode, err)
-		}
-		if err := env.Body.Validate(); err != nil {
-			return State{}, fmt.Errorf("%w: accepted manifest: %w", ErrStructural, err)
-		}
-		hash, err := ActiveManifestHash(env.Body)
+		candidate, err := s.loadAcceptedManifestFile(filepath.Join(s.manifestDir(), entry.Name()), entry.Name(), opts)
 		if err != nil {
 			return State{}, err
 		}
-		expectedName, err := hashFilename(hash, jsonExt)
-		if err != nil {
-			return State{}, err
+		candidates[candidate.hash] = candidate
+	}
+	var latest acceptedManifest
+	for hash, candidate := range candidates {
+		if err := s.acceptedChainContinuous(hash, candidates, opts, map[string]struct{}{}); err != nil {
+			continue
 		}
-		if expectedName != entry.Name() {
-			return State{}, fmt.Errorf("%w: accepted manifest filename/hash mismatch", ErrContractHistory)
-		}
-		if err := verifyEnvironment(env.Body.Environment, opts.Environment); err != nil {
-			return State{}, err
-		}
-		if err := verifyManifestSignatures(env, opts); err != nil {
-			return State{}, err
-		}
-		contracts, err := s.loadContracts(env.Body.Selectors, opts)
-		if err != nil {
-			return State{}, err
-		}
-		acceptedPath, err := s.manifestPath(hash)
-		if err != nil {
-			return State{}, err
-		}
-		if env.Body.Generation > latest.Envelope.Body.Generation {
-			latest = State{
-				Envelope:     env,
-				ManifestHash: hash,
-				Contracts:    contracts,
-				AcceptedPath: acceptedPath,
-			}
+		if candidate.env.Body.Generation > latest.env.Body.Generation {
+			latest = candidate
 		}
 	}
-	if latest.ManifestHash == "" {
+	if latest.hash == "" {
 		return State{}, os.ErrNotExist
 	}
-	return latest, nil
+	contracts, err := s.loadContracts(latest.env.Body.Selectors, opts)
+	if err != nil {
+		return State{}, err
+	}
+	return State{
+		Envelope:     latest.env,
+		ManifestHash: latest.hash,
+		Contracts:    contracts,
+		AcceptedPath: latest.path,
+	}, nil
+}
+
+type acceptedManifest struct {
+	env  contract.ActiveManifestEnvelope
+	hash string
+	path string
+}
+
+func (s Store) loadAcceptedManifestFile(path, filename string, opts Options) (acceptedManifest, error) {
+	raw, err := readFile(path)
+	if err != nil {
+		return acceptedManifest{}, fmt.Errorf("read accepted manifest: %w", err)
+	}
+	var env contract.ActiveManifestEnvelope
+	if err := contract.DecodeStrictJSON(raw, &env); err != nil {
+		return acceptedManifest{}, fmt.Errorf("%w: accepted manifest: %w", ErrDecode, err)
+	}
+	if err := env.Body.Validate(); err != nil {
+		return acceptedManifest{}, fmt.Errorf("%w: accepted manifest: %w", ErrStructural, err)
+	}
+	hash, err := ActiveManifestHash(env.Body)
+	if err != nil {
+		return acceptedManifest{}, err
+	}
+	expectedName, err := hashFilename(hash, jsonExt)
+	if err != nil {
+		return acceptedManifest{}, err
+	}
+	if expectedName != filename {
+		return acceptedManifest{}, fmt.Errorf("%w: accepted manifest filename/hash mismatch", ErrContractHistory)
+	}
+	if err := verifyEnvironment(env.Body.Environment, opts.Environment); err != nil {
+		return acceptedManifest{}, err
+	}
+	if err := verifyManifestSignatures(env, opts); err != nil {
+		return acceptedManifest{}, err
+	}
+	acceptedPath, err := s.manifestPath(hash)
+	if err != nil {
+		return acceptedManifest{}, err
+	}
+	return acceptedManifest{env: env, hash: hash, path: acceptedPath}, nil
+}
+
+func (s Store) acceptedChainContinuous(hash string, candidates map[string]acceptedManifest, opts Options, visiting map[string]struct{}) error {
+	candidate, ok := candidates[hash]
+	if !ok {
+		loaded, err := s.loadAcceptedManifestByHash(hash, opts)
+		if err != nil {
+			return err
+		}
+		candidate = loaded
+		candidates[hash] = loaded
+	}
+	if _, ok := visiting[hash]; ok {
+		return fmt.Errorf("%w: accepted manifest prior chain cycle at %s", ErrContractHistory, hash)
+	}
+	visiting[hash] = struct{}{}
+	defer delete(visiting, hash)
+
+	if candidate.env.Body.Generation <= 1 {
+		return nil
+	}
+	prior := candidate.env.Body.PriorManifestHash
+	if err := validateHash(prior); err != nil {
+		return fmt.Errorf("%w: generation %d prior manifest %q is not an accepted hash",
+			ErrContractHistory, candidate.env.Body.Generation, prior)
+	}
+	priorCandidate, ok := candidates[prior]
+	if !ok {
+		loaded, err := s.loadAcceptedManifestByHash(prior, opts)
+		if err != nil {
+			return err
+		}
+		priorCandidate = loaded
+		candidates[prior] = loaded
+	}
+	if priorCandidate.env.Body.Generation >= candidate.env.Body.Generation {
+		return fmt.Errorf("%w: prior generation %d is not below %d",
+			ErrContractHistory, priorCandidate.env.Body.Generation, candidate.env.Body.Generation)
+	}
+	return s.acceptedChainContinuous(prior, candidates, opts, visiting)
+}
+
+func (s Store) loadAcceptedManifestByHash(hash string, opts Options) (acceptedManifest, error) {
+	path, err := s.manifestPath(hash)
+	if err != nil {
+		return acceptedManifest{}, err
+	}
+	name, err := hashFilename(hash, jsonExt)
+	if err != nil {
+		return acceptedManifest{}, err
+	}
+	return s.loadAcceptedManifestFile(path, name, opts)
 }
 
 // ActiveManifestHash returns sha256 over the manifest body's canonical preimage.

--- a/internal/contract/store/store_test.go
+++ b/internal/contract/store/store_test.go
@@ -28,6 +28,11 @@ type testSigner struct {
 	priv      ed25519.PrivateKey
 }
 
+type testRosterKey struct {
+	signer  testSigner
+	purpose signing.KeyPurpose
+}
+
 func TestReloadAcceptsSignedManifestAndPersistsAccepted(t *testing.T) {
 	st := New(t.TempDir())
 	cHash := putTestContract(t, st)
@@ -77,7 +82,7 @@ func TestReloadReadOnlyDoesNotPersistAcceptedOrJournal(t *testing.T) {
 	}
 }
 
-func TestReloadReadOnlyJournalsRejections(t *testing.T) {
+func TestReloadReadOnlyDoesNotJournalRejections(t *testing.T) {
 	st := New(t.TempDir())
 	if err := os.MkdirAll(st.root, 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -90,12 +95,19 @@ func TestReloadReadOnlyJournalsRejections(t *testing.T) {
 	if _, err := st.Reload(opts); !errors.Is(err, ErrDecode) {
 		t.Fatalf("Reload err = %v, want ErrDecode", err)
 	}
-	raw, err := os.ReadFile(st.journalPath())
-	if err != nil {
-		t.Fatalf("read journal: %v", err)
+	if _, err := os.Stat(st.journalPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("journal err = %v, want not exist", err)
 	}
-	if !strings.Contains(string(raw), `"outcome":"rejected"`) {
-		t.Fatalf("journal = %s, want rejected outcome", raw)
+}
+
+func TestReloadPropagatesActiveReadError(t *testing.T) {
+	st := New(t.TempDir())
+	restore := replaceReadFile(func(string) ([]byte, error) {
+		return nil, fmt.Errorf("forced read error")
+	})
+	defer restore()
+	if _, err := st.Reload(testOptions(testRoster(newTestSigner(t, "act-1", "alice")), "", 0, 1)); !errors.Is(err, ErrDecode) {
+		t.Fatalf("Reload err = %v, want ErrDecode", err)
 	}
 }
 
@@ -209,6 +221,46 @@ func TestWriteActiveChecksExpectedPrior(t *testing.T) {
 	}
 }
 
+func TestWriteActiveChecksLockedCurrentActive(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env1 := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	hash1, err := st.WriteActive(mustJSON(t, env1), testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("WriteActive gen1: %v", err)
+	}
+	env2 := signedManifest(t, cHash, 2, "sha256:genesis", testEnv(), signer)
+	if _, err := st.WriteActive(mustJSON(t, env2), testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, ErrPriorManifest) {
+		t.Fatalf("WriteActive stale prior err = %v, want ErrPriorManifest", err)
+	}
+	env3 := signedManifest(t, cHash, 2, hash1, testEnv(), signer)
+	if _, err := st.WriteActive(mustJSON(t, env3), testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("WriteActive current prior: %v", err)
+	}
+}
+
+func TestWriteActiveRejectsUnreadableCurrentActive(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	if _, err := st.WriteActive(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("WriteActive initial: %v", err)
+	}
+	restore := replaceReadFile(func(path string) ([]byte, error) {
+		if path == st.activePath() {
+			return nil, fmt.Errorf("forced read error")
+		}
+		return nil, fmt.Errorf("unexpected read: %s", path)
+	})
+	defer restore()
+	env2 := signedManifest(t, cHash, 2, "sha256:genesis", testEnv(), signer)
+	if _, err := st.WriteActive(mustJSON(t, env2), testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, ErrDecode) {
+		t.Fatalf("WriteActive err = %v, want ErrDecode", err)
+	}
+}
+
 func TestReloadRejectsInvalidActiveAndJournalsFailure(t *testing.T) {
 	st := New(t.TempDir())
 	if err := os.MkdirAll(st.root, 0o700); err != nil {
@@ -319,7 +371,7 @@ func TestValidateEnvelopeRejectsRosterPurposeMismatch(t *testing.T) {
 	alice := newTestSigner(t, "act-1", "alice")
 	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), alice)
 	roster := testRoster(alice)
-	roster.Body.Keys[0].KeyPurpose = signing.PurposeReceiptSigning.String()
+	roster.Body.Keys[1].KeyPurpose = signing.PurposeReceiptSigning.String()
 	_, err := st.ValidateEnvelope(mustJSON(t, env), testOptions(roster, "", 0, 1))
 	if !errors.Is(err, ErrSignature) {
 		t.Fatalf("ValidateEnvelope err = %v, want ErrSignature", err)
@@ -341,31 +393,39 @@ func TestValidateEnvelopeRejectsStructuralManifest(t *testing.T) {
 func TestLoadContractsRejectsDecodeAndHashMismatch(t *testing.T) {
 	st := New(t.TempDir())
 	badHash := "sha256:" + stringsOf("b", 64)
-	if err := os.MkdirAll(filepath.Dir(st.historyPath(badHash)), 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(mustHistoryPath(t, st, badHash)), 0o700); err != nil {
 		t.Fatalf("mkdir history: %v", err)
 	}
-	if err := os.WriteFile(st.historyPath(badHash), []byte("{"), 0o600); err != nil {
+	if err := os.WriteFile(mustHistoryPath(t, st, badHash), []byte("{"), 0o600); err != nil {
 		t.Fatalf("write bad contract: %v", err)
 	}
 	sel := contract.ManifestSelector{SelectorID: "sha256:s", ContractHash: badHash}
-	if _, err := st.loadContracts([]contract.ManifestSelector{sel}); !errors.Is(err, ErrDecode) {
+	if _, err := st.loadContracts([]contract.ManifestSelector{sel}, Options{}); !errors.Is(err, ErrDecode) {
 		t.Fatalf("decode err = %v, want ErrDecode", err)
 	}
 
 	goodHash := putTestContract(t, st)
 	mismatch := "sha256:" + stringsOf("c", 64)
-	if err := os.Rename(st.historyPath(goodHash), st.historyPath(mismatch)); err != nil {
+	if err := os.Rename(mustHistoryPath(t, st, goodHash), mustHistoryPath(t, st, mismatch)); err != nil {
 		t.Fatalf("rename history: %v", err)
 	}
 	sel.ContractHash = mismatch
-	if _, err := st.loadContracts([]contract.ManifestSelector{sel}); !errors.Is(err, ErrContractHistory) {
+	if _, err := st.loadContracts([]contract.ManifestSelector{sel}, Options{}); !errors.Is(err, ErrContractHistory) {
 		t.Fatalf("mismatch err = %v, want ErrContractHistory", err)
+	}
+}
+
+func TestLoadContractsRejectsMalformedSelectorHashBeforePathUse(t *testing.T) {
+	st := New(t.TempDir())
+	sel := contract.ManifestSelector{SelectorID: "sha256:s", ContractHash: "sha256:../evil"}
+	if _, err := st.loadContracts([]contract.ManifestSelector{sel}, testOptions(testRoster(), "", 0, 1)); !errors.Is(err, ErrContractHistory) {
+		t.Fatalf("loadContracts err = %v, want ErrContractHistory", err)
 	}
 }
 
 func TestPutHistoryContractRejectsDecodeAndHashMismatch(t *testing.T) {
 	st := New(t.TempDir())
-	if _, err := st.PutHistoryContract([]byte("{")); !errors.Is(err, ErrDecode) {
+	if _, err := st.PutHistoryContract([]byte("{"), Options{}); !errors.Is(err, ErrDecode) {
 		t.Fatalf("decode err = %v, want ErrDecode", err)
 	}
 	c := contract.Contract{
@@ -376,8 +436,147 @@ func TestPutHistoryContractRejectsDecodeAndHashMismatch(t *testing.T) {
 		FieldDataClasses: map[string]string{},
 	}
 	raw := mustJSON(t, contract.ContractEnvelope{Body: c, Signature: "ed25519:" + stringsOf("0", 128)})
-	if _, err := st.PutHistoryContract(raw); !errors.Is(err, ErrContractHistory) {
+	if _, err := st.PutHistoryContract(raw, Options{}); !errors.Is(err, ErrContractHistory) {
 		t.Fatalf("hash mismatch err = %v, want ErrContractHistory", err)
+	}
+}
+
+func TestPutHistoryContractRejectsBadContractSignature(t *testing.T) {
+	st := New(t.TempDir())
+	compileSigner := testCompileSigner()
+	c := testContractBody(compileSigner)
+	hash, err := ContractHash(c)
+	if err != nil {
+		t.Fatalf("ContractHash: %v", err)
+	}
+	c.ContractHash = hash
+	raw := mustJSON(t, contract.ContractEnvelope{Body: c, Signature: "ed25519:" + stringsOf("0", 128)})
+	if _, err := st.PutHistoryContract(raw, testOptions(testRoster(), "", 0, 1)); !errors.Is(err, ErrContractSignature) {
+		t.Fatalf("PutHistoryContract err = %v, want ErrContractSignature", err)
+	}
+}
+
+func TestLoadContractsRejectsBadContractSignature(t *testing.T) {
+	st := New(t.TempDir())
+	compileSigner := testCompileSigner()
+	c := testContractBody(compileSigner)
+	hash, err := ContractHash(c)
+	if err != nil {
+		t.Fatalf("ContractHash: %v", err)
+	}
+	c.ContractHash = hash
+	raw := mustJSON(t, contract.ContractEnvelope{Body: c, Signature: "ed25519:" + stringsOf("0", 128)})
+	if err := os.MkdirAll(filepath.Dir(mustHistoryPath(t, st, hash)), 0o700); err != nil {
+		t.Fatalf("mkdir history: %v", err)
+	}
+	if err := os.WriteFile(mustHistoryPath(t, st, hash), raw, 0o600); err != nil {
+		t.Fatalf("write contract: %v", err)
+	}
+	sel := contract.ManifestSelector{SelectorID: "sha256:s", ContractHash: hash}
+	if _, err := st.loadContracts([]contract.ManifestSelector{sel}, testOptions(testRoster(), "", 0, 1)); !errors.Is(err, ErrContractSignature) {
+		t.Fatalf("loadContracts err = %v, want ErrContractSignature", err)
+	}
+}
+
+func TestVerifyContractSignatureRejectsAuthorityFailures(t *testing.T) {
+	compileSigner := testCompileSigner()
+	body := testContractBody(compileSigner)
+	hash, err := ContractHash(body)
+	if err != nil {
+		t.Fatalf("ContractHash: %v", err)
+	}
+	body.ContractHash = hash
+	base := signTestContract(t, body, compileSigner)
+
+	tests := []struct {
+		name   string
+		mutate func(*contract.ContractEnvelope, *signing.LoadedRoster)
+		roster *signing.LoadedRoster
+	}{
+		{
+			name:   "nil_roster",
+			roster: nil,
+		},
+		{
+			name:   "wrong_body_purpose",
+			roster: testRoster(),
+			mutate: func(env *contract.ContractEnvelope, _ *signing.LoadedRoster) {
+				env.Body.KeyPurpose = signing.PurposeReceiptSigning.String()
+			},
+		},
+		{
+			name:   "unknown_key",
+			roster: testRoster(),
+			mutate: func(env *contract.ContractEnvelope, _ *signing.LoadedRoster) {
+				env.Body.SignerKeyID = "missing"
+			},
+		},
+		{
+			name:   "wrong_roster_purpose",
+			roster: testRoster(),
+			mutate: func(_ *contract.ContractEnvelope, roster *signing.LoadedRoster) {
+				roster.Body.Keys[0].KeyPurpose = signing.PurposeReceiptSigning.String()
+			},
+		},
+		{
+			name:   "bad_signature_format",
+			roster: testRoster(),
+			mutate: func(env *contract.ContractEnvelope, _ *signing.LoadedRoster) {
+				env.Signature = "ed25519:aabb"
+			},
+		},
+		{
+			name:   "bad_public_key_hex",
+			roster: testRoster(),
+			mutate: func(_ *contract.ContractEnvelope, roster *signing.LoadedRoster) {
+				roster.Body.Keys[0].PublicKeyHex = "not-hex"
+			},
+		},
+		{
+			name:   "bad_signature_bytes",
+			roster: testRoster(),
+			mutate: func(env *contract.ContractEnvelope, _ *signing.LoadedRoster) {
+				env.Signature = "ed25519:" + stringsOf("0", 128)
+			},
+		},
+		{
+			name:   "preimage_error",
+			roster: testRoster(),
+			mutate: func(env *contract.ContractEnvelope, _ *signing.LoadedRoster) {
+				env.Body.Defaults.Confidence = map[string]any{"bad": make(chan int)}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := base
+			roster := tt.roster
+			if roster != nil {
+				copied := *roster
+				copied.Body.Keys = append([]contract.KeyInfo(nil), roster.Body.Keys...)
+				roster = &copied
+			}
+			if tt.mutate != nil {
+				tt.mutate(&env, roster)
+			}
+			if err := verifyContractSignature(env, testOptions(roster, "", 0, 1)); !errors.Is(err, ErrContractSignature) {
+				t.Fatalf("verifyContractSignature err = %v, want ErrContractSignature", err)
+			}
+		})
+	}
+}
+
+func TestHashPathValidationRejectsMalformedHashes(t *testing.T) {
+	for _, hash := range []string{
+		"not-sha256:" + stringsOf("0", 64),
+		"sha256:" + stringsOf("0", 63),
+		"sha256:" + stringsOf("A", 64),
+		"sha256:" + stringsOf("0", 63) + "/",
+	} {
+		if _, err := hashFilename(hash, jsonExt); !errors.Is(err, ErrContractHistory) {
+			t.Fatalf("hashFilename(%q) err = %v, want ErrContractHistory", hash, err)
+		}
 	}
 }
 
@@ -394,7 +593,7 @@ func TestLatestAcceptedRejectsBadHistoryAndMissingHistory(t *testing.T) {
 	}
 	signer := newTestSigner(t, "act-1", "alice")
 	env := signedManifest(t, "sha256:"+stringsOf("d", 64), 1, "sha256:genesis", testEnv(), signer)
-	if err := os.WriteFile(filepath.Join(st.manifestDir(), hashFilename("sha256:"+stringsOf("e", 64), jsonExt)), mustJSON(t, env), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(st.manifestDir(), mustHashFilename(t, "sha256:"+stringsOf("e", 64), jsonExt)), mustJSON(t, env), 0o600); err != nil {
 		t.Fatalf("write bad accepted manifest: %v", err)
 	}
 	if _, err := st.LatestAccepted(testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, ErrContractHistory) {
@@ -447,10 +646,10 @@ func TestReloadAcceptedManifestWriteConflict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ValidateEnvelope: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(st.manifestPath(state.ManifestHash)), 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(mustManifestPath(t, st, state.ManifestHash)), 0o700); err != nil {
 		t.Fatalf("mkdir manifest: %v", err)
 	}
-	if err := os.WriteFile(st.manifestPath(state.ManifestHash), []byte("different\n"), 0o600); err != nil {
+	if err := os.WriteFile(mustManifestPath(t, st, state.ManifestHash), []byte("different\n"), 0o600); err != nil {
 		t.Fatalf("write conflicting manifest: %v", err)
 	}
 	if err := os.WriteFile(st.activePath(), raw, 0o600); err != nil {
@@ -475,10 +674,10 @@ func TestReloadReturnsJournalAppendFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("encodeForStorage: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(st.manifestPath(state.ManifestHash)), 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(mustManifestPath(t, st, state.ManifestHash)), 0o700); err != nil {
 		t.Fatalf("mkdir manifest: %v", err)
 	}
-	if err := os.WriteFile(st.manifestPath(state.ManifestHash), accepted, 0o600); err != nil {
+	if err := os.WriteFile(mustManifestPath(t, st, state.ManifestHash), accepted, 0o600); err != nil {
 		t.Fatalf("write accepted: %v", err)
 	}
 	if err := os.WriteFile(st.activePath(), raw, 0o600); err != nil {
@@ -519,7 +718,7 @@ func TestReloadDoesNotPersistAcceptedWhenJournalFails(t *testing.T) {
 	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); err == nil {
 		t.Fatal("Reload returned nil error with journal open failure")
 	}
-	if _, err := os.Stat(st.manifestPath(state.ManifestHash)); !errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(mustManifestPath(t, st, state.ManifestHash)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("accepted manifest err = %v, want not exist", err)
 	}
 }
@@ -583,7 +782,7 @@ func TestPutHistoryContractRejectsStructuralContract(t *testing.T) {
 	}
 	c.ContractHash = hash
 	raw := mustJSON(t, contract.ContractEnvelope{Body: c, Signature: "ed25519:" + stringsOf("0", 128)})
-	if _, err := st.PutHistoryContract(raw); !errors.Is(err, ErrStructural) {
+	if _, err := st.PutHistoryContract(raw, Options{}); !errors.Is(err, ErrStructural) {
 		t.Fatalf("PutHistoryContract err = %v, want ErrStructural", err)
 	}
 }
@@ -591,13 +790,14 @@ func TestPutHistoryContractRejectsStructuralContract(t *testing.T) {
 func TestPutHistoryContractRejectsWriteOnceConflict(t *testing.T) {
 	st := New(t.TempDir())
 	cHash := putTestContract(t, st)
-	if err := os.WriteFile(st.historyPath(cHash), []byte("different\n"), 0o600); err != nil {
+	if err := os.WriteFile(mustHistoryPath(t, st, cHash), []byte("different\n"), 0o600); err != nil {
 		t.Fatalf("overwrite history: %v", err)
 	}
+	compileSigner := testCompileSigner()
 	c := contract.Contract{
 		SchemaVersion:    contract.SchemaVersionContract,
 		ContractKind:     contract.ContractKind,
-		SignerKeyID:      "compile-key",
+		SignerKeyID:      compileSigner.keyID,
 		KeyPurpose:       signing.PurposeContractCompileSigning.String(),
 		DataClassRoot:    "internal",
 		FieldDataClasses: map[string]string{},
@@ -608,8 +808,8 @@ func TestPutHistoryContractRejectsWriteOnceConflict(t *testing.T) {
 		t.Fatalf("ContractHash: %v", err)
 	}
 	c.ContractHash = hash
-	raw := mustJSON(t, contract.ContractEnvelope{Body: c, Signature: "ed25519:" + stringsOf("0", 128)})
-	if _, err := st.PutHistoryContract(raw); !errors.Is(err, ErrWriteOnceConflict) {
+	raw := mustJSON(t, signTestContract(t, c, compileSigner))
+	if _, err := st.PutHistoryContract(raw, testOptions(testRoster(), "", 0, 1)); !errors.Is(err, ErrWriteOnceConflict) {
 		t.Fatalf("PutHistoryContract err = %v, want ErrWriteOnceConflict", err)
 	}
 }
@@ -619,7 +819,7 @@ func TestLatestAcceptedRejectsReadAndDecodeErrors(t *testing.T) {
 	if err := os.MkdirAll(st.manifestDir(), 0o700); err != nil {
 		t.Fatalf("mkdir manifests: %v", err)
 	}
-	name := hashFilename("sha256:"+stringsOf("0", 64), jsonExt)
+	name := mustHashFilename(t, "sha256:"+stringsOf("0", 64), jsonExt)
 	if err := os.WriteFile(filepath.Join(st.manifestDir(), name), []byte("{"), 0o600); err != nil {
 		t.Fatalf("write bad manifest: %v", err)
 	}
@@ -633,6 +833,49 @@ func TestLatestAcceptedRejectsReadAndDecodeErrors(t *testing.T) {
 	if _, err := st.LatestAccepted(Options{}); err == nil {
 		t.Fatal("LatestAccepted returned nil error with read failure")
 	}
+}
+
+func TestLatestAcceptedRejectsStructuralAndEnvironmentErrors(t *testing.T) {
+	t.Run("structural", func(t *testing.T) {
+		st := New(t.TempDir())
+		cHash := putTestContract(t, st)
+		signer := newTestSigner(t, "act-1", "alice")
+		env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+		env.Body.SelectorSetHash = "sha256:wrong"
+		hash, err := ActiveManifestHash(env.Body)
+		if err != nil {
+			t.Fatalf("ActiveManifestHash: %v", err)
+		}
+		if err := os.MkdirAll(st.manifestDir(), 0o700); err != nil {
+			t.Fatalf("mkdir manifests: %v", err)
+		}
+		if err := os.WriteFile(mustManifestPath(t, st, hash), mustJSON(t, env), 0o600); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+		if _, err := st.LatestAccepted(testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, ErrStructural) {
+			t.Fatalf("LatestAccepted err = %v, want ErrStructural", err)
+		}
+	})
+
+	t.Run("environment", func(t *testing.T) {
+		st := New(t.TempDir())
+		cHash := putTestContract(t, st)
+		signer := newTestSigner(t, "act-1", "alice")
+		env := signedManifest(t, cHash, 1, "sha256:genesis", contract.Environment{ID: "dev", Tenant: "tenant", DeploymentID: "deployment"}, signer)
+		hash, err := ActiveManifestHash(env.Body)
+		if err != nil {
+			t.Fatalf("ActiveManifestHash: %v", err)
+		}
+		if err := os.MkdirAll(st.manifestDir(), 0o700); err != nil {
+			t.Fatalf("mkdir manifests: %v", err)
+		}
+		if err := os.WriteFile(mustManifestPath(t, st, hash), mustJSON(t, env), 0o600); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+		if _, err := st.LatestAccepted(testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, ErrEnvironmentMismatch) {
+			t.Fatalf("LatestAccepted err = %v, want ErrEnvironmentMismatch", err)
+		}
+	})
 }
 
 func TestLatestAcceptedSkipsNonManifestEntries(t *testing.T) {
@@ -661,7 +904,7 @@ func TestLatestAcceptedRejectsForgedManifestWithMatchingFilename(t *testing.T) {
 	if err := os.MkdirAll(st.manifestDir(), 0o700); err != nil {
 		t.Fatalf("mkdir manifests: %v", err)
 	}
-	if err := os.WriteFile(st.manifestPath(hash), mustJSON(t, env), 0o600); err != nil {
+	if err := os.WriteFile(mustManifestPath(t, st, hash), mustJSON(t, env), 0o600); err != nil {
 		t.Fatalf("write forged manifest: %v", err)
 	}
 	if _, err := st.LatestAccepted(testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, ErrSignature) {
@@ -680,7 +923,7 @@ func TestLatestAcceptedRejectsMissingContractHistory(t *testing.T) {
 	if err := os.MkdirAll(st.manifestDir(), 0o700); err != nil {
 		t.Fatalf("mkdir manifests: %v", err)
 	}
-	if err := os.WriteFile(st.manifestPath(hash), mustJSON(t, env), 0o600); err != nil {
+	if err := os.WriteFile(mustManifestPath(t, st, hash), mustJSON(t, env), 0o600); err != nil {
 		t.Fatalf("write accepted manifest: %v", err)
 	}
 	if _, err := st.LatestAccepted(testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, ErrContractHistory) {
@@ -741,7 +984,7 @@ func TestValidateEnvelopeRejectsBadRosterPublicKeyHex(t *testing.T) {
 	signer := newTestSigner(t, "act-1", "alice")
 	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
 	roster := testRoster(signer)
-	roster.Body.Keys[0].PublicKeyHex = "not-hex"
+	roster.Body.Keys[1].PublicKeyHex = "not-hex"
 	_, err := st.ValidateEnvelope(mustJSON(t, env), testOptions(roster, "", 0, 1))
 	if !errors.Is(err, ErrSignature) {
 		t.Fatalf("ValidateEnvelope err = %v, want ErrSignature", err)
@@ -846,14 +1089,14 @@ func TestLoadContractsRejectsStructurallyInvalidContract(t *testing.T) {
 	}
 	c.ContractHash = hash
 	raw := mustJSON(t, contract.ContractEnvelope{Body: c, Signature: "ed25519:" + stringsOf("0", 128)})
-	if err := os.MkdirAll(filepath.Dir(st.historyPath(hash)), 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(mustHistoryPath(t, st, hash)), 0o700); err != nil {
 		t.Fatalf("mkdir history: %v", err)
 	}
-	if err := os.WriteFile(st.historyPath(hash), raw, 0o600); err != nil {
+	if err := os.WriteFile(mustHistoryPath(t, st, hash), raw, 0o600); err != nil {
 		t.Fatalf("write contract: %v", err)
 	}
 	sel := contract.ManifestSelector{SelectorID: "sha256:s", ContractHash: hash}
-	if _, err := st.loadContracts([]contract.ManifestSelector{sel}); !errors.Is(err, ErrStructural) {
+	if _, err := st.loadContracts([]contract.ManifestSelector{sel}, Options{}); !errors.Is(err, ErrStructural) {
 		t.Fatalf("loadContracts err = %v, want ErrStructural", err)
 	}
 }
@@ -906,22 +1149,15 @@ func (f fakeWritableFile) Close() error {
 
 func putTestContract(t *testing.T, st Store) string {
 	t.Helper()
-	c := contract.Contract{
-		SchemaVersion:    contract.SchemaVersionContract,
-		ContractKind:     contract.ContractKind,
-		SignerKeyID:      "compile-key",
-		KeyPurpose:       signing.PurposeContractCompileSigning.String(),
-		DataClassRoot:    "internal",
-		FieldDataClasses: map[string]string{},
-		Selector:         contract.Selector{Agent: "agent-a", SelectorID: "sha256:selector"},
-	}
+	compileSigner := testCompileSigner()
+	c := testContractBody(compileSigner)
 	hash, err := ContractHash(c)
 	if err != nil {
 		t.Fatalf("ContractHash: %v", err)
 	}
 	c.ContractHash = hash
-	raw := mustJSON(t, contract.ContractEnvelope{Body: c, Signature: "ed25519:" + stringsOf("0", 128)})
-	got, err := st.PutHistoryContract(raw)
+	raw := mustJSON(t, signTestContract(t, c, compileSigner))
+	got, err := st.PutHistoryContract(raw, testOptions(testRoster(), "", 0, 1))
 	if err != nil {
 		t.Fatalf("PutHistoryContract: %v", err)
 	}
@@ -929,6 +1165,28 @@ func putTestContract(t *testing.T, st Store) string {
 		t.Fatalf("PutHistoryContract hash = %q, want %q", got, hash)
 	}
 	return hash
+}
+
+func testContractBody(signer testSigner) contract.Contract {
+	return contract.Contract{
+		SchemaVersion:    contract.SchemaVersionContract,
+		ContractKind:     contract.ContractKind,
+		SignerKeyID:      signer.keyID,
+		KeyPurpose:       signing.PurposeContractCompileSigning.String(),
+		DataClassRoot:    "internal",
+		FieldDataClasses: map[string]string{},
+		Selector:         contract.Selector{Agent: "agent-a", SelectorID: "sha256:selector"},
+	}
+}
+
+func signTestContract(t *testing.T, body contract.Contract, signer testSigner) contract.ContractEnvelope {
+	t.Helper()
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage: %v", err)
+	}
+	sig := ed25519.Sign(signer.priv, preimage)
+	return contract.ContractEnvelope{Body: body, Signature: "ed25519:" + hex.EncodeToString(sig)}
 }
 
 func signedManifest(t *testing.T, cHash string, generation uint64, prior string, env contract.Environment, signers ...testSigner) contract.ActiveManifestEnvelope {
@@ -984,18 +1242,33 @@ func testOptions(roster *signing.LoadedRoster, previousHash string, previousGene
 }
 
 func testRoster(signers ...testSigner) *signing.LoadedRoster {
-	keys := make([]contract.KeyInfo, 0, len(signers))
+	entries := make([]testRosterKey, 0, len(signers)+1)
+	entries = append(entries, testRosterKey{signer: testCompileSigner(), purpose: signing.PurposeContractCompileSigning})
 	for _, signer := range signers {
+		entries = append(entries, testRosterKey{signer: signer, purpose: signing.PurposeContractActivationSigning})
+	}
+	return testRosterWithKeys(entries...)
+}
+
+func testRosterWithKeys(entries ...testRosterKey) *signing.LoadedRoster {
+	keys := make([]contract.KeyInfo, 0, len(entries))
+	for _, entry := range entries {
 		keys = append(keys, contract.KeyInfo{
-			KeyID:        signer.keyID,
-			KeyPurpose:   signing.PurposeContractActivationSigning.String(),
-			PublicKeyHex: hex.EncodeToString(signer.pub),
+			KeyID:        entry.signer.keyID,
+			KeyPurpose:   entry.purpose.String(),
+			PublicKeyHex: hex.EncodeToString(entry.signer.pub),
 			ValidFrom:    testNow.Add(-time.Hour).Format(time.RFC3339),
 			Status:       contract.KeyStatusActive,
-			Principal:    signer.principal,
+			Principal:    entry.signer.principal,
 		})
 	}
 	return &signing.LoadedRoster{Body: contract.KeyRoster{Keys: keys}}
+}
+
+func testCompileSigner() testSigner {
+	priv := ed25519.NewKeyFromSeed([]byte("0123456789abcdef0123456789abcdef"))
+	pub := priv.Public().(ed25519.PublicKey)
+	return testSigner{keyID: "compile-key", principal: "compiler", pub: pub, priv: priv}
 }
 
 func newTestSigner(t *testing.T, keyID, principal string) testSigner {
@@ -1018,6 +1291,33 @@ func mustJSON(t *testing.T, v any) []byte {
 		t.Fatalf("Marshal: %v", err)
 	}
 	return append(raw, '\n')
+}
+
+func mustHistoryPath(t *testing.T, st Store, hash string) string {
+	t.Helper()
+	path, err := st.historyPath(hash)
+	if err != nil {
+		t.Fatalf("historyPath: %v", err)
+	}
+	return path
+}
+
+func mustManifestPath(t *testing.T, st Store, hash string) string {
+	t.Helper()
+	path, err := st.manifestPath(hash)
+	if err != nil {
+		t.Fatalf("manifestPath: %v", err)
+	}
+	return path
+}
+
+func mustHashFilename(t *testing.T, hash, ext string) string {
+	t.Helper()
+	name, err := hashFilename(hash, ext)
+	if err != nil {
+		t.Fatalf("hashFilename: %v", err)
+	}
+	return name
 }
 
 func stringsOf(s string, n int) string {

--- a/internal/contract/store/store_test.go
+++ b/internal/contract/store/store_test.go
@@ -743,7 +743,7 @@ func TestReloadReturnsJournalAppendFailure(t *testing.T) {
 		if strings.HasSuffix(name, journalFilename) {
 			return nil, fmt.Errorf("forced open error")
 		}
-		return os.OpenFile(name, flag, perm) //nolint:gosec // Test seam delegates to the production path for non-journal files.
+		return os.OpenFile(filepath.Clean(name), flag, perm)
 	})
 	defer restore()
 	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); err == nil {
@@ -768,7 +768,7 @@ func TestReloadPersistsAcceptedBeforeJournalAppend(t *testing.T) {
 		if strings.HasSuffix(name, journalFilename) {
 			return nil, fmt.Errorf("forced open error")
 		}
-		return os.OpenFile(name, flag, perm) //nolint:gosec // Test seam delegates to the production path for non-journal files.
+		return os.OpenFile(filepath.Clean(name), flag, perm)
 	})
 	defer restore()
 	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); err == nil {

--- a/internal/contract/store/store_test.go
+++ b/internal/contract/store/store_test.go
@@ -211,6 +211,59 @@ func TestLatestAcceptedUsesImmutableManifestHistory(t *testing.T) {
 	}
 }
 
+func TestLatestAcceptedSkipsBrokenPriorChain(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env1 := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	hash1, err := st.WriteActive(mustJSON(t, env1), testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("WriteActive gen1: %v", err)
+	}
+	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("Reload gen1: %v", err)
+	}
+
+	missingPrior := "sha256:" + stringsOf("a", 64)
+	env3 := signedManifest(t, cHash, 3, missingPrior, testEnv(), signer)
+	hash3, err := ActiveManifestHash(env3.Body)
+	if err != nil {
+		t.Fatalf("ActiveManifestHash gen3: %v", err)
+	}
+	if err := os.WriteFile(mustManifestPath(t, st, hash3), mustJSON(t, env3), 0o600); err != nil {
+		t.Fatalf("write broken-chain manifest: %v", err)
+	}
+
+	latest, err := st.LatestAccepted(testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("LatestAccepted: %v", err)
+	}
+	if latest.ManifestHash != hash1 || latest.Envelope.Body.Generation != 1 {
+		t.Fatalf("latest = (%s, gen %d), want gen1 %s", latest.ManifestHash, latest.Envelope.Body.Generation, hash1)
+	}
+}
+
+func TestLatestAcceptedRejectsOnlyBrokenPriorChain(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	missingPrior := "sha256:" + stringsOf("b", 64)
+	env2 := signedManifest(t, cHash, 2, missingPrior, testEnv(), signer)
+	hash2, err := ActiveManifestHash(env2.Body)
+	if err != nil {
+		t.Fatalf("ActiveManifestHash gen2: %v", err)
+	}
+	if err := os.MkdirAll(st.manifestDir(), 0o700); err != nil {
+		t.Fatalf("mkdir manifests: %v", err)
+	}
+	if err := os.WriteFile(mustManifestPath(t, st, hash2), mustJSON(t, env2), 0o600); err != nil {
+		t.Fatalf("write broken-chain manifest: %v", err)
+	}
+	if _, err := st.LatestAccepted(testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("LatestAccepted err = %v, want os.ErrNotExist", err)
+	}
+}
+
 func TestWriteActiveChecksExpectedPrior(t *testing.T) {
 	st := New(t.TempDir())
 	cHash := putTestContract(t, st)
@@ -658,6 +711,9 @@ func TestReloadAcceptedManifestWriteConflict(t *testing.T) {
 	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, ErrWriteOnceConflict) {
 		t.Fatalf("Reload err = %v, want ErrWriteOnceConflict", err)
 	}
+	if _, err := os.Stat(st.journalPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("journal err = %v, want not exist", err)
+	}
 }
 
 func TestReloadReturnsJournalAppendFailure(t *testing.T) {
@@ -695,7 +751,7 @@ func TestReloadReturnsJournalAppendFailure(t *testing.T) {
 	}
 }
 
-func TestReloadDoesNotPersistAcceptedWhenJournalFails(t *testing.T) {
+func TestReloadPersistsAcceptedBeforeJournalAppend(t *testing.T) {
 	st := New(t.TempDir())
 	cHash := putTestContract(t, st)
 	signer := newTestSigner(t, "act-1", "alice")
@@ -718,8 +774,8 @@ func TestReloadDoesNotPersistAcceptedWhenJournalFails(t *testing.T) {
 	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); err == nil {
 		t.Fatal("Reload returned nil error with journal open failure")
 	}
-	if _, err := os.Stat(mustManifestPath(t, st, state.ManifestHash)); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("accepted manifest err = %v, want not exist", err)
+	if _, err := os.Stat(mustManifestPath(t, st, state.ManifestHash)); err != nil {
+		t.Fatalf("accepted manifest missing after journal failure: %v", err)
 	}
 }
 

--- a/internal/contract/store/store_test.go
+++ b/internal/contract/store/store_test.go
@@ -194,6 +194,9 @@ func TestLatestAcceptedUsesImmutableManifestHistory(t *testing.T) {
 	if latest.Envelope.Body.Generation != 2 {
 		t.Fatalf("latest generation = %d, want 2", latest.Envelope.Body.Generation)
 	}
+	if len(latest.Contracts) != 1 {
+		t.Fatalf("latest contracts len = %d, want 1", len(latest.Contracts))
+	}
 }
 
 func TestWriteActiveChecksExpectedPrior(t *testing.T) {
@@ -666,6 +669,25 @@ func TestLatestAcceptedRejectsForgedManifestWithMatchingFilename(t *testing.T) {
 	}
 }
 
+func TestLatestAcceptedRejectsMissingContractHistory(t *testing.T) {
+	st := New(t.TempDir())
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, "sha256:"+stringsOf("f", 64), 1, "sha256:genesis", testEnv(), signer)
+	hash, err := ActiveManifestHash(env.Body)
+	if err != nil {
+		t.Fatalf("ActiveManifestHash: %v", err)
+	}
+	if err := os.MkdirAll(st.manifestDir(), 0o700); err != nil {
+		t.Fatalf("mkdir manifests: %v", err)
+	}
+	if err := os.WriteFile(st.manifestPath(hash), mustJSON(t, env), 0o600); err != nil {
+		t.Fatalf("write accepted manifest: %v", err)
+	}
+	if _, err := st.LatestAccepted(testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, ErrContractHistory) {
+		t.Fatalf("LatestAccepted err = %v, want ErrContractHistory", err)
+	}
+}
+
 func TestValidateEnvelopeAllowsEmptyExpectedEnvironmentAndDefaultSignatureCount(t *testing.T) {
 	st := New(t.TempDir())
 	cHash := putTestContract(t, st)
@@ -727,33 +749,37 @@ func TestValidateEnvelopeRejectsBadRosterPublicKeyHex(t *testing.T) {
 }
 
 func TestWriteOncePropagatesFilesystemErrors(t *testing.T) {
-	restoreMkdir := replaceMkdirAll(func(string, os.FileMode) error {
-		return fmt.Errorf("forced mkdir error")
+	t.Run("mkdir", func(t *testing.T) {
+		restore := replaceMkdirAll(func(string, os.FileMode) error {
+			return fmt.Errorf("forced mkdir error")
+		})
+		t.Cleanup(restore)
+		if err := writeOnce(filepath.Join(t.TempDir(), "a", "object"), []byte("x")); err == nil {
+			t.Fatal("writeOnce returned nil with mkdir failure")
+		}
 	})
-	if err := writeOnce(filepath.Join(t.TempDir(), "a", "object"), []byte("x")); err == nil {
-		t.Fatal("writeOnce returned nil with mkdir failure")
-	}
-	restoreMkdir()
-
-	restoreRead := replaceReadFile(func(string) ([]byte, error) {
-		return nil, fmt.Errorf("forced read error")
+	t.Run("read", func(t *testing.T) {
+		restore := replaceReadFile(func(string) ([]byte, error) {
+			return nil, fmt.Errorf("forced read error")
+		})
+		t.Cleanup(restore)
+		if err := writeOnce(filepath.Join(t.TempDir(), "object"), []byte("x")); err == nil {
+			t.Fatal("writeOnce returned nil with read failure")
+		}
 	})
-	if err := writeOnce(filepath.Join(t.TempDir(), "object"), []byte("x")); err == nil {
-		t.Fatal("writeOnce returned nil with read failure")
-	}
-	restoreRead()
-
-	restoreRead = replaceReadFile(func(string) ([]byte, error) {
-		return nil, os.ErrNotExist
+	t.Run("atomic", func(t *testing.T) {
+		restoreRead := replaceReadFile(func(string) ([]byte, error) {
+			return nil, os.ErrNotExist
+		})
+		t.Cleanup(restoreRead)
+		restoreAtomic := replaceAtomicWrite(func(string, []byte, os.FileMode) error {
+			return fmt.Errorf("forced atomic write error")
+		})
+		t.Cleanup(restoreAtomic)
+		if err := writeOnce(filepath.Join(t.TempDir(), "object"), []byte("x")); err == nil {
+			t.Fatal("writeOnce returned nil with atomic write failure")
+		}
 	})
-	restoreAtomic := replaceAtomicWrite(func(string, []byte, os.FileMode) error {
-		return fmt.Errorf("forced atomic write error")
-	})
-	if err := writeOnce(filepath.Join(t.TempDir(), "object"), []byte("x")); err == nil {
-		t.Fatal("writeOnce returned nil with atomic write failure")
-	}
-	restoreAtomic()
-	restoreRead()
 }
 
 func TestEncodeForStoragePropagatesMarshalError(t *testing.T) {
@@ -764,27 +790,30 @@ func TestEncodeForStoragePropagatesMarshalError(t *testing.T) {
 	if _, err := encodeForStorage(struct{}{}); err == nil {
 		t.Fatal("encodeForStorage returned nil with marshal failure")
 	}
-	if err := New(t.TempDir()).appendJournal(JournalEntry{}); err == nil {
+	if err := appendJournalForTest(New(t.TempDir())); err == nil {
 		t.Fatal("appendJournal returned nil with marshal failure")
 	}
 }
 
 func TestAppendJournalPropagatesWriteAndCloseErrors(t *testing.T) {
-	restoreOpen := replaceOpenFile(func(string, int, os.FileMode) (writableFile, error) {
-		return fakeWritableFile{writeErr: fmt.Errorf("forced write error")}, nil
+	t.Run("write", func(t *testing.T) {
+		restore := replaceOpenFile(func(string, int, os.FileMode) (writableFile, error) {
+			return fakeWritableFile{writeErr: fmt.Errorf("forced write error")}, nil
+		})
+		t.Cleanup(restore)
+		if err := appendJournalForTest(New(t.TempDir())); err == nil {
+			t.Fatal("appendJournal returned nil with write failure")
+		}
 	})
-	if err := New(t.TempDir()).appendJournal(JournalEntry{}); err == nil {
-		t.Fatal("appendJournal returned nil with write failure")
-	}
-	restoreOpen()
-
-	restoreOpen = replaceOpenFile(func(string, int, os.FileMode) (writableFile, error) {
-		return fakeWritableFile{closeErr: fmt.Errorf("forced close error")}, nil
+	t.Run("close", func(t *testing.T) {
+		restore := replaceOpenFile(func(string, int, os.FileMode) (writableFile, error) {
+			return fakeWritableFile{closeErr: fmt.Errorf("forced close error")}, nil
+		})
+		t.Cleanup(restore)
+		if err := appendJournalForTest(New(t.TempDir())); err == nil {
+			t.Fatal("appendJournal returned nil with close failure")
+		}
 	})
-	if err := New(t.TempDir()).appendJournal(JournalEntry{}); err == nil {
-		t.Fatal("appendJournal returned nil with close failure")
-	}
-	restoreOpen()
 }
 
 func TestAppendJournalPropagatesMkdirError(t *testing.T) {
@@ -792,9 +821,15 @@ func TestAppendJournalPropagatesMkdirError(t *testing.T) {
 		return fmt.Errorf("forced mkdir error")
 	})
 	defer restore()
-	if err := New(t.TempDir()).appendJournal(JournalEntry{}); err == nil {
+	if err := appendJournalForTest(New(t.TempDir())); err == nil {
 		t.Fatal("appendJournal returned nil with mkdir failure")
 	}
+}
+
+func appendJournalForTest(st Store) error {
+	return st.withLock(func() error {
+		return st.appendJournalLocked(JournalEntry{Outcome: "forced"})
+	})
 }
 
 func TestLoadContractsRejectsStructurallyInvalidContract(t *testing.T) {

--- a/internal/contract/store/store_test.go
+++ b/internal/contract/store/store_test.go
@@ -1,0 +1,994 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+var testNow = time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+
+type testSigner struct {
+	keyID     string
+	principal string
+	pub       ed25519.PublicKey
+	priv      ed25519.PrivateKey
+}
+
+func TestReloadAcceptsSignedManifestAndPersistsAccepted(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	raw := mustJSON(t, env)
+	hash, err := st.WriteActive(raw, testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("WriteActive: %v", err)
+	}
+	state, err := st.Reload(testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if state.ManifestHash != hash {
+		t.Fatalf("manifest hash = %q, want %q", state.ManifestHash, hash)
+	}
+	if len(state.Contracts) != 1 {
+		t.Fatalf("contracts len = %d, want 1", len(state.Contracts))
+	}
+	if _, err := os.Stat(state.AcceptedPath); err != nil {
+		t.Fatalf("accepted manifest missing: %v", err)
+	}
+	if _, err := os.Stat(st.journalPath()); err != nil {
+		t.Fatalf("journal missing: %v", err)
+	}
+}
+
+func TestReloadReadOnlyDoesNotPersistAcceptedOrJournal(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	if _, err := st.WriteActive(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("WriteActive: %v", err)
+	}
+	opts := testOptions(testRoster(signer), "", 0, 1)
+	opts.ReadOnly = true
+	if _, err := st.Reload(opts); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if _, err := os.Stat(st.manifestDir()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("manifest dir err = %v, want not exist", err)
+	}
+	if _, err := os.Stat(st.journalPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("journal err = %v, want not exist", err)
+	}
+}
+
+func TestReloadReadOnlyJournalsRejections(t *testing.T) {
+	st := New(t.TempDir())
+	if err := os.MkdirAll(st.root, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(st.activePath(), []byte(`{"body":`), 0o600); err != nil {
+		t.Fatalf("write active: %v", err)
+	}
+	opts := testOptions(testRoster(newTestSigner(t, "act-1", "alice")), "", 0, 1)
+	opts.ReadOnly = true
+	if _, err := st.Reload(opts); !errors.Is(err, ErrDecode) {
+		t.Fatalf("Reload err = %v, want ErrDecode", err)
+	}
+	raw, err := os.ReadFile(st.journalPath())
+	if err != nil {
+		t.Fatalf("read journal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"outcome":"rejected"`) {
+		t.Fatalf("journal = %s, want rejected outcome", raw)
+	}
+}
+
+func TestReloadRejectsEnvironmentMismatch(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", contract.Environment{ID: "dev", Tenant: "tenant", DeploymentID: "dep"}, signer)
+	_, err := st.ValidateEnvelope(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrEnvironmentMismatch) {
+		t.Fatalf("ValidateEnvelope err = %v, want ErrEnvironmentMismatch", err)
+	}
+}
+
+func TestReloadRequiresDistinctDualControl(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	alice := newTestSigner(t, "act-1", "alice")
+	bob := newTestSigner(t, "act-2", "bob")
+	one := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), alice)
+	if _, err := st.ValidateEnvelope(mustJSON(t, one), testOptions(testRoster(alice, bob), "", 0, 2)); !errors.Is(err, ErrDualControl) {
+		t.Fatalf("one signature err = %v, want ErrDualControl", err)
+	}
+	two := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), alice, bob)
+	if _, err := st.ValidateEnvelope(mustJSON(t, two), testOptions(testRoster(alice, bob), "", 0, 2)); err != nil {
+		t.Fatalf("two signatures ValidateEnvelope: %v", err)
+	}
+}
+
+func TestReloadRejectsPriorAndGenerationRegressions(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 2, "sha256:old", testEnv(), signer)
+	opts := testOptions(testRoster(signer), "sha256:current", 1, 1)
+	if _, err := st.ValidateEnvelope(mustJSON(t, env), opts); !errors.Is(err, ErrPriorManifest) {
+		t.Fatalf("prior err = %v, want ErrPriorManifest", err)
+	}
+	opts.PreviousHash = "sha256:old"
+	opts.PreviousGeneration = 2
+	if _, err := st.ValidateEnvelope(mustJSON(t, env), opts); !errors.Is(err, ErrGeneration) {
+		t.Fatalf("generation err = %v, want ErrGeneration", err)
+	}
+}
+
+func TestReloadRejectsMissingContractHistory(t *testing.T) {
+	st := New(t.TempDir())
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, "sha256:"+stringsOf("a", 64), 1, "sha256:genesis", testEnv(), signer)
+	_, err := st.ValidateEnvelope(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrContractHistory) {
+		t.Fatalf("ValidateEnvelope err = %v, want ErrContractHistory", err)
+	}
+}
+
+func TestWriteOnceRejectsDifferentBytes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "object.json")
+	if err := writeOnce(path, []byte("same\n")); err != nil {
+		t.Fatalf("writeOnce first: %v", err)
+	}
+	if err := writeOnce(path, []byte("same\n")); err != nil {
+		t.Fatalf("writeOnce same: %v", err)
+	}
+	if err := writeOnce(path, []byte("different\n")); !errors.Is(err, ErrWriteOnceConflict) {
+		t.Fatalf("writeOnce different err = %v, want ErrWriteOnceConflict", err)
+	}
+}
+
+func TestLatestAcceptedUsesImmutableManifestHistory(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env1 := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	raw1 := mustJSON(t, env1)
+	hash1, err := st.WriteActive(raw1, testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("WriteActive gen1: %v", err)
+	}
+	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("Reload gen1: %v", err)
+	}
+	env2 := signedManifest(t, cHash, 2, hash1, testEnv(), signer)
+	if _, err := st.WriteActive(mustJSON(t, env2), testOptions(testRoster(signer), hash1, 1, 1)); err != nil {
+		t.Fatalf("WriteActive gen2: %v", err)
+	}
+	if _, err := st.Reload(testOptions(testRoster(signer), hash1, 1, 1)); err != nil {
+		t.Fatalf("Reload gen2: %v", err)
+	}
+	if err := os.WriteFile(st.journalPath(), []byte(`{"outcome":"accepted","generation":99}`+"\n"), 0o600); err != nil {
+		t.Fatalf("tamper journal: %v", err)
+	}
+	latest, err := st.LatestAccepted(testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("LatestAccepted: %v", err)
+	}
+	if latest.Envelope.Body.Generation != 2 {
+		t.Fatalf("latest generation = %d, want 2", latest.Envelope.Body.Generation)
+	}
+}
+
+func TestWriteActiveChecksExpectedPrior(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:actual", testEnv(), signer)
+	if _, err := st.WriteActive(mustJSON(t, env), testOptions(testRoster(signer), "sha256:other", 0, 1)); !errors.Is(err, ErrPriorManifest) {
+		t.Fatalf("WriteActive err = %v, want ErrPriorManifest", err)
+	}
+}
+
+func TestReloadRejectsInvalidActiveAndJournalsFailure(t *testing.T) {
+	st := New(t.TempDir())
+	if err := os.MkdirAll(st.root, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(st.activePath(), []byte(`{"body":`), 0o600); err != nil {
+		t.Fatalf("write active: %v", err)
+	}
+	_, err := st.Reload(testOptions(testRoster(newTestSigner(t, "act-1", "alice")), "", 0, 1))
+	if !errors.Is(err, ErrDecode) {
+		t.Fatalf("Reload err = %v, want ErrDecode", err)
+	}
+	raw, err := os.ReadFile(st.journalPath())
+	if err != nil {
+		t.Fatalf("read journal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"outcome":"rejected"`) {
+		t.Fatalf("journal = %s, want rejected outcome", raw)
+	}
+}
+
+func TestValidateEnvelopeRejectsSignatureAuthorityFailures(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	alice := newTestSigner(t, "act-1", "alice")
+	base := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), alice)
+
+	tests := []struct {
+		name   string
+		mutate func(*contract.ActiveManifestEnvelope)
+		roster *signing.LoadedRoster
+		want   error
+	}{
+		{
+			name:   "nil_roster",
+			roster: nil,
+			want:   ErrSignature,
+		},
+		{
+			name: "wrong_purpose",
+			mutate: func(env *contract.ActiveManifestEnvelope) {
+				env.Signatures[0].KeyPurpose = signing.PurposeReceiptSigning.String()
+			},
+			roster: testRoster(alice),
+			want:   ErrSignature,
+		},
+		{
+			name: "wrong_algorithm",
+			mutate: func(env *contract.ActiveManifestEnvelope) {
+				env.Signatures[0].Algorithm = "ed25519ph"
+			},
+			roster: testRoster(alice),
+			want:   ErrSignature,
+		},
+		{
+			name: "unknown_key",
+			mutate: func(env *contract.ActiveManifestEnvelope) {
+				env.Signatures[0].KeyID = "missing"
+			},
+			roster: testRoster(alice),
+			want:   ErrSignature,
+		},
+		{
+			name: "principal_mismatch",
+			mutate: func(env *contract.ActiveManifestEnvelope) {
+				env.Signatures[0].Principal = "mallory"
+			},
+			roster: testRoster(alice),
+			want:   ErrSignature,
+		},
+		{
+			name: "bad_signature_format",
+			mutate: func(env *contract.ActiveManifestEnvelope) {
+				env.Signatures[0].Signature = "ed25519:aabb"
+			},
+			roster: testRoster(alice),
+			want:   ErrSignature,
+		},
+		{
+			name: "bad_signature_bytes",
+			mutate: func(env *contract.ActiveManifestEnvelope) {
+				env.Signatures[0].Signature = "ed25519:" + stringsOf("0", 128)
+			},
+			roster: testRoster(alice),
+			want:   ErrSignature,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := base
+			env.Signatures = append([]contract.ManifestSignature(nil), base.Signatures...)
+			if tt.mutate != nil {
+				tt.mutate(&env)
+			}
+			opts := testOptions(tt.roster, "", 0, 1)
+			_, err := st.ValidateEnvelope(mustJSON(t, env), opts)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("ValidateEnvelope err = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateEnvelopeRejectsRosterPurposeMismatch(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	alice := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), alice)
+	roster := testRoster(alice)
+	roster.Body.Keys[0].KeyPurpose = signing.PurposeReceiptSigning.String()
+	_, err := st.ValidateEnvelope(mustJSON(t, env), testOptions(roster, "", 0, 1))
+	if !errors.Is(err, ErrSignature) {
+		t.Fatalf("ValidateEnvelope err = %v, want ErrSignature", err)
+	}
+}
+
+func TestValidateEnvelopeRejectsStructuralManifest(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	env.Body.SelectorSetHash = "sha256:wrong"
+	_, err := st.ValidateEnvelope(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrStructural) {
+		t.Fatalf("ValidateEnvelope err = %v, want ErrStructural", err)
+	}
+}
+
+func TestLoadContractsRejectsDecodeAndHashMismatch(t *testing.T) {
+	st := New(t.TempDir())
+	badHash := "sha256:" + stringsOf("b", 64)
+	if err := os.MkdirAll(filepath.Dir(st.historyPath(badHash)), 0o700); err != nil {
+		t.Fatalf("mkdir history: %v", err)
+	}
+	if err := os.WriteFile(st.historyPath(badHash), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write bad contract: %v", err)
+	}
+	sel := contract.ManifestSelector{SelectorID: "sha256:s", ContractHash: badHash}
+	if _, err := st.loadContracts([]contract.ManifestSelector{sel}); !errors.Is(err, ErrDecode) {
+		t.Fatalf("decode err = %v, want ErrDecode", err)
+	}
+
+	goodHash := putTestContract(t, st)
+	mismatch := "sha256:" + stringsOf("c", 64)
+	if err := os.Rename(st.historyPath(goodHash), st.historyPath(mismatch)); err != nil {
+		t.Fatalf("rename history: %v", err)
+	}
+	sel.ContractHash = mismatch
+	if _, err := st.loadContracts([]contract.ManifestSelector{sel}); !errors.Is(err, ErrContractHistory) {
+		t.Fatalf("mismatch err = %v, want ErrContractHistory", err)
+	}
+}
+
+func TestPutHistoryContractRejectsDecodeAndHashMismatch(t *testing.T) {
+	st := New(t.TempDir())
+	if _, err := st.PutHistoryContract([]byte("{")); !errors.Is(err, ErrDecode) {
+		t.Fatalf("decode err = %v, want ErrDecode", err)
+	}
+	c := contract.Contract{
+		SchemaVersion:    contract.SchemaVersionContract,
+		ContractKind:     contract.ContractKind,
+		ContractHash:     "sha256:wrong",
+		DataClassRoot:    "internal",
+		FieldDataClasses: map[string]string{},
+	}
+	raw := mustJSON(t, contract.ContractEnvelope{Body: c, Signature: "ed25519:" + stringsOf("0", 128)})
+	if _, err := st.PutHistoryContract(raw); !errors.Is(err, ErrContractHistory) {
+		t.Fatalf("hash mismatch err = %v, want ErrContractHistory", err)
+	}
+}
+
+func TestLatestAcceptedRejectsBadHistoryAndMissingHistory(t *testing.T) {
+	st := New(t.TempDir())
+	if _, err := st.LatestAccepted(Options{}); err == nil {
+		t.Fatal("LatestAccepted on missing dir returned nil error")
+	}
+	if err := os.MkdirAll(st.manifestDir(), 0o700); err != nil {
+		t.Fatalf("mkdir manifests: %v", err)
+	}
+	if _, err := st.LatestAccepted(Options{}); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("LatestAccepted empty err = %v, want os.ErrNotExist", err)
+	}
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, "sha256:"+stringsOf("d", 64), 1, "sha256:genesis", testEnv(), signer)
+	if err := os.WriteFile(filepath.Join(st.manifestDir(), hashFilename("sha256:"+stringsOf("e", 64), jsonExt)), mustJSON(t, env), 0o600); err != nil {
+		t.Fatalf("write bad accepted manifest: %v", err)
+	}
+	if _, err := st.LatestAccepted(testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, ErrContractHistory) {
+		t.Fatalf("LatestAccepted mismatch err = %v, want ErrContractHistory", err)
+	}
+}
+
+func TestHashHelpersSurfacePreimageErrors(t *testing.T) {
+	_, err := ContractHash(contract.Contract{
+		Defaults: contract.ContractDefaults{Confidence: map[string]any{"bad": make(chan int)}},
+	})
+	if err == nil {
+		t.Fatal("ContractHash returned nil error for unmarshalable contract")
+	}
+}
+
+func TestParseSignatureRejectsMalformedValues(t *testing.T) {
+	for _, sig := range []string{
+		"",
+		"sha256:" + stringsOf("0", 128),
+		"ed25519:aabb",
+		"ed25519:" + stringsOf("z", 128),
+	} {
+		if _, err := parseSignature(sig); err == nil {
+			t.Fatalf("parseSignature(%q) returned nil error", sig)
+		}
+	}
+}
+
+func TestNowDefaultsToWallClock(t *testing.T) {
+	if now(Options{}).IsZero() {
+		t.Fatal("now returned zero time")
+	}
+}
+
+func TestReloadMissingActiveReturnsDecodeError(t *testing.T) {
+	_, err := New(t.TempDir()).Reload(Options{})
+	if !errors.Is(err, ErrNoActiveManifest) {
+		t.Fatalf("Reload err = %v, want ErrNoActiveManifest", err)
+	}
+}
+
+func TestReloadAcceptedManifestWriteConflict(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	raw := mustJSON(t, env)
+	state, err := st.ValidateEnvelope(raw, testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("ValidateEnvelope: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(st.manifestPath(state.ManifestHash)), 0o700); err != nil {
+		t.Fatalf("mkdir manifest: %v", err)
+	}
+	if err := os.WriteFile(st.manifestPath(state.ManifestHash), []byte("different\n"), 0o600); err != nil {
+		t.Fatalf("write conflicting manifest: %v", err)
+	}
+	if err := os.WriteFile(st.activePath(), raw, 0o600); err != nil {
+		t.Fatalf("write active: %v", err)
+	}
+	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, ErrWriteOnceConflict) {
+		t.Fatalf("Reload err = %v, want ErrWriteOnceConflict", err)
+	}
+}
+
+func TestReloadReturnsJournalAppendFailure(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	raw := mustJSON(t, env)
+	state, err := st.ValidateEnvelope(raw, testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("ValidateEnvelope: %v", err)
+	}
+	accepted, err := encodeForStorage(state.Envelope)
+	if err != nil {
+		t.Fatalf("encodeForStorage: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(st.manifestPath(state.ManifestHash)), 0o700); err != nil {
+		t.Fatalf("mkdir manifest: %v", err)
+	}
+	if err := os.WriteFile(st.manifestPath(state.ManifestHash), accepted, 0o600); err != nil {
+		t.Fatalf("write accepted: %v", err)
+	}
+	if err := os.WriteFile(st.activePath(), raw, 0o600); err != nil {
+		t.Fatalf("write active: %v", err)
+	}
+	restore := replaceOpenFile(func(name string, flag int, perm os.FileMode) (writableFile, error) {
+		if strings.HasSuffix(name, journalFilename) {
+			return nil, fmt.Errorf("forced open error")
+		}
+		return os.OpenFile(name, flag, perm) //nolint:gosec // Test seam delegates to the production path for non-journal files.
+	})
+	defer restore()
+	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); err == nil {
+		t.Fatal("Reload returned nil error with journal open failure")
+	}
+}
+
+func TestReloadDoesNotPersistAcceptedWhenJournalFails(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	raw := mustJSON(t, env)
+	state, err := st.ValidateEnvelope(raw, testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("ValidateEnvelope: %v", err)
+	}
+	if err := os.WriteFile(st.activePath(), raw, 0o600); err != nil {
+		t.Fatalf("write active: %v", err)
+	}
+	restore := replaceOpenFile(func(name string, flag int, perm os.FileMode) (writableFile, error) {
+		if strings.HasSuffix(name, journalFilename) {
+			return nil, fmt.Errorf("forced open error")
+		}
+		return os.OpenFile(name, flag, perm) //nolint:gosec // Test seam delegates to the production path for non-journal files.
+	})
+	defer restore()
+	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); err == nil {
+		t.Fatal("Reload returned nil error with journal open failure")
+	}
+	if _, err := os.Stat(st.manifestPath(state.ManifestHash)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("accepted manifest err = %v, want not exist", err)
+	}
+}
+
+func TestReloadPropagatesAcceptedMarshalFailure(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	if err := os.WriteFile(st.activePath(), mustJSON(t, env), 0o600); err != nil {
+		t.Fatalf("write active: %v", err)
+	}
+	restore := replaceMarshalJSON(func(any) ([]byte, error) {
+		return nil, fmt.Errorf("forced marshal error")
+	})
+	defer restore()
+	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); err == nil {
+		t.Fatal("Reload returned nil error with marshal failure")
+	}
+}
+
+func TestWriteActivePropagatesAtomicWriteError(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	restore := replaceAtomicWrite(func(string, []byte, os.FileMode) error {
+		return fmt.Errorf("forced atomic write error")
+	})
+	defer restore()
+	if _, err := st.WriteActive(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1)); err == nil {
+		t.Fatal("WriteActive returned nil error with atomic write failure")
+	}
+}
+
+func TestWriteActivePropagatesMkdirError(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	restore := replaceMkdirAll(func(string, os.FileMode) error {
+		return fmt.Errorf("forced mkdir error")
+	})
+	defer restore()
+	if _, err := st.WriteActive(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1)); err == nil {
+		t.Fatal("WriteActive returned nil error with mkdir failure")
+	}
+}
+
+func TestPutHistoryContractRejectsStructuralContract(t *testing.T) {
+	st := New(t.TempDir())
+	c := contract.Contract{
+		SchemaVersion:    99,
+		ContractKind:     contract.ContractKind,
+		DataClassRoot:    "internal",
+		FieldDataClasses: map[string]string{},
+	}
+	hash, err := ContractHash(c)
+	if err != nil {
+		t.Fatalf("ContractHash: %v", err)
+	}
+	c.ContractHash = hash
+	raw := mustJSON(t, contract.ContractEnvelope{Body: c, Signature: "ed25519:" + stringsOf("0", 128)})
+	if _, err := st.PutHistoryContract(raw); !errors.Is(err, ErrStructural) {
+		t.Fatalf("PutHistoryContract err = %v, want ErrStructural", err)
+	}
+}
+
+func TestPutHistoryContractRejectsWriteOnceConflict(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	if err := os.WriteFile(st.historyPath(cHash), []byte("different\n"), 0o600); err != nil {
+		t.Fatalf("overwrite history: %v", err)
+	}
+	c := contract.Contract{
+		SchemaVersion:    contract.SchemaVersionContract,
+		ContractKind:     contract.ContractKind,
+		SignerKeyID:      "compile-key",
+		KeyPurpose:       signing.PurposeContractCompileSigning.String(),
+		DataClassRoot:    "internal",
+		FieldDataClasses: map[string]string{},
+		Selector:         contract.Selector{Agent: "agent-a", SelectorID: "sha256:selector"},
+	}
+	hash, err := ContractHash(c)
+	if err != nil {
+		t.Fatalf("ContractHash: %v", err)
+	}
+	c.ContractHash = hash
+	raw := mustJSON(t, contract.ContractEnvelope{Body: c, Signature: "ed25519:" + stringsOf("0", 128)})
+	if _, err := st.PutHistoryContract(raw); !errors.Is(err, ErrWriteOnceConflict) {
+		t.Fatalf("PutHistoryContract err = %v, want ErrWriteOnceConflict", err)
+	}
+}
+
+func TestLatestAcceptedRejectsReadAndDecodeErrors(t *testing.T) {
+	st := New(t.TempDir())
+	if err := os.MkdirAll(st.manifestDir(), 0o700); err != nil {
+		t.Fatalf("mkdir manifests: %v", err)
+	}
+	name := hashFilename("sha256:"+stringsOf("0", 64), jsonExt)
+	if err := os.WriteFile(filepath.Join(st.manifestDir(), name), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write bad manifest: %v", err)
+	}
+	if _, err := st.LatestAccepted(Options{}); !errors.Is(err, ErrDecode) {
+		t.Fatalf("LatestAccepted decode err = %v, want ErrDecode", err)
+	}
+	restore := replaceReadFile(func(string) ([]byte, error) {
+		return nil, fmt.Errorf("forced read error")
+	})
+	defer restore()
+	if _, err := st.LatestAccepted(Options{}); err == nil {
+		t.Fatal("LatestAccepted returned nil error with read failure")
+	}
+}
+
+func TestLatestAcceptedSkipsNonManifestEntries(t *testing.T) {
+	st := New(t.TempDir())
+	if err := os.MkdirAll(filepath.Join(st.manifestDir(), "nested"), 0o700); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(st.manifestDir(), "notes.txt"), []byte("ignored"), 0o600); err != nil {
+		t.Fatalf("write ignored: %v", err)
+	}
+	if _, err := st.LatestAccepted(Options{}); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("LatestAccepted err = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestLatestAcceptedRejectsForgedManifestWithMatchingFilename(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	env.Signatures[0].Signature = "ed25519:" + stringsOf("0", 128)
+	hash, err := ActiveManifestHash(env.Body)
+	if err != nil {
+		t.Fatalf("ActiveManifestHash: %v", err)
+	}
+	if err := os.MkdirAll(st.manifestDir(), 0o700); err != nil {
+		t.Fatalf("mkdir manifests: %v", err)
+	}
+	if err := os.WriteFile(st.manifestPath(hash), mustJSON(t, env), 0o600); err != nil {
+		t.Fatalf("write forged manifest: %v", err)
+	}
+	if _, err := st.LatestAccepted(testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, ErrSignature) {
+		t.Fatalf("LatestAccepted err = %v, want ErrSignature", err)
+	}
+}
+
+func TestValidateEnvelopeAllowsEmptyExpectedEnvironmentAndDefaultSignatureCount(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	opts := testOptions(testRoster(signer), "", 0, 0)
+	opts.Environment = contract.Environment{}
+	if _, err := st.ValidateEnvelope(mustJSON(t, env), opts); err != nil {
+		t.Fatalf("ValidateEnvelope: %v", err)
+	}
+}
+
+func TestValidateEnvelopeSkipsDuplicateKeysAndPrincipals(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	alice1 := newTestSigner(t, "act-1", "alice")
+	alice2 := newTestSigner(t, "act-2", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), alice1, alice1, alice2)
+	_, err := st.ValidateEnvelope(mustJSON(t, env), testOptions(testRoster(alice1, alice2), "", 0, 2))
+	if !errors.Is(err, ErrDualControl) {
+		t.Fatalf("ValidateEnvelope err = %v, want ErrDualControl", err)
+	}
+}
+
+func TestValidateEnvelopeRejectsActivationKeyWithoutPrincipal(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	if _, err := st.ValidateEnvelope(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, ErrSignature) {
+		t.Fatalf("ValidateEnvelope err = %v, want ErrSignature", err)
+	}
+}
+
+func TestValidateEnvelopeRejectsClaimedPrincipalsWhenRosterPrincipalEmpty(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	first := newTestSigner(t, "act-1", "")
+	second := newTestSigner(t, "act-2", "")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), first, second)
+	env.Signatures[0].Principal = "alice"
+	env.Signatures[1].Principal = "bob"
+	if _, err := st.ValidateEnvelope(mustJSON(t, env), testOptions(testRoster(first, second), "", 0, 2)); !errors.Is(err, ErrSignature) {
+		t.Fatalf("ValidateEnvelope err = %v, want ErrSignature", err)
+	}
+}
+
+func TestValidateEnvelopeRejectsBadRosterPublicKeyHex(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	roster := testRoster(signer)
+	roster.Body.Keys[0].PublicKeyHex = "not-hex"
+	_, err := st.ValidateEnvelope(mustJSON(t, env), testOptions(roster, "", 0, 1))
+	if !errors.Is(err, ErrSignature) {
+		t.Fatalf("ValidateEnvelope err = %v, want ErrSignature", err)
+	}
+}
+
+func TestWriteOncePropagatesFilesystemErrors(t *testing.T) {
+	restoreMkdir := replaceMkdirAll(func(string, os.FileMode) error {
+		return fmt.Errorf("forced mkdir error")
+	})
+	if err := writeOnce(filepath.Join(t.TempDir(), "a", "object"), []byte("x")); err == nil {
+		t.Fatal("writeOnce returned nil with mkdir failure")
+	}
+	restoreMkdir()
+
+	restoreRead := replaceReadFile(func(string) ([]byte, error) {
+		return nil, fmt.Errorf("forced read error")
+	})
+	if err := writeOnce(filepath.Join(t.TempDir(), "object"), []byte("x")); err == nil {
+		t.Fatal("writeOnce returned nil with read failure")
+	}
+	restoreRead()
+
+	restoreRead = replaceReadFile(func(string) ([]byte, error) {
+		return nil, os.ErrNotExist
+	})
+	restoreAtomic := replaceAtomicWrite(func(string, []byte, os.FileMode) error {
+		return fmt.Errorf("forced atomic write error")
+	})
+	if err := writeOnce(filepath.Join(t.TempDir(), "object"), []byte("x")); err == nil {
+		t.Fatal("writeOnce returned nil with atomic write failure")
+	}
+	restoreAtomic()
+	restoreRead()
+}
+
+func TestEncodeForStoragePropagatesMarshalError(t *testing.T) {
+	restore := replaceMarshalJSON(func(any) ([]byte, error) {
+		return nil, fmt.Errorf("forced marshal error")
+	})
+	defer restore()
+	if _, err := encodeForStorage(struct{}{}); err == nil {
+		t.Fatal("encodeForStorage returned nil with marshal failure")
+	}
+	if err := New(t.TempDir()).appendJournal(JournalEntry{}); err == nil {
+		t.Fatal("appendJournal returned nil with marshal failure")
+	}
+}
+
+func TestAppendJournalPropagatesWriteAndCloseErrors(t *testing.T) {
+	restoreOpen := replaceOpenFile(func(string, int, os.FileMode) (writableFile, error) {
+		return fakeWritableFile{writeErr: fmt.Errorf("forced write error")}, nil
+	})
+	if err := New(t.TempDir()).appendJournal(JournalEntry{}); err == nil {
+		t.Fatal("appendJournal returned nil with write failure")
+	}
+	restoreOpen()
+
+	restoreOpen = replaceOpenFile(func(string, int, os.FileMode) (writableFile, error) {
+		return fakeWritableFile{closeErr: fmt.Errorf("forced close error")}, nil
+	})
+	if err := New(t.TempDir()).appendJournal(JournalEntry{}); err == nil {
+		t.Fatal("appendJournal returned nil with close failure")
+	}
+	restoreOpen()
+}
+
+func TestAppendJournalPropagatesMkdirError(t *testing.T) {
+	restore := replaceMkdirAll(func(string, os.FileMode) error {
+		return fmt.Errorf("forced mkdir error")
+	})
+	defer restore()
+	if err := New(t.TempDir()).appendJournal(JournalEntry{}); err == nil {
+		t.Fatal("appendJournal returned nil with mkdir failure")
+	}
+}
+
+func TestLoadContractsRejectsStructurallyInvalidContract(t *testing.T) {
+	st := New(t.TempDir())
+	c := contract.Contract{
+		SchemaVersion:    99,
+		ContractKind:     contract.ContractKind,
+		DataClassRoot:    "internal",
+		FieldDataClasses: map[string]string{},
+	}
+	hash, err := ContractHash(c)
+	if err != nil {
+		t.Fatalf("ContractHash: %v", err)
+	}
+	c.ContractHash = hash
+	raw := mustJSON(t, contract.ContractEnvelope{Body: c, Signature: "ed25519:" + stringsOf("0", 128)})
+	if err := os.MkdirAll(filepath.Dir(st.historyPath(hash)), 0o700); err != nil {
+		t.Fatalf("mkdir history: %v", err)
+	}
+	if err := os.WriteFile(st.historyPath(hash), raw, 0o600); err != nil {
+		t.Fatalf("write contract: %v", err)
+	}
+	sel := contract.ManifestSelector{SelectorID: "sha256:s", ContractHash: hash}
+	if _, err := st.loadContracts([]contract.ManifestSelector{sel}); !errors.Is(err, ErrStructural) {
+		t.Fatalf("loadContracts err = %v, want ErrStructural", err)
+	}
+}
+
+func replaceReadFile(fn func(string) ([]byte, error)) func() {
+	prev := readFile
+	readFile = fn
+	return func() { readFile = prev }
+}
+
+func replaceMkdirAll(fn func(string, os.FileMode) error) func() {
+	prev := mkdirAll
+	mkdirAll = fn
+	return func() { mkdirAll = prev }
+}
+
+func replaceOpenFile(fn func(string, int, os.FileMode) (writableFile, error)) func() {
+	prev := openFile
+	openFile = fn
+	return func() { openFile = prev }
+}
+
+func replaceAtomicWrite(fn func(string, []byte, os.FileMode) error) func() {
+	prev := atomicWrite
+	atomicWrite = fn
+	return func() { atomicWrite = prev }
+}
+
+func replaceMarshalJSON(fn func(any) ([]byte, error)) func() {
+	prev := marshalJSON
+	marshalJSON = fn
+	return func() { marshalJSON = prev }
+}
+
+type fakeWritableFile struct {
+	writeErr error
+	closeErr error
+}
+
+func (f fakeWritableFile) Write(p []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	return len(p), nil
+}
+
+func (f fakeWritableFile) Close() error {
+	return f.closeErr
+}
+
+func putTestContract(t *testing.T, st Store) string {
+	t.Helper()
+	c := contract.Contract{
+		SchemaVersion:    contract.SchemaVersionContract,
+		ContractKind:     contract.ContractKind,
+		SignerKeyID:      "compile-key",
+		KeyPurpose:       signing.PurposeContractCompileSigning.String(),
+		DataClassRoot:    "internal",
+		FieldDataClasses: map[string]string{},
+		Selector:         contract.Selector{Agent: "agent-a", SelectorID: "sha256:selector"},
+	}
+	hash, err := ContractHash(c)
+	if err != nil {
+		t.Fatalf("ContractHash: %v", err)
+	}
+	c.ContractHash = hash
+	raw := mustJSON(t, contract.ContractEnvelope{Body: c, Signature: "ed25519:" + stringsOf("0", 128)})
+	got, err := st.PutHistoryContract(raw)
+	if err != nil {
+		t.Fatalf("PutHistoryContract: %v", err)
+	}
+	if got != hash {
+		t.Fatalf("PutHistoryContract hash = %q, want %q", got, hash)
+	}
+	return hash
+}
+
+func signedManifest(t *testing.T, cHash string, generation uint64, prior string, env contract.Environment, signers ...testSigner) contract.ActiveManifestEnvelope {
+	t.Helper()
+	selector := contract.ManifestSelector{Agent: "agent-a", ContractHash: cHash}
+	id, err := selector.ComputeSelectorID()
+	if err != nil {
+		t.Fatalf("ComputeSelectorID: %v", err)
+	}
+	selector.SelectorID = id
+	setHash, err := contract.ComputeSelectorSetHash([]contract.ManifestSelector{selector})
+	if err != nil {
+		t.Fatalf("ComputeSelectorSetHash: %v", err)
+	}
+	body := contract.ActiveManifest{
+		SchemaVersion:     1,
+		ManifestKind:      contract.ManifestKindActivation,
+		Generation:        generation,
+		PriorManifestHash: prior,
+		SelectorSetHash:   setHash,
+		Environment:       env,
+		Selectors:         []contract.ManifestSelector{selector},
+		HistoryRoot:       "contracts/history/",
+		SignedAt:          testNow,
+	}
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage: %v", err)
+	}
+	out := contract.ActiveManifestEnvelope{Body: body}
+	for _, signer := range signers {
+		sig := ed25519.Sign(signer.priv, preimage)
+		out.Signatures = append(out.Signatures, contract.ManifestSignature{
+			KeyID:      signer.keyID,
+			Principal:  signer.principal,
+			KeyPurpose: signing.PurposeContractActivationSigning.String(),
+			Algorithm:  "ed25519",
+			Signature:  "ed25519:" + hex.EncodeToString(sig),
+		})
+	}
+	return out
+}
+
+func testOptions(roster *signing.LoadedRoster, previousHash string, previousGeneration uint64, required int) Options {
+	return Options{
+		Environment:        testEnv(),
+		Roster:             roster,
+		PreviousHash:       previousHash,
+		PreviousGeneration: previousGeneration,
+		MinSignatures:      required,
+		Now:                func() time.Time { return testNow },
+	}
+}
+
+func testRoster(signers ...testSigner) *signing.LoadedRoster {
+	keys := make([]contract.KeyInfo, 0, len(signers))
+	for _, signer := range signers {
+		keys = append(keys, contract.KeyInfo{
+			KeyID:        signer.keyID,
+			KeyPurpose:   signing.PurposeContractActivationSigning.String(),
+			PublicKeyHex: hex.EncodeToString(signer.pub),
+			ValidFrom:    testNow.Add(-time.Hour).Format(time.RFC3339),
+			Status:       contract.KeyStatusActive,
+			Principal:    signer.principal,
+		})
+	}
+	return &signing.LoadedRoster{Body: contract.KeyRoster{Keys: keys}}
+}
+
+func newTestSigner(t *testing.T, keyID, principal string) testSigner {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return testSigner{keyID: keyID, principal: principal, pub: pub, priv: priv}
+}
+
+func testEnv() contract.Environment {
+	return contract.Environment{ID: "prod", Tenant: "tenant", DeploymentID: "deployment"}
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	return append(raw, '\n')
+}
+
+func stringsOf(s string, n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString(s)
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary
- add an internal contract store for signed active manifests and content-addressed contract history
- validate activation signatures against the key roster before accepting active manifests
- persist immutable accepted manifests plus an append-only activation journal, with read-only reload support and an advisory writer lock

## Testing
- go test -race -count=1 ./...
- golangci-lint run ./...
- go test -cover ./internal/contract/store
- pipelock git scan-diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent contract store with manifest validation, signature checks, immutable manifest history, atomic active-manifest updates, and helpers for manifest/contract hashing.
  * Added cross-platform advisory locking to serialize store operations on Unix and Windows.

* **Tests**
  * Added a comprehensive end-to-end test suite validating store behavior, signature/validation rules, journaling, persistence, history selection, and numerous failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->