### PR TITLE
fix(runtime/loader): atomic writes in watcher tests to match production

### DIFF
--- a/internal/contract/runtime/contractruntimetest/fixture.go
+++ b/internal/contract/runtime/contractruntimetest/fixture.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	contractstore "github.com/luckyPipewrench/pipelock/internal/contract/store"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
@@ -163,7 +164,12 @@ func WriteSignedActiveStore(t *testing.T, fixture Fixture, storeDir string, opts
 	if err := os.MkdirAll(storeDir, 0o750); err != nil {
 		t.Fatalf("mkdir store: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(storeDir, "active.json"), append(raw, '\n'), 0o600); err != nil {
+	// atomicfile.Write mirrors how the production promote path lands the
+	// active manifest (temp + rename). Tests that rewrite active.json
+	// while a Watch goroutine is reading it would otherwise produce
+	// parse-error outcomes under -race load instead of the intended
+	// signature/generation/same-hash outcomes.
+	if err := atomicfile.Write(filepath.Join(storeDir, "active.json"), append(raw, '\n'), 0o600); err != nil {
 		t.Fatalf("write active.json: %v", err)
 	}
 }

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
 	contractstore "github.com/luckyPipewrench/pipelock/internal/contract/store"
@@ -586,11 +587,18 @@ func TestLoader_Watch_DebounceMaxWaitFlushesUnderSustainedWrites(t *testing.T) {
 	})
 	time.Sleep(80 * time.Millisecond)
 
-	// Producer that writes the same content every 40ms (well below the
-	// 100ms debounce window). Without the maxDebounceWait cap, the
+	// Producer that rewrites the same content every 40ms (well below
+	// the 100ms debounce window). Without the maxDebounceWait cap, the
 	// debounce timer would reset on every write and Reload would never
 	// fire. With the cap, Reload fires within roughly maxDebounceWait
 	// after the first write.
+	//
+	// Use atomicfile.Write (temp + rename) so the producer mirrors how
+	// real promotes write the active manifest. os.WriteFile truncates
+	// in place, which under -race CI load races with Reload's read and
+	// produces parse errors instead of same_hash outcomes; the assertion
+	// below would then never fire even though the maxDebounceWait code
+	// path is working as intended.
 	activePath := filepath.Clean(filepath.Join(storeDir, activeFilename))
 	raw, err := os.ReadFile(activePath)
 	if err != nil {
@@ -604,7 +612,7 @@ func TestLoader_Watch_DebounceMaxWaitFlushesUnderSustainedWrites(t *testing.T) {
 			case <-stop:
 				return
 			case <-ticker.C:
-				_ = os.WriteFile(activePath, raw, 0o600)
+				_ = atomicfile.Write(activePath, raw, 0o600)
 			}
 		}
 	}()

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -461,13 +461,18 @@ func TestLoader_Watch_DebounceCoalescesBurstAndSameHashIsNoop(t *testing.T) {
 	// multiple events; the 100ms debounce window should coalesce them
 	// into a single Reload, which the same-hash short-circuit then turns
 	// into one same_hash outcome (no swap, no rejection).
+	//
+	// atomicfile.Write mirrors the production promote path (temp +
+	// rename). os.WriteFile truncates in place and races with Reload's
+	// read under -race CI load, surfacing parse-error outcomes that
+	// would break the error == 0 assertion below for the wrong reason.
 	activePath := filepath.Clean(filepath.Join(storeDir, activeFilename))
 	raw, err := os.ReadFile(activePath)
 	if err != nil {
 		t.Fatalf("read active.json: %v", err)
 	}
 	for i := 0; i < 5; i++ {
-		if err := os.WriteFile(activePath, raw, 0o600); err != nil {
+		if err := atomicfile.Write(activePath, raw, 0o600); err != nil {
 			t.Fatalf("rewrite active.json: %v", err)
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes the CI flake on `TestLoader_Watch_DebounceMaxWaitFlushesUnderSustainedWrites` (run 25559008210, FAIL on `test (1.26)`). Also covers two adjacent paths with the same exposure so the flake class cannot resurface elsewhere.

## Root cause

The test producer rewrites `active.json` every 40ms with `os.WriteFile`, which truncates and writes in two syscalls. Under `-race` on a 2-core CI runner this races with the watcher's `Reload` -> `os.ReadFile` -> JSON-decode chain. The reader sees a partial file, decode fails, returns `store.ErrDecode` (`store.go:179`). `rejectionOutcome` (`loader.go:498`) collapses that to `outcomeError`.

The failure metrics match: `accepted:1 error:7`. One initial `accepted` from `NewLoader`, then seven Reload calls during the sustained burst all hitting the parse-error path. `rejected:0` rules out signature/generation/CAS classes. `same_hash:0` confirms Reload was reached but the read was always corrupted before the hash compare.

The production promote path does not write active.json non-atomically: every write goes through `atomicWrite = atomicfile.Write` (`store.go:31, 229`). An operator out-of-band rewrite could still be non-atomic; the watcher handles that fail-soft (a parse-error reload increments `outcomeError`, leaves the previous ActiveSet in place, keeps watching). The test producer was the only in-tree caller using the non-atomic pattern.

## What changed

- `loader_test.go:607` (prior commit): atomic write on the maxDebounceWait test producer.
- `loader_test.go:469`: same fix on `DebounceCoalescesBurstAndSameHashIsNoop`'s 5-event burst (same exposure, same `error == 0` assertion).
- `contractruntimetest/fixture.go:166`: the shared `WriteSignedActiveStore` helper now uses `atomicfile.Write` so every test that rewrites active.json mid-watch shares the safe pattern (RejectedReloadKeepsWatcherAlive, FileReplacementTriggersReload, plus future tests).

No production code changed. The race only existed in test producers.

## Verification

- `go test -race -count=20 ./internal/contract/runtime/...` clean (~45s)
- `go test -race -count=1 ./...` clean across the repo
- `go test -tags enterprise -race -count=1 ./...` clean
- `make test-replay-harness` clean
- `golangci-lint run ./...` zero issues
- Local stress repro on the pre-fix code (taskset -c 0-1, background CPU load, count=50) did not reproduce the flake. The failure mode is GitHub-Actions environment specific.

Local toolchain is Go 1.25.9 only; the CI matrix exercises both 1.25 and 1.26. CI on this branch is the canonical verification for the failing `test (1.26)` job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of configuration file handling during concurrent access by implementing atomic write operations for configuration files, preventing potential parsing errors that could occur under high concurrency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->