### PR TITLE
Guard ratify against low-confidence enforcement

### DIFF
--- a/internal/cli/learn/ratify.go
+++ b/internal/cli/learn/ratify.go
@@ -33,17 +33,25 @@ const (
 	ratifyDecisionEnforce = "enforce"
 	ratifyDecisionCapture = "capture_only"
 	ratifyDecisionReject  = "reject"
+
+	ratifyConfidenceNeverConfirmed = "never_confirmed"
+	ratifyConfidenceRefuted        = "refuted"
 )
 
+// ErrLowConfidenceRatification is returned when ratify would promote
+// low-confidence rules without explicit operator override.
+var ErrLowConfidenceRatification = errors.New("learn ratify: low-confidence rules require explicit override")
+
 type ratifyFlags struct {
-	candidatePath   string
-	outPath         string
-	receiptOut      string
-	keystore        string
-	compileKeyAgent string
-	receiptKey      string
-	interactive     bool
-	deterministic   bool
+	candidatePath       string
+	outPath             string
+	receiptOut          string
+	keystore            string
+	compileKeyAgent     string
+	receiptKey          string
+	interactive         bool
+	acceptLowConfidence bool
+	deterministic       bool
 }
 
 type ratifyDecision struct {
@@ -61,7 +69,12 @@ capture-only, or reject for each rule, then write a newly signed candidate
 and a contract_ratified evidence receipt.
 
 Interactive mode reads one decision per rule from stdin: e=enforce,
-c=capture-only, r=reject.`,
+c=capture-only, r=reject.
+
+Non-interactive ratification refuses never_confirmed and refuted rules unless
+--accept-low-confidence is set. That override can promote rules built from
+insufficient or refuted evidence into enforcement, so use it only for deliberate
+operator-reviewed dogfood workflows.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runRatify(cmd, flags)
@@ -74,6 +87,7 @@ c=capture-only, r=reject.`,
 	cmd.Flags().StringVar(&flags.compileKeyAgent, "compile-key-agent", "", "keystore agent name for contract re-signing; defaults to candidate signer")
 	cmd.Flags().StringVar(&flags.receiptKey, "receipt-key-agent", flags.receiptKey, "keystore agent name for ratification receipt signing")
 	cmd.Flags().BoolVar(&flags.interactive, "interactive", false, "prompt for each rule decision")
+	cmd.Flags().BoolVar(&flags.acceptLowConfidence, "accept-low-confidence", false, "allow ratifying never_confirmed or refuted rules; dangerous because thin or refuted evidence can become enforce policy")
 	cmd.Flags().BoolVar(&flags.deterministic, "deterministic", false, "use deterministic timestamps, ids, and signing keys for tests")
 	_ = cmd.MarkFlagRequired("candidate")
 	return cmd
@@ -87,7 +101,11 @@ func runRatify(cmd *cobra.Command, flags ratifyFlags) error {
 	if len(env.Body.Rules) == 0 {
 		return fmt.Errorf("%w: candidate has no rules", ErrInvalidCandidate)
 	}
-	decisions, err := collectRatifyDecisions(cmd, env.Body, flags.interactive)
+	if flags.interactive && !flags.acceptLowConfidence && allLowConfidenceRules(env.Body.Rules) {
+		return fmt.Errorf("%w: candidate has only low-confidence rules (%s); rerun with --accept-low-confidence only after operator review",
+			ErrLowConfidenceRatification, lowConfidenceRuleSummary(env.Body.Rules))
+	}
+	decisions, err := collectRatifyDecisions(cmd, env.Body, flags.interactive, flags.acceptLowConfidence)
 	if err != nil {
 		return err
 	}
@@ -186,9 +204,15 @@ func loadCandidateEnvelope(path string) (string, contract.ContractEnvelope, erro
 	return clean, env, nil
 }
 
-func collectRatifyDecisions(cmd *cobra.Command, c contract.Contract, interactive bool) ([]ratifyDecision, error) {
+func collectRatifyDecisions(cmd *cobra.Command, c contract.Contract, interactive, acceptLowConfidence bool) ([]ratifyDecision, error) {
 	decisions := make([]ratifyDecision, 0, len(c.Rules))
 	if !interactive {
+		if !acceptLowConfidence {
+			if summary := lowConfidenceRuleSummary(c.Rules); summary != "" {
+				return nil, fmt.Errorf("%w: refusing non-interactive enforce for %s; rerun with --interactive to review each rule or --accept-low-confidence to override",
+					ErrLowConfidenceRatification, summary)
+			}
+		}
 		for _, rule := range c.Rules {
 			decisions = append(decisions, ratifyDecision{RuleID: rule.RuleID, Decision: ratifyDecisionEnforce})
 		}
@@ -206,6 +230,37 @@ func collectRatifyDecisions(cmd *cobra.Command, c contract.Contract, interactive
 		decisions = append(decisions, ratifyDecision{RuleID: rule.RuleID, Decision: choice})
 	}
 	return decisions, nil
+}
+
+func allLowConfidenceRules(rules []contract.Rule) bool {
+	if len(rules) == 0 {
+		return false
+	}
+	for _, rule := range rules {
+		if !isLowConfidenceRule(rule) {
+			return false
+		}
+	}
+	return true
+}
+
+func lowConfidenceRuleSummary(rules []contract.Rule) string {
+	low := make([]string, 0)
+	for _, rule := range rules {
+		if isLowConfidenceRule(rule) {
+			low = append(low, fmt.Sprintf("%s(confidence=%s)", rule.RuleID, strings.TrimSpace(rule.Confidence)))
+		}
+	}
+	return strings.Join(low, ", ")
+}
+
+func isLowConfidenceRule(rule contract.Rule) bool {
+	switch strings.ToLower(strings.TrimSpace(rule.Confidence)) {
+	case ratifyConfidenceNeverConfirmed, ratifyConfidenceRefuted:
+		return true
+	default:
+		return false
+	}
 }
 
 func renderRatifyRule(w io.Writer, c contract.Contract, rule contract.Rule, index int) error {

--- a/internal/cli/learn/ratify_test.go
+++ b/internal/cli/learn/ratify_test.go
@@ -119,6 +119,10 @@ func TestRatifyLowConfidenceGuards(t *testing.T) {
 			if err != nil {
 				t.Fatalf("load ratified candidate: %v", err)
 			}
+			if len(env.Body.Rules) != len(tt.wantLifecycle) {
+				t.Fatalf("ratified rules count = %d (%#v), want %d from expected lifecycle map %#v",
+					len(env.Body.Rules), env.Body.Rules, len(tt.wantLifecycle), tt.wantLifecycle)
+			}
 			for _, rule := range env.Body.Rules {
 				want, ok := tt.wantLifecycle[rule.RuleID]
 				if !ok {

--- a/internal/cli/learn/ratify_test.go
+++ b/internal/cli/learn/ratify_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package learn
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+)
+
+const (
+	testRatifyConfidenceStable         = "stable"
+	testRatifyConfidenceBrittle        = "brittle"
+	testRatifyConfidenceNeverConfirmed = "never_confirmed"
+	testRatifyConfidenceRefuted        = "refuted"
+)
+
+func TestRatifyLowConfidenceGuards(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		interactive         bool
+		acceptLowConfidence bool
+		input               string
+		confidences         []string
+		wantErr             bool
+		wantErrRules        []string
+		wantLifecycle       map[string]string
+		wantPrompt          bool
+	}{
+		{
+			name:        "non-interactive all confirmed enforces",
+			confidences: []string{testRatifyConfidenceStable, testRatifyConfidenceBrittle},
+			wantLifecycle: map[string]string{
+				"r-enforce": ratifyDecisionEnforce,
+				"r-reject":  ratifyDecisionEnforce,
+			},
+		},
+		{
+			name:         "non-interactive mixed never-confirmed refuses with named error",
+			confidences:  []string{testRatifyConfidenceStable, testRatifyConfidenceNeverConfirmed},
+			wantErr:      true,
+			wantErrRules: []string{"r-reject", testRatifyConfidenceNeverConfirmed},
+		},
+		{
+			name:         "non-interactive mixed refuted refuses with named error",
+			confidences:  []string{testRatifyConfidenceStable, testRatifyConfidenceRefuted},
+			wantErr:      true,
+			wantErrRules: []string{"r-reject", testRatifyConfidenceRefuted},
+		},
+		{
+			name:                "non-interactive accept-low-confidence mixed enforces",
+			acceptLowConfidence: true,
+			confidences:         []string{testRatifyConfidenceStable, testRatifyConfidenceNeverConfirmed},
+			wantLifecycle: map[string]string{
+				"r-enforce": ratifyDecisionEnforce,
+				"r-reject":  ratifyDecisionEnforce,
+			},
+		},
+		{
+			name:        "interactive mixed remains per-rule prompt",
+			interactive: true,
+			input:       "e\nc\n",
+			confidences: []string{testRatifyConfidenceStable, testRatifyConfidenceNeverConfirmed},
+			wantLifecycle: map[string]string{
+				"r-enforce": ratifyDecisionEnforce,
+				"r-reject":  ratifyDecisionCapture,
+			},
+			wantPrompt: true,
+		},
+		{
+			name:         "interactive all low-confidence refuses without override",
+			interactive:  true,
+			input:        "e\ne\n",
+			confidences:  []string{testRatifyConfidenceNeverConfirmed, testRatifyConfidenceNeverConfirmed},
+			wantErr:      true,
+			wantErrRules: []string{"r-enforce", "r-reject", testRatifyConfidenceNeverConfirmed},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			candidate := writeCandidateEnvelope(t, dir, ratifyContractWithConfidences(t, tt.confidences...))
+			out := filepath.Join(dir, "ratified.yaml")
+			cmd, stdout := learnTestCmd(tt.input)
+
+			err := runRatify(cmd, ratifyFlags{
+				candidatePath:       candidate,
+				outPath:             out,
+				receiptOut:          filepath.Join(dir, "ratify.jsonl"),
+				interactive:         tt.interactive,
+				acceptLowConfidence: tt.acceptLowConfidence,
+				deterministic:       true,
+			})
+			if tt.wantErr {
+				if !errors.Is(err, ErrLowConfidenceRatification) {
+					t.Fatalf("runRatify err = %v, want ErrLowConfidenceRatification", err)
+				}
+				for _, want := range tt.wantErrRules {
+					if !strings.Contains(err.Error(), want) {
+						t.Fatalf("runRatify err = %q, want substring %q", err.Error(), want)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("runRatify: %v", err)
+			}
+			if tt.wantPrompt && !strings.Contains(stdout.String(), "Rule 1/2") {
+				t.Fatalf("interactive stdout missing prompt:\n%s", stdout.String())
+			}
+			_, env, err := loadCandidateEnvelope(out)
+			if err != nil {
+				t.Fatalf("load ratified candidate: %v", err)
+			}
+			for _, rule := range env.Body.Rules {
+				want, ok := tt.wantLifecycle[rule.RuleID]
+				if !ok {
+					t.Fatalf("unexpected rule %q in ratified candidate", rule.RuleID)
+				}
+				if rule.LifecycleState != want {
+					t.Fatalf("%s lifecycle_state = %q, want %q", rule.RuleID, rule.LifecycleState, want)
+				}
+			}
+		})
+	}
+}
+
+func ratifyContractWithConfidences(t *testing.T, confidences ...string) contract.Contract {
+	t.Helper()
+	c := testRatifyContract()
+	if len(confidences) != len(c.Rules) {
+		t.Fatalf("confidence count = %d, want %d", len(confidences), len(c.Rules))
+	}
+	for i := range c.Rules {
+		c.Rules[i].Confidence = confidences[i]
+	}
+	return c
+}


### PR DESCRIPTION
## Summary

This hardens \`pipelock learn ratify\` so non-interactive ratification no longer promotes low-confidence rules into enforcement by default.

Changes:
- refuse non-interactive ratification when any rule has \`confidence: never_confirmed\` or \`confidence: refuted\`
- add explicit \`--accept-low-confidence\` override for deliberate operator-reviewed workflows
- refuse all-low-confidence candidates even in interactive mode unless the override is set
- add regression coverage for confirmed, mixed-confidence, override, and interactive paths

## Adjacent Path Audit

- \`learn promote\` validates active manifests and referenced contract history through the contract store, but does not require the selected contract to contain an enforce-class rule.
- Runtime behavior for observation-only contracts remains scanner-only: contracts with zero enforce rules claim no jurisdiction and fall through to the scanner verdict.
- \`learn rollback\` reactivates a previously accepted manifest through the same store validation path and does not make new ratification decisions.

## Validation

- \`go test -race -count=1 ./internal/cli/learn\`
- \`golangci-lint run ./...\`
- \`go test -race -count=1 ./...\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added low-confidence safety controls to the learn ratify command to block ratification when all rules are low-confidence unless explicitly overridden
  * Added a new flag to allow accepting low-confidence ratifications and updated command help text

* **Tests**
  * Added tests covering non-interactive and interactive ratification flows with low-confidence rule scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->