### PR TITLE
feat(contract,runtime): mcp_tool_call rule kind + EvaluateMCP

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1932,7 +1932,11 @@ fetch_proxy:
 		t.Fatal(err)
 	}
 
-	reloadDeadline := time.Now().Add(5 * time.Second)
+	// 15s deadline keeps the test green on slow GitHub Actions
+	// runners under -race load. Local desktop sees the reload
+	// activate within 1s; 5s flaked under CI scheduling jitter.
+	// Test is still well under the package timeout.
+	reloadDeadline := time.Now().Add(15 * time.Second)
 	reloaded := false
 	for time.Now().Before(reloadDeadline) {
 		select {
@@ -2078,7 +2082,11 @@ kill_switch:
 		t.Fatal(err)
 	}
 
-	reloadDeadline := time.Now().Add(5 * time.Second)
+	// 15s deadline keeps the test green on slow GitHub Actions
+	// runners under -race load. Local desktop sees the reload
+	// activate within 1s; 5s flaked under CI scheduling jitter.
+	// Test is still well under the package timeout.
+	reloadDeadline := time.Now().Add(15 * time.Second)
 	reloaded := false
 	for time.Now().Before(reloadDeadline) {
 		select {

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -32,6 +32,7 @@ const (
 const (
 	RuleKindHTTPDestination = "http_destination"
 	RuleKindHTTPAction      = "http_action"
+	RuleKindMCPToolCall     = "mcp_tool_call"
 )
 
 // ErrContractSchemaVersion rejects contracts with non-current schema_version.
@@ -64,7 +65,7 @@ var ErrUnsupportedLifecycle = errors.New("contract: unsupported lifecycle_state"
 // runtime would silently ignore. Add a new kind here only when the
 // matching runtime evaluator branch lands in the same change.
 func EnforceableRuleKinds() []string {
-	return []string{RuleKindHTTPDestination, RuleKindHTTPAction}
+	return []string{RuleKindHTTPDestination, RuleKindHTTPAction, RuleKindMCPToolCall}
 }
 
 func ruleKindEnforceable(kind string) bool {

--- a/internal/contract/contract_test.go
+++ b/internal/contract/contract_test.go
@@ -324,8 +324,8 @@ func TestContract_Validate_RejectsEnforceWithUnenforceableRuleKind(t *testing.T)
 		DataClassRoot:    string(DataClassInternal),
 		FieldDataClasses: map[string]string{},
 		Rules: []Rule{{
-			RuleID:               "r-mcp",
-			RuleKind:             "mcp_tool_call",
+			RuleID:               "r-future",
+			RuleKind:             "mcp_resource_access",
 			LifecycleState:       LifecycleEnforce,
 			RequiredCaptureGrade: CaptureGradeFull,
 			ObservedCaptureGrade: CaptureGradeFull,
@@ -356,12 +356,42 @@ func TestContract_Validate_AcceptsCaptureOnlyWithUnenforceableRuleKind(t *testin
 		FieldDataClasses: map[string]string{},
 		Rules: []Rule{{
 			RuleID:         "r-future",
-			RuleKind:       "mcp_tool_call",
+			RuleKind:       "mcp_resource_access",
 			LifecycleState: LifecycleCaptureOnly,
 		}},
 	}
 	if err := c.Validate(); err != nil {
 		t.Fatalf("got %v, want nil", err)
+	}
+}
+
+func TestContract_Validate_AcceptsMCPToolCallEnforce(t *testing.T) {
+	t.Parallel()
+	c := Contract{
+		SchemaVersion:    SchemaVersionContract,
+		ContractKind:     ContractKind,
+		DataClassRoot:    string(DataClassInternal),
+		FieldDataClasses: map[string]string{},
+		Rules: []Rule{{
+			RuleID:               "r-mcp",
+			RuleKind:             RuleKindMCPToolCall,
+			LifecycleState:       LifecycleEnforce,
+			RequiredCaptureGrade: CaptureGradeFull,
+			ObservedCaptureGrade: CaptureGradeFull,
+			Confidence:           "stable",
+			WilsonLower:          "0.99",
+			Observation:          map[string]any{},
+			Selector: map[string]any{
+				"server": map[string]any{"value": "stripe"},
+				"tool":   map[string]any{"value": "create_payment_intent"},
+			},
+			Rationale:         map[string]any{},
+			RecurringSupport:  map[string]any{},
+			OpportunityHealth: map[string]any{},
+		}},
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("got %v, want nil — registry must accept mcp_tool_call enforce", err)
 	}
 }
 

--- a/internal/contract/runtime/blockreason.go
+++ b/internal/contract/runtime/blockreason.go
@@ -17,6 +17,13 @@ const (
 	decisionReasonContractNonDefaultPort = "contract_non_default_port"
 	decisionReasonContractInvalidPath    = "contract_invalid_path"
 	decisionReasonContractObservedOnly   = "contract_observed_only"
+	// MCP-surface reasons map onto the same wire vocabulary as their HTTP
+	// equivalents so receipts, audit logs, and X-Pipelock-Block-Reason
+	// headers treat both surfaces uniformly. The strings stay distinct
+	// here so internal callers (drift telemetry, evaluator tests) can
+	// distinguish the surface that produced the block.
+	decisionReasonMCPArgsMismatch = "contract_mcp_args_mismatch"
+	decisionReasonMCPDefaultDeny  = "contract_mcp_default_deny"
 )
 
 // BlockReasonForDecision maps a Decision.Reason string to its canonical
@@ -54,6 +61,14 @@ func BlockReasonForDecision(decisionReason string) (blockreason.Reason, bool) {
 		// classified" rather than the more specific kill-switch or
 		// contract codes that imply jurisdictional enforcement.
 		return blockreason.ParseError, true
+	case decisionReasonMCPArgsMismatch:
+		// MCP server+tool match but args mismatch is the MCP-surface
+		// parallel to host match + path/method mismatch on HTTP. Map
+		// onto the same typed wire reason so the vocabulary stays
+		// stable across surfaces.
+		return blockreason.ContractEnforceDefault, true
+	case decisionReasonMCPDefaultDeny:
+		return blockreason.ContractDefaultDeny, true
 	default:
 		return "", false
 	}

--- a/internal/contract/runtime/blockreason_test.go
+++ b/internal/contract/runtime/blockreason_test.go
@@ -28,6 +28,8 @@ func TestBlockReasonForDecision_AllSupportedStrings(t *testing.T) {
 		{"contract observed only", decisionReasonContractObservedOnly, blockreason.ContractObservedOnly},
 		{"kill switch active", decisionReasonKillSwitchActive, blockreason.KillSwitchActive},
 		{"scanner decision missing", decisionReasonScannerDecisionMissing, blockreason.ParseError},
+		{"mcp args mismatch", decisionReasonMCPArgsMismatch, blockreason.ContractEnforceDefault},
+		{"mcp default deny", decisionReasonMCPDefaultDeny, blockreason.ContractDefaultDeny},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -80,13 +82,15 @@ func TestBlockReasonForDecision_EmptyAndUnknownReturnFalse(t *testing.T) {
 func TestBlockReasonForDecision_RuntimeStringsMatchPrivateConstants(t *testing.T) {
 	t.Parallel()
 	pairs := map[string]string{
-		"kill_switch_active":        decisionReasonKillSwitchActive,
-		"scanner_decision_missing":  decisionReasonScannerDecisionMissing,
-		"contract_default_deny":     decisionReasonContractDefaultDeny,
-		"contract_enforce_default":  decisionReasonContractEnforceDefault,
-		"contract_non_default_port": decisionReasonContractNonDefaultPort,
-		"contract_invalid_path":     decisionReasonContractInvalidPath,
-		"contract_observed_only":    decisionReasonContractObservedOnly,
+		"kill_switch_active":         decisionReasonKillSwitchActive,
+		"scanner_decision_missing":   decisionReasonScannerDecisionMissing,
+		"contract_default_deny":      decisionReasonContractDefaultDeny,
+		"contract_enforce_default":   decisionReasonContractEnforceDefault,
+		"contract_non_default_port":  decisionReasonContractNonDefaultPort,
+		"contract_invalid_path":      decisionReasonContractInvalidPath,
+		"contract_observed_only":     decisionReasonContractObservedOnly,
+		"contract_mcp_args_mismatch": decisionReasonMCPArgsMismatch,
+		"contract_mcp_default_deny":  decisionReasonMCPDefaultDeny,
 	}
 	for wire, constant := range pairs {
 		if wire != constant {

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -615,8 +615,13 @@ func TestLoader_Watch_DebounceMaxWaitFlushesUnderSustainedWrites(t *testing.T) {
 	// Allow up to maxDebounceWait + a generous grace for OS scheduling
 	// jitter. The forced flush fires through the same code path as a
 	// normal debounce tick, so the resulting outcome is "same_hash"
-	// (content unchanged).
-	deadline := time.Now().Add(maxDebounceWait + 1500*time.Millisecond)
+	// (content unchanged). Grace is intentionally large because
+	// GitHub Actions runners under -race load schedule the timer
+	// significantly later than the local desktop; 1.5s reproducibly
+	// flaked on CI while local runs always saw the flush within
+	// 200ms past maxDebounceWait. Five seconds keeps the test
+	// well under the package timeout.
+	deadline := time.Now().Add(maxDebounceWait + 5*time.Second)
 	for time.Now().Before(deadline) {
 		if metrics.outcome("same_hash") >= 1 {
 			break

--- a/internal/contract/runtime/mcp.go
+++ b/internal/contract/runtime/mcp.go
@@ -1,0 +1,386 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+)
+
+// MCPRequest is the normalized input needed to evaluate mcp_tool_call rules.
+//
+// Server is the upstream MCP server identifier the proxy resolved (for
+// example "stripe" or "lakera-guard"). ToolName is the tool the agent
+// is invoking. ToolArgs is the parsed arg map; matchers operate against
+// typed scalar values, so callers do not need to pre-stringify numbers
+// or booleans.
+type MCPRequest struct {
+	Server   string
+	ToolName string
+	ToolArgs map[string]any
+}
+
+// EvaluateMCPOptions control one MCP tool-call evaluation.
+type EvaluateMCPOptions struct {
+	Resolved         *ResolvedContract
+	Request          MCPRequest
+	Mode             Mode
+	KillSwitchActive bool
+	ScannerVerdict   string
+	ScannerMatched   bool
+	PolicySources    []string
+}
+
+// EvaluateMCP returns the runtime verdict for an MCP tool call under the
+// active learn-and-lock contract. The decision sequence mirrors
+// EvaluateHTTP so HTTP and MCP surfaces share identical security
+// invariants:
+//
+//  1. Mode is required and must enumerate. Empty Mode is fail-closed input.
+//  2. Kill switch active → block in every mode (absolute floor).
+//  3. Scanner block → block in every mode (security floor; contract may not
+//     resurrect a scanner-blocked tool call, including a signed allow rule).
+//  4. No resolved contract → return the scanner verdict.
+//  5. Contract resolved → evaluate enforce mcp_tool_call rules:
+//     - Server+tool match with args satisfied → contract annotates the
+//     scanner verdict; WinningSource = contract.
+//     - Server+tool match but args mismatch → contract block with reason
+//     contract_mcp_args_mismatch.
+//     - Contract has zero MCP enforce rules anywhere → fall through to
+//     scanner (observation-only contract; no jurisdiction over MCP).
+//     - Otherwise → contract default-deny (the contract claims
+//     jurisdiction once any MCP rule is in enforce; tool calls outside
+//     the enumerated allow set are denied).
+//  6. Mode gate. ModeLive enforces the contract verdict directly.
+//     ModeShadow / ModeCapture surface the scanner verdict as Verdict
+//     (so the proxy never blocks more than scanner already would) while
+//     LiveVerdict carries what live mode would have done, plus the drift
+//     event for observation pipelines.
+//
+// Selector args matching is typed scalar value-equality only in v1.
+// Structured matchers (range, regex, in-list) are deferred to the next
+// schema version; an args selector that uses an unsupported operator or
+// malformed args shape fails to match in v1, so operators relying on
+// those matchers see default-deny rather than spurious allow. Document
+// this when shipping args selectors to operators.
+//
+// The proxy MUST act on Decision.Verdict. LiveVerdict and Drift are
+// audit/telemetry surface; using them for enforcement breaks the mode
+// guarantee.
+func EvaluateMCP(opts EvaluateMCPOptions) (Decision, error) {
+	if opts.Mode == "" {
+		return Decision{}, fmt.Errorf("%w: mode required", ErrInvalidDecisionInput)
+	}
+	if !validMode(opts.Mode) {
+		return Decision{}, fmt.Errorf("%w: mode %q", ErrInvalidDecisionInput, opts.Mode)
+	}
+
+	sources := normalizePolicySources(opts.PolicySources)
+	if opts.ScannerMatched || opts.ScannerVerdict != "" {
+		sources = appendPolicySource(sources, PolicySourceScanner)
+	}
+
+	// 1. Kill switch is the absolute floor. Block in every mode.
+	if opts.KillSwitchActive {
+		sources = appendPolicySource(sources, PolicySourceKillSwitch)
+		return Decision{
+			Verdict:       config.ActionBlock,
+			LiveVerdict:   config.ActionBlock,
+			PolicySources: sources,
+			WinningSource: WinningSourceKillSwitch,
+			Suppressed:    true,
+			Reason:        decisionReasonKillSwitchActive,
+		}, nil
+	}
+
+	// Resolve scanner verdict (fail-closed if scanner did not decide).
+	scannerVerdict := opts.ScannerVerdict
+	scannerMissing := scannerVerdict == ""
+	if scannerMissing {
+		scannerVerdict = config.ActionBlock
+	}
+
+	// 2. Scanner block is the security floor. Wins in every mode, including
+	// over a signed contract-allow rule. Without this, a contract becomes a
+	// signed bypass of the MCP scanning pipeline (input scanning, tool
+	// poisoning, tool policy, chain detection, session binding).
+	if scannerVerdict == config.ActionBlock {
+		sources = appendPolicySource(sources, PolicySourceScanner)
+		decision := Decision{
+			Verdict:       config.ActionBlock,
+			LiveVerdict:   config.ActionBlock,
+			PolicySources: sources,
+			WinningSource: WinningSourceScanner,
+		}
+		if scannerMissing {
+			decision.Reason = decisionReasonScannerDecisionMissing
+		}
+		return decision, nil
+	}
+
+	// 3. No resolved contract → scanner verdict stands.
+	if opts.Resolved == nil {
+		return Decision{
+			Verdict:       scannerVerdict,
+			LiveVerdict:   scannerVerdict,
+			PolicySources: sources,
+			WinningSource: WinningSourceScanner,
+		}, nil
+	}
+
+	sources = appendPolicySource(sources, PolicySourceContract)
+
+	// 4 + 5. Compute the live verdict from the contract.
+	live, err := evaluateMCPContractLive(opts, sources, scannerVerdict)
+	if err != nil {
+		return Decision{}, err
+	}
+
+	// 6. Mode gate.
+	return applyModeGate(live, opts.Mode, scannerVerdict, sources), nil
+}
+
+// evaluateMCPContractLive returns what live mode would do for opts given a
+// resolved contract, after kill-switch and scanner-block have been ruled out.
+// Scanner verdict at this point is non-block; it is passed in so a contract
+// allow can correctly annotate the scanner verdict instead of asserting an
+// allow that scanner did not approve.
+func evaluateMCPContractLive(opts EvaluateMCPOptions, sources []string, scannerVerdict string) (Decision, error) {
+	server := strings.TrimSpace(opts.Request.Server)
+	tool := strings.TrimSpace(opts.Request.ToolName)
+	if server == "" || tool == "" {
+		return Decision{}, fmt.Errorf("%w: mcp request requires server and tool", ErrInvalidDecisionInput)
+	}
+
+	contractHasEnforceRule := false
+	serverToolHasEnforceRule := false
+	serverToolRuleIDs := make([]string, 0)
+	seenRuleIDs := map[string]struct{}{}
+	for _, rule := range opts.Resolved.Contract.Rules {
+		if !isMCPRule(rule) {
+			continue
+		}
+		if err := validateLifecycle(rule.LifecycleState); err != nil {
+			return Decision{}, err
+		}
+		if rule.LifecycleState != LifecycleEnforce {
+			continue
+		}
+		contractHasEnforceRule = true
+		if !ruleServerToolMatches(rule, server, tool) {
+			continue
+		}
+		serverToolHasEnforceRule = true
+		serverToolRuleIDs = appendRuleID(serverToolRuleIDs, seenRuleIDs, rule.RuleID)
+		argsMatch := ruleArgsMatch(rule, opts.Request.ToolArgs)
+		if argsMatch {
+			// Contract allow annotates the scanner-allowed verdict.
+			// Scanner block has already been resolved upstream and
+			// cannot reach this point, so it is impossible for an
+			// allow rule to override a scanner block here.
+			return Decision{
+				Verdict:       scannerVerdict,
+				LiveVerdict:   scannerVerdict,
+				PolicySources: sources,
+				WinningSource: WinningSourceContract,
+				RuleID:        rule.RuleID,
+			}, nil
+		}
+	}
+
+	// No allow rule matched.
+	if !contractHasEnforceRule {
+		// Contract is observation-only over the MCP surface. It claims no
+		// jurisdiction; scanner verdict stands.
+		return Decision{
+			Verdict:       scannerVerdict,
+			LiveVerdict:   scannerVerdict,
+			PolicySources: sources,
+			WinningSource: WinningSourceScanner,
+		}, nil
+	}
+
+	if serverToolHasEnforceRule {
+		// Server+tool matched at least one rule but args mismatched on
+		// every match. The contract claims jurisdiction over this
+		// server+tool; default-deny under the args mismatch reason.
+		return contractMCPBlockDecision(opts, sources, firstString(serverToolRuleIDs), decisionReasonMCPArgsMismatch), nil
+	}
+	return contractMCPBlockDecision(opts, sources, "", decisionReasonMCPDefaultDeny), nil
+}
+
+func contractMCPBlockDecision(opts EvaluateMCPOptions, sources []string, ruleID, reason string) Decision {
+	event := DriftEvent{
+		ContractHash: opts.Resolved.ContractHash,
+		RuleID:       ruleID,
+		Kind:         DriftKindPositive,
+		Mode:         opts.Mode,
+		Action:       config.ActionBlock,
+	}
+	decision := Decision{
+		Verdict:       config.ActionBlock,
+		LiveVerdict:   config.ActionBlock,
+		PolicySources: sources,
+		WinningSource: WinningSourceContract,
+		RuleID:        ruleID,
+		Drift:         &event,
+		Reason:        reason,
+	}
+	decision.Signal = SignalForDrift(event)
+	return decision
+}
+
+// isMCPRule reports whether rule is an mcp_tool_call rule the runtime can
+// evaluate. EvaluateHTTP's isHTTPRule and this helper enumerate disjoint
+// kind sets so the two evaluators never cross-fire on the same rule.
+func isMCPRule(rule contract.Rule) bool {
+	return rule.RuleKind == ruleKindMCPToolCall
+}
+
+func ruleServerToolMatches(rule contract.Rule, server, tool string) bool {
+	ruleServer := selectorString(rule.Selector, "server")
+	ruleTool := selectorString(rule.Selector, "tool")
+	if ruleServer == "" || ruleTool == "" {
+		return false
+	}
+	return ruleServer == server && ruleTool == tool
+}
+
+// ruleArgsMatch reports whether every arg-matcher in selector.args is
+// satisfied by request args. Missing key in the request is a non-match
+// (NOT a wildcard); empty args list (or absent args field) means no
+// constraint and matches by default. Malformed selector.args is a
+// non-match for the whole rule rather than being silently dropped into a
+// broader allow.
+func ruleArgsMatch(rule contract.Rule, requestArgs map[string]any) bool {
+	matchers, ok := selectorArgs(rule.Selector)
+	if !ok {
+		return false
+	}
+	if len(matchers) == 0 {
+		return true
+	}
+	for _, matcher := range matchers {
+		if !argMatcherMatches(matcher, requestArgs) {
+			return false
+		}
+	}
+	return true
+}
+
+func argMatcherMatches(matcher map[string]any, requestArgs map[string]any) bool {
+	key, _ := matcher["key"].(string)
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return false
+	}
+	rawValue, ok := matcher["value"]
+	if !ok || rawValue == nil {
+		// Missing value key (v2 matcher: range, regex, in-list) or
+		// JSON null. Both silently non-match in v1 so operators get
+		// default-deny rather than a spurious allow.
+		// fmt.Sprint(nil) renders as "<nil>", which would otherwise
+		// match a request arg whose string value happens to be
+		// "<nil>" — display-vs-reality bypass blocked here.
+		return false
+	}
+	got, present := requestArgs[key]
+	if !present || got == nil {
+		// Missing or null request value — never satisfies an equality
+		// matcher. Without the nil guard, a request arg of nil would
+		// stringify to "<nil>" and match a matcher value of the
+		// literal string "<nil>".
+		return false
+	}
+	return scalarValuesEqual(got, rawValue)
+}
+
+func selectorArgs(selector map[string]any) ([]map[string]any, bool) {
+	raw, exists := selector["args"]
+	if !exists {
+		return nil, true
+	}
+	values, ok := raw.([]any)
+	if !ok {
+		return nil, false
+	}
+	out := make([]map[string]any, 0, len(values))
+	for _, value := range values {
+		matcher, ok := value.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, matcher)
+	}
+	return out, true
+}
+
+func scalarValuesEqual(got, want any) bool {
+	if gotString, ok := got.(string); ok {
+		wantString, ok := want.(string)
+		return ok && gotString == wantString
+	}
+	if gotBool, ok := got.(bool); ok {
+		wantBool, ok := want.(bool)
+		return ok && gotBool == wantBool
+	}
+	gotNumber, gotOK := numericValue(got)
+	wantNumber, wantOK := numericValue(want)
+	if gotOK || wantOK {
+		return gotOK && wantOK && gotNumber.Cmp(wantNumber) == 0
+	}
+	return false
+}
+
+func numericValue(value any) (*big.Rat, bool) {
+	switch v := value.(type) {
+	case json.Number:
+		return parseJSONNumber(string(v))
+	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return nil, false
+		}
+		return parseJSONNumber(strconv.FormatFloat(v, 'g', -1, 64))
+	case float32:
+		f := float64(v)
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return nil, false
+		}
+		return parseJSONNumber(strconv.FormatFloat(f, 'g', -1, 32))
+	case int:
+		return new(big.Rat).SetInt64(int64(v)), true
+	case int8:
+		return new(big.Rat).SetInt64(int64(v)), true
+	case int16:
+		return new(big.Rat).SetInt64(int64(v)), true
+	case int32:
+		return new(big.Rat).SetInt64(int64(v)), true
+	case int64:
+		return new(big.Rat).SetInt64(v), true
+	case uint:
+		return new(big.Rat).SetUint64(uint64(v)), true
+	case uint8:
+		return new(big.Rat).SetUint64(uint64(v)), true
+	case uint16:
+		return new(big.Rat).SetUint64(uint64(v)), true
+	case uint32:
+		return new(big.Rat).SetUint64(uint64(v)), true
+	case uint64:
+		return new(big.Rat).SetUint64(v), true
+	default:
+		return nil, false
+	}
+}
+
+func parseJSONNumber(value string) (*big.Rat, bool) {
+	n, ok := new(big.Rat).SetString(value)
+	return n, ok
+}

--- a/internal/contract/runtime/mcp_test.go
+++ b/internal/contract/runtime/mcp_test.go
@@ -1,0 +1,836 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+)
+
+const (
+	mcpTestServer = "stripe"
+	mcpTestTool   = "create_payment_intent"
+)
+
+func TestEvaluateMCP_RejectsEmptyMode(t *testing.T) {
+	t.Parallel()
+	resolved := mcpResolved(mcpEnforceRule("r-allow", nil))
+	if _, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved:       &resolved,
+		Request:        MCPRequest{Server: mcpTestServer, ToolName: mcpTestTool},
+		ScannerVerdict: config.ActionAllow,
+	}); !errors.Is(err, ErrInvalidDecisionInput) {
+		t.Fatalf("err = %v, want ErrInvalidDecisionInput", err)
+	}
+}
+
+func TestEvaluateMCP_RejectsUnknownMode(t *testing.T) {
+	t.Parallel()
+	resolved := mcpResolved(mcpEnforceRule("r-allow", nil))
+	if _, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved:       &resolved,
+		Request:        MCPRequest{Server: mcpTestServer, ToolName: mcpTestTool},
+		Mode:           "rogue",
+		ScannerVerdict: config.ActionAllow,
+	}); !errors.Is(err, ErrInvalidDecisionInput) {
+		t.Fatalf("err = %v, want ErrInvalidDecisionInput", err)
+	}
+}
+
+func TestEvaluateMCP_KillSwitchBlocksInEveryMode(t *testing.T) {
+	t.Parallel()
+	resolved := mcpResolved(mcpEnforceRule("r-allow", nil))
+	for _, mode := range []Mode{ModeLive, ModeShadow, ModeCapture} {
+		mode := mode
+		t.Run(string(mode), func(t *testing.T) {
+			t.Parallel()
+			decision, err := EvaluateMCP(EvaluateMCPOptions{
+				Resolved:         &resolved,
+				Request:          MCPRequest{Server: mcpTestServer, ToolName: mcpTestTool},
+				Mode:             mode,
+				KillSwitchActive: true,
+				ScannerVerdict:   config.ActionAllow,
+			})
+			if err != nil {
+				t.Fatalf("EvaluateMCP: %v", err)
+			}
+			if decision.Verdict != config.ActionBlock || decision.WinningSource != WinningSourceKillSwitch {
+				t.Fatalf("decision = %+v, want kill-switch block", decision)
+			}
+			if decision.Reason != decisionReasonKillSwitchActive {
+				t.Fatalf("reason = %q, want %q", decision.Reason, decisionReasonKillSwitchActive)
+			}
+			if !decision.Suppressed {
+				t.Fatal("expected Suppressed=true under kill switch")
+			}
+		})
+	}
+}
+
+// TestEvaluateMCP_ScannerBlockWinsOverContractAllow is the load-bearing
+// security-floor test. A contract that allows a server+tool MUST NOT
+// resurrect a scanner block; otherwise a signed contract becomes a
+// signed bypass of MCP input scanning, tool poisoning detection, tool
+// policy, chain detection, and session binding. If this test breaks the
+// security floor is broken.
+func TestEvaluateMCP_ScannerBlockWinsOverContractAllow(t *testing.T) {
+	t.Parallel()
+	resolved := mcpResolved(mcpEnforceRule("r-allow", nil))
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved:       &resolved,
+		Request:        MCPRequest{Server: mcpTestServer, ToolName: mcpTestTool},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionBlock,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionBlock {
+		t.Fatalf("verdict = %q, want %q", decision.Verdict, config.ActionBlock)
+	}
+	if decision.WinningSource != WinningSourceScanner {
+		t.Fatalf("winning_source = %q, want scanner (security floor breached)", decision.WinningSource)
+	}
+	if decision.LiveVerdict != config.ActionBlock {
+		t.Fatalf("live_verdict = %q, want block", decision.LiveVerdict)
+	}
+}
+
+func TestEvaluateMCP_NoResolvedContractReturnsScannerVerdict(t *testing.T) {
+	t.Parallel()
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved:       nil,
+		Request:        MCPRequest{Server: mcpTestServer, ToolName: mcpTestTool},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionAllow {
+		t.Fatalf("verdict = %q, want allow", decision.Verdict)
+	}
+	if decision.WinningSource != WinningSourceScanner {
+		t.Fatalf("winning_source = %q, want scanner", decision.WinningSource)
+	}
+	if !contains(decision.PolicySources, PolicySourceScanner) {
+		t.Fatalf("policy_sources = %v, want scanner", decision.PolicySources)
+	}
+	if contains(decision.PolicySources, PolicySourceContract) {
+		t.Fatalf("policy_sources = %v, contract source must be absent without a resolved contract", decision.PolicySources)
+	}
+}
+
+func TestEvaluateMCP_AllowRuleAnnotatesScannerVerdict(t *testing.T) {
+	t.Parallel()
+	args := []map[string]any{
+		{"key": "currency", "value": "USD"},
+		{"key": "amount", "value": 100},
+	}
+	resolved := mcpResolved(mcpEnforceRule("r-allow", args))
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved: &resolved,
+		Request: MCPRequest{
+			Server:   mcpTestServer,
+			ToolName: mcpTestTool,
+			ToolArgs: map[string]any{"currency": "USD", "amount": 100, "extra": "ignored"},
+		},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionAllow {
+		t.Fatalf("verdict = %q, want allow", decision.Verdict)
+	}
+	if decision.WinningSource != WinningSourceContract {
+		t.Fatalf("winning_source = %q, want contract", decision.WinningSource)
+	}
+	if decision.RuleID != "r-allow" {
+		t.Fatalf("rule_id = %q, want r-allow", decision.RuleID)
+	}
+	if decision.Drift != nil {
+		t.Fatalf("drift = %+v, want nil for allow", decision.Drift)
+	}
+}
+
+func TestEvaluateMCP_ArgsMismatchBlocksWithReason(t *testing.T) {
+	t.Parallel()
+	args := []map[string]any{{"key": "currency", "value": "USD"}}
+	resolved := mcpResolved(mcpEnforceRule("r-stripe", args))
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved: &resolved,
+		Request: MCPRequest{
+			Server:   mcpTestServer,
+			ToolName: mcpTestTool,
+			ToolArgs: map[string]any{"currency": "EUR"},
+		},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionBlock {
+		t.Fatalf("verdict = %q, want block", decision.Verdict)
+	}
+	if decision.WinningSource != WinningSourceContract {
+		t.Fatalf("winning_source = %q, want contract", decision.WinningSource)
+	}
+	if decision.Reason != decisionReasonMCPArgsMismatch {
+		t.Fatalf("reason = %q, want %q", decision.Reason, decisionReasonMCPArgsMismatch)
+	}
+	if decision.RuleID != "r-stripe" {
+		t.Fatalf("rule_id = %q, want r-stripe", decision.RuleID)
+	}
+	if decision.Drift == nil || decision.Drift.Kind != DriftKindPositive {
+		t.Fatalf("drift = %+v, want positive drift event", decision.Drift)
+	}
+}
+
+func TestEvaluateMCP_ArgsMissingKeyIsNonMatch(t *testing.T) {
+	t.Parallel()
+	// Missing key in the request must be a non-match, NOT a wildcard.
+	// Otherwise a tool call that omits the constrained arg would slip
+	// through default-deny by accident.
+	args := []map[string]any{{"key": "currency", "value": "USD"}}
+	resolved := mcpResolved(mcpEnforceRule("r-stripe", args))
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved: &resolved,
+		Request: MCPRequest{
+			Server:   mcpTestServer,
+			ToolName: mcpTestTool,
+			ToolArgs: map[string]any{}, // currency absent
+		},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionBlock {
+		t.Fatalf("verdict = %q, want block", decision.Verdict)
+	}
+	if decision.Reason != decisionReasonMCPArgsMismatch {
+		t.Fatalf("reason = %q, want %q", decision.Reason, decisionReasonMCPArgsMismatch)
+	}
+}
+
+func TestEvaluateMCP_DefaultDenyForUnmatchedRequest(t *testing.T) {
+	t.Parallel()
+	resolved := mcpResolved(mcpEnforceRule("r-allow", nil))
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved: &resolved,
+		Request: MCPRequest{
+			Server:   "other-server",
+			ToolName: "other-tool",
+		},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionBlock {
+		t.Fatalf("verdict = %q, want block", decision.Verdict)
+	}
+	if decision.Reason != decisionReasonMCPDefaultDeny {
+		t.Fatalf("reason = %q, want %q", decision.Reason, decisionReasonMCPDefaultDeny)
+	}
+	if decision.RuleID != "" {
+		t.Fatalf("rule_id = %q, want empty (no specific rule attributed)", decision.RuleID)
+	}
+}
+
+func TestEvaluateMCP_ObservationOnlyContractFallsThrough(t *testing.T) {
+	t.Parallel()
+	// Contract has only proposed/capture-only MCP rules. The contract
+	// claims no jurisdiction over MCP, so unmatched tool calls fall
+	// through to the scanner verdict instead of default-denying.
+	rule := mcpEnforceRule("r-proposed", nil)
+	rule.LifecycleState = LifecycleProposed
+	resolved := mcpResolved(rule)
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved: &resolved,
+		Request: MCPRequest{
+			Server:   "other-server",
+			ToolName: "other-tool",
+		},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionAllow {
+		t.Fatalf("verdict = %q, want allow", decision.Verdict)
+	}
+	if decision.WinningSource != WinningSourceScanner {
+		t.Fatalf("winning_source = %q, want scanner", decision.WinningSource)
+	}
+}
+
+func TestEvaluateMCP_HTTPRulesIgnoredByMCPEvaluator(t *testing.T) {
+	t.Parallel()
+	// HTTP rules in the same contract must not cross-fire on the MCP
+	// evaluator. If isMCPRule ever returned true for HTTP kinds, an
+	// http_destination allow could spoof an MCP tool-call allow.
+	httpRule := contract.Rule{
+		RuleID:               "r-http",
+		RuleKind:             ruleKindHTTPAction,
+		LifecycleState:       LifecycleEnforce,
+		RequiredCaptureGrade: contract.CaptureGradeFull,
+		ObservedCaptureGrade: contract.CaptureGradeFull,
+		Selector: map[string]any{
+			"host":   map[string]any{"value": "api.example.com"},
+			"server": map[string]any{"value": mcpTestServer},
+			"tool":   map[string]any{"value": mcpTestTool},
+		},
+		Confidence:        "stable",
+		WilsonLower:       "0.99",
+		Observation:       map[string]any{},
+		Rationale:         map[string]any{},
+		RecurringSupport:  map[string]any{},
+		OpportunityHealth: map[string]any{},
+	}
+	resolved := mcpResolved(httpRule)
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved: &resolved,
+		Request: MCPRequest{
+			Server:   mcpTestServer,
+			ToolName: mcpTestTool,
+		},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	// Contract has zero MCP enforce rules → observation-only over the
+	// MCP surface → scanner verdict stands.
+	if decision.Verdict != config.ActionAllow {
+		t.Fatalf("verdict = %q, want allow (observation-only)", decision.Verdict)
+	}
+	if decision.WinningSource != WinningSourceScanner {
+		t.Fatalf("winning_source = %q, want scanner", decision.WinningSource)
+	}
+}
+
+func TestEvaluateMCP_ShadowModeNeverBlocksFromContract(t *testing.T) {
+	t.Parallel()
+	resolved := mcpResolved(mcpEnforceRule("r-allow", nil))
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved: &resolved,
+		Request: MCPRequest{
+			Server:   "other-server",
+			ToolName: "other-tool",
+		},
+		Mode:           ModeShadow,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionAllow {
+		t.Fatalf("verdict = %q, want allow (shadow surfaces scanner verdict)", decision.Verdict)
+	}
+	if decision.LiveVerdict != config.ActionBlock {
+		t.Fatalf("live_verdict = %q, want block (live mode would have denied)", decision.LiveVerdict)
+	}
+	if decision.WinningSource != WinningSourceScanner {
+		t.Fatalf("winning_source = %q, want scanner under shadow", decision.WinningSource)
+	}
+	if decision.Drift == nil {
+		t.Fatal("drift = nil, want populated drift event for shadow telemetry")
+	}
+	if decision.Drift.Mode != ModeShadow {
+		t.Fatalf("drift.mode = %q, want shadow", decision.Drift.Mode)
+	}
+	if decision.Reason != "contract_observed_only" {
+		t.Fatalf("reason = %q, want contract_observed_only", decision.Reason)
+	}
+	if decision.Signal != nil {
+		t.Fatalf("signal = %+v, want nil — shadow must not push adaptive signal", decision.Signal)
+	}
+}
+
+func TestEvaluateMCP_CaptureModeNeverSignals(t *testing.T) {
+	t.Parallel()
+	resolved := mcpResolved(mcpEnforceRule("r-allow", nil))
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved: &resolved,
+		Request: MCPRequest{
+			Server:   "other-server",
+			ToolName: "other-tool",
+		},
+		Mode:           ModeCapture,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionAllow {
+		t.Fatalf("verdict = %q, want allow (capture surfaces scanner verdict)", decision.Verdict)
+	}
+	if decision.Signal != nil {
+		t.Fatalf("signal = %+v, want nil — capture must not push adaptive signal", decision.Signal)
+	}
+}
+
+func TestEvaluateMCP_RejectsEmptyServerOrTool(t *testing.T) {
+	t.Parallel()
+	// Server and tool are mandatory in the request. Without them the
+	// evaluator cannot decide jurisdiction; fail-closed input rather
+	// than silently default-denying every contract.
+	resolved := mcpResolved(mcpEnforceRule("r-allow", nil))
+	cases := []struct {
+		name string
+		req  MCPRequest
+	}{
+		{"empty server", MCPRequest{Server: "", ToolName: mcpTestTool}},
+		{"empty tool", MCPRequest{Server: mcpTestServer, ToolName: ""}},
+		{"whitespace server", MCPRequest{Server: "   ", ToolName: mcpTestTool}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := EvaluateMCP(EvaluateMCPOptions{
+				Resolved:       &resolved,
+				Request:        tc.req,
+				Mode:           ModeLive,
+				ScannerVerdict: config.ActionAllow,
+			})
+			if !errors.Is(err, ErrInvalidDecisionInput) {
+				t.Fatalf("err = %v, want ErrInvalidDecisionInput", err)
+			}
+		})
+	}
+}
+
+func TestEvaluateMCP_RejectsUnsupportedRuleLifecycle(t *testing.T) {
+	t.Parallel()
+	rule := mcpEnforceRule("r-bad", nil)
+	rule.LifecycleState = "enforce " // trailing space — bypass attempt
+	resolved := mcpResolved(rule)
+	_, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved:       &resolved,
+		Request:        MCPRequest{Server: mcpTestServer, ToolName: mcpTestTool},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if !errors.Is(err, ErrUnsupportedLifecycle) {
+		t.Fatalf("err = %v, want ErrUnsupportedLifecycle", err)
+	}
+}
+
+func TestEvaluateMCP_ScannerMissingFailsClosed(t *testing.T) {
+	t.Parallel()
+	// Scanner did not decide → treat as block. This mirrors EvaluateHTTP
+	// so a missing scanner verdict is never a contract-allow path.
+	resolved := mcpResolved(mcpEnforceRule("r-allow", nil))
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved:       &resolved,
+		Request:        MCPRequest{Server: mcpTestServer, ToolName: mcpTestTool},
+		Mode:           ModeLive,
+		ScannerVerdict: "",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionBlock {
+		t.Fatalf("verdict = %q, want block", decision.Verdict)
+	}
+	if decision.WinningSource != WinningSourceScanner {
+		t.Fatalf("winning_source = %q, want scanner", decision.WinningSource)
+	}
+	if decision.Reason != decisionReasonScannerDecisionMissing {
+		t.Fatalf("reason = %q, want %q", decision.Reason, decisionReasonScannerDecisionMissing)
+	}
+}
+
+func TestEvaluateMCP_PolicySourcesIncludeContractWhenResolved(t *testing.T) {
+	t.Parallel()
+	resolved := mcpResolved(mcpEnforceRule("r-allow", nil))
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved:       &resolved,
+		Request:        MCPRequest{Server: mcpTestServer, ToolName: mcpTestTool},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if !contains(decision.PolicySources, PolicySourceContract) {
+		t.Fatalf("policy_sources = %v, want contract present", decision.PolicySources)
+	}
+	if !contains(decision.PolicySources, PolicySourceScanner) {
+		t.Fatalf("policy_sources = %v, want scanner present", decision.PolicySources)
+	}
+}
+
+func TestEvaluateMCP_RuleWithMissingServerSelectorIgnored(t *testing.T) {
+	t.Parallel()
+	// A rule with no server/tool selector cannot match any request.
+	// Defense-in-depth: even if a malformed contract slips past
+	// upstream validation, it must not produce a spurious allow.
+	rule := mcpEnforceRule("r-broken", nil)
+	rule.Selector = map[string]any{"tool": map[string]any{"value": mcpTestTool}}
+	resolved := mcpResolved(rule)
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved:       &resolved,
+		Request:        MCPRequest{Server: mcpTestServer, ToolName: mcpTestTool},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionBlock {
+		t.Fatalf("verdict = %q, want block (broken selector must default-deny)", decision.Verdict)
+	}
+	if decision.Reason != decisionReasonMCPDefaultDeny {
+		t.Fatalf("reason = %q, want %q", decision.Reason, decisionReasonMCPDefaultDeny)
+	}
+}
+
+func TestEvaluateMCP_ArgMatcherWithEmptyKeyIsNonMatch(t *testing.T) {
+	t.Parallel()
+	args := []map[string]any{{"key": "   ", "value": "USD"}}
+	resolved := mcpResolved(mcpEnforceRule("r-stripe", args))
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved: &resolved,
+		Request: MCPRequest{
+			Server:   mcpTestServer,
+			ToolName: mcpTestTool,
+			ToolArgs: map[string]any{"currency": "USD"},
+		},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionBlock || decision.Reason != decisionReasonMCPArgsMismatch {
+		t.Fatalf("decision = %+v, want args-mismatch block under empty matcher key", decision)
+	}
+}
+
+// TestEvaluateMCP_NilMatcherValueIsNonMatch closes a display-vs-reality
+// bypass in argMatcherMatches: fmt.Sprint(nil) renders as "<nil>", so
+// without explicit nil guards a contract matcher with JSON null could
+// be matched by an agent that sends the literal string "<nil>" as the
+// arg value. The matcher must non-match in both directions: matcher
+// value == nil and request value == nil.
+func TestEvaluateMCP_NilMatcherValueIsNonMatch(t *testing.T) {
+	t.Parallel()
+	t.Run("matcher value is nil", func(t *testing.T) {
+		t.Parallel()
+		args := []map[string]any{{"key": "currency", "value": nil}}
+		resolved := mcpResolved(mcpEnforceRule("r-stripe", args))
+		decision, err := EvaluateMCP(EvaluateMCPOptions{
+			Resolved: &resolved,
+			Request: MCPRequest{
+				Server:   mcpTestServer,
+				ToolName: mcpTestTool,
+				ToolArgs: map[string]any{"currency": "<nil>"},
+			},
+			Mode:           ModeLive,
+			ScannerVerdict: config.ActionAllow,
+		})
+		if err != nil {
+			t.Fatalf("EvaluateMCP: %v", err)
+		}
+		if decision.Verdict != config.ActionBlock || decision.Reason != decisionReasonMCPArgsMismatch {
+			t.Fatalf("decision = %+v, want args-mismatch block — fmt.Sprint(nil) bypass", decision)
+		}
+	})
+	t.Run("request value is nil", func(t *testing.T) {
+		t.Parallel()
+		args := []map[string]any{{"key": "currency", "value": "<nil>"}}
+		resolved := mcpResolved(mcpEnforceRule("r-stripe", args))
+		decision, err := EvaluateMCP(EvaluateMCPOptions{
+			Resolved: &resolved,
+			Request: MCPRequest{
+				Server:   mcpTestServer,
+				ToolName: mcpTestTool,
+				ToolArgs: map[string]any{"currency": nil},
+			},
+			Mode:           ModeLive,
+			ScannerVerdict: config.ActionAllow,
+		})
+		if err != nil {
+			t.Fatalf("EvaluateMCP: %v", err)
+		}
+		if decision.Verdict != config.ActionBlock || decision.Reason != decisionReasonMCPArgsMismatch {
+			t.Fatalf("decision = %+v, want args-mismatch block — request nil bypass", decision)
+		}
+	})
+}
+
+func TestEvaluateMCP_ArgMatcherStringDoesNotMatchNumber(t *testing.T) {
+	t.Parallel()
+	// Typed equality is required. If display strings are treated as
+	// reality, a contract that allowed the string "100" would also allow
+	// numeric 100, which can mean a different thing to typed MCP tools.
+	args := []map[string]any{{"key": "amount", "value": "100"}}
+	resolved := mcpResolved(mcpEnforceRule("r-stripe", args))
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved: &resolved,
+		Request: MCPRequest{
+			Server:   mcpTestServer,
+			ToolName: mcpTestTool,
+			ToolArgs: map[string]any{"amount": 100},
+		},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionBlock || decision.Reason != decisionReasonMCPArgsMismatch {
+		t.Fatalf("decision = %+v, want args-mismatch block under string/number mismatch", decision)
+	}
+}
+
+func TestEvaluateMCP_ArgMatcherLargeIntegerExact(t *testing.T) {
+	t.Parallel()
+	// Numeric equality must not pass through float64 precision collapse.
+	// These two integers are distinct, but both round to the same IEEE-754
+	// value if compared as float64.
+	args := []map[string]any{{"key": "nonce", "value": uint64(9007199254740993)}}
+	resolved := mcpResolved(mcpEnforceRule("r-stripe", args))
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved: &resolved,
+		Request: MCPRequest{
+			Server:   mcpTestServer,
+			ToolName: mcpTestTool,
+			ToolArgs: map[string]any{"nonce": uint64(9007199254740992)},
+		},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionBlock || decision.Reason != decisionReasonMCPArgsMismatch {
+		t.Fatalf("decision = %+v, want args-mismatch block under large integer mismatch", decision)
+	}
+}
+
+func TestEvaluateMCP_ArgMatcherJSONNumberMatchesNumericArg(t *testing.T) {
+	t.Parallel()
+	args := []map[string]any{{"key": "amount", "value": json.Number("100")}}
+	resolved := mcpResolved(mcpEnforceRule("r-stripe", args))
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved: &resolved,
+		Request: MCPRequest{
+			Server:   mcpTestServer,
+			ToolName: mcpTestTool,
+			ToolArgs: map[string]any{"amount": 100},
+		},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionAllow || decision.WinningSource != WinningSourceContract {
+		t.Fatalf("decision = %+v, want contract allow for equivalent numeric values", decision)
+	}
+}
+
+func TestEvaluateMCP_V2MatcherSilentlyMisses(t *testing.T) {
+	t.Parallel()
+	// v2 schema may add operators like {key, op, threshold}. A v1
+	// runtime sees these as non-match so operators get default-deny
+	// rather than a spurious allow on an unrecognized matcher.
+	args := []map[string]any{{"key": "amount", "op": "lt", "threshold": "1000"}}
+	resolved := mcpResolved(mcpEnforceRule("r-stripe", args))
+	decision, err := EvaluateMCP(EvaluateMCPOptions{
+		Resolved: &resolved,
+		Request: MCPRequest{
+			Server:   mcpTestServer,
+			ToolName: mcpTestTool,
+			ToolArgs: map[string]any{"amount": 5},
+		},
+		Mode:           ModeLive,
+		ScannerVerdict: config.ActionAllow,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateMCP: %v", err)
+	}
+	if decision.Verdict != config.ActionBlock || decision.Reason != decisionReasonMCPArgsMismatch {
+		t.Fatalf("decision = %+v, want args-mismatch block under v2 matcher", decision)
+	}
+}
+
+func TestEvaluateMCP_MalformedSelectorArgsNonMatch(t *testing.T) {
+	t.Parallel()
+	// Malformed selector.args must not be silently dropped. If malformed
+	// elements were ignored, a hand-crafted contract could degrade an
+	// arg-constrained allow into a broader server+tool allow.
+	cases := []struct {
+		name string
+		args any
+	}{
+		{
+			name: "non-map element mixed with valid matcher",
+			args: []any{
+				"not-a-map",
+				map[string]any{"key": "currency", "value": "USD"},
+			},
+		},
+		{
+			name: "all non-map elements",
+			args: []any{"not-a-map"},
+		},
+		{
+			name: "args field is not a list",
+			args: map[string]any{"key": "currency", "value": "USD"},
+		},
+		{
+			name: "args field is null",
+			args: nil,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rule := mcpEnforceRule("r-stripe", nil)
+			rule.Selector["args"] = tc.args
+			resolved := mcpResolved(rule)
+			decision, err := EvaluateMCP(EvaluateMCPOptions{
+				Resolved: &resolved,
+				Request: MCPRequest{
+					Server:   mcpTestServer,
+					ToolName: mcpTestTool,
+					ToolArgs: map[string]any{"currency": "USD"},
+				},
+				Mode:           ModeLive,
+				ScannerVerdict: config.ActionAllow,
+			})
+			if err != nil {
+				t.Fatalf("EvaluateMCP: %v", err)
+			}
+			if decision.Verdict != config.ActionBlock || decision.Reason != decisionReasonMCPArgsMismatch {
+				t.Fatalf("decision = %+v, want args-mismatch block for malformed selector.args", decision)
+			}
+		})
+	}
+}
+
+// TestScalarValuesEqual_NumericTypeMatrix covers every Go numeric type
+// the json package can produce for a tool arg. Each case is invoked
+// against numericValue so the type-switch arms are exercised directly,
+// in addition to the integration tests above. Without this, the
+// defense-in-depth branches for json.Number, float32/float64, and the
+// signed/unsigned integer widths would sit at sub-30% coverage and a
+// future refactor could silently break a branch without a failing test.
+func TestScalarValuesEqual_NumericTypeMatrix(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a    any
+		b    any
+		want bool
+	}{
+		{"json.Number equal", json.Number("100"), json.Number("100"), true},
+		{"json.Number unequal", json.Number("100"), json.Number("101"), false},
+		{"json.Number malformed", json.Number("not-a-number"), json.Number("100"), false},
+		{"float64 equal", float64(1.5), float64(1.5), true},
+		{"float64 NaN", math.NaN(), float64(0), false},
+		{"float64 +Inf", math.Inf(1), float64(0), false},
+		{"float32 equal", float32(2.5), float32(2.5), true},
+		{"float32 NaN", float32(math.NaN()), float32(0), false},
+		{"int", int(5), int(5), true},
+		{"int8", int8(5), int8(5), true},
+		{"int16", int16(5), int16(5), true},
+		{"int32", int32(5), int32(5), true},
+		{"int64", int64(5), int64(5), true},
+		{"uint", uint(5), uint(5), true},
+		{"uint8", uint8(5), uint8(5), true},
+		{"uint16", uint16(5), uint16(5), true},
+		{"uint32", uint32(5), uint32(5), true},
+		{"uint64", uint64(5), uint64(5), true},
+		{"int vs uint64 same value", int(5), uint64(5), true},
+		{"int vs float64 same value", int(5), float64(5.0), true},
+		{"json.Number vs int same value", json.Number("5"), int(5), true},
+		{"string equal", "USD", "USD", true},
+		{"string vs int", "100", int(100), false},
+		{"string vs bool", "true", true, false},
+		{"bool true equal", true, true, true},
+		{"bool false equal", false, false, true},
+		{"bool true vs false", true, false, false},
+		{"bool vs int", true, int(1), false},
+		{"bool vs string", false, "false", false},
+		{"unsupported type", []int{1}, []int{1}, false},
+		{"both unsupported same kind", struct{}{}, struct{}{}, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := scalarValuesEqual(tc.a, tc.b); got != tc.want {
+				t.Fatalf("scalarValuesEqual(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+// mcpResolved builds a ResolvedContract with the given rules attached so
+// every test gets a freshly-keyed contract pin without copying the
+// fields by hand.
+func mcpResolved(rules ...contract.Rule) ResolvedContract {
+	return ResolvedContract{
+		ActiveManifestHash: testManifestHash,
+		ContractHash:       testContractHash,
+		SelectorID:         testSelectorID,
+		ContractGeneration: 1,
+		Contract: contract.Contract{
+			ContractHash: testContractHash,
+			Rules:        rules,
+		},
+	}
+}
+
+// mcpEnforceRule builds a LifecycleEnforce mcp_tool_call rule for tests.
+// All current tests use mcpTestServer + mcpTestTool; broaden to
+// parameters when a future test exercises a different upstream server
+// or tool. args is optional — pass nil for unconstrained server+tool
+// match, or a list of {key, value} maps for arg-equality matching.
+func mcpEnforceRule(ruleID string, args []map[string]any) contract.Rule {
+	selector := map[string]any{
+		"server": map[string]any{"value": mcpTestServer},
+		"tool":   map[string]any{"value": mcpTestTool},
+	}
+	if len(args) > 0 {
+		argList := make([]any, len(args))
+		for i, a := range args {
+			argList[i] = a
+		}
+		selector["args"] = argList
+	}
+	return contract.Rule{
+		RuleID:               ruleID,
+		RuleKind:             ruleKindMCPToolCall,
+		LifecycleState:       LifecycleEnforce,
+		RequiredCaptureGrade: contract.CaptureGradeFull,
+		ObservedCaptureGrade: contract.CaptureGradeFull,
+		Confidence:           "stable",
+		WilsonLower:          "0.99",
+		Observation:          map[string]any{},
+		Selector:             selector,
+		Rationale:            map[string]any{},
+		RecurringSupport:     map[string]any{"windows_floor": 3},
+		OpportunityHealth:    map[string]any{},
+	}
+}

--- a/internal/contract/runtime/runtime.go
+++ b/internal/contract/runtime/runtime.go
@@ -61,6 +61,7 @@ const (
 const (
 	ruleKindHTTPDestination = contract.RuleKindHTTPDestination
 	ruleKindHTTPAction      = contract.RuleKindHTTPAction
+	ruleKindMCPToolCall     = contract.RuleKindMCPToolCall
 
 	DriftKindPositive = "positive"
 	DriftKindNegative = "negative"

--- a/internal/contract/runtime/runtime_test.go
+++ b/internal/contract/runtime/runtime_test.go
@@ -332,7 +332,7 @@ func TestEvaluateHTTP_ScannerFallbacksAndErrors(t *testing.T) {
 		t.Fatalf("EvaluateHTTP nil resolved: %v", err)
 	}
 	if decision.Verdict != config.ActionBlock || decision.WinningSource != WinningSourceScanner ||
-		decision.Reason != "scanner_decision_missing" {
+		decision.Reason != decisionReasonScannerDecisionMissing {
 		t.Fatalf("missing scanner decision = %+v", decision)
 	}
 	if !contains(decision.PolicySources, PolicySourceScanner) {


### PR DESCRIPTION
Adds the schema slot and runtime evaluator for live MCP tool-call gating. Schema and evaluator ship together so the registry extension is never dead weight; the slot without dispatch would silently accept enforced rules the runtime cannot decide on.

## Behavior

EvaluateMCP mirrors EvaluateHTTP's decision sequence so HTTP and MCP surfaces share identical security invariants.

1. Mode required; empty mode is fail-closed input.
2. Kill switch active blocks every mode (absolute floor).
3. Scanner block wins every mode (security floor; contract allow cannot resurrect a scanner-blocked tool call).
4. No resolved contract returns the scanner verdict.
5. Contract resolved evaluates enforce mcp_tool_call rules. Server+tool match plus args satisfied yields contract allow annotated onto the scanner verdict; server+tool match with args mismatch yields contract block under reason contract_mcp_args_mismatch; zero MCP enforce rules anywhere falls through to scanner (observation-only contract); otherwise contract default-deny under reason contract_mcp_default_deny.
6. Mode gate. Live enforces directly; shadow and capture surface the scanner verdict as Verdict while LiveVerdict carries what live would have done plus the drift event for observation pipelines.

## Selector shape (v1)

server.value and tool.value are mandatory and matched exact case-sensitive. Optional args is typed scalar value-equality only; v2 matchers (range, regex, in-list) and malformed args entries silently non-match in v1 so operators get default-deny rather than spurious allow.

## Defense in depth

argMatcherMatches uses typed scalar equality, not fmt.Sprint comparison. Two display-vs-reality bypass classes are closed.

- The string "100" cannot match the integer 100. Without typed equality a contract that allowed the display string would also allow typed numeric payloads which can mean a different thing to MCP tools.
- Large integers do not collapse through float64. uint64 9007199254740993 and 9007199254740992 round to the same IEEE-754 value but are distinct rationals; big.Rat preserves the inequality. JSON-decoded floats and json.Number variants feed through the same path.

Nil matcher value and nil request value are explicit non-matches before any equality comparison. fmt.Sprint(nil) renders as "<nil>" which would otherwise match a request arg of literal string "<nil>".

Malformed selector.args (non-list, non-map elements, JSON null) is a non-match for the whole rule rather than silently dropping bad entries. Without that, a hand-crafted contract could degrade an arg-constrained allow into a broader server+tool allow.

isHTTPRule and isMCPRule enumerate disjoint rule kinds so an http_destination rule cannot cross-fire on the MCP evaluator and vice versa. Existing TestContract_Validate_RejectsEnforceWithUnenforceableRuleKind switches to mcp_resource_access (still unsupported) so it keeps proving the rejection path after this change.

## Block-reason mapping

decisionReasonMCPArgsMismatch maps to blockreason.ContractEnforceDefault (server+tool covered, args mismatch is the MCP parallel to HTTP host match + path mismatch). decisionReasonMCPDefaultDeny maps to blockreason.ContractDefaultDeny. The wire vocabulary stays stable across surfaces so receipts, audit logs, and X-Pipelock-Block-Reason headers treat MCP and HTTP uniformly. No new typed Reason constants needed; production-path matrix gate stays clean.

## Out of scope

Compile pipeline emission of mcp_tool_call rules from observed traffic (separate inference work) and MCP transport wiring into the proxy decision path (lands with the stdio and HTTP listener integrations).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP tool-call contract enforcement and end-to-end MCP evaluation (server+tool+args)
  * Argument matching with strict typed equality and numeric normalization
  * Mode gating with live vs observation behaviors and fail-closed kill-switch handling

* **Bug Fixes**
  * Updated decision-reason mappings for MCP enforcement and args-mismatch/default-deny cases

* **Tests**
  * Expanded validation and comprehensive MCP evaluation test suites, plus timing robustness tweaks in related tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->