### PR TITLE
Add route-scoped non-JSON redaction exceptions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -332,7 +332,7 @@ redaction:
 | `limits.max_depth` | `64` | Max JSON nesting depth the redactor will traverse |
 | `strict_reload` | `false` | Fail reload closed if an active dictionary disappears or corrupts |
 | `allowlist_unparseable` | `[]` | Bare hostnames allowed to pass non-JSON bodies/messages unchanged |
-| `allowlist_unparseable_routes` | `[]` | Route-scoped non-JSON exceptions with `host` plus optional `methods`, `path_prefixes`, `path_suffixes`, and `content_types` constraints |
+| `allowlist_unparseable_routes` | `[]` | Route-scoped non-JSON exceptions with `host` plus at least one of `methods`, `path_prefixes`, `path_suffixes`, or `content_types` |
 
 **Requirements and fail-closed behavior:**
 - `redaction.enabled: true` requires `request_body_scanning.enabled: true` because the rewrite hook lives in the request-body scan path.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -291,6 +291,11 @@ redaction:
   allowlist_unparseable:
     - api.anthropic.com
     - api.openai.com
+  allowlist_unparseable_routes:
+    - host: login.microsoftonline.com
+      methods: [POST]
+      path_suffixes: [/oauth2/v2.0/token]
+      content_types: [application/x-www-form-urlencoded]
   providers:
     acme_llm:
       host_patterns:
@@ -327,10 +332,11 @@ redaction:
 | `limits.max_depth` | `64` | Max JSON nesting depth the redactor will traverse |
 | `strict_reload` | `false` | Fail reload closed if an active dictionary disappears or corrupts |
 | `allowlist_unparseable` | `[]` | Bare hostnames allowed to pass non-JSON bodies/messages unchanged |
+| `allowlist_unparseable_routes` | `[]` | Route-scoped non-JSON exceptions with `host` plus optional `methods`, `path_prefixes`, `path_suffixes`, and `content_types` constraints |
 
 **Requirements and fail-closed behavior:**
 - `redaction.enabled: true` requires `request_body_scanning.enabled: true` because the rewrite hook lives in the request-body scan path.
-- Rewrites only operate on complete JSON payloads. Non-JSON HTTP bodies and non-JSON complete WebSocket messages are blocked unless the destination host is on `allowlist_unparseable`.
+- Rewrites only operate on complete JSON payloads. Non-JSON HTTP bodies and non-JSON complete WebSocket messages are blocked unless the destination host is on `allowlist_unparseable` or the request matches `allowlist_unparseable_routes`.
 - Outbound WebSocket fragments are blocked while redaction is enabled. The proxy cannot safely rewrite partial JSON messages.
 - Successful rewrites add a `redaction` summary to the signed action receipt only when one or more values were replaced; untouched requests keep the legacy receipt bytes unchanged.
 

--- a/docs/guides/redaction.md
+++ b/docs/guides/redaction.md
@@ -48,6 +48,11 @@ redaction:
   allowlist_unparseable:
     - api.anthropic.com
     - api.openai.com
+  allowlist_unparseable_routes:
+    - host: login.microsoftonline.com
+      methods: [POST]
+      path_suffixes: [/oauth2/v2.0/token]
+      content_types: [application/x-www-form-urlencoded]
   providers:
     acme_llm:
       host_patterns:
@@ -63,11 +68,13 @@ Use a narrow `code` profile for developer traffic and add broader `business` pro
 
 - `redaction.enabled: true` requires `request_body_scanning.enabled: true`.
 - Only complete JSON payloads are rewritten.
-- Non-JSON HTTP bodies and complete non-JSON WebSocket messages are blocked unless the destination host is on `allowlist_unparseable`.
+- Non-JSON HTTP bodies and complete non-JSON WebSocket messages are blocked unless the destination host is on `allowlist_unparseable` or the request matches `allowlist_unparseable_routes`.
 - Outbound WebSocket fragments are blocked while redaction is enabled because partial JSON messages cannot be rewritten safely.
 - Malformed JSON, numeric scalars containing secrets, key-collision rewrites, or redaction limits being exceeded all block the request instead of forwarding partially transformed data.
 
 `allowlist_unparseable` accepts bare lowercase hostnames only. Do not include schemes, paths, or ports. Use it sparingly for trusted endpoints that legitimately require non-JSON request formats.
