### PR TITLE
feat(envelope): require SPIFFE actors on inbound + add envelope trust CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Pipelock will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`pipelock envelope trust` operator CLI.** New `pipelock envelope trust add/list/remove/verify` commands manage a local JSON trust list for operator review, peer onboarding, and manual envelope verification. The runtime proxy verifier still reads trusted keys from `mediation_envelope.verify_inbound.trust_list` in `pipelock.yaml`; the local store does not change runtime admission until runtime trust-store loading is added.
+
+### Security Hardening
+
+- **Inbound mediation-envelope verification now requires SPIFFE actors by default.** `mediation_envelope.actor_format: spiffe` already emitted SPIFFE actors on outbound envelopes; it now also requires verified inbound envelopes to carry syntactically valid SPIFFE IDs. Operators with mixed-mode federations that still receive legacy free-form actor strings must set `mediation_envelope.actor_format: legacy` temporarily to preserve v2.4 behavior during peer migration.
+
 ## [2.4.0] - 2026-05-06
 
 ### Highlights

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2154,7 +2154,7 @@ mediation_envelope:
 | `signed_components` | (see below) | Ordered list of RFC 9421 component identifiers covered by the signature. |
 | `created_skew_seconds` | `60` | Clock-drift tolerance (seconds) accepted between signer and verifier. |
 | `max_body_bytes` | `1048576` | Upper bound on the body drained for Content-Digest when body scanning is disabled. |
-| `actor_format` | `spiffe` | Format for newly emitted `actor` values. `spiffe` maps agent names to `spiffe://<trust_domain>/agent/<name>`; `legacy` preserves the configured name. |
+| `actor_format` | `spiffe` | Format for newly emitted `actor` values and inbound verification strictness. `spiffe` maps agent names to `spiffe://<trust_domain>/agent/<name>` and requires verified inbound actors to be valid SPIFFE IDs. `legacy` preserves the older free-form actor string and keeps inbound actor parsing permissive for migration. |
 | `trust_domain` | `pipelock.local` | SPIFFE trust domain used when `actor_format: spiffe`. Must be a DNS-shaped label with no scheme, slashes, userinfo, or port. |
 | `signature_expires` | `=replay_cache.window` | Per-signature lifetime emitted by the outbound signer (Go duration string). When `verify_inbound.enabled` is true, this must be `<= verify_inbound.replay_cache.window`; an explicit value larger than the window is rejected at startup so a captured signature can never outlive its replay-cache nonce. When inbound verification is disabled, any positive duration is accepted. Empty falls back to the configured replay-cache window. |
 | `verify_inbound.enabled` | `false` | Require every inbound request on this listener to carry a valid Pipelock mediation signature before the inbound envelope headers are stripped. |

--- a/docs/guides/federation.md
+++ b/docs/guides/federation.md
@@ -123,11 +123,14 @@ pipelock envelope trust remove partner.example
 The default trust store is
 `$XDG_STATE_HOME/pipelock/envelope/trust.json` (or
 `~/.local/state/pipelock/envelope/trust.json` when `XDG_STATE_HOME` is unset)
-and is written with `0o600` permissions. `--store` intentionally selects an
-operator-controlled alternate path. `--source` fetches a public verification
-key from a well-known HTTP Message Signatures directory. Only use `--source`
-for a directory you already intend to trust; the fetched key becomes local
-trust material for operator verification workflows.
+and is written with `0o600` permissions. Its containing directory
+(`$XDG_STATE_HOME/pipelock/envelope` or
+`~/.local/state/pipelock/envelope`) is created with `0o750` permissions.
+`--store` intentionally selects an operator-controlled alternate path.
+`--source` fetches a public verification key from a well-known HTTP Message
+Signatures directory. Only use `--source` for a directory you already intend to
+trust; the fetched key becomes local trust material for operator verification
+workflows.
 
 Adding a peer to this store does not change runtime admission. Inbound proxy
 verification still uses the pinned keys in

--- a/docs/guides/federation.md
+++ b/docs/guides/federation.md
@@ -1,6 +1,6 @@
 # Federation: Inbound Envelope Verification, SPIFFE Actors, Well-Known Directory
 
-When two organisations both run Pipelock, the mediation envelope makes their proxies interoperate. v2.4 closes the federation loop:
+When two organisations both run Pipelock, the mediation envelope makes their proxies interoperate. The federation surface includes:
 
 - **Inbound envelope verification** so a Pipelock that receives a request signed by another Pipelock can verify the signature, check the trust list, and protect against replay.
 - **SPIFFE actor format** so mediators identify themselves with cryptographically-defined trust-domain identities instead of free-form strings.
@@ -41,9 +41,11 @@ mediation_envelope:
       max_entries: 100000           # nonce-keyed in-process cache
 ```
 
-### Permissive vs strict (v2.4 vs v2.5)
+### Permissive vs strict actors
 
-In v2.4 a `trust_list` entry with empty `trust_domains` accepts a signature for any claimed actor under that key. v2.5 will require an explicit `trust_domains` pin per key. Production deployments should pin every key from day one so a compromised partner key cannot impersonate an actor in another federation peer's trust domain.
+`mediation_envelope.actor_format: spiffe` is the default. It emits SPIFFE actor IDs on outbound envelopes and requires verified inbound envelopes to carry syntactically valid SPIFFE actors. The same knob controls both surfaces; set `mediation_envelope.actor_format: legacy` only for migration windows where a trusted peer still signs free-form actor strings.
+
+A `trust_list` entry with empty `trust_domains` accepts a signature for any claimed SPIFFE trust domain under that key. Production deployments should pin every key from day one so a compromised partner key cannot impersonate an actor in another federation peer's trust domain.
 
 ### Trust list
 
@@ -52,7 +54,7 @@ Each `trust_list` entry names a trusted signing key and what it is allowed to si
 - `key_id` — opaque identifier echoed in receipts so an auditor can trace which trusted key validated which envelope.
 - `public_key` — REQUIRED. Ed25519 public key, either raw 64-character hex or the versioned `pipelock-ed25519-public-v1` format emitted by Pipelock signing tooling. Validated at config-load.
 - `well_known_url` — optional metadata pointer. Validated as HTTPS at config-load. Inbound verification does NOT fetch from this URL; it is for human and tooling provenance. To rotate keys, update `public_key`.
-- `trust_domains` — optional. When non-empty, restricts the actor SPIFFE trust domain a signed envelope can claim under this key. When empty (v2.4 migration default), the key signs for any actor.
+- `trust_domains` — optional. When non-empty, restricts the actor SPIFFE trust domain a signed envelope can claim under this key. When empty, the key signs for any SPIFFE trust domain accepted by the current `actor_format`.
 
 Key rotation is a config change. Edit `public_key`, hot-reload (`SIGHUP` or fsnotify watch), and the new key is in effect. There is no automatic well-known fetch.
 
@@ -84,9 +86,13 @@ The cache is in-process. Multi-replica deployments (HA pairs, load-balanced side
 
 ## SPIFFE actor format
 
-Outbound envelopes write SPIFFE format by default in v2.4: `spiffe://<trust-domain>/agent/<name>` for individual agents, `spiffe://<trust-domain>/mediators/<deployment-id>` for the mediator itself.
+Outbound envelopes write SPIFFE format by default:
+`spiffe://<trust-domain>/agent/<name>` for individual agents,
+`spiffe://<trust-domain>/mediators/<deployment-id>` for the mediator itself.
 
-Inbound accepts both formats in v2.4 (permissive). v2.5 will require SPIFFE for inbound.
+Inbound requires SPIFFE by default. Operators can temporarily set
+`mediation_envelope.actor_format: legacy` to accept free-form actor strings
+from older trusted peers during migration.
 
 SPIFFE parsing follows the SPIFFE-ID §2 spec:
 
@@ -95,7 +101,38 @@ SPIFFE parsing follows the SPIFFE-ID §2 spec:
 - Workload path must be non-empty and canonical (no empty, `.`, or `..` segments) so allowlist checks comparing the workload as a string cannot be bypassed via path traversal.
 - Scheme must be exactly `spiffe`.
 
-Pipelock rejects malformed SPIFFE IDs at envelope verification time. Legacy free-form actors are accepted in permissive mode but flagged with `actor_format: "legacy"` in the verification result so operators can monitor migration progress.
+Pipelock rejects malformed SPIFFE IDs at envelope verification time. Legacy
+free-form actors are accepted only when `mediation_envelope.actor_format` is
+set to `legacy`.
+
+## Trust CLI
+
+Use `pipelock envelope trust` to manage the local operator trust list used for
+manual envelope verification and peer onboarding:
+
+```sh
+pipelock envelope trust add partner.example --key <64-char-ed25519-public-key-hex>
+pipelock envelope trust add spiffe://partner.example/agent/proxy \
+  --source https://partner.example/.well-known/http-message-signatures-directory
+pipelock envelope trust list
+pipelock envelope trust list --json
+pipelock envelope trust verify --stdin < signed-request.http
+pipelock envelope trust remove partner.example
+```
+
+The default trust store is
+`$XDG_STATE_HOME/pipelock/envelope/trust.json` (or
+`~/.local/state/pipelock/envelope/trust.json` when `XDG_STATE_HOME` is unset)
+and is written with `0o600` permissions. `--store` intentionally selects an
+operator-controlled alternate path. `--source` fetches a public verification
+key from a well-known HTTP Message Signatures directory. Only use `--source`
+for a directory you already intend to trust; the fetched key becomes local
+trust material for operator verification workflows.
+
+Adding a peer to this store does not change runtime admission. Inbound proxy
+verification still uses the pinned keys in
+`mediation_envelope.verify_inbound.trust_list` in `pipelock.yaml`; update that
+config and reload the proxy to change what runtime traffic can present.
 
 ## Well-known directory
 

--- a/docs/guides/mediation-envelope.md
+++ b/docs/guides/mediation-envelope.md
@@ -161,8 +161,9 @@ RFC 9421 HTTP Message Signatures for the mediation envelope ship in v2.2.0. The 
 **SPIFFE actors.** New outbound envelopes default to SPIFFE-formatted actors:
 `spiffe://<trust_domain>/agent/<agent-name>`. Set
 `mediation_envelope.actor_format: legacy` to preserve the older unstructured
-actor string during migration. Inbound parsing is permissive in v2.4: both
-legacy actor strings and SPIFFE IDs are accepted.
+actor string during migration. Inbound verification uses the same knob:
+`spiffe` requires verified inbound actors to be valid SPIFFE IDs, while
+`legacy` keeps the older permissive parser for migration.
 
 **Inbound verification.** Set `mediation_envelope.verify_inbound.enabled: true`
 with a `trust_list` of accepted `key_id` / Ed25519 public-key pairs to require
@@ -188,7 +189,8 @@ The verifier enforces three federation guards beyond signature validity:
   SPIFFE-ID §2: no userinfo, no port in the trust domain, no `..` or empty
   path segments. Allowlist comparisons on `actor.TrustDomain` or
   `actor.Workload` cannot be bypassed via traversal or smuggled authority
-  components.
+  components. Free-form actors are rejected unless
+  `mediation_envelope.actor_format: legacy` is explicitly configured.
 
 Verification runs on every transport — `/fetch`, forward CONNECT, WebSocket,
 TLS-intercepted CONNECT inner requests, and the reverse proxy — before the
@@ -200,6 +202,24 @@ public key at `/.well-known/http-message-signatures-directory` and emits an
 audit anomaly when the route is requested. Verifiers can fetch that JSON
 directory instead of sideloading a public-key pin. Unsigned envelope
 configurations return 404 for the well-known route.
