### PR TITLE
feat(contract/runtime): fsnotify watcher for active manifest

### DIFF
--- a/internal/contract/runtime/loader.go
+++ b/internal/contract/runtime/loader.go
@@ -29,6 +29,16 @@ const activeFilename = "active.json"
 // existing config hot-reload window so operator expectations stay consistent.
 const reloadDebounceWindow = 100 * time.Millisecond
 
+// maxDebounceWait caps how long the debounce timer can be reset by a
+// continuous burst of events before Reload fires anyway. Without a cap,
+// a producer (operator script, runaway CI) writing active.json faster
+// than reloadDebounceWindow indefinitely starves the debounce timer:
+// every event resets the 100ms wait, and Reload never runs. Two seconds
+// is well above any legitimate atomic-promote burst (which completes in
+// milliseconds) and short enough that a runaway producer cannot delay a
+// real promote indefinitely.
+const maxDebounceWait = 2 * time.Second
+
 // LoaderOptions configures a Loader. Every field is required when the
 // caller intends the lock runtime to gate decisions; partial inputs are
 // rejected at NewLoader time so a half-wired loader never silently
@@ -66,17 +76,25 @@ type LoaderOptions struct {
 // and so production callers can wire whatever registry they keep.
 type LoaderMetrics interface {
 	// IncReload records the outcome of a single Reload attempt. Outcomes:
-	//   - "accepted"     — new manifest accepted; ActiveSet swapped
-	//   - "same_hash"    — reload returned the same manifest hash; no-op
-	//   - "no_active"    — store has no active.json; Current() stays nil
-	//   - "rejected"     — store rejected the manifest (signature, env,
+	//   - "accepted"     : new manifest accepted; ActiveSet swapped
+	//   - "same_hash"    : reload returned the same manifest hash; no-op
+	//   - "no_active"    : store has no active.json; Current() stays nil
+	//   - "rejected"     : store rejected the manifest (signature, env,
 	//                      generation downgrade, prior_manifest_hash CAS)
-	//   - "error"        — I/O or other transient error; previous
+	//   - "error"        : I/O or other transient error; previous
 	//                      ActiveSet preserved
 	IncReload(outcome string)
 	// SetGeneration records the currently-active manifest generation.
 	// Zero means no active manifest.
 	SetGeneration(generation uint64)
+	// IncWatcherError records a non-fatal error from the fsnotify
+	// channel. The most operationally significant case is an inotify
+	// queue overflow, which silently drops events. Watch responds to
+	// every watcher error by triggering a defensive Reload on the next
+	// debounce tick so a missed promote event still lands eventually,
+	// but the counter exists so operators can alert on the underlying
+	// kernel pressure.
+	IncWatcherError()
 }
 
 // noopMetrics is the default LoaderMetrics when the caller passes nil.
@@ -84,6 +102,7 @@ type noopMetrics struct{}
 
 func (noopMetrics) IncReload(string)     {}
 func (noopMetrics) SetGeneration(uint64) {}
+func (noopMetrics) IncWatcherError()     {}
 
 // Loader watches an active manifest file and serves the latest ActiveSet
 // to the proxy decision path.
@@ -278,8 +297,15 @@ func (l *Loader) Watch(ctx context.Context) error {
 
 	// debounce is reset on every relevant event. When it fires, a single
 	// Reload runs and debounce resets to nil so a quiescent loop does not
-	// keep selecting on a closed channel.
-	var debounce <-chan time.Time
+	// keep selecting on a closed channel. burstStart is the timestamp of
+	// the first event in a still-active burst; once time.Since(burstStart)
+	// exceeds maxDebounceWait, the next event triggers an immediate
+	// Reload instead of resetting the timer, capping the worst-case
+	// reload latency at roughly maxDebounceWait under sustained writes.
+	var (
+		debounce   <-chan time.Time
+		burstStart time.Time
+	)
 
 	for {
 		select {
@@ -305,12 +331,27 @@ func (l *Loader) Watch(ctx context.Context) error {
 			if filepath.Base(event.Name) != activeFilename {
 				continue
 			}
-			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Rename) {
-				debounce = time.After(reloadDebounceWindow)
+			isReloadTrigger := event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Rename)
+			if !isReloadTrigger {
+				continue
 			}
+			now := time.Now()
+			if debounce == nil {
+				burstStart = now
+			} else if now.Sub(burstStart) >= maxDebounceWait {
+				// Sustained burst exceeded the cap. Force a Reload now
+				// instead of resetting the debounce window again, so a
+				// runaway producer cannot starve a real promote.
+				debounce = nil
+				_ = l.Reload()
+				burstStart = time.Time{}
+				continue
+			}
+			debounce = time.After(reloadDebounceWindow)
 
 		case <-debounce:
 			debounce = nil
+			burstStart = time.Time{}
 			// Reload's own metrics record outcome (accepted, same_hash,
 			// rejected, error). Error return is informational; a rejected
 			// reload is fail-soft and the watcher keeps running so the
@@ -321,9 +362,21 @@ func (l *Loader) Watch(ctx context.Context) error {
 			if !ok {
 				return nil
 			}
-			// Non-fatal: keep watching. fsnotify surfaces transient errors
-			// that are not actionable from here (e.g., a brief inotify
-			// queue overflow). The next event resyncs.
+			// fsnotify surfaces non-fatal errors here. The most
+			// operationally significant case is an inotify kernel queue
+			// overflow (ErrEventOverflow): events that were in the queue
+			// at overflow time are dropped. If the dropped event was a
+			// real promote, the watcher would silently miss it without
+			// a defensive trigger. Schedule a Reload on the next
+			// debounce tick so the same-hash short-circuit absorbs the
+			// no-change case and a real change still lands. The metrics
+			// counter lets operators alert on the underlying kernel
+			// pressure separately from the reload outcome.
+			l.metrics.IncWatcherError()
+			if debounce == nil {
+				burstStart = time.Now()
+			}
+			debounce = time.After(reloadDebounceWindow)
 		}
 	}
 }

--- a/internal/contract/runtime/loader.go
+++ b/internal/contract/runtime/loader.go
@@ -4,6 +4,7 @@
 package runtime
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -11,10 +12,22 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
+
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	"github.com/luckyPipewrench/pipelock/internal/contract/store"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
+
+// activeFilename is the active-manifest filename inside StoreDir. It mirrors
+// the unexported constant in internal/contract/store; redeclared here so the
+// watcher can filter directory events without importing private store state.
+const activeFilename = "active.json"
+
+// reloadDebounceWindow coalesces an fsnotify burst (CREATE + RENAME + WRITE
+// emitted on a single atomic active.json swap) into one Reload. Matches the
+// existing config hot-reload window so operator expectations stay consistent.
+const reloadDebounceWindow = 100 * time.Millisecond
 
 // LoaderOptions configures a Loader. Every field is required when the
 // caller intends the lock runtime to gate decisions; partial inputs are
@@ -230,6 +243,91 @@ func (l *Loader) Reload() error {
 	return nil
 }
 
+// Watch runs an fsnotify watcher on the store directory until ctx is
+// cancelled. CREATE, RENAME, and WRITE events on active.json trigger a
+// debounced Reload (single window matches the config hot-reload window
+// so an atomic active.json swap that fires multiple events coalesces to
+// one Reload call).
+//
+// Watch is fail-soft for reload errors: a rejected reload (bad signature,
+// generation downgrade, env mismatch, prior-manifest CAS) leaves the
+// previous ActiveSet in place and the watcher keeps running so the next
+// promote attempt succeeds.
+//
+// Watch returns nil on graceful ctx cancel. It returns a non-nil error
+// only when the watched directory is removed (the loader cannot recover
+// from that without re-construction) or when fsnotify itself fails to
+// initialize.
+//
+// Caller is responsible for goroutine lifecycle. Watch blocks until
+// return; spawn it in a goroutine if the caller wants background
+// behaviour.
+func (l *Loader) Watch(ctx context.Context) error {
+	if l == nil {
+		return errors.New("contract runtime: nil loader")
+	}
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("contract runtime: create file watcher: %w", err)
+	}
+	defer func() { _ = watcher.Close() }()
+
+	if err := watcher.Add(l.storeDir); err != nil {
+		return fmt.Errorf("contract runtime: watch %s: %w", l.storeDir, err)
+	}
+
+	// debounce is reset on every relevant event. When it fires, a single
+	// Reload runs and debounce resets to nil so a quiescent loop does not
+	// keep selecting on a closed channel.
+	var debounce <-chan time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			// Watched directory removed out from under us. fsnotify keeps
+			// the inotify slot allocated even after the inode is gone, but
+			// the loader has no path forward without operator intervention
+			// so we surface this to the caller.
+			if event.Name == l.storeDir && (event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename)) {
+				return fmt.Errorf("contract runtime: store directory removed: %s", l.storeDir)
+			}
+			// Filter to active.json events. The store atomically replaces
+			// active.json on every accepted promote, which fires CREATE +
+			// RENAME on the new path and (sometimes) REMOVE on the old.
+			// Treat all three as a reload trigger; debounce coalesces the
+			// burst.
+			if filepath.Base(event.Name) != activeFilename {
+				continue
+			}
+			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Rename) {
+				debounce = time.After(reloadDebounceWindow)
+			}
+
+		case <-debounce:
+			debounce = nil
+			// Reload's own metrics record outcome (accepted, same_hash,
+			// rejected, error). Error return is informational; a rejected
+			// reload is fail-soft and the watcher keeps running so the
+			// next event is another opportunity.
+			_ = l.Reload()
+
+		case _, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			// Non-fatal: keep watching. fsnotify surfaces transient errors
+			// that are not actionable from here (e.g., a brief inotify
+			// queue overflow). The next event resyncs.
+		}
+	}
+}
+
 // rejectionOutcome maps a store reload error to a metrics-friendly
 // outcome label. Validation errors collapse to "rejected"; transient
 // I/O collapses to "error" so an operator can distinguish a botched
