### PR TITLE
feat(contract): add runtime contract evaluation

### DIFF
--- a/internal/contract/runtime/drift.go
+++ b/internal/contract/runtime/drift.go
@@ -1,0 +1,221 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+// DriftObservation is one per-rule window summary from live evaluation.
+type DriftObservation struct {
+	Rule                  contract.Rule
+	ContractHash          string
+	Mode                  Mode
+	KillSwitchActive      bool
+	OpportunityObserved   bool
+	ExpectedObserved      bool
+	UnexpectedObserved    bool
+	MissedWindows         uint64
+	RequiredMissedWindows uint64
+	OpportunityHealthy    bool
+	HistoricalRate        string
+	CurrentRate           string
+	Window                string
+	ParentContext         string
+}
+
+// DriftResult contains telemetry produced from a DriftObservation.
+type DriftResult struct {
+	Suppressed        bool
+	Drift             *DriftEvent
+	OpportunityAlert  *OpportunityMissing
+	AdaptiveSignal    *session.SignalType
+	ShouldAutoDemote  bool
+	ShouldEmitReceipt bool
+}
+
+// DriftEvent describes a contract_drift receipt candidate.
+type DriftEvent struct {
+	ContractHash       string
+	RuleID             string
+	Kind               string
+	Mode               Mode
+	Action             string
+	ObservationSummary string
+	MissedWindows      uint64
+	OpportunityStatus  string
+}
+
+// OpportunityMissing describes an opportunity_missing receipt candidate.
+type OpportunityMissing struct {
+	ContractHash              string
+	RuleID                    string
+	ParentContext             string
+	HistoricalOpportunityRate string
+	CurrentOpportunityRate    string
+	Window                    string
+}
+
+// EvaluateDrift applies the drift state machine. Negative drift is gated on
+// three clauses: enough missed windows, observed opportunity, and healthy
+// opportunity telemetry. Opportunity suppression emits opportunity_missing and
+// deliberately does not auto-demote.
+func EvaluateDrift(obs DriftObservation) (DriftResult, error) {
+	if obs.KillSwitchActive {
+		return DriftResult{Suppressed: true}, nil
+	}
+	if err := validateLifecycle(obs.Rule.LifecycleState); err != nil {
+		return DriftResult{}, err
+	}
+	if obs.ContractHash == "" {
+		return DriftResult{}, fmt.Errorf("%w: contract_hash", ErrInvalidDecisionInput)
+	}
+	if obs.Rule.RuleID == "" {
+		return DriftResult{}, fmt.Errorf("%w: rule_id", ErrInvalidDecisionInput)
+	}
+	switch obs.Rule.LifecycleState {
+	case LifecycleExpired, LifecycleDemoted, LifecycleProposed:
+		return DriftResult{}, nil
+	}
+
+	if !obs.OpportunityHealthy {
+		alert := OpportunityMissing{
+			ContractHash:              obs.ContractHash,
+			RuleID:                    obs.Rule.RuleID,
+			ParentContext:             obs.ParentContext,
+			HistoricalOpportunityRate: obs.HistoricalRate,
+			CurrentOpportunityRate:    obs.CurrentRate,
+			Window:                    obs.Window,
+		}
+		return DriftResult{
+			OpportunityAlert:  &alert,
+			ShouldEmitReceipt: true,
+		}, nil
+	}
+
+	if obs.UnexpectedObserved {
+		event := DriftEvent{
+			ContractHash:       obs.ContractHash,
+			RuleID:             obs.Rule.RuleID,
+			Kind:               DriftKindPositive,
+			Mode:               effectiveMode(obs.Mode),
+			Action:             config.ActionBlock,
+			ObservationSummary: "unexpected observation outside enforced contract",
+			OpportunityStatus:  "healthy",
+		}
+		return driftResult(event), nil
+	}
+
+	required := obs.RequiredMissedWindows
+	if required == 0 {
+		required = observationUint(obs.Rule.RecurringSupport, "windows_floor")
+	}
+	if required == 0 {
+		required = 3
+	}
+	if obs.OpportunityObserved && !obs.ExpectedObserved && obs.MissedWindows >= required {
+		event := DriftEvent{
+			ContractHash:      obs.ContractHash,
+			RuleID:            obs.Rule.RuleID,
+			Kind:              DriftKindNegative,
+			Mode:              effectiveMode(obs.Mode),
+			MissedWindows:     obs.MissedWindows,
+			OpportunityStatus: "healthy",
+		}
+		return driftResult(event), nil
+	}
+	return DriftResult{}, nil
+}
+
+func driftResult(event DriftEvent) DriftResult {
+	signal := SignalForDrift(event)
+	return DriftResult{
+		Drift:             &event,
+		AdaptiveSignal:    signal,
+		ShouldAutoDemote:  false,
+		ShouldEmitReceipt: true,
+	}
+}
+
+func observationUint(m map[string]any, key string) uint64 {
+	if len(m) == 0 {
+		return 0
+	}
+	switch value := m[key].(type) {
+	case uint64:
+		return value
+	case uint:
+		return uint64(value)
+	case int:
+		if value < 0 {
+			return 0
+		}
+		return uint64(value)
+	case int64:
+		if value < 0 {
+			return 0
+		}
+		return uint64(value)
+	case float64:
+		if value < 0 {
+			return 0
+		}
+		return uint64(value)
+	case string:
+		parsed, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return parsed
+	default:
+		return 0
+	}
+}
+
+func effectiveMode(mode Mode) Mode {
+	if mode == "" {
+		return ModeLive
+	}
+	return mode
+}
+
+// SignalForDrift returns the live adaptive signal implied by a drift event.
+func SignalForDrift(event DriftEvent) *session.SignalType {
+	if event.Kind == DriftKindPositive && effectiveMode(event.Mode) == ModeLive && event.Action == config.ActionBlock {
+		sig := session.SignalBlock
+		return &sig
+	}
+	return nil
+}
+
+// ContractDriftPayload converts a DriftEvent into the typed receipt payload.
+func ContractDriftPayload(event DriftEvent) contractreceipt.PayloadContractDriftStruct {
+	return contractreceipt.PayloadContractDriftStruct{
+		ContractHash:       event.ContractHash,
+		RuleID:             event.RuleID,
+		DriftKind:          event.Kind,
+		ObservationSummary: event.ObservationSummary,
+		MissedWindows:      event.MissedWindows,
+		OpportunityStatus:  event.OpportunityStatus,
+	}
+}
+
+// OpportunityMissingPayload converts an OpportunityMissing event into the typed
+// receipt payload.
+func OpportunityMissingPayload(event OpportunityMissing) contractreceipt.PayloadOpportunityMissingStruct {
+	return contractreceipt.PayloadOpportunityMissingStruct{
+		ContractHash:              event.ContractHash,
+		RuleID:                    event.RuleID,
+		ParentContext:             event.ParentContext,
+		HistoricalOpportunityRate: event.HistoricalOpportunityRate,
+		CurrentOpportunityRate:    event.CurrentOpportunityRate,
+		Window:                    event.Window,
+	}
+}

