### PR TITLE
Add pipelock-verifier: standalone Audit Packet + receipt validator

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,6 +50,31 @@ builds:
     ldflags:
       - -s -w
 
+  # Pipelock-verifier: standalone receipt + Audit Packet validator. No
+  # network surface, no proxy, no scanner. Shipped as a separate binary so
+  # consumers (CI runners, third parties) can drop in a pure-verifier without
+  # provisioning the full firewall stack.
+  - id: pipelock-verifier
+    main: ./cmd/pipelock-verifier
+    binary: pipelock-verifier
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/luckyPipewrench/pipelock/internal/cliutil.Version={{.Version}}
+      - -X github.com/luckyPipewrench/pipelock/internal/cliutil.BuildDate={{.Date}}
+      - -X github.com/luckyPipewrench/pipelock/internal/cliutil.GitCommit={{.ShortCommit}}
+      - -X github.com/luckyPipewrench/pipelock/internal/cliutil.GoVersion={{.Env.GOVERSION}}
+
 archives:
   - id: pipelock
     ids: [pipelock]
@@ -59,6 +84,18 @@ archives:
         formats: [zip]
     name_template: >-
       {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- .Arch }}
+
+  - id: pipelock-verifier
+    ids: [pipelock-verifier]
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    name_template: >-
+      pipelock-verifier_
       {{- .Version }}_
       {{- .Os }}_
       {{- .Arch }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,7 +53,11 @@ builds:
   # Pipelock-verifier: standalone receipt + Audit Packet validator. No
   # network surface, no proxy, no scanner. Shipped as a separate binary so
   # consumers (CI runners, third parties) can drop in a pure-verifier without
-  # provisioning the full firewall stack.
+  # provisioning the full firewall stack. Intentionally NOT distributed via
+  # Homebrew or container images yet; raw archives are sufficient for the
+  # bring-your-own-verifier audit use case and keep the surface tight while
+  # the API stabilizes pre-v1. Add brews + dockers stanzas when the action
+  # repo or external pilots ask for them.
   - id: pipelock-verifier
     main: ./cmd/pipelock-verifier
     binary: pipelock-verifier

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,14 @@ LDFLAGS := -ldflags "-s -w \
 	-X $(MODULE)/internal/license.PublicKeyHex=$(LICENSE_PUBLIC_KEY) \
 	-X $(MODULE)/internal/rules.KeyringHex=$(LICENSE_PUBLIC_KEY)"
 
-.PHONY: build test bench lint clean docker install fmt vet tidy-check fuzz stats docs-check \
+.PHONY: build build-verifier test bench lint clean docker install fmt vet tidy-check fuzz stats docs-check \
 	test-runtime-critical test-replay-harness release-audit runtime-policy-audit debt-check release-check
 
 build:
 	go build -trimpath $(LDFLAGS) -o $(BINARY) ./cmd/pipelock
+
+build-verifier:
+	go build -trimpath $(LDFLAGS) -o pipelock-verifier ./cmd/pipelock-verifier
 
 install:
 	go install $(LDFLAGS) ./cmd/pipelock

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,15 @@ LDFLAGS := -ldflags "-s -w \
 build:
 	go build -trimpath $(LDFLAGS) -o $(BINARY) ./cmd/pipelock
 
+VERIFIER_BINARY := pipelock-verifier
+LDFLAGS_VERIFIER := -ldflags "-s -w \
+	-X $(MODULE)/internal/cliutil.Version=$(VERSION) \
+	-X $(MODULE)/internal/cliutil.BuildDate=$(BUILD_DATE) \
+	-X $(MODULE)/internal/cliutil.GitCommit=$(GIT_COMMIT) \
+	-X $(MODULE)/internal/cliutil.GoVersion=$(GO_VERSION)"
+
 build-verifier:
-	go build -trimpath $(LDFLAGS) -o pipelock-verifier ./cmd/pipelock-verifier
+	go build -trimpath $(LDFLAGS_VERIFIER) -o $(VERIFIER_BINARY) ./cmd/pipelock-verifier
 
 install:
 	go install $(LDFLAGS) ./cmd/pipelock
@@ -72,7 +79,7 @@ tidy-check:
 	git diff --exit-code go.mod go.sum
 
 clean:
-	rm -f $(BINARY) coverage.out coverage.html
+	rm -f $(BINARY) $(VERIFIER_BINARY) coverage.out coverage.html
 
 docker:
 	docker build \

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,10 @@ LDFLAGS := -ldflags "-s -w \
 	-X $(MODULE)/internal/license.PublicKeyHex=$(LICENSE_PUBLIC_KEY) \
 	-X $(MODULE)/internal/rules.KeyringHex=$(LICENSE_PUBLIC_KEY)"
 
-.PHONY: build build-verifier test bench lint clean docker install fmt vet tidy-check fuzz stats docs-check \
+.PHONY: all build build-verifier test bench lint clean docker install fmt vet tidy-check fuzz stats docs-check \
 	test-runtime-critical test-replay-harness release-audit runtime-policy-audit debt-check release-check
+
+all: build
 
 build:
 	go build -trimpath $(LDFLAGS) -o $(BINARY) ./cmd/pipelock

--- a/cmd/pipelock-verifier/auditpacket.go
+++ b/cmd/pipelock-verifier/auditpacket.go
@@ -278,6 +278,17 @@ func resolveArtifactPath(baseDir, rel string) (string, error) {
 	if err != nil || strings.HasPrefix(rel2, ".."+string(filepath.Separator)) || rel2 == ".." {
 		return "", fmt.Errorf("artifact path escapes packet directory after resolution: %q", rel)
 	}
+	// Re-check containment after symlink resolution. filepath.Rel inspects
+	// the path string only; a packet whose evidence.jsonl is itself a
+	// symlink to /etc/passwd would pass the path check and read outside the
+	// packet dir at open time. EvalSymlinks fails when the target does not
+	// yet exist, which is fine: downstream open will still fail.
+	if resolved, evalErr := filepath.EvalSymlinks(absFull); evalErr == nil {
+		rel3, relErr := filepath.Rel(absBase, resolved)
+		if relErr != nil || rel3 == ".." || strings.HasPrefix(rel3, ".."+string(filepath.Separator)) {
+			return "", fmt.Errorf("artifact path escapes packet directory via symlink: %q", rel)
+		}
+	}
 	return full, nil
 }
 

--- a/cmd/pipelock-verifier/auditpacket.go
+++ b/cmd/pipelock-verifier/auditpacket.go
@@ -1,0 +1,412 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	auditpacket "github.com/luckyPipewrench/pipelock/sdk/audit-packet"
+)
+
+// Stable status labels emitted in the textual report and the JSON
+// schema_check / chain_check / cross_check fields.
+const (
+	statusPass    = "pass"
+	statusFail    = "fail"
+	statusSkipped = "skipped"
+)
+
+// auditPacketOptions holds resolved CLI flags for the audit-packet command.
+type auditPacketOptions struct {
+	signerKey   string
+	jsonOutput  bool
+	offline     bool
+	allowSCO    bool
+	relaxTrust  bool
+	expectedSHA string
+}
+
+func newAuditPacketCmd() *cobra.Command {
+	var opts auditPacketOptions
+
+	cmd := &cobra.Command{
+		Use:   "audit-packet PATH",
+		Short: "Verify a Pipelock Audit Packet (v0)",
+		Long: `Validates an Audit Packet against the locked pipelock.audit_packet.v0
+schema, then re-verifies the embedded receipt chain and confirms that the
+packet's claimed verdict, receipt_count, and totals match the chain's
+actual contents.
+
+PATH may be either:
+
+  - A directory containing packet.json plus its sibling artifacts.
+  - A path to packet.json directly. Sibling artifacts are resolved
+    relative to the file's parent directory.
+
+Without --offline, the verifier reads artifacts.evidence (as recorded in
+the packet) and re-verifies the chain. With --offline, only the packet
+itself is validated.
+
+Without --key the verifier confirms internal chain self-consistency
+(prev-hash linkage, signer agreement) but cannot prove provenance. A
+packet that claims verdict=valid AND trusted=true MUST carry signer_key,
+and --key (or the packet's own signer_key) must match.`,
+		Args:          exactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAuditPacket(cmd.OutOrStdout(), cmd.ErrOrStderr(), args[0], opts)
+		},
+	}
+	cmd.SetFlagErrorFunc(usageFlagError)
+
+	cmd.Flags().StringVar(&opts.signerKey, "key", "", "expected signer public key (hex, public-key text, or file path)")
+	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit a structured JSON verdict on stdout")
+	cmd.Flags().BoolVar(&opts.offline, "offline", false, "validate only the packet schema; skip chain re-verification")
+	cmd.Flags().BoolVar(&opts.allowSCO, "allow-self-consistent-only", false, "do not fail when the packet's verdict is self_consistent_only")
+	cmd.Flags().BoolVar(&opts.relaxTrust, "no-trust-required", false, "do not require trusted=true; report verdict as-is")
+	cmd.Flags().StringVar(&opts.expectedSHA, "expect-sha256", "", "if set, fail when packet.json's SHA-256 does not match this hex digest")
+
+	return cmd
+}
+
+// auditPacketReport is the structured form emitted by --json. Field names are
+// deliberately stable so external CI checks can grep them.
+type auditPacketReport struct {
+	Path        string         `json:"path"`
+	Verdict     string         `json:"verdict"`
+	Trusted     bool           `json:"trusted"`
+	Valid       bool           `json:"valid"`
+	Summary     auditPktDigest `json:"summary"`
+	Posture     posturePeek    `json:"posture"`
+	Run         runPeek        `json:"run"`
+	Errors      []string       `json:"errors,omitempty"`
+	Warnings    []string       `json:"warnings,omitempty"`
+	SchemaCheck string         `json:"schema_check"`
+	ChainCheck  string         `json:"chain_check"`
+	CrossCheck  string         `json:"cross_check"`
+}
+
+type auditPktDigest struct {
+	ReceiptCount int            `json:"receipt_count"`
+	Totals       map[string]int `json:"totals"`
+}
+
+type posturePeek struct {
+	EnforcementMode  string   `json:"enforcement_mode"`
+	UnsupportedPaths []string `json:"unsupported_paths"`
+}
+
+type runPeek struct {
+	Provider      string `json:"provider"`
+	Repository    string `json:"repository,omitempty"`
+	SHA           string `json:"sha,omitempty"`
+	AgentIdentity string `json:"agent_identity"`
+}
+
+func runAuditPacket(stdout, stderr io.Writer, target string, opts auditPacketOptions) error {
+	packetPath, baseDir, err := resolvePacketPath(target)
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+	}
+
+	report := auditPacketReport{
+		Path:        packetPath,
+		SchemaCheck: statusSkipped,
+		ChainCheck:  statusSkipped,
+		CrossCheck:  statusSkipped,
+	}
+
+	rawPacket, err := os.ReadFile(filepath.Clean(packetPath))
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("read packet: %w", err))
+	}
+
+	if opts.expectedSHA != "" {
+		if err := verifyExpectedSHA(rawPacket, opts.expectedSHA); err != nil {
+			report.Errors = append(report.Errors, err.Error())
+			emitReport(stdout, stderr, report, opts.jsonOutput)
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, err)
+		}
+	}
+
+	var packet auditpacket.Packet
+	if err := json.Unmarshal(rawPacket, &packet); err != nil {
+		report.Errors = append(report.Errors, fmt.Sprintf("packet json: %v", err))
+		emitReport(stdout, stderr, report, opts.jsonOutput)
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("unmarshal packet: %w", err))
+	}
+
+	report.Verdict = packet.Verifier.Verdict
+	report.Trusted = packet.Verifier.Trusted
+	populateReportFromPacket(&report, &packet)
+
+	if err := packet.Validate(); err != nil {
+		report.SchemaCheck = statusFail
+		report.Errors = append(report.Errors, fmt.Sprintf("schema: %v", err))
+		emitReport(stdout, stderr, report, opts.jsonOutput)
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("packet schema: %w", err))
+	}
+	report.SchemaCheck = statusPass
+
+	if opts.offline {
+		report.Valid = trustVerdict(&packet, opts)
+		emitReport(stdout, stderr, report, opts.jsonOutput)
+		if !report.Valid {
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, errors.New("packet not trusted"))
+		}
+		return nil
+	}
+
+	chainResult, chainReceipts, chainErr := reverifyChain(baseDir, &packet, opts.signerKey)
+	if chainErr != nil {
+		report.ChainCheck = statusFail
+		report.Errors = append(report.Errors, fmt.Sprintf("chain: %v", chainErr))
+		emitReport(stdout, stderr, report, opts.jsonOutput)
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, chainErr)
+	}
+	report.ChainCheck = chainStatusLabel(chainResult)
+
+	if crossErrs := crossCheck(&packet, chainResult, chainReceipts); len(crossErrs) > 0 {
+		report.CrossCheck = statusFail
+		for _, e := range crossErrs {
+			report.Errors = append(report.Errors, fmt.Sprintf("cross-check: %v", e))
+		}
+		emitReport(stdout, stderr, report, opts.jsonOutput)
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, errors.New("packet vs chain mismatch"))
+	}
+	report.CrossCheck = statusPass
+
+	report.Valid = chainResult.Valid && trustVerdict(&packet, opts)
+	emitReport(stdout, stderr, report, opts.jsonOutput)
+	if !report.Valid {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, errors.New("packet not trusted"))
+	}
+	return nil
+}
+
+func populateReportFromPacket(r *auditPacketReport, p *auditpacket.Packet) {
+	totals := map[string]int{
+		"allow":    p.Summary.Totals.Allow,
+		"block":    p.Summary.Totals.Block,
+		"warn":     p.Summary.Totals.Warn,
+		"ask":      p.Summary.Totals.Ask,
+		"strip":    p.Summary.Totals.Strip,
+		"forward":  p.Summary.Totals.Forward,
+		"redirect": p.Summary.Totals.Redirect,
+		"other":    p.Summary.Totals.Other,
+	}
+	r.Summary = auditPktDigest{
+		ReceiptCount: p.Summary.ReceiptCount,
+		Totals:       totals,
+	}
+	r.Posture = posturePeek{
+		EnforcementMode:  p.Posture.EnforcementMode,
+		UnsupportedPaths: append([]string(nil), p.Posture.UnsupportedPaths...),
+	}
+	r.Run = runPeek{
+		Provider:      p.Run.Provider,
+		Repository:    p.Run.Repository,
+		SHA:           p.Run.SHA,
+		AgentIdentity: p.Run.AgentIdentity,
+	}
+}
+
+// resolvePacketPath accepts either a directory or a packet.json path and
+// returns (packet.json path, sibling-artifact base directory).
+func resolvePacketPath(target string) (string, string, error) {
+	clean := filepath.Clean(target)
+	info, err := os.Stat(clean)
+	if err != nil {
+		return "", "", fmt.Errorf("stat %q: %w", target, err)
+	}
+	if info.IsDir() {
+		return filepath.Join(clean, "packet.json"), clean, nil
+	}
+	return clean, filepath.Dir(clean), nil
+}
+
+// verifyExpectedSHA compares the SHA-256 of raw against the user-supplied
+// hex digest. Useful when an out-of-band trust anchor pins the packet bytes.
+func verifyExpectedSHA(raw []byte, want string) error {
+	want = strings.TrimSpace(strings.ToLower(want))
+	got := sha256Hex(raw)
+	if got != want {
+		return fmt.Errorf("packet sha256 mismatch: got %s, want %s", got, want)
+	}
+	return nil
+}
+
+// resolveArtifactPath joins base + relative artifact path with a containment
+// check, mirroring the schema's $defs/artifact_path validation.
+func resolveArtifactPath(baseDir, rel string) (string, error) {
+	if rel == "" {
+		return "", errors.New("artifact path is empty")
+	}
+	if filepath.IsAbs(rel) {
+		return "", fmt.Errorf("artifact path must be relative: %q", rel)
+	}
+	if strings.Contains(rel, "\\") || strings.Contains(rel, ":") {
+		return "", fmt.Errorf("artifact path contains forbidden character: %q", rel)
+	}
+	clean := filepath.Clean(rel)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("artifact path escapes packet directory: %q", rel)
+	}
+	full := filepath.Join(baseDir, clean)
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve base dir: %w", err)
+	}
+	absFull, err := filepath.Abs(full)
+	if err != nil {
+		return "", fmt.Errorf("resolve artifact: %w", err)
+	}
+	rel2, err := filepath.Rel(absBase, absFull)
+	if err != nil || strings.HasPrefix(rel2, ".."+string(filepath.Separator)) || rel2 == ".." {
+		return "", fmt.Errorf("artifact path escapes packet directory after resolution: %q", rel)
+	}
+	return full, nil
+}
+
+func reverifyChain(baseDir string, packet *auditpacket.Packet, signerOverride string) (receipt.ChainResult, []receipt.Receipt, error) {
+	evidencePath, err := resolveArtifactPath(baseDir, packet.Artifacts.Evidence)
+	if err != nil {
+		return receipt.ChainResult{}, nil, fmt.Errorf("evidence: %w", err)
+	}
+	receipts, err := receipt.ExtractReceipts(evidencePath)
+	if err != nil {
+		return receipt.ChainResult{}, nil, fmt.Errorf("extract receipts: %w", err)
+	}
+	keyHex := strings.TrimSpace(signerOverride)
+	if keyHex == "" {
+		keyHex = strings.TrimSpace(packet.Verifier.SignerKey)
+	}
+	resolvedKey, err := resolveSignerKey(keyHex)
+	if err != nil {
+		return receipt.ChainResult{}, nil, fmt.Errorf("resolve signer key: %w", err)
+	}
+	return receipt.VerifyChain(receipts, resolvedKey), receipts, nil
+}
+
+// crossCheck enforces that the packet's claimed totals, receipt_count, and
+// root_hash match the chain's actual contents. This is the post-emission
+// tamper-detection layer: a packet whose totals were edited after writing
+// will fail here even if both the schema and the chain individually verify.
+func crossCheck(packet *auditpacket.Packet, chain receipt.ChainResult, receipts []receipt.Receipt) []error {
+	var errs []error
+
+	if packet.Summary.ReceiptCount < 0 || chain.ReceiptCount != uint64(packet.Summary.ReceiptCount) {
+		errs = append(errs, fmt.Errorf("chain receipt_count %d != packet.summary.receipt_count %d", chain.ReceiptCount, packet.Summary.ReceiptCount))
+	}
+
+	expectedTotals := computeTotals(receipts)
+	gotTotals := map[string]int{
+		"allow":    packet.Summary.Totals.Allow,
+		"block":    packet.Summary.Totals.Block,
+		"warn":     packet.Summary.Totals.Warn,
+		"ask":      packet.Summary.Totals.Ask,
+		"strip":    packet.Summary.Totals.Strip,
+		"forward":  packet.Summary.Totals.Forward,
+		"redirect": packet.Summary.Totals.Redirect,
+		"other":    packet.Summary.Totals.Other,
+	}
+	for _, k := range sortedKeys(expectedTotals) {
+		if expectedTotals[k] != gotTotals[k] {
+			errs = append(errs, fmt.Errorf("totals[%s]: chain=%d packet=%d", k, expectedTotals[k], gotTotals[k]))
+		}
+	}
+
+	// root_hash + final_seq are optional in v0. Cross-check only when set.
+	if packet.Verifier.RootHash != "" && packet.Verifier.RootHash != chain.RootHash {
+		errs = append(errs, fmt.Errorf("root_hash mismatch: chain=%s packet=%s", chain.RootHash, packet.Verifier.RootHash))
+	}
+	if packet.Verifier.FinalSeq != 0 && (packet.Verifier.FinalSeq < 0 || uint64(packet.Verifier.FinalSeq) != chain.FinalSeq) {
+		errs = append(errs, fmt.Errorf("final_seq mismatch: chain=%d packet=%d", chain.FinalSeq, packet.Verifier.FinalSeq))
+	}
+
+	// verdict-vs-chain agreement: chain.Valid must align with verdict
+	// semantics. valid+trusted requires Valid; invalid requires !Valid; error
+	// and not_run carry no chain claim. self_consistent_only requires Valid
+	// (the chain hashed up) but no trust claim.
+	switch packet.Verifier.Verdict {
+	case auditpacket.VerdictValid, auditpacket.VerdictSelfConsistentOnly:
+		if !chain.Valid {
+			errs = append(errs, fmt.Errorf("verdict=%s but chain rejected: %s", packet.Verifier.Verdict, chain.Error))
+		}
+	case auditpacket.VerdictInvalid:
+		if chain.Valid {
+			errs = append(errs, errors.New("verdict=invalid but chain re-verified successfully"))
+		}
+	}
+
+	return errs
+}
+
+func computeTotals(receipts []receipt.Receipt) map[string]int {
+	totals := map[string]int{
+		"allow":    0,
+		"block":    0,
+		"warn":     0,
+		"ask":      0,
+		"strip":    0,
+		"forward":  0,
+		"redirect": 0,
+		"other":    0,
+	}
+	for _, r := range receipts {
+		v := strings.ToLower(strings.TrimSpace(r.ActionRecord.Verdict))
+		if _, ok := totals[v]; ok {
+			totals[v]++
+			continue
+		}
+		totals["other"]++
+	}
+	return totals
+}
+
+func sortedKeys(m map[string]int) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// trustVerdict applies the verifier's trust policy. Valid+trusted is always
+// trusted. self_consistent_only is opt-in via --allow-self-consistent-only;
+// the schema requires Trusted=false on it. --no-trust-required degrades the
+// check to "did the schema and chain both pass".
+func trustVerdict(packet *auditpacket.Packet, opts auditPacketOptions) bool {
+	if opts.relaxTrust {
+		return true
+	}
+	switch packet.Verifier.Verdict {
+	case auditpacket.VerdictValid:
+		return packet.Verifier.Trusted
+	case auditpacket.VerdictSelfConsistentOnly:
+		return opts.allowSCO
+	default:
+		return false
+	}
+}
+
+func chainStatusLabel(c receipt.ChainResult) string {
+	if c.Valid {
+		return statusPass
+	}
+	return statusFail
+}

