### PR TITLE
test: close error-branch coverage gaps in signing + integrity

### DIFF
--- a/internal/integrity/check_test.go
+++ b/internal/integrity/check_test.go
@@ -1152,3 +1152,18 @@ func TestGenerate_WalkError(t *testing.T) {
 		t.Fatal("expected error for unreadable subdirectory")
 	}
 }
+
+// TestMatchDoublestar_PatternWithoutStars covers the early-return branch
+// that fires when a caller passes a pattern that lacks the "**" wildcard.
+// strings.SplitN with no occurrence returns a single-element slice; the
+// function must refuse to match rather than treat the whole pattern as a
+// prefix. Other matchDoublestar tests only exercise patterns that already
+// contain "**".
+func TestMatchDoublestar_PatternWithoutStars(t *testing.T) {
+	if matchDoublestar("plain-pattern", "plain-pattern") {
+		t.Error("matchDoublestar must reject patterns with no '**' wildcard")
+	}
+	if matchDoublestar("dir/file.txt", "dir/file.txt") {
+		t.Error("matchDoublestar must reject literal path patterns")
+	}
+}

--- a/internal/signing/coverage_boost_test.go
+++ b/internal/signing/coverage_boost_test.go
@@ -5,9 +5,12 @@ package signing
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
 )
 
 // --- atomicWrite coverage tests (61.9% -> higher) ---
@@ -373,5 +376,55 @@ func TestKeystore_ListAgents(t *testing.T) {
 	// Should be sorted.
 	if agents[0] != "alpha" || agents[1] != "bravo" || agents[2] != "charlie" {
 		t.Errorf("agents not sorted: %v", agents)
+	}
+}
+
+// --- DefaultKeystorePath error-branch coverage ---
+
+// TestDefaultKeystorePath_NoHome exercises the os.UserHomeDir error branch
+// by emptying HOME. Go's os.UserHomeDir on Unix returns an error when HOME
+// is unset or empty, which is exactly the production failure mode this
+// branch is meant to surface.
+func TestDefaultKeystorePath_NoHome(t *testing.T) {
+	t.Setenv("HOME", "")
+
+	got, err := DefaultKeystorePath()
+	if err == nil {
+		t.Fatalf("expected error when HOME is empty, got path=%q", got)
+	}
+	if got != "" {
+		t.Errorf("expected empty path on error, got %q", got)
+	}
+}
+
+// --- findRootKey wrong-status branch coverage ---
+
+// TestFindRootKey_KeyIDMatchesButStatusNotRoot exercises the inner reject
+// branch where the roster body's RosterSignedBy points at a key that exists
+// but is marked active (or anything other than root). Findroot must reject
+// even though the key_id matches, because an attacker who manages to flip
+// a runtime key's status field could otherwise hijack root-only operations.
+func TestFindRootKey_KeyIDMatchesButStatusNotRoot(t *testing.T) {
+	body := contract.KeyRoster{
+		SchemaVersion:  1,
+		RosterSignedBy: "test-key-id",
+		Keys: []contract.KeyInfo{
+			{
+				KeyID:        "test-key-id",
+				KeyPurpose:   string(PurposeRosterRoot),
+				PublicKeyHex: testRosterPubHex,
+				ValidFrom:    testRosterValidFrom,
+				Status:       contract.KeyStatusActive, // wrong status
+			},
+		},
+		DataClassRoot: testRosterDataClass,
+	}
+
+	_, err := findRootKey(body)
+	if err == nil {
+		t.Fatal("expected error when matched key has wrong status, got nil")
+	}
+	if !errors.Is(err, ErrRosterRootMissing) {
+		t.Errorf("expected ErrRosterRootMissing, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Three targeted tests covering previously-uncovered error branches flagged in the long-standing per-package gap notes. No production code touched.

## Conformance notes

- \`TestDefaultKeystorePath_NoHome\` exercises the \`os.UserHomeDir\` error return (HOME empty).
- \`TestFindRootKey_KeyIDMatchesButStatusNotRoot\` exercises the reject path where the roster has the named key_id but with status \`active\` instead of \`root\`.
- \`TestMatchDoublestar_PatternWithoutStars\` covers \`matchDoublestar\`'s early return for patterns lacking \`**\` (the SplitN single-element branch). Existing cases only exercised patterns containing \`**\`.

Coverage moves: \`internal/signing\` 94.3% to 94.7%, \`internal/integrity\` 95.9% to 96.7%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for pattern matching and keystore initialization edge cases
  * Enhanced roster validation testing for improved reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/520)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->