@@ -254,7 +352,7 @@ func rejectionOutcome(err error) string {
 }
 
 func (l *Loader) validateActiveReadOnly() (store.State, error) {
-	activePath := filepath.Clean(filepath.Join(l.storeDir, "active.json"))
+	activePath := filepath.Clean(filepath.Join(l.storeDir, activeFilename))
 	raw, err := os.ReadFile(activePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/contract/runtime/loader.go
+++ b/internal/contract/runtime/loader.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -125,6 +126,7 @@ type Loader struct {
 	store     store.Store
 	storeDir  string
 	storeOpts store.Options
+	reloadMu  sync.Mutex
 	current   atomic.Pointer[ActiveSet]
 	mode      Mode
 	metrics   LoaderMetrics
@@ -212,13 +214,23 @@ func (l *Loader) Reload() error {
 	if l == nil {
 		return errors.New("contract runtime: nil loader")
 	}
+	l.reloadMu.Lock()
+	defer l.reloadMu.Unlock()
+
 	prev := l.current.Load()
 	opts := l.storeOpts
+	var activeState store.State
 	if prev != nil {
-		activeState, err := l.validateActiveReadOnly()
+		var err error
+		activeState, err = l.validateActiveReadOnly()
 		if err == nil && activeState.ManifestHash == prev.ManifestHash() {
 			l.metrics.IncReload("same_hash")
 			return nil
+		}
+		if err == nil && activeState.Envelope.Body.PriorManifestHash != prev.ManifestHash() {
+			if recovered, recoverErr := l.recoverAcceptedActive(activeState, prev); recoverErr == nil {
+				return l.acceptState(recovered)
+			}
 		}
 		opts.PreviousHash = prev.ManifestHash()
 		opts.PreviousGeneration = prev.Generation()
@@ -226,6 +238,16 @@ func (l *Loader) Reload() error {
 
 	state, err := l.store.Reload(opts)
 	if err != nil {
+		if prev != nil && errors.Is(err, store.ErrPriorManifest) {
+			if latestActive, activeErr := l.validateActiveReadOnly(); activeErr == nil {
+				if recovered, recoverErr := l.recoverAcceptedActive(latestActive, prev); recoverErr == nil {
+					return l.acceptState(recovered)
+				}
+			}
+			if recovered, recoverErr := l.recoverAcceptedActive(activeState, prev); recoverErr == nil {
+				return l.acceptState(recovered)
+			}
+		}
 		if errors.Is(err, store.ErrNoActiveManifest) {
 			if prev != nil {
 				l.metrics.IncReload("rejected")
@@ -251,6 +273,10 @@ func (l *Loader) Reload() error {
 		return nil
 	}
 
+	return l.acceptState(state)
+}
+
+func (l *Loader) acceptState(state store.State) error {
 	next, err := NewActiveSet(state)
 	if err != nil {
 		l.metrics.IncReload("rejected")
@@ -260,6 +286,51 @@ func (l *Loader) Reload() error {
 	l.metrics.IncReload("accepted")
 	l.metrics.SetGeneration(next.Generation())
 	return nil
+}
+
+func (l *Loader) recoverAcceptedActive(activeState store.State, prev *ActiveSet) (store.State, error) {
+	if prev == nil {
+		return store.State{}, errors.New("contract runtime: no previous active set")
+	}
+	if activeState.Envelope.Body.Generation <= prev.Generation() {
+		return store.State{}, fmt.Errorf("contract runtime: accepted active generation %d does not advance current generation %d",
+			activeState.Envelope.Body.Generation, prev.Generation())
+	}
+
+	opts := l.storeOpts
+	opts.PreviousHash = ""
+	opts.PreviousGeneration = 0
+	accepted, err := l.store.Accepted(activeState.ManifestHash, opts)
+	if err != nil {
+		return store.State{}, fmt.Errorf("contract runtime: active manifest is not accepted history: %w", err)
+	}
+	if accepted.ManifestHash != activeState.ManifestHash {
+		return store.State{}, fmt.Errorf("contract runtime: accepted active hash mismatch: got %s want %s", accepted.ManifestHash, activeState.ManifestHash)
+	}
+	if !l.acceptedChainReachesCurrent(accepted, prev, opts) {
+		return store.State{}, fmt.Errorf("contract runtime: accepted active chain does not reach current manifest %s", prev.ManifestHash())
+	}
+	return accepted, nil
+}
+
+func (l *Loader) acceptedChainReachesCurrent(state store.State, prev *ActiveSet, opts store.Options) bool {
+	for {
+		if state.ManifestHash == prev.ManifestHash() {
+			return true
+		}
+		if state.Envelope.Body.Generation <= prev.Generation() {
+			return false
+		}
+		prior := state.Envelope.Body.PriorManifestHash
+		if prior == "" || prior == "sha256:genesis" {
+			return false
+		}
+		next, err := l.store.Accepted(prior, opts)
+		if err != nil {
+			return false
+		}
+		state = next
+	}
 }
 
 // Watch runs an fsnotify watcher on the store directory until ctx is

--- a/internal/contract/runtime/loader.go
+++ b/internal/contract/runtime/loader.go
@@ -40,6 +40,17 @@ const reloadDebounceWindow = 100 * time.Millisecond
 // real promote indefinitely.
 const maxDebounceWait = 2 * time.Second
 
+// Reload outcome labels passed to LoaderMetrics.IncReload. Operators
+// alert on these strings so the values are part of the public surface
+// even though the metric interface is internal.
+const (
+	outcomeAccepted = "accepted"
+	outcomeSameHash = "same_hash"
+	outcomeNoActive = "no_active"
+	outcomeRejected = "rejected"
+	outcomeError    = "error"
+)
+
 // LoaderOptions configures a Loader. Every field is required when the
 // caller intends the lock runtime to gate decisions; partial inputs are
 // rejected at NewLoader time so a half-wired loader never silently
@@ -224,7 +235,7 @@ func (l *Loader) Reload() error {
 		var err error
 		activeState, err = l.validateActiveReadOnly()
 		if err == nil && activeState.ManifestHash == prev.ManifestHash() {
-			l.metrics.IncReload("same_hash")
+			l.metrics.IncReload(outcomeSameHash)
 			return nil
 		}
 		if err == nil && activeState.Envelope.Body.PriorManifestHash != prev.ManifestHash() {
@@ -250,13 +261,13 @@ func (l *Loader) Reload() error {
 		}
 		if errors.Is(err, store.ErrNoActiveManifest) {
 			if prev != nil {
-				l.metrics.IncReload("rejected")
+				l.metrics.IncReload(outcomeRejected)
 				return fmt.Errorf("contract runtime: active manifest disappeared after generation %d: %w", prev.Generation(), err)
 			}
 			// Store has no active.json — legitimate "nothing promoted"
 			// state during initial/never-active startup. Current() stays nil.
 			l.current.Store(nil)
-			l.metrics.IncReload("no_active")
+			l.metrics.IncReload(outcomeNoActive)
 			l.metrics.SetGeneration(0)
 			return nil
 		}
@@ -269,7 +280,7 @@ func (l *Loader) Reload() error {
 	// generation before returning state because generation monotonicity is
 	// part of the active-manifest CAS contract.
 	if prev != nil && state.ManifestHash == prev.ManifestHash() {
-		l.metrics.IncReload("same_hash")
+		l.metrics.IncReload(outcomeSameHash)
 		return nil
 	}
 
@@ -279,11 +290,11 @@ func (l *Loader) Reload() error {
 func (l *Loader) acceptState(state store.State) error {
 	next, err := NewActiveSet(state)
 	if err != nil {
-		l.metrics.IncReload("rejected")
+		l.metrics.IncReload(outcomeRejected)
 		return fmt.Errorf("contract runtime: build active set: %w", err)
 	}
 	l.current.Store(next)
-	l.metrics.IncReload("accepted")
+	l.metrics.IncReload(outcomeAccepted)
 	l.metrics.SetGeneration(next.Generation())
 	return nil
 }
@@ -402,7 +413,10 @@ func (l *Loader) Watch(ctx context.Context) error {
 			if filepath.Base(event.Name) != activeFilename {
 				continue
 			}
-			isReloadTrigger := event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Rename)
+			isReloadTrigger := event.Has(fsnotify.Write) ||
+				event.Has(fsnotify.Create) ||
+				event.Has(fsnotify.Rename) ||
+				event.Has(fsnotify.Remove)
 			if !isReloadTrigger {
 				continue
 			}
@@ -444,8 +458,20 @@ func (l *Loader) Watch(ctx context.Context) error {
 			// counter lets operators alert on the underlying kernel
 			// pressure separately from the reload outcome.
 			l.metrics.IncWatcherError()
+			now := time.Now()
 			if debounce == nil {
-				burstStart = time.Now()
+				burstStart = now
+			} else if now.Sub(burstStart) >= maxDebounceWait {
+				// Sustained watcher-error pressure (e.g., repeated
+				// inotify queue overflow) was resetting the debounce
+				// window without ever firing the defensive Reload.
+				// Force the flush when the burst exceeds the cap, so
+				// the recovery path lands under exactly the conditions
+				// it was added for.
+				debounce = nil
+				_ = l.Reload()
+				burstStart = time.Time{}
+				continue
 			}
 			debounce = time.After(reloadDebounceWindow)
 		}
@@ -466,12 +492,12 @@ func rejectionOutcome(err error) string {
 		errors.Is(err, store.ErrGeneration),
 		errors.Is(err, store.ErrPriorManifest),
 		errors.Is(err, store.ErrContractHistory):
-		return "rejected"
+		return outcomeRejected
 	case errors.Is(err, store.ErrDecode),
 		errors.Is(err, store.ErrWriteOnceConflict):
-		return "error"
+		return outcomeError
 	default:
-		return "error"
+		return outcomeError
 	}
 }
 

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -879,7 +879,9 @@ func waitFor(cond func() bool) bool {
 }
 
 // snapshotOutcomes returns a copy of the current outcome counters for
-// inclusion in test failure messages without holding the lock.
+// inclusion in test failure messages. Acquires m.mu so it is safe to
+// call from the test goroutine while the watcher goroutine fires its
+// own metric increments.
 func snapshotOutcomes(m *captureMetrics) map[string]int {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -291,6 +291,81 @@ func TestLoader_NilMetricsExercisesNoopImpl(t *testing.T) {
 	}
 }
 
+func TestLoader_ReloadAdoptsAcceptedActiveAfterMissedIntermediate(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	env := testLoaderEnv()
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
+
+	metrics := &captureMetrics{}
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, env), metrics)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	current := loader.Current()
+	if current == nil {
+		t.Fatal("Current() = nil, want active set")
+	}
+
+	// Simulate two valid promotions landing before the runtime watcher gets
+	// a debounce tick. Both manifests have already been accepted into the
+	// immutable store history by the promotion path, but the runtime loader
+	// still has generation 1 in memory.
+	hash2 := writeAcceptedActiveStore(t, fixture, storeDir, 2, current.ManifestHash(), current.Generation(), env)
+	hash3 := writeAcceptedActiveStore(t, fixture, storeDir, 3, hash2, 2, env)
+
+	if err := loader.Reload(); err != nil {
+		t.Fatalf("Reload after skipped intermediate accepted manifest: %v", err)
+	}
+	set := loader.Current()
+	if set == nil || set.Generation() != 3 || set.ManifestHash() != hash3 {
+		t.Fatalf("Current() = %+v, want generation 3 hash %s", set, hash3)
+	}
+	if metrics.outcome("accepted") != 2 {
+		t.Fatalf("accepted outcomes = %d, want 2 (initial + recovery)", metrics.outcome("accepted"))
+	}
+	journalPath := filepath.Clean(filepath.Join(storeDir, ".activation_journal.jsonl"))
+	journal, err := os.ReadFile(journalPath)
+	if err != nil {
+		t.Fatalf("read activation journal: %v", err)
+	}
+	if strings.Contains(string(journal), `"outcome":"rejected"`) {
+		t.Fatalf("recovered accepted active should not add a rejected journal entry: %s", journal)
+	}
+}
+
+func TestLoader_ReloadRejectsSkippedActiveWithoutAcceptedHistory(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	env := testLoaderEnv()
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
+
+	metrics := &captureMetrics{}
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, env), metrics)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	current := loader.Current()
+	if current == nil {
+		t.Fatal("Current() = nil, want active set")
+	}
+
+	hash2 := writeAcceptedActiveStore(t, fixture, storeDir, 2, current.ManifestHash(), current.Generation(), env)
+	writeSignedActiveStore(t, fixture, storeDir, 3, hash2, env)
+
+	if err := loader.Reload(); err == nil {
+		t.Fatal("Reload accepted skipped active manifest without immutable accepted history")
+	}
+	if loader.Current() != current {
+		t.Fatal("skipped active without accepted history must preserve previous active set")
+	}
+	if metrics.outcome("rejected") != 1 {
+		t.Fatalf("rejected outcomes = %d, want 1", metrics.outcome("rejected"))
+	}
+}
+
 func TestLoader_Watch_CancelExitsCleanly(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
@@ -748,6 +823,37 @@ func writeSignedActiveStore(t *testing.T, fixture rosterFixture, storeDir string
 	if err := os.WriteFile(filepath.Join(storeDir, "active.json"), append(raw, '\n'), 0o600); err != nil {
 		t.Fatalf("write active.json: %v", err)
 	}
+}
+
+func writeAcceptedActiveStore(t *testing.T, fixture rosterFixture, storeDir string, generation uint64, prior string, previousGeneration uint64, env contract.Environment) string {
+	t.Helper()
+	st := contractstore.New(storeDir)
+	contractHash := putSignedLoaderContract(t, st, fixture)
+	active := signedLoaderManifest(t, contractHash, generation, prior, env, fixture)
+	raw, err := json.Marshal(active)
+	if err != nil {
+		t.Fatalf("marshal active manifest: %v", err)
+	}
+	loadedRoster, err := signing.LoadRoster(fixture.rosterPath, fixture.rootFingerprint)
+	if err != nil {
+		t.Fatalf("load roster: %v", err)
+	}
+	opts := contractstore.Options{
+		Environment:        env,
+		Roster:             loadedRoster,
+		PreviousHash:       prior,
+		PreviousGeneration: previousGeneration,
+		MinSignatures:      1,
+		Now:                func() time.Time { return time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) },
+	}
+	hash, err := st.WriteActive(raw, opts)
+	if err != nil {
+		t.Fatalf("WriteActive generation %d: %v", generation, err)
+	}
+	if _, err := st.Reload(opts); err != nil {
+		t.Fatalf("Reload generation %d: %v", generation, err)
+	}
+	return hash
 }
 
 func putSignedLoaderContract(t *testing.T, st contractstore.Store, fixture rosterFixture) string {

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -4,6 +4,7 @@
 package runtime
 
 import (
+	"context"
 	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
@@ -11,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -289,6 +291,260 @@ func TestLoader_NilMetricsExercisesNoopImpl(t *testing.T) {
 	}
 }
 
+func TestLoader_Watch_CancelExitsCleanly(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	if err := os.MkdirAll(storeDir, 0o750); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, testLoaderEnv()), nil)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- loader.Watch(ctx) }()
+
+	// Give Watch enough time to call fsnotify.NewWatcher + Add.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Watch on cancel: %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Watch did not return after cancel")
+	}
+}
+
+func TestLoader_Watch_FileReplacementTriggersReload(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	env := testLoaderEnv()
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
+
+	metrics := &captureMetrics{}
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, env), metrics)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	priorHash := loader.Current().ManifestHash()
+	if loader.Current().Generation() != 1 {
+		t.Fatalf("initial generation = %d, want 1", loader.Current().Generation())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- loader.Watch(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+	time.Sleep(80 * time.Millisecond) // let watcher.Add complete
+
+	// Promote generation 2 with the correct prior-hash chain.
+	writeSignedActiveStore(t, fixture, storeDir, 2, priorHash, env)
+
+	if !waitFor(func() bool {
+		set := loader.Current()
+		return set != nil && set.Generation() == 2
+	}) {
+		t.Fatalf("generation 2 not loaded; current = %+v, metrics = %v", loader.Current(), snapshotOutcomes(metrics))
+	}
+}
+
+func TestLoader_Watch_DebounceCoalescesBurstAndSameHashIsNoop(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	env := testLoaderEnv()
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
+
+	metrics := &captureMetrics{}
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, env), metrics)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	if metrics.outcome("accepted") != 1 {
+		t.Fatalf("initial load accepted = %d, want 1", metrics.outcome("accepted"))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- loader.Watch(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+	time.Sleep(80 * time.Millisecond)
+
+	// Fire a burst of WRITEs against the same content. fsnotify will emit
+	// multiple events; the 100ms debounce window should coalesce them
+	// into a single Reload, which the same-hash short-circuit then turns
+	// into one same_hash outcome (no swap, no rejection).
+	activePath := filepath.Clean(filepath.Join(storeDir, activeFilename))
+	raw, err := os.ReadFile(activePath)
+	if err != nil {
+		t.Fatalf("read active.json: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		if err := os.WriteFile(activePath, raw, 0o600); err != nil {
+			t.Fatalf("rewrite active.json: %v", err)
+		}
+	}
+
+	// Wait for at least one debounce window plus a small Reload margin,
+	// then poll until the same_hash counter increments at least once.
+	if !waitFor(func() bool {
+		return metrics.outcome("same_hash") >= 1
+	}) {
+		t.Fatalf("same_hash never observed; metrics = %v", snapshotOutcomes(metrics))
+	}
+
+	// Drain any trailing event for a hair longer than the debounce window
+	// so a coalesced second pass would have already fired.
+	time.Sleep(reloadDebounceWindow + 100*time.Millisecond)
+
+	// 5 burst writes should coalesce; tolerate up to 2 same_hash outcomes
+	// in case the OS spreads the burst across two debounce windows under
+	// load. More than 2 indicates the debounce window is broken.
+	if got := metrics.outcome("same_hash"); got > 2 {
+		t.Fatalf("same_hash = %d, want <= 2 (5-event burst should coalesce)", got)
+	}
+	// No rejected or error outcomes should have fired.
+	if got := metrics.outcome("rejected"); got != 0 {
+		t.Fatalf("rejected = %d, want 0 for same-hash burst", got)
+	}
+	if got := metrics.outcome("error"); got != 0 {
+		t.Fatalf("error = %d, want 0 for same-hash burst", got)
+	}
+}
+
+func TestLoader_Watch_RejectedReloadKeepsWatcherAlive(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	env := testLoaderEnv()
+	writeSignedActiveStore(t, fixture, storeDir, 2, "sha256:genesis", env)
+
+	metrics := &captureMetrics{}
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, env), metrics)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	current := loader.Current()
+	if current == nil {
+		t.Fatal("expected initial active set")
+	}
+	priorHash := current.ManifestHash()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- loader.Watch(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+	time.Sleep(80 * time.Millisecond)
+
+	// Generation downgrade: write generation 1 over generation 2.
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:older", env)
+	if !waitFor(func() bool {
+		return metrics.outcome("rejected") >= 1
+	}) {
+		t.Fatalf("rejected outcome never observed; metrics = %v", snapshotOutcomes(metrics))
+	}
+	if loader.Current() != current {
+		t.Fatal("rejected reload must preserve previous active set")
+	}
+
+	// Write a valid generation 3 to prove the watcher still triggers
+	// Reload after the prior rejection.
+	writeSignedActiveStore(t, fixture, storeDir, 3, priorHash, env)
+	if !waitFor(func() bool {
+		set := loader.Current()
+		return set != nil && set.Generation() == 3
+	}) {
+		t.Fatalf("recovery to generation 3 never landed; metrics = %v", snapshotOutcomes(metrics))
+	}
+}
+
+func TestLoader_Watch_DirectoryDeletionEndsWatcher(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	env := testLoaderEnv()
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
+
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, env), nil)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- loader.Watch(ctx) }()
+	time.Sleep(80 * time.Millisecond)
+
+	// Drop the entire store directory. fsnotify fires a Remove event on
+	// the watched directory; Watch surfaces the loss to the caller so
+	// the supervisor can decide what to do (re-construct, alert, exit).
+	if err := os.RemoveAll(storeDir); err != nil {
+		t.Fatalf("remove store dir: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Watch returned nil after directory deletion")
+		}
+		if !strings.Contains(err.Error(), "store directory removed") {
+			t.Fatalf("err = %v, want store-directory-removed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Watch did not return within 2s after directory deletion")
+	}
+}
+
+// watchTestTimeout caps how long Watch tests poll for an expected
+// outcome before failing. Generous enough to absorb slow CI runners,
+// tight enough that a stuck watcher fails fast.
+const watchTestTimeout = 2 * time.Second
+
+// waitFor polls cond until it returns true or watchTestTimeout elapses.
+// Returns true on success, false on timeout. Used by Watch tests where
+// the signal is the watcher goroutine landing a Reload outcome: poll
+// the metric to increment rather than guess a fixed sleep.
+func waitFor(cond func() bool) bool {
+	deadline := time.Now().Add(watchTestTimeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+// snapshotOutcomes returns a copy of the current outcome counters for
+// inclusion in test failure messages without holding the lock.
+func snapshotOutcomes(m *captureMetrics) map[string]int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(map[string]int, len(m.outcomes))
+	for k, v := range m.outcomes {
+		out[k] = v
+	}
+	return out
+}
+
 // rosterFixture is the minimum fixture the Loader needs at construction
 // time: a real Ed25519 root key, a real activation-signing key, and a
 // roster file on disk that signing.LoadRoster can verify. Tests that
@@ -510,13 +766,18 @@ func rosterKey(keyID string, purpose signing.KeyPurpose, pub ed25519.PublicKey, 
 	}
 }
 
-// captureMetrics records LoaderMetrics calls for assertion in tests.
+// captureMetrics records LoaderMetrics calls for assertion in tests. The
+// mutex matters once Watch tests fire updates from the watcher goroutine
+// while the test goroutine reads outcomes for assertions.
 type captureMetrics struct {
+	mu             sync.Mutex
 	outcomes       map[string]int
 	lastGeneration uint64
 }
 
 func (m *captureMetrics) IncReload(outcome string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.outcomes == nil {
 		m.outcomes = map[string]int{}
 	}
@@ -524,5 +785,15 @@ func (m *captureMetrics) IncReload(outcome string) {
 }
 
 func (m *captureMetrics) SetGeneration(generation uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.lastGeneration = generation
+}
+
+// outcome returns the count for a specific outcome label. Safe for
+// concurrent reads while Watch fires updates.
+func (m *captureMetrics) outcome(label string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.outcomes[label]
 }

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -475,6 +475,84 @@ func TestLoader_Watch_RejectedReloadKeepsWatcherAlive(t *testing.T) {
 	}
 }
 
+func TestLoader_Watch_NilReceiverReturnsError(t *testing.T) {
+	t.Parallel()
+	var l *Loader
+	err := l.Watch(context.Background())
+	if err == nil {
+		t.Fatal("Watch on nil loader returned nil")
+	}
+	if !strings.Contains(err.Error(), "nil loader") {
+		t.Fatalf("err = %v, want nil-loader error", err)
+	}
+}
+
+func TestLoader_Watch_DebounceMaxWaitFlushesUnderSustainedWrites(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	env := testLoaderEnv()
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
+
+	metrics := &captureMetrics{}
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, env), metrics)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	if metrics.outcome("accepted") != 1 {
+		t.Fatalf("initial accepted = %d, want 1", metrics.outcome("accepted"))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() { done <- loader.Watch(ctx) }()
+	t.Cleanup(func() {
+		close(stop)
+		cancel()
+		<-done
+	})
+	time.Sleep(80 * time.Millisecond)
+
+	// Producer that writes the same content every 40ms (well below the
+	// 100ms debounce window). Without the maxDebounceWait cap, the
+	// debounce timer would reset on every write and Reload would never
+	// fire. With the cap, Reload fires within roughly maxDebounceWait
+	// after the first write.
+	activePath := filepath.Clean(filepath.Join(storeDir, activeFilename))
+	raw, err := os.ReadFile(activePath)
+	if err != nil {
+		t.Fatalf("read active.json: %v", err)
+	}
+	go func() {
+		ticker := time.NewTicker(40 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				_ = os.WriteFile(activePath, raw, 0o600)
+			}
+		}
+	}()
+
+	// Allow up to maxDebounceWait + a generous grace for OS scheduling
+	// jitter. The forced flush fires through the same code path as a
+	// normal debounce tick, so the resulting outcome is "same_hash"
+	// (content unchanged).
+	deadline := time.Now().Add(maxDebounceWait + 1500*time.Millisecond)
+	for time.Now().Before(deadline) {
+		if metrics.outcome("same_hash") >= 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if metrics.outcome("same_hash") < 1 {
+		t.Fatalf("debounce never flushed under sustained writes; metrics = %v", snapshotOutcomes(metrics))
+	}
+}
+
 func TestLoader_Watch_DirectoryDeletionEndsWatcher(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
@@ -773,6 +851,7 @@ type captureMetrics struct {
 	mu             sync.Mutex
 	outcomes       map[string]int
 	lastGeneration uint64
+	watcherErrors  int
 }
 
 func (m *captureMetrics) IncReload(outcome string) {
@@ -788,6 +867,12 @@ func (m *captureMetrics) SetGeneration(generation uint64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.lastGeneration = generation
+}
+
+func (m *captureMetrics) IncWatcherError() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.watcherErrors++
 }
 
 // outcome returns the count for a specific outcome label. Safe for

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -755,6 +755,71 @@ func TestRejectionOutcomeMapsErrorClasses(t *testing.T) {
 	}
 }
 
+func TestNewLoader_FailsOnMalformedActiveManifest(t *testing.T) {
+	t.Parallel()
+	// NewLoader is fail-closed: a present-but-invalid active.json must
+	// surface an error so the supervisor refuses to start with a broken
+	// lock. The store rejects the parse before signature/CAS gates even
+	// fire, so this exercises the initial-reload error path that maps to
+	// the wrapped initial reload error.
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	if err := os.MkdirAll(storeDir, 0o750); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(storeDir, activeFilename), []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("write malformed active.json: %v", err)
+	}
+	if _, err := NewLoader(loaderOptions(fixture, storeDir, testLoaderEnv()), nil); err == nil {
+		t.Fatal("NewLoader accepted a malformed active.json")
+	} else if !strings.Contains(err.Error(), "initial reload") {
+		t.Fatalf("err = %v, want initial-reload wrap", err)
+	}
+}
+
+func TestLoader_Watch_FailsOnMissingStoreDir(t *testing.T) {
+	t.Parallel()
+	// Watch wires fsnotify.Add against the store directory at startup. A
+	// missing directory at watch-setup time surfaces an error to the
+	// caller so the supervisor knows the lock runtime is unhealthy
+	// instead of silently looping.
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", testLoaderEnv())
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, testLoaderEnv()), nil)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	// Drop the store directory before Watch starts so fsnotify.Add fails.
+	if err := os.RemoveAll(storeDir); err != nil {
+		t.Fatalf("remove store dir: %v", err)
+	}
+	err = loader.Watch(context.Background())
+	if err == nil {
+		t.Fatal("Watch returned nil on missing store directory")
+	}
+	if !strings.Contains(err.Error(), "watch ") {
+		t.Fatalf("err = %v, want watcher.Add wrap", err)
+	}
+}
+
+func TestRecoverAcceptedActiveRejectsNilPrev(t *testing.T) {
+	t.Parallel()
+	// Defensive guard: a caller threading nil prev into recovery must
+	// not crash. Reload always passes a non-nil prev when invoking
+	// recovery, so this test exists to keep the guard wired.
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", testLoaderEnv())
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, testLoaderEnv()), nil)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	if _, err := loader.recoverAcceptedActive(contractstore.State{}, nil); err == nil {
+		t.Fatal("recoverAcceptedActive accepted nil prev")
+	}
+}
+
 func TestLoader_Watch_DirectoryDeletionEndsWatcher(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -628,6 +628,133 @@ func TestLoader_Watch_DebounceMaxWaitFlushesUnderSustainedWrites(t *testing.T) {
 	}
 }
 