--- a/cmd/pipelock-verifier/chain.go
+++ b/cmd/pipelock-verifier/chain.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -86,18 +87,19 @@ func runChain(stdout, stderr io.Writer, target string, opts chainOptions) error 
 		}
 		label = fmt.Sprintf("%s (session %s)", target, opts.sessionID)
 	} else {
-		info, statErr := os.Stat(target)
+		clean := filepath.Clean(target)
+		info, statErr := os.Stat(clean)
 		if statErr != nil {
 			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("stat %q: %w", target, statErr))
 		}
 		if info.IsDir() {
 			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("%q is a directory; pass --dir to verify a session directory", target))
 		}
-		receipts, err = receipt.ExtractReceipts(target)
+		receipts, err = receipt.ExtractReceipts(clean)
 		if err != nil {
 			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("extract receipts: %w", err))
 		}
-		label = target
+		label = clean
 	}
 
 	if len(receipts) == 0 {

--- a/cmd/pipelock-verifier/chain.go
+++ b/cmd/pipelock-verifier/chain.go
@@ -81,11 +81,12 @@ func runChain(stdout, stderr io.Writer, target string, opts chainOptions) error 
 		label    string
 	)
 	if opts.asDir {
-		receipts, err = receipt.ExtractReceiptsFromSessionDir(target, opts.sessionID)
+		clean := filepath.Clean(target)
+		receipts, err = receipt.ExtractReceiptsFromSessionDir(clean, opts.sessionID)
 		if err != nil {
 			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("extract receipts: %w", err))
 		}
