### PR TITLE
feat(blockreason): X-Pipelock-Block-Reason header schema and emit package

### DIFF
--- a/docs/specs/block-reason-header.md
+++ b/docs/specs/block-reason-header.md
@@ -15,7 +15,7 @@ This document is the canonical schema. Once an agent in production reads `dlp_ma
 | `X-Pipelock-Block-Reason-Severity` | yes (on every block) | `critical` | Matches pipelock's existing severity vocabulary: `info`, `warn`, `critical`. |
 | `X-Pipelock-Block-Reason-Retry` | yes (on every block) | `none` | Retry hint: `none` (permanent), `transient` (retry with backoff), `policy` (retry only after policy change). |
 | `X-Pipelock-Block-Reason-Layer` | optional | `dlp` | Scanner pipeline layer label. Uses `internal/scanner/` `Scanner*` constants verbatim so operators can correlate header-driven agent behavior with their existing audit logs and Prometheus labels. See the layer-label vocabulary below. |
-| `X-Pipelock-Block-Reason-Receipt` | optional | `01HZ8...` | Receipt ID. Lets the agent fetch the matching receipt (via the receipt-transports endpoint) for additional context. |
+| `X-Pipelock-Block-Reason-Receipt` | optional | `01J0GNYZ7XSQRTQ8FPYM5BHX2K` | Receipt ID. Exactly 26 characters, Crockford-base32 (ULID alphabet: `0-9` plus `A-Z` minus `I`, `L`, `O`, `U`). Lets the agent fetch the matching receipt (via the receipt-transports endpoint) for additional context. The strict format keeps the slot opaque so attacker-controlled metadata cannot reach agent-visible response headers. |
 
 Absent headers are treated as a generic block. Agents that don't read the headers continue to work unchanged — the headers are purely additive.
 
@@ -94,6 +94,7 @@ Reason codes are lowercase snake_case. The v1 set is derived from existing pipel
 | `pattern_unavailable` | Scanner pattern set unavailable at startup; fail-closed until ready. | `warn` | `transient` |
 | `not_enabled` | Endpoint exists but the feature is disabled in config. | `info` | `policy` |
 | `bad_request` | Malformed client request (missing parameter, invalid URL, etc.). | `info` | `none` |
+| `block_reason_overflow` | Internal sentinel: the block-emit metadata itself was malformed (oversized Reason value, etc.). Pipelock falls back to this rather than silently downgrading to `parse_error` so audit fidelity is preserved. Agents should treat this as a malformed-block signal worth logging. | `warn` | `transient` |
 
 ## Severity
 
@@ -116,11 +117,13 @@ The `info` / `warn` / `critical` values match pipelock's existing emit pipeline 
 The header is **operational metadata only**. The following must never appear in any header value:
 
 - Matched secret content. The reason `dlp_match` is fine; the matched substring is not.
-- DLP pattern names that would identify the regex (e.g. `aws_access_key_id`). Pattern fingerprints are too tight a signal — they invite probing.
+- DLP pattern names that would identify the regex (e.g. `aws_access_key_id`). Pattern fingerprints are too tight a signal because they invite probing.
 - Agent identifiers, session IDs, or any user-attributable data.
 - Internal IPs, private hostnames, or cluster-internal details.
 
-The optional `X-Pipelock-Block-Reason-Receipt` header carries a UUID. The receipt itself (fetched separately) may contain richer context, but the header value is just the opaque ID.
+The optional `X-Pipelock-Block-Reason-Receipt` header carries an opaque ULID. The 26-character Crockford-base32 format is enforced by the emit package's `WithReceipt` validator; non-conforming receipts are rejected at construction so call sites cannot smuggle arbitrary strings into the slot. The receipt itself (fetched separately via the receipt-transports endpoint) may contain richer context, but the header value is just the opaque ID.
+
+The required header values (`Reason`, `Severity`, `Retry`) are validated against fixed allowlists at construction. The `Layer` value is restricted to ASCII alphanumeric and underscore (the shape of `internal/scanner/Scanner*` constants). Any value that does not match its validator is rejected before the header reaches the wire.
 
 ## Versioning
 

--- a/docs/specs/block-reason-header.md
+++ b/docs/specs/block-reason-header.md
@@ -4,6 +4,8 @@ When pipelock blocks an outbound request, the response carries a small set of HT
 
 This document is the canonical schema. Once an agent in production reads `dlp_match`, the vocabulary is locked. Renaming a code in v2 breaks every consumer.
 
+> **Status:** the schema and emit package land first (this PR). The transport refactor that wires every block path to call `Info.SetHeaders` lands in a follow-up PR. Until that PR merges, the vocabulary below is the *target* — it is not currently emitted on production blocks. The split is intentional: locking the operator-facing vocabulary before any block site commits to it.
+
 ## Header set
 
 | Header | Required | Example | Meaning |
@@ -12,14 +14,33 @@ This document is the canonical schema. Once an agent in production reads `dlp_ma
 | `X-Pipelock-Block-Reason-Version` | yes (on every block) | `1` | Schema version. Increment for breaking changes. |
 | `X-Pipelock-Block-Reason-Severity` | yes (on every block) | `critical` | Matches pipelock's existing severity vocabulary: `info`, `warn`, `critical`. |
 | `X-Pipelock-Block-Reason-Retry` | yes (on every block) | `none` | Retry hint: `none` (permanent), `transient` (retry with backoff), `policy` (retry only after policy change). |
-| `X-Pipelock-Block-Reason-Layer` | optional | `dlp` | Scanner pipeline layer label. Aligns with `internal/scanner/` layer names: `scheme`, `domain_blocklist`, `dlp`, `path_entropy`, `subdomain_entropy`, `ssrf`, `rate_limit`, `url_length`, `data_budget`. |
+| `X-Pipelock-Block-Reason-Layer` | optional | `dlp` | Scanner pipeline layer label. Uses `internal/scanner/` `Scanner*` constants verbatim so operators can correlate header-driven agent behavior with their existing audit logs and Prometheus labels. See the layer-label vocabulary below. |
 | `X-Pipelock-Block-Reason-Receipt` | optional | `01HZ8...` | Receipt ID. Lets the agent fetch the matching receipt (via the receipt-transports endpoint) for additional context. |
 
 Absent headers are treated as a generic block. Agents that don't read the headers continue to work unchanged — the headers are purely additive.
 
+## Layer-label vocabulary
+
+The optional `X-Pipelock-Block-Reason-Layer` header reuses `internal/scanner/` `Scanner*` constants verbatim. These are intentionally short — they exist to correlate with audit logs and Prometheus labels, not to be human-friendly. The reason code (the main `X-Pipelock-Block-Reason` header) carries the human-friendlier vocabulary.
+
+| Layer label (header) | Source constant | Approximate reason mapping |
+|---|---|---|
+| `scheme` | `scanner.ScannerScheme` | `scheme_blocked` |
+| `blocklist` | `scanner.ScannerBlocklist` | `domain_blocklist` |
+| `dlp` | `scanner.ScannerDLP` | `dlp_match`, `redaction_failure` |
+| `entropy` | `scanner.ScannerEntropy` | `path_entropy` |
+| `subdomain_entropy` | `scanner.ScannerSubdomainEntropy` | `subdomain_entropy` |
+| `ssrf` | `scanner.ScannerSSRF` | `ssrf_private_ip`, `ssrf_metadata`, `ssrf_dns_rebind` |
+| `ratelimit` | `scanner.ScannerRateLimit` | `rate_limit` |
+| `length` | `scanner.ScannerLength` | `url_length` |
+| `databudget` | `scanner.ScannerDataBudget` | `data_budget` |
+| `parser` | `scanner.ScannerParser` | `parse_error` |
+
+Layers without a `Scanner*` constant (MCP layer, posture layer) leave the layer header unset; the reason code already conveys the layer at the granularity agents need.
+
 ## Reason vocabulary (v1)
 
-Reason codes are lowercase snake_case. The v1 set is derived from existing pipelock block paths — every code below has a real production emit site.
+Reason codes are lowercase snake_case. The v1 set is derived from existing pipelock block paths — every code below maps to an existing block path that the follow-up transport PR will wire to emit this header.
 
 ### Egress / network layer
 
@@ -109,7 +130,7 @@ Agents should treat unknown reason codes as a generic block at the declared seve
 
 ## Transport coverage
 
-The header is emitted on every pipelock block path. There is no transport split.
+The follow-up transport PR wires the header onto every pipelock block path. There is no transport split — the schema is the same on every surface; only the framing differs (HTTP headers vs WebSocket close-frame JSON).
 
 | Transport | Mechanism |
 |---|---|

