### PR TITLE
feat(cli): add pipelock cline install subcommand for MCP wrapping

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -110,6 +110,7 @@ Quick start:
 		// Setup (IDE integrations)
 		setup.InitCmd(),
 		setup.ClaudeCmd(),
+		setup.ClineCmd(),
 		setup.CursorCmd(),
 		setup.VscodeCmd(),
 		setup.JetbrainsCmd(),

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -112,6 +112,43 @@ func parseHeaderFlags(raw []string) (http.Header, error) {
 	return h, nil
 }
 
+// readHeaderFile reads "Key: Value" entries from a sidecar file with strict
+// permissions. Empty path returns nil. Lines starting with '#' and blank
+// lines are skipped. The file must be regular and its permission bits must
+// be 0o600 or 0o640 (group-read allowed for k8s fsGroup parity with
+// signing.LoadPrivateKeyFile). Values are not validated here; the caller
+// hands the returned lines to parseHeaderFlags which applies the same
+// validation as --header.
+func readHeaderFile(path string) ([]string, error) {
+	if path == "" {
+		return nil, nil
+	}
+	clean := filepath.Clean(path)
+	info, err := os.Stat(clean)
+	if err != nil {
+		return nil, fmt.Errorf("--header-file %q: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("--header-file %q: not a regular file (mode=%s)", path, info.Mode())
+	}
+	if info.Mode().Perm()&0o037 != 0 {
+		return nil, fmt.Errorf("--header-file %q: permissions %04o reveal the header values to other users; restrict to 0600 or 0640", path, info.Mode().Perm())
+	}
+	data, err := os.ReadFile(clean) //nolint:gosec // path is operator-supplied and cleaned + perm-gated above
+	if err != nil {
+		return nil, fmt.Errorf("--header-file %q: %w", path, err)
+	}
+	var lines []string
+	for _, raw := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		lines = append(lines, raw)
+	}
+	return lines, nil
+}
+
 func validHeaderName(key string) bool {
 	if key == "" {
 		return false
@@ -304,6 +341,7 @@ func mcpProxyCmd() *cobra.Command {
 	var listenAddr string
 	var envVars []string
 	var rawHeaders []string
+	var headerFile string
 	var agentName string
 	var sandboxEnabled bool
 	var sandboxStrict bool
@@ -718,7 +756,13 @@ signed action receipts for MCP decisions.`,
 					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning: --env is ignored in HTTP transport mode (no child process)")
 				}
 
-				extraHeaders, headerErr := parseHeaderFlags(rawHeaders)
+				fileHeaders, fileErr := readHeaderFile(headerFile)
+				if fileErr != nil {
+					return fileErr
+				}
+				mergedHeaders := append([]string{}, fileHeaders...)
+				mergedHeaders = append(mergedHeaders, rawHeaders...)
+				extraHeaders, headerErr := parseHeaderFlags(mergedHeaders)
 				if headerErr != nil {
 					return headerErr
 				}
@@ -1099,6 +1143,7 @@ signed action receipts for MCP decisions.`,
 	cmd.Flags().StringVar(&listenAddr, "listen", "", "listen address for HTTP reverse proxy mode (e.g. 0.0.0.0:8889)")
 	cmd.Flags().StringArrayVar(&envVars, "env", nil, "pass environment variable to child process (KEY or KEY=VALUE, repeatable)")
 	cmd.Flags().StringArrayVar(&rawHeaders, "header", nil, "extra HTTP header for upstream MCP server in --upstream HTTP mode (repeatable, format: 'Key: Value')")
+	cmd.Flags().StringVar(&headerFile, "header-file", "", "path to a 0o600 (or 0o640) file with extra HTTP headers, one per line as 'Key: Value' (comments with '#'); merged with --header")
 	cmd.Flags().StringVar(&agentName, "agent", "", "agent profile name (resolves to config profile for policy/scanner)")
 	cmd.Flags().BoolVar(&sandboxEnabled, "sandbox", false, "run child in sandbox (Landlock + seccomp + network namespace, Linux only)")
 	cmd.Flags().BoolVar(&sandboxStrict, "sandbox-strict", false, "strict sandbox: error on missing layers, private /dev/shm, block clone3 (implies --sandbox)")

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -1050,3 +1050,56 @@ func loadActionReceipts(t *testing.T, dir string) []receipt.Receipt {
 
 	return receipts
 }
+
+// TestReadHeaderFile_Strict locks in the file-mode and parse semantics so
+// the IDE wrap can rely on --header-file delivering the same validation
+// guarantees as --header without leaking credential values into argv.
+func TestReadHeaderFile_Strict(t *testing.T) {
+	dir := t.TempDir()
+
+	// Empty path returns nil, nil.
+	if got, err := readHeaderFile(""); err != nil || got != nil {
+		t.Errorf("readHeaderFile empty path = %v, %v; want nil, nil", got, err)
+	}
+
+	// Nonexistent path errors cleanly.
+	if _, err := readHeaderFile(filepath.Join(dir, "missing.headers")); err == nil {
+		t.Error("readHeaderFile on missing file should error")
+	}
+
+	// 0o644 (world-readable) is rejected.
+	loose := filepath.Join(dir, "loose.headers")
+	if err := os.WriteFile(loose, []byte("X-Foo: bar\n"), 0o644); err != nil { //nolint:gosec // intentionally loose for the rejection test
+		t.Fatal(err)
+	}
+	if _, err := readHeaderFile(loose); err == nil {
+		t.Error("readHeaderFile must reject 0o644-mode files")
+	}
+
+	// 0o600 with comments + blank lines + a valid header is accepted.
+	good := filepath.Join(dir, "good.headers")
+	body := "# comment\n\nX-Trace-Id: t-123\nAuthorization: Bearer abc\n"
+	if err := os.WriteFile(good, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lines, err := readHeaderFile(good)
+	if err != nil {
+		t.Fatalf("readHeaderFile good file: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 header lines after comment/blank filtering, got %d: %v", len(lines), lines)
+	}
+
+	// Pipe the lines into parseHeaderFlags to confirm the round-trip
+	// honors the same validation as --header.
+	hdrs, err := parseHeaderFlags(lines)
+	if err != nil {
+		t.Fatalf("parseHeaderFlags from sidecar lines: %v", err)
+	}
+	if hdrs.Get("X-Trace-Id") != "t-123" {
+		t.Errorf("X-Trace-Id = %q, want t-123", hdrs.Get("X-Trace-Id"))
+	}
+	if hdrs.Get("Authorization") != "Bearer abc" {
+		t.Errorf("Authorization = %q, want 'Bearer abc'", hdrs.Get("Authorization"))
+	}
+}

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -1102,4 +1102,22 @@ func TestReadHeaderFile_Strict(t *testing.T) {
 	if hdrs.Get("Authorization") != "Bearer abc" {
 		t.Errorf("Authorization = %q, want 'Bearer abc'", hdrs.Get("Authorization"))
 	}
+
+	// 0o640 is accepted for deployment environments that use fsGroup-style
+	// group readability while still rejecting world-readable sidecars.
+	groupReadable := filepath.Join(dir, "group-readable.headers")
+	if err := os.WriteFile(groupReadable, []byte("X-Group: ok\n"), 0o640); err != nil { //nolint:gosec // intentionally group-readable for the acceptance test
+		t.Fatal(err)
+	}
+	lines, err = readHeaderFile(groupReadable)
+	if err != nil {
+		t.Fatalf("readHeaderFile 0o640 file: %v", err)
+	}
+	hdrs, err = parseHeaderFlags(lines)
+	if err != nil {
+		t.Fatalf("parseHeaderFlags from 0o640 sidecar lines: %v", err)
+	}
+	if hdrs.Get("X-Group") != "ok" {
+		t.Errorf("X-Group = %q, want ok", hdrs.Get("X-Group"))
+	}
 }

--- a/internal/cli/setup/cline.go
+++ b/internal/cli/setup/cline.go
@@ -185,9 +185,9 @@ func runClineInstall(cmd *cobra.Command, override string, dryRun bool, configFil
 			return fmt.Errorf("marshaling metadata for %q: %w", name, err)
 		}
 		var metaMap interface{}
-		// metaJSON came from json.Marshal of a typed struct above, so
-		// unmarshalling into an interface{} cannot fail on valid input.
-		_ = json.Unmarshal(metaJSON, &metaMap)
+		if err := json.Unmarshal(metaJSON, &metaMap); err != nil {
+			return fmt.Errorf("unmarshaling metadata for %q: %w", name, err)
+		}
 		newServer[mcpFieldPipelock] = metaMap
 
 		mcpCfg.Servers[name] = newServer

--- a/internal/cli/setup/cline.go
+++ b/internal/cli/setup/cline.go
@@ -1,0 +1,391 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// Cline integration wraps the MCP servers declared in Cline's mcp.json file
+// so that every tool call, response, and description is scanned bidirectionally
+// by pipelock. Cline is MCP-native rather than hook-based, so the install
+// rewrites the config file in place. Unlike VS Code's mcp.json (which uses a
+// "servers" top-level key and a per-server "type" field), Cline uses
+// "mcpServers" and infers the transport from the presence of "command" or
+// "url". The wrap stores the original entry in a _pipelock metadata field so
+// remove can restore the config byte-for-byte for any unwrapped fields.
+
+const (
+	clineConfigFilename = "mcp.json"
+	clineConfigDirname  = ".cline"
+	clineServersKey     = "mcpServers"
+	clineHTTPProbeType  = "http"
+)
+
+// clineMCPConfig represents Cline's mcp.json file. Unknown top-level fields
+// are preserved through the raw-map roundtrip in marshalClineConfig.
+type clineMCPConfig struct {
+	Servers map[string]map[string]interface{} `json:"mcpServers"`
+}
+
+// ClineCmd returns the `pipelock cline` command tree.
+func ClineCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cline",
+		Short: "Cline integration",
+		Long: `Commands for integrating pipelock with Cline's MCP server support.
+
+Cline is MCP-native rather than hook-based, so install rewrites the
+mcp.json file so that every server runs through pipelock's MCP proxy.
+All tool calls, responses, and descriptions are scanned bidirectionally.
+
+The install subcommand rewrites mcp.json to route MCP servers through
+pipelock. The remove subcommand restores the original config from the
+_pipelock metadata field. Both commands are idempotent.`,
+	}
+
+	cmd.AddCommand(
+		clineInstallCmd(),
+		clineRemoveCmd(),
+	)
+
+	return cmd
+}
+
+func clineInstallCmd() *cobra.Command {
+	var (
+		path       string
+		dryRun     bool
+		configFile string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Wrap Cline MCP servers through pipelock",
+		Long: `Rewrites Cline's mcp.json to route all MCP servers through pipelock's
+MCP proxy. Stdio servers (entries with "command") get their command
+wrapped. Remote servers (entries with "url") are converted to stdio with
+--upstream and a synthetic "type" hint that is removed on unwrap.
+
+By default writes to ~/.cline/mcp.json. Use --path to point at a different
+file, for example the VS Code extension's settings file under the user's
+globalStorage directory.
+
+If mcp.json already exists, servers are wrapped in place. Already-wrapped
+servers are skipped (idempotent). A .bak backup is created before
+modification. Non-server fields are preserved.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runClineInstall(cmd, path, dryRun, configFile)
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "path to mcp.json (default ~/.cline/mcp.json)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be written without modifying files")
+	cmd.Flags().StringVarP(&configFile, "config", "c", "", "path to pipelock config file for --config passthrough")
+
+	return cmd
+}
+
+func clineRemoveCmd() *cobra.Command {
+	var (
+		path   string
+		dryRun bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove pipelock wrapping from Cline MCP servers",
+		Long: `Restores Cline's mcp.json by unwrapping servers that were wrapped by
+pipelock install. Original server configurations are restored from the
+_pipelock metadata field. Non-wrapped servers are left unchanged.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runClineRemove(cmd, path, dryRun)
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "path to mcp.json (default ~/.cline/mcp.json)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be written without modifying files")
+
+	return cmd
+}
+
+// clineConfigPath returns the target mcp.json path, defaulting to
+// ~/.cline/mcp.json when the operator did not supply an override.
+func clineConfigPath(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("finding home directory: %w", err)
+	}
+	return filepath.Join(home, clineConfigDirname, clineConfigFilename), nil
+}
+
+func runClineInstall(cmd *cobra.Command, override string, dryRun bool, configFile string) error {
+	targetPath, err := clineConfigPath(override)
+	if err != nil {
+		return err
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("finding pipelock binary: %w", err)
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return fmt.Errorf("resolving pipelock binary path: %w", err)
+	}
+
+	configFile = discoverConfigForWrap(cmd, configFile)
+
+	existingData, readErr := os.ReadFile(filepath.Clean(targetPath))
+	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		return fmt.Errorf("reading existing %s: %w", targetPath, readErr)
+	}
+
+	mcpCfg := &clineMCPConfig{Servers: make(map[string]map[string]interface{})}
+	if readErr == nil && len(existingData) > 0 {
+		if err := json.Unmarshal(existingData, mcpCfg); err != nil {
+			return fmt.Errorf("parsing %s: %w", targetPath, err)
+		}
+		if mcpCfg.Servers == nil {
+			mcpCfg.Servers = make(map[string]map[string]interface{})
+		}
+	}
+
+	wrapped := 0
+	skipped := 0
+	var sidecarOps []sidecarOp
+	for name, server := range mcpCfg.Servers {
+		if isVscodeWrapped(server) {
+			skipped++
+			continue
+		}
+
+		newServer, meta, plan, err := wrapClineServer(server, exe, configFile, targetPath, name)
+		if err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: skipping server %q: %v\n", name, err)
+			continue
+		}
+
+		metaJSON, err := json.Marshal(meta)
+		if err != nil {
+			return fmt.Errorf("marshaling metadata for %q: %w", name, err)
+		}
+		var metaMap interface{}
+		// metaJSON came from json.Marshal of a typed struct above, so
+		// unmarshalling into an interface{} cannot fail on valid input.
+		_ = json.Unmarshal(metaJSON, &metaMap)
+		newServer[mcpFieldPipelock] = metaMap
+
+		mcpCfg.Servers[name] = newServer
+		if plan != nil {
+			sidecarOps = append(sidecarOps, *plan)
+		}
+		wrapped++
+	}
+
+	output, err := marshalClineConfig(existingData, mcpCfg)
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", clineConfigFilename, err)
+	}
+
+	if dryRun {
+		// Dry-run is read-only: do not write the canonical config AND do not
+		// write any sidecar.
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Would write to %s (%d wrapped, %d already wrapped):\n%s", targetPath, wrapped, skipped, output)
+		return nil
+	}
+
+	targetDir := filepath.Dir(targetPath)
+	if err := os.MkdirAll(targetDir, 0o750); err != nil {
+		return fmt.Errorf("creating directory %s: %w", targetDir, err)
+	}
+
+	if readErr == nil {
+		if err := os.WriteFile(targetPath+".bak", existingData, 0o600); err != nil {
+			return fmt.Errorf("creating backup: %w", err)
+		}
+	}
+
+	// Sidecars are written FIRST so a sidecar failure leaves the operator's
+	// config untouched. applySidecarOps internally rolls back any partial
+	// writes if one of the writes fails partway through the plan.
+	if err := applySidecarOps(sidecarOps); err != nil {
+		return fmt.Errorf("writing header sidecar: %w", err)
+	}
+
+	// Atomic write of the canonical config. If this fails, the sidecars
+	// we just wrote would orphan to a config file that has no reference
+	// to them, so we clean them up before returning the error.
+	if err := vscodeAtomicWrite(targetPath, output, targetDir); err != nil {
+		rollbackSidecarWrites(sidecarOps)
+		return err
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Wrapped %d server(s) in %s (%d already wrapped)\n", wrapped, targetPath, skipped)
+	if wrapped > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Restart Cline to activate pipelock scanning.\n")
+	}
+	return nil
+}
+
+func runClineRemove(cmd *cobra.Command, override string, dryRun bool) error {
+	targetPath, err := clineConfigPath(override)
+	if err != nil {
+		return err
+	}
+
+	existingData, err := os.ReadFile(filepath.Clean(targetPath))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No %s found at %s\n", clineConfigFilename, targetPath)
+			return nil
+		}
+		return fmt.Errorf("reading %s: %w", targetPath, err)
+	}
+
+	mcpCfg := &clineMCPConfig{Servers: make(map[string]map[string]interface{})}
+	if err := json.Unmarshal(existingData, mcpCfg); err != nil {
+		return fmt.Errorf("parsing %s: %w", targetPath, err)
+	}
+
+	unwrapped := 0
+	var sidecarOps []sidecarOp
+	for name, server := range mcpCfg.Servers {
+		if !isVscodeWrapped(server) {
+			continue
+		}
+
+		restored, plan, err := unwrapVscodeServer(server)
+		if err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not unwrap %q: %v\n", name, err)
+			continue
+		}
+
+		mcpCfg.Servers[name] = restored
+		if plan != nil {
+			sidecarOps = append(sidecarOps, *plan)
+		}
+		unwrapped++
+	}
+
+	output, err := marshalClineConfig(existingData, mcpCfg)
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", clineConfigFilename, err)
+	}
+
+	if dryRun {
+		// Dry-run is read-only: do not delete the sidecars referenced by the
+		// still-wrapped on-disk config.
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Would write to %s (%d unwrapped):\n%s", targetPath, unwrapped, output)
+		return nil
+	}
+
+	if err := os.WriteFile(targetPath+".bak", existingData, 0o600); err != nil {
+		return fmt.Errorf("creating backup: %w", err)
+	}
+
+	targetDir := filepath.Dir(targetPath)
+	if err := vscodeAtomicWrite(targetPath, output, targetDir); err != nil {
+		return err
+	}
+
+	// Sidecars are deleted only after the restored config is committed to
+	// disk. Earlier failures leave the wrapped config and its sidecars in
+	// place so the operator can retry.
+	_ = applySidecarOps(sidecarOps)
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Unwrapped %d server(s) in %s\n", unwrapped, targetPath)
+	if unwrapped > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Restart Cline to apply changes.\n")
+	}
+	return nil
+}
+
+// wrapClineServer wraps a single Cline MCP server entry through pipelock mcp
+// proxy. Cline omits the "type" field, so we infer the transport from the
+// presence of "url" before delegating to wrapVscodeServer, then mark
+// TypeOmitted=true on the returned metadata so remove restores a Cline-shaped
+// entry rather than a VS Code-shaped one. Like wrapVscodeServer, this is pure
+// with respect to the filesystem: the returned sidecarOp (if non-nil) is the
+// caller's responsibility to apply only after the canonical config write
+// succeeds.
+func wrapClineServer(server map[string]interface{}, exe, configFile, targetConfigPath, serverName string) (map[string]interface{}, *pipelockMeta, *sidecarOp, error) {
+	_, hasCommand := server[mcpFieldCommand]
+	_, hasURL := server[mcpFieldURL]
+	if hasCommand && hasURL {
+		return nil, nil, nil, fmt.Errorf("server has both command and url")
+	}
+
+	if _, hasType := server[mcpFieldType]; hasType {
+		// Operator explicitly set a type. Treat exactly like the VS Code path,
+		// preserving the type on unwrap.
+		return wrapVscodeServer(server, exe, configFile, targetConfigPath, serverName)
+	}
+
+	if hasCommand {
+		// Stdio server with no type field: wrapVscodeServer's default branch
+		// (typeOmitted -> stdio) already produces the right output and the
+		// right TypeOmitted=true metadata. No extra work needed.
+		return wrapVscodeServer(server, exe, configFile, targetConfigPath, serverName)
+	}
+
+	if hasURL {
+		// Remote server with no type field. Pre-mutate to satisfy wrap's
+		// dispatch, then force TypeOmitted=true on the returned metadata so
+		// remove does not write a type field back into the Cline entry.
+		probe := make(map[string]interface{}, len(server)+1)
+		for k, v := range server {
+			probe[k] = v
+		}
+		probe[mcpFieldType] = clineHTTPProbeType
+
+		result, meta, plan, err := wrapVscodeServer(probe, exe, configFile, targetConfigPath, serverName)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		meta.TypeOmitted = true
+		return result, meta, plan, nil
+	}
+
+	return nil, nil, nil, fmt.Errorf("server has neither command nor url")
+}
+
+// marshalClineConfig marshals the Cline mcp.json while preserving unknown
+// top-level fields from the original file data.
+func marshalClineConfig(originalData []byte, cfg *clineMCPConfig) ([]byte, error) {
+	if len(originalData) > 0 {
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(originalData, &raw); err == nil {
+			serversJSON, err := json.Marshal(cfg.Servers)
+			if err != nil {
+				return nil, err
+			}
+			raw[clineServersKey] = serversJSON
+			output, err := json.MarshalIndent(raw, "", "  ")
+			if err != nil {
+				return nil, err
+			}
+			return append(output, '\n'), nil
+		}
+	}
+
+	output, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(output, '\n'), nil
+}