-		label = fmt.Sprintf("%s (session %s)", target, opts.sessionID)
+		label = fmt.Sprintf("%s (session %s)", clean, opts.sessionID)
 	} else {
 		clean := filepath.Clean(target)
 		info, statErr := os.Stat(clean)

--- a/cmd/pipelock-verifier/chain.go
+++ b/cmd/pipelock-verifier/chain.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+// chainOptions holds resolved CLI flags for the chain subcommand.
+type chainOptions struct {
+	signerKey  string
+	sessionID  string
+	jsonOutput bool
+	asDir      bool
+}
+
+func newChainCmd() *cobra.Command {
+	var opts chainOptions
+
+	cmd := &cobra.Command{
+		Use:   "chain PATH",
+		Short: "Verify a Pipelock receipt chain",
+		Long: `Verifies the hash linkage and Ed25519 signatures of a Pipelock receipt
+chain. PATH may be a single .jsonl evidence file or a session directory
+when --dir is set.
+
+Without --key the verifier confirms self-consistency: every receipt's
+signer must match the first receipt's signer, and prev-hash linkage must
+hold. Self-consistency does not prove provenance.
+
+With --key the verifier requires every receipt to be signed by the named
+key.`,
+		Args:          exactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runChain(cmd.OutOrStdout(), cmd.ErrOrStderr(), args[0], opts)
+		},
+	}
+	cmd.SetFlagErrorFunc(usageFlagError)
+
+	cmd.Flags().StringVar(&opts.signerKey, "key", "", "expected signer public key (hex, public-key text, or file path)")
+	cmd.Flags().StringVar(&opts.sessionID, "session", "proxy", "session ID inside the evidence directory (--dir)")
+	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit a structured JSON verdict on stdout")
+	cmd.Flags().BoolVar(&opts.asDir, "dir", false, "treat PATH as a session directory rather than a single file")
+
+	return cmd
+}
+
+// chainReport is the structured form emitted by --json on the chain
+// subcommand.
+type chainReport struct {
+	Path         string `json:"path"`
+	Valid        bool   `json:"valid"`
+	ReceiptCount uint64 `json:"receipt_count"`
+	FinalSeq     uint64 `json:"final_seq"`
+	RootHash     string `json:"root_hash,omitempty"`
+	Error        string `json:"error,omitempty"`
+	BrokenAtSeq  uint64 `json:"broken_at_seq,omitempty"`
+}
+
+func runChain(stdout, stderr io.Writer, target string, opts chainOptions) error {
+	keyHex, err := resolveSignerKey(strings.TrimSpace(opts.signerKey))
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("resolve signer key: %w", err))
+	}
+
+	var (
+		receipts []receipt.Receipt
+		label    string
+	)
+	if opts.asDir {
+		receipts, err = receipt.ExtractReceiptsFromSessionDir(target, opts.sessionID)
+		if err != nil {
+			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("extract receipts: %w", err))
+		}
+		label = fmt.Sprintf("%s (session %s)", target, opts.sessionID)
+	} else {
+		info, statErr := os.Stat(target)
+		if statErr != nil {
+			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("stat %q: %w", target, statErr))
+		}
+		if info.IsDir() {
+			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("%q is a directory; pass --dir to verify a session directory", target))
+		}
+		receipts, err = receipt.ExtractReceipts(target)
+		if err != nil {
+			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("extract receipts: %w", err))
+		}
+		label = target
+	}
+
+	if len(receipts) == 0 {
+		report := chainReport{Path: label, Valid: false, Error: "no receipts in chain"}
+		emitChainReport(stdout, stderr, report, opts.jsonOutput)
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, errors.New("empty chain"))
+	}
+
+	res := receipt.VerifyChain(receipts, keyHex)
+	report := chainReport{
+		Path:         label,
+		Valid:        res.Valid,
+		ReceiptCount: res.ReceiptCount,
+		FinalSeq:     res.FinalSeq,
+		RootHash:     res.RootHash,
+		Error:        res.Error,
+		BrokenAtSeq:  res.BrokenAtSeq,
+	}
+	emitChainReport(stdout, stderr, report, opts.jsonOutput)
+	if !res.Valid {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("chain rejected at seq %d: %s", res.BrokenAtSeq, res.Error))
+	}
+	return nil
+}

--- a/cmd/pipelock-verifier/main.go
+++ b/cmd/pipelock-verifier/main.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main is the entry point for pipelock-verifier, a self-contained
+// binary that verifies Pipelock action receipts and Audit Packets.
+//
+// The binary is deliberately separate from `pipelock` so callers (CI runners,
+// auditors, third parties) can drop in just the verifier without provisioning
+// the full firewall stack. There is no network surface, no proxy, no scanner,
+// and no config reload. It reads files, validates them, and exits.
+//
+// Subcommands:
+//
+//	audit-packet PATH   Validate an Audit Packet directory (packet.json plus
+//	                    sibling artifacts) against the v0 schema, then
+//	                    re-verify the embedded receipt chain and confirm the
+//	                    packet's claimed verdict / receipt_count / totals
+//	                    match the chain's actual contents.
+//	chain PATH          Verify a receipt chain (single .jsonl file or a
+//	                    session directory) for hash linkage and signatures.
+//	receipt PATH        Verify a single receipt JSON file's signature.
+//
+// All subcommands accept --key (raw hex, public-key text, or file path) for
+// trusted verification, and --json for machine-readable output. Exit codes:
+// 0 valid, 1 invalid, 2 error, 64 usage error.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+const exitUsage = 64
+
+func main() {
+	root := newRootCmd()
+	if err := root.Execute(); err != nil {
+		// cobra prints the error itself; we map it to a structured exit code.
+		os.Exit(exitCodeFor(err))
+	}
+}
+
+func newRootCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:   "pipelock-verifier",
+		Short: "Verify Pipelock action receipts and Audit Packets",
+		Long: `pipelock-verifier validates Pipelock action receipts, receipt chains, and
+Audit Packets against the locked v0 schema and signing rules. It is a
+self-contained binary with no network surface; consumers can drop it into a
+CI runner, an auditor's laptop, or an isolated environment.`,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		Version:       cliutil.Version,
+	}
+	root.SetFlagErrorFunc(usageFlagError)
+	root.SetVersionTemplate(fmt.Sprintf(
+		"pipelock-verifier %s (commit %s, built %s, %s)\n",
+		cliutil.Version, cliutil.GitCommit, cliutil.BuildDate, cliutil.GoVersion,
+	))
+
+	root.AddCommand(newAuditPacketCmd())
+	root.AddCommand(newChainCmd())
+	root.AddCommand(newReceiptCmd())
+
+	return root
+}
+
+func exactArgs(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := cobra.ExactArgs(n)(cmd, args); err != nil {
+			return cliutil.ExitCodeError(exitUsage, err)
+		}
+		return nil
+	}
+}
+
+func usageFlagError(_ *cobra.Command, err error) error {
+	return cliutil.ExitCodeError(exitUsage, err)
+}

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -753,6 +753,23 @@ func TestResolveArtifactPath(t *testing.T) {
 	}
 }
 
