### PR TITLE
fix(rules): separate official bundle keyring from license key

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,14 +66,49 @@ jobs:
       - name: Set GOVERSION
         run: echo "GOVERSION=$(go env GOVERSION)" >> "$GITHUB_ENV"
 
-      - name: Verify embedded license public key is configured
+      - name: Verify embedded public keys are configured
         env:
           LICENSE_PUBLIC_KEY: ${{ secrets.LICENSE_PUBLIC_KEY }}
+          RULES_KEYRING_HEX: ${{ secrets.RULES_KEYRING_HEX }}
         run: |
           test -n "$LICENSE_PUBLIC_KEY" || {
             echo "::error::LICENSE_PUBLIC_KEY secret is required for release builds"
             exit 1
           }
+          test -n "$RULES_KEYRING_HEX" || {
+            echo "::error::RULES_KEYRING_HEX secret is required for release builds"
+            exit 1
+          }
+          case "$LICENSE_PUBLIC_KEY" in
+            *[!0123456789abcdefABCDEF]*)
+              echo "::error::LICENSE_PUBLIC_KEY must be a raw Ed25519 public key encoded as hex"
+              exit 1
+              ;;
+          esac
+          test "${#LICENSE_PUBLIC_KEY}" -eq 64 || {
+            echo "::error::LICENSE_PUBLIC_KEY must be 64 hex characters"
+            exit 1
+          }
+          if [[ ! "$RULES_KEYRING_HEX" =~ ^[0-9A-Fa-f]{64}(,[0-9A-Fa-f]{64})*$ ]]; then
+            echo "::error::RULES_KEYRING_HEX must be one or more 64-hex Ed25519 public keys separated by commas"
+            exit 1
+          fi
+          license_public_key_normalized="${LICENSE_PUBLIC_KEY,,}"
+          IFS=',' read -r -a rules_keys <<< "$RULES_KEYRING_HEX"
+          for key in "${rules_keys[@]}"; do
+            test -n "$key" || {
+              echo "::error::RULES_KEYRING_HEX contains an empty key entry"
+              exit 1
+            }
+            test "${#key}" -eq 64 || {
+              echo "::error::RULES_KEYRING_HEX entries must be 64 hex characters"
+              exit 1
+            }
+            test "${key,,}" != "$license_public_key_normalized" || {
+              echo "::error::LICENSE_PUBLIC_KEY must not appear in RULES_KEYRING_HEX"
+              exit 1
+            }
+          done
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
@@ -86,6 +121,7 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           GOVERSION: ${{ env.GOVERSION }}
           LICENSE_PUBLIC_KEY: ${{ secrets.LICENSE_PUBLIC_KEY }}
+          RULES_KEYRING_HEX: ${{ secrets.RULES_KEYRING_HEX }}
 
       - name: Generate SBOM
         run: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,7 +29,7 @@ builds:
       - -X github.com/luckyPipewrench/pipelock/internal/cliutil.GoVersion={{.Env.GOVERSION}}
       - -X github.com/luckyPipewrench/pipelock/internal/proxy.Version={{.Version}}
       - -X github.com/luckyPipewrench/pipelock/internal/license.PublicKeyHex={{.Env.LICENSE_PUBLIC_KEY}}
-      - -X github.com/luckyPipewrench/pipelock/internal/rules.KeyringHex={{.Env.LICENSE_PUBLIC_KEY}}
+      - -X github.com/luckyPipewrench/pipelock/internal/rules.KeyringHex={{.Env.RULES_KEYRING_HEX}}
 
   # License service: cluster-only webhook handler for Polar subscription events.
   # Linux-only (runs in k8s), not distributed via Homebrew or public archives.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG VERSION=0.1.0-dev
 ARG BUILD_DATE=unknown
 ARG GIT_COMMIT=unknown
 ARG LICENSE_PUBLIC_KEY=""
+ARG RULES_KEYRING_HEX=""
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
@@ -20,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
       -X github.com/luckyPipewrench/pipelock/internal/cliutil.GoVersion=$(go version | awk '{print $3}') \
       -X github.com/luckyPipewrench/pipelock/internal/proxy.Version=${VERSION} \
       -X github.com/luckyPipewrench/pipelock/internal/license.PublicKeyHex=${LICENSE_PUBLIC_KEY} \