+func TestLoader_Watch_RemoveEventTriggersReload(t *testing.T) {
+	t.Parallel()
+	// fsnotify.Remove on active.json must trigger Reload. Atomic rename
+	// can fire IN_DELETE for the displaced inode on some kernels, and
+	// an explicit operator unlink fires Remove cleanly. Without Remove
+	// in the trigger predicate the loader would sit on stale state.
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	env := testLoaderEnv()
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
+
+	metrics := &captureMetrics{}
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, env), metrics)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	current := loader.Current()
+	if current == nil {
+		t.Fatal("expected initial active set")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- loader.Watch(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+	time.Sleep(80 * time.Millisecond)
+
+	// Remove active.json directly. The watcher should see Remove and
+	// trigger a Reload through the debounce. Reload then rejects the
+	// missing-file-after-current path and preserves the previous set.
+	activePath := filepath.Clean(filepath.Join(storeDir, activeFilename))
+	if err := os.Remove(activePath); err != nil {
+		t.Fatalf("remove active.json: %v", err)
+	}
+
+	if !waitFor(func() bool {
+		return metrics.outcome("rejected") >= 1
+	}) {
+		t.Fatalf("rejected outcome never observed after Remove; metrics = %v", snapshotOutcomes(metrics))
+	}
+	if loader.Current() != current {
+		t.Fatal("missing active.json after current must preserve previous active set")
+	}
+}
+
+func TestLoader_ReloadRejectsRecoveryChainBreak(t *testing.T) {
+	t.Parallel()
+	// Recovery walks the accepted-history chain back from the current
+	// active to the loader's prev. If a generation in that chain is
+	// missing from accepted history, the walk fails and the rejection
+	// stands. This exercises acceptedChainReachesCurrent's break path.
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.root, "store")
+	env := testLoaderEnv()
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
+
+	metrics := &captureMetrics{}
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, env), metrics)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	current := loader.Current()
+	if current == nil {
+		t.Fatal("expected initial active set")
+	}
+
+	// Promote gen 2 properly into accepted history, then write gen 4
+	// claiming gen 2 as its prior. Gen 3 is missing from history so
+	// the chain walk from gen 4 cannot reach gen 1.
+	hash2 := writeAcceptedActiveStore(t, fixture, storeDir, 2, current.ManifestHash(), current.Generation(), env)
+	writeSignedActiveStore(t, fixture, storeDir, 4, hash2, env)
+
+	if err := loader.Reload(); err == nil {
+		t.Fatal("Reload accepted skipped chain without intermediate accepted history")
+	}
+	if loader.Current() != current {
+		t.Fatal("broken recovery chain must preserve previous active set")
+	}
+	if metrics.outcome("rejected") != 1 {
+		t.Fatalf("rejected outcomes = %d, want 1", metrics.outcome("rejected"))
+	}
+}
+
+func TestRejectionOutcomeMapsErrorClasses(t *testing.T) {
+	t.Parallel()
+	// Sentinel errors that map to the "rejected" label vs the "error"
+	// label have to stay separated so operators alerting on rejections
+	// (signature failure, env mismatch, generation downgrade, prior CAS)
+	// do not see flapping I/O drown out a real promote rejection.
+	rejected := []error{
+		contractstore.ErrStructural,
+		contractstore.ErrSignature,
+		contractstore.ErrContractSignature,
+		contractstore.ErrDualControl,
+		contractstore.ErrEnvironmentMismatch,
+		contractstore.ErrGeneration,
+		contractstore.ErrPriorManifest,
+		contractstore.ErrContractHistory,
+	}
+	for _, err := range rejected {
+		err := err
+		t.Run("rejected_"+err.Error(), func(t *testing.T) {
+			t.Parallel()
+			if got := rejectionOutcome(err); got != "rejected" {
+				t.Fatalf("rejectionOutcome(%v) = %q, want rejected", err, got)
+			}
+		})
+	}
+	errs := []error{
+		contractstore.ErrDecode,
+		contractstore.ErrWriteOnceConflict,
+		errors.New("synthetic transient io"),
+	}
+	for _, err := range errs {
+		err := err
+		t.Run("error_"+err.Error(), func(t *testing.T) {
+			t.Parallel()
+			if got := rejectionOutcome(err); got != "error" {
+				t.Fatalf("rejectionOutcome(%v) = %q, want error", err, got)
+			}
+		})
+	}
+}
+
 func TestLoader_Watch_DirectoryDeletionEndsWatcher(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)


