### PR TITLE
feat(sdk): add TypeScript audit packet verifier

### DIFF
--- a/sdk/audit-packet/example.json
+++ b/sdk/audit-packet/example.json
@@ -56,7 +56,7 @@
     "receipt_count": 12,
     "root_hash": "sha256:91a2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f6071829a3b4c5d6e7f8091",
     "final_seq": 11,
-    "signer_key": "pipelock-public-key:ed25519:0000000000000000000000000000000000000000000000000000000000000001",
+    "signer_key": "0000000000000000000000000000000000000000000000000000000000000001",
     "output_file": "verifier.txt"
   },
   "posture": {

--- a/sdk/verifiers/ts/.gitignore
+++ b/sdk/verifiers/ts/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/sdk/verifiers/ts/README.md
+++ b/sdk/verifiers/ts/README.md
@@ -1,0 +1,41 @@
+# Pipelock TypeScript Verifier
+
+Reference TypeScript verifier for Pipelock Audit Packet v0, action receipts, and receipt chains.
+
+## Install
+
+```bash
+npm install
+npm run build
+```
+
+The package exposes `pipelock-verifier-ts` after build.
+
+## Usage
+
+```bash
+pipelock-verifier-ts audit-packet PATH [--json] [--key HEX_OR_FILE] [--offline]
+pipelock-verifier-ts chain PATH [--json] [--key HEX_OR_FILE] [--dir] [--session-id ID]
+pipelock-verifier-ts receipt PATH [--json] [--key HEX_OR_FILE]
+```
+
+Exit codes match the Go verifier:
+
+| Code | Meaning |
+| --- | --- |
+| 0 | valid |
+| 1 | invalid |
+| 2 | runtime error |
+| 64 | CLI usage error |
+
+`audit-packet` validates `packet.json` against `sdk/audit-packet/v0.json`, applies the structural v0 checks, and re-verifies the referenced receipt chain unless `--offline` is set. `chain` accepts either an `evidence.jsonl` file or a recorder session directory with `--dir`. `receipt` verifies one receipt JSON file.
+
+## Development
+
+```bash
+npm run typecheck
+npm run build
+npm test
+```
+
+The canonical encoder intentionally mirrors Go `encoding/json` for the receipt structs: declaration-order fields, Go `omitempty`, sorted map keys, compact output, and Go's default HTML escaping. This byte-level behavior is part of the verifier contract.

--- a/sdk/verifiers/ts/package-lock.json
+++ b/sdk/verifiers/ts/package-lock.json
@@ -1,0 +1,137 @@
+{
+  "name": "@pipelock/verifier-ts",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@pipelock/verifier-ts",
+      "version": "0.1.0",
+      "dependencies": {
+        "@noble/ed25519": "2.3.0",
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1"
+      },
+      "bin": {
+        "pipelock-verifier-ts": "dist/src/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "20.12.12",
+        "typescript": "5.4.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
+      "integrity": "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/sdk/verifiers/ts/package.json
+++ b/sdk/verifiers/ts/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@pipelock/verifier-ts",
+  "version": "0.1.0",
+  "description": "TypeScript reference verifier for Pipelock Audit Packet v0 receipts and chains.",
+  "type": "module",
+  "bin": {
+    "pipelock-verifier-ts": "./dist/src/cli.js"
+  },
+  "scripts": {
+    "build": "tsc && node scripts/copy-schema.mjs",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run build && node --test dist/tests/*.test.js",
+    "prepack": "npm run build"
+  },
+  "dependencies": {
+    "@noble/ed25519": "2.3.0",
+    "ajv": "8.20.0",
+    "ajv-formats": "3.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.12",
+    "typescript": "5.4.5"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "package.json",
+    "package-lock.json"
+  ]
+}

--- a/sdk/verifiers/ts/scripts/copy-schema.mjs
+++ b/sdk/verifiers/ts/scripts/copy-schema.mjs
@@ -1,0 +1,12 @@
+import { copyFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageDir = resolve(here, "..");
+const repoRoot = resolve(packageDir, "../../..");
+const source = resolve(repoRoot, "sdk/audit-packet/v0.json");
+const target = resolve(packageDir, "dist/src/v0.schema.json");
+
+mkdirSync(dirname(target), { recursive: true });
+copyFileSync(source, target);

--- a/sdk/verifiers/ts/src/audit-packet.ts
+++ b/sdk/verifiers/ts/src/audit-packet.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from "node:fs";
+import type { AuditPacket, AuditPacketReport, ChainResult, Receipt, Totals } from "./types.js";
+import { computeTotals, verifyChain } from "./chain.js";
+import { extractReceipts } from "./recorder.js";
+import { validateAuditPacket } from "./schema.js";
+import { resolveArtifactPath, resolvePacketPath, resolveSignerKey, sha256Hex } from "./util.js";
+
+export interface AuditPacketOptions {
+  signerKey: string;
+  offline: boolean;
+  allowSelfConsistentOnly: boolean;
+  noTrustRequired: boolean;
+  expectSha256: string;
+}
+
+const zeroTotals: Totals = {
+  allow: 0,
+  block: 0,
+  warn: 0,
+  ask: 0,
+  strip: 0,
+  forward: 0,
+  redirect: 0,
+  other: 0
+};
+
+function reportFromPacket(packetPath: string, packet?: AuditPacket): AuditPacketReport {
+  return {
+    path: packetPath,
+    verdict: packet?.verifier?.verdict ?? "",
+    trusted: packet?.verifier?.trusted ?? false,
+    valid: false,
+    summary: {
+      receipt_count: packet?.summary?.receipt_count ?? 0,
+      totals: { ...zeroTotals, ...(packet?.summary?.totals ?? {}) }
+    },
+    posture: {
+      enforcement_mode: packet?.posture?.enforcement_mode ?? "",
+      unsupported_paths: packet?.posture?.unsupported_paths ?? []
+    },
+    run: {
+      provider: packet?.run?.provider ?? "",
+      repository: packet?.run?.repository,
+      sha: packet?.run?.sha,
+      agent_identity: packet?.run?.agent_identity ?? ""
+    },
+    schema_check: "skipped",
+    chain_check: "skipped",
+    cross_check: "skipped"
+  };
+}
+
+function pushError(report: AuditPacketReport, message: string): void {
+  report.errors = [...(report.errors ?? []), message];
+}
+
+function trustVerdict(packet: AuditPacket, opts: AuditPacketOptions): boolean {
+  if (opts.noTrustRequired) return true;
+  switch (packet.verifier?.verdict) {
+    case "valid":
+      return packet.verifier.trusted === true;
+    case "self_consistent_only":
+      return opts.allowSelfConsistentOnly;
+    default:
+      return false;
+  }
+}
+
+function crossCheck(packet: AuditPacket, chain: ChainResult, receipts: Receipt[]): string[] {
+  const errors: string[] = [];
+  const receiptCount = packet.summary?.receipt_count ?? -1;
+  if (chain.receipt_count !== receiptCount) {
+    errors.push(`chain receipt_count ${chain.receipt_count} != packet.summary.receipt_count ${receiptCount}`);
+  }
+  const expectedTotals = computeTotals(receipts);
+  const gotTotals = { ...zeroTotals, ...(packet.summary?.totals ?? {}) };
+  for (const key of Object.keys(expectedTotals).sort() as (keyof Totals)[]) {
+    if (expectedTotals[key] !== gotTotals[key]) {
+      errors.push(`totals[${key}]: chain=${expectedTotals[key]} packet=${gotTotals[key]}`);
+    }
+  }
+  if (packet.verifier?.root_hash && packet.verifier.root_hash !== chain.root_hash) {
+    errors.push(`root_hash mismatch: chain=${chain.root_hash} packet=${packet.verifier.root_hash}`);
+  }
+  if ((packet.verifier?.final_seq ?? 0) !== 0 && packet.verifier?.final_seq !== chain.final_seq) {
+    errors.push(`final_seq mismatch: chain=${chain.final_seq} packet=${String(packet.verifier?.final_seq)}`);
+  }
+  switch (packet.verifier?.verdict) {
+    case "valid":
+    case "self_consistent_only":
+      if (!chain.valid) {
+        errors.push(`verdict=${packet.verifier.verdict} but chain rejected: ${chain.error ?? ""}`);
+      }
+      break;
+    case "invalid":
+      if (chain.valid) errors.push("verdict=invalid but chain re-verified successfully");
+      break;
+  }
+  return errors;
+}
+
+export async function verifyAuditPacket(target: string, opts: AuditPacketOptions): Promise<AuditPacketReport> {
+  const { packetPath, baseDir } = resolvePacketPath(target);
+  const rawPacket = readFileSync(packetPath);
+  const report = reportFromPacket(packetPath);
+
+  if (opts.expectSha256 !== "") {
+    const got = sha256Hex(rawPacket);
+    const want = opts.expectSha256.trim().toLowerCase();
+    if (got !== want) {
+      pushError(report, `packet sha256 mismatch: got ${got}, want ${want}`);
+      return report;
+    }
+  }
+
+  let packet: AuditPacket;
+  try {
+    packet = JSON.parse(rawPacket.toString("utf8")) as AuditPacket;
+  } catch (err) {
+    pushError(report, `packet json: ${(err as Error).message}`);
+    return report;
+  }
+  Object.assign(report, reportFromPacket(packetPath, packet));
+
+  const schemaErrors = validateAuditPacket(packet);
+  if (schemaErrors.length > 0) {
+    report.schema_check = "fail";
+    for (const err of schemaErrors) pushError(report, `schema: ${err}`);
+    return report;
+  }
+  report.schema_check = "pass";
+
+  if (opts.offline) {
+    report.valid = trustVerdict(packet, opts);
+    return report;
+  }
+
+  let receipts: Receipt[];
+  let chain: ChainResult;
+  try {
+    const evidencePath = resolveArtifactPath(baseDir, packet.artifacts?.evidence ?? "");
+    receipts = extractReceipts(evidencePath);
+    const keyInput = opts.signerKey.trim() === "" ? packet.verifier?.signer_key ?? "" : opts.signerKey;
+    chain = await verifyChain(receipts, resolveSignerKey(keyInput));
+  } catch (err) {
+    report.chain_check = "fail";
+    pushError(report, `chain: ${(err as Error).message}`);
+    return report;
+  }
+  report.chain_check = chain.valid ? "pass" : "fail";
+
+  const crossErrors = crossCheck(packet, chain, receipts);
+  if (crossErrors.length > 0) {
+    report.cross_check = "fail";
+    for (const err of crossErrors) pushError(report, `cross-check: ${err}`);
+    return report;
+  }
+  report.cross_check = "pass";
+  report.valid = chain.valid && trustVerdict(packet, opts);
+  if (!report.valid) pushError(report, "packet not trusted");
+  return report;
+}

--- a/sdk/verifiers/ts/src/canonical.ts
+++ b/sdk/verifiers/ts/src/canonical.ts
@@ -1,0 +1,163 @@
+import type { ActionRecord, Receipt, JSONValue } from "./types.js";
+
+type FieldSpec = readonly [name: string, omitempty: boolean, nested?: NestedKind];
+type NestedKind = "action_record" | "redaction" | "taint_source";
+
+const actionRecordFields: readonly FieldSpec[] = [
+  ["version", false],
+  ["action_id", false],
+  ["action_type", false],
+  ["timestamp", false],
+  ["principal", false],
+  ["actor", false],
+  ["delegation_chain", false],
+  ["target", false],
+  ["intent", true],
+  ["data_classes_in", true],
+  ["data_classes_out", true],
+  ["side_effect_class", false],
+  ["reversibility", false],
+  ["policy_hash", false],
+  ["verdict", false],
+  ["session_taint_level", true],
+  ["session_contaminated", true],
+  ["recent_taint_sources", true, "taint_source"],
+  ["session_task_id", true],
+  ["session_task_label", true],
+  ["authority_kind", true],
+  ["taint_decision", true],
+  ["taint_decision_reason", true],
+  ["task_override_applied", true],
+  ["contract_winning_source", true],
+  ["contract_live_verdict", true],
+  ["contract_policy_sources", true],
+  ["contract_rule_id", true],
+  ["active_manifest_hash", true],
+  ["contract_hash", true],
+  ["contract_selector_id", true],
+  ["contract_generation", true],
+  ["transport", false],
+  ["method", true],
+  ["layer", true],
+  ["pattern", true],
+  ["severity", true],
+  ["redaction", true, "redaction"],
+  ["request_id", true],
+  ["chain_prev_hash", false],
+  ["chain_seq", false],
+  ["venue", true],
+  ["jurisdiction", true],
+  ["rulebook_id", true],
+  ["remedy_class", true],
+  ["contestation_window", true],
+  ["precedent_refs", true]
+];
+
+const receiptFields: readonly FieldSpec[] = [
+  ["version", false],
+  ["action_record", false, "action_record"],
+  ["signature", false],
+  ["signer_key", false]
+];
+
+const redactionFields: readonly FieldSpec[] = [
+  ["profile", true],
+  ["provider", true],
+  ["parser", true],
+  ["total_redactions", true],
+  ["by_class", true],
+  ["cache_boundary_kept", true]
+];
+
+const taintSourceFields: readonly FieldSpec[] = [
+  ["url", false],
+  ["kind", false],
+  ["level", false],
+  ["timestamp", false],
+  ["receipt_id", true],
+  ["match_reason", true]
+];
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isGoZero(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === "boolean") return !value;
+  if (typeof value === "number") return value === 0;
+  if (typeof value === "string") return value === "";
+  if (Array.isArray(value)) return value.length === 0;
+  if (isPlainObject(value)) return Object.keys(value).length === 0;
+  return false;
+}
+
+function orderStruct(value: Record<string, unknown>, fields: readonly FieldSpec[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [name, omitempty, nested] of fields) {
+    let fieldValue = value[name];
+    if (!Object.prototype.hasOwnProperty.call(value, name)) {
+      if (omitempty) continue;
+      fieldValue = zeroValue(name, nested);
+    }
+    if (omitempty && isGoZero(fieldValue)) continue;
+    if (nested === "action_record" && isPlainObject(fieldValue)) {
+      fieldValue = orderStruct(fieldValue, actionRecordFields);
+    } else if (nested === "redaction" && isPlainObject(fieldValue)) {
+      fieldValue = orderStruct(fieldValue, redactionFields);
+    } else if (nested === "taint_source" && Array.isArray(fieldValue)) {
+      fieldValue = fieldValue.map((item) =>
+        isPlainObject(item) ? orderStruct(item, taintSourceFields) : item
+      );
+    } else {
+      fieldValue = normalizeMaps(fieldValue);
+    }
+    out[name] = fieldValue;
+  }
+  return out;
+}
+
+function zeroValue(name: string, nested?: NestedKind): unknown {
+  if (nested === "action_record") return {};
+  if (name === "version" || name === "chain_seq" || name === "level") return 0;
+  if (name === "delegation_chain") return null;
+  if (name === "timestamp") return "0001-01-01T00:00:00Z";
+  return "";
+}
+
+function normalizeMaps(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => normalizeMaps(item));
+  if (!isPlainObject(value)) return value;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    const item = value[key];
+    if (item === undefined) continue;
+    out[key] = normalizeMaps(item);
+  }
+  return out;
+}
+
+function stringifyCompact(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function goHTMLEscape(serialized: string): string {
+  return serialized
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+export function canonicalizeActionRecord(actionRecord: ActionRecord): Buffer {
+  return Buffer.from(goHTMLEscape(stringifyCompact(orderStruct(actionRecord, actionRecordFields))), "utf8");
+}
+
+export function canonicalizeReceipt(receipt: Receipt): Buffer {
+  return Buffer.from(goHTMLEscape(stringifyCompact(orderStruct(receipt, receiptFields))), "utf8");
+}
+
+export function canonicalJSONString(value: JSONValue): string {
+  return goHTMLEscape(stringifyCompact(value));
+}

--- a/sdk/verifiers/ts/src/chain.ts
+++ b/sdk/verifiers/ts/src/chain.ts
@@ -66,7 +66,8 @@ export async function verifyChain(receipts: Receipt[], expectedKeyHex = ""): Pro
 }
 
 export function computeTotals(receipts: Receipt[]) {
-  const totals = {
+  type VerdictBucket = "allow" | "block" | "warn" | "ask" | "strip" | "forward" | "redirect" | "other";
+  const totals: Record<VerdictBucket, number> = {
     allow: 0,
     block: 0,
     warn: 0,
@@ -78,8 +79,8 @@ export function computeTotals(receipts: Receipt[]) {
   };
   for (const receipt of receipts) {
     const verdict = String(receipt.action_record?.verdict ?? "").trim().toLowerCase();
-    if (verdict in totals) {
-      totals[verdict as keyof typeof totals]++;
+    if (Object.prototype.hasOwnProperty.call(totals, verdict)) {
+      totals[verdict as VerdictBucket] += 1;
     } else {
       totals.other++;
     }

--- a/sdk/verifiers/ts/src/chain.ts
+++ b/sdk/verifiers/ts/src/chain.ts
@@ -1,0 +1,88 @@
+import type { ChainResult, Receipt } from "./types.js";
+import { canonicalizeReceipt } from "./canonical.js";
+import { sha256Hex } from "./util.js";
+import { verifyReceipt } from "./signing.js";
+
+export const genesisHash = "genesis";
+
+export function receiptHash(receipt: Receipt): string {
+  return sha256Hex(canonicalizeReceipt(receipt));
+}
+
+export async function verifyChain(receipts: Receipt[], expectedKeyHex = ""): Promise<ChainResult> {
+  if (receipts.length === 0) {
+    return { valid: true, receipt_count: 0, final_seq: 0, root_hash: "" };
+  }
+
+  let keyHex = expectedKeyHex;
+  if (keyHex === "") keyHex = receipts[0]?.signer_key ?? "";
+
+  let prevHash = genesisHash;
+  for (let i = 0; i < receipts.length; i++) {
+    const receipt = receipts[i] as Receipt;
+    const seq = receipt.action_record?.chain_seq ?? 0;
+    try {
+      await verifyReceipt(receipt, keyHex);
+    } catch (err) {
+      return {
+        valid: false,
+        receipt_count: 0,
+        final_seq: 0,
+        root_hash: "",
+        broken_at_seq: seq,
+        error: `seq ${seq}: signature: ${(err as Error).message}`
+      };
+    }
+    if (seq !== i) {
+      return {
+        valid: false,
+        receipt_count: 0,
+        final_seq: 0,
+        root_hash: "",
+        broken_at_seq: seq,
+        error: `seq gap: expected ${i}, got ${seq}`
+      };
+    }
+    if (receipt.action_record?.chain_prev_hash !== prevHash) {
+      return {
+        valid: false,
+        receipt_count: 0,
+        final_seq: 0,
+        root_hash: "",
+        broken_at_seq: seq,
+        error: `seq ${seq}: chain_prev_hash mismatch`
+      };
+    }
+    prevHash = receiptHash(receipt);
+  }
+
+  const last = receipts[receipts.length - 1] as Receipt;
+  return {
+    valid: true,
+    receipt_count: receipts.length,
+    final_seq: last.action_record?.chain_seq ?? 0,
+    root_hash: prevHash
+  };
+}
+
+export function computeTotals(receipts: Receipt[]) {
+  const totals = {
+    allow: 0,
+    block: 0,
+    warn: 0,
+    ask: 0,
+    strip: 0,
+    forward: 0,
+    redirect: 0,
+    other: 0
+  };
+  for (const receipt of receipts) {
+    const verdict = String(receipt.action_record?.verdict ?? "").trim().toLowerCase();
+    if (verdict in totals) {
+      totals[verdict as keyof typeof totals]++;
+    } else {
+      totals.other++;
+    }
+  }
+  return totals;
+}

--- a/sdk/verifiers/ts/src/cli.ts
+++ b/sdk/verifiers/ts/src/cli.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import { statSync } from "node:fs";
+import * as path from "node:path";
+import { parseArgs } from "node:util";
+import { verifyAuditPacket } from "./audit-packet.js";
+import { verifyChain } from "./chain.js";
+import { emitAuditPacket, emitChain, emitReceipt } from "./output.js";
+import { extractReceipts, extractReceiptsFromSessionDir } from "./recorder.js";
+import { runReceipt } from "./receipt.js";
+import { RuntimeError, UsageError, errorMessage, resolveSignerKey } from "./util.js";
+
+export interface ChainCommandReport {
+  path: string;
+  valid: boolean;
+  receipt_count: number;
+  final_seq: number;
+  root_hash?: string;
+  error?: string;
+  broken_at_seq?: number;
+}
+
+function usage(command?: string): string {
+  if (command === "audit-packet") {
+    return "Usage: pipelock-verifier-ts audit-packet PATH [--json] [--key HEX_OR_FILE] [--offline] [--allow-self-consistent-only] [--no-trust-required] [--expect-sha256 HEX]";
+  }
+  if (command === "chain") {
+    return "Usage: pipelock-verifier-ts chain PATH [--json] [--key HEX_OR_FILE] [--dir] [--session-id ID]";
+  }
+  if (command === "receipt") {
+    return "Usage: pipelock-verifier-ts receipt PATH [--json] [--key HEX_OR_FILE]";
+  }
+  return "Usage: pipelock-verifier-ts {audit-packet|chain|receipt} PATH [flags]";
+}
+
+function requireOneArg(positionals: string[], command: string): string {
+  if (positionals.length !== 1) throw new UsageError(`${usage(command)}\naccepts 1 arg, received ${positionals.length}`);
+  return positionals[0] as string;
+}
+
+async function runAuditPacketCommand(args: string[]): Promise<number> {
+  const parsed = parseArgs({
+    args,
+    allowPositionals: true,
+    options: {
+      json: { type: "boolean", default: false },
+      key: { type: "string", default: "" },
+      offline: { type: "boolean", default: false },
+      "allow-self-consistent-only": { type: "boolean", default: false },
+      "no-trust-required": { type: "boolean", default: false },
+      "expect-sha256": { type: "string", default: "" }
+    }
+  });
+  const target = requireOneArg(parsed.positionals, "audit-packet");
+  const report = await verifyAuditPacket(target, {
+    signerKey: String(parsed.values.key ?? ""),
+    offline: parsed.values.offline === true,
+    allowSelfConsistentOnly: parsed.values["allow-self-consistent-only"] === true,
+    noTrustRequired: parsed.values["no-trust-required"] === true,
+    expectSha256: String(parsed.values["expect-sha256"] ?? "")
+  });
+  emitAuditPacket(report, parsed.values.json === true);
+  return report.valid ? 0 : 1;
+}
+
+async function runChainCommand(args: string[]): Promise<number> {
+  const parsed = parseArgs({
+    args,
+    allowPositionals: true,
+    options: {
+      json: { type: "boolean", default: false },
+      key: { type: "string", default: "" },
+      dir: { type: "boolean", default: false },
+      "session-id": { type: "string", default: "proxy" },
+      session: { type: "string", default: undefined }
+    }
+  });
+  const target = requireOneArg(parsed.positionals, "chain");
+  const keyHex = resolveSignerKey(String(parsed.values.key ?? ""));
+  const asDir = parsed.values.dir === true;
+  const sessionID = String(parsed.values.session ?? parsed.values["session-id"] ?? "proxy");
+  let receipts;
+  let label: string;
+  try {
+    if (asDir) {
+      const clean = path.normalize(target);
+      receipts = extractReceiptsFromSessionDir(clean, sessionID);
+      label = `${clean} (session ${sessionID})`;
+    } else {
+      const clean = path.normalize(target);
+      if (statSync(clean).isDirectory()) {
+        throw new RuntimeError(`${target} is a directory; pass --dir to verify a session directory`);
+      }
+      receipts = extractReceipts(clean);
+      label = clean;
+    }
+  } catch (err) {
+    throw new RuntimeError(`extract receipts: ${errorMessage(err)}`);
+  }
+  if (receipts.length === 0) {
+    const report: ChainCommandReport = { path: label, valid: false, receipt_count: 0, final_seq: 0, error: "no receipts in chain" };
+    emitChain(report, parsed.values.json === true);
+    return 1;
+  }
+  const result = await verifyChain(receipts, keyHex);
+  const report: ChainCommandReport = {
+    path: label,
+    valid: result.valid,
+    receipt_count: result.receipt_count,
+    final_seq: result.final_seq,
+    root_hash: result.root_hash || undefined,
+    error: result.error,
+    broken_at_seq: result.broken_at_seq
+  };
+  emitChain(report, parsed.values.json === true);
+  return result.valid ? 0 : 1;
+}
+
+async function runReceiptCommand(args: string[]): Promise<number> {
+  const parsed = parseArgs({
+    args,
+    allowPositionals: true,
+    options: {
+      json: { type: "boolean", default: false },
+      key: { type: "string", default: "" }
+    }
+  });
+  const target = requireOneArg(parsed.positionals, "receipt");
+  const report = await runReceipt(target, String(parsed.values.key ?? ""));
+  emitReceipt(report, parsed.values.json === true);
+  return report.valid ? 0 : 1;
+}
+
+async function main(): Promise<number> {
+  const [command, ...args] = process.argv.slice(2);
+  if (!command) throw new UsageError(usage());
+  switch (command) {
+    case "audit-packet":
+      return runAuditPacketCommand(args);
+    case "chain":
+      return runChainCommand(args);
+    case "receipt":
+      return runReceiptCommand(args);
+    default:
+      throw new UsageError(`unknown command ${command}\n${usage()}`);
+  }
+}
+
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((err: unknown) => {
+    const message = errorMessage(err);
+    if (err instanceof UsageError || message.startsWith("Unknown option")) {
+      process.stderr.write(`${message}\n`);
+      process.exitCode = 64;
+      return;
+    }
+    if (err instanceof RuntimeError) {
+      process.stderr.write(`${message}\n`);
+      process.exitCode = 2;
+      return;
+    }
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 2;
+  });

--- a/sdk/verifiers/ts/src/cli.ts
+++ b/sdk/verifiers/ts/src/cli.ts
@@ -52,11 +52,11 @@ async function runAuditPacketCommand(args: string[]): Promise<number> {
   });
   const target = requireOneArg(parsed.positionals, "audit-packet");
   const report = await verifyAuditPacket(target, {
-    signerKey: String(parsed.values.key ?? ""),
+    signerKey: parsed.values.key ?? "",
     offline: parsed.values.offline === true,
     allowSelfConsistentOnly: parsed.values["allow-self-consistent-only"] === true,
     noTrustRequired: parsed.values["no-trust-required"] === true,
-    expectSha256: String(parsed.values["expect-sha256"] ?? "")
+    expectSha256: parsed.values["expect-sha256"] ?? ""
   });
   emitAuditPacket(report, parsed.values.json === true);
   return report.valid ? 0 : 1;
@@ -70,14 +70,13 @@ async function runChainCommand(args: string[]): Promise<number> {
       json: { type: "boolean", default: false },
       key: { type: "string", default: "" },
       dir: { type: "boolean", default: false },
-      "session-id": { type: "string", default: "proxy" },
-      session: { type: "string", default: undefined }
+      "session-id": { type: "string", default: "proxy" }
     }
   });
   const target = requireOneArg(parsed.positionals, "chain");
-  const keyHex = resolveSignerKey(String(parsed.values.key ?? ""));
+  const keyHex = resolveSignerKey(parsed.values.key ?? "");
   const asDir = parsed.values.dir === true;
-  const sessionID = String(parsed.values.session ?? parsed.values["session-id"] ?? "proxy");
+  const sessionID = parsed.values["session-id"] ?? "proxy";
   let receipts;
   let label: string;
   try {
@@ -125,7 +124,7 @@ async function runReceiptCommand(args: string[]): Promise<number> {
     }
   });
   const target = requireOneArg(parsed.positionals, "receipt");
-  const report = await runReceipt(target, String(parsed.values.key ?? ""));
+  const report = await runReceipt(target, parsed.values.key ?? "");
   emitReceipt(report, parsed.values.json === true);
   return report.valid ? 0 : 1;
 }

--- a/sdk/verifiers/ts/src/output.ts
+++ b/sdk/verifiers/ts/src/output.ts
@@ -1,0 +1,71 @@
+import type { AuditPacketReport } from "./types.js";
+import type { ReceiptReport } from "./receipt.js";
+import type { ChainCommandReport } from "./cli.js";
+
+export function writeJSON(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function emitAuditPacket(report: AuditPacketReport, json: boolean): void {
+  if (json) {
+    writeJSON(report);
+    return;
+  }
+  const verdict = report.verdict === "" ? "(unset)" : report.verdict;
+  process.stdout.write(`Audit Packet:   ${report.path}\n`);
+  process.stdout.write(`  schema:       ${report.schema_check}\n`);
+  process.stdout.write(`  chain:        ${report.chain_check}\n`);
+  process.stdout.write(`  cross-check:  ${report.cross_check}\n`);
+  process.stdout.write(`  verdict:      ${verdict}\n`);
+  process.stdout.write(`  trusted:      ${String(report.trusted)}\n`);
+  process.stdout.write(`  receipts:     ${report.summary.receipt_count}\n`);
+  if (report.run.provider) process.stdout.write(`  provider:     ${report.run.provider}\n`);
+  if (report.run.repository) process.stdout.write(`  repository:   ${report.run.repository}\n`);
+  if (report.run.sha) process.stdout.write(`  sha:          ${report.run.sha}\n`);
+  if (report.run.agent_identity) process.stdout.write(`  agent:        ${report.run.agent_identity}\n`);
+  if (report.posture.enforcement_mode) process.stdout.write(`  enforcement:  ${report.posture.enforcement_mode}\n`);
+  if (report.posture.unsupported_paths.length > 0) {
+    process.stdout.write(`  unsupported:  ${report.posture.unsupported_paths.join(", ")}\n`);
+  }
+  for (const err of report.errors ?? []) process.stderr.write(`ERROR: ${err}\n`);
+  for (const warning of report.warnings ?? []) process.stderr.write(`WARN:  ${warning}\n`);
+  process.stdout.write(`  result:       ${report.valid ? "VALID" : "INVALID"}\n`);
+}
+
+export function emitReceipt(report: ReceiptReport, json: boolean): void {
+  if (json) {
+    writeJSON(report);
+    return;
+  }
+  if (report.valid) {
+    process.stdout.write(`RECEIPT VALID: ${report.path}\n`);
+    process.stdout.write(`  action_id:    ${report.action_id ?? ""}\n`);
+    process.stdout.write(`  verdict:      ${report.verdict ?? ""}\n`);
+    process.stdout.write(`  transport:    ${report.transport ?? ""}\n`);
+    process.stdout.write(`  signer:       ${report.signer_key ?? ""}\n`);
+    process.stdout.write(`  policy_hash:  ${report.policy_hash ?? ""}\n`);
+    process.stdout.write(`  chain_seq:    ${report.chain_seq ?? 0}\n`);
+    return;
+  }
+  process.stderr.write(`RECEIPT INVALID: ${report.path}\n`);
+  if (report.error) process.stderr.write(`  error: ${report.error}\n`);
+}
+
+export function emitChain(report: ChainCommandReport, json: boolean): void {
+  if (json) {
+    writeJSON(report);
+    return;
+  }
+  if (report.valid) {
+    process.stdout.write(`CHAIN VALID: ${report.path}\n`);
+    process.stdout.write(`  receipts:   ${report.receipt_count}\n`);
+    process.stdout.write(`  final seq:  ${report.final_seq}\n`);
+    process.stdout.write(`  root hash:  ${report.root_hash}\n`);
+    return;
+  }
+  process.stderr.write(`CHAIN BROKEN: ${report.path}\n`);
+  if (report.error) process.stderr.write(`  error:      ${report.error}\n`);
+  if ((report.broken_at_seq ?? 0) !== 0 || report.error) {
+    process.stderr.write(`  broken at:  seq ${report.broken_at_seq ?? 0}\n`);
+  }
+}

--- a/sdk/verifiers/ts/src/receipt.ts
+++ b/sdk/verifiers/ts/src/receipt.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import type { Receipt } from "./types.js";
+import { verifyReceipt } from "./signing.js";
+import { parseJSON, resolveSignerKey } from "./util.js";
+
+export interface ReceiptReport {
+  path: string;
+  valid: boolean;
+  action_id?: string;
+  verdict?: string;
+  transport?: string;
+  signer_key?: string;
+  policy_hash?: string;
+  chain_seq?: number;
+  error?: string;
+}
+
+export async function runReceipt(pathname: string, signerKey: string): Promise<ReceiptReport> {
+  const clean = path.normalize(pathname);
+  const keyHex = resolveSignerKey(signerKey);
+  const receipt = parseJSON<Receipt>(readFileSync(clean, "utf8"), "receipt json");
+  const report: ReceiptReport = {
+    path: clean,
+    valid: false,
+    action_id: receipt.action_record?.action_id,
+    verdict: receipt.action_record?.verdict,
+    transport: receipt.action_record?.transport,
+    signer_key: receipt.signer_key,
+    policy_hash: receipt.action_record?.policy_hash,
+    chain_seq: receipt.action_record?.chain_seq
+  };
+  try {
+    await verifyReceipt(receipt, keyHex);
+    report.valid = true;
+  } catch (err) {
+    report.error = (err as Error).message;
+  }
+  return report;
+}

--- a/sdk/verifiers/ts/src/recorder.ts
+++ b/sdk/verifiers/ts/src/recorder.ts
@@ -35,9 +35,12 @@ export function extractReceipts(file: string): Receipt[] {
 function seqStart(file: string): number {
   const base = path.basename(file, ".jsonl");
   const dash = base.lastIndexOf("-");
-  if (dash < 0) return 0;
-  const parsed = Number.parseInt(base.slice(dash + 1), 10);
-  return Number.isFinite(parsed) ? parsed : 0;
+  const suffix = dash < 0 ? "" : base.slice(dash + 1);
+  const parsed = Number.parseInt(suffix, 10);
+  if (!/^\d+$/u.test(suffix) || !Number.isFinite(parsed)) {
+    throw new RuntimeError(`evidence file has non-numeric sequence suffix: ${file}`);
+  }
+  return parsed;
 }
 
 export function extractReceiptsFromSessionDir(dir: string, sessionId: string): Receipt[] {

--- a/sdk/verifiers/ts/src/recorder.ts
+++ b/sdk/verifiers/ts/src/recorder.ts
@@ -1,0 +1,54 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import * as path from "node:path";
+import type { Receipt, RecorderEntry } from "./types.js";
+import { RuntimeError, parseJSON } from "./util.js";
+
+const actionReceiptType = "action_receipt";
+
+export function readEntries(file: string): RecorderEntry[] {
+  const text = readFileSync(path.normalize(file), "utf8");
+  const entries: RecorderEntry[] = [];
+  const lines = text.split(/\r?\n/u);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]?.trim() ?? "";
+    if (line === "") continue;
+    const entry = parseJSON<RecorderEntry>(line, `line ${i + 1}`);
+    if (entry.v !== 1 && entry.v !== 2) {
+      throw new RuntimeError(`line ${i + 1}: unsupported entry version ${String(entry.v)} (accepted: 1, 2)`);
+    }
+    entries.push(entry);
+  }
+  return entries;
+}
+
+export function extractReceipts(file: string): Receipt[] {
+  return readEntries(file)
+    .filter((entry) => entry.type === actionReceiptType)
+    .map((entry) => {
+      if (typeof entry.detail !== "object" || entry.detail === null) {
+        throw new RuntimeError(`entry seq ${String(entry.seq)}: receipt detail is not an object`);
+      }
+      return entry.detail as Receipt;
+    });
+}
+
+function seqStart(file: string): number {
+  const base = path.basename(file, ".jsonl");
+  const dash = base.lastIndexOf("-");
+  if (dash < 0) return 0;
+  const parsed = Number.parseInt(base.slice(dash + 1), 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function extractReceiptsFromSessionDir(dir: string, sessionId: string): Receipt[] {
+  const clean = path.normalize(dir);
+  const prefix = `evidence-${sessionId}-`;
+  const files = readdirSync(clean)
+    .filter((name) => {
+      const full = path.join(clean, name);
+      return !statSync(full).isDirectory() && name.startsWith(prefix) && name.endsWith(".jsonl");
+    })
+    .map((name) => path.join(clean, name))
+    .sort((a, b) => seqStart(a) - seqStart(b));
+  return files.flatMap((file) => extractReceipts(file));
+}

--- a/sdk/verifiers/ts/src/schema.ts
+++ b/sdk/verifiers/ts/src/schema.ts
@@ -8,6 +8,10 @@ import type { AuditPacket } from "./types.js";
 const schemaURL = new URL("./v0.schema.json", import.meta.url);
 const require = createRequire(import.meta.url);
 const addFormats = require("ajv-formats") as (ajv: Ajv2020) => void;
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+addFormats(ajv);
+const schema = JSON.parse(readFileSync(fileURLToPath(schemaURL), "utf8")) as object;
+const cachedValidator = ajv.compile(schema);
 
 function formatAjvError(error: ErrorObject): string {
   const location = error.instancePath === "" ? "/" : error.instancePath;
@@ -15,12 +19,8 @@ function formatAjvError(error: ErrorObject): string {
 }
 
 export function validateSchema(packet: unknown): string[] {
-  const ajv = new Ajv2020({ allErrors: true, strict: false });
-  addFormats(ajv);
-  const schema = JSON.parse(readFileSync(fileURLToPath(schemaURL), "utf8")) as object;
-  const validate = ajv.compile(schema);
-  if (validate(packet)) return [];
-  return (validate.errors ?? []).map(formatAjvError);
+  if (cachedValidator(packet)) return [];
+  return (cachedValidator.errors ?? []).map(formatAjvError);
 }
 
 const totalsKeys = ["allow", "block", "warn", "ask", "strip", "forward", "redirect", "other"] as const;

--- a/sdk/verifiers/ts/src/schema.ts
+++ b/sdk/verifiers/ts/src/schema.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import type { ErrorObject } from "ajv";
+import type { AuditPacket } from "./types.js";
+
+const schemaURL = new URL("./v0.schema.json", import.meta.url);
+const require = createRequire(import.meta.url);
+const addFormats = require("ajv-formats") as (ajv: Ajv2020) => void;
+
+function formatAjvError(error: ErrorObject): string {
+  const location = error.instancePath === "" ? "/" : error.instancePath;
+  return `${location} ${error.message ?? "failed validation"}`;
+}
+
+export function validateSchema(packet: unknown): string[] {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const schema = JSON.parse(readFileSync(fileURLToPath(schemaURL), "utf8")) as object;
+  const validate = ajv.compile(schema);
+  if (validate(packet)) return [];
+  return (validate.errors ?? []).map(formatAjvError);
+}
+
+const totalsKeys = ["allow", "block", "warn", "ask", "strip", "forward", "redirect", "other"] as const;
+const verifierVerdicts = new Set(["valid", "invalid", "error", "not_run", "self_consistent_only"]);
+const providers = new Set(["github_actions", "self_hosted", "local"]);
+const rawSocketStatuses = new Set(["denied", "allowed", "unknown"]);
+const dockerSocketStatuses = new Set(["denied", "masked", "allowed", "absent", "unknown"]);
+const dnsUDPStatuses = new Set(["denied", "proxied", "allowed", "unknown"]);
+const browserProxyStatuses = new Set(["forced", "advisory", "absent", "unknown"]);
+const websocketFrameScanning = new Set(["explicit_ws_proxy_path_required", "always_on", "off"]);
+
+function enumCheck(name: string, value: unknown, values: Set<string>, errors: string[]): void {
+  if (typeof value !== "string" || !values.has(value)) {
+    errors.push(`${name} ${JSON.stringify(value)} is not a valid v0 value`);
+  }
+}
+
+function nonNegativeMap(name: string, value: unknown, errors: string[]): void {
+  if (value === undefined) return;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return;
+  for (const [key, count] of Object.entries(value)) {
+    if (typeof count !== "number" || !Number.isInteger(count) || count < 0) {
+      errors.push(`${name}[${JSON.stringify(key)}] must be non-negative`);
+    }
+  }
+}
+
+export function validateStructural(packet: AuditPacket): string[] {
+  const errors: string[] = [];
+  if (packet.schema_version !== "pipelock.audit_packet.v0") {
+    errors.push(`schema_version ${JSON.stringify(packet.schema_version)} is not "pipelock.audit_packet.v0"`);
+  }
+  if (!packet.run) {
+    errors.push("run is required");
+  } else {
+    enumCheck("provider", packet.run.provider, providers, errors);
+    if (!packet.run.agent_identity) errors.push("agent_identity is required");
+    if (!packet.run.started_at) errors.push("started_at is required");
+  }
+  if (!packet.policy || !Array.isArray(packet.policy.policy_hashes)) {
+    errors.push("policy_hashes is required (use empty array, not null)");
+  }
+  if (!packet.summary || !packet.summary.totals) {
+    errors.push("summary.totals is required");
+  } else {
+    const receiptCount = packet.summary.receipt_count ?? -1;
+    if (!Number.isInteger(receiptCount) || receiptCount < 0) {
+      errors.push("receipt_count must be non-negative");
+    }
+    let sum = 0;
+    for (const key of totalsKeys) {
+      const value = packet.summary.totals[key];
+      if (!Number.isInteger(value) || value < 0) errors.push(`totals.${key} must be non-negative`);
+      sum += Number.isFinite(value) ? value : 0;
+    }
+    if (sum !== receiptCount) {
+      errors.push(`totals sum ${sum} does not match receipt_count ${receiptCount}`);
+    }
+    nonNegativeMap("transports", packet.summary.transports, errors);
+    nonNegativeMap("layers", packet.summary.layers, errors);
+    const domains = packet.summary.domains_touched ?? [];
+    for (let i = 1; i < domains.length; i++) {
+      if ((domains[i - 1] as string) > (domains[i] as string)) {
+        errors.push("domains_touched must be sorted");
+        break;
+      }
+      if (domains[i - 1] === domains[i]) {
+        errors.push(`domains_touched contains duplicate ${JSON.stringify(domains[i])}`);
+        break;
+      }
+    }
+  }
+  if (!packet.verifier) {
+    errors.push("verifier is required");
+  } else {
+    const verdict = packet.verifier.verdict;
+    if (typeof verdict !== "string" || !verifierVerdicts.has(verdict)) {
+      errors.push(`verdict ${JSON.stringify(verdict)} not in {valid, invalid, error, not_run, self_consistent_only}`);
+    }
+    if (packet.verifier.trusted === true && verdict !== "valid") {
+      errors.push(`trusted=true requires verdict=valid, got ${JSON.stringify(verdict)}`);
+    }
+    if (verdict === "valid" && packet.verifier.trusted !== true) {
+      errors.push("verdict=valid requires trusted=true");
+    }
+    if (packet.verifier.trusted === true && !packet.verifier.signer_key) {
+      errors.push("trusted=true requires signer_key");
+    }
+    if ((packet.verifier.receipt_count ?? 0) < 0) errors.push("receipt_count must be non-negative");
+    if ((packet.verifier.final_seq ?? 0) < 0) errors.push("final_seq must be non-negative");
+  }
+  if (!packet.posture) {
+    errors.push("posture is required");
+  } else {
+    if (!packet.posture.enforcement_mode) errors.push("enforcement_mode is required");
+    if (!packet.posture.runner_os) errors.push("runner_os is required");
+    enumCheck("raw_socket_status", packet.posture.raw_socket_status, rawSocketStatuses, errors);
+    enumCheck("docker_socket_status", packet.posture.docker_socket_status, dockerSocketStatuses, errors);
+    enumCheck("dns_udp_status", packet.posture.dns_udp_status, dnsUDPStatuses, errors);
+    enumCheck("browser_proxy_status", packet.posture.browser_proxy_status, browserProxyStatuses, errors);
+    enumCheck("websocket_frame_scanning", packet.posture.websocket_frame_scanning, websocketFrameScanning, errors);
+    if (!Array.isArray(packet.posture.unsupported_paths)) {
+      errors.push("unsupported_paths is required (use empty array, not null)");
+    }
+  }
+  if (!packet.artifacts?.packet) errors.push("packet path is required");
+  if (!packet.artifacts?.evidence) errors.push("evidence path is required");
+  if (!packet.artifacts?.verifier) errors.push("verifier path is required");
+  return errors;
+}
+
+export function validateAuditPacket(packet: AuditPacket): string[] {
+  return [...validateSchema(packet), ...validateStructural(packet)];
+}

--- a/sdk/verifiers/ts/src/signing.ts
+++ b/sdk/verifiers/ts/src/signing.ts
@@ -1,7 +1,8 @@
+import { createHash } from "node:crypto";
 import * as ed25519 from "@noble/ed25519";
 import type { ActionRecord, Receipt } from "./types.js";
 import { canonicalizeActionRecord } from "./canonical.js";
-import { decodeHex, sha256Hex } from "./util.js";
+import { decodeHex } from "./util.js";
 
 const signaturePrefix = "ed25519:";
 
@@ -58,10 +59,11 @@ export function normalizeReceipt(receipt: Receipt): Receipt {
 
 export async function verifyReceipt(receipt: Receipt, expectedKeyHex = ""): Promise<void> {
   normalizeReceipt(receipt);
-  const signerKey = receipt.signer_key ?? "";
-  const keyHex = expectedKeyHex === "" ? signerKey : expectedKeyHex;
-  if (expectedKeyHex !== "" && signerKey !== expectedKeyHex) {
-    throw new Error(`signer_key ${signerKey} does not match expected key ${expectedKeyHex}`);
+  const signerKey = (receipt.signer_key ?? "").toLowerCase();
+  const expected = expectedKeyHex.toLowerCase();
+  const keyHex = expected === "" ? signerKey : expected;
+  if (expected !== "" && signerKey !== expected) {
+    throw new Error(`signer_key ${signerKey} does not match expected key ${expected}`);
   }
 
   const pubKey = decodeHex(keyHex, 32, "signer_key");
@@ -70,7 +72,9 @@ export async function verifyReceipt(receipt: Receipt, expectedKeyHex = ""): Prom
     throw new Error(`invalid signature format: missing ${signaturePrefix} prefix`);
   }
   const sig = decodeHex(signature.slice(signaturePrefix.length), 64, "signature");
-  const digest = Buffer.from(sha256Hex(canonicalizeActionRecord(receipt.action_record as ActionRecord)), "hex");
-  const ok = await ed25519.verifyAsync(sig, digest, pubKey);
+  const digest = createHash("sha256")
+    .update(canonicalizeActionRecord(receipt.action_record as ActionRecord))
+    .digest();
+  const ok = await ed25519.verifyAsync(sig, digest, pubKey, { zip215: false });
   if (!ok) throw new Error("signature verification failed");
 }

--- a/sdk/verifiers/ts/src/signing.ts
+++ b/sdk/verifiers/ts/src/signing.ts
@@ -1,0 +1,76 @@
+import * as ed25519 from "@noble/ed25519";
+import type { ActionRecord, Receipt } from "./types.js";
+import { canonicalizeActionRecord } from "./canonical.js";
+import { decodeHex, sha256Hex } from "./util.js";
+
+const signaturePrefix = "ed25519:";
+
+const validActionTypes = new Set([
+  "read",
+  "derive",
+  "write",
+  "delegate",
+  "authorize",
+  "spend",
+  "commit",
+  "actuate",
+  "unclassified"
+]);
+
+function requireString(value: unknown, name: string): string {
+  if (typeof value !== "string" || value === "") throw new Error(`${name} is required`);
+  return value;
+}
+
+function requireNumber(value: unknown, name: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+export function validateActionRecord(actionRecord: ActionRecord | undefined): ActionRecord {
+  if (!actionRecord || typeof actionRecord !== "object") throw new Error("action_record is required");
+  if (actionRecord.version !== 1) {
+    throw new Error(`unsupported action record version ${String(actionRecord.version)} (expected 1)`);
+  }
+  requireString(actionRecord.action_id, "action_id");
+  const actionType = requireString(actionRecord.action_type, "action_type");
+  if (!validActionTypes.has(actionType)) throw new Error(`invalid action_type ${actionType}`);
+  requireString(actionRecord.timestamp, "timestamp");
+  requireString(actionRecord.target, "target");
+  requireString(actionRecord.verdict, "verdict");
+  requireString(actionRecord.transport, "transport");
+  requireString(actionRecord.chain_prev_hash, "chain_prev_hash");
+  requireNumber(actionRecord.chain_seq, "chain_seq");
+  return actionRecord;
+}
+
+export function normalizeReceipt(receipt: Receipt): Receipt {
+  if (receipt.version !== 1) {
+    throw new Error(`unsupported receipt version ${String(receipt.version)} (expected 1)`);
+  }
+  validateActionRecord(receipt.action_record);
+  requireString(receipt.signature, "signature");
+  requireString(receipt.signer_key, "signer_key");
+  return receipt;
+}
+
+export async function verifyReceipt(receipt: Receipt, expectedKeyHex = ""): Promise<void> {
+  normalizeReceipt(receipt);
+  const signerKey = receipt.signer_key ?? "";
+  const keyHex = expectedKeyHex === "" ? signerKey : expectedKeyHex;
+  if (expectedKeyHex !== "" && signerKey !== expectedKeyHex) {
+    throw new Error(`signer_key ${signerKey} does not match expected key ${expectedKeyHex}`);
+  }
+
+  const pubKey = decodeHex(keyHex, 32, "signer_key");
+  const signature = receipt.signature ?? "";
+  if (!signature.startsWith(signaturePrefix)) {
+    throw new Error(`invalid signature format: missing ${signaturePrefix} prefix`);
+  }
+  const sig = decodeHex(signature.slice(signaturePrefix.length), 64, "signature");
+  const digest = Buffer.from(sha256Hex(canonicalizeActionRecord(receipt.action_record as ActionRecord)), "hex");
+  const ok = await ed25519.verifyAsync(sig, digest, pubKey);
+  if (!ok) throw new Error("signature verification failed");
+}

--- a/sdk/verifiers/ts/src/types.ts
+++ b/sdk/verifiers/ts/src/types.ts
@@ -1,0 +1,189 @@
+export type JSONValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JSONValue[]
+  | { [key: string]: JSONValue };
+
+export type JSONObject = { [key: string]: JSONValue };
+
+export interface Receipt {
+  version?: number;
+  action_record?: ActionRecord;
+  signature?: string;
+  signer_key?: string;
+  [key: string]: unknown;
+}
+
+export interface ActionRecord {
+  version?: number;
+  action_id?: string;
+  action_type?: string;
+  timestamp?: string;
+  principal?: string;
+  actor?: string;
+  delegation_chain?: string[];
+  target?: string;
+  intent?: string;
+  data_classes_in?: string[];
+  data_classes_out?: string[];
+  side_effect_class?: string;
+  reversibility?: string;
+  policy_hash?: string;
+  verdict?: string;
+  session_taint_level?: string;
+  session_contaminated?: boolean;
+  recent_taint_sources?: TaintSourceRef[];
+  session_task_id?: string;
+  session_task_label?: string;
+  authority_kind?: string;
+  taint_decision?: string;
+  taint_decision_reason?: string;
+  task_override_applied?: boolean;
+  contract_winning_source?: string;
+  contract_live_verdict?: string;
+  contract_policy_sources?: string[];
+  contract_rule_id?: string;
+  active_manifest_hash?: string;
+  contract_hash?: string;
+  contract_selector_id?: string;
+  contract_generation?: number;
+  transport?: string;
+  method?: string;
+  layer?: string;
+  pattern?: string;
+  severity?: string;
+  redaction?: RedactionSummary;
+  request_id?: string;
+  chain_prev_hash?: string;
+  chain_seq?: number;
+  venue?: string;
+  jurisdiction?: string;
+  rulebook_id?: string;
+  remedy_class?: string;
+  contestation_window?: string;
+  precedent_refs?: string[];
+  [key: string]: unknown;
+}
+
+export interface TaintSourceRef {
+  url?: string;
+  kind?: string;
+  level?: string | number;
+  timestamp?: string;
+  receipt_id?: string;
+  match_reason?: string;
+  [key: string]: unknown;
+}
+
+export interface RedactionSummary {
+  profile?: string;
+  provider?: string;
+  parser?: string;
+  total_redactions?: number;
+  by_class?: Record<string, number>;
+  cache_boundary_kept?: boolean;
+  [key: string]: unknown;
+}
+
+export interface RecorderEntry {
+  v?: number;
+  seq?: number;
+  ts?: string;
+  session_id?: string;
+  type?: string;
+  detail?: unknown;
+}
+
+export interface Totals {
+  allow: number;
+  block: number;
+  warn: number;
+  ask: number;
+  strip: number;
+  forward: number;
+  redirect: number;
+  other: number;
+}
+
+export interface AuditPacket {
+  schema_version?: string;
+  generated_at?: string;
+  run?: {
+    provider?: string;
+    repository?: string;
+    sha?: string;
+    agent_identity?: string;
+    started_at?: string;
+    [key: string]: unknown;
+  };
+  policy?: {
+    policy_hashes?: unknown;
+    [key: string]: unknown;
+  };
+  summary?: {
+    receipt_count?: number;
+    totals?: Totals;
+    transports?: Record<string, number>;
+    layers?: Record<string, number>;
+    domains_touched?: string[];
+    [key: string]: unknown;
+  };
+  verifier?: {
+    verdict?: string;
+    trusted?: boolean;
+    receipt_count?: number;
+    root_hash?: string;
+    final_seq?: number;
+    signer_key?: string;
+    [key: string]: unknown;
+  };
+  posture?: {
+    enforcement_mode?: string;
+    unsupported_paths?: string[];
+    [key: string]: unknown;
+  };
+  artifacts?: {
+    packet?: string;
+    evidence?: string;
+    verifier?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface ChainResult {
+  valid: boolean;
+  receipt_count: number;
+  final_seq: number;
+  root_hash: string;
+  error?: string;
+  broken_at_seq?: number;
+}
+
+export interface AuditPacketReport {
+  path: string;
+  verdict: string;
+  trusted: boolean;
+  valid: boolean;
+  summary: {
+    receipt_count: number;
+    totals: Totals;
+  };
+  posture: {
+    enforcement_mode: string;
+    unsupported_paths: string[];
+  };
+  run: {
+    provider: string;
+    repository?: string;
+    sha?: string;
+    agent_identity: string;
+  };
+  errors?: string[];
+  warnings?: string[];
+  schema_check: "pass" | "fail" | "skipped";
+  chain_check: "pass" | "fail" | "skipped";
+  cross_check: "pass" | "fail" | "skipped";
+}

--- a/sdk/verifiers/ts/src/util.ts
+++ b/sdk/verifiers/ts/src/util.ts
@@ -1,0 +1,108 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import * as path from "node:path";
+
+export class UsageError extends Error {
+  readonly code = 64;
+}
+
+export class RuntimeError extends Error {
+  readonly code = 2;
+}
+
+export class InvalidError extends Error {
+  readonly code = 1;
+}
+
+export function sha256Hex(data: Buffer | string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+export function parseJSONFile<T>(file: string): T {
+  try {
+    return JSON.parse(readFileSync(path.normalize(file), "utf8")) as T;
+  } catch (err) {
+    if (err instanceof SyntaxError) throw new RuntimeError(`malformed JSON: ${err.message}`);
+    throw new RuntimeError(`read ${file}: ${(err as Error).message}`);
+  }
+}
+
+export function parseJSON<T>(text: string, label: string): T {
+  try {
+    return JSON.parse(text) as T;
+  } catch (err) {
+    throw new RuntimeError(`${label}: ${(err as Error).message}`);
+  }
+}
+
+export function decodeHex(input: string, byteLength: number, label: string): Uint8Array {
+  const trimmed = input.trim().toLowerCase();
+  if (!/^[0-9a-f]*$/u.test(trimmed) || trimmed.length !== byteLength * 2) {
+    throw new Error(`invalid ${label} length: got ${trimmed.length / 2}, want ${byteLength}`);
+  }
+  return Uint8Array.from(Buffer.from(trimmed, "hex"));
+}
+
+export function resolveSignerKey(input: string): string {
+  const trimmed = input.trim();
+  if (trimmed === "") return "";
+
+  let value = trimmed;
+  if (existsSync(trimmed)) {
+    value = readFileSync(trimmed, "utf8").trim();
+  }
+
+  if (value.startsWith("pipelock-ed25519-public-v1\n")) {
+    const body = value.split(/\n/u)[1]?.trim() ?? "";
+    value = Buffer.from(body, "base64").toString("hex");
+  }
+
+  decodeHex(value, 32, "public key");
+  return value.toLowerCase();
+}
+
+export function resolvePacketPath(target: string): { packetPath: string; baseDir: string } {
+  const clean = path.normalize(target);
+  let info;
+  try {
+    info = statSync(clean);
+  } catch (err) {
+    throw new RuntimeError(`stat ${target}: ${(err as Error).message}`);
+  }
+  if (info.isDirectory()) return { packetPath: path.join(clean, "packet.json"), baseDir: clean };
+  return { packetPath: clean, baseDir: path.dirname(clean) };
+}
+
+export function resolveArtifactPath(baseDir: string, rel: string): string {
+  if (rel === "") throw new Error("artifact path is empty");
+  if (path.isAbsolute(rel)) throw new Error(`artifact path must be relative: ${rel}`);
+  if (rel.includes("\\") || rel.includes(":")) {
+    throw new Error(`artifact path contains forbidden character: ${rel}`);
+  }
+  const clean = path.normalize(rel);
+  if (clean === "." || clean === ".." || clean.startsWith(`..${path.sep}`)) {
+    throw new Error(`artifact path escapes packet directory: ${rel}`);
+  }
+  const absBase = path.resolve(baseDir);
+  const absFull = path.resolve(baseDir, clean);
+  const relToBase = path.relative(absBase, absFull);
+  if (relToBase === ".." || relToBase.startsWith(`..${path.sep}`) || path.isAbsolute(relToBase)) {
+    throw new Error(`artifact path escapes packet directory after resolution: ${rel}`);
+  }
+  if (existsSync(absFull)) {
+    const resolved = realpathSync(absFull);
+    const realRel = path.relative(absBase, resolved);
+    if (realRel === ".." || realRel.startsWith(`..${path.sep}`) || path.isAbsolute(realRel)) {
+      throw new Error(`artifact path escapes packet directory via symlink: ${rel}`);
+    }
+  }
+  return absFull;
+}
+
+export function usage(message: string): never {
+  throw new UsageError(message);
+}
+
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/sdk/verifiers/ts/tests/audit-packet.test.ts
+++ b/sdk/verifiers/ts/tests/audit-packet.test.ts
@@ -1,0 +1,150 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { verifyAuditPacket } from "../src/audit-packet.js";
+import type { AuditPacket } from "../src/types.js";
+
+const publicKey = "4655a7e605c12ebb00a46037881c33c5bca5eb74b45a02e8e7261a7ff5a21678";
+const rootHash = "be904bd5ca82adc26c2969872c23925f22ff24e33faf44a1185b9ffc0e2c2b5a";
+
+function basePacket(): AuditPacket {
+  return {
+    schema_version: "pipelock.audit_packet.v0",
+    generated_at: "2026-05-10T00:00:00Z",
+    run: {
+      provider: "local",
+      agent_identity: "test-agent",
+      started_at: "2026-05-10T00:00:00Z"
+    },
+    policy: {
+      policy_hashes: ["sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]
+    },
+    summary: {
+      receipt_count: 5,
+      totals: {
+        allow: 5,
+        block: 0,
+        warn: 0,
+        ask: 0,
+        strip: 0,
+        forward: 0,
+        redirect: 0,
+        other: 0
+      }
+    },
+    verifier: {
+      verdict: "valid",
+      trusted: true,
+      receipt_count: 5,
+      root_hash: rootHash,
+      final_seq: 4,
+      signer_key: publicKey
+    },
+    posture: {
+      enforcement_mode: "local",
+      runner_os: "Linux",
+      raw_socket_status: "unknown",
+      docker_socket_status: "unknown",
+      dns_udp_status: "unknown",
+      browser_proxy_status: "unknown",
+      websocket_frame_scanning: "explicit_ws_proxy_path_required",
+      unsupported_paths: []
+    },
+    artifacts: {
+      packet: "packet.json",
+      evidence: "evidence.jsonl",
+      verifier: "verifier.txt"
+    }
+  };
+}
+
+function writePacket(mutator?: (packet: AuditPacket) => void): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "pipelock-ts-verifier-"));
+  const packet = basePacket();
+  mutator?.(packet);
+  writeFileSync(path.join(dir, "packet.json"), `${JSON.stringify(packet, null, 2)}\n`, { mode: 0o600 });
+  writeFileSync(path.join(dir, "evidence.jsonl"), readFileSync("../../conformance/testdata/valid-chain.jsonl"), { mode: 0o600 });
+  writeFileSync(path.join(dir, "verifier.txt"), "ok\n", { mode: 0o600 });
+  return dir;
+}
+
+const defaultOptions = {
+  signerKey: "",
+  offline: false,
+  allowSelfConsistentOnly: false,
+  noTrustRequired: false,
+  expectSha256: ""
+};
+
+test("audit packet verifies end to end", async () => {
+  const report = await verifyAuditPacket(writePacket(), defaultOptions);
+  assert.equal(report.valid, true);
+  assert.equal(report.schema_check, "pass");
+  assert.equal(report.chain_check, "pass");
+  assert.equal(report.cross_check, "pass");
+});
+
+test("audit packet detects totals mismatch", async () => {
+  const report = await verifyAuditPacket(writePacket((packet) => {
+    packet.summary!.totals!.allow = 4;
+    packet.summary!.totals!.block = 1;
+  }), defaultOptions);
+  assert.equal(report.valid, false);
+  assert.equal(report.cross_check, "fail");
+  assert.ok(report.errors?.some((err) => err.includes("totals[allow]")));
+});
+
+test("audit packet detects receipt_count mismatch", async () => {
+  const report = await verifyAuditPacket(writePacket((packet) => {
+    packet.summary!.receipt_count = 6;
+    packet.summary!.totals!.other = 1;
+  }), defaultOptions);
+  assert.equal(report.cross_check, "fail");
+  assert.ok(report.errors?.some((err) => err.includes("receipt_count")));
+});
+
+test("audit packet detects root_hash mismatch", async () => {
+  const report = await verifyAuditPacket(writePacket((packet) => {
+    packet.verifier!.root_hash = "0".repeat(64);
+  }), defaultOptions);
+  assert.equal(report.cross_check, "fail");
+  assert.ok(report.errors?.some((err) => err.includes("root_hash")));
+});
+
+test("audit packet detects final_seq mismatch", async () => {
+  const report = await verifyAuditPacket(writePacket((packet) => {
+    packet.verifier!.final_seq = 3;
+  }), defaultOptions);
+  assert.equal(report.cross_check, "fail");
+  assert.ok(report.errors?.some((err) => err.includes("final_seq")));
+});
+
+test("audit packet detects verdict-vs-chain disagreement", async () => {
+  const report = await verifyAuditPacket(writePacket((packet) => {
+    packet.verifier!.verdict = "invalid";
+    packet.verifier!.trusted = false;
+  }), defaultOptions);
+  assert.equal(report.cross_check, "fail");
+  assert.ok(report.errors?.some((err) => err.includes("verdict=invalid")));
+});
+
+test("--offline skips chain verification", async () => {
+  const report = await verifyAuditPacket(writePacket((packet) => {
+    packet.verifier!.root_hash = "0".repeat(64);
+  }), { ...defaultOptions, offline: true });
+  assert.equal(report.valid, true);
+  assert.equal(report.chain_check, "skipped");
+  assert.equal(report.cross_check, "skipped");
+});
+
+test("CLI missing argument exits 64", () => {
+  const result = spawnSync(process.execPath, ["dist/src/cli.js", "audit-packet"], {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  assert.equal(result.status, 64);
+  assert.match(result.stderr, /Usage: pipelock-verifier-ts audit-packet/u);
+});

--- a/sdk/verifiers/ts/tests/canonical.test.ts
+++ b/sdk/verifiers/ts/tests/canonical.test.ts
@@ -1,0 +1,100 @@
+import { createHash } from "node:crypto";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { canonicalizeActionRecord, canonicalizeReceipt } from "../src/canonical.js";
+import { verifyReceipt } from "../src/signing.js";
+import type { Receipt } from "../src/types.js";
+
+const fullReceipt: Receipt = {
+  version: 1,
+  action_record: {
+    version: 1,
+    action_id: "ts-full-0001",
+    action_type: "write",
+    timestamp: "2026-05-10T12:34:56.789Z",
+    principal: "org:test",
+    actor: "agent:test",
+    delegation_chain: ["root", "delegate"],
+    target: "https://example.com/<x>&y",
+    intent: "post data",
+    data_classes_in: ["secret", "prompt"],
+    data_classes_out: ["summary"],
+    side_effect_class: "external_write",
+    reversibility: "compensatable",
+    policy_hash: "sha256:abc",
+    verdict: "warn",
+    session_taint_level: "medium",
+    session_contaminated: true,
+    recent_taint_sources: [
+      {
+        url: "https://source.example/a",
+        kind: "prompt",
+        level: 5,
+        timestamp: "2026-05-10T12:34:55Z",
+        receipt_id: "r1",
+        match_reason: "pattern"
+      }
+    ],
+    session_task_id: "task-1",
+    session_task_label: "review",
+    authority_kind: "operator",
+    taint_decision: "ask",
+    taint_decision_reason: "tainted input",
+    task_override_applied: true,
+    contract_winning_source: "manifest",
+    contract_live_verdict: "warn",
+    contract_policy_sources: ["policy-a", "policy-b"],
+    contract_rule_id: "rule-1",
+    active_manifest_hash: "sha256:manifest",
+    contract_hash: "sha256:contract",
+    contract_selector_id: "selector-1",
+    contract_generation: 7,
+    transport: "https",
+    method: "POST",
+    layer: "dlp",
+    pattern: "token",
+    severity: "warning",
+    redaction: {
+      profile: "default",
+      provider: "openai",
+      parser: "json",
+      total_redactions: 2,
+      by_class: { token: 1, secret: 1 },
+      cache_boundary_kept: true
+    },
+    request_id: "req-1",
+    chain_prev_hash: "genesis",
+    chain_seq: 0,
+    venue: "test-venue",
+    jurisdiction: "test-jurisdiction",
+    rulebook_id: "rulebook-v1",
+    remedy_class: "notify",
+    contestation_window: "24h",
+    precedent_refs: ["p1", "p2"]
+  },
+  signature:
+    "ed25519:dc7bdb6220e7dd261ca6a55f295ee0ca44c8dbb04c36a07940ee11730c2119dd1bae6e96ea6d465a7c6ba357119c2218a795b2eec17f424d6e070e03b9c9540c",
+  signer_key: "7de2d117b21faaa0f1d9d3d02fcba13838bef0c75caddf71de376f0bb837bfbc"
+};
+
+function sha256(data: Buffer): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+test("canonical ActionRecord matches Go hash for all current fields", () => {
+  assert.equal(
+    sha256(canonicalizeActionRecord(fullReceipt.action_record!)),
+    "8d5805f40a979a44983971f1a1a5de677cfa173edc33d71146c586a12a1ff3e1"
+  );
+});
+
+test("canonical Receipt envelope matches Go hash", () => {
+  assert.equal(
+    sha256(canonicalizeReceipt(fullReceipt)),
+    "1b07dab8572e98c5f823cfdc449cbce6711d6ed626df500d739fd9ba9b630345"
+  );
+});
+
+test("full-field receipt signature verifies", async () => {
+  await assert.doesNotReject(verifyReceipt(fullReceipt));
+});

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -1,4 +1,6 @@
-import { readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 import { extractReceipts } from "../src/recorder.js";
@@ -46,8 +48,12 @@ test("mixed signer keys are rejected without pinned key", async () => {
 });
 
 test("malformed JSONL raises an error", () => {
-  assert.throws(() => {
-    JSON.parse(readFileSync(validChain, "utf8").split("\n")[0] ?? "");
-    extractReceipts("/nonexistent/evidence.jsonl");
-  });
+  const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
+  const file = join(dir, "malformed.jsonl");
+  try {
+    writeFileSync(file, "{\"v\":1,\"seq\":0,\"ts\":\"2026-05-10T00:00:00Z\",\"session_id\":\"s\",\"type\":\"noop\",\"transport\":\"x\",\"summary\":\"\",\"detail\":{},\"prev_hash\":\"genesis\",\"hash\":\"h\"}\n{\"bad\":\n", { mode: 0o600 });
+    assert.throws(() => extractReceipts(file), /line 2/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { extractReceipts } from "../src/recorder.js";
+import { verifyChain } from "../src/chain.js";
+
+const validChain = "../../conformance/testdata/valid-chain.jsonl";
+const brokenChain = "../../conformance/testdata/broken-chain.jsonl";
+
+test("valid Go-generated chain verifies", async () => {
+  const result = await verifyChain(extractReceipts(validChain));
+  assert.equal(result.valid, true);
+  assert.equal(result.receipt_count, 5);
+  assert.equal(result.final_seq, 4);
+  assert.equal(result.root_hash, "be904bd5ca82adc26c2969872c23925f22ff24e33faf44a1185b9ffc0e2c2b5a");
+});
+
+test("broken chain_prev_hash is rejected", async () => {
+  const result = await verifyChain(extractReceipts(brokenChain));
+  assert.equal(result.valid, false);
+  assert.match(result.error ?? "", /chain_prev_hash mismatch/u);
+});
+
+test("chain_seq gap is rejected", async () => {
+  const receipts = extractReceipts(validChain);
+  receipts.splice(2, 1);
+  const result = await verifyChain(receipts);
+  assert.equal(result.valid, false);
+  assert.match(result.error ?? "", /seq gap/u);
+});
+
+test("first receipt must link to genesis", async () => {
+  const receipts = extractReceipts(validChain);
+  receipts[0]!.action_record!.chain_prev_hash = "not-genesis";
+  const result = await verifyChain(receipts);
+  assert.equal(result.valid, false);
+  assert.match(result.error ?? "", /signature/u);
+});
+
+test("mixed signer keys are rejected without pinned key", async () => {
+  const receipts = extractReceipts(validChain);
+  receipts[1]!.signer_key = "0".repeat(64);
+  const result = await verifyChain(receipts);
+  assert.equal(result.valid, false);
+  assert.match(result.error ?? "", /does not match expected key/u);
+});
+
+test("malformed JSONL raises an error", () => {
+  assert.throws(() => {
+    JSON.parse(readFileSync(validChain, "utf8").split("\n")[0] ?? "");
+    extractReceipts("/nonexistent/evidence.jsonl");
+  });
+});

--- a/sdk/verifiers/ts/tests/receipt.test.ts
+++ b/sdk/verifiers/ts/tests/receipt.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { runReceipt } from "../src/receipt.js";
+import { verifyReceipt } from "../src/signing.js";
+import type { Receipt } from "../src/types.js";
+
+const validSingle = "../../conformance/testdata/valid-single.json";
+const invalidSignature = "../../conformance/testdata/invalid-signature.json";
+
+test("receipt command accepts a valid Go-generated receipt", async () => {
+  const report = await runReceipt(validSingle, "");
+  assert.equal(report.valid, true);
+  assert.equal(report.action_id, "conformance-00000");
+});
+
+test("receipt command rejects a tampered signature", async () => {
+  const report = await runReceipt(invalidSignature, "");
+  assert.equal(report.valid, false);
+  assert.match(report.error ?? "", /signature verification failed/u);
+});
+
+test("receipt verifier rejects a pinned-key mismatch", async () => {
+  const receipt = JSON.parse(readFileSync(validSingle, "utf8")) as Receipt;
+  await assert.rejects(
+    verifyReceipt(receipt, "0".repeat(64)),
+    /does not match expected key/u
+  );
+});

--- a/sdk/verifiers/ts/tests/schema.test.ts
+++ b/sdk/verifiers/ts/tests/schema.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { validateAuditPacket } from "../src/schema.js";
+import type { AuditPacket } from "../src/types.js";
+
+function example(): AuditPacket {
+  return JSON.parse(readFileSync("../../audit-packet/example.json", "utf8")) as AuditPacket;
+}
+
+test("sdk audit-packet example passes schema and structural checks", () => {
+  assert.deepEqual(validateAuditPacket(example()), []);
+});
+
+for (const field of ["schema_version", "generated_at", "run", "policy", "summary", "verifier", "posture", "artifacts"]) {
+  test(`missing ${field} fails clearly`, () => {
+    const packet = example();
+    delete packet[field];
+    const errors = validateAuditPacket(packet);
+    assert.ok(errors.some((err) => err.includes(field)), errors.join("\n"));
+  });
+}
+
+test("wrong schema_version fails", () => {
+  const packet = example();
+  packet.schema_version = "pipelock.audit_packet.v1";
+  assert.ok(validateAuditPacket(packet).some((err) => err.includes("schema_version")));
+});
+
+test("unknown verifier verdict fails", () => {
+  const packet = example();
+  packet.verifier!.verdict = "maybe";
+  assert.ok(validateAuditPacket(packet).some((err) => err.includes("verdict")));
+});
+
+test("trusted=true requires verifier verdict valid", () => {
+  const packet = example();
+  packet.verifier!.trusted = true;
+  packet.verifier!.verdict = "invalid";
+  assert.ok(validateAuditPacket(packet).some((err) => err.includes("trusted=true")));
+});
+
+test("trusted=true requires signer_key", () => {
+  const packet = example();
+  packet.verifier!.trusted = true;
+  packet.verifier!.verdict = "valid";
+  delete packet.verifier!.signer_key;
+  assert.ok(validateAuditPacket(packet).some((err) => err.includes("signer_key")));
+});
+
+test("summary totals must sum to receipt_count", () => {
+  const packet = example();
+  packet.summary!.totals!.allow += 1;
+  assert.ok(validateAuditPacket(packet).some((err) => err.includes("totals sum")));
+});

--- a/sdk/verifiers/ts/tsconfig.json
+++ b/sdk/verifiers/ts/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a TypeScript reference verifier for Audit Packet v0 with audit-packet, chain, and receipt commands
- mirror Go receipt canonicalization, Ed25519 verification, chain linkage, trust checks, and audit packet cross-checks
- package the locked v0 schema with the npm build and update the example signer key to the Go-supported raw hex form

## Tests
- npm test
- npm run typecheck
- npm audit --omit=dev
- npm pack --dry-run
- golangci-lint run ./...
- go test -race -count=1 ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces a TypeScript verifier CLI for audit-packet, chain, and receipt verification with offline mode and both JSON and human-readable outputs
  * Adds deterministic canonicalization and Ed25519 signature verification for compatibility with existing tooling

* **Tests**
  * Adds comprehensive end-to-end and unit tests covering schema, canonicalization, chain, and receipt verification

* **Documentation**
  * Adds a full README detailing installation, CLI commands, flags, and expected behavior

* **Chores**
  * Updated example audit-packet signer key in example data

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/505)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->