### PR TITLE
feat(cli/signing): operator commands to bootstrap live-lock trust

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true
+          publish_results: false
 
       - name: Upload Scorecard results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2179,3 +2179,62 @@ pipelock run --reverse-proxy --reverse-upstream http://localhost:7899 --reverse-
 ### Hot-reload
 
 The `listen`, `enabled`, and `upstream` fields cannot be changed via hot-reload (requires restart). All other scanning config (DLP patterns, response patterns, action, header mode) updates on reload.
+
+## Live lock trust topology
+
+The live-lock runtime activates per-agent behavioural contracts only after their candidate is signed by an operator-controlled activation key, and trusts that key only because the deployment-local roster names it under a fleet-root signature. Bootstrapping the roster is a one-time operator workflow.
+
+### Generating the roster
+
+Two commands compose the trust topology:
+
+- `pipelock signing key generate --purpose <purpose> --out <path>` writes a new Ed25519 keypair to a 0o600 JSON file with explicit purpose binding. Used for deployment-level keys (root, activation, recovery).
+- `pipelock signing roster build --root <root.json> --include id=,key=,purpose=,...` composes a signed `RosterEnvelope` from the root key plus a list of public-key includes. The output JSON is what `learn_lock.roster_path` consumes and what `pipelock signing roster verify` accepts.
+
+End-to-end example:
+
+```bash
+# Generate the fleet root.
+pipelock signing key generate \
+  --purpose roster-root \
+  --out /etc/pipelock/keys/fleet-root.json
+
+# Generate the operator activation key.
+pipelock signing key generate \
+  --purpose contract-activation-signing \
+  --out /etc/pipelock/keys/activation.json \
+  --id activation-primary
+
+# Per-agent compile keys (existing command, agent-scoped keystore).
+pipelock keygen agent-a
+pipelock keygen agent-b
+
+# Compose and sign the roster.
+pipelock signing roster build \
+  --root /etc/pipelock/keys/fleet-root.json \
+  --include id=activation-primary,key=/etc/pipelock/keys/activation.json,purpose=contract-activation-signing,role=operator \
+  --include id=compile-agent-a,key=$HOME/.pipelock/agents/agent-a/id_ed25519.pub,purpose=contract-compile-signing \
+  --include id=compile-agent-b,key=$HOME/.pipelock/agents/agent-b/id_ed25519.pub,purpose=contract-compile-signing \
+  --data-class internal \
+  --out /etc/pipelock/roster.json
+
+# Verify the signed roster against the printed root fingerprint.
+pipelock signing roster verify \
+  --path /etc/pipelock/roster.json \
+  --root-fingerprint sha256:<from-key-generate-output>
+```
+
+The fingerprint printed by `pipelock signing key generate --purpose roster-root` is what `learn_lock.pinned_root_fingerprint` consumes. Pin it once at deployment time; the runtime rejects any roster that does not chain back to that exact value.
+
+### Refusal cases
+
+`pipelock signing roster build` refuses with a typed error when:
+
+- two `--include` entries share the same `id`
+- an `--include` `purpose=` flag disagrees with the file's `purpose` field (only enforced when the include points at a JSON keyFile; agent keystore `.pub` files have no purpose binding and rely on the operator-supplied flag)
+- the `--data-class` value is not in `{public, internal, sensitive}` (`regulated` is rejected explicitly)
+- an include passes `status=root` (the root entry is auto-included from `--root`)
+- the `--root` file's purpose is not `roster-root`
+- the output file already exists and `--force` is not set
+
+All key files are written with `0o600` permission via atomic temp-file-then-rename, so a partial write cannot leave a malformed key on disk.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,6 +27,47 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
+
+type cliTestBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *cliTestBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *cliTestBuffer) contains(s string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return bytes.Contains(b.buf.Bytes(), []byte(s))
+}
+
+func (b *cliTestBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func waitForCLIOutput(t *testing.T, buf *cliTestBuffer, errCh <-chan error, cancel context.CancelFunc, want string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if buf.contains(want) {
+			return
+		}
+		select {
+		case cmdErr := <-errCh:
+			cancel()
+			t.Fatalf("run exited before output %q: %v\nstderr:\n%s", want, cmdErr, buf.String())
+		default:
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for output %q\nstderr:\n%s", want, buf.String())
+}
 
 func TestRootCmd_Version(t *testing.T) {
 	cmd := rootCmd()
@@ -2227,9 +2269,9 @@ fetch_proxy:
 	cmd := rootCmd()
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	var stderr bytes.Buffer
+	stderr := &cliTestBuffer{}
 	cmd.SetOut(io.Discard)
-	cmd.SetErr(&stderr)
+	cmd.SetErr(stderr)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -2270,8 +2312,7 @@ fetch_proxy:
 		t.Fatal(writeErr)
 	}
 
-	// Wait for reload to process.
-	time.Sleep(500 * time.Millisecond)
+	waitForCLIOutput(t, stderr, errCh, cancel, "metrics_listen changed")
 
 	cancel()
 	select {
@@ -2284,7 +2325,7 @@ fetch_proxy:
 	}
 
 	// Safe to read stderr now that the command has exited.
-	if !bytes.Contains(stderr.Bytes(), []byte("metrics_listen changed")) {
+	if !stderr.contains("metrics_listen changed") {
 		t.Errorf("expected metrics_listen reload warning, got:\n%s", stderr.String())
 	}
 }
@@ -2317,9 +2358,9 @@ fetch_proxy:
 	cmd := rootCmd()
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	var stderr bytes.Buffer
+	stderr := &cliTestBuffer{}
 	cmd.SetOut(io.Discard)
-	cmd.SetErr(&stderr)
+	cmd.SetErr(stderr)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -2360,8 +2401,7 @@ fetch_proxy:
 		t.Fatal(writeErr)
 	}
 
-	// Wait for reload to process.
-	time.Sleep(500 * time.Millisecond)
+	waitForCLIOutput(t, stderr, errCh, cancel, "license key inputs changed")
 
 	cancel()
 	select {
@@ -2374,7 +2414,7 @@ fetch_proxy:
 	}
 
 	// Verify license change warning appeared.
-	if !bytes.Contains(stderr.Bytes(), []byte("license key inputs changed")) {
+	if !stderr.contains("license key inputs changed") {
 		t.Errorf("expected license reload warning, got:\n%s", stderr.String())
 	}
 }
@@ -2407,9 +2447,9 @@ fetch_proxy:
 	cmd := rootCmd()
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	var stderr bytes.Buffer
+	stderr := &cliTestBuffer{}
 	cmd.SetOut(io.Discard)
-	cmd.SetErr(&stderr)
+	cmd.SetErr(stderr)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -2450,8 +2490,7 @@ fetch_proxy:
 		t.Fatal(writeErr)
 	}
 
-	// Wait for reload to process.
-	time.Sleep(500 * time.Millisecond)
+	waitForCLIOutput(t, stderr, errCh, cancel, "mode downgraded from balanced to audit")
 
 	cancel()
 	select {
@@ -2464,7 +2503,7 @@ fetch_proxy:
 	}
 
 	// Verify NO license warning appeared (same key, just mode change).
-	if bytes.Contains(stderr.Bytes(), []byte("license")) {
+	if stderr.contains("license") {
 		t.Errorf("unexpected license warning on non-license reload:\n%s", stderr.String())
 	}
 }
@@ -2496,9 +2535,9 @@ fetch_proxy:
 	cmd := rootCmd()
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	var stderr bytes.Buffer
+	stderr := &cliTestBuffer{}
 	cmd.SetOut(io.Discard)
-	cmd.SetErr(&stderr)
+	cmd.SetErr(stderr)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -2545,8 +2584,7 @@ fetch_proxy:
 		t.Fatal(writeErr)
 	}
 
-	// Wait for reload to process.
-	time.Sleep(500 * time.Millisecond)
+	waitForCLIOutput(t, stderr, errCh, cancel, "license key inputs changed")
 
 	cancel()
 	select {
@@ -2559,7 +2597,7 @@ fetch_proxy:
 	}
 
 	// Verify license change warning appeared from license_file addition.
-	if !bytes.Contains(stderr.Bytes(), []byte("license key inputs changed")) {
+	if !stderr.contains("license key inputs changed") {
 		t.Errorf("expected license reload warning from license_file change, got:\n%s", stderr.String())
 	}
 }