+func TestResolveArtifactPath_SymlinkContainmentRejected(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	outside := t.TempDir()
+	outsideTarget := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(outsideTarget, []byte("secret\n"), 0o600); err != nil {
+		t.Fatalf("write outside target: %v", err)
+	}
+	link := filepath.Join(base, "evidence.jsonl")
+	if err := os.Symlink(outsideTarget, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if _, err := resolveArtifactPath(base, "evidence.jsonl"); err == nil {
+		t.Fatalf("symlinked artifact pointing outside packet dir should be rejected")
+	}
+}
+
 func TestVerifyExpectedSHA(t *testing.T) {
 	t.Parallel()
 	data := []byte("payload")

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -1,0 +1,1061 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	auditpacket "github.com/luckyPipewrench/pipelock/sdk/audit-packet"
+)
+
+// Test-local constants to keep goconst happy.
+const (
+	tHTTPS         = "https"
+	tNotPipelock   = "not-pipelock"
+	verdictAllowed = "allow"
+)
+
+// fixture holds a fully signed chain of receipts plus the keys that signed
+// them. Tests reuse this shape to derive packets, evidence files, and
+// signing-key files.
+type fixture struct {
+	pub      ed25519.PublicKey
+	priv     ed25519.PrivateKey
+	receipts []receipt.Receipt
+	keyHex   string
+}
+
+func newFixture(t *testing.T, n int) *fixture {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey: %v", err)
+	}
+	receipts := make([]receipt.Receipt, 0, n)
+	prev := receipt.GenesisHash
+	base := time.Date(2026, 5, 10, 14, 0, 0, 0, time.UTC)
+	for i := range n {
+		ar := receipt.ActionRecord{
+			Version:       receipt.ActionRecordVersion,
+			ActionID:      receipt.NewActionID(),
+			ActionType:    receipt.ActionRead,
+			Timestamp:     base.Add(time.Duration(i) * time.Second),
+			Target:        "https://example.com/" + verdictAllowed,
+			Verdict:       verdictAllowed,
+			Transport:     tHTTPS,
+			ChainPrevHash: prev,
+			ChainSeq:      uint64(i),
+			PolicyHash:    "policy-fixture",
+		}
+		r, err := receipt.Sign(ar, priv)
+		if err != nil {
+			t.Fatalf("Sign[%d]: %v", i, err)
+		}
+		h, err := receipt.ReceiptHash(r)
+		if err != nil {
+			t.Fatalf("ReceiptHash[%d]: %v", i, err)
+		}
+		prev = h
+		receipts = append(receipts, r)
+	}
+	return &fixture{
+		pub:      pub,
+		priv:     priv,
+		receipts: receipts,
+		keyHex:   hex.EncodeToString(pub),
+	}
+}
+
+// writePacketDir lays out evidence.jsonl + verifier.txt + packet.json under
+// dir. If mutate is non-nil it is called on the packet just before writing
+// so individual tests can tamper specific fields.
+func (f *fixture) writePacketDir(t *testing.T, dir string, mutate func(*auditpacket.Packet)) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	evidence := filepath.Join(dir, "evidence.jsonl")
+	fhandle, err := os.OpenFile(filepath.Clean(evidence), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("create evidence: %v", err)
+	}
+	prev := recorder.GenesisHash
+	base := time.Date(2026, 5, 10, 14, 0, 0, 0, time.UTC)
+	for i, r := range f.receipts {
+		entry := recorder.Entry{
+			Version:   recorder.EntryVersion,
+			Sequence:  uint64(i),
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+			SessionID: "proxy",
+			Type:      "action_receipt",
+			Transport: tHTTPS,
+			Summary:   verdictAllowed,
+			Detail:    r,
+			PrevHash:  prev,
+		}
+		entry.Hash = recorder.ComputeHash(entry)
+		line, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("Marshal entry: %v", err)
+		}
+		prev = entry.Hash
+		if _, err := fhandle.Write(line); err != nil {
+			t.Fatalf("write evidence: %v", err)
+		}
+		if _, err := fhandle.WriteString("\n"); err != nil {
+			t.Fatalf("write newline: %v", err)
+		}
+	}
+	if err := fhandle.Close(); err != nil {
+		t.Fatalf("close evidence: %v", err)
+	}
+	verifier := filepath.Join(dir, "verifier.txt")
+	if err := os.WriteFile(verifier, []byte("synthetic\n"), 0o600); err != nil {
+		t.Fatalf("write verifier.txt: %v", err)
+	}
+	pkt := f.basePacket(len(f.receipts))
+	if mutate != nil {
+		mutate(&pkt)
+	}
+	pktPath := filepath.Join(dir, "packet.json")
+	pktBytes, err := json.MarshalIndent(pkt, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	if err := os.WriteFile(pktPath, pktBytes, 0o600); err != nil {
+		t.Fatalf("write packet.json: %v", err)
+	}
+	return pktPath
+}
+
+// basePacket builds a v0-conformant packet that matches the fixture's chain.
+// All counts go to summary.totals.allow, since the fixture mints `allowed`
+// verdicts. trusted=true and verdict=valid because the fixture pins a key.
+func (f *fixture) basePacket(n int) auditpacket.Packet {
+	return auditpacket.Packet{
+		SchemaVersion: auditpacket.SchemaVersion,
+		GeneratedAt:   "2026-05-10T14:00:00Z",
+		Run: auditpacket.Run{
+			Provider:      auditpacket.ProviderLocal,
+			AgentIdentity: "fixture-agent",
+			StartedAt:     "2026-05-10T14:00:00Z",
+		},
+		Policy: auditpacket.Policy{
+			PolicyHashes: []string{"policy-fixture"},
+		},
+		Summary: auditpacket.Summary{
+			ReceiptCount: n,
+			Totals: auditpacket.Totals{
+				Allow: n,
+			},
+		},
+		Verifier: auditpacket.Verifier{
+			Verdict:   auditpacket.VerdictValid,
+			Trusted:   true,
+			SignerKey: f.keyHex,
+		},
+		Posture: auditpacket.Posture{
+			EnforcementMode:        "linux_netns_iptables_setpriv",
+			RunnerOS:               "Linux",
+			RawSocketStatus:        auditpacket.StatusDenied,
+			DockerSocketStatus:     auditpacket.StatusMasked,
+			DNSUDPStatus:           auditpacket.StatusDenied,
+			BrowserProxyStatus:     auditpacket.StatusForced,
+			WebsocketFrameScanning: auditpacket.WebsocketFrameScanningExplicitProxyPathRequired,
+			UnsupportedPaths:       []string{"mcp_transports", "ssh_egress"},
+		},
+		Artifacts: auditpacket.Artifacts{
+			Packet:   "packet.json",
+			Summary:  "summary.md",
+			Evidence: "evidence.jsonl",
+			Verifier: "verifier.txt",
+		},
+	}
+}
+
+// runRoot drives the full cobra root with the given args and captures
+// stdout, stderr, and the resolved exit code.
+func runRoot(t *testing.T, args ...string) (string, string, int) {
+	t.Helper()
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs(args)
+	err := root.Execute()
+	return stdout.String(), stderr.String(), exitCodeFor(err)
+}
+
+func TestAuditPacket_HappyPath(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 3)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+
+	stdout, stderr, code := runRoot(t, "audit-packet", dir)
+	if code != cliutil.ExitOK {
+		t.Fatalf("exit code = %d, stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "VALID") {
+		t.Errorf("stdout missing VALID: %s", stdout)
+	}
+}
+
+func TestAuditPacket_OfflineMode(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	pkt := fix.writePacketDir(t, dir, nil)
+
+	// Delete evidence.jsonl to prove --offline does not read it.
+	if err := os.Remove(filepath.Join(dir, "evidence.jsonl")); err != nil {
+		t.Fatalf("remove evidence: %v", err)
+	}
+
+	stdout, stderr, code := runRoot(t, "audit-packet", "--offline", pkt)
+	if code != cliutil.ExitOK {
+		t.Fatalf("offline mode failed: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "chain:        skipped") {
+		t.Errorf("expected chain skipped marker, got %s", stdout)
+	}
+}
+
+func TestAuditPacket_SchemaViolation(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 1)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, func(p *auditpacket.Packet) {
+		p.SchemaVersion = "pipelock.audit_packet.v999" // forbidden
+	})
+
+	stdout, stderr, code := runRoot(t, "audit-packet", dir)
+	if code == cliutil.ExitOK {
+		t.Fatalf("expected non-zero exit on schema violation, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "schema") {
+		t.Errorf("expected schema error in stderr, got %q", stderr)
+	}
+}
+
+func TestAuditPacket_TotalsMismatch(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 4)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, func(p *auditpacket.Packet) {
+		// Tamper: claim 3 allows + 1 block when chain has 4 allows.
+		p.Summary.Totals.Allow = 3
+		p.Summary.Totals.Block = 1
+	})
+
+	stdout, stderr, code := runRoot(t, "audit-packet", dir)
+	if code == cliutil.ExitOK {
+		t.Fatalf("expected mismatch failure, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "totals") {
+		t.Errorf("expected totals error in stderr, got %q", stderr)
+	}
+}
+
+func TestAuditPacket_ReceiptCountMismatch(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 3)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, func(p *auditpacket.Packet) {
+		// receipt_count claims 2 but chain has 3. Totals must still sum to
+		// receipt_count for the schema to pass, so adjust both.
+		p.Summary.ReceiptCount = 2
+		p.Summary.Totals.Allow = 2
+	})
+
+	_, stderr, code := runRoot(t, "audit-packet", dir)
+	if code == cliutil.ExitOK {
+		t.Fatalf("expected receipt_count mismatch failure, stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "receipt_count") {
+		t.Errorf("expected receipt_count error in stderr, got %q", stderr)
+	}
+}
+
+func TestAuditPacket_VerdictTamperedToInvalid(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, func(p *auditpacket.Packet) {
+		// Schema requires verdict=valid <-> trusted=true. Tamper consistently
+		// across both fields to pass schema, fail cross-check.
+		p.Verifier.Verdict = auditpacket.VerdictInvalid
+		p.Verifier.Trusted = false
+	})
+
+	_, stderr, code := runRoot(t, "audit-packet", dir)
+	if code == cliutil.ExitOK {
+		t.Fatalf("expected verdict-vs-chain mismatch failure, stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "chain re-verified") {
+		t.Errorf("expected chain re-verified note, got %q", stderr)
+	}
+}
+
+func TestAuditPacket_SelfConsistentOnly_DefaultRejected(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, func(p *auditpacket.Packet) {
+		// Schema requires Trusted=false on self_consistent_only and signer_key
+		// must be omitted (we omit it here even though the chain pins one,
+		// because that is exactly the ephemeral-key shape).
+		p.Verifier.Verdict = auditpacket.VerdictSelfConsistentOnly
+		p.Verifier.Trusted = false
+		p.Verifier.SignerKey = ""
+	})
+
+	_, _, code := runRoot(t, "audit-packet", dir)
+	if code == cliutil.ExitOK {
+		t.Fatalf("self_consistent_only should be rejected without --allow-self-consistent-only")
+	}
+}
+
+func TestAuditPacket_SelfConsistentOnly_Allowed(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, func(p *auditpacket.Packet) {
+		p.Verifier.Verdict = auditpacket.VerdictSelfConsistentOnly
+		p.Verifier.Trusted = false
+		p.Verifier.SignerKey = ""
+	})
+
+	stdout, stderr, code := runRoot(t, "audit-packet", "--allow-self-consistent-only", dir)
+	if code != cliutil.ExitOK {
+		t.Fatalf("expected pass with allow-self-consistent-only, code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+}
+
+func TestAuditPacket_NoTrustRequired(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, func(p *auditpacket.Packet) {
+		// Use error verdict to prove the flag relaxes any verdict.
+		p.Verifier.Verdict = auditpacket.VerdictError
+		p.Verifier.Trusted = false
+		p.Verifier.SignerKey = ""
+	})
+
+	// Without --no-trust-required this would fail; cross-check still runs
+	// against an error-verdict packet, so we also need a tampered chain
+	// claim set to error to bypass the verdict-vs-chain agreement check.
+	_, stderr, code := runRoot(t, "audit-packet", "--no-trust-required", dir)
+	if code != cliutil.ExitOK {
+		t.Fatalf("--no-trust-required should pass error verdict, stderr=%q", stderr)
+	}
+}
+
+func TestAuditPacket_ExpectedSHAMismatch(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 1)
+	dir := t.TempDir()
+	pkt := fix.writePacketDir(t, dir, nil)
+
+	_, stderr, code := runRoot(t, "audit-packet", "--expect-sha256", strings.Repeat("a", 64), pkt)
+	if code == cliutil.ExitOK {
+		t.Fatalf("expected sha mismatch failure, stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "sha256 mismatch") {
+		t.Errorf("expected sha256 mismatch text, got %q", stderr)
+	}
+}
+
+func TestAuditPacket_ExpectedSHAMatch(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 1)
+	dir := t.TempDir()
+	pkt := fix.writePacketDir(t, dir, nil)
+	raw, err := os.ReadFile(filepath.Clean(pkt))
+	if err != nil {
+		t.Fatalf("read packet: %v", err)
+	}
+	sum := sha256Hex(raw)
+
+	_, stderr, code := runRoot(t, "audit-packet", "--expect-sha256", sum, pkt)
+	if code != cliutil.ExitOK {
+		t.Fatalf("matching sha should pass, stderr=%q", stderr)
+	}
+}
+
+func TestAuditPacket_PathContainmentRejected(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 1)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, func(p *auditpacket.Packet) {
+		// Forced-build a packet that would resolve outside the directory.
+		// Schema validation should reject this before we reach the resolver,
+		// but we exercise the outside-dir resolver path explicitly via
+		// resolveArtifactPath in a second sub-test below.
+		p.Artifacts.Evidence = "../../../etc/passwd"
+	})
+
+	_, stderr, code := runRoot(t, "audit-packet", dir)
+	if code == cliutil.ExitOK {
+		t.Fatalf("expected containment rejection, stderr=%q", stderr)
+	}
+}
+
+func TestAuditPacket_JSONOutput(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+
+	stdout, _, code := runRoot(t, "audit-packet", "--json", dir)
+	if code != cliutil.ExitOK {
+		t.Fatalf("happy path failed under --json: code=%d", code)
+	}
+	var report auditPacketReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("json output not parseable: %v\nstdout=%s", err, stdout)
+	}
+	if !report.Valid {
+		t.Errorf("expected valid=true, got %+v", report)
+	}
+	if report.Summary.ReceiptCount != 2 {
+		t.Errorf("expected receipt_count=2, got %d", report.Summary.ReceiptCount)
+	}
+}
+
+func TestAuditPacket_PacketAsFileArg(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 1)
+	dir := t.TempDir()
+	pkt := fix.writePacketDir(t, dir, nil)
+
+	_, stderr, code := runRoot(t, "audit-packet", pkt)
+	if code != cliutil.ExitOK {
+		t.Fatalf("file-arg form should pass, stderr=%q", stderr)
+	}
+}
+
+func TestAuditPacket_MissingPacket(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, stderr, code := runRoot(t, "audit-packet", filepath.Join(dir, "nonexistent.json"))
+	if code == cliutil.ExitOK {
+		t.Fatalf("expected non-zero exit, stderr=%q", stderr)
+	}
+}
+
+func TestAuditPacket_BadJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	pkt := filepath.Join(dir, "packet.json")
+	if err := os.WriteFile(pkt, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write bad packet: %v", err)
+	}
+
+	_, stderr, code := runRoot(t, "audit-packet", pkt)
+	if code == cliutil.ExitOK {
+		t.Fatalf("expected non-zero on bad json, stderr=%q", stderr)
+	}
+}
+
+func TestChain_Valid(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 3)
+	dir := t.TempDir()
+	pkt := fix.writePacketDir(t, dir, nil)
+	_ = pkt
+	evidence := filepath.Join(dir, "evidence.jsonl")
+
+	stdout, _, code := runRoot(t, "chain", evidence)
+	if code != cliutil.ExitOK {
+		t.Fatalf("valid chain should pass, stdout=%q", stdout)
+	}
+	if !strings.Contains(stdout, "CHAIN VALID") {
+		t.Errorf("missing CHAIN VALID marker, got %q", stdout)
+	}
+}
+
+func TestChain_TamperedSignature(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+	evidence := filepath.Join(dir, "evidence.jsonl")
+
+	// Corrupt the JSONL file by appending a malformed line; the chain
+	// extractor should drop it but this also exercises the empty-or-broken
+	// handling.
+	raw, err := os.ReadFile(filepath.Clean(evidence))
+	if err != nil {
+		t.Fatalf("read evidence: %v", err)
+	}
+	// Tamper the first receipt's signature byte.
+	tampered := bytes.Replace(raw, []byte(`"signature":"`), []byte(`"signature":"X`), 1)
+	if err := os.WriteFile(evidence, tampered, 0o600); err != nil {
+		t.Fatalf("write tampered: %v", err)
+	}
+
+	_, stderr, code := runRoot(t, "chain", evidence)
+	if code == cliutil.ExitOK {
+		t.Fatalf("tampered chain should fail")
+	}
+	if !strings.Contains(stderr, "CHAIN BROKEN") && !strings.Contains(stderr, "rejected") {
+		t.Errorf("expected broken-chain message, got %q", stderr)
+	}
+}
+
+func TestChain_JSONOutput(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+	evidence := filepath.Join(dir, "evidence.jsonl")
+
+	stdout, _, code := runRoot(t, "chain", "--json", evidence)
+	if code != cliutil.ExitOK {
+		t.Fatalf("valid chain --json should pass")
+	}
+	var rpt chainReport
+	if err := json.Unmarshal([]byte(stdout), &rpt); err != nil {
+		t.Fatalf("json output not parseable: %v\nstdout=%s", err, stdout)
+	}
+	if !rpt.Valid || rpt.ReceiptCount != 2 {
+		t.Errorf("unexpected report: %+v", rpt)
+	}
+}
+
+func TestChain_DirAsFileFails(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, stderr, code := runRoot(t, "chain", dir)
+	if code == cliutil.ExitOK {
+		t.Fatalf("passing a dir without --dir should fail, stderr=%q", stderr)
+	}
+}
+
+func TestChain_NotFound(t *testing.T) {
+	t.Parallel()
+	_, _, code := runRoot(t, "chain", filepath.Join(t.TempDir(), "missing.jsonl"))
+	if code == cliutil.ExitOK {
+		t.Fatalf("missing file should fail")
+	}
+}
+
+func TestReceipt_Valid(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 1)
+	dir := t.TempDir()
+	rPath := filepath.Join(dir, "r.json")
+	data, err := receipt.Marshal(fix.receipts[0])
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(rPath, data, 0o600); err != nil {
+		t.Fatalf("write receipt: %v", err)
+	}
+
+	stdout, _, code := runRoot(t, "receipt", rPath)
+	if code != cliutil.ExitOK {
+		t.Fatalf("valid receipt should pass, stdout=%q", stdout)
+	}
+}
+
+func TestReceipt_TamperedSignature(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 1)
+	dir := t.TempDir()
+	rPath := filepath.Join(dir, "r.json")
+	r := fix.receipts[0]
+	r.Signature = "ed25519:" + strings.Repeat("0", 128)
+	data, err := receipt.Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(rPath, data, 0o600); err != nil {
+		t.Fatalf("write tampered: %v", err)
+	}
+
+	_, stderr, code := runRoot(t, "receipt", rPath)
+	if code == cliutil.ExitOK {
+		t.Fatalf("tampered receipt should fail, stderr=%q", stderr)
+	}
+}
+
+func TestReceipt_JSONOutput(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 1)
+	dir := t.TempDir()
+	rPath := filepath.Join(dir, "r.json")
+	data, err := receipt.Marshal(fix.receipts[0])
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(rPath, data, 0o600); err != nil {
+		t.Fatalf("write receipt: %v", err)
+	}
+
+	stdout, _, code := runRoot(t, "receipt", "--json", rPath)
+	if code != cliutil.ExitOK {
+		t.Fatalf("valid receipt --json should pass")
+	}
+	var rpt receiptReport
+	if err := json.Unmarshal([]byte(stdout), &rpt); err != nil {
+		t.Fatalf("parse json: %v", err)
+	}
+	if !rpt.Valid {
+		t.Errorf("expected valid=true, got %+v", rpt)
+	}
+}
+
+func TestReceipt_BadJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rPath := filepath.Join(dir, "r.json")
+	if err := os.WriteFile(rPath, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("write bad: %v", err)
+	}
+
+	_, stderr, code := runRoot(t, "receipt", rPath)
+	if code == cliutil.ExitOK {
+		t.Fatalf("bad json should fail, stderr=%q", stderr)
+	}
+}
+
+func TestResolveSignerKey(t *testing.T) {
+	t.Parallel()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	hexKey := hex.EncodeToString(pub)
+
+	t.Run("empty", func(t *testing.T) {
+		got, err := resolveSignerKey("")
+		if err != nil || got != "" {
+			t.Errorf("want empty ok, got %q err=%v", got, err)
+		}
+	})
+
+	t.Run("raw_hex", func(t *testing.T) {
+		got, err := resolveSignerKey(hexKey)
+		if err != nil || got != hexKey {
+			t.Errorf("hex roundtrip failed: %q vs %q err=%v", got, hexKey, err)
+		}
+	})
+
+	t.Run("file_path", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "key.txt")
+		if err := os.WriteFile(f, []byte(hexKey), 0o600); err != nil {
+			t.Fatalf("write key: %v", err)
+		}
+		got, err := resolveSignerKey(f)
+		if err != nil || got != hexKey {
+			t.Errorf("file path failed: %q vs %q err=%v", got, hexKey, err)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		if _, err := resolveSignerKey("not-a-key"); err == nil {
+			t.Errorf("expected error on bad key")
+		}
+	})
+}
+
+func TestSha256Hex_Deterministic(t *testing.T) {
+	t.Parallel()
+	a := sha256Hex([]byte("hello"))
+	b := sha256Hex([]byte("hello"))
+	if a != b {
+		t.Errorf("not deterministic: %s vs %s", a, b)
+	}
+	if len(a) != 64 {
+		t.Errorf("expected 64-char hex, got %d", len(a))
+	}
+}
+
+func TestExitCodeFor(t *testing.T) {
+	t.Parallel()
+	if got := exitCodeFor(nil); got != cliutil.ExitOK {
+		t.Errorf("nil err -> %d, want %d", got, cliutil.ExitOK)
+	}
+	if got := exitCodeFor(errors.New("plain")); got != cliutil.ExitGeneral {
+		t.Errorf("plain err -> %d, want %d", got, cliutil.ExitGeneral)
+	}
+	wrapped := cliutil.ExitCodeError(cliutil.ExitConfig, errors.New("cfg"))
+	if got := exitCodeFor(wrapped); got != cliutil.ExitConfig {
+		t.Errorf("wrapped err -> %d, want %d", got, cliutil.ExitConfig)
+	}
+}
+
+func TestUsageErrorsExit64(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing subcommand", args: []string{"audit-packet"}},
+		{name: "unknown flag", args: []string{"chain", "--definitely-not-a-flag", "evidence.jsonl"}},
+		{name: "unknown command", args: []string{"definitely-not-a-command"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, code := runRoot(t, tt.args...)
+			if code != exitUsage {
+				t.Fatalf("exit code = %d, want %d", code, exitUsage)
+			}
+		})
+	}
+}
+
+func TestResolveArtifactPath(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	cases := []struct {
+		name    string
+		rel     string
+		wantErr bool
+	}{
+		{"ok_relative", "evidence.jsonl", false},
+		{"ok_subdir", filepath.Join("artifacts", "evidence.jsonl"), false},
+		{"empty_path", "", true},
+		{"absolute", "/etc/passwd", true},
+		{"backslash", "evidence\\jsonl", true},
+		{"colon", "C:evidence.jsonl", true},
+		{"escape", "../escape", true},
+		{"escape_deep", filepath.Join("..", "..", "..", "etc", "passwd"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := resolveArtifactPath(base, tc.rel)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error for %q", tc.rel)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error for %q: %v", tc.rel, err)
+			}
+		})
+	}
+}
+
+func TestVerifyExpectedSHA(t *testing.T) {
+	t.Parallel()
+	data := []byte("payload")
+	good := sha256Hex(data)
+	if err := verifyExpectedSHA(data, good); err != nil {
+		t.Errorf("matching sha rejected: %v", err)
+	}
+	if err := verifyExpectedSHA(data, "GOOD"+strings.Repeat("0", 60)); err == nil {
+		t.Errorf("mismatch accepted")
+	}
+	// Whitespace + uppercase tolerated.
+	if err := verifyExpectedSHA(data, "  "+strings.ToUpper(good)+"  "); err != nil {
+		t.Errorf("normalized sha rejected: %v", err)
+	}
+}
+
+func TestComputeTotals(t *testing.T) {
+	t.Parallel()
+	// Empty receipts -> all zero buckets.
+	totals := computeTotals(nil)
+	for _, k := range []string{"allow", "block", "warn", "ask", "strip", "forward", "redirect", "other"} {
+		if totals[k] != 0 {
+			t.Errorf("expected %s=0 got %d", k, totals[k])
+		}
+	}
+
+	// Build a synthetic mix exercising the unknown-verdict -> "other" branch.
+	receipts := []receipt.Receipt{
+		{ActionRecord: receipt.ActionRecord{Verdict: "allow"}},
+		{ActionRecord: receipt.ActionRecord{Verdict: "block"}},
+		{ActionRecord: receipt.ActionRecord{Verdict: "weird"}},
+	}
+	totals = computeTotals(receipts)
+	if totals["allow"] != 1 || totals["block"] != 1 || totals["other"] != 1 {
+		t.Errorf("unexpected totals: %+v", totals)
+	}
+}
+
+func TestSortedKeys(t *testing.T) {
+	t.Parallel()
+	in := map[string]int{"c": 3, "a": 1, "b": 2}
+	got := sortedKeys(in)
+	want := []string{"a", "b", "c"}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("sortedKeys[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestRootVersionFlag(t *testing.T) {
+	t.Parallel()
+	stdout, _, _ := runRoot(t, "--version")
+	if !strings.Contains(stdout, "pipelock-verifier") {
+		t.Errorf("expected version banner, got %q", stdout)
+	}
+}
+
+func TestAuditPacket_VerdictTamperedToValidWithBrokenChain(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	pkt := fix.writePacketDir(t, dir, nil)
+	_ = pkt
+	// Break the chain after writing the packet to force chain.Valid=false
+	// while the packet still claims verdict=valid.
+	evidence := filepath.Join(dir, "evidence.jsonl")
+	raw, err := os.ReadFile(filepath.Clean(evidence))
+	if err != nil {
+		t.Fatalf("read evidence: %v", err)
+	}
+	tampered := bytes.Replace(raw, []byte(`"chain_seq":1`), []byte(`"chain_seq":99`), 1)
+	if err := os.WriteFile(evidence, tampered, 0o600); err != nil {
+		t.Fatalf("write tampered evidence: %v", err)
+	}
+
+	_, stderr, code := runRoot(t, "audit-packet", dir)
+	if code == cliutil.ExitOK {
+		t.Fatalf("broken chain with valid claim should fail, stderr=%q", stderr)
+	}
+}
+
+func TestChain_DirMode(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+	// session-dir mode expects evidence-{session}-{N}.jsonl files. Rename
+	// our evidence.jsonl into that shape and pass --dir.
+	src := filepath.Join(dir, "evidence.jsonl")
+	dst := filepath.Join(dir, "evidence-proxy-0.jsonl")
+	if err := os.Rename(src, dst); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	stdout, _, code := runRoot(t, "chain", "--dir", dir)
+	if code != cliutil.ExitOK {
+		t.Fatalf("--dir mode should pass, stdout=%q", stdout)
+	}
+	if !strings.Contains(stdout, "session proxy") {
+		t.Errorf("expected session label, got %q", stdout)
+	}
+}
+
+func TestChain_WithExplicitKey(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+	keyPath := filepath.Join(dir, "key.txt")
+	if err := os.WriteFile(keyPath, []byte(fix.keyHex), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	evidence := filepath.Join(dir, "evidence.jsonl")
+	_, _, code := runRoot(t, "chain", "--key", keyPath, evidence)
+	if code != cliutil.ExitOK {
+		t.Fatalf("chain --key should pass")
+	}
+}
+
+func TestChain_BadKey(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 1)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+	evidence := filepath.Join(dir, "evidence.jsonl")
+	_, _, code := runRoot(t, "chain", "--key", "not-a-key", evidence)
+	if code == cliutil.ExitOK {
+		t.Fatalf("invalid key should fail")
+	}
+}
+
+func TestChain_EmptyChain(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	evidence := filepath.Join(dir, "evidence.jsonl")
+	if err := os.WriteFile(evidence, []byte(""), 0o600); err != nil {
+		t.Fatalf("write empty: %v", err)
+	}
+	_, _, code := runRoot(t, "chain", evidence)
+	if code == cliutil.ExitOK {
+		t.Fatalf("empty chain should fail")
+	}
+}
+
+func TestReceipt_BadKey(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 1)
+	dir := t.TempDir()
+	rPath := filepath.Join(dir, "r.json")
+	data, err := receipt.Marshal(fix.receipts[0])
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(rPath, data, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, _, code := runRoot(t, "receipt", "--key", "not-a-key", rPath)
+	if code == cliutil.ExitOK {
+		t.Fatalf("invalid key should fail")
+	}
+}
+
+func TestReceipt_NotFound(t *testing.T) {
+	t.Parallel()
+	_, _, code := runRoot(t, "receipt", filepath.Join(t.TempDir(), "missing.json"))
+	if code == cliutil.ExitOK {
+		t.Fatalf("missing receipt should fail")
+	}
+}
+
+func TestAuditPacket_BadSignerKey(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 1)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+	_, _, code := runRoot(t, "audit-packet", "--key", "not-a-key", dir)
+	if code == cliutil.ExitOK {
+		t.Fatalf("bad --key should fail")
+	}
+}
+
+func TestAuditPacket_BadEvidence(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 1)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+	// Replace evidence with an unparseable file; ExtractReceipts should
+	// surface the parse error and the audit-packet command should fail.
+	if err := os.WriteFile(filepath.Join(dir, "evidence.jsonl"), []byte("not a recorder line\n"), 0o600); err != nil {
+		t.Fatalf("write bad evidence: %v", err)
+	}
+	_, _, code := runRoot(t, "audit-packet", dir)
+	if code == cliutil.ExitOK {
+		t.Fatalf("bad evidence should fail")
+	}
+}
+
+func TestTrustVerdict_DefaultBranch(t *testing.T) {
+	t.Parallel()
+	pkt := &auditpacket.Packet{Verifier: auditpacket.Verifier{Verdict: auditpacket.VerdictError}}
+	if trustVerdict(pkt, auditPacketOptions{}) {
+		t.Errorf("error verdict should not be trusted by default")
+	}
+	if !trustVerdict(pkt, auditPacketOptions{relaxTrust: true}) {
+		t.Errorf("--no-trust-required should override")
+	}
+	pkt.Verifier.Verdict = auditpacket.VerdictNotRun
+	if trustVerdict(pkt, auditPacketOptions{}) {
+		t.Errorf("not_run should not be trusted by default")
+	}
+	pkt.Verifier.Verdict = auditpacket.VerdictInvalid
+	if trustVerdict(pkt, auditPacketOptions{}) {
+		t.Errorf("invalid should not be trusted by default")
+	}
+}
+
+func TestAuditPacket_FinalSeqAndRootHashCrossCheck(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 3)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, func(p *auditpacket.Packet) {
+		// Tamper the final_seq claim. v0 schema allows the field optional;
+		// when set it must match the chain.
+		p.Verifier.FinalSeq = 99
+	})
+	_, stderr, code := runRoot(t, "audit-packet", dir)
+	if code == cliutil.ExitOK {
+		t.Fatalf("final_seq mismatch should fail")
+	}
+	if !strings.Contains(stderr, "final_seq mismatch") {
+		t.Errorf("expected final_seq mismatch error, got %q", stderr)
+	}
+
+	dir2 := t.TempDir()
+	fix.writePacketDir(t, dir2, func(p *auditpacket.Packet) {
+		p.Verifier.RootHash = strings.Repeat("a", 64)
+	})
+	_, stderr, code = runRoot(t, "audit-packet", dir2)
+	if code == cliutil.ExitOK {
+		t.Fatalf("root_hash mismatch should fail")
+	}
+	if !strings.Contains(stderr, "root_hash mismatch") {
+		t.Errorf("expected root_hash mismatch error, got %q", stderr)
+	}
+}
+
+func TestWriteJSON_MarshalFailure(t *testing.T) {
+	t.Parallel()
+	// chan values are not encodable; writeJSON should fall back to the
+	// inline error envelope rather than panic.
+	var buf bytes.Buffer
+	writeJSON(&buf, make(chan int))
+	if !strings.Contains(buf.String(), "json marshal failed") {
+		t.Errorf("expected fallback envelope, got %q", buf.String())
+	}
+}
+
+func TestEmitReport_HumanWithErrorsAndWarnings(t *testing.T) {
+	t.Parallel()
+	r := auditPacketReport{
+		Path:        "/tmp/p",
+		Verdict:     "valid",
+		Trusted:     true,
+		Valid:       true,
+		SchemaCheck: "pass",
+		ChainCheck:  "pass",
+		CrossCheck:  "pass",
+		Errors:      []string{"err1"},
+		Warnings:    []string{"warn1"},
+	}
+	var stdout, stderr bytes.Buffer
+	emitReport(&stdout, &stderr, r, false)
+	if !strings.Contains(stdout.String(), "VALID") {
+		t.Errorf("missing VALID, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "err1") || !strings.Contains(stderr.String(), "warn1") {
+		t.Errorf("expected err1+warn1 in stderr, got %q", stderr.String())
+	}
+}
+
+// TestAuditPacket_ReportContainsRunMetadata locks the JSON shape so consumers
+// can grep stable field names.
+func TestAuditPacket_ReportContainsRunMetadata(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 1)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, func(p *auditpacket.Packet) {
+		p.Run.Repository = "owner/" + tNotPipelock
+		p.Run.SHA = "deadbeefcafebabe"
+	})
+
+	stdout, _, code := runRoot(t, "audit-packet", "--json", dir)
+	if code != cliutil.ExitOK {
+		t.Fatalf("happy path failed: stdout=%q", stdout)
+	}
+	var report auditPacketReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("parse json: %v", err)
+	}
+	if report.Run.Repository != "owner/"+tNotPipelock {
+		t.Errorf("repository propagation failed: %q", report.Run.Repository)
+	}
+	if report.Run.SHA == "" {
+		t.Errorf("sha missing")
+	}
+}