-      -X github.com/luckyPipewrench/pipelock/internal/rules.KeyringHex=${LICENSE_PUBLIC_KEY}" \
+      -X github.com/luckyPipewrench/pipelock/internal/rules.KeyringHex=${RULES_KEYRING_HEX}" \
     -o /pipelock ./cmd/pipelock
 
 # Scratch-based final image (~15MB)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BUILD_DATE := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 GO_VERSION := $(shell go version | awk '{print $$3}')
 LICENSE_PUBLIC_KEY ?=
+RULES_KEYRING_HEX ?=
 LDFLAGS := -ldflags "-s -w \
 	-X $(MODULE)/internal/cliutil.Version=$(VERSION) \
 	-X $(MODULE)/internal/cliutil.BuildDate=$(BUILD_DATE) \
@@ -12,7 +13,7 @@ LDFLAGS := -ldflags "-s -w \
 	-X $(MODULE)/internal/cliutil.GoVersion=$(GO_VERSION) \
 	-X $(MODULE)/internal/proxy.Version=$(VERSION) \
 	-X $(MODULE)/internal/license.PublicKeyHex=$(LICENSE_PUBLIC_KEY) \
-	-X $(MODULE)/internal/rules.KeyringHex=$(LICENSE_PUBLIC_KEY)"
+	-X $(MODULE)/internal/rules.KeyringHex=$(RULES_KEYRING_HEX)"
 
 .PHONY: all build build-verifier test bench lint clean docker install fmt vet tidy-check fuzz stats docs-check \
 	test-runtime-critical test-replay-harness release-audit runtime-policy-audit debt-check release-check
@@ -89,6 +90,7 @@ docker:
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg LICENSE_PUBLIC_KEY=$(LICENSE_PUBLIC_KEY) \
+		--build-arg RULES_KEYRING_HEX=$(RULES_KEYRING_HEX) \
 		-t $(BINARY):$(VERSION) -t $(BINARY):latest .
 
 fuzz:

--- a/scripts/release-audit.sh
+++ b/scripts/release-audit.sh
@@ -168,6 +168,15 @@ while IFS= read -r workflow; do
 	fi
 done < <(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
 
+note "release audit: checking build-time trust roots"
+
+if rg_search -n 'rules\.KeyringHex=.*LICENSE_PUBLIC_KEY|rules\.KeyringHex=\{\{\.Env\.LICENSE_PUBLIC_KEY\}\}' Makefile Dockerfile .goreleaser.yaml; then
+	if [[ -n "$rg_output" ]]; then
+		fail "rules.KeyringHex must not be sourced from LICENSE_PUBLIC_KEY; rule bundles and licenses use separate trust roots"
+		note "$rg_output"
+	fi
+fi
+
 if [[ "$errors" -ne 0 ]]; then
 	exit 1
 fi


### PR DESCRIPTION
## Summary

- Add a separate `RULES_KEYRING_HEX` build/release variable for official rule bundle verification.
- Keep `LICENSE_PUBLIC_KEY` scoped to license verification only.
- Wire Makefile, Dockerfile, GoReleaser, and release workflow builds to use the separate rules keyring.
- Validate `RULES_KEYRING_HEX` before release so malformed keyring secrets fail closed.
- Add release-audit coverage so `rules.KeyringHex` cannot regress to `LICENSE_PUBLIC_KEY`.

## Why

Official rule bundle installs verify `bundle.yaml.sig` against the public keys embedded in `internal/rules.KeyringHex`.

Release builds were wiring `rules.KeyringHex` from `LICENSE_PUBLIC_KEY`, which is the wrong trust root. That causes fresh installs of signed official bundles such as `pipelock-community` and `healthcare-phi-pii` to fail with `signature verification: no matching signer found for bundle`.

Rule bundle signing and license verification are separate trust domains and should use separate release secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release process now validates two separate cryptographic trust roots before publishing, rejects empty or malformed values, and prevents duplicate entries.
  * Build and release steps forward the additional trust-root value into artifacts so it’s embedded consistently.
  * Added a release-audit check that blocks releases if trust-root sourcing is misconfigured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/526)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->