### PR TITLE
feat(metrics,capture): soak observability, transport parity, header hardening, reason matrix

### DIFF
--- a/internal/blockreason/blockreason.go
+++ b/internal/blockreason/blockreason.go
@@ -148,6 +148,17 @@ var validReasons = map[Reason]struct{}{
 	BlockReasonOverflow:    {},
 }
 
+// AllReasons returns every Reason in the canonical allowlist. The returned
+// slice is freshly allocated on each call so callers can sort or filter
+// without affecting the package state. Order is not guaranteed.
+func AllReasons() []Reason {
+	out := make([]Reason, 0, len(validReasons))
+	for r := range validReasons {
+		out = append(out, r)
+	}
+	return out
+}
+
 // Severity matches pipelock's existing severity vocabulary in
 // internal/config/schema.go (SeverityInfo / SeverityWarn / SeverityCritical).
 type Severity string

--- a/internal/blockreason/production_path_matrix_test.go
+++ b/internal/blockreason/production_path_matrix_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package blockreason_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+)
+
+// TestProductionPathMatrix walks the in-tree Go source for every canonical
+// blockreason.Reason and asserts each one is referenced from at least one
+// production .go file outside the blockreason package itself. This is a
+// static-analysis gate against two regression classes:
+//
+//  1. A new Reason constant lands but no production block path emits it
+//     (block_reason_header.md spec drift versus shipped behavior).
+//  2. A production emitter is removed but the constant lives on, leaving
+//     dead vocabulary in the public header schema.
+//
+// The matrix is intentionally static — exercising every block path through
+// runtime traffic would require a transport-by-transport black-box rig that
+// belongs in the pen-test layer, not the unit suite. This test catches the
+// "constant exists but no live caller" class cheaply on every commit.
+//
+// Exemptions live in nonProductionEmitReasons below; each one carries a
+// comment explaining why the lack of a production caller is intentional.
+func TestProductionPathMatrix(t *testing.T) {
+	t.Parallel()
+
+	repoRoot, err := repoRootFromHere()
+	if err != nil {
+		t.Fatalf("locate repo root: %v", err)
+	}
+
+	references, err := collectBlockReasonReferences(repoRoot)
+	if err != nil {
+		t.Fatalf("walk source tree: %v", err)
+	}
+
+	for _, reason := range blockreason.AllReasons() {
+		if _, exempt := nonProductionEmitReasons[reason]; exempt {
+			continue
+		}
+		emitters, ok := references[constNameForReason(reason)]
+		if !ok || len(emitters) == 0 {
+			t.Errorf("Reason %q (%s) has no production emit site — either wire a caller or document an exemption in nonProductionEmitReasons",
+				constNameForReason(reason), string(reason))
+			continue
+		}
+		t.Logf("Reason %q referenced by: %s", string(reason), strings.Join(emitters, ", "))
+	}
+}
+
+// nonProductionEmitReasons documents Reasons that intentionally have no
+// runtime production emitter today. Each exemption MUST carry a justification
+// comment so a future reader knows whether the gap is by design or stale.
+var nonProductionEmitReasons = map[blockreason.Reason]string{
+	// BlockReasonOverflow is the dedicated sentinel CloseFramePayload uses
+	// when an Info has accumulated a Reason value too long to fit RFC 6455's
+	// 123-byte close-frame payload limit. It is never EMITTED by a block
+	// path; it is RESOLVED to inside CloseFramePayload as a fallback. No
+	// production caller is expected.
+	blockreason.BlockReasonOverflow: "sentinel resolved inside CloseFramePayload, not emitted by a block path",
+
+	// ToolPoisoning fires from internal/mcp/proxy.go via blockResponseReason
+	// on tools/list responses where a poisoned tool description was
+	// detected. The block surfaces as a JSON-RPC error in the MCP response
+	// stream, not as an HTTP response — there is no HTTP header surface to
+	// carry X-Pipelock-Block-Reason on the MCP transport. The vocabulary
+	// stays in the canonical allowlist for cross-system labeling
+	// (audit logs, receipts, dashboards) even though the HTTP header path
+	// does not apply.
+	blockreason.ToolPoisoning: "fires at JSON-RPC layer in MCP response stream; no HTTP header surface",
+
+	// ToolChainBlocked fires from internal/mcp/proxy_http.go and
+	// internal/mcp/input.go when a chain matcher rejects a tools/call
+	// sequence. Same shape as ToolPoisoning: the block becomes a JSON-RPC
+	// error in the MCP response stream, with no HTTP response to attach a
+	// header to. Reason vocabulary kept for receipt + audit consistency.
+	blockreason.ToolChainBlocked: "fires at JSON-RPC layer in MCP response stream; no HTTP header surface",
+}
+
+// constNameForReason maps a Reason value to the exported constant name in the
+// blockreason package, since references in production code use the constant
+// (e.g. blockreason.DLPMatch) not the underlying string ("dlp_match").
+func constNameForReason(r blockreason.Reason) string {
+	switch r {
+	case blockreason.SchemeBlocked:
+		return "SchemeBlocked"
+	case blockreason.DomainBlocklist:
+		return "DomainBlocklist"
+	case blockreason.SSRFPrivateIP:
+		return "SSRFPrivateIP"
+	case blockreason.SSRFMetadata:
+		return "SSRFMetadata"
+	case blockreason.SSRFDNSRebind:
+		return "SSRFDNSRebind"
+	case blockreason.PathEntropy:
+		return "PathEntropy"
+	case blockreason.SubdomainEntropy:
+		return "SubdomainEntropy"
+	case blockreason.URLLength:
+		return "URLLength"
+	case blockreason.RateLimit:
+		return "RateLimit"
+	case blockreason.DataBudget:
+		return "DataBudget"
+	case blockreason.DLPMatch:
+		return "DLPMatch"
+	case blockreason.PromptInjection:
+		return "PromptInjection"
+	case blockreason.RedactionFailure:
+		return "RedactionFailure"
+	case blockreason.MediaPolicy:
+		return "MediaPolicy"
+	case blockreason.ToolPolicyDeny:
+		return "ToolPolicyDeny"
+	case blockreason.ToolChainBlocked:
+		return "ToolChainBlocked"
+	case blockreason.ToolPoisoning:
+		return "ToolPoisoning"
+	case blockreason.SessionBinding:
+		return "SessionBinding"
+	case blockreason.AirlockActive:
+		return "AirlockActive"
+	case blockreason.KillSwitchActive:
+		return "KillSwitchActive"
+	case blockreason.EnvelopeVerifyFailed:
+		return "EnvelopeVerifyFailed"
+	case blockreason.OutboundEnvelopeFailed:
+		return "OutboundEnvelopeFailed"
+	case blockreason.RedirectScanDenied:
+		return "RedirectScanDenied"
+	case blockreason.AuthorityMismatch:
+		return "AuthorityMismatch"
+	case blockreason.EscalationLevel:
+		return "EscalationLevel"
+	case blockreason.SessionAnomaly:
+		return "SessionAnomaly"
+	case blockreason.CrossRequestDeny:
+		return "CrossRequestDeny"
+	case blockreason.CompressedResponse:
+		return "CompressedResponse"
+	case blockreason.BrowserShieldOversize:
+		return "BrowserShieldOversize"
+	case blockreason.ParseError:
+		return "ParseError"
+	case blockreason.Timeout:
+		return "Timeout"
+	case blockreason.PatternUnavailable:
+		return "PatternUnavailable"
+	case blockreason.NotEnabled:
+		return "NotEnabled"
+	case blockreason.BadRequest:
+		return "BadRequest"
+	case blockreason.BlockReasonOverflow:
+		return "BlockReasonOverflow"
+	}
+	return ""
+}
+
+// collectBlockReasonReferences walks the source tree under root and returns a
+// map of `<ConstantName> -> [files where blockreason.<ConstantName> appears]`,
+// considering only production .go files (skips _test.go, the blockreason
+// package itself, and vendor/build artifacts). AST-based so a `// blockreason.X`
+// comment does not count as a reference.
+func collectBlockReasonReferences(root string) (map[string][]string, error) {
+	hits := make(map[string][]string)
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == "vendor" || name == ".git" || name == "node_modules" || strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		// Skip the blockreason package itself; the constants are defined
+		// there and self-reference would mask missing production callers.
+		if strings.Contains(filepath.ToSlash(path), "/internal/blockreason/") {
+			return nil
+		}
+
+		f, parseErr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if parseErr != nil {
+			// Tolerate parse errors (e.g. test fixtures that include
+			// intentionally invalid Go) so the matrix never bricks the
+			// suite on unrelated breakage. The fmt-imported file would
+			// just be skipped.
+			return nil
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok || pkg.Name != "blockreason" {
+				return true
+			}
+			rel, _ := filepath.Rel(root, path)
+			hits[sel.Sel.Name] = append(hits[sel.Sel.Name], rel)
+			return true
+		})
+		return nil
+	})
+	return hits, err
+}
+
+// repoRootFromHere walks up from the test file's directory until it finds a
+// go.mod, returning the repository root. Lets the matrix run from any package
+// without hard-coding the repo path.
+func repoRootFromHere() (string, error) {
+	cwd, err := filepath.Abs(".")
+	if err != nil {
+		return "", err
+	}
+	for dir := cwd; ; {
+		if _, statErr := filepath.Glob(filepath.Join(dir, "go.mod")); statErr == nil {
+			matches, _ := filepath.Glob(filepath.Join(dir, "go.mod"))
+			if len(matches) > 0 {
+				return dir, nil
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fs.ErrNotExist
+		}
+		dir = parent
+	}
+}

--- a/internal/blockreason/production_path_matrix_test.go
+++ b/internal/blockreason/production_path_matrix_test.go
@@ -9,11 +9,18 @@ import (
 	"go/token"
 	"io/fs"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 )
+
+// blockreasonImportPath is the canonical import path the matrix anchors on.
+// Matching by import path (not by selector identifier name) means the gate
+// stays correct under aliased imports and ignores unrelated locals named
+// `blockreason`.
+const blockreasonImportPath = "github.com/luckyPipewrench/pipelock/internal/blockreason"
 
 // TestProductionPathMatrix walks the in-tree Go source for every canonical
 // blockreason.Reason and asserts each one is referenced from at least one
@@ -204,13 +211,41 @@ func collectBlockReasonReferences(root string) (map[string][]string, error) {
 			// just be skipped.
 			return nil
 		}
+		// Build the per-file alias set keyed on the import PATH, not the
+		// identifier name. This is the bug class CodeRabbit flagged: a
+		// looser `pkg.Name == "blockreason"` selector match would (a)
+		// count unrelated selectors on a local identifier shadowing the
+		// package name, and (b) miss valid references when the import is
+		// aliased. Dot/blank imports do not carry a usable selector
+		// identifier, so they are excluded from the alias set.
+		aliases := map[string]struct{}{}
+		for _, imp := range f.Imports {
+			p, unquoteErr := strconv.Unquote(imp.Path.Value)
+			if unquoteErr != nil || p != blockreasonImportPath {
+				continue
+			}
+			alias := "blockreason"
+			if imp.Name != nil {
+				if imp.Name.Name == "." || imp.Name.Name == "_" {
+					continue
+				}
+				alias = imp.Name.Name
+			}
+			aliases[alias] = struct{}{}
+		}
+		if len(aliases) == 0 {
+			return nil
+		}
 		ast.Inspect(f, func(n ast.Node) bool {
 			sel, ok := n.(*ast.SelectorExpr)
 			if !ok {
 				return true
 			}
 			pkg, ok := sel.X.(*ast.Ident)
-			if !ok || pkg.Name != "blockreason" {
+			if !ok {
+				return true
+			}
+			if _, ok := aliases[pkg.Name]; !ok {
 				return true
 			}
 			rel, _ := filepath.Rel(root, path)

--- a/internal/capture/types.go
+++ b/internal/capture/types.go
@@ -13,6 +13,18 @@ import "context"
 // Replay engines must reject summaries with unknown versions.
 const CaptureSchemaV1 = 1
 
+// MaxSessionKeyLen bounds the length of an on-disk session directory name.
+// Most filesystems cap a single path component at 255 bytes (NAME_MAX); the
+// ceiling here is conservative so the writer never bumps that limit.
+//
+// This is the SHARED contract between the proxy-side session-key construction
+// helpers (which decide whether to hash an unsafe or overlength logical key
+// for filesystem safety) and the writer-side reverse-engineering of the
+// sanitization reason for the capture_session_id_sanitized_total metric.
+// Both sides must agree on the threshold or the metric label silently
+// misclassifies; defining it once here keeps them in lockstep.
+const MaxSessionKeyLen = 200
+
 // Surface constants identify which proxy layer produced a capture entry.
 const (
 	ActionAllow       = "allow"
@@ -235,6 +247,15 @@ type CaptureDropDetail struct {
 // the evidence chain aware of the loss.
 type DropSink interface {
 	RecordCaptureDrop()
+}
+
+// MetricsSink receives capture-specific observability events. It is separate
+// from DropSink so existing drop-only test sinks do not need to implement the
+// broader learn-and-lock soak metric surface.
+type MetricsSink interface {
+	RecordCaptureSessionIDSanitized(reason string)
+	RecordLearnCaptureRecord()
+	RecordLearnCaptureDrop()
 }
 
 // CaptureObserver is called by proxy and MCP scanner hooks with the verdict for

--- a/internal/capture/writer.go
+++ b/internal/capture/writer.go
@@ -55,6 +55,9 @@ type WriterConfig struct {
 	EscrowPublicKey *[32]byte
 	// DropSink receives notifications when captures are dropped.
 	DropSink DropSink
+	// MetricsSink receives broader capture observability events for soak
+	// dashboards. Optional; nil disables these counters.
+	MetricsSink MetricsSink
 	// QueueSize is the bounded channel capacity. Zero uses a default of 4096.
 	QueueSize int
 	// BuildVersion is the pipelock version string baked into every summary.
@@ -74,6 +77,7 @@ type Writer struct {
 	privKey      ed25519.PrivateKey
 	escrowPub    *[32]byte
 	dropSink     DropSink
+	metricsSink  MetricsSink
 	recorders    map[string]*recorder.Recorder
 	payloadSeq   map[string]uint64
 	metaRec      *recorder.Recorder
@@ -119,6 +123,7 @@ func NewWriter(cfg WriterConfig) (*Writer, error) {
 		privKey:      cfg.PrivKey,
 		escrowPub:    cfg.EscrowPublicKey,
 		dropSink:     cfg.DropSink,
+		metricsSink:  cfg.MetricsSink,
 		recorders:    make(map[string]*recorder.Recorder),
 		payloadSeq:   make(map[string]uint64),
 		metaRec:      metaRec,
@@ -236,6 +241,14 @@ func (w *Writer) worker() {
 		ce.entry.Detail = ce.summary
 		if err := rec.Record(ce.entry); err != nil {
 			w.recordDrop()
+			continue
+		}
+		if w.metricsSink != nil {
+			if ce.summary.SessionIDOriginal != "" {
+				w.metricsSink.RecordCaptureSessionIDSanitized(
+					captureSessionIDSanitizationReason(ce.summary.SessionIDOriginal))
+			}
+			w.metricsSink.RecordLearnCaptureRecord()
 		}
 	}
 
@@ -267,8 +280,24 @@ func (w *Writer) recordDrop() {
 	if w.dropSink != nil {
 		w.dropSink.RecordCaptureDrop()
 	}
+	if w.metricsSink != nil {
+		w.metricsSink.RecordLearnCaptureDrop()
+	}
 	if n == 1 || n%dropSentinelInterval == 0 {
 		w.writeDropSentinel(n)
+	}
+}
+
+func captureSessionIDSanitizationReason(original string) string {
+	switch {
+	case original == "":
+		return "unknown"
+	case len(original) > MaxSessionKeyLen:
+		return "overlength"
+	case strings.ContainsAny(original, `/\`) || strings.Contains(original, ".."):
+		return "unsafe_path"
+	default:
+		return "unknown"
 	}
 }
 

--- a/internal/capture/writer_test.go
+++ b/internal/capture/writer_test.go
@@ -46,6 +46,33 @@ func (s *testDropSink) RecordCaptureDrop() {
 	s.drops.Add(1)
 }
 
+type testMetricsSink struct {
+	sanitizedUnsafe atomic.Int64
+	sanitizedLong   atomic.Int64
+	sanitizedOther  atomic.Int64
+	records         atomic.Int64
+	drops           atomic.Int64
+}
+
+func (s *testMetricsSink) RecordCaptureSessionIDSanitized(reason string) {
+	switch reason {
+	case "unsafe_path":
+		s.sanitizedUnsafe.Add(1)
+	case "overlength":
+		s.sanitizedLong.Add(1)
+	default:
+		s.sanitizedOther.Add(1)
+	}
+}
+
+func (s *testMetricsSink) RecordLearnCaptureRecord() {
+	s.records.Add(1)
+}
+
+func (s *testMetricsSink) RecordLearnCaptureDrop() {
+	s.drops.Add(1)
+}
+
 // newTestWriter creates a Writer with sensible test defaults.
 func newTestWriter(t *testing.T, opts ...func(*capture.WriterConfig)) *capture.Writer {
 	t.Helper()
@@ -316,6 +343,7 @@ func TestWriterRecordsURLVerdictWithEscrow(t *testing.T) {
 func TestWriterDropSentinel(t *testing.T) {
 	dir := t.TempDir()
 	sink := &testDropSink{}
+	metricsSink := &testMetricsSink{}
 
 	w, err := capture.NewWriter(capture.WriterConfig{
 		RecorderConfig: recorder.Config{
@@ -324,6 +352,7 @@ func TestWriterDropSentinel(t *testing.T) {
 			CheckpointInterval: 1000,
 		},
 		DropSink:     sink,
+		MetricsSink:  metricsSink,
 		QueueSize:    1,
 		BuildVersion: testVersion,
 		BuildSHA:     testSHA,
@@ -357,6 +386,12 @@ func TestWriterDropSentinel(t *testing.T) {
 	if drops == 0 {
 		t.Fatal("expected drops > 0 with queue size 1 and 500 sends")
 	}
+	if got := metricsSink.drops.Load(); got != drops {
+		t.Fatalf("metrics drop count = %d, want drop sink count %d", got, drops)
+	}
+	if got := metricsSink.records.Load(); got == 0 {
+		t.Fatal("expected learn capture records metric to count durable writes")
+	}
 	t.Logf("total drops: %d out of %d sends", drops, floodCount)
 
 	// Check for drop sentinel entries in the capture-meta subdirectory.
@@ -371,6 +406,9 @@ func TestWriterDropSentinel(t *testing.T) {
 
 	if len(dropEntries) == 0 {
 		t.Fatal("expected at least one capture_drop sentinel in capture-meta")
+	}
+	if err := recorder.VerifyChain(metaEntries); err != nil {
+		t.Fatalf("capture-meta drop sentinel chain is not continuous: %v", err)
 	}
 
 	// Verify the drop detail.
@@ -389,6 +427,52 @@ func TestWriterDropSentinel(t *testing.T) {
 	}
 	if dropDetail.Reason != "backpressure" {
 		t.Errorf("drop sentinel Reason: got %q, want %q", dropDetail.Reason, "backpressure")
+	}
+}
+
+func TestWriterMetricsSinkRecordsSanitizedSessionID(t *testing.T) {
+	dir := t.TempDir()
+	metricsSink := &testMetricsSink{}
+
+	w, err := capture.NewWriter(capture.WriterConfig{
+		RecorderConfig: recorder.Config{
+			Enabled:            true,
+			Dir:                dir,
+			CheckpointInterval: 1000,
+		},
+		MetricsSink:  metricsSink,
+		QueueSize:    testQueueSize,
+		BuildVersion: testVersion,
+		BuildSHA:     testSHA,
+	})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	w.ObserveURLVerdict(context.Background(), &capture.URLVerdictRecord{
+		Subsurface:        testSubsurface,
+		Transport:         testTransport,
+		SessionID:         "capture-abc123",
+		SessionIDOriginal: "../unsafe-agent|127.0.0.1",
+		RequestID:         "req-sanitized",
+		ConfigHash:        testConfigHash,
+		Request:           capture.CaptureRequest{Method: "GET", URL: testURLVerdict},
+		EffectiveAction:   "allow",
+		Outcome:           capture.OutcomeClean,
+	})
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if got := metricsSink.records.Load(); got != 1 {
+		t.Fatalf("learn capture records = %d, want 1", got)
+	}
+	if got := metricsSink.sanitizedUnsafe.Load(); got != 1 {
+		t.Fatalf("sanitized unsafe count = %d, want 1", got)
+	}
+	if got := metricsSink.sanitizedLong.Load(); got != 0 {
+		t.Fatalf("sanitized overlength count = %d, want 0", got)
 	}
 }
 

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"unicode"
 
 	"github.com/spf13/cobra"
 
@@ -90,12 +91,63 @@ func parseHeaderFlags(raw []string) (http.Header, error) {
 		if key == "" {
 			return nil, fmt.Errorf("--header %q: key is empty", entry)
 		}
+		if !validHeaderName(key) {
+			return nil, fmt.Errorf("--header %q: key contains invalid characters", entry)
+		}
+		value = strings.TrimSpace(value)
+		if !validHeaderValue(value) {
+			return nil, fmt.Errorf("--header %q: value contains invalid characters", entry)
+		}
 		if _, reserved := reservedTransportHeaders[http.CanonicalHeaderKey(key)]; reserved {
 			return nil, fmt.Errorf("--header %q: %q is managed by the MCP HTTP transport and cannot be overridden via --header", entry, key)
 		}
-		h.Add(key, strings.TrimSpace(value))
+		h.Add(key, value)
 	}
 	return h, nil
+}
+
+func validHeaderName(key string) bool {
+	if key == "" {
+		return false
+	}
+	for _, r := range key {
+		if r > 127 || !isHTTPTokenChar(byte(r)) {
+			return false
+		}
+	}
+	return true
+}
+
+func isHTTPTokenChar(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z':
+		return true
+	case c >= 'A' && c <= 'Z':
+		return true
+	case c >= '0' && c <= '9':
+		return true
+	}
+	switch c {
+	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+		return true
+	default:
+		return false
+	}
+}
+
+func validHeaderValue(value string) bool {
+	for _, r := range value {
+		if r == '\t' || r == ' ' {
+			continue
+		}
+		if r < 0x20 || r == 0x7f {
+			return false
+		}
+		if r > 127 && unicode.IsSpace(r) {
+			return false
+		}
+	}
+	return true
 }
 
 // handleProxyError classifies MCP proxy errors: subprocess exits get a

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -94,10 +94,16 @@ func parseHeaderFlags(raw []string) (http.Header, error) {
 		if !validHeaderName(key) {
 			return nil, fmt.Errorf("--header %q: key contains invalid characters", entry)
 		}
-		value = strings.TrimSpace(value)
+		// Validate the raw value before trimming so leading/trailing CRLF,
+		// control chars, or unicode whitespace are rejected rather than
+		// silently stripped by TrimSpace and then accepted.
 		if !validHeaderValue(value) {
 			return nil, fmt.Errorf("--header %q: value contains invalid characters", entry)
 		}
+		// Trim ASCII space/tab only after validation; full TrimSpace would
+		// strip unicode whitespace that the validator just rejected, leaving
+		// the bypass available through the header value's edges.
+		value = strings.Trim(value, " \t")
 		if _, reserved := reservedTransportHeaders[http.CanonicalHeaderKey(key)]; reserved {
 			return nil, fmt.Errorf("--header %q: %q is managed by the MCP HTTP transport and cannot be overridden via --header", entry, key)
 		}

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -677,6 +677,31 @@ func TestParseHeaderFlags(t *testing.T) {
 			wantErr: `--header "   : value": key is empty`,
 		},
 		{
+			name:    "key with space rejected",
+			input:   []string{"X Bad: value"},
+			wantErr: `--header "X Bad: value": key contains invalid characters`,
+		},
+		{
+			name:    "key with unicode rejected",
+			input:   []string{"X-\u2003Bad: value"},
+			wantErr: `--header "X-\u2003Bad: value": key contains invalid characters`,
+		},
+		{
+			name:    "value with crlf rejected",
+			input:   []string{"X-Test: ok\r\nX-Injected: yes"},
+			wantErr: "--header \"X-Test: ok\\r\\nX-Injected: yes\": value contains invalid characters",
+		},
+		{
+			name:    "value with control character rejected",
+			input:   []string{"X-Test: ok\x7f"},
+			wantErr: `--header "X-Test: ok\x7f": value contains invalid characters`,
+		},
+		{
+			name:    "value with unicode whitespace rejected",
+			input:   []string{"X-Test: ok\u2003hidden"},
+			wantErr: `--header "X-Test: ok\u2003hidden": value contains invalid characters`,
+		},
+		{
 			name:    "reserved Mcp-Session-Id rejected",
 			input:   []string{"Mcp-Session-Id: attacker-pinned"},
 			wantErr: `--header "Mcp-Session-Id: attacker-pinned": "Mcp-Session-Id" is managed by the MCP HTTP transport and cannot be overridden via --header`,

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -702,6 +702,26 @@ func TestParseHeaderFlags(t *testing.T) {
 			wantErr: `--header "X-Test: ok\u2003hidden": value contains invalid characters`,
 		},
 		{
+			// Boundary case: TrimSpace previously stripped a trailing CRLF
+			// before validation ran. Catches that regression.
+			name:    "value ending with crlf rejected",
+			input:   []string{"X-Test: ok\r\n"},
+			wantErr: "--header \"X-Test: ok\\r\\n\": value contains invalid characters",
+		},
+		{
+			// Boundary case: leading unicode whitespace would be stripped by
+			// strings.TrimSpace, bypassing validHeaderValue.
+			name:    "value starting with unicode whitespace rejected",
+			input:   []string{"X-Test: \u2003ok"},
+			wantErr: `--header "X-Test: \u2003ok": value contains invalid characters`,
+		},
+		{
+			// Boundary case: trailing unicode whitespace, same reasoning.
+			name:    "value ending with unicode whitespace rejected",
+			input:   []string{"X-Test: ok\u2003"},
+			wantErr: `--header "X-Test: ok\u2003": value contains invalid characters`,
+		},
+		{
 			name:    "reserved Mcp-Session-Id rejected",
 			input:   []string{"Mcp-Session-Id: attacker-pinned"},
 			wantErr: `--header "Mcp-Session-Id: attacker-pinned": "Mcp-Session-Id" is managed by the MCP HTTP transport and cannot be overridden via --header`,

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -469,6 +469,7 @@ func NewServer(opts ServerOpts) (*Server, error) {
 			},
 			EscrowPublicKey: escrowPub,
 			DropSink:        m,
+			MetricsSink:     m,
 			QueueSize:       4096, // bounded channel capacity
 			BuildVersion:    cliutil.Version,
 			BuildSHA:        cliutil.GitCommit,

--- a/internal/mcp/capture_metadata_test.go
+++ b/internal/mcp/capture_metadata_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/capture"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/transport"
+)
+
+type mcpCaptureMetadataObserver struct {
+	got chan capture.DLPVerdictRecord
+}
+
+func (o *mcpCaptureMetadataObserver) ObserveURLVerdict(context.Context, *capture.URLVerdictRecord) {}
+func (o *mcpCaptureMetadataObserver) ObserveResponseVerdict(context.Context, *capture.ResponseVerdictRecord) {
+}
+func (o *mcpCaptureMetadataObserver) ObserveCEEVerdict(context.Context, *capture.CEERecord) {}
+func (o *mcpCaptureMetadataObserver) ObserveToolPolicyVerdict(context.Context, *capture.ToolPolicyRecord) {
+}
+
+func (o *mcpCaptureMetadataObserver) ObserveToolScanVerdict(context.Context, *capture.ToolScanRecord) {
+}
+func (o *mcpCaptureMetadataObserver) Close() error { return nil }
+
+func (o *mcpCaptureMetadataObserver) ObserveDLPVerdict(_ context.Context, rec *capture.DLPVerdictRecord) {
+	o.got <- *rec
+}
+
+func TestCaptureMetadata_MCPHTTPInputTransport(t *testing.T) {
+	t.Parallel()
+
+	sc := testScannerForHTTP(t)
+	obs := &mcpCaptureMetadataObserver{got: make(chan capture.DLPVerdictRecord, 1)}
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"fetch","arguments":{"api_key":"` +
+		testSecretPrefix + `aaaaaaaaaaaaaaaaaaaaaaaaa"}}}`)
+
+	decision := scanHTTPInputDecision(msg, io.Discard, "sess", "sess", MCPProxyOpts{
+		Scanner:    sc,
+		InputCfg:   &InputScanConfig{Enabled: true, Action: config.ActionBlock},
+		CaptureObs: obs,
+		ConfigHash: "sha256:test-config",
+		Profile:    "mcp-profile",
+		Transport:  transportMCPHTTP,
+	})
+	if decision.Blocked == nil {
+		t.Fatal("expected MCP input DLP block")
+	}
+
+	select {
+	case rec := <-obs.got:
+		if rec.Subsurface != "dlp_mcp_input" {
+			t.Fatalf("subsurface = %q, want dlp_mcp_input", rec.Subsurface)
+		}
+		if rec.Transport != transportMCPHTTP {
+			t.Fatalf("transport = %q, want %q", rec.Transport, transportMCPHTTP)
+		}
+		if rec.SessionID == "" {
+			t.Fatal("session_id is empty")
+		}
+		if rec.ConfigHash != "sha256:test-config" {
+			t.Fatalf("config_hash = %q", rec.ConfigHash)
+		}
+		if rec.Profile != "mcp-profile" {
+			t.Fatalf("profile = %q", rec.Profile)
+		}
+		if rec.EffectiveAction != config.ActionBlock {
+			t.Fatalf("effective_action = %q, want block", rec.EffectiveAction)
+		}
+		if rec.Outcome != capture.OutcomeBlocked {
+			t.Fatalf("outcome = %q, want blocked", rec.Outcome)
+		}
+	default:
+		t.Fatal("expected DLP capture record")
+	}
+}
+
+func TestCaptureMetadata_MCPStdioInputTransport(t *testing.T) {
+	t.Parallel()
+
+	sc := testScannerForHTTP(t)
+	obs := &mcpCaptureMetadataObserver{got: make(chan capture.DLPVerdictRecord, 1)}
+
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"fetch","arguments":{"api_key":"` +
+		testSecretPrefix + `aaaaaaaaaaaaaaaaaaaaaaaaa"}}}` + "\n")
+
+	opts := buildTestOpts(sc)
+	opts.InputCfg = &InputScanConfig{Enabled: true, Action: config.ActionBlock, OnParseError: config.ActionBlock}
+	opts.CaptureObs = obs
+	opts.ConfigHash = "sha256:test-stdio-config"
+	opts.Profile = "stdio-profile"
+	opts.Transport = transportMCPStdio
+
+	var serverBuf, logBuf bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 1)
+
+	done := make(chan struct{})
+	go func() {
+		ForwardScannedInput(
+			transport.NewStdioReader(strings.NewReader(string(msg))),
+			transport.NewStdioWriter(&serverBuf),
+			&logBuf,
+			config.ActionBlock,
+			config.ActionBlock,
+			blockedCh,
+			nil,
+			nil,
+			opts,
+		)
+		close(done)
+	}()
+
+	// Drain the blocked-request channel so ForwardScannedInput can return.
+	select {
+	case blocked := <-blockedCh:
+		if blocked.ID == nil {
+			t.Fatal("blocked request missing ID")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for blocked request")
+	}
+	<-done
+
+	select {
+	case rec := <-obs.got:
+		if rec.Subsurface != "dlp_mcp_input" {
+			t.Fatalf("subsurface = %q, want dlp_mcp_input", rec.Subsurface)
+		}
+		if rec.Transport != transportMCPStdio {
+			t.Fatalf("transport = %q, want %q", rec.Transport, transportMCPStdio)
+		}
+		if rec.SessionID == "" {
+			t.Fatal("session_id is empty — stdio capture metadata regressed")
+		}
+		if rec.ConfigHash != "sha256:test-stdio-config" {
+			t.Fatalf("config_hash = %q, want sha256:test-stdio-config", rec.ConfigHash)
+		}
+		if rec.Profile != "stdio-profile" {
+			t.Fatalf("profile = %q, want stdio-profile", rec.Profile)
+		}
+		if rec.EffectiveAction != config.ActionBlock {
+			t.Fatalf("effective_action = %q, want block", rec.EffectiveAction)
+		}
+		if rec.Outcome != capture.OutcomeBlocked {
+			t.Fatalf("outcome = %q, want blocked", rec.Outcome)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected DLP capture record on stdio block path")
+	}
+}

--- a/internal/mcp/proxy_http.go
+++ b/internal/mcp/proxy_http.go
@@ -680,6 +680,26 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		}
 	}
 
+	// Capture: record DLP/injection input verdict before action dispatch so
+	// block/ask/redirect/warn all preserve the same replay metadata.
+	if !verdict.Clean {
+		var rawFindings []capture.Finding
+		rawFindings = append(rawFindings, dlpMatchesToFindings(verdict.Matches)...)
+		rawFindings = append(rawFindings, responseMatchesToFindings(verdict.Inject, effectiveAction)...)
+		obs.ObserveDLPVerdict(context.Background(), &capture.DLPVerdictRecord{
+			Subsurface:        "dlp_mcp_input",
+			Transport:         opts.Transport,
+			SessionID:         captureSessionID(opts.Transport),
+			SessionIDOriginal: captureSessionIDOriginal(opts.Transport),
+			ConfigHash:        opts.captureConfigHash(),
+			Profile:           opts.captureProfile(),
+			TransformKind:     capture.TransformJoinedFields,
+			RawFindings:       rawFindings,
+			EffectiveAction:   effectiveAction,
+			Outcome:           captureOutcome(effectiveAction, false),
+		})
+	}
+
 	switch effectiveAction {
 	case config.ActionBlock:
 		_, _ = fmt.Fprintf(logW, "pipelock: input: blocked (%s)\n", joinStrings(reasons))
@@ -843,24 +863,6 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 				ErrorMessage:   fmt.Sprintf("pipelock: %s", reason),
 			}
 			return result
-		}
-		// Capture: record DLP/injection input verdict when not clean.
-		if !verdict.Clean {
-			var rawFindings []capture.Finding
-			rawFindings = append(rawFindings, dlpMatchesToFindings(verdict.Matches)...)
-			rawFindings = append(rawFindings, responseMatchesToFindings(verdict.Inject, effectiveAction)...)
-			obs.ObserveDLPVerdict(context.Background(), &capture.DLPVerdictRecord{
-				Subsurface:        "dlp_mcp_input",
-				Transport:         opts.Transport,
-				SessionID:         captureSessionID(opts.Transport),
-				SessionIDOriginal: captureSessionIDOriginal(opts.Transport),
-				ConfigHash:        opts.captureConfigHash(),
-				Profile:           opts.captureProfile(),
-				TransformKind:     capture.TransformJoinedFields,
-				RawFindings:       rawFindings,
-				EffectiveAction:   effectiveAction,
-				Outcome:           captureOutcome(effectiveAction, false),
-			})
 		}
 		if verdict.Method == methodToolsCall {
 			var decorateErr error

--- a/internal/metrics/capture.go
+++ b/internal/metrics/capture.go
@@ -5,8 +5,18 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
-// registerCaptureMetrics builds and registers the capture-system drop
-// counter. Handles are attached to m.
+// CaptureSessionIDSanitizationReason is the closed label domain for
+// pipelock_capture_session_id_sanitized_total.
+type CaptureSessionIDSanitizationReason string
+
+const (
+	CaptureSessionIDUnsafePath CaptureSessionIDSanitizationReason = "unsafe_path"
+	CaptureSessionIDOverlength CaptureSessionIDSanitizationReason = "overlength"
+	CaptureSessionIDUnknown    CaptureSessionIDSanitizationReason = "unknown"
+)
+
+// registerCaptureMetrics builds and registers the capture-system counters.
+// Handles are attached to m.
 func (m *Metrics) registerCaptureMetrics(reg *prometheus.Registry) {
 	m.CaptureDropped = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "pipelock",
@@ -14,10 +24,33 @@ func (m *Metrics) registerCaptureMetrics(reg *prometheus.Registry) {
 		Help:      "Total capture entries dropped due to queue overflow.",
 	})
 
-	reg.MustRegister(m.CaptureDropped)
+	m.captureSessionIDSanitized = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "pipelock",
+		Name:      "capture_session_id_sanitized_total",
+		Help:      "Total capture entries whose unsafe or overlength logical session ID was replaced with a bounded hashed session ID.",
+	}, []string{"reason"})
+
+	reg.MustRegister(m.CaptureDropped, m.captureSessionIDSanitized)
 }
 
 // RecordCaptureDrop increments the capture dropped counter.
 func (m *Metrics) RecordCaptureDrop() {
+	if m == nil {
+		return
+	}
 	m.CaptureDropped.Inc()
+}
+
+// RecordCaptureSessionIDSanitized increments the capture session-id
+// sanitization counter for the given closed-domain reason. Non-canonical
+// labels are dropped to avoid cardinality drift from untrusted identity input.
+func (m *Metrics) RecordCaptureSessionIDSanitized(reason string) {
+	if m == nil {
+		return
+	}
+	switch CaptureSessionIDSanitizationReason(reason) {
+	case CaptureSessionIDUnsafePath, CaptureSessionIDOverlength, CaptureSessionIDUnknown:
+		m.captureSessionIDSanitized.WithLabelValues(reason).Inc()
+	default:
+	}
 }

--- a/internal/metrics/capture_test.go
+++ b/internal/metrics/capture_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecordCaptureSessionIDSanitized(t *testing.T) {
+	t.Parallel()
+	m := New()
+
+	m.RecordCaptureSessionIDSanitized("unsafe_path")
+	m.RecordCaptureSessionIDSanitized("unsafe_path")
+	m.RecordCaptureSessionIDSanitized("overlength")
+	m.RecordCaptureSessionIDSanitized("unknown")
+
+	if got := testutil.ToFloat64(m.captureSessionIDSanitized.WithLabelValues("unsafe_path")); got != 2 {
+		t.Errorf("unsafe_path counter = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(m.captureSessionIDSanitized.WithLabelValues("overlength")); got != 1 {
+		t.Errorf("overlength counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.captureSessionIDSanitized.WithLabelValues("unknown")); got != 1 {
+		t.Errorf("unknown counter = %v, want 1", got)
+	}
+}
+
+func TestRecordCaptureSessionIDSanitized_DropsNonCanonical(t *testing.T) {
+	t.Parallel()
+	m := New()
+
+	m.RecordCaptureSessionIDSanitized("../../../etc/passwd")
+	m.RecordCaptureSessionIDSanitized("")
+
+	for _, label := range []string{"unsafe_path", "overlength", "unknown"} {
+		if got := testutil.ToFloat64(m.captureSessionIDSanitized.WithLabelValues(label)); got != 0 {
+			t.Errorf("%s counter = %v, want 0 after non-canonical inputs", label, got)
+		}
+	}
+}
+
+func TestRecordCaptureDrop_NilSafe(t *testing.T) {
+	t.Parallel()
+	var m *Metrics
+	m.RecordCaptureDrop()
+}

--- a/internal/metrics/envelope.go
+++ b/internal/metrics/envelope.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// EnvelopeVerifyResult is the closed label domain for
+// pipelock_envelope_verify_total.
+type EnvelopeVerifyResult string
+
+const (
+	EnvelopeVerifyDisabled EnvelopeVerifyResult = "disabled"
+	EnvelopeVerifyVerified EnvelopeVerifyResult = "verified"
+	EnvelopeVerifyMissing  EnvelopeVerifyResult = "missing"
+	EnvelopeVerifyFailed   EnvelopeVerifyResult = "failed"
+)
+
+func (m *Metrics) registerEnvelopeMetrics(reg *prometheus.Registry) {
+	m.envelopeVerifyTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "pipelock",
+		Name:      "envelope_verify_total",
+		Help:      "Total inbound mediation envelope verification attempts, labeled by result.",
+	}, []string{"result"})
+
+	reg.MustRegister(m.envelopeVerifyTotal)
+}
+
+// RecordEnvelopeVerify increments the inbound mediation-envelope verification
+// counter for a closed-domain result label. Non-canonical labels are dropped to
+// avoid unbounded cardinality from error text.
+func (m *Metrics) RecordEnvelopeVerify(result EnvelopeVerifyResult) {
+	if m == nil {
+		return
+	}
+	switch result {
+	case EnvelopeVerifyDisabled, EnvelopeVerifyVerified, EnvelopeVerifyMissing, EnvelopeVerifyFailed:
+		m.envelopeVerifyTotal.WithLabelValues(string(result)).Inc()
+	default:
+	}
+}

--- a/internal/metrics/envelope_test.go
+++ b/internal/metrics/envelope_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecordEnvelopeVerify_AllResultLabels(t *testing.T) {
+	t.Parallel()
+	m := New()
+
+	for _, result := range []EnvelopeVerifyResult{
+		EnvelopeVerifyDisabled,
+		EnvelopeVerifyVerified,
+		EnvelopeVerifyMissing,
+		EnvelopeVerifyFailed,
+	} {
+		m.RecordEnvelopeVerify(result)
+	}
+	m.RecordEnvelopeVerify(EnvelopeVerifyFailed)
+
+	cases := map[string]float64{
+		"disabled": 1,
+		"verified": 1,
+		"missing":  1,
+		"failed":   2,
+	}
+	for result, want := range cases {
+		if got := testutil.ToFloat64(m.envelopeVerifyTotal.WithLabelValues(result)); got != want {
+			t.Errorf("result=%s counter = %v, want %v", result, got, want)
+		}
+	}
+}
+
+func TestRecordEnvelopeVerify_DropsNonCanonical(t *testing.T) {
+	t.Parallel()
+	m := New()
+
+	m.RecordEnvelopeVerify(EnvelopeVerifyResult("signature_error_with_user_input"))
+	m.RecordEnvelopeVerify(EnvelopeVerifyResult(""))
+
+	for _, result := range []string{"disabled", "verified", "missing", "failed"} {
+		if got := testutil.ToFloat64(m.envelopeVerifyTotal.WithLabelValues(result)); got != 0 {
+			t.Errorf("result=%s counter = %v, want 0 after non-canonical inputs", result, got)
+		}
+	}
+}
+
+func TestRecordEnvelopeVerify_NilSafe(t *testing.T) {
+	t.Parallel()
+	var m *Metrics
+	m.RecordEnvelopeVerify(EnvelopeVerifyVerified)
+}

--- a/internal/metrics/learn.go
+++ b/internal/metrics/learn.go
@@ -98,6 +98,18 @@ func (m *Metrics) registerLearnMetrics(reg *prometheus.Registry) {
 		Help:      "Total floor failures across all inference classifications, labeled by which floor caused the rule to fall back to never_confirmed (sessions, events, windows). Diagnostic for which floor is the bottleneck on a deployment's data volume.",
 	}, []string{"floor"})
 
+	m.learnCaptureRecords = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: learnNamespace,
+		Name:      "capture_records_total",
+		Help:      "Total capture records durably written by the learn-and-lock capture writer.",
+	})
+
+	m.learnCaptureDropped = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: learnNamespace,
+		Name:      "capture_dropped_total",
+		Help:      "Total capture records dropped before durable write by the learn-and-lock capture writer.",
+	})
+
 	reg.MustRegister(
 		m.learnObservationEvents,
 		m.learnRegulatedDataBlocked,
@@ -105,6 +117,8 @@ func (m *Metrics) registerLearnMetrics(reg *prometheus.Registry) {
 		m.learnUnclassifiedRate,
 		m.learnInferenceClassifications,
 		m.learnInferenceFloorFailures,
+		m.learnCaptureRecords,
+		m.learnCaptureDropped,
 	)
 }
 
@@ -247,4 +261,20 @@ func (m *Metrics) RecordInferenceFloorFailure(floor FloorFailure) {
 	default:
 		// Drop non-canonical (see RecordInferenceClassification).
 	}
+}
+
+// RecordLearnCaptureRecord increments the learn capture durable-write counter.
+func (m *Metrics) RecordLearnCaptureRecord() {
+	if m == nil {
+		return
+	}
+	m.learnCaptureRecords.Inc()
+}
+
+// RecordLearnCaptureDrop increments the learn capture drop counter.
+func (m *Metrics) RecordLearnCaptureDrop() {
+	if m == nil {
+		return
+	}
+	m.learnCaptureDropped.Inc()
 }

