### PR TITLE
Add redaction provider parser registry

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -291,6 +291,13 @@ redaction:
   allowlist_unparseable:
     - api.anthropic.com
     - api.openai.com
+  providers:
+    acme_llm:
+      host_patterns:
+        - api.acme-llm.example
+      path_prefixes:
+        - /v1/messages
+      parser: json
   limits:
     max_body_bytes: 10485760
     max_redactions_per_request: 10000
@@ -311,6 +318,10 @@ redaction:
 | `dictionaries.<name>.case_insensitive` | `false` | Case-insensitive dictionary matching |
 | `dictionaries.<name>.word_boundary` | `false` | Require word boundaries around dictionary entries |
 | `dictionaries.<name>.priority` | `0` | Overlap priority versus built-in classes |
+| `providers` | Anthropic/OpenAI/Gemini built-ins | Provider parser profiles for host/path matching |
+| `providers.<name>.host_patterns` | required when used | Bare hostnames or leading-wildcard host patterns |
+| `providers.<name>.path_prefixes` | `[]` | Optional path prefixes that select the provider profile |
+| `providers.<name>.parser` | `json` | Parser implementation. v1 supports `json` |
 | `limits.max_body_bytes` | `10485760` | Max JSON body size the redactor will rewrite |
 | `limits.max_redactions_per_request` | `10000` | Fail-closed cap on unique placeholders per request |
 | `limits.max_depth` | `64` | Max JSON nesting depth the redactor will traverse |

--- a/docs/guides/receipt-transports.md
+++ b/docs/guides/receipt-transports.md
@@ -69,7 +69,7 @@ Every receipt contains these fields:
 | `layer` | Scanner layer name | Which scanning layer triggered |
 | `pattern` | Reason string | What was matched |
 | `request_id` | Per-request UUID | Request correlation |
-| `redaction` | Request redaction summary | Present only when request-side redaction replaced one or more values; includes `profile`, `total_redactions`, and `by_class` |
+| `redaction` | Request redaction summary | Present only when request-side redaction replaced one or more values; includes `profile`, `provider`, `parser`, `total_redactions`, and `by_class` |
 | `agent` | Agent identity | Which agent made the request |
 | `chain_prev_hash` | SHA-256 of previous receipt | Hash chain linkage |
 | `chain_seq` | Monotonic counter | Position in chain |

--- a/docs/guides/redaction.md
+++ b/docs/guides/redaction.md
@@ -48,6 +48,13 @@ redaction:
   allowlist_unparseable:
     - api.anthropic.com
     - api.openai.com
