### PR TITLE
feat(proxy): live-lock enforcement on reverse and redirect paths

### DIFF
--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -1022,6 +1022,7 @@ func (s *Server) Start(ctx context.Context) error {
 		rpHandler.SetEnvelopeEmitter(s.proxy.EnvelopeEmitterPtr())
 		rpHandler.SetEnvelopeVerifier(s.proxy.EnvelopeVerifierPtr())
 		rpHandler.SetReceiptEmitter(s.proxy.ReceiptEmitterPtr())
+		rpHandler.SetContractLoader(s.proxy.ContractLoaderPtr())
 		rpHandler.SetReloadLock(s.proxy.ReloadLock())
 		rpHandler.SetRedactionRuntimePtr(s.proxy.RedactionRuntimePtr())
 

--- a/internal/proxy/contractgate.go
+++ b/internal/proxy/contractgate.go
@@ -213,6 +213,20 @@ func scannerVerdictForGate(hasFinding bool) string {
 	return config.ActionAllow
 }
 
+func scannerVerdictForContinuingAction(action string, enforce bool) string {
+	switch action {
+	case "", config.ActionAllow:
+		return config.ActionAllow
+	case config.ActionBlock:
+		if enforce {
+			return config.ActionBlock
+		}
+		return config.ActionWarn
+	default:
+		return action
+	}
+}
+
 // ForwardBlockReceiptInput is the per-request data the forward block-receipt
 // helper needs. It collapses the loose arguments forwardBlockReceiptOpts would
 // otherwise take.

--- a/internal/proxy/contractgate_test.go
+++ b/internal/proxy/contractgate_test.go
@@ -43,7 +43,7 @@ func TestEvaluateGate_NilLoaderFallsThroughToScanner(t *testing.T) {
 }
 
 func TestEvaluateGate_NoActiveManifestDoesNotEmitContractReceiptContext(t *testing.T) {
-	loader := emptyContractLoader(t, contractruntime.ModeLive)
+	loader := emptyContractLoader(t)
 	out, err := EvaluateGate(ContractGateInput{
 		Loader:         loader,
 		Agent:          "agent-a",
@@ -327,6 +327,29 @@ func TestScannerVerdictForGate(t *testing.T) {
 	}
 	if got := scannerVerdictForGate(false); got != config.ActionAllow {
 		t.Fatalf("hasFinding=false got %q, want allow", got)
+	}
+}
+
+func TestScannerVerdictForContinuingAction(t *testing.T) {
+	tests := []struct {
+		name    string
+		action  string
+		enforce bool
+		want    string
+	}{
+		{name: "empty", action: "", enforce: true, want: config.ActionAllow},
+		{name: "allow", action: config.ActionAllow, enforce: true, want: config.ActionAllow},
+		{name: "warn", action: config.ActionWarn, enforce: true, want: config.ActionWarn},
+		{name: "block enforce", action: config.ActionBlock, enforce: true, want: config.ActionBlock},
+		{name: "block audit", action: config.ActionBlock, enforce: false, want: config.ActionWarn},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := scannerVerdictForContinuingAction(tc.action, tc.enforce); got != tc.want {
+				t.Fatalf("scannerVerdictForContinuingAction(%q, %t) = %q, want %q", tc.action, tc.enforce, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1377,6 +1377,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx = context.WithValue(ctx, ctxKeyAgent, agent)
 	ctx = context.WithValue(ctx, ctxKeyAgentConfig, cfg)
 	ctx = context.WithValue(ctx, ctxKeyAgentScanner, sc)
+	ctx = context.WithValue(ctx, ctxKeyAgentContractLoader, snapshotContractLoader)
 	ctx = context.WithValue(ctx, ctxKeyRedirectTransport, TransportForward)
 	outReq := r.Clone(ctx)
 	outReq.RequestURI = "" // required for http.Client
@@ -1473,7 +1474,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("X-Pipelock-Hint", "Request was redirected to a different origin. Cross-origin redirects are blocked to prevent open redirect attacks.")
 			}
 			writeBlockedError(w,
-				blockInfoFor(blockreason.RedirectScanDenied, blockedErr.layer),
+				redirectBlockedInfo(blockedErr),
 				"blocked: "+blockedErr.reason, http.StatusForbidden)
 			return
 		}

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -178,7 +178,7 @@ func forwardHTTPClient(t *testing.T, proxyAddr string) *http.Client {
 	}
 }
 
-func emptyContractLoader(t *testing.T, mode contractruntime.Mode) *contractruntime.Loader {
+func emptyContractLoader(t *testing.T) *contractruntime.Loader {
 	t.Helper()
 	fixture := contractruntimetest.NewFixture(t)
 	storeDir := t.TempDir()
@@ -188,7 +188,7 @@ func emptyContractLoader(t *testing.T, mode contractruntime.Mode) *contractrunti
 		PinnedRootFingerprint: fixture.RootFingerprint(),
 		Environment:           contractruntimetest.Env(),
 		MinSignatures:         1,
-		Mode:                  mode,
+		Mode:                  contractruntime.ModeLive,
 	}, nil)
 	if err != nil {
 		t.Fatalf("NewLoader: %v", err)
@@ -206,7 +206,7 @@ func TestForwardLiveLock_NoActiveContractPassThrough(t *testing.T) {
 
 	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, nil)
 	defer cleanup()
-	p.contractLoaderPtr.Store(emptyContractLoader(t, contractruntime.ModeLive))
+	p.contractLoaderPtr.Store(emptyContractLoader(t))
 	installForwardTestDialer(p, backend.Listener.Addr().String())
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://evil.example.com/v1/chat", strings.NewReader("{}"))

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -183,7 +183,7 @@ func TestInterceptLiveLock_NoActiveContractPassThrough(t *testing.T) {
 	defer upstream.Close()
 
 	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
-	proxy := interceptLiveLockProxy(emptyContractLoader(t, contractruntime.ModeLive), nil, m)
+	proxy := interceptLiveLockProxy(emptyContractLoader(t), nil, m)
 	resp, _ := interceptLiveLockRequest(t, upstream, cache, pool, cfg, sc, logger, m,
 		"evil.example.com", newInterceptLiveLockRequest(t, "evil.example.com", "{}"), proxy)
 	defer func() { _ = resp.Body.Close() }()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -615,6 +615,9 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 			}
 			scannerMatched := !result.Allowed
 			contractLoader, _ := req.Context().Value(ctxKeyAgentContractLoader).(*contractruntime.Loader)
+			if contractLoader == nil {
+				contractLoader = p.currentContractLoader()
+			}
 			gate, gateErr := EvaluateGate(ContractGateInput{
 				Loader:          contractLoader,
 				Agent:           agentName,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -60,6 +60,7 @@ const (
 	ctxKeyAgent
 	ctxKeyAgentConfig  // per-agent resolved config for redirect scanning
 	ctxKeyAgentScanner // per-agent resolved scanner for redirect scanning
+	ctxKeyAgentContractLoader
 
 	// ctxKeyReverseEnvelopeOpts stores the envelope.BuildOpts that the
 	// reverse proxy pre-computes in ServeHTTP so the signing
@@ -195,6 +196,20 @@ func newRedirectEnvelopeBlockedRequest(err error) *blockedRequestError {
 		reason,
 		reason+": "+err.Error(),
 	)
+}
+
+func redirectBlockedInfo(blockedErr *blockedRequestError) blockreason.Info {
+	if blockedErr != nil && blockedErr.layer == blockLayerContract {
+		reason := strings.TrimPrefix(blockedErr.reason, "redirect blocked: ")
+		if info, ok := contractBlockInfo(reason); ok {
+			return info
+		}
+	}
+	layer := ""
+	if blockedErr != nil {
+		layer = blockedErr.layer
+	}
+	return blockInfoFor(blockreason.RedirectScanDenied, layer)
 }
 
 // Regex patterns for extracting content from HTML hiding spots that
@@ -576,7 +591,9 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 			// TransportFetch here mislabels every forward-proxy
 			// redirect — both paths share p.client and therefore
 			// share this CheckRedirect closure.
+			redirectTransport := TransportFetch
 			if t, ok := req.Context().Value(ctxKeyRedirectTransport).(string); ok && t != "" {
+				redirectTransport = t
 				redirectWarnCtx.Transport = t
 			} else {
 				redirectWarnCtx.Transport = TransportFetch
@@ -595,6 +612,32 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 					return newRedirectBlockedRequest(result.Scanner, result.Reason)
 				}
 				logger.LogAnomaly(actx, result.Scanner, fmt.Sprintf("redirect from %s: %s", originalURL, result.Reason), result.Score)
+			}
+			scannerMatched := !result.Allowed
+			contractLoader, _ := req.Context().Value(ctxKeyAgentContractLoader).(*contractruntime.Loader)
+			gate, gateErr := EvaluateGate(ContractGateInput{
+				Loader:          contractLoader,
+				Agent:           agentName,
+				URL:             redirectURL,
+				Method:          req.Method,
+				EffectiveAction: scannerVerdictForGate(scannerMatched),
+				ScannerVerdict:  scannerVerdictForGate(scannerMatched),
+				ScannerMatched:  scannerMatched,
+				Transport:       redirectTransport,
+			})
+			if gateErr != nil {
+				actx := newHTTPAuditContext(logger, req.Method, redirectURL, clientIP, requestID, agentName)
+				logger.LogBlocked(actx, blockLayerContract, "redirect from "+originalURL+" blocked: "+gateErr.Error())
+				return newRedirectBlockedRequest(blockLayerContract, "contract evaluation failed")
+			}
+			if gate.Verdict == config.ActionBlock {
+				reason := gate.Reason
+				if reason == "" {
+					reason = gate.WinningSource
+				}
+				actx := newHTTPAuditContext(logger, req.Method, redirectURL, clientIP, requestID, agentName)
+				logger.LogBlocked(actx, blockLayerContract, "redirect from "+originalURL+" blocked: "+reason)
+				return newRedirectBlockedRequest(blockLayerContract, reason)
 			}
 			// Mediation envelope refresh: on every allowed redirect,
 			// rebuild the envelope on req so ph, hop, and @target-uri
@@ -1134,6 +1177,12 @@ func (p *Proxy) EnvelopeVerifierPtr() *atomic.Pointer[envelope.Verifier] {
 // Long-lived runtimes use this to pick up hot-reload receipt config changes.
 func (p *Proxy) ReceiptEmitterPtr() *atomic.Pointer[receipt.Emitter] {
 	return &p.receiptEmitterPtr
+}
+
+// ContractLoaderPtr returns the atomic pointer to the learn-lock loader.
+// Long-lived runtimes use this to pick up hot-reload contract state changes.
+func (p *Proxy) ContractLoaderPtr() *atomic.Pointer[contractruntime.Loader] {
+	return &p.contractLoaderPtr
 }
 
 // RedactMatcherPtr returns the atomic pointer to the compiled redaction
@@ -2462,7 +2511,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	// does not invoke the HTTP contract gate today; the loader handle is
 	// discarded here and re-snapshotted by handleForwardHTTP for the
 	// forward path.
-	resolved, id, envEmitter, _ := p.resolveAgentRuntimeFromRequest(r)
+	resolved, id, envEmitter, snapshotContractLoader := p.resolveAgentRuntimeFromRequest(r)
 	cfg := resolved.Config
 	agent := id.Name
 	if agent == "" {
@@ -3104,6 +3153,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	ctx = context.WithValue(ctx, ctxKeyAgent, agent)
 	ctx = context.WithValue(ctx, ctxKeyAgentConfig, cfg)
 	ctx = context.WithValue(ctx, ctxKeyAgentScanner, sc)
+	ctx = context.WithValue(ctx, ctxKeyAgentContractLoader, snapshotContractLoader)
 	ctx = context.WithValue(ctx, ctxKeyRedirectTransport, TransportFetch)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
 	if err != nil {
@@ -3209,7 +3259,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 				Agent:     agent,
 			})
 			writeBlockedJSON(w,
-				blockInfoFor(blockreason.RedirectScanDenied, blockedErr.layer),
+				redirectBlockedInfo(blockedErr),
 				http.StatusForbidden, resp)
 			return
 		}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -21,8 +21,11 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/certgen"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
+	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
 	"github.com/luckyPipewrench/pipelock/internal/hitl"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
@@ -1471,6 +1474,178 @@ func TestFetchEndpoint_BindDefaultAgentIdentityIgnoresHeaderAndQuery(t *testing.
 }
 
 // --- Redirect Scanning Tests ---
+
+func installFetchRedirectLiveLockDialer(p *Proxy, routes map[string]string) {
+	p.client.Transport = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if target, ok := routes[addr]; ok {
+				return (&net.Dialer{}).DialContext(ctx, network, target)
+			}
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		},
+		DisableCompression: true,
+	}
+}
+
+func newFetchRedirectLiveLockProxy(t *testing.T, loader *contractruntime.Loader, routes map[string]string) *Proxy {
+	t.Helper()
+	cfg := config.Defaults()
+	cfg.FetchProxy.TimeoutSeconds = 5
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.APIAllowlist = nil
+
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	t.Cleanup(p.Close)
+	if loader != nil {
+		p.contractLoaderPtr.Store(loader)
+	}
+	installFetchRedirectLiveLockDialer(p, routes)
+	return p
+}
+
+func serveFetch(t *testing.T, p *Proxy, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/fetch?url="+url.QueryEscape(target), nil)
+	req.Header.Set(AgentHeader, "agent-a")
+	w := httptest.NewRecorder()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fetch", p.handleFetch)
+	mux.ServeHTTP(w, req)
+	return w
+}
+
+func TestFetchEndpoint_LiveLockRedirectAllowedDestinationFollows(t *testing.T) {
+	var finalHits int
+	origin := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/chat":
+			http.Redirect(w, r, "http://api.example.com/v2/chat", http.StatusFound)
+		case "/v2/chat":
+			finalHits++
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte("allowed destination"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer origin.Close()
+
+	ruleV1 := contractruntimetest.HTTPEnforceRule("r-chat-v1", "api.example.com", "/v1/chat", http.MethodGet)
+	ruleV2 := contractruntimetest.HTTPEnforceRule("r-chat-v2", "api.example.com", "/v2/chat", http.MethodGet)
+	p := newFetchRedirectLiveLockProxy(t, testContractLoader(t, contractruntime.ModeLive, ruleV1, ruleV2), map[string]string{
+		"api.example.com:80": origin.Listener.Addr().String(),
+	})
+
+	w := serveFetch(t, p, "http://api.example.com/v1/chat")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "allowed destination") {
+		t.Fatalf("body does not include final response: %q", w.Body.String())
+	}
+	if finalHits != 1 {
+		t.Fatalf("final hits = %d, want 1", finalHits)
+	}
+}
+
+func TestFetchEndpoint_LiveLockRedirectUnapprovedDestinationBlocks(t *testing.T) {
+	var evilHits int
+	origin := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://evil.example.com/steal", http.StatusFound)
+	}))
+	defer origin.Close()
+	evil := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		evilHits++
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer evil.Close()
+
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodGet)
+	p := newFetchRedirectLiveLockProxy(t, testContractLoader(t, contractruntime.ModeLive, rule), map[string]string{
+		"api.example.com:80":  origin.Listener.Addr().String(),
+		"evil.example.com:80": evil.Listener.Addr().String(),
+	})
+
+	w := serveFetch(t, p, "http://api.example.com/v1/chat")
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get(blockreason.HeaderReason); got != contractDefaultDenyReason {
+		t.Fatalf("block reason header = %q, want %s", got, contractDefaultDenyReason)
+	}
+	if !strings.Contains(w.Body.String(), "redirect blocked") {
+		t.Fatalf("body does not name redirect block: %q", w.Body.String())
+	}
+	if evilHits != 0 {
+		t.Fatalf("evil hits = %d, want 0", evilHits)
+	}
+}
+
+func TestFetchEndpoint_LiveLockRedirectChainCapStillApplies(t *testing.T) {
+	var redirects int
+	origin := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirects++
+		http.Redirect(w, r, r.URL.Path+"x", http.StatusFound)
+	}))
+	defer origin.Close()
+
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/a", http.MethodGet)
+	p := newFetchRedirectLiveLockProxy(t, testContractLoader(t, contractruntime.ModeShadow, rule), map[string]string{
+		"api.example.com:80": origin.Listener.Addr().String(),
+	})
+
+	w := serveFetch(t, p, "http://api.example.com/a")
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "too many redirects") {
+		t.Fatalf("body does not name redirect cap: %q", w.Body.String())
+	}
+	if redirects < 5 {
+		t.Fatalf("redirects = %d, want at least 5", redirects)
+	}
+}
+
+func TestFetchEndpoint_LiveLockRedirectShadowModeObservesWithoutBlocking(t *testing.T) {
+	var evilHits int
+	origin := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://evil.example.com/steal", http.StatusFound)
+	}))
+	defer origin.Close()
+	evil := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		evilHits++
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("shadow destination"))
+	}))
+	defer evil.Close()
+
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodGet)
+	p := newFetchRedirectLiveLockProxy(t, testContractLoader(t, contractruntime.ModeShadow, rule), map[string]string{
+		"api.example.com:80":  origin.Listener.Addr().String(),
+		"evil.example.com:80": evil.Listener.Addr().String(),
+	})
+
+	w := serveFetch(t, p, "http://api.example.com/v1/chat")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "shadow destination") {
+		t.Fatalf("body does not include redirected response: %q", w.Body.String())
+	}
+	if evilHits != 1 {
+		t.Fatalf("evil hits = %d, want 1", evilHits)
+	}
+}
 
 func TestFetchEndpoint_RedirectToBlockedDomain(t *testing.T) {
 	// Backend redirects to a blocklisted domain — should be caught by CheckRedirect

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1589,6 +1589,48 @@ func TestFetchEndpoint_LiveLockRedirectUnapprovedDestinationBlocks(t *testing.T)
 	}
 }
 
