### PR TITLE
feat(proxy): live-lock enforcement on intercept proxy

### DIFF
--- a/internal/proxy/contractgate.go
+++ b/internal/proxy/contractgate.go
@@ -190,20 +190,20 @@ func contractBlockInfo(reason string) (blockreason.Info, bool) {
 	}
 }
 
-func writeGateBlockedError(w http.ResponseWriter, gate ContractGateOutput, body string, status int) {
+func writeGateBlockedError(w http.ResponseWriter, gate ContractGateOutput, body string) {
 	if gate.Reason == killSwitchActiveReason || gate.WinningSource == contractruntime.WinningSourceKillSwitch {
-		writeBlockedError(w, blockInfoFor(blockreason.KillSwitchActive, "kill_switch"), body, status)
+		writeBlockedError(w, blockInfoFor(blockreason.KillSwitchActive, "kill_switch"), body, http.StatusForbidden)
 		return
 	}
 	if gate.WinningSource == contractruntime.WinningSourceScanner {
-		writeBlockedError(w, blockInfoFor(blockreason.ParseError, "scanner"), body, status)
+		writeBlockedError(w, blockInfoFor(blockreason.ParseError, "scanner"), body, http.StatusForbidden)
 		return
 	}
 	if info, ok := contractBlockInfo(gate.Reason); ok {
-		writeBlockedError(w, info, body, status)
+		writeBlockedError(w, info, body, http.StatusForbidden)
 		return
 	}
-	writeBlockedError(w, blockInfoFor(blockreason.ParseError, blockLayerContract), body, status)
+	writeBlockedError(w, blockInfoFor(blockreason.ParseError, blockLayerContract), body, http.StatusForbidden)
 }
 
 func scannerVerdictForGate(hasFinding bool) string {

--- a/internal/proxy/contractgate_test.go
+++ b/internal/proxy/contractgate_test.go
@@ -310,7 +310,7 @@ func TestWriteGateBlockedError_RoutesByGateShape(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			writeGateBlockedError(rec, tc.gate, "blocked", http.StatusForbidden)
+			writeGateBlockedError(rec, tc.gate, "blocked")
 			if got := rec.Header().Get(blockreason.HeaderReason); got != string(tc.want) {
 				t.Fatalf("header reason = %q, want %q", got, string(tc.want))
 			}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1366,7 +1366,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			Taint:     forwardTaint,
 		})))
 		p.metrics.RecordBlocked(r.URL.Hostname(), blockLayerContract, time.Since(start), agentLabel)
-		writeGateBlockedError(w, gate, "blocked: "+reason, http.StatusForbidden)
+		writeGateBlockedError(w, gate, "blocked: "+reason)
 		return
 	}
 

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -23,6 +23,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/certgen"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
 	"github.com/luckyPipewrench/pipelock/internal/decide"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
@@ -41,6 +42,13 @@ func recEscalationLevel(rec session.Recorder) int {
 		return rec.EscalationLevel()
 	}
 	return 0
+}
+
+func interceptContractLoader(ic *InterceptContext) *contractruntime.Loader {
+	if ic == nil || ic.Proxy == nil {
+		return nil
+	}
+	return ic.Proxy.currentContractLoader()
 }
 
 // InterceptContext carries shared state for TLS-intercepted tunnel processing.