### PR DESCRIPTION
## Summary

`Loader.Watch(ctx)` is the missing piece between the fail-soft `Reload` that landed in #482 and the proxy hot path. Watches the contract store directory, debounces atomic-promote bursts into a single `Reload`, and is fail-soft on rejected reloads so a botched promote keeps the previous active set in place instead of blackholing production.

Three commits, each independently reviewable. **No transport call sites in this PR.** The proxy still does not read the active manifest. Transport wiring lands in follow-ups.

## Behavior

Watches the store directory rather than `active.json` directly. The store atomically replaces `active.json` on every accepted promote (rename over a temp file), which kills any inode-attached watcher. Directory-watch + filename filter is the standard fix.

Debounce window is 100ms (matches the existing config hot-reload window). A `CREATE + RENAME + WRITE` burst from a single atomic promote coalesces into one `Reload` call. A new `maxDebounceWait` cap (2s) forces a flush when continuous events keep resetting the timer, so a runaway producer cannot starve a real promote indefinitely.

`Reload` itself now holds a `sync.Mutex` for its lifetime. Watch already serializes its own calls through the debounce gate, but a caller that runs `Watch` concurrently with manual `Reload` invocations (test harness, supervisor probe) could race the same-hash short-circuit against `store.Reload` and either skip a real promote or ratchet `PreviousGeneration` inconsistently. The mutex makes both paths safe to interleave.