--- a/internal/cli/setup/cline_test.go
+++ b/internal/cli/setup/cline_test.go
@@ -93,11 +93,19 @@ func writeClineFile(t *testing.T, body string) string {
 
 func runClineCmd(t *testing.T, args ...string) error {
 	t.Helper()
+	_, _, err := runClineCmdOutput(t, args...)
+	return err
+}
+
+func runClineCmdOutput(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
 	cmd := ClineCmd()
 	cmd.SetArgs(args)
-	cmd.SetOut(os.Stdout)
-	cmd.SetErr(os.Stderr)
-	return cmd.Execute()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	err := cmd.Execute()
+	return stdout.String(), stderr.String(), err
 }
 
 func hasAdjacentArg(args []string, flag, value string) bool {

--- a/internal/cli/setup/cline_test.go
+++ b/internal/cli/setup/cline_test.go
@@ -1,0 +1,790 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	testClineStdioConfig = `{
+  "mcpServers": {
+    "my-server": {
+      "command": "npx",
+      "args": ["-y", "@example/mcp-server"],
+      "env": { "MY_VAR": "test" }
+    }
+  }
+}`
+
+	testClineHTTPConfig = `{
+  "mcpServers": {
+    "remote": {
+      "url": "https://api.example.com/mcp",
+      "headers": { "X-Workspace-Id": "ws-cli-tok" }
+    }
+  }
+}`
+
+	testClineWithUnknownField = `{
+  "version": 2,
+  "mcpServers": {
+    "stdio-srv": {
+      "command": "node",
+      "args": ["server.js"]
+    }
+  }
+}`
+
+	testClineStdioEmptyArgs = `{
+  "mcpServers": {
+    "fixture": {
+      "command": "cat",
+      "args": []
+    }
+  }
+}`
+	testClineNullServers = `{"mcpServers": null}`
+	testClineNoCmdNoURL  = `{
+  "mcpServers": {
+    "broken": {
+      "env": { "FOO": "bar" }
+    }
+  }
+}`
+
+	testClineCommandAndURL = `{
+  "mcpServers": {
+    "ambiguous": {
+      "command": "node",
+      "url": "https://api.example.com/mcp"
+    }
+  }
+}`
+)
+
+// testClineHTTPConfigSecretHeader is built at init from a split bearer-token
+// value so gosec G101 does not flag the fixture as a hardcoded credential.
+var testClineHTTPConfigSecretHeader = `{
+  "mcpServers": {
+    "remote": {
+      "url": "https://api.example.com/mcp",
+      "headers": { "Authorization": "Bearer ` + "cli-tok" + `" }
+    }
+  }
+}`
+
+// writeClineFile writes a config string to a temp dir and returns the path.
+func writeClineFile(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "mcp.json")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	return p
+}
+
+func runClineCmd(t *testing.T, args ...string) error {
+	t.Helper()
+	cmd := ClineCmd()
+	cmd.SetArgs(args)
+	cmd.SetOut(os.Stdout)
+	cmd.SetErr(os.Stderr)
+	return cmd.Execute()
+}
+
+func hasAdjacentArg(args []string, flag, value string) bool {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func TestClineInstall_DryRun(t *testing.T) {
+	path := writeClineFile(t, testClineStdioConfig)
+
+	if err := runClineCmd(t, "install", "--path", path, "--dry-run"); err != nil {
+		t.Fatalf("install --dry-run failed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("re-read after dry-run: %v", err)
+	}
+	if string(got) != testClineStdioConfig {
+		t.Error("dry-run modified the file")
+	}
+}
+
+func TestClineInstall_StdioServerWithImplicitType(t *testing.T) {
+	path := writeClineFile(t, testClineStdioConfig)
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg clineMCPConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parsing result: %v", err)
+	}
+
+	server, ok := cfg.Servers["my-server"]
+	if !ok {
+		t.Fatal("server 'my-server' not in result")
+	}
+
+	if _, ok := server[mcpFieldPipelock]; !ok {
+		t.Error("missing _pipelock metadata after wrap")
+	}
+
+	args := interfaceSliceToStrings(server["args"])
+	if len(args) < 4 {
+		t.Fatalf("expected at least 4 wrapped args, got %d: %v", len(args), args)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.HasPrefix(joined, "mcp proxy ") {
+		t.Errorf("expected wrapped args to start with mcp proxy, got %v", args[:2])
+	}
+
+	dashIdx := -1
+	for i, a := range args {
+		if a == "--" {
+			dashIdx = i
+			break
+		}
+	}
+	if dashIdx < 0 {
+		t.Fatal("no -- separator in wrapped args")
+	}
+	if args[dashIdx+1] != testOriginalCmd {
+		t.Errorf("expected original command after --, got %q", args[dashIdx+1])
+	}
+
+	foundEnv := false
+	for i, a := range args {
+		if a == codexFlagEnv && i+1 < len(args) && args[i+1] == "MY_VAR" {
+			foundEnv = true
+			break
+		}
+	}
+	if !foundEnv {
+		t.Errorf("expected --env MY_VAR passthrough in args: %v", args)
+	}
+
+	env, ok := server["env"].(map[string]interface{})
+	if !ok || env["MY_VAR"] != "test" {
+		t.Errorf("env block not preserved: %v", server["env"])
+	}
+
+	if _, hasType := server[mcpFieldType]; !hasType {
+		t.Error("wrapped stdio entry must declare type=stdio so Cline launches the pipelock subprocess")
+	}
+}
+
+func TestClineInstall_HTTPServerWithImplicitType(t *testing.T) {
+	// Sidecar dir lives under HOME; point it at a temp dir so the sidecar
+	// file lands somewhere the test can read back without touching the
+	// operator's real config.
+	t.Setenv("HOME", t.TempDir())
+
+	path := writeClineFile(t, testClineHTTPConfig)
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg clineMCPConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parsing result: %v", err)
+	}
+
+	server := cfg.Servers["remote"]
+
+	args := interfaceSliceToStrings(server["args"])
+	foundUpstream := false
+	for i, a := range args {
+		if a == "--upstream" && i+1 < len(args) {
+			if args[i+1] != testExampleURL {
+				t.Errorf("upstream URL mismatch: got %q, want %q", args[i+1], testExampleURL)
+			}
+			foundUpstream = true
+			break
+		}
+	}
+	if !foundUpstream {
+		t.Error("--upstream flag missing from wrapped HTTP server")
+	}
+
+	// Wrapped argv carries the sidecar path, not the header value.
+	sidecarPath := ""
+	for i, a := range args {
+		if a == mcpFlagHeaderFile && i+1 < len(args) {
+			sidecarPath = args[i+1]
+			break
+		}
+	}
+	if sidecarPath == "" {
+		t.Fatalf("wrapped argv missing --header-file flag: %v", args)
+	}
+	if hasAdjacentArg(args, mcpFlagHeader, "X-Workspace-Id: ws-cli-tok") {
+		t.Errorf("header value leaked into argv via --header; sidecar must be the only carrier")
+	}
+	body, err := os.ReadFile(filepath.Clean(sidecarPath))
+	if err != nil {
+		t.Fatalf("read sidecar: %v", err)
+	}
+	if !strings.Contains(string(body), "X-Workspace-Id: ws-cli-tok") {
+		t.Errorf("sidecar missing the header line: %q", body)
+	}
+
+	metaJSON, _ := json.Marshal(server[mcpFieldPipelock])
+	var meta pipelockMeta
+	if err := json.Unmarshal(metaJSON, &meta); err != nil {
+		t.Fatal(err)
+	}
+	if meta.OriginalURL != testExampleURL {
+		t.Errorf("expected original URL preserved, got %q", meta.OriginalURL)
+	}
+	if !meta.TypeOmitted {
+		t.Error("Cline HTTP wrap must record TypeOmitted=true so remove restores a typeless entry")
+	}
+	if meta.OriginalHeaders["X-Workspace-Id"] != "ws-cli-tok" {
+		t.Errorf("headers not preserved in metadata: %v", meta.OriginalHeaders)
+	}
+	if meta.HeaderSidecarPath != sidecarPath {
+		t.Errorf("meta.HeaderSidecarPath = %q, want %q", meta.HeaderSidecarPath, sidecarPath)
+	}
+}
+
+func TestClineInstall_Idempotent(t *testing.T) {
+	path := writeClineFile(t, testClineStdioConfig)
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	firstRun, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	secondRun, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(firstRun) != string(secondRun) {
+		t.Errorf("install is not idempotent:\nfirst:\n%s\nsecond:\n%s", firstRun, secondRun)
+	}
+}
+
+func TestClineInstall_PreservesUnknownTopLevelFields(t *testing.T) {
+	path := writeClineFile(t, testClineWithUnknownField)
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"version"`) {
+		t.Error("unknown top-level field 'version' was dropped on install")
+	}
+}
+
+func TestClineInstall_CreatesMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.json")
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install on missing file: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected file to be created: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("expected mode 0600 on new file, got %o", info.Mode().Perm())
+	}
+}
+
+func TestClineInstall_BackupCreated(t *testing.T) {
+	path := writeClineFile(t, testClineStdioConfig)
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	backup, err := os.ReadFile(filepath.Clean(path + ".bak"))
+	if err != nil {
+		t.Fatalf("expected .bak backup: %v", err)
+	}
+	if string(backup) != testClineStdioConfig {
+		t.Error("backup content does not match original")
+	}
+}
+
+// TestClineRoundTrip_PreservesEmptyArgs locks in that `"args": []` on the
+// source round-trips byte-exact through install + remove. Prior to the
+// ArgsPresent metadata field, unwrap dropped empty args entirely because
+// the restore branch gated on len(meta.OriginalArgs) > 0; the E2E harness
+// in tests/e2e/cline-install.sh surfaced this in production-shaped configs.
+func TestClineRoundTrip_PreservesEmptyArgs(t *testing.T) {
+	path := writeClineFile(t, testClineStdioEmptyArgs)
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// Confirm the wrap recorded ArgsPresent on the metadata.
+	wrappedData, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wrappedCfg clineMCPConfig
+	if err := json.Unmarshal(wrappedData, &wrappedCfg); err != nil {
+		t.Fatal(err)
+	}
+	metaJSON, _ := json.Marshal(wrappedCfg.Servers["fixture"][mcpFieldPipelock])
+	var meta pipelockMeta
+	if err := json.Unmarshal(metaJSON, &meta); err != nil {
+		t.Fatal(err)
+	}
+	if !meta.ArgsPresent {
+		t.Error("wrap of stdio entry with empty args must record ArgsPresent=true")
+	}
+
+	// Run remove and assert the args field is restored as an empty array.
+	if err := runClineCmd(t, "remove", "--path", path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	restoredData, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restoredRaw map[string]map[string]map[string]interface{}
+	if err := json.Unmarshal(restoredData, &restoredRaw); err != nil {
+		t.Fatal(err)
+	}
+	args, hasArgs := restoredRaw["mcpServers"]["fixture"]["args"]
+	if !hasArgs {
+		t.Fatal("unwrap dropped the args field that was present in the source")
+	}
+	argsSlice, ok := args.([]interface{})
+	if !ok {
+		t.Fatalf("restored args has wrong type: %T", args)
+	}
+	if len(argsSlice) != 0 {
+		t.Errorf("expected empty args slice, got %v", argsSlice)
+	}
+}
+
+func TestClineRemove_UnwrapsStdio(t *testing.T) {
+	path := writeClineFile(t, testClineStdioConfig)
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if err := runClineCmd(t, "remove", "--path", path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg clineMCPConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse after remove: %v", err)
+	}
+
+	server := cfg.Servers["my-server"]
+	if _, hasMeta := server[mcpFieldPipelock]; hasMeta {
+		t.Error("_pipelock metadata not stripped after remove")
+	}
+	if server["command"] != testOriginalCmd {
+		t.Errorf("original command not restored: got %v", server["command"])
+	}
+	if _, hasType := server[mcpFieldType]; hasType {
+		t.Error("Cline stdio remove must not introduce a type field that was not in the original")
+	}
+}
+
+func TestClineRemove_UnwrapsHTTP(t *testing.T) {
+	path := writeClineFile(t, testClineHTTPConfig)
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if err := runClineCmd(t, "remove", "--path", path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg clineMCPConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse after remove: %v", err)
+	}
+
+	server := cfg.Servers["remote"]
+	if _, hasType := server[mcpFieldType]; hasType {
+		t.Error("Cline HTTP remove must not introduce a type field (Cline infers transport from url)")
+	}
+	if server["url"] != testExampleURL {
+		t.Errorf("original URL not restored: got %v", server["url"])
+	}
+	headers, ok := server["headers"].(map[string]interface{})
+	if !ok || headers["X-Workspace-Id"] != "ws-cli-tok" {
+		t.Errorf("headers not restored: %v", server["headers"])
+	}
+}
+
+// TestClineInstall_SecretHeaderRoutesThroughSidecar locks in that install
+// accepts credential-bearing headers because the values land in a 0o600
+// sidecar referenced via --header-file, not in the wrapped argv.
+func TestClineInstall_SecretHeaderRoutesThroughSidecar(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	path := writeClineFile(t, testClineHTTPConfigSecretHeader)
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install with credential header should succeed via sidecar: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg clineMCPConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	entry := cfg.Servers["remote"]
+	if _, wrapped := entry[mcpFieldPipelock]; !wrapped {
+		t.Fatal("entry must be wrapped via the sidecar path")
+	}
+	args := interfaceSliceToStrings(entry["args"])
+
+	for _, a := range args {
+		if strings.Contains(a, "cli-tok") {
+			t.Fatalf("credential value leaked into wrapped argv: %v", args)
+		}
+	}
+	sidecarPath := ""
+	for i, a := range args {
+		if a == mcpFlagHeaderFile && i+1 < len(args) {
+			sidecarPath = args[i+1]
+			break
+		}
+	}
+	if sidecarPath == "" {
+		t.Fatalf("wrapped argv missing --header-file flag: %v", args)
+	}
+	info, err := os.Stat(sidecarPath)
+	if err != nil {
+		t.Fatalf("sidecar not written: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("sidecar mode = %04o, want 0o600", info.Mode().Perm())
+	}
+}
+
+func TestClineRemove_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.json")
+
+	if err := runClineCmd(t, "remove", "--path", path); err != nil {
+		t.Errorf("remove on missing file should be a no-op, got: %v", err)
+	}
+}
+
+func TestClineRemove_Idempotent(t *testing.T) {
+	path := writeClineFile(t, testClineStdioConfig)
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if err := runClineCmd(t, "remove", "--path", path); err != nil {
+		t.Fatalf("first remove: %v", err)
+	}
+	firstRun, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runClineCmd(t, "remove", "--path", path); err != nil {
+		t.Fatalf("second remove: %v", err)
+	}
+	secondRun, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(firstRun) != string(secondRun) {
+		t.Errorf("remove is not idempotent:\nfirst:\n%s\nsecond:\n%s", firstRun, secondRun)
+	}
+}
+
+func TestClineInstall_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runClineCmd(t, "install", "--path", path); err == nil {
+		t.Error("expected install to fail on invalid JSON")
+	}
+}
+
+func TestClineInstall_NullServers(t *testing.T) {
+	path := writeClineFile(t, testClineNullServers)
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install with null servers: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"mcpServers"`) {
+		t.Error("mcpServers key missing after handling null input")
+	}
+}
+
+func TestClineInstall_SkipServersMissingCmdAndURL(t *testing.T) {
+	path := writeClineFile(t, testClineNoCmdNoURL)
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), `"_pipelock"`) {
+		t.Error("entries with neither command nor url must not be wrapped")
+	}
+}
+
+func TestClineInstall_SkipAmbiguousCommandAndURL(t *testing.T) {
+	path := writeClineFile(t, testClineCommandAndURL)
+
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg clineMCPConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse after install: %v", err)
+	}
+	server := cfg.Servers["ambiguous"]
+	if _, wrapped := server[mcpFieldPipelock]; wrapped {
+		t.Fatal("ambiguous command+url entry must not be wrapped")
+	}
+	if server[mcpFieldCommand] != testNodeCmd || server[mcpFieldURL] != testExampleURL {
+		t.Errorf("ambiguous entry was not preserved: %v", server)
+	}
+}
+
+func TestWrapClineServer_WithExplicitType(t *testing.T) {
+	server := map[string]interface{}{
+		"type":    testTypeStdio,
+		"command": testNodeCmd,
+		"args":    []interface{}{"server.js"},
+	}
+
+	result, meta, _, err := wrapClineServer(server, "/usr/local/bin/pipelock", "", "", "")
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	if meta.OriginalType != testTypeStdio {
+		t.Errorf("expected OriginalType=stdio, got %q", meta.OriginalType)
+	}
+	if meta.TypeOmitted {
+		t.Error("explicit type must produce TypeOmitted=false")
+	}
+	if result["type"] != testTypeStdio {
+		t.Errorf("expected wrapped type=stdio, got %v", result["type"])
+	}
+}
+
+func TestWrapClineServer_NeitherCommandNorURL(t *testing.T) {
+	server := map[string]interface{}{
+		"env": map[string]interface{}{"FOO": "bar"},
+	}
+
+	if _, _, _, err := wrapClineServer(server, "/usr/local/bin/pipelock", "", "", ""); err == nil {
+		t.Error("wrap should fail when the entry has neither command nor url")
+	}
+}
+
+func TestWrapClineServer_BothCommandAndURL(t *testing.T) {
+	server := map[string]interface{}{
+		mcpFieldCommand: testNodeCmd,
+		mcpFieldURL:     testExampleURL,
+	}
+
+	if _, _, _, err := wrapClineServer(server, "/usr/local/bin/pipelock", "", "", ""); err == nil {
+		t.Error("wrap should fail rather than silently dropping command or url")
+	}
+}
+
+func TestClineConfigPath_DefaultUsesHome(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	got, err := clineConfigPath("")
+	if err != nil {
+		t.Fatalf("clineConfigPath: %v", err)
+	}
+	want := filepath.Join(tmpHome, ".cline", "mcp.json")
+	if got != want {
+		t.Errorf("default path mismatch: got %q, want %q", got, want)
+	}
+}
+
+func TestClineConfigPath_OverrideRespected(t *testing.T) {
+	got, err := clineConfigPath("/etc/cline/custom.json")
+	if err != nil {
+		t.Fatalf("clineConfigPath: %v", err)
+	}
+	if got != "/etc/cline/custom.json" {
+		t.Errorf("override path not used: got %q", got)
+	}
+}
+
+// listSidecarFiles returns the entries in $HOME/.config/pipelock/wrap-headers
+// (or nil if the directory does not exist). Tests use this to assert the
+// dry-run paths never land a sidecar on disk.
+func listSidecarFiles(t *testing.T, home string) []string {
+	t.Helper()
+	dir := filepath.Join(home, ".config", "pipelock", "wrap-headers")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("reading sidecar dir: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+// TestClineInstall_DryRunWithHeadersCreatesNoSidecar locks in that --dry-run
+// is read-only across both the canonical config AND the operator-private
+// header sidecar dir. A dry-run that wrote a sidecar would leak the
+// operator's Authorization value to disk without their consent and would
+// also leave an orphan file the operator did not opt into.
+func TestClineInstall_DryRunWithHeadersCreatesNoSidecar(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path := writeClineFile(t, testClineHTTPConfigSecretHeader)
+
+	if err := runClineCmd(t, "install", "--path", path, "--dry-run"); err != nil {
+		t.Fatalf("install --dry-run failed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("re-read after dry-run: %v", err)
+	}
+	if string(got) != testClineHTTPConfigSecretHeader {
+		t.Error("dry-run modified the canonical config file")
+	}
+
+	if files := listSidecarFiles(t, home); len(files) > 0 {
+		t.Errorf("dry-run wrote sidecar(s) to disk: %v", files)
+	}
+}
+
+// TestClineRemove_DryRunPreservesSidecar locks in that --dry-run on remove
+// does NOT delete a wrapped server's header sidecar. A dry-run that deleted
+// the sidecar would put the agent into a broken state since the still-wrapped
+// argv references a --header-file path that no longer exists.
+func TestClineRemove_DryRunPreservesSidecar(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path := writeClineFile(t, testClineHTTPConfigSecretHeader)
+
+	// Install first so a real sidecar lands on disk.
+	if err := runClineCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	files := listSidecarFiles(t, home)
+	if len(files) != 1 {
+		t.Fatalf("expected one sidecar after install, got %d (%v)", len(files), files)
+	}
+	sidecarPath := filepath.Join(home, ".config", "pipelock", "wrap-headers", files[0])
+	sidecarBefore, err := os.ReadFile(filepath.Clean(sidecarPath))
+	if err != nil {
+		t.Fatalf("read sidecar before remove: %v", err)
+	}
+	cfgBefore, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// remove --dry-run must touch neither the canonical config nor the sidecar.
+	if err := runClineCmd(t, "remove", "--path", path, "--dry-run"); err != nil {
+		t.Fatalf("remove --dry-run failed: %v", err)
+	}
+
+	cfgAfter, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(cfgAfter, cfgBefore) {
+		t.Error("remove --dry-run modified the canonical config")
+	}
+
+	sidecarAfter, err := os.ReadFile(filepath.Clean(sidecarPath))
+	if err != nil {
+		t.Fatalf("remove --dry-run deleted the sidecar: %v", err)
+	}
+	if !bytes.Equal(sidecarAfter, sidecarBefore) {
+		t.Error("remove --dry-run mutated the sidecar contents")
+	}
+}

--- a/internal/cli/setup/vscode.go
+++ b/internal/cli/setup/vscode.go
@@ -4,15 +4,45 @@
 package setup
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 )
+
+// discoverConfigForWrap returns the configFile to pass into the wrapped MCP
+// proxy invocation. If the operator already supplied --config, that wins.
+// Otherwise we look for the standard pipelock config locations and embed the
+// first match in the wrapped argv. Without this auto-discovery the spawned
+// subprocess would load config.Defaults() which disables MCPInputScanning,
+// MCPToolScanning, MCPToolPolicy, and FlightRecorder, producing an install
+// that looks correct while silently scanning nothing.
+func discoverConfigForWrap(cmd *cobra.Command, configFile string) string {
+	if configFile != "" {
+		clean, err := filepath.Abs(filepath.Clean(configFile))
+		if err != nil {
+			return filepath.Clean(configFile)
+		}
+		return clean
+	}
+	if discovered := cliutil.DiscoverConfigPath(); discovered != "" {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Using config %s for the wrapped MCP proxy.\n", discovered)
+		return discovered
+	}
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
+		"warning: no pipelock config found at PIPELOCK_CONFIG, $XDG_CONFIG_HOME/pipelock/pipelock.yaml, ~/.config/pipelock/pipelock.yaml, or /etc/pipelock/pipelock.yaml. The wrapped MCP proxy will run with built-in defaults; MCP input scanning, tool scanning, tool policy, and the flight recorder are disabled in the defaults. Pass --config explicitly or place a config at one of the standard locations to enable scanning.")
+	return ""
+}
 
 // vscodeMCPConfig represents the VS Code .vscode/mcp.json file structure.
 // Top-level key is "servers" (not "mcpServers" like Cursor).
@@ -22,14 +52,82 @@ type vscodeMCPConfig struct {
 	Servers map[string]map[string]interface{} `json:"servers"`
 }
 
+// sidecarOp captures a deferred header-sidecar mutation produced by wrap or
+// unwrap. The wrap helpers are pure: they decide what the wrapped argv and
+// the metadata should contain, and they describe (but do not execute) the
+// header-sidecar write or delete that backs them. Callers accumulate these
+// ops during their wrap / unwrap loops. Install applies write ops immediately
+// before the canonical config rename and rolls them back if that rename fails;
+// remove applies delete ops only after the restored config is committed.
+// dry-run skips the apply step entirely.
+type sidecarOp struct {
+	// kind is "write" when install needs the sidecar created, or "delete"
+	// when remove needs it cleaned up.
+	kind string
+	// path is the deterministic sidecar file location.
+	path string
+	// body is the file content, only populated when kind == "write".
+	body []byte
+}
+
+// applySidecarOps performs the writes and deletes described by ops. On a
+// write failure it deletes any sidecars that were successfully written
+// earlier in the same call so callers never observe a partially-applied
+// plan. Delete ops are best-effort (absent paths return nil from
+// removeHeaderSidecar) so they cannot trigger the rollback path.
+func applySidecarOps(ops []sidecarOp) error {
+	written := make([]string, 0, len(ops))
+	for _, op := range ops {
+		switch op.kind {
+		case "write":
+			if err := commitHeaderSidecar(op.path, op.body); err != nil {
+				for _, p := range written {
+					removeHeaderSidecar(p)
+				}
+				return err
+			}
+			written = append(written, op.path)
+		case "delete":
+			removeHeaderSidecar(op.path)
+		}
+	}
+	return nil
+}
+
+// rollbackSidecarWrites deletes every sidecar referenced by a "write" op in
+// ops. Used when a later step (the canonical config atomic write) fails
+// after applySidecarOps has already landed sidecars on disk.
+func rollbackSidecarWrites(ops []sidecarOp) {
+	for _, op := range ops {
+		if op.kind == "write" {
+			removeHeaderSidecar(op.path)
+		}
+	}
+}
+
 // pipelockMeta stores original server config for unwrapping on remove.
+//
+// ArgsPresent distinguishes "source had an args field" from "source omitted
+// args entirely" so unwrap can restore `"args": []` byte-exact for sources
+// that declared it. Without it, an unwrap of a server seeded with empty args
+// would drop the field.
+//
+// HeaderSidecarPath, when set, points at the operator-private 0o600 file
+// the install wrote with the server's headers. The wrapped argv references
+// it via --header-file so credential values never appear in process argv
+// (visible via /proc/<pid>/cmdline). Remove deletes the sidecar.
+//
+// omitempty preserves backward compatibility with rosters wrapped before
+// these fields existed.
 type pipelockMeta struct {
-	OriginalType    string            `json:"original_type"`
-	TypeOmitted     bool              `json:"type_omitted,omitempty"`
-	OriginalCommand string            `json:"original_command,omitempty"`
-	OriginalArgs    []string          `json:"original_args,omitempty"`
-	OriginalURL     string            `json:"original_url,omitempty"`
-	OriginalHeaders map[string]string `json:"original_headers,omitempty"`
+	OriginalType      string            `json:"original_type"`
+	TypeOmitted       bool              `json:"type_omitted,omitempty"`
+	OriginalCommand   string            `json:"original_command,omitempty"`
+	OriginalArgs      []string          `json:"original_args,omitempty"`
+	ArgsPresent       bool              `json:"args_present,omitempty"`
+	OriginalURL       string            `json:"original_url,omitempty"`
+	OriginalHeaders   map[string]string `json:"original_headers,omitempty"`
+	HeaderSidecarPath string            `json:"header_sidecar_path,omitempty"`
 }
 
 func VscodeCmd() *cobra.Command {
@@ -161,6 +259,12 @@ func runVscodeInstall(cmd *cobra.Command, global, project, dryRun bool, configFi
 		return err
 	}
 
+	// Auto-discover the operator's pipelock.yaml when --config was not passed.
+	// Without this, the spawned MCP proxy loads config.Defaults() with MCP
+	// scanning and the flight recorder disabled — the wrap would look correct
+	// while silently providing no scanning. See discoverConfigForWrap below.
+	configFile = discoverConfigForWrap(cmd, configFile)
+
 	// Find pipelock binary path.
 	exe, err := os.Executable()
 	if err != nil {
@@ -192,13 +296,14 @@ func runVscodeInstall(cmd *cobra.Command, global, project, dryRun bool, configFi
 	// Wrap each server through pipelock.
 	wrapped := 0
 	skipped := 0
+	var sidecarOps []sidecarOp
 	for name, server := range mcpCfg.Servers {
 		if isVscodeWrapped(server) {
 			skipped++
 			continue
 		}
 
-		newServer, meta, err := wrapVscodeServer(server, exe, configFile)
+		newServer, meta, plan, err := wrapVscodeServer(server, exe, configFile, targetPath, name)
 		if err != nil {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: skipping server %q: %v\n", name, err)
 			continue
@@ -214,6 +319,9 @@ func runVscodeInstall(cmd *cobra.Command, global, project, dryRun bool, configFi
 		newServer["_pipelock"] = metaMap
 
 		mcpCfg.Servers[name] = newServer
+		if plan != nil {
+			sidecarOps = append(sidecarOps, *plan)
+		}
 		wrapped++
 	}
 
@@ -224,6 +332,10 @@ func runVscodeInstall(cmd *cobra.Command, global, project, dryRun bool, configFi
 	}
 
 	if dryRun {
+		// Dry-run is read-only end-to-end: do not write the canonical config
+		// AND do not write any sidecar file. The wrapped argv in the dry-run
+		// preview already references the deterministic sidecar path so the
+		// operator can see what would land where.
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Would write to %s (%d wrapped, %d already wrapped):\n%s", targetPath, wrapped, skipped, output)
 		return nil
 	}
@@ -241,8 +353,18 @@ func runVscodeInstall(cmd *cobra.Command, global, project, dryRun bool, configFi
 		}
 	}
 
-	// Atomic write.
+	// Sidecars are written FIRST so a sidecar failure leaves the operator's
+	// config untouched. applySidecarOps internally rolls back any partial
+	// writes if one of the writes fails partway through the plan.
+	if err := applySidecarOps(sidecarOps); err != nil {
+		return fmt.Errorf("writing header sidecar: %w", err)
+	}
+
+	// Atomic write of the canonical config. If this fails, the sidecars we
+	// just wrote would orphan to a config file that has no reference to
+	// them, so we clean them up before returning the error.
 	if err := vscodeAtomicWrite(targetPath, output, targetDir); err != nil {
+		rollbackSidecarWrites(sidecarOps)
 		return err
 	}
 
@@ -280,18 +402,22 @@ func runVscodeRemove(cmd *cobra.Command, global, project, dryRun bool) error {
 	}
 
 	unwrapped := 0
+	var sidecarOps []sidecarOp
 	for name, server := range mcpCfg.Servers {
 		if !isVscodeWrapped(server) {
 			continue
 		}
 
-		restored, err := unwrapVscodeServer(server)
+		restored, plan, err := unwrapVscodeServer(server)
 		if err != nil {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not unwrap %q: %v\n", name, err)
 			continue
 		}
 
 		mcpCfg.Servers[name] = restored
+		if plan != nil {
+			sidecarOps = append(sidecarOps, *plan)
+		}
 		unwrapped++
 	}
 
@@ -301,6 +427,8 @@ func runVscodeRemove(cmd *cobra.Command, global, project, dryRun bool) error {
 	}
 
 	if dryRun {
+		// Dry-run is read-only: do not write the restored config AND do not
+		// touch the sidecars referenced by the still-wrapped on-disk config.
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Would write to %s (%d unwrapped):\n%s", targetPath, unwrapped, output)
 		return nil
 	}
@@ -315,6 +443,11 @@ func runVscodeRemove(cmd *cobra.Command, global, project, dryRun bool) error {
 		return err
 	}
 
+	// Sidecars are deleted only after the restored config is committed to
+	// disk. A failure before this point leaves the wrapped config in place
+	// with its sidecars still readable, so the operator can retry.
+	_ = applySidecarOps(sidecarOps)
+
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Unwrapped %d server(s) in %s\n", unwrapped, targetPath)
 	if unwrapped > 0 {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Restart VS Code to apply changes.\n")
@@ -322,8 +455,12 @@ func runVscodeRemove(cmd *cobra.Command, global, project, dryRun bool) error {
 	return nil
 }
 
-// vsTypeStdio is the VS Code MCP server type for subprocess-based servers.
-const vsTypeStdio = "stdio"
+const (
+	// vsTypeStdio is the VS Code MCP server type for subprocess-based servers.
+	vsTypeStdio       = "stdio"
+	mcpFlagHeader     = "--header"
+	mcpFlagHeaderFile = "--header-file"
+)
 
 // isVscodeHTTPType returns true for server types that use URL-based upstream
 // (anything that is not stdio).
@@ -336,7 +473,19 @@ func isVscodeWrapped(server map[string]interface{}) bool {
 }
 
 // wrapVscodeServer wraps a single VS Code MCP server through pipelock mcp proxy.
-func wrapVscodeServer(server map[string]interface{}, exe, configFile string) (map[string]interface{}, *pipelockMeta, error) {
+// wrapVscodeServer wraps a single MCP server entry through pipelock mcp proxy.
+// targetConfigPath + serverName are used to derive the per-server 0o600 header
+// sidecar file when the entry carries an HTTP `headers` block; the wrapped
+// argv references it via --header-file so credential header values never
+// appear in /proc/<pid>/cmdline.
+//
+// The function is pure with respect to the file system: it computes the
+// sidecar path and body but does not write them. Callers receive a sidecarOp
+// (or nil) and decide when to apply it: install applies writes immediately
+// before the canonical config rename and rolls them back on rename failure;
+// remove applies deletes only after the restored config is committed; dry-run
+// skips the apply step entirely.
+func wrapVscodeServer(server map[string]interface{}, exe, configFile, targetConfigPath, serverName string) (map[string]interface{}, *pipelockMeta, *sidecarOp, error) {
 	serverType, _ := server["type"].(string)
 	typeOmitted := serverType == ""
 	if typeOmitted {
@@ -368,8 +517,9 @@ func wrapVscodeServer(server map[string]interface{}, exe, configFile string) (ma
 	if serverType == vsTypeStdio {
 		originalCmd, _ := server["command"].(string)
 		if originalCmd == "" {
-			return nil, nil, fmt.Errorf("stdio server missing command")
+			return nil, nil, nil, fmt.Errorf("stdio server missing command")
 		}
+		_, meta.ArgsPresent = server["args"]
 		originalArgs := interfaceSliceToStrings(server["args"])
 
 		meta.OriginalCommand = originalCmd
@@ -390,15 +540,33 @@ func wrapVscodeServer(server map[string]interface{}, exe, configFile string) (ma
 	} else if isVscodeHTTPType(serverType) {
 		originalURL, _ := server["url"].(string)
 		if originalURL == "" {
-			return nil, nil, fmt.Errorf("%s server missing url", serverType)
+			return nil, nil, nil, fmt.Errorf("%s server missing url", serverType)
 		}
 
 		meta.OriginalURL = originalURL
+		headerLines, err := extractHeaderLines(server)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		if headers, ok := server["headers"].(map[string]interface{}); ok {
 			meta.OriginalHeaders = make(map[string]string, len(headers))
 			for k, v := range headers {
 				meta.OriginalHeaders[k] = fmt.Sprint(v)
 			}
+		}
+		var (
+			sidecarFlags []string
+			plan         *sidecarOp
+		)
+		if len(headerLines) > 0 {
+			path, err := headerSidecarPath(targetConfigPath, serverName)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			body := []byte(strings.Join(headerLines, "\n") + "\n")
+			plan = &sidecarOp{kind: "write", path: path, body: body}
+			meta.HeaderSidecarPath = path
+			sidecarFlags = []string{mcpFlagHeaderFile, path}
 		}
 
 		args := []string{"mcp", "proxy"}
@@ -406,33 +574,45 @@ func wrapVscodeServer(server map[string]interface{}, exe, configFile string) (ma
 			args = append(args, "--config", configFile)
 		}
 		args = append(args, envFlags...)
+		args = append(args, sidecarFlags...)
 		args = append(args, "--upstream", originalURL)
 
 		result["type"] = vsTypeStdio
 		result["command"] = exe
 		result["args"] = args
+		return result, meta, plan, nil
 	} else {
-		return nil, nil, fmt.Errorf("unsupported server type %q", serverType)
+		return nil, nil, nil, fmt.Errorf("unsupported server type %q", serverType)
 	}
 
-	return result, meta, nil
+	return result, meta, nil, nil
 }
 
-// unwrapVscodeServer restores a server from its pipelock metadata.
-func unwrapVscodeServer(server map[string]interface{}) (map[string]interface{}, error) {
+// unwrapVscodeServer restores a server from its pipelock metadata. The
+// returned sidecarOp (when non-nil) describes a sidecar delete that the
+// caller MUST execute only after successfully writing the restored config to
+// disk; otherwise a marshal / atomic-write failure later in the remove path
+// would leave the still-wrapped config on disk while the credential carrier
+// it references is gone.
+func unwrapVscodeServer(server map[string]interface{}) (map[string]interface{}, *sidecarOp, error) {
 	metaRaw, ok := server["_pipelock"]
 	if !ok {
-		return server, nil
+		return server, nil, nil
 	}
 
 	// Marshal and unmarshal to get a typed struct.
 	metaJSON, err := json.Marshal(metaRaw)
 	if err != nil {
-		return nil, fmt.Errorf("reading _pipelock metadata: %w", err)
+		return nil, nil, fmt.Errorf("reading _pipelock metadata: %w", err)
 	}
 	var meta pipelockMeta
 	if err := json.Unmarshal(metaJSON, &meta); err != nil {
-		return nil, fmt.Errorf("parsing _pipelock metadata: %w", err)
+		return nil, nil, fmt.Errorf("parsing _pipelock metadata: %w", err)
+	}
+
+	var plan *sidecarOp
+	if meta.HeaderSidecarPath != "" {
+		plan = &sidecarOp{kind: "delete", path: meta.HeaderSidecarPath}
 	}
 
 	result := make(map[string]interface{})
@@ -451,13 +631,13 @@ func unwrapVscodeServer(server map[string]interface{}) (map[string]interface{}, 
 	switch meta.OriginalType {
 	case vsTypeStdio:
 		if meta.OriginalCommand == "" {
-			return nil, fmt.Errorf("invalid _pipelock metadata: missing original_command")
+			return nil, nil, fmt.Errorf("invalid _pipelock metadata: missing original_command")
 		}
 	case "":
-		return nil, fmt.Errorf("invalid _pipelock metadata: missing original_type")
+		return nil, nil, fmt.Errorf("invalid _pipelock metadata: missing original_type")
 	default:
 		if meta.OriginalURL == "" {
-			return nil, fmt.Errorf("invalid _pipelock metadata: missing original_url for %s server", meta.OriginalType)
+			return nil, nil, fmt.Errorf("invalid _pipelock metadata: missing original_url for %s server", meta.OriginalType)
 		}
 	}
 
@@ -469,7 +649,17 @@ func unwrapVscodeServer(server map[string]interface{}) (map[string]interface{}, 
 	switch meta.OriginalType {
 	case vsTypeStdio:
 		result["command"] = meta.OriginalCommand
-		if len(meta.OriginalArgs) > 0 {
+		// Restore args if the source had the field (new metadata) or if the
+		// stored args are non-empty (legacy metadata that lacked ArgsPresent).
+		// A source that had `"args": []` round-trips byte-exact via ArgsPresent.
+		switch {
+		case meta.ArgsPresent:
+			if meta.OriginalArgs != nil {
+				result["args"] = meta.OriginalArgs
+			} else {
+				result["args"] = []string{}
+			}
+		case len(meta.OriginalArgs) > 0:
 			result["args"] = meta.OriginalArgs
 		}
 	default:
@@ -483,7 +673,7 @@ func unwrapVscodeServer(server map[string]interface{}) (map[string]interface{}, 
 		}
 	}
 
-	return result, nil
+	return result, plan, nil
 }
 
 // buildEnvFlags extracts env var keys from a server's "env" block and returns
@@ -500,6 +690,194 @@ func buildEnvFlags(server map[string]interface{}) []string {
 		flags = append(flags, "--env", key)
 	}
 	return flags
+}
+
+// extractHeaderLines reads, validates, and returns the operator's HTTP header
+// declarations as "Key: Value" lines ready for a sidecar file. The runtime
+// parser repeats these checks at startup; doing them here means a bad header
+// fails install rather than surfacing only after the agent starts. Returns
+// nil when the server has no headers block.
+func extractHeaderLines(server map[string]interface{}) ([]string, error) {
+	headers, ok := server["headers"].(map[string]interface{})
+	if !ok || len(headers) == 0 {
+		return nil, nil
+	}
+
+	lines := make([]string, 0, len(headers))
+	for key, raw := range headers {
+		value, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("header %q has non-string value of type %T; only string header values are supported", key, raw)
+		}
+		key = strings.Trim(key, " \t")
+		value = strings.Trim(value, " \t")
+		if err := validateSetupHeader(key, value); err != nil {
+			return nil, err
+		}
+		lines = append(lines, key+": "+value)
+	}
+	// Deterministic ordering so the sidecar file is stable across reinstalls
+	// even when Go's map iteration order shifts.
+	sort.Strings(lines)
+	return lines, nil
+}
+
+// headerSidecarDir returns the operator-private directory where the install
+// command writes header sidecar files. Operator-private (0o700) so other
+// local users cannot read credential headers, even with /proc visibility.
+func headerSidecarDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("finding home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "pipelock", "wrap-headers"), nil
+}
+
+// headerSidecarPath returns the absolute path of the sidecar file for the
+// given (target IDE config, server name) pair. The hash of the absolute
+// config path keeps sidecars from different IDE installations from colliding
+// on a shared server name (e.g. two Cline configs both declaring "remote").
+// The hash of the raw server name keeps names that sanitize to the same path
+// component (e.g. "prod/api" and "prod_api") from sharing one sidecar.
+func headerSidecarPath(targetConfigPath, serverName string) (string, error) {
+	dir, err := headerSidecarDir()
+	if err != nil {
+		return "", err
+	}
+	abs, err := filepath.Abs(filepath.Clean(targetConfigPath))
+	if err != nil {
+		return "", fmt.Errorf("resolving config path for sidecar: %w", err)
+	}
+	configSum := sha256.Sum256([]byte(abs))
+	configPrefix := hex.EncodeToString(configSum[:])[:16]
+	serverSum := sha256.Sum256([]byte(serverName))
+	serverPrefix := hex.EncodeToString(serverSum[:])[:16]
+	safeName := sanitizeSidecarComponent(serverName)
+	if len(safeName) > 80 {
+		safeName = safeName[:80]
+	}
+	return filepath.Join(dir, configPrefix+"-"+serverPrefix+"-"+safeName+".headers"), nil
+}
+
+// sanitizeSidecarComponent strips characters that have meaning in path
+// segments so an attacker-named MCP server cannot redirect the sidecar
+// elsewhere. Replace anything outside [A-Za-z0-9._-] with '_'.
+func sanitizeSidecarComponent(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "_"
+	}
+	return b.String()
+}
+
+// commitHeaderSidecar atomically writes a sidecar body to path at 0o600
+// under a 0o700 parent. This is the side-effecting half of the sidecar
+// lifecycle; the deciding half is done by the wrap helpers, which produce
+// a sidecarOp plan. Install applies writes before the canonical config rename
+// and rolls them back if that rename fails; remove applies deletes only after
+// the restored config is committed.
+func commitHeaderSidecar(path string, body []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating sidecar dir %s: %w", dir, err)
+	}
+	// Re-tighten the parent in case it pre-existed with a looser mode.
+	// gosec G302 fires on the 0o700 directory mode because it treats the rule
+	// as file-only; directories need the execute bit to be enterable.
+	if err := os.Chmod(dir, 0o700); err != nil { //nolint:gosec // 0o700 is correct for a private directory
+		return fmt.Errorf("locking down sidecar dir %s: %w", dir, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".headers-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating sidecar temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(body); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("writing sidecar temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("closing sidecar temp file: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("setting sidecar permissions: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("renaming sidecar into place: %w", err)
+	}
+	return nil
+}
+
+// removeHeaderSidecar deletes the sidecar file. Best-effort; absent paths
+// or already-deleted files are not surfaced as errors.
+func removeHeaderSidecar(path string) {
+	if path == "" {
+		return
+	}
+	_ = os.Remove(filepath.Clean(path))
+}
+
+func validateSetupHeader(key, value string) error {
+	if key == "" {
+		return fmt.Errorf("header key is empty")
+	}
+	if !validSetupHeaderName(key) {
+		return fmt.Errorf("header %q has invalid characters", key)
+	}
+	switch strings.ToLower(key) {
+	case "content-type", "accept", "mcp-session-id", "content-length", "transfer-encoding", "host":
+		return fmt.Errorf("header %q is managed by the MCP HTTP transport and cannot be passed through", key)
+	}
+	if !validSetupHeaderValue(value) {
+		return fmt.Errorf("header %q has invalid value characters", key)
+	}
+	return nil
+}
+
+func validSetupHeaderName(key string) bool {
+	for _, r := range key {
+		if r > 127 || !isSetupHTTPTokenChar(byte(r)) {
+			return false
+		}
+	}
+	return true
+}
+
+func isSetupHTTPTokenChar(c byte) bool {
+	if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' {
+		return true
+	}
+	switch c {
+	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+		return true
+	default:
+		return false
+	}
+}
+
+func validSetupHeaderValue(value string) bool {
+	for _, r := range value {
+		if r > 127 || r == 0x7f || (r < 0x20 && r != '\t') {
+			return false
+		}
+	}
+	return true
 }
 
 // interfaceSliceToStrings converts []interface{} (from JSON unmarshal) to []string.

--- a/internal/cli/setup/vscode.go
+++ b/internal/cli/setup/vscode.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 
@@ -315,7 +316,9 @@ func runVscodeInstall(cmd *cobra.Command, global, project, dryRun bool, configFi
 			return fmt.Errorf("marshaling metadata for %q: %w", name, err)
 		}
 		var metaMap interface{}
-		_ = json.Unmarshal(metaJSON, &metaMap)
+		if err := json.Unmarshal(metaJSON, &metaMap); err != nil {
+			return fmt.Errorf("unmarshaling metadata for %q: %w", name, err)
+		}
 		newServer["_pipelock"] = metaMap
 
 		mcpCfg.Servers[name] = newServer
@@ -551,7 +554,11 @@ func wrapVscodeServer(server map[string]interface{}, exe, configFile, targetConf
 		if headers, ok := server["headers"].(map[string]interface{}); ok {
 			meta.OriginalHeaders = make(map[string]string, len(headers))
 			for k, v := range headers {
-				meta.OriginalHeaders[k] = fmt.Sprint(v)
+				value, ok := v.(string)
+				if !ok {
+					return nil, nil, nil, fmt.Errorf("header %q has non-string value of type %T; only string header values are supported", k, v)
+				}
+				meta.OriginalHeaders[k] = value
 			}
 		}
 		var (
@@ -612,7 +619,11 @@ func unwrapVscodeServer(server map[string]interface{}) (map[string]interface{}, 
 
 	var plan *sidecarOp
 	if meta.HeaderSidecarPath != "" {
-		plan = &sidecarOp{kind: "delete", path: meta.HeaderSidecarPath}
+		path, err := validatedHeaderSidecarDeletePath(meta.HeaderSidecarPath)
+		if err != nil {
+			return nil, nil, err
+		}
+		plan = &sidecarOp{kind: "delete", path: path}
 	}
 
 	result := make(map[string]interface{})
@@ -759,6 +770,55 @@ func headerSidecarPath(targetConfigPath, serverName string) (string, error) {
 	return filepath.Join(dir, configPrefix+"-"+serverPrefix+"-"+safeName+".headers"), nil
 }
 
+func validatedHeaderSidecarDeletePath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("invalid _pipelock metadata: header sidecar path must be absolute")
+	}
+	if !strings.HasSuffix(filepath.Base(path), ".headers") {
+		return "", fmt.Errorf("invalid _pipelock metadata: header sidecar path must end in .headers")
+	}
+	dir, err := headerSidecarDir()
+	if err != nil {
+		return "", err
+	}
+	cleanDir, err := filepath.Abs(filepath.Clean(dir))
+	if err != nil {
+		return "", fmt.Errorf("resolving header sidecar dir: %w", err)
+	}
+	cleanPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", fmt.Errorf("resolving header sidecar path: %w", err)
+	}
+	if !pathWithinDir(cleanDir, cleanPath) {
+		return "", fmt.Errorf("invalid _pipelock metadata: header sidecar path escapes %s", cleanDir)
+	}
+
+	resolvedDir := cleanDir
+	if realDir, err := filepath.EvalSymlinks(cleanDir); err == nil {
+		resolvedDir = realDir
+	}
+	if realPath, err := filepath.EvalSymlinks(cleanPath); err == nil {
+		if !pathWithinDir(resolvedDir, realPath) {
+			return "", fmt.Errorf("invalid _pipelock metadata: header sidecar path resolves outside %s", resolvedDir)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("resolving header sidecar path symlinks: %w", err)
+	}
+
+	return cleanPath, nil
+}
+
+func pathWithinDir(dir, path string) bool {
+	rel, err := filepath.Rel(dir, path)
+	if err != nil || rel == "." || rel == "" {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
 // sanitizeSidecarComponent strips characters that have meaning in path
 // segments so an attacker-named MCP server cannot redirect the sidecar
 // elsewhere. Replace anything outside [A-Za-z0-9._-] with '_'.
@@ -873,7 +933,13 @@ func isSetupHTTPTokenChar(c byte) bool {
 
 func validSetupHeaderValue(value string) bool {
 	for _, r := range value {
-		if r > 127 || r == 0x7f || (r < 0x20 && r != '\t') {
+		if r == '\t' || r == ' ' {
+			continue
+		}
+		if r < 0x20 || r == 0x7f {
+			return false
+		}
+		if r > 127 && unicode.IsSpace(r) {
 			return false
 		}
 	}

--- a/internal/cli/setup/vscode_test.go
+++ b/internal/cli/setup/vscode_test.go
@@ -958,6 +958,102 @@ func TestUnwrapVscodeServer_HTTPWithHeaders(t *testing.T) {
 	}
 }
 
+func TestUnwrapVscodeServer_HeaderSidecarDeletePathValidated(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sidecarPath, err := headerSidecarPath(filepath.Join(home, ".vscode", "mcp.json"), "remote")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := map[string]interface{}{
+		"type":    vsTypeStdio,
+		"command": "/usr/bin/pipelock",
+		"args":    []interface{}{"mcp", "proxy", "--header-file", sidecarPath, "--upstream", testExampleURL},
+		"_pipelock": map[string]interface{}{
+			"original_type":       testTypeHTTP,
+			"original_url":        testExampleURL,
+			"header_sidecar_path": sidecarPath,
+		},
+	}
+
+	_, plan, err := unwrapVscodeServer(server)
+	if err != nil {
+		t.Fatalf("unwrapVscodeServer: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("expected sidecar delete plan")
+	}
+	if plan.kind != "delete" {
+		t.Errorf("plan.kind = %q, want delete", plan.kind)
+	}
+	if plan.path != sidecarPath {
+		t.Errorf("plan.path = %q, want %q", plan.path, sidecarPath)
+	}
+}
+
+func TestUnwrapVscodeServer_RejectsEscapingHeaderSidecarPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	outside := filepath.Join(home, "victim.headers")
+
+	server := map[string]interface{}{
+		"_pipelock": map[string]interface{}{
+			"original_type":       testTypeHTTP,
+			"original_url":        testExampleURL,
+			"header_sidecar_path": outside,
+		},
+	}
+
+	_, _, err := unwrapVscodeServer(server)
+	if err == nil {
+		t.Fatal("expected escaping header sidecar path to be rejected")
+	}
+	if !strings.Contains(err.Error(), "escapes") {
+		t.Fatalf("unwrap error = %q, want escape rejection", err.Error())
+	}
+}
+
+func TestUnwrapVscodeServer_RejectsSymlinkEscapingHeaderSidecarPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir, err := headerSidecarDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(home, "outside")
+	if err := os.MkdirAll(outside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	escapedPath := filepath.Join(link, "victim.headers")
+	if err := os.WriteFile(escapedPath, []byte("X-Test: value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	server := map[string]interface{}{
+		"_pipelock": map[string]interface{}{
+			"original_type":       testTypeHTTP,
+			"original_url":        testExampleURL,
+			"header_sidecar_path": escapedPath,
+		},
+	}
+
+	_, _, err = unwrapVscodeServer(server)
+	if err == nil {
+		t.Fatal("expected symlink-escaping header sidecar path to be rejected")
+	}
+	if !strings.Contains(err.Error(), "resolves outside") {
+		t.Fatalf("unwrap error = %q, want symlink escape rejection", err.Error())
+	}
+}
+
 func TestUnwrapVscodeServer_StdioNoArgs(t *testing.T) {
 	// Stdio server with no original args should not have args after unwrap.
 	server := map[string]interface{}{
@@ -1606,6 +1702,93 @@ func TestHeaderSidecarPath_DistinguishesSanitizedNameCollisions(t *testing.T) {
 	}
 	if len(filepath.Base(longPath)) > 128 {
 		t.Fatalf("sidecar filename too long: %d bytes (%q)", len(filepath.Base(longPath)), filepath.Base(longPath))
+	}
+}
+
+func TestValidatedHeaderSidecarDeletePath_FailClosedBranches(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir, err := headerSidecarDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	inside := filepath.Join(dir, "valid.headers")
+
+	got, err := validatedHeaderSidecarDeletePath("")
+	if err != nil {
+		t.Fatalf("empty path returned error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("empty path = %q, want empty", got)
+	}
+
+	for _, tt := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "relative rejected",
+			path: filepath.Join("relative", "valid.headers"),
+			want: "must be absolute",
+		},
+		{
+			name: "wrong suffix rejected",
+			path: filepath.Join(dir, "valid.txt"),
+			want: "must end in .headers",
+		},
+		{
+			name: "sidecar dir itself rejected",
+			path: dir,
+			want: "must end in .headers",
+		},
+		{
+			name: "parent escape rejected",
+			path: filepath.Join(dir, "..", "victim.headers"),
+			want: "escapes",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := validatedHeaderSidecarDeletePath(tt.path); err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("validatedHeaderSidecarDeletePath(%q) err = %v, want containing %q", tt.path, err, tt.want)
+			}
+		})
+	}
+
+	got, err = validatedHeaderSidecarDeletePath(inside)
+	if err != nil {
+		t.Fatalf("inside missing path returned error: %v", err)
+	}
+	if got != inside {
+		t.Fatalf("inside missing path = %q, want %q", got, inside)
+	}
+
+	if pathWithinDir(dir, dir) {
+		t.Fatal("pathWithinDir accepted the directory itself")
+	}
+}
+
+func TestExtractHeaderLines_ValueValidationMatchesRuntime(t *testing.T) {
+	server := map[string]interface{}{
+		"headers": map[string]interface{}{
+			"X-Display-Name": "Cafe\u00e9",
+		},
+	}
+	lines, err := extractHeaderLines(server)
+	if err != nil {
+		t.Fatalf("extractHeaderLines accepted runtime-valid non-ASCII value: %v", err)
+	}
+	if len(lines) != 1 || lines[0] != "X-Display-Name: Cafe\u00e9" {
+		t.Fatalf("extractHeaderLines = %v, want non-ASCII header line", lines)
+	}
+
+	server = map[string]interface{}{
+		"headers": map[string]interface{}{
+			"X-Display-Name": "Cafe\u2003hidden",
+		},
+	}
+	if _, err := extractHeaderLines(server); err == nil {
+		t.Fatal("expected unicode whitespace in header value to be rejected")
 	}
 }
 

--- a/internal/cli/setup/vscode_test.go
+++ b/internal/cli/setup/vscode_test.go
@@ -4,19 +4,23 @@
 package setup
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 const (
-	testOriginalCmd = "npx"
-	testTypeHTTP    = "http" // VS Code MCP server type for HTTP upstream
-	testTypeStdio   = "stdio"
-	testExampleURL  = "https://api.example.com/mcp"
-	testNodeCmd     = "node"
-	testBearerTok   = "Bearer " + "vs-tok"
+	testOriginalCmd    = "npx"
+	testTypeHTTP       = "http" // VS Code MCP server type for HTTP upstream
+	testTypeStdio      = "stdio"
+	testExampleURL     = "https://api.example.com/mcp"
+	testNodeCmd        = "node"
+	testBearerTok      = "Bearer " + "vs-tok" // retained for the secret-rejection test below
+	testWorkspaceHdr   = "X-Workspace-Id"
+	testWorkspaceValue = "ws-vs-tok"
 
 	testStdioConfig = `{
   "servers": {
@@ -34,7 +38,7 @@ const (
     "remote": {
       "type": "http",
       "url": "https://api.example.com/mcp",
-      "headers": { "Authorization": "Bearer vs-tok" }
+      "headers": { "X-Workspace-Id": "ws-vs-tok" }
     }
   }
 }`
@@ -77,6 +81,18 @@ const (
   }
 }`
 )
+
+// testHTTPConfigSecretHeader is built at init to keep gosec G101 from
+// flagging the fixture as a hardcoded credential. The token value is split.
+var testHTTPConfigSecretHeader = `{
+  "servers": {
+    "remote": {
+      "type": "http",
+      "url": "https://api.example.com/mcp",
+      "headers": { "Authorization": "` + testBearerTok + `" }
+    }
+  }
+}`
 
 func TestVscodeInstall_DryRun(t *testing.T) {
 	dir := t.TempDir()
@@ -192,6 +208,7 @@ func TestVscodeInstall_StdioServer(t *testing.T) {
 }
 
 func TestVscodeInstall_HTTPServer(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	dir := t.TempDir()
 	vsDir := filepath.Join(dir, ".vscode")
 	if err := os.MkdirAll(vsDir, 0o750); err != nil {
@@ -241,6 +258,29 @@ func TestVscodeInstall_HTTPServer(t *testing.T) {
 	if !foundUpstream {
 		t.Error("--upstream not found in args")
 	}
+	// Header values now travel via a 0o600 sidecar referenced through
+	// --header-file, never in argv. The wrapped argv must not contain the
+	// header value; the sidecar file must contain the "Key: Value" line.
+	sidecarPath := ""
+	for i, a := range args {
+		if a == mcpFlagHeaderFile && i+1 < len(args) {
+			sidecarPath = args[i+1]
+			break
+		}
+	}
+	if sidecarPath == "" {
+		t.Fatalf("wrapped argv missing --header-file flag: %v", args)
+	}
+	if hasAdjacentArg(args, mcpFlagHeader, testWorkspaceHdr+": "+testWorkspaceValue) {
+		t.Errorf("header value leaked into argv via --header; sidecar must be the only carrier")
+	}
+	body, err := os.ReadFile(filepath.Clean(sidecarPath))
+	if err != nil {
+		t.Fatalf("read sidecar: %v", err)
+	}
+	if !strings.Contains(string(body), testWorkspaceHdr+": "+testWorkspaceValue) {
+		t.Errorf("sidecar missing %q line: %q", testWorkspaceHdr, body)
+	}
 
 	// Metadata should store original type and URL.
 	metaRaw, ok := server["_pipelock"]
@@ -258,7 +298,7 @@ func TestVscodeInstall_HTTPServer(t *testing.T) {
 	if meta.OriginalURL != testExampleURL {
 		t.Errorf("expected original URL, got %q", meta.OriginalURL)
 	}
-	if meta.OriginalHeaders["Authorization"] != testBearerTok {
+	if meta.OriginalHeaders[testWorkspaceHdr] != testWorkspaceValue {
 		t.Errorf("expected original headers preserved, got %v", meta.OriginalHeaders)
 	}
 }
@@ -569,6 +609,42 @@ func TestVscodeInstall_WithConfig(t *testing.T) {
 	}
 }
 
+func TestVscodeInstall_WithRelativeConfigPersistsAbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	vsDir := filepath.Join(dir, ".vscode")
+	if err := os.MkdirAll(vsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(vsDir, "mcp.json"), []byte(testStdioConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "relative.yaml"), []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	chdirTemp(t, dir)
+
+	cmd := VscodeCmd()
+	cmd.SetArgs([]string{"install", "--project", "--config", "relative.yaml"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install with relative --config failed: %v", err)
+	}
+
+	data, readErr := os.ReadFile(filepath.Clean(filepath.Join(vsDir, "mcp.json")))
+	var cfg vscodeMCPConfig
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	args := interfaceSliceToStrings(cfg.Servers["my-server"]["args"])
+	if !hasAdjacentArg(args, "--config", filepath.Join(dir, "relative.yaml")) {
+		t.Errorf("relative --config was not persisted as absolute path: %v", args)
+	}
+}
+
 func TestVscodeInstall_SpacedExecutablePath(t *testing.T) {
 	// Verify that command field contains the raw path, not shell-quoted.
 	server := map[string]interface{}{
@@ -578,7 +654,7 @@ func TestVscodeInstall_SpacedExecutablePath(t *testing.T) {
 	}
 
 	exePath := "/path with spaces/to/pipelock"
-	wrapped, _, err := wrapVscodeServer(server, exePath, "")
+	wrapped, _, _, err := wrapVscodeServer(server, exePath, "", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -708,7 +784,7 @@ func TestWrapVscodeServer_MissingCommand(t *testing.T) {
 		"type": testTypeStdio,
 		// No command field.
 	}
-	_, _, err := wrapVscodeServer(server, "/usr/bin/pipelock", "")
+	_, _, _, err := wrapVscodeServer(server, "/usr/bin/pipelock", "", "", "")
 	if err == nil {
 		t.Error("expected error for stdio server missing command")
 	}
@@ -719,9 +795,96 @@ func TestWrapVscodeServer_MissingURL(t *testing.T) {
 		"type": testTypeHTTP,
 		// No url field.
 	}
-	_, _, err := wrapVscodeServer(server, "/usr/bin/pipelock", "")
+	_, _, _, err := wrapVscodeServer(server, "/usr/bin/pipelock", "", "", "")
 	if err == nil {
 		t.Error("expected error for http server missing url")
+	}
+}
+
+// TestVscodeInstall_SecretHeaderRoutesThroughSidecar locks in that install
+// accepts credential-bearing headers because the values land in a 0o600
+// sidecar file referenced via --header-file, not in the wrapped argv. The
+// wrapped argv carries the sidecar path; the sidecar contents carry the
+// `Authorization: Bearer ...` line.
+func TestVscodeInstall_SecretHeaderRoutesThroughSidecar(t *testing.T) {
+	dir := t.TempDir()
+	vsDir := filepath.Join(dir, ".vscode")
+	if err := os.MkdirAll(vsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(vsDir, "mcp.json"), []byte(testHTTPConfigSecretHeader), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Sidecar dir lives under HOME; point it at a tempdir so the assertion
+	// can read the sidecar back without touching the operator's real config.
+	t.Setenv("HOME", dir)
+
+	cmd := VscodeCmd()
+	cmd.SetArgs([]string{"install", "--project"})
+	chdirTemp(t, dir)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install with credential header should succeed via sidecar, got: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(filepath.Join(vsDir, "mcp.json")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg vscodeMCPConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	entry := cfg.Servers["remote"]
+	if _, wrapped := entry["_pipelock"]; !wrapped {
+		t.Fatal("entry must be wrapped via the sidecar path")
+	}
+	args := interfaceSliceToStrings(entry["args"])
+
+	// Wrapped argv must NOT contain the credential value anywhere.
+	for _, a := range args {
+		if strings.Contains(a, testBearerTok) {
+			t.Fatalf("credential value leaked into wrapped argv: %v", args)
+		}
+		if strings.EqualFold(a, "Authorization") {
+			t.Fatalf("Authorization header name leaked into wrapped argv as a flag value: %v", args)
+		}
+	}
+
+	// Wrapped argv must reference the sidecar file via --header-file.
+	sidecarPath := ""
+	for i, a := range args {
+		if a == mcpFlagHeaderFile && i+1 < len(args) {
+			sidecarPath = args[i+1]
+			break
+		}
+	}
+	if sidecarPath == "" {
+		t.Fatalf("wrapped argv missing --header-file flag: %v", args)
+	}
+
+	// Sidecar must be 0o600 and contain the credential line.
+	info, err := os.Stat(sidecarPath)
+	if err != nil {
+		t.Fatalf("sidecar not written at %s: %v", sidecarPath, err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("sidecar mode = %04o, want 0o600", info.Mode().Perm())
+	}
+	body, err := os.ReadFile(filepath.Clean(sidecarPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "Authorization: "+testBearerTok) {
+		t.Errorf("sidecar content missing the Authorization line: %q", body)
+	}
+
+	// Sidecar dir must be 0o700 so other local users cannot enumerate.
+	dirInfo, err := os.Stat(filepath.Dir(sidecarPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dirInfo.Mode().Perm() != 0o700 {
+		t.Errorf("sidecar dir mode = %04o, want 0o700", dirInfo.Mode().Perm())
 	}
 }
 
@@ -730,7 +893,7 @@ func TestWrapVscodeServer_SSEType(t *testing.T) {
 		"type": "sse",
 		"url":  "https://example.com/sse",
 	}
-	wrapped, meta, err := wrapVscodeServer(server, "/usr/bin/pipelock", "")
+	wrapped, meta, _, err := wrapVscodeServer(server, "/usr/bin/pipelock", "", "", "")
 	if err != nil {
 		t.Fatalf("wrap sse failed: %v", err)
 	}
@@ -748,7 +911,7 @@ func TestUnwrapVscodeServer_NoMeta(t *testing.T) {
 		"type":    testTypeStdio,
 		"command": testNodeCmd,
 	}
-	result, err := unwrapVscodeServer(server)
+	result, _, err := unwrapVscodeServer(server)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -772,7 +935,7 @@ func TestUnwrapVscodeServer_HTTPWithHeaders(t *testing.T) {
 		},
 	}
 
-	result, err := unwrapVscodeServer(server)
+	result, _, err := unwrapVscodeServer(server)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -807,7 +970,7 @@ func TestUnwrapVscodeServer_StdioNoArgs(t *testing.T) {
 		},
 	}
 
-	result, err := unwrapVscodeServer(server)
+	result, _, err := unwrapVscodeServer(server)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1055,7 +1218,7 @@ func TestUnwrapVscodeServer_InvalidMeta_MissingCommand(t *testing.T) {
 			// Missing original_command.
 		},
 	}
-	_, err := unwrapVscodeServer(server)
+	_, _, err := unwrapVscodeServer(server)
 	if err == nil {
 		t.Error("expected error for missing original_command")
 	}
@@ -1068,7 +1231,7 @@ func TestUnwrapVscodeServer_InvalidMeta_MissingURL(t *testing.T) {
 			// Missing original_url.
 		},
 	}
-	_, err := unwrapVscodeServer(server)
+	_, _, err := unwrapVscodeServer(server)
 	if err == nil {
 		t.Error("expected error for missing original_url")
 	}
@@ -1080,7 +1243,7 @@ func TestUnwrapVscodeServer_InvalidMeta_MissingType(t *testing.T) {
 			// Missing original_type entirely.
 		},
 	}
-	_, err := unwrapVscodeServer(server)
+	_, _, err := unwrapVscodeServer(server)
 	if err == nil {
 		t.Error("expected error for missing original_type")
 	}
@@ -1248,7 +1411,7 @@ func TestWrapVscodeServer_PreservesExtraFields(t *testing.T) {
 		"sandboxEnabled": true,
 		"envFile":        "${workspaceFolder}/.env",
 	}
-	wrapped, _, err := wrapVscodeServer(server, "/usr/bin/pipelock", "")
+	wrapped, _, _, err := wrapVscodeServer(server, "/usr/bin/pipelock", "", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1286,5 +1449,272 @@ func TestVscodeAtomicWrite_OverwriteExisting(t *testing.T) {
 	}
 	if string(got) != string(newData) {
 		t.Errorf("overwrite failed: got %q, want %q", string(got), string(newData))
+	}
+}
+
+// listVscodeSidecarFiles returns entries in the sidecar dir under home, or
+// nil if the dir is absent. Tests use this to assert dry-run never lands a
+// sidecar on disk.
+func listVscodeSidecarFiles(t *testing.T, home string) []string {
+	t.Helper()
+	dir := filepath.Join(home, ".config", "pipelock", "wrap-headers")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("reading sidecar dir: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+// TestVscodeInstall_DryRunWithHeadersCreatesNoSidecar locks in that --dry-run
+// is read-only across both the canonical config AND the operator-private
+// header sidecar dir. A dry-run that wrote a sidecar would leak the
+// operator's Authorization value to disk without their consent.
+func TestVscodeInstall_DryRunWithHeadersCreatesNoSidecar(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := t.TempDir()
+	vsDir := filepath.Join(dir, ".vscode")
+	if err := os.MkdirAll(vsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(vsDir, "mcp.json")
+	if err := os.WriteFile(cfgPath, []byte(testHTTPConfigSecretHeader), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	chdirTemp(t, dir)
+
+	cmd := VscodeCmd()
+	cmd.SetArgs([]string{"install", "--project", "--dry-run"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install --dry-run failed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Clean(cfgPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != testHTTPConfigSecretHeader {
+		t.Error("dry-run modified the canonical config file")
+	}
+
+	if files := listVscodeSidecarFiles(t, home); len(files) > 0 {
+		t.Errorf("dry-run wrote sidecar(s) to disk: %v", files)
+	}
+}
+
+// TestVscodeRemove_DryRunPreservesSidecar locks in that --dry-run on remove
+// does NOT delete a wrapped server's header sidecar. A dry-run that deleted
+// the sidecar would put the agent into a broken state since the still-wrapped
+// argv references a --header-file path that no longer exists.
+func TestVscodeRemove_DryRunPreservesSidecar(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := t.TempDir()
+	vsDir := filepath.Join(dir, ".vscode")
+	if err := os.MkdirAll(vsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(vsDir, "mcp.json")
+	if err := os.WriteFile(cfgPath, []byte(testHTTPConfigSecretHeader), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	chdirTemp(t, dir)
+
+	// Install first so a real sidecar lands on disk.
+	installCmd := VscodeCmd()
+	installCmd.SetArgs([]string{"install", "--project"})
+	if err := installCmd.Execute(); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	files := listVscodeSidecarFiles(t, home)
+	if len(files) != 1 {
+		t.Fatalf("expected one sidecar after install, got %d (%v)", len(files), files)
+	}
+	sidecarPath := filepath.Join(home, ".config", "pipelock", "wrap-headers", files[0])
+	sidecarBefore, err := os.ReadFile(filepath.Clean(sidecarPath))
+	if err != nil {
+		t.Fatalf("read sidecar before remove: %v", err)
+	}
+	cfgBefore, err := os.ReadFile(filepath.Clean(cfgPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// remove --dry-run must touch neither the canonical config nor the sidecar.
+	removeCmd := VscodeCmd()
+	removeCmd.SetArgs([]string{"remove", "--project", "--dry-run"})
+	if err := removeCmd.Execute(); err != nil {
+		t.Fatalf("remove --dry-run failed: %v", err)
+	}
+
+	cfgAfter, err := os.ReadFile(filepath.Clean(cfgPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(cfgAfter, cfgBefore) {
+		t.Error("remove --dry-run modified the canonical config")
+	}
+
+	sidecarAfter, err := os.ReadFile(filepath.Clean(sidecarPath))
+	if err != nil {
+		t.Fatalf("remove --dry-run deleted the sidecar: %v", err)
+	}
+	if !bytes.Equal(sidecarAfter, sidecarBefore) {
+		t.Error("remove --dry-run mutated the sidecar contents")
+	}
+}
+
+// TestHeaderSidecarPath_DistinguishesSanitizedNameCollisions locks in that
+// attacker-controlled server names cannot collide after path-component
+// sanitization. Without the raw-name hash, "prod/api" and "prod_api" would
+// share one sidecar path and whichever install wrote last would determine the
+// headers used by both wrapped servers.
+func TestHeaderSidecarPath_DistinguishesSanitizedNameCollisions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configPath := filepath.Join(home, ".cline", "mcp.json")
+
+	slashed, err := headerSidecarPath(configPath, "prod/api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	underscored, err := headerSidecarPath(configPath, "prod_api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slashed == underscored {
+		t.Fatalf("sanitized server-name collision produced one sidecar path: %s", slashed)
+	}
+	if strings.Contains(filepath.Base(slashed), "/") || strings.Contains(filepath.Base(underscored), "/") {
+		t.Fatalf("sidecar filename contains a path separator: %q / %q", filepath.Base(slashed), filepath.Base(underscored))
+	}
+
+	longName := strings.Repeat("a", 512)
+	longPath, err := headerSidecarPath(configPath, longName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filepath.Base(longPath)) > 128 {
+		t.Fatalf("sidecar filename too long: %d bytes (%q)", len(filepath.Base(longPath)), filepath.Base(longPath))
+	}
+}
+
+// TestApplySidecarOps_RollsBackOnPartialWriteFailure locks in that a sidecar
+// write plan is atomic from the caller's perspective: if any write in the
+// plan fails, every previously-written sidecar from the same plan is
+// removed before the error returns. Without this guarantee, a multi-server
+// install could leave operator credentials on disk for servers whose wrap
+// completed before a later server's wrap failed.
+func TestApplySidecarOps_RollsBackOnPartialWriteFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	first, err := headerSidecarPath(filepath.Join(home, "a", "mcp.json"), "first")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second op writes through /dev/null/, which is not a directory. The
+	// write will fail when commitHeaderSidecar tries os.MkdirAll on the
+	// parent. /dev/null/ is platform-stable enough for the test's purposes
+	// (every supported pipelock dev OS treats /dev/null as a character
+	// device, not a directory).
+	impossible := "/dev/null/wrap-headers/second.headers"
+
+	ops := []sidecarOp{
+		{kind: "write", path: first, body: []byte("X-One: a\n")},
+		{kind: "write", path: impossible, body: []byte("X-Two: b\n")},
+	}
+
+	if err := applySidecarOps(ops); err == nil {
+		_ = os.Remove(first)
+		t.Fatal("expected applySidecarOps to fail on the second (impossible) write")
+	}
+
+	if _, statErr := os.Stat(first); !os.IsNotExist(statErr) {
+		t.Errorf("first sidecar was not rolled back after later failure: stat err=%v", statErr)
+	}
+}
+
+// TestApplySidecarOps_DeletesNeverRollBackWrites covers the asymmetric path
+// in applySidecarOps: delete ops are best-effort and a missing file is not
+// an error, so they can never trigger the rollback path. A "delete" before a
+// successful "write" must leave the written sidecar in place.
+func TestApplySidecarOps_DeletesNeverRollBackWrites(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	deletePath, err := headerSidecarPath(filepath.Join(home, "a", "mcp.json"), "delete-target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writePath, err := headerSidecarPath(filepath.Join(home, "b", "mcp.json"), "write-target")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ops := []sidecarOp{
+		{kind: "delete", path: deletePath},
+		{kind: "write", path: writePath, body: []byte("X: 1\n")},
+	}
+
+	if err := applySidecarOps(ops); err != nil {
+		t.Fatalf("applySidecarOps: %v", err)
+	}
+
+	body, err := os.ReadFile(filepath.Clean(writePath))
+	if err != nil {
+		t.Fatalf("expected the write to survive a preceding noop delete: %v", err)
+	}
+	if string(body) != "X: 1\n" {
+		t.Errorf("write payload mismatch: got %q", body)
+	}
+}
+
+// TestRollbackSidecarWrites_DeletesAllWrites locks in that the rollback
+// helper invoked when the canonical config write fails removes every
+// sidecar from the plan, leaving no orphaned credential files behind.
+func TestRollbackSidecarWrites_DeletesAllWrites(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	one, err := headerSidecarPath(filepath.Join(home, "a", "mcp.json"), "one")
+	if err != nil {
+		t.Fatal(err)
+	}
+	two, err := headerSidecarPath(filepath.Join(home, "b", "mcp.json"), "two")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ops := []sidecarOp{
+		{kind: "write", path: one, body: []byte("X-One: a\n")},
+		{kind: "write", path: two, body: []byte("X-Two: b\n")},
+	}
+	if err := applySidecarOps(ops); err != nil {
+		t.Fatalf("seed applySidecarOps: %v", err)
+	}
+	for _, p := range []string{one, two} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("seed sidecar missing: %v", err)
+		}
+	}
+
+	rollbackSidecarWrites(ops)
+
+	for _, p := range []string{one, two} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("sidecar %q survived rollback (err=%v)", p, err)
+		}
 	}
 }

--- a/internal/cliutil/config.go
+++ b/internal/cliutil/config.go
@@ -5,6 +5,8 @@ package cliutil
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 )
@@ -20,4 +22,45 @@ func LoadConfigOrDefault(path string) (*config.Config, error) {
 		return cfg, nil
 	}
 	return config.Defaults(), nil
+}
+
+// DiscoverConfigPath returns the first config file pipelock would naturally
+// look at, or empty string if none of the candidates exist. Search order
+// mirrors the systemd unit and CLI convention:
+//
+//  1. $PIPELOCK_CONFIG (operator override)
+//  2. $XDG_CONFIG_HOME/pipelock/pipelock.yaml
+//  3. ~/.config/pipelock/pipelock.yaml
+//  4. /etc/pipelock/pipelock.yaml
+//
+// Returns the absolute path on first hit and the empty string when nothing
+// is found. Callers decide how to react to the empty-string return — for
+// instance, the IDE install commands embed the discovered path into the
+// wrapped argv so the spawned subprocess loads the same config as the
+// operator's main pipelock service.
+func DiscoverConfigPath() string {
+	candidates := []string{}
+
+	if env := os.Getenv("PIPELOCK_CONFIG"); env != "" {
+		candidates = append(candidates, env)
+	}
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		candidates = append(candidates, filepath.Join(xdg, "pipelock", "pipelock.yaml"))
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		candidates = append(candidates, filepath.Join(home, ".config", "pipelock", "pipelock.yaml"))
+	}
+	candidates = append(candidates, "/etc/pipelock/pipelock.yaml")
+
+	for _, c := range candidates {
+		clean, err := filepath.Abs(filepath.Clean(c))
+		if err != nil {
+			continue
+		}
+		info, err := os.Stat(clean)
+		if err == nil && info.Mode().IsRegular() {
+			return clean
+		}
+	}
+	return ""
 }

--- a/internal/cliutil/config_test.go
+++ b/internal/cliutil/config_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package cliutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDiscoverConfigPath_PipelockConfigEnvWins exercises the highest-priority
+// candidate so an operator override always beats the standard locations.
+func TestDiscoverConfigPath_PipelockConfigEnvWins(t *testing.T) {
+	dir := t.TempDir()
+	override := filepath.Join(dir, "override.yaml")
+	if err := os.WriteFile(override, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", override)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "/dev/null")
+
+	got := DiscoverConfigPath()
+	if got != override {
+		t.Errorf("PIPELOCK_CONFIG override not honored: got %q, want %q", got, override)
+	}
+}
+
+// TestDiscoverConfigPath_PipelockConfigEnvReturnsAbsolute prevents IDE
+// wrappers from persisting a relative --config path that later resolves
+// against the IDE's working directory rather than the install-time directory.
+func TestDiscoverConfigPath_PipelockConfigEnvReturnsAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldwd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("relative.yaml", []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", "relative.yaml")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "/dev/null")
+
+	want := filepath.Join(dir, "relative.yaml")
+	got := DiscoverConfigPath()
+	if got != want {
+		t.Errorf("relative PIPELOCK_CONFIG not made absolute: got %q, want %q", got, want)
+	}
+}
+
+// TestDiscoverConfigPath_XDGFallback exercises the XDG_CONFIG_HOME branch
+// when no operator override is set.
+func TestDiscoverConfigPath_XDGFallback(t *testing.T) {
+	dir := t.TempDir()
+	xdgDir := filepath.Join(dir, "xdg")
+	pipelockDir := filepath.Join(xdgDir, "pipelock")
+	if err := os.MkdirAll(pipelockDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	cfg := filepath.Join(pipelockDir, "pipelock.yaml")
+	if err := os.WriteFile(cfg, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv("HOME", "/dev/null")
+
+	got := DiscoverConfigPath()
+	if got != cfg {
+		t.Errorf("XDG fallback not honored: got %q, want %q", got, cfg)
+	}
+}
+
+// TestDiscoverConfigPath_HomeFallback exercises the legacy ~/.config branch.
+func TestDiscoverConfigPath_HomeFallback(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".config", "pipelock")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	cfg := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfg, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", home)
+
+	got := DiscoverConfigPath()
+	if got != cfg {
+		t.Errorf("HOME fallback not honored: got %q, want %q", got, cfg)
+	}
+}
+
+// TestDiscoverConfigPath_NoMatch returns the empty string when every
+// candidate is absent rather than guessing or returning an arbitrary
+// nonexistent path the caller cannot use.
+func TestDiscoverConfigPath_NoMatch(t *testing.T) {
+	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	got := DiscoverConfigPath()
+	if got != "" {
+		t.Errorf("expected empty string when no candidate exists, got %q", got)
+	}
+}
+
+// TestDiscoverConfigPath_NonRegularRejected ensures that a directory at the
+// candidate path does not get returned as a config file.
+func TestDiscoverConfigPath_NonRegularRejected(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".config", "pipelock")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// Create a DIRECTORY at the expected pipelock.yaml path.
+	if err := os.MkdirAll(filepath.Join(dir, "pipelock.yaml"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", home)
+
+	got := DiscoverConfigPath()
+	if got != "" {
+		t.Errorf("non-regular candidate must not be returned, got %q", got)
+	}
+}

--- a/internal/integrity/check_test.go
+++ b/internal/integrity/check_test.go
@@ -1152,3 +1152,18 @@ func TestGenerate_WalkError(t *testing.T) {
 		t.Fatal("expected error for unreadable subdirectory")
 	}
 }
+
+// TestMatchDoublestar_PatternWithoutStars covers the early-return branch
+// that fires when a caller passes a pattern that lacks the "**" wildcard.
+// strings.SplitN with no occurrence returns a single-element slice; the
+// function must refuse to match rather than treat the whole pattern as a
+// prefix. Other matchDoublestar tests only exercise patterns that already
+// contain "**".
+func TestMatchDoublestar_PatternWithoutStars(t *testing.T) {
+	if matchDoublestar("plain-pattern", "plain-pattern") {
+		t.Error("matchDoublestar must reject patterns with no '**' wildcard")
+	}
+	if matchDoublestar("dir/file.txt", "dir/file.txt") {
+		t.Error("matchDoublestar must reject literal path patterns")
+	}
+}

--- a/internal/signing/coverage_boost_test.go
+++ b/internal/signing/coverage_boost_test.go
@@ -5,9 +5,13 @@ package signing
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
 )
 
 // --- atomicWrite coverage tests (61.9% -> higher) ---
@@ -373,5 +377,83 @@ func TestKeystore_ListAgents(t *testing.T) {
 	// Should be sorted.
 	if agents[0] != "alpha" || agents[1] != "bravo" || agents[2] != "charlie" {
 		t.Errorf("agents not sorted: %v", agents)
+	}
+}
+
+// --- DefaultKeystorePath error-branch coverage ---
+
+// TestDefaultKeystorePath_NoHome exercises the os.UserHomeDir error branch
+// by emptying HOME. Go's os.UserHomeDir on Unix returns an error when HOME
+// is unset or empty, which is exactly the production failure mode this
+// branch is meant to surface.
+func TestDefaultKeystorePath_NoHome(t *testing.T) {
+	t.Setenv("HOME", "")
+
+	got, err := DefaultKeystorePath()
+	if err == nil {
+		t.Fatalf("expected error when HOME is empty, got path=%q", got)
+	}
+	if got != "" {
+		t.Errorf("expected empty path on error, got %q", got)
+	}
+}
+
+// --- LoadPublicKey + LoadPrivateKeyFile error-branch coverage ---
+
+// TestLoadPublicKey_EmptyInput covers the early reject branch where the
+// caller supplies an empty or whitespace-only input. Without this guard,
+// downstream filepath.Clean and ParsePublicKey would receive a degenerate
+// value and produce a less informative error.
+func TestLoadPublicKey_EmptyInput(t *testing.T) {
+	for _, input := range []string{"", "   ", "\t\n"} {
+		if _, err := LoadPublicKey(input); err == nil {
+			t.Errorf("expected error for input %q, got nil", input)
+		}
+	}
+}
+
+// TestLoadPrivateKeyFile_NonexistentPath covers the filepath.EvalSymlinks
+// error branch. The path is operator-supplied, so the wrap-cleanly check
+// is worth pinning.
+func TestLoadPrivateKeyFile_NonexistentPath(t *testing.T) {
+	dir := t.TempDir()
+	_, err := LoadPrivateKeyFile(filepath.Join(dir, "does-not-exist"))
+	if err == nil {
+		t.Fatal("expected error for nonexistent private key path")
+	}
+	if !strings.Contains(err.Error(), "reading private key") {
+		t.Errorf("error should wrap 'reading private key', got: %v", err)
+	}
+}
+
+// --- findRootKey wrong-status branch coverage ---
+
+// TestFindRootKey_KeyIDMatchesButStatusNotRoot exercises the inner reject
+// branch where the roster body's RosterSignedBy points at a key that exists
+// but is marked active (or anything other than root). Findroot must reject
+// even though the key_id matches, because an attacker who manages to flip
+// a runtime key's status field could otherwise hijack root-only operations.
+func TestFindRootKey_KeyIDMatchesButStatusNotRoot(t *testing.T) {
+	body := contract.KeyRoster{
+		SchemaVersion:  1,
+		RosterSignedBy: "test-key-id",
+		Keys: []contract.KeyInfo{
+			{
+				KeyID:        "test-key-id",
+				KeyPurpose:   string(PurposeRosterRoot),
+				PublicKeyHex: testRosterPubHex,
+				ValidFrom:    testRosterValidFrom,
+				Status:       contract.KeyStatusActive, // wrong status
+			},
+		},
+		DataClassRoot: testRosterDataClass,
+	}
+
+	_, err := findRootKey(body)
+	if err == nil {
+		t.Fatal("expected error when matched key has wrong status, got nil")
+	}
+	if !errors.Is(err, ErrRosterRootMissing) {
+		t.Errorf("expected ErrRosterRootMissing, got %v", err)
 	}
 }

--- a/scripts/e2e/cline-install.sh
+++ b/scripts/e2e/cline-install.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# E2E test for `pipelock cline install` and `pipelock cline remove`.
+#
+# Exercises the full install flow against the installed pipelock binary:
+#   1. Seed a fixture cline_mcp_settings.json with one stdio server and
+#      one HTTP server with an Authorization header.
+#   2. Run `pipelock cline install --path <fixture>`.
+#   3. Assert wrapped argv structure: command=<pipelock>, args start with
+#      "mcp proxy", "--env" present for env-bearing stdio, "--header" present
+#      for header-bearing HTTP, "--upstream <url>" terminates HTTP wrap,
+#      "--" terminates stdio wrap.
+#   4. Assert _pipelock metadata is recorded and TypeOmitted=true for both
+#      typeless Cline entries.
+#   5. Spawn the wrapped stdio server invocation as a subprocess, send a
+#      minimal JSON-RPC initialize, confirm the subprocess accepts stdin
+#      and exits cleanly when stdin closes.
+#   6. Assert .bak backup matches the seed file.
+#   7. Run `pipelock cline remove --path <fixture>`.
+#   8. Assert the restored config matches the seed file byte-for-byte.
+#
+# Usage: bash tests/e2e/cline-install.sh
+# Exit:  0 if all assertions pass, 1 on first failure.
+
+set -euo pipefail
+
+# Resolve the repo root from this script's location so the build always uses
+# the same source tree the script ships with. Override PIPELOCK_BIN to skip
+# the build and use a pre-existing binary, but it must include the cline
+# subcommand or the structural assertions will fail.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKDIR="${WORKDIR:-$(mktemp -d -t pipelock-cline-e2e-XXXXXX)}"
+CONFIG="$WORKDIR/cline_mcp_settings.json"
+SEED="$WORKDIR/cline_mcp_settings.seed.json"
+
+if [[ -n "${PIPELOCK_BIN:-}" ]]; then
+  PIPELOCK="$PIPELOCK_BIN"
+else
+  PIPELOCK="$WORKDIR/pipelock"
+  echo "Building pipelock from $REPO_ROOT into $PIPELOCK ..."
+  (cd "$REPO_ROOT" && go build -o "$PIPELOCK" ./cmd/pipelock)
+fi
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+# Cleanup on exit.
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# assert <description> <command>: runs the command, records pass/fail.
+assert() {
+  local desc="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    PASS=$((PASS + 1))
+    echo "  PASS  $desc"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("$desc")
+    echo "  FAIL  $desc"
+  fi
+}
+
+# require_jq verifies jq is present; the script depends on it for structural
+# assertions.
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq is required for this test" >&2
+    exit 1
+  fi
+}
+
+# require_binary verifies the pipelock binary exists and is executable.
+require_binary() {
+  if [[ ! -x "$PIPELOCK" ]]; then
+    echo "ERROR: pipelock binary not found at $PIPELOCK" >&2
+    echo "Set PIPELOCK_BIN to override." >&2
+    exit 1
+  fi
+}
+
+# seed_config writes a fixture config with one stdio server and one HTTP
+# server with an Authorization header. Cline omits the type field on both.
+seed_config() {
+  cat >"$SEED" <<'EOF'
+{
+  "mcpServers": {
+    "fixture-stdio": {
+      "command": "cat",
+      "args": [],
+      "env": {
+        "FIXTURE_VAR": "value"
+      }
+    },
+    "fixture-http": {
+      "url": "https://fixture.invalid/mcp",
+      "headers": {
+        "Authorization": "Bearer fixture-token"
+      }
+    }
+  }
+}
+EOF
+  cp "$SEED" "$CONFIG"
+}
+
+echo "=== pipelock cline install E2E ==="
+echo "Binary:  $PIPELOCK"
+echo "Workdir: $WORKDIR"
+echo ""
+
+require_jq
+require_binary
+seed_config
+
+echo "[1] install"
+# Suppress pipelock config auto-discovery so this script remains hermetic and
+# does not pick up the operator's $HOME pipelock.yaml. Operators get
+# auto-discovery; the test asserts the no-discovery warning instead.
+PIPELOCK_CONFIG="" XDG_CONFIG_HOME="$WORKDIR/empty-xdg" HOME="$WORKDIR/empty-home" \
+  "$PIPELOCK" cline install --path "$CONFIG" >"$WORKDIR/install.stdout" 2>"$WORKDIR/install.stderr"
+assert "install exit 0" test -s "$WORKDIR/install.stdout"
+assert "install stdout reports 2 wrapped" grep -q "Wrapped 2 server(s)" "$WORKDIR/install.stdout"
+assert "install stderr warns when no pipelock config is discoverable" \
+  grep -q "no pipelock config found" "$WORKDIR/install.stderr"
+
+# Second install pass exercises the auto-discovery branch against a seeded
+# user config in a controlled HOME. The wrapped argv must carry --config.
+echo ""
+echo "[1b] install honors auto-discovery"
+DISCOVER_HOME="$WORKDIR/discover-home"
+mkdir -p "$DISCOVER_HOME/.config/pipelock"
+echo "mode: balanced" >"$DISCOVER_HOME/.config/pipelock/pipelock.yaml"
+DISCOVER_CFG="$WORKDIR/discover-cline.json"
+cp "$SEED" "$DISCOVER_CFG"
+PIPELOCK_CONFIG="" XDG_CONFIG_HOME="" HOME="$DISCOVER_HOME" \
+  "$PIPELOCK" cline install --path "$DISCOVER_CFG" >"$WORKDIR/install-discover.stdout" 2>"$WORKDIR/install-discover.stderr"
+assert "install-discover stderr notes the discovered config" \
+  grep -q "Using config $DISCOVER_HOME/.config/pipelock/pipelock.yaml" "$WORKDIR/install-discover.stderr"
+assert "install-discover stdio args carry --config" \
+  bash -c "jq -e '.mcpServers[\"fixture-stdio\"].args | index(\"--config\") as \$i | .[\$i+1] == \"$DISCOVER_HOME/.config/pipelock/pipelock.yaml\"' '$DISCOVER_CFG'"
+assert "install-discover http args carry --config" \
+  bash -c "jq -e '.mcpServers[\"fixture-http\"].args | index(\"--config\") as \$i | .[\$i+1] == \"$DISCOVER_HOME/.config/pipelock/pipelock.yaml\"' '$DISCOVER_CFG'"
+
+echo ""
+echo "[2] structural assertions on wrapped config"
+
+# Both entries should have _pipelock metadata.
+assert "stdio entry carries _pipelock metadata" \
+  bash -c "jq -e '.mcpServers[\"fixture-stdio\"]._pipelock' '$CONFIG'"
+assert "http entry carries _pipelock metadata" \
+  bash -c "jq -e '.mcpServers[\"fixture-http\"]._pipelock' '$CONFIG'"
+
+# Both entries should declare type=stdio (so Cline launches pipelock).
+assert "wrapped stdio entry type=stdio" \
+  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"].type' '$CONFIG') == 'stdio' ]]"
+assert "wrapped http entry type=stdio" \
+  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-http\"].type' '$CONFIG') == 'stdio' ]]"
+
+# Stdio entry: command = pipelock binary path, args starts with "mcp proxy".
+assert "stdio command points at pipelock" \
+  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"].command' '$CONFIG') == '$PIPELOCK' ]] || \
+           [[ \$(jq -r '.mcpServers[\"fixture-stdio\"].command' '$CONFIG') == \$(readlink -f '$PIPELOCK') ]]"
+assert "stdio args[0]=mcp" \
+  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"].args[0]' '$CONFIG') == 'mcp' ]]"
+assert "stdio args[1]=proxy" \
+  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"].args[1]' '$CONFIG') == 'proxy' ]]"
+
+# Stdio entry: --env FIXTURE_VAR passthrough is present.
+assert "stdio carries --env FIXTURE_VAR passthrough" \
+  bash -c "jq -e '.mcpServers[\"fixture-stdio\"].args | index(\"--env\") as \$i | .[\$i+1] == \"FIXTURE_VAR\"' '$CONFIG'"
+
+# Stdio entry: -- separator precedes the original command.
+assert "stdio carries -- separator before original command" \
+  bash -c "jq -e '.mcpServers[\"fixture-stdio\"].args | index(\"--\") as \$i | .[\$i+1] == \"cat\"' '$CONFIG'"
+
+# HTTP entry: --header-file carries the path to a 0o600 sidecar; the
+# Authorization value lives in the sidecar file, never in argv.
+assert "http carries --header-file flag with a sidecar path" \
+  bash -c "jq -e '.mcpServers[\"fixture-http\"].args | index(\"--header-file\") as \$i | (.[\$i+1] | type) == \"string\" and (.[\$i+1] | length) > 0' '$CONFIG'"
+
+SIDECAR_PATH=$(jq -r '.mcpServers["fixture-http"].args as $a | $a | index("--header-file") as $i | $a[$i+1]' "$CONFIG")
+assert "sidecar file exists at the path embedded in argv" test -f "$SIDECAR_PATH"
+assert "sidecar mode is 0o600" \
+  bash -c "[[ \$(stat -c '%a' '$SIDECAR_PATH') == '600' ]]"
+assert "sidecar contains the Authorization header line" \
+  grep -q "Authorization: Bearer fixture-token" "$SIDECAR_PATH"
+assert "wrapped argv does NOT contain the Authorization header value" \
+  bash -c "! jq -e '.mcpServers[\"fixture-http\"].args | any(. == \"Authorization: Bearer fixture-token\")' '$CONFIG' >/dev/null 2>&1"
+assert "_pipelock metadata records the sidecar path" \
+  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-http\"]._pipelock.header_sidecar_path' '$CONFIG') == '$SIDECAR_PATH' ]]"
+
+# HTTP entry: --upstream carries the original URL.
+assert "http carries --upstream original-url" \
+  bash -c "jq -e '.mcpServers[\"fixture-http\"].args | index(\"--upstream\") as \$i | .[\$i+1] == \"https://fixture.invalid/mcp\"' '$CONFIG'"
+
+# Both metadata entries: TypeOmitted=true (Cline omits type field).
+assert "stdio metadata TypeOmitted=true" \
+  bash -c "jq -e '.mcpServers[\"fixture-stdio\"]._pipelock.type_omitted == true' '$CONFIG'"
+assert "http metadata TypeOmitted=true" \
+  bash -c "jq -e '.mcpServers[\"fixture-http\"]._pipelock.type_omitted == true' '$CONFIG'"
+
+# Backup matches the seed file.
+assert "install wrote .bak matching seed" cmp -s "$SEED" "$CONFIG.bak"
+
+echo ""
+echo "[3] runtime: spawn wrapped stdio invocation, send initialize, expect clean exit"
+
+# Extract the wrapped argv for the stdio entry and reconstruct the command.
+WRAPPED_CMD=$(jq -r '.mcpServers["fixture-stdio"].command' "$CONFIG")
+mapfile -t WRAPPED_ARGS < <(jq -r '.mcpServers["fixture-stdio"].args[]' "$CONFIG")
+
+# Build a minimal JSON-RPC initialize request matching MCP 2025-06-18.
+INIT_REQ='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"cline-e2e","version":"0"}}}'
+
+# Spawn with a short timeout; pipelock should print at least one line of
+# output (initialize response or scan-related notice) and exit when stdin
+# closes after our single request.
+printf '%s\n' "$INIT_REQ" | timeout 5 "$WRAPPED_CMD" "${WRAPPED_ARGS[@]}" >"$WORKDIR/proxy.stdout" 2>"$WORKDIR/proxy.stderr" || true
+
+assert "proxy produced stdout or stderr output (didn't crash immediately)" \
+  bash -c "[[ -s '$WORKDIR/proxy.stdout' ]] || [[ -s '$WORKDIR/proxy.stderr' ]]"
+
+# Confirm the binary at least recognised the cline-install-shaped args
+# (cobra parse error would be in stderr, immediate help text). Either a
+# JSON response on stdout (proxy actually forwarded) or an mcp-related
+# message on stderr (proxy initialized then child exited) is acceptable;
+# what we are rejecting here is "unknown command" or "unknown flag" output.
+assert "wrapped argv parses without cobra error" \
+  bash -c "! grep -qE 'unknown command|unknown flag|invalid argument' '$WORKDIR/proxy.stderr'"
+
+echo ""
+echo "[4] remove and restore"
+
+"$PIPELOCK" cline remove --path "$CONFIG" >"$WORKDIR/remove.stdout" 2>"$WORKDIR/remove.stderr"
+assert "remove exit 0" test -s "$WORKDIR/remove.stdout"
+assert "remove stdout reports 2 unwrapped" grep -q "Unwrapped 2 server(s)" "$WORKDIR/remove.stdout"
+
+# Order-of-keys equivalence: parse both, compare as canonical JSON.
+assert "post-remove config equals seed (canonical JSON compare)" \
+  bash -c "diff <(jq -S . '$SEED') <(jq -S . '$CONFIG')"
+
+# Per-server fields should be exactly what the seed had: no leftover
+# _pipelock, no leftover type=stdio, original env/headers/url back.
+assert "stdio entry restored: no leftover _pipelock" \
+  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"]._pipelock // \"absent\"' '$CONFIG') == 'absent' ]]"
+assert "stdio entry restored: no leftover type field" \
+  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"].type // \"absent\"' '$CONFIG') == 'absent' ]]"
+assert "stdio entry restored: command back to 'cat'" \
+  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"].command' '$CONFIG') == 'cat' ]]"
+assert "stdio entry restored: env block intact" \
+  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"].env.FIXTURE_VAR' '$CONFIG') == 'value' ]]"
+
+assert "http entry restored: no leftover type field" \
+  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-http\"].type // \"absent\"' '$CONFIG') == 'absent' ]]"
+assert "http entry restored: url back" \
+  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-http\"].url' '$CONFIG') == 'https://fixture.invalid/mcp' ]]"
+assert "http entry restored: Authorization header back" \
+  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-http\"].headers.Authorization' '$CONFIG') == 'Bearer fixture-token' ]]"
+
+echo ""
+echo "[5] idempotence: re-run install on already-installed config (no double-wrap)"
+
+# Re-run install on the (restored) config; should wrap both servers exactly
+# once. Then re-run on the wrapped config; should skip both.
+"$PIPELOCK" cline install --path "$CONFIG" >/dev/null 2>&1
+"$PIPELOCK" cline install --path "$CONFIG" >"$WORKDIR/install2.stdout" 2>&1
+assert "second install skipped both servers" grep -q "Wrapped 0 server(s).*(2 already wrapped)" "$WORKDIR/install2.stdout"
+
+echo ""
+echo "=== Summary ==="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  echo ""
+  echo "Failed assertions:"
+  for t in "${FAILED_TESTS[@]}"; do
+    echo "  - $t"
+  done
+  exit 1
+fi
+
+exit 0

--- a/scripts/e2e/cline-install.sh
+++ b/scripts/e2e/cline-install.sh
@@ -29,7 +29,63 @@ set -euo pipefail
 # subcommand or the structural assertions will fail.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-WORKDIR="${WORKDIR:-$(mktemp -d -t pipelock-cline-e2e-XXXXXX)}"
+OWNED_WORKDIR=""
+
+validate_workdir() {
+  local dir="$1"
+
+  if [[ -z "$dir" || "$dir" == "/" ]]; then
+    echo "ERROR: refusing unsafe WORKDIR: ${dir:-<empty>}" >&2
+    exit 1
+  fi
+  if [[ -n "${HOME:-}" && -d "$HOME" ]]; then
+    local home_dir
+    home_dir="$(cd "$HOME" && pwd -P)"
+    if [[ "$dir" == "$home_dir" ]]; then
+      echo "ERROR: refusing WORKDIR equal to HOME: $dir" >&2
+      exit 1
+    fi
+  fi
+  if [[ "$dir" == "$REPO_ROOT" ]]; then
+    echo "ERROR: refusing WORKDIR equal to repository root: $dir" >&2
+    exit 1
+  fi
+}
+
+if [[ -n "${WORKDIR:-}" ]]; then
+  mkdir -p "$WORKDIR"
+  WORKDIR="$(cd "$WORKDIR" && pwd -P)"
+  validate_workdir "$WORKDIR"
+  WORKDIR_OWNED=0
+else
+  WORKDIR="$(mktemp -d -t pipelock-cline-e2e-XXXXXX)"
+  WORKDIR="$(cd "$WORKDIR" && pwd -P)"
+  validate_workdir "$WORKDIR"
+  OWNED_WORKDIR="$WORKDIR"
+  WORKDIR_OWNED=1
+fi
+
+cleanup() {
+  if [[ "$WORKDIR_OWNED" != "1" || -z "$OWNED_WORKDIR" ]]; then
+    return
+  fi
+
+  local tmp_base
+  tmp_base="$(cd "${TMPDIR:-/tmp}" && pwd -P)"
+  local owned_prefix
+  if [[ "$tmp_base" == "/" ]]; then
+    owned_prefix="/pipelock-cline-e2e-"
+  else
+    owned_prefix="$tmp_base/pipelock-cline-e2e-"
+  fi
+  if [[ "$OWNED_WORKDIR" == "$owned_prefix"* ]]; then
+    rm -rf -- "$OWNED_WORKDIR"
+  else
+    echo "WARNING: refusing to remove unexpected WORKDIR: $OWNED_WORKDIR" >&2
+  fi
+}
+trap cleanup EXIT
+
 CONFIG="$WORKDIR/cline_mcp_settings.json"
 SEED="$WORKDIR/cline_mcp_settings.seed.json"
 
@@ -44,9 +100,6 @@ fi
 PASS=0
 FAIL=0
 FAILED_TESTS=()
-
-# Cleanup on exit.
-trap 'rm -rf "$WORKDIR"' EXIT
 
 # assert <description> <command>: runs the command, records pass/fail.
 assert() {

--- a/scripts/e2e/cline-install.sh
+++ b/scripts/e2e/cline-install.sh
@@ -115,6 +115,38 @@ assert() {
   fi
 }
 
+json_value_equals() {
+  local file="$1"
+  local filter="$2"
+  local expected="$3"
+  local actual
+  actual="$(jq -r "$filter" "$file")"
+  [[ "$actual" == "$expected" ]]
+}
+
+stdio_command_points_at_pipelock() {
+  local actual
+  actual="$(jq -r '.mcpServers["fixture-stdio"].command' "$CONFIG")"
+  [[ "$actual" == "$PIPELOCK" || "$actual" == "$(readlink -f "$PIPELOCK")" ]]
+}
+
+mode_is_600() {
+  local path="$1"
+  [[ "$(stat -c '%a' "$path")" == "600" ]]
+}
+
+proxy_output_exists() {
+  [[ -s "$WORKDIR/proxy.stdout" || -s "$WORKDIR/proxy.stderr" ]]
+}
+
+wrapped_argv_has_no_cobra_error() {
+  ! grep -qE 'unknown command|unknown flag|invalid argument' "$WORKDIR/proxy.stderr"
+}
+
+canonical_json_matches() {
+  diff <(jq -S . "$SEED") <(jq -S . "$CONFIG")
+}
+
 # require_jq verifies jq is present; the script depends on it for structural
 # assertions.
 require_jq() {
@@ -192,67 +224,68 @@ PIPELOCK_CONFIG="" XDG_CONFIG_HOME="" HOME="$DISCOVER_HOME" \
 assert "install-discover stderr notes the discovered config" \
   grep -q "Using config $DISCOVER_HOME/.config/pipelock/pipelock.yaml" "$WORKDIR/install-discover.stderr"
 assert "install-discover stdio args carry --config" \
-  bash -c "jq -e '.mcpServers[\"fixture-stdio\"].args | index(\"--config\") as \$i | .[\$i+1] == \"$DISCOVER_HOME/.config/pipelock/pipelock.yaml\"' '$DISCOVER_CFG'"
+  jq -e --arg expected "$DISCOVER_HOME/.config/pipelock/pipelock.yaml" \
+    '.mcpServers["fixture-stdio"].args | index("--config") as $i | .[$i+1] == $expected' "$DISCOVER_CFG"
 assert "install-discover http args carry --config" \
-  bash -c "jq -e '.mcpServers[\"fixture-http\"].args | index(\"--config\") as \$i | .[\$i+1] == \"$DISCOVER_HOME/.config/pipelock/pipelock.yaml\"' '$DISCOVER_CFG'"
+  jq -e --arg expected "$DISCOVER_HOME/.config/pipelock/pipelock.yaml" \
+    '.mcpServers["fixture-http"].args | index("--config") as $i | .[$i+1] == $expected' "$DISCOVER_CFG"
 
 echo ""
 echo "[2] structural assertions on wrapped config"
 
 # Both entries should have _pipelock metadata.
 assert "stdio entry carries _pipelock metadata" \
-  bash -c "jq -e '.mcpServers[\"fixture-stdio\"]._pipelock' '$CONFIG'"
+  jq -e '.mcpServers["fixture-stdio"]._pipelock' "$CONFIG"
 assert "http entry carries _pipelock metadata" \
-  bash -c "jq -e '.mcpServers[\"fixture-http\"]._pipelock' '$CONFIG'"
+  jq -e '.mcpServers["fixture-http"]._pipelock' "$CONFIG"
 
 # Both entries should declare type=stdio (so Cline launches pipelock).
 assert "wrapped stdio entry type=stdio" \
-  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"].type' '$CONFIG') == 'stdio' ]]"
+  json_value_equals "$CONFIG" '.mcpServers["fixture-stdio"].type' "stdio"
 assert "wrapped http entry type=stdio" \
-  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-http\"].type' '$CONFIG') == 'stdio' ]]"
+  json_value_equals "$CONFIG" '.mcpServers["fixture-http"].type' "stdio"
 
 # Stdio entry: command = pipelock binary path, args starts with "mcp proxy".
 assert "stdio command points at pipelock" \
-  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"].command' '$CONFIG') == '$PIPELOCK' ]] || \
-           [[ \$(jq -r '.mcpServers[\"fixture-stdio\"].command' '$CONFIG') == \$(readlink -f '$PIPELOCK') ]]"
+  stdio_command_points_at_pipelock
 assert "stdio args[0]=mcp" \
-  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"].args[0]' '$CONFIG') == 'mcp' ]]"
+  json_value_equals "$CONFIG" '.mcpServers["fixture-stdio"].args[0]' "mcp"
 assert "stdio args[1]=proxy" \
-  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"].args[1]' '$CONFIG') == 'proxy' ]]"
+  json_value_equals "$CONFIG" '.mcpServers["fixture-stdio"].args[1]' "proxy"
 
 # Stdio entry: --env FIXTURE_VAR passthrough is present.
 assert "stdio carries --env FIXTURE_VAR passthrough" \
-  bash -c "jq -e '.mcpServers[\"fixture-stdio\"].args | index(\"--env\") as \$i | .[\$i+1] == \"FIXTURE_VAR\"' '$CONFIG'"
+  jq -e '.mcpServers["fixture-stdio"].args | index("--env") as $i | .[$i+1] == "FIXTURE_VAR"' "$CONFIG"
 
 # Stdio entry: -- separator precedes the original command.
 assert "stdio carries -- separator before original command" \
-  bash -c "jq -e '.mcpServers[\"fixture-stdio\"].args | index(\"--\") as \$i | .[\$i+1] == \"cat\"' '$CONFIG'"
+  jq -e '.mcpServers["fixture-stdio"].args | index("--") as $i | .[$i+1] == "cat"' "$CONFIG"
 
 # HTTP entry: --header-file carries the path to a 0o600 sidecar; the
 # Authorization value lives in the sidecar file, never in argv.
 assert "http carries --header-file flag with a sidecar path" \
-  bash -c "jq -e '.mcpServers[\"fixture-http\"].args | index(\"--header-file\") as \$i | (.[\$i+1] | type) == \"string\" and (.[\$i+1] | length) > 0' '$CONFIG'"
+  jq -e '.mcpServers["fixture-http"].args | index("--header-file") as $i | (.[ $i+1 ] | type) == "string" and (.[ $i+1 ] | length) > 0' "$CONFIG"
 
 SIDECAR_PATH=$(jq -r '.mcpServers["fixture-http"].args as $a | $a | index("--header-file") as $i | $a[$i+1]' "$CONFIG")
 assert "sidecar file exists at the path embedded in argv" test -f "$SIDECAR_PATH"
 assert "sidecar mode is 0o600" \
-  bash -c "[[ \$(stat -c '%a' '$SIDECAR_PATH') == '600' ]]"
+  mode_is_600 "$SIDECAR_PATH"
 assert "sidecar contains the Authorization header line" \
   grep -q "Authorization: Bearer fixture-token" "$SIDECAR_PATH"
 assert "wrapped argv does NOT contain the Authorization header value" \
-  bash -c "! jq -e '.mcpServers[\"fixture-http\"].args | any(. == \"Authorization: Bearer fixture-token\")' '$CONFIG' >/dev/null 2>&1"
+  jq -e '.mcpServers["fixture-http"].args | all(. != "Authorization: Bearer fixture-token")' "$CONFIG"
 assert "_pipelock metadata records the sidecar path" \
-  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-http\"]._pipelock.header_sidecar_path' '$CONFIG') == '$SIDECAR_PATH' ]]"
+  jq -e --arg path "$SIDECAR_PATH" '.mcpServers["fixture-http"]._pipelock.header_sidecar_path == $path' "$CONFIG"
 
 # HTTP entry: --upstream carries the original URL.
 assert "http carries --upstream original-url" \
-  bash -c "jq -e '.mcpServers[\"fixture-http\"].args | index(\"--upstream\") as \$i | .[\$i+1] == \"https://fixture.invalid/mcp\"' '$CONFIG'"
+  jq -e '.mcpServers["fixture-http"].args | index("--upstream") as $i | .[$i+1] == "https://fixture.invalid/mcp"' "$CONFIG"
 
 # Both metadata entries: TypeOmitted=true (Cline omits type field).
 assert "stdio metadata TypeOmitted=true" \
-  bash -c "jq -e '.mcpServers[\"fixture-stdio\"]._pipelock.type_omitted == true' '$CONFIG'"
+  jq -e '.mcpServers["fixture-stdio"]._pipelock.type_omitted == true' "$CONFIG"
 assert "http metadata TypeOmitted=true" \
-  bash -c "jq -e '.mcpServers[\"fixture-http\"]._pipelock.type_omitted == true' '$CONFIG'"
+  jq -e '.mcpServers["fixture-http"]._pipelock.type_omitted == true' "$CONFIG"
 
 # Backup matches the seed file.
 assert "install wrote .bak matching seed" cmp -s "$SEED" "$CONFIG.bak"
@@ -273,7 +306,7 @@ INIT_REQ='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersi
 printf '%s\n' "$INIT_REQ" | timeout 5 "$WRAPPED_CMD" "${WRAPPED_ARGS[@]}" >"$WORKDIR/proxy.stdout" 2>"$WORKDIR/proxy.stderr" || true
 
 assert "proxy produced stdout or stderr output (didn't crash immediately)" \
-  bash -c "[[ -s '$WORKDIR/proxy.stdout' ]] || [[ -s '$WORKDIR/proxy.stderr' ]]"
+  proxy_output_exists
 
 # Confirm the binary at least recognised the cline-install-shaped args
 # (cobra parse error would be in stderr, immediate help text). Either a
@@ -281,7 +314,7 @@ assert "proxy produced stdout or stderr output (didn't crash immediately)" \
 # message on stderr (proxy initialized then child exited) is acceptable;
 # what we are rejecting here is "unknown command" or "unknown flag" output.
 assert "wrapped argv parses without cobra error" \
-  bash -c "! grep -qE 'unknown command|unknown flag|invalid argument' '$WORKDIR/proxy.stderr'"
+  wrapped_argv_has_no_cobra_error
 
 echo ""
 echo "[4] remove and restore"
@@ -292,25 +325,25 @@ assert "remove stdout reports 2 unwrapped" grep -q "Unwrapped 2 server(s)" "$WOR
 
 # Order-of-keys equivalence: parse both, compare as canonical JSON.
 assert "post-remove config equals seed (canonical JSON compare)" \
-  bash -c "diff <(jq -S . '$SEED') <(jq -S . '$CONFIG')"
+  canonical_json_matches
 
 # Per-server fields should be exactly what the seed had: no leftover
 # _pipelock, no leftover type=stdio, original env/headers/url back.
 assert "stdio entry restored: no leftover _pipelock" \
-  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"]._pipelock // \"absent\"' '$CONFIG') == 'absent' ]]"
+  json_value_equals "$CONFIG" '.mcpServers["fixture-stdio"]._pipelock // "absent"' "absent"
 assert "stdio entry restored: no leftover type field" \
-  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"].type // \"absent\"' '$CONFIG') == 'absent' ]]"
+  json_value_equals "$CONFIG" '.mcpServers["fixture-stdio"].type // "absent"' "absent"
 assert "stdio entry restored: command back to 'cat'" \
-  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"].command' '$CONFIG') == 'cat' ]]"
+  json_value_equals "$CONFIG" '.mcpServers["fixture-stdio"].command' "cat"
 assert "stdio entry restored: env block intact" \
-  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-stdio\"].env.FIXTURE_VAR' '$CONFIG') == 'value' ]]"
+  json_value_equals "$CONFIG" '.mcpServers["fixture-stdio"].env.FIXTURE_VAR' "value"
 
 assert "http entry restored: no leftover type field" \
-  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-http\"].type // \"absent\"' '$CONFIG') == 'absent' ]]"
+  json_value_equals "$CONFIG" '.mcpServers["fixture-http"].type // "absent"' "absent"
 assert "http entry restored: url back" \
-  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-http\"].url' '$CONFIG') == 'https://fixture.invalid/mcp' ]]"
+  json_value_equals "$CONFIG" '.mcpServers["fixture-http"].url' "https://fixture.invalid/mcp"
 assert "http entry restored: Authorization header back" \
-  bash -c "[[ \$(jq -r '.mcpServers[\"fixture-http\"].headers.Authorization' '$CONFIG') == 'Bearer fixture-token' ]]"
+  json_value_equals "$CONFIG" '.mcpServers["fixture-http"].headers.Authorization' "Bearer fixture-token"
 
 echo ""
 echo "[5] idempotence: re-run install on already-installed config (no double-wrap)"

--- a/scripts/e2e/cline-mcp-runtime.py
+++ b/scripts/e2e/cline-mcp-runtime.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Real-upstream MCP runtime E2E for `pipelock cline install`.
+
+Builds the pipelock binary from the worktree (or reuses one passed via
+PIPELOCK_BIN), seeds a temp cline_mcp_settings.json with an entry for
+@modelcontextprotocol/server-everything (the official MCP test server),
+runs `pipelock cline install`, spawns the wrapped subprocess, drives the
+full MCP handshake (initialize, initialized notification, tools/list),
+asserts the everything server's known tools came back through pipelock's
+MCP proxy, then runs `pipelock cline remove` and verifies the config
+matches the seed byte-equivalent.
+
+Usage:
+    python3 scripts/e2e/cline-mcp-runtime.py
+    PIPELOCK_BIN=~/.local/bin/pipelock python3 scripts/e2e/cline-mcp-runtime.py
+    KEEP_WORKDIR=1 python3 scripts/e2e/cline-mcp-runtime.py
+
+Exit 0 on full pass, non-zero on first failure.
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Pinned upstream package. Updating this is a deliberate supply-chain choice;
+# do not loosen to `@latest` or unpinned without auditing the new version.
+EVERYTHING_PACKAGE = "@modelcontextprotocol/server-everything@2026.1.26"
+
+# Subset of tools the everything server is known to ship as of mid-2026.
+# Asserting these come back through pipelock proves the full handshake and
+# tools/list pipe both round-tripped (init -> notification -> request ->
+# response). The server's tool roster has shifted across versions: keep
+# this list to a few stable names that appear in every recent release.
+EXPECTED_TOOLS = {"echo", "get-sum"}
+
+
+def build_pipelock(workdir: Path) -> Path:
+    """Compile pipelock from the surrounding worktree or honor PIPELOCK_BIN."""
+    bin_override = os.environ.get("PIPELOCK_BIN")
+    if bin_override:
+        print(f"Using pre-built pipelock at {bin_override}")
+        return Path(bin_override)
+    out = workdir / "pipelock"
+    print(f"Building pipelock from {REPO_ROOT} -> {out}")
+    subprocess.run(
+        ["go", "build", "-o", str(out), "./cmd/pipelock"],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+    return out
+
+
+def seed_config(workdir: Path) -> Path:
+    """Write a Cline-shape config with one entry pointing at the everything server."""
+    cfg = {
+        "mcpServers": {
+            "everything": {
+                "command": "npx",
+                "args": ["-y", EVERYTHING_PACKAGE],
+            }
+        }
+    }
+    cfg_path = workdir / "cline_mcp_settings.json"
+    seed_path = workdir / "cline_mcp_settings.seed.json"
+    body = json.dumps(cfg, indent=2) + "\n"
+    cfg_path.write_text(body)
+    seed_path.write_text(body)
+    return cfg_path
+
+
+def seed_pipelock_config(workdir: Path) -> Path:
+    """Write a minimal pipelock config with sandbox off so the wrapped
+    subprocess can reach the npm registry to fetch the upstream package.
+
+    Auto-discovery would otherwise pick up the operator's config, which
+    typically has sandbox enabled. This test is hermetic by design.
+    """
+    body = """mode: balanced
+sandbox:
+  enabled: false
+file_sentry:
+  enabled: false
+flight_recorder:
+  enabled: false
+"""
+    p = workdir / "pipelock.yaml"
+    p.write_text(body)
+    return p
+
+
+def run_install(pipelock: Path, cfg_path: Path, pipelock_cfg: Path) -> None:
+    result = subprocess.run(
+        [str(pipelock), "cline", "install", "--path", str(cfg_path), "-c", str(pipelock_cfg)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.exit(f"install failed: {result.stderr}")
+    if "Wrapped 1 server" not in result.stdout:
+        sys.exit(f"install did not wrap the expected count: {result.stdout!r}")
+
+
+def extract_wrapped_argv(cfg_path: Path):
+    data = json.loads(cfg_path.read_text())
+    entry = data["mcpServers"]["everything"]
+    if "_pipelock" not in entry:
+        sys.exit("wrapped entry missing _pipelock metadata")
+    return entry["command"], entry["args"]
+
+
+def send_message(proc, payload: dict) -> None:
+    line = json.dumps(payload) + "\n"
+    proc.stdin.write(line.encode("utf-8"))
+    proc.stdin.flush()
+
+
+def _drain_stderr_briefly(proc, timeout: float = 1.0) -> str:
+    """Read whatever has accumulated on stderr within a short timeout.
+
+    Plain stderr.read() can block forever when a grandchild (npx -> node) still
+    holds the pipe after the immediate parent (pipelock) exits, so we use a
+    selector with a deadline and accept that we may miss the tail.
+    """
+    import selectors
+
+    sel = selectors.DefaultSelector()
+    sel.register(proc.stderr, selectors.EVENT_READ)
+    out = b""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        events = sel.select(0.1)
+        if not events:
+            continue
+        chunk = proc.stderr.read1(65536)
+        if not chunk:
+            break
+        out += chunk
+    sel.close()
+    return out.decode("utf-8", errors="replace")
+
+
+def read_response(proc, expected_id, timeout: float = 30.0) -> dict:
+    """Read JSON-RPC frames from stdout until one matches expected_id.
+
+    The proxy may interleave log lines; non-JSON output is skipped. Pure
+    timeout-and-poll loop avoids selectors that fight Python's buffered I/O.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        line = proc.stdout.readline()
+        if not line:
+            if proc.poll() is not None:
+                tail = _drain_stderr_briefly(proc)
+                sys.exit(
+                    f"subprocess exited before response id={expected_id}; "
+                    f"stderr tail:\n{tail[-2000:]}"
+                )
+            time.sleep(0.05)
+            continue
+        text = line.decode("utf-8", errors="replace").strip()
+        if not text or not text.startswith("{"):
+            continue
+        try:
+            obj = json.loads(text)
+        except json.JSONDecodeError:
+            continue
+        if obj.get("id") == expected_id:
+            return obj
+    sys.exit(f"timeout waiting for response id={expected_id}")
+
+
+def main():
+    # Opt-in gate. This E2E fetches an upstream npm package at runtime, which
+    # is a supply-chain surface even with a pinned version. The default is to
+    # skip; operators who want the live-upstream test set PIPELOCK_E2E_LIVE_UPSTREAM=1.
+    if not os.environ.get("PIPELOCK_E2E_LIVE_UPSTREAM"):
+        print(
+            "Skipping runtime MCP E2E. Set PIPELOCK_E2E_LIVE_UPSTREAM=1 to run "
+            "the test, which fetches @modelcontextprotocol/server-everything "
+            f"({EVERYTHING_PACKAGE}) from npm."
+        )
+        return
+
+    workdir = Path(tempfile.mkdtemp(prefix="pipelock-cline-runtime-"))
+    print(f"Workdir: {workdir}")
+    keep_workdir = bool(os.environ.get("KEEP_WORKDIR"))
+
+    try:
+        pipelock = build_pipelock(workdir)
+        cfg_path = seed_config(workdir)
+        pipelock_cfg = seed_pipelock_config(workdir)
+
+        print("\n[1] install")
+        run_install(pipelock, cfg_path, pipelock_cfg)
+        cmd, args = extract_wrapped_argv(cfg_path)
+        print(f"  wrapped command: {cmd}")
+        print(f"  wrapped args head: {' '.join(args[:6])} ...")
+
+        print("\n[2] spawn wrapped subprocess and drive MCP handshake")
+        proc = subprocess.Popen(
+            [cmd, *args],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            send_message(proc, {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "pipelock-e2e", "version": "0"},
+                },
+            })
+            resp = read_response(proc, expected_id=1, timeout=60.0)
+            if "result" not in resp or "serverInfo" not in resp["result"]:
+                sys.exit(f"initialize returned unexpected shape: {resp}")
+            server_name = resp["result"]["serverInfo"].get("name", "?")
+            print(f"  initialize OK; serverInfo.name={server_name!r}")
+
+            send_message(proc, {
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+            })
+
+            send_message(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+            resp = read_response(proc, expected_id=2, timeout=30.0)
+            tools = resp.get("result", {}).get("tools", [])
+            tool_names = {t.get("name") for t in tools}
+            print(f"  tools/list returned {len(tools)} tools")
+            missing = EXPECTED_TOOLS - tool_names
+            if missing:
+                sys.exit(
+                    f"expected tools missing from response: {missing}; "
+                    f"got {sorted(tool_names)}"
+                )
+            print(f"  all expected tools present: {sorted(EXPECTED_TOOLS)}")
+        finally:
+            try:
+                proc.stdin.close()
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+        print("\n[3] remove and verify canonical-JSON restoration")
+        remove = subprocess.run(
+            [str(pipelock), "cline", "remove", "--path", str(cfg_path)],
+            capture_output=True, text=True,
+        )
+        if remove.returncode != 0:
+            sys.exit(f"remove failed: {remove.stderr}")
+
+        # Semantic compare, not byte-for-byte: pipelock's Go json.MarshalIndent
+        # sorts map keys alphabetically, so the post-remove file may carry
+        # `{args, command}` where the seed had `{command, args}`. The contents
+        # are equivalent. The shell fixture E2E uses the same canonical compare
+        # via `jq -S`.
+        seed_obj = json.loads((workdir / "cline_mcp_settings.seed.json").read_text())
+        post_obj = json.loads(cfg_path.read_text())
+        if json.dumps(seed_obj, sort_keys=True) != json.dumps(post_obj, sort_keys=True):
+            sys.exit(
+                "post-remove config not semantically equal to seed:\n"
+                f"seed: {json.dumps(seed_obj, indent=2)}\n"
+                f"post: {json.dumps(post_obj, indent=2)}"
+            )
+        print("  config restored to canonical-JSON equivalent of seed")
+
+        print("\nALL PASS")
+    finally:
+        if keep_workdir:
+            print(f"\nKEEP_WORKDIR set; preserved {workdir}")
+        else:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/e2e/cline-mcp-runtime.py
+++ b/scripts/e2e/cline-mcp-runtime.py
@@ -7,8 +7,8 @@ PIPELOCK_BIN), seeds a temp cline_mcp_settings.json with an entry for
 runs `pipelock cline install`, spawns the wrapped subprocess, drives the
 full MCP handshake (initialize, initialized notification, tools/list),
 asserts the everything server's known tools came back through pipelock's
-MCP proxy, then runs `pipelock cline remove` and verifies the config
-matches the seed byte-equivalent.
+MCP proxy, then runs `pipelock cline remove` and verifies the config is
+semantically equivalent to the seed JSON.
 
 Usage:
     python3 scripts/e2e/cline-mcp-runtime.py
@@ -19,10 +19,13 @@ Exit 0 on full pass, non-zero on first failure.
 """
 import json
 import os
+import queue
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from pathlib import Path
 
@@ -121,48 +124,74 @@ def send_message(proc, payload: dict) -> None:
     proc.stdin.flush()
 
 
-def _drain_stderr_briefly(proc, timeout: float = 1.0) -> str:
-    """Read whatever has accumulated on stderr within a short timeout.
+class StreamTail:
+    """Thread-safe bounded text tail for subprocess diagnostics."""
 
-    Plain stderr.read() can block forever when a grandchild (npx -> node) still
-    holds the pipe after the immediate parent (pipelock) exits, so we use a
-    selector with a deadline and accept that we may miss the tail.
-    """
-    import selectors
+    def __init__(self, limit: int = 8192):
+        self._limit = limit
+        self._text = ""
+        self._lock = threading.Lock()
 
-    sel = selectors.DefaultSelector()
-    sel.register(proc.stderr, selectors.EVENT_READ)
-    out = b""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        events = sel.select(0.1)
-        if not events:
-            continue
-        chunk = proc.stderr.read1(65536)
-        if not chunk:
-            break
-        out += chunk
-    sel.close()
-    return out.decode("utf-8", errors="replace")
+    def append(self, raw: bytes) -> None:
+        text = raw.decode("utf-8", errors="replace")
+        with self._lock:
+            self._text = (self._text + text)[-self._limit:]
+
+    def tail(self, limit: int = 2000) -> str:
+        with self._lock:
+            return self._text[-limit:]
 
 
-def read_response(proc, expected_id, timeout: float = 30.0) -> dict:
+def start_stdout_reader(stream) -> tuple[queue.Queue, threading.Thread]:
+    lines = queue.Queue()
+
+    def read_lines() -> None:
+        try:
+            for raw in iter(stream.readline, b""):
+                lines.put(raw)
+        finally:
+            lines.put(None)
+
+    thread = threading.Thread(target=read_lines, name="pipelock-e2e-stdout", daemon=True)
+    thread.start()
+    return lines, thread
+
+
+def start_stderr_tailer(stream, tail: StreamTail) -> threading.Thread:
+    def read_stderr() -> None:
+        for chunk in iter(lambda: stream.read(4096), b""):
+            tail.append(chunk)
+
+    thread = threading.Thread(target=read_stderr, name="pipelock-e2e-stderr", daemon=True)
+    thread.start()
+    return thread
+
+
+def read_response(proc, stdout_lines, stderr_tail: StreamTail, expected_id, timeout: float = 30.0) -> dict:
     """Read JSON-RPC frames from stdout until one matches expected_id.
 
-    The proxy may interleave log lines; non-JSON output is skipped. Pure
-    timeout-and-poll loop avoids selectors that fight Python's buffered I/O.
+    The proxy may interleave log lines; non-JSON output is skipped. A
+    background reader owns the blocking pipe read so this function's timeout
+    cannot hang behind readline().
     """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        line = proc.stdout.readline()
-        if not line:
+        remaining = max(0.0, deadline - time.monotonic())
+        try:
+            line = stdout_lines.get(timeout=min(0.1, remaining))
+        except queue.Empty:
             if proc.poll() is not None:
-                tail = _drain_stderr_briefly(proc)
                 sys.exit(
                     f"subprocess exited before response id={expected_id}; "
-                    f"stderr tail:\n{tail[-2000:]}"
+                    f"stderr tail:\n{stderr_tail.tail()}"
                 )
-            time.sleep(0.05)
+            continue
+        if not line:
+            if proc.poll() is not None:
+                sys.exit(
+                    f"subprocess exited before response id={expected_id}; "
+                    f"stderr tail:\n{stderr_tail.tail()}"
+                )
             continue
         text = line.decode("utf-8", errors="replace").strip()
         if not text or not text.startswith("{"):
@@ -173,7 +202,10 @@ def read_response(proc, expected_id, timeout: float = 30.0) -> dict:
             continue
         if obj.get("id") == expected_id:
             return obj
-    sys.exit(f"timeout waiting for response id={expected_id}")
+    sys.exit(
+        f"timeout waiting for response id={expected_id}; "
+        f"stderr tail:\n{stderr_tail.tail()}"
+    )
 
 
 def main():
@@ -209,7 +241,11 @@ def main():
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            start_new_session=True,
         )
+        stdout_lines, stdout_thread = start_stdout_reader(proc.stdout)
+        stderr_tail = StreamTail()
+        stderr_thread = start_stderr_tailer(proc.stderr, stderr_tail)
         try:
             send_message(proc, {
                 "jsonrpc": "2.0",
@@ -221,7 +257,7 @@ def main():
                     "clientInfo": {"name": "pipelock-e2e", "version": "0"},
                 },
             })
-            resp = read_response(proc, expected_id=1, timeout=60.0)
+            resp = read_response(proc, stdout_lines, stderr_tail, expected_id=1, timeout=60.0)
             if "result" not in resp or "serverInfo" not in resp["result"]:
                 sys.exit(f"initialize returned unexpected shape: {resp}")
             server_name = resp["result"]["serverInfo"].get("name", "?")
@@ -233,7 +269,7 @@ def main():
             })
 
             send_message(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
-            resp = read_response(proc, expected_id=2, timeout=30.0)
+            resp = read_response(proc, stdout_lines, stderr_tail, expected_id=2, timeout=30.0)
             tools = resp.get("result", {}).get("tools", [])
             tool_names = {t.get("name") for t in tools}
             print(f"  tools/list returned {len(tools)} tools")
@@ -252,7 +288,18 @@ def main():
             try:
                 proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
-                proc.kill()
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                proc.wait(timeout=5)
+            for stream in (proc.stdout, proc.stderr):
+                try:
+                    stream.close()
+                except Exception:
+                    pass
+            stdout_thread.join(timeout=2)
+            stderr_thread.join(timeout=2)
 
         print("\n[3] remove and verify canonical-JSON restoration")
         remove = subprocess.run(


### PR DESCRIPTION
## Summary

- Adds \`pipelock cline\` with \`install\` and \`remove\`, alongside the existing \`claude\` / \`cursor\` / \`vscode\` / \`jetbrains\` / \`codex\` family.
- Wraps Cline's \`mcp.json\` entries through \`pipelock mcp proxy\` so MCP traffic gets scanned, recorded, and signed.
- Default path is \`~/.cline/mcp.json\`. \`--path\` overrides for VS Code-extension installs whose config lives in \`globalStorage\`.

## Conformance notes

- Cline omits \`type\` on entries. The wrap infers transport from \`command\` vs \`url\` and records \`TypeOmitted=true\` so remove restores a typeless entry. Entries with both \`command\` and \`url\` are rejected with a warning rather than silently dropping \`url\`.
- Remote MCP entries with \`headers\` now emit validated \`--header\` flags on the wrapped \`mcp proxy --upstream\` invocation. Same RFC 7230 token check and transport-managed-header blocklist (\`Content-Type\`, \`Accept\`, \`Mcp-Session-Id\`, \`Content-Length\`, \`Transfer-Encoding\`, \`Host\`) as the runtime parser. Bad headers fail install rather than failing at agent startup.
- Without \`-c\`, install auto-discovers a pipelock config (\`PIPELOCK_CONFIG\`, \`\$XDG_CONFIG_HOME/pipelock/pipelock.yaml\`, \`~/.config/pipelock/pipelock.yaml\`, \`/etc/pipelock/pipelock.yaml\`) and embeds it as \`--config\` in the wrapped argv. Without this, the spawned proxy loaded \`config.Defaults()\` which has \`MCPInputScanning\`, \`MCPToolScanning\`, \`MCPToolPolicy\`, and \`FlightRecorder\` all disabled. Same fix lands on \`vscode install\` via the shared helper. Stderr warns when nothing is discoverable.
- \`--config\` paths and discovered paths are absolutized at install time so the wrap stays correct when the IDE later spawns the subprocess from a different working directory.
- \`pipelockMeta\` gains \`ArgsPresent\` (with \`omitempty\`) so a source declaring \`\"args\": []\` round-trips byte-exact through install / remove. Without it the field was dropped because restore gated on \`len(OriginalArgs) > 0\`.
- Install and remove are idempotent. Atomic temp-file rename, \`0o600\` mode, \`.bak\` backup before mutation, unknown top-level and per-server fields preserved.

## Tests

- 16 cline cases in \`internal/cli/setup/cline_test.go\`, 6 \`DiscoverConfigPath\` cases in \`internal/cliutil/config_test.go\`, 1 relative-config regression in \`vscode_test.go\`.
- \`scripts/e2e/cline-install.sh\` (33 assertions) builds a fresh binary and exercises the install / wrap / spawn / remove cycle.
- \`scripts/e2e/cline-mcp-runtime.py\` drives a real MCP handshake (initialize / initialized / tools/list) through the wrapped subprocess against \`@modelcontextprotocol/server-everything\`.

## Known limitation

When \`sandbox.enabled: true\` and the wrapped server is a bridge MCP (stdio shim over an HTTPS backend, e.g. \`@upstash/context7-mcp\`), pipelock's sandbox isolates the subprocess in a network namespace, the bridge cannot reach its upstream, and the proxy SIGKILLs the child. Local-only MCP servers are unaffected. Tracked separately for follow-up work; this PR does not change sandbox behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cline IDE integration: new install/remove subcommands (registered in the CLI) to wrap/unwrap MCP servers with dry-run, backups, atomic updates, sidecar header files, and metadata-preserving round-trip.
  * VS Code integration: automatic config discovery and safer header/args handling, routing secrets via header sidecars.

* **Tests**
  * Expanded unit, integration, and e2e tests covering install/remove, sidecars, config discovery, header validation, and runtime MCP handshake.

* **Other**
  * Added config discovery helper and CLI support for header-sidecar files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/519)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->