### PR TITLE
feat(cli/contain): add read-only verify subcommand and cobra skeleton

### DIFF
--- a/internal/cli/contain/cmd.go
+++ b/internal/cli/contain/cmd.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+// stubMessage is the body of the "not yet implemented" error returned by
+// every subcommand except verify.
+const stubMessage = "not yet implemented in v0.1"
+
+// Cmd returns the `pipelock contain` cobra command tree.
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "contain",
+		Short: "Workstation containment for AI agents",
+		Long: `Install, verify, and roll back a kernel-enforced containment model
+for AI agents on Fedora workstations.
+
+The model splits a single workstation into three system users
+(operator / pipelock-proxy / cc-agent) and uses nftables owner-match
+rules to force every agent process through the Pipelock proxy.
+
+In v0.1 only ` + "`verify`" + ` is implemented; the mutating subcommands
+(install, rollback, add-tool, ca-refresh) are registered but return a
+"not yet implemented" error.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	cmd.AddCommand(
+		verifyCmd(),
+		installCmd(),
+		rollbackCmd(),
+		addToolCmd(),
+		caRefreshCmd(),
+	)
+
+	return cmd
+}
+
+// installCmd is the v0.1 stub for `pipelock contain install`.
+func installCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install the containment model (creates users, unit, nft rules, wrappers)",
+		Long: `Will create the pipelock-proxy and cc-agent system users, migrate the
+user-mode systemd unit to a system unit, install nftables rules, write
+wrapper scripts, install the sudoers entry, and bootstrap the
+combined-ca.pem.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New(stubMessage))
+		},
+	}
+	return cmd
+}
+
+// rollbackCmd is the v0.1 stub for `pipelock contain rollback`.
+func rollbackCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rollback",
+		Short: "Roll back the containment model (undoes install idempotently)",
+		Long: `Will reverse install: remove the nft table, disable the system unit,
+restore the user unit, remove wrappers, optionally remove users.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New(stubMessage))
+		},
+	}
+	return cmd
+}
+
+// addToolNamePattern bounds tool names to a small alphabet so that the
+// generated wrapper path is safe to construct without shell quoting.
+var addToolNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,30}$`)
+
+// addToolCmd is the v0.1 stub for `pipelock contain add-tool`.
+func addToolCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-tool <name>",
+		Short: "Drop a new /usr/local/bin/cc-<name> wrapper",
+		Long: `Will install a wrapper at /usr/local/bin/cc-<name> that execs
+cc-launch <name>.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if !addToolNamePattern.MatchString(args[0]) {
+				return cliutil.ExitCodeError(
+					cliutil.ExitConfig,
+					fmt.Errorf("invalid tool name %q (expected [a-z0-9][a-z0-9_-]{0,30})", args[0]),
+				)
+			}
+			return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New(stubMessage))
+		},
+	}
+	return cmd
+}
+
+// caRefreshCmd is the v0.1 stub for `pipelock contain ca-refresh`.
+func caRefreshCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ca-refresh",
+		Short: "Rebuild /etc/pipelock/combined-ca.pem after CA rotation",
+		Long: `Will re-export the Pipelock TLS-MITM CA and rebuild
+/etc/pipelock/combined-ca.pem.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New(stubMessage))
+		},
+	}
+	return cmd
+}

