### PR TITLE
feat(cli): add pipelock zed install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,7 @@ jobs:
             docs/scan-api.md
             docs/guides/deployment-recipes.md
             docs/guides/tls-interception.md
+            docs/guides/zed.md
             examples/demo-readme.sh
             examples/sample-events.jsonl
             examples/quickstart/

--- a/docs/guides/zed.md
+++ b/docs/guides/zed.md
@@ -1,0 +1,225 @@
+# Securing Zed with Pipelock
+
+Zed is a high-performance code editor with first-class MCP support through
+its `context_servers` block in `settings.json`. Zed agents that talk to MCP
+servers see source code, secrets in files you open, tool results, and the
+contents of remote services they call. Pipelock sits between Zed and those
+surfaces, scanning outbound tool calls and inbound responses before anything
+reaches the model or your filesystem.
+
+## Why Zed Needs an Agent Firewall
+
+Zed's agent workflows touch high-value targets:
+
+| Workflow | What Zed accesses | What could go wrong |
+|----------|--------------------|--------------------|
+| Code review / refactor | Source code, diffs, repo files | Secrets in files leaked through MCP arguments |
+| Agent panel / Claude integration | Files, terminals, project context | Prompt injection in fetched docs or repo READMEs |
+| MCP filesystem / fetch tools | Local files, URLs, external APIs | Tool poisoning, rug-pull attacks, credential exfil |
+| Project search | Workspace files | Sensitive data echoed back into the model |
+
+Zed itself does not inspect the content crossing the MCP boundary. Pipelock
+adds that layer: DLP on tool arguments, injection scanning on tool results,
+poisoning detection on tool descriptions, and policy enforcement on tool
+sequences.
+
+## Quick Start
+
+```bash
+# 1. Install pipelock
+brew install luckyPipewrench/tap/pipelock
+
+# 2. Wrap every Zed MCP context_server (default discovery; no args needed)
+pipelock zed install
+
+# 3. Restart Zed so the wrapped servers spawn through pipelock
+```
+
+The installer rewrites every `context_servers.<name>` entry in your Zed
+`settings.json` so that the spawned command is pipelock instead of the
+original MCP server. The original command, args, and env block are stashed
+in a `_pipelock` metadata field, which `pipelock zed remove` uses to restore
+the file later.
+
+## What `pipelock zed install` Wraps
+
+Default discovery scans every standard Zed `settings.json` location:
+
+| Path | Channel |
+|------|---------|
+| `<cwd>/.zed/settings.json` | Project-local |
+| `$XDG_CONFIG_HOME/zed/settings.json` (or `~/.config/zed/settings.json`) | Native stable |
+| `$XDG_CONFIG_HOME/zed-preview/settings.json` | Native Preview |
+| `~/.var/app/dev.zed.Zed/config/zed/settings.json` | Flatpak stable |
+| `~/.var/app/dev.zed.Zed.Preview/config/zed-preview/settings.json` | Flatpak Preview |
+
+Each file that exists is wrapped independently with its own `.bak` backup.
+If you want to operate on a single explicit file, pass `--path`:
+
+```bash
+pipelock zed install --path ~/some/custom/settings.json
+```
+
+If none of the default paths exist, install prints every probed path so you
+can see why nothing was wrapped and pick the right `--path` value.
+
+## The Wrap, Inside
+
+A native Zed stdio MCP server like this:
+
+```json
+"context_servers": {
+  "filesystem": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+  }
+}
+```
+
+becomes:
+
+```json
+"context_servers": {
+  "filesystem": {
+    "type": "stdio",
+    "command": "pipelock",
+    "args": [
+      "mcp", "proxy",
+      "--config", "/home/you/.config/pipelock/pipelock.yaml",
+      "--",
+      "npx", "-y", "@modelcontextprotocol/server-filesystem", "/tmp"
+    ],
+    "_pipelock": {
+      "original_command": "npx",
+      "original_args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+      "original_type": "stdio",
+      "type_omitted": true,
+      "args_present": true
+    }
+  }
+}
+```
+
+Remote (URL-based) `context_servers` are rewritten the same way, with
+pipelock spawned as a stdio-to-HTTP bridge via `--upstream`:
+
+```json
+"context_servers": {
+  "remote": {
+    "command": "pipelock",
+    "args": ["mcp", "proxy", "--config", "...", "--upstream", "https://api.example.com/mcp"]
+  }
+}
+```
+
+Credential-bearing `headers` blocks (e.g. `Authorization: Bearer ...`) land
+in a 0o600 header-sidecar file referenced via `--header-file`, so header
+values never appear in `/proc/<pid>/cmdline`.
+
+## What Gets Scanned
+
+| Direction | What | Scanning |
+|-----------|------|----------|
+| Zed → MCP server | Tool call arguments | DLP (secrets, credentials, env vars), injection patterns |
+| MCP server → Zed | Tool results, descriptions | Prompt injection (19 patterns, 6-pass normalization) |
+| Tool definitions | `tools/list` responses | Poisoned descriptions, schema injection, rug-pull detection |
+| Tool sequences | Multi-call patterns | Chain detection (read-then-exfil, persist-then-callback) |
+
+## End-to-End: a Real DLP Block
+
+With install in place and the filesystem MCP server configured, an attempted
+`write_file` call carrying an AWS-style key gets blocked at the MCP input
+boundary:
+
+```text
+$ # tools/call write_file with content "AKIAIOSFODNN7EXAMPLE"
+pipelock: proxying MCP server [npx -y @modelcontextprotocol/server-filesystem /tmp]
+          (response=warn, input=block, tools=block, policy=warn)
+pipelock: input line 3: blocked tools/call request (AWS Access ID)
+
+{"jsonrpc":"2.0","id":2,"error":{"code":-32001,
+  "message":"pipelock: request blocked by MCP input scanning"}}
+
+$ ls /tmp/mcp-leak.txt
+ls: cannot access '/tmp/mcp-leak.txt': No such file or directory
+```
+
+The credential never reaches the filesystem MCP server and the file is
+never written. The block is at the protocol layer, not just a model-side
+refusal.
+
+## Round-Trip Behavior with Zed Settings Saves
+
+Zed re-saves `settings.json` when you change settings through the UI
+(theme, font size, agent panel changes). The `_pipelock` metadata block
+survives that re-save because Zed preserves unknown top-level fields and
+unknown server keys. Verified live against Zed 1.2.6: install, change the
+UI theme, exit, and the `_pipelock` block is still intact and the wrap
+still spawns.
+
+## Discovering Wrap Status
+
+`pipelock discover` reports MCP servers across every IDE it knows about,
+including all four Zed channels:
+
+```bash
+$ pipelock discover
+zed                  1 server,  1 protected
+zed-preview          1 server,  0 protected   <-- channel missed during install
+zed-flatpak          0 servers
+zed-preview-flatpak  0 servers
+```
+
+Use `pipelock discover --json` for a machine-readable report.
+
+## Removing the Wrap
+
+```bash
+pipelock zed remove           # restores every wrapped file
+pipelock zed remove --path .. # single explicit file
+```
+
+Restores the original server entries from the `_pipelock` metadata field
+and strips that field. Non-wrapped entries and non-server top-level fields
+(theme, ui_font_size, agent settings, etc.) are left untouched.
+
+## Choosing a Config
+
+| Preset | Action | Best For |
+|--------|--------|----------|
+| `balanced.yaml` | warn | Getting started, tuning phase |
+| `claude-code.yaml` | block | Unattended Zed agent sessions |
+| `strict.yaml` | block | High-security repos, sensitive code |
+| `hostile-model.yaml` | block | Local / uncensored models routed through Zed |
+
+Start with `balanced.yaml` to surface false positives without breaking your
+workflow. Switch to `claude-code.yaml` or `strict.yaml` once you've tuned
+the pattern set.
+
+## Limitations
+
+- Project-local discovery scans `<cwd>/.zed/settings.json`, so run install
+  from the project directory if you want the project-local config wrapped.
+- The installer only touches `context_servers`. Zed's separate
+  `agent_servers` block (e.g. the `claude-acp` agent integration) is not an
+  MCP surface and is left alone.
+- Re-running install after Zed has written its own additions
+  (`agent.default_model`, etc.) is safe: wrapped entries are skipped
+  (idempotent), and Zed's other additions are preserved.
+
+## Evidence and Audit Trail
+
+Every scanning decision is logged. For Zed sessions that touch sensitive
+repos, enable the flight recorder:
+
+```yaml
+flight_recorder:
+  enabled: true
+  dir: /tmp/pipelock-zed-evidence
+  sign_checkpoints: true
+  redact: true
+```
+
+The recorder produces a hash-chained JSONL evidence log with signed
+checkpoints and DLP-redacted content. Hand it to your security team as
+proof of what each Zed session did and did not access.

--- a/docs/guides/zed.md
+++ b/docs/guides/zed.md
@@ -121,7 +121,7 @@ values never appear in `/proc/<pid>/cmdline`.
 | Direction | What | Scanning |
 |-----------|------|----------|
 | Zed → MCP server | Tool call arguments | DLP (secrets, credentials, env vars), injection patterns |
-| MCP server → Zed | Tool results, descriptions | Prompt injection (19 patterns, 6-pass normalization) |
+| MCP server → Zed | Tool results, descriptions | Prompt injection (default response patterns, 6-pass normalization) |
 | Tool definitions | `tools/list` responses | Poisoned descriptions, schema injection, rug-pull detection |
 | Tool sequences | Multi-call patterns | Chain detection (read-then-exfil, persist-then-callback) |
 

