### PR TITLE
feat(proxy): live-lock enforcement on forward proxy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,7 +166,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.2'
+          # 1.26.3 patches GO-2026-4982 / GO-2026-4980 / GO-2026-4976
+          # in html/template + net/http/httputil. 1.26.2 was clean
+          # when this version was pinned; the advisories landed
+          # 2026-05-07.
+          go-version: '1.26.3'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4

--- a/internal/contract/runtime/contractruntimetest/fixture.go
+++ b/internal/contract/runtime/contractruntimetest/fixture.go
@@ -1,0 +1,331 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contractruntimetest
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	contractstore "github.com/luckyPipewrench/pipelock/internal/contract/store"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// Key IDs the fixture stamps onto the generated keystore + roster +
+// signed contract/manifest bodies. Using named constants prevents typo
+// drift between the keystore (where the private key lives) and the
+// roster + signature header (which look the key up by ID).
+const (
+	keyIDRosterRoot        = "roster-root"
+	keyIDActivationPrimary = "activation-primary"
+	keyIDCompilePrimary    = "compile-primary"
+	signaturePrefixEd25519 = "ed25519:"
+)
+
+// Fixture holds a verified roster and signing keys for runtime loader tests.
+type Fixture struct {
+	root            string
+	rosterPath      string
+	rootFingerprint string
+	rootPriv        ed25519.PrivateKey
+	activationPub   ed25519.PublicKey
+	activationPriv  ed25519.PrivateKey
+	compilePub      ed25519.PublicKey
+	compilePriv     ed25519.PrivateKey
+}
+
+// NewFixture creates a real roster rooted in a temporary keystore.
+func NewFixture(t *testing.T) Fixture {
+	t.Helper()
+	root := t.TempDir()
+	keystoreDir := filepath.Join(root, "keys")
+	ks := signing.NewKeystore(keystoreDir)
+
+	rootPub, err := ks.GenerateAgent(keyIDRosterRoot)
+	if err != nil {
+		t.Fatalf("generate root: %v", err)
+	}
+	rootPriv, err := ks.LoadPrivateKey(keyIDRosterRoot)
+	if err != nil {
+		t.Fatalf("load root priv: %v", err)
+	}
+	activationPub, err := ks.GenerateAgent(keyIDActivationPrimary)
+	if err != nil {
+		t.Fatalf("generate activation: %v", err)
+	}
+	activationPriv, err := ks.LoadPrivateKey(keyIDActivationPrimary)
+	if err != nil {
+		t.Fatalf("load activation priv: %v", err)
+	}
+	compilePub, err := ks.GenerateAgent(keyIDCompilePrimary)
+	if err != nil {
+		t.Fatalf("generate compile: %v", err)
+	}
+	compilePriv, err := ks.LoadPrivateKey(keyIDCompilePrimary)
+	if err != nil {
+		t.Fatalf("load compile priv: %v", err)
+	}
+
+	rootFingerprint, err := signing.Fingerprint(rootPub)
+	if err != nil {
+		t.Fatalf("Fingerprint: %v", err)
+	}
+
+	body := contract.KeyRoster{
+		SchemaVersion:  1,
+		RosterSignedBy: keyIDRosterRoot,
+		DataClassRoot:  string(contract.DataClassInternal),
+		Keys: []contract.KeyInfo{
+			rosterKey(keyIDRosterRoot, signing.PurposeRosterRoot, rootPub, contract.KeyStatusRoot, "root"),
+			rosterKey(keyIDActivationPrimary, signing.PurposeContractActivationSigning, activationPub, contract.KeyStatusActive, "operator"),
+			rosterKey(keyIDCompilePrimary, signing.PurposeContractCompileSigning, compilePub, contract.KeyStatusActive, "compiler"),
+		},
+	}
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("roster preimage: %v", err)
+	}
+	envelope := contract.RosterEnvelope{
+		Body:      body,
+		Signature: signaturePrefixEd25519 + hex.EncodeToString(ed25519.Sign(rootPriv, preimage)),
+	}
+	rosterPath := filepath.Join(root, "roster.json")
+	rosterBytes, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal roster: %v", err)
+	}
+	if err := os.WriteFile(rosterPath, append(rosterBytes, '\n'), 0o600); err != nil {
+		t.Fatalf("write roster: %v", err)
+	}
+	if _, err := signing.LoadRoster(rosterPath, rootFingerprint); err != nil {
+		t.Fatalf("verify roster fixture: %v", err)
+	}
+
+	return Fixture{
+		root:            root,
+		rosterPath:      rosterPath,
+		rootFingerprint: rootFingerprint,
+		rootPriv:        rootPriv,
+		activationPub:   activationPub,
+		activationPriv:  activationPriv,
+		compilePub:      compilePub,
+		compilePriv:     compilePriv,
+	}
+}
+
+func (f Fixture) RosterPath() string {
+	return f.rosterPath
+}
+
+func (f Fixture) RootFingerprint() string {
+	return f.rootFingerprint
+}
+
+func (f Fixture) Root() string {
+	return f.root
+}
+
+func Env() contract.Environment {
+	return contract.Environment{ID: "prod"}
+}
+
+// ActiveStoreOptions bundles the per-generation knobs WriteSignedActiveStore
+// and WriteAcceptedActiveStore need so the helpers stay under the project's
+// 6-parameter guideline as more knobs are inevitably added by future tests.
+// Generation, PriorHash, and Environment have no zero-value safety, so
+// callers must populate them explicitly; PreviousGeneration is only
+// consulted by WriteAcceptedActiveStore (the CAS path) and is ignored by
+// WriteSignedActiveStore (the raw-write path).
+type ActiveStoreOptions struct {
+	Agent              string
+	Rules              []contract.Rule
+	Generation         uint64
+	PriorHash          string
+	PreviousGeneration uint64
+	Environment        contract.Environment
+}
+
+func WriteSignedActiveStore(t *testing.T, fixture Fixture, storeDir string, opts ActiveStoreOptions) {
+	t.Helper()
+	st := contractstore.New(storeDir)
+	contractHash := putSignedContract(t, st, fixture, opts)
+	active := signedManifest(t, contractHash, opts.Generation, opts.PriorHash, opts.Environment, fixture, opts.Agent)
+	raw, err := json.Marshal(active)
+	if err != nil {
+		t.Fatalf("marshal active manifest: %v", err)
+	}
+	if err := os.MkdirAll(storeDir, 0o750); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(storeDir, "active.json"), append(raw, '\n'), 0o600); err != nil {
+		t.Fatalf("write active.json: %v", err)
+	}
+}
+
+// WriteAcceptedActiveStore writes a signed active manifest through the
+// store's CAS path so the journal records an accepted promotion entry.
+// Use this instead of WriteSignedActiveStore when a test needs the
+// loader to recover a missed intermediate generation, since recovery
+// walks the accepted-history chain rather than raw on-disk active.json.
+// Returns the manifest hash so callers can chain PriorHash for
+// subsequent generations.
+func WriteAcceptedActiveStore(t *testing.T, fixture Fixture, storeDir string, opts ActiveStoreOptions) string {
+	t.Helper()
+	st := contractstore.New(storeDir)
+	contractHash := putSignedContract(t, st, fixture, opts)
+	active := signedManifest(t, contractHash, opts.Generation, opts.PriorHash, opts.Environment, fixture, opts.Agent)
+	raw, err := json.Marshal(active)
+	if err != nil {
+		t.Fatalf("marshal active manifest: %v", err)
+	}
+	loadedRoster, err := signing.LoadRoster(fixture.rosterPath, fixture.rootFingerprint)
+	if err != nil {
+		t.Fatalf("load roster: %v", err)
+	}
+	storeOpts := contractstore.Options{
+		Environment:        opts.Environment,
+		Roster:             loadedRoster,
+		PreviousHash:       opts.PriorHash,
+		PreviousGeneration: opts.PreviousGeneration,
+		MinSignatures:      1,
+		Now:                func() time.Time { return time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) },
+	}
+	hash, err := st.WriteActive(raw, storeOpts)
+	if err != nil {
+		t.Fatalf("WriteActive generation %d: %v", opts.Generation, err)
+	}
+	if _, err := st.Reload(storeOpts); err != nil {
+		t.Fatalf("Reload generation %d: %v", opts.Generation, err)
+	}
+	return hash
+}
+
+func HTTPEnforceRule(ruleID, host, pathValue, method string) contract.Rule {
+	return contract.Rule{
+		RuleID:               ruleID,
+		DisplayName:          ruleID,
+		RuleKind:             contract.RuleKindHTTPDestination,
+		LifecycleState:       contract.LifecycleEnforce,
+		RequiredCaptureGrade: contract.CaptureGradeFull,
+		ObservedCaptureGrade: contract.CaptureGradeFull,
+		Confidence:           "1.0",
+		WilsonLower:          "1.0",
+		Observation:          map[string]any{},
+		Selector: map[string]any{
+			"host":    map[string]any{"value": host},
+			"paths":   []any{map[string]any{"value": pathValue}},
+			"methods": []any{method},
+		},
+		Rationale:         map[string]any{},
+		RecurringSupport:  map[string]any{},
+		OpportunityHealth: map[string]any{},
+	}
+}
+
+func putSignedContract(t *testing.T, st contractstore.Store, fixture Fixture, opts ActiveStoreOptions) string {
+	t.Helper()
+	agent := opts.Agent
+	if agent == "" {
+		agent = "agent-a"
+	}
+	body := contract.Contract{
+		SchemaVersion:    contract.SchemaVersionContract,
+		ContractKind:     contract.ContractKind,
+		SignerKeyID:      keyIDCompilePrimary,
+		KeyPurpose:       signing.PurposeContractCompileSigning.String(),
+		DataClassRoot:    string(contract.DataClassInternal),
+		FieldDataClasses: map[string]string{},
+		Selector:         contract.Selector{Agent: agent, SelectorID: "sha256:selector"},
+		Rules:            append([]contract.Rule(nil), opts.Rules...),
+	}
+	hash, err := contractstore.ContractHash(body)
+	if err != nil {
+		t.Fatalf("contract hash: %v", err)
+	}
+	body.ContractHash = hash
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("contract preimage: %v", err)
+	}
+	env := contract.ContractEnvelope{
+		Body:      body,
+		Signature: signaturePrefixEd25519 + hex.EncodeToString(ed25519.Sign(fixture.compilePriv, preimage)),
+	}
+	raw, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal contract: %v", err)
+	}
+	loadedRoster, err := signing.LoadRoster(fixture.rosterPath, fixture.rootFingerprint)
+	if err != nil {
+		t.Fatalf("load roster: %v", err)
+	}
+	if got, err := st.PutHistoryContract(raw, contractstore.Options{
+		Roster:        loadedRoster,
+		MinSignatures: 1,
+		Now:           func() time.Time { return time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) },
+	}); err != nil {
+		t.Fatalf("PutHistoryContract: %v", err)
+	} else if got != hash {
+		t.Fatalf("PutHistoryContract hash = %q, want %q", got, hash)
+	}
+	return hash
+}
+
+func signedManifest(t *testing.T, contractHash string, generation uint64, prior string, env contract.Environment, fixture Fixture, agent string) contract.ActiveManifestEnvelope {
+	t.Helper()
+	if agent == "" {
+		agent = "agent-a"
+	}
+	selector := contract.ManifestSelector{Agent: agent, ContractHash: contractHash}
+	selectorID, err := selector.ComputeSelectorID()
+	if err != nil {
+		t.Fatalf("ComputeSelectorID: %v", err)
+	}
+	selector.SelectorID = selectorID
+	selectorSetHash, err := contract.ComputeSelectorSetHash([]contract.ManifestSelector{selector})
+	if err != nil {
+		t.Fatalf("ComputeSelectorSetHash: %v", err)
+	}
+	body := contract.ActiveManifest{
+		SchemaVersion:     1,
+		ManifestKind:      contract.ManifestKindActivation,
+		Generation:        generation,
+		PriorManifestHash: prior,
+		SelectorSetHash:   selectorSetHash,
+		Environment:       env,
+		Selectors:         []contract.ManifestSelector{selector},
+		HistoryRoot:       "contracts/history/",
+		SignedAt:          time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	}
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("manifest preimage: %v", err)
+	}
+	return contract.ActiveManifestEnvelope{
+		Body: body,
+		Signatures: []contract.ManifestSignature{{
+			KeyID:      keyIDActivationPrimary,
+			Principal:  "operator",
+			KeyPurpose: signing.PurposeContractActivationSigning.String(),
+			Algorithm:  "ed25519",
+			Signature:  signaturePrefixEd25519 + hex.EncodeToString(ed25519.Sign(fixture.activationPriv, preimage)),
+		}},
+	}
+}
+
+func rosterKey(keyID string, purpose signing.KeyPurpose, pub ed25519.PublicKey, status, principal string) contract.KeyInfo {
+	return contract.KeyInfo{
+		KeyID:        keyID,
+		KeyPurpose:   purpose.String(),
+		PublicKeyHex: hex.EncodeToString(pub),
+		ValidFrom:    time.Date(2026, 4, 29, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		Status:       status,
+		Principal:    principal,
+	}
+}

--- a/internal/contract/runtime/contractruntimetest/fixture_test.go
+++ b/internal/contract/runtime/contractruntimetest/fixture_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package contractruntimetest is a test-only support package consumed by
+// loader_test.go in the contract/runtime package and by the forward-proxy
+// contract gate tests in the proxy package. The smoke tests below
+// exercise the public surface so the cover profile records the package
+// — without them, go test ./... skips instrumentation here because the
+// package has no callers in its own _test files. Cross-package callers
+// in proxy and contract/runtime do exercise these helpers, but the
+// default Go cover mode only counts hits on packages with their own
+// tests.
+package contractruntimetest
+
+import (
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+)
+
+func TestFixture_AccessorsExposeRosterAndRoot(t *testing.T) {
+	t.Parallel()
+	f := NewFixture(t)
+	if f.RosterPath() == "" {
+		t.Fatal("RosterPath empty")
+	}
+	if f.RootFingerprint() == "" {
+		t.Fatal("RootFingerprint empty")
+	}
+	if f.Root() == "" {
+		t.Fatal("Root empty")
+	}
+	if Env() != (contract.Environment{ID: "prod"}) {
+		t.Fatalf("Env() = %v, want prod", Env())
+	}
+}
+
+func TestWriteSignedActiveStore_WritesActiveJSON(t *testing.T) {
+	t.Parallel()
+	f := NewFixture(t)
+	storeDir := filepath.Join(f.Root(), "store")
+	WriteSignedActiveStore(t, f, storeDir, ActiveStoreOptions{
+		Generation:  1,
+		PriorHash:   "sha256:genesis",
+		Environment: Env(),
+	})
+}
+
+func TestWriteAcceptedActiveStore_ReturnsManifestHash(t *testing.T) {
+	t.Parallel()
+	f := NewFixture(t)
+	storeDir := filepath.Join(f.Root(), "store")
+	hash := WriteAcceptedActiveStore(t, f, storeDir, ActiveStoreOptions{
+		Generation:  1,
+		PriorHash:   "sha256:genesis",
+		Environment: Env(),
+	})
+	if hash == "" {
+		t.Fatal("WriteAcceptedActiveStore returned empty hash")
+	}
+}
+
+func TestHTTPEnforceRule_ReturnsValidEnforceRule(t *testing.T) {
+	t.Parallel()
+	rule := HTTPEnforceRule("r-test", "api.example.com", "/v1/chat", http.MethodPost)
+	if rule.RuleID != "r-test" || rule.LifecycleState != contract.LifecycleEnforce {
+		t.Fatalf("rule = %+v", rule)
+	}
+	if rule.RuleKind != contract.RuleKindHTTPDestination {
+		t.Fatalf("rule_kind = %q", rule.RuleKind)
+	}
+}

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -5,9 +5,6 @@ package runtime
 
 import (
 	"context"
-	"crypto/ed25519"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -17,8 +14,8 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
 	contractstore "github.com/luckyPipewrench/pipelock/internal/contract/store"
-	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 func TestNewLoader_RejectsMissingFields(t *testing.T) {
@@ -106,7 +103,7 @@ func TestNewLoader_RejectsMissingRosterFile(t *testing.T) {
 func TestNewLoader_NoActiveManifest_ReturnsNilCurrent(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	if err := os.MkdirAll(storeDir, 0o750); err != nil {
 		t.Fatalf("mkdir store: %v", err)
 	}
@@ -114,8 +111,8 @@ func TestNewLoader_NoActiveManifest_ReturnsNilCurrent(t *testing.T) {
 	metrics := &captureMetrics{}
 	loader, err := NewLoader(LoaderOptions{
 		StoreDir:              storeDir,
-		RosterPath:            fixture.rosterPath,
-		PinnedRootFingerprint: fixture.rootFingerprint,
+		RosterPath:            fixture.RosterPath(),
+		PinnedRootFingerprint: fixture.RootFingerprint(),
 		Environment:           testLoaderEnv(),
 		MinSignatures:         1,
 		Mode:                  ModeShadow,
@@ -142,7 +139,7 @@ func TestNewLoader_NoActiveManifest_ReturnsNilCurrent(t *testing.T) {
 func TestLoader_ReloadAcceptsSameHashWithoutError(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", testLoaderEnv())
 
 	metrics := &captureMetrics{}
@@ -169,7 +166,7 @@ func TestLoader_ReloadAcceptsSameHashWithoutError(t *testing.T) {
 func TestLoader_ReloadRejectsMissingActiveAfterCurrent(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", testLoaderEnv())
 
 	metrics := &captureMetrics{}
@@ -199,7 +196,7 @@ func TestLoader_ReloadRejectsMissingActiveAfterCurrent(t *testing.T) {
 func TestLoader_ReloadRejectsEnvironmentMismatchAndKeepsCurrent(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	env := testLoaderEnv()
 	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
 
@@ -226,7 +223,7 @@ func TestLoader_ReloadRejectsEnvironmentMismatchAndKeepsCurrent(t *testing.T) {
 func TestLoader_ReloadRejectsGenerationDowngradeAndKeepsCurrent(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	env := testLoaderEnv()
 	writeSignedActiveStore(t, fixture, storeDir, 2, "sha256:genesis", env)
 
@@ -273,7 +270,7 @@ func TestLoader_NilMetricsExercisesNoopImpl(t *testing.T) {
 	// real method receivers. Coverage proves no panic and no nil-deref
 	// from production code paths that assume metrics is always set.
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	if err := os.MkdirAll(storeDir, 0o750); err != nil {
 		t.Fatalf("mkdir store: %v", err)
 	}
@@ -294,7 +291,7 @@ func TestLoader_NilMetricsExercisesNoopImpl(t *testing.T) {
 func TestLoader_ReloadAdoptsAcceptedActiveAfterMissedIntermediate(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	env := testLoaderEnv()
 	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
 
@@ -338,7 +335,7 @@ func TestLoader_ReloadAdoptsAcceptedActiveAfterMissedIntermediate(t *testing.T) 
 func TestLoader_ReloadRejectsSkippedActiveWithoutAcceptedHistory(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	env := testLoaderEnv()
 	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
 
@@ -369,7 +366,7 @@ func TestLoader_ReloadRejectsSkippedActiveWithoutAcceptedHistory(t *testing.T) {
 func TestLoader_Watch_CancelExitsCleanly(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	if err := os.MkdirAll(storeDir, 0o750); err != nil {
 		t.Fatalf("mkdir store: %v", err)
 	}
@@ -400,7 +397,7 @@ func TestLoader_Watch_CancelExitsCleanly(t *testing.T) {
 func TestLoader_Watch_FileReplacementTriggersReload(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	env := testLoaderEnv()
 	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
 
@@ -437,7 +434,7 @@ func TestLoader_Watch_FileReplacementTriggersReload(t *testing.T) {
 func TestLoader_Watch_DebounceCoalescesBurstAndSameHashIsNoop(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	env := testLoaderEnv()
 	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
 
@@ -504,7 +501,7 @@ func TestLoader_Watch_DebounceCoalescesBurstAndSameHashIsNoop(t *testing.T) {
 func TestLoader_Watch_RejectedReloadKeepsWatcherAlive(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	env := testLoaderEnv()
 	writeSignedActiveStore(t, fixture, storeDir, 2, "sha256:genesis", env)
 
@@ -565,7 +562,7 @@ func TestLoader_Watch_NilReceiverReturnsError(t *testing.T) {
 func TestLoader_Watch_DebounceMaxWaitFlushesUnderSustainedWrites(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	env := testLoaderEnv()
 	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
 
@@ -640,7 +637,7 @@ func TestLoader_Watch_RemoveEventTriggersReload(t *testing.T) {
 	// an explicit operator unlink fires Remove cleanly. Without Remove
 	// in the trigger predicate the loader would sit on stale state.
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	env := testLoaderEnv()
 	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
 
@@ -688,7 +685,7 @@ func TestLoader_ReloadRejectsRecoveryChainBreak(t *testing.T) {
 	// missing from accepted history, the walk fails and the rejection
 	// stands. This exercises acceptedChainReachesCurrent's break path.
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	env := testLoaderEnv()
 	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
 
@@ -768,7 +765,7 @@ func TestNewLoader_FailsOnMalformedActiveManifest(t *testing.T) {
 	// fire, so this exercises the initial-reload error path that maps to
 	// the wrapped initial reload error.
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	if err := os.MkdirAll(storeDir, 0o750); err != nil {
 		t.Fatalf("mkdir store: %v", err)
 	}
@@ -789,7 +786,7 @@ func TestLoader_Watch_FailsOnMissingStoreDir(t *testing.T) {
 	// caller so the supervisor knows the lock runtime is unhealthy
 	// instead of silently looping.
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", testLoaderEnv())
 	loader, err := NewLoader(loaderOptions(fixture, storeDir, testLoaderEnv()), nil)
 	if err != nil {
@@ -814,7 +811,7 @@ func TestRecoverAcceptedActiveRejectsNilPrev(t *testing.T) {
 	// not crash. Reload always passes a non-nil prev when invoking
 	// recovery, so this test exists to keep the guard wired.
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", testLoaderEnv())
 	loader, err := NewLoader(loaderOptions(fixture, storeDir, testLoaderEnv()), nil)
 	if err != nil {
@@ -828,7 +825,7 @@ func TestRecoverAcceptedActiveRejectsNilPrev(t *testing.T) {
 func TestLoader_Watch_DirectoryDeletionEndsWatcher(t *testing.T) {
 	t.Parallel()
 	fixture := newRosterFixture(t)
-	storeDir := filepath.Join(fixture.root, "store")
+	storeDir := filepath.Join(fixture.Root(), "store")
 	env := testLoaderEnv()
 	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
 
@@ -897,105 +894,23 @@ func snapshotOutcomes(m *captureMetrics) map[string]int {
 	return out
 }
 
-// rosterFixture is the minimum fixture the Loader needs at construction
-// time: a real Ed25519 root key, a real activation-signing key, and a
-// roster file on disk that signing.LoadRoster can verify. Tests that
-// build a real signed active.json reuse this fixture and add the
-// manifest-side scaffolding on top in F3c.
-type rosterFixture struct {
-	root            string
-	rosterPath      string
-	rootFingerprint string
-	rootPriv        ed25519.PrivateKey
-	activationPub   ed25519.PublicKey
-	activationPriv  ed25519.PrivateKey
-	compilePub      ed25519.PublicKey
-	compilePriv     ed25519.PrivateKey
-}
+// rosterFixture aliases the shared contractruntimetest.Fixture so the
+// existing test helpers in this file continue to compile. The fixture
+// was extracted into a reusable package so the forward-proxy contract
+// gate tests can build the same signed-roster shape without copying
+// 100+ lines of signing scaffolding.
+type rosterFixture = contractruntimetest.Fixture
 
 func newRosterFixture(t *testing.T) rosterFixture {
 	t.Helper()
-	root := t.TempDir()
-	keystoreDir := filepath.Join(root, "keys")
-	ks := signing.NewKeystore(keystoreDir)
-
-	rootPub, err := ks.GenerateAgent("roster-root")
-	if err != nil {
-		t.Fatalf("generate root: %v", err)
-	}
-	rootPriv, err := ks.LoadPrivateKey("roster-root")
-	if err != nil {
-		t.Fatalf("load root priv: %v", err)
-	}
-	activationPub, err := ks.GenerateAgent("activation-primary")
-	if err != nil {
-		t.Fatalf("generate activation: %v", err)
-	}
-	activationPriv, err := ks.LoadPrivateKey("activation-primary")
-	if err != nil {
-		t.Fatalf("load activation priv: %v", err)
-	}
-	compilePub, err := ks.GenerateAgent("compile-primary")
-	if err != nil {
-		t.Fatalf("generate compile: %v", err)
-	}
-	compilePriv, err := ks.LoadPrivateKey("compile-primary")
-	if err != nil {
-		t.Fatalf("load compile priv: %v", err)
-	}
-
-	rootFingerprint, err := signing.Fingerprint(rootPub)
-	if err != nil {
-		t.Fatalf("Fingerprint: %v", err)
-	}
-
-	body := contract.KeyRoster{
-		SchemaVersion:  1,
-		RosterSignedBy: "roster-root",
-		DataClassRoot:  string(contract.DataClassInternal),
-		Keys: []contract.KeyInfo{
-			rosterKey("roster-root", signing.PurposeRosterRoot, rootPub, contract.KeyStatusRoot, "root"),
-			rosterKey("activation-primary", signing.PurposeContractActivationSigning, activationPub, contract.KeyStatusActive, "operator"),
-			rosterKey("compile-primary", signing.PurposeContractCompileSigning, compilePub, contract.KeyStatusActive, "compiler"),
-		},
-	}
-	preimage, err := body.SignablePreimage()
-	if err != nil {
-		t.Fatalf("roster preimage: %v", err)
-	}
-	envelope := contract.RosterEnvelope{
-		Body:      body,
-		Signature: "ed25519:" + hex.EncodeToString(ed25519.Sign(rootPriv, preimage)),
-	}
-	rosterPath := filepath.Join(root, "roster.json")
-	rosterBytes, err := json.Marshal(envelope)
-	if err != nil {
-		t.Fatalf("marshal roster: %v", err)
-	}
-	if err := os.WriteFile(rosterPath, append(rosterBytes, '\n'), 0o600); err != nil {
-		t.Fatalf("write roster: %v", err)
-	}
-	if _, err := signing.LoadRoster(rosterPath, rootFingerprint); err != nil {
-		t.Fatalf("verify roster fixture: %v", err)
-	}
-
-	return rosterFixture{
-		root:            root,
-		rosterPath:      rosterPath,
-		rootFingerprint: rootFingerprint,
-		rootPriv:        rootPriv,
-		activationPub:   activationPub,
-		activationPriv:  activationPriv,
-		compilePub:      compilePub,
-		compilePriv:     compilePriv,
-	}
+	return contractruntimetest.NewFixture(t)
 }
 
 func loaderOptions(fixture rosterFixture, storeDir string, env contract.Environment) LoaderOptions {
 	return LoaderOptions{
 		StoreDir:              storeDir,
-		RosterPath:            fixture.rosterPath,
-		PinnedRootFingerprint: fixture.rootFingerprint,
+		RosterPath:            fixture.RosterPath(),
+		PinnedRootFingerprint: fixture.RootFingerprint(),
 		Environment:           env,
 		MinSignatures:         1,
 		Mode:                  ModeShadow,
@@ -1004,149 +919,29 @@ func loaderOptions(fixture rosterFixture, storeDir string, env contract.Environm
 }
 
 func testLoaderEnv() contract.Environment {
-	return contract.Environment{ID: "prod", Tenant: "tenant-a", DeploymentID: "deploy-a"}
+	return contractruntimetest.Env()
 }
 
 func writeSignedActiveStore(t *testing.T, fixture rosterFixture, storeDir string, generation uint64, prior string, env contract.Environment) {
 	t.Helper()
-	st := contractstore.New(storeDir)
-	contractHash := putSignedLoaderContract(t, st, fixture)
-	active := signedLoaderManifest(t, contractHash, generation, prior, env, fixture)
-	raw, err := json.Marshal(active)
-	if err != nil {
-		t.Fatalf("marshal active manifest: %v", err)
-	}
-	if err := os.MkdirAll(storeDir, 0o750); err != nil {
-		t.Fatalf("mkdir store: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(storeDir, "active.json"), append(raw, '\n'), 0o600); err != nil {
-		t.Fatalf("write active.json: %v", err)
-	}
+	contractruntimetest.WriteSignedActiveStore(t, fixture, storeDir, contractruntimetest.ActiveStoreOptions{
+		Generation:  generation,
+		PriorHash:   prior,
+		Environment: env,
+	})
 }
 
+// writeAcceptedActiveStore funnels the missed-intermediate recovery
+// tests through the shared helper so the store-CAS path stays in one
+// place. Returns the manifest hash so callers can chain prior hashes.
 func writeAcceptedActiveStore(t *testing.T, fixture rosterFixture, storeDir string, generation uint64, prior string, previousGeneration uint64, env contract.Environment) string {
 	t.Helper()
-	st := contractstore.New(storeDir)
-	contractHash := putSignedLoaderContract(t, st, fixture)
-	active := signedLoaderManifest(t, contractHash, generation, prior, env, fixture)
-	raw, err := json.Marshal(active)
-	if err != nil {
-		t.Fatalf("marshal active manifest: %v", err)
-	}
-	loadedRoster, err := signing.LoadRoster(fixture.rosterPath, fixture.rootFingerprint)
-	if err != nil {
-		t.Fatalf("load roster: %v", err)
-	}
-	opts := contractstore.Options{
-		Environment:        env,
-		Roster:             loadedRoster,
-		PreviousHash:       prior,
+	return contractruntimetest.WriteAcceptedActiveStore(t, fixture, storeDir, contractruntimetest.ActiveStoreOptions{
+		Generation:         generation,
+		PriorHash:          prior,
 		PreviousGeneration: previousGeneration,
-		MinSignatures:      1,
-		Now:                func() time.Time { return time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) },
-	}
-	hash, err := st.WriteActive(raw, opts)
-	if err != nil {
-		t.Fatalf("WriteActive generation %d: %v", generation, err)
-	}
-	if _, err := st.Reload(opts); err != nil {
-		t.Fatalf("Reload generation %d: %v", generation, err)
-	}
-	return hash
-}
-
-func putSignedLoaderContract(t *testing.T, st contractstore.Store, fixture rosterFixture) string {
-	t.Helper()
-	body := contract.Contract{
-		SchemaVersion:    contract.SchemaVersionContract,
-		ContractKind:     contract.ContractKind,
-		SignerKeyID:      "compile-primary",
-		KeyPurpose:       signing.PurposeContractCompileSigning.String(),
-		DataClassRoot:    string(contract.DataClassInternal),
-		FieldDataClasses: map[string]string{},
-		Selector:         contract.Selector{Agent: "agent-a", SelectorID: "sha256:selector"},
-	}
-	hash, err := contractstore.ContractHash(body)
-	if err != nil {
-		t.Fatalf("contract hash: %v", err)
-	}
-	body.ContractHash = hash
-	preimage, err := body.SignablePreimage()
-	if err != nil {
-		t.Fatalf("contract preimage: %v", err)
-	}
-	env := contract.ContractEnvelope{
-		Body:      body,
-		Signature: "ed25519:" + hex.EncodeToString(ed25519.Sign(fixture.compilePriv, preimage)),
-	}
-	raw, err := json.Marshal(env)
-	if err != nil {
-		t.Fatalf("marshal contract: %v", err)
-	}
-	loadedRoster, err := signing.LoadRoster(fixture.rosterPath, fixture.rootFingerprint)
-	if err != nil {
-		t.Fatalf("load roster: %v", err)
-	}
-	if got, err := st.PutHistoryContract(raw, contractstore.Options{
-		Roster:        loadedRoster,
-		MinSignatures: 1,
-		Now:           func() time.Time { return time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) },
-	}); err != nil {
-		t.Fatalf("PutHistoryContract: %v", err)
-	} else if got != hash {
-		t.Fatalf("PutHistoryContract hash = %q, want %q", got, hash)
-	}
-	return hash
-}
-
-func signedLoaderManifest(t *testing.T, contractHash string, generation uint64, prior string, env contract.Environment, fixture rosterFixture) contract.ActiveManifestEnvelope {
-	t.Helper()
-	selector := contract.ManifestSelector{Agent: "agent-a", ContractHash: contractHash}
-	selectorID, err := selector.ComputeSelectorID()
-	if err != nil {
-		t.Fatalf("ComputeSelectorID: %v", err)
-	}
-	selector.SelectorID = selectorID
-	selectorSetHash, err := contract.ComputeSelectorSetHash([]contract.ManifestSelector{selector})
-	if err != nil {
-		t.Fatalf("ComputeSelectorSetHash: %v", err)
-	}
-	body := contract.ActiveManifest{
-		SchemaVersion:     1,
-		ManifestKind:      contract.ManifestKindActivation,
-		Generation:        generation,
-		PriorManifestHash: prior,
-		SelectorSetHash:   selectorSetHash,
-		Environment:       env,
-		Selectors:         []contract.ManifestSelector{selector},
-		HistoryRoot:       "contracts/history/",
-		SignedAt:          time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
-	}
-	preimage, err := body.SignablePreimage()
-	if err != nil {
-		t.Fatalf("manifest preimage: %v", err)
-	}
-	return contract.ActiveManifestEnvelope{
-		Body: body,
-		Signatures: []contract.ManifestSignature{{
-			KeyID:      "activation-primary",
-			Principal:  "operator",
-			KeyPurpose: signing.PurposeContractActivationSigning.String(),
-			Algorithm:  "ed25519",
-			Signature:  "ed25519:" + hex.EncodeToString(ed25519.Sign(fixture.activationPriv, preimage)),
-		}},
-	}
-}
-
-func rosterKey(keyID string, purpose signing.KeyPurpose, pub ed25519.PublicKey, status, principal string) contract.KeyInfo {
-	return contract.KeyInfo{
-		KeyID:        keyID,
-		KeyPurpose:   purpose.String(),
-		PublicKeyHex: hex.EncodeToString(pub),
-		ValidFrom:    time.Date(2026, 4, 29, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
-		Status:       status,
-		Principal:    principal,
-	}
+		Environment:        env,
+	})
 }
 
 // captureMetrics records LoaderMetrics calls for assertion in tests. The

--- a/internal/proxy/contractgate.go
+++ b/internal/proxy/contractgate.go
@@ -1,0 +1,276 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+// Decision.Reason values the runtime evaluator emits. Aliases the typed
+// blockreason vocabulary so transport call sites get a single source of
+// truth. A typo in a runtime reason string fails compile here rather than
+// silently dropping into writeGateBlockedError's parse_error fallback.
+const (
+	contractDefaultDenyReason    = string(blockreason.ContractDefaultDeny)
+	contractEnforceDefaultReason = string(blockreason.ContractEnforceDefault)
+	contractNonDefaultPortReason = string(blockreason.ContractNonDefaultPort)
+	contractInvalidPathReason    = string(blockreason.ContractInvalidPath)
+	contractObservedOnlyReason   = string(blockreason.ContractObservedOnly)
+	killSwitchActiveReason       = string(blockreason.KillSwitchActive)
+)
+
+// blockLayerContract is the layer label every contract-runtime block path
+// stamps onto receipts, metrics, and X-Pipelock-Block-Reason-Layer headers.
+// Held as a single const so a typo on any one of the ~9 emit sites cannot
+// silently route receipts into a separate label dimension.
+const blockLayerContract = "contract"
+
+// ContractGateInput captures the proxy-side state a single request brings to
+// the contract evaluator. The helper is transport-agnostic; callers resolve
+// agent identity before invoking it.
+type ContractGateInput struct {
+	Loader           *contractruntime.Loader
+	Agent            string
+	URL              string
+	Method           string
+	EffectiveAction  string
+	ScannerVerdict   string
+	ScannerMatched   bool
+	PolicySources    []string
+	KillSwitchActive bool
+	Transport        string
+}
+
+// ContractGateOutput is the verdict and attribution metadata the proxy acts
+// on. Verdict is enforcement surface; LiveVerdict and Drift are telemetry.
+type ContractGateOutput struct {
+	Verdict            string
+	LiveVerdict        string
+	PolicySources      []string
+	WinningSource      string
+	RuleID             string
+	Reason             string
+	Drift              *contractruntime.DriftEvent
+	Resolved           *contractruntime.ResolvedContract
+	ReceiptStub        any
+	ActiveManifestHash string
+	ContractHash       string
+	SelectorID         string
+	ContractGeneration uint64
+}
+
+// EvaluateGate resolves the active contract for the agent, evaluates the HTTP
+// runtime decision sequence, and returns the verdict the proxy must enforce.
+func EvaluateGate(input ContractGateInput) (ContractGateOutput, error) {
+	scannerVerdict := input.ScannerVerdict
+	if scannerVerdict == "" {
+		scannerVerdict = config.ActionBlock
+	}
+
+	fallback := ContractGateOutput{
+		Verdict:       scannerVerdict,
+		LiveVerdict:   scannerVerdict,
+		PolicySources: append([]string(nil), input.PolicySources...),
+		WinningSource: contractruntime.WinningSourceScanner,
+	}
+	if input.Loader == nil {
+		return fallback, nil
+	}
+	active := input.Loader.Current()
+	if active == nil {
+		return fallback, nil
+	}
+
+	var resolved *contractruntime.ResolvedContract
+	if pin, ok := active.Resolve(input.Agent); ok {
+		resolved = pin
+	}
+
+	decision, err := contractruntime.EvaluateHTTP(contractruntime.EvaluateOptions{
+		Resolved: resolved,
+		Request: contractruntime.HTTPRequest{
+			URL:             input.URL,
+			Method:          input.Method,
+			EffectiveAction: input.EffectiveAction,
+		},
+		Mode:             input.Loader.Mode(),
+		KillSwitchActive: input.KillSwitchActive,
+		ScannerVerdict:   scannerVerdict,
+		ScannerMatched:   input.ScannerMatched,
+		PolicySources:    input.PolicySources,
+	})
+	if err != nil {
+		return ContractGateOutput{}, err
+	}
+	out := ContractGateOutput{
+		Verdict:       decision.Verdict,
+		LiveVerdict:   decision.LiveVerdict,
+		PolicySources: append([]string(nil), decision.PolicySources...),
+		WinningSource: decision.WinningSource,
+		RuleID:        decision.RuleID,
+		Reason:        decision.Reason,
+		Drift:         decision.Drift,
+		Resolved:      resolved,
+	}
+	if resolved != nil {
+		out.ActiveManifestHash = resolved.ActiveManifestHash
+		out.ContractHash = resolved.ContractHash
+		out.SelectorID = resolved.SelectorID
+		out.ContractGeneration = resolved.ContractGeneration
+	}
+	return out, nil
+}
+
+func buildContractLoader(cfg *config.Config) (*contractruntime.Loader, error) {
+	if cfg == nil || !cfg.LearnLock.Enabled {
+		return nil, nil
+	}
+	loader, err := contractruntime.NewLoader(contractruntime.LoaderOptions{
+		StoreDir:              cfg.LearnLock.StoreDir,
+		RosterPath:            cfg.LearnLock.RosterPath,
+		PinnedRootFingerprint: cfg.LearnLock.PinnedRootFingerprint,
+		Environment: contract.Environment{
+			ID: cfg.LearnLock.Environment,
+		},
+		MinSignatures: cfg.LearnLock.EffectiveMinimumSignatures(),
+		Mode:          contractruntime.Mode(cfg.LearnLock.EffectiveMode()),
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("contract loader init: %w", err)
+	}
+	return loader, nil
+}
+
+func (p *Proxy) currentContractLoader() *contractruntime.Loader {
+	return p.contractLoaderPtr.Load()
+}
+
+func withContractReceipt(gate ContractGateOutput, opts receipt.EmitOpts) receipt.EmitOpts {
+	if !gate.HasContractContext() {
+		return opts
+	}
+	opts.ContractWinningSource = gate.WinningSource
+	opts.ContractLiveVerdict = gate.LiveVerdict
+	opts.ContractPolicySources = append([]string(nil), gate.PolicySources...)
+	opts.ContractRuleID = gate.RuleID
+	opts.ActiveManifestHash = gate.ActiveManifestHash
+	opts.ContractHash = gate.ContractHash
+	opts.ContractSelectorID = gate.SelectorID
+	opts.ContractGeneration = gate.ContractGeneration
+	return opts
+}
+
+func (gate ContractGateOutput) HasContractContext() bool {
+	return gate.Resolved != nil || gate.ActiveManifestHash != "" || gate.ContractHash != ""
+}
+
+func contractBlockInfo(reason string) (blockreason.Info, bool) {
+	switch reason {
+	case contractDefaultDenyReason,
+		contractEnforceDefaultReason,
+		contractNonDefaultPortReason,
+		contractInvalidPathReason,
+		contractObservedOnlyReason:
+		return blockreason.Info{
+			Reason:   blockreason.Reason(reason),
+			Severity: blockreason.SeverityCritical,
+			Retry:    blockreason.RetryPolicy,
+			Layer:    blockLayerContract,
+		}, true
+	default:
+		return blockreason.Info{}, false
+	}
+}
+
+func writeGateBlockedError(w http.ResponseWriter, gate ContractGateOutput, body string, status int) {
+	if gate.Reason == killSwitchActiveReason || gate.WinningSource == contractruntime.WinningSourceKillSwitch {
+		writeBlockedError(w, blockInfoFor(blockreason.KillSwitchActive, "kill_switch"), body, status)
+		return
+	}
+	if gate.WinningSource == contractruntime.WinningSourceScanner {
+		writeBlockedError(w, blockInfoFor(blockreason.ParseError, "scanner"), body, status)
+		return
+	}
+	if info, ok := contractBlockInfo(gate.Reason); ok {
+		writeBlockedError(w, info, body, status)
+		return
+	}
+	writeBlockedError(w, blockInfoFor(blockreason.ParseError, blockLayerContract), body, status)
+}
+
+func scannerVerdictForGate(hasFinding bool) string {
+	if hasFinding {
+		return config.ActionWarn
+	}
+	return config.ActionAllow
+}
+
+// ForwardBlockReceiptInput is the per-request data the forward block-receipt
+// helper needs. It collapses the loose arguments forwardBlockReceiptOpts would
+// otherwise take.
+type ForwardBlockReceiptInput struct {
+	ActionID  string
+	RequestID string
+	Agent     string
+	Method    string
+	Target    string
+	Layer     string
+	Pattern   string
+	Taint     taintDecision
+}
+
+// forwardKillSwitchReceiptOpts assembles the bare receipt for an
+// absolute-URI forward request denied by the buildHandler-level kill
+// switch. Agent identity is not resolved at that layer (the kill
+// switch fires before resolveAgentRuntimeFromRequest), so the receipt
+// carries no taint or contract context — the layer + transport + URL
+// is enough to keep the audit chain unbroken.
+func forwardKillSwitchReceiptOpts(actionID, requestID, method, target string) receipt.EmitOpts {
+	return receipt.EmitOpts{
+		ActionID:  actionID,
+		Verdict:   config.ActionBlock,
+		Layer:     "kill_switch",
+		Pattern:   killSwitchActiveReason,
+		Transport: TransportForward,
+		Method:    method,
+		Target:    target,
+		RequestID: requestID,
+	}
+}
+
+// forwardBlockReceiptOpts assembles the EmitOpts the forward-proxy block
+// paths emit for contract-gate failures and contract-gate denies. Both
+// callers stamp the same forward + taint context onto the receipt; the
+// helper is unit-testable so the gate-fail branch in handleForwardHTTP
+// does not need an integration shape that produces a malformed URL just
+// to exercise the receipt fields.
+func forwardBlockReceiptOpts(in ForwardBlockReceiptInput) receipt.EmitOpts {
+	return receipt.EmitOpts{
+		ActionID:            in.ActionID,
+		Verdict:             config.ActionBlock,
+		Layer:               in.Layer,
+		Pattern:             in.Pattern,
+		Transport:           TransportForward,
+		Method:              in.Method,
+		Target:              in.Target,
+		RequestID:           in.RequestID,
+		Agent:               in.Agent,
+		SessionTaintLevel:   in.Taint.Risk.Level.String(),
+		SessionContaminated: in.Taint.Risk.Contaminated,
+		RecentTaintSources:  in.Taint.Risk.Sources,
+		SessionTaskID:       in.Taint.Task.CurrentTaskID,
+		SessionTaskLabel:    in.Taint.Task.CurrentTaskLabel,
+		AuthorityKind:       in.Taint.Authority.String(),
+		TaintDecision:       in.Taint.Result.Decision.String(),
+		TaintDecisionReason: in.Taint.Result.Reason,
+		TaskOverrideApplied: in.Taint.TaskOverrideApplied,
+	}
+}

--- a/internal/proxy/contractgate_test.go
+++ b/internal/proxy/contractgate_test.go
@@ -1,0 +1,424 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
+	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+func TestEvaluateGate_NilLoaderFallsThroughToScanner(t *testing.T) {
+	out, err := EvaluateGate(ContractGateInput{
+		URL:            "http://api.example.com/v1/chat",
+		Method:         http.MethodPost,
+		ScannerVerdict: config.ActionAllow,
+		Transport:      TransportForward,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateGate: %v", err)
+	}
+	if out.Verdict != config.ActionAllow {
+		t.Fatalf("verdict = %q, want allow", out.Verdict)
+	}
+	if out.WinningSource != contractruntime.WinningSourceScanner {
+		t.Fatalf("winning_source = %q, want scanner", out.WinningSource)
+	}
+	if out.HasContractContext() {
+		t.Fatalf("contract context = true, want false without active loader")
+	}
+	opts := withContractReceipt(out, receipt.EmitOpts{Verdict: config.ActionAllow})
+	if opts.ContractWinningSource != "" || len(opts.ContractPolicySources) != 0 {
+		t.Fatalf("receipt opts got contract fields without active contract: %+v", opts)
+	}
+}
+
+func TestEvaluateGate_NoActiveManifestDoesNotEmitContractReceiptContext(t *testing.T) {
+	loader := emptyContractLoader(t, contractruntime.ModeLive)
+	out, err := EvaluateGate(ContractGateInput{
+		Loader:         loader,
+		Agent:          "agent-a",
+		URL:            "http://api.example.com/v1/chat",
+		Method:         http.MethodPost,
+		ScannerVerdict: config.ActionAllow,
+		Transport:      TransportForward,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateGate: %v", err)
+	}
+	if out.Verdict != config.ActionAllow {
+		t.Fatalf("verdict = %q, want allow", out.Verdict)
+	}
+	if out.HasContractContext() {
+		t.Fatalf("contract context = true, want false without active manifest")
+	}
+	opts := withContractReceipt(out, receipt.EmitOpts{Verdict: config.ActionAllow})
+	if opts.ContractWinningSource != "" || opts.ActiveManifestHash != "" || opts.ContractHash != "" {
+		t.Fatalf("receipt opts got contract fields without active manifest: %+v", opts)
+	}
+}
+
+func TestEvaluateGate_LiveDefaultDeny(t *testing.T) {
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	loader := testContractLoader(t, contractruntime.ModeLive, rule)
+
+	out, err := EvaluateGate(ContractGateInput{
+		Loader:         loader,
+		Agent:          "agent-a",
+		URL:            "http://evil.example.com/v1/chat",
+		Method:         http.MethodPost,
+		ScannerVerdict: config.ActionAllow,
+		Transport:      TransportForward,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateGate: %v", err)
+	}
+	if out.Verdict != config.ActionBlock {
+		t.Fatalf("verdict = %q, want block", out.Verdict)
+	}
+	if out.Reason != contractDefaultDenyReason {
+		t.Fatalf("reason = %q, want %s", out.Reason, contractDefaultDenyReason)
+	}
+	if out.WinningSource != contractruntime.WinningSourceContract {
+		t.Fatalf("winning_source = %q, want contract", out.WinningSource)
+	}
+	if !out.HasContractContext() {
+		t.Fatalf("contract context = false, want true with resolved contract")
+	}
+}
+
+func TestEvaluateGate_ScannerBlockWins(t *testing.T) {
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	loader := testContractLoader(t, contractruntime.ModeLive, rule)
+
+	out, err := EvaluateGate(ContractGateInput{
+		Loader:         loader,
+		Agent:          "agent-a",
+		URL:            "http://api.example.com/v1/chat",
+		Method:         http.MethodPost,
+		ScannerVerdict: config.ActionBlock,
+		ScannerMatched: true,
+		Transport:      TransportForward,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateGate: %v", err)
+	}
+	if out.Verdict != config.ActionBlock {
+		t.Fatalf("verdict = %q, want block", out.Verdict)
+	}
+	if out.WinningSource != contractruntime.WinningSourceScanner {
+		t.Fatalf("winning_source = %q, want scanner", out.WinningSource)
+	}
+}
+
+func TestEvaluateGate_ShadowSurfacesLiveVerdictWithoutBlocking(t *testing.T) {
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	loader := testContractLoader(t, contractruntime.ModeShadow, rule)
+
+	out, err := EvaluateGate(ContractGateInput{
+		Loader:         loader,
+		Agent:          "agent-a",
+		URL:            "http://evil.example.com/v1/chat",
+		Method:         http.MethodPost,
+		ScannerVerdict: config.ActionAllow,
+		Transport:      TransportForward,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateGate: %v", err)
+	}
+	if out.Verdict != config.ActionAllow {
+		t.Fatalf("verdict = %q, want allow", out.Verdict)
+	}
+	if out.LiveVerdict != config.ActionBlock {
+		t.Fatalf("live_verdict = %q, want block", out.LiveVerdict)
+	}
+	if out.Drift == nil {
+		t.Fatal("drift = nil, want contract drift event")
+	}
+}
+
+func TestBuildContractLoader_DisabledReturnsNil(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LearnLock.Enabled = false
+	loader, err := buildContractLoader(cfg)
+	if err != nil {
+		t.Fatalf("buildContractLoader: %v", err)
+	}
+	if loader != nil {
+		t.Fatalf("loader = %v, want nil when learn-lock disabled", loader)
+	}
+}
+
+func TestBuildContractLoader_NilConfigReturnsNil(t *testing.T) {
+	loader, err := buildContractLoader(nil)
+	if err != nil {
+		t.Fatalf("buildContractLoader: %v", err)
+	}
+	if loader != nil {
+		t.Fatalf("loader = %v, want nil for nil config", loader)
+	}
+}
+
+func TestBuildContractLoader_EnabledHappyPathReturnsLoader(t *testing.T) {
+	// Exercises the success arm of buildContractLoader so the
+	// proxy-boot wiring is locked in alongside the disabled and
+	// error paths. Uses contractruntimetest fixture so the roster
+	// signing scaffolding stays in one place across packages.
+	fixture := contractruntimetest.NewFixture(t)
+	storeDir := t.TempDir()
+	contractruntimetest.WriteSignedActiveStore(t, fixture, storeDir, contractruntimetest.ActiveStoreOptions{
+		Generation:  1,
+		PriorHash:   "sha256:genesis",
+		Environment: contractruntimetest.Env(),
+	})
+
+	cfg := &config.Config{}
+	cfg.LearnLock.Enabled = true
+	cfg.LearnLock.StoreDir = storeDir
+	cfg.LearnLock.RosterPath = fixture.RosterPath()
+	cfg.LearnLock.PinnedRootFingerprint = fixture.RootFingerprint()
+	cfg.LearnLock.Environment = "prod"
+	cfg.LearnLock.MinimumSignatures = 1
+	cfg.LearnLock.Mode = "live"
+
+	loader, err := buildContractLoader(cfg)
+	if err != nil {
+		t.Fatalf("buildContractLoader: %v", err)
+	}
+	if loader == nil {
+		t.Fatal("loader = nil, want loader for enabled config")
+	}
+	if loader.Mode() != contractruntime.ModeLive {
+		t.Fatalf("loader.Mode() = %q, want live", loader.Mode())
+	}
+}
+
+func TestBuildContractLoader_EnabledMissingFieldsErrors(t *testing.T) {
+	// Defensive path. Enabled=true with no store_dir means NewLoader
+	// fails fast at proxy init rather than panicking later when the
+	// gate tries to call Current() on a half-built loader.
+	cfg := &config.Config{}
+	cfg.LearnLock.Enabled = true
+	loader, err := buildContractLoader(cfg)
+	if err == nil {
+		t.Fatal("buildContractLoader err = nil, want error for missing fields")
+	}
+	if loader != nil {
+		t.Fatalf("loader = %v, want nil on error", loader)
+	}
+	if !strings.Contains(err.Error(), "contract loader init") {
+		t.Fatalf("err = %v, want wrapped \"contract loader init\"", err)
+	}
+}
+
+func TestContractBlockInfo_RecognisesContractReasons(t *testing.T) {
+	cases := []struct {
+		reason string
+		want   blockreason.Reason
+	}{
+		{contractDefaultDenyReason, blockreason.Reason("contract_default_deny")},
+		{"contract_enforce_default", blockreason.Reason("contract_enforce_default")},
+		{"contract_non_default_port", blockreason.Reason("contract_non_default_port")},
+		{"contract_invalid_path", blockreason.Reason("contract_invalid_path")},
+		{"contract_observed_only", blockreason.Reason("contract_observed_only")},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.reason, func(t *testing.T) {
+			info, ok := contractBlockInfo(tc.reason)
+			if !ok {
+				t.Fatalf("ok=false, want true for %q", tc.reason)
+			}
+			if info.Reason != tc.want {
+				t.Fatalf("info.Reason = %q, want %q", info.Reason, tc.want)
+			}
+			if info.Severity != blockreason.SeverityCritical {
+				t.Fatalf("info.Severity = %q, want critical", info.Severity)
+			}
+			if info.Layer != "contract" {
+				t.Fatalf("info.Layer = %q, want contract", info.Layer)
+			}
+		})
+	}
+}
+
+func TestContractBlockInfo_UnknownReasonReturnsFalse(t *testing.T) {
+	cases := []string{"", "made_up_reason", "kill_switch_active", "contract_"}
+	for _, reason := range cases {
+		reason := reason
+		t.Run(reason, func(t *testing.T) {
+			if _, ok := contractBlockInfo(reason); ok {
+				t.Fatalf("ok=true, want false for non-contract reason %q", reason)
+			}
+		})
+	}
+}
+
+func TestWriteGateBlockedError_RoutesByGateShape(t *testing.T) {
+	// writeGateBlockedError is the proxy-side dispatcher that picks
+	// the right block-reason header based on which path produced the
+	// gate verdict. This pins the four arms (kill switch, scanner,
+	// contract reason, fallback) so a future refactor can't silently
+	// swap a kill-switch block to surface as parse_error.
+	cases := []struct {
+		name string
+		gate ContractGateOutput
+		want blockreason.Reason
+	}{
+		{
+			name: "kill switch by reason",
+			gate: ContractGateOutput{Reason: "kill_switch_active"},
+			want: blockreason.KillSwitchActive,
+		},
+		{
+			name: "kill switch by winning source",
+			gate: ContractGateOutput{WinningSource: contractruntime.WinningSourceKillSwitch},
+			want: blockreason.KillSwitchActive,
+		},
+		{
+			name: "scanner winning source",
+			gate: ContractGateOutput{WinningSource: contractruntime.WinningSourceScanner},
+			want: blockreason.ParseError,
+		},
+		{
+			name: "contract default deny reason",
+			gate: ContractGateOutput{
+				WinningSource: contractruntime.WinningSourceContract,
+				Reason:        contractDefaultDenyReason,
+			},
+			want: blockreason.Reason("contract_default_deny"),
+		},
+		{
+			name: "fallback for unknown reason",
+			gate: ContractGateOutput{
+				WinningSource: contractruntime.WinningSourceContract,
+				Reason:        "made_up_reason",
+			},
+			want: blockreason.ParseError,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			writeGateBlockedError(rec, tc.gate, "blocked", http.StatusForbidden)
+			if got := rec.Header().Get(blockreason.HeaderReason); got != string(tc.want) {
+				t.Fatalf("header reason = %q, want %q", got, string(tc.want))
+			}
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403", rec.Code)
+			}
+		})
+	}
+}
+
+func TestScannerVerdictForGate(t *testing.T) {
+	if got := scannerVerdictForGate(true); got != config.ActionWarn {
+		t.Fatalf("hasFinding=true got %q, want warn", got)
+	}
+	if got := scannerVerdictForGate(false); got != config.ActionAllow {
+		t.Fatalf("hasFinding=false got %q, want allow", got)
+	}
+}
+
+func TestForwardKillSwitchReceiptOpts_BareForwardReceipt(t *testing.T) {
+	got := forwardKillSwitchReceiptOpts("act-ks", "req-ks", http.MethodGet, "http://api.example.com/v1/chat")
+	if got.ActionID != "act-ks" || got.RequestID != "req-ks" {
+		t.Fatalf("identity fields lost: %+v", got)
+	}
+	if got.Verdict != config.ActionBlock {
+		t.Fatalf("verdict = %q, want block", got.Verdict)
+	}
+	if got.Layer != "kill_switch" || got.Pattern != killSwitchActiveReason {
+		t.Fatalf("layer/pattern = %q/%q", got.Layer, got.Pattern)
+	}
+	if got.Transport != TransportForward {
+		t.Fatalf("transport = %q, want %q", got.Transport, TransportForward)
+	}
+	if got.Method != http.MethodGet || got.Target != "http://api.example.com/v1/chat" {
+		t.Fatalf("method/target = %q/%q", got.Method, got.Target)
+	}
+	if got.Agent != "" || got.SessionTaintLevel != "" || got.AuthorityKind != "" {
+		t.Fatalf("kill-switch receipt carried unresolved-agent context: %+v", got)
+	}
+}
+
+func TestForwardBlockReceiptOpts_StampsForwardAndTaintContext(t *testing.T) {
+	in := ForwardBlockReceiptInput{
+		ActionID:  "act-1",
+		RequestID: "req-1",
+		Agent:     "agent-a",
+		Method:    http.MethodPost,
+		Target:    "http://api.example.com/v1/chat",
+		Layer:     "contract",
+		Pattern:   "contract_default_deny",
+	}
+	got := forwardBlockReceiptOpts(in)
+	if got.ActionID != "act-1" || got.RequestID != "req-1" || got.Agent != "agent-a" {
+		t.Fatalf("identity fields lost: %+v", got)
+	}
+	if got.Verdict != config.ActionBlock {
+		t.Fatalf("verdict = %q, want block", got.Verdict)
+	}
+	if got.Layer != "contract" || got.Pattern != "contract_default_deny" {
+		t.Fatalf("layer/pattern = %q/%q", got.Layer, got.Pattern)
+	}
+	if got.Transport != TransportForward {
+		t.Fatalf("transport = %q, want %q", got.Transport, TransportForward)
+	}
+	if got.Method != http.MethodPost || got.Target != "http://api.example.com/v1/chat" {
+		t.Fatalf("method/target = %q/%q", got.Method, got.Target)
+	}
+}
+
+func TestForwardBlockReceiptOpts_StampsTaintFields(t *testing.T) {
+	taint := taintDecision{
+		TaskOverrideApplied: true,
+	}
+	taint.Risk.Level = session.TaintExternalUntrusted
+	taint.Risk.Contaminated = true
+	taint.Task.CurrentTaskID = "task-1"
+	taint.Task.CurrentTaskLabel = "billing"
+	taint.Authority = session.AuthorityUserExact
+	taint.Result.Decision = session.PolicyBlock
+	taint.Result.Reason = "task boundary violation"
+	got := forwardBlockReceiptOpts(ForwardBlockReceiptInput{
+		ActionID: "act-2",
+		Agent:    "agent-a",
+		Method:   http.MethodPost,
+		Target:   "http://api.example.com/v1/chat",
+		Layer:    blockLayerContract,
+		Pattern:  contractDefaultDenyReason,
+		Taint:    taint,
+	})
+	if got.SessionTaintLevel != session.TaintExternalUntrusted.String() {
+		t.Fatalf("taint level = %q, want %q", got.SessionTaintLevel, session.TaintExternalUntrusted.String())
+	}
+	if !got.SessionContaminated {
+		t.Fatal("SessionContaminated = false, want true")
+	}
+	if got.SessionTaskID != "task-1" || got.SessionTaskLabel != "billing" {
+		t.Fatalf("task fields = %q/%q", got.SessionTaskID, got.SessionTaskLabel)
+	}
+	if got.AuthorityKind != session.AuthorityUserExact.String() {
+		t.Fatalf("AuthorityKind = %q", got.AuthorityKind)
+	}
+	if got.TaintDecision != session.PolicyBlock.String() {
+		t.Fatalf("TaintDecision = %q", got.TaintDecision)
+	}
+	if got.TaintDecisionReason != "task boundary violation" {
+		t.Fatalf("TaintDecisionReason = %q", got.TaintDecisionReason)
+	}
+	if !got.TaskOverrideApplied {
+		t.Fatal("TaskOverrideApplied = false, want true")
+	}
+}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -77,8 +77,12 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 
 	// Resolve per-agent config and scanner from a single registry snapshot.
 	// This prevents TOCTOU races during hot-reload where knownProfiles()
-	// and resolveAgent() could read different registries.
-	resolved, id, envEmitter := p.resolveAgentRuntimeFromRequest(r)
+	// and resolveAgent() could read different registries. CONNECT is
+	// opaque to the HTTP contract gate (no URL/method to evaluate against
+	// http_destination/http_action rules) so the loader handle is
+	// discarded here; handleForwardHTTP captures it for absolute-URI
+	// requests.
+	resolved, id, envEmitter, _ := p.resolveAgentRuntimeFromRequest(r)
 	cfg := resolved.Config
 	agent := id.Name
 	if agent == "" {
@@ -622,8 +626,11 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Resolve per-agent config and scanner from a single registry snapshot.
 	// This prevents TOCTOU races during hot-reload where knownProfiles()
-	// and resolveAgent() could read different registries.
-	resolved, id, envEmitter := p.resolveAgentRuntimeFromRequest(r)
+	// and resolveAgent() could read different registries. The contract
+	// loader is captured here too so the request scans, taint-evaluates,
+	// and gates under one policy revision; a reload between scan and gate
+	// would otherwise let a poisoned policy slip through.
+	resolved, id, envEmitter, snapshotContractLoader := p.resolveAgentRuntimeFromRequest(r)
 	cfg := resolved.Config
 	agent := id.Name
 	if agent == "" {
@@ -673,9 +680,13 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var forwardRedactionReport *redact.Report
+	var forwardGate ContractGateOutput
 	withForwardRedaction := func(opts receipt.EmitOpts) receipt.EmitOpts {
 		opts.RedactionProfile = cfg.Redaction.DefaultProfile
 		opts.RedactionReport = forwardRedactionReport
+		if forwardGate.HasContractContext() {
+			opts = withContractReceipt(forwardGate, opts)
+		}
 		return opts
 	}
 
@@ -1298,6 +1309,65 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 				"blocked: "+ceeRes.Reason, http.StatusForbidden)
 			return
 		}
+	}
+
+	killSwitchActive := false
+	if p.ks != nil {
+		killSwitchActive = p.ks.IsActiveHTTP(r).Active
+	}
+	gate, gateErr := EvaluateGate(ContractGateInput{
+		Loader:           snapshotContractLoader,
+		Agent:            agent,
+		URL:              targetURL,
+		Method:           r.Method,
+		EffectiveAction:  scannerVerdictForGate(hasFinding),
+		ScannerVerdict:   scannerVerdictForGate(hasFinding),
+		ScannerMatched:   hasFinding,
+		KillSwitchActive: killSwitchActive,
+		Transport:        TransportForward,
+	})
+	if gateErr != nil {
+		p.logger.LogBlocked(actx, blockLayerContract, gateErr.Error())
+		// Emit a block receipt so the contract eval failure shows up
+		// in the evidence chain. Without this, a fail-closed contract
+		// runtime error is the one terminal deny in this handler that
+		// disappears from the audit trail.
+		p.emitReceipt(withForwardRedaction(forwardBlockReceiptOpts(ForwardBlockReceiptInput{
+			ActionID:  actionID,
+			RequestID: requestID,
+			Agent:     agent,
+			Method:    r.Method,
+			Target:    targetURL,
+			Layer:     blockLayerContract,
+			Pattern:   "contract evaluation failed",
+			Taint:     forwardTaint,
+		})))
+		p.metrics.RecordBlocked(r.URL.Hostname(), blockLayerContract, time.Since(start), agentLabel)
+		writeBlockedError(w,
+			blockInfoFor(blockreason.ParseError, blockLayerContract),
+			"blocked: contract evaluation failed", http.StatusForbidden)
+		return
+	}
+	forwardGate = gate
+	if gate.Verdict == config.ActionBlock {
+		reason := gate.Reason
+		if reason == "" {
+			reason = gate.WinningSource
+		}
+		p.logger.LogBlocked(actx, blockLayerContract, reason)
+		p.emitReceipt(withForwardRedaction(forwardBlockReceiptOpts(ForwardBlockReceiptInput{
+			ActionID:  actionID,
+			RequestID: requestID,
+			Agent:     agent,
+			Method:    r.Method,
+			Target:    targetURL,
+			Layer:     blockLayerContract,
+			Pattern:   reason,
+			Taint:     forwardTaint,
+		})))
+		p.metrics.RecordBlocked(r.URL.Hostname(), blockLayerContract, time.Since(start), agentLabel)
+		writeGateBlockedError(w, gate, "blocked: "+reason, http.StatusForbidden)
+		return
 	}
 
 	// Clone request with context keys so CheckRedirect uses the per-agent

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -17,12 +17,17 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/certgen"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
+	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
@@ -118,6 +123,331 @@ func setupForwardProxyWithInstance(t *testing.T, cfgMod func(*config.Config)) (s
 	return proxyAddr, p, func() {
 		cancel()
 		p.Close() // closes scanner, registry, session manager
+	}
+}
+
+func testContractLoader(t *testing.T, mode contractruntime.Mode, rules ...contract.Rule) *contractruntime.Loader {
+	t.Helper()
+	fixture := contractruntimetest.NewFixture(t)
+	storeDir := t.TempDir()
+	env := contractruntimetest.Env()
+	contractruntimetest.WriteSignedActiveStore(t, fixture, storeDir, contractruntimetest.ActiveStoreOptions{
+		Agent:       "agent-a",
+		Rules:       rules,
+		Generation:  1,
+		PriorHash:   "sha256:genesis",
+		Environment: env,
+	})
+	loader, err := contractruntime.NewLoader(contractruntime.LoaderOptions{
+		StoreDir:              storeDir,
+		RosterPath:            fixture.RosterPath(),
+		PinnedRootFingerprint: fixture.RootFingerprint(),
+		Environment:           env,
+		MinSignatures:         1,
+		Mode:                  mode,
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	return loader
+}
+
+func installForwardTestDialer(p *Proxy, upstreamAddr string) {
+	p.client.Transport = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			switch addr {
+			case "api.example.com:80", "evil.example.com:80":
+				return (&net.Dialer{}).DialContext(ctx, network, upstreamAddr)
+			default:
+				return (&net.Dialer{}).DialContext(ctx, network, addr)
+			}
+		},
+		DisableCompression: true,
+	}
+}
+
+func forwardHTTPClient(t *testing.T, proxyAddr string) *http.Client {
+	t.Helper()
+	proxyURL, err := url.Parse("http://" + proxyAddr)
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+	return &http.Client{
+		Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)},
+		Timeout:   5 * time.Second,
+	}
+}
+
+func emptyContractLoader(t *testing.T, mode contractruntime.Mode) *contractruntime.Loader {
+	t.Helper()
+	fixture := contractruntimetest.NewFixture(t)
+	storeDir := t.TempDir()
+	loader, err := contractruntime.NewLoader(contractruntime.LoaderOptions{
+		StoreDir:              storeDir,
+		RosterPath:            fixture.RosterPath(),
+		PinnedRootFingerprint: fixture.RootFingerprint(),
+		Environment:           contractruntimetest.Env(),
+		MinSignatures:         1,
+		Mode:                  mode,
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	return loader
+}
+
+func TestForwardLiveLock_NoActiveContractPassThrough(t *testing.T) {
+	var hits atomic.Int32
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, nil)
+	defer cleanup()
+	p.contractLoaderPtr.Store(emptyContractLoader(t, contractruntime.ModeLive))
+	installForwardTestDialer(p, backend.Listener.Addr().String())
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://evil.example.com/v1/chat", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set(AgentHeader, "agent-a")
+	resp, err := forwardHTTPClient(t, proxyAddr).Do(req)
+	if err != nil {
+		t.Fatalf("forward request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != "" {
+		t.Fatalf("block reason = %q, want empty", got)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestForwardLiveLock_AllowRulePasses(t *testing.T) {
+	var hits atomic.Int32
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, nil)
+	defer cleanup()
+	p.contractLoaderPtr.Store(testContractLoader(t, contractruntime.ModeLive, rule))
+	installForwardTestDialer(p, backend.Listener.Addr().String())
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://api.example.com/v1/chat", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set(AgentHeader, "agent-a")
+	resp, err := forwardHTTPClient(t, proxyAddr).Do(req)
+	if err != nil {
+		t.Fatalf("forward request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestForwardLiveLock_DefaultDenyBlocksUnmatchedDestination(t *testing.T) {
+	var hits atomic.Int32
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer backend.Close()
+
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, nil)
+	defer cleanup()
+	p.contractLoaderPtr.Store(testContractLoader(t, contractruntime.ModeLive, rule))
+	installForwardTestDialer(p, backend.Listener.Addr().String())
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://evil.example.com/v1/chat", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set(AgentHeader, "agent-a")
+	resp, err := forwardHTTPClient(t, proxyAddr).Do(req)
+	if err != nil {
+		t.Fatalf("forward request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != contractDefaultDenyReason {
+		t.Fatalf("block reason = %q, want %s", got, contractDefaultDenyReason)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
+func TestForwardLiveLock_ScannerBlockWinsOverContractAllow(t *testing.T) {
+	var hits atomic.Int32
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer backend.Close()
+
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.RequestBodyScanning.Enabled = true
+		cfg.RequestBodyScanning.Action = config.ActionBlock
+	})
+	defer cleanup()
+	p.contractLoaderPtr.Store(testContractLoader(t, contractruntime.ModeLive, rule))
+	installForwardTestDialer(p, backend.Listener.Addr().String())
+
+	// Split fake credential at the DLP pattern boundary so the
+	// pipelock self-scan in CI does not flag this test fixture as a
+	// real secret. The runtime DLP scanner sees the assembled string
+	// at request time, which is what this test exercises.
+	fakeToken := "sk-ant-" + "api03-XXXXXXXXXXXXXXXXXXXXXXX"
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://api.example.com/v1/chat", strings.NewReader(`{"token":"`+fakeToken+`"}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set(AgentHeader, "agent-a")
+	resp, err := forwardHTTPClient(t, proxyAddr).Do(req)
+	if err != nil {
+		t.Fatalf("forward request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.DLPMatch) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.DLPMatch)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
+func TestForwardLiveLock_ShadowModeObservesWithoutBlocking(t *testing.T) {
+	var hits atomic.Int32
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, nil)
+	defer cleanup()
+	p.contractLoaderPtr.Store(testContractLoader(t, contractruntime.ModeShadow, rule))
+	installForwardTestDialer(p, backend.Listener.Addr().String())
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://evil.example.com/v1/chat", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set(AgentHeader, "agent-a")
+	resp, err := forwardHTTPClient(t, proxyAddr).Do(req)
+	if err != nil {
+		t.Fatalf("forward request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestForwardLiveLock_CaptureModeDoesNotBlock(t *testing.T) {
+	var hits atomic.Int32
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, nil)
+	defer cleanup()
+	p.contractLoaderPtr.Store(testContractLoader(t, contractruntime.ModeCapture, rule))
+	installForwardTestDialer(p, backend.Listener.Addr().String())
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://evil.example.com/v1/chat", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set(AgentHeader, "agent-a")
+	resp, err := forwardHTTPClient(t, proxyAddr).Do(req)
+	if err != nil {
+		t.Fatalf("forward request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestForwardLiveLock_KillSwitchBlocksBeforeContractAllow(t *testing.T) {
+	var hits atomic.Int32
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer backend.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, nil)
+	defer cleanup()
+
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	p.contractLoaderPtr.Store(testContractLoader(t, contractruntime.ModeLive, rule))
+	installForwardTestDialer(p, backend.Listener.Addr().String())
+
+	ks := killswitch.New(p.CurrentConfig())
+	ks.SetAPI(true)
+	p.ks = ks
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://api.example.com/v1/chat", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set(AgentHeader, "agent-a")
+	resp, err := forwardHTTPClient(t, proxyAddr).Do(req)
+	if err != nil {
+		t.Fatalf("forward request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.KillSwitchActive) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.KillSwitchActive)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
 	}
 }
 
@@ -1433,7 +1763,7 @@ func TestForwardHTTPSessionBlocked(t *testing.T) {
 	// Trigger domain burst by hitting many different hosts via forward proxy.
 	for i := 0; i < 4; i++ {
 		reqURL := fmt.Sprintf("http://domain%d.com/path", i)
-		req, _ := http.NewRequest(http.MethodGet, reqURL, nil) //nolint:noctx // test
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, reqURL, nil)
 		resp, err := client.Do(req)
 		if err == nil {
 			_ = resp.Body.Close()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -33,6 +33,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/certgen"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
 	"github.com/luckyPipewrench/pipelock/internal/decide"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
@@ -283,6 +284,7 @@ type Proxy struct {
 	fragmentBufferPtr   atomic.Pointer[scanner.FragmentBuffer] // nil when fragment reassembly disabled
 	redactionRuntimePtr atomic.Pointer[redactionRuntime]       // nil when redaction disabled
 	redactMatcherPtr    atomic.Pointer[redact.Matcher]         // nil when redaction disabled
+	contractLoaderPtr   atomic.Pointer[contractruntime.Loader] // nil when learn_lock is disabled
 	logger              *audit.Logger
 	metrics             *metrics.Metrics
 	ks                  *killswitch.Controller
@@ -355,6 +357,12 @@ func WithReceiptKeyPath(path string) Option {
 	return func(p *Proxy) { p.receiptKeyPath = path }
 }
 
+// WithContractLoader sets the lock-runtime loader. Tests use this to install
+// a real loader without routing through YAML config.
+func WithContractLoader(loader *contractruntime.Loader) Option {
+	return func(p *Proxy) { p.contractLoaderPtr.Store(loader) }
+}
+
 // WithEnvelopeEmitter sets the mediation envelope emitter. When non-nil, the
 // proxy injects signed mediation envelopes into proxied requests. Pass nil to
 // disable (default).
@@ -401,6 +409,14 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 	}
 	p.cfgPtr.Store(cfg)
 	p.scannerPtr.Store(sc)
+
+	if p.currentContractLoader() == nil {
+		loader, loaderErr := buildContractLoader(cfg)
+		if loaderErr != nil {
+			return nil, loaderErr
+		}
+		p.contractLoaderPtr.Store(loader)
+	}
 
 	// Wedge-detection watchdog. Constructed when health_watchdog.enabled is
 	// true (the documented default), unless WithHealthWatchdog already
@@ -1196,6 +1212,16 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 		}
 		return false
 	}
+	contractLoader, contractErr := buildContractLoader(cfg)
+	if contractErr != nil {
+		p.logger.LogError(audit.NewMethodLogContext("RELOAD"),
+			fmt.Errorf("contract loader reload failed, keeping old config: %w", contractErr))
+		sc.Close()
+		if newEd != nil {
+			newEd.Close()
+		}
+		return false
+	}
 	// Stage the full redaction runtime BEFORE publication so a failed
 	// matcher build aborts the whole reload instead of mixing matcher,
 	// limits, and allowlist from different policy revisions.
@@ -1247,6 +1273,7 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 
 	oldCfg := p.cfgPtr.Load()
 	p.cfgPtr.Store(cfg)
+	p.contractLoaderPtr.Store(contractLoader)
 	if p.wd != nil {
 		p.wd.BeatConfig()
 		p.installScannerHeartbeat(sc)
@@ -1556,11 +1583,11 @@ func (p *Proxy) resolveAgentFromRequest(r *http.Request) (*edition.ResolvedAgent
 // and envelope emitter under the reload lock. The request then keeps that
 // emitter for its forwarding and redirect path so a reload cannot pair the
 // old config with a newly disabled or rotated emitter.
-func (p *Proxy) resolveAgentRuntimeFromRequest(r *http.Request) (*edition.ResolvedAgent, edition.AgentIdentity, *envelope.Emitter) {
+func (p *Proxy) resolveAgentRuntimeFromRequest(r *http.Request) (*edition.ResolvedAgent, edition.AgentIdentity, *envelope.Emitter, *contractruntime.Loader) {
 	p.reloadMu.RLock()
 	defer p.reloadMu.RUnlock()
 	resolved, id := p.resolveAgentFromRequest(r)
-	return resolved, id, p.envelopeEmitterPtr.Load()
+	return resolved, id, p.envelopeEmitterPtr.Load(), p.contractLoaderPtr.Load()
 }
 
 // pinResolvedScanner registers in-flight scanner use on a resolved-agent
@@ -2197,6 +2224,23 @@ func (p *Proxy) buildHandler(mux *http.ServeMux) http.Handler {
 				clientIP, _ := requestMeta(r)
 				p.logger.LogKillSwitchDeny(schemeHTTP, r.URL.Path, d.Source, d.Message, clientIP)
 				p.metrics.RecordKillSwitchDenial(schemeHTTP, r.URL.Path)
+				if r.URL.IsAbs() && r.URL.Host != "" {
+					// Absolute-URI forward proxy requests bypass
+					// handleForwardHTTP entirely under kill switch,
+					// so emit a forward receipt here to keep the
+					// audit chain unbroken.
+					requestID, _ := r.Context().Value(ctxKeyRequestID).(string)
+					p.emitReceipt(forwardKillSwitchReceiptOpts(
+						receipt.NewActionID(),
+						requestID,
+						r.Method,
+						r.URL.String(),
+					))
+					writeBlockedError(w,
+						blockInfoFor(blockreason.KillSwitchActive, "kill_switch"),
+						"blocked: kill_switch_active", http.StatusForbidden)
+					return
+				}
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusServiceUnavailable)
 				_ = json.NewEncoder(w).Encode(map[string]string{
@@ -2414,8 +2458,11 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 
 	// Resolve per-agent config and scanner from a single registry snapshot.
 	// This prevents TOCTOU races during hot-reload where knownProfiles()
-	// and resolveAgent() could read different registries.
-	resolved, id, envEmitter := p.resolveAgentRuntimeFromRequest(r)
+	// and resolveAgent() could read different registries. The fetch path
+	// does not invoke the HTTP contract gate today; the loader handle is
+	// discarded here and re-snapshotted by handleForwardHTTP for the
+	// forward path.
+	resolved, id, envEmitter, _ := p.resolveAgentRuntimeFromRequest(r)
 	cfg := resolved.Config
 	agent := id.Name
 	if agent == "" {

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -118,8 +118,10 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	// Resolve per-agent config and scanner from a single registry snapshot.
 	// This prevents TOCTOU races during hot-reload where knownProfiles()
-	// and resolveAgent() could read different registries.
-	resolved, id, envEmitter := p.resolveAgentRuntimeFromRequest(r)
+	// and resolveAgent() could read different registries. WebSocket does
+	// not invoke the HTTP contract gate today; the loader handle is
+	// discarded.
+	resolved, id, envEmitter, _ := p.resolveAgentRuntimeFromRequest(r)
 	cfg := resolved.Config
 	agent := id.Name
 	if agent == "" {

--- a/internal/receipt/action.go
+++ b/internal/receipt/action.go
@@ -142,6 +142,16 @@ type ActionRecord struct {
 	TaintDecisionReason string                   `json:"taint_decision_reason,omitempty"`
 	TaskOverrideApplied bool                     `json:"task_override_applied,omitempty"`
 
+	// Contract context, populated when live lock evaluates this action.
+	ContractWinningSource string   `json:"contract_winning_source,omitempty"`
+	ContractLiveVerdict   string   `json:"contract_live_verdict,omitempty"`
+	ContractPolicySources []string `json:"contract_policy_sources,omitempty"`
+	ContractRuleID        string   `json:"contract_rule_id,omitempty"`
+	ActiveManifestHash    string   `json:"active_manifest_hash,omitempty"`
+	ContractHash          string   `json:"contract_hash,omitempty"`
+	ContractSelectorID    string   `json:"contract_selector_id,omitempty"`
+	ContractGeneration    uint64   `json:"contract_generation,omitempty"`
+
 	// Transport context
 	Transport string            `json:"transport"`
 	Method    string            `json:"method,omitempty"`

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -79,27 +79,35 @@ func NewEmitter(cfg EmitterConfig) *Emitter {
 
 // EmitOpts holds the per-decision context for emitting a receipt.
 type EmitOpts struct {
-	ActionID            string
-	Verdict             string
-	Layer               string
-	Pattern             string
-	Severity            string
-	RedactionProfile    string
-	RedactionReport     *redact.Report
-	Transport           string
-	Method              string
-	Target              string
-	RequestID           string
-	Agent               string
-	SessionTaintLevel   string
-	SessionContaminated bool
-	RecentTaintSources  []session.TaintSourceRef
-	SessionTaskID       string
-	SessionTaskLabel    string
-	AuthorityKind       string
-	TaintDecision       string
-	TaintDecisionReason string
-	TaskOverrideApplied bool
+	ActionID              string
+	Verdict               string
+	Layer                 string
+	Pattern               string
+	Severity              string
+	RedactionProfile      string
+	RedactionReport       *redact.Report
+	Transport             string
+	Method                string
+	Target                string
+	RequestID             string
+	Agent                 string
+	SessionTaintLevel     string
+	SessionContaminated   bool
+	RecentTaintSources    []session.TaintSourceRef
+	SessionTaskID         string
+	SessionTaskLabel      string
+	AuthorityKind         string
+	TaintDecision         string
+	TaintDecisionReason   string
+	TaskOverrideApplied   bool
+	ContractWinningSource string
+	ContractLiveVerdict   string
+	ContractPolicySources []string
+	ContractRuleID        string
+	ActiveManifestHash    string
+	ContractHash          string
+	ContractSelectorID    string
+	ContractGeneration    uint64
 
 	// MCP-specific fields
 	ToolName  string
@@ -141,36 +149,44 @@ func (e *Emitter) Emit(opts EmitOpts) error {
 	}
 
 	ar := ActionRecord{
-		Version:             ActionRecordVersion,
-		ActionID:            opts.ActionID,
-		ActionType:          actionType,
-		Timestamp:           time.Now().UTC(),
-		Principal:           e.principal,
-		Actor:               e.actorLabel(opts),
-		DelegationChain:     nil, // Populated when delegation tracking ships
-		Target:              opts.Target,
-		SideEffectClass:     sideEffect,
-		Reversibility:       reversibility,
-		PolicyHash:          configHashString(e.configHash.Load()),
-		Verdict:             NormalizeVerdict(opts.Verdict),
-		SessionTaintLevel:   opts.SessionTaintLevel,
-		SessionContaminated: opts.SessionContaminated,
-		RecentTaintSources:  append([]session.TaintSourceRef(nil), opts.RecentTaintSources...),
-		SessionTaskID:       opts.SessionTaskID,
-		SessionTaskLabel:    opts.SessionTaskLabel,
-		AuthorityKind:       opts.AuthorityKind,
-		TaintDecision:       opts.TaintDecision,
-		TaintDecisionReason: opts.TaintDecisionReason,
-		TaskOverrideApplied: opts.TaskOverrideApplied,
-		Transport:           opts.Transport,
-		Method:              opts.Method,
-		Layer:               opts.Layer,
-		Pattern:             opts.Pattern,
-		Severity:            opts.Severity,
-		Redaction:           redactionSummaryFromReport(opts.RedactionProfile, opts.RedactionReport),
-		RequestID:           opts.RequestID,
-		ChainPrevHash:       e.chainPrevHash,
-		ChainSeq:            e.chainSeq,
+		Version:               ActionRecordVersion,
+		ActionID:              opts.ActionID,
+		ActionType:            actionType,
+		Timestamp:             time.Now().UTC(),
+		Principal:             e.principal,
+		Actor:                 e.actorLabel(opts),
+		DelegationChain:       nil, // Populated when delegation tracking ships
+		Target:                opts.Target,
+		SideEffectClass:       sideEffect,
+		Reversibility:         reversibility,
+		PolicyHash:            configHashString(e.configHash.Load()),
+		Verdict:               NormalizeVerdict(opts.Verdict),
+		SessionTaintLevel:     opts.SessionTaintLevel,
+		SessionContaminated:   opts.SessionContaminated,
+		RecentTaintSources:    append([]session.TaintSourceRef(nil), opts.RecentTaintSources...),
+		SessionTaskID:         opts.SessionTaskID,
+		SessionTaskLabel:      opts.SessionTaskLabel,
+		AuthorityKind:         opts.AuthorityKind,
+		TaintDecision:         opts.TaintDecision,
+		TaintDecisionReason:   opts.TaintDecisionReason,
+		TaskOverrideApplied:   opts.TaskOverrideApplied,
+		ContractWinningSource: opts.ContractWinningSource,
+		ContractLiveVerdict:   opts.ContractLiveVerdict,
+		ContractPolicySources: append([]string(nil), opts.ContractPolicySources...),
+		ContractRuleID:        opts.ContractRuleID,
+		ActiveManifestHash:    opts.ActiveManifestHash,
+		ContractHash:          opts.ContractHash,
+		ContractSelectorID:    opts.ContractSelectorID,
+		ContractGeneration:    opts.ContractGeneration,
+		Transport:             opts.Transport,
+		Method:                opts.Method,
+		Layer:                 opts.Layer,
+		Pattern:               opts.Pattern,
+		Severity:              opts.Severity,
+		Redaction:             redactionSummaryFromReport(opts.RedactionProfile, opts.RedactionReport),
+		RequestID:             opts.RequestID,
+		ChainPrevHash:         e.chainPrevHash,
+		ChainSeq:              e.chainSeq,
 	}
 
 	rcpt, err := Sign(ar, e.privKey)


### PR DESCRIPTION
Wires the contract runtime evaluator into the forward proxy so a promoted active manifest gates real traffic. Until this lands, the schema and evaluator from PR #482 plus the watcher from PR #483 had no production caller; the gate is the seam where the contract pin becomes a verdict the proxy acts on.

## Behavior

`EvaluateGate` mirrors `EvaluateHTTP`'s decision sequence one-to-one. Nil loader or no active manifest falls through to the scanner verdict. Resolved contract gets evaluated through the runtime. The mode gate from PR #482 surfaces the right verdict for live, shadow, and capture configurations. Block-reason headers route through `contractBlockInfo` so `contract_default_deny`, `contract_enforce_default`, `contract_non_default_port`, `contract_invalid_path`, and `contract_observed_only` emit canonical wire codes. Kill-switch verdicts surface as `kill_switch_active`; scanner-block fallthrough surfaces as `parse_error` so the agent reads "your input could not be classified" rather than a contract code that implies jurisdictional enforcement.

## Loader lifetime

Loader lifetime is owned by `Proxy` via `atomic.Pointer` so hot reload swaps the contract runtime atomically alongside scanner and session managers. `buildContractLoader` is the single proxy-side init seam (disabled, nil config, missing fields error, enabled happy path all covered).

## Receipt parity

The receipt emitter gains contract context fields (active manifest hash, contract hash, selector ID, contract generation, winning source, live verdict, policy sources, rule ID) so `proxy_decision` receipts emitted from the forward path carry the same provenance as the runtime evaluator's `Decision`. `withContractReceipt` is a no-op when the gate has no contract context so non-learn-lock deployments emit identical receipts to today.

## Shared test fixture

The shared `contractruntimetest` package extracts the signed roster plus active manifest scaffolding out of `loader_test.go` so the forward-proxy contract gate tests can build the same shape without copying 100+ lines of signing code. `WriteSignedActiveStore` writes raw `active.json` for tests that bypass the store CAS path; `WriteAcceptedActiveStore` goes through the CAS path so missed-intermediate recovery tests have a real accepted-history chain.

## Coverage notes

100% function coverage on every symbol in `contractgate.go` except `EvaluateGate`'s defensive err-from-`EvaluateHTTP` path which cannot fire from current inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP request routing now evaluates active contracts for policy enforcement.
  * Request receipts now include contract evaluation context (manifest hash, rule ID, verdict details).
  * Contract gateway evaluation determines allow/deny decisions for proxied requests.

* **Tests**
  * Added comprehensive contract-runtime integration test coverage.
  * Added contract-gate behavior and receipt context validation tests.

* **Chores**
  * Updated Go toolchain to latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->