### PR TITLE
chore: --header for mcp http upstream + wildcard exempt-domain parity

### DIFF
--- a/internal/cli/runtime/dlp_warn_emit_test.go
+++ b/internal/cli/runtime/dlp_warn_emit_test.go
@@ -20,7 +20,11 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
-const mcpToolsCallResource = "tools/call"
+const (
+	mcpInitializeResource = "initialize"
+	mcpToolsListResource  = "tools/list"
+	mcpToolsCallResource  = "tools/call"
+)
 
 func TestEmitDLPWarnWritesReceiptAndMetric(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(nil)

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
@@ -44,6 +45,58 @@ import (
 	session "github.com/luckyPipewrench/pipelock/internal/session"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
+
+// reservedTransportHeaders are header names operators must not override via
+// --header. The MCP HTTP transport manages framing (Content-Type, Accept,
+// Content-Length, Transfer-Encoding), session correlation (Mcp-Session-Id),
+// and host routing (Host). Letting --header clobber any of these would
+// either break the transport contract or — for Mcp-Session-Id specifically —
+// let an attacker pin the upstream's session correlation to a value of their
+// choice on the very first request, before HTTPClient has a session ID to
+// overwrite with. Lookup is canonical (textproto) so case variants like
+// "mcp-session-id" or "MCP-SESSION-ID" are also rejected.
+var reservedTransportHeaders = map[string]struct{}{
+	http.CanonicalHeaderKey("Content-Type"):      {},
+	http.CanonicalHeaderKey("Accept"):            {},
+	http.CanonicalHeaderKey("Mcp-Session-Id"):    {},
+	http.CanonicalHeaderKey("Content-Length"):    {},
+	http.CanonicalHeaderKey("Transfer-Encoding"): {},
+	http.CanonicalHeaderKey("Host"):              {},
+}
+
+// parseHeaderFlags converts repeatable --header "Key: Value" entries into an
+// http.Header. Returns nil for an empty input so callers can pass the result
+// straight to transports that interpret nil as "no extras". Both an empty
+// key and a missing colon are rejected with a descriptive error so a typo
+// (e.g. "Authorization Bearer xyz") can't silently drop the auth header.
+//
+// Reserved transport-managed headers are rejected with a descriptive error
+// so an operator does not accidentally poison transport framing or — in the
+// Mcp-Session-Id case — force the upstream onto an attacker-chosen session
+// correlation token on the first request. The transport also strips these
+// defensively (defense-in-depth), but rejecting at parse time gives a
+// clearer error than silent removal would.
+func parseHeaderFlags(raw []string) (http.Header, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	h := make(http.Header, len(raw))
+	for _, entry := range raw {
+		key, value, ok := strings.Cut(entry, ":")
+		if !ok {
+			return nil, fmt.Errorf("--header %q: expected 'Key: Value' format", entry)
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("--header %q: key is empty", entry)
+		}
+		if _, reserved := reservedTransportHeaders[http.CanonicalHeaderKey(key)]; reserved {
+			return nil, fmt.Errorf("--header %q: %q is managed by the MCP HTTP transport and cannot be overridden via --header", entry, key)
+		}
+		h.Add(key, strings.TrimSpace(value))
+	}
+	return h, nil
+}
 
 // handleProxyError classifies MCP proxy errors: subprocess exits get a
 // user-facing message and a specific exit code; other errors are reported
@@ -192,6 +245,7 @@ func mcpProxyCmd() *cobra.Command {
 	var upstreamURL string
 	var listenAddr string
 	var envVars []string
+	var rawHeaders []string
 	var agentName string
 	var sandboxEnabled bool
 	var sandboxStrict bool
@@ -591,6 +645,14 @@ signed action receipts for MCP decisions.`,
 					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning: --env is ignored in HTTP transport mode (no child process)")
 				}
 
+				extraHeaders, headerErr := parseHeaderFlags(rawHeaders)
+				if headerErr != nil {
+					return headerErr
+				}
+				if len(extraHeaders) > 0 && (hasListen || isWSUpstream) {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning: --header is only honored in stdio-to-HTTP --upstream mode; ignored for --listen and ws/wss upstreams")
+				}
+
 				ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 				defer cancel()
 
@@ -693,7 +755,7 @@ signed action receipts for MCP decisions.`,
 					RedactProfile:   cfg.Redaction.DefaultProfile,
 					TaintCfg:        &cfg.Taint,
 				}
-				if err := mcp.RunHTTPProxy(ctx, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), upstreamURL, nil, httpOpts); err != nil {
+				if err := mcp.RunHTTPProxy(ctx, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), upstreamURL, extraHeaders, httpOpts); err != nil {
 					if sentryClient != nil {
 						sentryClient.CaptureError(err)
 					}
@@ -947,6 +1009,7 @@ signed action receipts for MCP decisions.`,
 	cmd.Flags().StringVar(&upstreamURL, "upstream", "", "upstream MCP server URL (Streamable HTTP transport)")
 	cmd.Flags().StringVar(&listenAddr, "listen", "", "listen address for HTTP reverse proxy mode (e.g. 0.0.0.0:8889)")
 	cmd.Flags().StringArrayVar(&envVars, "env", nil, "pass environment variable to child process (KEY or KEY=VALUE, repeatable)")
+	cmd.Flags().StringArrayVar(&rawHeaders, "header", nil, "extra HTTP header for upstream MCP server in --upstream HTTP mode (repeatable, format: 'Key: Value')")
 	cmd.Flags().StringVar(&agentName, "agent", "", "agent profile name (resolves to config profile for policy/scanner)")
 	cmd.Flags().BoolVar(&sandboxEnabled, "sandbox", false, "run child in sandbox (Landlock + seccomp + network namespace, Linux only)")
 	cmd.Flags().BoolVar(&sandboxStrict, "sandbox-strict", false, "strict sandbox: error on missing layers, private /dev/shm, block clone3 (implies --sandbox)")

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -608,6 +609,259 @@ func TestMCPRuntimeHelperProcess(t *testing.T) {
 	if err := scanner.Err(); err != nil {
 		t.Fatalf("helper stdin scan: %v", err)
 	}
+}
+
+func TestParseHeaderFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   []string
+		want    http.Header
+		wantErr string
+	}{
+		{
+			name:  "nil input returns nil",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "empty input returns nil",
+			input: []string{},
+			want:  nil,
+		},
+		{
+			name:  "single header",
+			input: []string{"Authorization: Bearer abc123"},
+			want:  http.Header{"Authorization": []string{"Bearer abc123"}},
+		},
+		{
+			name: "repeatable headers accumulate",
+			input: []string{
+				"Authorization: Bearer abc123",
+				"X-MCP-Toolsets: default,git,code_security",
+			},
+			want: http.Header{
+				"Authorization":  []string{"Bearer abc123"},
+				"X-Mcp-Toolsets": []string{"default,git,code_security"},
+			},
+		},
+		{
+			name:  "value whitespace trimmed",
+			input: []string{"X-Foo:    bar   "},
+			want:  http.Header{"X-Foo": []string{"bar"}},
+		},
+		{
+			name:  "empty value allowed",
+			input: []string{"X-Empty:"},
+			want:  http.Header{"X-Empty": []string{""}},
+		},
+		{
+			name:  "same key repeats append",
+			input: []string{"X-Foo: a", "X-Foo: b"},
+			want:  http.Header{"X-Foo": []string{"a", "b"}},
+		},
+		{
+			name:    "missing colon rejected",
+			input:   []string{"Authorization Bearer abc"},
+			wantErr: `--header "Authorization Bearer abc": expected 'Key: Value' format`,
+		},
+		{
+			name:    "empty key rejected",
+			input:   []string{": value-only"},
+			wantErr: `--header ": value-only": key is empty`,
+		},
+		{
+			name:    "whitespace-only key rejected",
+			input:   []string{"   : value"},
+			wantErr: `--header "   : value": key is empty`,
+		},
+		{
+			name:    "reserved Mcp-Session-Id rejected",
+			input:   []string{"Mcp-Session-Id: attacker-pinned"},
+			wantErr: `--header "Mcp-Session-Id: attacker-pinned": "Mcp-Session-Id" is managed by the MCP HTTP transport and cannot be overridden via --header`,
+		},
+		{
+			name:    "reserved Mcp-Session-Id rejected case-insensitive",
+			input:   []string{"mcp-session-id: attacker-pinned"},
+			wantErr: `--header "mcp-session-id: attacker-pinned": "mcp-session-id" is managed by the MCP HTTP transport and cannot be overridden via --header`,
+		},
+		{
+			name:    "reserved Content-Type rejected",
+			input:   []string{"Content-Type: text/plain"},
+			wantErr: `--header "Content-Type: text/plain": "Content-Type" is managed by the MCP HTTP transport and cannot be overridden via --header`,
+		},
+		{
+			name:    "reserved Host rejected",
+			input:   []string{"Host: evil.example"},
+			wantErr: `--header "Host: evil.example": "Host" is managed by the MCP HTTP transport and cannot be overridden via --header`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseHeaderFlags(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("parseHeaderFlags(%v) = nil error, want %q", tt.input, tt.wantErr)
+				}
+				if err.Error() != tt.wantErr {
+					t.Fatalf("parseHeaderFlags(%v) err = %q, want %q", tt.input, err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseHeaderFlags(%v) unexpected error: %v", tt.input, err)
+			}
+			if !headerEqual(got, tt.want) {
+				t.Errorf("parseHeaderFlags(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMcpProxyCmd_HTTPUpstreamForwardsExtraHeaders confirms that --header
+// flags reach the upstream MCP server. This is the user-facing fix for
+// auth-required HTTP MCP endpoints (e.g., GitHub Copilot's MCP server, where
+// without this the agent had no way to send Authorization: Bearer ... through
+// pipelock's --upstream stdio bridge).
+func TestMcpProxyCmd_HTTPUpstreamForwardsExtraHeaders(t *testing.T) {
+	t.Parallel()
+
+	var (
+		captureOnce      sync.Once
+		capturedAuth     string
+		capturedToolsets string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture only the first request's headers via sync.Once so later
+		// requests in the same MCP session (initialize, tools/list, tools/call)
+		// can't race-overwrite the captured values relative to the test
+		// goroutine's later read.
+		captureOnce.Do(func() {
+			capturedAuth = r.Header.Get("Authorization")
+			capturedToolsets = r.Header.Get("X-MCP-Toolsets")
+		})
+		w.Header().Set("Content-Type", "application/json")
+
+		var request struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		response := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      request.ID,
+			"result":  map[string]any{},
+		}
+		switch request.Method {
+		case mcpInitializeResource:
+			response["result"] = map[string]any{
+				"protocolVersion": "2024-11-05",
+				"capabilities":    map[string]any{"tools": map[string]any{}},
+				"serverInfo":      map[string]any{"name": "header-test", "version": "0.0.1"},
+			}
+		case mcpToolsListResource:
+			response["result"] = map[string]any{"tools": []map[string]any{}}
+		case mcpToolsCallResource:
+			response["result"] = map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("Encode(response): %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	_, keyPath := writeReceiptSigningKey(t)
+	evidenceDir := filepath.Join(t.TempDir(), "evidence")
+	configPath := writeMCPProxyConfig(t, evidenceDir, keyPath, false)
+
+	_, stderr, err := runMCPProxyCommandWithArgs(t, []string{
+		"proxy",
+		"--config", configPath,
+		"--upstream", srv.URL,
+		"--header", "Authorization: Bearer fake-pat",
+		"--header", "X-MCP-Toolsets: default,git",
+	})
+	if err != nil {
+		t.Fatalf("run mcp proxy http upstream with headers: %v\nstderr:\n%s", err, stderr)
+	}
+
+	if capturedAuth != "Bearer fake-pat" {
+		t.Errorf("upstream Authorization header = %q, want %q", capturedAuth, "Bearer fake-pat")
+	}
+	if capturedToolsets != "default,git" {
+		t.Errorf("upstream X-MCP-Toolsets header = %q, want %q", capturedToolsets, "default,git")
+	}
+}
+
+// TestMcpProxyCmd_MalformedHeaderFlagFails confirms typos surface to the user
+// instead of silently dropping the auth header. Any of these scenarios
+// without an error would mean an attacker (or a tired operator) can ship a
+// pipelock-wrapped MCP that thinks it's authenticated and isn't.
+func TestMcpProxyCmd_MalformedHeaderFlagFails(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	defer srv.Close()
+
+	_, keyPath := writeReceiptSigningKey(t)
+	evidenceDir := filepath.Join(t.TempDir(), "evidence")
+	configPath := writeMCPProxyConfig(t, evidenceDir, keyPath, false)
+
+	cases := []struct {
+		name string
+		flag string
+	}{
+		{name: "missing colon", flag: "Authorization Bearer abc"},
+		{name: "empty key", flag: ": value-only"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := runMCPProxyCommandWithArgs(t, []string{
+				"proxy",
+				"--config", configPath,
+				"--upstream", srv.URL,
+				"--header", tc.flag,
+			})
+			if err == nil {
+				t.Fatalf("expected error for malformed --header %q, got nil", tc.flag)
+			}
+			if !strings.Contains(err.Error(), "--header") {
+				t.Errorf("error %q does not mention --header", err.Error())
+			}
+		})
+	}
+}
+
+// headerEqual is a deep equality helper for http.Header values. http.Header
+// canonicalises keys via textproto, so the comparison normalises both maps
+// before comparing length and per-key value slices.
+func headerEqual(a, b http.Header) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, vs := range a {
+		other, ok := b[http.CanonicalHeaderKey(k)]
+		if !ok || len(other) != len(vs) {
+			return false
+		}
+		for i, v := range vs {
+			if other[i] != v {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func runMCPProxyCommand(t *testing.T, configPath string) (string, string, error) {

--- a/internal/mcp/transport/httpclient.go
+++ b/internal/mcp/transport/httpclient.go
@@ -122,6 +122,15 @@ func (c *HTTPClient) SendMessage(ctx context.Context, msg []byte) (MessageReader
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
 
+	// Always remove any caller-supplied Mcp-Session-Id BEFORE the conditional
+	// Set below: on the first request c.sessionID is empty and Set is skipped,
+	// so without this Del a caller-supplied "Mcp-Session-Id: ..." in extras
+	// would reach the upstream and let an attacker pin session correlation
+	// to a value of their choice. The CLI's parseHeaderFlags rejects this
+	// header at parse time too; this Del is the defense-in-depth layer for
+	// programmatic callers that build *HTTPClient directly.
+	req.Header.Del("Mcp-Session-Id")
+
 	// Include session ID if established.
 	c.sessionMu.Lock()
 	if c.sessionID != "" {

--- a/internal/mcp/transport/httpclient_test.go
+++ b/internal/mcp/transport/httpclient_test.go
@@ -304,6 +304,44 @@ func TestHTTPClient_ExtraHeadersCannotOverrideTransport(t *testing.T) {
 	drain(t, reader)
 }
 
+// TestHTTPClient_ExtrasCannotInjectMcpSessionIdOnFirstRequest is the regression
+// for a defense-in-depth gap that survived the original
+// TestHTTPClient_ExtraHeadersCannotOverrideTransport: that test only checked
+// Content-Type / Accept, both of which are unconditionally Set after the
+// extras Add loop. Mcp-Session-Id was only Set when the client already had
+// a session ID — so on the very first request (empty session ID) a caller-
+// supplied "Mcp-Session-Id" in extras flowed through to the upstream and
+// let an attacker pin session correlation to a value of their choice.
+//
+// The fix unconditionally Dels Mcp-Session-Id from the request headers before
+// the conditional Set, so first-request extras cannot reach upstream. The
+// CLI parser rejects this header at parse time too (see
+// runtime.parseHeaderFlags), but this transport-level guard catches
+// programmatic callers that build a *HTTPClient directly.
+func TestHTTPClient_ExtrasCannotInjectMcpSessionIdOnFirstRequest(t *testing.T) {
+	var seen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("Mcp-Session-Id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	defer srv.Close()
+
+	headers := http.Header{}
+	headers.Set("Mcp-Session-Id", "attacker-pinned-session")
+	c := NewHTTPClient(srv.URL, headers)
+
+	reader, err := c.SendMessage(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	drain(t, reader)
+
+	if seen != "" {
+		t.Fatalf("upstream Mcp-Session-Id = %q, want empty (extras must not pin session correlation on the first request)", seen)
+	}
+}
+
 func TestHTTPClient_OpenGETStream_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1782,9 +1782,15 @@ func (p *Proxy) ShieldEngine() *shield.Engine {
 }
 
 // isShieldExempt checks whether a hostname is in the browser shield exempt list.
+// Uses scanner.MatchDomain so wildcard patterns ("*.example.com") work the same
+// way they do for the SSRF trusted-domain list, the response-scan exempt list,
+// the body-scan exempt list, and the adaptive-enforcement exempt list. Before
+// this, an operator who configured "*.cloudflare.com" silently got zero
+// matches because shield used exact-match while everything else used
+// MatchDomain — a parity gap, not a hardening gain.
 func isShieldExempt(hostname string, exempts []string) bool {
-	for _, d := range exempts {
-		if strings.EqualFold(hostname, d) {
+	for _, pattern := range exempts {
+		if scanner.MatchDomain(hostname, pattern) {
 			return true
 		}
 	}

--- a/internal/proxy/shield_integration_test.go
+++ b/internal/proxy/shield_integration_test.go
@@ -60,6 +60,39 @@ func TestIsShieldExempt(t *testing.T) {
 		{"no match", "other.com", []string{"hcaptcha.com"}, false},
 		{"empty host", "", []string{"hcaptcha.com"}, false},
 		{"multiple exempts", "hcaptcha.com", []string{"challenges.cloudflare.com", "hcaptcha.com"}, true},
+
+		// Wildcard parity with scanner.MatchDomain. Every other domain
+		// list in pipelock (SSRF trusted-domains, response-scan exempt,
+		// body-scan exempt, adaptive exempt) supports "*.example.com" —
+		// shield used to be the odd one out and silently produced zero
+		// matches when an operator wrote a wildcard.
+		{"wildcard subdomain match", "challenges.cloudflare.com", []string{"*.cloudflare.com"}, true},
+		{"wildcard nested subdomain match", "a.b.cloudflare.com", []string{"*.cloudflare.com"}, true},
+		{"wildcard base domain match", "cloudflare.com", []string{"*.cloudflare.com"}, true},
+		{"wildcard mismatch", "evil.com", []string{"*.cloudflare.com"}, false},
+
+		// Bypass defense: the wildcard must not match a sibling domain
+		// that merely shares a suffix with the wildcard tail. Without
+		// this property, "*.example.com" would also match
+		// "evilexample.com" via plain string suffix matching, and the
+		// exempt list would become a footgun rather than a feature.
+		{"sibling-domain bypass attempt rejected", "evilexample.com", []string{"*.example.com"}, false},
+		{"adjacent-tld bypass attempt rejected", "example.com.attacker.test", []string{"*.example.com"}, false},
+
+		// Double-star (**) is not a recognized wildcard in
+		// scanner.MatchDomain — only "*." is. Operators who type "**"
+		// expecting a different semantic should get a literal-prefix
+		// pattern that matches nothing real, not silent acceptance of
+		// every host. Test pins this so a future MatchDomain change
+		// that expanded "**" support would have to update this row
+		// rather than ship undetected.
+		{"double-star treated literally", "anything.example.com", []string{"**.example.com"}, false},
+
+		// IPs only support exact match per scanner.MatchDomain. A
+		// pattern like "*.168.1.1" must not bypass to "192.168.1.1"
+		// because dots in IPs are not subdomain separators.
+		{"ip exact match", "127.0.0.1", []string{"127.0.0.1"}, true},
+		{"ip wildcard rejected", "192.168.1.1", []string{"*.168.1.1"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Two small unrelated fixes bundled because they share the same shape: a missing CLI/config surface for capability the internals already supported.

- **Closes #464:** `pipelock mcp proxy --upstream <URL>` now accepts repeatable `--header "Key: Value"` so callers can authenticate to HTTP MCP servers that require an `Authorization: Bearer <token>` (or any other custom header). `transport.HTTPClient` already accepted extra headers, the CLI flag was the missing piece.
- **`browser_shield.exempt_domains` wildcard parity:** `isShieldExempt` now uses `scanner.MatchDomain` instead of `strings.EqualFold`, in line with every other domain list in pipelock (SSRF trusted, response-scan exempt, body-scan exempt, adaptive exempt). Operators who already wrote `"*.cloudflare.com"` in the shield exempt list will now get the matches they expected.

## Defense in depth on transport-managed headers

`parseHeaderFlags` rejects `Content-Type`, `Accept`, `Mcp-Session-Id`, `Content-Length`, `Transfer-Encoding`, and `Host` with a clear "managed by the transport" error. Independently, `transport.HTTPClient.SendMessage` now unconditionally `Del`s `Mcp-Session-Id` before the conditional `Set`. Without this, the first request (empty `c.sessionID`) would have leaked a caller-supplied `Mcp-Session-Id` extra to the upstream and let a malicious header pin session correlation. Existing `TestHTTPClient_ExtraHeadersCannotOverrideTransport` only covered `Content-Type` and `Accept`; new transport-level regression covers the new path.

## Behavior

- `pipelock mcp proxy --upstream X --header "Authorization: Bearer ..."` works.
- `--header "Mcp-Session-Id: ..."` (or any reserved transport header) returns a descriptive error instead of being applied silently.
- Malformed `--header` (missing colon, empty key) returns a descriptive error rather than silently dropping.
- `--listen` and ws/wss upstream modes warn-and-ignore `--header` (those modes don't yet plumb operator extras).
- Operators with existing wildcard `browser_shield.exempt_domains` entries will now match as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for custom HTTP headers in MCP stdio-to-HTTP upstream mode
  * Browser shield domain exemptions now support wildcard patterns (e.g., `*.example.com`) to match subdomains

* **Improvements**
  * Added validation to prevent overriding system-managed HTTP headers
  * Enhanced domain pattern matching for shield exemption rules with improved accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->