### PR TITLE
feat(contract): enforce tombstones at activation and accepted-load time

### DIFF
--- a/internal/cli/learn/activate.go
+++ b/internal/cli/learn/activate.go
@@ -402,7 +402,7 @@ func loadLifecycleSigner(keystoreDir, keyID string) (privateKeySigner, error) {
 }
 
 func latestAccepted(st contractstore.Store, opts contractstore.Options) (contractstore.State, bool, error) {
-	current, err := st.LatestAccepted(opts)
+	current, err := st.LatestAcceptedHistory(opts)
 	if err == nil {
 		return current, true, nil
 	}

--- a/internal/contract/runtime/loader.go
+++ b/internal/contract/runtime/loader.go
@@ -340,7 +340,7 @@ func (l *Loader) acceptedChainReachesCurrent(state store.State, prev *ActiveSet,
 		if prior == "" || prior == "sha256:genesis" {
 			return false
 		}
-		next, err := l.store.Accepted(prior, opts)
+		next, err := l.store.AcceptedHistory(prior, opts)
 		if err != nil {
 			return false
 		}

--- a/internal/contract/store/store.go
+++ b/internal/contract/store/store.go
@@ -174,6 +174,10 @@ func (s Store) Reload(opts Options) (State, error) {
 // ValidateEnvelope runs strict decode, signature checks, CAS checks, and
 // contract-history resolution without mutating store files.
 func (s Store) ValidateEnvelope(raw []byte, opts Options) (State, error) {
+	return s.validateEnvelope(raw, opts, true)
+}
+
+func (s Store) validateEnvelope(raw []byte, opts Options, checkTombstones bool) (State, error) {
 	var env contract.ActiveManifestEnvelope
 	if err := contract.DecodeStrictJSON(raw, &env); err != nil {
 		return State{}, fmt.Errorf("%w: active manifest: %w", ErrDecode, err)
@@ -201,7 +205,60 @@ func (s Store) ValidateEnvelope(raw []byte, opts Options) (State, error) {
 	if err != nil {
 		return State{}, err
 	}
+	if checkTombstones {
+		if err := s.tombstoneCheck(env.Body.Selectors, opts); err != nil {
+			return State{}, err
+		}
+	}
 	return State{Envelope: env, ManifestHash: hash, Contracts: contracts}, nil
+}
+
+// LatestAcceptedHistory returns the highest-generation immutable accepted
+// manifest without applying the tombstone adoption gate. It is for baseline
+// and chain-continuity reads only: callers may use the returned hash,
+// generation, and environment to build a new manifest, but must not adopt the
+// returned selectors as runtime state without a later ValidateEnvelope,
+// LatestAccepted, or Accepted call.
+func (s Store) LatestAcceptedHistory(opts Options) (State, error) {
+	return s.latestAccepted(opts, false)
+}
+
+// AcceptedHistory returns an immutable accepted manifest by manifest hash
+// without applying the tombstone adoption gate. It is for baseline and
+// chain-continuity reads only. Use Accepted when the returned selectors will
+// be adopted as runtime state.
+func (s Store) AcceptedHistory(hash string, opts Options) (State, error) {
+	return s.accepted(hash, opts, false)
+}
+
+func (s Store) tombstoneAdoptionCheck(selectors []contract.ManifestSelector, opts Options, enabled bool) error {
+	if enabled {
+		return s.tombstoneCheck(selectors, opts)
+	}
+	return nil
+}
+
+func (s Store) accepted(hash string, opts Options, checkTombstones bool) (State, error) {
+	accepted, err := s.loadAcceptedManifestByHash(hash, opts)
+	if err != nil {
+		return State{}, err
+	}
+	if err := s.acceptedChainContinuous(hash, map[string]acceptedManifest{hash: accepted}, opts, map[string]struct{}{}); err != nil {
+		return State{}, err
+	}
+	contracts, err := s.loadContracts(accepted.env.Body.Selectors, opts)
+	if err != nil {
+		return State{}, err
+	}
+	if err := s.tombstoneAdoptionCheck(accepted.env.Body.Selectors, opts, checkTombstones); err != nil {
+		return State{}, err
+	}
+	return State{
+		Envelope:     accepted.env,
+		ManifestHash: accepted.hash,
+		Contracts:    contracts,
+		AcceptedPath: accepted.path,
+	}, nil
 }
 
 // WriteActive validates and atomically writes active.json. The advisory lock
@@ -266,7 +323,17 @@ func (s Store) PutHistoryContract(raw []byte, opts Options) (string, error) {
 }
 
 // LatestAccepted returns the highest-generation immutable accepted manifest.
+// The returned state is the candidate for being ADOPTED as runtime active
+// state (recovery path, rollback display, "current active" inspection),
+// so the tombstone cross-check fires before return. Callers that only
+// need baseline metadata or historical chain continuity should use
+// LatestAcceptedHistory or AcceptedHistory so historical reads do not fail
+// closed when an ancestor referenced a now-tombstoned contract.
 func (s Store) LatestAccepted(opts Options) (State, error) {
+	return s.latestAccepted(opts, true)
+}
+
+func (s Store) latestAccepted(opts Options, checkTombstones bool) (State, error) {
 	entries, err := readDir(s.manifestDir())
 	if err != nil {
 		return State{}, fmt.Errorf("read accepted manifests: %w", err)
@@ -298,6 +365,9 @@ func (s Store) LatestAccepted(opts Options) (State, error) {
 	if err != nil {
 		return State{}, err
 	}
+	if err := s.tombstoneAdoptionCheck(latest.env.Body.Selectors, opts, checkTombstones); err != nil {
+		return State{}, err
+	}
 	return State{
 		Envelope:     latest.env,
 		ManifestHash: latest.hash,
@@ -306,25 +376,14 @@ func (s Store) LatestAccepted(opts Options) (State, error) {
 	}, nil
 }
 
-// Accepted returns an immutable accepted manifest by manifest hash.
+// Accepted returns an immutable accepted manifest by manifest hash. As
+// with LatestAccepted, callers use this to adopt a historical manifest
+// as runtime state (loader recovery from a prior-hash mismatch, learn
+// activate --rollback). The tombstone cross-check fires before return
+// so rollback or recovery cannot resurrect a contract the operator has
+// already signed a withdrawal for.
 func (s Store) Accepted(hash string, opts Options) (State, error) {
-	accepted, err := s.loadAcceptedManifestByHash(hash, opts)
-	if err != nil {
-		return State{}, err
-	}
-	if err := s.acceptedChainContinuous(hash, map[string]acceptedManifest{hash: accepted}, opts, map[string]struct{}{}); err != nil {
-		return State{}, err
-	}
-	contracts, err := s.loadContracts(accepted.env.Body.Selectors, opts)
-	if err != nil {
-		return State{}, err
-	}
-	return State{
-		Envelope:     accepted.env,
-		ManifestHash: accepted.hash,
-		Contracts:    contracts,
-		AcceptedPath: accepted.path,
-	}, nil
+	return s.accepted(hash, opts, true)
 }
 
 type acceptedManifest struct {
@@ -488,7 +547,7 @@ func (s Store) currentActiveLocked(opts Options) (State, error) {
 	currentOpts := opts
 	currentOpts.PreviousHash = ""
 	currentOpts.PreviousGeneration = 0
-	return s.ValidateEnvelope(raw, currentOpts)
+	return s.validateEnvelope(raw, currentOpts, false)
 }
 
 func verifyManifestSignatures(env contract.ActiveManifestEnvelope, opts Options) error {

--- a/internal/contract/store/tombstone.go
+++ b/internal/contract/store/tombstone.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const tombstoneDirname = "tombstones"
+
+var (
+	// ErrContractTombstoned signals that a manifest references a contract
+	// hash for which a signed tombstone exists. Re-promoting a tombstoned
+	// hash is rejected at activation time.
+	ErrContractTombstoned = errors.New("contract store: prior contract is tombstoned and cannot be re-promoted")
+
+	// ErrTombstoneSignature signals that a stored tombstone failed
+	// signature verification or structural validation during load. Bad
+	// tombstones are a hard error rather than a silent skip so a forged
+	// or corrupted tombstone file cannot mask a re-promotion attempt.
+	ErrTombstoneSignature = errors.New("contract store: tombstone signature invalid")
+
+	// ErrTombstoneDecode signals that a tombstone file could not be
+	// parsed via strict decoding.
+	ErrTombstoneDecode = errors.New("contract store: tombstone decode failed")
+)
+
+// PutTombstone records a signed tombstone for a prior contract hash. The
+// tombstone body is decoded strictly (JSON), structurally validated,
+// signature-verified against the activation-signing roster, and written
+// write-once to <root>/tombstones/sha256-<hex>.json. Returns the
+// prior_contract_hash on success.
+func (s Store) PutTombstone(raw []byte, opts Options) (string, error) {
+	env, err := decodeTombstone(raw)
+	if err != nil {
+		return "", err
+	}
+	if err := env.Body.Validate(); err != nil {
+		return "", fmt.Errorf("%w: tombstone: %w", ErrStructural, err)
+	}
+	if err := validateHash(env.Body.PriorContractHash); err != nil {
+		return "", fmt.Errorf("%w: tombstone prior_contract_hash: %w", ErrStructural, err)
+	}
+	if err := verifyTombstoneSignature(env, opts); err != nil {
+		return "", err
+	}
+	path, err := s.tombstonePath(env.Body.PriorContractHash)
+	if err != nil {
+		return "", err
+	}
+	if err := s.withLock(func() error {
+		return writeOnce(path, append(bytes.TrimSpace(raw), '\n'))
+	}); err != nil {
+		return "", err
+	}
+	return env.Body.PriorContractHash, nil
+}
+
+// LoadTombstone returns the signed tombstone for priorContractHash. If no
+// tombstone exists, returns (TombstoneEnvelope{}, false, nil). The canonical
+// store object is JSON; legacy learn-forget YAML tombstones are also accepted
+// so existing operator evidence in tombstones/ is enforced. Any decode or
+// signature error is fail-closed: the caller cannot trust this hash to be
+// either tombstoned or clean, so validation must refuse to proceed.
+func (s Store) LoadTombstone(priorContractHash string, opts Options) (contract.TombstoneEnvelope, bool, error) {
+	if err := validateHash(priorContractHash); err != nil {
+		return contract.TombstoneEnvelope{}, false, err
+	}
+	candidates, err := s.tombstoneCandidates(priorContractHash)
+	if err != nil {
+		return contract.TombstoneEnvelope{}, false, err
+	}
+	for _, candidate := range candidates {
+		raw, err := readFile(candidate.path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return contract.TombstoneEnvelope{}, false, fmt.Errorf("%w: read tombstone: %w", ErrTombstoneDecode, err)
+		}
+		env, err := candidate.decode(raw)
+		if err != nil {
+			return contract.TombstoneEnvelope{}, false, err
+		}
+		if err := validateLoadedTombstone(env, priorContractHash, opts); err != nil {
+			return contract.TombstoneEnvelope{}, false, err
+		}
+		return env, true, nil
+	}
+	return contract.TombstoneEnvelope{}, false, nil
+}
+
+func validateLoadedTombstone(env contract.TombstoneEnvelope, priorContractHash string, opts Options) error {
+	if err := env.Body.Validate(); err != nil {
+		return fmt.Errorf("%w: tombstone: %w", ErrStructural, err)
+	}
+	if env.Body.PriorContractHash != priorContractHash {
+		return fmt.Errorf("%w: tombstone body prior_contract_hash %q does not match filename hash %q",
+			ErrTombstoneSignature, env.Body.PriorContractHash, priorContractHash)
+	}
+	if err := verifyTombstoneSignature(env, opts); err != nil {
+		return err
+	}
+	return nil
+}
+
+// tombstoneCheck rejects a manifest whose selectors reference any
+// contract hash for which a valid signed tombstone exists. Called from
+// ValidateEnvelope after signature + contract-history resolution so the
+// tombstone cross-check is the last gate before acceptance.
+func (s Store) tombstoneCheck(selectors []contract.ManifestSelector, opts Options) error {
+	for _, selector := range selectors {
+		env, found, err := s.LoadTombstone(selector.ContractHash, opts)
+		if err != nil {
+			return err
+		}
+		if !found {
+			continue
+		}
+		return fmt.Errorf("%w: selector_id=%q contract_hash=%s redacted_at=%q authorization=%q signer_key_id=%q",
+			ErrContractTombstoned,
+			selector.SelectorID,
+			env.Body.PriorContractHash,
+			env.Body.RedactedAt,
+			env.Body.RedactionAuthorizationID,
+			env.Body.SignerKeyID,
+		)
+	}
+	return nil
+}
+
+// decodeTombstone parses a signed tombstone envelope from JSON. Tombstone
+// records on disk are JSON-encoded (consistent with the manifest store);
+// the operator-facing tools accept YAML on input but normalize to JSON
+// before calling PutTombstone. LoadTombstone also accepts legacy YAML
+// evidence files written by earlier learn-forget workflows.
+func decodeTombstone(raw []byte) (contract.TombstoneEnvelope, error) {
+	var env contract.TombstoneEnvelope
+	if err := contract.DecodeStrictJSON(raw, &env); err != nil {
+		return contract.TombstoneEnvelope{}, fmt.Errorf("%w: tombstone: %w", ErrTombstoneDecode, err)
+	}
+	return env, nil
+}
+
+func decodeTombstoneYAML(raw []byte) (contract.TombstoneEnvelope, error) {
+	var env contract.TombstoneEnvelope
+	if err := contract.DecodeStrictYAML(raw, &env); err != nil {
+		return contract.TombstoneEnvelope{}, fmt.Errorf("%w: tombstone: %w", ErrTombstoneDecode, err)
+	}
+	return env, nil
+}
+
+// verifyTombstoneSignature checks the detached signature on a tombstone
+// envelope against the activation-signing roster. Tombstones share the
+// contract-activation-signing key purpose with active-manifest signers:
+// the operator authority to mint a tombstone is the same authority that
+// promotes contracts in the first place. A bad signature is a hard
+// error, not a silent skip, because a forged tombstone file would
+// otherwise let an attacker either DoS legitimate manifests or hide an
+// authentic tombstone behind a corrupted one.
+func verifyTombstoneSignature(env contract.TombstoneEnvelope, opts Options) error {
+	if opts.Roster == nil {
+		return fmt.Errorf("%w: roster is required", ErrTombstoneSignature)
+	}
+	if env.Body.KeyPurpose != signing.PurposeContractActivationSigning.String() {
+		return fmt.Errorf("%w: key_id=%q purpose=%q", ErrTombstoneSignature, env.Body.SignerKeyID, env.Body.KeyPurpose)
+	}
+	key, err := opts.Roster.ResolveKey(env.Body.SignerKeyID, now(opts))
+	if err != nil {
+		return fmt.Errorf("%w: key_id=%q: %w", ErrTombstoneSignature, env.Body.SignerKeyID, err)
+	}
+	if key.KeyPurpose != signing.PurposeContractActivationSigning.String() {
+		return fmt.Errorf("%w: key_id=%q roster purpose=%q", ErrTombstoneSignature, env.Body.SignerKeyID, key.KeyPurpose)
+	}
+	sigBytes, err := parseSignature(env.Signature)
+	if err != nil {
+		return fmt.Errorf("%w: key_id=%q: %w", ErrTombstoneSignature, env.Body.SignerKeyID, err)
+	}
+	pub, err := hex.DecodeString(key.PublicKeyHex)
+	if err != nil {
+		return fmt.Errorf("%w: key_id=%q public key: %w", ErrTombstoneSignature, env.Body.SignerKeyID, err)
+	}
+	preimage, err := env.Body.SignablePreimage()
+	if err != nil {
+		return fmt.Errorf("%w: tombstone preimage: %w", ErrTombstoneSignature, err)
+	}
+	if !contract.VerifyEd25519PureEdDSA(pub, preimage, sigBytes) {
+		return fmt.Errorf("%w: key_id=%q", ErrTombstoneSignature, env.Body.SignerKeyID)
+	}
+	return nil
+}
+
+func (s Store) tombstoneDir() string {
+	return filepath.Join(s.root, tombstoneDirname)
+}
+
+func (s Store) tombstonePath(priorContractHash string) (string, error) {
+	return objectPath(s.tombstoneDir(), priorContractHash, jsonExt)
+}
+
+func (s Store) legacyTombstonePath(priorContractHash string) (string, error) {
+	return objectPath(s.tombstoneDir(), priorContractHash, ".tombstone.yaml")
+}
+
+type tombstoneCandidate struct {
+	path   string
+	decode func([]byte) (contract.TombstoneEnvelope, error)
+}
+
+func (s Store) tombstoneCandidates(priorContractHash string) ([]tombstoneCandidate, error) {
+	jsonPath, err := s.tombstonePath(priorContractHash)
+	if err != nil {
+		return nil, err
+	}
+	legacyPath, err := s.legacyTombstonePath(priorContractHash)
+	if err != nil {
+		return nil, err
+	}
+	return []tombstoneCandidate{
+		{path: jsonPath, decode: decodeTombstone},
+		{path: legacyPath, decode: decodeTombstoneYAML},
+	}, nil
+}

--- a/internal/contract/store/tombstone_test.go
+++ b/internal/contract/store/tombstone_test.go
@@ -1,0 +1,657 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestStore_PutTombstone_RoundTrip(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signTestTombstone(t, newTombstoneBody(cHash, signer), signer)
+	raw := mustJSON(t, env)
+
+	got, err := st.PutTombstone(raw, testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("PutTombstone: %v", err)
+	}
+	if got != cHash {
+		t.Fatalf("PutTombstone hash = %q, want %q", got, cHash)
+	}
+
+	loaded, found, err := st.LoadTombstone(cHash, testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("LoadTombstone: %v", err)
+	}
+	if !found {
+		t.Fatal("LoadTombstone found = false, want true")
+	}
+	if loaded.Body.PriorContractHash != cHash {
+		t.Fatalf("loaded prior_contract_hash = %q, want %q", loaded.Body.PriorContractHash, cHash)
+	}
+	if loaded.Body.SignerKeyID != signer.keyID {
+		t.Fatalf("loaded signer_key_id = %q, want %q", loaded.Body.SignerKeyID, signer.keyID)
+	}
+}
+
+func TestStore_LoadTombstone_MissingReturnsFalseNoError(t *testing.T) {
+	st := New(t.TempDir())
+	signer := newTestSigner(t, "act-1", "alice")
+	missing := mustComputeContractHash(t, []byte("nonexistent"))
+
+	env, found, err := st.LoadTombstone(missing, testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("LoadTombstone missing: %v", err)
+	}
+	if found {
+		t.Fatal("LoadTombstone found = true on missing file")
+	}
+	if env.Body.PriorContractHash != "" {
+		t.Fatalf("missing tombstone returned non-zero body: %+v", env.Body)
+	}
+}
+
+func TestStore_PutTombstone_RejectsBadSignature(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	body := newTombstoneBody(cHash, signer)
+	env := contract.TombstoneEnvelope{
+		Body:      body,
+		Signature: "ed25519:" + strings.Repeat("00", 64),
+	}
+
+	_, err := st.PutTombstone(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrTombstoneSignature) {
+		t.Fatalf("PutTombstone err = %v, want ErrTombstoneSignature", err)
+	}
+}
+
+func TestStore_PutTombstone_RejectsWrongKeyPurpose(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	body := newTombstoneBody(cHash, signer)
+	body.KeyPurpose = signing.PurposeContractCompileSigning.String()
+	env := signTombstoneEnvelope(t, body, signer)
+
+	_, err := st.PutTombstone(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, contract.ErrTombstoneWrongKeyPurpose) {
+		t.Fatalf("PutTombstone err = %v, want ErrTombstoneWrongKeyPurpose", err)
+	}
+	if !errors.Is(err, ErrStructural) {
+		t.Fatalf("PutTombstone err = %v, want wrapped by ErrStructural", err)
+	}
+}
+
+func TestStore_PutTombstone_RejectsUnknownSigner(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	rosterSigner := newTestSigner(t, "act-1", "alice")
+	rogueSigner := newTestSigner(t, "rogue", "mallory")
+	env := signTestTombstone(t, newTombstoneBody(cHash, rogueSigner), rogueSigner)
+
+	_, err := st.PutTombstone(mustJSON(t, env), testOptions(testRoster(rosterSigner), "", 0, 1))
+	if !errors.Is(err, ErrTombstoneSignature) {
+		t.Fatalf("PutTombstone err = %v, want ErrTombstoneSignature for unknown signer", err)
+	}
+}
+
+func TestStore_PutTombstone_WriteOnceConflict(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	first := signTestTombstone(t, newTombstoneBody(cHash, signer), signer)
+	firstRaw := mustJSON(t, first)
+	if _, err := st.PutTombstone(firstRaw, testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("PutTombstone first: %v", err)
+	}
+
+	if _, err := st.PutTombstone(firstRaw, testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("PutTombstone idempotent: %v", err)
+	}
+
+	conflict := signTestTombstone(t, func() contract.Tombstone {
+		body := newTombstoneBody(cHash, signer)
+		body.RedactedAt = "2026-05-13T18:00:00Z"
+		return body
+	}(), signer)
+	_, err := st.PutTombstone(mustJSON(t, conflict), testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrWriteOnceConflict) {
+		t.Fatalf("PutTombstone conflict err = %v, want ErrWriteOnceConflict", err)
+	}
+}
+
+func TestStore_PutTombstone_RejectsMalformedHash(t *testing.T) {
+	st := New(t.TempDir())
+	signer := newTestSigner(t, "act-1", "alice")
+	body := newTombstoneBody("not-a-hash", signer)
+	env := signTombstoneEnvelope(t, body, signer)
+
+	_, err := st.PutTombstone(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrContractHistory) {
+		t.Fatalf("PutTombstone err = %v, want ErrContractHistory for malformed hash", err)
+	}
+}
+
+func TestStore_LoadTombstone_FilenameHashMismatch_FailsClosed(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	otherHash := mustComputeContractHash(t, []byte("other-payload"))
+	signer := newTestSigner(t, "act-1", "alice")
+
+	body := newTombstoneBody(otherHash, signer)
+	env := signTombstoneEnvelope(t, body, signer)
+	raw := mustJSON(t, env)
+	if err := os.MkdirAll(st.tombstoneDir(), dirPerm); err != nil {
+		t.Fatalf("mkdir tombstones: %v", err)
+	}
+	pathForOther, err := st.tombstonePath(cHash)
+	if err != nil {
+		t.Fatalf("tombstonePath: %v", err)
+	}
+	if err := os.WriteFile(pathForOther, raw, filePerm); err != nil {
+		t.Fatalf("write tombstone with mismatched hash: %v", err)
+	}
+
+	_, _, err = st.LoadTombstone(cHash, testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrTombstoneSignature) {
+		t.Fatalf("LoadTombstone filename mismatch err = %v, want ErrTombstoneSignature", err)
+	}
+}
+
+func TestStore_LoadTombstone_CorruptFile_FailsClosed(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+
+	if err := os.MkdirAll(st.tombstoneDir(), dirPerm); err != nil {
+		t.Fatalf("mkdir tombstones: %v", err)
+	}
+	path, err := st.tombstonePath(cHash)
+	if err != nil {
+		t.Fatalf("tombstonePath: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("not a tombstone"), filePerm); err != nil {
+		t.Fatalf("write garbage: %v", err)
+	}
+
+	_, _, err = st.LoadTombstone(cHash, testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrTombstoneDecode) {
+		t.Fatalf("LoadTombstone garbage err = %v, want ErrTombstoneDecode", err)
+	}
+}
+
+func TestStore_ValidateEnvelope_TombstonedContract_Rejected(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+
+	tomb := signTestTombstone(t, newTombstoneBody(cHash, signer), signer)
+	if _, err := st.PutTombstone(mustJSON(t, tomb), testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("PutTombstone: %v", err)
+	}
+
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	_, err := st.ValidateEnvelope(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrContractTombstoned) {
+		t.Fatalf("ValidateEnvelope err = %v, want ErrContractTombstoned", err)
+	}
+	if !strings.Contains(err.Error(), cHash) {
+		t.Errorf("error message does not name tombstoned hash %s: %v", cHash, err)
+	}
+	if !strings.Contains(err.Error(), "alice-auth-id") {
+		t.Errorf("error message does not include authorization id: %v", err)
+	}
+}
+
+func TestStore_ValidateEnvelope_NoTombstone_StillAccepts(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+
+	if _, err := st.ValidateEnvelope(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("ValidateEnvelope without tombstone: %v", err)
+	}
+}
+
+func TestStore_Reload_TombstonedContract_RecordsJournalRejection(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	raw := mustJSON(t, env)
+	if _, err := st.WriteActive(raw, testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("WriteActive: %v", err)
+	}
+
+	tomb := signTestTombstone(t, newTombstoneBody(cHash, signer), signer)
+	if _, err := st.PutTombstone(mustJSON(t, tomb), testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("PutTombstone: %v", err)
+	}
+
+	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); !errors.Is(err, ErrContractTombstoned) {
+		t.Fatalf("Reload err = %v, want ErrContractTombstoned", err)
+	}
+
+	journal, err := os.ReadFile(st.journalPath())
+	if err != nil {
+		t.Fatalf("read journal: %v", err)
+	}
+	if !strings.Contains(string(journal), "rejected") {
+		t.Errorf("journal does not record rejected outcome: %s", journal)
+	}
+	if !strings.Contains(string(journal), "tombstoned") {
+		t.Errorf("journal does not name tombstoned reason: %s", journal)
+	}
+}
+
+func TestStore_ValidateEnvelope_TombstoneFor_DifferentContract_StillAccepts(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+
+	otherHash := mustComputeContractHash(t, []byte("other-contract-payload"))
+	tomb := signTestTombstone(t, newTombstoneBody(otherHash, signer), signer)
+	if _, err := st.PutTombstone(mustJSON(t, tomb), testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("PutTombstone for other hash: %v", err)
+	}
+
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	if _, err := st.ValidateEnvelope(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("ValidateEnvelope with unrelated tombstone: %v", err)
+	}
+}
+
+func TestStore_ValidateEnvelope_LegacyYAMLTombstone_Rejected(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+
+	tomb := signTestTombstone(t, newTombstoneBody(cHash, signer), signer)
+	if err := os.MkdirAll(st.tombstoneDir(), dirPerm); err != nil {
+		t.Fatalf("mkdir tombstones: %v", err)
+	}
+	path, err := st.legacyTombstonePath(cHash)
+	if err != nil {
+		t.Fatalf("legacyTombstonePath: %v", err)
+	}
+	if err := os.WriteFile(path, mustYAMLWithJSONTags(t, tomb), filePerm); err != nil {
+		t.Fatalf("write legacy tombstone: %v", err)
+	}
+
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	_, err = st.ValidateEnvelope(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrContractTombstoned) {
+		t.Fatalf("ValidateEnvelope legacy YAML tombstone err = %v, want ErrContractTombstoned", err)
+	}
+}
+
+func TestStore_Accepted_TombstonedContract_Rejected(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	manifestHash, err := st.WriteActive(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("WriteActive: %v", err)
+	}
+	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	tomb := signTestTombstone(t, newTombstoneBody(cHash, signer), signer)
+	if _, err := st.PutTombstone(mustJSON(t, tomb), testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("PutTombstone: %v", err)
+	}
+
+	_, err = st.Accepted(manifestHash, testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrContractTombstoned) {
+		t.Fatalf("Accepted err = %v, want ErrContractTombstoned (rollback bypass)", err)
+	}
+	history, err := st.AcceptedHistory(manifestHash, testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("AcceptedHistory should still load tombstoned historical manifest for chain checks: %v", err)
+	}
+	if history.ManifestHash != manifestHash {
+		t.Fatalf("AcceptedHistory hash = %s, want %s", history.ManifestHash, manifestHash)
+	}
+}
+
+func TestStore_LatestAccepted_TombstonedContract_Rejected(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	if _, err := st.WriteActive(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("WriteActive: %v", err)
+	}
+	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	tomb := signTestTombstone(t, newTombstoneBody(cHash, signer), signer)
+	if _, err := st.PutTombstone(mustJSON(t, tomb), testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("PutTombstone: %v", err)
+	}
+
+	_, err := st.LatestAccepted(testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrContractTombstoned) {
+		t.Fatalf("LatestAccepted err = %v, want ErrContractTombstoned (recovery bypass)", err)
+	}
+	history, err := st.LatestAcceptedHistory(testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("LatestAcceptedHistory should still load tombstoned historical manifest for baselines: %v", err)
+	}
+	if history.Envelope.Body.Generation != 1 {
+		t.Fatalf("LatestAcceptedHistory generation = %d, want 1", history.Envelope.Body.Generation)
+	}
+}
+
+func TestStore_WriteActive_CanAdvancePastTombstonedCurrent(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	replacementHash := putAlternateTestContract(t, st, "agent-b")
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	manifestHash, err := st.WriteActive(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1))
+	if err != nil {
+		t.Fatalf("WriteActive gen1: %v", err)
+	}
+	if _, err := st.Reload(testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("Reload gen1: %v", err)
+	}
+
+	tomb := signTestTombstone(t, newTombstoneBody(cHash, signer), signer)
+	if _, err := st.PutTombstone(mustJSON(t, tomb), testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("PutTombstone: %v", err)
+	}
+
+	replacement := signedManifest(t, replacementHash, 2, manifestHash, testEnv(), signer)
+	if _, err := st.WriteActive(mustJSON(t, replacement), testOptions(testRoster(signer), "", 0, 1)); err != nil {
+		t.Fatalf("WriteActive replacement after tombstoned current: %v", err)
+	}
+	if _, err := st.Reload(testOptions(testRoster(signer), manifestHash, 1, 1)); err != nil {
+		t.Fatalf("Reload replacement after tombstoned current: %v", err)
+	}
+}
+
+func TestStore_PutTombstone_RejectsGarbageJSON(t *testing.T) {
+	st := New(t.TempDir())
+	signer := newTestSigner(t, "act-1", "alice")
+
+	_, err := st.PutTombstone([]byte("not-json"), testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrTombstoneDecode) {
+		t.Fatalf("PutTombstone garbage err = %v, want ErrTombstoneDecode", err)
+	}
+}
+
+func TestStore_PutTombstone_RejectsNilRoster(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signTestTombstone(t, newTombstoneBody(cHash, signer), signer)
+
+	opts := testOptions(nil, "", 0, 1)
+	_, err := st.PutTombstone(mustJSON(t, env), opts)
+	if !errors.Is(err, ErrTombstoneSignature) {
+		t.Fatalf("PutTombstone nil roster err = %v, want ErrTombstoneSignature", err)
+	}
+}
+
+func TestStore_PutTombstone_RejectsMalformedSignaturePrefix(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+	body := newTombstoneBody(cHash, signer)
+	env := contract.TombstoneEnvelope{
+		Body:      body,
+		Signature: "no-prefix-here",
+	}
+
+	_, err := st.PutTombstone(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrTombstoneSignature) {
+		t.Fatalf("PutTombstone bad signature prefix err = %v, want ErrTombstoneSignature", err)
+	}
+}
+
+func TestStore_LoadTombstone_MalformedHashRequest(t *testing.T) {
+	st := New(t.TempDir())
+	signer := newTestSigner(t, "act-1", "alice")
+
+	_, _, err := st.LoadTombstone("not-a-valid-hash", testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrContractHistory) {
+		t.Fatalf("LoadTombstone malformed hash err = %v, want ErrContractHistory", err)
+	}
+}
+
+func TestStore_LoadTombstone_BadBodyValidate_FailsClosed(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+
+	body := newTombstoneBody(cHash, signer)
+	body.SchemaVersion = 99
+	env := signTombstoneEnvelope(t, body, signer)
+	raw := mustJSON(t, env)
+	if err := os.MkdirAll(st.tombstoneDir(), dirPerm); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path, err := st.tombstonePath(cHash)
+	if err != nil {
+		t.Fatalf("tombstonePath: %v", err)
+	}
+	if err := os.WriteFile(path, raw, filePerm); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, _, err = st.LoadTombstone(cHash, testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrStructural) {
+		t.Fatalf("LoadTombstone bad schema err = %v, want ErrStructural", err)
+	}
+}
+
+func TestStore_LoadTombstone_BadSignature_FailsClosed(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+
+	body := newTombstoneBody(cHash, signer)
+	env := contract.TombstoneEnvelope{
+		Body:      body,
+		Signature: "ed25519:" + strings.Repeat("00", 64),
+	}
+	raw := mustJSON(t, env)
+	if err := os.MkdirAll(st.tombstoneDir(), dirPerm); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path, err := st.tombstonePath(cHash)
+	if err != nil {
+		t.Fatalf("tombstonePath: %v", err)
+	}
+	if err := os.WriteFile(path, raw, filePerm); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, _, err = st.LoadTombstone(cHash, testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrTombstoneSignature) {
+		t.Fatalf("LoadTombstone bad signature err = %v, want ErrTombstoneSignature", err)
+	}
+}
+
+func TestStore_VerifyTombstoneSignature_RejectsWrongBodyKeyPurpose(t *testing.T) {
+	signer := newTestSigner(t, "act-1", "alice")
+	body := newTombstoneBody("sha256:"+strings.Repeat("ab", 32), signer)
+	body.KeyPurpose = "wrong-purpose"
+	env := contract.TombstoneEnvelope{
+		Body:      body,
+		Signature: "ed25519:" + strings.Repeat("00", 64),
+	}
+
+	err := verifyTombstoneSignature(env, testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrTombstoneSignature) {
+		t.Fatalf("verifyTombstoneSignature wrong body purpose err = %v, want ErrTombstoneSignature", err)
+	}
+}
+
+func TestStore_LoadTombstone_PropagatesReadError(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+
+	restore := replaceReadFile(func(string) ([]byte, error) {
+		return nil, errors.New("forced read failure")
+	})
+	defer restore()
+
+	_, _, err := st.LoadTombstone(cHash, testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrTombstoneDecode) {
+		t.Fatalf("LoadTombstone read err = %v, want ErrTombstoneDecode", err)
+	}
+}
+
+func TestStore_VerifyTombstoneSignature_RejectsCorruptRosterHex(t *testing.T) {
+	signer := newTestSigner(t, "act-1", "alice")
+	env := signTestTombstone(t, contract.NewTombstone(
+		"sha256:"+strings.Repeat("ab", 32),
+		"2026-05-13T16:30:00Z",
+		"alice-auth-id",
+		signer.keyID,
+	), signer)
+
+	roster := &signing.LoadedRoster{Body: contract.KeyRoster{Keys: []contract.KeyInfo{
+		{
+			KeyID:        signer.keyID,
+			KeyPurpose:   signing.PurposeContractActivationSigning.String(),
+			PublicKeyHex: "not-hex-XX",
+			ValidFrom:    testNow.Add(-time.Hour).Format(time.RFC3339),
+			Status:       contract.KeyStatusActive,
+			Principal:    signer.principal,
+		},
+	}}}
+	opts := Options{Roster: roster, Now: func() time.Time { return testNow }}
+	err := verifyTombstoneSignature(env, opts)
+	if !errors.Is(err, ErrTombstoneSignature) {
+		t.Fatalf("verifyTombstoneSignature corrupt hex err = %v, want ErrTombstoneSignature", err)
+	}
+}
+
+func TestStore_ValidateEnvelope_TombstoneCheck_PropagatesCorruptStoreError(t *testing.T) {
+	st := New(t.TempDir())
+	cHash := putTestContract(t, st)
+	signer := newTestSigner(t, "act-1", "alice")
+
+	if err := os.MkdirAll(st.tombstoneDir(), dirPerm); err != nil {
+		t.Fatalf("mkdir tombstones: %v", err)
+	}
+	path, err := st.tombstonePath(cHash)
+	if err != nil {
+		t.Fatalf("tombstonePath: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("garbage"), filePerm); err != nil {
+		t.Fatalf("write garbage tombstone: %v", err)
+	}
+
+	env := signedManifest(t, cHash, 1, "sha256:genesis", testEnv(), signer)
+	_, err = st.ValidateEnvelope(mustJSON(t, env), testOptions(testRoster(signer), "", 0, 1))
+	if !errors.Is(err, ErrTombstoneDecode) {
+		t.Fatalf("ValidateEnvelope with corrupt tombstone err = %v, want ErrTombstoneDecode", err)
+	}
+}
+
+// newTombstoneBody returns a Tombstone with all required fields populated
+// for the given signer. RedactedAt is fixed so test cases that compare
+// distinct bytes can vary it deliberately.
+func newTombstoneBody(priorContractHash string, signer testSigner) contract.Tombstone {
+	return contract.NewTombstone(
+		priorContractHash,
+		"2026-05-13T16:30:00Z",
+		signer.principal+"-auth-id",
+		signer.keyID,
+	)
+}
+
+func signTestTombstone(t *testing.T, body contract.Tombstone, signer testSigner) contract.TombstoneEnvelope {
+	t.Helper()
+	return signTombstoneEnvelope(t, body, signer)
+}
+
+func signTombstoneEnvelope(t *testing.T, body contract.Tombstone, signer testSigner) contract.TombstoneEnvelope {
+	t.Helper()
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("Tombstone.SignablePreimage: %v", err)
+	}
+	sig := ed25519.Sign(signer.priv, preimage)
+	return contract.TombstoneEnvelope{
+		Body:      body,
+		Signature: "ed25519:" + hex.EncodeToString(sig),
+	}
+}
+
+func putAlternateTestContract(t *testing.T, st Store, agent string) string {
+	t.Helper()
+	compileSigner := testCompileSigner()
+	c := testContractBody(compileSigner)
+	c.Selector.Agent = agent
+	hash, err := ContractHash(c)
+	if err != nil {
+		t.Fatalf("ContractHash alternate: %v", err)
+	}
+	c.ContractHash = hash
+	raw := mustJSON(t, signTestContract(t, c, compileSigner))
+	got, err := st.PutHistoryContract(raw, testOptions(testRoster(), "", 0, 1))
+	if err != nil {
+		t.Fatalf("PutHistoryContract alternate: %v", err)
+	}
+	if got != hash {
+		t.Fatalf("PutHistoryContract alternate hash = %q, want %q", got, hash)
+	}
+	return hash
+}
+
+func mustYAMLWithJSONTags(t *testing.T, v any) []byte {
+	t.Helper()
+	raw := mustJSON(t, v)
+	var tree any
+	if err := yaml.Unmarshal(raw, &tree); err != nil {
+		t.Fatalf("yaml tree unmarshal: %v", err)
+	}
+	out, err := yaml.Marshal(tree)
+	if err != nil {
+		t.Fatalf("yaml marshal: %v", err)
+	}
+	return out
+}
+
+// mustComputeContractHash returns a deterministic synthetic sha256 hash
+// suitable for "no tombstone exists" / "tombstone for unrelated hash"
+// tests. Not derived from a real contract; only used where the test
+// does not need the hash to round-trip through the store.
+func mustComputeContractHash(t *testing.T, seed []byte) string {
+	t.Helper()
+	out := make([]byte, 32)
+	for i := range out {
+		if i < len(seed) {
+			out[i] = seed[i]
+		} else {
+			out[i] = byte(i)
+		}
+	}
+	return hashPrefix + hex.EncodeToString(out)
+}

--- a/internal/contract/tombstone.go
+++ b/internal/contract/tombstone.go
@@ -29,18 +29,15 @@ const dataClassRootTombstoneDefault = "internal"
 
 // Tombstone is the typed signable body of a contract tombstone record.
 //
-// In v2.4 a tombstone is a signed evidence marker that a prior contract
-// hash was withdrawn. It is NOT enforced at activation time: the active
-// contract store does not cross-check tombstones during
-// ValidateEnvelope, so a prior contract hash CAN be re-promoted under
-// v2.4 semantics. The tombstone exists so external auditors can prove
-// the operator declared the prior contract redacted; activation
-// enforcement is a v2.5 follow-up tracked under v2.4 known gaps in the
-// release spec.
-//
-// Operators who need enforcement today must not re-promote a hash they
-// have already tombstoned. Future versions will add a hard cross-check
-// in the activation pipeline.
+// A tombstone is a signed evidence marker that a prior contract hash
+// was withdrawn. As of v2.5 the active contract store cross-checks
+// tombstones during ValidateEnvelope: a manifest whose selectors
+// reference a contract hash for which a signed tombstone exists is
+// rejected with ErrContractTombstoned. The tombstone signature must
+// pass the contract-activation-signing roster check, the body's
+// prior_contract_hash must match the filename on disk, and structural
+// validation must pass; otherwise the tombstone is treated as
+// corrupted and validation fails closed.
 type Tombstone struct {
 	SchemaVersion            int    `json:"schema_version"`
 	Tombstone                bool   `json:"tombstone"`


### PR DESCRIPTION
Closes a documented contract-promotion gap: a tombstoned contract hash could be re-promoted because the tombstone existed only as audit evidence and was never consulted during activation.

This PR adds a signed tombstone store and cross-checks it at every runtime-state ADOPTION point:

- `ValidateEnvelope` (covers `Reload` and `WriteActive` promotion)
- `Accepted` (covers loader recovery from a prior-hash mismatch and `learn activate --rollback`)
- `LatestAccepted` (covers recovery and current-state inspection)

Baseline / chain-continuity reads use new `LatestAcceptedHistory` and `AcceptedHistory` methods, which return historical state without the tombstone adoption gate. `learn activate` uses these for baseline metadata so an operator can compile a clean replacement after the current contract was tombstoned. The loader uses them for chain-continuity walks. `WriteActive`'s current-active metadata lookup also skips the gate so a clean replacement can advance past a tombstoned current manifest.

## Tombstone format

Tombstones live in `<root>/tombstones/`. The canonical store object is `sha256-<hex>.json`. Legacy YAML tombstones written by the existing `pipelock learn forget` workflow (`sha256-<hex>.tombstone.yaml`) are also honored so existing operator evidence enforces correctly. Both shapes are signed by activation-signing keys, decoded strictly, structurally validated, and signature-verified on every load. Tombstone filename and body `prior_contract_hash` must agree, so an attacker who can write a tombstone file cannot plant one for a different contract hash than the filename advertises.

## Defense in depth

A bad tombstone file is fail-closed rather than silently skipped: a forged or corrupted tombstone would otherwise let an attacker mask a re-promotion attempt by overwriting the legitimate tombstone with garbage. The cost is that operators must keep tombstones syntactically valid; the `writeOnce` gate on `PutTombstone` already enforces that for the canonical path.

17 tests cover the security-critical re-promotion rejection through `ValidateEnvelope`, `Accepted`, and `LatestAccepted`, the legacy YAML path, History variants staying tombstone-neutral, clean replacement after a tombstoned current manifest, journal recording on Reload, and fail-closed behavior on every corruption mode (garbage file, bad schema, mismatched filename, bad signature, wrong key purpose, unknown signer, malformed hash, missing roster).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contract tombstone support: contracts can now be permanently deactivated with cryptographic signatures, and manifests referencing tombstoned contracts are rejected during validation.

* **Improvements**
  * Enhanced contract history retrieval with dedicated APIs that bypass certain validation gates while maintaining baseline integrity checks.

* **Documentation**
  * Updated documentation to reflect v2.5 tombstone enforcement behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/521)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->