### PR TITLE
fix(claude-hook): close fail-open path for unknown tools

### DIFF
--- a/internal/cli/setup/claude.go
+++ b/internal/cli/setup/claude.go
@@ -190,10 +190,6 @@ func runClaudeHook(cmd *cobra.Command, configFile string, exitCodeMode bool) (re
 		return claudeResult(cmd, exitCodeMode, payload.HookEventName, decisionDeny,
 			"pipelock: "+err.Error())
 	}
-	if action == nil {
-		// Unknown tool: default allow.
-		return claudeResult(cmd, exitCodeMode, payload.HookEventName, decisionAllow, "")
-	}
 
 	// Decide.
 	decision := decide.Decide(cmd.Context(), cfg, sc, pc, *action)
@@ -231,7 +227,10 @@ func claudeResult(cmd *cobra.Command, exitCodeMode bool, hookEventName, permissi
 }
 
 // claudePayloadToAction routes a Claude Code tool_name to a decide.Action.
-// Returns nil action for unknown tools (default allow).
+// Known built-in tools (Bash, WebFetch, Write, Edit) and MCP tools route to
+// their tool-aware scanning pipelines. Everything else falls through to a
+// generic catch-all that runs DLP + injection on every string in tool_input,
+// so unknown or future tools cannot silently exfiltrate secrets.
 // Returns error for known tools with unparseable tool_input (fail-closed).
 func claudePayloadToAction(p claudeCodePayload) (*decide.Action, error) {
 	action := decide.Action{Source: "claude-code"}
@@ -298,8 +297,15 @@ func claudePayloadToAction(p claudeCodePayload) (*decide.Action, error) {
 		return &action, nil
 
 	default:
-		// Unknown tool: return nil to signal default allow.
-		return nil, nil //nolint:nilnil // nil,nil signals "unknown tool, allow by default"
+		// Generic catch-all: scan every string in tool_input for DLP +
+		// injection. Closes the fail-open path for tools we don't parse
+		// specifically (WebSearch, Task, NotebookEdit, future tools, etc.).
+		action.Kind = decide.EventToolUse
+		action.ToolUse = &decide.ToolUsePayload{
+			ToolName:  p.ToolName,
+			ToolInput: string(p.ToolInput),
+		}
+		return &action, nil
 	}
 }
 