+func TestFetchEndpoint_LiveLockRedirectUsesGlobalLoaderFallback(t *testing.T) {
+	var evilHits int
+	origin := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://evil.example.com/steal", http.StatusFound)
+	}))
+	defer origin.Close()
+	evil := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		evilHits++
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer evil.Close()
+
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodGet)
+	p := newFetchRedirectLiveLockProxy(t, testContractLoader(t, contractruntime.ModeLive, rule), map[string]string{
+		"api.example.com:80":  origin.Listener.Addr().String(),
+		"evil.example.com:80": evil.Listener.Addr().String(),
+	})
+
+	ctx := context.WithValue(context.Background(), ctxKeyAgent, "agent-a")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://api.example.com/v1/chat", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := p.client.Do(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("client.Do err = nil, want redirect block")
+	}
+	blockedErr, ok := blockedRequestErrorFrom(err)
+	if !ok {
+		t.Fatalf("client.Do err = %T %[1]v, want blockedRequestError", err)
+	}
+	if blockedErr.layer != blockLayerContract {
+		t.Fatalf("blocked layer = %q, want %q", blockedErr.layer, blockLayerContract)
+	}
+	if evilHits != 0 {
+		t.Fatalf("evil hits = %d, want 0", evilHits)
+	}
+}
+
 func TestFetchEndpoint_LiveLockRedirectChainCapStillApplies(t *testing.T) {
 	var redirects int
 	origin := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -546,6 +546,8 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		}
 		if verdict != "" {
 			forwardedVerdict = verdict
+		}
+		if bodyFinding && verdict != "" {
 			requestEffectiveAction = verdict
 			requestScannerVerdict = scannerVerdictForContinuingAction(verdict, cfg.EnforceEnabled())
 		}
