### PR TITLE
feat(sandbox): bridge MCP sandbox egress through scanner

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1722,13 +1722,20 @@ If `filesystem` is omitted, the default Landlock policy is used (safe for Python
 
 **Containment layers:**
 - **Landlock LSM:** Restricts filesystem access to declared paths. Allowlist model. Protected directories (`~/.ssh`, `~/.aws`, `~/.kube`, etc.) are denied. Only dirs that exist on the system are checked.
-- **Network namespaces:** Agent runs in an isolated network namespace. All traffic is kernel-forced through pipelock's bridge proxy. Raw socket bypass is impossible. For MCP (stdio), no network is needed.
+- **Network namespaces:** Agent runs in an isolated network namespace. All HTTP/HTTPS traffic is kernel-confined to the namespace and routed through pipelock's bridge proxy. Raw socket direct egress is impossible. MCP stdio servers that act as HTTP bridges receive `HTTP_PROXY`/`HTTPS_PROXY` pointing at the in-namespace bridge, so upstream calls still traverse Pipelock's forward-proxy scanner.
 - **Seccomp BPF:** Syscall allowlist (~130 safe syscalls for Go/Python/Node.js). Blocks ptrace, mount, module loading, kexec (KILL). io_uring returns EPERM (allows runtimes like Node.js 22 to fall back to epoll). Clone flags filtered to prevent namespace escape.
+
+For sandboxed MCP stdio servers on Linux, the bridge enables forward-proxy handling internally even when `forward_proxy.enabled` is false in YAML. This is scoped to the sandbox bridge only and does not expose the normal forward proxy listener.
+
+In `--best-effort` mode (for containers without user-namespace support), the bridge still scans traffic but network enforcement is cooperative: a child process that clears `HTTP_PROXY` / `HTTPS_PROXY` can bypass Pipelock.
 
 **Usage:**
 ```bash
 # Sandbox an MCP server
 pipelock mcp proxy --sandbox --config pipelock.yaml -- npx server
+
+# Sandbox a bridge-style MCP server; its outbound HTTP(S) goes through Pipelock
+pipelock mcp proxy --sandbox --config pipelock.yaml -- npx -y @upstash/context7-mcp
 
 # Sandbox a standalone command
 pipelock sandbox --config pipelock.yaml -- python agent.py

--- a/docs/security/current-unsupported-paths.md
+++ b/docs/security/current-unsupported-paths.md
@@ -26,7 +26,7 @@ Some tooling does not honour the standard proxy environment variables. Examples 
 
 MCP servers spoken to over a child-process stdio pipe are not on the network. Pipelock's MCP scanning runs through the `pipelock mcp proxy --` wrapper, which executes the MCP server as a subprocess and inspects messages on the JSON-RPC boundary. An MCP server invoked directly by the agent host, without the wrapper, is not inspected.
 
-**Integrator action.** Every MCP server invocation must run through `pipelock mcp proxy -- COMMAND ARGS`. The `pipelock claude install`, `pipelock cursor install`, and `pipelock jetbrains install` subcommands rewrite first-party agent host configuration to insert the wrapper. For agent hosts that are not first-party, the operator inserts the wrapper by editing the host configuration directly.
+**Integrator action.** Every MCP server invocation must run through `pipelock mcp proxy -- COMMAND ARGS`. The `pipelock claude install`, `pipelock cursor install`, and `pipelock jetbrains install` subcommands rewrite first-party agent host configuration to insert the wrapper. For agent hosts that are not first-party, the operator inserts the wrapper by editing the host configuration directly. When `--sandbox` is enabled for a wrapped stdio server on Linux, bridge-style MCP servers that make their own HTTP(S) upstream calls are routed through Pipelock's in-namespace bridge and parent forward-proxy scanner.
 
 ## UDP and direct DNS egress
 

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -994,23 +994,14 @@ signed action receipts for MCP decisions.`,
 					}
 				}
 
-				var bridge *mcpSandboxBridge
-				if runtime.GOOS == "linux" {
-					var bridgeErr error
-					bridge, bridgeErr = startMCPSandboxBridge(ctx, cfg, ks, auditLogger, mcpMetrics, receiptEmitter, envEmitter)
-					if bridgeErr != nil {
-						return bridgeErr
-					}
-					defer bridge.Close()
-					launchCfg.BridgeSocketPath = bridge.SocketPath()
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
-						"pipelock: MCP sandbox egress bridge enabled; forward_proxy forced on for sandboxed MCP egress (child loopback -> parent scanner)\n")
-				} else {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
-						"pipelock: WARNING: MCP sandbox egress bridge is Linux-only; bridge-style MCP servers on %s may need separate egress controls to ensure upstream HTTP(S) traverses pipelock. "+
-							"Configure the MCP server to use pipelock's forward proxy listener via HTTPS_PROXY and disable any built-in proxy bypass.\n",
-						runtime.GOOS)
+				closeBridge, bridgeErr := setupMCPSandboxBridge(
+					ctx, runtime.GOOS, cfg, ks, auditLogger, mcpMetrics, receiptEmitter, envEmitter,
+					cmd.ErrOrStderr(), &launchCfg, startMCPSandboxBridge,
+				)
+				if bridgeErr != nil {
+					return bridgeErr
 				}