--- a/internal/cli/contain/doc.go
+++ b/internal/cli/contain/doc.go
@@ -1,0 +1,10 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package contain implements the `pipelock contain` family of subcommands
+// for workstation-tier containment.
+//
+// In v0.1 only `verify` is implemented; the four mutating subcommands
+// (install, rollback, add-tool, ca-refresh) are registered as stubs and
+// return a "not yet implemented" error.
+package contain

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -759,8 +759,15 @@ func probeOperatorEgress(ctx context.Context, env *probeEnv) (string, string) {
 	// exits 0 even on 4xx/5xx, so we must inspect the printed status
 	// code instead of trusting curl's exit code alone. A captive portal
 	// or carrier intercept returning a synthetic 4xx would otherwise
-	// look like "operator reachable".
-	httpCodeStr := strings.TrimSpace(oneLine(out))
+	// look like "operator reachable". realRunCommand merges stdout and
+	// stderr, so benign sudo/PAM/libnss warnings can land in front of
+	// curl's HTTP code; take the trailing whitespace-separated token
+	// since `-w '%{http_code}'` writes the code last with no newline.
+	fields := strings.Fields(oneLine(out))
+	if len(fields) == 0 {
+		return statusFail, "operator curl produced no output"
+	}
+	httpCodeStr := fields[len(fields)-1]
 	httpCode, parseErr := strconv.Atoi(httpCodeStr)
 	if parseErr != nil {
 		return statusFail, fmt.Sprintf("operator returned unparseable HTTP code: %q", httpCodeStr)

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -1,0 +1,812 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+// Probe environment defaults. These match the layout produced by
+// the future `pipelock contain install` subcommand. Operators who
+// installed the model elsewhere can override via flags.
+const (
+	defaultProxyPort    = 8888
+	defaultProxyUser    = "pipelock-proxy"
+	defaultAgentUser    = "cc-agent"
+	defaultWrapperDir   = "/usr/local/bin"
+	defaultLaunchScript = "/usr/local/bin/cc-launch"
+	defaultCABundlePath = "/etc/pipelock/combined-ca.pem"
+	defaultServiceName  = "pipelock.service"
+	defaultNFTTable     = "pipelock_containment"
+	defaultNFTChain     = "output_filter"
+
+	probeDialTimeout = 2 * time.Second
+
+	// curl flags shared between the egress canary and the operator
+	// reachability probe. Connect timeout is intentionally lower than
+	// max time so a slow handshake still returns within probe budget.
+	curlConnectTimeout = "3"
+	curlMaxTime        = "5"
+	curlPath           = "/usr/bin/curl"
+	canaryURL          = "https://example.com/"
+
+	// Probe status values. Strings (not an enum type) so JSON
+	// serialization is identity and tests can compare cheaply.
+	statusPass = "pass"
+	statusFail = "fail"
+	statusSkip = "skip"
+
+	// Internal: cap on stdout/stderr we keep from a subprocess so a
+	// runaway command can't blow the runner's heap.
+	maxCmdOutputBytes = 64 << 10
+)
+
+// expectedNoProxy is the exact NO_PROXY value the cc-launch wrapper must
+// set per the 2026-05-04 decision in the runbook's open questions
+// (cluster traffic flows through Pipelock, so NO_PROXY is limited to
+// loopback). Any deviation is a policy regression.
+const expectedNoProxy = "NO_PROXY=127.0.0.1,localhost"
+
+// defaultToolWrappers is the v0.1 fixed list checked by probe 4. The
+// design doc tracks the eventual move to a wrapper inventory file
+// produced by `pipelock contain add-tool`.
+var defaultToolWrappers = []string{"cc-claude", "cc-codex", "cc-gemini", "cc-playwright"}
+
+// runCommand is the function shape used by probes that shell out.
+// Factored as a type so tests can inject canned outputs without
+// spawning a real process.
+//
+// Contract:
+//   - On a process that ran (even with a non-zero exit), returns
+//     stdout+stderr, the exit code, and a nil error.
+//   - On context cancellation or executable-not-found, returns
+//     whatever output was captured, an exit code of -1, and the wrap
+//     error from exec.
+type runCommand func(ctx context.Context, name string, args ...string) (output string, exitCode int, err error)
+
+// dialFunc is the dialer signature probe 6 uses. Same shape as
+// net.Dialer.DialContext + a timeout.
+type dialFunc func(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error)
+
+// lookupUserFunc is the os/user.Lookup signature, factored so tests can
+// substitute a deterministic lookup.
+type lookupUserFunc func(name string) (*user.User, error)
+
+// probeEnv carries the inputs every probe needs. Everything is
+// addressable from outside the package so tests can populate it
+// directly without going through the cobra layer.
+type probeEnv struct {
+	port          int
+	operatorUser  string
+	proxyUserName string
+	agentUserName string
+	wrapperDir    string
+	toolWrappers  []string
+	caBundlePath  string
+	launchPath    string
+	nftTable      string
+	nftChain      string
+	serviceName   string
+
+	runCmd     runCommand
+	dialCtx    dialFunc
+	lookupUser lookupUserFunc
+}
+
+// defaultProbeEnv returns the production environment. The operator user
+// is derived from $SUDO_USER (set by sudo to the invoking user) when
+// present; otherwise probe 9 runs curl as the current process user
+// directly. See probe 9 implementation for the runtime branch.
+func defaultProbeEnv() *probeEnv {
+	return &probeEnv{
+		port:          defaultProxyPort,
+		operatorUser:  os.Getenv("SUDO_USER"),
+		proxyUserName: defaultProxyUser,
+		agentUserName: defaultAgentUser,
+		wrapperDir:    defaultWrapperDir,
+		toolWrappers:  append([]string(nil), defaultToolWrappers...),
+		caBundlePath:  defaultCABundlePath,
+		launchPath:    defaultLaunchScript,
+		nftTable:      defaultNFTTable,
+		nftChain:      defaultNFTChain,
+		serviceName:   defaultServiceName,
+		runCmd:        realRunCommand,
+		dialCtx:       realDial,
+		lookupUser:    user.Lookup,
+	}
+}
+
+// realRunCommand executes name+args under ctx, captures merged stdout
+// and stderr (bounded), and returns the process exit code. An
+// ExitError is treated as a successful invocation with a non-zero
+// exit code — only failure to start the binary returns a non-nil
+// error.
+func realRunCommand(ctx context.Context, name string, args ...string) (string, int, error) {
+	cmd := exec.CommandContext(ctx, name, args...) //nolint:gosec // G204: name comes from probe definitions (compile-time string literals or package consts), never user input.
+	buf := newCappedBuffer(maxCmdOutputBytes)
+	cmd.Stdout = buf
+	cmd.Stderr = buf
+	runErr := cmd.Run()
+
+	out := buf.String()
+
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		return out, exitErr.ExitCode(), nil
+	}
+	if runErr != nil {
+		return out, -1, runErr
+	}
+	return out, 0, nil
+}
+
+// cappedBuffer captures the first N bytes written and silently
+// drops the rest. Every Write reports the full input length back to
+// the caller so a chatty subprocess is not backpressured; the
+// runner just stops accumulating once the cap is hit. This bounds
+// memory at probe-runner level even if the target command produces
+// gigabytes of output.
+type cappedBuffer struct {
+	buf bytes.Buffer
+	rem int
+}
+
+func newCappedBuffer(capBytes int) *cappedBuffer {
+	return &cappedBuffer{rem: capBytes}
+}
+
+func (c *cappedBuffer) Write(p []byte) (int, error) {
+	if c.rem > 0 {
+		n := len(p)
+		if n > c.rem {
+			n = c.rem
+		}
+		_, _ = c.buf.Write(p[:n])
+		c.rem -= n
+	}
+	return len(p), nil
+}
+
+func (c *cappedBuffer) String() string { return c.buf.String() }
+
+// realDial dials network+address with a fixed timeout, honoring ctx
+// cancellation. Tests inject a deterministic dialer.
+func realDial(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error) {
+	d := net.Dialer{Timeout: timeout}
+	return d.DialContext(ctx, network, address)
+}
+
+// probe is one verification step. Probes are walked in slice order;
+// reordering is a contract change (operators may key off probe numbers
+// in dashboards).
+type probe struct {
+	n    int
+	name string
+	desc string
+	fn   func(ctx context.Context, env *probeEnv) (status, detail string)
+}
+
+func allProbes() []probe {
+	return []probe{
+		{1, "system_users_exist", "system users exist", probeSystemUsers},
+		{2, "pipelock_systemd_unit", "pipelock systemd unit running as pipelock-proxy", probeSystemdUnit},
+		{3, "nftables_containment_ruleset", "nftables containment ruleset present", probeNFTContainment},
+		{4, "wrapper_scripts_installed", "wrapper scripts installed", probeWrapperScripts},
+		{5, "ca_bundle_present", "pipelock CA bundle readable", probeCABundle},
+		{6, "pipelock_listening_loopback", "pipelock listening on loopback", probeLoopbackListen},
+		{7, "no_proxy_env_correct", "NO_PROXY in cc-launch matches policy", probeNoProxyEnv},
+		{8, "cc_agent_egress_denied", "cc-agent cannot reach the internet directly", probeCCAgentEgressDenied},
+		{9, "operator_egress_reachable", "operator user can still reach the internet", probeOperatorEgress},
+	}
+}
+
+// probeRecord is one JSON record per probe in --json output.
+type probeRecord struct {
+	Probe  int    `json:"probe"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// aggregateRecord is the trailing JSON record summarizing the run.
+type aggregateRecord struct {
+	Aggregate aggregateBody `json:"aggregate"`
+}
+
+type aggregateBody struct {
+	Pass     int `json:"pass"`
+	Fail     int `json:"fail"`
+	Skip     int `json:"skip"`
+	Total    int `json:"total"`
+	ExitCode int `json:"exit_code"`
+}
+
+// verifyOpts collects all flag-derived state for runVerify.
+type verifyOpts struct {
+	jsonOutput bool
+	port       int
+}
+
+func verifyCmd() *cobra.Command {
+	var opts verifyOpts
+
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Run read-only probes against the containment model",
+		Long: `Run nine read-only probes to verify the workstation containment model
+is installed correctly and the boundary is intact.
+
+Probes inspect system users, the pipelock systemd unit, nftables rules,
+wrapper scripts, the CA bundle, the pipelock loopback bind, the NO_PROXY
+policy, and run two egress canaries (cc-agent must NOT reach the
+internet directly; the operator user must still reach the internet).
+
+verify never mutates state. Probes that require root visibility
+(nft list ruleset) record skip when run unprivileged.
+
+Exit codes:
+  0  All probes passed.
+  1  At least one probe failed (containment is broken or partially installed).
+  2  Verification incomplete (one or more probes skipped, curl/sudo missing,
+     context cancelled).`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := validatePort(opts.port); err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			env := defaultProbeEnv()
+			env.port = opts.port
+			return runVerify(cmd, env, opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit newline-delimited JSON instead of text")
+	cmd.Flags().IntVar(&opts.port, "port", defaultProxyPort, "pipelock listen port to probe on loopback")
+
+	return cmd
+}
+
+func validatePort(port int) error {
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("invalid --port %d (must be 1-65535)", port)
+	}
+	return nil
+}
+
+// runVerify walks every probe in order, prints per-probe output in
+// either text or JSON mode, and returns an ExitError carrying the
+// aggregate exit code.
+func runVerify(cmd *cobra.Command, env *probeEnv, opts verifyOpts) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	w := cmd.OutOrStdout()
+	enc := json.NewEncoder(w)
+
+	if !opts.jsonOutput {
+		_, _ = fmt.Fprintln(w, "pipelock contain verify")
+	}
+
+	probes := allProbes()
+	var passN, failN, skipN int
+
+	for _, p := range probes {
+		status, detail := p.fn(ctx, env)
+		switch status {
+		case statusPass:
+			passN++
+		case statusFail:
+			failN++
+		case statusSkip:
+			skipN++
+		default:
+			// A probe returned something unexpected. Coerce to fail
+			// and carry the value forward so we don't silently drop it.
+			failN++
+			detail = fmt.Sprintf("invalid status %q (detail: %s)", status, detail)
+			status = statusFail
+		}
+
+		if opts.jsonOutput {
+			if err := enc.Encode(probeRecord{
+				Probe:  p.n,
+				Name:   p.name,
+				Status: status,
+				Detail: detail,
+			}); err != nil {
+				return fmt.Errorf("encoding probe %d JSON: %w", p.n, err)
+			}
+			continue
+		}
+
+		writeTextLine(w, p, status, detail)
+	}
+
+	exitCode := cliutil.ExitOK
+	switch {
+	case failN > 0:
+		exitCode = cliutil.ExitGeneral
+	case skipN > 0:
+		exitCode = cliutil.ExitConfig
+	}
+
+	if opts.jsonOutput {
+		if err := enc.Encode(aggregateRecord{Aggregate: aggregateBody{
+			Pass:     passN,
+			Fail:     failN,
+			Skip:     skipN,
+			Total:    len(probes),
+			ExitCode: exitCode,
+		}}); err != nil {
+			return fmt.Errorf("encoding aggregate JSON: %w", err)
+		}
+	} else {
+		_, _ = fmt.Fprintf(w, "Result: %d PASS / %d FAIL / %d SKIP — exit %d\n", passN, failN, skipN, exitCode)
+	}
+
+	if exitCode == cliutil.ExitOK {
+		return nil
+	}
+	if failN > 0 {
+		return cliutil.ExitCodeError(exitCode, fmt.Errorf("%d probe(s) failed", failN))
+	}
+	return cliutil.ExitCodeError(exitCode, fmt.Errorf("%d probe(s) skipped; verification incomplete", skipN))
+}
+
+// writeTextLine renders one probe outcome in text mode.
+func writeTextLine(w io.Writer, p probe, status, detail string) {
+	tag := "[PASS]"
+	switch status {
+	case statusFail:
+		tag = "[FAIL]"
+	case statusSkip:
+		tag = "[SKIP]"
+	}
+
+	line := fmt.Sprintf("  %s probe %d: %s", tag, p.n, p.desc)
+	if status != statusPass && detail != "" {
+		line += " (" + detail + ")"
+	} else if status == statusPass && detail != "" {
+		line += " — " + detail
+	}
+	_, _ = fmt.Fprintln(w, line)
+}
+
+// ---------------------------------------------------------------------------
+// Probe 1: system_users_exist
+// ---------------------------------------------------------------------------
+
+func probeSystemUsers(_ context.Context, env *probeEnv) (string, string) {
+	proxy, perr := env.lookupUser(env.proxyUserName)
+	agent, aerr := env.lookupUser(env.agentUserName)
+
+	switch {
+	case perr != nil && aerr != nil:
+		return statusFail, fmt.Sprintf("neither %s nor %s exist", env.proxyUserName, env.agentUserName)
+	case perr != nil:
+		return statusFail, fmt.Sprintf("%s missing: %v", env.proxyUserName, perr)
+	case aerr != nil:
+		return statusFail, fmt.Sprintf("%s missing: %v", env.agentUserName, aerr)
+	}
+
+	return statusPass, fmt.Sprintf("%s uid=%s, %s uid=%s",
+		env.proxyUserName, proxy.Uid, env.agentUserName, agent.Uid)
+}
+
+// ---------------------------------------------------------------------------
+// Probe 2: pipelock_systemd_unit
+// ---------------------------------------------------------------------------
+
+func probeSystemdUnit(ctx context.Context, env *probeEnv) (string, string) {
+	out, code, err := env.runCmd(ctx, "systemctl", "show", env.serviceName,
+		"--property=ActiveState,SubState,User,Type",
+	)
+	if err != nil {
+		return statusSkip, fmt.Sprintf("systemctl unavailable: %v", err)
+	}
+	if code != 0 {
+		return statusFail, fmt.Sprintf("systemctl exit=%d: %s", code, oneLine(out))
+	}
+
+	fields := parseSystemdShow(out)
+	active := fields["ActiveState"]
+	sub := fields["SubState"]
+	svcUser := fields["User"]
+
+	if svcUser != env.proxyUserName {
+		return statusFail, fmt.Sprintf("ActiveState=%s SubState=%s User=%q (want User=%s)",
+			active, sub, svcUser, env.proxyUserName)
+	}
+	if active != "active" || sub != "running" {
+		return statusFail, fmt.Sprintf("ActiveState=%s SubState=%s User=%s (want active/running)",
+			active, sub, svcUser)
+	}
+	return statusPass, fmt.Sprintf("ActiveState=%s SubState=%s User=%s", active, sub, svcUser)
+}
+
+// parseSystemdShow parses `systemctl show --property=...` key=value
+// output into a map. Empty lines and lines without an '=' are ignored.
+func parseSystemdShow(out string) map[string]string {
+	fields := map[string]string{}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		fields[k] = v
+	}
+	return fields
+}
+
+// ---------------------------------------------------------------------------
+// Probe 3: nftables_containment_ruleset
+// ---------------------------------------------------------------------------
+
+func probeNFTContainment(ctx context.Context, env *probeEnv) (string, string) {
+	out, code, err := env.runCmd(ctx, "nft", "list", "table", "inet", env.nftTable)
+	if err != nil {
+		return statusSkip, fmt.Sprintf("nft unavailable: %v", err)
+	}
+	if code != 0 {
+		low := strings.ToLower(out)
+		if strings.Contains(low, "operation not permitted") || strings.Contains(low, "permission denied") {
+			return statusSkip, "nft list table requires root; rerun as root"
+		}
+		if strings.Contains(low, "no such file") || strings.Contains(low, "does not exist") {
+			return statusFail, fmt.Sprintf("table inet %s not loaded", env.nftTable)
+		}
+		return statusFail, fmt.Sprintf("nft exit=%d: %s", code, oneLine(out))
+	}
+
+	if !strings.Contains(out, "chain "+env.nftChain) {
+		return statusFail, fmt.Sprintf("chain %s missing from table", env.nftChain)
+	}
+	// The containment rule signature: a drop tied to an skuid match.
+	// We don't pin the exact UID since it varies per machine.
+	if !chainHasSkuidDrop(out, env.nftChain) {
+		return statusFail, "chain present but skuid-drop rule missing"
+	}
+	return statusPass, fmt.Sprintf("table inet %s has chain %s with skuid drop rule",
+		env.nftTable, env.nftChain)
+}
+
+func chainHasSkuidDrop(out, chainName string) bool {
+	inChain := false
+	depth := 0
+	for _, raw := range strings.Split(out, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		if !inChain && (strings.HasPrefix(line, "chain "+chainName+" ") || line == "chain "+chainName+"{") {
+			inChain = true
+		}
+		if !inChain {
+			continue
+		}
+		if strings.Contains(line, "{") {
+			depth += strings.Count(line, "{")
+		}
+		if strings.Contains(line, "skuid") && strings.Contains(line, "drop") {
+			return true
+		}
+		if strings.Contains(line, "}") {
+			depth -= strings.Count(line, "}")
+			if depth <= 0 {
+				inChain = false
+				depth = 0
+			}
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Probe 4: wrapper_scripts_installed
+// ---------------------------------------------------------------------------
+
+func probeWrapperScripts(_ context.Context, env *probeEnv) (string, string) {
+	info, err := os.Stat(filepath.Clean(env.launchPath))
+	if err != nil {
+		return statusFail, fmt.Sprintf("%s missing: %v", env.launchPath, err)
+	}
+	mode := info.Mode().Perm()
+	if mode != 0o755 {
+		return statusFail, fmt.Sprintf("%s has perm 0o%03o, want 0o755", env.launchPath, mode)
+	}
+
+	var foundNames []string
+	for _, name := range env.toolWrappers {
+		p := filepath.Join(env.wrapperDir, name)
+		info, err := os.Stat(filepath.Clean(p))
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return statusFail, fmt.Sprintf("%s stat failed: %v", p, err)
+		}
+		mode := info.Mode().Perm()
+		if mode != 0o755 {
+			return statusFail, fmt.Sprintf("%s has perm 0o%03o, want 0o755", p, mode)
+		}
+		foundNames = append(foundNames, name)
+	}
+	if len(foundNames) == 0 {
+		return statusFail, fmt.Sprintf("no tool wrappers found in %s (expected one of %v)",
+			env.wrapperDir, env.toolWrappers)
+	}
+	return statusPass, fmt.Sprintf("cc-launch + %d tool wrapper(s): %s",
+		len(foundNames), strings.Join(foundNames, ","))
+}
+
+// ---------------------------------------------------------------------------
+// Probe 5: ca_bundle_present
+// ---------------------------------------------------------------------------
+
+func probeCABundle(_ context.Context, env *probeEnv) (string, string) {
+	data, err := os.ReadFile(filepath.Clean(env.caBundlePath))
+	if err != nil {
+		return statusFail, fmt.Sprintf("read %s: %v", env.caBundlePath, err)
+	}
+
+	count, pipelockCN, parseErr := scanPipelockCertCN(data)
+	if parseErr != nil {
+		return statusFail, fmt.Sprintf("parse %s: %v", env.caBundlePath, parseErr)
+	}
+	if count == 0 {
+		return statusFail, fmt.Sprintf("%s parsed 0 certificates", env.caBundlePath)
+	}
+	if pipelockCN == "" {
+		return statusFail, fmt.Sprintf("%s has %d cert(s); none match Pipelock", env.caBundlePath, count)
+	}
+	return statusPass, fmt.Sprintf("%d certs in bundle; pipelock CA CN=%s", count, pipelockCN)
+}
+
+// scanPipelockCertCN walks a PEM blob and returns the total cert
+// count and the CN of the first certificate whose subject CN
+// contains "pipelock" (case-insensitive).
+func scanPipelockCertCN(data []byte) (int, string, error) {
+	var count int
+	var pipelockCN string
+	rest := data
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return count, pipelockCN, fmt.Errorf("certificate %d: %w", count+1, err)
+		}
+		count++
+		if pipelockCN == "" && strings.Contains(strings.ToLower(cert.Subject.CommonName), "pipelock") {
+			pipelockCN = cert.Subject.CommonName
+		}
+	}
+	return count, pipelockCN, nil
+}
+
+// ---------------------------------------------------------------------------
+// Probe 6: pipelock_listening_loopback
+// ---------------------------------------------------------------------------
+
+func probeLoopbackListen(ctx context.Context, env *probeEnv) (string, string) {
+	addr := net.JoinHostPort("127.0.0.1", fmt.Sprintf("%d", env.port))
+	start := time.Now()
+	conn, err := env.dialCtx(ctx, "tcp", addr, probeDialTimeout)
+	if err != nil {
+		return statusFail, fmt.Sprintf("dial %s: %v", addr, err)
+	}
+	elapsed := time.Since(start)
+	_ = conn.Close()
+	return statusPass, fmt.Sprintf("%s accepted TCP within %s", addr, formatDialDuration(elapsed))
+}
+
+// formatDialDuration renders an elapsed dial time at millisecond
+// resolution, special-casing sub-millisecond results so they don't
+// appear as a misleading "0s".
+func formatDialDuration(d time.Duration) string {
+	if d < time.Millisecond {
+		return "<1ms"
+	}
+	return d.Round(time.Millisecond).String()
+}
+
+// ---------------------------------------------------------------------------
+// Probe 7: no_proxy_env_correct
+// ---------------------------------------------------------------------------
+
+func probeNoProxyEnv(_ context.Context, env *probeEnv) (string, string) {
+	data, err := os.ReadFile(filepath.Clean(env.launchPath))
+	if err != nil {
+		return statusFail, fmt.Sprintf("read %s: %v", env.launchPath, err)
+	}
+	actual := extractNoProxy(data)
+	if actual == "" {
+		return statusFail, fmt.Sprintf("NO_PROXY assignment not found in %s", env.launchPath)
+	}
+	if actual != expectedNoProxy {
+		return statusFail, fmt.Sprintf("NO_PROXY value differs from policy: %q (want %q)", actual, expectedNoProxy)
+	}
+	return statusPass, expectedNoProxy
+}
+
+// extractNoProxy finds the first NO_PROXY=<value> assignment in the
+// wrapper script and returns the full assignment string up to the
+// first whitespace or shell line continuation. Returns "" if no
+// assignment is present.
+func extractNoProxy(data []byte) string {
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		for _, field := range strings.Fields(line) {
+			field = strings.TrimSuffix(field, "\\")
+			if strings.HasPrefix(field, "NO_PROXY=") {
+				return field
+			}
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Probe 8: cc_agent_egress_denied
+// ---------------------------------------------------------------------------
+
+// curlNoProxyArgs is the argv tail shared by probes 8 and 9: try to
+// reach the canary URL, never proxy, return only the HTTP status code
+// or zero on failure.
+func curlNoProxyArgs() []string {
+	return []string{
+		curlPath,
+		"--connect-timeout", curlConnectTimeout,
+		"--max-time", curlMaxTime,
+		"--noproxy", "*",
+		"-sS",
+		"-o", "/dev/null",
+		"-w", "%{http_code}",
+		canaryURL,
+	}
+}
+
+func probeCCAgentEgressDenied(ctx context.Context, env *probeEnv) (string, string) {
+	args := append([]string{"-n", "-u", env.agentUserName, "--"}, curlNoProxyArgs()...)
+	out, code, err := env.runCmd(ctx, "sudo", args...)
+	if err != nil {
+		return statusSkip, fmt.Sprintf("sudo/curl unavailable: %v", err)
+	}
+	if isSudoRefusal(out) {
+		return statusSkip, "sudo refused without password; configure NOPASSWD entry to enable canary"
+	}
+	if isSudoUserMissing(out) {
+		return statusSkip, fmt.Sprintf("%s user not present; install containment model first", env.agentUserName)
+	}
+	if isSudoTargetCommandMissing(out) {
+		return statusSkip, "sudo could not execute /usr/bin/curl; install curl to enable canary"
+	}
+	if code == 0 {
+		return statusFail, fmt.Sprintf("unexpected curl success: HTTP %s from example.com", oneLine(out))
+	}
+	return statusPass, fmt.Sprintf("curl blocked (exit=%d) — containment enforced", code)
+}
+
+// ---------------------------------------------------------------------------
+// Probe 9: operator_egress_reachable
+// ---------------------------------------------------------------------------
+
+func probeOperatorEgress(ctx context.Context, env *probeEnv) (string, string) {
+	var out string
+	var code int
+	var err error
+
+	if env.operatorUser == "" {
+		out, code, err = env.runCmd(ctx, curlPath, curlNoProxyArgs()[1:]...)
+	} else {
+		args := append([]string{"-n", "-u", env.operatorUser, "--"}, curlNoProxyArgs()...)
+		out, code, err = env.runCmd(ctx, "sudo", args...)
+	}
+
+	if err != nil {
+		return statusSkip, fmt.Sprintf("curl unavailable: %v", err)
+	}
+	if isSudoRefusal(out) {
+		return statusSkip, "sudo refused without password; rerun curl manually as operator"
+	}
+	if isSudoUserMissing(out) {
+		return statusSkip, fmt.Sprintf("%s user not present", env.operatorUser)
+	}
+	if isSudoTargetCommandMissing(out) {
+		return statusSkip, "curl not executable for operator canary"
+	}
+	if code != 0 {
+		return statusFail, fmt.Sprintf("operator curl failed (exit=%d): %s", code, oneLine(out))
+	}
+	// Probe 9 contract is "any 2xx/3xx HTTP". Curl with -w '%{http_code}'
+	// exits 0 even on 4xx/5xx, so we must inspect the printed status
+	// code instead of trusting curl's exit code alone. A captive portal
+	// or carrier intercept returning a synthetic 4xx would otherwise
+	// look like "operator reachable".
+	httpCodeStr := strings.TrimSpace(oneLine(out))
+	httpCode, parseErr := strconv.Atoi(httpCodeStr)
+	if parseErr != nil {
+		return statusFail, fmt.Sprintf("operator returned unparseable HTTP code: %q", httpCodeStr)
+	}
+	if httpCode < 200 || httpCode >= 400 {
+		return statusFail, fmt.Sprintf("operator returned non-2xx/3xx HTTP %d", httpCode)
+	}
+	return statusPass, fmt.Sprintf("HTTP %d from example.com", httpCode)
+}
+
+// isSudoRefusal scans subprocess output for the well-known sudo
+// failure modes that indicate no NOPASSWD entry, not a curl-level
+// failure. Used by probes 8 and 9 to disambiguate skip vs fail.
+func isSudoRefusal(out string) bool {
+	low := strings.ToLower(out)
+	switch {
+	case strings.Contains(low, "password is required"),
+		strings.Contains(low, "may not run"),
+		strings.Contains(low, "not allowed to execute"),
+		strings.Contains(low, "no tty present"):
+		return true
+	}
+	return false
+}
+
+// isSudoUserMissing detects sudo's "unknown user" failure mode. If the
+// target user (cc-agent or the operator) does not exist on the system,
+// sudo exits non-zero before invoking the target command. Probes 8
+// and 9 must treat this as skip rather than fail, otherwise an
+// uninstalled containment model would falsely report PASS on the
+// canary.
+func isSudoUserMissing(out string) bool {
+	return strings.Contains(strings.ToLower(out), "unknown user")
+}
+
+func isSudoTargetCommandMissing(out string) bool {
+	low := strings.ToLower(out)
+	return strings.Contains(low, "command not found") ||
+		strings.Contains(low, "no such file or directory")
+}
+
+// oneLine trims trailing whitespace and collapses internal newlines so
+// detail lines don't break text output.
+func oneLine(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return s
+}

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -918,13 +918,48 @@ func TestProbeOperatorEgress(t *testing.T) {
 		}
 	})
 
-	t.Run("operator unparseable HTTP code -> fail", func(t *testing.T) {
+	t.Run("operator empty output -> fail", func(t *testing.T) {
 		env := makeProbeEnv(t, func(e *probeEnv) {
 			e.operatorUser = testOperatorUser
 			e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
 				// Empty stdout but exit 0 — pathological but
 				// catchable.
 				return "", 0, nil
+			}
+		})
+		gotStatus, gotDetail := probeOperatorEgress(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "no output") {
+			t.Fatalf("detail: got %q, want substring 'no output'", gotDetail)
+		}
+	})
+
+	t.Run("operator stderr noise prefix -> pass", func(t *testing.T) {
+		// realRunCommand merges stdout+stderr; benign sudo/PAM warnings
+		// can land in front of curl's HTTP code. The last whitespace-
+		// separated token is what `-w '%{http_code}'` printed.
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.operatorUser = testOperatorUser
+			e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+				return "sudo: setrlimit(RLIMIT_CORE): Operation not permitted 200", 0, nil
+			}
+		})
+		gotStatus, gotDetail := probeOperatorEgress(context.Background(), env)
+		if gotStatus != statusPass {
+			t.Fatalf("status: got %q, want pass (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "HTTP 200") {
+			t.Fatalf("detail: got %q, want substring 'HTTP 200'", gotDetail)
+		}
+	})
+
+	t.Run("operator non-numeric last token -> fail", func(t *testing.T) {
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.operatorUser = testOperatorUser
+			e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+				return "curl: warning something something garbage", 0, nil
 			}
 		})
 		gotStatus, gotDetail := probeOperatorEgress(context.Background(), env)

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -1,0 +1,1481 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+// Test helpers ---------------------------------------------------------------
+
+const (
+	testProxyUser    = "pipelock-proxy"
+	testAgentUser    = "cc-agent"
+	testTable        = "pipelock_containment"
+	testChain        = "output_filter"
+	testService      = "pipelock.service"
+	testSudoCmd      = "sudo"
+	testOperatorUser = "operator"
+)
+
+// fakeRunResult is a canned subprocess response keyed by the leading
+// argv element (the command name). Tests pre-populate the map with
+// the expected calls; unexpected calls return an error.
+type fakeRunResult struct {
+	stdout string
+	code   int
+	err    error
+}
+
+// newFakeRun returns a runCommand that matches by command name and
+// optionally by argv prefix. The first matching response wins. Empty
+// match means "match any argv".
+type fakeMatcher struct {
+	cmd    string
+	prefix []string
+	result fakeRunResult
+}
+
+func newFakeRun(matchers ...fakeMatcher) (runCommand, *[]string) {
+	var calls []string
+	matched := make([]bool, len(matchers))
+	run := func(_ context.Context, name string, args ...string) (string, int, error) {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		for i, m := range matchers {
+			if m.cmd != name {
+				continue
+			}
+			if !prefixMatches(m.prefix, args) {
+				continue
+			}
+			matched[i] = true
+			return m.result.stdout, m.result.code, m.result.err
+		}
+		return "", -1, fmt.Errorf("unexpected call: %s %v", name, args)
+	}
+	return run, &calls
+}
+
+func prefixMatches(prefix, args []string) bool {
+	if len(prefix) == 0 {
+		return true
+	}
+	if len(args) < len(prefix) {
+		return false
+	}
+	for i, p := range prefix {
+		if args[i] != p {
+			return false
+		}
+	}
+	return true
+}
+
+// makeProbeEnv builds a probeEnv with sane defaults plus overrides.
+// The pure-Go probes (1, 4, 5, 6, 7) get filesystem and lookup stubs;
+// the shell-out probes (2, 3, 8, 9) get runCmd.
+func makeProbeEnv(t *testing.T, opts ...func(*probeEnv)) *probeEnv {
+	t.Helper()
+	env := &probeEnv{
+		port:          8888,
+		operatorUser:  "",
+		proxyUserName: testProxyUser,
+		agentUserName: testAgentUser,
+		wrapperDir:    t.TempDir(),
+		toolWrappers:  []string{"cc-claude", "cc-codex"},
+		caBundlePath:  filepath.Join(t.TempDir(), "combined-ca.pem"),
+		launchPath:    "", // populated below
+		nftTable:      testTable,
+		nftChain:      testChain,
+		serviceName:   testService,
+		runCmd:        rejectAllRun,
+		dialCtx:       rejectAllDial,
+		lookupUser:    rejectAllLookup,
+	}
+	env.launchPath = filepath.Join(env.wrapperDir, "cc-launch")
+	for _, opt := range opts {
+		opt(env)
+	}
+	return env
+}
+
+func rejectAllRun(_ context.Context, name string, args ...string) (string, int, error) {
+	return "", -1, fmt.Errorf("unstubbed run: %s %v", name, args)
+}
+
+func rejectAllDial(_ context.Context, _, address string, _ time.Duration) (net.Conn, error) {
+	return nil, fmt.Errorf("unstubbed dial: %s", address)
+}
+
+func rejectAllLookup(name string) (*user.User, error) {
+	return nil, fmt.Errorf("unstubbed lookup: %s", name)
+}
+
+// Probe 1: system_users_exist ------------------------------------------------
+
+func TestProbeSystemUsers(t *testing.T) {
+	tests := []struct {
+		name       string
+		proxy      *user.User
+		proxyErr   error
+		agent      *user.User
+		agentErr   error
+		wantStatus string
+		wantDetail string
+	}{
+		{
+			name:       "both present",
+			proxy:      &user.User{Uid: "988", Username: testProxyUser},
+			agent:      &user.User{Uid: "987", Username: testAgentUser},
+			wantStatus: statusPass,
+			wantDetail: "pipelock-proxy uid=988, cc-agent uid=987",
+		},
+		{
+			name:       "proxy missing",
+			proxyErr:   user.UnknownUserError(testProxyUser),
+			agent:      &user.User{Uid: "987", Username: testAgentUser},
+			wantStatus: statusFail,
+			wantDetail: "pipelock-proxy missing",
+		},
+		{
+			name:       "agent missing",
+			proxy:      &user.User{Uid: "988", Username: testProxyUser},
+			agentErr:   user.UnknownUserError(testAgentUser),
+			wantStatus: statusFail,
+			wantDetail: "cc-agent missing",
+		},
+		{
+			name:       "both missing",
+			proxyErr:   user.UnknownUserError(testProxyUser),
+			agentErr:   user.UnknownUserError(testAgentUser),
+			wantStatus: statusFail,
+			wantDetail: "neither",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := makeProbeEnv(t, func(e *probeEnv) {
+				e.lookupUser = func(name string) (*user.User, error) {
+					switch name {
+					case testProxyUser:
+						return tc.proxy, tc.proxyErr
+					case testAgentUser:
+						return tc.agent, tc.agentErr
+					}
+					return nil, fmt.Errorf("unexpected lookup %q", name)
+				}
+			})
+			gotStatus, gotDetail := probeSystemUsers(context.Background(), env)
+			if gotStatus != tc.wantStatus {
+				t.Fatalf("status: got %q, want %q (detail=%q)", gotStatus, tc.wantStatus, gotDetail)
+			}
+			if !strings.Contains(gotDetail, tc.wantDetail) {
+				t.Fatalf("detail: got %q, want substring %q", gotDetail, tc.wantDetail)
+			}
+		})
+	}
+}
+
+// Probe 2: pipelock_systemd_unit ---------------------------------------------
+
+func TestProbeSystemdUnit(t *testing.T) {
+	const goodOutput = "ActiveState=active\nSubState=running\nUser=pipelock-proxy\nType=simple\n"
+
+	tests := []struct {
+		name       string
+		stdout     string
+		code       int
+		runErr     error
+		wantStatus string
+		wantDetail string
+	}{
+		{
+			name:       "happy path",
+			stdout:     goodOutput,
+			code:       0,
+			wantStatus: statusPass,
+			wantDetail: "User=pipelock-proxy",
+		},
+		{
+			name:       "wrong user",
+			stdout:     "ActiveState=active\nSubState=running\nUser=root\n",
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "want User=pipelock-proxy",
+		},
+		{
+			name:       "service inactive",
+			stdout:     "ActiveState=inactive\nSubState=dead\nUser=pipelock-proxy\n",
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "want active/running",
+		},
+		{
+			name:       "systemctl missing",
+			runErr:     errors.New("exec: \"systemctl\": executable file not found in $PATH"),
+			wantStatus: statusSkip,
+			wantDetail: "systemctl unavailable",
+		},
+		{
+			name:       "non-zero exit",
+			stdout:     "Unit pipelock.service could not be found.\n",
+			code:       1,
+			wantStatus: statusFail,
+			wantDetail: "systemctl exit=1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := makeProbeEnv(t, func(e *probeEnv) {
+				e.runCmd = func(_ context.Context, name string, _ ...string) (string, int, error) {
+					if name != "systemctl" {
+						return "", -1, fmt.Errorf("unexpected cmd %q", name)
+					}
+					return tc.stdout, tc.code, tc.runErr
+				}
+			})
+			gotStatus, gotDetail := probeSystemdUnit(context.Background(), env)
+			if gotStatus != tc.wantStatus {
+				t.Fatalf("status: got %q, want %q (detail=%q)", gotStatus, tc.wantStatus, gotDetail)
+			}
+			if !strings.Contains(gotDetail, tc.wantDetail) {
+				t.Fatalf("detail: got %q, want substring %q", gotDetail, tc.wantDetail)
+			}
+		})
+	}
+}
+
+func TestParseSystemdShow(t *testing.T) {
+	out := "ActiveState=active\nSubState=running\n\nUser=pipelock-proxy\n# comment with no =\nType=simple\n"
+	got := parseSystemdShow(out)
+	want := map[string]string{
+		"ActiveState": "active",
+		"SubState":    "running",
+		"User":        "pipelock-proxy",
+		"Type":        "simple",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("key %s: got %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+// Probe 3: nftables_containment_ruleset --------------------------------------
+
+func TestProbeNFTContainment(t *testing.T) {
+	goodOutput := `table inet pipelock_containment {
+	chain output_filter {
+		type filter hook output priority filter; policy accept;
+		meta oif "lo" accept
+		meta skuid 987 drop
+	}
+}
+`
+
+	tests := []struct {
+		name       string
+		stdout     string
+		code       int
+		runErr     error
+		wantStatus string
+		wantDetail string
+	}{
+		{
+			name:       "happy path",
+			stdout:     goodOutput,
+			code:       0,
+			wantStatus: statusPass,
+			wantDetail: "skuid drop rule",
+		},
+		{
+			name:       "permission denied",
+			stdout:     "Error: Operation not permitted\n",
+			code:       1,
+			wantStatus: statusSkip,
+			wantDetail: "requires root",
+		},
+		{
+			name:       "table missing",
+			stdout:     "Error: No such file or directory\n",
+			code:       1,
+			wantStatus: statusFail,
+			wantDetail: "not loaded",
+		},
+		{
+			name:       "nft missing",
+			runErr:     errors.New("exec: \"nft\": executable file not found"),
+			wantStatus: statusSkip,
+			wantDetail: "nft unavailable",
+		},
+		{
+			name:       "chain missing",
+			stdout:     "table inet pipelock_containment {\n}\n",
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "chain output_filter missing",
+		},
+		{
+			name: "no skuid drop rule",
+			stdout: `table inet pipelock_containment {
+	chain output_filter {
+		meta oif "lo" accept
+	}
+}
+`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "skuid-drop rule missing",
+		},
+		{
+			name: "skuid and drop outside target chain",
+			stdout: `table inet pipelock_containment {
+	chain output_filter {
+		meta oif "lo" accept
+	}
+	chain decoy {
+		meta skuid 987 drop
+	}
+}
+`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "skuid-drop rule missing",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := makeProbeEnv(t, func(e *probeEnv) {
+				e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+					return tc.stdout, tc.code, tc.runErr
+				}
+			})
+			gotStatus, gotDetail := probeNFTContainment(context.Background(), env)
+			if gotStatus != tc.wantStatus {
+				t.Fatalf("status: got %q, want %q (detail=%q)", gotStatus, tc.wantStatus, gotDetail)
+			}
+			if !strings.Contains(gotDetail, tc.wantDetail) {
+				t.Fatalf("detail: got %q, want substring %q", gotDetail, tc.wantDetail)
+			}
+		})
+	}
+}
+
+// Probe 4: wrapper_scripts_installed -----------------------------------------
+
+func TestProbeWrapperScripts(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		writeFakeWrapper(t, env.launchPath, 0o755)
+		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "cc-claude"), 0o755)
+		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
+		if gotStatus != statusPass {
+			t.Fatalf("status: got %q, want pass (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "cc-claude") {
+			t.Fatalf("detail: got %q, want substring cc-claude", gotDetail)
+		}
+	})
+
+	t.Run("launcher missing", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "cc-launch") {
+			t.Fatalf("detail: got %q, want cc-launch", gotDetail)
+		}
+	})
+
+	t.Run("launcher wrong mode", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		writeFakeWrapper(t, env.launchPath, 0o600)
+		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "perm") {
+			t.Fatalf("detail: got %q, want substring perm", gotDetail)
+		}
+	})
+
+	t.Run("no tool wrappers", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		writeFakeWrapper(t, env.launchPath, 0o755)
+		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "no tool wrappers") {
+			t.Fatalf("detail: got %q, want substring 'no tool wrappers'", gotDetail)
+		}
+	})
+
+	t.Run("tool wrapper wrong mode", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		writeFakeWrapper(t, env.launchPath, 0o755)
+		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "cc-claude"), 0o644)
+		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "want 0o755") {
+			t.Fatalf("detail: got %q, want wrapper mode failure", gotDetail)
+		}
+	})
+}
+
+func writeFakeWrapper(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+	body := []byte("#!/bin/bash\nexit 0\n")
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+}
+
+// Probe 5: ca_bundle_present --------------------------------------------------
+
+func TestProbeCABundle(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		writeFakePEMBundle(t, env.caBundlePath, "Pipelock Test CA", "Some Other Root")
+		gotStatus, gotDetail := probeCABundle(context.Background(), env)
+		if gotStatus != statusPass {
+			t.Fatalf("status: got %q, want pass (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "Pipelock Test CA") {
+			t.Fatalf("detail: got %q, want substring 'Pipelock Test CA'", gotDetail)
+		}
+	})
+
+	t.Run("file missing", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		gotStatus, gotDetail := probeCABundle(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail", gotStatus)
+		}
+		if !strings.Contains(gotDetail, "read") {
+			t.Fatalf("detail: got %q, want substring 'read'", gotDetail)
+		}
+	})
+
+	t.Run("no pipelock cert", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		writeFakePEMBundle(t, env.caBundlePath, "Some Other Root")
+		gotStatus, gotDetail := probeCABundle(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail", gotStatus)
+		}
+		if !strings.Contains(gotDetail, "none match Pipelock") {
+			t.Fatalf("detail: got %q, want substring 'none match Pipelock'", gotDetail)
+		}
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		if err := os.WriteFile(env.caBundlePath, []byte{}, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		gotStatus, _ := probeCABundle(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail", gotStatus)
+		}
+	})
+
+	t.Run("malformed pem", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		// Wrap garbage in a PEM envelope so the decoder consumes a block
+		// whose Bytes are not a valid DER certificate.
+		bad := []byte("-----BEGIN CERTIFICATE-----\nbm90YWNlcnQ=\n-----END CERTIFICATE-----\n")
+		if err := os.WriteFile(env.caBundlePath, bad, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		gotStatus, gotDetail := probeCABundle(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "parse") {
+			t.Fatalf("detail: got %q, want substring 'parse'", gotDetail)
+		}
+	})
+}
+
+// writeFakePEMBundle generates one self-signed cert per CN and writes
+// the concatenated PEM to path.
+func writeFakePEMBundle(t *testing.T, path string, commonNames ...string) {
+	t.Helper()
+	var buf bytes.Buffer
+	for _, cn := range commonNames {
+		buf.Write(makeFakeCertPEM(t, cn))
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+}
+
+func makeFakeCertPEM(t *testing.T, commonName string) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// Probe 6: pipelock_listening_loopback ---------------------------------------
+
+func TestProbeLoopbackListen(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.dialCtx = func(_ context.Context, _, _ string, _ time.Duration) (net.Conn, error) {
+				return &fakeConn{}, nil
+			}
+		})
+		gotStatus, gotDetail := probeLoopbackListen(context.Background(), env)
+		if gotStatus != statusPass {
+			t.Fatalf("status: got %q, want pass (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "127.0.0.1:8888") {
+			t.Fatalf("detail: got %q, want substring 127.0.0.1:8888", gotDetail)
+		}
+	})
+
+	t.Run("dial refused", func(t *testing.T) {
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.dialCtx = func(_ context.Context, _, _ string, _ time.Duration) (net.Conn, error) {
+				return nil, errors.New("connection refused")
+			}
+		})
+		gotStatus, gotDetail := probeLoopbackListen(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail", gotStatus)
+		}
+		if !strings.Contains(gotDetail, "refused") {
+			t.Fatalf("detail: got %q, want substring refused", gotDetail)
+		}
+	})
+}
+
+// fakeConn implements net.Conn for probe 6's dial stub.
+type fakeConn struct{}
+
+func (*fakeConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (*fakeConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (*fakeConn) Close() error                     { return nil }
+func (*fakeConn) LocalAddr() net.Addr              { return nil }
+func (*fakeConn) RemoteAddr() net.Addr             { return nil }
+func (*fakeConn) SetDeadline(time.Time) error      { return nil }
+func (*fakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (*fakeConn) SetWriteDeadline(time.Time) error { return nil }
+
+// Probe 7: no_proxy_env_correct ----------------------------------------------
+
+func TestProbeNoProxyEnv(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		body := "#!/bin/bash\nexec env NO_PROXY=127.0.0.1,localhost HTTPS_PROXY=http://127.0.0.1:8888 sh\n"
+		if err := os.WriteFile(env.launchPath, []byte(body), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		gotStatus, gotDetail := probeNoProxyEnv(context.Background(), env)
+		if gotStatus != statusPass {
+			t.Fatalf("status: got %q, want pass (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "127.0.0.1,localhost") {
+			t.Fatalf("detail: got %q, want substring 127.0.0.1,localhost", gotDetail)
+		}
+	})
+
+	t.Run("wrong value", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		body := "#!/bin/bash\nexec env NO_PROXY=127.0.0.1,localhost,10.0.0.0/24 sh\n"
+		if err := os.WriteFile(env.launchPath, []byte(body), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		gotStatus, gotDetail := probeNoProxyEnv(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "differs from policy") {
+			t.Fatalf("detail: got %q, want substring 'differs from policy'", gotDetail)
+		}
+	})
+
+	t.Run("no assignment", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		body := "#!/bin/bash\nexec env HTTPS_PROXY=http://127.0.0.1:8888 sh\n"
+		if err := os.WriteFile(env.launchPath, []byte(body), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		gotStatus, gotDetail := probeNoProxyEnv(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail", gotStatus)
+		}
+		if !strings.Contains(gotDetail, "not found") {
+			t.Fatalf("detail: got %q, want substring 'not found'", gotDetail)
+		}
+	})
+
+	t.Run("file missing", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		gotStatus, _ := probeNoProxyEnv(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail", gotStatus)
+		}
+	})
+}
+
+func TestExtractNoProxy(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"NO_PROXY=127.0.0.1,localhost foo bar", "NO_PROXY=127.0.0.1,localhost"},
+		{"    NO_PROXY=a,b \\", "NO_PROXY=a,b"},
+		{"no NO_PROXY here\nHTTPS_PROXY=x", ""},
+		{"first\nNO_PROXY=x\nNO_PROXY=y\n", "NO_PROXY=x"},
+		{"# NO_PROXY=127.0.0.1,localhost\nHTTPS_PROXY=x", ""},
+		{"OTHER_NO_PROXY=127.0.0.1,localhost\nNO_PROXY=x", "NO_PROXY=x"},
+	}
+	for _, c := range cases {
+		got := extractNoProxy([]byte(c.in))
+		if got != c.want {
+			t.Errorf("extractNoProxy(%q): got %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// Probe 8 + 9: egress canary + operator reachability -------------------------
+
+func TestProbeCCAgentEgressDenied(t *testing.T) {
+	tests := []struct {
+		name       string
+		stdout     string
+		code       int
+		runErr     error
+		wantStatus string
+		wantDetail string
+	}{
+		{
+			name:       "egress blocked (curl exit 7)",
+			stdout:     "curl: (7) Failed to connect",
+			code:       7,
+			wantStatus: statusPass,
+			wantDetail: "containment enforced",
+		},
+		{
+			name:       "egress succeeded (regression)",
+			stdout:     "200",
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "unexpected curl success",
+		},
+		{
+			name:       "sudo no password",
+			stdout:     "sudo: a password is required\n",
+			code:       1,
+			wantStatus: statusSkip,
+			wantDetail: "configure NOPASSWD",
+		},
+		{
+			name:       "sudo no tty",
+			stdout:     "sudo: no tty present and no askpass program specified\n",
+			code:       1,
+			wantStatus: statusSkip,
+			wantDetail: "configure NOPASSWD",
+		},
+		{
+			name:       "sudo not in sudoers",
+			stdout:     "user operator may not run sudo on host\n",
+			code:       1,
+			wantStatus: statusSkip,
+			wantDetail: "configure NOPASSWD",
+		},
+		{
+			name:       "binary missing",
+			runErr:     errors.New("exec: \"sudo\": executable file not found"),
+			wantStatus: statusSkip,
+			wantDetail: "sudo/curl unavailable",
+		},
+		{
+			name:       "cc-agent user missing",
+			stdout:     "sudo: unknown user cc-agent\nsudo: error initializing audit plugin sudoers_audit\n",
+			code:       1,
+			wantStatus: statusSkip,
+			wantDetail: "install containment model first",
+		},
+		{
+			name:       "target curl missing",
+			stdout:     "sudo: /usr/bin/curl: command not found\n",
+			code:       1,
+			wantStatus: statusSkip,
+			wantDetail: "install curl",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := makeProbeEnv(t, func(e *probeEnv) {
+				e.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+					if name != testSudoCmd {
+						t.Fatalf("unexpected cmd %q", name)
+					}
+					// Sanity: confirm we drop to cc-agent.
+					joined := strings.Join(args, " ")
+					if !strings.Contains(joined, "-u "+testAgentUser) {
+						t.Fatalf("argv missing -u %s: %v", testAgentUser, args)
+					}
+					return tc.stdout, tc.code, tc.runErr
+				}
+			})
+			gotStatus, gotDetail := probeCCAgentEgressDenied(context.Background(), env)
+			if gotStatus != tc.wantStatus {
+				t.Fatalf("status: got %q, want %q (detail=%q)", gotStatus, tc.wantStatus, gotDetail)
+			}
+			if !strings.Contains(gotDetail, tc.wantDetail) {
+				t.Fatalf("detail: got %q, want substring %q", gotDetail, tc.wantDetail)
+			}
+		})
+	}
+}
+
+func TestProbeOperatorEgress(t *testing.T) {
+	t.Run("operator reachable via sudo", func(t *testing.T) {
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.operatorUser = testOperatorUser
+			e.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+				if name != testSudoCmd {
+					t.Fatalf("unexpected cmd %q", name)
+				}
+				if !strings.Contains(strings.Join(args, " "), "-u "+testOperatorUser) {
+					t.Fatalf("argv missing -u %s: %v", testOperatorUser, args)
+				}
+				return "200", 0, nil
+			}
+		})
+		gotStatus, gotDetail := probeOperatorEgress(context.Background(), env)
+		if gotStatus != statusPass {
+			t.Fatalf("status: got %q, want pass (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "HTTP 200") {
+			t.Fatalf("detail: got %q, want HTTP 200", gotDetail)
+		}
+	})
+
+	t.Run("not running under sudo: invoke curl directly", func(t *testing.T) {
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.operatorUser = ""
+			e.runCmd = func(_ context.Context, name string, _ ...string) (string, int, error) {
+				if name != curlPath {
+					t.Fatalf("expected direct curl invoke, got %q", name)
+				}
+				return "200", 0, nil
+			}
+		})
+		gotStatus, _ := probeOperatorEgress(context.Background(), env)
+		if gotStatus != statusPass {
+			t.Fatalf("status: got %q, want pass", gotStatus)
+		}
+	})
+
+	t.Run("operator unreachable", func(t *testing.T) {
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.operatorUser = testOperatorUser
+			e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+				return "curl: (6) Could not resolve host", 6, nil
+			}
+		})
+		gotStatus, gotDetail := probeOperatorEgress(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "operator curl failed") {
+			t.Fatalf("detail: got %q, want 'operator curl failed'", gotDetail)
+		}
+	})
+
+	t.Run("sudo refusal -> skip", func(t *testing.T) {
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.operatorUser = testOperatorUser
+			e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+				return "sudo: a password is required", 1, nil
+			}
+		})
+		gotStatus, _ := probeOperatorEgress(context.Background(), env)
+		if gotStatus != statusSkip {
+			t.Fatalf("status: got %q, want skip", gotStatus)
+		}
+	})
+
+	t.Run("operator user missing -> skip", func(t *testing.T) {
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.operatorUser = "ghost"
+			e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+				return "sudo: unknown user ghost", 1, nil
+			}
+		})
+		gotStatus, gotDetail := probeOperatorEgress(context.Background(), env)
+		if gotStatus != statusSkip {
+			t.Fatalf("status: got %q, want skip (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "ghost") {
+			t.Fatalf("detail: got %q, want substring 'ghost'", gotDetail)
+		}
+	})
+
+	t.Run("operator sudo target curl missing -> skip", func(t *testing.T) {
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.operatorUser = testOperatorUser
+			e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+				return "sudo: /usr/bin/curl: No such file or directory", 1, nil
+			}
+		})
+		gotStatus, gotDetail := probeOperatorEgress(context.Background(), env)
+		if gotStatus != statusSkip {
+			t.Fatalf("status: got %q, want skip (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "curl not executable") {
+			t.Fatalf("detail: got %q, want curl not executable", gotDetail)
+		}
+	})
+
+	t.Run("operator HTTP 503 -> fail", func(t *testing.T) {
+		// curl with -w '%{http_code}' exits 0 even on 5xx; a captive
+		// portal or carrier intercept must not look like
+		// "operator reachable".
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.operatorUser = testOperatorUser
+			e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+				return "503", 0, nil
+			}
+		})
+		gotStatus, gotDetail := probeOperatorEgress(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "non-2xx/3xx HTTP 503") {
+			t.Fatalf("detail: got %q, want substring 'non-2xx/3xx HTTP 503'", gotDetail)
+		}
+	})
+
+	t.Run("operator HTTP 301 -> pass (redirect counts as reachable)", func(t *testing.T) {
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.operatorUser = testOperatorUser
+			e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+				return "301", 0, nil
+			}
+		})
+		gotStatus, gotDetail := probeOperatorEgress(context.Background(), env)
+		if gotStatus != statusPass {
+			t.Fatalf("status: got %q, want pass (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "HTTP 301") {
+			t.Fatalf("detail: got %q, want HTTP 301", gotDetail)
+		}
+	})
+
+	t.Run("operator unparseable HTTP code -> fail", func(t *testing.T) {
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.operatorUser = testOperatorUser
+			e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+				// Empty stdout but exit 0 — pathological but
+				// catchable.
+				return "", 0, nil
+			}
+		})
+		gotStatus, gotDetail := probeOperatorEgress(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "unparseable") {
+			t.Fatalf("detail: got %q, want substring 'unparseable'", gotDetail)
+		}
+	})
+}
+
+func TestCappedBuffer(t *testing.T) {
+	t.Run("under cap", func(t *testing.T) {
+		b := newCappedBuffer(100)
+		n, err := b.Write([]byte("hello"))
+		if err != nil || n != 5 {
+			t.Fatalf("Write returned n=%d err=%v", n, err)
+		}
+		if b.String() != "hello" {
+			t.Errorf("got %q, want hello", b.String())
+		}
+	})
+
+	t.Run("over cap silently drops, Write reports full length", func(t *testing.T) {
+		b := newCappedBuffer(5)
+		n, err := b.Write([]byte("hello world"))
+		if err != nil {
+			t.Fatalf("Write returned err=%v", err)
+		}
+		if n != 11 {
+			t.Errorf("Write reported n=%d, want 11 (never backpressure subprocess)", n)
+		}
+		if b.String() != "hello" {
+			t.Errorf("buffered %q, want first 5 bytes 'hello'", b.String())
+		}
+	})
+
+	t.Run("multiple writes accumulate to cap", func(t *testing.T) {
+		b := newCappedBuffer(7)
+		_, _ = b.Write([]byte("abc"))
+		_, _ = b.Write([]byte("defgh"))   // 5 bytes, only 4 fit
+		_, _ = b.Write([]byte("ignored")) // cap is full, dropped
+		if got := b.String(); got != "abcdefg" {
+			t.Errorf("got %q, want abcdefg", got)
+		}
+	})
+
+	t.Run("zero cap accumulates nothing", func(t *testing.T) {
+		b := newCappedBuffer(0)
+		n, _ := b.Write([]byte("noise"))
+		if n != 5 {
+			t.Errorf("Write reported n=%d, want 5", n)
+		}
+		if b.String() != "" {
+			t.Errorf("got %q, want empty", b.String())
+		}
+	})
+}
+
+// Runner ---------------------------------------------------------------------
+
+func TestRunVerify_TextOutput_AllPass(t *testing.T) {
+	env := allPassEnv(t)
+	cmd := newVerifyCmd(t)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := runVerify(cmd, env, verifyOpts{jsonOutput: false})
+	if err != nil {
+		t.Fatalf("runVerify returned err: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.HasPrefix(out, "pipelock contain verify") {
+		t.Errorf("missing header: %q", out)
+	}
+	if strings.Count(out, "[PASS]") != 9 {
+		t.Errorf("want 9 [PASS] lines, got %d in %q", strings.Count(out, "[PASS]"), out)
+	}
+	if !strings.Contains(out, "9 PASS / 0 FAIL / 0 SKIP") {
+		t.Errorf("missing aggregate: %q", out)
+	}
+}
+
+func TestRunVerify_JSONOutput_AllPass(t *testing.T) {
+	env := allPassEnv(t)
+	cmd := newVerifyCmd(t)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := runVerify(cmd, env, verifyOpts{jsonOutput: true})
+	if err != nil {
+		t.Fatalf("runVerify returned err: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 10 {
+		t.Fatalf("expected 10 JSON records (9 probes + aggregate), got %d: %q", len(lines), buf.String())
+	}
+	for i := 0; i < 9; i++ {
+		var rec probeRecord
+		if err := json.Unmarshal([]byte(lines[i]), &rec); err != nil {
+			t.Fatalf("line %d: parse: %v (line=%q)", i, err, lines[i])
+		}
+		if rec.Probe != i+1 {
+			t.Errorf("line %d: probe=%d, want %d", i, rec.Probe, i+1)
+		}
+		if rec.Status != statusPass {
+			t.Errorf("line %d: status=%q, want pass", i, rec.Status)
+		}
+	}
+	var agg aggregateRecord
+	if err := json.Unmarshal([]byte(lines[9]), &agg); err != nil {
+		t.Fatalf("aggregate: parse: %v (line=%q)", err, lines[9])
+	}
+	if agg.Aggregate.Pass != 9 || agg.Aggregate.Fail != 0 || agg.Aggregate.Skip != 0 {
+		t.Errorf("aggregate counts: %+v", agg.Aggregate)
+	}
+	if agg.Aggregate.ExitCode != cliutil.ExitOK {
+		t.Errorf("aggregate exit_code: got %d, want %d", agg.Aggregate.ExitCode, cliutil.ExitOK)
+	}
+}
+
+func TestRunVerify_FailExitCode(t *testing.T) {
+	env := allPassEnv(t)
+	// Force one probe to fail by making the egress canary "succeed".
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == testSudoCmd && containsArg(args, testAgentUser) {
+			return "200", 0, nil
+		}
+		return defaultRunForAllPass(name, args)
+	}
+
+	cmd := newVerifyCmd(t)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := runVerify(cmd, env, verifyOpts{jsonOutput: false})
+	if err == nil {
+		t.Fatalf("expected error for fail exit, got nil")
+	}
+	if code := cliutil.ExitCodeOf(err); code != cliutil.ExitGeneral {
+		t.Errorf("exit code: got %d, want %d", code, cliutil.ExitGeneral)
+	}
+	if !strings.Contains(buf.String(), "1 FAIL") {
+		t.Errorf("missing fail in aggregate: %q", buf.String())
+	}
+}
+
+func TestRunVerify_SkipExitCode(t *testing.T) {
+	env := allPassEnv(t)
+	// Force one probe to skip while leaving the rest green. A skipped
+	// security canary must not return exit 0, or CI can mistake an
+	// incomplete verification for a clean containment boundary.
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == testSudoCmd && containsArg(args, testAgentUser) {
+			return "sudo: a password is required", 1, nil
+		}
+		return defaultRunForAllPass(name, args)
+	}
+
+	cmd := newVerifyCmd(t)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := runVerify(cmd, env, verifyOpts{jsonOutput: false})
+	if err == nil {
+		t.Fatalf("expected error for skip exit, got nil")
+	}
+	if code := cliutil.ExitCodeOf(err); code != cliutil.ExitConfig {
+		t.Errorf("exit code: got %d, want %d", code, cliutil.ExitConfig)
+	}
+	if !strings.Contains(buf.String(), "1 SKIP") {
+		t.Errorf("missing skip in aggregate: %q", buf.String())
+	}
+}
+
+func TestVerifyCmd_Wiring(t *testing.T) {
+	root := Cmd()
+	verify := findSubcmd(t, root, "verify")
+	if verify == nil {
+		t.Fatalf("verify subcommand not registered")
+	}
+	if !verify.HasFlags() {
+		t.Fatalf("verify command exposes no flags")
+	}
+	if f := verify.Flag("json"); f == nil {
+		t.Errorf("--json flag missing")
+	}
+	if f := verify.Flag("port"); f == nil {
+		t.Errorf("--port flag missing")
+	}
+}
+
+func TestVerifyCmd_InvalidPort(t *testing.T) {
+	root := Cmd()
+	root.SetArgs([]string{"verify", "--port", "0"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatalf("expected invalid port error, got nil")
+	}
+	if code := cliutil.ExitCodeOf(err); code != cliutil.ExitConfig {
+		t.Errorf("exit code: got %d, want %d", code, cliutil.ExitConfig)
+	}
+	if !strings.Contains(err.Error(), "invalid --port") {
+		t.Errorf("error: got %q, want invalid --port", err)
+	}
+}
+
+func TestStubSubcommands(t *testing.T) {
+	cases := []struct {
+		subcmd string
+		args   []string
+	}{
+		{"install", nil},
+		{"rollback", nil},
+		{"add-tool", []string{"validname"}},
+		{"ca-refresh", nil},
+	}
+	root := Cmd()
+	for _, tc := range cases {
+		t.Run(tc.subcmd, func(t *testing.T) {
+			sub := findSubcmd(t, root, tc.subcmd)
+			if sub == nil {
+				t.Fatalf("subcommand %s not registered", tc.subcmd)
+			}
+			err := sub.RunE(sub, tc.args)
+			if err == nil {
+				t.Fatalf("stub %s returned nil; want ExitError", tc.subcmd)
+			}
+			if code := cliutil.ExitCodeOf(err); code != cliutil.ExitConfig {
+				t.Errorf("stub %s exit code: got %d, want %d", tc.subcmd, code, cliutil.ExitConfig)
+			}
+			if !strings.Contains(err.Error(), "not yet implemented") {
+				t.Errorf("stub %s error: got %q, want substring 'not yet implemented'", tc.subcmd, err)
+			}
+		})
+	}
+}
+
+func TestAddToolNameValidation(t *testing.T) {
+	root := Cmd()
+	addTool := findSubcmd(t, root, "add-tool")
+
+	bad := []string{"", "Tool", "tool!", "../etc/passwd", strings.Repeat("a", 32)}
+	for _, name := range bad {
+		t.Run("invalid_"+name, func(t *testing.T) {
+			err := addTool.RunE(addTool, []string{name})
+			if err == nil {
+				t.Fatalf("add-tool %q returned nil; want validation error", name)
+			}
+			if !strings.Contains(err.Error(), "invalid tool name") {
+				// Pattern allows up to 31 chars; a 32-char name should be rejected too.
+				if !strings.Contains(err.Error(), "not yet implemented") {
+					t.Errorf("add-tool %q: got error %q", name, err)
+				}
+			}
+		})
+	}
+}
+
+// Helpers used by runner tests -----------------------------------------------
+
+func newVerifyCmd(_ *testing.T) *cobra.Command {
+	return &cobra.Command{Use: "verify"}
+}
+
+func findSubcmd(t *testing.T, root *cobra.Command, name string) *cobra.Command {
+	t.Helper()
+	for _, c := range root.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func containsArg(args []string, needle string) bool {
+	for _, a := range args {
+		if a == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// allPassEnv returns a probeEnv where every probe will pass. Used as
+// the baseline for runner tests; individual tests override one field
+// to introduce a fail/skip.
+func allPassEnv(t *testing.T) *probeEnv {
+	t.Helper()
+	env := makeProbeEnv(t)
+	env.operatorUser = testOperatorUser
+
+	// Probe 1: both users present.
+	env.lookupUser = func(name string) (*user.User, error) {
+		switch name {
+		case testProxyUser:
+			return &user.User{Uid: "988", Username: testProxyUser}, nil
+		case testAgentUser:
+			return &user.User{Uid: "987", Username: testAgentUser}, nil
+		}
+		return nil, fmt.Errorf("unexpected lookup %q", name)
+	}
+
+	// Probe 6: dial succeeds.
+	env.dialCtx = func(_ context.Context, _, _ string, _ time.Duration) (net.Conn, error) {
+		return &fakeConn{}, nil
+	}
+
+	// Probes 2, 3, 8, 9: subprocess stubs.
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		return defaultRunForAllPass(name, args)
+	}
+
+	// Filesystem state for probes 4, 5, 7.
+	writeFakeWrapper(t, env.launchPath, 0o755)
+	writeFakeWrapper(t, filepath.Join(env.wrapperDir, "cc-claude"), 0o755)
+	body := "#!/bin/bash\nexec env NO_PROXY=127.0.0.1,localhost HTTPS_PROXY=http://127.0.0.1:8888 sh\n"
+	if err := os.WriteFile(env.launchPath, []byte(body), 0o755); err != nil { //nolint:gosec // wrapper script must be executable in test
+		t.Fatalf("rewrite launch: %v", err)
+	}
+	writeFakePEMBundle(t, env.caBundlePath, "Pipelock Test CA")
+
+	return env
+}
+
+// defaultRunForAllPass is the canned subprocess response set when
+// every probe should pass.
+func defaultRunForAllPass(name string, args []string) (string, int, error) {
+	switch name {
+	case "systemctl":
+		return "ActiveState=active\nSubState=running\nUser=pipelock-proxy\nType=simple\n", 0, nil
+	case "nft":
+		return `table inet pipelock_containment {
+	chain output_filter {
+		meta skuid 987 drop
+	}
+}
+`, 0, nil
+	case testSudoCmd:
+		// Either cc-agent (probe 8) or operator (probe 9). Match by argv.
+		if containsArg(args, testAgentUser) {
+			return "curl: (7) Failed to connect", 7, nil
+		}
+		return "200", 0, nil
+	case curlPath:
+		// Direct invoke for operator probe when env.operatorUser == "".
+		return "200", 0, nil
+	}
+	return "", -1, fmt.Errorf("defaultRunForAllPass: unexpected cmd %q args=%v", name, args)
+}
+
+func TestOneLine(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"hello\nworld\r\n", "hello world"},
+		{"  trim me\n", "trim me"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := oneLine(c.in); got != c.want {
+			t.Errorf("oneLine(%q): got %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestIsSudoUserMissing(t *testing.T) {
+	yes := []string{
+		"sudo: unknown user cc-agent",
+		"sudo: unknown user: pipelock-proxy",
+		"SUDO: UNKNOWN USER FOO",
+	}
+	for _, s := range yes {
+		if !isSudoUserMissing(s) {
+			t.Errorf("isSudoUserMissing(%q) = false, want true", s)
+		}
+	}
+	no := []string{
+		"sudo: a password is required",
+		"curl: (7) Failed to connect",
+		"",
+	}
+	for _, s := range no {
+		if isSudoUserMissing(s) {
+			t.Errorf("isSudoUserMissing(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestIsSudoTargetCommandMissing(t *testing.T) {
+	yes := []string{
+		"sudo: /usr/bin/curl: command not found",
+		"sudo: /usr/bin/curl: No such file or directory",
+	}
+	for _, s := range yes {
+		if !isSudoTargetCommandMissing(s) {
+			t.Errorf("isSudoTargetCommandMissing(%q) = false, want true", s)
+		}
+	}
+	no := []string{
+		"curl: (7) Failed to connect",
+		"sudo: a password is required",
+		"",
+	}
+	for _, s := range no {
+		if isSudoTargetCommandMissing(s) {
+			t.Errorf("isSudoTargetCommandMissing(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestFormatDialDuration(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{500 * time.Microsecond, "<1ms"},
+		{0, "<1ms"},
+		{time.Millisecond, "1ms"},
+		{17 * time.Millisecond, "17ms"},
+		{2 * time.Second, "2s"},
+	}
+	for _, c := range cases {
+		if got := formatDialDuration(c.in); got != c.want {
+			t.Errorf("formatDialDuration(%s): got %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDefaultProbeEnv(t *testing.T) {
+	t.Setenv("SUDO_USER", "alice")
+	env := defaultProbeEnv()
+	if env.port != defaultProxyPort {
+		t.Errorf("port: got %d, want %d", env.port, defaultProxyPort)
+	}
+	if env.operatorUser != "alice" {
+		t.Errorf("operatorUser: got %q, want %q", env.operatorUser, "alice")
+	}
+	if env.proxyUserName != defaultProxyUser {
+		t.Errorf("proxyUserName: got %q, want %q", env.proxyUserName, defaultProxyUser)
+	}
+	if env.launchPath != defaultLaunchScript {
+		t.Errorf("launchPath: got %q, want %q", env.launchPath, defaultLaunchScript)
+	}
+	if len(env.toolWrappers) != len(defaultToolWrappers) {
+		t.Errorf("toolWrappers: got %d, want %d", len(env.toolWrappers), len(defaultToolWrappers))
+	}
+	if env.runCmd == nil || env.dialCtx == nil || env.lookupUser == nil {
+		t.Errorf("hooks: runCmd=%v dialCtx=%v lookupUser=%v",
+			env.runCmd != nil, env.dialCtx != nil, env.lookupUser != nil)
+	}
+}
+
+func TestRealDial_ConnRefused(t *testing.T) {
+	// Dial a known-closed port on loopback. The kernel returns
+	// ECONNREFUSED synchronously, so the test does not depend on
+	// the dial timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := realDial(ctx, "tcp", "127.0.0.1:1", probeDialTimeout)
+	if err == nil {
+		t.Fatalf("dial to 127.0.0.1:1 succeeded, want refusal")
+	}
+}
+
+func TestVerifyCmdExecute(t *testing.T) {
+	root := Cmd()
+	root.SetArgs([]string{"verify", "--json", "--port", "1"})
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+
+	// Running with the live environment will fail probes 1-7 on a
+	// machine without the containment model. We only check the
+	// command exits via ExitError, not the specific code (which
+	// depends on whether sudo/systemctl/nft are even installed).
+	err := root.Execute()
+	if err == nil {
+		t.Fatalf("expected error on uninstalled containment, got nil")
+	}
+	if code := cliutil.ExitCodeOf(err); code != cliutil.ExitGeneral && code != cliutil.ExitConfig && code != cliutil.ExitOK {
+		t.Errorf("exit code: got %d, want 0, 1, or 2", code)
+	}
+	// Sanity: verify wrote JSON records to stdout (not the help text).
+	if !strings.Contains(buf.String(), `"probe":1`) {
+		t.Errorf("expected JSON output, got: %q", buf.String())
+	}
+}
+
+func TestIsSudoRefusal(t *testing.T) {
+	yes := []string{
+		"sudo: a password is required",
+		"User operator may not run sudo",
+		"not allowed to execute",
+		"sudo: no tty present and no askpass program specified",
+		"SUDO: A PASSWORD IS REQUIRED",
+	}
+	for _, s := range yes {
+		if !isSudoRefusal(s) {
+			t.Errorf("isSudoRefusal(%q) = false, want true", s)
+		}
+	}
+	no := []string{
+		"curl: (7) Failed to connect",
+		"200",
+		"",
+	}
+	for _, s := range no {
+		if isSudoRefusal(s) {
+			t.Errorf("isSudoRefusal(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestRealRunCommand_Roundtrip(t *testing.T) {
+	// Use /bin/sh -c to avoid platform-specific binary discovery.
+	out, code, err := realRunCommand(context.Background(), "/bin/sh", "-c", "echo hello && false")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if code != 1 {
+		t.Errorf("exit code: got %d, want 1", code)
+	}
+	if !strings.Contains(out, "hello") {
+		t.Errorf("output: got %q, want substring hello", out)
+	}
+}
+
+func TestRealRunCommand_BinaryMissing(t *testing.T) {
+	_, code, err := realRunCommand(context.Background(), "/nonexistent/binary", "arg")
+	if err == nil {
+		t.Fatalf("expected error for missing binary")
+	}
+	if code != -1 {
+		t.Errorf("exit code: got %d, want -1", code)
+	}
+}
+
+func TestNewFakeRunHelper(t *testing.T) {
+	// Exercises the test helper itself so a failure isolates whether
+	// the harness is the bug.
+	run, _ := newFakeRun(fakeMatcher{cmd: "echo", result: fakeRunResult{stdout: "hi", code: 0}})
+	out, code, err := run(context.Background(), "echo", "hello")
+	if err != nil || code != 0 || out != "hi" {
+		t.Fatalf("got out=%q code=%d err=%v", out, code, err)
+	}
+	_, _, err = run(context.Background(), "no-match")
+	if err == nil {
+		t.Fatalf("expected error for unstubbed call")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/cli/assess"
 	"github.com/luckyPipewrench/pipelock/internal/cli/audit"
 	"github.com/luckyPipewrench/pipelock/internal/cli/canary"
+	"github.com/luckyPipewrench/pipelock/internal/cli/contain"
 	"github.com/luckyPipewrench/pipelock/internal/cli/diag"
 	"github.com/luckyPipewrench/pipelock/internal/cli/generate"
 	"github.com/luckyPipewrench/pipelock/internal/cli/git"
@@ -79,6 +80,8 @@ Quick start:
 		canary.Cmd(),
 		audit.ReportCmd(),
 		audit.SimulateCmd(),
+		// Containment (workstation-tier)
+		contain.Cmd(),
 		// Diagnostics
 		diag.DiagnoseCmd(),
 		diag.DiscoverCmd(),


### PR DESCRIPTION
## Summary

`pipelock contain` is workstation containment automation for AI agents on Fedora. The model splits a workstation into three system users enforced by nftables owner-match rules: an unchanged operator user, a `pipelock-proxy` system user that runs the proxy with full network, and a `cc-agent` system user that runs AI agent tools with no direct internet (kernel firewall drops every outbound except DNS to loopback). Wrappers in `/usr/local/bin/cc-<tool>` exec target tools under `cc-agent` with `HTTPS_PROXY` pointed at Pipelock, so the only path out is through the proxy.

This PR ships only the cobra skeleton for five subcommands plus a working read-only `verify` subcommand. The four mutating subcommands (`install`, `rollback`, `add-tool`, `ca-refresh`) register and appear in `--help` but return a "not yet implemented in v0.1" error.

## `verify` probes

Nine read-only probes. Each returns pass, fail, or skip with a one-line detail.

1. `system_users_exist`: both system users present.
2. `pipelock_systemd_unit`: service running as `pipelock-proxy`.
3. `nftables_containment_ruleset`: skuid drop rule inside the target chain.
4. `wrapper_scripts_installed`: cc-launch plus at least one tool wrapper, mode 0755.
5. `ca_bundle_present`: combined CA bundle parses and contains a Pipelock CA.
6. `pipelock_listening_loopback`: TCP dial to the configured port.
7. `no_proxy_env_correct`: wrapper sets `NO_PROXY=127.0.0.1,localhost`.
8. `cc_agent_egress_denied`: sudo-down-to-cc-agent curl must fail (canary).
9. `operator_egress_reachable`: operator's normal curl must succeed.

Exit codes: `0` all pass, `1` any fail, `2` any skip with no fail. JSON output via `--json` emits one record per probe plus an aggregate. `verify` never mutates state; probes that require root visibility skip cleanly when run unprivileged.

## Out of scope

Non-Fedora distros, macOS, Windows, remote workstation operation, and cluster or server containment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pipelock contain verify` to run nine workstation containment checks with text or newline-delimited JSON output and exit codes for pass/fail/skip.
  * Registered top-level `pipelock contain` command and stubbed mutating subcommands (`install`, `rollback`, `add-tool`, `ca-refresh`) that present consistent "not yet implemented" responses.

* **Validation**
  * `add-tool` now validates tool names and reports clear invalid-name errors.

* **Documentation**
  * Added package-level docs describing the containment command family and v0.1 behavior.

* **Tests**
  * Added a comprehensive test suite covering probes, output modes, exit-code mapping, and command wiring.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/512)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->