--- a/internal/contract/runtime/runtime.go
+++ b/internal/contract/runtime/runtime.go
@@ -1,0 +1,543 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package runtime resolves active learn-and-lock contracts for live sessions
+// and evaluates contract-aware decisions without coupling the proxy runtime to
+// the contract store.
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/contract/inference/normalize"
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/contract/store"
+	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+const (
+	// LifecycleProposed means the rule is visible to operators but not active.
+	LifecycleProposed = "proposed"
+	// LifecycleCaptureOnly records telemetry without changing live enforcement.
+	LifecycleCaptureOnly = "capture_only"
+	// LifecycleEnforce allows the rule to affect live decisions.
+	LifecycleEnforce = "enforce"
+	// LifecycleExpired marks a rule as no longer active.
+	LifecycleExpired = "expired"
+	// LifecycleDemoted marks a rule removed from enforcement by drift handling.
+	LifecycleDemoted = "demoted"
+)
+
+const (
+	// PolicySourceScanner identifies the regular scanner/config path.
+	PolicySourceScanner = "scanner"
+	// PolicySourceBundle identifies bundled static policy.
+	PolicySourceBundle = "bundle"
+	// PolicySourceContract identifies an active learn-and-lock contract.
+	PolicySourceContract = "contract"
+	// PolicySourceKillSwitch identifies the global fail-closed kill switch.
+	PolicySourceKillSwitch = "kill_switch"
+)
+
+const (
+	// WinningSourceScanner means the scanner/config path decided the verdict.
+	WinningSourceScanner = PolicySourceScanner
+	// WinningSourceContract means the active contract decided the verdict.
+	WinningSourceContract = PolicySourceContract
+	// WinningSourceKillSwitch means the kill switch decided the verdict.
+	WinningSourceKillSwitch = PolicySourceKillSwitch
+)
+
+const (
+	ruleKindHTTPDestination = "http_destination"
+	ruleKindHTTPAction      = "http_action"
+
+	DriftKindPositive = "positive"
+	DriftKindNegative = "negative"
+)
+
+var (
+	// ErrNoResolvedContract is returned when a caller asks for evaluation
+	// without an active contract pin.
+	ErrNoResolvedContract = errors.New("contract runtime: no resolved contract")
+	// ErrUnsupportedLifecycle is returned for non-enumerated rule states.
+	ErrUnsupportedLifecycle = errors.New("contract runtime: unsupported lifecycle state")
+	// ErrInvalidDecisionInput is returned for malformed request/evaluation input.
+	ErrInvalidDecisionInput = errors.New("contract runtime: invalid decision input")
+)
+
+// ActiveSet is the immutable in-memory view derived from store.State.
+type ActiveSet struct {
+	manifestHash string
+	generation   uint64
+	selectors    []contract.ManifestSelector
+	contracts    map[string]contract.ContractEnvelope
+}
+
+// NewActiveSet builds an immutable active set from a validated store state.
+func NewActiveSet(state store.State) (*ActiveSet, error) {
+	if state.ManifestHash == "" {
+		return nil, fmt.Errorf("%w: manifest_hash", ErrInvalidDecisionInput)
+	}
+	if state.Envelope.Body.Generation == 0 {
+		return nil, fmt.Errorf("%w: generation", ErrInvalidDecisionInput)
+	}
+	selectors := append([]contract.ManifestSelector(nil), state.Envelope.Body.Selectors...)
+	contracts := make(map[string]contract.ContractEnvelope, len(state.Contracts))
+	for selectorID, env := range state.Contracts {
+		contracts[selectorID] = env
+	}
+	for _, selector := range selectors {
+		env, ok := contracts[selector.SelectorID]
+		if !ok {
+			return nil, fmt.Errorf("%w: selector %q missing contract", ErrNoResolvedContract, selector.SelectorID)
+		}
+		if env.Body.ContractHash != selector.ContractHash {
+			return nil, fmt.Errorf("%w: selector %q contract_hash mismatch", ErrInvalidDecisionInput, selector.SelectorID)
+		}
+	}
+	return &ActiveSet{
+		manifestHash: state.ManifestHash,
+		generation:   state.Envelope.Body.Generation,
+		selectors:    selectors,
+		contracts:    contracts,
+	}, nil
+}
+
+// ManifestHash returns the active manifest hash stamped into receipts.
+func (a *ActiveSet) ManifestHash() string {
+	if a == nil {
+		return ""
+	}
+	return a.manifestHash
+}
+
+// Generation returns the active manifest generation.
+func (a *ActiveSet) Generation() uint64 {
+	if a == nil {
+		return 0
+	}
+	return a.generation
+}
+
+// Resolve picks the active contract for an agent/session. Exact agent matches
+// win over glob selectors, and glob selectors win over the default selector.
+func (a *ActiveSet) Resolve(agent string) (*ResolvedContract, bool) {
+	if a == nil {
+		return nil, false
+	}
+	agent = strings.TrimSpace(agent)
+	candidates := make([]selectorCandidate, 0, len(a.selectors))
+	for i, selector := range a.selectors {
+		priority, ok := selectorPriority(selector, agent)
+		if !ok {
+			continue
+		}
+		env, exists := a.contracts[selector.SelectorID]
+		if !exists {
+			continue
+		}
+		candidates = append(candidates, selectorCandidate{
+			priority: priority,
+			index:    i,
+			selector: selector,
+			env:      env,
+		})
+	}
+	if len(candidates) == 0 {
+		return nil, false
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].priority != candidates[j].priority {
+			return candidates[i].priority > candidates[j].priority
+		}
+		return candidates[i].index < candidates[j].index
+	})
+	winner := candidates[0]
+	return &ResolvedContract{
+		ActiveManifestHash: a.manifestHash,
+		ContractHash:       winner.selector.ContractHash,
+		SelectorID:         winner.selector.SelectorID,
+		ContractGeneration: a.generation,
+		Contract:           winner.env.Body,
+	}, true
+}
+
+type selectorCandidate struct {
+	priority int
+	index    int
+	selector contract.ManifestSelector
+	env      contract.ContractEnvelope
+}
+
+func selectorPriority(selector contract.ManifestSelector, agent string) (int, bool) {
+	if selector.Agent != "" {
+		return 3, selector.Agent == agent
+	}
+	if selector.AgentGlob != "" {
+		matched, err := path.Match(selector.AgentGlob, agent)
+		return 2, err == nil && matched
+	}
+	if selector.Default {
+		return 1, true
+	}
+	return 0, false
+}
+
+// ResolvedContract is the per-session contract pin. Pass this by value to keep
+// in-flight requests bound to the contract selected at request start.
+type ResolvedContract struct {
+	ActiveManifestHash string
+	ContractHash       string
+	SelectorID         string
+	ContractGeneration uint64
+	Contract           contract.Contract
+}
+
+// ReceiptContext is the subset stamped into every EvidenceReceipt v2 emitted
+// under an active contract.
+type ReceiptContext struct {
+	ActiveManifestHash string
+	ContractHash       string
+	SelectorID         string
+	ContractGeneration uint64
+}
+
+// ReceiptContext returns the v2 receipt stamping fields for this pin.
+func (r ResolvedContract) ReceiptContext() ReceiptContext {
+	return ReceiptContext{
+		ActiveManifestHash: r.ActiveManifestHash,
+		ContractHash:       r.ContractHash,
+		SelectorID:         r.SelectorID,
+		ContractGeneration: r.ContractGeneration,
+	}
+}
+
+// StampReceipt returns a copy of receipt with the active contract context set.
+func (c ReceiptContext) StampReceipt(receipt contractreceipt.EvidenceReceipt) contractreceipt.EvidenceReceipt {
+	receipt.ActiveManifestHash = c.ActiveManifestHash
+	receipt.ContractHash = c.ContractHash
+	receipt.SelectorID = c.SelectorID
+	receipt.ContractGeneration = c.ContractGeneration
+	return receipt
+}
+
+// Mode describes whether a contract decision can affect live enforcement.
+type Mode string
+
+const (
+	ModeLive    Mode = "live"
+	ModeShadow  Mode = "shadow"
+	ModeCapture Mode = "capture"
+)
+
+// HTTPRequest is the normalized input needed to evaluate HTTP contract rules.
+type HTTPRequest struct {
+	URL             string
+	Method          string
+	EffectiveAction string
+}
+
+// EvaluateOptions control one request evaluation.
+type EvaluateOptions struct {
+	Resolved         *ResolvedContract
+	Request          HTTPRequest
+	Mode             Mode
+	KillSwitchActive bool
+	ScannerVerdict   string
+	ScannerMatched   bool
+	PolicySources    []string
+}
+
+// Decision is the contract-aware verdict metadata for a request.
+type Decision struct {
+	Verdict       string
+	PolicySources []string
+	WinningSource string
+	RuleID        string
+	Drift         *DriftEvent
+	Signal        *session.SignalType
+	Suppressed    bool
+	Reason        string
+}
+
+// EvaluateHTTP evaluates active HTTP destination/action rules. It implements
+// host-scoped deny-default: only hosts with comparable enforce rules can be
+// denied by contract default.
+func EvaluateHTTP(opts EvaluateOptions) (Decision, error) {
+	sources := normalizePolicySources(opts.PolicySources)
+	if opts.ScannerMatched || opts.ScannerVerdict != "" {
+		sources = appendPolicySource(sources, PolicySourceScanner)
+	}
+	if opts.KillSwitchActive {
+		sources = appendPolicySource(sources, PolicySourceKillSwitch)
+		return Decision{
+			Verdict:       config.ActionBlock,
+			PolicySources: sources,
+			WinningSource: WinningSourceKillSwitch,
+			Suppressed:    true,
+			Reason:        "kill_switch_active",
+		}, nil
+	}
+	if opts.Resolved == nil {
+		return scannerDecision(opts.ScannerVerdict, sources), nil
+	}
+	sources = appendPolicySource(sources, PolicySourceContract)
+	u, err := url.Parse(opts.Request.URL)
+	if err != nil || u.Hostname() == "" {
+		return Decision{}, fmt.Errorf("%w: url", ErrInvalidDecisionInput)
+	}
+
+	hostHasEnforceRule := false
+	hasComparableEvidence := false
+	hostRuleIDs := make([]string, 0)
+	seenRuleIDs := map[string]struct{}{}
+	for _, rule := range opts.Resolved.Contract.Rules {
+		if !isHTTPRule(rule) {
+			continue
+		}
+		if err := validateLifecycle(rule.LifecycleState); err != nil {
+			return Decision{}, err
+		}
+		if rule.LifecycleState != LifecycleEnforce {
+			continue
+		}
+		if !ruleHostMatches(rule, u.Hostname()) {
+			continue
+		}
+		hostHasEnforceRule = true
+		hostRuleIDs = appendRuleID(hostRuleIDs, seenRuleIDs, rule.RuleID)
+		matches, canCompare := ruleMatchesHTTP(rule, u, opts.Request)
+		if !canCompare {
+			continue
+		}
+		hasComparableEvidence = true
+		if matches {
+			return Decision{
+				Verdict:       config.ActionAllow,
+				PolicySources: sources,
+				WinningSource: WinningSourceContract,
+				RuleID:        rule.RuleID,
+			}, nil
+		}
+	}
+	if hostHasEnforceRule && hasComparableEvidence {
+		ruleID := firstString(hostRuleIDs)
+		event := DriftEvent{
+			ContractHash: opts.Resolved.ContractHash,
+			RuleID:       ruleID,
+			Kind:         DriftKindPositive,
+			Mode:         effectiveMode(opts.Mode),
+			Action:       config.ActionBlock,
+		}
+		decision := Decision{
+			Verdict:       config.ActionBlock,
+			PolicySources: sources,
+			WinningSource: WinningSourceContract,
+			RuleID:        ruleID,
+			Drift:         &event,
+			Reason:        "contract_enforce_default",
+		}
+		decision.Signal = SignalForDrift(event)
+		return decision, nil
+	}
+	return scannerDecision(opts.ScannerVerdict, sources), nil
+}
+
+func scannerDecision(scannerVerdict string, sources []string) Decision {
+	if scannerVerdict == "" {
+		scannerVerdict = config.ActionAllow
+	}
+	sources = appendPolicySource(sources, PolicySourceScanner)
+	return Decision{
+		Verdict:       scannerVerdict,
+		PolicySources: sources,
+		WinningSource: WinningSourceScanner,
+	}
+}
+
+func isHTTPRule(rule contract.Rule) bool {
+	return rule.RuleKind == ruleKindHTTPDestination || rule.RuleKind == ruleKindHTTPAction
+}
+
+func validateLifecycle(state string) error {
+	switch state {
+	case LifecycleProposed, LifecycleCaptureOnly, LifecycleEnforce, LifecycleExpired, LifecycleDemoted:
+		return nil
+	default:
+		return fmt.Errorf("%w: %q", ErrUnsupportedLifecycle, state)
+	}
+}
+
+func ruleHostMatches(rule contract.Rule, host string) bool {
+	ruleHost := normalizeHost(selectorString(rule.Selector, "host"))
+	return ruleHost != "" && ruleHost == normalizeHost(host)
+}
+
+func ruleMatchesHTTP(rule contract.Rule, u *url.URL, req HTTPRequest) (bool, bool) {
+	matchedConstraint := selectorString(rule.Selector, "host") != ""
+	if methods := selectorMethods(rule.Selector); len(methods) > 0 {
+		matchedConstraint = true
+		if !containsFolded(methods, req.Method) {
+			return false, true
+		}
+	}
+	if paths := selectorPathValues(rule.Selector); len(paths) > 0 {
+		matchedConstraint = true
+		matches, canCompare := pathMatchesAny(u.EscapedPath(), paths)
+		if !canCompare || !matches {
+			return matches, canCompare
+		}
+	}
+	if action := selectorRawString(rule.Selector, "effective_action"); action != "" {
+		matchedConstraint = true
+		if action != req.EffectiveAction {
+			return false, true
+		}
+	}
+	return matchedConstraint, true
+}
+
+func selectorString(selector map[string]any, key string) string {
+	value, ok := selector[key].(map[string]any)
+	if !ok {
+		return ""
+	}
+	raw, _ := value["value"].(string)
+	return raw
+}
+
+func selectorRawString(selector map[string]any, key string) string {
+	value, _ := selector[key].(string)
+	return value
+}
+
+func selectorMethods(selector map[string]any) []string {
+	values, ok := selector["methods"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		text, ok := value.(string)
+		if ok {
+			out = append(out, text)
+		}
+	}
+	return out
+}
+
+func selectorPathValues(selector map[string]any) []string {
+	values, ok := selector["paths"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		item, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		text, ok := item["value"].(string)
+		if ok {
+			out = append(out, text)
+		}
+	}
+	return out
+}
+
+func containsFolded(values []string, target string) bool {
+	target = strings.ToUpper(strings.TrimSpace(target))
+	for _, value := range values {
+		if strings.ToUpper(strings.TrimSpace(value)) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeHost(host string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+}
+
+func pathMatchesAny(escapedPath string, values []string) (bool, bool) {
+	if escapedPath == "" {
+		escapedPath = "/"
+	}
+	canonicalPath, _, err := normalize.Canonicalize(escapedPath)
+	if err != nil {
+		return false, false
+	}
+	for _, value := range values {
+		if value == canonicalPath {
+			return true, true
+		}
+	}
+	return false, true
+}
+
+func appendRuleID(ruleIDs []string, seen map[string]struct{}, ruleID string) []string {
+	ruleID = strings.TrimSpace(ruleID)
+	if ruleID == "" {
+		return ruleIDs
+	}
+	if _, ok := seen[ruleID]; ok {
+		return ruleIDs
+	}
+	seen[ruleID] = struct{}{}
+	return append(ruleIDs, ruleID)
+}
+
+func firstString(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func normalizePolicySources(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func appendPolicySource(values []string, source string) []string {
+	for _, value := range values {
+		if value == source {
+			return values
+		}
+	}
+	return append(values, source)
+}
+
+// ProxyDecisionPayload builds the typed EvidenceReceipt v2 proxy_decision
+// payload from a runtime decision.
+func ProxyDecisionPayload(decision Decision, actionType, target, transport string) contractreceipt.PayloadProxyDecisionStruct {
+	return contractreceipt.PayloadProxyDecisionStruct{
+		ActionType:    actionType,
+		Target:        target,
+		Verdict:       decision.Verdict,
+		Transport:     transport,
+		PolicySources: append([]string(nil), decision.PolicySources...),
+		WinningSource: decision.WinningSource,
+		RuleID:        decision.RuleID,
+	}
+}

--- a/internal/contract/runtime/runtime.go
+++ b/internal/contract/runtime/runtime.go
@@ -71,6 +71,8 @@ var (
 	ErrUnsupportedLifecycle = errors.New("contract runtime: unsupported lifecycle state")
 	// ErrInvalidDecisionInput is returned for malformed request/evaluation input.
 	ErrInvalidDecisionInput = errors.New("contract runtime: invalid decision input")
+	// ErrInvalidSelector is returned when an active-set selector cannot be used safely.
+	ErrInvalidSelector = errors.New("contract runtime: invalid selector")
 )
 
 // ActiveSet is the immutable in-memory view derived from store.State.
@@ -95,6 +97,11 @@ func NewActiveSet(state store.State) (*ActiveSet, error) {
 		contracts[selectorID] = env
 	}
 	for _, selector := range selectors {
+		if selector.AgentGlob != "" {
+			if _, err := path.Match(selector.AgentGlob, ""); err != nil {
+				return nil, fmt.Errorf("%w: selector %q agent_glob: %w", ErrInvalidSelector, selector.SelectorID, err)
+			}
+		}
 		env, ok := contracts[selector.SelectorID]
 		if !ok {
 			return nil, fmt.Errorf("%w: selector %q missing contract", ErrNoResolvedContract, selector.SelectorID)
@@ -314,7 +321,13 @@ func EvaluateHTTP(opts EvaluateOptions) (Decision, error) {
 		}
 		hostHasEnforceRule = true
 		hostRuleIDs = appendRuleID(hostRuleIDs, seenRuleIDs, rule.RuleID)
-		matches, canCompare := ruleMatchesHTTP(rule, u, opts.Request)
+		if !usesDefaultHTTPPort(u) {
+			return contractBlockDecision(opts, sources, rule.RuleID, "contract_non_default_port"), nil
+		}
+		matches, canCompare, invalidPath := ruleMatchesHTTP(rule, u, opts.Request)
+		if invalidPath {
+			return contractBlockDecision(opts, sources, rule.RuleID, "contract_invalid_path"), nil
+		}
 		if !canCompare {
 			continue
 		}
@@ -329,38 +342,46 @@ func EvaluateHTTP(opts EvaluateOptions) (Decision, error) {
 		}
 	}
 	if hostHasEnforceRule && hasComparableEvidence {
-		ruleID := firstString(hostRuleIDs)
-		event := DriftEvent{
-			ContractHash: opts.Resolved.ContractHash,
-			RuleID:       ruleID,
-			Kind:         DriftKindPositive,
-			Mode:         effectiveMode(opts.Mode),
-			Action:       config.ActionBlock,
-		}
-		decision := Decision{
-			Verdict:       config.ActionBlock,
-			PolicySources: sources,
-			WinningSource: WinningSourceContract,
-			RuleID:        ruleID,
-			Drift:         &event,
-			Reason:        "contract_enforce_default",
-		}
-		decision.Signal = SignalForDrift(event)
-		return decision, nil
+		return contractBlockDecision(opts, sources, firstString(hostRuleIDs), "contract_enforce_default"), nil
 	}
 	return scannerDecision(opts.ScannerVerdict, sources), nil
 }
 
 func scannerDecision(scannerVerdict string, sources []string) Decision {
+	missing := scannerVerdict == ""
 	if scannerVerdict == "" {
-		scannerVerdict = config.ActionAllow
+		scannerVerdict = config.ActionBlock
 	}
 	sources = appendPolicySource(sources, PolicySourceScanner)
-	return Decision{
+	decision := Decision{
 		Verdict:       scannerVerdict,
 		PolicySources: sources,
 		WinningSource: WinningSourceScanner,
 	}
+	if missing {
+		decision.Reason = "scanner_decision_missing"
+	}
+	return decision
+}
+
+func contractBlockDecision(opts EvaluateOptions, sources []string, ruleID, reason string) Decision {
+	event := DriftEvent{
+		ContractHash: opts.Resolved.ContractHash,
+		RuleID:       ruleID,
+		Kind:         DriftKindPositive,
+		Mode:         effectiveMode(opts.Mode),
+		Action:       config.ActionBlock,
+	}
+	decision := Decision{
+		Verdict:       config.ActionBlock,
+		PolicySources: sources,
+		WinningSource: WinningSourceContract,
+		RuleID:        ruleID,
+		Drift:         &event,
+		Reason:        reason,
+	}
+	decision.Signal = SignalForDrift(event)
+	return decision
 }
 
 func isHTTPRule(rule contract.Rule) bool {
@@ -381,28 +402,31 @@ func ruleHostMatches(rule contract.Rule, host string) bool {
 	return ruleHost != "" && ruleHost == normalizeHost(host)
 }
 
-func ruleMatchesHTTP(rule contract.Rule, u *url.URL, req HTTPRequest) (bool, bool) {
+func ruleMatchesHTTP(rule contract.Rule, u *url.URL, req HTTPRequest) (bool, bool, bool) {
 	matchedConstraint := selectorString(rule.Selector, "host") != ""
 	if methods := selectorMethods(rule.Selector); len(methods) > 0 {
 		matchedConstraint = true
 		if !containsFolded(methods, req.Method) {
-			return false, true
+			return false, true, false
 		}
 	}
 	if paths := selectorPathValues(rule.Selector); len(paths) > 0 {
 		matchedConstraint = true
 		matches, canCompare := pathMatchesAny(u.EscapedPath(), paths)
-		if !canCompare || !matches {
-			return matches, canCompare
+		if !canCompare {
+			return false, false, true
+		}
+		if !matches {
+			return false, true, false
 		}
 	}
 	if action := selectorRawString(rule.Selector, "effective_action"); action != "" {
 		matchedConstraint = true
 		if action != req.EffectiveAction {
-			return false, true
+			return false, true, false
 		}
 	}
-	return matchedConstraint, true
+	return matchedConstraint, true, false
 }
 
 func selectorString(selector map[string]any, key string) string {
@@ -465,6 +489,17 @@ func containsFolded(values []string, target string) bool {
 
 func normalizeHost(host string) string {
 	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+}
+
+func usesDefaultHTTPPort(u *url.URL) bool {
+	switch strings.ToLower(strings.TrimSpace(u.Scheme)) {
+	case "https":
+		return u.Port() == "" || u.Port() == "443"
+	case "http":
+		return u.Port() == "" || u.Port() == "80"
+	default:
+		return false
+	}
 }
 
 func pathMatchesAny(escapedPath string, values []string) (bool, bool) {

--- a/internal/contract/runtime/runtime_test.go
+++ b/internal/contract/runtime/runtime_test.go
@@ -148,7 +148,7 @@ func TestActiveSetAccessorsAndInvalidState(t *testing.T) {
 	}
 }
 
-func TestResolveNilNoMatchAndBadGlob(t *testing.T) {
+func TestResolveNilNoMatchAndRejectsBadGlob(t *testing.T) {
 	if resolved, ok := (*ActiveSet)(nil).Resolve("agent"); ok || resolved != nil {
 		t.Fatalf("nil Resolve = (%v, %v), want no match", resolved, ok)
 	}
@@ -168,9 +168,14 @@ func TestResolveNilNoMatchAndBadGlob(t *testing.T) {
 			"other":    {Body: contract.Contract{ContractHash: testContractHash}},
 		},
 	}
+	if _, err := NewActiveSet(state); !errors.Is(err, ErrInvalidSelector) {
+		t.Fatalf("NewActiveSet bad glob err = %v, want ErrInvalidSelector", err)
+	}
+
+	state.Envelope.Body.Selectors[0].AgentGlob = "no-match-*"
 	active, err := NewActiveSet(state)
 	if err != nil {
-		t.Fatalf("NewActiveSet: %v", err)
+		t.Fatalf("NewActiveSet valid glob: %v", err)
 	}
 	if resolved, ok := active.Resolve("agent"); ok || resolved != nil {
 		t.Fatalf("Resolve = (%v, %v), want no match", resolved, ok)
@@ -221,6 +226,33 @@ func TestEvaluateHTTP_ContractAllowAndDenyDefault(t *testing.T) {
 		t.Fatalf("allowed decision = %+v", allowed)
 	}
 
+	explicitDefaultPort, err := EvaluateHTTP(EvaluateOptions{
+		Resolved:       &resolved,
+		Request:        HTTPRequest{URL: "https://api.example.com:443/v1/chat", Method: "POST"},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP explicit default port: %v", err)
+	}
+	if explicitDefaultPort.Verdict != config.ActionAllow || explicitDefaultPort.RuleID != "r-chat" {
+		t.Fatalf("explicit default port decision = %+v", explicitDefaultPort)
+	}
+
+	alternatePort, err := EvaluateHTTP(EvaluateOptions{
+		Resolved:       &resolved,
+		Request:        HTTPRequest{URL: "https://api.example.com:8443/v1/chat", Method: "POST"},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP alternate port: %v", err)
+	}
+	if alternatePort.Verdict != config.ActionBlock || alternatePort.WinningSource != WinningSourceContract ||
+		alternatePort.Reason != "contract_non_default_port" {
+		t.Fatalf("alternate port decision = %+v, want contract non-default-port block", alternatePort)
+	}
+
 	denied, err := EvaluateHTTP(EvaluateOptions{
 		Resolved:       &resolved,
 		Request:        HTTPRequest{URL: "https://api.example.com/v1/completions", Method: "POST"},
@@ -263,11 +295,19 @@ func TestEvaluateHTTP_ScannerFallbacksAndErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EvaluateHTTP nil resolved: %v", err)
 	}
-	if decision.Verdict != config.ActionAllow || decision.WinningSource != WinningSourceScanner {
-		t.Fatalf("default scanner decision = %+v", decision)
+	if decision.Verdict != config.ActionBlock || decision.WinningSource != WinningSourceScanner ||
+		decision.Reason != "scanner_decision_missing" {
+		t.Fatalf("missing scanner decision = %+v", decision)
 	}
 	if !contains(decision.PolicySources, PolicySourceScanner) {
 		t.Fatalf("policy_sources = %v, want scanner", decision.PolicySources)
+	}
+	decision, err = EvaluateHTTP(EvaluateOptions{ScannerVerdict: config.ActionAllow})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP explicit scanner allow: %v", err)
+	}
+	if decision.Verdict != config.ActionAllow || decision.Reason != "" {
+		t.Fatalf("explicit scanner decision = %+v", decision)
 	}
 
 	resolved := resolvedContractWithRules(enforceRule("r1", "api.example.com", "/v1/chat", "POST"))
@@ -325,7 +365,7 @@ func TestEvaluateHTTP_SelectorConstraintBranches(t *testing.T) {
 
 	badPathRule := enforceRule("r-badpath", "api.example.com", "/v1/chat", "POST")
 	resolved = resolvedContractWithRules(badPathRule)
-	fallback, err := EvaluateHTTP(EvaluateOptions{
+	blocked, err := EvaluateHTTP(EvaluateOptions{
 		Resolved:       &resolved,
 		Request:        HTTPRequest{URL: "https://api.example.com/v1%2Fchat", Method: "POST"},
 		ScannerVerdict: config.ActionWarn,
@@ -333,8 +373,9 @@ func TestEvaluateHTTP_SelectorConstraintBranches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EvaluateHTTP bad path: %v", err)
 	}
-	if fallback.Verdict != config.ActionWarn || fallback.WinningSource != WinningSourceScanner {
-		t.Fatalf("bad path decision = %+v, want scanner fallback", fallback)
+	if blocked.Verdict != config.ActionBlock || blocked.WinningSource != WinningSourceContract ||
+		blocked.Reason != "contract_invalid_path" {
+		t.Fatalf("bad path decision = %+v, want contract invalid-path block", blocked)
 	}
 }
 
@@ -587,11 +628,17 @@ func TestHelperBranches(t *testing.T) {
 	if containsFolded([]string{"GET"}, "POST") {
 		t.Fatal("containsFolded unexpectedly matched")
 	}
-	if matches, canCompare := ruleMatchesHTTP(contract.Rule{}, mustURL(t, "https://api.example.com/"), HTTPRequest{}); matches || !canCompare {
-		t.Fatalf("empty rule match = (%v, %v), want false,true", matches, canCompare)
+	if matches, canCompare, invalidPath := ruleMatchesHTTP(contract.Rule{}, mustURL(t, "https://api.example.com/"), HTTPRequest{}); matches || !canCompare || invalidPath {
+		t.Fatalf("empty rule match = (%v, %v, %v), want false,true,false", matches, canCompare, invalidPath)
 	}
 	if priority, ok := selectorPriority(contract.ManifestSelector{}, "agent"); priority != 0 || ok {
 		t.Fatalf("selectorPriority empty = (%d, %v)", priority, ok)
+	}
+	if !usesDefaultHTTPPort(mustURL(t, "http://api.example.com:80/")) {
+		t.Fatal("http explicit default port should compare")
+	}
+	if usesDefaultHTTPPort(mustURL(t, "ftp://api.example.com/")) {
+		t.Fatal("non-http scheme should not compare")
 	}
 	alt := enforceRule("r-alt", "api.example.com", "/v2/chat", "GET")
 	if got := selectorPathValues(alt.Selector); len(got) != 1 || got[0] != "/v2/chat" {

--- a/internal/contract/runtime/runtime_test.go
+++ b/internal/contract/runtime/runtime_test.go
@@ -1,0 +1,677 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"encoding/json"
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/contract/store"
+	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+const (
+	testManifestHash = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testContractHash = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	testSelectorID   = "sha256:selector"
+)
+
+func TestActiveSetResolvePrecedenceAndReceiptStamp(t *testing.T) {
+	exactHash := testContractHash
+	globHash := "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	defaultHash := "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	state := store.State{
+		Envelope: contract.ActiveManifestEnvelope{
+			Body: contract.ActiveManifest{
+				Generation: 7,
+				Selectors: []contract.ManifestSelector{
+					{SelectorID: "default", Default: true, ContractHash: defaultHash},
+					{SelectorID: "glob", AgentGlob: "build-*", ContractHash: globHash},
+					{SelectorID: "exact", Agent: "build-agent", ContractHash: exactHash},
+				},
+			},
+		},
+		ManifestHash: testManifestHash,
+		Contracts: map[string]contract.ContractEnvelope{
+			"default": {Body: contract.Contract{ContractHash: defaultHash}},
+			"glob":    {Body: contract.Contract{ContractHash: globHash}},
+			"exact":   {Body: contract.Contract{ContractHash: exactHash}},
+		},
+	}
+
+	active, err := NewActiveSet(state)
+	if err != nil {
+		t.Fatalf("NewActiveSet: %v", err)
+	}
+	resolved, ok := active.Resolve("build-agent")
+	if !ok {
+		t.Fatal("Resolve returned no match")
+	}
+	if resolved.SelectorID != "exact" {
+		t.Fatalf("selector_id = %q, want exact", resolved.SelectorID)
+	}
+	other, ok := active.Resolve("build-worker")
+	if !ok || other.SelectorID != "glob" {
+		t.Fatalf("glob resolve = (%v, %v), want glob match", other, ok)
+	}
+	fallback, ok := active.Resolve("unknown")
+	if !ok || fallback.SelectorID != "default" {
+		t.Fatalf("default resolve = (%v, %v), want default match", fallback, ok)
+	}
+
+	stamped := resolved.ReceiptContext().StampReceipt(contractreceipt.EvidenceReceipt{})
+	if stamped.ActiveManifestHash != testManifestHash {
+		t.Fatalf("active_manifest_hash = %q", stamped.ActiveManifestHash)
+	}
+	if stamped.ContractHash != exactHash || stamped.SelectorID != "exact" || stamped.ContractGeneration != 7 {
+		t.Fatalf("stamped context = %+v", stamped)
+	}
+}
+
+func TestNewActiveSetRejectsMissingContract(t *testing.T) {
+	_, err := NewActiveSet(store.State{
+		Envelope: contract.ActiveManifestEnvelope{
+			Body: contract.ActiveManifest{
+				Generation: 1,
+				Selectors:  []contract.ManifestSelector{{SelectorID: testSelectorID, ContractHash: testContractHash}},
+			},
+		},
+		ManifestHash: testManifestHash,
+		Contracts:    map[string]contract.ContractEnvelope{},
+	})
+	if !errors.Is(err, ErrNoResolvedContract) {
+		t.Fatalf("err = %v, want ErrNoResolvedContract", err)
+	}
+}
+
+func TestActiveSetAccessorsAndInvalidState(t *testing.T) {
+	if (*ActiveSet)(nil).ManifestHash() != "" {
+		t.Fatal("nil ManifestHash should be empty")
+	}
+	if (*ActiveSet)(nil).Generation() != 0 {
+		t.Fatal("nil Generation should be zero")
+	}
+	active, err := NewActiveSet(store.State{
+		Envelope:     contract.ActiveManifestEnvelope{Body: contract.ActiveManifest{Generation: 2}},
+		ManifestHash: testManifestHash,
+		Contracts:    map[string]contract.ContractEnvelope{},
+	})
+	if err != nil {
+		t.Fatalf("NewActiveSet: %v", err)
+	}
+	if active.ManifestHash() != testManifestHash || active.Generation() != 2 {
+		t.Fatalf("accessors = (%q, %d)", active.ManifestHash(), active.Generation())
+	}
+
+	tests := []struct {
+		name  string
+		state store.State
+	}{
+		{
+			name:  "missing manifest hash",
+			state: store.State{Envelope: contract.ActiveManifestEnvelope{Body: contract.ActiveManifest{Generation: 1}}},
+		},
+		{
+			name:  "missing generation",
+			state: store.State{ManifestHash: testManifestHash},
+		},
+		{
+			name: "contract hash mismatch",
+			state: store.State{
+				Envelope: contract.ActiveManifestEnvelope{
+					Body: contract.ActiveManifest{
+						Generation: 1,
+						Selectors:  []contract.ManifestSelector{{SelectorID: testSelectorID, ContractHash: testContractHash}},
+					},
+				},
+				ManifestHash: testManifestHash,
+				Contracts: map[string]contract.ContractEnvelope{
+					testSelectorID: {Body: contract.Contract{ContractHash: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"}},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewActiveSet(tt.state); !errors.Is(err, ErrInvalidDecisionInput) {
+				t.Fatalf("err = %v, want ErrInvalidDecisionInput", err)
+			}
+		})
+	}
+}
+
+func TestResolveNilNoMatchAndBadGlob(t *testing.T) {
+	if resolved, ok := (*ActiveSet)(nil).Resolve("agent"); ok || resolved != nil {
+		t.Fatalf("nil Resolve = (%v, %v), want no match", resolved, ok)
+	}
+	state := store.State{
+		Envelope: contract.ActiveManifestEnvelope{
+			Body: contract.ActiveManifest{
+				Generation: 1,
+				Selectors: []contract.ManifestSelector{
+					{SelectorID: "bad-glob", AgentGlob: "[", ContractHash: testContractHash},
+					{SelectorID: "other", Agent: "other", ContractHash: testContractHash},
+				},
+			},
+		},
+		ManifestHash: testManifestHash,
+		Contracts: map[string]contract.ContractEnvelope{
+			"bad-glob": {Body: contract.Contract{ContractHash: testContractHash}},
+			"other":    {Body: contract.Contract{ContractHash: testContractHash}},
+		},
+	}
+	active, err := NewActiveSet(state)
+	if err != nil {
+		t.Fatalf("NewActiveSet: %v", err)
+	}
+	if resolved, ok := active.Resolve("agent"); ok || resolved != nil {
+		t.Fatalf("Resolve = (%v, %v), want no match", resolved, ok)
+	}
+}
+
+func TestEvaluateHTTP_KillSwitchSuppressesContractEvalButKeepsAuditDecision(t *testing.T) {
+	resolved := resolvedContractWithRules(enforceRule("r-allow", "api.example.com", "/v1/chat", "POST"))
+
+	decision, err := EvaluateHTTP(EvaluateOptions{
+		Resolved:         &resolved,
+		Request:          HTTPRequest{URL: "https://api.example.com/v1/other", Method: "POST"},
+		Mode:             ModeLive,
+		KillSwitchActive: true,
+		ScannerVerdict:   config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP: %v", err)
+	}
+	if decision.Verdict != config.ActionBlock || decision.WinningSource != WinningSourceKillSwitch {
+		t.Fatalf("decision = %+v, want kill-switch block", decision)
+	}
+	if !decision.Suppressed || decision.Drift != nil || decision.Signal != nil {
+		t.Fatalf("kill switch should suppress drift/signal, got %+v", decision)
+	}
+	payload := ProxyDecisionPayload(decision, "delegate", "https://api.example.com/v1/other", "fetch")
+	if payload.WinningSource != WinningSourceKillSwitch {
+		t.Fatalf("winning_source = %q", payload.WinningSource)
+	}
+	if !contains(payload.PolicySources, PolicySourceKillSwitch) {
+		t.Fatalf("policy_sources = %v, want kill_switch", payload.PolicySources)
+	}
+}
+
+func TestEvaluateHTTP_ContractAllowAndDenyDefault(t *testing.T) {
+	resolved := resolvedContractWithRules(enforceRule("r-chat", "api.example.com", "/v1/chat", "POST"))
+
+	allowed, err := EvaluateHTTP(EvaluateOptions{
+		Resolved:       &resolved,
+		Request:        HTTPRequest{URL: "https://API.example.com/V1/CHAT", Method: "post"},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP allow: %v", err)
+	}
+	if allowed.Verdict != config.ActionAllow || allowed.RuleID != "r-chat" || allowed.WinningSource != WinningSourceContract {
+		t.Fatalf("allowed decision = %+v", allowed)
+	}
+
+	denied, err := EvaluateHTTP(EvaluateOptions{
+		Resolved:       &resolved,
+		Request:        HTTPRequest{URL: "https://api.example.com/v1/completions", Method: "POST"},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP deny: %v", err)
+	}
+	if denied.Verdict != config.ActionBlock || denied.WinningSource != WinningSourceContract {
+		t.Fatalf("denied decision = %+v", denied)
+	}
+	if denied.Drift == nil || denied.Drift.Kind != DriftKindPositive {
+		t.Fatalf("drift = %+v, want positive", denied.Drift)
+	}
+	if denied.Signal == nil || *denied.Signal != session.SignalBlock {
+		t.Fatalf("signal = %v, want SignalBlock", denied.Signal)
+	}
+}
+
+func TestEvaluateHTTP_HostScopedDenyDefaultFallsBackToScanner(t *testing.T) {
+	resolved := resolvedContractWithRules(enforceRule("r-chat", "blocked.example.com", "/v1/chat", "POST"))
+
+	decision, err := EvaluateHTTP(EvaluateOptions{
+		Resolved:       &resolved,
+		Request:        HTTPRequest{URL: "https://other.example.com/v1/chat", Method: "POST"},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionWarn,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP: %v", err)
+	}
+	if decision.Verdict != config.ActionWarn || decision.WinningSource != WinningSourceScanner {
+		t.Fatalf("decision = %+v, want scanner fallback", decision)
+	}
+}
+
+func TestEvaluateHTTP_ScannerFallbacksAndErrors(t *testing.T) {
+	decision, err := EvaluateHTTP(EvaluateOptions{})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP nil resolved: %v", err)
+	}
+	if decision.Verdict != config.ActionAllow || decision.WinningSource != WinningSourceScanner {
+		t.Fatalf("default scanner decision = %+v", decision)
+	}
+	if !contains(decision.PolicySources, PolicySourceScanner) {
+		t.Fatalf("policy_sources = %v, want scanner", decision.PolicySources)
+	}
+
+	resolved := resolvedContractWithRules(enforceRule("r1", "api.example.com", "/v1/chat", "POST"))
+	if _, err := EvaluateHTTP(EvaluateOptions{
+		Resolved: &resolved,
+		Request:  HTTPRequest{URL: "://bad"},
+	}); !errors.Is(err, ErrInvalidDecisionInput) {
+		t.Fatalf("invalid URL err = %v", err)
+	}
+
+	badLifecycle := enforceRule("r1", "api.example.com", "/v1/chat", "POST")
+	badLifecycle.LifecycleState = "surprise"
+	resolved = resolvedContractWithRules(badLifecycle)
+	if _, err := EvaluateHTTP(EvaluateOptions{
+		Resolved: &resolved,
+		Request:  HTTPRequest{URL: "https://api.example.com/v1/chat", Method: "POST"},
+	}); !errors.Is(err, ErrUnsupportedLifecycle) {
+		t.Fatalf("lifecycle err = %v", err)
+	}
+}
+
+func TestEvaluateHTTP_SelectorConstraintBranches(t *testing.T) {
+	actionRule := enforceRule("r-action", "api.example.com", "/v1/chat", "POST")
+	actionRule.Selector["effective_action"] = "delegate"
+	resolved := resolvedContractWithRules(actionRule)
+	allowed, err := EvaluateHTTP(EvaluateOptions{
+		Resolved: &resolved,
+		Request: HTTPRequest{
+			URL:             "https://api.example.com/v1/chat",
+			Method:          "POST",
+			EffectiveAction: "delegate",
+		},
+	})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP action match: %v", err)
+	}
+	if allowed.RuleID != "r-action" || allowed.Verdict != config.ActionAllow {
+		t.Fatalf("action match decision = %+v", allowed)
+	}
+
+	denied, err := EvaluateHTTP(EvaluateOptions{
+		Resolved: &resolved,
+		Request: HTTPRequest{
+			URL:             "https://api.example.com/v1/chat",
+			Method:          "POST",
+			EffectiveAction: "read",
+		},
+	})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP action mismatch: %v", err)
+	}
+	if denied.Verdict != config.ActionBlock || denied.RuleID != "r-action" {
+		t.Fatalf("action mismatch decision = %+v", denied)
+	}
+
+	badPathRule := enforceRule("r-badpath", "api.example.com", "/v1/chat", "POST")
+	resolved = resolvedContractWithRules(badPathRule)
+	fallback, err := EvaluateHTTP(EvaluateOptions{
+		Resolved:       &resolved,
+		Request:        HTTPRequest{URL: "https://api.example.com/v1%2Fchat", Method: "POST"},
+		ScannerVerdict: config.ActionWarn,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP bad path: %v", err)
+	}
+	if fallback.Verdict != config.ActionWarn || fallback.WinningSource != WinningSourceScanner {
+		t.Fatalf("bad path decision = %+v, want scanner fallback", fallback)
+	}
+}
+
+func TestEvaluateDrift_OpportunityMissingBlocksAutoDemotion(t *testing.T) {
+	result, err := EvaluateDrift(DriftObservation{
+		Rule:               captureRule("r1"),
+		ContractHash:       testContractHash,
+		Mode:               ModeLive,
+		OpportunityHealthy: false,
+		HistoricalRate:     "0.90",
+		CurrentRate:        "0.10",
+		Window:             "2026-04-30T00:00:00Z/2026-04-30T01:00:00Z",
+		ParentContext:      "api.example.com",
+		MissedWindows:      9,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateDrift: %v", err)
+	}
+	if result.OpportunityAlert == nil {
+		t.Fatal("expected opportunity_missing alert")
+	}
+	if result.Drift != nil || result.AdaptiveSignal != nil || result.ShouldAutoDemote {
+		t.Fatalf("opportunity_missing must not demote or signal: %+v", result)
+	}
+	payload := OpportunityMissingPayload(*result.OpportunityAlert)
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := validateTestPayload(contractreceipt.PayloadOpportunityMissing, raw); err != nil {
+		t.Fatalf("payload validate: %v", err)
+	}
+}
+
+func TestEvaluateDrift_NegativeRequiresThreeClausesAndIsAdaptiveNeutral(t *testing.T) {
+	base := DriftObservation{
+		Rule:                  captureRule("r1"),
+		ContractHash:          testContractHash,
+		Mode:                  ModeLive,
+		OpportunityHealthy:    true,
+		OpportunityObserved:   true,
+		ExpectedObserved:      false,
+		MissedWindows:         3,
+		RequiredMissedWindows: 3,
+	}
+	result, err := EvaluateDrift(base)
+	if err != nil {
+		t.Fatalf("EvaluateDrift: %v", err)
+	}
+	if result.Drift == nil || result.Drift.Kind != DriftKindNegative {
+		t.Fatalf("drift = %+v, want negative", result.Drift)
+	}
+	if result.AdaptiveSignal != nil {
+		t.Fatalf("negative drift should be adaptive-neutral, got %v", result.AdaptiveSignal)
+	}
+
+	base.OpportunityObserved = false
+	none, err := EvaluateDrift(base)
+	if err != nil {
+		t.Fatalf("EvaluateDrift no-op: %v", err)
+	}
+	if none.Drift != nil || none.OpportunityAlert != nil {
+		t.Fatalf("missing opportunity clause should suppress drift, got %+v", none)
+	}
+}
+
+func TestEvaluateDrift_PositiveSignalOnlyInLiveMode(t *testing.T) {
+	live, err := EvaluateDrift(DriftObservation{
+		Rule:               enforceRule("r1", "api.example.com", "/v1/chat", "POST"),
+		ContractHash:       testContractHash,
+		Mode:               ModeLive,
+		OpportunityHealthy: true,
+		UnexpectedObserved: true,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateDrift live: %v", err)
+	}
+	if live.AdaptiveSignal == nil || *live.AdaptiveSignal != session.SignalBlock {
+		t.Fatalf("live signal = %v, want SignalBlock", live.AdaptiveSignal)
+	}
+
+	shadow, err := EvaluateDrift(DriftObservation{
+		Rule:               enforceRule("r1", "api.example.com", "/v1/chat", "POST"),
+		ContractHash:       testContractHash,
+		Mode:               ModeShadow,
+		OpportunityHealthy: true,
+		UnexpectedObserved: true,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateDrift shadow: %v", err)
+	}
+	if shadow.AdaptiveSignal != nil {
+		t.Fatalf("shadow signal = %v, want nil", shadow.AdaptiveSignal)
+	}
+}
+
+func TestEvaluateDrift_SuppressedInvalidAndInactiveBranches(t *testing.T) {
+	result, err := EvaluateDrift(DriftObservation{
+		Rule:             enforceRule("r1", "api.example.com", "/v1/chat", "POST"),
+		ContractHash:     testContractHash,
+		KillSwitchActive: true,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateDrift kill switch: %v", err)
+	}
+	if !result.Suppressed || result.Drift != nil {
+		t.Fatalf("kill switch result = %+v", result)
+	}
+
+	_, err = EvaluateDrift(DriftObservation{
+		Rule:         contract.Rule{RuleID: "r1", LifecycleState: "bad"},
+		ContractHash: testContractHash,
+	})
+	if !errors.Is(err, ErrUnsupportedLifecycle) {
+		t.Fatalf("bad lifecycle err = %v", err)
+	}
+	_, err = EvaluateDrift(DriftObservation{Rule: captureRule("r1")})
+	if !errors.Is(err, ErrInvalidDecisionInput) {
+		t.Fatalf("missing contract hash err = %v", err)
+	}
+	_, err = EvaluateDrift(DriftObservation{
+		Rule:         contract.Rule{LifecycleState: LifecycleCaptureOnly},
+		ContractHash: testContractHash,
+	})
+	if !errors.Is(err, ErrInvalidDecisionInput) {
+		t.Fatalf("missing rule id err = %v", err)
+	}
+
+	for _, state := range []string{LifecycleProposed, LifecycleExpired, LifecycleDemoted} {
+		result, err := EvaluateDrift(DriftObservation{
+			Rule:         contract.Rule{RuleID: "r1", LifecycleState: state},
+			ContractHash: testContractHash,
+		})
+		if err != nil {
+			t.Fatalf("EvaluateDrift %s: %v", state, err)
+		}
+		if result.Drift != nil || result.OpportunityAlert != nil {
+			t.Fatalf("inactive state %s result = %+v", state, result)
+		}
+	}
+}
+
+func TestEvaluateDrift_UsesRuleWindowFloor(t *testing.T) {
+	rule := captureRule("r1")
+	rule.RecurringSupport = map[string]any{"windows_floor": "4"}
+	tooEarly, err := EvaluateDrift(DriftObservation{
+		Rule:                rule,
+		ContractHash:        testContractHash,
+		OpportunityHealthy:  true,
+		OpportunityObserved: true,
+		MissedWindows:       3,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateDrift too early: %v", err)
+	}
+	if tooEarly.Drift != nil {
+		t.Fatalf("drift before floor = %+v", tooEarly)
+	}
+	fired, err := EvaluateDrift(DriftObservation{
+		Rule:                rule,
+		ContractHash:        testContractHash,
+		OpportunityHealthy:  true,
+		OpportunityObserved: true,
+		MissedWindows:       4,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateDrift fired: %v", err)
+	}
+	if fired.Drift == nil || fired.Drift.MissedWindows != 4 {
+		t.Fatalf("drift after floor = %+v", fired)
+	}
+}
+
+func TestContractDriftPayloadValidates(t *testing.T) {
+	payload := ContractDriftPayload(DriftEvent{
+		ContractHash:      testContractHash,
+		RuleID:            "r1",
+		Kind:              DriftKindNegative,
+		MissedWindows:     4,
+		OpportunityStatus: "healthy",
+	})
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := validateTestPayload(contractreceipt.PayloadContractDrift, raw); err != nil {
+		t.Fatalf("payload validate: %v", err)
+	}
+}
+
+func TestHelperBranches(t *testing.T) {
+	if got := observationUint(map[string]any{"n": uint64(9)}, "n"); got != 9 {
+		t.Fatalf("uint64 observation = %d", got)
+	}
+	if got := observationUint(map[string]any{"n": uint(8)}, "n"); got != 8 {
+		t.Fatalf("uint observation = %d", got)
+	}
+	if got := observationUint(map[string]any{"n": int(7)}, "n"); got != 7 {
+		t.Fatalf("int observation = %d", got)
+	}
+	if got := observationUint(map[string]any{"n": int64(6)}, "n"); got != 6 {
+		t.Fatalf("int64 observation = %d", got)
+	}
+	if got := observationUint(map[string]any{"n": float64(5)}, "n"); got != 5 {
+		t.Fatalf("float observation = %d", got)
+	}
+	for _, m := range []map[string]any{
+		nil,
+		{"n": -1},
+		{"n": int64(-1)},
+		{"n": float64(-1)},
+		{"n": "bad"},
+		{"n": []string{"bad"}},
+	} {
+		if got := observationUint(m, "n"); got != 0 {
+			t.Fatalf("observationUint(%v) = %d, want 0", m, got)
+		}
+	}
+
+	sources := normalizePolicySources([]string{" scanner ", "", "scanner", "bundle"})
+	if len(sources) != 2 || sources[0] != PolicySourceScanner || sources[1] != PolicySourceBundle {
+		t.Fatalf("normalizePolicySources = %v", sources)
+	}
+	seen := map[string]struct{}{}
+	rules := appendRuleID(nil, seen, "")
+	rules = appendRuleID(rules, seen, "r1")
+	rules = appendRuleID(rules, seen, "r1")
+	if len(rules) != 1 || rules[0] != "r1" {
+		t.Fatalf("appendRuleID = %v", rules)
+	}
+	if firstString(nil) != "" {
+		t.Fatal("firstString(nil) should be empty")
+	}
+
+	if got := selectorString(map[string]any{"host": "bad"}, "host"); got != "" {
+		t.Fatalf("selectorString bad = %q", got)
+	}
+	if got := selectorMethods(map[string]any{"methods": "bad"}); got != nil {
+		t.Fatalf("selectorMethods bad = %v", got)
+	}
+	if got := selectorMethods(map[string]any{"methods": []any{"GET", 4}}); len(got) != 1 || got[0] != "GET" {
+		t.Fatalf("selectorMethods mixed = %v", got)
+	}
+	if got := selectorPathValues(map[string]any{"paths": "bad"}); got != nil {
+		t.Fatalf("selectorPathValues bad = %v", got)
+	}
+	if got := selectorPathValues(map[string]any{"paths": []any{"bad", map[string]any{"value": 3}, map[string]any{"value": "/ok"}}}); len(got) != 1 || got[0] != "/ok" {
+		t.Fatalf("selectorPathValues mixed = %v", got)
+	}
+	if containsFolded([]string{"GET"}, "POST") {
+		t.Fatal("containsFolded unexpectedly matched")
+	}
+	if matches, canCompare := ruleMatchesHTTP(contract.Rule{}, mustURL(t, "https://api.example.com/"), HTTPRequest{}); matches || !canCompare {
+		t.Fatalf("empty rule match = (%v, %v), want false,true", matches, canCompare)
+	}
+	if priority, ok := selectorPriority(contract.ManifestSelector{}, "agent"); priority != 0 || ok {
+		t.Fatalf("selectorPriority empty = (%d, %v)", priority, ok)
+	}
+	alt := enforceRule("r-alt", "api.example.com", "/v2/chat", "GET")
+	if got := selectorPathValues(alt.Selector); len(got) != 1 || got[0] != "/v2/chat" {
+		t.Fatalf("alternate enforceRule path = %v", got)
+	}
+	if got := selectorMethods(alt.Selector); len(got) != 1 || got[0] != "GET" {
+		t.Fatalf("alternate enforceRule method = %v", got)
+	}
+}
+
+func resolvedContractWithRules(rules ...contract.Rule) ResolvedContract {
+	return ResolvedContract{
+		ActiveManifestHash: testManifestHash,
+		ContractHash:       testContractHash,
+		SelectorID:         testSelectorID,
+		ContractGeneration: 1,
+		Contract: contract.Contract{
+			ContractHash: testContractHash,
+			Rules:        rules,
+		},
+	}
+}
+
+func enforceRule(ruleID, host, pathValue, method string) contract.Rule {
+	rule := captureRule(ruleID)
+	rule.LifecycleState = LifecycleEnforce
+	rule.RuleKind = ruleKindHTTPAction
+	rule.Selector = map[string]any{
+		"host":    map[string]any{"value": host},
+		"paths":   []any{map[string]any{"value": pathValue}},
+		"methods": []any{method},
+	}
+	return rule
+}
+
+func captureRule(ruleID string) contract.Rule {
+	return contract.Rule{
+		RuleID:               ruleID,
+		RuleKind:             ruleKindHTTPDestination,
+		LifecycleState:       LifecycleCaptureOnly,
+		RequiredCaptureGrade: contract.CaptureGradeFull,
+		ObservedCaptureGrade: contract.CaptureGradeFull,
+		RecurringSupport:     map[string]any{"windows_floor": 3},
+		Selector: map[string]any{
+			"host": map[string]any{"value": "api.example.com"},
+		},
+	}
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse URL: %v", err)
+	}
+	return u
+}
+
+func validateTestPayload(kind contractreceipt.PayloadKind, raw []byte) error {
+	return contractreceipt.EvidenceReceipt{
+		RecordType:     contractreceipt.RecordTypeEvidenceV2,
+		ReceiptVersion: 2,
+		PayloadKind:    kind,
+		EventID:        "018f0000-0000-7000-8000-000000000000",
+		Timestamp:      time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC),
+		Signature: contractreceipt.SignatureProof{
+			SignerKeyID: "receipt-key",
+			KeyPurpose:  "receipt-signing",
+			Algorithm:   "ed25519",
+			Signature:   "ed25519:" + strings.Repeat("0", 128),
+		},
+		Payload: raw,
+	}.Validate()
+}


### PR DESCRIPTION
## Summary
- add a contract runtime package for active-set resolution and per-session contract pins
- add HTTP contract evaluation with host-scoped enforce defaults and scanner fallback
- add drift/opportunity helpers plus adaptive signal mapping for live contract enforcement

## Validation
- `go test -race -count=1 ./...`
- `go test -count=1 -cover ./internal/contract/runtime`
- `golangci-lint run ./internal/contract/... ./internal/session/... ./internal/decide/...`
- `git diff --check origin/main...HEAD`
- `git diff origin/main...HEAD | pipelock git scan-diff`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contract-based HTTP request evaluation with configurable enforcement rules
  * Implemented drift detection to identify and alert on unexpected behavior deviations
  * Support for multiple enforcement modes (live, shadow, capture) and dynamic policy resolution
  * Kill-switch mechanism for emergency request blocking

* **Tests**
  * Comprehensive test coverage for request evaluation, drift detection, and contract enforcement behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->