### PR TITLE
feat(rules): add opt-in ATR rules adapter

### DIFF
--- a/docs/guides/atr-rules-import.md
+++ b/docs/guides/atr-rules-import.md
@@ -1,0 +1,68 @@
+# Importing Agent Threat Rules (ATR) into Pipelock
+
+This guide documents the optional `atrimport` adapter at
+`internal/rules/atrimport/`. It loads YAML rules from the external
+Agent Threat Rules (ATR) project and converts the regex-based subset
+into Pipelock pattern types.
+
+ATR is an MIT-licensed community-maintained detection standard for AI
+agent threats. Upstream: https://github.com/Agent-Threat-Rule/agent-threat-rules.
+
+The adapter is read-only and does not touch the signed bundle pipeline.
+Operators who do not call `atrimport.LoadDir` will see no behaviour
+change.
+
+## Scope and limits
+
+The adapter intentionally imports only the subset of ATR that maps
+cleanly onto Pipelock's existing pattern types:
+
+- Rules with `detection_tier: pattern` (regex-based).
+- Conditions with `operator: regex`.
+- Single-condition rules, or multi-condition rules with
+  `condition: any` (logical OR).
+
+Rules that fall outside that subset are recorded in
+`Result.Skipped` with a per-rule reason, including:
+
+- `detection_tier: behavioral` and other non-pattern tiers.
+- `condition: all` with multiple conditions (requires boolean
+  composition that the scanner does not model today).
+- Experimental or draft rules, unless the operator opts in via
+  `Options.IncludeExperimental`.
+- Rules with no regex condition at all.
+
+Two further safety caps are hard-coded:
+
+- A 1 MiB per-file size limit.
+- A 2000-rule import ceiling per call.
+
+## Usage
+
+```go
+import "github.com/luckyPipewrench/pipelock/internal/rules/atrimport"
+
+res, err := atrimport.LoadDir("/path/to/atr/rules", atrimport.Options{
+    MinSeverity: "high",
+    ScanTargets: []string{"mcp", "llm"},
+})
+if err != nil {
+    return err
+}
+// res.DLP and res.Injection can be appended to the corresponding
+// config.DLP.Patterns and response-scan pattern slices.
+// res.Skipped enumerates everything that was not imported.
+```
+
+Every imported pattern carries `Bundle = "atr"` and
+`BundleVersion = <rule-id>` so audit events and metrics can attribute
+matches back to the ATR source rather than Pipelock's standard tier.
+
+## Why this is not a signed bundle
+
+Pipelock's signed bundle format (`internal/rules`) carries
+provenance, freshness, and tier-key binding guarantees. ATR is an
+external standard with its own release cadence. Wrapping ATR into the
+signed bundle format would conflate two different trust roots. The
+adapter keeps them separate: operators opt in explicitly, and any
+non-regex ATR rule is surfaced to them rather than silently dropped.

