### PR TITLE
feat(mcp): attribute Layer/Pattern/Severity on block receipts

### DIFF
--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -281,10 +281,14 @@ func ForwardScannedInput(
 			_, _ = fmt.Fprintf(logW, "pipelock: input line %d: %s\n", lineNum, reason)
 			recordAdaptiveSignal(session.SignalBlock)
 			if pendingActionID != "" && receiptEmitter != nil {
+				layer, pattern, severity := redactionBlockAttribution(redactErr)
 				_, _ = EmitMCPDecision(receiptEmitter, nil, MCPDecision{
 					Receipt: receipt.EmitOpts{
 						ActionID:         pendingActionID,
 						Verdict:          config.ActionBlock,
+						Layer:            layer,
+						Pattern:          pattern,
+						Severity:         severity,
 						RedactionProfile: redactionCfg.Profile,
 						Transport:        opts.Transport,
 						Target:           pendingToolCallName,
@@ -420,7 +424,25 @@ func ForwardScannedInput(
 		emitToolReceipt := func(receiptVerdict string, contractGate ...mcpContractGateOutput) {
 			// Delegate to the shared helper so stdio and HTTP/WS emit
 			// tool receipts through the same EmitMCPDecision entry.
-			emitMCPToolReceipt(receiptEmitter, opts.Transport, redactionCfg.Profile, actionID, verdict.Method, toolCallName, receiptVerdict, taintDecision, redactionReport, contractGate...)
+			layer, pattern, severity := pickAttribution(eval)
+			receiptOpts := mcpToolReceiptOpts{
+				Emitter:          receiptEmitter,
+				Transport:        opts.Transport,
+				RedactionProfile: redactionCfg.Profile,
+				ActionID:         actionID,
+				MCPMethod:        verdict.Method,
+				ToolName:         toolCallName,
+				Verdict:          receiptVerdict,
+				Layer:            layer,
+				Pattern:          pattern,
+				Severity:         severity,
+				Decision:         taintDecision,
+				Report:           redactionReport,
+			}
+			if len(contractGate) > 0 {
+				receiptOpts.ContractGate = &contractGate[0]
+			}
+			emitMCPToolReceipt(receiptOpts)
 		}
 
 		logTaintDecision := func() {

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -275,6 +275,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 						RequestID: requestID,
 						Layer:     "media_policy",
 						Pattern:   mediaResult.BlockReason,
+						Severity:  config.SeverityHigh,
 					},
 				}); emitErr != nil {
 					_, _ = fmt.Fprintf(logW, "pipelock: receipt emission failed: %v\n", emitErr)
@@ -575,6 +576,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 					RequestID: requestID,
 					Layer:     "mcp_response_scan",
 					Pattern:   pattern,
+					Severity:  config.SeverityHigh,
 				},
 			}); emitErr != nil {
 				_, _ = fmt.Fprintf(logW, "pipelock: receipt emission failed: %v\n", emitErr)

--- a/internal/mcp/proxy_http.go
+++ b/internal/mcp/proxy_http.go
@@ -333,13 +333,27 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		Result:    session.PolicyDecisionResult{Decision: session.PolicyAllow, Reason: taintReasonDisabled},
 	}
 	receiptVerdict := ""
+	receiptLayer := ""
+	receiptPattern := ""
+	receiptSeverity := ""
 	var receiptContractGate *mcpContractGateOutput
 	defer func() {
-		if receiptContractGate != nil {
-			emitMCPToolReceipt(receiptEmitter, opts.Transport, redactionCfg.Profile, actionID, mcpMethod, toolName, receiptVerdict, taintEval, redactionReport, *receiptContractGate)
-			return
+		receiptOpts := mcpToolReceiptOpts{
+			Emitter:          receiptEmitter,
+			Transport:        opts.Transport,
+			RedactionProfile: redactionCfg.Profile,
+			ActionID:         actionID,
+			MCPMethod:        mcpMethod,
+			ToolName:         toolName,
+			Verdict:          receiptVerdict,
+			Layer:            receiptLayer,
+			Pattern:          receiptPattern,
+			Severity:         receiptSeverity,
+			Decision:         taintEval,
+			Report:           redactionReport,
+			ContractGate:     receiptContractGate,
 		}
-		emitMCPToolReceipt(receiptEmitter, opts.Transport, redactionCfg.Profile, actionID, mcpMethod, toolName, receiptVerdict, taintEval, redactionReport)
+		emitMCPToolReceipt(receiptOpts)
 	}()
 
 	// Parse the inbound frame once. Every gate below reads ID / Method /
@@ -402,6 +416,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		}
 		_, _ = fmt.Fprintf(logW, "pipelock: input: blocked (%s)\n", reason)
 		recordAdaptiveSignal(session.SignalBlock)
+		receiptLayer, receiptPattern, receiptSeverity = redactionBlockAttribution(redactErr)
 		receiptVerdict = config.ActionBlock
 		result.Blocked = &BlockedRequest{
 			ID:             frame.ID,
@@ -443,6 +458,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	eval := EvaluateMCPInputGates(inputScanCtx, frame, msg, sessionKey, opts, action, onParseError, scanEnabled)
 	verdict := eval.ContentVerdict
 	policyVerdict := eval.PolicyVerdict
+	receiptLayer, receiptPattern, receiptSeverity = pickAttribution(eval)
 
 	mcpMethod = verdict.Method
 	if verdict.Method == methodToolsCall {

--- a/internal/mcp/receipt_attribution_test.go
+++ b/internal/mcp/receipt_attribution_test.go
@@ -1,0 +1,338 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/addressprotect"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/policy"
+	"github.com/luckyPipewrench/pipelock/internal/redact"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+func TestPickAttribution(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name              string
+		eval              MCPInputEvaluation
+		wantLayer         string
+		wantPattern       string
+		wantSeverity      string
+		wantEmptySeverity bool
+	}{
+		{
+			name: "chain block",
+			eval: MCPInputEvaluation{
+				BlockingGate:     blockingGateChain,
+				ChainPatternName: "tool-bounce",
+				ChainSeverity:    config.SeverityCritical,
+			},
+			wantLayer:    "mcp_chain_detection",
+			wantPattern:  "tool-bounce",
+			wantSeverity: config.SeverityCritical,
+		},
+		{
+			name: "policy match",
+			eval: MCPInputEvaluation{
+				PolicyVerdict: policy.Verdict{Matched: true, Rules: []string{"dangerous-shell"}},
+			},
+			wantLayer:    "mcp_tool_policy",
+			wantPattern:  "dangerous-shell",
+			wantSeverity: config.SeverityHigh,
+		},
+		{
+			name: "binding violation",
+			eval: MCPInputEvaluation{
+				BindingReason: "session_binding:unknown_tool",
+			},
+			wantLayer:    "mcp_session_binding",
+			wantPattern:  "session_binding:unknown_tool",
+			wantSeverity: config.SeverityHigh,
+		},
+		{
+			name: "taint block",
+			eval: MCPInputEvaluation{
+				BlockingGate: blockingGateTaintBlock,
+				TaintDecision: taintDecision{
+					Result: session.PolicyDecisionResult{
+						Decision: session.PolicyBlock,
+						Reason:   "protected_write_after_untrusted_external_exposure",
+					},
+				},
+			},
+			wantLayer:    "mcp_tool_taint",
+			wantPattern:  "protected_write_after_untrusted_external_exposure",
+			wantSeverity: config.SeverityCritical,
+		},
+		{
+			name: "content scan fallback",
+			eval: MCPInputEvaluation{
+				ContentVerdict: InputVerdict{
+					Clean: false,
+					Matches: []scanner.TextDLPMatch{{
+						PatternName: "anthropic-key",
+						Severity:    config.SeverityCritical,
+					}},
+				},
+			},
+			wantLayer:    "mcp_input_scanning",
+			wantPattern:  "anthropic-key",
+			wantSeverity: config.SeverityCritical,
+		},
+		{
+			name: "a2a body block via BlockingGate",
+			eval: MCPInputEvaluation{
+				BlockingGate: blockingGateA2ABody,
+				A2AResult:    A2AScanResult{Reason: "embedded prompt injection"},
+			},
+			wantLayer:    "mcp_a2a_scanning",
+			wantPattern:  "embedded prompt injection",
+			wantSeverity: config.SeverityHigh,
+		},
+		{
+			name: "dow block via BlockingGate",
+			eval: MCPInputEvaluation{
+				BlockingGate: blockingGateDoW,
+				DoWReason:    "budget_exceeded",
+			},
+			wantLayer:    "mcp_denial_of_wallet",
+			wantPattern:  "budget_exceeded",
+			wantSeverity: config.SeverityHigh,
+		},
+		{
+			name: "frozen tool block",
+			eval: MCPInputEvaluation{
+				BlockingGate:   blockingGateFrozenTool,
+				FrozenToolName: "exec",
+			},
+			wantLayer:    "mcp_tool_inventory",
+			wantPattern:  "exec",
+			wantSeverity: config.SeverityHigh,
+		},
+		{
+			name: "parse error block",
+			eval: MCPInputEvaluation{
+				BlockingGate:   blockingGateParseError,
+				ContentVerdict: InputVerdict{Error: "malformed JSON"},
+			},
+			wantLayer:    "mcp_input_scanning",
+			wantPattern:  "malformed JSON",
+			wantSeverity: config.SeverityHigh,
+		},
+		{
+			name: "taint ask denied",
+			eval: MCPInputEvaluation{
+				BlockingGate: blockingGateTaintAskDenied,
+				TaintDecision: taintDecision{
+					Result: session.PolicyDecisionResult{
+						Decision: session.PolicyAsk,
+						Reason:   "high_risk_pending_approval",
+					},
+				},
+			},
+			wantLayer:    "mcp_tool_taint",
+			wantPattern:  "high_risk_pending_approval",
+			wantSeverity: config.SeverityHigh,
+		},
+		{
+			name: "a2a fallback when BlockingGate empty",
+			eval: MCPInputEvaluation{
+				A2AResult: A2AScanResult{Clean: false, Reason: "tool_poisoning"},
+			},
+			wantLayer:    "mcp_a2a_scanning",
+			wantPattern:  "tool_poisoning",
+			wantSeverity: config.SeverityHigh,
+		},
+		{
+			name: "dow fallback when BlockingGate empty",
+			eval: MCPInputEvaluation{
+				DoWAction:  config.ActionBlock,
+				DoWAllowed: false,
+				DoWReason:  "ratelimit_exceeded",
+			},
+			wantLayer:    "mcp_denial_of_wallet",
+			wantPattern:  "ratelimit_exceeded",
+			wantSeverity: config.SeverityHigh,
+		},
+		{
+			name: "content scan injection fallback",
+			eval: MCPInputEvaluation{
+				ContentVerdict: InputVerdict{
+					Inject: []scanner.ResponseMatch{{PatternName: "ignore-previous"}},
+				},
+			},
+			wantLayer:    "mcp_input_scanning",
+			wantPattern:  "ignore-previous",
+			wantSeverity: config.SeverityHigh,
+		},
+		{
+			name: "content scan address fallback",
+			eval: MCPInputEvaluation{
+				ContentVerdict: InputVerdict{
+					AddressFindings: []addressprotect.Finding{{Explanation: "swapped_btc_addr"}},
+				},
+			},
+			wantLayer:    "mcp_input_scanning",
+			wantPattern:  "address:swapped_btc_addr",
+			wantSeverity: config.SeverityHigh,
+		},
+		{
+			name: "content scan error fallback",
+			eval: MCPInputEvaluation{
+				ContentVerdict: InputVerdict{Error: "scan_failed"},
+			},
+			wantLayer:    "mcp_input_scanning",
+			wantPattern:  "scan_failed",
+			wantSeverity: config.SeverityHigh,
+		},
+		{
+			name:              "clean eval",
+			eval:              MCPInputEvaluation{ContentVerdict: InputVerdict{Clean: true}},
+			wantEmptySeverity: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotLayer, gotPattern, gotSeverity := pickAttribution(tc.eval)
+			if gotLayer != tc.wantLayer {
+				t.Fatalf("layer = %q, want %q", gotLayer, tc.wantLayer)
+			}
+			if gotPattern != tc.wantPattern {
+				t.Fatalf("pattern = %q, want %q", gotPattern, tc.wantPattern)
+			}
+			if gotSeverity != tc.wantSeverity {
+				t.Fatalf("severity = %q, want %q", gotSeverity, tc.wantSeverity)
+			}
+			if tc.wantEmptySeverity && gotSeverity != "" {
+				t.Fatalf("severity = %q, want empty", gotSeverity)
+			}
+		})
+	}
+}
+
+func TestRedactionBlockAttribution(t *testing.T) {
+	t.Parallel()
+	layer, pattern, severity := redactionBlockAttribution(&redact.BlockError{Reason: redact.ReasonOverflow})
+	if layer != "mcp_input_redaction" {
+		t.Fatalf("layer = %q, want mcp_input_redaction", layer)
+	}
+	if pattern != string(redact.ReasonOverflow) {
+		t.Fatalf("pattern = %q, want %q", pattern, redact.ReasonOverflow)
+	}
+	if severity != config.SeverityHigh {
+		t.Fatalf("severity = %q, want %q", severity, config.SeverityHigh)
+	}
+
+	_, pattern, _ = redactionBlockAttribution(errors.New("plain failure"))
+	if pattern != string(redact.ReasonInternalError) {
+		t.Fatalf("plain pattern = %q, want %q", pattern, redact.ReasonInternalError)
+	}
+}
+
+func TestEmitMCPToolReceiptIncludesAttribution(t *testing.T) {
+	emitter, _, dir, _ := newReceiptTestHarness(t)
+	emitMCPToolReceipt(mcpToolReceiptOpts{
+		Emitter:   emitter,
+		Transport: transportMCPStdio,
+		ActionID:  "mcp-tool-attribution-1",
+		MCPMethod: methodToolsCall,
+		ToolName:  "shell",
+		Verdict:   config.ActionBlock,
+		Layer:     "mcp_tool_policy",
+		Pattern:   "dangerous-shell",
+		Severity:  config.SeverityHigh,
+		Decision: taintDecision{
+			Authority: session.AuthorityUserBroad,
+			Result: session.PolicyDecisionResult{
+				Decision: session.PolicyBlock,
+				Reason:   "policy",
+			},
+		},
+	})
+
+	receipts := readActionReceipts(t, dir)
+	if len(receipts) != 1 {
+		t.Fatalf("receipts = %d, want 1", len(receipts))
+	}
+	record := receipts[0].ActionRecord
+	if record.Layer != "mcp_tool_policy" {
+		t.Fatalf("layer = %q, want mcp_tool_policy", record.Layer)
+	}
+	if record.Pattern != "dangerous-shell" {
+		t.Fatalf("pattern = %q, want dangerous-shell", record.Pattern)
+	}
+	if record.Severity != config.SeverityHigh {
+		t.Fatalf("severity = %q, want %q", record.Severity, config.SeverityHigh)
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		inputs []string
+		want   string
+	}{
+		{name: "first non-empty", inputs: []string{"a", "b"}, want: "a"},
+		{name: "skip empty then return", inputs: []string{"", "b"}, want: "b"},
+		{name: "skip whitespace-only then return", inputs: []string{"   ", "\t", "real"}, want: "real"},
+		{name: "all empty or whitespace", inputs: []string{"", "  ", "\n"}, want: ""},
+		{name: "no inputs", inputs: nil, want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := firstNonEmpty(tc.inputs...)
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFirstPolicyRule(t *testing.T) {
+	t.Parallel()
+	if got := firstPolicyRule(nil); got != mcpReceiptPatternPolicyDefault {
+		t.Fatalf("nil rules = %q, want %q", got, mcpReceiptPatternPolicyDefault)
+	}
+	if got := firstPolicyRule([]string{}); got != mcpReceiptPatternPolicyDefault {
+		t.Fatalf("empty rules = %q, want %q", got, mcpReceiptPatternPolicyDefault)
+	}
+	if got := firstPolicyRule([]string{"   "}); got != mcpReceiptPatternPolicyDefault {
+		t.Fatalf("whitespace-only rule = %q, want %q", got, mcpReceiptPatternPolicyDefault)
+	}
+	if got := firstPolicyRule([]string{"shell-exec", "extra"}); got != "shell-exec" {
+		t.Fatalf("first concrete rule = %q, want shell-exec", got)
+	}
+}
+
+func TestTaintReceiptSeverity(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		dec  session.PolicyDecision
+		want string
+	}{
+		{name: "block maps to critical", dec: session.PolicyBlock, want: config.SeverityCritical},
+		{name: "ask maps to high", dec: session.PolicyAsk, want: config.SeverityHigh},
+		{name: "allow maps to medium", dec: session.PolicyAllow, want: config.SeverityMedium},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := taintReceiptSeverity(taintDecision{
+				Result: session.PolicyDecisionResult{Decision: tc.dec},
+			})
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/mcp/receipt_attribution_test.go
+++ b/internal/mcp/receipt_attribution_test.go
@@ -32,7 +32,7 @@ func TestPickAttribution(t *testing.T) {
 				ChainPatternName: "tool-bounce",
 				ChainSeverity:    config.SeverityCritical,
 			},
-			wantLayer:    "mcp_chain_detection",
+			wantLayer:    mcpReceiptLayerChain,
 			wantPattern:  "tool-bounce",
 			wantSeverity: config.SeverityCritical,
 		},
@@ -41,7 +41,7 @@ func TestPickAttribution(t *testing.T) {
 			eval: MCPInputEvaluation{
 				PolicyVerdict: policy.Verdict{Matched: true, Rules: []string{"dangerous-shell"}},
 			},
-			wantLayer:    "mcp_tool_policy",
+			wantLayer:    mcpReceiptLayerPolicy,
 			wantPattern:  "dangerous-shell",
 			wantSeverity: config.SeverityHigh,
 		},
@@ -50,7 +50,7 @@ func TestPickAttribution(t *testing.T) {
 			eval: MCPInputEvaluation{
 				BindingReason: "session_binding:unknown_tool",
 			},
-			wantLayer:    "mcp_session_binding",
+			wantLayer:    mcpReceiptLayerSessionBind,
 			wantPattern:  "session_binding:unknown_tool",
 			wantSeverity: config.SeverityHigh,
 		},
@@ -65,7 +65,7 @@ func TestPickAttribution(t *testing.T) {
 					},
 				},
 			},
-			wantLayer:    "mcp_tool_taint",
+			wantLayer:    mcpReceiptLayerTaint,
 			wantPattern:  "protected_write_after_untrusted_external_exposure",
 			wantSeverity: config.SeverityCritical,
 		},
@@ -80,7 +80,7 @@ func TestPickAttribution(t *testing.T) {
 					}},
 				},
 			},