@@ -342,11 +348,10 @@ type claudeHookEntry struct {
 // claudeHookTimeout is the default timeout (seconds) for pipelock hook entries.
 const claudeHookTimeout = 10
 
-// claudeBuiltinMatcher matches the built-in tools pipelock scans.
-const claudeBuiltinMatcher = "Bash|WebFetch|Write|Edit"
-
-// claudeMCPMatcher matches all MCP tool calls.
-const claudeMCPMatcher = "mcp__.*"
+// claudeToolMatcher matches every tool call. Built-in tools (Bash, WebFetch,
+// Write, Edit) and MCP tools route to tool-aware scanning; all others fall
+// through to a generic DLP + injection catch-all in claudePayloadToAction.
+const claudeToolMatcher = ".*"
 
 // parseClaudeSettings parses the hooks section from settings.json data.
 func parseClaudeSettings(data []byte) (*claudeSettings, error) {
@@ -399,21 +404,15 @@ func mergeClaudeHooks(settings *claudeSettings, exe string) *claudeSettings {
 		}
 	}
 
-	// Add fresh pipelock groups to PreToolUse.
+	// Add fresh pipelock group to PreToolUse. A single .* matcher catches
+	// every tool; dispatch in claudePayloadToAction decides what to scan.
 	quoted := shellQuote(exe)
 	hookCommand := quoted + " claude hook"
 
-	result.Hooks[claudeHookEventPreToolUse] = append(result.Hooks[claudeHookEventPreToolUse],
+	result.Hooks[claudeHookEventPreToolUse] = append(
+		result.Hooks[claudeHookEventPreToolUse],
 		claudeMatcherGroup{
-			Matcher: claudeBuiltinMatcher,
-			Hooks: []claudeHookEntry{{
-				Type:    "command",
-				Command: hookCommand,
-				Timeout: claudeHookTimeout,
-			}},
-		},
-		claudeMatcherGroup{
-			Matcher: claudeMCPMatcher,
+			Matcher: claudeToolMatcher,
 			Hooks: []claudeHookEntry{{
 				Type:    "command",
 				Command: hookCommand,

--- a/internal/cli/setup/claude_test.go
+++ b/internal/cli/setup/claude_test.go
@@ -156,8 +156,8 @@ func TestClaudeHookCmd_EmptyStdin(t *testing.T) {
 	}
 }
 
-func TestClaudeHookCmd_UnknownTool_DefaultsAllow(t *testing.T) {
-	input := `{"session_id":"s1","hook_event_name":"PreToolUse","tool_name":"SomeNewTool","tool_input":{},"tool_use_id":"t1"}`
+func TestClaudeHookCmd_UnknownTool_CleanInputAllows(t *testing.T) {
+	input := `{"session_id":"s1","hook_event_name":"PreToolUse","tool_name":"SomeNewTool","tool_input":{"arg":"hello"},"tool_use_id":"t1"}`
 
 	cmd := ClaudeCmd()
 	cmd.SetArgs([]string{"hook"})
@@ -174,7 +174,53 @@ func TestClaudeHookCmd_UnknownTool_DefaultsAllow(t *testing.T) {
 		t.Fatalf("output not valid JSON: %v\noutput: %s", err, buf.String())
 	}
 	if resp.HookSpecificOutput.PermissionDecision != decisionAllow {
-		t.Errorf("unknown tool should allow by default, got %s", resp.HookSpecificOutput.PermissionDecision)
+		t.Errorf("unknown tool with clean input should allow, got %s", resp.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+func TestClaudeHookCmd_UnknownTool_SecretInArgsDenies(t *testing.T) {
+	secret := "sk-ant-" + "api03-AABBCCDDEE123456789012345678901234"
+	input := `{"session_id":"s1","hook_event_name":"PreToolUse","tool_name":"SomeNewTool","tool_input":{"data":"` + secret + `"},"tool_use_id":"t1"}`
+
+	cmd := ClaudeCmd()
+	cmd.SetArgs([]string{"hook"})
+	cmd.SetIn(bytes.NewReader([]byte(input)))
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var resp claudeCodeResponse
+	if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &resp); err != nil {
+		t.Fatalf("output not valid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if resp.HookSpecificOutput.PermissionDecision != decisionDeny {
+		t.Errorf("unknown tool with secret in args should deny, got %s", resp.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+func TestClaudeHookCmd_WebSearch_SecretInQueryDenies(t *testing.T) {
+	secret := "ghp_" + "ABCDEFghijklmnopqrstuvwxyz0123456789"
+	input := `{"session_id":"s1","hook_event_name":"PreToolUse","tool_name":"WebSearch","tool_input":{"query":"docs ` + secret + `"},"tool_use_id":"t1"}`
+
+	cmd := ClaudeCmd()
+	cmd.SetArgs([]string{"hook"})
+	cmd.SetIn(bytes.NewReader([]byte(input)))
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var resp claudeCodeResponse
+	if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &resp); err != nil {
+		t.Fatalf("output not valid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if resp.HookSpecificOutput.PermissionDecision != decisionDeny {
+		t.Errorf("WebSearch query with secret should deny, got %s", resp.HookSpecificOutput.PermissionDecision)
 	}
 }
 
@@ -348,8 +394,11 @@ func TestMergeClaudeHooks_Fresh(t *testing.T) {
 	merged := mergeClaudeHooks(settings, "/usr/local/bin/pipelock")
 
 	groups := merged.Hooks["PreToolUse"]
-	if len(groups) != 2 {
-		t.Fatalf("expected 2 matcher groups (builtin + MCP), got %d", len(groups))
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 matcher group (.*), got %d", len(groups))
+	}
+	if groups[0].Matcher != claudeToolMatcher {
+		t.Errorf("matcher = %q, want %q", groups[0].Matcher, claudeToolMatcher)
 	}
 }
 
@@ -400,9 +449,9 @@ func TestMergeClaudeHooks_Idempotent(t *testing.T) {
 			}
 		}
 	}
-	// Expect exactly 2 pipelock hook entries (builtin + MCP matchers).
-	if count != 2 {
-		t.Errorf("expected 2 pipelock entries after idempotent merge, got %d", count)
+	// Expect exactly 1 pipelock hook entry (single .* matcher).
+	if count != 1 {
+		t.Errorf("expected 1 pipelock entry after idempotent merge, got %d", count)
 	}
 }
 
@@ -492,7 +541,7 @@ func TestRemoveClaudeHooks_PreservesOthers(t *testing.T) {
 		Hooks: map[string][]claudeMatcherGroup{
 			"PreToolUse": {
 				{Matcher: "Bash", Hooks: []claudeHookEntry{{Type: "command", Command: "other-tool"}}},
-				{Matcher: claudeBuiltinMatcher, Hooks: []claudeHookEntry{{Type: "command", Command: "/usr/bin/pipelock claude hook"}}},
+				{Matcher: claudeToolMatcher, Hooks: []claudeHookEntry{{Type: "command", Command: "/usr/bin/pipelock claude hook"}}},
 			},
 		},
 	}
@@ -617,10 +666,10 @@ func TestClaudeSetupCmd_Idempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Count occurrences of "claude hook" (should be exactly 2: builtin + MCP).
+	// Count occurrences of "claude hook" (should be exactly 1: single .* matcher).
 	count := strings.Count(string(data), "claude hook")
-	if count != 2 {
-		t.Errorf("expected 2 'claude hook' entries after idempotent setup, got %d", count)
+	if count != 1 {
+		t.Errorf("expected 1 'claude hook' entry after idempotent setup, got %d", count)
 	}
 }
 

--- a/internal/decide/decide.go
+++ b/internal/decide/decide.go
@@ -25,6 +25,11 @@ const (
 	// Claude Code hook event kinds (tool_name values, no "before" prefix).
 	EventWebFetch  EventKind = "WebFetch"
 	EventWriteFile EventKind = "WriteFile"
+
+	// EventToolUse is the generic catch-all for any tool call whose schema
+	// pipelock does not parse specifically. Runs DLP + injection scanning on
+	// every string extracted from tool_input.
+	EventToolUse EventKind = "ToolUse"
 )
 
 // ShellPayload holds fields specific to shell execution events.
@@ -62,6 +67,12 @@ type WritePayload struct {
 	OldString string `json:"old_string,omitempty"`
 }
 
+// ToolUsePayload holds the raw tool_input for generic catch-all scanning.
+type ToolUsePayload struct {
+	ToolName  string `json:"tool_name"`
+	ToolInput string `json:"tool_input"` // escaped JSON string
+}
+
 // Action describes an agent action to be evaluated.
 type Action struct {
 	Source string    // originating IDE (e.g., "cursor")
@@ -73,6 +84,7 @@ type Action struct {
 	File     *FilePayload
 	WebFetch *WebFetchPayload
 	Write    *WritePayload
+	ToolUse  *ToolUsePayload
 }
 
 // Outcome is the decision result: allow or deny.
@@ -115,6 +127,8 @@ func Decide(ctx context.Context, cfg *config.Config, sc *scanner.Scanner, policy
 		return decideWebFetch(ctx, cfg, sc, action.WebFetch)
 	case EventWriteFile:
 		return decideWrite(cfg, sc, policyCfg, action.Write)
+	case EventToolUse:
+		return decideToolUse(cfg, sc, action.ToolUse)
 	default:
 		return Decision{
 			Outcome:     Deny,
@@ -240,6 +254,48 @@ func decideWrite(cfg *config.Config, sc *scanner.Scanner, policyCfg *policy.Conf
 		return deny("pipelock: missing WriteFile payload")
 	}
 	return decideFileContent(cfg, sc, policyCfg, "write_file", p.FilePath, p.Content)
+}
+
+// decideToolUse is the generic catch-all path for tool calls whose schema
+// pipelock does not parse specifically. It extracts every string from
+// tool_input and runs DLP + injection scanning, so unknown tools cannot
+// silently exfiltrate secrets or relay prompt injection. Malformed JSON is a
+// block-level finding (fail-closed).
+func decideToolUse(cfg *config.Config, sc *scanner.Scanner, p *ToolUsePayload) Decision {
+	if p == nil {
+		return deny("pipelock: missing ToolUse payload")
+	}
+
+	var evidence []Evidence
+	var scanText string
+
+	if p.ToolInput != "" {
+		if !json.Valid([]byte(p.ToolInput)) {
+			evidence = append(evidence, Evidence{
+				Scanner:  "decide",
+				Pattern:  "Malformed Tool Input",
+				Severity: config.SeverityHigh,
+				Detail:   "tool_input is not valid JSON",
+				Action:   config.ActionBlock,
+			})
+			scanText = p.ToolInput
+		} else {
+			argStrings := ExtractAllStringsFromJSON(json.RawMessage(p.ToolInput))
+			scanText = strings.Join(argStrings, " ")
+		}
+	}
+
+	if scanText != "" {
+		dlpResult := sc.ScanTextForDLP(context.Background(), scanText)
+		evidence = append(evidence, evidenceFromDLP(dlpResult)...)
+
+		if cfg.ResponseScanning.Enabled {
+			injResult := sc.ScanResponse(context.Background(), scanText)
+			evidence = append(evidence, evidenceFromInjection(injResult, cfg.ResponseScanning.Action)...)
+		}
+	}
+
+	return buildDecision(cfg, evidence)
 }
 
 // decideFileContent is the shared logic for file read and write events.

--- a/internal/decide/decide_test.go
+++ b/internal/decide/decide_test.go
@@ -302,6 +302,7 @@ func TestDecide_NilPayload(t *testing.T) {
 		{"nil file payload", EventReadFile},
 		{"nil WebFetch payload", EventWebFetch},
 		{"nil WriteFile payload", EventWriteFile},
+		{"nil ToolUse payload", EventToolUse},
 	}
 
 	for _, tt := range tests {
@@ -783,6 +784,62 @@ func TestDecide_WriteFile(t *testing.T) {
 				Write:  &WritePayload{FilePath: tt.path, Content: tt.content},
 			}
 			decision := Decide(context.Background(), cfg, sc, pc, action)
+			if decision.Outcome != tt.want {
+				t.Errorf("Decide() outcome = %s, want %s; evidence = %+v", decision.Outcome, tt.want, decision.Evidence)
+			}
+		})
+	}
+}
+
+func TestDecide_ToolUse(t *testing.T) {
+	cfg, sc, _ := testSetup(t)
+
+	tests := []struct {
+		name      string
+		toolName  string
+		toolInput string
+		want      Outcome
+	}{
+		{
+			name:      "clean input allows",
+			toolName:  "WebSearch",
+			toolInput: `{"query":"golang generics tutorial"}`,
+			want:      Allow,
+		},
+		{
+			name:      "secret in input denies",
+			toolName:  "WebSearch",
+			toolInput: `{"query":"docs ` + "sk-ant-" + `api03-AABBCCDDEE123456789012345678901234"}`,
+			want:      Deny,
+		},
+		{
+			name:      "malformed JSON denies",
+			toolName:  "SomeTool",
+			toolInput: `{broken`,
+			want:      Deny,
+		},
+		{
+			name:      "empty input allows",
+			toolName:  "SomeTool",
+			toolInput: "",
+			want:      Allow,
+		},
+		{
+			name:      "secret nested in object denies",
+			toolName:  "Task",
+			toolInput: `{"description":"work","prompt":"use ` + "sk-ant-" + `api03-AABBCCDDEE123456789012345678901234"}`,
+			want:      Deny,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action := Action{
+				Source:  "claude-code",
+				Kind:    EventToolUse,
+				ToolUse: &ToolUsePayload{ToolName: tt.toolName, ToolInput: tt.toolInput},
+			}
+			decision := Decide(context.Background(), cfg, sc, nil, action)
 			if decision.Outcome != tt.want {
 				t.Errorf("Decide() outcome = %s, want %s; evidence = %+v", decision.Outcome, tt.want, decision.Evidence)
 			}


### PR DESCRIPTION
## Summary

The Claude Code `PreToolUse` hook had a fail-open path that contradicts the project's "fail-closed everywhere" hard rule:

- The installed matchers were `Bash|WebFetch|Write|Edit` and `mcp__.*`. Every other tool (`WebSearch`, `Task`, `NotebookEdit`, and any future tool Anthropic ships) never reached pipelock at all.
- For tool names that *did* reach the hook but were not parsed specifically, `claudePayloadToAction` returned `(nil, nil)` with the comment `// Unknown tool: default allow`, which `runClaudeHook` treated as approve.

Net effect: an agent could call `WebSearch` with an Anthropic API key in the query, or any future tool with secrets in its arguments, and pipelock would silently approve it.

This PR closes that path:

- Replaces the two split matchers with a single `.*` matcher so every tool call reaches the hook.
- Adds a new generic `EventToolUse` kind in `internal/decide` with a `decideToolUse` handler. It extracts every string from `tool_input` via the existing `ExtractAllStringsFromJSON` helper and runs DLP + (optional) injection scanning on the joined text.
- Malformed `tool_input` is now block-level evidence rather than a silent allow.
- `claudePayloadToAction` falls through to this catch-all in its `default` arm, so the specific Bash/WebFetch/Write/Edit/MCP paths still get their tool-aware scanning; everything else gets the generic DLP+injection sweep.

No new direct dependencies. No config-schema changes. No public CLI changes (hook entries are regenerated by `pipelock claude install`; users will see one `.*` group instead of two split groups after re-running it).

## Why

- `CLAUDE.md` Hard Rules: *"Never bypass fail-closed defaults. ... If in doubt, block."*
- `CLAUDE.md` Security Invariants: *"Allowlist/suppression must not bypass content scanning... unless the exception is deliberate, documented, and tested."* The old `nil, nil` path was none of those.
- Transport parity: the forward proxy, fetch proxy, WebSocket proxy, and MCP proxy all scan unknown traffic. The Claude Code hook was the odd one out.

## Test plan

- [x] `go test -race -count=1 ./internal/cli/setup/... ./internal/decide/...` (only unrelated `TestVscodeInstall_WithRelativeConfigPersistsAbsolutePath` fails — pre-existing macOS `/var` vs `/private/var` symlink artifact on `main`, untouched by this PR).
- [x] `go vet ./internal/cli/setup/... ./internal/decide/...` clean.
- [x] `gofumpt -l` clean on the four touched files.
- [ ] Maintainer: verify against full CI matrix (Go 1.25 + 1.26, golangci-lint v2, govulncheck, CodeQL, self-scan).
- [ ] Manual: run `pipelock claude install` against a fresh `~/.claude/settings.json`, confirm a single `.*` matcher group is written; re-run and confirm idempotence.
- [ ] Manual: invoke `WebSearch` with a secret in the query and confirm the hook denies.

New tests in this PR:
- `TestClaudeHookCmd_UnknownTool_CleanInputAllows` — sanity: unknown tool with clean input still allows.
- `TestClaudeHookCmd_UnknownTool_SecretInArgsDenies` — secret in arbitrary tool's args is now caught.
- `TestClaudeHookCmd_WebSearch_SecretInQueryDenies` — concrete regression for the `WebSearch` exfil path.
- `TestDecide_ToolUse` — 5 subcases: clean, secret, malformed JSON (fail-closed), empty input, nested secret in object.
- `TestDecide_NilPayload` extended to cover `EventToolUse`.
- `TestMergeClaudeHooks_Fresh` / `_Idempotent` / `TestClaudeSetupCmd_Idempotent` updated to expect one matcher group instead of two.

## Compatibility

Users who already ran `pipelock claude install` keep their existing two-group config and the hook still works (both matchers route to the same binary, which now handles the unknown-tool case correctly). Re-running install will collapse the two groups into the single `.*` group via the existing remove-then-add merge logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced Claude Code tool integration with safer, more consistent event routing for tool calls.
  * Unknown and future tools now undergo security scanning for secrets and injection attempts rather than being silently allowed.
  * Tool inputs are scanned for data leakage and injection vulnerabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/525)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->