### PR TITLE
feat(contract): live-lock foundation: validator, evaluator, loader

### DIFF
--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -461,6 +461,15 @@ func Defaults() *Config {
 			Enabled:         true,
 			IntervalSeconds: 2,
 		},
+		LearnLock: LearnLock{
+			// Default off. The lock runtime is opt-in; if Enabled is
+			// flipped on without the rest of the fields the validator
+			// rejects the config at startup so a half-wired lock can
+			// never silently downgrade to scanner-only.
+			Enabled:           false,
+			Mode:              LockModeShadow, // safe-by-default; live requires explicit opt-in
+			MinimumSignatures: 1,
+		},
 	}
 	// Mark all compiled defaults with provenance so the standard tier source
 	// selector can distinguish them from user-supplied patterns. Set at

--- a/internal/config/learn_lock_test.go
+++ b/internal/config/learn_lock_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaults_LearnLock(t *testing.T) {
+	cfg := Defaults()
+	if cfg.LearnLock.Enabled {
+		t.Errorf("expected LearnLock.Enabled=false, got true")
+	}
+	if cfg.LearnLock.Mode != LockModeShadow {
+		t.Errorf("expected LearnLock.Mode=shadow (safe default), got %q", cfg.LearnLock.Mode)
+	}
+	if cfg.LearnLock.MinimumSignatures != 1 {
+		t.Errorf("expected LearnLock.MinimumSignatures=1, got %d", cfg.LearnLock.MinimumSignatures)
+	}
+}
+
+func TestLearnLock_EffectiveModeFallsBackToShadow(t *testing.T) {
+	cases := map[string]string{
+		"":         LockModeShadow,
+		"unknown":  LockModeShadow,
+		"  live  ": LockModeShadow, // strict match — no whitespace coercion
+		"Live":     LockModeShadow, // strict match — case-sensitive
+		"live":     LockModeLive,
+		"shadow":   LockModeShadow,
+		"capture":  LockModeCapture,
+	}
+	for input, want := range cases {
+		input, want := input, want
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			got := LearnLock{Mode: input}.EffectiveMode()
+			if got != want {
+				t.Fatalf("EffectiveMode(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
+func TestLearnLock_EffectiveMinimumSignaturesDefaultsToOne(t *testing.T) {
+	cases := map[int]int{
+		0:  1,
+		-1: 1,
+		1:  1,
+		2:  2,
+		7:  7,
+	}
+	for input, want := range cases {
+		input, want := input, want
+		t.Run("input", func(t *testing.T) {
+			t.Parallel()
+			got := LearnLock{MinimumSignatures: input}.EffectiveMinimumSignatures()
+			if got != want {
+				t.Fatalf("EffectiveMinimumSignatures(%d) = %d, want %d", input, got, want)
+			}
+		})
+	}
+}
+
+func TestValidate_LearnLockDisabledIgnoresOtherFields(t *testing.T) {
+	// When Enabled is false, no other field is required. This is important
+	// for the v2.3 → v2.4 upgrade path: an existing config without
+	// learn_lock.* fields must still validate cleanly.
+	cfg := Defaults()
+	cfg.LearnLock = LearnLock{Enabled: false}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("disabled lock with empty fields should validate: %v", err)
+	}
+}
+
+func TestValidate_LearnLockEnabledRequiresEveryField(t *testing.T) {
+	t.Parallel()
+	const validFP = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	cases := []struct {
+		name string
+		mut  func(*LearnLock)
+		want string
+	}{
+		{
+			name: "missing store_dir",
+			mut:  func(l *LearnLock) { l.StoreDir = "" },
+			want: "learn_lock.store_dir required",
+		},
+		{
+			name: "relative store_dir rejected",
+			mut:  func(l *LearnLock) { l.StoreDir = "relative/path" },
+			want: "absolute path",
+		},
+		{
+			name: "missing roster_path",
+			mut:  func(l *LearnLock) { l.RosterPath = "" },
+			want: "learn_lock.roster_path required",
+		},
+		{
+			name: "relative roster_path rejected",
+			mut:  func(l *LearnLock) { l.RosterPath = "etc/roster.json" },
+			want: "roster_path must be an absolute path",
+		},
+		{
+			name: "missing environment",
+			mut:  func(l *LearnLock) { l.Environment = "" },
+			want: "learn_lock.environment required",
+		},
+		{
+			name: "missing pinned root fingerprint",
+			mut:  func(l *LearnLock) { l.PinnedRootFingerprint = "" },
+			want: "pinned_root_fingerprint required",
+		},
+		{
+			name: "wrong-length fingerprint",
+			mut:  func(l *LearnLock) { l.PinnedRootFingerprint = "abc" },
+			want: "64 hex characters",
+		},
+		{
+			name: "uppercase fingerprint rejected",
+			mut: func(l *LearnLock) {
+				l.PinnedRootFingerprint = strings.ToUpper(validFP)
+			},
+			want: "lowercase hex",
+		},
+		{
+			name: "non-hex fingerprint rejected",
+			mut: func(l *LearnLock) {
+				// 64 chars but contains 'g'
+				l.PinnedRootFingerprint = "g" + validFP[1:]
+			},
+			want: "lowercase hex",
+		},
+		{
+			name: "unknown mode rejected",
+			mut:  func(l *LearnLock) { l.Mode = "preview" },
+			want: "live/shadow/capture",
+		},
+		{
+			name: "negative minimum_signatures rejected",
+			mut:  func(l *LearnLock) { l.MinimumSignatures = -1 },
+			want: "minimum_signatures must be >= 0",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := Defaults()
+			cfg.LearnLock = LearnLock{
+				Enabled:               true,
+				Mode:                  LockModeShadow,
+				StoreDir:              "/var/lib/pipelock/contracts",
+				RosterPath:            "/etc/pipelock/roster.json",
+				Environment:           "production",
+				PinnedRootFingerprint: validFP,
+				MinimumSignatures:     1,
+			}
+			tc.mut(&cfg.LearnLock)
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("%s: expected error, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("%s: error %q does not contain %q", tc.name, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidate_LearnLockEnabledHappyPath(t *testing.T) {
+	cfg := Defaults()
+	cfg.LearnLock = LearnLock{
+		Enabled:               true,
+		Mode:                  LockModeLive,
+		StoreDir:              "/var/lib/pipelock/contracts",
+		RosterPath:            "/etc/pipelock/roster.json",
+		Environment:           "production",
+		PinnedRootFingerprint: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		MinimumSignatures:     2,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("happy-path lock should validate: %v", err)
+	}
+}
+
+func TestValidate_LearnLockEnabledEmptyModeAccepted(t *testing.T) {
+	// Empty Mode is accepted at validation time and resolves to "shadow"
+	// at runtime via EffectiveMode. This avoids forcing every operator
+	// who wants shadow-default to type "shadow" explicitly.
+	cfg := Defaults()
+	cfg.LearnLock = LearnLock{
+		Enabled:               true,
+		Mode:                  "",
+		StoreDir:              "/var/lib/pipelock/contracts",
+		RosterPath:            "/etc/pipelock/roster.json",
+		Environment:           "production",
+		PinnedRootFingerprint: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("empty Mode at validation time: %v", err)
+	}
+	if cfg.LearnLock.EffectiveMode() != LockModeShadow {
+		t.Fatalf("empty Mode should resolve to shadow, got %q", cfg.LearnLock.EffectiveMode())
+	}
+}

--- a/internal/config/learn_lock_test.go
+++ b/internal/config/learn_lock_test.go
@@ -76,7 +76,7 @@ func TestValidate_LearnLockDisabledIgnoresOtherFields(t *testing.T) {
 
 func TestValidate_LearnLockEnabledRequiresEveryField(t *testing.T) {
 	t.Parallel()
-	const validFP = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	const validFP = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 	cases := []struct {
 		name string
 		mut  func(*LearnLock)
@@ -114,23 +114,30 @@ func TestValidate_LearnLockEnabledRequiresEveryField(t *testing.T) {
 		},
 		{
 			name: "wrong-length fingerprint",
-			mut:  func(l *LearnLock) { l.PinnedRootFingerprint = "abc" },
-			want: "64 hex characters",
+			mut:  func(l *LearnLock) { l.PinnedRootFingerprint = "sha256:abc" },
+			want: "sha256:<64 lowercase hex>",
+		},
+		{
+			name: "missing fingerprint prefix",
+			mut: func(l *LearnLock) {
+				l.PinnedRootFingerprint = strings.TrimPrefix(validFP, "sha256:")
+			},
+			want: "sha256:<64 lowercase hex>",
 		},
 		{
 			name: "uppercase fingerprint rejected",
 			mut: func(l *LearnLock) {
 				l.PinnedRootFingerprint = strings.ToUpper(validFP)
 			},
-			want: "lowercase hex",
+			want: "sha256:<64 lowercase hex>",
 		},
 		{
 			name: "non-hex fingerprint rejected",
 			mut: func(l *LearnLock) {
-				// 64 chars but contains 'g'
-				l.PinnedRootFingerprint = "g" + validFP[1:]
+				// Correct prefix/length but contains 'g'.
+				l.PinnedRootFingerprint = "sha256:g" + strings.TrimPrefix(validFP, "sha256:")[1:]
 			},
-			want: "lowercase hex",
+			want: "sha256:<64 lowercase hex>",
 		},
 		{
 			name: "unknown mode rejected",
@@ -177,7 +184,7 @@ func TestValidate_LearnLockEnabledHappyPath(t *testing.T) {
 		StoreDir:              "/var/lib/pipelock/contracts",
 		RosterPath:            "/etc/pipelock/roster.json",
 		Environment:           "production",
-		PinnedRootFingerprint: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		PinnedRootFingerprint: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 		MinimumSignatures:     2,
 	}
 	if err := cfg.Validate(); err != nil {
@@ -196,7 +203,7 @@ func TestValidate_LearnLockEnabledEmptyModeAccepted(t *testing.T) {
 		StoreDir:              "/var/lib/pipelock/contracts",
 		RosterPath:            "/etc/pipelock/roster.json",
 		Environment:           "production",
-		PinnedRootFingerprint: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		PinnedRootFingerprint: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("empty Mode at validation time: %v", err)

--- a/internal/config/learn_lock_test.go
+++ b/internal/config/learn_lock_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -53,7 +54,7 @@ func TestLearnLock_EffectiveMinimumSignaturesDefaultsToOne(t *testing.T) {
 	}
 	for input, want := range cases {
 		input, want := input, want
-		t.Run("input", func(t *testing.T) {
+		t.Run(strconv.Itoa(input), func(t *testing.T) {
 			t.Parallel()
 			got := LearnLock{MinimumSignatures: input}.EffectiveMinimumSignatures()
 			if got != want {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -250,6 +250,7 @@ type Config struct {
 	MediationEnvelope        MediationEnvelope       `yaml:"mediation_envelope"`
 	Redaction                redact.Config           `yaml:"redaction"`
 	Learn                    Learn                   `yaml:"learn"`
+	LearnLock                LearnLock               `yaml:"learn_lock" json:"-"` // operational lock-runtime config, excluded from canonical policy hash
 	Agents                   map[string]AgentProfile `yaml:"agents,omitempty"`
 	DefaultAgentIdentity     string                  `yaml:"default_agent_identity,omitempty"`      // operator-configured agent name used when no stronger identity source resolves the caller
 	BindDefaultAgentIdentity bool                    `yaml:"bind_default_agent_identity,omitempty"` // when true, ignore self-declared header/query identities and bind requests to default_agent_identity
@@ -1368,4 +1369,92 @@ type LearnInferenceNormalization struct {
 	// requires operator acknowledgement). Strict greater-than: a
 	// tail at exactly the threshold does not block.
 	TailPromotionBlockPct float64 `yaml:"tail_promotion_block_pct"`
+}
+
+// Lock mode constants control whether a promoted contract gates live
+// proxy decisions. Live enforces, shadow only emits decisions/drift,
+// capture never blocks. The default for an enabled lock is "shadow";
+// operators must opt explicitly into "live".
+const (
+	LockModeLive    = "live"
+	LockModeShadow  = "shadow"
+	LockModeCapture = "capture"
+)
+
+// LearnLock governs the runtime that consumes a promoted active manifest
+// and gates proxy decisions on it. The block is operational (excluded
+// from the canonical policy hash) so two deployments that ratify the
+// same contract but enforce in different modes do not produce diverging
+// receipts. Settings are immutable across hot reload — the loader's
+// fsnotify watcher runs against StoreDir, so changes to StoreDir or
+// PinnedRootFingerprint require a process restart.
+//
+// When Enabled is false, the proxy never resolves an active contract
+// and behaves identically to v2.3 (scanner-only). When Enabled is true,
+// every required field below must be set; partial config is rejected at
+// startup so a half-wired lock never silently downgrades to scanner-only.
+type LearnLock struct {
+	// Enabled toggles the lock runtime. Default false. Operators opt in
+	// explicitly, mirroring the cautious-by-default stance for
+	// security-sensitive features that observe agent behaviour.
+	Enabled bool `yaml:"enabled"`
+
+	// Mode controls the gate semantics.
+	//   - "live"    — promoted contract gates proxy decisions
+	//   - "shadow"  — contract evaluates and emits drift but never blocks
+	//   - "capture" — contract path is silent (no signal, no receipts)
+	// Empty Mode falls through to "shadow" so a misconfigured config
+	// fails toward observation, not enforcement. Operators who want
+	// live enforcement must say so.
+	Mode string `yaml:"mode"`
+
+	// StoreDir points at the contract store rooted at active.json + history/.
+	// Required when Enabled is true. Must be an absolute path.
+	StoreDir string `yaml:"store_dir"`
+
+	// RosterPath is the absolute path to the deployment-level roster
+	// JSON file that names which signing keys are authorised for which
+	// purposes. Required when Enabled is true. The roster's root
+	// fingerprint must match PinnedRootFingerprint.
+	RosterPath string `yaml:"roster_path"`
+
+	// Environment binds the lock runtime to a specific deployment
+	// environment string (e.g., "production", "staging"). The store
+	// rejects active manifests whose env field does not match, so a
+	// production cluster cannot accidentally enforce a staging
+	// contract. Required when Enabled is true.
+	Environment string `yaml:"environment"`
+
+	// PinnedRootFingerprint is the hex-encoded sha256 of the trust
+	// roster root key. Active manifests must chain to a roster signed
+	// by this root; mismatch fails-closed at load. Required when
+	// Enabled is true; must be 64 lowercase hex characters.
+	PinnedRootFingerprint string `yaml:"pinned_root_fingerprint"`
+
+	// MinimumSignatures is the minimum number of valid manifest
+	// signatures required for the loader to accept an active.json.
+	// Defaults to 1 when 0 or negative. Higher values require dual
+	// control on promotes.
+	MinimumSignatures int `yaml:"minimum_signatures"`
+}
+
+// EffectiveMode returns Mode resolved through the safety default.
+// Empty/unknown modes resolve to "shadow" so a misconfigured lock
+// observes rather than enforces.
+func (l LearnLock) EffectiveMode() string {
+	switch l.Mode {
+	case LockModeLive, LockModeShadow, LockModeCapture:
+		return l.Mode
+	default:
+		return LockModeShadow
+	}
+}
+
+// EffectiveMinimumSignatures returns MinimumSignatures resolved through
+// the safety default. Zero or negative values resolve to 1.
+func (l LearnLock) EffectiveMinimumSignatures() int {
+	if l.MinimumSignatures <= 0 {
+		return 1
+	}
+	return l.MinimumSignatures
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1425,10 +1425,11 @@ type LearnLock struct {
 	// contract. Required when Enabled is true.
 	Environment string `yaml:"environment"`
 
-	// PinnedRootFingerprint is the hex-encoded sha256 of the trust
-	// roster root key. Active manifests must chain to a roster signed
-	// by this root; mismatch fails-closed at load. Required when
-	// Enabled is true; must be 64 lowercase hex characters.
+	// PinnedRootFingerprint is the canonical sha256 fingerprint of the
+	// trust roster root key: "sha256:" followed by 64 lowercase hex
+	// characters. Active manifests must chain to a roster signed by
+	// this root; mismatch fails-closed at load. Required when Enabled
+	// is true.
 	PinnedRootFingerprint string `yaml:"pinned_root_fingerprint"`
 
 	// MinimumSignatures is the minimum number of valid manifest

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -278,16 +278,13 @@ func validateLockRootFingerprint(fp string) error {
 	if fp == "" {
 		return fmt.Errorf("learn_lock.pinned_root_fingerprint required when learn_lock.enabled is true")
 	}
-	if len(fp) != 64 {
-		return fmt.Errorf("learn_lock.pinned_root_fingerprint must be 64 hex characters (sha256), got %d", len(fp))
+	algorithm, digest, err := signing.ParseFingerprint(fp)
+	if err != nil {
+		return fmt.Errorf("learn_lock.pinned_root_fingerprint must be sha256:<64 lowercase hex>: %w", err)
 	}
-	for _, r := range fp {
-		switch {
-		case r >= '0' && r <= '9':
-		case r >= 'a' && r <= 'f':
-		default:
-			return fmt.Errorf("learn_lock.pinned_root_fingerprint must be lowercase hex sha256, found %q", r)
-		}
+	canonical := algorithm + ":" + digest
+	if fp != canonical {
+		return fmt.Errorf("learn_lock.pinned_root_fingerprint must be lowercase canonical fingerprint %q, got %q", canonical, fp)
 	}
 	return nil
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -222,7 +222,74 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 	if err := c.validateLearn(); err != nil {
 		return warnings, err
 	}
+	if err := c.validateLearnLock(); err != nil {
+		return warnings, err
+	}
 	return warnings, nil
+}
+
+// validateLearnLock enforces the schema for the lock runtime. When
+// learn_lock.enabled is true every other field is required; partial
+// configs are rejected at startup so a half-wired lock cannot silently
+// degrade to scanner-only and leave a customer thinking they are
+// enforcing a contract when they are not.
+func (c *Config) validateLearnLock() error {
+	l := c.LearnLock
+	if !l.Enabled {
+		return nil
+	}
+	if l.StoreDir == "" {
+		return fmt.Errorf("learn_lock.store_dir required when learn_lock.enabled is true")
+	}
+	if !filepath.IsAbs(l.StoreDir) {
+		return fmt.Errorf("learn_lock.store_dir must be an absolute path, got %q", l.StoreDir)
+	}
+	if l.RosterPath == "" {
+		return fmt.Errorf("learn_lock.roster_path required when learn_lock.enabled is true")
+	}
+	if !filepath.IsAbs(l.RosterPath) {
+		return fmt.Errorf("learn_lock.roster_path must be an absolute path, got %q", l.RosterPath)
+	}
+	if l.Environment == "" {
+		return fmt.Errorf("learn_lock.environment required when learn_lock.enabled is true")
+	}
+	if err := validateLockMode(l.Mode); err != nil {
+		return err
+	}
+	if err := validateLockRootFingerprint(l.PinnedRootFingerprint); err != nil {
+		return err
+	}
+	if l.MinimumSignatures < 0 {
+		return fmt.Errorf("learn_lock.minimum_signatures must be >= 0, got %d", l.MinimumSignatures)
+	}
+	return nil
+}
+
+func validateLockMode(mode string) error {
+	switch mode {
+	case "", LockModeLive, LockModeShadow, LockModeCapture:
+		return nil
+	default:
+		return fmt.Errorf("learn_lock.mode must be one of live/shadow/capture, got %q", mode)
+	}
+}
+
+func validateLockRootFingerprint(fp string) error {
+	if fp == "" {
+		return fmt.Errorf("learn_lock.pinned_root_fingerprint required when learn_lock.enabled is true")
+	}
+	if len(fp) != 64 {
+		return fmt.Errorf("learn_lock.pinned_root_fingerprint must be 64 hex characters (sha256), got %d", len(fp))
+	}
+	for _, r := range fp {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		default:
+			return fmt.Errorf("learn_lock.pinned_root_fingerprint must be lowercase hex sha256, found %q", r)
+		}
+	}
+	return nil
 }
 
 // validateRedaction delegates to the redact package's own schema

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -16,6 +16,24 @@ const SchemaVersionContract = 1
 // ContractKind is the only valid contract_kind value for v2.4.
 const ContractKind = "behavioral_contract"
 
+// Rule lifecycle states. The runtime evaluator only honors LifecycleEnforce
+// for live decisions; other states observe or are inert.
+const (
+	LifecycleProposed    = "proposed"
+	LifecycleCaptureOnly = "capture_only"
+	LifecycleEnforce     = "enforce"
+	LifecycleExpired     = "expired"
+	LifecycleDemoted     = "demoted"
+)
+
+// Rule kinds enforceable by the v1 contract runtime. New kinds must land
+// in the runtime evaluator AND in EnforceableRuleKinds() in the same change;
+// otherwise they fail validation in LifecycleEnforce state.
+const (
+	RuleKindHTTPDestination = "http_destination"
+	RuleKindHTTPAction      = "http_action"
+)
+
 // ErrContractSchemaVersion rejects contracts with non-current schema_version.
 var ErrContractSchemaVersion = errors.New("contract: unsupported schema_version")
 
@@ -25,6 +43,30 @@ var ErrContractKind = errors.New("contract: invalid contract_kind")
 // ErrCaptureGrade rejects rules that claim enforcement without sufficient
 // capture-surface evidence.
 var ErrCaptureGrade = errors.New("contract: invalid capture grade")
+
+// ErrUnenforceableRuleKind rejects rules in LifecycleEnforce state whose
+// rule_kind is not in EnforceableRuleKinds(). Rules in non-enforce states
+// (proposed, capture_only, expired, demoted) may carry forward-compatible
+// kinds; only enforced rules are gated.
+var ErrUnenforceableRuleKind = errors.New("contract: rule_kind not enforceable in this schema version")
+
+// EnforceableRuleKinds returns the rule kinds the v1 runtime can evaluate
+// for live enforcement. The validator uses this to gate
+// LifecycleEnforce rules so a contract cannot ship enforced rules the
+// runtime would silently ignore. Add a new kind here only when the
+// matching runtime evaluator branch lands in the same change.
+func EnforceableRuleKinds() []string {
+	return []string{RuleKindHTTPDestination, RuleKindHTTPAction}
+}
+
+func ruleKindEnforceable(kind string) bool {
+	for _, k := range EnforceableRuleKinds() {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
 
 // Capture-grade values describe how much scanner evidence backed a rule.
 const (
@@ -154,6 +196,9 @@ func (c Contract) Validate() error {
 	if !ok {
 		return fmt.Errorf("contract body is not a map after marshal+parse")
 	}
+	if err := validateRuleKinds(c.Rules); err != nil {
+		return err
+	}
 	if err := validateRuleCaptureGrades(c.Rules); err != nil {
 		return err
 	}
@@ -162,6 +207,24 @@ func (c Contract) Validate() error {
 		fcls[k] = v
 	}
 	return ValidateDataClassCoverage(bodyMap, fcls)
+}
+
+func validateRuleKinds(rules []Rule) error {
+	for i, rule := range rules {
+		if rule.LifecycleState != LifecycleEnforce {
+			continue
+		}
+		if !ruleKindEnforceable(rule.RuleKind) {
+			return fmt.Errorf(
+				"%w: rules[%d] kind %q (enforceable: %v)",
+				ErrUnenforceableRuleKind,
+				i,
+				rule.RuleKind,
+				EnforceableRuleKinds(),
+			)
+		}
+	}
+	return nil
 }
 
 func validateRuleCaptureGrades(rules []Rule) error {

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -50,6 +50,14 @@ var ErrCaptureGrade = errors.New("contract: invalid capture grade")
 // kinds; only enforced rules are gated.
 var ErrUnenforceableRuleKind = errors.New("contract: rule_kind not enforceable in this schema version")
 
+// ErrUnsupportedLifecycle rejects rules whose lifecycle_state is not in the
+// enumerated set. Without this gate a typo (e.g. "enforce ", "enabled")
+// silently falls through every state-keyed branch — the rule-kind validator
+// only runs on the literal LifecycleEnforce string, so a poisoned lifecycle
+// can carry a rule that was meant to be enforced and turn it into runtime
+// dead code.
+var ErrUnsupportedLifecycle = errors.New("contract: unsupported lifecycle_state")
+
 // EnforceableRuleKinds returns the rule kinds the v1 runtime can evaluate
 // for live enforcement. The validator uses this to gate
 // LifecycleEnforce rules so a contract cannot ship enforced rules the
@@ -66,6 +74,16 @@ func ruleKindEnforceable(kind string) bool {
 		}
 	}
 	return false
+}
+
+// validLifecycle reports whether state is one of the enumerated values.
+func validLifecycle(state string) bool {
+	switch state {
+	case LifecycleProposed, LifecycleCaptureOnly, LifecycleEnforce, LifecycleExpired, LifecycleDemoted:
+		return true
+	default:
+		return false
+	}
 }
 
 // Capture-grade values describe how much scanner evidence backed a rule.
@@ -196,6 +214,9 @@ func (c Contract) Validate() error {
 	if !ok {
 		return fmt.Errorf("contract body is not a map after marshal+parse")
 	}
+	if err := validateRuleLifecycles(c.Rules); err != nil {
+		return err
+	}
 	if err := validateRuleKinds(c.Rules); err != nil {
 		return err
 	}
@@ -207,6 +228,20 @@ func (c Contract) Validate() error {
 		fcls[k] = v
 	}
 	return ValidateDataClassCoverage(bodyMap, fcls)
+}
+
+func validateRuleLifecycles(rules []Rule) error {
+	for i, rule := range rules {
+		if !validLifecycle(rule.LifecycleState) {
+			return fmt.Errorf(
+				"%w: rules[%d] lifecycle_state %q",
+				ErrUnsupportedLifecycle,
+				i,
+				rule.LifecycleState,
+			)
+		}
+	}
+	return nil
 }
 
 func validateRuleKinds(rules []Rule) error {
@@ -245,7 +280,7 @@ func validateRuleCaptureGrades(rules []Rule) error {
 		if !validCaptureGrade(observed) {
 			return fmt.Errorf("%w: rules[%d] invalid observed_capture_grade %q", ErrCaptureGrade, i, observed)
 		}
-		if rule.LifecycleState == "enforce" && compareCaptureGrade(observed, required) < 0 {
+		if rule.LifecycleState == LifecycleEnforce && compareCaptureGrade(observed, required) < 0 {
 			return fmt.Errorf(
 				"%w: rules[%d] enforce requires %s evidence, observed %s",
 				ErrCaptureGrade,
@@ -259,7 +294,7 @@ func validateRuleCaptureGrades(rules []Rule) error {
 }
 
 func effectiveCaptureGrades(rule Rule) (string, string) {
-	if rule.LifecycleState == "capture_only" && rule.RequiredCaptureGrade == "" && rule.ObservedCaptureGrade == "" {
+	if rule.LifecycleState == LifecycleCaptureOnly && rule.RequiredCaptureGrade == "" && rule.ObservedCaptureGrade == "" {
 		return CaptureGradeFull, CaptureGradeFull
 	}
 	return rule.RequiredCaptureGrade, rule.ObservedCaptureGrade

--- a/internal/contract/contract_test.go
+++ b/internal/contract/contract_test.go
@@ -244,6 +244,78 @@ func TestContract_Validate_RejectsMissingRuleKind(t *testing.T) {
 	}
 }
 
+func TestContract_Validate_RejectsUnknownLifecycleState(t *testing.T) {
+	t.Parallel()
+	// A lifecycle string that isn't in the enumerated set must be rejected at
+	// validation time. Without this, a poisoned or typo'd lifecycle ("enforce ",
+	// "enabled") slips past the rule-kind gate (which only fires when the value
+	// is exactly LifecycleEnforce) and gets silently treated as inert.
+	cases := []string{"enforce ", "Enforce", "enabled", "active", " "}
+	for _, state := range cases {
+		state := state
+		t.Run(state, func(t *testing.T) {
+			t.Parallel()
+			c := Contract{
+				SchemaVersion:    SchemaVersionContract,
+				ContractKind:     ContractKind,
+				DataClassRoot:    string(DataClassInternal),
+				FieldDataClasses: map[string]string{},
+				Rules: []Rule{{
+					RuleID:               "r-1",
+					RuleKind:             RuleKindHTTPDestination,
+					LifecycleState:       state,
+					RequiredCaptureGrade: CaptureGradeFull,
+					ObservedCaptureGrade: CaptureGradeFull,
+					Confidence:           "stable",
+					WilsonLower:          "0.99",
+					Observation:          map[string]any{},
+					Selector:             map[string]any{},
+					Rationale:            map[string]any{},
+					RecurringSupport:     map[string]any{},
+					OpportunityHealth:    map[string]any{},
+				}},
+			}
+			err := c.Validate()
+			if !errors.Is(err, ErrUnsupportedLifecycle) {
+				t.Fatalf("lifecycle %q: got %v, want ErrUnsupportedLifecycle", state, err)
+			}
+		})
+	}
+}
+
+func TestContract_Validate_AcceptsAllEnumeratedLifecycles(t *testing.T) {
+	t.Parallel()
+	for _, state := range []string{LifecycleProposed, LifecycleCaptureOnly, LifecycleEnforce, LifecycleExpired, LifecycleDemoted} {
+		state := state
+		t.Run(state, func(t *testing.T) {
+			t.Parallel()
+			c := Contract{
+				SchemaVersion:    SchemaVersionContract,
+				ContractKind:     ContractKind,
+				DataClassRoot:    string(DataClassInternal),
+				FieldDataClasses: map[string]string{},
+				Rules: []Rule{{
+					RuleID:               "r-1",
+					RuleKind:             RuleKindHTTPDestination,
+					LifecycleState:       state,
+					RequiredCaptureGrade: CaptureGradeFull,
+					ObservedCaptureGrade: CaptureGradeFull,
+					Confidence:           "stable",
+					WilsonLower:          "0.99",
+					Observation:          map[string]any{},
+					Selector:             map[string]any{},
+					Rationale:            map[string]any{},
+					RecurringSupport:     map[string]any{},
+					OpportunityHealth:    map[string]any{},
+				}},
+			}
+			if err := c.Validate(); err != nil {
+				t.Fatalf("lifecycle %q: got %v, want nil", state, err)
+			}
+		})
+	}
+}
+
 func TestContract_Validate_RejectsEnforceWithUnenforceableRuleKind(t *testing.T) {
 	t.Parallel()
 	c := Contract{

--- a/internal/contract/contract_test.go
+++ b/internal/contract/contract_test.go
@@ -123,9 +123,9 @@ func TestContract_Validate_RejectsEnforceWithInsufficientCaptureGrade(t *testing
 		DataClassRoot:    string(DataClassInternal),
 		FieldDataClasses: map[string]string{},
 		Rules: []Rule{{
-			RuleID:               "r-response",
-			RuleKind:             "response_injection",
-			LifecycleState:       "enforce",
+			RuleID:               "r-http-action",
+			RuleKind:             RuleKindHTTPAction,
+			LifecycleState:       LifecycleEnforce,
 			RequiredCaptureGrade: CaptureGradeFull,
 			ObservedCaptureGrade: CaptureGradePartial,
 			Confidence:           "stable",
@@ -241,6 +241,88 @@ func TestContract_Validate_RejectsMissingRuleKind(t *testing.T) {
 	}
 	if err := c.Validate(); !errors.Is(err, ErrCaptureGrade) {
 		t.Errorf("got %v, want ErrCaptureGrade", err)
+	}
+}
+
+func TestContract_Validate_RejectsEnforceWithUnenforceableRuleKind(t *testing.T) {
+	t.Parallel()
+	c := Contract{
+		SchemaVersion:    SchemaVersionContract,
+		ContractKind:     ContractKind,
+		DataClassRoot:    string(DataClassInternal),
+		FieldDataClasses: map[string]string{},
+		Rules: []Rule{{
+			RuleID:               "r-mcp",
+			RuleKind:             "mcp_tool_call",
+			LifecycleState:       LifecycleEnforce,
+			RequiredCaptureGrade: CaptureGradeFull,
+			ObservedCaptureGrade: CaptureGradeFull,
+			Confidence:           "stable",
+			WilsonLower:          "0.99",
+			Observation:          map[string]any{},
+			Selector:             map[string]any{},
+			Rationale:            map[string]any{},
+			RecurringSupport:     map[string]any{},
+			OpportunityHealth:    map[string]any{},
+		}},
+	}
+	err := c.Validate()
+	if !errors.Is(err, ErrUnenforceableRuleKind) {
+		t.Fatalf("got %v, want ErrUnenforceableRuleKind", err)
+	}
+}
+
+func TestContract_Validate_AcceptsCaptureOnlyWithUnenforceableRuleKind(t *testing.T) {
+	t.Parallel()
+	// Forward compat: non-enforce rules can carry kinds the runtime
+	// does not yet evaluate. They are observation-only and never gate
+	// live decisions, so they cannot bypass the floor.
+	c := Contract{
+		SchemaVersion:    SchemaVersionContract,
+		ContractKind:     ContractKind,
+		DataClassRoot:    string(DataClassInternal),
+		FieldDataClasses: map[string]string{},
+		Rules: []Rule{{
+			RuleID:         "r-future",
+			RuleKind:       "mcp_tool_call",
+			LifecycleState: LifecycleCaptureOnly,
+		}},
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("got %v, want nil", err)
+	}
+}
+
+func TestContract_Validate_AcceptsEnforceForEveryEnforceableRuleKind(t *testing.T) {
+	t.Parallel()
+	for _, kind := range EnforceableRuleKinds() {
+		kind := kind
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+			c := Contract{
+				SchemaVersion:    SchemaVersionContract,
+				ContractKind:     ContractKind,
+				DataClassRoot:    string(DataClassInternal),
+				FieldDataClasses: map[string]string{},
+				Rules: []Rule{{
+					RuleID:               "r-" + kind,
+					RuleKind:             kind,
+					LifecycleState:       LifecycleEnforce,
+					RequiredCaptureGrade: CaptureGradeFull,
+					ObservedCaptureGrade: CaptureGradeFull,
+					Confidence:           "stable",
+					WilsonLower:          "0.99",
+					Observation:          map[string]any{},
+					Selector:             map[string]any{},
+					Rationale:            map[string]any{},
+					RecurringSupport:     map[string]any{},
+					OpportunityHealth:    map[string]any{},
+				}},
+			}
+			if err := c.Validate(); err != nil {
+				t.Fatalf("kind %q: got %v, want nil", kind, err)
+			}
+		})
 	}
 }
 

--- a/internal/contract/merkle_test.go
+++ b/internal/contract/merkle_test.go
@@ -36,8 +36,8 @@ func TestMerkleRoot_Single(t *testing.T) {
 func TestMerkleRoot_Deterministic(t *testing.T) {
 	t.Parallel()
 	r := []Rule{
-		{RuleID: "r-1", RuleKind: "http_destination"},
-		{RuleID: "r-2", RuleKind: "mcp_tool"},
+		{RuleID: "r-1", RuleKind: RuleKindHTTPDestination},
+		{RuleID: "r-2", RuleKind: RuleKindHTTPAction},
 	}
 	a, err := MerkleRoot(r)
 	if err != nil {

--- a/internal/contract/runtime/drift.go
+++ b/internal/contract/runtime/drift.go
@@ -67,9 +67,20 @@ type OpportunityMissing struct {
 // three clauses: enough missed windows, observed opportunity, and healthy
 // opportunity telemetry. Opportunity suppression emits opportunity_missing and
 // deliberately does not auto-demote.
+//
+// Mode is required — empty mode is fail-closed input. Without this, an
+// observation that omits Mode silently becomes ModeLive in the emitted
+// DriftEvent, which causes SignalForDrift to fire session.SignalBlock and
+// push adaptive enforcement from a path the operator did not opt into.
 func EvaluateDrift(obs DriftObservation) (DriftResult, error) {
 	if obs.KillSwitchActive {
 		return DriftResult{Suppressed: true}, nil
+	}
+	if obs.Mode == "" {
+		return DriftResult{}, fmt.Errorf("%w: mode required", ErrInvalidDecisionInput)
+	}
+	if !validMode(obs.Mode) {
+		return DriftResult{}, fmt.Errorf("%w: mode %q", ErrInvalidDecisionInput, obs.Mode)
 	}
 	if err := validateLifecycle(obs.Rule.LifecycleState); err != nil {
 		return DriftResult{}, err
@@ -105,7 +116,7 @@ func EvaluateDrift(obs DriftObservation) (DriftResult, error) {
 			ContractHash:       obs.ContractHash,
 			RuleID:             obs.Rule.RuleID,
 			Kind:               DriftKindPositive,
-			Mode:               effectiveMode(obs.Mode),
+			Mode:               obs.Mode,
 			Action:             config.ActionBlock,
 			ObservationSummary: "unexpected observation outside enforced contract",
 			OpportunityStatus:  "healthy",
@@ -125,7 +136,7 @@ func EvaluateDrift(obs DriftObservation) (DriftResult, error) {
 			ContractHash:      obs.ContractHash,
 			RuleID:            obs.Rule.RuleID,
 			Kind:              DriftKindNegative,
-			Mode:              effectiveMode(obs.Mode),
+			Mode:              obs.Mode,
 			MissedWindows:     obs.MissedWindows,
 			OpportunityStatus: "healthy",
 		}
@@ -177,13 +188,6 @@ func observationUint(m map[string]any, key string) uint64 {
 	default:
 		return 0
 	}
-}
-
-func effectiveMode(mode Mode) Mode {
-	if mode == "" {
-		return ModeLive
-	}
-	return mode
 }
 
 // SignalForDrift returns the live adaptive signal implied by a drift event.

--- a/internal/contract/runtime/drift.go
+++ b/internal/contract/runtime/drift.go
@@ -187,8 +187,11 @@ func effectiveMode(mode Mode) Mode {
 }
 
 // SignalForDrift returns the live adaptive signal implied by a drift event.
+// The signal fires only when DriftEvent.Mode is exactly ModeLive — empty mode,
+// ModeShadow, and ModeCapture all return nil so observation paths cannot push
+// adaptive enforcement.
 func SignalForDrift(event DriftEvent) *session.SignalType {
-	if event.Kind == DriftKindPositive && effectiveMode(event.Mode) == ModeLive && event.Action == config.ActionBlock {
+	if event.Mode == ModeLive && event.Kind == DriftKindPositive && event.Action == config.ActionBlock {
 		sig := session.SignalBlock
 		return &sig
 	}

--- a/internal/contract/runtime/loader.go
+++ b/internal/contract/runtime/loader.go
@@ -1,0 +1,235 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/contract/store"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// LoaderOptions configures a Loader. Every field is required when the
+// caller intends the lock runtime to gate decisions; partial inputs are
+// rejected at NewLoader time so a half-wired loader never silently
+// degrades to scanner-only.
+type LoaderOptions struct {
+	// StoreDir is the absolute path to the contract store rooted at
+	// active.json + history/.
+	StoreDir string
+	// RosterPath is the absolute path to the deployment-level roster JSON.
+	RosterPath string
+	// PinnedRootFingerprint is the hex-encoded sha256 of the trust roster
+	// root key. Roster mismatch fails-closed at construction.
+	PinnedRootFingerprint string
+	// Environment binds the loader to a specific deployment environment.
+	// Active manifests whose env field does not match are rejected by
+	// the store on Reload.
+	Environment contract.Environment
+	// MinSignatures is the minimum number of valid manifest signatures
+	// required to accept an active.json. Must be >= 1.
+	MinSignatures int
+	// Mode is the enforcement mode applied by EvaluateHTTP/EvaluateMCP
+	// for callers that pass Loader.Mode() as their EvaluateOptions.Mode.
+	Mode Mode
+	// Now is an optional clock injection point used by store validation
+	// (manifest envelope expiry, journal timestamps). Defaults to
+	// time.Now when nil.
+	Now func() time.Time
+}
+
+// LoaderMetrics is the minimal Prometheus-friendly counter surface a
+// caller can register against the loader. It is an interface so tests
+// can stub it without dragging the prometheus package into this file
+// and so production callers can wire whatever registry they keep.
+type LoaderMetrics interface {
+	// IncReload records the outcome of a single Reload attempt. Outcomes:
+	//   - "accepted"     — new manifest accepted; ActiveSet swapped
+	//   - "same_hash"    — reload returned the same manifest hash; no-op
+	//   - "no_active"    — store has no active.json; Current() stays nil
+	//   - "rejected"     — store rejected the manifest (signature, env,
+	//                      generation downgrade, prior_manifest_hash CAS)
+	//   - "error"        — I/O or other transient error; previous
+	//                      ActiveSet preserved
+	IncReload(outcome string)
+	// SetGeneration records the currently-active manifest generation.
+	// Zero means no active manifest.
+	SetGeneration(generation uint64)
+}
+
+// noopMetrics is the default LoaderMetrics when the caller passes nil.
+type noopMetrics struct{}
+
+func (noopMetrics) IncReload(string)     {}
+func (noopMetrics) SetGeneration(uint64) {}
+
+// Loader watches an active manifest file and serves the latest ActiveSet
+// to the proxy decision path.
+//
+// Initial load is fail-closed: if the roster cannot be loaded or the
+// store rejects the existing active.json, NewLoader returns an error so
+// the caller refuses to start. A store with no active.json is NOT an
+// error — that's the legitimate "lock enabled but nothing promoted yet"
+// state and Current() returns nil for it; the proxy path treats nil as
+// "no contract resolved" and falls through to scanner-only.
+//
+// After construction, subsequent Reload calls (driven by an fsnotify
+// watcher in F3c) are fail-soft: a rejected reload keeps the previous
+// ActiveSet so a botched promote does not blackhole production traffic.
+// Operators see the rejection in the store's journal and via metrics.
+//
+// Loader is safe for concurrent use. Current() reads through
+// atomic.Pointer so the proxy hot path never blocks on Reload.
+type Loader struct {
+	store     store.Store
+	storeOpts store.Options
+	current   atomic.Pointer[ActiveSet]
+	mode      Mode
+	metrics   LoaderMetrics
+	now       func() time.Time
+}
+
+// NewLoader builds a Loader and runs an initial Reload. The metrics
+// argument is optional; nil means no metrics.
+func NewLoader(opts LoaderOptions, metrics LoaderMetrics) (*Loader, error) {
+	if opts.StoreDir == "" {
+		return nil, fmt.Errorf("%w: store_dir required", ErrInvalidDecisionInput)
+	}
+	if opts.RosterPath == "" {
+		return nil, fmt.Errorf("%w: roster_path required", ErrInvalidDecisionInput)
+	}
+	if opts.PinnedRootFingerprint == "" {
+		return nil, fmt.Errorf("%w: pinned_root_fingerprint required", ErrInvalidDecisionInput)
+	}
+	if opts.MinSignatures < 1 {
+		return nil, fmt.Errorf("%w: min_signatures must be >= 1, got %d", ErrInvalidDecisionInput, opts.MinSignatures)
+	}
+	if !validMode(opts.Mode) {
+		return nil, fmt.Errorf("%w: mode %q", ErrInvalidDecisionInput, opts.Mode)
+	}
+	if metrics == nil {
+		metrics = noopMetrics{}
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	roster, err := signing.LoadRoster(opts.RosterPath, opts.PinnedRootFingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("contract runtime: load roster: %w", err)
+	}
+
+	l := &Loader{
+		store:   store.New(opts.StoreDir),
+		mode:    opts.Mode,
+		metrics: metrics,
+		now:     now,
+		storeOpts: store.Options{
+			Environment:   opts.Environment,
+			Roster:        roster,
+			MinSignatures: opts.MinSignatures,
+			Now:           now,
+		},
+	}
+	if err := l.Reload(); err != nil {
+		return nil, fmt.Errorf("contract runtime: initial reload: %w", err)
+	}
+	return l, nil
+}
+
+// Current returns the latest ActiveSet, or nil if no manifest is active.
+// Safe for concurrent use; readers see a consistent snapshot.
+func (l *Loader) Current() *ActiveSet {
+	if l == nil {
+		return nil
+	}
+	return l.current.Load()
+}
+
+// Mode returns the loader's enforcement mode.
+func (l *Loader) Mode() Mode {
+	if l == nil {
+		return ""
+	}
+	return l.mode
+}
+
+// Reload re-reads active.json and swaps the in-memory ActiveSet if the
+// manifest has changed. Same-hash reloads are no-ops. Rejected reloads
+// keep the previous ActiveSet and increment metrics.
+//
+// The store enforces generation monotonicity and prior-manifest-hash CAS
+// internally; this method threads PreviousHash and PreviousGeneration
+// through so a rollback attempt is rejected with ErrGeneration / ErrPriorManifest.
+func (l *Loader) Reload() error {
+	if l == nil {
+		return errors.New("contract runtime: nil loader")
+	}
+	prev := l.current.Load()
+	opts := l.storeOpts
+	if prev != nil {
+		opts.PreviousHash = prev.ManifestHash()
+		opts.PreviousGeneration = prev.Generation()
+	}
+
+	state, err := l.store.Reload(opts)
+	if err != nil {
+		if errors.Is(err, store.ErrNoActiveManifest) {
+			// Store has no active.json — legitimate "nothing promoted"
+			// state. Drop any stale ActiveSet so Current() returns nil.
+			l.current.Store(nil)
+			l.metrics.IncReload("no_active")
+			l.metrics.SetGeneration(0)
+			return nil
+		}
+		l.metrics.IncReload(rejectionOutcome(err))
+		return fmt.Errorf("contract runtime: store reload: %w", err)
+	}
+
+	// Same-hash short circuit: store accepted the same manifest we already
+	// have in memory. No swap, no metric outcome change beyond a counter
+	// bump on the same_hash bucket.
+	if prev != nil && state.ManifestHash == prev.ManifestHash() {
+		l.metrics.IncReload("same_hash")
+		return nil
+	}
+
+	next, err := NewActiveSet(state)
+	if err != nil {
+		l.metrics.IncReload("rejected")
+		return fmt.Errorf("contract runtime: build active set: %w", err)
+	}
+	l.current.Store(next)
+	l.metrics.IncReload("accepted")
+	l.metrics.SetGeneration(next.Generation())
+	return nil
+}
+
+// rejectionOutcome maps a store reload error to a metrics-friendly
+// outcome label. Validation errors collapse to "rejected"; transient
+// I/O collapses to "error" so an operator can distinguish a botched
+// promote from a flaky disk.
+func rejectionOutcome(err error) string {
+	switch {
+	case errors.Is(err, store.ErrStructural),
+		errors.Is(err, store.ErrSignature),
+		errors.Is(err, store.ErrContractSignature),
+		errors.Is(err, store.ErrDualControl),
+		errors.Is(err, store.ErrEnvironmentMismatch),
+		errors.Is(err, store.ErrGeneration),
+		errors.Is(err, store.ErrPriorManifest),
+		errors.Is(err, store.ErrContractHistory):
+		return "rejected"
+	case errors.Is(err, store.ErrDecode),
+		errors.Is(err, store.ErrWriteOnceConflict):
+		return "error"
+	default:
+		return "error"
+	}
+}

--- a/internal/contract/runtime/loader.go
+++ b/internal/contract/runtime/loader.go
@@ -6,6 +6,8 @@ package runtime
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 
@@ -25,11 +27,13 @@ type LoaderOptions struct {
 	// RosterPath is the absolute path to the deployment-level roster JSON.
 	RosterPath string
 	// PinnedRootFingerprint is the hex-encoded sha256 of the trust roster
-	// root key. Roster mismatch fails-closed at construction.
+	// root key: "sha256:" followed by 64 lowercase hex characters. Roster
+	// mismatch fails-closed at construction.
 	PinnedRootFingerprint string
 	// Environment binds the loader to a specific deployment environment.
 	// Active manifests whose env field does not match are rejected by
-	// the store on Reload.
+	// the store on Reload. A zero environment is rejected so callers cannot
+	// accidentally disable the store's environment pin.
 	Environment contract.Environment
 	// MinSignatures is the minimum number of valid manifest signatures
 	// required to accept an active.json. Must be >= 1.
@@ -87,6 +91,7 @@ func (noopMetrics) SetGeneration(uint64) {}
 // atomic.Pointer so the proxy hot path never blocks on Reload.
 type Loader struct {
 	store     store.Store
+	storeDir  string
 	storeOpts store.Options
 	current   atomic.Pointer[ActiveSet]
 	mode      Mode
@@ -105,6 +110,9 @@ func NewLoader(opts LoaderOptions, metrics LoaderMetrics) (*Loader, error) {
 	}
 	if opts.PinnedRootFingerprint == "" {
 		return nil, fmt.Errorf("%w: pinned_root_fingerprint required", ErrInvalidDecisionInput)
+	}
+	if opts.Environment == (contract.Environment{}) {
+		return nil, fmt.Errorf("%w: environment required", ErrInvalidDecisionInput)
 	}
 	if opts.MinSignatures < 1 {
 		return nil, fmt.Errorf("%w: min_signatures must be >= 1, got %d", ErrInvalidDecisionInput, opts.MinSignatures)
@@ -126,10 +134,11 @@ func NewLoader(opts LoaderOptions, metrics LoaderMetrics) (*Loader, error) {
 	}
 
 	l := &Loader{
-		store:   store.New(opts.StoreDir),
-		mode:    opts.Mode,
-		metrics: metrics,
-		now:     now,
+		store:    store.New(opts.StoreDir),
+		storeDir: filepath.Clean(opts.StoreDir),
+		mode:     opts.Mode,
+		metrics:  metrics,
+		now:      now,
 		storeOpts: store.Options{
 			Environment:   opts.Environment,
 			Roster:        roster,
@@ -174,6 +183,11 @@ func (l *Loader) Reload() error {
 	prev := l.current.Load()
 	opts := l.storeOpts
 	if prev != nil {
+		activeState, err := l.validateActiveReadOnly()
+		if err == nil && activeState.ManifestHash == prev.ManifestHash() {
+			l.metrics.IncReload("same_hash")
+			return nil
+		}
 		opts.PreviousHash = prev.ManifestHash()
 		opts.PreviousGeneration = prev.Generation()
 	}
@@ -181,8 +195,12 @@ func (l *Loader) Reload() error {
 	state, err := l.store.Reload(opts)
 	if err != nil {
 		if errors.Is(err, store.ErrNoActiveManifest) {
+			if prev != nil {
+				l.metrics.IncReload("rejected")
+				return fmt.Errorf("contract runtime: active manifest disappeared after generation %d: %w", prev.Generation(), err)
+			}
 			// Store has no active.json — legitimate "nothing promoted"
-			// state. Drop any stale ActiveSet so Current() returns nil.
+			// state during initial/never-active startup. Current() stays nil.
 			l.current.Store(nil)
 			l.metrics.IncReload("no_active")
 			l.metrics.SetGeneration(0)
@@ -192,9 +210,10 @@ func (l *Loader) Reload() error {
 		return fmt.Errorf("contract runtime: store reload: %w", err)
 	}
 
-	// Same-hash short circuit: store accepted the same manifest we already
-	// have in memory. No swap, no metric outcome change beyond a counter
-	// bump on the same_hash bucket.
+	// Same-hash short circuit for first accepted reload after an empty
+	// loader. Once prev is non-nil, store.Reload rejects an unchanged
+	// generation before returning state because generation monotonicity is
+	// part of the active-manifest CAS contract.
 	if prev != nil && state.ManifestHash == prev.ManifestHash() {
 		l.metrics.IncReload("same_hash")
 		return nil
@@ -232,4 +251,20 @@ func rejectionOutcome(err error) string {
 	default:
 		return "error"
 	}
+}
+
+func (l *Loader) validateActiveReadOnly() (store.State, error) {
+	activePath := filepath.Clean(filepath.Join(l.storeDir, "active.json"))
+	raw, err := os.ReadFile(activePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return store.State{}, fmt.Errorf("%w: %w", store.ErrNoActiveManifest, err)
+		}
+		return store.State{}, fmt.Errorf("%w: read active manifest: %w", store.ErrDecode, err)
+	}
+	opts := l.storeOpts
+	opts.PreviousHash = ""
+	opts.PreviousGeneration = 0
+	opts.ReadOnly = true
+	return l.store.ValidateEnvelope(raw, opts)
 }

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -15,12 +15,14 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/contract"
+	contractstore "github.com/luckyPipewrench/pipelock/internal/contract/store"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 func TestNewLoader_RejectsMissingFields(t *testing.T) {
 	t.Parallel()
-	const validFP = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	const validFP = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	validEnv := testLoaderEnv()
 	cases := []struct {
 		name string
 		opts LoaderOptions
@@ -28,32 +30,37 @@ func TestNewLoader_RejectsMissingFields(t *testing.T) {
 	}{
 		{
 			name: "missing store_dir",
-			opts: LoaderOptions{RosterPath: "/tmp/r.json", PinnedRootFingerprint: validFP, MinSignatures: 1, Mode: ModeShadow},
+			opts: LoaderOptions{RosterPath: "/tmp/r.json", PinnedRootFingerprint: validFP, Environment: validEnv, MinSignatures: 1, Mode: ModeShadow},
 			want: "store_dir required",
 		},
 		{
 			name: "missing roster_path",
-			opts: LoaderOptions{StoreDir: "/tmp/s", PinnedRootFingerprint: validFP, MinSignatures: 1, Mode: ModeShadow},
+			opts: LoaderOptions{StoreDir: "/tmp/s", PinnedRootFingerprint: validFP, Environment: validEnv, MinSignatures: 1, Mode: ModeShadow},
 			want: "roster_path required",
 		},
 		{
 			name: "missing fingerprint",
-			opts: LoaderOptions{StoreDir: "/tmp/s", RosterPath: "/tmp/r.json", MinSignatures: 1, Mode: ModeShadow},
+			opts: LoaderOptions{StoreDir: "/tmp/s", RosterPath: "/tmp/r.json", Environment: validEnv, MinSignatures: 1, Mode: ModeShadow},
 			want: "pinned_root_fingerprint required",
 		},
 		{
+			name: "missing environment",
+			opts: LoaderOptions{StoreDir: "/tmp/s", RosterPath: "/tmp/r.json", PinnedRootFingerprint: validFP, MinSignatures: 1, Mode: ModeShadow},
+			want: "environment required",
+		},
+		{
 			name: "zero min_signatures",
-			opts: LoaderOptions{StoreDir: "/tmp/s", RosterPath: "/tmp/r.json", PinnedRootFingerprint: validFP, MinSignatures: 0, Mode: ModeShadow},
+			opts: LoaderOptions{StoreDir: "/tmp/s", RosterPath: "/tmp/r.json", PinnedRootFingerprint: validFP, Environment: validEnv, MinSignatures: 0, Mode: ModeShadow},
 			want: "min_signatures must be >= 1",
 		},
 		{
 			name: "empty mode",
-			opts: LoaderOptions{StoreDir: "/tmp/s", RosterPath: "/tmp/r.json", PinnedRootFingerprint: validFP, MinSignatures: 1},
+			opts: LoaderOptions{StoreDir: "/tmp/s", RosterPath: "/tmp/r.json", PinnedRootFingerprint: validFP, Environment: validEnv, MinSignatures: 1},
 			want: "mode",
 		},
 		{
 			name: "unknown mode",
-			opts: LoaderOptions{StoreDir: "/tmp/s", RosterPath: "/tmp/r.json", PinnedRootFingerprint: validFP, MinSignatures: 1, Mode: Mode("preview")},
+			opts: LoaderOptions{StoreDir: "/tmp/s", RosterPath: "/tmp/r.json", PinnedRootFingerprint: validFP, Environment: validEnv, MinSignatures: 1, Mode: Mode("preview")},
 			want: "mode",
 		},
 	}
@@ -81,7 +88,8 @@ func TestNewLoader_RejectsMissingRosterFile(t *testing.T) {
 	_, err := NewLoader(LoaderOptions{
 		StoreDir:              filepath.Join(dir, "store"),
 		RosterPath:            filepath.Join(dir, "does-not-exist.json"),
-		PinnedRootFingerprint: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		PinnedRootFingerprint: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		Environment:           testLoaderEnv(),
 		MinSignatures:         1,
 		Mode:                  ModeShadow,
 	}, nil)
@@ -106,6 +114,7 @@ func TestNewLoader_NoActiveManifest_ReturnsNilCurrent(t *testing.T) {
 		StoreDir:              storeDir,
 		RosterPath:            fixture.rosterPath,
 		PinnedRootFingerprint: fixture.rootFingerprint,
+		Environment:           testLoaderEnv(),
 		MinSignatures:         1,
 		Mode:                  ModeShadow,
 		Now:                   func() time.Time { return time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) },
@@ -128,6 +137,116 @@ func TestNewLoader_NoActiveManifest_ReturnsNilCurrent(t *testing.T) {
 	}
 }
 
+func TestLoader_ReloadAcceptsSameHashWithoutError(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", testLoaderEnv())
+
+	metrics := &captureMetrics{}
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, testLoaderEnv()), metrics)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	current := loader.Current()
+	if current == nil {
+		t.Fatal("Current() = nil, want active set")
+	}
+
+	if err := loader.Reload(); err != nil {
+		t.Fatalf("Reload same hash: %v", err)
+	}
+	if loader.Current() != current {
+		t.Fatal("same-hash reload should preserve active set pointer")
+	}
+	if metrics.outcomes["same_hash"] != 1 {
+		t.Fatalf("same_hash metrics = %v, want one same_hash", metrics.outcomes)
+	}
+}
+
+func TestLoader_ReloadRejectsMissingActiveAfterCurrent(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", testLoaderEnv())
+
+	metrics := &captureMetrics{}
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, testLoaderEnv()), metrics)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	current := loader.Current()
+	if current == nil {
+		t.Fatal("Current() = nil, want active set")
+	}
+	if err := os.Remove(filepath.Join(storeDir, "active.json")); err != nil {
+		t.Fatalf("remove active.json: %v", err)
+	}
+
+	if err := loader.Reload(); err == nil {
+		t.Fatal("Reload after active.json deletion returned nil error")
+	}
+	if loader.Current() != current {
+		t.Fatal("missing active.json after a current manifest must preserve previous active set")
+	}
+	if metrics.outcomes["rejected"] != 1 {
+		t.Fatalf("metrics = %v, want one rejected outcome", metrics.outcomes)
+	}
+}
+
+func TestLoader_ReloadRejectsEnvironmentMismatchAndKeepsCurrent(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	env := testLoaderEnv()
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
+
+	metrics := &captureMetrics{}
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, env), metrics)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	current := loader.Current()
+	otherEnv := contract.Environment{ID: "staging", Tenant: env.Tenant, DeploymentID: env.DeploymentID}
+	writeSignedActiveStore(t, fixture, storeDir, 2, current.ManifestHash(), otherEnv)
+
+	if err := loader.Reload(); err == nil {
+		t.Fatal("Reload environment mismatch returned nil error")
+	}
+	if loader.Current() != current {
+		t.Fatal("environment mismatch must preserve previous active set")
+	}
+	if metrics.outcomes["rejected"] != 1 {
+		t.Fatalf("metrics = %v, want one rejected outcome", metrics.outcomes)
+	}
+}
+
+func TestLoader_ReloadRejectsGenerationDowngradeAndKeepsCurrent(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	env := testLoaderEnv()
+	writeSignedActiveStore(t, fixture, storeDir, 2, "sha256:genesis", env)
+
+	metrics := &captureMetrics{}
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, env), metrics)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	current := loader.Current()
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:older", env)
+
+	if err := loader.Reload(); err == nil {
+		t.Fatal("Reload generation downgrade returned nil error")
+	}
+	if loader.Current() != current {
+		t.Fatal("generation downgrade must preserve previous active set")
+	}
+	if metrics.outcomes["rejected"] != 1 {
+		t.Fatalf("metrics = %v, want one rejected outcome", metrics.outcomes)
+	}
+}
+
 // rosterFixture is the minimum fixture the Loader needs at construction
 // time: a real Ed25519 root key, a real activation-signing key, and a
 // roster file on disk that signing.LoadRoster can verify. Tests that
@@ -140,6 +259,8 @@ type rosterFixture struct {
 	rootPriv        ed25519.PrivateKey
 	activationPub   ed25519.PublicKey
 	activationPriv  ed25519.PrivateKey
+	compilePub      ed25519.PublicKey
+	compilePriv     ed25519.PrivateKey
 }
 
 func newRosterFixture(t *testing.T) rosterFixture {
@@ -164,6 +285,14 @@ func newRosterFixture(t *testing.T) rosterFixture {
 	if err != nil {
 		t.Fatalf("load activation priv: %v", err)
 	}
+	compilePub, err := ks.GenerateAgent("compile-primary")
+	if err != nil {
+		t.Fatalf("generate compile: %v", err)
+	}
+	compilePriv, err := ks.LoadPrivateKey("compile-primary")
+	if err != nil {
+		t.Fatalf("load compile priv: %v", err)
+	}
 
 	rootFingerprint, err := signing.Fingerprint(rootPub)
 	if err != nil {
@@ -177,6 +306,7 @@ func newRosterFixture(t *testing.T) rosterFixture {
 		Keys: []contract.KeyInfo{
 			rosterKey("roster-root", signing.PurposeRosterRoot, rootPub, contract.KeyStatusRoot, "root"),
 			rosterKey("activation-primary", signing.PurposeContractActivationSigning, activationPub, contract.KeyStatusActive, "operator"),
+			rosterKey("compile-primary", signing.PurposeContractCompileSigning, compilePub, contract.KeyStatusActive, "compiler"),
 		},
 	}
 	preimage, err := body.SignablePreimage()
@@ -206,6 +336,124 @@ func newRosterFixture(t *testing.T) rosterFixture {
 		rootPriv:        rootPriv,
 		activationPub:   activationPub,
 		activationPriv:  activationPriv,
+		compilePub:      compilePub,
+		compilePriv:     compilePriv,
+	}
+}
+
+func loaderOptions(fixture rosterFixture, storeDir string, env contract.Environment) LoaderOptions {
+	return LoaderOptions{
+		StoreDir:              storeDir,
+		RosterPath:            fixture.rosterPath,
+		PinnedRootFingerprint: fixture.rootFingerprint,
+		Environment:           env,
+		MinSignatures:         1,
+		Mode:                  ModeShadow,
+		Now:                   func() time.Time { return time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) },
+	}
+}
+
+func testLoaderEnv() contract.Environment {
+	return contract.Environment{ID: "prod", Tenant: "tenant-a", DeploymentID: "deploy-a"}
+}
+
+func writeSignedActiveStore(t *testing.T, fixture rosterFixture, storeDir string, generation uint64, prior string, env contract.Environment) {
+	t.Helper()
+	st := contractstore.New(storeDir)
+	contractHash := putSignedLoaderContract(t, st, fixture)
+	active := signedLoaderManifest(t, contractHash, generation, prior, env, fixture)
+	raw, err := json.Marshal(active)
+	if err != nil {
+		t.Fatalf("marshal active manifest: %v", err)
+	}
+	if err := os.MkdirAll(storeDir, 0o750); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(storeDir, "active.json"), append(raw, '\n'), 0o600); err != nil {
+		t.Fatalf("write active.json: %v", err)
+	}
+}
+
+func putSignedLoaderContract(t *testing.T, st contractstore.Store, fixture rosterFixture) string {
+	t.Helper()
+	body := contract.Contract{
+		SchemaVersion:    contract.SchemaVersionContract,
+		ContractKind:     contract.ContractKind,
+		SignerKeyID:      "compile-primary",
+		KeyPurpose:       signing.PurposeContractCompileSigning.String(),
+		DataClassRoot:    string(contract.DataClassInternal),
+		FieldDataClasses: map[string]string{},
+		Selector:         contract.Selector{Agent: "agent-a", SelectorID: "sha256:selector"},
+	}
+	hash, err := contractstore.ContractHash(body)
+	if err != nil {
+		t.Fatalf("contract hash: %v", err)
+	}
+	body.ContractHash = hash
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("contract preimage: %v", err)
+	}
+	env := contract.ContractEnvelope{
+		Body:      body,
+		Signature: "ed25519:" + hex.EncodeToString(ed25519.Sign(fixture.compilePriv, preimage)),
+	}
+	raw, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal contract: %v", err)
+	}
+	loadedRoster, err := signing.LoadRoster(fixture.rosterPath, fixture.rootFingerprint)
+	if err != nil {
+		t.Fatalf("load roster: %v", err)
+	}
+	if got, err := st.PutHistoryContract(raw, contractstore.Options{
+		Roster:        loadedRoster,
+		MinSignatures: 1,
+		Now:           func() time.Time { return time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) },
+	}); err != nil {
+		t.Fatalf("PutHistoryContract: %v", err)
+	} else if got != hash {
+		t.Fatalf("PutHistoryContract hash = %q, want %q", got, hash)
+	}
+	return hash
+}
+
+func signedLoaderManifest(t *testing.T, contractHash string, generation uint64, prior string, env contract.Environment, fixture rosterFixture) contract.ActiveManifestEnvelope {
+	t.Helper()
+	selector := contract.ManifestSelector{Agent: "agent-a", ContractHash: contractHash}
+	selectorID, err := selector.ComputeSelectorID()
+	if err != nil {
+		t.Fatalf("ComputeSelectorID: %v", err)
+	}
+	selector.SelectorID = selectorID
+	selectorSetHash, err := contract.ComputeSelectorSetHash([]contract.ManifestSelector{selector})
+	if err != nil {
+		t.Fatalf("ComputeSelectorSetHash: %v", err)
+	}
+	body := contract.ActiveManifest{
+		SchemaVersion:     1,
+		ManifestKind:      contract.ManifestKindActivation,
+		Generation:        generation,
+		PriorManifestHash: prior,
+		SelectorSetHash:   selectorSetHash,
+		Environment:       env,
+		Selectors:         []contract.ManifestSelector{selector},
+		HistoryRoot:       "contracts/history/",
+		SignedAt:          time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	}
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("manifest preimage: %v", err)
+	}
+	return contract.ActiveManifestEnvelope{
+		Body: body,
+		Signatures: []contract.ManifestSignature{{
+			KeyID:      "activation-primary",
+			Principal:  "operator",
+			KeyPurpose: signing.PurposeContractActivationSigning.String(),
+			Algorithm:  "ed25519",
+			Signature:  "ed25519:" + hex.EncodeToString(ed25519.Sign(fixture.activationPriv, preimage)),
+		}},
 	}
 }
 

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestNewLoader_RejectsMissingFields(t *testing.T) {
+	t.Parallel()
+	const validFP = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	cases := []struct {
+		name string
+		opts LoaderOptions
+		want string
+	}{
+		{
+			name: "missing store_dir",
+			opts: LoaderOptions{RosterPath: "/tmp/r.json", PinnedRootFingerprint: validFP, MinSignatures: 1, Mode: ModeShadow},
+			want: "store_dir required",
+		},
+		{
+			name: "missing roster_path",
+			opts: LoaderOptions{StoreDir: "/tmp/s", PinnedRootFingerprint: validFP, MinSignatures: 1, Mode: ModeShadow},
+			want: "roster_path required",
+		},
+		{
+			name: "missing fingerprint",
+			opts: LoaderOptions{StoreDir: "/tmp/s", RosterPath: "/tmp/r.json", MinSignatures: 1, Mode: ModeShadow},
+			want: "pinned_root_fingerprint required",
+		},
+		{
+			name: "zero min_signatures",
+			opts: LoaderOptions{StoreDir: "/tmp/s", RosterPath: "/tmp/r.json", PinnedRootFingerprint: validFP, MinSignatures: 0, Mode: ModeShadow},
+			want: "min_signatures must be >= 1",
+		},
+		{
+			name: "empty mode",
+			opts: LoaderOptions{StoreDir: "/tmp/s", RosterPath: "/tmp/r.json", PinnedRootFingerprint: validFP, MinSignatures: 1},
+			want: "mode",
+		},
+		{
+			name: "unknown mode",
+			opts: LoaderOptions{StoreDir: "/tmp/s", RosterPath: "/tmp/r.json", PinnedRootFingerprint: validFP, MinSignatures: 1, Mode: Mode("preview")},
+			want: "mode",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewLoader(tc.opts, nil)
+			if err == nil {
+				t.Fatalf("%s: expected error, got nil", tc.name)
+			}
+			if !errors.Is(err, ErrInvalidDecisionInput) {
+				t.Fatalf("%s: err = %v, want ErrInvalidDecisionInput", tc.name, err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("%s: err = %q, want to contain %q", tc.name, err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestNewLoader_RejectsMissingRosterFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, err := NewLoader(LoaderOptions{
+		StoreDir:              filepath.Join(dir, "store"),
+		RosterPath:            filepath.Join(dir, "does-not-exist.json"),
+		PinnedRootFingerprint: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		MinSignatures:         1,
+		Mode:                  ModeShadow,
+	}, nil)
+	if err == nil {
+		t.Fatal("missing roster file: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "load roster") {
+		t.Fatalf("err = %v, want load roster wrap", err)
+	}
+}
+
+func TestNewLoader_NoActiveManifest_ReturnsNilCurrent(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	if err := os.MkdirAll(storeDir, 0o750); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+
+	metrics := &captureMetrics{}
+	loader, err := NewLoader(LoaderOptions{
+		StoreDir:              storeDir,
+		RosterPath:            fixture.rosterPath,
+		PinnedRootFingerprint: fixture.rootFingerprint,
+		MinSignatures:         1,
+		Mode:                  ModeShadow,
+		Now:                   func() time.Time { return time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) },
+	}, metrics)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+
+	if loader.Current() != nil {
+		t.Fatalf("Current() = %v, want nil for empty store", loader.Current())
+	}
+	if loader.Mode() != ModeShadow {
+		t.Fatalf("Mode() = %q, want shadow", loader.Mode())
+	}
+	if metrics.outcomes["no_active"] != 1 {
+		t.Fatalf("expected one no_active reload outcome, got %v", metrics.outcomes)
+	}
+	if metrics.lastGeneration != 0 {
+		t.Fatalf("expected generation 0 for empty store, got %d", metrics.lastGeneration)
+	}
+}
+
+// rosterFixture is the minimum fixture the Loader needs at construction
+// time: a real Ed25519 root key, a real activation-signing key, and a
+// roster file on disk that signing.LoadRoster can verify. Tests that
+// build a real signed active.json reuse this fixture and add the
+// manifest-side scaffolding on top in F3c.
+type rosterFixture struct {
+	root            string
+	rosterPath      string
+	rootFingerprint string
+	rootPriv        ed25519.PrivateKey
+	activationPub   ed25519.PublicKey
+	activationPriv  ed25519.PrivateKey
+}
+
+func newRosterFixture(t *testing.T) rosterFixture {
+	t.Helper()
+	root := t.TempDir()
+	keystoreDir := filepath.Join(root, "keys")
+	ks := signing.NewKeystore(keystoreDir)
+
+	rootPub, err := ks.GenerateAgent("roster-root")
+	if err != nil {
+		t.Fatalf("generate root: %v", err)
+	}
+	rootPriv, err := ks.LoadPrivateKey("roster-root")
+	if err != nil {
+		t.Fatalf("load root priv: %v", err)
+	}
+	activationPub, err := ks.GenerateAgent("activation-primary")
+	if err != nil {
+		t.Fatalf("generate activation: %v", err)
+	}
+	activationPriv, err := ks.LoadPrivateKey("activation-primary")
+	if err != nil {
+		t.Fatalf("load activation priv: %v", err)
+	}
+
+	rootFingerprint, err := signing.Fingerprint(rootPub)
+	if err != nil {
+		t.Fatalf("Fingerprint: %v", err)
+	}
+
+	body := contract.KeyRoster{
+		SchemaVersion:  1,
+		RosterSignedBy: "roster-root",
+		DataClassRoot:  string(contract.DataClassInternal),
+		Keys: []contract.KeyInfo{
+			rosterKey("roster-root", signing.PurposeRosterRoot, rootPub, contract.KeyStatusRoot, "root"),
+			rosterKey("activation-primary", signing.PurposeContractActivationSigning, activationPub, contract.KeyStatusActive, "operator"),
+		},
+	}
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("roster preimage: %v", err)
+	}
+	envelope := contract.RosterEnvelope{
+		Body:      body,
+		Signature: "ed25519:" + hex.EncodeToString(ed25519.Sign(rootPriv, preimage)),
+	}
+	rosterPath := filepath.Join(root, "roster.json")
+	rosterBytes, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal roster: %v", err)
+	}
+	if err := os.WriteFile(rosterPath, append(rosterBytes, '\n'), 0o600); err != nil {
+		t.Fatalf("write roster: %v", err)
+	}
+	if _, err := signing.LoadRoster(rosterPath, rootFingerprint); err != nil {
+		t.Fatalf("verify roster fixture: %v", err)
+	}
+
+	return rosterFixture{
+		root:            root,
+		rosterPath:      rosterPath,
+		rootFingerprint: rootFingerprint,
+		rootPriv:        rootPriv,
+		activationPub:   activationPub,
+		activationPriv:  activationPriv,
+	}
+}
+
+func rosterKey(keyID string, purpose signing.KeyPurpose, pub ed25519.PublicKey, status, principal string) contract.KeyInfo {
+	return contract.KeyInfo{
+		KeyID:        keyID,
+		KeyPurpose:   purpose.String(),
+		PublicKeyHex: hex.EncodeToString(pub),
+		ValidFrom:    time.Date(2026, 4, 29, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		Status:       status,
+		Principal:    principal,
+	}
+}
+
+// captureMetrics records LoaderMetrics calls for assertion in tests.
+type captureMetrics struct {
+	outcomes       map[string]int
+	lastGeneration uint64
+}
+
+func (m *captureMetrics) IncReload(outcome string) {
+	if m.outcomes == nil {
+		m.outcomes = map[string]int{}
+	}
+	m.outcomes[outcome]++
+}
+
+func (m *captureMetrics) SetGeneration(generation uint64) {
+	m.lastGeneration = generation
+}

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -247,6 +247,48 @@ func TestLoader_ReloadRejectsGenerationDowngradeAndKeepsCurrent(t *testing.T) {
 	}
 }
 
+func TestLoader_NilReceiverAccessorsAreSafe(t *testing.T) {
+	t.Parallel()
+	// Defensive guard: a misconfigured caller that passes nil through to
+	// Current() or Mode() must not panic. The proxy hot path calls these
+	// on every request, and a nil-deref there would blackhole traffic.
+	var l *Loader
+	if got := l.Current(); got != nil {
+		t.Fatalf("nil-loader Current() = %v, want nil", got)
+	}
+	if got := l.Mode(); got != "" {
+		t.Fatalf("nil-loader Mode() = %q, want empty", got)
+	}
+	if err := l.Reload(); err == nil {
+		t.Fatal("nil-loader Reload() returned nil error")
+	}
+}
+
+func TestLoader_NilMetricsExercisesNoopImpl(t *testing.T) {
+	t.Parallel()
+	// Constructing a Loader with metrics=nil must wire the noopMetrics
+	// implementation so all reload-outcome and generation calls land on
+	// real method receivers. Coverage proves no panic and no nil-deref
+	// from production code paths that assume metrics is always set.
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	if err := os.MkdirAll(storeDir, 0o750); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, testLoaderEnv()), nil)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	if loader.Current() != nil {
+		t.Fatalf("Current() = %v, want nil for empty store", loader.Current())
+	}
+	// Reload again to confirm noopMetrics handles a same-no-active path
+	// without surfacing an error.
+	if err := loader.Reload(); err != nil {
+		t.Fatalf("Reload with nil metrics: %v", err)
+	}
+}
+
 // rosterFixture is the minimum fixture the Loader needs at construction
 // time: a real Ed25519 root key, a real activation-signing key, and a
 // roster file on disk that signing.LoadRoster can verify. Tests that

--- a/internal/contract/runtime/runtime.go
+++ b/internal/contract/runtime/runtime.go
@@ -267,8 +267,20 @@ type EvaluateOptions struct {
 }
 
 // Decision is the contract-aware verdict metadata for a request.
+//
+// Verdict is what the proxy MUST act on for this request — block or allow.
+// LiveVerdict is what live mode WOULD have done given the same inputs:
+// in ModeLive these are equal; in ModeShadow / ModeCapture, Verdict
+// reflects the scanner-floor result (so the proxy never blocks more than
+// scanner already would) while LiveVerdict surfaces the contract's
+// would-have-been verdict for drift signalling and audit.
+//
+// WinningSource names the source that decided Verdict (kill_switch,
+// scanner, contract). Drift carries the contract-attributed event when
+// the contract path produced a non-allow verdict in any mode.
 type Decision struct {
 	Verdict       string
+	LiveVerdict   string
 	PolicySources []string
 	WinningSource string
 	RuleID        string
@@ -278,34 +290,116 @@ type Decision struct {
 	Reason        string
 }
 
-// EvaluateHTTP evaluates active HTTP destination/action rules. It implements
-// host-scoped deny-default: only hosts with comparable enforce rules can be
-// denied by contract default.
+// EvaluateHTTP returns the runtime verdict for an HTTP request under the
+// active learn-and-lock contract. The decision sequence is:
+//
+//  1. Mode is required and must enumerate. Empty Mode is fail-closed input.
+//  2. Kill switch active → block in every mode (absolute floor).
+//  3. Scanner block → block in every mode (security floor; contract may not
+//     resurrect a scanner-blocked request, including a signed allow rule).
+//  4. No resolved contract → return the scanner verdict.
+//  5. Contract resolved → evaluate enforce rules:
+//     - Allow rule matches → contract annotates the (already-allowed)
+//     scanner verdict; WinningSource = contract.
+//     - Contract has zero enforce rules anywhere → fall through to
+//     scanner (observation-only contract; no jurisdiction).
+//     - Otherwise → contract default-deny (the contract claims
+//     jurisdiction once any rule is in enforce; traffic outside the
+//     enumerated allow set is denied).
+//  6. Mode gate. ModeLive enforces the contract verdict directly.
+//     ModeShadow / ModeCapture surface the scanner verdict as Verdict
+//     (so the proxy never blocks more than scanner already would) while
+//     LiveVerdict carries what live mode would have done, plus the drift
+//     event for observation pipelines.
+//
+// The proxy MUST act on Decision.Verdict. LiveVerdict and Drift are
+// audit/telemetry surface; using them for enforcement breaks the mode
+// guarantee.
 func EvaluateHTTP(opts EvaluateOptions) (Decision, error) {
+	if opts.Mode == "" {
+		return Decision{}, fmt.Errorf("%w: mode required", ErrInvalidDecisionInput)
+	}
+	if !validMode(opts.Mode) {
+		return Decision{}, fmt.Errorf("%w: mode %q", ErrInvalidDecisionInput, opts.Mode)
+	}
+
 	sources := normalizePolicySources(opts.PolicySources)
 	if opts.ScannerMatched || opts.ScannerVerdict != "" {
 		sources = appendPolicySource(sources, PolicySourceScanner)
 	}
+
+	// 1. Kill switch is the absolute floor. Block in every mode.
 	if opts.KillSwitchActive {
 		sources = appendPolicySource(sources, PolicySourceKillSwitch)
 		return Decision{
 			Verdict:       config.ActionBlock,
+			LiveVerdict:   config.ActionBlock,
 			PolicySources: sources,
 			WinningSource: WinningSourceKillSwitch,
 			Suppressed:    true,
 			Reason:        "kill_switch_active",
 		}, nil
 	}
-	if opts.Resolved == nil {
-		return scannerDecision(opts.ScannerVerdict, sources), nil
+
+	// Resolve scanner verdict (fail-closed if scanner did not decide).
+	scannerVerdict := opts.ScannerVerdict
+	scannerMissing := scannerVerdict == ""
+	if scannerMissing {
+		scannerVerdict = config.ActionBlock
 	}
+
+	// 2. Scanner block is the security floor. Wins in every mode, including
+	// over a signed contract-allow rule. Without this, a contract becomes a
+	// signed bypass of DLP / SSRF / blocklist.
+	if scannerVerdict == config.ActionBlock {
+		sources = appendPolicySource(sources, PolicySourceScanner)
+		decision := Decision{
+			Verdict:       config.ActionBlock,
+			LiveVerdict:   config.ActionBlock,
+			PolicySources: sources,
+			WinningSource: WinningSourceScanner,
+		}
+		if scannerMissing {
+			decision.Reason = "scanner_decision_missing"
+		}
+		return decision, nil
+	}
+
+	// 3. No resolved contract → scanner verdict stands.
+	if opts.Resolved == nil {
+		return Decision{
+			Verdict:       scannerVerdict,
+			LiveVerdict:   scannerVerdict,
+			PolicySources: sources,
+			WinningSource: WinningSourceScanner,
+		}, nil
+	}
+
 	sources = appendPolicySource(sources, PolicySourceContract)
+
+	// 4 + 5. Compute the live verdict from the contract.
+	live, err := evaluateContractLive(opts, sources, scannerVerdict)
+	if err != nil {
+		return Decision{}, err
+	}
+
+	// 6. Mode gate.
+	return applyModeGate(live, opts.Mode, scannerVerdict, sources), nil
+}
+
+// evaluateContractLive returns what live mode would do for opts given a
+// resolved contract, after kill-switch and scanner-block have been ruled out.
+// Scanner verdict at this point is non-block; it is passed in so a contract
+// allow can correctly annotate the scanner verdict instead of asserting an
+// allow that scanner did not approve.
+func evaluateContractLive(opts EvaluateOptions, sources []string, scannerVerdict string) (Decision, error) {
 	u, err := url.Parse(opts.Request.URL)
 	if err != nil || u.Hostname() == "" {
 		return Decision{}, fmt.Errorf("%w: url", ErrInvalidDecisionInput)
 	}
 
 	hostHasEnforceRule := false
+	contractHasEnforceRule := false
 	hasComparableEvidence := false
 	hostRuleIDs := make([]string, 0)
 	seenRuleIDs := map[string]struct{}{}
@@ -319,6 +413,7 @@ func EvaluateHTTP(opts EvaluateOptions) (Decision, error) {
 		if rule.LifecycleState != LifecycleEnforce {
 			continue
 		}
+		contractHasEnforceRule = true
 		if !ruleHostMatches(rule, u.Hostname()) {
 			continue
 		}
@@ -336,35 +431,73 @@ func EvaluateHTTP(opts EvaluateOptions) (Decision, error) {
 		}
 		hasComparableEvidence = true
 		if matches {
+			// Contract allow annotates the scanner-allowed verdict.
+			// Scanner block has already been resolved upstream and
+			// cannot reach this point, so it is impossible for an
+			// allow rule to override a scanner block here.
 			return Decision{
-				Verdict:       config.ActionAllow,
+				Verdict:       scannerVerdict,
+				LiveVerdict:   scannerVerdict,
 				PolicySources: sources,
 				WinningSource: WinningSourceContract,
 				RuleID:        rule.RuleID,
 			}, nil
 		}
 	}
-	if hostHasEnforceRule && hasComparableEvidence {
-		return contractBlockDecision(opts, sources, firstString(hostRuleIDs), "contract_enforce_default"), nil
+
+	// No allow rule matched.
+	if !contractHasEnforceRule {
+		// Contract is observation-only (zero enforce rules anywhere). It
+		// claims no jurisdiction; scanner verdict stands.
+		return Decision{
+			Verdict:       scannerVerdict,
+			LiveVerdict:   scannerVerdict,
+			PolicySources: sources,
+			WinningSource: WinningSourceScanner,
+		}, nil
 	}
-	return scannerDecision(opts.ScannerVerdict, sources), nil
+
+	reason := "contract_default_deny"
+	ruleID := ""
+	if hostHasEnforceRule && hasComparableEvidence {
+		reason = "contract_enforce_default"
+		ruleID = firstString(hostRuleIDs)
+	}
+	return contractBlockDecision(opts, sources, ruleID, reason), nil
 }
 
-func scannerDecision(scannerVerdict string, sources []string) Decision {
-	missing := scannerVerdict == ""
-	if scannerVerdict == "" {
-		scannerVerdict = config.ActionBlock
+// applyModeGate adapts a live-mode decision to the configured mode.
+// ModeLive returns it unchanged. ModeShadow and ModeCapture surface the
+// scanner verdict as the enforced Verdict (so the proxy never blocks more
+// than scanner already would) and carry the live verdict + drift event
+// for telemetry. SignalForDrift gates the adaptive signal on
+// DriftEvent.Mode == ModeLive directly, so shadow/capture never emit
+// the live block signal even when Drift is populated.
+func applyModeGate(live Decision, mode Mode, scannerVerdict string, sources []string) Decision {
+	if mode == ModeLive {
+		return live
 	}
-	sources = appendPolicySource(sources, PolicySourceScanner)
-	decision := Decision{
+	out := Decision{
 		Verdict:       scannerVerdict,
+		LiveVerdict:   live.Verdict,
 		PolicySources: sources,
 		WinningSource: WinningSourceScanner,
+		RuleID:        live.RuleID,
+		Drift:         live.Drift,
 	}
-	if missing {
-		decision.Reason = "scanner_decision_missing"
+	if live.WinningSource == WinningSourceContract {
+		out.Reason = "contract_observed_only"
 	}
-	return decision
+	return out
+}
+
+func validMode(mode Mode) bool {
+	switch mode {
+	case ModeLive, ModeShadow, ModeCapture:
+		return true
+	default:
+		return false
+	}
 }
 
 func contractBlockDecision(opts EvaluateOptions, sources []string, ruleID, reason string) Decision {
@@ -372,11 +505,12 @@ func contractBlockDecision(opts EvaluateOptions, sources []string, ruleID, reaso
 		ContractHash: opts.Resolved.ContractHash,
 		RuleID:       ruleID,
 		Kind:         DriftKindPositive,
-		Mode:         effectiveMode(opts.Mode),
+		Mode:         opts.Mode,
 		Action:       config.ActionBlock,
 	}
 	decision := Decision{
 		Verdict:       config.ActionBlock,
+		LiveVerdict:   config.ActionBlock,
 		PolicySources: sources,
 		WinningSource: WinningSourceContract,
 		RuleID:        ruleID,

--- a/internal/contract/runtime/runtime.go
+++ b/internal/contract/runtime/runtime.go
@@ -70,8 +70,10 @@ var (
 	// ErrNoResolvedContract is returned when a caller asks for evaluation
 	// without an active contract pin.
 	ErrNoResolvedContract = errors.New("contract runtime: no resolved contract")
-	// ErrUnsupportedLifecycle is returned for non-enumerated rule states.
-	ErrUnsupportedLifecycle = errors.New("contract runtime: unsupported lifecycle state")
+	// ErrUnsupportedLifecycle aliases the contract package's lifecycle
+	// error so a single sentinel works for validation-time and
+	// evaluation-time rejection.
+	ErrUnsupportedLifecycle = contract.ErrUnsupportedLifecycle
 	// ErrInvalidDecisionInput is returned for malformed request/evaluation input.
 	ErrInvalidDecisionInput = errors.New("contract runtime: invalid decision input")
 	// ErrInvalidSelector is returned when an active-set selector cannot be used safely.

--- a/internal/contract/runtime/runtime.go
+++ b/internal/contract/runtime/runtime.go
@@ -22,17 +22,15 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/session"
 )
 
+// Lifecycle constants alias the canonical schema-package values so the
+// runtime and the contract validator share one source of truth. Adding
+// a new lifecycle state must happen in the contract package.
 const (
-	// LifecycleProposed means the rule is visible to operators but not active.
-	LifecycleProposed = "proposed"
-	// LifecycleCaptureOnly records telemetry without changing live enforcement.
-	LifecycleCaptureOnly = "capture_only"
-	// LifecycleEnforce allows the rule to affect live decisions.
-	LifecycleEnforce = "enforce"
-	// LifecycleExpired marks a rule as no longer active.
-	LifecycleExpired = "expired"
-	// LifecycleDemoted marks a rule removed from enforcement by drift handling.
-	LifecycleDemoted = "demoted"
+	LifecycleProposed    = contract.LifecycleProposed
+	LifecycleCaptureOnly = contract.LifecycleCaptureOnly
+	LifecycleEnforce     = contract.LifecycleEnforce
+	LifecycleExpired     = contract.LifecycleExpired
+	LifecycleDemoted     = contract.LifecycleDemoted
 )
 
 const (
@@ -55,9 +53,14 @@ const (
 	WinningSourceKillSwitch = PolicySourceKillSwitch
 )
 
+// Rule-kind aliases keep the runtime in lock-step with the validator's
+// EnforceableRuleKinds() registry. Adding a new kind requires updating
+// both the contract package's enforceable list AND the runtime evaluator
+// dispatch in the same change; otherwise validation rejects enforced
+// rules of that kind.
 const (
-	ruleKindHTTPDestination = "http_destination"
-	ruleKindHTTPAction      = "http_action"
+	ruleKindHTTPDestination = contract.RuleKindHTTPDestination
+	ruleKindHTTPAction      = contract.RuleKindHTTPAction
 
 	DriftKindPositive = "positive"
 	DriftKindNegative = "negative"

--- a/internal/contract/runtime/runtime_test.go
+++ b/internal/contract/runtime/runtime_test.go
@@ -273,8 +273,44 @@ func TestEvaluateHTTP_ContractAllowAndDenyDefault(t *testing.T) {
 	}
 }
 
-func TestEvaluateHTTP_HostScopedDenyDefaultFallsBackToScanner(t *testing.T) {
-	resolved := resolvedContractWithRules(enforceRule("r-chat", "blocked.example.com", "/v1/chat", "POST"))
+func TestEvaluateHTTP_DefaultDenyOnceContractHasEnforceRule(t *testing.T) {
+	// A contract with at least one enforce rule claims jurisdiction. Traffic
+	// to a host the contract does not enumerate is denied by default in live
+	// mode — without this the "lock" is just per-host policy refinement and
+	// any new domain (including exfil) falls through to the scanner.
+	resolved := resolvedContractWithRules(enforceRule("r-chat", "chat.example.com", "/v1/chat", "POST"))
+
+	decision, err := EvaluateHTTP(EvaluateOptions{
+		Resolved:       &resolved,
+		Request:        HTTPRequest{URL: "https://other.example.com/v1/chat", Method: "POST"},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP default-deny: %v", err)
+	}
+	if decision.Verdict != config.ActionBlock || decision.WinningSource != WinningSourceContract {
+		t.Fatalf("decision = %+v, want contract default-deny block", decision)
+	}
+	if decision.Reason != "contract_default_deny" {
+		t.Fatalf("reason = %q, want contract_default_deny", decision.Reason)
+	}
+	if decision.LiveVerdict != config.ActionBlock {
+		t.Fatalf("live_verdict = %q, want block", decision.LiveVerdict)
+	}
+	if decision.Drift == nil || decision.Drift.Kind != DriftKindPositive {
+		t.Fatalf("drift = %+v, want positive", decision.Drift)
+	}
+}
+
+func TestEvaluateHTTP_ObservationOnlyContractFallsThroughToScanner(t *testing.T) {
+	// A contract with zero enforce rules anywhere is observation-only and
+	// claims no jurisdiction. Traffic falls through to the scanner verdict
+	// regardless of host. This lets operators promote a fresh contract
+	// without immediately locking out every request.
+	rule := enforceRule("r-chat", "api.example.com", "/v1/chat", "POST")
+	rule.LifecycleState = LifecycleProposed
+	resolved := resolvedContractWithRules(rule)
 
 	decision, err := EvaluateHTTP(EvaluateOptions{
 		Resolved:       &resolved,
@@ -283,7 +319,7 @@ func TestEvaluateHTTP_HostScopedDenyDefaultFallsBackToScanner(t *testing.T) {
 		ScannerVerdict: config.ActionWarn,
 	})
 	if err != nil {
-		t.Fatalf("EvaluateHTTP: %v", err)
+		t.Fatalf("EvaluateHTTP observation-only: %v", err)
 	}
 	if decision.Verdict != config.ActionWarn || decision.WinningSource != WinningSourceScanner {
 		t.Fatalf("decision = %+v, want scanner fallback", decision)
@@ -291,7 +327,7 @@ func TestEvaluateHTTP_HostScopedDenyDefaultFallsBackToScanner(t *testing.T) {
 }
 
 func TestEvaluateHTTP_ScannerFallbacksAndErrors(t *testing.T) {
-	decision, err := EvaluateHTTP(EvaluateOptions{})
+	decision, err := EvaluateHTTP(EvaluateOptions{Mode: ModeLive})
 	if err != nil {
 		t.Fatalf("EvaluateHTTP nil resolved: %v", err)
 	}
@@ -302,7 +338,10 @@ func TestEvaluateHTTP_ScannerFallbacksAndErrors(t *testing.T) {
 	if !contains(decision.PolicySources, PolicySourceScanner) {
 		t.Fatalf("policy_sources = %v, want scanner", decision.PolicySources)
 	}
-	decision, err = EvaluateHTTP(EvaluateOptions{ScannerVerdict: config.ActionAllow})
+	decision, err = EvaluateHTTP(EvaluateOptions{
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
 	if err != nil {
 		t.Fatalf("EvaluateHTTP explicit scanner allow: %v", err)
 	}
@@ -312,8 +351,10 @@ func TestEvaluateHTTP_ScannerFallbacksAndErrors(t *testing.T) {
 
 	resolved := resolvedContractWithRules(enforceRule("r1", "api.example.com", "/v1/chat", "POST"))
 	if _, err := EvaluateHTTP(EvaluateOptions{
-		Resolved: &resolved,
-		Request:  HTTPRequest{URL: "://bad"},
+		Mode:           ModeLive,
+		Resolved:       &resolved,
+		Request:        HTTPRequest{URL: "://bad"},
+		ScannerVerdict: config.ActionAllow,
 	}); !errors.Is(err, ErrInvalidDecisionInput) {
 		t.Fatalf("invalid URL err = %v", err)
 	}
@@ -322,10 +363,103 @@ func TestEvaluateHTTP_ScannerFallbacksAndErrors(t *testing.T) {
 	badLifecycle.LifecycleState = "surprise"
 	resolved = resolvedContractWithRules(badLifecycle)
 	if _, err := EvaluateHTTP(EvaluateOptions{
-		Resolved: &resolved,
-		Request:  HTTPRequest{URL: "https://api.example.com/v1/chat", Method: "POST"},
+		Mode:           ModeLive,
+		Resolved:       &resolved,
+		Request:        HTTPRequest{URL: "https://api.example.com/v1/chat", Method: "POST"},
+		ScannerVerdict: config.ActionAllow,
 	}); !errors.Is(err, ErrUnsupportedLifecycle) {
 		t.Fatalf("lifecycle err = %v", err)
+	}
+}
+
+func TestEvaluateHTTP_RejectsEmptyAndUnknownMode(t *testing.T) {
+	if _, err := EvaluateHTTP(EvaluateOptions{ScannerVerdict: config.ActionAllow}); !errors.Is(err, ErrInvalidDecisionInput) {
+		t.Fatalf("empty mode err = %v, want ErrInvalidDecisionInput", err)
+	}
+	if _, err := EvaluateHTTP(EvaluateOptions{
+		Mode:           Mode("preview"),
+		ScannerVerdict: config.ActionAllow,
+	}); !errors.Is(err, ErrInvalidDecisionInput) {
+		t.Fatalf("unknown mode err = %v, want ErrInvalidDecisionInput", err)
+	}
+}
+
+func TestEvaluateHTTP_ScannerBlockBeatsContractAllow(t *testing.T) {
+	// The scanner-floor invariant: a signed contract that allows
+	// https://api.example.com/v1/chat must NOT resurrect a request the
+	// scanner blocked (DLP / SSRF / blocklist all flow through scanner).
+	// Without this, the contract becomes a signed bypass.
+	resolved := resolvedContractWithRules(enforceRule("r-chat", "api.example.com", "/v1/chat", "POST"))
+
+	decision, err := EvaluateHTTP(EvaluateOptions{
+		Mode:           ModeLive,
+		Resolved:       &resolved,
+		Request:        HTTPRequest{URL: "https://api.example.com/v1/chat", Method: "POST"},
+		ScannerVerdict: config.ActionBlock,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP scanner-block-floor: %v", err)
+	}
+	if decision.Verdict != config.ActionBlock || decision.LiveVerdict != config.ActionBlock {
+		t.Fatalf("verdict = %q live = %q, want both block", decision.Verdict, decision.LiveVerdict)
+	}
+	if decision.WinningSource != WinningSourceScanner {
+		t.Fatalf("winning_source = %q, want scanner (floor)", decision.WinningSource)
+	}
+	if decision.Drift != nil {
+		t.Fatalf("drift should not fire when scanner is the winning source: %+v", decision.Drift)
+	}
+}
+
+func TestEvaluateHTTP_ShadowModeObservesContractBlockButLetsScannerVerdictStand(t *testing.T) {
+	resolved := resolvedContractWithRules(enforceRule("r-chat", "api.example.com", "/v1/chat", "POST"))
+
+	decision, err := EvaluateHTTP(EvaluateOptions{
+		Mode:           ModeShadow,
+		Resolved:       &resolved,
+		Request:        HTTPRequest{URL: "https://other.example.com/v1/chat", Method: "POST"},
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP shadow: %v", err)
+	}
+	if decision.Verdict != config.ActionAllow {
+		t.Fatalf("verdict = %q, want scanner allow (shadow does not enforce)", decision.Verdict)
+	}
+	if decision.LiveVerdict != config.ActionBlock {
+		t.Fatalf("live_verdict = %q, want block (live mode would have denied)", decision.LiveVerdict)
+	}
+	if decision.WinningSource != WinningSourceScanner {
+		t.Fatalf("winning_source = %q, want scanner (shadow mode never lets contract decide Verdict)", decision.WinningSource)
+	}
+	if decision.Drift == nil || decision.Drift.Mode != ModeShadow {
+		t.Fatalf("drift = %+v, want shadow-mode positive drift", decision.Drift)
+	}
+	if decision.Signal != nil {
+		t.Fatalf("signal must not fire in shadow mode: %v", decision.Signal)
+	}
+}
+
+func TestEvaluateHTTP_CaptureModeNeverBlocksFromContract(t *testing.T) {
+	resolved := resolvedContractWithRules(enforceRule("r-chat", "api.example.com", "/v1/chat", "POST"))
+
+	decision, err := EvaluateHTTP(EvaluateOptions{
+		Mode:           ModeCapture,
+		Resolved:       &resolved,
+		Request:        HTTPRequest{URL: "https://other.example.com/v1/chat", Method: "POST"},
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP capture: %v", err)
+	}
+	if decision.Verdict != config.ActionAllow {
+		t.Fatalf("verdict = %q, want scanner allow (capture never blocks)", decision.Verdict)
+	}
+	if decision.LiveVerdict != config.ActionBlock {
+		t.Fatalf("live_verdict = %q, want block (live would have denied)", decision.LiveVerdict)
+	}
+	if decision.Signal != nil {
+		t.Fatalf("signal must not fire in capture mode: %v", decision.Signal)
 	}
 }
 
@@ -334,7 +468,9 @@ func TestEvaluateHTTP_SelectorConstraintBranches(t *testing.T) {
 	actionRule.Selector["effective_action"] = "delegate"
 	resolved := resolvedContractWithRules(actionRule)
 	allowed, err := EvaluateHTTP(EvaluateOptions{
-		Resolved: &resolved,
+		Mode:           ModeLive,
+		Resolved:       &resolved,
+		ScannerVerdict: config.ActionAllow,
 		Request: HTTPRequest{
 			URL:             "https://api.example.com/v1/chat",
 			Method:          "POST",
@@ -349,7 +485,9 @@ func TestEvaluateHTTP_SelectorConstraintBranches(t *testing.T) {
 	}
 
 	denied, err := EvaluateHTTP(EvaluateOptions{
-		Resolved: &resolved,
+		Mode:           ModeLive,
+		Resolved:       &resolved,
+		ScannerVerdict: config.ActionAllow,
 		Request: HTTPRequest{
 			URL:             "https://api.example.com/v1/chat",
 			Method:          "POST",
@@ -366,6 +504,7 @@ func TestEvaluateHTTP_SelectorConstraintBranches(t *testing.T) {
 	badPathRule := enforceRule("r-badpath", "api.example.com", "/v1/chat", "POST")
 	resolved = resolvedContractWithRules(badPathRule)
 	blocked, err := EvaluateHTTP(EvaluateOptions{
+		Mode:           ModeLive,
 		Resolved:       &resolved,
 		Request:        HTTPRequest{URL: "https://api.example.com/v1%2Fchat", Method: "POST"},
 		ScannerVerdict: config.ActionWarn,

--- a/internal/contract/runtime/runtime_test.go
+++ b/internal/contract/runtime/runtime_test.go
@@ -581,6 +581,33 @@ func TestEvaluateDrift_NegativeRequiresThreeClausesAndIsAdaptiveNeutral(t *testi
 	}
 }
 
+func TestEvaluateDrift_RejectsEmptyAndUnknownMode(t *testing.T) {
+	// An observation without an explicit mode previously fell through
+	// effectiveMode("") → ModeLive, which then caused SignalForDrift to
+	// emit session.SignalBlock and push adaptive enforcement. Empty mode
+	// must now fail-closed so the caller is forced to be explicit.
+	_, err := EvaluateDrift(DriftObservation{
+		Rule:               enforceRule("r1", "api.example.com", "/v1/chat", "POST"),
+		ContractHash:       testContractHash,
+		OpportunityHealthy: true,
+		UnexpectedObserved: true,
+	})
+	if !errors.Is(err, ErrInvalidDecisionInput) {
+		t.Fatalf("empty mode err = %v, want ErrInvalidDecisionInput", err)
+	}
+
+	_, err = EvaluateDrift(DriftObservation{
+		Rule:               enforceRule("r1", "api.example.com", "/v1/chat", "POST"),
+		ContractHash:       testContractHash,
+		Mode:               Mode("preview"),
+		OpportunityHealthy: true,
+		UnexpectedObserved: true,
+	})
+	if !errors.Is(err, ErrInvalidDecisionInput) {
+		t.Fatalf("unknown mode err = %v, want ErrInvalidDecisionInput", err)
+	}
+}
+
 func TestEvaluateDrift_PositiveSignalOnlyInLiveMode(t *testing.T) {
 	live, err := EvaluateDrift(DriftObservation{
 		Rule:               enforceRule("r1", "api.example.com", "/v1/chat", "POST"),
@@ -627,17 +654,19 @@ func TestEvaluateDrift_SuppressedInvalidAndInactiveBranches(t *testing.T) {
 	_, err = EvaluateDrift(DriftObservation{
 		Rule:         contract.Rule{RuleID: "r1", LifecycleState: "bad"},
 		ContractHash: testContractHash,
+		Mode:         ModeLive,
 	})
 	if !errors.Is(err, ErrUnsupportedLifecycle) {
 		t.Fatalf("bad lifecycle err = %v", err)
 	}
-	_, err = EvaluateDrift(DriftObservation{Rule: captureRule("r1")})
+	_, err = EvaluateDrift(DriftObservation{Rule: captureRule("r1"), Mode: ModeLive})
 	if !errors.Is(err, ErrInvalidDecisionInput) {
 		t.Fatalf("missing contract hash err = %v", err)
 	}
 	_, err = EvaluateDrift(DriftObservation{
 		Rule:         contract.Rule{LifecycleState: LifecycleCaptureOnly},
 		ContractHash: testContractHash,
+		Mode:         ModeLive,
 	})
 	if !errors.Is(err, ErrInvalidDecisionInput) {
 		t.Fatalf("missing rule id err = %v", err)
@@ -647,6 +676,7 @@ func TestEvaluateDrift_SuppressedInvalidAndInactiveBranches(t *testing.T) {
 		result, err := EvaluateDrift(DriftObservation{
 			Rule:         contract.Rule{RuleID: "r1", LifecycleState: state},
 			ContractHash: testContractHash,
+			Mode:         ModeLive,
 		})
 		if err != nil {
 			t.Fatalf("EvaluateDrift %s: %v", state, err)
@@ -663,6 +693,7 @@ func TestEvaluateDrift_UsesRuleWindowFloor(t *testing.T) {
 	tooEarly, err := EvaluateDrift(DriftObservation{
 		Rule:                rule,
 		ContractHash:        testContractHash,
+		Mode:                ModeLive,
 		OpportunityHealthy:  true,
 		OpportunityObserved: true,
 		MissedWindows:       3,
@@ -676,6 +707,7 @@ func TestEvaluateDrift_UsesRuleWindowFloor(t *testing.T) {
 	fired, err := EvaluateDrift(DriftObservation{
 		Rule:                rule,
 		ContractHash:        testContractHash,
+		Mode:                ModeLive,
 		OpportunityHealthy:  true,
 		OpportunityObserved: true,
 		MissedWindows:       4,


### PR DESCRIPTION
## Summary

Foundation for v2.4 learn-and-lock live enforcement. Lands the validator, evaluator semantics, config surface, and active-set loader so subsequent PRs can wire promoted contracts into the proxy hot path on every URL-bearing transport.

**No behavior change in production.** No transport calls the contract evaluator yet. This PR ships the apparatus. Transport wiring lands in follow-ups so reviewers can stage in safety without worrying about latent regressions in the proxy decision path.

Six commits, each independently reviewable.

## Behavior

The canonical evaluator decision sequence is now: kill switch (block), scanner block (block, security floor), no resolved contract (scanner verdict), rule matches (contract annotates the scanner-allowed verdict, `WinningSource: contract`), contract has at least one enforce rule but nothing matches (contract default-deny).

Default-deny only fires once at least one rule is in `LifecycleEnforce`. A contract with zero enforce rules stays observation-only so operators can promote a fresh contract without immediately denying everything.

Mode is now an enforcement gate, not metadata. Live enforces the contract verdict. Shadow and capture surface the scanner verdict as the enforced `Verdict` (so the proxy never blocks more than scanner already would) while a new `LiveVerdict` field carries what live mode would have done plus the drift event for telemetry. Empty Mode is fail-closed input.

The new `learn_lock` config block declares `enabled`, `mode` (live/shadow/capture, defaults to shadow), `store_dir`, `roster_path`, `environment`, `pinned_root_fingerprint` (canonical `sha256:<64 lowercase hex>`), and `minimum_signatures`. Excluded from the canonical policy hash via `json:"-"` so two deployments that ratify identical contracts but enforce in different modes emit interchangeable receipts. Disabled-lock validation passes empty-field configs cleanly so existing configs keep validating.

`runtime.NewLoader` is fail-closed at startup (rejects missing fields, fails on roster load failure, fails on store rejection). A store with no `active.json` is the legitimate "nothing promoted yet" state and `Current()` returns nil so the proxy falls through to scanner. Subsequent `Reload` calls are fail-soft so a botched promote keeps the previous active set instead of blackholing production traffic.

## Defense in depth

Scanner is the floor. A signed contract-allow rule cannot resurrect a request that scanner blocked. Without this, DLP, SSRF, and the blocklist all become bypassable by anything the operator ratifies. Implemented as ordering: scanner-block resolution runs before contract evaluation in every mode, so a contract path can only annotate a scanner-allowed verdict, never override a scanner-blocked one.

Empty Mode is rejected at evaluator entry. The previous behavior silently upgraded empty mode to live, which then caused `SignalForDrift` to emit `session.SignalBlock` and push adaptive enforcement from a path the operator did not opt into. Empty mode is now a fail-closed input error in both `EvaluateHTTP` and `EvaluateDrift`.

Lifecycle enum validation. `Contract.Validate()` rejects unknown lifecycle strings ("enforce ", "Enforce", "enabled") so a typo cannot turn intended enforcement into runtime dead code. The capture-grade gate also switches from string literal `"enforce"` to the `LifecycleEnforce` constant.

Rule-kind validation. Enforced rules whose kind is not in `EnforceableRuleKinds()` are rejected. Forward-compat states (proposed, capture_only, expired, demoted) accept any kind so a v2.5 schema extension does not break v2.4 contracts in observation-only states.

Zero-Environment rejection in `NewLoader`. The store's environment pin protects against accidentally enforcing a staging contract in production. An empty Environment in `LoaderOptions` previously silently disabled the pin. Callers must now name the environment explicitly or fail at construction.

Missing `active.json` after a current manifest preserves the previous active set. The previous behavior dropped to nil on missing file regardless of prior state, which means an operator who accidentally deletes `active.json` would blackhole production onto scanner-only. Now: missing-on-startup is the legitimate "nothing promoted yet" path; missing-after-current is an operator-error rejection that retains the last good state.

Same-hash short-circuit ordering. Reads and validates `active.json` read-only before threading `PreviousHash` and `PreviousGeneration` into `store.Reload`. The store's strict generation-monotonicity gate would have rejected an unchanged-manifest reload before any same-hash check could fire, so an fsnotify spurious replay would have looked like a rejection rather than a no-op.

## What is not in this PR

No transport call sites. The proxy still does not read the active manifest. Promoted contracts have no live effect until follow-ups wire `decisionGate` into forward, intercept, reverse, fetch, CONNECT, WebSocket, MCP HTTP, and MCP stdio paths.

No fsnotify watcher. `Loader.Watch(ctx)` is the next follow-up so something automatically calls `Reload` on file changes.

No `proxy_decision` EvidenceReceipt v2 emission. New block-reason vocabulary lands with the receipt builder follow-up.

No `mcp_tool_call` rule kind. The runtime evaluator only knows `http_destination` and `http_action`. MCP locking is a separate follow-up arc that adds the schema, compile pipeline, and `EvaluateMCP`.

Each missing piece has a dedicated follow-up PR with its own scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable LearnLock feature (disabled by default) and a runtime Loader for active policy sets with safe startup behavior.

* **Improvements**
  * Stricter config validation and fingerprint/mode checks.
  * Tighter enforcement-mode handling in decision and drift evaluation; live-mode gating for adaptive signals.
  * Contract lifecycle and rule-kind validation strengthened; decisions now record live verdicts.

* **Tests**
  * Expanded unit tests covering LearnLock, loader, runtime decision/drift, and contract lifecycle rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->