-			wantLayer:    "mcp_input_scanning",
+			wantLayer:    mcpReceiptLayerInput,
 			wantPattern:  "anthropic-key",
 			wantSeverity: config.SeverityCritical,
 		},
@@ -90,7 +90,7 @@ func TestPickAttribution(t *testing.T) {
 				BlockingGate: blockingGateA2ABody,
 				A2AResult:    A2AScanResult{Reason: "embedded prompt injection"},
 			},
-			wantLayer:    "mcp_a2a_scanning",
+			wantLayer:    mcpReceiptLayerA2A,
 			wantPattern:  "embedded prompt injection",
 			wantSeverity: config.SeverityHigh,
 		},
@@ -100,7 +100,7 @@ func TestPickAttribution(t *testing.T) {
 				BlockingGate: blockingGateDoW,
 				DoWReason:    "budget_exceeded",
 			},
-			wantLayer:    "mcp_denial_of_wallet",
+			wantLayer:    mcpReceiptLayerDoW,
 			wantPattern:  "budget_exceeded",
 			wantSeverity: config.SeverityHigh,
 		},
@@ -110,7 +110,7 @@ func TestPickAttribution(t *testing.T) {
 				BlockingGate:   blockingGateFrozenTool,
 				FrozenToolName: "exec",
 			},