--- a/cmd/pipelock-verifier/output.go
+++ b/cmd/pipelock-verifier/output.go
@@ -110,13 +110,21 @@ func emitReceiptReport(stdout, stderr io.Writer, r receiptReport, jsonMode bool)
 	}
 }
 
-// writeJSON marshals v to stdout. Marshal failures degrade to a minimal
-// machine-readable error envelope rather than blowing up; the caller's
-// non-zero exit code communicates the problem.
+// writeJSON marshals v to stdout. Marshal failures degrade to a
+// machine-readable error envelope. The envelope is itself produced via
+// json.Marshal so quotes / backslashes / control bytes in the inner error
+// text round-trip safely; falling back to fmt.Sprintf would have produced
+// invalid JSON for any error containing those characters.
 func writeJSON(out io.Writer, v any) {
 	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
-		_, _ = fmt.Fprintf(out, `{"error":"json marshal failed: %s"}`, err.Error())
+		envelope, mErr := json.Marshal(struct {
+			Error string `json:"error"`
+		}{Error: "json marshal failed: " + err.Error()})
+		if mErr != nil {
+			envelope = []byte(`{"error":"json marshal failed"}`)
+		}
+		_, _ = out.Write(envelope)
 		_, _ = fmt.Fprintln(out)
 		return
 	}