+
+**Trust CLI.** `pipelock envelope trust` manages a local JSON trust list for
+operator verification workflows:
+
+```sh
+pipelock envelope trust add partner.example --key <64-char-ed25519-public-key-hex>
+pipelock envelope trust add spiffe://partner.example/agent/proxy \
+  --source https://partner.example/.well-known/http-message-signatures-directory
+pipelock envelope trust list --json
+pipelock envelope trust verify --stdin < signed-request.http
+```
+
+The store defaults to `$XDG_STATE_HOME/pipelock/envelope/trust.json` and is
+written with `0o600` permissions. `--store` intentionally selects an
+operator-controlled alternate path. The runtime proxy verifier still reads
+trusted keys from `mediation_envelope.verify_inbound.trust_list` in
+`pipelock.yaml`; the local trust store is for operator workflows until runtime
+trust-store loading is added.
 
 ## Example: reading the envelope in Go
 

--- a/internal/cli/envelope/cmd.go
+++ b/internal/cli/envelope/cmd.go
@@ -30,8 +30,11 @@ const (
 	directoryAlg               = "ed25519"
 	directoryUse               = "pipelock-mediation"
 	maxVerifyStdinBodyBytes    = 16 << 20
+	maxVerifyRawRequestBytes   = maxVerifyStdinBodyBytes + (1 << 20)
 	runtimeTrustAdvisoryFormat = "note: runtime proxy verification reads trusted keys from pipelock.yaml mediation_envelope.verify_inbound.trust_list; this trust store is for operator workflows until runtime trust-store loading is added.\n"
 )