--- a/internal/cli/diag/discover.go
+++ b/internal/cli/diag/discover.go
@@ -25,8 +25,9 @@ func DiscoverCmd() *cobra.Command {
 		Use:   "discover",
 		Short: "Scan for AI agent configs and report MCP server protection status",
 		Long: `Scan the local machine for AI agent client configurations (Claude Code,
-Claude Desktop, Cursor, VS Code, Cline, Continue.dev, JetBrains/Junie) and report which MCP
-servers are configured, their protection status, and risk level.
+Claude Desktop, Cursor, VS Code, Cline, Continue.dev, JetBrains/Junie, Zed
+stable, Zed Preview, Flatpak Zed stable, Flatpak Zed Preview) and report
+which MCP servers are configured, their protection status, and risk level.
 
 Exit codes:
   0  All servers protected (or none found)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -119,6 +119,7 @@ Quick start:
 		setup.JetbrainsCmd(),
 		setup.CodexCmd(),
 		setup.OpenCodeCmd(),
+		setup.ZedCmd(),
 		// Signing & integrity
 		clisigning.IntegrityCmd(),
 		clisigning.SignCmd(),

--- a/internal/cli/setup/cline_test.go
+++ b/internal/cli/setup/cline_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	testClineEnvKey   = "MY_VAR"
 	testClineEnvValue = "test"
 
 	testClineStdioConfig = `{
@@ -190,17 +191,17 @@ func TestClineInstall_StdioServerWithImplicitType(t *testing.T) {
 
 	foundEnv := false
 	for i, a := range args {
-		if a == codexFlagEnv && i+1 < len(args) && args[i+1] == "MY_VAR" {
+		if a == codexFlagEnv && i+1 < len(args) && args[i+1] == testClineEnvKey {
 			foundEnv = true
 			break
 		}
 	}
 	if !foundEnv {
-		t.Errorf("expected --env MY_VAR passthrough in args: %v", args)
+		t.Errorf("expected --env %s passthrough in args: %v", testClineEnvKey, args)
 	}
 
 	env, ok := server["env"].(map[string]interface{})
-	if !ok || env["MY_VAR"] != testClineEnvValue {
+	if !ok || env[testClineEnvKey] != testClineEnvValue {
 		t.Errorf("env block not preserved: %v", server["env"])
 	}
 
@@ -236,7 +237,7 @@ func TestClineInstall_HTTPServerWithImplicitType(t *testing.T) {
 	args := interfaceSliceToStrings(server["args"])
 	foundUpstream := false
 	for i, a := range args {
-		if a == "--upstream" && i+1 < len(args) {
+		if a == codexFlagUpstream && i+1 < len(args) {
 			if args[i+1] != testExampleURL {
 				t.Errorf("upstream URL mismatch: got %q, want %q", args[i+1], testExampleURL)
 			}

--- a/internal/cli/setup/zed.go
+++ b/internal/cli/setup/zed.go
@@ -1,0 +1,420 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// Zed integration wraps the MCP servers declared in Zed's settings.json
+// `context_servers` block so that every tool call, response, and description
+// is scanned bidirectionally by pipelock. Zed's MCP config shape is identical
+// to Cline's (no `type` field; transport inferred from `command` vs `url`),
+// so the install path delegates to wrapClineServer. What is unique is that
+// Zed supports two settings.json locations simultaneously: a user-level file
+// (~/.config/zed/settings.json, honoring $XDG_CONFIG_HOME) and a project-level
+// file (<project>/.zed/settings.json). The installer scans both by default so
+// an operator's project MCP servers and global MCP servers are wrapped in one
+// command. Use --path to operate on a single explicit file (parity with the
+// other installers).
+
+const (
+	zedConfigFilename   = "settings.json"
+	zedUserConfigSubdir = "zed"
+	zedProjectConfigDir = ".zed"
+	zedServersKey       = "context_servers"
+	zedDefaultConfigDir = ".config" // joined under HOME when XDG_CONFIG_HOME is unset
+)
+
+// ZedCmd returns the `pipelock zed` command tree.
+func ZedCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "zed",
+		Short: "Zed integration",
+		Long: `Commands for integrating pipelock with Zed's MCP context_servers support.
+
+Zed is MCP-native, so install rewrites the settings.json file so that every
+context server runs through pipelock's MCP proxy. All tool calls, responses,
+and descriptions are scanned bidirectionally.
+
+By default install scans both the user-level settings.json
+($XDG_CONFIG_HOME/zed/settings.json or ~/.config/zed/settings.json) and the
+project-level .zed/settings.json in the current directory, wrapping every
+existing file. Use --path to target a single explicit file.
+
+The install subcommand rewrites settings.json to route MCP servers through
+pipelock. The remove subcommand restores the original config from the
+_pipelock metadata field. Both commands are idempotent.`,
+	}
+
+	cmd.AddCommand(
+		zedInstallCmd(),
+		zedRemoveCmd(),
+	)
+
+	return cmd
+}
+
+func zedInstallCmd() *cobra.Command {
+	var (
+		path       string
+		dryRun     bool
+		configFile string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Wrap Zed context_servers through pipelock",
+		Long: `Rewrites Zed's settings.json to route all context_servers through
+pipelock's MCP proxy. Stdio servers (entries with "command") get their
+command wrapped. Remote servers (entries with "url") are converted to
+stdio with --upstream. Header values, if present, land in a 0o600
+header sidecar file referenced via --header-file so secrets never
+appear in /proc/<pid>/cmdline.
+
+Default discovery scans both:
+  - $XDG_CONFIG_HOME/zed/settings.json (or ~/.config/zed/settings.json)
+  - <cwd>/.zed/settings.json
+
+Each file that exists is wrapped independently with its own .bak backup.
+If neither exists, install prints a friendly hint and exits 0. Use --path
+to target a single specific file, in which case the file is created if
+it does not exist (matching the behavior of pipelock cline install).
+
+Already-wrapped servers are skipped (idempotent). Non-server top-level
+fields in settings.json are preserved byte-for-byte.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runZedInstall(cmd, path, dryRun, configFile)
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "single settings.json to operate on (default: scan user + project)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be written without modifying files")
+	cmd.Flags().StringVarP(&configFile, "config", "c", "", "path to pipelock config file for --config passthrough")
+
+	return cmd
+}
+
+func zedRemoveCmd() *cobra.Command {
+	var (
+		path   string
+		dryRun bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove pipelock wrapping from Zed context_servers",
+		Long: `Restores Zed's settings.json by unwrapping context_servers that were
+wrapped by pipelock install. Original server configurations are restored
+from the _pipelock metadata field. Non-wrapped servers are left unchanged.
+
+Default discovery is the same as install. Use --path to target a single
+specific file.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runZedRemove(cmd, path, dryRun)
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "single settings.json to operate on (default: scan user + project)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be written without modifying files")
+
+	return cmd
+}
+
+// zedUserConfigPath returns the user-level settings.json location, honoring
+// $XDG_CONFIG_HOME when set. Zed uses the same path on Linux and macOS per
+// Zed's official docs (https://zed.dev/docs/configuring-zed): the legacy
+// macOS path under ~/Library/Application Support is not the current default.
+func zedUserConfigPath() (string, error) {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, zedUserConfigSubdir, zedConfigFilename), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("finding home directory: %w", err)
+	}
+	return filepath.Join(home, zedDefaultConfigDir, zedUserConfigSubdir, zedConfigFilename), nil
+}
+
+// zedProjectConfigPath returns <cwd>/.zed/settings.json. The path is always
+// returned (even when the file does not exist); callers decide whether to
+// act on it. Returning an error here would mean "I cannot derive the path,"
+// which is different from "the path is derivable but the file is absent".
+func zedProjectConfigPath() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("finding current directory: %w", err)
+	}
+	return filepath.Join(cwd, zedProjectConfigDir, zedConfigFilename), nil
+}
+
+// zedDiscoveryResult describes the outcome of resolving install/remove
+// targets. existingPaths is the subset of candidatePaths that exist on disk
+// and is what install/remove actually operate on in default-discovery mode.
+type zedDiscoveryResult struct {
+	candidatePaths []string
+	existingPaths  []string
+}
+
+// resolveZedTargets returns the paths the command should operate on. When
+// override is set, only that path is returned (and is treated as required,
+// even if missing — install creates it, remove no-ops on it). When override
+// is empty, both default paths are probed; only the ones that exist are
+// returned in existingPaths, but candidatePaths always carries both so the
+// "no settings.json found" message can name what was looked for.
+func resolveZedTargets(override string) (zedDiscoveryResult, error) {
+	if override != "" {
+		clean := filepath.Clean(override)
+		return zedDiscoveryResult{
+			candidatePaths: []string{clean},
+			existingPaths:  []string{clean},
+		}, nil
+	}
+
+	user, err := zedUserConfigPath()
+	if err != nil {
+		return zedDiscoveryResult{}, err
+	}
+	project, err := zedProjectConfigPath()
+	if err != nil {
+		return zedDiscoveryResult{}, err
+	}
+
+	// Order: project first so that when both exist the more-specific scope
+	// is processed (and shown in output) before the broader scope.
+	candidates := []string{project, user}
+	existing := make([]string, 0, len(candidates))
+	for _, p := range candidates {
+		info, statErr := os.Stat(p)
+		if statErr != nil {
+			continue
+		}
+		if info.IsDir() {
+			continue
+		}
+		existing = append(existing, p)
+	}
+
+	return zedDiscoveryResult{
+		candidatePaths: candidates,
+		existingPaths:  existing,
+	}, nil
+}
+
+func runZedInstall(cmd *cobra.Command, override string, dryRun bool, configFile string) error {
+	targets, err := resolveZedTargets(override)
+	if err != nil {
+		return err
+	}
+	paths := targets.existingPaths
+	if override == "" && len(paths) == 0 {
+		// Default discovery with neither file present: name what was looked
+		// for so the operator can decide whether to point --path at a custom
+		// location or to bootstrap one of the defaults.
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"No Zed settings.json found at any default location:\n  %s\n  %s\nRun `pipelock zed install --path <file>` to create one explicitly.\n",
+			targets.candidatePaths[0], targets.candidatePaths[1])
+		return nil
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("finding pipelock binary: %w", err)
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return fmt.Errorf("resolving pipelock binary path: %w", err)
+	}
+
+	configFile = discoverConfigForWrap(cmd, configFile)
+
+	for _, targetPath := range paths {
+		if err := installZedPath(cmd, targetPath, exe, configFile, dryRun); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func installZedPath(cmd *cobra.Command, targetPath, exe, configFile string, dryRun bool) error {
+	cfg, existingData, parseErr := readZedConfig(targetPath)
+	if parseErr != nil {
+		return parseErr
+	}
+
+	wrapped := 0
+	skipped := 0
+	var sidecarOps []sidecarOp
+	for name, server := range cfg.Servers {
+		if isWrapped(server) {
+			skipped++
+			continue
+		}
+
+		newServer, meta, plan, wrapErr := wrapClineServer(server, exe, configFile, targetPath, name)
+		if wrapErr != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: skipping server %q in %s: %v\n", name, targetPath, wrapErr)
+			continue
+		}
+
+		metaJSON, err := json.Marshal(meta)
+		if err != nil {
+			return fmt.Errorf("marshaling metadata for %q in %s: %w", name, targetPath, err)
+		}
+		var metaMap interface{}
+		if err := json.Unmarshal(metaJSON, &metaMap); err != nil {
+			return fmt.Errorf("unmarshaling metadata for %q in %s: %w", name, targetPath, err)
+		}
+		newServer[mcpFieldPipelock] = metaMap
+
+		cfg.Servers[name] = newServer
+		if plan != nil {
+			sidecarOps = append(sidecarOps, *plan)
+		}
+		wrapped++
+	}
+
+	output, err := marshalMCPConfig(existingData, cfg, zedServersKey)
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", targetPath, err)
+	}
+
+	if dryRun {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"Would write to %s (%d wrapped, %d already wrapped):\n%s",
+			targetPath, wrapped, skipped, output)
+		return nil
+	}
+
+	targetDir := filepath.Dir(targetPath)
+	if err := os.MkdirAll(targetDir, 0o750); err != nil {
+		return fmt.Errorf("creating directory %s: %w", targetDir, err)
+	}
+
+	if len(existingData) > 0 {
+		if err := os.WriteFile(targetPath+".bak", existingData, 0o600); err != nil {
+			return fmt.Errorf("creating backup: %w", err)
+		}
+	}
+
+	// Sidecars first so a sidecar failure leaves the operator's config
+	// untouched; applySidecarOps rolls back partial writes internally.
+	if err := applySidecarOps(sidecarOps); err != nil {
+		return fmt.Errorf("writing header sidecar: %w", err)
+	}
+
+	if err := vscodeAtomicWrite(targetPath, output, targetDir); err != nil {
+		rollbackSidecarWrites(sidecarOps)
+		return err
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+		"Wrapped %d server(s) in %s (%d already wrapped)\n",
+		wrapped, targetPath, skipped)
+	if wrapped > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Restart Zed to activate pipelock scanning.\n")
+	}
+	return nil
+}
+
+func runZedRemove(cmd *cobra.Command, override string, dryRun bool) error {
+	targets, err := resolveZedTargets(override)
+	if err != nil {
+		return err
+	}
+	paths := targets.existingPaths
+	if override == "" && len(paths) == 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"No Zed settings.json found at any default location:\n  %s\n  %s\n",
+			targets.candidatePaths[0], targets.candidatePaths[1])
+		return nil
+	}
+
+	for _, targetPath := range paths {
+		if err := removeZedPath(cmd, targetPath, dryRun); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeZedPath(cmd *cobra.Command, targetPath string, dryRun bool) error {
+	cfg, existingData, parseErr := readZedConfig(targetPath)
+	if parseErr != nil {
+		return parseErr
+	}
+	if len(existingData) == 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No %s found at %s\n", zedConfigFilename, targetPath)
+		return nil
+	}
+
+	unwrapped := 0
+	var sidecarOps []sidecarOp
+	for name, server := range cfg.Servers {
+		if !isWrapped(server) {
+			continue
+		}
+
+		restored, plan, unwrapErr := unwrapVscodeServer(server)
+		if unwrapErr != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not unwrap %q in %s: %v\n", name, targetPath, unwrapErr)
+			continue
+		}
+
+		cfg.Servers[name] = restored
+		if plan != nil {
+			sidecarOps = append(sidecarOps, *plan)
+		}
+		unwrapped++
+	}
+
+	output, err := marshalMCPConfig(existingData, cfg, zedServersKey)
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", targetPath, err)
+	}
+
+	if dryRun {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"Would write to %s (%d unwrapped):\n%s",
+			targetPath, unwrapped, output)
+		return nil
+	}
+
+	if err := os.WriteFile(targetPath+".bak", existingData, 0o600); err != nil {
+		return fmt.Errorf("creating backup: %w", err)
+	}
+
+	targetDir := filepath.Dir(targetPath)
+	if err := vscodeAtomicWrite(targetPath, output, targetDir); err != nil {
+		return err
+	}
+
+	// Sidecars are deleted only after the restored config commits, so a
+	// partial failure leaves the wrapped config + carriers consistent.
+	_ = applySidecarOps(sidecarOps)
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+		"Unwrapped %d server(s) in %s\n", unwrapped, targetPath)
+	if unwrapped > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Restart Zed to apply changes.\n")
+	}
+	return nil
+}
+
+// readZedConfig reads and parses a Zed settings.json. A missing file produces
+// an empty config rather than an error so the install path can create new
+// files when --path points at one that does not yet exist (consistent with
+// cline install).
+func readZedConfig(path string) (*mcpConfig, []byte, error) {
+	return readMCPConfig(path, zedServersKey)
+}

