### PR TITLE
feat(health): wedge-detection watchdog reports /health 503 on wedge

### DIFF
--- a/docs/guides/health.md
+++ b/docs/guides/health.md
@@ -1,0 +1,136 @@
+# Health Endpoint and Wedge-Detection Watchdog
+
+The `/health` endpoint reports whether pipelock's main HTTP server is responsive AND whether its internal subsystems are healthy. External supervisors — Kubernetes liveness/readiness probes, KiloClaw's controller, generic process supervisors — poll `/health` to decide when to restart pipelock or route traffic away from it.
+
+Before v2.4, `/health` returned 200 as long as the HTTP handler itself responded. A scanner deadlock, config-reload race, or dead session-manager goroutine would not surface here: the process looked healthy from outside while customer traffic failed inside. v2.4 introduces an internal wedge-detection watchdog that flips `/health` to **503 Service Unavailable** when any tracked subsystem is unhealthy.
+
+## Response Shape
+
+```http
+GET /health
+```
+
+Healthy response (HTTP 200):
+
+```json
+{
+  "status": "healthy",
+  "version": "v2.4.0",
+  "mode": "balanced",
+  "uptime_seconds": 1234.56,
+  "dlp_patterns": 78,
+  "response_scan_enabled": true,
+  "git_protection_enabled": false,
+  "rate_limit_enabled": true,
+  "forward_proxy_enabled": true,
+  "websocket_proxy_enabled": false,
+  "request_body_scan_enabled": true,
+  "tls_interception_enabled": false,
+  "kill_switch_active": false,
+  "subsystems": {
+    "scanner": true,
+    "config": true,
+    "session": true,
+    "killswitch": true,
+    "watchdog": true
+  }
+}
+```
+
+Unhealthy response (HTTP 503):
+
+```json
+{
+  "status": "unhealthy",
+  "version": "v2.4.0",
+  ...
+  "subsystems": {
+    "scanner": false,
+    "config": true,
+    "session": true,
+    "killswitch": true,
+    "watchdog": true
+  }
+}
+```
+
+The top-level fields (`version`, `mode`, `uptime_seconds`, the feature-enabled booleans, `kill_switch_active`) keep their pre-v2.4 shape so existing consumers parse cleanly. The new field is `subsystems` — a map of subsystem name to liveness boolean. When the watchdog is disabled the `subsystems` field is omitted entirely (legacy shape).
+
+`status` is `"healthy"` (HTTP 200) when every value in `subsystems` is `true`; `"unhealthy"` (HTTP 503) otherwise.
+
+## The Subsystems
+
+| Name | Healthy when | Notes |
+|------|--------------|-------|
+| `scanner` | The scanner pointer and config pointer are both non-nil AND either the scanner heartbeat is fresh or a synthetic probe completes within `interval/2` | The probe scans a fail-fast scheme URL through the live scanner; it's the only subsystem that uses an active probe |
+| `config` | The atomic config pointer is non-nil | Hot reload swaps the pointer atomically; a nil pointer means a reload race left the proxy unable to read config |
+| `session` | Session profiling is disabled, OR the session-manager pointer is non-nil | Sessions are optional (`session_profiling.enabled`); a missing manager when expected is unhealthy |
+| `killswitch` | The kill switch is disabled in config, OR the kill-switch controller is wired | The controller is independent of `kill_switch_active`: `active` reports whether traffic is currently denied; `subsystems.killswitch` reports whether the kill-switch state machine itself is reachable |
+| `watchdog` | Watchdog goroutine has bumped its self-heartbeat within the staleness threshold | If the goroutine dies, `/health` flips to 503 even when other subsystems look fine |
+
+## Detection Strategy
+
+The watchdog uses **hybrid passive + active** detection.
+
+- **Passive scanner heartbeats** are the cheap normal-path signal. Each `Scan()` completion bumps an `atomic.Int64` timestamp. One atomic store per scan; effectively free at scan-rate.
+- **Bounded synthetic probe** runs only when the scanner heartbeat is stale. The watchdog asks the live scanner to scan a fail-fast scheme URL (`ftp://wedge-probe.invalid/`) under an `interval/2` deadline. A timeout means scanner is wedged. On success, the heartbeat is refreshed so subsequent `/health` calls don't re-pay the probe cost until the heartbeat ages out again.
+- **Structural presence checks** cover config, session, and kill switch state. Optional subsystems report healthy when disabled; enabled subsystems report unhealthy if their live pointer/controller is missing.
+
+Idle systems do not flag false positives. If no traffic has reached the scanner for several intervals — common in dev or low-volume agents — the heartbeat ages out, the probe runs, the scanner answers immediately, the heartbeat re-seeds, and `/health` stays 200. The probe path only surfaces a wedge when the scanner cannot complete a trivial scan within `interval/2`.
+
+The watchdog goroutine itself is intentionally minimal: a ticker that stores `time.Now()` into one atomic on each tick. If it dies (panic, runtime crash), its self-heartbeat goes stale and `/health` flips to 503 even when every other subsystem looks fine.
+
+## Configuration
+
+```yaml
+health_watchdog:
+  enabled: true            # default: true
+  interval_seconds: 2      # default: 2; staleness threshold = 3 × interval
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `true` | Turn the watchdog off to restore pre-v2.4 `/health` behavior (no `subsystems` map, always 200). Operators rarely want this off. |
+| `interval_seconds` | `2` | Self-beat tick rate. The staleness threshold (when the watchdog declares a heartbeat stale) is derived as 3 × interval, so the default 2s gives a 6s window. |
+
+If `health_watchdog` is omitted entirely from the YAML, the section defaults to `enabled: true, interval_seconds: 2` (fail-open for the watchdog: an operator who omits the section still gets wedge protection). YAML `null`/blank for the section or for `enabled` is treated as omitted.
+
+**Hot reload note.** Watchdog settings are immutable across hot reload in v2.4 — restarting pipelock is required to change the interval. The settings are purely operational and do not affect the canonical policy hash, so toggling them does not rotate `ph` for downstream verifiers.
+
+## Polling Contract for External Watchdogs
+
+Pipelock's wedge-detection design assumes an **external supervisor** to act on the 503 signal. A wedged process cannot reliably restart itself; the watchdog provides the diagnostic, the supervisor performs the action.
+
+Recommended polling pattern:
+
+```yaml
+# Kubernetes liveness/readiness probe
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8888
+  periodSeconds: 5            # ≥ interval_seconds
+  failureThreshold: 3         # restart after ~15s of consecutive 503s
+  timeoutSeconds: 2
+```
+
+The `failureThreshold` × `periodSeconds` budget should be larger than the staleness threshold (3 × `interval_seconds`) so transient probe blips don't trigger restarts.
+
+Supervisors that are not Kubernetes (KiloClaw controller, systemd, custom watchdogs) should follow the same pattern: poll every N seconds, restart after K consecutive failures, where N ≥ `interval_seconds` and N × K > 3 × `interval_seconds`.
+
+## Disabling the Watchdog
+
+```yaml
+health_watchdog:
+  enabled: false
+```
+
+The `/health` endpoint returns the pre-v2.4 shape: status always `"healthy"`, no `subsystems` map, HTTP 200 regardless of internal state. Use only when an external system already provides equivalent liveness signal and you want to silence pipelock's view.
+
+## Relationship to `kill_switch_active`
+
+`kill_switch_active` (top-level field) reports whether the kill switch is currently denying traffic. It is a *policy* signal — operators can flip it on/off through any of four sources (config, API, signal, sentinel file).
+
+`subsystems.killswitch` (under the watchdog map) reports whether the kill-switch *state machine* is reachable from the proxy. A pipelock that cannot read its kill switch is wedged; one that reads it and reports "active" is fine.
+
+External watchdogs interested in "should this instance receive traffic?" check both: `status == "healthy"` AND `kill_switch_active == false`. The first answers "is pipelock alive?", the second answers "is pipelock currently allowing traffic?".

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -163,6 +163,12 @@ func (c *Config) policySemanticView() Config {
 	// max_body_bytes DO affect the envelope contract and stay in view.
 	view.MediationEnvelope.SigningKeyPath = ""
 
+	// HealthWatchdog is excluded from the canonical hash via the `json:"-"`
+	// tag on the Config field — operational liveness, not policy. Whether
+	// the watchdog is enabled or what tick interval it uses does not change
+	// what pipelock would decide about a scanned request; it only changes
+	// whether /health flips to 503 when internal state is wedged.
+
 	// Agents map — handled via per-agent resolved configs. See the
 	// CanonicalPolicyHash doc comment.
 	view.Agents = nil

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -456,6 +456,10 @@ func Defaults() *Config {
 			// strip metadata, log exposure). AllowedImageTypes and
 			// MaxImageBytes also fall through to defaults via their getters.
 		},
+		HealthWatchdog: HealthWatchdog{
+			Enabled:         true,
+			IntervalSeconds: 2,
+		},
 	}
 	// Mark all compiled defaults with provenance so the standard tier source
 	// selector can distinguish them from user-supplied patterns. Set at

--- a/internal/config/health_watchdog_test.go
+++ b/internal/config/health_watchdog_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestHealthWatchdog_DefaultsEnabled verifies Defaults() produces an enabled
+// watchdog with the documented 2-second tick.
+func TestHealthWatchdog_DefaultsEnabled(t *testing.T) {
+	cfg := Defaults()
+	if !cfg.HealthWatchdog.Enabled {
+		t.Errorf("expected Enabled=true, got false")
+	}
+	if cfg.HealthWatchdog.IntervalSeconds != 2 {
+		t.Errorf("expected IntervalSeconds=2, got %d", cfg.HealthWatchdog.IntervalSeconds)
+	}
+}
+
+// TestHealthWatchdog_IntervalDuration covers the helper's positive, zero, and
+// negative branches.
+func TestHealthWatchdog_IntervalDuration(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want time.Duration
+	}{
+		{"positive", 5, 5 * time.Second},
+		{"zero defaults to 2s", 0, 2 * time.Second},
+		{"negative defaults to 2s", -1, 2 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := HealthWatchdog{IntervalSeconds: tc.in}
+			if got := h.IntervalDuration(); got != tc.want {
+				t.Errorf("IntervalDuration()=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHealthWatchdog_ApplyDefaults_FillsZeroInterval covers the
+// ApplyDefaults path: an explicitly-zero IntervalSeconds is bumped to 2.
+func TestHealthWatchdog_ApplyDefaults_FillsZeroInterval(t *testing.T) {
+	cfg := &Config{}
+	cfg.ApplyDefaults()
+	if cfg.HealthWatchdog.IntervalSeconds != 2 {
+		t.Errorf("expected IntervalSeconds=2 after ApplyDefaults, got %d", cfg.HealthWatchdog.IntervalSeconds)
+	}
+}
+
+// TestHealthWatchdog_Load_OmittedSection verifies the 6-state coverage rule
+// (state 1: section omitted entirely from YAML). Should default to enabled.
+func TestHealthWatchdog_Load_OmittedSection(t *testing.T) {
+	cfgPath := writeTempConfig(t, `version: 1
+mode: balanced
+`)
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.HealthWatchdog.Enabled {
+		t.Errorf("omitted section should default Enabled=true; got false")
+	}
+	if cfg.HealthWatchdog.IntervalSeconds != 2 {
+		t.Errorf("omitted section should default IntervalSeconds=2; got %d", cfg.HealthWatchdog.IntervalSeconds)
+	}
+}
+
+// TestHealthWatchdog_Load_NullSection covers state 2: YAML `null` for the
+// whole section.
+func TestHealthWatchdog_Load_NullSection(t *testing.T) {
+	cfgPath := writeTempConfig(t, `version: 1
+mode: balanced
+health_watchdog: ~
+`)
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.HealthWatchdog.Enabled {
+		t.Errorf("null section should default Enabled=true; got false")
+	}
+}
+
+// TestHealthWatchdog_Load_BlankEnabled covers state 2b: section present but
+// `enabled` key blank/null.
+func TestHealthWatchdog_Load_BlankEnabled(t *testing.T) {
+	cfgPath := writeTempConfig(t, `version: 1
+mode: balanced
+health_watchdog:
+  enabled: ~
+`)
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.HealthWatchdog.Enabled {
+		t.Errorf("blank enabled should default to true; got false")
+	}
+}
+
+// TestHealthWatchdog_Load_ExplicitFalse covers state 3.
+func TestHealthWatchdog_Load_ExplicitFalse(t *testing.T) {
+	cfgPath := writeTempConfig(t, `version: 1
+mode: balanced
+health_watchdog:
+  enabled: false
+`)
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.HealthWatchdog.Enabled {
+		t.Errorf("explicit false should be respected; got true")
+	}
+}
+
+// TestHealthWatchdog_Load_ExplicitTrue covers state 4.
+func TestHealthWatchdog_Load_ExplicitTrue(t *testing.T) {
+	cfgPath := writeTempConfig(t, `version: 1
+mode: balanced
+health_watchdog:
+  enabled: true
+  interval_seconds: 5
+`)
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.HealthWatchdog.Enabled {
+		t.Errorf("explicit true should be respected; got false")
+	}
+	if cfg.HealthWatchdog.IntervalSeconds != 5 {
+		t.Errorf("explicit interval_seconds should be respected; got %d", cfg.HealthWatchdog.IntervalSeconds)
+	}
+}
+
+// TestHealthWatchdog_Reload_PreservesDisabled covers state 5/6: reload with
+// and without change. The first load disables; the second load (same YAML)
+// must keep it disabled. Reload with a re-enabled YAML must take effect.
+func TestHealthWatchdog_Reload_StateChanges(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+
+	// State 5 prep: disabled
+	if err := os.WriteFile(cfgPath, []byte(`version: 1
+mode: balanced
+health_watchdog:
+  enabled: false
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg1, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("first Load: %v", err)
+	}
+	if cfg1.HealthWatchdog.Enabled {
+		t.Fatalf("expected disabled after first load")
+	}
+
+	// State 6: reload identical YAML — must stay disabled.
+	cfg2, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("idempotent reload: %v", err)
+	}
+	if cfg2.HealthWatchdog.Enabled {
+		t.Errorf("idempotent reload flipped Enabled to true")
+	}
+
+	// State 5: change YAML to re-enable, reload — must take effect.
+	if err := os.WriteFile(cfgPath, []byte(`version: 1
+mode: balanced
+health_watchdog:
+  enabled: true
+  interval_seconds: 4
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg3, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("changing reload: %v", err)
+	}
+	if !cfg3.HealthWatchdog.Enabled {
+		t.Errorf("reload with enabled:true did not enable")
+	}
+	if cfg3.HealthWatchdog.IntervalSeconds != 4 {
+		t.Errorf("reload IntervalSeconds=%d, want 4", cfg3.HealthWatchdog.IntervalSeconds)
+	}
+}
+
+// TestHealthWatchdog_NotInCanonicalHash verifies the operational-not-policy
+// invariant: changing watchdog settings must not alter the canonical policy
+// hash. Otherwise downstream verifiers would see spurious policy churn.
+func TestHealthWatchdog_NotInCanonicalHash(t *testing.T) {
+	a := Defaults()
+	b := Defaults()
+	b.HealthWatchdog.Enabled = false
+	b.HealthWatchdog.IntervalSeconds = 99
+
+	if a.CanonicalPolicyHash() != b.CanonicalPolicyHash() {
+		t.Fatalf("canonical hash diverged on watchdog change: %s vs %s",
+			a.CanonicalPolicyHash(), b.CanonicalPolicyHash())
+	}
+}
+
+func TestValidateReload_HealthWatchdogChanged(t *testing.T) {
+	old := Defaults()
+	updated := Defaults()
+	updated.HealthWatchdog.IntervalSeconds = old.HealthWatchdog.IntervalSeconds + 1
+
+	warnings := ValidateReload(old, updated)
+	found := false
+	for _, w := range warnings {
+		if w.Field == "health_watchdog" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected reload warning for health_watchdog change")
+	}
+}
+
+func TestValidateReload_HealthWatchdogUnchanged_NoWarning(t *testing.T) {
+	old := Defaults()
+	updated := Defaults()
+
+	warnings := ValidateReload(old, updated)
+	for _, w := range warnings {
+		if w.Field == "health_watchdog" {
+			t.Fatalf("unexpected health_watchdog warning: %+v", w)
+		}
+	}
+}
+
+// writeTempConfig writes the given YAML body to a temp file and returns its
+// path. Used by table tests that load minimal configs.
+func writeTempConfig(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return p
+}

--- a/internal/config/health_watchdog_test.go
+++ b/internal/config/health_watchdog_test.go
@@ -20,6 +20,13 @@ func TestHealthWatchdog_DefaultsEnabled(t *testing.T) {
 	if cfg.HealthWatchdog.IntervalSeconds != 2 {
 		t.Errorf("expected IntervalSeconds=2, got %d", cfg.HealthWatchdog.IntervalSeconds)
 	}
+	// ExposeSubsystems defaults to false: the per-subsystem map on /health
+	// is opt-in because exposing scanner / config / killswitch breakdown
+	// to unauthenticated callers helps attacker reconnaissance against a
+	// security boundary product.
+	if cfg.HealthWatchdog.ExposeSubsystems {
+		t.Errorf("expected ExposeSubsystems=false (default-secure), got true")
+	}
 }
 
 // TestHealthWatchdog_IntervalDuration covers the helper's positive, zero, and

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -57,6 +57,7 @@ func applySecurityDefaults(rawYAML []byte, cfg *Config) {
 		cfg.ScanAPI.Kinds.ToolCall = true
 		cfg.Taint.Enabled = true
 		cfg.Learn.Privacy.PublicAllowlistDefault = true
+		cfg.HealthWatchdog.Enabled = true
 		return
 	}
 
@@ -143,6 +144,12 @@ func applySecurityDefaults(rawYAML []byte, cfg *Config) {
 		privacy, _ = learn["privacy"].(map[string]interface{})
 	}
 	setBoolDefault(privacy, "public_allowlist_default", &cfg.Learn.Privacy.PublicAllowlistDefault)
+
+	// Health watchdog: enabled defaults to true so wedge detection runs out of
+	// the box. An operator who omits health_watchdog (or sets it to ~) still
+	// gets the watchdog; explicit `enabled: false` is required to opt out.
+	hw, _ := raw["health_watchdog"].(map[string]interface{})
+	setBoolDefault(hw, "enabled", &cfg.HealthWatchdog.Enabled)
 }
 
 // ApplyDefaults fills in zero-value fields with sensible defaults.
@@ -616,6 +623,12 @@ func (c *Config) ApplyDefaults() {
 		}
 	}
 	// PoisonResistance defaults to true via applySecurityDefaults.
+
+	// Health watchdog: interval defaults to 2s when omitted or non-positive.
+	// Enabled is handled by applySecurityDefaults (defaults to true).
+	if c.HealthWatchdog.IntervalSeconds <= 0 {
+		c.HealthWatchdog.IntervalSeconds = 2
+	}
 }
 
 // mergeDLPPatterns merges default DLP patterns with user-defined patterns.

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -424,6 +424,16 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 		})
 	}
 
+	// Health watchdog settings are startup-only: the goroutine interval and
+	// enabled/disabled wiring are established when the proxy is constructed.
+	if old.HealthWatchdog.Enabled != updated.HealthWatchdog.Enabled ||
+		old.HealthWatchdog.IntervalSeconds != updated.HealthWatchdog.IntervalSeconds {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "health_watchdog",
+			Message: "health_watchdog config changes require restart — ignored on reload",
+		})
+	}
+
 	// Secrets file changed or removed (security-relevant)
 	if old.DLP.SecretsFile != updated.DLP.SecretsFile {
 		if updated.DLP.SecretsFile == "" {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -663,6 +663,18 @@ type KillSwitch struct {
 type HealthWatchdog struct {
 	Enabled         bool `yaml:"enabled"`
 	IntervalSeconds int  `yaml:"interval_seconds"` // tick rate; staleness threshold is 3 × this. Defaults to 2.
+	// ExposeSubsystems controls whether /health includes the per-subsystem
+	// boolean breakdown (scanner / config / session / killswitch / watchdog)
+	// alongside the overall status. The breakdown is operationally useful
+	// for diagnosing wedges but lets unauthenticated callers distinguish
+	// scanner failure from config failure from killswitch wiring, which is
+	// material reconnaissance against a security boundary product. Defaults
+	// to false: /health still returns 503 when any subsystem is unhealthy
+	// so external supervisors keep a clean liveness signal, but the response
+	// body omits the subsystem map. Operators who want the breakdown on a
+	// trusted network set this to true; a future change can move the detail
+	// to the authenticated kill-switch API listener.
+	ExposeSubsystems bool `yaml:"expose_subsystems"`
 }
 
 // IntervalDuration returns the watchdog tick interval. Defaults to 2s when

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -223,6 +223,7 @@ type Config struct {
 	MCPSessionBinding        MCPSessionBinding       `yaml:"mcp_session_binding"`
 	RequestBodyScanning      RequestBodyScanning     `yaml:"request_body_scanning"`
 	KillSwitch               KillSwitch              `yaml:"kill_switch"`
+	HealthWatchdog           HealthWatchdog          `yaml:"health_watchdog" json:"-"` // operational liveness, excluded from canonical policy hash
 	Sentry                   SentryConfig            `yaml:"sentry"`
 	MetricsListen            string                  `yaml:"metrics_listen"` // separate listen address for /metrics and /stats
 	Emit                     EmitConfig              `yaml:"emit"`
@@ -644,6 +645,33 @@ type KillSwitch struct {
 	APIToken      string   `yaml:"api_token"`
 	APIListen     string   `yaml:"api_listen"` // separate listen address for kill switch API (e.g. "0.0.0.0:9090")
 	AllowlistIPs  []string `yaml:"allowlist_ips"`
+}
+
+// HealthWatchdog configures the wedge-detection watchdog.
+//
+// The watchdog tracks scanner and self heartbeats plus proxy-supplied
+// structural checks for config, session, and killswitch wiring. The /health
+// endpoint reports a nested subsystems map and returns 503 Service Unavailable
+// when any subsystem is unhealthy. Detection is hybrid for the scanner:
+// passive heartbeats are the normal-path signal, and a bounded synthetic
+// scanner probe runs only when the scanner heartbeat is stale.
+//
+// Settings are immutable across hot reload for v1 — changes require a process
+// restart. Reload logs a warning if values differ from startup. Enabled
+// defaults to true (fail-open for the watchdog: detection on by default so an
+// operator who omits the section still gets wedge protection).
+type HealthWatchdog struct {
+	Enabled         bool `yaml:"enabled"`
+	IntervalSeconds int  `yaml:"interval_seconds"` // tick rate; staleness threshold is 3 × this. Defaults to 2.
+}
+
+// IntervalDuration returns the watchdog tick interval. Defaults to 2s when
+// IntervalSeconds is zero or negative.
+func (h HealthWatchdog) IntervalDuration() time.Duration {
+	if h.IntervalSeconds <= 0 {
+		return 2 * time.Second
+	}
+	return time.Duration(h.IntervalSeconds) * time.Second
 }
 
 // EmitConfig configures external event emission (webhook, syslog, and OTLP).

--- a/internal/health/watchdog.go
+++ b/internal/health/watchdog.go
@@ -1,0 +1,281 @@
+// Package health provides a wedge-detection watchdog for pipelock.
+//
+// The /health endpoint historically answered 200 as long as the HTTP handler
+// itself responded, even if internal subsystems were deadlocked. This package
+// adds liveness signals: the scanner bumps a heartbeat on normal-path scan
+// completion, the watchdog itself ticks a self-heartbeat, and Snapshot combines
+// those timestamps with proxy-supplied subsystem presence checks that /health
+// uses to set its status code (503 when any subsystem is unhealthy).
+//
+// Detection is hybrid:
+//
+//   - The scanner heartbeat is the cheap normal-path signal: each Scan()
+//     completion performs one atomic store.
+//   - A bounded synthetic probe runs only when the scanner heartbeat is stale.
+//     This distinguishes a quiet-idle system from a wedged one without
+//     poisoning every /health call with a probe.
+//   - Config, session, and kill-switch checks are structural presence checks
+//     supplied by the proxy: optional subsystems are healthy when disabled, and
+//     required subsystems are unhealthy when their live pointer is missing.
+//
+// The watchdog goroutine is intentionally minimal: it stores time.Now into an
+// atomic on each tick and otherwise does nothing. If it dies, its self-beat
+// ages out and /health flips to 503 even if every other subsystem looks fine.
+package health
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Subsystem name keys returned in Snapshot.Subsystems. Stable for probes and
+// dashboards; do not rename without coordinating with KiloClaw integration.
+const (
+	SubsystemScanner    = "scanner"
+	SubsystemConfig     = "config"
+	SubsystemSession    = "session"
+	SubsystemKillSwitch = "killswitch"
+	SubsystemWatchdog   = "watchdog"
+)
+
+// Probe is a synthetic scanner call. It must respect ctx and return a
+// non-nil error on timeout or scanner unavailability. Any non-nil error from
+// Probe is treated as a wedge indicator.
+type Probe func(ctx context.Context) error
+
+// SnapshotInput carries live presence state from the calling Proxy. The
+// watchdog cannot read these directly without taking a dependency on the
+// proxy package; passing them in keeps internal/health acyclic.
+//
+// SessionEnabled and KillSwitchEnabled mirror config-side opt-in flags. When
+// false, the corresponding subsystem is considered healthy regardless of
+// its pointer state — the operator legitimately turned the feature off, so
+// a missing controller is normal, not wedged. When the flag is true the
+// pointer must be wired or the subsystem reports unhealthy.
+type SnapshotInput struct {
+	ScannerPtrAlive   bool // proxy.scannerPtr.Load() != nil
+	ConfigPtrAlive    bool // proxy.cfgPtr.Load() != nil
+	SessionEnabled    bool // session profiling configured at all
+	SessionPtrAlive   bool // proxy.sessionMgrPtr.Load() != nil; ignored when !SessionEnabled
+	KillSwitchEnabled bool // cfg.KillSwitch.Enabled
+	KillSwitchPresent bool // proxy.ks != nil; ignored when !KillSwitchEnabled
+}
+
+// Snapshot is the watchdog's view of system liveness. Healthy is the AND of
+// every value in Subsystems.
+type Snapshot struct {
+	Healthy    bool
+	Subsystems map[string]bool
+}
+
+// Config configures a Watchdog at construction.
+type Config struct {
+	// Interval is the self-beat tick rate and the basis for the staleness
+	// threshold (3 × Interval). Required, must be > 0.
+	Interval time.Duration
+	// Probe is the synthetic scanner check invoked when the scanner
+	// heartbeat is stale. Required.
+	Probe Probe
+	// NowFn is an injectable clock; defaults to time.Now. Tests use this
+	// to control staleness without time.Sleep.
+	NowFn func() time.Time
+}
+
+// Watchdog tracks per-subsystem heartbeats and answers Snapshot for the
+// /health endpoint. The zero value is unusable; call New.
+type Watchdog struct {
+	interval   time.Duration
+	staleAfter time.Duration
+	probe      Probe
+	nowFn      func() time.Time
+
+	scannerBeat    atomic.Int64
+	configBeat     atomic.Int64
+	sessionBeat    atomic.Int64
+	killSwitchBeat atomic.Int64
+	selfBeat       atomic.Int64
+
+	// startedOnce flips true the first time Start is called and never goes
+	// back. Snapshot uses this so a Watchdog constructed but never Started
+	// (common in unit tests that exercise handlers without the full proxy
+	// lifecycle) reports watchdog=true — there is no goroutine that should
+	// be running, so there is no signal to be stale. Once Start is called,
+	// staleness on selfBeat means the goroutine died (or was deliberately
+	// Stopped, which we treat the same: no further heartbeats expected).
+	startedOnce atomic.Bool
+
+	startMu sync.Mutex
+	started bool
+	cancel  context.CancelFunc
+	done    chan struct{}
+}
+
+// New constructs a Watchdog. Returns an error if cfg is invalid.
+func New(cfg Config) (*Watchdog, error) {
+	if cfg.Interval <= 0 {
+		return nil, errors.New("health: Interval must be > 0")
+	}
+	if cfg.Probe == nil {
+		return nil, errors.New("health: Probe is required")
+	}
+	nowFn := cfg.NowFn
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	return &Watchdog{
+		interval:   cfg.Interval,
+		staleAfter: 3 * cfg.Interval,
+		probe:      cfg.Probe,
+		nowFn:      nowFn,
+		done:       make(chan struct{}),
+	}, nil
+}
+
+// Start seeds every heartbeat to the current clock value and launches the
+// self-beat goroutine. Idempotent; subsequent calls are no-ops while the
+// goroutine is running. Stop must be called to halt it.
+//
+// Seeding prevents a cold-start system from reporting unhealthy before any
+// real traffic has arrived.
+func (w *Watchdog) Start(parent context.Context) {
+	w.startMu.Lock()
+	defer w.startMu.Unlock()
+	if w.started {
+		return
+	}
+	w.started = true
+	w.startedOnce.Store(true)
+
+	now := w.nowFn().UnixNano()
+	w.scannerBeat.Store(now)
+	w.configBeat.Store(now)
+	w.sessionBeat.Store(now)
+	w.killSwitchBeat.Store(now)
+	w.selfBeat.Store(now)
+
+	ctx, cancel := context.WithCancel(parent)
+	w.cancel = cancel
+
+	go w.tick(ctx)
+}
+
+// Stop cancels the self-beat goroutine and blocks until it exits. Safe to
+// call before Start (no-op) or twice (second call returns immediately).
+func (w *Watchdog) Stop() {
+	w.startMu.Lock()
+	cancel := w.cancel
+	w.cancel = nil
+	w.startMu.Unlock()
+	if cancel == nil {
+		return
+	}
+	cancel()
+	<-w.done
+}
+
+func (w *Watchdog) tick(ctx context.Context) {
+	defer close(w.done)
+	t := time.NewTicker(w.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			w.selfBeat.Store(w.nowFn().UnixNano())
+		}
+	}
+}
+
+// BeatScanner records that the scanner just completed a scan. Cheap; safe
+// to call from every Scanner.Scan completion.
+func (w *Watchdog) BeatScanner() { w.scannerBeat.Store(w.nowFn().UnixNano()) }
+
+// BeatConfig records a successful config load or reload.
+func (w *Watchdog) BeatConfig() { w.configBeat.Store(w.nowFn().UnixNano()) }
+
+// BeatSession records session-manager activity.
+func (w *Watchdog) BeatSession() { w.sessionBeat.Store(w.nowFn().UnixNano()) }
+
+// BeatKillSwitch records kill-switch state observation.
+func (w *Watchdog) BeatKillSwitch() { w.killSwitchBeat.Store(w.nowFn().UnixNano()) }
+
+// Interval returns the configured tick interval; useful for callers that
+// want to budget probe timeouts as a fraction of it.
+func (w *Watchdog) Interval() time.Duration { return w.interval }
+
+// AgeScannerForTest backdates the scanner heartbeat by d so the next
+// Snapshot sees it as stale. Test-only helper: the suffix marks intent.
+// Production code paths use BeatScanner to record activity; nothing
+// production should ever subtract from a heartbeat.
+func (w *Watchdog) AgeScannerForTest(d time.Duration) {
+	w.scannerBeat.Add(-d.Nanoseconds())
+}
+
+// Snapshot returns the current per-subsystem liveness map. The scanner
+// uses the hybrid rule: pointer alive AND (fresh heartbeat OR probe returns
+// nil within Interval/2). Config / session / killswitch are presence
+// checks. Watchdog is healthy iff its self-heartbeat is fresh — if the
+// goroutine dies, this flips to false within staleAfter.
+//
+// On a successful probe Snapshot re-beats the scanner so subsequent /health
+// calls do not re-pay the probe cost until the heartbeat ages out again.
+func (w *Watchdog) Snapshot(ctx context.Context, in SnapshotInput) Snapshot {
+	now := w.nowFn().UnixNano()
+	threshold := w.staleAfter.Nanoseconds()
+
+	sub := make(map[string]bool, 5)
+	if !w.startedOnce.Load() {
+		// Constructed but never Started (test path that exercises the
+		// handler without the full proxy lifecycle). No goroutine is
+		// expected to bump selfBeat, so there is nothing to be stale.
+		sub[SubsystemWatchdog] = true
+	} else {
+		sub[SubsystemWatchdog] = (now - w.selfBeat.Load()) < threshold
+	}
+	sub[SubsystemConfig] = in.ConfigPtrAlive
+	if in.KillSwitchEnabled {
+		sub[SubsystemKillSwitch] = in.KillSwitchPresent
+	} else {
+		sub[SubsystemKillSwitch] = true
+	}
+	if in.SessionEnabled {
+		sub[SubsystemSession] = in.SessionPtrAlive
+	} else {
+		sub[SubsystemSession] = true
+	}
+
+	switch {
+	case !in.ScannerPtrAlive || !in.ConfigPtrAlive:
+		// Pointer first: a missing scanner or config is structurally
+		// broken regardless of how recent the last beat was.
+		sub[SubsystemScanner] = false
+	case (now - w.scannerBeat.Load()) < threshold:
+		sub[SubsystemScanner] = true
+	default:
+		// Beat stale, pointers alive: probe synthetically with an
+		// Interval/2 budget. On success re-beat so /health does not
+		// re-probe on every call.
+		probeCtx, cancel := context.WithTimeout(ctx, w.interval/2)
+		err := w.probe(probeCtx)
+		cancel()
+		if err == nil {
+			w.scannerBeat.Store(now)
+			sub[SubsystemScanner] = true
+		} else {
+			sub[SubsystemScanner] = false
+		}
+	}
+
+	healthy := true
+	for _, ok := range sub {
+		if !ok {
+			healthy = false
+			break
+		}
+	}
+	return Snapshot{Healthy: healthy, Subsystems: sub}
+}

--- a/internal/health/watchdog_test.go
+++ b/internal/health/watchdog_test.go
@@ -1,0 +1,546 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const (
+	testInterval = 100 * time.Millisecond
+	testEpoch    = int64(1_700_000_000_000_000_000) // 2023-11-14 in nanos
+)
+
+// fakeClock is a monotonic mock clock advanced explicitly by tests. nowFn
+// reads stored nanos; Advance bumps them. Safe for concurrent use because
+// the goroutine calls nowFn while tests advance the clock.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{t: time.Unix(0, testEpoch)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// allAlive is the SnapshotInput shape used when a test wants to isolate a
+// specific failure mode and have all other presence bools be true. Both
+// SessionEnabled and KillSwitchEnabled default to false here so the
+// "subsystem turned off → healthy" branch is exercised; tests that need
+// the enabled-and-required path flip the flags explicitly.
+var allAlive = SnapshotInput{
+	ScannerPtrAlive:   bool(true),
+	ConfigPtrAlive:    bool(true),
+	SessionEnabled:    bool(false),
+	SessionPtrAlive:   bool(false),
+	KillSwitchEnabled: bool(true),
+	KillSwitchPresent: bool(true),
+}
+
+func okProbe(_ context.Context) error  { return nil }
+func errProbe(_ context.Context) error { return errors.New("probe failed") }
+
+// hangProbe blocks until ctx is canceled. Use with a context that has a
+// deadline; the probe returns ctx.Err() once the deadline fires.
+func hangProbe(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// recordingProbe captures the deadline visible to the probe so tests can
+// assert that Snapshot wrapped the parent context with Interval/2.
+type recordingProbe struct {
+	mu       sync.Mutex
+	deadline time.Time
+	hadDL    bool
+	calls    atomic.Int32
+	ret      error
+}
+
+func (r *recordingProbe) Call(ctx context.Context) error {
+	dl, ok := ctx.Deadline()
+	r.mu.Lock()
+	r.deadline = dl
+	r.hadDL = ok
+	r.mu.Unlock()
+	r.calls.Add(1)
+	return r.ret
+}
+
+func mustNew(t *testing.T, cfg Config) *Watchdog {
+	t.Helper()
+	w, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return w
+}
+
+func TestNew_ValidatesConfig(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{"zero interval", Config{Probe: okProbe}},
+		{"negative interval", Config{Interval: -1, Probe: okProbe}},
+		{"nil probe", Config{Interval: testInterval}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := New(tc.cfg); err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestNew_NowFnDefaultsToTimeNow(t *testing.T) {
+	t.Parallel()
+	w, err := New(Config{Interval: testInterval, Probe: okProbe})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Must not panic when nowFn is invoked.
+	w.BeatScanner()
+	if w.scannerBeat.Load() == 0 {
+		t.Fatalf("BeatScanner did not store time")
+	}
+}
+
+func TestSnapshot_AllHealthy(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	w := mustNew(t, Config{Interval: testInterval, Probe: okProbe, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Stop()
+
+	snap := w.Snapshot(ctx, allAlive)
+	if !snap.Healthy {
+		t.Fatalf("expected Healthy=true, got %+v", snap)
+	}
+	for _, key := range []string{SubsystemScanner, SubsystemConfig, SubsystemSession, SubsystemKillSwitch, SubsystemWatchdog} {
+		if !snap.Subsystems[key] {
+			t.Errorf("subsystem %q expected true, got false", key)
+		}
+	}
+}
+
+func TestSnapshot_ScannerStale_ProbeOK_RebeatsAndHealthy(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	probe := &recordingProbe{}
+	w := mustNew(t, Config{Interval: testInterval, Probe: probe.Call, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Stop()
+
+	// Age the scanner heartbeat past the threshold.
+	clock.Advance(4 * testInterval)
+
+	// First Snapshot: scanner beat stale → probe runs → healthy.
+	// But watchdog beat is also stale because goroutine stopped — split that
+	// out by re-seeding selfBeat to "now" so we can isolate the scanner path.
+	w.selfBeat.Store(clock.Now().UnixNano())
+
+	snap := w.Snapshot(ctx, allAlive)
+	if !snap.Subsystems[SubsystemScanner] {
+		t.Fatalf("expected scanner healthy after successful probe, got %+v", snap)
+	}
+	if got := probe.calls.Load(); got != 1 {
+		t.Fatalf("expected probe called once, got %d", got)
+	}
+
+	// Probe should have wrapped a deadline ≤ Interval/2 from clock.Now.
+	probe.mu.Lock()
+	if !probe.hadDL {
+		t.Fatalf("probe context had no deadline")
+	}
+	probe.mu.Unlock()
+
+	// Second Snapshot: scanner beat was refreshed by the successful probe,
+	// so probe must NOT be called again.
+	snap2 := w.Snapshot(ctx, allAlive)
+	if !snap2.Subsystems[SubsystemScanner] {
+		t.Fatalf("expected scanner still healthy")
+	}
+	if got := probe.calls.Load(); got != 1 {
+		t.Fatalf("expected probe still called once after re-beat, got %d", got)
+	}
+}
+
+func TestSnapshot_ScannerStale_ProbeFails_Unhealthy(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	w := mustNew(t, Config{Interval: testInterval, Probe: errProbe, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Stop()
+	w.selfBeat.Store(clock.Now().UnixNano()) // isolate from watchdog staleness
+
+	clock.Advance(4 * testInterval)
+	snap := w.Snapshot(ctx, allAlive)
+	if snap.Healthy {
+		t.Fatalf("expected Healthy=false")
+	}
+	if snap.Subsystems[SubsystemScanner] {
+		t.Fatalf("expected scanner=false, got %+v", snap)
+	}
+	// Other subsystems should remain healthy.
+	if !snap.Subsystems[SubsystemConfig] || !snap.Subsystems[SubsystemSession] || !snap.Subsystems[SubsystemKillSwitch] {
+		t.Fatalf("unexpected cascading unhealth: %+v", snap)
+	}
+}
+
+func TestSnapshot_ScannerPtrNil_ProbeNotCalled(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	probe := &recordingProbe{}
+	w := mustNew(t, Config{Interval: testInterval, Probe: probe.Call, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Stop()
+
+	in := allAlive
+	in.ScannerPtrAlive = false
+	snap := w.Snapshot(ctx, in)
+	if snap.Subsystems[SubsystemScanner] {
+		t.Fatalf("expected scanner=false when pointer nil")
+	}
+	if got := probe.calls.Load(); got != 0 {
+		t.Fatalf("probe called %d times when pointer nil; expected 0", got)
+	}
+}
+
+func TestSnapshot_ConfigPtrNil_CascadesToScanner(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	probe := &recordingProbe{}
+	w := mustNew(t, Config{Interval: testInterval, Probe: probe.Call, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Stop()
+
+	in := allAlive
+	in.ConfigPtrAlive = false
+	snap := w.Snapshot(ctx, in)
+	if snap.Subsystems[SubsystemConfig] {
+		t.Fatalf("expected config=false")
+	}
+	if snap.Subsystems[SubsystemScanner] {
+		t.Fatalf("expected scanner=false (cascaded from config nil)")
+	}
+	if got := probe.calls.Load(); got != 0 {
+		t.Fatalf("probe called %d times when config nil; expected 0", got)
+	}
+}
+
+func TestSnapshot_SessionDisabled_AlwaysHealthy(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	w := mustNew(t, Config{Interval: testInterval, Probe: okProbe, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Stop()
+
+	in := allAlive // SessionEnabled=false, SessionPtrAlive=false
+	snap := w.Snapshot(ctx, in)
+	if !snap.Subsystems[SubsystemSession] {
+		t.Fatalf("expected session=true when profiling disabled")
+	}
+}
+
+func TestSnapshot_SessionEnabled_PtrNil_Unhealthy(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	w := mustNew(t, Config{Interval: testInterval, Probe: okProbe, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Stop()
+
+	in := allAlive
+	in.SessionEnabled = true
+	in.SessionPtrAlive = false
+	snap := w.Snapshot(ctx, in)
+	if snap.Subsystems[SubsystemSession] {
+		t.Fatalf("expected session=false when enabled-but-nil")
+	}
+}
+
+func TestSnapshot_KillSwitchEnabledButAbsent_Unhealthy(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	w := mustNew(t, Config{Interval: testInterval, Probe: okProbe, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Stop()
+
+	in := allAlive
+	in.KillSwitchEnabled = true
+	in.KillSwitchPresent = false
+	snap := w.Snapshot(ctx, in)
+	if snap.Subsystems[SubsystemKillSwitch] {
+		t.Fatalf("expected killswitch=false when enabled-but-absent")
+	}
+	if snap.Healthy {
+		t.Fatalf("expected overall unhealthy")
+	}
+}
+
+func TestSnapshot_KillSwitchDisabled_Healthy(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	w := mustNew(t, Config{Interval: testInterval, Probe: okProbe, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Stop()
+
+	in := allAlive
+	in.KillSwitchEnabled = false
+	in.KillSwitchPresent = false
+	snap := w.Snapshot(ctx, in)
+	if !snap.Subsystems[SubsystemKillSwitch] {
+		t.Fatalf("expected killswitch=true when disabled (subsystem not in use)")
+	}
+}
+
+func TestSnapshot_WatchdogGoroutineDeath_FlipsUnhealthy(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	w := mustNew(t, Config{Interval: testInterval, Probe: okProbe, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Stop() // simulate goroutine death
+
+	// Immediately after Stop, selfBeat is fresh from Start seed → healthy.
+	snap := w.Snapshot(ctx, allAlive)
+	if !snap.Subsystems[SubsystemWatchdog] {
+		t.Fatalf("expected watchdog fresh right after Stop")
+	}
+
+	// Advance fake clock past staleAfter (3 × interval). With the goroutine
+	// stopped, no further selfBeat updates happen.
+	clock.Advance(4 * testInterval)
+	snap = w.Snapshot(ctx, allAlive)
+	if snap.Subsystems[SubsystemWatchdog] {
+		t.Fatalf("expected watchdog=false after goroutine death")
+	}
+	if snap.Healthy {
+		t.Fatalf("expected overall unhealthy on watchdog death")
+	}
+}
+
+func TestProbe_ContextHasIntervalHalfDeadline(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	probe := &recordingProbe{}
+	w := mustNew(t, Config{Interval: testInterval, Probe: probe.Call, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Stop()
+	w.selfBeat.Store(clock.Now().UnixNano())
+
+	// Force probe path.
+	clock.Advance(4 * testInterval)
+	beforeNow := time.Now()
+	_ = w.Snapshot(ctx, allAlive)
+
+	probe.mu.Lock()
+	defer probe.mu.Unlock()
+	if !probe.hadDL {
+		t.Fatalf("probe got no deadline")
+	}
+	// Deadline should be roughly within Interval/2 of real now (timeouts use
+	// real clock; nowFn only governs heartbeat math).
+	maxDeadline := beforeNow.Add(testInterval/2 + 50*time.Millisecond)
+	if probe.deadline.After(maxDeadline) {
+		t.Fatalf("probe deadline %v exceeds Interval/2 budget (max %v)", probe.deadline, maxDeadline)
+	}
+}
+
+func TestProbe_HangingScanner_TimesOutToUnhealthy(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	w := mustNew(t, Config{Interval: 20 * time.Millisecond, Probe: hangProbe, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Stop()
+	w.selfBeat.Store(clock.Now().UnixNano())
+
+	// Force probe path.
+	clock.Advance(4 * 20 * time.Millisecond)
+
+	snap := w.Snapshot(ctx, allAlive)
+	if snap.Subsystems[SubsystemScanner] {
+		t.Fatalf("expected scanner=false on probe timeout")
+	}
+	if snap.Healthy {
+		t.Fatalf("expected unhealthy")
+	}
+}
+
+func TestStartIdempotent(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	w := mustNew(t, Config{Interval: testInterval, Probe: okProbe, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Start(ctx) // must not double-launch or panic
+	w.Stop()
+}
+
+func TestStopBeforeStart_NoOp(t *testing.T) {
+	t.Parallel()
+	w := mustNew(t, Config{Interval: testInterval, Probe: okProbe})
+	w.Stop() // must not block or panic
+}
+
+func TestStopTwice_SecondCallReturns(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	w := mustNew(t, Config{Interval: testInterval, Probe: okProbe, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Stop()
+	w.Stop() // must not block or panic
+}
+
+func TestBeatMethods_StoreUniqueTimes(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	w := mustNew(t, Config{Interval: testInterval, Probe: okProbe, NowFn: clock.Now})
+
+	w.BeatScanner()
+	scannerT := w.scannerBeat.Load()
+
+	clock.Advance(time.Second)
+	w.BeatConfig()
+	configT := w.configBeat.Load()
+
+	clock.Advance(time.Second)
+	w.BeatSession()
+	sessionT := w.sessionBeat.Load()
+
+	clock.Advance(time.Second)
+	w.BeatKillSwitch()
+	ksT := w.killSwitchBeat.Load()
+
+	if scannerT >= configT || configT >= sessionT || sessionT >= ksT {
+		t.Fatalf("expected monotonic beats: scanner=%d config=%d session=%d ks=%d", scannerT, configT, sessionT, ksT)
+	}
+}
+
+func TestInterval_Getter(t *testing.T) {
+	t.Parallel()
+	w := mustNew(t, Config{Interval: testInterval, Probe: okProbe})
+	if got := w.Interval(); got != testInterval {
+		t.Fatalf("Interval()=%v want %v", got, testInterval)
+	}
+}
+
+func TestSnapshot_NeverStarted_WatchdogReportsHealthy(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	w := mustNew(t, Config{Interval: testInterval, Probe: okProbe, NowFn: clock.Now})
+
+	// Construct only — no Start. Tests that exercise handlers without the
+	// full proxy lifecycle hit this path. Watchdog must report healthy
+	// because there is no goroutine that should be bumping selfBeat.
+	snap := w.Snapshot(context.Background(), allAlive)
+	if !snap.Subsystems[SubsystemWatchdog] {
+		t.Fatalf("expected watchdog=true when never Started, got %+v", snap)
+	}
+	// Even after a long fake-clock advance, the not-started signal stays.
+	clock.Advance(time.Hour)
+	snap = w.Snapshot(context.Background(), allAlive)
+	if !snap.Subsystems[SubsystemWatchdog] {
+		t.Fatalf("expected watchdog=true after never-started + long advance, got %+v", snap)
+	}
+}
+
+func TestAgeScannerForTest_BackdatesBeat(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock()
+	probe := &recordingProbe{}
+	w := mustNew(t, Config{Interval: testInterval, Probe: probe.Call, NowFn: clock.Now})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Stop()
+	w.selfBeat.Store(clock.Now().UnixNano()) // isolate from watchdog staleness
+
+	// Without aging, Snapshot uses the fresh seeded heartbeat — no probe.
+	_ = w.Snapshot(ctx, allAlive)
+	if probe.calls.Load() != 0 {
+		t.Fatalf("probe ran without aging; expected 0 calls, got %d", probe.calls.Load())
+	}
+
+	// Age the scanner beat past staleAfter (3 × testInterval). Next Snapshot
+	// should see staleness and run the probe.
+	w.AgeScannerForTest(4 * testInterval)
+	_ = w.Snapshot(ctx, allAlive)
+	if probe.calls.Load() != 1 {
+		t.Fatalf("probe expected 1 call after AgeScannerForTest, got %d", probe.calls.Load())
+	}
+}
+
+func TestGoroutineBumpsSelfBeat(t *testing.T) {
+	// Real time, very small interval. Single integration check that the
+	// goroutine actually does its job. No time.Sleep; we poll the atomic
+	// with a generous deadline and exit as soon as it advances.
+	t.Parallel()
+	w, err := New(Config{Interval: 5 * time.Millisecond, Probe: okProbe})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	defer w.Stop()
+
+	initial := w.selfBeat.Load()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if w.selfBeat.Load() > initial {
+			return
+		}
+		// Yield without sleeping — the ticker fires on real wallclock.
+		select {
+		case <-time.After(time.Millisecond):
+		case <-ctx.Done():
+			t.Fatal("ctx canceled during poll")
+		}
+	}
+	t.Fatalf("selfBeat never advanced: initial=%d final=%d", initial, w.selfBeat.Load())
+}

--- a/internal/proxy/health_watchdog_test.go
+++ b/internal/proxy/health_watchdog_test.go
@@ -1,0 +1,334 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/health"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+// healthRespParse pulls the parts the watchdog tests inspect from /health.
+type healthRespParse struct {
+	Status     string          `json:"status"`
+	Subsystems map[string]bool `json:"subsystems"`
+}
+
+// callHealth invokes the /health handler against the given proxy and returns
+// the HTTP status plus parsed body. Uses ServeMux directly to avoid a real
+// listener.
+func callHealth(t *testing.T, p *Proxy) (int, healthRespParse) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", p.handleHealth)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	var body healthRespParse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode /health body: %v (raw=%s)", err, rec.Body.String())
+	}
+	return rec.Code, body
+}
+
+// newWatchdogProxy builds a proxy with cfg.HealthWatchdog.Enabled defaulted
+// to true and a custom-constructed watchdog whose probe is supplied by the
+// caller. The interval is small (50ms) so tests can advance the watchdog
+// past staleness quickly. Returns the proxy plus a cleanup func that
+// guarantees the watchdog goroutine exits.
+func newWatchdogProxy(t *testing.T, probe health.Probe) (*Proxy, func()) {
+	t.Helper()
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.APIAllowlist = nil
+	cfg.HealthWatchdog.IntervalSeconds = 1 // 1s interval, 3s threshold
+
+	wd, err := health.New(health.Config{
+		Interval: 50 * time.Millisecond,
+		Probe:    probe,
+	})
+	if err != nil {
+		t.Fatalf("health.New: %v", err)
+	}
+
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	p, err := New(cfg, logger, sc, metrics.New(), WithHealthWatchdog(wd))
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	wd.Start(ctx)
+
+	cleanup := func() {
+		cancel()
+		p.Close()
+	}
+	return p, cleanup
+}
+
+// TestHealth_DefaultProbeReportsHealthy verifies the live scanner-probe path:
+// after construction the watchdog's first /health call has a stale scanner
+// heartbeat (no Scan happened yet under fast-test interval), the default probe
+// runs, scans the synthetic fail-fast URL, returns nil, and /health is 200.
+//
+// This is the inverse of the deadlock test: with a real scanner the probe
+// completes well within the interval/2 budget.
+func TestHealth_DefaultProbeReportsHealthy(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.APIAllowlist = nil
+	cfg.HealthWatchdog.IntervalSeconds = 1
+
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	defer p.Close()
+	p.wd.Start(ctx)
+
+	code, body := callHealth(t, p)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%+v)", code, body)
+	}
+	if body.Status != healthStatusHealthy {
+		t.Errorf("expected status=healthy, got %q", body.Status)
+	}
+	for _, name := range []string{"scanner", "config", "session", "killswitch", "watchdog"} {
+		if !body.Subsystems[name] {
+			t.Errorf("subsystem %q expected true, got false", name)
+		}
+	}
+}
+
+// TestHealth_ScannerDeadlock_FlipsTo503 is the kickoff-spec integration test.
+// A probe that blocks until ctx is cancelled simulates a scanner whose Scan
+// won't return. The watchdog's interval/2 timeout fires, probe returns
+// ctx.Err(), Snapshot marks scanner unhealthy, and /health flips to 503.
+//
+// The "within the check interval" guarantee in the kickoff is satisfied
+// because the probe runs synchronously inside Snapshot under an interval/2
+// deadline; one /health call after the scanner heartbeat ages out is
+// sufficient to surface the wedge.
+func TestHealth_ScannerDeadlock_FlipsTo503(t *testing.T) {
+	t.Parallel()
+
+	hang := func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	p, cleanup := newWatchdogProxy(t, hang)
+	defer cleanup()
+
+	// Force the scanner heartbeat into the stale region. Construction-time
+	// seed bumps it; we age it deterministically by reaching into the
+	// watchdog directly. This avoids time.Sleep flakes under CI load.
+	p.wd.AgeScannerForTest(time.Hour)
+
+	code, body := callHealth(t, p)
+	if code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d (body=%+v)", code, body)
+	}
+	if body.Status != healthStatusUnhealthy {
+		t.Errorf("expected status=unhealthy, got %q", body.Status)
+	}
+	if body.Subsystems["scanner"] {
+		t.Errorf("expected subsystems.scanner=false, got true (body=%+v)", body)
+	}
+	// Other subsystems should remain healthy — wedge is isolated.
+	if !body.Subsystems["config"] || !body.Subsystems["session"] ||
+		!body.Subsystems["killswitch"] || !body.Subsystems["watchdog"] {
+		t.Errorf("unexpected cascading unhealth: %+v", body.Subsystems)
+	}
+}
+
+// TestHealth_ProbeRecovers_RebeatsToHealthy verifies the re-beat behavior:
+// once the probe returns nil after a stale period, the scanner heartbeat is
+// refreshed and /health returns 200 again on the next call.
+func TestHealth_ProbeRecovers_RebeatsToHealthy(t *testing.T) {
+	t.Parallel()
+
+	failNext := make(chan struct{}, 1)
+	probe := func(ctx context.Context) error {
+		select {
+		case <-failNext:
+			return context.DeadlineExceeded
+		default:
+			return nil
+		}
+	}
+	p, cleanup := newWatchdogProxy(t, probe)
+	defer cleanup()
+
+	// First /health: scanner stale → probe nil → re-beat → healthy.
+	p.wd.AgeScannerForTest(time.Hour)
+	code, body := callHealth(t, p)
+	if code != http.StatusOK {
+		t.Fatalf("after recovery expected 200, got %d (body=%+v)", code, body)
+	}
+	if !body.Subsystems["scanner"] {
+		t.Fatalf("expected scanner=true after re-beat")
+	}
+
+	// Now arm the probe to fail and age the scanner again — should flip to 503.
+	failNext <- struct{}{}
+	p.wd.AgeScannerForTest(time.Hour)
+	code, body = callHealth(t, p)
+	if code != http.StatusServiceUnavailable {
+		t.Fatalf("after probe-fails-arm expected 503, got %d (body=%+v)", code, body)
+	}
+	if body.Subsystems["scanner"] {
+		t.Errorf("expected scanner=false on probe failure")
+	}
+}
+
+// TestScannerProbe_NilPointers_ReturnsError covers the two early-return
+// branches in scannerProbe: a nil scannerPtr or nil cfgPtr both yield a
+// non-nil error so the watchdog marks scanner unhealthy.
+func TestScannerProbe_NilPointers_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.APIAllowlist = nil
+
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	defer p.Close()
+
+	t.Run("nil scanner pointer", func(t *testing.T) {
+		var emptyScanner *scanner.Scanner
+		p.scannerPtr.Store(emptyScanner)
+		t.Cleanup(func() { p.scannerPtr.Store(sc) })
+
+		if err := p.scannerProbe(context.Background()); err == nil {
+			t.Fatal("expected error on nil scanner, got nil")
+		}
+	})
+
+	t.Run("nil config pointer", func(t *testing.T) {
+		var emptyCfg *config.Config
+		p.cfgPtr.Store(emptyCfg)
+		t.Cleanup(func() { p.cfgPtr.Store(cfg) })
+
+		if err := p.scannerProbe(context.Background()); err == nil {
+			t.Fatal("expected error on nil config, got nil")
+		}
+	})
+
+	t.Run("live scanner returns nil", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := p.scannerProbe(ctx); err != nil {
+			t.Fatalf("expected nil error from live scanner probe, got %v", err)
+		}
+	})
+}
+
+func TestHealth_ConfigPointerNil_Returns503NotPanic(t *testing.T) {
+	t.Parallel()
+
+	p, cleanup := newWatchdogProxy(t, func(context.Context) error {
+		t.Fatal("probe must not run when config pointer is nil")
+		return nil
+	})
+	defer cleanup()
+
+	var nilCfg *config.Config
+	p.cfgPtr.Store(nilCfg)
+
+	code, body := callHealth(t, p)
+	if code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d (body=%+v)", code, body)
+	}
+	if body.Status != healthStatusUnhealthy {
+		t.Fatalf("expected status=unhealthy, got %q", body.Status)
+	}
+	if body.Subsystems["config"] {
+		t.Fatalf("expected config=false, got %+v", body.Subsystems)
+	}
+	if body.Subsystems["scanner"] {
+		t.Fatalf("expected scanner=false when config is nil, got %+v", body.Subsystems)
+	}
+}
+
+func TestHealth_ReloadedScannerKeepsHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	p, cleanup := newWatchdogProxy(t, func(context.Context) error {
+		return context.DeadlineExceeded
+	})
+	defer cleanup()
+
+	cfg := p.CurrentConfig().Clone()
+	newSc := scanner.New(cfg)
+	if ok := p.Reload(cfg, newSc); !ok {
+		t.Fatal("Reload returned false")
+	}
+
+	p.wd.AgeScannerForTest(time.Hour)
+	_ = newSc.Scan(context.Background(), "ftp://heartbeat-after-reload.invalid/")
+
+	code, body := callHealth(t, p)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200 after reloaded scanner heartbeat, got %d (body=%+v)", code, body)
+	}
+	if !body.Subsystems["scanner"] {
+		t.Fatalf("expected scanner=true after reloaded scanner Scan heartbeat, got %+v", body.Subsystems)
+	}
+}
+
+// TestHealth_WatchdogDisabled_LegacyShape verifies that turning the watchdog
+// off in config restores the pre-watchdog response (no `subsystems` key, 200
+// regardless of subsystem state).
+func TestHealth_WatchdogDisabled_LegacyShape(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.APIAllowlist = nil
+	cfg.HealthWatchdog.Enabled = false
+
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	defer p.Close()
+	if p.wd != nil {
+		t.Fatalf("expected nil watchdog when disabled, got %v", p.wd)
+	}
+
+	code, body := callHealth(t, p)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if body.Status != healthStatusHealthy {
+		t.Errorf("expected status=healthy, got %q", body.Status)
+	}
+	if body.Subsystems != nil {
+		t.Errorf("expected subsystems omitted when watchdog disabled, got %+v", body.Subsystems)
+	}
+}

--- a/internal/proxy/health_watchdog_test.go
+++ b/internal/proxy/health_watchdog_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,7 +52,8 @@ func newWatchdogProxy(t *testing.T, probe health.Probe) (*Proxy, func()) {
 	cfg := config.Defaults()
 	cfg.Internal = nil
 	cfg.APIAllowlist = nil
-	cfg.HealthWatchdog.IntervalSeconds = 1 // 1s interval, 3s threshold
+	cfg.HealthWatchdog.IntervalSeconds = 1     // 1s interval, 3s threshold
+	cfg.HealthWatchdog.ExposeSubsystems = true // tests assert against subsystems map
 
 	wd, err := health.New(health.Config{
 		Interval: 50 * time.Millisecond,
@@ -91,6 +94,7 @@ func TestHealth_DefaultProbeReportsHealthy(t *testing.T) {
 	cfg.Internal = nil
 	cfg.APIAllowlist = nil
 	cfg.HealthWatchdog.IntervalSeconds = 1
+	cfg.HealthWatchdog.ExposeSubsystems = true // assert against subsystems map
 
 	logger := audit.NewNop()
 	sc := scanner.New(cfg)
@@ -244,6 +248,121 @@ func TestScannerProbe_NilPointers_ReturnsError(t *testing.T) {
 			t.Fatalf("expected nil error from live scanner probe, got %v", err)
 		}
 	})
+}
+
+// TestScannerProbe_SingleflightPreventsGoroutineLeak covers the singleflight
+// guard that stops /health from spawning a fresh probe goroutine on every
+// poll while the scanner is wedged. Without the guard an attacker (or a
+// noisy monitor) hitting unauthenticated /health repeatedly during a wedge
+// would accumulate unbounded leaked goroutines, turning the health endpoint
+// into a denial-of-service amplifier exactly when enforcement is already
+// degraded. After the fix, concurrent probes during a wedge return an
+// immediate error without launching a second scan goroutine.
+func TestScannerProbe_SingleflightPreventsGoroutineLeak(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.APIAllowlist = nil
+
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	defer p.Close()
+
+	// Simulate a wedged scan by pinning the inflight flag to true. The next
+	// scannerProbe call must short-circuit without spawning a goroutine.
+	if !p.probeInflight.CompareAndSwap(false, true) {
+		t.Fatal("probeInflight should start false")
+	}
+	t.Cleanup(func() { p.probeInflight.Store(false) })
+
+	gBefore := runtime.NumGoroutine()
+	for i := 0; i < 20; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		err := p.scannerProbe(ctx)
+		cancel()
+		if err == nil {
+			t.Fatalf("expected error while inflight, got nil")
+		}
+		if !strings.Contains(err.Error(), "in flight") {
+			t.Fatalf("expected 'in flight' error, got %v", err)
+		}
+	}
+	gAfter := runtime.NumGoroutine()
+	if gAfter > gBefore+2 {
+		t.Errorf("goroutines leaked under inflight contention: before=%d after=%d (want growth <= 2 for goroutine GC slack)", gBefore, gAfter)
+	}
+}
+
+// TestHealth_ExposeSubsystemsDefault_HidesMap covers the default-secure
+// behavior of /health: with HealthWatchdog.ExposeSubsystems left at its
+// false default, the per-subsystem boolean map MUST be omitted from the
+// response so unauthenticated callers cannot distinguish scanner-wedge
+// from config-failure from kill-switch wiring. The 503 status on wedge
+// is preserved unconditionally so external supervisors keep a clean
+// liveness signal.
+func TestHealth_ExposeSubsystemsDefault_HidesMap(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.APIAllowlist = nil
+	cfg.HealthWatchdog.IntervalSeconds = 1
+	// ExposeSubsystems default is false; do not set it.
+
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	defer p.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p.wd.Start(ctx)
+
+	code, body := callHealth(t, p)
+	if code != http.StatusOK {
+		t.Errorf("status = %d, want 200", code)
+	}
+	if len(body.Subsystems) != 0 {
+		t.Errorf("Subsystems must be omitted by default, got %+v", body.Subsystems)
+	}
+}
+
+// TestHealth_ExposeSubsystemsTrue_IncludesMapAnd503OnWedge confirms the
+// opt-in path still works: when the operator sets ExposeSubsystems=true
+// the per-subsystem map is present, AND a wedge still flips status to
+// 503 so the breakdown remains accurate diagnostic data on the trusted
+// network the operator chose to expose it on.
+func TestHealth_ExposeSubsystemsTrue_IncludesMapAnd503OnWedge(t *testing.T) {
+	t.Parallel()
+
+	hang := func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	p, cleanup := newWatchdogProxy(t, hang)
+	defer cleanup()
+
+	// Force the scanner heartbeat to look stale; the wedged probe will
+	// fail and flip scanner unhealthy.
+	p.wd.AgeScannerForTest(time.Hour)
+	code, body := callHealth(t, p)
+	if code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503 (subsystem unhealthy)", code)
+	}
+	if len(body.Subsystems) == 0 {
+		t.Fatalf("Subsystems must be present when ExposeSubsystems=true")
+	}
+	if body.Subsystems["scanner"] {
+		t.Errorf("expected scanner=false on wedge probe, got %+v", body.Subsystems)
+	}
 }
 
 func TestHealth_ConfigPointerNil_Returns503NotPanic(t *testing.T) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -306,6 +306,7 @@ type Proxy struct {
 	shieldEngine        *shield.Engine                    // browser shield HTML/JS rewriter (nil = not initialized)
 	frozenTools         *FrozenToolRegistry               // frozen tool inventories for airlock hard tier
 	wd                  *health.Watchdog                  // wedge-detection watchdog (nil = disabled)
+	probeInflight       atomic.Bool                       // singleflight guard for scannerProbe (prevents goroutine leak when scanner wedges)
 }
 
 // Option configures optional Proxy behavior.
@@ -1482,21 +1483,36 @@ func (p *Proxy) Close() {
 // did not complete within ctx's deadline (i.e. scanner is wedged) or if
 // scanner / config pointers are unavailable.
 //
-// The probe runs Scan in a goroutine because Scanner has internal
-// regex-matching paths that do not yield to context. If a regex pinpoints
-// the wedge, the probe goroutine leaks until the scan eventually returns;
-// that leak is bounded by /health call frequency and is the lesser harm
-// against a true deadlock blocking probe completion.
+// Singleflight: at most one probe goroutine exists at any time. The
+// scanner has internal regex-matching paths that do not yield to context,
+// so a wedge inside Scan cannot be cancelled and the goroutine outlives
+// the probe call. /health is unauthenticated and commonly polled by
+// external supervisors, so without this guard a stuck scanner would let
+// every poll spawn a fresh leaked goroutine and turn the health endpoint
+// into a denial-of-service amplifier exactly when the proxy is already
+// degraded. Concurrent callers while a probe is in flight return an
+// immediate error so the watchdog still reports the wedge without
+// queueing more work behind it.
 func (p *Proxy) scannerProbe(ctx context.Context) error {
+	if !p.probeInflight.CompareAndSwap(false, true) {
+		return errors.New("scanner probe already in flight (wedge suspected)")
+	}
 	sc := p.scannerPtr.Load()
 	if sc == nil {
+		p.probeInflight.Store(false)
 		return errors.New("scanner unavailable")
 	}
 	if cfg := p.cfgPtr.Load(); cfg == nil {
+		p.probeInflight.Store(false)
 		return errors.New("config unavailable")
 	}
 	done := make(chan struct{})
 	go func() {
+		// Clear the inflight flag only when Scan actually returns. If the
+		// scanner is wedged this goroutine outlives the caller; future
+		// /health calls will short-circuit on CompareAndSwap above and
+		// return the wedge error without spawning more goroutines.
+		defer p.probeInflight.Store(false)
 		defer close(done)
 		_ = sc.Scan(ctx, "ftp://wedge-probe.invalid/")
 	}()
@@ -3803,7 +3819,15 @@ func (p *Proxy) handleHealth(w http.ResponseWriter, r *http.Request) {
 			KillSwitchEnabled: killSwitchEnabled,
 			KillSwitchPresent: p.ks != nil,
 		})
-		resp.Subsystems = snap.Subsystems
+		// Always honor the overall liveness signal (status code + status
+		// string) so external supervisors get a clean 503 when any
+		// subsystem is unhealthy. Only attach the per-subsystem map when
+		// the operator has explicitly opted in via expose_subsystems; the
+		// breakdown is recon material for an unauthenticated caller and
+		// defaults off.
+		if cfg != nil && cfg.HealthWatchdog.ExposeSubsystems {
+			resp.Subsystems = snap.Subsystems
+		}
 		if !snap.Healthy {
 			resp.Status = healthStatusUnhealthy
 			status = http.StatusServiceUnavailable

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -36,6 +36,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/decide"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
+	"github.com/luckyPipewrench/pipelock/internal/health"
 	"github.com/luckyPipewrench/pipelock/internal/hitl"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/mcp"
@@ -304,6 +305,7 @@ type Proxy struct {
 	envelopeVerifierPtr atomic.Pointer[envelope.Verifier] // inbound mediation envelope verifier (nil = disabled)
 	shieldEngine        *shield.Engine                    // browser shield HTML/JS rewriter (nil = not initialized)
 	frozenTools         *FrozenToolRegistry               // frozen tool inventories for airlock hard tier
+	wd                  *health.Watchdog                  // wedge-detection watchdog (nil = disabled)
 }
 
 // Option configures optional Proxy behavior.
@@ -359,6 +361,15 @@ func WithEnvelopeEmitter(e *envelope.Emitter) Option {
 	return func(p *Proxy) { p.envelopeEmitterPtr.Store(e) }
 }
 
+// WithHealthWatchdog overrides the wedge-detection watchdog the proxy would
+// otherwise build from cfg.HealthWatchdog. Used by tests to inject a watchdog
+// with a controllable probe (e.g. one that hangs to simulate scanner
+// deadlock). Setting this implicitly opts in to watchdog wiring even if
+// cfg.HealthWatchdog.Enabled is false.
+func WithHealthWatchdog(wd *health.Watchdog) Option {
+	return func(p *Proxy) { p.wd = wd }
+}
+
 // FetchResponse is the JSON response returned by the /fetch endpoint.
 type FetchResponse struct {
 	URL         string `json:"url"`
@@ -389,6 +400,26 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 	}
 	p.cfgPtr.Store(cfg)
 	p.scannerPtr.Store(sc)
+
+	// Wedge-detection watchdog. Constructed when health_watchdog.enabled is
+	// true (the documented default), unless WithHealthWatchdog already
+	// installed a test override. The probe scans a synthetic fail-fast
+	// scheme through the live scanner with an Interval/2 budget; any
+	// non-nil error (including timeout) is treated as a wedge. Heartbeats
+	// from Scan() come via Scanner.SetHeartbeat below.
+	if cfg.HealthWatchdog.Enabled || p.wd != nil {
+		if p.wd == nil {
+			wd, wdErr := health.New(health.Config{
+				Interval: cfg.HealthWatchdog.IntervalDuration(),
+				Probe:    p.scannerProbe,
+			})
+			if wdErr != nil {
+				return nil, fmt.Errorf("health watchdog init: %w", wdErr)
+			}
+			p.wd = wd
+		}
+		p.installScannerHeartbeat(sc)
+	}
 
 	// Startup envelope wiring mirrors the reload lane: ensure an
 	// enabled envelope always has the canonical policy hash installed,
@@ -1215,6 +1246,10 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 
 	oldCfg := p.cfgPtr.Load()
 	p.cfgPtr.Store(cfg)
+	if p.wd != nil {
+		p.wd.BeatConfig()
+		p.installScannerHeartbeat(sc)
+	}
 
 	// Hot-reload the admin API bearer token so operators can rotate
 	// kill_switch.api_token (or the env override) without restarting.
@@ -1288,6 +1323,13 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 	// No separate UpdateConfigHash needed — emitter is always (re)created
 	// with the current cfg.Hash() when a signing key is configured.
 	return true
+}
+
+func (p *Proxy) installScannerHeartbeat(sc *scanner.Scanner) {
+	if p.wd == nil || sc == nil {
+		return
+	}
+	sc.SetHeartbeat(p.wd.BeatScanner)
 }
 
 // LoadCertCache creates or replaces the cert cache based on current config.
@@ -1411,6 +1453,9 @@ func (p *Proxy) updateCEEStats() {
 }
 
 func (p *Proxy) Close() {
+	if p.wd != nil {
+		p.wd.Stop()
+	}
 	if sm := p.sessionMgrPtr.Load(); sm != nil {
 		sm.Close()
 	}
@@ -1428,6 +1473,38 @@ func (p *Proxy) Close() {
 	}
 	if p.tlsTransport != nil {
 		p.tlsTransport.CloseIdleConnections()
+	}
+}
+
+// scannerProbe is the synthetic scanner check the watchdog runs when the
+// scanner heartbeat is stale. It uses a fail-fast scheme that the scanner
+// rejects without DNS resolution. Returns a non-nil error if the scan
+// did not complete within ctx's deadline (i.e. scanner is wedged) or if
+// scanner / config pointers are unavailable.
+//
+// The probe runs Scan in a goroutine because Scanner has internal
+// regex-matching paths that do not yield to context. If a regex pinpoints
+// the wedge, the probe goroutine leaks until the scan eventually returns;
+// that leak is bounded by /health call frequency and is the lesser harm
+// against a true deadlock blocking probe completion.
+func (p *Proxy) scannerProbe(ctx context.Context) error {
+	sc := p.scannerPtr.Load()
+	if sc == nil {
+		return errors.New("scanner unavailable")
+	}
+	if cfg := p.cfgPtr.Load(); cfg == nil {
+		return errors.New("config unavailable")
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = sc.Scan(ctx, "ftp://wedge-probe.invalid/")
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
@@ -2200,6 +2277,10 @@ func (p *Proxy) Handler() http.Handler {
 // is cancelled or the server encounters a fatal error.
 func (p *Proxy) Start(ctx context.Context) error {
 	cfg := p.cfgPtr.Load()
+
+	if p.wd != nil {
+		p.wd.Start(ctx)
+	}
 
 	handler := p.buildHandler(p.buildMux())
 
@@ -3645,38 +3726,55 @@ func extractRawURLParam(rawQuery string) string {
 }
 
 // healthResponse is the JSON response returned by the /health endpoint.
+//
+// Status is "healthy" (HTTP 200) or "unhealthy" (HTTP 503). When the wedge
+// detection watchdog is enabled, Subsystems carries a per-subsystem boolean
+// map; when disabled, Subsystems is omitted and Status is always "healthy"
+// (preserving the legacy shape).
 type healthResponse struct {
-	Status                 string  `json:"status"`
-	Version                string  `json:"version"`
-	Mode                   string  `json:"mode"`
-	UptimeSeconds          float64 `json:"uptime_seconds"`
-	DLPPatterns            int     `json:"dlp_patterns"`
-	ResponseScanEnabled    bool    `json:"response_scan_enabled"`
-	GitProtectionEnabled   bool    `json:"git_protection_enabled"`
-	RateLimitEnabled       bool    `json:"rate_limit_enabled"`
-	ForwardProxyEnabled    bool    `json:"forward_proxy_enabled"`
-	WebSocketProxyEnabled  bool    `json:"websocket_proxy_enabled"`
-	RequestBodyScanEnabled bool    `json:"request_body_scan_enabled"`
-	TLSInterceptionEnabled bool    `json:"tls_interception_enabled"`
-	KillSwitchActive       bool    `json:"kill_switch_active"`
+	Status                 string          `json:"status"`
+	Version                string          `json:"version"`
+	Mode                   string          `json:"mode"`
+	UptimeSeconds          float64         `json:"uptime_seconds"`
+	DLPPatterns            int             `json:"dlp_patterns"`
+	ResponseScanEnabled    bool            `json:"response_scan_enabled"`
+	GitProtectionEnabled   bool            `json:"git_protection_enabled"`
+	RateLimitEnabled       bool            `json:"rate_limit_enabled"`
+	ForwardProxyEnabled    bool            `json:"forward_proxy_enabled"`
+	WebSocketProxyEnabled  bool            `json:"websocket_proxy_enabled"`
+	RequestBodyScanEnabled bool            `json:"request_body_scan_enabled"`
+	TLSInterceptionEnabled bool            `json:"tls_interception_enabled"`
+	KillSwitchActive       bool            `json:"kill_switch_active"`
+	Subsystems             map[string]bool `json:"subsystems,omitempty"`
 }
 
-// handleHealth returns proxy health status including uptime and feature flags.
-func (p *Proxy) handleHealth(w http.ResponseWriter, _ *http.Request) {
+const (
+	healthStatusHealthy   = "healthy"
+	healthStatusUnhealthy = "unhealthy"
+)
+
+// handleHealth returns proxy health status including uptime, feature flags,
+// and (when the watchdog is enabled) a per-subsystem liveness map. Returns
+// HTTP 503 Service Unavailable when any subsystem is unhealthy so external
+// supervisors (k8s readiness probes, KiloClaw controller, etc.) get a clean
+// signal even if the HTTP handler itself is fine.
+func (p *Proxy) handleHealth(w http.ResponseWriter, r *http.Request) {
 	cfg := p.cfgPtr.Load()
 	resp := healthResponse{
-		Status:                 "healthy",
-		Version:                Version,
-		Mode:                   cfg.Mode,
-		UptimeSeconds:          time.Since(p.startTime).Seconds(),
-		DLPPatterns:            len(cfg.DLP.Patterns),
-		ResponseScanEnabled:    cfg.ResponseScanning.Enabled,
-		GitProtectionEnabled:   cfg.GitProtection.Enabled,
-		RateLimitEnabled:       cfg.FetchProxy.Monitoring.MaxReqPerMinute > 0,
-		ForwardProxyEnabled:    cfg.ForwardProxy.Enabled,
-		WebSocketProxyEnabled:  cfg.WebSocketProxy.Enabled,
-		RequestBodyScanEnabled: cfg.RequestBodyScanning.Enabled,
-		TLSInterceptionEnabled: cfg.TLSInterception.Enabled,
+		Status:        healthStatusHealthy,
+		Version:       Version,
+		UptimeSeconds: time.Since(p.startTime).Seconds(),
+	}
+	if cfg != nil {
+		resp.Mode = cfg.Mode
+		resp.DLPPatterns = len(cfg.DLP.Patterns)
+		resp.ResponseScanEnabled = cfg.ResponseScanning.Enabled
+		resp.GitProtectionEnabled = cfg.GitProtection.Enabled
+		resp.RateLimitEnabled = cfg.FetchProxy.Monitoring.MaxReqPerMinute > 0
+		resp.ForwardProxyEnabled = cfg.ForwardProxy.Enabled
+		resp.WebSocketProxyEnabled = cfg.WebSocketProxy.Enabled
+		resp.RequestBodyScanEnabled = cfg.RequestBodyScanning.Enabled
+		resp.TLSInterceptionEnabled = cfg.TLSInterception.Enabled
 	}
 	if p.ks != nil {
 		// Read-only kill switch status — no auth needed. Lets operators
@@ -3689,7 +3787,29 @@ func (p *Proxy) handleHealth(w http.ResponseWriter, _ *http.Request) {
 			}
 		}
 	}
-	writeJSON(w, http.StatusOK, resp)
+
+	status := http.StatusOK
+	if p.wd != nil {
+		var sessionEnabled, killSwitchEnabled bool
+		if cfg != nil {
+			sessionEnabled = cfg.SessionProfiling.Enabled
+			killSwitchEnabled = cfg.KillSwitch.Enabled
+		}
+		snap := p.wd.Snapshot(r.Context(), health.SnapshotInput{
+			ScannerPtrAlive:   p.scannerPtr.Load() != nil,
+			ConfigPtrAlive:    cfg != nil,
+			SessionEnabled:    sessionEnabled,
+			SessionPtrAlive:   p.sessionMgrPtr.Load() != nil,
+			KillSwitchEnabled: killSwitchEnabled,
+			KillSwitchPresent: p.ks != nil,
+		})
+		resp.Subsystems = snap.Subsystems
+		if !snap.Healthy {
+			resp.Status = healthStatusUnhealthy
+			status = http.StatusServiceUnavailable
+		}
+	}
+	writeJSON(w, status, resp)
 }
 
 func writeJSON(w http.ResponseWriter, status int, data any) {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -701,7 +701,18 @@ func HintForBlock(r *Result) string {
 // Scan checks a URL against all scanners and returns the result.
 // Blocked results include a Hint field with actionable guidance.
 // Fail-closed: nil or already-cancelled contexts are rejected before scanning.
+//
+// Heartbeat fires on EVERY return (including the early fail-closed path
+// for nil/cancelled contexts) via defer. The watchdog interprets the
+// heartbeat as "Scan is making progress, not wedged in a regex"; a fast
+// reject is still progress and must register so a flood of cancelled-
+// context probes does not falsely trip the wedge detector.
 func (s *Scanner) Scan(ctx context.Context, rawURL string) Result {
+	defer func() {
+		if h := s.heartbeat.Load(); h != nil {
+			h.fn()
+		}
+	}()
 	if ctx == nil || ctx.Err() != nil {
 		return Result{
 			Allowed: false,
@@ -714,9 +725,6 @@ func (s *Scanner) Scan(ctx context.Context, rawURL string) Result {
 	r := s.scan(ctx, rawURL)
 	if !r.Allowed && r.Hint == "" {
 		r.Hint = HintForBlock(&r)
-	}
-	if h := s.heartbeat.Load(); h != nil {
-		h.fn()
 	}
 	return r
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -184,6 +184,26 @@ type Scanner struct {
 	closed  bool
 	inUse   sync.WaitGroup
 	drained atomic.Bool
+
+	// heartbeat is invoked at the end of every Scan() to feed the
+	// wedge-detection watchdog. atomic.Pointer keeps SetHeartbeat
+	// race-safe even though production wires it before Start.
+	heartbeat atomic.Pointer[heartbeatFn]
+}
+
+// heartbeatFn wraps a func() so it can live behind atomic.Pointer (which
+// requires a concrete pointer-to-struct, not a pointer-to-function).
+type heartbeatFn struct{ fn func() }
+
+// SetHeartbeat installs a callback invoked after every successful Scan.
+// Pass nil to detach. Cheap; safe to call concurrently with Scan because
+// the holder is read via atomic.Pointer.
+func (s *Scanner) SetHeartbeat(fn func()) {
+	if fn == nil {
+		s.heartbeat.Store(nil)
+		return
+	}
+	s.heartbeat.Store(&heartbeatFn{fn: fn})
 }
 
 // scannerCloseDrainTimeout caps how long Close() waits for in-flight scans
@@ -694,6 +714,9 @@ func (s *Scanner) Scan(ctx context.Context, rawURL string) Result {
 	r := s.scan(ctx, rawURL)
 	if !r.Allowed && r.Hint == "" {
 		r.Hint = HintForBlock(&r)
+	}
+	if h := s.heartbeat.Load(); h != nil {
+		h.fn()
 	}
 	return r
 }

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -4256,6 +4256,41 @@ func TestScan_NilContext(t *testing.T) {
 	}
 }
 
+// TestScan_HeartbeatFiresOnEarlyReturn covers the deferred heartbeat
+// added so the wedge-detection watchdog sees activity even when Scan
+// returns through the fail-closed nil/cancelled-context branch. Before
+// the deferred form, the early return left the heartbeat unfired and a
+// flood of cancelled-context probes (or any short-circuit path that
+// might be added later) could let the watchdog falsely conclude the
+// scanner was wedged while it was actually rejecting cleanly.
+func TestScan_HeartbeatFiresOnEarlyReturn(t *testing.T) {
+	sc := New(testConfig())
+	defer sc.Close()
+
+	var beats int
+	sc.SetHeartbeat(func() { beats++ })
+
+	// Cancelled context: hits the early-return branch before s.scan.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = sc.Scan(ctx, "https://example.com/test")
+	if beats != 1 {
+		t.Errorf("heartbeat after cancelled-context early return = %d, want 1", beats)
+	}
+
+	// Nil context: also hits the early-return branch.
+	_ = sc.Scan(nil, "https://example.com/test") //nolint:staticcheck // intentional nil context test
+	if beats != 2 {
+		t.Errorf("heartbeat after nil-context early return = %d, want 2", beats)
+	}
+
+	// Normal scan path: still fires once per scan.
+	_ = sc.Scan(context.Background(), "https://example.com/test")
+	if beats != 3 {
+		t.Errorf("heartbeat after normal scan = %d, want 3", beats)
+	}
+}
+
 func TestScan_CanceledContextWithSSRFDisabled(t *testing.T) {
 	cfg := testConfig() // cfg.Internal = nil disables SSRF
 	sc := New(cfg)


### PR DESCRIPTION
## Summary

`/health` previously returned 200 as long as the HTTP handler itself responded. A scanner deadlock, config-reload race, or dead session-manager goroutine left external supervisors blind to the wedge. This adds an internal `health` package with hybrid wedge detection and flips `/health` to HTTP 503 when any tracked subsystem is unhealthy.

## Detection model

- **Passive heartbeats** are the cheap normal-path signal: Scanner bumps an `atomic.Int64` on every `Scan()` completion. One atomic store per operation.
- **Bounded synthetic probe** runs only when the scanner heartbeat is stale. The probe scans a fail-fast scheme URL through the live scanner under an `interval/2` deadline. Idle systems re-beat on success and do not flag false positives; only a true wedge surfaces 503.
- **Self-heartbeat** on the watchdog goroutine. If the goroutine itself dies, `/health` flips even when other subsystems look fine.
- **Structural presence** for config, session, and killswitch. Each is healthy when disabled OR when its live pointer is wired.

## Response shape

Adds a `subsystems` map to the existing `/health` JSON; existing top-level fields preserved. When the watchdog is disabled, `subsystems` is omitted (legacy shape). Status is 200 when all subsystems are true, 503 otherwise.

## Configuration

```
health_watchdog:
  enabled: true
  interval_seconds: 2
```

Settings are operational, not policy: changes do not rotate the canonical policy hash. Reload logs a warning that watchdog changes require restart.

## Files

internal/health/{watchdog.go,watchdog_test.go} (new package), internal/proxy/{proxy.go,health_watchdog_test.go}, internal/scanner/scanner.go, internal/config/{schema.go,defaults.go,normalize.go,canonical.go,reloadwarn.go,health_watchdog_test.go}, docs/guides/health.md.
