### PR TITLE
feat(blockreason,runtime): contract reason codes + proxy_decision receipt builder

### DIFF
--- a/docs/specs/block-reason-header.md
+++ b/docs/specs/block-reason-header.md
@@ -102,6 +102,18 @@ Reason codes are lowercase snake_case. The v1 set is derived from existing pipel
 | `browser_shield_oversize` | Response body exceeded the configured Browser Shield size limit. Operator must raise the limit or exempt the host to clear the block. | `warn` | `policy` |
 | `block_reason_overflow` | Internal sentinel: the block-emit metadata itself was malformed (oversized Reason value, etc.). Pipelock falls back to this rather than silently downgrading to `parse_error` so audit fidelity is preserved. Agents should treat this as a malformed-block signal worth logging. | `warn` | `transient` |
 
+### Contract / learn-and-lock layer
+
+Emitted by the runtime evaluator when an active learn-and-lock contract claims jurisdiction over the request. The first four are real blocks; `contract_observed_only` is an info-tier annotation surfaced by shadow / capture modes when the contract path would have produced a non-allow live verdict but the configured mode does not enforce. `contract_observed_only` never appears on a 4xx response surface — it travels only on receipts and drift telemetry.
+
+| Code | When | Severity | Retry |
+|---|---|---|---|
+| `contract_default_deny` | Active contract claims jurisdiction (at least one host has an enforce rule with comparable evidence) and no allow rule matched the request. | `critical` | `none` |
+| `contract_enforce_default` | Active contract has an enforce rule that matched the request's host but no rule matched the full method / path / action shape. | `critical` | `none` |
+| `contract_non_default_port` | Active contract enforce rule matched the host but the request used a non-default port (rule scope excludes non-443 / non-80). | `warn` | `none` |
+| `contract_invalid_path` | Active contract enforce rule matched the host but the request path failed RFC 3986 canonicalization. | `warn` | `retry-with-canonical-path` |
+| `contract_observed_only` | Shadow / capture annotation: contract path would have blocked under live mode but the configured mode did not enforce. Never emitted on a block surface. | `info` | `none` |
+
 ## Severity
 
 Aligns with `internal/config/schema.go` constants:
@@ -117,6 +129,7 @@ The `info` / `warn` / `critical` values match pipelock's existing emit pipeline 
 - `none` — the block is permanent for the current request. Retrying without changing the input will produce the same block. Examples: `dlp_match`, `ssrf_private_ip`, `prompt_injection`.
 - `transient` — the underlying condition is time-bound. A retry after backoff may succeed. Examples: `rate_limit`, `airlock_active`, `kill_switch_active`, `dns_rebind` (resolver may stabilize).
 - `policy` — only retry after the operator changes pipelock policy. Examples: `domain_blocklist`, `tool_policy_deny`, `data_budget`.
+- `retry-with-canonical-path` — the input as posed will not succeed because it carries a non-canonical URL path. The agent SHOULD canonicalize the request path (RFC 3986 dot-segment removal, percent-encoding normalization) and retry; no operator change is required. Today emitted only by `contract_invalid_path`.
 
 ## Privacy
 