-			wantLayer:    "mcp_tool_inventory",
+			wantLayer:    mcpReceiptLayerToolInventory,
 			wantPattern:  "exec",
 			wantSeverity: config.SeverityHigh,
 		},
@@ -120,7 +120,7 @@ func TestPickAttribution(t *testing.T) {
 				BlockingGate:   blockingGateParseError,
 				ContentVerdict: InputVerdict{Error: "malformed JSON"},
 			},
-			wantLayer:    "mcp_input_scanning",
+			wantLayer:    mcpReceiptLayerInput,
 			wantPattern:  "malformed JSON",
 			wantSeverity: config.SeverityHigh,
 		},
@@ -135,7 +135,7 @@ func TestPickAttribution(t *testing.T) {
 					},
 				},
 			},
-			wantLayer:    "mcp_tool_taint",
+			wantLayer:    mcpReceiptLayerTaint,
 			wantPattern:  "high_risk_pending_approval",
 			wantSeverity: config.SeverityHigh,
 		},
@@ -144,7 +144,7 @@ func TestPickAttribution(t *testing.T) {
 			eval: MCPInputEvaluation{
 				A2AResult: A2AScanResult{Clean: false, Reason: "tool_poisoning"},
 			},
-			wantLayer:    "mcp_a2a_scanning",
+			wantLayer:    mcpReceiptLayerA2A,
 			wantPattern:  "tool_poisoning",
 			wantSeverity: config.SeverityHigh,
 		},
