### PR TITLE
feat(sdk): publish Audit Packet v0 schema with Go bindings

### DIFF
--- a/sdk/audit-packet/CHANGELOG.md
+++ b/sdk/audit-packet/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Audit Packet schema changelog
+
+Schema versions are independent from pipelock binary releases. Producers stamp the schema
+version into every packet under `schema_version`.
+
+## v0 — initial release
+
+`schema_version`: `pipelock.audit_packet.v0`
+
+Locks:
+
+- Top-level required: `schema_version`, `generated_at`, `run`, `policy`, `summary`,
+  `verifier`, `posture`, `artifacts`. Top-level `additionalProperties: false`.
+- Eight verdict buckets in `summary.totals`: `allow`, `block`, `warn`, `ask`, `strip`,
+  `forward`, `redirect`, `other`. All eight are required, even when zero.
+- Verifier verdict enum: `valid`, `invalid`, `error`, `not_run`, `self_consistent_only`.
+- `verifier.trusted` is true only when `verdict` is `valid` AND a long-lived signer public
+  key was pinned at verification time.
+- Posture status enums for `raw_socket_status`, `docker_socket_status`, `dns_udp_status`,
+  `browser_proxy_status` (each includes an `unknown` value for "not probed").
+- `enforcement_mode` is free-form (linux_netns_iptables_setpriv is the v0 reference).
+- `policy.policy_hashes` is plural because hot-reload can change policy mid-run.
+
+v0 deliberately leaves these for later schema versions: multi-agent rollups, framework
+mappings, embedded transparency-log inclusion proofs, OTel SemConv field name aliasing.

--- a/sdk/audit-packet/CHANGELOG.md
+++ b/sdk/audit-packet/CHANGELOG.md
@@ -17,7 +17,9 @@ Locks:
 - `verifier.trusted` is required. It is true only when `verdict` is `valid` AND a long-lived
   signer public key was pinned at verification time.
 - Posture status enums for `raw_socket_status`, `docker_socket_status`, `dns_udp_status`,
-  `browser_proxy_status` (each is required and includes an `unknown` value for "not probed").
+  `browser_proxy_status`, and `websocket_frame_scanning` (each is required and includes
+  an explicit value for "not probed" or "off"; the four status enums use `unknown`,
+  `websocket_frame_scanning` uses `off`).
 - `unsupported_paths` is required; emit an empty array when no unsupported paths are known.
 - `enforcement_mode` is free-form (linux_netns_iptables_setpriv is the v0 reference).
 - `policy.policy_hashes` is plural because hot-reload can change policy mid-run.

--- a/sdk/audit-packet/CHANGELOG.md
+++ b/sdk/audit-packet/CHANGELOG.md
@@ -14,10 +14,11 @@ Locks:
 - Eight verdict buckets in `summary.totals`: `allow`, `block`, `warn`, `ask`, `strip`,
   `forward`, `redirect`, `other`. All eight are required, even when zero.
 - Verifier verdict enum: `valid`, `invalid`, `error`, `not_run`, `self_consistent_only`.
-- `verifier.trusted` is true only when `verdict` is `valid` AND a long-lived signer public
-  key was pinned at verification time.
+- `verifier.trusted` is required. It is true only when `verdict` is `valid` AND a long-lived
+  signer public key was pinned at verification time.
 - Posture status enums for `raw_socket_status`, `docker_socket_status`, `dns_udp_status`,
-  `browser_proxy_status` (each includes an `unknown` value for "not probed").
+  `browser_proxy_status` (each is required and includes an `unknown` value for "not probed").
+- `unsupported_paths` is required; emit an empty array when no unsupported paths are known.
 - `enforcement_mode` is free-form (linux_netns_iptables_setpriv is the v0 reference).
 - `policy.policy_hashes` is plural because hot-reload can change policy mid-run.
 

--- a/sdk/audit-packet/CHANGELOG.md
+++ b/sdk/audit-packet/CHANGELOG.md
@@ -21,6 +21,9 @@ Locks:
   an explicit value for "not probed" or "off"; the four status enums use `unknown`,
   `websocket_frame_scanning` uses `off`).
 - `unsupported_paths` is required; emit an empty array when no unsupported paths are known.
+- Artifact paths in the `artifacts` block must stay inside the packet directory. The
+  validator rejects empty paths (where required), absolute paths, Windows-style paths
+  (backslash or colon), and `..` traversal.
 - `enforcement_mode` is free-form (linux_netns_iptables_setpriv is the v0 reference).
 - `policy.policy_hashes` is plural because hot-reload can change policy mid-run.
 

--- a/sdk/audit-packet/README.md
+++ b/sdk/audit-packet/README.md
@@ -1,0 +1,114 @@
+# Pipelock Audit Packet v0
+
+The Audit Packet is the evidence bundle Pipelock writes after a Pipelock-mediated agent run.
+It pairs a verifier verdict from the signed receipt chain with the enforcement posture that
+produced it, so a relying party (CISO, auditor, downstream platform) can decide whether the
+run is trustworthy without re-running the agent.
+
+This directory holds the locked v0 spec.
+
+| File          | What it is                                                              |
+| ------------- | ----------------------------------------------------------------------- |
+| `v0.json`     | JSON Schema (draft 2020-12). The canonical contract.                    |
+| `example.json`| Fully populated minimal packet that conforms to `v0.json`.              |
+| `audit_packet.go` | Go bindings (struct tags match `v0.json` field names).              |
+| `CHANGELOG.md`| Schema-version history. Independent of pipelock binary versions.        |
+
+## Where packets come from
+
+The first packet producer is the
+[`pipelock-agent-egress-action`](https://github.com/luckyPipewrench/pipelock-agent-egress-action)
+GitHub Action. It runs an agent script under a Linux netns + iptables + setpriv boundary,
+emits signed receipts via Pipelock's flight recorder, runs the receipt verifier after exit,
+and writes the four artifact files below into the Audit Packet directory:
+
+| File             | What                                                                  |
+| ---------------- | --------------------------------------------------------------------- |
+| `packet.json`    | The structured packet that conforms to this schema.                   |
+| `summary.md`     | Human-readable summary of `packet.json` for PR reviewers.             |
+| `evidence.jsonl` | Byte-for-byte receipt chain (one `action_receipt` per line).          |
+| `verifier.txt`   | Raw stdout/stderr from `pipelock verify-receipt`.                     |
+
+`packet.json` is the entry point. `evidence.jsonl` is the underlying signed input.
+
+## What the schema enforces
+
+The schema is the contract between producers (the action, future producers) and consumers
+(verifiers, SIEM exporters, compliance evidence pipelines). It locks down:
+
+- **Top-level shape.** Required: `schema_version`, `generated_at`, `run`, `policy`, `summary`,
+  `verifier`, `posture`, `artifacts`. Optional: `packet_id`, `receipts`, `scanner_config_snapshot`.
+- **Verdict bucket set.** Eight buckets keyed by pipelock's seven `config.Action*` constants
+  (`allow`, `block`, `warn`, `ask`, `strip`, `forward`, `redirect`) plus `other` for unrecognized
+  verdicts. Producers MUST emit all eight keys, even when zero, so consumers can sum without
+  nil-checks.
+- **Verifier verdict enum.** `valid`, `invalid`, `error`, `not_run`, `self_consistent_only`.
+  `self_consistent_only` is required: it captures the realistic case where a chain hashes
+  correctly but no signer key was pinned — the chain proves internal consistency, not Pipelock
+  provenance. Consumers that conflate this with `valid` defeat the whole point of pinning.
+- **Posture status enums.** `raw_socket_status`, `docker_socket_status`, `dns_udp_status`,
+  `browser_proxy_status` each have a closed enum that distinguishes "denied" from "unknown".
+  Producers MUST NOT emit "unknown" for a path they did not probe AND treat that as evidence;
+  consumers reading "unknown" treat it as no claim, not as a denial.
+- **`additionalProperties: false`** at the top level and on most nested objects. Schema-version
+  bumps add fields; v0 packets must NOT silently smuggle unknown fields.
+
+## Rationale
+
+`v0.json` was reconciled from two earlier drafts:
+
+1. A schema sketch favoring 3-bucket totals and nested `run` / `policy` / `summary`.
+2. The shape the action repo's `audit-packet.sh` actually emits (8-bucket totals, flat top
+   level, `verifier.trusted` boolean, additional posture runtime fields).
+
+The merged spec keeps the impl's 8-bucket totals (each maps 1:1 to a `config.Action*` constant
+— summarizing `strip` and `redirect` into `block` would lose forensic granularity), the draft's
+nested `run` / `policy` blocks (so a CISO can ctrl-F `policy_hash` and find it in one section),
+and the impl's `self_consistent_only` verdict (it already happens; consumers need to model it).
+
+Posture-claim fields from the draft (`raw_socket_status`, `docker_socket_status`, etc.) are
+required because the packet's job is to document _what was enforced_, not just _what the
+receipts said_. A clean receipt chain under a posture that admits unsupported paths is weaker
+evidence than the same chain under stricter posture, and the schema needs to make that
+visible to relying parties.
+
+## Validating a packet
+
+The Go binding lives in this directory:
+
+```go
+import "github.com/luckyPipewrench/pipelock/sdk/auditpacket"
+
+var p auditpacket.Packet
+if err := json.Unmarshal(data, &p); err != nil {
+    return err
+}
+if err := p.Validate(); err != nil {
+    return err
+}
+```
+
+`Packet.Validate()` enforces structural invariants the JSON Schema also enforces (required
+fields, enum values, totals key set). For full schema-level validation, run any JSON Schema
+2020-12 validator against `v0.json`; we do not ship a validator dependency in pipelock to
+keep the direct-dependency count minimal.
+
+## Versioning
+
+Schema versions are independent from pipelock binary releases. The schema_version constant
+(`pipelock.audit_packet.v0`) MUST NOT change across pipelock minor or patch releases. A v1
+schema would be a new file at `sdk/audit-packet/v1.json`.
+
+See [CHANGELOG.md](CHANGELOG.md) for what each schema version locks down.
+
+## Out of scope for v0
+
+- **Multi-agent rollups.** v0 packets describe a single agent run. Cross-run aggregation
+  is a Pro-tier feature and lives in a future `audit_packet_rollup_v0.json` schema.
+- **Framework mappings (OWASP, NIST, EU AI Act).** Pro-tier producers MAY add a top-level
+  `framework_mappings` field; v0 ignores it (because of `additionalProperties: false`, that
+  field is rejected, so Pro outputs MUST emit a different `schema_version` such as
+  `pipelock.audit_packet.v0_pro`).
+- **Inline transparency-log proof.** v0 includes `verifier.root_hash` so relying parties can
+  anchor the chain externally, but the packet itself does not embed transparency-log inclusion
+  proofs. v1 candidate.