--- a/docs/specs/block-reason-header.md
+++ b/docs/specs/block-reason-header.md
@@ -1,0 +1,150 @@
+# X-Pipelock-Block-Reason Header Schema (v1)
+
+When pipelock blocks an outbound request, the response carries a small set of HTTP headers that explain *why* in machine-readable form. Agents that read these headers can react intelligently — back off, switch tools, surface the right error to the user — instead of treating every block as an opaque 403.
+
+This document is the canonical schema. Once an agent in production reads `dlp_match`, the vocabulary is locked. Renaming a code in v2 breaks every consumer.
+
+## Header set
+
+| Header | Required | Example | Meaning |
+|---|---|---|---|
+| `X-Pipelock-Block-Reason` | yes (on every block) | `dlp_match` | Machine-readable reason code. See vocabulary below. |
+| `X-Pipelock-Block-Reason-Version` | yes (on every block) | `1` | Schema version. Increment for breaking changes. |
+| `X-Pipelock-Block-Reason-Severity` | yes (on every block) | `critical` | Matches pipelock's existing severity vocabulary: `info`, `warn`, `critical`. |
+| `X-Pipelock-Block-Reason-Retry` | yes (on every block) | `none` | Retry hint: `none` (permanent), `transient` (retry with backoff), `policy` (retry only after policy change). |
+| `X-Pipelock-Block-Reason-Layer` | optional | `dlp` | Scanner pipeline layer label. Aligns with `internal/scanner/` layer names: `scheme`, `domain_blocklist`, `dlp`, `path_entropy`, `subdomain_entropy`, `ssrf`, `rate_limit`, `url_length`, `data_budget`. |
+| `X-Pipelock-Block-Reason-Receipt` | optional | `01HZ8...` | Receipt ID. Lets the agent fetch the matching receipt (via the receipt-transports endpoint) for additional context. |
+
+Absent headers are treated as a generic block. Agents that don't read the headers continue to work unchanged — the headers are purely additive.
+
+## Reason vocabulary (v1)
+
+Reason codes are lowercase snake_case. The v1 set is derived from existing pipelock block paths — every code below has a real production emit site.
+
+### Egress / network layer
+
+| Code | When | Severity | Retry |
+|---|---|---|---|
+| `scheme_blocked` | URL scheme other than http/https. | `warn` | `none` |
+| `domain_blocklist` | Hostname matched the configured blocklist. | `critical` | `policy` |
+| `ssrf_private_ip` | Resolved IP is in private/loopback/link-local range. | `critical` | `none` |
+| `ssrf_metadata` | Resolved IP is a cloud metadata endpoint (169.254.169.254, etc.). | `critical` | `none` |
+| `ssrf_dns_rebind` | DNS resolution flipped between scan and dial (TOCTOU). | `critical` | `transient` |
+| `path_entropy` | URL path entropy exceeded configured ceiling (covert channel signal). | `warn` | `policy` |
+| `subdomain_entropy` | Hostname subdomain entropy exceeded configured ceiling. | `warn` | `policy` |
+| `url_length` | URL length exceeded configured ceiling. | `warn` | `policy` |
+| `rate_limit` | Per-session or per-host rate limit exceeded. | `warn` | `transient` |
+| `data_budget` | Per-session data budget exceeded. | `warn` | `policy` |
+
+### Content / payload layer
+
+| Code | When | Severity | Retry |
+|---|---|---|---|
+| `dlp_match` | Outbound payload matched a DLP pattern (secret, credential, PII). | `critical` | `none` |
+| `prompt_injection` | Inbound response matched an injection pattern. | `critical` | `none` |
+| `redaction_failure` | Outbound redaction stage encountered an unrecoverable parse error and fail-closed. | `critical` | `transient` |
+| `media_policy` | Image / audio / video policy block (size, type, count). | `warn` | `policy` |
+
+### MCP / tool layer
+
+| Code | When | Severity | Retry |
+|---|---|---|---|
+| `tool_policy_deny` | An `mcp_tool_policy` rule denied the call. | `critical` | `policy` |
+| `tool_chain_blocked` | A configured tool-chain detection sequence triggered. | `critical` | `none` |
+| `tool_poisoning` | A poisoned tool description or rug-pull drift was detected. | `critical` | `none` |
+| `session_binding` | The current call's tool inventory diverged from the session's pinned baseline. | `critical` | `policy` |
+
+### Posture / runtime layer
+
+| Code | When | Severity | Retry |
+|---|---|---|---|
+| `airlock_active` | Adaptive enforcement escalated this session into the airlock tier. | `critical` | `transient` |
+| `kill_switch_active` | One of the four kill-switch sources is active. | `critical` | `transient` |
+| `envelope_verify_failed` | Inbound mediation envelope did not verify (signature / replay / trust). | `critical` | `none` |
+| `authority_mismatch` | Posture-capsule authority did not match the request's claimed authority. | `critical` | `policy` |
+| `escalation_level` | Per-session escalation level exceeded the configured ceiling. | `critical` | `transient` |
+
+### Generic
+
+| Code | When | Severity | Retry |
+|---|---|---|---|
+| `parse_error` | Unparseable input on a fail-closed surface. | `warn` | `none` |
+| `timeout` | Scanner or HITL timed out (fail-closed default). | `warn` | `transient` |
+| `pattern_unavailable` | Scanner pattern set unavailable at startup; fail-closed until ready. | `warn` | `transient` |
+| `not_enabled` | Endpoint exists but the feature is disabled in config. | `info` | `policy` |
+| `bad_request` | Malformed client request (missing parameter, invalid URL, etc.). | `info` | `none` |
+
+## Severity
+
+Aligns with `internal/config/schema.go` constants:
+
+- `info` — informational; agent can ignore or surface as a status line.
+- `warn` — agent should log and continue, but the operator may want to investigate.
+- `critical` — the block represents a real security event. Agent should not retry without an operator-driven policy change.
+
+The `info` / `warn` / `critical` values match pipelock's existing emit pipeline (`Emit.MinSeverity`, etc.). Reusing the same vocabulary lets operators correlate header-driven agent behavior with their existing emit / receipt streams.
+
+## Retry hints
+
+- `none` — the block is permanent for the current request. Retrying without changing the input will produce the same block. Examples: `dlp_match`, `ssrf_private_ip`, `prompt_injection`.
+- `transient` — the underlying condition is time-bound. A retry after backoff may succeed. Examples: `rate_limit`, `airlock_active`, `kill_switch_active`, `dns_rebind` (resolver may stabilize).
+- `policy` — only retry after the operator changes pipelock policy. Examples: `domain_blocklist`, `tool_policy_deny`, `data_budget`.
+
+## Privacy
+
+The header is **operational metadata only**. The following must never appear in any header value:
+
+- Matched secret content. The reason `dlp_match` is fine; the matched substring is not.
+- DLP pattern names that would identify the regex (e.g. `aws_access_key_id`). Pattern fingerprints are too tight a signal — they invite probing.
+- Agent identifiers, session IDs, or any user-attributable data.
+- Internal IPs, private hostnames, or cluster-internal details.
+
+The optional `X-Pipelock-Block-Reason-Receipt` header carries a UUID. The receipt itself (fetched separately) may contain richer context, but the header value is just the opaque ID.
+
+## Versioning
+
+The schema version sits in `X-Pipelock-Block-Reason-Version`. v1 covers everything in this document. Breaking changes — renames, removed codes, semantic shifts — increment the version. Additive changes (new codes, new optional headers) leave the version unchanged.
+
+Agents should treat unknown reason codes as a generic block at the declared severity. Agents should treat unknown versions as a generic block.
+
+## Transport coverage
+
+The header is emitted on every pipelock block path. There is no transport split.
+
+| Transport | Mechanism |
+|---|---|
+| Forward proxy (CONNECT + absolute-URI) | HTTP response headers on the 403/etc. |
+| TLS-intercept (MITM) | HTTP response headers on the synthetic block response. |
+| Fetch endpoint (`/fetch?url=...`) | HTTP response headers on the 403 JSON body. |
+| Reverse proxy (`pipelock run --reverse-listen`) | HTTP response headers on the synthetic block response (request-side and response-side). |
+| MCP HTTP / SSE | HTTP response headers on the 403. |
+| WebSocket | Close-frame reason payload as a JSON document carrying the same fields (see below). |
+
+### WebSocket close-frame payload
+
+WebSocket blocks happen via close frames, not response headers. The close-frame `Reason` field carries a UTF-8 JSON document with the same shape as the headers:
+
+```json
+{
+  "block_reason": "dlp_match",
+  "version": "1",
+  "severity": "critical",
+  "retry": "none",
+  "layer": "dlp",
+  "receipt": "01HZ8..."
+}
+```
+
+Per RFC 6455 the close-frame reason payload is limited to 123 bytes. Agents should plan for truncation: if the JSON would exceed the limit, fields drop in this order — `receipt`, `layer`, `retry`, `severity`, `version` — leaving `block_reason` as the always-present floor.
+
+MCP stdio is not covered. There is no HTTP layer to attach headers to; MCP-stdio errors flow through the JSON-RPC error envelope. Block-reason taxonomy in JSON-RPC errors is tracked separately.
+
+## Compatibility
+
+- Agents that ignore the header continue to work. The 403 status code and existing JSON body are unchanged.
+- Agents that read the header but don't recognize a code or severity should fall back to "generic block" handling.
+- Adding a new reason code is an additive change. Removing or renaming a code is a breaking change requiring a version bump.
+
+## Why design first
+
+Once an agent in production reads `dlp_match`, renaming the code to `secret_detected` later breaks that agent. The header is operator-facing — long-lived, hard to migrate. Locking the vocabulary before any code commits to it is the only honest path. v2.4 ships v1; v2 (if ever needed) will be a deliberate, versioned migration.

--- a/internal/blockreason/blockreason.go
+++ b/internal/blockreason/blockreason.go
@@ -7,7 +7,13 @@
 // instead of treating every 403 as opaque.
 //
 // The schema is locked at v1. See docs/specs/block-reason-header.md for the
-// canonical reason vocabulary, severity values, retry hints, and privacy rules.
+// canonical reason vocabulary, severity values, retry hints, layer-label
+// mapping, and privacy rules.
+//
+// Construction: callers MUST use New(reason, severity, retry) — the required
+// triple is enforced at construction time. Optional fields use the fluent
+// WithLayer / WithReceipt helpers. Direct struct literals (Info{...}) bypass
+// the invariant and should not be used outside tests of the helper itself.
 //
 // Privacy: header values must never carry matched secret content, DLP pattern
 // names, agent identifiers, session IDs, or any user-attributable data. The
