### PR TITLE
docs: drop coverage % stat from public README

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ Pipelock is tested like a security product. The open-source core has thousands o
 | Metric | Value |
 |--------|-------|
 | Go tests (with `-race`) | Thousands across unit, integration, and end-to-end paths |
-| Statement coverage | 88%+ |
+| Releases shipped | 40 (current: v2.4.0) |
 | Evasion techniques tested | 230+ |
 | Scanner pipeline overhead | ~40us per URL scan |
 | CI matrix | Go 1.25 + 1.26, CodeQL, golangci-lint |


### PR DESCRIPTION
CLAUDE.local "no coverage % on public surfaces". Same fix already landed on the pipelab.org site (data/stats.yaml + about/index/enterprise templates + comparison page). Pipelock README testing table previously listed "Statement coverage | 88%+", which is the same class of public-surface leak.

## Changes

- `README.md`: replace "Statement coverage | 88%+" row with "Releases shipped | 40 (current: v2.4.0)". Preserves grid layout; the table still communicates maturity using a non-leaky stat.

## Not changed

- Test counts, evasion-techniques counts, scanner overhead, CI matrix, supply-chain rows.
- No code, lint, or test surface touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with current version v2.4.0 and release metrics reflecting 40 completed releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/497)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->