+
+Prefer `allowlist_unparseable_routes` for OAuth token endpoints and upload paths. Each route requires a bare lowercase `host` plus at least one additional constraint: `methods`, `path_prefixes`, `path_suffixes`, or `content_types`. Matching requests skip only the JSON rewrite gate; request body and header scanning still run.
 
 ## Provider Parsers
 

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -182,6 +182,12 @@ func (c *Config) policySemanticView() Config {
 	view.APIAllowlist = sortedCopy(view.APIAllowlist)
 	view.Internal = sortedCopy(view.Internal)
 	view.TrustedDomains = sortedCopy(view.TrustedDomains)
+	if view.Redaction.Enabled {
+		view.Redaction.AllowlistUnparseable = sortedCopy(view.Redaction.AllowlistUnparseable)
+	} else {
+		view.Redaction.AllowlistUnparseable = nil
+	}
+	view.Redaction.AllowlistUnparseableRoutes = canonicalUnparseableRoutes(view.Redaction.Enabled, view.Redaction.AllowlistUnparseableRoutes)
 	view.Redaction.Providers = canonicalRedactionProviders(view.Redaction.Enabled, view.Redaction.Providers)
 
 	// Resolve omitted-or-zero learn-inference fields to their effective
@@ -195,6 +201,27 @@ func (c *Config) policySemanticView() Config {
 	view.Learn.Inference.Normalization = view.Learn.Inference.Normalization.Resolved()
 
 	return view
+}
+
+func canonicalUnparseableRoutes(enabled bool, routes []redact.UnparseableRouteSpec) []redact.UnparseableRouteSpec {
+	if !enabled || len(routes) == 0 {
+		return nil
+	}
+	out := make([]redact.UnparseableRouteSpec, len(routes))
+	for i, route := range routes {
+		cpy := route
+		cpy.Methods = sortedCopy(cpy.Methods)
+		cpy.PathPrefixes = sortedCopy(cpy.PathPrefixes)
+		cpy.PathSuffixes = sortedCopy(cpy.PathSuffixes)
+		cpy.ContentTypes = sortedCopy(cpy.ContentTypes)
+		out[i] = cpy
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left, _ := json.Marshal(out[i])
+		right, _ := json.Marshal(out[j])
+		return string(left) < string(right)
+	})
+	return out
 }
 
 func canonicalRedactionProviders(enabled bool, providers map[string]redact.ProviderSpec) map[string]redact.ProviderSpec {

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -67,7 +67,10 @@ const (
 	// trust_domains (per-key actor binding so a compromised partner key
 	// cannot impersonate another peer's trust domain). Both change the
 	// attested envelope trust contract.
-	goldenHashDefaults = "900c875010b9b2aea4ca20b1ef9b5f9d3383f33c6eb343417bb022dd7e4855af"
+	// Re-bumped for route-scoped redaction non-JSON exceptions:
+	// redaction.allowlist_unparseable_routes is new policy surface that
+	// constrains which opaque request formats may skip JSON rewriting.
+	goldenHashDefaults = "180b942eeb225400c1e6c2850c70f70a96eb0238ab39d0a57c12bcd136771621"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -92,7 +95,9 @@ const (
 	// resolved-default values flow into ph identically to Defaults().
 	// Re-bumped for federation plumbing: see goldenHashDefaults note.
 	// Re-bumped for federation hardening: see goldenHashDefaults note.
-	goldenHashRichConfig = "84e565a39537756c063ca4bc8d7bc69a1a10dba8b3e750f909b163bd7f345dc3"
+	// Re-bumped for route-scoped redaction non-JSON exceptions: see
+	// goldenHashDefaults note.
+	goldenHashRichConfig = "a0ec45732d24b1c5d914ab60c116cea97557cf784384f01bd2785615f1283a5d"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/canonical_test.go
+++ b/internal/config/canonical_test.go
@@ -214,6 +214,26 @@ func TestCanonicalPolicyHash_PolicyFieldsDoAffect(t *testing.T) {
 			},
 		},
 		{
+			name: "redaction route-scoped non-json exception changed",
+			mut: func(c *Config) {
+				c.RequestBodyScanning.Enabled = true
+				c.Redaction = redact.Config{
+					Enabled:        true,
+					DefaultProfile: "code",
+					Profiles: map[string]redact.ProfileSpec{
+						"code": {Classes: []string{string(redact.ClassAWSAccessKey)}},
+					},
+					AllowlistUnparseableRoutes: []redact.UnparseableRouteSpec{{
+						Host:         "login.microsoftonline.com",
+						Methods:      []string{"POST"},
+						PathSuffixes: []string{"/oauth2/v2.0/token"},
+						ContentTypes: []string{"application/x-www-form-urlencoded"},
+					}},
+					Limits: redact.DefaultLimits(),
+				}
+			},
+		},
+		{
 			// Transport timeouts are enforcement-relevant (DoS
 			// exposure bound, tunnel lifetime) so they must flip ph.
 			// Listen / Upstream addresses are separately excluded as
@@ -262,6 +282,51 @@ func TestCanonicalPolicyHash_RedactionProviderOrderCanonical(t *testing.T) {
 	}
 }
 
+func TestCanonicalPolicyHash_RedactionUnparseableRouteOrderCanonical(t *testing.T) {
+	t.Parallel()
+
+	mkRedaction := func(routes []redact.UnparseableRouteSpec) redact.Config {
+		return redact.Config{
+			Enabled:        true,
+			DefaultProfile: "code",
+			Profiles: map[string]redact.ProfileSpec{
+				"code": {Classes: []string{string(redact.ClassAWSAccessKey)}},
+			},
+			AllowlistUnparseable:       []string{"b.example", "a.example"},
+			AllowlistUnparseableRoutes: routes,
+			Limits:                     redact.DefaultLimits(),
+		}
+	}
+	routeA := redact.UnparseableRouteSpec{
+		Host:         "login.microsoftonline.com",
+		Methods:      []string{"POST"},
+		PathSuffixes: []string{"/oauth2/v2.0/token"},
+		ContentTypes: []string{"application/x-www-form-urlencoded"},
+	}
+	routeB := redact.UnparseableRouteSpec{
+		Host:         "graph.microsoft.com",
+		Methods:      []string{"PUT"},
+		PathPrefixes: []string{"/v1.0/drives/", "/v1.0/me/drive/"},
+		PathSuffixes: []string{":/content"},
+		ContentTypes: []string{"application/octet-stream", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+	}
+
+	first := canonicalHashOf(t, func(c *Config) {
+		c.RequestBodyScanning.Enabled = true
+		c.Redaction = mkRedaction([]redact.UnparseableRouteSpec{routeA, routeB})
+	})
+	second := canonicalHashOf(t, func(c *Config) {
+		c.RequestBodyScanning.Enabled = true
+		routeBReordered := routeB
+		routeBReordered.PathPrefixes = []string{"/v1.0/me/drive/", "/v1.0/drives/"}
+		routeBReordered.ContentTypes = []string{"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "application/octet-stream"}
+		c.Redaction = mkRedaction([]redact.UnparseableRouteSpec{routeBReordered, routeA})
+	})
+	if first != second {
+		t.Fatalf("redaction unparseable route order should canonicalize:\nfirst:  %s\nsecond: %s", first, second)
+	}
+}
+
 func TestCanonicalPolicyHash_DisabledRedactionProviderIsInert(t *testing.T) {
 	t.Parallel()
 
@@ -276,6 +341,24 @@ func TestCanonicalPolicyHash_DisabledRedactionProviderIsInert(t *testing.T) {
 	})
 	if got != base {
 		t.Fatalf("disabled redaction provider profile changed canonical hash:\nbase: %s\ngot:  %s", base, got)
+	}
+}
+
+func TestCanonicalPolicyHash_DisabledRedactionUnparseableRoutesAreInert(t *testing.T) {
+	t.Parallel()
+
+	base := canonicalHashOf(t, nil)
+	got := canonicalHashOf(t, func(c *Config) {
+		c.Redaction.AllowlistUnparseable = []string{"api.example.com"}
+		c.Redaction.AllowlistUnparseableRoutes = []redact.UnparseableRouteSpec{{
+			Host:         "login.microsoftonline.com",
+			Methods:      []string{"POST"},
+			PathSuffixes: []string{"/oauth2/v2.0/token"},
+			ContentTypes: []string{"application/x-www-form-urlencoded"},
+		}}
+	})
+	if got != base {
+		t.Fatalf("disabled redaction unparseable allowlists changed canonical hash:\nbase: %s\ngot:  %s", base, got)
 	}
 }
 

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -355,7 +355,7 @@ func unparseableRouteMatches(req BodyScanRequest, route redact.UnparseableRouteS
 		method := strings.ToUpper(req.Method)
 		matched := false
 		for _, candidate := range route.Methods {
-			if method == candidate {
+			if method == strings.ToUpper(candidate) {
 				matched = true
 				break
 			}
@@ -396,7 +396,11 @@ func unparseableRouteMatches(req BodyScanRequest, route redact.UnparseableRouteS
 		mt = strings.ToLower(mt)
 		matched := false
 		for _, candidate := range route.ContentTypes {
-			if mt == candidate {
+			candidateMT, _, err := mime.ParseMediaType(candidate)
+			if err != nil {
+				continue
+			}
+			if mt == strings.ToLower(candidateMT) {
 				matched = true
 				break
 			}

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -121,6 +121,7 @@ type BodyScanResult struct {
 // function signature under the 6-parameter guideline (ctx is passed separately).
 type BodyScanRequest struct {
 	Body            io.Reader
+	Method          string
 	ContentType     string
 	ContentEncoding string
 	MaxBytes        int
@@ -139,6 +140,10 @@ type BodyScanRequest struct {
 	// permitted through as-is. When the Host is not in this list and the
 	// body is not JSON, redaction fails closed. Nil/empty = strict.
 	RedactAllowlistUnparseable []string
+	// RedactAllowlistUnparseableRoutes lists route-scoped exceptions for
+	// trusted non-JSON bodies. These are preferred over host-only entries
+	// for OAuth token and upload endpoints.
+	RedactAllowlistUnparseableRoutes []redact.UnparseableRouteSpec
 	// RedactProviderRegistry selects the provider parser profile for JSON
 	// redaction. Nil falls back to the generic JSON parser.
 	RedactProviderRegistry *redact.ProviderRegistry
@@ -299,7 +304,7 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 }
 
 func allowlistSkipsRedactionRewrite(req BodyScanRequest) bool {
-	return !isJSONContentType(req.ContentType) && hostAllowlisted(req.Host, req.RedactAllowlistUnparseable)
+	return !isJSONContentType(req.ContentType) && unparseableBodyAllowlisted(req)
 }
 
 // applyRedaction is the pre-DLP content-transformation step. Returns
@@ -309,10 +314,10 @@ func allowlistSkipsRedactionRewrite(req BodyScanRequest) bool {
 // redaction gate fired.
 func applyRedaction(buf []byte, req BodyScanRequest) ([]byte, *redact.Report, error) {
 	if !isJSONContentType(req.ContentType) {
-		if !hostAllowlisted(req.Host, req.RedactAllowlistUnparseable) {
+		if !unparseableBodyAllowlisted(req) {
 			return nil, nil, &redact.BlockError{
 				Reason: redact.ReasonNonJSONBody,
-				Detail: fmt.Sprintf("redaction enabled but body Content-Type %q is not JSON and host %q is not on redaction.allowlist_unparseable", req.ContentType, req.Host),
+				Detail: fmt.Sprintf("redaction enabled but body Content-Type %q is not JSON and request host %q/path %q is not allowed by redaction.allowlist_unparseable or redaction.allowlist_unparseable_routes", req.ContentType, req.Host, req.Path),
 			}
 		}
 		// Allowlisted host with non-JSON body: caller forwards as-is.
@@ -328,6 +333,79 @@ func applyRedaction(buf []byte, req BodyScanRequest) ([]byte, *redact.Report, er
 		return nil, nil, err
 	}
 	return rewritten, report, nil
+}
+
+func unparseableBodyAllowlisted(req BodyScanRequest) bool {
+	if hostAllowlisted(req.Host, req.RedactAllowlistUnparseable) {
+		return true
+	}
+	for _, route := range req.RedactAllowlistUnparseableRoutes {
+		if unparseableRouteMatches(req, route) {
+			return true
+		}
+	}
+	return false
+}
+
+func unparseableRouteMatches(req BodyScanRequest, route redact.UnparseableRouteSpec) bool {
+	if !hostAllowlisted(req.Host, []string{route.Host}) {
+		return false
+	}
+	if len(route.Methods) > 0 {
+		method := strings.ToUpper(req.Method)
+		matched := false
+		for _, candidate := range route.Methods {
+			if method == candidate {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	if len(route.PathPrefixes) > 0 {
+		matched := false
+		for _, prefix := range route.PathPrefixes {
+			if strings.HasPrefix(req.Path, prefix) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	if len(route.PathSuffixes) > 0 {
+		matched := false
+		for _, suffix := range route.PathSuffixes {
+			if strings.HasSuffix(req.Path, suffix) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	if len(route.ContentTypes) > 0 {
+		mt, _, err := mime.ParseMediaType(req.ContentType)
+		if err != nil {
+			return false
+		}
+		mt = strings.ToLower(mt)
+		matched := false
+		for _, candidate := range route.ContentTypes {
+			if mt == candidate {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
 }
 
 // isFailClosedBodyResult reports whether a body-scan result must block even

--- a/internal/proxy/bodyscan_redact_test.go
+++ b/internal/proxy/bodyscan_redact_test.go
@@ -133,6 +133,81 @@ func TestScanRequestBody_Redaction_HostPortMatchesAllowlist(t *testing.T) {
 	}
 }
 
+func TestScanRequestBody_Redaction_RouteAllowlistRequiresFullMatch(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	route := redact.UnparseableRouteSpec{
+		Host:         "login.microsoftonline.com",
+		Methods:      []string{"POST"},
+		PathSuffixes: []string{"/oauth2/v2.0/token"},
+		ContentTypes: []string{"application/x-www-form-urlencoded"},
+	}
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:                             strings.NewReader(`grant_type=refresh_token&refresh_token=opaque`),
+		Method:                           "POST",
+		ContentType:                      "application/x-www-form-urlencoded; charset=utf-8",
+		MaxBytes:                         1024,
+		Scanner:                          sc,
+		RedactMatcher:                    redact.NewDefaultMatcher(),
+		Host:                             "login.microsoftonline.com:443",
+		Path:                             "/tenant-id/oauth2/v2.0/token",
+		RedactAllowlistUnparseableRoutes: []redact.UnparseableRouteSpec{route},
+	})
+	if !result.Clean {
+		t.Fatalf("matching route should skip JSON redaction gate, got block: reason=%q detail=%q", result.RedactionBlockReason, result.Reason)
+	}
+
+	_, result = scanRequestBody(context.Background(), BodyScanRequest{
+		Body:                             strings.NewReader(`grant_type=refresh_token&refresh_token=opaque`),
+		Method:                           "POST",
+		ContentType:                      "application/x-www-form-urlencoded",
+		MaxBytes:                         1024,
+		Scanner:                          sc,
+		RedactMatcher:                    redact.NewDefaultMatcher(),
+		Host:                             "login.microsoftonline.com:443",
+		Path:                             "/tenant-id/oauth2/v2.0/devicecode",
+		RedactAllowlistUnparseableRoutes: []redact.UnparseableRouteSpec{route},
+	})
+	if result.Clean {
+		t.Fatal("route with wrong path should fail the non-JSON redaction gate")
+	}
+	if result.RedactionBlockReason != redact.ReasonNonJSONBody {
+		t.Fatalf("RedactionBlockReason = %q, want %q", result.RedactionBlockReason, redact.ReasonNonJSONBody)
+	}
+}
+
+func TestScanRequestBody_Redaction_RouteAllowlistStillRunsDLP(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:          strings.NewReader(`refresh_token=` + redactionE2ESecret()),
+		Method:        "POST",
+		ContentType:   "application/x-www-form-urlencoded",
+		MaxBytes:      1024,
+		Scanner:       sc,
+		RedactMatcher: redact.NewDefaultMatcher(),
+		Host:          "login.microsoftonline.com",
+		Path:          "/tenant-id/oauth2/v2.0/token",
+		RedactAllowlistUnparseableRoutes: []redact.UnparseableRouteSpec{{
+			Host:         "login.microsoftonline.com",
+			Methods:      []string{"POST"},
+			PathSuffixes: []string{"/oauth2/v2.0/token"},
+			ContentTypes: []string{"application/x-www-form-urlencoded"},
+		}},
+	})
+	if result.Clean {
+		t.Fatal("route-scoped redaction exception skipped DLP; expected body DLP finding")
+	}
+	if len(result.DLPMatches) == 0 {
+		t.Fatalf("expected DLP matches after route allowlist, got %+v", result)
+	}
+}
+
 // TestScanRequestBody_Redaction_NilMatcherIsNoop confirms the existing
 // scan path is unaffected when redaction is not enabled (RedactMatcher
 // is nil).

--- a/internal/proxy/bodyscan_redact_test.go
+++ b/internal/proxy/bodyscan_redact_test.go
@@ -208,6 +208,32 @@ func TestScanRequestBody_Redaction_RouteAllowlistStillRunsDLP(t *testing.T) {
 	}
 }
 
+func TestScanRequestBody_Redaction_RouteAllowlistNormalizesRuntimeCandidates(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:          strings.NewReader(`grant_type=refresh_token&refresh_token=opaque`),
+		Method:        "POST",
+		ContentType:   "application/x-www-form-urlencoded; charset=utf-8",
+		MaxBytes:      1024,
+		Scanner:       sc,
+		RedactMatcher: redact.NewDefaultMatcher(),
+		Host:          "login.microsoftonline.com",
+		Path:          "/tenant-id/oauth2/v2.0/token",
+		RedactAllowlistUnparseableRoutes: []redact.UnparseableRouteSpec{{
+			Host:         "login.microsoftonline.com",
+			Methods:      []string{"post"},
+			PathSuffixes: []string{"/oauth2/v2.0/token"},
+			ContentTypes: []string{"Application/X-WWW-Form-Urlencoded"},
+		}},
+	})
+	if !result.Clean {
+		t.Fatalf("runtime route matcher should normalize method and content type candidates, got block: reason=%q detail=%q", result.RedactionBlockReason, result.Reason)
+	}
+}
+
 // TestScanRequestBody_Redaction_NilMatcherIsNoop confirms the existing
 // scan path is unaffected when redaction is not enabled (RedactMatcher
 // is nil).

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1011,6 +1011,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	if cfg.RequestBodyScanning.Enabled && r.Body != nil && r.Body != http.NoBody {
 		bodyReq := BodyScanRequest{
 			Body:            r.Body,
+			Method:          r.Method,
 			ContentType:     r.Header.Get("Content-Type"),
 			ContentEncoding: r.Header.Get("Content-Encoding"),
 			MaxBytes:        cfg.RequestBodyScanning.MaxBodyBytes,

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -724,6 +724,7 @@ func newInterceptHandler(
 			}
 			bodyReq := BodyScanRequest{
 				Body:            r.Body,
+				Method:          r.Method,
 				ContentType:     r.Header.Get("Content-Type"),
 				ContentEncoding: r.Header.Get("Content-Encoding"),
 				MaxBytes:        ic.Config.RequestBodyScanning.MaxBodyBytes,

--- a/internal/proxy/redaction_runtime.go
+++ b/internal/proxy/redaction_runtime.go
@@ -18,12 +18,13 @@ import (
 // consistent for a single request or tunnel. Callers load this atomically
 // instead of mixing cfg.Redaction fields with an independently-swapped matcher.
 type redactionRuntime struct {
-	matcher              *redact.Matcher
-	limits               redact.Limits
-	allowlistUnparseable []string
-	providers            *redact.ProviderRegistry
-	configKey            string
-	required             bool
+	matcher                    *redact.Matcher
+	limits                     redact.Limits
+	allowlistUnparseable       []string
+	allowlistUnparseableRoutes []redact.UnparseableRouteSpec
+	providers                  *redact.ProviderRegistry
+	configKey                  string
+	required                   bool
 }
 
 func (p *Proxy) buildRedactionRuntime(cfg *config.Config) (*redactionRuntime, error) {
@@ -39,13 +40,15 @@ func (p *Proxy) buildRedactionRuntime(cfg *config.Config) (*redactionRuntime, er
 		return nil, fmt.Errorf("build redaction provider registry: %w", err)
 	}
 	allowlist := append([]string(nil), cfg.Redaction.AllowlistUnparseable...)
+	routes := append([]redact.UnparseableRouteSpec(nil), cfg.Redaction.AllowlistUnparseableRoutes...)
 	return &redactionRuntime{
-		matcher:              matcher,
-		limits:               cfg.Redaction.Limits.ToLimits(),
-		allowlistUnparseable: allowlist,
-		providers:            providers,
-		configKey:            redactionConfigKey(cfg),
-		required:             cfg.Redaction.Enabled,
+		matcher:                    matcher,
+		limits:                     cfg.Redaction.Limits.ToLimits(),
+		allowlistUnparseable:       allowlist,
+		allowlistUnparseableRoutes: routes,
+		providers:                  providers,
+		configKey:                  redactionConfigKey(cfg),
+		required:                   cfg.Redaction.Enabled,
 	}, nil
 }
 
@@ -101,11 +104,12 @@ func currentRedactionRuntimeForConfig(cfg *config.Config, ptr *atomic.Pointer[re
 	// only happen before startup setup runs. Keep the fail-closed sentinel
 	// so request handlers block instead of silently skipping.
 	return &redactionRuntime{
-		limits:               cfg.Redaction.Limits.ToLimits(),
-		allowlistUnparseable: append([]string(nil), cfg.Redaction.AllowlistUnparseable...),
-		providers:            nil,
-		configKey:            redactionConfigKey(cfg),
-		required:             true,
+		limits:                     cfg.Redaction.Limits.ToLimits(),
+		allowlistUnparseable:       append([]string(nil), cfg.Redaction.AllowlistUnparseable...),
+		allowlistUnparseableRoutes: append([]redact.UnparseableRouteSpec(nil), cfg.Redaction.AllowlistUnparseableRoutes...),
+		providers:                  nil,
+		configKey:                  redactionConfigKey(cfg),
+		required:                   true,
 	}
 }
 
@@ -129,5 +133,6 @@ func applyBodyScanRedaction(req *BodyScanRequest, rt *redactionRuntime) {
 	req.RedactMatcher = rt.matcher
 	req.RedactLimits = rt.limits
 	req.RedactAllowlistUnparseable = rt.allowlistUnparseable
+	req.RedactAllowlistUnparseableRoutes = rt.allowlistUnparseableRoutes
 	req.RedactProviderRegistry = rt.providers
 }

--- a/internal/proxy/redaction_runtime.go
+++ b/internal/proxy/redaction_runtime.go
@@ -79,24 +79,18 @@ func (p *Proxy) CurrentRedactionConfigFor(cfg *config.Config) (*redact.Matcher, 
 }
 
 func currentRedactionRuntimeForConfig(cfg *config.Config, ptr *atomic.Pointer[redactionRuntime]) *redactionRuntime {
-	// Trust whatever the reload path stored last. Earlier versions of this
-	// factory compared the caller's `cfg` hash against the stored runtime's
-	// `configKey`; during hot-reload, the cfgPtr and redactionRuntimePtr
-	// atomics are updated with a gap of a few instructions, so a request
-	// landing in that window would see OLD cfg + NEW runtime, the hashes
-	// would disagree, and the factory would return a fail-closed sentinel
-	// (matcher nil, required true) even though the freshly-published
-	// runtime was authoritative. The reload-time invariant is that
-	// `redactionRuntimePtr` reflects the current policy: nil when disabled,
-	// non-nil with a populated matcher when enabled. Honor that directly
-	// and stop racing with our own reload sequence.
 	if ptr != nil {
 		if rt := ptr.Load(); rt != nil && rt.matcher != nil {
-			return rt
+			if cfg != nil && rt.configKey == redactionConfigKey(cfg) {
+				return rt
+			}
 		}
 	}
 	// No runtime published yet (startup, or cfg disables redaction). Fall
-	// back to cfg so callers see the intended operator state.
+	// back to cfg so callers see the intended operator state. A populated
+	// runtime whose configKey does not match cfg is treated the same way:
+	// fail closed instead of mixing one policy's matcher with another
+	// policy's receipts and canonical hash.
 	if cfg == nil || !cfg.Redaction.Enabled {
 		return nil
 	}

--- a/internal/proxy/redaction_runtime_test.go
+++ b/internal/proxy/redaction_runtime_test.go
@@ -51,17 +51,10 @@ func TestCurrentRedactionRuntimeForConfig_MatchingRuntime(t *testing.T) {
 	}
 }
 
-func TestCurrentRedactionRuntimeForConfig_MismatchUsesStoredRuntime(t *testing.T) {
-	// Regression for CC-4: during the hot-reload window the atomic may hold
-	// a runtime whose configKey was computed from a config that the caller
-	// has not yet observed. The previous behavior was to fail-closed with a
-	// nil-matcher sentinel, which meant requests landing in a
-	// sub-millisecond window during reload were blocked with
-	// "redaction runtime unavailable". The corrected behavior is to trust
-	// the atomically-stored runtime (the reload path only publishes a
-	// non-nil runtime when the matcher is populated and the policy is
-	// enabled), which keeps redaction running through the reload window
-	// instead of flipping to fail-closed.
+func TestCurrentRedactionRuntimeForConfig_MismatchFailsClosed(t *testing.T) {
+	// The request-scoped cfg drives receipt policy hashes. If the stored
+	// runtime was built from a different config, returning it would mix one
+	// policy's matcher with another policy's signed evidence.
 	cfg := config.Defaults()
 	applyRedactionTestProfile(cfg)
 
@@ -74,17 +67,21 @@ func TestCurrentRedactionRuntimeForConfig_MismatchUsesStoredRuntime(t *testing.T
 	ptr.Store(stored)
 
 	got := currentRedactionRuntimeForConfig(cfg, &ptr)
-	if got != stored {
-		t.Fatalf("expected stored runtime to win during reload window, got %p (want %p)", got, stored)
+	if got == nil {
+		t.Fatal("expected fail-closed sentinel on runtime/config mismatch")
+	}
+	if got == stored {
+		t.Fatal("mismatched runtime must not be returned")
+	}
+	if got.matcher != nil {
+		t.Fatal("sentinel must not expose a matcher")
+	}
+	if !got.required {
+		t.Fatal("sentinel must require redaction")
 	}
 }
 
-func TestCurrentRedactionConfigFor_ReloadWindowStillPropagatesMatcher(t *testing.T) {
-	// Paired with TestCurrentRedactionRuntimeForConfig_MismatchUsesStoredRuntime:
-	// when the atomic holds a populated runtime the public accessor must
-	// expose its matcher even if the caller's cfg has not yet been swapped
-	// in. Previously this path returned (nil, limits, true) as a
-	// fail-closed sentinel, which was spurious during hot reload.
+func TestCurrentRedactionConfigFor_MismatchFailsClosed(t *testing.T) {
 	cfg := config.Defaults()
 	applyRedactionTestProfile(cfg)
 
@@ -97,11 +94,11 @@ func TestCurrentRedactionConfigFor_ReloadWindowStillPropagatesMatcher(t *testing
 	})
 
 	matcher, _, required := p.CurrentRedactionConfigFor(cfg)
-	if matcher != matcherInstance {
-		t.Fatalf("expected stored matcher (%p), got %p", matcherInstance, matcher)
+	if matcher != nil {
+		t.Fatalf("mismatched runtime exposed matcher %p", matcher)
 	}
 	if !required {
-		t.Fatal("stored runtime had required=true; must be preserved")
+		t.Fatal("mismatched enabled config must fail closed")
 	}
 }
 

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -718,6 +718,7 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 
 	bodyReq := BodyScanRequest{
 		Body:            r.Body,
+		Method:          r.Method,
 		ContentType:     r.Header.Get("Content-Type"),
 		ContentEncoding: r.Header.Get("Content-Encoding"),
 		MaxBytes:        maxBytes,

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -899,6 +899,7 @@ func (r *wsRelay) scanClientMessageBody(ctx context.Context, msg []byte) ([]byte
 
 	bodyReq := BodyScanRequest{
 		Body:        bytes.NewReader(msg),
+		Method:      "WS",
 		ContentType: contentType,
 		MaxBytes:    maxBytes,
 		Scanner:     r.scanner,

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -899,7 +899,7 @@ func (r *wsRelay) scanClientMessageBody(ctx context.Context, msg []byte) ([]byte
 
 	bodyReq := BodyScanRequest{
 		Body:        bytes.NewReader(msg),
-		Method:      "WS",
+		Method:      http.MethodGet,
 		ContentType: contentType,
 		MaxBytes:    maxBytes,
 		Scanner:     r.scanner,

--- a/internal/redact/config.go
+++ b/internal/redact/config.go
@@ -210,6 +210,9 @@ func (r UnparseableRouteSpec) Validate() error {
 		if !strings.HasPrefix(prefix, "/") {
 			return fmt.Errorf("path_prefixes[%d] %q: must start with /", i, prefix)
 		}
+		if prefix == "/" && len(r.Methods) == 0 && len(r.PathSuffixes) == 0 && len(r.ContentTypes) == 0 {
+			return fmt.Errorf("path_prefixes[%d] %q: root prefix requires methods, path_suffixes, or content_types", i, prefix)
+		}
 	}
 	for i, suffix := range r.PathSuffixes {
 		if suffix == "" {

--- a/internal/redact/config.go
+++ b/internal/redact/config.go
@@ -6,6 +6,7 @@ package redact
 import (
 	"errors"
 	"fmt"
+	"mime"
 	"strings"
 )
 
@@ -45,6 +46,11 @@ type Config struct {
 	// parseable JSON. Bodies from hosts not in this list are blocked per
 	// the fail-closed invariant.
 	AllowlistUnparseable []string `yaml:"allowlist_unparseable"`
+
+	// AllowlistUnparseableRoutes narrows non-JSON redaction bypasses to a
+	// host plus at least one route constraint. Use this for trusted OAuth
+	// token endpoints or upload routes instead of broad host-only entries.
+	AllowlistUnparseableRoutes []UnparseableRouteSpec `yaml:"allowlist_unparseable_routes"`
 
 	// Providers registers provider parser profiles. Built-ins for Anthropic,
 	// OpenAI, and Gemini are always present; entries here add or override
@@ -92,6 +98,17 @@ type LimitsSpec struct {
 	MaxDepth                int `yaml:"max_depth"`
 }
 
+// UnparseableRouteSpec is a route-scoped non-JSON redaction exception.
+// Matching requests still pass through request body/header scanning; this
+// only skips the JSON rewrite gate for trusted non-JSON formats.
+type UnparseableRouteSpec struct {
+	Host         string   `yaml:"host"`
+	Methods      []string `yaml:"methods,omitempty"`
+	PathPrefixes []string `yaml:"path_prefixes,omitempty"`
+	PathSuffixes []string `yaml:"path_suffixes,omitempty"`
+	ContentTypes []string `yaml:"content_types,omitempty"`
+}
+
 // ToLimits converts the YAML form into the internal Limits type.
 // Struct fields match one-for-one so a Go conversion is sufficient.
 func (s LimitsSpec) ToLimits() Limits {
@@ -112,6 +129,11 @@ func (c *Config) Validate() error {
 	for i, host := range c.AllowlistUnparseable {
 		if err := validateHostEntry(host); err != nil {
 			return fmt.Errorf("redact: allowlist_unparseable[%d] %q: %w", i, host, err)
+		}
+	}
+	for i, route := range c.AllowlistUnparseableRoutes {
+		if err := route.Validate(); err != nil {
+			return fmt.Errorf("redact: allowlist_unparseable_routes[%d]: %w", i, err)
 		}
 	}
 	// Structural: dictionary class names must match the placeholder-safe
@@ -158,6 +180,52 @@ func (c *Config) Validate() error {
 		}
 		if len(d.Entries) == 0 && d.EntriesFile == "" {
 			return fmt.Errorf("redact: dictionary %q has no entries or entries_file", name)
+		}
+	}
+	return nil
+}
+
+// Validate rejects broad or ambiguous route exceptions. Host is required,
+// and at least one route constraint beyond host is required so operators do
+// not accidentally recreate a host-only allowlist entry in the route surface.
+func (r UnparseableRouteSpec) Validate() error {
+	if err := validateHostEntry(r.Host); err != nil {
+		return fmt.Errorf("host %q: %w", r.Host, err)
+	}
+	if len(r.Methods) == 0 && len(r.PathPrefixes) == 0 && len(r.PathSuffixes) == 0 && len(r.ContentTypes) == 0 {
+		return errors.New("must include at least one of methods, path_prefixes, path_suffixes, or content_types")
+	}
+	for i, method := range r.Methods {
+		if method == "" {
+			return fmt.Errorf("methods[%d]: empty", i)
+		}
+		if strings.ToUpper(method) != method {
+			return fmt.Errorf("methods[%d] %q: must be uppercase", i, method)
+		}
+		if strings.ContainsAny(method, " \t\r\n") {
+			return fmt.Errorf("methods[%d] %q: must not contain whitespace", i, method)
+		}
+	}
+	for i, prefix := range r.PathPrefixes {
+		if !strings.HasPrefix(prefix, "/") {
+			return fmt.Errorf("path_prefixes[%d] %q: must start with /", i, prefix)
+		}
+	}
+	for i, suffix := range r.PathSuffixes {
+		if suffix == "" {
+			return fmt.Errorf("path_suffixes[%d]: empty", i)
+		}
+	}
+	for i, ct := range r.ContentTypes {
+		mt, params, err := mime.ParseMediaType(ct)
+		if err != nil {
+			return fmt.Errorf("content_types[%d] %q: %w", i, ct, err)
+		}
+		if len(params) != 0 {
+			return fmt.Errorf("content_types[%d] %q: parameters are not allowed", i, ct)
+		}
+		if strings.ToLower(mt) != ct {
+			return fmt.Errorf("content_types[%d] %q: must be lowercase canonical media type", i, ct)
 		}
 	}
 	return nil

--- a/internal/redact/config_test.go
+++ b/internal/redact/config_test.go
@@ -326,6 +326,7 @@ func TestConfig_ValidateAllowlistUnparseableRoutes(t *testing.T) {
 		{"bad-host", UnparseableRouteSpec{Host: "https://graph.microsoft.com", Methods: []string{"PUT"}}},
 		{"lowercase-method", UnparseableRouteSpec{Host: "graph.microsoft.com", Methods: []string{"put"}}},
 		{"bad-prefix", UnparseableRouteSpec{Host: "graph.microsoft.com", PathPrefixes: []string{"v1.0/me"}}},
+		{"root-prefix-only", UnparseableRouteSpec{Host: "graph.microsoft.com", PathPrefixes: []string{"/"}}},
 		{"empty-suffix", UnparseableRouteSpec{Host: "graph.microsoft.com", PathSuffixes: []string{""}}},
 		{"content-type-param", UnparseableRouteSpec{Host: "graph.microsoft.com", ContentTypes: []string{"application/octet-stream; charset=utf-8"}}},
 		{"uppercase-content-type", UnparseableRouteSpec{Host: "graph.microsoft.com", ContentTypes: []string{"Application/Octet-Stream"}}},

--- a/internal/redact/config_test.go
+++ b/internal/redact/config_test.go
@@ -297,6 +297,50 @@ func TestConfig_ValidateStructureWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestConfig_ValidateAllowlistUnparseableRoutes(t *testing.T) {
+	t.Parallel()
+	mkCfg := func(route UnparseableRouteSpec) *Config {
+		return &Config{
+			Enabled:                    true,
+			DefaultProfile:             "p",
+			Profiles:                   map[string]ProfileSpec{"p": {Classes: []string{"ipv4"}}},
+			AllowlistUnparseableRoutes: []UnparseableRouteSpec{route},
+		}
+	}
+
+	valid := UnparseableRouteSpec{
+		Host:         "login.microsoftonline.com",
+		Methods:      []string{"POST"},
+		PathSuffixes: []string{"/oauth2/v2.0/token"},
+		ContentTypes: []string{"application/x-www-form-urlencoded"},
+	}
+	if err := mkCfg(valid).Validate(); err != nil {
+		t.Fatalf("valid route should validate: %v", err)
+	}
+
+	rejectCases := []struct {
+		name  string
+		route UnparseableRouteSpec
+	}{
+		{"host-only", UnparseableRouteSpec{Host: "graph.microsoft.com"}},
+		{"bad-host", UnparseableRouteSpec{Host: "https://graph.microsoft.com", Methods: []string{"PUT"}}},
+		{"lowercase-method", UnparseableRouteSpec{Host: "graph.microsoft.com", Methods: []string{"put"}}},
+		{"bad-prefix", UnparseableRouteSpec{Host: "graph.microsoft.com", PathPrefixes: []string{"v1.0/me"}}},
+		{"empty-suffix", UnparseableRouteSpec{Host: "graph.microsoft.com", PathSuffixes: []string{""}}},
+		{"content-type-param", UnparseableRouteSpec{Host: "graph.microsoft.com", ContentTypes: []string{"application/octet-stream; charset=utf-8"}}},
+		{"uppercase-content-type", UnparseableRouteSpec{Host: "graph.microsoft.com", ContentTypes: []string{"Application/Octet-Stream"}}},
+	}
+	for _, tc := range rejectCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := mkCfg(tc.route).Validate()
+			if err == nil || !strings.Contains(err.Error(), "allowlist_unparseable_routes") {
+				t.Fatalf("route should be rejected, got %v", err)
+			}
+		})
+	}
+}
+
 func TestConfig_ValidateAllowlistUnparseable(t *testing.T) {
 	t.Parallel()
 	mkCfg := func(hosts ...string) *Config {


### PR DESCRIPTION
## Summary
- add `redaction.allowlist_unparseable_routes` for scoped non-JSON redaction exceptions
- match trusted opaque-body routes by host, method, path prefix/suffix, and content type
- keep request body/header scanning active after the JSON rewrite gate is skipped
- document the new route-scoped option and canonicalize it in policy hashes

## Tests
- `go test -race -count=1 ./...`
- `golangci-lint run ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Route-scoped redaction allowlist for fine-grained non-JSON payload exceptions (host + optional method, path, content-type constraints).

* **Documentation**
  * Updated configuration reference and redaction guide with examples, validation rules, and guidance for common endpoints (OAuth, uploads).

* **Behavior Changes**
  * Fail-closed redaction clarified: non-JSON bodies/messages are blocked unless host or route allowlist matches.

* **Tests**
  * Added/updated tests covering route allowlists, canonicalization, and fail-closed runtime behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/506)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->