@@ -578,7 +580,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			Agent:     agent,
 		}))
 		writeReverseProxyBlock(w, http.StatusForbidden,
-			blockInfoFor(blockreason.ParseError, blockLayerContract),
+			blockInfoFor(blockreason.ContractDefaultDeny, blockLayerContract),
 			"contract evaluation failed")
 		return
 	}
@@ -590,7 +592,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		}
 		info, ok := contractBlockInfo(reason)
 		if !ok {
-			info = blockInfoFor(blockreason.ParseError, blockLayerContract)
+			info = blockInfoFor(blockreason.ContractDefaultDeny, blockLayerContract)
 		}
 		rp.logger.LogBlocked(newHTTPAuditContext(rp.logger, r.Method, targetURL, clientIP, requestID, agent), blockLayerContract, reason)
 		rp.metrics.RecordReverseProxyRequest(r.Method, "403")

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -445,6 +445,8 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	// host is operator-configured so we skip the full URL pipeline (SSRF,
 	// blocklist, rate limit) which only applies to agent-chosen destinations.
 	hasFinding := false
+	requestEffectiveAction := config.ActionAllow
+	requestScannerVerdict := config.ActionAllow
 	if pathQuery := r.URL.RequestURI(); pathQuery != "" {
 		pathDLP := sc.ScanTextForDLP(r.Context(), pathQuery)
 
@@ -480,6 +482,8 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			if action == "" {
 				action = config.ActionBlock
 			}
+			requestEffectiveAction = action
+			requestScannerVerdict = scannerVerdictForContinuingAction(action, cfg.EnforceEnabled())
 			patternNames := dlpMatchNames(pathDLP.Matches)
 			rp.logger.LogBodyDLP(newHTTPAuditContext(rp.logger, r.Method, r.URL.String(), clientIP, requestID, ""),
 				action,
@@ -506,6 +510,8 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			if action == "" {
 				action = config.ActionBlock
 			}
+			requestEffectiveAction = action
+			requestScannerVerdict = scannerVerdictForContinuingAction(action, cfg.EnforceEnabled())
 			patternNames := dlpMatchNames(headerResult.DLPMatches)
 			rp.logger.LogHeaderDLP(newHTTPAuditContext(rp.logger, r.Method, r.URL.String(), clientIP, requestID, ""), headerResult.HeaderName,
 				action, patternNames, nil)
@@ -540,6 +546,8 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		}
 		if verdict != "" {
 			forwardedVerdict = verdict
+			requestEffectiveAction = verdict
+			requestScannerVerdict = scannerVerdictForContinuingAction(verdict, cfg.EnforceEnabled())
 		}
 		reverseBodyBytes = bodyBytes
 	}