--- a/internal/cli/signing/key_generate.go
+++ b/internal/cli/signing/key_generate.go
@@ -233,14 +233,12 @@ func readPublicKeyForRoster(path string) ([]byte, string, error) {
 	}
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) > 0 && trimmed[0] == '{' {
-		kf, err := decodeKeyFile(raw)
-		if err != nil {
-			return nil, "", fmt.Errorf("decode key file %q: %w", cleanPath, err)
-		}
-		if _, err := validateKeyFileMetadata(kf); err != nil {
-			return nil, "", fmt.Errorf("decode key file %q: %w", cleanPath, err)
-		}
-		pub, err := decodeKeyFilePublic(kf)
+		// Delegate to loadKeyFile so the include path inherits the full
+		// keyFile gate (schema, purpose, hex sizes, trailing JSON, AND the
+		// private->public derivation check). Otherwise an include-side
+		// keyFile with a tampered private half could be silently accepted
+		// since this branch never uses the private key.
+		kf, pub, _, err := loadKeyFile(cleanPath, "")
 		if err != nil {
 			return nil, "", fmt.Errorf("decode key file %q: %w", cleanPath, err)
 		}
@@ -254,14 +252,36 @@ func readPublicKeyForRoster(path string) ([]byte, string, error) {
 }
 
 func readKeyFileBytes(cleanPath string) ([]byte, error) {
-	info, err := os.Stat(cleanPath)
+	// Open first so the subsequent Stat is on the same file descriptor
+	// (TOCTOU defense) AND so a non-regular file like a FIFO or device
+	// is detected before any read can block. Plain os.Stat + os.ReadFile
+	// would happily ReadFile-block-forever on a named pipe whose size
+	// reports 0.
+	f, err := os.Open(cleanPath) //nolint:gosec // path is operator-supplied and cleaned; size cap and regular-file check below
 	if err != nil {
 		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("key file %q is not a regular file (mode=%s)", cleanPath, info.Mode())
 	}
 	if info.Size() > keyFileMaxSize {
 		return nil, fmt.Errorf("%w: got %d bytes, max %d", errKeyFileTooLarge, info.Size(), keyFileMaxSize)
 	}
-	return os.ReadFile(cleanPath) //nolint:gosec // path is operator-supplied, cleaned, stat-checked, and size-capped above
+	// LimitReader is belt-and-suspenders: even if the file grew between
+	// stat and read, the read is bounded.
+	raw, err := io.ReadAll(io.LimitReader(f, keyFileMaxSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) > keyFileMaxSize {
+		return nil, fmt.Errorf("%w: got %d bytes, max %d", errKeyFileTooLarge, len(raw), keyFileMaxSize)
+	}
+	return raw, nil
 }
 
 func decodeKeyFile(raw []byte) (keyFile, error) {

--- a/internal/cli/signing/key_generate.go
+++ b/internal/cli/signing/key_generate.go
@@ -1,0 +1,248 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	domsigning "github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// keyFileSchemaVersion is the wire schema version of files written by
+// "pipelock signing key generate". Bump only on a breaking change.
+const keyFileSchemaVersion = 1
+
+// keyFileShortFingerprintHex is the number of hex chars taken from the
+// canonical sha256 fingerprint when deriving a default key_id.
+const keyFileShortFingerprintHex = 8
+
+// fingerprintPrefix is the canonical prefix on sha256 fingerprints emitted
+// by signing.Fingerprint and consumed by pinned-fingerprint config fields.
+const fingerprintPrefix = "sha256:"
+
+// keyFile is the on-disk JSON shape produced by "pipelock signing key generate".
+// Both private and public keys are stored hex-encoded; the file is written
+// 0o600 because the private key is sensitive.
+type keyFile struct {
+	SchemaVersion int    `json:"schema_version"`
+	Purpose       string `json:"purpose"`
+	KeyID         string `json:"key_id"`
+	Public        string `json:"public"`     // 64-char hex
+	Private       string `json:"private"`    // 128-char hex
+	CreatedAt     string `json:"created_at"` // RFC 3339 UTC
+}
+
+// keyGenerateGroupCmd is the parent "key" cobra command hosting key
+// generation subcommands. Distinct from the agent-scoped pipelock keygen
+// command because deployment-level keys (root, activation) live outside the
+// per-agent keystore layout and carry an explicit purpose binding.
+func keyGenerateGroupCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "key",
+		Short: "Generate deployment-level signing keys",
+		Long: `Generate deployment-level Ed25519 keys with explicit purpose
+binding. Subcommands:
+  generate    Generate one keypair bound to a recognised wire purpose`,
+	}
+	cmd.AddCommand(keyGenerateCmd())
+	return cmd
+}
+
+func keyGenerateCmd() *cobra.Command {
+	var purpose string
+	var outPath string
+	var keyID string
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "generate",
+		Short: "Generate an Ed25519 keypair bound to a specific purpose",
+		Long: `Generates a new Ed25519 keypair for a deployment-level role and
+writes it to disk as a JSON file. Distinct from "pipelock keygen <agent>",
+which writes per-agent keystore files under ~/.pipelock/agents/.
+
+The --purpose flag binds the key to one of the recognised wire purposes:
+  roster-root                    deployment-local trust root that signs the roster
+  contract-activation-signing    operator key that signs ratify and promote
+  contract-compile-signing       per-agent compile signing
+  recovery-root                  break-glass root for recovery operations
+  receipt-signing                runtime receipt signing
+  rules-official-signing         official rules package signing
+
+Writes a 0o600 JSON file containing schema_version, purpose, key_id, public
+(hex), private (hex), and created_at. The canonical sha256 fingerprint is
+printed on success for use in pinned_root_fingerprint configuration.
+
+Examples:
+  pipelock signing key generate --purpose roster-root --out /etc/pipelock/keys/fleet-root.json
+  pipelock signing key generate --purpose contract-activation-signing \
+    --out /etc/pipelock/keys/activation.json --id activation-primary`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out := cmd.OutOrStdout()
+
+			kp := domsigning.KeyPurpose(purpose)
+			if err := kp.Validate(); err != nil {
+				return err
+			}
+
+			if !filepath.IsAbs(outPath) {
+				return fmt.Errorf("--out must be absolute, got %q", outPath)
+			}
+			cleanOut := filepath.Clean(outPath)
+
+			if !force {
+				if _, statErr := os.Stat(cleanOut); statErr == nil {
+					return fmt.Errorf("output file %q already exists (use --force to overwrite)", cleanOut)
+				}
+			}
+
+			pub, priv, err := domsigning.GenerateKeyPair()
+			if err != nil {
+				return err
+			}
+
+			fp, err := domsigning.Fingerprint(pub)
+			if err != nil {
+				return fmt.Errorf("compute fingerprint: %w", err)
+			}
+
+			resolvedID := keyID
+			if resolvedID == "" {
+				short := strings.TrimPrefix(fp, fingerprintPrefix)
+				if len(short) > keyFileShortFingerprintHex {
+					short = short[:keyFileShortFingerprintHex]
+				}
+				resolvedID = fmt.Sprintf("%s-%s", purpose, short)
+			}
+
+			file := keyFile{
+				SchemaVersion: keyFileSchemaVersion,
+				Purpose:       purpose,
+				KeyID:         resolvedID,
+				Public:        hex.EncodeToString(pub),
+				Private:       hex.EncodeToString(priv),
+				CreatedAt:     time.Now().UTC().Format(time.RFC3339),
+			}
+
+			data, err := json.MarshalIndent(file, "", "  ")
+			if err != nil {
+				return fmt.Errorf("marshal key file: %w", err)
+			}
+			data = append(data, '\n')
+
+			if err := atomicfile.Write(cleanOut, data, 0o600); err != nil {
+				return fmt.Errorf("write key file: %w", err)
+			}
+
+			_, _ = fmt.Fprintf(out, "Generated %s keypair\n", purpose)
+			_, _ = fmt.Fprintf(out, "  key_id:      %s\n", resolvedID)
+			_, _ = fmt.Fprintf(out, "  fingerprint: %s\n", fp)
+			_, _ = fmt.Fprintf(out, "  out:         %s\n", cleanOut)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&purpose, "purpose", "",
+		"key purpose (one of: roster-root, contract-activation-signing, contract-compile-signing, recovery-root, receipt-signing, rules-official-signing)")
+	cmd.Flags().StringVar(&outPath, "out", "", "absolute output path for the keypair JSON file")
+	cmd.Flags().StringVar(&keyID, "id", "", "operator-chosen key ID (default: <purpose>-<short-fingerprint>)")
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite an existing output file")
+	_ = cmd.MarkFlagRequired("purpose")
+	_ = cmd.MarkFlagRequired("out")
+	return cmd
+}
+
+// loadKeyFile reads a keyFile from disk and returns the parsed struct
+// alongside the decoded public and private keys. If expectedPurpose is
+// non-empty, the file's purpose field must match exactly.
+//
+// Strict JSON decoding rejects unknown fields so a hostile or stale key file
+// cannot smuggle extra metadata past the loader.
+func loadKeyFile(path string, expectedPurpose domsigning.KeyPurpose) (*keyFile, ed25519.PublicKey, ed25519.PrivateKey, error) {
+	cleanPath := filepath.Clean(path)
+	raw, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("read key file %q: %w", cleanPath, err)
+	}
+	var kf keyFile
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&kf); err != nil {
+		return nil, nil, nil, fmt.Errorf("decode key file %q: %w", cleanPath, err)
+	}
+	if kf.SchemaVersion != keyFileSchemaVersion {
+		return nil, nil, nil, fmt.Errorf("unsupported key file schema_version %d (expected %d)", kf.SchemaVersion, keyFileSchemaVersion)
+	}
+	kp := domsigning.KeyPurpose(kf.Purpose)
+	if err := kp.Validate(); err != nil {
+		return nil, nil, nil, fmt.Errorf("invalid key file purpose: %w", err)
+	}
+	if expectedPurpose != "" && kp != expectedPurpose {
+		return nil, nil, nil, fmt.Errorf("key file purpose mismatch: file=%q expected=%q", kf.Purpose, expectedPurpose)
+	}
+	pubBytes, err := hex.DecodeString(kf.Public)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("decode public key hex: %w", err)
+	}
+	if len(pubBytes) != ed25519.PublicKeySize {
+		return nil, nil, nil, fmt.Errorf("public key has wrong size: got %d, want %d", len(pubBytes), ed25519.PublicKeySize)
+	}
+	privBytes, err := hex.DecodeString(kf.Private)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("decode private key hex: %w", err)
+	}
+	if len(privBytes) != ed25519.PrivateKeySize {
+		return nil, nil, nil, fmt.Errorf("private key has wrong size: got %d, want %d", len(privBytes), ed25519.PrivateKeySize)
+	}
+	return &kf, ed25519.PublicKey(pubBytes), ed25519.PrivateKey(privBytes), nil
+}
+
+// readPublicKeyForRoster reads a public key from disk in either the JSON
+// keyFile format produced by "pipelock signing key generate" or the agent
+// keystore .pub format produced by "pipelock keygen". Returns the raw
+// 32-byte public key and the file's declared purpose if available.
+//
+// The detected purpose is used to enforce that a roster --include entry's
+// purpose= flag matches the file's binding. The agent keystore .pub format
+// has no purpose field, so callers fall back to the operator-supplied flag.
+func readPublicKeyForRoster(path string) ([]byte, string, error) {
+	cleanPath := filepath.Clean(path)
+	raw, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("read public key %q: %w", cleanPath, err)
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) > 0 && trimmed[0] == '{' {
+		var kf keyFile
+		dec := json.NewDecoder(bytes.NewReader(raw))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&kf); err != nil {
+			return nil, "", fmt.Errorf("decode key file %q: %w", cleanPath, err)
+		}
+		pub, err := hex.DecodeString(kf.Public)
+		if err != nil {
+			return nil, "", fmt.Errorf("decode public key hex in %q: %w", cleanPath, err)
+		}
+		if len(pub) != ed25519.PublicKeySize {
+			return nil, "", fmt.Errorf("public key in %q has wrong size: got %d, want %d", cleanPath, len(pub), ed25519.PublicKeySize)
+		}
+		return pub, kf.Purpose, nil
+	}
+	pub, err := domsigning.DecodePublicKey(string(raw))
+	if err != nil {
+		return nil, "", fmt.Errorf("decode agent keystore .pub file %q: %w", cleanPath, err)
+	}
+	return pub, "", nil
+}

