### PR TITLE
feat(cli/setup): add codex install command for Codex CLI MCP servers

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -110,6 +110,7 @@ Quick start:
 		setup.CursorCmd(),
 		setup.VscodeCmd(),
 		setup.JetbrainsCmd(),
+		setup.CodexCmd(),
 		// Signing & integrity
 		clisigning.IntegrityCmd(),
 		clisigning.SignCmd(),

--- a/internal/cli/setup/codex.go
+++ b/internal/cli/setup/codex.go
@@ -1,0 +1,712 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Codex MCP wrapping uses the same shape as VS Code: rewrite each server's
+// command/args so traffic flows through `pipelock mcp proxy` before reaching
+// the original server. Differences from vscode.go: Codex stores config in
+// TOML (~/.codex/config.toml), so we shell out to `codex mcp list/add/remove`
+// rather than parse the file directly. This avoids a TOML dependency and
+// keeps us aligned with whatever schema Codex evolves to.
+
+const (
+	codexBinaryDefault  = "codex"
+	pipelockBinaryName  = "pipelock"
+	codexMCPProxy       = "proxy"
+	codexMCP            = "mcp"
+	codexArgSeparator   = "--"
+	codexFlagConfig     = "--config"
+	codexFlagEnv        = "--env"
+	codexFlagUpstream   = "--upstream"
+	codexTransportStdio = "stdio"
+
+	codexActionWrapStdio       = "wrap-stdio"
+	codexActionWrapURL         = "wrap-url"
+	codexActionSkipWrapped     = "skip-already-wrapped"
+	codexActionSkipUnsupported = "skip-unsupported"
+	codexActionUnwrapStdio     = "unwrap-stdio"
+	codexActionUnwrapURL       = "unwrap-url"
+	codexActionSkipNotWrapped  = "skip-not-wrapped"
+)
+
+// codexMCPServer mirrors `codex mcp list --json` output.
+type codexMCPServer struct {
+	Name              string            `json:"name"`
+	Enabled           *bool             `json:"enabled"`
+	Transport         codexMCPTransport `json:"transport"`
+	StartupTimeoutSec json.RawMessage   `json:"startup_timeout_sec,omitempty"`
+	ToolTimeoutSec    json.RawMessage   `json:"tool_timeout_sec,omitempty"`
+}
+
+// codexMCPTransport is the per-server transport block. Codex emits both
+// stdio (command/args/env) and streamable HTTP (url) shapes under this key
+// distinguished by `type`.
+type codexMCPTransport struct {
+	Type              string            `json:"type"`
+	Command           string            `json:"command,omitempty"`
+	Args              []string          `json:"args,omitempty"`
+	Env               map[string]string `json:"env,omitempty"`
+	EnvVars           []string          `json:"env_vars,omitempty"`
+	CWD               string            `json:"cwd,omitempty"`
+	URL               string            `json:"url,omitempty"`
+	BearerTokenEnvVar string            `json:"bearer_token_env_var,omitempty"`
+	HTTPHeaders       json.RawMessage   `json:"http_headers,omitempty"`
+	EnvHTTPHeaders    json.RawMessage   `json:"env_http_headers,omitempty"`
+}
+
+// CodexCmd returns the `pipelock codex` command tree.
+func CodexCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "codex",
+		Short: "Codex CLI integration",
+		Long: `Wrap Codex CLI's MCP servers through pipelock so all tool traffic is scanned.
+
+The install subcommand rewrites each registered MCP server in ~/.codex/config.toml
+so its command becomes 'pipelock mcp proxy -- <original command>'. URL-based
+streamable HTTP servers are converted to stdio with --upstream.
+
+The remove subcommand restores wrapped servers by reading the original command
+out of the wrapped args list. Servers that were not wrapped by pipelock are
+left unchanged.
+
+HTTP fetches from Codex itself (LLM API calls, the WebFetch tool) are routed
+through pipelock when HTTPS_PROXY is set in the user's shell. Codex inherits
+HTTP_PROXY/HTTPS_PROXY/NO_PROXY by default per its shell_environment_policy,
+so no codex-side change is needed for those.`,
+	}
+	cmd.AddCommand(codexInstallCmd(), codexRemoveCmd())
+	return cmd
+}
+
+func codexInstallCmd() *cobra.Command {
+	var (
+		dryRun     bool
+		configFile string
+		codexPath  string
+	)
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Wrap Codex MCP servers through pipelock",
+		Long: `Iterates servers reported by 'codex mcp list --json' and wraps each one
+through pipelock's MCP proxy. Already-wrapped servers are skipped (idempotent).
+Streamable HTTP (URL) servers are converted to stdio with --upstream.
+
+Use --dry-run to preview the changes without modifying the Codex config.
+Use --config to point pipelock at a specific YAML config when wrapping.
+Use --codex-path to override the codex binary location (default: PATH lookup).`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCodexInstall(cmd, dryRun, configFile, codexPath)
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview changes without modifying Codex config")
+	cmd.Flags().StringVarP(&configFile, "config", "c", "", "pipelock config path passed through to 'pipelock mcp proxy'")
+	cmd.Flags().StringVar(&codexPath, "codex-path", "", "path to the codex binary (default: PATH lookup)")
+	return cmd
+}
+
+func codexRemoveCmd() *cobra.Command {
+	var (
+		dryRun    bool
+		codexPath string
+	)
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Unwrap Codex MCP servers previously wrapped by pipelock",
+		Long: `Reverses 'pipelock codex install'. For each server whose command points at
+the running pipelock binary, the original command/args are recovered from the
+wrapped args list and re-registered. Non-wrapped servers are left unchanged.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCodexRemove(cmd, dryRun, codexPath)
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview changes without modifying Codex config")
+	cmd.Flags().StringVar(&codexPath, "codex-path", "", "path to the codex binary (default: PATH lookup)")
+	return cmd
+}
+
+// resolveCodexBinary returns the codex binary path. Honors --codex-path if set,
+// otherwise falls back to PATH lookup. Errors clearly if not found.
+func resolveCodexBinary(override string) (string, error) {
+	if override != "" {
+		abs, err := filepath.Abs(override)
+		if err != nil {
+			return "", fmt.Errorf("resolving --codex-path: %w", err)
+		}
+		if _, err := os.Stat(abs); err != nil {
+			return "", fmt.Errorf("codex binary at %s: %w", abs, err)
+		}
+		return abs, nil
+	}
+	resolved, err := exec.LookPath(codexBinaryDefault)
+	if err != nil {
+		return "", fmt.Errorf("codex binary not found on PATH (install Codex CLI or pass --codex-path)")
+	}
+	return resolved, nil
+}
+
+// resolvePipelockBinary returns the running pipelock binary path with symlinks
+// evaluated. Used so wrapped configs reference a stable absolute path.
+func resolvePipelockBinary() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("finding pipelock binary: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return "", fmt.Errorf("resolving pipelock binary path: %w", err)
+	}
+	return resolved, nil
+}
+
+// codexMCPList shells out to `codex mcp list --json` and parses the result.
+func codexMCPList(ctx context.Context, codexBin string) ([]codexMCPServer, error) {
+	out, err := runCodexCommand(ctx, codexBin, "mcp", "list", "--json")
+	if err != nil {
+		return nil, fmt.Errorf("codex mcp list: %w", err)
+	}
+	return parseCodexMCPList(out)
+}
+
+// parseCodexMCPList separates parsing from the shell-out so tests can feed
+// canned JSON without mocking exec.
+func parseCodexMCPList(data []byte) ([]codexMCPServer, error) {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var servers []codexMCPServer
+	if err := json.Unmarshal(data, &servers); err != nil {
+		return nil, fmt.Errorf("parsing codex mcp list JSON: %w", err)
+	}
+	return servers, nil
+}
+
+// isCodexWrapped reports whether a server's transport is already wrapped by
+// pipelock. Detection keys on the args prefix ["mcp", "proxy"] AND a binary
+// basename of "pipelock" (with optional suffix like "pipelock-dev"). This
+// matches both the current pipelock binary and any prior pipelock binary at
+// a different path — important so a rebuild at a new location does not
+// double-wrap servers on the next install.
+//
+// The basename check guards against the unlikely case of a non-pipelock tool
+// that also uses `mcp proxy` as its leading args. Operators who want to point
+// the wrap at an alternate binary should `pipelock codex remove` first and
+// then `pipelock codex install` from the new binary.
+func isCodexWrapped(server codexMCPServer, _ string) bool {
+	if server.Transport.Type != codexTransportStdio {
+		return false
+	}
+	if !looksLikePipelockBinary(server.Transport.Command) {
+		return false
+	}
+	if len(server.Transport.Args) < 2 {
+		return false
+	}
+	return server.Transport.Args[0] == codexMCP && server.Transport.Args[1] == codexMCPProxy
+}
+
+// looksLikePipelockBinary reports whether the command path is plausibly a
+// pipelock binary. Matches "pipelock", "pipelock.exe", and dev variants like
+// "pipelock-dev". Path is matched on basename so it is location-independent.
+func looksLikePipelockBinary(command string) bool {
+	if command == "" {
+		return false
+	}
+	base := filepath.Base(command)
+	base = strings.TrimSuffix(base, ".exe")
+	return base == pipelockBinaryName || strings.HasPrefix(base, pipelockBinaryName+"-")
+}
+
+func serverEnabled(server codexMCPServer) bool {
+	return server.Enabled == nil || *server.Enabled
+}
+
+func rawJSONHasValue(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return false
+	}
+	switch string(trimmed) {
+	case "null", "{}", "[]", `""`:
+		return false
+	default:
+		return true
+	}
+}
+
+func unsupportedCodexInstallReason(server codexMCPServer) string {
+	if !serverEnabled(server) {
+		return "server disabled"
+	}
+	if rawJSONHasValue(server.StartupTimeoutSec) || rawJSONHasValue(server.ToolTimeoutSec) {
+		return "custom timeout settings cannot be preserved by codex mcp add"
+	}
+	if server.Transport.CWD != "" {
+		return "cwd cannot be preserved by codex mcp add"
+	}
+	if len(server.Transport.EnvVars) > 0 {
+		return "env_vars passthrough cannot be preserved by codex mcp add"
+	}
+	if hasUnsafeEnvKey(server.Transport.Env) {
+		return "unsafe env key cannot be passed through safely"
+	}
+	if server.Transport.URL != "" && codexURLTransportHasAuthOrHeaders(server.Transport) {
+		return "HTTP auth/header settings cannot be preserved by stdio --upstream wrapper"
+	}
+	return ""
+}
+
+func unsupportedCodexRemoveReason(server codexMCPServer) string {
+	if rawJSONHasValue(server.StartupTimeoutSec) || rawJSONHasValue(server.ToolTimeoutSec) {
+		return "custom timeout settings cannot be preserved by codex mcp add"
+	}
+	if server.Transport.CWD != "" {
+		return "cwd cannot be preserved by codex mcp add"
+	}
+	if len(server.Transport.EnvVars) > 0 {
+		return "env_vars passthrough cannot be preserved by codex mcp add"
+	}
+	if hasUnsafeEnvKey(server.Transport.Env) {
+		return "unsafe env key cannot be passed through safely"
+	}
+	return ""
+}
+
+func codexURLTransportHasAuthOrHeaders(transport codexMCPTransport) bool {
+	return transport.BearerTokenEnvVar != "" ||
+		rawJSONHasValue(transport.HTTPHeaders) ||
+		rawJSONHasValue(transport.EnvHTTPHeaders)
+}
+
+func hasUnsafeEnvKey(env map[string]string) bool {
+	for key := range env {
+		if key == "" || strings.HasPrefix(key, "-") {
+			return true
+		}
+	}
+	return false
+}
+
+// wrapCodexArgs builds the args list for a stdio server wrapped through
+// pipelock. The result is: ["mcp", "proxy", "--config", CFG?, "--env", K1, ...,
+// "--", ORIG_CMD, ORIG_ARG_1, ...]. Pass-through env keys are included as
+// `--env KEY` repeats so pipelock's mcp proxy forwards them to the wrapped
+// subprocess (matching the `--env` flag pattern used in claude-peers/openclaw
+// entries on Josh's machine).
+func wrapCodexArgs(origCmd string, origArgs []string, env map[string]string, configFile string) []string {
+	args := []string{codexMCP, codexMCPProxy}
+	if configFile != "" {
+		args = append(args, codexFlagConfig, configFile)
+	}
+	// Sort env keys so output is deterministic for tests and dry-run diffs.
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		args = append(args, codexFlagEnv, k)
+	}
+	args = append(args, codexArgSeparator)
+	args = append(args, origCmd)
+	args = append(args, origArgs...)
+	return args
+}
+
+// wrapCodexURL builds the args list for an HTTP/SSE server wrapped through
+// pipelock. Streamable-HTTP servers convert to stdio with --upstream pointing
+// at the original URL.
+func wrapCodexURL(url, configFile string) []string {
+	args := []string{codexMCP, codexMCPProxy}
+	if configFile != "" {
+		args = append(args, codexFlagConfig, configFile)
+	}
+	args = append(args, codexFlagUpstream, url)
+	return args
+}
+
+// unwrapCodexArgs reverses wrapCodexArgs / wrapCodexURL, returning the
+// original command/args (or url, in the streamable-HTTP case) so the server
+// can be re-registered with codex mcp add. Returns origURL non-empty for
+// URL-shaped wraps, otherwise origCmd+origArgs are populated.
+func unwrapCodexArgs(args []string) (origCmd string, origArgs []string, origURL string, err error) {
+	if len(args) < 2 || args[0] != codexMCP || args[1] != codexMCPProxy {
+		return "", nil, "", errors.New("not a pipelock-wrapped args list")
+	}
+	rest := args[2:]
+	for len(rest) > 0 {
+		switch rest[0] {
+		case codexFlagConfig, codexFlagEnv:
+			if len(rest) < 2 {
+				return "", nil, "", fmt.Errorf("malformed wrap: trailing %s", rest[0])
+			}
+			rest = rest[2:]
+		case codexFlagUpstream:
+			if len(rest) < 2 {
+				return "", nil, "", fmt.Errorf("malformed wrap: trailing %s", codexFlagUpstream)
+			}
+			return "", nil, rest[1], nil
+		case codexArgSeparator:
+			rest = rest[1:]
+			if len(rest) == 0 {
+				return "", nil, "", errors.New("malformed wrap: separator with no command")
+			}
+			return rest[0], append([]string(nil), rest[1:]...), "", nil
+		default:
+			return "", nil, "", fmt.Errorf("malformed wrap: unexpected token %q", rest[0])
+		}
+	}
+	return "", nil, "", errors.New("malformed wrap: no command or upstream found")
+}
+
+// codexInstallPlan is the precomputed action list for a server (preview-able
+// before any shell-out). One per input server.
+type codexInstallPlan struct {
+	Server  string
+	Action  string // codexActionWrapStdio, codexActionWrapURL, codexActionSkipWrapped, codexActionSkipUnsupported
+	Reason  string // human-readable detail; empty when not skipped
+	NewCmd  string
+	NewArgs []string
+	Env     map[string]string
+}
+
+// planCodexInstall computes the wrap plan for each server. Pure function:
+// no I/O, no exec.
+func planCodexInstall(servers []codexMCPServer, pipelockBin, configFile string) []codexInstallPlan {
+	plans := make([]codexInstallPlan, 0, len(servers))
+	for _, s := range servers {
+		unsupportedReason := unsupportedCodexInstallReason(s)
+		switch {
+		case isCodexWrapped(s, pipelockBin):
+			plans = append(plans, codexInstallPlan{
+				Server: s.Name,
+				Action: codexActionSkipWrapped,
+				Reason: "already routed through pipelock",
+			})
+		case unsupportedReason != "":
+			plans = append(plans, codexInstallPlan{
+				Server: s.Name,
+				Action: codexActionSkipUnsupported,
+				Reason: unsupportedReason,
+			})
+		case s.Transport.Type == codexTransportStdio && s.Transport.Command != "":
+			plans = append(plans, codexInstallPlan{
+				Server:  s.Name,
+				Action:  codexActionWrapStdio,
+				NewCmd:  pipelockBin,
+				NewArgs: wrapCodexArgs(s.Transport.Command, s.Transport.Args, s.Transport.Env, configFile),
+				Env:     copyStringMap(s.Transport.Env),
+			})
+		case s.Transport.URL != "":
+			plans = append(plans, codexInstallPlan{
+				Server:  s.Name,
+				Action:  codexActionWrapURL,
+				NewCmd:  pipelockBin,
+				NewArgs: wrapCodexURL(s.Transport.URL, configFile),
+			})
+		default:
+			plans = append(plans, codexInstallPlan{
+				Server: s.Name,
+				Action: codexActionSkipUnsupported,
+				Reason: fmt.Sprintf("unsupported transport %q", s.Transport.Type),
+			})
+		}
+	}
+	return plans
+}
+
+// codexRemovePlan describes how to unwrap one server. Pure function output.
+type codexRemovePlan struct {
+	Server  string
+	Action  string // codexActionUnwrapStdio, codexActionUnwrapURL, codexActionSkipNotWrapped
+	Reason  string
+	NewCmd  string
+	NewArgs []string
+	NewURL  string
+	Env     map[string]string
+}
+
+// planCodexRemove computes the unwrap plan for each server. Pure function.
+func planCodexRemove(servers []codexMCPServer, pipelockBin string) ([]codexRemovePlan, error) {
+	plans := make([]codexRemovePlan, 0, len(servers))
+	for _, s := range servers {
+		if !isCodexWrapped(s, pipelockBin) {
+			plans = append(plans, codexRemovePlan{
+				Server: s.Name,
+				Action: codexActionSkipNotWrapped,
+				Reason: "not wrapped by pipelock",
+			})
+			continue
+		}
+		if reason := unsupportedCodexRemoveReason(s); reason != "" {
+			return nil, fmt.Errorf("unwrapping %q: %s; edit ~/.codex/config.toml manually", s.Name, reason)
+		}
+		origCmd, origArgs, origURL, err := unwrapCodexArgs(s.Transport.Args)
+		if err != nil {
+			return nil, fmt.Errorf("unwrapping %q: %w", s.Name, err)
+		}
+		switch {
+		case origURL != "":
+			plans = append(plans, codexRemovePlan{
+				Server: s.Name,
+				Action: codexActionUnwrapURL,
+				NewURL: origURL,
+			})
+		default:
+			plans = append(plans, codexRemovePlan{
+				Server:  s.Name,
+				Action:  codexActionUnwrapStdio,
+				NewCmd:  origCmd,
+				NewArgs: origArgs,
+				Env:     copyStringMap(s.Transport.Env),
+			})
+		}
+	}
+	return plans, nil
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+// runCodexInstall is the top-level handler for `pipelock codex install`.
+func runCodexInstall(cmd *cobra.Command, dryRun bool, configFile, codexPathOverride string) error {
+	codexBin, err := resolveCodexBinary(codexPathOverride)
+	if err != nil {
+		return err
+	}
+	pipelockBin, err := resolvePipelockBinary()
+	if err != nil {
+		return err
+	}
+
+	servers, err := codexMCPList(cmd.Context(), codexBin)
+	if err != nil {
+		return err
+	}
+	plans := planCodexInstall(servers, pipelockBin, configFile)
+
+	wrapped, skipped := 0, 0
+	for _, p := range plans {
+		switch p.Action {
+		case codexActionWrapStdio, codexActionWrapURL:
+			if dryRun {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+					"would wrap %s (%s): codex mcp add %s%s -- %s %s\n",
+					p.Server, p.Action, p.Server, formatEnvFlags(p.Env), p.NewCmd, joinArgs(p.NewArgs))
+				wrapped++
+				continue
+			}
+			if err := codexReplaceServer(cmd.Context(), codexBin, p.Server, p.NewCmd, p.NewArgs, p.Env); err != nil {
+				return fmt.Errorf("wrapping %q: %w", p.Server, err)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "wrapped %s\n", p.Server)
+			wrapped++
+		case codexActionSkipWrapped, codexActionSkipUnsupported:
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "skip %s (%s)\n", p.Server, p.Reason)
+			skipped++
+		}
+	}
+
+	if dryRun {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Plan: %d to wrap, %d skipped (dry-run, no changes made)\n", wrapped, skipped)
+	} else {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Wrapped %d server(s), skipped %d.\n", wrapped, skipped)
+		if wrapped > 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Restart Codex sessions to pick up the wrapped MCP servers.")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Note: Codex's HTTP fetches (LLM calls, WebFetch) follow HTTPS_PROXY from your shell.")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "      Run pipelock locally and export HTTPS_PROXY=http://127.0.0.1:8888 to scan those.")
+		}
+	}
+	return nil
+}
+
+// runCodexRemove is the top-level handler for `pipelock codex remove`.
+func runCodexRemove(cmd *cobra.Command, dryRun bool, codexPathOverride string) error {
+	codexBin, err := resolveCodexBinary(codexPathOverride)
+	if err != nil {
+		return err
+	}
+	pipelockBin, err := resolvePipelockBinary()
+	if err != nil {
+		return err
+	}
+
+	servers, err := codexMCPList(cmd.Context(), codexBin)
+	if err != nil {
+		return err
+	}
+	plans, err := planCodexRemove(servers, pipelockBin)
+	if err != nil {
+		return err
+	}
+
+	unwrapped, skipped := 0, 0
+	for _, p := range plans {
+		switch p.Action {
+		case codexActionUnwrapStdio:
+			if dryRun {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+					"would unwrap %s: codex mcp add %s%s -- %s %s\n",
+					p.Server, p.Server, formatEnvFlags(p.Env), p.NewCmd, joinArgs(p.NewArgs))
+				unwrapped++
+				continue
+			}
+			if err := codexReplaceServer(cmd.Context(), codexBin, p.Server, p.NewCmd, p.NewArgs, p.Env); err != nil {
+				return fmt.Errorf("unwrapping %q: %w", p.Server, err)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "unwrapped %s\n", p.Server)
+			unwrapped++
+		case codexActionUnwrapURL:
+			if dryRun {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "would unwrap %s: codex mcp add %s --url %s\n", p.Server, p.Server, p.NewURL)
+				unwrapped++
+				continue
+			}
+			if err := codexReplaceURL(cmd.Context(), codexBin, p.Server, p.NewURL); err != nil {
+				return fmt.Errorf("unwrapping %q: %w", p.Server, err)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "unwrapped %s\n", p.Server)
+			unwrapped++
+		case codexActionSkipNotWrapped:
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "skip %s (%s)\n", p.Server, p.Reason)
+			skipped++
+		}
+	}
+
+	if dryRun {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Plan: %d to unwrap, %d skipped (dry-run, no changes made)\n", unwrapped, skipped)
+	} else {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Unwrapped %d server(s), skipped %d.\n", unwrapped, skipped)
+	}
+	return nil
+}
+
+// codexReplaceServer is the stdio-server replace primitive: remove + add.
+// Codex's `mcp add` rejects duplicates, so we always remove first. The remove
+// is best-effort: a "not found" error is treated as success (idempotent).
+func codexReplaceServer(ctx context.Context, codexBin, name, command string, args []string, env map[string]string) error {
+	if err := codexMCPRemoveBestEffort(ctx, codexBin, name); err != nil {
+		return err
+	}
+	addArgs := []string{"mcp", "add"}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		addArgs = append(addArgs, "--env", k+"="+env[k])
+	}
+	addArgs = append(addArgs, name, "--", command)
+	addArgs = append(addArgs, args...)
+	if _, err := runCodexCommand(ctx, codexBin, addArgs...); err != nil {
+		return fmt.Errorf("codex mcp add %s: %w", name, err)
+	}
+	return nil
+}
+
+// codexReplaceURL is the URL-server replace primitive: remove + add --url.
+func codexReplaceURL(ctx context.Context, codexBin, name, url string) error {
+	if err := codexMCPRemoveBestEffort(ctx, codexBin, name); err != nil {
+		return err
+	}
+	if _, err := runCodexCommand(ctx, codexBin, "mcp", "add", name, "--url", url); err != nil {
+		return fmt.Errorf("codex mcp add --url %s: %w", name, err)
+	}
+	return nil
+}
+
+// codexMCPRemoveBestEffort removes a server, treating "not found" as success.
+func codexMCPRemoveBestEffort(ctx context.Context, codexBin, name string) error {
+	out, err := runCodexCommand(ctx, codexBin, "mcp", "remove", name)
+	if err == nil {
+		return nil
+	}
+	// Codex returns nonzero with a "not found" message when the server is
+	// already gone. We don't have a stable error code to key on, so match the
+	// substring as a fallback (case-insensitive in case Codex changes message
+	// casing). Worst case: a real failure becomes a soft error and the
+	// subsequent `mcp add` will fail loudly with the duplicate.
+	low := bytes.ToLower(out)
+	if bytes.Contains(low, []byte("not found")) || bytes.Contains(low, []byte("does not exist")) {
+		return nil
+	}
+	return fmt.Errorf("codex mcp remove %s: %w", name, err)
+}
+
+// runCodexCommand executes `codexBin args...` and returns combined output.
+// Used directly so we can inspect stderr in error paths (Codex emits errors
+// there). codexBin is the resolved path of an external CLI tool, either from
+// exec.LookPath (PATH) or the user-supplied --codex-path; passing a malicious
+// path would be the user attacking themselves.
+//
+//nolint:gosec // G204: canonical CLI subprocess invocation; see comment above.
+func runCodexCommand(ctx context.Context, codexBin string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, codexBin, args...)
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("%w: %s", err, bytes.TrimSpace(out))
+	}
+	return out, nil
+}
+
+// formatEnvFlags renders redacted `--env K=<redacted> ...` entries for dry-run
+// output. Codex stores env values in its MCP config, and those values are often
+// credentials; dry-run output must not copy them into terminal scrollback.
+func formatEnvFlags(env map[string]string) string {
+	if len(env) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := ""
+	for _, k := range keys {
+		out += " --env " + k + "=<redacted>"
+	}
+	return out
+}
+
+// joinArgs renders args for human-readable preview output.
+func joinArgs(args []string) string {
+	out := ""
+	for i, a := range args {
+		if i > 0 {
+			out += " "
+		}
+		out += strconv.Quote(a)
+	}
+	return out
+}

--- a/internal/cli/setup/codex.go
+++ b/internal/cli/setup/codex.go
@@ -278,6 +278,9 @@ func unsupportedCodexInstallReason(server codexMCPServer) string {
 }
 
 func unsupportedCodexRemoveReason(server codexMCPServer) string {
+	if !serverEnabled(server) {
+		return "server disabled (codex mcp add re-adds as enabled, which would silently mutate state)"
+	}
 	if rawJSONHasValue(server.StartupTimeoutSec) || rawJSONHasValue(server.ToolTimeoutSec) {
 		return "custom timeout settings cannot be preserved by codex mcp add"
 	}
@@ -383,12 +386,13 @@ func unwrapCodexArgs(args []string) (origCmd string, origArgs []string, origURL 
 // codexInstallPlan is the precomputed action list for a server (preview-able
 // before any shell-out). One per input server.
 type codexInstallPlan struct {
-	Server  string
-	Action  string // codexActionWrapStdio, codexActionWrapURL, codexActionSkipWrapped, codexActionSkipUnsupported
-	Reason  string // human-readable detail; empty when not skipped
-	NewCmd  string
-	NewArgs []string
-	Env     map[string]string
+	Server   string
+	Action   string // codexActionWrapStdio, codexActionWrapURL, codexActionSkipWrapped, codexActionSkipUnsupported
+	Reason   string // human-readable detail; empty when not skipped
+	NewCmd   string
+	NewArgs  []string
+	Env      map[string]string
+	Original codexMCPTransport // pre-wrap state, used for rollback if `codex mcp add` fails
 }
 
 // planCodexInstall computes the wrap plan for each server. Pure function:
@@ -412,18 +416,20 @@ func planCodexInstall(servers []codexMCPServer, pipelockBin, configFile string) 
 			})
 		case s.Transport.Type == codexTransportStdio && s.Transport.Command != "":
 			plans = append(plans, codexInstallPlan{
-				Server:  s.Name,
-				Action:  codexActionWrapStdio,
-				NewCmd:  pipelockBin,
-				NewArgs: wrapCodexArgs(s.Transport.Command, s.Transport.Args, s.Transport.Env, configFile),
-				Env:     copyStringMap(s.Transport.Env),
+				Server:   s.Name,
+				Action:   codexActionWrapStdio,
+				NewCmd:   pipelockBin,
+				NewArgs:  wrapCodexArgs(s.Transport.Command, s.Transport.Args, s.Transport.Env, configFile),
+				Env:      copyStringMap(s.Transport.Env),
+				Original: s.Transport,
 			})
 		case s.Transport.URL != "":
 			plans = append(plans, codexInstallPlan{
-				Server:  s.Name,
-				Action:  codexActionWrapURL,
-				NewCmd:  pipelockBin,
-				NewArgs: wrapCodexURL(s.Transport.URL, configFile),
+				Server:   s.Name,
+				Action:   codexActionWrapURL,
+				NewCmd:   pipelockBin,
+				NewArgs:  wrapCodexURL(s.Transport.URL, configFile),
+				Original: s.Transport,
 			})
 		default:
 			plans = append(plans, codexInstallPlan{
@@ -438,13 +444,14 @@ func planCodexInstall(servers []codexMCPServer, pipelockBin, configFile string) 
 
 // codexRemovePlan describes how to unwrap one server. Pure function output.
 type codexRemovePlan struct {
-	Server  string
-	Action  string // codexActionUnwrapStdio, codexActionUnwrapURL, codexActionSkipNotWrapped
-	Reason  string
-	NewCmd  string
-	NewArgs []string
-	NewURL  string
-	Env     map[string]string
+	Server   string
+	Action   string // codexActionUnwrapStdio, codexActionUnwrapURL, codexActionSkipNotWrapped
+	Reason   string
+	NewCmd   string
+	NewArgs  []string
+	NewURL   string
+	Env      map[string]string
+	Original codexMCPTransport // pre-unwrap (wrapped) state, used for rollback if `codex mcp add` fails
 }
 
 // planCodexRemove computes the unwrap plan for each server. Pure function.
@@ -469,17 +476,19 @@ func planCodexRemove(servers []codexMCPServer, pipelockBin string) ([]codexRemov
 		switch {
 		case origURL != "":
 			plans = append(plans, codexRemovePlan{
-				Server: s.Name,
-				Action: codexActionUnwrapURL,
-				NewURL: origURL,
+				Server:   s.Name,
+				Action:   codexActionUnwrapURL,
+				NewURL:   origURL,
+				Original: s.Transport,
 			})
 		default:
 			plans = append(plans, codexRemovePlan{
-				Server:  s.Name,
-				Action:  codexActionUnwrapStdio,
-				NewCmd:  origCmd,
-				NewArgs: origArgs,
-				Env:     copyStringMap(s.Transport.Env),
+				Server:   s.Name,
+				Action:   codexActionUnwrapStdio,
+				NewCmd:   origCmd,
+				NewArgs:  origArgs,
+				Env:      copyStringMap(s.Transport.Env),
+				Original: s.Transport,
 			})
 		}
 	}
@@ -521,11 +530,11 @@ func runCodexInstall(cmd *cobra.Command, dryRun bool, configFile, codexPathOverr
 			if dryRun {
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 					"would wrap %s (%s): codex mcp add %s%s -- %s %s\n",
-					p.Server, p.Action, p.Server, formatEnvFlags(p.Env), p.NewCmd, joinArgs(p.NewArgs))
+					p.Server, p.Action, p.Server, formatEnvFlags(p.Env), strconv.Quote(p.NewCmd), joinArgs(p.NewArgs))
 				wrapped++
 				continue
 			}
-			if err := codexReplaceServer(cmd.Context(), codexBin, p.Server, p.NewCmd, p.NewArgs, p.Env); err != nil {
+			if err := codexReplaceServer(cmd.Context(), codexBin, p.Server, p.NewCmd, p.NewArgs, p.Env, p.Original); err != nil {
 				return fmt.Errorf("wrapping %q: %w", p.Server, err)
 			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "wrapped %s\n", p.Server)
@@ -576,22 +585,22 @@ func runCodexRemove(cmd *cobra.Command, dryRun bool, codexPathOverride string) e
 			if dryRun {
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 					"would unwrap %s: codex mcp add %s%s -- %s %s\n",
-					p.Server, p.Server, formatEnvFlags(p.Env), p.NewCmd, joinArgs(p.NewArgs))
+					p.Server, p.Server, formatEnvFlags(p.Env), strconv.Quote(p.NewCmd), joinArgs(p.NewArgs))
 				unwrapped++
 				continue
 			}
-			if err := codexReplaceServer(cmd.Context(), codexBin, p.Server, p.NewCmd, p.NewArgs, p.Env); err != nil {
+			if err := codexReplaceServer(cmd.Context(), codexBin, p.Server, p.NewCmd, p.NewArgs, p.Env, p.Original); err != nil {
 				return fmt.Errorf("unwrapping %q: %w", p.Server, err)
 			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "unwrapped %s\n", p.Server)
 			unwrapped++
 		case codexActionUnwrapURL:
 			if dryRun {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "would unwrap %s: codex mcp add %s --url %s\n", p.Server, p.Server, p.NewURL)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "would unwrap %s: codex mcp add %s --url %s\n", p.Server, p.Server, strconv.Quote(p.NewURL))
 				unwrapped++
 				continue
 			}
-			if err := codexReplaceURL(cmd.Context(), codexBin, p.Server, p.NewURL); err != nil {
+			if err := codexReplaceURL(cmd.Context(), codexBin, p.Server, p.NewURL, p.Original); err != nil {
 				return fmt.Errorf("unwrapping %q: %w", p.Server, err)
 			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "unwrapped %s\n", p.Server)
@@ -613,10 +622,44 @@ func runCodexRemove(cmd *cobra.Command, dryRun bool, codexPathOverride string) e
 // codexReplaceServer is the stdio-server replace primitive: remove + add.
 // Codex's `mcp add` rejects duplicates, so we always remove first. The remove
 // is best-effort: a "not found" error is treated as success (idempotent).
-func codexReplaceServer(ctx context.Context, codexBin, name, command string, args []string, env map[string]string) error {
+//
+// If the add step fails after the remove succeeded, the server is gone from
+// Codex's config. We attempt to roll back by re-adding the original transport
+// (captured before the remove call). The error returned distinguishes the
+// rollback-succeeded case ("rolled back to original config") from the
+// rollback-failed case ("rollback also failed; verify with codex mcp list").
+func codexReplaceServer(ctx context.Context, codexBin, name, command string, args []string, env map[string]string, original codexMCPTransport) error {
 	if err := codexMCPRemoveBestEffort(ctx, codexBin, name); err != nil {
 		return err
 	}
+	if _, addErr := runCodexCommand(ctx, codexBin, buildCodexAddArgs(name, command, args, env)...); addErr != nil {
+		if rbErr := rollbackCodexAdd(ctx, codexBin, name, original); rbErr != nil {
+			return fmt.Errorf("codex mcp add %s failed and rollback also failed (server may be missing; verify with `codex mcp list`): %w", name, errors.Join(addErr, rbErr))
+		}
+		return fmt.Errorf("codex mcp add %s: %w (rolled back to original config)", name, addErr)
+	}
+	return nil
+}
+
+// codexReplaceURL is the URL-server replace primitive: remove + add --url.
+// Same rollback semantics as codexReplaceServer.
+func codexReplaceURL(ctx context.Context, codexBin, name, url string, original codexMCPTransport) error {
+	if err := codexMCPRemoveBestEffort(ctx, codexBin, name); err != nil {
+		return err
+	}
+	if _, addErr := runCodexCommand(ctx, codexBin, "mcp", "add", name, "--url", url); addErr != nil {
+		if rbErr := rollbackCodexAdd(ctx, codexBin, name, original); rbErr != nil {
+			return fmt.Errorf("codex mcp add %s --url failed and rollback also failed (server may be missing; verify with `codex mcp list`): %w", name, errors.Join(addErr, rbErr))
+		}
+		return fmt.Errorf("codex mcp add %s --url: %w (rolled back to original config)", name, addErr)
+	}
+	return nil
+}
+
+// buildCodexAddArgs assembles the argv for `codex mcp add NAME [--env K=V]... -- COMMAND ARGS...`.
+// Extracted so codexReplaceServer and rollbackCodexAdd share one source of
+// truth for the add shape.
+func buildCodexAddArgs(name, command string, args []string, env map[string]string) []string {
 	addArgs := []string{"mcp", "add"}
 	keys := make([]string, 0, len(env))
 	for k := range env {
@@ -628,21 +671,22 @@ func codexReplaceServer(ctx context.Context, codexBin, name, command string, arg
 	}
 	addArgs = append(addArgs, name, "--", command)
 	addArgs = append(addArgs, args...)
-	if _, err := runCodexCommand(ctx, codexBin, addArgs...); err != nil {
-		return fmt.Errorf("codex mcp add %s: %w", name, err)
-	}
-	return nil
+	return addArgs
 }
 
-// codexReplaceURL is the URL-server replace primitive: remove + add --url.
-func codexReplaceURL(ctx context.Context, codexBin, name, url string) error {
-	if err := codexMCPRemoveBestEffort(ctx, codexBin, name); err != nil {
+// rollbackCodexAdd re-registers a server using the captured original transport
+// so a failed wrap or unwrap does not leave the user's Codex config with a
+// missing server. Returns the rollback error if the re-add itself fails.
+func rollbackCodexAdd(ctx context.Context, codexBin, name string, original codexMCPTransport) error {
+	if original.Type == codexTransportStdio || (original.Command != "" && original.URL == "") {
+		_, err := runCodexCommand(ctx, codexBin, buildCodexAddArgs(name, original.Command, original.Args, original.Env)...)
 		return err
 	}
-	if _, err := runCodexCommand(ctx, codexBin, "mcp", "add", name, "--url", url); err != nil {
-		return fmt.Errorf("codex mcp add --url %s: %w", name, err)
+	if original.URL != "" {
+		_, err := runCodexCommand(ctx, codexBin, "mcp", "add", name, "--url", original.URL)
+		return err
 	}
-	return nil
+	return fmt.Errorf("captured original transport has neither command nor url (type=%q)", original.Type)
 }
 
 // codexMCPRemoveBestEffort removes a server, treating "not found" as success.

--- a/internal/cli/setup/codex_test.go
+++ b/internal/cli/setup/codex_test.go
@@ -1,0 +1,1340 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	pipelockBin    = "/usr/local/bin/pipelock"
+	pipelockBinAlt = "/opt/pipelock/bin/pipelock"
+	cfgPath        = "/etc/pipelock/cfg.yaml"
+	osWindows      = "windows"
+)
+
+// writeShellScript writes a shell-script fixture to t.TempDir(). G306 wants
+// ≤0o600, but a shell script needs the owner-execute bit. Helper localizes
+// the suppression.
+func writeShellScript(t *testing.T, path, content string) {
+	t.Helper()
+	//nolint:gosec // G306: test fixture under t.TempDir(); exec bit needed for fork+exec
+	if err := os.WriteFile(path, []byte(content), 0o700); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}
+
+func codexBoolPtr(v bool) *bool {
+	return &v
+}
+
+func TestParseCodexMCPList(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []codexMCPServer
+		wantErr bool
+	}{
+		{
+			name:  "empty input is empty list",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "whitespace-only input is empty list",
+			input: "   \n\t  ",
+			want:  nil,
+		},
+		{
+			name: "single stdio server with env",
+			input: `[{
+				"name": "claude-peers",
+				"enabled": true,
+				"transport": {
+					"type": "stdio",
+					"command": "/usr/local/bin/pipelock",
+					"args": ["mcp", "proxy", "--env", "TOKEN", "--", "/usr/bin/bun", "server.ts"],
+					"env": {"TOKEN": "abc"}
+				}
+			}]`,
+			want: []codexMCPServer{{
+				Name:    "claude-peers",
+				Enabled: codexBoolPtr(true),
+				Transport: codexMCPTransport{
+					Type:    "stdio",
+					Command: "/usr/local/bin/pipelock",
+					Args:    []string{"mcp", "proxy", "--env", "TOKEN", "--", "/usr/bin/bun", "server.ts"},
+					Env:     map[string]string{"TOKEN": "abc"},
+				},
+			}},
+		},
+		{
+			name:    "malformed JSON returns error",
+			input:   `[{"name":`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCodexMCPList([]byte(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsCodexWrapped(t *testing.T) {
+	tests := []struct {
+		name        string
+		server      codexMCPServer
+		pipelockBin string
+		want        bool
+	}{
+		{
+			name: "stdio with pipelock + mcp proxy prefix is wrapped",
+			server: codexMCPServer{
+				Transport: codexMCPTransport{
+					Type:    "stdio",
+					Command: pipelockBin,
+					Args:    []string{"mcp", "proxy", "--", "node", "x.js"},
+				},
+			},
+			pipelockBin: pipelockBin,
+			want:        true,
+		},
+		{
+			name: "stdio with pipelock but wrong subcommand is NOT wrapped",
+			server: codexMCPServer{
+				Transport: codexMCPTransport{
+					Type:    "stdio",
+					Command: pipelockBin,
+					Args:    []string{"run", "--config", "x.yaml"},
+				},
+			},
+			pipelockBin: pipelockBin,
+			want:        false,
+		},
+		{
+			name: "stdio with different binary is NOT wrapped",
+			server: codexMCPServer{
+				Transport: codexMCPTransport{
+					Type:    "stdio",
+					Command: "/usr/bin/node",
+					Args:    []string{"mcp", "proxy"},
+				},
+			},
+			pipelockBin: pipelockBin,
+			want:        false,
+		},
+		{
+			name: "stdio command containing 'pipelock' substring is NOT wrapped",
+			server: codexMCPServer{
+				Transport: codexMCPTransport{
+					Type:    "stdio",
+					Command: "/some/path/with-pipelock-in-name/run.sh",
+					Args:    []string{"mcp", "proxy"},
+				},
+			},
+			pipelockBin: pipelockBin,
+			want:        false,
+		},
+		{
+			name: "URL transport is NOT wrapped",
+			server: codexMCPServer{
+				Transport: codexMCPTransport{
+					Type: "streamable_http",
+					URL:  "https://api.example.com/mcp",
+				},
+			},
+			pipelockBin: pipelockBin,
+			want:        false,
+		},
+		{
+			name: "stdio with too-short args is NOT wrapped",
+			server: codexMCPServer{
+				Transport: codexMCPTransport{
+					Type:    "stdio",
+					Command: pipelockBin,
+					Args:    []string{"mcp"},
+				},
+			},
+			pipelockBin: pipelockBin,
+			want:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCodexWrapped(tt.server, tt.pipelockBin); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapCodexArgs(t *testing.T) {
+	tests := []struct {
+		name       string
+		origCmd    string
+		origArgs   []string
+		env        map[string]string
+		configFile string
+		want       []string
+	}{
+		{
+			name:     "no env, no config",
+			origCmd:  "node",
+			origArgs: []string{"server.js"},
+			want:     []string{"mcp", "proxy", "--", "node", "server.js"},
+		},
+		{
+			name:       "with config",
+			origCmd:    "node",
+			origArgs:   []string{"server.js"},
+			configFile: cfgPath,
+			want:       []string{"mcp", "proxy", "--config", cfgPath, "--", "node", "server.js"},
+		},
+		{
+			name:     "with env keys, sorted deterministically",
+			origCmd:  "node",
+			origArgs: []string{"server.js"},
+			env:      map[string]string{"BANANA": "y", "APPLE": "x"},
+			want:     []string{"mcp", "proxy", "--env", "APPLE", "--env", "BANANA", "--", "node", "server.js"},
+		},
+		{
+			name:       "config + env + args together",
+			origCmd:    "/usr/bin/bun",
+			origArgs:   []string{"--quiet", "server.ts"},
+			env:        map[string]string{"TOKEN": "x"},
+			configFile: cfgPath,
+			want:       []string{"mcp", "proxy", "--config", cfgPath, "--env", "TOKEN", "--", "/usr/bin/bun", "--quiet", "server.ts"},
+		},
+		{
+			name:    "no orig args, just command",
+			origCmd: "/bin/foo",
+			want:    []string{"mcp", "proxy", "--", "/bin/foo"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapCodexArgs(tt.origCmd, tt.origArgs, tt.env, tt.configFile)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapCodexURL(t *testing.T) {
+	got := wrapCodexURL("https://example.com/mcp", "")
+	want := []string{"mcp", "proxy", "--upstream", "https://example.com/mcp"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	gotCfg := wrapCodexURL("https://example.com/mcp", cfgPath)
+	wantCfg := []string{"mcp", "proxy", "--config", cfgPath, "--upstream", "https://example.com/mcp"}
+	if !reflect.DeepEqual(gotCfg, wantCfg) {
+		t.Errorf("got %v, want %v", gotCfg, wantCfg)
+	}
+}
+
+func TestUnwrapCodexArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantCmd     string
+		wantArgs    []string
+		wantURL     string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "stdio: just command after separator",
+			args:     []string{"mcp", "proxy", "--", "/bin/foo"},
+			wantCmd:  "/bin/foo",
+			wantArgs: []string{},
+		},
+		{
+			name:     "stdio: command + args",
+			args:     []string{"mcp", "proxy", "--", "node", "server.js", "--quiet"},
+			wantCmd:  "node",
+			wantArgs: []string{"server.js", "--quiet"},
+		},
+		{
+			name:     "stdio: with --config and --env preceding separator",
+			args:     []string{"mcp", "proxy", "--config", cfgPath, "--env", "TOKEN", "--env", "OTHER", "--", "/bin/bun", "x.ts"},
+			wantCmd:  "/bin/bun",
+			wantArgs: []string{"x.ts"},
+		},
+		{
+			name:    "url: --upstream URL",
+			args:    []string{"mcp", "proxy", "--upstream", "https://example.com/mcp"},
+			wantURL: "https://example.com/mcp",
+		},
+		{
+			name:    "url: --config + --upstream",
+			args:    []string{"mcp", "proxy", "--config", cfgPath, "--upstream", "https://example.com/mcp"},
+			wantURL: "https://example.com/mcp",
+		},
+		{
+			name:        "not wrapped: missing prefix",
+			args:        []string{"run", "--config", "x.yaml"},
+			wantErr:     true,
+			errContains: "not a pipelock-wrapped",
+		},
+		{
+			name:        "malformed: trailing --config",
+			args:        []string{"mcp", "proxy", "--config"},
+			wantErr:     true,
+			errContains: "trailing --config",
+		},
+		{
+			name:        "malformed: trailing --upstream",
+			args:        []string{"mcp", "proxy", "--upstream"},
+			wantErr:     true,
+			errContains: "trailing --upstream",
+		},
+		{
+			name:        "malformed: separator with no command",
+			args:        []string{"mcp", "proxy", "--"},
+			wantErr:     true,
+			errContains: "no command",
+		},
+		{
+			name:        "malformed: unknown token before separator",
+			args:        []string{"mcp", "proxy", "--bogus", "x"},
+			wantErr:     true,
+			errContains: "unexpected token",
+		},
+		{
+			name:        "malformed: no command or upstream found",
+			args:        []string{"mcp", "proxy", "--config", cfgPath},
+			wantErr:     true,
+			errContains: "no command or upstream",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, args, url, err := unwrapCodexArgs(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cmd != tt.wantCmd {
+				t.Errorf("cmd: got %q, want %q", cmd, tt.wantCmd)
+			}
+			// Treat nil and empty as equivalent for args.
+			if len(args) != len(tt.wantArgs) {
+				t.Errorf("args: got %v, want %v", args, tt.wantArgs)
+			} else {
+				for i := range args {
+					if args[i] != tt.wantArgs[i] {
+						t.Errorf("args[%d]: got %q, want %q", i, args[i], tt.wantArgs[i])
+					}
+				}
+			}
+			if url != tt.wantURL {
+				t.Errorf("url: got %q, want %q", url, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestPlanCodexInstall(t *testing.T) {
+	servers := []codexMCPServer{
+		{
+			Name: "already-wrapped",
+			Transport: codexMCPTransport{
+				Type:    "stdio",
+				Command: pipelockBin,
+				Args:    []string{"mcp", "proxy", "--", "node", "x.js"},
+			},
+		},
+		{
+			Name: "fresh-stdio",
+			Transport: codexMCPTransport{
+				Type:    "stdio",
+				Command: "/usr/bin/node",
+				Args:    []string{"server.js"},
+				Env:     map[string]string{"PORT": "3000"},
+			},
+		},
+		{
+			Name: "fresh-url",
+			Transport: codexMCPTransport{
+				Type: "streamable_http",
+				URL:  "https://example.com/mcp",
+			},
+		},
+		{
+			Name: "weird-no-command",
+			Transport: codexMCPTransport{
+				Type: "stdio",
+				// Command empty: skip-unsupported.
+			},
+		},
+	}
+	plans := planCodexInstall(servers, pipelockBin, cfgPath)
+	if len(plans) != 4 {
+		t.Fatalf("expected 4 plans, got %d", len(plans))
+	}
+
+	if plans[0].Server != "already-wrapped" || plans[0].Action != "skip-already-wrapped" {
+		t.Errorf("plan[0]: got %+v", plans[0])
+	}
+	if plans[1].Server != "fresh-stdio" || plans[1].Action != codexActionWrapStdio {
+		t.Errorf("plan[1]: got %+v", plans[1])
+	}
+	if plans[1].NewCmd != pipelockBin {
+		t.Errorf("plan[1] NewCmd: got %q, want %q", plans[1].NewCmd, pipelockBin)
+	}
+	wantArgs := []string{"mcp", "proxy", "--config", cfgPath, "--env", "PORT", "--", "/usr/bin/node", "server.js"}
+	if !reflect.DeepEqual(plans[1].NewArgs, wantArgs) {
+		t.Errorf("plan[1] NewArgs: got %v, want %v", plans[1].NewArgs, wantArgs)
+	}
+	if plans[1].Env["PORT"] != "3000" {
+		t.Errorf("plan[1] Env: lost PORT, got %v", plans[1].Env)
+	}
+
+	if plans[2].Server != "fresh-url" || plans[2].Action != "wrap-url" {
+		t.Errorf("plan[2]: got %+v", plans[2])
+	}
+	wantURLArgs := []string{"mcp", "proxy", "--config", cfgPath, "--upstream", "https://example.com/mcp"}
+	if !reflect.DeepEqual(plans[2].NewArgs, wantURLArgs) {
+		t.Errorf("plan[2] NewArgs: got %v, want %v", plans[2].NewArgs, wantURLArgs)
+	}
+
+	if plans[3].Server != "weird-no-command" || plans[3].Action != "skip-unsupported" {
+		t.Errorf("plan[3]: got %+v", plans[3])
+	}
+}
+
+func TestPlanCodexInstall_DifferentPipelockBinIsSkipped(t *testing.T) {
+	// Server is wrapped with an OLDER pipelock binary path (e.g.,
+	// /tmp/pipelock-dev or a previous install location). A fresh install from
+	// a different pipelock binary must NOT re-wrap it — that would produce
+	// nested `pipelock proxy -- pipelock proxy -- node x.js` and break unwrap.
+	// Detection keys on basename "pipelock" + canonical args prefix, not on
+	// exact-match against the running pipelock path.
+	servers := []codexMCPServer{{
+		Name: "old-wrap",
+		Transport: codexMCPTransport{
+			Type:    "stdio",
+			Command: pipelockBinAlt,
+			Args:    []string{"mcp", "proxy", "--", "node", "x.js"},
+		},
+	}}
+	plans := planCodexInstall(servers, pipelockBin, "")
+	if len(plans) != 1 {
+		t.Fatalf("expected 1 plan, got %d", len(plans))
+	}
+	if plans[0].Action != codexActionSkipWrapped {
+		t.Errorf("expected skip-already-wrapped (idempotent across pipelock paths), got %q", plans[0].Action)
+	}
+}
+
+func TestPlanCodexInstall_SkipsUnsupportedCodexState(t *testing.T) {
+	servers := []codexMCPServer{
+		{
+			Name:    "disabled",
+			Enabled: codexBoolPtr(false),
+			Transport: codexMCPTransport{
+				Type:    "stdio",
+				Command: "/usr/bin/node",
+				Args:    []string{"server.js"},
+			},
+		},
+		{
+			Name: "with-cwd",
+			Transport: codexMCPTransport{
+				Type:    "stdio",
+				Command: "/usr/bin/node",
+				Args:    []string{"server.js"},
+				CWD:     "/srv/mcp",
+			},
+		},
+		{
+			Name: "with-env-vars",
+			Transport: codexMCPTransport{
+				Type:    "stdio",
+				Command: "/usr/bin/node",
+				Args:    []string{"server.js"},
+				EnvVars: []string{"TOKEN"},
+			},
+		},
+		{
+			Name: "with-timeout",
+			Transport: codexMCPTransport{
+				Type:    "stdio",
+				Command: "/usr/bin/node",
+				Args:    []string{"server.js"},
+			},
+			StartupTimeoutSec: json.RawMessage(`15`),
+		},
+		{
+			Name: "with-unsafe-env",
+			Transport: codexMCPTransport{
+				Type:    "stdio",
+				Command: "/usr/bin/node",
+				Args:    []string{"server.js"},
+				Env:     map[string]string{"--config": "evil"},
+			},
+		},
+		{
+			Name: "url-with-bearer",
+			Transport: codexMCPTransport{
+				Type:              "streamable_http",
+				URL:               "https://api.example.com/mcp",
+				BearerTokenEnvVar: "MCP_TOKEN",
+			},
+		},
+		{
+			Name: "url-with-headers",
+			Transport: codexMCPTransport{
+				Type:           "streamable_http",
+				URL:            "https://api.example.com/mcp",
+				EnvHTTPHeaders: json.RawMessage(`{"Authorization":"MCP_TOKEN"}`),
+			},
+		},
+	}
+
+	plans := planCodexInstall(servers, pipelockBin, "")
+	if len(plans) != len(servers) {
+		t.Fatalf("expected %d plans, got %d", len(servers), len(plans))
+	}
+	for _, plan := range plans {
+		if plan.Action != codexActionSkipUnsupported {
+			t.Errorf("%s action = %q, want %q", plan.Server, plan.Action, codexActionSkipUnsupported)
+		}
+		if plan.Reason == "" {
+			t.Errorf("%s missing skip reason", plan.Server)
+		}
+	}
+}
+
+func TestLooksLikePipelockBinary(t *testing.T) {
+	tests := []struct {
+		command string
+		want    bool
+	}{
+		{"/usr/local/bin/pipelock", true},
+		{"/tmp/pipelock-dev", true},
+		{"/opt/build/pipelock-rc1", true},
+		{"./pipelock.exe", true},
+		{"pipelock", true},
+		{"/usr/bin/node", false},
+		{"/some/path/with-pipelock-in-name/run.sh", false},
+		{"", false},
+		{"/usr/bin/pipelocker", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			if got := looksLikePipelockBinary(tt.command); got != tt.want {
+				t.Errorf("looksLikePipelockBinary(%q) = %v, want %v", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlanCodexRemove(t *testing.T) {
+	servers := []codexMCPServer{
+		{
+			Name: "wrapped-stdio",
+			Transport: codexMCPTransport{
+				Type:    "stdio",
+				Command: pipelockBin,
+				Args:    []string{"mcp", "proxy", "--config", cfgPath, "--env", "TOKEN", "--", "/usr/bin/bun", "x.ts"},
+				Env:     map[string]string{"TOKEN": "secret"},
+			},
+		},
+		{
+			Name: "wrapped-url",
+			Transport: codexMCPTransport{
+				Type:    "stdio",
+				Command: pipelockBin,
+				Args:    []string{"mcp", "proxy", "--upstream", "https://example.com/mcp"},
+			},
+		},
+		{
+			Name: "not-wrapped",
+			Transport: codexMCPTransport{
+				Type:    "stdio",
+				Command: "/usr/bin/node",
+				Args:    []string{"server.js"},
+			},
+		},
+	}
+	plans, err := planCodexRemove(servers, pipelockBin)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plans) != 3 {
+		t.Fatalf("expected 3 plans, got %d", len(plans))
+	}
+
+	if plans[0].Action != "unwrap-stdio" {
+		t.Errorf("plan[0]: got %+v", plans[0])
+	}
+	if plans[0].NewCmd != "/usr/bin/bun" {
+		t.Errorf("plan[0] NewCmd: got %q", plans[0].NewCmd)
+	}
+	if !reflect.DeepEqual(plans[0].NewArgs, []string{"x.ts"}) {
+		t.Errorf("plan[0] NewArgs: got %v", plans[0].NewArgs)
+	}
+	if plans[0].Env["TOKEN"] != "secret" {
+		t.Errorf("plan[0] env preservation: got %v", plans[0].Env)
+	}
+
+	if plans[1].Action != "unwrap-url" || plans[1].NewURL != "https://example.com/mcp" {
+		t.Errorf("plan[1]: got %+v", plans[1])
+	}
+
+	if plans[2].Action != "skip-not-wrapped" {
+		t.Errorf("plan[2]: got %+v", plans[2])
+	}
+}
+
+func TestPlanCodexRemove_MalformedWrapErrors(t *testing.T) {
+	// Wrapped command pointing at pipelock but with malformed args after the
+	// prefix should propagate the unwrap error rather than silently skipping.
+	servers := []codexMCPServer{{
+		Name: "bad",
+		Transport: codexMCPTransport{
+			Type:    "stdio",
+			Command: pipelockBin,
+			Args:    []string{"mcp", "proxy", "--config"}, // trailing flag
+		},
+	}}
+	_, err := planCodexRemove(servers, pipelockBin)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `"bad"`) {
+		t.Errorf("error should reference server name: %v", err)
+	}
+}
+
+func TestPlanCodexRemove_UnsupportedCodexStateErrors(t *testing.T) {
+	wrappedArgs := []string{"mcp", "proxy", "--", "node", "x.js"}
+	tests := []struct {
+		name       string
+		transport  codexMCPTransport
+		startupRaw json.RawMessage
+		toolRaw    json.RawMessage
+		errMatch   string
+	}{
+		{
+			name: "cwd",
+			transport: codexMCPTransport{
+				Type: "stdio", Command: pipelockBin, Args: wrappedArgs,
+				CWD: "/srv/mcp",
+			},
+			errMatch: "cwd cannot be preserved",
+		},
+		{
+			name: "env_vars passthrough",
+			transport: codexMCPTransport{
+				Type: "stdio", Command: pipelockBin, Args: wrappedArgs,
+				EnvVars: []string{"HOME"},
+			},
+			errMatch: "env_vars passthrough",
+		},
+		{
+			name: "unsafe env key",
+			transport: codexMCPTransport{
+				Type: "stdio", Command: pipelockBin, Args: wrappedArgs,
+				Env: map[string]string{"--config": "evil"},
+			},
+			errMatch: "unsafe env key",
+		},
+		{
+			name: "startup timeout",
+			transport: codexMCPTransport{
+				Type: "stdio", Command: pipelockBin, Args: wrappedArgs,
+			},
+			startupRaw: json.RawMessage(`30`),
+			errMatch:   "custom timeout",
+		},
+		{
+			name: "tool timeout",
+			transport: codexMCPTransport{
+				Type: "stdio", Command: pipelockBin, Args: wrappedArgs,
+			},
+			toolRaw:  json.RawMessage(`5`),
+			errMatch: "custom timeout",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			servers := []codexMCPServer{{
+				Name:              "x",
+				Transport:         tt.transport,
+				StartupTimeoutSec: tt.startupRaw,
+				ToolTimeoutSec:    tt.toolRaw,
+			}}
+			_, err := planCodexRemove(servers, pipelockBin)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errMatch) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.errMatch)
+			}
+		})
+	}
+}
+
+func TestRawJSONHasValue(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want bool
+	}{
+		{"", false},
+		{"null", false},
+		{"{}", false},
+		{"[]", false},
+		{`""`, false},
+		{"  null  ", false},
+		{"42", true},
+		{`"hello"`, true},
+		{`{"k":1}`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			if got := rawJSONHasValue(json.RawMessage(tt.raw)); got != tt.want {
+				t.Errorf("rawJSONHasValue(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveCodexBinary(t *testing.T) {
+	// Override path that exists.
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "codex")
+	writeShellScript(t, bin, "#!/bin/sh\nexit 0\n")
+	got, err := resolveCodexBinary(bin)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if got != bin {
+		t.Errorf("got %q, want %q", got, bin)
+	}
+
+	// Override path that doesn't exist.
+	if _, err := resolveCodexBinary(filepath.Join(tmp, "nope")); err == nil {
+		t.Errorf("expected error for missing override, got nil")
+	}
+
+	// PATH lookup: ensure the function compiles in this code path. We don't
+	// assert success because the test environment may or may not have codex
+	// installed; we only assert that "no override + not on PATH" produces a
+	// clear error.
+	t.Setenv("PATH", tmp) // tmp has 'codex' from above, so this should succeed
+	if _, err := resolveCodexBinary(""); err != nil {
+		t.Errorf("expected PATH lookup to find tmp/codex: %v", err)
+	}
+	t.Setenv("PATH", filepath.Join(tmp, "definitely-not-here"))
+	if _, err := resolveCodexBinary(""); err == nil {
+		t.Errorf("expected PATH lookup to fail with no codex on PATH")
+	}
+}
+
+// fakeCodex is a small helper that synthesizes a `codex` binary in a tempdir
+// for end-to-end tests of runCodexInstall / runCodexRemove. It writes a shell
+// script that:
+//   - For `mcp list --json`, prints the canned JSON from listJSON.
+//   - For `mcp add` and `mcp remove`, appends the full argv to invokeLog.
+//   - Returns `0` always (success).
+//
+// The script is portable to the test machines we care about (Linux/macOS).
+// On Windows we skip the helper.
+func fakeCodex(t *testing.T, listJSON string) (binPath, invokeLog string) {
+	t.Helper()
+	if runtime.GOOS == osWindows {
+		t.Skip("fakeCodex shell helper not supported on Windows")
+	}
+	dir := t.TempDir()
+	binPath = filepath.Join(dir, "codex")
+	invokeLog = filepath.Join(dir, "invocations.log")
+	listFile := filepath.Join(dir, "list.json")
+	if err := os.WriteFile(listFile, []byte(listJSON), 0o600); err != nil {
+		t.Fatalf("writing list.json: %v", err)
+	}
+	script := fmt.Sprintf(`#!/bin/sh
+case "$1 $2" in
+"mcp list")
+  cat %q
+  exit 0
+  ;;
+esac
+echo "$@" >> %q
+exit 0
+`, listFile, invokeLog)
+	writeShellScript(t, binPath, script)
+	return binPath, invokeLog
+}
+
+func TestRunCodexInstall_DryRun(t *testing.T) {
+	listJSON := `[{
+		"name": "demo",
+		"enabled": true,
+		"transport": {
+			"type": "stdio",
+			"command": "/usr/bin/node",
+			"args": ["server.js"],
+			"env": {"PORT": "3000"}
+		}
+	}]`
+	codexBin, invokeLog := fakeCodex(t, listJSON)
+
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "install", "--dry-run", "--codex-path", codexBin})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "would wrap demo") {
+		t.Errorf("expected dry-run plan in output, got: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "Plan: 1 to wrap") {
+		t.Errorf("expected summary in output, got: %s", out.String())
+	}
+	if strings.Contains(out.String(), "3000") {
+		t.Errorf("dry-run output leaked env value: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "--env PORT=<redacted>") {
+		t.Errorf("expected redacted env preview, got: %s", out.String())
+	}
+
+	// Dry-run must NOT have called codex mcp add or remove.
+	if data, err := os.ReadFile(filepath.Clean(invokeLog)); err == nil && len(bytes.TrimSpace(data)) > 0 {
+		t.Errorf("dry-run invoked codex: %s", data)
+	}
+}
+
+func TestRunCodexInstall_RealInstall(t *testing.T) {
+	listJSON := `[{
+		"name": "demo",
+		"enabled": true,
+		"transport": {
+			"type": "stdio",
+			"command": "/usr/bin/node",
+			"args": ["server.js"],
+			"env": {"PORT": "3000"}
+		}
+	}]`
+	codexBin, invokeLog := fakeCodex(t, listJSON)
+
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "install", "--codex-path", codexBin, "--config", cfgPath})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "wrapped demo") {
+		t.Errorf("expected 'wrapped demo' in output, got: %s", out.String())
+	}
+
+	logData, err := os.ReadFile(filepath.Clean(invokeLog))
+	if err != nil {
+		t.Fatalf("reading invoke log: %v", err)
+	}
+	logStr := string(logData)
+	if !strings.Contains(logStr, "mcp remove demo") {
+		t.Errorf("expected codex mcp remove in log, got: %s", logStr)
+	}
+	if !strings.Contains(logStr, "mcp add") {
+		t.Errorf("expected codex mcp add in log, got: %s", logStr)
+	}
+	if !strings.Contains(logStr, "--env PORT=3000") {
+		t.Errorf("expected env to be passed to codex mcp add, got: %s", logStr)
+	}
+	if !strings.Contains(logStr, cfgPath) {
+		t.Errorf("expected --config %s passthrough in log, got: %s", cfgPath, logStr)
+	}
+}
+
+func TestRunCodexInstall_AlreadyWrappedSkipped(t *testing.T) {
+	// Wrapped server's command is a "pipelock" basename at any path —
+	// detection is location-independent so a server wrapped by an earlier
+	// pipelock binary at a different path is still treated as already-wrapped.
+	listJSON := `[{
+		"name": "preWrapped",
+		"enabled": true,
+		"transport": {
+			"type": "stdio",
+			"command": "/some/prior/install/pipelock",
+			"args": ["mcp", "proxy", "--", "node", "x.js"]
+		}
+	}]`
+	codexBin, invokeLog := fakeCodex(t, listJSON)
+
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "install", "--codex-path", codexBin})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "skip preWrapped") {
+		t.Errorf("expected skip line in output: %s", out.String())
+	}
+	if data, err := os.ReadFile(filepath.Clean(invokeLog)); err == nil && len(bytes.TrimSpace(data)) > 0 {
+		t.Errorf("idempotent install should not have called codex add/remove: %s", data)
+	}
+}
+
+func TestRunCodexInstall_URLServer(t *testing.T) {
+	listJSON := `[{
+		"name": "remote",
+		"enabled": true,
+		"transport": {
+			"type": "streamable_http",
+			"url": "https://api.example.com/mcp"
+		}
+	}]`
+	codexBin, invokeLog := fakeCodex(t, listJSON)
+
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "install", "--codex-path", codexBin})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "wrapped remote") {
+		t.Errorf("expected 'wrapped remote' in output: %s", out.String())
+	}
+	logData, err := os.ReadFile(filepath.Clean(invokeLog))
+	if err != nil {
+		t.Fatalf("reading invoke log: %v", err)
+	}
+	logStr := string(logData)
+	if !strings.Contains(logStr, "mcp remove remote") {
+		t.Errorf("expected mcp remove for URL server: %s", logStr)
+	}
+	if !strings.Contains(logStr, "--upstream https://api.example.com/mcp") {
+		t.Errorf("expected --upstream in wrap args: %s", logStr)
+	}
+}
+
+func TestRunCodexInstall_UnsupportedTransport(t *testing.T) {
+	// Stdio transport with empty command — falls through to skip-unsupported.
+	listJSON := `[{
+		"name": "weird",
+		"enabled": true,
+		"transport": {
+			"type": "stdio",
+			"command": ""
+		}
+	}]`
+	codexBin, invokeLog := fakeCodex(t, listJSON)
+
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "install", "--codex-path", codexBin})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "skip weird") {
+		t.Errorf("expected skip line for unsupported transport: %s", out.String())
+	}
+	if data, err := os.ReadFile(filepath.Clean(invokeLog)); err == nil && len(bytes.TrimSpace(data)) > 0 {
+		t.Errorf("unsupported server should not have triggered codex calls: %s", data)
+	}
+}
+
+func TestRunCodexRemove_DryRun(t *testing.T) {
+	listJSON := `[{
+		"name": "wrapped",
+		"enabled": true,
+		"transport": {
+			"type": "stdio",
+			"command": "/usr/local/bin/pipelock",
+			"args": ["mcp", "proxy", "--", "/bin/foo"]
+		}
+	}]`
+	codexBin, invokeLog := fakeCodex(t, listJSON)
+
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "remove", "--dry-run", "--codex-path", codexBin})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "would unwrap wrapped") {
+		t.Errorf("expected dry-run preview line: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "Plan: 1 to unwrap") {
+		t.Errorf("expected plan summary: %s", out.String())
+	}
+	if data, err := os.ReadFile(filepath.Clean(invokeLog)); err == nil && len(bytes.TrimSpace(data)) > 0 {
+		t.Errorf("dry-run should not invoke codex: %s", data)
+	}
+}
+
+func TestRunCodexRemove_URLServer(t *testing.T) {
+	listJSON := `[{
+		"name": "wrappedURL",
+		"enabled": true,
+		"transport": {
+			"type": "stdio",
+			"command": "/usr/local/bin/pipelock",
+			"args": ["mcp", "proxy", "--upstream", "https://api.example.com/mcp"]
+		}
+	}]`
+	codexBin, invokeLog := fakeCodex(t, listJSON)
+
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "remove", "--codex-path", codexBin})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "unwrapped wrappedURL") {
+		t.Errorf("expected unwrap line: %s", out.String())
+	}
+	logData, err := os.ReadFile(filepath.Clean(invokeLog))
+	if err != nil {
+		t.Fatalf("reading invoke log: %v", err)
+	}
+	logStr := string(logData)
+	if !strings.Contains(logStr, "mcp add wrappedURL --url https://api.example.com/mcp") {
+		t.Errorf("expected URL re-add: %s", logStr)
+	}
+}
+
+func TestRunCodexRemove_NotWrapped(t *testing.T) {
+	listJSON := `[{
+		"name": "plain",
+		"enabled": true,
+		"transport": {
+			"type": "stdio",
+			"command": "/usr/bin/node",
+			"args": ["server.js"]
+		}
+	}]`
+	codexBin, invokeLog := fakeCodex(t, listJSON)
+
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "remove", "--codex-path", codexBin})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "skip plain") {
+		t.Errorf("expected skip line: %s", out.String())
+	}
+	if data, err := os.ReadFile(filepath.Clean(invokeLog)); err == nil && len(bytes.TrimSpace(data)) > 0 {
+		t.Errorf("non-wrapped server should not invoke codex: %s", data)
+	}
+}
+
+func TestRunCodexRemove_CodexBinaryMissing(t *testing.T) {
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "remove", "--codex-path", "/definitely/not/here/codex"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.ExecuteContext(context.Background()); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestRunCodexInstall_CodexBinaryMissing(t *testing.T) {
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "install", "--codex-path", "/definitely/not/here/codex"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	err := root.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "/definitely/not/here/codex") {
+		t.Errorf("error should reference path: %v", err)
+	}
+}
+
+func TestRunCodexRemove_RoundTrip(t *testing.T) {
+	listJSON := `[{
+		"name": "wrapped",
+		"enabled": true,
+		"transport": {
+			"type": "stdio",
+			"command": "/usr/local/bin/pipelock",
+			"args": ["mcp", "proxy", "--env", "TOKEN", "--", "/usr/bin/bun", "x.ts"],
+			"env": {"TOKEN": "abc"}
+		}
+	}]`
+	codexBin, invokeLog := fakeCodex(t, listJSON)
+
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "remove", "--codex-path", codexBin})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "unwrapped wrapped") {
+		t.Errorf("expected unwrap line in output: %s", out.String())
+	}
+
+	logData, err := os.ReadFile(filepath.Clean(invokeLog))
+	if err != nil {
+		t.Fatalf("reading invoke log: %v", err)
+	}
+	logStr := string(logData)
+	if !strings.Contains(logStr, "mcp remove wrapped") {
+		t.Errorf("expected mcp remove in log: %s", logStr)
+	}
+	if !strings.Contains(logStr, "mcp add") || !strings.Contains(logStr, "/usr/bin/bun") {
+		t.Errorf("expected mcp add with original command: %s", logStr)
+	}
+	if !strings.Contains(logStr, "x.ts") {
+		t.Errorf("expected original args preserved: %s", logStr)
+	}
+	if !strings.Contains(logStr, "--env TOKEN=abc") {
+		t.Errorf("expected env preserved: %s", logStr)
+	}
+}
+
+// failingFakeCodex returns a codex binary that succeeds on `mcp list --json`
+// but fails on every other call (used to exercise add/remove error paths).
+func failingFakeCodex(t *testing.T, listJSON string) string {
+	t.Helper()
+	if runtime.GOOS == osWindows {
+		t.Skip("failingFakeCodex shell helper not supported on Windows")
+	}
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "codex")
+	listFile := filepath.Join(dir, "list.json")
+	if err := os.WriteFile(listFile, []byte(listJSON), 0o600); err != nil {
+		t.Fatalf("writing list.json: %v", err)
+	}
+	script := fmt.Sprintf(`#!/bin/sh
+case "$1 $2" in
+"mcp list")
+  cat %q
+  exit 0
+  ;;
+esac
+echo "Error: synthetic failure" >&2
+exit 1
+`, listFile)
+	writeShellScript(t, bin, script)
+	return bin
+}
+
+// alwaysFailingCodex fails on every call (used to exercise `codex mcp list`
+// error path).
+func alwaysFailingCodex(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == osWindows {
+		t.Skip("alwaysFailingCodex shell helper not supported on Windows")
+	}
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "codex")
+	writeShellScript(t, bin, `#!/bin/sh
+echo "Error: codex broken" >&2
+exit 1
+`)
+	return bin
+}
+
+func TestRunCodexInstall_MCPListFails(t *testing.T) {
+	codexBin := alwaysFailingCodex(t)
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "install", "--codex-path", codexBin})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.ExecuteContext(context.Background()); err == nil {
+		t.Fatalf("expected error from failing mcp list, got nil")
+	} else if !strings.Contains(err.Error(), "codex mcp list") {
+		t.Errorf("error should reference mcp list, got: %v", err)
+	}
+}
+
+func TestRunCodexRemove_MCPListFails(t *testing.T) {
+	codexBin := alwaysFailingCodex(t)
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "remove", "--codex-path", codexBin})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.ExecuteContext(context.Background()); err == nil {
+		t.Fatalf("expected error from failing mcp list, got nil")
+	}
+}
+
+func TestRunCodexInstall_AddFails(t *testing.T) {
+	listJSON := `[{
+		"name": "demo",
+		"enabled": true,
+		"transport": {"type": "stdio", "command": "/usr/bin/node", "args": ["x.js"]}
+	}]`
+	codexBin := failingFakeCodex(t, listJSON)
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "install", "--codex-path", codexBin})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	err := root.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatalf("expected error from failing mcp add, got nil")
+	}
+	if !strings.Contains(err.Error(), "wrapping") || !strings.Contains(err.Error(), "demo") {
+		t.Errorf("error should reference wrap target: %v", err)
+	}
+}
+
+func TestRunCodexRemove_AddFails(t *testing.T) {
+	listJSON := `[{
+		"name": "wrappedURL",
+		"enabled": true,
+		"transport": {
+			"type": "stdio",
+			"command": "/usr/local/bin/pipelock",
+			"args": ["mcp", "proxy", "--upstream", "https://api.example.com/mcp"]
+		}
+	}]`
+	codexBin := failingFakeCodex(t, listJSON)
+
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "remove", "--codex-path", codexBin})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.ExecuteContext(context.Background()); err == nil {
+		t.Fatalf("expected error from failing mcp add (URL), got nil")
+	}
+}
+
+func TestCodexMCPRemoveBestEffort(t *testing.T) {
+	t.Run("not found is success", func(t *testing.T) {
+		tmp := t.TempDir()
+		bin := filepath.Join(tmp, "codex")
+		writeShellScript(t, bin, `#!/bin/sh
+echo "Error: server 'foo' not found" >&2
+exit 1
+`)
+		if err := codexMCPRemoveBestEffort(context.Background(), bin, "foo"); err != nil {
+			t.Errorf("expected 'not found' to be treated as success, got: %v", err)
+		}
+	})
+
+	t.Run("other error propagates", func(t *testing.T) {
+		tmp := t.TempDir()
+		bin := filepath.Join(tmp, "codex")
+		writeShellScript(t, bin, `#!/bin/sh
+echo "Error: permission denied" >&2
+exit 1
+`)
+		err := codexMCPRemoveBestEffort(context.Background(), bin, "foo")
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+	})
+}
+
+func TestCopyStringMap(t *testing.T) {
+	if got := copyStringMap(nil); got != nil {
+		t.Errorf("nil input should return nil, got %v", got)
+	}
+	in := map[string]string{"a": "1", "b": "2"}
+	got := copyStringMap(in)
+	if !reflect.DeepEqual(got, in) {
+		t.Errorf("copy mismatch: got %v, want %v", got, in)
+	}
+	got["a"] = "mutated"
+	if in["a"] == "mutated" {
+		t.Errorf("copy is not deep — mutating result mutated source")
+	}
+}
+
+func TestFormatEnvFlagsRedactsValues(t *testing.T) {
+	got := formatEnvFlags(map[string]string{
+		"TOKEN": "secret value",
+	})
+	if strings.Contains(got, "secret value") {
+		t.Fatalf("formatEnvFlags leaked env value: %s", got)
+	}
+	if got != " --env TOKEN=<redacted>" {
+		t.Fatalf("got %q, want redacted env flag", got)
+	}
+}
+
+func TestJoinArgsQuotesTokenBoundaries(t *testing.T) {
+	got := joinArgs([]string{"mcp", "proxy", "--", "node", "server with spaces.js"})
+	want := `"mcp" "proxy" "--" "node" "server with spaces.js"`
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestUnwrapCodexArgs_NilArgsErrors(t *testing.T) {
+	_, _, _, err := unwrapCodexArgs(nil)
+	if err == nil {
+		t.Fatalf("expected error for nil args, got nil")
+	}
+}
+
+// newCodexTestRoot constructs a minimal cobra root with the codex command
+// attached, so end-to-end tests don't pull in the full pipelock root command
+// graph.
+func newCodexTestRoot() *cobra.Command {
+	root := &cobra.Command{Use: "pipelock"}
+	root.AddCommand(CodexCmd())
+	return root
+}

--- a/internal/cli/setup/codex_test.go
+++ b/internal/cli/setup/codex_test.go
@@ -713,6 +713,28 @@ func TestPlanCodexRemove_UnsupportedCodexStateErrors(t *testing.T) {
 	}
 }
 
+func TestPlanCodexRemove_DisabledServerErrors(t *testing.T) {
+	// A wrapped server flagged disabled in Codex's config must NOT be unwrapped
+	// blindly: codex mcp add re-adds as enabled, silently mutating state. The
+	// remove path errors with a clear reason rather than re-enabling.
+	servers := []codexMCPServer{{
+		Name:    "wrapped-disabled",
+		Enabled: codexBoolPtr(false),
+		Transport: codexMCPTransport{
+			Type:    "stdio",
+			Command: pipelockBin,
+			Args:    []string{"mcp", "proxy", "--", "node", "x.js"},
+		},
+	}}
+	_, err := planCodexRemove(servers, pipelockBin)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "server disabled") {
+		t.Errorf("error should explain disabled state: %v", err)
+	}
+}
+
 func TestRawJSONHasValue(t *testing.T) {
 	tests := []struct {
 		raw  string
@@ -1149,6 +1171,50 @@ func TestRunCodexRemove_RoundTrip(t *testing.T) {
 	}
 }
 
+// rollbackFakeCodex returns a codex binary that simulates a failed wrap-add
+// followed by a succeeding rollback-add. It detects the wrap by checking
+// whether the add line contains "pipelock" (i.e. is wrapping a server
+// through pipelock) and rejects only that. Other adds (the rollback) succeed.
+// Each invocation is appended to invokeLog for assertion.
+func rollbackFakeCodex(t *testing.T, listJSON string) (binPath, invokeLog string) {
+	t.Helper()
+	if runtime.GOOS == osWindows {
+		t.Skip("rollbackFakeCodex shell helper not supported on Windows")
+	}
+	dir := t.TempDir()
+	binPath = filepath.Join(dir, "codex")
+	invokeLog = filepath.Join(dir, "invocations.log")
+	listFile := filepath.Join(dir, "list.json")
+	if err := os.WriteFile(listFile, []byte(listJSON), 0o600); err != nil {
+		t.Fatalf("writing list.json: %v", err)
+	}
+	script := fmt.Sprintf(`#!/bin/sh
+echo "$@" >> %q
+case "$1 $2" in
+"mcp list")
+  cat %q
+  exit 0
+  ;;
+"mcp remove")
+  exit 0
+  ;;
+"mcp add")
+  # Reject only the wrap-add (args contain "mcp proxy" after the "--"
+  # separator, the canonical pipelock wrap shape). Accept the rollback-add
+  # which re-registers the original command.
+  if echo "$@" | grep -q "mcp proxy"; then
+    echo "Error: synthetic wrap-add failure" >&2
+    exit 1
+  fi
+  exit 0
+  ;;
+esac
+exit 0
+`, invokeLog, listFile)
+	writeShellScript(t, binPath, script)
+	return binPath, invokeLog
+}
+
 // failingFakeCodex returns a codex binary that succeeds on `mcp list --json`
 // but fails on every other call (used to exercise add/remove error paths).
 func failingFakeCodex(t *testing.T, listJSON string) string {
@@ -1162,11 +1228,20 @@ func failingFakeCodex(t *testing.T, listJSON string) string {
 	if err := os.WriteFile(listFile, []byte(listJSON), 0o600); err != nil {
 		t.Fatalf("writing list.json: %v", err)
 	}
+	// mcp remove returns "not found" (which codexMCPRemoveBestEffort treats as
+	// success), so the install/remove path proceeds to mcp add. mcp add fails
+	// with a generic synthetic failure, which then triggers the rollback path
+	// which ALSO fails (same script). Tests use this to exercise the
+	// "rollback also failed" branch.
 	script := fmt.Sprintf(`#!/bin/sh
 case "$1 $2" in
 "mcp list")
   cat %q
   exit 0