--- a/internal/cli/setup/zed.go
+++ b/internal/cli/setup/zed.go
@@ -89,7 +89,7 @@ to target a single specific file, in which case the file is created if
 it does not exist (matching the behavior of pipelock cline install).
 
 Already-wrapped servers are skipped (idempotent). Non-server top-level
-fields in settings.json are preserved byte-for-byte.`,
+fields in settings.json are preserved.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/setup/zed.go
+++ b/internal/cli/setup/zed.go
@@ -18,12 +18,12 @@ import (
 // is scanned bidirectionally by pipelock. Zed's MCP config shape is identical
 // to Cline's (no `type` field; transport inferred from `command` vs `url`),
 // so the install path delegates to wrapClineServer. What is unique is that
-// Zed supports two settings.json locations simultaneously: a user-level file
-// (~/.config/zed/settings.json, honoring $XDG_CONFIG_HOME) and a project-level
-// file (<project>/.zed/settings.json). The installer scans both by default so
-// an operator's project MCP servers and global MCP servers are wrapped in one
-// command. Use --path to operate on a single explicit file (parity with the
-// other installers).
+// Zed supports settings.json in multiple scopes and install channels:
+// project-local, native stable, native Preview, Flatpak stable, and Flatpak
+// Preview. The installer scans all of them by default so an operator's
+// project MCP servers and global MCP servers are wrapped in one command. Use
+// --path to operate on a single explicit file (parity with the other
+// installers).
 
 const (
 	zedConfigFilename       = "settings.json"
@@ -47,9 +47,8 @@ Zed is MCP-native, so install rewrites the settings.json file so that every
 context server runs through pipelock's MCP proxy. All tool calls, responses,
 and descriptions are scanned bidirectionally.
 
-By default install scans both the user-level settings.json
-($XDG_CONFIG_HOME/zed/settings.json or ~/.config/zed/settings.json) and the
-project-level .zed/settings.json in the current directory, wrapping every
+By default install scans project-local, native stable, native Preview,
+Flatpak stable, and Flatpak Preview settings.json locations, wrapping every
 existing file. Use --path to target a single explicit file.
 
 The install subcommand rewrites settings.json to route MCP servers through
@@ -104,7 +103,7 @@ fields in settings.json are preserved.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&path, "path", "", "single settings.json to operate on (default: scan user + project)")
+	cmd.Flags().StringVar(&path, "path", "", "single settings.json to operate on (default: scan project, native, and Flatpak)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be written without modifying files")
 	cmd.Flags().StringVarP(&configFile, "config", "c", "", "path to pipelock config file for --config passthrough")
 
@@ -133,7 +132,7 @@ specific file.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&path, "path", "", "single settings.json to operate on (default: scan user + project)")
+	cmd.Flags().StringVar(&path, "path", "", "single settings.json to operate on (default: scan project, native, and Flatpak)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be written without modifying files")
 
 	return cmd

--- a/internal/cli/setup/zed.go
+++ b/internal/cli/setup/zed.go
@@ -5,6 +5,7 @@ package setup
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -197,7 +198,10 @@ func resolveZedTargets(override string) (zedDiscoveryResult, error) {
 	for _, p := range candidates {
 		info, statErr := os.Stat(p)
 		if statErr != nil {
-			continue
+			if errors.Is(statErr, os.ErrNotExist) {
+				continue
+			}
+			return zedDiscoveryResult{}, fmt.Errorf("checking Zed settings path %s: %w", p, statErr)
 		}
 		if info.IsDir() {
 			continue

--- a/internal/cli/setup/zed.go
+++ b/internal/cli/setup/zed.go
@@ -26,11 +26,14 @@ import (
 // other installers).
 
 const (
-	zedConfigFilename   = "settings.json"
-	zedUserConfigSubdir = "zed"
-	zedProjectConfigDir = ".zed"
-	zedServersKey       = "context_servers"
-	zedDefaultConfigDir = ".config" // joined under HOME when XDG_CONFIG_HOME is unset
+	zedConfigFilename       = "settings.json"
+	zedUserConfigSubdir     = "zed"
+	zedPreviewConfigSubdir  = "zed-preview"
+	zedProjectConfigDir     = ".zed"
+	zedServersKey           = "context_servers"
+	zedDefaultConfigDir     = ".config" // joined under HOME when XDG_CONFIG_HOME is unset
+	zedFlatpakAppStableDir  = "dev.zed.Zed"
+	zedFlatpakAppPreviewDir = "dev.zed.Zed.Preview"
 )
 
 // ZedCmd returns the `pipelock zed` command tree.
@@ -79,14 +82,18 @@ stdio with --upstream. Header values, if present, land in a 0o600
 header sidecar file referenced via --header-file so secrets never
 appear in /proc/<pid>/cmdline.
 
-Default discovery scans both:
-  - $XDG_CONFIG_HOME/zed/settings.json (or ~/.config/zed/settings.json)
-  - <cwd>/.zed/settings.json
+Default discovery scans:
+  - <cwd>/.zed/settings.json                                     (project)
+  - $XDG_CONFIG_HOME/zed/settings.json                           (native stable)
+  - $XDG_CONFIG_HOME/zed-preview/settings.json                   (native preview)
+  - ~/.var/app/dev.zed.Zed/config/zed/settings.json              (Flatpak stable)
+  - ~/.var/app/dev.zed.Zed.Preview/config/zed-preview/settings.json (Flatpak preview)
 
 Each file that exists is wrapped independently with its own .bak backup.
-If neither exists, install prints a friendly hint and exits 0. Use --path
-to target a single specific file, in which case the file is created if
-it does not exist (matching the behavior of pipelock cline install).
+If none exist, install prints a friendly hint listing every probed path
+and exits 0. Use --path to target a single specific file, in which case
+the file is created if it does not exist (matching the behavior of
+pipelock cline install).
 
 Already-wrapped servers are skipped (idempotent). Non-server top-level
 fields in settings.json are preserved.`,