@@ -163,11 +171,16 @@ func exitCodeFor(err error) int {
 	return cliutil.ExitGeneral
 }
 
+// isCobraUsageError matches the four prefixes cobra emits today for
+// usage-class failures. Flag errors are routed through SetFlagErrorFunc
+// directly, so they never reach this matcher; this exists only to map the
+// remaining unknown-command and missing-arg paths to exit code 64. Cobra
+// version bumps may shift wording; if a future cobra changes a prefix the
+// CLI degrades to ExitGeneral, not to a wrong exit code.
 func isCobraUsageError(err error) bool {
 	msg := err.Error()
 	return strings.HasPrefix(msg, "unknown command ") ||
 		strings.HasPrefix(msg, "unknown flag:") ||
 		strings.HasPrefix(msg, "accepts ") ||
-		strings.HasPrefix(msg, "requires at least ") ||
-		strings.HasPrefix(msg, "requires a command")
+		strings.HasPrefix(msg, "requires at least ")
 }

--- a/cmd/pipelock-verifier/output.go
+++ b/cmd/pipelock-verifier/output.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	sigutil "github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// emitReport writes the audit-packet report to stdout in either JSON or
+// human-readable form. The human form is loosely structured so script
+// consumers should prefer --json.
+func emitReport(stdout, stderr io.Writer, r auditPacketReport, jsonMode bool) {
+	if jsonMode {
+		writeJSON(stdout, r)
+		return
+	}
+	verdict := r.Verdict
+	if verdict == "" {
+		verdict = "(unset)"
+	}
+	_, _ = fmt.Fprintf(stdout, "Audit Packet:   %s\n", r.Path)
+	_, _ = fmt.Fprintf(stdout, "  schema:       %s\n", r.SchemaCheck)
+	_, _ = fmt.Fprintf(stdout, "  chain:        %s\n", r.ChainCheck)
+	_, _ = fmt.Fprintf(stdout, "  cross-check:  %s\n", r.CrossCheck)
+	_, _ = fmt.Fprintf(stdout, "  verdict:      %s\n", verdict)
+	_, _ = fmt.Fprintf(stdout, "  trusted:      %t\n", r.Trusted)
+	_, _ = fmt.Fprintf(stdout, "  receipts:     %d\n", r.Summary.ReceiptCount)
+	if r.Run.Provider != "" {
+		_, _ = fmt.Fprintf(stdout, "  provider:     %s\n", r.Run.Provider)
+	}
+	if r.Run.Repository != "" {
+		_, _ = fmt.Fprintf(stdout, "  repository:   %s\n", r.Run.Repository)
+	}
+	if r.Run.SHA != "" {
+		_, _ = fmt.Fprintf(stdout, "  sha:          %s\n", r.Run.SHA)
+	}
+	if r.Run.AgentIdentity != "" {
+		_, _ = fmt.Fprintf(stdout, "  agent:        %s\n", r.Run.AgentIdentity)
+	}
+	if r.Posture.EnforcementMode != "" {
+		_, _ = fmt.Fprintf(stdout, "  enforcement:  %s\n", r.Posture.EnforcementMode)
+	}
+	if len(r.Posture.UnsupportedPaths) > 0 {
+		_, _ = fmt.Fprintf(stdout, "  unsupported:  %s\n", strings.Join(r.Posture.UnsupportedPaths, ", "))
+	}
+	for _, e := range r.Errors {
+		_, _ = fmt.Fprintf(stderr, "ERROR: %s\n", e)
+	}
+	for _, w := range r.Warnings {
+		_, _ = fmt.Fprintf(stderr, "WARN:  %s\n", w)
+	}
+	if r.Valid {
+		_, _ = fmt.Fprintln(stdout, "  result:       VALID")
+	} else {
+		_, _ = fmt.Fprintln(stdout, "  result:       INVALID")
+	}
+}
+
+// emitChainReport mirrors emitReport for the chain subcommand.
+func emitChainReport(stdout, stderr io.Writer, r chainReport, jsonMode bool) {
+	if jsonMode {
+		writeJSON(stdout, r)
+		return
+	}
+	if r.Valid {
+		_, _ = fmt.Fprintf(stdout, "CHAIN VALID: %s\n", r.Path)
+		_, _ = fmt.Fprintf(stdout, "  receipts:   %d\n", r.ReceiptCount)
+		_, _ = fmt.Fprintf(stdout, "  final seq:  %d\n", r.FinalSeq)
+		_, _ = fmt.Fprintf(stdout, "  root hash:  %s\n", r.RootHash)
+		return
+	}
+	_, _ = fmt.Fprintf(stderr, "CHAIN BROKEN: %s\n", r.Path)
+	if r.Error != "" {
+		_, _ = fmt.Fprintf(stderr, "  error:      %s\n", r.Error)
+	}
+	if r.BrokenAtSeq != 0 || r.Error != "" {
+		_, _ = fmt.Fprintf(stderr, "  broken at:  seq %d\n", r.BrokenAtSeq)
+	}
+}
+
+// emitReceiptReport mirrors emitReport for the receipt subcommand.
+func emitReceiptReport(stdout, stderr io.Writer, r receiptReport, jsonMode bool) {
+	if jsonMode {
+		writeJSON(stdout, r)
+		return
+	}
+	if r.Valid {
+		_, _ = fmt.Fprintf(stdout, "RECEIPT VALID: %s\n", r.Path)
+		_, _ = fmt.Fprintf(stdout, "  action_id:    %s\n", r.ActionID)
+		_, _ = fmt.Fprintf(stdout, "  verdict:      %s\n", r.Verdict)
+		_, _ = fmt.Fprintf(stdout, "  transport:    %s\n", r.Transport)
+		_, _ = fmt.Fprintf(stdout, "  signer:       %s\n", r.SignerKey)
+		_, _ = fmt.Fprintf(stdout, "  policy_hash:  %s\n", r.PolicyHash)
+		_, _ = fmt.Fprintf(stdout, "  chain_seq:    %d\n", r.ChainSeq)
+		return
+	}
+	_, _ = fmt.Fprintf(stderr, "RECEIPT INVALID: %s\n", r.Path)
+	if r.Error != "" {
+		_, _ = fmt.Fprintf(stderr, "  error: %s\n", r.Error)
+	}
+}
+
+// writeJSON marshals v to stdout. Marshal failures degrade to a minimal
+// machine-readable error envelope rather than blowing up; the caller's
+// non-zero exit code communicates the problem.
+func writeJSON(out io.Writer, v any) {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		_, _ = fmt.Fprintf(out, `{"error":"json marshal failed: %s"}`, err.Error())
+		_, _ = fmt.Fprintln(out)
+		return
+	}
+	_, _ = out.Write(data)
+	_, _ = fmt.Fprintln(out)
+}
+
+// resolveSignerKey accepts a key as raw hex, Pipelock public-key text form,
+// or a file path holding either, and returns the canonical lowercase hex.
+// An empty input yields an empty hex string, which downstream verification
+// interprets as self-consistent mode.
+func resolveSignerKey(input string) (string, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", nil
+	}
+	key, err := sigutil.LoadPublicKey(input)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(key), nil
+}
+
+// sha256Hex returns the lowercase hex digest of data.
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// exitCodeFor maps an error to a verifier exit code. ExitError carries an
+// explicit code; cobra usage errors map to exitUsage. Other bare errors
+// default to ExitGeneral.
+func exitCodeFor(err error) int {
+	if err == nil {
+		return cliutil.ExitOK
+	}
+	var ee *cliutil.ExitError
+	if errors.As(err, &ee) {
+		return ee.Code
+	}
+	if isCobraUsageError(err) {
+		return exitUsage
+	}
+	return cliutil.ExitGeneral
+}
+
+func isCobraUsageError(err error) bool {
+	msg := err.Error()
+	return strings.HasPrefix(msg, "unknown command ") ||
+		strings.HasPrefix(msg, "unknown flag:") ||
+		strings.HasPrefix(msg, "accepts ") ||
+		strings.HasPrefix(msg, "requires at least ") ||
+		strings.HasPrefix(msg, "requires a command")
+}