--- a/sdk/audit-packet/README.md
+++ b/sdk/audit-packet/README.md
@@ -47,9 +47,12 @@ The schema is the contract between producers (the action, future producers) and 
   correctly but no signer key was pinned — the chain proves internal consistency, not Pipelock
   provenance. Consumers that conflate this with `valid` defeat the whole point of pinning.
 - **Posture status enums.** `raw_socket_status`, `docker_socket_status`, `dns_udp_status`,
-  `browser_proxy_status` each have a closed enum that distinguishes "denied" from "unknown".
-  Producers MUST emit these fields; if they did not probe a path, they emit `unknown`.
-  Consumers reading `unknown` treat it as no claim, not as a denial.
+  `browser_proxy_status`, and `websocket_frame_scanning` each have a closed enum.
+  Producers MUST emit all five plus `unsupported_paths`; the first four use `unknown` for
+  "not probed" and `websocket_frame_scanning` uses `off`. `unsupported_paths` is a
+  required array of egress vectors the producer explicitly does not enforce; emit an
+  empty array when none are known. Consumers reading `unknown` treat it as no claim,
+  not as a denial.
 - **Verifier trust semantics.** `verifier.trusted` is required. `verdict=valid` requires
   `trusted=true` and a signer key; all other verifier verdicts require `trusted=false`.
 - **`additionalProperties: false`** at the top level and on most nested objects. Schema-version

--- a/sdk/audit-packet/README.md
+++ b/sdk/audit-packet/README.md
@@ -48,8 +48,10 @@ The schema is the contract between producers (the action, future producers) and 
   provenance. Consumers that conflate this with `valid` defeat the whole point of pinning.
 - **Posture status enums.** `raw_socket_status`, `docker_socket_status`, `dns_udp_status`,
   `browser_proxy_status` each have a closed enum that distinguishes "denied" from "unknown".
-  Producers MUST NOT emit "unknown" for a path they did not probe AND treat that as evidence;
-  consumers reading "unknown" treat it as no claim, not as a denial.
+  Producers MUST emit these fields; if they did not probe a path, they emit `unknown`.
+  Consumers reading `unknown` treat it as no claim, not as a denial.
+- **Verifier trust semantics.** `verifier.trusted` is required. `verdict=valid` requires
+  `trusted=true` and a signer key; all other verifier verdicts require `trusted=false`.
 - **`additionalProperties: false`** at the top level and on most nested objects. Schema-version
   bumps add fields; v0 packets must NOT silently smuggle unknown fields.
 
@@ -66,18 +68,18 @@ The merged spec keeps the impl's 8-bucket totals (each maps 1:1 to a `config.Act
 nested `run` / `policy` blocks (so a CISO can ctrl-F `policy_hash` and find it in one section),
 and the impl's `self_consistent_only` verdict (it already happens; consumers need to model it).
 
-Posture-claim fields from the draft (`raw_socket_status`, `docker_socket_status`, etc.) are
-required because the packet's job is to document _what was enforced_, not just _what the
-receipts said_. A clean receipt chain under a posture that admits unsupported paths is weaker
-evidence than the same chain under stricter posture, and the schema needs to make that
-visible to relying parties.
+Posture-claim fields from the draft (`raw_socket_status`, `docker_socket_status`, etc.) and
+`unsupported_paths` are required because the packet's job is to document _what was enforced_,
+not just _what the receipts said_. A clean receipt chain under a posture that admits
+unsupported paths is weaker evidence than the same chain under stricter posture, and the
+schema needs to make that visible to relying parties.
 
 ## Validating a packet
 
 The Go binding lives in this directory:
 
 ```go
-import "github.com/luckyPipewrench/pipelock/sdk/auditpacket"
+import auditpacket "github.com/luckyPipewrench/pipelock/sdk/audit-packet"
 
 var p auditpacket.Packet
 if err := json.Unmarshal(data, &p); err != nil {
@@ -88,10 +90,12 @@ if err := p.Validate(); err != nil {
 }
 ```
 
-`Packet.Validate()` enforces structural invariants the JSON Schema also enforces (required
-fields, enum values, totals key set). For full schema-level validation, run any JSON Schema
-2020-12 validator against `v0.json`; we do not ship a validator dependency in pipelock to
-keep the direct-dependency count minimal.
+`Packet.Validate()` enforces structural invariants the JSON Schema also enforces: required
+semantic fields, enum values, non-negative counts, verifier trust semantics, summary total
+consistency, sorted unique domains, and artifact path containment. For full schema-level
+validation, including JSON key presence and `additionalProperties: false`, run any JSON
+Schema 2020-12 validator against `v0.json`; we do not ship a validator dependency in
+pipelock to keep the direct-dependency count minimal.
 
 ## Versioning
 

--- a/sdk/audit-packet/audit_packet.go
+++ b/sdk/audit-packet/audit_packet.go
@@ -6,7 +6,9 @@ package auditpacket
 import (
 	"errors"
 	"fmt"
+	"path"
 	"sort"
+	"strings"
 )
 
 // SchemaVersion is the locked identifier producers stamp into every v0 packet.
@@ -50,6 +52,13 @@ const (
 	StatusAdvisory = "advisory"
 )
 
