### PR TITLE
feat(contain): implement containment install lifecycle

### DIFF
--- a/internal/cli/contain/addtool.go
+++ b/internal/cli/contain/addtool.go
@@ -1,0 +1,221 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+// addToolNamePattern bounds tool names to a small alphabet so the wrapper
+// path is safe to construct without shell quoting (a-z0-9, _-, max 31
+// chars, must start with [a-z0-9]).
+var addToolNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,30}$`)
+
+// addToolOpts collects flag state for the add-tool subcommand.
+type addToolOpts struct {
+	dryRun bool
+	target string
+}
+
+func addToolCmd() *cobra.Command {
+	var opts addToolOpts
+
+	cmd := &cobra.Command{
+		Use:   "add-tool <name>",
+		Short: "Drop a new /usr/local/bin/plk-<name> wrapper",
+		Long: `Install a wrapper at /usr/local/bin/plk-<name> that execs
+` + "`plk-launch <name>`" + ` and records the new wrapper in the contain
+wrapper inventory used by ` + "`pipelock contain verify`" + `.
+
+Validates that the target tool resolves to an executable on pipelock-agent's
+PATH so the wrapper isn't installed pointing at nothing. Pass --target
+to override the auto-detected path.
+
+Must be run as root.
+
+Exit codes:
+  0  Wrapper installed (or already in place).
+  1  Failed to write wrapper / update inventory.
+  2  Invalid tool name, target missing, or precondition error.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if !addToolNamePattern.MatchString(name) {
+				return cliutil.ExitCodeError(
+					cliutil.ExitConfig,
+					fmt.Errorf("invalid tool name %q (expected [a-z0-9][a-z0-9_-]{0,30})", name),
+				)
+			}
+			if !opts.dryRun && os.Geteuid() != 0 {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New("add-tool must be run as root (use sudo)"))
+			}
+			env := defaultInstallEnv(cmd.OutOrStdout())
+			return runAddTool(cmd.Context(), env, name, opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "print planned actions without mutating state")
+	cmd.Flags().StringVar(&opts.target, "target", "", "explicit path to the target tool (default: which <name> from pipelock-agent's PATH)")
+
+	return cmd
+}
+
+// runAddTool is the testable entry point.
+func runAddTool(ctx context.Context, env *installEnv, name string, opts addToolOpts) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// The cobra RunE wrapper does the os.Geteuid root check; tests drive
+	// this function directly with fakes.
+
+	wrapperName := "plk-" + name
+	wrapperPath := filepath.Join(env.wrapperDir, wrapperName)
+
+	// Desired wrapper body is known before target resolution, but idempotency
+	// also depends on tools.list and is checked after target validation.
+	desiredBody := renderToolWrapper(env, name)
+	existing, readErr := env.readFile(wrapperPath)
+	alreadyInInventory := wrapperInInventory(env, wrapperName)
+
+	// Target resolution. --target trumps. Otherwise we run `which` AS
+	// pipelock-agent so the lookup uses pipelock-agent's PATH, not root's.
+	target := opts.target
+	if target == "" {
+		out, code, _ := env.runCmd(ctx, "sudo", "-n", "-u", env.agentUserName, "--", "which", name)
+		if code != 0 {
+			return cliutil.ExitCodeError(
+				cliutil.ExitConfig,
+				fmt.Errorf("tool %q not found in pipelock-agent's PATH (pass --target if it lives elsewhere)", name),
+			)
+		}
+		target = strings.TrimSpace(out)
+	}
+	if target == "" {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("could not resolve target for %q", name))
+	}
+	if !filepath.IsAbs(target) {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("target %q must be an absolute path", target))
+	}
+	info, err := env.stat(target)
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("target %q: %w", target, err))
+	}
+	if info.IsDir() {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("target %q is a directory", target))
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("target %q is not executable", target))
+	}
+	if out, code, err := env.runCmd(ctx, "sudo", "-n", "-u", env.agentUserName, "--", "test", "-x", target); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("validate target %q as %s: %w", target, env.agentUserName, err))
+	} else if code != 0 {
+		return cliutil.ExitCodeError(cliutil.ExitConfig,
+			fmt.Errorf("target %q is not executable by %s (sudo test exit=%d: %s)", target, env.agentUserName, code, oneLine(out)))
+	}
+
+	if opts.dryRun {
+		_, _ = fmt.Fprintf(env.out, "pipelock contain add-tool %s — planned:\n", name)
+		_, _ = fmt.Fprintf(env.out, "  1. write %s (mode 0o755)\n", wrapperPath)
+		_, _ = fmt.Fprintf(env.out, "  2. append %q to %s\n", wrapperName, env.wrapperInvPath)
+		_, _ = fmt.Fprintf(env.out, "  3. allow %q via %s\n", name, env.toolsListPath)
+		return nil
+	}
+
+	allowListTarget := opts.target
+	if readErr == nil && string(existing) == desiredBody && alreadyInInventory && toolEntryMatches(env, name, allowListTarget) {
+		_, _ = fmt.Fprintf(env.out, "wrapper %s already installed and inventoried — nothing to do.\n", wrapperPath)
+		return nil
+	}
+
+	if err := backupAndWrite(env, wrapperPath, []byte(desiredBody), modeWrapperExec); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("write %s: %w", wrapperPath, err))
+	}
+	if err := appendInventory(env, wrapperName); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("update inventory: %w", err))
+	}
+	// Add to the plk-launch runtime allow-list. The --target value, when
+	// provided, is baked in here so plk-launch execs the exact binary the
+	// operator approved instead of re-resolving via PATH at runtime. An
+	// empty target falls back to pipelock-agent's PATH lookup.
+	if _, err := upsertToolEntry(env, name, allowListTarget); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("update tools.list: %w", err))
+	}
+
+	_, _ = fmt.Fprintf(env.out, "installed wrapper %s -> plk-launch %s (target %s).\n", wrapperPath, name, target)
+	return nil
+}
+
+func toolEntryMatches(env *installEnv, name, target string) bool {
+	entries, err := readToolsList(env)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.name == name {
+			return entry.target == target
+		}
+	}
+	return false
+}
+
+// wrapperInInventory returns true if the inventory file lists name. A
+// missing or unparseable inventory yields false (callers will rewrite it).
+func wrapperInInventory(env *installEnv, name string) bool {
+	data, err := env.readFile(env.wrapperInvPath)
+	if err != nil {
+		return false
+	}
+	var inv wrapperInventory
+	if err := json.Unmarshal(data, &inv); err != nil {
+		return false
+	}
+	for _, w := range inv.Wrappers {
+		if w == name {
+			return true
+		}
+	}
+	return false
+}
+
+// appendInventory adds name to the inventory file if not already present.
+// Creates the file (and its directory) if missing.
+func appendInventory(env *installEnv, name string) error {
+	if err := env.mkdirAll(filepath.Dir(env.wrapperInvPath), modeDirTraversable); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(env.wrapperInvPath), err)
+	}
+	if err := env.chmod(filepath.Dir(env.wrapperInvPath), modeDirTraversable); err != nil {
+		return fmt.Errorf("chmod %s: %w", filepath.Dir(env.wrapperInvPath), err)
+	}
+	var inv wrapperInventory
+	data, err := env.readFile(env.wrapperInvPath)
+	if err == nil {
+		if err := json.Unmarshal(data, &inv); err != nil {
+			return fmt.Errorf("parse inventory %s: %w", env.wrapperInvPath, err)
+		}
+	}
+	for _, w := range inv.Wrappers {
+		if w == name {
+			return nil
+		}
+	}
+	inv.Wrappers = append(inv.Wrappers, name)
+	out, err := json.MarshalIndent(inv, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal inventory: %w", err)
+	}
+	return backupAndWrite(env, env.wrapperInvPath, append(out, '\n'), modeAllowListReadable)
+}

--- a/internal/cli/contain/addtool.go
+++ b/internal/cli/contain/addtool.go
@@ -202,7 +202,11 @@ func appendInventory(env *installEnv, name string) error {
 	}
 	var inv wrapperInventory
 	data, err := env.readFile(env.wrapperInvPath)
-	if err == nil {
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("read inventory %s: %w", env.wrapperInvPath, err)
+		}
+	} else {
 		if err := json.Unmarshal(data, &inv); err != nil {
 			return fmt.Errorf("parse inventory %s: %w", env.wrapperInvPath, err)
 		}

--- a/internal/cli/contain/addtool.go
+++ b/internal/cli/contain/addtool.go
@@ -104,15 +104,20 @@ func runAddTool(ctx context.Context, env *installEnv, name string, opts addToolO
 		}
 		target = strings.TrimSpace(out)
 	}
+	target = strings.TrimSpace(target)
 	if target == "" {
 		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("could not resolve target for %q", name))
 	}
+	target = filepath.Clean(target)
 	if !filepath.IsAbs(target) {
 		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("target %q must be an absolute path", target))
 	}
-	info, err := env.stat(target)
+	info, err := env.lstat(target)
 	if err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("target %q: %w", target, err))
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("target %q is a symlink; pass the resolved executable path", target))
 	}
 	if info.IsDir() {
 		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("target %q is a directory", target))
@@ -135,7 +140,7 @@ func runAddTool(ctx context.Context, env *installEnv, name string, opts addToolO
 		return nil
 	}
 
-	allowListTarget := opts.target
+	allowListTarget := target
 	if readErr == nil && string(existing) == desiredBody && alreadyInInventory && toolEntryMatches(env, name, allowListTarget) {
 		_, _ = fmt.Fprintf(env.out, "wrapper %s already installed and inventoried — nothing to do.\n", wrapperPath)
 		return nil
@@ -194,11 +199,15 @@ func wrapperInInventory(env *installEnv, name string) bool {
 // appendInventory adds name to the inventory file if not already present.
 // Creates the file (and its directory) if missing.
 func appendInventory(env *installEnv, name string) error {
-	if err := env.mkdirAll(filepath.Dir(env.wrapperInvPath), modeDirTraversable); err != nil {
-		return fmt.Errorf("mkdir %s: %w", filepath.Dir(env.wrapperInvPath), err)
+	dir := filepath.Dir(env.wrapperInvPath)
+	if err := ensureSafeDirectory(env, dir); err != nil {
+		return err
 	}
-	if err := env.chmod(filepath.Dir(env.wrapperInvPath), modeDirTraversable); err != nil {
-		return fmt.Errorf("chmod %s: %w", filepath.Dir(env.wrapperInvPath), err)
+	if err := env.mkdirAll(dir, modeDirTraversable); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	if err := env.chmod(dir, modeDirTraversable); err != nil {
+		return fmt.Errorf("chmod %s: %w", dir, err)
 	}
 	var inv wrapperInventory
 	data, err := env.readFile(env.wrapperInvPath)

--- a/internal/cli/contain/addtool_test.go
+++ b/internal/cli/contain/addtool_test.go
@@ -1,0 +1,334 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+func TestAddToolNamePattern(t *testing.T) {
+	good := []string{"claude", "codex", "tool-1", "x", "a_b", "tool-with-dashes"}
+	for _, n := range good {
+		if !addToolNamePattern.MatchString(n) {
+			t.Errorf("expected %q to validate", n)
+		}
+	}
+	bad := []string{"", "Capital", "-leading", "_leading", "../etc", "a b", "tool!", strings.Repeat("a", 32)}
+	for _, n := range bad {
+		if addToolNamePattern.MatchString(n) {
+			t.Errorf("expected %q to be rejected", n)
+		}
+	}
+}
+
+func TestRunAddTool_DryRunNonMutating(t *testing.T) {
+	env, runner, buf := newFakeEnv(t)
+	if err := os.WriteFile(filepath.Join(env.wrapperDir, "plk-launch"), []byte("#!/bin/bash\n"), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("plant: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "tool")
+	if err := os.WriteFile(target, []byte("x"), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("plant target: %v", err)
+	}
+	err := runAddTool(context.Background(), env, "claude", addToolOpts{dryRun: true, target: target})
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	// No wrapper should have been written.
+	if _, err := os.Stat(filepath.Join(env.wrapperDir, "plk-claude")); err == nil {
+		t.Errorf("dry-run wrote wrapper")
+	}
+	// No inventory file either.
+	if _, err := os.Stat(env.wrapperInvPath); err == nil {
+		t.Errorf("dry-run wrote inventory")
+	}
+	_ = runner
+	if !strings.Contains(buf.String(), "planned") {
+		t.Errorf("output: %q", buf.String())
+	}
+}
+
+func TestRunAddTool_UsesWhichToResolveTarget(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	if err := os.WriteFile(filepath.Join(env.wrapperDir, "plk-launch"), []byte("#!/bin/bash\n"), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("plant: %v", err)
+	}
+	whichTarget := filepath.Join(t.TempDir(), "discovered-tool")
+	if err := os.WriteFile(whichTarget, []byte("x"), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("plant: %v", err)
+	}
+	// Pre-bake the which response.
+	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "which", "discovered"), whichTarget+"\n", 0, nil)
+	err := runAddTool(context.Background(), env, "discovered", addToolOpts{})
+	if err != nil {
+		t.Fatalf("addTool: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(env.wrapperDir, "plk-discovered")); err != nil {
+		t.Errorf("wrapper not written: %v", err)
+	}
+}
+
+func TestRunAddTool_FailsWhenWhichNotInPath(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "which", "nopath"), "", 1, nil)
+	err := runAddTool(context.Background(), env, "nopath", addToolOpts{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if cliutil.ExitCodeOf(err) != cliutil.ExitConfig {
+		t.Errorf("exit: %d", cliutil.ExitCodeOf(err))
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("err: %v", err)
+	}
+}
+
+func TestRunAddTool_FailsWhenExplicitTargetNotExecutableByAgent(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	target := filepath.Join(t.TempDir(), "private-tool")
+	if err := os.WriteFile(target, []byte("x"), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("plant target: %v", err)
+	}
+	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "test", "-x", target), "permission denied\n", 1, nil)
+	err := runAddTool(context.Background(), env, "private", addToolOpts{target: target})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "not executable by pipelock-agent") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestRunAddTool_IdempotentWhenWrapperAndInventoryMatch(t *testing.T) {
+	env, _, buf := newFakeEnv(t)
+	target := filepath.Join(t.TempDir(), "tool")
+	if err := os.WriteFile(target, []byte("x"), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("plant: %v", err)
+	}
+	if err := runAddTool(context.Background(), env, "claude", addToolOpts{target: target}); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	buf.Reset()
+	if err := runAddTool(context.Background(), env, "claude", addToolOpts{target: target}); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if !strings.Contains(buf.String(), "already installed") {
+		t.Errorf("expected idempotent message, got %q", buf.String())
+	}
+}
+
+// runAddToolBypassRoot exercises the post-root-check path. runAddTool is
+// already the testable post-Cobra entry point; the Cobra wrapper owns the
+// os.Geteuid check.
+func runAddToolBypassRoot(t *testing.T, env *installEnv, name string, opts addToolOpts) error {
+	t.Helper()
+	if !addToolNamePattern.MatchString(name) {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("invalid tool name %q", name))
+	}
+	return runAddTool(context.Background(), env, name, opts)
+}
+
+func TestAddTool_WritesWrapperAndAppendsInventory(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	// Plant plk-launch since the wrapper template references it (otherwise
+	// the rendered file is fine but verify checks would later spot it).
+	if err := os.WriteFile(filepath.Join(env.wrapperDir, "plk-launch"), []byte("#!/bin/bash\n"), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("plant plk-launch: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "rustup")
+	if err := os.WriteFile(target, []byte("#!/bin/bash\n"), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("plant target: %v", err)
+	}
+	if err := runAddToolBypassRoot(t, env, "rustup", addToolOpts{target: target}); err != nil {
+		t.Fatalf("runAddTool: %v", err)
+	}
+	wrapperPath := filepath.Join(env.wrapperDir, "plk-rustup")
+	if _, err := os.Stat(wrapperPath); err != nil {
+		t.Errorf("wrapper not written: %v", err)
+	}
+	// Inventory must list the new wrapper.
+	data, err := os.ReadFile(env.wrapperInvPath)
+	if err != nil {
+		t.Fatalf("read inventory: %v", err)
+	}
+	var inv wrapperInventory
+	if err := json.Unmarshal(data, &inv); err != nil {
+		t.Fatalf("unmarshal inventory: %v", err)
+	}
+	found := false
+	for _, w := range inv.Wrappers {
+		if w == "plk-rustup" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("inventory missing plk-rustup: %v", inv.Wrappers)
+	}
+}
+
+func TestAddTool_IdempotentReapply(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	target := filepath.Join(t.TempDir(), "tool")
+	if err := os.WriteFile(target, []byte("x"), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("plant target: %v", err)
+	}
+	// First call writes.
+	if err := runAddToolBypassRoot(t, env, "claude", addToolOpts{target: target}); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	// Second call must be no-op.
+	var buf bytes.Buffer
+	env.out = &buf
+	if err := runAddToolBypassRoot(t, env, "claude", addToolOpts{target: target}); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if !strings.Contains(buf.String(), "already installed") {
+		t.Errorf("expected noop output, got %q", buf.String())
+	}
+}
+
+func TestAppendInventory_DeduplicatesEntries(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := appendInventory(env, "plk-claude"); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if err := appendInventory(env, "plk-claude"); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	inv := readWrapperInventory(env)
+	count := 0
+	for _, w := range inv {
+		if w == "plk-claude" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("duplicate entries: got %d plk-claude rows, want 1: %v", count, inv)
+	}
+}
+
+func TestAppendInventory_RejectsMalformedInventory(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.wrapperInvPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.wrapperInvPath, []byte("{"), 0o600); err != nil {
+		t.Fatalf("write inventory: %v", err)
+	}
+	err := appendInventory(env, "plk-claude")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "parse inventory") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestWrapperInInventory_NoFile(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if wrapperInInventory(env, "plk-anything") {
+		t.Errorf("expected false when inventory file is absent")
+	}
+}
+
+func TestWrapperInInventory_Hit(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := appendInventory(env, "plk-codex"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if !wrapperInInventory(env, "plk-codex") {
+		t.Errorf("expected true after append")
+	}
+	if wrapperInInventory(env, "plk-other") {
+		t.Errorf("expected false for unrelated name")
+	}
+}
+
+func TestAddToolCmd_Wiring(t *testing.T) {
+	cmd := addToolCmd()
+	if cmd.Use != "add-tool <name>" {
+		t.Errorf("Use: %q", cmd.Use)
+	}
+	for _, f := range []string{"dry-run", "target"} {
+		if cmd.Flag(f) == nil {
+			t.Errorf("missing flag %s", f)
+		}
+	}
+	// Args validator rejects 0 / 2+ positional.
+	if err := cmd.Args(cmd, nil); err == nil {
+		t.Errorf("expected error for 0 args")
+	}
+	if err := cmd.Args(cmd, []string{"a", "b"}); err == nil {
+		t.Errorf("expected error for 2 args")
+	}
+}
+
+func TestAddTool_RejectsMissingTarget(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	missing := filepath.Join(t.TempDir(), "nope")
+	err := runAddToolBypassRoot(t, env, "tool", addToolOpts{target: missing})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, err) { // sanity
+		_ = err
+	}
+	if cliutil.ExitCodeOf(err) != cliutil.ExitConfig {
+		t.Errorf("exit code: %d", cliutil.ExitCodeOf(err))
+	}
+}
+
+func TestAddTool_RejectsInvalidName(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	err := runAddToolBypassRoot(t, env, "INVALID", addToolOpts{target: "/bin/ls"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if cliutil.ExitCodeOf(err) != cliutil.ExitConfig {
+		t.Errorf("exit code: %d", cliutil.ExitCodeOf(err))
+	}
+}
+
+func TestAddTool_RejectsRelativeTarget(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	err := runAddToolBypassRoot(t, env, "tool", addToolOpts{target: "relative-tool"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if cliutil.ExitCodeOf(err) != cliutil.ExitConfig {
+		t.Errorf("exit code: %d", cliutil.ExitCodeOf(err))
+	}
+	if !strings.Contains(err.Error(), "absolute path") {
+		t.Errorf("err: %v", err)
+	}
+}
+
+func TestAddTool_RejectsNonExecutableTarget(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	target := filepath.Join(t.TempDir(), "tool")
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatalf("plant target: %v", err)
+	}
+	err := runAddToolBypassRoot(t, env, "tool", addToolOpts{target: target})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if cliutil.ExitCodeOf(err) != cliutil.ExitConfig {
+		t.Errorf("exit code: %d", cliutil.ExitCodeOf(err))
+	}
+	if !strings.Contains(err.Error(), "not executable") {
+		t.Errorf("err: %v", err)
+	}
+}

--- a/internal/cli/contain/addtool_test.go
+++ b/internal/cli/contain/addtool_test.go
@@ -275,6 +275,24 @@ func TestAddToolCmd_Wiring(t *testing.T) {
 	}
 }
 
+func TestAddToolCmdRejectsInvalidNameBeforeRootCheck(t *testing.T) {
+	cmd := addToolCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"bad/name", "--dry-run"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected invalid tool name error")
+	}
+	if cliutil.ExitCodeOf(err) != cliutil.ExitConfig {
+		t.Fatalf("exit code: got %d want %d", cliutil.ExitCodeOf(err), cliutil.ExitConfig)
+	}
+	if !strings.Contains(err.Error(), "invalid tool name") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
 func TestAddTool_RejectsMissingTarget(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	missing := filepath.Join(t.TempDir(), "nope")

--- a/internal/cli/contain/carefresh.go
+++ b/internal/cli/contain/carefresh.go
@@ -4,11 +4,14 @@
 package contain
 
 import (
+	"bytes"
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"os"
-	"strings"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -77,6 +80,12 @@ func runCARefresh(ctx context.Context, env *installEnv, opts caRefreshOpts) erro
 	if systemBundle == "" {
 		systemBundle = defaultSystemCABundle
 	}
+	systemBundle = filepath.Clean(systemBundle)
+	env.caExportPath = filepath.Clean(env.caExportPath)
+	env.caBundlePath = filepath.Clean(env.caBundlePath)
+	if err := validateCARefreshPaths(env, systemBundle); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+	}
 
 	if opts.dryRun {
 		_, _ = fmt.Fprintln(env.out, "pipelock contain ca-refresh — planned:")
@@ -95,6 +104,32 @@ func runCARefresh(ctx context.Context, env *installEnv, opts caRefreshOpts) erro
 	return nil
 }
 
+func validateCARefreshPaths(env *installEnv, systemBundle string) error {
+	if !filepath.IsAbs(systemBundle) {
+		return fmt.Errorf("--system-bundle %q must be absolute", systemBundle)
+	}
+	if info, err := env.stat(systemBundle); err != nil {
+		return fmt.Errorf("--system-bundle %q: %w", systemBundle, err)
+	} else if info.IsDir() {
+		return fmt.Errorf("--system-bundle %q is a directory", systemBundle)
+	}
+	for flag, path := range map[string]string{
+		"--ca-output":     env.caExportPath,
+		"--bundle-output": env.caBundlePath,
+	} {
+		if !filepath.IsAbs(path) {
+			return fmt.Errorf("%s %q must be absolute", flag, path)
+		}
+		if !pathWithin(env.configDir, path) {
+			return fmt.Errorf("%s %q must stay under %s", flag, path, env.configDir)
+		}
+		if err := ensureSafeWriteTarget(env, path); err != nil {
+			return fmt.Errorf("%s %q: %w", flag, path, err)
+		}
+	}
+	return nil
+}
+
 // exportPipelockCA writes pipelock-proxy's TLS-MITM CA to env.caExportPath.
 //
 // pipelock stores the CA under each user's $HOME/.pipelock/ — on a fresh
@@ -108,6 +143,9 @@ func runCARefresh(ctx context.Context, env *installEnv, opts caRefreshOpts) erro
 // written to disk. There is no --output flag on the underlying CLI; the
 // runbook's `--output` reference was speculative and never shipped.
 func exportPipelockCA(ctx context.Context, env *installEnv) error {
+	if err := ensureSafeWriteTarget(env, env.caExportPath); err != nil {
+		return fmt.Errorf("validate CA export path %s: %w", env.caExportPath, err)
+	}
 	// Drop any stale on-disk export so a partial write can't fool the
 	// combined-bundle step into reading old bytes.
 	_ = env.removeFile(env.caExportPath)
@@ -125,24 +163,45 @@ func exportPipelockCA(ctx context.Context, env *installEnv) error {
 			env.pipelockTarget, "tls", "init",
 		)
 		if initErr != nil {
-			return fmt.Errorf("exec sudo pipelock tls init: %w (out: %s)", initErr, truncateForErr(initOut))
+			return fmt.Errorf("exec sudo pipelock tls init: %w (captured %d bytes of output)", initErr, len(initOut))
 		}
 		if initCode != 0 {
-			return fmt.Errorf("pipelock tls init exited %d: %s", initCode, truncateForErr(initOut))
+			return fmt.Errorf("pipelock tls init exited %d (captured %d bytes of output)", initCode, len(initOut))
 		}
 		out, code, err = runShowCA(ctx, env)
 		if err != nil {
 			return err
 		}
 		if code != 0 {
-			return fmt.Errorf("pipelock tls show-ca after init exited %d: %s", code, truncateForErr(out))
+			return fmt.Errorf("pipelock tls show-ca after init exited %d (captured %d bytes of output)", code, len(out))
 		}
 	}
 
-	if !strings.Contains(out, "-----BEGIN CERTIFICATE-----") {
-		return fmt.Errorf("pipelock tls show-ca returned non-PEM output: %s", truncateForErr(out))
+	if err := validateSingleCAPEM([]byte(out)); err != nil {
+		return fmt.Errorf("pipelock tls show-ca returned invalid CA PEM: %w", err)
 	}
 	return env.writeFile(env.caExportPath, []byte(out), modeCAReadable)
+}
+
+func validateSingleCAPEM(data []byte) error {
+	block, rest := pem.Decode(data)
+	if block == nil {
+		return errors.New("no PEM certificate block")
+	}
+	if block.Type != "CERTIFICATE" {
+		return fmt.Errorf("unexpected PEM block type %q", block.Type)
+	}
+	if len(bytes.TrimSpace(rest)) != 0 {
+		return errors.New("extra data after certificate PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse certificate: %w", err)
+	}
+	if !cert.IsCA {
+		return errors.New("certificate is not a CA")
+	}
+	return nil
 }
 
 // runShowCA shells out to `sudo -n -u pipelock-proxy pipelock tls show-ca`

--- a/internal/cli/contain/carefresh.go
+++ b/internal/cli/contain/carefresh.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+type caRefreshOpts struct {
+	dryRun       bool
+	caOutput     string
+	bundleOutput string
+	systemBundle string
+}
+
+func caRefreshCmd() *cobra.Command {
+	var opts caRefreshOpts
+
+	cmd := &cobra.Command{
+		Use:   "ca-refresh",
+		Short: "Rebuild /etc/pipelock/combined-ca.pem after CA rotation",
+		Long: `Re-export the Pipelock TLS-MITM CA and rebuild the combined CA bundle
+that pipelock-agent uses to validate TLS. Run after rotating pipelock's CA
+(rare; typically only when ` + "`pipelock tls init`" + ` is rerun).
+
+Wrappers and the systemd unit do not need to be touched: they read
+/etc/pipelock/combined-ca.pem at runtime.
+
+Must be run as root.
+
+Exit codes:
+  0  CA bundle refreshed (or already up to date).
+  1  Export / read / write failed.
+  2  Precondition error (not root, source bundle missing).`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !opts.dryRun && os.Geteuid() != 0 {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New("ca-refresh must be run as root (use sudo)"))
+			}
+			env := defaultInstallEnv(cmd.OutOrStdout())
+			if opts.caOutput != "" {
+				env.caExportPath = opts.caOutput
+			}
+			if opts.bundleOutput != "" {
+				env.caBundlePath = opts.bundleOutput
+			}
+			return runCARefresh(cmd.Context(), env, opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "print planned actions without mutating state")
+	cmd.Flags().StringVar(&opts.caOutput, "ca-output", "", "destination for the Pipelock-only CA (default /etc/pipelock/ca.pem)")
+	cmd.Flags().StringVar(&opts.bundleOutput, "bundle-output", "", "destination for the combined bundle (default /etc/pipelock/combined-ca.pem)")
+	cmd.Flags().StringVar(&opts.systemBundle, "system-bundle", defaultSystemCABundle, "source system CA bundle to combine with")
+
+	return cmd
+}
+
+func runCARefresh(ctx context.Context, env *installEnv, opts caRefreshOpts) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// The cobra RunE wrapper does the os.Geteuid root check; tests drive
+	// this function directly with fakes.
+	systemBundle := opts.systemBundle
+	if systemBundle == "" {
+		systemBundle = defaultSystemCABundle
+	}
+
+	if opts.dryRun {
+		_, _ = fmt.Fprintln(env.out, "pipelock contain ca-refresh — planned:")
+		_, _ = fmt.Fprintf(env.out, "  1. re-export pipelock CA to %s (as %s)\n", env.caExportPath, env.proxyUserName)
+		_, _ = fmt.Fprintf(env.out, "  2. write combined bundle to %s (mode 0o644)\n", env.caBundlePath)
+		return nil
+	}
+
+	if err := exportPipelockCA(ctx, env); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, err)
+	}
+	if err := rebuildCombinedBundle(env, systemBundle); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, err)
+	}
+	_, _ = fmt.Fprintln(env.out, "ca-refresh complete.")
+	return nil
+}
+
+// exportPipelockCA writes pipelock-proxy's TLS-MITM CA to env.caExportPath.
+//
+// pipelock stores the CA under each user's $HOME/.pipelock/ — on a fresh
+// install pipelock-proxy's home dir is empty so `show-ca` would fail.
+// The flow is therefore:
+//
+//  1. Try `show-ca`. If it succeeds (CA already exists), capture stdout.
+//  2. Otherwise run `tls init` to materialize the CA, then `show-ca`.
+//
+// Stdout is captured in Go and validated as PEM-shaped before being
+// written to disk. There is no --output flag on the underlying CLI; the
+// runbook's `--output` reference was speculative and never shipped.
+func exportPipelockCA(ctx context.Context, env *installEnv) error {
+	// Drop any stale on-disk export so a partial write can't fool the
+	// combined-bundle step into reading old bytes.
+	_ = env.removeFile(env.caExportPath)
+
+	out, code, err := runShowCA(ctx, env)
+	if err != nil {
+		return err
+	}
+	if code != 0 {
+		// Likely "ca.pem not found" because pipelock-proxy has no CA
+		// yet. Initialize then retry. tls init is also captured so an
+		// init failure surfaces a clear error instead of an opaque exit.
+		initOut, initCode, initErr := env.runCmd(ctx,
+			"sudo", "-n", "-u", env.proxyUserName, "--",
+			env.pipelockTarget, "tls", "init",
+		)
+		if initErr != nil {
+			return fmt.Errorf("exec sudo pipelock tls init: %w (out: %s)", initErr, truncateForErr(initOut))
+		}
+		if initCode != 0 {
+			return fmt.Errorf("pipelock tls init exited %d: %s", initCode, truncateForErr(initOut))
+		}
+		out, code, err = runShowCA(ctx, env)
+		if err != nil {
+			return err
+		}
+		if code != 0 {
+			return fmt.Errorf("pipelock tls show-ca after init exited %d: %s", code, truncateForErr(out))
+		}
+	}
+
+	if !strings.Contains(out, "-----BEGIN CERTIFICATE-----") {
+		return fmt.Errorf("pipelock tls show-ca returned non-PEM output: %s", truncateForErr(out))
+	}
+	return env.writeFile(env.caExportPath, []byte(out), modeCAReadable)
+}
+
+// runShowCA shells out to `sudo -n -u pipelock-proxy pipelock tls show-ca`
+// and returns (stdout, exitCode, startupErr). Factored so the caller can
+// retry after `tls init` without duplicating the argv.
+func runShowCA(ctx context.Context, env *installEnv) (string, int, error) {
+	out, code, err := env.runCmd(ctx,
+		"sudo", "-n", "-u", env.proxyUserName, "--",
+		env.pipelockTarget, "tls", "show-ca",
+	)
+	if err != nil {
+		return out, code, fmt.Errorf("exec sudo pipelock tls show-ca: %w", err)
+	}
+	return out, code, nil
+}
+
+// rebuildCombinedBundle reads the system bundle and the pipelock CA and
+// writes the combined file. Atomic write via backupAndWrite so a crash
+// mid-write doesn't leave pipelock-agent with a half-written bundle.
+func rebuildCombinedBundle(env *installEnv, systemBundle string) error {
+	sys, err := env.readFile(systemBundle)
+	if err != nil {
+		return fmt.Errorf("read system CA bundle %s: %w", systemBundle, err)
+	}
+	pl, err := env.readFile(env.caExportPath)
+	if err != nil {
+		return fmt.Errorf("read pipelock CA %s: %w", env.caExportPath, err)
+	}
+	bundle := append([]byte{}, sys...)
+	if len(bundle) > 0 && bundle[len(bundle)-1] != '\n' {
+		bundle = append(bundle, '\n')
+	}
+	bundle = append(bundle, pl...)
+	return backupAndWrite(env, env.caBundlePath, bundle, modeCAReadable)
+}

--- a/internal/cli/contain/carefresh.go
+++ b/internal/cli/contain/carefresh.go
@@ -108,8 +108,10 @@ func validateCARefreshPaths(env *installEnv, systemBundle string) error {
 	if !filepath.IsAbs(systemBundle) {
 		return fmt.Errorf("--system-bundle %q must be absolute", systemBundle)
 	}
-	if info, err := env.stat(systemBundle); err != nil {
+	if info, err := env.lstat(systemBundle); err != nil {
 		return fmt.Errorf("--system-bundle %q: %w", systemBundle, err)
+	} else if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("--system-bundle %q is a symlink; pass the resolved bundle path", systemBundle)
 	} else if info.IsDir() {
 		return fmt.Errorf("--system-bundle %q is a directory", systemBundle)
 	}

--- a/internal/cli/contain/carefresh_test.go
+++ b/internal/cli/contain/carefresh_test.go
@@ -140,9 +140,6 @@ func TestExportPipelockCA_RemovesStaleBeforeExport(t *testing.T) {
 }
 
 func TestRunCARefresh_DryRunIsNonMutating(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("dry-run path includes root check; cover via direct helper")
-	}
 	env, _, _ := newFakeEnv(t)
 	systemBundle := filepath.Join(t.TempDir(), "system.pem")
 	if err := os.WriteFile(systemBundle, []byte("SYS"), 0o600); err != nil {

--- a/internal/cli/contain/carefresh_test.go
+++ b/internal/cli/contain/carefresh_test.go
@@ -317,6 +317,14 @@ func TestValidateCARefreshPathsRejectsUnsafeInputs(t *testing.T) {
 	if err := validateCARefreshPaths(env, systemBundle); err == nil || !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("symlink output err: %v", err)
 	}
+	env.caExportPath = filepath.Join(env.configDir, "ca.pem")
+	bundleLink := filepath.Join(t.TempDir(), "bundle-link.pem")
+	if err := os.Symlink(systemBundle, bundleLink); err != nil {
+		t.Fatalf("bundle symlink: %v", err)
+	}
+	if err := validateCARefreshPaths(env, bundleLink); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("symlink bundle err: %v", err)
+	}
 }
 
 func TestValidateSingleCAPEMRejectsExtraDataAndNonCA(t *testing.T) {

--- a/internal/cli/contain/carefresh_test.go
+++ b/internal/cli/contain/carefresh_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testPEMCA is a minimal PEM-shaped string for stubbing pipelock tls
+// show-ca output. Tests don't validate the certificate, only that the
+// pipeline accepts a PEM and rejects non-PEM.
+const testPEMCA = "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKvHM6vHM6vHMA0GCSqGSIb3DQEBCwUAMA0xCzAJBgNVBAYTAlVT\n-----END CERTIFICATE-----\n"
+
+func TestRunCARefresh_FullSuccessPath(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	// show-ca emits PEM to stdout. Go captures it and writes
+	// env.caExportPath; the fake just supplies the bytes.
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == testSudoCmd && containsArg(args, "show-ca") {
+			return testPEMCA, 0, nil
+		}
+		return "", 0, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(env.caExportPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	systemBundle := filepath.Join(t.TempDir(), "system.pem")
+	if err := os.WriteFile(systemBundle, []byte("SYS\n"), 0o600); err != nil {
+		t.Fatalf("plant system: %v", err)
+	}
+	err := runCARefresh(context.Background(), env, caRefreshOpts{systemBundle: systemBundle})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	got, _ := os.ReadFile(env.caBundlePath) //nolint:gosec // tmpdir-scoped test path
+	if !strings.Contains(string(got), "BEGIN CERTIFICATE") || !strings.Contains(string(got), "SYS") {
+		t.Errorf("bundle: %q", got)
+	}
+}
+
+func TestRebuildCombinedBundle_ConcatenatesSourceAndPipelock(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	system := filepath.Join(t.TempDir(), "system.pem")
+	if err := os.WriteFile(system, []byte("SYSTEM_BUNDLE_DATA"), 0o600); err != nil {
+		t.Fatalf("write system: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(env.caExportPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.caExportPath, []byte("PIPELOCK_CA_DATA\n"), 0o600); err != nil {
+		t.Fatalf("write pipelock ca: %v", err)
+	}
+	if err := rebuildCombinedBundle(env, system); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	got, err := os.ReadFile(env.caBundlePath)
+	if err != nil {
+		t.Fatalf("read bundle: %v", err)
+	}
+	// The system bundle has no trailing newline; we inject one before
+	// appending the pipelock CA.
+	want := "SYSTEM_BUNDLE_DATA\nPIPELOCK_CA_DATA\n"
+	if string(got) != want {
+		t.Errorf("bundle: got %q, want %q", got, want)
+	}
+}
+
+func TestRebuildCombinedBundle_HonorsExistingTrailingNewline(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	system := filepath.Join(t.TempDir(), "system.pem")
+	if err := os.WriteFile(system, []byte("SYSTEM\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(env.caExportPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.caExportPath, []byte("PIPELOCK\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := rebuildCombinedBundle(env, system); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	got, _ := os.ReadFile(env.caBundlePath)
+	// Don't add a SECOND newline when source already ends with one.
+	if string(got) != "SYSTEM\nPIPELOCK\n" {
+		t.Errorf("bundle: %q", got)
+	}
+}
+
+func TestExportPipelockCA_RemovesStaleBeforeExport(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	// Stub show-ca: return a PEM on stdout. exportPipelockCA captures it
+	// and writes env.caExportPath.
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		runner.mu.Lock()
+		runner.calls = append(runner.calls, fakeCall{name: name, args: append([]string(nil), args...)})
+		runner.mu.Unlock()
+		if name == testSudoCmd && containsArg(args, "show-ca") {
+			return testPEMCA, 0, nil
+		}
+		return "", 0, nil
+	}
+	// Plant a stale export with content distinct from testPEMCA.
+	if err := os.MkdirAll(filepath.Dir(env.caExportPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.caExportPath, []byte("OLD STALE CONTENT"), 0o600); err != nil {
+		t.Fatalf("write old: %v", err)
+	}
+	if err := exportPipelockCA(context.Background(), env); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	// After: file must exist with the new PEM, not the stale bytes.
+	got, err := os.ReadFile(env.caExportPath) //nolint:gosec // tmpdir-scoped test path
+	if err != nil {
+		t.Fatalf("read after export: %v", err)
+	}
+	if string(got) != testPEMCA {
+		t.Errorf("export wrote wrong content: %q", got)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected 1 shell-out, got %v", runner.calls)
+	}
+	call := runner.calls[0]
+	if call.name != testSudoCmd {
+		t.Errorf("expected sudo, got %s", call.name)
+	}
+	if !containsArg(call.args, env.proxyUserName) {
+		t.Errorf("sudo args missing proxy user: %v", call.args)
+	}
+	if !containsArg(call.args, "tls") || !containsArg(call.args, "show-ca") {
+		t.Errorf("sudo args missing tls show-ca: %v", call.args)
+	}
+}
+
+func TestRunCARefresh_DryRunIsNonMutating(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("dry-run path includes root check; cover via direct helper")
+	}
+	env, _, _ := newFakeEnv(t)
+	systemBundle := filepath.Join(t.TempDir(), "system.pem")
+	if err := os.WriteFile(systemBundle, []byte("SYS"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var buf bytes.Buffer
+	env.out = &buf
+	opts := caRefreshOpts{dryRun: true, systemBundle: systemBundle}
+	if err := runCARefresh(context.Background(), env, opts); err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "ca-refresh") || !strings.Contains(out, "planned") {
+		t.Errorf("dry-run output: %q", out)
+	}
+}
+
+func TestCARefreshCmd_Wiring(t *testing.T) {
+	cmd := caRefreshCmd()
+	if cmd.Use != "ca-refresh" {
+		t.Errorf("Use: %q", cmd.Use)
+	}
+	for _, f := range []string{"dry-run", "ca-output", "bundle-output", "system-bundle"} {
+		if cmd.Flag(f) == nil {
+			t.Errorf("missing flag %s", f)
+		}
+	}
+}

--- a/internal/cli/contain/carefresh_test.go
+++ b/internal/cli/contain/carefresh_test.go
@@ -6,16 +6,44 @@ package contain
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
-// testPEMCA is a minimal PEM-shaped string for stubbing pipelock tls
-// show-ca output. Tests don't validate the certificate, only that the
-// pipeline accepts a PEM and rejects non-PEM.
-const testPEMCA = "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKvHM6vHM6vHMA0GCSqGSIb3DQEBCwUAMA0xCzAJBgNVBAYTAlVT\n-----END CERTIFICATE-----\n"
+func testPEMCA(t *testing.T) string {
+	return testPEMCert(t, true)
+}
+
+func testPEMCert(t *testing.T, isCA bool) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Pipelock Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  isCA,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
 
 func TestRunCARefresh_FullSuccessPath(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
@@ -23,7 +51,7 @@ func TestRunCARefresh_FullSuccessPath(t *testing.T) {
 	// env.caExportPath; the fake just supplies the bytes.
 	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
 		if name == testSudoCmd && containsArg(args, "show-ca") {
-			return testPEMCA, 0, nil
+			return testPEMCA(t), 0, nil
 		}
 		return "", 0, nil
 	}
@@ -102,7 +130,7 @@ func TestExportPipelockCA_RemovesStaleBeforeExport(t *testing.T) {
 		runner.calls = append(runner.calls, fakeCall{name: name, args: append([]string(nil), args...)})
 		runner.mu.Unlock()
 		if name == testSudoCmd && containsArg(args, "show-ca") {
-			return testPEMCA, 0, nil
+			return testPEMCA(t), 0, nil
 		}
 		return "", 0, nil
 	}
@@ -121,7 +149,7 @@ func TestExportPipelockCA_RemovesStaleBeforeExport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read after export: %v", err)
 	}
-	if string(got) != testPEMCA {
+	if !strings.Contains(string(got), "BEGIN CERTIFICATE") {
 		t.Errorf("export wrote wrong content: %q", got)
 	}
 	if len(runner.calls) != 1 {
@@ -151,7 +179,7 @@ func TestExportPipelockCAInitializesMissingCAThenRetries(t *testing.T) {
 			if showCalls == 1 {
 				return "missing ca", 1, nil
 			}
-			return testPEMCA, 0, nil
+			return testPEMCA(t), 0, nil
 		}
 		if name == testSudoCmd && containsArg(args, "init") {
 			return "initialized", 0, nil
@@ -168,7 +196,7 @@ func TestExportPipelockCAInitializesMissingCAThenRetries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read export: %v", err)
 	}
-	if string(got) != testPEMCA {
+	if !strings.Contains(string(got), "BEGIN CERTIFICATE") {
 		t.Fatalf("exported CA: %q", got)
 	}
 	if showCalls != 2 {
@@ -200,7 +228,7 @@ func TestExportPipelockCARejectsNonPEMOutput(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected non-PEM rejection")
 	}
-	if !strings.Contains(err.Error(), "non-PEM") {
+	if !strings.Contains(err.Error(), "invalid CA PEM") {
 		t.Fatalf("err: %v", err)
 	}
 }
@@ -248,6 +276,58 @@ func TestRunCARefresh_DryRunIsNonMutating(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, "ca-refresh") || !strings.Contains(out, "planned") {
 		t.Errorf("dry-run output: %q", out)
+	}
+}
+
+func TestRunCARefresh_DryRunValidatesPaths(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	systemBundle := filepath.Join(t.TempDir(), "system.pem")
+	if err := os.WriteFile(systemBundle, []byte("system"), 0o600); err != nil {
+		t.Fatalf("write system: %v", err)
+	}
+	env.caExportPath = filepath.Join(t.TempDir(), "outside-ca.pem")
+	err := runCARefresh(context.Background(), env, caRefreshOpts{dryRun: true, systemBundle: systemBundle})
+	if err == nil {
+		t.Fatal("expected output path rejection")
+	}
+	if !strings.Contains(err.Error(), "must stay under") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestValidateCARefreshPathsRejectsUnsafeInputs(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := validateCARefreshPaths(env, "relative.pem"); err == nil || !strings.Contains(err.Error(), "must be absolute") {
+		t.Fatalf("relative bundle err: %v", err)
+	}
+	systemBundle := filepath.Join(t.TempDir(), "system.pem")
+	if err := os.WriteFile(systemBundle, []byte("system"), 0o600); err != nil {
+		t.Fatalf("write system: %v", err)
+	}
+	env.caBundlePath = filepath.Join(t.TempDir(), "combined-ca.pem")
+	if err := validateCARefreshPaths(env, systemBundle); err == nil || !strings.Contains(err.Error(), "must stay under") {
+		t.Fatalf("outside output err: %v", err)
+	}
+	env.caBundlePath = filepath.Join(env.configDir, "combined-ca.pem")
+	link := filepath.Join(env.configDir, "ca-link.pem")
+	if err := os.Symlink(filepath.Join(t.TempDir(), "target.pem"), link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	env.caExportPath = link
+	if err := validateCARefreshPaths(env, systemBundle); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("symlink output err: %v", err)
+	}
+}
+
+func TestValidateSingleCAPEMRejectsExtraDataAndNonCA(t *testing.T) {
+	if err := validateSingleCAPEM([]byte(testPEMCA(t) + "junk")); err == nil || !strings.Contains(err.Error(), "extra data") {
+		t.Fatalf("extra data err: %v", err)
+	}
+	if err := validateSingleCAPEM([]byte(testPEMCert(t, false))); err == nil || !strings.Contains(err.Error(), "not a CA") {
+		t.Fatalf("non-CA err: %v", err)
+	}
+	if err := validateSingleCAPEM([]byte("-----BEGIN PIPELOCK TEST BLOCK-----\nAA==\n-----END PIPELOCK TEST BLOCK-----\n")); err == nil || !strings.Contains(err.Error(), "unexpected PEM") {
+		t.Fatalf("wrong block err: %v", err)
 	}
 }
 

--- a/internal/cli/contain/carefresh_test.go
+++ b/internal/cli/contain/carefresh_test.go
@@ -139,6 +139,100 @@ func TestExportPipelockCA_RemovesStaleBeforeExport(t *testing.T) {
 	}
 }
 
+func TestExportPipelockCAInitializesMissingCAThenRetries(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	var showCalls int
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		runner.mu.Lock()
+		runner.calls = append(runner.calls, fakeCall{name: name, args: append([]string(nil), args...)})
+		runner.mu.Unlock()
+		if name == testSudoCmd && containsArg(args, "show-ca") {
+			showCalls++
+			if showCalls == 1 {
+				return "missing ca", 1, nil
+			}
+			return testPEMCA, 0, nil
+		}
+		if name == testSudoCmd && containsArg(args, "init") {
+			return "initialized", 0, nil
+		}
+		return "", 0, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(env.caExportPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := exportPipelockCA(context.Background(), env); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	got, err := os.ReadFile(env.caExportPath)
+	if err != nil {
+		t.Fatalf("read export: %v", err)
+	}
+	if string(got) != testPEMCA {
+		t.Fatalf("exported CA: %q", got)
+	}
+	if showCalls != 2 {
+		t.Fatalf("show-ca calls: got %d want 2", showCalls)
+	}
+	var sawInit bool
+	for _, c := range runner.calls {
+		if containsArg(c.args, "init") {
+			sawInit = true
+		}
+	}
+	if !sawInit {
+		t.Fatalf("tls init not called, calls=%v", runner.calls)
+	}
+}
+
+func TestExportPipelockCARejectsNonPEMOutput(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == testSudoCmd && containsArg(args, "show-ca") {
+			return "not a certificate", 0, nil
+		}
+		return "", 0, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(env.caExportPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	err := exportPipelockCA(context.Background(), env)
+	if err == nil {
+		t.Fatal("expected non-PEM rejection")
+	}
+	if !strings.Contains(err.Error(), "non-PEM") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestRunShowCAPropagatesExecError(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+		return "boom", 0, stringError("sudo unavailable")
+	}
+	_, _, err := runShowCA(context.Background(), env)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "sudo unavailable") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestRebuildCombinedBundleReportsMissingInputs(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	system := filepath.Join(t.TempDir(), "system.pem")
+	if err := rebuildCombinedBundle(env, system); err == nil || !strings.Contains(err.Error(), "read system CA bundle") {
+		t.Fatalf("missing system err: %v", err)
+	}
+	if err := os.WriteFile(system, []byte("SYSTEM\n"), 0o600); err != nil {
+		t.Fatalf("write system: %v", err)
+	}
+	if err := rebuildCombinedBundle(env, system); err == nil || !strings.Contains(err.Error(), "read pipelock CA") {
+		t.Fatalf("missing pipelock err: %v", err)
+	}
+}
+
 func TestRunCARefresh_DryRunIsNonMutating(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	systemBundle := filepath.Join(t.TempDir(), "system.pem")

--- a/internal/cli/contain/cmd.go
+++ b/internal/cli/contain/cmd.go
@@ -4,18 +4,8 @@
 package contain
 
 import (
-	"errors"
-	"fmt"
-	"regexp"
-
 	"github.com/spf13/cobra"
-
-	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 )
-
-// stubMessage is the body of the "not yet implemented" error returned by
-// every subcommand except verify.
-const stubMessage = "not yet implemented in v0.1"
 
 // Cmd returns the `pipelock contain` cobra command tree.
 func Cmd() *cobra.Command {
@@ -26,12 +16,18 @@ func Cmd() *cobra.Command {
 for AI agents on Fedora workstations.
 
 The model splits a single workstation into three system users
-(operator / pipelock-proxy / cc-agent) and uses nftables owner-match
+(operator / pipelock-proxy / pipelock-agent) and uses nftables owner-match
 rules to force every agent process through the Pipelock proxy.
 
-In v0.1 only ` + "`verify`" + ` is implemented; the mutating subcommands
-(install, rollback, add-tool, ca-refresh) are registered but return a
-"not yet implemented" error.`,
+Subcommands:
+  install     Create users, systemd unit, nft rules, wrappers, sudoers.
+  verify      Run read-only probes; report pass/fail/skip.
+  rollback    Undo install (idempotent).
+  add-tool    Drop a new /usr/local/bin/plk-<name> wrapper.
+  ca-refresh  Rebuild the combined CA bundle after a CA rotation.
+
+All mutating subcommands accept --dry-run to print the planned actions
+without touching state.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -44,82 +40,5 @@ In v0.1 only ` + "`verify`" + ` is implemented; the mutating subcommands
 		caRefreshCmd(),
 	)
 
-	return cmd
-}
-
-// installCmd is the v0.1 stub for `pipelock contain install`.
-func installCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "install",
-		Short: "Install the containment model (creates users, unit, nft rules, wrappers)",
-		Long: `Will create the pipelock-proxy and cc-agent system users, migrate the
-user-mode systemd unit to a system unit, install nftables rules, write
-wrapper scripts, install the sudoers entry, and bootstrap the
-combined-ca.pem.`,
-		SilenceUsage:  true,
-		SilenceErrors: true,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New(stubMessage))
-		},
-	}
-	return cmd
-}
-
-// rollbackCmd is the v0.1 stub for `pipelock contain rollback`.
-func rollbackCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "rollback",
-		Short: "Roll back the containment model (undoes install idempotently)",
-		Long: `Will reverse install: remove the nft table, disable the system unit,
-restore the user unit, remove wrappers, optionally remove users.`,
-		SilenceUsage:  true,
-		SilenceErrors: true,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New(stubMessage))
-		},
-	}
-	return cmd
-}
-
-// addToolNamePattern bounds tool names to a small alphabet so that the
-// generated wrapper path is safe to construct without shell quoting.
-var addToolNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,30}$`)
-
-// addToolCmd is the v0.1 stub for `pipelock contain add-tool`.
-func addToolCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "add-tool <name>",
-		Short: "Drop a new /usr/local/bin/cc-<name> wrapper",
-		Long: `Will install a wrapper at /usr/local/bin/cc-<name> that execs
-cc-launch <name>.`,
-		SilenceUsage:  true,
-		SilenceErrors: true,
-		Args:          cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			if !addToolNamePattern.MatchString(args[0]) {
-				return cliutil.ExitCodeError(
-					cliutil.ExitConfig,
-					fmt.Errorf("invalid tool name %q (expected [a-z0-9][a-z0-9_-]{0,30})", args[0]),
-				)
-			}
-			return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New(stubMessage))
-		},
-	}
-	return cmd
-}
-
-// caRefreshCmd is the v0.1 stub for `pipelock contain ca-refresh`.
-func caRefreshCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "ca-refresh",
-		Short: "Rebuild /etc/pipelock/combined-ca.pem after CA rotation",
-		Long: `Will re-export the Pipelock TLS-MITM CA and rebuild
-/etc/pipelock/combined-ca.pem.`,
-		SilenceUsage:  true,
-		SilenceErrors: true,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New(stubMessage))
-		},
-	}
 	return cmd
 }

--- a/internal/cli/contain/cmd.go
+++ b/internal/cli/contain/cmd.go
@@ -11,11 +11,11 @@ import (
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "contain",
-		Short: "Workstation containment for AI agents",
+		Short: "Host containment for AI coding agents",
 		Long: `Install, verify, and roll back a kernel-enforced containment model
-for AI agents on Fedora workstations.
+for AI coding agents on Linux hosts.
 
-The model splits a single workstation into three system users
+The model splits a single host into three system users
 (operator / pipelock-proxy / pipelock-agent) and uses nftables owner-match
 rules to force every agent process through the Pipelock proxy.
 

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -397,6 +397,13 @@ func copyConfigFile(ctx *configMigrationContext, src, dest string, mode os.FileM
 	if err != nil {
 		return fmt.Errorf("read source %s: %w", src, err)
 	}
+	after, err := ctx.env.lstat(src)
+	if err != nil {
+		return fmt.Errorf("stat source %s after read: %w", src, err)
+	}
+	if !os.SameFile(info, after) || !after.Mode().IsRegular() {
+		return fmt.Errorf("source %s changed during migration; retry after quiescing config writes", src)
+	}
 	if err := ensureMigratedDir(ctx, filepath.Dir(dest), migrationDirMode(ctx.env, filepath.Dir(dest))); err != nil {
 		return err
 	}
@@ -502,17 +509,28 @@ func isDirectoryNotEmpty(err error) bool {
 }
 
 func backupAndWriteIfChanged(env *installEnv, path string, contents []byte, mode os.FileMode) (bool, error) {
-	if existing, err := env.readFile(path); err == nil {
+	clean := filepath.Clean(path)
+	if info, err := env.lstat(clean); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return false, fmt.Errorf("%s is a symlink; refusing privileged write", clean)
+		}
+		if info.IsDir() {
+			return false, fmt.Errorf("%s is a directory", clean)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("stat existing %s: %w", clean, err)
+	}
+	if existing, err := env.readFile(clean); err == nil {
 		if bytesEqual(existing, contents) {
-			if err := env.chmod(path, mode); err != nil {
-				return false, fmt.Errorf("chmod %s: %w", path, err)
+			if err := env.chmod(clean, mode); err != nil {
+				return false, fmt.Errorf("chmod %s: %w", clean, err)
 			}
 			return false, nil
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
-		return false, fmt.Errorf("read existing %s: %w", path, err)
+		return false, fmt.Errorf("read existing %s: %w", clean, err)
 	}
-	if err := backupAndWrite(env, path, contents, mode); err != nil {
+	if err := backupAndWrite(env, clean, contents, mode); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -1,0 +1,654 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+	"gopkg.in/yaml.v3"
+)
+
+type migratedConfigArtifact struct {
+	path string
+	dir  bool
+}
+
+type configMigrationContext struct {
+	env          *installEnv
+	configDir    string
+	operatorHome string
+	artifacts    []migratedConfigArtifact
+}
+
+func migratePipelockConfigForContain(env *installEnv, configSource string, data []byte) ([]byte, []migratedConfigArtifact, error) {
+	root, err := parseSingleYAMLDocument(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	mapping := documentMapping(root)
+	if mapping == nil {
+		return nil, nil, errors.New("pipelock config must be a YAML mapping")
+	}
+
+	ctx := &configMigrationContext{
+		env:       env,
+		configDir: filepath.Dir(configSource),
+	}
+	home, err := operatorHomeDir(env)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve operator home for config migration: %w", err)
+	}
+	ctx.operatorHome = home
+
+	if err := migrateScalarFile(ctx, mapping, []string{"license_file"}, filepath.Join(env.configDir, "license.token"), modeConfigSecret); err != nil {
+		return nil, nil, err
+	}
+	if err := migrateFlightRecorderSigningKey(ctx, mapping); err != nil {
+		return nil, nil, err
+	}
+	if err := migrateScalarFile(ctx, mapping, []string{"mediation_envelope", "signing_key_path"}, filepath.Join(env.configDir, "keys", "mediation-envelope-signing.key"), modePinSecret); err != nil {
+		return nil, nil, err
+	}
+	if err := migrateScalarFile(ctx, mapping, []string{"mcp_binary_integrity", "manifest_path"}, filepath.Join(env.configDir, "integrity", "manifest.json"), modeConfigSecret); err != nil {
+		return nil, nil, err
+	}
+	if err := migrateScalarFile(ctx, mapping, []string{"learn_lock", "roster_path"}, filepath.Join(env.configDir, "roster.json"), modeConfigSecret); err != nil {
+		return nil, nil, err
+	}
+	if err := migrateSaltSource(ctx, mapping); err != nil {
+		return nil, nil, err
+	}
+	if err := migrateTLSCA(ctx, mapping); err != nil {
+		return nil, nil, err
+	}
+
+	if err := migrateScalarDir(ctx, mapping, []string{"rules", "rules_dir"}, filepath.Join(env.dataDir, "rules")); err != nil {
+		return nil, nil, err
+	}
+	if err := migrateScalarDir(ctx, mapping, []string{"flight_recorder", "dir"}, filepath.Join(env.dataDir, "recorder")); err != nil {
+		return nil, nil, err
+	}
+	if err := migrateScalarDir(ctx, mapping, []string{"learn", "capture_dir"}, filepath.Join(env.dataDir, "captures", "local")); err != nil {
+		return nil, nil, err
+	}
+	if err := migrateScalarDir(ctx, mapping, []string{"behavioral_baseline", "profile_dir"}, filepath.Join(env.dataDir, "baselines")); err != nil {
+		return nil, nil, err
+	}
+	if err := migrateScalarDir(ctx, mapping, []string{"learn_lock", "store_dir"}, filepath.Join(env.dataDir, "contracts", "active")); err != nil {
+		return nil, nil, err
+	}
+	if err := migrateScalarDir(ctx, mapping, []string{"mcp_tool_policy", "quarantine_dir"}, filepath.Join(env.dataDir, "quarantine")); err != nil {
+		return nil, nil, err
+	}
+	if err := migrateLoggingFile(ctx, mapping); err != nil {
+		return nil, nil, err
+	}
+	migrateRedirectProfiles(ctx, mapping)
+
+	out, err := encodeYAML(root)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, ctx.artifacts, nil
+}
+
+func parseSingleYAMLDocument(data []byte) (*yaml.Node, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	var root yaml.Node
+	if err := dec.Decode(&root); err != nil {
+		return nil, fmt.Errorf("parse pipelock config: %w", err)
+	}
+	var extra yaml.Node
+	if err := dec.Decode(&extra); err == nil {
+		return nil, errors.New("pipelock config must be a single YAML document")
+	} else if !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("parse pipelock config: %w", err)
+	}
+	return &root, nil
+}
+
+func encodeYAML(root *yaml.Node) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(root); err != nil {
+		_ = enc.Close()
+		return nil, fmt.Errorf("encode migrated pipelock config: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("close migrated pipelock config encoder: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func documentMapping(root *yaml.Node) *yaml.Node {
+	if root.Kind == yaml.DocumentNode && len(root.Content) == 1 {
+		root = root.Content[0]
+	}
+	if root.Kind != yaml.MappingNode {
+		return nil
+	}
+	return root
+}
+
+func operatorHomeDir(env *installEnv) (string, error) {
+	if env.operatorUser == "" {
+		return "", errors.New("operator user not set")
+	}
+	u, err := env.lookupUser(env.operatorUser)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(u.HomeDir), nil
+}
+
+func migrateScalarFile(ctx *configMigrationContext, root *yaml.Node, path []string, dest string, mode os.FileMode) error {
+	n := getMappingPath(root, path)
+	if n == nil || n.Kind != yaml.ScalarNode || strings.TrimSpace(n.Value) == "" {
+		return nil
+	}
+	src, ok := ctx.resolveMigratablePath(n.Value)
+	if !ok {
+		return nil
+	}
+	if err := copyConfigFile(ctx, src, dest, mode); err != nil {
+		return fmt.Errorf("migrate %s: %w", strings.Join(path, "."), err)
+	}
+	n.Value = dest
+	return nil
+}
+
+func migrateFlightRecorderSigningKey(ctx *configMigrationContext, root *yaml.Node) error {
+	const field = "flight_recorder.signing_key_path"
+
+	n := getMappingPath(root, []string{"flight_recorder", "signing_key_path"})
+	if n == nil || n.Kind != yaml.ScalarNode || strings.TrimSpace(n.Value) == "" {
+		return nil
+	}
+	src, ok := ctx.resolveMigratablePath(n.Value)
+	if !ok {
+		return nil
+	}
+	dest := filepath.Join(ctx.env.configDir, "keys", "flight-recorder-signing.key")
+	if err := copyConfigFile(ctx, src, dest, modePinSecret); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("migrate %s: %w", field, err)
+		}
+		if err := ensureFlightRecorderSigningKey(ctx, dest); err != nil {
+			return fmt.Errorf("migrate %s: %w", field, err)
+		}
+	} else if _, err := signing.LoadPrivateKeyFile(dest); err != nil {
+		return fmt.Errorf("migrate %s: validate migrated signing key %s: %w", field, dest, err)
+	}
+	n.Value = dest
+	return nil
+}
+
+func ensureFlightRecorderSigningKey(ctx *configMigrationContext, dest string) error {
+	if info, err := ctx.env.lstat(dest); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("existing target %s is a symlink; refusing to use as signing key", dest)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("existing target %s is not a regular file", dest)
+		}
+		if err := ctx.env.chmod(dest, modePinSecret); err != nil {
+			return fmt.Errorf("chmod %s: %w", dest, err)
+		}
+		if _, err := signing.LoadPrivateKeyFile(dest); err != nil {
+			return fmt.Errorf("validate existing signing key %s: %w", dest, err)
+		}
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat existing target %s: %w", dest, err)
+	}
+
+	if err := ensureMigratedDir(ctx, filepath.Dir(dest), migrationDirMode(ctx.env, filepath.Dir(dest))); err != nil {
+		return err
+	}
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		return fmt.Errorf("generate signing key: %w", err)
+	}
+	if wrote, err := backupAndWriteIfChanged(ctx.env, dest, []byte(signing.EncodePrivateKey(priv)), modePinSecret); err != nil {
+		return err
+	} else if wrote {
+		ctx.artifacts = append(ctx.artifacts, migratedConfigArtifact{path: dest})
+	}
+	return nil
+}
+
+func migrateScalarDir(ctx *configMigrationContext, root *yaml.Node, path []string, dest string) error {
+	n := getMappingPath(root, path)
+	if n == nil || n.Kind != yaml.ScalarNode || strings.TrimSpace(n.Value) == "" {
+		return nil
+	}
+	src, ok := ctx.resolveMigratablePath(n.Value)
+	if !ok {
+		return nil
+	}
+	if err := copyConfigDir(ctx, src, dest); err != nil {
+		return fmt.Errorf("migrate %s: %w", strings.Join(path, "."), err)
+	}
+	n.Value = dest
+	return nil
+}
+
+func migrateSaltSource(ctx *configMigrationContext, root *yaml.Node) error {
+	n := getMappingPath(root, []string{"learn", "privacy", "salt_source"})
+	if n == nil || n.Kind != yaml.ScalarNode {
+		return nil
+	}
+	value := strings.TrimSpace(n.Value)
+	if !strings.HasPrefix(value, "file:") {
+		return nil
+	}
+	src, ok := ctx.resolveMigratablePath(strings.TrimPrefix(value, "file:"))
+	if !ok {
+		return nil
+	}
+	dest := filepath.Join(ctx.env.configDir, "learn-privacy-salt")
+	if err := copyConfigFile(ctx, src, dest, modePinSecret); err != nil {
+		return fmt.Errorf("migrate learn.privacy.salt_source: %w", err)
+	}
+	n.Value = "file:" + dest
+	return nil
+}
+
+func migrateTLSCA(ctx *configMigrationContext, root *yaml.Node) error {
+	tlsNode := getMappingPath(root, []string{"tls_interception"})
+	if tlsNode == nil || tlsNode.Kind != yaml.MappingNode {
+		return nil
+	}
+	certNode := getMappingPath(tlsNode, []string{"ca_cert"})
+	keyNode := getMappingPath(tlsNode, []string{"ca_key"})
+
+	certValue := scalarValue(certNode)
+	keyValue := scalarValue(keyNode)
+	if certValue == "" && keyValue == "" && !yamlBool(getMappingPath(tlsNode, []string{"enabled"})) {
+		return nil
+	}
+	if certValue == "" {
+		certValue = filepath.Join(ctx.operatorHome, ".pipelock", "ca.pem")
+		certNode = setMappingScalar(tlsNode, "ca_cert", certValue)
+	}
+	if keyValue == "" {
+		keyValue = filepath.Join(ctx.operatorHome, ".pipelock", "ca-key.pem")
+		keyNode = setMappingScalar(tlsNode, "ca_key", keyValue)
+	}
+	if err := migrateScalarFileValue(ctx, certNode, certValue, filepath.Join(ctx.env.configDir, "tls", "ca.pem"), modeConfigSecret); err != nil {
+		return fmt.Errorf("migrate tls_interception.ca_cert: %w", err)
+	}
+	if err := migrateScalarFileValue(ctx, keyNode, keyValue, filepath.Join(ctx.env.configDir, "tls", "ca-key.pem"), modePinSecret); err != nil {
+		return fmt.Errorf("migrate tls_interception.ca_key: %w", err)
+	}
+	return nil
+}
+
+func migrateScalarFileValue(ctx *configMigrationContext, n *yaml.Node, value, dest string, mode os.FileMode) error {
+	src, ok := ctx.resolveMigratablePath(value)
+	if !ok {
+		return nil
+	}
+	if err := copyConfigFile(ctx, src, dest, mode); err != nil {
+		return err
+	}
+	n.Value = dest
+	return nil
+}
+
+func migrateLoggingFile(ctx *configMigrationContext, root *yaml.Node) error {
+	n := getMappingPath(root, []string{"logging", "file"})
+	if n == nil || n.Kind != yaml.ScalarNode || strings.TrimSpace(n.Value) == "" {
+		return nil
+	}
+	_, ok := ctx.resolveMigratablePath(n.Value)
+	if !ok {
+		return nil
+	}
+	dest := filepath.Join(ctx.env.dataDir, "logs", "audit.log")
+	if err := ensureMigratedDir(ctx, filepath.Dir(dest), migrationDirMode(ctx.env, filepath.Dir(dest))); err != nil {
+		return err
+	}
+	n.Value = dest
+	return nil
+}
+
+func migrateRedirectProfiles(ctx *configMigrationContext, root *yaml.Node) {
+	profiles := getMappingPath(root, []string{"mcp_tool_policy", "redirect_profiles"})
+	if profiles == nil || profiles.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(profiles.Content); i += 2 {
+		profile := profiles.Content[i+1]
+		execNode := getMappingPath(profile, []string{"exec"})
+		if execNode == nil || execNode.Kind != yaml.SequenceNode || len(execNode.Content) == 0 {
+			continue
+		}
+		first := execNode.Content[0]
+		if first.Kind != yaml.ScalarNode {
+			continue
+		}
+		src, ok := ctx.resolveMigratablePath(first.Value)
+		if !ok {
+			continue
+		}
+		if filepath.Base(src) == "pipelock" {
+			first.Value = ctx.env.pipelockTarget
+		}
+	}
+}
+
+func (ctx *configMigrationContext) resolveMigratablePath(raw string) (string, bool) {
+	raw = strings.TrimSpace(strings.Trim(raw, `"`))
+	if raw == "" {
+		return "", false
+	}
+	if strings.HasPrefix(raw, "~") {
+		if ctx.operatorHome == "" {
+			return "", false
+		}
+		switch {
+		case raw == "~":
+			raw = ctx.operatorHome
+		case strings.HasPrefix(raw, "~/"):
+			raw = filepath.Join(ctx.operatorHome, strings.TrimPrefix(raw, "~/"))
+		default:
+			return "", false
+		}
+	}
+	if !filepath.IsAbs(raw) {
+		raw = filepath.Join(ctx.configDir, raw)
+	}
+	clean := filepath.Clean(raw)
+	if ctx.operatorHome == "" {
+		return clean, false
+	}
+	rel, err := filepath.Rel(ctx.operatorHome, clean)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return clean, false
+	}
+	return clean, true
+}
+
+func copyConfigFile(ctx *configMigrationContext, src, dest string, mode os.FileMode) error {
+	if err := rejectSymlinkComponents(ctx, src); err != nil {
+		return err
+	}
+	info, err := ctx.env.lstat(src)
+	if err != nil {
+		return fmt.Errorf("stat source %s: %w", src, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("source %s is a symlink; refusing to copy as root", src)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("source %s is not a regular file", src)
+	}
+	data, err := readRegularFileNoFollow(src)
+	if err != nil {
+		return fmt.Errorf("read source %s: %w", src, err)
+	}
+	if err := ensureMigratedDir(ctx, filepath.Dir(dest), migrationDirMode(ctx.env, filepath.Dir(dest))); err != nil {
+		return err
+	}
+	if wrote, err := backupAndWriteIfChanged(ctx.env, dest, data, mode); err != nil {
+		return err
+	} else if wrote {
+		ctx.artifacts = append(ctx.artifacts, migratedConfigArtifact{path: dest})
+	}
+	return nil
+}
+
+func copyConfigDir(ctx *configMigrationContext, src, dest string) error {
+	info, err := ctx.env.lstat(src)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ensureMigratedDir(ctx, dest, migrationDirMode(ctx.env, dest))
+		}
+		return fmt.Errorf("stat source %s: %w", src, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("source %s is a symlink; refusing to copy as root", src)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("source %s is not a directory", src)
+	}
+	if err := rejectSymlinkComponents(ctx, src); err != nil {
+		return err
+	}
+	if err := ensureMigratedDir(ctx, dest, migrationDirMode(ctx.env, dest)); err != nil {
+		return err
+	}
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dest, rel)
+		if rel == "." {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("source %s is a symlink; refusing to copy as root", path)
+		}
+		if d.IsDir() {
+			return ensureMigratedDir(ctx, target, migrationDirMode(ctx.env, target))
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		data, err := readRegularFileNoFollow(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		if wrote, err := backupAndWriteIfChanged(ctx.env, target, data, modeConfigSecret); err != nil {
+			return err
+		} else if wrote {
+			ctx.artifacts = append(ctx.artifacts, migratedConfigArtifact{path: target})
+		}
+		return nil
+	})
+}
+
+func cleanupMigratedConfigArtifacts(env *installEnv, artifacts []migratedConfigArtifact) error {
+	var errs []error
+	for i := len(artifacts) - 1; i >= 0; i-- {
+		artifact := artifacts[i]
+		var err error
+		if artifact.dir {
+			err = env.removeFile(artifact.path)
+			if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTEMPTY) {
+				err = nil
+			}
+		} else {
+			err = restoreBackup(env, artifact.path)
+		}
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func backupAndWriteIfChanged(env *installEnv, path string, contents []byte, mode os.FileMode) (bool, error) {
+	if existing, err := env.readFile(path); err == nil {
+		if bytesEqual(existing, contents) {
+			if err := env.chmod(path, mode); err != nil {
+				return false, fmt.Errorf("chmod %s: %w", path, err)
+			}
+			return false, nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("read existing %s: %w", path, err)
+	}
+	if err := backupAndWrite(env, path, contents, mode); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func ensureMigratedDir(ctx *configMigrationContext, path string, mode os.FileMode) error {
+	if info, err := ctx.env.stat(path); err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("%s exists and is not a directory", path)
+		}
+		return ctx.env.chmod(path, mode)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	for _, dir := range missingDirs(ctx, path) {
+		ctx.artifacts = append(ctx.artifacts, migratedConfigArtifact{path: dir, dir: true})
+	}
+	if err := ctx.env.mkdirAll(path, mode); err != nil {
+		return fmt.Errorf("mkdir %s: %w", path, err)
+	}
+	if err := ctx.env.chmod(path, mode); err != nil {
+		return fmt.Errorf("chmod %s: %w", path, err)
+	}
+	return nil
+}
+
+func migrationDirMode(env *installEnv, path string) os.FileMode {
+	clean := filepath.Clean(path)
+	switch clean {
+	case filepath.Clean(env.configDir), filepath.Join(filepath.Clean(env.configDir), "contain"):
+		return modeDirTraversable
+	default:
+		return modeDirPrivate
+	}
+}
+
+func missingDirs(ctx *configMigrationContext, path string) []string {
+	var base string
+	switch {
+	case pathWithin(ctx.env.configDir, path):
+		base = ctx.env.configDir
+	case pathWithin(ctx.env.dataDir, path):
+		base = ctx.env.dataDir
+	default:
+		return nil
+	}
+	rel, err := filepath.Rel(base, path)
+	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || rel == ".." {
+		return nil
+	}
+	var out []string
+	cur := base
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		cur = filepath.Join(cur, part)
+		if _, err := ctx.env.stat(cur); errors.Is(err, os.ErrNotExist) {
+			out = append(out, cur)
+		}
+	}
+	return out
+}
+
+func pathWithin(base, path string) bool {
+	rel, err := filepath.Rel(filepath.Clean(base), filepath.Clean(path))
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
+func rejectSymlinkComponents(ctx *configMigrationContext, path string) error {
+	if ctx.operatorHome == "" {
+		return nil
+	}
+	rel, err := filepath.Rel(ctx.operatorHome, path)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return nil
+	}
+	cur := ctx.operatorHome
+	if info, err := ctx.env.lstat(cur); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("source %s has symlink component %s; refusing to copy as root", path, cur)
+	}
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		cur = filepath.Join(cur, part)
+		info, err := ctx.env.lstat(cur)
+		if err != nil {
+			return fmt.Errorf("stat source %s: %w", cur, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("source %s has symlink component %s; refusing to copy as root", path, cur)
+		}
+	}
+	return nil
+}
+
+func readRegularFileNoFollow(path string) ([]byte, error) {
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_CLOEXEC|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	f := os.NewFile(uintptr(fd), path) //nolint:gosec // syscall.Open returned a non-negative fd; needed for O_NOFOLLOW root-copy reads.
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+	return io.ReadAll(f)
+}
+
+func getMappingPath(root *yaml.Node, path []string) *yaml.Node {
+	cur := root
+	for _, key := range path {
+		if cur == nil || cur.Kind != yaml.MappingNode {
+			return nil
+		}
+		cur = mappingValue(cur, key)
+	}
+	return cur
+}
+
+func mappingValue(m *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func setMappingScalar(m *yaml.Node, key, value string) *yaml.Node {
+	if n := mappingValue(m, key); n != nil {
+		n.Kind = yaml.ScalarNode
+		n.Tag = "!!str"
+		n.Value = value
+		return n
+	}
+	n := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+	m.Content = append(m.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, n)
+	return n
+}
+
+func scalarValue(n *yaml.Node) string {
+	if n == nil || n.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return strings.TrimSpace(n.Value)
+}
+
+func yamlBool(n *yaml.Node) bool {
+	if n == nil || n.Kind != yaml.ScalarNode {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(n.Value), "true")
+}

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -512,13 +512,19 @@ func backupAndWriteIfChanged(env *installEnv, path string, contents []byte, mode
 }
 
 func ensureMigratedDir(ctx *configMigrationContext, path string, mode os.FileMode) error {
-	if info, err := ctx.env.stat(path); err == nil {
+	if info, err := ctx.env.lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s is a symlink; refusing to create migrated directory", path)
+		}
 		if !info.IsDir() {
 			return fmt.Errorf("%s exists and is not a directory", path)
 		}
 		return ctx.env.chmod(path, mode)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	if err := rejectSymlinkParents(ctx.env, path); err != nil {
+		return err
 	}
 	for _, dir := range missingDirs(ctx, path) {
 		ctx.artifacts = append(ctx.artifacts, migratedConfigArtifact{path: dir, dir: true})
@@ -528,6 +534,27 @@ func ensureMigratedDir(ctx *configMigrationContext, path string, mode os.FileMod
 	}
 	if err := ctx.env.chmod(path, mode); err != nil {
 		return fmt.Errorf("chmod %s: %w", path, err)
+	}
+	return nil
+}
+
+func rejectSymlinkParents(env *installEnv, path string) error {
+	clean := filepath.Clean(path)
+	parent := filepath.Dir(clean)
+	for parent != "." && parent != string(os.PathSeparator) {
+		info, err := env.lstat(parent)
+		if err == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("path %s has symlink parent %s; refusing to create as root", clean, parent)
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("stat parent %s: %w", parent, err)
+		}
+		next := filepath.Dir(parent)
+		if next == parent {
+			break
+		}
+		parent = next
 	}
 	return nil
 }

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 	"gopkg.in/yaml.v3"
@@ -474,7 +473,7 @@ func cleanupMigratedConfigArtifacts(env *installEnv, artifacts []migratedConfigA
 		var err error
 		if artifact.dir {
 			err = env.removeFile(artifact.path)
-			if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTEMPTY) {
+			if errors.Is(err, os.ErrNotExist) || isDirectoryNotEmpty(err) {
 				err = nil
 			}
 		} else {
@@ -485,6 +484,14 @@ func cleanupMigratedConfigArtifacts(env *installEnv, artifacts []migratedConfigA
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func isDirectoryNotEmpty(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "directory not empty") || strings.Contains(msg, "not empty")
 }
 
 func backupAndWriteIfChanged(env *installEnv, path string, contents []byte, mode os.FileMode) (bool, error) {
@@ -588,23 +595,6 @@ func rejectSymlinkComponents(ctx *configMigrationContext, path string) error {
 		}
 	}
 	return nil
-}
-
-func readRegularFileNoFollow(path string) ([]byte, error) {
-	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_CLOEXEC|syscall.O_NOFOLLOW, 0)
-	if err != nil {
-		return nil, err
-	}
-	f := os.NewFile(uintptr(fd), path) //nolint:gosec // syscall.Open returned a non-negative fd; needed for O_NOFOLLOW root-copy reads.
-	defer func() { _ = f.Close() }()
-	info, err := f.Stat()
-	if err != nil {
-		return nil, err
-	}
-	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("%s is not a regular file", path)
-	}
-	return io.ReadAll(f)
 }
 
 func getMappingPath(root *yaml.Node, path []string) *yaml.Node {

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -457,6 +457,13 @@ func copyConfigDir(ctx *configMigrationContext, src, dest string) error {
 		if err != nil {
 			return fmt.Errorf("read %s: %w", path, err)
 		}
+		after, err := ctx.env.lstat(path)
+		if err != nil {
+			return fmt.Errorf("stat source %s after read: %w", path, err)
+		}
+		if !os.SameFile(info, after) || !after.Mode().IsRegular() {
+			return fmt.Errorf("source %s changed during migration; retry after quiescing config writes", path)
+		}
 		if wrote, err := backupAndWriteIfChanged(ctx.env, target, data, modeConfigSecret); err != nil {
 			return err
 		} else if wrote {

--- a/internal/cli/contain/config_migrate_nofollow_unix.go
+++ b/internal/cli/contain/config_migrate_nofollow_unix.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package contain
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+)
+
+func readRegularFileNoFollow(path string) ([]byte, error) {
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_CLOEXEC|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	f := os.NewFile(uintptr(fd), path) //nolint:gosec // syscall.Open returned a non-negative fd; needed for O_NOFOLLOW root-copy reads.
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+	return io.ReadAll(f)
+}

--- a/internal/cli/contain/config_migrate_nofollow_windows.go
+++ b/internal/cli/contain/config_migrate_nofollow_windows.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package contain
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func readRegularFileNoFollow(path string) ([]byte, error) {
+	f, err := os.Open(path) //nolint:gosec // Windows has no O_NOFOLLOW; caller rejects symlink components before opening.
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+	return io.ReadAll(f)
+}

--- a/internal/cli/contain/config_migrate_test.go
+++ b/internal/cli/contain/config_migrate_test.go
@@ -551,6 +551,34 @@ func TestCopyConfigFileRejectsBadSources(t *testing.T) {
 	}
 }
 
+func TestCopyConfigFileRejectsFileChangedDuringMigration(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	filePath := filepath.Join(home, "license.token")
+	otherPath := filepath.Join(home, "other.token")
+	mustWriteFile(t, filePath, "token\n")
+	mustWriteFile(t, otherPath, "other\n")
+	origLstat := env.lstat
+	calls := 0
+	env.lstat = func(path string) (os.FileInfo, error) {
+		if path == filePath {
+			calls++
+			if calls > 2 {
+				return origLstat(otherPath)
+			}
+		}
+		return origLstat(path)
+	}
+	ctx := &configMigrationContext{env: env, operatorHome: home}
+	err := copyConfigFile(ctx, filePath, filepath.Join(env.configDir, "license.token"), modeConfigSecret)
+	if err == nil {
+		t.Fatal("expected changed-file rejection")
+	}
+	if !strings.Contains(err.Error(), "changed during migration") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
 func TestSmallYAMLHelpers(t *testing.T) {
 	root, err := parseSingleYAMLDocument([]byte("enabled: true\nname: old\n"))
 	if err != nil {

--- a/internal/cli/contain/config_migrate_test.go
+++ b/internal/cli/contain/config_migrate_test.go
@@ -313,6 +313,31 @@ func TestCopyConfigDirRejectsSymlinkChild(t *testing.T) {
 	}
 }
 
+func TestCopyConfigDirRejectsFileChangedDuringMigration(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	src := filepath.Join(home, "rules")
+	filePath := filepath.Join(src, "bundle.yaml")
+	otherPath := filepath.Join(src, "other.yaml")
+	mustWriteFile(t, filePath, "rules\n")
+	mustWriteFile(t, otherPath, "other\n")
+	origLstat := env.lstat
+	env.lstat = func(path string) (os.FileInfo, error) {
+		if path == filePath {
+			return origLstat(otherPath)
+		}
+		return origLstat(path)
+	}
+	ctx := &configMigrationContext{env: env, operatorHome: home}
+	err := copyConfigDir(ctx, src, filepath.Join(env.configDir, "rules"))
+	if err == nil {
+		t.Fatal("expected changed-file rejection")
+	}
+	if !strings.Contains(err.Error(), "changed during migration") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
 func TestEnsureMigratedDirRejectsSymlinkTarget(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	root := t.TempDir()
@@ -401,6 +426,71 @@ func TestIsDirectoryNotEmpty(t *testing.T) {
 	}
 	if !isDirectoryNotEmpty(&os.PathError{Op: "remove", Path: "/tmp/x", Err: stringError("directory not empty")}) {
 		t.Fatal("expected directory-not-empty message to match")
+	}
+}
+
+func TestResolveMigratablePathVariants(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	ctx := &configMigrationContext{
+		env:          env,
+		configDir:    filepath.Join(home, ".config", "pipelock"),
+		operatorHome: home,
+	}
+	tests := []struct {
+		name string
+		raw  string
+		ok   bool
+		want string
+	}{
+		{name: "tilde home", raw: "~", ok: true, want: home},
+		{name: "tilde child", raw: "~/token", ok: true, want: filepath.Join(home, "token")},
+		{name: "relative config", raw: "license.token", ok: true, want: filepath.Join(ctx.configDir, "license.token")},
+		{name: "outside", raw: "/etc/passwd", ok: false, want: "/etc/passwd"},
+		{name: "unsupported user tilde", raw: "~other/token", ok: false},
+		{name: "empty", raw: "  ", ok: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ctx.resolveMigratablePath(tc.raw)
+			if ok != tc.ok {
+				t.Fatalf("ok=%v want %v (path %q)", ok, tc.ok, got)
+			}
+			if tc.want != "" && got != filepath.Clean(tc.want) {
+				t.Fatalf("path=%q want %q", got, filepath.Clean(tc.want))
+			}
+		})
+	}
+	ctx.operatorHome = ""
+	if _, ok := ctx.resolveMigratablePath("~/token"); ok {
+		t.Fatal("expected no migration when operator home is empty")
+	}
+}
+
+func TestSmallYAMLHelpers(t *testing.T) {
+	root, err := parseSingleYAMLDocument([]byte("enabled: true\nname: old\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	mapping := documentMapping(root)
+	if scalarValue(getMappingPath(mapping, []string{"missing"})) != "" {
+		t.Fatal("missing scalar should be empty")
+	}
+	if !yamlBool(getMappingPath(mapping, []string{"enabled"})) {
+		t.Fatal("enabled should parse true")
+	}
+	if yamlBool(nil) {
+		t.Fatal("nil bool should be false")
+	}
+	setMappingScalar(mapping, "name", "new")
+	setMappingScalar(mapping, "added", "value")
+	out, err := encodeYAML(root)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	text := string(out)
+	if !strings.Contains(text, "name: new") || !strings.Contains(text, "added: value") {
+		t.Fatalf("encoded yaml missing updated fields:\n%s", text)
 	}
 }
 

--- a/internal/cli/contain/config_migrate_test.go
+++ b/internal/cli/contain/config_migrate_test.go
@@ -1,0 +1,291 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestMigratePipelockConfigForContain_RewritesHomePaths(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	origLookup := env.lookupUser
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return origLookup(name)
+	}
+
+	configDir := filepath.Join(home, ".config", "pipelock")
+	mustWriteFile(t, filepath.Join(configDir, "license.token"), "pipelock_lic_v1_test\n")
+	mustWriteFile(t, filepath.Join(home, ".pipelock", "ca.pem"), "CA\n")
+	mustWriteFile(t, filepath.Join(home, ".pipelock", "ca-key.pem"), "KEY\n")
+	mustWriteSigningKey(t, filepath.Join(home, ".pipelock", "agents", "pipelock-official", "id_ed25519"))
+	mustWriteFile(t, filepath.Join(home, ".local", "share", "pipelock", "learn-salt"), "SALT\n")
+	mustWriteFile(t, filepath.Join(configDir, "integrity", "manifest.json"), "{}\n")
+	mustWriteFile(t, filepath.Join(configDir, "roster.json"), "{}\n")
+	mustWriteFile(t, filepath.Join(configDir, "recorder", "existing.jsonl"), "{}\n")
+	mustWriteFile(t, filepath.Join(home, ".local", "share", "pipelock", "captures", "local", "cap.jsonl"), "{}\n")
+	mustWriteFile(t, filepath.Join(home, ".config", "pipelock", "baselines", "profile.json"), "{}\n")
+	mustWriteFile(t, filepath.Join(home, ".pipelock", "contracts", "production", "active", "active.json"), "{}\n")
+
+	data := []byte(`
+mode: balanced
+license_file: ` + filepath.Join(configDir, "license.token") + `
+mcp_tool_policy:
+  redirect_profiles:
+    fetch-proxy:
+      exec: ["` + filepath.Join(home, ".local", "bin", "pipelock") + `", "internal-redirect", "fetch-proxy"]
+logging:
+  output: file
+  file: ` + filepath.Join(home, ".local", "share", "pipelock", "audit.log") + `
+flight_recorder:
+  enabled: true
+  dir: ` + filepath.Join(configDir, "recorder") + `
+  signing_key_path: ` + filepath.Join(home, ".pipelock", "agents", "pipelock-official", "id_ed25519") + `
+learn:
+  enabled: true
+  capture_dir: ` + filepath.Join(home, ".local", "share", "pipelock", "captures", "local") + `
+  privacy:
+    salt_source: file:` + filepath.Join(home, ".local", "share", "pipelock", "learn-salt") + `
+mcp_binary_integrity:
+  enabled: true
+  manifest_path: ` + filepath.Join(configDir, "integrity", "manifest.json") + `
+behavioral_baseline:
+  enabled: true
+  profile_dir: ` + filepath.Join(configDir, "baselines") + `
+tls_interception:
+  enabled: true
+learn_lock:
+  enabled: true
+  store_dir: ` + filepath.Join(home, ".pipelock", "contracts", "production", "active") + `
+  roster_path: ` + filepath.Join(configDir, "roster.json") + `
+`)
+
+	out, artifacts, err := migratePipelockConfigForContain(env, filepath.Join(configDir, "pipelock.yaml"), data)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	text := string(out)
+	for _, forbidden := range []string{
+		filepath.Join(home, ".config", "pipelock"),
+		filepath.Join(home, ".pipelock"),
+		filepath.Join(home, ".local", "share", "pipelock"),
+		filepath.Join(home, ".local", "bin", "pipelock"),
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("migrated config still contains %s:\n%s", forbidden, text)
+		}
+	}
+	for _, want := range []string{
+		"license_file: " + filepath.Join(env.configDir, "license.token"),
+		"ca_cert: " + filepath.Join(env.configDir, "tls", "ca.pem"),
+		"ca_key: " + filepath.Join(env.configDir, "tls", "ca-key.pem"),
+		"signing_key_path: " + filepath.Join(env.configDir, "keys", "flight-recorder-signing.key"),
+		"salt_source: file:" + filepath.Join(env.configDir, "learn-privacy-salt"),
+		"manifest_path: " + filepath.Join(env.configDir, "integrity", "manifest.json"),
+		"roster_path: " + filepath.Join(env.configDir, "roster.json"),
+		"file: " + filepath.Join(env.dataDir, "logs", "audit.log"),
+		"dir: " + filepath.Join(env.dataDir, "recorder"),
+		"capture_dir: " + filepath.Join(env.dataDir, "captures", "local"),
+		"profile_dir: " + filepath.Join(env.dataDir, "baselines"),
+		"store_dir: " + filepath.Join(env.dataDir, "contracts", "active"),
+		env.pipelockTarget,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("migrated config missing %q:\n%s", want, text)
+		}
+	}
+	for _, p := range []string{
+		filepath.Join(env.configDir, "license.token"),
+		filepath.Join(env.configDir, "tls", "ca.pem"),
+		filepath.Join(env.configDir, "tls", "ca-key.pem"),
+		filepath.Join(env.configDir, "keys", "flight-recorder-signing.key"),
+		filepath.Join(env.configDir, "learn-privacy-salt"),
+		filepath.Join(env.configDir, "integrity", "manifest.json"),
+		filepath.Join(env.configDir, "roster.json"),
+		filepath.Join(env.dataDir, "recorder", "existing.jsonl"),
+		filepath.Join(env.dataDir, "captures", "local", "cap.jsonl"),
+		filepath.Join(env.dataDir, "baselines", "profile.json"),
+		filepath.Join(env.dataDir, "contracts", "active", "active.json"),
+	} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("expected migrated artifact %s: %v", p, err)
+		}
+	}
+	for _, p := range []string{
+		filepath.Join(env.configDir, "learn-privacy-salt"),
+		filepath.Join(env.configDir, "tls", "ca-key.pem"),
+		filepath.Join(env.configDir, "keys", "flight-recorder-signing.key"),
+	} {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat %s: %v", p, err)
+		}
+		if got := info.Mode().Perm(); got != modePinSecret {
+			t.Fatalf("%s mode = %s, want %s", p, got, modePinSecret)
+		}
+	}
+	if len(artifacts) == 0 {
+		t.Fatal("expected tracked migrated artifacts")
+	}
+}
+
+func TestMigratePipelockConfigForContain_RejectsSymlinkSource(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	origLookup := env.lookupUser
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return origLookup(name)
+	}
+	configDir := filepath.Join(home, ".config", "pipelock")
+	if err := os.MkdirAll(configDir, 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir: %v", err)
+	}
+	target := filepath.Join(configDir, "real.token")
+	mustWriteFile(t, target, "token\n")
+	link := filepath.Join(configDir, "license.token")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	_, _, err := migratePipelockConfigForContain(env, filepath.Join(configDir, "pipelock.yaml"), []byte("license_file: "+link+"\n"))
+	if err == nil {
+		t.Fatal("expected symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestMigratePipelockConfigForContain_RejectsSymlinkParent(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	origLookup := env.lookupUser
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return origLookup(name)
+	}
+	realConfigDir := filepath.Join(home, "real-config")
+	mustWriteFile(t, filepath.Join(realConfigDir, "license.token"), "token\n")
+	if err := os.Symlink(realConfigDir, filepath.Join(home, ".config")); err != nil {
+		t.Fatalf("symlink parent: %v", err)
+	}
+	linkPath := filepath.Join(home, ".config", "license.token")
+	_, _, err := migratePipelockConfigForContain(env, filepath.Join(home, "pipelock.yaml"), []byte("license_file: "+linkPath+"\n"))
+	if err == nil {
+		t.Fatal("expected symlink parent rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink component") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestMigratePipelockConfigForContain_SkipsIdenticalArtifactWrite(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	origLookup := env.lookupUser
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return origLookup(name)
+	}
+	src := filepath.Join(home, ".config", "pipelock", "license.token")
+	dst := filepath.Join(env.configDir, "license.token")
+	mustWriteFile(t, src, "same\n")
+	mustWriteFile(t, dst, "same\n")
+
+	_, artifacts, err := migratePipelockConfigForContain(env, filepath.Join(home, ".config", "pipelock", "pipelock.yaml"), []byte("license_file: "+src+"\n"))
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if len(artifacts) != 0 {
+		t.Fatalf("expected no artifacts for identical migrated file, got %#v", artifacts)
+	}
+	if _, err := os.Stat(dst + ".bak"); !os.IsNotExist(err) {
+		t.Fatalf("expected no backup for identical migrated file, stat err=%v", err)
+	}
+}
+
+func TestMigratePipelockConfigForContain_GeneratesMissingFlightRecorderSigningKey(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	origLookup := env.lookupUser
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return origLookup(name)
+	}
+
+	configDir := filepath.Join(home, ".config", "pipelock")
+	missingKey := filepath.Join(home, ".pipelock", "agents", "pipelock-official", "id_ed25519")
+	data := []byte(`
+flight_recorder:
+  enabled: true
+  signing_key_path: ` + missingKey + `
+`)
+
+	out, artifacts, err := migratePipelockConfigForContain(env, filepath.Join(configDir, "pipelock.yaml"), data)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	dest := filepath.Join(env.configDir, "keys", "flight-recorder-signing.key")
+	text := string(out)
+	if strings.Contains(text, missingKey) {
+		t.Fatalf("migrated config still references missing home key:\n%s", text)
+	}
+	if !strings.Contains(text, "signing_key_path: "+dest) {
+		t.Fatalf("migrated config missing generated signing key path %q:\n%s", dest, text)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat generated key: %v", err)
+	}
+	if got := info.Mode().Perm(); got != modePinSecret {
+		t.Fatalf("generated key mode = %s, want %s", got, modePinSecret)
+	}
+	if _, err := signing.LoadPrivateKeyFile(dest); err != nil {
+		t.Fatalf("load generated key: %v", err)
+	}
+	if len(artifacts) == 0 {
+		t.Fatal("expected generated key artifact to be tracked")
+	}
+}
+
+func mustWriteFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func mustWriteSigningKey(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate signing key: %v", err)
+	}
+	if err := signing.SavePrivateKey(priv, path); err != nil {
+		t.Fatalf("write signing key %s: %v", path, err)
+	}
+}

--- a/internal/cli/contain/config_migrate_test.go
+++ b/internal/cli/contain/config_migrate_test.go
@@ -273,6 +273,50 @@ flight_recorder:
 	}
 }
 
+func TestEnsureFlightRecorderSigningKeyUsesExistingTarget(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	dest := filepath.Join(env.configDir, "keys", "flight-recorder-signing.key")
+	mustWriteSigningKey(t, dest)
+	ctx := &configMigrationContext{env: env}
+	if err := ensureFlightRecorderSigningKey(ctx, dest); err != nil {
+		t.Fatalf("ensure existing: %v", err)
+	}
+	if len(ctx.artifacts) != 0 {
+		t.Fatalf("existing key should not add artifacts: %+v", ctx.artifacts)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat key: %v", err)
+	}
+	if got := info.Mode().Perm(); got != modePinSecret {
+		t.Fatalf("mode=%s want %s", got, modePinSecret)
+	}
+}
+
+func TestEnsureFlightRecorderSigningKeyRejectsBadExistingTargets(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	ctx := &configMigrationContext{env: env}
+	dirDest := filepath.Join(env.configDir, "keys", "as-dir")
+	if err := os.MkdirAll(dirDest, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := ensureFlightRecorderSigningKey(ctx, dirDest); err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("dir err: %v", err)
+	}
+	badKey := filepath.Join(env.configDir, "keys", "bad.key")
+	mustWriteFile(t, badKey, "not a key")
+	if err := ensureFlightRecorderSigningKey(ctx, badKey); err == nil || !strings.Contains(err.Error(), "validate existing signing key") {
+		t.Fatalf("bad key err: %v", err)
+	}
+	link := filepath.Join(env.configDir, "keys", "link.key")
+	if err := os.Symlink(badKey, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if err := ensureFlightRecorderSigningKey(ctx, link); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("symlink err: %v", err)
+	}
+}
+
 func TestCopyConfigDirCopiesNestedFiles(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	home := t.TempDir()
@@ -464,6 +508,46 @@ func TestResolveMigratablePathVariants(t *testing.T) {
 	ctx.operatorHome = ""
 	if _, ok := ctx.resolveMigratablePath("~/token"); ok {
 		t.Fatal("expected no migration when operator home is empty")
+	}
+}
+
+func TestOperatorHomeDirErrors(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.operatorUser = ""
+	if _, err := operatorHomeDir(env); err == nil || !strings.Contains(err.Error(), "operator user not set") {
+		t.Fatalf("empty operator err: %v", err)
+	}
+	env.operatorUser = containInstallOperatorUser
+	env.lookupUser = func(string) (*user.User, error) {
+		return nil, user.UnknownUserError("missing")
+	}
+	if _, err := operatorHomeDir(env); err == nil {
+		t.Fatal("expected lookup error")
+	}
+}
+
+func TestCopyConfigFileRejectsBadSources(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	ctx := &configMigrationContext{env: env, operatorHome: home}
+	missing := filepath.Join(home, "missing.token")
+	if err := copyConfigFile(ctx, missing, filepath.Join(env.configDir, "missing.token"), modeConfigSecret); err == nil || !strings.Contains(err.Error(), "stat source") {
+		t.Fatalf("missing err: %v", err)
+	}
+	dirSrc := filepath.Join(home, "dir-source")
+	if err := os.MkdirAll(dirSrc, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := copyConfigFile(ctx, dirSrc, filepath.Join(env.configDir, "dir-source"), modeConfigSecret); err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("dir err: %v", err)
+	}
+	fileSrc := filepath.Join(home, "token")
+	mustWriteFile(t, fileSrc, "token")
+	env.readFile = func(string) ([]byte, error) {
+		return nil, stringError("read denied")
+	}
+	if _, err := backupAndWriteIfChanged(env, filepath.Join(env.configDir, "token"), []byte("token"), modeConfigSecret); err == nil || !strings.Contains(err.Error(), "read existing") {
+		t.Fatalf("read existing err: %v", err)
 	}
 }
 

--- a/internal/cli/contain/config_migrate_test.go
+++ b/internal/cli/contain/config_migrate_test.go
@@ -196,7 +196,7 @@ func TestMigratePipelockConfigForContain_RejectsSymlinkSource(t *testing.T) {
 		return origLookup(name)
 	}
 	configDir := filepath.Join(home, ".config", "pipelock")
-	if err := os.MkdirAll(configDir, 0o755); err != nil { //nolint:gosec // tmpdir
+	if err := os.MkdirAll(configDir, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	target := filepath.Join(configDir, "real.token")
@@ -483,7 +483,7 @@ flight_recorder:
 
 func mustWriteFile(t *testing.T, path, body string) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { //nolint:gosec // tmpdir
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
 	}
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
@@ -493,7 +493,7 @@ func mustWriteFile(t *testing.T, path, body string) {
 
 func mustWriteSigningKey(t *testing.T, path string) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { //nolint:gosec // tmpdir
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
 	}
 	_, priv, err := signing.GenerateKeyPair()

--- a/internal/cli/contain/config_migrate_test.go
+++ b/internal/cli/contain/config_migrate_test.go
@@ -139,6 +139,52 @@ learn_lock:
 	}
 }
 
+func TestMigratePipelockConfigForContain_EmptyMappingIsNoOp(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	origLookup := env.lookupUser
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return origLookup(name)
+	}
+	out, artifacts, err := migratePipelockConfigForContain(env, filepath.Join(home, ".config", "pipelock", "pipelock.yaml"), []byte("{}\n"))
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if len(artifacts) != 0 {
+		t.Fatalf("expected no artifacts, got %+v", artifacts)
+	}
+	if strings.TrimSpace(string(out)) != "{}" {
+		t.Fatalf("output: %q", out)
+	}
+}
+
+func TestMigratePipelockConfigForContainRejectsInvalidDocuments(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "invalid yaml", body: ":\n", want: "parse pipelock config"},
+		{name: "multi document", body: "{}\n---\n{}\n", want: "single YAML document"},
+		{name: "non mapping", body: "[]\n", want: "YAML mapping"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := migratePipelockConfigForContain(env, filepath.Join(t.TempDir(), "pipelock.yaml"), []byte(tc.body))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err: %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestMigratePipelockConfigForContain_RejectsSymlinkSource(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	home := t.TempDir()
@@ -192,6 +238,175 @@ func TestMigratePipelockConfigForContain_RejectsSymlinkParent(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 }
+
+func TestMigratePipelockConfigForContain_GeneratesMissingFlightRecorderKey(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	origLookup := env.lookupUser
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return origLookup(name)
+	}
+	configDir := filepath.Join(home, ".config", "pipelock")
+	if err := os.MkdirAll(configDir, 0o750); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	missingKey := filepath.Join(home, ".pipelock", "agents", "pipelock-official", "id_ed25519")
+	out, artifacts, err := migratePipelockConfigForContain(env, filepath.Join(configDir, "pipelock.yaml"), []byte(`
+flight_recorder:
+  signing_key_path: "`+missingKey+`"
+`))
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	dest := filepath.Join(env.configDir, "keys", "flight-recorder-signing.key")
+	if !strings.Contains(string(out), dest) {
+		t.Fatalf("rewritten config missing generated key path:\n%s", out)
+	}
+	if _, err := signing.LoadPrivateKeyFile(dest); err != nil {
+		t.Fatalf("generated key invalid: %v", err)
+	}
+	if len(artifacts) == 0 {
+		t.Fatal("expected generated key artifacts to be tracked")
+	}
+}
+
+func TestCopyConfigDirCopiesNestedFiles(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	src := filepath.Join(home, "rules")
+	mustWriteFile(t, filepath.Join(src, "nested", "bundle.yaml"), "rules\n")
+	ctx := &configMigrationContext{env: env, operatorHome: home}
+	dest := filepath.Join(env.configDir, "rules")
+	if err := copyConfigDir(ctx, src, dest); err != nil {
+		t.Fatalf("copy dir: %v", err)
+	}
+	got, err := env.readFile(filepath.Join(dest, "nested", "bundle.yaml"))
+	if err != nil {
+		t.Fatalf("read copied: %v", err)
+	}
+	if string(got) != "rules\n" {
+		t.Fatalf("copied content: %q", got)
+	}
+	if len(ctx.artifacts) == 0 {
+		t.Fatal("expected copied artifacts to be tracked")
+	}
+}
+
+func TestCopyConfigDirRejectsSymlinkChild(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	src := filepath.Join(home, "rules")
+	mustWriteFile(t, filepath.Join(src, "real.yaml"), "rules\n")
+	if err := os.Symlink(filepath.Join(src, "real.yaml"), filepath.Join(src, "link.yaml")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	ctx := &configMigrationContext{env: env, operatorHome: home}
+	err := copyConfigDir(ctx, src, filepath.Join(env.configDir, "rules"))
+	if err == nil {
+		t.Fatal("expected symlink child rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestEnsureMigratedDirRejectsSymlinkTarget(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	root := t.TempDir()
+	target := filepath.Join(root, "real")
+	if err := os.MkdirAll(target, 0o750); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	ctx := &configMigrationContext{env: env}
+	err := ensureMigratedDir(ctx, link, modeDirPrivate)
+	if err == nil {
+		t.Fatal("expected symlink target rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestEnsureMigratedDirRejectsSymlinkParent(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	root := t.TempDir()
+	realParent := filepath.Join(root, "real-parent")
+	if err := os.MkdirAll(realParent, 0o750); err != nil {
+		t.Fatalf("mkdir parent: %v", err)
+	}
+	linkParent := filepath.Join(root, "link-parent")
+	if err := os.Symlink(realParent, linkParent); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	ctx := &configMigrationContext{env: env}
+	err := ensureMigratedDir(ctx, filepath.Join(linkParent, "child"), modeDirPrivate)
+	if err == nil {
+		t.Fatal("expected symlink parent rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink parent") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestCleanupMigratedConfigArtifactsRestoresFilesAndKeepsNonEmptyDirs(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	root := t.TempDir()
+	filePath := filepath.Join(root, "migrated-token")
+	if err := os.WriteFile(filePath, []byte("new"), 0o600); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+	if err := os.WriteFile(filePath+".bak", []byte("old"), 0o600); err != nil {
+		t.Fatalf("write backup: %v", err)
+	}
+	nonEmptyDir := filepath.Join(root, "dir")
+	if err := os.MkdirAll(nonEmptyDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nonEmptyDir, "kept"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write child: %v", err)
+	}
+
+	err := cleanupMigratedConfigArtifacts(env, []migratedConfigArtifact{
+		{path: filePath},
+		{path: nonEmptyDir, dir: true},
+	})
+	if err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	got, err := env.readFile(filePath)
+	if err != nil {
+		t.Fatalf("read restored: %v", err)
+	}
+	if string(got) != "old" {
+		t.Fatalf("restored file: got %q, want old", got)
+	}
+	if _, err := os.Stat(nonEmptyDir); err != nil {
+		t.Fatalf("non-empty dir should remain: %v", err)
+	}
+}
+
+func TestIsDirectoryNotEmpty(t *testing.T) {
+	if isDirectoryNotEmpty(nil) {
+		t.Fatal("nil must not report directory-not-empty")
+	}
+	if isDirectoryNotEmpty(os.ErrInvalid) {
+		t.Fatal("unrelated errors must not report directory-not-empty")
+	}
+	if !isDirectoryNotEmpty(&os.PathError{Op: "remove", Path: "/tmp/x", Err: stringError("directory not empty")}) {
+		t.Fatal("expected directory-not-empty message to match")
+	}
+}
+
+type stringError string
+
+func (e stringError) Error() string { return string(e) }
 
 func TestMigratePipelockConfigForContain_SkipsIdenticalArtifactWrite(t *testing.T) {
 	env, _, _ := newFakeEnv(t)

--- a/internal/cli/contain/contain_hardening_test.go
+++ b/internal/cli/contain/contain_hardening_test.go
@@ -96,6 +96,32 @@ func TestPrivilegedWritesRejectSymlinkTargets(t *testing.T) {
 	}
 }
 
+func TestBackupAndWriteIfChangedRejectsUnchangedSymlinkTarget(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	target := filepath.Join(env.configDir, "target")
+	link := filepath.Join(env.configDir, "link")
+	if err := os.WriteFile(target, []byte("same"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	applied, err := backupAndWriteIfChanged(env, link, []byte("same"), modeAllowListReadable)
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink rejection, got applied=%v err=%v", applied, err)
+	}
+	if applied {
+		t.Fatal("symlink rejection must not report applied")
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("symlink target mode changed: got %s want 0o600", got)
+	}
+}
+
 func TestWriteFileAtomicWritesModeAndReportsBadParent(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "atomic.txt")
@@ -174,6 +200,54 @@ func TestBackupAndWriteRejectsSymlinkBackup(t *testing.T) {
 	err := backupAndWrite(env, path, []byte("new"), 0o600)
 	if err == nil || !strings.Contains(err.Error(), "symlink backup") {
 		t.Fatalf("expected symlink backup rejection, got %v", err)
+	}
+}
+
+func TestRestoreBackupRejectsSymlinkBackup(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "host.conf")
+	const current = "restore-backup-current"
+	if err := os.WriteFile(path, []byte(current), 0o600); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "elsewhere"), path+".bak"); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	err := restoreBackup(env, path)
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink backup rejection, got %v", err)
+	}
+	got, err := os.ReadFile(path) //nolint:gosec // tmpdir-scoped test path
+	if err != nil {
+		t.Fatalf("read current: %v", err)
+	}
+	if string(got) != current {
+		t.Fatalf("current file changed: %q", got)
+	}
+}
+
+func TestRestoreBackupIfPresentRejectsSymlinkBackup(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "host.conf")
+	const current = "restore-if-present-current"
+	if err := os.WriteFile(path, []byte(current), 0o600); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "elsewhere"), path+".bak"); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	err := restoreBackupIfPresent(env, path)
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink backup rejection, got %v", err)
+	}
+	got, err := os.ReadFile(path) //nolint:gosec // tmpdir-scoped test path
+	if err != nil {
+		t.Fatalf("read current: %v", err)
+	}
+	if string(got) != current {
+		t.Fatalf("current file changed: %q", got)
 	}
 }
 

--- a/internal/cli/contain/contain_hardening_test.go
+++ b/internal/cli/contain/contain_hardening_test.go
@@ -6,6 +6,7 @@ package contain
 import (
 	"context"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -143,6 +144,273 @@ func TestEnsureSafeDirectoryRejectsBadPaths(t *testing.T) {
 	}
 	if err := ensureSafeDirectory(env, filepath.Join(linkParent, "child")); err == nil || !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("symlink parent err: %v", err)
+	}
+}
+
+func TestEnsureSafeWriteTargetRejectsRelativeAndDirectory(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := ensureSafeWriteTarget(env, "relative"); err == nil || !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("relative err: %v", err)
+	}
+	dir := filepath.Join(t.TempDir(), "dir")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := ensureSafeWriteTarget(env, dir); err == nil || !strings.Contains(err.Error(), "directory") {
+		t.Fatalf("directory err: %v", err)
+	}
+}
+
+func TestBackupAndWriteRejectsSymlinkBackup(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "host.conf")
+	if err := os.WriteFile(path, []byte("current"), 0o600); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "elsewhere"), path+".bak"); err != nil {
+		t.Fatalf("symlink backup: %v", err)
+	}
+	err := backupAndWrite(env, path, []byte("new"), 0o600)
+	if err == nil || !strings.Contains(err.Error(), "symlink backup") {
+		t.Fatalf("expected symlink backup rejection, got %v", err)
+	}
+}
+
+func TestStepWriteCombinedCABundleBranches(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.WriteFile(env.caExportPath, []byte("PIPELOCK"), 0o600); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+	step := stepWriteCombinedCABundle()
+	applied, err := step.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected initial bundle write")
+	}
+	if err := step.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	applied, err = step.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected restored bundle to be written again")
+	}
+	applied, err = step.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("idempotent apply: %v", err)
+	}
+	if applied {
+		t.Fatal("expected idempotent bundle skip")
+	}
+	if err := os.Remove(env.caExportPath); err != nil {
+		t.Fatalf("remove ca: %v", err)
+	}
+	if _, err := step.apply(context.Background(), env); err == nil || !strings.Contains(err.Error(), "read pipelock CA") {
+		t.Fatalf("missing ca err: %v", err)
+	}
+}
+
+func TestStepWritePipelockConfigUndoRestoresMigratedArtifacts(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return &user.User{Uid: "988", Gid: "988", Username: name, HomeDir: "/tmp"}, nil
+	}
+	configDir := filepath.Join(home, ".config", "pipelock")
+	license := filepath.Join(configDir, "license.token")
+	mustWriteFile(t, license, "token\n")
+	src := filepath.Join(configDir, "pipelock.yaml")
+	mustWriteFile(t, src, "license_file: "+license+"\n")
+	step := stepWritePipelockConfig(installOpts{configSource: src})
+	applied, err := step.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected config write")
+	}
+	migrated := filepath.Join(env.configDir, "license.token")
+	if _, err := os.Stat(migrated); err != nil {
+		t.Fatalf("migrated license missing: %v", err)
+	}
+	if err := step.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if _, err := os.Stat(migrated); !os.IsNotExist(err) {
+		t.Fatalf("migrated license should be removed, stat err=%v", err)
+	}
+}
+
+func TestStepExportPipelockCAUndoAndErrorBranches(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	step := stepExportPipelockCA()
+	env.runCmd = func(context.Context, string, ...string) (string, int, error) {
+		return "bad", 0, nil
+	}
+	if _, err := step.apply(context.Background(), env); err == nil || !strings.Contains(err.Error(), "invalid CA PEM") {
+		t.Fatalf("expected invalid pem error, got %v", err)
+	}
+	if err := os.WriteFile(env.caExportPath, []byte(testPEMCA(t)), 0o600); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+	applied, err := step.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("existing ca apply: %v", err)
+	}
+	if applied {
+		t.Fatal("existing CA should skip")
+	}
+	if err := step.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if _, err := os.Stat(env.caExportPath); !os.IsNotExist(err) {
+		t.Fatalf("CA export should be removed, stat err=%v", err)
+	}
+}
+
+func TestEnsureIntegrityOwnershipSurfacesFilesystemErrors(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.MkdirAll(env.integrityDir, 0o750); err != nil {
+		t.Fatalf("mkdir integrity: %v", err)
+	}
+	if err := os.WriteFile(env.integrityPin, []byte("pin"), 0o600); err != nil {
+		t.Fatalf("write pin: %v", err)
+	}
+	env.chmod = func(path string, _ os.FileMode) error {
+		if path == env.integrityDir {
+			return stringError("chmod denied")
+		}
+		return nil
+	}
+	if err := ensureIntegrityOwnership(env); err == nil || !strings.Contains(err.Error(), "chmod denied") {
+		t.Fatalf("expected chmod error, got %v", err)
+	}
+}
+
+func TestWalkAndChownSkipsSymlinkAndSurfacesChownError(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "regular"), "x")
+	if err := os.Symlink(filepath.Join(root, "regular"), filepath.Join(root, "link")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	var seen []string
+	env.chown = func(path string, _, _ int) error {
+		seen = append(seen, filepath.Base(path))
+		if filepath.Base(path) == "regular" {
+			return stringError("chown denied")
+		}
+		return nil
+	}
+	err := walkAndChown(env, root, 1, 1)
+	if err == nil || !strings.Contains(err.Error(), "chown denied") {
+		t.Fatalf("expected chown error, got %v", err)
+	}
+	for _, base := range seen {
+		if base == "link" {
+			t.Fatalf("chowned symlink: %v", seen)
+		}
+	}
+}
+
+func TestStepWriteToolWrappersRollsBackPartialWrite(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := writeToolsList(env, []toolsListEntry{
+		{name: "claude", target: "/usr/bin/claude"},
+		{name: "codex", target: "/usr/bin/codex"},
+	}); err != nil {
+		t.Fatalf("write tools.list: %v", err)
+	}
+	origWrite := env.writeFile
+	env.writeFile = func(path string, contents []byte, mode os.FileMode) error {
+		if filepath.Base(path) == "plk-codex" {
+			return stringError("disk full")
+		}
+		return origWrite(path, contents, mode)
+	}
+	step := stepWriteToolWrappers()
+	if _, err := step.apply(context.Background(), env); err == nil || !strings.Contains(err.Error(), "disk full") {
+		t.Fatalf("expected partial write error, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(env.wrapperDir, "plk-claude")); !os.IsNotExist(err) {
+		t.Fatalf("partial wrapper should be rolled back, stat err=%v", err)
+	}
+}
+
+func TestStepWriteToolWrappersBacksUpAndRestoresStaleDefault(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := writeToolsList(env, []toolsListEntry{{name: "claude", target: "/usr/bin/claude"}}); err != nil {
+		t.Fatalf("write tools.list: %v", err)
+	}
+	stale := filepath.Join(env.wrapperDir, "plk-playwright")
+	if err := os.WriteFile(stale, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write stale wrapper: %v", err)
+	}
+	step := stepWriteToolWrappers()
+	applied, err := step.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected wrapper changes")
+	}
+	if _, err := os.Stat(stale + ".bak"); err != nil {
+		t.Fatalf("stale backup missing: %v", err)
+	}
+	if err := step.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if got, err := os.ReadFile(stale); err != nil || string(got) != "stale" { //nolint:gosec // tmpdir-scoped test path
+		t.Fatalf("stale wrapper not restored, got %q err=%v", got, err)
+	}
+}
+
+func TestStepWriteWrapperInventoryBranches(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := writeToolsList(env, []toolsListEntry{{name: "claude", target: "/usr/bin/claude"}}); err != nil {
+		t.Fatalf("write tools.list: %v", err)
+	}
+	step := stepWriteWrapperInventory()
+	applied, err := step.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("initial apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected inventory write")
+	}
+	applied, err = step.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("idempotent apply: %v", err)
+	}
+	if applied {
+		t.Fatal("expected inventory skip")
+	}
+	if err := os.WriteFile(env.wrapperInvPath, []byte(`{"wrappers":["plk-old"]}`), 0o600); err != nil {
+		t.Fatalf("write mismatched inventory: %v", err)
+	}
+	applied, err = step.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("rewrite apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected mismatched inventory rewrite")
+	}
+	if err := step.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if err := os.WriteFile(env.wrapperInvPath, []byte("{"), 0o600); err != nil {
+		t.Fatalf("write bad inventory: %v", err)
+	}
+	if _, err := step.apply(context.Background(), env); err == nil || !strings.Contains(err.Error(), "parse wrapper inventory") {
+		t.Fatalf("expected parse error, got %v", err)
 	}
 }
 

--- a/internal/cli/contain/contain_hardening_test.go
+++ b/internal/cli/contain/contain_hardening_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadToolsListRejectsMalformedPolicyLines(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for name, body := range map[string]string{
+		"bad name":        "bad name\t/bin/true\n",
+		"missing tab":     "tool\n",
+		"relative target": "tool\trelative/bin\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := os.WriteFile(env.toolsListPath, []byte(body), 0o600); err != nil {
+				t.Fatalf("write tools.list: %v", err)
+			}
+			if _, err := readToolsList(env); err == nil || !strings.Contains(err.Error(), "malformed tools.list") {
+				t.Fatalf("err: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunAddToolAutoResolvedTargetIsPinned(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	target, err := os.Executable()
+	if err != nil {
+		t.Fatalf("executable: %v", err)
+	}
+	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "which", "discovered"), target+"\n", 0, nil)
+	if err := runAddTool(context.Background(), env, "discovered", addToolOpts{}); err != nil {
+		t.Fatalf("add tool: %v", err)
+	}
+	entries, err := readToolsList(env)
+	if err != nil {
+		t.Fatalf("read tools.list: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.name == "discovered" {
+			if entry.target != target {
+				t.Fatalf("auto-resolved target not pinned: got %q want %q", entry.target, target)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing discovered entry: %+v", entries)
+}
+
+func TestRunAddToolRejectsSymlinkTarget(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	target, err := os.Executable()
+	if err != nil {
+		t.Fatalf("executable: %v", err)
+	}
+	link := filepath.Join(t.TempDir(), "tool-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	err = runAddTool(context.Background(), env, "linked", addToolOpts{target: link})
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink target rejection, got %v", err)
+	}
+}
+
+func TestPrivilegedWritesRejectSymlinkTargets(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	target := filepath.Join(env.configDir, "target")
+	link := filepath.Join(env.configDir, "link")
+	if err := os.WriteFile(target, []byte("original-bytes"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if err := backupAndWrite(env, link, []byte("new"), 0o600); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+	got, err := os.ReadFile(target) //nolint:gosec // tmpdir-scoped test path
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "original-bytes" {
+		t.Fatalf("symlink target was modified: %q", got)
+	}
+}
+
+func TestWriteFileAtomicWritesModeAndReportsBadParent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "atomic.txt")
+	if err := writeFileAtomic(path, []byte("body"), 0o600); err != nil {
+		t.Fatalf("write atomic: %v", err)
+	}
+	got, err := os.ReadFile(path) //nolint:gosec // tmpdir-scoped test path
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "body" {
+		t.Fatalf("body: %q", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode=%s want 0o600", got)
+	}
+	if err := writeFileAtomic(filepath.Join(dir, "missing", "file"), []byte("x"), 0o600); err == nil {
+		t.Fatal("expected missing parent error")
+	}
+}
+
+func TestEnsureSafeDirectoryRejectsBadPaths(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := ensureSafeDirectory(env, "relative"); err == nil || !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("relative err: %v", err)
+	}
+	root := t.TempDir()
+	filePath := filepath.Join(root, "not-dir")
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := ensureSafeDirectory(env, filePath); err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("file err: %v", err)
+	}
+	realParent := filepath.Join(root, "real")
+	if err := os.MkdirAll(realParent, 0o750); err != nil {
+		t.Fatalf("mkdir real: %v", err)
+	}
+	linkParent := filepath.Join(root, "link")
+	if err := os.Symlink(realParent, linkParent); err != nil {
+		t.Fatalf("symlink parent: %v", err)
+	}
+	if err := ensureSafeDirectory(env, filepath.Join(linkParent, "child")); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("symlink parent err: %v", err)
+	}
+}
+
+func TestWriteToolsListRejectsSymlinkTarget(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	target := filepath.Join(t.TempDir(), "outside-tools.list")
+	if err := os.WriteFile(target, []byte("old"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Remove(env.toolsListPath); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("remove old tools.list: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o750); err != nil {
+		t.Fatalf("mkdir tools.list parent: %v", err)
+	}
+	if err := os.Symlink(target, env.toolsListPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	err := writeToolsList(env, []toolsListEntry{{name: "claude", target: "/usr/bin/claude"}})
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}
+
+func TestAppendInventoryRejectsSymlinkInventory(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	target := filepath.Join(t.TempDir(), "outside-inventory.json")
+	if err := os.WriteFile(target, []byte(`{"wrappers":[]}`), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(env.wrapperInvPath), 0o750); err != nil {
+		t.Fatalf("mkdir inventory parent: %v", err)
+	}
+	if err := os.Symlink(target, env.wrapperInvPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	err := appendInventory(env, "plk-claude")
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}

--- a/internal/cli/contain/contain_hardening_test.go
+++ b/internal/cli/contain/contain_hardening_test.go
@@ -345,8 +345,8 @@ func TestStepExportPipelockCAUndoAndErrorBranches(t *testing.T) {
 	if err := step.undo(context.Background(), env); err != nil {
 		t.Fatalf("undo: %v", err)
 	}
-	if _, err := os.Stat(env.caExportPath); !os.IsNotExist(err) {
-		t.Fatalf("CA export should be removed, stat err=%v", err)
+	if _, err := os.Stat(env.caExportPath); err != nil {
+		t.Fatalf("CA export should be preserved on skipped apply, stat err=%v", err)
 	}
 }
 

--- a/internal/cli/contain/doc.go
+++ b/internal/cli/contain/doc.go
@@ -3,8 +3,4 @@
 
 // Package contain implements the `pipelock contain` family of subcommands
 // for workstation-tier containment.
-//
-// In v0.1 only `verify` is implemented; the four mutating subcommands
-// (install, rollback, add-tool, ca-refresh) are registered as stubs and
-// return a "not yet implemented" error.
 package contain

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -520,8 +520,11 @@ func stepCreateDir(label string, pathFn func(*installEnv) string, mode os.FileMo
 		desc: "create " + label + " directory",
 		apply: func(_ context.Context, env *installEnv) (bool, error) {
 			path := pathFn(env)
-			info, err := env.stat(path)
+			info, err := env.lstat(path)
 			if err == nil {
+				if info.Mode()&os.ModeSymlink != 0 {
+					return false, fmt.Errorf("%s is a symlink; refusing to create install directory", path)
+				}
 				if !info.IsDir() {
 					return false, fmt.Errorf("%s exists and is not a directory", path)
 				}
@@ -533,6 +536,9 @@ func stepCreateDir(label string, pathFn func(*installEnv) string, mode os.FileMo
 			}
 			if !errors.Is(err, os.ErrNotExist) {
 				return false, fmt.Errorf("stat %s: %w", path, err)
+			}
+			if err := rejectSymlinkParents(env, path); err != nil {
+				return false, err
 			}
 			if err := env.mkdirAll(path, mode); err != nil {
 				return false, fmt.Errorf("mkdir %s: %w", path, err)
@@ -1033,6 +1039,7 @@ func stepInstallNFTRules() step {
 				return false, fmt.Errorf("nft persistence validation failed: %w", err)
 			}
 			if tableLoaded && (rulesChanged || liveRulesDrifted) {
+				captureNFTPreState(ctx, env)
 				// nft -f merges into an existing table. Drop our managed table
 				// first so stale rules from an older contain install cannot
 				// survive beside the new ruleset.
@@ -1040,6 +1047,7 @@ func stepInstallNFTRules() step {
 				tableLoaded = false
 			}
 			if !tableLoaded || rulesChanged || liveRulesDrifted {
+				captureNFTPreState(ctx, env)
 				if err := runOrErr(ctx, env, "nft", "-f", env.nftRulesPath); err != nil {
 					return false, fmt.Errorf("nft load failed: %w", err)
 				}
@@ -1050,15 +1058,57 @@ func stepInstallNFTRules() step {
 			return true, nil
 		},
 		undo: func(ctx context.Context, env *installEnv) error {
-			// Drop the table best-effort, then remove the file, then leave
-			// nftables.service alone (it may have been enabled before).
+			// Drop the managed table best-effort, restore any previous live
+			// table captured during this install attempt, then restore files.
 			_, _, _ = env.runCmd(ctx, "nft", "delete", "table", "inet", env.nftTableOrDefault())
+			if err := restorePreviousNFTState(ctx, env); err != nil {
+				return err
+			}
 			if err := restoreBackup(env, env.nftRulesPath); err != nil {
 				return err
 			}
-			return restoreOrRemoveNFTMainInclude(env)
+			if err := restoreOrRemoveNFTMainInclude(env); err != nil {
+				return err
+			}
+			if env.prevNftablesStateKnown && !env.prevNftablesEnabled {
+				if err := runOrErr(ctx, env, "systemctl", "disable", "nftables.service"); err != nil {
+					return fmt.Errorf("restore nftables.service disabled state: %w", err)
+				}
+			}
+			return nil
 		},
 	}
+}
+
+func captureNFTPreState(ctx context.Context, env *installEnv) {
+	if env.prevNFTTableDump == "" {
+		out, code, err := env.runCmd(ctx, "nft", "list", "table", "inet", env.nftTableOrDefault())
+		if err == nil && code == 0 {
+			env.prevNFTTableDump = out
+		}
+	}
+	if !env.prevNftablesStateKnown {
+		_, code, err := env.runCmd(ctx, "systemctl", "is-enabled", "nftables.service")
+		if err == nil {
+			env.prevNftablesEnabled = code == 0
+			env.prevNftablesStateKnown = true
+		}
+	}
+}
+
+func restorePreviousNFTState(ctx context.Context, env *installEnv) error {
+	if strings.TrimSpace(env.prevNFTTableDump) == "" {
+		return nil
+	}
+	restorePath := env.nftRulesPath + ".restore"
+	if err := env.writeFile(restorePath, []byte(env.prevNFTTableDump), modeConfigSecret); err != nil {
+		return fmt.Errorf("write nft restore file %s: %w", restorePath, err)
+	}
+	defer func() { _ = env.removeFile(restorePath) }()
+	if err := runOrErr(ctx, env, "nft", "-f", restorePath); err != nil {
+		return fmt.Errorf("restore previous nft table: %w", err)
+	}
+	return nil
 }
 
 func liveNFTContainmentMatches(out, chainName string, proxyPort int) bool {

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -1074,6 +1074,7 @@ func stepInstallNFTRules() step {
 					return false, fmt.Errorf("nft load failed: %w", err)
 				}
 			}
+			captureNFTPreState(ctx, env)
 			if err := runOrErr(ctx, env, "systemctl", "enable", "nftables.service"); err != nil {
 				return false, fmt.Errorf("enable nftables.service: %w", err)
 			}

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -333,48 +333,53 @@ type toolsListEntry struct {
 	target string // empty = resolve via pipelock-agent PATH at runtime
 }
 
-// readToolsList parses the runtime allow-list. Unrecognized lines (blank,
-// comment, malformed) are silently skipped — the file is root-owned and
-// pre-validated by the install/add-tool path, so a malformed line at
-// runtime is a programmer error worth reporting via plk-launch's stderr
-// rather than blowing up the Go caller.
+// readToolsList parses the runtime allow-list. Blank and comment lines
+// are ignored, but malformed policy lines fail closed: tools.list is an
+// enforcement artifact, so corruption must be visible to install/verify.
 func readToolsList(env *installEnv) ([]toolsListEntry, error) {
 	data, err := env.readFile(env.toolsListPath)
 	if err != nil {
 		return nil, err
 	}
-	return parseToolsList(data), nil
+	return parseToolsList(data)
 }
 
-func parseToolsList(data []byte) []toolsListEntry {
+func parseToolsList(data []byte) ([]toolsListEntry, error) {
 	var entries []toolsListEntry
-	for _, line := range strings.Split(string(data), "\n") {
+	for lineNo, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimRight(line, "\r")
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
 		parts := strings.SplitN(line, "\t", 2)
-		name := strings.TrimSpace(parts[0])
-		if name == "" {
-			continue
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("malformed tools.list line %d: missing tab separator", lineNo+1)
 		}
-		target := ""
-		if len(parts) == 2 {
-			target = strings.TrimSpace(parts[1])
+		name := strings.TrimSpace(parts[0])
+		if !addToolNamePattern.MatchString(name) {
+			return nil, fmt.Errorf("malformed tools.list line %d: invalid tool name %q", lineNo+1, name)
+		}
+		target := strings.TrimSpace(parts[1])
+		if target != "" && !filepath.IsAbs(target) {
+			return nil, fmt.Errorf("malformed tools.list line %d: target %q is not absolute", lineNo+1, target)
 		}
 		entries = append(entries, toolsListEntry{name: name, target: target})
 	}
-	return entries
+	return entries, nil
 }
 
 // writeToolsList renders entries back to disk preserving the header
 // comments produced by renderDefaultToolsList. Used by add-tool.
 func writeToolsList(env *installEnv, entries []toolsListEntry) error {
-	if err := env.mkdirAll(filepath.Dir(env.toolsListPath), modeDirTraversable); err != nil {
-		return fmt.Errorf("mkdir %s: %w", filepath.Dir(env.toolsListPath), err)
+	dir := filepath.Dir(env.toolsListPath)
+	if err := ensureSafeDirectory(env, dir); err != nil {
+		return err
 	}
-	if err := env.chmod(filepath.Dir(env.toolsListPath), modeDirTraversable); err != nil {
-		return fmt.Errorf("chmod %s: %w", filepath.Dir(env.toolsListPath), err)
+	if err := env.mkdirAll(dir, modeDirTraversable); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	if err := env.chmod(dir, modeDirTraversable); err != nil {
+		return fmt.Errorf("chmod %s: %w", dir, err)
 	}
 	return backupAndWrite(env, env.toolsListPath, []byte(renderToolsList(entries)), modeAllowListReadable)
 }
@@ -1345,8 +1350,18 @@ func renderLaunchWrapper(env *installEnv) string {
 		`# at runtime via the pipelock-agent PATH".`,
 		`TARGET=""`,
 		`FOUND=0`,
-		`while IFS=$'\t' read -r name target; do`,
-		`    case "$name" in ''|'#'*) continue ;; esac`,
+		`while IFS= read -r line; do`,
+		`    case "$line" in ''|'#'*) continue ;; esac`,
+		`    if [[ "$line" != *$'\t'* ]]; then`,
+		`        echo "plk-launch: malformed allow-list entry missing tab separator" >&2`,
+		`        exit 9`,
+		`    fi`,
+		`    IFS=$'\t' read -r name target <<< "$line"`,
+		`    case "$name" in *[!a-z0-9_-]*|"") echo "plk-launch: malformed allow-list entry for $name" >&2; exit 9 ;; esac`,
+		`    if [[ -n "$target" && "$target" != /* ]]; then`,
+		`        echo "plk-launch: malformed allow-list target $target for $name" >&2`,
+		`        exit 9`,
+		`    fi`,
 		`    if [[ "$name" == "$TOOL" ]]; then`,
 		`        TARGET="$target"`,
 		`        FOUND=1`,

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -943,10 +943,12 @@ func stepEnableSystemUnit() step {
 // ---------------------------------------------------------------------------
 
 func stepExportPipelockCA() step {
+	wrote := false
 	return step{
 		name: "export-pipelock-ca",
 		desc: "export pipelock TLS-MITM CA to /etc/pipelock/ca.pem",
 		apply: func(ctx context.Context, env *installEnv) (bool, error) {
+			wrote = false
 			if pathExists(env, env.caExportPath) {
 				return false, nil
 			}
@@ -958,9 +960,13 @@ func stepExportPipelockCA() step {
 			if err := exportPipelockCA(ctx, env); err != nil {
 				return false, err
 			}
+			wrote = true
 			return true, nil
 		},
 		undo: func(_ context.Context, env *installEnv) error {
+			if !wrote {
+				return nil
+			}
 			if err := env.removeFile(env.caExportPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 				return fmt.Errorf("remove %s: %w", env.caExportPath, err)
 			}

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -1,0 +1,1538 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+// installOpts collects the flag-derived state for runInstall. Mirrored as
+// fields on installEnv so the step functions can read them without holding
+// a reference to the flag layer.
+type installOpts struct {
+	dryRun         bool
+	operatorUser   string
+	proxyPort      int
+	pipelockBinary string
+	configSource   string
+}
+
+var containUsernamePattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,31}$`)
+
+// installCmd builds the `pipelock contain install` cobra command.
+func installCmd() *cobra.Command {
+	var opts installOpts
+
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install the containment model (creates users, unit, nft rules, wrappers)",
+		Long: `Install the kernel-enforced workstation containment model.
+
+Creates the pipelock-proxy and pipelock-agent system users, migrates the
+user-mode systemd unit to a system unit, installs nftables owner-match
+rules, writes wrapper scripts, installs the sudoers entry, and bootstraps
+the combined CA bundle.
+
+Must be run as root. Each step is idempotent: rerunning install on a
+fully-installed system is a no-op. If a step fails, every previously-
+applied step is rolled back before exit so the system never settles in a
+partial state.
+
+The installed binary is pinned at install time (SHA-256 stored in
+/etc/pipelock/integrity/binary-pin.sha256); subsequent verify runs
+re-hash and compare so a swapped binary is caught on the next probe.
+
+Flags let CI and reviewers see the planned commands before running.
+
+Exit codes:
+  0  All steps applied (or already in place).
+  1  A step failed; earlier applied steps were rolled back.
+  2  Precondition error (not root, missing executable, bad --config).`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := validatePort(opts.proxyPort); err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			if !opts.dryRun && os.Geteuid() != 0 {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New("install must be run as root (use sudo)"))
+			}
+			env := defaultInstallEnv(cmd.OutOrStdout())
+			if opts.operatorUser != "" {
+				env.operatorUser = opts.operatorUser
+			}
+			env.proxyPort = opts.proxyPort
+			env.pipelockBinary = opts.pipelockBinary
+			return runInstall(cmd.Context(), env, opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "print the planned steps without mutating state")
+	cmd.Flags().StringVar(&opts.operatorUser, "operator-user", "", "operator user the pipelock-agent wrappers run from (default: $SUDO_USER)")
+	cmd.Flags().IntVar(&opts.proxyPort, "proxy-port", defaultProxyPort, "pipelock listen port baked into wrappers and the unit")
+	cmd.Flags().StringVar(&opts.pipelockBinary, "pipelock-binary", "", "path to the pipelock binary to install (default: current process)")
+	cmd.Flags().StringVar(&opts.configSource, "config", "", "source pipelock.yaml to copy to /etc/pipelock/pipelock.yaml")
+
+	return cmd
+}
+
+// systemctlActive is the literal systemd-reports-active state. Extracted
+// because the install + verify code both compare against it and goconst
+// flags repeated string literals.
+const (
+	systemctlActive  = "active"
+	systemctlEnabled = "enabled"
+)
+
+// runInstall is the runtime entry point. Separated from installCmd so tests
+// can drive it directly with a fake installEnv.
+//
+// Preconditions (operator-user resolvable, --config file readable, source
+// binary readable) are checked BEFORE the step loop so they exit
+// ExitConfig. The cobra RunE handler is responsible for the os.Geteuid
+// root check; this function trusts its caller.
+func runInstall(ctx context.Context, env *installEnv, opts installOpts) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if opts.operatorUser != "" {
+		env.operatorUser = opts.operatorUser
+	}
+
+	if env.operatorUser == "" && opts.operatorUser == "" {
+		return cliutil.ExitCodeError(cliutil.ExitConfig,
+			errors.New("operator user not set; rerun via sudo (SUDO_USER) or pass --operator-user"))
+	}
+	if err := validateContainUsername("operator user", env.operatorUser); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+	}
+	if _, err := env.lookupUser(env.operatorUser); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("lookup operator user %s: %w", env.operatorUser, err))
+	}
+	if opts.configSource != "" {
+		if info, err := env.stat(opts.configSource); err != nil {
+			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("--config %q: %w", opts.configSource, err))
+		} else if info.IsDir() {
+			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("--config %q is a directory", opts.configSource))
+		}
+	}
+
+	// Resolve --pipelock-binary defaults early. If not supplied, use the
+	// currently-running binary path; that's the only safe TOFU source
+	// because the operator just invoked it as root.
+	if env.pipelockBinary == "" {
+		self, err := env.selfPath()
+		if err != nil {
+			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("locate pipelock binary: %w", err))
+		}
+		env.pipelockBinary = self
+	}
+	if info, err := env.stat(env.pipelockBinary); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("--pipelock-binary %q: %w", env.pipelockBinary, err))
+	} else if info.IsDir() {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("--pipelock-binary %q is a directory", env.pipelockBinary))
+	}
+
+	steps := installSteps(opts)
+
+	if opts.dryRun {
+		printPlan(env.out, "pipelock contain install — planned steps:", steps)
+		return nil
+	}
+
+	_, _ = fmt.Fprintln(env.out, "pipelock contain install")
+	_, err := runSteps(ctx, env, env.out, steps)
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, err)
+	}
+	_, _ = fmt.Fprintln(env.out, "install complete — run `pipelock contain verify` to confirm.")
+	return nil
+}
+
+func validateContainUsername(label, name string) error {
+	if !containUsernamePattern.MatchString(name) {
+		return fmt.Errorf("invalid %s %q (expected Linux username [a-z_][a-z0-9_-]{0,31})", label, name)
+	}
+	return nil
+}
+
+// installSteps returns the ordered step list for install. Order is
+// load-bearing:
+//
+//   - Users created before anything that chown's to them.
+//   - Config/data dirs before the service unit (the unit references them).
+//   - Binary installed before the integrity pin (we hash what we'll run).
+//   - Pipelock service running before the CA export (the export uses the
+//     running instance's state).
+//   - Combined CA built before nft rules (nft enforcement makes pipelock-agent's
+//     first invocation fail without a CA to validate TLS).
+//   - Wrappers + sudoers last (operators only exercise them once the
+//     boundary is enforceable).
+func installSteps(opts installOpts) []step {
+	return []step{
+		stepPreflight(opts),
+		stepCreateUser(true),  // proxy
+		stepCreateUser(false), // agent
+		// /etc/pipelock must be traversable by pipelock-agent so the wrappers
+		// can reach /etc/pipelock/{ca.pem,combined-ca.pem,contain/tools.list}.
+		// /var/lib/pipelock holds capture data and stays pipelock-proxy-private.
+		stepCreateDir("config", func(e *installEnv) string { return e.configDir }, modeDirTraversable),
+		stepCreateDir("data", func(e *installEnv) string { return e.dataDir }, modeDirPrivate),
+		stepWritePipelockConfig(opts),
+		stepChownToProxy("config", func(e *installEnv) string { return e.configDir }),
+		stepChownToProxy("data", func(e *installEnv) string { return e.dataDir }),
+		stepInstallPipelockBinary(),
+		stepWriteIntegrityPin(),
+		stepStopUserService(),
+		stepWriteSystemUnit(),
+		stepEnableSystemUnit(),
+		stepExportPipelockCA(),
+		stepWriteCombinedCABundle(),
+		stepInstallNFTRules(),
+		stepWriteToolsList(),
+		stepWriteLaunchWrapper(),
+		stepWriteToolWrappers(),
+		stepWriteWrapperInventory(),
+		stepInstallSudoers(),
+	}
+}
+
+// stepWriteToolsList seeds /etc/pipelock/contain/tools.list with only the
+// default tools that pipelock-agent can actually execute. add-tool appends;
+// rollback removes. The file is pipelock-agent-readable; root-owned directory
+// write permissions gate allow-list mutation.
+func stepWriteToolsList() step {
+	return step{
+		name: "write-tools-list",
+		desc: "write /etc/pipelock/contain/tools.list (plk-launch runtime allow-list)",
+		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			// /etc/pipelock/contain must be traversable by pipelock-agent so the
+			// wrapper can open tools.list. The file itself is world-readable
+			// (modeAllowListReadable); mutation is gated by directory write
+			// perms which only root holds.
+			if err := env.mkdirAll(filepath.Dir(env.toolsListPath), modeDirTraversable); err != nil {
+				return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(env.toolsListPath), err)
+			}
+			if err := env.chmod(filepath.Dir(env.toolsListPath), modeDirTraversable); err != nil {
+				return false, fmt.Errorf("chmod %s: %w", filepath.Dir(env.toolsListPath), err)
+			}
+			defaults := resolvableDefaultToolEntries(env)
+			if len(defaults) == 0 {
+				return false, errors.New("no default agent tools found in pipelock-agent PATH (/home/pipelock-agent/.local/bin:/usr/local/bin:/usr/bin:/bin); install a tool such as claude into /usr/local/bin or use add-tool after install")
+			}
+			entries, err := readToolsList(env)
+			if err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					return false, fmt.Errorf("read tools.list: %w", err)
+				}
+				return true, writeToolsList(env, defaults)
+			}
+			merged, changed := mergeDefaultToolEntries(entries, defaults)
+			if !changed {
+				return false, nil
+			}
+			return true, writeToolsList(env, merged)
+		},
+		undo: func(_ context.Context, env *installEnv) error {
+			return restoreBackup(env, env.toolsListPath)
+		},
+	}
+}
+
+// renderDefaultToolsList emits the v0.2 default allow-list. Format is
+// well-known across plk-launch + add-tool + readToolsList: one line per
+// entry, tab-separated NAME and absolute TARGET path (empty target means
+// "use pipelock-agent PATH at runtime"). Lines beginning with '#' and blank
+// lines are comments — preserved on rewrite so an operator can leave a
+// note.
+func renderDefaultToolsList() string {
+	return renderToolsList(defaultToolEntriesWithoutTargets())
+}
+
+// defaultToolNames mirrors defaultToolWrappers minus the "plk-" prefix.
+func defaultToolNames() []string {
+	out := make([]string, 0, len(defaultToolWrappers))
+	for _, w := range defaultToolWrappers {
+		out = append(out, strings.TrimPrefix(w, "plk-"))
+	}
+	return out
+}
+
+func defaultToolEntriesWithoutTargets() []toolsListEntry {
+	names := defaultToolNames()
+	out := make([]toolsListEntry, 0, len(names))
+	for _, name := range names {
+		out = append(out, toolsListEntry{name: name})
+	}
+	return out
+}
+
+func resolvableDefaultToolEntries(env *installEnv) []toolsListEntry {
+	names := defaultToolNames()
+	out := make([]toolsListEntry, 0, len(names))
+	for _, name := range names {
+		target, ok := resolveToolInAgentPath(env, name)
+		if ok {
+			out = append(out, toolsListEntry{name: name, target: target})
+		}
+	}
+	return out
+}
+
+func resolveToolInAgentPath(env *installEnv, name string) (string, bool) {
+	for _, dir := range filepath.SplitList(agentExecPath(env.agentUserName)) {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, name)
+		info, err := env.stat(candidate)
+		if err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0 {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+func mergeDefaultToolEntries(existing, defaults []toolsListEntry) ([]toolsListEntry, bool) {
+	defaultNames := make(map[string]bool, len(defaultToolWrappers))
+	for _, name := range defaultToolNames() {
+		defaultNames[name] = true
+	}
+	merged := make([]toolsListEntry, 0, len(existing)+len(defaults))
+	merged = append(merged, defaults...)
+	for _, e := range existing {
+		if defaultNames[e.name] {
+			continue
+		}
+		merged = append(merged, e)
+	}
+	return merged, !toolsListEntriesEqual(existing, merged)
+}
+
+// toolsListEntry is one row of /etc/pipelock/contain/tools.list.
+type toolsListEntry struct {
+	name   string
+	target string // empty = resolve via pipelock-agent PATH at runtime
+}
+
+// readToolsList parses the runtime allow-list. Unrecognized lines (blank,
+// comment, malformed) are silently skipped — the file is root-owned and
+// pre-validated by the install/add-tool path, so a malformed line at
+// runtime is a programmer error worth reporting via plk-launch's stderr
+// rather than blowing up the Go caller.
+func readToolsList(env *installEnv) ([]toolsListEntry, error) {
+	data, err := env.readFile(env.toolsListPath)
+	if err != nil {
+		return nil, err
+	}
+	return parseToolsList(data), nil
+}
+
+func parseToolsList(data []byte) []toolsListEntry {
+	var entries []toolsListEntry
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 2)
+		name := strings.TrimSpace(parts[0])
+		if name == "" {
+			continue
+		}
+		target := ""
+		if len(parts) == 2 {
+			target = strings.TrimSpace(parts[1])
+		}
+		entries = append(entries, toolsListEntry{name: name, target: target})
+	}
+	return entries
+}
+
+// writeToolsList renders entries back to disk preserving the header
+// comments produced by renderDefaultToolsList. Used by add-tool.
+func writeToolsList(env *installEnv, entries []toolsListEntry) error {
+	if err := env.mkdirAll(filepath.Dir(env.toolsListPath), modeDirTraversable); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(env.toolsListPath), err)
+	}
+	if err := env.chmod(filepath.Dir(env.toolsListPath), modeDirTraversable); err != nil {
+		return fmt.Errorf("chmod %s: %w", filepath.Dir(env.toolsListPath), err)
+	}
+	return backupAndWrite(env, env.toolsListPath, []byte(renderToolsList(entries)), modeAllowListReadable)
+}
+
+func renderToolsList(entries []toolsListEntry) string {
+	var b strings.Builder
+	b.WriteString("# Managed by `pipelock contain install / add-tool`. " +
+		"One tool per line, tab-separated NAME\\tTARGET.\n" +
+		"# Empty TARGET means: resolve via pipelock-agent's PATH at exec time.\n")
+	for _, e := range entries {
+		b.WriteString(e.name)
+		b.WriteByte('\t')
+		b.WriteString(e.target)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// upsertToolEntry inserts or updates a tool entry in the allow-list.
+// Returns (changed, error). When changed=false the file already contained
+// an identical entry; caller can short-circuit instead of rewriting.
+func upsertToolEntry(env *installEnv, name, target string) (bool, error) {
+	entries, err := readToolsList(env)
+	if err != nil {
+		// Missing file: start fresh with the defaults plus this entry.
+		if errors.Is(err, os.ErrNotExist) {
+			entries = nil
+		} else {
+			return false, fmt.Errorf("read tools.list: %w", err)
+		}
+	}
+	for i := range entries {
+		if entries[i].name == name {
+			if entries[i].target == target {
+				return false, nil
+			}
+			entries[i].target = target
+			return true, writeToolsList(env, entries)
+		}
+	}
+	entries = append(entries, toolsListEntry{name: name, target: target})
+	return true, writeToolsList(env, entries)
+}
+
+func toolsListEntriesEqual(a, b []toolsListEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: preflight
+// ---------------------------------------------------------------------------
+
+func stepPreflight(_ installOpts) step {
+	return step{
+		name: "preflight",
+		desc: "preflight: required binaries present (useradd / systemctl / nft / visudo)",
+		apply: func(_ context.Context, _ *installEnv) (bool, error) {
+			for _, b := range []string{"useradd", "userdel", "systemctl", "nft", "visudo"} {
+				if err := expectExec(b); err != nil {
+					return false, err
+				}
+			}
+			return true, nil
+		},
+		// Preflight is read-only. Nothing to undo.
+		undo: nil,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Step 2/3: create system users
+// ---------------------------------------------------------------------------
+
+// stepCreateUser builds a step that creates either pipelock-proxy or
+// pipelock-agent. proxyUser=true means we're creating the proxy user (no login
+// shell, /var/lib/pipelock-proxy home). Otherwise pipelock-agent (bash shell so
+// tools can resolve PATH/HOME, /home/pipelock-agent home).
+func stepCreateUser(proxyUser bool) step {
+	pick := func(env *installEnv) (name, shell, home string) {
+		if proxyUser {
+			return env.proxyUserName, "/usr/sbin/nologin", "/var/lib/" + env.proxyUserName
+		}
+		return env.agentUserName, "/bin/bash", "/home/" + env.agentUserName
+	}
+	return step{
+		name: func() string {
+			if proxyUser {
+				return "create-proxy-user"
+			}
+			return "create-agent-user"
+		}(),
+		desc: func() string {
+			if proxyUser {
+				return "create pipelock-proxy system user (no login shell)"
+			}
+			return "create pipelock-agent system user (bash shell, denied direct egress)"
+		}(),
+		apply: func(ctx context.Context, env *installEnv) (bool, error) {
+			name, shell, home := pick(env)
+			if _, err := env.lookupUser(name); err == nil {
+				return false, nil // already exists
+			} else if !errors.As(err, new(user.UnknownUserError)) {
+				return false, fmt.Errorf("user lookup %s: %w", name, err)
+			}
+			args := []string{
+				"--system",
+				"--shell", shell,
+				"--home-dir", home,
+				"--create-home",
+				"--user-group",
+				name,
+			}
+			return true, runOrErr(ctx, env, "useradd", args...)
+		},
+		undo: func(ctx context.Context, env *installEnv) error {
+			name, _, _ := pick(env)
+			if _, err := env.lookupUser(name); err != nil {
+				if errors.As(err, new(user.UnknownUserError)) {
+					return nil
+				}
+				return fmt.Errorf("user lookup %s: %w", name, err)
+			}
+			return runOrErr(ctx, env, "userdel", "-r", name)
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Step 4/5: create system dirs
+// ---------------------------------------------------------------------------
+
+func stepCreateDir(label string, pathFn func(*installEnv) string, mode os.FileMode) step {
+	return step{
+		name: "create-dir-" + label,
+		desc: "create " + label + " directory",
+		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			path := pathFn(env)
+			info, err := env.stat(path)
+			if err == nil {
+				if !info.IsDir() {
+					return false, fmt.Errorf("%s exists and is not a directory", path)
+				}
+				// Even if dir exists, ensure mode matches.
+				if err := env.chmod(path, mode); err != nil {
+					return false, fmt.Errorf("chmod %s: %w", path, err)
+				}
+				return false, nil
+			}
+			if !errors.Is(err, os.ErrNotExist) {
+				return false, fmt.Errorf("stat %s: %w", path, err)
+			}
+			if err := env.mkdirAll(path, mode); err != nil {
+				return false, fmt.Errorf("mkdir %s: %w", path, err)
+			}
+			if err := env.chmod(path, mode); err != nil {
+				return false, fmt.Errorf("chmod %s: %w", path, err)
+			}
+			return true, nil
+		},
+		undo: func(_ context.Context, env *installEnv) error {
+			path := pathFn(env)
+			// Only remove if it's empty AND we created it. We don't keep a
+			// flag; we just refuse to remove non-empty dirs to avoid losing
+			// operator data.
+			if err := env.removeFile(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return nil // best-effort; dir non-empty or in use
+			}
+			return nil
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Step 6: write pipelock.yaml
+// ---------------------------------------------------------------------------
+
+func stepWritePipelockConfig(opts installOpts) step {
+	const targetName = "pipelock.yaml"
+	var migrated []migratedConfigArtifact
+	var configWritten bool
+	return step{
+		name: "write-pipelock-config",
+		desc: "write /etc/pipelock/pipelock.yaml (from --config, with home-path migration)",
+		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			migrated = nil
+			configWritten = false
+			if opts.configSource == "" {
+				return false, nil
+			}
+			dst := filepath.Join(env.configDir, targetName)
+			data, err := env.readFile(opts.configSource)
+			if err != nil {
+				return false, fmt.Errorf("read --config %s: %w", opts.configSource, err)
+			}
+			data, migrated, err = migratePipelockConfigForContain(env, opts.configSource, data)
+			if err != nil {
+				_ = cleanupMigratedConfigArtifacts(env, migrated)
+				return false, err
+			}
+			// Compare with the existing config (if any). Identical -> skip
+			// silently. Different -> overwrite with .bak, and print a loud
+			// warning so an operator running install twice with different
+			// --config values is never silently misled about which one is
+			// live. The previous "skip if exists" behaviour hid that case.
+			if existing, err := env.readFile(dst); err == nil {
+				if bytesEqual(existing, data) {
+					return len(migrated) > 0, nil
+				}
+				_, _ = fmt.Fprintf(env.out,
+					"  WARN: --config %s differs from existing %s; overwriting (prior content saved to %s.bak)\n",
+					opts.configSource, dst, dst)
+			}
+			if err := backupAndWrite(env, dst, data, modeConfigSecret); err != nil {
+				_ = cleanupMigratedConfigArtifacts(env, migrated)
+				return false, err
+			}
+			configWritten = true
+			return true, nil
+		},
+		undo: func(_ context.Context, env *installEnv) error {
+			dst := filepath.Join(env.configDir, targetName)
+			var configErr error
+			if configWritten {
+				configErr = restoreBackup(env, dst)
+			}
+			return errors.Join(configErr, cleanupMigratedConfigArtifacts(env, migrated))
+		},
+	}
+}
+
+// bytesEqual compares two byte slices without dragging in the bytes
+// import for one call site. Equivalent to bytes.Equal.
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// Step 7/8: chown dirs to pipelock-proxy
+// ---------------------------------------------------------------------------
+
+func stepChownToProxy(label string, pathFn func(*installEnv) string) step {
+	return step{
+		name: "chown-" + label,
+		desc: "chown " + label + " directory to pipelock-proxy:pipelock-proxy",
+		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			path := pathFn(env)
+			uid, gid, err := uidGidFor(env, env.proxyUserName)
+			if err != nil {
+				return false, err
+			}
+			return true, walkAndChown(env, path, uid, gid)
+		},
+		// undo intentionally absent: chown back to root is safe and what
+		// removing /etc/pipelock on a follow-up rollback would do anyway.
+		undo: nil,
+	}
+}
+
+// walkAndChown chowns path and every descendant. Used because the runbook
+// runs `chown -R` and the install needs the same recursive ownership.
+func walkAndChown(env *installEnv, root string, uid, gid int) error {
+	return filepath.WalkDir(root, func(p string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if err := env.chown(p, uid, gid); err != nil {
+			return fmt.Errorf("chown %s: %w", p, err)
+		}
+		return nil
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Step 9: install pipelock binary
+// ---------------------------------------------------------------------------
+
+func stepInstallPipelockBinary() step {
+	return step{
+		name: "install-pipelock-binary",
+		desc: "install pipelock binary to /usr/local/bin/pipelock (0o755)",
+		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			data, err := env.readFile(env.pipelockBinary)
+			if err != nil {
+				return false, fmt.Errorf("read source binary: %w", err)
+			}
+
+			// Idempotency: if /usr/local/bin/pipelock exists AND its sha256
+			// matches the source, skip. This makes rerunning install over an
+			// up-to-date system a no-op.
+			if pathExists(env, env.pipelockTarget) {
+				srcHash, err := env.hashFile(env.pipelockBinary)
+				if err != nil {
+					return false, err
+				}
+				dstHash, err := env.hashFile(env.pipelockTarget)
+				if err == nil && srcHash == dstHash {
+					return false, nil
+				}
+			}
+			if err := backupAndWrite(env, env.pipelockTarget, data, modeWrapperExec); err != nil {
+				return false, err
+			}
+			return true, nil
+		},
+		undo: func(_ context.Context, env *installEnv) error {
+			return restoreBackup(env, env.pipelockTarget)
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Step 10: write integrity pin
+// ---------------------------------------------------------------------------
+
+func stepWriteIntegrityPin() step {
+	return step{
+		name: "write-integrity-pin",
+		desc: "pin installed binary SHA-256 (TOFU) to /etc/pipelock/integrity/binary-pin.sha256",
+		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			if !pathExists(env, env.pipelockTarget) {
+				return false, fmt.Errorf("pipelock binary not installed at %s", env.pipelockTarget)
+			}
+			if err := env.mkdirAll(env.integrityDir, modeDirSystem); err != nil {
+				return false, fmt.Errorf("mkdir %s: %w", env.integrityDir, err)
+			}
+			hash, err := env.hashFile(env.pipelockTarget)
+			if err != nil {
+				return false, err
+			}
+			contents := []byte(hash + "\n")
+
+			// Idempotency: if the pin already matches, skip.
+			if existing, err := env.readFile(env.integrityPin); err == nil {
+				if strings.TrimSpace(string(existing)) == hash {
+					if err := ensureIntegrityOwnership(env); err != nil {
+						return false, err
+					}
+					return false, nil
+				}
+			}
+			if err := backupAndWrite(env, env.integrityPin, contents, modePinSecret); err != nil {
+				return false, err
+			}
+			// Pin file ownership: pipelock-proxy owns the private
+			// integrity directory and pin. pipelock-agent cannot traverse it.
+			if err := ensureIntegrityOwnership(env); err != nil {
+				return false, err
+			}
+			return true, nil
+		},
+		undo: func(_ context.Context, env *installEnv) error {
+			return restoreBackup(env, env.integrityPin)
+		},
+	}
+}
+
+func ensureIntegrityOwnership(env *installEnv) error {
+	uid, gid, err := uidGidFor(env, env.proxyUserName)
+	if err != nil {
+		return err
+	}
+	if err := env.chmod(env.integrityDir, modeDirPrivate); err != nil {
+		return fmt.Errorf("chmod %s: %w", env.integrityDir, err)
+	}
+	if err := env.chown(env.integrityDir, uid, gid); err != nil {
+		return fmt.Errorf("chown %s: %w", env.integrityDir, err)
+	}
+	if err := env.chmod(env.integrityPin, modePinSecret); err != nil {
+		return fmt.Errorf("chmod %s: %w", env.integrityPin, err)
+	}
+	if err := env.chown(env.integrityPin, uid, gid); err != nil {
+		return fmt.Errorf("chown %s: %w", env.integrityPin, err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Step 11: stop the user-mode pipelock service
+// ---------------------------------------------------------------------------
+
+func stepStopUserService() step {
+	return step{
+		name: "stop-user-pipelock",
+		desc: "stop the operator's user-mode pipelock.service (if running)",
+		apply: func(ctx context.Context, env *installEnv) (bool, error) {
+			if env.operatorUser == "" {
+				return false, nil
+			}
+			// Best-effort: query is-active first; only stop if active.
+			out, _, _ := env.runCmd(ctx, "systemctl", "--user", "-M", env.operatorUser+"@.host", "is-active", "pipelock")
+			if strings.TrimSpace(out) != systemctlActive {
+				return false, nil
+			}
+			return true, runOrErr(ctx, env, "systemctl", "--user", "-M", env.operatorUser+"@.host", "disable", "--now", "pipelock")
+		},
+		// undo re-enables the user-mode service so a mid-install failure
+		// never leaves the operator with pipelock fully off. apply only
+		// returns true (and so undo only runs) when it actually stopped a
+		// running user service — meaning enable --now is safe and
+		// expected to succeed.
+		undo: func(ctx context.Context, env *installEnv) error {
+			if env.operatorUser == "" {
+				return nil
+			}
+			return runOrErr(ctx, env, "systemctl", "--user", "-M", env.operatorUser+"@.host", "enable", "--now", "pipelock")
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Step 12: write the system pipelock.service unit
+// ---------------------------------------------------------------------------
+
+func stepWriteSystemUnit() step {
+	return step{
+		name: "write-system-unit",
+		desc: "write /etc/systemd/system/pipelock.service",
+		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			body := renderSystemUnit(env)
+			// Idempotency: only write if content differs.
+			if existing, err := env.readFile(env.systemUnitPath); err == nil && string(existing) == body {
+				return false, nil
+			}
+			return true, backupAndWrite(env, env.systemUnitPath, []byte(body), modeUnitFile)
+		},
+		undo: func(_ context.Context, env *installEnv) error {
+			return restoreBackup(env, env.systemUnitPath)
+		},
+	}
+}
+
+// renderSystemUnit produces the pipelock.service body. Inline here so tests
+// can call it directly without a tmpdir. The hardening directives mirror
+// the runbook; the firewall is the real boundary, these are defense in
+// depth.
+func renderSystemUnit(env *installEnv) string {
+	configPath := filepath.Join(env.configDir, "pipelock.yaml")
+	capturePath := filepath.Join(env.dataDir, "captures")
+	return strings.Join([]string{
+		"[Unit]",
+		"Description=Pipelock AI Egress Proxy",
+		"Documentation=https://github.com/luckyPipewrench/pipelock",
+		"After=network-online.target",
+		"Wants=network-online.target",
+		"",
+		"[Service]",
+		"Type=simple",
+		"User=" + env.proxyUserName,
+		"Group=" + env.proxyUserName,
+		"ExecStart=" + env.pipelockTarget + " run --config " + configPath + " --capture-output " + capturePath,
+		"Restart=on-failure",
+		"RestartSec=5",
+		"",
+		"NoNewPrivileges=true",
+		"ProtectSystem=strict",
+		"ProtectHome=true",
+		"ReadWritePaths=" + env.dataDir,
+		"PrivateTmp=true",
+		"ProtectKernelTunables=true",
+		"ProtectKernelModules=true",
+		"ProtectControlGroups=true",
+		"RestrictNamespaces=true",
+		"LockPersonality=true",
+		"MemoryDenyWriteExecute=true",
+		"RestrictRealtime=true",
+		"RestrictSUIDSGID=true",
+		"",
+		"[Install]",
+		"WantedBy=multi-user.target",
+		"",
+	}, "\n")
+}
+
+// ---------------------------------------------------------------------------
+// Step 13: daemon-reload + enable --now
+// ---------------------------------------------------------------------------
+
+func stepEnableSystemUnit() step {
+	return step{
+		name: "enable-system-pipelock",
+		desc: "systemctl daemon-reload + enable --now pipelock.service",
+		apply: func(ctx context.Context, env *installEnv) (bool, error) {
+			if err := runOrErr(ctx, env, "systemctl", "daemon-reload"); err != nil {
+				return false, err
+			}
+			activeOut, _, _ := env.runCmd(ctx, "systemctl", "is-active", "pipelock")
+			enabledOut, _, _ := env.runCmd(ctx, "systemctl", "is-enabled", "pipelock")
+			if strings.TrimSpace(activeOut) == systemctlActive && strings.TrimSpace(enabledOut) == systemctlEnabled {
+				// Re-issuing enable when already enabled is a no-op anyway,
+				// but skip to keep the dry-run/run output clean.
+				return false, nil
+			}
+			return true, runOrErr(ctx, env, "systemctl", "enable", "--now", "pipelock")
+		},
+		undo: func(ctx context.Context, env *installEnv) error {
+			// Best-effort: disable and stop. If the unit file was removed
+			// already by a sibling undo, systemctl reports an error we can
+			// safely ignore.
+			_, _, _ = env.runCmd(ctx, "systemctl", "disable", "--now", "pipelock")
+			_, _, _ = env.runCmd(ctx, "systemctl", "daemon-reload")
+			return nil
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Step 14: export pipelock TLS CA
+// ---------------------------------------------------------------------------
+
+func stepExportPipelockCA() step {
+	return step{
+		name: "export-pipelock-ca",
+		desc: "export pipelock TLS-MITM CA to /etc/pipelock/ca.pem",
+		apply: func(ctx context.Context, env *installEnv) (bool, error) {
+			if pathExists(env, env.caExportPath) {
+				return false, nil
+			}
+			// Run as pipelock-proxy so the CA lookup uses the running
+			// instance's data dir layout. The pipelock CLI writes the CA
+			// PEM to stdout via `tls show-ca` — there is no --output flag,
+			// so we capture stdout here and write the file in Go after a
+			// PEM-shape sanity check.
+			if err := exportPipelockCA(ctx, env); err != nil {
+				return false, err
+			}
+			return true, nil
+		},
+		undo: func(_ context.Context, env *installEnv) error {
+			if err := env.removeFile(env.caExportPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove %s: %w", env.caExportPath, err)
+			}
+			return nil
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Step 15: write /etc/pipelock/combined-ca.pem
+// ---------------------------------------------------------------------------
+
+func stepWriteCombinedCABundle() step {
+	return step{
+		name: "write-combined-ca",
+		desc: "build /etc/pipelock/combined-ca.pem (system bundle + pipelock CA)",
+		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			sys, err := env.readFile(defaultSystemCABundle)
+			if err != nil {
+				return false, fmt.Errorf("read system CA bundle %s: %w", defaultSystemCABundle, err)
+			}
+			pl, err := env.readFile(env.caExportPath)
+			if err != nil {
+				return false, fmt.Errorf("read pipelock CA %s: %w", env.caExportPath, err)
+			}
+			bundle := append([]byte{}, sys...)
+			if len(bundle) > 0 && bundle[len(bundle)-1] != '\n' {
+				bundle = append(bundle, '\n')
+			}
+			bundle = append(bundle, pl...)
+
+			if existing, err := env.readFile(env.caBundlePath); err == nil && string(existing) == string(bundle) {
+				return false, nil
+			}
+			return true, backupAndWrite(env, env.caBundlePath, bundle, modeCAReadable)
+		},
+		undo: func(_ context.Context, env *installEnv) error {
+			return restoreBackup(env, env.caBundlePath)
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Step 16: nftables rules (write + validate + load + enable service)
+// ---------------------------------------------------------------------------
+
+func stepInstallNFTRules() step {
+	return step{
+		name: "install-nft-rules",
+		desc: "write + load /etc/nftables.d/50-pipelock-containment.nft + persist via nftables.service",
+		apply: func(ctx context.Context, env *installEnv) (bool, error) {
+			operatorUID, err := operatorUIDFromEnv(env)
+			if err != nil {
+				return false, err
+			}
+			proxyUID, agentUID, err := resolveUIDs(env)
+			if err != nil {
+				return false, err
+			}
+			body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, env.nftTableOrDefault(), env.nftChainOrDefault())
+
+			rulesMatch := false
+			if existing, err := env.readFile(env.nftRulesPath); err == nil {
+				rulesMatch = string(existing) == body
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return false, fmt.Errorf("read %s: %w", env.nftRulesPath, err)
+			}
+			tableLoaded := false
+			liveRulesDrifted := false
+			if out, code, _ := env.runCmd(ctx, "nft", "list", "table", "inet", env.nftTableOrDefault()); code == 0 {
+				tableLoaded = true
+				liveRulesDrifted = !liveNFTContainmentMatches(out, env.nftChainOrDefault(), env.proxyPort)
+			}
+
+			rulesChanged := false
+			if !rulesMatch {
+				if err := env.mkdirAll(filepath.Dir(env.nftRulesPath), modeDirReadable); err != nil {
+					return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(env.nftRulesPath), err)
+				}
+				if err := env.chmod(filepath.Dir(env.nftRulesPath), modeDirReadable); err != nil {
+					return false, fmt.Errorf("chmod %s: %w", filepath.Dir(env.nftRulesPath), err)
+				}
+				if err := backupAndWrite(env, env.nftRulesPath, []byte(body), modeNFTFile); err != nil {
+					return false, err
+				}
+				rulesChanged = true
+			}
+			mainChanged, err := ensureNFTMainIncludesRules(env)
+			if err != nil {
+				return false, err
+			}
+			if mainChanged {
+				_, _ = fmt.Fprintf(env.out, "WARN: added %s include to %s for nftables.service persistence\n", env.nftRulesPath, env.nftMainPath)
+			}
+			if !rulesChanged && !mainChanged && tableLoaded && !liveRulesDrifted {
+				return false, nil
+			}
+			// Validate before loading.
+			if err := runOrErr(ctx, env, "nft", "-c", "-f", env.nftRulesPath); err != nil {
+				return false, fmt.Errorf("nft validation failed: %w", err)
+			}
+			if err := runOrErr(ctx, env, "nft", "-c", "-f", env.nftMainPath); err != nil {
+				return false, fmt.Errorf("nft persistence validation failed: %w", err)
+			}
+			if tableLoaded && (rulesChanged || liveRulesDrifted) {
+				// nft -f merges into an existing table. Drop our managed table
+				// first so stale rules from an older contain install cannot
+				// survive beside the new ruleset.
+				_, _, _ = env.runCmd(ctx, "nft", "delete", "table", "inet", env.nftTableOrDefault())
+				tableLoaded = false
+			}
+			if !tableLoaded || rulesChanged || liveRulesDrifted {
+				if err := runOrErr(ctx, env, "nft", "-f", env.nftRulesPath); err != nil {
+					return false, fmt.Errorf("nft load failed: %w", err)
+				}
+			}
+			if err := runOrErr(ctx, env, "systemctl", "enable", "nftables.service"); err != nil {
+				return false, fmt.Errorf("enable nftables.service: %w", err)
+			}
+			return true, nil
+		},
+		undo: func(ctx context.Context, env *installEnv) error {
+			// Drop the table best-effort, then remove the file, then leave
+			// nftables.service alone (it may have been enabled before).
+			_, _, _ = env.runCmd(ctx, "nft", "delete", "table", "inet", env.nftTableOrDefault())
+			if err := restoreBackup(env, env.nftRulesPath); err != nil {
+				return err
+			}
+			return restoreOrRemoveNFTMainInclude(env)
+		},
+	}
+}
+
+func liveNFTContainmentMatches(out, chainName string, proxyPort int) bool {
+	return chainHasSkuidDrop(out, chainName) &&
+		chainHasAgentProxyLoopbackAllow(out, chainName, proxyPort) &&
+		!chainHasBroadLoopbackAccept(out, chainName)
+}
+
+func nftRulesIncludeLine(path string) string {
+	return fmt.Sprintf("include %q", path)
+}
+
+func ensureNFTMainIncludesRules(env *installEnv) (bool, error) {
+	if err := env.mkdirAll(filepath.Dir(env.nftMainPath), modeDirReadable); err != nil {
+		return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(env.nftMainPath), err)
+	}
+	if err := env.chmod(filepath.Dir(env.nftMainPath), modeDirReadable); err != nil {
+		return false, fmt.Errorf("chmod %s: %w", filepath.Dir(env.nftMainPath), err)
+	}
+
+	includeLine := nftRulesIncludeLine(env.nftRulesPath)
+	data, err := env.readFile(env.nftMainPath)
+	if err == nil && nftMainHasInclude(string(data), includeLine) {
+		return false, nil
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("read %s: %w", env.nftMainPath, err)
+	}
+
+	var body string
+	if errors.Is(err, os.ErrNotExist) || len(data) == 0 {
+		body = "# Pipelock containment persistence\n" + includeLine + "\n"
+	} else {
+		body = strings.TrimRight(string(data), "\n") + "\n\n# Pipelock containment persistence\n" + includeLine + "\n"
+	}
+	if err := backupAndWrite(env, env.nftMainPath, []byte(body), modeNFTMainConfig); err != nil {
+		return false, fmt.Errorf("write %s: %w", env.nftMainPath, err)
+	}
+	return true, nil
+}
+
+func nftMainHasInclude(body, includeLine string) bool {
+	for _, line := range strings.Split(body, "\n") {
+		if strings.TrimSpace(line) == includeLine {
+			return true
+		}
+	}
+	return false
+}
+
+func restoreOrRemoveNFTMainInclude(env *installEnv) error {
+	bak := env.nftMainPath + ".bak"
+	if _, err := env.stat(bak); err == nil {
+		return restoreBackupIfPresent(env, env.nftMainPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat %s: %w", bak, err)
+	}
+	return removeNFTMainInclude(env)
+}
+
+func removeNFTMainInclude(env *installEnv) error {
+	data, err := env.readFile(env.nftMainPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", env.nftMainPath, err)
+	}
+	includeLine := nftRulesIncludeLine(env.nftRulesPath)
+	lines := strings.Split(string(data), "\n")
+	kept := lines[:0]
+	changed := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == includeLine {
+			changed = true
+			if len(kept) > 0 && strings.TrimSpace(kept[len(kept)-1]) == "# Pipelock containment persistence" {
+				kept = kept[:len(kept)-1]
+			}
+			continue
+		}
+		if trimmed == "# Pipelock containment persistence" && i+1 < len(lines) && strings.TrimSpace(lines[i+1]) == includeLine {
+			changed = true
+			continue
+		}
+		kept = append(kept, line)
+	}
+	if !changed {
+		return nil
+	}
+	body := strings.TrimRight(strings.Join(kept, "\n"), "\n")
+	if body != "" {
+		body += "\n"
+	}
+	return env.writeFile(env.nftMainPath, []byte(body), modeNFTMainConfig)
+}
+
+// nftTableOrDefault returns the configured nft table or the package
+// default. Helper makes tests easier to read.
+func (e *installEnv) nftTableOrDefault() string {
+	return defaultNFTTable
+}
+
+func (e *installEnv) nftChainOrDefault() string {
+	return defaultNFTChain
+}
+
+// operatorUIDFromEnv returns the numeric UID for the operator-side user.
+func operatorUIDFromEnv(env *installEnv) (int, error) {
+	if env.operatorUser == "" {
+		return 0, errors.New("operator user not set")
+	}
+	u, err := env.lookupUser(env.operatorUser)
+	if err != nil {
+		return 0, fmt.Errorf("lookup operator user %s: %w", env.operatorUser, err)
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return 0, fmt.Errorf("parse uid for %s: %w", env.operatorUser, err)
+	}
+	return uid, nil
+}
+
+// renderNFTRules emits the table definition. Matches the runbook one-to-one
+// with concrete UIDs interpolated.
+func renderNFTRules(operatorUID, proxyUID, agentUID, proxyPort int, table, chain string) string {
+	return fmt.Sprintf(`# Pipelock containment ruleset (managed by pipelock contain install).
+	# operator=%d  pipelock-proxy=%d  pipelock-agent=%d  proxy-port=%d
+	table inet %s {
+	    chain %s {
+	        type filter hook output priority filter; policy accept;
+
+	        meta skuid %d accept
+	        meta skuid %d accept
+
+	        meta skuid %d ip daddr 127.0.0.1 tcp dport %d accept
+	        meta skuid %d drop
+	    }
+	}
+	`, operatorUID, proxyUID, agentUID, proxyPort, table, chain,
+		operatorUID, proxyUID, agentUID, proxyPort, agentUID)
+}
+
+// ---------------------------------------------------------------------------
+// Step 17: write plk-launch
+// ---------------------------------------------------------------------------
+
+func stepWriteLaunchWrapper() step {
+	return step{
+		name: "write-plk-launch",
+		desc: "write /usr/local/bin/plk-launch (runs AS pipelock-agent with proxy env)",
+		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			body := renderLaunchWrapper(env)
+			path := filepath.Join(env.wrapperDir, "plk-launch")
+			if existing, err := env.readFile(path); err == nil && string(existing) == body {
+				_ = env.chmod(path, modeWrapperExec)
+				return false, nil
+			}
+			if err := backupAndWrite(env, path, []byte(body), modeWrapperExec); err != nil {
+				return false, err
+			}
+			return true, nil
+		},
+		undo: func(_ context.Context, env *installEnv) error {
+			path := filepath.Join(env.wrapperDir, "plk-launch")
+			return restoreBackup(env, path)
+		},
+	}
+}
+
+// renderLaunchWrapper emits the plk-launch script body. plk-launch reads
+// the runtime allow-list at /etc/pipelock/contain/tools.list and refuses
+// to exec any tool that isn't in it. The allow-list itself is root-owned
+// but pipelock-agent-readable; root-owned directory permissions gate mutation,
+// so plk-launch's tool argument can be operator-controlled without
+// granting arbitrary command execution as pipelock-agent.
+//
+// Per the locked sudo-shape decision: per-tool wrappers do the outer
+// sudo, plk-launch already runs AS pipelock-agent, no nested sudo here.
+func renderLaunchWrapper(env *installEnv) string {
+	port := strconv.Itoa(env.proxyPort)
+	proxy := "http://127.0.0.1:" + port
+	return strings.Join([]string{
+		"#!/bin/bash",
+		"# Managed by `pipelock contain install`. Edits are clobbered on next install.",
+		"# Runs AS pipelock-agent. Validates the tool name against the install-time",
+		"# allow-list (root-mutated, pipelock-agent-readable at " + env.toolsListPath + ") before exec.",
+		"set -euo pipefail",
+		"",
+		"TOOLS_LIST=" + shellQuote(env.toolsListPath),
+		"",
+		`if [[ $# -lt 1 ]]; then`,
+		`    echo "usage: plk-launch <tool> [args...]" >&2`,
+		`    exit 2`,
+		`fi`,
+		`TOOL="$1"; shift`,
+		"",
+		`# Reject tool names with shell metacharacters or path separators up`,
+		`# front. The install-time regex is tighter; this is defense in depth.`,
+		`case "$TOOL" in`,
+		`    *[!a-z0-9_-]*|"") echo "plk-launch: invalid tool name $TOOL" >&2; exit 3 ;;`,
+		`esac`,
+		"",
+		`if [[ ! -r "$TOOLS_LIST" ]]; then`,
+		`    echo "plk-launch: missing allow-list at $TOOLS_LIST (run pipelock contain install)" >&2`,
+		`    exit 4`,
+		`fi`,
+		"",
+		`# Look up the tool in the allow-list. The file format is one entry`,
+		`# per line, tab-separated NAME\tTARGET. Empty TARGET means "resolve`,
+		`# at runtime via the pipelock-agent PATH".`,
+		`TARGET=""`,
+		`FOUND=0`,
+		`while IFS=$'\t' read -r name target; do`,
+		`    case "$name" in ''|'#'*) continue ;; esac`,
+		`    if [[ "$name" == "$TOOL" ]]; then`,
+		`        TARGET="$target"`,
+		`        FOUND=1`,
+		`        break`,
+		`    fi`,
+		`done < "$TOOLS_LIST"`,
+		"",
+		`if (( FOUND == 0 )); then`,
+		`    echo "plk-launch: tool $TOOL not in pipelock contain allow-list" >&2`,
+		`    exit 5`,
+		`fi`,
+		"",
+		`# Resolve target. If tools.list baked in an absolute path, use it.`,
+		`# Otherwise look up the binary in the SAME PATH we will exec under,`,
+		`# not the wrapper process's inherited PATH — sudo's secure_path or`,
+		`# the caller's environment would otherwise leak through.`,
+		"AGENT_PATH=" + agentExecPath(env.agentUserName),
+		`if [[ -z "$TARGET" ]]; then`,
+		`    TARGET="$(PATH="$AGENT_PATH" command -v "$TOOL")" || {`,
+		`        echo "plk-launch: $TOOL not found in pipelock-agent PATH" >&2`,
+		`        exit 6`,
+		`    }`,
+		`fi`,
+		`if [[ "$TARGET" != /* ]]; then`,
+		`    echo "plk-launch: refusing non-absolute target $TARGET for $TOOL" >&2`,
+		`    exit 7`,
+		`fi`,
+		`if [[ ! -x "$TARGET" ]]; then`,
+		`    echo "plk-launch: target $TARGET for $TOOL is not executable" >&2`,
+		`    exit 8`,
+		`fi`,
+		"",
+		"exec env \\",
+		"    HOME=/home/" + env.agentUserName + " \\",
+		"    HTTPS_PROXY=" + proxy + " \\",
+		"    HTTP_PROXY=" + proxy + " \\",
+		"    ALL_PROXY=" + proxy + " \\",
+		"    NO_PROXY=127.0.0.1,localhost \\",
+		"    NODE_EXTRA_CA_CERTS=" + env.caExportPath + " \\",
+		"    SSL_CERT_FILE=" + env.caBundlePath + " \\",
+		"    REQUESTS_CA_BUNDLE=" + env.caBundlePath + " \\",
+		"    CURL_CA_BUNDLE=" + env.caBundlePath + " \\",
+		`    PATH="$AGENT_PATH" \`,
+		`    "$TARGET" "$@"`,
+		"",
+	}, "\n")
+}
+
+// shellQuote single-quotes a string for safe inclusion in a bash literal.
+// Escapes embedded single quotes. The tools-list path comes from an
+// installEnv field controlled by the operator (--config / defaults), not
+// from agent input, but quoting it makes the rendered script robust to
+// future refactors.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// ---------------------------------------------------------------------------
+// Step 18: write per-tool wrappers for allow-listed tools.
+// ---------------------------------------------------------------------------
+
+func stepWriteToolWrappers() step {
+	var touched []string
+	return step{
+		name: "write-tool-wrappers",
+		desc: "write plk-* wrappers for allow-listed tools",
+		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			touched = nil
+			restoreTouched := func(cause error) (bool, error) {
+				var errs []error
+				errs = append(errs, cause)
+				for i := len(touched) - 1; i >= 0; i-- {
+					if err := restoreBackup(env, touched[i]); err != nil {
+						errs = append(errs, err)
+					}
+				}
+				return false, errors.Join(errs...)
+			}
+			entries, err := readToolsList(env)
+			if err != nil {
+				return false, fmt.Errorf("read tools.list: %w", err)
+			}
+			desired := wrapperNamesForEntries(entries)
+			desiredSet := make(map[string]bool, len(desired))
+			for _, wrapper := range desired {
+				desiredSet[wrapper] = true
+				name := strings.TrimPrefix(wrapper, "plk-")
+				path := filepath.Join(env.wrapperDir, wrapper)
+				body := renderToolWrapper(env, name)
+				if existing, err := env.readFile(path); err == nil && string(existing) == body {
+					_ = env.chmod(path, modeWrapperExec)
+					continue
+				}
+				if err := backupAndWrite(env, path, []byte(body), modeWrapperExec); err != nil {
+					return restoreTouched(fmt.Errorf("write %s: %w", path, err))
+				}
+				touched = append(touched, path)
+			}
+			for _, wrapper := range defaultToolWrappers {
+				if desiredSet[wrapper] {
+					continue
+				}
+				path := filepath.Join(env.wrapperDir, wrapper)
+				if _, err := env.stat(path); err == nil {
+					if err := env.rename(path, path+".bak"); err != nil {
+						return restoreTouched(fmt.Errorf("backup stale wrapper %s: %w", path, err))
+					}
+					touched = append(touched, path)
+				} else if !errors.Is(err, os.ErrNotExist) {
+					return restoreTouched(fmt.Errorf("stat stale wrapper %s: %w", path, err))
+				}
+			}
+			return len(touched) > 0, nil
+		},
+		undo: func(_ context.Context, env *installEnv) error {
+			var errs []error
+			for i := len(touched) - 1; i >= 0; i-- {
+				path := touched[i]
+				if err := restoreBackup(env, path); err != nil {
+					errs = append(errs, err)
+				}
+			}
+			return errors.Join(errs...)
+		},
+	}
+}
+
+func wrapperNamesForEntries(entries []toolsListEntry) []string {
+	out := make([]string, 0, len(entries))
+	seen := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		wrapper := "plk-" + entry.name
+		if seen[wrapper] {
+			continue
+		}
+		seen[wrapper] = true
+		out = append(out, wrapper)
+	}
+	return out
+}
+
+// renderToolWrapper emits a per-tool wrapper that does the outer sudo so
+// the operator just types `plk-claude foo` instead of `sudo plk-launch claude foo`.
+// `-n` (non-interactive) makes the wrapper fail fast if the sudoers rule
+// does not match instead of hanging on a password prompt — the rule we
+// install is NOPASSWD-scoped so the legitimate case never prompts.
+func renderToolWrapper(env *installEnv, tool string) string {
+	return strings.Join([]string{
+		"#!/bin/bash",
+		"# Managed by `pipelock contain install`. Edits are clobbered on next install.",
+		"exec sudo -n -u " + env.agentUserName + " " + filepath.Join(env.wrapperDir, "plk-launch") + " " + tool + ` "$@"`,
+		"",
+	}, "\n")
+}
+
+// ---------------------------------------------------------------------------
+// Step 19: write wrapper inventory (so verify probe 4 can enumerate)
+// ---------------------------------------------------------------------------
+
+type wrapperInventory struct {
+	Wrappers []string `json:"wrappers"`
+}
+
+func stepWriteWrapperInventory() step {
+	return step{
+		name: "write-wrapper-inventory",
+		desc: "record wrapper inventory in /etc/pipelock/contain/wrappers.json",
+		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			// Parent dir must be traversable by pipelock-agent (shared with
+			// tools.list). The file itself is pipelock-agent-readable so verify
+			// probe 4 can enumerate wrappers under unprivileged invocation.
+			if err := env.mkdirAll(filepath.Dir(env.wrapperInvPath), modeDirTraversable); err != nil {
+				return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(env.wrapperInvPath), err)
+			}
+			if err := env.chmod(filepath.Dir(env.wrapperInvPath), modeDirTraversable); err != nil {
+				return false, fmt.Errorf("chmod %s: %w", filepath.Dir(env.wrapperInvPath), err)
+			}
+			entries, err := readToolsList(env)
+			if err != nil {
+				return false, fmt.Errorf("read tools.list: %w", err)
+			}
+			desired := wrapperNamesForEntries(entries)
+			data, err := env.readFile(env.wrapperInvPath)
+			if err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					return false, fmt.Errorf("read wrapper inventory: %w", err)
+				}
+				out, err := marshalWrapperInventory(wrapperInventory{Wrappers: desired})
+				if err != nil {
+					return false, err
+				}
+				return true, backupAndWrite(env, env.wrapperInvPath, out, modeAllowListReadable)
+			}
+			var inv wrapperInventory
+			if err := json.Unmarshal(data, &inv); err != nil {
+				return false, fmt.Errorf("parse wrapper inventory: %w", err)
+			}
+			if stringSlicesEqual(inv.Wrappers, desired) {
+				return false, nil
+			}
+			out, err := marshalWrapperInventory(wrapperInventory{Wrappers: desired})
+			if err != nil {
+				return false, err
+			}
+			return true, backupAndWrite(env, env.wrapperInvPath, out, modeAllowListReadable)
+		},
+		undo: func(_ context.Context, env *installEnv) error {
+			return restoreBackup(env, env.wrapperInvPath)
+		},
+	}
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func marshalWrapperInventory(inv wrapperInventory) ([]byte, error) {
+	data, err := json.MarshalIndent(inv, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal wrapper inventory: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+// ---------------------------------------------------------------------------
+// Step 20: sudoers entry
+// ---------------------------------------------------------------------------
+
+func stepInstallSudoers() step {
+	return step{
+		name: "install-sudoers",
+		desc: "write /etc/sudoers.d/50-pipelock-agent (validated with visudo -c)",
+		apply: func(ctx context.Context, env *installEnv) (bool, error) {
+			body := renderSudoers(env)
+			if existing, err := env.readFile(env.sudoersPath); err == nil && string(existing) == body {
+				_ = env.chmod(env.sudoersPath, modeSudoers)
+				return false, nil
+			}
+			if err := backupAndWrite(env, env.sudoersPath, []byte(body), modeSudoers); err != nil {
+				return false, err
+			}
+			if err := runOrErr(ctx, env, "visudo", "-cf", env.sudoersPath); err != nil {
+				// Roll back inside the step so a malformed sudoers never
+				// ends up loaded. The orchestrator would also undo, but
+				// removing the bad file ourselves is cheaper and clearer.
+				_ = restoreBackup(env, env.sudoersPath)
+				return false, fmt.Errorf("visudo rejected new sudoers: %w", err)
+			}
+			return true, nil
+		},
+		undo: func(_ context.Context, env *installEnv) error {
+			return restoreBackup(env, env.sudoersPath)
+		},
+	}
+}
+
+// renderSudoers builds the sudoers entry. Scoped to the launcher path so
+// the operator can run plk-* wrappers without prompting, but the rule does
+// NOT grant general-purpose sudo to pipelock-agent.
+func renderSudoers(env *installEnv) string {
+	launcher := filepath.Join(env.wrapperDir, "plk-launch")
+	return fmt.Sprintf(
+		"# Managed by `pipelock contain install`. Do not edit by hand.\n%s ALL=(%s) NOPASSWD: %s *\n",
+		env.operatorUser, env.agentUserName, launcher,
+	)
+}

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -401,7 +401,7 @@ func upsertToolEntry(env *installEnv, name, target string) (bool, error) {
 	if err != nil {
 		// Missing file: start fresh with the defaults plus this entry.
 		if errors.Is(err, os.ErrNotExist) {
-			entries = nil
+			entries = resolvableDefaultToolEntries(env)
 		} else {
 			return false, fmt.Errorf("read tools.list: %w", err)
 		}
@@ -787,6 +787,7 @@ func ensureIntegrityOwnership(env *installEnv) error {
 // ---------------------------------------------------------------------------
 
 func stepStopUserService() step {
+	var stopped bool
 	return step{
 		name: "stop-user-pipelock",
 		desc: "stop the operator's user-mode pipelock.service (if running)",
@@ -799,18 +800,20 @@ func stepStopUserService() step {
 			if strings.TrimSpace(out) != systemctlActive {
 				return false, nil
 			}
-			return true, runOrErr(ctx, env, "systemctl", "--user", "-M", env.operatorUser+"@.host", "disable", "--now", "pipelock")
+			if err := runOrErr(ctx, env, "systemctl", "--user", "-M", env.operatorUser+"@.host", "stop", "pipelock"); err != nil {
+				return true, err
+			}
+			stopped = true
+			return true, nil
 		},
-		// undo re-enables the user-mode service so a mid-install failure
-		// never leaves the operator with pipelock fully off. apply only
-		// returns true (and so undo only runs) when it actually stopped a
-		// running user service — meaning enable --now is safe and
-		// expected to succeed.
+		// undo restarts only when this install attempt actually stopped
+		// the operator service. It deliberately does not enable/disable
+		// the unit, preserving the operator's previous enablement state.
 		undo: func(ctx context.Context, env *installEnv) error {
-			if env.operatorUser == "" {
+			if env.operatorUser == "" || !stopped {
 				return nil
 			}
-			return runOrErr(ctx, env, "systemctl", "--user", "-M", env.operatorUser+"@.host", "enable", "--now", "pipelock")
+			return runOrErr(ctx, env, "systemctl", "--user", "-M", env.operatorUser+"@.host", "start", "pipelock")
 		},
 	}
 }
@@ -831,8 +834,12 @@ func stepWriteSystemUnit() step {
 			}
 			return true, backupAndWrite(env, env.systemUnitPath, []byte(body), modeUnitFile)
 		},
-		undo: func(_ context.Context, env *installEnv) error {
-			return restoreBackup(env, env.systemUnitPath)
+		undo: func(ctx context.Context, env *installEnv) error {
+			if err := restoreBackup(env, env.systemUnitPath); err != nil {
+				return err
+			}
+			_, _, _ = env.runCmd(ctx, "systemctl", "daemon-reload")
+			return nil
 		},
 	}
 }
@@ -884,6 +891,9 @@ func renderSystemUnit(env *installEnv) string {
 // ---------------------------------------------------------------------------
 
 func stepEnableSystemUnit() step {
+	var preStateKnown bool
+	var wasActive bool
+	var wasEnabled bool
 	return step{
 		name: "enable-system-pipelock",
 		desc: "systemctl daemon-reload + enable --now pipelock.service",
@@ -893,7 +903,10 @@ func stepEnableSystemUnit() step {
 			}
 			activeOut, _, _ := env.runCmd(ctx, "systemctl", "is-active", "pipelock")
 			enabledOut, _, _ := env.runCmd(ctx, "systemctl", "is-enabled", "pipelock")
-			if strings.TrimSpace(activeOut) == systemctlActive && strings.TrimSpace(enabledOut) == systemctlEnabled {
+			wasActive = strings.TrimSpace(activeOut) == systemctlActive
+			wasEnabled = strings.TrimSpace(enabledOut) == systemctlEnabled
+			preStateKnown = true
+			if wasActive && wasEnabled {
 				// Re-issuing enable when already enabled is a no-op anyway,
 				// but skip to keep the dry-run/run output clean.
 				return false, nil
@@ -901,10 +914,19 @@ func stepEnableSystemUnit() step {
 			return true, runOrErr(ctx, env, "systemctl", "enable", "--now", "pipelock")
 		},
 		undo: func(ctx context.Context, env *installEnv) error {
-			// Best-effort: disable and stop. If the unit file was removed
-			// already by a sibling undo, systemctl reports an error we can
-			// safely ignore.
-			_, _, _ = env.runCmd(ctx, "systemctl", "disable", "--now", "pipelock")
+			if !preStateKnown {
+				// Explicit rollback command path: no apply pre-state exists,
+				// so remove the containment-managed system service.
+				_, _, _ = env.runCmd(ctx, "systemctl", "disable", "--now", "pipelock")
+				_, _, _ = env.runCmd(ctx, "systemctl", "daemon-reload")
+				return nil
+			}
+			if !wasEnabled {
+				_, _, _ = env.runCmd(ctx, "systemctl", "disable", "pipelock")
+			}
+			if !wasActive {
+				_, _, _ = env.runCmd(ctx, "systemctl", "stop", "pipelock")
+			}
 			_, _, _ = env.runCmd(ctx, "systemctl", "daemon-reload")
 			return nil
 		},

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -125,6 +125,7 @@ func runInstall(ctx context.Context, env *installEnv, opts installOpts) error {
 		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("lookup operator user %s: %w", env.operatorUser, err))
 	}
 	if opts.configSource != "" {
+		opts.configSource = filepath.Clean(opts.configSource)
 		if info, err := env.stat(opts.configSource); err != nil {
 			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("--config %q: %w", opts.configSource, err))
 		} else if info.IsDir() {
@@ -140,7 +141,9 @@ func runInstall(ctx context.Context, env *installEnv, opts installOpts) error {
 		if err != nil {
 			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("locate pipelock binary: %w", err))
 		}
-		env.pipelockBinary = self
+		env.pipelockBinary = filepath.Clean(self)
+	} else {
+		env.pipelockBinary = filepath.Clean(env.pipelockBinary)
 	}
 	if info, err := env.stat(env.pipelockBinary); err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("--pipelock-binary %q: %w", env.pipelockBinary, err))
@@ -649,9 +652,18 @@ func stepChownToProxy(label string, pathFn func(*installEnv) string) step {
 // walkAndChown chowns path and every descendant. Used because the runbook
 // runs `chown -R` and the install needs the same recursive ownership.
 func walkAndChown(env *installEnv, root string, uid, gid int) error {
-	return filepath.WalkDir(root, func(p string, _ os.DirEntry, err error) error {
+	root = filepath.Clean(root)
+	return filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return fmt.Errorf("walk %s: %w", p, err)
+		}
+		p = filepath.Clean(p)
+		rel, err := filepath.Rel(root, p)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return fmt.Errorf("refusing to chown path outside %s: %s", root, p)
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
 		}
 		if err := env.chown(p, uid, gid); err != nil {
 			return fmt.Errorf("chown %s: %w", p, err)

--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -231,14 +231,14 @@ func TestStepStopUserService_StopsWhenActive(t *testing.T) {
 	if !applied {
 		t.Errorf("expected applied=true when active")
 	}
-	var sawDisable bool
+	var sawStop bool
 	for _, c := range runner.calls {
-		if c.name == testSystemctl && containsArg(c.args, "disable") {
-			sawDisable = true
+		if c.name == testSystemctl && containsArg(c.args, "stop") {
+			sawStop = true
 		}
 	}
-	if !sawDisable {
-		t.Errorf("expected systemctl disable, got %v", runner.calls)
+	if !sawStop {
+		t.Errorf("expected systemctl stop, got %v", runner.calls)
 	}
 }
 
@@ -312,6 +312,72 @@ func TestStepEnableSystemUnit_UndoDisables(t *testing.T) {
 	}
 	if !sawDisable {
 		t.Errorf("expected systemctl disable in undo, got %v", runner.calls)
+	}
+}
+
+func TestStepEnableSystemUnit_UndoRestoresPreviouslyEnabledInactive(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor(testSystemctl, "daemon-reload"), "", 0, nil)
+	runner.on(argvFor(testSystemctl, "is-active", "pipelock"), "inactive\n", 3, nil)
+	runner.on(argvFor(testSystemctl, "is-enabled", "pipelock"), "enabled\n", 0, nil)
+	s := stepEnableSystemUnit()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected apply")
+	}
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	var sawStop, sawDisable bool
+	for _, c := range runner.calls {
+		if c.name == testSystemctl && len(c.args) > 0 && c.args[0] == "stop" {
+			sawStop = true
+		}
+		if c.name == testSystemctl && len(c.args) > 0 && c.args[0] == "disable" {
+			sawDisable = true
+		}
+	}
+	if !sawStop {
+		t.Fatalf("expected undo to stop previously inactive unit, calls=%v", runner.calls)
+	}
+	if sawDisable {
+		t.Fatalf("undo disabled previously enabled unit, calls=%v", runner.calls)
+	}
+}
+
+func TestStepEnableSystemUnit_UndoRestoresPreviouslyActiveDisabled(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor(testSystemctl, "daemon-reload"), "", 0, nil)
+	runner.on(argvFor(testSystemctl, "is-active", "pipelock"), "active\n", 0, nil)
+	runner.on(argvFor(testSystemctl, "is-enabled", "pipelock"), "disabled\n", 1, nil)
+	s := stepEnableSystemUnit()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected apply")
+	}
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	var sawDisable, sawStop bool
+	for _, c := range runner.calls {
+		if c.name == testSystemctl && len(c.args) > 0 && c.args[0] == "disable" {
+			sawDisable = true
+		}
+		if c.name == testSystemctl && len(c.args) > 0 && c.args[0] == "stop" {
+			sawStop = true
+		}
+	}
+	if !sawDisable {
+		t.Fatalf("expected undo to disable previously disabled unit, calls=%v", runner.calls)
+	}
+	if sawStop {
+		t.Fatalf("undo stopped previously active unit, calls=%v", runner.calls)
 	}
 }
 

--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -131,7 +131,7 @@ func TestStepWritePipelockConfig_SkipsWhenIdentical(t *testing.T) {
 		t.Fatalf("write src: %v", err)
 	}
 	dst := filepath.Join(env.configDir, "pipelock.yaml")
-	if err := os.MkdirAll(env.configDir, 0o755); err != nil { //nolint:gosec // tmpdir
+	if err := os.MkdirAll(env.configDir, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	if err := os.WriteFile(dst, body, 0o600); err != nil {
@@ -154,7 +154,7 @@ func TestStepWritePipelockConfig_OverwritesAndWarnsOnDifference(t *testing.T) {
 		t.Fatalf("write src: %v", err)
 	}
 	dst := filepath.Join(env.configDir, "pipelock.yaml")
-	if err := os.MkdirAll(env.configDir, 0o755); err != nil { //nolint:gosec // tmpdir
+	if err := os.MkdirAll(env.configDir, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	if err := os.WriteFile(dst, []byte("mode: balanced\n"), 0o600); err != nil {
@@ -723,7 +723,7 @@ func TestActionDisablePipelockService_SkipsWhenAbsent(t *testing.T) {
 
 func TestActionRemoveNFTRules_DropsAndCleans(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
-	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o755); err != nil { //nolint:gosec // tmpdir
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	if err := os.WriteFile(env.nftRulesPath, []byte("rules"), 0o600); err != nil {

--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -1,0 +1,688 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Extra coverage for the install step builders that hit error / undo paths
+// missed by the happy-path tests in install_test.go.
+
+func TestStepCreateUser_LookupNonUnknownErrorPropagates(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.lookupUser = func(string) (*user.User, error) {
+		return nil, errors.New("transient lookup failure")
+	}
+	s := stepCreateUser(false)
+	_, err := s.apply(context.Background(), env)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "user lookup") {
+		t.Errorf("err: %v", err)
+	}
+}
+
+func TestStepCreateUser_UndoSkipsUnknownUser(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	env.lookupUser = func(name string) (*user.User, error) {
+		return nil, user.UnknownUserError(name)
+	}
+	s := stepCreateUser(true)
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	for _, c := range runner.calls {
+		if c.name == testUserDel {
+			t.Errorf("userdel called on missing user: %v", c)
+		}
+	}
+}
+
+func TestStepCreateDir_AppliedThenUndoIsNoop(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	target := filepath.Join(t.TempDir(), "newdir")
+	s := stepCreateDir("test", func(*installEnv) string { return target }, modeDirSystem)
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Errorf("first apply should create dir")
+	}
+	// Second apply: dir exists, skip.
+	applied, err = s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply 2: %v", err)
+	}
+	if applied {
+		t.Errorf("second apply should skip")
+	}
+	// Undo: empty dir gets removed.
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+}
+
+func TestStepCreateDir_RejectsExistingFile(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	target := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	s := stepCreateDir("test", func(*installEnv) string { return target }, modeDirSystem)
+	_, err := s.apply(context.Background(), env)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "not a directory") {
+		t.Errorf("err: %v", err)
+	}
+}
+
+func TestStepWritePipelockConfig_CopiesFromSource(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	src := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(src, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	opts := installOpts{configSource: src}
+	s := stepWritePipelockConfig(opts)
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Errorf("expected applied=true when source given and dest missing")
+	}
+	dst := filepath.Join(env.configDir, "pipelock.yaml")
+	got, _ := os.ReadFile(dst) //nolint:gosec // tmpdir-scoped test path
+	if string(got) != "mode: balanced\n" {
+		t.Errorf("dst: %q", got)
+	}
+}
+
+func TestStepWritePipelockConfig_SkipsWhenNoSource(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	s := stepWritePipelockConfig(installOpts{})
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if applied {
+		t.Errorf("expected skip when --config not set")
+	}
+}
+
+func TestStepWritePipelockConfig_SkipsWhenIdentical(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	src := filepath.Join(t.TempDir(), "src.yaml")
+	body := []byte("mode: balanced\n")
+	if err := os.WriteFile(src, body, 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	dst := filepath.Join(env.configDir, "pipelock.yaml")
+	if err := os.MkdirAll(env.configDir, 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(dst, body, 0o600); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+	s := stepWritePipelockConfig(installOpts{configSource: src})
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if applied {
+		t.Errorf("expected skip when src and dst contents match")
+	}
+}
+
+func TestStepWritePipelockConfig_OverwritesAndWarnsOnDifference(t *testing.T) {
+	env, _, buf := newFakeEnv(t)
+	src := filepath.Join(t.TempDir(), "new.yaml")
+	if err := os.WriteFile(src, []byte("mode: strict\n"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	dst := filepath.Join(env.configDir, "pipelock.yaml")
+	if err := os.MkdirAll(env.configDir, 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(dst, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s := stepWritePipelockConfig(installOpts{configSource: src})
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Errorf("expected overwrite when --config differs")
+	}
+	got, _ := os.ReadFile(dst) //nolint:gosec // tmpdir-scoped test path
+	if string(got) != "mode: strict\n" {
+		t.Errorf("dst not overwritten: %q", got)
+	}
+	bak, _ := os.ReadFile(dst + ".bak") //nolint:gosec // tmpdir-scoped test path
+	if string(bak) != "mode: balanced\n" {
+		t.Errorf("backup missing prior content: %q", bak)
+	}
+	if !strings.Contains(buf.String(), "WARN: --config") {
+		t.Errorf("expected warning in output, got %q", buf.String())
+	}
+}
+
+func TestStepChownToProxy_CallsChownPerFile(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.MkdirAll(env.configDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(env.configDir, "f"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	chownCalls := 0
+	env.chown = func(string, int, int) error {
+		chownCalls++
+		return nil
+	}
+	s := stepChownToProxy("config", func(e *installEnv) string { return e.configDir })
+	if _, err := s.apply(context.Background(), env); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if chownCalls < 2 {
+		t.Errorf("expected at least 2 chown calls (dir + file), got %d", chownCalls)
+	}
+}
+
+func TestStepStopUserService_NoOpWhenNoOperator(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	env.operatorUser = ""
+	s := stepStopUserService()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if applied {
+		t.Errorf("expected skip when operator user empty")
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("expected no shell-out, got %v", runner.calls)
+	}
+}
+
+func TestStepStopUserService_StopsWhenActive(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	// runCmd returns "active" for is-active.
+	runner.on(argvFor(testSystemctl, "--user", "-M", "operator@.host", "is-active", "pipelock"), "active\n", 0, nil)
+	s := stepStopUserService()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Errorf("expected applied=true when active")
+	}
+	var sawDisable bool
+	for _, c := range runner.calls {
+		if c.name == testSystemctl && containsArg(c.args, "disable") {
+			sawDisable = true
+		}
+	}
+	if !sawDisable {
+		t.Errorf("expected systemctl disable, got %v", runner.calls)
+	}
+}
+
+func TestStepEnableSystemUnit_SkipsWhenActive(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor(testSystemctl, "daemon-reload"), "", 0, nil)
+	runner.on(argvFor(testSystemctl, "is-active", "pipelock"), "active\n", 0, nil)
+	runner.on(argvFor(testSystemctl, "is-enabled", "pipelock"), "enabled\n", 0, nil)
+	s := stepEnableSystemUnit()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if applied {
+		t.Errorf("expected skip when unit already active")
+	}
+}
+
+func TestStepEnableSystemUnit_EnablesWhenActiveButDisabled(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor(testSystemctl, "daemon-reload"), "", 0, nil)
+	runner.on(argvFor(testSystemctl, "is-active", "pipelock"), "active\n", 0, nil)
+	runner.on(argvFor(testSystemctl, "is-enabled", "pipelock"), "disabled\n", 1, nil)
+	s := stepEnableSystemUnit()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected apply=true when active but disabled")
+	}
+	var sawEnable bool
+	for _, c := range runner.calls {
+		if c.name == testSystemctl && containsArg(c.args, "enable") {
+			sawEnable = true
+		}
+	}
+	if !sawEnable {
+		t.Errorf("expected systemctl enable, got %v", runner.calls)
+	}
+}
+
+func TestStepEnableSystemUnit_EnablesWhenInactive(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	s := stepEnableSystemUnit()
+	if _, err := s.apply(context.Background(), env); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	var sawEnable bool
+	for _, c := range runner.calls {
+		if c.name == testSystemctl && containsArg(c.args, "enable") {
+			sawEnable = true
+		}
+	}
+	if !sawEnable {
+		t.Errorf("expected systemctl enable, got %v", runner.calls)
+	}
+}
+
+func TestStepEnableSystemUnit_UndoDisables(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	s := stepEnableSystemUnit()
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	var sawDisable bool
+	for _, c := range runner.calls {
+		if c.name == testSystemctl && containsArg(c.args, "disable") {
+			sawDisable = true
+		}
+	}
+	if !sawDisable {
+		t.Errorf("expected systemctl disable in undo, got %v", runner.calls)
+	}
+}
+
+func TestStepExportPipelockCA_SkipsWhenAlreadyPresent(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.caExportPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.caExportPath, []byte("CA"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	s := stepExportPipelockCA()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if applied {
+		t.Errorf("expected skip when ca.pem present")
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("no shell-out expected, got %v", runner.calls)
+	}
+}
+
+func TestStepExportPipelockCA_ExportsViaSudo(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	// Stub show-ca to return a PEM.
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		runner.mu.Lock()
+		runner.calls = append(runner.calls, fakeCall{name: name, args: append([]string(nil), args...)})
+		runner.mu.Unlock()
+		if name == testSudoCmd && containsArg(args, "show-ca") {
+			return testPEMCA, 0, nil
+		}
+		return "", 0, nil
+	}
+	s := stepExportPipelockCA()
+	if _, err := s.apply(context.Background(), env); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected 1 call, got %v", runner.calls)
+	}
+	if runner.calls[0].name != testSudoCmd {
+		t.Errorf("expected sudo, got %s", runner.calls[0].name)
+	}
+}
+
+func TestStepWriteCombinedCABundle_FailsWhenCAMissing(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	// System bundle is plumbed by newFakeEnv. caExportPath is NOT planted,
+	// so the read must fail.
+	s := stepWriteCombinedCABundle()
+	_, err := s.apply(context.Background(), env)
+	if err == nil {
+		t.Fatal("expected error on missing pipelock CA")
+	}
+	if !strings.Contains(err.Error(), "read pipelock CA") {
+		t.Errorf("err: %v", err)
+	}
+}
+
+func TestStepWriteCombinedCABundle_Succeeds(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.caExportPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.caExportPath, []byte("PIPE_CA"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	s := stepWriteCombinedCABundle()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Errorf("expected applied=true on first run")
+	}
+	got, _ := os.ReadFile(env.caBundlePath)
+	if !strings.Contains(string(got), "PIPE_CA") {
+		t.Errorf("bundle missing pipelock CA: %q", got)
+	}
+	if !strings.Contains(string(got), "system bundle") {
+		t.Errorf("bundle missing system root marker: %q", got)
+	}
+}
+
+func TestStepWriteLaunchWrapper_IdempotentAndUndoable(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	s := stepWriteLaunchWrapper()
+	a1, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !a1 {
+		t.Errorf("first apply should write")
+	}
+	a2, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply 2: %v", err)
+	}
+	if a2 {
+		t.Errorf("second apply should skip")
+	}
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+}
+
+func TestStepInstallNFTRules_UndoDropsTable(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	s := stepInstallNFTRules()
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	var sawDelete bool
+	for _, c := range runner.calls {
+		if c.name == testNFT && containsArg(c.args, "delete") && containsArg(c.args, "pipelock_containment") {
+			sawDelete = true
+		}
+	}
+	if !sawDelete {
+		t.Errorf("expected nft delete table in undo, got %v", runner.calls)
+	}
+}
+
+func TestStepInstallNFTRules_ValidationFailureSurfaces(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	// Force nft validate to fail.
+	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), "", 1, fmt.Errorf("not loaded"))
+	runner.on(argvFor(testNFT, "-c", "-f", env.nftRulesPath), "syntax error", 1, nil)
+	s := stepInstallNFTRules()
+	_, err := s.apply(context.Background(), env)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "validation failed") {
+		t.Errorf("err: %v", err)
+	}
+}
+
+func TestRollbackApplied_HandlesUndoFailureNonFatally(t *testing.T) {
+	env, _, out := newFakeEnv(t)
+	applied := []step{
+		{
+			name: "ok", desc: "ok",
+			undo: func(context.Context, *installEnv) error { return nil },
+		},
+		{
+			name: "boom", desc: "boom",
+			undo: func(context.Context, *installEnv) error { return errors.New("kaboom") },
+		},
+	}
+	// applied[0] was first; rollbackApplied walks in reverse: boom then ok.
+	rollbackApplied(context.Background(), env, out, applied)
+	got := out.String()
+	if !strings.Contains(got, "[FAIL] undo boom") {
+		t.Errorf("missing fail line for boom: %q", got)
+	}
+	if !strings.Contains(got, "[ OK ] undo ok") {
+		t.Errorf("missing ok line for ok: %q", got)
+	}
+}
+
+func TestRollbackApplied_HandlesEmptySliceAsNoop(t *testing.T) {
+	env, _, out := newFakeEnv(t)
+	rollbackApplied(context.Background(), env, out, nil)
+	if out.Len() != 0 {
+		t.Errorf("expected no output: %q", out.String())
+	}
+}
+
+func TestRollbackApplied_SkipsStepsWithNilUndo(t *testing.T) {
+	env, _, out := newFakeEnv(t)
+	applied := []step{{name: "nostep", desc: "nostep", undo: nil}}
+	rollbackApplied(context.Background(), env, out, applied)
+	if !strings.Contains(out.String(), "[SKIP] undo nostep") {
+		t.Errorf("expected skip line: %q", out.String())
+	}
+}
+
+func TestResolveUIDs_BothLookupsSucceed(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	pUID, aUID, err := resolveUIDs(env)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if pUID != 988 || aUID != 987 {
+		t.Errorf("UIDs: proxy=%d agent=%d", pUID, aUID)
+	}
+}
+
+func TestResolveUIDs_AgentLookupErrorPropagates(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == "pipelock-agent" {
+			return nil, errors.New("nope")
+		}
+		return &user.User{Uid: "988", Gid: "988"}, nil
+	}
+	if _, _, err := resolveUIDs(env); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestOperatorUIDFromEnv_ErrorsWhenUnset(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.operatorUser = ""
+	if _, err := operatorUIDFromEnv(env); err == nil {
+		t.Fatal("expected error when operatorUser empty")
+	}
+}
+
+func TestProbeBinaryIntegrity_SkipsWhenPinAbsent(t *testing.T) {
+	env := makeProbeEnv(t)
+	env.pinPath = filepath.Join(t.TempDir(), "absent")
+	env.readFile = os.ReadFile
+	env.selfPath = func() (string, error) { return "/bin/ls", nil }
+	status, _ := probeBinaryIntegrity(context.Background(), env)
+	if status != statusSkip {
+		t.Errorf("status: %s, want skip", status)
+	}
+}
+
+func TestProbeBinaryIntegrity_FailsOnMismatch(t *testing.T) {
+	env := makeProbeEnv(t)
+	tmp := t.TempDir()
+	pinPath := filepath.Join(tmp, "pin")
+	if err := os.WriteFile(pinPath, []byte("0000000000000000000000000000000000000000000000000000000000000000\n"), 0o600); err != nil {
+		t.Fatalf("write pin: %v", err)
+	}
+	env.pinPath = pinPath
+	env.readFile = os.ReadFile
+	env.selfPath = func() (string, error) { return "/bin/ls", nil }
+	env.hashFile = func(string) (string, error) {
+		return "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", nil
+	}
+	status, detail := probeBinaryIntegrity(context.Background(), env)
+	if status != statusFail {
+		t.Errorf("status: %s, want fail", status)
+	}
+	if !strings.Contains(detail, "mismatch") {
+		t.Errorf("detail: %s", detail)
+	}
+}
+
+func TestProbeBinaryIntegrity_FailsOnCorruptedPin(t *testing.T) {
+	env := makeProbeEnv(t)
+	pinPath := filepath.Join(t.TempDir(), "pin")
+	if err := os.WriteFile(pinPath, []byte("\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	env.pinPath = pinPath
+	env.readFile = os.ReadFile
+	status, detail := probeBinaryIntegrity(context.Background(), env)
+	if status != statusFail {
+		t.Errorf("status: %s, want fail (empty pin is corrupted)", status)
+	}
+	if !strings.Contains(detail, "empty") {
+		t.Errorf("detail: %s", detail)
+	}
+}
+
+func TestProbeBinaryIntegrity_FailsOnMalformedPin(t *testing.T) {
+	env := makeProbeEnv(t)
+	pinPath := filepath.Join(t.TempDir(), "pin")
+	if err := os.WriteFile(pinPath, []byte("short\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	env.pinPath = pinPath
+	env.readFile = os.ReadFile
+	status, detail := probeBinaryIntegrity(context.Background(), env)
+	if status != statusFail {
+		t.Errorf("status: %s, want fail (malformed pin is corrupted)", status)
+	}
+	if !strings.Contains(detail, "malformed") {
+		t.Errorf("detail: %s", detail)
+	}
+}
+
+func TestActionRemovePath_RemovesFileAndBak(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	target := filepath.Join(t.TempDir(), "f")
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(target+".bak", []byte("y"), 0o600); err != nil {
+		t.Fatalf("write bak: %v", err)
+	}
+	a := actionRemovePath("test", func(*installEnv) string { return target })
+	if err := a.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if _, err := os.Stat(target); err == nil {
+		t.Errorf("target not removed")
+	}
+	if _, err := os.Stat(target + ".bak"); err == nil {
+		t.Errorf("bak not removed")
+	}
+}
+
+func TestActionRemoveSystemUnit_RemovesAndReloads(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.systemUnitPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.systemUnitPath, []byte("unit"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	a := actionRemoveSystemUnit()
+	if err := a.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if _, err := os.Stat(env.systemUnitPath); err == nil {
+		t.Errorf("unit not removed")
+	}
+	var sawReload bool
+	for _, c := range runner.calls {
+		if c.name == testSystemctl && containsArg(c.args, "daemon-reload") {
+			sawReload = true
+		}
+	}
+	if !sawReload {
+		t.Errorf("expected daemon-reload, got %v", runner.calls)
+	}
+}
+
+func TestActionDisablePipelockService_SkipsWhenAbsent(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	// runCmd default returns ("", 0, nil) for unmatched calls, but we want
+	// list-unit-files to return code 0 with empty output (meaning unit not
+	// known). The default behavior already does that.
+	a := actionDisablePipelockService()
+	if err := a.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	for _, c := range runner.calls {
+		if c.name == testSystemctl && containsArg(c.args, "disable") {
+			t.Errorf("disable called despite unit being absent: %v", c)
+		}
+	}
+}
+
+func TestActionRemoveNFTRules_DropsAndCleans(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath, []byte("rules"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath+".bak", []byte("bak"), 0o600); err != nil {
+		t.Fatalf("write bak: %v", err)
+	}
+	a := actionRemoveNFTRules()
+	if err := a.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	var sawDelete bool
+	for _, c := range runner.calls {
+		if c.name == testNFT && containsArg(c.args, "delete") {
+			sawDelete = true
+		}
+	}
+	if !sawDelete {
+		t.Errorf("expected nft delete in undo, got %v", runner.calls)
+	}
+	if _, err := os.Stat(env.nftRulesPath); err == nil {
+		t.Errorf("rules file not removed")
+	}
+	if _, err := os.Stat(env.nftRulesPath + ".bak"); err == nil {
+		t.Errorf("bak not removed")
+	}
+}

--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -410,7 +410,7 @@ func TestStepExportPipelockCA_ExportsViaSudo(t *testing.T) {
 		runner.calls = append(runner.calls, fakeCall{name: name, args: append([]string(nil), args...)})
 		runner.mu.Unlock()
 		if name == testSudoCmd && containsArg(args, "show-ca") {
-			return testPEMCA, 0, nil
+			return testPEMCA(t), 0, nil
 		}
 		return "", 0, nil
 	}

--- a/internal/cli/contain/install_review_fixes_test.go
+++ b/internal/cli/contain/install_review_fixes_test.go
@@ -5,6 +5,7 @@ package contain
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -114,8 +115,8 @@ func TestReadToolsList_RoundTrips(t *testing.T) {
 func TestReadToolsList_MissingFileSurfacesNotExist(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	_, err := readToolsList(env)
-	if err == nil {
-		t.Fatal("expected error for missing file")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected missing-file error, got %v", err)
 	}
 }
 
@@ -135,7 +136,10 @@ func TestUpsertToolEntry_InsertsNew(t *testing.T) {
 	if !changed {
 		t.Errorf("expected changed=true on insert")
 	}
-	got, _ := readToolsList(env)
+	got, err := readToolsList(env)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
 	found := false
 	for _, e := range got {
 		if e.name == testRustup && e.target == "/home/pipelock-agent/.cargo/bin/rustup" {
@@ -180,7 +184,10 @@ func TestUpsertToolEntry_UpdatesExistingTarget(t *testing.T) {
 	if !changed {
 		t.Errorf("expected changed=true on target change")
 	}
-	entries, _ := readToolsList(env)
+	entries, err := readToolsList(env)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
 	if entries[0].target != "/usr/local/bin/claude" {
 		t.Errorf("target not updated: %+v", entries)
 	}
@@ -195,7 +202,10 @@ func TestUpsertToolEntry_BootstrapsOnlyRequestedToolWhenMissing(t *testing.T) {
 	if !changed {
 		t.Errorf("expected changed=true on bootstrap")
 	}
-	entries, _ := readToolsList(env)
+	entries, err := readToolsList(env)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
 	if len(entries) != 1 {
 		t.Errorf("entries: %d, want 1", len(entries))
 	}
@@ -245,7 +255,7 @@ func TestStepWriteToolsList_IdempotentReapply(t *testing.T) {
 func TestStepWriteToolsList_PreservesCustomEntries(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	plantResolvableDefaultTools(t, env, "claude")
-	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o755); err != nil { //nolint:gosec // tmpdir
+	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	custom := renderToolsList([]toolsListEntry{
@@ -276,7 +286,7 @@ func TestStepWriteToolsList_PreservesCustomEntries(t *testing.T) {
 func TestStepWriteToolsList_AddsMissingDefaultWithoutDroppingCustom(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	plantResolvableDefaultTools(t, env, "claude", "codex", "gemini")
-	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o755); err != nil { //nolint:gosec // tmpdir
+	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	if err := os.WriteFile(env.toolsListPath, []byte("rustup\t/tmp/rustup\n"), 0o600); err != nil {
@@ -352,7 +362,10 @@ func TestAddTool_RecordsTargetInToolsList(t *testing.T) {
 	if err := runAddTool(context.Background(), env, testRustup, addToolOpts{target: target}); err != nil {
 		t.Fatalf("addTool: %v", err)
 	}
-	entries, _ := readToolsList(env)
+	entries, err := readToolsList(env)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
 	var got *toolsListEntry
 	for i := range entries {
 		if entries[i].name == testRustup {
@@ -428,7 +441,7 @@ func TestRenderedCCLaunch_ExecutesUnderBash(t *testing.T) {
 	// Seed an allow-list with one entry pointing at /bin/true so we can
 	// exercise the happy path without depending on pipelock-agent's PATH.
 	allowList := "claude\t/bin/true\n"
-	if err := os.WriteFile(toolsListPath, []byte(allowList), 0o644); err != nil { //nolint:gosec // test fixture; mode mirrors production
+	if err := os.WriteFile(toolsListPath, []byte(allowList), 0o600); err != nil {
 		t.Fatalf("write tools.list: %v", err)
 	}
 
@@ -457,7 +470,7 @@ func TestRenderedCCLaunch_ExecutesUnderBash(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Re-seed list before each subtest to undo prior mutations.
-			if err := os.WriteFile(toolsListPath, []byte(allowList), 0o644); err != nil { //nolint:gosec // test fixture
+			if err := os.WriteFile(toolsListPath, []byte(allowList), 0o600); err != nil {
 				t.Fatalf("reseed: %v", err)
 			}
 			if tc.mutate != nil {

--- a/internal/cli/contain/install_review_fixes_test.go
+++ b/internal/cli/contain/install_review_fixes_test.go
@@ -1,0 +1,490 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Tests covering review blockers found during contain install hardening:
+//   - stepStopUserService must have an undo that re-enables the user service
+//   - plk-launch must validate $TOOL against the runtime allow-list
+//   - per-tool wrappers must use `sudo -n` for fail-fast
+//   - --target must be honored at runtime (baked into tools.list)
+
+func TestStepStopUserService_UndoReenablesUserService(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	s := stepStopUserService()
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	var sawEnable bool
+	for _, c := range runner.calls {
+		if c.name == testSystemctl && containsArg(c.args, "enable") && containsArg(c.args, "pipelock") {
+			sawEnable = true
+		}
+	}
+	if !sawEnable {
+		t.Errorf("undo did not re-enable user pipelock, calls=%v", runner.calls)
+	}
+}
+
+func TestStepStopUserService_UndoNoOpWhenNoOperator(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	env.operatorUser = ""
+	s := stepStopUserService()
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("expected no shell-out when operator empty, got %v", runner.calls)
+	}
+}
+
+func TestRenderLaunchWrapper_EmbedsAllowListLookup(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	body := renderLaunchWrapper(env)
+	requirements := []string{
+		"TOOLS_LIST=", // file path baked in
+		env.toolsListPath,
+		"not in pipelock contain allow-list",
+		"refusing non-absolute target",
+		`case "$TOOL" in`, // metacharacter rejection
+		"set -euo pipefail",
+	}
+	for _, r := range requirements {
+		if !strings.Contains(body, r) {
+			t.Errorf("plk-launch body missing %q in:\n%s", r, body)
+		}
+	}
+	// MUST NOT just exec $TOOL — must exec $TARGET resolved through the
+	// allow-list pipeline.
+	if !strings.Contains(body, `"$TARGET" "$@"`) {
+		t.Errorf("plk-launch must exec $TARGET, not $TOOL")
+	}
+}
+
+func TestRenderDefaultToolsList_IncludesEveryDefaultTool(t *testing.T) {
+	got := renderDefaultToolsList()
+	for _, name := range defaultToolNames() {
+		// Each default tool appears on its own line with an empty target
+		// (single tab + newline) so plk-launch resolves via PATH.
+		want := name + "\t\n"
+		if !strings.Contains(got, want) {
+			t.Errorf("tools.list missing line %q in:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, "# Managed by") {
+		t.Errorf("tools.list missing header comment")
+	}
+}
+
+func TestReadToolsList_RoundTrips(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	content := "# comment\n\nclaude\t\ncodex\t/usr/local/bin/codex\nrustup\t/home/pipelock-agent/.cargo/bin/rustup\n"
+	if err := os.WriteFile(env.toolsListPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := readToolsList(env)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("entries: got %d, want 3 (got %+v)", len(got), got)
+	}
+	if got[0].name != "claude" || got[0].target != "" {
+		t.Errorf("[0]: %+v", got[0])
+	}
+	if got[1].name != "codex" || got[1].target != "/usr/local/bin/codex" {
+		t.Errorf("[1]: %+v", got[1])
+	}
+	if got[2].name != testRustup || got[2].target != "/home/pipelock-agent/.cargo/bin/rustup" {
+		t.Errorf("[2]: %+v", got[2])
+	}
+}
+
+func TestReadToolsList_MissingFileSurfacesNotExist(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	_, err := readToolsList(env)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestUpsertToolEntry_InsertsNew(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	// Seed the defaults.
+	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.toolsListPath, []byte(renderDefaultToolsList()), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	changed, err := upsertToolEntry(env, testRustup, "/home/pipelock-agent/.cargo/bin/rustup")
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if !changed {
+		t.Errorf("expected changed=true on insert")
+	}
+	got, _ := readToolsList(env)
+	found := false
+	for _, e := range got {
+		if e.name == testRustup && e.target == "/home/pipelock-agent/.cargo/bin/rustup" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("rustup not present after upsert: %+v", got)
+	}
+}
+
+func TestUpsertToolEntry_IdempotentOnIdenticalEntry(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.toolsListPath, []byte(renderDefaultToolsList()), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// claude is already present with empty target.
+	changed, err := upsertToolEntry(env, "claude", "")
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if changed {
+		t.Errorf("expected changed=false on identical entry")
+	}
+}
+
+func TestUpsertToolEntry_UpdatesExistingTarget(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.toolsListPath, []byte("claude\t\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	changed, err := upsertToolEntry(env, "claude", "/usr/local/bin/claude")
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if !changed {
+		t.Errorf("expected changed=true on target change")
+	}
+	entries, _ := readToolsList(env)
+	if entries[0].target != "/usr/local/bin/claude" {
+		t.Errorf("target not updated: %+v", entries)
+	}
+}
+
+func TestUpsertToolEntry_BootstrapsOnlyRequestedToolWhenMissing(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	changed, err := upsertToolEntry(env, testRustup, "/usr/local/bin/rustup")
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if !changed {
+		t.Errorf("expected changed=true on bootstrap")
+	}
+	entries, _ := readToolsList(env)
+	if len(entries) != 1 {
+		t.Errorf("entries: %d, want 1", len(entries))
+	}
+}
+
+func TestStepWriteToolsList_SeedsDefaults(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	plantResolvableDefaultTools(t, env, "claude", "codex")
+	s := stepWriteToolsList()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Errorf("first apply should write file")
+	}
+	body, err := os.ReadFile(env.toolsListPath) //nolint:gosec // tmpdir-scoped
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	for _, name := range []string{"claude", "codex"} {
+		if !strings.Contains(string(body), name+"\t/usr/local/bin/"+name+"\n") {
+			t.Errorf("tools.list missing %q", name)
+		}
+	}
+	if strings.Contains(string(body), "playwright") {
+		t.Errorf("tools.list included unresolved playwright:\n%s", body)
+	}
+}
+
+func TestStepWriteToolsList_IdempotentReapply(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	plantResolvableDefaultTools(t, env, "claude")
+	s := stepWriteToolsList()
+	if _, err := s.apply(context.Background(), env); err != nil {
+		t.Fatalf("apply 1: %v", err)
+	}
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply 2: %v", err)
+	}
+	if applied {
+		t.Errorf("expected idempotent skip on rerun")
+	}
+}
+
+func TestStepWriteToolsList_PreservesCustomEntries(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	plantResolvableDefaultTools(t, env, "claude")
+	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir: %v", err)
+	}
+	custom := renderToolsList([]toolsListEntry{
+		{name: "claude", target: "/usr/local/bin/claude"},
+		{name: "rustup", target: "/tmp/rustup"},
+	})
+	if err := os.WriteFile(env.toolsListPath, []byte(custom), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	s := stepWriteToolsList()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if applied {
+		t.Fatal("expected no-op when defaults and custom entries are present")
+	}
+	body, err := os.ReadFile(env.toolsListPath) //nolint:gosec // tmpdir-scoped
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(body), "rustup\t/tmp/rustup\n") {
+		t.Fatalf("custom entry was not preserved:\n%s", body)
+	}
+}
+
+func TestStepWriteToolsList_AddsMissingDefaultWithoutDroppingCustom(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	plantResolvableDefaultTools(t, env, "claude", "codex", "gemini")
+	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.toolsListPath, []byte("rustup\t/tmp/rustup\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	s := stepWriteToolsList()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected missing defaults to be added")
+	}
+	body, err := os.ReadFile(env.toolsListPath) //nolint:gosec // tmpdir-scoped
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(body), "rustup\t/tmp/rustup\n") {
+		t.Fatalf("custom entry was dropped:\n%s", body)
+	}
+	for _, name := range []string{"claude", "codex", "gemini"} {
+		if !strings.Contains(string(body), name+"\t/usr/local/bin/"+name+"\n") {
+			t.Fatalf("default %q missing after merge:\n%s", name, body)
+		}
+	}
+	if strings.Contains(string(body), "playwright") {
+		t.Fatalf("unresolved default present after merge:\n%s", body)
+	}
+}
+
+func plantResolvableDefaultTools(t *testing.T, env *installEnv, names ...string) {
+	t.Helper()
+	targets := make(map[string]string, len(names))
+	for _, name := range names {
+		target := filepath.Join(t.TempDir(), name)
+		if err := os.WriteFile(target, []byte("x"), 0o755); err != nil { //nolint:gosec // tmpdir
+			t.Fatalf("plant target %s: %v", name, err)
+		}
+		targets["/usr/local/bin/"+name] = target
+	}
+	origStat := env.stat
+	env.stat = func(path string) (os.FileInfo, error) {
+		if target, ok := targets[path]; ok {
+			return origStat(target)
+		}
+		if strings.HasPrefix(path, "/home/"+env.agentUserName+"/.local/bin/") ||
+			strings.HasPrefix(path, "/usr/local/bin/") ||
+			strings.HasPrefix(path, "/usr/bin/") ||
+			strings.HasPrefix(path, "/bin/") {
+			return nil, os.ErrNotExist
+		}
+		return origStat(path)
+	}
+}
+
+func TestAddTool_RecordsTargetInToolsList(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.WriteFile(filepath.Join(env.wrapperDir, "plk-launch"), []byte("#!/bin/bash\n"), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("plant: %v", err)
+	}
+	// Seed default tools.list so we observe append behaviour, not bootstrap.
+	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.toolsListPath, []byte(renderDefaultToolsList()), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), testRustup)
+	if err := os.WriteFile(target, []byte("x"), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("plant target: %v", err)
+	}
+	if err := runAddTool(context.Background(), env, testRustup, addToolOpts{target: target}); err != nil {
+		t.Fatalf("addTool: %v", err)
+	}
+	entries, _ := readToolsList(env)
+	var got *toolsListEntry
+	for i := range entries {
+		if entries[i].name == testRustup {
+			got = &entries[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("rustup not in tools.list: %+v", entries)
+	}
+	if got.target != target {
+		t.Errorf("target: got %q, want %q", got.target, target)
+	}
+}
+
+func TestRollback_RemovesToolsList(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.toolsListPath, []byte("claude\t\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	actions := rollbackActions(rollbackOpts{keepData: true})
+	for i := len(actions) - 1; i >= 0; i-- {
+		a := actions[i]
+		if a.undo == nil {
+			continue
+		}
+		_ = a.undo(context.Background(), env)
+	}
+	if _, err := os.Stat(env.toolsListPath); err == nil {
+		t.Errorf("tools.list not removed")
+	}
+}
+
+// Smoke-test the rendered plk-launch script by spawning a real bash to
+// parse + reject malformed input. Skipped when bash is missing (none of
+// our supported platforms ship without it, but CI containers vary).
+func TestRenderedCCLaunch_ParsesUnderBash(t *testing.T) {
+	if _, err := os.Stat("/bin/bash"); err != nil {
+		t.Skip("bash unavailable")
+	}
+	env, _, _ := newFakeEnv(t)
+	tmp := t.TempDir()
+	scriptPath := filepath.Join(tmp, "plk-launch")
+	if err := os.WriteFile(scriptPath, []byte(renderLaunchWrapper(env)), 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write: %v", err)
+	}
+	// bash -n parses without executing. Any syntax error fails the test.
+	cmd := exec_realCommand(t, "/bin/bash", "-n", scriptPath)
+	if cmd.exit != 0 {
+		t.Fatalf("bash -n rejected plk-launch:\n%s\n--- script ---\n%s", cmd.output, renderLaunchWrapper(env))
+	}
+}
+
+// TestRenderedCCLaunch_ExecutesUnderBash exercises the rendered plk-launch
+// against a real bash with controlled inputs and asserts each documented
+// exit code path is reachable. This is the test that would have caught a
+// silent allow-list bypass before live install — the Go-side unit tests
+// can't, because they don't run the script as bash sees it.
+func TestRenderedCCLaunch_ExecutesUnderBash(t *testing.T) {
+	if _, err := os.Stat("/bin/bash"); err != nil {
+		t.Skip("bash unavailable")
+	}
+	env, _, _ := newFakeEnv(t)
+	tmp := t.TempDir()
+	scriptPath := filepath.Join(tmp, "plk-launch")
+	toolsListPath := filepath.Join(tmp, "tools.list")
+	env.toolsListPath = toolsListPath
+	if err := os.WriteFile(scriptPath, []byte(renderLaunchWrapper(env)), 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write script: %v", err)
+	}
+	// Seed an allow-list with one entry pointing at /bin/true so we can
+	// exercise the happy path without depending on pipelock-agent's PATH.
+	allowList := "claude\t/bin/true\n"
+	if err := os.WriteFile(toolsListPath, []byte(allowList), 0o644); err != nil { //nolint:gosec // test fixture; mode mirrors production
+		t.Fatalf("write tools.list: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		argv     []string
+		mutate   func()
+		wantExit int
+	}{
+		{name: "no-args-exits-2", argv: nil, wantExit: 2},
+		{name: "bad-name-exits-3", argv: []string{"BadName!"}, wantExit: 3},
+		{
+			name: "missing-list-exits-4",
+			argv: []string{"claude"},
+			mutate: func() {
+				if err := os.Remove(toolsListPath); err != nil {
+					t.Fatalf("remove list: %v", err)
+				}
+			},
+			wantExit: 4,
+		},
+		{name: "not-in-list-exits-5", argv: []string{probe11Sentinel}, wantExit: 5},
+		{name: "happy-path-exits-0", argv: []string{"claude"}, wantExit: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Re-seed list before each subtest to undo prior mutations.
+			if err := os.WriteFile(toolsListPath, []byte(allowList), 0o644); err != nil { //nolint:gosec // test fixture
+				t.Fatalf("reseed: %v", err)
+			}
+			if tc.mutate != nil {
+				tc.mutate()
+			}
+			args := append([]string{scriptPath}, tc.argv...)
+			out := exec_realCommand(t, "/bin/bash", args...)
+			if out.exit != tc.wantExit {
+				t.Fatalf("exit: got %d, want %d (output: %s)", out.exit, tc.wantExit, out.output)
+			}
+		})
+	}
+}
+
+// exec_realCommand runs cmd outside the runner abstraction. Used only for
+// the rendered-script smoke test above; this is the one place we need a
+// real subprocess and not a fake. Kept tiny on purpose.
+type cmdResult struct {
+	output string
+	exit   int
+}
+
+func exec_realCommand(t *testing.T, name string, args ...string) cmdResult { //nolint:revive // test helper
+	t.Helper()
+	out, code, err := realRunCommand(context.Background(), name, args...)
+	if err != nil {
+		return cmdResult{output: err.Error(), exit: -1}
+	}
+	return cmdResult{output: out, exit: code}
+}

--- a/internal/cli/contain/install_review_fixes_test.go
+++ b/internal/cli/contain/install_review_fixes_test.go
@@ -13,25 +13,39 @@ import (
 )
 
 // Tests covering review blockers found during contain install hardening:
-//   - stepStopUserService must have an undo that re-enables the user service
+//   - stepStopUserService must have an undo that restarts the user service without changing enablement
 //   - plk-launch must validate $TOOL against the runtime allow-list
 //   - per-tool wrappers must use `sudo -n` for fail-fast
 //   - --target must be honored at runtime (baked into tools.list)
 
-func TestStepStopUserService_UndoReenablesUserService(t *testing.T) {
+func TestStepStopUserService_UndoRestartsStoppedUserService(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor(testSystemctl, "--user", "-M", "operator@.host", "is-active", "pipelock"), "active\n", 0, nil)
 	s := stepStopUserService()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected apply")
+	}
 	if err := s.undo(context.Background(), env); err != nil {
 		t.Fatalf("undo: %v", err)
 	}
-	var sawEnable bool
+	var sawStart, sawEnable bool
 	for _, c := range runner.calls {
+		if c.name == testSystemctl && containsArg(c.args, "start") && containsArg(c.args, "pipelock") {
+			sawStart = true
+		}
 		if c.name == testSystemctl && containsArg(c.args, "enable") && containsArg(c.args, "pipelock") {
 			sawEnable = true
 		}
 	}
-	if !sawEnable {
-		t.Errorf("undo did not re-enable user pipelock, calls=%v", runner.calls)
+	if !sawStart {
+		t.Errorf("undo did not restart user pipelock, calls=%v", runner.calls)
+	}
+	if sawEnable {
+		t.Errorf("undo changed user service enablement, calls=%v", runner.calls)
 	}
 }
 
@@ -193,8 +207,9 @@ func TestUpsertToolEntry_UpdatesExistingTarget(t *testing.T) {
 	}
 }
 
-func TestUpsertToolEntry_BootstrapsOnlyRequestedToolWhenMissing(t *testing.T) {
+func TestUpsertToolEntry_BootstrapsDefaultsWhenMissing(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
+	plantResolvableDefaultTools(t, env, "claude", "codex")
 	changed, err := upsertToolEntry(env, testRustup, "/usr/local/bin/rustup")
 	if err != nil {
 		t.Fatalf("upsert: %v", err)
@@ -206,8 +221,14 @@ func TestUpsertToolEntry_BootstrapsOnlyRequestedToolWhenMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
-	if len(entries) != 1 {
-		t.Errorf("entries: %d, want 1", len(entries))
+	names := map[string]bool{}
+	for _, entry := range entries {
+		names[entry.name] = true
+	}
+	for _, want := range []string{"claude", "codex", testRustup} {
+		if !names[want] {
+			t.Fatalf("tools.list missing %q after bootstrap: %+v", want, entries)
+		}
 	}
 }
 
@@ -322,9 +343,9 @@ func plantResolvableDefaultTools(t *testing.T, env *installEnv, names ...string)
 	t.Helper()
 	targets := make(map[string]string, len(names))
 	for _, name := range names {
-		target := filepath.Join(t.TempDir(), name)
-		if err := os.WriteFile(target, []byte("x"), 0o755); err != nil { //nolint:gosec // tmpdir
-			t.Fatalf("plant target %s: %v", name, err)
+		target, err := os.Executable()
+		if err != nil {
+			t.Fatalf("locate test executable: %v", err)
 		}
 		targets["/usr/local/bin/"+name] = target
 	}
@@ -343,11 +364,16 @@ func plantResolvableDefaultTools(t *testing.T, env *installEnv, names ...string)
 	}
 }
 
+func writeScriptFixture(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write script fixture %s: %v", path, err)
+	}
+}
+
 func TestAddTool_RecordsTargetInToolsList(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
-	if err := os.WriteFile(filepath.Join(env.wrapperDir, "plk-launch"), []byte("#!/bin/bash\n"), 0o755); err != nil { //nolint:gosec // tmpdir
-		t.Fatalf("plant: %v", err)
-	}
+	writeScriptFixture(t, filepath.Join(env.wrapperDir, "plk-launch"), "#!/bin/bash\n")
 	// Seed default tools.list so we observe append behaviour, not bootstrap.
 	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -355,9 +381,9 @@ func TestAddTool_RecordsTargetInToolsList(t *testing.T) {
 	if err := os.WriteFile(env.toolsListPath, []byte(renderDefaultToolsList()), 0o600); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	target := filepath.Join(t.TempDir(), testRustup)
-	if err := os.WriteFile(target, []byte("x"), 0o755); err != nil { //nolint:gosec // tmpdir
-		t.Fatalf("plant target: %v", err)
+	target, err := os.Executable()
+	if err != nil {
+		t.Fatalf("locate test executable: %v", err)
 	}
 	if err := runAddTool(context.Background(), env, testRustup, addToolOpts{target: target}); err != nil {
 		t.Fatalf("addTool: %v", err)
@@ -411,9 +437,7 @@ func TestRenderedCCLaunch_ParsesUnderBash(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	tmp := t.TempDir()
 	scriptPath := filepath.Join(tmp, "plk-launch")
-	if err := os.WriteFile(scriptPath, []byte(renderLaunchWrapper(env)), 0o755); err != nil { //nolint:gosec // test fixture
-		t.Fatalf("write: %v", err)
-	}
+	writeScriptFixture(t, scriptPath, renderLaunchWrapper(env))
 	// bash -n parses without executing. Any syntax error fails the test.
 	cmd := exec_realCommand(t, "/bin/bash", "-n", scriptPath)
 	if cmd.exit != 0 {
@@ -435,9 +459,7 @@ func TestRenderedCCLaunch_ExecutesUnderBash(t *testing.T) {
 	scriptPath := filepath.Join(tmp, "plk-launch")
 	toolsListPath := filepath.Join(tmp, "tools.list")
 	env.toolsListPath = toolsListPath
-	if err := os.WriteFile(scriptPath, []byte(renderLaunchWrapper(env)), 0o755); err != nil { //nolint:gosec // test fixture
-		t.Fatalf("write script: %v", err)
-	}
+	writeScriptFixture(t, scriptPath, renderLaunchWrapper(env))
 	// Seed an allow-list with one entry pointing at /bin/true so we can
 	// exercise the happy path without depending on pipelock-agent's PATH.
 	allowList := "claude\t/bin/true\n"

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -364,6 +364,52 @@ func TestRunInstall_DryRunPrintsPlan(t *testing.T) {
 	t.Skip("root path covered in TestRunInstall_EndToEnd")
 }
 
+func TestRunInstall_EndToEndWithExistingUsers(t *testing.T) {
+	env, runner, buf := newFakeEnv(t)
+	binDir := t.TempDir()
+	for _, name := range []string{"useradd", "userdel", "systemctl", "nft", "visudo"} {
+		path := filepath.Join(binDir, name)
+		if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil { //nolint:gosec // executable fixture required for preflight PATH lookup.
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	t.Setenv("PATH", binDir)
+
+	// Let the default allow-list find one agent tool without depending on
+	// host-global /usr/local/bin contents.
+	origStat := env.stat
+	env.stat = func(path string) (os.FileInfo, error) {
+		if path == "/usr/local/bin/claude" {
+			return origStat(env.pipelockBinary)
+		}
+		return origStat(path)
+	}
+	if err := os.WriteFile(env.caExportPath, []byte(testPEMCA(t)), 0o600); err != nil {
+		t.Fatalf("write ca export: %v", err)
+	}
+
+	if err := runInstall(context.Background(), env, installOpts{}); err != nil {
+		t.Fatalf("runInstall: %v\noutput:\n%s\ncalls:%+v", err, buf.String(), runner.calls)
+	}
+	for _, path := range []string{
+		env.pipelockTarget,
+		env.integrityPin,
+		env.systemUnitPath,
+		env.nftRulesPath,
+		filepath.Join(env.wrapperDir, "plk-launch"),
+		filepath.Join(env.wrapperDir, "plk-claude"),
+		env.wrapperInvPath,
+		env.sudoersPath,
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected install artifact %s: %v", path, err)
+		}
+	}
+	if !strings.Contains(buf.String(), "install complete") {
+		t.Fatalf("missing success output:\n%s", buf.String())
+	}
+}
+
 // ---------------------------------------------------------------------------
 // step-level idempotency and rollback
 // ---------------------------------------------------------------------------
@@ -381,6 +427,43 @@ func TestStepCreateUser_SkipsWhenExists(t *testing.T) {
 	if len(runner.calls) != 0 {
 		t.Errorf("expected no useradd shell-out, got %v", runner.calls)
 	}
+}
+
+func TestStepPreflightChecksRequiredBinaries(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	s := stepPreflight(installOpts{})
+
+	t.Run("success", func(t *testing.T) {
+		binDir := t.TempDir()
+		for _, name := range []string{"useradd", "userdel", "systemctl", "nft", "visudo"} {
+			path := filepath.Join(binDir, name)
+			if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil { //nolint:gosec // executable fixture required for preflight PATH lookup.
+				t.Fatalf("write %s: %v", name, err)
+			}
+		}
+		t.Setenv("PATH", binDir)
+		applied, err := s.apply(context.Background(), env)
+		if err != nil {
+			t.Fatalf("preflight: %v", err)
+		}
+		if !applied {
+			t.Fatal("preflight should report applied=true")
+		}
+	})
+
+	t.Run("missing binary", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+		applied, err := s.apply(context.Background(), env)
+		if err == nil {
+			t.Fatal("expected missing executable error")
+		}
+		if applied {
+			t.Fatal("missing executable must not report applied")
+		}
+		if !strings.Contains(err.Error(), "required executable") {
+			t.Fatalf("err: %v", err)
+		}
+	})
 }
 
 func TestStepCreateUser_CallsUseradd(t *testing.T) {
@@ -1182,6 +1265,24 @@ func TestInstallCmd_Wiring(t *testing.T) {
 	}
 	if cmd.Flag("proxy-port") == nil {
 		t.Errorf("--proxy-port flag missing")
+	}
+}
+
+func TestInstallCmdRejectsInvalidPortBeforeRootCheck(t *testing.T) {
+	cmd := installCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--dry-run", "--proxy-port", "0", "--operator-user", containInstallOperatorUser})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected invalid port error")
+	}
+	if cliutil.ExitCodeOf(err) != cliutil.ExitConfig {
+		t.Fatalf("exit code: got %d want %d", cliutil.ExitCodeOf(err), cliutil.ExitConfig)
+	}
+	if !strings.Contains(err.Error(), "--port") {
+		t.Fatalf("err: %v", err)
 	}
 }
 

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -19,6 +20,22 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 )
+
+func TestDefaultInstallEnvWiresContainmentDefaults(t *testing.T) {
+	env := defaultInstallEnv(io.Discard)
+	if env.runCmd == nil || env.stat == nil || env.lstat == nil || env.writeFile == nil || env.lookupUser == nil {
+		t.Fatal("default env has nil OS hooks")
+	}
+	if env.proxyUserName != defaultProxyUser || env.agentUserName != defaultAgentUser {
+		t.Fatalf("users: proxy=%q agent=%q", env.proxyUserName, env.agentUserName)
+	}
+	if env.configDir != defaultConfigDir || env.nftRulesPath != defaultNFTRulesPath {
+		t.Fatalf("paths not wired to defaults: config=%q nft=%q", env.configDir, env.nftRulesPath)
+	}
+	if env.proxyPort != defaultProxyPort {
+		t.Fatalf("proxy port: got %d want %d", env.proxyPort, defaultProxyPort)
+	}
+}
 
 const containInstallOperatorUser = "operator"
 
@@ -595,6 +612,34 @@ func TestStepInstallSudoers_VisudoRejectsBadFile(t *testing.T) {
 	}
 }
 
+func TestStepInstallSudoers_IdempotentExistingRule(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.sudoersPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.sudoersPath, []byte(renderSudoers(env)), 0o600); err != nil {
+		t.Fatalf("seed sudoers: %v", err)
+	}
+	s := stepInstallSudoers()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if applied {
+		t.Fatal("expected existing sudoers to skip")
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("idempotent sudoers should not run visudo, got %v", runner.calls)
+	}
+	info, err := os.Stat(env.sudoersPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != modeSudoers {
+		t.Fatalf("mode: got 0o%03o want 0o%03o", info.Mode().Perm(), modeSudoers)
+	}
+}
+
 func TestStepWriteToolWrappers_WritesAllowListedWrappers(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	writeTestToolsList(t, env, []toolsListEntry{{name: "claude", target: "/usr/local/bin/claude"}, {name: "codex", target: "/usr/local/bin/codex"}})
@@ -609,6 +654,35 @@ func TestStepWriteToolWrappers_WritesAllowListedWrappers(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(env.wrapperDir, "plk-playwright")); !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("unexpected unresolved wrapper stat err=%v", err)
+	}
+}
+
+func TestStepWriteToolWrappers_BackupsStaleDefaultWrapper(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	writeTestToolsList(t, env, []toolsListEntry{{name: "claude", target: "/usr/local/bin/claude"}})
+	stale := filepath.Join(env.wrapperDir, "plk-codex")
+	if err := os.WriteFile(stale, []byte("old codex wrapper\n"), 0o755); err != nil { //nolint:gosec // executable wrapper fixture
+		t.Fatalf("seed stale wrapper: %v", err)
+	}
+	s := stepWriteToolWrappers()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected stale wrapper backup to apply")
+	}
+	if _, err := os.Stat(stale); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stale wrapper should be moved aside, stat err=%v", err)
+	}
+	if _, err := os.Stat(stale + ".bak"); err != nil {
+		t.Fatalf("stale backup missing: %v", err)
+	}
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if _, err := os.Stat(stale); err != nil {
+		t.Fatalf("stale wrapper not restored: %v", err)
 	}
 }
 
@@ -957,6 +1031,57 @@ func TestStepInstallNFTRules_PersistsViaMainConfigAndRestores(t *testing.T) {
 	}
 }
 
+func TestStepInstallNFTRules_UndoRestoresPreviousLiveTableAndServiceState(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	previousTable := `table inet pipelock_containment {
+	chain output_filter {
+		meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+		meta skuid 987 drop
+	}
+}
+`
+	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), previousTable, 0, nil)
+	runner.on(argvFor(testSystemctl, "is-enabled", "nftables.service"), "disabled\n", 1, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected changed nft rules to apply")
+	}
+	if env.prevNFTTableDump != previousTable {
+		t.Fatalf("previous table not captured: %q", env.prevNFTTableDump)
+	}
+	if !env.prevNftablesStateKnown || env.prevNftablesEnabled {
+		t.Fatalf("previous nftables service state not captured as disabled")
+	}
+
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	restorePath := env.nftRulesPath + ".restore"
+	if _, err := os.Stat(restorePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("restore file should be removed, stat err=%v", err)
+	}
+	var sawRestore, sawDisable bool
+	for _, c := range runner.calls {
+		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == restorePath {
+			sawRestore = true
+		}
+		if c.name == testSystemctl && strings.Join(c.args, " ") == "disable nftables.service" {
+			sawDisable = true
+		}
+	}
+	if !sawRestore {
+		t.Fatalf("expected nft restore from captured table, got %v", runner.calls)
+	}
+	if !sawDisable {
+		t.Fatalf("expected nftables.service disabled-state restore, got %v", runner.calls)
+	}
+}
+
 func TestStepInstallNFTRules_UndoRemovesManagedIncludeWhenNoBackup(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	if err := os.MkdirAll(filepath.Dir(env.nftMainPath), 0o755); err != nil { //nolint:gosec // tmpdir
@@ -979,6 +1104,55 @@ func TestStepInstallNFTRules_UndoRemovesManagedIncludeWhenNoBackup(t *testing.T)
 	}
 	if strings.Contains(string(got), "Pipelock containment persistence") {
 		t.Fatalf("managed comment not removed:\n%s", got)
+	}
+}
+
+func TestStepCreateDirRejectsSymlinkTarget(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	root := t.TempDir()
+	target := filepath.Join(root, "real")
+	if err := os.MkdirAll(target, 0o750); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	s := stepCreateDir("test", func(*installEnv) string { return link }, modeDirPrivate)
+	applied, err := s.apply(context.Background(), env)
+	if err == nil {
+		t.Fatal("expected symlink target rejection")
+	}
+	if applied {
+		t.Fatal("symlink rejection must not report applied")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestStepCreateDirRejectsSymlinkParent(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	root := t.TempDir()
+	realParent := filepath.Join(root, "real-parent")
+	if err := os.MkdirAll(realParent, 0o750); err != nil {
+		t.Fatalf("mkdir parent: %v", err)
+	}
+	linkParent := filepath.Join(root, "link-parent")
+	if err := os.Symlink(realParent, linkParent); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	path := filepath.Join(linkParent, "child")
+	s := stepCreateDir("test", func(*installEnv) string { return path }, modeDirPrivate)
+	applied, err := s.apply(context.Background(), env)
+	if err == nil {
+		t.Fatal("expected symlink parent rejection")
+	}
+	if applied {
+		t.Fatal("symlink parent rejection must not report applied")
+	}
+	if !strings.Contains(err.Error(), "symlink parent") {
+		t.Fatalf("err: %v", err)
 	}
 }
 
@@ -1115,6 +1289,30 @@ func TestBackupAndWrite_NewFileNoBak(t *testing.T) {
 	}
 }
 
+func TestWriteFileAtomicWritesContentsAndMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "atomic")
+	if err := writeFileAtomic(path, []byte("one"), 0o600); err != nil {
+		t.Fatalf("write first: %v", err)
+	}
+	if err := writeFileAtomic(path, []byte("two"), 0o600); err != nil {
+		t.Fatalf("write second: %v", err)
+	}
+	got, err := os.ReadFile(path) //nolint:gosec // tmpdir-scoped test path
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "two" {
+		t.Fatalf("contents: got %q", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("mode: got 0o%03o want 0o600", info.Mode().Perm())
+	}
+}
+
 func TestBackupAndWrite_ExistingPromotesToBak(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	path := filepath.Join(t.TempDir(), "f")
@@ -1134,6 +1332,71 @@ func TestBackupAndWrite_ExistingPromotesToBak(t *testing.T) {
 	cur, _ := os.ReadFile(path) //nolint:gosec // tmpdir-scoped test path
 	if string(cur) != "new" {
 		t.Errorf("cur: %q", cur)
+	}
+}
+
+func TestBackupAndWriteRefusesExistingBackup(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "host.conf")
+	if err := os.WriteFile(path, []byte("current"), 0o600); err != nil {
+		t.Fatalf("seed current: %v", err)
+	}
+	if err := os.WriteFile(path+".bak", []byte("original"), 0o600); err != nil {
+		t.Fatalf("seed backup: %v", err)
+	}
+	err := backupAndWrite(env, path, []byte("new"), 0o600)
+	if err == nil {
+		t.Fatal("expected existing backup guard")
+	}
+	if !strings.Contains(err.Error(), "refusing to overwrite existing backup") {
+		t.Fatalf("err: %v", err)
+	}
+	got, err := env.readFile(path)
+	if err != nil {
+		t.Fatalf("read current: %v", err)
+	}
+	if string(got) != "current" {
+		t.Fatalf("current file changed: %q", got)
+	}
+	bak, err := env.readFile(path + ".bak")
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(bak) != "original" {
+		t.Fatalf("backup changed: %q", bak)
+	}
+}
+
+func TestRestoreBackupIfPresentRestoresOnlyWhenBakExists(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "host.conf")
+	if err := os.WriteFile(path, []byte("current"), 0o600); err != nil {
+		t.Fatalf("seed current: %v", err)
+	}
+	if err := restoreBackupIfPresent(env, path); err != nil {
+		t.Fatalf("restore without backup: %v", err)
+	}
+	got, err := env.readFile(path)
+	if err != nil {
+		t.Fatalf("read current: %v", err)
+	}
+	if string(got) != "current" {
+		t.Fatalf("file changed without backup: %q", got)
+	}
+	if err := os.WriteFile(path+".bak", []byte("backup"), 0o600); err != nil {
+		t.Fatalf("seed backup: %v", err)
+	}
+	if err := restoreBackupIfPresent(env, path); err != nil {
+		t.Fatalf("restore with backup: %v", err)
+	}
+	got, err = env.readFile(path)
+	if err != nil {
+		t.Fatalf("read restored: %v", err)
+	}
+	if string(got) != "backup" {
+		t.Fatalf("restored: got %q want backup", got)
 	}
 }
 

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -1,0 +1,1180 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+const containInstallOperatorUser = "operator"
+
+// fakeCall records one invocation through env.runCmd.
+type fakeCall struct {
+	name string
+	args []string
+}
+
+// fakeRunner is a programmable runCmd stand-in. tests register responses
+// keyed by full argv joined with spaces. unmatched calls return ("",0,nil)
+// so the orchestration doesn't fail just because a test didn't pre-bake a
+// response for an idempotent no-op invocation.
+type fakeRunner struct {
+	mu        sync.Mutex
+	calls     []fakeCall
+	responses map[string]struct {
+		out  string
+		code int
+		err  error
+	}
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{responses: map[string]struct {
+		out  string
+		code int
+		err  error
+	}{}}
+}
+
+func (f *fakeRunner) on(argv string, out string, code int, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.responses[argv] = struct {
+		out  string
+		code int
+		err  error
+	}{out, code, err}
+}
+
+func (f *fakeRunner) run(_ context.Context, name string, args ...string) (string, int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, fakeCall{name: name, args: append([]string(nil), args...)})
+	key := name + " " + strings.Join(args, " ")
+	if r, ok := f.responses[key]; ok {
+		return r.out, r.code, r.err
+	}
+	return "", 0, nil
+}
+
+// argvFor builds the lookup key matching fakeRunner.run.
+func argvFor(name string, args ...string) string {
+	return name + " " + strings.Join(args, " ")
+}
+
+// newFakeEnv builds an installEnv backed by tmpdirs and fake hooks. The
+// filesystem-side fields (chown, mkdirAll, etc.) are wired to real os
+// calls operating under root, the tmpdir constructed for the test; the
+// shell-out fields use a fakeRunner.
+func newFakeEnv(t *testing.T) (*installEnv, *fakeRunner, *bytes.Buffer) {
+	t.Helper()
+	root := t.TempDir()
+	runner := newFakeRunner()
+	out := &bytes.Buffer{}
+	env := &installEnv{
+		runCmd: runner.run,
+		stat:   os.Stat,
+		lstat:  os.Lstat,
+		readFile: func(p string) ([]byte, error) {
+			return os.ReadFile(filepath.Clean(p))
+		},
+		writeFile: writeFileAtomic,
+		removeFile: func(p string) error {
+			err := os.Remove(p)
+			if err != nil && errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+			return err
+		},
+		mkdirAll: os.MkdirAll,
+		// chown can't really run under non-root tests; record the call and
+		// no-op so the orchestration progresses. Tests that need to assert
+		// the chown happened can substitute their own hook.
+		chown:   func(string, int, int) error { return nil },
+		rename:  os.Rename,
+		chmod:   os.Chmod,
+		symlink: os.Symlink,
+		lookupUser: func(name string) (*user.User, error) {
+			switch name {
+			case "pipelock-proxy":
+				return &user.User{Uid: "988", Gid: "988", Username: name, HomeDir: "/var/lib/pipelock-proxy"}, nil
+			case "pipelock-agent":
+				return &user.User{Uid: "987", Gid: "987", Username: name, HomeDir: "/home/pipelock-agent"}, nil
+			case containInstallOperatorUser:
+				return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: "/home/operator"}, nil
+			}
+			return nil, user.UnknownUserError(name)
+		},
+		selfPath: func() (string, error) { return filepath.Join(root, "src", "pipelock"), nil },
+		hashFile: func(p string) (string, error) {
+			data, err := os.ReadFile(filepath.Clean(p))
+			if err != nil {
+				return "", err
+			}
+			h := sha256.Sum256(data)
+			return hex.EncodeToString(h[:]), nil
+		},
+		out:            out,
+		operatorUser:   containInstallOperatorUser,
+		proxyUserName:  "pipelock-proxy",
+		agentUserName:  "pipelock-agent",
+		configDir:      filepath.Join(root, "etc", "pipelock"),
+		dataDir:        filepath.Join(root, "var", "lib", "pipelock"),
+		wrapperDir:     filepath.Join(root, "usr", "local", "bin"),
+		systemUnitPath: filepath.Join(root, "etc", "systemd", "system", "pipelock.service"),
+		nftRulesPath:   filepath.Join(root, "etc", "nftables.d", "50-pipelock-containment.nft"),
+		nftMainPath:    filepath.Join(root, "etc", "sysconfig", "nftables.conf"),
+		sudoersPath:    filepath.Join(root, "etc", "sudoers.d", "50-pipelock-agent"),
+		caBundlePath:   filepath.Join(root, "etc", "pipelock", "combined-ca.pem"),
+		caExportPath:   filepath.Join(root, "etc", "pipelock", "ca.pem"),
+		integrityDir:   filepath.Join(root, "etc", "pipelock", "integrity"),
+		integrityPin:   filepath.Join(root, "etc", "pipelock", "integrity", "binary-pin.sha256"),
+		wrapperInvPath: filepath.Join(root, "etc", "pipelock", "contain", "wrappers.json"),
+		toolsListPath:  filepath.Join(root, "etc", "pipelock", "contain", "tools.list"),
+		pipelockTarget: filepath.Join(root, "usr", "local", "bin", "pipelock"),
+		proxyPort:      8888,
+	}
+
+	// Plant the source binary the install will copy.
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0o750); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "src", "pipelock"), []byte("fake pipelock binary"), 0o755); err != nil { //nolint:gosec // test binary fixture must be executable
+		t.Fatalf("write fake src: %v", err)
+	}
+	env.pipelockBinary = filepath.Join(root, "src", "pipelock")
+
+	// Pre-create the wrapperDir so wrapper writes don't fail.
+	if err := os.MkdirAll(env.wrapperDir, 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir wrapperDir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(env.sudoersPath), 0o750); err != nil {
+		t.Fatalf("mkdir sudoers parent: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(env.systemUnitPath), 0o750); err != nil {
+		t.Fatalf("mkdir unit parent: %v", err)
+	}
+	// Plant a fake system CA bundle the install will read.
+	systemBundle := filepath.Join(root, "etc", "ssl", "certs", "ca-bundle.crt")
+	if err := os.MkdirAll(filepath.Dir(systemBundle), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir system bundle parent: %v", err)
+	}
+	if err := os.WriteFile(systemBundle, []byte("# system bundle\n"), 0o600); err != nil {
+		t.Fatalf("write fake system bundle: %v", err)
+	}
+	// Plant a CA export file (will be created during install but we
+	// pre-create it so the runner doesn't need to mock the export
+	// subprocess writing through pipelock).
+	if err := os.MkdirAll(env.configDir, 0o750); err != nil {
+		t.Fatalf("mkdir configDir: %v", err)
+	}
+
+	// Patch defaultSystemCABundle indirection by overriding readFile so
+	// the canonical path resolves to our test path.
+	origReadFile := env.readFile
+	env.readFile = func(p string) ([]byte, error) {
+		if p == defaultSystemCABundle {
+			return os.ReadFile(systemBundle) //nolint:gosec // tmpdir-scoped test path
+		}
+		return origReadFile(p)
+	}
+
+	return env, runner, out
+}
+
+// ---------------------------------------------------------------------------
+// runInstall: root-check coverage lives in TestMutatingSubcommandsRequireRoot
+// (verify_test.go). The functions below cover the post-root-check branches.
+// ---------------------------------------------------------------------------
+
+func TestRunInstall_RejectsMissingOperatorUser(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.operatorUser = ""
+	err := runInstall(context.Background(), env, installOpts{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if cliutil.ExitCodeOf(err) != cliutil.ExitConfig {
+		t.Errorf("exit code: %d", cliutil.ExitCodeOf(err))
+	}
+	if !strings.Contains(err.Error(), "operator user not set") {
+		t.Errorf("err: %v", err)
+	}
+}
+
+func TestRunInstall_RejectsInvalidOperatorUser(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	err := runInstall(context.Background(), env, installOpts{operatorUser: "operator\nroot ALL=(ALL) NOPASSWD:ALL"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if cliutil.ExitCodeOf(err) != cliutil.ExitConfig {
+		t.Errorf("exit code: %d", cliutil.ExitCodeOf(err))
+	}
+	if !strings.Contains(err.Error(), "invalid operator user") {
+		t.Errorf("err: %v", err)
+	}
+}
+
+func TestRunInstall_RejectsUnknownOperatorUserBeforeMutation(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	err := runInstall(context.Background(), env, installOpts{operatorUser: "ghost"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if cliutil.ExitCodeOf(err) != cliutil.ExitConfig {
+		t.Errorf("exit code: %d", cliutil.ExitCodeOf(err))
+	}
+	if !strings.Contains(err.Error(), "lookup operator user ghost") {
+		t.Errorf("err: %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("expected no mutating commands before operator lookup succeeds, got %v", runner.calls)
+	}
+}
+
+func TestRunInstall_RejectsMissingConfigSource(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	err := runInstall(context.Background(), env, installOpts{configSource: "/nonexistent/pipelock.yaml"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if cliutil.ExitCodeOf(err) != cliutil.ExitConfig {
+		t.Errorf("exit code: %d", cliutil.ExitCodeOf(err))
+	}
+}
+
+func TestRunInstall_RejectsDirectoryConfigSource(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	dir := t.TempDir()
+	err := runInstall(context.Background(), env, installOpts{configSource: dir})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if cliutil.ExitCodeOf(err) != cliutil.ExitConfig {
+		t.Errorf("exit code: %d", cliutil.ExitCodeOf(err))
+	}
+	if !strings.Contains(err.Error(), "is a directory") {
+		t.Errorf("err: %v", err)
+	}
+}
+
+func TestRunInstall_RejectsMissingBinary(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.pipelockBinary = ""
+	env.selfPath = func() (string, error) { return "/nonexistent/pipelock", nil }
+	err := runInstall(context.Background(), env, installOpts{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if cliutil.ExitCodeOf(err) != cliutil.ExitConfig {
+		t.Errorf("exit code: %d", cliutil.ExitCodeOf(err))
+	}
+}
+
+func TestRunInstall_RejectsBinaryIsDirectory(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.pipelockBinary = t.TempDir() // a dir
+	err := runInstall(context.Background(), env, installOpts{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "is a directory") {
+		t.Errorf("err: %v", err)
+	}
+}
+
+func TestRunInstall_SelfPathFallback(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.pipelockBinary = ""
+	env.selfPath = func() (string, error) { return "", errors.New("no exe") }
+	err := runInstall(context.Background(), env, installOpts{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "locate pipelock binary") {
+		t.Errorf("err: %v", err)
+	}
+}
+
+func TestRunInstall_DryRunSucceedsWithoutMutation(t *testing.T) {
+	env, runner, buf := newFakeEnv(t)
+	err := runInstall(context.Background(), env, installOpts{dryRun: true})
+	if err != nil {
+		t.Fatalf("dry-run err: %v", err)
+	}
+	// Dry-run should NOT have shelled out for any mutation.
+	if len(runner.calls) != 0 {
+		t.Errorf("dry-run shelled out: %v", runner.calls)
+	}
+	if !strings.Contains(buf.String(), "planned steps") {
+		t.Errorf("missing 'planned steps' header: %q", buf.String())
+	}
+}
+
+func TestRunInstall_DryRunPrintsPlan(t *testing.T) {
+	if os.Geteuid() != 0 {
+		// We can't bypass the root check from a unit test. Instead, drive
+		// installSteps directly and print the plan to verify content.
+		opts := installOpts{dryRun: true}
+		steps := installSteps(opts)
+		var buf bytes.Buffer
+		printPlan(&buf, "header:", steps)
+		out := buf.String()
+		if !strings.Contains(out, "preflight") || !strings.Contains(out, "install pipelock binary") || !strings.Contains(out, "/etc/sudoers.d/50-pipelock-agent") {
+			t.Errorf("plan missing required steps: %q", out)
+		}
+		// Sanity: the plan should NOT execute anything in dry-run.
+		if strings.Contains(out, "[FAIL]") || strings.Contains(out, "[ OK ]") {
+			t.Errorf("dry-run plan should not include step outcomes: %q", out)
+		}
+		return
+	}
+	t.Skip("root path covered in TestRunInstall_EndToEnd")
+}
+
+// ---------------------------------------------------------------------------
+// step-level idempotency and rollback
+// ---------------------------------------------------------------------------
+
+func TestStepCreateUser_SkipsWhenExists(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	s := stepCreateUser(true) // proxy
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if applied {
+		t.Errorf("expected skip (user already exists in fake lookup), got applied=true; runner=%v", runner.calls)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("expected no useradd shell-out, got %v", runner.calls)
+	}
+}
+
+func TestStepCreateUser_CallsUseradd(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	// Make the proxy user unknown so apply has to call useradd.
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == "pipelock-proxy" {
+			return nil, user.UnknownUserError(name)
+		}
+		return &user.User{Uid: "987", Gid: "987", Username: name}, nil
+	}
+	s := stepCreateUser(true)
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Errorf("expected applied=true")
+	}
+	if len(runner.calls) != 1 || runner.calls[0].name != "useradd" {
+		t.Errorf("expected one useradd call, got %v", runner.calls)
+	}
+	if !containsArg(runner.calls[0].args, "pipelock-proxy") {
+		t.Errorf("useradd missing target user: %v", runner.calls[0].args)
+	}
+}
+
+func TestStepWriteSystemUnit_IdempotentOnReapply(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	s := stepWriteSystemUnit()
+	a1, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply 1: %v", err)
+	}
+	if !a1 {
+		t.Errorf("first apply should write the unit")
+	}
+	a2, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply 2: %v", err)
+	}
+	if a2 {
+		t.Errorf("second apply should skip (unit already correct)")
+	}
+}
+
+func TestStepWriteSystemUnit_UndoRestoresBackup(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	// Pre-create a unit file so write triggers backup.
+	prior := []byte("[Unit]\nDescription=original\n")
+	if err := os.WriteFile(env.systemUnitPath, prior, 0o600); err != nil {
+		t.Fatalf("seed unit: %v", err)
+	}
+	s := stepWriteSystemUnit()
+	if _, err := s.apply(context.Background(), env); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	// Backup must exist with original contents.
+	bak, err := os.ReadFile(env.systemUnitPath + ".bak")
+	if err != nil {
+		t.Fatalf("read bak: %v", err)
+	}
+	if string(bak) != string(prior) {
+		t.Errorf(".bak contents drift: got %q", bak)
+	}
+	// Undo must restore.
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	restored, err := os.ReadFile(env.systemUnitPath)
+	if err != nil {
+		t.Fatalf("read restored: %v", err)
+	}
+	if string(restored) != string(prior) {
+		t.Errorf("restore drift: got %q", restored)
+	}
+}
+
+func TestStepInstallPipelockBinary_SkipsWhenIdentical(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	// Run apply once.
+	s := stepInstallPipelockBinary()
+	if _, err := s.apply(context.Background(), env); err != nil {
+		t.Fatalf("apply 1: %v", err)
+	}
+	// Re-run apply; should skip because hashes match.
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply 2: %v", err)
+	}
+	if applied {
+		t.Errorf("expected skip when binary already matches")
+	}
+}
+
+func TestStepWriteIntegrityPin_WritesAndIsIdempotent(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	var chowned []string
+	env.chown = func(path string, _, _ int) error {
+		chowned = append(chowned, path)
+		return nil
+	}
+	// Plant the target binary.
+	if err := os.MkdirAll(filepath.Dir(env.pipelockTarget), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.pipelockTarget, []byte("installed pipelock"), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("plant target: %v", err)
+	}
+
+	pinStep := stepWriteIntegrityPin()
+	a1, err := pinStep.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !a1 {
+		t.Errorf("first apply should write pin")
+	}
+
+	pin, err := os.ReadFile(env.integrityPin)
+	if err != nil {
+		t.Fatalf("read pin: %v", err)
+	}
+	want := sha256.Sum256([]byte("installed pipelock"))
+	if strings.TrimSpace(string(pin)) != hex.EncodeToString(want[:]) {
+		t.Errorf("pin: got %q, want %q", pin, hex.EncodeToString(want[:]))
+	}
+	if !containsString(chowned, env.integrityDir) {
+		t.Errorf("integrity dir was not chowned: %v", chowned)
+	}
+	if !containsString(chowned, env.integrityPin) {
+		t.Errorf("integrity pin was not chowned: %v", chowned)
+	}
+
+	a2, err := pinStep.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply 2: %v", err)
+	}
+	if a2 {
+		t.Errorf("second apply should skip when pin matches")
+	}
+}
+
+func TestRenderNFTRules_ContainsExpectedRules(t *testing.T) {
+	body := renderNFTRules(1000, 988, 987, 8888, "pipelock_containment", "output_filter")
+	wantSubstrings := []string{
+		`table inet pipelock_containment`,
+		`chain output_filter`,
+		"meta skuid 1000 accept",
+		"meta skuid 988 accept",
+		"meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept",
+		"meta skuid 987 drop",
+	}
+	for _, s := range wantSubstrings {
+		if !strings.Contains(body, s) {
+			t.Errorf("rules missing %q in:\n%s", s, body)
+		}
+	}
+}
+
+func TestRenderLaunchWrapper_HasExpectedEnv(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	body := renderLaunchWrapper(env)
+	wants := []string{
+		"#!/bin/bash",
+		"HTTPS_PROXY=http://127.0.0.1:8888",
+		"NO_PROXY=127.0.0.1,localhost",
+		"NODE_EXTRA_CA_CERTS=" + env.caExportPath,
+		"SSL_CERT_FILE=" + env.caBundlePath,
+		`"$TARGET"`,
+	}
+	for _, s := range wants {
+		if !strings.Contains(body, s) {
+			t.Errorf("plk-launch body missing %q", s)
+		}
+	}
+	// plk-launch must never call sudo as a command — the per-tool wrapper
+	// does the outer sudo. We allow the word "sudo" to appear inside
+	// comments (describing why we set our own PATH instead of inheriting
+	// sudo's secure_path), but NOT as an actual command invocation.
+	for _, l := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(l)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.Contains(trimmed, "sudo ") || strings.HasPrefix(trimmed, "sudo") {
+			t.Errorf("plk-launch must NOT use inner sudo (found: %q)", l)
+		}
+	}
+}
+
+func TestRenderToolWrapper_UsesSudo(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	body := renderToolWrapper(env, "claude")
+	if !strings.Contains(body, "sudo -n -u pipelock-agent") {
+		t.Errorf("missing outer non-interactive sudo: %s", body)
+	}
+	if !strings.Contains(body, "plk-launch claude") {
+		t.Errorf("missing plk-launch dispatch: %s", body)
+	}
+}
+
+func TestRenderSudoers_HasOperatorAndLauncher(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	body := renderSudoers(env)
+	if !strings.Contains(body, "operator ALL=(pipelock-agent) NOPASSWD: ") {
+		t.Errorf("sudoers missing rule: %s", body)
+	}
+	if !strings.Contains(body, "plk-launch *") {
+		t.Errorf("sudoers missing glob: %s", body)
+	}
+}
+
+func TestStepInstallSudoers_VisudoRejectsBadFile(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	// Make visudo fail validation. The step must roll the file back via
+	// restoreBackup so a bad sudoers never persists.
+	runner.on(argvFor("visudo", "-cf", env.sudoersPath), "syntax error", 1, nil)
+	s := stepInstallSudoers()
+	applied, err := s.apply(context.Background(), env)
+	if err == nil {
+		t.Fatalf("expected visudo rejection error; applied=%v", applied)
+	}
+	if !strings.Contains(err.Error(), "visudo rejected") {
+		t.Errorf("err: %v", err)
+	}
+	if _, err := os.Stat(env.sudoersPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("bad sudoers must be removed after visudo failure; stat err=%v", err)
+	}
+}
+
+func TestStepWriteToolWrappers_WritesAllowListedWrappers(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	writeTestToolsList(t, env, []toolsListEntry{{name: "claude", target: "/usr/local/bin/claude"}, {name: "codex", target: "/usr/local/bin/codex"}})
+	s := stepWriteToolWrappers()
+	if _, err := s.apply(context.Background(), env); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	for _, tool := range []string{"plk-claude", "plk-codex"} {
+		if _, err := os.Stat(filepath.Join(env.wrapperDir, tool)); err != nil {
+			t.Errorf("missing wrapper %s: %v", tool, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(env.wrapperDir, "plk-playwright")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("unexpected unresolved wrapper stat err=%v", err)
+	}
+}
+
+func TestStepWriteToolWrappers_UndoRestoresCustomWrapper(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	writeTestToolsList(t, env, []toolsListEntry{{name: "rustup", target: "/usr/local/bin/rustup"}})
+	path := filepath.Join(env.wrapperDir, "plk-rustup")
+	if err := os.WriteFile(path, []byte("old wrapper\n"), 0o755); err != nil { //nolint:gosec // wrapper fixture
+		t.Fatalf("write old wrapper: %v", err)
+	}
+
+	s := stepWriteToolWrappers()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected wrapper rewrite")
+	}
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Clean(path)) //nolint:gosec // test fixture path is under t.TempDir.
+	if err != nil {
+		t.Fatalf("read restored wrapper: %v", err)
+	}
+	if string(got) != "old wrapper\n" {
+		t.Fatalf("wrapper not restored: %q", got)
+	}
+}
+
+func TestStepWriteWrapperInventory_RoundTrip(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	writeTestToolsList(t, env, []toolsListEntry{{name: "claude", target: "/usr/local/bin/claude"}})
+	s := stepWriteWrapperInventory()
+	if _, err := s.apply(context.Background(), env); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	// Idempotency: rerun.
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply 2: %v", err)
+	}
+	if applied {
+		t.Errorf("expected idempotent no-op on second apply")
+	}
+	inv := readWrapperInventory(env)
+	if !stringSlicesEqual(inv, []string{"plk-claude"}) {
+		t.Errorf("inventory: got %v, want [plk-claude]", inv)
+	}
+}
+
+func TestStepWriteWrapperInventory_UsesToolsListEntries(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	writeTestToolsList(t, env, []toolsListEntry{{name: "rustup", target: "/usr/local/bin/rustup"}})
+	if err := os.MkdirAll(filepath.Dir(env.wrapperInvPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir: %v", err)
+	}
+	body, err := marshalWrapperInventory(wrapperInventory{
+		Wrappers: []string{"plk-claude", "plk-rustup"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(env.wrapperInvPath, body, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	s := stepWriteWrapperInventory()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected inventory rewrite to match tools.list")
+	}
+	inv := readWrapperInventory(env)
+	if !stringSlicesEqual(inv, []string{"plk-rustup"}) {
+		t.Fatalf("inventory: %v, want [plk-rustup]", inv)
+	}
+}
+
+func TestStepWriteWrapperInventory_AddsMissingToolsListWrapper(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	writeTestToolsList(t, env, []toolsListEntry{{name: "claude", target: "/usr/local/bin/claude"}, {name: "rustup", target: "/usr/local/bin/rustup"}})
+	if err := os.MkdirAll(filepath.Dir(env.wrapperInvPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir: %v", err)
+	}
+	body, err := marshalWrapperInventory(wrapperInventory{Wrappers: []string{"plk-rustup"}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(env.wrapperInvPath, body, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	s := stepWriteWrapperInventory()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected missing defaults to be added")
+	}
+	inv := readWrapperInventory(env)
+	if !stringSlicesEqual(inv, []string{"plk-claude", "plk-rustup"}) {
+		t.Fatalf("inventory: %v, want [plk-claude plk-rustup]", inv)
+	}
+}
+
+func writeTestToolsList(t *testing.T, env *installEnv, entries []toolsListEntry) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(env.toolsListPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir tools.list parent: %v", err)
+	}
+	if err := os.WriteFile(env.toolsListPath, []byte(renderToolsList(entries)), 0o600); err != nil {
+		t.Fatalf("write tools.list: %v", err)
+	}
+}
+
+func TestStepInstallNFTRules_SkipsWhenLoaded(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	// Pre-write the file so the body matches.
+	operatorUID, proxyUID, agentUID := 1000, 988, 987
+	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(env.nftMainPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir main config parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftMainPath, []byte(nftRulesIncludeLine(env.nftRulesPath)+"\n"), 0o600); err != nil {
+		t.Fatalf("write main config: %v", err)
+	}
+	// Make `nft list table` succeed with a healthy live table.
+	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), body, 0, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if applied {
+		t.Errorf("expected skip when rules file matches and table is loaded")
+	}
+}
+
+func TestStepInstallNFTRules_ReloadsWhenLoadedTableDrifted(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	operatorUID, proxyUID, agentUID := 1000, 988, 987
+	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir rules parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(env.nftMainPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir main config parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftMainPath, []byte(nftRulesIncludeLine(env.nftRulesPath)+"\n"), 0o600); err != nil {
+		t.Fatalf("write main config: %v", err)
+	}
+	drifted := `table inet pipelock_containment {
+		chain output_filter {
+			meta oif "lo" accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 drop
+		}
+	}
+`
+	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), drifted, 0, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected live drift repair")
+	}
+
+	var sawDelete, sawLoad bool
+	for _, c := range runner.calls {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+			sawDelete = true
+		}
+		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
+			sawLoad = true
+		}
+	}
+	if !sawDelete || !sawLoad {
+		t.Fatalf("expected delete+reload for live drift, got %v", runner.calls)
+	}
+}
+
+func TestStepInstallNFTRules_RepairsMissingPersistenceOnRerun(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	operatorUID, proxyUID, agentUID := 1000, 988, 987
+	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir rules parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), "table inet pipelock_containment {}", 0, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected rerun to repair missing persistence include")
+	}
+	mainBody, err := os.ReadFile(env.nftMainPath)
+	if err != nil {
+		t.Fatalf("read main config: %v", err)
+	}
+	if !strings.Contains(string(mainBody), nftRulesIncludeLine(env.nftRulesPath)) {
+		t.Fatalf("main config missing include:\n%s", mainBody)
+	}
+}
+
+func TestStepInstallNFTRules_LoadsWhenAbsent(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	// nft validate + load + systemctl enable should all succeed by default.
+	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), "", 1, fmt.Errorf("not loaded"))
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Errorf("expected apply=true on fresh install")
+	}
+	// Verify the file exists.
+	if _, err := os.Stat(env.nftRulesPath); err != nil {
+		t.Errorf("rules file not written: %v", err)
+	}
+	// Verify the run sequence included validate then load.
+	var sawValidate, sawLoad bool
+	for _, c := range runner.calls {
+		if c.name == testNFT && len(c.args) >= 2 && c.args[0] == "-c" && c.args[1] == "-f" {
+			sawValidate = true
+		}
+		if c.name == testNFT && len(c.args) >= 1 && c.args[0] == "-f" && (len(c.args) < 2 || c.args[0] != "-c") {
+			sawLoad = true
+		}
+	}
+	if !sawValidate || !sawLoad {
+		t.Errorf("expected validate + load in run sequence, got %v", runner.calls)
+	}
+}
+
+func TestStepInstallNFTRules_DropsLoadedTableBeforeChangedReload(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir rules parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath, []byte("old broad-loopback rules\n"), 0o600); err != nil {
+		t.Fatalf("write old rules: %v", err)
+	}
+	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), "table inet pipelock_containment {}", 0, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected changed rules to apply")
+	}
+
+	deleteIdx, loadIdx := -1, -1
+	for i, c := range runner.calls {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+			deleteIdx = i
+		}
+		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
+			loadIdx = i
+		}
+	}
+	if deleteIdx == -1 {
+		t.Fatalf("expected nft delete table before reload, got %v", runner.calls)
+	}
+	if loadIdx == -1 {
+		t.Fatalf("expected nft -f reload, got %v", runner.calls)
+	}
+	if deleteIdx > loadIdx {
+		t.Fatalf("delete must precede reload: delete=%d load=%d calls=%v", deleteIdx, loadIdx, runner.calls)
+	}
+}
+
+func TestStepInstallNFTRules_PersistsViaMainConfigAndRestores(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	original := "flush ruleset\n"
+	if err := os.MkdirAll(filepath.Dir(env.nftMainPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir main config parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftMainPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write main config: %v", err)
+	}
+	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), "", 1, fmt.Errorf("not loaded"))
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected apply=true")
+	}
+
+	mainBody, err := os.ReadFile(env.nftMainPath)
+	if err != nil {
+		t.Fatalf("read main config: %v", err)
+	}
+	if !strings.Contains(string(mainBody), nftRulesIncludeLine(env.nftRulesPath)) {
+		t.Fatalf("main config missing include:\n%s", mainBody)
+	}
+
+	var sawMainValidation bool
+	for _, c := range runner.calls {
+		if c.name == testNFT && len(c.args) == 3 && c.args[0] == "-c" && c.args[1] == "-f" && c.args[2] == env.nftMainPath {
+			sawMainValidation = true
+		}
+	}
+	if !sawMainValidation {
+		t.Fatalf("expected nft -c -f main config validation, got %v", runner.calls)
+	}
+
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	restored, err := os.ReadFile(env.nftMainPath)
+	if err != nil {
+		t.Fatalf("read restored main config: %v", err)
+	}
+	if string(restored) != original {
+		t.Fatalf("main config not restored: got %q want %q", restored, original)
+	}
+}
+
+func TestStepInstallNFTRules_UndoRemovesManagedIncludeWhenNoBackup(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.nftMainPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir main config parent: %v", err)
+	}
+	body := "flush ruleset\n\n# Pipelock containment persistence\n" + nftRulesIncludeLine(env.nftRulesPath) + "\n"
+	if err := os.WriteFile(env.nftMainPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write main config: %v", err)
+	}
+
+	if err := restoreOrRemoveNFTMainInclude(env); err != nil {
+		t.Fatalf("restore/remove include: %v", err)
+	}
+	got, err := os.ReadFile(env.nftMainPath)
+	if err != nil {
+		t.Fatalf("read main config: %v", err)
+	}
+	if strings.Contains(string(got), nftRulesIncludeLine(env.nftRulesPath)) {
+		t.Fatalf("include not removed:\n%s", got)
+	}
+	if strings.Contains(string(got), "Pipelock containment persistence") {
+		t.Fatalf("managed comment not removed:\n%s", got)
+	}
+}
+
+func TestInstallSteps_Count(t *testing.T) {
+	// Sanity: the install flow has 21 steps total (20 install + 1 tools.list
+	// allow-list). Changing this count is a documented breaking change for
+	// the dry-run / verify probe-4 inventory.
+	steps := installSteps(installOpts{})
+	if len(steps) != 21 {
+		t.Errorf("installSteps count: got %d, want 21", len(steps))
+	}
+}
+
+func TestInstallCmd_Wiring(t *testing.T) {
+	cmd := installCmd()
+	if cmd.Use != "install" {
+		t.Errorf("cmd.Use: %q", cmd.Use)
+	}
+	if cmd.Flag("dry-run") == nil {
+		t.Errorf("--dry-run flag missing")
+	}
+	if cmd.Flag("pipelock-binary") == nil {
+		t.Errorf("--pipelock-binary flag missing")
+	}
+	if cmd.Flag("config") == nil {
+		t.Errorf("--config flag missing")
+	}
+	if cmd.Flag("proxy-port") == nil {
+		t.Errorf("--proxy-port flag missing")
+	}
+}
+
+func TestWalkAndChown_NoOpEnvCallsForEveryFile(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	chownCalls := 0
+	env.chown = func(string, int, int) error {
+		chownCalls++
+		return nil
+	}
+	root := filepath.Join(t.TempDir(), "tree")
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "file"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "sub", "file2"), []byte("y"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := walkAndChown(env, root, 988, 988); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	// root + sub + file + file2 = 4 entries.
+	if chownCalls != 4 {
+		t.Errorf("chown calls: got %d, want 4", chownCalls)
+	}
+}
+
+func TestPathExists(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if pathExists(env, "/definitely/not/a/real/path/here") {
+		t.Errorf("expected false for missing")
+	}
+	if !pathExists(env, env.pipelockBinary) {
+		t.Errorf("expected true for planted source binary")
+	}
+}
+
+func TestExpectExec_HitsAndMisses(t *testing.T) {
+	// /bin/sh exists everywhere we care about.
+	if err := expectExec("sh"); err != nil {
+		t.Errorf("sh expected to exist: %v", err)
+	}
+	if err := expectExec("nonexistent-binary-pipelock-test-12345"); err == nil {
+		t.Errorf("expected error for missing binary")
+	}
+}
+
+func TestCollapseWS(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"hello\n  world", "hello world"},
+		{"  leading  ", "leading"},
+		{"tabs\tand\tnewlines\n", "tabs and newlines"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := collapseWS(c.in); got != c.want {
+			t.Errorf("collapseWS(%q): got %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTruncateForErr(t *testing.T) {
+	long := strings.Repeat("x", 500)
+	got := truncateForErr(long)
+	// 200 chars + the UTF-8 ellipsis (3 bytes). Use HasSuffix to avoid
+	// hard-coding the rune byte length.
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncated string missing ellipsis suffix: %q", got)
+	}
+	if len(strings.TrimSuffix(got, "…")) != 200 {
+		t.Errorf("truncated prefix len: got %d, want 200", len(strings.TrimSuffix(got, "…")))
+	}
+	if got := truncateForErr("short"); got != "short" {
+		t.Errorf("short: %q", got)
+	}
+}
+
+func TestSHA256HexOfFile(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "x")
+	if err := os.WriteFile(tmp, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := sha256HexOfFile(tmp)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	want := "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+	if got != want {
+		t.Errorf("hash: got %s, want %s", got, want)
+	}
+}
+
+func TestBackupAndWrite_NewFileNoBak(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	path := filepath.Join(t.TempDir(), "new")
+	if err := backupAndWrite(env, path, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := os.Stat(path + ".bak"); err == nil {
+		t.Errorf("unexpected .bak when path was new")
+	}
+}
+
+func TestBackupAndWrite_ExistingPromotesToBak(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	path := filepath.Join(t.TempDir(), "f")
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := backupAndWrite(env, path, []byte("new"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	bak, err := os.ReadFile(path + ".bak") //nolint:gosec // tmpdir-scoped test path
+	if err != nil {
+		t.Fatalf("read bak: %v", err)
+	}
+	if string(bak) != "old" {
+		t.Errorf("bak: %q", bak)
+	}
+	cur, _ := os.ReadFile(path) //nolint:gosec // tmpdir-scoped test path
+	if string(cur) != "new" {
+		t.Errorf("cur: %q", cur)
+	}
+}
+
+func TestRestoreBackup_PromotesBak(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f")
+	if err := os.WriteFile(path+".bak", []byte("backup"), 0o600); err != nil {
+		t.Fatalf("seed bak: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("current"), 0o600); err != nil {
+		t.Fatalf("seed current: %v", err)
+	}
+	if err := restoreBackup(env, path); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	got, _ := os.ReadFile(path) //nolint:gosec // tmpdir-scoped test path
+	if string(got) != "backup" {
+		t.Errorf("restored: %q", got)
+	}
+}
+
+func TestRestoreBackup_RemovesWhenNoBak(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	path := filepath.Join(t.TempDir(), "f")
+	if err := os.WriteFile(path, []byte("current"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := restoreBackup(env, path); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected path removed; stat err=%v", err)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/contain/osops.go
+++ b/internal/cli/contain/osops.go
@@ -1,0 +1,395 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+)
+
+// installEnv is the OS-facing dependency surface used by every mutating
+// subcommand. Each operation is a function value so tests can inject fakes
+// without touching the real filesystem, /etc/sudoers, or the running
+// systemd. Real construction is via defaultInstallEnv(); tests build a
+// struct literal with their own hooks.
+type installEnv struct {
+	// runCmd shells out. Returns merged stdout+stderr (bounded), the
+	// process exit code, and a startup error (nil if the binary ran even
+	// when it exited non-zero). Same contract as verify.go's runCommand.
+	runCmd runCommand
+
+	// stat / readFile / writeFile / removeFile mirror the os package. They
+	// are abstracted only so tests can run on a tmpdir without sudo. Path
+	// arguments are absolute by convention; the orchestration code
+	// constructs them via env helpers (etcPath, wrapperPath, ...).
+	stat       func(path string) (os.FileInfo, error)
+	lstat      func(path string) (os.FileInfo, error)
+	readFile   func(path string) ([]byte, error)
+	writeFile  func(path string, contents []byte, mode os.FileMode) error
+	removeFile func(path string) error
+	mkdirAll   func(path string, mode os.FileMode) error
+	chown      func(path string, uid, gid int) error
+	rename     func(oldPath, newPath string) error
+	chmod      func(path string, mode os.FileMode) error
+	symlink    func(target, linkPath string) error
+
+	// lookupUser resolves system users by name. Used to translate the
+	// configured proxy/agent user names into numeric UIDs for nft rules
+	// and chown calls.
+	lookupUser lookupUserFunc
+
+	// selfPath returns the absolute path of the currently-executing
+	// pipelock binary. Used to default the --pipelock-binary flag and to
+	// compute the integrity-pin hash.
+	selfPath func() (string, error)
+
+	// hashFile reads path and returns its SHA-256 as a hex string. Split
+	// from runCmd so tests can pin without round-tripping through sha256sum.
+	hashFile func(path string) (string, error)
+
+	// Output sink for human progress lines. cmd.OutOrStdout() in production.
+	out io.Writer
+
+	// Static configuration. These mirror the constants in verify.go so the
+	// two subsystems agree on filesystem layout. Made fields rather than
+	// constants so the install subcommand can accept flag overrides.
+	operatorUser   string
+	proxyUserName  string
+	agentUserName  string
+	configDir      string
+	dataDir        string
+	wrapperDir     string
+	systemUnitPath string
+	nftRulesPath   string
+	nftMainPath    string
+	sudoersPath    string
+	caBundlePath   string
+	caExportPath   string
+	integrityDir   string
+	integrityPin   string
+	wrapperInvPath string
+	toolsListPath  string // plk-launch's runtime allow-list (tab-separated NAME\tTARGET)
+	pipelockBinary string // source binary path passed to --pipelock-binary
+	pipelockTarget string // destination, default /usr/local/bin/pipelock
+	proxyPort      int
+}
+
+// defaultInstallEnv wires installEnv to the real OS. Callers fill in
+// pipelockBinary (from --pipelock-binary or os.Executable) before running
+// steps. operatorUser defaults to $SUDO_USER and is only honored if non-empty
+// — step1 (preflight) errors out cleanly if root invoked install without
+// sudo (where $SUDO_USER is empty) and -- no override flag was passed.
+func defaultInstallEnv(out io.Writer) *installEnv {
+	return &installEnv{
+		runCmd:         realRunCommand,
+		stat:           os.Stat,
+		lstat:          os.Lstat,
+		readFile:       os.ReadFile,
+		writeFile:      writeFileAtomic,
+		removeFile:     os.Remove,
+		mkdirAll:       os.MkdirAll,
+		chown:          os.Chown,
+		rename:         os.Rename,
+		chmod:          os.Chmod,
+		symlink:        os.Symlink,
+		lookupUser:     user.Lookup,
+		selfPath:       os.Executable,
+		hashFile:       sha256HexOfFile,
+		out:            out,
+		operatorUser:   os.Getenv("SUDO_USER"),
+		proxyUserName:  defaultProxyUser,
+		agentUserName:  defaultAgentUser,
+		configDir:      defaultConfigDir,
+		dataDir:        defaultDataDir,
+		wrapperDir:     defaultWrapperDir,
+		systemUnitPath: defaultSystemUnitPath,
+		nftRulesPath:   defaultNFTRulesPath,
+		nftMainPath:    defaultNFTMainConfigPath,
+		sudoersPath:    defaultSudoersPath,
+		caBundlePath:   defaultCABundlePath,
+		caExportPath:   defaultCAExportPath,
+		integrityDir:   defaultIntegrityDir,
+		integrityPin:   defaultIntegrityPin,
+		wrapperInvPath: defaultWrapperInvPath,
+		toolsListPath:  defaultToolsListPath,
+		pipelockTarget: defaultPipelockTarget,
+		proxyPort:      defaultProxyPort,
+	}
+}
+
+// Additional layout constants. They live alongside the verify.go defaults
+// so the two subsystems agree on filesystem layout. Names are picked to
+// avoid collision with verify.go constants.
+const (
+	defaultConfigDir         = "/etc/pipelock"
+	defaultDataDir           = "/var/lib/pipelock"
+	defaultSystemUnitPath    = "/etc/systemd/system/pipelock.service"
+	defaultNFTRulesPath      = "/etc/nftables.d/50-pipelock-containment.nft"
+	defaultNFTMainConfigPath = "/etc/sysconfig/nftables.conf"
+	defaultSudoersPath       = "/etc/sudoers.d/50-pipelock-agent"
+	defaultCAExportPath      = "/etc/pipelock/ca.pem"
+	defaultIntegrityDir      = "/etc/pipelock/integrity"
+	defaultIntegrityPin      = "/etc/pipelock/integrity/binary-pin.sha256"
+	defaultWrapperInvPath    = "/etc/pipelock/contain/wrappers.json"
+	defaultToolsListPath     = "/etc/pipelock/contain/tools.list"
+	defaultPipelockTarget    = "/usr/local/bin/pipelock"
+	defaultSystemCABundle    = "/etc/ssl/certs/ca-bundle.crt"
+
+	// File modes. The model is "pipelock-agent UID must be able to read every
+	// file the wrappers depend on at runtime, but cannot read secrets
+	// (config, integrity pin)." pipelock-agent reads CA bundles, the runtime
+	// allow-list, and the wrapper inventory; everything else stays
+	// pipelock-proxy/root scoped.
+	modeCAReadable        os.FileMode = 0o644 // /etc/pipelock/{ca,combined-ca}.pem — pipelock-agent reads
+	modeAllowListReadable os.FileMode = 0o644 // /etc/pipelock/contain/{tools.list,wrappers.json} — pipelock-agent reads
+	modeConfigSecret      os.FileMode = 0o640 // /etc/pipelock/pipelock.yaml — pipelock-proxy reads, pipelock-agent denied
+	modePinSecret         os.FileMode = 0o600 // integrity pin — pipelock-proxy only
+	modeSudoers           os.FileMode = 0o440 // /etc/sudoers.d/*
+	modeWrapperExec       os.FileMode = 0o755 // /usr/local/bin/plk-*
+	modeUnitFile          os.FileMode = 0o644
+	modeNFTFile           os.FileMode = 0o644
+	modeNFTMainConfig     os.FileMode = 0o600
+	// Directory modes. modeDirTraversable applies to dirs pipelock-agent must
+	// walk into (/etc/pipelock, /etc/pipelock/contain); modeDirPrivate is
+	// for dirs containing only pipelock-proxy-readable secrets (integrity
+	// pin, captures).
+	modeDirTraversable os.FileMode = 0o755
+	modeDirPrivate     os.FileMode = 0o750
+	// modeDirSystem is retained for callers that don't yet distinguish
+	// traversable from private. Prefer the explicit variants in new code.
+	modeDirSystem   os.FileMode = 0o750
+	modeDirReadable os.FileMode = 0o755
+)
+
+// writeFileAtomic writes path by creating a sibling .tmp and renaming it
+// into place. This makes installs robust to crash mid-write: either the
+// previous content stays intact, or the new content is fully present.
+func writeFileAtomic(path string, contents []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".pipelock-contain-*")
+	if err != nil {
+		return fmt.Errorf("create temp in %s: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+
+	if _, err := tmp.Write(contents); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("write %s: %w", tmpName, err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("chmod %s: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close %s: %w", tmpName, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename %s -> %s: %w", tmpName, path, err)
+	}
+	return nil
+}
+
+// sha256HexOfFile computes SHA-256 of the file at path and returns the
+// lower-case hex digest. Used for the integrity pin write at install and
+// the integrity probe at verify.
+func sha256HexOfFile(path string) (string, error) {
+	clean := filepath.Clean(path)
+	f, err := os.Open(clean) //nolint:gosec // G304: clean path; binary pin is install-time TOFU, see contain-cli-design §3.2
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", clean, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("hash %s: %w", clean, err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// backupAndWrite writes a new version of path while preserving the old
+// content as path.bak. The .bak is created via atomic rename so a crash
+// mid-backup either leaves the original in place or has fully moved it
+// aside. Step undo functions look for path.bak and restore it.
+//
+// If path doesn't exist, no .bak is created; the new file is written as-is.
+func backupAndWrite(env *installEnv, path string, contents []byte, mode os.FileMode) error {
+	if _, err := env.stat(path); err == nil {
+		bak := path + ".bak"
+		if err := env.rename(path, bak); err != nil {
+			return fmt.Errorf("backup %s -> %s: %w", path, bak, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	return env.writeFile(path, contents, mode)
+}
+
+// restoreBackup is the inverse of backupAndWrite, used by undo functions.
+// If path.bak exists, restore it over path. If path.bak does not exist,
+// remove path (the install created it fresh). Errors that don't matter for
+// rollback (target already gone) are swallowed.
+func restoreBackup(env *installEnv, path string) error {
+	bak := path + ".bak"
+	if _, err := env.stat(bak); err == nil {
+		// Best-effort cleanup of any non-bak file first; rename below
+		// then atomically promotes the backup.
+		_ = env.removeFile(path)
+		if err := env.rename(bak, path); err != nil {
+			return fmt.Errorf("restore %s from %s: %w", path, bak, err)
+		}
+		return nil
+	}
+	if err := env.removeFile(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove %s: %w", path, err)
+	}
+	return nil
+}
+
+// restoreBackupIfPresent restores path.bak over path when a backup exists.
+// If no backup exists, it leaves path untouched. Use this for host-owned
+// files such as /etc/sysconfig/nftables.conf where deleting the file on
+// rollback would be worse than leaving a harmless managed include absent.
+func restoreBackupIfPresent(env *installEnv, path string) error {
+	bak := path + ".bak"
+	if _, err := env.stat(bak); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("stat %s: %w", bak, err)
+	}
+	_ = env.removeFile(path)
+	if err := env.rename(bak, path); err != nil {
+		return fmt.Errorf("restore %s from %s: %w", path, bak, err)
+	}
+	return nil
+}
+
+// resolveUIDs returns the numeric UIDs for the configured proxy and agent
+// users. Returns an error wrapping os/user.UnknownUserError when either is
+// missing — callers translate that into a clear install error.
+func resolveUIDs(env *installEnv) (proxyUID, agentUID int, err error) {
+	proxy, err := env.lookupUser(env.proxyUserName)
+	if err != nil {
+		return 0, 0, fmt.Errorf("lookup %s: %w", env.proxyUserName, err)
+	}
+	agent, err := env.lookupUser(env.agentUserName)
+	if err != nil {
+		return 0, 0, fmt.Errorf("lookup %s: %w", env.agentUserName, err)
+	}
+	pUID, err := strconv.Atoi(proxy.Uid)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse proxy uid %q: %w", proxy.Uid, err)
+	}
+	aUID, err := strconv.Atoi(agent.Uid)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse agent uid %q: %w", agent.Uid, err)
+	}
+	return pUID, aUID, nil
+}
+
+// uidGidFor looks up a system user and returns its uid+gid as ints.
+func uidGidFor(env *installEnv, name string) (uid, gid int, err error) {
+	u, err := env.lookupUser(name)
+	if err != nil {
+		return 0, 0, fmt.Errorf("lookup %s: %w", name, err)
+	}
+	uid, err = strconv.Atoi(u.Uid)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse uid for %s: %w", name, err)
+	}
+	gid, err = strconv.Atoi(u.Gid)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse gid for %s: %w", name, err)
+	}
+	return uid, gid, nil
+}
+
+// runOrErr is a thin wrapper around env.runCmd that turns a non-zero exit
+// into an error. Used by steps that shell out for side effects only and
+// don't need to inspect the output.
+func runOrErr(ctx context.Context, env *installEnv, name string, args ...string) error {
+	out, code, err := env.runCmd(ctx, name, args...)
+	if err != nil {
+		return fmt.Errorf("exec %s: %w", name, err)
+	}
+	if code != 0 {
+		return fmt.Errorf("%s exited %d: %s", name, code, truncateForErr(out))
+	}
+	return nil
+}
+
+// truncateForErr trims long subprocess output to a single readable line for
+// inclusion in an error message. Real diagnostic detail still flows to the
+// dry-run / verbose stream; this is just the error message that propagates
+// up to the caller.
+func truncateForErr(s string) string {
+	const maxLen = 200
+	s = collapseWS(s)
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "…"
+}
+
+// collapseWS turns any run of whitespace into a single space. Keeps error
+// messages on one line regardless of how the subprocess formatted output.
+// Iterates over bytes (not runes) because the only whitespace we collapse
+// is ASCII and we want to preserve multi-byte UTF-8 sequences verbatim.
+func collapseWS(s string) string {
+	var b []byte
+	prevSpace := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == ' ' || c == '\n' || c == '\t' || c == '\r' {
+			if !prevSpace {
+				b = append(b, ' ')
+				prevSpace = true
+			}
+			continue
+		}
+		b = append(b, c)
+		prevSpace = false
+	}
+	start, end := 0, len(b)
+	for start < end && b[start] == ' ' {
+		start++
+	}
+	for end > start && b[end-1] == ' ' {
+		end--
+	}
+	return string(b[start:end])
+}
+
+// pathExists is a small helper used in step idempotency checks. Treats any
+// non-NotExist error as existence to avoid silently re-applying a step on a
+// permissions error (better to surface the real error in apply()).
+func pathExists(env *installEnv, path string) bool {
+	_, err := env.stat(path)
+	return err == nil || !errors.Is(err, os.ErrNotExist)
+}
+
+// expectExec ensures the binary at name is executable. Used by preflight
+// checks (nft, systemctl, visudo). Returns a clear error message naming the
+// missing binary.
+func expectExec(name string) error {
+	if _, err := exec.LookPath(name); err != nil {
+		return fmt.Errorf("required executable %q not found in PATH: %w", name, err)
+	}
+	return nil
+}

--- a/internal/cli/contain/osops.go
+++ b/internal/cli/contain/osops.go
@@ -15,6 +15,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strconv"
+	"syscall"
 )
 
 // installEnv is the OS-facing dependency surface used by every mutating
@@ -197,6 +198,11 @@ func writeFileAtomic(path string, contents []byte, mode os.FileMode) error {
 		cleanup()
 		return fmt.Errorf("chmod %s: %w", tmpName, err)
 	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("sync %s: %w", tmpName, err)
+	}
 	if err := tmp.Close(); err != nil {
 		cleanup()
 		return fmt.Errorf("close %s: %w", tmpName, err)
@@ -204,6 +210,31 @@ func writeFileAtomic(path string, contents []byte, mode os.FileMode) error {
 	if err := os.Rename(tmpName, path); err != nil {
 		cleanup()
 		return fmt.Errorf("rename %s -> %s: %w", tmpName, path, err)
+	}
+	if err := syncDir(dir); err != nil {
+		return err
+	}
+	return nil
+}
+
+func syncDir(dir string) error {
+	clean := filepath.Clean(dir)
+	dirFile, err := os.Open(clean) //nolint:gosec // G304: parent dir is derived from the already-opened temp file target and used only for fsync.
+	if err != nil {
+		return fmt.Errorf("open dir %s: %w", clean, err)
+	}
+	syncErr := dirFile.Sync()
+	closeErr := dirFile.Close()
+	if syncErr != nil {
+		// Some platforms/filesystems reject directory fsync. The temp file
+		// itself was already fsynced; keep atomic writes portable there.
+		if errors.Is(syncErr, syscall.EINVAL) || errors.Is(syncErr, syscall.ENOTSUP) {
+			return nil
+		}
+		return fmt.Errorf("sync dir %s: %w", clean, syncErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close dir %s: %w", clean, closeErr)
 	}
 	return nil
 }

--- a/internal/cli/contain/osops.go
+++ b/internal/cli/contain/osops.go
@@ -82,6 +82,10 @@ type installEnv struct {
 	pipelockBinary string // source binary path passed to --pipelock-binary
 	pipelockTarget string // destination, default /usr/local/bin/pipelock
 	proxyPort      int
+
+	prevNFTTableDump       string
+	prevNftablesEnabled    bool
+	prevNftablesStateKnown bool
 }
 
 // defaultInstallEnv wires installEnv to the real OS. Callers fill in
@@ -231,6 +235,11 @@ func sha256HexOfFile(path string) (string, error) {
 func backupAndWrite(env *installEnv, path string, contents []byte, mode os.FileMode) error {
 	if _, err := env.stat(path); err == nil {
 		bak := path + ".bak"
+		if _, err := env.stat(bak); err == nil {
+			return fmt.Errorf("refusing to overwrite existing backup %s; resolve manually before re-running install", bak)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("stat %s: %w", bak, err)
+		}
 		if err := env.rename(path, bak); err != nil {
 			return fmt.Errorf("backup %s -> %s: %w", path, bak, err)
 		}

--- a/internal/cli/contain/osops.go
+++ b/internal/cli/contain/osops.go
@@ -233,20 +233,75 @@ func sha256HexOfFile(path string) (string, error) {
 //
 // If path doesn't exist, no .bak is created; the new file is written as-is.
 func backupAndWrite(env *installEnv, path string, contents []byte, mode os.FileMode) error {
-	if _, err := env.stat(path); err == nil {
-		bak := path + ".bak"
-		if _, err := env.stat(bak); err == nil {
+	clean := filepath.Clean(path)
+	if err := ensureSafeWriteTarget(env, clean); err != nil {
+		return err
+	}
+	if _, err := env.lstat(clean); err == nil {
+		bak := clean + ".bak"
+		if info, err := env.lstat(bak); err == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("refusing to overwrite symlink backup %s", bak)
+			}
 			return fmt.Errorf("refusing to overwrite existing backup %s; resolve manually before re-running install", bak)
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("stat %s: %w", bak, err)
 		}
-		if err := env.rename(path, bak); err != nil {
-			return fmt.Errorf("backup %s -> %s: %w", path, bak, err)
+		if err := env.rename(clean, bak); err != nil {
+			return fmt.Errorf("backup %s -> %s: %w", clean, bak, err)
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("stat %s: %w", path, err)
+		return fmt.Errorf("stat %s: %w", clean, err)
 	}
-	return env.writeFile(path, contents, mode)
+	return env.writeFile(clean, contents, mode)
+}
+
+func ensureSafeWriteTarget(env *installEnv, path string) error {
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) {
+		return fmt.Errorf("%s is not an absolute path", clean)
+	}
+	if err := ensureSafeDirectory(env, filepath.Dir(clean)); err != nil {
+		return err
+	}
+	info, err := env.lstat(clean)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("stat %s: %w", clean, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symlink; refusing privileged write", clean)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s is a directory", clean)
+	}
+	return nil
+}
+
+func ensureSafeDirectory(env *installEnv, path string) error {
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) {
+		return fmt.Errorf("%s is not an absolute path", clean)
+	}
+	if err := rejectSymlinkParents(env, clean); err != nil {
+		return err
+	}
+	info, err := env.lstat(clean)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("stat %s: %w", clean, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symlink; refusing privileged write", clean)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s exists and is not a directory", clean)
+	}
+	return nil
 }
 
 // restoreBackup is the inverse of backupAndWrite, used by undo functions.

--- a/internal/cli/contain/osops.go
+++ b/internal/cli/contain/osops.go
@@ -150,23 +150,23 @@ const (
 	defaultSystemCABundle    = "/etc/ssl/certs/ca-bundle.crt"
 
 	// File modes. The model is "pipelock-agent UID must be able to read every
-	// file the wrappers depend on at runtime, but cannot read secrets
-	// (config, integrity pin)." pipelock-agent reads CA bundles, the runtime
-	// allow-list, and the wrapper inventory; everything else stays
-	// pipelock-proxy/root scoped.
-	modeCAReadable        os.FileMode = 0o644 // /etc/pipelock/{ca,combined-ca}.pem — pipelock-agent reads
-	modeAllowListReadable os.FileMode = 0o644 // /etc/pipelock/contain/{tools.list,wrappers.json} — pipelock-agent reads
+	// non-secret file the wrappers depend on at runtime, but cannot read
+	// secrets (config, integrity pin)." The CA files contain public
+	// certificates only; the runtime allow-list and wrapper inventory contain
+	// tool names/paths only. Mutation remains gated by root-owned directories.
+	modeCAReadable        os.FileMode = 0o644 // public CA certs, read by pipelock-agent
+	modeAllowListReadable os.FileMode = 0o644 // runtime policy metadata, read by pipelock-agent
 	modeConfigSecret      os.FileMode = 0o640 // /etc/pipelock/pipelock.yaml — pipelock-proxy reads, pipelock-agent denied
 	modePinSecret         os.FileMode = 0o600 // integrity pin — pipelock-proxy only
 	modeSudoers           os.FileMode = 0o440 // /etc/sudoers.d/*
-	modeWrapperExec       os.FileMode = 0o755 // /usr/local/bin/plk-*
+	modeWrapperExec       os.FileMode = 0o755 // /usr/local/bin/plk-* wrappers, executed by operator
 	modeUnitFile          os.FileMode = 0o644
 	modeNFTFile           os.FileMode = 0o644
 	modeNFTMainConfig     os.FileMode = 0o600
-	// Directory modes. modeDirTraversable applies to dirs pipelock-agent must
-	// walk into (/etc/pipelock, /etc/pipelock/contain); modeDirPrivate is
-	// for dirs containing only pipelock-proxy-readable secrets (integrity
-	// pin, captures).
+	// Directory modes. modeDirTraversable is intentionally world-traversable
+	// because pipelock-agent is a separate UID and must walk into
+	// /etc/pipelock/contain; modeDirPrivate is for dirs containing only
+	// pipelock-proxy-readable secrets (integrity pin, captures).
 	modeDirTraversable os.FileMode = 0o755
 	modeDirPrivate     os.FileMode = 0o750
 	// modeDirSystem is retained for callers that don't yet distinguish
@@ -309,18 +309,24 @@ func ensureSafeDirectory(env *installEnv, path string) error {
 // remove path (the install created it fresh). Errors that don't matter for
 // rollback (target already gone) are swallowed.
 func restoreBackup(env *installEnv, path string) error {
-	bak := path + ".bak"
-	if _, err := env.stat(bak); err == nil {
+	clean := filepath.Clean(path)
+	bak := clean + ".bak"
+	if info, err := env.lstat(bak); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("backup %s is a symlink; refusing restore", bak)
+		}
 		// Best-effort cleanup of any non-bak file first; rename below
 		// then atomically promotes the backup.
-		_ = env.removeFile(path)
-		if err := env.rename(bak, path); err != nil {
-			return fmt.Errorf("restore %s from %s: %w", path, bak, err)
+		_ = env.removeFile(clean)
+		if err := env.rename(bak, clean); err != nil {
+			return fmt.Errorf("restore %s from %s: %w", clean, bak, err)
 		}
 		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat %s: %w", bak, err)
 	}
-	if err := env.removeFile(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove %s: %w", path, err)
+	if err := env.removeFile(clean); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove %s: %w", clean, err)
 	}
 	return nil
 }
@@ -330,16 +336,21 @@ func restoreBackup(env *installEnv, path string) error {
 // files such as /etc/sysconfig/nftables.conf where deleting the file on
 // rollback would be worse than leaving a harmless managed include absent.
 func restoreBackupIfPresent(env *installEnv, path string) error {
-	bak := path + ".bak"
-	if _, err := env.stat(bak); err != nil {
+	clean := filepath.Clean(path)
+	bak := clean + ".bak"
+	info, err := env.lstat(bak)
+	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return fmt.Errorf("stat %s: %w", bak, err)
 	}
-	_ = env.removeFile(path)
-	if err := env.rename(bak, path); err != nil {
-		return fmt.Errorf("restore %s from %s: %w", path, bak, err)
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("backup %s is a symlink; refusing restore", bak)
+	}
+	_ = env.removeFile(clean)
+	if err := env.rename(bak, clean); err != nil {
+		return fmt.Errorf("restore %s from %s: %w", clean, bak, err)
 	}
 	return nil
 }

--- a/internal/cli/contain/rollback.go
+++ b/internal/cli/contain/rollback.go
@@ -1,0 +1,351 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+// rollbackOpts is the flag bag for rollback.
+type rollbackOpts struct {
+	dryRun     bool
+	keepData   bool
+	keepUsers  bool
+	purgeUsers bool // explicit --purge-users override; takes precedence over keepUsers
+}
+
+func rollbackCmd() *cobra.Command {
+	var opts rollbackOpts
+
+	cmd := &cobra.Command{
+		Use:   "rollback",
+		Short: "Roll back the containment model (undoes install idempotently)",
+		Long: `Reverse the changes made by ` + "`pipelock contain install`" + `.
+
+Always tries every cleanup action — a partial uninstall left from a prior
+crashed run is still safe to call rollback on. Per-action failures are
+accumulated and reported, but the chain does not stop.
+
+By default, /etc/pipelock and /var/lib/pipelock are preserved (--keep-data
+defaults true). Users are removed by default; pass --keep-users to keep
+pipelock-proxy and pipelock-agent in place (useful when re-installing soon).
+
+Must be run as root.
+
+Exit codes:
+  0  All actions completed (or already in target state).
+  1  One or more actions failed.
+  2  Precondition error (not root, missing executable).`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !opts.dryRun && os.Geteuid() != 0 {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New("rollback must be run as root (use sudo)"))
+			}
+			env := defaultInstallEnv(cmd.OutOrStdout())
+			return runRollback(cmd.Context(), env, opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "print the planned rollback actions without mutating state")
+	cmd.Flags().BoolVar(&opts.keepData, "keep-data", true, "preserve /etc/pipelock and /var/lib/pipelock (default true)")
+	cmd.Flags().BoolVar(&opts.keepUsers, "keep-users", false, "preserve the pipelock-proxy and pipelock-agent users")
+	cmd.Flags().BoolVar(&opts.purgeUsers, "purge-users", false, "force user deletion even if --keep-users is set (sticky safety net)")
+
+	return cmd
+}
+
+// runRollback walks every cleanup action in install-reverse order. Each
+// action is implemented as a step where apply is the cleanup itself. We
+// invoke them directly rather than going through runSteps because we want
+// to continue past per-action failures.
+func runRollback(ctx context.Context, env *installEnv, opts rollbackOpts) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// The cobra RunE wrapper does the os.Geteuid root check; tests drive
+	// this function directly with fakes.
+
+	actions := rollbackActions(opts)
+
+	if opts.dryRun {
+		printPlan(env.out, "pipelock contain rollback — planned actions:", actions)
+		return nil
+	}
+
+	_, _ = fmt.Fprintln(env.out, "pipelock contain rollback")
+	if err := runUndo(ctx, env, env.out, actions); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, err)
+	}
+	_, _ = fmt.Fprintln(env.out, "rollback complete.")
+	return nil
+}
+
+// rollbackActions enumerates the cleanup steps in the order install
+// applied them, so that runUndo (which walks reverse) executes them in
+// proper reverse order:
+//
+//   - sudoers off first (so any stray plk-* wrapper invocation stops being
+//     no-password authorized immediately)
+//   - then wrappers (so even if sudoers is restored, the wrappers are gone)
+//   - then nft rules (so future `plk-launch` attempts stop being firewalled
+//     before we go and remove the firewall)
+//   - then service (so we don't leave a running pipelock pointed at a
+//     half-removed config dir)
+//   - then artifacts (binary, CA, integrity pin)
+//   - finally users + dirs (controlled by --keep-* flags)
+//
+// The runUndo helper walks the slice in reverse, so the steps are LISTED in
+// install order for readability but EXECUTED in reverse.
+func rollbackActions(opts rollbackOpts) []step {
+	return []step{
+		// Install ordering, executed in reverse by runUndo.
+		actionPreserve("preflight (no-op for rollback)"),
+		actionMaybeDeleteUser(opts, true),  // proxy
+		actionMaybeDeleteUser(opts, false), // agent
+		actionMaybeRemoveDir(opts, "config", func(e *installEnv) string { return e.configDir }),
+		actionMaybeRemoveDir(opts, "data", func(e *installEnv) string { return e.dataDir }),
+		actionPreserve("pipelock.yaml (kept with --keep-data)"),
+		actionPreserve("config chown (resolved by dir removal)"),
+		actionPreserve("data chown (resolved by dir removal)"),
+		actionRemovePath("pipelock binary", func(e *installEnv) string { return e.pipelockTarget }),
+		actionRemovePath("integrity pin", func(e *installEnv) string { return e.integrityPin }),
+		actionPreserve("user-mode pipelock (operator decides whether to re-enable)"),
+		actionRemoveSystemUnit(),
+		actionDisablePipelockService(),
+		actionRemovePath("pipelock CA export", func(e *installEnv) string { return e.caExportPath }),
+		actionRemovePath("combined CA bundle", func(e *installEnv) string { return e.caBundlePath }),
+		actionRemoveNFTRules(),
+		actionRemovePath("plk-launch tools.list", func(e *installEnv) string { return e.toolsListPath }),
+		actionRemoveWrapper("plk-launch", "plk-launch"),
+		actionRemoveToolWrappers(),
+		actionRemovePath("wrapper inventory", func(e *installEnv) string { return e.wrapperInvPath }),
+		actionRemoveSudoers(),
+	}
+}
+
+// actionPreserve is a no-op slot used to keep the rollback list aligned
+// with the install list 1:1. Each slot is logged in --dry-run so the
+// operator can see the action being intentionally skipped.
+func actionPreserve(desc string) step {
+	return step{
+		name: "preserve",
+		desc: desc,
+		undo: func(context.Context, *installEnv) error { return nil },
+	}
+}
+
+// actionRemovePath removes a file managed by the install. Missing files
+// are not an error.
+func actionRemovePath(desc string, pathFn func(*installEnv) string) step {
+	return step{
+		name: "remove-" + desc,
+		desc: "remove " + desc,
+		undo: func(_ context.Context, env *installEnv) error {
+			path := pathFn(env)
+			if err := env.removeFile(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove %s: %w", path, err)
+			}
+			// Also drop the .bak if present.
+			_ = env.removeFile(path + ".bak")
+			return nil
+		},
+	}
+}
+
+// actionMaybeDeleteUser deletes pipelock-proxy or pipelock-agent unless
+// --keep-users is set. --purge-users overrides --keep-users.
+func actionMaybeDeleteUser(opts rollbackOpts, proxyUser bool) step {
+	label := "agent"
+	if proxyUser {
+		label = "proxy"
+	}
+	return step{
+		name: "delete-" + label + "-user",
+		desc: "delete " + label + " user (skipped when --keep-users is set)",
+		undo: func(ctx context.Context, env *installEnv) error {
+			if opts.keepUsers && !opts.purgeUsers {
+				return nil
+			}
+			name := env.agentUserName
+			if proxyUser {
+				name = env.proxyUserName
+			}
+			if _, err := env.lookupUser(name); err != nil {
+				if errors.As(err, new(user.UnknownUserError)) {
+					return nil
+				}
+				return fmt.Errorf("user lookup %s: %w", name, err)
+			}
+			return runOrErr(ctx, env, "userdel", "-r", name)
+		},
+	}
+}
+
+// actionMaybeRemoveDir removes /etc/pipelock or /var/lib/pipelock when the
+// operator explicitly passes --keep-data=false. Default keeps them in
+// place: the most common rollback case is re-installing soon, and losing
+// /etc/pipelock means redoing TLS init and config.
+func actionMaybeRemoveDir(opts rollbackOpts, label string, pathFn func(*installEnv) string) step {
+	return step{
+		name: "remove-dir-" + label,
+		desc: "remove " + label + " directory (skipped unless --keep-data=false)",
+		undo: func(_ context.Context, env *installEnv) error {
+			if opts.keepData {
+				return nil
+			}
+			path := pathFn(env)
+			if err := os.RemoveAll(filepath.Clean(path)); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("rm -rf %s: %w", path, err)
+			}
+			return nil
+		},
+	}
+}
+
+// actionRemoveSystemUnit removes the pipelock.service unit and reloads
+// systemd so it stops being known.
+func actionRemoveSystemUnit() step {
+	return step{
+		name: "remove-system-unit",
+		desc: "remove /etc/systemd/system/pipelock.service",
+		undo: func(ctx context.Context, env *installEnv) error {
+			if err := env.removeFile(env.systemUnitPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove %s: %w", env.systemUnitPath, err)
+			}
+			_ = env.removeFile(env.systemUnitPath + ".bak")
+			_, _, _ = env.runCmd(ctx, "systemctl", "daemon-reload")
+			return nil
+		},
+	}
+}
+
+// actionDisablePipelockService disables + stops the system service if
+// present. Missing service is fine.
+func actionDisablePipelockService() step {
+	return step{
+		name: "disable-pipelock-service",
+		desc: "systemctl disable --now pipelock.service",
+		undo: func(ctx context.Context, env *installEnv) error {
+			out, code, _ := env.runCmd(ctx, "systemctl", "list-unit-files", "pipelock.service", "--no-legend")
+			if code != 0 || out == "" {
+				return nil
+			}
+			_, _, _ = env.runCmd(ctx, "systemctl", "disable", "--now", "pipelock")
+			return nil
+		},
+	}
+}
+
+// actionRemoveNFTRules deletes the table, removes the rules file, and
+// restores/removes the managed persistence include. We do NOT disable
+// nftables.service: the operator may have had it enabled before our install.
+func actionRemoveNFTRules() step {
+	return step{
+		name: "remove-nft-rules",
+		desc: "drop pipelock_containment table and remove nftables persistence include",
+		undo: func(ctx context.Context, env *installEnv) error {
+			_, _, _ = env.runCmd(ctx, "nft", "delete", "table", "inet", defaultNFTTable)
+			if err := env.removeFile(env.nftRulesPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove %s: %w", env.nftRulesPath, err)
+			}
+			_ = env.removeFile(env.nftRulesPath + ".bak")
+			return restoreOrRemoveNFTMainInclude(env)
+		},
+	}
+}
+
+// actionRemoveWrapper removes one named wrapper from the wrapper dir.
+func actionRemoveWrapper(label, name string) step {
+	return step{
+		name: "remove-" + label,
+		desc: "remove /usr/local/bin/" + name,
+		undo: func(_ context.Context, env *installEnv) error {
+			path := filepath.Join(env.wrapperDir, name)
+			if err := env.removeFile(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove %s: %w", path, err)
+			}
+			_ = env.removeFile(path + ".bak")
+			return nil
+		},
+	}
+}
+
+// actionRemoveToolWrappers removes every wrapper listed in the inventory.
+// Falls back to the static defaultToolWrappers list when the inventory is
+// missing — that's the case when rollback runs against a half-installed
+// system where the inventory was never written.
+func actionRemoveToolWrappers() step {
+	return step{
+		name: "remove-tool-wrappers",
+		desc: "remove plk-* tool wrappers listed in /etc/pipelock/contain/wrappers.json",
+		undo: func(_ context.Context, env *installEnv) error {
+			wrappers := readWrapperInventory(env)
+			for _, w := range wrappers {
+				path := filepath.Join(env.wrapperDir, w)
+				if err := env.removeFile(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+					return fmt.Errorf("remove %s: %w", path, err)
+				}
+				_ = env.removeFile(path + ".bak")
+			}
+			return nil
+		},
+	}
+}
+
+// readWrapperInventory loads the wrapper list from /etc/pipelock/contain/
+// wrappers.json. On any error (missing, malformed, unreadable) it returns
+// the static defaultToolWrappers set so rollback never silently leaves
+// installed wrappers behind.
+func readWrapperInventory(env *installEnv) []string {
+	data, err := env.readFile(env.wrapperInvPath)
+	if err != nil {
+		if wrappers := wrappersFromToolsList(env); len(wrappers) > 0 {
+			return wrappers
+		}
+		return append([]string(nil), defaultToolWrappers...)
+	}
+	var inv wrapperInventory
+	if err := json.Unmarshal(data, &inv); err != nil || len(inv.Wrappers) == 0 {
+		if wrappers := wrappersFromToolsList(env); len(wrappers) > 0 {
+			return wrappers
+		}
+		return append([]string(nil), defaultToolWrappers...)
+	}
+	return inv.Wrappers
+}
+
+func wrappersFromToolsList(env *installEnv) []string {
+	entries, err := readToolsList(env)
+	if err != nil {
+		return nil
+	}
+	return wrapperNamesForEntries(entries)
+}
+
+// actionRemoveSudoers removes /etc/sudoers.d/50-pipelock-agent.
+func actionRemoveSudoers() step {
+	return step{
+		name: "remove-sudoers",
+		desc: "remove /etc/sudoers.d/50-pipelock-agent",
+		undo: func(_ context.Context, env *installEnv) error {
+			if err := env.removeFile(env.sudoersPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove %s: %w", env.sudoersPath, err)
+			}
+			_ = env.removeFile(env.sudoersPath + ".bak")
+			return nil
+		},
+	}
+}

--- a/internal/cli/contain/rollback_test.go
+++ b/internal/cli/contain/rollback_test.go
@@ -1,0 +1,266 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunRollback_DryRunDoesNotShellOut(t *testing.T) {
+	env, runner, buf := newFakeEnv(t)
+	err := runRollback(context.Background(), env, rollbackOpts{dryRun: true, keepData: true})
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("dry-run shelled out: %v", runner.calls)
+	}
+	if !strings.Contains(buf.String(), "planned actions") {
+		t.Errorf("missing 'planned actions': %q", buf.String())
+	}
+}
+
+func TestRunRollback_ExecutesActionsInReverse(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	// Plant some artifacts so several actions have something to remove.
+	if err := os.MkdirAll(filepath.Dir(env.sudoersPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.sudoersPath, []byte("sudoers"), 0o440); err != nil { //nolint:gosec // sudoers requires 0o440 per visudo
+		t.Fatalf("write: %v", err)
+	}
+	err := runRollback(context.Background(), env, rollbackOpts{keepData: true, keepUsers: true})
+	if err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if _, err := os.Stat(env.sudoersPath); err == nil {
+		t.Errorf("sudoers not removed")
+	}
+}
+
+func TestReadWrapperInventory_FallsBackToToolsList(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	writeTestToolsList(t, env, []toolsListEntry{
+		{name: "claude", target: "/usr/local/bin/claude"},
+		{name: "rustup", target: "/usr/local/bin/rustup"},
+	})
+
+	got := readWrapperInventory(env)
+	want := []string{"plk-claude", "plk-rustup"}
+	if !stringSlicesEqual(got, want) {
+		t.Fatalf("wrappers = %#v, want %#v", got, want)
+	}
+}
+
+func TestRollbackActions_KeepUsersSuppressesUserDel(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	// Make both users "exist" so the unguarded path would call userdel.
+	env.lookupUser = func(name string) (*user.User, error) {
+		return &user.User{Uid: "988", Gid: "988", Username: name}, nil
+	}
+	actions := rollbackActions(rollbackOpts{keepUsers: true, keepData: true})
+	// Walk in reverse (matches runUndo) and call each undo. We don't go
+	// through runUndo here because we want to assert that userdel was NOT
+	// called by any of the user-delete actions.
+	for i := len(actions) - 1; i >= 0; i-- {
+		a := actions[i]
+		if a.undo == nil {
+			continue
+		}
+		_ = a.undo(context.Background(), env)
+	}
+	for _, c := range runner.calls {
+		if c.name == testUserDel {
+			t.Errorf("userdel called despite --keep-users: %v", c)
+		}
+	}
+}
+
+func TestRollbackActions_PurgeUsersOverridesKeepUsers(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	env.lookupUser = func(name string) (*user.User, error) {
+		return &user.User{Uid: "988", Gid: "988", Username: name}, nil
+	}
+	actions := rollbackActions(rollbackOpts{keepUsers: true, purgeUsers: true, keepData: true})
+	for i := len(actions) - 1; i >= 0; i-- {
+		a := actions[i]
+		if a.undo == nil {
+			continue
+		}
+		_ = a.undo(context.Background(), env)
+	}
+	// userdel must run for BOTH users.
+	count := 0
+	for _, c := range runner.calls {
+		if c.name == testUserDel {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("expected 2 userdel calls (proxy + agent), got %d in %v", count, runner.calls)
+	}
+}
+
+func TestRollbackActions_KeepDataLeavesDirs(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	// Plant the directories so we can check they survive.
+	if err := os.MkdirAll(env.configDir, 0o750); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.MkdirAll(env.dataDir, 0o750); err != nil {
+		t.Fatalf("mkdir data: %v", err)
+	}
+	// keep-data=true (default).
+	actions := rollbackActions(rollbackOpts{keepData: true})
+	for i := len(actions) - 1; i >= 0; i-- {
+		a := actions[i]
+		if a.undo == nil {
+			continue
+		}
+		_ = a.undo(context.Background(), env)
+	}
+	if _, err := os.Stat(env.configDir); err != nil {
+		t.Errorf("configDir removed despite --keep-data: %v", err)
+	}
+	if _, err := os.Stat(env.dataDir); err != nil {
+		t.Errorf("dataDir removed despite --keep-data: %v", err)
+	}
+}
+
+func TestRollbackActions_DropDataWhenKeepDataFalse(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.MkdirAll(env.configDir, 0o750); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.MkdirAll(env.dataDir, 0o750); err != nil {
+		t.Fatalf("mkdir data: %v", err)
+	}
+	actions := rollbackActions(rollbackOpts{keepData: false})
+	for i := len(actions) - 1; i >= 0; i-- {
+		a := actions[i]
+		if a.undo == nil {
+			continue
+		}
+		_ = a.undo(context.Background(), env)
+	}
+	if _, err := os.Stat(env.configDir); err == nil {
+		t.Errorf("configDir survived --keep-data=false")
+	}
+	if _, err := os.Stat(env.dataDir); err == nil {
+		t.Errorf("dataDir survived --keep-data=false")
+	}
+}
+
+func TestRollbackActions_RemovesWrappersFromInventory(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	// Plant wrapper inventory with a custom tool plus standard ones.
+	if err := os.MkdirAll(filepath.Dir(env.wrapperInvPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	inv := wrapperInventory{Wrappers: append(append([]string{}, defaultToolWrappers...), "plk-custom")}
+	data, _ := json.MarshalIndent(inv, "", "  ")
+	if err := os.WriteFile(env.wrapperInvPath, append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("write inventory: %v", err)
+	}
+	// Plant the wrapper files so we can confirm removal.
+	for _, w := range inv.Wrappers {
+		if err := os.WriteFile(filepath.Join(env.wrapperDir, w), []byte("#!/bin/bash\n"), 0o755); err != nil { //nolint:gosec // tmpdir
+			t.Fatalf("plant wrapper %s: %v", w, err)
+		}
+	}
+
+	actions := rollbackActions(rollbackOpts{keepData: true})
+	// Find the remove-tool-wrappers action and invoke it.
+	for _, a := range actions {
+		if a.name == "remove-tool-wrappers" {
+			if err := a.undo(context.Background(), env); err != nil {
+				t.Fatalf("undo: %v", err)
+			}
+			break
+		}
+	}
+	for _, w := range inv.Wrappers {
+		if _, err := os.Stat(filepath.Join(env.wrapperDir, w)); err == nil {
+			t.Errorf("wrapper %s not removed", w)
+		}
+	}
+}
+
+func TestRollback_DryRunPrintsPlan(t *testing.T) {
+	actions := rollbackActions(rollbackOpts{keepData: true})
+	var buf bytes.Buffer
+	printPlan(&buf, "rollback plan:", actions)
+	out := buf.String()
+	// Spot-check a few entries from the install order.
+	for _, want := range []string{
+		"delete proxy user",
+		"delete agent user",
+		"remove pipelock binary",
+		"remove /etc/sudoers.d/50-pipelock-agent",
+		"drop pipelock_containment table",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plan missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestRollback_RunUndoContinuesOnPerActionError(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	// Force an undo to fail.
+	first := step{
+		name: "fails", desc: "fails",
+		undo: func(context.Context, *installEnv) error { return errAny() },
+	}
+	second := step{
+		name: "ok", desc: "ok",
+		undo: func(context.Context, *installEnv) error { return nil },
+	}
+	var buf bytes.Buffer
+	if err := runUndo(context.Background(), env, &buf, []step{first, second}); err == nil {
+		t.Fatalf("expected joined error")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[FAIL] fails") {
+		t.Errorf("missing fail line: %q", out)
+	}
+	if !strings.Contains(out, "[ OK ] ok") {
+		t.Errorf("missing ok line: %q", out)
+	}
+}
+
+func errAny() error { return jsonError("synthetic") }
+
+// jsonError makes a small typed error for the test above without inflating
+// the package's import surface.
+type jsonError string
+
+func (j jsonError) Error() string { return string(j) }
+
+func TestReadWrapperInventory_FallsBackToDefaults(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	got := readWrapperInventory(env) // file does not exist yet
+	if len(got) != len(defaultToolWrappers) {
+		t.Errorf("fallback len: got %d, want %d", len(got), len(defaultToolWrappers))
+	}
+}
+
+func TestRollbackCmd_Wiring(t *testing.T) {
+	cmd := rollbackCmd()
+	if cmd.Use != "rollback" {
+		t.Errorf("Use: %q", cmd.Use)
+	}
+	for _, f := range []string{"dry-run", "keep-data", "keep-users", "purge-users"} {
+		if cmd.Flag(f) == nil {
+			t.Errorf("missing flag %s", f)
+		}
+	}
+}

--- a/internal/cli/contain/step.go
+++ b/internal/cli/contain/step.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// step is one idempotent unit of work in the install/rollback orchestration.
+//
+// Each step owns its own idempotency check: apply must be safe to call on
+// already-correct state and return (false, nil) to indicate "nothing to do".
+// When apply returns (true, nil) the step is considered applied and is added
+// to the rollback chain — if a later step fails, this step's undo runs to
+// restore the prior state.
+//
+// undo must itself be idempotent: rollback may be invoked when the step never
+// finished applying, or against state that has already drifted (operator did
+// a manual partial uninstall, prior rollback was interrupted, etc.).
+type step struct {
+	name string
+	desc string
+	// apply mutates state. Returns (applied, err): applied=true when a real
+	// mutation happened, applied=false when the state was already correct.
+	apply func(ctx context.Context, env *installEnv) (bool, error)
+	// undo reverses apply. Must be safe to call against partial state.
+	undo func(ctx context.Context, env *installEnv) error
+}
+
+// stepOutcome records what happened for a single step during an install or
+// rollback run. Surfaced to the operator via dry-run / verbose output.
+type stepOutcome struct {
+	name    string
+	desc    string
+	applied bool
+	err     error
+}
+
+// runSteps walks steps in order. When a step fails, every previously-applied
+// step's undo runs in reverse order before returning the original error.
+//
+// A step whose apply returns (false, nil) — i.e. already done — is NOT added
+// to the rollback chain. We must not undo state we did not create.
+func runSteps(ctx context.Context, env *installEnv, w io.Writer, steps []step) ([]stepOutcome, error) {
+	outcomes := make([]stepOutcome, 0, len(steps))
+	var applied []step
+
+	for i, s := range steps {
+		if err := ctx.Err(); err != nil {
+			outcomes = append(outcomes, stepOutcome{name: s.name, desc: s.desc, err: err})
+			rollbackApplied(ctx, env, w, applied)
+			return outcomes, fmt.Errorf("context cancelled before step %d (%s): %w", i+1, s.name, err)
+		}
+
+		didApply, err := s.apply(ctx, env)
+		outcomes = append(outcomes, stepOutcome{name: s.name, desc: s.desc, applied: didApply, err: err})
+
+		if err != nil {
+			_, _ = fmt.Fprintf(w, "  [FAIL] step %d %s: %v\n", i+1, s.name, err)
+			rollbackApplied(ctx, env, w, applied)
+			return outcomes, fmt.Errorf("step %d (%s): %w", i+1, s.name, err)
+		}
+
+		tag := "[SKIP]"
+		if didApply {
+			tag = "[ OK ]"
+			applied = append(applied, s)
+		}
+		_, _ = fmt.Fprintf(w, "  %s step %d: %s\n", tag, i+1, s.desc)
+	}
+
+	return outcomes, nil
+}
+
+// rollbackApplied walks the applied steps in reverse and invokes each undo.
+// Errors are collected and printed but do not stop the chain — a partial
+// rollback is always better than a half-installed state with an early exit.
+func rollbackApplied(ctx context.Context, env *installEnv, w io.Writer, applied []step) {
+	if len(applied) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(w, "rolling back applied steps:")
+	for i := len(applied) - 1; i >= 0; i-- {
+		s := applied[i]
+		if s.undo == nil {
+			_, _ = fmt.Fprintf(w, "  [SKIP] undo %s (no undo defined)\n", s.name)
+			continue
+		}
+		if err := s.undo(ctx, env); err != nil {
+			_, _ = fmt.Fprintf(w, "  [FAIL] undo %s: %v\n", s.name, err)
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "  [ OK ] undo %s\n", s.name)
+	}
+}
+
+// runUndo walks an explicit step list in REVERSE order and calls each undo.
+// Used by the rollback subcommand against the full install sequence: every
+// step gets a best-effort undo regardless of whether install actually ran
+// it. Errors are accumulated and joined into a single returned error so the
+// caller can decide whether to exit non-zero.
+func runUndo(ctx context.Context, env *installEnv, w io.Writer, steps []step) error {
+	var errs []error
+	for i := len(steps) - 1; i >= 0; i-- {
+		s := steps[i]
+		if s.undo == nil {
+			_, _ = fmt.Fprintf(w, "  [SKIP] %s (no undo defined)\n", s.name)
+			continue
+		}
+		if err := s.undo(ctx, env); err != nil {
+			_, _ = fmt.Fprintf(w, "  [FAIL] %s: %v\n", s.name, err)
+			errs = append(errs, fmt.Errorf("%s: %w", s.name, err))
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "  [ OK ] %s\n", s.desc)
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	return errors.Join(errs...)
+}
+
+// printPlan emits a dry-run plan listing every step with its description.
+// No apply/undo is invoked. Used for `install --dry-run` and friends.
+func printPlan(w io.Writer, header string, steps []step) {
+	_, _ = fmt.Fprintln(w, header)
+	for i, s := range steps {
+		_, _ = fmt.Fprintf(w, "  %d. %s\n", i+1, s.desc)
+	}
+}

--- a/internal/cli/contain/step.go
+++ b/internal/cli/contain/step.go
@@ -52,23 +52,25 @@ func runSteps(ctx context.Context, env *installEnv, w io.Writer, steps []step) (
 	for i, s := range steps {
 		if err := ctx.Err(); err != nil {
 			outcomes = append(outcomes, stepOutcome{name: s.name, desc: s.desc, err: err})
-			rollbackApplied(ctx, env, w, applied)
+			rollbackApplied(context.Background(), env, w, applied)
 			return outcomes, fmt.Errorf("context cancelled before step %d (%s): %w", i+1, s.name, err)
 		}
 
 		didApply, err := s.apply(ctx, env)
 		outcomes = append(outcomes, stepOutcome{name: s.name, desc: s.desc, applied: didApply, err: err})
+		if didApply {
+			applied = append(applied, s)
+		}
 
 		if err != nil {
 			_, _ = fmt.Fprintf(w, "  [FAIL] step %d %s: %v\n", i+1, s.name, err)
-			rollbackApplied(ctx, env, w, applied)
+			rollbackApplied(context.Background(), env, w, applied)
 			return outcomes, fmt.Errorf("step %d (%s): %w", i+1, s.name, err)
 		}
 
 		tag := "[SKIP]"
 		if didApply {
 			tag = "[ OK ]"
-			applied = append(applied, s)
 		}
 		_, _ = fmt.Fprintf(w, "  %s step %d: %s\n", tag, i+1, s.desc)
 	}
@@ -116,7 +118,7 @@ func runUndo(ctx context.Context, env *installEnv, w io.Writer, steps []step) er
 			errs = append(errs, fmt.Errorf("%s: %w", s.name, err))
 			continue
 		}
-		_, _ = fmt.Fprintf(w, "  [ OK ] %s\n", s.desc)
+		_, _ = fmt.Fprintf(w, "  [ OK ] %s\n", s.name)
 	}
 	if len(errs) == 0 {
 		return nil

--- a/internal/cli/contain/step_test.go
+++ b/internal/cli/contain/step_test.go
@@ -1,0 +1,280 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRunSteps_AllAppliedNoFailure(t *testing.T) {
+	var order []string
+	steps := []step{
+		{
+			name: "a",
+			desc: "step a",
+			apply: func(context.Context, *installEnv) (bool, error) {
+				order = append(order, "apply-a")
+				return true, nil
+			},
+			undo: func(context.Context, *installEnv) error {
+				order = append(order, "undo-a")
+				return nil
+			},
+		},
+		{
+			name: "b",
+			desc: "step b",
+			apply: func(context.Context, *installEnv) (bool, error) {
+				order = append(order, "apply-b")
+				return true, nil
+			},
+		},
+	}
+	var buf bytes.Buffer
+	env := &installEnv{out: &buf}
+	outcomes, err := runSteps(context.Background(), env, &buf, steps)
+	if err != nil {
+		t.Fatalf("runSteps err: %v", err)
+	}
+	if len(outcomes) != 2 {
+		t.Fatalf("outcomes len=%d, want 2", len(outcomes))
+	}
+	if got := strings.Join(order, ","); got != "apply-a,apply-b" {
+		t.Errorf("order: got %q, want apply-a,apply-b", got)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[ OK ] step 1") || !strings.Contains(out, "[ OK ] step 2") {
+		t.Errorf("missing OK lines: %q", out)
+	}
+}
+
+func TestRunSteps_SkippedStepNotRolledBack(t *testing.T) {
+	var order []string
+	steps := []step{
+		{
+			name: "applied",
+			desc: "applied step",
+			apply: func(context.Context, *installEnv) (bool, error) {
+				order = append(order, "apply-applied")
+				return true, nil
+			},
+			undo: func(context.Context, *installEnv) error {
+				order = append(order, "undo-applied")
+				return nil
+			},
+		},
+		{
+			name: "already-done",
+			desc: "skip step",
+			apply: func(context.Context, *installEnv) (bool, error) {
+				order = append(order, "apply-skip")
+				return false, nil // not applied
+			},
+			undo: func(context.Context, *installEnv) error {
+				order = append(order, "undo-skip-SHOULD-NOT-RUN")
+				return nil
+			},
+		},
+		{
+			name: "failed",
+			desc: "fail step",
+			apply: func(context.Context, *installEnv) (bool, error) {
+				order = append(order, "apply-fail")
+				return false, errors.New("boom")
+			},
+		},
+	}
+	var buf bytes.Buffer
+	env := &installEnv{out: &buf}
+	_, err := runSteps(context.Background(), env, &buf, steps)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	// "apply-skip" was called but didApply=false so undo MUST NOT have run
+	// for it. "apply-applied" did apply, so its undo must run.
+	got := strings.Join(order, ",")
+	wantSuffix := "apply-applied,apply-skip,apply-fail,undo-applied"
+	if got != wantSuffix {
+		t.Errorf("order: got %q, want %q", got, wantSuffix)
+	}
+}
+
+func TestRunSteps_FailureMidwayRollsBackInReverse(t *testing.T) {
+	var order []string
+	mkApply := func(label string) func(context.Context, *installEnv) (bool, error) {
+		return func(context.Context, *installEnv) (bool, error) {
+			order = append(order, "apply-"+label)
+			return true, nil
+		}
+	}
+	mkUndo := func(label string) func(context.Context, *installEnv) error {
+		return func(context.Context, *installEnv) error {
+			order = append(order, "undo-"+label)
+			return nil
+		}
+	}
+	steps := []step{
+		{name: "a", desc: "a", apply: mkApply("a"), undo: mkUndo("a")},
+		{name: "b", desc: "b", apply: mkApply("b"), undo: mkUndo("b")},
+		{
+			name: "c", desc: "c",
+			apply: func(context.Context, *installEnv) (bool, error) {
+				order = append(order, "apply-c")
+				return false, errors.New("boom at c")
+			},
+			undo: mkUndo("c"),
+		},
+		{name: "d", desc: "d", apply: mkApply("d"), undo: mkUndo("d")},
+	}
+	var buf bytes.Buffer
+	env := &installEnv{out: &buf}
+	_, err := runSteps(context.Background(), env, &buf, steps)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "step 3") || !strings.Contains(err.Error(), "boom at c") {
+		t.Errorf("error: got %v, want step 3 + boom at c", err)
+	}
+	got := strings.Join(order, ",")
+	want := "apply-a,apply-b,apply-c,undo-b,undo-a"
+	if got != want {
+		t.Errorf("order: got %q, want %q", got, want)
+	}
+}
+
+func TestRunSteps_ContextCancelledBetweenSteps(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var order []string
+	steps := []step{
+		{
+			name: "a", desc: "a",
+			apply: func(context.Context, *installEnv) (bool, error) {
+				order = append(order, "apply-a")
+				cancel() // cancel after step a
+				return true, nil
+			},
+			undo: func(context.Context, *installEnv) error {
+				order = append(order, "undo-a")
+				return nil
+			},
+		},
+		{
+			name: "b", desc: "b",
+			apply: func(context.Context, *installEnv) (bool, error) {
+				order = append(order, "apply-b-SHOULD-NOT-RUN")
+				return true, nil
+			},
+		},
+	}
+	var buf bytes.Buffer
+	env := &installEnv{out: &buf}
+	_, err := runSteps(ctx, env, &buf, steps)
+	if err == nil {
+		t.Fatalf("expected context error")
+	}
+	if !strings.Contains(err.Error(), "context cancelled") {
+		t.Errorf("error: got %v, want substring 'context cancelled'", err)
+	}
+	if !strings.Contains(strings.Join(order, ","), "undo-a") {
+		t.Errorf("applied step a was not rolled back: %v", order)
+	}
+}
+
+func TestRunUndo_ReverseOrderContinuesOnError(t *testing.T) {
+	var order []string
+	steps := []step{
+		{name: "a", desc: "a", undo: func(context.Context, *installEnv) error {
+			order = append(order, "undo-a")
+			return nil
+		}},
+		{name: "b", desc: "b", undo: func(context.Context, *installEnv) error {
+			order = append(order, "undo-b")
+			return errors.New("b failed")
+		}},
+		{name: "c", desc: "c", undo: func(context.Context, *installEnv) error {
+			order = append(order, "undo-c")
+			return nil
+		}},
+	}
+	var buf bytes.Buffer
+	env := &installEnv{out: &buf}
+	err := runUndo(context.Background(), env, &buf, steps)
+	if err == nil {
+		t.Fatalf("expected joined error")
+	}
+	// Reverse order: c, b, a. Failures don't stop the chain.
+	if got := strings.Join(order, ","); got != "undo-c,undo-b,undo-a" {
+		t.Errorf("order: got %q, want undo-c,undo-b,undo-a", got)
+	}
+	if !strings.Contains(err.Error(), "b failed") {
+		t.Errorf("joined err missing inner: %v", err)
+	}
+}
+
+func TestRunUndo_SkipsStepsWithoutUndo(t *testing.T) {
+	steps := []step{
+		{name: "no-undo", desc: "preserve action", undo: nil},
+	}
+	var buf bytes.Buffer
+	env := &installEnv{out: &buf}
+	if err := runUndo(context.Background(), env, &buf, steps); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.Contains(buf.String(), "[SKIP] no-undo") {
+		t.Errorf("missing skip line: %q", buf.String())
+	}
+}
+
+func TestPrintPlan(t *testing.T) {
+	steps := []step{
+		{name: "a", desc: "first thing"},
+		{name: "b", desc: "second thing"},
+	}
+	var buf bytes.Buffer
+	printPlan(&buf, "header:", steps)
+	want := "header:\n  1. first thing\n  2. second thing\n"
+	if got := buf.String(); got != want {
+		t.Errorf("printPlan output: got %q, want %q", got, want)
+	}
+}
+
+// Sanity check that the rollback chain interaction works with a real
+// example: a step that applies multiple side-effects in apply and reverses
+// all of them in undo.
+func TestRunSteps_RollbackRunsExactlyOnceEvenWithRetries(t *testing.T) {
+	var undoCalls int
+	steps := []step{
+		{
+			name: "side-effect",
+			desc: "side effect",
+			apply: func(context.Context, *installEnv) (bool, error) {
+				return true, nil
+			},
+			undo: func(context.Context, *installEnv) error {
+				undoCalls++
+				return nil
+			},
+		},
+		{
+			name: "fail",
+			desc: "fail",
+			apply: func(context.Context, *installEnv) (bool, error) {
+				return false, fmt.Errorf("boom")
+			},
+		},
+	}
+	var buf bytes.Buffer
+	env := &installEnv{out: &buf}
+	if _, err := runSteps(context.Background(), env, &buf, steps); err == nil {
+		t.Fatalf("expected error")
+	}
+	if undoCalls != 1 {
+		t.Errorf("undoCalls=%d, want 1", undoCalls)
+	}
+}

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -439,7 +439,7 @@ func verifyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "Run read-only probes against the containment model",
-		Long: `Run eleven read-only probes to verify the workstation containment model
+		Long: `Run twelve read-only probes to verify the workstation containment model
 is installed correctly and the boundary is intact.
 
 Probes inspect system users, the pipelock systemd unit, nftables rules,
@@ -727,10 +727,44 @@ func chainHasAgentProxyLoopbackAllow(out, chainName string, port int) bool {
 }
 
 func chainHasBroadLoopbackAccept(out, chainName string) bool {
-	return chainHasLine(out, chainName, func(line string) bool {
+	return chainHasLineBeforeSkuidDrop(out, chainName, func(line string) bool {
 		return strings.Contains(line, "accept") &&
 			(strings.Contains(line, `meta oif "lo"`) || strings.Contains(line, "ip daddr 127.0.0.0/8"))
 	})
+}
+
+func chainHasLineBeforeSkuidDrop(out, chainName string, match func(string) bool) bool {
+	inChain := false
+	depth := 0
+	for _, raw := range strings.Split(out, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		if !inChain && (strings.HasPrefix(line, "chain "+chainName+" ") || line == "chain "+chainName+"{") {
+			inChain = true
+		}
+		if !inChain {
+			continue
+		}
+		if strings.Contains(line, "{") {
+			depth += strings.Count(line, "{")
+		}
+		if strings.Contains(line, "skuid") && strings.Contains(line, "drop") {
+			return false
+		}
+		if match(line) {
+			return true
+		}
+		if strings.Contains(line, "}") {
+			depth -= strings.Count(line, "}")
+			if depth <= 0 {
+				inChain = false
+				depth = 0
+			}
+		}
+	}
+	return false
 }
 
 func chainHasLine(out, chainName string, match func(string) bool) bool {
@@ -784,6 +818,9 @@ func probeWrapperScripts(_ context.Context, env *probeEnv) (string, string) {
 	}
 	var foundNames []string
 	for _, name := range wrappers {
+		if strings.TrimSpace(name) == "" {
+			return statusFail, "wrapper inventory contains empty wrapper name"
+		}
 		p := filepath.Join(env.wrapperDir, name)
 		info, err := os.Stat(filepath.Clean(p))
 		if err != nil {
@@ -791,6 +828,9 @@ func probeWrapperScripts(_ context.Context, env *probeEnv) (string, string) {
 				continue
 			}
 			return statusFail, fmt.Sprintf("%s stat failed: %v", p, err)
+		}
+		if !info.Mode().IsRegular() || info.Size() == 0 {
+			return statusFail, fmt.Sprintf("%s is not a non-empty executable wrapper file", p)
 		}
 		mode := info.Mode().Perm()
 		if mode != 0o755 {

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -249,7 +249,10 @@ func probeListedToolTargets(_ context.Context, env *probeEnv) (string, string) {
 		}
 		return statusFail, fmt.Sprintf("read %s: %v", env.toolsListPath, err)
 	}
-	entries := parseToolsList(data)
+	entries, err := parseToolsList(data)
+	if err != nil {
+		return statusFail, fmt.Sprintf("parse %s: %v", env.toolsListPath, err)
+	}
 	if len(entries) == 0 {
 		return statusFail, fmt.Sprintf("%s has no tool entries", env.toolsListPath)
 	}

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -27,14 +28,14 @@ import (
 )
 
 // Probe environment defaults. These match the layout produced by
-// the future `pipelock contain install` subcommand. Operators who
-// installed the model elsewhere can override via flags.
+// `pipelock contain install`. Operators who installed the model
+// elsewhere can override via flags.
 const (
 	defaultProxyPort    = 8888
 	defaultProxyUser    = "pipelock-proxy"
-	defaultAgentUser    = "cc-agent"
+	defaultAgentUser    = "pipelock-agent"
 	defaultWrapperDir   = "/usr/local/bin"
-	defaultLaunchScript = "/usr/local/bin/cc-launch"
+	defaultLaunchScript = "/usr/local/bin/plk-launch"
 	defaultCABundlePath = "/etc/pipelock/combined-ca.pem"
 	defaultServiceName  = "pipelock.service"
 	defaultNFTTable     = "pipelock_containment"
@@ -61,16 +62,15 @@ const (
 	maxCmdOutputBytes = 64 << 10
 )
 
-// expectedNoProxy is the exact NO_PROXY value the cc-launch wrapper must
+// expectedNoProxy is the exact NO_PROXY value the plk-launch wrapper must
 // set per the 2026-05-04 decision in the runbook's open questions
 // (cluster traffic flows through Pipelock, so NO_PROXY is limited to
 // loopback). Any deviation is a policy regression.
 const expectedNoProxy = "NO_PROXY=127.0.0.1,localhost"
 
-// defaultToolWrappers is the v0.1 fixed list checked by probe 4. The
-// design doc tracks the eventual move to a wrapper inventory file
-// produced by `pipelock contain add-tool`.
-var defaultToolWrappers = []string{"cc-claude", "cc-codex", "cc-gemini", "cc-playwright"}
+// defaultToolWrappers is the fallback wrapper list used when the inventory
+// file has not been written yet.
+var defaultToolWrappers = []string{"plk-claude", "plk-codex", "plk-gemini", "plk-playwright"}
 
 // runCommand is the function shape used by probes that shell out.
 // Factored as a type so tests can inject canned outputs without
@@ -96,21 +96,30 @@ type lookupUserFunc func(name string) (*user.User, error)
 // addressable from outside the package so tests can populate it
 // directly without going through the cobra layer.
 type probeEnv struct {
-	port          int
-	operatorUser  string
-	proxyUserName string
-	agentUserName string
-	wrapperDir    string
-	toolWrappers  []string
-	caBundlePath  string
-	launchPath    string
-	nftTable      string
-	nftChain      string
-	serviceName   string
+	port           int
+	operatorUser   string
+	proxyUserName  string
+	agentUserName  string
+	wrapperDir     string
+	toolWrappers   []string
+	caBundlePath   string
+	launchPath     string
+	nftTable       string
+	nftChain       string
+	nftRulesPath   string
+	nftMainPath    string
+	serviceName    string
+	pinPath        string
+	wrapperInvPath string
+	toolsListPath  string
 
 	runCmd     runCommand
 	dialCtx    dialFunc
 	lookupUser lookupUserFunc
+	stat       func(path string) (os.FileInfo, error)
+	readFile   func(path string) ([]byte, error)
+	selfPath   func() (string, error)
+	hashFile   func(path string) (string, error)
 }
 
 // defaultProbeEnv returns the production environment. The operator user
@@ -119,20 +128,29 @@ type probeEnv struct {
 // directly. See probe 9 implementation for the runtime branch.
 func defaultProbeEnv() *probeEnv {
 	return &probeEnv{
-		port:          defaultProxyPort,
-		operatorUser:  os.Getenv("SUDO_USER"),
-		proxyUserName: defaultProxyUser,
-		agentUserName: defaultAgentUser,
-		wrapperDir:    defaultWrapperDir,
-		toolWrappers:  append([]string(nil), defaultToolWrappers...),
-		caBundlePath:  defaultCABundlePath,
-		launchPath:    defaultLaunchScript,
-		nftTable:      defaultNFTTable,
-		nftChain:      defaultNFTChain,
-		serviceName:   defaultServiceName,
-		runCmd:        realRunCommand,
-		dialCtx:       realDial,
-		lookupUser:    user.Lookup,
+		port:           defaultProxyPort,
+		operatorUser:   os.Getenv("SUDO_USER"),
+		proxyUserName:  defaultProxyUser,
+		agentUserName:  defaultAgentUser,
+		wrapperDir:     defaultWrapperDir,
+		toolWrappers:   append([]string(nil), defaultToolWrappers...),
+		caBundlePath:   defaultCABundlePath,
+		launchPath:     defaultLaunchScript,
+		nftTable:       defaultNFTTable,
+		nftChain:       defaultNFTChain,
+		nftRulesPath:   defaultNFTRulesPath,
+		nftMainPath:    defaultNFTMainConfigPath,
+		serviceName:    defaultServiceName,
+		pinPath:        defaultIntegrityPin,
+		wrapperInvPath: defaultWrapperInvPath,
+		toolsListPath:  defaultToolsListPath,
+		runCmd:         realRunCommand,
+		dialCtx:        realDial,
+		lookupUser:     user.Lookup,
+		stat:           os.Stat,
+		readFile:       os.ReadFile,
+		selfPath:       os.Executable,
+		hashFile:       sha256HexOfFile,
 	}
 }
 
@@ -214,10 +232,178 @@ func allProbes() []probe {
 		{4, "wrapper_scripts_installed", "wrapper scripts installed", probeWrapperScripts},
 		{5, "ca_bundle_present", "pipelock CA bundle readable", probeCABundle},
 		{6, "pipelock_listening_loopback", "pipelock listening on loopback", probeLoopbackListen},
-		{7, "no_proxy_env_correct", "NO_PROXY in cc-launch matches policy", probeNoProxyEnv},
-		{8, "cc_agent_egress_denied", "cc-agent cannot reach the internet directly", probeCCAgentEgressDenied},
+		{7, "no_proxy_env_correct", "NO_PROXY in plk-launch matches policy", probeNoProxyEnv},
+		{8, "cc_agent_egress_denied", "pipelock-agent cannot reach the internet directly", probeCCAgentEgressDenied},
 		{9, "operator_egress_reachable", "operator user can still reach the internet", probeOperatorEgress},
+		{10, "binary_integrity_pin", "installed pipelock binary matches TOFU pin", probeBinaryIntegrity},
+		{11, "cc_launch_allow_list_enforced", "plk-launch rejects tools missing from the allow-list", probeCCLaunchAllowList},
+		{12, "listed_tool_targets_resolvable", "tools.list entries resolve for pipelock-agent", probeListedToolTargets},
 	}
+}
+
+func probeListedToolTargets(_ context.Context, env *probeEnv) (string, string) {
+	data, err := env.readFile(env.toolsListPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return statusSkip, fmt.Sprintf("tools.list missing at %s (install never ran)", env.toolsListPath)
+		}
+		return statusFail, fmt.Sprintf("read %s: %v", env.toolsListPath, err)
+	}
+	entries := parseToolsList(data)
+	if len(entries) == 0 {
+		return statusFail, fmt.Sprintf("%s has no tool entries", env.toolsListPath)
+	}
+
+	agentPath := agentExecPath(env.agentUserName)
+	var bad []string
+	for _, entry := range entries {
+		target := entry.target
+		if target == "" {
+			var ok bool
+			target, ok = resolveToolInPath(env, entry.name, agentPath)
+			if !ok {
+				bad = append(bad, fmt.Sprintf("%s not found in pipelock-agent PATH", entry.name))
+				continue
+			}
+		}
+		if !filepath.IsAbs(target) {
+			bad = append(bad, fmt.Sprintf("%s target %q is not absolute", entry.name, target))
+			continue
+		}
+		info, err := env.stat(target)
+		if err != nil {
+			bad = append(bad, fmt.Sprintf("%s target %s: %v", entry.name, target, err))
+			continue
+		}
+		if info.IsDir() {
+			bad = append(bad, fmt.Sprintf("%s target %s is a directory", entry.name, target))
+			continue
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			bad = append(bad, fmt.Sprintf("%s target %s is not executable", entry.name, target))
+		}
+	}
+	if len(bad) > 0 {
+		return statusFail, strings.Join(bad, "; ")
+	}
+	return statusPass, fmt.Sprintf("%d allow-listed tool target(s) resolvable via %s", len(entries), agentPath)
+}
+
+func agentExecPath(agentUserName string) string {
+	return "/home/" + agentUserName + "/.local/bin:/usr/local/bin:/usr/bin:/bin"
+}
+
+func resolveToolInPath(env *probeEnv, name, pathList string) (string, bool) {
+	for _, dir := range filepath.SplitList(pathList) {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, name)
+		info, err := env.stat(candidate)
+		if err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0 {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+// probeCCLaunchAllowList runs `plk-launch <something-not-installed>` as
+// pipelock-agent and asserts the script exits 5 — "tool not in allow-list".
+// This exercises the full read path: sudoers grants no-password to
+// plk-launch, /etc/pipelock is directory-traversable for pipelock-agent,
+// /etc/pipelock/contain is traversable, /etc/pipelock/contain/tools.list
+// is readable, and the bash script's allow-list lookup is intact.
+//
+// We use a sentinel tool name (random + obviously not a real tool) so
+// that even on a system where the operator's `pipelock contain add-tool`
+// invocations accidentally collide with real binaries, this probe still
+// exercises the denial branch.
+//
+// Exit code mapping (matches install.go renderLaunchWrapper):
+//   - 0  unexpected — the sentinel was somehow accepted and executed
+//   - 1  sudo refused (NOPASSWD rule missing) → skip
+//   - 3  tool-name regex rejected — sentinel chosen wrong
+//   - 4  tools.list unreadable — fail, this breaks the launcher boundary
+//   - 5  tool not in allow-list — PASS
+//   - 6  in allow-list but PATH lookup failed — unexpected
+func probeCCLaunchAllowList(ctx context.Context, env *probeEnv) (string, string) {
+	const sentinelTool = "pipelock-probe-sentinel-not-a-real-tool"
+
+	out, code, err := env.runCmd(ctx, "sudo", "-n", "-u", env.agentUserName, "--",
+		env.launchPath, sentinelTool)
+	if err != nil {
+		return statusSkip, fmt.Sprintf("plk-launch invocation failed: %v", err)
+	}
+	if isSudoUserMissing(out) {
+		return statusSkip, "pipelock-agent user missing (install never ran)"
+	}
+	if isSudoRefusal(out) {
+		return statusSkip, "sudo -n refused (no NOPASSWD rule for operator -> pipelock-agent)"
+	}
+	if isSudoTargetCommandMissing(out) {
+		return statusSkip, fmt.Sprintf("plk-launch missing at %s (install never ran)", env.launchPath)
+	}
+
+	switch code {
+	case 5:
+		return statusPass, "allow-list correctly rejected sentinel tool"
+	case 4:
+		return statusFail, fmt.Sprintf("tools.list unreadable by pipelock-agent (exit 4): %s", oneLine(out))
+	case 0:
+		return statusFail, fmt.Sprintf("sentinel tool %q was unexpectedly allowed; allow-list bypass", sentinelTool)
+	default:
+		// Anything else is unexpected. Report the exit code + first
+		// stderr line so the operator can map it back to the wrapper's
+		// exit-code table.
+		return statusFail, fmt.Sprintf("plk-launch exit %d (expected 5): %s", code, oneLine(out))
+	}
+}
+
+// probeBinaryIntegrity reads the integrity pin written at install time and
+// compares it against the SHA-256 of the currently-running binary.
+// Skipped when the pin file is missing (install never happened) or
+// unreadable to this user (run as root to verify). Failure means either
+// the binary was swapped after install OR a different pipelock binary is
+// being used to run verify than the one that was installed.
+func probeBinaryIntegrity(_ context.Context, env *probeEnv) (string, string) {
+	data, err := env.readFile(env.pinPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return statusSkip, fmt.Sprintf("no pin at %s (install never ran or skipped)", env.pinPath)
+		}
+		return statusSkip, fmt.Sprintf("read %s: %v (rerun as root)", env.pinPath, err)
+	}
+	pinned := strings.TrimSpace(string(data))
+	if pinned == "" {
+		return statusFail, fmt.Sprintf("%s is empty (corrupted pin)", env.pinPath)
+	}
+	if _, err := hex.DecodeString(pinned); err != nil || len(pinned) != sha256HexLen {
+		return statusFail, fmt.Sprintf("%s contains malformed SHA-256 pin (length %d)", env.pinPath, len(pinned))
+	}
+
+	self, err := env.selfPath()
+	if err != nil {
+		return statusFail, fmt.Sprintf("resolve self path: %v", err)
+	}
+	got, err := env.hashFile(self)
+	if err != nil {
+		return statusFail, fmt.Sprintf("hash %s: %v", self, err)
+	}
+	if got != pinned {
+		// Truncate for readability; full hashes are 64 chars.
+		return statusFail, fmt.Sprintf("binary hash mismatch: pin=%s got=%s (binary swapped after install or different binary running verify)",
+			shortHash(pinned), shortHash(got))
+	}
+	return statusPass, fmt.Sprintf("binary hash %s matches pin", shortHash(pinned))
+}
+
+const sha256HexLen = 64
+
+func shortHash(s string) string {
+	if len(s) <= 12 {
+		return s
+	}
+	return s[:12] + "…"
 }
 
 // probeRecord is one JSON record per probe in --json output.
@@ -253,13 +439,16 @@ func verifyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "Run read-only probes against the containment model",
-		Long: `Run nine read-only probes to verify the workstation containment model
+		Long: `Run eleven read-only probes to verify the workstation containment model
 is installed correctly and the boundary is intact.
 
 Probes inspect system users, the pipelock systemd unit, nftables rules,
 wrapper scripts, the CA bundle, the pipelock loopback bind, the NO_PROXY
-policy, and run two egress canaries (cc-agent must NOT reach the
-internet directly; the operator user must still reach the internet).
+policy, run two egress canaries (pipelock-agent must NOT reach the internet
+directly; the operator user must still reach the internet), verify the
+installed binary matches the TOFU integrity pin written at install
+time, and exercise plk-launch end-to-end with a sentinel tool to confirm
+the allow-list enforcement path actually fires.
 
 verify never mutates state. Probes that require root visibility
 (nft list ruleset) record skip when run unprivileged.
@@ -494,11 +683,57 @@ func probeNFTContainment(ctx context.Context, env *probeEnv) (string, string) {
 	if !chainHasSkuidDrop(out, env.nftChain) {
 		return statusFail, "chain present but skuid-drop rule missing"
 	}
-	return statusPass, fmt.Sprintf("table inet %s has chain %s with skuid drop rule",
+	if !chainHasAgentProxyLoopbackAllow(out, env.nftChain, env.port) {
+		return statusFail, fmt.Sprintf("chain present but pipelock-agent loopback allow is not limited to 127.0.0.1:%d", env.port)
+	}
+	if chainHasBroadLoopbackAccept(out, env.nftChain) {
+		return statusFail, "chain contains broad loopback accept before agent drop"
+	}
+	if env.nftMainPath != "" && env.nftRulesPath != "" {
+		if err := verifyNFTPersistence(env); err != nil {
+			return statusFail, err.Error()
+		}
+	}
+	return statusPass, fmt.Sprintf("table inet %s has chain %s with skuid drop rule, proxy-only loopback allow, and persistence include",
 		env.nftTable, env.nftChain)
 }
 
+func verifyNFTPersistence(env *probeEnv) error {
+	data, err := env.readFile(env.nftMainPath)
+	if err != nil {
+		return fmt.Errorf("read nftables persistence config %s: %w", env.nftMainPath, err)
+	}
+	includeLine := nftRulesIncludeLine(env.nftRulesPath)
+	if !nftMainHasInclude(string(data), includeLine) {
+		return fmt.Errorf("%s missing persistence include %q", env.nftMainPath, includeLine)
+	}
+	return nil
+}
+
 func chainHasSkuidDrop(out, chainName string) bool {
+	return chainHasLine(out, chainName, func(line string) bool {
+		return strings.Contains(line, "skuid") && strings.Contains(line, "drop")
+	})
+}
+
+func chainHasAgentProxyLoopbackAllow(out, chainName string, port int) bool {
+	portText := strconv.Itoa(port)
+	return chainHasLine(out, chainName, func(line string) bool {
+		return strings.Contains(line, "skuid") &&
+			strings.Contains(line, "ip daddr 127.0.0.1") &&
+			strings.Contains(line, "tcp dport "+portText) &&
+			strings.Contains(line, "accept")
+	})
+}
+
+func chainHasBroadLoopbackAccept(out, chainName string) bool {
+	return chainHasLine(out, chainName, func(line string) bool {
+		return strings.Contains(line, "accept") &&
+			(strings.Contains(line, `meta oif "lo"`) || strings.Contains(line, "ip daddr 127.0.0.0/8"))
+	})
+}
+
+func chainHasLine(out, chainName string, match func(string) bool) bool {
 	inChain := false
 	depth := 0
 	for _, raw := range strings.Split(out, "\n") {
@@ -515,7 +750,7 @@ func chainHasSkuidDrop(out, chainName string) bool {
 		if strings.Contains(line, "{") {
 			depth += strings.Count(line, "{")
 		}
-		if strings.Contains(line, "skuid") && strings.Contains(line, "drop") {
+		if match(line) {
 			return true
 		}
 		if strings.Contains(line, "}") {
@@ -543,8 +778,12 @@ func probeWrapperScripts(_ context.Context, env *probeEnv) (string, string) {
 		return statusFail, fmt.Sprintf("%s has perm 0o%03o, want 0o755", env.launchPath, mode)
 	}
 
+	wrappers, err := wrappersForVerify(env)
+	if err != nil {
+		return statusFail, err.Error()
+	}
 	var foundNames []string
-	for _, name := range env.toolWrappers {
+	for _, name := range wrappers {
 		p := filepath.Join(env.wrapperDir, name)
 		info, err := os.Stat(filepath.Clean(p))
 		if err != nil {
@@ -561,10 +800,31 @@ func probeWrapperScripts(_ context.Context, env *probeEnv) (string, string) {
 	}
 	if len(foundNames) == 0 {
 		return statusFail, fmt.Sprintf("no tool wrappers found in %s (expected one of %v)",
-			env.wrapperDir, env.toolWrappers)
+			env.wrapperDir, wrappers)
 	}
-	return statusPass, fmt.Sprintf("cc-launch + %d tool wrapper(s): %s",
+	return statusPass, fmt.Sprintf("plk-launch + %d tool wrapper(s): %s",
 		len(foundNames), strings.Join(foundNames, ","))
+}
+
+func wrappersForVerify(env *probeEnv) ([]string, error) {
+	if env.wrapperInvPath == "" {
+		return append([]string(nil), env.toolWrappers...), nil
+	}
+	data, err := env.readFile(env.wrapperInvPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return append([]string(nil), env.toolWrappers...), nil
+		}
+		return nil, fmt.Errorf("read wrapper inventory %s: %w", env.wrapperInvPath, err)
+	}
+	var inv wrapperInventory
+	if err := json.Unmarshal(data, &inv); err != nil {
+		return nil, fmt.Errorf("parse wrapper inventory %s: %w", env.wrapperInvPath, err)
+	}
+	if len(inv.Wrappers) == 0 {
+		return nil, fmt.Errorf("wrapper inventory %s is empty", env.wrapperInvPath)
+	}
+	return append([]string(nil), inv.Wrappers...), nil
 }
 
 // ---------------------------------------------------------------------------
@@ -794,7 +1054,7 @@ func isSudoRefusal(out string) bool {
 }
 
 // isSudoUserMissing detects sudo's "unknown user" failure mode. If the
-// target user (cc-agent or the operator) does not exist on the system,
+// target user (pipelock-agent or the operator) does not exist on the system,
 // sudo exits non-zero before invoking the target command. Probes 8
 // and 9 must treat this as skip rather than fail, otherwise an
 // uninstalled containment model would falsely report PASS on the

--- a/internal/cli/contain/verify_probe11_test.go
+++ b/internal/cli/contain/verify_probe11_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Probe 11 is the post-install self-test: invoke plk-launch with a
+// sentinel tool and assert it exits 5 (denied by allow-list). These
+// tests verify the probe's classification of every relevant plk-launch
+// exit code.
+
+const probe11Sentinel = "pipelock-probe-sentinel-not-a-real-tool"
+
+func TestProbeCCLaunchAllowList_PassOnExit5(t *testing.T) {
+	env := makeProbeEnv(t)
+	env.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+		return "plk-launch: tool " + probe11Sentinel + " not in pipelock contain allow-list", 5, nil
+	}
+	status, _ := probeCCLaunchAllowList(context.Background(), env)
+	if status != statusPass {
+		t.Errorf("status: %s, want pass", status)
+	}
+}
+
+func TestProbeCCLaunchAllowList_FailOnExit0Bypass(t *testing.T) {
+	env := makeProbeEnv(t)
+	env.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+		return "executed sentinel — uh oh", 0, nil
+	}
+	status, detail := probeCCLaunchAllowList(context.Background(), env)
+	if status != statusFail {
+		t.Errorf("status: %s, want fail", status)
+	}
+	if !strings.Contains(detail, "bypass") {
+		t.Errorf("detail missing bypass hint: %s", detail)
+	}
+}
+
+func TestProbeCCLaunchAllowList_FailOnExit4ToolsListUnreadable(t *testing.T) {
+	env := makeProbeEnv(t)
+	env.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+		return "plk-launch: missing allow-list at /etc/pipelock/contain/tools.list", 4, nil
+	}
+	status, detail := probeCCLaunchAllowList(context.Background(), env)
+	if status != statusFail {
+		t.Errorf("status: %s, want fail", status)
+	}
+	if !strings.Contains(detail, "unreadable") {
+		t.Errorf("detail: %s", detail)
+	}
+}
+
+func TestProbeCCLaunchAllowList_SkipOnSudoRefusal(t *testing.T) {
+	env := makeProbeEnv(t)
+	env.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+		return testSudoNeedsPwd, 1, nil
+	}
+	status, detail := probeCCLaunchAllowList(context.Background(), env)
+	if status != statusSkip {
+		t.Errorf("status: %s, want skip", status)
+	}
+	if !strings.Contains(detail, "NOPASSWD") {
+		t.Errorf("detail: %s", detail)
+	}
+}
+
+func TestProbeCCLaunchAllowList_SkipOnMissingCCAgent(t *testing.T) {
+	env := makeProbeEnv(t)
+	env.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+		return "sudo: unknown user pipelock-agent", 1, nil
+	}
+	status, detail := probeCCLaunchAllowList(context.Background(), env)
+	if status != statusSkip {
+		t.Errorf("status: %s, want skip", status)
+	}
+	if !strings.Contains(detail, "pipelock-agent user missing") {
+		t.Errorf("detail: %s", detail)
+	}
+}
+
+func TestProbeCCLaunchAllowList_SkipOnMissingLauncher(t *testing.T) {
+	env := makeProbeEnv(t)
+	env.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+		return "sudo: plk-launch: command not found", 1, nil
+	}
+	status, detail := probeCCLaunchAllowList(context.Background(), env)
+	if status != statusSkip {
+		t.Errorf("status: %s, want skip", status)
+	}
+	if !strings.Contains(detail, "plk-launch missing") {
+		t.Errorf("detail: %s", detail)
+	}
+}
+
+func TestProbeCCLaunchAllowList_FailOnUnexpectedExit(t *testing.T) {
+	env := makeProbeEnv(t)
+	env.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+		return "plk-launch: target /nope is not executable", 8, nil
+	}
+	status, detail := probeCCLaunchAllowList(context.Background(), env)
+	if status != statusFail {
+		t.Errorf("status: %s, want fail", status)
+	}
+	if !strings.Contains(detail, "exit 8") {
+		t.Errorf("detail: %s", detail)
+	}
+}
+
+func TestProbeCCLaunchAllowList_SkipOnRunErr(t *testing.T) {
+	env := makeProbeEnv(t)
+	env.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+		return "", -1, fmt.Errorf("exec failed")
+	}
+	status, _ := probeCCLaunchAllowList(context.Background(), env)
+	if status != statusSkip {
+		t.Errorf("status: %s, want skip", status)
+	}
+}
+
+func TestProbeListedToolTargets_PassWithExplicitTarget(t *testing.T) {
+	env := makeProbeEnv(t)
+	target := filepath.Join(t.TempDir(), "claude")
+	writeFakeWrapper(t, target, 0o755)
+	env.readFile = func(path string) ([]byte, error) {
+		if path == env.toolsListPath {
+			return []byte("claude\t" + target + "\n"), nil
+		}
+		return nil, fmt.Errorf("unexpected readFile %s", path)
+	}
+	status, detail := probeListedToolTargets(context.Background(), env)
+	if status != statusPass {
+		t.Fatalf("status: %s detail=%s", status, detail)
+	}
+}
+
+func TestProbeListedToolTargets_FailsWhenPathLookupMissing(t *testing.T) {
+	env := makeProbeEnv(t)
+	env.stat = func(path string) (os.FileInfo, error) {
+		if strings.Contains(path, "/claude") {
+			return nil, os.ErrNotExist
+		}
+		return os.Stat(path)
+	}
+	env.readFile = func(path string) ([]byte, error) {
+		if path == env.toolsListPath {
+			return []byte("claude\t\n"), nil
+		}
+		return nil, fmt.Errorf("unexpected readFile %s", path)
+	}
+	status, detail := probeListedToolTargets(context.Background(), env)
+	if status != statusFail {
+		t.Fatalf("status: %s detail=%s", status, detail)
+	}
+	if !strings.Contains(detail, "claude not found in pipelock-agent PATH") {
+		t.Fatalf("detail: %s", detail)
+	}
+}
+
+func TestProbeListedToolTargets_PassWithAgentPathLookup(t *testing.T) {
+	env := makeProbeEnv(t)
+	agentHomeBin := filepath.Join(t.TempDir(), "home", testAgentUser, ".local", "bin")
+	env.agentUserName = testAgentUser
+	env.stat = func(path string) (os.FileInfo, error) {
+		if path == "/home/"+testAgentUser+"/.local/bin/claude" {
+			return os.Stat(filepath.Join(agentHomeBin, "claude"))
+		}
+		return os.Stat(path)
+	}
+	if err := os.MkdirAll(agentHomeBin, 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFakeWrapper(t, filepath.Join(agentHomeBin, "claude"), 0o755)
+	env.readFile = func(path string) ([]byte, error) {
+		if path == env.toolsListPath {
+			return []byte("claude\t\n"), nil
+		}
+		return nil, fmt.Errorf("unexpected readFile %s", path)
+	}
+	status, detail := probeListedToolTargets(context.Background(), env)
+	if status != statusPass {
+		t.Fatalf("status: %s detail=%s", status, detail)
+	}
+}

--- a/internal/cli/contain/verify_probe11_test.go
+++ b/internal/cli/contain/verify_probe11_test.go
@@ -174,7 +174,7 @@ func TestProbeListedToolTargets_PassWithAgentPathLookup(t *testing.T) {
 		}
 		return os.Stat(path)
 	}
-	if err := os.MkdirAll(agentHomeBin, 0o755); err != nil { //nolint:gosec // tmpdir
+	if err := os.MkdirAll(agentHomeBin, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	writeFakeWrapper(t, filepath.Join(agentHomeBin, "claude"), 0o755)

--- a/internal/cli/contain/verify_probe11_test.go
+++ b/internal/cli/contain/verify_probe11_test.go
@@ -5,6 +5,7 @@ package contain
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -187,5 +188,98 @@ func TestProbeListedToolTargets_PassWithAgentPathLookup(t *testing.T) {
 	status, detail := probeListedToolTargets(context.Background(), env)
 	if status != statusPass {
 		t.Fatalf("status: %s detail=%s", status, detail)
+	}
+}
+
+func TestProbeListedToolTargets_EdgeFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		plant      func(t *testing.T, env *probeEnv) string
+		readErr    error
+		wantStatus string
+		wantDetail string
+	}{
+		{
+			name:       "missing tools list skips",
+			readErr:    os.ErrNotExist,
+			wantStatus: statusSkip,
+			wantDetail: "install never ran",
+		},
+		{
+			name:       "read error fails",
+			readErr:    errors.New("permission denied"),
+			wantStatus: statusFail,
+			wantDetail: "permission denied",
+		},
+		{
+			name:       "malformed tools list fails",
+			body:       "not-a-valid-line\n",
+			wantStatus: statusFail,
+			wantDetail: "malformed tools.list",
+		},
+		{
+			name:       "empty tools list fails",
+			body:       "# no tools\n\n",
+			wantStatus: statusFail,
+			wantDetail: "no tool entries",
+		},
+		{
+			name: "directory target fails",
+			body: "claude\tTARGET\n",
+			plant: func(t *testing.T, _ *probeEnv) string {
+				t.Helper()
+				return t.TempDir()
+			},
+			wantStatus: statusFail,
+			wantDetail: "is a directory",
+		},
+		{
+			name: "non-executable target fails",
+			body: "claude\tTARGET\n",
+			plant: func(t *testing.T, _ *probeEnv) string {
+				t.Helper()
+				target := filepath.Join(t.TempDir(), "claude")
+				if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+					t.Fatalf("write target: %v", err)
+				}
+				return target
+			},
+			wantStatus: statusFail,
+			wantDetail: "not executable",
+		},
+		{
+			name:       "missing explicit target fails",
+			body:       "claude\t/no/such/target\n",
+			wantStatus: statusFail,
+			wantDetail: "no such",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := makeProbeEnv(t)
+			body := tc.body
+			if tc.plant != nil {
+				body = strings.ReplaceAll(body, "TARGET", tc.plant(t, env))
+			}
+			env.readFile = func(path string) ([]byte, error) {
+				if path != env.toolsListPath {
+					return nil, fmt.Errorf("unexpected readFile %s", path)
+				}
+				if tc.readErr != nil {
+					return nil, tc.readErr
+				}
+				return []byte(body), nil
+			}
+
+			status, detail := probeListedToolTargets(context.Background(), env)
+			if status != tc.wantStatus {
+				t.Fatalf("status: got %s want %s detail=%s", status, tc.wantStatus, detail)
+			}
+			if !strings.Contains(detail, tc.wantDetail) {
+				t.Fatalf("detail: got %q want substring %q", detail, tc.wantDetail)
+			}
+		})
 	}
 }

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -34,13 +34,26 @@ import (
 
 const (
 	testProxyUser    = "pipelock-proxy"
-	testAgentUser    = "cc-agent"
+	testAgentUser    = "pipelock-agent"
 	testTable        = "pipelock_containment"
 	testChain        = "output_filter"
 	testService      = "pipelock.service"
 	testSudoCmd      = "sudo"
 	testOperatorUser = "operator"
+	testSystemctl    = "systemctl"
+	testNFT          = "nft"
+	testUserDel      = "userdel"
+	testRustup       = "rustup"
+	testSudoNeedsPwd = "sudo: a password is required"
 )
+
+const goodNFTContainmentOutput = `table inet pipelock_containment {
+	chain output_filter {
+		meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+		meta skuid 987 drop
+	}
+}
+`
 
 // fakeRunResult is a canned subprocess response keyed by the leading
 // argv element (the command name). Tests pre-populate the map with
@@ -106,17 +119,23 @@ func makeProbeEnv(t *testing.T, opts ...func(*probeEnv)) *probeEnv {
 		proxyUserName: testProxyUser,
 		agentUserName: testAgentUser,
 		wrapperDir:    t.TempDir(),
-		toolWrappers:  []string{"cc-claude", "cc-codex"},
+		toolWrappers:  []string{"plk-claude", "plk-codex"},
 		caBundlePath:  filepath.Join(t.TempDir(), "combined-ca.pem"),
 		launchPath:    "", // populated below
 		nftTable:      testTable,
 		nftChain:      testChain,
 		serviceName:   testService,
+		pinPath:       filepath.Join(t.TempDir(), "binary-pin.sha256"),
+		toolsListPath: filepath.Join(t.TempDir(), "tools.list"),
 		runCmd:        rejectAllRun,
 		dialCtx:       rejectAllDial,
 		lookupUser:    rejectAllLookup,
+		stat:          os.Stat,
+		readFile:      rejectAllReadFile,
+		selfPath:      rejectAllSelfPath,
+		hashFile:      rejectAllHashFile,
 	}
-	env.launchPath = filepath.Join(env.wrapperDir, "cc-launch")
+	env.launchPath = filepath.Join(env.wrapperDir, "plk-launch")
 	for _, opt := range opts {
 		opt(env)
 	}
@@ -133,6 +152,18 @@ func rejectAllDial(_ context.Context, _, address string, _ time.Duration) (net.C
 
 func rejectAllLookup(name string) (*user.User, error) {
 	return nil, fmt.Errorf("unstubbed lookup: %s", name)
+}
+
+func rejectAllReadFile(path string) ([]byte, error) {
+	return nil, fmt.Errorf("unstubbed readFile: %s", path)
+}
+
+func rejectAllSelfPath() (string, error) {
+	return "", fmt.Errorf("unstubbed selfPath")
+}
+
+func rejectAllHashFile(path string) (string, error) {
+	return "", fmt.Errorf("unstubbed hashFile: %s", path)
 }
 
 // Probe 1: system_users_exist ------------------------------------------------
@@ -152,7 +183,7 @@ func TestProbeSystemUsers(t *testing.T) {
 			proxy:      &user.User{Uid: "988", Username: testProxyUser},
 			agent:      &user.User{Uid: "987", Username: testAgentUser},
 			wantStatus: statusPass,
-			wantDetail: "pipelock-proxy uid=988, cc-agent uid=987",
+			wantDetail: "pipelock-proxy uid=988, pipelock-agent uid=987",
 		},
 		{
 			name:       "proxy missing",
@@ -166,7 +197,7 @@ func TestProbeSystemUsers(t *testing.T) {
 			proxy:      &user.User{Uid: "988", Username: testProxyUser},
 			agentErr:   user.UnknownUserError(testAgentUser),
 			wantStatus: statusFail,
-			wantDetail: "cc-agent missing",
+			wantDetail: "pipelock-agent missing",
 		},
 		{
 			name:       "both missing",
@@ -254,7 +285,7 @@ func TestProbeSystemdUnit(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			env := makeProbeEnv(t, func(e *probeEnv) {
 				e.runCmd = func(_ context.Context, name string, _ ...string) (string, int, error) {
-					if name != "systemctl" {
+					if name != testSystemctl {
 						return "", -1, fmt.Errorf("unexpected cmd %q", name)
 					}
 					return tc.stdout, tc.code, tc.runErr
@@ -290,15 +321,6 @@ func TestParseSystemdShow(t *testing.T) {
 // Probe 3: nftables_containment_ruleset --------------------------------------
 
 func TestProbeNFTContainment(t *testing.T) {
-	goodOutput := `table inet pipelock_containment {
-	chain output_filter {
-		type filter hook output priority filter; policy accept;
-		meta oif "lo" accept
-		meta skuid 987 drop
-	}
-}
-`
-
 	tests := []struct {
 		name       string
 		stdout     string
@@ -309,7 +331,7 @@ func TestProbeNFTContainment(t *testing.T) {
 	}{
 		{
 			name:       "happy path",
-			stdout:     goodOutput,
+			stdout:     goodNFTContainmentOutput,
 			code:       0,
 			wantStatus: statusPass,
 			wantDetail: "skuid drop rule",
@@ -344,23 +366,49 @@ func TestProbeNFTContainment(t *testing.T) {
 		{
 			name: "no skuid drop rule",
 			stdout: `table inet pipelock_containment {
-	chain output_filter {
-		meta oif "lo" accept
+		chain output_filter {
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+		}
 	}
-}
-`,
+	`,
 			code:       0,
 			wantStatus: statusFail,
 			wantDetail: "skuid-drop rule missing",
 		},
 		{
+			name: "broad loopback accept",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta oif "lo" accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "broad loopback accept",
+		},
+		{
+			name: "missing proxy port allow",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "loopback allow",
+		},
+		{
 			name: "skuid and drop outside target chain",
 			stdout: `table inet pipelock_containment {
-	chain output_filter {
-		meta oif "lo" accept
-	}
-	chain decoy {
-		meta skuid 987 drop
+		chain output_filter {
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+		}
+		chain decoy {
+			meta skuid 987 drop
 	}
 }
 `,
@@ -388,19 +436,67 @@ func TestProbeNFTContainment(t *testing.T) {
 	}
 }
 
+func TestProbeNFTContainment_ChecksPersistenceInclude(t *testing.T) {
+	tmp := t.TempDir()
+	mainPath := filepath.Join(tmp, "nftables.conf")
+	rulesPath := filepath.Join(tmp, "50-pipelock-containment.nft")
+	if err := os.WriteFile(mainPath, []byte(nftRulesIncludeLine(rulesPath)+"\n"), 0o600); err != nil {
+		t.Fatalf("write main config: %v", err)
+	}
+	env := makeProbeEnv(t, func(e *probeEnv) {
+		e.nftRulesPath = rulesPath
+		e.nftMainPath = mainPath
+		e.readFile = os.ReadFile
+		e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+			return goodNFTContainmentOutput, 0, nil
+		}
+	})
+	gotStatus, gotDetail := probeNFTContainment(context.Background(), env)
+	if gotStatus != statusPass {
+		t.Fatalf("status: got %q, want pass (detail=%q)", gotStatus, gotDetail)
+	}
+	if !strings.Contains(gotDetail, "persistence include") {
+		t.Fatalf("detail: got %q, want persistence include", gotDetail)
+	}
+}
+
+func TestProbeNFTContainment_FailsWhenPersistenceIncludeMissing(t *testing.T) {
+	tmp := t.TempDir()
+	mainPath := filepath.Join(tmp, "nftables.conf")
+	rulesPath := filepath.Join(tmp, "50-pipelock-containment.nft")
+	if err := os.WriteFile(mainPath, []byte("flush ruleset\n"), 0o600); err != nil {
+		t.Fatalf("write main config: %v", err)
+	}
+	env := makeProbeEnv(t, func(e *probeEnv) {
+		e.nftRulesPath = rulesPath
+		e.nftMainPath = mainPath
+		e.readFile = os.ReadFile
+		e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+			return goodNFTContainmentOutput, 0, nil
+		}
+	})
+	gotStatus, gotDetail := probeNFTContainment(context.Background(), env)
+	if gotStatus != statusFail {
+		t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+	}
+	if !strings.Contains(gotDetail, "missing persistence include") {
+		t.Fatalf("detail: got %q, want missing persistence include", gotDetail)
+	}
+}
+
 // Probe 4: wrapper_scripts_installed -----------------------------------------
 
 func TestProbeWrapperScripts(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		env := makeProbeEnv(t)
 		writeFakeWrapper(t, env.launchPath, 0o755)
-		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "cc-claude"), 0o755)
+		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk-claude"), 0o755)
 		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
 		if gotStatus != statusPass {
 			t.Fatalf("status: got %q, want pass (detail=%q)", gotStatus, gotDetail)
 		}
-		if !strings.Contains(gotDetail, "cc-claude") {
-			t.Fatalf("detail: got %q, want substring cc-claude", gotDetail)
+		if !strings.Contains(gotDetail, "plk-claude") {
+			t.Fatalf("detail: got %q, want substring plk-claude", gotDetail)
 		}
 	})
 
@@ -410,8 +506,8 @@ func TestProbeWrapperScripts(t *testing.T) {
 		if gotStatus != statusFail {
 			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
 		}
-		if !strings.Contains(gotDetail, "cc-launch") {
-			t.Fatalf("detail: got %q, want cc-launch", gotDetail)
+		if !strings.Contains(gotDetail, "plk-launch") {
+			t.Fatalf("detail: got %q, want plk-launch", gotDetail)
 		}
 	})
 
@@ -442,13 +538,54 @@ func TestProbeWrapperScripts(t *testing.T) {
 	t.Run("tool wrapper wrong mode", func(t *testing.T) {
 		env := makeProbeEnv(t)
 		writeFakeWrapper(t, env.launchPath, 0o755)
-		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "cc-claude"), 0o644)
+		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk-claude"), 0o644)
 		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
 		if gotStatus != statusFail {
 			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
 		}
 		if !strings.Contains(gotDetail, "want 0o755") {
 			t.Fatalf("detail: got %q, want wrapper mode failure", gotDetail)
+		}
+	})
+
+	t.Run("uses wrapper inventory when present", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		env.wrapperInvPath = filepath.Join(t.TempDir(), "wrappers.json")
+		env.readFile = os.ReadFile
+		writeFakeWrapper(t, env.launchPath, 0o755)
+		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk-rustup"), 0o755)
+		body, err := json.Marshal(wrapperInventory{Wrappers: []string{"plk-rustup"}})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(env.wrapperInvPath, append(body, '\n'), 0o600); err != nil {
+			t.Fatalf("write inventory: %v", err)
+		}
+
+		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
+		if gotStatus != statusPass {
+			t.Fatalf("status: got %q, want pass (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "plk-rustup") {
+			t.Fatalf("detail: got %q, want custom wrapper", gotDetail)
+		}
+	})
+
+	t.Run("malformed wrapper inventory fails", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		env.wrapperInvPath = filepath.Join(t.TempDir(), "wrappers.json")
+		env.readFile = os.ReadFile
+		writeFakeWrapper(t, env.launchPath, 0o755)
+		if err := os.WriteFile(env.wrapperInvPath, []byte("{"), 0o600); err != nil {
+			t.Fatalf("write inventory: %v", err)
+		}
+
+		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "parse wrapper inventory") {
+			t.Fatalf("detail: got %q, want parse failure", gotDetail)
 		}
 	})
 }
@@ -716,7 +853,7 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 		},
 		{
 			name:       "sudo no password",
-			stdout:     "sudo: a password is required\n",
+			stdout:     testSudoNeedsPwd + "\n",
 			code:       1,
 			wantStatus: statusSkip,
 			wantDetail: "configure NOPASSWD",
@@ -742,8 +879,8 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 			wantDetail: "sudo/curl unavailable",
 		},
 		{
-			name:       "cc-agent user missing",
-			stdout:     "sudo: unknown user cc-agent\nsudo: error initializing audit plugin sudoers_audit\n",
+			name:       "pipelock-agent user missing",
+			stdout:     "sudo: unknown user pipelock-agent\nsudo: error initializing audit plugin sudoers_audit\n",
 			code:       1,
 			wantStatus: statusSkip,
 			wantDetail: "install containment model first",
@@ -764,7 +901,7 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 					if name != testSudoCmd {
 						t.Fatalf("unexpected cmd %q", name)
 					}
-					// Sanity: confirm we drop to cc-agent.
+					// Sanity: confirm we drop to pipelock-agent.
 					joined := strings.Join(args, " ")
 					if !strings.Contains(joined, "-u "+testAgentUser) {
 						t.Fatalf("argv missing -u %s: %v", testAgentUser, args)
@@ -842,7 +979,7 @@ func TestProbeOperatorEgress(t *testing.T) {
 		env := makeProbeEnv(t, func(e *probeEnv) {
 			e.operatorUser = testOperatorUser
 			e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
-				return "sudo: a password is required", 1, nil
+				return testSudoNeedsPwd, 1, nil
 			}
 		})
 		gotStatus, _ := probeOperatorEgress(context.Background(), env)
@@ -1037,10 +1174,10 @@ func TestRunVerify_TextOutput_AllPass(t *testing.T) {
 	if !strings.HasPrefix(out, "pipelock contain verify") {
 		t.Errorf("missing header: %q", out)
 	}
-	if strings.Count(out, "[PASS]") != 9 {
-		t.Errorf("want 9 [PASS] lines, got %d in %q", strings.Count(out, "[PASS]"), out)
+	if strings.Count(out, "[PASS]") != 12 {
+		t.Errorf("want 12 [PASS] lines, got %d in %q", strings.Count(out, "[PASS]"), out)
 	}
-	if !strings.Contains(out, "9 PASS / 0 FAIL / 0 SKIP") {
+	if !strings.Contains(out, "12 PASS / 0 FAIL / 0 SKIP") {
 		t.Errorf("missing aggregate: %q", out)
 	}
 }
@@ -1057,10 +1194,10 @@ func TestRunVerify_JSONOutput_AllPass(t *testing.T) {
 	}
 
 	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
-	if len(lines) != 10 {
-		t.Fatalf("expected 10 JSON records (9 probes + aggregate), got %d: %q", len(lines), buf.String())
+	if len(lines) != 13 {
+		t.Fatalf("expected 13 JSON records (12 probes + aggregate), got %d: %q", len(lines), buf.String())
 	}
-	for i := 0; i < 9; i++ {
+	for i := 0; i < 12; i++ {
 		var rec probeRecord
 		if err := json.Unmarshal([]byte(lines[i]), &rec); err != nil {
 			t.Fatalf("line %d: parse: %v (line=%q)", i, err, lines[i])
@@ -1073,10 +1210,10 @@ func TestRunVerify_JSONOutput_AllPass(t *testing.T) {
 		}
 	}
 	var agg aggregateRecord
-	if err := json.Unmarshal([]byte(lines[9]), &agg); err != nil {
-		t.Fatalf("aggregate: parse: %v (line=%q)", err, lines[9])
+	if err := json.Unmarshal([]byte(lines[12]), &agg); err != nil {
+		t.Fatalf("aggregate: parse: %v (line=%q)", err, lines[12])
 	}
-	if agg.Aggregate.Pass != 9 || agg.Aggregate.Fail != 0 || agg.Aggregate.Skip != 0 {
+	if agg.Aggregate.Pass != 12 || agg.Aggregate.Fail != 0 || agg.Aggregate.Skip != 0 {
 		t.Errorf("aggregate counts: %+v", agg.Aggregate)
 	}
 	if agg.Aggregate.ExitCode != cliutil.ExitOK {
@@ -1086,9 +1223,12 @@ func TestRunVerify_JSONOutput_AllPass(t *testing.T) {
 
 func TestRunVerify_FailExitCode(t *testing.T) {
 	env := allPassEnv(t)
-	// Force one probe to fail by making the egress canary "succeed".
+	// Force the egress canary (probe 8) to fail by reporting curl success.
+	// Probe 11 also uses sudo + pipelock-agent; distinguish by checking for the
+	// curl path in argv. Without this guard, probe 11 would short-circuit
+	// here and the test would observe an unrelated failure.
 	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
-		if name == testSudoCmd && containsArg(args, testAgentUser) {
+		if name == testSudoCmd && containsArg(args, testAgentUser) && containsArg(args, curlPath) {
 			return "200", 0, nil
 		}
 		return defaultRunForAllPass(name, args)
@@ -1116,8 +1256,10 @@ func TestRunVerify_SkipExitCode(t *testing.T) {
 	// security canary must not return exit 0, or CI can mistake an
 	// incomplete verification for a clean containment boundary.
 	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
-		if name == testSudoCmd && containsArg(args, testAgentUser) {
-			return "sudo: a password is required", 1, nil
+		// Match probe 8 (curl) only — probe 11 (plk-launch) needs the
+		// default canned response so it doesn't also skip.
+		if name == testSudoCmd && containsArg(args, testAgentUser) && containsArg(args, curlPath) {
+			return testSudoNeedsPwd, 1, nil
 		}
 		return defaultRunForAllPass(name, args)
 	}
@@ -1170,7 +1312,15 @@ func TestVerifyCmd_InvalidPort(t *testing.T) {
 	}
 }
 
-func TestStubSubcommands(t *testing.T) {
+// TestMutatingSubcommandsRequireRoot covers the precondition gate every
+// mutating subcommand runs first: a non-root invocation must exit ExitConfig
+// with a clear "must be run as root" message. This test exists so a future
+// refactor can't accidentally turn the root gate into a no-op (which would
+// let unprivileged callers attempt mutations and fail mid-step).
+func TestMutatingSubcommandsRequireRoot(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("test must run as non-root to exercise the precondition")
+	}
 	cases := []struct {
 		subcmd string
 		args   []string
@@ -1189,13 +1339,13 @@ func TestStubSubcommands(t *testing.T) {
 			}
 			err := sub.RunE(sub, tc.args)
 			if err == nil {
-				t.Fatalf("stub %s returned nil; want ExitError", tc.subcmd)
+				t.Fatalf("%s as non-root returned nil; want ExitError", tc.subcmd)
 			}
 			if code := cliutil.ExitCodeOf(err); code != cliutil.ExitConfig {
-				t.Errorf("stub %s exit code: got %d, want %d", tc.subcmd, code, cliutil.ExitConfig)
+				t.Errorf("%s exit code: got %d, want %d (ExitConfig)", tc.subcmd, code, cliutil.ExitConfig)
 			}
-			if !strings.Contains(err.Error(), "not yet implemented") {
-				t.Errorf("stub %s error: got %q, want substring 'not yet implemented'", tc.subcmd, err)
+			if !strings.Contains(err.Error(), "must be run as root") {
+				t.Errorf("%s error: got %q, want substring 'must be run as root'", tc.subcmd, err)
 			}
 		})
 	}
@@ -1213,10 +1363,7 @@ func TestAddToolNameValidation(t *testing.T) {
 				t.Fatalf("add-tool %q returned nil; want validation error", name)
 			}
 			if !strings.Contains(err.Error(), "invalid tool name") {
-				// Pattern allows up to 31 chars; a 32-char name should be rejected too.
-				if !strings.Contains(err.Error(), "not yet implemented") {
-					t.Errorf("add-tool %q: got error %q", name, err)
-				}
+				t.Errorf("add-tool %q: got error %q, want 'invalid tool name'", name, err)
 			}
 		})
 	}
@@ -1276,14 +1423,37 @@ func allPassEnv(t *testing.T) *probeEnv {
 		return defaultRunForAllPass(name, args)
 	}
 
-	// Filesystem state for probes 4, 5, 7.
+	// Filesystem state for probes 4, 5, 7, 12.
 	writeFakeWrapper(t, env.launchPath, 0o755)
-	writeFakeWrapper(t, filepath.Join(env.wrapperDir, "cc-claude"), 0o755)
+	writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk-claude"), 0o755)
+	toolTarget := filepath.Join(t.TempDir(), "claude")
+	writeFakeWrapper(t, toolTarget, 0o755)
 	body := "#!/bin/bash\nexec env NO_PROXY=127.0.0.1,localhost HTTPS_PROXY=http://127.0.0.1:8888 sh\n"
 	if err := os.WriteFile(env.launchPath, []byte(body), 0o755); err != nil { //nolint:gosec // wrapper script must be executable in test
 		t.Fatalf("rewrite launch: %v", err)
 	}
 	writeFakePEMBundle(t, env.caBundlePath, "Pipelock Test CA")
+
+	// Probe 10: binary integrity. allPassEnv emits matching pin + hash so
+	// the probe returns pass. Tests that want to exercise mismatch override
+	// hashFile or readFile after calling allPassEnv.
+	const allPassHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abcd"
+	env.readFile = func(path string) ([]byte, error) {
+		if path == env.pinPath {
+			return []byte(allPassHash + "\n"), nil
+		}
+		if path == env.toolsListPath {
+			return []byte("claude\t" + toolTarget + "\n"), nil
+		}
+		return nil, fmt.Errorf("unexpected readFile %s", path)
+	}
+	env.selfPath = func() (string, error) { return "/usr/local/bin/pipelock", nil }
+	env.hashFile = func(path string) (string, error) {
+		if path == "/usr/local/bin/pipelock" {
+			return allPassHash, nil
+		}
+		return "", fmt.Errorf("unexpected hashFile %s", path)
+	}
 
 	return env
 }
@@ -1292,17 +1462,17 @@ func allPassEnv(t *testing.T) *probeEnv {
 // every probe should pass.
 func defaultRunForAllPass(name string, args []string) (string, int, error) {
 	switch name {
-	case "systemctl":
+	case testSystemctl:
 		return "ActiveState=active\nSubState=running\nUser=pipelock-proxy\nType=simple\n", 0, nil
-	case "nft":
-		return `table inet pipelock_containment {
-	chain output_filter {
-		meta skuid 987 drop
-	}
-}
-`, 0, nil
+	case testNFT:
+		return goodNFTContainmentOutput, 0, nil
 	case testSudoCmd:
-		// Either cc-agent (probe 8) or operator (probe 9). Match by argv.
+		// Probe 11: plk-launch allow-list probe invokes plk-launch with a
+		// sentinel tool name. Expect exit 5 = denial.
+		if containsArg(args, "plk-launch") || containsArg(args, "pipelock-probe-sentinel-not-a-real-tool") {
+			return "plk-launch: tool pipelock-probe-sentinel-not-a-real-tool not in pipelock contain allow-list", 5, nil
+		}
+		// Either pipelock-agent (probe 8) or operator (probe 9). Match by argv.
 		if containsArg(args, testAgentUser) {
 			return "curl: (7) Failed to connect", 7, nil
 		}
@@ -1331,7 +1501,7 @@ func TestOneLine(t *testing.T) {
 
 func TestIsSudoUserMissing(t *testing.T) {
 	yes := []string{
-		"sudo: unknown user cc-agent",
+		"sudo: unknown user pipelock-agent",
 		"sudo: unknown user: pipelock-proxy",
 		"SUDO: UNKNOWN USER FOO",
 	}
@@ -1341,7 +1511,7 @@ func TestIsSudoUserMissing(t *testing.T) {
 		}
 	}
 	no := []string{
-		"sudo: a password is required",
+		testSudoNeedsPwd,
 		"curl: (7) Failed to connect",
 		"",
 	}
@@ -1364,7 +1534,7 @@ func TestIsSudoTargetCommandMissing(t *testing.T) {
 	}
 	no := []string{
 		"curl: (7) Failed to connect",
-		"sudo: a password is required",
+		testSudoNeedsPwd,
 		"",
 	}
 	for _, s := range no {
@@ -1410,9 +1580,18 @@ func TestDefaultProbeEnv(t *testing.T) {
 	if len(env.toolWrappers) != len(defaultToolWrappers) {
 		t.Errorf("toolWrappers: got %d, want %d", len(env.toolWrappers), len(defaultToolWrappers))
 	}
-	if env.runCmd == nil || env.dialCtx == nil || env.lookupUser == nil {
-		t.Errorf("hooks: runCmd=%v dialCtx=%v lookupUser=%v",
-			env.runCmd != nil, env.dialCtx != nil, env.lookupUser != nil)
+	if env.wrapperInvPath != defaultWrapperInvPath {
+		t.Errorf("wrapperInvPath: got %q, want %q", env.wrapperInvPath, defaultWrapperInvPath)
+	}
+	if env.nftRulesPath != defaultNFTRulesPath {
+		t.Errorf("nftRulesPath: got %q, want %q", env.nftRulesPath, defaultNFTRulesPath)
+	}
+	if env.nftMainPath != defaultNFTMainConfigPath {
+		t.Errorf("nftMainPath: got %q, want %q", env.nftMainPath, defaultNFTMainConfigPath)
+	}
+	if env.runCmd == nil || env.dialCtx == nil || env.lookupUser == nil || env.readFile == nil {
+		t.Errorf("hooks: runCmd=%v dialCtx=%v lookupUser=%v readFile=%v",
+			env.runCmd != nil, env.dialCtx != nil, env.lookupUser != nil, env.readFile != nil)
 	}
 }
 
@@ -1454,7 +1633,7 @@ func TestVerifyCmdExecute(t *testing.T) {
 
 func TestIsSudoRefusal(t *testing.T) {
 	yes := []string{
-		"sudo: a password is required",
+		testSudoNeedsPwd,
 		"User operator may not run sudo",
 		"not allowed to execute",
 		"sudo: no tty present and no askpass program specified",

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -588,6 +588,80 @@ func TestProbeWrapperScripts(t *testing.T) {
 			t.Fatalf("detail: got %q, want parse failure", gotDetail)
 		}
 	})
+
+	t.Run("empty wrapper inventory entry fails", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		env.wrapperInvPath = filepath.Join(t.TempDir(), "wrappers.json")
+		env.readFile = os.ReadFile
+		writeFakeWrapper(t, env.launchPath, 0o755)
+		body, err := json.Marshal(wrapperInventory{Wrappers: []string{""}})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(env.wrapperInvPath, append(body, '\n'), 0o600); err != nil {
+			t.Fatalf("write inventory: %v", err)
+		}
+
+		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "empty wrapper name") {
+			t.Fatalf("detail: got %q, want empty wrapper failure", gotDetail)
+		}
+	})
+
+	t.Run("directory wrapper inventory entry fails", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		env.wrapperInvPath = filepath.Join(t.TempDir(), "wrappers.json")
+		env.readFile = os.ReadFile
+		writeFakeWrapper(t, env.launchPath, 0o755)
+		dirWrapper := filepath.Join(env.wrapperDir, "plk-dir")
+		if err := os.Mkdir(dirWrapper, 0o750); err != nil {
+			t.Fatalf("mkdir wrapper dir: %v", err)
+		}
+		body, err := json.Marshal(wrapperInventory{Wrappers: []string{"plk-dir"}})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(env.wrapperInvPath, append(body, '\n'), 0o600); err != nil {
+			t.Fatalf("write inventory: %v", err)
+		}
+
+		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "non-empty executable wrapper file") {
+			t.Fatalf("detail: got %q, want regular-file failure", gotDetail)
+		}
+	})
+
+	t.Run("empty wrapper file fails", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		env.wrapperInvPath = filepath.Join(t.TempDir(), "wrappers.json")
+		env.readFile = os.ReadFile
+		writeFakeWrapper(t, env.launchPath, 0o755)
+		emptyWrapper := filepath.Join(env.wrapperDir, "plk-empty")
+		if err := os.WriteFile(emptyWrapper, nil, 0o755); err != nil { //nolint:gosec // executable mode mirrors production wrapper contract.
+			t.Fatalf("write empty wrapper: %v", err)
+		}
+		body, err := json.Marshal(wrapperInventory{Wrappers: []string{"plk-empty"}})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(env.wrapperInvPath, append(body, '\n'), 0o600); err != nil {
+			t.Fatalf("write inventory: %v", err)
+		}
+
+		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "non-empty executable wrapper file") {
+			t.Fatalf("detail: got %q, want empty wrapper failure", gotDetail)
+		}
+	})
 }
 
 func writeFakeWrapper(t *testing.T, path string, mode os.FileMode) {

--- a/internal/cli/setup/codex_test.go
+++ b/internal/cli/setup/codex_test.go
@@ -855,7 +855,7 @@ func TestRunCodexInstall_DryRun(t *testing.T) {
 	if !strings.Contains(out.String(), "Plan: 1 to wrap") {
 		t.Errorf("expected summary in output, got: %s", out.String())
 	}
-	if strings.Contains(out.String(), "3000") {
+	if strings.Contains(out.String(), "PORT=3000") || strings.Contains(out.String(), `"PORT":"3000"`) {
 		t.Errorf("dry-run output leaked env value: %s", out.String())
 	}
 	if !strings.Contains(out.String(), "--env PORT=<redacted>") {

--- a/internal/cli/setup/codex_test.go
+++ b/internal/cli/setup/codex_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -855,7 +856,8 @@ func TestRunCodexInstall_DryRun(t *testing.T) {
 	if !strings.Contains(out.String(), "Plan: 1 to wrap") {
 		t.Errorf("expected summary in output, got: %s", out.String())
 	}
-	if strings.Contains(out.String(), "PORT=3000") || strings.Contains(out.String(), `"PORT":"3000"`) {
+	leakedEnv := regexp.MustCompile(`PORT=3000|"PORT"\s*:\s*"3000"`)
+	if leakedEnv.MatchString(out.String()) {
 		t.Errorf("dry-run output leaked env value: %s", out.String())
 	}
 	if !strings.Contains(out.String(), "--env PORT=<redacted>") {

--- a/internal/cliutil/config.go
+++ b/internal/cliutil/config.go
@@ -39,6 +39,10 @@ func LoadConfigOrDefault(path string) (*config.Config, error) {
 // wrapped argv so the spawned subprocess loads the same config as the
 // operator's main pipelock service.
 func DiscoverConfigPath() string {
+	return discoverConfigPath("/etc/pipelock/pipelock.yaml")
+}
+
+func discoverConfigPath(systemPath string) string {
 	candidates := []string{}
 
 	if env := os.Getenv("PIPELOCK_CONFIG"); env != "" {
@@ -50,7 +54,9 @@ func DiscoverConfigPath() string {
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
 		candidates = append(candidates, filepath.Join(home, ".config", "pipelock", "pipelock.yaml"))
 	}
-	candidates = append(candidates, "/etc/pipelock/pipelock.yaml")
+	if systemPath != "" {
+		candidates = append(candidates, systemPath)
+	}
 
 	for _, c := range candidates {
 		clean, err := filepath.Abs(filepath.Clean(c))

--- a/internal/cliutil/config_test.go
+++ b/internal/cliutil/config_test.go
@@ -22,7 +22,7 @@ func TestDiscoverConfigPath_PipelockConfigEnvWins(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("HOME", "/dev/null")
 
-	got := DiscoverConfigPath()
+	got := discoverConfigPath(filepath.Join(t.TempDir(), "system.yaml"))
 	if got != override {
 		t.Errorf("PIPELOCK_CONFIG override not honored: got %q, want %q", got, override)
 	}
@@ -54,7 +54,7 @@ func TestDiscoverConfigPath_PipelockConfigEnvReturnsAbsolute(t *testing.T) {
 	t.Setenv("HOME", "/dev/null")
 
 	want := filepath.Join(dir, "relative.yaml")
-	got := DiscoverConfigPath()
+	got := discoverConfigPath(filepath.Join(t.TempDir(), "system.yaml"))
 	if got != want {
 		t.Errorf("relative PIPELOCK_CONFIG not made absolute: got %q, want %q", got, want)
 	}
@@ -78,7 +78,7 @@ func TestDiscoverConfigPath_XDGFallback(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", xdgDir)
 	t.Setenv("HOME", "/dev/null")
 
-	got := DiscoverConfigPath()
+	got := discoverConfigPath(filepath.Join(t.TempDir(), "system.yaml"))
 	if got != cfg {
 		t.Errorf("XDG fallback not honored: got %q, want %q", got, cfg)
 	}
@@ -100,7 +100,7 @@ func TestDiscoverConfigPath_HomeFallback(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("HOME", home)
 
-	got := DiscoverConfigPath()
+	got := discoverConfigPath(filepath.Join(t.TempDir(), "system.yaml"))
 	if got != cfg {
 		t.Errorf("HOME fallback not honored: got %q, want %q", got, cfg)
 	}
@@ -114,7 +114,7 @@ func TestDiscoverConfigPath_NoMatch(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("HOME", t.TempDir())
 
-	got := DiscoverConfigPath()
+	got := discoverConfigPath(filepath.Join(t.TempDir(), "system.yaml"))
 	if got != "" {
 		t.Errorf("expected empty string when no candidate exists, got %q", got)
 	}
@@ -137,7 +137,7 @@ func TestDiscoverConfigPath_NonRegularRejected(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("HOME", home)
 
-	got := DiscoverConfigPath()
+	got := discoverConfigPath(filepath.Join(t.TempDir(), "system.yaml"))
 	if got != "" {
 		t.Errorf("non-regular candidate must not be returned, got %q", got)
 	}


### PR DESCRIPTION
## Summary
- replace the contain install/rollback/add-tool/ca-refresh stubs with the containment install lifecycle
- install and verify the proxy/contained system users, systemd unit, nftables rules, CA bundles, plk-* wrappers, sudoers entry, migrated config, and TOFU binary pin
- harden wrapper execution with a runtime allow-list, target validation, config migration, and nft table drift repair
- extend contain verify with binary integrity, launcher allow-list, and allow-listed target resolution probes

## Validation
- `go test -race -count=1 ./...`
- `go test -race -count=1 -tags enterprise ./...`
- `golangci-lint run ./...`
- `git diff --check`
- manual install/verify smoke test passed with all contain verification probes green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pipelock contain install` command to provision Linux host containment with system users, policy rules, tool wrappers, and TLS certificate management.
  * Added `pipelock contain add-tool` command to manage tool allow-lists.
  * Added `pipelock contain ca-refresh` command to manage TLS interception certificates.
  * Added `pipelock contain rollback` command to remove containment setup.
  * Enhanced `pipelock contain verify` with new containment integrity probes.
  * Added configuration migration for existing pipelock deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->