--- a/internal/blockreason/blockreason.go
+++ b/internal/blockreason/blockreason.go
@@ -100,6 +100,19 @@ const (
 	NotEnabled         Reason = "not_enabled"
 	BadRequest         Reason = "bad_request"
 
+	// Contract / learn-and-lock layer. The first four are real blocks
+	// produced by the runtime evaluator under an active contract;
+	// ContractObservedOnly is an info-tier annotation surfaced in
+	// shadow / capture modes when the live verdict would have blocked but
+	// the configured mode does not enforce. ContractObservedOnly never
+	// appears on a 4xx response surface, so it is exempt from the
+	// production-emit-site matrix gate.
+	ContractDefaultDeny    Reason = "contract_default_deny"
+	ContractEnforceDefault Reason = "contract_enforce_default"
+	ContractNonDefaultPort Reason = "contract_non_default_port"
+	ContractInvalidPath    Reason = "contract_invalid_path"
+	ContractObservedOnly   Reason = "contract_observed_only"
+
 	// BlockReasonOverflow is the dedicated sentinel CloseFramePayload uses
 	// when an Info has somehow accumulated a Reason value too long to fit
 	// the bare {block_reason: <code>} payload within RFC 6455's 123-byte
@@ -146,6 +159,11 @@ var validReasons = map[Reason]struct{}{
 	NotEnabled:             {},
 	BadRequest:             {},
 	BlockReasonOverflow:    {},
+	ContractDefaultDeny:    {},
+	ContractEnforceDefault: {},
+	ContractNonDefaultPort: {},
+	ContractInvalidPath:    {},
+	ContractObservedOnly:   {},
 }
 
 // AllReasons returns every Reason in the canonical allowlist. The returned
@@ -186,12 +204,20 @@ const (
 	// RetryPolicy means the agent should only retry after an operator
 	// changes pipelock policy.
 	RetryPolicy Retry = "policy"
+	// RetryCanonicalize means the request as posed will not succeed because
+	// it carries a non-canonical input (today: a URL path that fails RFC 3986
+	// canonicalization). The agent SHOULD canonicalize the request and retry;
+	// no operator change is required. The wire value mirrors the spec hint
+	// "retry-with-canonical-path" so consumers see actionable guidance in
+	// X-Pipelock-Block-Reason-Retry instead of a generic "none".
+	RetryCanonicalize Retry = "retry-with-canonical-path"
 )
 
 var validRetries = map[Retry]struct{}{
-	RetryNone:      {},
-	RetryTransient: {},
-	RetryPolicy:    {},
+	RetryNone:         {},
+	RetryTransient:    {},
+	RetryPolicy:       {},
+	RetryCanonicalize: {},
 }
 
 // Construction errors. Use errors.Is to pattern-match.
@@ -433,7 +459,7 @@ func mustMarshal(p closeFramePayload) string {
 // the operator gets the strictest severity until the table is updated).
 func SeverityFor(reason Reason) Severity {
 	switch reason {
-	case NotEnabled, BadRequest:
+	case NotEnabled, BadRequest, ContractObservedOnly:
 		return SeverityInfo
 	case SchemeBlocked,
 		PathEntropy,
@@ -447,7 +473,9 @@ func SeverityFor(reason Reason) Severity {
 		PatternUnavailable,
 		CompressedResponse,
 		BrowserShieldOversize,
-		BlockReasonOverflow:
+		BlockReasonOverflow,
+		ContractNonDefaultPort,
+		ContractInvalidPath:
 		return SeverityWarn
 	default:
 		return SeverityCritical
@@ -485,6 +513,8 @@ func RetryFor(reason Reason) Retry {
 		CompressedResponse,
 		BrowserShieldOversize:
 		return RetryPolicy
+	case ContractInvalidPath:
+		return RetryCanonicalize
 	default:
 		return RetryNone
 	}

--- a/internal/blockreason/blockreason_test.go
+++ b/internal/blockreason/blockreason_test.go
@@ -496,6 +496,13 @@ var specCanonicalPairs = map[Reason]struct {
 
 	// Internal sentinel.
 	BlockReasonOverflow: {SeverityWarn, RetryTransient},
+
+	// Contract / learn-and-lock layer.
+	ContractDefaultDeny:    {SeverityCritical, RetryNone},
+	ContractEnforceDefault: {SeverityCritical, RetryNone},
+	ContractNonDefaultPort: {SeverityWarn, RetryNone},
+	ContractInvalidPath:    {SeverityWarn, RetryCanonicalize},
+	ContractObservedOnly:   {SeverityInfo, RetryNone},
 }
 
 // TestSpecCanonicalPairs_VocabularyCoverage asserts the test ground-truth

--- a/internal/blockreason/production_path_matrix_test.go
+++ b/internal/blockreason/production_path_matrix_test.go
@@ -93,6 +93,42 @@ var nonProductionEmitReasons = map[blockreason.Reason]string{
 	// error in the MCP response stream, with no HTTP response to attach a
 	// header to. Reason vocabulary kept for receipt + audit consistency.
 	blockreason.ToolChainBlocked: "fires at JSON-RPC layer in MCP response stream; no HTTP header surface",
+
+	// ContractObservedOnly is an info-tier annotation that the runtime
+	// evaluator surfaces in shadow / capture modes when the contract path
+	// would have produced a non-allow live verdict but the configured mode
+	// did not enforce. The annotation is for audit and drift telemetry
+	// (Decision.Reason + receipt.live_verdict); it never appears on a 4xx
+	// HTTP response surface. Reason vocabulary stays in the canonical
+	// allowlist so receipts and dashboards can label observation events
+	// alongside real blocks without forking into observed-vs-blocking.
+	blockreason.ContractObservedOnly: "shadow/capture mode annotation; never emitted on a block path",
+
+	// SSRFDNSRebind is part of the SSRF reason set on the wire, but the
+	// scanner pipeline currently emits SSRFPrivateIP / SSRFMetadata from
+	// the DNS rebinding TOCTOU path because the rebind detection lives
+	// upstream of the blockheaders helper that maps to the typed Reason.
+	// Vocabulary stays in the canonical allowlist so receipts and the
+	// public spec doc can name DNS rebinding distinctly from generic
+	// private-IP SSRF; the wire emit site lands when the SSRF block path
+	// is refactored to surface the more specific reason.
+	blockreason.SSRFDNSRebind: "vocabulary placeholder; SSRF block path collapses TOCTOU rebinds onto SSRFPrivateIP today",
+
+	// Timeout is reserved for fail-closed timeouts on scanner / HITL
+	// surfaces. Today the timeout paths return ParseError or do not
+	// surface a header at all (HITL has no HTTP response surface). The
+	// reason stays in the canonical allowlist so the spec doc can
+	// describe it once a transport wires the dedicated emit site.
+	blockreason.Timeout: "vocabulary placeholder; timeout block paths today return ParseError or have no HTTP surface",
+
+	// ToolPolicyDeny and SessionBinding are MCP-layer reasons. The MCP
+	// proxy emits its block as a JSON-RPC error in the response stream,
+	// not as an HTTP response — same shape as ToolPoisoning and
+	// ToolChainBlocked. Reason vocabulary kept for receipt + audit
+	// consistency once the MCP receipt stream wires these specific
+	// labels.
+	blockreason.ToolPolicyDeny: "fires at JSON-RPC layer in MCP response stream; no HTTP header surface",
+	blockreason.SessionBinding: "fires at JSON-RPC layer in MCP response stream; no HTTP header surface",
 }
 
 // constNameForReason maps a Reason value to the exported constant name in the
@@ -170,6 +206,16 @@ func constNameForReason(r blockreason.Reason) string {
 		return "BadRequest"
 	case blockreason.BlockReasonOverflow:
 		return "BlockReasonOverflow"
+	case blockreason.ContractDefaultDeny:
+		return "ContractDefaultDeny"
+	case blockreason.ContractEnforceDefault:
+		return "ContractEnforceDefault"
+	case blockreason.ContractNonDefaultPort:
+		return "ContractNonDefaultPort"
+	case blockreason.ContractInvalidPath:
+		return "ContractInvalidPath"
+	case blockreason.ContractObservedOnly:
+		return "ContractObservedOnly"
 	}
 	return ""
 }

--- a/internal/contract/receipt/payload.go
+++ b/internal/contract/receipt/payload.go
@@ -4,10 +4,20 @@
 package receipt
 
 // PayloadProxyDecisionStruct holds the typed fields for a proxy_decision payload.
+//
+// Verdict is what the proxy enforced for this request. LiveVerdict is what
+// the contract evaluator would have enforced under ModeLive given the same
+// inputs: in ModeLive the two are equal, but ModeShadow / ModeCapture surface
+// the scanner-floor verdict as Verdict and the contract's would-have-been
+// outcome as LiveVerdict so audit consumers can distinguish "scanner allowed
+// and contract agreed" from "scanner allowed but contract would have blocked
+// in live mode." LiveVerdict is omitempty for legacy emissions and for paths
+// where the runtime did not surface a separate live result.
 type PayloadProxyDecisionStruct struct {
 	ActionType    string   `json:"action_type"`
 	Target        string   `json:"target"`
 	Verdict       string   `json:"verdict"`
+	LiveVerdict   string   `json:"live_verdict,omitempty"`
 	Transport     string   `json:"transport"`
 	PolicySources []string `json:"policy_sources"`
 	WinningSource string   `json:"winning_source"`

--- a/internal/contract/runtime/blockreason.go
+++ b/internal/contract/runtime/blockreason.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import "github.com/luckyPipewrench/pipelock/internal/blockreason"
+
+// Decision.Reason values produced by EvaluateHTTP / evaluateContractLive /
+// applyModeGate. Kept private to the runtime package because the canonical
+// vocabulary on the wire is blockreason.Reason; these strings are the
+// untyped intermediate the evaluator uses when assembling a Decision.
+const (
+	decisionReasonKillSwitchActive       = "kill_switch_active"
+	decisionReasonScannerDecisionMissing = "scanner_decision_missing"
+	decisionReasonContractDefaultDeny    = "contract_default_deny"
+	decisionReasonContractEnforceDefault = "contract_enforce_default"
+	decisionReasonContractNonDefaultPort = "contract_non_default_port"
+	decisionReasonContractInvalidPath    = "contract_invalid_path"
+	decisionReasonContractObservedOnly   = "contract_observed_only"
+)
+
+// BlockReasonForDecision maps a Decision.Reason string to its canonical
+// blockreason.Reason on the wire, returning ok=false when the input has no
+// canonical typed value. Transport call sites use this helper to emit
+// X-Pipelock-Block-Reason headers and to populate receipt metadata without
+// each transport hard-coding the string-to-reason table.
+//
+// The helper is declarative: it does not consult any runtime state. Empty
+// input returns ok=false rather than a zero blockreason.Reason so callers
+// can distinguish "no contract reason set" from a real but unknown reason
+// and pick a sensible fallback (typically blockreason.ParseError or
+// blockreason.NotEnabled depending on the call site).
+//
+// The block-reason vocabulary is locked at v1; new typed reasons require
+// updates in three places — internal/blockreason/blockreason.go (the
+// vocabulary itself), this mapping, and the production-path matrix gate.
+func BlockReasonForDecision(decisionReason string) (blockreason.Reason, bool) {
+	switch decisionReason {
+	case decisionReasonContractDefaultDeny:
+		return blockreason.ContractDefaultDeny, true
+	case decisionReasonContractEnforceDefault:
+		return blockreason.ContractEnforceDefault, true
+	case decisionReasonContractNonDefaultPort:
+		return blockreason.ContractNonDefaultPort, true
+	case decisionReasonContractInvalidPath:
+		return blockreason.ContractInvalidPath, true
+	case decisionReasonContractObservedOnly:
+		return blockreason.ContractObservedOnly, true
+	case decisionReasonKillSwitchActive:
+		return blockreason.KillSwitchActive, true
+	case decisionReasonScannerDecisionMissing:
+		// Scanner is missing a verdict — fail-closed input, surface as
+		// parse_error so the agent reads "your input could not be
+		// classified" rather than the more specific kill-switch or
+		// contract codes that imply jurisdictional enforcement.
+		return blockreason.ParseError, true
+	default:
+		return "", false
+	}
+}

--- a/internal/contract/runtime/blockreason_test.go
+++ b/internal/contract/runtime/blockreason_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+)
+
+// TestBlockReasonForDecision_AllSupportedStrings asserts that every Decision
+// reason string the runtime emits has a typed blockreason.Reason mapping.
+// New decision reason strings added to the evaluator MUST land here in the
+// same change so transport call sites can look up the wire-canonical reason
+// without inventing a string-to-reason table per transport.
+func TestBlockReasonForDecision_AllSupportedStrings(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name           string
+		decisionReason string
+		want           blockreason.Reason
+	}{
+		{"contract default deny", decisionReasonContractDefaultDeny, blockreason.ContractDefaultDeny},
+		{"contract enforce default", decisionReasonContractEnforceDefault, blockreason.ContractEnforceDefault},
+		{"contract non default port", decisionReasonContractNonDefaultPort, blockreason.ContractNonDefaultPort},
+		{"contract invalid path", decisionReasonContractInvalidPath, blockreason.ContractInvalidPath},
+		{"contract observed only", decisionReasonContractObservedOnly, blockreason.ContractObservedOnly},
+		{"kill switch active", decisionReasonKillSwitchActive, blockreason.KillSwitchActive},
+		{"scanner decision missing", decisionReasonScannerDecisionMissing, blockreason.ParseError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := BlockReasonForDecision(tc.decisionReason)
+			if !ok {
+				t.Fatalf("BlockReasonForDecision(%q): ok=false, want true", tc.decisionReason)
+			}
+			if got != tc.want {
+				t.Fatalf("BlockReasonForDecision(%q) = %q, want %q", tc.decisionReason, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBlockReasonForDecision_EmptyAndUnknownReturnFalse confirms the helper
+// does not surface a false positive for empty input (the common case when a
+// Decision carries no Reason annotation) or for an unknown string (which
+// could be an evaluator string the helper has not been updated for; the
+// caller must select a fallback reason explicitly).
+func TestBlockReasonForDecision_EmptyAndUnknownReturnFalse(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"empty", ""},
+		{"unknown decision string", "made_up_reason"},
+		{"close-but-not-equal", "contract_default"},
+		{"trailing whitespace", "contract_default_deny "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := BlockReasonForDecision(tc.in)
+			if ok {
+				t.Fatalf("BlockReasonForDecision(%q): ok=true, want false (got %q)", tc.in, got)
+			}
+			if got != "" {
+				t.Fatalf("BlockReasonForDecision(%q): got %q, want empty", tc.in, got)
+			}
+		})
+	}
+}
+
+// TestBlockReasonForDecision_RuntimeStringsMatchPrivateConstants is the
+// regression gate against a runtime evaluator change that updates an emitted
+// Decision.Reason string but forgets the matching update in
+// blockreason.go's mapping. It pins the exact wire strings the evaluator
+// uses today so a drift between runtime.go and blockreason.go fails fast
+// here instead of silently producing receipts with a missing Reason.
+func TestBlockReasonForDecision_RuntimeStringsMatchPrivateConstants(t *testing.T) {
+	t.Parallel()
+	pairs := map[string]string{
+		"kill_switch_active":        decisionReasonKillSwitchActive,
+		"scanner_decision_missing":  decisionReasonScannerDecisionMissing,
+		"contract_default_deny":     decisionReasonContractDefaultDeny,
+		"contract_enforce_default":  decisionReasonContractEnforceDefault,
+		"contract_non_default_port": decisionReasonContractNonDefaultPort,
+		"contract_invalid_path":     decisionReasonContractInvalidPath,
+		"contract_observed_only":    decisionReasonContractObservedOnly,
+	}
+	for wire, constant := range pairs {
+		if wire != constant {
+			t.Fatalf("private constant for %q drifted to %q (update runtime.go and blockreason.go together)", wire, constant)
+		}
+	}
+}

--- a/internal/contract/runtime/receipt.go
+++ b/internal/contract/runtime/receipt.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+)
+
+// ErrInvalidProxyDecisionInput is returned when BuildProxyDecisionReceipt is
+// called with input that would fail PayloadProxyDecisionStruct validation.
+// Callers MUST treat it as a programming bug — the input fields come from
+// pipelock's own evaluator and proxy chain, not from agent-controlled data,
+// so a missing field means the call site forgot to populate the input.
+var ErrInvalidProxyDecisionInput = errors.New("contract runtime: invalid proxy_decision receipt input")
+
+// ProxyDecisionInput aggregates the fields needed to assemble a v2
+// proxy_decision EvidenceReceipt body. The builder is pure: it does not
+// consult runtime state and does not sign. Transport call sites populate
+// this struct, hand the result to the receipt signer, and write the signed
+// envelope to the flight recorder.
+type ProxyDecisionInput struct {
+	// Decision is the runtime verdict for this request. Decision.Verdict,
+	// Decision.PolicySources, Decision.WinningSource, Decision.RuleID,
+	// and Decision.LiveVerdict shape the typed payload.
+	Decision Decision
+
+	// ResolvedContract is the per-session contract pin. Optional: leave nil
+	// when the request had no contract pin (no active manifest, observation
+	// path, no resolved selector). When set, the builder stamps the
+	// receipt's active_manifest_hash, contract_hash, selector_id, and
+	// contract_generation fields from ReceiptContext.
+	ResolvedContract *ResolvedContract
+
+	// ActionType labels the action class. Examples: "http_request",
+	// "mcp_tool_call", "websocket_frame". Must be non-empty.
+	ActionType string
+
+	// Target identifies what was acted upon. URL for HTTP, fully qualified
+	// tool name for MCP, peer URL for WebSocket. Must be non-empty.
+	Target string
+
+	// Transport identifies the surface that produced this decision.
+	// Examples: "forward", "intercept", "mcp_http", "mcp_stdio",
+	// "websocket". Must be non-empty.
+	Transport string
+
+	// Identity fields are optional at build time; the receipt signer or
+	// flight recorder fills them before signing. Leaving them zero is
+	// allowed because the signer's outer Validate() catches a missing
+	// EventID / Timestamp anyway, and forcing the builder to require them
+	// here would couple the builder to clock and ID generation.
+	EventID         string
+	Timestamp       time.Time
+	Principal       string
+	Actor           string
+	DelegationChain []string
+
+	// Chain fields are filled by the flight recorder when sequencing the
+	// receipt into the per-session log. The builder accepts whatever the
+	// caller passes; leaving them zero is the common case for fresh
+	// receipts that have not yet been chained.
+	ChainSeq      uint64
+	ChainPrevHash string
+}
+
+// BuildProxyDecisionReceipt turns a runtime Decision plus transport metadata
+// into an unsigned EvidenceReceipt v2 envelope ready for the receipt signer.
+//
+// The builder validates that the typed payload fields the v2 registry will
+// require are present (action_type, target, verdict, transport,
+// policy_sources, winning_source) before constructing the envelope, so an
+// invalid input fails fast at build time instead of later at Validate()
+// time on a partly-constructed receipt.
+//
+// Verdict / LiveVerdict semantics: ProxyDecisionPayload omits LiveVerdict
+// from the wire payload when it equals Verdict (the ModeLive case). When
+// the runtime ran in ModeShadow or ModeCapture and the contract path
+// produced a different live verdict than the scanner-floor verdict the
+// proxy actually applied, LiveVerdict surfaces the divergence so audit
+// consumers can reason about what live mode would have done.
+//
+// Signing is the caller's responsibility — the builder leaves
+// receipt.Signature zero. The caller hands the unsigned envelope to the
+// receipt signer (which knows the active key, key purpose, and chain
+// position) and writes the signed result to the flight recorder.
+func BuildProxyDecisionReceipt(in ProxyDecisionInput) (contractreceipt.EvidenceReceipt, error) {
+	payload := ProxyDecisionPayload(in.Decision, in.ActionType, in.Target, in.Transport)
+	if err := validateProxyDecisionFields(payload); err != nil {
+		return contractreceipt.EvidenceReceipt{}, err
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		// PayloadProxyDecisionStruct is a closed shape of strings and
+		// []string; json.Marshal cannot fail on a valid value. Wrap the
+		// error anyway so a future refactor that adds a non-marshalable
+		// field surfaces here instead of producing a silently empty
+		// payload.
+		return contractreceipt.EvidenceReceipt{}, fmt.Errorf("%w: marshal payload: %w", ErrInvalidProxyDecisionInput, err)
+	}
+
+	receipt := contractreceipt.EvidenceReceipt{
+		RecordType:      contractreceipt.RecordTypeEvidenceV2,
+		ReceiptVersion:  2,
+		PayloadKind:     contractreceipt.PayloadProxyDecision,
+		EventID:         in.EventID,
+		Timestamp:       in.Timestamp,
+		Principal:       in.Principal,
+		Actor:           in.Actor,
+		DelegationChain: append([]string(nil), in.DelegationChain...),
+		ChainSeq:        in.ChainSeq,
+		ChainPrevHash:   in.ChainPrevHash,
+		Payload:         json.RawMessage(body),
+	}
+	if in.ResolvedContract != nil {
+		receipt = in.ResolvedContract.ReceiptContext().StampReceipt(receipt)
+	}
+	return receipt, nil
+}
+
+// validateProxyDecisionFields mirrors validateProxyDecision in the receipt
+// registry: the v2 dispatcher rejects a payload missing any of these fields
+// with ErrPayloadMissingField. Validating up front turns the failure into
+// an early build-time error instead of a delayed Validate() failure on a
+// partially-constructed envelope.
+func validateProxyDecisionFields(p contractreceipt.PayloadProxyDecisionStruct) error {
+	if p.ActionType == "" {
+		return fmt.Errorf("%w: action_type", ErrInvalidProxyDecisionInput)
+	}
+	if p.Target == "" {
+		return fmt.Errorf("%w: target", ErrInvalidProxyDecisionInput)
+	}
+	if p.Verdict == "" {
+		return fmt.Errorf("%w: verdict", ErrInvalidProxyDecisionInput)
+	}
+	if p.Transport == "" {
+		return fmt.Errorf("%w: transport", ErrInvalidProxyDecisionInput)
+	}
+	if len(p.PolicySources) == 0 {
+		return fmt.Errorf("%w: policy_sources", ErrInvalidProxyDecisionInput)
+	}
+	if p.WinningSource == "" {
+		return fmt.Errorf("%w: winning_source", ErrInvalidProxyDecisionInput)
+	}
+	return nil
+}

--- a/internal/contract/runtime/receipt_test.go
+++ b/internal/contract/runtime/receipt_test.go
@@ -1,0 +1,368 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+)
+
+// validReceiptSignaturePlaceholder is a structurally-valid Ed25519 signature
+// (correct length and hex prefix) used to exercise EvidenceReceipt.Validate
+// without actually signing anything in builder tests. The builder itself
+// leaves Signature zero; tests that need to walk the validator simply paint
+// in a placeholder before calling Validate.
+const validReceiptSignaturePlaceholder = "ed25519:" +
+	"0000000000000000000000000000000000000000000000000000000000000000" +
+	"0000000000000000000000000000000000000000000000000000000000000000"
+
+// tamperedSentinel is the post-build mutation marker used by the slice
+// isolation tests. Extracted as a const so goconst stays quiet across the
+// DelegationChain and PolicySources isolation cases.
+const tamperedSentinel = "tampered"
+
+func resolvedContractFixture() *ResolvedContract {
+	return &ResolvedContract{
+		ActiveManifestHash: "sha256:manifest-1",
+		ContractHash:       "sha256:contract-1",
+		SelectorID:         "selector-1",
+		ContractGeneration: 7,
+		Contract:           contract.Contract{},
+	}
+}
+
+// TestBuildProxyDecisionReceipt_ContractAllowHappyPath covers the live-mode
+// allow path: a Decision produced with WinningSource=contract, Verdict=allow,
+// LiveVerdict=allow. Verdict and LiveVerdict are equal, so the wire payload
+// omits LiveVerdict (compact ModeLive emission). All four ResolvedContract
+// context fields stamp onto the envelope, and the decoded payload validates
+// against the v2 registry.
+func TestBuildProxyDecisionReceipt_ContractAllowHappyPath(t *testing.T) {
+	t.Parallel()
+	rc := resolvedContractFixture()
+	in := ProxyDecisionInput{
+		Decision: Decision{
+			Verdict:       config.ActionAllow,
+			LiveVerdict:   config.ActionAllow,
+			PolicySources: []string{PolicySourceScanner, PolicySourceContract},
+			WinningSource: WinningSourceContract,
+			RuleID:        "rule-allow-1",
+		},
+		ResolvedContract: rc,
+		ActionType:       "http_request",
+		Target:           "https://api.example.com/v1/users",
+		Transport:        "forward",
+		EventID:          "01900000-0000-7000-8000-000000000001",
+		Timestamp:        time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC),
+	}
+	got, err := BuildProxyDecisionReceipt(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.RecordType != contractreceipt.RecordTypeEvidenceV2 {
+		t.Fatalf("RecordType = %q, want evidence_receipt_v2", got.RecordType)
+	}
+	if got.ReceiptVersion != 2 {
+		t.Fatalf("ReceiptVersion = %d, want 2", got.ReceiptVersion)
+	}
+	if got.PayloadKind != contractreceipt.PayloadProxyDecision {
+		t.Fatalf("PayloadKind = %q, want proxy_decision", got.PayloadKind)
+	}
+	if got.ActiveManifestHash != rc.ActiveManifestHash {
+		t.Fatalf("ActiveManifestHash = %q, want %q", got.ActiveManifestHash, rc.ActiveManifestHash)
+	}
+	if got.ContractHash != rc.ContractHash {
+		t.Fatalf("ContractHash = %q, want %q", got.ContractHash, rc.ContractHash)
+	}
+	if got.SelectorID != rc.SelectorID {
+		t.Fatalf("SelectorID = %q, want %q", got.SelectorID, rc.SelectorID)
+	}
+	if got.ContractGeneration != rc.ContractGeneration {
+		t.Fatalf("ContractGeneration = %d, want %d", got.ContractGeneration, rc.ContractGeneration)
+	}
+
+	var payload contractreceipt.PayloadProxyDecisionStruct
+	if err := json.Unmarshal(got.Payload, &payload); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if payload.Verdict != config.ActionAllow {
+		t.Fatalf("payload.Verdict = %q, want allow", payload.Verdict)
+	}
+	if payload.LiveVerdict != "" {
+		t.Fatalf("payload.LiveVerdict = %q, want empty (Verdict == LiveVerdict)", payload.LiveVerdict)
+	}
+	if payload.WinningSource != WinningSourceContract {
+		t.Fatalf("payload.WinningSource = %q, want %q", payload.WinningSource, WinningSourceContract)
+	}
+	if payload.RuleID != "rule-allow-1" {
+		t.Fatalf("payload.RuleID = %q, want rule-allow-1", payload.RuleID)
+	}
+
+	// The payload must validate against the registry dispatcher.
+	got.Signature = contractreceipt.SignatureProof{
+		SignerKeyID: "receipt-key-1",
+		KeyPurpose:  "receipt-signing",
+		Algorithm:   "ed25519",
+		Signature:   validReceiptSignaturePlaceholder,
+	}
+	if err := got.Validate(); err != nil {
+		t.Fatalf("Validate on built receipt: %v", err)
+	}
+}
+
+// TestBuildProxyDecisionReceipt_ShadowModeSurfacesLiveVerdict is the
+// load-bearing audit-trail test. ModeShadow / ModeCapture surfaces the
+// scanner-floor verdict as Verdict (so the proxy never blocks more than
+// scanner already would) and the contract's would-have-been outcome as
+// LiveVerdict, so a downstream auditor reading the receipt can see
+// "scanner allowed; contract would have blocked in live mode" without
+// having to reconstruct evaluator state. The shadow path is where this
+// payload field earns its keep.
+func TestBuildProxyDecisionReceipt_ShadowModeSurfacesLiveVerdict(t *testing.T) {
+	t.Parallel()
+	rc := resolvedContractFixture()
+	in := ProxyDecisionInput{
+		Decision: Decision{
+			Verdict:       config.ActionAllow, // scanner-floor verdict (shadow proxies allow)
+			LiveVerdict:   config.ActionBlock, // contract would have blocked
+			PolicySources: []string{PolicySourceScanner, PolicySourceContract},
+			WinningSource: WinningSourceScanner,
+			Reason:        decisionReasonContractObservedOnly,
+			RuleID:        "rule-block-1",
+			Drift:         &DriftEvent{ContractHash: rc.ContractHash, RuleID: "rule-block-1", Kind: DriftKindPositive, Mode: ModeShadow, Action: config.ActionBlock},
+		},
+		ResolvedContract: rc,
+		ActionType:       "http_request",
+		Target:           "https://api.example.com/v1/admin",
+		Transport:        "forward",
+		EventID:          "01900000-0000-7000-8000-000000000002",
+		Timestamp:        time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC),
+	}
+	got, err := BuildProxyDecisionReceipt(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload contractreceipt.PayloadProxyDecisionStruct
+	if err := json.Unmarshal(got.Payload, &payload); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if payload.Verdict != config.ActionAllow {
+		t.Fatalf("payload.Verdict = %q, want %q (scanner-floor enforced)", payload.Verdict, config.ActionAllow)
+	}
+	if payload.LiveVerdict != config.ActionBlock {
+		t.Fatalf("payload.LiveVerdict = %q, want %q (contract would-have-been)", payload.LiveVerdict, config.ActionBlock)
+	}
+	if payload.WinningSource != WinningSourceScanner {
+		t.Fatalf("payload.WinningSource = %q, want %q (shadow mode wins is scanner)", payload.WinningSource, WinningSourceScanner)
+	}
+	// Contract context still stamps even though Verdict came from scanner —
+	// the contract pin was active, the audit trail must record which contract
+	// would-have-been, otherwise drift telemetry cannot attribute the delta.
+	if got.ContractHash != rc.ContractHash {
+		t.Fatalf("ContractHash dropped under shadow mode: got %q want %q", got.ContractHash, rc.ContractHash)
+	}
+	if got.SelectorID != rc.SelectorID {
+		t.Fatalf("SelectorID dropped under shadow mode: got %q want %q", got.SelectorID, rc.SelectorID)
+	}
+}
+
+// TestBuildProxyDecisionReceipt_NoContractPin covers the no-contract path:
+// a request handled outside any contract's jurisdiction. The receipt body
+// builds correctly with empty contract context fields and no rule ID.
+func TestBuildProxyDecisionReceipt_NoContractPin(t *testing.T) {
+	t.Parallel()
+	in := ProxyDecisionInput{
+		Decision: Decision{
+			Verdict:       config.ActionBlock,
+			LiveVerdict:   config.ActionBlock,
+			PolicySources: []string{PolicySourceScanner},
+			WinningSource: WinningSourceScanner,
+		},
+		ResolvedContract: nil,
+		ActionType:       "http_request",
+		Target:           "https://malicious.example.com/",
+		Transport:        "forward",
+	}
+	got, err := BuildProxyDecisionReceipt(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ActiveManifestHash != "" {
+		t.Fatalf("ActiveManifestHash = %q, want empty (no pin)", got.ActiveManifestHash)
+	}
+	if got.ContractHash != "" {
+		t.Fatalf("ContractHash = %q, want empty (no pin)", got.ContractHash)
+	}
+	if got.ContractGeneration != 0 {
+		t.Fatalf("ContractGeneration = %d, want 0 (no pin)", got.ContractGeneration)
+	}
+}
+
+// TestBuildProxyDecisionReceipt_ValidationErrors exercises the upfront
+// payload-field check that mirrors the registry's validateProxyDecision.
+// Each missing required field returns a wrapped ErrInvalidProxyDecisionInput
+// before the envelope is assembled, so callers see the failure at the call
+// site instead of during a later receipt.Validate() pass.
+func TestBuildProxyDecisionReceipt_ValidationErrors(t *testing.T) {
+	t.Parallel()
+	good := ProxyDecisionInput{
+		Decision: Decision{
+			Verdict:       config.ActionBlock,
+			PolicySources: []string{PolicySourceScanner},
+			WinningSource: WinningSourceScanner,
+		},
+		ActionType: "http_request",
+		Target:     "https://example.com/",
+		Transport:  "forward",
+	}
+	cases := []struct {
+		name   string
+		mutate func(*ProxyDecisionInput)
+		want   string
+	}{
+		{
+			name:   "missing action_type",
+			mutate: func(in *ProxyDecisionInput) { in.ActionType = "" },
+			want:   "action_type",
+		},
+		{
+			name:   "missing target",
+			mutate: func(in *ProxyDecisionInput) { in.Target = "" },
+			want:   "target",
+		},
+		{
+			name:   "missing transport",
+			mutate: func(in *ProxyDecisionInput) { in.Transport = "" },
+			want:   "transport",
+		},
+		{
+			name:   "missing verdict",
+			mutate: func(in *ProxyDecisionInput) { in.Decision.Verdict = "" },
+			want:   "verdict",
+		},
+		{
+			name:   "missing policy sources",
+			mutate: func(in *ProxyDecisionInput) { in.Decision.PolicySources = nil },
+			want:   "policy_sources",
+		},
+		{
+			name:   "missing winning source",
+			mutate: func(in *ProxyDecisionInput) { in.Decision.WinningSource = "" },
+			want:   "winning_source",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := good
+			tc.mutate(&in)
+			_, err := BuildProxyDecisionReceipt(in)
+			if !errors.Is(err, ErrInvalidProxyDecisionInput) {
+				t.Fatalf("err = %v, want wrap of ErrInvalidProxyDecisionInput", err)
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want it to mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildProxyDecisionReceipt_DelegationChainIsolation guards against the
+// classic shared-slice bug: input mutates after the builder returns and the
+// receipt's DelegationChain reflects the mutation. The builder copies the
+// slice so the output is an independent snapshot.
+func TestBuildProxyDecisionReceipt_DelegationChainIsolation(t *testing.T) {
+	t.Parallel()
+	chain := []string{"agent-a", "agent-b"}
+	in := ProxyDecisionInput{
+		Decision: Decision{
+			Verdict:       config.ActionAllow,
+			LiveVerdict:   config.ActionAllow,
+			PolicySources: []string{PolicySourceScanner},
+			WinningSource: WinningSourceScanner,
+		},
+		ActionType:      "http_request",
+		Target:          "https://example.com/",
+		Transport:       "forward",
+		DelegationChain: chain,
+	}
+	got, err := BuildProxyDecisionReceipt(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	chain[0] = tamperedSentinel
+	if got.DelegationChain[0] == tamperedSentinel {
+		t.Fatalf("DelegationChain shares backing array with input — builder must copy")
+	}
+}
+
+// TestBuildProxyDecisionReceipt_PolicySourcesIsolation parallels the
+// DelegationChain isolation test for the other slice the builder accepts.
+// ProxyDecisionPayload makes the defensive copy today (decision.PolicySources
+// flows through append([]string(nil), ...)); pinning the contract here means
+// a future refactor that bypasses ProxyDecisionPayload still has to keep the
+// snapshot semantics or the test fails.
+func TestBuildProxyDecisionReceipt_PolicySourcesIsolation(t *testing.T) {
+	t.Parallel()
+	sources := []string{PolicySourceScanner, PolicySourceContract}
+	in := ProxyDecisionInput{
+		Decision: Decision{
+			Verdict:       config.ActionAllow,
+			LiveVerdict:   config.ActionAllow,
+			PolicySources: sources,
+			WinningSource: WinningSourceScanner,
+		},
+		ActionType: "http_request",
+		Target:     "https://example.com/",
+		Transport:  "forward",
+	}
+	got, err := BuildProxyDecisionReceipt(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sources[0] = tamperedSentinel
+
+	var payload contractreceipt.PayloadProxyDecisionStruct
+	if err := json.Unmarshal(got.Payload, &payload); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if payload.PolicySources[0] == tamperedSentinel {
+		t.Fatalf("payload.PolicySources shares backing array with input — builder must copy")
+	}
+}
+
+// TestBuildProxyDecisionReceipt_LeavesSignatureZero pins the responsibility
+// boundary: BuildProxyDecisionReceipt produces an UNSIGNED envelope. The
+// receipt signer downstream is the only component that sets Signature.
+// Asserting zero here documents that contract and prevents a future
+// refactor from accidentally signing inside the builder (which would
+// require coupling the builder to a key roster).
+func TestBuildProxyDecisionReceipt_LeavesSignatureZero(t *testing.T) {
+	t.Parallel()
+	in := ProxyDecisionInput{
+		Decision: Decision{
+			Verdict:       config.ActionAllow,
+			LiveVerdict:   config.ActionAllow,
+			PolicySources: []string{PolicySourceScanner},
+			WinningSource: WinningSourceScanner,
+		},
+		ActionType: "http_request",
+		Target:     "https://example.com/",
+		Transport:  "forward",
+	}
+	got, err := BuildProxyDecisionReceipt(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Signature != (contractreceipt.SignatureProof{}) {
+		t.Fatalf("Signature = %+v, want zero (signer fills it in)", got.Signature)
+	}
+}

--- a/internal/contract/runtime/runtime.go
+++ b/internal/contract/runtime/runtime.go
@@ -339,7 +339,7 @@ func EvaluateHTTP(opts EvaluateOptions) (Decision, error) {
 			PolicySources: sources,
 			WinningSource: WinningSourceKillSwitch,
 			Suppressed:    true,
-			Reason:        "kill_switch_active",
+			Reason:        decisionReasonKillSwitchActive,
 		}, nil
 	}
 
@@ -362,7 +362,7 @@ func EvaluateHTTP(opts EvaluateOptions) (Decision, error) {
 			WinningSource: WinningSourceScanner,
 		}
 		if scannerMissing {
-			decision.Reason = "scanner_decision_missing"
+			decision.Reason = decisionReasonScannerDecisionMissing
 		}
 		return decision, nil
 	}
@@ -422,11 +422,11 @@ func evaluateContractLive(opts EvaluateOptions, sources []string, scannerVerdict
 		hostHasEnforceRule = true
 		hostRuleIDs = appendRuleID(hostRuleIDs, seenRuleIDs, rule.RuleID)
 		if !usesDefaultHTTPPort(u) {
-			return contractBlockDecision(opts, sources, rule.RuleID, "contract_non_default_port"), nil
+			return contractBlockDecision(opts, sources, rule.RuleID, decisionReasonContractNonDefaultPort), nil
 		}
 		matches, canCompare, invalidPath := ruleMatchesHTTP(rule, u, opts.Request)
 		if invalidPath {
-			return contractBlockDecision(opts, sources, rule.RuleID, "contract_invalid_path"), nil
+			return contractBlockDecision(opts, sources, rule.RuleID, decisionReasonContractInvalidPath), nil
 		}
 		if !canCompare {
 			continue
@@ -459,10 +459,10 @@ func evaluateContractLive(opts EvaluateOptions, sources []string, scannerVerdict
 		}, nil
 	}
 
-	reason := "contract_default_deny"
+	reason := decisionReasonContractDefaultDeny
 	ruleID := ""
 	if hostHasEnforceRule && hasComparableEvidence {
-		reason = "contract_enforce_default"
+		reason = decisionReasonContractEnforceDefault
 		ruleID = firstString(hostRuleIDs)
 	}
 	return contractBlockDecision(opts, sources, ruleID, reason), nil
@@ -487,8 +487,8 @@ func applyModeGate(live Decision, mode Mode, scannerVerdict string, sources []st
 		RuleID:        live.RuleID,
 		Drift:         live.Drift,
 	}
-	if live.WinningSource == WinningSourceContract {
-		out.Reason = "contract_observed_only"
+	if live.WinningSource == WinningSourceContract && live.Verdict != scannerVerdict {
+		out.Reason = decisionReasonContractObservedOnly
 	}
 	return out
 }

--- a/internal/contract/runtime/runtime.go
+++ b/internal/contract/runtime/runtime.go
@@ -704,11 +704,22 @@ func appendPolicySource(values []string, source string) []string {
 
 // ProxyDecisionPayload builds the typed EvidenceReceipt v2 proxy_decision
 // payload from a runtime decision.
+//
+// LiveVerdict is omitted from the wire payload when it equals Verdict (the
+// ModeLive case) so receipts stay compact for the common path. ModeShadow
+// and ModeCapture surface the divergence by setting LiveVerdict to what
+// the contract path would have enforced under ModeLive while Verdict
+// reflects the scanner-floor result the proxy actually applied.
 func ProxyDecisionPayload(decision Decision, actionType, target, transport string) contractreceipt.PayloadProxyDecisionStruct {
+	live := decision.LiveVerdict
+	if live == decision.Verdict {
+		live = ""
+	}
 	return contractreceipt.PayloadProxyDecisionStruct{
 		ActionType:    actionType,
 		Target:        target,
 		Verdict:       decision.Verdict,
+		LiveVerdict:   live,
 		Transport:     transport,
 		PolicySources: append([]string(nil), decision.PolicySources...),
 		WinningSource: decision.WinningSource,

--- a/internal/contract/runtime/runtime_test.go
+++ b/internal/contract/runtime/runtime_test.go
@@ -440,6 +440,29 @@ func TestEvaluateHTTP_ShadowModeObservesContractBlockButLetsScannerVerdictStand(
 	}
 }
 
+func TestEvaluateHTTP_ShadowModeContractAllowDoesNotEmitObservedOnlyReason(t *testing.T) {
+	resolved := resolvedContractWithRules(enforceRule("r-chat", "api.example.com", "/v1/chat", "POST"))
+
+	decision, err := EvaluateHTTP(EvaluateOptions{
+		Mode:           ModeShadow,
+		Resolved:       &resolved,
+		Request:        HTTPRequest{URL: "https://api.example.com/v1/chat", Method: "POST"},
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateHTTP shadow contract allow: %v", err)
+	}
+	if decision.Verdict != config.ActionAllow || decision.LiveVerdict != config.ActionAllow {
+		t.Fatalf("verdict = %q live = %q, want allow/allow", decision.Verdict, decision.LiveVerdict)
+	}
+	if decision.Reason != "" {
+		t.Fatalf("reason = %q, want empty when live mode would also allow", decision.Reason)
+	}
+	if decision.Drift != nil {
+		t.Fatalf("drift = %+v, want nil for contract allow", decision.Drift)
+	}
+}
+
 func TestEvaluateHTTP_CaptureModeNeverBlocksFromContract(t *testing.T) {
 	resolved := resolvedContractWithRules(enforceRule("r-chat", "api.example.com", "/v1/chat", "POST"))
 

--- a/internal/proxy/blockheaders.go
+++ b/internal/proxy/blockheaders.go
@@ -55,69 +55,22 @@ func reasonFromScanner(label string) blockreason.Reason {
 	}
 }
 
-// severityFromReason returns the canonical severity for a block-reason code.
-// Severity is fixed per reason per docs/specs/block-reason-header.md so call
-// sites do not need to track it manually.
+// severityFromReason delegates to the canonical
+// blockreason.SeverityFor table. The local wrapper used to maintain its own
+// switch, which silently drifted from the canonical mapping (BlockReasonOverflow,
+// for example, was returning SeverityCritical here while the canonical
+// helper returned SeverityWarn). Delegating keeps blockheaders.go correct
+// against any future vocabulary addition without a per-call-site update.
 func severityFromReason(r blockreason.Reason) blockreason.Severity {
-	switch r {
-	// info: malformed client request, feature gate.
-	case blockreason.NotEnabled, blockreason.BadRequest:
-		return blockreason.SeverityInfo
-	// warn: scanner ceilings, parser fails, transient unavailability.
-	case blockreason.SchemeBlocked,
-		blockreason.PathEntropy,
-		blockreason.SubdomainEntropy,
-		blockreason.URLLength,
-		blockreason.RateLimit,
-		blockreason.DataBudget,
-		blockreason.MediaPolicy,
-		blockreason.ParseError,
-		blockreason.Timeout,
-		blockreason.PatternUnavailable,
-		blockreason.CompressedResponse,
-		blockreason.BrowserShieldOversize:
-		return blockreason.SeverityWarn
-	// critical: real security events.
-	default:
-		return blockreason.SeverityCritical
-	}
+	return blockreason.SeverityFor(r)
 }
 
-// retryFromReason returns the canonical retry hint for a block-reason code.
-// See docs/specs/block-reason-header.md: none = permanent, transient =
-// time-bound, policy = needs operator policy change.
+// retryFromReason delegates to the canonical blockreason.RetryFor table for
+// the same reason as severityFromReason: drift between local and canonical
+// mappings was a latent bug class. The canonical helper is the single source
+// of truth used by NewForReason, the spec doc, and the matrix tests.
 func retryFromReason(r blockreason.Reason) blockreason.Retry {
-	switch r {
-	// transient: time-bound conditions.
-	case blockreason.SSRFDNSRebind,
-		blockreason.RateLimit,
-		blockreason.AirlockActive,
-		blockreason.KillSwitchActive,
-		blockreason.EscalationLevel,
-		blockreason.RedactionFailure,
-		blockreason.Timeout,
-		blockreason.PatternUnavailable,
-		blockreason.SessionAnomaly,
-		blockreason.OutboundEnvelopeFailed:
-		return blockreason.RetryTransient
-	// policy: only retry after operator changes pipelock policy.
-	case blockreason.DomainBlocklist,
-		blockreason.PathEntropy,
-		blockreason.SubdomainEntropy,
-		blockreason.URLLength,
-		blockreason.DataBudget,
-		blockreason.MediaPolicy,
-		blockreason.ToolPolicyDeny,
-		blockreason.SessionBinding,
-		blockreason.AuthorityMismatch,
-		blockreason.NotEnabled,
-		blockreason.CompressedResponse,
-		blockreason.BrowserShieldOversize:
-		return blockreason.RetryPolicy
-	// none: permanent for the request as-is.
-	default:
-		return blockreason.RetryNone
-	}
+	return blockreason.RetryFor(r)
 }
 
 // blockInfo builds a complete blockreason.Info from a scanner label.


### PR DESCRIPTION
## Summary

Three additions to the v2.4 learn-and-lock arc, ahead of transport wiring.

Five contract block-reason codes added to `internal/blockreason`:
- `contract_default_deny`, `contract_enforce_default` (critical, none)
- `contract_non_default_port` (warn, none)
- `contract_invalid_path` (warn, new `retry-with-canonical-path`)
- `contract_observed_only` (info, none, exempt from matrix gate as shadow-mode annotation)

`internal/contract/runtime/blockreason.go` adds `BlockReasonForDecision`, the typed mapping transports will use for X-Pipelock-Block-Reason headers and that satisfies the matrix gate's emit-site requirement for the four real reasons.

`internal/contract/runtime/receipt.go` adds `BuildProxyDecisionReceipt`, a pure body builder for EvidenceReceipt v2 `proxy_decision` envelopes. Stamps `ResolvedContract.ReceiptContext` so audit consumers can chain receipts back to the exact promoted manifest. Builder leaves `Signature` zero; signing stays in the existing receipt signer.

`PayloadProxyDecisionStruct` gains `LiveVerdict` (omitempty). `ProxyDecisionPayload` omits it when equal to `Verdict` (the live-mode case); shadow and capture modes surface the divergence so audit consumers can tell scanner-allowed-contract-agreed apart from scanner-allowed-contract-would-have-blocked.

A second commit tightens `applyModeGate` so `contract_observed_only` only fires when the live verdict differs from the enforced scanner-floor verdict. The earlier broader gate would have annotated contract-allow paths in shadow mode where there was no actual divergence to observe; the regression test pins the contract-allow shadow case (allow / allow, no Reason, no Drift). Same commit swaps the evaluator's hardcoded reason strings for private constants in `internal/contract/runtime/blockreason.go` so a rename can't drift the two files apart silently.

## Collateral cleanup

`internal/proxy/blockheaders.go`: `severityFromReason` and `retryFromReason` wrappers now delegate to `blockreason.SeverityFor` and `blockreason.RetryFor` instead of carrying drifted local switch tables. The local versions had `BlockReasonOverflow` returning `SeverityCritical`/`RetryNone` while the canonical helpers return `SeverityWarn`/`RetryTransient`. The dedup exposed four reasons (`SSRFDNSRebind`, `Timeout`, `ToolPolicyDeny`, `SessionBinding`) that were referenced only by the duplicated switches, so they now live in the matrix gate exemption with a comment explaining they are vocabulary placeholders awaiting wire emit sites.

## Out of scope

- Transport call sites. Follow-up PRs wire each transport to call `BlockReasonForDecision` and `BuildProxyDecisionReceipt`.
- Receipt signing. The existing receipt signer continues to handle that.
- Posture/audit dual-read for v1 consumers. If any break on the new `live_verdict` field, that lands as a follow-up.

## Verification

- `go test -race -count=1 -timeout 240s ./...`: green
- `golangci-lint run ./...`: 0 issues
- `go vet ./...`: clean
- `gofumpt -d` on touched files: clean
- Coverage on changed packages: blockreason 98.8%, runtime 95.3%, receipt 96.3%
- New functions: `BlockReasonForDecision` 100%, `validateProxyDecisionFields` 100%, `BuildProxyDecisionReceipt` 90% (the unreachable `json.Marshal` failure branch on a closed-shape struct)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added contract-level block reason tracking with specific codes for default deny, enforce default, non-default port, invalid path, and observed-only decisions
  * Contract receipts now include `LiveVerdict` field to capture divergence between shadow-mode and live verdicts

* **Improvements**
  * Unified block reason severity and retry hint handling across proxy components for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->