### PR TITLE
Fix inbound envelope verification for origin-form requests

### DIFF
--- a/docs/guides/detection-integration.md
+++ b/docs/guides/detection-integration.md
@@ -143,13 +143,12 @@ not up for attacker manipulation. The attacker cannot inject text
 into the stream that changes what these fields say. The stream is
 signed and chain-linked, so injection is detectable.
 
-This is the architecture Zack Korman gestures at in his April 2026
-video on AI agent threat detection: a funnel of cheaper LLMs
-filtering events, stronger LLMs confirming, and an agentic layer
-trying to disprove the finding. Whether that funnel works is its
-own question. But if it does, it only works on inputs the attacker
-cannot massage. Structured receipts are that kind of input. Raw
-reasoning tokens are not.
+This is the architecture behind long-window AI agent threat detection:
+a funnel of cheaper LLMs filtering events, stronger LLMs confirming,
+and an agentic layer trying to disprove the finding. Whether that
+funnel works is its own question. But if it does, it only works on
+inputs the attacker cannot massage. Structured receipts are that kind
+of input. Raw reasoning tokens are not.
 
 ## Worked example
 

--- a/internal/envelope/signer.go
+++ b/internal/envelope/signer.go
@@ -442,16 +442,7 @@ func buildComponentValue(req *http.Request, body []byte, comp string) (string, e
 		// RFC 9421 §2.2.1: no case transformation on the method value.
 		return req.Method, nil
 	case derivedTargetURI:
-		if req.URL == nil {
-			return "", errors.New("request has nil URL")
-		}
-		// RFC 9421 §2.2.2: @target-uri is the target URI of the request
-		// excluding any fragment component. Go never sends fragments on
-		// the wire, so a verifier reconstructing from the wire would not
-		// see them. Including fragments would cause verification failure.
-		u := *req.URL
-		u.Fragment = ""
-		return u.String(), nil
+		return targetURIComponent(req)
 	case derivedAuthority:
 		// RFC 9421 §2.2.3: @authority is the on-wire authority the
 		// request is sent to, not the URL's host. When a caller
@@ -493,6 +484,44 @@ func buildComponentValue(req *http.Request, body []byte, comp string) (string, e
 	default:
 		return "", fmt.Errorf("unsupported signed component %q", comp)
 	}
+}
+
+func targetURIComponent(req *http.Request) (string, error) {
+	if req.URL == nil {
+		return "", errors.New("request has nil URL")
+	}
+	// RFC 9421 §2.2.2: @target-uri is the absolute target URI of the
+	// request, excluding any fragment component. Client-side requests
+	// already carry an absolute URL. Server-side handlers usually see
+	// origin-form URLs such as "/" instead, so reconstruct the absolute
+	// target from the request scheme, Host authority, and RequestURI.
+	u := *req.URL
+	u.Fragment = ""
+	if u.Scheme != "" && u.Host != "" {
+		return u.String(), nil
+	}
+
+	scheme := u.Scheme
+	if scheme == "" {
+		scheme = "http"
+		if req.TLS != nil {
+			scheme = "https"
+		}
+	}
+
+	authority := req.Host
+	if authority == "" {
+		authority = u.Host
+	}
+	if authority == "" {
+		return "", errors.New("request has no authority")
+	}
+
+	target := u.RequestURI()
+	if target == "" {
+		target = "/"
+	}
+	return scheme + "://" + authority + target, nil
 }
 
 // mergeSignatureInput adds (or replaces) the pipelock1 member on the

--- a/internal/envelope/verify_test.go
+++ b/internal/envelope/verify_test.go
@@ -6,6 +6,7 @@ package envelope
 import (
 	"bytes"
 	"crypto/ed25519"
+	"crypto/tls"
 	"errors"
 	"io"
 	"net/http"
@@ -32,6 +33,100 @@ func TestVerifier_VerifyRequestAcceptsSignedEnvelope(t *testing.T) {
 	}
 	if env.Actor != "spiffe://example.test/agent/alpha" {
 		t.Fatalf("actor = %q", env.Actor)
+	}
+}
+
+func TestVerifier_VerifyRequestAcceptsServerOriginFormTargetURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		targetURL string
+		tls       bool
+	}{
+		{
+			name:      "http path",
+			targetURL: "http://upstream.example/api",
+		},
+		{
+			name:      "http path and query",
+			targetURL: "http://upstream.example/api?x=1&next=%2Fok",
+		},
+		{
+			name:      "https path",
+			targetURL: "https://upstream.example/api",
+			tls:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pub, priv := testSignerKey(t)
+			now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+			body := strings.Repeat("a", 16)
+			signed := signedVerifierRequestWithURL(t, priv, now, tt.targetURL, body)
+
+			serverReq := newTestRequest(t, signed.Method, signed.URL.RequestURI(), strings.NewReader(body))
+			serverReq.Host = signed.URL.Host
+			serverReq.Header = signed.Header.Clone()
+			if tt.tls {
+				serverReq.TLS = &tls.ConnectionState{}
+			}
+
+			verifier := newTestVerifier(t, pub, now)
+			if _, err := verifier.VerifyRequest(serverReq, []byte(body)); err != nil {
+				t.Fatalf("VerifyRequest with origin-form target URI: %v", err)
+			}
+		})
+	}
+}
+
+func TestVerifier_RejectsOriginFormTargetURIMismatch(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := testSignerKey(t)
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	body := strings.Repeat("a", 16)
+	signed := signedVerifierRequestWithURL(t, priv, now, "https://upstream.example/api", body)
+
+	t.Run("host mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		serverReq := newTestRequest(t, signed.Method, signed.URL.RequestURI(), strings.NewReader(body))
+		serverReq.Host = "attacker.example"
+		serverReq.TLS = &tls.ConnectionState{}
+		serverReq.Header = signed.Header.Clone()
+
+		verifier := newTestVerifier(t, pub, now)
+		if _, err := verifier.VerifyRequest(serverReq, []byte(body)); err == nil {
+			t.Fatal("host mismatch should fail verification")
+		}
+	})
+
+	t.Run("scheme mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		serverReq := newTestRequest(t, signed.Method, signed.URL.RequestURI(), strings.NewReader(body))
+		serverReq.Host = signed.URL.Host
+		serverReq.Header = signed.Header.Clone()
+
+		verifier := newTestVerifier(t, pub, now)
+		if _, err := verifier.VerifyRequest(serverReq, []byte(body)); err == nil {
+			t.Fatal("scheme mismatch should fail verification")
+		}
+	})
+}
+
+func TestTargetURIComponentRequiresAuthorityForOriginForm(t *testing.T) {
+	t.Parallel()
+
+	req := newTestRequest(t, http.MethodGet, "/", nil)
+	req.Host = ""
+	if _, err := targetURIComponent(req); err == nil {
+		t.Fatal("origin-form request without Host should fail")
 	}
 }
 
