### PR TITLE
chore: SPIFFE IP rejection, blockreason pairing helpers, tombstone scope, conformance fixtures

### DIFF
--- a/internal/blockreason/blockreason.go
+++ b/internal/blockreason/blockreason.go
@@ -433,7 +433,10 @@ func SeverityFor(reason Reason) Severity {
 		MediaPolicy,
 		ParseError,
 		Timeout,
-		PatternUnavailable:
+		PatternUnavailable,
+		CompressedResponse,
+		BrowserShieldOversize,
+		BlockReasonOverflow:
 		return SeverityWarn
 	default:
 		return SeverityCritical
@@ -453,7 +456,10 @@ func RetryFor(reason Reason) Retry {
 		EscalationLevel,
 		RedactionFailure,
 		Timeout,
-		PatternUnavailable:
+		PatternUnavailable,
+		OutboundEnvelopeFailed,
+		SessionAnomaly,
+		BlockReasonOverflow:
 		return RetryTransient
 	case DomainBlocklist,
 		PathEntropy,
@@ -464,7 +470,9 @@ func RetryFor(reason Reason) Retry {
 		ToolPolicyDeny,
 		SessionBinding,
 		AuthorityMismatch,
-		NotEnabled:
+		NotEnabled,
+		CompressedResponse,
+		BrowserShieldOversize:
 		return RetryPolicy
 	default:
 		return RetryNone

--- a/internal/blockreason/blockreason.go
+++ b/internal/blockreason/blockreason.go
@@ -413,3 +413,85 @@ func mustMarshal(p closeFramePayload) string {
 	}
 	return string(b)
 }
+
+// SeverityFor returns the canonical severity for a block-reason code per
+// docs/specs/block-reason-header.md. The mapping is locked at v1; new
+// reasons must add a case here at the same time the constant is added.
+// Unknown reasons return SeverityCritical so a missing-mapping bug
+// fails closed (the reason is real enough to constructor-validate, but
+// the operator gets the strictest severity until the table is updated).
+func SeverityFor(reason Reason) Severity {
+	switch reason {
+	case NotEnabled, BadRequest:
+		return SeverityInfo
+	case SchemeBlocked,
+		PathEntropy,
+		SubdomainEntropy,
+		URLLength,
+		RateLimit,
+		DataBudget,
+		MediaPolicy,
+		ParseError,
+		Timeout,
+		PatternUnavailable:
+		return SeverityWarn
+	default:
+		return SeverityCritical
+	}
+}
+
+// RetryFor returns the canonical retry hint for a block-reason code per
+// docs/specs/block-reason-header.md. As with SeverityFor, the mapping is
+// locked at v1 and unknown reasons fail closed: an unrecognised reason
+// returns RetryNone so the agent does not retry blindly.
+func RetryFor(reason Reason) Retry {
+	switch reason {
+	case SSRFDNSRebind,
+		RateLimit,
+		AirlockActive,
+		KillSwitchActive,
+		EscalationLevel,
+		RedactionFailure,
+		Timeout,
+		PatternUnavailable:
+		return RetryTransient
+	case DomainBlocklist,
+		PathEntropy,
+		SubdomainEntropy,
+		URLLength,
+		DataBudget,
+		MediaPolicy,
+		ToolPolicyDeny,
+		SessionBinding,
+		AuthorityMismatch,
+		NotEnabled:
+		return RetryPolicy
+	default:
+		return RetryNone
+	}
+}
+
+// NewForReason is the recommended constructor for production block paths.
+// It looks up the canonical severity + retry pair from the v1 spec
+// (SeverityFor / RetryFor) so call sites cannot accidentally emit a
+// mismatched pair such as `dlp_match` + `info` + `policy`. Equivalent to
+// New(reason, SeverityFor(reason), RetryFor(reason)).
+//
+// The lower-level New constructor remains available for tests and edge
+// cases that legitimately need to assemble an Info with a non-canonical
+// pair (e.g. the redteam suite proving the validators reject every axis).
+// Production callers should default to NewForReason.
+func NewForReason(reason Reason) (Info, error) {
+	return New(reason, SeverityFor(reason), RetryFor(reason))
+}
+
+// MustNewForReason is NewForReason that panics on construction error.
+// Use only at startup or in test setup; production paths should use
+// NewForReason and route an error to a parse_error fallback.
+func MustNewForReason(reason Reason) Info {
+	info, err := NewForReason(reason)
+	if err != nil {
+		panic(err)
+	}
+	return info
+}

--- a/internal/blockreason/blockreason_test.go
+++ b/internal/blockreason/blockreason_test.go
@@ -441,32 +441,88 @@ func TestMustMarshal_FixedShapeProducesValidJSON(t *testing.T) {
 	}
 }
 
+// specCanonicalPairs is the ground truth from docs/specs/block-reason-header.md.
+// Every Reason in validReasons MUST appear here with its spec-canonical
+// (Severity, Retry) pair. The vocabulary-coverage test below enforces that
+// adding a Reason without updating this table is a build break, so the spec
+// table and the helper functions cannot drift apart in either direction.
+var specCanonicalPairs = map[Reason]struct {
+	severity Severity
+	retry    Retry
+}{
+	// Egress / network layer.
+	SchemeBlocked:    {SeverityWarn, RetryNone},
+	DomainBlocklist:  {SeverityCritical, RetryPolicy},
+	SSRFPrivateIP:    {SeverityCritical, RetryNone},
+	SSRFMetadata:     {SeverityCritical, RetryNone},
+	SSRFDNSRebind:    {SeverityCritical, RetryTransient},
+	PathEntropy:      {SeverityWarn, RetryPolicy},
+	SubdomainEntropy: {SeverityWarn, RetryPolicy},
+	URLLength:        {SeverityWarn, RetryPolicy},
+	RateLimit:        {SeverityWarn, RetryTransient},
+	DataBudget:       {SeverityWarn, RetryPolicy},
+
+	// Content / payload layer.
+	DLPMatch:         {SeverityCritical, RetryNone},
+	PromptInjection:  {SeverityCritical, RetryNone},
+	RedactionFailure: {SeverityCritical, RetryTransient},
+	MediaPolicy:      {SeverityWarn, RetryPolicy},
+
+	// MCP / tool layer.
+	ToolPolicyDeny:   {SeverityCritical, RetryPolicy},
+	ToolChainBlocked: {SeverityCritical, RetryNone},
+	ToolPoisoning:    {SeverityCritical, RetryNone},
+	SessionBinding:   {SeverityCritical, RetryPolicy},
+
+	// Posture / runtime layer.
+	AirlockActive:          {SeverityCritical, RetryTransient},
+	KillSwitchActive:       {SeverityCritical, RetryTransient},
+	EnvelopeVerifyFailed:   {SeverityCritical, RetryNone},
+	OutboundEnvelopeFailed: {SeverityCritical, RetryTransient},
+	RedirectScanDenied:     {SeverityCritical, RetryNone},
+	AuthorityMismatch:      {SeverityCritical, RetryPolicy},
+	EscalationLevel:        {SeverityCritical, RetryTransient},
+	SessionAnomaly:         {SeverityCritical, RetryTransient},
+	CrossRequestDeny:       {SeverityCritical, RetryNone},
+	CompressedResponse:     {SeverityWarn, RetryPolicy},
+	BrowserShieldOversize:  {SeverityWarn, RetryPolicy},
+
+	// Generic.
+	ParseError:         {SeverityWarn, RetryNone},
+	Timeout:            {SeverityWarn, RetryTransient},
+	PatternUnavailable: {SeverityWarn, RetryTransient},
+	NotEnabled:         {SeverityInfo, RetryPolicy},
+	BadRequest:         {SeverityInfo, RetryNone},
+
+	// Internal sentinel.
+	BlockReasonOverflow: {SeverityWarn, RetryTransient},
+}
+
+// TestSpecCanonicalPairs_VocabularyCoverage asserts the test ground-truth
+// table is exhaustive: every Reason in validReasons has an entry, and the
+// table has no entries that are not in validReasons. This guarantees adding
+// a new Reason cannot silently bypass the spec-conformance test below.
+func TestSpecCanonicalPairs_VocabularyCoverage(t *testing.T) {
+	t.Parallel()
+	for reason := range validReasons {
+		if _, ok := specCanonicalPairs[reason]; !ok {
+			t.Errorf("Reason %q is in validReasons but missing from specCanonicalPairs (update docs/specs/block-reason-header.md and the test table together)", reason)
+		}
+	}
+	for reason := range specCanonicalPairs {
+		if _, ok := validReasons[reason]; !ok {
+			t.Errorf("Reason %q is in specCanonicalPairs but not in validReasons (stale test entry?)", reason)
+		}
+	}
+}
+
 func TestSeverityFor_AllVocabulary(t *testing.T) {
 	t.Parallel()
-	cases := map[Reason]Severity{
-		// info: malformed client request, feature gate.
-		NotEnabled: SeverityInfo, BadRequest: SeverityInfo,
-		// warn: scanner ceilings, parser fails, transient unavailability.
-		SchemeBlocked: SeverityWarn, PathEntropy: SeverityWarn,
-		SubdomainEntropy: SeverityWarn, URLLength: SeverityWarn,
-		RateLimit: SeverityWarn, DataBudget: SeverityWarn,
-		MediaPolicy: SeverityWarn, ParseError: SeverityWarn,
-		Timeout: SeverityWarn, PatternUnavailable: SeverityWarn,
-		// critical: real security events.
-		DomainBlocklist: SeverityCritical, SSRFPrivateIP: SeverityCritical,
-		SSRFMetadata: SeverityCritical, SSRFDNSRebind: SeverityCritical,
-		DLPMatch: SeverityCritical, PromptInjection: SeverityCritical,
-		RedactionFailure: SeverityCritical, ToolPolicyDeny: SeverityCritical,
-		ToolChainBlocked: SeverityCritical, ToolPoisoning: SeverityCritical,
-		SessionBinding: SeverityCritical, AirlockActive: SeverityCritical,
-		KillSwitchActive: SeverityCritical, EnvelopeVerifyFailed: SeverityCritical,
-		AuthorityMismatch: SeverityCritical, EscalationLevel: SeverityCritical,
-	}
-	for reason, want := range cases {
+	for reason, want := range specCanonicalPairs {
 		t.Run(string(reason), func(t *testing.T) {
 			got := SeverityFor(reason)
-			if got != want {
-				t.Fatalf("SeverityFor(%q) = %q, want %q", reason, got, want)
+			if got != want.severity {
+				t.Fatalf("SeverityFor(%q) = %q, want %q (spec)", reason, got, want.severity)
 			}
 		})
 	}
@@ -478,30 +534,11 @@ func TestSeverityFor_AllVocabulary(t *testing.T) {
 
 func TestRetryFor_AllVocabulary(t *testing.T) {
 	t.Parallel()
-	cases := map[Reason]Retry{
-		// transient: time-bound conditions.
-		SSRFDNSRebind: RetryTransient, RateLimit: RetryTransient,
-		AirlockActive: RetryTransient, KillSwitchActive: RetryTransient,
-		EscalationLevel: RetryTransient, RedactionFailure: RetryTransient,
-		Timeout: RetryTransient, PatternUnavailable: RetryTransient,
-		// policy: only retry after operator changes pipelock policy.
-		DomainBlocklist: RetryPolicy, PathEntropy: RetryPolicy,
-		SubdomainEntropy: RetryPolicy, URLLength: RetryPolicy,
-		DataBudget: RetryPolicy, MediaPolicy: RetryPolicy,
-		ToolPolicyDeny: RetryPolicy, SessionBinding: RetryPolicy,
-		AuthorityMismatch: RetryPolicy, NotEnabled: RetryPolicy,
-		// none: permanent for the request as-is.
-		SchemeBlocked: RetryNone, SSRFPrivateIP: RetryNone,
-		SSRFMetadata: RetryNone, DLPMatch: RetryNone,
-		PromptInjection: RetryNone, ToolChainBlocked: RetryNone,
-		ToolPoisoning: RetryNone, EnvelopeVerifyFailed: RetryNone,
-		ParseError: RetryNone, BadRequest: RetryNone,
-	}
-	for reason, want := range cases {
+	for reason, want := range specCanonicalPairs {
 		t.Run(string(reason), func(t *testing.T) {
 			got := RetryFor(reason)
-			if got != want {
-				t.Fatalf("RetryFor(%q) = %q, want %q", reason, got, want)
+			if got != want.retry {
+				t.Fatalf("RetryFor(%q) = %q, want %q (spec)", reason, got, want.retry)
 			}
 		})
 	}

--- a/internal/blockreason/blockreason_test.go
+++ b/internal/blockreason/blockreason_test.go
@@ -440,3 +440,121 @@ func TestMustMarshal_FixedShapeProducesValidJSON(t *testing.T) {
 		t.Errorf("block_reason round-trip failed: got %q", parsed["block_reason"])
 	}
 }
+
+func TestSeverityFor_AllVocabulary(t *testing.T) {
+	t.Parallel()
+	cases := map[Reason]Severity{
+		// info: malformed client request, feature gate.
+		NotEnabled: SeverityInfo, BadRequest: SeverityInfo,
+		// warn: scanner ceilings, parser fails, transient unavailability.
+		SchemeBlocked: SeverityWarn, PathEntropy: SeverityWarn,
+		SubdomainEntropy: SeverityWarn, URLLength: SeverityWarn,
+		RateLimit: SeverityWarn, DataBudget: SeverityWarn,
+		MediaPolicy: SeverityWarn, ParseError: SeverityWarn,
+		Timeout: SeverityWarn, PatternUnavailable: SeverityWarn,
+		// critical: real security events.
+		DomainBlocklist: SeverityCritical, SSRFPrivateIP: SeverityCritical,
+		SSRFMetadata: SeverityCritical, SSRFDNSRebind: SeverityCritical,
+		DLPMatch: SeverityCritical, PromptInjection: SeverityCritical,
+		RedactionFailure: SeverityCritical, ToolPolicyDeny: SeverityCritical,
+		ToolChainBlocked: SeverityCritical, ToolPoisoning: SeverityCritical,
+		SessionBinding: SeverityCritical, AirlockActive: SeverityCritical,
+		KillSwitchActive: SeverityCritical, EnvelopeVerifyFailed: SeverityCritical,
+		AuthorityMismatch: SeverityCritical, EscalationLevel: SeverityCritical,
+	}
+	for reason, want := range cases {
+		t.Run(string(reason), func(t *testing.T) {
+			got := SeverityFor(reason)
+			if got != want {
+				t.Fatalf("SeverityFor(%q) = %q, want %q", reason, got, want)
+			}
+		})
+	}
+	// Unknown reason fails closed to critical.
+	if got := SeverityFor(Reason("not_a_real_reason")); got != SeverityCritical {
+		t.Fatalf("SeverityFor unknown = %q, want SeverityCritical (fail-closed)", got)
+	}
+}
+
+func TestRetryFor_AllVocabulary(t *testing.T) {
+	t.Parallel()
+	cases := map[Reason]Retry{
+		// transient: time-bound conditions.
+		SSRFDNSRebind: RetryTransient, RateLimit: RetryTransient,
+		AirlockActive: RetryTransient, KillSwitchActive: RetryTransient,
+		EscalationLevel: RetryTransient, RedactionFailure: RetryTransient,
+		Timeout: RetryTransient, PatternUnavailable: RetryTransient,
+		// policy: only retry after operator changes pipelock policy.
+		DomainBlocklist: RetryPolicy, PathEntropy: RetryPolicy,
+		SubdomainEntropy: RetryPolicy, URLLength: RetryPolicy,
+		DataBudget: RetryPolicy, MediaPolicy: RetryPolicy,
+		ToolPolicyDeny: RetryPolicy, SessionBinding: RetryPolicy,
+		AuthorityMismatch: RetryPolicy, NotEnabled: RetryPolicy,
+		// none: permanent for the request as-is.
+		SchemeBlocked: RetryNone, SSRFPrivateIP: RetryNone,
+		SSRFMetadata: RetryNone, DLPMatch: RetryNone,
+		PromptInjection: RetryNone, ToolChainBlocked: RetryNone,
+		ToolPoisoning: RetryNone, EnvelopeVerifyFailed: RetryNone,
+		ParseError: RetryNone, BadRequest: RetryNone,
+	}
+	for reason, want := range cases {
+		t.Run(string(reason), func(t *testing.T) {
+			got := RetryFor(reason)
+			if got != want {
+				t.Fatalf("RetryFor(%q) = %q, want %q", reason, got, want)
+			}
+		})
+	}
+	// Unknown reason fails closed to none.
+	if got := RetryFor(Reason("not_a_real_reason")); got != RetryNone {
+		t.Fatalf("RetryFor unknown = %q, want RetryNone (fail-closed)", got)
+	}
+}
+
+func TestNewForReason_BuildsValidInfoForEveryReason(t *testing.T) {
+	t.Parallel()
+	for reason := range validReasons {
+		t.Run(string(reason), func(t *testing.T) {
+			info, err := NewForReason(reason)
+			if err != nil {
+				t.Fatalf("NewForReason(%q): %v", reason, err)
+			}
+			if info.Reason != reason {
+				t.Fatalf("info.Reason = %q, want %q", info.Reason, reason)
+			}
+			if info.Severity != SeverityFor(reason) {
+				t.Fatalf("info.Severity = %q, want SeverityFor(%q) = %q",
+					info.Severity, reason, SeverityFor(reason))
+			}
+			if info.Retry != RetryFor(reason) {
+				t.Fatalf("info.Retry = %q, want RetryFor(%q) = %q",
+					info.Retry, reason, RetryFor(reason))
+			}
+		})
+	}
+}
+
+func TestNewForReason_InvalidReasonRejects(t *testing.T) {
+	t.Parallel()
+	if _, err := NewForReason(Reason("not_a_real_reason")); err == nil {
+		t.Fatal("NewForReason on unknown reason expected error, got nil")
+	}
+}
+
+func TestMustNewForReason_PanicsOnInvalid(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("MustNewForReason on unknown reason expected panic, got nil")
+		}
+	}()
+	_ = MustNewForReason(Reason("not_a_real_reason"))
+}
+
+func TestMustNewForReason_HappyPath(t *testing.T) {
+	t.Parallel()
+	info := MustNewForReason(DLPMatch)
+	if info.Reason != DLPMatch {
+		t.Fatalf("info.Reason = %q, want %q", info.Reason, DLPMatch)
+	}
+}

--- a/internal/contract/receipt/golden_vectors_test.go
+++ b/internal/contract/receipt/golden_vectors_test.go
@@ -73,3 +73,132 @@ func TestGolden_EvidenceReceiptProxyDecision(t *testing.T) {
 		t.Errorf("drift in evidence_receipt golden\n--- expected\n%s\n--- got\n%s", got, body)
 	}
 }
+
+// TestGolden_EvidenceReceiptPromoteCommitted is the cross-implementation
+// fixture for a `contract_promote_committed` v2 envelope. Covered by
+// pipelock-verify-python's tests/test_v2_conformance.py to prove
+// byte-for-byte JCS preimage parity for a contract-lifecycle payload
+// kind, complementing the existing proxy_decision fixture.
+func TestGolden_EvidenceReceiptPromoteCommitted(t *testing.T) {
+	t.Parallel()
+	seed, err := hex.DecodeString(receiptTestPrivateSeedHex)
+	if err != nil {
+		t.Fatalf("decode seed: %v", err)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+
+	payload := json.RawMessage(`{` +
+		`"target_manifest_hash":"sha256:tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt",` +
+		`"prior_manifest_hash":"sha256:pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",` +
+		`"intent_id":"01F8MECHZX3TBDSZ7XRADM79XW",` +
+		`"validation_outcome":"accepted"` +
+		`}`)
+	r := EvidenceReceipt{
+		RecordType:     RecordTypeEvidenceV2,
+		ReceiptVersion: 2,
+		PayloadKind:    PayloadContractPromoteCommitted,
+		EventID:        "01F8MECHZX3TBDSZ7XRADM79XX",
+		Timestamp:      time.Date(2026, 4, 25, 22, 0, 0, 0, time.UTC),
+		ChainSeq:       1,
+		ChainPrevHash:  "sha256:0",
+		Payload:        payload,
+	}
+	preimage, err := r.SignablePreimage()
+	if err != nil {
+		t.Fatalf("preimage: %v", err)
+	}
+	r.Signature = SignatureProof{
+		SignerKeyID: "receipt-signing-test",
+		KeyPurpose:  "receipt-signing",
+		Algorithm:   "ed25519",
+		Signature:   "ed25519:" + hex.EncodeToString(ed25519.Sign(priv, preimage)),
+	}
+	body, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal receipt: %v", err)
+	}
+	body = append(body, '\n')
+
+	const goldenPath = "../testdata/golden/valid_evidence_receipt_promote_committed.json"
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		if err := os.WriteFile(filepath.Clean(goldenPath), body, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		return
+	}
+	got, err := os.ReadFile(filepath.Clean(goldenPath))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("drift in promote_committed golden\n--- expected\n%s\n--- got\n%s", got, body)
+	}
+}
+
+// TestGolden_EvidenceReceiptShadowDelta is the cross-implementation
+// fixture for a `shadow_delta` v2 envelope. Shadow-delta is the
+// load-bearing payload kind for the LL soak window: every shadow run
+// against a candidate contract emits one of these per (rule_id, window)
+// bucket. Cross-impl parity here is essential for external auditors
+// verifying the soak evidence.
+func TestGolden_EvidenceReceiptShadowDelta(t *testing.T) {
+	t.Parallel()
+	seed, err := hex.DecodeString(receiptTestPrivateSeedHex)
+	if err != nil {
+		t.Fatalf("decode seed: %v", err)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+
+	payload := json.RawMessage(`{` +
+		`"contract_hash":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",` +
+		`"rule_id":"r-deadbeef0000-aaaa00",` +
+		`"original_verdict":"allow",` +
+		`"candidate_verdict":"block",` +
+		`"aggregation":{` +
+		`"window_start":"2026-04-25T20:00:00Z",` +
+		`"window_end":"2026-04-25T21:00:00Z",` +
+		`"lossless_count":42,` +
+		`"delta_sample_count":7,` +
+		`"exemplar_ids":["01F8MECHZX3TBDSZ7XRADM79YA","01F8MECHZX3TBDSZ7XRADM79YB"]` +
+		`}}`)
+	r := EvidenceReceipt{
+		RecordType:     RecordTypeEvidenceV2,
+		ReceiptVersion: 2,
+		PayloadKind:    PayloadShadowDelta,
+		EventID:        "01F8MECHZX3TBDSZ7XRADM79YC",
+		Timestamp:      time.Date(2026, 4, 25, 22, 0, 0, 0, time.UTC),
+		ChainSeq:       1,
+		ChainPrevHash:  "sha256:0",
+		Payload:        payload,
+	}
+	preimage, err := r.SignablePreimage()
+	if err != nil {
+		t.Fatalf("preimage: %v", err)
+	}
+	r.Signature = SignatureProof{
+		SignerKeyID: "receipt-signing-test",
+		KeyPurpose:  "receipt-signing",
+		Algorithm:   "ed25519",
+		Signature:   "ed25519:" + hex.EncodeToString(ed25519.Sign(priv, preimage)),
+	}
+	body, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal receipt: %v", err)
+	}
+	body = append(body, '\n')
+
+	const goldenPath = "../testdata/golden/valid_evidence_receipt_shadow_delta.json"
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		if err := os.WriteFile(filepath.Clean(goldenPath), body, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		return
+	}
+	got, err := os.ReadFile(filepath.Clean(goldenPath))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("drift in shadow_delta golden\n--- expected\n%s\n--- got\n%s", got, body)
+	}
+}

--- a/internal/contract/testdata/golden/valid_evidence_receipt_promote_committed.json
+++ b/internal/contract/testdata/golden/valid_evidence_receipt_promote_committed.json
@@ -1,0 +1,21 @@
+{
+  "record_type": "evidence_receipt_v2",
+  "receipt_version": 2,
+  "payload_kind": "contract_promote_committed",
+  "event_id": "01F8MECHZX3TBDSZ7XRADM79XX",
+  "timestamp": "2026-04-25T22:00:00Z",
+  "signature": {
+    "signer_key_id": "receipt-signing-test",
+    "key_purpose": "receipt-signing",
+    "algorithm": "ed25519",
+    "signature": "ed25519:9d9e7b554fe9176cd05730caab3dd9f5dac0b88821f44ab5e16855cc1f3a178c7d21987db28deb876af65048eef8e74488000125c6604deb6b245c8c44780f0a"
+  },
+  "chain_seq": 1,
+  "chain_prev_hash": "sha256:0",
+  "payload": {
+    "target_manifest_hash": "sha256:tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt",
+    "prior_manifest_hash": "sha256:pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+    "intent_id": "01F8MECHZX3TBDSZ7XRADM79XW",
+    "validation_outcome": "accepted"
+  }
+}

--- a/internal/contract/testdata/golden/valid_evidence_receipt_shadow_delta.json
+++ b/internal/contract/testdata/golden/valid_evidence_receipt_shadow_delta.json
@@ -1,0 +1,31 @@
+{
+  "record_type": "evidence_receipt_v2",
+  "receipt_version": 2,
+  "payload_kind": "shadow_delta",
+  "event_id": "01F8MECHZX3TBDSZ7XRADM79YC",
+  "timestamp": "2026-04-25T22:00:00Z",
+  "signature": {
+    "signer_key_id": "receipt-signing-test",
+    "key_purpose": "receipt-signing",
+    "algorithm": "ed25519",
+    "signature": "ed25519:bc5722516ff6370565f961a70d4b4616a346e3739f563bd0a67b50e6cbba0b29db9be7ccafbc6805b2f2b4aee286133e373ac5e3dbe942d691b22d4968d7890a"
+  },
+  "chain_seq": 1,
+  "chain_prev_hash": "sha256:0",
+  "payload": {
+    "contract_hash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "rule_id": "r-deadbeef0000-aaaa00",
+    "original_verdict": "allow",
+    "candidate_verdict": "block",
+    "aggregation": {
+      "window_start": "2026-04-25T20:00:00Z",
+      "window_end": "2026-04-25T21:00:00Z",
+      "lossless_count": 42,
+      "delta_sample_count": 7,
+      "exemplar_ids": [
+        "01F8MECHZX3TBDSZ7XRADM79YA",
+        "01F8MECHZX3TBDSZ7XRADM79YB"
+      ]
+    }
+  }
+}

--- a/internal/contract/tombstone.go
+++ b/internal/contract/tombstone.go
@@ -28,7 +28,19 @@ const keyPurposeTombstone = "contract-activation-signing"
 const dataClassRootTombstoneDefault = "internal"
 
 // Tombstone is the typed signable body of a contract tombstone record.
-// A tombstone marks a prior contract as redacted and prevents its reactivation.
+//
+// In v2.4 a tombstone is a signed evidence marker that a prior contract
+// hash was withdrawn. It is NOT enforced at activation time: the active
+// contract store does not cross-check tombstones during
+// ValidateEnvelope, so a prior contract hash CAN be re-promoted under
+// v2.4 semantics. The tombstone exists so external auditors can prove
+// the operator declared the prior contract redacted; activation
+// enforcement is a v2.5 follow-up tracked under v2.4 known gaps in the
+// release spec.
+//
+// Operators who need enforcement today must not re-promote a hash they
+// have already tombstoned. Future versions will add a hard cross-check
+// in the activation pipeline.
 type Tombstone struct {
 	SchemaVersion            int    `json:"schema_version"`
 	Tombstone                bool   `json:"tombstone"`

--- a/internal/envelope/spiffe.go
+++ b/internal/envelope/spiffe.go
@@ -5,6 +5,7 @@ package envelope
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"path"
 	"strings"
@@ -57,6 +58,12 @@ func ParseActor(raw string) (ParsedActor, error) {
 	if u.Port() != "" {
 		return ParsedActor{}, fmt.Errorf("SPIFFE actor trust domain must not include a port")
 	}
+	// u.Host normalises IPv6 hosts to bracketed form ("[2001:db8::1]");
+	// u.Hostname() strips the brackets so net.ParseIP can recognise the
+	// literal. Reject either form.
+	if net.ParseIP(u.Hostname()) != nil {
+		return ParsedActor{}, fmt.Errorf("SPIFFE actor trust domain must be a DNS name, not an IP address")
+	}
 	if u.Path == "" || u.Path == "/" {
 		return ParsedActor{}, fmt.Errorf("SPIFFE actor workload path must not be empty")
 	}
@@ -96,9 +103,11 @@ func isCanonicalSPIFFEPath(p string) bool {
 
 // IsValidTrustDomain reports whether s is a syntactically valid SPIFFE
 // trust domain — a non-empty DNS-shaped label with no scheme, slashes,
-// userinfo, or port. Used by both spiffe.go (when parsing actor URIs)
-// and config validation (when checking the operator-supplied
-// trust_domain field).
+// userinfo, or port. Per SPIFFE-ID §2 the trust domain MUST be a DNS
+// name; raw IP addresses (IPv4 or IPv6) are explicitly forbidden so a
+// partner cannot impersonate a domain by claiming a numeric host. Used
+// by both spiffe.go (when parsing actor URIs) and config validation
+// (when checking the operator-supplied trust_domain field).
 func IsValidTrustDomain(s string) bool {
 	if s == "" {
 		return false
@@ -116,7 +125,14 @@ func IsValidTrustDomain(s string) bool {
 	if u.Host == "" || u.User != nil || u.Port() != "" {
 		return false
 	}
-	return strings.EqualFold(u.Host, s)
+	if !strings.EqualFold(u.Host, s) {
+		return false
+	}
+	// SPIFFE-ID §2 forbids IP-address trust domains.
+	if net.ParseIP(s) != nil {
+		return false
+	}
+	return true
 }
 
 // FormatActor returns the wire actor for a newly emitted envelope.

--- a/internal/envelope/verify_test.go
+++ b/internal/envelope/verify_test.go
@@ -253,6 +253,11 @@ func TestParseActor_StrictSPIFFE(t *testing.T) {
 		{"empty segment", "spiffe://trust.example/agent//x"},
 		{"dot segment", "spiffe://trust.example/./agent/x"},
 		{"trailing slash", "spiffe://trust.example/agent/x/"},
+		// SPIFFE-ID §2 prohibits IP-address trust domains. A partner
+		// claiming a numeric host could otherwise impersonate any
+		// allowlist that compares trust domains as opaque strings.
+		{"ipv4 trust domain", "spiffe://192.0.2.1/agent/x"},
+		{"ipv6 trust domain", "spiffe://[2001:db8::1]/agent/x"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -271,7 +276,12 @@ func TestIsValidTrustDomain(t *testing.T) {
 			t.Errorf("IsValidTrustDomain(%q) = false; want true", d)
 		}
 	}
-	bad := []string{"", "trust.example/agent/x", "trust.example:8443", "u@trust.example", "scheme://trust", "with spaces", "trailing/"}
+	bad := []string{
+		"", "trust.example/agent/x", "trust.example:8443", "u@trust.example",
+		"scheme://trust", "with spaces", "trailing/",
+		// SPIFFE-ID §2 forbids IP-address trust domains.
+		"192.0.2.1", "10.0.0.1", "::1", "2001:db8::1",
+	}
 	for _, d := range bad {
 		if IsValidTrustDomain(d) {
 			t.Errorf("IsValidTrustDomain(%q) = true; want false", d)


### PR DESCRIPTION
## Summary

- Four targeted v2.4 pre-tag fixes from the pre-release sweep.
- `internal/envelope/spiffe.go` rejects IPv4/IPv6 literals as SPIFFE trust domains. SPIFFE-ID section 2 prohibits raw IP addresses; the prior implementation accepted them, which would let a federation partner impersonate a domain by claiming a numeric host.
- `internal/blockreason/blockreason.go` exports `SeverityFor(reason)`, `RetryFor(reason)`, `NewForReason(reason)`, and `MustNewForReason(reason)`. The exported pair-lookup helpers encode the canonical reason-to-severity-and-retry mapping from `docs/specs/block-reason-header.md` so production call sites can build an Info without tracking the spec table manually. Production callers should default to `NewForReason` so a future call site outside `internal/proxy` cannot accidentally emit a mismatched pair.
- `internal/contract/tombstone.go` scopes the `Tombstone` type doc comment from "prevents reactivation" to evidence-marker semantics. `Store.ValidateEnvelope` does not cross-check tombstones during activation today, so a tombstoned contract hash can be re-promoted under v2.4 semantics. The tombstone exists so external auditors can prove the operator declared the prior contract redacted; activation enforcement is a v2.5 follow-up. The previous comment overstated the guarantee.
- `internal/contract/receipt/golden_vectors_test.go` adds `TestGolden_EvidenceReceiptPromoteCommitted` and `TestGolden_EvidenceReceiptShadowDelta` with corresponding fixtures under `testdata/golden/`. The `pipelock-verify-python` 0.2.0 release uses these to prove byte-for-byte JCS preimage parity with the Go reference for the two load-bearing audit kinds beyond `proxy_decision`.

## Behaviour changes

- A federation peer that previously claimed a SPIFFE actor under an IP-literal trust domain (`spiffe://192.0.2.1/agent/foo`) is now rejected with `SPIFFE actor trust domain must be a DNS name, not an IP address`. Operators using IP literals must migrate to DNS names. No production deployment should be relying on this; SPIFFE-ID section 2 has prohibited it since the spec was published.
- The `Tombstone` doc comment correction is cosmetic. No behaviour change.
- The `blockreason` helper additions are additive. No existing call site changes; the existing `New` constructor is untouched. Future call sites get a recommended path that prevents pair-mismatch bugs.
- The new golden vectors are additive test data. No production code path consumes them.