`Reload` also gains a missed-promote recovery path. When the on-disk `active.json` carries a `PriorManifestHash` that does not match the loader's prev (because Watch missed several intermediate promotes through inotify queue overflow, supervisor pause, or burst), the recovery walks the accepted-history chain back from the current active manifest to the loader's prev hash. Each step calls `store.Accepted` which runs the full validation pipeline: signature verification, environment check, filename-binding (the file's name must match its content hash), and chain-continuous validation that recurses through every intermediate manifest. If the chain reaches prev, the active manifest is adopted. If it breaks, the rejection stands and the previous active set is preserved.

Termination on the chain walk is bounded. Each iteration moves back exactly one generation. The chain-continuous check inside `store.Accepted` enforces strict generation monotonicity. Content-addressing prevents cycles (each manifest's hash is deterministic from its body, so two manifests cannot point at each other unless they are identical, in which case the same-hash check fires first).

`Watch` returns nil on graceful `ctx` cancel. It returns a non-nil error only when the watched directory is removed out from under the loader (the loader cannot recover without operator intervention so the loss is surfaced to the caller) or when fsnotify itself fails to initialize.

## Defense in depth

`watcher.Errors` is now treated as actionable. The most operationally significant case is an inotify kernel queue overflow (`ErrEventOverflow`): events that were in the queue at overflow time are dropped silently. If the dropped event was a real promote, the watcher would never reload until something else touched the directory. Watch now schedules a defensive `Reload` on the next debounce tick whenever `watcher.Errors` fires. The same-hash short-circuit absorbs the no-change case so the cost is one extra peek per kernel error, and a real change still lands. New `LoaderMetrics.IncWatcherError()` lets operators alert on kernel inotify pressure separately from reload outcomes.

Scanner is still the floor. The loader's contribution to the live-lock decision pipeline is `Loader.Current()` returning either the active set or nil. Nothing in this PR changes the evaluator's ordering: kill-switch then scanner-block then resolved-contract then default-deny. A nil `Current()` falls through to scanner-only, which is the safe direction.

`reloadMu` ensures concurrent `Reload` callers see consistent state. Watch is the primary caller in production but a supervisor probe or operator-driven manual reload via the gateway API would otherwise be free to race the same-hash gate. The mutex closes that.

Recovery walk is fully signature-verified end to end. Each intermediate manifest is loaded via `store.Accepted` which decodes strict, validates structure, computes the content hash, verifies the filename matches the hash, verifies the deployment environment, verifies the manifest signatures against the trust roster, and recurses through the prior chain with cycle detection. Skipping verification at any step would defeat the lock.

## What is not in this PR

No transport call sites. The proxy still does not read the active manifest. The decisionGate helper plus per-transport wiring lands in follow-up PRs.

No `proxy_decision` EvidenceReceipt v2 emission. New block-reason vocabulary plus the receipt builder ships separately.

No `mcp_tool_call` rule kind. The runtime evaluator only knows `http_destination` and `http_action`. MCP locking is its own arc that adds the schema, compile pipeline, and `EvaluateMCP`.

Each missing piece has a dedicated follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manifest reload reliability by serializing reloads, validating on-disk state to skip redundant work, and adding history-based recovery for certain failed reloads.
  * Harder watcher resilience: filters relevant file events, defensive reloads on watcher errors/overflows, and increments a watcher-error metric for non-fatal watcher failures.

* **Tests**
  * Expanded coverage for reload recovery and watcher behaviors (debounce/coalescing, error recovery, directory deletion, forced flush) and made metric capture concurrency-safe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->