@@ -549,8 +557,8 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		Agent:           agent,
 		URL:             targetURL,
 		Method:          r.Method,
-		EffectiveAction: scannerVerdictForGate(hasFinding),
-		ScannerVerdict:  scannerVerdictForGate(hasFinding),
+		EffectiveAction: requestEffectiveAction,
+		ScannerVerdict:  requestScannerVerdict,
 		ScannerMatched:  hasFinding,
 		Transport:       TransportReverse,
 	})

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -23,6 +24,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
@@ -72,6 +74,7 @@ type ReverseProxyHandler struct {
 	envelopeEmitterPtr  *atomic.Pointer[envelope.Emitter]
 	envelopeVerifierPtr *atomic.Pointer[envelope.Verifier]
 	receiptEmitterPtr   *atomic.Pointer[receipt.Emitter]
+	contractLoaderPtr   *atomic.Pointer[contractruntime.Loader]
 	reloadMu            *sync.RWMutex
 }
 
@@ -111,6 +114,8 @@ func NewReverseProxy(
 	originalDirector := proxy.Director
 	proxy.Director = func(req *http.Request) {
 		originalDirector(req)
+		req.URL.Path = cleanReversePath(req.URL.Path)
+		req.URL.RawPath = ""
 		req.Host = upstream.Host
 	}
 
@@ -164,6 +169,11 @@ func (rp *ReverseProxyHandler) SetReceiptEmitter(ptr *atomic.Pointer[receipt.Emi
 	rp.receiptEmitterPtr = ptr
 }
 
+// SetContractLoader sets the atomic pointer to the learn-lock loader.
+func (rp *ReverseProxyHandler) SetContractLoader(ptr *atomic.Pointer[contractruntime.Loader]) {
+	rp.contractLoaderPtr = ptr
+}
+
 // emitReceipt records a signed action receipt for a reverse-proxy
 // decision. Mirrors Proxy.emitReceipt: nil emitter is a no-op, errors are
 // logged but never propagated so a recorder failure cannot poison the
@@ -190,6 +200,47 @@ func (rp *ReverseProxyHandler) emitReceipt(opts receipt.EmitOpts) {
 	}
 }
 
+func reverseTargetURL(upstream *url.URL, r *http.Request) string {
+	if upstream == nil || r == nil || r.URL == nil {
+		return ""
+	}
+	target := *upstream
+	target.Path = joinReversePaths(upstream.Path, r.URL.Path)
+	target.RawPath = ""
+	switch {
+	case upstream.RawQuery == "":
+		target.RawQuery = r.URL.RawQuery
+	case r.URL.RawQuery == "":
+		target.RawQuery = upstream.RawQuery
+	default:
+		target.RawQuery = upstream.RawQuery + "&" + r.URL.RawQuery
+	}
+	return target.String()
+}
+
+func joinReversePaths(basePath, reqPath string) string {
+	baseSlash := strings.HasSuffix(basePath, "/")
+	reqSlash := strings.HasPrefix(reqPath, "/")
+	var joined string
+	switch {
+	case baseSlash && reqSlash:
+		joined = basePath + reqPath[1:]
+	case !baseSlash && !reqSlash:
+		joined = basePath + "/" + reqPath
+	default:
+		joined = basePath + reqPath
+	}
+	return cleanReversePath(joined)
+}
+
+func cleanReversePath(joined string) string {
+	cleaned := path.Clean(joined)
+	if strings.HasSuffix(joined, "/") && cleaned != "/" {
+		return cleaned + "/"
+	}
+	return cleaned
+}
+
 // SetReloadLock lets ServeHTTP snapshot cfg/scanner/emitter state coherently
 // with Proxy.Reload publication.
 func (rp *ReverseProxyHandler) SetReloadLock(mu *sync.RWMutex) {
@@ -209,6 +260,7 @@ type reverseRuntimeSnapshot struct {
 	sc               *scanner.Scanner
 	admissionEmitter *envelope.Emitter
 	inboundVerifier  *envelope.Verifier
+	contractLoader   *contractruntime.Loader
 }
 
 func (rp *ReverseProxyHandler) snapshotRuntime() reverseRuntimeSnapshot {
@@ -225,6 +277,9 @@ func (rp *ReverseProxyHandler) snapshotRuntime() reverseRuntimeSnapshot {
 	}
 	if rp.envelopeVerifierPtr != nil {
 		snap.inboundVerifier = rp.envelopeVerifierPtr.Load()
+	}
+	if rp.contractLoaderPtr != nil {
+		snap.contractLoader = rp.contractLoaderPtr.Load()
 	}
 	return snap
 }
@@ -285,12 +340,24 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	admissionEmitter := snap.admissionEmitter
 	clientIP, requestID := requestMeta(r)
 	agent, _ := r.Context().Value(ctxKeyAgent).(string)
+	if agent == "" {
+		agent = edition.ResolveAgentIdentity(r, nil, cfg.DefaultAgentIdentity, cfg.BindDefaultAgentIdentity).Name
+	}
+	targetURL := reverseTargetURL(rp.upstream, r)
+	var reverseGate ContractGateOutput
+	withReverseContractReceipt := func(opts receipt.EmitOpts) receipt.EmitOpts {
+		if reverseGate.HasContractContext() {
+			opts = withContractReceipt(reverseGate, opts)
+		}
+		return opts
+	}
 	ctx := scanner.WithDLPWarnContext(r.Context(), scanner.DLPWarnContext{
-		Method: r.Method, URL: r.URL.String(), ClientIP: clientIP,
+		Method: r.Method, URL: targetURL, ClientIP: clientIP,
 		RequestID: requestID, Agent: agent, Transport: "reverse",
 	})
 	ctx = context.WithValue(ctx, ctxKeyClientIP, clientIP)
 	ctx = context.WithValue(ctx, ctxKeyRequestID, requestID)
+	ctx = context.WithValue(ctx, ctxKeyAgent, agent)
 	ctx = context.WithValue(ctx, ctxKeyReverseEnvelopeCfg, cfg)
 	ctx = context.WithValue(ctx, ctxKeyReverseScanner, sc)
 	r = r.WithContext(ctx)
@@ -323,6 +390,45 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	// Kill switch: deny all traffic when active.
 	if rp.ks != nil && rp.ks.IsActive() {
+		gate, gateErr := EvaluateGate(ContractGateInput{
+			Loader:           snap.contractLoader,
+			Agent:            agent,
+			URL:              targetURL,
+			Method:           r.Method,
+			EffectiveAction:  config.ActionAllow,
+			ScannerVerdict:   config.ActionAllow,
+			KillSwitchActive: true,
+			Transport:        TransportReverse,
+		})
+		if gateErr != nil {
+			rp.logger.LogBlocked(newHTTPAuditContext(rp.logger, r.Method, targetURL, clientIP, requestID, agent), "kill_switch", killSwitchActiveReason)
+		}
+		if gateErr == nil && gate.Verdict == config.ActionBlock {
+			reverseGate = gate
+			reason := gate.Reason
+			if reason == "" {
+				reason = gate.WinningSource
+			}
+			rp.logger.LogBlocked(newHTTPAuditContext(rp.logger, r.Method, targetURL, clientIP, requestID, agent), blockLayerContract, reason)
+			rp.metrics.RecordReverseProxyRequest(r.Method, "403")
+			rp.metrics.RecordReverseProxyScanBlocked(scanDirectionRequest, blockLayerContract)
+			rp.metrics.RecordKillSwitchDenial("reverse_proxy", r.URL.Path)
+			rp.emitReceipt(withReverseContractReceipt(receipt.EmitOpts{
+				ActionID:  receipt.NewActionID(),
+				Verdict:   config.ActionBlock,
+				Layer:     blockLayerContract,
+				Pattern:   reason,
+				Transport: TransportReverse,
+				Method:    r.Method,
+				Target:    targetURL,
+				RequestID: requestID,
+				Agent:     agent,
+			}))
+			writeReverseProxyBlock(w, http.StatusForbidden,
+				blockInfoFor(blockreason.KillSwitchActive, "kill_switch"),
+				reason)
+			return
+		}
 		rp.metrics.RecordReverseProxyRequest(r.Method, "503")
 		rp.metrics.RecordKillSwitchDenial("reverse_proxy", r.URL.Path)
 		writeReverseProxyBlock(w, http.StatusServiceUnavailable,
@@ -338,6 +444,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	// is disabled. Only the path+query are agent-controlled; the upstream
 	// host is operator-configured so we skip the full URL pipeline (SSRF,
 	// blocklist, rate limit) which only applies to agent-chosen destinations.
+	hasFinding := false
 	if pathQuery := r.URL.RequestURI(); pathQuery != "" {
 		pathDLP := sc.ScanTextForDLP(r.Context(), pathQuery)
 
@@ -368,6 +475,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		}
 
 		if !pathDLP.Clean {
+			hasFinding = true
 			action := cfg.RequestBodyScanning.Action
 			if action == "" {
 				action = config.ActionBlock
@@ -393,6 +501,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	if cfg.RequestBodyScanning.Enabled && cfg.RequestBodyScanning.ScanHeaders {
 		headerResult := scanRequestHeaders(r.Context(), r.Header, cfg, sc)
 		if headerResult != nil {
+			hasFinding = true
 			action := cfg.RequestBodyScanning.Action
 			if action == "" {
 				action = config.ActionBlock
@@ -418,14 +527,79 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	var reverseBodyBytes []byte
 	if r.Body != nil && r.ContentLength != 0 && cfg.RequestBodyScanning.Enabled {
 		redaction := currentRedactionRuntimeForConfig(cfg, rp.redactionRuntimePtr)
-		blocked, verdict, bodyBytes := rp.scanRequest(w, r, cfg, sc, redaction)
+		blocked, verdict, bodyBytes, bodyFinding := rp.scanRequest(w, r, cfg, sc, redaction, reverseBlockReceiptInput{
+			RequestID: requestID,
+			Agent:     agent,
+			Target:    targetURL,
+		})
 		if blocked {
 			return
+		}
+		if bodyFinding {
+			hasFinding = true
 		}
 		if verdict != "" {
 			forwardedVerdict = verdict
 		}
 		reverseBodyBytes = bodyBytes
+	}
+
+	gate, gateErr := EvaluateGate(ContractGateInput{
+		Loader:          snap.contractLoader,
+		Agent:           agent,
+		URL:             targetURL,
+		Method:          r.Method,
+		EffectiveAction: scannerVerdictForGate(hasFinding),
+		ScannerVerdict:  scannerVerdictForGate(hasFinding),
+		ScannerMatched:  hasFinding,
+		Transport:       TransportReverse,
+	})
+	if gateErr != nil {
+		rp.logger.LogBlocked(newHTTPAuditContext(rp.logger, r.Method, targetURL, clientIP, requestID, agent), blockLayerContract, gateErr.Error())
+		rp.metrics.RecordReverseProxyRequest(r.Method, "403")
+		rp.metrics.RecordReverseProxyScanBlocked(scanDirectionRequest, blockLayerContract)
+		rp.emitReceipt(withReverseContractReceipt(receipt.EmitOpts{
+			ActionID:  receipt.NewActionID(),
+			Verdict:   config.ActionBlock,
+			Layer:     blockLayerContract,
+			Pattern:   "contract evaluation failed",
+			Transport: TransportReverse,
+			Method:    r.Method,
+			Target:    targetURL,
+			RequestID: requestID,
+			Agent:     agent,
+		}))
+		writeReverseProxyBlock(w, http.StatusForbidden,
+			blockInfoFor(blockreason.ParseError, blockLayerContract),
+			"contract evaluation failed")
+		return
+	}
+	reverseGate = gate
+	if gate.Verdict == config.ActionBlock {
+		reason := gate.Reason
+		if reason == "" {
+			reason = gate.WinningSource
+		}
+		info, ok := contractBlockInfo(reason)
+		if !ok {
+			info = blockInfoFor(blockreason.ParseError, blockLayerContract)
+		}
+		rp.logger.LogBlocked(newHTTPAuditContext(rp.logger, r.Method, targetURL, clientIP, requestID, agent), blockLayerContract, reason)
+		rp.metrics.RecordReverseProxyRequest(r.Method, "403")
+		rp.metrics.RecordReverseProxyScanBlocked(scanDirectionRequest, blockLayerContract)
+		rp.emitReceipt(withReverseContractReceipt(receipt.EmitOpts{
+			ActionID:  receipt.NewActionID(),
+			Verdict:   config.ActionBlock,
+			Layer:     blockLayerContract,
+			Pattern:   reason,
+			Transport: TransportReverse,
+			Method:    r.Method,
+			Target:    targetURL,
+			RequestID: requestID,
+			Agent:     agent,
+		}))
+		writeReverseProxyBlock(w, http.StatusForbidden, info, reason)
+		return
 	}
 
 	// Stash envelope build metadata on the request context so the
@@ -481,6 +655,12 @@ type reverseSigningRoundTripper struct {
 	rp   *ReverseProxyHandler
 }
 
+type reverseBlockReceiptInput struct {
+	RequestID string
+	Agent     string
+	Target    string
+}
+
 // RoundTrip implements http.RoundTripper. It runs envelope injection
 // and signing before handing the request off to the base transport.
 // Errors from InjectAndSign fail closed and block the outbound request.
@@ -515,10 +695,10 @@ func (t *reverseSigningRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 // request had no scannable body) and the caller may hand it to the
 // envelope signer via ctxKeyReverseEnvelopeBody so the signing
 // RoundTripper can compute content-digest without a second drain.
-func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Request, cfg *config.Config, sc *scanner.Scanner, redaction *redactionRuntime) (blocked bool, verdict string, body []byte) {
+func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Request, cfg *config.Config, sc *scanner.Scanner, redaction *redactionRuntime, receiptInput reverseBlockReceiptInput) (blocked bool, verdict string, body []byte, finding bool) {
 	// Skip binary content types — no secrets to scan in images/video.
 	if isBinaryMIME(r.Header.Get("Content-Type")) && redaction == nil {
-		return false, "", nil
+		return false, "", nil, false
 	}
 
 	maxBytes := cfg.RequestBodyScanning.MaxBodyBytes
@@ -579,7 +759,7 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 		r.GetBody = func() (io.ReadCloser, error) {
 			return io.NopCloser(bytes.NewReader(bodyBytesCopy)), nil
 		}
-		return false, config.ActionAllow, bodyBytes
+		return false, config.ActionAllow, bodyBytes, false
 	}
 
 	action := result.Action
@@ -617,19 +797,41 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 	if isFailClosedBodyResult(result, bodyBytes) {
 		rp.metrics.RecordReverseProxyRequest(r.Method, "403")
 		rp.metrics.RecordReverseProxyScanBlocked(scanDirectionRequest, layer)
+		rp.emitReceipt(receipt.EmitOpts{
+			ActionID:  receipt.NewActionID(),
+			Verdict:   config.ActionBlock,
+			Layer:     layer,
+			Pattern:   reason,
+			Transport: TransportReverse,
+			Method:    r.Method,
+			Target:    receiptInput.Target,
+			RequestID: receiptInput.RequestID,
+			Agent:     receiptInput.Agent,
+		})
 		writeReverseProxyBlock(w, http.StatusForbidden,
 			blockInfoFor(bodyBlockReason, scanner.ScannerDLP),
 			reason)
-		return true, config.ActionBlock, nil
+		return true, config.ActionBlock, nil, true
 	}
 
 	if action == config.ActionBlock && cfg.EnforceEnabled() {
 		rp.metrics.RecordReverseProxyRequest(r.Method, "403")
 		rp.metrics.RecordReverseProxyScanBlocked(scanDirectionRequest, "dlp")
+		rp.emitReceipt(receipt.EmitOpts{
+			ActionID:  receipt.NewActionID(),
+			Verdict:   config.ActionBlock,
+			Layer:     "dlp",
+			Pattern:   reason,
+			Transport: TransportReverse,
+			Method:    r.Method,
+			Target:    receiptInput.Target,
+			RequestID: receiptInput.RequestID,
+			Agent:     receiptInput.Agent,
+		})
 		writeReverseProxyBlock(w, http.StatusForbidden,
 			blockInfoFor(bodyBlockReason, scanner.ScannerDLP),
 			reason)
-		return true, config.ActionBlock, nil
+		return true, config.ActionBlock, nil, true
 	}
 
 	// Warn mode: re-wrap body and continue.
@@ -639,7 +841,7 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 	r.GetBody = func() (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(bodyBytesCopy)), nil
 	}
-	return false, action, bodyBytes
+	return false, action, bodyBytes, true
 }
 
 // modifyResponse scans the upstream response body for prompt injection.

--- a/internal/proxy/reverse_test.go
+++ b/internal/proxy/reverse_test.go
@@ -22,7 +22,10 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
+	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
@@ -52,6 +55,21 @@ func testPost(t *testing.T, url, contentType, body string) *http.Response {
 		t.Fatalf("create request: %v", err)
 	}
 	req.Header.Set("Content-Type", contentType)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	return resp
+}
+
+func testAgentPost(t *testing.T, url, body string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(AgentHeader, "agent-a")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
@@ -103,6 +121,70 @@ func reverseTestSetup(t *testing.T, cfg *config.Config, upstreamHandler http.Han
 	return proxy
 }
 
+type reverseLiveLockTransport struct {
+	base http.RoundTripper
+	addr string
+}
+
+func (rt reverseLiveLockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	u := *req.URL
+	u.Scheme = "http"
+	u.Host = rt.addr
+	clone.URL = &u
+	return rt.base.RoundTrip(clone)
+}
+
+func reverseLiveLockSetup(
+	t *testing.T,
+	targetHost string,
+	loader *contractruntime.Loader,
+	ks *killswitch.Controller,
+	upstreamHandler http.HandlerFunc,
+) *httptest.Server {
+	t.Helper()
+
+	upstream := newIPv4Server(t, upstreamHandler)
+	t.Cleanup(upstream.Close)
+
+	upstreamURL, err := url.Parse("http://" + targetHost)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+
+	cfg := reverseTestConfig()
+	cfg.ApplyDefaults()
+
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	var cfgPtr atomic.Pointer[config.Config]
+	var scPtr atomic.Pointer[scanner.Scanner]
+	cfgPtr.Store(cfg)
+	scPtr.Store(sc)
+
+	var loaderPtr atomic.Pointer[contractruntime.Loader]
+	if loader != nil {
+		loaderPtr.Store(loader)
+	}
+	if ks == nil {
+		ks = killswitch.New(cfg)
+	}
+
+	logger := audit.NewNop()
+	m := metrics.New()
+	handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, logger, m, ks, nil, nil)
+	handler.SetContractLoader(&loaderPtr)
+	handler.proxy.Transport = reverseLiveLockTransport{
+		base: &http.Transport{DisableCompression: true},
+		addr: upstream.Listener.Addr().String(),
+	}
+
+	proxy := newIPv4Server(t, handler)
+	t.Cleanup(proxy.Close)
+	return proxy
+}
+
 // reverseTestConfig returns a config with DLP and response scanning enabled,
 // SSRF disabled for unit tests.
 func reverseTestConfig() *config.Config {
@@ -117,6 +199,195 @@ func reverseTestConfig() *config.Config {
 	cfg.ResponseScanning.Action = config.ActionBlock
 	cfg.ApplyDefaults()
 	return cfg
+}
+
+func TestReverseTargetURLCleansTraversalBeforeContractGate(t *testing.T) {
+	upstream, err := url.Parse("http://api.example.com/v1/chat")
+	if err != nil {
+		t.Fatalf("parse upstream: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "http://proxy.local/../../admin?x=1", nil)
+
+	got := reverseTargetURL(upstream, req)
+	want := "http://api.example.com/admin?x=1"
+	if got != want {
+		t.Fatalf("reverseTargetURL = %q, want %q", got, want)
+	}
+}
+
+func TestReverseLiveLock_PathTraversalDoesNotMatchAllowedPath(t *testing.T) {
+	var hits atomic.Int32
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxy := reverseLiveLockSetup(t, "api.example.com", testContractLoader(t, contractruntime.ModeLive, rule), nil,
+		func(w http.ResponseWriter, _ *http.Request) {
+			hits.Add(1)
+			_, _ = w.Write([]byte("unexpected"))
+		})
+
+	resp := testAgentPost(t, proxy.URL+"/v1/chat/../../admin", "{}")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != contractEnforceDefaultReason {
+		t.Fatalf("block reason = %q, want %s", got, contractEnforceDefaultReason)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
+func TestReverseLiveLock_NoActiveContractPassThrough(t *testing.T) {
+	var hits atomic.Int32
+	proxy := reverseLiveLockSetup(t, "evil.example.com", emptyContractLoader(t, contractruntime.ModeLive), nil,
+		func(w http.ResponseWriter, _ *http.Request) {
+			hits.Add(1)
+			_, _ = w.Write([]byte("ok"))
+		})
+
+	resp := testAgentPost(t, proxy.URL+"/v1/chat", "{}")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestReverseLiveLock_AllowRulePasses(t *testing.T) {
+	var hits atomic.Int32
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxy := reverseLiveLockSetup(t, "api.example.com", testContractLoader(t, contractruntime.ModeLive, rule), nil,
+		func(w http.ResponseWriter, _ *http.Request) {
+			hits.Add(1)
+			_, _ = w.Write([]byte("ok"))
+		})
+
+	resp := testAgentPost(t, proxy.URL+"/v1/chat", "{}")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestReverseLiveLock_DefaultDenyBlocksUnmatchedDestination(t *testing.T) {
+	var hits atomic.Int32
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxy := reverseLiveLockSetup(t, "evil.example.com", testContractLoader(t, contractruntime.ModeLive, rule), nil,
+		func(w http.ResponseWriter, _ *http.Request) {
+			hits.Add(1)
+			_, _ = w.Write([]byte("unexpected"))
+		})
+
+	resp := testAgentPost(t, proxy.URL+"/v1/chat", "{}")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != contractDefaultDenyReason {
+		t.Fatalf("block reason = %q, want %s", got, contractDefaultDenyReason)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
+func TestReverseLiveLock_ScannerBlockWinsOverContractAllow(t *testing.T) {
+	var hits atomic.Int32
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxy := reverseLiveLockSetup(t, "api.example.com", testContractLoader(t, contractruntime.ModeLive, rule), nil,
+		func(w http.ResponseWriter, _ *http.Request) {
+			hits.Add(1)
+			_, _ = w.Write([]byte("unexpected"))
+		})
+
+	fakeToken := "sk-ant-" + "api03-XXXXXXXXXXXXXXXXXXXXXXX"
+	resp := testAgentPost(t, proxy.URL+"/v1/chat", `{"token":"`+fakeToken+`"}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.DLPMatch) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.DLPMatch)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
+func TestReverseLiveLock_ShadowModeObservesWithoutBlocking(t *testing.T) {
+	var hits atomic.Int32
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxy := reverseLiveLockSetup(t, "evil.example.com", testContractLoader(t, contractruntime.ModeShadow, rule), nil,
+		func(w http.ResponseWriter, _ *http.Request) {
+			hits.Add(1)
+			_, _ = w.Write([]byte("ok"))
+		})
+
+	resp := testAgentPost(t, proxy.URL+"/v1/chat", "{}")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestReverseLiveLock_CaptureModeDoesNotBlock(t *testing.T) {
+	var hits atomic.Int32
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxy := reverseLiveLockSetup(t, "evil.example.com", testContractLoader(t, contractruntime.ModeCapture, rule), nil,
+		func(w http.ResponseWriter, _ *http.Request) {
+			hits.Add(1)
+			_, _ = w.Write([]byte("ok"))
+		})
+
+	resp := testAgentPost(t, proxy.URL+"/v1/chat", "{}")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestReverseLiveLock_KillSwitchBlocksBeforeContractAllow(t *testing.T) {
+	var hits atomic.Int32
+	cfg := reverseTestConfig()
+	ks := killswitch.New(cfg)
+	ks.SetAPI(true)
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxy := reverseLiveLockSetup(t, "api.example.com", testContractLoader(t, contractruntime.ModeLive, rule), ks,
+		func(w http.ResponseWriter, _ *http.Request) {
+			hits.Add(1)
+			_, _ = w.Write([]byte("unexpected"))
+		})
+
+	resp := testAgentPost(t, proxy.URL+"/v1/chat", "{}")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.KillSwitchActive) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.KillSwitchActive)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
 }
 
 func TestReverseProxy_CleanPassthrough(t *testing.T) {

--- a/internal/proxy/reverse_test.go
+++ b/internal/proxy/reverse_test.go
@@ -143,6 +143,18 @@ func reverseLiveLockSetup(
 	upstreamHandler http.HandlerFunc,
 ) *httptest.Server {
 	t.Helper()
+	return reverseLiveLockSetupWithConfig(t, reverseTestConfig(), targetHost, loader, ks, upstreamHandler)
+}
+
+func reverseLiveLockSetupWithConfig(
+	t *testing.T,
+	cfg *config.Config,
+	targetHost string,
+	loader *contractruntime.Loader,
+	ks *killswitch.Controller,
+	upstreamHandler http.HandlerFunc,
+) *httptest.Server {
+	t.Helper()
 
 	upstream := newIPv4Server(t, upstreamHandler)
 	t.Cleanup(upstream.Close)
@@ -152,7 +164,6 @@ func reverseLiveLockSetup(
 		t.Fatalf("parse upstream URL: %v", err)
 	}
 
-	cfg := reverseTestConfig()
 	cfg.ApplyDefaults()
 
 	sc := scanner.New(cfg)
@@ -240,7 +251,7 @@ func TestReverseLiveLock_PathTraversalDoesNotMatchAllowedPath(t *testing.T) {
 
 func TestReverseLiveLock_NoActiveContractPassThrough(t *testing.T) {
 	var hits atomic.Int32
-	proxy := reverseLiveLockSetup(t, "evil.example.com", emptyContractLoader(t, contractruntime.ModeLive), nil,
+	proxy := reverseLiveLockSetup(t, "evil.example.com", emptyContractLoader(t), nil,
 		func(w http.ResponseWriter, _ *http.Request) {
 			hits.Add(1)
 			_, _ = w.Write([]byte("ok"))
@@ -321,6 +332,32 @@ func TestReverseLiveLock_ScannerBlockWinsOverContractAllow(t *testing.T) {
 	}
 	if hits.Load() != 0 {
 		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
+func TestReverseLiveLock_AuditScannerBlockContinuesAsWarn(t *testing.T) {
+	var hits atomic.Int32
+	cfg := reverseTestConfig()
+	enforce := false
+	cfg.Enforce = &enforce
+	cfg.RequestBodyScanning.Action = config.ActionBlock
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)
+	proxy := reverseLiveLockSetupWithConfig(t, cfg, "api.example.com", testContractLoader(t, contractruntime.ModeLive, rule), nil,
+		func(w http.ResponseWriter, r *http.Request) {
+			hits.Add(1)
+			_, _ = io.ReadAll(r.Body)
+			_, _ = w.Write([]byte("forwarded"))
+		})
+
+	fakeToken := "sk-ant-" + "api03-XXXXXXXXXXXXXXXXXXXXXXX"
+	resp := testAgentPost(t, proxy.URL+"/v1/chat", `{"token":"`+fakeToken+`"}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits.Load())
 	}
 }
 


### PR DESCRIPTION
Live lock now enforces contract decisions on the reverse transport and on each followed redirect leg. This closes the redirect bridge case where an allowed origin can hand the agent to an unapproved destination after the original request passes scanner checks.

## Behavior

Reverse proxy admission resolves the request agent, evaluates the active contract against the configured upstream URL, and blocks live default-deny decisions before forwarding. Nil loader or no active contract still falls through to scanner behavior. Shadow and capture modes observe without adding blocks.

Redirect-refresh now evaluates the redirected URL before rebuilding the mediation envelope. A redirect from api.example.com /v1/chat to api.example.com /v2/chat follows when both legs are approved. A redirect from an approved origin to evil.example.com /steal terminates with contract_default_deny on the redirected leg.

Reverse target paths are cleaned before both contract evaluation and upstream forwarding. That keeps the URL shown to the contract runtime aligned with the URL sent to the upstream when a request contains dot segments.

## Defense in depth

Scanner remains the floor on reverse. TestReverseLiveLock_ScannerBlockWinsOverContractAllow proves a contract allow rule cannot override a DLP block.

TestFetchEndpoint_LiveLockRedirectUnapprovedDestinationBlocks proves an approved origin cannot become a redirect bridge to an unapproved destination. The redirect chain cap still wins after gate wiring, and shadow mode follows the redirect while observing the would-have-blocked decision.

TestReverseLiveLock_PathTraversalDoesNotMatchAllowedPath proves a dot-segment request cannot match an allowed path while reaching a different upstream path after normalization.

Reverse body-DLP terminal blocks now emit action receipts. Contract receipts remain v1 ActionReceipt with contract context through the existing gate helper. The v2 EvidenceReceipt swap is left for the planned transport-wide receipt follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request contract evaluation for redirects and enforceable redirect blocking.
  * Reverse proxy path normalization and deterministic upstream target computation.
  * Contract-aware kill-switch handling that returns contract-specific block reasons.

* **Improvements**
  * Richer block reason reporting for denied redirects and DLP-triggered blocks.
  * Request-side DLP scanning reports structured receipts and finding flags.
  * Redirect enforcement now honors per-request contract snapshots.

* **Tests**
  * Expanded live-lock and redirect enforcement tests covering live/shadow modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->