+  providers:
+    acme_llm:
+      host_patterns:
+        - api.acme-llm.example
+      path_prefixes:
+        - /v1/messages
+      parser: json
 ```
 
 Use a narrow `code` profile for developer traffic and add broader `business` profiles only where you intentionally want hostnames, emails, or customer literals rewritten before they reach upstream systems.
@@ -62,6 +69,12 @@ Use a narrow `code` profile for developer traffic and add broader `business` pro
 
 `allowlist_unparseable` accepts bare lowercase hostnames only. Do not include schemes, paths, or ports. Use it sparingly for trusted endpoints that legitimately require non-JSON request formats.
 
+## Provider Parsers
+
+Pipelock ships parser profiles for Anthropic, OpenAI, and Gemini. All three use the same `json` parser, which walks every string scalar in the request body. Provider matching is only for parser selection and receipt labeling; it does not exempt `system`, `tools`, `messages`, Gemini `contents`, or any other field from redaction.
+
+Third-party JSON providers can be added under `redaction.providers` with `host_patterns`, optional `path_prefixes`, and `parser: json`. Unknown JSON providers still fall back to the generic JSON parser, so a missing provider profile does not become a redaction bypass.
+
 ## Receipts
 
 Successful rewrites add a `redaction` block to the signed action receipt:
@@ -70,6 +83,8 @@ Successful rewrites add a `redaction` block to the signed action receipt:
 {
   "redaction": {
     "profile": "code",
+    "provider": "gemini",
+    "parser": "json",
     "total_redactions": 2,
     "by_class": {
       "aws-access-key": 1,

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"sort"
 	"sync/atomic"
+
+	"github.com/luckyPipewrench/pipelock/internal/redact"
 )
 
 // CanonicalPolicyHash returns a stable SHA-256 digest (hex-encoded) of the
@@ -174,6 +176,7 @@ func (c *Config) policySemanticView() Config {
 	view.APIAllowlist = sortedCopy(view.APIAllowlist)
 	view.Internal = sortedCopy(view.Internal)
 	view.TrustedDomains = sortedCopy(view.TrustedDomains)
+	view.Redaction.Providers = canonicalRedactionProviders(view.Redaction.Enabled, view.Redaction.Providers)
 
 	// Resolve omitted-or-zero learn-inference fields to their effective
 	// defaults so the policy hash reflects the runtime-effective policy,
@@ -186,6 +189,20 @@ func (c *Config) policySemanticView() Config {
 	view.Learn.Inference.Normalization = view.Learn.Inference.Normalization.Resolved()
 
 	return view
+}
+
+func canonicalRedactionProviders(enabled bool, providers map[string]redact.ProviderSpec) map[string]redact.ProviderSpec {
+	if !enabled || len(providers) == 0 {
+		return nil
+	}
+	out := make(map[string]redact.ProviderSpec, len(providers))
+	for name, spec := range providers {
+		cpy := spec
+		cpy.HostPatterns = sortedCopy(cpy.HostPatterns)
+		cpy.PathPrefixes = sortedCopy(cpy.PathPrefixes)
+		out[name] = cpy
+	}
+	return out
 }
 
 // sortedCopy returns a sorted copy of s. Nil in, nil out so that an

--- a/internal/config/canonical_test.go
+++ b/internal/config/canonical_test.go
@@ -5,6 +5,8 @@ package config
 
 import (
 	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/redact"
 )
 
 // Test-local constants for envelope signing field values that repeat
@@ -171,6 +173,27 @@ func TestCanonicalPolicyHash_PolicyFieldsDoAffect(t *testing.T) {
 			},
 		},
 		{
+			name: "redaction provider profile changed",
+			mut: func(c *Config) {
+				c.RequestBodyScanning.Enabled = true
+				c.Redaction = redact.Config{
+					Enabled:        true,
+					DefaultProfile: "code",
+					Profiles: map[string]redact.ProfileSpec{
+						"code": {Classes: []string{string(redact.ClassAWSAccessKey)}},
+					},
+					Providers: map[string]redact.ProviderSpec{
+						"custom": {
+							HostPatterns: []string{"api.custom-llm.example"},
+							PathPrefixes: []string{"/v1/messages"},
+							Parser:       redact.ParserJSON,
+						},
+					},
+					Limits: redact.DefaultLimits(),
+				}
+			},
+		},
+		{
 			// Transport timeouts are enforcement-relevant (DoS
 			// exposure bound, tunnel lifetime) so they must flip ph.
 			// Listen / Upstream addresses are separately excluded as
@@ -200,6 +223,57 @@ func TestCanonicalPolicyHash_PolicyFieldsDoAffect(t *testing.T) {
 					tc.name, base, got)
 			}
 		})
+	}
+}
+
+func TestCanonicalPolicyHash_RedactionProviderOrderCanonical(t *testing.T) {
+	t.Parallel()
+
+	first := canonicalHashOf(t, func(c *Config) {
+		c.RequestBodyScanning.Enabled = true
+		c.Redaction = canonicalProviderTestRedaction([]string{"b.example", "a.example"}, []string{"/v1/messages", "/v1/responses"})
+	})
+	second := canonicalHashOf(t, func(c *Config) {
+		c.RequestBodyScanning.Enabled = true
+		c.Redaction = canonicalProviderTestRedaction([]string{"a.example", "b.example"}, []string{"/v1/responses", "/v1/messages"})
+	})
+	if first != second {
+		t.Fatalf("redaction provider host/path order should canonicalize:\nfirst:  %s\nsecond: %s", first, second)
+	}
+}
+
+func TestCanonicalPolicyHash_DisabledRedactionProviderIsInert(t *testing.T) {
+	t.Parallel()
+
+	base := canonicalHashOf(t, nil)
+	got := canonicalHashOf(t, func(c *Config) {
+		c.Redaction.Providers = map[string]redact.ProviderSpec{
+			"custom": {
+				HostPatterns: []string{"api.custom-llm.example"},
+				Parser:       redact.ParserJSON,
+			},
+		}
+	})
+	if got != base {
+		t.Fatalf("disabled redaction provider profile changed canonical hash:\nbase: %s\ngot:  %s", base, got)
+	}
+}
+
+func canonicalProviderTestRedaction(hosts, paths []string) redact.Config {
+	return redact.Config{
+		Enabled:        true,
+		DefaultProfile: "code",
+		Profiles: map[string]redact.ProfileSpec{
+			"code": {Classes: []string{string(redact.ClassAWSAccessKey)}},
+		},
+		Providers: map[string]redact.ProviderSpec{
+			"custom": {
+				HostPatterns: hosts,
+				PathPrefixes: paths,
+				Parser:       redact.ParserJSON,
+			},
+		},
+		Limits: redact.DefaultLimits(),
 	}
 }
 

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -139,6 +139,9 @@ type BodyScanRequest struct {
 	// permitted through as-is. When the Host is not in this list and the
 	// body is not JSON, redaction fails closed. Nil/empty = strict.
 	RedactAllowlistUnparseable []string
+	// RedactProviderRegistry selects the provider parser profile for JSON
+	// redaction. Nil falls back to the generic JSON parser.
+	RedactProviderRegistry *redact.ProviderRegistry
 	// RedactionRequired indicates the request-scoped policy expects redaction
 	// to run. When the matching runtime is unavailable during a reload window,
 	// scanRequestBody fails closed instead of silently forwarding raw bytes.
@@ -146,6 +149,8 @@ type BodyScanRequest struct {
 	// Host is the upstream hostname being forwarded to, used for allowlist
 	// matching. Empty disables allowlist behavior (strict everywhere).
 	Host string
+	// Path is the upstream request path, used for provider parser selection.
+	Path string
 }
 
 // scanRequestBody reads, buffers, and DLP-scans an HTTP request body.
@@ -315,7 +320,10 @@ func applyRedaction(buf []byte, req BodyScanRequest) ([]byte, *redact.Report, er
 		// receipt summary for a body that was never scanned.
 		return buf, nil, nil
 	}
-	rewritten, report, err := redact.RewriteJSON(buf, req.RedactMatcher, redact.NewRedactor(), req.RedactLimits)
+	rewritten, report, err := redact.RewriteRequestJSON(buf, req.RedactMatcher, redact.NewRedactor(), req.RedactLimits, redact.RequestMetadata{
+		Host: req.Host,
+		Path: req.Path,
+	}, req.RedactProviderRegistry)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/proxy/bodyscan_redact_test.go
+++ b/internal/proxy/bodyscan_redact_test.go
@@ -54,6 +54,38 @@ func TestScanRequestBody_Redaction_BeforeDLPEarlyReturn(t *testing.T) {
 	}
 }
 
+func TestScanRequestBody_Redaction_AnnotatesProviderParser(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	registry, err := redact.NewProviderRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewProviderRegistry: %v", err)
+	}
+	body := `{"contents":[{"parts":[{"text":"use ` + redactionE2ESecret() + `"}]}]}`
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:                   strings.NewReader(body),
+		ContentType:            contentTypeJSON,
+		MaxBytes:               1024,
+		Scanner:                sc,
+		RedactMatcher:          redact.NewDefaultMatcher(),
+		RedactProviderRegistry: registry,
+		Host:                   "generativelanguage.googleapis.com:443",
+		Path:                   "/v1beta/models/gemini-2.5-pro:generateContent",
+	})
+
+	if result.RedactionReport == nil {
+		t.Fatal("expected redaction report")
+	}
+	if result.RedactionReport.Provider != "gemini" {
+		t.Fatalf("provider = %q, want gemini", result.RedactionReport.Provider)
+	}
+	if result.RedactionReport.Parser != redact.ParserJSON {
+		t.Fatalf("parser = %q, want %q", result.RedactionReport.Parser, redact.ParserJSON)
+	}
+}
+
 // TestScanRequestBody_Redaction_NonJSONBlocked enforces fail-closed on
 // non-JSON bodies when redaction is enabled and the host is not on the
 // allowlist. Review §4.7 + round-1 #1.

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -870,6 +870,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			Scanner:         sc,
 			AgentID:         agent,
 			Host:            r.URL.Hostname(),
+			Path:            r.URL.Path,
 		}
 		applyBodyScanRedaction(&bodyReq, p.currentRedactionRuntimeFor(cfg))
 		buf, bodyResult := scanRequestBody(r.Context(), bodyReq)

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -631,6 +631,7 @@ func newInterceptHandler(
 				Scanner:         ic.Scanner,
 				AgentID:         ic.Agent,
 				Host:            r.URL.Hostname(),
+				Path:            r.URL.Path,
 			}
 			applyBodyScanRedaction(&bodyReq, redaction)
 			bodyBytes, result := scanRequestBody(r.Context(), bodyReq)

--- a/internal/proxy/redaction_runtime.go
+++ b/internal/proxy/redaction_runtime.go
@@ -20,6 +20,7 @@ type redactionRuntime struct {
 	matcher              *redact.Matcher
 	limits               redact.Limits
 	allowlistUnparseable []string
+	providers            *redact.ProviderRegistry
 	configKey            string
 	required             bool
 }
@@ -32,11 +33,16 @@ func (p *Proxy) buildRedactionRuntime(cfg *config.Config) (*redactionRuntime, er
 	if matcher == nil {
 		return nil, nil
 	}
+	providers, err := cfg.Redaction.BuildProviderRegistry()
+	if err != nil {
+		return nil, err
+	}
 	allowlist := append([]string(nil), cfg.Redaction.AllowlistUnparseable...)
 	return &redactionRuntime{
 		matcher:              matcher,
 		limits:               cfg.Redaction.Limits.ToLimits(),
 		allowlistUnparseable: allowlist,
+		providers:            providers,
 		configKey:            redactionConfigKey(cfg),
 		required:             cfg.Redaction.Enabled,
 	}, nil
@@ -96,6 +102,7 @@ func currentRedactionRuntimeForConfig(cfg *config.Config, ptr *atomic.Pointer[re
 	return &redactionRuntime{
 		limits:               cfg.Redaction.Limits.ToLimits(),
 		allowlistUnparseable: append([]string(nil), cfg.Redaction.AllowlistUnparseable...),
+		providers:            nil,
 		configKey:            redactionConfigKey(cfg),
 		required:             true,
 	}
@@ -121,4 +128,5 @@ func applyBodyScanRedaction(req *BodyScanRequest, rt *redactionRuntime) {
 	req.RedactMatcher = rt.matcher
 	req.RedactLimits = rt.limits
 	req.RedactAllowlistUnparseable = rt.allowlistUnparseable
+	req.RedactProviderRegistry = rt.providers
 }

--- a/internal/proxy/redaction_runtime.go
+++ b/internal/proxy/redaction_runtime.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"sync/atomic"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -35,7 +36,7 @@ func (p *Proxy) buildRedactionRuntime(cfg *config.Config) (*redactionRuntime, er
 	}
 	providers, err := cfg.Redaction.BuildProviderRegistry()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("build redaction provider registry: %w", err)
 	}
 	allowlist := append([]string(nil), cfg.Redaction.AllowlistUnparseable...)
 	return &redactionRuntime{

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -486,6 +486,7 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 		MaxBytes:        maxBytes,
 		Scanner:         sc,
 		Host:            rp.upstream.Hostname(),
+		Path:            r.URL.Path,
 	}
 	applyBodyScanRedaction(&bodyReq, redaction)
 	bodyBytes, result := scanRequestBody(r.Context(), bodyReq)

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -62,6 +62,7 @@ type wsRelay struct {
 	requestID    string
 	targetURL    string
 	hostname     string
+	path         string
 	maxMsg       int
 	scanText     bool
 	allowBinary  bool
@@ -576,6 +577,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		requestID:    requestID,
 		targetURL:    targetURL,
 		hostname:     strings.ToLower(parsed.Hostname()),
+		path:         parsed.Path,
 		maxMsg:       cfg.WebSocketProxy.MaxMessageBytes,
 		scanText:     scanTextFrames,
 		allowBinary:  cfg.WebSocketProxy.AllowBinaryFrames,
@@ -796,6 +798,7 @@ func (r *wsRelay) scanClientMessageBody(ctx context.Context, msg []byte) ([]byte
 		Scanner:     r.scanner,
 		AgentID:     r.agent,
 		Host:        r.hostname,
+		Path:        r.path,
 	}
 	applyBodyScanRedaction(&bodyReq, r.redaction)
 	return scanRequestBody(ctx, bodyReq)

--- a/internal/receipt/action.go
+++ b/internal/receipt/action.go
@@ -170,6 +170,8 @@ type ActionRecord struct {
 // action. Present only when redaction actually replaced one or more values.
 type RedactionSummary struct {
 	Profile           string         `json:"profile,omitempty"`
+	Provider          string         `json:"provider,omitempty"`
+	Parser            string         `json:"parser,omitempty"`
 	TotalRedactions   int            `json:"total_redactions,omitempty"`
 	ByClass           map[string]int `json:"by_class,omitempty"`
 	CacheBoundaryKept bool           `json:"cache_boundary_kept,omitempty"`

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -337,6 +337,8 @@ func redactionSummaryFromReport(profile string, report *redact.Report) *Redactio
 	}
 	return &RedactionSummary{
 		Profile:         profile,
+		Provider:        report.Provider,
+		Parser:          report.Parser,
 		TotalRedactions: report.TotalRedactions,
 		ByClass:         byClass,
 	}

--- a/internal/receipt/emitter_test.go
+++ b/internal/receipt/emitter_test.go
@@ -270,6 +270,8 @@ func TestEmitter_Emit_RedactionSummary(t *testing.T) {
 		RedactionProfile: "code",
 		RedactionReport: &redact.Report{
 			Applied:         true,
+			Provider:        "gemini",
+			Parser:          redact.ParserJSON,
 			TotalRedactions: 2,
 			ByClass: map[redact.Class]int{
 				redact.ClassAWSAccessKey: 1,
@@ -290,6 +292,12 @@ func TestEmitter_Emit_RedactionSummary(t *testing.T) {
 	}
 	if got.ActionRecord.Redaction.Profile != "code" {
 		t.Fatalf("profile = %q, want %q", got.ActionRecord.Redaction.Profile, "code")
+	}
+	if got.ActionRecord.Redaction.Provider != "gemini" {
+		t.Fatalf("provider = %q, want gemini", got.ActionRecord.Redaction.Provider)
+	}
+	if got.ActionRecord.Redaction.Parser != redact.ParserJSON {
+		t.Fatalf("parser = %q, want %q", got.ActionRecord.Redaction.Parser, redact.ParserJSON)
 	}
 	if got.ActionRecord.Redaction.TotalRedactions != 2 {
 		t.Fatalf("total_redactions = %d, want 2", got.ActionRecord.Redaction.TotalRedactions)

--- a/internal/redact/config.go
+++ b/internal/redact/config.go
@@ -45,6 +45,12 @@ type Config struct {
 	// parseable JSON. Bodies from hosts not in this list are blocked per
 	// the fail-closed invariant.
 	AllowlistUnparseable []string `yaml:"allowlist_unparseable"`
+
+	// Providers registers provider parser profiles. Built-ins for Anthropic,
+	// OpenAI, and Gemini are always present; entries here add or override
+	// profiles without code changes. Provider selection never exempts fields
+	// from scanning — v1 profiles map to the whole-body JSON parser.
+	Providers map[string]ProviderSpec `yaml:"providers" json:"providers,omitempty"`
 }
 
 // ProfileSpec describes a single redaction profile as YAML.
@@ -114,6 +120,9 @@ func (c *Config) Validate() error {
 		if d.Class != "" && !classNameRe.MatchString(d.Class) {
 			return fmt.Errorf("redact: dictionary %q class %q must match [a-z0-9][a-z0-9_-]*", name, d.Class)
 		}
+	}
+	if _, err := NewProviderRegistry(c.Providers); err != nil {
+		return err
 	}
 
 	if !c.Enabled {
@@ -242,6 +251,11 @@ func (c *Config) BuildMatcher(profileName string) (*Matcher, error) {
 	}
 
 	return m, nil
+}
+
+// BuildProviderRegistry returns the redaction provider parser registry for c.
+func (c *Config) BuildProviderRegistry() (*ProviderRegistry, error) {
+	return NewProviderRegistry(c.Providers)
 }
 
 // shippedClassNames returns the set of class string values known to the

--- a/internal/redact/config_test.go
+++ b/internal/redact/config_test.go
@@ -283,6 +283,18 @@ func TestConfig_ValidateStructureWhenDisabled(t *testing.T) {
 		!strings.Contains(err.Error(), "must match") {
 		t.Fatalf("disabled-with-bad-dict-class should still fail, got %v", err)
 	}
+
+	// Malformed provider profile, feature disabled — must still reject.
+	c = Config{
+		Enabled: false,
+		Providers: map[string]ProviderSpec{
+			"bad_provider": {HostPatterns: []string{"api.example.com"}, Parser: "form"},
+		},
+	}
+	if err := c.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "parser") {
+		t.Fatalf("disabled-with-bad-provider should still fail, got %v", err)
+	}
 }
 
 func TestConfig_ValidateAllowlistUnparseable(t *testing.T) {

--- a/internal/redact/providers.go
+++ b/internal/redact/providers.go
@@ -1,0 +1,266 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+)
+
+const (
+	// ParserJSON is the provider parser that walks every string scalar in a
+	// JSON document. Provider-specific parsers intentionally share this
+	// implementation so redaction cannot depend on attacker-controlled field
+	// placement.
+	ParserJSON = "json"
+
+	// ProviderGenericJSON is used when no provider profile matches. It keeps
+	// unknown JSON providers fail-closed-and-redacted instead of depending on a
+	// known-provider allowlist.
+	ProviderGenericJSON = "generic-json"
+)
+
+// RequestMetadata identifies the upstream request enough to select a provider
+// parser profile. Provider selection never suppresses scanning; it only
+// chooses the parser implementation and labels the report.
+type RequestMetadata struct {
+	Host string
+	Path string
+}
+
+// ProviderSpec describes a provider parser profile. Third-party providers can
+// be configured by mapping host patterns and optional path prefixes to a
+// parser. v1 supports the JSON scalar walker only.
+type ProviderSpec struct {
+	HostPatterns []string `yaml:"host_patterns"`
+	PathPrefixes []string `yaml:"path_prefixes,omitempty"`
+	Parser       string   `yaml:"parser,omitempty"`
+}
+
+type providerEntry struct {
+	name string
+	spec ProviderSpec
+}
+
+type providerMatch struct {
+	entry        providerEntry
+	hostExact    bool
+	hostLength   int
+	prefixLength int
+}
+
+// ProviderRegistry is an immutable provider parser registry.
+type ProviderRegistry struct {
+	entries []providerEntry
+}
+
+// DefaultProviderSpecs returns the built-in LLM provider parser profiles.
+func DefaultProviderSpecs() map[string]ProviderSpec {
+	return map[string]ProviderSpec{
+		"anthropic": {
+			HostPatterns: []string{"api.anthropic.com"},
+			PathPrefixes: []string{"/v1/messages"},
+			Parser:       ParserJSON,
+		},
+		"openai": {
+			HostPatterns: []string{"api.openai.com"},
+			PathPrefixes: []string{"/v1/chat/completions", "/v1/responses"},
+			Parser:       ParserJSON,
+		},
+		"gemini": {
+			HostPatterns: []string{"generativelanguage.googleapis.com", "*.generativelanguage.googleapis.com"},
+			PathPrefixes: []string{"/v1/models/", "/v1beta/models/", "/v1alpha/models/"},
+			Parser:       ParserJSON,
+		},
+	}
+}
+
+// NewProviderRegistry builds a registry from built-ins plus operator-defined
+// profiles. Custom profiles with a built-in name override the built-in entry.
+func NewProviderRegistry(custom map[string]ProviderSpec) (*ProviderRegistry, error) {
+	merged := DefaultProviderSpecs()
+	for name, spec := range custom {
+		merged[name] = spec
+	}
+
+	names := make([]string, 0, len(merged))
+	for name, spec := range merged {
+		if err := validateProviderSpec(name, spec); err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	entries := make([]providerEntry, 0, len(names))
+	for _, name := range names {
+		spec := merged[name]
+		if spec.Parser == "" {
+			spec.Parser = ParserJSON
+		}
+		entries = append(entries, providerEntry{name: name, spec: spec})
+	}
+	return &ProviderRegistry{entries: entries}, nil
+}
+
+// Match returns the most specific provider parser for meta, or the generic
+// JSON parser if no provider profile matches.
+func (r *ProviderRegistry) Match(meta RequestMetadata) (provider, parser string) {
+	if r == nil {
+		return ProviderGenericJSON, ParserJSON
+	}
+	host := canonicalHost(meta.Host)
+	path := meta.Path
+	if path == "" {
+		path = "/"
+	}
+
+	var best *providerMatch
+	for _, entry := range r.entries {
+		hostExact, hostLength, ok := providerHostMatch(host, entry.spec.HostPatterns)
+		if !ok {
+			continue
+		}
+		prefixLength, ok := providerPathMatch(path, entry.spec.PathPrefixes)
+		if !ok {
+			continue
+		}
+		candidate := providerMatch{
+			entry:        entry,
+			hostExact:    hostExact,
+			hostLength:   hostLength,
+			prefixLength: prefixLength,
+		}
+		if best == nil || providerMatchLess(*best, candidate) {
+			best = &candidate
+		}
+	}
+	if best != nil {
+		entry := best.entry
+		parser := entry.spec.Parser
+		if parser == "" {
+			parser = ParserJSON
+		}
+		return entry.name, parser
+	}
+	return ProviderGenericJSON, ParserJSON
+}
+
+// RewriteRequestJSON selects the configured provider parser and rewrites body.
+func RewriteRequestJSON(body []byte, m *Matcher, redactor *Redactor, lim Limits, meta RequestMetadata, registry *ProviderRegistry) ([]byte, *Report, error) {
+	provider, parser := registry.Match(meta)
+	if parser != ParserJSON {
+		return nil, nil, newBlock(ReasonInternalError, redactor.Total(), "unsupported redaction provider parser "+parser)
+	}
+	out, report, err := RewriteJSON(body, m, redactor, lim)
+	if err != nil {
+		return nil, nil, err
+	}
+	report.Provider = provider
+	report.Parser = parser
+	return out, report, nil
+}
+
+func validateProviderSpec(name string, spec ProviderSpec) error {
+	if !classNameRe.MatchString(name) {
+		return fmt.Errorf("redact: provider %q must match [a-z0-9][a-z0-9_-]*", name)
+	}
+	parser := spec.Parser
+	if parser == "" {
+		parser = ParserJSON
+	}
+	if parser != ParserJSON {
+		return fmt.Errorf("redact: provider %q parser %q is not supported", name, parser)
+	}
+	if len(spec.HostPatterns) == 0 {
+		return fmt.Errorf("redact: provider %q must define at least one host_pattern", name)
+	}
+	for i, pattern := range spec.HostPatterns {
+		if err := validateProviderHostPattern(pattern); err != nil {
+			return fmt.Errorf("redact: provider %q host_patterns[%d] %q: %w", name, i, pattern, err)
+		}
+	}
+	for i, prefix := range spec.PathPrefixes {
+		if prefix == "" || !strings.HasPrefix(prefix, "/") || strings.ContainsAny(prefix, "?#") {
+			return fmt.Errorf("redact: provider %q path_prefixes[%d] %q must be an absolute path prefix without query or fragment", name, i, prefix)
+		}
+	}
+	return nil
+}
+
+func validateProviderHostPattern(pattern string) error {
+	if pattern == "" {
+		return fmt.Errorf("empty")
+	}
+	if strings.HasPrefix(pattern, "*.") {
+		return validateHostEntry(strings.TrimPrefix(pattern, "*."))
+	}
+	if strings.Contains(pattern, "*") {
+		return fmt.Errorf("wildcard is only supported as a leading *. prefix")
+	}
+	return validateHostEntry(pattern)
+}
+
+func providerMatchLess(a, b providerMatch) bool {
+	if a.hostExact != b.hostExact {
+		return !a.hostExact && b.hostExact
+	}
+	if a.prefixLength != b.prefixLength {
+		return a.prefixLength < b.prefixLength
+	}
+	if a.hostLength != b.hostLength {
+		return a.hostLength < b.hostLength
+	}
+	return a.entry.name > b.entry.name
+}
+
+func providerHostMatch(host string, patterns []string) (exact bool, length int, ok bool) {
+	if host == "" {
+		return false, 0, false
+	}
+	for _, pattern := range patterns {
+		pattern = strings.ToLower(pattern)
+		if pattern == host {
+			if !ok || !exact || len(pattern) > length {
+				exact = true
+				length = len(pattern)
+				ok = true
+			}
+			continue
+		}
+		if strings.HasPrefix(pattern, "*.") && strings.HasSuffix(host, pattern[1:]) {
+			if !ok || (!exact && len(pattern) > length) {
+				exact = false
+				length = len(pattern)
+				ok = true
+			}
+		}
+	}
+	return exact, length, ok
+}
+
+func providerPathMatch(path string, prefixes []string) (length int, ok bool) {
+	if len(prefixes) == 0 {
+		return 0, true
+	}
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(path, prefix) {
+			if len(prefix) > length {
+				length = len(prefix)
+				ok = true
+			}
+		}
+	}
+	return length, ok
+}
+
+func canonicalHost(host string) string {
+	host = strings.ToLower(host)
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return host
+}

--- a/internal/redact/providers.go
+++ b/internal/redact/providers.go
@@ -196,7 +196,11 @@ func validateProviderHostPattern(pattern string) error {
 		return fmt.Errorf("empty")
 	}
 	if strings.HasPrefix(pattern, "*.") {
-		return validateHostEntry(strings.TrimPrefix(pattern, "*."))
+		trimmed := strings.TrimPrefix(pattern, "*.")
+		if strings.Contains(trimmed, "*") {
+			return fmt.Errorf("wildcard is only supported as a leading *. prefix")
+		}
+		return validateHostEntry(trimmed)
 	}
 	if strings.Contains(pattern, "*") {
 		return fmt.Errorf("wildcard is only supported as a leading *. prefix")

--- a/internal/redact/providers_test.go
+++ b/internal/redact/providers_test.go
@@ -131,3 +131,17 @@ func TestProviderRegistry_RejectsUnsupportedParser(t *testing.T) {
 		t.Fatalf("expected unsupported parser error, got %v", err)
 	}
 }
+
+func TestProviderRegistry_RejectsNestedWildcardHostPattern(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewProviderRegistry(map[string]ProviderSpec{
+		"bad_provider": {
+			HostPatterns: []string{"*.*.example.com"},
+			Parser:       ParserJSON,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "wildcard") {
+		t.Fatalf("expected wildcard host pattern error, got %v", err)
+	}
+}

--- a/internal/redact/providers_test.go
+++ b/internal/redact/providers_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRewriteRequestJSON_GeminiParserRedactsWholeBody(t *testing.T) {
+	t.Parallel()
+
+	awsKey := "AKIA" + "IOSFODNN7EXAMPLE"
+	body := []byte(`{
+		"systemInstruction": {"parts": [{"text": "use ` + awsKey + `"}]},
+		"contents": [{"role": "user", "parts": [{"text": "connect to 10.0.0.1"}]}],
+		"tools": [{"functionDeclarations": [{"name": "lookup", "description": "send mail to root@example.com"}]}]
+	}`)
+
+	registry, err := NewProviderRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewProviderRegistry: %v", err)
+	}
+	out, report, err := RewriteRequestJSON(body, NewDefaultMatcher(), NewRedactor(), Limits{}, RequestMetadata{
+		Host: "generativelanguage.googleapis.com:443",
+		Path: "/v1beta/models/gemini-2.5-pro:generateContent",
+	}, registry)
+	if err != nil {
+		t.Fatalf("RewriteRequestJSON: %v", err)
+	}
+	if report.Provider != "gemini" {
+		t.Fatalf("provider = %q, want gemini", report.Provider)
+	}
+	if report.Parser != ParserJSON {
+		t.Fatalf("parser = %q, want %q", report.Parser, ParserJSON)
+	}
+	outStr := string(out)
+	for _, leaked := range []string{awsKey, "10.0.0.1", "root@example.com"} {
+		if strings.Contains(outStr, leaked) {
+			t.Fatalf("Gemini parser leaked %q in %s", leaked, outStr)
+		}
+	}
+}
+
+func TestRewriteRequestJSON_CustomProviderParserRedactsWithoutCodeChange(t *testing.T) {
+	t.Parallel()
+
+	registry, err := NewProviderRegistry(map[string]ProviderSpec{
+		"acme_llm": {
+			HostPatterns: []string{"api.acme-llm.example"},
+			PathPrefixes: []string{"/v1/messages"},
+			Parser:       ParserJSON,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewProviderRegistry: %v", err)
+	}
+
+	body := []byte(`{"input":[{"text":"customer host dc01.corp.local"}]}`)
+	out, report, err := RewriteRequestJSON(body, NewDefaultMatcher(), NewRedactor(), Limits{}, RequestMetadata{
+		Host: "api.acme-llm.example",
+		Path: "/v1/messages",
+	}, registry)
+	if err != nil {
+		t.Fatalf("RewriteRequestJSON: %v", err)
+	}
+	if report.Provider != "acme_llm" {
+		t.Fatalf("provider = %q, want acme_llm", report.Provider)
+	}
+	if strings.Contains(string(out), "dc01.corp.local") {
+		t.Fatalf("custom provider parser leaked FQDN: %s", out)
+	}
+}
+
+func TestProviderRegistry_UnknownProviderFallsBackToGenericJSON(t *testing.T) {
+	t.Parallel()
+
+	registry, err := NewProviderRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewProviderRegistry: %v", err)
+	}
+	provider, parser := registry.Match(RequestMetadata{Host: "unknown.example", Path: "/chat"})
+	if provider != ProviderGenericJSON {
+		t.Fatalf("provider = %q, want %q", provider, ProviderGenericJSON)
+	}
+	if parser != ParserJSON {
+		t.Fatalf("parser = %q, want %q", parser, ParserJSON)
+	}
+}
+
+func TestProviderRegistry_SelectsMostSpecificMatch(t *testing.T) {
+	t.Parallel()
+
+	registry, err := NewProviderRegistry(map[string]ProviderSpec{
+		"aaa_broad_openai": {
+			HostPatterns: []string{"api.openai.com"},
+			PathPrefixes: []string{"/v1"},
+			Parser:       ParserJSON,
+		},
+		"zzz_exact_gemini": {
+			HostPatterns: []string{"us.generativelanguage.googleapis.com"},
+			Parser:       ParserJSON,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewProviderRegistry: %v", err)
+	}
+
+	provider, _ := registry.Match(RequestMetadata{Host: "api.openai.com", Path: "/v1/responses"})
+	if provider != "openai" {
+		t.Fatalf("provider = %q, want openai from longer built-in path prefix", provider)
+	}
+
+	provider, _ = registry.Match(RequestMetadata{Host: "us.generativelanguage.googleapis.com", Path: "/v1beta/models/gemini-2.5-pro:generateContent"})
+	if provider != "zzz_exact_gemini" {
+		t.Fatalf("provider = %q, want exact host custom provider over wildcard built-in", provider)
+	}
+}
+
+func TestProviderRegistry_RejectsUnsupportedParser(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewProviderRegistry(map[string]ProviderSpec{
+		"bad_provider": {
+			HostPatterns: []string{"api.bad-provider.example"},
+			Parser:       "form",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "parser") {
+		t.Fatalf("expected unsupported parser error, got %v", err)
+	}
+}

--- a/internal/redact/walker.go
+++ b/internal/redact/walker.go
@@ -14,6 +14,14 @@ type Report struct {
 	// request was blocked; in that case the accompanying error is a
 	// *BlockError and Body is nil.
 	Applied bool
+	// Provider is the matched provider parser profile. Built-in profiles
+	// include "anthropic", "openai", and "gemini"; unmatched JSON bodies
+	// use "generic-json".
+	Provider string
+	// Parser is the parser implementation used for this request. v1 parsers
+	// all use "json" because security depends on walking every JSON scalar,
+	// not on provider-specific field exemptions.
+	Parser string
 	// TotalRedactions is the count of unique redactions applied.
 	TotalRedactions int
 	// ByClass is the per-class count of unique redactions.


### PR DESCRIPTION
## Summary

- Add a redaction provider registry with built-in Anthropic, OpenAI, and Gemini JSON parser profiles
- Support custom JSON provider profiles through `redaction.providers`
- Thread provider/path metadata through request body redaction for forward, intercept, reverse, and WebSocket paths
- Include redaction `provider` and `parser` metadata in signed receipt summaries
- Canonicalize enabled custom provider profiles into the policy hash
- Document provider parser configuration and receipt fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added configuration and usage guides for provider-specific redaction profiles, host-pattern and path-prefix matching, and updated receipt docs to show provider and parser fields.

* **New Features**
  * Provider-specific parser profiles for redaction (host/path selection).
  * Request scanning now carries path context.
  * Redaction receipts now include provider and parser identifiers for auditability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->