@@ -389,22 +397,6 @@ func newInterceptHandler(
 		// trusted before we drop it.
 		envelope.StripInbound(r.Header)
 
-		// Kill switch re-check for intercepted CONNECT tunnels.
-		// Raw relay (relay.go) polls this per copy iteration. Intercepted
-		// tunnels must check per inner request. Use IsActiveForIP (not
-		// IsActiveHTTP) because inner request paths belong to the upstream
-		// origin — /health and /metrics exemptions must not apply here.
-		if ic.KillSwitch != nil {
-			d := ic.KillSwitch.IsActiveForIP(ic.ClientIP)
-			if d.Active {
-				ic.Metrics.RecordKillSwitchDenial("intercept", r.URL.Path)
-				writeBlockedError(w,
-					blockInfoFor(blockreason.KillSwitchActive, ""),
-					"kill switch active", http.StatusServiceUnavailable)
-				return
-			}
-		}
-
 		// Authority check: Host must match CONNECT target (host:port).
 		// Prevents domain fronting where the agent CONNECTs to allowed.com
 		// but sends Host: evil.com inside the encrypted tunnel. Also prevents
@@ -463,9 +455,13 @@ func newInterceptHandler(
 		// warn/strip findings do not contribute to score decay.
 		hasFinding := false
 		var interceptRedactionReport *redact.Report
+		var interceptGate ContractGateOutput
 		withInterceptRedaction := func(opts receipt.EmitOpts) receipt.EmitOpts {
 			opts.RedactionProfile = ic.Config.Redaction.DefaultProfile
 			opts.RedactionReport = interceptRedactionReport
+			if interceptGate.HasContractContext() {
+				opts = withContractReceipt(interceptGate, opts)
+			}
 			return opts
 		}
 
@@ -473,6 +469,62 @@ func newInterceptHandler(
 		// scans the synthetic host URL; inside the intercepted tunnel we have
 		// the real path and query, which may contain exfiltrated secrets.
 		targetURL := r.URL.String()
+
+		// Kill switch re-check for intercepted CONNECT tunnels.
+		// Raw relay (relay.go) polls this per copy iteration. Intercepted
+		// tunnels must check per inner request. Use IsActiveForIP (not
+		// IsActiveHTTP) because inner request paths belong to the upstream
+		// origin — /health and /metrics exemptions must not apply here.
+		if ic.KillSwitch != nil {
+			d := ic.KillSwitch.IsActiveForIP(ic.ClientIP)
+			if d.Active {
+				gate, gateErr := EvaluateGate(ContractGateInput{
+					Loader:           interceptContractLoader(ic),
+					Agent:            ic.Agent,
+					URL:              targetURL,
+					Method:           r.Method,
+					EffectiveAction:  config.ActionAllow,
+					ScannerVerdict:   config.ActionAllow,
+					KillSwitchActive: true,
+					Transport:        "intercept",
+				})
+				if gateErr != nil {
+					ic.Logger.LogBlocked(actx, "contract", gateErr.Error())
+					ic.Metrics.RecordTLSRequestBlocked("contract")
+					writeBlockedError(w,
+						blockInfoFor(blockreason.ParseError, "contract"),
+						"blocked: contract evaluation failed", http.StatusForbidden)
+					return
+				}
+				if gate.Verdict == config.ActionBlock {
+					interceptGate = gate
+					reason := gate.Reason
+					if reason == "" {
+						reason = gate.WinningSource
+					}
+					ic.Logger.LogBlocked(actx, "contract", reason)
+					ic.Metrics.RecordKillSwitchDenial("intercept", r.URL.Path)
+					interceptEmitReceipt(ic, withInterceptRedaction(receipt.EmitOpts{
+						ActionID:  actionID,
+						Verdict:   config.ActionBlock,
+						Layer:     "contract",
+						Pattern:   reason,
+						Transport: "intercept",
+						Method:    r.Method,
+						Target:    targetURL,
+						RequestID: ic.RequestID,
+						Agent:     ic.Agent,
+					}))
+					writeGateBlockedError(w, gate, "blocked: "+reason)
+					return
+				}
+				ic.Metrics.RecordKillSwitchDenial("intercept", r.URL.Path)
+				writeBlockedError(w,
+					blockInfoFor(blockreason.KillSwitchActive, ""),
+					"kill switch active", http.StatusServiceUnavailable)
+				return
+			}
+		}
 		interceptScanCtx := scanner.WithDLPWarnContext(r.Context(), scanner.DLPWarnContext{
 			Method: r.Method, URL: targetURL, Target: target,
 			ClientIP: ic.ClientIP, RequestID: ic.RequestID,
@@ -1061,6 +1113,47 @@ func newInterceptHandler(
 				blockInfoFor(blockreason.EscalationLevel, "session_deny"),
 				"blocked: session escalation level "+session.EscalationLabel(recEscalationLevel(ic.Recorder)),
 				http.StatusForbidden)
+			return
+		}
+
+		gate, gateErr := EvaluateGate(ContractGateInput{
+			Loader:          interceptContractLoader(ic),
+			Agent:           ic.Agent,
+			URL:             targetURL,
+			Method:          r.Method,
+			EffectiveAction: scannerVerdictForGate(hasFinding),
+			ScannerVerdict:  scannerVerdictForGate(hasFinding),
+			ScannerMatched:  hasFinding,
+			Transport:       "intercept",
+		})
+		if gateErr != nil {
+			ic.Logger.LogBlocked(actx, "contract", gateErr.Error())
+			ic.Metrics.RecordTLSRequestBlocked("contract")
+			writeBlockedError(w,
+				blockInfoFor(blockreason.ParseError, "contract"),
+				"blocked: contract evaluation failed", http.StatusForbidden)
+			return
+		}
+		interceptGate = gate
+		if gate.Verdict == config.ActionBlock {
+			reason := gate.Reason
+			if reason == "" {
+				reason = gate.WinningSource
+			}
+			ic.Logger.LogBlocked(actx, "contract", reason)
+			ic.Metrics.RecordTLSRequestBlocked("contract")
+			interceptEmitReceipt(ic, withInterceptRedaction(receipt.EmitOpts{
+				ActionID:  actionID,
+				Verdict:   config.ActionBlock,
+				Layer:     "contract",
+				Pattern:   reason,
+				Transport: "intercept",
+				Method:    r.Method,
+				Target:    targetURL,
+				RequestID: ic.RequestID,
+				Agent:     ic.Agent,
+			}))
+			writeGateBlockedError(w, gate, "blocked: "+reason)
 			return
 		}
 

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -469,6 +469,24 @@ func newInterceptHandler(
 		// scans the synthetic host URL; inside the intercepted tunnel we have
 		// the real path and query, which may contain exfiltrated secrets.
 		targetURL := r.URL.String()
+		emitKillSwitchBlock := func() {
+			ic.Logger.LogBlocked(actx, "kill_switch", killSwitchActiveReason)
+			ic.Metrics.RecordKillSwitchDenial("intercept", r.URL.Path)
+			interceptEmitReceipt(ic, receipt.EmitOpts{
+				ActionID:  actionID,
+				Verdict:   config.ActionBlock,
+				Layer:     "kill_switch",
+				Pattern:   killSwitchActiveReason,
+				Transport: "intercept",
+				Method:    r.Method,
+				Target:    targetURL,
+				RequestID: ic.RequestID,
+				Agent:     ic.Agent,
+			})
+			writeBlockedError(w,
+				blockInfoFor(blockreason.KillSwitchActive, ""),
+				"kill switch active", http.StatusServiceUnavailable)
+		}
 
 		// Kill switch re-check for intercepted CONNECT tunnels.
 		// Raw relay (relay.go) polls this per copy iteration. Intercepted
@@ -489,11 +507,7 @@ func newInterceptHandler(
 					Transport:        "intercept",
 				})
 				if gateErr != nil {
-					ic.Logger.LogBlocked(actx, "contract", gateErr.Error())
-					ic.Metrics.RecordTLSRequestBlocked("contract")
-					writeBlockedError(w,
-						blockInfoFor(blockreason.ParseError, "contract"),
-						"blocked: contract evaluation failed", http.StatusForbidden)
+					emitKillSwitchBlock()
 					return
 				}
 				if gate.Verdict == config.ActionBlock {
@@ -501,6 +515,10 @@ func newInterceptHandler(
 					reason := gate.Reason
 					if reason == "" {
 						reason = gate.WinningSource
+					}
+					if reason == killSwitchActiveReason || gate.WinningSource == contractruntime.WinningSourceKillSwitch {
+						emitKillSwitchBlock()
+						return
 					}
 					ic.Logger.LogBlocked(actx, "contract", reason)
 					ic.Metrics.RecordKillSwitchDenial("intercept", r.URL.Path)
@@ -518,10 +536,7 @@ func newInterceptHandler(
 					writeGateBlockedError(w, gate, "blocked: "+reason)
 					return
 				}
-				ic.Metrics.RecordKillSwitchDenial("intercept", r.URL.Path)
-				writeBlockedError(w,
-					blockInfoFor(blockreason.KillSwitchActive, ""),
-					"kill switch active", http.StatusServiceUnavailable)
+				emitKillSwitchBlock()
 				return
 			}
 		}

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -496,7 +496,13 @@ func newInterceptHandler(
 		if ic.KillSwitch != nil {
 			d := ic.KillSwitch.IsActiveForIP(ic.ClientIP)
 			if d.Active {
-				gate, gateErr := EvaluateGate(ContractGateInput{
+				// Evaluate the contract gate purely so the kill-switch
+				// receipt carries any active-contract context (policy
+				// sources, contract hash, generation). The runtime
+				// guarantees that KillSwitchActive=true returns
+				// Verdict=Block with WinningSource=KillSwitch, so we
+				// never branch on the verdict — kill switch always wins.
+				if gate, gateErr := EvaluateGate(ContractGateInput{
 					Loader:           interceptContractLoader(ic),
 					Agent:            ic.Agent,
 					URL:              targetURL,
@@ -505,36 +511,8 @@ func newInterceptHandler(
 					ScannerVerdict:   config.ActionAllow,
 					KillSwitchActive: true,
 					Transport:        "intercept",
-				})
-				if gateErr != nil {
-					emitKillSwitchBlock()
-					return
-				}
-				if gate.Verdict == config.ActionBlock {
+				}); gateErr == nil {
 					interceptGate = gate
-					reason := gate.Reason
-					if reason == "" {
-						reason = gate.WinningSource
-					}
-					if reason == killSwitchActiveReason || gate.WinningSource == contractruntime.WinningSourceKillSwitch {
-						emitKillSwitchBlock()
-						return
-					}
-					ic.Logger.LogBlocked(actx, "contract", reason)
-					ic.Metrics.RecordKillSwitchDenial("intercept", r.URL.Path)
-					interceptEmitReceipt(ic, withInterceptRedaction(receipt.EmitOpts{
-						ActionID:  actionID,
-						Verdict:   config.ActionBlock,
-						Layer:     "contract",
-						Pattern:   reason,
-						Transport: "intercept",
-						Method:    r.Method,
-						Target:    targetURL,
-						RequestID: ic.RequestID,
-						Agent:     ic.Agent,
-					}))
-					writeGateBlockedError(w, gate, "blocked: "+reason)
-					return
 				}
 				emitKillSwitchBlock()
 				return
@@ -1151,10 +1129,10 @@ func newInterceptHandler(
 		}
 		interceptGate = gate
 		if gate.Verdict == config.ActionBlock {
+			// The runtime always populates Reason on contract-block paths
+			// (kill-switch, scanner-missing, contractBlockDecision); empty
+			// is impossible per the EvaluateHTTP contract.
 			reason := gate.Reason
-			if reason == "" {
-				reason = gate.WinningSource
-			}
 			ic.Logger.LogBlocked(actx, "contract", reason)
 			ic.Metrics.RecordTLSRequestBlocked("contract")
 			interceptEmitReceipt(ic, withInterceptRedaction(receipt.EmitOpts{

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -21,9 +21,13 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/certgen"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
+	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
+	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
@@ -71,6 +75,311 @@ func testInterceptRedactProxy(t *testing.T, cfg *config.Config) *Proxy {
 	p.redactionRuntimePtr.Store(rt)
 	p.redactMatcherPtr.Store(rt.matcher)
 	return p
+}
+
+type interceptRewriteRoundTripper struct {
+	base http.RoundTripper
+	addr string
+}
+
+func (rt interceptRewriteRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	u := *req.URL
+	u.Host = rt.addr
+	clone.URL = &u
+	return rt.base.RoundTrip(clone)
+}
+
+func interceptLiveLockProxy(loader *contractruntime.Loader, ks *killswitch.Controller, m *metrics.Metrics) *Proxy {
+	p := &Proxy{captureObs: capture.NopObserver{}, metrics: m, ks: ks}
+	if loader != nil {
+		p.contractLoaderPtr.Store(loader)
+	}
+	return p
+}
+
+func interceptLiveLockRequest(
+	t *testing.T,
+	upstream *httptest.Server,
+	cache *certgen.CertCache,
+	pool *x509.CertPool,
+	cfg *config.Config,
+	sc *scanner.Scanner,
+	logger *audit.Logger,
+	m *metrics.Metrics,
+	targetHost string,
+	req *http.Request,
+	proxy *Proxy,
+) (*http.Response, tls.ConnectionState) {
+	t.Helper()
+
+	clientConn, proxyConn := net.Pipe()
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	go func() {
+		_ = interceptTunnel(ctx, proxyConn, &InterceptContext{
+			TargetHost: targetHost,
+			TargetPort: "443",
+			Config:     cfg,
+			Scanner:    sc,
+			CertCache:  cache,
+			Logger:     logger,
+			Metrics:    m,
+			ClientIP:   "10.0.0.1",
+			RequestID:  "test-req-1",
+			Agent:      "agent-a",
+			Profile:    "agent-a",
+			UpstreamRT: interceptRewriteRoundTripper{
+				base: upstream.Client().Transport,
+				addr: upstream.Listener.Addr().String(),
+			},
+			Proxy:      proxy,
+			KillSwitch: proxy.ks,
+		})
+	}()
+
+	tlsConn := tls.Client(clientConn, &tls.Config{
+		RootCAs:    pool,
+		ServerName: targetHost,
+	})
+	t.Cleanup(func() { _ = tlsConn.Close() })
+	if err := tlsConn.HandshakeContext(context.Background()); err != nil {
+		t.Fatalf("client handshake: %v", err)
+	}
+	state := tlsConn.ConnectionState()
+
+	if err := req.Write(tlsConn); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(tlsConn), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp, state
+}
+
+func newInterceptLiveLockRequest(t *testing.T, host, body string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://"+host+"/v1/chat", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set(AgentHeader, "agent-a")
+	return req
+}
+
+func TestInterceptLiveLock_NoActiveContractPassThrough(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	proxy := interceptLiveLockProxy(emptyContractLoader(t, contractruntime.ModeLive), nil, m)
+	resp, _ := interceptLiveLockRequest(t, upstream, cache, pool, cfg, sc, logger, m,
+		"evil.example.com", newInterceptLiveLockRequest(t, "evil.example.com", "{}"), proxy)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != "" {
+		t.Fatalf("block reason = %q, want empty", got)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestInterceptLiveLock_AllowRulePasses(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxy := interceptLiveLockProxy(testContractLoader(t, contractruntime.ModeLive, rule), nil, m)
+	resp, _ := interceptLiveLockRequest(t, upstream, cache, pool, cfg, sc, logger, m,
+		"api.example.com", newInterceptLiveLockRequest(t, "api.example.com", "{}"), proxy)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestInterceptLiveLock_DefaultDenyBlocksUnmatchedDestination(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer upstream.Close()
+
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxy := interceptLiveLockProxy(testContractLoader(t, contractruntime.ModeLive, rule), nil, m)
+	resp, _ := interceptLiveLockRequest(t, upstream, cache, pool, cfg, sc, logger, m,
+		"evil.example.com", newInterceptLiveLockRequest(t, "evil.example.com", "{}"), proxy)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != contractDefaultDenyReason {
+		t.Fatalf("block reason = %q, want %s", got, contractDefaultDenyReason)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
+func TestInterceptLiveLock_ScannerBlockWinsOverContractAllow(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer upstream.Close()
+
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	cfg.RequestBodyScanning.Enabled = true
+	cfg.RequestBodyScanning.Action = config.ActionBlock
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxy := interceptLiveLockProxy(testContractLoader(t, contractruntime.ModeLive, rule), nil, m)
+	fakeToken := "sk-ant-" + "api03-XXXXXXXXXXXXXXXXXXXXXXX"
+	resp, _ := interceptLiveLockRequest(t, upstream, cache, pool, cfg, sc, logger, m,
+		"api.example.com", newInterceptLiveLockRequest(t, "api.example.com", `{"token":"`+fakeToken+`"}`), proxy)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.DLPMatch) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.DLPMatch)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
+func TestInterceptLiveLock_ShadowModeObservesWithoutBlocking(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxy := interceptLiveLockProxy(testContractLoader(t, contractruntime.ModeShadow, rule), nil, m)
+	resp, _ := interceptLiveLockRequest(t, upstream, cache, pool, cfg, sc, logger, m,
+		"evil.example.com", newInterceptLiveLockRequest(t, "evil.example.com", "{}"), proxy)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestInterceptLiveLock_CaptureModeDoesNotBlock(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxy := interceptLiveLockProxy(testContractLoader(t, contractruntime.ModeCapture, rule), nil, m)
+	resp, _ := interceptLiveLockRequest(t, upstream, cache, pool, cfg, sc, logger, m,
+		"evil.example.com", newInterceptLiveLockRequest(t, "evil.example.com", "{}"), proxy)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestInterceptLiveLock_KillSwitchBlocksBeforeContractAllow(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer upstream.Close()
+
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	ks := killswitch.New(cfg)
+	ks.SetAPI(true)
+	proxy := interceptLiveLockProxy(testContractLoader(t, contractruntime.ModeLive, rule), ks, m)
+	resp, _ := interceptLiveLockRequest(t, upstream, cache, pool, cfg, sc, logger, m,
+		"api.example.com", newInterceptLiveLockRequest(t, "api.example.com", "{}"), proxy)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.KillSwitchActive) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.KillSwitchActive)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
+func TestInterceptLiveLock_CertForgeCompletesBeforeContractBlock(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer upstream.Close()
+
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxy := interceptLiveLockProxy(testContractLoader(t, contractruntime.ModeLive, rule), nil, m)
+	resp, state := interceptLiveLockRequest(t, upstream, cache, pool, cfg, sc, logger, m,
+		"evil.example.com", newInterceptLiveLockRequest(t, "evil.example.com", "{}"), proxy)
+	defer func() { _ = resp.Body.Close() }()
+
+	if len(state.PeerCertificates) == 0 {
+		t.Fatal("peer certificates len = 0, want forged leaf")
+	}
+	if got := state.PeerCertificates[0].DNSNames; len(got) != 1 || got[0] != "evil.example.com" {
+		t.Fatalf("forged DNSNames = %v, want [evil.example.com]", got)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != contractDefaultDenyReason {
+		t.Fatalf("block reason = %q, want %s", got, contractDefaultDenyReason)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
 }
 
 // interceptAndRequest performs a TLS MITM test: runs interceptTunnel in a

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -144,6 +144,7 @@ func interceptLiveLockRequest(
 	tlsConn := tls.Client(clientConn, &tls.Config{
 		RootCAs:    pool,
 		ServerName: targetHost,
+		MinVersion: tls.VersionTLS13,
 	})
 	t.Cleanup(func() { _ = tlsConn.Close() })
 	if err := tlsConn.HandshakeContext(context.Background()); err != nil {
@@ -339,8 +340,8 @@ func TestInterceptLiveLock_KillSwitchBlocksBeforeContractAllow(t *testing.T) {
 		"api.example.com", newInterceptLiveLockRequest(t, "api.example.com", "{}"), proxy)
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusForbidden {
-		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", resp.StatusCode)
 	}
 	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.KillSwitchActive) {
 		t.Fatalf("block reason = %q, want %s", got, blockreason.KillSwitchActive)

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -351,6 +351,38 @@ func TestInterceptLiveLock_KillSwitchBlocksBeforeContractAllow(t *testing.T) {
 	}
 }
 
+// TestInterceptLiveLock_KillSwitchWithoutContractLoaderEmitsKSBlock exercises
+// the kill-switch path when no contract loader is configured. EvaluateGate
+// returns its scanner-verdict fallback (Verdict=Allow) so the post-eval
+// fall-through emitKillSwitchBlock fires instead of the contract-block branch
+// short-circuit, keeping kill-switch semantics intact.
+func TestInterceptLiveLock_KillSwitchWithoutContractLoaderEmitsKSBlock(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer upstream.Close()
+
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	ks := killswitch.New(cfg)
+	ks.SetAPI(true)
+	proxy := interceptLiveLockProxy(nil, ks, m)
+	resp, _ := interceptLiveLockRequest(t, upstream, cache, pool, cfg, sc, logger, m,
+		"api.example.com", newInterceptLiveLockRequest(t, "api.example.com", "{}"), proxy)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.KillSwitchActive) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.KillSwitchActive)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
 func TestInterceptLiveLock_CertForgeCompletesBeforeContractBlock(t *testing.T) {
 	var hits atomic.Int32
 	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
Live lock now enforces contract decisions on the TLS intercept transport.

## Behavior

TLS-intercepted requests now route through the same `EvaluateGate` path used by the forward proxy before opening the upstream request. Deployments without a configured loader or without an active manifest keep the existing scanner-only behavior.

A matching enforce rule lets scanner-allowed traffic pass. A promoted contract with enforce rules default-denies unmatched TLS-intercepted destinations and returns `contract_default_deny` in `X-Pipelock-Block-Reason`.

Kill switch remains the absolute floor and surfaces `kill_switch_active` over the forged TLS connection. Shadow and capture modes observe the contract decision without blocking more than the scanner already would.

## Defense in depth

Scanner block still wins over contract allow on the intercept transport. `TestInterceptLiveLock_ScannerBlockWinsOverContractAllow` proves a body DLP block returns 403 with the DLP block reason even when the active contract allows the destination.

`TestInterceptLiveLock_CertForgeCompletesBeforeContractBlock` proves the proxy completes the forged leaf certificate handshake for the requested host before returning a contract block. The agent receives a clean HTTP 403 inside the intercepted TLS session rather than a TLS handshake failure or reset.

## Receipt notes

Intercept receipts use the existing proxy receipt path with contract context fields attached: active manifest hash, contract hash, selector ID, generation, winning source, live verdict, policy sources, and rule ID.

The v2 EvidenceReceipt path remains a follow-up across transports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contract gate enforcement now applies to intercepted CONNECT inner-requests and is evaluated before forwarding; contract receipts and metrics are emitted on blocks.

* **Refactor**
  * Contract-gate denials now consistently return Forbidden (403) and callers are simplified.

* **Tests**
  * Expanded live-lock/intercept test coverage: kill-switch, scanner precedence, shadow/capture modes, and certificate-forging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->