### PR TITLE
ci: pin release build to Go 1.25.10 for stdlib security fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25'
+          go-version: '1.25.10'
 
       - name: Verify dependencies
         run: go mod verify


### PR DESCRIPTION
## Summary

Pin `.github/workflows/release.yaml` from `go-version: '1.25'` to `'1.25.10'` so the v2.4.0 (and subsequent) release artifacts are built with the May 7, 2026 stdlib security fixes baked in.

govulncheck against the current `main` flags 8 advisories with call traces into pipelock's actual code paths:

| Advisory | Component | Pipelock surface |
|---|---|---|
| GO-2026-4976 | `net/http/httputil` ReverseProxy query forwarding | `internal/proxy/reverse.go` |
| GO-2026-4918 | HTTP/2 transport infinite loop on bad SETTINGS_MAX_FRAME_SIZE | every outbound HTTPS path |
| GO-2026-4982 | `html/template` meta content URL escaping bypass | indirect |
| GO-2026-4980 | `html/template` escaper bypass | indirect |
| GO-2026-4981 | `net` long-CNAME crash | DNS resolution |
| GO-2026-4971 | `net` Windows NUL panic | non-applicable on Linux/darwin runners |
| GO-2026-4986 | `net/mail` quadratic comment concat | indirect |
| GO-2026-4977 | `net/mail` quadratic phrase concat | indirect |

All eight are fixed in stdlib `go1.25.10` and `go1.26.3` per `vuln.go.dev`.

## Why exact pin, not `'1.25'`

`actions/setup-go` resolves a floating `'1.25'` constraint against the runner's local tool cache *first* (without `check-latest: true`). On a runner with a cached older 1.25.x layer that policy can silently produce an unpatched binary even after 1.25.10 ships. Exact pin removes that ambiguity and makes the embedded `GOVERSION` ldflag deterministic across builds.

## Why not bumping to `'1.26.3'` here

Larger change immediately before tag. CI matrix (`['1.25', '1.26']` in `ci.yaml`) already proves we build and test green on both lines, so a deliberate move to 1.26 can land after v2.4 without time pressure.

## Scope

One line, `.github/workflows/release.yaml` only. CI matrix unchanged (still tests both 1.25 and 1.26 floating). `go.mod` `go 1.25.0` directive unchanged so SDK consumers on Go 1.25 keep working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration to enhance consistency and reliability of release processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/496)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->