--- a/internal/cli/signing/key_generate.go
+++ b/internal/cli/signing/key_generate.go
@@ -8,7 +8,9 @@ import (
 	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,9 +30,16 @@ const keyFileSchemaVersion = 1
 // canonical sha256 fingerprint when deriving a default key_id.
 const keyFileShortFingerprintHex = 8
 
+// keyFileMaxSize caps JSON key files accepted by the roster CLI. Generated
+// files are under 1 KiB; this leaves room for formatting while avoiding
+// accidental reads of large non-key files.
+const keyFileMaxSize = 16 * 1024
+
 // fingerprintPrefix is the canonical prefix on sha256 fingerprints emitted
 // by signing.Fingerprint and consumed by pinned-fingerprint config fields.
 const fingerprintPrefix = "sha256:"
+
+var errKeyFileTooLarge = errors.New("key file exceeds size cap")
 
 // keyFile is the on-disk JSON shape produced by "pipelock signing key generate".
 // Both private and public keys are stored hex-encoded; the file is written
@@ -105,6 +114,8 @@ Examples:
 			if !force {
 				if _, statErr := os.Stat(cleanOut); statErr == nil {
 					return fmt.Errorf("output file %q already exists (use --force to overwrite)", cleanOut)
+				} else if !errors.Is(statErr, os.ErrNotExist) {
+					return fmt.Errorf("stat output file %q: %w", cleanOut, statErr)
 				}
 			}
 
@@ -172,32 +183,24 @@ Examples:
 // cannot smuggle extra metadata past the loader.
 func loadKeyFile(path string, expectedPurpose domsigning.KeyPurpose) (*keyFile, ed25519.PublicKey, ed25519.PrivateKey, error) {
 	cleanPath := filepath.Clean(path)
-	raw, err := os.ReadFile(cleanPath)
+	raw, err := readKeyFileBytes(cleanPath)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("read key file %q: %w", cleanPath, err)
 	}
-	var kf keyFile
-	dec := json.NewDecoder(bytes.NewReader(raw))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(&kf); err != nil {
+	kf, err := decodeKeyFile(raw)
+	if err != nil {
 		return nil, nil, nil, fmt.Errorf("decode key file %q: %w", cleanPath, err)
 	}
-	if kf.SchemaVersion != keyFileSchemaVersion {
-		return nil, nil, nil, fmt.Errorf("unsupported key file schema_version %d (expected %d)", kf.SchemaVersion, keyFileSchemaVersion)
-	}
-	kp := domsigning.KeyPurpose(kf.Purpose)
-	if err := kp.Validate(); err != nil {
-		return nil, nil, nil, fmt.Errorf("invalid key file purpose: %w", err)
+	kp, err := validateKeyFileMetadata(kf)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 	if expectedPurpose != "" && kp != expectedPurpose {
 		return nil, nil, nil, fmt.Errorf("key file purpose mismatch: file=%q expected=%q", kf.Purpose, expectedPurpose)
 	}
-	pubBytes, err := hex.DecodeString(kf.Public)
+	pubBytes, err := decodeKeyFilePublic(kf)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("decode public key hex: %w", err)
-	}
-	if len(pubBytes) != ed25519.PublicKeySize {
-		return nil, nil, nil, fmt.Errorf("public key has wrong size: got %d, want %d", len(pubBytes), ed25519.PublicKeySize)
+		return nil, nil, nil, err
 	}
 	privBytes, err := hex.DecodeString(kf.Private)
 	if err != nil {
@@ -206,7 +209,12 @@ func loadKeyFile(path string, expectedPurpose domsigning.KeyPurpose) (*keyFile, 
 	if len(privBytes) != ed25519.PrivateKeySize {
 		return nil, nil, nil, fmt.Errorf("private key has wrong size: got %d, want %d", len(privBytes), ed25519.PrivateKeySize)
 	}
-	return &kf, ed25519.PublicKey(pubBytes), ed25519.PrivateKey(privBytes), nil
+	priv := ed25519.PrivateKey(privBytes)
+	derivedPub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok || !bytes.Equal(derivedPub, pubBytes) {
+		return nil, nil, nil, fmt.Errorf("private key does not match public key")
+	}
+	return &kf, pubBytes, priv, nil
 }
 
 // readPublicKeyForRoster reads a public key from disk in either the JSON
@@ -219,24 +227,22 @@ func loadKeyFile(path string, expectedPurpose domsigning.KeyPurpose) (*keyFile, 
 // has no purpose field, so callers fall back to the operator-supplied flag.
 func readPublicKeyForRoster(path string) ([]byte, string, error) {
 	cleanPath := filepath.Clean(path)
-	raw, err := os.ReadFile(cleanPath)
+	raw, err := readKeyFileBytes(cleanPath)
 	if err != nil {
 		return nil, "", fmt.Errorf("read public key %q: %w", cleanPath, err)
 	}
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) > 0 && trimmed[0] == '{' {
-		var kf keyFile
-		dec := json.NewDecoder(bytes.NewReader(raw))
-		dec.DisallowUnknownFields()
-		if err := dec.Decode(&kf); err != nil {
+		kf, err := decodeKeyFile(raw)
+		if err != nil {
 			return nil, "", fmt.Errorf("decode key file %q: %w", cleanPath, err)
 		}
-		pub, err := hex.DecodeString(kf.Public)
-		if err != nil {
-			return nil, "", fmt.Errorf("decode public key hex in %q: %w", cleanPath, err)
+		if _, err := validateKeyFileMetadata(kf); err != nil {
+			return nil, "", fmt.Errorf("decode key file %q: %w", cleanPath, err)
 		}
-		if len(pub) != ed25519.PublicKeySize {
-			return nil, "", fmt.Errorf("public key in %q has wrong size: got %d, want %d", cleanPath, len(pub), ed25519.PublicKeySize)
+		pub, err := decodeKeyFilePublic(kf)
+		if err != nil {
+			return nil, "", fmt.Errorf("decode key file %q: %w", cleanPath, err)
 		}
 		return pub, kf.Purpose, nil
 	}
@@ -245,4 +251,53 @@ func readPublicKeyForRoster(path string) ([]byte, string, error) {
 		return nil, "", fmt.Errorf("decode agent keystore .pub file %q: %w", cleanPath, err)
 	}
 	return pub, "", nil
+}
+
+func readKeyFileBytes(cleanPath string) ([]byte, error) {
+	info, err := os.Stat(cleanPath)
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > keyFileMaxSize {
+		return nil, fmt.Errorf("%w: got %d bytes, max %d", errKeyFileTooLarge, info.Size(), keyFileMaxSize)
+	}
+	return os.ReadFile(cleanPath) //nolint:gosec // path is operator-supplied, cleaned, stat-checked, and size-capped above
+}
+
+func decodeKeyFile(raw []byte) (keyFile, error) {
+	var kf keyFile
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&kf); err != nil {
+		return keyFile{}, err
+	}
+	var extra any
+	if err := dec.Decode(&extra); err == nil {
+		return keyFile{}, fmt.Errorf("trailing JSON after key file object")
+	} else if !errors.Is(err, io.EOF) {
+		return keyFile{}, fmt.Errorf("trailing JSON after key file object")
+	}
+	return kf, nil
+}
+
+func validateKeyFileMetadata(kf keyFile) (domsigning.KeyPurpose, error) {
+	if kf.SchemaVersion != keyFileSchemaVersion {
+		return "", fmt.Errorf("unsupported key file schema_version %d (expected %d)", kf.SchemaVersion, keyFileSchemaVersion)
+	}
+	kp := domsigning.KeyPurpose(kf.Purpose)
+	if err := kp.Validate(); err != nil {
+		return "", fmt.Errorf("invalid key file purpose: %w", err)
+	}
+	return kp, nil
+}
+
+func decodeKeyFilePublic(kf keyFile) (ed25519.PublicKey, error) {
+	pubBytes, err := hex.DecodeString(kf.Public)
+	if err != nil {
+		return nil, fmt.Errorf("decode public key hex: %w", err)
+	}
+	if len(pubBytes) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("public key has wrong size: got %d, want %d", len(pubBytes), ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(pubBytes), nil
 }

--- a/internal/cli/signing/key_generate_test.go
+++ b/internal/cli/signing/key_generate_test.go
@@ -1,0 +1,251 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	domsigning "github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestKeyGenerate_WritesValidKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "fleet-root.json")
+
+	cmd := keyGenerateCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--purpose", string(domsigning.PurposeRosterRoot), "--out", out})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	info, err := os.Stat(out)
+	if err != nil {
+		t.Fatalf("stat output: %v", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Errorf("output mode = %o, want 0o600 (group/world bits clear)", info.Mode().Perm())
+	}
+	if want := fs.FileMode(0o600); info.Mode().Perm() != want {
+		t.Errorf("output mode = %o, want %o", info.Mode().Perm(), want)
+	}
+
+	raw, err := os.ReadFile(filepath.Clean(out))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var kf keyFile
+	if err := json.Unmarshal(raw, &kf); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if kf.SchemaVersion != keyFileSchemaVersion {
+		t.Errorf("schema_version = %d, want %d", kf.SchemaVersion, keyFileSchemaVersion)
+	}
+	if kf.Purpose != string(domsigning.PurposeRosterRoot) {
+		t.Errorf("purpose = %q, want %q", kf.Purpose, domsigning.PurposeRosterRoot)
+	}
+	if !strings.HasPrefix(kf.KeyID, string(domsigning.PurposeRosterRoot)+"-") {
+		t.Errorf("derived key_id %q missing purpose prefix", kf.KeyID)
+	}
+	pub, err := hex.DecodeString(kf.Public)
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		t.Fatalf("public hex bad: err=%v len=%d", err, len(pub))
+	}
+	priv, err := hex.DecodeString(kf.Private)
+	if err != nil || len(priv) != ed25519.PrivateKeySize {
+		t.Fatalf("private hex bad: err=%v len=%d", err, len(priv))
+	}
+	if !bytes.Equal(ed25519.PrivateKey(priv).Public().(ed25519.PublicKey), ed25519.PublicKey(pub)) {
+		t.Errorf("private key does not derive declared public key")
+	}
+	if kf.CreatedAt == "" {
+		t.Errorf("created_at empty")
+	}
+}
+
+func TestKeyGenerate_RejectsUnknownPurpose(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "x.json")
+
+	cmd := keyGenerateCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--purpose", "bogus-purpose", "--out", out})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected unknown-purpose error")
+	}
+	if !errors.Is(err, domsigning.ErrUnknownKeyPurpose) {
+		t.Errorf("err = %v, want ErrUnknownKeyPurpose", err)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf("output file should not exist after error, statErr=%v", statErr)
+	}
+}
+
+func TestKeyGenerate_RejectsRelativeOutPath(t *testing.T) {
+	cmd := keyGenerateCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--purpose", string(domsigning.PurposeRosterRoot), "--out", "relative.json"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected absolute-path error")
+	}
+	if !strings.Contains(err.Error(), "absolute") {
+		t.Errorf("error %q does not mention absolute requirement", err.Error())
+	}
+}
+
+func TestKeyGenerate_RefusesOverwriteWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "fleet-root.json")
+	if err := os.WriteFile(out, []byte("preexisting"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	cmd := keyGenerateCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--purpose", string(domsigning.PurposeRosterRoot), "--out", out})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected refuse-overwrite error")
+	}
+
+	got, _ := os.ReadFile(filepath.Clean(out))
+	if string(got) != "preexisting" {
+		t.Errorf("file contents changed without --force, got %q", string(got))
+	}
+}
+
+func TestKeyGenerate_AllowsOverwriteWithForce(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "fleet-root.json")
+	if err := os.WriteFile(out, []byte("preexisting"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	cmd := keyGenerateCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--purpose", string(domsigning.PurposeRosterRoot), "--out", out, "--force"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Clean(out))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if bytes.Equal(got, []byte("preexisting")) {
+		t.Errorf("file contents not overwritten under --force")
+	}
+}
+
+func TestKeyGenerate_HonoursExplicitID(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "act.json")
+
+	cmd := keyGenerateCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--purpose", string(domsigning.PurposeContractActivationSigning),
+		"--out", out,
+		"--id", "activation-primary",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Clean(out))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var kf keyFile
+	if err := json.Unmarshal(raw, &kf); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if kf.KeyID != "activation-primary" {
+		t.Errorf("key_id = %q, want %q", kf.KeyID, "activation-primary")
+	}
+}
+
+func TestLoadKeyFile_DetectsPurposeMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "k.json")
+
+	gen := keyGenerateCmd()
+	gen.SetOut(&bytes.Buffer{})
+	gen.SetErr(&bytes.Buffer{})
+	gen.SetArgs([]string{"--purpose", string(domsigning.PurposeRosterRoot), "--out", path})
+	if err := gen.Execute(); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	_, _, _, err := loadKeyFile(path, domsigning.PurposeContractActivationSigning)
+	if err == nil {
+		t.Fatalf("expected purpose-mismatch error")
+	}
+	if !strings.Contains(err.Error(), "purpose mismatch") {
+		t.Errorf("error %q does not name the mismatch", err.Error())
+	}
+}
+
+func TestReadPublicKeyForRoster_AcceptsKeyFileJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "k.json")
+	gen := keyGenerateCmd()
+	gen.SetOut(&bytes.Buffer{})
+	gen.SetErr(&bytes.Buffer{})
+	gen.SetArgs([]string{"--purpose", string(domsigning.PurposeContractCompileSigning), "--out", path})
+	if err := gen.Execute(); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	pub, purpose, err := readPublicKeyForRoster(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		t.Errorf("pub len = %d, want %d", len(pub), ed25519.PublicKeySize)
+	}
+	if purpose != string(domsigning.PurposeContractCompileSigning) {
+		t.Errorf("purpose = %q, want %q", purpose, domsigning.PurposeContractCompileSigning)
+	}
+}
+
+func TestReadPublicKeyForRoster_AcceptsAgentKeystorePub(t *testing.T) {
+	dir := t.TempDir()
+	pub, _, err := domsigning.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("gen: %v", err)
+	}
+	pubPath := filepath.Join(dir, "id_ed25519.pub")
+	if err := domsigning.SavePublicKey(pub, pubPath); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, purpose, err := readPublicKeyForRoster(pubPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, pub) {
+		t.Errorf("public key bytes differ: got=%x want=%x", got, pub)
+	}
+	if purpose != "" {
+		t.Errorf("purpose should be empty for agent keystore .pub, got %q", purpose)
+	}
+}