+// WebSocket frame-scanning posture values.
+const (
+	WebsocketFrameScanningExplicitProxyPathRequired = "explicit_ws_proxy_path_required"
+	WebsocketFrameScanningAlwaysOn                  = "always_on"
+	WebsocketFrameScanningOff                       = "off"
+)
+
 // totalsKeys is the locked v0 set. All eight keys MUST be present in
 // summary.totals, even when zero.
 var totalsKeys = []string{
@@ -76,6 +85,40 @@ var validProviders = map[string]struct{}{
 	ProviderGitHubActions: {},
 	ProviderSelfHosted:    {},
 	ProviderLocal:         {},
+}
+
+var validRawSocketStatuses = map[string]struct{}{
+	StatusDenied:  {},
+	StatusAllowed: {},
+	StatusUnknown: {},
+}
+
+var validDockerSocketStatuses = map[string]struct{}{
+	StatusDenied:  {},
+	StatusMasked:  {},
+	StatusAllowed: {},
+	StatusAbsent:  {},
+	StatusUnknown: {},
+}
+
+var validDNSUDPStatuses = map[string]struct{}{
+	StatusDenied:  {},
+	StatusProxied: {},
+	StatusAllowed: {},
+	StatusUnknown: {},
+}
+
+var validBrowserProxyStatuses = map[string]struct{}{
+	StatusForced:   {},
+	StatusAdvisory: {},
+	StatusAbsent:   {},
+	StatusUnknown:  {},
+}
+
+var validWebsocketFrameScanning = map[string]struct{}{
+	WebsocketFrameScanningExplicitProxyPathRequired: {},
+	WebsocketFrameScanningAlwaysOn:                  {},
+	WebsocketFrameScanningOff:                       {},
 }
 
 // Packet is the top-level audit packet structure. Field tags match the JSON
@@ -191,11 +234,11 @@ type Posture struct {
 	EnforcementMode        string   `json:"enforcement_mode"`
 	RunnerOS               string   `json:"runner_os"`
 	RunnerArch             string   `json:"runner_arch,omitempty"`
-	RawSocketStatus        string   `json:"raw_socket_status,omitempty"`
-	DockerSocketStatus     string   `json:"docker_socket_status,omitempty"`
-	DNSUDPStatus           string   `json:"dns_udp_status,omitempty"`
-	BrowserProxyStatus     string   `json:"browser_proxy_status,omitempty"`
-	WebsocketFrameScanning string   `json:"websocket_frame_scanning,omitempty"`
+	RawSocketStatus        string   `json:"raw_socket_status"`
+	DockerSocketStatus     string   `json:"docker_socket_status"`
+	DNSUDPStatus           string   `json:"dns_udp_status"`
+	BrowserProxyStatus     string   `json:"browser_proxy_status"`
+	WebsocketFrameScanning string   `json:"websocket_frame_scanning"`
 	NetworkNamespace       string   `json:"network_namespace,omitempty"`
 	AgentUser              string   `json:"agent_user,omitempty"`
 	AgentUID               int      `json:"agent_uid,omitempty"`
@@ -206,7 +249,7 @@ type Posture struct {
 	ProxyURL               string   `json:"proxy_url,omitempty"`
 	ScriptBasename         string   `json:"script_basename,omitempty"`
 	ScriptArgCount         int      `json:"script_arg_count,omitempty"`
-	UnsupportedPaths       []string `json:"unsupported_paths,omitempty"`
+	UnsupportedPaths       []string `json:"unsupported_paths"`
 }
 
 // Artifacts records relative paths to sibling files in the audit packet
@@ -242,6 +285,16 @@ func (p *Packet) Validate() error {
 	}
 	if err := p.Verifier.validate(); err != nil {
 		return fmt.Errorf("auditpacket: verifier: %w", err)
+	}
+	for i, receipt := range p.Receipts {
+		if err := receipt.validate(); err != nil {
+			return fmt.Errorf("auditpacket: receipts[%d]: %w", i, err)
+		}
+	}
+	if p.ScannerConfigSnapshot != nil {
+		if err := p.ScannerConfigSnapshot.validate(); err != nil {
+			return fmt.Errorf("auditpacket: scanner_config_snapshot: %w", err)
+		}
 	}
 	if err := p.Posture.validate(); err != nil {
 		return fmt.Errorf("auditpacket: posture: %w", err)
@@ -284,6 +337,25 @@ func (s Summary) validate() error {
 		s.Totals.Redirect < 0 || s.Totals.Other < 0 {
 		return errors.New("totals counts must be non-negative")
 	}
+	totalReceipts := s.Totals.Allow + s.Totals.Block + s.Totals.Warn + s.Totals.Ask +
+		s.Totals.Strip + s.Totals.Forward + s.Totals.Redirect + s.Totals.Other
+	if totalReceipts != s.ReceiptCount {
+		return fmt.Errorf("totals sum %d does not match receipt_count %d", totalReceipts, s.ReceiptCount)
+	}
+	if err := validateCountsMap("transports", s.Transports); err != nil {
+		return err
+	}
+	if err := validateCountsMap("layers", s.Layers); err != nil {
+		return err
+	}
+	if !sort.StringsAreSorted(s.DomainsTouched) {
+		return errors.New("domains_touched must be sorted")
+	}
+	for i := 1; i < len(s.DomainsTouched); i++ {
+		if s.DomainsTouched[i] == s.DomainsTouched[i-1] {
+			return fmt.Errorf("domains_touched contains duplicate %q", s.DomainsTouched[i])
+		}
+	}
 	return nil
 }
 
@@ -296,6 +368,50 @@ func (v Verifier) validate() error {
 	if v.Trusted && v.Verdict != VerdictValid {
 		return fmt.Errorf("trusted=true requires verdict=valid, got %q", v.Verdict)
 	}
+	if v.Verdict == VerdictValid && !v.Trusted {
+		return errors.New("verdict=valid requires trusted=true")
+	}
+	if v.Trusted && v.SignerKey == "" {
+		return errors.New("trusted=true requires signer_key")
+	}
+	if v.ReceiptCount < 0 {
+		return errors.New("receipt_count must be non-negative")
+	}
+	if v.FinalSeq < 0 {
+		return errors.New("final_seq must be non-negative")
+	}
+	return nil
+}
+
+func (r Receipt) validate() error {
+	if r.ActionID == "" {
+		return errors.New("action_id is required")
+	}
+	if r.ReceiptHash == "" {
+		return errors.New("receipt_hash is required")
+	}
+	if r.ChainSeq < 0 {
+		return errors.New("chain_seq must be non-negative")
+	}
+	if r.ChainPrevHash == "" {
+		return errors.New("chain_prev_hash is required")
+	}
+	if r.Verdict == "" {
+		return errors.New("verdict is required")
+	}
+	if r.PolicyHash == "" {
+		return errors.New("policy_hash is required")
+	}
+	return nil
+}
+
+func (s ScannerConfigSnapshot) validate() error {
+	if s.DLPPatternsCount < 0 {
+		return errors.New("dlp_patterns_count must be non-negative")
+	}
+	if s.ResponsePatternsCount < 0 {
+		return errors.New("response_patterns_count must be non-negative")
+	}
 	return nil
 }
 
@@ -306,18 +422,75 @@ func (p Posture) validate() error {
 	if p.RunnerOS == "" {
 		return errors.New("runner_os is required")
 	}
+	if err := validateEnum("raw_socket_status", p.RawSocketStatus, validRawSocketStatuses); err != nil {
+		return err
+	}
+	if err := validateEnum("docker_socket_status", p.DockerSocketStatus, validDockerSocketStatuses); err != nil {
+		return err
+	}
+	if err := validateEnum("dns_udp_status", p.DNSUDPStatus, validDNSUDPStatuses); err != nil {
+		return err
+	}
+	if err := validateEnum("browser_proxy_status", p.BrowserProxyStatus, validBrowserProxyStatuses); err != nil {
+		return err
+	}
+	if err := validateEnum("websocket_frame_scanning", p.WebsocketFrameScanning, validWebsocketFrameScanning); err != nil {
+		return err
+	}
+	if p.ScriptArgCount < 0 {
+		return errors.New("script_arg_count must be non-negative")
+	}
+	if p.UnsupportedPaths == nil {
+		return errors.New("unsupported_paths is required (use empty array, not null)")
+	}
 	return nil
 }
 
 func (a Artifacts) validate() error {
-	if a.Packet == "" {
-		return errors.New("packet path is required")
+	return errors.Join(
+		validateArtifactPath("packet", a.Packet),
+		validateOptionalArtifactPath("summary", a.Summary),
+		validateArtifactPath("evidence", a.Evidence),
+		validateArtifactPath("verifier", a.Verifier),
+	)
+}
+
+func validateCountsMap(name string, counts map[string]int) error {
+	for key, count := range counts {
+		if count < 0 {
+			return fmt.Errorf("%s[%q] must be non-negative", name, key)
+		}
 	}
-	if a.Evidence == "" {
-		return errors.New("evidence path is required")
+	return nil
+}
+
+func validateEnum(name, value string, valid map[string]struct{}) error {
+	if _, ok := valid[value]; ok {
+		return nil
 	}
-	if a.Verifier == "" {
-		return errors.New("verifier path is required")
+	return fmt.Errorf("%s %q is not a valid v0 value", name, value)
+}
+
+func validateArtifactPath(name, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s path is required", name)
+	}
+	return validateOptionalArtifactPath(name, value)
+}
+
+func validateOptionalArtifactPath(name, value string) error {
+	if value == "" {
+		return nil
+	}
+	if strings.Contains(value, "\\") || strings.Contains(value, ":") {
+		return fmt.Errorf("%s path must be slash-relative inside the packet directory", name)
+	}
+	if path.IsAbs(value) {
+		return fmt.Errorf("%s path must be relative", name)
+	}
+	clean := path.Clean(value)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return fmt.Errorf("%s path must stay inside the packet directory", name)
 	}
 	return nil
 }

--- a/sdk/audit-packet/audit_packet.go
+++ b/sdk/audit-packet/audit_packet.go
@@ -1,0 +1,353 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package auditpacket
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// SchemaVersion is the locked identifier producers stamp into every v0 packet.
+// Consumers MUST reject packets whose schema_version does not match exactly.
+const SchemaVersion = "pipelock.audit_packet.v0"
+
+// Verifier verdict values. Producers MUST emit exactly one of these.
+const (
+	VerdictValid              = "valid"
+	VerdictInvalid            = "invalid"
+	VerdictError              = "error"
+	VerdictNotRun             = "not_run"
+	VerdictSelfConsistentOnly = "self_consistent_only"
+)
+
+// Run provider values for github_actions, self_hosted, and local. Other
+// providers extend the enum in a future schema version, not v0.
+const (
+	ProviderGitHubActions = "github_actions"
+	ProviderSelfHosted    = "self_hosted"
+	ProviderLocal         = "local"
+)
+
+// Posture status enum values shared across the four status fields.
+const (
+	StatusUnknown = "unknown"
+
+	// StatusDenied / StatusAllowed apply to raw_socket_status and dns_udp_status.
+	StatusDenied  = "denied"
+	StatusAllowed = "allowed"
+
+	// StatusMasked / StatusAbsent apply to docker_socket_status only.
+	StatusMasked = "masked"
+	StatusAbsent = "absent"
+
+	// StatusProxied applies to dns_udp_status and browser_proxy_status.
+	StatusProxied = "proxied"
+
+	// StatusForced / StatusAdvisory apply to browser_proxy_status only.
+	StatusForced   = "forced"
+	StatusAdvisory = "advisory"
+)
+
+// totalsKeys is the locked v0 set. All eight keys MUST be present in
+// summary.totals, even when zero.
+var totalsKeys = []string{
+	"allow",
+	"block",
+	"warn",
+	"ask",
+	"strip",
+	"forward",
+	"redirect",
+	"other",
+}
+
+// validVerdicts mirrors the verifier.verdict enum in v0.json.
+var validVerdicts = map[string]struct{}{
+	VerdictValid:              {},
+	VerdictInvalid:            {},
+	VerdictError:              {},
+	VerdictNotRun:             {},
+	VerdictSelfConsistentOnly: {},
+}
+
+var validProviders = map[string]struct{}{
+	ProviderGitHubActions: {},
+	ProviderSelfHosted:    {},
+	ProviderLocal:         {},
+}
+
+// Packet is the top-level audit packet structure. Field tags match the JSON
+// field names in v0.json exactly.
+type Packet struct {
+	SchemaVersion         string                 `json:"schema_version"`
+	PacketID              string                 `json:"packet_id,omitempty"`
+	GeneratedAt           string                 `json:"generated_at"`
+	Run                   Run                    `json:"run"`
+	Policy                Policy                 `json:"policy"`
+	Summary               Summary                `json:"summary"`
+	Verifier              Verifier               `json:"verifier"`
+	Receipts              []Receipt              `json:"receipts,omitempty"`
+	ScannerConfigSnapshot *ScannerConfigSnapshot `json:"scanner_config_snapshot,omitempty"`
+	Posture               Posture                `json:"posture"`
+	Artifacts             Artifacts              `json:"artifacts"`
+}
+
+// Run captures provider, repo, and agent identity for the run that produced
+// the receipts.
+type Run struct {
+	Provider      string `json:"provider"`
+	Repository    string `json:"repository,omitempty"`
+	Workflow      string `json:"workflow,omitempty"`
+	RunID         string `json:"run_id,omitempty"`
+	RunAttempt    string `json:"run_attempt,omitempty"`
+	Ref           string `json:"ref,omitempty"`
+	SHA           string `json:"sha,omitempty"`
+	AgentIdentity string `json:"agent_identity"`
+	StartedAt     string `json:"started_at"`
+	CompletedAt   string `json:"completed_at,omitempty"`
+	AgentExitCode *int   `json:"agent_exit_code,omitempty"`
+}
+
+// Policy captures the pipelock policy state observed during the run.
+// PolicyHashes is plural because hot-reload across the run can produce
+// multiple distinct hashes.
+type Policy struct {
+	PolicyHashes         []string `json:"policy_hashes"`
+	ConfigPath           string   `json:"config_path,omitempty"`
+	RuntimeConfigPath    string   `json:"runtime_config_path,omitempty"`
+	ConfigSnapshotSHA256 string   `json:"config_snapshot_sha256,omitempty"`
+}
+
+// Summary aggregates counts derived from the receipt chain.
+type Summary struct {
+	ReceiptCount   int            `json:"receipt_count"`
+	Totals         Totals         `json:"totals"`
+	Transports     map[string]int `json:"transports,omitempty"`
+	Layers         map[string]int `json:"layers,omitempty"`
+	DomainsTouched []string       `json:"domains_touched,omitempty"`
+}
+
+// Totals carries the eight verdict buckets. All eight MUST be emitted, even
+// when zero, so consumers can sum without nil-checks.
+type Totals struct {
+	Allow    int `json:"allow"`
+	Block    int `json:"block"`
+	Warn     int `json:"warn"`
+	Ask      int `json:"ask"`
+	Strip    int `json:"strip"`
+	Forward  int `json:"forward"`
+	Redirect int `json:"redirect"`
+	Other    int `json:"other"`
+}
+
+// Verifier carries the verdict from the receipt chain verifier.
+type Verifier struct {
+	Verdict      string `json:"verdict"`
+	Trusted      bool   `json:"trusted"`
+	ReceiptCount int    `json:"receipt_count,omitempty"`
+	RootHash     string `json:"root_hash,omitempty"`
+	FinalSeq     int    `json:"final_seq,omitempty"`
+	SignerKey    string `json:"signer_key,omitempty"`
+	OutputFile   string `json:"output_file,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
+// Receipt is the inline form of a receipt entry. Consumers SHOULD prefer
+// reading evidence.jsonl directly because that is the byte-for-byte signed
+// input to the verifier.
+type Receipt struct {
+	ActionID       string `json:"action_id"`
+	ReceiptHash    string `json:"receipt_hash"`
+	ChainSeq       int    `json:"chain_seq"`
+	ChainPrevHash  string `json:"chain_prev_hash"`
+	Timestamp      string `json:"timestamp,omitempty"`
+	ActionType     string `json:"action_type,omitempty"`
+	Verdict        string `json:"verdict"`
+	Transport      string `json:"transport,omitempty"`
+	Method         string `json:"method,omitempty"`
+	TargetRedacted string `json:"target_redacted,omitempty"`
+	Layer          string `json:"layer,omitempty"`
+	Pattern        string `json:"pattern,omitempty"`
+	Severity       string `json:"severity,omitempty"`
+	PolicyHash     string `json:"policy_hash"`
+	SignerKey      string `json:"signer_key,omitempty"`
+}
+
+// ScannerConfigSnapshot is the optional summary of the pipelock config that
+// produced the receipts.
+type ScannerConfigSnapshot struct {
+	Mode                  string `json:"mode,omitempty"`
+	DLPPatternsCount      int    `json:"dlp_patterns_count,omitempty"`
+	ResponsePatternsCount int    `json:"response_patterns_count,omitempty"`
+	SSRFEnabled           *bool  `json:"ssrf_enabled,omitempty"`
+	RedactionEnabled      *bool  `json:"redaction_enabled,omitempty"`
+	FlightRecorderEnabled *bool  `json:"flight_recorder_enabled,omitempty"`
+}
+
+// Posture documents the enforcement posture claimed by the producer.
+type Posture struct {
+	EnforcementMode        string   `json:"enforcement_mode"`
+	RunnerOS               string   `json:"runner_os"`
+	RunnerArch             string   `json:"runner_arch,omitempty"`
+	RawSocketStatus        string   `json:"raw_socket_status,omitempty"`
+	DockerSocketStatus     string   `json:"docker_socket_status,omitempty"`
+	DNSUDPStatus           string   `json:"dns_udp_status,omitempty"`
+	BrowserProxyStatus     string   `json:"browser_proxy_status,omitempty"`
+	WebsocketFrameScanning string   `json:"websocket_frame_scanning,omitempty"`
+	NetworkNamespace       string   `json:"network_namespace,omitempty"`
+	AgentUser              string   `json:"agent_user,omitempty"`
+	AgentUID               int      `json:"agent_uid,omitempty"`
+	HostUser               string   `json:"host_user,omitempty"`
+	HostUID                int      `json:"host_uid,omitempty"`
+	HostIP                 string   `json:"host_ip,omitempty"`
+	AgentIP                string   `json:"agent_ip,omitempty"`
+	ProxyURL               string   `json:"proxy_url,omitempty"`
+	ScriptBasename         string   `json:"script_basename,omitempty"`
+	ScriptArgCount         int      `json:"script_arg_count,omitempty"`
+	UnsupportedPaths       []string `json:"unsupported_paths,omitempty"`
+}
+
+// Artifacts records relative paths to sibling files in the audit packet
+// directory.
+type Artifacts struct {
+	Packet   string `json:"packet"`
+	Summary  string `json:"summary,omitempty"`
+	Evidence string `json:"evidence"`
+	Verifier string `json:"verifier"`
+}
+
+// Validate enforces the structural invariants the JSON Schema also enforces.
+// It is intended as a defense-in-depth check for Go callers; producers in
+// other languages MUST also pass v0.json validation.
+func (p *Packet) Validate() error {
+	if p == nil {
+		return errors.New("auditpacket: nil packet")
+	}
+	if p.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("auditpacket: schema_version %q is not %q", p.SchemaVersion, SchemaVersion)
+	}
+	if p.GeneratedAt == "" {
+		return errors.New("auditpacket: generated_at is required")
+	}
+	if err := p.Run.validate(); err != nil {
+		return fmt.Errorf("auditpacket: run: %w", err)
+	}
+	if err := p.Policy.validate(); err != nil {
+		return fmt.Errorf("auditpacket: policy: %w", err)
+	}
+	if err := p.Summary.validate(); err != nil {
+		return fmt.Errorf("auditpacket: summary: %w", err)
+	}
+	if err := p.Verifier.validate(); err != nil {
+		return fmt.Errorf("auditpacket: verifier: %w", err)
+	}
+	if err := p.Posture.validate(); err != nil {
+		return fmt.Errorf("auditpacket: posture: %w", err)
+	}
+	if err := p.Artifacts.validate(); err != nil {
+		return fmt.Errorf("auditpacket: artifacts: %w", err)
+	}
+	return nil
+}
+
+func (r Run) validate() error {
+	if _, ok := validProviders[r.Provider]; !ok {
+		return fmt.Errorf("provider %q not in {github_actions, self_hosted, local}", r.Provider)
+	}
+	if r.AgentIdentity == "" {
+		return errors.New("agent_identity is required")
+	}
+	if r.StartedAt == "" {
+		return errors.New("started_at is required")
+	}
+	return nil
+}
+
+func (p Policy) validate() error {
+	if p.PolicyHashes == nil {
+		return errors.New("policy_hashes is required (use empty array, not null)")
+	}
+	return nil
+}
+
+func (s Summary) validate() error {
+	if s.ReceiptCount < 0 {
+		return errors.New("receipt_count must be non-negative")
+	}
+	// Confirm computed sum across the eight buckets is non-negative; per-field
+	// negative counts are caught by the JSON Schema and would also fail here
+	// when the caller hand-builds a Totals.
+	if s.Totals.Allow < 0 || s.Totals.Block < 0 || s.Totals.Warn < 0 ||
+		s.Totals.Ask < 0 || s.Totals.Strip < 0 || s.Totals.Forward < 0 ||
+		s.Totals.Redirect < 0 || s.Totals.Other < 0 {
+		return errors.New("totals counts must be non-negative")
+	}
+	return nil
+}
+
+func (v Verifier) validate() error {
+	if _, ok := validVerdicts[v.Verdict]; !ok {
+		return fmt.Errorf("verdict %q not in {valid, invalid, error, not_run, self_consistent_only}", v.Verdict)
+	}
+	// Consumers must not conflate self_consistent_only with valid; the schema
+	// makes this hard to misconfigure, but enforce here too.
+	if v.Trusted && v.Verdict != VerdictValid {
+		return fmt.Errorf("trusted=true requires verdict=valid, got %q", v.Verdict)
+	}
+	return nil
+}
+
+func (p Posture) validate() error {
+	if p.EnforcementMode == "" {
+		return errors.New("enforcement_mode is required")
+	}
+	if p.RunnerOS == "" {
+		return errors.New("runner_os is required")
+	}
+	return nil
+}
+
+func (a Artifacts) validate() error {
+	if a.Packet == "" {
+		return errors.New("packet path is required")
+	}
+	if a.Evidence == "" {
+		return errors.New("evidence path is required")
+	}
+	if a.Verifier == "" {
+		return errors.New("verifier path is required")
+	}
+	return nil
+}
+
+// TotalsKeys returns the locked v0 totals key list. Producers iterating to
+// emit zero buckets SHOULD walk this list so they cannot accidentally drop
+// a key during a refactor.
+func TotalsKeys() []string {
+	out := make([]string, len(totalsKeys))
+	copy(out, totalsKeys)
+	return out
+}
+
+// SortedDomains returns a sorted unique copy of the input domain list.
+// Producers SHOULD use it before stamping summary.domains_touched so two
+// runs with the same hosts in different observation order produce
+// byte-identical packets.
+func SortedDomains(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, d := range in {
+		if _, ok := seen[d]; ok {
+			continue
+		}
+		seen[d] = struct{}{}
+		out = append(out, d)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/sdk/audit-packet/audit_packet_test.go
+++ b/sdk/audit-packet/audit_packet_test.go
@@ -165,14 +165,51 @@ func TestValidate(t *testing.T) {
 			wantSub: "totals counts",
 		},
 		{
+			name:    "totals sum mismatch",
+			mutate:  func(p *auditpacket.Packet) { p.Summary.Totals.Allow++ },
+			wantSub: "totals sum",
+		},
+		{
 			name:    "negative receipt_count",
 			mutate:  func(p *auditpacket.Packet) { p.Summary.ReceiptCount = -1 },
 			wantSub: "receipt_count",
 		},
 		{
+			name:    "negative transport count",
+			mutate:  func(p *auditpacket.Packet) { p.Summary.Transports["https"] = -1 },
+			wantSub: "transports",
+		},
+		{
+			name:    "negative layer count",
+			mutate:  func(p *auditpacket.Packet) { p.Summary.Layers["dlp"] = -1 },
+			wantSub: "layers",
+		},
+		{
+			name: "domains_touched must be sorted",
+			mutate: func(p *auditpacket.Packet) {
+				p.Summary.DomainsTouched = []string{"z.example", "a.example"}
+			},
+			wantSub: "domains_touched must be sorted",
+		},
+		{
+			name: "domains_touched must be unique",
+			mutate: func(p *auditpacket.Packet) {
+				p.Summary.DomainsTouched = []string{"a.example", "a.example"}
+			},
+			wantSub: "domains_touched contains duplicate",
+		},
+		{
 			name:    "unknown verdict",
 			mutate:  func(p *auditpacket.Packet) { p.Verifier.Verdict = "ok" },
 			wantSub: "verdict",
+		},
+		{
+			name: "valid verdict requires trusted",
+			mutate: func(p *auditpacket.Packet) {
+				p.Verifier.Verdict = auditpacket.VerdictValid
+				p.Verifier.Trusted = false
+			},
+			wantSub: "verdict=valid requires trusted=true",
 		},
 		{
 			name: "trusted=true with self_consistent_only is rejected",
@@ -183,6 +220,138 @@ func TestValidate(t *testing.T) {
 			wantSub: "trusted=true requires verdict=valid",
 		},
 		{
+			name: "trusted=true requires signer_key",
+			mutate: func(p *auditpacket.Packet) {
+				p.Verifier.SignerKey = ""
+			},
+			wantSub: "trusted=true requires signer_key",
+		},
+		{
+			name:    "negative verifier receipt_count",
+			mutate:  func(p *auditpacket.Packet) { p.Verifier.ReceiptCount = -1 },
+			wantSub: "receipt_count",
+		},
+		{
+			name:    "negative final_seq",
+			mutate:  func(p *auditpacket.Packet) { p.Verifier.FinalSeq = -1 },
+			wantSub: "final_seq",
+		},
+		{
+			name: "invalid inline receipt",
+			mutate: func(p *auditpacket.Packet) {
+				p.Receipts = []auditpacket.Receipt{{}}
+			},
+			wantSub: "receipts[0]",
+		},
+		{
+			name: "inline receipt missing receipt_hash",
+			mutate: func(p *auditpacket.Packet) {
+				p.Receipts = []auditpacket.Receipt{{
+					ActionID:      "a",
+					ChainSeq:      0,
+					ChainPrevHash: "genesis",
+					Verdict:       "allow",
+					PolicyHash:    "sha256:test",
+				}}
+			},
+			wantSub: "receipt_hash",
+		},
+		{
+			name: "invalid inline receipt chain seq",
+			mutate: func(p *auditpacket.Packet) {
+				p.Receipts = []auditpacket.Receipt{{
+					ActionID:      "a",
+					ReceiptHash:   "h",
+					ChainSeq:      -1,
+					ChainPrevHash: "genesis",
+					Verdict:       "allow",
+					PolicyHash:    "sha256:test",
+				}}
+			},
+			wantSub: "chain_seq",
+		},
+		{
+			name: "inline receipt missing chain_prev_hash",
+			mutate: func(p *auditpacket.Packet) {
+				p.Receipts = []auditpacket.Receipt{{
+					ActionID:    "a",
+					ReceiptHash: "h",
+					ChainSeq:    0,
+					Verdict:     "allow",
+					PolicyHash:  "sha256:test",
+				}}
+			},
+			wantSub: "chain_prev_hash",
+		},
+		{
+			name: "inline receipt missing verdict",
+			mutate: func(p *auditpacket.Packet) {
+				p.Receipts = []auditpacket.Receipt{{
+					ActionID:      "a",
+					ReceiptHash:   "h",
+					ChainSeq:      0,
+					ChainPrevHash: "genesis",
+					PolicyHash:    "sha256:test",
+				}}
+			},
+			wantSub: "verdict",
+		},
+		{
+			name: "inline receipt missing policy_hash",
+			mutate: func(p *auditpacket.Packet) {
+				p.Receipts = []auditpacket.Receipt{{
+					ActionID:      "a",
+					ReceiptHash:   "h",
+					ChainSeq:      0,
+					ChainPrevHash: "genesis",
+					Verdict:       "allow",
+				}}
+			},
+			wantSub: "policy_hash",
+		},
+		{
+			name: "valid inline receipt",
+			mutate: func(p *auditpacket.Packet) {
+				p.Receipts = []auditpacket.Receipt{{
+					ActionID:      "a",
+					ReceiptHash:   "h",
+					ChainSeq:      0,
+					ChainPrevHash: "genesis",
+					Verdict:       "allow",
+					PolicyHash:    "sha256:test",
+				}}
+			},
+			wantSub: "",
+		},
+		{
+			name: "valid scanner config snapshot",
+			mutate: func(p *auditpacket.Packet) {
+				truthy := true
+				p.ScannerConfigSnapshot = &auditpacket.ScannerConfigSnapshot{
+					DLPPatternsCount:      1,
+					ResponsePatternsCount: 2,
+					SSRFEnabled:           &truthy,
+					RedactionEnabled:      &truthy,
+					FlightRecorderEnabled: &truthy,
+				}
+			},
+			wantSub: "",
+		},
+		{
+			name: "negative scanner config count",
+			mutate: func(p *auditpacket.Packet) {
+				p.ScannerConfigSnapshot = &auditpacket.ScannerConfigSnapshot{DLPPatternsCount: -1}
+			},
+			wantSub: "dlp_patterns_count",
+		},
+		{
+			name: "negative scanner response count",
+			mutate: func(p *auditpacket.Packet) {
+				p.ScannerConfigSnapshot = &auditpacket.ScannerConfigSnapshot{ResponsePatternsCount: -1}
+			},
+			wantSub: "response_patterns_count",
+		},
+		{
 			name:    "missing enforcement_mode",
 			mutate:  func(p *auditpacket.Packet) { p.Posture.EnforcementMode = "" },
 			wantSub: "enforcement_mode",
@@ -191,6 +360,41 @@ func TestValidate(t *testing.T) {
 			name:    "missing runner_os",
 			mutate:  func(p *auditpacket.Packet) { p.Posture.RunnerOS = "" },
 			wantSub: "runner_os",
+		},
+		{
+			name:    "invalid raw_socket_status",
+			mutate:  func(p *auditpacket.Packet) { p.Posture.RawSocketStatus = "" },
+			wantSub: "raw_socket_status",
+		},
+		{
+			name:    "invalid docker_socket_status",
+			mutate:  func(p *auditpacket.Packet) { p.Posture.DockerSocketStatus = "mounted" },
+			wantSub: "docker_socket_status",
+		},
+		{
+			name:    "invalid dns_udp_status",
+			mutate:  func(p *auditpacket.Packet) { p.Posture.DNSUDPStatus = "blocked" },
+			wantSub: "dns_udp_status",
+		},
+		{
+			name:    "invalid browser_proxy_status",
+			mutate:  func(p *auditpacket.Packet) { p.Posture.BrowserProxyStatus = "enabled" },
+			wantSub: "browser_proxy_status",
+		},
+		{
+			name:    "invalid websocket_frame_scanning",
+			mutate:  func(p *auditpacket.Packet) { p.Posture.WebsocketFrameScanning = "unknown" },
+			wantSub: "websocket_frame_scanning",
+		},
+		{
+			name:    "negative script_arg_count",
+			mutate:  func(p *auditpacket.Packet) { p.Posture.ScriptArgCount = -1 },
+			wantSub: "script_arg_count",
+		},
+		{
+			name:    "unsupported_paths nil rejected",
+			mutate:  func(p *auditpacket.Packet) { p.Posture.UnsupportedPaths = nil },
+			wantSub: "unsupported_paths",
 		},
 		{
 			name:    "missing artifacts.packet",
@@ -206,6 +410,26 @@ func TestValidate(t *testing.T) {
 			name:    "missing artifacts.verifier",
 			mutate:  func(p *auditpacket.Packet) { p.Artifacts.Verifier = "" },
 			wantSub: "verifier path",
+		},
+		{
+			name:    "absolute artifact path rejected",
+			mutate:  func(p *auditpacket.Packet) { p.Artifacts.Evidence = "/tmp/evidence.jsonl" },
+			wantSub: "evidence path must be relative",
+		},
+		{
+			name:    "windows artifact path rejected",
+			mutate:  func(p *auditpacket.Packet) { p.Artifacts.Packet = `C:\tmp\packet.json` },
+			wantSub: "packet path must be slash-relative",
+		},
+		{
+			name:    "traversal artifact path rejected",
+			mutate:  func(p *auditpacket.Packet) { p.Artifacts.Verifier = "../verifier.txt" },
+			wantSub: "verifier path must stay inside",
+		},
+		{
+			name:    "optional summary artifact may be empty",
+			mutate:  func(p *auditpacket.Packet) { p.Artifacts.Summary = "" },
+			wantSub: "",
 		},
 	}
 

--- a/sdk/audit-packet/audit_packet_test.go
+++ b/sdk/audit-packet/audit_packet_test.go
@@ -1,0 +1,330 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package auditpacket_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	auditpacket "github.com/luckyPipewrench/pipelock/sdk/audit-packet"
+)
+
+// exampleFile is the golden minimal packet that conforms to v0.json.
+const exampleFile = "example.json"
+
+// schemaFile is the locked JSON Schema this package binds to.
+const schemaFile = "v0.json"
+
+// loadExample returns the example.json bytes and parsed Packet.
+func loadExample(t *testing.T) ([]byte, auditpacket.Packet) {
+	t.Helper()
+	path := filepath.Clean(filepath.Join(".", exampleFile))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var p auditpacket.Packet
+	if err := json.Unmarshal(data, &p); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	return data, p
+}
+
+// TestExampleConformsToV0 is the central round-trip test: the golden packet
+// MUST unmarshal cleanly, MUST pass Validate(), and MUST re-marshal to a
+// JSON document semantically equal to the original (allowing for whitespace
+// differences only).
+func TestExampleConformsToV0(t *testing.T) {
+	original, p := loadExample(t)
+
+	if err := p.Validate(); err != nil {
+		t.Fatalf("example.json should validate: %v", err)
+	}
+
+	if p.SchemaVersion != auditpacket.SchemaVersion {
+		t.Errorf("schema_version=%q want %q", p.SchemaVersion, auditpacket.SchemaVersion)
+	}
+
+	// Round-trip: marshal back, parse both into generic JSON, compare.
+	round, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var orig, again any
+	if err := json.Unmarshal(original, &orig); err != nil {
+		t.Fatalf("unmarshal original generic: %v", err)
+	}
+	if err := json.Unmarshal(round, &again); err != nil {
+		t.Fatalf("unmarshal round-trip generic: %v", err)
+	}
+	if !reflect.DeepEqual(orig, again) {
+		t.Errorf("round-trip diverged from original\norig:\n%s\nagain:\n%s",
+			string(original), string(round))
+	}
+}
+
+// TestSchemaFileIsValidJSON guards against the schema file becoming malformed
+// during edits. We do NOT invoke a full JSON Schema validator (that would
+// require a third-party dep). The schema's job is enforced externally; here we
+// only verify it parses and declares the v0 $id we expect.
+func TestSchemaFileIsValidJSON(t *testing.T) {
+	path := filepath.Clean(filepath.Join(".", schemaFile))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", schemaFile, err)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("unmarshal %s: %v", schemaFile, err)
+	}
+	gotID, _ := meta["$id"].(string)
+	wantID := "https://pipelab.org/schemas/audit-packet-v0.schema.json"
+	if gotID != wantID {
+		t.Errorf("$id = %q want %q", gotID, wantID)
+	}
+	gotTitle, _ := meta["title"].(string)
+	if !strings.Contains(gotTitle, "Audit Packet v0") {
+		t.Errorf("title = %q must mention Audit Packet v0", gotTitle)
+	}
+}
+
+// TestTotalsKeys verifies the locked v0 bucket set. Adding or removing a
+// bucket would silently break consumers and would belong in a v1 schema, not
+// a v0 patch.
+func TestTotalsKeys(t *testing.T) {
+	got := auditpacket.TotalsKeys()
+	want := []string{"allow", "block", "warn", "ask", "strip", "forward", "redirect", "other"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("TotalsKeys = %v want %v", got, want)
+	}
+
+	// Mutating the returned slice MUST NOT affect future calls.
+	got[0] = "tampered"
+	again := auditpacket.TotalsKeys()
+	if again[0] != "allow" {
+		t.Errorf("TotalsKeys returned aliased slice; mutation leaked: %v", again)
+	}
+}
+
+// TestValidate covers the validator's contract: valid packets pass, malformed
+// packets fail with informative errors. Each row is one mutation of the
+// golden packet.
+func TestValidate(t *testing.T) {
+	_, base := loadExample(t)
+
+	cases := []struct {
+		name    string
+		mutate  func(*auditpacket.Packet)
+		wantSub string
+	}{
+		{
+			name:    "valid example",
+			mutate:  func(*auditpacket.Packet) {},
+			wantSub: "",
+		},
+		{
+			name:    "wrong schema_version",
+			mutate:  func(p *auditpacket.Packet) { p.SchemaVersion = "pipelock.audit_packet.v1" },
+			wantSub: "schema_version",
+		},
+		{
+			name:    "missing generated_at",
+			mutate:  func(p *auditpacket.Packet) { p.GeneratedAt = "" },
+			wantSub: "generated_at",
+		},
+		{
+			name:    "unknown provider",
+			mutate:  func(p *auditpacket.Packet) { p.Run.Provider = "jenkins" },
+			wantSub: "provider",
+		},
+		{
+			name:    "missing agent_identity",
+			mutate:  func(p *auditpacket.Packet) { p.Run.AgentIdentity = "" },
+			wantSub: "agent_identity",
+		},
+		{
+			name:    "missing started_at",
+			mutate:  func(p *auditpacket.Packet) { p.Run.StartedAt = "" },
+			wantSub: "started_at",
+		},
+		{
+			name:    "policy_hashes nil rejected",
+			mutate:  func(p *auditpacket.Packet) { p.Policy.PolicyHashes = nil },
+			wantSub: "policy_hashes",
+		},
+		{
+			name:    "negative totals bucket",
+			mutate:  func(p *auditpacket.Packet) { p.Summary.Totals.Block = -1 },
+			wantSub: "totals counts",
+		},
+		{
+			name:    "negative receipt_count",
+			mutate:  func(p *auditpacket.Packet) { p.Summary.ReceiptCount = -1 },
+			wantSub: "receipt_count",
+		},
+		{
+			name:    "unknown verdict",
+			mutate:  func(p *auditpacket.Packet) { p.Verifier.Verdict = "ok" },
+			wantSub: "verdict",
+		},
+		{
+			name: "trusted=true with self_consistent_only is rejected",
+			mutate: func(p *auditpacket.Packet) {
+				p.Verifier.Verdict = auditpacket.VerdictSelfConsistentOnly
+				p.Verifier.Trusted = true
+			},
+			wantSub: "trusted=true requires verdict=valid",
+		},
+		{
+			name:    "missing enforcement_mode",
+			mutate:  func(p *auditpacket.Packet) { p.Posture.EnforcementMode = "" },
+			wantSub: "enforcement_mode",
+		},
+		{
+			name:    "missing runner_os",
+			mutate:  func(p *auditpacket.Packet) { p.Posture.RunnerOS = "" },
+			wantSub: "runner_os",
+		},
+		{
+			name:    "missing artifacts.packet",
+			mutate:  func(p *auditpacket.Packet) { p.Artifacts.Packet = "" },
+			wantSub: "packet path",
+		},
+		{
+			name:    "missing artifacts.evidence",
+			mutate:  func(p *auditpacket.Packet) { p.Artifacts.Evidence = "" },
+			wantSub: "evidence path",
+		},
+		{
+			name:    "missing artifacts.verifier",
+			mutate:  func(p *auditpacket.Packet) { p.Artifacts.Verifier = "" },
+			wantSub: "verifier path",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := clonePacket(t, base)
+			tc.mutate(&p)
+			err := p.Validate()
+			if tc.wantSub == "" {
+				if err != nil {
+					t.Fatalf("expected valid, got err: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("err = %q want substring %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestValidateNilPacket covers the nil-receiver path explicitly so the
+// 95% coverage target on this file holds.
+func TestValidateNilPacket(t *testing.T) {
+	var p *auditpacket.Packet
+	err := p.Validate()
+	if err == nil {
+		t.Fatalf("nil packet must fail validation")
+	}
+	if !strings.Contains(err.Error(), "nil packet") {
+		t.Errorf("err = %q want substring %q", err.Error(), "nil packet")
+	}
+}
+
+// TestSortedDomains exercises the helper that producers SHOULD use to make
+// summary.domains_touched byte-deterministic.
+func TestSortedDomains(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{name: "empty", in: nil, want: nil},
+		{name: "empty slice", in: []string{}, want: nil},
+		{
+			name: "dedupes and sorts",
+			in:   []string{"github.com", "api.anthropic.com", "github.com", "registry.npmjs.org"},
+			want: []string{"api.anthropic.com", "github.com", "registry.npmjs.org"},
+		},
+		{
+			name: "single",
+			in:   []string{"only.example"},
+			want: []string{"only.example"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := auditpacket.SortedDomains(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("SortedDomains(%v) = %v want %v", tc.in, got, tc.want)
+			}
+			if got != nil && !sort.StringsAreSorted(got) {
+				t.Errorf("SortedDomains output not sorted: %v", got)
+			}
+		})
+	}
+}
+
+// TestExampleEmitsAllTotalsKeys guards the producer convention: the example
+// packet (and any real packet) MUST include all eight totals keys, even when
+// zero.
+func TestExampleEmitsAllTotalsKeys(t *testing.T) {
+	data, _ := loadExample(t)
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	summary, ok := raw["summary"]
+	if !ok {
+		t.Fatalf("missing summary")
+	}
+	var sumMap map[string]json.RawMessage
+	if err := json.Unmarshal(summary, &sumMap); err != nil {
+		t.Fatalf("unmarshal summary: %v", err)
+	}
+	totalsRaw, ok := sumMap["totals"]
+	if !ok {
+		t.Fatalf("missing summary.totals")
+	}
+	var totals map[string]int
+	if err := json.Unmarshal(totalsRaw, &totals); err != nil {
+		t.Fatalf("unmarshal totals: %v", err)
+	}
+	for _, key := range auditpacket.TotalsKeys() {
+		if _, present := totals[key]; !present {
+			t.Errorf("example.json totals missing required key %q", key)
+		}
+	}
+	if len(totals) != len(auditpacket.TotalsKeys()) {
+		t.Errorf("example.json totals has %d keys, want exactly %d (%v)",
+			len(totals), len(auditpacket.TotalsKeys()), auditpacket.TotalsKeys())
+	}
+}
+
+// clonePacket returns a deep copy of p by JSON round-trip. Sufficient for the
+// small fixture sizes here.
+func clonePacket(t *testing.T, p auditpacket.Packet) auditpacket.Packet {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(p); err != nil {
+		t.Fatalf("clone marshal: %v", err)
+	}
+	var out auditpacket.Packet
+	if err := json.NewDecoder(&buf).Decode(&out); err != nil {
+		t.Fatalf("clone unmarshal: %v", err)
+	}
+	return out
+}

--- a/sdk/audit-packet/doc.go
+++ b/sdk/audit-packet/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package auditpacket holds the canonical Go binding for the Pipelock Audit
+// Packet v0 schema published at sdk/audit-packet/v0.json.
+//
+// The Audit Packet is the procurement-ready evidence bundle Pipelock writes
+// after a Pipelock-mediated agent run. It pairs a verifier verdict from the
+// signed receipt chain with the enforcement posture that produced it.
+//
+// The locked contract is v0.json. Go consumers SHOULD use the structs in this
+// package; producers in other languages MUST validate against v0.json with a
+// JSON Schema 2020-12 validator. example.json is the golden minimal packet
+// and round-trips through this package without loss.
+//
+// See README.md in this directory for design rationale, intended consumers,
+// and what is deliberately out of scope for v0.
+package auditpacket

--- a/sdk/audit-packet/example.json
+++ b/sdk/audit-packet/example.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "pipelock.audit_packet.v0",
+  "packet_id": "ap-2026-05-09-d4f2c1a8",
+  "generated_at": "2026-05-09T17:32:18Z",
+  "run": {
+    "provider": "github_actions",
+    "repository": "luckyPipewrench/pipelock",
+    "workflow": "agent-egress-demo",
+    "run_id": "8923477112",
+    "run_attempt": "1",
+    "ref": "refs/pull/498/merge",
+    "sha": "cef4f47ec55c2e7d8f3a6b1f9c0e2d1a4b3c5d6e",
+    "agent_identity": "github-actions-agent",
+    "started_at": "2026-05-09T17:30:42Z",
+    "completed_at": "2026-05-09T17:32:11Z",
+    "agent_exit_code": 0
+  },
+  "policy": {
+    "policy_hashes": [
+      "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    ],
+    "config_path": ".pipelock/ci.yaml",
+    "runtime_config_path": "/home/runner/work/_temp/pipelock-runtime.yaml",
+    "config_snapshot_sha256": "sha256:bd17b22b3a3d6c8c6d2dfb5e84a13d7a2e7eecb6c8d9d2b1c4e5a6b7c8d9e0f1"
+  },
+  "summary": {
+    "receipt_count": 12,
+    "totals": {
+      "allow": 9,
+      "block": 2,
+      "warn": 1,
+      "ask": 0,
+      "strip": 0,
+      "forward": 0,
+      "redirect": 0,
+      "other": 0
+    },
+    "transports": {
+      "https": 11,
+      "ws": 1
+    },
+    "layers": {
+      "domain_blocklist": 1,
+      "dlp": 1,
+      "response_injection": 1
+    },
+    "domains_touched": [
+      "api.anthropic.com",
+      "github.com",
+      "registry.npmjs.org"
+    ]
+  },
+  "verifier": {
+    "verdict": "valid",
+    "trusted": true,
+    "receipt_count": 12,
+    "root_hash": "sha256:91a2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f6071829a3b4c5d6e7f8091",
+    "final_seq": 11,
+    "signer_key": "pipelock-public-key:ed25519:0000000000000000000000000000000000000000000000000000000000000001",
+    "output_file": "verifier.txt"
+  },
+  "posture": {
+    "enforcement_mode": "linux_netns_iptables_setpriv",
+    "runner_os": "Linux",
+    "runner_arch": "X64",
+    "raw_socket_status": "denied",
+    "docker_socket_status": "masked",
+    "dns_udp_status": "denied",
+    "browser_proxy_status": "forced",
+    "websocket_frame_scanning": "explicit_ws_proxy_path_required",
+    "network_namespace": "pipelock-agent",
+    "agent_user": "pipelock-agent",
+    "agent_uid": 2001,
+    "host_user": "pipelock-host",
+    "host_uid": 2002,
+    "host_ip": "10.20.30.1",
+    "agent_ip": "10.20.30.2",
+    "proxy_url": "http://10.20.30.1:8888",
+    "script_basename": "agent-review.sh",
+    "script_arg_count": 2,
+    "unsupported_paths": [
+      "nested-docker",
+      "github-service-containers",
+      "ssh-egress"
+    ]
+  },
+  "artifacts": {
+    "packet": "packet.json",
+    "summary": "summary.md",
+    "evidence": "evidence.jsonl",
+    "verifier": "verifier.txt"
+  }
+}

--- a/sdk/audit-packet/example.json
+++ b/sdk/audit-packet/example.json
@@ -73,9 +73,9 @@
     "agent_uid": 2001,
     "host_user": "pipelock-host",
     "host_uid": 2002,
-    "host_ip": "10.20.30.1",
-    "agent_ip": "10.20.30.2",
-    "proxy_url": "http://10.20.30.1:8888",
+    "host_ip": "192.0.2.10",
+    "agent_ip": "192.0.2.11",
+    "proxy_url": "http://192.0.2.10:8888",
     "script_basename": "agent-review.sh",
     "script_arg_count": 2,
     "unsupported_paths": [

--- a/sdk/audit-packet/v0.json
+++ b/sdk/audit-packet/v0.json
@@ -1,0 +1,305 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pipelab.org/schemas/audit-packet-v0.schema.json",
+  "title": "Pipelock Audit Packet v0",
+  "description": "Procurement-ready evidence bundle emitted after a Pipelock-mediated agent run. Pairs a verdict from a signed receipt chain with the enforcement posture claims that produced it. Versioned independently from pipelock binary releases.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "generated_at",
+    "run",
+    "policy",
+    "summary",
+    "verifier",
+    "posture",
+    "artifacts"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": "pipelock.audit_packet.v0",
+      "description": "Locked identifier for this packet shape. Producers MUST emit exactly this string."
+    },
+    "packet_id": {
+      "type": "string",
+      "description": "Optional opaque identifier for this packet. When omitted, consumers correlate by run.repository + run.sha + run.started_at."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC 3339 UTC timestamp recorded when the packet was assembled."
+    },
+    "run": {
+      "type": "object",
+      "description": "Identity of the agent run that produced the receipts. v0 targets GitHub Actions; future schema versions may add other providers.",
+      "required": ["provider", "agent_identity", "started_at"],
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["github_actions", "self_hosted", "local"],
+          "description": "Where the run executed. Other providers are accepted by registering a new enum value in a future schema version."
+        },
+        "repository": {
+          "type": "string",
+          "description": "Repository identifier from the provider (owner/name on GitHub). Optional for local runs."
+        },
+        "workflow": {
+          "type": "string",
+          "description": "Provider workflow name when applicable."
+        },
+        "run_id": {
+          "type": "string",
+          "description": "Provider run identifier when applicable."
+        },
+        "run_attempt": {
+          "type": "string",
+          "description": "Provider run attempt counter when applicable."
+        },
+        "ref": {
+          "type": "string",
+          "description": "Git ref at run start (refs/heads/main, refs/pull/N/merge, etc.)."
+        },
+        "sha": {
+          "type": "string",
+          "description": "Git commit SHA at run start."
+        },
+        "agent_identity": {
+          "type": "string",
+          "description": "Caller-supplied identity stamped into every receipt and the packet metadata. Maps to the action's agent-identity input."
+        },
+        "started_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 UTC timestamp recorded when the agent command started."
+        },
+        "completed_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 UTC timestamp recorded when the agent command exited (before verifier or packet assembly)."
+        },
+        "agent_exit_code": {
+          "type": "integer",
+          "description": "Exit code of the agent command. Captured even when receipt verification later fails."
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "description": "Pipelock policy state observed during the run. policy_hashes is plural because hot-reload across the run can produce multiple distinct hashes; the action records every hash that signed at least one receipt.",
+      "required": ["policy_hashes"],
+      "additionalProperties": false,
+      "properties": {
+        "policy_hashes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Sorted unique policy hashes observed across receipts. Empty array means no receipts carried a policy_hash, which is itself a signal."
+        },
+        "config_path": {
+          "type": "string",
+          "description": "Path on the runner to the user-supplied pipelock config file."
+        },
+        "runtime_config_path": {
+          "type": "string",
+          "description": "Path on the runner to the materialized runtime config (after action-owned overrides)."
+        },
+        "config_snapshot_sha256": {
+          "type": "string",
+          "description": "Optional SHA-256 of the runtime config file as fed to pipelock. Lets verifiers prove which config produced the receipts."
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "description": "Aggregated counts derived from the receipt chain. Counts are point-in-time: editing evidence.jsonl after the fact will not change them.",
+      "required": ["receipt_count", "totals"],
+      "additionalProperties": false,
+      "properties": {
+        "receipt_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of action_receipt entries in evidence.jsonl."
+        },
+        "totals": {
+          "type": "object",
+          "description": "One bucket per pipelock verdict. The eight buckets correspond to the seven config.Action* constants plus an other bucket for unrecognized verdicts. Producers MUST emit all eight keys, even when zero, so consumers can sum without nil-checks.",
+          "required": ["allow", "block", "warn", "ask", "strip", "forward", "redirect", "other"],
+          "additionalProperties": false,
+          "properties": {
+            "allow":    { "type": "integer", "minimum": 0 },
+            "block":    { "type": "integer", "minimum": 0 },
+            "warn":     { "type": "integer", "minimum": 0 },
+            "ask":      { "type": "integer", "minimum": 0 },
+            "strip":    { "type": "integer", "minimum": 0 },
+            "forward":  { "type": "integer", "minimum": 0 },
+            "redirect": { "type": "integer", "minimum": 0 },
+            "other":    { "type": "integer", "minimum": 0 }
+          }
+        },
+        "transports": {
+          "type": "object",
+          "description": "Counts of receipts grouped by transport label (https, http, ws, mcp_stdio, mcp_http, etc.). Keys are open-ended.",
+          "additionalProperties": { "type": "integer", "minimum": 0 }
+        },
+        "layers": {
+          "type": "object",
+          "description": "Counts of blocked receipts grouped by detection layer label. Optional in v0; producers MAY omit when no layer telemetry is captured.",
+          "additionalProperties": { "type": "integer", "minimum": 0 }
+        },
+        "domains_touched": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional sorted unique list of destination hosts seen in receipts. Producers MAY redact, omit, or hash entries; consumers MUST treat absence as no claim, not as zero hosts."
+        }
+      }
+    },
+    "verifier": {
+      "type": "object",
+      "description": "Verdict from the receipt chain verifier. The verdict alone is not the proof; consumers MUST cross-reference posture claims and the signer key when assigning trust.",
+      "required": ["verdict"],
+      "additionalProperties": false,
+      "properties": {
+        "verdict": {
+          "type": "string",
+          "enum": ["valid", "invalid", "error", "not_run", "self_consistent_only"],
+          "description": "valid: chain verified against a pinned signer key. invalid: chain rejected. error: verifier could not run (config failure or empty chain). not_run: verifier was deliberately skipped. self_consistent_only: chain hashes are consistent but no signer key was pinned, so the chain proves internal consistency only, not Pipelock provenance."
+        },
+        "trusted": {
+          "type": "boolean",
+          "description": "true only when verdict is valid and a long-lived signer public key was pinned at verification time. self_consistent_only and not_run MUST set this to false."
+        },
+        "receipt_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Receipts the verifier examined. May differ from summary.receipt_count if the verifier filtered entries; producers SHOULD flag the divergence in verifier.error when it happens."
+        },
+        "root_hash": {
+          "type": "string",
+          "description": "Hash of the final receipt in the chain (sha256:hex), used by relying parties to anchor the chain in external transparency logs."
+        },
+        "final_seq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Sequence number of the final receipt examined."
+        },
+        "signer_key": {
+          "type": "string",
+          "description": "Signer public key in pipelock public-key text form, or empty when no key was pinned."
+        },
+        "output_file": {
+          "type": "string",
+          "description": "Relative path inside the audit packet directory to the verifier's raw stdout/stderr capture. Defaults to verifier.txt."
+        },
+        "error": {
+          "type": "string",
+          "description": "Human-readable failure reason when verdict is error or invalid."
+        }
+      }
+    },
+    "receipts": {
+      "type": "array",
+      "description": "Optional inline copy of the receipt chain. Producers MAY omit and reference artifacts.evidence_jsonl instead. Consumers SHOULD prefer evidence.jsonl when present because it is the byte-for-byte signed input to the verifier.",
+      "items": {
+        "type": "object",
+        "required": ["action_id", "receipt_hash", "chain_seq", "chain_prev_hash", "verdict", "policy_hash"],
+        "additionalProperties": true,
+        "properties": {
+          "action_id":      { "type": "string" },
+          "receipt_hash":   { "type": "string" },
+          "chain_seq":      { "type": "integer", "minimum": 0 },
+          "chain_prev_hash": { "type": "string" },
+          "timestamp":      { "type": "string", "format": "date-time" },
+          "action_type":    { "type": "string" },
+          "verdict":        { "type": "string" },
+          "transport":      { "type": "string" },
+          "method":         { "type": "string" },
+          "target_redacted": { "type": "string" },
+          "layer":          { "type": "string" },
+          "pattern":        { "type": "string" },
+          "severity":       { "type": "string" },
+          "policy_hash":    { "type": "string" },
+          "signer_key":     { "type": "string" }
+        }
+      }
+    },
+    "scanner_config_snapshot": {
+      "type": "object",
+      "description": "Optional summary of the pipelock config that produced the receipts. Producers MAY omit when no snapshot is available; consumers MUST NOT treat absence as a claim that scanning was disabled.",
+      "additionalProperties": false,
+      "properties": {
+        "mode":                    { "type": "string" },
+        "dlp_patterns_count":      { "type": "integer", "minimum": 0 },
+        "response_patterns_count": { "type": "integer", "minimum": 0 },
+        "ssrf_enabled":            { "type": "boolean" },
+        "redaction_enabled":       { "type": "boolean" },
+        "flight_recorder_enabled": { "type": "boolean" }
+      }
+    },
+    "posture": {
+      "type": "object",
+      "description": "Enforcement posture claimed by the producer. These fields document WHAT was enforced; the receipts in evidence.jsonl prove what happened under that posture. Both sides matter: a clean receipt chain under a posture that admits unsupported paths is weaker evidence than the same chain under stricter posture.",
+      "required": ["enforcement_mode", "runner_os"],
+      "additionalProperties": false,
+      "properties": {
+        "enforcement_mode": {
+          "type": "string",
+          "description": "Free-form identifier for the enforcement architecture. The action repo emits linux_netns_iptables_setpriv. Future modes (docker_container, host_proxy_only, self_hosted_runner) extend this enum."
+        },
+        "runner_os":   { "type": "string" },
+        "runner_arch": { "type": "string" },
+        "raw_socket_status": {
+          "type": "string",
+          "enum": ["denied", "allowed", "unknown"],
+          "description": "denied: agent could not open raw sockets. allowed: agent could (e.g., self-hosted runner with broader caps). unknown: producer did not probe."
+        },
+        "docker_socket_status": {
+          "type": "string",
+          "enum": ["denied", "masked", "allowed", "absent", "unknown"],
+          "description": "denied: explicit deny. masked: socket bind-mounted to /dev/null inside the boundary. allowed: agent had socket access. absent: socket not present on the runner. unknown: producer did not probe."
+        },
+        "dns_udp_status": {
+          "type": "string",
+          "enum": ["denied", "proxied", "allowed", "unknown"],
+          "description": "denied: agent UDP/53 dropped. proxied: DNS routed through pipelock. allowed: agent could resolve directly. unknown: producer did not probe."
+        },
+        "browser_proxy_status": {
+          "type": "string",
+          "enum": ["forced", "advisory", "absent", "unknown"],
+          "description": "forced: HTTPS_PROXY env var is set inside the boundary AND no path bypasses it. advisory: env var set but bypassable. absent: no browser-class workload. unknown: not probed."
+        },
+        "websocket_frame_scanning": {
+          "type": "string",
+          "enum": ["explicit_ws_proxy_path_required", "always_on", "off"],
+          "description": "Frame-level scanning is automatic for /ws?url= proxy path; for arbitrary wss:// destinations the boundary contains the destination but does not scan frames unless the agent uses the proxy path."
+        },
+        "network_namespace": { "type": "string" },
+        "agent_user":        { "type": "string", "description": "Linux UNIX user the agent command ran as (NOT the AI agent identity; see run.agent_identity for that)." },
+        "agent_uid":         { "type": "integer" },
+        "host_user":         { "type": "string" },
+        "host_uid":          { "type": "integer" },
+        "host_ip":           { "type": "string" },
+        "agent_ip":          { "type": "string" },
+        "proxy_url":         { "type": "string" },
+        "script_basename":   { "type": "string" },
+        "script_arg_count":  { "type": "integer", "minimum": 0 },
+        "unsupported_paths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Egress vectors the producer explicitly does not enforce in this mode (e.g., nested-docker, ssh-egress). Honest disclosure is part of the proof."
+        }
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "description": "Relative paths to sibling files in the audit packet directory. All paths are relative to the directory holding packet.json.",
+      "required": ["packet", "evidence", "verifier"],
+      "additionalProperties": false,
+      "properties": {
+        "packet":   { "type": "string", "description": "Relative path to this packet.json." },
+        "summary":  { "type": "string", "description": "Relative path to the human-readable summary.md." },
+        "evidence": { "type": "string", "description": "Relative path to evidence.jsonl, the byte-for-byte signed receipt chain." },
+        "verifier": { "type": "string", "description": "Relative path to verifier.txt, the verifier's raw output." }
+      }
+    }
+  }
+}

--- a/sdk/audit-packet/v0.json
+++ b/sdk/audit-packet/v0.json
@@ -3,6 +3,19 @@
   "$id": "https://pipelab.org/schemas/audit-packet-v0.schema.json",
   "title": "Pipelock Audit Packet v0",
   "description": "Procurement-ready evidence bundle emitted after a Pipelock-mediated agent run. Pairs a verdict from a signed receipt chain with the enforcement posture claims that produced it. Versioned independently from pipelock binary releases.",
+  "$defs": {
+    "artifact_path": {
+      "type": "string",
+      "minLength": 1,
+      "allOf": [
+        { "not": { "const": "." } },
+        { "not": { "pattern": "^/" } },
+        { "not": { "pattern": ":" } },
+        { "not": { "pattern": "\\\\" } },
+        { "not": { "pattern": "(^|/)\\.\\.(/|$)" } }
+      ]
+    }
+  },
   "type": "object",
   "required": [
     "schema_version",
@@ -156,8 +169,30 @@
     "verifier": {
       "type": "object",
       "description": "Verdict from the receipt chain verifier. The verdict alone is not the proof; consumers MUST cross-reference posture claims and the signer key when assigning trust.",
-      "required": ["verdict"],
+      "required": ["verdict", "trusted"],
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "required": ["trusted"],
+            "properties": { "trusted": { "const": true } }
+          },
+          "then": {
+            "required": ["signer_key"],
+            "properties": { "verdict": { "const": "valid" } }
+          }
+        },
+        {
+          "if": {
+            "required": ["verdict"],
+            "properties": { "verdict": { "const": "valid" } }
+          },
+          "then": {
+            "required": ["signer_key"],
+            "properties": { "trusted": { "const": true } }
+          }
+        }
+      ],
       "properties": {
         "verdict": {
           "type": "string",
@@ -184,7 +219,8 @@
         },
         "signer_key": {
           "type": "string",
-          "description": "Signer public key in pipelock public-key text form, or empty when no key was pinned."
+          "minLength": 1,
+          "description": "Signer public key in pipelock public-key text form. Omitted when no key was pinned."
         },
         "output_file": {
           "type": "string",
@@ -238,7 +274,16 @@
     "posture": {
       "type": "object",
       "description": "Enforcement posture claimed by the producer. These fields document WHAT was enforced; the receipts in evidence.jsonl prove what happened under that posture. Both sides matter: a clean receipt chain under a posture that admits unsupported paths is weaker evidence than the same chain under stricter posture.",
-      "required": ["enforcement_mode", "runner_os"],
+      "required": [
+        "enforcement_mode",
+        "runner_os",
+        "raw_socket_status",
+        "docker_socket_status",
+        "dns_udp_status",
+        "browser_proxy_status",
+        "websocket_frame_scanning",
+        "unsupported_paths"
+      ],
       "additionalProperties": false,
       "properties": {
         "enforcement_mode": {
@@ -295,10 +340,22 @@
       "required": ["packet", "evidence", "verifier"],
       "additionalProperties": false,
       "properties": {
-        "packet":   { "type": "string", "description": "Relative path to this packet.json." },
-        "summary":  { "type": "string", "description": "Relative path to the human-readable summary.md." },
-        "evidence": { "type": "string", "description": "Relative path to evidence.jsonl, the byte-for-byte signed receipt chain." },
-        "verifier": { "type": "string", "description": "Relative path to verifier.txt, the verifier's raw output." }
+        "packet": {
+          "$ref": "#/$defs/artifact_path",
+          "description": "Relative path to this packet.json."
+        },
+        "summary": {
+          "$ref": "#/$defs/artifact_path",
+          "description": "Relative path to the human-readable summary.md."
+        },
+        "evidence": {
+          "$ref": "#/$defs/artifact_path",
+          "description": "Relative path to evidence.jsonl, the byte-for-byte signed receipt chain."
+        },
+        "verifier": {
+          "$ref": "#/$defs/artifact_path",
+          "description": "Relative path to verifier.txt, the verifier's raw output."
+        }
       }
     }
   }


### PR DESCRIPTION
## What

Adds `sdk/audit-packet/` with the locked v0 schema, Go binding, golden example, and design docs for the procurement-ready evidence bundle Pipelock writes after a Pipelock-mediated agent run.

| File | What |
| --- | --- |
| `v0.json` | JSON Schema (draft 2020-12). Canonical contract. |
| `audit_packet.go` | Go binding with `Packet.Validate()` + helpers. |
| `example.json` | Golden minimal packet that round-trips through the binding. |
| `README.md` | Design rationale, intended consumers, what is out of scope for v0. |
| `CHANGELOG.md` | Schema-version history (independent of pipelock binary releases). |

## Locked invariants

- **Eight verdict buckets** in `summary.totals` (one per `config.Action*` constant: `allow`, `block`, `warn`, `ask`, `strip`, `forward`, `redirect`, plus `other`). All eight required, even when zero.
- **`summary.totals` sums to `receipt_count`.** Every action_receipt is bucketed exactly once by the v0 producer; the validator enforces this so producer bugs that miscount get caught at validation time.
- **`verifier.trusted` is required.** `trusted=true` iff `verdict=valid` (those two imply each other); whichever is true requires non-empty `signer_key`. The asymmetry is intentional: `signer_key` set with `verdict=invalid`/`trusted=false` is a legitimate forensic state (verifier ran against a pinned key, chain failed). Both implications are enforced by schema-level `if/then` AND a Go-validator check (defense in depth).
- **`self_consistent_only` verifier verdict** is part of the enum because it captures the realistic case where the chain hashes correctly but no signer key was pinned. Consumers conflating it with `valid` defeat the whole point of pinning.
- **Five required posture status enums.** `raw_socket_status`, `docker_socket_status`, `dns_udp_status`, `browser_proxy_status`, and `websocket_frame_scanning` MUST be emitted. The first four use an explicit `unknown` value meaning "not probed", not "denied"; `websocket_frame_scanning` uses `off`. `unsupported_paths` is required (empty array allowed) because honest disclosure of unsupported egress vectors is part of the proof.
- **Artifact paths must stay inside the packet directory.** The validator rejects empty (where required), absolute, Windows-style (backslash/colon), and `..` traversal. Stops a malicious or buggy producer from steering downstream consumers to host paths.
- **`additionalProperties: false`** at the top level and most nested objects, so future schema bumps stay explicit.

## Quality gates

- 100% statement coverage on the new package.
- `golangci-lint run ./...`: 0 issues.
- `go test -race -count=1 ./...`: green across whole repo.
- `go vet ./...`: clean.
- `go mod tidy`: no diff (no new direct deps).
- Round-trip test: `example.json` survives unmarshal/marshal/unmarshal with semantic equality.
- All 19 required CI checks: green.

## Out of scope

- **Action-repo conformance update.** `pipelock-agent-egress-action` needs to populate `run.repository`, `run.sha`, `run.agent_identity`, and the posture status enums. Stacked PR in a separate change.
- **Multi-agent rollups, framework mappings, embedded transparency-log proofs.** Future schema versions; v0 stays narrow on purpose.
- **Bundled JSON Schema validator dependency.** External validators exist; pipelock keeps direct-deps minimal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Pipelock Audit Packet v0: a formal, strictly validated audit packet format with precise field and artifact-path constraints.
  * Added a Go SDK with exported packet types and runtime validation to ensure emitted packets conform to v0.

* **Documentation**
  * Added spec docs, changelog, package guidance and a complete example audit packet.

* **Tests**
  * Added comprehensive tests validating schema compliance, validator behavior, and deterministic helpers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/498)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->