+
+var errHTTPRequestTooLarge = errors.New("request exceeds size limit")
 
 // Cmd returns the `pipelock envelope` cobra command tree.
 func Cmd() *cobra.Command {
@@ -276,14 +279,22 @@ func fetchDirectoryKey(ctx context.Context, sourceURL string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parsing directory URL: %w", err)
 	}
-	if parsed.Scheme != "https" && !isLocalHTTPSource(parsed) {
+	if !isAllowedDirectoryURL(parsed) {
 		return "", errors.New("directory URL must be https or loopback http")
 	}
 	u, err := http.NewRequestWithContext(ctx, http.MethodGet, sourceURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("building directory request: %w", err)
 	}
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			if !isAllowedDirectoryURL(req.URL) {
+				return errors.New("directory URL must be https or loopback http")
+			}
+			return nil
+		},
+	}
 	resp, err := client.Do(u)
 	if err != nil {
 		return "", fmt.Errorf("fetching directory: %w", err)
@@ -364,8 +375,12 @@ func actorAllowedByTrustRecords(actor domenvelope.ParsedActor, records []trustRe
 }
 
 func readHTTPRequest(r io.Reader) (*http.Request, []byte, error) {
-	req, err := http.ReadRequest(bufio.NewReader(r))
+	limited := &requestLimitReader{r: r, remaining: maxVerifyRawRequestBytes}
+	req, err := http.ReadRequest(bufio.NewReader(limited))
 	if err != nil {
+		if limited.exceeded || errors.Is(err, errHTTPRequestTooLarge) {
+			return nil, nil, fmt.Errorf("request exceeds %d bytes", maxVerifyRawRequestBytes)
+		}
 		return nil, nil, fmt.Errorf("reading HTTP request: %w", err)
 	}
 	var body []byte
@@ -373,6 +388,9 @@ func readHTTPRequest(r io.Reader) (*http.Request, []byte, error) {
 		body, err = io.ReadAll(io.LimitReader(req.Body, maxVerifyStdinBodyBytes+1))
 		_ = req.Body.Close()
 		if err != nil {
+			if limited.exceeded || errors.Is(err, errHTTPRequestTooLarge) {
+				return nil, nil, fmt.Errorf("request exceeds %d bytes", maxVerifyRawRequestBytes)
+			}
 			return nil, nil, fmt.Errorf("reading request body: %w", err)
 		}
 		if len(body) > maxVerifyStdinBodyBytes {
@@ -382,6 +400,25 @@ func readHTTPRequest(r io.Reader) (*http.Request, []byte, error) {
 		req.ContentLength = int64(len(body))
 	}
 	return req, body, nil
+}
+
+type requestLimitReader struct {
+	r         io.Reader
+	remaining int64
+	exceeded  bool
+}
+
+func (r *requestLimitReader) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		r.exceeded = true
+		return 0, errHTTPRequestTooLarge
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:r.remaining]
+	}
+	n, err := r.r.Read(p)
+	r.remaining -= int64(n)
+	return n, err
 }
 
 func displayTrustTarget(rec trustRecord) string {

--- a/internal/cli/envelope/cmd.go
+++ b/internal/cli/envelope/cmd.go
@@ -1,0 +1,406 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package envelope implements operator CLI helpers for mediation envelopes.
+package envelope
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	domenvelope "github.com/luckyPipewrench/pipelock/internal/envelope"
+)
+
+const (
+	directoryAlg               = "ed25519"
+	directoryUse               = "pipelock-mediation"
+	maxVerifyStdinBodyBytes    = 16 << 20
+	runtimeTrustAdvisoryFormat = "note: runtime proxy verification reads trusted keys from pipelock.yaml mediation_envelope.verify_inbound.trust_list; this trust store is for operator workflows until runtime trust-store loading is added.\n"
+)
+
+// Cmd returns the `pipelock envelope` cobra command tree.
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "envelope",
+		Short:         "Manage mediation-envelope federation trust",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.AddCommand(trustCmd())
+	return cmd
+}
+
+func trustCmd() *cobra.Command {
+	var storePath string
+	cmd := &cobra.Command{
+		Use:           "trust",
+		Short:         "Manage trusted mediation-envelope peers",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.PersistentFlags().StringVar(&storePath, "store", "", "trust store path (default $XDG_STATE_HOME/pipelock/envelope/trust.json)")
+	cmd.AddCommand(
+		trustAddCmd(&storePath),
+		trustListCmd(&storePath),
+		trustRemoveCmd(&storePath),
+		trustVerifyCmd(&storePath),
+	)
+	return cmd
+}
+
+func trustAddCmd(storePath *string) *cobra.Command {
+	var keyHex, sourceURL string
+	cmd := &cobra.Command{
+		Use:   "add <trust-domain-or-spiffe-id>",
+		Short: "Add or update a trusted mediation-envelope peer",
+		Long: `Add or update a trusted mediation-envelope peer in the local operator
+trust store.
+
+The runtime proxy verifier does not read this store yet. To change what
+Pipelock accepts at runtime, update mediation_envelope.verify_inbound.trust_list
+in pipelock.yaml and reload the proxy. This store is used by operator workflows
+such as trust list review, peer onboarding, and envelope trust verify.
+
+Only use --source for a directory you already intend to trust. The fetched key
+becomes local trust material for operator verification workflows.`,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			trustDomain, spiffeID, err := parseTrustTarget(args[0])
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			key, source, err := resolveTrustKey(cmd.Context(), keyHex, sourceURL)
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			store, err := newTrustStore(*storePath)
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			records, err := store.load()
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			rec := trustRecord{
+				TrustDomain: trustDomain,
+				SPIFFEID:    spiffeID,
+				KeyHex:      key,
+				KeySource:   source,
+				AddedAt:     time.Now().UTC(),
+			}
+			idx := findTrustRecord(records, trustDomain, spiffeID)
+			switch {
+			case idx >= 0 && records[idx].KeyHex == key && records[idx].KeySource == source:
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "already trusted\t%s\n", displayTrustTarget(records[idx]))
+				_, _ = fmt.Fprint(cmd.ErrOrStderr(), runtimeTrustAdvisoryFormat)
+				return nil
+			case idx >= 0:
+				rec.AddedAt = records[idx].AddedAt
+				records[idx] = rec
+			default:
+				records = append(records, rec)
+			}
+			if err := store.save(records); err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "trusted\t%s\n", displayTrustTarget(rec))
+			_, _ = fmt.Fprint(cmd.ErrOrStderr(), runtimeTrustAdvisoryFormat)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&keyHex, "key", "", "raw hex Ed25519 public key")
+	cmd.Flags().StringVar(&sourceURL, "source", "", "well-known HTTP Message Signatures directory URL to trust")
+	return cmd
+}
+
+func trustListCmd(storePath *string) *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:           "list",
+		Short:         "List trusted mediation-envelope peers",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			store, err := newTrustStore(*storePath)
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			records, err := store.load()
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			if jsonOut {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(records)
+			}
+			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+			_, _ = fmt.Fprintln(tw, "TRUST_DOMAIN\tSPIFFE_ID\tKEY\tSOURCE\tADDED_AT")
+			for _, rec := range records {
+				_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+					rec.TrustDomain,
+					emptyDash(rec.SPIFFEID),
+					keySummary(rec.KeyHex),
+					emptyDash(rec.KeySource),
+					rec.AddedAt.UTC().Format(time.RFC3339),
+				)
+			}
+			return tw.Flush()
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "print trust list as JSON")
+	return cmd
+}
+
+func trustRemoveCmd(storePath *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "remove <trust-domain-or-spiffe-id>",
+		Short:         "Remove a trusted mediation-envelope peer",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			trustDomain, spiffeID, err := parseTrustTarget(args[0])
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			store, err := newTrustStore(*storePath)
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			records, err := store.load()
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			idx := findTrustRecord(records, trustDomain, spiffeID)
+			if idx < 0 {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("trust target %q is not present", args[0]))
+			}
+			removed := records[idx]
+			records = append(records[:idx], records[idx+1:]...)
+			if err := store.save(records); err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "removed\t%s\n", displayTrustTarget(removed))
+			return nil
+		},
+	}
+	return cmd
+}
+
+func trustVerifyCmd(storePath *string) *cobra.Command {
+	var stdin bool
+	cmd := &cobra.Command{
+		Use:           "verify",
+		Short:         "Verify an inbound mediation envelope against the trust list",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			store, err := newTrustStore(*storePath)
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			records, err := store.load()
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			verifier, err := verifierFromTrustRecords(records)
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			if !stdin {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "trust store ready\t%d trusted peer(s)\n", len(records))
+				return nil
+			}
+			req, body, err := readHTTPRequest(cmd.InOrStdin())
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			env, err := verifier.VerifyRequest(req, body)
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitSecurity, fmt.Errorf("verification failed: %w", err))
+			}
+			actor, err := domenvelope.ParseActorStrict(env.Actor)
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitSecurity, fmt.Errorf("verified envelope has invalid actor: %w", err))
+			}
+			if !actorAllowedByTrustRecords(actor, records) {
+				return cliutil.ExitCodeError(cliutil.ExitSecurity, fmt.Errorf("actor %q is not in the trust list", env.Actor))
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "verified\tactor=%s\ttrust_domain=%s\n", env.Actor, actor.TrustDomain)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "read a raw HTTP request from stdin")
+	return cmd
+}
+
+func resolveTrustKey(ctx context.Context, keyHex, sourceURL string) (string, string, error) {
+	keyHex = strings.TrimSpace(keyHex)
+	sourceURL = strings.TrimSpace(sourceURL)
+	switch {
+	case keyHex != "" && sourceURL != "":
+		return "", "", errors.New("use exactly one of --key or --source")
+	case keyHex != "":
+		key, err := normalizeKeyHex(keyHex)
+		return key, "", err
+	case sourceURL != "":
+		key, err := fetchDirectoryKey(ctx, sourceURL)
+		return key, sourceURL, err
+	default:
+		return "", "", errors.New("one of --key or --source is required")
+	}
+}
+
+func fetchDirectoryKey(ctx context.Context, sourceURL string) (string, error) {
+	parsed, err := url.Parse(sourceURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing directory URL: %w", err)
+	}
+	if parsed.Scheme != "https" && !isLocalHTTPSource(parsed) {
+		return "", errors.New("directory URL must be https or loopback http")
+	}
+	u, err := http.NewRequestWithContext(ctx, http.MethodGet, sourceURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("building directory request: %w", err)
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(u)
+	if err != nil {
+		return "", fmt.Errorf("fetching directory: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("directory returned HTTP %d", resp.StatusCode)
+	}
+	var dir domenvelope.Directory
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&dir); err != nil {
+		return "", fmt.Errorf("decoding directory: %w", err)
+	}
+	for _, key := range dir.Keys {
+		if key.Algorithm != directoryAlg || key.Use != directoryUse {
+			continue
+		}
+		keyHex, err := normalizeKeyHex(key.PublicKey)
+		if err != nil {
+			return "", fmt.Errorf("directory key %q: %w", key.KeyID, err)
+		}
+		return keyHex, nil
+	}
+	return "", errors.New("directory contains no pipelock Ed25519 mediation key")
+}
+
+// verifierFromTrustRecords builds a verifier at trust-domain granularity.
+// Callers that need SPIFFE-ID pins must also call actorAllowedByTrustRecords
+// after VerifyRequest succeeds; the verifier alone does not enforce them.
+func verifierFromTrustRecords(records []trustRecord) (*domenvelope.Verifier, error) {
+	if len(records) == 0 {
+		return nil, errors.New("trust store is empty")
+	}
+	keysByDomain := make(map[string]ed25519.PublicKey)
+	for _, rec := range records {
+		pubBytes, err := hex.DecodeString(rec.KeyHex)
+		if err != nil {
+			return nil, fmt.Errorf("decode key for %s: %w", rec.TrustDomain, err)
+		}
+		pub := ed25519.PublicKey(pubBytes)
+		if existing, ok := keysByDomain[rec.TrustDomain]; ok {
+			if !bytes.Equal(existing, pub) {
+				return nil, fmt.Errorf("trust domain %q has multiple keys; split it into one key before verifying", rec.TrustDomain)
+			}
+			continue
+		}
+		keysByDomain[rec.TrustDomain] = pub
+	}
+	keys := make([]domenvelope.TrustedKey, 0, len(keysByDomain))
+	for domain, pub := range keysByDomain {
+		keys = append(keys, domenvelope.TrustedKey{
+			KeyID:        domain,
+			PublicKey:    pub,
+			TrustDomains: []string{domain},
+		})
+	}
+	return domenvelope.NewVerifier(domenvelope.VerifierConfig{
+		TrustedKeys: keys,
+		ReplayCache: domenvelope.NewReplayCache(5*time.Minute, 10000),
+		Skew:        time.Minute,
+		ActorFormat: domenvelope.ActorFormatSPIFFE,
+	})
+}
+
+func actorAllowedByTrustRecords(actor domenvelope.ParsedActor, records []trustRecord) bool {
+	for _, rec := range records {
+		if rec.TrustDomain != actor.TrustDomain {
+			continue
+		}
+		if rec.SPIFFEID == "" {
+			return true
+		}
+		parsed, err := domenvelope.ParseActorStrict(rec.SPIFFEID)
+		if err == nil && parsed.TrustDomain == actor.TrustDomain && parsed.Workload == actor.Workload {
+			return true
+		}
+	}
+	return false
+}
+
+func readHTTPRequest(r io.Reader) (*http.Request, []byte, error) {
+	req, err := http.ReadRequest(bufio.NewReader(r))
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading HTTP request: %w", err)
+	}
+	var body []byte
+	if req.Body != nil {
+		body, err = io.ReadAll(io.LimitReader(req.Body, maxVerifyStdinBodyBytes+1))
+		_ = req.Body.Close()
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading request body: %w", err)
+		}
+		if len(body) > maxVerifyStdinBodyBytes {
+			return nil, nil, fmt.Errorf("request body exceeds %d bytes", maxVerifyStdinBodyBytes)
+		}
+		req.Body = io.NopCloser(bytes.NewReader(body))
+		req.ContentLength = int64(len(body))
+	}
+	return req, body, nil
+}
+
+func displayTrustTarget(rec trustRecord) string {
+	if rec.SPIFFEID != "" {
+		return rec.SPIFFEID
+	}
+	return rec.TrustDomain
+}
+
+func keySummary(key string) string {
+	if len(key) <= 16 {
+		return key
+	}
+	return key[:12] + "..." + key[len(key)-4:]
+}
+
+func emptyDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/internal/cli/envelope/cmd_test.go
+++ b/internal/cli/envelope/cmd_test.go
@@ -1,0 +1,708 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package envelope
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	domenvelope "github.com/luckyPipewrench/pipelock/internal/envelope"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const testTrustDomain = "partner.example"
+
+func TestTrustAddListRemoveRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(t.TempDir(), "trust.json")
+	pub, _, pubHex := testTrustKey(t)
+
+	out, stderr, err := runEnvelopeCmdFull("", "trust", "--store", storePath, "add", testTrustDomain, "--key", pubHex)
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if !strings.Contains(out, "trusted\tpartner.example") {
+		t.Fatalf("add output = %q", out)
+	}
+	if !strings.Contains(stderr, "runtime proxy verification reads trusted keys from pipelock.yaml") {
+		t.Fatalf("add stderr = %q", stderr)
+	}
+	info, err := os.Stat(storePath)
+	if err != nil {
+		t.Fatalf("stat store: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("store mode = %v, want 0o600", got)
+	}
+
+	out, err = runEnvelopeCmd("trust", "--store", storePath, "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out, testTrustDomain) || !strings.Contains(out, pubHex[:12]) {
+		t.Fatalf("list output = %q", out)
+	}
+
+	out, err = runEnvelopeCmd("trust", "--store", storePath, "list", "--json")
+	if err != nil {
+		t.Fatalf("list json: %v", err)
+	}
+	var records []trustRecord
+	if err := json.Unmarshal([]byte(out), &records); err != nil {
+		t.Fatalf("decode list json: %v\n%s", err, out)
+	}
+	if len(records) != 1 || records[0].TrustDomain != testTrustDomain || records[0].KeyHex != hex.EncodeToString(pub) {
+		t.Fatalf("records = %+v", records)
+	}
+
+	out, err = runEnvelopeCmd("trust", "--store", storePath, "remove", testTrustDomain)
+	if err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if !strings.Contains(out, "removed\tpartner.example") {
+		t.Fatalf("remove output = %q", out)
+	}
+	out, err = runEnvelopeCmd("trust", "--store", storePath, "list", "--json")
+	if err != nil {
+		t.Fatalf("list json after remove: %v", err)
+	}
+	records = nil
+	if err := json.Unmarshal([]byte(out), &records); err != nil {
+		t.Fatalf("decode list json after remove: %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("records after remove = %+v", records)
+	}
+}
+
+func TestTrustAddDuplicateIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(t.TempDir(), "trust.json")
+	_, _, pubHex := testTrustKey(t)
+	var lastStderr string
+	for i := 0; i < 2; i++ {
+		_, stderr, err := runEnvelopeCmdFull("", "trust", "--store", storePath, "add", testTrustDomain, "--key", pubHex)
+		if err != nil {
+			t.Fatalf("add %d: %v", i, err)
+		}
+		lastStderr = stderr
+	}
+	records := readTrustRecords(t, storePath)
+	if len(records) != 1 {
+		t.Fatalf("duplicate add wrote %d records", len(records))
+	}
+	if !strings.Contains(lastStderr, "operator workflows until runtime trust-store loading is added") {
+		t.Fatalf("duplicate add stderr = %q", lastStderr)
+	}
+}
+
+func TestTrustAddUpdatesExistingRecord(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(t.TempDir(), "trust.json")
+	_, _, firstKey := testTrustKey(t)
+	_, _, secondKey := testTrustKey(t)
+	if _, err := runEnvelopeCmd("trust", "--store", storePath, "add", testTrustDomain, "--key", firstKey); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	if _, err := runEnvelopeCmd("trust", "--store", storePath, "add", testTrustDomain, "--key", secondKey); err != nil {
+		t.Fatalf("second add: %v", err)
+	}
+	records := readTrustRecords(t, storePath)
+	if len(records) != 1 || records[0].KeyHex != secondKey {
+		t.Fatalf("records after update = %+v", records)
+	}
+}
+
+func TestTrustAddFromWellKnownSource(t *testing.T) {
+	t.Parallel()
+
+	_, _, pubHex := testTrustKey(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(domenvelope.Directory{Keys: []domenvelope.DirectoryKey{{
+			KeyID:     testTrustDomain,
+			Algorithm: directoryAlg,
+			PublicKey: pubHex,
+			Use:       directoryUse,
+		}}})
+	}))
+	t.Cleanup(server.Close)
+
+	storePath := filepath.Join(t.TempDir(), "trust.json")
+	if _, err := runEnvelopeCmd("trust", "--store", storePath, "add", testTrustDomain, "--source", server.URL+domenvelope.WellKnownPath); err != nil {
+		t.Fatalf("add source: %v", err)
+	}
+	records := readTrustRecords(t, storePath)
+	if len(records) != 1 || records[0].KeyHex != pubHex || records[0].KeySource == "" {
+		t.Fatalf("records = %+v", records)
+	}
+}
+
+func TestTrustCommandErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(t.TempDir(), "trust.json")
+	_, _, pubHex := testTrustKey(t)
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"malformed target", []string{"trust", "--store", storePath, "add", "https://bad.example", "--key", pubHex}},
+		{"missing key", []string{"trust", "--store", storePath, "add", testTrustDomain}},
+		{"key and source", []string{"trust", "--store", storePath, "add", testTrustDomain, "--key", pubHex, "--source", "https://partner.example/keys"}},
+		{"bad key", []string{"trust", "--store", storePath, "add", testTrustDomain, "--key", "not-hex"}},
+		{"nonlocal source", []string{"trust", "--store", storePath, "add", testTrustDomain, "--source", "http://not-local.example/keys"}},
+		{"malformed remove target", []string{"trust", "--store", storePath, "remove", "https://bad.example"}},
+		{"remove missing", []string{"trust", "--store", storePath, "remove", "missing.example"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := runEnvelopeCmd(tc.args...); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestTrustCommandStoreErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, _, pubHex := testTrustKey(t)
+	badStore := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(badStore, []byte("{"), 0o600); err != nil {
+		t.Fatalf("write bad store: %v", err)
+	}
+	for _, args := range [][]string{
+		{"trust", "--store", badStore, "add", testTrustDomain, "--key", pubHex},
+		{"trust", "--store", badStore, "list"},
+		{"trust", "--store", badStore, "remove", testTrustDomain},
+		{"trust", "--store", badStore, "verify"},
+	} {
+		if _, err := runEnvelopeCmd(args...); err == nil {
+			t.Fatalf("%v should fail on bad store", args)
+		}
+	}
+
+	parentFile := filepath.Join(dir, "not-dir")
+	if err := os.WriteFile(parentFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write parent file: %v", err)
+	}
+	if _, err := runEnvelopeCmd("trust", "--store", filepath.Join(parentFile, "trust.json"), "add", testTrustDomain, "--key", pubHex); err == nil {
+		t.Fatal("add should fail when store parent is a file")
+	}
+	if _, err := runEnvelopeCmd("trust", "--store", dir, "list"); err == nil {
+		t.Fatal("list should fail when store path is a directory")
+	}
+}
+
+func TestTrustVerifyNoStdinExercisesTrustStore(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(t.TempDir(), "trust.json")
+	_, _, pubHex := testTrustKey(t)
+	if _, err := runEnvelopeCmd("trust", "--store", storePath, "add", testTrustDomain, "--key", pubHex); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	out, err := runEnvelopeCmd("trust", "--store", storePath, "verify")
+	if err != nil {
+		t.Fatalf("verify no stdin: %v", err)
+	}
+	if !strings.Contains(out, "trust store ready\t1 trusted peer") {
+		t.Fatalf("verify no stdin output = %q", out)
+	}
+}
+
+func TestTrustVerifyInputErrors(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(t.TempDir(), "trust.json")
+	if _, err := runEnvelopeCmd("trust", "--store", storePath, "verify"); err == nil {
+		t.Fatal("empty trust store should fail verify")
+	}
+	_, _, pubHex := testTrustKey(t)
+	if _, err := runEnvelopeCmd("trust", "--store", storePath, "add", testTrustDomain, "--key", pubHex); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := runEnvelopeCmdWithInput("not http", "trust", "--store", storePath, "verify", "--stdin"); err == nil {
+		t.Fatal("bad HTTP stdin should fail")
+	}
+}
+
+func TestTrustVerifyStdinKnownGoodAndForged(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(t.TempDir(), "trust.json")
+	_, priv, pubHex := testTrustKey(t)
+	if _, err := runEnvelopeCmd("trust", "--store", storePath, "add", testTrustDomain, "--key", pubHex); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	goodReq := signedTrustVerifyRequest(t, priv, testTrustDomain, "spiffe://partner.example/agent/proxy", "payload")
+	out, err := runEnvelopeCmdWithInput(goodReq, "trust", "--store", storePath, "verify", "--stdin")
+	if err != nil {
+		t.Fatalf("verify good: %v", err)
+	}
+	if !strings.Contains(out, "verified\tactor=spiffe://partner.example/agent/proxy") {
+		t.Fatalf("verify output = %q", out)
+	}
+
+	_, forgedPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey forged: %v", err)
+	}
+	forgedReq := signedTrustVerifyRequest(t, forgedPriv, testTrustDomain, "spiffe://partner.example/agent/proxy", "payload")
+	_, err = runEnvelopeCmdWithInput(forgedReq, "trust", "--store", storePath, "verify", "--stdin")
+	if err == nil {
+		t.Fatal("forged envelope should fail verification")
+	}
+	var exitErr *cliutil.ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != cliutil.ExitSecurity {
+		t.Fatalf("forged error = %T %[1]v, want ExitSecurity", err)
+	}
+}
+
+func TestTrustVerifyRejectsActorOutsideSpiffeRecord(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(t.TempDir(), "trust.json")
+	_, priv, pubHex := testTrustKey(t)
+	if _, err := runEnvelopeCmd("trust", "--store", storePath, "add", "spiffe://partner.example/agent/allowed", "--key", pubHex); err != nil {
+		t.Fatalf("add spiffe target: %v", err)
+	}
+	rawReq := signedTrustVerifyRequest(t, priv, testTrustDomain, "spiffe://partner.example/agent/other", "payload")
+	if _, err := runEnvelopeCmdWithInput(rawReq, "trust", "--store", storePath, "verify", "--stdin"); err == nil {
+		t.Fatal("actor outside exact SPIFFE trust record should fail")
+	}
+}
+
+func TestTrustStoreHelpers(t *testing.T) {
+	pub, _, pubHex := testTrustKey(t)
+	now := time.Now().UTC()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store, err := newTrustStore("")
+	if err != nil {
+		t.Fatalf("new default trust store: %v", err)
+	}
+	if !strings.HasSuffix(store.path, filepath.Join("pipelock", "envelope", "trust.json")) {
+		t.Fatalf("default store path = %q", store.path)
+	}
+	if records, err := store.load(); err != nil || len(records) != 0 {
+		t.Fatalf("missing store load = %+v, %v", records, err)
+	}
+
+	explicit := filepath.Join(t.TempDir(), "trust.json")
+	store, err = newTrustStore(explicit)
+	if err != nil {
+		t.Fatalf("new explicit trust store: %v", err)
+	}
+	if err := store.save([]trustRecord{{
+		TrustDomain: testTrustDomain,
+		KeyHex:      pubHex,
+		AddedAt:     now,
+	}}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	records, err := store.load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(records) != 1 || !records[0].AddedAt.Equal(now) {
+		t.Fatalf("loaded records = %+v", records)
+	}
+
+	if _, _, err := parseTrustTarget(""); err == nil {
+		t.Fatal("empty trust target should fail")
+	}
+	if _, _, err := parseTrustTarget("spiffe:///missing-domain"); err == nil {
+		t.Fatal("bad SPIFFE trust target should fail")
+	}
+	domain, spiffeID, err := parseTrustTarget("spiffe://Partner.Example/agent/proxy")
+	if err != nil {
+		t.Fatalf("parse SPIFFE target: %v", err)
+	}
+	if domain != testTrustDomain || spiffeID == "" {
+		t.Fatalf("parsed target = %q %q", domain, spiffeID)
+	}
+	if got := keySummary("short"); got != "short" {
+		t.Fatalf("short key summary = %q", got)
+	}
+	if got := emptyDash("value"); got != "value" {
+		t.Fatalf("emptyDash non-empty = %q", got)
+	}
+	if !bytes.Equal(pub, pub) {
+		t.Fatal("unreachable")
+	}
+
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+	_, fallback, err := defaultTrustStorePath()
+	if err != nil {
+		t.Fatalf("fallback default path: %v", err)
+	}
+	if !strings.Contains(fallback, filepath.Join(".local", "state", "pipelock")) {
+		t.Fatalf("fallback path = %q", fallback)
+	}
+}
+
+func TestDefaultTrustStoreSaveWithinStateHome(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	store, err := newTrustStore("")
+	if err != nil {
+		t.Fatalf("new default store: %v", err)
+	}
+	_, _, pubHex := testTrustKey(t)
+	now := time.Now().UTC()
+	if err := store.save([]trustRecord{{
+		TrustDomain: testTrustDomain,
+		KeyHex:      pubHex,
+		AddedAt:     now,
+	}}); err != nil {
+		t.Fatalf("save default store: %v", err)
+	}
+	records, err := store.load()
+	if err != nil {
+		t.Fatalf("load default store: %v", err)
+	}
+	if len(records) != 1 || records[0].TrustDomain != testTrustDomain {
+		t.Fatalf("default store records = %+v", records)
+	}
+	info, err := os.Stat(filepath.Dir(store.path))
+	if err != nil {
+		t.Fatalf("stat default store dir: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o750 {
+		t.Fatalf("default store dir mode = %v, want 0o750", got)
+	}
+}
+
+func TestTrustStoreValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	_, _, pubHex := testTrustKey(t)
+	pub, _, _ := testTrustKey(t)
+	now := time.Now().UTC()
+	cases := []trustRecord{
+		{TrustDomain: "bad/domain", KeyHex: pubHex, AddedAt: now},
+		{TrustDomain: testTrustDomain, SPIFFEID: "spiffe://other.example/agent/proxy", KeyHex: pubHex, AddedAt: now},
+		{TrustDomain: testTrustDomain, SPIFFEID: "not-spiffe", KeyHex: pubHex, AddedAt: now},
+		{TrustDomain: testTrustDomain, KeyHex: "not-hex", AddedAt: now},
+		{TrustDomain: testTrustDomain, KeyHex: signing.EncodePublicKey(pub), AddedAt: now},
+		{TrustDomain: testTrustDomain, KeyHex: pubHex, KeySource: "%", AddedAt: now},
+		{TrustDomain: testTrustDomain, KeyHex: pubHex, KeySource: "http://not-local.example/keys", AddedAt: now},
+		{TrustDomain: testTrustDomain, KeyHex: pubHex},
+	}
+	for _, rec := range cases {
+		if err := validateTrustRecord(rec); err == nil {
+			t.Fatalf("validateTrustRecord(%+v) succeeded", rec)
+		}
+	}
+
+	parentFile := filepath.Join(t.TempDir(), "not-dir")
+	if err := os.WriteFile(parentFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write parent file: %v", err)
+	}
+	store := &trustStore{path: filepath.Join(parentFile, "trust.json")}
+	if err := store.save(nil); err == nil {
+		t.Fatal("save under file parent should fail")
+	}
+	store = &trustStore{path: t.TempDir()}
+	if err := store.save(nil); err == nil {
+		t.Fatal("save over directory should fail")
+	}
+	store = &trustStore{path: filepath.Join(t.TempDir(), "trust.json")}
+	if err := store.save([]trustRecord{{TrustDomain: "bad", KeyHex: "bad"}}); err == nil {
+		t.Fatal("save should validate records")
+	}
+
+	target := filepath.Join(t.TempDir(), "target.json")
+	link := filepath.Join(t.TempDir(), "trust.json")
+	if err := os.WriteFile(target, []byte("[]\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink trust store: %v", err)
+	}
+	store = &trustStore{path: link}
+	if err := store.save(nil); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("save over symlink error = %v, want symlink rejection", err)
+	}
+}
+
+func TestDefaultTrustStoreRejectsEscapingSymlink(t *testing.T) {
+	stateHome := t.TempDir()
+	outside := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	if err := os.Symlink(outside, filepath.Join(stateHome, "pipelock")); err != nil {
+		t.Fatalf("symlink state subdir: %v", err)
+	}
+	store, err := newTrustStore("")
+	if err != nil {
+		t.Fatalf("new default store: %v", err)
+	}
+	_, _, pubHex := testTrustKey(t)
+	err = store.save([]trustRecord{{
+		TrustDomain: testTrustDomain,
+		KeyHex:      pubHex,
+		AddedAt:     time.Now().UTC(),
+	}})
+	if err == nil || !strings.Contains(err.Error(), "escapes XDG state home") {
+		t.Fatalf("save through escaping symlink error = %v", err)
+	}
+}
+
+func TestTrustStoreValidateWritePathErrors(t *testing.T) {
+	missingRoot := filepath.Join(t.TempDir(), "missing-root")
+	store := &trustStore{path: filepath.Join(t.TempDir(), "trust.json"), root: missingRoot}
+	if err := store.validateWritePath(); err == nil || !strings.Contains(err.Error(), "resolving trust store root") {
+		t.Fatalf("missing root error = %v", err)
+	}
+
+	root := t.TempDir()
+	store = &trustStore{path: filepath.Join(root, "missing-parent", "trust.json"), root: root}
+	if err := store.validateWritePath(); err == nil || !strings.Contains(err.Error(), "resolving trust store directory") {
+		t.Fatalf("missing parent error = %v", err)
+	}
+}
+
+func TestTrustStoreLoadErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	badJSON := &trustStore{path: filepath.Join(dir, "bad.json")}
+	if err := os.WriteFile(badJSON.path, []byte("{"), 0o600); err != nil {
+		t.Fatalf("write bad json: %v", err)
+	}
+	if _, err := badJSON.load(); err == nil {
+		t.Fatal("bad json load should fail")
+	}
+
+	badRecord := &trustStore{path: filepath.Join(dir, "bad-record.json")}
+	if err := os.WriteFile(badRecord.path, []byte(`[{"trust_domain":"bad","key_hex":"bad","added_at":"2026-05-01T00:00:00Z"}]`), 0o600); err != nil {
+		t.Fatalf("write bad record: %v", err)
+	}
+	if _, err := badRecord.load(); err == nil {
+		t.Fatal("bad record load should fail")
+	}
+
+	empty := &trustStore{path: filepath.Join(dir, "empty.json")}
+	if err := os.WriteFile(empty.path, []byte(" \n"), 0o600); err != nil {
+		t.Fatalf("write empty: %v", err)
+	}
+	records, err := empty.load()
+	if err != nil || len(records) != 0 {
+		t.Fatalf("empty load = %+v, %v", records, err)
+	}
+}
+
+func TestDirectoryFetchErrors(t *testing.T) {
+	t.Parallel()
+
+	_, _, pubHex := testTrustKey(t)
+	servers := []http.HandlerFunc{
+		func(w http.ResponseWriter, _ *http.Request) { http.Error(w, "nope", http.StatusTeapot) },
+		func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("{")) },
+		func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(domenvelope.Directory{Keys: []domenvelope.DirectoryKey{{Algorithm: "rsa", Use: directoryUse, PublicKey: pubHex}}})
+		},
+		func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(domenvelope.Directory{Keys: []domenvelope.DirectoryKey{{KeyID: "bad", Algorithm: directoryAlg, Use: directoryUse, PublicKey: "bad"}}})
+		},
+	}
+	for _, handler := range servers {
+		server := httptest.NewServer(handler)
+		_, err := fetchDirectoryKey(t.Context(), server.URL)
+		server.Close()
+		if err == nil {
+			t.Fatal("fetchDirectoryKey should fail")
+		}
+	}
+	if _, err := fetchDirectoryKey(t.Context(), "%"); err == nil {
+		t.Fatal("bad source URL should fail")
+	}
+	if _, err := fetchDirectoryKey(t.Context(), "http://127.0.0.1:1"); err == nil {
+		t.Fatal("unreachable loopback source should fail")
+	}
+}
+
+func TestVerifierFromTrustRecordsErrors(t *testing.T) {
+	t.Parallel()
+
+	_, _, firstKey := testTrustKey(t)
+	_, _, secondKey := testTrustKey(t)
+	now := time.Now().UTC()
+	if _, err := verifierFromTrustRecords(nil); err == nil {
+		t.Fatal("empty trust records should fail")
+	}
+	if _, err := verifierFromTrustRecords([]trustRecord{{TrustDomain: testTrustDomain, KeyHex: "bad", AddedAt: now}}); err == nil {
+		t.Fatal("bad key should fail")
+	}
+	if _, err := verifierFromTrustRecords([]trustRecord{
+		{TrustDomain: testTrustDomain, SPIFFEID: "spiffe://partner.example/agent/a", KeyHex: firstKey, AddedAt: now},
+		{TrustDomain: testTrustDomain, SPIFFEID: "spiffe://partner.example/agent/b", KeyHex: secondKey, AddedAt: now},
+	}); err == nil {
+		t.Fatal("conflicting keys for one domain should fail")
+	}
+	if _, err := verifierFromTrustRecords([]trustRecord{
+		{TrustDomain: testTrustDomain, SPIFFEID: "spiffe://partner.example/agent/a", KeyHex: firstKey, AddedAt: now},
+		{TrustDomain: testTrustDomain, SPIFFEID: "spiffe://partner.example/agent/b", KeyHex: firstKey, AddedAt: now},
+	}); err != nil {
+		t.Fatalf("same key for one domain should build verifier: %v", err)
+	}
+}
+
+func TestActorAndRequestHelpers(t *testing.T) {
+	t.Parallel()
+
+	actor, err := domenvelope.ParseActorStrict("spiffe://partner.example/agent/a")
+	if err != nil {
+		t.Fatalf("ParseActorStrict: %v", err)
+	}
+	records := []trustRecord{{TrustDomain: "other.example"}}
+	if actorAllowedByTrustRecords(actor, records) {
+		t.Fatal("different trust domain should not be allowed")
+	}
+	records = []trustRecord{{TrustDomain: testTrustDomain, SPIFFEID: "spiffe://partner.example/agent/a"}}
+	if !actorAllowedByTrustRecords(actor, records) {
+		t.Fatal("exact SPIFFE record should be allowed")
+	}
+	records = []trustRecord{{TrustDomain: testTrustDomain, SPIFFEID: "not-spiffe"}}
+	if actorAllowedByTrustRecords(actor, records) {
+		t.Fatal("invalid stored SPIFFE record should not match")
+	}
+
+	req, body, err := readHTTPRequest(strings.NewReader("GET / HTTP/1.1\r\nHost: example.test\r\n\r\n"))
+	if err != nil {
+		t.Fatalf("readHTTPRequest no body: %v", err)
+	}
+	if req.Host != "example.test" || len(body) != 0 {
+		t.Fatalf("request host/body = %q/%q", req.Host, body)
+	}
+	if _, _, err := readHTTPRequest(strings.NewReader("not http")); err == nil {
+		t.Fatal("bad HTTP request should fail")
+	}
+	oversize := "POST / HTTP/1.1\r\nHost: example.test\r\nContent-Length: 16777217\r\n\r\n" +
+		strings.Repeat("a", maxVerifyStdinBodyBytes+1)
+	if _, _, err := readHTTPRequest(strings.NewReader(oversize)); err == nil || !strings.Contains(err.Error(), "request body exceeds") {
+		t.Fatalf("oversize request error = %v, want body cap", err)
+	}
+}
+
+func TestLocalHTTPSource(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{"http://localhost/keys", "http://127.0.0.1/keys", "http://[::1]/keys"} {
+		u := mustParseURL(t, raw)
+		if !isLocalHTTPSource(u) {
+			t.Fatalf("%s should be local HTTP", raw)
+		}
+	}
+	if isLocalHTTPSource(mustParseURL(t, "https://127.0.0.1/keys")) {
+		t.Fatal("https should not be classified as local HTTP")
+	}
+}
+
+func testTrustKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return pub, priv, hex.EncodeToString(pub)
+}
+
+func signedTrustVerifyRequest(t *testing.T, priv ed25519.PrivateKey, keyID, actor, body string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "http://upstream.example/api", strings.NewReader(body))
+	env := domenvelope.Envelope{
+		Version:   1,
+		Action:    "write",
+		Verdict:   config.ActionAllow,
+		Actor:     actor,
+		ActorAuth: domenvelope.ActorAuthBound,
+		ReceiptID: "01961f3a-7b2c-7000-8000-000000000001",
+		Timestamp: time.Now().UTC().Unix(),
+	}
+	if err := domenvelope.InjectHTTP(req.Header, env); err != nil {
+		t.Fatalf("InjectHTTP: %v", err)
+	}
+	signer, err := domenvelope.NewSigner(domenvelope.SignerConfig{
+		PrivKey:          priv,
+		KeyID:            keyID,
+		SignedComponents: config.DefaultEnvelopeSignedComponents(),
+		Expires:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	if err := signer.SignRequest(req, []byte(body)); err != nil {
+		t.Fatalf("SignRequest: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := req.Write(&buf); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	return buf.String()
+}
+
+func runEnvelopeCmd(args ...string) (string, error) {
+	return runEnvelopeCmdWithInput("", args...)
+}
+
+func runEnvelopeCmdWithInput(input string, args ...string) (string, error) {
+	out, _, err := runEnvelopeCmdFull(input, args...)
+	return out, err
+}
+
+func runEnvelopeCmdFull(input string, args ...string) (string, string, error) {
+	cmd := Cmd()
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&stderr)
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), stderr.String(), err
+}
+
+func readTrustRecords(t *testing.T, path string) []trustRecord {
+	t.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned path.
+	if err != nil {
+		t.Fatalf("read store: %v", err)
+	}
+	var records []trustRecord
+	if err := json.Unmarshal(data, &records); err != nil {
+		t.Fatalf("decode store: %v", err)
+	}
+	return records
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", raw, err)
+	}
+	return u
+}