+				defer closeBridge()
 
 				sandboxCmd, sErr := sandbox.PrepareSandboxCmd(launchCfg)
 				if sErr != nil {

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -991,6 +992,24 @@ signed action receipts for MCP decisions.`,
 					if err := mcp.VerifyBinaryIntegrity(serverCmd, &cfg.MCPBinaryIntegrity, cmd.ErrOrStderr()); err != nil {
 						return err
 					}
+				}
+
+				var bridge *mcpSandboxBridge
+				if runtime.GOOS == "linux" {
+					var bridgeErr error
+					bridge, bridgeErr = startMCPSandboxBridge(ctx, cfg, ks, auditLogger, mcpMetrics, receiptEmitter, envEmitter)
+					if bridgeErr != nil {
+						return bridgeErr
+					}
+					defer bridge.Close()
+					launchCfg.BridgeSocketPath = bridge.SocketPath()
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+						"pipelock: MCP sandbox egress bridge enabled; forward_proxy forced on for sandboxed MCP egress (child loopback -> parent scanner)\n")
+				} else {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+						"pipelock: WARNING: MCP sandbox egress bridge is Linux-only; bridge-style MCP servers on %s may need separate egress controls to ensure upstream HTTP(S) traverses pipelock. "+
+							"Configure the MCP server to use pipelock's forward proxy listener via HTTPS_PROXY and disable any built-in proxy bypass.\n",
+						runtime.GOOS)
 				}
 
 				sandboxCmd, sErr := sandbox.PrepareSandboxCmd(launchCfg)

--- a/internal/cli/runtime/mcp_sandbox_bridge.go
+++ b/internal/cli/runtime/mcp_sandbox_bridge.go
@@ -6,6 +6,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -23,6 +24,16 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
+type startMCPSandboxBridgeFunc func(
+	context.Context,
+	*config.Config,
+	*killswitch.Controller,
+	*audit.Logger,
+	*metrics.Metrics,
+	*receipt.Emitter,
+	*envelope.Emitter,
+) (*mcpSandboxBridge, error)
+
 type mcpSandboxBridge struct {
 	dir        string
 	socketPath string
@@ -34,6 +45,37 @@ type mcpSandboxBridge struct {
 	mu         sync.Mutex
 	conns      map[net.Conn]struct{}
 	closed     bool
+}
+
+func setupMCPSandboxBridge(
+	ctx context.Context,
+	goos string,
+	cfg *config.Config,
+	ks *killswitch.Controller,
+	log *audit.Logger,
+	m *metrics.Metrics,
+	receiptEmitter *receipt.Emitter,
+	envEmitter *envelope.Emitter,
+	stderr io.Writer,
+	launchCfg *sandbox.LaunchConfig,
+	startBridge startMCPSandboxBridgeFunc,
+) (func(), error) {
+	if goos != "linux" {
+		_, _ = fmt.Fprintf(stderr,
+			"pipelock: WARNING: MCP sandbox egress bridge is Linux-only; bridge-style MCP servers on %s may need separate egress controls to ensure upstream HTTP(S) traverses pipelock. "+
+				"Configure the MCP server to use pipelock's forward proxy listener via HTTPS_PROXY and disable any built-in proxy bypass.\n",
+			goos)
+		return func() {}, nil
+	}
+
+	bridge, err := startBridge(ctx, cfg, ks, log, m, receiptEmitter, envEmitter)
+	if err != nil {
+		return nil, err
+	}
+	launchCfg.BridgeSocketPath = bridge.SocketPath()
+	_, _ = fmt.Fprintf(stderr,
+		"pipelock: MCP sandbox egress bridge enabled; forward_proxy forced on for sandboxed MCP egress (child loopback -> parent scanner)\n")
+	return bridge.Close, nil
 }
 
 func startMCPSandboxBridge(
@@ -108,7 +150,7 @@ func startMCPSandboxBridge(
 				return
 			}
 			bridge.connWg.Add(1)
-			go func() {
+			go func(conn net.Conn) {
 				defer bridge.connWg.Done()
 				defer bridge.untrackConn(conn)
 				srv := &http.Server{
@@ -117,7 +159,7 @@ func startMCPSandboxBridge(
 					IdleTimeout:       30 * time.Second,
 				}
 				_ = srv.Serve(&singleConnListener{conn: conn})
-			}()
+			}(conn)
 		}
 	}()
 

--- a/internal/cli/runtime/mcp_sandbox_bridge.go
+++ b/internal/cli/runtime/mcp_sandbox_bridge.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/envelope"
+	"github.com/luckyPipewrench/pipelock/internal/killswitch"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/sandbox"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+type mcpSandboxBridge struct {
+	dir        string
+	socketPath string
+	listener   net.Listener
+	scanner    *scanner.Scanner
+	acceptDone chan struct{}
+	connWg     sync.WaitGroup
+	closeOnce  sync.Once
+	mu         sync.Mutex
+	conns      map[net.Conn]struct{}
+	closed     bool
+}
+
+func startMCPSandboxBridge(
+	ctx context.Context,
+	cfg *config.Config,
+	ks *killswitch.Controller,
+	log *audit.Logger,
+	m *metrics.Metrics,
+	receiptEmitter *receipt.Emitter,
+	envEmitter *envelope.Emitter,
+) (*mcpSandboxBridge, error) {
+	dir, err := os.MkdirTemp("", "pl-mcp-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating MCP sandbox bridge dir: %w", err)
+	}
+
+	bridge := &mcpSandboxBridge{dir: dir}
+	bridge.socketPath = sandbox.ProxySocketPath(dir)
+
+	ln, err := (&net.ListenConfig{}).Listen(ctx, "unix", bridge.socketPath)
+	if err != nil {
+		bridge.Close()
+		return nil, fmt.Errorf("MCP sandbox bridge listen: %w", err)
+	}
+	bridge.listener = ln
+
+	if err := os.Chmod(bridge.socketPath, 0o600); err != nil {
+		bridge.Close()
+		return nil, fmt.Errorf("MCP sandbox bridge socket permissions: %w", err)
+	}
+
+	egressCfg := cfg.Clone()
+	egressCfg.ForwardProxy.Enabled = true
+	bridge.scanner = scanner.New(egressCfg)
+	if m == nil {
+		m = metrics.New()
+	}
+	bridge.scanner.SetDLPWarnHook(func(ctx context.Context, patternName, severity string) {
+		emitDLPWarn(log, m, receiptEmitter, ctx, patternName, severity)
+	})
+
+	p, err := proxy.New(
+		egressCfg,
+		log,
+		bridge.scanner,
+		m,
+		proxy.WithKillSwitch(ks),
+		proxy.WithReceiptEmitter(receiptEmitter),
+		proxy.WithEnvelopeEmitter(envEmitter),
+	)
+	if err != nil {
+		bridge.Close()
+		return nil, fmt.Errorf("MCP sandbox bridge proxy init: %w", err)
+	}
+	handler := p.Handler()
+	bridge.conns = make(map[net.Conn]struct{})
+
+	bridge.acceptDone = make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		bridge.Close()
+	}()
+	go func() {
+		defer close(bridge.acceptDone)
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			if !bridge.trackConn(conn) {
+				_ = conn.Close()
+				return
+			}
+			bridge.connWg.Add(1)
+			go func() {
+				defer bridge.connWg.Done()
+				defer bridge.untrackConn(conn)
+				srv := &http.Server{
+					Handler:           handler,
+					ReadHeaderTimeout: 30 * time.Second,
+					IdleTimeout:       30 * time.Second,
+				}
+				_ = srv.Serve(&singleConnListener{conn: conn})
+			}()
+		}
+	}()
+
+	return bridge, nil
+}
+
+func (b *mcpSandboxBridge) SocketPath() string {
+	if b == nil {
+		return ""
+	}
+	return b.socketPath
+}
+
+func (b *mcpSandboxBridge) Close() {
+	if b == nil {
+		return
+	}
+	b.closeOnce.Do(func() {
+		conns := b.markClosed()
+		if b.listener != nil {
+			_ = b.listener.Close()
+		}
+		for _, conn := range conns {
+			_ = conn.Close()
+		}
+		if b.acceptDone != nil {
+			<-b.acceptDone
+		}
+		b.connWg.Wait()
+		if b.scanner != nil {
+			b.scanner.Close()
+		}
+		if b.dir != "" {
+			_ = os.RemoveAll(b.dir)
+		}
+	})
+}
+
+func (b *mcpSandboxBridge) trackConn(conn net.Conn) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return false
+	}
+	if b.conns != nil {
+		b.conns[conn] = struct{}{}
+	}
+	return true
+}
+
+func (b *mcpSandboxBridge) untrackConn(conn net.Conn) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.conns != nil {
+		delete(b.conns, conn)
+	}
+}
+
+func (b *mcpSandboxBridge) markClosed() []net.Conn {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.closed = true
+	conns := make([]net.Conn, 0, len(b.conns))
+	for conn := range b.conns {
+		conns = append(conns, conn)
+	}
+	return conns
+}

--- a/internal/cli/runtime/mcp_sandbox_bridge_test.go
+++ b/internal/cli/runtime/mcp_sandbox_bridge_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/killswitch"
+)
+
+func TestStartMCPSandboxBridge_ForcesForwardProxyIntoScanner(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "bridge-ok")
+	}))
+	t.Cleanup(upstream.Close)
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.ForwardProxy.Enabled = false
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	bridge, err := startMCPSandboxBridge(ctx, cfg, killswitch.New(cfg), audit.NewNop(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("startMCPSandboxBridge: %v", err)
+	}
+	t.Cleanup(bridge.Close)
+
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", bridge.SocketPath())
+	if err != nil {
+		t.Fatalf("dial bridge socket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_, _ = fmt.Fprintf(conn, "GET %s HTTP/1.1\r\nHost: ignored.invalid\r\nConnection: close\r\n\r\n", upstream.URL)
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want scanner block 403; body=%q", resp.StatusCode, string(body))
+	}
+	if got := string(body); !strings.Contains(got, "SSRF") {
+		t.Fatalf("body = %q, want scanner SSRF block", got)
+	}
+	if cfg.ForwardProxy.Enabled {
+		t.Fatal("startMCPSandboxBridge mutated caller config")
+	}
+}
+
+func TestStartMCPSandboxBridge_CONNECTThroughScanner(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	targetLn, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen target: %v", err)
+	}
+	t.Cleanup(func() { _ = targetLn.Close() })
+
+	go func() {
+		conn, acceptErr := targetLn.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		buf := make([]byte, 4)
+		if _, readErr := io.ReadFull(conn, buf); readErr != nil {
+			return
+		}
+		_, _ = conn.Write([]byte("pong"))
+	}()
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8"}
+	cfg.ForwardProxy.Enabled = false
+
+	bridge, err := startMCPSandboxBridge(ctx, cfg, killswitch.New(cfg), audit.NewNop(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("startMCPSandboxBridge: %v", err)
+	}
+	t.Cleanup(bridge.Close)
+
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", bridge.SocketPath())
+	if err != nil {
+		t.Fatalf("dial bridge socket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	target := targetLn.Addr().String()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("CONNECT status = %d, want 200; body=%q", resp.StatusCode, string(body))
+	}
+
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatalf("write tunnel payload: %v", err)
+	}
+	got := make([]byte, 4)
+	if _, err := io.ReadFull(br, got); err != nil {
+		t.Fatalf("read tunnel payload: %v", err)
+	}
+	if string(got) != "pong" {
+		t.Fatalf("tunnel echo = %q, want pong", string(got))
+	}
+}
+
+func TestStartMCPSandboxBridge_ContextCancelClosesTunnel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	targetLn, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen target: %v", err)
+	}
+	t.Cleanup(func() { _ = targetLn.Close() })
+
+	targetSeen := make(chan struct{})
+	go func() {
+		conn, acceptErr := targetLn.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		buf := make([]byte, 4)
+		if _, readErr := io.ReadFull(conn, buf); readErr == nil {
+			close(targetSeen)
+		}
+		_, _ = io.Copy(io.Discard, conn)
+	}()
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8"}
+	cfg.ForwardProxy.Enabled = false
+
+	bridge, err := startMCPSandboxBridge(ctx, cfg, killswitch.New(cfg), audit.NewNop(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("startMCPSandboxBridge: %v", err)
+	}
+	t.Cleanup(bridge.Close)
+
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", bridge.SocketPath())
+	if err != nil {
+		t.Fatalf("dial bridge socket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	target := targetLn.Addr().String()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("CONNECT status = %d, want 200; body=%q", resp.StatusCode, string(body))
+	}
+
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatalf("write tunnel payload: %v", err)
+	}
+	select {
+	case <-targetSeen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("target did not receive tunnel payload before cancel")
+	}
+
+	cancel()
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 1)
+	if n, err := br.Read(buf); err == nil {
+		t.Fatalf("read after cancel succeeded with %d byte(s), want closed tunnel", n)
+	}
+}
+
+func TestStartMCPSandboxBridge_KillSwitchBlocks(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.KillSwitch.Enabled = true
+	cfg.KillSwitch.Message = "bridge denied"
+	cfg.ForwardProxy.Enabled = false
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	bridge, err := startMCPSandboxBridge(ctx, cfg, killswitch.New(cfg), audit.NewNop(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("startMCPSandboxBridge: %v", err)
+	}
+	t.Cleanup(bridge.Close)
+
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", bridge.SocketPath())
+	if err != nil {
+		t.Fatalf("dial bridge socket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_, _ = fmt.Fprint(conn, "GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n")
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%q", resp.StatusCode, string(body))
+	}
+	if got := string(body); !strings.Contains(got, "kill_switch_active") {
+		t.Fatalf("body = %q, want kill_switch_active", got)
+	}
+}

--- a/internal/cli/runtime/mcp_sandbox_bridge_test.go
+++ b/internal/cli/runtime/mcp_sandbox_bridge_test.go
@@ -5,7 +5,9 @@ package runtime
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -17,8 +19,152 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/sandbox"
 )
+
+func TestSetupMCPSandboxBridge_LinuxStartsBridge(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	ks := killswitch.New(cfg)
+	var stderr bytes.Buffer
+	launchCfg := sandbox.LaunchConfig{}
+	started := false
+
+	closeBridge, err := setupMCPSandboxBridge(
+		context.Background(),
+		"linux",
+		cfg,
+		ks,
+		audit.NewNop(),
+		nil,
+		nil,
+		nil,
+		&stderr,
+		&launchCfg,
+		func(context.Context, *config.Config, *killswitch.Controller, *audit.Logger, *metrics.Metrics, *receipt.Emitter, *envelope.Emitter) (*mcpSandboxBridge, error) {
+			started = true
+			return &mcpSandboxBridge{socketPath: "/tmp/pl-mcp-test/proxy.sock"}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("setupMCPSandboxBridge: %v", err)
+	}
+	if !started {
+		t.Fatal("bridge starter was not called")
+	}
+	if launchCfg.BridgeSocketPath != "/tmp/pl-mcp-test/proxy.sock" {
+		t.Fatalf("BridgeSocketPath = %q", launchCfg.BridgeSocketPath)
+	}
+	if got := stderr.String(); !strings.Contains(got, "MCP sandbox egress bridge enabled") {
+		t.Fatalf("stderr = %q, want bridge enabled message", got)
+	}
+	closeBridge()
+}
+
+func TestSetupMCPSandboxBridge_StartError(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	wantErr := errors.New("bridge unavailable")
+	launchCfg := sandbox.LaunchConfig{}
+
+	closeBridge, err := setupMCPSandboxBridge(
+		context.Background(),
+		"linux",
+		cfg,
+		killswitch.New(cfg),
+		audit.NewNop(),
+		nil,
+		nil,
+		nil,
+		io.Discard,
+		&launchCfg,
+		func(context.Context, *config.Config, *killswitch.Controller, *audit.Logger, *metrics.Metrics, *receipt.Emitter, *envelope.Emitter) (*mcpSandboxBridge, error) {
+			return nil, wantErr
+		},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if closeBridge != nil {
+		t.Fatal("closeBridge should be nil on start error")
+	}
+	if launchCfg.BridgeSocketPath != "" {
+		t.Fatalf("BridgeSocketPath = %q, want empty", launchCfg.BridgeSocketPath)
+	}
+}
+
+func TestSetupMCPSandboxBridge_NonLinuxWarns(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	var stderr bytes.Buffer
+	launchCfg := sandbox.LaunchConfig{}
+	started := false
+
+	closeBridge, err := setupMCPSandboxBridge(
+		context.Background(),
+		"darwin",
+		cfg,
+		killswitch.New(cfg),
+		audit.NewNop(),
+		nil,
+		nil,
+		nil,
+		&stderr,
+		&launchCfg,
+		func(context.Context, *config.Config, *killswitch.Controller, *audit.Logger, *metrics.Metrics, *receipt.Emitter, *envelope.Emitter) (*mcpSandboxBridge, error) {
+			started = true
+			return nil, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("setupMCPSandboxBridge: %v", err)
+	}
+	if started {
+		t.Fatal("bridge starter should not run on non-Linux")
+	}
+	if launchCfg.BridgeSocketPath != "" {
+		t.Fatalf("BridgeSocketPath = %q, want empty", launchCfg.BridgeSocketPath)
+	}
+	got := stderr.String()
+	if !strings.Contains(got, "Linux-only") || !strings.Contains(got, "HTTPS_PROXY") {
+		t.Fatalf("stderr = %q, want actionable non-Linux warning", got)
+	}
+	closeBridge()
+}
+
+func TestMCPSandboxBridgeHelpers_NilAndClosed(t *testing.T) {
+	t.Parallel()
+
+	var nilBridge *mcpSandboxBridge
+	if nilBridge.SocketPath() != "" {
+		t.Fatal("nil bridge SocketPath should be empty")
+	}
+	nilBridge.Close()
+
+	trackedConn, peerConn := net.Pipe()
+	t.Cleanup(func() { _ = peerConn.Close() })
+
+	bridge := &mcpSandboxBridge{
+		conns: map[net.Conn]struct{}{
+			trackedConn: {},
+		},
+	}
+	conns := bridge.markClosed()
+	if len(conns) != 1 || conns[0] != trackedConn {
+		t.Fatalf("markClosed tracked %d conn(s), want original tracked conn", len(conns))
+	}
+	if bridge.trackConn(peerConn) {
+		t.Fatal("trackConn succeeded after bridge was marked closed")
+	}
+	bridge.Close()
+}
 
 func TestStartMCPSandboxBridge_ForcesForwardProxyIntoScanner(t *testing.T) {
 	t.Parallel()
@@ -216,6 +362,7 @@ func TestStartMCPSandboxBridge_KillSwitchBlocks(t *testing.T) {
 	t.Parallel()
 
 	cfg := config.Defaults()
+	cfg.Internal = nil
 	cfg.KillSwitch.Enabled = true
 	cfg.KillSwitch.Message = "bridge denied"
 	cfg.ForwardProxy.Enabled = false

--- a/internal/sandbox/child_init.go
+++ b/internal/sandbox/child_init.go
@@ -254,9 +254,7 @@ func exitBridgeChild(err error) {
 	if errors.As(err, &exitErr) {
 		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
 			sig := status.Signal()
-			signal.Reset(sig)
-			_ = syscall.Kill(syscall.Getpid(), sig)
-			os.Exit(128 + int(sig))
+			terminateSelfWithSignal(sig)
 		}
 		os.Exit(exitErr.ExitCode())
 	}

--- a/internal/sandbox/child_init.go
+++ b/internal/sandbox/child_init.go
@@ -11,8 +11,13 @@
 package sandbox
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 )
@@ -24,6 +29,7 @@ func RunInit() {
 	workspace := os.Getenv("__PIPELOCK_SANDBOX_WORKSPACE")
 	commandStr := os.Getenv("__PIPELOCK_SANDBOX_COMMAND")
 	extraEnvStr := os.Getenv("__PIPELOCK_SANDBOX_EXTRA_ENV")
+	socketPath := os.Getenv(sandboxSocketEnv)
 
 	if workspace == "" || commandStr == "" {
 		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] missing workspace or command env vars\n")
@@ -66,6 +72,15 @@ func RunInit() {
 	// this prevents cross-sandbox data leakage via temp files.
 	policy := resolvePolicy(workspace)
 	policy.AllowRWDirs = append(policy.AllowRWDirs, sandboxDir)
+	if socketPath != "" {
+		// Bridge mode grants RW to a fresh 0o700 per-invocation dir so the
+		// child can connect to proxy.sock. The parent owns the bound socket
+		// inode for this session and removes the whole dir on teardown.
+		// A malicious child can create files in the dir, but the parent never
+		// reopens proxy.sock after binding it, so replacement affects no future
+		// parent listener and dies with the per-invocation directory.
+		policy.AllowRWDirs = append(policy.AllowRWDirs, filepath.Dir(socketPath))
+	}
 	llStatus, llErr := ApplyLandlock(policy)
 	reportLayer(os.Stderr, llStatus, llErr)
 
@@ -103,6 +118,14 @@ func RunInit() {
 				"For kernel-enforced isolation, run under a user namespace (CLONE_NEWUSER) or use the companion-proxy topology from `pipelock init sidecar`.\n")
 	} else {
 		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] network: ACTIVE (isolated namespace)\n")
+		if socketPath != "" {
+			// MCP stdio servers only need loopback when the bridge is wired.
+			// Keeping it down otherwise preserves the empty-netns posture.
+			if err := bringUpLoopback(); err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "[sandbox] loopback: %v\n", err)
+				os.Exit(1)
+			}
+		}
 	}
 
 	// Report summary.
@@ -119,11 +142,16 @@ func RunInit() {
 		os.Exit(1)
 	}
 
+	if socketPath != "" {
+		runInitWithBridge(command, env, workspace, socketPath)
+		return
+	}
+
 	// Clear sandbox env vars.
 	for _, key := range []string{
 		initEnvKey, "__PIPELOCK_SANDBOX_WORKSPACE", "__PIPELOCK_SANDBOX_COMMAND",
 		"__PIPELOCK_SANDBOX_EXTRA_ENV", "__PIPELOCK_SANDBOX_POLICY",
-		noNetNSEnvKey,
+		sandboxSocketEnv, noNetNSEnvKey,
 	} {
 		env = removeEnvKey(env, key)
 	}
@@ -143,4 +171,81 @@ func RunInit() {
 	err = syscall.Exec(binary, command, env) //nolint:gosec // G204: intentional exec of user-specified command
 	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] exec failed: %v\n", err)
 	os.Exit(1)
+}
+
+func runInitWithBridge(command, env []string, workspace, socketPath string) {
+	noNetNS := IsNoNetNS()
+	bridgeAddr := ""
+	if noNetNS {
+		bridgeAddr = "127.0.0.1:0"
+	}
+	bridge, err := NewBridgeProxy(socketPath, bridgeAddr)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] bridge proxy: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	go bridge.Serve(ctx)
+	defer bridge.Close()
+
+	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] bridge proxy: %s → %s\n", bridge.Addr(), socketPath)
+
+	env = appendBridgeProxyEnv(env, bridge.Addr())
+
+	for _, key := range []string{
+		initEnvKey, "__PIPELOCK_SANDBOX_WORKSPACE", "__PIPELOCK_SANDBOX_COMMAND",
+		"__PIPELOCK_SANDBOX_EXTRA_ENV", "__PIPELOCK_SANDBOX_POLICY",
+		sandboxSocketEnv, noNetNSEnvKey,
+	} {
+		env = removeEnvKey(env, key)
+	}
+
+	binary, err := lookPathIn(command[0], env)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] command not found: %s (%v)\n", command[0], err)
+		os.Exit(127)
+	}
+
+	childCmd := exec.CommandContext(ctx, binary, command[1:]...) //nolint:gosec // G204: user-specified MCP server command
+	childCmd.Stdin = os.Stdin
+	childCmd.Stdout = os.Stdout
+	childCmd.Stderr = os.Stderr
+	childCmd.Env = env
+	childCmd.Dir = workspace
+
+	if err := childCmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.ExitCode())
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] command error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func appendBridgeProxyEnv(env []string, addr string) []string {
+	env = removeProxyEnvKeys(env)
+	// addr comes from BridgeProxy.Addr(), so it is a listener-backed host:port.
+	proxyURL := "http://" + addr
+	return append(env,
+		"HTTP_PROXY="+proxyURL,
+		"HTTPS_PROXY="+proxyURL,
+		"http_proxy="+proxyURL,
+		"https_proxy="+proxyURL,
+	)
+}
+
+func removeProxyEnvKeys(env []string) []string {
+	result := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && strings.HasSuffix(strings.ToUpper(key), "_PROXY") {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return result
 }

--- a/internal/sandbox/child_init.go
+++ b/internal/sandbox/child_init.go
@@ -185,11 +185,12 @@ func runInitWithBridge(command, env []string, workspace, socketPath string) {
 		os.Exit(1)
 	}
 
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
 
 	go bridge.Serve(ctx)
-	defer bridge.Close()
 
 	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] bridge proxy: %s → %s\n", bridge.Addr(), socketPath)
 
@@ -205,25 +206,62 @@ func runInitWithBridge(command, env []string, workspace, socketPath string) {
 
 	binary, err := lookPathIn(command[0], env)
 	if err != nil {
+		cancel()
+		bridge.Close()
 		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] command not found: %s (%v)\n", command[0], err)
 		os.Exit(127)
 	}
 
-	childCmd := exec.CommandContext(ctx, binary, command[1:]...) //nolint:gosec // G204: user-specified MCP server command
+	childCmd := exec.CommandContext(context.Background(), binary, command[1:]...) //nolint:gosec // G204: user-specified MCP server command; signal lifecycle is handled explicitly below.
 	childCmd.Stdin = os.Stdin
 	childCmd.Stdout = os.Stdout
 	childCmd.Stderr = os.Stderr
 	childCmd.Env = env
 	childCmd.Dir = workspace
 
-	if err := childCmd.Run(); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			os.Exit(exitErr.ExitCode())
-		}
+	if err := childCmd.Start(); err != nil {
+		cancel()
+		bridge.Close()
 		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] command error: %v\n", err)
 		os.Exit(1)
 	}
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- childCmd.Wait()
+	}()
+
+	for {
+		select {
+		case sig := <-sigCh:
+			if sig != nil && childCmd.Process != nil {
+				_ = childCmd.Process.Signal(sig)
+			}
+		case err := <-waitCh:
+			cancel()
+			bridge.Close()
+			exitBridgeChild(err)
+			return
+		}
+	}
+}
+
+func exitBridgeChild(err error) {
+	if err == nil {
+		return
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+			sig := status.Signal()
+			signal.Reset(sig)
+			_ = syscall.Kill(syscall.Getpid(), sig)
+			os.Exit(128 + int(sig))
+		}
+		os.Exit(exitErr.ExitCode())
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] command error: %v\n", err)
+	os.Exit(1)
 }
 
 func appendBridgeProxyEnv(env []string, addr string) []string {

--- a/internal/sandbox/child_standalone_init.go
+++ b/internal/sandbox/child_standalone_init.go
@@ -28,7 +28,7 @@ import (
 func RunStandaloneInit() {
 	workspace := os.Getenv("__PIPELOCK_SANDBOX_WORKSPACE")
 	commandStr := os.Getenv("__PIPELOCK_SANDBOX_COMMAND")
-	socketPath := os.Getenv("__PIPELOCK_SANDBOX_SOCKET")
+	socketPath := os.Getenv(sandboxSocketEnv)
 	extraEnvStr := os.Getenv("__PIPELOCK_SANDBOX_EXTRA_ENV")
 
 	if workspace == "" || commandStr == "" || socketPath == "" {
@@ -68,6 +68,12 @@ func RunStandaloneInit() {
 	policy.AllowRWDirs = append(policy.AllowRWDirs, sandboxDir)
 	// The socket's parent dir must be accessible for the bridge proxy.
 	if socketPath != "" {
+		// Bridge mode grants RW to a fresh 0o700 per-invocation dir so the
+		// child can connect to proxy.sock. The parent owns the bound socket
+		// inode for this session and removes the whole dir on teardown.
+		// A malicious child can create files in the dir, but the parent never
+		// reopens proxy.sock after binding it, so replacement affects no future
+		// parent listener and dies with the per-invocation directory.
 		policy.AllowRWDirs = append(policy.AllowRWDirs, filepath.Dir(socketPath))
 	}
 	llStatus, llErr := ApplyLandlock(policy)
@@ -151,19 +157,13 @@ func RunStandaloneInit() {
 	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] bridge proxy: %s → %s\n", bridge.Addr(), socketPath)
 
 	// Add HTTP_PROXY/HTTPS_PROXY to agent's environment.
-	proxyURL := "http://" + bridge.Addr()
-	env = append(env,
-		"HTTP_PROXY="+proxyURL,
-		"HTTPS_PROXY="+proxyURL,
-		"http_proxy="+proxyURL,
-		"https_proxy="+proxyURL,
-	)
+	env = appendBridgeProxyEnv(env, bridge.Addr())
 
 	// Clean sandbox env vars.
 	for _, key := range []string{
 		standaloneInitEnv, initEnvKey,
 		"__PIPELOCK_SANDBOX_WORKSPACE", "__PIPELOCK_SANDBOX_COMMAND",
-		"__PIPELOCK_SANDBOX_SOCKET", "__PIPELOCK_SANDBOX_EXTRA_ENV",
+		sandboxSocketEnv, "__PIPELOCK_SANDBOX_EXTRA_ENV",
 		"__PIPELOCK_SANDBOX_POLICY", noNetNSEnvKey,
 	} {
 		env = removeEnvKey(env, key)

--- a/internal/sandbox/env.go
+++ b/internal/sandbox/env.go
@@ -121,7 +121,7 @@ func SyntheticEnv(sandboxDir, workspace string, extraEnv []string) ([]string, er
 	// Validate against dangerous keys that could subvert containment.
 	for _, entry := range extraEnv {
 		key, _, _ := strings.Cut(entry, "=")
-		if dangerousEnvKeys[key] {
+		if IsDangerousEnvKey(key) {
 			return nil, fmt.Errorf("sandbox: env key %q is blocked (could subvert containment)", key)
 		}
 		env = append(env, entry)

--- a/internal/sandbox/env.go
+++ b/internal/sandbox/env.go
@@ -27,7 +27,11 @@ var safePassthroughKeys = []string{
 // injecting code before the agent process starts.
 // IsDangerousEnvKey returns true if the key could subvert sandbox containment.
 func IsDangerousEnvKey(key string) bool {
-	return dangerousEnvKeys[key]
+	if dangerousEnvKeys[key] {
+		return true
+	}
+	upper := strings.ToUpper(key)
+	return strings.HasSuffix(upper, "_PROXY")
 }
 
 var dangerousEnvKeys = map[string]bool{

--- a/internal/sandbox/env_dangerous_test.go
+++ b/internal/sandbox/env_dangerous_test.go
@@ -22,6 +22,9 @@ func TestIsDangerousEnvKey(t *testing.T) {
 		{name: "BASH_ENV", key: "BASH_ENV", want: true},
 		{name: "ENV", key: "ENV", want: true},
 		{name: "CDPATH", key: "CDPATH", want: true},
+		{name: "HTTP_PROXY", key: "HTTP_PROXY", want: true},
+		{name: "mixed-case proxy", key: "Http_Proxy", want: true},
+		{name: "NO_PROXY", key: "NO_PROXY", want: true},
 
 		// Safe keys that should NOT be flagged.
 		{name: "PATH is safe", key: "PATH", want: false},
@@ -33,7 +36,7 @@ func TestIsDangerousEnvKey(t *testing.T) {
 		{name: "empty string is safe", key: "", want: false},
 		{name: "OPENAI_API_KEY is safe", key: "OPENAI_API_KEY", want: false},
 
-		// Case sensitivity: map keys are exact match.
+		// Non-proxy injection keys are exact match.
 		{name: "lowercase ld_preload is safe", key: "ld_preload", want: false},
 		{name: "mixed case Node_Options is safe", key: "Node_Options", want: false},
 	}

--- a/internal/sandbox/env_test.go
+++ b/internal/sandbox/env_test.go
@@ -222,6 +222,43 @@ func TestSyntheticEnv_AllowsSafeExtraEnv(t *testing.T) {
 	}
 }
 
+func TestAppendBridgeProxyEnvRemovesExistingProxyVars(t *testing.T) {
+	env := []string{
+		"HTTP_PROXY=http://attacker",
+		"Http_Proxy=http://attacker",
+		"HTTPS_proxy=http://attacker",
+		"https_proxy=http://attacker",
+		"ALL_PROXY=socks5://attacker",
+		"NO_proxy=*",
+		"CUSTOM_PROXY=http://attacker",
+		"SAFE=value",
+	}
+
+	got := appendBridgeProxyEnv(env, "127.0.0.1:8888")
+
+	if envValue(got, "HTTP_PROXY") != "http://127.0.0.1:8888" {
+		t.Fatalf("HTTP_PROXY = %q", envValue(got, "HTTP_PROXY"))
+	}
+	if envValue(got, "https_proxy") != "http://127.0.0.1:8888" {
+		t.Fatalf("https_proxy = %q", envValue(got, "https_proxy"))
+	}
+	if envValue(got, "ALL_PROXY") != "" {
+		t.Fatalf("ALL_PROXY should be removed, got %q", envValue(got, "ALL_PROXY"))
+	}
+	if envValue(got, "NO_proxy") != "" {
+		t.Fatalf("NO_proxy should be removed, got %q", envValue(got, "NO_proxy"))
+	}
+	if envValue(got, "Http_Proxy") != "" {
+		t.Fatalf("Http_Proxy should be removed, got %q", envValue(got, "Http_Proxy"))
+	}
+	if envValue(got, "CUSTOM_PROXY") != "" {
+		t.Fatalf("CUSTOM_PROXY should be removed, got %q", envValue(got, "CUSTOM_PROXY"))
+	}
+	if envValue(got, "SAFE") != "value" {
+		t.Fatalf("SAFE = %q", envValue(got, "SAFE"))
+	}
+}
+
 // envValue extracts the value of a key from an env slice.
 func envValue(env []string, key string) string {
 	prefix := key + "="

--- a/internal/sandbox/env_test.go
+++ b/internal/sandbox/env_test.go
@@ -209,6 +209,12 @@ func TestSyntheticEnv_BlocksDangerousExtraEnv(t *testing.T) {
 			t.Errorf("expected error for dangerous env key %q, got nil", key)
 		}
 	}
+	for _, key := range []string{"HTTP_PROXY", "Http_Proxy", "HTTPS_proxy", "NO_proxy", "CUSTOM_PROXY"} {
+		_, err := SyntheticEnv(dir, dir, []string{key + "=http://attacker"})
+		if err == nil {
+			t.Errorf("expected error for proxy env key %q, got nil", key)
+		}
+	}
 }
 
 func TestSyntheticEnv_AllowsSafeExtraEnv(t *testing.T) {

--- a/internal/sandbox/launcher.go
+++ b/internal/sandbox/launcher.go
@@ -45,6 +45,12 @@ type LaunchConfig struct {
 	// ExtraEnv contains additional KEY=VALUE pairs to pass to the child.
 	ExtraEnv []string
 
+	// BridgeSocketPath enables namespace-to-proxy bridge mode. When set,
+	// sandbox-init keeps a child-side loopback proxy alive, injects
+	// HTTP(S)_PROXY for the wrapped command, and forwards those connections
+	// to this parent Unix socket path.
+	BridgeSocketPath string
+
 	// Stdin, Stdout, Stderr are connected to the child process.
 	Stdin  io.Reader
 	Stdout io.Writer
@@ -114,6 +120,9 @@ func PrepareSandboxCmd(cfg LaunchConfig) (*exec.Cmd, error) {
 		initEnvKey + "=1",
 		"__PIPELOCK_SANDBOX_WORKSPACE=" + cfg.Workspace,
 		"__PIPELOCK_SANDBOX_COMMAND=" + strings.Join(cfg.Command, "\x1f"),
+	}
+	if cfg.BridgeSocketPath != "" {
+		cmd.Env = append(cmd.Env, sandboxSocketEnv+"="+cfg.BridgeSocketPath)
 	}
 	if cfg.Strict {
 		cmd.Env = append(cmd.Env, strictEnvKey+"=1")

--- a/internal/sandbox/launcher_darwin.go
+++ b/internal/sandbox/launcher_darwin.go
@@ -32,10 +32,11 @@ type LaunchConfig struct {
 	// no effect on macOS (sandbox-exec doesn't use namespaces).
 	BestEffort bool
 
-	ExtraEnv []string
-	Stdin    io.Reader
-	Stdout   io.Writer
-	Stderr   io.Writer
+	ExtraEnv         []string
+	BridgeSocketPath string // Linux-only; ignored by sandbox-exec.
+	Stdin            io.Reader
+	Stdout           io.Writer
+	Stderr           io.Writer
 }
 
 // StandaloneLaunchConfig configures the standalone sandbox launcher.

--- a/internal/sandbox/launcher_other.go
+++ b/internal/sandbox/launcher_other.go
@@ -23,9 +23,11 @@ type LaunchConfig struct {
 	Strict     bool
 	BestEffort bool
 	ExtraEnv   []string
-	Stdin      io.Reader
-	Stdout     io.Writer
-	Stderr     io.Writer
+	// BridgeSocketPath is Linux-only.
+	BridgeSocketPath string
+	Stdin            io.Reader
+	Stdout           io.Writer
+	Stderr           io.Writer
 }
 
 // StandaloneLaunchConfig configures the standalone sandbox launcher.

--- a/internal/sandbox/signal_self_unix.go
+++ b/internal/sandbox/signal_self_unix.go
@@ -9,10 +9,12 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 )
 
 func terminateSelfWithSignal(sig syscall.Signal) {
 	signal.Reset(sig)
 	_ = syscall.Kill(syscall.Getpid(), sig)
+	time.Sleep(100 * time.Millisecond)
 	os.Exit(128 + int(sig))
 }

--- a/internal/sandbox/signal_self_unix.go
+++ b/internal/sandbox/signal_self_unix.go
@@ -1,0 +1,18 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package sandbox
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func terminateSelfWithSignal(sig syscall.Signal) {
+	signal.Reset(sig)
+	_ = syscall.Kill(syscall.Getpid(), sig)
+	os.Exit(128 + int(sig))
+}

--- a/internal/sandbox/signal_self_windows.go
+++ b/internal/sandbox/signal_self_windows.go
@@ -1,0 +1,15 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package sandbox
+
+import (
+	"os"
+	"syscall"
+)
+
+func terminateSelfWithSignal(sig syscall.Signal) {
+	os.Exit(128 + int(sig))
+}

--- a/internal/sandbox/standalone.go
+++ b/internal/sandbox/standalone.go
@@ -12,6 +12,10 @@ import (
 // (with bridge proxy, unlike MCP mode which uses syscall.Exec).
 const standaloneInitEnv = "__PIPELOCK_SANDBOX_STANDALONE"
 
+// sandboxSocketEnv carries the parent Unix socket path used by sandbox
+// bridge mode. The child-side loopback proxy forwards connections there.
+const sandboxSocketEnv = "__PIPELOCK_SANDBOX_SOCKET"
+
 // IsStandaloneInitMode returns true if the current process is a re-exec'd
 // standalone sandbox child.
 func IsStandaloneInitMode() bool {

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -164,7 +164,7 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 		standaloneInitEnv + "=1",
 		"__PIPELOCK_SANDBOX_WORKSPACE=" + cfg.Workspace,
 		"__PIPELOCK_SANDBOX_COMMAND=" + strings.Join(cfg.Command, "\x1f"),
-		"__PIPELOCK_SANDBOX_SOCKET=" + socketPath,
+		sandboxSocketEnv + "=" + socketPath,
 	}
 	if cfg.Strict {
 		cmd.Env = append(cmd.Env, strictEnvKey+"=1")


### PR DESCRIPTION
## Summary
- route Linux sandboxed MCP subprocess HTTP(S) egress through an in-namespace loopback bridge into Pipelock's forward-proxy scanner
- preserve sandbox network isolation while supporting bridge-style MCP servers that need upstream HTTP(S)
- harden sandbox proxy env handling and document Linux bridge / best-effort behavior

## Testing
- go test -race -count=1 ./...
- golangci-lint run ./...
- git diff --check
- real E2E: built pipelock, ran `pipelock mcp proxy --sandbox` with a sandboxed Python stdlib HTTP client fetching `http://example.com/`; verified 3/3 sandbox layers active and bridge-routed HTTP success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux sandboxed MCP stdio servers can route HTTP/S egress through an in-namespace bridge, subject to parent forward-proxy scanning (DLP/kill-switch) and supporting CONNECT tunnels.
  * Sandboxed launches now inject bridge proxy env vars into child processes for bridge-mode operation.

* **Documentation**
  * Clarified sandbox network containment, proxy env injection, added a “bridge-style MCP server” example, and a best-effort caveat when HTTP_PROXY/HTTPS_PROXY are unset.

* **Behavior**
  * Sandbox now blocks user-supplied *_PROXY env vars from being injected.

* **Tests**
  * Added tests validating bridge startup, proxy enforcement, CONNECT tunnels, cancellation, and kill-switch behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->