--- a/internal/cli/signing/key_generate_test.go
+++ b/internal/cli/signing/key_generate_test.go
@@ -204,6 +204,90 @@ func TestLoadKeyFile_DetectsPurposeMismatch(t *testing.T) {
 	}
 }
 
+func TestLoadKeyFile_RejectsMismatchedPrivatePublic(t *testing.T) {
+	dir := t.TempDir()
+	rootPath := filepath.Join(dir, "root.json")
+	otherPath := filepath.Join(dir, "other.json")
+
+	for _, e := range []struct {
+		purpose string
+		out     string
+	}{
+		{string(domsigning.PurposeRosterRoot), rootPath},
+		{string(domsigning.PurposeContractActivationSigning), otherPath},
+	} {
+		cmd := keyGenerateCmd()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		cmd.SetArgs([]string{"--purpose", e.purpose, "--out", e.out})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("seed %s: %v", e.purpose, err)
+		}
+	}
+
+	rootRaw, err := os.ReadFile(filepath.Clean(rootPath))
+	if err != nil {
+		t.Fatalf("read root: %v", err)
+	}
+	otherRaw, err := os.ReadFile(filepath.Clean(otherPath))
+	if err != nil {
+		t.Fatalf("read other: %v", err)
+	}
+	var rootKF keyFile
+	if err := json.Unmarshal(rootRaw, &rootKF); err != nil {
+		t.Fatalf("unmarshal root: %v", err)
+	}
+	var otherKF keyFile
+	if err := json.Unmarshal(otherRaw, &otherKF); err != nil {
+		t.Fatalf("unmarshal other: %v", err)
+	}
+	rootKF.Public = otherKF.Public
+	tampered, err := json.Marshal(rootKF)
+	if err != nil {
+		t.Fatalf("marshal tampered: %v", err)
+	}
+	if err := os.WriteFile(rootPath, tampered, 0o600); err != nil {
+		t.Fatalf("write tampered: %v", err)
+	}
+
+	_, _, _, err = loadKeyFile(rootPath, domsigning.PurposeRosterRoot)
+	if err == nil {
+		t.Fatalf("expected public/private mismatch error")
+	}
+	if !strings.Contains(err.Error(), "does not match public key") {
+		t.Errorf("err %q does not mention public/private mismatch", err.Error())
+	}
+}
+
+func TestLoadKeyFile_RejectsTrailingJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "k.json")
+
+	gen := keyGenerateCmd()
+	gen.SetOut(&bytes.Buffer{})
+	gen.SetErr(&bytes.Buffer{})
+	gen.SetArgs([]string{"--purpose", string(domsigning.PurposeRosterRoot), "--out", path})
+	if err := gen.Execute(); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	raw = append(raw, []byte("\n{}")...)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write trailing: %v", err)
+	}
+
+	_, _, _, err = loadKeyFile(path, domsigning.PurposeRosterRoot)
+	if err == nil {
+		t.Fatalf("expected trailing-json error")
+	}
+	if !strings.Contains(err.Error(), "trailing JSON") {
+		t.Errorf("err %q does not mention trailing JSON", err.Error())
+	}
+}
+
 func TestReadPublicKeyForRoster_AcceptsKeyFileJSON(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "k.json")