@@ -155,7 +155,7 @@ func TestPickAttribution(t *testing.T) {
 				DoWAllowed: false,
 				DoWReason:  "ratelimit_exceeded",
 			},
-			wantLayer:    "mcp_denial_of_wallet",
+			wantLayer:    mcpReceiptLayerDoW,
 			wantPattern:  "ratelimit_exceeded",
 			wantSeverity: config.SeverityHigh,
 		},
@@ -166,7 +166,7 @@ func TestPickAttribution(t *testing.T) {
 					Inject: []scanner.ResponseMatch{{PatternName: "ignore-previous"}},
 				},
 			},
-			wantLayer:    "mcp_input_scanning",
+			wantLayer:    mcpReceiptLayerInput,
 			wantPattern:  "ignore-previous",
 			wantSeverity: config.SeverityHigh,
 		},
@@ -177,7 +177,7 @@ func TestPickAttribution(t *testing.T) {
 					AddressFindings: []addressprotect.Finding{{Explanation: "swapped_btc_addr"}},
 				},
 			},
-			wantLayer:    "mcp_input_scanning",
+			wantLayer:    mcpReceiptLayerInput,
 			wantPattern:  "address:swapped_btc_addr",
 			wantSeverity: config.SeverityHigh,
 		},
@@ -186,7 +186,7 @@ func TestPickAttribution(t *testing.T) {
 			eval: MCPInputEvaluation{
 				ContentVerdict: InputVerdict{Error: "scan_failed"},
 			},
-			wantLayer:    "mcp_input_scanning",
+			wantLayer:    mcpReceiptLayerInput,
 			wantPattern:  "scan_failed",
 			wantSeverity: config.SeverityHigh,
 		},