+  ;;
+"mcp remove")
+  echo "Error: server not found" >&2
+  exit 1
   ;;
 esac
 echo "Error: synthetic failure" >&2
@@ -1218,7 +1293,51 @@ func TestRunCodexRemove_MCPListFails(t *testing.T) {
 	}
 }
 
-func TestRunCodexInstall_AddFails(t *testing.T) {
+func TestRunCodexInstall_AddFailsRollsBackToOriginal(t *testing.T) {
+	// Wrap-add fails; rollback re-adds the original stdio server. The user
+	// should see the failure but be told the rollback succeeded so they know
+	// the server is still functional in its original (unwrapped) form.
+	listJSON := `[{
+		"name": "demo",
+		"enabled": true,
+		"transport": {"type": "stdio", "command": "/usr/bin/node", "args": ["server.js"], "env": {"PORT": "3000"}}
+	}]`
+	codexBin, invokeLog := rollbackFakeCodex(t, listJSON)
+
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "install", "--codex-path", codexBin})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	err := root.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatalf("expected error from failed wrap-add, got nil")
+	}
+	if !strings.Contains(err.Error(), "rolled back") {
+		t.Errorf("error should mention successful rollback, got: %v", err)
+	}
+
+	logData, readErr := os.ReadFile(filepath.Clean(invokeLog))
+	if readErr != nil {
+		t.Fatalf("reading invoke log: %v", readErr)
+	}
+	logStr := string(logData)
+	// Expect: 1 list, 1 remove, 1 wrap-add (fails), 1 rollback-add (succeeds with original cmd).
+	if strings.Count(logStr, "mcp add") != 2 {
+		t.Errorf("expected exactly 2 mcp add invocations (wrap + rollback), got log: %s", logStr)
+	}
+	if !strings.Contains(logStr, "/usr/bin/node") {
+		t.Errorf("rollback should re-add original /usr/bin/node command, got: %s", logStr)
+	}
+	if !strings.Contains(logStr, "--env PORT=3000") {
+		t.Errorf("rollback should preserve original env, got: %s", logStr)
+	}
+}
+
+func TestRunCodexInstall_AddFailsAndRollbackFails(t *testing.T) {
+	// failingFakeCodex fails on every non-list call, so both the wrap-add AND
+	// the rollback-add will fail. The error should explicitly tell the user
+	// the rollback failed and to verify with `codex mcp list`.
 	listJSON := `[{
 		"name": "demo",
 		"enabled": true,
@@ -1236,6 +1355,78 @@ func TestRunCodexInstall_AddFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "wrapping") || !strings.Contains(err.Error(), "demo") {
 		t.Errorf("error should reference wrap target: %v", err)
+	}
+	if !strings.Contains(err.Error(), "rollback also failed") {
+		t.Errorf("error should report rollback failure, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "codex mcp list") {
+		t.Errorf("error should tell operator to verify with codex mcp list, got: %v", err)
+	}
+}
+
+func TestRunCodexRemove_AddFailsRollsBackToWrapped(t *testing.T) {
+	// Unwrap-add fails; rollback re-adds the wrapped (original input) server.
+	// rollbackFakeCodex succeeds on rollback because the rollback-add args
+	// contain "pipelock" (the wrap), which our fake script accepts since it
+	// only fails when "pipelock" is in args. We invert: use a fake that
+	// fails when "pipelock" is NOT in args (i.e. fails the unwrap).
+	if runtime.GOOS == osWindows {
+		t.Skip("shell helper not supported on Windows")
+	}
+	listJSON := `[{
+		"name": "wrapped",
+		"enabled": true,
+		"transport": {
+			"type": "stdio",
+			"command": "/usr/local/bin/pipelock",
+			"args": ["mcp", "proxy", "--", "/usr/bin/node", "server.js"],
+			"env": {"PORT": "3000"}
+		}
+	}]`
+	dir := t.TempDir()
+	codexBin := filepath.Join(dir, "codex")
+	invokeLog := filepath.Join(dir, "invocations.log")
+	listFile := filepath.Join(dir, "list.json")
+	if err := os.WriteFile(listFile, []byte(listJSON), 0o600); err != nil {
+		t.Fatalf("writing list.json: %v", err)
+	}
+	// Script: list/remove succeed, mcp add SUCCEEDS only when args contain
+	// "pipelock" (the rollback re-adds the wrapped form, which contains
+	// "pipelock" in its command). Unwrap-add (no "pipelock") fails.
+	script := fmt.Sprintf(`#!/bin/sh
+echo "$@" >> %q
+case "$1 $2" in
+"mcp list") cat %q; exit 0 ;;
+"mcp remove") exit 0 ;;
+"mcp add")
+  if echo "$@" | grep -q "pipelock"; then exit 0; fi
+  echo "Error: synthetic unwrap-add failure" >&2
+  exit 1
+  ;;
+esac
+exit 0
+`, invokeLog, listFile)
+	writeShellScript(t, codexBin, script)
+
+	root := newCodexTestRoot()
+	root.SetArgs([]string{"codex", "remove", "--codex-path", codexBin})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	err := root.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatalf("expected error from failed unwrap-add, got nil")
+	}
+	if !strings.Contains(err.Error(), "rolled back") {
+		t.Errorf("error should mention successful rollback, got: %v", err)
+	}
+	logData, readErr := os.ReadFile(filepath.Clean(invokeLog))
+	if readErr != nil {
+		t.Fatalf("reading invoke log: %v", readErr)
+	}
+	logStr := string(logData)
+	if strings.Count(logStr, "mcp add") != 2 {
+		t.Errorf("expected exactly 2 mcp add invocations (unwrap + rollback), got log: %s", logStr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `pipelock codex install` and `pipelock codex remove` as a sister command family to the existing `claude install`, `cursor install`, `vscode install`, and `jetbrains install` commands. Iterates servers reported by `codex mcp list --json` and rewrites each through `pipelock mcp proxy` so MCP traffic from the Codex CLI is scanned by the same pipeline the other IDE integrations use.
- Already-wrapped servers are skipped, with detection that keys on the `pipelock` basename plus the canonical `mcp proxy` args prefix, so a rebuild at a different binary path does not double-wrap servers on the next install.
- State that `codex mcp add` has no flag for is preserved by skipping the server with an explanatory reason rather than silently dropping it: a disabled server stays disabled (the re-add would re-enable it), and servers with cwd, custom startup or tool timeouts, env_vars passthrough, unsafe env keys, or URL auth/header metadata are left untouched. The remove path returns a clean error pointing the operator at manual config edits when those fields are present.

## Implementation notes

- Shells out to `codex mcp add`, `codex mcp remove`, and `codex mcp list` rather than parsing `~/.codex/config.toml` directly. This avoids a TOML dependency and stays aligned with whatever schema the Codex CLI evolves to. The shell-out boundary is narrow: `exec.LookPath` for default discovery, `--codex-path` override, `NO_COLOR=1` in the subprocess env.
- Streamable HTTP (URL) servers convert to stdio with `--upstream`. The remove path reverses both stdio and URL wraps by parsing args after the canonical `mcp proxy` prefix.
- Dry-run output redacts env values (`--env KEY=<redacted>`) so configured credentials never enter terminal scrollback, and quotes each argv token so the preview is unambiguous when a path or arg contains spaces.
- Codex's HTTP fetches (its own model API calls, the WebFetch tool) follow `HTTPS_PROXY` from the user's shell. Codex includes `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` in its `shell_environment_policy.include_only` by default, so no codex-side change is needed there. The `--help` text documents this for operators.
- No new dependencies. Pure-function plan, wrap, and unwrap helpers are unit-tested. End-to-end tests use a fake `codex` shell-script binary so the test suite does not require a real Codex CLI install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pipelock codex install` to wrap Codex MCP servers (supports `--dry-run`, env values redacted).
  * Added `pipelock codex remove` to unwrap Codex MCP servers (idempotent, refuses unsafe restores).

* **Tests**
  * Added comprehensive tests covering install/remove flows, parsing, dry-run output, error and rollback paths.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/499)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->