@@ -224,6 +308,43 @@ func TestReadPublicKeyForRoster_AcceptsKeyFileJSON(t *testing.T) {
 	}
 	if purpose != string(domsigning.PurposeContractCompileSigning) {
 		t.Errorf("purpose = %q, want %q", purpose, domsigning.PurposeContractCompileSigning)
+	}
+}
+
+func TestReadPublicKeyForRoster_RejectsUnsupportedKeyFileSchema(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "k.json")
+	gen := keyGenerateCmd()
+	gen.SetOut(&bytes.Buffer{})
+	gen.SetErr(&bytes.Buffer{})
+	gen.SetArgs([]string{"--purpose", string(domsigning.PurposeContractCompileSigning), "--out", path})
+	if err := gen.Execute(); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var kf keyFile
+	if err := json.Unmarshal(raw, &kf); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	kf.SchemaVersion = keyFileSchemaVersion + 1
+	tampered, err := json.Marshal(kf)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, tampered, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, _, err = readPublicKeyForRoster(path)
+	if err == nil {
+		t.Fatalf("expected unsupported-schema error")
+	}
+	if !strings.Contains(err.Error(), "unsupported key file schema_version") {
+		t.Errorf("err %q does not mention schema version", err.Error())
 	}
 }
 

--- a/internal/cli/signing/key_generate_test.go
+++ b/internal/cli/signing/key_generate_test.go
@@ -348,6 +348,90 @@ func TestReadPublicKeyForRoster_RejectsUnsupportedKeyFileSchema(t *testing.T) {
 	}
 }
 