@@ -16,6 +22,7 @@ package blockreason
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
@@ -107,13 +114,18 @@ const (
 // Info is the operational metadata for a block. Privacy: never populate
 // Layer or Receipt with anything that could identify matched content,
 // session, or agent.
+//
+// Construct via New() so the required triple (reason, severity, retry) is
+// enforced. Use WithLayer / WithReceipt for optional fields.
 type Info struct {
 	Reason   Reason
 	Severity Severity
 	Retry    Retry
 
 	// Layer is the scanner pipeline layer label, e.g. "dlp", "ssrf",
-	// "rate_limit". Optional. Aligns with internal/scanner/ layer names.
+	// "ratelimit". Optional. Aligns with internal/scanner/ Scanner*
+	// constants so operators can correlate header-driven agent behavior
+	// with their existing audit / metrics streams.
 	Layer string
 
 	// Receipt is the receipt UUID for this block, if a receipt was emitted.
@@ -122,26 +134,47 @@ type Info struct {
 	Receipt string
 }
 
-// SetHeaders writes the required headers and any populated optional headers
-// onto h. Call BEFORE the response's WriteHeader; the headers are only
-// honored by net/http when set before status is written.
-func (i Info) SetHeaders(h http.Header) {
-	if i.Reason == "" {
-		// A block with no reason is a programming error in the call site.
-		// We still emit the version header so consumers can detect the
-		// schema; the reason header is omitted to preserve the invariant
-		// that an emitted reason code is always one we documented.
-		h.Set(HeaderVersion, SchemaVersion)
-		return
+// New constructs a complete Info. Reason, severity, and retry are required;
+// New panics if any is empty. The panic surfaces a programming error in the
+// call site — every documented reason has a fixed severity and retry hint
+// per docs/specs/block-reason-header.md.
+//
+// This is consistent with the codebase's panic policy: panics flag
+// post-validation programming errors, not runtime input.
+func New(reason Reason, severity Severity, retry Retry) Info {
+	if reason == "" || severity == "" || retry == "" {
+		panic(fmt.Sprintf("blockreason.New: required field empty (reason=%q severity=%q retry=%q)",
+			reason, severity, retry))
 	}
+	return Info{Reason: reason, Severity: severity, Retry: retry}
+}
+
+// WithLayer returns a copy of i with the Layer label set. Layer should be
+// one of the internal/scanner/ Scanner* constants for operator correlation.
+func (i Info) WithLayer(layer string) Info {
+	i.Layer = layer
+	return i
+}
+
+// WithReceipt returns a copy of i with the Receipt UUID set.
+func (i Info) WithReceipt(receipt string) Info {
+	i.Receipt = receipt
+	return i
+}
+
+// SetHeaders writes all four required headers (reason, version, severity,
+// retry) and any populated optional headers onto h. Call BEFORE the
+// response's WriteHeader; net/http only honors headers set before status.
+//
+// SetHeaders unconditionally emits the four required headers. Empty values
+// in the required slots indicate the Info was not constructed via New(),
+// which is a contract violation — the headers will still emit (with empty
+// values) but downstream consumers may treat that as a malformed block.
+func (i Info) SetHeaders(h http.Header) {
 	h.Set(HeaderReason, string(i.Reason))
 	h.Set(HeaderVersion, SchemaVersion)
-	if i.Severity != "" {
-		h.Set(HeaderSeverity, string(i.Severity))
-	}
-	if i.Retry != "" {
-		h.Set(HeaderRetry, string(i.Retry))
-	}
+	h.Set(HeaderSeverity, string(i.Severity))
+	h.Set(HeaderRetry, string(i.Retry))
 	if i.Layer != "" {
 		h.Set(HeaderLayer, i.Layer)
 	}
@@ -154,7 +187,7 @@ func (i Info) SetHeaders(h http.Header) {
 // fields. Field names mirror the header set without the X-Pipelock prefix.
 type closeFramePayload struct {
 	BlockReason string `json:"block_reason"`
-	Version     string `json:"version"`
+	Version     string `json:"version,omitempty"`
 	Severity    string `json:"severity,omitempty"`
 	Retry       string `json:"retry,omitempty"`
 	Layer       string `json:"layer,omitempty"`
@@ -165,10 +198,23 @@ type closeFramePayload struct {
 // total, minus 2 bytes for the close-status code = 123 bytes for UTF-8 reason).
 const closeFrameMaxBytes = 123
 
+// closeFrameOverflowFallback is a fixed sentinel that is guaranteed to fit
+// within closeFrameMaxBytes. Used when even the bare {"block_reason":"..."}
+// would overflow because the Reason value is unusually long. The fallback
+// preserves a useful signal (parse_error severity warn / retry none, by
+// schema convention) while honoring the byte ceiling.
+const closeFrameOverflowFallback = `{"block_reason":"parse_error","version":"1"}`
+
 // CloseFramePayload returns a JSON document for the WebSocket close-frame
-// Reason field. If the full document would exceed RFC 6455's 123-byte limit,
-// optional fields drop in this order: receipt, layer, retry, severity, version.
-// The block_reason field is always present (or the result is "{}").
+// Reason field. The result is GUARANTEED to be at most closeFrameMaxBytes
+// bytes (RFC 6455's 123-byte ceiling). To honor the ceiling, optional
+// fields drop in this order: receipt, layer, retry, severity, version.
+// If even the bare {"block_reason":"<code>"} would overflow (extremely
+// long Reason values), CloseFramePayload returns the fixed fallback
+// closeFrameOverflowFallback rather than a malformed close frame.
+//
+// CloseFramePayload assumes Info was constructed via New(); a zero Info
+// returns an empty-object sentinel.
 func (i Info) CloseFramePayload() string {
 	if i.Reason == "" {
 		return "{}"
@@ -201,21 +247,22 @@ func (i Info) CloseFramePayload() string {
 			return out
 		}
 	}
-	// Even the bare {block_reason} can in principle exceed the limit if a
-	// future code is unusually long. Return what we have; the WebSocket
-	// caller is responsible for the final truncation policy.
-	return out
+	// Even the bare {"block_reason":"<code>"} doesn't fit: the Reason value
+	// is so long that we can't honor the byte ceiling without dropping the
+	// only required field. Return the fixed fallback so the close frame is
+	// always RFC 6455-compliant.
+	return closeFrameOverflowFallback
 }
 
 // mustMarshal is json.Marshal with a known-good fixed-shape struct. The
-// struct has no funky types (no interface{}, no time.Time, no big.Int) so
-// json.Marshal cannot fail. We treat any error as a programming bug.
+// struct has only string fields (no interface{}, no time.Time) so
+// json.Marshal cannot fail. The error fallback is defensive code; if it
+// ever fires, treat it as a programming bug, not a runtime condition.
 func mustMarshal(p closeFramePayload) string {
 	b, err := json.Marshal(p)
 	if err != nil {
-		// Programmer error: closeFramePayload only contains strings.
-		// Surface a stable sentinel rather than panic in a server path.
-		return `{"block_reason":"parse_error","version":"1"}`
+		// Defensive: closeFramePayload only contains strings.
+		return closeFrameOverflowFallback
 	}
 	return string(b)
 }

--- a/internal/blockreason/blockreason.go
+++ b/internal/blockreason/blockreason.go
@@ -8,20 +8,24 @@
 //
 // The schema is locked at v1. See docs/specs/block-reason-header.md for the
 // canonical reason vocabulary, severity values, retry hints, layer-label
-// mapping, and privacy rules.
+// mapping, receipt format, and privacy rules.
 //
-// Construction: callers MUST use New(reason, severity, retry) — the required
-// triple is enforced at construction time. Optional fields use the fluent
-// WithLayer / WithReceipt helpers. Direct struct literals (Info{...}) bypass
-// the invariant and should not be used outside tests of the helper itself.
+// Construction: callers MUST use New(reason, severity, retry) which validates
+// every required field against the fixed v1 vocabulary. Optional fields use
+// the WithLayer / WithReceipt builders, both of which validate before
+// returning. Direct struct literals (Info{...}) bypass validation; use them
+// only inside this package's tests.
 //
-// Privacy: header values must never carry matched secret content, DLP pattern
-// names, agent identifiers, session IDs, or any user-attributable data. The
-// header is operational metadata only.
+// Privacy: the validators reject any value that is not in the fixed vocabulary
+// or the documented opaque-ID format. Headers and close-frame payloads emitted
+// by this package therefore cannot carry matched secret content, DLP pattern
+// names, agent identifiers, or session IDs even if a future caller mistakenly
+// tries.
 package blockreason
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -38,6 +42,13 @@ const (
 	// SchemaVersion increments only on breaking changes. Additive changes
 	// (new reason codes, new optional headers) keep v1.
 	SchemaVersion = "1"
+
+	// layerMaxLen bounds the layer header value. The longest scanner label
+	// at v1 is "subdomain_entropy" (17 chars); 32 leaves headroom.
+	layerMaxLen = 32
+	// receiptLen is the fixed Crockford-base32 ULID length. Receipts that
+	// don't match this length are rejected at WithReceipt time.
+	receiptLen = 26
 )
 
 // Reason is a machine-readable block-reason code. The full vocabulary is
@@ -82,7 +93,48 @@ const (
 	PatternUnavailable Reason = "pattern_unavailable"
 	NotEnabled         Reason = "not_enabled"
 	BadRequest         Reason = "bad_request"
+
+	// BlockReasonOverflow is the dedicated sentinel CloseFramePayload uses
+	// when an Info has somehow accumulated a Reason value too long to fit
+	// the bare {block_reason: <code>} payload within RFC 6455's 123-byte
+	// close-frame limit. Distinct from ParseError because it preserves the
+	// signal that the block emit metadata itself was malformed, rather than
+	// silently re-classifying the block as a parser failure.
+	BlockReasonOverflow Reason = "block_reason_overflow"
 )
+
+// validReasons is the fixed v1 allowlist enforced at construction.
+var validReasons = map[Reason]struct{}{
+	SchemeBlocked:        {},
+	DomainBlocklist:      {},
+	SSRFPrivateIP:        {},
+	SSRFMetadata:         {},
+	SSRFDNSRebind:        {},
+	PathEntropy:          {},
+	SubdomainEntropy:     {},
+	URLLength:            {},
+	RateLimit:            {},
+	DataBudget:           {},
+	DLPMatch:             {},
+	PromptInjection:      {},
+	RedactionFailure:     {},
+	MediaPolicy:          {},
+	ToolPolicyDeny:       {},
+	ToolChainBlocked:     {},
+	ToolPoisoning:        {},
+	SessionBinding:       {},
+	AirlockActive:        {},
+	KillSwitchActive:     {},
+	EnvelopeVerifyFailed: {},
+	AuthorityMismatch:    {},
+	EscalationLevel:      {},
+	ParseError:           {},
+	Timeout:              {},
+	PatternUnavailable:   {},
+	NotEnabled:           {},
+	BadRequest:           {},
+	BlockReasonOverflow:  {},
+}
 
 // Severity matches pipelock's existing severity vocabulary in
 // internal/config/schema.go (SeverityInfo / SeverityWarn / SeverityCritical).
@@ -94,82 +146,170 @@ const (
 	SeverityCritical Severity = "critical"
 )
 
+var validSeverities = map[Severity]struct{}{
+	SeverityInfo:     {},
+	SeverityWarn:     {},
+	SeverityCritical: {},
+}
+
 // Retry hints tell the agent whether and how to retry.
 type Retry string
 
 const (
 	// RetryNone means the block is permanent for this request as-is.
-	// Retrying without changing the input produces the same block.
 	RetryNone Retry = "none"
-
-	// RetryTransient means the condition is time-bound. Retry with backoff
-	// may succeed (rate limits, airlock cooldown, kill switch deactivation).
+	// RetryTransient means the condition is time-bound; backoff may help.
 	RetryTransient Retry = "transient"
-
 	// RetryPolicy means the agent should only retry after an operator
-	// changes pipelock policy (domain blocklist, tool policy, data budget).
+	// changes pipelock policy.
 	RetryPolicy Retry = "policy"
 )
 
-// Info is the operational metadata for a block. Privacy: never populate
-// Layer or Receipt with anything that could identify matched content,
-// session, or agent.
+var validRetries = map[Retry]struct{}{
+	RetryNone:      {},
+	RetryTransient: {},
+	RetryPolicy:    {},
+}
+
+// Construction errors. Use errors.Is to pattern-match.
+var (
+	ErrInvalidReason   = errors.New("blockreason: reason is not in the v1 vocabulary")
+	ErrInvalidSeverity = errors.New("blockreason: severity is not in the v1 vocabulary")
+	ErrInvalidRetry    = errors.New("blockreason: retry is not in the v1 vocabulary")
+	ErrInvalidLayer    = errors.New("blockreason: layer must be ASCII alphanumeric/underscore and within length bound")
+	ErrInvalidReceipt  = errors.New("blockreason: receipt must be ULID-shaped (Crockford base32, 26 chars) or empty")
+)
+
+// Info is the operational metadata for a block.
 //
-// Construct via New() so the required triple (reason, severity, retry) is
-// enforced. Use WithLayer / WithReceipt for optional fields.
+// Info instances should always come from New() + WithLayer() / WithReceipt().
+// The fields are exported because the surrounding codebase prefers exported
+// fields for tests; do not rely on direct struct construction outside this
+// package's tests.
 type Info struct {
 	Reason   Reason
 	Severity Severity
 	Retry    Retry
-
-	// Layer is the scanner pipeline layer label, e.g. "dlp", "ssrf",
-	// "ratelimit". Optional. Aligns with internal/scanner/ Scanner*
-	// constants so operators can correlate header-driven agent behavior
-	// with their existing audit / metrics streams.
-	Layer string
-
-	// Receipt is the receipt UUID for this block, if a receipt was emitted.
-	// Lets the agent fetch richer context via the receipt-transports
-	// endpoint. Optional.
-	Receipt string
+	Layer    string
+	Receipt  string
 }
 
-// New constructs a complete Info. Reason, severity, and retry are required;
-// New panics if any is empty. The panic surfaces a programming error in the
-// call site — every documented reason has a fixed severity and retry hint
-// per docs/specs/block-reason-header.md.
+// New constructs an Info, validating reason / severity / retry against the
+// fixed v1 vocabulary. Returns ErrInvalidReason / ErrInvalidSeverity /
+// ErrInvalidRetry on a vocabulary miss.
 //
-// This is consistent with the codebase's panic policy: panics flag
-// post-validation programming errors, not runtime input.
-func New(reason Reason, severity Severity, retry Retry) Info {
-	if reason == "" || severity == "" || retry == "" {
-		panic(fmt.Sprintf("blockreason.New: required field empty (reason=%q severity=%q retry=%q)",
-			reason, severity, retry))
+// Designed for the enforcement hot path: never panics. Call sites should
+// propagate the error to a fail-closed branch — typically by treating an
+// invalid Info as a programming bug while still emitting the underlying
+// 4xx without the reason headers.
+func New(reason Reason, severity Severity, retry Retry) (Info, error) {
+	if _, ok := validReasons[reason]; !ok {
+		return Info{}, fmt.Errorf("%w: %q", ErrInvalidReason, reason)
 	}
-	return Info{Reason: reason, Severity: severity, Retry: retry}
+	if _, ok := validSeverities[severity]; !ok {
+		return Info{}, fmt.Errorf("%w: %q", ErrInvalidSeverity, severity)
+	}
+	if _, ok := validRetries[retry]; !ok {
+		return Info{}, fmt.Errorf("%w: %q", ErrInvalidRetry, retry)
+	}
+	return Info{Reason: reason, Severity: severity, Retry: retry}, nil
+}
+
+// MustNew is the panicking variant of New. Reserved for compile-time-known
+// constants and tests; never use it on the request hot path.
+func MustNew(reason Reason, severity Severity, retry Retry) Info {
+	info, err := New(reason, severity, retry)
+	if err != nil {
+		panic(fmt.Sprintf("blockreason.MustNew: %v", err))
+	}
+	return info
 }
 
 // WithLayer returns a copy of i with the Layer label set. Layer should be
 // one of the internal/scanner/ Scanner* constants for operator correlation.
-func (i Info) WithLayer(layer string) Info {
+// Returns ErrInvalidLayer if layer contains any non-ASCII-alphanumeric/underscore
+// byte or exceeds layerMaxLen. Empty layer is allowed (clears the optional field).
+func (i Info) WithLayer(layer string) (Info, error) {
+	if !validLayer(layer) {
+		return Info{}, fmt.Errorf("%w: %q", ErrInvalidLayer, layer)
+	}
 	i.Layer = layer
-	return i
+	return i, nil
 }
 
-// WithReceipt returns a copy of i with the Receipt UUID set.
-func (i Info) WithReceipt(receipt string) Info {
+// WithReceipt returns a copy of i with the Receipt set. Receipt MUST be
+// either empty or a 26-character Crockford-base32 ULID (the format the
+// receipt subsystem emits). The strict validation prevents arbitrary
+// strings — and therefore arbitrary attacker-controlled metadata — from
+// reaching agent-visible response headers via the Receipt slot.
+func (i Info) WithReceipt(receipt string) (Info, error) {
+	if !validReceipt(receipt) {
+		return Info{}, fmt.Errorf("%w: %q", ErrInvalidReceipt, receipt)
+	}
 	i.Receipt = receipt
-	return i
+	return i, nil
+}
+
+// isLayerByte returns true for the byte alphabet that internal/scanner/
+// Scanner* constants use: ASCII alphanumeric and underscore.
+func isLayerByte(c byte) bool {
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') ||
+		c == '_'
+}
+
+// validLayer permits only the layer byte alphabet, bounded by layerMaxLen.
+// Empty is allowed (clears the optional Layer field).
+func validLayer(s string) bool {
+	if len(s) > layerMaxLen {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if !isLayerByte(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// isReceiptByte returns true for the Crockford-base32 ULID alphabet:
+// 0-9 plus A-Z minus I, L, O, U (excluded to avoid ambiguity).
+func isReceiptByte(c byte) bool {
+	switch {
+	case c >= '0' && c <= '9':
+		return true
+	case c >= 'A' && c <= 'Z' && c != 'I' && c != 'L' && c != 'O' && c != 'U':
+		return true
+	}
+	return false
+}
+
+// validReceipt permits only the receipt byte alphabet at the fixed
+// receiptLen, or empty (clears the optional Receipt field).
+func validReceipt(s string) bool {
+	if s == "" {
+		return true
+	}
+	if len(s) != receiptLen {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if !isReceiptByte(s[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // SetHeaders writes all four required headers (reason, version, severity,
 // retry) and any populated optional headers onto h. Call BEFORE the
 // response's WriteHeader; net/http only honors headers set before status.
 //
-// SetHeaders unconditionally emits the four required headers. Empty values
-// in the required slots indicate the Info was not constructed via New(),
-// which is a contract violation — the headers will still emit (with empty
-// values) but downstream consumers may treat that as a malformed block.
+// SetHeaders trusts the Info to be well-formed (constructed via New +
+// WithLayer + WithReceipt). Empty required slots indicate a contract
+// violation; the headers still emit but downstream consumers may treat
+// the block as malformed.
 func (i Info) SetHeaders(h http.Header) {
 	h.Set(HeaderReason, string(i.Reason))
 	h.Set(HeaderVersion, SchemaVersion)
@@ -198,22 +338,23 @@ type closeFramePayload struct {
 // total, minus 2 bytes for the close-status code = 123 bytes for UTF-8 reason).
 const closeFrameMaxBytes = 123
 
-// closeFrameOverflowFallback is a fixed sentinel that is guaranteed to fit
-// within closeFrameMaxBytes. Used when even the bare {"block_reason":"..."}
-// would overflow because the Reason value is unusually long. The fallback
-// preserves a useful signal (parse_error severity warn / retry none, by
-// schema convention) while honoring the byte ceiling.
-const closeFrameOverflowFallback = `{"block_reason":"parse_error","version":"1"}`
+// closeFrameOverflowFallback preserves the operational signal that the block
+// metadata was malformed (BlockReasonOverflow) rather than silently
+// reclassifying the block as a parser failure. Always fits within
+// closeFrameMaxBytes (44 bytes).
+const closeFrameOverflowFallback = `{"block_reason":"block_reason_overflow","version":"1"}`
 
 // CloseFramePayload returns a JSON document for the WebSocket close-frame
 // Reason field. The result is GUARANTEED to be at most closeFrameMaxBytes
 // bytes (RFC 6455's 123-byte ceiling). To honor the ceiling, optional
 // fields drop in this order: receipt, layer, retry, severity, version.
-// If even the bare {"block_reason":"<code>"} would overflow (extremely
-// long Reason values), CloseFramePayload returns the fixed fallback
-// closeFrameOverflowFallback rather than a malformed close frame.
+// If even the bare {"block_reason":"<code>"} would overflow because the
+// Reason value is unusually long, CloseFramePayload returns
+// closeFrameOverflowFallback (block_reason_overflow). The fallback
+// preserves the security signal that the block metadata is malformed,
+// rather than silently downgrading to parse_error.
 //
-// CloseFramePayload assumes Info was constructed via New(); a zero Info
+// CloseFramePayload trusts the Info was constructed via New(); a zero Info
 // returns an empty-object sentinel.
 func (i Info) CloseFramePayload() string {
 	if i.Reason == "" {
@@ -231,8 +372,6 @@ func (i Info) CloseFramePayload() string {
 	if len(out) <= closeFrameMaxBytes {
 		return out
 	}
-
-	// Drop optional fields in order until the payload fits.
 	dropFields := []func(*closeFramePayload){
 		func(p *closeFramePayload) { p.Receipt = "" },
 		func(p *closeFramePayload) { p.Layer = "" },
@@ -247,21 +386,17 @@ func (i Info) CloseFramePayload() string {
 			return out
 		}
 	}
-	// Even the bare {"block_reason":"<code>"} doesn't fit: the Reason value
-	// is so long that we can't honor the byte ceiling without dropping the
-	// only required field. Return the fixed fallback so the close frame is
-	// always RFC 6455-compliant.
 	return closeFrameOverflowFallback
 }
 
 // mustMarshal is json.Marshal with a known-good fixed-shape struct. The
 // struct has only string fields (no interface{}, no time.Time) so
-// json.Marshal cannot fail. The error fallback is defensive code; if it
-// ever fires, treat it as a programming bug, not a runtime condition.
+// json.Marshal cannot fail on real input. The error fallback is defensive
+// code; it would surface the BlockReasonOverflow sentinel rather than a
+// silent zero value.
 func mustMarshal(p closeFramePayload) string {
 	b, err := json.Marshal(p)
 	if err != nil {
-		// Defensive: closeFramePayload only contains strings.
 		return closeFrameOverflowFallback
 	}
 	return string(b)

--- a/internal/blockreason/blockreason.go
+++ b/internal/blockreason/blockreason.go
@@ -1,0 +1,221 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package blockreason emits the X-Pipelock-Block-Reason header set on every
+// pipelock block path. The header carries a small, finite vocabulary of
+// machine-readable reason codes so agents can react intelligently to a block
+// instead of treating every 403 as opaque.
+//
+// The schema is locked at v1. See docs/specs/block-reason-header.md for the
+// canonical reason vocabulary, severity values, retry hints, and privacy rules.
+//
+// Privacy: header values must never carry matched secret content, DLP pattern
+// names, agent identifiers, session IDs, or any user-attributable data. The
+// header is operational metadata only.
+package blockreason
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// HTTP response headers emitted on every block.
+const (
+	HeaderReason   = "X-Pipelock-Block-Reason"
+	HeaderVersion  = "X-Pipelock-Block-Reason-Version"
+	HeaderSeverity = "X-Pipelock-Block-Reason-Severity"
+	HeaderRetry    = "X-Pipelock-Block-Reason-Retry"
+	HeaderLayer    = "X-Pipelock-Block-Reason-Layer"
+	HeaderReceipt  = "X-Pipelock-Block-Reason-Receipt"
+
+	// SchemaVersion increments only on breaking changes. Additive changes
+	// (new reason codes, new optional headers) keep v1.
+	SchemaVersion = "1"
+)
+
+// Reason is a machine-readable block-reason code. The full vocabulary is
+// defined as constants below and mirrored in docs/specs/block-reason-header.md.
+type Reason string
+
+const (
+	// Egress / network layer.
+	SchemeBlocked    Reason = "scheme_blocked"
+	DomainBlocklist  Reason = "domain_blocklist"
+	SSRFPrivateIP    Reason = "ssrf_private_ip"
+	SSRFMetadata     Reason = "ssrf_metadata"
+	SSRFDNSRebind    Reason = "ssrf_dns_rebind"
+	PathEntropy      Reason = "path_entropy"
+	SubdomainEntropy Reason = "subdomain_entropy"
+	URLLength        Reason = "url_length"
+	RateLimit        Reason = "rate_limit"
+	DataBudget       Reason = "data_budget"
+
+	// Content / payload layer.
+	DLPMatch         Reason = "dlp_match"
+	PromptInjection  Reason = "prompt_injection"
+	RedactionFailure Reason = "redaction_failure"
+	MediaPolicy      Reason = "media_policy"
+
+	// MCP / tool layer.
+	ToolPolicyDeny   Reason = "tool_policy_deny"
+	ToolChainBlocked Reason = "tool_chain_blocked"
+	ToolPoisoning    Reason = "tool_poisoning"
+	SessionBinding   Reason = "session_binding"
+
+	// Posture / runtime layer.
+	AirlockActive        Reason = "airlock_active"
+	KillSwitchActive     Reason = "kill_switch_active"
+	EnvelopeVerifyFailed Reason = "envelope_verify_failed"
+	AuthorityMismatch    Reason = "authority_mismatch"
+	EscalationLevel      Reason = "escalation_level"
+
+	// Generic.
+	ParseError         Reason = "parse_error"
+	Timeout            Reason = "timeout"
+	PatternUnavailable Reason = "pattern_unavailable"
+	NotEnabled         Reason = "not_enabled"
+	BadRequest         Reason = "bad_request"
+)
+
+// Severity matches pipelock's existing severity vocabulary in
+// internal/config/schema.go (SeverityInfo / SeverityWarn / SeverityCritical).
+type Severity string
+
+const (
+	SeverityInfo     Severity = "info"
+	SeverityWarn     Severity = "warn"
+	SeverityCritical Severity = "critical"
+)
+
+// Retry hints tell the agent whether and how to retry.
+type Retry string
+
+const (
+	// RetryNone means the block is permanent for this request as-is.
+	// Retrying without changing the input produces the same block.
+	RetryNone Retry = "none"
+
+	// RetryTransient means the condition is time-bound. Retry with backoff
+	// may succeed (rate limits, airlock cooldown, kill switch deactivation).
+	RetryTransient Retry = "transient"
+
+	// RetryPolicy means the agent should only retry after an operator
+	// changes pipelock policy (domain blocklist, tool policy, data budget).
+	RetryPolicy Retry = "policy"
+)
+
+// Info is the operational metadata for a block. Privacy: never populate
+// Layer or Receipt with anything that could identify matched content,
+// session, or agent.
+type Info struct {
+	Reason   Reason
+	Severity Severity
+	Retry    Retry
+
+	// Layer is the scanner pipeline layer label, e.g. "dlp", "ssrf",
+	// "rate_limit". Optional. Aligns with internal/scanner/ layer names.
+	Layer string
+
+	// Receipt is the receipt UUID for this block, if a receipt was emitted.
+	// Lets the agent fetch richer context via the receipt-transports
+	// endpoint. Optional.
+	Receipt string
+}
+
+// SetHeaders writes the required headers and any populated optional headers
+// onto h. Call BEFORE the response's WriteHeader; the headers are only
+// honored by net/http when set before status is written.
+func (i Info) SetHeaders(h http.Header) {
+	if i.Reason == "" {
+		// A block with no reason is a programming error in the call site.
+		// We still emit the version header so consumers can detect the
+		// schema; the reason header is omitted to preserve the invariant
+		// that an emitted reason code is always one we documented.
+		h.Set(HeaderVersion, SchemaVersion)
+		return
+	}
+	h.Set(HeaderReason, string(i.Reason))
+	h.Set(HeaderVersion, SchemaVersion)
+	if i.Severity != "" {
+		h.Set(HeaderSeverity, string(i.Severity))
+	}
+	if i.Retry != "" {
+		h.Set(HeaderRetry, string(i.Retry))
+	}
+	if i.Layer != "" {
+		h.Set(HeaderLayer, i.Layer)
+	}
+	if i.Receipt != "" {
+		h.Set(HeaderReceipt, i.Receipt)
+	}
+}
+
+// closeFramePayload is the JSON shape carried in WebSocket close-frame Reason
+// fields. Field names mirror the header set without the X-Pipelock prefix.
+type closeFramePayload struct {
+	BlockReason string `json:"block_reason"`
+	Version     string `json:"version"`
+	Severity    string `json:"severity,omitempty"`
+	Retry       string `json:"retry,omitempty"`
+	Layer       string `json:"layer,omitempty"`
+	Receipt     string `json:"receipt,omitempty"`
+}
+
+// closeFrameMaxBytes is RFC 6455's close-frame reason payload limit (125 bytes
+// total, minus 2 bytes for the close-status code = 123 bytes for UTF-8 reason).
+const closeFrameMaxBytes = 123
+
+// CloseFramePayload returns a JSON document for the WebSocket close-frame
+// Reason field. If the full document would exceed RFC 6455's 123-byte limit,
+// optional fields drop in this order: receipt, layer, retry, severity, version.
+// The block_reason field is always present (or the result is "{}").
+func (i Info) CloseFramePayload() string {
+	if i.Reason == "" {
+		return "{}"
+	}
+	p := closeFramePayload{
+		BlockReason: string(i.Reason),
+		Version:     SchemaVersion,
+		Severity:    string(i.Severity),
+		Retry:       string(i.Retry),
+		Layer:       i.Layer,
+		Receipt:     i.Receipt,
+	}
+	out := mustMarshal(p)
+	if len(out) <= closeFrameMaxBytes {
+		return out
+	}
+
+	// Drop optional fields in order until the payload fits.
+	dropFields := []func(*closeFramePayload){
+		func(p *closeFramePayload) { p.Receipt = "" },
+		func(p *closeFramePayload) { p.Layer = "" },
+		func(p *closeFramePayload) { p.Retry = "" },
+		func(p *closeFramePayload) { p.Severity = "" },
+		func(p *closeFramePayload) { p.Version = "" },
+	}
+	for _, drop := range dropFields {
+		drop(&p)
+		out = mustMarshal(p)
+		if len(out) <= closeFrameMaxBytes {
+			return out
+		}
+	}
+	// Even the bare {block_reason} can in principle exceed the limit if a
+	// future code is unusually long. Return what we have; the WebSocket
+	// caller is responsible for the final truncation policy.
+	return out
+}
+
+// mustMarshal is json.Marshal with a known-good fixed-shape struct. The
+// struct has no funky types (no interface{}, no time.Time, no big.Int) so
+// json.Marshal cannot fail. We treat any error as a programming bug.
+func mustMarshal(p closeFramePayload) string {
+	b, err := json.Marshal(p)
+	if err != nil {
+		// Programmer error: closeFramePayload only contains strings.
+		// Surface a stable sentinel rather than panic in a server path.
+		return `{"block_reason":"parse_error","version":"1"}`
+	}
+	return string(b)
+}

--- a/internal/blockreason/blockreason_test.go
+++ b/internal/blockreason/blockreason_test.go
@@ -10,40 +10,98 @@ import (
 	"testing"
 )
 
-func TestSetHeaders_PopulatesAllFields(t *testing.T) {
+func TestNew_RequiredTriple(t *testing.T) {
 	t.Parallel()
-	info := Info{
-		Reason:   DLPMatch,
-		Severity: SeverityCritical,
-		Retry:    RetryNone,
-		Layer:    "dlp",
-		Receipt:  "01HZ8EXAMPLERECEIPTID",
+	info := New(DLPMatch, SeverityCritical, RetryNone)
+	if info.Reason != DLPMatch {
+		t.Errorf("Reason = %q, want %q", info.Reason, DLPMatch)
 	}
+	if info.Severity != SeverityCritical {
+		t.Errorf("Severity = %q, want %q", info.Severity, SeverityCritical)
+	}
+	if info.Retry != RetryNone {
+		t.Errorf("Retry = %q, want %q", info.Retry, RetryNone)
+	}
+}
+
+func TestNew_PanicsOnEmptyRequiredField(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		reason   Reason
+		severity Severity
+		retry    Retry
+	}{
+		{"empty reason", "", SeverityCritical, RetryNone},
+		{"empty severity", DLPMatch, "", RetryNone},
+		{"empty retry", DLPMatch, SeverityCritical, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic for %s, got none", tc.name)
+				}
+			}()
+			_ = New(tc.reason, tc.severity, tc.retry)
+		})
+	}
+}
+
+func TestWithLayer_AndWithReceipt(t *testing.T) {
+	t.Parallel()
+	info := New(DLPMatch, SeverityCritical, RetryNone).
+		WithLayer("dlp").
+		WithReceipt("01HZ8EXAMPLE")
+	if info.Layer != "dlp" {
+		t.Errorf("Layer = %q, want %q", info.Layer, "dlp")
+	}
+	if info.Receipt != "01HZ8EXAMPLE" {
+		t.Errorf("Receipt = %q, want %q", info.Receipt, "01HZ8EXAMPLE")
+	}
+}
+
+func TestSetHeaders_AlwaysEmitsRequiredFour(t *testing.T) {
+	t.Parallel()
+	// Required headers must always emit. Empty values still surface so a
+	// downstream consumer can detect a malformed block from a misconstructed
+	// Info — the only way to get an empty required header is bypassing New().
+	info := New(SSRFPrivateIP, SeverityCritical, RetryNone)
 	h := make(http.Header)
 	info.SetHeaders(h)
 
-	cases := map[string]string{
-		HeaderReason:   "dlp_match",
+	required := map[string]string{
+		HeaderReason:   "ssrf_private_ip",
 		HeaderVersion:  "1",
 		HeaderSeverity: "critical",
 		HeaderRetry:    "none",
-		HeaderLayer:    "dlp",
-		HeaderReceipt:  "01HZ8EXAMPLERECEIPTID",
 	}
-	for k, want := range cases {
+	for k, want := range required {
 		if got := h.Get(k); got != want {
-			t.Errorf("header %s = %q, want %q", k, got, want)
+			t.Errorf("required header %s = %q, want %q", k, got, want)
 		}
 	}
 }
 
-func TestSetHeaders_OmitsEmptyOptionalFields(t *testing.T) {
+func TestSetHeaders_OptionalFieldsSurfaceWhenSet(t *testing.T) {
 	t.Parallel()
-	info := Info{
-		Reason:   PromptInjection,
-		Severity: SeverityCritical,
-		Retry:    RetryNone,
+	info := New(DLPMatch, SeverityCritical, RetryNone).
+		WithLayer("dlp").
+		WithReceipt("01HZ8EXAMPLE")
+	h := make(http.Header)
+	info.SetHeaders(h)
+
+	if got := h.Get(HeaderLayer); got != "dlp" {
+		t.Errorf("HeaderLayer = %q, want %q", got, "dlp")
 	}
+	if got := h.Get(HeaderReceipt); got != "01HZ8EXAMPLE" {
+		t.Errorf("HeaderReceipt = %q, want %q", got, "01HZ8EXAMPLE")
+	}
+}
+
+func TestSetHeaders_OmitsOptionalFieldsWhenUnset(t *testing.T) {
+	t.Parallel()
+	info := New(PromptInjection, SeverityCritical, RetryNone)
 	h := make(http.Header)
 	info.SetHeaders(h)
 
@@ -53,65 +111,22 @@ func TestSetHeaders_OmitsEmptyOptionalFields(t *testing.T) {
 	if h.Get(HeaderReceipt) != "" {
 		t.Errorf("HeaderReceipt should be empty, got %q", h.Get(HeaderReceipt))
 	}
-	if got := h.Get(HeaderReason); got != "prompt_injection" {
-		t.Errorf("HeaderReason = %q, want prompt_injection", got)
-	}
-}
-
-func TestSetHeaders_OmitsEmptySeverityAndRetry(t *testing.T) {
-	t.Parallel()
-	// Some legacy call sites may not have severity/retry context. The
-	// helper must still emit reason + version without panicking.
-	info := Info{Reason: BadRequest}
-	h := make(http.Header)
-	info.SetHeaders(h)
-
-	if got := h.Get(HeaderReason); got != "bad_request" {
-		t.Errorf("HeaderReason = %q, want bad_request", got)
-	}
-	if got := h.Get(HeaderVersion); got != "1" {
-		t.Errorf("HeaderVersion = %q, want 1", got)
-	}
-	if got := h.Get(HeaderSeverity); got != "" {
-		t.Errorf("HeaderSeverity should be empty, got %q", got)
-	}
-	if got := h.Get(HeaderRetry); got != "" {
-		t.Errorf("HeaderRetry should be empty, got %q", got)
-	}
-}
-
-func TestSetHeaders_EmptyReasonEmitsOnlyVersion(t *testing.T) {
-	t.Parallel()
-	// A zero-Info is a programming error at the call site. We still emit
-	// the version header so consumers can detect the schema; the reason
-	// header is omitted to preserve the invariant that an emitted reason
-	// code is always one we documented.
-	h := make(http.Header)
-	Info{}.SetHeaders(h)
-
-	if got := h.Get(HeaderReason); got != "" {
-		t.Errorf("HeaderReason should be empty for zero-Info, got %q", got)
-	}
-	if got := h.Get(HeaderVersion); got != "1" {
-		t.Errorf("HeaderVersion = %q, want 1", got)
-	}
 }
 
 func TestCloseFramePayload_FullShape(t *testing.T) {
 	t.Parallel()
-	info := Info{
-		Reason:   DLPMatch,
-		Severity: SeverityCritical,
-		Retry:    RetryNone,
-		Layer:    "dlp",
-		Receipt:  "rcpt1",
-	}
+	info := New(DLPMatch, SeverityCritical, RetryNone).
+		WithLayer("dlp").
+		WithReceipt("rcpt1")
 	got := info.CloseFramePayload()
+
+	if len(got) > closeFrameMaxBytes {
+		t.Errorf("payload %d bytes exceeds RFC 6455 limit %d", len(got), closeFrameMaxBytes)
+	}
 	var parsed map[string]string
 	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
 		t.Fatalf("payload not valid JSON: %v (%q)", err, got)
 	}
-
 	want := map[string]string{
 		"block_reason": "dlp_match",
 		"version":      "1",
@@ -127,7 +142,7 @@ func TestCloseFramePayload_FullShape(t *testing.T) {
 	}
 }
 
-func TestCloseFramePayload_EmptyReason(t *testing.T) {
+func TestCloseFramePayload_ZeroInfoSentinel(t *testing.T) {
 	t.Parallel()
 	got := Info{}.CloseFramePayload()
 	if got != "{}" {
@@ -135,52 +150,72 @@ func TestCloseFramePayload_EmptyReason(t *testing.T) {
 	}
 }
 
-func TestCloseFramePayload_FitsRFC6455Limit(t *testing.T) {
+func TestCloseFramePayload_AlwaysFitsRFC6455Limit(t *testing.T) {
 	t.Parallel()
-	// Construct an Info large enough to exceed 123 bytes if all fields
-	// were emitted, then verify graceful truncation drops fields in the
-	// documented order: receipt, layer, retry, severity, version.
-	big := strings.Repeat("X", 80)
-	info := Info{
-		Reason:   DLPMatch,
-		Severity: SeverityCritical,
-		Retry:    RetryNone,
-		Layer:    "dlp_layer",
-		Receipt:  big,
+	// Invariant: the helper owns RFC 6455 framing semantics. Every output
+	// must fit within closeFrameMaxBytes regardless of input. This test
+	// covers normal, optional-field-truncated, and overlong-Reason cases.
+	cases := []struct {
+		name string
+		info Info
+	}{
+		{"normal", New(DLPMatch, SeverityCritical, RetryNone)},
+		{"with optional fields", New(DLPMatch, SeverityCritical, RetryNone).
+			WithLayer("dlp").WithReceipt("01HZ8EXAMPLE")},
+		{"large receipt forces drop", New(ToolPolicyDeny, SeverityCritical, RetryPolicy).
+			WithLayer(strings.Repeat("L", 50)).
+			WithReceipt(strings.Repeat("R", 90))},
+		{"overlong reason forces fallback", Info{
+			Reason: Reason(strings.Repeat("X", 200)),
+		}},
+		{"barely-fitting reason at floor", Info{
+			Reason: Reason(strings.Repeat("X", 100)),
+		}},
 	}
-	got := info.CloseFramePayload()
-	if len(got) > closeFrameMaxBytes {
-		t.Errorf("payload %d bytes exceeds RFC 6455 limit %d (%q)",
-			len(got), closeFrameMaxBytes, got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.info.CloseFramePayload()
+			if len(got) > closeFrameMaxBytes {
+				t.Errorf("payload %d bytes exceeds RFC 6455 limit %d (%q)",
+					len(got), closeFrameMaxBytes, got)
+			}
+			var parsed map[string]string
+			if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+				t.Fatalf("payload not valid JSON: %v (%q)", err, got)
+			}
+			if parsed["block_reason"] == "" {
+				t.Errorf("block_reason missing: %q", got)
+			}
+		})
 	}
+}
 
-	var parsed map[string]string
-	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
-		t.Fatalf("truncated payload not valid JSON: %v (%q)", err, got)
+func TestCloseFramePayload_OverlongReasonReturnsFallback(t *testing.T) {
+	t.Parallel()
+	// When the Reason itself exceeds what can fit in a bare
+	// {"block_reason":"..."} document, CloseFramePayload returns a fixed
+	// fallback rather than a malformed close frame.
+	info := Info{Reason: Reason(strings.Repeat("X", 200))}
+	got := info.CloseFramePayload()
+	if got != closeFrameOverflowFallback {
+		t.Errorf("overlong-reason payload = %q, want fallback %q",
+			got, closeFrameOverflowFallback)
 	}
-	// block_reason is always present.
-	if parsed["block_reason"] != "dlp_match" {
-		t.Errorf("block_reason missing from truncated payload: %q", got)
-	}
-	// receipt is dropped first.
-	if parsed["receipt"] != "" {
-		t.Errorf("receipt should drop first, got %q", parsed["receipt"])
+	if len(got) > closeFrameMaxBytes {
+		t.Errorf("fallback %d bytes exceeds RFC 6455 limit %d", len(got), closeFrameMaxBytes)
 	}
 }
 
 func TestCloseFramePayload_ProgressiveTruncation(t *testing.T) {
 	t.Parallel()
-	// Each field longer than the previous so each truncation step is
-	// forced. After all optional fields drop the payload should still
-	// be valid JSON containing block_reason at minimum.
-	info := Info{
-		Reason:   ToolPolicyDeny,
-		Severity: SeverityCritical,
-		Retry:    RetryPolicy,
-		Layer:    strings.Repeat("L", 50),
-		Receipt:  strings.Repeat("R", 90),
-	}
+	// Force each truncation step to fire so the fall-through algorithm is
+	// fully exercised. The receipt drops first, then layer, then retry,
+	// then severity, then version. block_reason always remains.
+	info := New(ToolPolicyDeny, SeverityCritical, RetryPolicy).
+		WithLayer(strings.Repeat("L", 50)).
+		WithReceipt(strings.Repeat("R", 90))
 	got := info.CloseFramePayload()
+
 	if len(got) > closeFrameMaxBytes {
 		t.Errorf("progressive truncation failed: %d bytes > %d (%q)",
 			len(got), closeFrameMaxBytes, got)
@@ -194,52 +229,31 @@ func TestCloseFramePayload_ProgressiveTruncation(t *testing.T) {
 	}
 }
 
-func TestReasonConstants_AllDocumentedCodes(t *testing.T) {
+func TestReasonConstants_AllSnakeCase(t *testing.T) {
 	t.Parallel()
-	// Privacy invariant: every constant we expose is a code consumers will
+	// Privacy and contract: every constant is a code consumers will
 	// permanently see in the wild. Renaming is a breaking change. This
 	// test snapshots the v1 vocabulary so silent renames trip CI.
-	want := map[Reason]bool{
+	codes := []Reason{
 		// Egress / network
-		SchemeBlocked:    true,
-		DomainBlocklist:  true,
-		SSRFPrivateIP:    true,
-		SSRFMetadata:     true,
-		SSRFDNSRebind:    true,
-		PathEntropy:      true,
-		SubdomainEntropy: true,
-		URLLength:        true,
-		RateLimit:        true,
-		DataBudget:       true,
+		SchemeBlocked, DomainBlocklist, SSRFPrivateIP, SSRFMetadata, SSRFDNSRebind,
+		PathEntropy, SubdomainEntropy, URLLength, RateLimit, DataBudget,
 		// Content
-		DLPMatch:         true,
-		PromptInjection:  true,
-		RedactionFailure: true,
-		MediaPolicy:      true,
+		DLPMatch, PromptInjection, RedactionFailure, MediaPolicy,
 		// MCP
-		ToolPolicyDeny:   true,
-		ToolChainBlocked: true,
-		ToolPoisoning:    true,
-		SessionBinding:   true,
+		ToolPolicyDeny, ToolChainBlocked, ToolPoisoning, SessionBinding,
 		// Posture
-		AirlockActive:        true,
-		KillSwitchActive:     true,
-		EnvelopeVerifyFailed: true,
-		AuthorityMismatch:    true,
-		EscalationLevel:      true,
+		AirlockActive, KillSwitchActive, EnvelopeVerifyFailed, AuthorityMismatch, EscalationLevel,
 		// Generic
-		ParseError:         true,
-		Timeout:            true,
-		PatternUnavailable: true,
-		NotEnabled:         true,
-		BadRequest:         true,
+		ParseError, Timeout, PatternUnavailable, NotEnabled, BadRequest,
 	}
-	for r := range want {
-		if r == "" {
+	for _, r := range codes {
+		s := string(r)
+		if s == "" {
 			t.Errorf("Reason constant has empty value")
 		}
-		if got := string(r); got != strings.ToLower(got) {
-			t.Errorf("Reason %q is not snake_case lowercase", r)
+		if s != strings.ToLower(s) {
+			t.Errorf("Reason %q is not lowercase", r)
 		}
 	}
 }
@@ -275,46 +289,31 @@ func TestRetryConstants_v1Vocabulary(t *testing.T) {
 	}
 }
 
-func TestCloseFramePayload_OvergrownReasonStillReturnsJSON(t *testing.T) {
+func TestSetHeaders_DoesNotLeakSecretContent(t *testing.T) {
 	t.Parallel()
-	// Defensive: if a future Reason value were ever long enough that even
-	// the bare {"block_reason":"..."} document exceeded the RFC 6455
-	// limit, CloseFramePayload must still return a parseable JSON string.
-	// No real v1 Reason approaches this length; we synthesize one to pin
-	// the fall-through behavior.
-	giant := Reason(strings.Repeat("X", 200))
-	got := Info{Reason: giant}.CloseFramePayload()
+	// Privacy invariant: the Info struct deliberately exposes only
+	// {Reason, Severity, Retry, Layer, Receipt}. None of those fields
+	// can carry matched content, pattern names, or agent identifiers
+	// without an explicit (and reviewable) call-site decision. This test
+	// pins the surface so a future field addition trips review.
+	info := New(DLPMatch, SeverityCritical, RetryNone)
+	h := make(http.Header)
+	info.SetHeaders(h)
 
-	var parsed map[string]string
-	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
-		t.Fatalf("overgrown payload not valid JSON: %v (%q)", err, got)
-	}
-	if parsed["block_reason"] == "" {
-		t.Errorf("block_reason missing from overgrown payload: %q", got)
+	for k, vs := range h {
+		for _, v := range vs {
+			lc := strings.ToLower(v)
+			if strings.Contains(lc, "akia") ||
+				strings.Contains(lc, "sk-") ||
+				strings.Contains(lc, "ghp_") {
+				t.Errorf("header %s = %q looks like a secret leak", k, v)
+			}
+		}
 	}
 }
 
-func TestCloseFramePayload_NoOptionalFieldsRequired(t *testing.T) {
+func TestMustMarshal_FixedShapeProducesValidJSON(t *testing.T) {
 	t.Parallel()
-	// A minimal Info — reason only — must produce a valid payload that
-	// fits trivially within the limit.
-	info := Info{Reason: KillSwitchActive}
-	got := info.CloseFramePayload()
-	if len(got) > closeFrameMaxBytes {
-		t.Errorf("minimal payload %d bytes exceeds limit %d", len(got), closeFrameMaxBytes)
-	}
-	if !strings.Contains(got, `"block_reason":"kill_switch_active"`) {
-		t.Errorf("payload missing kill_switch_active: %q", got)
-	}
-}
-
-func TestMustMarshal_FixedShapeNeverReturnsEmptyString(t *testing.T) {
-	t.Parallel()
-	// The closeFramePayload struct has only string fields. json.Marshal
-	// cannot fail on it. mustMarshal's error sentinel is defensive and
-	// not reachable through the public API; this test pins the contract
-	// so any future schema change that introduces a non-string field
-	// (which CAN fail to marshal) trips review.
 	got := mustMarshal(closeFramePayload{
 		BlockReason: "dlp_match",
 		Version:     "1",
@@ -328,30 +327,5 @@ func TestMustMarshal_FixedShapeNeverReturnsEmptyString(t *testing.T) {
 	}
 	if parsed["block_reason"] != "dlp_match" {
 		t.Errorf("block_reason round-trip failed: got %q", parsed["block_reason"])
-	}
-}
-
-func TestSetHeaders_DoesNotLeakSecretContent(t *testing.T) {
-	t.Parallel()
-	// Privacy invariant: the helper has no path that takes secret content
-	// or pattern names. The Info struct deliberately exposes only
-	// {Reason, Severity, Retry, Layer, Receipt}. This test pins that
-	// shape so a future field addition trips review.
-	info := Info{
-		Reason:   DLPMatch,
-		Severity: SeverityCritical,
-		Retry:    RetryNone,
-	}
-	h := make(http.Header)
-	info.SetHeaders(h)
-
-	for k, vs := range h {
-		for _, v := range vs {
-			if strings.Contains(strings.ToLower(v), "akia") ||
-				strings.Contains(strings.ToLower(v), "sk-") ||
-				strings.Contains(strings.ToLower(v), "ghp_") {
-				t.Errorf("header %s = %q looks like a secret leak", k, v)
-			}
-		}
 	}
 }

--- a/internal/blockreason/blockreason_test.go
+++ b/internal/blockreason/blockreason_test.go
@@ -5,14 +5,21 @@ package blockreason
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
 )
 
-func TestNew_RequiredTriple(t *testing.T) {
+// validULID is a 26-char Crockford-base32 string (no I, L, O, U).
+const validULID = "01J0GNYZ7XSQRTQ8FPYM5BHX2K"
+
+func TestNew_AcceptsValidTriple(t *testing.T) {
 	t.Parallel()
-	info := New(DLPMatch, SeverityCritical, RetryNone)
+	info, err := New(DLPMatch, SeverityCritical, RetryNone)
+	if err != nil {
+		t.Fatalf("New returned error for valid input: %v", err)
+	}
 	if info.Reason != DLPMatch {
 		t.Errorf("Reason = %q, want %q", info.Reason, DLPMatch)
 	}
@@ -24,49 +31,154 @@ func TestNew_RequiredTriple(t *testing.T) {
 	}
 }
 
-func TestNew_PanicsOnEmptyRequiredField(t *testing.T) {
+func TestNew_RejectsInvalidVocabulary(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name     string
 		reason   Reason
 		severity Severity
 		retry    Retry
+		wantErr  error
 	}{
-		{"empty reason", "", SeverityCritical, RetryNone},
-		{"empty severity", DLPMatch, "", RetryNone},
-		{"empty retry", DLPMatch, SeverityCritical, ""},
+		{"unknown reason", "made_up_reason", SeverityCritical, RetryNone, ErrInvalidReason},
+		{"empty reason", "", SeverityCritical, RetryNone, ErrInvalidReason},
+		{"unknown severity", DLPMatch, "boom", RetryNone, ErrInvalidSeverity},
+		{"empty severity", DLPMatch, "", RetryNone, ErrInvalidSeverity},
+		{"unknown retry", DLPMatch, SeverityCritical, "later", ErrInvalidRetry},
+		{"empty retry", DLPMatch, SeverityCritical, "", ErrInvalidRetry},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer func() {
-				if r := recover(); r == nil {
-					t.Errorf("expected panic for %s, got none", tc.name)
-				}
-			}()
-			_ = New(tc.reason, tc.severity, tc.retry)
+			_, err := New(tc.reason, tc.severity, tc.retry)
+			if err == nil {
+				t.Errorf("expected error for %s, got nil", tc.name)
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("error = %v, want wrap of %v", err, tc.wantErr)
+			}
 		})
 	}
 }
 
-func TestWithLayer_AndWithReceipt(t *testing.T) {
+func TestMustNew_PanicsOnInvalid(t *testing.T) {
 	t.Parallel()
-	info := New(DLPMatch, SeverityCritical, RetryNone).
-		WithLayer("dlp").
-		WithReceipt("01HZ8EXAMPLE")
-	if info.Layer != "dlp" {
-		t.Errorf("Layer = %q, want %q", info.Layer, "dlp")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic for invalid MustNew")
+		}
+	}()
+	_ = MustNew("nope", SeverityCritical, RetryNone)
+}
+
+func TestMustNew_OkOnValid(t *testing.T) {
+	t.Parallel()
+	info := MustNew(DLPMatch, SeverityCritical, RetryNone)
+	if info.Reason != DLPMatch {
+		t.Errorf("Reason = %q", info.Reason)
 	}
-	if info.Receipt != "01HZ8EXAMPLE" {
-		t.Errorf("Receipt = %q, want %q", info.Receipt, "01HZ8EXAMPLE")
+}
+
+func TestWithLayer_AcceptsValidScannerLabel(t *testing.T) {
+	t.Parallel()
+	base := MustNew(DLPMatch, SeverityCritical, RetryNone)
+	got, err := base.WithLayer("dlp")
+	if err != nil {
+		t.Fatalf("WithLayer error: %v", err)
+	}
+	if got.Layer != "dlp" {
+		t.Errorf("Layer = %q, want dlp", got.Layer)
+	}
+}
+
+func TestWithLayer_RejectsInvalid(t *testing.T) {
+	t.Parallel()
+	base := MustNew(DLPMatch, SeverityCritical, RetryNone)
+	cases := []struct {
+		name  string
+		layer string
+	}{
+		{"control char", "dlp\n"},
+		{"slash", "dl/p"},
+		{"space", "dl p"},
+		{"too long", strings.Repeat("a", layerMaxLen+1)},
+		{"non-ascii", "dlp" + "\xc3\xa9"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := base.WithLayer(tc.layer)
+			if !errors.Is(err, ErrInvalidLayer) {
+				t.Errorf("error = %v, want wrap of ErrInvalidLayer", err)
+			}
+		})
+	}
+}
+
+func TestWithLayer_EmptyAllowed(t *testing.T) {
+	t.Parallel()
+	base := MustNew(DLPMatch, SeverityCritical, RetryNone)
+	got, err := base.WithLayer("")
+	if err != nil {
+		t.Fatalf("empty layer rejected: %v", err)
+	}
+	if got.Layer != "" {
+		t.Errorf("Layer = %q, want empty", got.Layer)
+	}
+}
+
+func TestWithReceipt_AcceptsValidULID(t *testing.T) {
+	t.Parallel()
+	base := MustNew(DLPMatch, SeverityCritical, RetryNone)
+	got, err := base.WithReceipt(validULID)
+	if err != nil {
+		t.Fatalf("WithReceipt error: %v", err)
+	}
+	if got.Receipt != validULID {
+		t.Errorf("Receipt = %q, want %q", got.Receipt, validULID)
+	}
+}
+
+func TestWithReceipt_RejectsNonULIDShapes(t *testing.T) {
+	t.Parallel()
+	base := MustNew(DLPMatch, SeverityCritical, RetryNone)
+	cases := []struct {
+		name    string
+		receipt string
+	}{
+		{"too short", "01HZ8"},
+		{"too long", validULID + "EXTRA"},
+		{"contains lowercase", strings.ToLower(validULID)},
+		{"contains forbidden I", "I1HZ8EXAMPLERECEIPTID00000"},
+		{"contains forbidden L", "L1HZ8EXAMPLERECEIPTID00000"},
+		{"contains forbidden O", "O1HZ8EXAMPLERECEIPTID00000"},
+		{"contains forbidden U", "U1HZ8EXAMPLERECEIPTID00000"},
+		{"contains punctuation", "01HZ8-XAMPLERECEIPTID00000"},
+		{"contains control", "01HZ8\nXAMPLERECEIPTID00000"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := base.WithReceipt(tc.receipt)
+			if !errors.Is(err, ErrInvalidReceipt) {
+				t.Errorf("error = %v, want wrap of ErrInvalidReceipt", err)
+			}
+		})
+	}
+}
+
+func TestWithReceipt_EmptyAllowed(t *testing.T) {
+	t.Parallel()
+	base := MustNew(DLPMatch, SeverityCritical, RetryNone)
+	got, err := base.WithReceipt("")
+	if err != nil {
+		t.Fatalf("empty receipt rejected: %v", err)
+	}
+	if got.Receipt != "" {
+		t.Errorf("Receipt = %q, want empty", got.Receipt)
 	}
 }
 
 func TestSetHeaders_AlwaysEmitsRequiredFour(t *testing.T) {
 	t.Parallel()
-	// Required headers must always emit. Empty values still surface so a
-	// downstream consumer can detect a malformed block from a misconstructed
-	// Info — the only way to get an empty required header is bypassing New().
-	info := New(SSRFPrivateIP, SeverityCritical, RetryNone)
+	info := MustNew(SSRFPrivateIP, SeverityCritical, RetryNone)
 	h := make(http.Header)
 	info.SetHeaders(h)
 
@@ -85,23 +197,29 @@ func TestSetHeaders_AlwaysEmitsRequiredFour(t *testing.T) {
 
 func TestSetHeaders_OptionalFieldsSurfaceWhenSet(t *testing.T) {
 	t.Parallel()
-	info := New(DLPMatch, SeverityCritical, RetryNone).
-		WithLayer("dlp").
-		WithReceipt("01HZ8EXAMPLE")
+	info := MustNew(DLPMatch, SeverityCritical, RetryNone)
+	info, err := info.WithLayer("dlp")
+	if err != nil {
+		t.Fatalf("WithLayer: %v", err)
+	}
+	info, err = info.WithReceipt(validULID)
+	if err != nil {
+		t.Fatalf("WithReceipt: %v", err)
+	}
 	h := make(http.Header)
 	info.SetHeaders(h)
 
 	if got := h.Get(HeaderLayer); got != "dlp" {
-		t.Errorf("HeaderLayer = %q, want %q", got, "dlp")
+		t.Errorf("HeaderLayer = %q, want dlp", got)
 	}
-	if got := h.Get(HeaderReceipt); got != "01HZ8EXAMPLE" {
-		t.Errorf("HeaderReceipt = %q, want %q", got, "01HZ8EXAMPLE")
+	if got := h.Get(HeaderReceipt); got != validULID {
+		t.Errorf("HeaderReceipt = %q, want %q", got, validULID)
 	}
 }
 
 func TestSetHeaders_OmitsOptionalFieldsWhenUnset(t *testing.T) {
 	t.Parallel()
-	info := New(PromptInjection, SeverityCritical, RetryNone)
+	info := MustNew(PromptInjection, SeverityCritical, RetryNone)
 	h := make(http.Header)
 	info.SetHeaders(h)
 
@@ -113,11 +231,14 @@ func TestSetHeaders_OmitsOptionalFieldsWhenUnset(t *testing.T) {
 	}
 }
 
-func TestCloseFramePayload_FullShape(t *testing.T) {
+func TestCloseFramePayload_FullShapeWithoutReceipt(t *testing.T) {
 	t.Parallel()
-	info := New(DLPMatch, SeverityCritical, RetryNone).
-		WithLayer("dlp").
-		WithReceipt("rcpt1")
+	// Without the optional receipt the document fits with all other fields
+	// present. The full Reason+Severity+Retry+Layer+Receipt combination
+	// runs over the 123-byte ceiling; receipt dropping is exercised in the
+	// truncation tests.
+	info := MustNew(DLPMatch, SeverityCritical, RetryNone)
+	info, _ = info.WithLayer("dlp")
 	got := info.CloseFramePayload()
 
 	if len(got) > closeFrameMaxBytes {
@@ -133,12 +254,36 @@ func TestCloseFramePayload_FullShape(t *testing.T) {
 		"severity":     "critical",
 		"retry":        "none",
 		"layer":        "dlp",
-		"receipt":      "rcpt1",
 	}
 	for k, v := range want {
 		if parsed[k] != v {
 			t.Errorf("payload[%q] = %q, want %q", k, parsed[k], v)
 		}
+	}
+}
+
+func TestCloseFramePayload_ReceiptDropsToFitLimit(t *testing.T) {
+	t.Parallel()
+	// With every optional field populated the full document exceeds 123
+	// bytes. Receipt is the first field documented to drop, so it should
+	// be absent while the required fields remain.
+	info := MustNew(DLPMatch, SeverityCritical, RetryNone)
+	info, _ = info.WithLayer("dlp")
+	info, _ = info.WithReceipt(validULID)
+	got := info.CloseFramePayload()
+
+	if len(got) > closeFrameMaxBytes {
+		t.Errorf("payload %d bytes exceeds RFC 6455 limit %d", len(got), closeFrameMaxBytes)
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Fatalf("payload not valid JSON: %v (%q)", err, got)
+	}
+	if parsed["receipt"] != "" {
+		t.Errorf("receipt should drop first to fit limit, got %q", parsed["receipt"])
+	}
+	if parsed["block_reason"] != "dlp_match" {
+		t.Errorf("block_reason missing: got %q", parsed["block_reason"])
 	}
 }
 
@@ -152,25 +297,29 @@ func TestCloseFramePayload_ZeroInfoSentinel(t *testing.T) {
 
 func TestCloseFramePayload_AlwaysFitsRFC6455Limit(t *testing.T) {
 	t.Parallel()
-	// Invariant: the helper owns RFC 6455 framing semantics. Every output
-	// must fit within closeFrameMaxBytes regardless of input. This test
-	// covers normal, optional-field-truncated, and overlong-Reason cases.
+	hugeReceipt := MustNew(ToolPolicyDeny, SeverityCritical, RetryPolicy)
 	cases := []struct {
 		name string
 		info Info
 	}{
-		{"normal", New(DLPMatch, SeverityCritical, RetryNone)},
-		{"with optional fields", New(DLPMatch, SeverityCritical, RetryNone).
-			WithLayer("dlp").WithReceipt("01HZ8EXAMPLE")},
-		{"large receipt forces drop", New(ToolPolicyDeny, SeverityCritical, RetryPolicy).
-			WithLayer(strings.Repeat("L", 50)).
-			WithReceipt(strings.Repeat("R", 90))},
+		{"normal", MustNew(DLPMatch, SeverityCritical, RetryNone)},
+		// Direct struct-literal Info bypassing validators on purpose, to
+		// exercise the truncation algorithm with synthetic oversize values
+		// that the public API would refuse.
+		{"large receipt forces drop", Info{
+			Reason:   ToolPolicyDeny,
+			Severity: SeverityCritical,
+			Retry:    RetryPolicy,
+			Layer:    strings.Repeat("L", 50),
+			Receipt:  strings.Repeat("R", 90),
+		}},
 		{"overlong reason forces fallback", Info{
 			Reason: Reason(strings.Repeat("X", 200)),
 		}},
 		{"barely-fitting reason at floor", Info{
 			Reason: Reason(strings.Repeat("X", 100)),
 		}},
+		{"valid info with no optional", hugeReceipt},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -190,11 +339,13 @@ func TestCloseFramePayload_AlwaysFitsRFC6455Limit(t *testing.T) {
 	}
 }
 
-func TestCloseFramePayload_OverlongReasonReturnsFallback(t *testing.T) {
+func TestCloseFramePayload_OverlongReasonReturnsOverflowSignal(t *testing.T) {
 	t.Parallel()
-	// When the Reason itself exceeds what can fit in a bare
-	// {"block_reason":"..."} document, CloseFramePayload returns a fixed
-	// fallback rather than a malformed close frame.
+	// Direct struct literal with an oversize Reason. The public API rejects
+	// this at construction (New), but CloseFramePayload must still defend
+	// against it because Info is a value type Go cannot prevent direct
+	// construction of. The fallback uses BlockReasonOverflow, NOT
+	// ParseError, so audit fidelity is preserved.
 	info := Info{Reason: Reason(strings.Repeat("X", 200))}
 	got := info.CloseFramePayload()
 	if got != closeFrameOverflowFallback {
@@ -204,50 +355,14 @@ func TestCloseFramePayload_OverlongReasonReturnsFallback(t *testing.T) {
 	if len(got) > closeFrameMaxBytes {
 		t.Errorf("fallback %d bytes exceeds RFC 6455 limit %d", len(got), closeFrameMaxBytes)
 	}
-}
-
-func TestCloseFramePayload_ProgressiveTruncation(t *testing.T) {
-	t.Parallel()
-	// Force each truncation step to fire so the fall-through algorithm is
-	// fully exercised. The receipt drops first, then layer, then retry,
-	// then severity, then version. block_reason always remains.
-	info := New(ToolPolicyDeny, SeverityCritical, RetryPolicy).
-		WithLayer(strings.Repeat("L", 50)).
-		WithReceipt(strings.Repeat("R", 90))
-	got := info.CloseFramePayload()
-
-	if len(got) > closeFrameMaxBytes {
-		t.Errorf("progressive truncation failed: %d bytes > %d (%q)",
-			len(got), closeFrameMaxBytes, got)
-	}
-	var parsed map[string]string
-	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
-		t.Fatalf("not JSON after truncation: %v (%q)", err, got)
-	}
-	if parsed["block_reason"] != "tool_policy_deny" {
-		t.Errorf("block_reason missing after truncation: %q", got)
+	if !strings.Contains(got, string(BlockReasonOverflow)) {
+		t.Errorf("overflow payload does not carry BlockReasonOverflow signal: %q", got)
 	}
 }
 
 func TestReasonConstants_AllSnakeCase(t *testing.T) {
 	t.Parallel()
-	// Privacy and contract: every constant is a code consumers will
-	// permanently see in the wild. Renaming is a breaking change. This
-	// test snapshots the v1 vocabulary so silent renames trip CI.
-	codes := []Reason{
-		// Egress / network
-		SchemeBlocked, DomainBlocklist, SSRFPrivateIP, SSRFMetadata, SSRFDNSRebind,
-		PathEntropy, SubdomainEntropy, URLLength, RateLimit, DataBudget,
-		// Content
-		DLPMatch, PromptInjection, RedactionFailure, MediaPolicy,
-		// MCP
-		ToolPolicyDeny, ToolChainBlocked, ToolPoisoning, SessionBinding,
-		// Posture
-		AirlockActive, KillSwitchActive, EnvelopeVerifyFailed, AuthorityMismatch, EscalationLevel,
-		// Generic
-		ParseError, Timeout, PatternUnavailable, NotEnabled, BadRequest,
-	}
-	for _, r := range codes {
+	for r := range validReasons {
 		s := string(r)
 		if s == "" {
 			t.Errorf("Reason constant has empty value")
@@ -260,9 +375,6 @@ func TestReasonConstants_AllSnakeCase(t *testing.T) {
 
 func TestSeverityConstants_MatchExistingVocabulary(t *testing.T) {
 	t.Parallel()
-	// Severity values must match internal/config/schema.go vocabulary
-	// (info / warn / critical) so operators can correlate header-driven
-	// agent behavior with their existing emit / receipt streams.
 	cases := map[Severity]string{
 		SeverityInfo:     "info",
 		SeverityWarn:     "warn",
@@ -291,12 +403,11 @@ func TestRetryConstants_v1Vocabulary(t *testing.T) {
 
 func TestSetHeaders_DoesNotLeakSecretContent(t *testing.T) {
 	t.Parallel()
-	// Privacy invariant: the Info struct deliberately exposes only
-	// {Reason, Severity, Retry, Layer, Receipt}. None of those fields
-	// can carry matched content, pattern names, or agent identifiers
-	// without an explicit (and reviewable) call-site decision. This test
-	// pins the surface so a future field addition trips review.
-	info := New(DLPMatch, SeverityCritical, RetryNone)
+	// Privacy: Info exposes only {Reason, Severity, Retry, Layer, Receipt},
+	// each of which is constructor-validated against the v1 vocabulary or
+	// opaque-ID format. No path through the public API can put attacker-
+	// controlled or secret content into a header.
+	info := MustNew(DLPMatch, SeverityCritical, RetryNone)
 	h := make(http.Header)
 	info.SetHeaders(h)
 

--- a/internal/blockreason/blockreason_test.go
+++ b/internal/blockreason/blockreason_test.go
@@ -1,0 +1,357 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package blockreason
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestSetHeaders_PopulatesAllFields(t *testing.T) {
+	t.Parallel()
+	info := Info{
+		Reason:   DLPMatch,
+		Severity: SeverityCritical,
+		Retry:    RetryNone,
+		Layer:    "dlp",
+		Receipt:  "01HZ8EXAMPLERECEIPTID",
+	}
+	h := make(http.Header)
+	info.SetHeaders(h)
+
+	cases := map[string]string{
+		HeaderReason:   "dlp_match",
+		HeaderVersion:  "1",
+		HeaderSeverity: "critical",
+		HeaderRetry:    "none",
+		HeaderLayer:    "dlp",
+		HeaderReceipt:  "01HZ8EXAMPLERECEIPTID",
+	}
+	for k, want := range cases {
+		if got := h.Get(k); got != want {
+			t.Errorf("header %s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestSetHeaders_OmitsEmptyOptionalFields(t *testing.T) {
+	t.Parallel()
+	info := Info{
+		Reason:   PromptInjection,
+		Severity: SeverityCritical,
+		Retry:    RetryNone,
+	}
+	h := make(http.Header)
+	info.SetHeaders(h)
+
+	if h.Get(HeaderLayer) != "" {
+		t.Errorf("HeaderLayer should be empty, got %q", h.Get(HeaderLayer))
+	}
+	if h.Get(HeaderReceipt) != "" {
+		t.Errorf("HeaderReceipt should be empty, got %q", h.Get(HeaderReceipt))
+	}
+	if got := h.Get(HeaderReason); got != "prompt_injection" {
+		t.Errorf("HeaderReason = %q, want prompt_injection", got)
+	}
+}
+
+func TestSetHeaders_OmitsEmptySeverityAndRetry(t *testing.T) {
+	t.Parallel()
+	// Some legacy call sites may not have severity/retry context. The
+	// helper must still emit reason + version without panicking.
+	info := Info{Reason: BadRequest}
+	h := make(http.Header)
+	info.SetHeaders(h)
+
+	if got := h.Get(HeaderReason); got != "bad_request" {
+		t.Errorf("HeaderReason = %q, want bad_request", got)
+	}
+	if got := h.Get(HeaderVersion); got != "1" {
+		t.Errorf("HeaderVersion = %q, want 1", got)
+	}
+	if got := h.Get(HeaderSeverity); got != "" {
+		t.Errorf("HeaderSeverity should be empty, got %q", got)
+	}
+	if got := h.Get(HeaderRetry); got != "" {
+		t.Errorf("HeaderRetry should be empty, got %q", got)
+	}
+}
+
+func TestSetHeaders_EmptyReasonEmitsOnlyVersion(t *testing.T) {
+	t.Parallel()
+	// A zero-Info is a programming error at the call site. We still emit
+	// the version header so consumers can detect the schema; the reason
+	// header is omitted to preserve the invariant that an emitted reason
+	// code is always one we documented.
+	h := make(http.Header)
+	Info{}.SetHeaders(h)
+
+	if got := h.Get(HeaderReason); got != "" {
+		t.Errorf("HeaderReason should be empty for zero-Info, got %q", got)
+	}
+	if got := h.Get(HeaderVersion); got != "1" {
+		t.Errorf("HeaderVersion = %q, want 1", got)
+	}
+}
+
+func TestCloseFramePayload_FullShape(t *testing.T) {
+	t.Parallel()
+	info := Info{
+		Reason:   DLPMatch,
+		Severity: SeverityCritical,
+		Retry:    RetryNone,
+		Layer:    "dlp",
+		Receipt:  "rcpt1",
+	}
+	got := info.CloseFramePayload()
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Fatalf("payload not valid JSON: %v (%q)", err, got)
+	}
+
+	want := map[string]string{
+		"block_reason": "dlp_match",
+		"version":      "1",
+		"severity":     "critical",
+		"retry":        "none",
+		"layer":        "dlp",
+		"receipt":      "rcpt1",
+	}
+	for k, v := range want {
+		if parsed[k] != v {
+			t.Errorf("payload[%q] = %q, want %q", k, parsed[k], v)
+		}
+	}
+}
+
+func TestCloseFramePayload_EmptyReason(t *testing.T) {
+	t.Parallel()
+	got := Info{}.CloseFramePayload()
+	if got != "{}" {
+		t.Errorf("zero-Info payload = %q, want \"{}\"", got)
+	}
+}
+
+func TestCloseFramePayload_FitsRFC6455Limit(t *testing.T) {
+	t.Parallel()
+	// Construct an Info large enough to exceed 123 bytes if all fields
+	// were emitted, then verify graceful truncation drops fields in the
+	// documented order: receipt, layer, retry, severity, version.
+	big := strings.Repeat("X", 80)
+	info := Info{
+		Reason:   DLPMatch,
+		Severity: SeverityCritical,
+		Retry:    RetryNone,
+		Layer:    "dlp_layer",
+		Receipt:  big,
+	}
+	got := info.CloseFramePayload()
+	if len(got) > closeFrameMaxBytes {
+		t.Errorf("payload %d bytes exceeds RFC 6455 limit %d (%q)",
+			len(got), closeFrameMaxBytes, got)
+	}
+
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Fatalf("truncated payload not valid JSON: %v (%q)", err, got)
+	}
+	// block_reason is always present.
+	if parsed["block_reason"] != "dlp_match" {
+		t.Errorf("block_reason missing from truncated payload: %q", got)
+	}
+	// receipt is dropped first.
+	if parsed["receipt"] != "" {
+		t.Errorf("receipt should drop first, got %q", parsed["receipt"])
+	}
+}
+
+func TestCloseFramePayload_ProgressiveTruncation(t *testing.T) {
+	t.Parallel()
+	// Each field longer than the previous so each truncation step is
+	// forced. After all optional fields drop the payload should still
+	// be valid JSON containing block_reason at minimum.
+	info := Info{
+		Reason:   ToolPolicyDeny,
+		Severity: SeverityCritical,
+		Retry:    RetryPolicy,
+		Layer:    strings.Repeat("L", 50),
+		Receipt:  strings.Repeat("R", 90),
+	}
+	got := info.CloseFramePayload()
+	if len(got) > closeFrameMaxBytes {
+		t.Errorf("progressive truncation failed: %d bytes > %d (%q)",
+			len(got), closeFrameMaxBytes, got)
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Fatalf("not JSON after truncation: %v (%q)", err, got)
+	}
+	if parsed["block_reason"] != "tool_policy_deny" {
+		t.Errorf("block_reason missing after truncation: %q", got)
+	}
+}
+
+func TestReasonConstants_AllDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	// Privacy invariant: every constant we expose is a code consumers will
+	// permanently see in the wild. Renaming is a breaking change. This
+	// test snapshots the v1 vocabulary so silent renames trip CI.
+	want := map[Reason]bool{
+		// Egress / network
+		SchemeBlocked:    true,
+		DomainBlocklist:  true,
+		SSRFPrivateIP:    true,
+		SSRFMetadata:     true,
+		SSRFDNSRebind:    true,
+		PathEntropy:      true,
+		SubdomainEntropy: true,
+		URLLength:        true,
+		RateLimit:        true,
+		DataBudget:       true,
+		// Content
+		DLPMatch:         true,
+		PromptInjection:  true,
+		RedactionFailure: true,
+		MediaPolicy:      true,
+		// MCP
+		ToolPolicyDeny:   true,
+		ToolChainBlocked: true,
+		ToolPoisoning:    true,
+		SessionBinding:   true,
+		// Posture
+		AirlockActive:        true,
+		KillSwitchActive:     true,
+		EnvelopeVerifyFailed: true,
+		AuthorityMismatch:    true,
+		EscalationLevel:      true,
+		// Generic
+		ParseError:         true,
+		Timeout:            true,
+		PatternUnavailable: true,
+		NotEnabled:         true,
+		BadRequest:         true,
+	}
+	for r := range want {
+		if r == "" {
+			t.Errorf("Reason constant has empty value")
+		}
+		if got := string(r); got != strings.ToLower(got) {
+			t.Errorf("Reason %q is not snake_case lowercase", r)
+		}
+	}
+}
+
+func TestSeverityConstants_MatchExistingVocabulary(t *testing.T) {
+	t.Parallel()
+	// Severity values must match internal/config/schema.go vocabulary
+	// (info / warn / critical) so operators can correlate header-driven
+	// agent behavior with their existing emit / receipt streams.
+	cases := map[Severity]string{
+		SeverityInfo:     "info",
+		SeverityWarn:     "warn",
+		SeverityCritical: "critical",
+	}
+	for s, want := range cases {
+		if string(s) != want {
+			t.Errorf("Severity %v = %q, want %q", s, string(s), want)
+		}
+	}
+}
+
+func TestRetryConstants_v1Vocabulary(t *testing.T) {
+	t.Parallel()
+	cases := map[Retry]string{
+		RetryNone:      "none",
+		RetryTransient: "transient",
+		RetryPolicy:    "policy",
+	}
+	for r, want := range cases {
+		if string(r) != want {
+			t.Errorf("Retry %v = %q, want %q", r, string(r), want)
+		}
+	}
+}
+
+func TestCloseFramePayload_OvergrownReasonStillReturnsJSON(t *testing.T) {
+	t.Parallel()
+	// Defensive: if a future Reason value were ever long enough that even
+	// the bare {"block_reason":"..."} document exceeded the RFC 6455
+	// limit, CloseFramePayload must still return a parseable JSON string.
+	// No real v1 Reason approaches this length; we synthesize one to pin
+	// the fall-through behavior.
+	giant := Reason(strings.Repeat("X", 200))
+	got := Info{Reason: giant}.CloseFramePayload()
+
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Fatalf("overgrown payload not valid JSON: %v (%q)", err, got)
+	}
+	if parsed["block_reason"] == "" {
+		t.Errorf("block_reason missing from overgrown payload: %q", got)
+	}
+}
+
+func TestCloseFramePayload_NoOptionalFieldsRequired(t *testing.T) {
+	t.Parallel()
+	// A minimal Info — reason only — must produce a valid payload that
+	// fits trivially within the limit.
+	info := Info{Reason: KillSwitchActive}
+	got := info.CloseFramePayload()
+	if len(got) > closeFrameMaxBytes {
+		t.Errorf("minimal payload %d bytes exceeds limit %d", len(got), closeFrameMaxBytes)
+	}
+	if !strings.Contains(got, `"block_reason":"kill_switch_active"`) {
+		t.Errorf("payload missing kill_switch_active: %q", got)
+	}
+}
+
+func TestMustMarshal_FixedShapeNeverReturnsEmptyString(t *testing.T) {
+	t.Parallel()
+	// The closeFramePayload struct has only string fields. json.Marshal
+	// cannot fail on it. mustMarshal's error sentinel is defensive and
+	// not reachable through the public API; this test pins the contract
+	// so any future schema change that introduces a non-string field
+	// (which CAN fail to marshal) trips review.
+	got := mustMarshal(closeFramePayload{
+		BlockReason: "dlp_match",
+		Version:     "1",
+	})
+	if got == "" {
+		t.Errorf("mustMarshal returned empty for valid input")
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Fatalf("mustMarshal output not valid JSON: %v (%q)", err, got)
+	}
+	if parsed["block_reason"] != "dlp_match" {
+		t.Errorf("block_reason round-trip failed: got %q", parsed["block_reason"])
+	}
+}
+
+func TestSetHeaders_DoesNotLeakSecretContent(t *testing.T) {
+	t.Parallel()
+	// Privacy invariant: the helper has no path that takes secret content
+	// or pattern names. The Info struct deliberately exposes only
+	// {Reason, Severity, Retry, Layer, Receipt}. This test pins that
+	// shape so a future field addition trips review.
+	info := Info{
+		Reason:   DLPMatch,
+		Severity: SeverityCritical,
+		Retry:    RetryNone,
+	}
+	h := make(http.Header)
+	info.SetHeaders(h)
+
+	for k, vs := range h {
+		for _, v := range vs {
+			if strings.Contains(strings.ToLower(v), "akia") ||
+				strings.Contains(strings.ToLower(v), "sk-") ||
+				strings.Contains(strings.ToLower(v), "ghp_") {
+				t.Errorf("header %s = %q looks like a secret leak", k, v)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Defines the v1 vocabulary for `X-Pipelock-Block-Reason`, the response header set agents read to decide whether to retry, switch tools, or surface a useful error to the user. Lands the schema doc and the emit package now so the vocabulary can be reviewed before any block site commits to it. The transport refactor that wires every block path to call `Info.SetHeaders` follows in a separate PR.

The header set:

- `X-Pipelock-Block-Reason` (required): machine-readable code. 28 codes across egress, content, MCP, posture, and generic.
- `X-Pipelock-Block-Reason-Version` (required): schema version.
- `X-Pipelock-Block-Reason-Severity` (required): matches the existing `internal/config/schema.go` vocabulary (`info`, `warn`, `critical`).
- `X-Pipelock-Block-Reason-Retry` (required): retry hint (`none`, `transient`, `policy`).
- `X-Pipelock-Block-Reason-Layer` (optional): reuses `internal/scanner/` `Scanner*` constants verbatim so operators can correlate header-driven agent behavior with existing audit logs and Prometheus labels.
- `X-Pipelock-Block-Reason-Receipt` (optional): receipt UUID.

## Why design first

Once an agent in production reads `dlp_match`, the vocabulary is locked. Renaming a code in v2 breaks every consumer. Splitting the schema and the transport refactor into separate PRs gives reviewers a chance to challenge the vocabulary before any of the roughly 50 block sites commits to it.

## Privacy

The `Info` struct deliberately exposes only `Reason`, `Severity`, `Retry`, `Layer`, and `Receipt`. None of those fields can carry matched content, pattern names, or agent identifiers. Tests pin the surface so a future field addition trips review.

## RFC 6455 floor

`CloseFramePayload()` is bounded to RFC 6455's 123-byte close-frame limit. Optional fields drop in a documented order (receipt, layer, retry, severity, version). If even the bare `{"block_reason":"<code>"}` would overflow because the Reason value is unusually long, the helper returns a fixed sentinel rather than a malformed close frame. Test invariant pins the size ceiling across normal, truncated, overlong-reason, and floor cases.

## Anti-scope-creep

- No call sites yet. The spec status block at the top of the doc says so explicitly. Transport PR follows.
- No JSON-RPC error vocabulary for MCP stdio. Tracked separately; stdio has no HTTP layer to attach headers to.
- No agent-side retry orchestration. Pipelock emits, the agent decides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added block reason metadata for HTTP responses and WebSocket connections, providing detailed information about blocked requests including reason, severity, and retry guidance.

* **Documentation**
  * Added specification for `X-Pipelock-Block-Reason` header format and WebSocket close-frame behavior.

* **Tests**
  * Added comprehensive test coverage for block reason functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->