--- a/internal/metrics/learn_test.go
+++ b/internal/metrics/learn_test.go
@@ -19,9 +19,11 @@ var expectedLearnMetricNames = []string{
 	"pipelock_learn_unclassified_rate",
 	"pipelock_learn_inference_classify_total",
 	"pipelock_learn_inference_floor_failures_total",
+	"pipelock_learn_capture_records_total",
+	"pipelock_learn_capture_dropped_total",
 }
 
-func TestRegisterLearnMetrics_RegistersAllSix(t *testing.T) {
+func TestRegisterLearnMetrics_RegistersAll(t *testing.T) {
 	t.Parallel()
 	m := New()
 
@@ -38,6 +40,8 @@ func TestRegisterLearnMetrics_RegistersAllSix(t *testing.T) {
 	m.RecordRegulatedDataBlocked(BlockReasonFieldClassRegulated)
 	m.RecordInferenceClassification(OutcomeStable)
 	m.RecordInferenceFloorFailure(FloorSessions)
+	m.RecordLearnCaptureRecord()
+	m.RecordLearnCaptureDrop()
 
 	families, err := m.Registry().Gather()
 	if err != nil {
@@ -54,6 +58,29 @@ func TestRegisterLearnMetrics_RegistersAllSix(t *testing.T) {
 			t.Errorf("expected metric %q in registry, not found", want)
 		}
 	}
+}
+
+func TestRecordLearnCaptureCounters(t *testing.T) {
+	t.Parallel()
+	m := New()
+
+	m.RecordLearnCaptureRecord()
+	m.RecordLearnCaptureRecord()
+	m.RecordLearnCaptureDrop()
+
+	if got := testutil.ToFloat64(m.learnCaptureRecords); got != 2 {
+		t.Errorf("learn capture records = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(m.learnCaptureDropped); got != 1 {
+		t.Errorf("learn capture dropped = %v, want 1", got)
+	}
+}
+
+func TestRecordLearnCaptureCounters_NilSafe(t *testing.T) {
+	t.Parallel()
+	var m *Metrics
+	m.RecordLearnCaptureRecord()
+	m.RecordLearnCaptureDrop()
 }
 
 func TestRecordObservationEvent_IncrementsByActionClass(t *testing.T) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -99,7 +99,8 @@ type Metrics struct {
 	responseScanExemptTotal *prometheus.CounterVec
 
 	// Capture (capture.go).
-	CaptureDropped prometheus.Counter
+	CaptureDropped            prometheus.Counter
+	captureSessionIDSanitized *prometheus.CounterVec
 
 	// Learn-and-lock observation pipeline (learn.go).
 	learnObservationEvents        *prometheus.CounterVec
@@ -108,6 +109,11 @@ type Metrics struct {
 	learnUnclassifiedRate         prometheus.Gauge
 	learnInferenceClassifications *prometheus.CounterVec
 	learnInferenceFloorFailures   *prometheus.CounterVec
+	learnCaptureRecords           prometheus.Counter
+	learnCaptureDropped           prometheus.Counter
+
+	// Mediation envelope verification (envelope.go).
+	envelopeVerifyTotal *prometheus.CounterVec
 
 	// Stats endpoint state (stats_handler.go).
 	mu                     sync.Mutex
@@ -168,6 +174,7 @@ func New() *Metrics {
 	m.registerShieldMetrics(reg)
 	m.registerCaptureMetrics(reg)
 	m.registerLearnMetrics(reg)
+	m.registerEnvelopeMetrics(reg)
 
 	return m
 }

--- a/internal/proxy/capture_metadata_transport_test.go
+++ b/internal/proxy/capture_metadata_transport_test.go
@@ -1,0 +1,388 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gobwas/ws"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/capture"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/killswitch"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+type captureMetadataObserver struct {
+	mu      sync.Mutex
+	records []capture.CaptureSummary
+	ch      chan capture.CaptureSummary
+}
+
+func newCaptureMetadataObserver() *captureMetadataObserver {
+	return &captureMetadataObserver{ch: make(chan capture.CaptureSummary, 16)}
+}
+
+func (o *captureMetadataObserver) append(s capture.CaptureSummary) {
+	o.mu.Lock()
+	o.records = append(o.records, s)
+	o.mu.Unlock()
+	o.ch <- s
+}
+
+func (o *captureMetadataObserver) ObserveURLVerdict(_ context.Context, rec *capture.URLVerdictRecord) {
+	o.append(summaryFromURLRecord(rec))
+}
+
+func (o *captureMetadataObserver) ObserveResponseVerdict(_ context.Context, rec *capture.ResponseVerdictRecord) {
+	o.append(capture.CaptureSummary{
+		Surface:           capture.SurfaceResponse,
+		Subsurface:        rec.Subsurface,
+		ConfigHash:        rec.ConfigHash,
+		Agent:             rec.Agent,
+		Profile:           rec.Profile,
+		SessionIDOriginal: rec.SessionIDOriginal,
+		EffectiveAction:   rec.EffectiveAction,
+		Outcome:           rec.Outcome,
+		Request:           rec.Request,
+	})
+}
+
+func (o *captureMetadataObserver) ObserveDLPVerdict(_ context.Context, rec *capture.DLPVerdictRecord) {
+	o.append(capture.CaptureSummary{
+		Surface:           capture.SurfaceDLP,
+		Subsurface:        rec.Subsurface,
+		ConfigHash:        rec.ConfigHash,
+		Agent:             rec.Agent,
+		Profile:           rec.Profile,
+		SessionIDOriginal: rec.SessionIDOriginal,
+		EffectiveAction:   rec.EffectiveAction,
+		Outcome:           rec.Outcome,
+		Request:           rec.Request,
+	})
+}
+
+func (o *captureMetadataObserver) ObserveCEEVerdict(_ context.Context, rec *capture.CEERecord) {
+	o.append(capture.CaptureSummary{
+		Surface:           capture.SurfaceCEE,
+		Subsurface:        rec.Subsurface,
+		ConfigHash:        rec.ConfigHash,
+		Agent:             rec.Agent,
+		Profile:           rec.Profile,
+		SessionIDOriginal: rec.SessionIDOriginal,
+		EffectiveAction:   rec.EffectiveAction,
+		Outcome:           rec.Outcome,
+		Request:           rec.Request,
+	})
+}
+
+func (o *captureMetadataObserver) ObserveToolPolicyVerdict(_ context.Context, rec *capture.ToolPolicyRecord) {
+	o.append(capture.CaptureSummary{
+		Surface:           capture.SurfaceToolPolicy,
+		Subsurface:        rec.Subsurface,
+		ConfigHash:        rec.ConfigHash,
+		Agent:             rec.Agent,
+		Profile:           rec.Profile,
+		SessionIDOriginal: rec.SessionIDOriginal,
+		EffectiveAction:   rec.EffectiveAction,
+		Outcome:           rec.Outcome,
+		Request:           rec.Request,
+	})
+}
+
+func (o *captureMetadataObserver) ObserveToolScanVerdict(_ context.Context, rec *capture.ToolScanRecord) {
+	o.append(capture.CaptureSummary{
+		Surface:           capture.SurfaceToolScan,
+		Subsurface:        rec.Subsurface,
+		ConfigHash:        rec.ConfigHash,
+		Agent:             rec.Agent,
+		Profile:           rec.Profile,
+		SessionIDOriginal: rec.SessionIDOriginal,
+		EffectiveAction:   rec.EffectiveAction,
+		Outcome:           rec.Outcome,
+		Request:           rec.Request,
+	})
+}
+
+func (o *captureMetadataObserver) Close() error { return nil }
+
+func summaryFromURLRecord(rec *capture.URLVerdictRecord) capture.CaptureSummary {
+	return capture.CaptureSummary{
+		Surface:           capture.SurfaceURL,
+		Subsurface:        rec.Subsurface,
+		ConfigHash:        rec.ConfigHash,
+		Agent:             rec.Agent,
+		Profile:           rec.Profile,
+		SessionIDOriginal: rec.SessionIDOriginal,
+		EffectiveAction:   rec.EffectiveAction,
+		Outcome:           rec.Outcome,
+		Request:           rec.Request,
+	}
+}
+
+func requireCaptureMetadata(t *testing.T, got capture.CaptureSummary, surface, subsurface string) {
+	t.Helper()
+	if got.Surface != surface {
+		t.Fatalf("surface = %q, want %q (record=%+v)", got.Surface, surface, got)
+	}
+	if got.Subsurface != subsurface {
+		t.Fatalf("subsurface = %q, want %q (record=%+v)", got.Subsurface, subsurface, got)
+	}
+	for field, value := range map[string]string{
+		"config_hash":      got.ConfigHash,
+		"profile":          got.Profile,
+		"agent":            got.Agent,
+		"effective_action": got.EffectiveAction,
+		"outcome":          got.Outcome,
+	} {
+		if value == "" {
+			t.Fatalf("%s is empty in capture record: %+v", field, got)
+		}
+	}
+}
+
+func waitCaptureRecord(t *testing.T, obs *captureMetadataObserver, surface, subsurface string) capture.CaptureSummary {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case got := <-obs.ch:
+			if got.Surface == surface && got.Subsurface == subsurface {
+				return got
+			}
+		case <-deadline:
+			t.Fatalf("timeout waiting for capture record surface=%s subsurface=%s", surface, subsurface)
+		}
+	}
+}
+
+func newCaptureMetadataProxy(t *testing.T, cfg *config.Config, obs *captureMetadataObserver) *Proxy {
+	t.Helper()
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+	p, err := New(cfg, logger, sc, metrics.New(), WithCaptureObserver(obs))
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	t.Cleanup(p.Close)
+	return p
+}
+
+func captureMetadataConfig() *config.Config {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.APIAllowlist = nil
+	cfg.ForwardProxy.Enabled = true
+	cfg.WebSocketProxy.Enabled = true
+	cfg.WebSocketProxy.MaxMessageBytes = 1048576
+	cfg.WebSocketProxy.MaxConcurrentConnections = 128
+	cfg.WebSocketProxy.MaxConnectionSeconds = 10
+	cfg.WebSocketProxy.IdleTimeoutSeconds = 5
+	cfg.FetchProxy.TimeoutSeconds = 5
+	cfg.RequestBodyScanning.Enabled = true
+	cfg.RequestBodyScanning.Action = config.ActionBlock
+	cfg.RequestBodyScanning.MaxBodyBytes = 1024 * 1024
+	cfg.ResponseScanning.Enabled = true
+	cfg.ResponseScanning.Action = config.ActionBlock
+	cfg.ApplyDefaults()
+	cfg.Internal = nil
+	return cfg
+}
+
+func TestCaptureMetadata_ForwardTransport(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	obs := newCaptureMetadataObserver()
+	p := newCaptureMetadataProxy(t, captureMetadataConfig(), obs)
+
+	req := httptest.NewRequest(http.MethodGet, upstream.URL, nil)
+	rec := httptest.NewRecorder()
+	p.handleForwardHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("forward status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	got := waitCaptureRecord(t, obs, capture.SurfaceURL, "forward_url")
+	requireCaptureMetadata(t, got, capture.SurfaceURL, "forward_url")
+}
+
+func TestCaptureMetadata_ReverseTransport(t *testing.T) {
+	t.Parallel()
+
+	cfg := captureMetadataConfig()
+	obs := newCaptureMetadataObserver()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("should not be reached"))
+	}))
+	defer upstream.Close()
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream: %v", err)
+	}
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+	var cfgPtr atomic.Pointer[config.Config]
+	var scPtr atomic.Pointer[scanner.Scanner]
+	cfgPtr.Store(cfg)
+	scPtr.Store(sc)
+	handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, audit.NewNop(), metrics.New(), killswitch.New(cfg), obs, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api", strings.NewReader(`{"key":"`+fakeAPIKey()+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(AgentHeader, "reverse-agent")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("reverse status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+
+	got := waitCaptureRecord(t, obs, capture.SurfaceDLP, "dlp_reverse_request")
+	requireCaptureMetadata(t, got, capture.SurfaceDLP, "dlp_reverse_request")
+}
+
+func TestCaptureMetadata_WebSocketTransport(t *testing.T) {
+	t.Parallel()
+
+	backendAddr, backendClose := wsEchoServer(t)
+	defer backendClose()
+
+	cfg := captureMetadataConfig()
+	obs := newCaptureMetadataObserver()
+	p := newCaptureMetadataProxy(t, cfg, obs)
+
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close() //nolint:errcheck // test cleanup
+
+	srv := &http.Server{
+		Handler:           p.buildHandler(http.NewServeMux()),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ws", p.handleWebSocket)
+	srv.Handler = p.buildHandler(mux)
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close() //nolint:errcheck // test cleanup
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, _, err := ws.Dialer{Extensions: nil}.Dial(ctx, "ws://"+ln.Addr().String()+"/ws?url=ws://"+backendAddr)
+	if err != nil {
+		t.Fatalf("ws dial: %v", err)
+	}
+	_ = conn.Close()
+
+	got := waitCaptureRecord(t, obs, capture.SurfaceURL, "ws_url")
+	requireCaptureMetadata(t, got, capture.SurfaceURL, "ws_url")
+}
+
+// TestCaptureMetadata_InterceptTransport drives a TLS-intercepted GET through
+// the intercept handler with a real Proxy + capture observer attached, and
+// asserts the URL-pipeline capture record carries the metadata the LL pipeline
+// needs (config_hash, profile, agent, effective_action, outcome). Closes the
+// last gap in the v2.4 capture transport-parity matrix.
+func TestCaptureMetadata_InterceptTransport(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer upstream.Close()
+
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	enforceTrue := true
+	cfg.Enforce = &enforceTrue
+
+	obs := newCaptureMetadataObserver()
+	p, err := New(cfg, logger, sc, m, WithCaptureObserver(obs))
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	t.Cleanup(p.Close)
+
+	host := upstream.Listener.Addr().(*net.TCPAddr).IP.String()
+	port := fmt.Sprintf("%d", upstream.Listener.Addr().(*net.TCPAddr).Port)
+
+	clientConn, proxyConn := net.Pipe()
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	go func() {
+		_ = interceptTunnel(ctx, proxyConn, &InterceptContext{
+			TargetHost: host,
+			TargetPort: port,
+			Config:     cfg,
+			Scanner:    sc,
+			CertCache:  cache,
+			Logger:     logger,
+			Metrics:    m,
+			ClientIP:   "10.0.0.42",
+			RequestID:  "intercept-capture-test",
+			Agent:      "intercept-agent",
+			Profile:    "intercept-profile",
+			UpstreamRT: upstream.Client().Transport,
+			Proxy:      p,
+		})
+	}()
+
+	tlsConn := tls.Client(clientConn, &tls.Config{
+		RootCAs:    pool,
+		ServerName: host,
+		MinVersion: tls.VersionTLS12,
+	})
+	t.Cleanup(func() { _ = tlsConn.Close() })
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://"+net.JoinHostPort(host, port)+"/", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Host = net.JoinHostPort(host, port)
+	if err := req.Write(tlsConn); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(tlsConn), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("intercept response status = %d, want 200", resp.StatusCode)
+	}
+
+	got := waitCaptureRecord(t, obs, capture.SurfaceURL, "intercept_url")
+	requireCaptureMetadata(t, got, capture.SurfaceURL, "intercept_url")
+	if got.Agent != "intercept-agent" {
+		t.Fatalf("agent = %q, want intercept-agent", got.Agent)
+	}
+	if got.Profile != "intercept-profile" {
+		t.Fatalf("profile = %q, want intercept-profile", got.Profile)
+	}
+}

--- a/internal/proxy/cee.go
+++ b/internal/proxy/cee.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/decide"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
@@ -31,10 +32,10 @@ func CeeSessionKey(agent, clientIP string) string {
 	return clientIP
 }
 
-// maxCaptureSessionKeyLen bounds the on-disk session directory name length.
-// Most filesystems cap a single path component at 255 bytes (NAME_MAX); pick a
-// conservative ceiling so the writer never bumps that limit.
-const maxCaptureSessionKeyLen = 200
+// maxCaptureSessionKeyLen aliases the writer-side ceiling so the
+// proxy-side sanitization decision and the writer-side reason metric stay
+// in lockstep. Source of truth: capture.MaxSessionKeyLen.
+const maxCaptureSessionKeyLen = capture.MaxSessionKeyLen
 
 // captureSessionKey returns the CEE session identity when it is safe to use as
 // a recorder directory name. Self-declared agent names are untrusted, so unsafe

--- a/internal/proxy/envelope_failure_pattern_test.go
+++ b/internal/proxy/envelope_failure_pattern_test.go
@@ -71,12 +71,17 @@ func TestRecordInboundEnvelopeVerifyMetricMapping(t *testing.T) {
 		Err:  errors.New("missing envelope"),
 	})
 	recordInboundEnvelopeVerify(m, cfgEnabled, errors.New("signature verification failed"))
+	// nil cfg with a non-nil error must classify as failed, not disabled.
+	// verifyInboundEnvelope returns an error when cfg is nil; folding that
+	// into the disabled label silently buries fail-closed verifier failures
+	// (nil cfg implies a misconfigured deployment, not an opt-out).
+	recordInboundEnvelopeVerify(m, nil, errors.New("missing config"))
 
 	cases := map[string]float64{
 		"disabled": 1,
 		"verified": 1,
 		"missing":  1,
-		"failed":   1,
+		"failed":   2,
 	}
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rec := httptest.NewRecorder()

--- a/internal/proxy/envelope_failure_pattern_test.go
+++ b/internal/proxy/envelope_failure_pattern_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
@@ -52,6 +53,40 @@ func TestInboundEnvelopeFailurePatternUsesVerifierCodes(t *testing.T) {
 				t.Fatalf("pattern = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRecordInboundEnvelopeVerifyMetricMapping(t *testing.T) {
+	t.Parallel()
+
+	cfgDisabled := config.Defaults()
+	cfgEnabled := config.Defaults()
+	cfgEnabled.MediationEnvelope.VerifyInbound.Enabled = true
+
+	m := metrics.New()
+	recordInboundEnvelopeVerify(m, cfgDisabled, nil)
+	recordInboundEnvelopeVerify(m, cfgEnabled, nil)
+	recordInboundEnvelopeVerify(m, cfgEnabled, &envelope.VerificationError{
+		Code: envelope.VerificationFailureMissing,
+		Err:  errors.New("missing envelope"),
+	})
+	recordInboundEnvelopeVerify(m, cfgEnabled, errors.New("signature verification failed"))
+
+	cases := map[string]float64{
+		"disabled": 1,
+		"verified": 1,
+		"missing":  1,
+		"failed":   1,
+	}
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	m.PrometheusHandler().ServeHTTP(rec, req)
+	body := rec.Body.String()
+	for result, want := range cases {
+		line := fmt.Sprintf(`pipelock_envelope_verify_total{result="%s"} %g`, result, want)
+		if !strings.Contains(body, line) {
+			t.Fatalf("metrics output missing %q\n%s", line, body)
+		}
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1610,19 +1610,25 @@ func (p *Proxy) verifyInboundEnvelope(r *http.Request, cfg *config.Config) error
 }
 
 func recordInboundEnvelopeVerify(m *metrics.Metrics, cfg *config.Config, err error) {
+	// Errors must be classified before the disabled fast-path: a nil cfg or a
+	// nil verifier still produces an error from verifyInboundEnvelope, and
+	// folding those into "disabled" hides fail-closed verifier failures in
+	// telemetry. Operators correlate the failed counter with the audit log
+	// to spot misconfigured deployments; the disabled label is for genuinely
+	// non-enabled verifiers only.
+	if err != nil {
+		if code, ok := envelope.VerificationFailureCodeOf(err); ok && code == envelope.VerificationFailureMissing {
+			m.RecordEnvelopeVerify(metrics.EnvelopeVerifyMissing)
+			return
+		}
+		m.RecordEnvelopeVerify(metrics.EnvelopeVerifyFailed)
+		return
+	}
 	if cfg == nil || !cfg.MediationEnvelope.VerifyInbound.Enabled {
 		m.RecordEnvelopeVerify(metrics.EnvelopeVerifyDisabled)
 		return
 	}
-	if err == nil {
-		m.RecordEnvelopeVerify(metrics.EnvelopeVerifyVerified)
-		return
-	}
-	if code, ok := envelope.VerificationFailureCodeOf(err); ok && code == envelope.VerificationFailureMissing {
-		m.RecordEnvelopeVerify(metrics.EnvelopeVerifyMissing)
-		return
-	}
-	m.RecordEnvelopeVerify(metrics.EnvelopeVerifyFailed)
+	m.RecordEnvelopeVerify(metrics.EnvelopeVerifyVerified)
 }
 
 func inboundEnvelopeFailurePattern(err error) string {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1604,7 +1604,25 @@ func (p *Proxy) currentEnvelopeEmitter() *envelope.Emitter {
 }
 
 func (p *Proxy) verifyInboundEnvelope(r *http.Request, cfg *config.Config) error {
-	return verifyInboundEnvelope(r, cfg, p.envelopeVerifierPtr.Load())
+	err := verifyInboundEnvelope(r, cfg, p.envelopeVerifierPtr.Load())
+	recordInboundEnvelopeVerify(p.metrics, cfg, err)
+	return err
+}
+
+func recordInboundEnvelopeVerify(m *metrics.Metrics, cfg *config.Config, err error) {
+	if cfg == nil || !cfg.MediationEnvelope.VerifyInbound.Enabled {
+		m.RecordEnvelopeVerify(metrics.EnvelopeVerifyDisabled)
+		return
+	}
+	if err == nil {
+		m.RecordEnvelopeVerify(metrics.EnvelopeVerifyVerified)
+		return
+	}
+	if code, ok := envelope.VerificationFailureCodeOf(err); ok && code == envelope.VerificationFailureMissing {
+		m.RecordEnvelopeVerify(metrics.EnvelopeVerifyMissing)
+		return
+	}
+	m.RecordEnvelopeVerify(metrics.EnvelopeVerifyFailed)
 }
 
 func inboundEnvelopeFailurePattern(err error) string {
@@ -1670,7 +1688,10 @@ func verifyInboundEnvelope(r *http.Request, cfg *config.Config, verifier *envelo
 	// — gets fully buffered up to max_body_bytes. That is a free
 	// amplification surface for unauthenticated callers.
 	if r != nil && r.Header.Get(envelope.HeaderName) == "" {
-		return fmt.Errorf("missing %s header", envelope.HeaderName)
+		return &envelope.VerificationError{
+			Code: envelope.VerificationFailureMissing,
+			Err:  fmt.Errorf("missing %s header", envelope.HeaderName),
+		}
 	}
 	body, err := bufferInboundEnvelopeBody(r, cfg.MediationEnvelope.MaxBodyBytes)
 	if err != nil {

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -296,6 +296,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	r = r.WithContext(ctx)
 
 	if err := verifyInboundEnvelope(r, cfg, snap.inboundVerifier); err != nil {
+		recordInboundEnvelopeVerify(rp.metrics, cfg, err)
 		pattern := inboundEnvelopeFailurePattern(err)
 		rp.metrics.RecordReverseProxyRequest(r.Method, "403")
 		rp.metrics.RecordReverseProxyScanBlocked(scanDirectionRequest, blockLayerMediationEnvelope)
@@ -315,6 +316,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			"inbound mediation envelope verification failed")
 		return
 	}
+	recordInboundEnvelopeVerify(rp.metrics, cfg, nil)
 	// Strip inbound mediation envelope headers after optional trust
 	// verification so forged mediation metadata cannot survive to upstreams.
 	envelope.StripInbound(r.Header)
@@ -354,6 +356,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 				SessionID:         captureSessionKey(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
 				SessionIDOriginal: captureSessionKeyOriginal(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
 				ConfigHash:        cfg.CanonicalPolicyHash(),
+				Agent:             r.Header.Get("X-Pipelock-Agent"),
 				Profile:           edition.ProfileDefault,
 				Request:           capture.CaptureRequest{Method: r.Method, URL: r.URL.String()},
 				TransformKind:     capture.TransformRaw,
@@ -552,6 +555,7 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 			SessionID:         captureSessionKey(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
 			SessionIDOriginal: captureSessionKeyOriginal(r.Header.Get("X-Pipelock-Agent"), reverseClientIP(r)),
 			ConfigHash:        cfg.CanonicalPolicyHash(),
+			Agent:             r.Header.Get("X-Pipelock-Agent"),
 			Profile:           edition.ProfileDefault,
 			Request:           capture.CaptureRequest{Method: r.Method, URL: r.URL.String()},
 			TransformKind:     capture.TransformJoinedFields,
@@ -1012,6 +1016,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 			SessionID:         captureSessionKey(resp.Request.Header.Get("X-Pipelock-Agent"), reverseClientIP(resp.Request)),
 			SessionIDOriginal: captureSessionKeyOriginal(resp.Request.Header.Get("X-Pipelock-Agent"), reverseClientIP(resp.Request)),
 			ConfigHash:        cfg.CanonicalPolicyHash(),
+			Agent:             resp.Request.Header.Get("X-Pipelock-Agent"),
 			Profile:           edition.ProfileDefault,
 			Request:           capture.CaptureRequest{Method: resp.Request.Method, URL: resp.Request.URL.String()},
 			TransformKind:     capture.TransformRaw,


### PR DESCRIPTION
## Summary

Stacks four landings on top of the merged capture-pipeline fix.

### Soak observability counters
- `pipelock_capture_dropped_total` and `pipelock_capture_session_id_sanitized_total{reason}`
- `pipelock_learn_capture_records_total` and `pipelock_learn_capture_dropped_total`
- `pipelock_envelope_verify_total{result}`
- All counters use closed-domain label allowlists; non-canonical label values drop at record time so untrusted identity input cannot expand cardinality on a security-relevant counter.
- New `capture.MetricsSink` interface lets the writer publish via dependency injection without importing `internal/metrics` (avoids the import cycle).
- Envelope verify metric mapping is purely structured: replaces an earlier brittle string-match fallback with a wrapped `envelope.VerificationError` carrying `VerificationFailureMissing` on the proxy-side missing-header check.

### Capture transport parity tests
- Forward, reverse, websocket on the proxy side.
- MCP HTTP and MCP stdio on the mcp side.
- Intercept via real TLS handshake through `interceptTunnel` with a `Proxy` plus capture observer attached.
- Each test asserts surface, subsurface, `config_hash`, `profile`, `agent`, `effective_action`, and `outcome` propagate end-to-end.

### Capture pipeline regressions caught and fixed by the new tests
- Reverse proxy capture sites (3 of them) were never stamping `Agent`. Downstream filtering by agent silently broke on reverse traffic. Fix reads `X-Pipelock-Agent` into the record's `Agent` field at all three sites.
- `mcp/proxy_http.go` `scanHTTPInputDecision` emitted `ObserveDLPVerdict` from inside the default warn branch only. `ActionBlock` and `ActionAsk` paths silently dropped the capture record. Fix moves the call to before the action switch so every action path captures.

### --header validation hardening
- `parseHeaderFlags` rejects keys that contain non-RFC 7230 token characters (space, unicode, control chars).
- Rejects values that contain control characters, CRLF (response-split protection), DEL (0x7f), or unicode whitespace (homoglyph hidden chars).
- Reserved transport-managed headers (`Content-Type`, `Accept`, `Mcp-Session-Id`) remain blocked.

### X-Pipelock-Block-Reason production-path matrix
- New static-analysis test enumerates every `Reason` in the canonical allowlist and walks the source AST to confirm each one has at least one production caller outside the `blockreason` package itself.
- Caught two real gaps: `ToolPoisoning` and `ToolChainBlocked` have no production HTTP-header emit site. Both are MCP JSON-RPC layer blocks with no HTTP response surface to attach the header to. Documented as intentional exemptions with rationale on the exemption entry.
- New `blockreason.AllReasons()` exported helper iterates the allowlist (used by the matrix test).

### Capture session-key sanitization constant
- Promoted `maxCaptureSessionKeyLen` (proxy) and `maxSanitizedSessionOriginalLen` (capture) to `capture.MaxSessionKeyLen` as a single source of truth so the proxy-side sanitization decision and the writer-side reverse-engineered reason metric stay in lockstep.

## Behavior

- Every capture transport now has a regression test asserting metadata round-trips end-to-end.
- Every Block-Reason vocabulary entry now has a static guarantee of at least one production emit site or an exemption with documented rationale.
- The new metrics are gated on a configured `MetricsSink`; existing deployments without the wiring see zero behavior change.
- Binary size stays at 22M with release ldflags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session ID sanitization metrics with categorized reasons (unsafe path, overlength, unknown)
  * Introduced envelope verification outcome tracking metrics
  * Added learn and capture record/drop metrics for observability
  * Enhanced HTTP header validation for stricter compliance with control character and whitespace restrictions

* **Bug Fixes**
  * Improved capture metadata recording across proxy transports with agent field inclusion
  * Enhanced nil-safety for metrics operations

* **Tests**
  * Added comprehensive capture metadata transport tests
  * Added envelope verification and learn metrics tests
  * Added production path validation tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->