+func TestReadPublicKeyForRoster_RejectsJSONKeyFileWithMismatchedPriv(t *testing.T) {
+	dir := t.TempDir()
+	rootPath := filepath.Join(dir, "root.json")
+	otherPath := filepath.Join(dir, "other.json")
+
+	for _, e := range []struct {
+		purpose string
+		out     string
+	}{
+		{string(domsigning.PurposeContractCompileSigning), rootPath},
+		{string(domsigning.PurposeContractCompileSigning), otherPath},
+	} {
+		gen := keyGenerateCmd()
+		gen.SetOut(&bytes.Buffer{})
+		gen.SetErr(&bytes.Buffer{})
+		gen.SetArgs([]string{"--purpose", e.purpose, "--out", e.out, "--id", filepath.Base(e.out)})
+		if err := gen.Execute(); err != nil {
+			t.Fatalf("seed %s: %v", e.out, err)
+		}
+	}
+
+	rootRaw, err := os.ReadFile(filepath.Clean(rootPath))
+	if err != nil {
+		t.Fatalf("read root: %v", err)
+	}
+	otherRaw, err := os.ReadFile(filepath.Clean(otherPath))
+	if err != nil {
+		t.Fatalf("read other: %v", err)
+	}
+	var rootKF, otherKF keyFile
+	if err := json.Unmarshal(rootRaw, &rootKF); err != nil {
+		t.Fatalf("unmarshal root: %v", err)
+	}
+	if err := json.Unmarshal(otherRaw, &otherKF); err != nil {
+		t.Fatalf("unmarshal other: %v", err)
+	}
+	rootKF.Public = otherKF.Public
+	tampered, err := json.Marshal(rootKF)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(rootPath, tampered, 0o600); err != nil {
+		t.Fatalf("write tampered: %v", err)
+	}
+
+	_, _, err = readPublicKeyForRoster(rootPath)
+	if err == nil {
+		t.Fatalf("expected mismatched-keypair rejection on JSON include path")
+	}
+	if !strings.Contains(err.Error(), "private") || !strings.Contains(err.Error(), "public") {
+		t.Errorf("err %q does not name the priv/pub mismatch", err.Error())
+	}
+}
+
+func TestReadKeyFileBytes_RejectsNonRegularFile(t *testing.T) {
+	// Directory is the most portable non-regular file; FIFOs require mkfifo
+	// which is platform-specific. Both fail the IsRegular() gate identically.
+	dir := t.TempDir()
+	_, err := readKeyFileBytes(dir)
+	if err == nil {
+		t.Fatalf("expected non-regular-file rejection on directory")
+	}
+	if !strings.Contains(err.Error(), "regular file") {
+		t.Errorf("err %q does not mention regular file", err.Error())
+	}
+}
+
+func TestReadKeyFileBytes_RejectsOversizedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.json")
+	// Slightly above the cap; the LimitReader path also catches grows-after-stat.
+	big := bytes.Repeat([]byte("x"), keyFileMaxSize+10)
+	if err := os.WriteFile(path, big, 0o600); err != nil {
+		t.Fatalf("write big: %v", err)
+	}
+	_, err := readKeyFileBytes(path)
+	if err == nil {
+		t.Fatalf("expected oversize rejection")
+	}
+	if !errors.Is(err, errKeyFileTooLarge) {
+		t.Errorf("err = %v, want errKeyFileTooLarge", err)
+	}
+}
+
 func TestReadPublicKeyForRoster_AcceptsAgentKeystorePub(t *testing.T) {
 	dir := t.TempDir()
 	pub, _, err := domsigning.GenerateKeyPair()

--- a/internal/cli/signing/roster_build.go
+++ b/internal/cli/signing/roster_build.go
@@ -7,6 +7,7 @@ import (
 	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -88,6 +89,8 @@ Examples:
 			if !force {
 				if _, statErr := os.Stat(cleanOut); statErr == nil {
 					return fmt.Errorf("output file %q already exists (use --force to overwrite)", cleanOut)
+				} else if !errors.Is(statErr, os.ErrNotExist) {
+					return fmt.Errorf("stat output file %q: %w", cleanOut, statErr)
 				}
 			}
 

--- a/internal/cli/signing/roster_build.go
+++ b/internal/cli/signing/roster_build.go
@@ -252,9 +252,12 @@ func parseIncludeSpecs(raw []string) ([]includeSpec, error) {
 
 // parseIncludeSpec parses one comma-separated key=value entry. Required keys:
 // id, key, purpose. Optional: status, role. Unknown keys reject so a
-// fat-fingered operator does not silently lose data.
+// fat-fingered operator does not silently lose data. Duplicate keys also
+// reject; otherwise "id=A,id=B" silently wins B and the operator-intended
+// roster differs from what got signed.
 func parseIncludeSpec(entry string) (includeSpec, error) {
 	var spec includeSpec
+	seen := make(map[string]struct{}, 5)
 	for _, raw := range strings.Split(entry, ",") {
 		raw = strings.TrimSpace(raw)
 		if raw == "" {
@@ -264,6 +267,12 @@ func parseIncludeSpec(entry string) (includeSpec, error) {
 		if !ok {
 			return includeSpec{}, fmt.Errorf("expected key=value, got %q", raw)
 		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if _, dup := seen[k]; dup {
+			return includeSpec{}, fmt.Errorf("duplicate key %q", k)
+		}
+		seen[k] = struct{}{}
 		switch k {
 		case "id":
 			spec.ID = v

--- a/internal/cli/signing/roster_build.go
+++ b/internal/cli/signing/roster_build.go
@@ -1,0 +1,289 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	domsigning "github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// rosterBuildSchemaVersion is the only KeyRoster schema version this command
+// emits today. Wire compat with the runtime loader requires it stays at 1
+// until contract.KeyRoster bumps and a parallel loader change ships.
+const rosterBuildSchemaVersion = 1
+
+// rosterDefaultDataClass is the default data_class_root if --data-class is
+// not supplied. Matches the conservative default the runtime expects: most
+// roster bodies carry internal-classification keys.
+const rosterDefaultDataClass = string(contract.DataClassInternal)
+
+// includeSpec is one parsed --include entry. Operator supplies these as
+// repeatable comma-separated key=value pairs.
+type includeSpec struct {
+	ID      string
+	KeyPath string
+	Purpose string
+	Status  string
+	Role    string
+}
+
+func rosterBuildCmd() *cobra.Command {
+	var rootPath string
+	var includes []string
+	var dataClass string
+	var schemaVersion int
+	var outPath string
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "build",
+		Short: "Compose and sign a key roster from a root and a set of includes",
+		Long: `Builds a signed RosterEnvelope from a root key file and one or more
+public-key includes. The output is a JSON roster file that
+"pipelock signing roster verify" accepts and that the live-lock runtime loader
+binds against learn_lock.pinned_root_fingerprint.
+
+The --root flag points at a JSON keypair file produced by
+"pipelock signing key generate --purpose roster-root". The --include flag is
+repeatable and accepts comma-separated key=value pairs:
+
+  id=<key_id>          required, unique within the roster
+  key=<path>           required, path to a public-key file (JSON keyFile or
+                       agent keystore .pub)
+  purpose=<purpose>    required, one of the recognised wire purposes
+  status=<status>      optional, default active. One of: active, revoked
+  role=<text>          optional, operator-facing principal label
+
+The roster's root entry is auto-included from --root; do not pass an
+--include for the root.
+
+Examples:
+  pipelock signing roster build \
+    --root /etc/pipelock/keys/fleet-root.json \
+    --include id=activation-primary,key=/etc/pipelock/keys/activation.pub.json,purpose=contract-activation-signing,role=operator \
+    --include id=compile-agentA,key=$HOME/.pipelock/agents/agentA/id_ed25519.pub,purpose=contract-compile-signing \
+    --data-class internal \
+    --out /etc/pipelock/roster.json`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out := cmd.OutOrStdout()
+
+			if !filepath.IsAbs(outPath) {
+				return fmt.Errorf("--out must be absolute, got %q", outPath)
+			}
+			cleanOut := filepath.Clean(outPath)
+
+			if !force {
+				if _, statErr := os.Stat(cleanOut); statErr == nil {
+					return fmt.Errorf("output file %q already exists (use --force to overwrite)", cleanOut)
+				}
+			}
+
+			if schemaVersion != rosterBuildSchemaVersion {
+				return fmt.Errorf("--schema-version %d unsupported (expected %d)", schemaVersion, rosterBuildSchemaVersion)
+			}
+
+			if err := contract.DataClass(dataClass).Validate(); err != nil {
+				return err
+			}
+			if dataClass == string(contract.DataClassRegulated) {
+				return fmt.Errorf("--data-class regulated is forbidden in signed artifacts")
+			}
+
+			rootFile, rootPub, rootPriv, err := loadKeyFile(rootPath, domsigning.PurposeRosterRoot)
+			if err != nil {
+				return fmt.Errorf("load root key: %w", err)
+			}
+
+			specs, err := parseIncludeSpecs(includes)
+			if err != nil {
+				return err
+			}
+
+			now := time.Now().UTC().Format(time.RFC3339)
+			seenIDs := make(map[string]struct{}, len(specs)+1)
+			seenIDs[rootFile.KeyID] = struct{}{}
+
+			keys := make([]contract.KeyInfo, 0, len(specs)+1)
+			keys = append(keys, contract.KeyInfo{
+				KeyID:        rootFile.KeyID,
+				KeyPurpose:   string(domsigning.PurposeRosterRoot),
+				PublicKeyHex: hex.EncodeToString(rootPub),
+				ValidFrom:    now,
+				ValidUntil:   nil,
+				Status:       contract.KeyStatusRoot,
+				Principal:    "root",
+			})
+
+			for _, spec := range specs {
+				if _, dup := seenIDs[spec.ID]; dup {
+					return fmt.Errorf("duplicate --include id %q (root takes id %q)", spec.ID, rootFile.KeyID)
+				}
+				seenIDs[spec.ID] = struct{}{}
+
+				flagPurpose := domsigning.KeyPurpose(spec.Purpose)
+				if err := flagPurpose.Validate(); err != nil {
+					return fmt.Errorf("--include id=%q: %w", spec.ID, err)
+				}
+				if flagPurpose == domsigning.PurposeRosterRoot {
+					return fmt.Errorf("--include id=%q: roster-root entries are auto-included from --root and must not be passed as --include", spec.ID)
+				}
+
+				pubBytes, filePurpose, err := readPublicKeyForRoster(spec.KeyPath)
+				if err != nil {
+					return fmt.Errorf("--include id=%q: %w", spec.ID, err)
+				}
+				if filePurpose != "" && filePurpose != spec.Purpose {
+					return fmt.Errorf("--include id=%q: purpose flag %q disagrees with key file purpose %q", spec.ID, spec.Purpose, filePurpose)
+				}
+
+				status := spec.Status
+				if status == "" {
+					status = contract.KeyStatusActive
+				}
+				switch status {
+				case contract.KeyStatusActive, contract.KeyStatusRevoked:
+					// allowed for non-root entries
+				case contract.KeyStatusRoot:
+					return fmt.Errorf("--include id=%q: status=root is reserved for the auto-included root entry", spec.ID)
+				default:
+					return fmt.Errorf("--include id=%q: unknown status %q (allowed: active, revoked)", spec.ID, status)
+				}
+
+				keys = append(keys, contract.KeyInfo{
+					KeyID:        spec.ID,
+					KeyPurpose:   spec.Purpose,
+					PublicKeyHex: hex.EncodeToString(pubBytes),
+					ValidFrom:    now,
+					ValidUntil:   nil,
+					Status:       status,
+					Principal:    spec.Role,
+				})
+			}
+
+			body := contract.KeyRoster{
+				SchemaVersion:  schemaVersion,
+				RosterSignedBy: rootFile.KeyID,
+				Keys:           keys,
+				DataClassRoot:  dataClass,
+			}
+			if err := body.Validate(); err != nil {
+				return fmt.Errorf("roster body validation: %w", err)
+			}
+
+			preimage, err := body.SignablePreimage()
+			if err != nil {
+				return fmt.Errorf("compute signable preimage: %w", err)
+			}
+			sig := ed25519.Sign(rootPriv, preimage)
+			envelope := contract.RosterEnvelope{
+				Body:      body,
+				Signature: "ed25519:" + hex.EncodeToString(sig),
+			}
+
+			data, err := json.MarshalIndent(envelope, "", "  ")
+			if err != nil {
+				return fmt.Errorf("marshal roster envelope: %w", err)
+			}
+			data = append(data, '\n')
+
+			if err := atomicfile.Write(cleanOut, data, 0o600); err != nil {
+				return fmt.Errorf("write roster: %w", err)
+			}
+
+			fp, err := domsigning.Fingerprint(rootPub)
+			if err != nil {
+				return fmt.Errorf("compute root fingerprint: %w", err)
+			}
+			_, _ = fmt.Fprintf(out, "Built signed roster\n")
+			_, _ = fmt.Fprintf(out, "  keys:                %d\n", len(keys))
+			_, _ = fmt.Fprintf(out, "  root_signed_by:      %s\n", rootFile.KeyID)
+			_, _ = fmt.Fprintf(out, "  root_fingerprint:    %s\n", fp)
+			_, _ = fmt.Fprintf(out, "  data_class_root:     %s\n", dataClass)
+			_, _ = fmt.Fprintf(out, "  out:                 %s\n", cleanOut)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&rootPath, "root", "", "path to root key JSON file (output of 'pipelock signing key generate --purpose roster-root')")
+	cmd.Flags().StringArrayVar(&includes, "include", nil, "include entry as id=ID,key=PATH,purpose=PURPOSE[,status=STATUS][,role=ROLE]; repeatable")
+	cmd.Flags().StringVar(&dataClass, "data-class", rosterDefaultDataClass, "data_class_root for the roster body (public, internal, or sensitive)")
+	cmd.Flags().IntVar(&schemaVersion, "schema-version", rosterBuildSchemaVersion, "key_roster schema_version")
+	cmd.Flags().StringVar(&outPath, "out", "", "absolute output path for the signed roster JSON")
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite an existing output file")
+	_ = cmd.MarkFlagRequired("root")
+	_ = cmd.MarkFlagRequired("include")
+	_ = cmd.MarkFlagRequired("out")
+	return cmd
+}
+
+// parseIncludeSpecs converts the repeatable --include strings into structured
+// entries. Returns a typed error per malformed entry that names the offending
+// flag value so the operator can correct it without grepping the source.
+func parseIncludeSpecs(raw []string) ([]includeSpec, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("at least one --include is required")
+	}
+	out := make([]includeSpec, 0, len(raw))
+	for i, entry := range raw {
+		spec, err := parseIncludeSpec(entry)
+		if err != nil {
+			return nil, fmt.Errorf("--include[%d] %q: %w", i, entry, err)
+		}
+		out = append(out, spec)
+	}
+	return out, nil
+}
+
+// parseIncludeSpec parses one comma-separated key=value entry. Required keys:
+// id, key, purpose. Optional: status, role. Unknown keys reject so a
+// fat-fingered operator does not silently lose data.
+func parseIncludeSpec(entry string) (includeSpec, error) {
+	var spec includeSpec
+	for _, raw := range strings.Split(entry, ",") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(raw, "=")
+		if !ok {
+			return includeSpec{}, fmt.Errorf("expected key=value, got %q", raw)
+		}
+		switch k {
+		case "id":
+			spec.ID = v
+		case "key":
+			spec.KeyPath = v
+		case "purpose":
+			spec.Purpose = v
+		case "status":
+			spec.Status = v
+		case "role":
+			spec.Role = v
+		default:
+			return includeSpec{}, fmt.Errorf("unknown key %q (allowed: id, key, purpose, status, role)", k)
+		}
+	}
+	if spec.ID == "" {
+		return includeSpec{}, fmt.Errorf("missing required field id")
+	}
+	if spec.KeyPath == "" {
+		return includeSpec{}, fmt.Errorf("missing required field key")
+	}
+	if spec.Purpose == "" {
+		return includeSpec{}, fmt.Errorf("missing required field purpose")
+	}
+	return spec, nil
+}

--- a/internal/cli/signing/roster_build_test.go
+++ b/internal/cli/signing/roster_build_test.go
@@ -1,0 +1,479 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	domsigning "github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// rosterBuildFixture seeds a working root + activation + compile key triple
+// and returns each path. Used by every roster-build positive test.
+type rosterBuildFixture struct {
+	dir            string
+	rootPath       string
+	rootPubHex     string
+	activationPath string
+	compilePath    string
+}
+
+func newRosterBuildFixture(t *testing.T) rosterBuildFixture {
+	t.Helper()
+	dir := t.TempDir()
+	rootPath := filepath.Join(dir, "root.json")
+	activationPath := filepath.Join(dir, "activation.json")
+	compilePath := filepath.Join(dir, "compile.json")
+
+	for _, e := range []struct {
+		purpose string
+		out     string
+		id      string
+	}{
+		{string(domsigning.PurposeRosterRoot), rootPath, ""},
+		{string(domsigning.PurposeContractActivationSigning), activationPath, "activation-primary"},
+		{string(domsigning.PurposeContractCompileSigning), compilePath, "compile-test"},
+	} {
+		cmd := keyGenerateCmd()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		args := []string{"--purpose", e.purpose, "--out", e.out}
+		if e.id != "" {
+			args = append(args, "--id", e.id)
+		}
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("seed key generate %s: %v", e.purpose, err)
+		}
+	}
+
+	rootRaw, err := os.ReadFile(filepath.Clean(rootPath))
+	if err != nil {
+		t.Fatalf("read root: %v", err)
+	}
+	var rootKF keyFile
+	if err := json.Unmarshal(rootRaw, &rootKF); err != nil {
+		t.Fatalf("unmarshal root: %v", err)
+	}
+	return rosterBuildFixture{
+		dir:            dir,
+		rootPath:       rootPath,
+		rootPubHex:     rootKF.Public,
+		activationPath: activationPath,
+		compilePath:    compilePath,
+	}
+}
+
+func TestRosterBuild_RoundTripVerifies(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=activation-primary,key=" + fx.activationPath + ",purpose=" + string(domsigning.PurposeContractActivationSigning) + ",role=operator",
+		"--include", "id=compile-test,key=" + fx.compilePath + ",purpose=" + string(domsigning.PurposeContractCompileSigning) + ",role=compiler",
+		"--out", out,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("roster build: %v", err)
+	}
+
+	rootPubBytes, err := hex.DecodeString(fx.rootPubHex)
+	if err != nil {
+		t.Fatalf("decode root pub: %v", err)
+	}
+	pinnedFP, err := domsigning.Fingerprint(rootPubBytes)
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+
+	loaded, err := domsigning.LoadRoster(out, pinnedFP)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+	if loaded == nil {
+		t.Fatalf("LoadRoster returned nil")
+	}
+	if got := len(loaded.Body.Keys); got != 3 {
+		t.Errorf("loaded.Keys = %d, want 3", got)
+	}
+}
+
+func TestRosterBuild_EnforcesAtomicOutputPermissions(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=activation-primary,key=" + fx.activationPath + ",purpose=" + string(domsigning.PurposeContractActivationSigning),
+		"--out", out,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	info, err := os.Stat(out)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Errorf("output mode = %o leaks group/world bits", info.Mode().Perm())
+	}
+}
+
+func TestRosterBuild_RefusesDuplicateID(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=dup,key=" + fx.activationPath + ",purpose=" + string(domsigning.PurposeContractActivationSigning),
+		"--include", "id=dup,key=" + fx.compilePath + ",purpose=" + string(domsigning.PurposeContractCompileSigning),
+		"--out", out,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected duplicate-id error")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("err %q does not mention duplicate", err.Error())
+	}
+}
+
+func TestRosterBuild_RefusesPurposeMismatchInJSONKeyFile(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=activation-primary,key=" + fx.activationPath + ",purpose=" + string(domsigning.PurposeContractCompileSigning),
+		"--out", out,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected purpose-mismatch error")
+	}
+	if !strings.Contains(err.Error(), "purpose flag") || !strings.Contains(err.Error(), "key file purpose") {
+		t.Errorf("err %q does not name both flag and file purpose", err.Error())
+	}
+}
+
+func TestRosterBuild_RefusesIncludeOfRosterRoot(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=second-root,key=" + fx.rootPath + ",purpose=" + string(domsigning.PurposeRosterRoot),
+		"--out", out,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected refuse-roster-root-include error")
+	}
+	if !strings.Contains(err.Error(), "auto-included") {
+		t.Errorf("err %q does not mention auto-include policy", err.Error())
+	}
+}
+
+func TestRosterBuild_RefusesUnknownDataClass(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=activation-primary,key=" + fx.activationPath + ",purpose=" + string(domsigning.PurposeContractActivationSigning),
+		"--data-class", "bogus",
+		"--out", out,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected data-class error")
+	}
+	if !strings.Contains(err.Error(), "invalid data_class") {
+		t.Errorf("err %q does not name invalid data_class", err.Error())
+	}
+}
+
+func TestRosterBuild_RefusesRegulatedDataClass(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=activation-primary,key=" + fx.activationPath + ",purpose=" + string(domsigning.PurposeContractActivationSigning),
+		"--data-class", string(contract.DataClassRegulated),
+		"--out", out,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected regulated-data-class error")
+	}
+	if !strings.Contains(err.Error(), "regulated") {
+		t.Errorf("err %q does not name regulated", err.Error())
+	}
+}
+
+func TestRosterBuild_RefusesUnknownIncludeStatus(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=activation-primary,key=" + fx.activationPath + ",purpose=" + string(domsigning.PurposeContractActivationSigning) + ",status=bogus",
+		"--out", out,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected unknown-status error")
+	}
+	if !strings.Contains(err.Error(), "unknown status") {
+		t.Errorf("err %q does not mention unknown status", err.Error())
+	}
+}
+
+func TestRosterBuild_AllowsRevokedIncludeStatus(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=activation-primary,key=" + fx.activationPath + ",purpose=" + string(domsigning.PurposeContractActivationSigning) + ",status=" + contract.KeyStatusRevoked,
+		"--out", out,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	rootPubBytes, err := hex.DecodeString(fx.rootPubHex)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	pinnedFP, err := domsigning.Fingerprint(rootPubBytes)
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	loaded, err := domsigning.LoadRoster(out, pinnedFP)
+	if err != nil {
+		t.Fatalf("LoadRoster: %v", err)
+	}
+	gotRevoked := false
+	for _, k := range loaded.Body.Keys {
+		if k.KeyID == "activation-primary" && k.Status == contract.KeyStatusRevoked {
+			gotRevoked = true
+		}
+	}
+	if !gotRevoked {
+		t.Errorf("revoked status was not preserved")
+	}
+}
+
+func TestRosterBuild_RefusesStatusRootInInclude(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=activation-primary,key=" + fx.activationPath + ",purpose=" + string(domsigning.PurposeContractActivationSigning) + ",status=" + contract.KeyStatusRoot,
+		"--out", out,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected refuse-status-root error")
+	}
+	if !strings.Contains(err.Error(), "status=root is reserved") {
+		t.Errorf("err %q does not name reserved-root policy", err.Error())
+	}
+}
+
+func TestRosterBuild_RefusesRelativeOutPath(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=activation-primary,key=" + fx.activationPath + ",purpose=" + string(domsigning.PurposeContractActivationSigning),
+		"--out", "relative.json",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected absolute-path error")
+	}
+	if !strings.Contains(err.Error(), "absolute") {
+		t.Errorf("err %q does not mention absolute requirement", err.Error())
+	}
+}
+
+func TestParseIncludeSpec_RejectsUnknownKey(t *testing.T) {
+	_, err := parseIncludeSpec("id=x,key=/k,purpose=p,bogus=z")
+	if err == nil {
+		t.Fatalf("expected unknown-key error")
+	}
+	if !strings.Contains(err.Error(), "unknown key") {
+		t.Errorf("err %q does not mention unknown key", err.Error())
+	}
+}
+
+func TestParseIncludeSpec_RejectsMissingRequiredField(t *testing.T) {
+	cases := []string{
+		"key=/k,purpose=p",
+		"id=x,purpose=p",
+		"id=x,key=/k",
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			_, err := parseIncludeSpec(c)
+			if err == nil {
+				t.Fatalf("expected missing-required-field error for %q", c)
+			}
+			if !strings.Contains(err.Error(), "missing required field") {
+				t.Errorf("err %q does not mention missing required", err.Error())
+			}
+		})
+	}
+}
+
+func TestRosterBuild_BuiltRosterIsLoadableByLoadRoster(t *testing.T) {
+	// End-to-end: generate keys, build roster, sign with built-in workflow,
+	// then load through the runtime LoadRoster path. Proves the wire shape
+	// matches what the loader expects.
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=activation-primary,key=" + fx.activationPath + ",purpose=" + string(domsigning.PurposeContractActivationSigning),
+		"--include", "id=compile-test,key=" + fx.compilePath + ",purpose=" + string(domsigning.PurposeContractCompileSigning),
+		"--out", out,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	rootPubBytes, err := hex.DecodeString(fx.rootPubHex)
+	if err != nil {
+		t.Fatalf("decode pub: %v", err)
+	}
+	pinnedFP, err := domsigning.Fingerprint(rootPubBytes)
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	loaded, err := domsigning.LoadRoster(out, pinnedFP)
+	if err != nil {
+		t.Fatalf("LoadRoster on built roster: %v", err)
+	}
+	if loaded.RosterRootFingerprint != pinnedFP {
+		t.Errorf("loaded fingerprint = %s, want %s", loaded.RosterRootFingerprint, pinnedFP)
+	}
+
+	// And a forged signature must reject. Replace the body, keep the signature,
+	// confirm LoadRoster rejects rather than trusting.
+	raw, err := os.ReadFile(filepath.Clean(out))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var envelope contract.RosterEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for i := range envelope.Body.Keys {
+		if envelope.Body.Keys[i].Status == contract.KeyStatusActive {
+			envelope.Body.Keys[i].Principal = "tampered"
+			break
+		}
+	}
+	tampered, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	tamperedPath := filepath.Join(fx.dir, "tampered.json")
+	if err := os.WriteFile(tamperedPath, tampered, 0o600); err != nil {
+		t.Fatalf("write tampered: %v", err)
+	}
+	if _, err := domsigning.LoadRoster(tamperedPath, pinnedFP); err == nil {
+		t.Errorf("LoadRoster accepted tampered roster")
+	}
+}
+
+// TestRosterBuild_IncludeRequiresAtLeastOne verifies cobra's MarkFlagRequired
+// fires when --include is omitted. Defense in depth on top of parseIncludeSpecs.
+func TestRosterBuild_IncludeRequiresAtLeastOne(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--root", fx.rootPath, "--out", out})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected missing-include error")
+	}
+	if !strings.Contains(err.Error(), "include") {
+		t.Errorf("err %q does not mention include", err.Error())
+	}
+}
+
+// rosterBuildFixture sanity check: the test fixture itself is valid.
+func TestNewRosterBuildFixture_GeneratesParseableKeys(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+
+	for _, p := range []string{fx.rootPath, fx.activationPath, fx.compilePath} {
+		raw, err := os.ReadFile(filepath.Clean(p))
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		var kf keyFile
+		if err := json.Unmarshal(raw, &kf); err != nil {
+			t.Fatalf("unmarshal %s: %v", p, err)
+		}
+		pub, err := hex.DecodeString(kf.Public)
+		if err != nil || len(pub) != ed25519.PublicKeySize {
+			t.Errorf("public hex bad in %s: err=%v len=%d", p, err, len(pub))
+		}
+	}
+}