@@ -750,6 +845,11 @@ func signedLegacyActorRequest(t *testing.T, priv ed25519.PrivateKey, now time.Ti
 
 func signedVerifierRequest(t *testing.T, priv ed25519.PrivateKey, now time.Time, bodyText string) *http.Request {
 	t.Helper()
+	return signedVerifierRequestWithURL(t, priv, now, "https://upstream.example/api", bodyText)
+}
+
+func signedVerifierRequestWithURL(t *testing.T, priv ed25519.PrivateKey, now time.Time, targetURL, bodyText string) *http.Request {
+	t.Helper()
 	var bodyBytes []byte
 	var body *strings.Reader
 	if bodyText != "" {
@@ -773,9 +873,9 @@ func signedVerifierRequest(t *testing.T, priv ed25519.PrivateKey, now time.Time,
 		ActorFormat: ActorFormatSPIFFE,
 		TrustDomain: "example.test",
 	})
-	req := newTestRequest(t, http.MethodPost, "https://upstream.example/api", body)
+	req := newTestRequest(t, http.MethodPost, targetURL, body)
 	if body == nil {
-		req = newTestRequest(t, http.MethodGet, "https://upstream.example/api", nil)
+		req = newTestRequest(t, http.MethodGet, targetURL, nil)
 	}
 	err = em.InjectAndSign(req, bodyBytes, BuildOpts{
 		ActionID:  "01961f3a-7b2c-7000-8000-000000000001",

--- a/internal/envelope/verify_test.go
+++ b/internal/envelope/verify_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -127,6 +128,32 @@ func TestTargetURIComponentRequiresAuthorityForOriginForm(t *testing.T) {
 	req.Host = ""
 	if _, err := targetURIComponent(req); err == nil {
 		t.Fatal("origin-form request without Host should fail")
+	}
+}
+
+func TestTargetURIComponentRejectsNilURL(t *testing.T) {
+	t.Parallel()
+
+	req := newTestRequest(t, http.MethodGet, "https://upstream.example/api", nil)
+	req.URL = nil
+	if _, err := targetURIComponent(req); err == nil {
+		t.Fatal("request with nil URL should fail")
+	}
+}
+
+func TestTargetURIComponentDefaultsEmptyRequestURIToSlash(t *testing.T) {
+	t.Parallel()
+
+	req := newTestRequest(t, http.MethodGet, "https://upstream.example/api", nil)
+	req.URL = &url.URL{}
+	req.Host = "upstream.example"
+
+	target, err := targetURIComponent(req)
+	if err != nil {
+		t.Fatalf("targetURIComponent: %v", err)
+	}
+	if target != "http://upstream.example/" {
+		t.Fatalf("target URI = %q, want %q", target, "http://upstream.example/")
 	}
 }
 

--- a/internal/proxy/health_watchdog_test.go
+++ b/internal/proxy/health_watchdog_test.go
@@ -259,8 +259,6 @@ func TestScannerProbe_NilPointers_ReturnsError(t *testing.T) {
 // degraded. After the fix, concurrent probes during a wedge return an
 // immediate error without launching a second scan goroutine.
 func TestScannerProbe_SingleflightPreventsGoroutineLeak(t *testing.T) {
-	t.Parallel()
-
 	cfg := config.Defaults()
 	cfg.Internal = nil
 	cfg.APIAllowlist = nil


### PR DESCRIPTION
## Summary
- reconstruct `@target-uri` for server-side origin-form requests using scheme, Host, and request URI
- keep absolute client-side request signing behavior unchanged
- add regression coverage for HTTP/HTTPS origin-form verification, query preservation, authority mismatches, scheme mismatches, and missing authority

## Tests
- `go test -race -count=1 ./...`
- `golangci-lint run ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved target URI component generation for request envelopes with clearer logic and better error handling.

* **Tests**
  * Added comprehensive test coverage for target URI verification across HTTP and HTTPS scenarios, ensuring proper handling of host and scheme validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->