@@ -132,19 +139,58 @@ specific file.`,
 	return cmd
 }
 
-// zedUserConfigPath returns the user-level settings.json location, honoring
-// $XDG_CONFIG_HOME when set. Zed uses the same path on Linux and macOS per
-// Zed's official docs (https://zed.dev/docs/configuring-zed): the legacy
-// macOS path under ~/Library/Application Support is not the current default.
-func zedUserConfigPath() (string, error) {
+// xdgConfigDir returns $XDG_CONFIG_HOME when set, otherwise $HOME/.config.
+// This is the convention used by Zed (and most XDG-aware Linux apps) for the
+// native install. Flatpak Zed uses a separate per-app config root that is NOT
+// affected by the operator's outer XDG_CONFIG_HOME (see zedFlatpakConfigPath).
+func xdgConfigDir() (string, error) {
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
-		return filepath.Join(xdg, zedUserConfigSubdir, zedConfigFilename), nil
+		return xdg, nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("finding home directory: %w", err)
 	}
-	return filepath.Join(home, zedDefaultConfigDir, zedUserConfigSubdir, zedConfigFilename), nil
+	return filepath.Join(home, zedDefaultConfigDir), nil
+}
+
+// zedUserConfigPath returns the native-install user-level settings.json
+// location (stable channel). Zed uses the same path on Linux and macOS per
+// Zed's official docs (https://zed.dev/docs/configuring-zed); the legacy
+// macOS path under ~/Library/Application Support is not the current default.
+func zedUserConfigPath() (string, error) {
+	root, err := xdgConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, zedUserConfigSubdir, zedConfigFilename), nil
+}
+
+// zedUserPreviewConfigPath returns the native-install Zed Preview channel
+// settings.json location. Zed Preview is a separate binary that ships ahead
+// of the stable channel and stores its config under "zed-preview" rather
+// than "zed"; users who follow both channels need both wraps.
+func zedUserPreviewConfigPath() (string, error) {
+	root, err := xdgConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, zedPreviewConfigSubdir, zedConfigFilename), nil
+}
+
+// zedFlatpakConfigPath returns the Flatpak-sandboxed settings.json location
+// for the given Flatpak app id and channel-config subdir. Flatpak apps store
+// config under $HOME/.var/app/<app-id>/config/ regardless of the operator's
+// outer $XDG_CONFIG_HOME, because the sandbox rewrites XDG paths inside the
+// container. The operator running `pipelock zed install` is OUTSIDE the
+// sandbox, so we have to spell out the Flatpak path explicitly; the outer
+// XDG_CONFIG_HOME does not apply to it.
+func zedFlatpakConfigPath(appID, channelSubdir string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("finding home directory: %w", err)
+	}
+	return filepath.Join(home, ".var", "app", appID, "config", channelSubdir, zedConfigFilename), nil
 }
 
 // zedProjectConfigPath returns <cwd>/.zed/settings.json. The path is always
@@ -167,12 +213,46 @@ type zedDiscoveryResult struct {
 	existingPaths  []string
 }
 
+// zedDefaultCandidates returns the ordered list of settings.json paths the
+// default-discovery flow probes. The ordering is deliberate: project scope
+// first (most-specific) so the friendly output names the local override
+// before the user-level config; then the native channels (stable, preview);
+// then the Flatpak channels (stable, preview). Each path is reported in the
+// "no Zed settings.json found" message even when absent so the operator can
+// see what was looked for.
+func zedDefaultCandidates() ([]string, error) {
+	project, err := zedProjectConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	userStable, err := zedUserConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	userPreview, err := zedUserPreviewConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	flatpakStable, err := zedFlatpakConfigPath(zedFlatpakAppStableDir, zedUserConfigSubdir)
+	if err != nil {
+		return nil, err
+	}
+	flatpakPreview, err := zedFlatpakConfigPath(zedFlatpakAppPreviewDir, zedPreviewConfigSubdir)
+	if err != nil {
+		return nil, err
+	}
+	return []string{project, userStable, userPreview, flatpakStable, flatpakPreview}, nil
+}
+
 // resolveZedTargets returns the paths the command should operate on. When
 // override is set, only that path is returned (and is treated as required,
 // even if missing — install creates it, remove no-ops on it). When override
-// is empty, both default paths are probed; only the ones that exist are
-// returned in existingPaths, but candidatePaths always carries both so the
-// "no settings.json found" message can name what was looked for.
+// is empty, every default-discovery candidate is probed; only the ones that
+// exist are returned in existingPaths, but candidatePaths always carries
+// every probed location so the "no settings.json found" message can name
+// what was looked for. Stat errors other than os.ErrNotExist surface as an
+// error so a permission-denied probe on the operator's settings.json never
+// silently leaves MCP servers unwrapped.
 func resolveZedTargets(override string) (zedDiscoveryResult, error) {
 	if override != "" {
 		clean := filepath.Clean(override)
@@ -182,18 +262,10 @@ func resolveZedTargets(override string) (zedDiscoveryResult, error) {
 		}, nil
 	}
 
-	user, err := zedUserConfigPath()
+	candidates, err := zedDefaultCandidates()
 	if err != nil {
 		return zedDiscoveryResult{}, err
 	}
-	project, err := zedProjectConfigPath()
-	if err != nil {
-		return zedDiscoveryResult{}, err
-	}
-
-	// Order: project first so that when both exist the more-specific scope
-	// is processed (and shown in output) before the broader scope.
-	candidates := []string{project, user}
 	existing := make([]string, 0, len(candidates))
 	for _, p := range candidates {
 		info, statErr := os.Stat(p)
@@ -222,12 +294,15 @@ func runZedInstall(cmd *cobra.Command, override string, dryRun bool, configFile 
 	}
 	paths := targets.existingPaths
 	if override == "" && len(paths) == 0 {
-		// Default discovery with neither file present: name what was looked
-		// for so the operator can decide whether to point --path at a custom
-		// location or to bootstrap one of the defaults.
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-			"No Zed settings.json found at any default location:\n  %s\n  %s\nRun `pipelock zed install --path <file>` to create one explicitly.\n",
-			targets.candidatePaths[0], targets.candidatePaths[1])
+		// Default discovery with no file present: name every path we probed
+		// so the operator can decide whether to point --path at a custom
+		// location, install Zed in a different channel, or bootstrap one
+		// of the defaults.
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No Zed settings.json found at any default location:")
+		for _, p := range targets.candidatePaths {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", p)
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Run `pipelock zed install --path <file>` to create one explicitly.")
 		return nil
 	}
 
@@ -338,9 +413,10 @@ func runZedRemove(cmd *cobra.Command, override string, dryRun bool) error {
 	}
 	paths := targets.existingPaths
 	if override == "" && len(paths) == 0 {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-			"No Zed settings.json found at any default location:\n  %s\n  %s\n",
-			targets.candidatePaths[0], targets.candidatePaths[1])
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No Zed settings.json found at any default location:")
+		for _, p := range targets.candidatePaths {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", p)
+		}
 		return nil
 	}
 

--- a/internal/cli/setup/zed_test.go
+++ b/internal/cli/setup/zed_test.go
@@ -1,0 +1,1234 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	testZedEnvValue = "test"
+
+	testZedStdioConfig = `{
+  "context_servers": {
+    "my-server": {
+      "command": "npx",
+      "args": ["-y", "@example/mcp-server"],
+      "env": { "MY_VAR": "test" }
+    }
+  }
+}`
+
+	testZedHTTPConfig = `{
+  "context_servers": {
+    "remote": {
+      "url": "https://api.example.com/mcp",
+      "headers": { "X-Workspace-Id": "ws-zed-tok" }
+    }
+  }
+}`
+
+	testZedWithUnknownField = `{
+  "theme": "One Dark",
+  "ui_font_size": 16,
+  "context_servers": {
+    "stdio-srv": {
+      "command": "node",
+      "args": ["server.js"]
+    }
+  }
+}`
+
+	testZedStdioEmptyArgs = `{
+  "context_servers": {
+    "fixture": {
+      "command": "cat",
+      "args": []
+    }
+  }
+}`
+
+	testZedNullServers  = `{"context_servers": null}`
+	testZedEmptyServers = `{"context_servers": {}}`
+
+	testZedNoCmdNoURL = `{
+  "context_servers": {
+    "broken": {
+      "env": { "FOO": "bar" }
+    }
+  }
+}`
+
+	testZedCommandAndURL = `{
+  "context_servers": {
+    "ambiguous": {
+      "command": "node",
+      "url": "https://api.example.com/mcp"
+    }
+  }
+}`
+
+	testZedMultipleServers = `{
+  "context_servers": {
+    "stdio-a": {
+      "command": "node",
+      "args": ["a.js"]
+    },
+    "stdio-b": {
+      "command": "python",
+      "args": ["-m", "server"]
+    }
+  }
+}`
+)
+
+// testZedHTTPConfigSecretHeader carries a credential-bearing Authorization
+// header. Split-string construction keeps gosec G101 from flagging the
+// fixture as a hardcoded token.
+var (
+	testZedWorkspaceToken = "ws-zed-" + "tok"
+
+	testZedHTTPConfigSecretHeader = `{
+  "context_servers": {
+    "remote": {
+      "url": "https://api.example.com/mcp",
+      "headers": { "Authorization": "Bearer ` + "zed-tok" + `" }
+    }
+  }
+}`
+)
+
+// writeZedFile writes a settings.json body to a temp dir and returns the path.
+func writeZedFile(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	return p
+}
+
+func runZedCmd(t *testing.T, args ...string) error {
+	t.Helper()
+	_, _, err := runZedCmdOutput(t, args...)
+	return err
+}
+
+func runZedCmdOutput(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	cmd := ZedCmd()
+	cmd.SetArgs(args)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	err := cmd.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+// isolateHome returns a private $HOME for the test that also overrides
+// XDG_CONFIG_HOME so the sidecar dir lookups land under it. Returns the home
+// directory the test can write into.
+func isolateHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	return home
+}
+
+// chdirIsolated chdirs into a temp dir for the duration of the test, returning
+// the dir. zedProjectConfigPath uses os.Getwd, so this prevents tests from
+// stumbling onto the developer's real .zed/settings.json.
+func chdirIsolated(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Chdir(dir)
+	return dir
+}
+
+func TestZedInstall_DryRun(t *testing.T) {
+	path := writeZedFile(t, testZedStdioConfig)
+
+	if err := runZedCmd(t, "install", "--path", path, "--dry-run"); err != nil {
+		t.Fatalf("install --dry-run failed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("re-read after dry-run: %v", err)
+	}
+	if string(got) != testZedStdioConfig {
+		t.Error("dry-run modified the file")
+	}
+}
+
+func TestZedInstall_StdioServerWithImplicitType(t *testing.T) {
+	path := writeZedFile(t, testZedStdioConfig)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _, err := readMCPConfig(path, zedServersKey)
+	if err != nil {
+		t.Fatalf("parsing result: %v", err)
+	}
+	_ = data
+
+	server, ok := cfg.Servers["my-server"]
+	if !ok {
+		t.Fatal("server 'my-server' not in result")
+	}
+	if _, ok := server[mcpFieldPipelock]; !ok {
+		t.Error("missing _pipelock metadata after wrap")
+	}
+
+	args := interfaceSliceToStrings(server["args"])
+	if len(args) < 4 {
+		t.Fatalf("expected at least 4 wrapped args, got %d: %v", len(args), args)
+	}
+	if !strings.HasPrefix(strings.Join(args, " "), "mcp proxy ") {
+		t.Errorf("expected wrapped args to start with mcp proxy, got %v", args[:2])
+	}
+
+	dashIdx := -1
+	for i, a := range args {
+		if a == "--" {
+			dashIdx = i
+			break
+		}
+	}
+	if dashIdx < 0 {
+		t.Fatal("no -- separator in wrapped args")
+	}
+	if args[dashIdx+1] != testOriginalCmd {
+		t.Errorf("expected original command after --, got %q", args[dashIdx+1])
+	}
+
+	foundEnv := false
+	for i, a := range args {
+		if a == codexFlagEnv && i+1 < len(args) && args[i+1] == "MY_VAR" {
+			foundEnv = true
+			break
+		}
+	}
+	if !foundEnv {
+		t.Errorf("expected --env MY_VAR passthrough in args: %v", args)
+	}
+
+	env, ok := server["env"].(map[string]interface{})
+	if !ok || env["MY_VAR"] != testZedEnvValue {
+		t.Errorf("env block not preserved: %v", server["env"])
+	}
+
+	if _, hasType := server[mcpFieldType]; !hasType {
+		t.Error("wrapped stdio entry must declare type=stdio so Zed launches the pipelock subprocess")
+	}
+}
+
+func TestZedInstall_HTTPServerWithImplicitType(t *testing.T) {
+	isolateHome(t)
+	path := writeZedFile(t, testZedHTTPConfig)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	cfg, _, err := readMCPConfig(path, zedServersKey)
+	if err != nil {
+		t.Fatalf("parsing result: %v", err)
+	}
+
+	server := cfg.Servers["remote"]
+	args := interfaceSliceToStrings(server["args"])
+	foundUpstream := false
+	for i, a := range args {
+		if a == "--upstream" && i+1 < len(args) {
+			if args[i+1] != testExampleURL {
+				t.Errorf("upstream URL mismatch: got %q, want %q", args[i+1], testExampleURL)
+			}
+			foundUpstream = true
+			break
+		}
+	}
+	if !foundUpstream {
+		t.Error("--upstream flag missing from wrapped HTTP server")
+	}
+
+	sidecarPath := ""
+	for i, a := range args {
+		if a == mcpFlagHeaderFile && i+1 < len(args) {
+			sidecarPath = args[i+1]
+			break
+		}
+	}
+	if sidecarPath == "" {
+		t.Fatalf("wrapped argv missing --header-file flag: %v", args)
+	}
+	body, err := os.ReadFile(filepath.Clean(sidecarPath))
+	if err != nil {
+		t.Fatalf("read sidecar: %v", err)
+	}
+	if !strings.Contains(string(body), "X-Workspace-Id: ws-zed-tok") {
+		t.Errorf("sidecar missing the header line: %q", body)
+	}
+
+	metaJSON, _ := json.Marshal(server[mcpFieldPipelock])
+	var meta pipelockMeta
+	if err := json.Unmarshal(metaJSON, &meta); err != nil {
+		t.Fatal(err)
+	}
+	if meta.OriginalURL != testExampleURL {
+		t.Errorf("expected original URL preserved, got %q", meta.OriginalURL)
+	}
+	if !meta.TypeOmitted {
+		t.Error("Zed HTTP wrap must record TypeOmitted=true so remove restores a typeless entry")
+	}
+	if meta.OriginalHeaders["X-Workspace-Id"] != testZedWorkspaceToken {
+		t.Errorf("headers not preserved in metadata: %v", meta.OriginalHeaders)
+	}
+	if meta.HeaderSidecarPath != sidecarPath {
+		t.Errorf("meta.HeaderSidecarPath = %q, want %q", meta.HeaderSidecarPath, sidecarPath)
+	}
+}
+
+func TestZedInstall_Idempotent(t *testing.T) {
+	path := writeZedFile(t, testZedStdioConfig)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	firstRun, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	secondRun, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(firstRun) != string(secondRun) {
+		t.Errorf("install is not idempotent:\nfirst:\n%s\nsecond:\n%s", firstRun, secondRun)
+	}
+}
+
+func TestZedInstall_PreservesUnknownTopLevelFields(t *testing.T) {
+	path := writeZedFile(t, testZedWithUnknownField)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"theme"`) {
+		t.Error("unknown top-level field 'theme' was dropped on install")
+	}
+	if !strings.Contains(string(data), `"ui_font_size"`) {
+		t.Error("unknown top-level field 'ui_font_size' was dropped on install")
+	}
+}
+
+func TestZedInstall_CreatesMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "settings.json")
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install on missing file: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected file to be created: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("expected mode 0600 on new file, got %o", info.Mode().Perm())
+	}
+}
+
+func TestZedInstall_BackupCreated(t *testing.T) {
+	path := writeZedFile(t, testZedStdioConfig)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	backup, err := os.ReadFile(filepath.Clean(path + ".bak"))
+	if err != nil {
+		t.Fatalf("expected .bak backup: %v", err)
+	}
+	if string(backup) != testZedStdioConfig {
+		t.Error("backup content does not match original")
+	}
+}
+
+// TestZedRoundTrip_PreservesEmptyArgs locks in that `"args": []` round-trips
+// byte-exact through install + remove, mirroring the cline regression.
+func TestZedRoundTrip_PreservesEmptyArgs(t *testing.T) {
+	path := writeZedFile(t, testZedStdioEmptyArgs)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	cfg, _, err := readMCPConfig(path, zedServersKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metaJSON, _ := json.Marshal(cfg.Servers["fixture"][mcpFieldPipelock])
+	var meta pipelockMeta
+	if err := json.Unmarshal(metaJSON, &meta); err != nil {
+		t.Fatal(err)
+	}
+	if !meta.ArgsPresent {
+		t.Error("wrap of stdio entry with empty args must record ArgsPresent=true")
+	}
+
+	if err := runZedCmd(t, "remove", "--path", path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	restoredData, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restoredRaw map[string]map[string]map[string]interface{}
+	if err := json.Unmarshal(restoredData, &restoredRaw); err != nil {
+		t.Fatal(err)
+	}
+	args, hasArgs := restoredRaw["context_servers"]["fixture"]["args"]
+	if !hasArgs {
+		t.Fatal("unwrap dropped the args field that was present in the source")
+	}
+	argsSlice, ok := args.([]interface{})
+	if !ok {
+		t.Fatalf("restored args has wrong type: %T", args)
+	}
+	if len(argsSlice) != 0 {
+		t.Errorf("expected empty args slice, got %v", argsSlice)
+	}
+}
+
+func TestZedRemove_UnwrapsStdio(t *testing.T) {
+	path := writeZedFile(t, testZedStdioConfig)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if err := runZedCmd(t, "remove", "--path", path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	cfg, _, err := readMCPConfig(path, zedServersKey)
+	if err != nil {
+		t.Fatalf("parse after remove: %v", err)
+	}
+
+	server := cfg.Servers["my-server"]
+	if _, hasMeta := server[mcpFieldPipelock]; hasMeta {
+		t.Error("_pipelock metadata not stripped after remove")
+	}
+	if server[mcpFieldCommand] != testOriginalCmd {
+		t.Errorf("original command not restored: got %v", server[mcpFieldCommand])
+	}
+	if _, hasType := server[mcpFieldType]; hasType {
+		t.Error("Zed stdio remove must not introduce a type field that was not in the original")
+	}
+}
+
+func TestZedRemove_UnwrapsHTTP(t *testing.T) {
+	isolateHome(t)
+	path := writeZedFile(t, testZedHTTPConfig)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if err := runZedCmd(t, "remove", "--path", path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	cfg, _, err := readMCPConfig(path, zedServersKey)
+	if err != nil {
+		t.Fatalf("parse after remove: %v", err)
+	}
+
+	server := cfg.Servers["remote"]
+	if _, hasType := server[mcpFieldType]; hasType {
+		t.Error("Zed HTTP remove must not introduce a type field (Zed infers transport from url)")
+	}
+	if server[mcpFieldURL] != testExampleURL {
+		t.Errorf("original URL not restored: got %v", server[mcpFieldURL])
+	}
+	headers, ok := server["headers"].(map[string]interface{})
+	if !ok || headers["X-Workspace-Id"] != testZedWorkspaceToken {
+		t.Errorf("headers not restored: %v", server["headers"])
+	}
+}
+
+// TestZedInstall_SecretHeaderRoutesThroughSidecar locks in that install accepts
+// credential-bearing headers because the values land in a 0o600 sidecar
+// referenced via --header-file, not in the wrapped argv.
+func TestZedInstall_SecretHeaderRoutesThroughSidecar(t *testing.T) {
+	isolateHome(t)
+	path := writeZedFile(t, testZedHTTPConfigSecretHeader)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install with credential header should succeed via sidecar: %v", err)
+	}
+
+	cfg, _, err := readMCPConfig(path, zedServersKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := cfg.Servers["remote"]
+	if _, wrapped := entry[mcpFieldPipelock]; !wrapped {
+		t.Fatal("entry must be wrapped via the sidecar path")
+	}
+	args := interfaceSliceToStrings(entry["args"])
+
+	for _, a := range args {
+		if strings.Contains(a, "zed-tok") {
+			t.Fatalf("credential value leaked into wrapped argv: %v", args)
+		}
+	}
+	sidecarPath := ""
+	for i, a := range args {
+		if a == mcpFlagHeaderFile && i+1 < len(args) {
+			sidecarPath = args[i+1]
+			break
+		}
+	}
+	if sidecarPath == "" {
+		t.Fatalf("wrapped argv missing --header-file flag: %v", args)
+	}
+	info, err := os.Stat(sidecarPath)
+	if err != nil {
+		t.Fatalf("sidecar not written: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("sidecar mode = %04o, want 0o600", info.Mode().Perm())
+	}
+}
+
+func TestZedRemove_NoFileWithPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.json")
+
+	if err := runZedCmd(t, "remove", "--path", path); err != nil {
+		t.Errorf("remove on missing file should be a no-op, got: %v", err)
+	}
+}
+
+func TestZedRemove_Idempotent(t *testing.T) {
+	path := writeZedFile(t, testZedStdioConfig)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if err := runZedCmd(t, "remove", "--path", path); err != nil {
+		t.Fatalf("first remove: %v", err)
+	}
+	firstRun, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runZedCmd(t, "remove", "--path", path); err != nil {
+		t.Fatalf("second remove: %v", err)
+	}
+	secondRun, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(firstRun) != string(secondRun) {
+		t.Errorf("remove is not idempotent:\nfirst:\n%s\nsecond:\n%s", firstRun, secondRun)
+	}
+}
+
+func TestZedInstall_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runZedCmd(t, "install", "--path", path); err == nil {
+		t.Error("expected install to fail on invalid JSON")
+	}
+}
+
+func TestZedInstall_NullServers(t *testing.T) {
+	path := writeZedFile(t, testZedNullServers)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install with null servers: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"context_servers"`) {
+		t.Error("context_servers key missing after handling null input")
+	}
+}
+
+func TestZedInstall_EmptyServers(t *testing.T) {
+	path := writeZedFile(t, testZedEmptyServers)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install with empty servers: %v", err)
+	}
+}
+
+func TestZedInstall_SkipServersMissingCmdAndURL(t *testing.T) {
+	path := writeZedFile(t, testZedNoCmdNoURL)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), `"_pipelock"`) {
+		t.Error("entries with neither command nor url must not be wrapped")
+	}
+}
+
+func TestZedInstall_SkipAmbiguousCommandAndURL(t *testing.T) {
+	path := writeZedFile(t, testZedCommandAndURL)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	cfg, _, err := readMCPConfig(path, zedServersKey)
+	if err != nil {
+		t.Fatalf("parse after install: %v", err)
+	}
+	server := cfg.Servers["ambiguous"]
+	if _, wrapped := server[mcpFieldPipelock]; wrapped {
+		t.Fatal("ambiguous command+url entry must not be wrapped")
+	}
+	if server[mcpFieldCommand] != testNodeCmd || server[mcpFieldURL] != testExampleURL {
+		t.Errorf("ambiguous entry was not preserved: %v", server)
+	}
+}
+
+func TestZedInstall_WrapsMultipleServers(t *testing.T) {
+	path := writeZedFile(t, testZedMultipleServers)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	cfg, _, err := readMCPConfig(path, zedServersKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"stdio-a", "stdio-b"} {
+		if _, ok := cfg.Servers[name][mcpFieldPipelock]; !ok {
+			t.Errorf("server %q not wrapped", name)
+		}
+	}
+}
+
+// TestZedInstall_DryRunWithHeadersCreatesNoSidecar locks in that --dry-run is
+// read-only across both the canonical config AND the operator-private header
+// sidecar dir.
+func TestZedInstall_DryRunWithHeadersCreatesNoSidecar(t *testing.T) {
+	home := isolateHome(t)
+	path := writeZedFile(t, testZedHTTPConfigSecretHeader)
+
+	if err := runZedCmd(t, "install", "--path", path, "--dry-run"); err != nil {
+		t.Fatalf("install --dry-run failed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("re-read after dry-run: %v", err)
+	}
+	if string(got) != testZedHTTPConfigSecretHeader {
+		t.Error("dry-run modified the canonical config file")
+	}
+	if files := listSidecarFiles(t, home); len(files) > 0 {
+		t.Errorf("dry-run wrote sidecar(s) to disk: %v", files)
+	}
+}
+
+// TestZedRemove_DryRunPreservesSidecar locks in that remove --dry-run does NOT
+// delete a wrapped server's header sidecar.
+func TestZedRemove_DryRunPreservesSidecar(t *testing.T) {
+	home := isolateHome(t)
+	path := writeZedFile(t, testZedHTTPConfigSecretHeader)
+
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	files := listSidecarFiles(t, home)
+	if len(files) != 1 {
+		t.Fatalf("expected one sidecar after install, got %d (%v)", len(files), files)
+	}
+	sidecarPath := filepath.Join(home, ".config", "pipelock", "wrap-headers", files[0])
+	sidecarBefore, err := os.ReadFile(filepath.Clean(sidecarPath))
+	if err != nil {
+		t.Fatalf("read sidecar before remove: %v", err)
+	}
+	cfgBefore, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runZedCmd(t, "remove", "--path", path, "--dry-run"); err != nil {
+		t.Fatalf("remove --dry-run failed: %v", err)
+	}
+
+	cfgAfter, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(cfgAfter, cfgBefore) {
+		t.Error("remove --dry-run modified the canonical config")
+	}
+	sidecarAfter, err := os.ReadFile(filepath.Clean(sidecarPath))
+	if err != nil {
+		t.Fatalf("remove --dry-run deleted the sidecar: %v", err)
+	}
+	if !bytes.Equal(sidecarAfter, sidecarBefore) {
+		t.Error("remove --dry-run mutated the sidecar contents")
+	}
+}
+
+// --- Zed-specific multi-path discovery ---
+
+func TestZedUserConfigPath_HonorsXDGConfigHome(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+
+	got, err := zedUserConfigPath()
+	if err != nil {
+		t.Fatalf("zedUserConfigPath: %v", err)
+	}
+	want := filepath.Join(xdg, zedUserConfigSubdir, zedConfigFilename)
+	if got != want {
+		t.Errorf("XDG-rooted user path mismatch: got %q, want %q", got, want)
+	}
+}
+
+func TestZedUserConfigPath_FallsBackToHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	got, err := zedUserConfigPath()
+	if err != nil {
+		t.Fatalf("zedUserConfigPath: %v", err)
+	}
+	want := filepath.Join(home, ".config", zedUserConfigSubdir, zedConfigFilename)
+	if got != want {
+		t.Errorf("HOME-rooted user path mismatch: got %q, want %q", got, want)
+	}
+}
+
+func TestZedProjectConfigPath_IsCwdRelative(t *testing.T) {
+	dir := chdirIsolated(t)
+
+	got, err := zedProjectConfigPath()
+	if err != nil {
+		t.Fatalf("zedProjectConfigPath: %v", err)
+	}
+	want := filepath.Join(dir, zedProjectConfigDir, zedConfigFilename)
+	if got != want {
+		t.Errorf("project path mismatch: got %q, want %q", got, want)
+	}
+}
+
+func TestResolveZedTargets_OverrideShortCircuits(t *testing.T) {
+	got, err := resolveZedTargets("/tmp/explicit/settings.json")
+	if err != nil {
+		t.Fatalf("resolveZedTargets: %v", err)
+	}
+	if len(got.candidatePaths) != 1 || got.candidatePaths[0] != "/tmp/explicit/settings.json" {
+		t.Errorf("override should yield exactly that path, got %v", got.candidatePaths)
+	}
+	if len(got.existingPaths) != 1 || got.existingPaths[0] != "/tmp/explicit/settings.json" {
+		t.Errorf("override existingPaths mismatch: %v", got.existingPaths)
+	}
+}
+
+func TestResolveZedTargets_DefaultProbesBoth(t *testing.T) {
+	home := isolateHome(t)
+	cwd := chdirIsolated(t)
+
+	// Seed only the user-level file.
+	userPath := filepath.Join(home, ".config", zedUserConfigSubdir, zedConfigFilename)
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userPath, []byte(testZedStdioConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveZedTargets("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.candidatePaths) != 2 {
+		t.Errorf("expected 2 candidates, got %d: %v", len(got.candidatePaths), got.candidatePaths)
+	}
+	if len(got.existingPaths) != 1 {
+		t.Fatalf("expected only user path to be present, got %d", len(got.existingPaths))
+	}
+	if got.existingPaths[0] != userPath {
+		t.Errorf("existingPaths should hold user path %q, got %q", userPath, got.existingPaths[0])
+	}
+	_ = cwd
+}
+
+func TestZedInstall_DefaultScansBothPathsWhenBothExist(t *testing.T) {
+	home := isolateHome(t)
+	cwd := chdirIsolated(t)
+
+	userPath := filepath.Join(home, ".config", zedUserConfigSubdir, zedConfigFilename)
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userPath, []byte(testZedStdioConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	projectPath := filepath.Join(cwd, zedProjectConfigDir, zedConfigFilename)
+	if err := os.MkdirAll(filepath.Dir(projectPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(projectPath, []byte(testZedMultipleServers), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _, err := runZedCmdOutput(t, "install")
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// Both files should be summarized in stdout so the operator can see what
+	// was wrapped at each scope.
+	if !strings.Contains(stdout, userPath) {
+		t.Errorf("install output missing user path %q: %s", userPath, stdout)
+	}
+	if !strings.Contains(stdout, projectPath) {
+		t.Errorf("install output missing project path %q: %s", projectPath, stdout)
+	}
+
+	for _, p := range []string{userPath, projectPath} {
+		cfg, _, parseErr := readMCPConfig(p, zedServersKey)
+		if parseErr != nil {
+			t.Fatalf("parse %s: %v", p, parseErr)
+		}
+		wrapCount := 0
+		for _, server := range cfg.Servers {
+			if isWrapped(server) {
+				wrapCount++
+			}
+		}
+		if wrapCount == 0 {
+			t.Errorf("expected at least one wrapped server in %s", p)
+		}
+	}
+}
+
+// TestZedInstall_DualSidecarNoCollision proves the invariant that two
+// settings.json files (user + project) sharing a context_server name still
+// produce two distinct header-sidecar files. headerSidecarPath hashes the
+// absolute settings.json path into the sidecar name, so a same-named server
+// at different scopes cannot clobber the credential carrier of the other.
+func TestZedInstall_DualSidecarNoCollision(t *testing.T) {
+	home := isolateHome(t)
+	cwd := chdirIsolated(t)
+
+	httpServerCfg := `{
+  "context_servers": {
+    "remote": {
+      "url": "https://api.example.com/mcp",
+      "headers": { "X-Workspace-Id": "ws-zed-tok" }
+    }
+  }
+}`
+
+	userPath := filepath.Join(home, ".config", zedUserConfigSubdir, zedConfigFilename)
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userPath, []byte(httpServerCfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	projectPath := filepath.Join(cwd, zedProjectConfigDir, zedConfigFilename)
+	if err := os.MkdirAll(filepath.Dir(projectPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(projectPath, []byte(httpServerCfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runZedCmd(t, "install"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	files := listSidecarFiles(t, home)
+	if len(files) != 2 {
+		t.Fatalf("expected 2 sidecar files (one per scope), got %d: %v", len(files), files)
+	}
+
+	sidecarPaths := map[string]string{}
+	for _, scope := range []struct{ label, path string }{
+		{"user", userPath},
+		{"project", projectPath},
+	} {
+		cfg, _, err := readMCPConfig(scope.path, zedServersKey)
+		if err != nil {
+			t.Fatalf("parse %s: %v", scope.path, err)
+		}
+		args := interfaceSliceToStrings(cfg.Servers["remote"]["args"])
+		var sidecar string
+		for i, a := range args {
+			if a == mcpFlagHeaderFile && i+1 < len(args) {
+				sidecar = args[i+1]
+				break
+			}
+		}
+		if sidecar == "" {
+			t.Fatalf("%s scope missing --header-file flag in wrapped args: %v", scope.label, args)
+		}
+		body, err := os.ReadFile(filepath.Clean(sidecar))
+		if err != nil {
+			t.Fatalf("read %s sidecar: %v", scope.label, err)
+		}
+		if !strings.Contains(string(body), "X-Workspace-Id: ws-zed-tok") {
+			t.Errorf("%s sidecar missing expected header line: %q", scope.label, body)
+		}
+		sidecarPaths[scope.label] = sidecar
+	}
+
+	if sidecarPaths["user"] == sidecarPaths["project"] {
+		t.Fatalf("user and project sidecars must not share a path, got %q for both", sidecarPaths["user"])
+	}
+}
+
+func TestZedInstall_DefaultNoFilesPrintsHint(t *testing.T) {
+	home := isolateHome(t)
+	chdirIsolated(t)
+
+	stdout, _, err := runZedCmdOutput(t, "install")
+	if err != nil {
+		t.Fatalf("install with no files should succeed: %v", err)
+	}
+	if !strings.Contains(stdout, "No Zed settings.json found") {
+		t.Errorf("expected friendly hint when no settings.json exists, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, ".config/zed/settings.json") {
+		t.Errorf("hint should name the user-level path it looked for: %s", stdout)
+	}
+	if !strings.Contains(stdout, ".zed/settings.json") {
+		t.Errorf("hint should name the project-level path it looked for: %s", stdout)
+	}
+	_ = home
+}
+
+func TestZedRemove_DefaultNoFilesPrintsHint(t *testing.T) {
+	isolateHome(t)
+	chdirIsolated(t)
+
+	stdout, _, err := runZedCmdOutput(t, "remove")
+	if err != nil {
+		t.Fatalf("remove with no files should succeed: %v", err)
+	}
+	if !strings.Contains(stdout, "No Zed settings.json found") {
+		t.Errorf("expected friendly hint when no settings.json exists, got: %s", stdout)
+	}
+}
+
+func TestZedInstall_DefaultUserOnly(t *testing.T) {
+	home := isolateHome(t)
+	chdirIsolated(t)
+
+	userPath := filepath.Join(home, ".config", zedUserConfigSubdir, zedConfigFilename)
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userPath, []byte(testZedStdioConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runZedCmd(t, "install"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	cfg, _, err := readMCPConfig(userPath, zedServersKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isWrapped(cfg.Servers["my-server"]) {
+		t.Error("user-level server should be wrapped")
+	}
+}
+
+func TestZedInstall_DefaultProjectOnly(t *testing.T) {
+	isolateHome(t)
+	cwd := chdirIsolated(t)
+
+	projectPath := filepath.Join(cwd, zedProjectConfigDir, zedConfigFilename)
+	if err := os.MkdirAll(filepath.Dir(projectPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(projectPath, []byte(testZedStdioConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runZedCmd(t, "install"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	cfg, _, err := readMCPConfig(projectPath, zedServersKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isWrapped(cfg.Servers["my-server"]) {
+		t.Error("project-level server should be wrapped")
+	}
+}
+
+// TestZedInstall_DefaultIgnoresDirectoryNamedSettings locks in that a
+// directory named settings.json at a default location is treated as absent.
+// This protects against a misconfiguration where ~/.config/zed/settings.json
+// is itself a directory (e.g. user mistakenly mkdir'd it) — the installer
+// should not error out, it should ignore that candidate.
+func TestZedInstall_DefaultIgnoresDirectoryNamedSettings(t *testing.T) {
+	home := isolateHome(t)
+	chdirIsolated(t)
+
+	userDir := filepath.Join(home, ".config", zedUserConfigSubdir, zedConfigFilename)
+	if err := os.MkdirAll(userDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _, err := runZedCmdOutput(t, "install")
+	if err != nil {
+		t.Fatalf("install with directory at user path should succeed: %v", err)
+	}
+	if !strings.Contains(stdout, "No Zed settings.json found") {
+		t.Errorf("expected friendly hint when settings.json is a directory, got: %s", stdout)
+	}
+}
+
+// TestZedInstall_MkdirAllError ensures the parent-directory creation error
+// surfaces. We bait it by making the grandparent dir read-only AND pointing
+// --path at a missing file inside a not-yet-created subdir, so readZedConfig
+// short-circuits on IsNotExist and the MkdirAll call is the first thing that
+// actually touches the filesystem under the unwritable root.
+func TestZedInstall_MkdirAllError(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Chmod(root, os.ModeDir|0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { restoreDirPerms(root) })
+
+	target := filepath.Join(root, "subdir", "settings.json")
+	if err := runZedCmd(t, "install", "--path", target); err == nil {
+		t.Error("expected install to fail when parent dir is read-only")
+	}
+}
+
+// TestZedInstall_AtomicWriteErrorOnNewFile covers the vscodeAtomicWrite
+// error branch on the "no existing data" path: target is a fresh file in
+// a read-only dir, so backup is skipped (nothing to back up) and the temp
+// rename inside vscodeAtomicWrite is the first write that fails.
+func TestZedInstall_AtomicWriteErrorOnNewFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, os.ModeDir|0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { restoreDirPerms(dir) })
+
+	target := filepath.Join(dir, "settings.json")
+	if err := runZedCmd(t, "install", "--path", target); err == nil {
+		t.Error("expected install to fail when target dir is not writable")
+	}
+}
+
+// TestZedInstall_AtomicWriteError makes the destination directory read-only
+// after seeding settings.json so the temp-file rename inside vscodeAtomicWrite
+// cannot land. The wrap loop should surface the I/O error.
+func TestZedInstall_AtomicWriteError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte(testZedStdioConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, os.ModeDir|0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { restoreDirPerms(dir) })
+
+	if err := runZedCmd(t, "install", "--path", path); err == nil {
+		t.Error("expected install to fail when target directory is not writable")
+	}
+}
+
+// TestZedRemove_AtomicWriteError mirrors the install error-path test for the
+// unwrap loop.
+func TestZedRemove_AtomicWriteError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte(testZedStdioConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Install first so there's something to unwrap.
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if err := os.Chmod(dir, os.ModeDir|0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { restoreDirPerms(dir) })
+
+	if err := runZedCmd(t, "remove", "--path", path); err == nil {
+		t.Error("expected remove to fail when target directory is not writable")
+	}
+}
+
+// TestZedRemove_InvalidJSON covers the parse-error branch in removeZedPath.
+func TestZedRemove_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runZedCmd(t, "remove", "--path", path); err == nil {
+		t.Error("expected remove to fail on invalid JSON")
+	}
+}
+
+// TestZedRemove_MalformedMetadata triggers the unwrap-error warning branch
+// by hand-crafting a server entry with an unparseable _pipelock metadata
+// payload. The remove path should warn (not fail) and leave that entry alone.
+func TestZedRemove_MalformedMetadata(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	corrupt := `{
+  "context_servers": {
+    "broken-meta": {
+      "type": "stdio",
+      "command": "/usr/local/bin/pipelock",
+      "args": ["mcp", "proxy", "--", "node"],
+      "_pipelock": {"original_type": "stdio"}
+    }
+  }
+}`
+	if err := os.WriteFile(path, []byte(corrupt), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := runZedCmdOutput(t, "remove", "--path", path)
+	if err != nil {
+		t.Fatalf("remove should succeed even with malformed metadata: %v", err)
+	}
+	if !strings.Contains(stderr, "warning: could not unwrap") {
+		t.Errorf("expected unwrap warning in stderr, got stderr=%q stdout=%q", stderr, stdout)
+	}
+}
+
+// TestZedInstall_ConfigFlagPassthrough verifies that --config is propagated
+// into the wrapped argv as `--config <path>` ahead of the `--` separator.
+func TestZedInstall_ConfigFlagPassthrough(t *testing.T) {
+	path := writeZedFile(t, testZedStdioConfig)
+	cfgFile := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(cfgFile, []byte("mode: enforce\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runZedCmd(t, "install", "--path", path, "--config", cfgFile); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	cfg, _, err := readMCPConfig(path, zedServersKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := interfaceSliceToStrings(cfg.Servers["my-server"]["args"])
+	found := false
+	for i, a := range args {
+		if a == "--config" && i+1 < len(args) {
+			if !strings.HasSuffix(args[i+1], "pipelock.yaml") {
+				t.Errorf("--config value should match the supplied path, got %q", args[i+1])
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected --config in wrapped args, got %v", args)
+	}
+}
+
+// TestZedInstall_RemoveDryRunShowsPath verifies the dry-run output path is
+// hit on remove and names the file that would be touched.
+func TestZedRemove_DryRunShowsPath(t *testing.T) {
+	path := writeZedFile(t, testZedStdioConfig)
+	if err := runZedCmd(t, "install", "--path", path); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	stdout, _, err := runZedCmdOutput(t, "remove", "--path", path, "--dry-run")
+	if err != nil {
+		t.Fatalf("remove --dry-run: %v", err)
+	}
+	if !strings.Contains(stdout, "Would write to") {
+		t.Errorf("expected dry-run preview in stdout, got %q", stdout)
+	}
+	if !strings.Contains(stdout, path) {
+		t.Errorf("dry-run output should mention the target path %q, got %q", path, stdout)
+	}
+}
+
+func TestWrapClineServer_ZedConfigShape_Stdio(t *testing.T) {
+	// Verify shape parity: a server in the shape Zed uses produces the same
+	// wrap outcome as the Cline-shape, since wrapClineServer is the shared
+	// entry point.
+	server := map[string]interface{}{
+		mcpFieldCommand: testNodeCmd,
+		mcpFieldArgs:    []interface{}{"server.js"},
+		"env":           map[string]interface{}{"FOO": "bar"},
+	}
+
+	result, meta, _, err := wrapClineServer(server, "/usr/local/bin/pipelock", "", "", "")
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	if !meta.TypeOmitted {
+		t.Error("Zed-shaped server (no type) must record TypeOmitted=true")
+	}
+	if result[mcpFieldType] != testTypeStdio {
+		t.Errorf("wrapped result should declare type=stdio for Zed launch, got %v", result[mcpFieldType])
+	}
+}

--- a/internal/cli/setup/zed_test.go
+++ b/internal/cli/setup/zed_test.go
@@ -219,7 +219,7 @@ func TestZedInstall_StdioServerWithImplicitType(t *testing.T) {
 
 	foundEnv := false
 	for i, a := range args {
-		if a == codexFlagEnv && i+1 < len(args) && args[i+1] == "MY_VAR" {
+		if a == codexFlagEnv && i+1 < len(args) && args[i+1] == testClineEnvKey {
 			foundEnv = true
 			break
 		}
@@ -229,7 +229,7 @@ func TestZedInstall_StdioServerWithImplicitType(t *testing.T) {
 	}
 
 	env, ok := server["env"].(map[string]interface{})
-	if !ok || env["MY_VAR"] != testZedEnvValue {
+	if !ok || env[testClineEnvKey] != testZedEnvValue {
 		t.Errorf("env block not preserved: %v", server["env"])
 	}
 
@@ -255,7 +255,7 @@ func TestZedInstall_HTTPServerWithImplicitType(t *testing.T) {
 	args := interfaceSliceToStrings(server["args"])
 	foundUpstream := false
 	for i, a := range args {
-		if a == "--upstream" && i+1 < len(args) {
+		if a == codexFlagUpstream && i+1 < len(args) {
 			if args[i+1] != testExampleURL {
 				t.Errorf("upstream URL mismatch: got %q, want %q", args[i+1], testExampleURL)
 			}
@@ -805,6 +805,31 @@ func TestResolveZedTargets_DefaultProbesBoth(t *testing.T) {
 		t.Errorf("existingPaths should hold user path %q, got %q", userPath, got.existingPaths[0])
 	}
 	_ = cwd
+}
+
+func TestResolveZedTargets_DefaultStatError(t *testing.T) {
+	home := t.TempDir()
+	xdg := filepath.Join(home, ".config")
+	zedDir := filepath.Join(xdg, zedUserConfigSubdir)
+	if err := os.MkdirAll(zedDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	chdirIsolated(t)
+
+	if err := os.Chmod(zedDir, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { restoreDirPerms(zedDir) })
+
+	_, err := resolveZedTargets("")
+	if err == nil {
+		t.Fatal("expected inaccessible default path to fail target discovery")
+	}
+	if !strings.Contains(err.Error(), "checking Zed settings path") {
+		t.Fatalf("error should name failed stat probe, got: %v", err)
+	}
 }
 
 func TestZedInstall_DefaultScansBothPathsWhenBothExist(t *testing.T) {

--- a/internal/cli/setup/zed_test.go
+++ b/internal/cli/setup/zed_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -153,6 +154,20 @@ func chdirIsolated(t *testing.T) string {
 	return dir
 }
 
+// requirePOSIXPermissions skips the test on Windows (no POSIX mode bits) and
+// when running as uid 0 (root bypasses chmod-based access checks, so a test
+// that depends on EACCES from a chmod 0 dir gets a false-pass under root).
+// Permission-manipulating tests should call this first.
+func requirePOSIXPermissions(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("permission test skipped on Windows: no POSIX mode bits")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("permission test skipped under root: uid 0 bypasses chmod-based access checks")
+	}
+}
+
 func TestZedInstall_DryRun(t *testing.T) {
 	path := writeZedFile(t, testZedStdioConfig)
 
@@ -212,6 +227,9 @@ func TestZedInstall_StdioServerWithImplicitType(t *testing.T) {
 	}
 	if dashIdx < 0 {
 		t.Fatal("no -- separator in wrapped args")
+	}
+	if dashIdx+1 >= len(args) {
+		t.Fatalf("-- separator at end of args with no original command following: %v", args)
 	}
 	if args[dashIdx+1] != testOriginalCmd {
 		t.Errorf("expected original command after --, got %q", args[dashIdx+1])
@@ -795,8 +813,8 @@ func TestResolveZedTargets_DefaultProbesBoth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got.candidatePaths) != 2 {
-		t.Errorf("expected 2 candidates, got %d: %v", len(got.candidatePaths), got.candidatePaths)
+	if len(got.candidatePaths) != 5 {
+		t.Errorf("expected 5 candidates (project + native stable + native preview + flatpak stable + flatpak preview), got %d: %v", len(got.candidatePaths), got.candidatePaths)
 	}
 	if len(got.existingPaths) != 1 {
 		t.Fatalf("expected only user path to be present, got %d", len(got.existingPaths))
@@ -808,6 +826,7 @@ func TestResolveZedTargets_DefaultProbesBoth(t *testing.T) {
 }
 
 func TestResolveZedTargets_DefaultStatError(t *testing.T) {
+	requirePOSIXPermissions(t)
 	home := t.TempDir()
 	xdg := filepath.Join(home, ".config")
 	zedDir := filepath.Join(xdg, zedUserConfigSubdir)
@@ -993,6 +1012,168 @@ func TestZedRemove_DefaultNoFilesPrintsHint(t *testing.T) {
 	}
 }
 
+// TestZedInstall_DefaultWrapsZedPreviewChannel covers users who run Zed
+// Preview alongside the stable channel: the installer must wrap both
+// channels' settings.json files when both exist.
+func TestZedInstall_DefaultWrapsZedPreviewChannel(t *testing.T) {
+	home := isolateHome(t)
+	chdirIsolated(t)
+
+	previewPath := filepath.Join(home, ".config", zedPreviewConfigSubdir, zedConfigFilename)
+	if err := os.MkdirAll(filepath.Dir(previewPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(previewPath, []byte(testZedStdioConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runZedCmd(t, "install"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	cfg, _, err := readMCPConfig(previewPath, zedServersKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isWrapped(cfg.Servers["my-server"]) {
+		t.Error("Zed Preview channel settings.json should have been wrapped")
+	}
+}
+
+// TestZedInstall_DefaultWrapsFlatpakStable proves the Flatpak-sandboxed
+// settings.json (~/.var/app/dev.zed.Zed/config/zed/settings.json) is in the
+// default-discovery list. Operators who install Zed from Flathub keep their
+// MCP config there; the installer must reach it without --path.
+func TestZedInstall_DefaultWrapsFlatpakStable(t *testing.T) {
+	home := isolateHome(t)
+	chdirIsolated(t)
+
+	flatpakPath := filepath.Join(home, ".var", "app", zedFlatpakAppStableDir, "config", zedUserConfigSubdir, zedConfigFilename)
+	if err := os.MkdirAll(filepath.Dir(flatpakPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(flatpakPath, []byte(testZedStdioConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runZedCmd(t, "install"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	cfg, _, err := readMCPConfig(flatpakPath, zedServersKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isWrapped(cfg.Servers["my-server"]) {
+		t.Error("Flatpak Zed stable settings.json should have been wrapped")
+	}
+}
+
+// TestZedInstall_DefaultWrapsFlatpakPreview covers Zed Preview installed via
+// Flatpak. Different app id (dev.zed.Zed.Preview) and channel subdir
+// (zed-preview) than the stable Flatpak.
+func TestZedInstall_DefaultWrapsFlatpakPreview(t *testing.T) {
+	home := isolateHome(t)
+	chdirIsolated(t)
+
+	flatpakPath := filepath.Join(home, ".var", "app", zedFlatpakAppPreviewDir, "config", zedPreviewConfigSubdir, zedConfigFilename)
+	if err := os.MkdirAll(filepath.Dir(flatpakPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(flatpakPath, []byte(testZedStdioConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runZedCmd(t, "install"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	cfg, _, err := readMCPConfig(flatpakPath, zedServersKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isWrapped(cfg.Servers["my-server"]) {
+		t.Error("Flatpak Zed Preview settings.json should have been wrapped")
+	}
+}
+
+// TestZedInstall_DefaultEnumeratesAllPathsInHint locks in that the
+// "no Zed settings.json found" message lists every default candidate (not
+// just the first two), so operators on Flatpak or Preview can see why the
+// installer didn't find their config.
+func TestZedInstall_DefaultEnumeratesAllPathsInHint(t *testing.T) {
+	isolateHome(t)
+	chdirIsolated(t)
+
+	stdout, _, err := runZedCmdOutput(t, "install")
+	if err != nil {
+		t.Fatalf("install with no files: %v", err)
+	}
+
+	wantSubstrings := []string{
+		"/.zed/settings.json",                                            // project
+		"/.config/zed/settings.json",                                     // native stable
+		"/.config/zed-preview/settings.json",                             // native preview
+		"/.var/app/dev.zed.Zed/config/zed/settings.json",                 // flatpak stable
+		"/.var/app/dev.zed.Zed.Preview/config/zed-preview/settings.json", // flatpak preview
+	}
+	for _, s := range wantSubstrings {
+		if !strings.Contains(stdout, s) {
+			t.Errorf("friendly hint missing expected path fragment %q\nfull stdout:\n%s", s, stdout)
+		}
+	}
+}
+
+func TestZedDefaultCandidates_OrderingIsStable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Chdir(home)
+
+	got, err := zedDefaultCandidates()
+	if err != nil {
+		t.Fatalf("zedDefaultCandidates: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("expected 5 candidates, got %d: %v", len(got), got)
+	}
+	wantSuffixes := []string{
+		"/.zed/settings.json",                                            // project (first)
+		"/.config/zed/settings.json",                                     // native stable
+		"/.config/zed-preview/settings.json",                             // native preview
+		"/.var/app/dev.zed.Zed/config/zed/settings.json",                 // flatpak stable
+		"/.var/app/dev.zed.Zed.Preview/config/zed-preview/settings.json", // flatpak preview (last)
+	}
+	for i, suf := range wantSuffixes {
+		if !strings.HasSuffix(got[i], suf) {
+			t.Errorf("candidate[%d] = %q, want suffix %q", i, got[i], suf)
+		}
+	}
+}
+
+func TestZedFlatpakConfigPath_HonorsAppID(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	stable, err := zedFlatpakConfigPath(zedFlatpakAppStableDir, zedUserConfigSubdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preview, err := zedFlatpakConfigPath(zedFlatpakAppPreviewDir, zedPreviewConfigSubdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stable == preview {
+		t.Errorf("stable and preview flatpak paths must differ, both = %q", stable)
+	}
+	if !strings.Contains(stable, "dev.zed.Zed/config/zed/") {
+		t.Errorf("stable flatpak path missing expected app id, got %q", stable)
+	}
+	if !strings.Contains(preview, "dev.zed.Zed.Preview/config/zed-preview/") {
+		t.Errorf("preview flatpak path missing expected app id, got %q", preview)
+	}
+}
+
 func TestZedInstall_DefaultUserOnly(t *testing.T) {
 	home := isolateHome(t)
 	chdirIsolated(t)
@@ -1072,6 +1253,7 @@ func TestZedInstall_DefaultIgnoresDirectoryNamedSettings(t *testing.T) {
 // short-circuits on IsNotExist and the MkdirAll call is the first thing that
 // actually touches the filesystem under the unwritable root.
 func TestZedInstall_MkdirAllError(t *testing.T) {
+	requirePOSIXPermissions(t)
 	root := t.TempDir()
 	if err := os.Chmod(root, os.ModeDir|0o500); err != nil {
 		t.Fatal(err)
@@ -1089,6 +1271,7 @@ func TestZedInstall_MkdirAllError(t *testing.T) {
 // a read-only dir, so backup is skipped (nothing to back up) and the temp
 // rename inside vscodeAtomicWrite is the first write that fails.
 func TestZedInstall_AtomicWriteErrorOnNewFile(t *testing.T) {
+	requirePOSIXPermissions(t)
 	dir := t.TempDir()
 	if err := os.Chmod(dir, os.ModeDir|0o500); err != nil {
 		t.Fatal(err)
@@ -1105,6 +1288,7 @@ func TestZedInstall_AtomicWriteErrorOnNewFile(t *testing.T) {
 // after seeding settings.json so the temp-file rename inside vscodeAtomicWrite
 // cannot land. The wrap loop should surface the I/O error.
 func TestZedInstall_AtomicWriteError(t *testing.T) {
+	requirePOSIXPermissions(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "settings.json")
 	if err := os.WriteFile(path, []byte(testZedStdioConfig), 0o600); err != nil {
@@ -1123,6 +1307,7 @@ func TestZedInstall_AtomicWriteError(t *testing.T) {
 // TestZedRemove_AtomicWriteError mirrors the install error-path test for the
 // unwrap loop.
 func TestZedRemove_AtomicWriteError(t *testing.T) {
+	requirePOSIXPermissions(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "settings.json")
 	if err := os.WriteFile(path, []byte(testZedStdioConfig), 0o600); err != nil {

--- a/internal/cli/setup/zed_test.go
+++ b/internal/cli/setup/zed_test.go
@@ -225,7 +225,7 @@ func TestZedInstall_StdioServerWithImplicitType(t *testing.T) {
 		}
 	}
 	if !foundEnv {
-		t.Errorf("expected --env MY_VAR passthrough in args: %v", args)
+		t.Errorf("expected --env %s passthrough in args: %v", testClineEnvKey, args)
 	}
 
 	env, ok := server["env"].(map[string]interface{})

--- a/internal/cli/setup/zed_test.go
+++ b/internal/cli/setup/zed_test.go
@@ -1117,8 +1117,14 @@ func TestZedInstall_DefaultEnumeratesAllPathsInHint(t *testing.T) {
 		"/.var/app/dev.zed.Zed/config/zed/settings.json",                 // flatpak stable
 		"/.var/app/dev.zed.Zed.Preview/config/zed-preview/settings.json", // flatpak preview
 	}
+	// Normalize the captured stdout for cross-platform path comparison. The
+	// installer renders paths with the platform's filepath separator, so on
+	// Windows the hint contains backslashes; assertions written against
+	// '/'-separated fragments would false-fail there. Other tests in the
+	// codebase use filepath.ToSlash for the same reason.
+	stdoutSlash := filepath.ToSlash(stdout)
 	for _, s := range wantSubstrings {
-		if !strings.Contains(stdout, s) {
+		if !strings.Contains(stdoutSlash, s) {
 			t.Errorf("friendly hint missing expected path fragment %q\nfull stdout:\n%s", s, stdout)
 		}
 	}
@@ -1145,7 +1151,7 @@ func TestZedDefaultCandidates_OrderingIsStable(t *testing.T) {
 		"/.var/app/dev.zed.Zed.Preview/config/zed-preview/settings.json", // flatpak preview (last)
 	}
 	for i, suf := range wantSuffixes {
-		if !strings.HasSuffix(got[i], suf) {
+		if !strings.HasSuffix(filepath.ToSlash(got[i]), suf) {
 			t.Errorf("candidate[%d] = %q, want suffix %q", i, got[i], suf)
 		}
 	}
@@ -1166,10 +1172,10 @@ func TestZedFlatpakConfigPath_HonorsAppID(t *testing.T) {
 	if stable == preview {
 		t.Errorf("stable and preview flatpak paths must differ, both = %q", stable)
 	}
-	if !strings.Contains(stable, "dev.zed.Zed/config/zed/") {
+	if !strings.Contains(filepath.ToSlash(stable), "dev.zed.Zed/config/zed/") {
 		t.Errorf("stable flatpak path missing expected app id, got %q", stable)
 	}
-	if !strings.Contains(preview, "dev.zed.Zed.Preview/config/zed-preview/") {
+	if !strings.Contains(filepath.ToSlash(preview), "dev.zed.Zed.Preview/config/zed-preview/") {
 		t.Errorf("preview flatpak path missing expected app id, got %q", preview)
 	}
 }

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -278,10 +278,45 @@ func configPaths(home string) []clientPath {
 			Key:    "mcpServers",
 			Scope:  "user",
 		},
-		// Note: project-local .junie/mcp/mcp.json is not scanned here.
-		// Discover(home) must be deterministic from its inputs. Project-local
-		// scanning requires an explicit project root parameter (future work).
-		// Consistent with VS Code (.vscode/mcp.json also not scanned).
+		// Zed stores config under ~/.config/zed/ on both Linux and macOS
+		// per zed.dev/docs (it does not follow the macOS Application Support
+		// convention). The settings.json top-level key is "context_servers"
+		// rather than "mcpServers" or "servers".
+		{
+			Client: "zed",
+			Path:   filepath.Join(home, ".config", "zed", "settings.json"),
+			Key:    "context_servers",
+			Scope:  "user",
+		},
+		// Zed Preview is a separate binary that ships ahead of stable; its
+		// config dir is "zed-preview" rather than "zed". Users who run both
+		// channels need both wraps detected.
+		{
+			Client: "zed-preview",
+			Path:   filepath.Join(home, ".config", "zed-preview", "settings.json"),
+			Key:    "context_servers",
+			Scope:  "user",
+		},
+		// Flatpak-sandboxed Zed lives under $HOME/.var/app/<app-id>/config/.
+		// Inside the sandbox Zed sees its own XDG_CONFIG_HOME pointing at
+		// that dir, but from outside (where discover runs) the path is fixed.
+		{
+			Client: "zed-flatpak",
+			Path:   filepath.Join(home, ".var", "app", "dev.zed.Zed", "config", "zed", "settings.json"),
+			Key:    "context_servers",
+			Scope:  "user",
+		},
+		{
+			Client: "zed-preview-flatpak",
+			Path:   filepath.Join(home, ".var", "app", "dev.zed.Zed.Preview", "config", "zed-preview", "settings.json"),
+			Key:    "context_servers",
+			Scope:  "user",
+		},
+		// Note: project-local .junie/mcp/mcp.json and project-local
+		// .zed/settings.json are not scanned here. Discover(home) must be
+		// deterministic from its inputs. Project-local scanning requires
+		// an explicit project root parameter (future work). Consistent
+		// with VS Code (.vscode/mcp.json also not scanned).
 	}
 }
 

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -107,7 +107,7 @@ func TestConfigPathsContainExpectedClients(t *testing.T) {
 		clients[p.Client] = true
 	}
 
-	expected := []string{"claude-code", "claude-desktop", "cursor", "vscode", "cline", "continue", "junie"}
+	expected := []string{"claude-code", "claude-desktop", "cursor", "vscode", "cline", "continue", "junie", "zed", "zed-preview", "zed-flatpak", "zed-preview-flatpak"}
 	for _, c := range expected {
 		if !clients[c] {
 			t.Errorf("missing expected client %q", c)
@@ -231,6 +231,98 @@ func TestDiscoverMultipleClients(t *testing.T) {
 	}
 	if report.Summary.TotalServers != 2 {
 		t.Errorf("total_servers = %d, want 2", report.Summary.TotalServers)
+	}
+}
+
+// TestDiscoverFindsZedAllChannels covers every Zed config path that
+// discover knows about: native stable, native preview, Flatpak stable,
+// and Flatpak preview. Each channel uses the `context_servers` top-level
+// key (not `mcpServers`), and discover must enumerate servers from all
+// four so an operator running multiple channels gets a complete report.
+func TestDiscoverFindsZedAllChannels(t *testing.T) {
+	home := t.TempDir()
+
+	zedConfig := `{"context_servers":{"filesystem":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/tmp"]}}}`
+
+	channels := []struct {
+		name string
+		path string
+	}{
+		{"native stable", filepath.Join(home, ".config", "zed", "settings.json")},
+		{"native preview", filepath.Join(home, ".config", "zed-preview", "settings.json")},
+		{"flatpak stable", filepath.Join(home, ".var", "app", "dev.zed.Zed", "config", "zed", "settings.json")},
+		{"flatpak preview", filepath.Join(home, ".var", "app", "dev.zed.Zed.Preview", "config", "zed-preview", "settings.json")},
+	}
+	for _, ch := range channels {
+		if err := os.MkdirAll(filepath.Dir(ch.path), 0o750); err != nil {
+			t.Fatalf("%s mkdir: %v", ch.name, err)
+		}
+		if err := os.WriteFile(ch.path, []byte(zedConfig), 0o600); err != nil {
+			t.Fatalf("%s write: %v", ch.name, err)
+		}
+	}
+
+	report, err := Discover(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.Summary.TotalClients != 4 {
+		t.Errorf("total_clients = %d, want 4 (zed + zed-preview + zed-flatpak + zed-preview-flatpak)", report.Summary.TotalClients)
+	}
+	if report.Summary.TotalServers != 4 {
+		t.Errorf("total_servers = %d, want 4 (one filesystem server per channel)", report.Summary.TotalServers)
+	}
+
+	wantClients := map[string]bool{
+		"zed":                 false,
+		"zed-preview":         false,
+		"zed-flatpak":         false,
+		"zed-preview-flatpak": false,
+	}
+	for _, server := range report.Servers {
+		if _, ok := wantClients[server.Client]; ok {
+			wantClients[server.Client] = true
+		}
+	}
+	for client, found := range wantClients {
+		if !found {
+			t.Errorf("discover did not report client %q", client)
+		}
+	}
+}
+
+// TestDiscoverZedWrappedShowsProtected covers the case where Zed's
+// settings.json carries a pipelock-wrapped context_server entry: discover
+// must classify it as ProtectedPipelock, matching what it does for other
+// IDEs that share the same wrap shape (command=pipelock, args contain mcp
+// and proxy).
+func TestDiscoverZedWrappedShowsProtected(t *testing.T) {
+	home := t.TempDir()
+
+	wrapped := `{"context_servers":{"filesystem":{"type":"stdio","command":"pipelock","args":["mcp","proxy","--config","/etc/pipelock/pipelock.yaml","--","npx","-y","@modelcontextprotocol/server-filesystem","/tmp"]}}}`
+	zedPath := filepath.Join(home, ".config", "zed", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(zedPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(zedPath, []byte(wrapped), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := Discover(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(report.Servers) != 1 {
+		t.Fatalf("expected exactly 1 server, got %d", len(report.Servers))
+	}
+	got := report.Servers[0]
+	if got.Client != "zed" {
+		t.Errorf("client = %q, want zed", got.Client)
+	}
+	if got.Protection != ProtectedPipelock {
+		t.Errorf("protection = %q, want %q", got.Protection, ProtectedPipelock)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `pipelock zed install` and `pipelock zed remove` for wrapping MCP `context_servers` entries in Zed's `settings.json` through the MCP proxy.

Default discovery scans both user-level (`$XDG_CONFIG_HOME/zed/settings.json` or `~/.config/zed/settings.json`) and project-level (`<cwd>/.zed/settings.json`); each existing file is wrapped independently with its own `.bak` backup. `--path` targets a single explicit file. If neither default exists, install prints a friendly hint and exits 0.

Zed's MCP shape is identical to Cline's (flat `command` plus `args` plus `env`; transport inferred from `command` vs `url`), so wrap delegates to `wrapClineServer` and reuses the `--header-file` sidecar path (`0o600`) for credential-bearing `headers` blocks. Header values never appear in `/proc/<pid>/cmdline`. Install is idempotent and preserves all non-server top-level `settings.json` fields (theme, ui_font_size, etc.) across the rewrite.

## Behavior

`resolveZedTargets` continues only on `os.ErrNotExist` for missing default paths. Any other stat failure (`EACCES`, `ENOTDIR`, `EIO`) surfaces as an error so a permission-denied probe on the operator's `settings.json` cannot silently leave MCP servers unwrapped. The two default paths produce distinct sidecar files because `headerSidecarPath` hashes the absolute `settings.json` path: a same-named server at user vs project scope cannot clobber the other's credential carrier (`TestZedInstall_DualSidecarNoCollision`).

End-to-end against installed Zed 1.2.6 plus `@modelcontextprotocol/server-filesystem`: a `tools/call write_file` carrying an AWS access key ID is blocked by `mcp_input_scanning` with a structured JSON-RPC `-32001` error, and the file never reaches disk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pipelock zed` (install/remove, discovery, explicit path, --dry-run, backups) and registered it with the CLI.
  * Discovery now includes multiple Zed channels (native + Flatpak) and reports them; discover help text updated.

* **Documentation**
  * New Zed guide covering integration, wrapping behavior, header sidecars, examples, and audit evidence.

* **Tests**
  * Extensive install/remove, discovery, idempotency, sidecar, error, and permission tests.

* **Chores**
  * CI security scan now excludes the Zed guide from diffs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->