--- a/internal/cli/signing/roster_build_test.go
+++ b/internal/cli/signing/roster_build_test.go
@@ -447,6 +447,37 @@ func TestRosterBuild_AllowsOverwriteWithForce(t *testing.T) {
 	}
 }
 
+func TestParseIncludeSpec_RejectsDuplicateKeys(t *testing.T) {
+	cases := []string{
+		"id=a,id=b,key=/k,purpose=p",
+		"id=x,key=/k,key=/other,purpose=p",
+		"id=x,key=/k,purpose=p,purpose=q",
+		"id=x,key=/k,purpose=p,status=active,status=revoked",
+		"id=x,key=/k,purpose=p,role=foo,role=bar",
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			_, err := parseIncludeSpec(c)
+			if err == nil {
+				t.Fatalf("expected duplicate-key rejection for %q", c)
+			}
+			if !strings.Contains(err.Error(), "duplicate key") {
+				t.Errorf("err %q does not mention duplicate key", err.Error())
+			}
+		})
+	}
+}
+
+func TestParseIncludeSpec_TrimsWhitespaceAroundKeyAndValue(t *testing.T) {
+	spec, err := parseIncludeSpec(" id = x , key = /k , purpose = p ")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if spec.ID != "x" || spec.KeyPath != "/k" || spec.Purpose != "p" {
+		t.Errorf("trim failed: %+v", spec)
+	}
+}
+
 func TestParseIncludeSpec_RejectsUnknownKey(t *testing.T) {
 	_, err := parseIncludeSpec("id=x,key=/k,purpose=p,bogus=z")
 	if err == nil {

--- a/internal/cli/signing/roster_build_test.go
+++ b/internal/cli/signing/roster_build_test.go
@@ -325,6 +325,27 @@ func TestRosterBuild_RefusesStatusRootInInclude(t *testing.T) {
 	}
 }
 
+func TestRosterBuild_RefusesWrongPurposeRoot(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.activationPath,
+		"--include", "id=compile-test,key=" + fx.compilePath + ",purpose=" + string(domsigning.PurposeContractCompileSigning),
+		"--out", out,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected wrong-purpose-root error")
+	}
+	if !strings.Contains(err.Error(), "purpose mismatch") {
+		t.Errorf("err %q does not mention purpose mismatch", err.Error())
+	}
+}
+
 func TestRosterBuild_RefusesRelativeOutPath(t *testing.T) {
 	fx := newRosterBuildFixture(t)
 
@@ -342,6 +363,87 @@ func TestRosterBuild_RefusesRelativeOutPath(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "absolute") {
 		t.Errorf("err %q does not mention absolute requirement", err.Error())
+	}
+}
+
+func TestRosterBuild_RefusesUnsupportedSchemaVersion(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=activation-primary,key=" + fx.activationPath + ",purpose=" + string(domsigning.PurposeContractActivationSigning),
+		"--schema-version", "2",
+		"--out", out,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected unsupported-schema-version error")
+	}
+	if !strings.Contains(err.Error(), "unsupported") {
+		t.Errorf("err %q does not mention unsupported schema", err.Error())
+	}
+}
+
+func TestRosterBuild_RefusesOverwriteWithoutForce(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+	if err := os.WriteFile(out, []byte("preexisting"), 0o600); err != nil {
+		t.Fatalf("seed output: %v", err)
+	}
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=activation-primary,key=" + fx.activationPath + ",purpose=" + string(domsigning.PurposeContractActivationSigning),
+		"--out", out,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected refuse-overwrite error")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("err %q does not mention existing output", err.Error())
+	}
+	got, err := os.ReadFile(filepath.Clean(out))
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if string(got) != "preexisting" {
+		t.Errorf("output changed without --force: %q", string(got))
+	}
+}
+
+func TestRosterBuild_AllowsOverwriteWithForce(t *testing.T) {
+	fx := newRosterBuildFixture(t)
+	out := filepath.Join(fx.dir, "roster.json")
+	if err := os.WriteFile(out, []byte("preexisting"), 0o600); err != nil {
+		t.Fatalf("seed output: %v", err)
+	}
+
+	cmd := rosterBuildCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--root", fx.rootPath,
+		"--include", "id=activation-primary,key=" + fx.activationPath + ",purpose=" + string(domsigning.PurposeContractActivationSigning),
+		"--out", out,
+		"--force",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Clean(out))
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if bytes.Equal(got, []byte("preexisting")) {
+		t.Errorf("output was not overwritten under --force")
 	}
 }
 

