### PR TITLE
Add enforcement doctor and universal containment launcher

### DIFF
--- a/internal/cli/contain/cmd.go
+++ b/internal/cli/contain/cmd.go
@@ -24,6 +24,10 @@ Subcommands:
   verify      Run read-only probes; report pass/fail/skip.
   rollback    Undo install (idempotent).
   add-tool    Drop a new /usr/local/bin/plk-<name> wrapper.
+  grant-workspace
+              Grant pipelock-agent ACL access to a project directory.
+  revoke-workspace
+              Revoke pipelock-agent ACL access from a project directory.
   ca-refresh  Rebuild the combined CA bundle after a CA rotation.
 
 All mutating subcommands accept --dry-run to print the planned actions
@@ -37,6 +41,8 @@ without touching state.`,
 		installCmd(),
 		rollbackCmd(),
 		addToolCmd(),
+		grantWorkspaceCmd(),
+		revokeWorkspaceCmd(),
 		caRefreshCmd(),
 	)
 

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -33,6 +33,13 @@ type installOpts struct {
 
 var containUsernamePattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,31}$`)
 
+// containToolNameRegex is the shared regex that both plk-launch and the plk
+// meta-wrapper enforce on operator-supplied tool names. Keeping a single
+// source of truth prevents the two wrappers from drifting and letting a name
+// through one layer that the other rejects. The regex is rendered as a bash
+// =~ pattern in both scripts.
+const containToolNameRegex = "^[a-z0-9][a-z0-9_-]{0,30}$"
+
 // installCmd builds the `pipelock contain install` cobra command.
 func installCmd() *cobra.Command {
 	var opts installOpts
@@ -210,6 +217,7 @@ func installSteps(opts installOpts) []step {
 		stepInstallNFTRules(),
 		stepWriteToolsList(),
 		stepWriteLaunchWrapper(),
+		stepWriteMetaWrapper(),
 		stepWriteToolWrappers(),
 		stepWriteWrapperInventory(),
 		stepInstallSudoers(),
@@ -1353,11 +1361,13 @@ func renderLaunchWrapper(env *installEnv) string {
 		`fi`,
 		`TOOL="$1"; shift`,
 		"",
-		`# Reject tool names with shell metacharacters or path separators up`,
-		`# front. The install-time regex is tighter; this is defense in depth.`,
-		`case "$TOOL" in`,
-		`    *[!a-z0-9_-]*|"") echo "plk-launch: invalid tool name $TOOL" >&2; exit 3 ;;`,
-		`esac`,
+		`# Reject tool names that violate the shared install-time regex.`,
+		`# Same pattern is enforced in the plk meta-wrapper so the two`,
+		`# layers never drift.`,
+		`if [[ ! "$TOOL" =~ ` + containToolNameRegex + ` ]]; then`,
+		`    echo "plk-launch: invalid tool name $TOOL" >&2`,
+		`    exit 3`,
+		`fi`,
 		"",
 		`if [[ ! -r "$TOOLS_LIST" ]]; then`,
 		`    echo "plk-launch: missing allow-list at $TOOLS_LIST (run pipelock contain install)" >&2`,
@@ -1441,6 +1451,53 @@ func shellQuote(s string) string {
 // ---------------------------------------------------------------------------
 // Step 18: write per-tool wrappers for allow-listed tools.
 // ---------------------------------------------------------------------------
+
+func stepWriteMetaWrapper() step {
+	return step{
+		name: "write-plk-meta-wrapper",
+		desc: "write /usr/local/bin/plk (dispatches to plk-launch)",
+		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			body := renderMetaWrapper(env)
+			path := filepath.Join(env.wrapperDir, "plk")
+			if existing, err := env.readFile(path); err == nil && string(existing) == body {
+				_ = env.chmod(path, modeWrapperExec)
+				return false, nil
+			}
+			if err := backupAndWrite(env, path, []byte(body), modeWrapperExec); err != nil {
+				return false, err
+			}
+			return true, nil
+		},
+		undo: func(_ context.Context, env *installEnv) error {
+			path := filepath.Join(env.wrapperDir, "plk")
+			return restoreBackup(env, path)
+		},
+	}
+}
+
+func renderMetaWrapper(env *installEnv) string {
+	return strings.Join([]string{
+		"#!/bin/bash",
+		"# Managed by `pipelock contain install`. Edits are clobbered on next install.",
+		"set -euo pipefail",
+		"",
+		`if [[ $# -lt 1 ]]; then`,
+		`    echo "usage: plk <tool> [args...]" >&2`,
+		`    exit 2`,
+		`fi`,
+		`if [[ ! "$1" =~ ` + containToolNameRegex + ` ]]; then`,
+		`    echo "plk: invalid tool name $1" >&2`,
+		`    exit 3`,
+		`fi`,
+		"TOOLS_LIST=" + shellQuote(env.toolsListPath),
+		`if [[ ! -s "$TOOLS_LIST" ]]; then`,
+		`    echo "plk: missing or empty allow-list at $TOOLS_LIST (run pipelock contain install)" >&2`,
+		`    exit 4`,
+		`fi`,
+		"exec sudo -n -u " + env.agentUserName + " " + filepath.Join(env.wrapperDir, "plk-launch") + ` "$@"`,
+		"",
+	}, "\n")
+}
 
 func stepWriteToolWrappers() step {
 	var touched []string

--- a/internal/cli/contain/install_review_fixes_test.go
+++ b/internal/cli/contain/install_review_fixes_test.go
@@ -69,7 +69,7 @@ func TestRenderLaunchWrapper_EmbedsAllowListLookup(t *testing.T) {
 		env.toolsListPath,
 		"not in pipelock contain allow-list",
 		"refusing non-absolute target",
-		`case "$TOOL" in`, // metacharacter rejection
+		`[[ ! "$TOOL" =~ ` + containToolNameRegex, // shared regex check
 		"set -euo pipefail",
 	}
 	for _, r := range requirements {

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -157,26 +157,27 @@ func newFakeEnv(t *testing.T) (*installEnv, *fakeRunner, *bytes.Buffer) {
 			h := sha256.Sum256(data)
 			return hex.EncodeToString(h[:]), nil
 		},
-		out:            out,
-		errOut:         out,
-		operatorUser:   containInstallOperatorUser,
-		proxyUserName:  "pipelock-proxy",
-		agentUserName:  "pipelock-agent",
-		configDir:      filepath.Join(root, "etc", "pipelock"),
-		dataDir:        filepath.Join(root, "var", "lib", "pipelock"),
-		wrapperDir:     filepath.Join(root, "usr", "local", "bin"),
-		systemUnitPath: filepath.Join(root, "etc", "systemd", "system", "pipelock.service"),
-		nftRulesPath:   filepath.Join(root, "etc", "nftables.d", "50-pipelock-containment.nft"),
-		nftMainPath:    filepath.Join(root, "etc", "sysconfig", "nftables.conf"),
-		sudoersPath:    filepath.Join(root, "etc", "sudoers.d", "50-pipelock-agent"),
-		caBundlePath:   filepath.Join(root, "etc", "pipelock", "combined-ca.pem"),
-		caExportPath:   filepath.Join(root, "etc", "pipelock", "ca.pem"),
-		integrityDir:   filepath.Join(root, "etc", "pipelock", "integrity"),
-		integrityPin:   filepath.Join(root, "etc", "pipelock", "integrity", "binary-pin.sha256"),
-		wrapperInvPath: filepath.Join(root, "etc", "pipelock", "contain", "wrappers.json"),
-		toolsListPath:  filepath.Join(root, "etc", "pipelock", "contain", "tools.list"),
-		pipelockTarget: filepath.Join(root, "usr", "local", "bin", "pipelock"),
-		proxyPort:      8888,
+		out:              out,
+		errOut:           out,
+		operatorUser:     containInstallOperatorUser,
+		proxyUserName:    "pipelock-proxy",
+		agentUserName:    "pipelock-agent",
+		configDir:        filepath.Join(root, "etc", "pipelock"),
+		dataDir:          filepath.Join(root, "var", "lib", "pipelock"),
+		wrapperDir:       filepath.Join(root, "usr", "local", "bin"),
+		systemUnitPath:   filepath.Join(root, "etc", "systemd", "system", "pipelock.service"),
+		nftRulesPath:     filepath.Join(root, "etc", "nftables.d", "50-pipelock-containment.nft"),
+		nftMainPath:      filepath.Join(root, "etc", "sysconfig", "nftables.conf"),
+		sudoersPath:      filepath.Join(root, "etc", "sudoers.d", "50-pipelock-agent"),
+		caBundlePath:     filepath.Join(root, "etc", "pipelock", "combined-ca.pem"),
+		caExportPath:     filepath.Join(root, "etc", "pipelock", "ca.pem"),
+		integrityDir:     filepath.Join(root, "etc", "pipelock", "integrity"),
+		integrityPin:     filepath.Join(root, "etc", "pipelock", "integrity", "binary-pin.sha256"),
+		wrapperInvPath:   filepath.Join(root, "etc", "pipelock", "contain", "wrappers.json"),
+		toolsListPath:    filepath.Join(root, "etc", "pipelock", "contain", "tools.list"),
+		workspaceInvPath: filepath.Join(root, "etc", "pipelock", "contain", "workspaces.json"),
+		pipelockTarget:   filepath.Join(root, "usr", "local", "bin", "pipelock"),
+		proxyPort:        8888,
 	}
 
 	// Plant the source binary the install will copy.
@@ -403,6 +404,7 @@ func TestRunInstall_EndToEndWithExistingUsers(t *testing.T) {
 		env.systemUnitPath,
 		env.nftRulesPath,
 		filepath.Join(env.wrapperDir, "plk-launch"),
+		filepath.Join(env.wrapperDir, "plk"),
 		filepath.Join(env.wrapperDir, "plk-claude"),
 		env.wrapperInvPath,
 		env.sudoersPath,
@@ -482,6 +484,7 @@ func TestRunInstall_UpgradeRotatesExistingBackups(t *testing.T) {
 		env.nftRulesPath,
 		env.toolsListPath,
 		filepath.Join(env.wrapperDir, "plk-launch"),
+		filepath.Join(env.wrapperDir, "plk"),
 		filepath.Join(env.wrapperDir, "plk-claude"),
 		env.wrapperInvPath,
 		env.sudoersPath,
@@ -894,6 +897,26 @@ func TestRenderToolWrapper_UsesSudo(t *testing.T) {
 	}
 	if !strings.Contains(body, "plk-launch claude") {
 		t.Errorf("missing plk-launch dispatch: %s", body)
+	}
+}
+
+func TestRenderMetaWrapper_UsesSudoAndDispatchesArgs(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	body := renderMetaWrapper(env)
+	if !strings.Contains(body, "usage: plk <tool> [args...]") {
+		t.Errorf("missing usage: %s", body)
+	}
+	if !strings.Contains(body, "sudo -n -u pipelock-agent") {
+		t.Errorf("missing outer non-interactive sudo: %s", body)
+	}
+	if !strings.Contains(body, `=~ ^[a-z0-9][a-z0-9_-]{0,30}$`) {
+		t.Errorf("missing tool-name regex guard: %s", body)
+	}
+	if !strings.Contains(body, "missing or empty allow-list") {
+		t.Errorf("missing allow-list precheck: %s", body)
+	}
+	if !strings.Contains(body, "plk-launch") || !strings.Contains(body, `"$@"`) {
+		t.Errorf("missing full argv dispatch to plk-launch: %s", body)
 	}
 }
 
@@ -1471,12 +1494,12 @@ func TestStepCreateDirRejectsSymlinkParent(t *testing.T) {
 }
 
 func TestInstallSteps_Count(t *testing.T) {
-	// Sanity: the install flow has 21 steps total (20 install + 1 tools.list
-	// allow-list). Changing this count is a documented breaking change for
-	// the dry-run / verify probe-4 inventory.
+	// Sanity: the install flow has 22 steps total (20 install + 1 tools.list
+	// allow-list + 1 meta-wrapper). Changing this count is a documented
+	// breaking change for the dry-run / verify probe-4 inventory.
 	steps := installSteps(installOpts{})
-	if len(steps) != 21 {
-		t.Errorf("installSteps count: got %d, want 21", len(steps))
+	if len(steps) != 22 {
+		t.Errorf("installSteps count: got %d, want 22", len(steps))
 	}
 }
 

--- a/internal/cli/contain/osops.go
+++ b/internal/cli/contain/osops.go
@@ -66,25 +66,26 @@ type installEnv struct {
 	// Static configuration. These mirror the constants in verify.go so the
 	// two subsystems agree on filesystem layout. Made fields rather than
 	// constants so the install subcommand can accept flag overrides.
-	operatorUser   string
-	proxyUserName  string
-	agentUserName  string
-	configDir      string
-	dataDir        string
-	wrapperDir     string
-	systemUnitPath string
-	nftRulesPath   string
-	nftMainPath    string
-	sudoersPath    string
-	caBundlePath   string
-	caExportPath   string
-	integrityDir   string
-	integrityPin   string
-	wrapperInvPath string
-	toolsListPath  string // plk-launch's runtime allow-list (tab-separated NAME\tTARGET)
-	pipelockBinary string // source binary path passed to --pipelock-binary
-	pipelockTarget string // destination, default /usr/local/bin/pipelock
-	proxyPort      int
+	operatorUser     string
+	proxyUserName    string
+	agentUserName    string
+	configDir        string
+	dataDir          string
+	wrapperDir       string
+	systemUnitPath   string
+	nftRulesPath     string
+	nftMainPath      string
+	sudoersPath      string
+	caBundlePath     string
+	caExportPath     string
+	integrityDir     string
+	integrityPin     string
+	wrapperInvPath   string
+	toolsListPath    string // plk-launch's runtime allow-list (tab-separated NAME\tTARGET)
+	workspaceInvPath string
+	pipelockBinary   string // source binary path passed to --pipelock-binary
+	pipelockTarget   string // destination, default /usr/local/bin/pipelock
+	proxyPort        int
 
 	prevNFTTableDump       string
 	prevNftablesEnabled    bool
@@ -99,40 +100,41 @@ type installEnv struct {
 // sudo (where $SUDO_USER is empty) and -- no override flag was passed.
 func defaultInstallEnv(out io.Writer) *installEnv {
 	return &installEnv{
-		runCmd:         realRunCommand,
-		stat:           os.Stat,
-		lstat:          os.Lstat,
-		readFile:       os.ReadFile,
-		writeFile:      writeFileAtomic,
-		removeFile:     os.Remove,
-		mkdirAll:       os.MkdirAll,
-		chown:          os.Chown,
-		rename:         os.Rename,
-		chmod:          os.Chmod,
-		symlink:        os.Symlink,
-		lookupUser:     user.Lookup,
-		selfPath:       os.Executable,
-		hashFile:       sha256HexOfFile,
-		out:            out,
-		errOut:         os.Stderr,
-		operatorUser:   os.Getenv("SUDO_USER"),
-		proxyUserName:  defaultProxyUser,
-		agentUserName:  defaultAgentUser,
-		configDir:      defaultConfigDir,
-		dataDir:        defaultDataDir,
-		wrapperDir:     defaultWrapperDir,
-		systemUnitPath: defaultSystemUnitPath,
-		nftRulesPath:   defaultNFTRulesPath,
-		nftMainPath:    defaultNFTMainConfigPath,
-		sudoersPath:    defaultSudoersPath,
-		caBundlePath:   defaultCABundlePath,
-		caExportPath:   defaultCAExportPath,
-		integrityDir:   defaultIntegrityDir,
-		integrityPin:   defaultIntegrityPin,
-		wrapperInvPath: defaultWrapperInvPath,
-		toolsListPath:  defaultToolsListPath,
-		pipelockTarget: defaultPipelockTarget,
-		proxyPort:      defaultProxyPort,
+		runCmd:           realRunCommand,
+		stat:             os.Stat,
+		lstat:            os.Lstat,
+		readFile:         os.ReadFile,
+		writeFile:        writeFileAtomic,
+		removeFile:       os.Remove,
+		mkdirAll:         os.MkdirAll,
+		chown:            os.Chown,
+		rename:           os.Rename,
+		chmod:            os.Chmod,
+		symlink:          os.Symlink,
+		lookupUser:       user.Lookup,
+		selfPath:         os.Executable,
+		hashFile:         sha256HexOfFile,
+		out:              out,
+		errOut:           os.Stderr,
+		operatorUser:     os.Getenv("SUDO_USER"),
+		proxyUserName:    defaultProxyUser,
+		agentUserName:    defaultAgentUser,
+		configDir:        defaultConfigDir,
+		dataDir:          defaultDataDir,
+		wrapperDir:       defaultWrapperDir,
+		systemUnitPath:   defaultSystemUnitPath,
+		nftRulesPath:     defaultNFTRulesPath,
+		nftMainPath:      defaultNFTMainConfigPath,
+		sudoersPath:      defaultSudoersPath,
+		caBundlePath:     defaultCABundlePath,
+		caExportPath:     defaultCAExportPath,
+		integrityDir:     defaultIntegrityDir,
+		integrityPin:     defaultIntegrityPin,
+		wrapperInvPath:   defaultWrapperInvPath,
+		toolsListPath:    defaultToolsListPath,
+		workspaceInvPath: defaultWorkspaceInvPath,
+		pipelockTarget:   defaultPipelockTarget,
+		proxyPort:        defaultProxyPort,
 	}
 }
 
@@ -151,6 +153,7 @@ const (
 	defaultIntegrityPin      = "/etc/pipelock/integrity/binary-pin.sha256"
 	defaultWrapperInvPath    = "/etc/pipelock/contain/wrappers.json"
 	defaultToolsListPath     = "/etc/pipelock/contain/tools.list"
+	defaultWorkspaceInvPath  = "/etc/pipelock/contain/workspaces.json"
 	defaultPipelockTarget    = "/usr/local/bin/pipelock"
 	defaultSystemCABundle    = "/etc/ssl/certs/ca-bundle.crt"
 

--- a/internal/cli/contain/rollback.go
+++ b/internal/cli/contain/rollback.go
@@ -117,6 +117,11 @@ func rollbackActions(opts rollbackOpts) []step {
 		actionMaybeDeleteUser(opts, false), // agent
 		actionMaybeRemoveDir(opts, "config", func(e *installEnv) string { return e.configDir }),
 		actionMaybeRemoveDir(opts, "data", func(e *installEnv) string { return e.dataDir }),
+		// Revoke MUST execute (in reverse walk: first) before the agent
+		// user is deleted AND before the config dir removal wipes the
+		// inventory file. List position controls reverse-walk priority,
+		// so revoke sits at a higher index than both blockers.
+		actionRevokeWorkspaceACLs(opts),
 		actionPreserve("pipelock.yaml (kept with --keep-data)"),
 		actionPreserve("config chown (resolved by dir removal)"),
 		actionPreserve("data chown (resolved by dir removal)"),
@@ -130,9 +135,47 @@ func rollbackActions(opts rollbackOpts) []step {
 		actionRemoveNFTRules(),
 		actionRemovePath("plk-launch tools.list", func(e *installEnv) string { return e.toolsListPath }),
 		actionRemoveWrapper("plk-launch", "plk-launch"),
+		actionRemoveWrapper("plk meta-wrapper", "plk"),
 		actionRemoveToolWrappers(),
 		actionRemovePath("wrapper inventory", func(e *installEnv) string { return e.wrapperInvPath }),
 		actionRemoveSudoers(),
+	}
+}
+
+// actionRevokeWorkspaceACLs removes workspace ACLs before rollback deletes
+// pipelock-agent. That prevents orphan numeric ACL entries if the UID is later
+// reused by an unrelated account. The on-disk inventory is preserved when
+// --keep-data is set so a subsequent install + grant-workspace round trip
+// can rebuild ACLs from the saved mapping; otherwise it is removed alongside
+// other rollback artifacts.
+func actionRevokeWorkspaceACLs(opts rollbackOpts) step {
+	return step{
+		name: "revoke-workspace-acls",
+		desc: "revoke workspace ACLs tracked in /etc/pipelock/contain/workspaces.json",
+		undo: func(ctx context.Context, env *installEnv) error {
+			inv, err := loadWorkspaceInventory(env)
+			if err != nil {
+				return err
+			}
+			if len(inv.Workspaces) == 0 {
+				return nil
+			}
+			commands, err := workspaceRevokeAllCommands(env, inv.Workspaces, env.agentUserName)
+			if err != nil {
+				return err
+			}
+			if err := runWorkspaceCommands(ctx, env, commands); err != nil {
+				return err
+			}
+			if opts.keepData {
+				return nil
+			}
+			if err := env.removeFile(env.workspaceInvPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove %s: %w", env.workspaceInvPath, err)
+			}
+			_ = env.removeFile(env.workspaceInvPath + ".bak")
+			return nil
+		},
 	}
 }
 

--- a/internal/cli/contain/rollback_test.go
+++ b/internal/cli/contain/rollback_test.go
@@ -194,6 +194,128 @@ func TestRollbackActions_RemovesWrappersFromInventory(t *testing.T) {
 	}
 }
 
+func TestRollbackActions_RevokesWorkspaceACLsBeforeUserDelete(t *testing.T) {
+	cases := []struct {
+		name           string
+		opts           rollbackOpts
+		wantInventory  bool
+		assertOrdering bool
+	}{
+		{
+			name:           "keep-data preserves inventory",
+			opts:           rollbackOpts{keepData: true},
+			wantInventory:  true,
+			assertOrdering: true,
+		},
+		{
+			name:           "purge removes inventory",
+			opts:           rollbackOpts{keepData: false},
+			wantInventory:  false,
+			assertOrdering: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, runner, _ := newFakeEnv(t)
+			workspace := t.TempDir()
+			if err := writeWorkspaceInventory(env, workspaceInventory{Workspaces: []workspaceGrant{
+				{Path: workspace, Mode: workspaceModeReadOnly},
+			}}); err != nil {
+				t.Fatalf("write workspace inventory: %v", err)
+			}
+			env.lookupUser = func(name string) (*user.User, error) {
+				return &user.User{Uid: "988", Gid: "988", Username: name}, nil
+			}
+
+			actions := rollbackActions(tc.opts)
+			for i := len(actions) - 1; i >= 0; i-- {
+				a := actions[i]
+				if a.undo == nil {
+					continue
+				}
+				_ = a.undo(context.Background(), env)
+			}
+
+			if tc.assertOrdering {
+				revokeIndex, userdelIndex := -1, -1
+				for i, call := range runner.calls {
+					if call.name == testSetfaclCmd && revokeIndex == -1 {
+						revokeIndex = i
+					}
+					if call.name == testUserDel && userdelIndex == -1 {
+						userdelIndex = i
+					}
+				}
+				if revokeIndex == -1 || userdelIndex == -1 || revokeIndex > userdelIndex {
+					t.Fatalf("workspace ACL revoke must happen before userdel; calls=%+v", runner.calls)
+				}
+			}
+
+			_, statErr := os.Stat(env.workspaceInvPath)
+			if tc.wantInventory && statErr != nil {
+				t.Fatalf("inventory must be preserved with keep-data=true: %v", statErr)
+			}
+			if !tc.wantInventory && statErr == nil {
+				t.Fatalf("inventory must be removed with keep-data=false")
+			}
+		})
+	}
+}
+
+func TestRollbackActions_RevokesAncestorsForDeletedWorkspace(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	parent := t.TempDir()
+	workspace := filepath.Join(parent, "deleted")
+	if err := writeWorkspaceInventory(env, workspaceInventory{Workspaces: []workspaceGrant{
+		{Path: workspace, Mode: workspaceModeReadOnly},
+	}}); err != nil {
+		t.Fatalf("write workspace inventory: %v", err)
+	}
+	env.lookupUser = func(name string) (*user.User, error) {
+		return &user.User{Uid: "988", Gid: "988", Username: name}, nil
+	}
+
+	actions := rollbackActions(rollbackOpts{keepData: true})
+	for i := len(actions) - 1; i >= 0; i-- {
+		a := actions[i]
+		if a.undo == nil {
+			continue
+		}
+		_ = a.undo(context.Background(), env)
+	}
+
+	var ancestorCleanup bool
+	for _, call := range runner.calls {
+		if call.name == testSetfaclCmd && containsArg(call.args, parent) {
+			ancestorCleanup = true
+		}
+	}
+	if !ancestorCleanup {
+		t.Fatalf("rollback did not clean parent ACL for deleted workspace; calls=%+v", runner.calls)
+	}
+}
+
+func TestRollbackActions_FailsOnMalformedWorkspaceInventory(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.workspaceInvPath), 0o750); err != nil {
+		t.Fatalf("mkdir inventory dir: %v", err)
+	}
+	if err := os.WriteFile(env.workspaceInvPath, []byte("{nope"), 0o600); err != nil {
+		t.Fatalf("write inventory: %v", err)
+	}
+	actions := rollbackActions(rollbackOpts{keepData: true})
+	for _, a := range actions {
+		if a.name == "revoke-workspace-acls" {
+			err := a.undo(context.Background(), env)
+			if err == nil || !strings.Contains(err.Error(), "workspaces.json") {
+				t.Fatalf("err = %v, want malformed inventory failure", err)
+			}
+			return
+		}
+	}
+	t.Fatal("revoke-workspace-acls action not found")
+}
+
 func TestRollback_DryRunPrintsPlan(t *testing.T) {
 	actions := rollbackActions(rollbackOpts{keepData: true})
 	var buf bytes.Buffer

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -112,6 +112,7 @@ type probeEnv struct {
 	pinPath        string
 	wrapperInvPath string
 	toolsListPath  string
+	workspacePaths []string
 
 	runCmd     runCommand
 	dialCtx    dialFunc
@@ -241,6 +242,52 @@ func allProbes() []probe {
 	}
 }
 
+func probesForEnv(env *probeEnv) []probe {
+	probes := allProbes()
+	if len(env.workspacePaths) > 0 {
+		probes = append(probes, probe{13, "workspace_access", "pipelock-agent can read configured workspace paths", probeWorkspaceAccess})
+	}
+	return probes
+}
+
+func probeWorkspaceAccess(ctx context.Context, env *probeEnv) (string, string) {
+	var bad []string
+	for _, path := range env.workspacePaths {
+		clean, err := filepath.Abs(filepath.Clean(path))
+		if err != nil {
+			bad = append(bad, fmt.Sprintf("%s resolve: %v", path, err))
+			continue
+		}
+		info, err := env.stat(clean)
+		if err != nil {
+			bad = append(bad, fmt.Sprintf("%s stat: %v", clean, err))
+			continue
+		}
+		args := []string{"-n", "-u", env.agentUserName, "--", "test", "-r", clean}
+		if info.IsDir() {
+			args = []string{"-n", "-u", env.agentUserName, "--", "test", "-r", clean, "-a", "-x", clean}
+		}
+		out, code, err := env.runCmd(ctx, "sudo", args...)
+		if err != nil {
+			bad = append(bad, fmt.Sprintf("%s check failed: %v", clean, err))
+			continue
+		}
+		if isSudoUserMissing(out) {
+			return statusSkip, "pipelock-agent user missing (install never ran)"
+		}
+		if isSudoRefusal(out) {
+			return statusSkip, "sudo -n refused (no NOPASSWD rule for operator -> pipelock-agent)"
+		}
+		if code != 0 {
+			bad = append(bad, fmt.Sprintf("%s not readable/traversable by %s: %s", clean, env.agentUserName, oneLine(out)))
+		}
+	}
+	if len(bad) > 0 {
+		return statusFail, strings.Join(bad, "; ")
+	}
+	return statusPass, fmt.Sprintf("%d workspace path(s) readable by %s", len(env.workspacePaths), env.agentUserName)
+}
+
 func probeListedToolTargets(_ context.Context, env *probeEnv) (string, string) {
 	data, err := env.readFile(env.toolsListPath)
 	if err != nil {
@@ -330,7 +377,10 @@ func resolveToolInPath(env *probeEnv, name, pathList string) (string, bool) {
 //   - 5  tool not in allow-list — PASS
 //   - 6  in allow-list but PATH lookup failed — unexpected
 func probeCCLaunchAllowList(ctx context.Context, env *probeEnv) (string, string) {
-	const sentinelTool = "pipelock-probe-sentinel-not-a-real-tool"
+	// Sentinel must satisfy containToolNameRegex (max 31 chars) so plk-launch
+	// reaches the allow-list rejection path (exit 5) instead of the up-front
+	// name regex (exit 3). "not-a-real-tool" suffix preserves operator intent.
+	const sentinelTool = "pipelock-probe-sentinel-tool"
 
 	out, code, err := env.runCmd(ctx, "sudo", "-n", "-u", env.agentUserName, "--",
 		env.launchPath, sentinelTool)
@@ -432,8 +482,9 @@ type aggregateBody struct {
 
 // verifyOpts collects all flag-derived state for runVerify.
 type verifyOpts struct {
-	jsonOutput bool
-	port       int
+	jsonOutput     bool
+	port           int
+	workspacePaths []string
 }
 
 func verifyCmd() *cobra.Command {
@@ -451,7 +502,9 @@ policy, run two egress canaries (pipelock-agent must NOT reach the internet
 directly; the operator user must still reach the internet), verify the
 installed binary matches the TOFU integrity pin written at install
 time, and exercise plk-launch end-to-end with a sentinel tool to confirm
-the allow-list enforcement path actually fires.
+the allow-list enforcement path actually fires. Pass --workspace to also
+verify that pipelock-agent can read/traverse real project directories before
+making plk wrappers the default entry point.
 
 verify never mutates state. Probes that require root visibility
 (nft list ruleset) record skip when run unprivileged.
@@ -470,12 +523,14 @@ Exit codes:
 			}
 			env := defaultProbeEnv()
 			env.port = opts.port
+			env.workspacePaths = append([]string(nil), opts.workspacePaths...)
 			return runVerify(cmd, env, opts)
 		},
 	}
 
 	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit newline-delimited JSON instead of text")
 	cmd.Flags().IntVar(&opts.port, "port", defaultProxyPort, "pipelock listen port to probe on loopback")
+	cmd.Flags().StringArrayVar(&opts.workspacePaths, "workspace", nil, "workspace path that pipelock-agent must be able to read/traverse (repeatable)")
 
 	return cmd
 }
@@ -503,7 +558,7 @@ func runVerify(cmd *cobra.Command, env *probeEnv, opts verifyOpts) error {
 		_, _ = fmt.Fprintln(w, "pipelock contain verify")
 	}
 
-	probes := allProbes()
+	probes := probesForEnv(env)
 	var passN, failN, skipN int
 
 	for _, p := range probes {
@@ -815,6 +870,19 @@ func probeWrapperScripts(_ context.Context, env *probeEnv) (string, string) {
 		return statusFail, fmt.Sprintf("%s has perm 0o%03o, want 0o755", env.launchPath, mode)
 	}
 
+	metaPath := filepath.Join(env.wrapperDir, "plk")
+	info, err = os.Stat(filepath.Clean(metaPath))
+	if err != nil {
+		return statusFail, fmt.Sprintf("%s missing: %v", metaPath, err)
+	}
+	if !info.Mode().IsRegular() || info.Size() == 0 {
+		return statusFail, fmt.Sprintf("%s is not a non-empty executable wrapper file", metaPath)
+	}
+	mode = info.Mode().Perm()
+	if mode != 0o755 {
+		return statusFail, fmt.Sprintf("%s has perm 0o%03o, want 0o755", metaPath, mode)
+	}
+
 	wrappers, err := wrappersForVerify(env)
 	if err != nil {
 		return statusFail, err.Error()
@@ -845,7 +913,7 @@ func probeWrapperScripts(_ context.Context, env *probeEnv) (string, string) {
 		return statusFail, fmt.Sprintf("no tool wrappers found in %s (expected one of %v)",
 			env.wrapperDir, wrappers)
 	}
-	return statusPass, fmt.Sprintf("plk-launch + %d tool wrapper(s): %s",
+	return statusPass, fmt.Sprintf("plk + plk-launch + %d tool wrapper(s): %s",
 		len(foundNames), strings.Join(foundNames, ","))
 }
 

--- a/internal/cli/contain/verify_probe11_test.go
+++ b/internal/cli/contain/verify_probe11_test.go
@@ -18,7 +18,10 @@ import (
 // tests verify the probe's classification of every relevant plk-launch
 // exit code.
 
-const probe11Sentinel = "pipelock-probe-sentinel-not-a-real-tool"
+// Mirrors verify.go's sentinelTool. Must satisfy containToolNameRegex (max 31
+// chars) so plk-launch routes the sentinel to the allow-list rejection path
+// (exit 5), not the early name regex (exit 3).
+const probe11Sentinel = "pipelock-probe-sentinel-tool"
 
 func TestProbeCCLaunchAllowList_PassOnExit5(t *testing.T) {
 	env := makeProbeEnv(t)
@@ -124,6 +127,61 @@ func TestProbeCCLaunchAllowList_SkipOnRunErr(t *testing.T) {
 	if status != statusSkip {
 		t.Errorf("status: %s, want skip", status)
 	}
+}
+
+func TestProbeWorkspaceAccess(t *testing.T) {
+	t.Run("passes for readable path", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		dir := t.TempDir()
+		env.workspacePaths = []string{dir}
+		env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+			if name != "sudo" || !containsArg(args, dir) {
+				t.Fatalf("unexpected command: %s %v", name, args)
+			}
+			return "", 0, nil
+		}
+		status, detail := probeWorkspaceAccess(context.Background(), env)
+		if status != statusPass {
+			t.Fatalf("status: %s detail=%s", status, detail)
+		}
+	})
+
+	t.Run("fails for unreadable path", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		dir := t.TempDir()
+		env.workspacePaths = []string{dir}
+		env.runCmd = func(context.Context, string, ...string) (string, int, error) {
+			return "Permission denied", 1, nil
+		}
+		status, detail := probeWorkspaceAccess(context.Background(), env)
+		if status != statusFail {
+			t.Fatalf("status: %s detail=%s", status, detail)
+		}
+		if !strings.Contains(detail, "not readable/traversable") {
+			t.Fatalf("detail: %s", detail)
+		}
+	})
+
+	t.Run("resolves relative path before sudo check", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		cwd := t.TempDir()
+		t.Chdir(cwd)
+		dir := filepath.Join(cwd, "project")
+		if err := os.Mkdir(dir, 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		env.workspacePaths = []string{"project"}
+		env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+			if name != "sudo" || !containsArg(args, dir) {
+				t.Fatalf("unexpected command: %s %v, want absolute path %s", name, args, dir)
+			}
+			return "", 0, nil
+		}
+		status, detail := probeWorkspaceAccess(context.Background(), env)
+		if status != statusPass {
+			t.Fatalf("status: %s detail=%s", status, detail)
+		}
+	})
 }
 
 func TestProbeListedToolTargets_PassWithExplicitTarget(t *testing.T) {

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -490,6 +490,7 @@ func TestProbeWrapperScripts(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		env := makeProbeEnv(t)
 		writeFakeWrapper(t, env.launchPath, 0o755)
+		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk"), 0o755)
 		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk-claude"), 0o755)
 		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
 		if gotStatus != statusPass {
@@ -523,9 +524,23 @@ func TestProbeWrapperScripts(t *testing.T) {
 		}
 	})
 
+	t.Run("meta wrapper missing", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		writeFakeWrapper(t, env.launchPath, 0o755)
+		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk-claude"), 0o755)
+		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, filepath.Join(env.wrapperDir, "plk")) {
+			t.Fatalf("detail: got %q, want plk meta wrapper", gotDetail)
+		}
+	})
+
 	t.Run("no tool wrappers", func(t *testing.T) {
 		env := makeProbeEnv(t)
 		writeFakeWrapper(t, env.launchPath, 0o755)
+		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk"), 0o755)
 		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
 		if gotStatus != statusFail {
 			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
@@ -538,6 +553,7 @@ func TestProbeWrapperScripts(t *testing.T) {
 	t.Run("tool wrapper wrong mode", func(t *testing.T) {
 		env := makeProbeEnv(t)
 		writeFakeWrapper(t, env.launchPath, 0o755)
+		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk"), 0o755)
 		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk-claude"), 0o644)
 		gotStatus, gotDetail := probeWrapperScripts(context.Background(), env)
 		if gotStatus != statusFail {
@@ -553,6 +569,7 @@ func TestProbeWrapperScripts(t *testing.T) {
 		env.wrapperInvPath = filepath.Join(t.TempDir(), "wrappers.json")
 		env.readFile = os.ReadFile
 		writeFakeWrapper(t, env.launchPath, 0o755)
+		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk"), 0o755)
 		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk-rustup"), 0o755)
 		body, err := json.Marshal(wrapperInventory{Wrappers: []string{"plk-rustup"}})
 		if err != nil {
@@ -576,6 +593,7 @@ func TestProbeWrapperScripts(t *testing.T) {
 		env.wrapperInvPath = filepath.Join(t.TempDir(), "wrappers.json")
 		env.readFile = os.ReadFile
 		writeFakeWrapper(t, env.launchPath, 0o755)
+		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk"), 0o755)
 		if err := os.WriteFile(env.wrapperInvPath, []byte("{"), 0o600); err != nil {
 			t.Fatalf("write inventory: %v", err)
 		}
@@ -594,6 +612,7 @@ func TestProbeWrapperScripts(t *testing.T) {
 		env.wrapperInvPath = filepath.Join(t.TempDir(), "wrappers.json")
 		env.readFile = os.ReadFile
 		writeFakeWrapper(t, env.launchPath, 0o755)
+		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk"), 0o755)
 		body, err := json.Marshal(wrapperInventory{Wrappers: []string{""}})
 		if err != nil {
 			t.Fatalf("marshal: %v", err)
@@ -616,6 +635,7 @@ func TestProbeWrapperScripts(t *testing.T) {
 		env.wrapperInvPath = filepath.Join(t.TempDir(), "wrappers.json")
 		env.readFile = os.ReadFile
 		writeFakeWrapper(t, env.launchPath, 0o755)
+		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk"), 0o755)
 		dirWrapper := filepath.Join(env.wrapperDir, "plk-dir")
 		if err := os.Mkdir(dirWrapper, 0o750); err != nil {
 			t.Fatalf("mkdir wrapper dir: %v", err)
@@ -642,6 +662,7 @@ func TestProbeWrapperScripts(t *testing.T) {
 		env.wrapperInvPath = filepath.Join(t.TempDir(), "wrappers.json")
 		env.readFile = os.ReadFile
 		writeFakeWrapper(t, env.launchPath, 0o755)
+		writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk"), 0o755)
 		emptyWrapper := filepath.Join(env.wrapperDir, "plk-empty")
 		if err := os.WriteFile(emptyWrapper, nil, 0o755); err != nil { //nolint:gosec // executable mode mirrors production wrapper contract.
 			t.Fatalf("write empty wrapper: %v", err)
@@ -1499,6 +1520,7 @@ func allPassEnv(t *testing.T) *probeEnv {
 
 	// Filesystem state for probes 4, 5, 7, 12.
 	writeFakeWrapper(t, env.launchPath, 0o755)
+	writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk"), 0o755)
 	writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk-claude"), 0o755)
 	toolTarget := filepath.Join(t.TempDir(), "claude")
 	writeFakeWrapper(t, toolTarget, 0o755)
@@ -1543,8 +1565,8 @@ func defaultRunForAllPass(name string, args []string) (string, int, error) {
 	case testSudoCmd:
 		// Probe 11: plk-launch allow-list probe invokes plk-launch with a
 		// sentinel tool name. Expect exit 5 = denial.
-		if containsArg(args, "plk-launch") || containsArg(args, "pipelock-probe-sentinel-not-a-real-tool") {
-			return "plk-launch: tool pipelock-probe-sentinel-not-a-real-tool not in pipelock contain allow-list", 5, nil
+		if containsArg(args, "plk-launch") || containsArg(args, probe11Sentinel) {
+			return "plk-launch: tool " + probe11Sentinel + " not in pipelock contain allow-list", 5, nil
 		}
 		// Either pipelock-agent (probe 8) or operator (probe 9). Match by argv.
 		if containsArg(args, testAgentUser) {

--- a/internal/cli/contain/workspace.go
+++ b/internal/cli/contain/workspace.go
@@ -1,0 +1,473 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+const (
+	workspaceModeReadOnly  = "read-only"
+	workspaceModeReadWrite = "read-write"
+)
+
+type workspaceOpts struct {
+	allowSystemPath bool
+	dryRun          bool
+	mode            string
+	agentUser       string
+}
+
+type workspaceCommand struct {
+	name string
+	args []string
+}
+
+type workspaceInventory struct {
+	Workspaces []workspaceGrant `json:"workspaces"`
+}
+
+type workspaceGrant struct {
+	Path string `json:"path"`
+	Mode string `json:"mode"`
+}
+
+var deniedWorkspacePrefixes = []string{
+	"/",
+	"/bin",
+	"/boot",
+	"/dev",
+	"/etc",
+	"/lib",
+	"/lib64",
+	"/opt",
+	"/proc",
+	"/root",
+	"/run",
+	"/sbin",
+	"/sys",
+	"/usr",
+	"/var",
+}
+
+// Note: workspace inventory read-modify-write is not protected against
+// concurrent invocations. Operators should not run grant-workspace or
+// revoke-workspace in parallel against the same host; the JSON file can
+// be corrupted by interleaved writes. Pipelock contain is a host-local
+// admin tool, so this is acceptable in the current threat model.
+
+func grantWorkspaceCmd() *cobra.Command {
+	var opts workspaceOpts
+
+	cmd := &cobra.Command{
+		Use:   "grant-workspace <path>",
+		Short: "Grant pipelock-agent ACL access to a workspace",
+		Long: `Grant the contained agent user access to one workspace directory.
+
+This fixes the common EACCES case where plk-claude/plk-codex run correctly
+under nftables containment, but cannot read or edit the operator's project
+directory. The command grants execute-only traversal on parent directories and
+read-only ACLs by default only inside the named workspace. Use --mode read-write
+when the contained agent should edit files in place.
+
+The workspace path should live under an operator-owned project tree. System
+paths such as /etc, /usr, /var, /proc, /sys, /root, and / are rejected by
+default because granting parent traversal there widens the contained agent's
+filesystem reach. If the workspace path sits in a directory writable by someone
+other than the operator, ACLs may apply to an unexpected inode.
+
+Must be run as root.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !opts.dryRun && os.Geteuid() != 0 {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New("grant-workspace must be run as root (use sudo)"))
+			}
+			if opts.agentUser == "" {
+				opts.agentUser = defaultAgentUser
+			}
+			if err := validateContainUsername("agent user", opts.agentUser); err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			env := defaultInstallEnv(cmd.OutOrStdout())
+			env.agentUserName = opts.agentUser
+			return runGrantWorkspace(cmd.Context(), env, args[0], opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "print planned ACL commands without mutating state")
+	cmd.Flags().BoolVar(&opts.allowSystemPath, "allow-system-path", false, "allow granting ACLs under protected system path prefixes")
+	cmd.Flags().StringVar(&opts.mode, "mode", workspaceModeReadOnly, "workspace ACL mode: read-only or read-write")
+	cmd.Flags().StringVar(&opts.agentUser, "agent-user", defaultAgentUser, "contained agent user to grant access to")
+
+	return cmd
+}
+
+func revokeWorkspaceCmd() *cobra.Command {
+	var opts workspaceOpts
+
+	cmd := &cobra.Command{
+		Use:   "revoke-workspace <path>",
+		Short: "Revoke pipelock-agent ACL access from a workspace",
+		Long: `Revoke ACL access previously granted by pipelock contain grant-workspace.
+
+This removes the contained agent user's access ACLs from the workspace and
+removes execute-only traversal ACLs from parent directories that are no longer
+needed by other tracked workspaces.
+
+Must be run as root.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !opts.dryRun && os.Geteuid() != 0 {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New("revoke-workspace must be run as root (use sudo)"))
+			}
+			if opts.agentUser == "" {
+				opts.agentUser = defaultAgentUser
+			}
+			if err := validateContainUsername("agent user", opts.agentUser); err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			env := defaultInstallEnv(cmd.OutOrStdout())
+			env.agentUserName = opts.agentUser
+			return runRevokeWorkspace(cmd.Context(), env, args[0], opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "print planned ACL commands without mutating state")
+	cmd.Flags().StringVar(&opts.agentUser, "agent-user", defaultAgentUser, "contained agent user to revoke access from")
+
+	return cmd
+}
+
+func runGrantWorkspace(ctx context.Context, env *installEnv, path string, opts workspaceOpts) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	mode := opts.mode
+	if mode == "" {
+		mode = workspaceModeReadOnly
+	}
+	if mode != workspaceModeReadWrite && mode != workspaceModeReadOnly {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("invalid --mode %q (want read-write or read-only)", mode))
+	}
+	workspace, err := resolveWorkspaceDir(env, path, opts.allowSystemPath)
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+	}
+	commands := workspaceACLCommands(workspace, env.agentUserName, mode)
+	if opts.dryRun {
+		_, _ = fmt.Fprintf(env.out, "pipelock contain grant-workspace %s - planned:\n", workspace)
+		for i, c := range commands {
+			_, _ = fmt.Fprintf(env.out, "  %d. %s %s\n", i+1, c.name, strings.Join(shellQuoteArgs(c.args), " "))
+		}
+		_, _ = fmt.Fprintf(env.out, "  %d. record grant in %s\n", len(commands)+1, env.workspaceInvPath)
+		return nil
+	}
+	if err := runWorkspaceCommands(ctx, env, commands); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, err)
+	}
+	if err := recordWorkspaceGrant(env, workspaceGrant{Path: workspace, Mode: mode}); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("record workspace grant: %w", err))
+	}
+	_, _ = fmt.Fprintf(env.out, "granted %s access to %s for %s.\n", mode, workspace, env.agentUserName)
+	return nil
+}
+
+func runRevokeWorkspace(ctx context.Context, env *installEnv, path string, opts workspaceOpts) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	inv, err := loadWorkspaceInventory(env)
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("read workspace inventory: %w", err))
+	}
+	workspace, workspaceExists, err := resolveWorkspaceForRevoke(env, path, inv)
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+	}
+	remaining := workspaceGrantsExcept(inv.Workspaces, workspace)
+	commands := workspaceRevokeCommands(workspace, env.agentUserName, ancestorsNeededBy(remaining), workspaceExists)
+	if opts.dryRun {
+		_, _ = fmt.Fprintf(env.out, "pipelock contain revoke-workspace %s - planned:\n", workspace)
+		for i, c := range commands {
+			_, _ = fmt.Fprintf(env.out, "  %d. %s %s\n", i+1, c.name, strings.Join(shellQuoteArgs(c.args), " "))
+		}
+		_, _ = fmt.Fprintf(env.out, "  %d. update %s\n", len(commands)+1, env.workspaceInvPath)
+		return nil
+	}
+	if err := runWorkspaceCommands(ctx, env, commands); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, err)
+	}
+	if err := writeWorkspaceInventory(env, workspaceInventory{Workspaces: remaining}); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("update workspace inventory: %w", err))
+	}
+	_, _ = fmt.Fprintf(env.out, "revoked workspace access to %s for %s.\n", workspace, env.agentUserName)
+	return nil
+}
+
+func resolveWorkspaceForRevoke(env *installEnv, path string, inv workspaceInventory) (string, bool, error) {
+	workspace, err := resolveWorkspaceDir(env, path, true)
+	if err == nil {
+		return workspace, true, nil
+	}
+	if strings.TrimSpace(path) == "" {
+		return "", false, err
+	}
+	abs, absErr := filepath.Abs(filepath.Clean(path))
+	if absErr != nil {
+		return "", false, fmt.Errorf("resolve workspace path: %w", absErr)
+	}
+	for _, grant := range inv.Workspaces {
+		if grant.Path == abs {
+			return abs, false, nil
+		}
+	}
+	return "", false, err
+}
+
+func resolveWorkspaceDir(env *installEnv, path string, allowSystemPath bool) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("workspace path is empty")
+	}
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace path: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace symlinks %s: %w", abs, err)
+	}
+	info, err := env.stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("stat workspace %s: %w", resolved, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("workspace %s is not a directory", resolved)
+	}
+	if !allowSystemPath {
+		if denied := deniedWorkspacePrefix(resolved); denied != "" {
+			return "", fmt.Errorf("workspace %s is under protected system path %s (choose an operator project directory or pass --allow-system-path explicitly)", resolved, denied)
+		}
+	}
+	return resolved, nil
+}
+
+func workspaceACLCommands(workspace, agentUser, mode string) []workspaceCommand {
+	perms := "rwX"
+	if mode == workspaceModeReadOnly {
+		perms = "rX"
+	}
+	var commands []workspaceCommand
+	ancestors := workspaceAncestors(workspace)
+	if len(ancestors) > 0 {
+		args := []string{"-m", "u:" + agentUser + ":--x"}
+		args = append(args, ancestors...)
+		commands = append(commands, workspaceCommand{name: "setfacl", args: args})
+	}
+	commands = append(commands,
+		workspaceCommand{name: "setfacl", args: []string{"-R", "-m", "u:" + agentUser + ":" + perms, workspace}},
+		workspaceCommand{name: "find", args: []string{workspace, "-type", "d", "-exec", "setfacl", "-m", "d:u:" + agentUser + ":" + perms, "{}", "+"}},
+	)
+	return commands
+}
+
+func workspaceRevokeCommands(workspace, agentUser string, keepAncestors map[string]bool, workspaceExists bool) []workspaceCommand {
+	var commands []workspaceCommand
+	if workspaceExists {
+		commands = append(commands,
+			workspaceCommand{name: "setfacl", args: []string{"-R", "-x", "u:" + agentUser, workspace}},
+			workspaceCommand{name: "find", args: []string{workspace, "-type", "d", "-exec", "setfacl", "-x", "d:u:" + agentUser, "{}", "+"}},
+		)
+	}
+	var ancestors []string
+	for _, ancestor := range workspaceAncestors(workspace) {
+		if !keepAncestors[ancestor] {
+			ancestors = append(ancestors, ancestor)
+		}
+	}
+	if len(ancestors) > 0 {
+		args := []string{"-x", "u:" + agentUser}
+		args = append(args, ancestors...)
+		commands = append(commands, workspaceCommand{name: "setfacl", args: args})
+	}
+	return commands
+}
+
+func workspaceRevokeAllCommands(env *installEnv, grants []workspaceGrant, agentUser string) ([]workspaceCommand, error) {
+	seenWorkspaces := make(map[string]bool, len(grants))
+	seenAncestors := map[string]bool{}
+	var commands []workspaceCommand
+	for _, grant := range grants {
+		if seenWorkspaces[grant.Path] {
+			continue
+		}
+		seenWorkspaces[grant.Path] = true
+		if _, err := env.stat(grant.Path); err == nil {
+			commands = append(commands,
+				workspaceCommand{name: "setfacl", args: []string{"-R", "-x", "u:" + agentUser, grant.Path}},
+				workspaceCommand{name: "find", args: []string{grant.Path, "-type", "d", "-exec", "setfacl", "-x", "d:u:" + agentUser, "{}", "+"}},
+			)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("stat workspace %s: %w", grant.Path, err)
+		}
+		for _, ancestor := range workspaceAncestors(grant.Path) {
+			seenAncestors[ancestor] = true
+		}
+	}
+	if len(seenAncestors) > 0 {
+		ancestors := make([]string, 0, len(seenAncestors))
+		for ancestor := range seenAncestors {
+			ancestors = append(ancestors, ancestor)
+		}
+		slices.Sort(ancestors)
+		args := []string{"-x", "u:" + agentUser}
+		args = append(args, ancestors...)
+		commands = append(commands, workspaceCommand{name: "setfacl", args: args})
+	}
+	return commands, nil
+}
+
+func workspaceAncestors(workspace string) []string {
+	clean := filepath.Clean(workspace)
+	var reversed []string
+	for parent := filepath.Dir(clean); parent != "." && parent != "/" && parent != clean; parent = filepath.Dir(parent) {
+		reversed = append(reversed, parent)
+	}
+	ancestors := make([]string, 0, len(reversed))
+	for i := len(reversed) - 1; i >= 0; i-- {
+		ancestors = append(ancestors, reversed[i])
+	}
+	return ancestors
+}
+
+func deniedWorkspacePrefix(path string) string {
+	clean := filepath.Clean(path)
+	for _, prefix := range deniedWorkspacePrefixes {
+		if prefix == "/" {
+			if clean == "/" {
+				return prefix
+			}
+			continue
+		}
+		if clean == prefix || strings.HasPrefix(clean, prefix+string(os.PathSeparator)) {
+			return prefix
+		}
+	}
+	return ""
+}
+
+func runWorkspaceCommands(ctx context.Context, env *installEnv, commands []workspaceCommand) error {
+	for _, c := range commands {
+		out, code, err := env.runCmd(ctx, c.name, c.args...)
+		if err != nil {
+			return fmt.Errorf("%s: %w", c.name, err)
+		}
+		if code != 0 {
+			return fmt.Errorf("%s exit %d: %s", c.name, code, oneLine(out))
+		}
+	}
+	return nil
+}
+
+func recordWorkspaceGrant(env *installEnv, grant workspaceGrant) error {
+	inv, err := loadWorkspaceInventory(env)
+	if err != nil {
+		return err
+	}
+	replaced := false
+	for i, existing := range inv.Workspaces {
+		if existing.Path == grant.Path {
+			inv.Workspaces[i] = grant
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		inv.Workspaces = append(inv.Workspaces, grant)
+	}
+	slices.SortFunc(inv.Workspaces, func(a, b workspaceGrant) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+	return writeWorkspaceInventory(env, inv)
+}
+
+func readWorkspaceInventory(env *installEnv) workspaceInventory {
+	inv, err := loadWorkspaceInventory(env)
+	if err != nil {
+		return workspaceInventory{}
+	}
+	return inv
+}
+
+func loadWorkspaceInventory(env *installEnv) (workspaceInventory, error) {
+	data, err := env.readFile(env.workspaceInvPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return workspaceInventory{}, nil
+		}
+		return workspaceInventory{}, err
+	}
+	var inv workspaceInventory
+	if err := json.Unmarshal(data, &inv); err != nil {
+		return workspaceInventory{}, fmt.Errorf("parse %s: %w", env.workspaceInvPath, err)
+	}
+	return inv, nil
+}
+
+func writeWorkspaceInventory(env *installEnv, inv workspaceInventory) error {
+	if err := env.mkdirAll(filepath.Dir(env.workspaceInvPath), modeDirTraversable); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(env.workspaceInvPath), err)
+	}
+	if err := env.chmod(filepath.Dir(env.workspaceInvPath), modeDirTraversable); err != nil {
+		return fmt.Errorf("chmod %s: %w", filepath.Dir(env.workspaceInvPath), err)
+	}
+	data, err := json.MarshalIndent(inv, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal workspace inventory: %w", err)
+	}
+	data = append(data, '\n')
+	return backupAndWrite(env, env.workspaceInvPath, data, modeAllowListReadable)
+}
+
+func workspaceGrantsExcept(grants []workspaceGrant, path string) []workspaceGrant {
+	out := make([]workspaceGrant, 0, len(grants))
+	for _, grant := range grants {
+		if grant.Path != path {
+			out = append(out, grant)
+		}
+	}
+	return out
+}
+
+func ancestorsNeededBy(grants []workspaceGrant) map[string]bool {
+	needed := map[string]bool{}
+	for _, grant := range grants {
+		for _, ancestor := range workspaceAncestors(grant.Path) {
+			needed[ancestor] = true
+		}
+	}
+	return needed
+}
+
+func shellQuoteArgs(args []string) []string {
+	out := make([]string, 0, len(args))
+	for _, arg := range args {
+		out = append(out, shellQuote(arg))
+	}
+	return out
+}

--- a/internal/cli/contain/workspace_test.go
+++ b/internal/cli/contain/workspace_test.go
@@ -1,0 +1,392 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testSetfaclCmd = "setfacl"
+
+func TestWorkspaceACLCommands(t *testing.T) {
+	commands := workspaceACLCommands("/home/josh/dev/pipelock", "pipelock-agent", workspaceModeReadWrite)
+	if len(commands) != 3 {
+		t.Fatalf("commands len = %d, want 3", len(commands))
+	}
+	if commands[0].name != testSetfaclCmd || !containsArg(commands[0].args, "/home/josh/dev") {
+		t.Fatalf("ancestor command = %+v", commands[0])
+	}
+	if got := strings.Join(commands[1].args, " "); !strings.Contains(got, "u:pipelock-agent:rwX") {
+		t.Fatalf("recursive command args = %q, want rwX ACL", got)
+	}
+	if commands[2].name != "find" || !containsArg(commands[2].args, "d:u:pipelock-agent:rwX") {
+		t.Fatalf("default ACL command = %+v", commands[2])
+	}
+}
+
+func TestWorkspaceACLCommandsReadOnly(t *testing.T) {
+	commands := workspaceACLCommands("/srv/project", "pipelock-agent", workspaceModeReadOnly)
+	if got := strings.Join(commands[1].args, " "); !strings.Contains(got, "u:pipelock-agent:rX") {
+		t.Fatalf("recursive command args = %q, want rX ACL", got)
+	}
+	if !containsArg(commands[2].args, "d:u:pipelock-agent:rX") {
+		t.Fatalf("default ACL command = %+v", commands[2])
+	}
+}
+
+func TestRunGrantWorkspaceDryRun(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	var buf bytes.Buffer
+	env.out = &buf
+	workspace := t.TempDir()
+	err := runGrantWorkspace(context.Background(), env, workspace, workspaceOpts{dryRun: true})
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "u:pipelock-agent:rX") || !strings.Contains(out, "workspaces.json") {
+		t.Fatalf("dry-run output missing ACL commands:\n%s", out)
+	}
+}
+
+func TestWorkspaceCommandsWireFlags(t *testing.T) {
+	t.Run("grant dry run", func(t *testing.T) {
+		var buf bytes.Buffer
+		cmd := grantWorkspaceCmd()
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"--dry-run", "--mode", workspaceModeReadWrite, t.TempDir()})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("grant command: %v", err)
+		}
+		if out := buf.String(); !strings.Contains(out, "rwX") || !strings.Contains(out, "planned") {
+			t.Fatalf("grant dry-run output missing plan:\n%s", out)
+		}
+	})
+
+	t.Run("grant invalid agent user", func(t *testing.T) {
+		cmd := grantWorkspaceCmd()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetArgs([]string{"--dry-run", "--agent-user", "bad user", t.TempDir()})
+		if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "agent user") {
+			t.Fatalf("err = %v, want agent user validation failure", err)
+		}
+	})
+
+	t.Run("revoke dry run", func(t *testing.T) {
+		var buf bytes.Buffer
+		cmd := revokeWorkspaceCmd()
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"--dry-run", t.TempDir()})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("revoke command: %v", err)
+		}
+		if out := buf.String(); !strings.Contains(out, "revoke-workspace") || !strings.Contains(out, "planned") {
+			t.Fatalf("revoke dry-run output missing plan:\n%s", out)
+		}
+	})
+
+	t.Run("revoke invalid agent user", func(t *testing.T) {
+		cmd := revokeWorkspaceCmd()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetArgs([]string{"--dry-run", "--agent-user", "bad user", t.TempDir()})
+		if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "agent user") {
+			t.Fatalf("err = %v, want agent user validation failure", err)
+		}
+	})
+}
+
+func TestRunGrantWorkspaceExecutesCommands(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	workspace := t.TempDir()
+	err := runGrantWorkspace(context.Background(), env, workspace, workspaceOpts{mode: workspaceModeReadWrite})
+	if err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	if len(runner.calls) != 3 {
+		t.Fatalf("calls = %d, want 3: %+v", len(runner.calls), runner.calls)
+	}
+	if runner.calls[0].name != testSetfaclCmd || runner.calls[1].name != testSetfaclCmd || runner.calls[2].name != "find" {
+		t.Fatalf("unexpected command sequence: %+v", runner.calls)
+	}
+	inv := readWorkspaceInventory(env)
+	if len(inv.Workspaces) != 1 || inv.Workspaces[0].Path != workspace || inv.Workspaces[0].Mode != workspaceModeReadWrite {
+		t.Fatalf("workspace inventory = %+v", inv)
+	}
+}
+
+func TestRunGrantWorkspaceErrorBranches(t *testing.T) {
+	t.Run("invalid mode", func(t *testing.T) {
+		env, _, _ := newFakeEnv(t)
+		err := runGrantWorkspace(context.Background(), env, t.TempDir(), workspaceOpts{mode: "write-only"})
+		if err == nil || !strings.Contains(err.Error(), "invalid --mode") {
+			t.Fatalf("err = %v, want invalid mode", err)
+		}
+	})
+
+	t.Run("command failure", func(t *testing.T) {
+		env, runner, _ := newFakeEnv(t)
+		workspace := t.TempDir()
+		commands := workspaceACLCommands(workspace, env.agentUserName, workspaceModeReadOnly)
+		runner.on(argvFor(commands[0].name, commands[0].args...), "permission denied", 1, nil)
+		err := runGrantWorkspace(context.Background(), env, workspace, workspaceOpts{})
+		if err == nil || !strings.Contains(err.Error(), "exit 1") {
+			t.Fatalf("err = %v, want command exit failure", err)
+		}
+	})
+
+	t.Run("inventory write failure", func(t *testing.T) {
+		env, _, _ := newFakeEnv(t)
+		env.workspaceInvPath = filepath.Join(t.TempDir(), "inventory-dir")
+		if err := os.Mkdir(env.workspaceInvPath, 0o750); err != nil {
+			t.Fatalf("mkdir inventory path: %v", err)
+		}
+		err := runGrantWorkspace(context.Background(), env, t.TempDir(), workspaceOpts{})
+		if err == nil || !strings.Contains(err.Error(), "record workspace grant") {
+			t.Fatalf("err = %v, want inventory record failure", err)
+		}
+	})
+}
+
+func TestRunGrantWorkspaceRejectsSystemPath(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	for _, prefix := range []string{"/etc", "/opt", "/var", "/usr", "/root"} {
+		t.Run("denies "+prefix, func(t *testing.T) {
+			_, err := resolveWorkspaceDir(env, prefix, false)
+			if err == nil || !strings.Contains(err.Error(), "protected system path") {
+				t.Fatalf("err = %v, want protected system path", err)
+			}
+			_, err = resolveWorkspaceDir(env, prefix, true)
+			if err != nil {
+				t.Fatalf("allow system path: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunRevokeWorkspaceDryRun(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	var buf bytes.Buffer
+	env.out = &buf
+	workspace := t.TempDir()
+	if err := writeWorkspaceInventory(env, workspaceInventory{Workspaces: []workspaceGrant{
+		{Path: workspace, Mode: workspaceModeReadOnly},
+	}}); err != nil {
+		t.Fatalf("write inventory: %v", err)
+	}
+	err := runRevokeWorkspace(context.Background(), env, workspace, workspaceOpts{dryRun: true})
+	if err != nil {
+		t.Fatalf("dry-run revoke: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "revoke-workspace") || !strings.Contains(out, "workspaces.json") {
+		t.Fatalf("dry-run output missing revoke plan:\n%s", out)
+	}
+}
+
+func TestRunRevokeWorkspaceExecutesCommandsAndUpdatesInventory(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	parent := t.TempDir()
+	workspaceA := filepath.Join(parent, "a")
+	workspaceB := filepath.Join(parent, "b")
+	if err := os.Mkdir(workspaceA, 0o750); err != nil {
+		t.Fatalf("mkdir a: %v", err)
+	}
+	if err := os.Mkdir(workspaceB, 0o750); err != nil {
+		t.Fatalf("mkdir b: %v", err)
+	}
+	if err := writeWorkspaceInventory(env, workspaceInventory{Workspaces: []workspaceGrant{
+		{Path: workspaceA, Mode: workspaceModeReadOnly},
+		{Path: workspaceB, Mode: workspaceModeReadWrite},
+	}}); err != nil {
+		t.Fatalf("write inventory: %v", err)
+	}
+	runner.calls = nil
+	err := runRevokeWorkspace(context.Background(), env, workspaceA, workspaceOpts{})
+	if err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("calls = %d, want 2 because shared parent ancestors are preserved: %+v", len(runner.calls), runner.calls)
+	}
+	inv := readWorkspaceInventory(env)
+	if len(inv.Workspaces) != 1 || inv.Workspaces[0].Path != workspaceB {
+		t.Fatalf("workspace inventory = %+v", inv)
+	}
+}
+
+func TestRunRevokeWorkspaceErrorBranches(t *testing.T) {
+	t.Run("empty path", func(t *testing.T) {
+		env, _, _ := newFakeEnv(t)
+		err := runRevokeWorkspace(context.Background(), env, "", workspaceOpts{})
+		if err == nil || !strings.Contains(err.Error(), "workspace path is empty") {
+			t.Fatalf("err = %v, want empty path", err)
+		}
+	})
+
+	t.Run("command failure", func(t *testing.T) {
+		env, runner, _ := newFakeEnv(t)
+		workspace := t.TempDir()
+		if err := writeWorkspaceInventory(env, workspaceInventory{Workspaces: []workspaceGrant{
+			{Path: workspace, Mode: workspaceModeReadOnly},
+		}}); err != nil {
+			t.Fatalf("write inventory: %v", err)
+		}
+		commands := workspaceRevokeCommands(workspace, env.agentUserName, nil, true)
+		runner.on(argvFor(commands[0].name, commands[0].args...), "", 0, errors.New("setfacl unavailable"))
+		err := runRevokeWorkspace(context.Background(), env, workspace, workspaceOpts{})
+		if err == nil || !strings.Contains(err.Error(), "setfacl unavailable") {
+			t.Fatalf("err = %v, want command error", err)
+		}
+	})
+
+	t.Run("inventory update failure", func(t *testing.T) {
+		env, _, _ := newFakeEnv(t)
+		workspace := t.TempDir()
+		if err := writeWorkspaceInventory(env, workspaceInventory{Workspaces: []workspaceGrant{
+			{Path: workspace, Mode: workspaceModeReadOnly},
+		}}); err != nil {
+			t.Fatalf("write inventory: %v", err)
+		}
+		env.writeFile = func(string, []byte, os.FileMode) error {
+			return errors.New("disk full")
+		}
+		err := runRevokeWorkspace(context.Background(), env, workspace, workspaceOpts{})
+		if err == nil || !strings.Contains(err.Error(), "update workspace inventory") {
+			t.Fatalf("err = %v, want inventory update failure", err)
+		}
+	})
+}
+
+func TestRunRevokeWorkspaceHandlesDeletedTrackedWorkspace(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	parent := t.TempDir()
+	workspace := filepath.Join(parent, "deleted")
+	if err := writeWorkspaceInventory(env, workspaceInventory{Workspaces: []workspaceGrant{
+		{Path: workspace, Mode: workspaceModeReadOnly},
+	}}); err != nil {
+		t.Fatalf("write inventory: %v", err)
+	}
+	err := runRevokeWorkspace(context.Background(), env, workspace, workspaceOpts{})
+	if err != nil {
+		t.Fatalf("revoke deleted workspace: %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("calls = %d, want only ancestor ACL cleanup: %+v", len(runner.calls), runner.calls)
+	}
+	if runner.calls[0].name != testSetfaclCmd || !containsArg(runner.calls[0].args, parent) {
+		t.Fatalf("unexpected cleanup command: %+v", runner.calls[0])
+	}
+	inv := readWorkspaceInventory(env)
+	if len(inv.Workspaces) != 0 {
+		t.Fatalf("workspace inventory = %+v, want empty", inv)
+	}
+}
+
+func TestRunRevokeWorkspaceFailsOnMalformedInventory(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(env.workspaceInvPath), 0o750); err != nil {
+		t.Fatalf("mkdir inventory dir: %v", err)
+	}
+	if err := os.WriteFile(env.workspaceInvPath, []byte("{nope"), 0o600); err != nil {
+		t.Fatalf("write inventory: %v", err)
+	}
+	err := runRevokeWorkspace(context.Background(), env, workspace, workspaceOpts{})
+	if err == nil || !strings.Contains(err.Error(), "read workspace inventory") {
+		t.Fatalf("err = %v, want inventory parse failure", err)
+	}
+}
+
+func TestResolveWorkspaceDirRejectsFile(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	path := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	_, err := resolveWorkspaceDir(env, path, false)
+	if err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("err = %v, want not a directory", err)
+	}
+}
+
+func TestResolveWorkspaceDirRejectsEmptyAndMissing(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if _, err := resolveWorkspaceDir(env, "  ", false); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("empty path err = %v", err)
+	}
+	missing := filepath.Join(t.TempDir(), "missing")
+	if _, err := resolveWorkspaceDir(env, missing, false); err == nil || !strings.Contains(err.Error(), "resolve workspace symlinks") {
+		t.Fatalf("missing path err = %v", err)
+	}
+}
+
+func TestWorkspaceRevokeAllCommandsDeduplicatesAncestors(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	commands, err := workspaceRevokeAllCommands(env, []workspaceGrant{
+		{Path: "/home/josh/dev/a", Mode: workspaceModeReadOnly},
+		{Path: "/home/josh/dev/b", Mode: workspaceModeReadOnly},
+	}, "pipelock-agent")
+	if err != nil {
+		t.Fatalf("commands: %v", err)
+	}
+	if len(commands) != 1 {
+		t.Fatalf("commands len = %d, want 1 ancestor cleanup for missing workspaces", len(commands))
+	}
+	last := commands[len(commands)-1]
+	if last.name != testSetfaclCmd {
+		t.Fatalf("last command = %+v", last)
+	}
+	if strings.Count(strings.Join(last.args, " "), "/home/josh/dev") != 1 {
+		t.Fatalf("ancestors not deduplicated: %+v", last)
+	}
+}
+
+func TestWorkspaceRevokeAllCommandsCoversExistingDuplicateAndStatError(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	workspace := t.TempDir()
+	commands, err := workspaceRevokeAllCommands(env, []workspaceGrant{
+		{Path: workspace, Mode: workspaceModeReadOnly},
+		{Path: workspace, Mode: workspaceModeReadWrite},
+	}, env.agentUserName)
+	if err != nil {
+		t.Fatalf("commands: %v", err)
+	}
+	if len(commands) != 3 {
+		t.Fatalf("commands len = %d, want revoke file, default ACL, and ancestor cleanup: %+v", len(commands), commands)
+	}
+
+	env.stat = func(string) (os.FileInfo, error) {
+		return nil, errors.New("stat boom")
+	}
+	_, err = workspaceRevokeAllCommands(env, []workspaceGrant{{Path: workspace, Mode: workspaceModeReadOnly}}, env.agentUserName)
+	if err == nil || !strings.Contains(err.Error(), "stat workspace") {
+		t.Fatalf("err = %v, want stat workspace failure", err)
+	}
+}
+
+func TestRecordWorkspaceGrantReplacesAndSorts(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := recordWorkspaceGrant(env, workspaceGrant{Path: "/tmp/z", Mode: workspaceModeReadOnly}); err != nil {
+		t.Fatalf("record z: %v", err)
+	}
+	if err := recordWorkspaceGrant(env, workspaceGrant{Path: "/tmp/a", Mode: workspaceModeReadOnly}); err != nil {
+		t.Fatalf("record a: %v", err)
+	}
+	if err := recordWorkspaceGrant(env, workspaceGrant{Path: "/tmp/z", Mode: workspaceModeReadWrite}); err != nil {
+		t.Fatalf("replace z: %v", err)
+	}
+	inv := readWorkspaceInventory(env)
+	if len(inv.Workspaces) != 2 {
+		t.Fatalf("inventory len = %d, want 2: %+v", len(inv.Workspaces), inv)
+	}
+	if inv.Workspaces[0].Path != "/tmp/a" || inv.Workspaces[1].Mode != workspaceModeReadWrite {
+		t.Fatalf("inventory not sorted/replaced: %+v", inv.Workspaces)
+	}
+}

--- a/internal/cli/diag/doctor.go
+++ b/internal/cli/diag/doctor.go
@@ -1,0 +1,572 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package diag
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const (
+	doctorStatusOK      = "ok"
+	doctorStatusWarn    = "warn"
+	doctorStatusFail    = "fail"
+	doctorStatusInfo    = "info"
+	doctorSurfaceHTTP   = "http"
+	doctorSurfaceMCP    = "mcp"
+	doctorSurfaceHost   = "host"
+	doctorSurfaceConfig = "config"
+)
+
+const doctorRootBannerText = "running as root: readability checks reflect root's view, not pipelock-proxy's. Re-run as the service user for an accurate readability report."
+
+type doctorReport struct {
+	ConfigFile    string              `json:"config_file"`
+	Mode          string              `json:"mode"`
+	Version       string              `json:"version"`
+	RootRunBanner string              `json:"root_run_banner,omitempty"`
+	Summary       doctorSummary       `json:"summary"`
+	Checks        []doctorReportCheck `json:"checks"`
+}
+
+type doctorSummary struct {
+	OK       int `json:"ok"`
+	Warnings int `json:"warnings"`
+	Failures int `json:"failures"`
+	Info     int `json:"info"`
+}
+
+type doctorReportCheck struct {
+	Name       string `json:"name"`
+	Surface    string `json:"surface"`
+	Status     string `json:"status"`
+	Configured bool   `json:"configured"`
+	Reachable  bool   `json:"reachable"`
+	Enforcing  bool   `json:"enforcing"`
+	Detail     string `json:"detail,omitempty"`
+	Next       string `json:"next,omitempty"`
+}
+
+func DoctorCmd() *cobra.Command {
+	var configFile string
+	var jsonOutput bool
+	var noColor bool
+
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Report whether configured protections are actually enforceable",
+		Long: `Report the difference between configured protections and protections that
+can actually enforce in the current topology. This command does not perform
+network access. It checks local config, filesystem reachability, and known
+deployment prerequisites so operators can catch no-op security settings before
+claiming production coverage.
+
+Readability checks reflect the calling user's view. When run as root (sudo),
+DAC checks are bypassed and any file the kernel can stat will look readable.
+Re-run as the pipelock service user for an accurate "can the service read
+this" report.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, cfgLabel, err := loadTestConfig(configFile)
+			if err != nil {
+				return cliutil.ExitCodeError(2, err)
+			}
+			report := buildDoctorReport(cfg, cfgLabel)
+			if jsonOutput {
+				report.RootRunBanner = doctorRootBannerMessage()
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				if err := enc.Encode(report); err != nil {
+					return fmt.Errorf("encode doctor report JSON: %w", err)
+				}
+			} else {
+				printDoctorReport(cmd, report, !noColor && cliutil.UseColor())
+			}
+			if report.Summary.Failures > 0 {
+				return cliutil.ExitCodeError(2, fmt.Errorf("%d doctor failure(s)", report.Summary.Failures))
+			}
+			if report.Summary.Warnings > 0 {
+				return cliutil.ExitCodeError(1, fmt.Errorf("%d doctor warning(s)", report.Summary.Warnings))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&configFile, "config", "c", "", "config file (default: built-in defaults)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output report as JSON")
+	cmd.Flags().BoolVar(&noColor, "no-color", false, "disable color output")
+
+	return cmd
+}
+
+func buildDoctorReport(cfg *config.Config, cfgLabel string) doctorReport {
+	report := doctorReport{
+		ConfigFile: cfgLabel,
+		Mode:       cfg.Mode,
+		Version:    cliutil.Version,
+	}
+	report.Checks = []doctorReportCheck{
+		checkDoctorHTTPProxy(cfg),
+		checkDoctorTLSInterception(cfg),
+		checkDoctorRequestBodyScanning(cfg),
+		checkDoctorBrowserShield(cfg),
+		checkDoctorMCPWrapperFeatures(cfg),
+		checkDoctorMCPBinaryIntegrity(cfg),
+		checkDoctorMCPToolProvenance(cfg),
+		checkDoctorFileSentry(cfg),
+		checkDoctorSentry(cfg),
+		checkDoctorDeploymentBoundary(cfg),
+	}
+	for _, check := range report.Checks {
+		switch check.Status {
+		case doctorStatusOK:
+			report.Summary.OK++
+		case doctorStatusWarn:
+			report.Summary.Warnings++
+		case doctorStatusFail:
+			report.Summary.Failures++
+		default:
+			report.Summary.Info++
+		}
+	}
+	return report
+}
+
+func checkDoctorHTTPProxy(cfg *config.Config) doctorReportCheck {
+	configured := cfg.ForwardProxy.Enabled || cfg.FetchProxy.Listen != "" || cfg.WebSocketProxy.Enabled || cfg.ReverseProxy.Enabled
+	if !configured {
+		return doctorReportCheck{
+			Name:    "http_proxy",
+			Surface: doctorSurfaceHTTP,
+			Status:  doctorStatusFail,
+			Detail:  "no HTTP, forward, WebSocket, or reverse proxy listener is enabled",
+			Next:    "enable at least one proxy listener for agent network traffic",
+		}
+	}
+	if !doctorGlobalEnforce(cfg) {
+		return doctorReportCheck{
+			Name:       "http_proxy",
+			Surface:    doctorSurfaceHTTP,
+			Status:     doctorStatusWarn,
+			Configured: true,
+			Reachable:  true,
+			Detail:     "proxy listener is configured, but global enforce=false means observation/audit mode",
+			Next:       "set enforce=true before claiming blocking enforcement",
+		}
+	}
+	return doctorReportCheck{
+		Name:       "http_proxy",
+		Surface:    doctorSurfaceHTTP,
+		Status:     doctorStatusOK,
+		Configured: true,
+		Reachable:  true,
+		Enforcing:  true,
+		Detail:     "proxy listener is configured; OS/container policy must still force agents to use it",
+		Next:       "pair this with contain/network-policy checks so direct raw egress is blocked",
+	}
+}
+
+func checkDoctorTLSInterception(cfg *config.Config) doctorReportCheck {
+	if !cfg.TLSInterception.Enabled {
+		return doctorReportCheck{
+			Name:    "tls_interception",
+			Surface: doctorSurfaceHTTP,
+			Status:  doctorStatusInfo,
+			Detail:  "disabled; HTTPS bodies are not visible unless traffic is plaintext or otherwise terminated",
+			Next:    "enable TLS interception and install the Pipelock CA for Browser Shield/body scanning on HTTPS",
+		}
+	}
+	missing := missingReadableFiles(cfg.TLSInterception.CACertPath, cfg.TLSInterception.CAKeyPath)
+	if len(missing) > 0 {
+		return doctorReportCheck{
+			Name:       "tls_interception",
+			Surface:    doctorSurfaceHTTP,
+			Status:     doctorStatusFail,
+			Configured: true,
+			Detail:     "configured but CA material is not readable: " + strings.Join(missing, ", "),
+			Next:       "fix ca_cert/ca_key paths or rerun TLS/contain CA setup",
+		}
+	}
+	if !doctorGlobalEnforce(cfg) {
+		return doctorReportCheck{
+			Name:       "tls_interception",
+			Surface:    doctorSurfaceHTTP,
+			Status:     doctorStatusWarn,
+			Configured: true,
+			Reachable:  true,
+			Detail:     "CA material is readable, but global enforce=false means findings on intercepted bodies are not blocking",
+			Next:       "set enforce=true before claiming blocking enforcement on intercepted HTTPS",
+		}
+	}
+	return doctorReportCheck{
+		Name:       "tls_interception",
+		Surface:    doctorSurfaceHTTP,
+		Status:     doctorStatusOK,
+		Configured: true,
+		Reachable:  true,
+		Enforcing:  true,
+		Detail:     "CA material is readable; clients still need to trust the CA",
+		Next:       "verify agent and browser trust stores use this CA",
+	}
+}
+
+func checkDoctorRequestBodyScanning(cfg *config.Config) doctorReportCheck {
+	if !cfg.RequestBodyScanning.Enabled {
+		return doctorReportCheck{
+			Name:    "request_body_scanning",
+			Surface: doctorSurfaceHTTP,
+			Status:  doctorStatusWarn,
+			Detail:  "disabled; POST bodies and headers can miss DLP unless another layer sees them",
+			Next:    "enable request_body_scanning for agent HTTP/TLS proxy paths",
+		}
+	}
+	if !doctorGlobalEnforce(cfg) {
+		return doctorReportCheck{
+			Name:       "request_body_scanning",
+			Surface:    doctorSurfaceHTTP,
+			Status:     doctorStatusWarn,
+			Configured: true,
+			Reachable:  true,
+			Detail:     "enabled, but global enforce=false means request body findings are not blocking",
+			Next:       "set enforce=true and request_body_scanning.action=block for blocking enforcement",
+		}
+	}
+	if cfg.RequestBodyScanning.Action != config.ActionBlock {
+		return doctorReportCheck{
+			Name:       "request_body_scanning",
+			Surface:    doctorSurfaceHTTP,
+			Status:     doctorStatusWarn,
+			Configured: true,
+			Reachable:  true,
+			Detail:     "enabled with action=" + cfg.RequestBodyScanning.Action + "; this is not blocking enforcement",
+			Next:       "set request_body_scanning.action=block before claiming enforcement",
+		}
+	}
+	return doctorReportCheck{
+		Name:       "request_body_scanning",
+		Surface:    doctorSurfaceHTTP,
+		Status:     doctorStatusOK,
+		Configured: true,
+		Reachable:  true,
+		Enforcing:  true,
+		Detail:     "configured on proxy paths; CONNECT HTTPS bodies require TLS interception",
+	}
+}
+
+func checkDoctorBrowserShield(cfg *config.Config) doctorReportCheck {
+	if !cfg.BrowserShield.Enabled {
+		return doctorReportCheck{
+			Name:    "browser_shield",
+			Surface: doctorSurfaceHTTP,
+			Status:  doctorStatusInfo,
+			Detail:  "disabled",
+			Next:    "enable browser_shield where agent browser responses should be rewritten",
+		}
+	}
+	status := doctorStatusOK
+	detail := "enabled; only enforces on response bodies visible to Pipelock"
+	next := "prove with a shieldable HTTPS response through the proxy"
+	enforcing := cfg.TLSInterception.Enabled
+	switch {
+	case !cfg.TLSInterception.Enabled:
+		status = doctorStatusWarn
+		detail = "enabled, but HTTPS Browser Shield coverage needs TLS interception or plaintext response bodies"
+		next = "enable TLS interception or limit the claim to plaintext/fetch-visible bodies"
+		enforcing = false
+	case !doctorGlobalEnforce(cfg):
+		status = doctorStatusWarn
+		detail = "enabled with TLS interception, but global enforce=false means findings are not blocking"
+		next = "set enforce=true before claiming blocking enforcement on browser responses"
+		enforcing = false
+	}
+	return doctorReportCheck{
+		Name:       "browser_shield",
+		Surface:    doctorSurfaceHTTP,
+		Status:     status,
+		Configured: true,
+		Reachable:  cfg.TLSInterception.Enabled,
+		Enforcing:  enforcing,
+		Detail:     detail,
+		Next:       next,
+	}
+}
+
+func checkDoctorMCPWrapperFeatures(cfg *config.Config) doctorReportCheck {
+	enabled := []string{}
+	if cfg.MCPInputScanning.Enabled {
+		enabled = append(enabled, "mcp_input_scanning")
+	}
+	if cfg.MCPToolScanning.Enabled {
+		enabled = append(enabled, "mcp_tool_scanning")
+	}
+	if cfg.MCPToolPolicy.Enabled {
+		enabled = append(enabled, "mcp_tool_policy")
+	}
+	if cfg.MCPSessionBinding.Enabled {
+		enabled = append(enabled, "mcp_session_binding")
+	}
+	if len(enabled) == 0 {
+		return doctorReportCheck{
+			Name:    "mcp_wrapper_scanning",
+			Surface: doctorSurfaceMCP,
+			Status:  doctorStatusInfo,
+			Detail:  "MCP wrapper-dependent scanning features are disabled",
+			Next:    "enable MCP scanning where tools are launched through pipelock mcp proxy or an MCP listener",
+		}
+	}
+	return doctorReportCheck{
+		Name:       "mcp_wrapper_scanning",
+		Surface:    doctorSurfaceMCP,
+		Status:     doctorStatusWarn,
+		Configured: true,
+		Detail:     "configured features: " + strings.Join(enabled, ", "),
+		Next:       "prove the agent launches MCP servers through pipelock mcp proxy -- or a Pipelock MCP listener",
+	}
+}
+
+func checkDoctorMCPBinaryIntegrity(cfg *config.Config) doctorReportCheck {
+	if !cfg.MCPBinaryIntegrity.Enabled {
+		return doctorReportCheck{
+			Name:    "mcp_binary_integrity",
+			Surface: doctorSurfaceMCP,
+			Status:  doctorStatusInfo,
+			Detail:  "disabled",
+			Next:    "enable after generating a real manifest for wrapped MCP server binaries",
+		}
+	}
+	check := doctorReportCheck{
+		Name:       "mcp_binary_integrity",
+		Surface:    doctorSurfaceMCP,
+		Configured: true,
+		Detail:     "configured; enforcement only runs before pipelock-spawned MCP subprocesses",
+		Next:       "generate/mount the manifest and prove MCP servers are launched through the wrapper",
+	}
+	if cfg.MCPBinaryIntegrity.ManifestPath == "" {
+		check.Status = doctorStatusFail
+		check.Detail = "enabled but manifest_path is empty"
+		return check
+	}
+	if pathReadableFile(cfg.MCPBinaryIntegrity.ManifestPath) {
+		check.Status = doctorStatusWarn
+		check.Reachable = true
+		check.Detail = "manifest is readable, but wrapper invocation still must be proven"
+		return check
+	}
+	check.Status = doctorStatusFail
+	check.Detail = "enabled but manifest is not readable: " + cfg.MCPBinaryIntegrity.ManifestPath
+	return check
+}
+
+func checkDoctorMCPToolProvenance(cfg *config.Config) doctorReportCheck {
+	if !cfg.MCPToolProvenance.Enabled {
+		return doctorReportCheck{
+			Name:    "mcp_tool_provenance",
+			Surface: doctorSurfaceMCP,
+			Status:  doctorStatusInfo,
+			Detail:  "disabled",
+			Next:    "enable where signed tools/list provenance should be required",
+		}
+	}
+	return doctorReportCheck{
+		Name:       "mcp_tool_provenance",
+		Surface:    doctorSurfaceMCP,
+		Status:     doctorStatusWarn,
+		Configured: true,
+		Detail:     "configured in " + cfg.MCPToolProvenance.Mode + " mode; enforcement only runs on tools/list traffic through MCP wrapper/listener paths",
+		Next:       "prove signed and unsigned tools/list fixtures through the live MCP path",
+	}
+}
+
+func checkDoctorFileSentry(cfg *config.Config) doctorReportCheck {
+	if !cfg.FileSentry.Enabled {
+		return doctorReportCheck{
+			Name:    "file_sentry",
+			Surface: doctorSurfaceMCP,
+			Status:  doctorStatusInfo,
+			Detail:  "disabled",
+			Next:    "enable with reachable watch_paths where workspace drift should be detected",
+		}
+	}
+	missing := missingReadablePaths(cfg.FileSentry.WatchPaths...)
+	check := doctorReportCheck{
+		Name:       "file_sentry",
+		Surface:    doctorSurfaceMCP,
+		Configured: true,
+		Detail:     "configured; current implementation is tied to MCP proxy lifecycle",
+		Next:       "prove the watched workspace is reachable from the process that arms file_sentry",
+	}
+	if len(cfg.FileSentry.WatchPaths) == 0 {
+		check.Status = doctorStatusFail
+		check.Detail = "enabled but no watch_paths are configured"
+		return check
+	}
+	if len(missing) > 0 {
+		check.Status = doctorStatusFail
+		check.Detail = "watch path(s) not readable: " + strings.Join(missing, ", ")
+		return check
+	}
+	check.Status = doctorStatusWarn
+	check.Reachable = true
+	check.Detail = "watch paths are readable, but wrapper/sidecar lifecycle still must be proven"
+	return check
+}
+
+func checkDoctorSentry(cfg *config.Config) doctorReportCheck {
+	dsnConfigured := cfg.Sentry.DSN != "" || os.Getenv("SENTRY_DSN") != ""
+	if !cfg.Sentry.IsEnabled() {
+		return doctorReportCheck{
+			Name:    "sentry",
+			Surface: doctorSurfaceHost,
+			Status:  doctorStatusWarn,
+			Detail:  "disabled",
+			Next:    "enable Sentry or equivalent alerting before production claims",
+		}
+	}
+	if !dsnConfigured {
+		return doctorReportCheck{
+			Name:       "sentry",
+			Surface:    doctorSurfaceHost,
+			Status:     doctorStatusWarn,
+			Configured: true,
+			Detail:     "enabled but no DSN is configured via YAML or SENTRY_DSN",
+			Next:       "configure DSN without printing it in logs/docs, then emit a scrubbed test event",
+		}
+	}
+	return doctorReportCheck{
+		Name:       "sentry",
+		Surface:    doctorSurfaceHost,
+		Status:     doctorStatusOK,
+		Configured: true,
+		Reachable:  true,
+		Enforcing:  true,
+		Detail:     "enabled and DSN is present (value redacted)",
+		Next:       "verify one scrubbed breadcrumb/error path",
+	}
+}
+
+func checkDoctorDeploymentBoundary(_ *config.Config) doctorReportCheck {
+	return doctorReportCheck{
+		Name:    "direct_egress_boundary",
+		Surface: doctorSurfaceHost,
+		Status:  doctorStatusInfo,
+		Detail:  "proxy env vars are not a wall; child processes can bypass unless contain/network policy blocks raw egress",
+		Next:    "run contain verify or cluster topology smoke tests to prove direct raw egress is blocked",
+	}
+}
+
+func missingReadablePaths(paths ...string) []string {
+	return missingByPredicate(pathReadable, paths...)
+}
+
+func missingReadableFiles(paths ...string) []string {
+	return missingByPredicate(pathReadableFile, paths...)
+}
+
+func missingByPredicate(pred func(string) bool, paths ...string) []string {
+	missing := []string{}
+	for _, path := range paths {
+		if path == "" {
+			missing = append(missing, "<empty>")
+			continue
+		}
+		if !pred(path) {
+			missing = append(missing, path)
+		}
+	}
+	return missing
+}
+
+func pathReadableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	return openReadable(path)
+}
+
+func pathReadable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if !info.Mode().IsRegular() && !info.IsDir() {
+		return false
+	}
+	return openReadable(path)
+}
+
+func openReadable(path string) bool {
+	f, err := os.Open(filepath.Clean(path)) //nolint:gosec // doctor checks operator-visible config paths from local configuration.
+	if err != nil {
+		return false
+	}
+	_ = f.Close()
+	return true
+}
+
+func doctorGlobalEnforce(cfg *config.Config) bool {
+	return cfg.Enforce == nil || *cfg.Enforce
+}
+
+// doctorRootBannerMessage returns a non-empty advisory string when the
+// process is running with euid 0. Doctor's readability checks reflect the
+// caller's view, and root bypasses DAC, so paths that pipelock-proxy cannot
+// read still look readable. Surfacing this in both human and JSON output
+// keeps "configured ≠ enforcing" honest in the most common invocation.
+func doctorRootBannerMessage() string {
+	if os.Geteuid() != 0 {
+		return ""
+	}
+	return doctorRootBannerText
+}
+
+func printDoctorReport(cmd *cobra.Command, report doctorReport, color bool) {
+	w := cmd.OutOrStdout()
+	_, _ = fmt.Fprintln(w, "Pipelock Enforcement Doctor")
+	_, _ = fmt.Fprintln(w, "===========================")
+	_, _ = fmt.Fprintf(w, "Config: %s\n", report.ConfigFile)
+	_, _ = fmt.Fprintf(w, "Mode:   %s\n", report.Mode)
+	if banner := doctorRootBannerMessage(); banner != "" {
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintf(w, "%s %s\n", doctorStatusTag(doctorStatusWarn, color), banner)
+	}
+	_, _ = fmt.Fprintln(w)
+	for _, check := range report.Checks {
+		_, _ = fmt.Fprintf(w, "%s %-24s [%s]\n", doctorStatusTag(check.Status, color), check.Name, check.Surface)
+		if check.Detail != "" {
+			_, _ = fmt.Fprintf(w, "  %s\n", check.Detail)
+		}
+		if check.Next != "" {
+			_, _ = fmt.Fprintf(w, "  next: %s\n", check.Next)
+		}
+	}
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "Summary: %d ok, %d warning, %d failure, %d info\n",
+		report.Summary.OK, report.Summary.Warnings, report.Summary.Failures, report.Summary.Info)
+}
+
+func doctorStatusTag(status string, color bool) string {
+	if !color {
+		return "[" + strings.ToUpper(status) + "]"
+	}
+	switch status {
+	case doctorStatusOK:
+		return "\033[32m[OK]\033[0m"
+	case doctorStatusWarn:
+		return "\033[33m[WARN]\033[0m"
+	case doctorStatusFail:
+		return "\033[31m[FAIL]\033[0m"
+	default:
+		return "\033[36m[INFO]\033[0m"
+	}
+}

--- a/internal/cli/diag/doctor_test.go
+++ b/internal/cli/diag/doctor_test.go
@@ -1,0 +1,390 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package diag
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestDoctorJSONReportsWarningsForDefaultTopology(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := DoctorCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--json"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected warnings for default topology")
+	}
+	if cliutil.ExitCodeOf(err) != 1 {
+		t.Fatalf("exit code = %d, want 1", cliutil.ExitCodeOf(err))
+	}
+
+	var report doctorReport
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, buf.String())
+	}
+	if report.Summary.Warnings == 0 {
+		t.Fatalf("expected warnings in report: %+v", report.Summary)
+	}
+	if !doctorReportHasCheck(report, "direct_egress_boundary", doctorStatusInfo) {
+		t.Fatalf("missing direct egress info: %+v", report.Checks)
+	}
+}
+
+func TestBuildDoctorReportFlagsMissingMCPManifest(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.MCPBinaryIntegrity.Enabled = true
+	cfg.MCPBinaryIntegrity.ManifestPath = filepath.Join(t.TempDir(), "missing.json")
+
+	report := buildDoctorReport(cfg, configLabelDefaults)
+	if !doctorReportHasCheck(report, "mcp_binary_integrity", doctorStatusFail) {
+		t.Fatalf("expected mcp_binary_integrity failure: %+v", report.Checks)
+	}
+}
+
+func TestBuildDoctorReportAcceptsReadableMCPManifestButStillWarns(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.json")
+	if err := os.WriteFile(manifestPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	cfg := config.Defaults()
+	cfg.MCPBinaryIntegrity.Enabled = true
+	cfg.MCPBinaryIntegrity.ManifestPath = manifestPath
+
+	report := buildDoctorReport(cfg, configLabelDefaults)
+	var got doctorReportCheck
+	for _, check := range report.Checks {
+		if check.Name == "mcp_binary_integrity" {
+			got = check
+			break
+		}
+	}
+	if got.Status != doctorStatusWarn {
+		t.Fatalf("status = %q, want warn; check=%+v", got.Status, got)
+	}
+	if !strings.Contains(got.Detail, "wrapper invocation") {
+		t.Fatalf("detail should mention wrapper proof, got %q", got.Detail)
+	}
+}
+
+func TestBuildDoctorReportRejectsDirectoryMCPManifest(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.MCPBinaryIntegrity.Enabled = true
+	cfg.MCPBinaryIntegrity.ManifestPath = t.TempDir()
+
+	report := buildDoctorReport(cfg, configLabelDefaults)
+	if !doctorReportHasCheck(report, "mcp_binary_integrity", doctorStatusFail) {
+		t.Fatalf("expected directory mcp_binary_integrity failure: %+v", report.Checks)
+	}
+}
+
+func TestBuildDoctorReportRejectsStatOnlyMCPManifest(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can open mode 000 files")
+	}
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.json")
+	if err := os.WriteFile(manifestPath, []byte("{}\n"), 0o000); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	cfg := config.Defaults()
+	cfg.MCPBinaryIntegrity.Enabled = true
+	cfg.MCPBinaryIntegrity.ManifestPath = manifestPath
+
+	report := buildDoctorReport(cfg, configLabelDefaults)
+	if !doctorReportHasCheck(report, "mcp_binary_integrity", doctorStatusFail) {
+		t.Fatalf("expected unreadable mcp_binary_integrity failure: %+v", report.Checks)
+	}
+}
+
+func TestBuildDoctorReportWarnsWhenGlobalEnforceDisabled(t *testing.T) {
+	dir := t.TempDir()
+	caCert := filepath.Join(dir, "ca.pem")
+	caKey := filepath.Join(dir, "ca.key")
+	if err := os.WriteFile(caCert, []byte("test ca cert bytes\n"), 0o600); err != nil {
+		t.Fatalf("write ca cert: %v", err)
+	}
+	if err := os.WriteFile(caKey, []byte("test ca key bytes\n"), 0o600); err != nil {
+		t.Fatalf("write ca key: %v", err)
+	}
+
+	cfg := config.Defaults()
+	enforce := false
+	cfg.Enforce = &enforce
+	cfg.TLSInterception.Enabled = true
+	cfg.TLSInterception.CACertPath = caCert
+	cfg.TLSInterception.CAKeyPath = caKey
+	cfg.BrowserShield.Enabled = true
+
+	report := buildDoctorReport(cfg, configLabelDefaults)
+	for _, name := range []string{"http_proxy", "request_body_scanning", "tls_interception", "browser_shield"} {
+		if !doctorReportHasCheck(report, name, doctorStatusWarn) {
+			t.Errorf("expected %s warning when enforce=false: %+v", name, doctorCheckFor(report, name))
+		}
+		if check := doctorCheckFor(report, name); check.Enforcing {
+			t.Errorf("expected %s Enforcing=false when enforce=false, got %+v", name, check)
+		}
+	}
+}
+
+func TestDoctorChecksCoverConfiguredBranches(t *testing.T) {
+	dir := t.TempDir()
+	caCert := filepath.Join(dir, "ca.pem")
+	caKey := filepath.Join(dir, "ca.key")
+	manifestPath := filepath.Join(dir, "manifest.json")
+	watchDir := filepath.Join(dir, "watch")
+	for path, data := range map[string][]byte{
+		caCert:       []byte("cert\n"),
+		caKey:        []byte("key\n"),
+		manifestPath: []byte("{}\n"),
+	} {
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	if err := os.Mkdir(watchDir, 0o700); err != nil {
+		t.Fatalf("mkdir watch: %v", err)
+	}
+
+	t.Run("tls ok when ca files readable", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.TLSInterception.Enabled = true
+		cfg.TLSInterception.CACertPath = caCert
+		cfg.TLSInterception.CAKeyPath = caKey
+		check := checkDoctorTLSInterception(cfg)
+		if check.Status != doctorStatusOK || !check.Enforcing {
+			t.Fatalf("check = %+v, want enforcing ok", check)
+		}
+	})
+
+	t.Run("request body scanning action gates enforcement", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.RequestBodyScanning.Enabled = false
+		if check := checkDoctorRequestBodyScanning(cfg); check.Status != doctorStatusWarn {
+			t.Fatalf("disabled check = %+v, want warn", check)
+		}
+		cfg.RequestBodyScanning.Enabled = true
+		cfg.RequestBodyScanning.Action = config.ActionWarn
+		if check := checkDoctorRequestBodyScanning(cfg); check.Status != doctorStatusWarn || check.Enforcing {
+			t.Fatalf("warn action check = %+v, want warning without enforcement", check)
+		}
+		cfg.RequestBodyScanning.Action = config.ActionBlock
+		if check := checkDoctorRequestBodyScanning(cfg); check.Status != doctorStatusOK || !check.Enforcing {
+			t.Fatalf("block action check = %+v, want enforcing ok", check)
+		}
+	})
+
+	t.Run("browser shield reachability follows TLS visibility", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.BrowserShield.Enabled = false
+		if check := checkDoctorBrowserShield(cfg); check.Status != doctorStatusInfo {
+			t.Fatalf("disabled check = %+v, want info", check)
+		}
+		cfg.BrowserShield.Enabled = true
+		cfg.TLSInterception.Enabled = false
+		if check := checkDoctorBrowserShield(cfg); check.Status != doctorStatusWarn || check.Reachable {
+			t.Fatalf("no tls check = %+v, want warning without reachability", check)
+		}
+		cfg.TLSInterception.Enabled = true
+		if check := checkDoctorBrowserShield(cfg); check.Status != doctorStatusOK || !check.Enforcing {
+			t.Fatalf("tls check = %+v, want enforcing ok", check)
+		}
+	})
+
+	t.Run("mcp wrapper and provenance report configured warnings", func(t *testing.T) {
+		cfg := config.Defaults()
+		if check := checkDoctorMCPWrapperFeatures(cfg); check.Status != doctorStatusInfo {
+			t.Fatalf("disabled wrapper check = %+v, want info", check)
+		}
+		cfg.MCPInputScanning.Enabled = true
+		cfg.MCPToolScanning.Enabled = true
+		cfg.MCPToolPolicy.Enabled = true
+		cfg.MCPSessionBinding.Enabled = true
+		check := checkDoctorMCPWrapperFeatures(cfg)
+		if check.Status != doctorStatusWarn || !strings.Contains(check.Detail, "mcp_session_binding") {
+			t.Fatalf("enabled wrapper check = %+v, want warning with enabled feature list", check)
+		}
+		cfg.MCPToolProvenance.Enabled = true
+		cfg.MCPToolProvenance.Mode = config.ProvenanceModePipelock
+		check = checkDoctorMCPToolProvenance(cfg)
+		if check.Status != doctorStatusWarn || !strings.Contains(check.Detail, config.ProvenanceModePipelock) {
+			t.Fatalf("provenance check = %+v, want warning with mode", check)
+		}
+	})
+
+	t.Run("binary integrity manifest states", func(t *testing.T) {
+		cfg := config.Defaults()
+		if check := checkDoctorMCPBinaryIntegrity(cfg); check.Status != doctorStatusInfo {
+			t.Fatalf("disabled check = %+v, want info", check)
+		}
+		cfg.MCPBinaryIntegrity.Enabled = true
+		cfg.MCPBinaryIntegrity.ManifestPath = ""
+		if check := checkDoctorMCPBinaryIntegrity(cfg); check.Status != doctorStatusFail {
+			t.Fatalf("empty manifest check = %+v, want fail", check)
+		}
+		cfg.MCPBinaryIntegrity.ManifestPath = manifestPath
+		if check := checkDoctorMCPBinaryIntegrity(cfg); check.Status != doctorStatusWarn || !check.Reachable {
+			t.Fatalf("readable manifest check = %+v, want reachable warning", check)
+		}
+	})
+
+	t.Run("file sentry watch path states", func(t *testing.T) {
+		cfg := config.Defaults()
+		if check := checkDoctorFileSentry(cfg); check.Status != doctorStatusInfo {
+			t.Fatalf("disabled check = %+v, want info", check)
+		}
+		cfg.FileSentry.Enabled = true
+		cfg.FileSentry.WatchPaths = nil
+		if check := checkDoctorFileSentry(cfg); check.Status != doctorStatusFail {
+			t.Fatalf("empty paths check = %+v, want fail", check)
+		}
+		cfg.FileSentry.WatchPaths = []string{filepath.Join(dir, "missing")}
+		if check := checkDoctorFileSentry(cfg); check.Status != doctorStatusFail {
+			t.Fatalf("missing path check = %+v, want fail", check)
+		}
+		cfg.FileSentry.WatchPaths = []string{watchDir}
+		check := checkDoctorFileSentry(cfg)
+		if check.Status != doctorStatusWarn || !check.Reachable {
+			t.Fatalf("readable path check = %+v, want reachable warning", check)
+		}
+	})
+
+	t.Run("sentry states", func(t *testing.T) {
+		cfg := config.Defaults()
+		disabled := false
+		cfg.Sentry.Enabled = &disabled
+		if check := checkDoctorSentry(cfg); check.Status != doctorStatusWarn || check.Configured {
+			t.Fatalf("disabled sentry check = %+v, want unconfigured warning", check)
+		}
+		enabled := true
+		cfg.Sentry.Enabled = &enabled
+		cfg.Sentry.DSN = ""
+		t.Setenv("SENTRY_DSN", "")
+		if check := checkDoctorSentry(cfg); check.Status != doctorStatusWarn || !check.Configured {
+			t.Fatalf("no dsn sentry check = %+v, want configured warning", check)
+		}
+		cfg.Sentry.DSN = "https://public@example.invalid/1"
+		if check := checkDoctorSentry(cfg); check.Status != doctorStatusOK || !check.Enforcing {
+			t.Fatalf("dsn sentry check = %+v, want ok", check)
+		}
+	})
+}
+
+func TestDoctorHelpersAndStatusTags(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	if missing := missingReadablePaths("", file, dir); len(missing) != 1 || missing[0] != "<empty>" {
+		t.Fatalf("missingReadablePaths = %+v, want only empty path", missing)
+	}
+	if missing := missingReadableFiles("", file, dir); len(missing) != 2 || missing[0] != "<empty>" || missing[1] != dir {
+		t.Fatalf("missingReadableFiles = %+v, want empty and directory", missing)
+	}
+	if !pathReadable(file) || !pathReadable(dir) {
+		t.Fatalf("pathReadable should accept readable files and directories")
+	}
+	if pathReadable(filepath.Join(dir, "missing")) || pathReadableFile(dir) {
+		t.Fatalf("pathReadable helpers accepted missing path or directory file")
+	}
+
+	cases := []struct {
+		status string
+		want   string
+	}{
+		{doctorStatusOK, "\033[32m[OK]\033[0m"},
+		{doctorStatusWarn, "\033[33m[WARN]\033[0m"},
+		{doctorStatusFail, "\033[31m[FAIL]\033[0m"},
+		{doctorStatusInfo, "\033[36m[INFO]\033[0m"},
+		{"other", "\033[36m[INFO]\033[0m"},
+	}
+	for _, tt := range cases {
+		if got := doctorStatusTag(tt.status, true); got != tt.want {
+			t.Fatalf("doctorStatusTag(%q, true) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+	if got := doctorStatusTag(doctorStatusWarn, false); got != "[WARN]" {
+		t.Fatalf("plain status tag = %q, want [WARN]", got)
+	}
+}
+
+func TestDoctorReportJSONOmitsBannerWhenUnprivileged(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("test only meaningful when run unprivileged")
+	}
+	var buf bytes.Buffer
+	cmd := DoctorCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--json"})
+	_ = cmd.Execute()
+	var report doctorReport
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if report.RootRunBanner != "" {
+		t.Fatalf("root_run_banner should be omitted/empty when euid != 0, got %q", report.RootRunBanner)
+	}
+}
+
+func TestDoctorRootBannerMessageShape(t *testing.T) {
+	const wantSubstr = "running as root"
+	if os.Geteuid() == 0 {
+		if msg := doctorRootBannerMessage(); !strings.Contains(msg, wantSubstr) {
+			t.Fatalf("banner = %q, want substring %q", msg, wantSubstr)
+		}
+		return
+	}
+	if !strings.Contains(doctorRootBannerText, wantSubstr) {
+		t.Fatalf("banner constant = %q, want substring %q", doctorRootBannerText, wantSubstr)
+	}
+	if msg := doctorRootBannerMessage(); msg != "" {
+		t.Fatalf("banner = %q, want substring %q", msg, wantSubstr)
+	}
+}
+
+func doctorCheckFor(report doctorReport, name string) doctorReportCheck {
+	for _, check := range report.Checks {
+		if check.Name == name {
+			return check
+		}
+	}
+	return doctorReportCheck{}
+}
+
+func TestDoctorHumanOutputMentionsConfiguredVsEnforcing(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := DoctorCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--no-color"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected warning exit")
+	}
+	out := buf.String()
+	for _, want := range []string{"Pipelock Enforcement Doctor", "direct_egress_boundary", "proxy env vars are not a wall"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func doctorReportHasCheck(report doctorReport, name, status string) bool {
+	for _, check := range report.Checks {
+		if check.Name == name && check.Status == status {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -86,6 +86,7 @@ Quick start:
 		// Mediation envelope trust management
 		clienvelope.Cmd(),
 		// Diagnostics
+		diag.DoctorCmd(),
 		diag.DiagnoseCmd(),
 		diag.DiscoverCmd(),
 		diag.PreflightCmd(),

--- a/internal/cli/setup/claude.go
+++ b/internal/cli/setup/claude.go
@@ -245,6 +245,10 @@ func claudeResult(cmd *cobra.Command, exitCodeMode bool, hookEventName, permissi
 // Returns nil action for unknown tools (default allow).
 // Returns error for known tools with unparseable tool_input (fail-closed).
 func claudePayloadToAction(p claudeCodePayload) (*decide.Action, error) {
+	if strings.TrimSpace(string(p.ToolInput)) == "null" {
+		return nil, errors.New("tool_input must not be null")
+	}
+
 	action := decide.Action{Source: "claude-code"}
 
 	switch {

--- a/internal/cli/setup/claude_test.go
+++ b/internal/cli/setup/claude_test.go
@@ -1077,6 +1077,30 @@ func TestClaudePayloadToAction_BadToolInput(t *testing.T) {
 	}
 }
 
+func TestClaudePayloadToAction_NullToolInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+	}{
+		{"bash", "Bash"},
+		{"mcp", "mcp__server__tool"},
+		{"unknown", "NotebookRead"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := claudeCodePayload{
+				ToolName:  tt.toolName,
+				ToolInput: json.RawMessage(` null `),
+			}
+			_, err := claudePayloadToAction(p)
+			if err == nil {
+				t.Fatal("expected error for null tool_input")
+			}
+		})
+	}
+}
+
 func TestClaudeHookCmd_BadToolInputDenies(t *testing.T) {
 	input := `{"session_id":"s1","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":"not-an-object","tool_use_id":"t1"}`
 


### PR DESCRIPTION
## Summary

- add `pipelock doctor` to report configured protections versus actually enforceable topology
- add universal `plk <tool> [args...]` dispatch through the contained launcher path
- add `contain verify --workspace` plus `grant-workspace` / `revoke-workspace` ACL lifecycle commands
- harden workspace grants with read-only default, protected path denial, tracked rollback cleanup, and deleted-workspace cleanup
- align launcher tool-name validation across `plk` and `plk-launch`
- fail closed on null hook tool input before routing tool decisions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added grant-workspace and revoke-workspace commands to manage per-project filesystem ACLs.
  * Added a local "doctor" diagnostics command for enforcement/health checks.

* **Improvements / Bug Fixes**
  * Installer now writes a meta-wrapper and validates tool names before dispatch.
  * Verify now checks workspace accessibility and meta-wrapper presence; rollback reliably revokes workspace ACLs.

* **Tests**
  * Expanded test coverage for workspace grant/revoke, installer wrappers, rollback, verify, and doctor.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->