--- a/internal/rules/atrimport/atrimport.go
+++ b/internal/rules/atrimport/atrimport.go
@@ -1,0 +1,241 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package atrimport is an opt-in adapter that loads Agent Threat Rules (ATR,
+// https://github.com/Agent-Threat-Rule/agent-threat-rules, MIT licensed)
+// YAML files and converts the regex subset into Pipelock pattern types.
+// It does NOT touch the signed bundle pipeline. Non-regex ATR rules are
+// surfaced in Result.Skipped with a reason so operators can audit what
+// they are giving up.
+package atrimport
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// Safety caps.
+const (
+	MaxRuleFileBytes = 1 << 20 // 1 MiB per file
+	MaxRegexLength   = 4096
+	MaxRules         = 2000 // hard cap per LoadDir call
+	SourceName       = "atr"
+)
+
+// Options configures a single import.
+type Options struct {
+	MinSeverity         string   // low|medium|high|critical; empty = no filter
+	IncludeExperimental bool     // accept status=experimental|draft and maturity=experimental|test
+	ScanTargets         []string // allow list against tags.scan_target; empty = no filter
+}
+
+// Result is what LoadDir returns. DLP / Injection map onto the existing
+// Pipelock pattern types. Skipped records every rule we parsed but did not
+// import, with a reason.
+type Result struct {
+	DLP       []config.DLPPattern
+	Injection []config.ResponseScanPattern
+	Skipped   []SkipRecord
+}
+
+// SkipRecord explains why a single ATR rule was not imported.
+type SkipRecord struct {
+	RuleID string
+	Path   string
+	Reason string
+}
+
+type atrRule struct {
+	ID            string       `yaml:"id"`
+	Status        string       `yaml:"status"`
+	Maturity      string       `yaml:"maturity"`
+	DetectionTier string       `yaml:"detection_tier"`
+	Severity      string       `yaml:"severity"`
+	Tags          atrTags      `yaml:"tags"`
+	Detection     atrDetection `yaml:"detection"`
+}
+
+type atrTags struct {
+	ScanTarget string `yaml:"scan_target"`
+}
+
+type atrDetection struct {
+	Condition  string         `yaml:"condition"`
+	Conditions []atrCondition `yaml:"conditions"`
+}
+
+type atrCondition struct {
+	Field    string `yaml:"field"`
+	Operator string `yaml:"operator"`
+	Value    string `yaml:"value"`
+}
+
+var (
+	idRegex      = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{1,95}$`)
+	severityRank = map[string]int{"low": 1, "medium": 2, "high": 3, "critical": 4}
+	errSkip      = errors.New("atrimport: rule skipped")
+)
+
+// LoadDir walks dir, parses every *.yaml/*.yml file as an ATR rule, and
+// returns the regex subset mapped onto Pipelock pattern types. Per-file
+// errors become Skipped records; only directory-level errors abort.
+func LoadDir(dir string, opts Options) (*Result, error) {
+	if dir == "" {
+		return nil, errors.New("atrimport: dir is empty")
+	}
+	files, err := walkRuleFiles(dir)
+	if err != nil {
+		return nil, fmt.Errorf("atrimport: walking %s: %w", dir, err)
+	}
+	sort.Strings(files)
+
+	result := &Result{}
+	minRank := severityRank[strings.ToLower(opts.MinSeverity)]
+	for _, p := range files {
+		if len(result.DLP)+len(result.Injection) >= MaxRules {
+			result.Skipped = append(result.Skipped, SkipRecord{Path: p, Reason: fmt.Sprintf("rule cap %d reached", MaxRules)})
+			continue
+		}
+		rule, readErr := readRuleFile(p)
+		if readErr != nil {
+			result.Skipped = append(result.Skipped, SkipRecord{Path: p, Reason: readErr.Error()})
+			continue
+		}
+		convErr := convertRule(rule, p, opts, minRank, result)
+		if convErr != nil && !errors.Is(convErr, errSkip) {
+			result.Skipped = append(result.Skipped, SkipRecord{RuleID: rule.ID, Path: p, Reason: convErr.Error()})
+		}
+	}
+	return result, nil
+}
+
+func walkRuleFiles(dir string) ([]string, error) {
+	var out []string
+	walkErr := filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		base := d.Name()
+		if d.IsDir() {
+			if p != dir && strings.HasPrefix(base, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasPrefix(base, ".") || (!strings.HasSuffix(base, ".yaml") && !strings.HasSuffix(base, ".yml")) {
+			return nil
+		}
+		out = append(out, p)
+		return nil
+	})
+	return out, walkErr
+}
+
+func readRuleFile(p string) (*atrRule, error) {
+	info, err := os.Stat(p)
+	if err != nil {
+		return nil, fmt.Errorf("stat: %w", err)
+	}
+	if info.Size() > MaxRuleFileBytes {
+		return nil, fmt.Errorf("file size %d exceeds %d", info.Size(), MaxRuleFileBytes)
+	}
+	data, err := os.ReadFile(filepath.Clean(p))
+	if err != nil {
+		return nil, fmt.Errorf("read: %w", err)
+	}
+	var rule atrRule
+	if err := yaml.Unmarshal(data, &rule); err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+	return &rule, nil
+}
+
+func convertRule(rule *atrRule, path string, opts Options, minRank int, result *Result) error {
+	if !idRegex.MatchString(rule.ID) {
+		return fmt.Errorf("rule id %q does not match %s", rule.ID, idRegex)
+	}
+	skip := func(reason string) error {
+		result.Skipped = append(result.Skipped, SkipRecord{RuleID: rule.ID, Path: path, Reason: reason})
+		return errSkip
+	}
+
+	if !opts.IncludeExperimental {
+		s, m := strings.ToLower(rule.Status), strings.ToLower(rule.Maturity)
+		if s == "experimental" || s == "draft" || m == "experimental" || m == "test" {
+			return skip("experimental status not opted in")
+		}
+	}
+	if tier := strings.ToLower(rule.DetectionTier); tier != "" && tier != "pattern" {
+		return skip(fmt.Sprintf("detection_tier=%s not supported (only pattern)", tier))
+	}
+	severity := normalizeSeverity(rule.Severity)
+	if minRank > 0 && severityRank[severity] < minRank {
+		return skip(fmt.Sprintf("severity %s below minimum", severity))
+	}
+	scanTarget := strings.ToLower(rule.Tags.ScanTarget)
+	if len(opts.ScanTargets) > 0 && !containsFold(opts.ScanTargets, scanTarget) {
+		return skip(fmt.Sprintf("scan_target %q not in allow list", scanTarget))
+	}
+	if strings.ToLower(rule.Detection.Condition) == "all" && len(rule.Detection.Conditions) > 1 {
+		return skip("multi-condition all-of rules require boolean composition")
+	}
+
+	imported := 0
+	total := len(rule.Detection.Conditions)
+	for i, c := range rule.Detection.Conditions {
+		if strings.ToLower(c.Operator) != "regex" || c.Value == "" {
+			continue
+		}
+		if len(c.Value) > MaxRegexLength {
+			result.Skipped = append(result.Skipped, SkipRecord{RuleID: rule.ID, Path: path, Reason: fmt.Sprintf("regex %d exceeds %d chars", i, MaxRegexLength)})
+			continue
+		}
+		if _, err := regexp.Compile(c.Value); err != nil {
+			return fmt.Errorf("rule %s condition %d invalid regex: %w", rule.ID, i, err)
+		}
+		name := SourceName + ":" + rule.ID
+		if total > 1 {
+			name = fmt.Sprintf("%s:%s.%d", SourceName, rule.ID, i)
+		}
+		if strings.ToLower(c.Field) == "content" || scanTarget == "llm" {
+			result.Injection = append(result.Injection, config.ResponseScanPattern{
+				Name: name, Regex: c.Value, Bundle: SourceName, BundleVersion: rule.ID,
+			})
+		} else {
+			result.DLP = append(result.DLP, config.DLPPattern{
+				Name: name, Regex: c.Value, Severity: severity, Bundle: SourceName, BundleVersion: rule.ID,
+			})
+		}
+		imported++
+	}
+	if imported == 0 {
+		return skip("no regex conditions found")
+	}
+	return nil
+}
+
+func normalizeSeverity(s string) string {
+	v := strings.ToLower(strings.TrimSpace(s))
+	if _, ok := severityRank[v]; ok {
+		return v
+	}
+	return "medium"
+}
+
+func containsFold(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if strings.EqualFold(h, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/atrimport/atrimport_test.go
+++ b/internal/rules/atrimport/atrimport_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package atrimport
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadDir_DefaultsSkipExperimentalAndNonPattern(t *testing.T) {
+	t.Parallel()
+	got, err := LoadDir("testdata", Options{})
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	// Under defaults: 09001 → 2 Injection, 09002 → 1 DLP; the rest skipped.
+	if l := len(got.Injection); l != 2 {
+		t.Errorf("Injection len = %d, want 2", l)
+	}
+	if l := len(got.DLP); l != 1 {
+		t.Errorf("DLP len = %d, want 1", l)
+	}
+	if len(got.Skipped) == 0 {
+		t.Fatal("expected Skipped records, got 0")
+	}
+	for _, s := range got.Skipped {
+		if strings.TrimSpace(s.Reason) == "" {
+			t.Errorf("Skipped record %+v has empty Reason", s)
+		}
+	}
+	for _, p := range got.DLP {
+		if p.Severity == "" || p.Bundle != SourceName {
+			t.Errorf("DLP pattern %+v missing severity or wrong bundle", p)
+		}
+	}
+}
+
+func TestLoadDir_IncludeExperimentalImportsDraft(t *testing.T) {
+	t.Parallel()
+	got, err := LoadDir("testdata", Options{IncludeExperimental: true})
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if l := len(got.Injection); l != 3 {
+		t.Errorf("Injection len = %d, want 3", l)
+	}
+}
+
+func TestLoadDir_MinSeverityFiltersBelow(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name, min       string
+		wantDLP, wantIJ int
+	}{
+		{"low admits all", "low", 1, 2},
+		{"medium admits all", "medium", 1, 2},
+		{"high drops medium", "high", 0, 2},
+		{"critical drops all", "critical", 0, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := LoadDir("testdata", Options{MinSeverity: tc.min})
+			if err != nil {
+				t.Fatalf("LoadDir: %v", err)
+			}
+			if len(got.DLP) != tc.wantDLP || len(got.Injection) != tc.wantIJ {
+				t.Errorf("got DLP=%d Injection=%d, want DLP=%d Injection=%d",
+					len(got.DLP), len(got.Injection), tc.wantDLP, tc.wantIJ)
+			}
+		})
+	}
+}
+
+func TestLoadDir_ScanTargetAllowList(t *testing.T) {
+	t.Parallel()
+	got, err := LoadDir("testdata", Options{ScanTargets: []string{"mcp"}})
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if len(got.Injection) != 0 || len(got.DLP) != 1 {
+		t.Errorf("got DLP=%d Injection=%d, want 1/0", len(got.DLP), len(got.Injection))
+	}
+}
+
+func TestLoadDir_EmptyDirReturnsError(t *testing.T) {
+	t.Parallel()
+	if _, err := LoadDir("", Options{}); err == nil {
+		t.Fatal("LoadDir(\"\") returned nil error, want one")
+	}
+}
+
+func TestLoadDir_MissingDirReportsError(t *testing.T) {
+	t.Parallel()
+	if _, err := LoadDir(filepath.Join("testdata", "missing"), Options{}); err == nil {
+		t.Fatal("LoadDir on missing dir returned nil error, want one")
+	}
+}
+
+func TestLoadDir_OversizeFileSkipped(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	big := make([]byte, MaxRuleFileBytes+1)
+	if err := os.WriteFile(filepath.Join(dir, "big.yaml"), big, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := LoadDir(dir, Options{})
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if len(got.Skipped) != 1 || !strings.Contains(got.Skipped[0].Reason, "exceeds") {
+		t.Errorf("got Skipped=%+v, want one record mentioning 'exceeds'", got.Skipped)
+	}
+}
+
+func TestLoadDir_InvalidRegexReported(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	bad := []byte(`
+title: bad regex
+id: ATR-2026-09099
+status: stable
+detection_tier: pattern
+severity: high
+tags:
+  scan_target: mcp
+detection:
+  condition: any
+  conditions:
+    - field: url
+      operator: regex
+      value: "[unclosed"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "bad.yaml"), bad, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := LoadDir(dir, Options{})
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if len(got.DLP) != 0 || len(got.Skipped) != 1 ||
+		!strings.Contains(got.Skipped[0].Reason, "invalid regex") {
+		t.Errorf("got DLP=%d Skipped=%+v, want zero DLP + one invalid-regex skip", len(got.DLP), got.Skipped)
+	}
+}
+
+func TestLoadDir_RuleIDMustMatchPattern(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	bad := []byte(`
+title: bad id
+id: "not a valid id"
+status: stable
+detection_tier: pattern
+severity: high
+tags:
+  scan_target: mcp
+detection:
+  condition: any
+  conditions:
+    - field: url
+      operator: regex
+      value: "abc"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "rule.yaml"), bad, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := LoadDir(dir, Options{})
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if len(got.DLP)+len(got.Injection) != 0 ||
+		len(got.Skipped) != 1 ||
+		!strings.Contains(got.Skipped[0].Reason, "does not match") {
+		t.Errorf("got DLP=%d Inj=%d Skipped=%+v, want zero imports + one id-mismatch skip",
+			len(got.DLP), len(got.Injection), got.Skipped)
+	}
+}

--- a/internal/rules/atrimport/testdata/all-of-multi.yaml
+++ b/internal/rules/atrimport/testdata/all-of-multi.yaml
@@ -1,0 +1,17 @@
+title: Multi-condition AND rule, skipped because boolean composition is needed
+id: ATR-2026-09005
+status: stable
+detection_tier: pattern
+severity: high
+tags:
+  category: tool-poisoning
+  scan_target: mcp
+detection:
+  condition: all
+  conditions:
+    - field: content
+      operator: regex
+      value: "(?i)token"
+    - field: content
+      operator: regex
+      value: "(?i)leak"

--- a/internal/rules/atrimport/testdata/experimental.yaml
+++ b/internal/rules/atrimport/testdata/experimental.yaml
@@ -1,0 +1,14 @@
+title: Experimental rule, skipped unless opted in
+id: ATR-2026-09003
+status: experimental
+detection_tier: pattern
+severity: high
+tags:
+  category: prompt-injection
+  scan_target: llm
+detection:
+  condition: any
+  conditions:
+    - field: content
+      operator: regex
+      value: "(?i)experimental probe"

--- a/internal/rules/atrimport/testdata/non-regex.yaml
+++ b/internal/rules/atrimport/testdata/non-regex.yaml
@@ -1,0 +1,14 @@
+title: Behavioral rule, skipped because tier is not pattern
+id: ATR-2026-09004
+status: stable
+detection_tier: behavioral
+severity: high
+tags:
+  category: agent-manipulation
+  scan_target: mcp
+detection:
+  condition: any
+  conditions:
+    - field: content
+      operator: similarity
+      value: "0.9"

--- a/internal/rules/atrimport/testdata/regex-content.yaml
+++ b/internal/rules/atrimport/testdata/regex-content.yaml
@@ -1,0 +1,18 @@
+title: Test rule with two regex conditions on content
+id: ATR-2026-09001
+status: stable
+detection_tier: pattern
+severity: high
+tags:
+  category: prompt-injection
+  scan_target: llm
+  confidence: high
+detection:
+  condition: any
+  conditions:
+    - field: content
+      operator: regex
+      value: "(?i)ignore previous instructions"
+    - field: content
+      operator: regex
+      value: "(?i)reveal your system prompt"

--- a/internal/rules/atrimport/testdata/regex-url.yaml
+++ b/internal/rules/atrimport/testdata/regex-url.yaml
@@ -1,0 +1,15 @@
+title: Test rule with regex on URL (lands in DLP bucket)
+id: ATR-2026-09002
+status: stable
+detection_tier: pattern
+severity: medium
+tags:
+  category: data-poisoning
+  scan_target: mcp
+  confidence: high
+detection:
+  condition: any
+  conditions:
+    - field: url
+      operator: regex
+      value: "(?i)attacker\\.example\\.com"


### PR DESCRIPTION
## What

Adds an opt-in adapter at `internal/rules/atrimport/` that loads
Agent Threat Rules (ATR) YAML files and converts the regex-based
subset into the existing `config.DLPPattern` and
`config.ResponseScanPattern` types.

The adapter does not touch the signed bundle pipeline at
`internal/rules/`. Operators who do not call `atrimport.LoadDir`
see no behaviour change.

## Why

ATR is an MIT-licensed external detection standard for AI agent
threats (419 rules across 10 categories as of 2026-05). It is
already in production at:

- microsoft/agent-governance-toolkit (PR #908, merged)
- cisco-ai-defense/skill-scanner (PR #79, merged)
- MISP taxonomies and galaxy (#323, #1207, merged)
- OWASP Agentic-Security-Resources-Hub (#74, merged)

Operators running Pipelock against agents that also need to satisfy
those ecosystems were previously copy-pasting regexes by hand. This
adapter makes the import a one-line call.

As discussed on open-telemetry/semantic-conventions-genai#132, the
two projects share an interest in standard names for agent-threat
detection attributes; this PR is the read-only feeder side of that
conversation, not the OTel side.

## Design

- Read-only. ATR's release cadence and trust root are separate from
  Pipelock's signed bundles, so wrapping ATR into the signed bundle
  format would conflate two trust models. The adapter keeps them
  apart.
- Surfaces what is dropped. ATR rules with `detection_tier:
  behavioral`, multi-condition `all` rules, or non-regex operators
  are recorded in `Result.Skipped` with a per-rule reason, not
  silently ignored.
- Safety caps: 1 MiB per-file size limit, 4096-char regex ceiling,
  2000-rule cap per call.
- Filters: `MinSeverity`, `IncludeExperimental`, `ScanTargets`
  allow list. All default to the conservative posture.

## Files

- `internal/rules/atrimport/atrimport.go` (241 LOC)
- `internal/rules/atrimport/atrimport_test.go` (181 LOC, 7 test cases)
- 5 testdata YAML fixtures
- `docs/guides/atr-rules-import.md`

## License

Adapter code is Apache-2.0, matching the rest of the core. ATR
upstream is MIT licensed. Both are compatible.

---

**Local CI status:** code self-reviewed against the agent's design; Go is not installed on the authoring machine, so go test/go build were not run locally before push. Pipelock CI should validate. Happy to iterate on any test failures or design concerns.