--- a/internal/cli/signing/signing_subtree.go
+++ b/internal/cli/signing/signing_subtree.go
@@ -44,15 +44,17 @@ ceremonies to confirm that signed artifacts are authentic before
 trusting them in production.
 
 Subcommand groups:
-  roster      Show and verify key rosters
+  key         Generate deployment-level signing keys
+  roster      Build, show, and verify key rosters
   recovery    Verify recovery authorizations
   transition  Verify root transition documents`,
 	}
 
 	roster := &cobra.Command{
 		Use:   "roster",
-		Short: "Show and verify key rosters",
+		Short: "Build, show, and verify key rosters",
 	}
+	roster.AddCommand(rosterBuildCmd())
 	roster.AddCommand(rosterShowCmd())
 	roster.AddCommand(rosterVerifyCmd())
 
@@ -68,7 +70,7 @@ Subcommand groups:
 	}
 	transition.AddCommand(transitionVerifyCmd())
 
-	cmd.AddCommand(roster, recovery, transition)
+	cmd.AddCommand(keyGenerateGroupCmd(), roster, recovery, transition)
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

Adds `pipelock signing key generate` and `pipelock signing roster build`. Together with the existing `pipelock keygen`, an operator can produce the signed roster `learn_lock.roster_path` consumes without writing Go. Closes the gap where the live-lock runtime shipped requiring a roster the operator could not bootstrap from public CLI surface.

## Behavior

`pipelock signing key generate` writes a 0o600 JSON keypair with explicit purpose binding (one of the six recognised wire purposes), an operator-supplied or derived key_id, and the canonical sha256 fingerprint printed to stdout for pinning into `learn_lock.pinned_root_fingerprint`.

`pipelock signing roster build` composes a signed `contract.RosterEnvelope` from a root key plus repeatable `--include id=,key=,purpose=[,status=,role=]` entries. The root entry is auto-included from `--root`. Output JSON is the wire shape `pipelock signing roster verify` accepts and that `runtime.Loader` binds against the pinned root fingerprint.

`docs/configuration.md` gains a Live lock trust topology section with the end-to-end recipe.

## Defense in depth

`roster build` refuses with typed errors on duplicate `--include` ids, purpose mismatch between `--include purpose=` and a JSON keyFile, bad data-class (`regulated` rejected explicitly), `status=root` on an include, non-`roster-root` purpose on `--root`, existing output without `--force`, and non-`ErrNotExist` stat errors on the output path.

`loadKeyFile` rejects mismatched public/private hex (private must derive declared public), trailing JSON after the object (`dec.More()` checked post-Decode), unknown fields, unsupported `schema_version`, wrong-length hex, and files over 16 KiB.

Round-trip integration test proves a CLI-built roster loads via `runtime.LoadRoster` and a tampered envelope rejects. All writes use `atomicfile.Write` at `0o600`.

## Bundled fixes

Folds in two CI hardening fixes that main needs to clear pre-tag CI:

- Reload integration tests in `internal/cli/cli_test.go` wait for observed reload output instead of sleeping a fixed 500ms.
- Scorecard workflow no longer fails main on optional public publish timeouts; SARIF and artifacts continue uploading.

Folded rather than split because main's CI is failing on both and sequencing adds a merge cycle.

## Tradeoffs

- Agent keystore `.pub` files have no purpose field, so `--include purpose=` is operator-trusted for those. JSON keyFile includes get the strict cross-check.
- Schema version fixed at 1 for both `keyFile` and `KeyRoster`.
- No multi-signature roster support; `learn_lock.minimum_signatures` defaults to 1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to generate Ed25519 signing keys and to compose/sign rosters with validation, atomic output, and strict file permissions.

* **Documentation**
  * Added "Live lock trust topology" guide describing operator-managed trust bootstrapping and key/roster workflows.

* **Tests**
  * Improved CLI tests with concurrency-safe stderr capture and expanded key/roster test coverage.

* **Chores**
  * Adjusted Scorecard workflow to stop publishing results while still producing SARIF and uploading artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->