--- a/internal/cli/envelope/cmd_test.go
+++ b/internal/cli/envelope/cmd_test.go
@@ -465,8 +465,8 @@ func TestDefaultTrustStoreRejectsEscapingSymlink(t *testing.T) {
 		KeyHex:      pubHex,
 		AddedAt:     time.Now().UTC(),
 	}})
-	if err == nil || !strings.Contains(err.Error(), "escapes XDG state home") {
-		t.Fatalf("save through escaping symlink error = %v", err)
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("save through escaping symlink error = %v, want symlink rejection", err)
 	}
 }
 
@@ -481,6 +481,12 @@ func TestTrustStoreValidateWritePathErrors(t *testing.T) {
 	store = &trustStore{path: filepath.Join(root, "missing-parent", "trust.json"), root: root}
 	if err := store.validateWritePath(); err == nil || !strings.Contains(err.Error(), "resolving trust store directory") {
 		t.Fatalf("missing parent error = %v", err)
+	}
+
+	outside := t.TempDir()
+	store = &trustStore{root: root}
+	if err := store.validateContained(outside); err == nil || !strings.Contains(err.Error(), "escapes XDG state home") {
+		t.Fatalf("outside containment error = %v, want escape rejection", err)
 	}
 }
 
@@ -512,6 +518,38 @@ func TestTrustStoreLoadErrors(t *testing.T) {
 	if err != nil || len(records) != 0 {
 		t.Fatalf("empty load = %+v, %v", records, err)
 	}
+
+	target := filepath.Join(dir, "target.json")
+	link := filepath.Join(dir, "link.json")
+	if err := os.WriteFile(target, []byte("[]\n"), 0o600); err != nil {
+		t.Fatalf("write symlink target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink trust store: %v", err)
+	}
+	if _, err := (&trustStore{path: link}).load(); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("load through symlink error = %v, want symlink rejection", err)
+	}
+}
+
+func TestTrustStoreRejectsSymlinkedParent(t *testing.T) {
+	outside := t.TempDir()
+	linkParent := filepath.Join(t.TempDir(), "store-link")
+	if err := os.Symlink(outside, linkParent); err != nil {
+		t.Fatalf("symlink parent: %v", err)
+	}
+	store := &trustStore{path: filepath.Join(linkParent, "trust.json")}
+	if err := store.save(nil); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("save through parent symlink error = %v, want symlink rejection", err)
+	}
+
+	target := filepath.Join(outside, "trust.json")
+	if err := os.WriteFile(target, []byte("[]\n"), 0o600); err != nil {
+		t.Fatalf("write parent symlink target: %v", err)
+	}
+	if _, err := store.load(); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("load through parent symlink error = %v, want symlink rejection", err)
+	}
 }
 
 func TestDirectoryFetchErrors(t *testing.T) {
@@ -541,6 +579,47 @@ func TestDirectoryFetchErrors(t *testing.T) {
 	}
 	if _, err := fetchDirectoryKey(t.Context(), "http://127.0.0.1:1"); err == nil {
 		t.Fatal("unreachable loopback source should fail")
+	}
+}
+
+func TestDirectoryFetchRejectsUnsafeRedirect(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://not-local.example/keys", http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := fetchDirectoryKey(t.Context(), server.URL+domenvelope.WellKnownPath)
+	if err == nil || !strings.Contains(err.Error(), "directory URL must be https or loopback http") {
+		t.Fatalf("redirect error = %v, want unsafe redirect rejection", err)
+	}
+}
+
+func TestDirectoryFetchAllowsSafeRedirect(t *testing.T) {
+	t.Parallel()
+
+	_, _, pubHex := testTrustKey(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redirect" {
+			http.Redirect(w, r, domenvelope.WellKnownPath, http.StatusFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(domenvelope.Directory{Keys: []domenvelope.DirectoryKey{{
+			KeyID:     testTrustDomain,
+			Algorithm: directoryAlg,
+			PublicKey: pubHex,
+			Use:       directoryUse,
+		}}})
+	}))
+	t.Cleanup(server.Close)
+
+	got, err := fetchDirectoryKey(t.Context(), server.URL+"/redirect")
+	if err != nil {
+		t.Fatalf("fetch through safe redirect: %v", err)
+	}
+	if got != pubHex {
+		t.Fatalf("redirect key = %q, want %q", got, pubHex)
 	}
 }
 