--- a/cmd/pipelock-verifier/receipt.go
+++ b/cmd/pipelock-verifier/receipt.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+type receiptOptions struct {
+	signerKey  string
+	jsonOutput bool
+}
+
+func newReceiptCmd() *cobra.Command {
+	var opts receiptOptions
+
+	cmd := &cobra.Command{
+		Use:   "receipt PATH",
+		Short: "Verify a single Pipelock action receipt",
+		Long: `Verifies the Ed25519 signature on a single Pipelock action receipt
+written as JSON. PATH must point at a JSON file holding one receipt
+(version + action_record + signature + signer_key).
+
+Without --key the verifier checks the receipt's embedded signer_key.
+With --key it requires the receipt's signer to match the named key.`,
+		Args:          exactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReceipt(cmd.OutOrStdout(), cmd.ErrOrStderr(), args[0], opts)
+		},
+	}
+	cmd.SetFlagErrorFunc(usageFlagError)
+
+	cmd.Flags().StringVar(&opts.signerKey, "key", "", "expected signer public key (hex, public-key text, or file path)")
+	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit a structured JSON verdict on stdout")
+
+	return cmd
+}
+
+type receiptReport struct {
+	Path       string `json:"path"`
+	Valid      bool   `json:"valid"`
+	ActionID   string `json:"action_id,omitempty"`
+	Verdict    string `json:"verdict,omitempty"`
+	Transport  string `json:"transport,omitempty"`
+	SignerKey  string `json:"signer_key,omitempty"`
+	PolicyHash string `json:"policy_hash,omitempty"`
+	ChainSeq   uint64 `json:"chain_seq,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+func runReceipt(stdout, stderr io.Writer, target string, opts receiptOptions) error {
+	keyHex, err := resolveSignerKey(strings.TrimSpace(opts.signerKey))
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("resolve signer key: %w", err))
+	}
+
+	clean := filepath.Clean(target)
+	data, err := os.ReadFile(clean)
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("read receipt: %w", err))
+	}
+
+	r, err := receipt.Unmarshal(data)
+	if err != nil {
+		report := receiptReport{Path: clean, Valid: false, Error: err.Error()}
+		emitReceiptReport(stdout, stderr, report, opts.jsonOutput)
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("parse receipt: %w", err))
+	}
+
+	report := receiptReport{
+		Path:       clean,
+		ActionID:   r.ActionRecord.ActionID,
+		Verdict:    r.ActionRecord.Verdict,
+		Transport:  r.ActionRecord.Transport,
+		SignerKey:  r.SignerKey,
+		PolicyHash: r.ActionRecord.PolicyHash,
+		ChainSeq:   r.ActionRecord.ChainSeq,
+	}
+
+	if err := receipt.VerifyWithKey(r, keyHex); err != nil {
+		report.Valid = false
+		report.Error = err.Error()
+		emitReceiptReport(stdout, stderr, report, opts.jsonOutput)
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("verify: %w", err))
+	}
+	report.Valid = true
+	emitReceiptReport(stdout, stderr, report, opts.jsonOutput)
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds a self-contained binary `pipelock-verifier` that validates Pipelock action receipts, receipt chains, and Audit Packets against the locked `pipelock.audit_packet.v0` schema and signing rules. The binary has no network surface, no proxy, no scanner, and no config-reload machinery; consumers (CI runners, auditors, third parties) can drop it into an isolated environment and exit with structured pass/fail.

### Subcommands

`audit-packet PATH` validates a packet directory (or a `packet.json` file directly), then re-verifies the embedded receipt chain and confirms that the packet's claimed verdict, receipt_count, totals, root_hash, and final_seq match the chain's actual contents. PATH may be either a directory containing `packet.json` plus its sibling artifacts, or a path to `packet.json` directly. With `--offline` the verifier validates only the packet schema. `--expect-sha256 <hex>` pins the packet bytes for tamper detection from an out-of-band trust anchor.

`chain PATH` verifies an evidence JSONL file or, with `--dir`, a session directory. Without `--key` it confirms self-consistency (prev-hash linkage, single-signer agreement). With `--key` it requires every receipt to carry the named signer.

`receipt PATH` verifies a single receipt JSON file's Ed25519 signature.

All subcommands accept `--json` for machine-readable output. Exit codes: 0 valid, 1 invalid, 2 error, 64 usage.

### Cross-check semantics (audit-packet)

The novel piece. Even when the schema validates and the chain re-verifies, an Audit Packet whose summary or verifier block was edited after emission (e.g., totals tampered, root_hash swapped, verdict claim flipped) will fail here:

- `chain.ReceiptCount` matches `summary.receipt_count`.
- Per-bucket totals computed from receipts match `summary.totals.*` exactly across all eight `config.Action*` buckets.
- `verifier.root_hash`, when set, matches the chain's actual root hash.
- `verifier.final_seq`, when set, matches the chain's actual final seq.
- Verdict-vs-chain agreement: `valid` and `self_consistent_only` require `chain.Valid=true`; `invalid` requires `chain.Valid=false`.

These checks layer on top of the schema's asymmetric trust invariants (`trusted=true ↔ verdict=valid ↔ signer_key set`), giving a verifier defense-in-depth against post-emission edits.

### Trust policy flags

`trusted = (verdict == "valid")` is the default. `--allow-self-consistent-only` opts into accepting a chain that hashed up but had no pinned signer key. `--no-trust-required` skips the trust check entirely (still runs schema and cross-check); useful when a downstream system records the verdict for forensic analysis without acting on trust.

### Dependency note

This binary reuses `internal/receipt`, `internal/signing`, and `sdk/audit-packet` directly. `internal/receipt` currently transitively pulls `internal/config`, `internal/recorder`, `internal/redact`, and `internal/session`, which is why the binary is 9.6MB rather than the ~3MB a pure verifier would need. Splitting the receipt package into a leaf-verify package (no scanner/recorder deps) is tracked as future work; not in scope for this PR.

### Action repo integration

A follow-up PR in `pipelock-agent-egress-action` will optionally route the action's verify step through this binary instead of the full `pipelock` binary, cutting the Action runtime download. Out of scope here; the action's existing `pipelock verify-receipt` path stays the supported flow until that PR lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pipelock-verifier CLI with subcommands to audit packets, verify chains, and validate receipts; supports offline mode, expected SHA-256 checks, signer key override, trust-policy flags, and JSON/text output.

* **Packaging**
  * Build and archive pipelock-verifier for Linux, macOS, and Windows (amd64/arm64) with OS-appropriate archive formats and versioned naming.

* **Tests**
  * Comprehensive end-to-end and unit tests covering verifier flows, error paths, tampering cases, and JSON output.

* **Chores**
  * Makefile and cleanup updated to build and remove the verifier binary.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/500)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->