### PR TITLE
fix(learn): require nested live-lock environment

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2184,6 +2184,24 @@ The `listen`, `enabled`, and `upstream` fields cannot be changed via hot-reload 
 
 The live-lock runtime activates per-agent behavioural contracts only after their candidate is signed by an operator-controlled activation key, and trusts that key only because the deployment-local roster names it under a fleet-root signature. Bootstrapping the roster is a one-time operator workflow.
 
+Runtime config uses a nested environment tuple. All three keys are required when `learn_lock.enabled` is true. Use explicit empty strings for `tenant` or `deployment_id` only when the deployment is intentionally unscoped on that axis.
+
+```yaml
+learn_lock:
+  enabled: true
+  mode: shadow
+  store_dir: /var/lib/pipelock/contracts/active
+  roster_path: /etc/pipelock/roster.json
+  environment:
+    id: production
+    tenant: acme
+    deployment_id: prod-us-1
+  pinned_root_fingerprint: sha256:<64 lowercase hex>
+  minimum_signatures: 1
+```
+
+The old string form, `learn_lock.environment: production`, is not accepted by the v2.4 runtime. Migrate it to the nested block before enabling live-lock with a v2.4 binary.
+
 ### Generating the roster
 
 Two commands compose the trust topology:

--- a/internal/cli/learn/activate.go
+++ b/internal/cli/learn/activate.go
@@ -126,8 +126,8 @@ func addLifecycleFlags(cmd *cobra.Command, flags *lifecycleFlags) {
 	cmd.Flags().StringVar(&flags.receiptKey, "receipt-key-agent", flags.receiptKey, "keystore agent name for committed lifecycle receipts")
 	cmd.Flags().StringVar(&flags.receiptOut, "receipt-out", "", "signed lifecycle receipt JSONL path; defaults under --contract-store")
 	cmd.Flags().StringVar(&flags.environmentID, "environment-id", "", "manifest environment id; inherited from current active manifest when omitted")
-	cmd.Flags().StringVar(&flags.tenant, "tenant", "", "manifest tenant; inherited from current active manifest when omitted")
-	cmd.Flags().StringVar(&flags.deploymentID, "deployment-id", "", "manifest deployment id; inherited from current active manifest when omitted")
+	cmd.Flags().StringVar(&flags.tenant, "tenant", "", "manifest tenant; inherited from current active manifest when all environment flags are omitted; empty means unscoped")
+	cmd.Flags().StringVar(&flags.deploymentID, "deployment-id", "", "manifest deployment id; inherited from current active manifest when all environment flags are omitted; empty means unscoped")
 	cmd.Flags().BoolVar(&flags.production, "production", false, "enforce production activation policy")
 	cmd.Flags().BoolVar(&flags.deterministic, "deterministic", false, "use deterministic timestamps and ids for tests")
 	_ = cmd.MarkFlagRequired("contract-store")
@@ -417,8 +417,8 @@ func resolveLifecycleEnvironment(flags lifecycleFlags, current contractstore.Sta
 	if !provided && hasCurrent {
 		return current.Envelope.Body.Environment, nil
 	}
-	if flags.environmentID == "" || flags.tenant == "" || flags.deploymentID == "" {
-		return contract.Environment{}, fmt.Errorf("learn lifecycle: --environment-id, --tenant, and --deployment-id are required without an accepted manifest")
+	if flags.environmentID == "" {
+		return contract.Environment{}, fmt.Errorf("learn lifecycle: --environment-id is required without an accepted manifest")
 	}
 	env := contract.Environment{ID: flags.environmentID, Tenant: flags.tenant, DeploymentID: flags.deploymentID}
 	if hasCurrent && env != current.Envelope.Body.Environment {

--- a/internal/cli/learn/activate_test.go
+++ b/internal/cli/learn/activate_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
 	contractstore "github.com/luckyPipewrench/pipelock/internal/contract/store"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
@@ -114,9 +115,17 @@ func TestResolveLifecycleEnvironmentInheritsOrRequiresExplicit(t *testing.T) {
 		t.Fatalf("mismatched environment err = %v, want mismatch", err)
 	}
 
-	_, err = resolveLifecycleEnvironment(lifecycleFlags{environmentID: "stage"}, contractstore.State{}, false)
-	if err == nil || !strings.Contains(err.Error(), "--tenant") {
-		t.Fatalf("partial environment err = %v, want missing flag error", err)
+	got, err = resolveLifecycleEnvironment(lifecycleFlags{environmentID: "stage"}, contractstore.State{}, false)
+	if err != nil {
+		t.Fatalf("resolve environment with empty tenant/deployment_id: %v", err)
+	}
+	if got != (contract.Environment{ID: "stage"}) {
+		t.Fatalf("explicit environment with empty tuple scopes = %+v, want id-only stage", got)
+	}
+
+	_, err = resolveLifecycleEnvironment(lifecycleFlags{tenant: "tenant"}, contractstore.State{}, false)
+	if err == nil || !strings.Contains(err.Error(), "--environment-id") {
+		t.Fatalf("missing environment id err = %v, want missing flag error", err)
 	}
 }
 
@@ -192,6 +201,55 @@ func TestRunPromoteWritesReceiptsAndAcceptedManifest(t *testing.T) {
 	mustUnmarshalPayload(t, committed, &committedPayload)
 	if committedPayload.ValidationOutcome != lifecycleOutcomeAccepted || committedPayload.TargetManifestHash != latest.ManifestHash {
 		t.Fatalf("committed payload = %+v, latest=%s", committedPayload, latest.ManifestHash)
+	}
+}
+
+func TestRunPromoteManifestLoadsInRuntimeWithEnvironmentTuple(t *testing.T) {
+	fixture := newLifecycleTestFixture(t)
+	firstContract := fixture.putContract(t, "agent-a")
+	if err := runPromote(lifecycleTestCmd(nil, nil), fixture.promoteFlags(firstContract, "agent-a", filepath.Join(fixture.root, "first-receipts.jsonl"))); err != nil {
+		t.Fatalf("runPromote first: %v", err)
+	}
+
+	loader, err := contractruntime.NewLoader(contractruntime.LoaderOptions{
+		StoreDir:              fixture.storeDir,
+		RosterPath:            fixture.rosterPath,
+		PinnedRootFingerprint: fixture.rootFingerprint,
+		Environment:           fixture.env,
+		MinSignatures:         1,
+		Mode:                  contractruntime.ModeLive,
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewLoader with matching environment tuple: %v", err)
+	}
+	if loader.Current() == nil || loader.Current().Generation() != 1 {
+		t.Fatalf("runtime current = %+v, want generation 1", loader.Current())
+	}
+
+	secondContract := fixture.putContract(t, "agent-b")
+	if err := runPromote(lifecycleTestCmd(nil, nil), fixture.promoteFlags(secondContract, "agent-b", filepath.Join(fixture.root, "second-receipts.jsonl"))); err != nil {
+		t.Fatalf("runPromote second: %v", err)
+	}
+	if err := loader.Reload(); err != nil {
+		t.Fatalf("runtime Reload after second promote: %v", err)
+	}
+	if loader.Current() == nil || loader.Current().Generation() != 2 {
+		t.Fatalf("runtime current after reload = %+v, want generation 2", loader.Current())
+	}
+
+	_, err = contractruntime.NewLoader(contractruntime.LoaderOptions{
+		StoreDir:              fixture.storeDir,
+		RosterPath:            fixture.rosterPath,
+		PinnedRootFingerprint: fixture.rootFingerprint,
+		Environment:           contract.Environment{ID: fixture.env.ID, Tenant: "wrong", DeploymentID: fixture.env.DeploymentID},
+		MinSignatures:         1,
+		Mode:                  contractruntime.ModeLive,
+	}, nil)
+	if err == nil {
+		t.Fatal("NewLoader accepted mismatched environment tuple")
+	}
+	if !strings.Contains(err.Error(), "environment mismatch") {
+		t.Fatalf("mismatch err = %v, want environment mismatch", err)
 	}
 }
 
@@ -282,6 +340,27 @@ func TestLifecycleErrorPaths(t *testing.T) {
 	missingEnv.deploymentID = ""
 	if err := runPromote(lifecycleTestCmd(nil, nil), missingEnv); err == nil || !strings.Contains(err.Error(), "--environment-id") {
 		t.Fatalf("runPromote missing env err = %v, want environment flag error", err)
+	}
+
+	emptyFixture := newLifecycleTestFixture(t)
+	emptyContractHash := emptyFixture.putContract(t, "agent-a")
+	emptyTupleScopes := emptyFixture.promoteFlags(emptyContractHash, "agent-a", filepath.Join(emptyFixture.root, "empty-scope-receipts.jsonl"))
+	emptyTupleScopes.tenant = ""
+	emptyTupleScopes.deploymentID = ""
+	if err := runPromote(lifecycleTestCmd(nil, nil), emptyTupleScopes); err != nil {
+		t.Fatalf("runPromote should accept empty tenant/deployment_id with environment id: %v", err)
+	}
+	latest, err := contractstore.New(emptyFixture.storeDir).LatestAccepted(contractstore.Options{
+		Environment:   contract.Environment{ID: emptyFixture.env.ID},
+		Roster:        emptyFixture.roster,
+		MinSignatures: 1,
+		Now:           lifecycleTestNow,
+	})
+	if err != nil {
+		t.Fatalf("LatestAccepted with id-only environment: %v", err)
+	}
+	if latest.Envelope.Body.Environment != (contract.Environment{ID: emptyFixture.env.ID}) {
+		t.Fatalf("promote environment = %+v, want id-only environment", latest.Envelope.Body.Environment)
 	}
 
 	missingSelector := base

--- a/internal/cli/learn/ratify.go
+++ b/internal/cli/learn/ratify.go
@@ -73,10 +73,10 @@ and a contract_ratified evidence receipt.
 Interactive mode reads one decision per rule from stdin: e=enforce,
 c=capture-only, r=reject.
 
-Non-interactive ratification refuses never_confirmed and refuted rules unless
---accept-low-confidence is set. That override can promote rules built from
-insufficient or refuted evidence into enforcement, so use it only for deliberate
-operator-reviewed dogfood workflows.`,
+Non-interactive ratification treats any confidence other than stable or brittle
+as low-confidence unless --accept-low-confidence is set. That override can
+promote rules built from insufficient, novel, or refuted evidence into
+enforcement, so use it only for deliberate operator-reviewed dogfood workflows.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runRatify(cmd, flags)
@@ -89,7 +89,7 @@ operator-reviewed dogfood workflows.`,
 	cmd.Flags().StringVar(&flags.compileKeyAgent, "compile-key-agent", "", "keystore agent name for contract re-signing; defaults to candidate signer")
 	cmd.Flags().StringVar(&flags.receiptKey, "receipt-key-agent", flags.receiptKey, "keystore agent name for ratification receipt signing")
 	cmd.Flags().BoolVar(&flags.interactive, "interactive", false, "prompt for each rule decision")
-	cmd.Flags().BoolVar(&flags.acceptLowConfidence, "accept-low-confidence", false, "allow ratifying never_confirmed or refuted rules; dangerous because thin or refuted evidence can become enforce policy")
+	cmd.Flags().BoolVar(&flags.acceptLowConfidence, "accept-low-confidence", false, "allow ratifying rules whose confidence is not stable or brittle; dangerous because thin or refuted evidence can become enforce policy")
 	cmd.Flags().BoolVar(&flags.deterministic, "deterministic", false, "use deterministic timestamps, ids, and signing keys for tests")
 	_ = cmd.MarkFlagRequired("candidate")
 	return cmd

--- a/internal/cli/learn/ratify.go
+++ b/internal/cli/learn/ratify.go
@@ -34,6 +34,8 @@ const (
 	ratifyDecisionCapture = "capture_only"
 	ratifyDecisionReject  = "reject"
 
+	ratifyConfidenceStable         = "stable"
+	ratifyConfidenceBrittle        = "brittle"
 	ratifyConfidenceNeverConfirmed = "never_confirmed"
 	ratifyConfidenceRefuted        = "refuted"
 )
@@ -256,10 +258,10 @@ func lowConfidenceRuleSummary(rules []contract.Rule) string {
 
 func isLowConfidenceRule(rule contract.Rule) bool {
 	switch strings.ToLower(strings.TrimSpace(rule.Confidence)) {
-	case ratifyConfidenceNeverConfirmed, ratifyConfidenceRefuted:
-		return true
-	default:
+	case ratifyConfidenceStable, ratifyConfidenceBrittle:
 		return false
+	default:
+		return true
 	}
 }
 

--- a/internal/cli/learn/ratify_forget_test.go
+++ b/internal/cli/learn/ratify_forget_test.go
@@ -182,7 +182,7 @@ func testRule(id, host, path string) contract.Rule {
 		LifecycleState:       "capture_only",
 		RequiredCaptureGrade: contract.CaptureGradeFull,
 		ObservedCaptureGrade: contract.CaptureGradeFull,
-		Confidence:           "high",
+		Confidence:           "stable",
 		WilsonLower:          "0.990000",
 		Observation:          map[string]any{"event_count": "21", "redacted_samples": []any{"sha256:sample"}},
 		Selector:             map[string]any{"host": host, "path": path},

--- a/internal/cli/learn/ratify_test.go
+++ b/internal/cli/learn/ratify_test.go
@@ -54,6 +54,38 @@ func TestRatifyLowConfidenceGuards(t *testing.T) {
 			wantErrRules: []string{"r-reject", testRatifyConfidenceRefuted},
 		},
 		{
+			name:         "non-interactive empty confidence refuses fail-closed",
+			confidences:  []string{testRatifyConfidenceStable, ""},
+			wantErr:      true,
+			wantErrRules: []string{"r-reject", "confidence="},
+		},
+		{
+			name:         "non-interactive novel confidence refuses fail-closed",
+			confidences:  []string{testRatifyConfidenceStable, "maybe_ok"},
+			wantErr:      true,
+			wantErrRules: []string{"r-reject", "maybe_ok"},
+		},
+		{
+			name:         "non-interactive homoglyph confidence refuses fail-closed",
+			confidences:  []string{testRatifyConfidenceStable, "stаble"},
+			wantErr:      true,
+			wantErrRules: []string{"r-reject", "stаble"},
+		},
+		{
+			name:         "non-interactive whitespace confidence refuses fail-closed",
+			confidences:  []string{testRatifyConfidenceStable, "   "},
+			wantErr:      true,
+			wantErrRules: []string{"r-reject", "confidence="},
+		},
+		{
+			name:        "non-interactive uppercase stable accepted via case-fold",
+			confidences: []string{testRatifyConfidenceStable, "STABLE"},
+			wantLifecycle: map[string]string{
+				"r-enforce": ratifyDecisionEnforce,
+				"r-reject":  ratifyDecisionEnforce,
+			},
+		},
+		{
 			name:                "non-interactive accept-low-confidence mixed enforces",
 			acceptLowConfidence: true,
 			confidences:         []string{testRatifyConfidenceStable, testRatifyConfidenceNeverConfirmed},

--- a/internal/cli/signing/key_generate.go
+++ b/internal/cli/signing/key_generate.go
@@ -35,6 +35,10 @@ const keyFileShortFingerprintHex = 8
 // accidental reads of large non-key files.
 const keyFileMaxSize = 16 * 1024
 
+// privateKeyDisallowedPermBits masks group-write, group-execute, and all world
+// bits. Group-read is allowed for Kubernetes fsGroup read-only mounts.
+const privateKeyDisallowedPermBits = 0o037
+
 // fingerprintPrefix is the canonical prefix on sha256 fingerprints emitted
 // by signing.Fingerprint and consumed by pinned-fingerprint config fields.
 const fingerprintPrefix = "sha256:"
@@ -269,7 +273,7 @@ func readKeyFileBytes(cleanPath string, requireSecretPerms bool) ([]byte, error)
 	if !info.Mode().IsRegular() {
 		return nil, fmt.Errorf("key file %q is not a regular file (mode=%s)", cleanPath, info.Mode())
 	}
-	if requireSecretPerms && info.Mode().Perm()&0o037 != 0 {
+	if requireSecretPerms && info.Mode().Perm()&privateKeyDisallowedPermBits != 0 {
 		return nil, fmt.Errorf("private key %s has permissions %04o, want 0600 or 0640 (run: chmod 640 %s)", cleanPath, info.Mode().Perm(), cleanPath)
 	}
 	if info.Size() > keyFileMaxSize {

--- a/internal/cli/signing/key_generate.go
+++ b/internal/cli/signing/key_generate.go
@@ -183,7 +183,7 @@ Examples:
 // cannot smuggle extra metadata past the loader.
 func loadKeyFile(path string, expectedPurpose domsigning.KeyPurpose) (*keyFile, ed25519.PublicKey, ed25519.PrivateKey, error) {
 	cleanPath := filepath.Clean(path)
-	raw, err := readKeyFileBytes(cleanPath)
+	raw, err := readKeyFileBytes(cleanPath, true)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("read key file %q: %w", cleanPath, err)
 	}
@@ -227,7 +227,7 @@ func loadKeyFile(path string, expectedPurpose domsigning.KeyPurpose) (*keyFile, 
 // has no purpose field, so callers fall back to the operator-supplied flag.
 func readPublicKeyForRoster(path string) ([]byte, string, error) {
 	cleanPath := filepath.Clean(path)
-	raw, err := readKeyFileBytes(cleanPath)
+	raw, err := readKeyFileBytes(cleanPath, false)
 	if err != nil {
 		return nil, "", fmt.Errorf("read public key %q: %w", cleanPath, err)
 	}
@@ -251,7 +251,7 @@ func readPublicKeyForRoster(path string) ([]byte, string, error) {
 	return pub, "", nil
 }
 
-func readKeyFileBytes(cleanPath string) ([]byte, error) {
+func readKeyFileBytes(cleanPath string, requireSecretPerms bool) ([]byte, error) {
 	// Open first so the subsequent Stat is on the same file descriptor
 	// (TOCTOU defense) AND so a non-regular file like a FIFO or device
 	// is detected before any read can block. Plain os.Stat + os.ReadFile
@@ -268,6 +268,9 @@ func readKeyFileBytes(cleanPath string) ([]byte, error) {
 	}
 	if !info.Mode().IsRegular() {
 		return nil, fmt.Errorf("key file %q is not a regular file (mode=%s)", cleanPath, info.Mode())
+	}
+	if requireSecretPerms && info.Mode().Perm()&0o037 != 0 {
+		return nil, fmt.Errorf("private key %s has permissions %04o, want 0600 or 0640 (run: chmod 640 %s)", cleanPath, info.Mode().Perm(), cleanPath)
 	}
 	if info.Size() > keyFileMaxSize {
 		return nil, fmt.Errorf("%w: got %d bytes, max %d", errKeyFileTooLarge, info.Size(), keyFileMaxSize)

--- a/internal/cli/signing/key_generate_test.go
+++ b/internal/cli/signing/key_generate_test.go
@@ -406,12 +406,61 @@ func TestReadKeyFileBytes_RejectsNonRegularFile(t *testing.T) {
 	// Directory is the most portable non-regular file; FIFOs require mkfifo
 	// which is platform-specific. Both fail the IsRegular() gate identically.
 	dir := t.TempDir()
-	_, err := readKeyFileBytes(dir)
+	_, err := readKeyFileBytes(dir, false)
 	if err == nil {
 		t.Fatalf("expected non-regular-file rejection on directory")
 	}
 	if !strings.Contains(err.Error(), "regular file") {
 		t.Errorf("err %q does not mention regular file", err.Error())
+	}
+}
+
+func TestReadKeyFileBytes_RejectsLoosePermissions(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		mode os.FileMode
+	}{
+		{name: "group write", mode: 0o620},
+		{name: "world read", mode: 0o604},
+		{name: "world writable", mode: 0o666},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "key.json")
+			if err := os.WriteFile(path, []byte("{}"), tc.mode); err != nil {
+				t.Fatalf("write key: %v", err)
+			}
+			if err := os.Chmod(path, tc.mode); err != nil {
+				t.Fatalf("chmod key: %v", err)
+			}
+			_, err := readKeyFileBytes(path, true)
+			if err == nil {
+				t.Fatalf("readKeyFileBytes accepted mode %04o", tc.mode)
+			}
+			if !strings.Contains(err.Error(), "permissions") {
+				t.Fatalf("err = %v, want permissions rejection", err)
+			}
+		})
+	}
+}
+
+func TestReadKeyFileBytes_AcceptsGroupReadPermissions(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "key.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	if err := os.Chmod(path, 0o640); err != nil { //nolint:gosec // test intentionally verifies k8s fsGroup-style 0640 is accepted.
+		t.Fatalf("chmod key: %v", err)
+	}
+	raw, err := readKeyFileBytes(path, true)
+	if err != nil {
+		t.Fatalf("readKeyFileBytes should accept 0640: %v", err)
+	}
+	if string(raw) != "{}" {
+		t.Fatalf("raw = %q, want {}", raw)
 	}
 }
 
@@ -423,7 +472,7 @@ func TestReadKeyFileBytes_RejectsOversizedFile(t *testing.T) {
 	if err := os.WriteFile(path, big, 0o600); err != nil {
 		t.Fatalf("write big: %v", err)
 	}
-	_, err := readKeyFileBytes(path)
+	_, err := readKeyFileBytes(path, false)
 	if err == nil {
 		t.Fatalf("expected oversize rejection")
 	}

--- a/internal/config/learn_lock.go
+++ b/internal/config/learn_lock.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LearnLockEnvironment binds a live-lock runtime to one deployment
+// environment. Tenant and DeploymentID may be explicit empty strings for
+// single-tenant deployments, but the YAML keys must still be present so
+// operators do not silently lose scoping by omission.
+//
+// All three fields are opaque-string identifiers compared by exact
+// byte-equality at manifest load time. They carry no path or URL
+// semantics, so values like "../staging" are accepted as-is and produce
+// no path-traversal effect; they just become a tuple component the
+// runtime mismatches against. There is no length cap at the schema
+// layer; YAML loading caps the input upstream.
+type LearnLockEnvironment struct {
+	ID           string `yaml:"id"`
+	Tenant       string `yaml:"tenant"`
+	DeploymentID string `yaml:"deployment_id"`
+}
+
+func (e *LearnLockEnvironment) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("learn_lock.environment must be a mapping with id, tenant, and deployment_id; migrate string form to environment: {id: <env>, tenant: \"\", deployment_id: \"\"}")
+	}
+
+	*e = LearnLockEnvironment{}
+	seen := map[string]bool{}
+	for i := 0; i < len(value.Content); i += 2 {
+		key := value.Content[i]
+		val := value.Content[i+1]
+		if seen[key.Value] {
+			return fmt.Errorf("learn_lock.environment.%s is duplicated", key.Value)
+		}
+		seen[key.Value] = true
+
+		var target *string
+		switch key.Value {
+		case "id":
+			target = &e.ID
+		case "tenant":
+			target = &e.Tenant
+		case "deployment_id":
+			target = &e.DeploymentID
+		default:
+			return fmt.Errorf("learn_lock.environment.%s is not supported", key.Value)
+		}
+		if val.Kind != yaml.ScalarNode || val.Tag != "!!str" {
+			return fmt.Errorf("learn_lock.environment.%s must be a string", key.Value)
+		}
+		*target = val.Value
+	}
+
+	for _, field := range []string{"id", "tenant", "deployment_id"} {
+		if !seen[field] {
+			return fmt.Errorf("learn_lock.environment.%s required; use an explicit empty string if intentionally unscoped", field)
+		}
+	}
+	return nil
+}

--- a/internal/config/learn_lock_test.go
+++ b/internal/config/learn_lock_test.go
@@ -4,6 +4,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -104,9 +106,9 @@ func TestValidate_LearnLockEnabledRequiresEveryField(t *testing.T) {
 			want: "roster_path must be an absolute path",
 		},
 		{
-			name: "missing environment",
-			mut:  func(l *LearnLock) { l.Environment = "" },
-			want: "learn_lock.environment required",
+			name: "missing environment id",
+			mut:  func(l *LearnLock) { l.Environment.ID = "" },
+			want: "learn_lock.environment.id required",
 		},
 		{
 			name: "missing pinned root fingerprint",
@@ -161,7 +163,7 @@ func TestValidate_LearnLockEnabledRequiresEveryField(t *testing.T) {
 				Mode:                  LockModeShadow,
 				StoreDir:              "/var/lib/pipelock/contracts",
 				RosterPath:            "/etc/pipelock/roster.json",
-				Environment:           "production",
+				Environment:           LearnLockEnvironment{ID: "production", Tenant: "acme", DeploymentID: "prod-us-1"},
 				PinnedRootFingerprint: validFP,
 				MinimumSignatures:     1,
 			}
@@ -184,7 +186,7 @@ func TestValidate_LearnLockEnabledHappyPath(t *testing.T) {
 		Mode:                  LockModeLive,
 		StoreDir:              "/var/lib/pipelock/contracts",
 		RosterPath:            "/etc/pipelock/roster.json",
-		Environment:           "production",
+		Environment:           LearnLockEnvironment{ID: "production", Tenant: "acme", DeploymentID: "prod-us-1"},
 		PinnedRootFingerprint: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 		MinimumSignatures:     2,
 	}
@@ -203,7 +205,7 @@ func TestValidate_LearnLockEnabledEmptyModeAccepted(t *testing.T) {
 		Mode:                  "",
 		StoreDir:              "/var/lib/pipelock/contracts",
 		RosterPath:            "/etc/pipelock/roster.json",
-		Environment:           "production",
+		Environment:           LearnLockEnvironment{ID: "production", Tenant: "", DeploymentID: ""},
 		PinnedRootFingerprint: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 	}
 	if err := cfg.Validate(); err != nil {
@@ -211,5 +213,132 @@ func TestValidate_LearnLockEnabledEmptyModeAccepted(t *testing.T) {
 	}
 	if cfg.LearnLock.EffectiveMode() != LockModeShadow {
 		t.Fatalf("empty Mode should resolve to shadow, got %q", cfg.LearnLock.EffectiveMode())
+	}
+}
+
+func TestLoad_LearnLockEnvironmentNestedSchema(t *testing.T) {
+	t.Parallel()
+	const validFP = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	base := `
+learn_lock:
+  enabled: true
+  mode: live
+  store_dir: /var/lib/pipelock/contracts
+  roster_path: /etc/pipelock/roster.json
+  pinned_root_fingerprint: ` + validFP + `
+  minimum_signatures: 1
+`
+	cases := []struct {
+		name      string
+		envYAML   string
+		wantID    string
+		wantTen   string
+		wantDep   string
+		wantError string
+	}{
+		{
+			name: "nested full tuple",
+			envYAML: `  environment:
+    id: production
+    tenant: acme
+    deployment_id: prod-us-1
+`,
+			wantID:  "production",
+			wantTen: "acme",
+			wantDep: "prod-us-1",
+		},
+		{
+			name: "explicit empty tuple scopes",
+			envYAML: `  environment:
+    id: production
+    tenant: ""
+    deployment_id: ""
+`,
+			wantID: "production",
+		},
+		{
+			name: "old string form rejected",
+			envYAML: `  environment: production
+`,
+			wantError: "must be a mapping",
+		},
+		{
+			name: "missing tenant rejected",
+			envYAML: `  environment:
+    id: production
+    deployment_id: prod-us-1
+`,
+			wantError: "environment.tenant required",
+		},
+		{
+			name: "missing deployment_id rejected",
+			envYAML: `  environment:
+    id: production
+    tenant: acme
+`,
+			wantError: "environment.deployment_id required",
+		},
+		{
+			name: "null tenant rejected",
+			envYAML: `  environment:
+    id: production
+    tenant: null
+    deployment_id: prod-us-1
+`,
+			wantError: "environment.tenant must be a string",
+		},
+		{
+			name: "unknown nested field rejected",
+			envYAML: `  environment:
+    id: production
+    tenant: acme
+    deployment_id: prod-us-1
+    cluster: acme
+`,
+			wantError: "environment.cluster is not supported",
+		},
+		{
+			name: "empty mapping rejected via missing-required-key",
+			envYAML: `  environment: {}
+`,
+			wantError: "environment.id required",
+		},
+		{
+			name: "duplicate key rejected",
+			envYAML: `  environment:
+    id: production
+    id: staging
+    tenant: acme
+    deployment_id: prod-us-1
+`,
+			wantError: "environment.id is duplicated",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "pipelock.yaml")
+			if err := os.WriteFile(path, []byte(base+tc.envYAML), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			cfg, err := Load(path)
+			if tc.wantError != "" {
+				if err == nil {
+					t.Fatalf("Load() err = nil, want %q", tc.wantError)
+				}
+				if !strings.Contains(err.Error(), tc.wantError) {
+					t.Fatalf("Load() err = %q, want substring %q", err, tc.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load(): %v", err)
+			}
+			got := cfg.LearnLock.Environment
+			if got.ID != tc.wantID || got.Tenant != tc.wantTen || got.DeploymentID != tc.wantDep {
+				t.Fatalf("environment = %+v, want id=%q tenant=%q deployment_id=%q", got, tc.wantID, tc.wantTen, tc.wantDep)
+			}
+		})
 	}
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1419,11 +1419,11 @@ type LearnLock struct {
 	RosterPath string `yaml:"roster_path"`
 
 	// Environment binds the lock runtime to a specific deployment
-	// environment string (e.g., "production", "staging"). The store
-	// rejects active manifests whose env field does not match, so a
-	// production cluster cannot accidentally enforce a staging
-	// contract. Required when Enabled is true.
-	Environment string `yaml:"environment"`
+	// environment tuple. The store rejects active manifests whose env
+	// tuple does not match, so a production cluster cannot accidentally
+	// enforce a staging or wrong-tenant contract. Required when Enabled
+	// is true.
+	Environment LearnLockEnvironment `yaml:"environment"`
 
 	// PinnedRootFingerprint is the canonical sha256 fingerprint of the
 	// trust roster root key: "sha256:" followed by 64 lowercase hex

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -250,8 +250,8 @@ func (c *Config) validateLearnLock() error {
 	if !filepath.IsAbs(l.RosterPath) {
 		return fmt.Errorf("learn_lock.roster_path must be an absolute path, got %q", l.RosterPath)
 	}
-	if l.Environment == "" {
-		return fmt.Errorf("learn_lock.environment required when learn_lock.enabled is true")
+	if l.Environment.ID == "" {
+		return fmt.Errorf("learn_lock.environment.id required when learn_lock.enabled is true")
 	}
 	if err := validateLockMode(l.Mode); err != nil {
 		return err

--- a/internal/contract/runtime/loader.go
+++ b/internal/contract/runtime/loader.go
@@ -231,6 +231,10 @@ func (l *Loader) Reload() error {
 	prev := l.current.Load()
 	opts := l.storeOpts
 	var activeState store.State
+	if err := l.validateActivePath(); err != nil {
+		l.metrics.IncReload(rejectionOutcome(err))
+		return fmt.Errorf("contract runtime: active manifest path: %w", err)
+	}
 	if prev != nil {
 		var err error
 		activeState, err = l.validateActiveReadOnly()
@@ -501,7 +505,37 @@ func rejectionOutcome(err error) string {
 	}
 }
 
+// validateActivePath rejects active manifest paths whose Lstat is anything
+// other than a regular file or absent. Symlinks, FIFOs, and device nodes
+// are refused so a hostile object planted at <storeDir>/active.json cannot
+// redirect the loader's read to attacker-controlled bytes.
+//
+// Threat-model assumption: the store directory is owner-only (0o700) on
+// the filesystem layer. A check-then-read race exists between this Lstat
+// and the subsequent manifest read; an attacker who can replace the regular
+// file with a symlink in that window could still redirect the read. Mitigation
+// lives in the operator runbook (chmod 0o700 the store dir owned by the
+// pipelock UID); a future O_NOFOLLOW + fstat path here closes the race
+// entirely. Tracked as a v2.4.1 hardening item.
+func (l *Loader) validateActivePath() error {
+	activePath := filepath.Clean(filepath.Join(l.storeDir, activeFilename))
+	info, err := os.Lstat(activePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("%w: stat active manifest: %w", store.ErrDecode, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%w: active manifest %s must be a regular file (mode=%s)", store.ErrStructural, activePath, info.Mode())
+	}
+	return nil
+}
+
 func (l *Loader) validateActiveReadOnly() (store.State, error) {
+	if err := l.validateActivePath(); err != nil {
+		return store.State{}, err
+	}
 	activePath := filepath.Clean(filepath.Join(l.storeDir, activeFilename))
 	raw, err := os.ReadFile(activePath)
 	if err != nil {

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -792,6 +792,71 @@ func TestNewLoader_FailsOnMalformedActiveManifest(t *testing.T) {
 	}
 }
 
+func TestNewLoader_RejectsActiveManifestSymlink(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.Root(), "store")
+	env := testLoaderEnv()
+	externalDir := t.TempDir()
+	writeSignedActiveStore(t, fixture, externalDir, 1, "sha256:genesis", env)
+	if err := os.MkdirAll(storeDir, 0o750); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(externalDir, activeFilename), filepath.Join(storeDir, activeFilename)); err != nil {
+		t.Fatalf("symlink active.json: %v", err)
+	}
+
+	_, err := NewLoader(loaderOptions(fixture, storeDir, env), nil)
+	if err == nil {
+		t.Fatal("NewLoader accepted active.json symlink")
+	}
+	if !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("err = %v, want regular-file rejection", err)
+	}
+}
+
+func TestLoader_ReloadRejectsActiveManifestSymlinkAndKeepsCurrent(t *testing.T) {
+	t.Parallel()
+	fixture := newRosterFixture(t)
+	storeDir := filepath.Join(fixture.Root(), "store")
+	env := testLoaderEnv()
+	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:genesis", env)
+
+	metrics := &captureMetrics{}
+	loader, err := NewLoader(loaderOptions(fixture, storeDir, env), metrics)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	current := loader.Current()
+	if current == nil {
+		t.Fatal("expected initial active set")
+	}
+
+	externalDir := t.TempDir()
+	writeSignedActiveStore(t, fixture, externalDir, 2, current.ManifestHash(), env)
+	activePath := filepath.Join(storeDir, activeFilename)
+	if err := os.Remove(activePath); err != nil {
+		t.Fatalf("remove active.json: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(externalDir, activeFilename), activePath); err != nil {
+		t.Fatalf("symlink active.json: %v", err)
+	}
+
+	err = loader.Reload()
+	if err == nil {
+		t.Fatal("Reload accepted active.json symlink")
+	}
+	if !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("err = %v, want regular-file rejection", err)
+	}
+	if loader.Current() != current {
+		t.Fatal("symlink rejection must preserve previous active set")
+	}
+	if metrics.outcome("rejected") != 1 {
+		t.Fatalf("rejected outcomes = %d, want 1", metrics.outcome("rejected"))
+	}
+}
+
 func TestLoader_Watch_FailsOnMissingStoreDir(t *testing.T) {
 	t.Parallel()
 	// Watch wires fsnotify.Add against the store directory at startup. A

--- a/internal/mcp/contractgate.go
+++ b/internal/mcp/contractgate.go
@@ -51,7 +51,9 @@ func NewContractLoaderFromConfig(cfg *config.Config) (*contractruntime.Loader, e
 		RosterPath:            cfg.LearnLock.RosterPath,
 		PinnedRootFingerprint: cfg.LearnLock.PinnedRootFingerprint,
 		Environment: contract.Environment{
-			ID: cfg.LearnLock.Environment,
+			ID:           cfg.LearnLock.Environment.ID,
+			Tenant:       cfg.LearnLock.Environment.Tenant,
+			DeploymentID: cfg.LearnLock.Environment.DeploymentID,
 		},
 		MinSignatures: cfg.LearnLock.EffectiveMinimumSignatures(),
 		Mode:          contractruntime.Mode(cfg.LearnLock.EffectiveMode()),

--- a/internal/mcp/mcp_livelock_test.go
+++ b/internal/mcp/mcp_livelock_test.go
@@ -123,7 +123,7 @@ func mcpLiveLockConfig(t *testing.T) *config.Config {
 	cfg.LearnLock.StoreDir = storeDir
 	cfg.LearnLock.RosterPath = fixture.RosterPath()
 	cfg.LearnLock.PinnedRootFingerprint = fixture.RootFingerprint()
-	cfg.LearnLock.Environment = env.ID
+	cfg.LearnLock.Environment = config.LearnLockEnvironment{ID: env.ID, Tenant: env.Tenant, DeploymentID: env.DeploymentID}
 	cfg.LearnLock.MinimumSignatures = 1
 	return cfg
 }

--- a/internal/proxy/contractgate.go
+++ b/internal/proxy/contractgate.go
@@ -144,7 +144,9 @@ func buildContractLoader(cfg *config.Config) (*contractruntime.Loader, error) {
 		RosterPath:            cfg.LearnLock.RosterPath,
 		PinnedRootFingerprint: cfg.LearnLock.PinnedRootFingerprint,
 		Environment: contract.Environment{
-			ID: cfg.LearnLock.Environment,
+			ID:           cfg.LearnLock.Environment.ID,
+			Tenant:       cfg.LearnLock.Environment.Tenant,
+			DeploymentID: cfg.LearnLock.Environment.DeploymentID,
 		},
 		MinSignatures: cfg.LearnLock.EffectiveMinimumSignatures(),
 		Mode:          contractruntime.Mode(cfg.LearnLock.EffectiveMode()),

--- a/internal/proxy/contractgate_test.go
+++ b/internal/proxy/contractgate_test.go
@@ -243,10 +243,13 @@ func TestBuildContractLoader_EnabledHappyPathReturnsLoader(t *testing.T) {
 	// signing scaffolding stays in one place across packages.
 	fixture := contractruntimetest.NewFixture(t)
 	storeDir := t.TempDir()
+	env := contractruntimetest.Env()
+	env.Tenant = "tenant-a"
+	env.DeploymentID = "deploy-a"
 	contractruntimetest.WriteSignedActiveStore(t, fixture, storeDir, contractruntimetest.ActiveStoreOptions{
 		Generation:  1,
 		PriorHash:   "sha256:genesis",
-		Environment: contractruntimetest.Env(),
+		Environment: env,
 	})
 
 	cfg := &config.Config{}
@@ -254,7 +257,7 @@ func TestBuildContractLoader_EnabledHappyPathReturnsLoader(t *testing.T) {
 	cfg.LearnLock.StoreDir = storeDir
 	cfg.LearnLock.RosterPath = fixture.RosterPath()
 	cfg.LearnLock.PinnedRootFingerprint = fixture.RootFingerprint()
-	cfg.LearnLock.Environment = "prod"
+	cfg.LearnLock.Environment = config.LearnLockEnvironment{ID: env.ID, Tenant: env.Tenant, DeploymentID: env.DeploymentID}
 	cfg.LearnLock.MinimumSignatures = 1
 	cfg.LearnLock.Mode = "live"
 


### PR DESCRIPTION
## Summary

Switches live-lock config to the nested `learn_lock.environment` schema used by runtime validation: `id`, `tenant`, and `deployment_id`.

Updates promote, proxy, MCP, and runtime wiring so promoted manifests and deployment config compare the same environment tuple.

## Changes

- Allows explicit empty `tenant` and `deployment_id` values for unscoped deployments.
- Rejects the old string-form environment with a direct migration error.
- Tightens ratify confidence handling to the accepted allowlist.
- Rejects unsafe `active.json` filesystem entries before loading.
- Enforces private-key file permissions for roster CLI JSON key files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment configuration now uses a structured tuple (id, tenant, deployment_id) for learn_lock.

* **Bug Fixes**
  * Stricter validation for key file permissions (allowing 0600/0640).
  * Runtime validation to reject non-regular manifest files (e.g., symlinks).

* **Documentation**
  * Clarified nested learn_lock.environment usage, examples, and legacy-form rejection.

* **Chores**
  * Updated CLI help text about environment inheritance and empty/unscoped values.

* **Tests**
  * Added/expanded tests for environment parsing, ratification confidence, key permissions, and manifest loader behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->