### PR TITLE
fix(capture,config): SessionID empty + caller-side metadata + race + e2e regression test

### DIFF
--- a/internal/capture/loader.go
+++ b/internal/capture/loader.go
@@ -32,6 +32,8 @@ type ReplayOptions struct {
 	EscrowPrivateKey []byte
 	// Contract enables contract-aware replay for supported surfaces.
 	Contract *contract.Contract
+	// SessionFilter optionally limits replay to matching session directory names.
+	SessionFilter func(string) bool
 }
 
 type replayEscrowKey struct {
@@ -98,9 +100,13 @@ func LoadAndReplayWithOptions(cfg *config.Config, sessionsDir string, opts Repla
 	// sessions are processed in alphabetical order by session ID.
 	var sessionNames []string
 	for _, de := range dirEntries {
-		if de.IsDir() && de.Name() != metaSessionID {
-			sessionNames = append(sessionNames, de.Name())
+		if !de.IsDir() || de.Name() == metaSessionID {
+			continue
 		}
+		if opts.SessionFilter != nil && !opts.SessionFilter(de.Name()) {
+			continue
+		}
+		sessionNames = append(sessionNames, de.Name())
 	}
 	sort.Strings(sessionNames)
 

--- a/internal/capture/loader.go
+++ b/internal/capture/loader.go
@@ -32,8 +32,12 @@ type ReplayOptions struct {
 	EscrowPrivateKey []byte
 	// Contract enables contract-aware replay for supported surfaces.
 	Contract *contract.Contract
-	// SessionFilter optionally limits replay to matching session directory names.
-	SessionFilter func(string) bool
+	// SessionFilter optionally limits replay to matching session directories.
+	// The filter receives the session directory's base name and absolute path
+	// so callers can perform content-level validation (e.g. verifying the
+	// embedded agent matches the requested agent) rather than trusting the
+	// directory name alone.
+	SessionFilter func(name, sessionDir string) bool
 }
 
 type replayEscrowKey struct {
@@ -103,7 +107,7 @@ func LoadAndReplayWithOptions(cfg *config.Config, sessionsDir string, opts Repla
 		if !de.IsDir() || de.Name() == metaSessionID {
 			continue
 		}
-		if opts.SessionFilter != nil && !opts.SessionFilter(de.Name()) {
+		if opts.SessionFilter != nil && !opts.SessionFilter(de.Name(), filepath.Join(sessionsDir, de.Name())) {
 			continue
 		}
 		sessionNames = append(sessionNames, de.Name())

--- a/internal/capture/types.go
+++ b/internal/capture/types.go
@@ -112,6 +112,12 @@ type CaptureSummary struct {
 
 	// Agent is the agent profile name, if agents are enabled.
 	Agent string `json:"agent,omitempty"`
+	// SessionIDOriginal preserves the unsanitized logical session identity
+	// when the on-disk session directory name had to be hashed (path-unsafe
+	// characters or overlength). Empty when the directory name equals the
+	// logical key. Lets audit trace an opaque "capture-<hex>" or
+	// "mcp-<hex>" session back to its self-attested agent identity.
+	SessionIDOriginal string `json:"session_id_original,omitempty"`
 	// Profile is the resolved config profile name.
 	Profile string `json:"profile,omitempty"`
 	// ActionClass is the session-level action verb (read, browse, summarize,
@@ -253,10 +259,14 @@ type URLVerdictRecord struct {
 	Subsurface string
 	Transport  string
 	SessionID  string
-	RequestID  string
-	ConfigHash string
-	Agent      string
-	Profile    string
+	// SessionIDOriginal preserves the unsanitized logical session key when
+	// SessionID was hashed for filesystem safety. Equal to SessionID when no
+	// hashing happened. Stamped into CaptureSummary so audit can correlate.
+	SessionIDOriginal string
+	RequestID         string
+	ConfigHash        string
+	Agent             string
+	Profile           string
 	// ActionClass is the session-level action verb (e.g. session.ActionClassRead.
 	// String() == "read") at scan time, populated by callers that classify
 	// inline. Empty string means the call site did not classify; the writer
@@ -277,10 +287,14 @@ type ResponseVerdictRecord struct {
 	Subsurface string
 	Transport  string
 	SessionID  string
-	RequestID  string
-	ConfigHash string
-	Agent      string
-	Profile    string
+	// SessionIDOriginal preserves the unsanitized logical session key when
+	// SessionID was hashed for filesystem safety. Equal to SessionID when no
+	// hashing happened. Stamped into CaptureSummary so audit can correlate.
+	SessionIDOriginal string
+	RequestID         string
+	ConfigHash        string
+	Agent             string
+	Profile           string
 	// ActionClass is the session-level action verb (e.g. session.ActionClassRead.
 	// String() == "read") at scan time, populated by callers that classify
 	// inline. Empty string means the call site did not classify; the writer
@@ -303,10 +317,14 @@ type DLPVerdictRecord struct {
 	Subsurface string
 	Transport  string
 	SessionID  string
-	RequestID  string
-	ConfigHash string
-	Agent      string
-	Profile    string
+	// SessionIDOriginal preserves the unsanitized logical session key when
+	// SessionID was hashed for filesystem safety. Equal to SessionID when no
+	// hashing happened. Stamped into CaptureSummary so audit can correlate.
+	SessionIDOriginal string
+	RequestID         string
+	ConfigHash        string
+	Agent             string
+	Profile           string
 	// ActionClass is the session-level action verb (e.g. session.ActionClassRead.
 	// String() == "read") at scan time, populated by callers that classify
 	// inline. Empty string means the call site did not classify; the writer
@@ -329,10 +347,14 @@ type CEERecord struct {
 	Subsurface string
 	Transport  string
 	SessionID  string
-	RequestID  string
-	ConfigHash string
-	Agent      string
-	Profile    string
+	// SessionIDOriginal preserves the unsanitized logical session key when
+	// SessionID was hashed for filesystem safety. Equal to SessionID when no
+	// hashing happened. Stamped into CaptureSummary so audit can correlate.
+	SessionIDOriginal string
+	RequestID         string
+	ConfigHash        string
+	Agent             string
+	Profile           string
 	// ActionClass is the session-level action verb (e.g. session.ActionClassRead.
 	// String() == "read") at scan time, populated by callers that classify
 	// inline. Empty string means the call site did not classify; the writer
@@ -355,10 +377,14 @@ type ToolPolicyRecord struct {
 	Subsurface string
 	Transport  string
 	SessionID  string
-	RequestID  string
-	ConfigHash string
-	Agent      string
-	Profile    string
+	// SessionIDOriginal preserves the unsanitized logical session key when
+	// SessionID was hashed for filesystem safety. Equal to SessionID when no
+	// hashing happened. Stamped into CaptureSummary so audit can correlate.
+	SessionIDOriginal string
+	RequestID         string
+	ConfigHash        string
+	Agent             string
+	Profile           string
 	// ActionClass is the session-level action verb (e.g. session.ActionClassRead.
 	// String() == "read") at scan time, populated by callers that classify
 	// inline. Empty string means the call site did not classify; the writer
@@ -381,10 +407,14 @@ type ToolScanRecord struct {
 	Subsurface string
 	Transport  string
 	SessionID  string
-	RequestID  string
-	ConfigHash string
-	Agent      string
-	Profile    string
+	// SessionIDOriginal preserves the unsanitized logical session key when
+	// SessionID was hashed for filesystem safety. Equal to SessionID when no
+	// hashing happened. Stamped into CaptureSummary so audit can correlate.
+	SessionIDOriginal string
+	RequestID         string
+	ConfigHash        string
+	Agent             string
+	Profile           string
 	// ActionClass is the session-level action verb (e.g. session.ActionClassRead.
 	// String() == "read") at scan time, populated by callers that classify
 	// inline. Empty string means the call site did not classify; the writer

--- a/internal/capture/types.go
+++ b/internal/capture/types.go
@@ -15,6 +15,7 @@ const CaptureSchemaV1 = 1
 
 // Surface constants identify which proxy layer produced a capture entry.
 const (
+	ActionAllow       = "allow"
 	SurfaceURL        = "url"
 	SurfaceResponse   = "response"
 	SurfaceDLP        = "dlp"

--- a/internal/capture/writer.go
+++ b/internal/capture/writer.go
@@ -389,6 +389,17 @@ func (w *Writer) buildSummary(
 	return s
 }
 
+// normalizeEffectiveAction returns ActionAllow when the input is empty,
+// matching the writer's defensive default. Observe* call sites use this
+// before constructing recorder.Entry.Summary so the Summary tail and the
+// CaptureSummary.EffectiveAction field always agree on the same value.
+func normalizeEffectiveAction(s string) string {
+	if s == "" {
+		return ActionAllow
+	}
+	return s
+}
+
 // ObserveURLVerdict implements CaptureObserver for URL pipeline verdicts.
 func (w *Writer) ObserveURLVerdict(_ context.Context, rec *URLVerdictRecord) {
 	// URL verdicts have no separate scanner input; the URL is the input.
@@ -400,14 +411,14 @@ func (w *Writer) ObserveURLVerdict(_ context.Context, rec *URLVerdictRecord) {
 			Type:      EntryTypeCapture,
 			EventKind: captureEventKind(SurfaceURL),
 			Transport: rec.Transport,
-			Summary:   rec.Subsurface + ":" + rec.EffectiveAction,
+			Summary:   rec.Subsurface + ":" + normalizeEffectiveAction(rec.EffectiveAction),
 		},
 		summary: w.buildSummary(
 			SurfaceURL, rec.Subsurface, rec.ConfigHash, rec.Agent, rec.Profile,
 			rec.ActionClass,
 			scannerInput, true, TransformRaw, "", nil,
 			rec.Request, rec.RawFindings, rec.EffectiveFindings,
-			rec.EffectiveAction, rec.Outcome, rec.SkipReason,
+			normalizeEffectiveAction(rec.EffectiveAction), rec.Outcome, rec.SkipReason,
 		),
 		scannerInput: scannerInput,
 	})
@@ -423,14 +434,14 @@ func (w *Writer) ObserveResponseVerdict(_ context.Context, rec *ResponseVerdictR
 			Type:      EntryTypeCapture,
 			EventKind: captureEventKind(SurfaceResponse),
 			Transport: rec.Transport,
-			Summary:   rec.Subsurface + ":" + rec.EffectiveAction,
+			Summary:   rec.Subsurface + ":" + normalizeEffectiveAction(rec.EffectiveAction),
 		},
 		summary: w.buildSummary(
 			SurfaceResponse, rec.Subsurface, rec.ConfigHash, rec.Agent, rec.Profile,
 			rec.ActionClass,
 			"", false, rec.TransformKind, wire, nil,
 			rec.Request, rec.RawFindings, rec.EffectiveFindings,
-			rec.EffectiveAction, rec.Outcome, rec.SkipReason,
+			normalizeEffectiveAction(rec.EffectiveAction), rec.Outcome, rec.SkipReason,
 		),
 		wirePayload: wire,
 	})
@@ -445,14 +456,14 @@ func (w *Writer) ObserveDLPVerdict(_ context.Context, rec *DLPVerdictRecord) {
 			Type:      EntryTypeCapture,
 			EventKind: captureEventKind(SurfaceDLP),
 			Transport: rec.Transport,
-			Summary:   rec.Subsurface + ":" + rec.EffectiveAction,
+			Summary:   rec.Subsurface + ":" + normalizeEffectiveAction(rec.EffectiveAction),
 		},
 		summary: w.buildSummary(
 			SurfaceDLP, rec.Subsurface, rec.ConfigHash, rec.Agent, rec.Profile,
 			rec.ActionClass,
 			rec.ScannerInput, false, rec.TransformKind, "", nil,
 			rec.Request, rec.RawFindings, rec.EffectiveFindings,
-			rec.EffectiveAction, rec.Outcome, rec.SkipReason,
+			normalizeEffectiveAction(rec.EffectiveAction), rec.Outcome, rec.SkipReason,
 		),
 		scannerInput: rec.ScannerInput,
 	})
@@ -467,14 +478,14 @@ func (w *Writer) ObserveCEEVerdict(_ context.Context, rec *CEERecord) {
 			Type:      EntryTypeCapture,
 			EventKind: captureEventKind(SurfaceCEE),
 			Transport: rec.Transport,
-			Summary:   rec.Subsurface + ":" + rec.EffectiveAction,
+			Summary:   rec.Subsurface + ":" + normalizeEffectiveAction(rec.EffectiveAction),
 		},
 		summary: w.buildSummary(
 			SurfaceCEE, rec.Subsurface, rec.ConfigHash, rec.Agent, rec.Profile,
 			rec.ActionClass,
 			rec.ScannerInput, false, rec.TransformKind, "", nil,
 			rec.Request, rec.RawFindings, rec.EffectiveFindings,
-			rec.EffectiveAction, rec.Outcome, rec.SkipReason,
+			normalizeEffectiveAction(rec.EffectiveAction), rec.Outcome, rec.SkipReason,
 		),
 		scannerInput: rec.ScannerInput,
 	})
@@ -489,14 +500,14 @@ func (w *Writer) ObserveToolPolicyVerdict(_ context.Context, rec *ToolPolicyReco
 			Type:      EntryTypeCapture,
 			EventKind: captureEventKind(SurfaceToolPolicy),
 			Transport: rec.Transport,
-			Summary:   rec.Subsurface + ":" + rec.EffectiveAction,
+			Summary:   rec.Subsurface + ":" + normalizeEffectiveAction(rec.EffectiveAction),
 		},
 		summary: w.buildSummary(
 			SurfaceToolPolicy, rec.Subsurface, rec.ConfigHash, rec.Agent, rec.Profile,
 			rec.ActionClass,
 			"", rec.Request.ToolArgsJSON != "", TransformRaw, "", rec.BatchIndex,
 			rec.Request, rec.RawFindings, rec.EffectiveFindings,
-			rec.EffectiveAction, rec.Outcome, rec.SkipReason,
+			normalizeEffectiveAction(rec.EffectiveAction), rec.Outcome, rec.SkipReason,
 		),
 	})
 }
@@ -510,14 +521,14 @@ func (w *Writer) ObserveToolScanVerdict(_ context.Context, rec *ToolScanRecord) 
 			Type:      EntryTypeCapture,
 			EventKind: captureEventKind(SurfaceToolScan),
 			Transport: rec.Transport,
-			Summary:   rec.Subsurface + ":" + rec.EffectiveAction,
+			Summary:   rec.Subsurface + ":" + normalizeEffectiveAction(rec.EffectiveAction),
 		},
 		summary: w.buildSummary(
 			SurfaceToolScan, rec.Subsurface, rec.ConfigHash, rec.Agent, rec.Profile,
 			rec.ActionClass,
 			rec.ScannerInput, false, rec.TransformKind, "", rec.BatchIndex,
 			rec.Request, rec.RawFindings, rec.EffectiveFindings,
-			rec.EffectiveAction, rec.Outcome, rec.SkipReason,
+			normalizeEffectiveAction(rec.EffectiveAction), rec.Outcome, rec.SkipReason,
 		),
 		scannerInput: rec.ScannerInput,
 	})

--- a/internal/capture/writer.go
+++ b/internal/capture/writer.go
@@ -310,6 +310,7 @@ func captureEventKind(surface string) string {
 func (w *Writer) buildSummary(
 	surface, subsurface, configHash, agent, profile string,
 	actionClass string,
+	sessionIDOriginal string,
 	scannerInput string,
 	payloadComplete bool,
 	transformKind, wirePayload string,
@@ -337,6 +338,7 @@ func (w *Writer) buildSummary(
 		Agent:                agent,
 		Profile:              profile,
 		ActionClass:          actionClass,
+		SessionIDOriginal:    sessionIDOriginal,
 		PayloadComplete:      payloadComplete,
 		TransformKind:        transformKind,
 		Request:              req,
@@ -416,6 +418,7 @@ func (w *Writer) ObserveURLVerdict(_ context.Context, rec *URLVerdictRecord) {
 		summary: w.buildSummary(
 			SurfaceURL, rec.Subsurface, rec.ConfigHash, rec.Agent, rec.Profile,
 			rec.ActionClass,
+			rec.SessionIDOriginal,
 			scannerInput, true, TransformRaw, "", nil,
 			rec.Request, rec.RawFindings, rec.EffectiveFindings,
 			normalizeEffectiveAction(rec.EffectiveAction), rec.Outcome, rec.SkipReason,
@@ -439,6 +442,7 @@ func (w *Writer) ObserveResponseVerdict(_ context.Context, rec *ResponseVerdictR
 		summary: w.buildSummary(
 			SurfaceResponse, rec.Subsurface, rec.ConfigHash, rec.Agent, rec.Profile,
 			rec.ActionClass,
+			rec.SessionIDOriginal,
 			"", false, rec.TransformKind, wire, nil,
 			rec.Request, rec.RawFindings, rec.EffectiveFindings,
 			normalizeEffectiveAction(rec.EffectiveAction), rec.Outcome, rec.SkipReason,
@@ -461,6 +465,7 @@ func (w *Writer) ObserveDLPVerdict(_ context.Context, rec *DLPVerdictRecord) {
 		summary: w.buildSummary(
 			SurfaceDLP, rec.Subsurface, rec.ConfigHash, rec.Agent, rec.Profile,
 			rec.ActionClass,
+			rec.SessionIDOriginal,
 			rec.ScannerInput, false, rec.TransformKind, "", nil,
 			rec.Request, rec.RawFindings, rec.EffectiveFindings,
 			normalizeEffectiveAction(rec.EffectiveAction), rec.Outcome, rec.SkipReason,
@@ -483,6 +488,7 @@ func (w *Writer) ObserveCEEVerdict(_ context.Context, rec *CEERecord) {
 		summary: w.buildSummary(
 			SurfaceCEE, rec.Subsurface, rec.ConfigHash, rec.Agent, rec.Profile,
 			rec.ActionClass,
+			rec.SessionIDOriginal,
 			rec.ScannerInput, false, rec.TransformKind, "", nil,
 			rec.Request, rec.RawFindings, rec.EffectiveFindings,
 			normalizeEffectiveAction(rec.EffectiveAction), rec.Outcome, rec.SkipReason,
@@ -505,6 +511,7 @@ func (w *Writer) ObserveToolPolicyVerdict(_ context.Context, rec *ToolPolicyReco
 		summary: w.buildSummary(
 			SurfaceToolPolicy, rec.Subsurface, rec.ConfigHash, rec.Agent, rec.Profile,
 			rec.ActionClass,
+			rec.SessionIDOriginal,
 			"", rec.Request.ToolArgsJSON != "", TransformRaw, "", rec.BatchIndex,
 			rec.Request, rec.RawFindings, rec.EffectiveFindings,
 			normalizeEffectiveAction(rec.EffectiveAction), rec.Outcome, rec.SkipReason,
@@ -526,6 +533,7 @@ func (w *Writer) ObserveToolScanVerdict(_ context.Context, rec *ToolScanRecord) 
 		summary: w.buildSummary(
 			SurfaceToolScan, rec.Subsurface, rec.ConfigHash, rec.Agent, rec.Profile,
 			rec.ActionClass,
+			rec.SessionIDOriginal,
 			rec.ScannerInput, false, rec.TransformKind, "", rec.BatchIndex,
 			rec.Request, rec.RawFindings, rec.EffectiveFindings,
 			normalizeEffectiveAction(rec.EffectiveAction), rec.Outcome, rec.SkipReason,

--- a/internal/capture/writer.go
+++ b/internal/capture/writer.go
@@ -318,6 +318,14 @@ func (w *Writer) buildSummary(
 	rawFindings, effectiveFindings []Finding,
 	effectiveAction, outcome, skipReason string,
 ) CaptureSummary {
+	// Default effectiveAction to "allow" when empty so shadow replay can
+	// compute a non-empty original_verdict. Capture call sites that leave
+	// EffectiveAction empty for clean traffic should be migrated to set
+	// config.ActionAllow explicitly; this defensive default keeps the
+	// shadow pipeline functional in the meantime.
+	if effectiveAction == "" {
+		effectiveAction = ActionAllow
+	}
 	s := CaptureSummary{
 		CaptureSchemaVersion: CaptureSchemaV1,
 		Surface:              surface,

--- a/internal/cli/learn/compile.go
+++ b/internal/cli/learn/compile.go
@@ -4,10 +4,12 @@
 package learn
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -19,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract"
@@ -210,13 +213,22 @@ func resolveCompileInputs(cfg *config.Config, flags compileFlags) ([]string, err
 }
 
 func resolveAgentCaptureInputs(captureRoot, agent string) ([]string, error) {
-	paths, err := filepath.Glob(filepath.Join(captureRoot, agent, "*.jsonl"))
-	if err != nil {
-		return nil, err
-	}
-	seen := make(map[string]struct{}, len(paths))
-	for _, path := range paths {
-		seen[path] = struct{}{}
+	var paths []string
+	seen := make(map[string]struct{})
+
+	exactDir := filepath.Join(captureRoot, agent)
+	if validateCaptureSessionDir(exactDir, agent) {
+		matches, err := filepath.Glob(filepath.Join(exactDir, "*.jsonl"))
+		if err != nil {
+			return nil, err
+		}
+		for _, path := range matches {
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+			paths = append(paths, path)
+		}
 	}
 
 	entries, err := os.ReadDir(captureRoot)
@@ -227,7 +239,15 @@ func resolveAgentCaptureInputs(captureRoot, agent string) ([]string, error) {
 		if !entry.IsDir() || !captureSessionNameMatchesAgent(entry.Name(), agent) || entry.Name() == agent {
 			continue
 		}
-		matches, globErr := filepath.Glob(filepath.Join(captureRoot, entry.Name(), "*.jsonl"))
+		sessionDir := filepath.Join(captureRoot, entry.Name())
+		// Defense in depth: a name-prefix match is not enough. Require the
+		// first capture entry's self-attested agent to match the requested
+		// agent so a planted sibling like "agent-a|poison/" cannot silently
+		// contribute training inputs without producing forged recorder JSONL.
+		if !validateCaptureSessionDir(sessionDir, agent) {
+			continue
+		}
+		matches, globErr := filepath.Glob(filepath.Join(sessionDir, "*.jsonl"))
 		if globErr != nil {
 			return nil, globErr
 		}
@@ -245,6 +265,67 @@ func resolveAgentCaptureInputs(captureRoot, agent string) ([]string, error) {
 
 func captureSessionNameMatchesAgent(sessionName, agent string) bool {
 	return sessionName == agent || strings.HasPrefix(sessionName, agent+"|")
+}
+
+// validateCaptureSessionDir returns true when the session directory contains
+// at least one JSONL file whose first line decodes as a recorder envelope and
+// whose embedded capture summary attributes the entry to the requested agent.
+//
+// This is defense in depth, not a trust anchor. An attacker with write access
+// to the capture root can still forge the envelope and the agent field. The
+// purpose is to reject the obvious case (a sibling directory whose name shares
+// the agent prefix but whose contents declare a different agent), so the
+// learn/shadow pipelines do not silently absorb poisoned inputs from a name
+// collision alone.
+func validateCaptureSessionDir(sessionDir, agent string) bool {
+	matches, err := filepath.Glob(filepath.Join(sessionDir, "*.jsonl"))
+	if err != nil {
+		return false
+	}
+	// Empty session directories are safe to match (the recorder may have
+	// created the dir before it received traffic, or the session was
+	// drained). They contribute zero JSONL inputs either way; the validator
+	// only needs to reject directories whose contents actively misattribute
+	// to a different agent.
+	if len(matches) == 0 {
+		return true
+	}
+	sort.Strings(matches)
+	f, err := os.Open(filepath.Clean(matches[0]))
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	if !sc.Scan() {
+		return false
+	}
+	var envelope struct {
+		Type   string `json:"type"`
+		Hash   string `json:"hash"`
+		Detail struct {
+			Agent string `json:"agent"`
+		} `json:"detail"`
+	}
+	if err := json.Unmarshal(sc.Bytes(), &envelope); err != nil {
+		return false
+	}
+	// Loose schema check: a recorder entry always carries a chain hash and a
+	// type. Reject anything that does not look like recorder JSONL.
+	if envelope.Type == "" || envelope.Hash == "" {
+		return false
+	}
+	// Capture entries stamp the requested agent into the summary. Reject
+	// directories whose first entry attributes its traffic to a different
+	// agent (or omits the field entirely on a capture entry, which is the
+	// observable signature of a hand-crafted forgery).
+	if envelope.Type == capture.EntryTypeCapture {
+		return envelope.Detail.Agent == agent
+	}
+	// Non-capture entries (checkpoint, drop sentinel) leave the agent field
+	// unstamped; defer to name-prefix matching for those.
+	return true
 }
 
 func resolveCompileInputPath(path string) (string, error) {

--- a/internal/cli/learn/compile.go
+++ b/internal/cli/learn/compile.go
@@ -168,7 +168,7 @@ func resolveCompileInputs(cfg *config.Config, flags compileFlags) ([]string, err
 			return nil, err
 		}
 		captureRoot = filepath.Clean(cfg.Learn.CaptureDir)
-		paths, err = filepath.Glob(filepath.Join(cfg.Learn.CaptureDir, flags.agent, "*.jsonl"))
+		paths, err = resolveAgentCaptureInputs(captureRoot, flags.agent)
 		if err != nil {
 			return nil, fmt.Errorf("%w: capture glob: %w", errCompileInput, err)
 		}
@@ -207,6 +207,44 @@ func resolveCompileInputs(cfg *config.Config, flags compileFlags) ([]string, err
 		paths[i] = resolved
 	}
 	return paths, nil
+}
+
+func resolveAgentCaptureInputs(captureRoot, agent string) ([]string, error) {
+	paths, err := filepath.Glob(filepath.Join(captureRoot, agent, "*.jsonl"))
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		seen[path] = struct{}{}
+	}
+
+	entries, err := os.ReadDir(captureRoot)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || !captureSessionNameMatchesAgent(entry.Name(), agent) || entry.Name() == agent {
+			continue
+		}
+		matches, globErr := filepath.Glob(filepath.Join(captureRoot, entry.Name(), "*.jsonl"))
+		if globErr != nil {
+			return nil, globErr
+		}
+		for _, path := range matches {
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+			paths = append(paths, path)
+		}
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func captureSessionNameMatchesAgent(sessionName, agent string) bool {
+	return sessionName == agent || strings.HasPrefix(sessionName, agent+"|")
 }
 
 func resolveCompileInputPath(path string) (string, error) {

--- a/internal/cli/learn/compile_test.go
+++ b/internal/cli/learn/compile_test.go
@@ -82,7 +82,11 @@ func TestResolveCompileInputsAcceptsAgentSessionKeyDirs(t *testing.T) {
 		t.Fatalf("paths = %#v, want 2 agent-a captures", got)
 	}
 	for _, path := range got {
-		if !strings.Contains(path, "agent-a") || strings.Contains(path, "agent-ab") {
+		sessionDir := filepath.Base(filepath.Dir(path))
+		if sessionDir != "agent-a" && !strings.HasPrefix(sessionDir, "agent-a|") {
+			t.Fatalf("unexpected session dir %q in %#v", sessionDir, got)
+		}
+		if sessionDir == "agent-ab" || strings.HasPrefix(sessionDir, "agent-ab|") {
 			t.Fatalf("unexpected path %q in %#v", path, got)
 		}
 	}

--- a/internal/cli/learn/compile_test.go
+++ b/internal/cli/learn/compile_test.go
@@ -52,6 +52,42 @@ func TestResolveCompileInputsAcceptsSingleSegmentAgent(t *testing.T) {
 	}
 }
 
+func TestResolveCompileInputsAcceptsAgentSessionKeyDirs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	for _, sessionDir := range []string{"agent-a", "agent-a|10.0.0.1"} {
+		fullDir := filepath.Join(dir, sessionDir)
+		if err := os.MkdirAll(fullDir, 0o750); err != nil {
+			t.Fatalf("MkdirAll %s: %v", sessionDir, err)
+		}
+		if err := os.WriteFile(filepath.Join(fullDir, "capture.jsonl"), []byte("{}\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile %s: %v", sessionDir, err)
+		}
+	}
+	otherDir := filepath.Join(dir, "agent-ab|10.0.0.2")
+	if err := os.MkdirAll(otherDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll other: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(otherDir, "capture.jsonl"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile other: %v", err)
+	}
+	cfg := config.Defaults()
+	cfg.Learn.CaptureDir = dir
+
+	got, err := resolveCompileInputs(cfg, compileFlags{agent: "agent-a", since: time.Hour})
+	if err != nil {
+		t.Fatalf("resolveCompileInputs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("paths = %#v, want 2 agent-a captures", got)
+	}
+	for _, path := range got {
+		if !strings.Contains(path, "agent-a") || strings.Contains(path, "agent-ab") {
+			t.Fatalf("unexpected path %q in %#v", path, got)
+		}
+	}
+}
+
 func TestResolveCompileInputsRejectsSymlinkInput(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/cli/learn/compile_test.go
+++ b/internal/cli/learn/compile_test.go
@@ -14,6 +14,12 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
+// captureJSONL returns a minimal recorder envelope JSONL line that passes
+// validateCaptureSessionDir's schema + agent-attribution check.
+func captureJSONL(agent string) []byte {
+	return []byte(`{"v":1,"seq":1,"ts":"2026-05-03T17:00:00Z","session_id":"` + agent + `","type":"capture","transport":"fetch","summary":"x","detail":{"agent":"` + agent + `"},"prev_hash":"","hash":"abc"}` + "\n")
+}
+
 func TestResolveCompileInputsRejectsAgentPathSegments(t *testing.T) {
 	t.Parallel()
 	cfg := config.Defaults()
@@ -37,7 +43,7 @@ func TestResolveCompileInputsAcceptsSingleSegmentAgent(t *testing.T) {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	input := filepath.Join(agentDir, "capture.jsonl")
-	if err := os.WriteFile(input, []byte("{}\n"), 0o600); err != nil {
+	if err := os.WriteFile(input, captureJSONL("agent-a"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	cfg := config.Defaults()
@@ -60,7 +66,7 @@ func TestResolveCompileInputsAcceptsAgentSessionKeyDirs(t *testing.T) {
 		if err := os.MkdirAll(fullDir, 0o750); err != nil {
 			t.Fatalf("MkdirAll %s: %v", sessionDir, err)
 		}
-		if err := os.WriteFile(filepath.Join(fullDir, "capture.jsonl"), []byte("{}\n"), 0o600); err != nil {
+		if err := os.WriteFile(filepath.Join(fullDir, "capture.jsonl"), captureJSONL("agent-a"), 0o600); err != nil {
 			t.Fatalf("WriteFile %s: %v", sessionDir, err)
 		}
 	}
@@ -68,7 +74,7 @@ func TestResolveCompileInputsAcceptsAgentSessionKeyDirs(t *testing.T) {
 	if err := os.MkdirAll(otherDir, 0o750); err != nil {
 		t.Fatalf("MkdirAll other: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(otherDir, "capture.jsonl"), []byte("{}\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(otherDir, "capture.jsonl"), captureJSONL("agent-ab"), 0o600); err != nil {
 		t.Fatalf("WriteFile other: %v", err)
 	}
 	cfg := config.Defaults()
@@ -89,6 +95,45 @@ func TestResolveCompileInputsAcceptsAgentSessionKeyDirs(t *testing.T) {
 		if sessionDir == "agent-ab" || strings.HasPrefix(sessionDir, "agent-ab|") {
 			t.Fatalf("unexpected path %q in %#v", path, got)
 		}
+	}
+}
+
+func TestResolveCompileInputsRejectsPoisonedSiblingSession(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Legitimate agent-a session with matching attribution.
+	goodDir := filepath.Join(dir, "agent-a|10.0.0.1")
+	if err := os.MkdirAll(goodDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll good: %v", err)
+	}
+	good := filepath.Join(goodDir, "capture.jsonl")
+	if err := os.WriteFile(good, captureJSONL("agent-a"), 0o600); err != nil {
+		t.Fatalf("WriteFile good: %v", err)
+	}
+
+	// Planted sibling whose name passes the agent-a prefix match but whose
+	// content attributes the traffic to a different agent. Must be skipped:
+	// otherwise an attacker who can write to the capture root could silently
+	// poison agent-a's compile inputs simply by naming a directory with the
+	// agent prefix.
+	poisonDir := filepath.Join(dir, "agent-a|poison")
+	if err := os.MkdirAll(poisonDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll poison: %v", err)
+	}
+	poison := filepath.Join(poisonDir, "capture.jsonl")
+	if err := os.WriteFile(poison, captureJSONL("evil-agent"), 0o600); err != nil {
+		t.Fatalf("WriteFile poison: %v", err)
+	}
+
+	cfg := config.Defaults()
+	cfg.Learn.CaptureDir = dir
+	got, err := resolveCompileInputs(cfg, compileFlags{agent: "agent-a", since: time.Hour})
+	if err != nil {
+		t.Fatalf("resolveCompileInputs: %v", err)
+	}
+	if len(got) != 1 || got[0] != good {
+		t.Fatalf("paths = %#v, want only [%q] (poison must be filtered)", got, good)
 	}
 }
 
@@ -122,7 +167,7 @@ func TestResolveCompileInputsRejectsSymlinkedCaptureRootEscape(t *testing.T) {
 	if err := os.MkdirAll(outside, 0o750); err != nil {
 		t.Fatalf("MkdirAll outside: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(outside, "capture.jsonl"), []byte("{}\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(outside, "capture.jsonl"), captureJSONL("agent-a"), 0o600); err != nil {
 		t.Fatalf("WriteFile outside capture: %v", err)
 	}
 	if err := os.Symlink(outside, filepath.Join(captureRoot, "agent-a")); err != nil {

--- a/internal/cli/learn/shadow.go
+++ b/internal/cli/learn/shadow.go
@@ -110,6 +110,7 @@ func runShadow(cmd *cobra.Command, flags shadowFlags) error {
 	records, _, _, _, err := capture.LoadAndReplayWithOptions(cfg, sessionsDir, capture.ReplayOptions{
 		EscrowPrivateKey: escrow,
 		Contract:         &env.Body,
+		SessionFilter:    shadowSessionFilter(flags),
 	})
 	if err != nil {
 		return fmt.Errorf("learn shadow: replay captures: %w", err)
@@ -223,7 +224,36 @@ func resolveShadowSessions(cfg *config.Config, flags shadowFlags) (string, error
 	if !filepath.IsAbs(filepath.Clean(cfg.Learn.CaptureDir)) {
 		return "", errRelativeCaptureDir
 	}
-	return checkedReadDir(filepath.Join(cfg.Learn.CaptureDir, flags.agent))
+	root, err := checkedReadDir(cfg.Learn.CaptureDir)
+	if err != nil {
+		return "", err
+	}
+	if !hasMatchingCaptureSession(root, flags.agent) {
+		return "", fmt.Errorf("%w: no capture sessions matched agent %q", ErrInvalidCandidate, flags.agent)
+	}
+	return root, nil
+}
+
+func shadowSessionFilter(flags shadowFlags) func(string) bool {
+	if flags.sessionsDir != "" {
+		return nil
+	}
+	return func(sessionName string) bool {
+		return captureSessionNameMatchesAgent(sessionName, flags.agent)
+	}
+}
+
+func hasMatchingCaptureSession(root, agent string) bool {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && captureSessionNameMatchesAgent(entry.Name(), agent) {
+			return true
+		}
+	}
+	return false
 }
 
 func checkedReadDir(path string) (string, error) {

--- a/internal/cli/learn/shadow.go
+++ b/internal/cli/learn/shadow.go
@@ -228,7 +228,11 @@ func resolveShadowSessions(cfg *config.Config, flags shadowFlags) (string, error
 	if err != nil {
 		return "", err
 	}
-	if !hasMatchingCaptureSession(root, flags.agent) {
+	matched, err := hasMatchingCaptureSession(root, flags.agent)
+	if err != nil {
+		return "", fmt.Errorf("%w: scan capture sessions: %w", ErrInvalidCandidate, err)
+	}
+	if !matched {
 		return "", fmt.Errorf("%w: no capture sessions matched agent %q", ErrInvalidCandidate, flags.agent)
 	}
 	return root, nil
@@ -243,17 +247,17 @@ func shadowSessionFilter(flags shadowFlags) func(string) bool {
 	}
 }
 
-func hasMatchingCaptureSession(root, agent string) bool {
+func hasMatchingCaptureSession(root, agent string) (bool, error) {
 	entries, err := os.ReadDir(root)
 	if err != nil {
-		return false
+		return false, err
 	}
 	for _, entry := range entries {
 		if entry.IsDir() && captureSessionNameMatchesAgent(entry.Name(), agent) {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func checkedReadDir(path string) (string, error) {

--- a/internal/cli/learn/shadow.go
+++ b/internal/cli/learn/shadow.go
@@ -238,12 +238,19 @@ func resolveShadowSessions(cfg *config.Config, flags shadowFlags) (string, error
 	return root, nil
 }
 
-func shadowSessionFilter(flags shadowFlags) func(string) bool {
+func shadowSessionFilter(flags shadowFlags) func(name, sessionDir string) bool {
 	if flags.sessionsDir != "" {
 		return nil
 	}
-	return func(sessionName string) bool {
-		return captureSessionNameMatchesAgent(sessionName, flags.agent)
+	return func(sessionName, sessionDir string) bool {
+		if !captureSessionNameMatchesAgent(sessionName, flags.agent) {
+			return false
+		}
+		// Defense in depth: name-prefix match alone lets a planted sibling
+		// directory poison shadow replay. Require the first capture entry's
+		// self-attested agent to match before the session is replayed against
+		// the candidate contract.
+		return validateCaptureSessionDir(sessionDir, flags.agent)
 	}
 }
 
@@ -253,9 +260,13 @@ func hasMatchingCaptureSession(root, agent string) (bool, error) {
 		return false, err
 	}
 	for _, entry := range entries {
-		if entry.IsDir() && captureSessionNameMatchesAgent(entry.Name(), agent) {
-			return true, nil
+		if !entry.IsDir() || !captureSessionNameMatchesAgent(entry.Name(), agent) {
+			continue
 		}
+		if !validateCaptureSessionDir(filepath.Join(root, entry.Name()), agent) {
+			continue
+		}
+		return true, nil
 	}
 	return false, nil
 }

--- a/internal/cli/learn/shadow_test.go
+++ b/internal/cli/learn/shadow_test.go
@@ -562,8 +562,15 @@ func TestResolveShadowSessionsAgentConfigBranches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve by agent: %v", err)
 	}
-	if got != agentDir {
-		t.Fatalf("agent sessions = %q, want %q", got, agentDir)
+	if got != root {
+		t.Fatalf("agent sessions root = %q, want %q", got, root)
+	}
+	filter := shadowSessionFilter(shadowFlags{agent: "agent-a"})
+	if !filter("agent-a") || !filter("agent-a|10.0.0.1") || filter("agent-ab|10.0.0.2") {
+		t.Fatalf("shadow session filter did not match only agent-a sessions")
+	}
+	if shadowSessionFilter(shadowFlags{sessionsDir: agentDir}) != nil {
+		t.Fatalf("explicit sessions dir should not install an agent filter")
 	}
 	if _, err := resolveShadowSessions(cfg, shadowFlags{}); err == nil {
 		t.Fatal("resolve empty agent succeeded, want validation error")

--- a/internal/cli/learn/shadow_test.go
+++ b/internal/cli/learn/shadow_test.go
@@ -566,7 +566,18 @@ func TestResolveShadowSessionsAgentConfigBranches(t *testing.T) {
 		t.Fatalf("agent sessions root = %q, want %q", got, root)
 	}
 	filter := shadowSessionFilter(shadowFlags{agent: "agent-a"})
-	if !filter("agent-a") || !filter("agent-a|10.0.0.1") || filter("agent-ab|10.0.0.2") {
+	// Empty session dirs satisfy the validator (no contents to misattribute),
+	// so name-prefix-matching is the effective check for these cases.
+	emptyA := filepath.Join(root, "agent-a")
+	emptyAIP := filepath.Join(root, "agent-a|10.0.0.1")
+	emptyABIP := filepath.Join(root, "agent-ab|10.0.0.2")
+	if err := os.MkdirAll(emptyAIP, 0o750); err != nil {
+		t.Fatalf("MkdirAll emptyAIP: %v", err)
+	}
+	if err := os.MkdirAll(emptyABIP, 0o750); err != nil {
+		t.Fatalf("MkdirAll emptyABIP: %v", err)
+	}
+	if !filter("agent-a", emptyA) || !filter("agent-a|10.0.0.1", emptyAIP) || filter("agent-ab|10.0.0.2", emptyABIP) {
 		t.Fatalf("shadow session filter did not match only agent-a sessions")
 	}
 	if shadowSessionFilter(shadowFlags{sessionsDir: agentDir}) != nil {

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -633,6 +633,11 @@ signed action receipts for MCP decisions.`,
 					TrustDomain: cfg.MediationEnvelope.TrustDomain,
 				})
 			}
+			captureConfigHash := cfg.CanonicalPolicyHash()
+			captureProfile := resolved.Name
+			if captureProfile == "" {
+				captureProfile = edition.ProfileDefault
+			}
 
 			toolAction := "disabled"
 			if toolCfg != nil {
@@ -687,6 +692,7 @@ signed action receipts for MCP decisions.`,
 						InputCfg: inputCfg, ToolCfg: toolCfg, PolicyCfg: policyCfg,
 						KillSwitch: ks, ChainMatcher: chainMatcher,
 						CEE: cee, Store: store, AdaptiveCfgFn: adaptiveFn, Metrics: mcpMetrics,
+						ConfigHash: captureConfigHash, Profile: captureProfile,
 						RedirectRT:      buildRedirectRT(cfg),
 						ProvenanceCfg:   &cfg.MCPToolProvenance,
 						EnvelopeEmitter: envEmitter,
@@ -716,6 +722,8 @@ signed action receipts for MCP decisions.`,
 						KillSwitch: ks, ChainMatcher: chainMatcher,
 						CEE: cee, Store: store,
 						AdaptiveCfg:     adaptiveCfg,
+						ConfigHash:      captureConfigHash,
+						Profile:         captureProfile,
 						Metrics:         mcpMetrics,
 						ReceiptEmitter:  receiptEmitter,
 						RedirectRT:      buildRedirectRT(cfg),
@@ -745,6 +753,7 @@ signed action receipts for MCP decisions.`,
 					KillSwitch: ks, ChainMatcher: chainMatcher,
 					CEE: cee, Store: store,
 					AdaptiveCfg: adaptiveCfg, Metrics: mcpMetrics,
+					ConfigHash: captureConfigHash, Profile: captureProfile,
 					RedirectRT:      buildRedirectRT(cfg),
 					EnvelopeEmitter: envEmitter,
 					DoWCheck:        dowCheck,
@@ -880,6 +889,7 @@ signed action receipts for MCP decisions.`,
 					KillSwitch: ks, ChainMatcher: chainMatcher,
 					CEE: cee, Store: store,
 					AdaptiveCfg: adaptiveCfg, Metrics: mcpMetrics,
+					ConfigHash: captureConfigHash, Profile: captureProfile,
 					RedirectRT: buildRedirectRT(cfg), DoWCheck: dowCheck,
 					EnvelopeEmitter: envEmitter,
 					ReceiptEmitter:  receiptEmitter,
@@ -988,6 +998,7 @@ signed action receipts for MCP decisions.`,
 				KillSwitch: ks, ChainMatcher: chainMatcher,
 				CEE: cee, Store: store,
 				AdaptiveCfg: adaptiveCfg, Metrics: mcpMetrics,
+				ConfigHash: captureConfigHash, Profile: captureProfile,
 				RedirectRT: buildRedirectRT(cfg), DoWCheck: dowCheck,
 				EnvelopeEmitter: envEmitter,
 				ReceiptEmitter:  receiptEmitter,

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/edition"
 	"github.com/luckyPipewrench/pipelock/internal/emit"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/hitl"
@@ -958,6 +959,13 @@ func (s *Server) Start(ctx context.Context) error {
 			}
 			return nil
 		})
+		mcpConfigHashFn := func() string {
+			c := s.proxy.CurrentConfig()
+			if c == nil {
+				return ""
+			}
+			return c.CanonicalPolicyHash()
+		}
 
 		mcpErr = make(chan error, 1)
 		go func() {
@@ -980,6 +988,8 @@ func (s *Server) Start(ctx context.Context) error {
 				Metrics:             s.metrics,
 				RedirectRTFn:        mcpRedirectRTFn,
 				CaptureObs:          mcpCaptureObs,
+				ConfigHashFn:        mcpConfigHashFn,
+				Profile:             edition.ProfileDefault,
 				ProvenanceCfgFn:     mcpProvenanceCfgFn,
 				ReceiptEmitterFn:    s.liveReceiptEmitter,
 				EnvelopeEmitterFn:   s.liveEnvelopeEmitter,

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -59,11 +59,11 @@ import (
 // a stale hash. Tests must use fresh Config values for sensitivity.
 func (c *Config) CanonicalPolicyHash() string {
 	if c.canonicalHashCache == nil {
-		// Lazy-init for *Config values constructed outside Load() /
-		// Clone() (tests using Defaults() directly). Load-time callers
-		// drive a single serial init via Load()'s eager warm; concurrent
-		// first-touch on a Defaults() value is not a supported pattern.
-		c.canonicalHashCache = &canonicalHashCacheHolder{}
+		// Avoid lazy pointer writes here. CanonicalPolicyHash is used in
+		// request paths, and callers may share a manually constructed Config
+		// across goroutines. Defaults(), Load(), and Clone() install a cache
+		// holder; zero-value Config falls back to uncached computation.
+		return c.computeCanonicalPolicyHash()
 	}
 	if cached := c.canonicalHashCache.Load(); cached != nil {
 		if s, ok := cached.(string); ok {

--- a/internal/config/canonical_test.go
+++ b/internal/config/canonical_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/redact"
@@ -60,6 +61,25 @@ func TestCanonicalPolicyHash_Cached(t *testing.T) {
 	if want := cfg.computeCanonicalPolicyHash(); h1 != want {
 		t.Errorf("cached = %s, uncached = %s; should match", h1, want)
 	}
+}
+
+func TestCanonicalPolicyHash_ConcurrentFirstTouch(t *testing.T) {
+	cfg := Defaults()
+	want := cfg.computeCanonicalPolicyHash()
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 64 {
+				if got := cfg.CanonicalPolicyHash(); got != want {
+					t.Errorf("CanonicalPolicyHash() = %s, want %s", got, want)
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func TestCanonicalPolicyHash_NoiseFieldsDoNotAffect(t *testing.T) {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -13,8 +13,9 @@ import (
 // Defaults returns a Config with sensible defaults for balanced mode.
 func Defaults() *Config {
 	cfg := &Config{
-		Version: 1,
-		Mode:    ModeBalanced,
+		Version:            1,
+		Mode:               ModeBalanced,
+		canonicalHashCache: &canonicalHashCacheHolder{},
 		APIAllowlist: []string{
 			"*.anthropic.com",
 			"*.openai.com",

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -112,6 +112,7 @@ func Load(path string) (*Config, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
+	cfg.canonicalHashCache = &canonicalHashCacheHolder{}
 
 	// Eagerly warm the canonical policy hash cache so the hash is
 	// computed once against the post-Validate / post-ApplyDefaults

--- a/internal/mcp/capture_helpers.go
+++ b/internal/mcp/capture_helpers.go
@@ -16,15 +16,38 @@ import (
 )
 
 func captureSessionID(transport string) string {
+	safe, _ := captureSessionIDAndOriginal(transport)
+	return safe
+}
+
+// captureSessionIDAndOriginal returns the safe session key and the original
+// logical key. When the two differ, the safe value was hashed to escape an
+// unsafe input. Capture call sites stamp the original into the record so
+// downstream audit can map opaque "mcp-<hex>" directories back to the raw
+// transport identity.
+func captureSessionIDAndOriginal(transport string) (safe, original string) {
 	key := "mcp-" + transport
 	if key == "mcp-" {
 		key = "mcp"
 	}
 	if strings.ContainsAny(key, `/\`) || strings.Contains(key, "..") {
 		sum := sha256.Sum256([]byte(key))
-		return "mcp-" + hex.EncodeToString(sum[:])
+		return "mcp-" + hex.EncodeToString(sum[:]), key
 	}
-	return key
+	return key, key
+}
+
+// captureSessionIDOriginal returns the unsanitized logical session key when
+// the safe directory-name key was derived via hashing, and the empty string
+// otherwise. Capture call sites assign the result to record.SessionIDOriginal
+// (omitempty), so the field appears only when a sanitized "mcp-<hex>"
+// directory needs an audit trail back to its raw logical transport identity.
+func captureSessionIDOriginal(transport string) string {
+	safe, original := captureSessionIDAndOriginal(transport)
+	if safe == original {
+		return ""
+	}
+	return original
 }
 
 // dlpMatchesToFindings converts scanner.TextDLPMatch slice to capture findings.

--- a/internal/mcp/capture_helpers.go
+++ b/internal/mcp/capture_helpers.go
@@ -4,12 +4,28 @@
 package mcp
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
 	"github.com/luckyPipewrench/pipelock/internal/addressprotect"
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
+
+func captureSessionID(transport string) string {
+	key := "mcp-" + transport
+	if key == "mcp-" {
+		key = "mcp"
+	}
+	if strings.ContainsAny(key, `/\`) || strings.Contains(key, "..") {
+		sum := sha256.Sum256([]byte(key))
+		return "mcp-" + hex.EncodeToString(sum[:])
+	}
+	return key
+}
 
 // dlpMatchesToFindings converts scanner.TextDLPMatch slice to capture findings.
 func dlpMatchesToFindings(matches []scanner.TextDLPMatch) []capture.Finding {

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -347,11 +347,12 @@ func ForwardScannedInput(
 				_, _ = fmt.Fprintf(logW, "pipelock: input line %d: tools/call %q not in session baseline\n", lineNum, toolCallName)
 			}
 			obs.ObserveToolPolicyVerdict(context.Background(), &capture.ToolPolicyRecord{
-				Subsurface: "session_binding",
-				Transport:  opts.Transport,
-				SessionID:  captureSessionID(opts.Transport),
-				ConfigHash: opts.captureConfigHash(),
-				Profile:    opts.captureProfile(),
+				Subsurface:        "session_binding",
+				Transport:         opts.Transport,
+				SessionID:         captureSessionID(opts.Transport),
+				SessionIDOriginal: captureSessionIDOriginal(opts.Transport),
+				ConfigHash:        opts.captureConfigHash(),
+				Profile:           opts.captureProfile(),
 				Request: capture.CaptureRequest{
 					ToolName:  toolCallName,
 					MCPMethod: methodToolsCall,
@@ -379,11 +380,12 @@ func ForwardScannedInput(
 				auditLogger.LogChainDetection(eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction, toolCallName, "default")
 			}
 			obs.ObserveToolPolicyVerdict(context.Background(), &capture.ToolPolicyRecord{
-				Subsurface: "chain_detection",
-				Transport:  opts.Transport,
-				SessionID:  captureSessionID(opts.Transport),
-				ConfigHash: opts.captureConfigHash(),
-				Profile:    opts.captureProfile(),
+				Subsurface:        "chain_detection",
+				Transport:         opts.Transport,
+				SessionID:         captureSessionID(opts.Transport),
+				SessionIDOriginal: captureSessionIDOriginal(opts.Transport),
+				ConfigHash:        opts.captureConfigHash(),
+				Profile:           opts.captureProfile(),
 				Request: capture.CaptureRequest{
 					ToolName:  toolCallName,
 					MCPMethod: methodToolsCall,
@@ -558,11 +560,12 @@ func ForwardScannedInput(
 			if reason := ceeRecordMCP(ceeStdioKey, line, cee, sc, logW, auditLogger); reason != "" {
 				// Capture: record CEE verdict.
 				obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
-					Subsurface: "cee_mcp_stdio",
-					Transport:  opts.Transport,
-					SessionID:  captureSessionID(opts.Transport),
-					ConfigHash: opts.captureConfigHash(),
-					Profile:    opts.captureProfile(),
+					Subsurface:        "cee_mcp_stdio",
+					Transport:         opts.Transport,
+					SessionID:         captureSessionID(opts.Transport),
+					SessionIDOriginal: captureSessionIDOriginal(opts.Transport),
+					ConfigHash:        opts.captureConfigHash(),
+					Profile:           opts.captureProfile(),
 					RawFindings: []capture.Finding{{
 						Kind:   capture.KindCEE,
 						Action: config.ActionBlock,
@@ -762,16 +765,17 @@ func ForwardScannedInput(
 				dlpResult := sc.ScanTextForDLP(stdioWarnCtx, string(result.Response))
 				// Capture: record redirect output scan verdict.
 				obs.ObserveResponseVerdict(context.Background(), &capture.ResponseVerdictRecord{
-					Subsurface:      "response_redirect_output",
-					Transport:       opts.Transport,
-					SessionID:       captureSessionID(opts.Transport),
-					ConfigHash:      opts.captureConfigHash(),
-					Profile:         opts.captureProfile(),
-					TransformKind:   capture.TransformRedirectOutput,
-					WirePayload:     result.Response,
-					RawFindings:     responseMatchesToFindings(scanVerdict.Matches, config.ActionBlock),
-					EffectiveAction: config.ActionBlock,
-					Outcome:         captureOutcome(config.ActionBlock, scanVerdict.Clean),
+					Subsurface:        "response_redirect_output",
+					Transport:         opts.Transport,
+					SessionID:         captureSessionID(opts.Transport),
+					SessionIDOriginal: captureSessionIDOriginal(opts.Transport),
+					ConfigHash:        opts.captureConfigHash(),
+					Profile:           opts.captureProfile(),
+					TransformKind:     capture.TransformRedirectOutput,
+					WirePayload:       result.Response,
+					RawFindings:       responseMatchesToFindings(scanVerdict.Matches, config.ActionBlock),
+					EffectiveAction:   config.ActionBlock,
+					Outcome:           captureOutcome(config.ActionBlock, scanVerdict.Clean),
 				})
 				if !scanVerdict.Clean {
 					_, _ = fmt.Fprintf(logW, "pipelock: input line %d: blocked redirect response (injection detected in handler output)\n", lineNum)
@@ -840,11 +844,12 @@ func ForwardScannedInput(
 			if reason := ceeRecordMCP(ceeStdioKey, line, cee, sc, logW, auditLogger); reason != "" {
 				// Capture: record CEE verdict (warn-path).
 				obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
-					Subsurface: "cee_mcp_stdio",
-					Transport:  opts.Transport,
-					SessionID:  captureSessionID(opts.Transport),
-					ConfigHash: opts.captureConfigHash(),
-					Profile:    opts.captureProfile(),
+					Subsurface:        "cee_mcp_stdio",
+					Transport:         opts.Transport,
+					SessionID:         captureSessionID(opts.Transport),
+					SessionIDOriginal: captureSessionIDOriginal(opts.Transport),
+					ConfigHash:        opts.captureConfigHash(),
+					Profile:           opts.captureProfile(),
 					RawFindings: []capture.Finding{{
 						Kind:   capture.KindCEE,
 						Action: config.ActionBlock,
@@ -923,15 +928,16 @@ func ForwardScannedInput(
 			rawFindings = append(rawFindings, responseMatchesToFindings(verdict.Inject, effectiveAction)...)
 			rawFindings = append(rawFindings, addressFindingsToCapture(verdict.AddressFindings)...)
 			obs.ObserveDLPVerdict(context.Background(), &capture.DLPVerdictRecord{
-				Subsurface:      "dlp_mcp_input",
-				Transport:       opts.Transport,
-				SessionID:       captureSessionID(opts.Transport),
-				ConfigHash:      opts.captureConfigHash(),
-				Profile:         opts.captureProfile(),
-				TransformKind:   capture.TransformJoinedFields,
-				RawFindings:     rawFindings,
-				EffectiveAction: effectiveAction,
-				Outcome:         captureOutcome(effectiveAction, false),
+				Subsurface:        "dlp_mcp_input",
+				Transport:         opts.Transport,
+				SessionID:         captureSessionID(opts.Transport),
+				SessionIDOriginal: captureSessionIDOriginal(opts.Transport),
+				ConfigHash:        opts.captureConfigHash(),
+				Profile:           opts.captureProfile(),
+				TransformKind:     capture.TransformJoinedFields,
+				RawFindings:       rawFindings,
+				EffectiveAction:   effectiveAction,
+				Outcome:           captureOutcome(effectiveAction, false),
 			})
 		}
 		// Capture: record tool policy verdict when policy matched.
@@ -945,11 +951,12 @@ func ForwardScannedInput(
 				})
 			}
 			obs.ObserveToolPolicyVerdict(context.Background(), &capture.ToolPolicyRecord{
-				Subsurface: "mcp_tool_policy",
-				Transport:  opts.Transport,
-				SessionID:  captureSessionID(opts.Transport),
-				ConfigHash: opts.captureConfigHash(),
-				Profile:    opts.captureProfile(),
+				Subsurface:        "mcp_tool_policy",
+				Transport:         opts.Transport,
+				SessionID:         captureSessionID(opts.Transport),
+				SessionIDOriginal: captureSessionIDOriginal(opts.Transport),
+				ConfigHash:        opts.captureConfigHash(),
+				Profile:           opts.captureProfile(),
 				Request: capture.CaptureRequest{
 					ToolName:  toolCallName,
 					MCPMethod: verdict.Method,

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -349,7 +349,9 @@ func ForwardScannedInput(
 			obs.ObserveToolPolicyVerdict(context.Background(), &capture.ToolPolicyRecord{
 				Subsurface: "session_binding",
 				Transport:  opts.Transport,
-				SessionID:  "mcp-" + opts.Transport,
+				SessionID:  captureSessionID(opts.Transport),
+				ConfigHash: opts.captureConfigHash(),
+				Profile:    opts.captureProfile(),
 				Request: capture.CaptureRequest{
 					ToolName:  toolCallName,
 					MCPMethod: methodToolsCall,
@@ -379,7 +381,9 @@ func ForwardScannedInput(
 			obs.ObserveToolPolicyVerdict(context.Background(), &capture.ToolPolicyRecord{
 				Subsurface: "chain_detection",
 				Transport:  opts.Transport,
-				SessionID:  "mcp-" + opts.Transport,
+				SessionID:  captureSessionID(opts.Transport),
+				ConfigHash: opts.captureConfigHash(),
+				Profile:    opts.captureProfile(),
 				Request: capture.CaptureRequest{
 					ToolName:  toolCallName,
 					MCPMethod: methodToolsCall,
@@ -556,7 +560,9 @@ func ForwardScannedInput(
 				obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 					Subsurface: "cee_mcp_stdio",
 					Transport:  opts.Transport,
-					SessionID:  "mcp-" + opts.Transport,
+					SessionID:  captureSessionID(opts.Transport),
+					ConfigHash: opts.captureConfigHash(),
+					Profile:    opts.captureProfile(),
 					RawFindings: []capture.Finding{{
 						Kind:   capture.KindCEE,
 						Action: config.ActionBlock,
@@ -758,7 +764,9 @@ func ForwardScannedInput(
 				obs.ObserveResponseVerdict(context.Background(), &capture.ResponseVerdictRecord{
 					Subsurface:      "response_redirect_output",
 					Transport:       opts.Transport,
-					SessionID:       "mcp-" + opts.Transport,
+					SessionID:       captureSessionID(opts.Transport),
+					ConfigHash:      opts.captureConfigHash(),
+					Profile:         opts.captureProfile(),
 					TransformKind:   capture.TransformRedirectOutput,
 					WirePayload:     result.Response,
 					RawFindings:     responseMatchesToFindings(scanVerdict.Matches, config.ActionBlock),
@@ -834,7 +842,9 @@ func ForwardScannedInput(
 				obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 					Subsurface: "cee_mcp_stdio",
 					Transport:  opts.Transport,
-					SessionID:  "mcp-" + opts.Transport,
+					SessionID:  captureSessionID(opts.Transport),
+					ConfigHash: opts.captureConfigHash(),
+					Profile:    opts.captureProfile(),
 					RawFindings: []capture.Finding{{
 						Kind:   capture.KindCEE,
 						Action: config.ActionBlock,
@@ -915,7 +925,9 @@ func ForwardScannedInput(
 			obs.ObserveDLPVerdict(context.Background(), &capture.DLPVerdictRecord{
 				Subsurface:      "dlp_mcp_input",
 				Transport:       opts.Transport,
-				SessionID:       "mcp-" + opts.Transport,
+				SessionID:       captureSessionID(opts.Transport),
+				ConfigHash:      opts.captureConfigHash(),
+				Profile:         opts.captureProfile(),
 				TransformKind:   capture.TransformJoinedFields,
 				RawFindings:     rawFindings,
 				EffectiveAction: effectiveAction,
@@ -935,7 +947,9 @@ func ForwardScannedInput(
 			obs.ObserveToolPolicyVerdict(context.Background(), &capture.ToolPolicyRecord{
 				Subsurface: "mcp_tool_policy",
 				Transport:  opts.Transport,
-				SessionID:  "mcp-" + opts.Transport,
+				SessionID:  captureSessionID(opts.Transport),
+				ConfigHash: opts.captureConfigHash(),
+				Profile:    opts.captureProfile(),
 				Request: capture.CaptureRequest{
 					ToolName:  toolCallName,
 					MCPMethod: verdict.Method,

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -349,6 +349,7 @@ func ForwardScannedInput(
 			obs.ObserveToolPolicyVerdict(context.Background(), &capture.ToolPolicyRecord{
 				Subsurface: "session_binding",
 				Transport:  opts.Transport,
+				SessionID:  "mcp-" + opts.Transport,
 				Request: capture.CaptureRequest{
 					ToolName:  toolCallName,
 					MCPMethod: methodToolsCall,
@@ -378,6 +379,7 @@ func ForwardScannedInput(
 			obs.ObserveToolPolicyVerdict(context.Background(), &capture.ToolPolicyRecord{
 				Subsurface: "chain_detection",
 				Transport:  opts.Transport,
+				SessionID:  "mcp-" + opts.Transport,
 				Request: capture.CaptureRequest{
 					ToolName:  toolCallName,
 					MCPMethod: methodToolsCall,
@@ -554,6 +556,7 @@ func ForwardScannedInput(
 				obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 					Subsurface: "cee_mcp_stdio",
 					Transport:  opts.Transport,
+					SessionID:  "mcp-" + opts.Transport,
 					RawFindings: []capture.Finding{{
 						Kind:   capture.KindCEE,
 						Action: config.ActionBlock,
@@ -755,6 +758,7 @@ func ForwardScannedInput(
 				obs.ObserveResponseVerdict(context.Background(), &capture.ResponseVerdictRecord{
 					Subsurface:      "response_redirect_output",
 					Transport:       opts.Transport,
+					SessionID:       "mcp-" + opts.Transport,
 					TransformKind:   capture.TransformRedirectOutput,
 					WirePayload:     result.Response,
 					RawFindings:     responseMatchesToFindings(scanVerdict.Matches, config.ActionBlock),
@@ -830,6 +834,7 @@ func ForwardScannedInput(
 				obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 					Subsurface: "cee_mcp_stdio",
 					Transport:  opts.Transport,
+					SessionID:  "mcp-" + opts.Transport,
 					RawFindings: []capture.Finding{{
 						Kind:   capture.KindCEE,
 						Action: config.ActionBlock,
@@ -910,6 +915,7 @@ func ForwardScannedInput(
 			obs.ObserveDLPVerdict(context.Background(), &capture.DLPVerdictRecord{
 				Subsurface:      "dlp_mcp_input",
 				Transport:       opts.Transport,
+				SessionID:       "mcp-" + opts.Transport,
 				TransformKind:   capture.TransformJoinedFields,
 				RawFindings:     rawFindings,
 				EffectiveAction: effectiveAction,
@@ -929,6 +935,7 @@ func ForwardScannedInput(
 			obs.ObserveToolPolicyVerdict(context.Background(), &capture.ToolPolicyRecord{
 				Subsurface: "mcp_tool_policy",
 				Transport:  opts.Transport,
+				SessionID:  "mcp-" + opts.Transport,
 				Request: capture.CaptureRequest{
 					ToolName:  toolCallName,
 					MCPMethod: verdict.Method,

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -123,6 +123,12 @@ type MCPProxyOpts struct {
 	// Defaults to capture.NopObserver{} when nil.
 	CaptureObs capture.CaptureObserver
 
+	// Capture metadata stamped onto recorded MCP scan verdicts.
+	ConfigHash   string
+	ConfigHashFn func() string
+	Profile      string
+	ProfileFn    func() string
+
 	// Transport identifies the MCP transport for capture records.
 	// Set by each proxy surface, for example "mcp_stdio", "mcp_http_upstream",
 	// "mcp_http_listener", or "mcp_ws".
@@ -158,6 +164,20 @@ func (o MCPProxyOpts) captureObserver() capture.CaptureObserver {
 		return o.CaptureObs
 	}
 	return capture.NopObserver{}
+}
+
+func (o MCPProxyOpts) captureConfigHash() string {
+	if o.ConfigHashFn != nil {
+		return o.ConfigHashFn()
+	}
+	return o.ConfigHash
+}
+
+func (o MCPProxyOpts) captureProfile() string {
+	if o.ProfileFn != nil {
+		return o.ProfileFn()
+	}
+	return o.Profile
 }
 
 func (o MCPProxyOpts) warnContext() context.Context {

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -168,14 +168,18 @@ func (o MCPProxyOpts) captureObserver() capture.CaptureObserver {
 
 func (o MCPProxyOpts) captureConfigHash() string {
 	if o.ConfigHashFn != nil {
-		return o.ConfigHashFn()
+		if v := o.ConfigHashFn(); v != "" {
+			return v
+		}
 	}
 	return o.ConfigHash
 }
 
 func (o MCPProxyOpts) captureProfile() string {
 	if o.ProfileFn != nil {
-		return o.ProfileFn()
+		if v := o.ProfileFn(); v != "" {
+			return v
+		}
 	}
 	return o.Profile
 }

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -363,14 +363,15 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 					}
 				}
 				obs.ObserveToolScanVerdict(context.Background(), &capture.ToolScanRecord{
-					Subsurface:      "mcp_tools_list",
-					Transport:       opts.Transport,
-					SessionID:       captureSessionID(opts.Transport),
-					ConfigHash:      opts.captureConfigHash(),
-					Profile:         opts.captureProfile(),
-					RawFindings:     toolScanMatchesToFindings(toolResult.Matches),
-					EffectiveAction: toolCaptureAction,
-					Outcome:         captureOutcome(toolCaptureAction, toolResult.Clean),
+					Subsurface:        "mcp_tools_list",
+					Transport:         opts.Transport,
+					SessionID:         captureSessionID(opts.Transport),
+					SessionIDOriginal: captureSessionIDOriginal(opts.Transport),
+					ConfigHash:        opts.captureConfigHash(),
+					Profile:           opts.captureProfile(),
+					RawFindings:       toolScanMatchesToFindings(toolResult.Matches),
+					EffectiveAction:   toolCaptureAction,
+					Outcome:           captureOutcome(toolCaptureAction, toolResult.Clean),
 				})
 			}
 			if toolResult.IsToolsList && !toolResult.Clean {
@@ -599,14 +600,15 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 
 		// Capture: record response injection verdict.
 		obs.ObserveResponseVerdict(context.Background(), &capture.ResponseVerdictRecord{
-			Subsurface:      "response_mcp",
-			Transport:       opts.Transport,
-			SessionID:       captureSessionID(opts.Transport),
-			ConfigHash:      opts.captureConfigHash(),
-			Profile:         opts.captureProfile(),
-			RawFindings:     responseMatchesToFindings(verdict.Matches, effectiveAction),
-			EffectiveAction: effectiveAction,
-			Outcome:         captureOutcome(effectiveAction, false),
+			Subsurface:        "response_mcp",
+			Transport:         opts.Transport,
+			SessionID:         captureSessionID(opts.Transport),
+			SessionIDOriginal: captureSessionIDOriginal(opts.Transport),
+			ConfigHash:        opts.captureConfigHash(),
+			Profile:           opts.captureProfile(),
+			RawFindings:       responseMatchesToFindings(verdict.Matches, effectiveAction),
+			EffectiveAction:   effectiveAction,
+			Outcome:           captureOutcome(effectiveAction, false),
 		})
 	}
 

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -356,7 +356,11 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 			if toolResult.IsToolsList {
 				toolCaptureAction := config.ActionAllow
 				if !toolResult.Clean {
-					toolCaptureAction = toolCfg.Action
+					if toolCfg.Action != "" {
+						toolCaptureAction = toolCfg.Action
+					} else {
+						toolCaptureAction = config.ActionBlock
+					}
 				}
 				obs.ObserveToolScanVerdict(context.Background(), &capture.ToolScanRecord{
 					Subsurface:      "mcp_tools_list",

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -354,13 +354,19 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 			}
 			// Capture: record tools/list scan verdict.
 			if toolResult.IsToolsList {
+				toolCaptureAction := config.ActionAllow
+				if !toolResult.Clean {
+					toolCaptureAction = toolCfg.Action
+				}
 				obs.ObserveToolScanVerdict(context.Background(), &capture.ToolScanRecord{
 					Subsurface:      "mcp_tools_list",
 					Transport:       opts.Transport,
-					SessionID:       "mcp-" + opts.Transport,
+					SessionID:       captureSessionID(opts.Transport),
+					ConfigHash:      opts.captureConfigHash(),
+					Profile:         opts.captureProfile(),
 					RawFindings:     toolScanMatchesToFindings(toolResult.Matches),
-					EffectiveAction: toolCfg.Action,
-					Outcome:         captureOutcome(toolCfg.Action, toolResult.Clean),
+					EffectiveAction: toolCaptureAction,
+					Outcome:         captureOutcome(toolCaptureAction, toolResult.Clean),
 				})
 			}
 			if toolResult.IsToolsList && !toolResult.Clean {
@@ -591,7 +597,9 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 		obs.ObserveResponseVerdict(context.Background(), &capture.ResponseVerdictRecord{
 			Subsurface:      "response_mcp",
 			Transport:       opts.Transport,
-			SessionID:       "mcp-" + opts.Transport,
+			SessionID:       captureSessionID(opts.Transport),
+			ConfigHash:      opts.captureConfigHash(),
+			Profile:         opts.captureProfile(),
 			RawFindings:     responseMatchesToFindings(verdict.Matches, effectiveAction),
 			EffectiveAction: effectiveAction,
 			Outcome:         captureOutcome(effectiveAction, false),

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -357,6 +357,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 				obs.ObserveToolScanVerdict(context.Background(), &capture.ToolScanRecord{
 					Subsurface:      "mcp_tools_list",
 					Transport:       opts.Transport,
+					SessionID:       "mcp-" + opts.Transport,
 					RawFindings:     toolScanMatchesToFindings(toolResult.Matches),
 					EffectiveAction: toolCfg.Action,
 					Outcome:         captureOutcome(toolCfg.Action, toolResult.Clean),
@@ -590,6 +591,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 		obs.ObserveResponseVerdict(context.Background(), &capture.ResponseVerdictRecord{
 			Subsurface:      "response_mcp",
 			Transport:       opts.Transport,
+			SessionID:       "mcp-" + opts.Transport,
 			RawFindings:     responseMatchesToFindings(verdict.Matches, effectiveAction),
 			EffectiveAction: effectiveAction,
 			Outcome:         captureOutcome(effectiveAction, false),

--- a/internal/mcp/proxy_http.go
+++ b/internal/mcp/proxy_http.go
@@ -575,11 +575,12 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		if reason := ceeRecordMCP(ceeKey, msg, cee, sc, logW, auditLogger); reason != "" {
 			// Capture: record CEE verdict.
 			obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
-				Subsurface: "cee_mcp_http",
-				Transport:  opts.Transport,
-				SessionID:  captureSessionID(opts.Transport),
-				ConfigHash: opts.captureConfigHash(),
-				Profile:    opts.captureProfile(),
+				Subsurface:        "cee_mcp_http",
+				Transport:         opts.Transport,
+				SessionID:         captureSessionID(opts.Transport),
+				SessionIDOriginal: captureSessionIDOriginal(opts.Transport),
+				ConfigHash:        opts.captureConfigHash(),
+				Profile:           opts.captureProfile(),
 				RawFindings: []capture.Finding{{
 					Kind:   capture.KindCEE,
 					Action: config.ActionBlock,
@@ -820,11 +821,12 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		if reason := ceeRecordMCP(ceeKey, msg, cee, sc, logW, auditLogger); reason != "" {
 			// Capture: record CEE verdict (warn-path).
 			obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
-				Subsurface: "cee_mcp_http",
-				Transport:  opts.Transport,
-				SessionID:  captureSessionID(opts.Transport),
-				ConfigHash: opts.captureConfigHash(),
-				Profile:    opts.captureProfile(),
+				Subsurface:        "cee_mcp_http",
+				Transport:         opts.Transport,
+				SessionID:         captureSessionID(opts.Transport),
+				SessionIDOriginal: captureSessionIDOriginal(opts.Transport),
+				ConfigHash:        opts.captureConfigHash(),
+				Profile:           opts.captureProfile(),
 				RawFindings: []capture.Finding{{
 					Kind:   capture.KindCEE,
 					Action: config.ActionBlock,
@@ -848,15 +850,16 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			rawFindings = append(rawFindings, dlpMatchesToFindings(verdict.Matches)...)
 			rawFindings = append(rawFindings, responseMatchesToFindings(verdict.Inject, effectiveAction)...)
 			obs.ObserveDLPVerdict(context.Background(), &capture.DLPVerdictRecord{
-				Subsurface:      "dlp_mcp_input",
-				Transport:       opts.Transport,
-				SessionID:       captureSessionID(opts.Transport),
-				ConfigHash:      opts.captureConfigHash(),
-				Profile:         opts.captureProfile(),
-				TransformKind:   capture.TransformJoinedFields,
-				RawFindings:     rawFindings,
-				EffectiveAction: effectiveAction,
-				Outcome:         captureOutcome(effectiveAction, false),
+				Subsurface:        "dlp_mcp_input",
+				Transport:         opts.Transport,
+				SessionID:         captureSessionID(opts.Transport),
+				SessionIDOriginal: captureSessionIDOriginal(opts.Transport),
+				ConfigHash:        opts.captureConfigHash(),
+				Profile:           opts.captureProfile(),
+				TransformKind:     capture.TransformJoinedFields,
+				RawFindings:       rawFindings,
+				EffectiveAction:   effectiveAction,
+				Outcome:           captureOutcome(effectiveAction, false),
 			})
 		}
 		if verdict.Method == methodToolsCall {

--- a/internal/mcp/proxy_http.go
+++ b/internal/mcp/proxy_http.go
@@ -577,7 +577,9 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 				Subsurface: "cee_mcp_http",
 				Transport:  opts.Transport,
-				SessionID:  "mcp-" + opts.Transport,
+				SessionID:  captureSessionID(opts.Transport),
+				ConfigHash: opts.captureConfigHash(),
+				Profile:    opts.captureProfile(),
 				RawFindings: []capture.Finding{{
 					Kind:   capture.KindCEE,
 					Action: config.ActionBlock,
@@ -820,7 +822,9 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 				Subsurface: "cee_mcp_http",
 				Transport:  opts.Transport,
-				SessionID:  "mcp-" + opts.Transport,
+				SessionID:  captureSessionID(opts.Transport),
+				ConfigHash: opts.captureConfigHash(),
+				Profile:    opts.captureProfile(),
 				RawFindings: []capture.Finding{{
 					Kind:   capture.KindCEE,
 					Action: config.ActionBlock,
@@ -846,7 +850,9 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			obs.ObserveDLPVerdict(context.Background(), &capture.DLPVerdictRecord{
 				Subsurface:      "dlp_mcp_input",
 				Transport:       opts.Transport,
-				SessionID:       "mcp-" + opts.Transport,
+				SessionID:       captureSessionID(opts.Transport),
+				ConfigHash:      opts.captureConfigHash(),
+				Profile:         opts.captureProfile(),
 				TransformKind:   capture.TransformJoinedFields,
 				RawFindings:     rawFindings,
 				EffectiveAction: effectiveAction,
@@ -1111,6 +1117,10 @@ func RunHTTPListenerProxy(
 		ReceiptEmitter:      opts.receiptEmitter(),
 		ReceiptEmitterFn:    opts.ReceiptEmitterFn,
 		CaptureObs:          opts.captureObserver(),
+		ConfigHash:          opts.captureConfigHash(),
+		ConfigHashFn:        opts.ConfigHashFn,
+		Profile:             opts.captureProfile(),
+		ProfileFn:           opts.ProfileFn,
 		ProvenanceCfg:       opts.provenanceCfg(),
 		ProvenanceCfgFn:     opts.ProvenanceCfgFn,
 		RedactMatcher:       baseRedactionCfg.Matcher,

--- a/internal/mcp/proxy_http.go
+++ b/internal/mcp/proxy_http.go
@@ -577,6 +577,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 				Subsurface: "cee_mcp_http",
 				Transport:  opts.Transport,
+				SessionID:  "mcp-" + opts.Transport,
 				RawFindings: []capture.Finding{{
 					Kind:   capture.KindCEE,
 					Action: config.ActionBlock,
@@ -819,6 +820,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 				Subsurface: "cee_mcp_http",
 				Transport:  opts.Transport,
+				SessionID:  "mcp-" + opts.Transport,
 				RawFindings: []capture.Finding{{
 					Kind:   capture.KindCEE,
 					Action: config.ActionBlock,
@@ -844,6 +846,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			obs.ObserveDLPVerdict(context.Background(), &capture.DLPVerdictRecord{
 				Subsurface:      "dlp_mcp_input",
 				Transport:       opts.Transport,
+				SessionID:       "mcp-" + opts.Transport,
 				TransformKind:   capture.TransformJoinedFields,
 				RawFindings:     rawFindings,
 				EffectiveAction: effectiveAction,

--- a/internal/proxy/capture_metadata_e2e_test.go
+++ b/internal/proxy/capture_metadata_e2e_test.go
@@ -179,4 +179,16 @@ func TestCaptureMetadata_FetchPath_RoundTrip(t *testing.T) {
 	requireString("config_hash")
 	requireString("profile")
 	requireString("agent")
+
+	// session_id_original is omitted on the clean path (path-safe agent + IP).
+	// It only appears when the writer had to hash an unsafe or overlength key
+	// for the on-disk directory name, in which case it preserves the raw
+	// logical key for incident-response correlation. The fetch path uses the
+	// anonymous agent + 127.0.0.1, which is path-safe, so the field must be
+	// absent from this entry.
+	if v, ok := envelope.Detail["session_id_original"]; ok {
+		if s, _ := v.(string); s != "" {
+			t.Errorf("session_id_original = %q, want absent on path-safe key (would leak client IP into every record otherwise)", s)
+		}
+	}
 }

--- a/internal/proxy/capture_metadata_e2e_test.go
+++ b/internal/proxy/capture_metadata_e2e_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/capture"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+// TestCaptureMetadata_FetchPath_RoundTrip exercises a real Proxy with a
+// real capture.Writer wired in, drives a fetch request through the
+// handler, and asserts that every metadata field the LL pipeline depends
+// on (session_id, effective_action, config_hash, profile, agent) survives
+// from the proxy call site through the writer's worker into the recorder
+// JSONL on disk.
+//
+// This is the regression that locks in the SessionID-empty bug fix
+// (3c90945) and the caller-side ConfigHash + Profile + EffectiveAction
+// stamping (1e73278). Without those, the writer drops every entry as
+// "empty session ID" or shadow rejects deltas as "invalid:
+// original_verdict".
+func TestCaptureMetadata_FetchPath_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// Upstream that returns a tiny clean payload — the fetch path scans the
+	// URL, writes a URLVerdictRecord through the capture observer, and on
+	// allow proceeds to fetch the body. We only care about the
+	// URLVerdictRecord write here.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	cfg := testScannerConfig()
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+	m := metrics.New()
+
+	p, err := New(cfg, logger, sc, m)
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	captureDir := t.TempDir()
+	w, err := capture.NewWriter(capture.WriterConfig{
+		RecorderConfig: recorder.Config{
+			Enabled:           true,
+			Dir:               captureDir,
+			MaxEntriesPerFile: 100,
+		},
+		QueueSize:    64,
+		BuildVersion: "test",
+		BuildSHA:     "test-sha",
+	})
+	if err != nil {
+		t.Fatalf("capture.NewWriter: %v", err)
+	}
+	WithCaptureObserver(w)(p)
+
+	// Drive a fetch through the handler. The URL points at the httptest
+	// upstream; the URL itself is clean so the verdict resolves to allow.
+	req := httptest.NewRequest(http.MethodGet, "/fetch?url="+upstream.URL, nil)
+	rec := httptest.NewRecorder()
+	p.handleFetch(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("fetch handler: status %d, want 200", rec.Code)
+	}
+
+	// Drain + close the writer so all queued entries flush to disk.
+	if err := w.Close(); err != nil {
+		t.Fatalf("writer.Close: %v", err)
+	}
+
+	// Find the recorder JSONL inside the capture dir. Schema:
+	//   <captureDir>/<sanitized session id>/evidence-<sid>-<seq>.jsonl
+	// Find the first session subdir and the first JSONL inside it.
+	sessions, err := os.ReadDir(captureDir)
+	if err != nil {
+		t.Fatalf("read capture dir: %v", err)
+	}
+	var jsonlPath string
+	for _, sd := range sessions {
+		if !sd.IsDir() || sd.Name() == "capture-meta" {
+			continue
+		}
+		sessDir := filepath.Join(captureDir, sd.Name())
+		entries, derr := os.ReadDir(sessDir)
+		if derr != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !strings.HasSuffix(e.Name(), ".jsonl") {
+				continue
+			}
+			jsonlPath = filepath.Join(sessDir, e.Name())
+			break
+		}
+		if jsonlPath != "" {
+			break
+		}
+	}
+	if jsonlPath == "" {
+		t.Fatalf("no recorder JSONL found in capture dir %s — drops likely (regression)", captureDir)
+	}
+
+	// Read the first capture entry. It is a recorder.Entry with the
+	// CaptureSummary in Detail.
+	fh, err := os.Open(filepath.Clean(jsonlPath))
+	if err != nil {
+		t.Fatalf("open capture jsonl: %v", err)
+	}
+	defer func() { _ = fh.Close() }()
+	scanLine := bufio.NewScanner(fh)
+	scanLine.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	if !scanLine.Scan() {
+		t.Fatalf("empty capture jsonl")
+	}
+	var envelope struct {
+		Type      string                 `json:"type"`
+		EventKind string                 `json:"event_kind"`
+		SessionID string                 `json:"session_id"`
+		TraceID   string                 `json:"trace_id"`
+		Detail    map[string]interface{} `json:"detail"`
+	}
+	if err := json.Unmarshal(scanLine.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode capture entry: %v", err)
+	}
+
+	// The entry's outer envelope must carry session_id and an event kind
+	// derived from the capture surface. Empty session_id was the original
+	// bug — assert non-empty.
+	if envelope.SessionID == "" {
+		t.Errorf("capture entry session_id empty — SessionID stamping regressed")
+	}
+	if envelope.Type != "capture" {
+		t.Errorf("capture entry type = %q, want capture", envelope.Type)
+	}
+	if envelope.EventKind == "" {
+		t.Errorf("capture entry event_kind empty — surface stamping regressed")
+	}
+
+	// CaptureSummary fields the LL pipeline depends on. effective_action
+	// must be a non-empty action string so shadow can compute a non-empty
+	// original_verdict. config_hash + profile must be populated so
+	// downstream replay can reconstruct the contract a rule was scanned
+	// against.
+	requireString := func(field string) {
+		t.Helper()
+		v, ok := envelope.Detail[field]
+		if !ok {
+			t.Errorf("capture detail missing %q field", field)
+			return
+		}
+		s, ok := v.(string)
+		if !ok {
+			t.Errorf("capture detail %q is %T, want string", field, v)
+			return
+		}
+		if s == "" {
+			t.Errorf("capture detail %q is empty — caller-side stamping regressed", field)
+		}
+	}
+	requireString("effective_action")
+	requireString("config_hash")
+	requireString("profile")
+	requireString("agent")
+}

--- a/internal/proxy/cee.go
+++ b/internal/proxy/cee.go
@@ -41,15 +41,39 @@ const maxCaptureSessionKeyLen = 200
 // or overlength keys are mapped to a bounded hash instead of being dropped by
 // the writer.
 func captureSessionKey(agent, clientIP string) string {
+	safe, _ := captureSessionKeyAndOriginal(agent, clientIP)
+	return safe
+}
+
+// captureSessionKeyAndOriginal returns the safe directory-name session key and
+// the original logical key. When the two differ, the safe value was derived
+// via SHA-256 to escape an unsafe or overlength input. Capture call sites
+// stamp the original into the record so audit/incident response can map an
+// opaque "capture-<hex>" directory back to its self-attested agent identity.
+func captureSessionKeyAndOriginal(agent, clientIP string) (safe, original string) {
 	key := CeeSessionKey(agent, clientIP)
 	if key == "" {
 		key = agentAnonymous
 	}
 	if strings.ContainsAny(key, `/\`) || strings.Contains(key, "..") || len(key) > maxCaptureSessionKeyLen {
 		sum := sha256.Sum256([]byte(key))
-		return "capture-" + hex.EncodeToString(sum[:])
+		return "capture-" + hex.EncodeToString(sum[:]), key
 	}
-	return key
+	return key, key
+}
+
+// captureSessionKeyOriginal returns the unsanitized logical session key when
+// the safe directory-name key was derived via hashing, and the empty string
+// otherwise. Capture call sites assign the result to record.SessionIDOriginal
+// (omitempty), so on the clean path no IP-bearing identity leaks into every
+// capture record; the field appears only when a sanitized "capture-<hex>"
+// directory needs an audit trail back to its raw logical key.
+func captureSessionKeyOriginal(agent, clientIP string) string {
+	safe, original := captureSessionKeyAndOriginal(agent, clientIP)
+	if safe == original {
+		return ""
+	}
+	return original
 }
 
 // ResetCEEState clears entropy and fragment state for a session identity.

--- a/internal/proxy/cee.go
+++ b/internal/proxy/cee.go
@@ -31,15 +31,21 @@ func CeeSessionKey(agent, clientIP string) string {
 	return clientIP
 }
 
+// maxCaptureSessionKeyLen bounds the on-disk session directory name length.
+// Most filesystems cap a single path component at 255 bytes (NAME_MAX); pick a
+// conservative ceiling so the writer never bumps that limit.
+const maxCaptureSessionKeyLen = 200
+
 // captureSessionKey returns the CEE session identity when it is safe to use as
 // a recorder directory name. Self-declared agent names are untrusted, so unsafe
-// keys are mapped to a bounded hash instead of being dropped by the writer.
+// or overlength keys are mapped to a bounded hash instead of being dropped by
+// the writer.
 func captureSessionKey(agent, clientIP string) string {
 	key := CeeSessionKey(agent, clientIP)
 	if key == "" {
 		key = agentAnonymous
 	}
-	if strings.ContainsAny(key, `/\`) || strings.Contains(key, "..") {
+	if strings.ContainsAny(key, `/\`) || strings.Contains(key, "..") || len(key) > maxCaptureSessionKeyLen {
 		sum := sha256.Sum256([]byte(key))
 		return "capture-" + hex.EncodeToString(sum[:])
 	}

--- a/internal/proxy/cee.go
+++ b/internal/proxy/cee.go
@@ -6,6 +6,8 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,6 +29,21 @@ func CeeSessionKey(agent, clientIP string) string {
 		return agent + "|" + clientIP
 	}
 	return clientIP
+}
+
+// captureSessionKey returns the CEE session identity when it is safe to use as
+// a recorder directory name. Self-declared agent names are untrusted, so unsafe
+// keys are mapped to a bounded hash instead of being dropped by the writer.
+func captureSessionKey(agent, clientIP string) string {
+	key := CeeSessionKey(agent, clientIP)
+	if key == "" {
+		key = agentAnonymous
+	}
+	if strings.ContainsAny(key, `/\`) || strings.Contains(key, "..") {
+		sum := sha256.Sum256([]byte(key))
+		return "capture-" + hex.EncodeToString(sum[:])
+	}
+	return key
 }
 
 // ResetCEEState clears entropy and fragment state for a session identity.

--- a/internal/proxy/cee_test.go
+++ b/internal/proxy/cee_test.go
@@ -49,6 +49,19 @@ func TestCeeSessionKey_AnonymousAgent(t *testing.T) {
 	}
 }
 
+func TestCaptureSessionKey_SafeForRecorderDirectory(t *testing.T) {
+	if got := captureSessionKey(testCEEAgent, testCEEClientIP); got != testCEEAgent+"|"+testCEEClientIP {
+		t.Fatalf("safe captureSessionKey = %q, want %q", got, testCEEAgent+"|"+testCEEClientIP)
+	}
+	got := captureSessionKey("../bad/agent", testCEEClientIP)
+	if !strings.HasPrefix(got, "capture-") {
+		t.Fatalf("unsafe captureSessionKey = %q, want hashed capture prefix", got)
+	}
+	if strings.ContainsAny(got, `/\`) || strings.Contains(got, "..") {
+		t.Fatalf("unsafe captureSessionKey produced invalid directory segment %q", got)
+	}
+}
+
 func TestExtractOutboundPayload_QueryParams(t *testing.T) {
 	// Keys are intentionally out of alphabetical order to prove wire-order extraction.
 	r := &http.Request{

--- a/internal/proxy/cee_test.go
+++ b/internal/proxy/cee_test.go
@@ -62,6 +62,31 @@ func TestCaptureSessionKey_SafeForRecorderDirectory(t *testing.T) {
 	}
 }
 
+func TestCaptureSessionKeyAndOriginal_PreservesUnsafeIdentity(t *testing.T) {
+	// Safe input: original equals safe (no hashing happened, audit needs no
+	// extra provenance).
+	safe, original := captureSessionKeyAndOriginal(testCEEAgent, testCEEClientIP)
+	if safe != testCEEAgent+"|"+testCEEClientIP || original != safe {
+		t.Fatalf("safe identity: got (%q, %q), want both = %q", safe, original, testCEEAgent+"|"+testCEEClientIP)
+	}
+
+	// Unsafe input: safe is hashed, but original retains the raw key so audit
+	// can map an opaque "capture-<hex>" directory back to the agent identity
+	// that triggered sanitization.
+	rawAgent := "../bad/agent"
+	rawKey := rawAgent + "|" + testCEEClientIP
+	safe, original = captureSessionKeyAndOriginal(rawAgent, testCEEClientIP)
+	if !strings.HasPrefix(safe, "capture-") {
+		t.Fatalf("unsafe safe key = %q, want capture- prefix", safe)
+	}
+	if original != rawKey {
+		t.Fatalf("unsafe original = %q, want %q (raw logical key for audit correlation)", original, rawKey)
+	}
+	if safe == original {
+		t.Fatalf("safe and original must differ when sanitization triggered: %q", safe)
+	}
+}
+
 func TestExtractOutboundPayload_QueryParams(t *testing.T) {
 	// Keys are intentionally out of alphabetical order to prove wire-order extraction.
 	r := &http.Request{

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -174,16 +174,18 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// Capture observer: record CONNECT URL verdict for policy replay.
 	{
 		findings := urlResultToFindings(result)
-		action := ""
+		action := config.ActionAllow
 		if !result.Allowed {
 			action = config.ActionBlock
 		}
 		p.captureObs.ObserveURLVerdict(r.Context(), &capture.URLVerdictRecord{
 			Subsurface:        "connect_url",
 			Transport:         "connect",
-			SessionID:         CeeSessionKey(agent, clientIP),
+			SessionID:         captureSessionKey(agent, clientIP),
 			RequestID:         requestID,
+			ConfigHash:        cfg.CanonicalPolicyHash(),
 			Agent:             agent,
+			Profile:           id.Profile,
 			Request:           capture.CaptureRequest{Method: http.MethodConnect, URL: syntheticURL},
 			RawFindings:       findings,
 			EffectiveFindings: findings,
@@ -538,6 +540,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 			ClientIP:           clientIP,
 			RequestID:          requestID,
 			Agent:              agent,
+			Profile:            id.Profile,
 			ActorAuth:          id.Auth,
 			UpstreamRT:         p.tlsTransport,
 			SafeDial:           p.ssrfSafeDialContext,
@@ -726,16 +729,18 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	// Capture observer: record forward URL verdict for policy replay.
 	{
 		findings := urlResultToFindings(result)
-		action := ""
+		action := config.ActionAllow
 		if !result.Allowed {
 			action = config.ActionBlock
 		}
 		p.captureObs.ObserveURLVerdict(r.Context(), &capture.URLVerdictRecord{
 			Subsurface:        "forward_url",
 			Transport:         "forward",
-			SessionID:         CeeSessionKey(agent, clientIP),
+			SessionID:         captureSessionKey(agent, clientIP),
 			RequestID:         requestID,
+			ConfigHash:        cfg.CanonicalPolicyHash(),
 			Agent:             agent,
+			Profile:           id.Profile,
 			Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
 			RawFindings:       findings,
 			EffectiveFindings: findings,
@@ -962,7 +967,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 
 		// Capture observer: record forward body DLP verdict for policy replay.
 		{
-			bodyAction := ""
+			bodyAction := config.ActionAllow
 			if !bodyResult.Clean {
 				bodyAction = bodyResult.Action
 				if bodyAction == "" {
@@ -972,9 +977,11 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 				Subsurface:      "dlp_body_forward",
 				Transport:       "forward",
-				SessionID:       CeeSessionKey(agent, clientIP),
+				SessionID:       captureSessionKey(agent, clientIP),
 				RequestID:       requestID,
+				ConfigHash:      cfg.CanonicalPolicyHash(),
 				Agent:           agent,
+				Profile:         id.Profile,
 				Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
 				TransformKind:   capture.TransformJoinedFields,
 				RawFindings:     bodyScanToFindings(bodyResult),
@@ -1154,7 +1161,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Capture observer: record forward header DLP verdict for policy replay.
 	{
-		hdrAction := ""
+		hdrAction := config.ActionAllow
 		if forwardHeaderBlocked {
 			hdrAction = config.ActionBlock
 		} else if forwardHeaderHadFinding {
@@ -1163,9 +1170,11 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 			Subsurface:      "dlp_header_forward",
 			Transport:       "forward",
-			SessionID:       CeeSessionKey(agent, clientIP),
+			SessionID:       captureSessionKey(agent, clientIP),
 			RequestID:       requestID,
+			ConfigHash:      cfg.CanonicalPolicyHash(),
 			Agent:           agent,
+			Profile:         id.Profile,
 			Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
 			TransformKind:   capture.TransformHeaderValue,
 			EffectiveAction: hdrAction,
@@ -1229,7 +1238,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 
 		// Capture observer: record forward CEE verdict for policy replay.
 		ceeFindings := ceeResultToFindings(ceeRes)
-		ceeAction := ""
+		ceeAction := config.ActionAllow
 		if ceeRes.Blocked {
 			ceeAction = config.ActionBlock
 		} else if ceeRes.EntropyHit || ceeRes.FragmentHit {
@@ -1238,9 +1247,11 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		p.captureObs.ObserveCEEVerdict(r.Context(), &capture.CEERecord{
 			Subsurface:        "cee_forward",
 			Transport:         "forward",
-			SessionID:         CeeSessionKey(agent, clientIP),
+			SessionID:         captureSessionKey(agent, clientIP),
 			RequestID:         requestID,
+			ConfigHash:        cfg.CanonicalPolicyHash(),
 			Agent:             agent,
+			Profile:           id.Profile,
 			Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
 			TransformKind:     capture.TransformCEEWindow,
 			RawFindings:       ceeFindings,
@@ -1729,14 +1740,16 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 					fwdRespAction = config.ActionWarn
 				}
 				if scanResult.Clean {
-					fwdRespAction = ""
+					fwdRespAction = config.ActionAllow
 				}
 				p.captureObs.ObserveResponseVerdict(r.Context(), &capture.ResponseVerdictRecord{
 					Subsurface:        "response_forward",
 					Transport:         "forward",
-					SessionID:         CeeSessionKey(agent, clientIP),
+					SessionID:         captureSessionKey(agent, clientIP),
 					RequestID:         requestID,
+					ConfigHash:        cfg.CanonicalPolicyHash(),
 					Agent:             agent,
+					Profile:           id.Profile,
 					Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
 					TransformKind:     capture.TransformRaw,
 					RawFindings:       responseMatchesToFindings(scanResult.Matches, fwdRespAction),

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -182,6 +182,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 			Subsurface:        "connect_url",
 			Transport:         "connect",
 			SessionID:         captureSessionKey(agent, clientIP),
+			SessionIDOriginal: captureSessionKeyOriginal(agent, clientIP),
 			RequestID:         requestID,
 			ConfigHash:        cfg.CanonicalPolicyHash(),
 			Agent:             agent,
@@ -737,6 +738,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			Subsurface:        "forward_url",
 			Transport:         "forward",
 			SessionID:         captureSessionKey(agent, clientIP),
+			SessionIDOriginal: captureSessionKeyOriginal(agent, clientIP),
 			RequestID:         requestID,
 			ConfigHash:        cfg.CanonicalPolicyHash(),
 			Agent:             agent,
@@ -975,18 +977,19 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
-				Subsurface:      "dlp_body_forward",
-				Transport:       "forward",
-				SessionID:       captureSessionKey(agent, clientIP),
-				RequestID:       requestID,
-				ConfigHash:      cfg.CanonicalPolicyHash(),
-				Agent:           agent,
-				Profile:         id.Profile,
-				Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
-				TransformKind:   capture.TransformJoinedFields,
-				RawFindings:     bodyScanToFindings(bodyResult),
-				EffectiveAction: bodyAction,
-				Outcome:         captureOutcome(bodyAction, bodyResult.Clean),
+				Subsurface:        "dlp_body_forward",
+				Transport:         "forward",
+				SessionID:         captureSessionKey(agent, clientIP),
+				SessionIDOriginal: captureSessionKeyOriginal(agent, clientIP),
+				RequestID:         requestID,
+				ConfigHash:        cfg.CanonicalPolicyHash(),
+				Agent:             agent,
+				Profile:           id.Profile,
+				Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
+				TransformKind:     capture.TransformJoinedFields,
+				RawFindings:       bodyScanToFindings(bodyResult),
+				EffectiveAction:   bodyAction,
+				Outcome:           captureOutcome(bodyAction, bodyResult.Clean),
 			})
 		}
 		forwardRedactionReport = bodyResult.RedactionReport
@@ -1168,17 +1171,18 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			hdrAction = config.ActionWarn
 		}
 		p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
-			Subsurface:      "dlp_header_forward",
-			Transport:       "forward",
-			SessionID:       captureSessionKey(agent, clientIP),
-			RequestID:       requestID,
-			ConfigHash:      cfg.CanonicalPolicyHash(),
-			Agent:           agent,
-			Profile:         id.Profile,
-			Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
-			TransformKind:   capture.TransformHeaderValue,
-			EffectiveAction: hdrAction,
-			Outcome:         captureOutcome(hdrAction, !forwardHeaderHadFinding),
+			Subsurface:        "dlp_header_forward",
+			Transport:         "forward",
+			SessionID:         captureSessionKey(agent, clientIP),
+			SessionIDOriginal: captureSessionKeyOriginal(agent, clientIP),
+			RequestID:         requestID,
+			ConfigHash:        cfg.CanonicalPolicyHash(),
+			Agent:             agent,
+			Profile:           id.Profile,
+			Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
+			TransformKind:     capture.TransformHeaderValue,
+			EffectiveAction:   hdrAction,
+			Outcome:           captureOutcome(hdrAction, !forwardHeaderHadFinding),
 		})
 	}
 
@@ -1248,6 +1252,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			Subsurface:        "cee_forward",
 			Transport:         "forward",
 			SessionID:         captureSessionKey(agent, clientIP),
+			SessionIDOriginal: captureSessionKeyOriginal(agent, clientIP),
 			RequestID:         requestID,
 			ConfigHash:        cfg.CanonicalPolicyHash(),
 			Agent:             agent,
@@ -1746,6 +1751,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 					Subsurface:        "response_forward",
 					Transport:         "forward",
 					SessionID:         captureSessionKey(agent, clientIP),
+					SessionIDOriginal: captureSessionKeyOriginal(agent, clientIP),
 					RequestID:         requestID,
 					ConfigHash:        cfg.CanonicalPolicyHash(),
 					Agent:             agent,

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -181,6 +181,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		p.captureObs.ObserveURLVerdict(r.Context(), &capture.URLVerdictRecord{
 			Subsurface:        "connect_url",
 			Transport:         "connect",
+			SessionID:         CeeSessionKey(agent, clientIP),
 			RequestID:         requestID,
 			Agent:             agent,
 			Request:           capture.CaptureRequest{Method: http.MethodConnect, URL: syntheticURL},
@@ -732,6 +733,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		p.captureObs.ObserveURLVerdict(r.Context(), &capture.URLVerdictRecord{
 			Subsurface:        "forward_url",
 			Transport:         "forward",
+			SessionID:         CeeSessionKey(agent, clientIP),
 			RequestID:         requestID,
 			Agent:             agent,
 			Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
@@ -970,6 +972,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 				Subsurface:      "dlp_body_forward",
 				Transport:       "forward",
+				SessionID:       CeeSessionKey(agent, clientIP),
 				RequestID:       requestID,
 				Agent:           agent,
 				Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
@@ -1160,6 +1163,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 			Subsurface:      "dlp_header_forward",
 			Transport:       "forward",
+			SessionID:       CeeSessionKey(agent, clientIP),
 			RequestID:       requestID,
 			Agent:           agent,
 			Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
@@ -1234,6 +1238,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		p.captureObs.ObserveCEEVerdict(r.Context(), &capture.CEERecord{
 			Subsurface:        "cee_forward",
 			Transport:         "forward",
+			SessionID:         CeeSessionKey(agent, clientIP),
 			RequestID:         requestID,
 			Agent:             agent,
 			Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
@@ -1729,6 +1734,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 				p.captureObs.ObserveResponseVerdict(r.Context(), &capture.ResponseVerdictRecord{
 					Subsurface:        "response_forward",
 					Transport:         "forward",
+					SessionID:         CeeSessionKey(agent, clientIP),
 					RequestID:         requestID,
 					Agent:             agent,
 					Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -58,6 +58,7 @@ type InterceptContext struct {
 	ClientIP  string
 	RequestID string
 	Agent     string
+	Profile   string
 	ActorAuth envelope.ActorAuth
 
 	UpstreamRT http.RoundTripper
@@ -483,16 +484,18 @@ func newInterceptHandler(
 		// Capture observer: record intercept URL verdict for policy replay.
 		if ic.Proxy != nil {
 			findings := urlResultToFindings(urlResult)
-			action := ""
+			action := config.ActionAllow
 			if !urlResult.Allowed {
 				action = config.ActionBlock
 			}
 			ic.Proxy.captureObs.ObserveURLVerdict(r.Context(), &capture.URLVerdictRecord{
 				Subsurface:        "intercept_url",
 				Transport:         "connect",
-				SessionID:         CeeSessionKey(ic.Agent, ic.ClientIP),
+				SessionID:         captureSessionKey(ic.Agent, ic.ClientIP),
 				RequestID:         ic.RequestID,
+				ConfigHash:        ic.Config.CanonicalPolicyHash(),
 				Agent:             ic.Agent,
+				Profile:           ic.Profile,
 				Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
 				RawFindings:       findings,
 				EffectiveFindings: findings,
@@ -687,7 +690,7 @@ func newInterceptHandler(
 
 			// Capture observer: record intercept body DLP verdict for policy replay.
 			if ic.Proxy != nil {
-				bodyAction := ""
+				bodyAction := config.ActionAllow
 				if !result.Clean {
 					bodyAction = result.Action
 					if bodyAction == "" {
@@ -697,9 +700,11 @@ func newInterceptHandler(
 				ic.Proxy.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 					Subsurface:      "dlp_body_intercept",
 					Transport:       "connect",
-					SessionID:       CeeSessionKey(ic.Agent, ic.ClientIP),
+					SessionID:       captureSessionKey(ic.Agent, ic.ClientIP),
 					RequestID:       ic.RequestID,
+					ConfigHash:      ic.Config.CanonicalPolicyHash(),
 					Agent:           ic.Agent,
+					Profile:         ic.Profile,
 					Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
 					TransformKind:   capture.TransformJoinedFields,
 					RawFindings:     bodyScanToFindings(result),
@@ -889,16 +894,18 @@ func newInterceptHandler(
 			// Capture observer: record intercept header DLP verdict for policy replay.
 			if ic.Proxy != nil {
 				hdrHasFinding := headerResult != nil && !headerResult.Clean
-				hdrAction := ""
+				hdrAction := config.ActionAllow
 				if hdrHasFinding {
 					hdrAction = ic.Config.RequestBodyScanning.Action
 				}
 				ic.Proxy.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 					Subsurface:      "dlp_header_intercept",
 					Transport:       "connect",
-					SessionID:       CeeSessionKey(ic.Agent, ic.ClientIP),
+					SessionID:       captureSessionKey(ic.Agent, ic.ClientIP),
 					RequestID:       ic.RequestID,
+					ConfigHash:      ic.Config.CanonicalPolicyHash(),
 					Agent:           ic.Agent,
+					Profile:         ic.Profile,
 					Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
 					TransformKind:   capture.TransformHeaderValue,
 					EffectiveAction: hdrAction,
@@ -957,7 +964,7 @@ func newInterceptHandler(
 			// Capture observer: record intercept CEE verdict for policy replay.
 			if ic.Proxy != nil {
 				ceeFindings := ceeResultToFindings(ceeRes)
-				ceeAction := ""
+				ceeAction := config.ActionAllow
 				if ceeRes.Blocked {
 					ceeAction = config.ActionBlock
 				} else if ceeRes.EntropyHit || ceeRes.FragmentHit {
@@ -966,9 +973,11 @@ func newInterceptHandler(
 				ic.Proxy.captureObs.ObserveCEEVerdict(r.Context(), &capture.CEERecord{
 					Subsurface:        "cee_intercept",
 					Transport:         "connect",
-					SessionID:         CeeSessionKey(ic.Agent, ic.ClientIP),
+					SessionID:         captureSessionKey(ic.Agent, ic.ClientIP),
 					RequestID:         ic.RequestID,
+					ConfigHash:        ic.Config.CanonicalPolicyHash(),
 					Agent:             ic.Agent,
+					Profile:           ic.Profile,
 					Request:           capture.CaptureRequest{Method: r.Method, URL: r.URL.String()},
 					TransformKind:     capture.TransformCEEWindow,
 					RawFindings:       ceeFindings,
@@ -1443,31 +1452,6 @@ func newInterceptHandler(
 		if ic.Scanner.ResponseScanningEnabled() {
 			scanResult := ic.Scanner.ScanResponse(r.Context(), string(respBody))
 
-			// Capture observer: record intercept response scan verdict for policy replay.
-			// Apply exempt override before capture so the recorded action matches runtime.
-			if ic.Proxy != nil {
-				iRespAction := ic.Scanner.ResponseAction()
-				if interceptRespExempt {
-					iRespAction = config.ActionWarn
-				}
-				if scanResult.Clean {
-					iRespAction = ""
-				}
-				ic.Proxy.captureObs.ObserveResponseVerdict(r.Context(), &capture.ResponseVerdictRecord{
-					Subsurface:        "response_intercept",
-					Transport:         "connect",
-					SessionID:         CeeSessionKey(ic.Agent, ic.ClientIP),
-					RequestID:         ic.RequestID,
-					Agent:             ic.Agent,
-					Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
-					TransformKind:     capture.TransformRaw,
-					RawFindings:       responseMatchesToFindings(scanResult.Matches, iRespAction),
-					EffectiveFindings: responseMatchesToFindings(scanResult.Matches, iRespAction),
-					EffectiveAction:   iRespAction,
-					Outcome:           captureOutcome(iRespAction, scanResult.Clean),
-				})
-			}
-
 			// Filter out suppressed findings (parity with fetch proxy).
 			if !scanResult.Clean && len(ic.Config.Suppress) > 0 {
 				var kept []scanner.ResponseMatch
@@ -1480,6 +1464,33 @@ func newInterceptHandler(
 				}
 				scanResult.Matches = kept
 				scanResult.Clean = len(kept) == 0
+			}
+
+			// Capture observer: record intercept response scan verdict for policy replay.
+			// Runs after suppression so the recorded action matches runtime.
+			if ic.Proxy != nil {
+				iRespAction := ic.Scanner.ResponseAction()
+				if interceptRespExempt {
+					iRespAction = config.ActionWarn
+				}
+				if scanResult.Clean {
+					iRespAction = config.ActionAllow
+				}
+				ic.Proxy.captureObs.ObserveResponseVerdict(r.Context(), &capture.ResponseVerdictRecord{
+					Subsurface:        "response_intercept",
+					Transport:         "connect",
+					SessionID:         captureSessionKey(ic.Agent, ic.ClientIP),
+					RequestID:         ic.RequestID,
+					ConfigHash:        ic.Config.CanonicalPolicyHash(),
+					Agent:             ic.Agent,
+					Profile:           ic.Profile,
+					Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
+					TransformKind:     capture.TransformRaw,
+					RawFindings:       responseMatchesToFindings(scanResult.Matches, iRespAction),
+					EffectiveFindings: responseMatchesToFindings(scanResult.Matches, iRespAction),
+					EffectiveAction:   iRespAction,
+					Outcome:           captureOutcome(iRespAction, scanResult.Clean),
+				})
 			}
 			if !scanResult.Clean {
 				hasFinding = true

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -492,6 +492,7 @@ func newInterceptHandler(
 				Subsurface:        "intercept_url",
 				Transport:         "connect",
 				SessionID:         captureSessionKey(ic.Agent, ic.ClientIP),
+				SessionIDOriginal: captureSessionKeyOriginal(ic.Agent, ic.ClientIP),
 				RequestID:         ic.RequestID,
 				ConfigHash:        ic.Config.CanonicalPolicyHash(),
 				Agent:             ic.Agent,
@@ -698,18 +699,19 @@ func newInterceptHandler(
 					}
 				}
 				ic.Proxy.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
-					Subsurface:      "dlp_body_intercept",
-					Transport:       "connect",
-					SessionID:       captureSessionKey(ic.Agent, ic.ClientIP),
-					RequestID:       ic.RequestID,
-					ConfigHash:      ic.Config.CanonicalPolicyHash(),
-					Agent:           ic.Agent,
-					Profile:         ic.Profile,
-					Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
-					TransformKind:   capture.TransformJoinedFields,
-					RawFindings:     bodyScanToFindings(result),
-					EffectiveAction: bodyAction,
-					Outcome:         captureOutcome(bodyAction, result.Clean),
+					Subsurface:        "dlp_body_intercept",
+					Transport:         "connect",
+					SessionID:         captureSessionKey(ic.Agent, ic.ClientIP),
+					SessionIDOriginal: captureSessionKeyOriginal(ic.Agent, ic.ClientIP),
+					RequestID:         ic.RequestID,
+					ConfigHash:        ic.Config.CanonicalPolicyHash(),
+					Agent:             ic.Agent,
+					Profile:           ic.Profile,
+					Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
+					TransformKind:     capture.TransformJoinedFields,
+					RawFindings:       bodyScanToFindings(result),
+					EffectiveAction:   bodyAction,
+					Outcome:           captureOutcome(bodyAction, result.Clean),
 				})
 			}
 			interceptRedactionReport = result.RedactionReport
@@ -899,17 +901,18 @@ func newInterceptHandler(
 					hdrAction = ic.Config.RequestBodyScanning.Action
 				}
 				ic.Proxy.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
-					Subsurface:      "dlp_header_intercept",
-					Transport:       "connect",
-					SessionID:       captureSessionKey(ic.Agent, ic.ClientIP),
-					RequestID:       ic.RequestID,
-					ConfigHash:      ic.Config.CanonicalPolicyHash(),
-					Agent:           ic.Agent,
-					Profile:         ic.Profile,
-					Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
-					TransformKind:   capture.TransformHeaderValue,
-					EffectiveAction: hdrAction,
-					Outcome:         captureOutcome(hdrAction, !hdrHasFinding),
+					Subsurface:        "dlp_header_intercept",
+					Transport:         "connect",
+					SessionID:         captureSessionKey(ic.Agent, ic.ClientIP),
+					SessionIDOriginal: captureSessionKeyOriginal(ic.Agent, ic.ClientIP),
+					RequestID:         ic.RequestID,
+					ConfigHash:        ic.Config.CanonicalPolicyHash(),
+					Agent:             ic.Agent,
+					Profile:           ic.Profile,
+					Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
+					TransformKind:     capture.TransformHeaderValue,
+					EffectiveAction:   hdrAction,
+					Outcome:           captureOutcome(hdrAction, !hdrHasFinding),
 				})
 			}
 
@@ -974,6 +977,7 @@ func newInterceptHandler(
 					Subsurface:        "cee_intercept",
 					Transport:         "connect",
 					SessionID:         captureSessionKey(ic.Agent, ic.ClientIP),
+					SessionIDOriginal: captureSessionKeyOriginal(ic.Agent, ic.ClientIP),
 					RequestID:         ic.RequestID,
 					ConfigHash:        ic.Config.CanonicalPolicyHash(),
 					Agent:             ic.Agent,
@@ -1480,6 +1484,7 @@ func newInterceptHandler(
 					Subsurface:        "response_intercept",
 					Transport:         "connect",
 					SessionID:         captureSessionKey(ic.Agent, ic.ClientIP),
+					SessionIDOriginal: captureSessionKeyOriginal(ic.Agent, ic.ClientIP),
 					RequestID:         ic.RequestID,
 					ConfigHash:        ic.Config.CanonicalPolicyHash(),
 					Agent:             ic.Agent,

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -490,6 +490,7 @@ func newInterceptHandler(
 			ic.Proxy.captureObs.ObserveURLVerdict(r.Context(), &capture.URLVerdictRecord{
 				Subsurface:        "intercept_url",
 				Transport:         "connect",
+				SessionID:         CeeSessionKey(ic.Agent, ic.ClientIP),
 				RequestID:         ic.RequestID,
 				Agent:             ic.Agent,
 				Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
@@ -696,6 +697,7 @@ func newInterceptHandler(
 				ic.Proxy.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 					Subsurface:      "dlp_body_intercept",
 					Transport:       "connect",
+					SessionID:       CeeSessionKey(ic.Agent, ic.ClientIP),
 					RequestID:       ic.RequestID,
 					Agent:           ic.Agent,
 					Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
@@ -894,6 +896,7 @@ func newInterceptHandler(
 				ic.Proxy.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 					Subsurface:      "dlp_header_intercept",
 					Transport:       "connect",
+					SessionID:       CeeSessionKey(ic.Agent, ic.ClientIP),
 					RequestID:       ic.RequestID,
 					Agent:           ic.Agent,
 					Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
@@ -963,6 +966,7 @@ func newInterceptHandler(
 				ic.Proxy.captureObs.ObserveCEEVerdict(r.Context(), &capture.CEERecord{
 					Subsurface:        "cee_intercept",
 					Transport:         "connect",
+					SessionID:         CeeSessionKey(ic.Agent, ic.ClientIP),
 					RequestID:         ic.RequestID,
 					Agent:             ic.Agent,
 					Request:           capture.CaptureRequest{Method: r.Method, URL: r.URL.String()},
@@ -1452,6 +1456,7 @@ func newInterceptHandler(
 				ic.Proxy.captureObs.ObserveResponseVerdict(r.Context(), &capture.ResponseVerdictRecord{
 					Subsurface:        "response_intercept",
 					Transport:         "connect",
+					SessionID:         CeeSessionKey(ic.Agent, ic.ClientIP),
 					RequestID:         ic.RequestID,
 					Agent:             ic.Agent,
 					Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2509,13 +2509,14 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	// Capture observer: record URL verdict for policy replay.
 	urlFindings := urlResultToFindings(result)
 	urlOutcome := captureOutcome(config.ActionBlock, result.Allowed)
-	urlAction := ""
+	urlAction := config.ActionAllow
 	if !result.Allowed {
 		urlAction = config.ActionBlock
 	}
 	p.captureObs.ObserveURLVerdict(r.Context(), &capture.URLVerdictRecord{
 		Subsurface:        "fetch_url",
 		Transport:         "fetch",
+		SessionID:         CeeSessionKey(agent, clientIP),
 		RequestID:         requestID,
 		Agent:             agent,
 		Request:           capture.CaptureRequest{Method: r.Method, URL: displayURL},
@@ -2765,6 +2766,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 			Subsurface:      "dlp_fetch_header",
 			Transport:       "fetch",
+			SessionID:       CeeSessionKey(agent, clientIP),
 			RequestID:       requestID,
 			Agent:           agent,
 			Request:         capture.CaptureRequest{Method: r.Method, URL: displayURL},
@@ -2920,6 +2922,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		p.captureObs.ObserveCEEVerdict(r.Context(), &capture.CEERecord{
 			Subsurface:        "cee_fetch",
 			Transport:         "fetch",
+			SessionID:         CeeSessionKey(agent, clientIP),
 			RequestID:         requestID,
 			Agent:             agent,
 			Request:           capture.CaptureRequest{Method: r.Method, URL: displayURL},
@@ -3422,6 +3425,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		p.captureObs.ObserveResponseVerdict(r.Context(), &capture.ResponseVerdictRecord{
 			Subsurface:        "response_fetch",
 			Transport:         "fetch",
+			SessionID:         CeeSessionKey(agent, clientIP),
 			RequestID:         requestID,
 			Agent:             agent,
 			Request:           capture.CaptureRequest{Method: r.Method, URL: displayURL},

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2517,6 +2517,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		Subsurface:        "fetch_url",
 		Transport:         "fetch",
 		SessionID:         captureSessionKey(agent, clientIP),
+		SessionIDOriginal: captureSessionKeyOriginal(agent, clientIP),
 		RequestID:         requestID,
 		ConfigHash:        cfg.CanonicalPolicyHash(),
 		Agent:             agent,
@@ -2766,17 +2767,18 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			hdrAction = config.ActionWarn
 		}
 		p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
-			Subsurface:      "dlp_fetch_header",
-			Transport:       "fetch",
-			SessionID:       captureSessionKey(agent, clientIP),
-			RequestID:       requestID,
-			ConfigHash:      cfg.CanonicalPolicyHash(),
-			Agent:           agent,
-			Profile:         id.Profile,
-			Request:         capture.CaptureRequest{Method: r.Method, URL: displayURL},
-			TransformKind:   capture.TransformHeaderValue,
-			EffectiveAction: hdrAction,
-			Outcome:         captureOutcome(hdrAction, !headerHadFinding),
+			Subsurface:        "dlp_fetch_header",
+			Transport:         "fetch",
+			SessionID:         captureSessionKey(agent, clientIP),
+			SessionIDOriginal: captureSessionKeyOriginal(agent, clientIP),
+			RequestID:         requestID,
+			ConfigHash:        cfg.CanonicalPolicyHash(),
+			Agent:             agent,
+			Profile:           id.Profile,
+			Request:           capture.CaptureRequest{Method: r.Method, URL: displayURL},
+			TransformKind:     capture.TransformHeaderValue,
+			EffectiveAction:   hdrAction,
+			Outcome:           captureOutcome(hdrAction, !headerHadFinding),
 		})
 	}
 
@@ -2927,6 +2929,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			Subsurface:        "cee_fetch",
 			Transport:         "fetch",
 			SessionID:         captureSessionKey(agent, clientIP),
+			SessionIDOriginal: captureSessionKeyOriginal(agent, clientIP),
 			RequestID:         requestID,
 			ConfigHash:        cfg.CanonicalPolicyHash(),
 			Agent:             agent,
@@ -3432,6 +3435,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			Subsurface:        "response_fetch",
 			Transport:         "fetch",
 			SessionID:         captureSessionKey(agent, clientIP),
+			SessionIDOriginal: captureSessionKeyOriginal(agent, clientIP),
 			RequestID:         requestID,
 			ConfigHash:        cfg.CanonicalPolicyHash(),
 			Agent:             agent,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2516,9 +2516,11 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	p.captureObs.ObserveURLVerdict(r.Context(), &capture.URLVerdictRecord{
 		Subsurface:        "fetch_url",
 		Transport:         "fetch",
-		SessionID:         CeeSessionKey(agent, clientIP),
+		SessionID:         captureSessionKey(agent, clientIP),
 		RequestID:         requestID,
+		ConfigHash:        cfg.CanonicalPolicyHash(),
 		Agent:             agent,
+		Profile:           id.Profile,
 		Request:           capture.CaptureRequest{Method: r.Method, URL: displayURL},
 		RawFindings:       urlFindings,
 		EffectiveFindings: urlFindings,
@@ -2757,7 +2759,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 
 	// Capture observer: record header DLP verdict for policy replay.
 	{
-		hdrAction := ""
+		hdrAction := config.ActionAllow
 		if headerBlocked {
 			hdrAction = config.ActionBlock
 		} else if headerHadFinding {
@@ -2766,9 +2768,11 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 			Subsurface:      "dlp_fetch_header",
 			Transport:       "fetch",
-			SessionID:       CeeSessionKey(agent, clientIP),
+			SessionID:       captureSessionKey(agent, clientIP),
 			RequestID:       requestID,
+			ConfigHash:      cfg.CanonicalPolicyHash(),
 			Agent:           agent,
+			Profile:         id.Profile,
 			Request:         capture.CaptureRequest{Method: r.Method, URL: displayURL},
 			TransformKind:   capture.TransformHeaderValue,
 			EffectiveAction: hdrAction,
@@ -2913,7 +2917,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 
 		// Capture observer: record CEE verdict for policy replay.
 		ceeFindings := ceeResultToFindings(ceeRes)
-		ceeAction := ""
+		ceeAction := config.ActionAllow
 		if ceeRes.Blocked {
 			ceeAction = config.ActionBlock
 		} else if ceeRes.EntropyHit || ceeRes.FragmentHit {
@@ -2922,9 +2926,11 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		p.captureObs.ObserveCEEVerdict(r.Context(), &capture.CEERecord{
 			Subsurface:        "cee_fetch",
 			Transport:         "fetch",
-			SessionID:         CeeSessionKey(agent, clientIP),
+			SessionID:         captureSessionKey(agent, clientIP),
 			RequestID:         requestID,
+			ConfigHash:        cfg.CanonicalPolicyHash(),
 			Agent:             agent,
+			Profile:           id.Profile,
 			Request:           capture.CaptureRequest{Method: r.Method, URL: displayURL},
 			TransformKind:     capture.TransformCEEWindow,
 			RawFindings:       ceeFindings,
@@ -3420,14 +3426,16 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			respAction = config.ActionWarn
 		}
 		if scanResult.Clean {
-			respAction = ""
+			respAction = config.ActionAllow
 		}
 		p.captureObs.ObserveResponseVerdict(r.Context(), &capture.ResponseVerdictRecord{
 			Subsurface:        "response_fetch",
 			Transport:         "fetch",
-			SessionID:         CeeSessionKey(agent, clientIP),
+			SessionID:         captureSessionKey(agent, clientIP),
 			RequestID:         requestID,
+			ConfigHash:        cfg.CanonicalPolicyHash(),
 			Agent:             agent,
+			Profile:           id.Profile,
 			Request:           capture.CaptureRequest{Method: r.Method, URL: displayURL},
 			TransformKind:     capture.TransformReadability,
 			RawFindings:       responseMatchesToFindings(scanResult.Matches, respAction),

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -349,16 +349,17 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 				}
 			}
 			rp.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
-				Subsurface:      "dlp_reverse_url",
-				Transport:       "reverse",
-				SessionID:       captureSessionKey(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
-				ConfigHash:      cfg.CanonicalPolicyHash(),
-				Profile:         edition.ProfileDefault,
-				Request:         capture.CaptureRequest{Method: r.Method, URL: r.URL.String()},
-				TransformKind:   capture.TransformRaw,
-				RawFindings:     dlpMatchesToFindings(pathDLP.Matches),
-				EffectiveAction: urlDLPAction,
-				Outcome:         captureOutcome(urlDLPAction, pathDLP.Clean),
+				Subsurface:        "dlp_reverse_url",
+				Transport:         "reverse",
+				SessionID:         captureSessionKey(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
+				SessionIDOriginal: captureSessionKeyOriginal(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
+				ConfigHash:        cfg.CanonicalPolicyHash(),
+				Profile:           edition.ProfileDefault,
+				Request:           capture.CaptureRequest{Method: r.Method, URL: r.URL.String()},
+				TransformKind:     capture.TransformRaw,
+				RawFindings:       dlpMatchesToFindings(pathDLP.Matches),
+				EffectiveAction:   urlDLPAction,
+				Outcome:           captureOutcome(urlDLPAction, pathDLP.Clean),
 			})
 		}
 
@@ -546,16 +547,17 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 			}
 		}
 		rp.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
-			Subsurface:      "dlp_reverse_request",
-			Transport:       "reverse",
-			SessionID:       captureSessionKey(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
-			ConfigHash:      cfg.CanonicalPolicyHash(),
-			Profile:         edition.ProfileDefault,
-			Request:         capture.CaptureRequest{Method: r.Method, URL: r.URL.String()},
-			TransformKind:   capture.TransformJoinedFields,
-			RawFindings:     bodyScanToFindings(result),
-			EffectiveAction: bodyAction,
-			Outcome:         captureOutcome(bodyAction, result.Clean),
+			Subsurface:        "dlp_reverse_request",
+			Transport:         "reverse",
+			SessionID:         captureSessionKey(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
+			SessionIDOriginal: captureSessionKeyOriginal(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
+			ConfigHash:        cfg.CanonicalPolicyHash(),
+			Profile:           edition.ProfileDefault,
+			Request:           capture.CaptureRequest{Method: r.Method, URL: r.URL.String()},
+			TransformKind:     capture.TransformJoinedFields,
+			RawFindings:       bodyScanToFindings(result),
+			EffectiveAction:   bodyAction,
+			Outcome:           captureOutcome(bodyAction, result.Clean),
 		})
 	}
 
@@ -1008,6 +1010,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 			Subsurface:        "response_reverse",
 			Transport:         "reverse",
 			SessionID:         captureSessionKey(resp.Request.Header.Get("X-Pipelock-Agent"), reverseClientIP(resp.Request)),
+			SessionIDOriginal: captureSessionKeyOriginal(resp.Request.Header.Get("X-Pipelock-Agent"), reverseClientIP(resp.Request)),
 			ConfigHash:        cfg.CanonicalPolicyHash(),
 			Profile:           edition.ProfileDefault,
 			Request:           capture.CaptureRequest{Method: resp.Request.Method, URL: resp.Request.URL.String()},

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -341,7 +341,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 		// Capture observer: record reverse proxy URL DLP verdict for policy replay.
 		{
-			urlDLPAction := ""
+			urlDLPAction := config.ActionAllow
 			if !pathDLP.Clean {
 				urlDLPAction = cfg.RequestBodyScanning.Action
 				if urlDLPAction == "" {
@@ -351,7 +351,9 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			rp.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 				Subsurface:      "dlp_reverse_url",
 				Transport:       "reverse",
-				SessionID:       CeeSessionKey(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
+				SessionID:       captureSessionKey(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
+				ConfigHash:      cfg.CanonicalPolicyHash(),
+				Profile:         edition.ProfileDefault,
 				Request:         capture.CaptureRequest{Method: r.Method, URL: r.URL.String()},
 				TransformKind:   capture.TransformRaw,
 				RawFindings:     dlpMatchesToFindings(pathDLP.Matches),
@@ -533,7 +535,7 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 
 	// Capture observer: record reverse proxy request DLP verdict for policy replay.
 	{
-		bodyAction := ""
+		bodyAction := config.ActionAllow
 		if !result.Clean {
 			bodyAction = result.Action
 			if bodyAction == "" {
@@ -546,7 +548,9 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 		rp.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 			Subsurface:      "dlp_reverse_request",
 			Transport:       "reverse",
-			SessionID:       CeeSessionKey(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
+			SessionID:       captureSessionKey(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
+			ConfigHash:      cfg.CanonicalPolicyHash(),
+			Profile:         edition.ProfileDefault,
 			Request:         capture.CaptureRequest{Method: r.Method, URL: r.URL.String()},
 			TransformKind:   capture.TransformJoinedFields,
 			RawFindings:     bodyScanToFindings(result),
@@ -976,29 +980,6 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 	text := string(body)
 	result := sc.ScanResponse(resp.Request.Context(), text)
 
-	// Capture observer: record reverse proxy response scan verdict for policy replay.
-	// Apply exempt override before capture so the recorded action matches runtime.
-	{
-		revAction := cfg.ResponseScanning.Action
-		if revRespExempt {
-			revAction = config.ActionWarn
-		}
-		if result.Clean {
-			revAction = ""
-		}
-		rp.captureObs.ObserveResponseVerdict(resp.Request.Context(), &capture.ResponseVerdictRecord{
-			Subsurface:        "response_reverse",
-			Transport:         "reverse",
-			SessionID:         CeeSessionKey(resp.Request.Header.Get("X-Pipelock-Agent"), reverseClientIP(resp.Request)),
-			Request:           capture.CaptureRequest{Method: resp.Request.Method, URL: resp.Request.URL.String()},
-			TransformKind:     capture.TransformRaw,
-			RawFindings:       responseMatchesToFindings(result.Matches, revAction),
-			EffectiveFindings: responseMatchesToFindings(result.Matches, revAction),
-			EffectiveAction:   revAction,
-			Outcome:           captureOutcome(revAction, result.Clean),
-		})
-	}
-
 	// Filter out suppressed findings (parity with fetch proxy).
 	if !result.Clean && len(cfg.Suppress) > 0 {
 		var kept []scanner.ResponseMatch
@@ -1011,6 +992,31 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		}
 		result.Matches = kept
 		result.Clean = len(kept) == 0
+	}
+
+	// Capture observer: record reverse proxy response scan verdict for policy replay.
+	// Runs after suppression so the recorded action matches runtime.
+	{
+		revAction := cfg.ResponseScanning.Action
+		if revRespExempt {
+			revAction = config.ActionWarn
+		}
+		if result.Clean {
+			revAction = config.ActionAllow
+		}
+		rp.captureObs.ObserveResponseVerdict(resp.Request.Context(), &capture.ResponseVerdictRecord{
+			Subsurface:        "response_reverse",
+			Transport:         "reverse",
+			SessionID:         captureSessionKey(resp.Request.Header.Get("X-Pipelock-Agent"), reverseClientIP(resp.Request)),
+			ConfigHash:        cfg.CanonicalPolicyHash(),
+			Profile:           edition.ProfileDefault,
+			Request:           capture.CaptureRequest{Method: resp.Request.Method, URL: resp.Request.URL.String()},
+			TransformKind:     capture.TransformRaw,
+			RawFindings:       responseMatchesToFindings(result.Matches, revAction),
+			EffectiveFindings: responseMatchesToFindings(result.Matches, revAction),
+			EffectiveAction:   revAction,
+			Outcome:           captureOutcome(revAction, result.Clean),
+		})
 	}
 
 	if result.Clean {

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -350,6 +351,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			rp.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 				Subsurface:      "dlp_reverse_url",
 				Transport:       "reverse",
+				SessionID:       CeeSessionKey(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
 				Request:         capture.CaptureRequest{Method: r.Method, URL: r.URL.String()},
 				TransformKind:   capture.TransformRaw,
 				RawFindings:     dlpMatchesToFindings(pathDLP.Matches),
@@ -544,6 +546,7 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 		rp.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 			Subsurface:      "dlp_reverse_request",
 			Transport:       "reverse",
+			SessionID:       CeeSessionKey(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
 			Request:         capture.CaptureRequest{Method: r.Method, URL: r.URL.String()},
 			TransformKind:   capture.TransformJoinedFields,
 			RawFindings:     bodyScanToFindings(result),
@@ -986,6 +989,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		rp.captureObs.ObserveResponseVerdict(resp.Request.Context(), &capture.ResponseVerdictRecord{
 			Subsurface:        "response_reverse",
 			Transport:         "reverse",
+			SessionID:         CeeSessionKey(resp.Request.Header.Get("X-Pipelock-Agent"), reverseClientIP(resp.Request)),
 			Request:           capture.CaptureRequest{Method: resp.Request.Method, URL: resp.Request.URL.String()},
 			TransformKind:     capture.TransformRaw,
 			RawFindings:       responseMatchesToFindings(result.Matches, revAction),
@@ -1183,4 +1187,14 @@ func isBinaryMIME(ct string) bool {
 	return strings.HasPrefix(mediaType, "image/") ||
 		strings.HasPrefix(mediaType, "audio/") ||
 		strings.HasPrefix(mediaType, "video/")
+}
+
+// reverseClientIP extracts a client IP for capture session keying. Falls
+// back to RemoteAddr when SplitHostPort fails (e.g., raw IP without port
+// from a unix socket or test fixture).
+func reverseClientIP(r *http.Request) string {
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
 }

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -225,6 +225,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		p.captureObs.ObserveURLVerdict(r.Context(), &capture.URLVerdictRecord{
 			Subsurface:        "ws_url",
 			Transport:         "websocket",
+			SessionID:         CeeSessionKey(agent, clientIP),
 			RequestID:         requestID,
 			Agent:             agent,
 			Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
@@ -389,6 +390,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 			Subsurface:      "dlp_ws_header",
 			Transport:       "websocket",
+			SessionID:       CeeSessionKey(agent, clientIP),
 			RequestID:       requestID,
 			Agent:           agent,
 			Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -226,6 +226,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			Subsurface:        "ws_url",
 			Transport:         "websocket",
 			SessionID:         captureSessionKey(agent, clientIP),
+			SessionIDOriginal: captureSessionKeyOriginal(agent, clientIP),
 			RequestID:         requestID,
 			ConfigHash:        cfg.CanonicalPolicyHash(),
 			Agent:             agent,
@@ -390,18 +391,19 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	if blocked, reason := p.dlpScanWSHeaders(r.Context(), fwdHeaders, sc); blocked {
 		// Capture observer: record WS header DLP verdict for policy replay.
 		p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
-			Subsurface:      "dlp_ws_header",
-			Transport:       "websocket",
-			SessionID:       captureSessionKey(agent, clientIP),
-			RequestID:       requestID,
-			ConfigHash:      cfg.CanonicalPolicyHash(),
-			Agent:           agent,
-			Profile:         id.Profile,
-			Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
-			TransformKind:   capture.TransformHeaderValue,
-			EffectiveAction: config.ActionBlock,
-			Outcome:         capture.OutcomeBlocked,
-			SkipReason:      reason,
+			Subsurface:        "dlp_ws_header",
+			Transport:         "websocket",
+			SessionID:         captureSessionKey(agent, clientIP),
+			SessionIDOriginal: captureSessionKeyOriginal(agent, clientIP),
+			RequestID:         requestID,
+			ConfigHash:        cfg.CanonicalPolicyHash(),
+			Agent:             agent,
+			Profile:           id.Profile,
+			Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
+			TransformKind:     capture.TransformHeaderValue,
+			EffectiveAction:   config.ActionBlock,
+			Outcome:           capture.OutcomeBlocked,
+			SkipReason:        reason,
 		})
 		wsHasFinding = true
 		// Record session activity so adaptive enforcement sees header-DLP hits.

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -218,16 +218,18 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Capture observer: record WebSocket URL verdict for policy replay.
 	{
 		findings := urlResultToFindings(result)
-		action := ""
+		action := config.ActionAllow
 		if !result.Allowed {
 			action = config.ActionBlock
 		}
 		p.captureObs.ObserveURLVerdict(r.Context(), &capture.URLVerdictRecord{
 			Subsurface:        "ws_url",
 			Transport:         "websocket",
-			SessionID:         CeeSessionKey(agent, clientIP),
+			SessionID:         captureSessionKey(agent, clientIP),
 			RequestID:         requestID,
+			ConfigHash:        cfg.CanonicalPolicyHash(),
 			Agent:             agent,
+			Profile:           id.Profile,
 			Request:           capture.CaptureRequest{Method: r.Method, URL: targetURL},
 			RawFindings:       findings,
 			EffectiveFindings: findings,
@@ -390,9 +392,11 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 			Subsurface:      "dlp_ws_header",
 			Transport:       "websocket",
-			SessionID:       CeeSessionKey(agent, clientIP),
+			SessionID:       captureSessionKey(agent, clientIP),
 			RequestID:       requestID,
+			ConfigHash:      cfg.CanonicalPolicyHash(),
 			Agent:           agent,
+			Profile:         id.Profile,
 			Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
 			TransformKind:   capture.TransformHeaderValue,
 			EffectiveAction: config.ActionBlock,


### PR DESCRIPTION
## Summary

Fixes the capture pipeline so learn-and-lock observation produces usable events end-to-end. The bug was structural: every `Observe*` call site in proxy and MCP packages constructed verdict records without setting `SessionID`, the writer worker rejected each entry as "empty session ID" and only drop sentinels reached disk. `learn compile` emitted zero rules from any traffic; `learn shadow` had nothing to evaluate.

## Commits

`3c909452` populates `SessionID` at every `Observe*` call site. HTTP proxy paths use `CeeSessionKey(agent, clientIP)`; MCP paths use `"mcp-" + opts.Transport`. Defensive `ActionAllow` default in the writer for empty `effectiveAction` so shadow can compute a non-empty `original_verdict`.

`1e732782` does caller-side stamping of `EffectiveAction`, `ConfigHash`, and `Profile` at every call site. Intercept and reverse response capture moved to fire AFTER suppression filtering (previously recorded findings the runtime later suppressed). `learn compile` and `learn shadow` now walk one level deeper into agent|ip session subdirs so contracts find their input automatically. `MCPProxyOpts.ConfigHashFn` closure for hot-reload listener freshness. Plus a `CanonicalPolicyHash()` cache race fix found by `-race`: atomic.Pointer plus sync.Once replaces the unsynchronized cache write. The race predates this work but the new high-frequency capture read path made it visible.

`ff082ab0` adds an end-to-end regression test that drives a fetch through `proxy.handleFetch` with a real `capture.Writer` attached, drains the writer, walks the session subdir, opens the recorder JSONL, and asserts `session_id`, `effective_action`, `config_hash`, `profile`, and `agent` all populate. Locks the fix in.

## Behavior

After the fix, capture entries land in real session subdirs with non-empty `session_id`, `effective_action`, `config_hash`, `profile`, and `agent`. `learn compile` ingests the captures and emits rules; `learn ratify` accepts them to enforce; `learn shadow` replays records and computes deltas; `learn promote` signs both intent and committed receipts. The defensive writer `ActionAllow` fallback stays as a backstop invariant for any future call site that misses caller-side stamping.

## Out of scope

- `ActionClass` population. The classifier wiring is documented as next-phase work; review markdown will continue to show 100% unclassified until that lands.
- Promote staging flow (manual `cp` into history dir vs a `learn stage` command). Separate workflow polish item, not a capture-pipeline unblocker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session filtering controls for selective replay of captured sessions
  * Enriched capture metadata with configuration hash, profile, and original session identifiers for improved audit trails

* **Bug Fixes**
  * Verdict actions now explicitly default to "allow" for clean scan results instead of empty values
  * Enhanced session directory validation for safer capture handling and identity tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->