@@ -605,6 +684,21 @@ func TestActorAndRequestHelpers(t *testing.T) {
 	if _, _, err := readHTTPRequest(strings.NewReader(oversize)); err == nil || !strings.Contains(err.Error(), "request body exceeds") {
 		t.Fatalf("oversize request error = %v, want body cap", err)
 	}
+	oversizeHeader := "GET / HTTP/1.1\r\nHost: example.test\r\nX-Large: " +
+		strings.Repeat("a", maxVerifyRawRequestBytes) + "\r\n\r\n"
+	if _, _, err := readHTTPRequest(strings.NewReader(oversizeHeader)); err == nil || !strings.Contains(err.Error(), "request exceeds") {
+		t.Fatalf("oversize header error = %v, want raw request cap", err)
+	}
+	brokenBody := &chunkErrorReader{
+		chunks: []string{
+			"POST / HTTP/1.1\r\nHost: example.test\r\nContent-Length: 7\r\n\r\n",
+			"part",
+		},
+		err: errors.New("body broke"),
+	}
+	if _, _, err := readHTTPRequest(brokenBody); err == nil || !strings.Contains(err.Error(), "reading request body") {
+		t.Fatalf("broken body error = %v, want body read failure", err)
+	}
 }
 
 func TestLocalHTTPSource(t *testing.T) {
@@ -666,6 +760,25 @@ func signedTrustVerifyRequest(t *testing.T, priv ed25519.PrivateKey, keyID, acto
 
 func runEnvelopeCmd(args ...string) (string, error) {
 	return runEnvelopeCmdWithInput("", args...)
+}
+
+type chunkErrorReader struct {
+	chunks []string
+	err    error
+}
+
+func (r *chunkErrorReader) Read(p []byte) (int, error) {
+	if len(r.chunks) == 0 {
+		return 0, r.err
+	}
+	chunk := r.chunks[0]
+	n := copy(p, chunk)
+	if n == len(chunk) {
+		r.chunks = r.chunks[1:]
+		return n, nil
+	}
+	r.chunks[0] = chunk[n:]
+	return n, nil
 }
 
 func runEnvelopeCmdWithInput(input string, args ...string) (string, error) {

--- a/internal/cli/envelope/store.go
+++ b/internal/cli/envelope/store.go
@@ -60,10 +60,14 @@ func defaultTrustStorePath() (string, string, error) {
 }
 
 func (s *trustStore) load() ([]trustRecord, error) {
-	data, err := os.ReadFile(s.path) //nolint:gosec // path is operator-selected state store path.
-	if os.IsNotExist(err) {
+	path, err := s.readPath()
+	if err != nil {
+		return nil, err
+	}
+	if path == "" {
 		return nil, nil
 	}
+	data, err := os.ReadFile(path) //nolint:gosec // path is operator-selected state store path after validation.
 	if err != nil {
 		return nil, fmt.Errorf("reading trust store: %w", err)
 	}
@@ -109,26 +113,78 @@ func (s *trustStore) save(records []trustRecord) error {
 	return nil
 }
 
+func (s *trustStore) readPath() (string, error) {
+	cleanPath := filepath.Clean(s.path)
+	info, err := os.Lstat(cleanPath)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("checking trust store path: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("trust store path must not be a symlink")
+	}
+	if err := validateTrustStoreParent(cleanPath); err != nil {
+		return "", err
+	}
+	if s.root == "" {
+		return cleanPath, nil
+	}
+	resolvedPath, err := filepath.EvalSymlinks(cleanPath)
+	if err != nil {
+		return "", fmt.Errorf("resolving trust store path: %w", err)
+	}
+	if err := s.validateContained(resolvedPath); err != nil {
+		return "", err
+	}
+	return resolvedPath, nil
+}
+
 func (s *trustStore) validateWritePath() error {
-	info, err := os.Lstat(s.path)
+	cleanPath := filepath.Clean(s.path)
+	info, err := os.Lstat(cleanPath)
 	if err == nil && info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("trust store path must not be a symlink")
 	}
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("checking trust store path: %w", err)
 	}
+	if err := validateTrustStoreParent(cleanPath); err != nil {
+		return err
+	}
 	if s.root == "" {
 		return nil
 	}
+	return s.validateContained(filepath.Dir(cleanPath))
+}
+
+func validateTrustStoreParent(cleanPath string) error {
+	parent := filepath.Dir(cleanPath)
+	absParent, err := filepath.Abs(parent)
+	if err != nil {
+		return fmt.Errorf("resolving trust store directory: %w", err)
+	}
+	resolvedParent, err := filepath.EvalSymlinks(absParent)
+	if err != nil {
+		return fmt.Errorf("resolving trust store directory: %w", err)
+	}
+	if filepath.Clean(resolvedParent) != filepath.Clean(absParent) {
+		return fmt.Errorf("trust store path must not be a symlink")
+	}
+	return nil
+}
+
+func (s *trustStore) validateContained(path string) error {
 	root, err := filepath.EvalSymlinks(s.root)
 	if err != nil {
 		return fmt.Errorf("resolving trust store root: %w", err)
 	}
-	parent, err := filepath.EvalSymlinks(filepath.Dir(s.path))
+	resolvedPath, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return fmt.Errorf("resolving trust store directory: %w", err)
+		return fmt.Errorf("resolving trust store path: %w", err)
 	}
-	rel, err := filepath.Rel(root, parent)
+	rel, err := filepath.Rel(root, resolvedPath)
 	if err != nil {
 		return fmt.Errorf("checking trust store containment: %w", err)
 	}
@@ -163,7 +219,7 @@ func validateTrustRecord(rec trustRecord) error {
 		if err != nil {
 			return fmt.Errorf("key_source: %w", err)
 		}
-		if u.Scheme != "https" && !isLocalHTTPSource(u) {
+		if !isAllowedDirectoryURL(u) {
 			return fmt.Errorf("key_source must be https or loopback http")
 		}
 	}
@@ -215,4 +271,8 @@ func isLocalHTTPSource(u *url.URL) bool {
 	}
 	host := strings.ToLower(u.Hostname())
 	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+func isAllowedDirectoryURL(u *url.URL) bool {
+	return u.Scheme == "https" || isLocalHTTPSource(u)
 }

--- a/internal/cli/envelope/store.go
+++ b/internal/cli/envelope/store.go
@@ -1,0 +1,218 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package envelope
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	domenvelope "github.com/luckyPipewrench/pipelock/internal/envelope"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+type trustRecord struct {
+	TrustDomain string    `json:"trust_domain"`
+	SPIFFEID    string    `json:"spiffe_id,omitempty"`
+	KeyHex      string    `json:"key_hex"`
+	KeySource   string    `json:"key_source,omitempty"`
+	AddedAt     time.Time `json:"added_at"`
+}
+
+type trustStore struct {
+	path string
+	root string
+}
+
+func newTrustStore(path string) (*trustStore, error) {
+	var root string
+	if path == "" {
+		var err error
+		root, path, err = defaultTrustStorePath()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if root != "" {
+		root = filepath.Clean(root)
+	}
+	return &trustStore{path: filepath.Clean(path), root: root}, nil
+}
+
+func defaultTrustStorePath() (string, string, error) {
+	stateHome := strings.TrimSpace(os.Getenv("XDG_STATE_HOME"))
+	if stateHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", "", fmt.Errorf("determining home directory: %w", err)
+		}
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+	root := filepath.Clean(stateHome)
+	return root, filepath.Join(root, "pipelock", "envelope", "trust.json"), nil
+}
+
+func (s *trustStore) load() ([]trustRecord, error) {
+	data, err := os.ReadFile(s.path) //nolint:gosec // path is operator-selected state store path.
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading trust store: %w", err)
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return nil, nil
+	}
+	var records []trustRecord
+	if err := json.Unmarshal(data, &records); err != nil {
+		return nil, fmt.Errorf("parsing trust store: %w", err)
+	}
+	for i := range records {
+		records[i].TrustDomain = strings.ToLower(strings.TrimSpace(records[i].TrustDomain))
+		records[i].SPIFFEID = strings.TrimSpace(records[i].SPIFFEID)
+		records[i].KeyHex = strings.ToLower(strings.TrimSpace(records[i].KeyHex))
+		records[i].KeySource = strings.TrimSpace(records[i].KeySource)
+		if err := validateTrustRecord(records[i]); err != nil {
+			return nil, fmt.Errorf("trust store record %d: %w", i, err)
+		}
+	}
+	return records, nil
+}
+
+func (s *trustStore) save(records []trustRecord) error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o750); err != nil {
+		return fmt.Errorf("creating trust store directory: %w", err)
+	}
+	if err := s.validateWritePath(); err != nil {
+		return err
+	}
+	for i, rec := range records {
+		if err := validateTrustRecord(rec); err != nil {
+			return fmt.Errorf("trust store record %d: %w", i, err)
+		}
+	}
+	data, err := json.MarshalIndent(records, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding trust store: %w", err)
+	}
+	data = append(data, '\n')
+	if err := atomicfile.Write(s.path, data, 0o600); err != nil {
+		return fmt.Errorf("writing trust store: %w", err)
+	}
+	return nil
+}
+
+func (s *trustStore) validateWritePath() error {
+	info, err := os.Lstat(s.path)
+	if err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("trust store path must not be a symlink")
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("checking trust store path: %w", err)
+	}
+	if s.root == "" {
+		return nil
+	}
+	root, err := filepath.EvalSymlinks(s.root)
+	if err != nil {
+		return fmt.Errorf("resolving trust store root: %w", err)
+	}
+	parent, err := filepath.EvalSymlinks(filepath.Dir(s.path))
+	if err != nil {
+		return fmt.Errorf("resolving trust store directory: %w", err)
+	}
+	rel, err := filepath.Rel(root, parent)
+	if err != nil {
+		return fmt.Errorf("checking trust store containment: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return fmt.Errorf("trust store directory escapes XDG state home")
+	}
+	return nil
+}
+
+func validateTrustRecord(rec trustRecord) error {
+	if !domenvelope.IsValidTrustDomain(rec.TrustDomain) {
+		return fmt.Errorf("trust_domain %q must be a DNS-shaped SPIFFE trust domain", rec.TrustDomain)
+	}
+	if rec.SPIFFEID != "" {
+		parsed, err := domenvelope.ParseActorStrict(rec.SPIFFEID)
+		if err != nil {
+			return fmt.Errorf("spiffe_id: %w", err)
+		}
+		if parsed.TrustDomain != rec.TrustDomain {
+			return fmt.Errorf("spiffe_id trust domain %q does not match trust_domain %q", parsed.TrustDomain, rec.TrustDomain)
+		}
+	}
+	pub, err := signing.ParsePublicKey(rec.KeyHex)
+	if err != nil {
+		return fmt.Errorf("key_hex: %w", err)
+	}
+	if rec.KeyHex != hex.EncodeToString(pub) {
+		return fmt.Errorf("key_hex must be raw lowercase Ed25519 public-key hex")
+	}
+	if rec.KeySource != "" {
+		u, err := url.Parse(rec.KeySource)
+		if err != nil {
+			return fmt.Errorf("key_source: %w", err)
+		}
+		if u.Scheme != "https" && !isLocalHTTPSource(u) {
+			return fmt.Errorf("key_source must be https or loopback http")
+		}
+	}
+	if rec.AddedAt.IsZero() {
+		return fmt.Errorf("added_at must be set")
+	}
+	return nil
+}
+
+func parseTrustTarget(raw string) (trustDomain, spiffeID string, err error) {
+	target := strings.TrimSpace(raw)
+	if target == "" {
+		return "", "", fmt.Errorf("trust target must not be empty")
+	}
+	if strings.HasPrefix(strings.ToLower(target), "spiffe://") {
+		parsed, err := domenvelope.ParseActorStrict(target)
+		if err != nil {
+			return "", "", err
+		}
+		return parsed.TrustDomain, parsed.Raw, nil
+	}
+	domain := strings.ToLower(target)
+	if !domenvelope.IsValidTrustDomain(domain) {
+		return "", "", fmt.Errorf("trust target %q must be a SPIFFE ID or DNS-shaped trust domain", raw)
+	}
+	return domain, "", nil
+}
+
+func normalizeKeyHex(raw string) (string, error) {
+	pub, err := signing.ParsePublicKey(raw)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(pub), nil
+}
+
+func findTrustRecord(records []trustRecord, trustDomain, spiffeID string) int {
+	for i, rec := range records {
+		if rec.TrustDomain == trustDomain && rec.SPIFFEID == spiffeID {
+			return i
+		}
+	}
+	return -1
+}
+
+func isLocalHTTPSource(u *url.URL) bool {
+	if u.Scheme != "http" {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/cli/canary"
 	"github.com/luckyPipewrench/pipelock/internal/cli/contain"
 	"github.com/luckyPipewrench/pipelock/internal/cli/diag"
+	clienvelope "github.com/luckyPipewrench/pipelock/internal/cli/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/cli/generate"
 	"github.com/luckyPipewrench/pipelock/internal/cli/git"
 	"github.com/luckyPipewrench/pipelock/internal/cli/learn"
@@ -82,6 +83,8 @@ Quick start:
 		audit.SimulateCmd(),
 		// Containment (workstation-tier)
 		contain.Cmd(),
+		// Mediation envelope trust management
+		clienvelope.Cmd(),
 		// Diagnostics
 		diag.DiagnoseCmd(),
 		diag.DiscoverCmd(),

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -4,6 +4,8 @@
 package cli
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -36,5 +38,20 @@ func TestRegisterCommand(t *testing.T) {
 	}
 	if !found {
 		t.Error("registered command not found in rootCmd subcommands")
+	}
+}
+
+func TestEnvelopeHelpRegistered(t *testing.T) {
+	cmd := rootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"envelope", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("envelope help: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "trust") {
+		t.Fatalf("help output = %q, want trust subcommand", got)
 	}
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -913,9 +913,10 @@ type MediationEnvelope struct {
 	// the cache.
 	SignatureExpires string `yaml:"signature_expires"`
 
-	// ActorFormat controls new outbound envelope actor values. v2.4
-	// defaults to SPIFFE format while inbound parsing remains permissive
-	// for legacy actor strings.
+	// ActorFormat controls emitted envelope actor values and inbound
+	// verification strictness. "spiffe" emits SPIFFE IDs and requires
+	// inbound verified actors to be SPIFFE IDs. "legacy" preserves the
+	// older free-form actor string for migration.
 	ActorFormat string `yaml:"actor_format"`
 	TrustDomain string `yaml:"trust_domain"`
 

--- a/internal/envelope/spiffe.go
+++ b/internal/envelope/spiffe.go
@@ -24,9 +24,8 @@ type ParsedActor struct {
 	Workload    string
 }
 
-// ParseActor accepts legacy free-form actor strings and SPIFFE IDs. The
-// permissive behavior is the v2.4 migration mode; callers that need the v2.5
-// strict behavior can require ParsedActor.IsSPIFFE after parsing.
+// ParseActor accepts legacy free-form actor strings and SPIFFE IDs. Call
+// ParseActorStrict on inbound federation paths that require SPIFFE identity.
 //
 // SPIFFE-ID parsing follows SPIFFE-ID §2: trust domain must be a bare
 // authority (no userinfo, no port), and the workload path must be
@@ -79,6 +78,18 @@ func ParseActor(raw string) (ParsedActor, error) {
 		TrustDomain: strings.ToLower(u.Host),
 		Workload:    u.EscapedPath(),
 	}, nil
+}
+
+// ParseActorStrict accepts only syntactically valid SPIFFE IDs.
+func ParseActorStrict(raw string) (ParsedActor, error) {
+	parsed, err := ParseActor(raw)
+	if err != nil {
+		return ParsedActor{}, err
+	}
+	if !parsed.IsSPIFFE {
+		return ParsedActor{}, fmt.Errorf("actor must be a SPIFFE ID")
+	}
+	return parsed, nil
 }
 
 // isCanonicalSPIFFEPath returns true when p is already in canonical form:
@@ -146,7 +157,7 @@ func FormatActor(actor, actorFormat, trustDomain string) (string, error) {
 		return trimmed, nil
 	case ActorFormatSPIFFE:
 		if strings.HasPrefix(strings.ToLower(trimmed), "spiffe://") {
-			if _, err := ParseActor(trimmed); err != nil {
+			if _, err := ParseActorStrict(trimmed); err != nil {
 				return "", err
 			}
 			return trimmed, nil

--- a/internal/envelope/verify.go
+++ b/internal/envelope/verify.go
@@ -33,6 +33,10 @@ type VerifierConfig struct {
 	TrustedKeys []TrustedKey
 	ReplayCache *ReplayCache
 	Skew        time.Duration
+	// ActorFormat controls inbound actor parsing. "spiffe" requires
+	// every verified envelope actor to be a valid SPIFFE ID; "legacy"
+	// keeps the permissive migration path.
+	ActorFormat string
 	// MaxSignatureLifetime caps the (expires - created) duration the
 	// verifier accepts. Without a cap, a trusted-but-careless signer that
 	// emits long-lived signatures defeats the replay window: the cache
@@ -49,6 +53,7 @@ type Verifier struct {
 	keys                 map[string]trustedKey
 	replayCache          *ReplayCache
 	skew                 time.Duration
+	actorFormat          string
 	maxSignatureLifetime time.Duration
 	nowFn                func() time.Time
 }
@@ -157,10 +162,19 @@ func NewVerifier(cfg VerifierConfig) (*Verifier, error) {
 	if now == nil {
 		now = time.Now
 	}
+	actorFormat := strings.ToLower(strings.TrimSpace(cfg.ActorFormat))
+	switch actorFormat {
+	case "", ActorFormatSPIFFE:
+		actorFormat = ActorFormatSPIFFE
+	case ActorFormatLegacy:
+	default:
+		return nil, fmt.Errorf("unknown inbound actor_format %q", cfg.ActorFormat)
+	}
 	return &Verifier{
 		keys:                 keys,
 		replayCache:          cfg.ReplayCache,
 		skew:                 cfg.Skew,
+		actorFormat:          actorFormat,
 		maxSignatureLifetime: cfg.MaxSignatureLifetime,
 		nowFn:                now,
 	}, nil
@@ -184,7 +198,7 @@ func (v *Verifier) VerifyRequest(req *http.Request, body []byte) (Envelope, erro
 	if err != nil {
 		return Envelope{}, verificationError(VerificationFailureParse, "parse %s: %w", HeaderName, err)
 	}
-	parsedActor, err := ParseActor(env.Actor)
+	parsedActor, err := v.parseActor(env.Actor)
 	if err != nil {
 		return Envelope{}, verificationError(VerificationFailureParse, "parse actor: %w", err)
 	}
@@ -269,6 +283,13 @@ func (v *Verifier) VerifyRequest(req *http.Request, body []byte) (Envelope, erro
 		return Envelope{}, wrapVerificationError(code, err)
 	}
 	return env, nil
+}
+
+func (v *Verifier) parseActor(raw string) (ParsedActor, error) {
+	if v.actorFormat == ActorFormatLegacy {
+		return ParseActor(raw)
+	}
+	return ParseActorStrict(raw)
 }
 
 func (v *Verifier) validateTime(created, expires int64) error {

--- a/internal/envelope/verify_test.go
+++ b/internal/envelope/verify_test.go
@@ -390,6 +390,24 @@ func TestParseActor_StrictSPIFFE(t *testing.T) {
 	}
 }
 
+func TestParseActorStrictRequiresSPIFFE(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ParseActorStrict("agent:legacy"); err == nil {
+		t.Fatal("strict parser should reject free-form actors")
+	}
+	if _, err := ParseActorStrict("spiffe:///missing-domain"); err == nil {
+		t.Fatal("strict parser should reject malformed SPIFFE actors")
+	}
+	parsed, err := ParseActorStrict("spiffe://Strict.Test/agent/alpha")
+	if err != nil {
+		t.Fatalf("ParseActorStrict SPIFFE: %v", err)
+	}
+	if !parsed.IsSPIFFE || parsed.TrustDomain != "strict.test" {
+		t.Fatalf("strict parser returned %+v", parsed)
+	}
+}
+
 func TestIsValidTrustDomain(t *testing.T) {
 	t.Parallel()
 	good := []string{"trust.example", "partner.internal", "a", "single-label"}
@@ -761,6 +779,43 @@ func TestVerifier_TrustDomainPinRequiresSPIFFEActor(t *testing.T) {
 	}
 	if _, err := verifier.VerifyRequest(req, nil); err == nil {
 		t.Fatal("trust-domain-pinned key should reject legacy actor")
+	}
+}
+
+func TestVerifier_StrictActorFormatRejectsLegacyActor(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := testSignerKey(t)
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	req := signedLegacyActorRequest(t, priv, now)
+	verifier := newTestVerifier(t, pub, now)
+
+	if _, err := verifier.VerifyRequest(req, nil); err == nil {
+		t.Fatal("strict verifier should reject legacy actor")
+	}
+}
+
+func TestVerifier_LegacyActorFormatAllowsMigrationPath(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := testSignerKey(t)
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	req := signedLegacyActorRequest(t, priv, now)
+	verifier, err := NewVerifier(VerifierConfig{
+		TrustedKeys: []TrustedKey{{
+			KeyID:     "trusted-key",
+			PublicKey: pub,
+		}},
+		ReplayCache: newReplayCache(5*time.Minute, 1000, func() time.Time { return now }),
+		Skew:        time.Minute,
+		ActorFormat: ActorFormatLegacy,
+		NowFn:       func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewVerifier legacy: %v", err)
+	}
+	if _, err := verifier.VerifyRequest(req, nil); err != nil {
+		t.Fatalf("legacy actor should verify under migration format: %v", err)
 	}
 }
 

--- a/internal/proxy/envelope_failure_pattern_test.go
+++ b/internal/proxy/envelope_failure_pattern_test.go
@@ -21,7 +21,12 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
-const testInboundVerifyMissingPattern = "inbound_verify_missing"
+const (
+	testInboundVerifyMissingPattern = "inbound_verify_missing"
+	testInboundVerifyParsePattern   = "inbound_verify_parse"
+	testInboundKeyID                = "partner-key"
+	testInboundBody                 = "payload"
+)
 
 func TestInboundEnvelopeFailurePatternUsesVerifierCodes(t *testing.T) {
 	t.Parallel()
@@ -37,7 +42,7 @@ func TestInboundEnvelopeFailurePatternUsesVerifierCodes(t *testing.T) {
 		{name: "missing", code: envelope.VerificationFailureMissing, want: testInboundVerifyMissingPattern},
 		{name: "digest", code: envelope.VerificationFailureDigest, want: "inbound_verify_digest"},
 		{name: "signature", code: envelope.VerificationFailureSignature, want: "inbound_verify_signature"},
-		{name: "parse", code: envelope.VerificationFailureParse, want: "inbound_verify_parse"},
+		{name: "parse", code: envelope.VerificationFailureParse, want: testInboundVerifyParsePattern},
 	}
 
 	for _, tt := range tests {
@@ -110,7 +115,7 @@ func TestInboundEnvelopeFailurePatternFallback(t *testing.T) {
 		{name: "missing", err: errors.New("missing header"), want: testInboundVerifyMissingPattern},
 		{name: "digest", err: errors.New("content-digest mismatch"), want: "inbound_verify_digest"},
 		{name: "signature", err: errors.New("signature verification failed"), want: "inbound_verify_signature"},
-		{name: "parse", err: errors.New("parse Signature-Input"), want: "inbound_verify_parse"},
+		{name: "parse", err: errors.New("parse Signature-Input"), want: testInboundVerifyParsePattern},
 		{name: "failed", err: errors.New("unexpected verifier failure"), want: "inbound_verify_failed"},
 	}
 
@@ -143,7 +148,7 @@ func TestBuildInboundEnvelopeVerifier(t *testing.T) {
 	}
 	cfg.MediationEnvelope.VerifyInbound.Enabled = true
 	cfg.MediationEnvelope.VerifyInbound.TrustList = []config.MediationEnvelopeTrustedKey{{
-		KeyID:        "partner-key",
+		KeyID:        testInboundKeyID,
 		PublicKey:    hex.EncodeToString(pub),
 		TrustDomains: []string{"partner.example"},
 	}}
@@ -169,10 +174,44 @@ func TestVerifyInboundEnvelopeValidSignedRequest(t *testing.T) {
 
 	pub, priv := testInboundEnvelopeKey(t)
 	cfg, verifier := testInboundVerifier(t, pub)
-	req := signedInboundRequest(t, priv, "partner-key", "spiffe://partner.example/agent/proxy", "payload")
+	req := signedInboundRequest(t, priv, "spiffe://partner.example/agent/proxy")
 
 	if err := verifyInboundEnvelope(req, cfg, verifier); err != nil {
 		t.Fatalf("verifyInboundEnvelope: %v", err)
+	}
+}
+
+func TestVerifyInboundEnvelopeStrictActorFormatRejectsLegacyActor(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := testInboundEnvelopeKey(t)
+	cfg, verifier := testInboundVerifier(t, pub)
+	req := signedInboundRequest(t, priv, "legacy-agent")
+
+	err := verifyInboundEnvelope(req, cfg, verifier)
+	if err == nil {
+		t.Fatal("strict inbound actor format should reject legacy actor")
+	}
+	if got := inboundEnvelopeFailurePattern(err); got != testInboundVerifyParsePattern {
+		t.Fatalf("pattern = %q, want %s", got, testInboundVerifyParsePattern)
+	}
+}
+
+func TestVerifyInboundEnvelopeLegacyActorFormatAllowsMigrationPath(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := testInboundEnvelopeKey(t)
+	cfg, _ := testInboundVerifier(t, pub)
+	cfg.MediationEnvelope.ActorFormat = envelope.ActorFormatLegacy
+	cfg.MediationEnvelope.VerifyInbound.TrustList[0].TrustDomains = nil
+	verifier, err := buildInboundEnvelopeVerifier(cfg)
+	if err != nil {
+		t.Fatalf("buildInboundEnvelopeVerifier: %v", err)
+	}
+	req := signedInboundRequest(t, priv, "legacy-agent")
+
+	if err := verifyInboundEnvelope(req, cfg, verifier); err != nil {
+		t.Fatalf("legacy actor should verify in migration mode: %v", err)
 	}
 }
 
@@ -238,7 +277,7 @@ func testInboundVerifier(t *testing.T, pub ed25519.PublicKey) (*config.Config, *
 	cfg.MediationEnvelope.MaxBodyBytes = 1024
 	cfg.MediationEnvelope.VerifyInbound.Enabled = true
 	cfg.MediationEnvelope.VerifyInbound.TrustList = []config.MediationEnvelopeTrustedKey{{
-		KeyID:        "partner-key",
+		KeyID:        testInboundKeyID,
 		PublicKey:    hex.EncodeToString(pub),
 		TrustDomains: []string{"partner.example"},
 	}}
@@ -252,10 +291,10 @@ func testInboundVerifier(t *testing.T, pub ed25519.PublicKey) (*config.Config, *
 	return cfg, verifier
 }
 
-func signedInboundRequest(t *testing.T, priv ed25519.PrivateKey, keyID, actor, body string) *http.Request {
+func signedInboundRequest(t *testing.T, priv ed25519.PrivateKey, actor string) *http.Request {
 	t.Helper()
 
-	req := httptest.NewRequest(http.MethodPost, "https://upstream.example/api", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "https://upstream.example/api", strings.NewReader(testInboundBody))
 	env := envelope.Envelope{
 		Version:   1,
 		Action:    "write",
@@ -270,14 +309,14 @@ func signedInboundRequest(t *testing.T, priv ed25519.PrivateKey, keyID, actor, b
 	}
 	signer, err := envelope.NewSigner(envelope.SignerConfig{
 		PrivKey:          priv,
-		KeyID:            keyID,
+		KeyID:            testInboundKeyID,
 		SignedComponents: config.DefaultEnvelopeSignedComponents(),
 		Expires:          time.Minute,
 	})
 	if err != nil {
 		t.Fatalf("NewSigner: %v", err)
 	}
-	if err := signer.SignRequest(req, []byte(body)); err != nil {
+	if err := signer.SignRequest(req, []byte(testInboundBody)); err != nil {
 		t.Fatalf("SignRequest: %v", err)
 	}
 	return req

--- a/internal/proxy/envelope_reload_test.go
+++ b/internal/proxy/envelope_reload_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -333,6 +334,78 @@ func TestProxy_ReloadEnvelopeEmitter_DisabledNilsEmitter(t *testing.T) {
 	// not mask the assertion.
 	if em := p.envelopeEmitterPtr.Load(); em != nil {
 		t.Errorf("envelope emitter pointer should be nil after enabled=false reload, got %p", em)
+	}
+}
+
+func TestProxy_ReloadInboundVerifierActorFormatStrictFlip(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := testInboundEnvelopeKey(t)
+	strictCfg := inboundVerifierReloadConfig(pub, envelope.ActorFormatSPIFFE, []string{"partner.example"})
+	p, err := New(strictCfg, audit.NewNop(), scanner.New(strictCfg), metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	t.Cleanup(p.Close)
+
+	assertInboundActorRejected(t, p, strictCfg, signedInboundRequest(t, priv, "legacy-agent"))
+	assertInboundActorVerified(t, p, strictCfg, signedInboundRequest(t, priv, "spiffe://partner.example/agent/proxy"))
+
+	firstReload := inboundVerifierReloadConfig(pub, envelope.ActorFormatSPIFFE, []string{"partner.example"})
+	if ok := p.Reload(firstReload, scanner.New(firstReload)); !ok {
+		t.Fatal("first strict reload should publish")
+	}
+	assertInboundActorRejected(t, p, firstReload, signedInboundRequest(t, priv, "legacy-agent"))
+
+	unrelatedReload := inboundVerifierReloadConfig(pub, envelope.ActorFormatSPIFFE, []string{"partner.example"})
+	unrelatedReload.FetchProxy.UserAgent = "pipelock-test-reload"
+	if ok := p.Reload(unrelatedReload, scanner.New(unrelatedReload)); !ok {
+		t.Fatal("second unrelated reload should publish")
+	}
+	assertInboundActorRejected(t, p, unrelatedReload, signedInboundRequest(t, priv, "legacy-agent"))
+
+	permissiveCfg := inboundVerifierReloadConfig(pub, envelope.ActorFormatLegacy, nil)
+	if ok := p.Reload(permissiveCfg, scanner.New(permissiveCfg)); !ok {
+		t.Fatal("downgrade to legacy actor format should publish")
+	}
+	assertInboundActorVerified(t, p, permissiveCfg, signedInboundRequest(t, priv, "legacy-agent"))
+
+	strictAgain := inboundVerifierReloadConfig(pub, envelope.ActorFormatSPIFFE, []string{"partner.example"})
+	if ok := p.Reload(strictAgain, scanner.New(strictAgain)); !ok {
+		t.Fatal("upgrade back to strict actor format should publish")
+	}
+	assertInboundActorRejected(t, p, strictAgain, signedInboundRequest(t, priv, "legacy-agent"))
+	assertInboundActorVerified(t, p, strictAgain, signedInboundRequest(t, priv, "spiffe://partner.example/agent/proxy"))
+}
+
+func inboundVerifierReloadConfig(pub ed25519.PublicKey, actorFormat string, trustDomains []string) *config.Config {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.MediationEnvelope.ActorFormat = actorFormat
+	cfg.MediationEnvelope.MaxBodyBytes = 1024
+	cfg.MediationEnvelope.VerifyInbound.Enabled = true
+	cfg.MediationEnvelope.VerifyInbound.TrustList = []config.MediationEnvelopeTrustedKey{{
+		KeyID:        testInboundKeyID,
+		PublicKey:    hex.EncodeToString(pub),
+		TrustDomains: append([]string(nil), trustDomains...),
+	}}
+	cfg.MediationEnvelope.VerifyInbound.ReplayCache.Window = "5m"
+	cfg.MediationEnvelope.VerifyInbound.ReplayCache.MaxEntries = 32
+	return cfg
+}
+
+func assertInboundActorRejected(t *testing.T, p *Proxy, cfg *config.Config, req *http.Request) {
+	t.Helper()
+	if err := verifyInboundEnvelope(req, cfg, p.envelopeVerifierPtr.Load()); err == nil {
+		t.Fatal("expected inbound envelope verification to reject actor")
+	}
+}
+
+func assertInboundActorVerified(t *testing.T, p *Proxy, cfg *config.Config, req *http.Request) {
+	t.Helper()
+	if err := verifyInboundEnvelope(req, cfg, p.envelopeVerifierPtr.Load()); err != nil {
+		t.Fatalf("expected inbound envelope verification to accept actor: %v", err)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1109,6 +1109,7 @@ func buildInboundEnvelopeVerifier(cfg *config.Config) (*envelope.Verifier, error
 		TrustedKeys:          keys,
 		ReplayCache:          envelope.NewReplayCache(window, verify.ReplayCache.MaxEntries),
 		Skew:                 skew,
+		ActorFormat:          cfg.MediationEnvelope.ActorFormat,
 		MaxSignatureLifetime: window + skew,
 	})
 }


### PR DESCRIPTION
Inbound mediation-envelope verifier now requires syntactically valid SPIFFE actors when `mediation_envelope.actor_format: spiffe` (the existing default). v2.4 was permissive on inbound regardless of the configured format. Operators with peers still signing legacy free-form actors must set `actor_format: legacy` during migration. CHANGELOG covers the behavior change.

New `pipelock envelope trust add/list/remove/verify` operator CLI. Local JSON store at `$XDG_STATE_HOME/pipelock/envelope/trust.json` (0o600). Runtime proxy verifier still reads from `pipelock.yaml mediation_envelope.verify_inbound.trust_list`; stderr advisory on every `add` names the YAML key so operators do not assume the CLI changed runtime admission.

Strict-flip applies across all five inbound verify call sites (forward CONNECT and absolute-URI, intercept, reverse, WebSocket, .well-known dispatch) through a single `verifier.VerifyRequest`. Reload test covers strict to legacy downgrade and back.

Symlink containment on the default trust store path via `os.Lstat` + `EvalSymlinks` + `filepath.Rel`. 16 MiB body cap on `verify --stdin`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New `pipelock envelope trust` command for managing federation trust stores with add, list, remove, and verify operations.
  * Inbound envelope verification now requires SPIFFE actors by default for enhanced security.
  * Legacy actor format supported via configuration for migration purposes.

* **Documentation**
  * Updated federation and mediation envelope guides with SPIFFE configuration and trust management details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/522)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->