### PR TITLE
feat(learn): add ratify and forget commands

### DIFF
--- a/internal/cli/learn/forget.go
+++ b/internal/cli/learn/forget.go
@@ -1,0 +1,286 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package learn
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/contract/activation"
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const localErasureTombstone = "local_erasure_tombstone"
+
+type forgetFlags struct {
+	candidatePath   string
+	ruleID          string
+	reason          string
+	outPath         string
+	tombstoneDir    string
+	receiptOut      string
+	keystore        string
+	compileKeyAgent string
+	activationKey   string
+	deterministic   bool
+}
+
+func forgetCmd() *cobra.Command {
+	var flags forgetFlags
+	cmd := &cobra.Command{
+		Use:   "forget",
+		Short: "Remove a rule from a candidate and write signed erasure tombstone evidence",
+		Long: `Remove one rule from a candidate contract, re-sign the reduced
+candidate, write a signed tombstone for the prior contract hash, and emit a
+contract_redaction_request evidence receipt.
+
+The original history blob is not overwritten. This command writes a new
+candidate artifact plus tombstone-index evidence for local private erasure.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runForget(cmd, flags)
+		},
+	}
+	cmd.Flags().StringVar(&flags.candidatePath, "candidate", "", "candidate YAML path (required, absolute)")
+	cmd.Flags().StringVar(&flags.ruleID, "rule-id", "", "rule_id to forget (required)")
+	cmd.Flags().StringVar(&flags.reason, "reason", "", "legal reason or ticket reference (required)")
+	cmd.Flags().StringVar(&flags.outPath, "out", "", "forgotten candidate output path")
+	cmd.Flags().StringVar(&flags.tombstoneDir, "tombstone-dir", "", "directory for signed tombstone YAML; defaults next to candidate")
+	cmd.Flags().StringVar(&flags.receiptOut, "receipt-out", "", "redaction receipt JSONL path")
+	cmd.Flags().StringVar(&flags.keystore, "keystore", "", "keystore directory for compile and activation signing")
+	cmd.Flags().StringVar(&flags.compileKeyAgent, "compile-key-agent", "", "keystore agent name for contract re-signing; defaults to candidate signer")
+	cmd.Flags().StringVar(&flags.activationKey, "activation-key", "", "keystore key id for redaction authorization signing")
+	cmd.Flags().BoolVar(&flags.deterministic, "deterministic", false, "use deterministic timestamps, ids, and signing keys for tests")
+	_ = cmd.MarkFlagRequired("candidate")
+	_ = cmd.MarkFlagRequired("rule-id")
+	_ = cmd.MarkFlagRequired("reason")
+	return cmd
+}
+
+func runForget(cmd *cobra.Command, flags forgetFlags) error {
+	if strings.TrimSpace(flags.ruleID) == "" {
+		return fmt.Errorf("%w: --rule-id is required", ErrRuleNotFound)
+	}
+	if strings.TrimSpace(flags.reason) == "" {
+		return fmt.Errorf("learn forget: --reason is required")
+	}
+	clean, env, err := loadCandidateEnvelope(flags.candidatePath)
+	if err != nil {
+		return err
+	}
+	priorHash := env.Body.ContractHash
+	if priorHash == "" {
+		return fmt.Errorf("%w: candidate contract_hash is empty", ErrInvalidCandidate)
+	}
+	if !removeRule(&env.Body, flags.ruleID) {
+		return fmt.Errorf("%w: %q", ErrRuleNotFound, flags.ruleID)
+	}
+	if len(env.Body.Rules) == 0 {
+		return fmt.Errorf("learn forget: refusing to write candidate with no rules")
+	}
+
+	compileSigner, err := resolveForgetCompileSigner(flags, env.Body.SignerKeyID)
+	if err != nil {
+		return err
+	}
+	activationSigner, err := resolveForgetActivationSigner(flags)
+	if err != nil {
+		return err
+	}
+	env.Body.PriorContractHash = priorHash
+	if err := signContractEnvelope(&env, compileSigner); err != nil {
+		return fmt.Errorf("learn forget: sign reduced candidate: %w", err)
+	}
+
+	dest, err := resolveForgetOut(clean, flags.outPath)
+	if err != nil {
+		return err
+	}
+	if err := writeContractEnvelopeYAML(dest, env); err != nil {
+		return err
+	}
+	now := ratifyNow(flags.deterministic)
+	authID := forgetAuthorizationID(flags.deterministic)
+	tombstone := contract.NewTombstone(priorHash, now.Format(timeFormatRFC3339Nano), authID, activationSigner.KeyID())
+	tombstoneEnv, tombstoneHash, err := signTombstone(tombstone, activationSigner)
+	if err != nil {
+		return err
+	}
+	tombstonePath, err := resolveTombstonePath(flags.tombstoneDir, clean, priorHash)
+	if err != nil {
+		return err
+	}
+	if err := writeTombstoneYAML(tombstonePath, tombstoneEnv); err != nil {
+		return err
+	}
+	receiptOut, err := resolveReceiptOut(flags.receiptOut, dest, "redaction-receipts.jsonl")
+	if err != nil {
+		return err
+	}
+	receipt, err := activation.SignReceipt(
+		contractreceipt.PayloadContractRedactionRequest,
+		contractreceipt.PayloadContractRedactionRequestStruct{
+			TargetContractHash: priorHash,
+			RequestKind:        localErasureTombstone,
+			ReasonClass:        strings.TrimSpace(flags.reason),
+			AuthorizationID:    authID,
+			TombstoneHash:      tombstoneHash,
+		},
+		activation.ReceiptContext{
+			EventID:      authID,
+			Timestamp:    now,
+			Principal:    activationSigner.KeyID(),
+			Actor:        "learn forget",
+			ContractHash: priorHash,
+			SelectorID:   env.Body.Selector.SelectorID,
+		},
+		activationSigner,
+		signing.PurposeContractActivationSigning,
+	)
+	if err != nil {
+		return err
+	}
+	if err := appendLifecycleReceipts(receiptOut, receipt); err != nil {
+		return err
+	}
+
+	emitAuditEvent(cmd, auditEvent{
+		Event:           "learn_forget",
+		Candidate:       clean,
+		Dest:            dest,
+		Rule:            flags.ruleID,
+		Output:          receiptOut,
+		Tombstone:       tombstonePath,
+		SignerKeyID:     activationSigner.KeyID(),
+		ReceiptsEmitted: 1,
+	})
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "forget: rule %s removed, candidate written to %s, tombstone written to %s\n",
+		flags.ruleID, dest, tombstonePath)
+	return nil
+}
+
+func removeRule(c *contract.Contract, ruleID string) bool {
+	rules := c.Rules[:0]
+	removed := false
+	for _, rule := range c.Rules {
+		if rule.RuleID == ruleID {
+			removed = true
+			continue
+		}
+		rules = append(rules, rule)
+	}
+	c.Rules = rules
+	return removed
+}
+
+func resolveForgetOut(candidate, out string) (string, error) {
+	if out == "" {
+		out = strings.TrimSuffix(candidate, filepath.Ext(candidate)) + ".forgotten.yaml"
+	}
+	return resolveOut(candidate, out)
+}
+
+func resolveForgetCompileSigner(flags forgetFlags, defaultKey string) (privateKeySigner, error) {
+	if flags.deterministic {
+		seed := sha256.Sum256([]byte("pipelock deterministic forget compile signer"))
+		return privateKeySigner{keyID: "deterministic-contract-compile", key: ed25519.NewKeyFromSeed(seed[:])}, nil
+	}
+	key := flags.compileKeyAgent
+	if key == "" {
+		key = defaultKey
+	}
+	return loadLifecycleSigner(flags.keystore, key)
+}
+
+func resolveForgetActivationSigner(flags forgetFlags) (privateKeySigner, error) {
+	if flags.deterministic {
+		seed := sha256.Sum256([]byte("pipelock deterministic forget activation signer"))
+		return privateKeySigner{keyID: "deterministic-contract-activation", key: ed25519.NewKeyFromSeed(seed[:])}, nil
+	}
+	return loadLifecycleSigner(flags.keystore, flags.activationKey)
+}
+
+func forgetAuthorizationID(deterministic bool) string {
+	if deterministic {
+		return "redaction-deterministic"
+	}
+	id, err := uuid.NewV7()
+	if err != nil {
+		return uuid.NewString()
+	}
+	return id.String()
+}
+
+func signTombstone(body contract.Tombstone, signer privateKeySigner) (contract.TombstoneEnvelope, string, error) {
+	if err := body.Validate(); err != nil {
+		return contract.TombstoneEnvelope{}, "", err
+	}
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		return contract.TombstoneEnvelope{}, "", err
+	}
+	sig, err := signer.Sign(preimage)
+	if err != nil {
+		return contract.TombstoneEnvelope{}, "", err
+	}
+	env := contract.TombstoneEnvelope{Body: body, Signature: "ed25519:" + hex.EncodeToString(sig)}
+	hash, err := tombstoneHash(env)
+	if err != nil {
+		return contract.TombstoneEnvelope{}, "", err
+	}
+	return env, hash, nil
+}
+
+func tombstoneHash(env contract.TombstoneEnvelope) (string, error) {
+	raw, err := json.Marshal(env)
+	if err != nil {
+		return "", err
+	}
+	tree, err := contract.ParseJSONStrict(raw)
+	if err != nil {
+		return "", err
+	}
+	canon, err := contract.Canonicalize(tree)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canon)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func resolveTombstonePath(dir, candidate, priorHash string) (string, error) {
+	if dir == "" {
+		dir = filepath.Join(filepath.Dir(candidate), "tombstones")
+	}
+	cleanDir, err := checkedWriteDir(filepath.Clean(dir))
+	if err != nil {
+		return "", err
+	}
+	name := strings.NewReplacer(":", "-", "/", "-").Replace(priorHash) + ".tombstone.yaml"
+	return checkedWritePath(filepath.Join(cleanDir, name))
+}
+
+func writeTombstoneYAML(path string, env contract.TombstoneEnvelope) error {
+	out, err := marshalYAMLWithJSONTags(env)
+	if err != nil {
+		return fmt.Errorf("learn forget: marshal tombstone: %w", err)
+	}
+	if err := atomicfile.Write(path, out, 0o600); err != nil {
+		return fmt.Errorf("learn forget: write tombstone: %w", err)
+	}
+	return nil
+}
+
+const timeFormatRFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"

--- a/internal/cli/learn/forget.go
+++ b/internal/cli/learn/forget.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -108,9 +109,6 @@ func runForget(cmd *cobra.Command, flags forgetFlags) error {
 	if err != nil {
 		return err
 	}
-	if err := writeContractEnvelopeYAML(dest, env); err != nil {
-		return err
-	}
 	now := ratifyNow(flags.deterministic)
 	authID := forgetAuthorizationID(flags.deterministic)
 	tombstone := contract.NewTombstone(priorHash, now.Format(timeFormatRFC3339Nano), authID, activationSigner.KeyID())
@@ -120,9 +118,6 @@ func runForget(cmd *cobra.Command, flags forgetFlags) error {
 	}
 	tombstonePath, err := resolveTombstonePath(flags.tombstoneDir, clean, priorHash)
 	if err != nil {
-		return err
-	}
-	if err := writeTombstoneYAML(tombstonePath, tombstoneEnv); err != nil {
 		return err
 	}
 	receiptOut, err := resolveReceiptOut(flags.receiptOut, dest, "redaction-receipts.jsonl")
@@ -152,7 +147,20 @@ func runForget(cmd *cobra.Command, flags forgetFlags) error {
 	if err != nil {
 		return err
 	}
+	if err := writeTombstoneYAML(tombstonePath, tombstoneEnv); err != nil {
+		return err
+	}
+	stagedCandidate, err := stageContractEnvelopeYAML(dest, env)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = os.Remove(stagedCandidate)
+	}()
 	if err := appendLifecycleReceipts(receiptOut, receipt); err != nil {
+		return err
+	}
+	if err := commitStagedContract(stagedCandidate, dest); err != nil {
 		return err
 	}
 
@@ -172,6 +180,8 @@ func runForget(cmd *cobra.Command, flags forgetFlags) error {
 }
 
 func removeRule(c *contract.Contract, ruleID string) bool {
+	oldRules := c.Rules
+	oldFieldDataClasses := c.FieldDataClasses
 	rules := c.Rules[:0]
 	removed := false
 	for _, rule := range c.Rules {
@@ -182,6 +192,9 @@ func removeRule(c *contract.Contract, ruleID string) bool {
 		rules = append(rules, rule)
 	}
 	c.Rules = rules
+	if removed {
+		remapRuleFieldDataClasses(c, oldRules, oldFieldDataClasses)
+	}
 	return removed
 }
 

--- a/internal/cli/learn/learn.go
+++ b/internal/cli/learn/learn.go
@@ -43,8 +43,10 @@ Compile and review:
   pipelock learn review <candidate.yaml>
   pipelock learn shadow --contract <candidate.yaml> --sessions <dir>
   pipelock learn diff <shadow-a.json> <shadow-b.json>
+  pipelock learn ratify --candidate <candidate.yaml> --interactive
   pipelock learn promote --contract <hash> --selector <agent|glob|default>
   pipelock learn rollback --to <manifest-hash>
+  pipelock learn forget --candidate <candidate.yaml> --rule-id <id> --reason <legal>
 
 Operator affordances (mutate candidate YAML before ratification):
   pipelock learn split --candidate <path> --rule <rule_id> [--index N] [--out <path>]
@@ -55,8 +57,10 @@ Operator affordances (mutate candidate YAML before ratification):
 	cmd.AddCommand(reviewCmd())
 	cmd.AddCommand(shadowCmd())
 	cmd.AddCommand(diffCmd())
+	cmd.AddCommand(ratifyCmd())
 	cmd.AddCommand(promoteCmd())
 	cmd.AddCommand(rollbackCmd())
+	cmd.AddCommand(forgetCmd())
 	cmd.AddCommand(splitCmd())
 	cmd.AddCommand(pinCmd())
 	return cmd

--- a/internal/cli/learn/ratify.go
+++ b/internal/cli/learn/ratify.go
@@ -1,0 +1,432 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package learn
+
+import (
+	"bufio"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/contract/activation"
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	contractstore "github.com/luckyPipewrench/pipelock/internal/contract/store"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const (
+	ratifyDecisionEnforce = "enforce"
+	ratifyDecisionCapture = "capture_only"
+	ratifyDecisionReject  = "reject"
+)
+
+type ratifyFlags struct {
+	candidatePath   string
+	outPath         string
+	receiptOut      string
+	keystore        string
+	compileKeyAgent string
+	receiptKey      string
+	interactive     bool
+	deterministic   bool
+}
+
+type ratifyDecision struct {
+	RuleID   string
+	Decision string
+}
+
+func ratifyCmd() *cobra.Command {
+	flags := ratifyFlags{receiptKey: defaultReceiptKeyAgent}
+	cmd := &cobra.Command{
+		Use:   "ratify",
+		Short: "Review and ratify candidate contract rules",
+		Long: `Review a candidate contract rule by rule, choose enforce,
+capture-only, or reject for each rule, then write a newly signed candidate
+and a contract_ratified evidence receipt.
+
+Interactive mode reads one decision per rule from stdin: e=enforce,
+c=capture-only, r=reject.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runRatify(cmd, flags)
+		},
+	}
+	cmd.Flags().StringVar(&flags.candidatePath, "candidate", "", "candidate YAML path (required, absolute)")
+	cmd.Flags().StringVar(&flags.outPath, "out", "", "ratified candidate output path; empty rewrites candidate")
+	cmd.Flags().StringVar(&flags.receiptOut, "receipt-out", "", "contract_ratified receipt JSONL path")
+	cmd.Flags().StringVar(&flags.keystore, "keystore", "", "keystore directory for compile and receipt signing")
+	cmd.Flags().StringVar(&flags.compileKeyAgent, "compile-key-agent", "", "keystore agent name for contract re-signing; defaults to candidate signer")
+	cmd.Flags().StringVar(&flags.receiptKey, "receipt-key-agent", flags.receiptKey, "keystore agent name for ratification receipt signing")
+	cmd.Flags().BoolVar(&flags.interactive, "interactive", false, "prompt for each rule decision")
+	cmd.Flags().BoolVar(&flags.deterministic, "deterministic", false, "use deterministic timestamps, ids, and signing keys for tests")
+	_ = cmd.MarkFlagRequired("candidate")
+	return cmd
+}
+
+func runRatify(cmd *cobra.Command, flags ratifyFlags) error {
+	clean, env, err := loadCandidateEnvelope(flags.candidatePath)
+	if err != nil {
+		return err
+	}
+	if len(env.Body.Rules) == 0 {
+		return fmt.Errorf("%w: candidate has no rules", ErrInvalidCandidate)
+	}
+	decisions, err := collectRatifyDecisions(cmd, env.Body, flags.interactive)
+	if err != nil {
+		return err
+	}
+	ratified, decisionMap := applyRatifyDecisions(&env.Body, decisions)
+	if len(ratified) == 0 {
+		return fmt.Errorf("learn ratify: all rules rejected; refusing to emit empty ratification")
+	}
+
+	compileSigner, err := resolveRatifyCompileSigner(flags, env.Body.SignerKeyID)
+	if err != nil {
+		return err
+	}
+	receiptSigner, err := resolveRatifyReceiptSigner(flags)
+	if err != nil {
+		return err
+	}
+	if err := signContractEnvelope(&env, compileSigner); err != nil {
+		return fmt.Errorf("learn ratify: sign candidate: %w", err)
+	}
+
+	dest, err := resolveOut(clean, flags.outPath)
+	if err != nil {
+		return err
+	}
+	if err := writeContractEnvelopeYAML(dest, env); err != nil {
+		return err
+	}
+	receiptOut, err := resolveReceiptOut(flags.receiptOut, dest, "ratification-receipts.jsonl")
+	if err != nil {
+		return err
+	}
+	now := ratifyNow(flags.deterministic)
+	eventID := lifecycleID("", flags.deterministic, "contract-ratified")
+	receipt, err := activation.SignReceipt(
+		contractreceipt.PayloadContractRatified,
+		contractreceipt.PayloadContractRatifiedStruct{
+			ContractHash:                env.Body.ContractHash,
+			RatifierKeyID:               receiptSigner.KeyID(),
+			RatifiedRuleIDs:             ratified,
+			RatificationDecisionPerRule: decisionMap,
+		},
+		activation.ReceiptContext{
+			EventID:            eventID,
+			Timestamp:          now,
+			Principal:          receiptSigner.KeyID(),
+			Actor:              "learn ratify",
+			ContractHash:       env.Body.ContractHash,
+			SelectorID:         env.Body.Selector.SelectorID,
+			ContractGeneration: env.Body.ObservationWindow.EventCount,
+		},
+		receiptSigner,
+		signing.PurposeReceiptSigning,
+	)
+	if err != nil {
+		return err
+	}
+	if err := appendLifecycleReceipts(receiptOut, receipt); err != nil {
+		return err
+	}
+
+	emitAuditEvent(cmd, auditEvent{
+		Event:           "learn_ratify",
+		Candidate:       clean,
+		Dest:            dest,
+		Output:          receiptOut,
+		SignerKeyID:     receiptSigner.KeyID(),
+		RulesRatified:   len(ratified),
+		RulesRejected:   countDecision(decisionMap, ratifyDecisionReject),
+		ReceiptsEmitted: 1,
+	})
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "ratify: %d rules ratified, %d rejected, written to %s\n",
+		len(ratified), countDecision(decisionMap, ratifyDecisionReject), dest)
+	return nil
+}
+
+func loadCandidateEnvelope(path string) (string, contract.ContractEnvelope, error) {
+	clean, doc, err := loadCandidate(path)
+	if err != nil {
+		return "", contract.ContractEnvelope{}, err
+	}
+	raw, err := yamlBytes(doc)
+	if err != nil {
+		return "", contract.ContractEnvelope{}, err
+	}
+	var env contract.ContractEnvelope
+	if err := contract.DecodeStrictYAML(raw, &env); err != nil {
+		return "", contract.ContractEnvelope{}, fmt.Errorf("learn: decode candidate envelope: %w", err)
+	}
+	return clean, env, nil
+}
+
+func collectRatifyDecisions(cmd *cobra.Command, c contract.Contract, interactive bool) ([]ratifyDecision, error) {
+	decisions := make([]ratifyDecision, 0, len(c.Rules))
+	if !interactive {
+		for _, rule := range c.Rules {
+			decisions = append(decisions, ratifyDecision{RuleID: rule.RuleID, Decision: ratifyDecisionEnforce})
+		}
+		return decisions, nil
+	}
+	reader := bufio.NewReader(cmd.InOrStdin())
+	for i, rule := range c.Rules {
+		if err := renderRatifyRule(cmd.OutOrStdout(), c, rule, i); err != nil {
+			return nil, err
+		}
+		choice, err := readRatifyChoice(reader)
+		if err != nil {
+			return nil, err
+		}
+		decisions = append(decisions, ratifyDecision{RuleID: rule.RuleID, Decision: choice})
+	}
+	return decisions, nil
+}
+
+func renderRatifyRule(w io.Writer, c contract.Contract, rule contract.Rule, index int) error {
+	dataClass := dataClassForRule(c, index)
+	_, err := fmt.Fprintf(w, "\nRule %d/%d: %s\nselector: %s\nobservations: %s\nwilson: %s\nconfidence: %s\ndata_class: %s\nfp_risk: %s\nrationale: %s\nsamples: %s\n[e]nforce [c]apture-only [r]eject > ",
+		index+1,
+		len(c.Rules),
+		rule.RuleID,
+		summarizeSelector(rule.Selector),
+		mapValueString(rule.Observation, "event_count"),
+		rule.WilsonLower,
+		rule.Confidence,
+		dataClass,
+		mapValueString(rule.Rationale, "fp_risk_class"),
+		summarizeMap(rule.Rationale),
+		summarizeSamples(rule.Observation),
+	)
+	return err
+}
+
+func readRatifyChoice(reader *bufio.Reader) (string, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil && !errorsIsEOF(err) {
+		return "", fmt.Errorf("learn ratify: read decision: %w", err)
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "e", "enforce":
+		return ratifyDecisionEnforce, nil
+	case "c", "capture", "capture_only":
+		return ratifyDecisionCapture, nil
+	case "r", "reject":
+		return ratifyDecisionReject, nil
+	default:
+		return "", fmt.Errorf("learn ratify: invalid decision %q (want e, c, or r)", strings.TrimSpace(line))
+	}
+}
+
+func errorsIsEOF(err error) bool {
+	return errors.Is(err, io.EOF)
+}
+
+func applyRatifyDecisions(c *contract.Contract, decisions []ratifyDecision) ([]string, map[string]string) {
+	byRule := map[string]string{}
+	for _, d := range decisions {
+		byRule[d.RuleID] = d.Decision
+	}
+	kept := make([]contract.Rule, 0, len(c.Rules))
+	ratified := make([]string, 0, len(c.Rules))
+	decisionMap := make(map[string]string, len(c.Rules))
+	for _, rule := range c.Rules {
+		decision := byRule[rule.RuleID]
+		if decision == "" {
+			decision = ratifyDecisionEnforce
+		}
+		decisionMap[rule.RuleID] = decision
+		if decision == ratifyDecisionReject {
+			continue
+		}
+		rule.LifecycleState = decision
+		kept = append(kept, rule)
+		ratified = append(ratified, rule.RuleID)
+	}
+	sort.Strings(ratified)
+	c.Rules = kept
+	return ratified, decisionMap
+}
+
+func signContractEnvelope(env *contract.ContractEnvelope, signer privateKeySigner) error {
+	env.Body.SignerKeyID = signer.KeyID()
+	env.Body.KeyPurpose = signing.PurposeContractCompileSigning.String()
+	hash, err := contractstore.ContractHash(env.Body)
+	if err != nil {
+		return err
+	}
+	env.Body.ContractHash = hash
+	if err := env.Body.Validate(); err != nil {
+		return err
+	}
+	preimage, err := env.Body.SignablePreimage()
+	if err != nil {
+		return err
+	}
+	sig, err := signer.Sign(preimage)
+	if err != nil {
+		return err
+	}
+	env.Signature = "ed25519:" + hex.EncodeToString(sig)
+	return nil
+}
+
+func writeContractEnvelopeYAML(dest string, env contract.ContractEnvelope) error {
+	out, err := marshalYAMLWithJSONTags(env)
+	if err != nil {
+		return fmt.Errorf("learn: marshal candidate envelope: %w", err)
+	}
+	if err := atomicfile.Write(dest, out, 0o600); err != nil {
+		return fmt.Errorf("learn: write candidate envelope: %w", err)
+	}
+	return nil
+}
+
+func marshalYAMLWithJSONTags(v any) ([]byte, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var tree any
+	if err := yaml.Unmarshal(raw, &tree); err != nil {
+		return nil, err
+	}
+	return yaml.Marshal(tree)
+}
+
+func resolveRatifyCompileSigner(flags ratifyFlags, defaultKey string) (privateKeySigner, error) {
+	if flags.deterministic {
+		seed := sha256.Sum256([]byte("pipelock deterministic ratify compile signer"))
+		return privateKeySigner{keyID: "deterministic-contract-compile", key: ed25519Key(seed)}, nil
+	}
+	key := flags.compileKeyAgent
+	if key == "" {
+		key = defaultKey
+	}
+	return loadLifecycleSigner(flags.keystore, key)
+}
+
+func resolveRatifyReceiptSigner(flags ratifyFlags) (privateKeySigner, error) {
+	if flags.deterministic {
+		seed := sha256.Sum256([]byte("pipelock deterministic ratify receipt signer"))
+		return privateKeySigner{keyID: "deterministic-receipt-signing", key: ed25519Key(seed)}, nil
+	}
+	return loadLifecycleSigner(flags.keystore, flags.receiptKey)
+}
+
+func ed25519Key(seed [32]byte) ed25519.PrivateKey {
+	return ed25519.NewKeyFromSeed(seed[:])
+}
+
+func resolveReceiptOut(path, sibling, name string) (string, error) {
+	if path == "" {
+		path = filepath.Join(filepath.Dir(sibling), name)
+	}
+	return checkedWritePath(filepath.Clean(path))
+}
+
+func ratifyNow(deterministic bool) time.Time {
+	if deterministic {
+		return time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	}
+	return time.Now().UTC()
+}
+
+func dataClassForRule(c contract.Contract, index int) string {
+	for _, key := range []string{
+		fmt.Sprintf("/rules/%d", index),
+		fmt.Sprintf("rules.%d", index),
+		"rules",
+	} {
+		if v := c.FieldDataClasses[key]; v != "" {
+			return v
+		}
+	}
+	if c.DataClassRoot != "" {
+		return c.DataClassRoot
+	}
+	return string(c.Defaults.Privacy.DefaultDataClass)
+}
+
+func summarizeSelector(m map[string]any) string {
+	if len(m) == 0 {
+		return "(none)"
+	}
+	if host := mapValueString(m, "host"); host != "" {
+		if path := mapValueString(m, "path"); path != "" {
+			return host + path
+		}
+		return host
+	}
+	raw, _ := json.Marshal(m)
+	if len(raw) > 160 {
+		return string(raw[:157]) + "..."
+	}
+	return string(raw)
+}
+
+func summarizeMap(m map[string]any) string {
+	if len(m) == 0 {
+		return "(none)"
+	}
+	raw, _ := json.Marshal(m)
+	if len(raw) > 180 {
+		return string(raw[:177]) + "..."
+	}
+	return string(raw)
+}
+
+func summarizeSamples(m map[string]any) string {
+	for _, key := range []string{"redacted_samples", "sample_hashes", "exemplar_ids"} {
+		if v := mapValueString(m, key); v != "" {
+			return v
+		}
+	}
+	return "(redacted)"
+}
+
+func mapValueString(m map[string]any, key string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	v, ok := m[key]
+	if !ok || v == nil {
+		return ""
+	}
+	switch typed := v.(type) {
+	case string:
+		return typed
+	case json.Number:
+		return typed.String()
+	default:
+		raw, _ := json.Marshal(typed)
+		return string(raw)
+	}
+}
+
+func countDecision(decisions map[string]string, decision string) int {
+	n := 0
+	for _, got := range decisions {
+		if got == decision {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/cli/learn/ratify.go
+++ b/internal/cli/learn/ratify.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -111,9 +112,6 @@ func runRatify(cmd *cobra.Command, flags ratifyFlags) error {
 	if err != nil {
 		return err
 	}
-	if err := writeContractEnvelopeYAML(dest, env); err != nil {
-		return err
-	}
 	receiptOut, err := resolveReceiptOut(flags.receiptOut, dest, "ratification-receipts.jsonl")
 	if err != nil {
 		return err
@@ -143,7 +141,17 @@ func runRatify(cmd *cobra.Command, flags ratifyFlags) error {
 	if err != nil {
 		return err
 	}
+	stagedCandidate, err := stageContractEnvelopeYAML(dest, env)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = os.Remove(stagedCandidate)
+	}()
 	if err := appendLifecycleReceipts(receiptOut, receipt); err != nil {
+		return err
+	}
+	if err := commitStagedContract(stagedCandidate, dest); err != nil {
 		return err
 	}
 
@@ -247,7 +255,9 @@ func applyRatifyDecisions(c *contract.Contract, decisions []ratifyDecision) ([]s
 	kept := make([]contract.Rule, 0, len(c.Rules))
 	ratified := make([]string, 0, len(c.Rules))
 	decisionMap := make(map[string]string, len(c.Rules))
-	for _, rule := range c.Rules {
+	oldRules := c.Rules
+	oldFieldDataClasses := c.FieldDataClasses
+	for _, rule := range oldRules {
 		decision := byRule[rule.RuleID]
 		if decision == "" {
 			decision = ratifyDecisionEnforce
@@ -262,6 +272,7 @@ func applyRatifyDecisions(c *contract.Contract, decisions []ratifyDecision) ([]s
 	}
 	sort.Strings(ratified)
 	c.Rules = kept
+	remapRuleFieldDataClasses(c, oldRules, oldFieldDataClasses)
 	return ratified, decisionMap
 }
 
@@ -297,6 +308,55 @@ func writeContractEnvelopeYAML(dest string, env contract.ContractEnvelope) error
 		return fmt.Errorf("learn: write candidate envelope: %w", err)
 	}
 	return nil
+}
+
+func stageContractEnvelopeYAML(dest string, env contract.ContractEnvelope) (string, error) {
+	tmp, err := os.CreateTemp(filepath.Dir(dest), "."+filepath.Base(dest)+".*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("learn: create candidate staging file: %w", err)
+	}
+	staged := tmp.Name()
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(staged)
+		return "", fmt.Errorf("learn: close candidate staging file: %w", err)
+	}
+	if err := os.Remove(staged); err != nil {
+		return "", fmt.Errorf("learn: clear candidate staging file: %w", err)
+	}
+	if err := writeContractEnvelopeYAML(staged, env); err != nil {
+		_ = os.Remove(staged)
+		return "", err
+	}
+	return staged, nil
+}
+
+func commitStagedContract(staged, dest string) error {
+	if err := os.Rename(staged, dest); err != nil {
+		return fmt.Errorf("learn: commit candidate envelope: %w", err)
+	}
+	return nil
+}
+
+func remapRuleFieldDataClasses(c *contract.Contract, oldRules []contract.Rule, oldClasses map[string]string) {
+	if len(oldClasses) == 0 {
+		return
+	}
+	byRuleID := map[string]string{}
+	for i, rule := range oldRules {
+		if class := oldClasses[fmt.Sprintf("/rules/%d", i)]; class != "" {
+			byRuleID[rule.RuleID] = class
+		}
+	}
+	for key := range c.FieldDataClasses {
+		if strings.HasPrefix(key, "/rules/") {
+			delete(c.FieldDataClasses, key)
+		}
+	}
+	for i, rule := range c.Rules {
+		if class := byRuleID[rule.RuleID]; class != "" {
+			c.FieldDataClasses[fmt.Sprintf("/rules/%d", i)] = class
+		}
+	}
 }
 
 func marshalYAMLWithJSONTags(v any) ([]byte, error) {

--- a/internal/cli/learn/ratify_forget_test.go
+++ b/internal/cli/learn/ratify_forget_test.go
@@ -1,0 +1,228 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package learn
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+)
+
+func TestLearnCmdRegistersRatifyAndForget(t *testing.T) {
+	cmd := Cmd()
+	for _, name := range []string{"ratify", "forget"} {
+		t.Run(name, func(t *testing.T) {
+			for _, child := range cmd.Commands() {
+				if child.Name() == name {
+					return
+				}
+			}
+			t.Fatalf("learn command missing %q", name)
+		})
+	}
+}
+
+func TestRatifyInteractiveRejectsOneRuleAndSignsReceipt(t *testing.T) {
+	dir := t.TempDir()
+	candidate := writeCandidateEnvelope(t, dir, testRatifyContract())
+	out := filepath.Join(dir, "ratified.yaml")
+	receiptOut := filepath.Join(dir, "ratify.jsonl")
+	cmd, stdout := learnTestCmd("e\nr\n")
+
+	err := runRatify(cmd, ratifyFlags{
+		candidatePath: candidate,
+		outPath:       out,
+		receiptOut:    receiptOut,
+		interactive:   true,
+		deterministic: true,
+	})
+	if err != nil {
+		t.Fatalf("runRatify: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Rule 1/2") || !strings.Contains(stdout.String(), "data_class: internal") {
+		t.Fatalf("interactive review output missing rule/data-class context:\n%s", stdout.String())
+	}
+	_, env, err := loadCandidateEnvelope(out)
+	if err != nil {
+		t.Fatalf("load ratified candidate: %v", err)
+	}
+	if len(env.Body.Rules) != 1 || env.Body.Rules[0].RuleID != "r-enforce" {
+		t.Fatalf("ratified rules = %#v", env.Body.Rules)
+	}
+	if env.Body.Rules[0].LifecycleState != ratifyDecisionEnforce {
+		t.Fatalf("lifecycle_state = %q", env.Body.Rules[0].LifecycleState)
+	}
+	rcpt := readOneReceipt(t, receiptOut)
+	if rcpt.PayloadKind != contractreceipt.PayloadContractRatified {
+		t.Fatalf("payload_kind = %q", rcpt.PayloadKind)
+	}
+	var payload contractreceipt.PayloadContractRatifiedStruct
+	if err := json.Unmarshal(rcpt.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.RatificationDecisionPerRule["r-reject"] != ratifyDecisionReject {
+		t.Fatalf("decision map = %#v", payload.RatificationDecisionPerRule)
+	}
+}
+
+func TestForgetRemovesRuleWritesTombstoneAndRedactionReceipt(t *testing.T) {
+	dir := t.TempDir()
+	candidate := writeCandidateEnvelope(t, dir, testRatifyContract())
+	out := filepath.Join(dir, "forgotten.yaml")
+	receiptOut := filepath.Join(dir, "redaction.jsonl")
+	tombstoneDir := filepath.Join(dir, "tombstones")
+	cmd, stdout := learnTestCmd("")
+
+	err := runForget(cmd, forgetFlags{
+		candidatePath: candidate,
+		ruleID:        "r-reject",
+		reason:        "legal-ticket-123",
+		outPath:       out,
+		tombstoneDir:  tombstoneDir,
+		receiptOut:    receiptOut,
+		deterministic: true,
+	})
+	if err != nil {
+		t.Fatalf("runForget: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "tombstone written") {
+		t.Fatalf("stdout missing tombstone path: %s", stdout.String())
+	}
+	_, env, err := loadCandidateEnvelope(out)
+	if err != nil {
+		t.Fatalf("load forgotten candidate: %v", err)
+	}
+	if len(env.Body.Rules) != 1 || env.Body.Rules[0].RuleID != "r-enforce" {
+		t.Fatalf("forgotten rules = %#v", env.Body.Rules)
+	}
+	matches, err := filepath.Glob(filepath.Join(tombstoneDir, "*.tombstone.yaml"))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("tombstone matches=%v err=%v", matches, err)
+	}
+	var tombstone contract.TombstoneEnvelope
+	raw, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatalf("read tombstone: %v", err)
+	}
+	if err := yaml.Unmarshal(raw, &tombstone); err != nil {
+		t.Fatalf("unmarshal tombstone: %v", err)
+	}
+	if !tombstone.Body.Tombstone || tombstone.Signature == "" {
+		t.Fatalf("bad tombstone envelope: %+v", tombstone)
+	}
+	rcpt := readOneReceipt(t, receiptOut)
+	if rcpt.PayloadKind != contractreceipt.PayloadContractRedactionRequest {
+		t.Fatalf("payload_kind = %q", rcpt.PayloadKind)
+	}
+	var payload contractreceipt.PayloadContractRedactionRequestStruct
+	if err := json.Unmarshal(rcpt.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal redaction payload: %v", err)
+	}
+	if payload.RequestKind != localErasureTombstone || payload.ReasonClass != "legal-ticket-123" || payload.TombstoneHash == "" {
+		t.Fatalf("redaction payload = %+v", payload)
+	}
+}
+
+func testRatifyContract() contract.Contract {
+	return contract.Contract{
+		SchemaVersion:    contract.SchemaVersionContract,
+		ContractKind:     contract.ContractKind,
+		SignerKeyID:      "compile-signer",
+		KeyPurpose:       "contract-compile-signing",
+		DataClassRoot:    "internal",
+		FieldDataClasses: map[string]string{"/rules/0": "internal", "/rules/1": "internal"},
+		Selector:         contract.Selector{Agent: "agent-a", SelectorID: "sha256:selector"},
+		ObservationWindow: contract.ObservationWindow{
+			Start:                 time.Date(2026, 4, 30, 10, 0, 0, 0, time.UTC),
+			End:                   time.Date(2026, 4, 30, 11, 0, 0, 0, time.UTC),
+			EventCount:            42,
+			SessionCount:          3,
+			ObservationWindowRoot: "sha256:window",
+		},
+		Defaults: contract.ContractDefaults{
+			Privacy: contract.ContractDefaultsPrivacy{DefaultDataClass: "internal"},
+		},
+		Rules: []contract.Rule{
+			testRule("r-enforce", "api.example.com", "/v1/users"),
+			testRule("r-reject", "api.example.com", "/v1/admin"),
+		},
+	}
+}
+
+func testRule(id, host, path string) contract.Rule {
+	return contract.Rule{
+		RuleID:               id,
+		DisplayName:          id,
+		RuleKind:             "http_destination",
+		LifecycleState:       "capture_only",
+		RequiredCaptureGrade: contract.CaptureGradeFull,
+		ObservedCaptureGrade: contract.CaptureGradeFull,
+		Confidence:           "high",
+		WilsonLower:          "0.990000",
+		Observation:          map[string]any{"event_count": "21", "redacted_samples": []any{"sha256:sample"}},
+		Selector:             map[string]any{"host": host, "path": path},
+		Rationale:            map[string]any{"fp_risk_class": "low"},
+		RecurringSupport:     map[string]any{},
+		OpportunityHealth:    map[string]any{},
+	}
+}
+
+func writeCandidateEnvelope(t *testing.T, dir string, c contract.Contract) string {
+	t.Helper()
+	seed := sha256.Sum256([]byte("test candidate signer"))
+	env := contract.ContractEnvelope{Body: c}
+	if err := signContractEnvelope(&env, privateKeySigner{
+		keyID: "compile-signer",
+		key:   ed25519.NewKeyFromSeed(seed[:]),
+	}); err != nil {
+		t.Fatalf("signContractEnvelope: %v", err)
+	}
+	path := filepath.Join(dir, "candidate.yaml")
+	if err := writeContractEnvelopeYAML(path, env); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+	return path
+}
+
+func learnTestCmd(input string) (*cobra.Command, *bytes.Buffer) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	return cmd, stdout
+}
+
+func readOneReceipt(t *testing.T, path string) contractreceipt.EvidenceReceipt {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Clean(path)) //nolint:gosec // test path is generated inside t.TempDir
+	if err != nil {
+		t.Fatalf("read receipt: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("receipt lines = %d, want 1\n%s", len(lines), string(raw))
+	}
+	var rcpt contractreceipt.EvidenceReceipt
+	if err := json.Unmarshal([]byte(lines[0]), &rcpt); err != nil {
+		t.Fatalf("unmarshal receipt: %v", err)
+	}
+	if err := rcpt.Validate(); err != nil {
+		t.Fatalf("receipt Validate: %v", err)
+	}
+	return rcpt
+}

--- a/internal/cli/learn/ratify_forget_test.go
+++ b/internal/cli/learn/ratify_forget_test.go
@@ -40,7 +40,7 @@ func TestRatifyInteractiveRejectsOneRuleAndSignsReceipt(t *testing.T) {
 	candidate := writeCandidateEnvelope(t, dir, testRatifyContract())
 	out := filepath.Join(dir, "ratified.yaml")
 	receiptOut := filepath.Join(dir, "ratify.jsonl")
-	cmd, stdout := learnTestCmd("e\nr\n")
+	cmd, stdout := learnTestCmd("r\ne\n")
 
 	err := runRatify(cmd, ratifyFlags{
 		candidatePath: candidate,
@@ -59,11 +59,17 @@ func TestRatifyInteractiveRejectsOneRuleAndSignsReceipt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load ratified candidate: %v", err)
 	}
-	if len(env.Body.Rules) != 1 || env.Body.Rules[0].RuleID != "r-enforce" {
+	if len(env.Body.Rules) != 1 || env.Body.Rules[0].RuleID != "r-reject" {
 		t.Fatalf("ratified rules = %#v", env.Body.Rules)
 	}
 	if env.Body.Rules[0].LifecycleState != ratifyDecisionEnforce {
 		t.Fatalf("lifecycle_state = %q", env.Body.Rules[0].LifecycleState)
+	}
+	if env.Body.FieldDataClasses["/rules/0"] != "internal" {
+		t.Fatalf("field_data_classes[/rules/0] = %q, want internal", env.Body.FieldDataClasses["/rules/0"])
+	}
+	if _, ok := env.Body.FieldDataClasses["/rules/1"]; ok {
+		t.Fatalf("stale field_data_classes[/rules/1] remains: %#v", env.Body.FieldDataClasses)
 	}
 	rcpt := readOneReceipt(t, receiptOut)
 	if rcpt.PayloadKind != contractreceipt.PayloadContractRatified {
@@ -73,7 +79,7 @@ func TestRatifyInteractiveRejectsOneRuleAndSignsReceipt(t *testing.T) {
 	if err := json.Unmarshal(rcpt.Payload, &payload); err != nil {
 		t.Fatalf("unmarshal payload: %v", err)
 	}
-	if payload.RatificationDecisionPerRule["r-reject"] != ratifyDecisionReject {
+	if payload.RatificationDecisionPerRule["r-enforce"] != ratifyDecisionReject {
 		t.Fatalf("decision map = %#v", payload.RatificationDecisionPerRule)
 	}
 }
@@ -88,7 +94,7 @@ func TestForgetRemovesRuleWritesTombstoneAndRedactionReceipt(t *testing.T) {
 
 	err := runForget(cmd, forgetFlags{
 		candidatePath: candidate,
-		ruleID:        "r-reject",
+		ruleID:        "r-enforce",
 		reason:        "legal-ticket-123",
 		outPath:       out,
 		tombstoneDir:  tombstoneDir,
@@ -105,8 +111,14 @@ func TestForgetRemovesRuleWritesTombstoneAndRedactionReceipt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load forgotten candidate: %v", err)
 	}
-	if len(env.Body.Rules) != 1 || env.Body.Rules[0].RuleID != "r-enforce" {
+	if len(env.Body.Rules) != 1 || env.Body.Rules[0].RuleID != "r-reject" {
 		t.Fatalf("forgotten rules = %#v", env.Body.Rules)
+	}
+	if env.Body.FieldDataClasses["/rules/0"] != "internal" {
+		t.Fatalf("field_data_classes[/rules/0] = %q, want internal", env.Body.FieldDataClasses["/rules/0"])
+	}
+	if _, ok := env.Body.FieldDataClasses["/rules/1"]; ok {
+		t.Fatalf("stale field_data_classes[/rules/1] remains: %#v", env.Body.FieldDataClasses)
 	}
 	matches, err := filepath.Glob(filepath.Join(tombstoneDir, "*.tombstone.yaml"))
 	if err != nil || len(matches) != 1 {

--- a/internal/cli/learn/split.go
+++ b/internal/cli/learn/split.go
@@ -748,6 +748,9 @@ type auditEvent struct {
 	RulesEmitted      int      `json:"rules_emitted,omitempty"`
 	Quarantines       int      `json:"quarantines,omitempty"`
 	ReceiptsEmitted   int      `json:"receipts_emitted,omitempty"`
+	RulesRatified     int      `json:"rules_ratified,omitempty"`
+	RulesRejected     int      `json:"rules_rejected,omitempty"`
+	Tombstone         string   `json:"tombstone,omitempty"`
 	CrossAgentSigning bool     `json:"cross_agent_signing,omitempty"`
 	NoOp              bool     `json:"noop"`
 }


### PR DESCRIPTION
## Summary
- add `pipelock learn ratify` for rule-level enforce/capture/reject decisions
- add `pipelock learn forget` for local rule removal with signed tombstone evidence
- emit signed ratification and redaction-request receipts
- add tests for ratify and forget command flows

## Tests
- go test -race -count=1 ./...
- golangci-lint run ./...
- git diff --check
- git diff | pipelock git scan-diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `learn ratify` for interactive or batch rule ratification with signed receipts.
  * Added `learn forget` to remove rules, emit tombstones, and produce redaction receipts.
  * Audit logging extended to include ratification/rejection counts and tombstone references.

* **Tests**
  * New test suite covering `ratify` and `forget` flows, outputs, and generated receipts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->