@@ -220,7 +220,7 @@ func TestPickAttribution(t *testing.T) {
 func TestRedactionBlockAttribution(t *testing.T) {
 	t.Parallel()
 	layer, pattern, severity := redactionBlockAttribution(&redact.BlockError{Reason: redact.ReasonOverflow})
-	if layer != "mcp_input_redaction" {
+	if layer != mcpReceiptLayerRedaction {
 		t.Fatalf("layer = %q, want mcp_input_redaction", layer)
 	}
 	if pattern != string(redact.ReasonOverflow) {
@@ -245,7 +245,7 @@ func TestEmitMCPToolReceiptIncludesAttribution(t *testing.T) {
 		MCPMethod: methodToolsCall,
 		ToolName:  "shell",
 		Verdict:   config.ActionBlock,
-		Layer:     "mcp_tool_policy",
+		Layer:     mcpReceiptLayerPolicy,
 		Pattern:   "dangerous-shell",
 		Severity:  config.SeverityHigh,
 		Decision: taintDecision{
@@ -262,7 +262,7 @@ func TestEmitMCPToolReceiptIncludesAttribution(t *testing.T) {
 		t.Fatalf("receipts = %d, want 1", len(receipts))
 	}
 	record := receipts[0].ActionRecord
-	if record.Layer != "mcp_tool_policy" {
+	if record.Layer != mcpReceiptLayerPolicy {
 		t.Fatalf("layer = %q, want mcp_tool_policy", record.Layer)
 	}
 	if record.Pattern != "dangerous-shell" {

--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -4,6 +4,7 @@
 package mcp
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -23,6 +24,24 @@ const (
 	taintScopeAction    = "action"
 	taintScopeSource    = "source"
 	taintScopeTask      = "task"
+)
+
+const (
+	mcpReceiptLayerA2A           = "mcp_a2a_scanning"
+	mcpReceiptLayerChain         = "mcp_chain_detection"
+	mcpReceiptLayerDoW           = "mcp_denial_of_wallet"
+	mcpReceiptLayerInput         = "mcp_input_scanning"
+	mcpReceiptLayerPolicy        = "mcp_tool_policy"
+	mcpReceiptLayerRedaction     = "mcp_input_redaction"
+	mcpReceiptLayerSessionBind   = "mcp_session_binding"
+	mcpReceiptLayerTaint         = "mcp_tool_taint"
+	mcpReceiptLayerToolInventory = "mcp_tool_inventory"
+
+	// mcpReceiptPatternPolicyDefault is the fallback Pattern emitted on
+	// receipts when policy matched but the rule list is empty or
+	// whitespace. Concrete rule names override this. Extracted as a const
+	// so production and tests share the same string (goconst).
+	mcpReceiptPatternPolicyDefault = "policy"
 )
 
 type taintDecision struct {
@@ -232,47 +251,163 @@ func taintApprovalReason(decision taintDecision) string {
 	return fmt.Sprintf("%s after %s", decision.ActionClass.String(), decision.Result.Reason)
 }
 
+type mcpToolReceiptOpts struct {
+	Emitter          *receipt.Emitter
+	Transport        string
+	RedactionProfile string
+	ActionID         string
+	MCPMethod        string
+	ToolName         string
+	Verdict          string
+	Layer            string
+	Pattern          string
+	Severity         string
+	Decision         taintDecision
+	Report           *redact.Report
+	ContractGate     *mcpContractGateOutput
+}
+
 // emitMCPToolReceipt emits the post-decision tool receipt for an MCP
 // tools/call message. The receipt payload bundles redaction context,
-// transport, and the full taint snapshot. Routed through
-// EmitMCPDecision so every tool receipt in the MCP inbound pipeline
-// goes through a single emission entry point.
-func emitMCPToolReceipt(
-	receiptEmitter *receipt.Emitter,
-	transport, redactionProfile string,
-	actionID, mcpMethod, toolName, receiptVerdict string,
-	decision taintDecision,
-	report *redact.Report,
-	contractGate ...mcpContractGateOutput,
-) {
-	if actionID == "" || receiptEmitter == nil {
+// transport, scanner attribution, and the full taint snapshot. Routed
+// through EmitMCPDecision so every tool receipt in the MCP inbound
+// pipeline goes through a single emission entry point.
+func emitMCPToolReceipt(opts mcpToolReceiptOpts) {
+	if opts.ActionID == "" || opts.Emitter == nil {
 		return
 	}
 	emitOpts := receipt.EmitOpts{
-		ActionID:            actionID,
-		Verdict:             receiptVerdict,
-		RedactionProfile:    redactionProfile,
-		RedactionReport:     report,
-		Transport:           transport,
-		Target:              toolName,
-		MCPMethod:           mcpMethod,
-		ToolName:            toolName,
-		SessionTaintLevel:   decision.Risk.Level.String(),
-		SessionContaminated: decision.Risk.Contaminated,
-		RecentTaintSources:  decision.Risk.Sources,
-		SessionTaskID:       decision.Task.CurrentTaskID,
-		SessionTaskLabel:    decision.Task.CurrentTaskLabel,
-		AuthorityKind:       decision.Authority.String(),
-		TaintDecision:       decision.Result.Decision.String(),
-		TaintDecisionReason: decision.Result.Reason,
-		TaskOverrideApplied: decision.TaskOverrideApplied,
+		ActionID:            opts.ActionID,
+		Verdict:             opts.Verdict,
+		Layer:               opts.Layer,
+		Pattern:             opts.Pattern,
+		Severity:            opts.Severity,
+		RedactionProfile:    opts.RedactionProfile,
+		RedactionReport:     opts.Report,
+		Transport:           opts.Transport,
+		Target:              opts.ToolName,
+		MCPMethod:           opts.MCPMethod,
+		ToolName:            opts.ToolName,
+		SessionTaintLevel:   opts.Decision.Risk.Level.String(),
+		SessionContaminated: opts.Decision.Risk.Contaminated,
+		RecentTaintSources:  opts.Decision.Risk.Sources,
+		SessionTaskID:       opts.Decision.Task.CurrentTaskID,
+		SessionTaskLabel:    opts.Decision.Task.CurrentTaskLabel,
+		AuthorityKind:       opts.Decision.Authority.String(),
+		TaintDecision:       opts.Decision.Result.Decision.String(),
+		TaintDecisionReason: opts.Decision.Result.Reason,
+		TaskOverrideApplied: opts.Decision.TaskOverrideApplied,
 	}
-	if len(contractGate) > 0 {
-		emitOpts = mcpWithContractReceipt(emitOpts, contractGate[0])
+	if opts.ContractGate != nil {
+		emitOpts = mcpWithContractReceipt(emitOpts, *opts.ContractGate)
 	}
-	_, _ = EmitMCPDecision(receiptEmitter, nil, MCPDecision{
+	_, _ = EmitMCPDecision(opts.Emitter, nil, MCPDecision{
 		Receipt: emitOpts,
 	})
+}
+
+// pickAttribution derives the receipt Layer / Pattern / Severity for a
+// block verdict, based on which gate inside MCPInputEvaluation fired.
+//
+// Maintenance contract: every value the gate-evaluation code assigns to
+// eval.BlockingGate (see internal/mcp/pipeline_gates.go) must have a
+// matching case in the switch below. The fall-through if-chain covers
+// gates that produce signal on eval fields without setting BlockingGate
+// (currently policy, binding, taint-allow-with-reason, dow-fallback,
+// a2a-fallback, content-scan). When you add a new gate, extend the
+// switch in the same change — otherwise the new gate's block receipts
+// will emit empty Layer / Pattern / Severity from the final fallback.
+func pickAttribution(eval MCPInputEvaluation) (layer, pattern, severity string) {
+	switch eval.BlockingGate {
+	case blockingGateA2ABody:
+		return mcpReceiptLayerA2A, firstNonEmpty(eval.A2AResult.Reason, blockingGateA2ABody), config.SeverityHigh
+	case blockingGateDoW:
+		return mcpReceiptLayerDoW, firstNonEmpty(eval.DoWReason, blockingGateDoW), config.SeverityHigh
+	case blockingGateFrozenTool:
+		return mcpReceiptLayerToolInventory, firstNonEmpty(eval.FrozenToolName, blockingGateFrozenTool), config.SeverityHigh
+	case blockingGateChain:
+		return mcpReceiptLayerChain, firstNonEmpty(eval.ChainPatternName, eval.ChainReason), firstNonEmpty(eval.ChainSeverity, config.SeverityHigh)
+	case blockingGateParseError:
+		return mcpReceiptLayerInput, firstNonEmpty(eval.ContentVerdict.Error, blockingGateParseError), config.SeverityHigh
+	case blockingGateTaintBlock, blockingGateTaintAskDenied:
+		return mcpReceiptLayerTaint, firstNonEmpty(eval.TaintDecision.Result.Reason, eval.BlockingGate), taintReceiptSeverity(eval.TaintDecision)
+	}
+
+	if eval.ChainMatched || eval.ChainReason != "" {
+		return mcpReceiptLayerChain, firstNonEmpty(eval.ChainPatternName, eval.ChainReason), firstNonEmpty(eval.ChainSeverity, config.SeverityHigh)
+	}
+	if eval.PolicyVerdict.Matched {
+		return mcpReceiptLayerPolicy, firstPolicyRule(eval.PolicyVerdict.Rules), config.SeverityHigh
+	}
+	if eval.BindingReason != "" {
+		return mcpReceiptLayerSessionBind, eval.BindingReason, config.SeverityHigh
+	}
+	if eval.TaintDecision.Result.Decision != session.PolicyAllow && eval.TaintDecision.Result.Reason != "" {
+		return mcpReceiptLayerTaint, eval.TaintDecision.Result.Reason, taintReceiptSeverity(eval.TaintDecision)
+	}
+	if eval.DoWAction != "" && !eval.DoWAllowed {
+		return mcpReceiptLayerDoW, firstNonEmpty(eval.DoWReason, eval.DoWAction), config.SeverityHigh
+	}
+	if !eval.A2AResult.Clean && eval.A2AResult.Reason != "" {
+		return mcpReceiptLayerA2A, eval.A2AResult.Reason, config.SeverityHigh
+	}
+	if layer, pattern, severity := contentScanAttribution(eval.ContentVerdict); layer != "" {
+		return layer, pattern, severity
+	}
+	return "", "", ""
+}
+
+func contentScanAttribution(verdict InputVerdict) (layer, pattern, severity string) {
+	if len(verdict.Matches) > 0 {
+		m := verdict.Matches[0]
+		return mcpReceiptLayerInput, m.PatternName, firstNonEmpty(m.Severity, config.SeverityHigh)
+	}
+	if len(verdict.Inject) > 0 {
+		return mcpReceiptLayerInput, verdict.Inject[0].PatternName, config.SeverityHigh
+	}
+	if len(verdict.AddressFindings) > 0 {
+		return mcpReceiptLayerInput, "address:" + verdict.AddressFindings[0].Explanation, config.SeverityHigh
+	}
+	if verdict.Error != "" {
+		return mcpReceiptLayerInput, verdict.Error, config.SeverityHigh
+	}
+	return "", "", ""
+}
+
+func firstPolicyRule(rules []string) string {
+	if len(rules) == 0 || strings.TrimSpace(rules[0]) == "" {
+		return mcpReceiptPatternPolicyDefault
+	}
+	return rules[0]
+}
+
+func taintReceiptSeverity(decision taintDecision) string {
+	switch decision.Result.Decision {
+	case session.PolicyBlock:
+		return config.SeverityCritical
+	case session.PolicyAsk:
+		return config.SeverityHigh
+	default:
+		return config.SeverityMedium
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func redactionBlockAttribution(err error) (layer, pattern, severity string) {
+	pattern = string(redact.ReasonInternalError)
+	var blockErr *redact.BlockError
+	if errors.As(err, &blockErr) && blockErr.Reason != "" {
+		pattern = string(blockErr.Reason)
+	}
+	return mcpReceiptLayerRedaction, pattern, config.SeverityHigh
 }
 
 // decorateMCPToolMessage injects the mediation envelope for a clean or


### PR DESCRIPTION
## Summary

- populate `ActionRecord.Layer / Pattern / Severity` on MCP scan block-emit receipts
- 9 newly-attributed layers: `mcp_input_scanning`, `mcp_input_redaction`, `mcp_tool_policy`, `mcp_chain_detection`, `mcp_session_binding`, `mcp_tool_taint`, `mcp_denial_of_wallet`, `mcp_a2a_scanning`, `mcp_tool_inventory`
- `Severity` also added to the existing `media_policy` and `mcp_response_scan` emit sites for consistency
- refactor `emitMCPToolReceipt` to `mcpToolReceiptOpts` (per the >6-params options-struct rule)

## Why

Captured MCP receipts on a local block scenario previously left `ActionRecord.Layer / Pattern / Severity` empty. Auditors reading receipts could not tell which scanner produced a block from the receipt alone. The fields already exist at `internal/receipt/action.go` with `omitempty`, so populating them is non-breaking on audit-packet v0.

## How

- new `pickAttribution(eval MCPInputEvaluation)` in `internal/mcp/taint.go` derives the right attribution from whichever gate fired, covering every `BlockingGate` switch arm plus fall-through paths for policy, binding, taint, DoW, A2A, and content-scan
- new `redactionBlockAttribution(err error)` covers the redaction-block emit path
- attribution is threaded through both stdio (`internal/mcp/input.go`) and HTTP/WS (`internal/mcp/proxy_http.go`) tool-receipt callers
- new layer constants extracted in `internal/mcp/taint.go` to follow goconst discipline
- maintenance-contract comment on `pickAttribution` binds new `BlockingGate` constants to required switch updates

## Conformance notes

- audit-packet v0 schema treats `Layer / Pattern / Severity` as optional via `omitempty`, so populating them is additive
- 3-layer security suite was run locally against the built binary; 2 pre-existing failures (CHE-11, CHE-12 in section 60d) depend on the in-flight `fix/claude-hook-unknown-tools-fail-open` PR currently blocked on CLA, unrelated to this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tool-blocking decisions now surface richer attribution metadata (layer, pattern, severity) in emitted receipts for clearer traceability.
  * Blocked server responses and prompt-injection verdicts now carry a high-severity flag in their receipts.

* **Tests**
  * Expanded coverage for receipt attribution, redaction-handling, and severity mapping across many evaluation scenarios.

* **Refactor**
  * Unified receipt emission to a consistent options-based flow for more reliable and consistent receipts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->