### PR TITLE
Tune adaptive burst scoring and Browser Shield defaults

### DIFF
--- a/docs/cli/adaptive.md
+++ b/docs/cli/adaptive.md
@@ -1,0 +1,48 @@
+# pipelock adaptive — operator CLI for adaptive enforcement
+
+The `pipelock adaptive` command group exposes fleet-level adaptive-enforcement
+state from the running proxy. Use it when a session escalation looks systemic,
+when a cooperative tool burst needs inspection, or when an operator needs to
+clear adaptive state without reloading config.
+
+Every subcommand talks to the authenticated admin API. The API URL and bearer
+token resolve the same way as `pipelock session`: explicit flags, environment
+variables, then the configured `kill_switch.api_listen` and
+`kill_switch.api_token`.
+
+## Quick reference
+
+| Command | Purpose |
+|---|---|
+| `pipelock adaptive status [--json]` | Summarize adaptive state, escalation counts, recent event counts, and top anomalies |
+| `pipelock adaptive flush [--json]` | Reset identity-session adaptive state and clear shared IP-domain burst tracking |
+| `pipelock adaptive whoami [--json]` | Show how the running proxy classifies the calling client |
+
+## adaptive status
+
+```sh
+pipelock adaptive status [--json]
+```
+
+Returns whether adaptive enforcement is enabled, how many sessions are tracked,
+the highest current escalation level, the active airlock TTL, recent event
+counts, and the top recent session anomalies.
+
+## adaptive flush
+
+```sh
+pipelock adaptive flush [--json]
+```
+
+Resets all identity-session adaptive state: threat scores, escalation levels,
+`block_all`, and shared IP-domain burst tracking. Invocation sessions used for
+ephemeral MCP transports are skipped.
+
+## adaptive whoami
+
+```sh
+pipelock adaptive whoami [--json]
+```
+
+Shows the client IP and session key the admin API assigns to the caller. Use it
+to confirm which identity a proxy-side operator command will affect.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,7 +160,7 @@ tls_interception:
   ca_cert: ""                    # path to CA cert PEM (default: ~/.pipelock/ca.pem)
   ca_key: ""                     # path to CA key PEM (default: ~/.pipelock/ca-key.pem)
   passthrough_domains:           # domains to splice (not intercept)
-    - "*.anthropic.com"
+    - "*.googlevideo.com"
   cert_ttl: "24h"
   cert_cache_size: 10000
   max_response_bytes: 5242880    # 5MB; responses larger than this are blocked
@@ -171,7 +171,7 @@ tls_interception:
 | `enabled` | `false` | Enable TLS interception on CONNECT tunnels |
 | `ca_cert` | `""` | Path to CA certificate PEM. Empty resolves to `~/.pipelock/ca.pem` |
 | `ca_key` | `""` | Path to CA private key PEM. Empty resolves to `~/.pipelock/ca-key.pem` |
-| `passthrough_domains` | `[]` | Domains to splice (pass through without interception). Supports `*.example.com` wildcards (also matches apex `example.com`). |
+| `passthrough_domains` | `["*.googlevideo.com"]` | Domains to splice (pass through without interception). Supports `*.example.com` wildcards (also matches apex `example.com`). |
 | `cert_ttl` | `"24h"` | TTL for forged leaf certificates (Go duration string) |
 | `cert_cache_size` | `10000` | Max cached leaf certificates. Evicts oldest when full. |
 | `max_response_bytes` | `5242880` | Max response body to buffer for scanning. Responses exceeding this are blocked (fail-closed). |
@@ -791,6 +791,7 @@ adaptive_enforcement:
   enabled: true
   escalation_threshold: 5.0
   decay_per_clean_request: 0.5
+  cooperative_tool_downweight: true
   levels:
     elevated:
       upgrade_warn: block       # warn→block when session is elevated
@@ -808,6 +809,7 @@ adaptive_enforcement:
 | `enabled` | `false` | Enable adaptive enforcement |
 | `escalation_threshold` | `5.0` | Score before first escalation. Lower values escalate faster. |
 | `decay_per_clean_request` | `0.5` | Score reduction per clean request. Lower values slow trust recovery. |
+| `cooperative_tool_downweight` | `true` | Downweight domain-burst and IP-domain-burst adaptive signals from known cooperative tool user agents such as `yt-dlp`, package managers, `curl`, and `git`. |
 | `levels` | *(see below)* | Per-level enforcement upgrades |
 
 ### Escalation Levels
@@ -858,7 +860,7 @@ When a session is at a `block_all` level, blocked retries do not refresh the ses
 
 ### Domain Burst Scoring
 
-Session profiling detects domain bursts (many unique domains in a short window). When the burst threshold is crossed, the anomaly is signaled once per window with the configured score. Subsequent requests in the same window still trigger the configured `anomaly_action` (block or warn) but do not add further adaptive score, preventing burst detection from driving sessions to critical on its own.
+Session profiling detects domain bursts (many unique domains in a short window). When the burst threshold is crossed, the anomaly is signaled once per window with the configured score. Subsequent requests in the same window still trigger the configured `anomaly_action` (block or warn) but do not add further adaptive score, preventing burst detection from driving sessions to critical on its own. IP-wide domain bursts are tracked separately to catch agent-identity rotation from a single client IP. When `cooperative_tool_downweight` is enabled, burst signals from known cooperative tool user agents are reduced instead of scored at full browser-like weight.
 
 ## Kill Switch
 
@@ -918,6 +920,9 @@ When `kill_switch.api_token` is configured, the session admin API is available a
 | `/api/v1/sessions/{key}/airlock` | POST | Transition the session's airlock tier (admin override) |
 | `/api/v1/sessions/{key}/task` | POST | Rotate the session's task boundary |
 | `/api/v1/sessions/{key}/trust` | POST | Grant a task-scoped trust override |
+| `/api/v1/adaptive/status` | GET | Summarize adaptive state, escalation counts, recent event counts, and top anomalies |
+| `/api/v1/adaptive/flush` | POST | Reset identity-session adaptive state and clear shared IP-domain burst tracking |
+| `/api/v1/adaptive/whoami` | GET | Show the caller's client-IP/session classification as seen by the proxy |
 
 The `{key}` parameter is URL-encoded. For example, `my-agent|10.0.0.1` becomes `my-agent%7C10.0.0.1`.
 
@@ -927,7 +932,7 @@ The `{key}` parameter is URL-encoded. For example, `my-agent|10.0.0.1` becomes `
 
 Sessions are classified as `identity` (operator-targetable, e.g. `my-agent|10.0.0.1`) or `invocation` (internal MCP sessions, e.g. `mcp-stdio-42`). Only identity sessions can be reset, mutated, or terminated.
 
-**Operator CLI:** the session admin API is also exposed through `pipelock session <subcommand>` for interactive recovery. See [cli/session.md](cli/session.md) for the full operator reference.
+**Operator CLI:** the session admin API is exposed through `pipelock session <subcommand>` for airlock recovery and `pipelock adaptive <subcommand>` for fleet-level adaptive state. See [cli/session.md](cli/session.md) and [cli/adaptive.md](cli/adaptive.md) for the operator references.
 
 **Token hot-reload:** `kill_switch.api_token` is hot-reloaded on SIGHUP or fsnotify config-file changes. Rotating the token in YAML (or via the `PIPELOCK_KILLSWITCH_API_TOKEN` env var, which wins over YAML) takes effect on the next admin API call without restarting the proxy. The previous bearer credential is revoked atomically: requests in flight at the moment of rotation complete against the token they were issued against; subsequent requests must present the new bearer. Setting `api_token` to the empty string disables the endpoint (HTTP 503) without tearing down the listener, so an operator can revoke access during an incident and restore it later with a second reload.
 
@@ -2219,9 +2224,15 @@ browser_shield:
   enabled: true
   strictness: standard
   max_shield_bytes: 5242880
-  oversize_action: block
+  oversize_action: scan_head
   exempt_domains:
     - challenges.cloudflare.com
+    - developer.mozilla.org
+    - docs.github.com
+    - github.dev
+    - go.dev
+    - pkg.go.dev
+    - vscode.dev
     - hcaptcha.com
     - www.recaptcha.net
   strip_extension_probing: true
@@ -2236,8 +2247,8 @@ browser_shield:
 | `enabled` | bool | `false` | Master switch for response rewriting |
 | `strictness` | string | `standard` | Rewrite posture: `minimal`, `standard`, or `aggressive` |
 | `max_shield_bytes` | int | `5242880` (5 MiB) | Maximum shieldable response body size before `oversize_action` applies |
-| `oversize_action` | string | `block` | Oversize behavior: `block`, `scan_head`, or `warn`; `warn` is only valid with `strictness: minimal` |
-| `exempt_domains` | []string | challenge providers | Hostnames that bypass Browser Shield entirely |
+| `oversize_action` | string | `scan_head` | Oversize behavior: `block`, `scan_head`, or `warn`; `warn` is only valid with `strictness: minimal` |
+| `exempt_domains` | []string | challenge providers plus common developer documentation/browser IDE hosts | Hostnames that bypass Browser Shield entirely |
 | `strip_extension_probing` | bool | `true` | Remove browser-extension probing URLs and runtime probes |
 | `strip_hidden_traps` | bool | `true` | Remove hidden prompt-trap DOM content |
 | `strip_tracking_pixels` | bool | `true` | Remove tracking pixels and beacon-style calls |
@@ -2250,12 +2261,13 @@ For production soak, start with:
 browser_shield:
   enabled: true
   strictness: minimal
-  oversize_action: warn
+  oversize_action: scan_head
 ```
 
 Then monitor shield receipts, response rewrite metrics, adaptive session score
 movement, block deltas, and application breakage before moving to the standard
-fail-closed posture.
+fail-closed posture. Use `oversize_action: warn` only for short, explicitly
+scoped diagnostics because it returns oversized shieldable bodies unchanged.
 
 ## Media Policy (v2.1)
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -192,6 +192,7 @@ integrations. Disabled by default; set `scan_api.listen` to enable.
 | `pipelock_shield_bytes_stripped_total` | counter | `category` | Bytes stripped by browser shield. |
 | `pipelock_shield_shims_injected_total` | counter | `transport` | Shim injections by transport. |
 | `pipelock_shield_skipped_total` | counter | `reason` | Shield skips by reason. |
+| `pipelock_shield_oversize_scan_head_total` | counter | `transport` | Oversized shieldable responses handled with `oversize_action: scan_head`. |
 | `pipelock_shield_latency_seconds` | histogram | `transport` | Browser shield latency. |
 
 ## Reverse Proxy Metrics

--- a/docs/security/browser-shield-production-readiness.md
+++ b/docs/security/browser-shield-production-readiness.md
@@ -6,8 +6,8 @@ Pipelock. It is not an anti-bot bypass system, and it does not promise access
 to websites that deliberately deny automation or proxy traffic.
 
 Browser Shield is opt-in. `browser_shield.enabled` defaults to `false`; the
-strictness, size, and rewrite toggles have safe defaults for operators that
-explicitly enable it.
+strictness, size, oversize, exempt-domain, and rewrite toggles have safe
+defaults for operators that explicitly enable it.
 
 ## Current enforcement boundary
 
@@ -28,8 +28,11 @@ This avoids treating large legitimate media responses as shield failures.
 - Shield rewrites are additive to scanning. Response injection scanning still
   runs after shield rewriting on applicable transports.
 - Oversized shieldable responses fail according to `oversize_action`.
-  `block` fails closed. `warn` returns the body unchanged. `scan_head` rewrites
-  only the configured prefix and records the intervention as partial.
+  `scan_head` is the default: it rewrites only the configured prefix and records
+  the intervention as partial. `block` fails closed. `warn` returns the body
+  unchanged and should stay limited to short diagnostics.
+- Common developer documentation and browser IDE hosts are exempt by default to
+  reduce false positives on large rendered reference pages.
 - Signed action receipts include a `shield` summary whenever Browser Shield
   rewrites a response and receipt emission is enabled.
 - Adaptive enforcement records a low-weight `SignalShieldRewrite` signal for
@@ -124,8 +127,8 @@ standard fail-closed posture.
 2. Run the synthetic transport canary across fetch, forward, intercept, and
    reverse paths with receipt signing enabled.
 3. Enable Browser Shield on a small opt-in agent group with
-   `strictness: minimal` and `oversize_action: warn`.
+   `strictness: minimal` and the default `oversize_action: scan_head`.
 4. Monitor shield receipts, validator-clearing behavior, adaptive score
    movement, response scanner deltas, and page breakage.
-5. Move to `strictness: standard` and `oversize_action: block` only after the
-   soak shows stable browsing behavior and no unexpected escalation.
+5. Move to `strictness: standard`, then consider `oversize_action: block` only
+   after the soak shows stable browsing behavior and no unexpected escalation.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -109,6 +109,7 @@ Quick start:
 		runtime.InternalRedirectCmd(),
 		runtime.HealthcheckCmd(),
 		// Session admin (airlock recovery)
+		session.AdaptiveCmd(),
 		session.Cmd(),
 		// Setup (IDE integrations)
 		setup.InitCmd(),

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -718,6 +718,9 @@ func (s *Server) Start(ctx context.Context) error {
 		// configured — in that case we skip registration and the
 		// admin routes simply don't exist on the listener.
 		if sessionAPI := s.proxy.SessionAPI(); sessionAPI != nil {
+			apiMux.HandleFunc("/api/v1/adaptive/status", sessionAPI.HandleAdaptiveStatus)
+			apiMux.HandleFunc("/api/v1/adaptive/flush", sessionAPI.HandleAdaptiveFlush)
+			apiMux.HandleFunc("/api/v1/adaptive/whoami", sessionAPI.HandleAdaptiveWhoami)
 			apiMux.HandleFunc("/api/v1/sessions", sessionAPI.HandleList)
 			apiMux.HandleFunc("/api/v1/sessions/", func(w http.ResponseWriter, r *http.Request) {
 				path := r.URL.EscapedPath()

--- a/internal/cli/session/adaptive.go
+++ b/internal/cli/session/adaptive.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+)
+
+// AdaptiveCmd is the top-level `pipelock adaptive` operator command.
+func AdaptiveCmd() *cobra.Command {
+	flags := &rootFlags{}
+	cmd := &cobra.Command{
+		Use:   "adaptive",
+		Short: "Inspect and reset adaptive enforcement state",
+		Long: `Inspect and reset adaptive enforcement state on the running
+pipelock instance. These commands use the same authenticated admin API as
+pipelock session and require the kill switch API token.`,
+	}
+	bindPersistentFlags(cmd, flags)
+	cmd.AddCommand(
+		adaptiveStatusCmd(flags),
+		adaptiveFlushCmd(flags),
+		adaptiveWhoamiCmd(flags),
+	)
+	return cmd
+}
+
+func adaptiveStatusCmd(flags *rootFlags) *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:           "status",
+		Short:         "Show adaptive escalation and anomaly state",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.Flags().BoolVar(&jsonOutput, flagJSON, false, usageJSON)
+	cmd.RunE = func(c *cobra.Command, _ []string) error {
+		return runClientCmd(flags, c.Context(), c.OutOrStdout(), func(ctx context.Context, client *Client, out io.Writer) error {
+			resp, err := client.AdaptiveStatus(ctx)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return writeJSON(out, resp)
+			}
+			return renderAdaptiveStatus(out, resp)
+		})
+	}
+	return cmd
+}
+
+func adaptiveFlushCmd(flags *rootFlags) *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:           "flush",
+		Short:         "Reset adaptive state without reloading config",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.Flags().BoolVar(&jsonOutput, flagJSON, false, usageJSON)
+	cmd.RunE = func(c *cobra.Command, _ []string) error {
+		return runClientCmd(flags, c.Context(), c.OutOrStdout(), func(ctx context.Context, client *Client, out io.Writer) error {
+			resp, err := client.AdaptiveFlush(ctx)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return writeJSON(out, resp)
+			}
+			_, _ = fmt.Fprintf(out, "flushed adaptive state: identity_sessions=%d skipped_invocations=%d ip_domain_state_cleared=%t\n",
+				resp.IdentitySessions, resp.SkippedInvocations, resp.IPDomainStateCleared)
+			return nil
+		})
+	}
+	return cmd
+}
+
+func adaptiveWhoamiCmd(flags *rootFlags) *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:           "whoami",
+		Short:         "Show adaptive classification for this client",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.Flags().BoolVar(&jsonOutput, flagJSON, false, usageJSON)
+	cmd.RunE = func(c *cobra.Command, _ []string) error {
+		return runClientCmd(flags, c.Context(), c.OutOrStdout(), func(ctx context.Context, client *Client, out io.Writer) error {
+			resp, err := client.AdaptiveWhoami(ctx)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return writeJSON(out, resp)
+			}
+			_, _ = fmt.Fprintf(out, "client_ip=%s session=%s classification=%s tier=%s level=%s score=%.2f ttl_seconds=%d\n",
+				resp.ClientIP, resp.SessionKey, resp.Classification, resp.AirlockTier, resp.EscalationLevel, resp.ThreatScore, resp.LockdownTTLSeconds)
+			return nil
+		})
+	}
+	return cmd
+}
+
+func renderAdaptiveStatus(w io.Writer, status proxy.AdaptiveStatus) error {
+	_, _ = fmt.Fprintf(w, "adaptive status: sessions=%d max_level=%s ttl_seconds=%d\n",
+		status.ActiveSessions, status.MaxEscalationLevel, status.LockdownTTLSeconds)
+	_, _ = fmt.Fprintf(w, "levels: normal=%d elevated=%d high=%d critical=%d\n",
+		status.SessionsByLevel["normal"], status.SessionsByLevel["elevated"], status.SessionsByLevel["high"], status.SessionsByLevel["critical"])
+	_, _ = fmt.Fprintf(w, "airlock: none=%d soft=%d hard=%d drain=%d\n",
+		status.AirlockTiers["none"], status.AirlockTiers["soft"], status.AirlockTiers["hard"], status.AirlockTiers["drain"])
+	if len(status.TopAnomalies) == 0 {
+		_, _ = fmt.Fprintln(w, "top_anomalies: none")
+		return nil
+	}
+	_, _ = fmt.Fprintln(w, "top_anomalies:")
+	for _, a := range status.TopAnomalies {
+		_, _ = fmt.Fprintf(w, "  %s %d\n", a.Name, a.Count)
+	}
+	return nil
+}

--- a/internal/cli/session/adaptive_test.go
+++ b/internal/cli/session/adaptive_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+)
+
+func TestAdaptiveCmd_RegistersSubcommands(t *testing.T) {
+	cmd := AdaptiveCmd()
+	for _, name := range []string{"status", "flush", "whoami"} {
+		if _, _, err := cmd.Find([]string{name}); err != nil {
+			t.Errorf("adaptive subcommand %q not registered: %v", name, err)
+		}
+	}
+	if cmd.Use != "adaptive" {
+		t.Errorf("Use: got %q, want adaptive", cmd.Use)
+	}
+}
+
+func TestAdaptiveStatusCmd_HumanAndJSON(t *testing.T) {
+	status := makeAdaptiveStatus()
+	for _, tt := range []struct {
+		name     string
+		args     []string
+		validate func(*testing.T, string)
+	}{
+		{
+			name: "human",
+			validate: func(t *testing.T, out string) {
+				t.Helper()
+				for _, want := range []string{"adaptive status:", "sessions=2", "domain_burst 2"} {
+					if !strings.Contains(out, want) {
+						t.Errorf("output missing %q: %s", want, out)
+					}
+				}
+			},
+		},
+		{
+			name: "json",
+			args: []string{"--json"},
+			validate: func(t *testing.T, out string) {
+				t.Helper()
+				var got proxy.AdaptiveStatus
+				if err := json.Unmarshal([]byte(out), &got); err != nil {
+					t.Fatalf("json output not parseable: %v; out=%s", err, out)
+				}
+				if got.ActiveSessions != status.ActiveSessions {
+					t.Errorf("active_sessions: got %d, want %d", got.ActiveSessions, status.ActiveSessions)
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertBearer(t, r)
+				if r.Method != http.MethodGet {
+					t.Errorf("method: got %s, want GET", r.Method)
+				}
+				if r.URL.Path != "/api/v1/adaptive/status" {
+					t.Errorf("path: got %q", r.URL.Path)
+				}
+				writeJSONResponse(w, http.StatusOK, status)
+			}))
+			overrideClientFactory(t, flags)
+
+			out, err := runCommand(adaptiveStatusCmd(&rootFlags{}), tt.args...)
+			if err != nil {
+				t.Fatalf("execute: %v; out=%s", err, out)
+			}
+			tt.validate(t, out)
+		})
+	}
+}
+
+func TestAdaptiveFlushCmd_HumanAndJSON(t *testing.T) {
+	resp := proxy.AdaptiveFlushResult{
+		Flushed:              true,
+		IdentitySessions:     2,
+		SkippedInvocations:   1,
+		IPDomainStateCleared: true,
+	}
+	for _, tt := range []struct {
+		name     string
+		args     []string
+		validate func(*testing.T, string)
+	}{
+		{
+			name: "human",
+			validate: func(t *testing.T, out string) {
+				t.Helper()
+				for _, want := range []string{"flushed adaptive state", "identity_sessions=2", "skipped_invocations=1"} {
+					if !strings.Contains(out, want) {
+						t.Errorf("output missing %q: %s", want, out)
+					}
+				}
+			},
+		},
+		{
+			name: "json",
+			args: []string{"--json"},
+			validate: func(t *testing.T, out string) {
+				t.Helper()
+				var got proxy.AdaptiveFlushResult
+				if err := json.Unmarshal([]byte(out), &got); err != nil {
+					t.Fatalf("json output not parseable: %v; out=%s", err, out)
+				}
+				if !got.Flushed || got.IdentitySessions != 2 {
+					t.Errorf("unexpected flush result: %+v", got)
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertBearer(t, r)
+				if r.Method != http.MethodPost {
+					t.Errorf("method: got %s, want POST", r.Method)
+				}
+				if r.URL.Path != "/api/v1/adaptive/flush" {
+					t.Errorf("path: got %q", r.URL.Path)
+				}
+				writeJSONResponse(w, http.StatusOK, resp)
+			}))
+			overrideClientFactory(t, flags)
+
+			out, err := runCommand(adaptiveFlushCmd(&rootFlags{}), tt.args...)
+			if err != nil {
+				t.Fatalf("execute: %v; out=%s", err, out)
+			}
+			tt.validate(t, out)
+		})
+	}
+}
+
+func TestAdaptiveWhoamiCmd_HumanAndJSON(t *testing.T) {
+	resp := proxy.AdaptiveWhoami{
+		ClientIP:           "203.0.113.9",
+		Agent:              "agent-a",
+		SessionKey:         "agent-a|203.0.113.9",
+		Exists:             true,
+		Classification:     "observe",
+		EscalationLevel:    "elevated",
+		EscalationLevelInt: 1,
+		ThreatScore:        3.5,
+		AirlockTier:        "soft",
+		LockdownTTLSeconds: 120,
+	}
+	for _, tt := range []struct {
+		name     string
+		args     []string
+		validate func(*testing.T, string)
+	}{
+		{
+			name: "human",
+			validate: func(t *testing.T, out string) {
+				t.Helper()
+				for _, want := range []string{"client_ip=203.0.113.9", "classification=observe", "score=3.50"} {
+					if !strings.Contains(out, want) {
+						t.Errorf("output missing %q: %s", want, out)
+					}
+				}
+			},
+		},
+		{
+			name: "json",
+			args: []string{"--json"},
+			validate: func(t *testing.T, out string) {
+				t.Helper()
+				var got proxy.AdaptiveWhoami
+				if err := json.Unmarshal([]byte(out), &got); err != nil {
+					t.Fatalf("json output not parseable: %v; out=%s", err, out)
+				}
+				if got.SessionKey != resp.SessionKey || got.Classification != resp.Classification {
+					t.Errorf("unexpected whoami response: %+v", got)
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := stubServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertBearer(t, r)
+				if r.Method != http.MethodGet {
+					t.Errorf("method: got %s, want GET", r.Method)
+				}
+				if r.URL.Path != "/api/v1/adaptive/whoami" {
+					t.Errorf("path: got %q", r.URL.Path)
+				}
+				writeJSONResponse(w, http.StatusOK, resp)
+			}))
+			overrideClientFactory(t, flags)
+
+			out, err := runCommand(adaptiveWhoamiCmd(&rootFlags{}), tt.args...)
+			if err != nil {
+				t.Fatalf("execute: %v; out=%s", err, out)
+			}
+			tt.validate(t, out)
+		})
+	}
+}
+
+func TestRenderAdaptiveStatus_EmptyAnomalies(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderAdaptiveStatus(&buf, proxy.AdaptiveStatus{
+		SessionsByLevel:    map[string]int{"normal": 1},
+		AirlockTiers:       map[string]int{"none": 1},
+		RecentSignalCounts: map[string]int{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "top_anomalies: none") {
+		t.Errorf("empty anomaly output: %s", buf.String())
+	}
+}
+
+func makeAdaptiveStatus() proxy.AdaptiveStatus {
+	return proxy.AdaptiveStatus{
+		ActiveSessions:     2,
+		MaxEscalationLevel: "high",
+		MaxEscalationInt:   2,
+		SessionsByLevel:    map[string]int{"normal": 1, "high": 1},
+		AirlockTiers:       map[string]int{"none": 1, "soft": 1},
+		RecentSignalCounts: map[string]int{"anomaly": 2, "block": 1},
+		TopAnomalies:       []proxy.AdaptiveTopAnomaly{{Name: "domain_burst", Count: 2}},
+		LockdownTTLSeconds: 30,
+	}
+}

--- a/internal/cli/session/client.go
+++ b/internal/cli/session/client.go
@@ -138,6 +138,33 @@ func (c *Client) Terminate(ctx context.Context, key string) (proxy.SessionTermin
 	return resp, nil
 }
 
+func (c *Client) AdaptiveStatus(ctx context.Context) (proxy.AdaptiveStatus, error) {
+	target := c.base + "/api/v1/adaptive/status"
+	var resp proxy.AdaptiveStatus
+	if err := c.do(ctx, http.MethodGet, target, nil, &resp); err != nil {
+		return proxy.AdaptiveStatus{}, err
+	}
+	return resp, nil
+}
+
+func (c *Client) AdaptiveFlush(ctx context.Context) (proxy.AdaptiveFlushResult, error) {
+	target := c.base + "/api/v1/adaptive/flush"
+	var resp proxy.AdaptiveFlushResult
+	if err := c.do(ctx, http.MethodPost, target, nil, &resp); err != nil {
+		return proxy.AdaptiveFlushResult{}, err
+	}
+	return resp, nil
+}
+
+func (c *Client) AdaptiveWhoami(ctx context.Context) (proxy.AdaptiveWhoami, error) {
+	target := c.base + "/api/v1/adaptive/whoami"
+	var resp proxy.AdaptiveWhoami
+	if err := c.do(ctx, http.MethodGet, target, nil, &resp); err != nil {
+		return proxy.AdaptiveWhoami{}, err
+	}
+	return resp, nil
+}
+
 // do performs the HTTP call with bearer auth, decodes the JSON response
 // into out, and returns a typed APIError for non-2xx statuses so the
 // caller can map each class to a distinct exit code.

--- a/internal/cli/session/client_test.go
+++ b/internal/cli/session/client_test.go
@@ -145,6 +145,135 @@ func TestClient_Terminate_HappyPath(t *testing.T) {
 	}
 }
 
+func TestClient_AdaptiveStatus_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertBearer(t, r)
+		if r.Method != http.MethodGet {
+			t.Errorf("method: got %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/adaptive/status" {
+			t.Errorf("path: got %q", r.URL.Path)
+		}
+		writeJSONResponse(w, http.StatusOK, proxy.AdaptiveStatus{
+			ActiveSessions:     1,
+			MaxEscalationLevel: "normal",
+			SessionsByLevel:    map[string]int{"normal": 1},
+			AirlockTiers:       map[string]int{"none": 1},
+		})
+	}))
+	defer srv.Close()
+
+	c := newClient(endpoint{URL: srv.URL, Token: testToken})
+	resp, err := c.AdaptiveStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ActiveSessions != 1 || resp.MaxEscalationLevel != "normal" {
+		t.Errorf("unexpected adaptive status: %+v", resp)
+	}
+}
+
+func TestClient_AdaptiveFlush_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertBearer(t, r)
+		if r.Method != http.MethodPost {
+			t.Errorf("method: got %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/adaptive/flush" {
+			t.Errorf("path: got %q", r.URL.Path)
+		}
+		writeJSONResponse(w, http.StatusOK, proxy.AdaptiveFlushResult{
+			Flushed:            true,
+			IdentitySessions:   2,
+			SkippedInvocations: 1,
+		})
+	}))
+	defer srv.Close()
+
+	c := newClient(endpoint{URL: srv.URL, Token: testToken})
+	resp, err := c.AdaptiveFlush(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Flushed || resp.IdentitySessions != 2 || resp.SkippedInvocations != 1 {
+		t.Errorf("unexpected adaptive flush: %+v", resp)
+	}
+}
+
+func TestClient_AdaptiveWhoami_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertBearer(t, r)
+		if r.Method != http.MethodGet {
+			t.Errorf("method: got %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/adaptive/whoami" {
+			t.Errorf("path: got %q", r.URL.Path)
+		}
+		writeJSONResponse(w, http.StatusOK, proxy.AdaptiveWhoami{
+			ClientIP:       "203.0.113.9",
+			SessionKey:     "agent-a|203.0.113.9",
+			Exists:         true,
+			Classification: "observe",
+		})
+	}))
+	defer srv.Close()
+
+	c := newClient(endpoint{URL: srv.URL, Token: testToken})
+	resp, err := c.AdaptiveWhoami(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.SessionKey != "agent-a|203.0.113.9" || resp.Classification != "observe" {
+		t.Errorf("unexpected adaptive whoami: %+v", resp)
+	}
+}
+
+func TestClient_AdaptiveMethodsReturnAPIError(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(context.Context, *Client) error
+	}{
+		{
+			name: "status",
+			call: func(ctx context.Context, c *Client) error {
+				_, err := c.AdaptiveStatus(ctx)
+				return err
+			},
+		},
+		{
+			name: "flush",
+			call: func(ctx context.Context, c *Client) error {
+				_, err := c.AdaptiveFlush(ctx)
+				return err
+			},
+		},
+		{
+			name: "whoami",
+			call: func(ctx context.Context, c *Client) error {
+				_, err := c.AdaptiveWhoami(ctx)
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "bad token", http.StatusUnauthorized)
+			}))
+			defer srv.Close()
+
+			c := newClient(endpoint{URL: srv.URL, Token: testToken})
+			err := tt.call(context.Background(), c)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !IsUnauthorized(err) {
+				t.Fatalf("expected unauthorized APIError, got %v", err)
+			}
+		})
+	}
+}
+
 func TestClient_NonSuccessReturnsAPIError(t *testing.T) {
 	tests := []struct {
 		status     int

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -78,7 +78,15 @@ const (
 	// of plural ".aws/credentials" files, covert exfil verbs including
 	// exfiltrate/leak/stream/transmit/relay/forward/smuggle). See
 	// TestSkillPoisoningCorpus for the six-vector regression suite.
-	goldenHashDefaults = "ecb13adaa7ab0d2686ca1944a9ded8c265a082a77ba859378934ec787f4b9fb9"
+	// Re-bumped for production-readiness tuning: Browser Shield
+	// oversize handling now defaults to scan_head, TLS passthrough has a
+	// googlevideo baseline, Browser Shield has a small large-site exempt
+	// baseline, and adaptive enforcement defaults to downweighting
+	// cooperative tool burst anomalies.
+	// Re-bumped to include the effective session-profiling defaults in
+	// Defaults() itself, so programmatic enablement gets the same domain
+	// burst/window/volume baselines as YAML-loaded configs.
+	goldenHashDefaults = "0bee03ac400bdca8104e0e4dc4921516580c25f471d848fbfa154a85c8963888"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -109,7 +117,9 @@ const (
 	// goldenHashDefaults note. The rich fixture inherits the response
 	// scanning pattern set from Defaults(), so the hash shifts in
 	// lockstep.
-	goldenHashRichConfig = "6589f303225d574e76472bc069c532bb0e60e044e4e02f382672384fc1abd8a0"
+	// Re-bumped for production-readiness tuning: see
+	// goldenHashDefaults note.
+	goldenHashRichConfig = "80e42dfc77b047fc1fc52a6086f4f07d87ef27471aebd297073d2f6a16db96e5"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10973,6 +10973,175 @@ func TestValidate_AdaptiveExemptDomainsNonPrefixWildcard(t *testing.T) {
 	}
 }
 
+func TestProductionTuningDefaults(t *testing.T) {
+	cfg := Defaults()
+	if cfg.BrowserShield.OversizeAction != ShieldOversizeScanHead {
+		t.Fatalf("browser_shield.oversize_action = %q, want %q", cfg.BrowserShield.OversizeAction, ShieldOversizeScanHead)
+	}
+	if !containsString(cfg.BrowserShield.ExemptDomains, "docs.github.com") {
+		t.Fatalf("browser_shield.exempt_domains missing docs.github.com: %v", cfg.BrowserShield.ExemptDomains)
+	}
+	if !containsString(cfg.TLSInterception.PassthroughDomains, "*.googlevideo.com") {
+		t.Fatalf("tls_interception.passthrough_domains missing *.googlevideo.com: %v", cfg.TLSInterception.PassthroughDomains)
+	}
+	if !cfg.AdaptiveEnforcement.CooperativeToolDownweight {
+		t.Fatal("adaptive_enforcement.cooperative_tool_downweight default = false, want true")
+	}
+}
+
+func TestLoad_ProductionTuningDefaultsWhenOmitted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	yaml := []byte(`mode: balanced
+session_profiling:
+  enabled: true
+adaptive_enforcement:
+  enabled: true
+browser_shield:
+  enabled: true
+`)
+	if err := os.WriteFile(path, yaml, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.BrowserShield.OversizeAction != ShieldOversizeScanHead {
+		t.Fatalf("browser_shield.oversize_action = %q, want %q", cfg.BrowserShield.OversizeAction, ShieldOversizeScanHead)
+	}
+	if !cfg.AdaptiveEnforcement.CooperativeToolDownweight {
+		t.Fatal("adaptive_enforcement.cooperative_tool_downweight omitted = false, want true")
+	}
+}
+
+func TestLoad_AdaptiveCooperativeDownweightExplicitFalse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	yaml := []byte(`mode: balanced
+session_profiling:
+  enabled: true
+adaptive_enforcement:
+  enabled: true
+  cooperative_tool_downweight: false
+`)
+	if err := os.WriteFile(path, yaml, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.AdaptiveEnforcement.CooperativeToolDownweight {
+		t.Fatal("adaptive_enforcement.cooperative_tool_downweight explicit false was not preserved")
+	}
+}
+
+// TestLoad_AdaptiveCooperativeDownweightExplicitTrue confirms an operator
+// who explicitly sets the field to true is preserved (no normalize override).
+func TestLoad_AdaptiveCooperativeDownweightExplicitTrue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	yaml := []byte(`mode: balanced
+session_profiling:
+  enabled: true
+adaptive_enforcement:
+  enabled: true
+  cooperative_tool_downweight: true
+`)
+	if err := os.WriteFile(path, yaml, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.AdaptiveEnforcement.CooperativeToolDownweight {
+		t.Fatal("adaptive_enforcement.cooperative_tool_downweight explicit true was not preserved")
+	}
+}
+
+// TestLoad_AdaptiveCooperativeDownweightYAMLNull covers the YAML null/blank
+// state — a section with the key explicitly set to ~. The setBoolDefault
+// helper treats nil as "omitted" and fails-open-to-default-true, mirroring
+// the established security-default pattern.
+func TestLoad_AdaptiveCooperativeDownweightYAMLNull(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	yaml := []byte(`mode: balanced
+session_profiling:
+  enabled: true
+adaptive_enforcement:
+  enabled: true
+  cooperative_tool_downweight: ~
+`)
+	if err := os.WriteFile(path, yaml, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.AdaptiveEnforcement.CooperativeToolDownweight {
+		t.Fatal("adaptive_enforcement.cooperative_tool_downweight=null should default to true, got false")
+	}
+}
+
+// TestLoad_AdaptiveCooperativeDownweightReloadFlips covers the hot-reload
+// states for the field: an initial load with explicit false, then a reload
+// that flips it back to true (with change), then a reload that re-applies
+// the same true value (no change). Each load is a fresh Load call, which
+// matches the runtime hot-reload path that re-parses the YAML and re-runs
+// applySecurityDefaults / ApplyDefaults on the new config before the
+// atomic.Pointer swap.
+func TestLoad_AdaptiveCooperativeDownweightReloadFlips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	writeYAML := func(value string) {
+		yaml := []byte(`mode: balanced
+session_profiling:
+  enabled: true
+adaptive_enforcement:
+  enabled: true
+  cooperative_tool_downweight: ` + value + "\n")
+		if err := os.WriteFile(path, yaml, 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	}
+
+	writeYAML("false")
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(false): %v", err)
+	}
+	if cfg.AdaptiveEnforcement.CooperativeToolDownweight {
+		t.Fatal("first load with explicit false should preserve false")
+	}
+
+	// Reload with change: flip to true.
+	writeYAML("true")
+	cfg, err = Load(path)
+	if err != nil {
+		t.Fatalf("Load(true): %v", err)
+	}
+	if !cfg.AdaptiveEnforcement.CooperativeToolDownweight {
+		t.Fatal("reload with explicit true should preserve true (reload-with-change)")
+	}
+
+	// Reload without change: same true value should remain true.
+	cfg, err = Load(path)
+	if err != nil {
+		t.Fatalf("Load(true) second: %v", err)
+	}
+	if !cfg.AdaptiveEnforcement.CooperativeToolDownweight {
+		t.Fatal("idempotent reload with explicit true should preserve true (reload-without-change)")
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
 // adaptiveTestConfig returns a minimal config with adaptive enforcement
 // enabled, suitable for validation tests.
 func adaptiveTestConfig() *Config {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -282,12 +282,22 @@ func Defaults() *Config {
 			MaxConnections: 100,
 		},
 		SessionProfiling: SessionProfiling{
+			AnomalyAction:          ActionWarn,
+			DomainBurst:            5,
+			WindowMinutes:          5,
+			VolumeSpikeRatio:       3.0,
 			MaxSessions:            1000,
 			SessionTTLMinutes:      30,
 			CleanupIntervalSeconds: 60,
 		},
+		AdaptiveEnforcement: AdaptiveEnforcement{
+			CooperativeToolDownweight: true,
+		},
 		TLSInterception: TLSInterception{
-			Enabled:          false,
+			Enabled: false,
+			PassthroughDomains: []string{
+				"*.googlevideo.com",
+			},
 			CertTTL:          DefaultCertTTL,
 			CertCacheSize:    10000,
 			MaxResponseBytes: 5 * 1024 * 1024, // 5MB
@@ -408,13 +418,19 @@ func Defaults() *Config {
 		BrowserShield: BrowserShield{
 			Strictness:            ShieldStrictnessStandard,
 			MaxShieldBytes:        5 * 1024 * 1024, // 5MB
-			OversizeAction:        ShieldOversizeBlock,
+			OversizeAction:        ShieldOversizeScanHead,
 			StripExtensionProbing: true,
 			StripHiddenTraps:      true,
 			StripTrackingPixels:   true,
 			ExemptDomains: []string{
 				"challenges.cloudflare.com",
+				"developer.mozilla.org",
+				"docs.github.com",
+				"github.dev",
+				"go.dev",
 				"hcaptcha.com",
+				"pkg.go.dev",
+				"vscode.dev",
 				"www.recaptcha.net",
 			},
 		},

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -127,6 +127,11 @@ func applySecurityDefaults(rawYAML []byte, cfg *Config) {
 	prov, _ := raw["mcp_tool_provenance"].(map[string]interface{})
 	setBoolDefault(prov, "offline_only", &cfg.MCPToolProvenance.OfflineOnly)
 
+	// Adaptive cooperative-tool burst downweighting defaults on. Operators can
+	// explicitly set false if they want every burst anomaly scored at full weight.
+	adaptive, _ := raw["adaptive_enforcement"].(map[string]interface{})
+	setBoolDefault(adaptive, "cooperative_tool_downweight", &cfg.AdaptiveEnforcement.CooperativeToolDownweight)
+
 	// Behavioral baseline: poison_resistance defaults to true (trimmed-mean scoring).
 	bb, _ := raw["behavioral_baseline"].(map[string]interface{})
 	setBoolDefault(bb, "poison_resistance", &cfg.BehavioralBaseline.PoisonResistance)
@@ -336,6 +341,10 @@ func (c *Config) ApplyDefaults() {
 		}
 	}
 
+	if c.TLSInterception.PassthroughDomains == nil {
+		c.TLSInterception.PassthroughDomains = append([]string(nil), Defaults().TLSInterception.PassthroughDomains...)
+	}
+
 	// Kill switch defaults
 	if c.KillSwitch.Message == "" {
 		c.KillSwitch.Message = "Emergency deny-all active"
@@ -408,6 +417,21 @@ func (c *Config) ApplyDefaults() {
 	}
 	if c.TLSInterception.MaxResponseBytes <= 0 {
 		c.TLSInterception.MaxResponseBytes = 5 * 1024 * 1024 // 5MB
+	}
+
+	// Browser Shield defaults are applied even when disabled so enabling
+	// browser_shield with only `enabled: true` yields production-safe knobs.
+	if c.BrowserShield.Strictness == "" {
+		c.BrowserShield.Strictness = ShieldStrictnessStandard
+	}
+	if c.BrowserShield.MaxShieldBytes <= 0 {
+		c.BrowserShield.MaxShieldBytes = 5 * 1024 * 1024 // 5MB
+	}
+	if c.BrowserShield.OversizeAction == "" {
+		c.BrowserShield.OversizeAction = ShieldOversizeScanHead
+	}
+	if c.BrowserShield.ExemptDomains == nil {
+		c.BrowserShield.ExemptDomains = append([]string(nil), Defaults().BrowserShield.ExemptDomains...)
 	}
 
 	// MCP WS listener defaults

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -546,11 +546,12 @@ type SessionProfiling struct {
 // Score accumulates from DLP near-misses and blocks. When threshold is exceeded,
 // the session's enforcement level escalates (audit->warn or warn->block).
 type AdaptiveEnforcement struct {
-	Enabled              bool             `yaml:"enabled"`
-	EscalationThreshold  float64          `yaml:"escalation_threshold"`    // points before escalation
-	DecayPerCleanRequest float64          `yaml:"decay_per_clean_request"` // score reduction per clean request
-	Levels               EscalationLevels `yaml:"levels"`
-	ExemptDomains        []string         `yaml:"exempt_domains"` // DLP findings on these hosts skip escalation scoring and action upgrades
+	Enabled                   bool             `yaml:"enabled"`
+	EscalationThreshold       float64          `yaml:"escalation_threshold"`        // points before escalation
+	DecayPerCleanRequest      float64          `yaml:"decay_per_clean_request"`     // score reduction per clean request
+	CooperativeToolDownweight bool             `yaml:"cooperative_tool_downweight"` // downweight burst anomalies from known cooperative tool UAs
+	Levels                    EscalationLevels `yaml:"levels"`
+	ExemptDomains             []string         `yaml:"exempt_domains"` // DLP findings on these hosts skip escalation scoring and action upgrades
 }
 
 // EscalationLevels configures per-level enforcement behavior.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -96,6 +96,7 @@ type Metrics struct {
 	shieldBytesStripped     *prometheus.CounterVec
 	shieldShimsInjected     *prometheus.CounterVec
 	shieldSkipped           *prometheus.CounterVec
+	shieldOversizeScanHead  *prometheus.CounterVec
 	shieldLatency           *prometheus.HistogramVec
 	responseScanExemptTotal *prometheus.CounterVec
 

--- a/internal/metrics/metrics_airlock_test.go
+++ b/internal/metrics/metrics_airlock_test.go
@@ -193,6 +193,31 @@ func TestRecordShieldSkipped_NilReceiver(t *testing.T) {
 	m.RecordShieldSkipped("disabled") // no panic
 }
 
+func TestRecordShieldOversizeScanHead(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		transport string
+	}{
+		{"fetch", "fetch"},
+		{"connect", "connect"},
+		{"reverse", "reverse_proxy"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := New()
+			m.RecordShieldOversizeScanHead(tt.transport)
+		})
+	}
+}
+
+func TestRecordShieldOversizeScanHead_NilReceiver(t *testing.T) {
+	t.Parallel()
+	var m *Metrics
+	m.RecordShieldOversizeScanHead("fetch") // no panic
+}
+
 func TestRecordShieldLatency(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/metrics/shield.go
+++ b/internal/metrics/shield.go
@@ -38,6 +38,12 @@ func (m *Metrics) registerShieldMetrics(reg *prometheus.Registry) {
 		Help:      "Total shield processing skips by reason.",
 	}, []string{"reason"})
 
+	m.shieldOversizeScanHead = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "pipelock",
+		Name:      "shield_oversize_scan_head_total",
+		Help:      "Oversized shieldable responses handled with scan_head by transport.",
+	}, []string{"transport"})
+
 	m.shieldLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "pipelock",
 		Name:      "shield_latency_seconds",
@@ -53,7 +59,7 @@ func (m *Metrics) registerShieldMetrics(reg *prometheus.Registry) {
 
 	reg.MustRegister(
 		m.shieldRewrites, m.shieldBytesStripped, m.shieldShimsInjected,
-		m.shieldSkipped, m.shieldLatency,
+		m.shieldSkipped, m.shieldOversizeScanHead, m.shieldLatency,
 		m.responseScanExemptTotal,
 	)
 }
@@ -88,6 +94,14 @@ func (m *Metrics) RecordShieldSkipped(reason string) {
 		return
 	}
 	m.shieldSkipped.WithLabelValues(reason).Inc()
+}
+
+// RecordShieldOversizeScanHead increments the oversize scan_head counter.
+func (m *Metrics) RecordShieldOversizeScanHead(transport string) {
+	if m == nil {
+		return
+	}
+	m.shieldOversizeScanHead.WithLabelValues(transport).Inc()
 }
 
 // RecordShieldLatency observes shield rewriting latency.

--- a/internal/proxy/adaptive_cooperative_burst_test.go
+++ b/internal/proxy/adaptive_cooperative_burst_test.go
@@ -11,23 +11,30 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
+const (
+	cooperativeUAYtDlp          = "yt-dlp/2026.3.17"
+	cooperativeUAPythonRequests = "python-requests/2.32.0"
+	cooperativeUAPip            = "pip/26.0"
+	cooperativeUAMozilla        = "Mozilla/5.0"
+)
+
 func TestIsCooperativeToolBurstUserAgent(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		ua   string
 		want bool
 	}{
-		{"yt-dlp/2026.3.17", true},
-		{"python-requests/2.32.0", true},
-		{"pip/26.0", true},
+		{cooperativeUAYtDlp, true},
+		{cooperativeUAPythonRequests, true},
+		{cooperativeUAPip, true},
 		{"npm/11.0.0", true},
 		{"pnpm/10.0.0", true},
 		{"apt/2.7.0", true},
 		{"dnf/5.2.0", true},
 		{"curl/8.7.1", true},
 		{"git/2.45.0", true},
-		{"Mozilla/5.0", false},
-		{"evil yt-dlp/2026.3.17", false},
+		{cooperativeUAMozilla, false},
+		{"evil " + cooperativeUAYtDlp, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.ua, func(t *testing.T) {
@@ -53,7 +60,7 @@ func TestAdaptiveCooperativeToolBurstDownweightsDomainAnomalies(t *testing.T) {
 	}
 
 	for i, host := range hosts {
-		p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts(host, "req-coop", "yt-dlp/2026.3.17", cfg, logger))
+		p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts(host, "req-coop", cooperativeUAYtDlp, cfg, logger))
 		if i < len(hosts)-1 && p.sessionMgrPtr.Load().GetOrCreate(clientIP).EscalationLevel() > 0 {
 			t.Fatalf("cooperative burst escalated early at host %s", host)
 		}
@@ -75,8 +82,8 @@ func TestAdaptiveNonCooperativeBurstStillEscalates(t *testing.T) {
 	logger := audit.NewNop()
 	clientIP := adaptiveSessionKeyLoopback
 
-	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("www.youtube.com", "req-1", "Mozilla/5.0", cfg, logger))
-	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("youtubei.googleapis.com", "req-2", "Mozilla/5.0", cfg, logger))
+	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("www.youtube.com", "req-1", cooperativeUAMozilla, cfg, logger))
+	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("youtubei.googleapis.com", "req-2", cooperativeUAMozilla, cfg, logger))
 
 	rec := p.sessionMgrPtr.Load().GetOrCreate(clientIP)
 	if rec.EscalationLevel() == 0 {
@@ -92,8 +99,8 @@ func TestAdaptiveCooperativeDownweightCanBeDisabled(t *testing.T) {
 	logger := audit.NewNop()
 	clientIP := adaptiveSessionKeyLoopback
 
-	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("www.youtube.com", "req-1", "yt-dlp/2026.3.17", cfg, logger))
-	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("youtubei.googleapis.com", "req-2", "yt-dlp/2026.3.17", cfg, logger))
+	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("www.youtube.com", "req-1", cooperativeUAYtDlp, cfg, logger))
+	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("youtubei.googleapis.com", "req-2", cooperativeUAYtDlp, cfg, logger))
 
 	rec := p.sessionMgrPtr.Load().GetOrCreate(clientIP)
 	if rec.EscalationLevel() == 0 {
@@ -109,8 +116,8 @@ func TestAdaptiveExemptDomainBurstDoesNotScore(t *testing.T) {
 	logger := audit.NewNop()
 	clientIP := adaptiveSessionKeyLoopback
 
-	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("www.youtube.com", "req-1", "Mozilla/5.0", cfg, logger))
-	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("youtubei.googleapis.com", "req-2", "Mozilla/5.0", cfg, logger))
+	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("www.youtube.com", "req-1", cooperativeUAMozilla, cfg, logger))
+	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("youtubei.googleapis.com", "req-2", cooperativeUAMozilla, cfg, logger))
 
 	rec := p.sessionMgrPtr.Load().GetOrCreate(clientIP)
 	if rec.ThreatScore() != 0 {

--- a/internal/proxy/adaptive_cooperative_burst_test.go
+++ b/internal/proxy/adaptive_cooperative_burst_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+func TestIsCooperativeToolBurstUserAgent(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		ua   string
+		want bool
+	}{
+		{"yt-dlp/2026.3.17", true},
+		{"python-requests/2.32.0", true},
+		{"pip/26.0", true},
+		{"npm/11.0.0", true},
+		{"pnpm/10.0.0", true},
+		{"apt/2.7.0", true},
+		{"dnf/5.2.0", true},
+		{"curl/8.7.1", true},
+		{"git/2.45.0", true},
+		{"Mozilla/5.0", false},
+		{"evil yt-dlp/2026.3.17", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ua, func(t *testing.T) {
+			t.Parallel()
+			if got := isCooperativeToolBurstUserAgent(tt.ua); got != tt.want {
+				t.Errorf("isCooperativeToolBurstUserAgent(%q) = %v, want %v", tt.ua, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAdaptiveCooperativeToolBurstDownweightsDomainAnomalies(t *testing.T) {
+	t.Parallel()
+	cfg := cooperativeBurstTestConfig()
+	p := newTestProxyWithConfig(t, cfg)
+	logger := audit.NewNop()
+	clientIP := adaptiveSessionKeyLoopback
+	hosts := []string{
+		"www.youtube.com",
+		"youtubei.googleapis.com",
+		"i.ytimg.com",
+		"rr1---sn.googlevideo.com",
+	}
+
+	for i, host := range hosts {
+		p.recordSessionActivityWithUserAgent(clientIP, agentAnonymous, host, "req-coop", "yt-dlp/2026.3.17", scanner.Result{Allowed: true}, cfg, logger, true)
+		if i < len(hosts)-1 && p.sessionMgrPtr.Load().GetOrCreate(clientIP).EscalationLevel() > 0 {
+			t.Fatalf("cooperative burst escalated early at host %s", host)
+		}
+	}
+
+	rec := p.sessionMgrPtr.Load().GetOrCreate(clientIP)
+	if rec.EscalationLevel() != 0 {
+		t.Fatalf("cooperative burst escalated to level %d with score %.2f", rec.EscalationLevel(), rec.ThreatScore())
+	}
+	if rec.ThreatScore() >= cfg.AdaptiveEnforcement.EscalationThreshold {
+		t.Fatalf("cooperative burst score %.2f crossed threshold %.2f", rec.ThreatScore(), cfg.AdaptiveEnforcement.EscalationThreshold)
+	}
+}
+
+func TestAdaptiveNonCooperativeBurstStillEscalates(t *testing.T) {
+	t.Parallel()
+	cfg := cooperativeBurstTestConfig()
+	p := newTestProxyWithConfig(t, cfg)
+	logger := audit.NewNop()
+	clientIP := adaptiveSessionKeyLoopback
+
+	p.recordSessionActivityWithUserAgent(clientIP, agentAnonymous, "www.youtube.com", "req-1", "Mozilla/5.0", scanner.Result{Allowed: true}, cfg, logger, true)
+	p.recordSessionActivityWithUserAgent(clientIP, agentAnonymous, "youtubei.googleapis.com", "req-2", "Mozilla/5.0", scanner.Result{Allowed: true}, cfg, logger, true)
+
+	rec := p.sessionMgrPtr.Load().GetOrCreate(clientIP)
+	if rec.EscalationLevel() == 0 {
+		t.Fatalf("non-cooperative burst did not escalate; score %.2f threshold %.2f", rec.ThreatScore(), cfg.AdaptiveEnforcement.EscalationThreshold)
+	}
+}
+
+func TestAdaptiveCooperativeDownweightCanBeDisabled(t *testing.T) {
+	t.Parallel()
+	cfg := cooperativeBurstTestConfig()
+	cfg.AdaptiveEnforcement.CooperativeToolDownweight = false
+	p := newTestProxyWithConfig(t, cfg)
+	logger := audit.NewNop()
+	clientIP := adaptiveSessionKeyLoopback
+
+	p.recordSessionActivityWithUserAgent(clientIP, agentAnonymous, "www.youtube.com", "req-1", "yt-dlp/2026.3.17", scanner.Result{Allowed: true}, cfg, logger, true)
+	p.recordSessionActivityWithUserAgent(clientIP, agentAnonymous, "youtubei.googleapis.com", "req-2", "yt-dlp/2026.3.17", scanner.Result{Allowed: true}, cfg, logger, true)
+
+	rec := p.sessionMgrPtr.Load().GetOrCreate(clientIP)
+	if rec.EscalationLevel() == 0 {
+		t.Fatalf("disabled cooperative downweight did not preserve full burst scoring; score %.2f", rec.ThreatScore())
+	}
+}
+
+func cooperativeBurstTestConfig() *config.Config {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.SessionProfiling.Enabled = true
+	cfg.SessionProfiling.AnomalyAction = config.ActionWarn
+	cfg.SessionProfiling.DomainBurst = 2
+	cfg.SessionProfiling.WindowMinutes = 5
+	cfg.SessionProfiling.MaxSessions = 100
+	cfg.SessionProfiling.SessionTTLMinutes = 30
+	cfg.SessionProfiling.CleanupIntervalSeconds = 60
+	cfg.AdaptiveEnforcement.Enabled = true
+	cfg.AdaptiveEnforcement.EscalationThreshold = 5.0
+	cfg.AdaptiveEnforcement.DecayPerCleanRequest = 0.5
+	cfg.AdaptiveEnforcement.CooperativeToolDownweight = true
+	cfg.ApplyDefaults()
+	return cfg
+}

--- a/internal/proxy/adaptive_cooperative_burst_test.go
+++ b/internal/proxy/adaptive_cooperative_burst_test.go
@@ -53,7 +53,7 @@ func TestAdaptiveCooperativeToolBurstDownweightsDomainAnomalies(t *testing.T) {
 	}
 
 	for i, host := range hosts {
-		p.recordSessionActivityWithUserAgent(clientIP, agentAnonymous, host, "req-coop", "yt-dlp/2026.3.17", scanner.Result{Allowed: true}, cfg, logger, true)
+		p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts(host, "req-coop", "yt-dlp/2026.3.17", cfg, logger))
 		if i < len(hosts)-1 && p.sessionMgrPtr.Load().GetOrCreate(clientIP).EscalationLevel() > 0 {
 			t.Fatalf("cooperative burst escalated early at host %s", host)
 		}
@@ -75,8 +75,8 @@ func TestAdaptiveNonCooperativeBurstStillEscalates(t *testing.T) {
 	logger := audit.NewNop()
 	clientIP := adaptiveSessionKeyLoopback
 
-	p.recordSessionActivityWithUserAgent(clientIP, agentAnonymous, "www.youtube.com", "req-1", "Mozilla/5.0", scanner.Result{Allowed: true}, cfg, logger, true)
-	p.recordSessionActivityWithUserAgent(clientIP, agentAnonymous, "youtubei.googleapis.com", "req-2", "Mozilla/5.0", scanner.Result{Allowed: true}, cfg, logger, true)
+	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("www.youtube.com", "req-1", "Mozilla/5.0", cfg, logger))
+	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("youtubei.googleapis.com", "req-2", "Mozilla/5.0", cfg, logger))
 
 	rec := p.sessionMgrPtr.Load().GetOrCreate(clientIP)
 	if rec.EscalationLevel() == 0 {
@@ -92,8 +92,8 @@ func TestAdaptiveCooperativeDownweightCanBeDisabled(t *testing.T) {
 	logger := audit.NewNop()
 	clientIP := adaptiveSessionKeyLoopback
 
-	p.recordSessionActivityWithUserAgent(clientIP, agentAnonymous, "www.youtube.com", "req-1", "yt-dlp/2026.3.17", scanner.Result{Allowed: true}, cfg, logger, true)
-	p.recordSessionActivityWithUserAgent(clientIP, agentAnonymous, "youtubei.googleapis.com", "req-2", "yt-dlp/2026.3.17", scanner.Result{Allowed: true}, cfg, logger, true)
+	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("www.youtube.com", "req-1", "yt-dlp/2026.3.17", cfg, logger))
+	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("youtubei.googleapis.com", "req-2", "yt-dlp/2026.3.17", cfg, logger))
 
 	rec := p.sessionMgrPtr.Load().GetOrCreate(clientIP)
 	if rec.EscalationLevel() == 0 {
@@ -109,8 +109,8 @@ func TestAdaptiveExemptDomainBurstDoesNotScore(t *testing.T) {
 	logger := audit.NewNop()
 	clientIP := adaptiveSessionKeyLoopback
 
-	p.recordSessionActivityWithUserAgent(clientIP, agentAnonymous, "www.youtube.com", "req-1", "Mozilla/5.0", scanner.Result{Allowed: true}, cfg, logger, true)
-	p.recordSessionActivityWithUserAgent(clientIP, agentAnonymous, "youtubei.googleapis.com", "req-2", "Mozilla/5.0", scanner.Result{Allowed: true}, cfg, logger, true)
+	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("www.youtube.com", "req-1", "Mozilla/5.0", cfg, logger))
+	p.recordSessionActivityWithUserAgent(cooperativeBurstActivityOpts("youtubei.googleapis.com", "req-2", "Mozilla/5.0", cfg, logger))
 
 	rec := p.sessionMgrPtr.Load().GetOrCreate(clientIP)
 	if rec.ThreatScore() != 0 {
@@ -118,6 +118,20 @@ func TestAdaptiveExemptDomainBurstDoesNotScore(t *testing.T) {
 	}
 	if rec.EscalationLevel() != 0 {
 		t.Fatalf("adaptive-exempt burst escalated to level %d", rec.EscalationLevel())
+	}
+}
+
+func cooperativeBurstActivityOpts(host, requestID, userAgent string, cfg *config.Config, logger *audit.Logger) sessionActivityOptions {
+	return sessionActivityOptions{
+		ClientIP:   adaptiveSessionKeyLoopback,
+		Agent:      agentAnonymous,
+		Hostname:   host,
+		RequestID:  requestID,
+		UserAgent:  userAgent,
+		Result:     scanner.Result{Allowed: true},
+		Config:     cfg,
+		Logger:     logger,
+		DeferClean: true,
 	}
 }
 

--- a/internal/proxy/adaptive_cooperative_burst_test.go
+++ b/internal/proxy/adaptive_cooperative_burst_test.go
@@ -101,6 +101,26 @@ func TestAdaptiveCooperativeDownweightCanBeDisabled(t *testing.T) {
 	}
 }
 
+func TestAdaptiveExemptDomainBurstDoesNotScore(t *testing.T) {
+	t.Parallel()
+	cfg := cooperativeBurstTestConfig()
+	cfg.AdaptiveEnforcement.ExemptDomains = []string{"www.youtube.com", "youtubei.googleapis.com"}
+	p := newTestProxyWithConfig(t, cfg)
+	logger := audit.NewNop()
+	clientIP := adaptiveSessionKeyLoopback
+
+	p.recordSessionActivityWithUserAgent(clientIP, agentAnonymous, "www.youtube.com", "req-1", "Mozilla/5.0", scanner.Result{Allowed: true}, cfg, logger, true)
+	p.recordSessionActivityWithUserAgent(clientIP, agentAnonymous, "youtubei.googleapis.com", "req-2", "Mozilla/5.0", scanner.Result{Allowed: true}, cfg, logger, true)
+
+	rec := p.sessionMgrPtr.Load().GetOrCreate(clientIP)
+	if rec.ThreatScore() != 0 {
+		t.Fatalf("adaptive-exempt burst scored %.2f, want 0", rec.ThreatScore())
+	}
+	if rec.EscalationLevel() != 0 {
+		t.Fatalf("adaptive-exempt burst escalated to level %d", rec.EscalationLevel())
+	}
+}
+
 func cooperativeBurstTestConfig() *config.Config {
 	cfg := config.Defaults()
 	cfg.Internal = nil
@@ -117,5 +137,7 @@ func cooperativeBurstTestConfig() *config.Config {
 	cfg.AdaptiveEnforcement.DecayPerCleanRequest = 0.5
 	cfg.AdaptiveEnforcement.CooperativeToolDownweight = true
 	cfg.ApplyDefaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
 	return cfg
 }

--- a/internal/proxy/adaptive_escalation_test.go
+++ b/internal/proxy/adaptive_escalation_test.go
@@ -1839,8 +1839,10 @@ func TestAdaptive_RateLimitBlock_NoDecaySuppression(t *testing.T) {
 			scoreAfterDLP, sess.ThreatScore())
 	}
 
-	// Clean request with deferClean=false — SHOULD decay.
-	p.recordSessionActivity("127.0.0.1", agentAnonymous, "safe.com", "req-clean",
+	// Clean repeat request with deferClean=false — SHOULD decay. Use an
+	// already-seen hostname so this test isolates rate-limit neutrality from
+	// adaptive domain-burst scoring.
+	p.recordSessionActivity("127.0.0.1", agentAnonymous, "registry.npmjs.org", "req-clean",
 		scanner.Result{Allowed: true},
 		cfg, logger, false)
 	if sess.ThreatScore() >= scoreAfterDLP {
@@ -1933,8 +1935,10 @@ func TestAdaptive_RateLimitBlock_AuditMode_ScoreNeutral(t *testing.T) {
 		t.Errorf("ThreatScore = %v, want 0 in audit mode after protective block", sess.ThreatScore())
 	}
 
-	// Clean request — verify no crash and score stays 0.
-	p.recordSessionActivity("127.0.0.1", agentAnonymous, "safe.com", "req-clean",
+	// Clean repeat request — verify no crash and score stays 0. Use an
+	// already-seen hostname so this test isolates rate-limit neutrality from
+	// adaptive domain-burst scoring.
+	p.recordSessionActivity("127.0.0.1", agentAnonymous, "registry.npmjs.org", "req-clean",
 		scanner.Result{Allowed: true},
 		cfg, logger, false)
 	if sess.ThreatScore() != 0 {

--- a/internal/proxy/adaptive_operator_test.go
+++ b/internal/proxy/adaptive_operator_test.go
@@ -1,0 +1,515 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+const (
+	adaptiveAPIIdentityKey   = "agent-a|203.0.113.9"
+	adaptiveAPIInvocationKey = "mcp-stdio-adaptive"
+	adaptiveAPIAgent         = "agent-a"
+	adaptiveAPIClientIP      = "203.0.113.9"
+	adaptiveAPIAuthHeader    = "Bearer " + testSessionAPIToken
+)
+
+func TestSessionManager_AdaptiveStatusAggregatesOperatorView(t *testing.T) {
+	sm := newAdaptiveOperatorTestManager(t)
+
+	identity := sm.GetOrCreate(adaptiveAPIIdentityKey)
+	identity.RecordSignal(session.SignalBlock, 1.0)
+	identity.SetBlockAll(true)
+	identity.RecordEvent(SessionEvent{Kind: "anomaly", Type: testDomainBurst, Target: "a.example"})
+	identity.RecordEvent(SessionEvent{Kind: "anomaly", Type: testDomainBurst, Target: "b.example"})
+	identity.RecordEvent(SessionEvent{Kind: "anomaly", Type: testIPDomainBurst, Target: "c.example"})
+	_, _, _ = identity.Airlock().SetTierWithProvenance(config.AirlockTierSoft, airlockTriggerOnHigh, airlockSourceTriggers)
+
+	invocation := sm.GetOrCreate(adaptiveAPIInvocationKey)
+	invocation.RecordEvent(SessionEvent{Kind: "block", Target: "tool"})
+
+	status := sm.AdaptiveStatus()
+	if status.ActiveSessions != 2 {
+		t.Fatalf("ActiveSessions: got %d, want 2", status.ActiveSessions)
+	}
+	if status.MaxEscalationLevel != testLevelElevated || status.MaxEscalationInt != 1 {
+		t.Fatalf("max escalation: got %q/%d", status.MaxEscalationLevel, status.MaxEscalationInt)
+	}
+	if status.SessionsByLevel[testLevelElevated] != 1 || status.SessionsByLevel[testLevelNormal] != 1 {
+		t.Errorf("sessions by level: %+v", status.SessionsByLevel)
+	}
+	if status.AirlockTiers[config.AirlockTierSoft] != 1 || status.AirlockTiers[config.AirlockTierNone] != 1 {
+		t.Errorf("airlock tiers: %+v", status.AirlockTiers)
+	}
+	if status.RecentSignalCounts["anomaly"] != 3 || status.RecentSignalCounts["block"] != 1 {
+		t.Errorf("recent signal counts: %+v", status.RecentSignalCounts)
+	}
+	if len(status.TopAnomalies) < 2 || status.TopAnomalies[0].Name != testDomainBurst || status.TopAnomalies[0].Count != 2 {
+		t.Fatalf("top anomalies: %+v", status.TopAnomalies)
+	}
+	if len(status.Sessions) != 2 || status.Sessions[0].Key != adaptiveAPIIdentityKey || status.Sessions[1].Kind != sessionKindInvocation {
+		t.Fatalf("sessions sorted identity before invocation: %+v", status.Sessions)
+	}
+	if status.LockdownTTLSeconds <= 0 {
+		t.Error("expected positive lockdown TTL for soft airlock tier")
+	}
+}
+
+func TestSignalForSessionAnomaly(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		anomalyType string
+		cooperative bool
+		wantSignal  session.SignalType
+		wantOK      bool
+	}{
+		{"domain", testDomainBurst, false, session.SignalDomainAnomaly, true},
+		{"domain cooperative", testDomainBurst, true, session.SignalDomainAnomalyCooperative, true},
+		{"ip domain", testIPDomainBurst, false, session.SignalIPDomainAnomaly, true},
+		{"ip domain cooperative", testIPDomainBurst, true, session.SignalIPDomainAnomalyCooperative, true},
+		{"unknown", "volume_spike", false, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := signalForSessionAnomaly(tt.anomalyType, tt.cooperative)
+			if got != tt.wantSignal || ok != tt.wantOK {
+				t.Fatalf("signalForSessionAnomaly(%q, %t) = %v/%t, want %v/%t",
+					tt.anomalyType, tt.cooperative, got, ok, tt.wantSignal, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestAdaptiveLockdownTTLSeconds(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Airlock{Timers: config.AirlockTimers{SoftMinutes: 5}}
+	if got := adaptiveLockdownTTLSeconds(config.AirlockTierNone, time.Now(), cfg); got != 0 {
+		t.Fatalf("none tier TTL = %d, want 0", got)
+	}
+	if got := adaptiveLockdownTTLSeconds(config.AirlockTierSoft, time.Time{}, cfg); got != 0 {
+		t.Fatalf("zero entered-at TTL = %d, want 0", got)
+	}
+	if got := adaptiveLockdownTTLSeconds(config.AirlockTierSoft, time.Now(), nil); got != 0 {
+		t.Fatalf("nil config TTL = %d, want 0", got)
+	}
+	if got := adaptiveLockdownTTLSeconds(config.AirlockTierSoft, time.Now().Add(-10*time.Minute), cfg); got != 0 {
+		t.Fatalf("expired TTL = %d, want 0", got)
+	}
+	if got := adaptiveLockdownTTLSeconds(config.AirlockTierSoft, time.Now(), cfg); got <= 0 {
+		t.Fatalf("active TTL = %d, want positive", got)
+	}
+}
+
+func TestTopAdaptiveAnomaliesSortsAndCaps(t *testing.T) {
+	t.Parallel()
+	got := topAdaptiveAnomalies(map[string]int{
+		"zeta":    1,
+		"alpha":   3,
+		"beta":    3,
+		"gamma":   2,
+		"delta":   1,
+		"epsilon": 1,
+	})
+	if len(got) != 5 {
+		t.Fatalf("len = %d, want cap at 5: %+v", len(got), got)
+	}
+	if got[0].Name != "alpha" || got[1].Name != "beta" {
+		t.Fatalf("top anomaly sort = %+v", got)
+	}
+	if got[4].Name == "zeta" {
+		t.Fatalf("expected lexical cap to drop zeta, got %+v", got)
+	}
+}
+
+func TestSessionManager_AdaptiveWhoamiClassifiesIdentity(t *testing.T) {
+	sm := newAdaptiveOperatorTestManager(t)
+
+	missing := sm.AdaptiveWhoami(adaptiveAPIClientIP, adaptiveAPIAgent)
+	if missing.Exists || missing.Classification != config.ActionAllow || missing.SessionKey != adaptiveAPIIdentityKey {
+		t.Fatalf("missing whoami response: %+v", missing)
+	}
+
+	sess := sm.GetOrCreate(adaptiveAPIIdentityKey)
+	sess.RecordSignal(session.SignalBlock, 1.0)
+
+	observed := sm.AdaptiveWhoami(adaptiveAPIClientIP, adaptiveAPIAgent)
+	if !observed.Exists || observed.Classification != adaptiveClassificationObserve || observed.EscalationLevel != testLevelElevated {
+		t.Fatalf("observed whoami response: %+v", observed)
+	}
+
+	sess.SetBlockAll(true)
+	blocked := sm.AdaptiveWhoami(adaptiveAPIClientIP, adaptiveAPIAgent)
+	if blocked.Classification != config.ActionBlock || !blocked.BlockAll {
+		t.Fatalf("blocked whoami response: %+v", blocked)
+	}
+
+	ipOnly := sm.AdaptiveWhoami(adaptiveAPIClientIP, "")
+	if ipOnly.SessionKey != adaptiveAPIClientIP || ipOnly.Agent != "" {
+		t.Fatalf("ip-only whoami response: %+v", ipOnly)
+	}
+}
+
+func TestSessionManager_ResetAllIdentitySessionsSkipsInvocationsAndClearsIPState(t *testing.T) {
+	sm := newAdaptiveOperatorTestManager(t)
+	cfg := adaptiveOperatorSessionConfig()
+
+	identity := sm.GetOrCreate(adaptiveAPIIdentityKey)
+	identity.RecordSignal(session.SignalBlock, 1.0)
+	identity.SetBlockAll(true)
+	_, _, _ = identity.Airlock().SetTierWithProvenance(config.AirlockTierHard, airlockTriggerOnCritical, airlockSourceTriggers)
+	sm.GetOrCreate(adaptiveAPIInvocationKey).RecordSignal(session.SignalBlock, 1.0)
+	sm.RecordIPDomain(adaptiveAPIClientIP, "a.example", cfg)
+	sm.RecordIPDomain(adaptiveAPIClientIP, "b.example", cfg)
+
+	reset, skipped := sm.ResetAllIdentitySessions()
+	if reset != 1 || skipped != 1 {
+		t.Fatalf("reset/skipped = %d/%d, want 1/1", reset, skipped)
+	}
+	if identity.ThreatScore() != 0 || identity.EscalationLevel() != 0 || identity.BlockAll() {
+		t.Fatalf("identity not reset: score=%.2f level=%d block_all=%t", identity.ThreatScore(), identity.EscalationLevel(), identity.BlockAll())
+	}
+	if tier := identity.Airlock().Tier(); tier != config.AirlockTierNone {
+		t.Fatalf("identity airlock tier = %q, want none", tier)
+	}
+	if got := sm.GetOrCreate(adaptiveAPIInvocationKey).ThreatScore(); got == 0 {
+		t.Fatal("invocation session should be skipped, not reset")
+	}
+	sm.mu.RLock()
+	ipDomainCount := len(sm.ipDomains)
+	cooldownCount := len(sm.ipBurstCooldown)
+	sm.mu.RUnlock()
+	if ipDomainCount != 0 || cooldownCount != 0 {
+		t.Fatalf("IP-domain state not cleared: domains=%d cooldowns=%d", ipDomainCount, cooldownCount)
+	}
+}
+
+func TestSessionAPI_HandleAdaptiveStatus(t *testing.T) {
+	sm := newAdaptiveOperatorTestManager(t)
+	sm.GetOrCreate(adaptiveAPIIdentityKey).RecordEvent(SessionEvent{Kind: "anomaly", Type: testDomainBurst})
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/adaptive/status", nil)
+	req.Header.Set("Authorization", adaptiveAPIAuthHeader)
+	w := httptest.NewRecorder()
+
+	handler.HandleAdaptiveStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp AdaptiveStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.ActiveSessions != 1 || len(resp.TopAnomalies) != 1 {
+		t.Fatalf("unexpected adaptive status: %+v", resp)
+	}
+}
+
+func TestSessionAPI_HandleAdaptiveStatusRejectsWrongMethodAndMissingManager(t *testing.T) {
+	sm := newAdaptiveOperatorTestManager(t)
+	handler := newTestSessionAPIHandler(t, sm)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/adaptive/status", nil)
+	req.Header.Set("Authorization", adaptiveAPIAuthHeader)
+	w := httptest.NewRecorder()
+
+	handler.HandleAdaptiveStatus(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("wrong method: got %d, want 405", w.Code)
+	}
+	if allow := w.Header().Get("Allow"); allow != http.MethodGet {
+		t.Fatalf("Allow: got %q, want GET", allow)
+	}
+
+	handler = newTestSessionAPIHandler(t, nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/adaptive/status", nil)
+	req.Header.Set("Authorization", adaptiveAPIAuthHeader)
+	w = httptest.NewRecorder()
+
+	handler.HandleAdaptiveStatus(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("missing manager: got %d, want 503", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleAdaptiveFlush(t *testing.T) {
+	sm := newAdaptiveOperatorTestManager(t)
+	sm.GetOrCreate(adaptiveAPIIdentityKey).RecordSignal(session.SignalBlock, 1.0)
+	sm.GetOrCreate(adaptiveAPIInvocationKey).RecordSignal(session.SignalBlock, 1.0)
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/adaptive/flush", nil)
+	req.Header.Set("Authorization", adaptiveAPIAuthHeader)
+	w := httptest.NewRecorder()
+
+	handler.HandleAdaptiveFlush(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp AdaptiveFlushResult
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.Flushed || resp.IdentitySessions != 1 || resp.SkippedInvocations != 1 || !resp.IPDomainStateCleared {
+		t.Fatalf("unexpected flush result: %+v", resp)
+	}
+	if sm.GetOrCreate(adaptiveAPIIdentityKey).ThreatScore() != 0 {
+		t.Fatal("identity session should be reset after adaptive flush")
+	}
+	if sm.GetOrCreate(adaptiveAPIInvocationKey).ThreatScore() == 0 {
+		t.Fatal("invocation session should remain untouched after adaptive flush")
+	}
+}
+
+func TestSessionAPI_HandleAdaptiveFlushRejectsMethodAndBadBody(t *testing.T) {
+	sm := newAdaptiveOperatorTestManager(t)
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/adaptive/flush", nil)
+	req.Header.Set("Authorization", adaptiveAPIAuthHeader)
+	w := httptest.NewRecorder()
+
+	handler.HandleAdaptiveFlush(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("wrong method: got %d, want 405", w.Code)
+	}
+	if allow := w.Header().Get("Allow"); allow != http.MethodPost {
+		t.Fatalf("Allow: got %q, want POST", allow)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/adaptive/flush", strings.NewReader(`{"unexpected":true}`))
+	req.Header.Set("Authorization", adaptiveAPIAuthHeader)
+	w = httptest.NewRecorder()
+
+	handler.HandleAdaptiveFlush(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("bad body: got %d, want 400", w.Code)
+	}
+}
+
+func TestSessionAPI_HandleAdaptiveFlushRejectsMissingManagerAndRateLimit(t *testing.T) {
+	handler := newTestSessionAPIHandler(t, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/adaptive/flush", nil)
+	req.Header.Set("Authorization", adaptiveAPIAuthHeader)
+	w := httptest.NewRecorder()
+
+	handler.HandleAdaptiveFlush(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("missing manager: got %d, want 503", w.Code)
+	}
+
+	sm := newAdaptiveOperatorTestManager(t)
+	handler = newTestSessionAPIHandler(t, sm)
+	for range sessionAPIRateLimitMax {
+		req = httptest.NewRequest(http.MethodPost, "/api/v1/adaptive/flush", nil)
+		req.Header.Set("Authorization", adaptiveAPIAuthHeader)
+		w = httptest.NewRecorder()
+		handler.HandleAdaptiveFlush(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("warmup flush: got %d, want 200; body=%s", w.Code, w.Body.String())
+		}
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/adaptive/flush", nil)
+	req.Header.Set("Authorization", adaptiveAPIAuthHeader)
+	w = httptest.NewRecorder()
+	handler.HandleAdaptiveFlush(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("rate limited flush: got %d, want 429", w.Code)
+	}
+	if retryAfter := w.Header().Get("Retry-After"); retryAfter != "60" {
+		t.Fatalf("Retry-After: got %q, want 60", retryAfter)
+	}
+}
+
+func TestSessionAPI_HandleAdaptiveWhoami(t *testing.T) {
+	sm := newAdaptiveOperatorTestManager(t)
+	sm.GetOrCreate(adaptiveAPIIdentityKey).RecordSignal(session.SignalBlock, 1.0)
+	handler := newTestSessionAPIHandler(t, sm)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/adaptive/whoami", nil)
+	req.RemoteAddr = adaptiveAPIClientIP + ":4567"
+	req.Header.Set("Authorization", adaptiveAPIAuthHeader)
+	req.Header.Set("X-Pipelock-Agent", " "+adaptiveAPIAgent+" ")
+	w := httptest.NewRecorder()
+
+	handler.HandleAdaptiveWhoami(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp AdaptiveWhoami
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.ClientIP != adaptiveAPIClientIP || resp.Agent != adaptiveAPIAgent || resp.SessionKey != adaptiveAPIIdentityKey {
+		t.Fatalf("unexpected whoami identity: %+v", resp)
+	}
+	if !resp.Exists || resp.Classification != adaptiveClassificationObserve {
+		t.Fatalf("unexpected whoami classification: %+v", resp)
+	}
+}
+
+func TestSessionAPI_HandleAdaptiveWhoamiRejectsWrongMethodAndMissingManager(t *testing.T) {
+	sm := newAdaptiveOperatorTestManager(t)
+	handler := newTestSessionAPIHandler(t, sm)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/adaptive/whoami", nil)
+	req.Header.Set("Authorization", adaptiveAPIAuthHeader)
+	w := httptest.NewRecorder()
+
+	handler.HandleAdaptiveWhoami(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("wrong method: got %d, want 405", w.Code)
+	}
+	if allow := w.Header().Get("Allow"); allow != http.MethodGet {
+		t.Fatalf("Allow: got %q, want GET", allow)
+	}
+
+	handler = newTestSessionAPIHandler(t, nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/adaptive/whoami", nil)
+	req.Header.Set("Authorization", adaptiveAPIAuthHeader)
+	w = httptest.NewRecorder()
+
+	handler.HandleAdaptiveWhoami(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("missing manager: got %d, want 503", w.Code)
+	}
+}
+
+func TestSessionAPI_AdaptiveRoutesViaProxyMux(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.APIAllowlist = nil
+	cfg.SessionProfiling.Enabled = true
+	cfg.SessionProfiling.MaxSessions = 100
+	cfg.SessionProfiling.SessionTTLMinutes = 30
+	cfg.SessionProfiling.CleanupIntervalSeconds = 300
+	cfg.SessionProfiling.DomainBurst = 10
+	cfg.SessionProfiling.WindowMinutes = 5
+	cfg.KillSwitch.APIToken = testSessionAPIToken
+	cfg.KillSwitch.APIListen = ""
+
+	p, err := New(cfg, nil, nil, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	defer p.Close()
+
+	sm := p.sessionMgrPtr.Load()
+	if sm == nil {
+		t.Fatal("expected session manager")
+	}
+	sm.GetOrCreate(adaptiveAPIIdentityKey).RecordSignal(session.SignalBlock, 1.0)
+	handler := p.buildHandler(p.buildMux())
+
+	for _, tt := range []struct {
+		name   string
+		method string
+		path   string
+		check  func(*testing.T, []byte)
+	}{
+		{
+			name:   "status",
+			method: http.MethodGet,
+			path:   "/api/v1/adaptive/status",
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp AdaptiveStatus
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("unmarshal status: %v", err)
+				}
+				if resp.ActiveSessions != 1 {
+					t.Fatalf("active sessions: got %d, want 1", resp.ActiveSessions)
+				}
+			},
+		},
+		{
+			name:   "whoami",
+			method: http.MethodGet,
+			path:   "/api/v1/adaptive/whoami",
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp AdaptiveWhoami
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("unmarshal whoami: %v", err)
+				}
+				if resp.SessionKey != adaptiveAPIIdentityKey {
+					t.Fatalf("session key: got %q, want %q", resp.SessionKey, adaptiveAPIIdentityKey)
+				}
+			},
+		},
+		{
+			name:   "flush",
+			method: http.MethodPost,
+			path:   "/api/v1/adaptive/flush",
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp AdaptiveFlushResult
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("unmarshal flush: %v", err)
+				}
+				if !resp.Flushed || resp.IdentitySessions != 1 {
+					t.Fatalf("flush result: %+v", resp)
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req.RemoteAddr = adaptiveAPIClientIP + ":4567"
+			req.Header.Set("Authorization", adaptiveAPIAuthHeader)
+			req.Header.Set("X-Pipelock-Agent", adaptiveAPIAgent)
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status: got %d, want 200; body=%s", w.Code, w.Body.String())
+			}
+			tt.check(t, w.Body.Bytes())
+		})
+	}
+}
+
+func newAdaptiveOperatorTestManager(t *testing.T) *SessionManager {
+	t.Helper()
+	sm := NewSessionManager(adaptiveOperatorSessionConfig(), nil, metrics.New())
+	t.Cleanup(sm.Close)
+	setAirlockConfigForTest(sm, &config.Airlock{
+		Enabled: true,
+		Timers:  config.AirlockTimers{SoftMinutes: 5, HardMinutes: 10},
+	})
+	return sm
+}
+
+func adaptiveOperatorSessionConfig() *config.SessionProfiling {
+	return &config.SessionProfiling{
+		MaxSessions:            100,
+		SessionTTLMinutes:      30,
+		CleanupIntervalSeconds: 300,
+		DomainBurst:            2,
+		WindowMinutes:          5,
+	}
+}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -234,9 +234,9 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		// so session profiling tracks the domain but neither escalation signals nor
 		// clean-decay fire. Blocked exempt traffic is score-neutral.
 		if isAdaptiveExempt(host, cfg.AdaptiveEnforcement.ExemptDomains) {
-			p.recordSessionActivity(clientIP, agent, host, requestID, scanner.Result{Allowed: true}, cfg, p.logger, true)
+			p.recordSessionActivityWithUserAgent(clientIP, agent, host, requestID, r.UserAgent(), scanner.Result{Allowed: true}, cfg, p.logger, true)
 		} else {
-			p.recordSessionActivity(clientIP, agent, host, requestID, scanner.Result{Allowed: false, Score: 0.9}, cfg, p.logger, false)
+			p.recordSessionActivityWithUserAgent(clientIP, agent, host, requestID, r.UserAgent(), scanner.Result{Allowed: false, Score: 0.9}, cfg, p.logger, false)
 		}
 		p.metrics.RecordTunnelBlocked(agentLabel)
 		writeBlockedError(w,
@@ -249,7 +249,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// signals (SignalBlock) fire even for blocked requests. Pass deferClean=true
 	// so a warn-only header or CEE finding on the same CONNECT request does not
 	// get offset by a clean decay from the URL stage.
-	sr := p.recordSessionActivity(clientIP, agent, host, requestID, result, cfg, p.logger, true)
+	sr := p.recordSessionActivityWithUserAgent(clientIP, agent, host, requestID, r.UserAgent(), result, cfg, p.logger, true)
 	// hasFinding excludes IsAdaptiveNeutral (protective enforcement + infrastructure
 	// errors) so resolver wobble doesn't taint downstream "finding" behavior like
 	// clean-decay suppression or CEE signal recording. Fail-closed enforcement
@@ -810,7 +810,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	// signals (SignalBlock) fire even for blocked requests. Pass deferClean=true
 	// so later request/response findings on the same round trip do not get
 	// offset by an early clean decay from the URL stage.
-	sr := p.recordSessionActivity(clientIP, agent, r.URL.Hostname(), requestID, result, cfg, p.logger, true)
+	sr := p.recordSessionActivityWithUserAgent(clientIP, agent, r.URL.Hostname(), requestID, r.UserAgent(), result, cfg, p.logger, true)
 
 	forwardSessionKey := CeeSessionKey(agent, clientIP)
 	var forwardRec session.Recorder

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -234,9 +234,29 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		// so session profiling tracks the domain but neither escalation signals nor
 		// clean-decay fire. Blocked exempt traffic is score-neutral.
 		if isAdaptiveExempt(host, cfg.AdaptiveEnforcement.ExemptDomains) {
-			p.recordSessionActivityWithUserAgent(clientIP, agent, host, requestID, r.UserAgent(), scanner.Result{Allowed: true}, cfg, p.logger, true)
+			p.recordSessionActivityWithUserAgent(sessionActivityOptions{
+				ClientIP:   clientIP,
+				Agent:      agent,
+				Hostname:   host,
+				RequestID:  requestID,
+				UserAgent:  r.UserAgent(),
+				Result:     scanner.Result{Allowed: true},
+				Config:     cfg,
+				Logger:     p.logger,
+				DeferClean: true,
+			})
 		} else {
-			p.recordSessionActivityWithUserAgent(clientIP, agent, host, requestID, r.UserAgent(), scanner.Result{Allowed: false, Score: 0.9}, cfg, p.logger, false)
+			p.recordSessionActivityWithUserAgent(sessionActivityOptions{
+				ClientIP:   clientIP,
+				Agent:      agent,
+				Hostname:   host,
+				RequestID:  requestID,
+				UserAgent:  r.UserAgent(),
+				Result:     scanner.Result{Allowed: false, Score: 0.9},
+				Config:     cfg,
+				Logger:     p.logger,
+				DeferClean: false,
+			})
 		}
 		p.metrics.RecordTunnelBlocked(agentLabel)
 		writeBlockedError(w,
@@ -249,7 +269,17 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// signals (SignalBlock) fire even for blocked requests. Pass deferClean=true
 	// so a warn-only header or CEE finding on the same CONNECT request does not
 	// get offset by a clean decay from the URL stage.
-	sr := p.recordSessionActivityWithUserAgent(clientIP, agent, host, requestID, r.UserAgent(), result, cfg, p.logger, true)
+	sr := p.recordSessionActivityWithUserAgent(sessionActivityOptions{
+		ClientIP:   clientIP,
+		Agent:      agent,
+		Hostname:   host,
+		RequestID:  requestID,
+		UserAgent:  r.UserAgent(),
+		Result:     result,
+		Config:     cfg,
+		Logger:     p.logger,
+		DeferClean: true,
+	})
 	// hasFinding excludes IsAdaptiveNeutral (protective enforcement + infrastructure
 	// errors) so resolver wobble doesn't taint downstream "finding" behavior like
 	// clean-decay suppression or CEE signal recording. Fail-closed enforcement
@@ -810,7 +840,17 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	// signals (SignalBlock) fire even for blocked requests. Pass deferClean=true
 	// so later request/response findings on the same round trip do not get
 	// offset by an early clean decay from the URL stage.
-	sr := p.recordSessionActivityWithUserAgent(clientIP, agent, r.URL.Hostname(), requestID, r.UserAgent(), result, cfg, p.logger, true)
+	sr := p.recordSessionActivityWithUserAgent(sessionActivityOptions{
+		ClientIP:   clientIP,
+		Agent:      agent,
+		Hostname:   r.URL.Hostname(),
+		RequestID:  requestID,
+		UserAgent:  r.UserAgent(),
+		Result:     result,
+		Config:     cfg,
+		Logger:     p.logger,
+		DeferClean: true,
+	})
 
 	forwardSessionKey := CeeSessionKey(agent, clientIP)
 	var forwardRec session.Recorder

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1905,10 +1905,20 @@ func newTLSInterceptTransport(
 // scan result; the caller is responsible for calling it after all scanning is
 // complete (fetch uses this to avoid decaying score before header DLP, CEE, and
 // response scanning have run).
+// recordSessionActivity is a backward-compat wrapper for callers (currently
+// only tests) that don't carry a User-Agent. Production handlers should call
+// recordSessionActivityWithUserAgent directly so cooperative-tool burst
+// downweighting can fire. The wrapper drops the SessionResult return because
+// no existing caller captures it; if a future caller needs the result, switch
+// to the full function rather than widening this wrapper.
+func (p *Proxy) recordSessionActivity(clientIP, agent, hostname, requestID string, result scanner.Result, cfg *config.Config, log *audit.Logger, deferClean bool) {
+	p.recordSessionActivityWithUserAgent(clientIP, agent, hostname, requestID, "", result, cfg, log, deferClean)
+}
+
 // Returns a SessionResult with Blocked set when the request should be rejected
 // due to a session anomaly in block mode, and Level set to the current
 // escalation level for downstream use by UpgradeAction().
-func (p *Proxy) recordSessionActivity(clientIP, agent, hostname, requestID string, result scanner.Result, cfg *config.Config, log *audit.Logger, deferClean bool) SessionResult {
+func (p *Proxy) recordSessionActivityWithUserAgent(clientIP, agent, hostname, requestID, userAgent string, result scanner.Result, cfg *config.Config, log *audit.Logger, deferClean bool) SessionResult {
 	sm := p.sessionMgrPtr.Load()
 	if sm == nil || !cfg.SessionProfiling.Enabled {
 		return SessionResult{}
@@ -1947,9 +1957,11 @@ func (p *Proxy) recordSessionActivity(clientIP, agent, hostname, requestID strin
 	// slam SetTier(drain) again, and the loop never broke. See
 	// TestAirlockEdgeTrigger_NoPlateauReentry.
 	escalated := false
+	var adaptiveCfg config.AdaptiveEnforcement
+	var ep decide.EscalationParams
 	if cfg.AdaptiveEnforcement.Enabled {
-		adaptiveCfg := cfg.AdaptiveEnforcement
-		ep := decide.EscalationParams{
+		adaptiveCfg = cfg.AdaptiveEnforcement
+		ep = decide.EscalationParams{
 			Threshold: adaptiveCfg.EscalationThreshold,
 			Logger:    log,
 			Metrics:   p.metrics,
@@ -1989,6 +2001,20 @@ func (p *Proxy) recordSessionActivity(clientIP, agent, hostname, requestID strin
 			// request lifecycle (fetch), so that later scanning stages (header
 			// DLP, CEE, response) can still raise a finding before decay fires.
 			sess.RecordClean(adaptiveCfg.DecayPerCleanRequest)
+		}
+	}
+
+	if cfg.AdaptiveEnforcement.Enabled && !result.IsAdaptiveNeutral() {
+		cooperativeBurst := cfg.AdaptiveEnforcement.CooperativeToolDownweight && isCooperativeToolBurstUserAgent(userAgent)
+		for _, a := range anomalies {
+			sig, ok := signalForSessionAnomaly(a.Type, cooperativeBurst)
+			if !ok || a.Score <= 0 {
+				continue
+			}
+			if decide.RecordSignal(sess, sig, ep) {
+				escalated = true
+				sess.SetBlockAll(decide.UpgradeAction("", sess.EscalationLevel(), &adaptiveCfg) == config.ActionBlock)
+			}
 		}
 	}
 
@@ -2036,6 +2062,7 @@ func (p *Proxy) recordSessionActivity(clientIP, agent, hostname, requestID strin
 
 		sess.RecordEvent(SessionEvent{
 			Kind:     "anomaly",
+			Type:     a.Type,
 			Target:   hostname,
 			Detail:   a.Detail,
 			Severity: "warn",
@@ -2103,6 +2130,7 @@ func (p *Proxy) applyShield(body []byte, contentType, hostname string, respHeade
 		p.metrics.RecordShieldSkipped("oversize")
 		switch cfg.BrowserShield.OversizeAction {
 		case config.ShieldOversizeScanHead:
+			p.metrics.RecordShieldOversizeScanHead(transport)
 			// Rewrite only the head; append the unshielded tail so the full
 			// response body is returned intact.
 			head, summary := p.runShieldPipelineResult(body[:cfg.BrowserShield.MaxShieldBytes], contentType, respHeaders, &cfg.BrowserShield, p.metrics, actx, clientIP, requestID, transport)
@@ -2607,6 +2635,9 @@ func (p *Proxy) buildMux() *http.ServeMux {
 	}
 	// Register session admin API routes only when NOT on a separate port.
 	if p.sessionAPI != nil && cfg.KillSwitch.APIListen == "" {
+		mux.HandleFunc("/api/v1/adaptive/status", p.sessionAPI.HandleAdaptiveStatus)
+		mux.HandleFunc("/api/v1/adaptive/flush", p.sessionAPI.HandleAdaptiveFlush)
+		mux.HandleFunc("/api/v1/adaptive/whoami", p.sessionAPI.HandleAdaptiveWhoami)
 		mux.HandleFunc("/api/v1/sessions", p.sessionAPI.HandleList)
 		mux.HandleFunc("/api/v1/sessions/", p.sessionAPIRouter)
 	}
@@ -2896,7 +2927,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	// so RecordClean is NOT applied inside recordSessionActivity: header DLP,
 	// CEE, and response scanning may still find something after this point, and
 	// a clean decay before those stages would incorrectly counteract a later signal.
-	sr := p.recordSessionActivity(clientIP, agent, parsed.Hostname(), requestID, result, cfg, log, true)
+	sr := p.recordSessionActivityWithUserAgent(clientIP, agent, parsed.Hostname(), requestID, r.UserAgent(), result, cfg, log, true)
 
 	// Look up the live session recorder for Fix 4+5: use EscalationLevel() at
 	// each enforcement point (not the snapshot in sr.Level) so mid-request CEE

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2004,7 +2004,7 @@ func (p *Proxy) recordSessionActivityWithUserAgent(clientIP, agent, hostname, re
 		}
 	}
 
-	if cfg.AdaptiveEnforcement.Enabled && !result.IsAdaptiveNeutral() {
+	if cfg.AdaptiveEnforcement.Enabled && !result.IsAdaptiveNeutral() && !isAdaptiveExempt(hostname, cfg.AdaptiveEnforcement.ExemptDomains) {
 		cooperativeBurst := cfg.AdaptiveEnforcement.CooperativeToolDownweight && isCooperativeToolBurstUserAgent(userAgent)
 		for _, a := range anomalies {
 			sig, ok := signalForSessionAnomaly(a.Type, cooperativeBurst)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1912,13 +1912,44 @@ func newTLSInterceptTransport(
 // no existing caller captures it; if a future caller needs the result, switch
 // to the full function rather than widening this wrapper.
 func (p *Proxy) recordSessionActivity(clientIP, agent, hostname, requestID string, result scanner.Result, cfg *config.Config, log *audit.Logger, deferClean bool) {
-	p.recordSessionActivityWithUserAgent(clientIP, agent, hostname, requestID, "", result, cfg, log, deferClean)
+	p.recordSessionActivityWithUserAgent(sessionActivityOptions{
+		ClientIP:   clientIP,
+		Agent:      agent,
+		Hostname:   hostname,
+		RequestID:  requestID,
+		Result:     result,
+		Config:     cfg,
+		Logger:     log,
+		DeferClean: deferClean,
+	})
+}
+
+type sessionActivityOptions struct {
+	ClientIP   string
+	Agent      string
+	Hostname   string
+	RequestID  string
+	UserAgent  string
+	Result     scanner.Result
+	Config     *config.Config
+	Logger     *audit.Logger
+	DeferClean bool
 }
 
 // Returns a SessionResult with Blocked set when the request should be rejected
 // due to a session anomaly in block mode, and Level set to the current
 // escalation level for downstream use by UpgradeAction().
-func (p *Proxy) recordSessionActivityWithUserAgent(clientIP, agent, hostname, requestID, userAgent string, result scanner.Result, cfg *config.Config, log *audit.Logger, deferClean bool) SessionResult {
+func (p *Proxy) recordSessionActivityWithUserAgent(opts sessionActivityOptions) SessionResult {
+	clientIP := opts.ClientIP
+	agent := opts.Agent
+	hostname := opts.Hostname
+	requestID := opts.RequestID
+	userAgent := opts.UserAgent
+	result := opts.Result
+	cfg := opts.Config
+	log := opts.Logger
+	deferClean := opts.DeferClean
+
 	sm := p.sessionMgrPtr.Load()
 	if sm == nil || !cfg.SessionProfiling.Enabled {
 		return SessionResult{}
@@ -2927,7 +2958,17 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	// so RecordClean is NOT applied inside recordSessionActivity: header DLP,
 	// CEE, and response scanning may still find something after this point, and
 	// a clean decay before those stages would incorrectly counteract a later signal.
-	sr := p.recordSessionActivityWithUserAgent(clientIP, agent, parsed.Hostname(), requestID, r.UserAgent(), result, cfg, log, true)
+	sr := p.recordSessionActivityWithUserAgent(sessionActivityOptions{
+		ClientIP:   clientIP,
+		Agent:      agent,
+		Hostname:   parsed.Hostname(),
+		RequestID:  requestID,
+		UserAgent:  r.UserAgent(),
+		Result:     result,
+		Config:     cfg,
+		Logger:     log,
+		DeferClean: true,
+	})
 
 	// Look up the live session recorder for Fix 4+5: use EscalationLevel() at
 	// each enforcement point (not the snapshot in sr.Level) so mid-request CEE

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -41,6 +41,8 @@ type Anomaly struct {
 // discarded to bound memory growth on long-lived sessions.
 const maxRecentEvents = 20
 
+const adaptiveClassificationObserve = "observe"
+
 var cooperativeToolUserAgentPattern = regexp.MustCompile(`(?i)^(?:yt-dlp|python-requests|pip|npm|pnpm|apt|dnf|curl|git)/`)
 
 func isCooperativeToolBurstUserAgent(userAgent string) bool {
@@ -1338,7 +1340,7 @@ func (sm *SessionManager) AdaptiveWhoami(clientIP, agent string) AdaptiveWhoami 
 	if sess.atBlockAll || tier == config.AirlockTierHard || tier == config.AirlockTierDrain {
 		out.Classification = config.ActionBlock
 	} else if tier == config.AirlockTierSoft || sess.escalationLevel > 0 {
-		out.Classification = "observe"
+		out.Classification = adaptiveClassificationObserve
 	}
 	out.LockdownTTLSeconds = adaptiveLockdownTTLSeconds(tier, enteredAt, sm.AirlockConfig())
 	return out

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -6,6 +6,7 @@ package proxy
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -40,17 +41,41 @@ type Anomaly struct {
 // discarded to bound memory growth on long-lived sessions.
 const maxRecentEvents = 20
 
+var cooperativeToolUserAgentPattern = regexp.MustCompile(`(?i)^(?:yt-dlp|python-requests|pip|npm|pnpm|apt|dnf|curl|git)/`)
+
+func isCooperativeToolBurstUserAgent(userAgent string) bool {
+	return cooperativeToolUserAgentPattern.MatchString(strings.TrimSpace(userAgent))
+}
+
+func signalForSessionAnomaly(anomalyType string, cooperative bool) (session.SignalType, bool) {
+	switch anomalyType {
+	case "domain_burst":
+		if cooperative {
+			return session.SignalDomainAnomalyCooperative, true
+		}
+		return session.SignalDomainAnomaly, true
+	case "ip_domain_burst":
+		if cooperative {
+			return session.SignalIPDomainAnomalyCooperative, true
+		}
+		return session.SignalIPDomainAnomaly, true
+	default:
+		return 0, false
+	}
+}
+
 // SessionEvent is a structured record of a notable event on a session used
 // by the operator admin API to explain airlock state and recent activity.
 // Events are pushed into a bounded ring buffer on SessionState and read out
 // in chronological order (oldest first).
 type SessionEvent struct {
 	At       time.Time `json:"at"`
-	Kind     string    `json:"kind"`     // e.g. "block", "anomaly", "airlock_enter"
-	Target   string    `json:"target"`   // hostname, tool name, or transport where observed
-	Detail   string    `json:"detail"`   // short human-readable description
-	Severity string    `json:"severity"` // info / warn / critical, mirrors audit severity
-	Score    float64   `json:"score"`    // scanner score at time of event (0 when N/A)
+	Kind     string    `json:"kind"`           // e.g. "block", "anomaly", "airlock_enter"
+	Type     string    `json:"type,omitempty"` // subtype for anomaly/block events
+	Target   string    `json:"target"`         // hostname, tool name, or transport where observed
+	Detail   string    `json:"detail"`         // short human-readable description
+	Severity string    `json:"severity"`       // info / warn / critical, mirrors audit severity
+	Score    float64   `json:"score"`          // scanner score at time of event (0 when N/A)
 }
 
 // SessionState tracks behavioral state for a single agent session.
@@ -551,6 +576,44 @@ type SessionSnapshot struct {
 	TaintLevel       string    `json:"taint_level"`
 	Contaminated     bool      `json:"contaminated"`
 	LastActivity     time.Time `json:"last_activity"`
+}
+
+type AdaptiveTopAnomaly struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+type AdaptiveStatus struct {
+	ActiveSessions     int                  `json:"active_sessions"`
+	MaxEscalationLevel string               `json:"max_escalation_level"`
+	MaxEscalationInt   int                  `json:"max_escalation_level_int"`
+	SessionsByLevel    map[string]int       `json:"sessions_by_level"`
+	AirlockTiers       map[string]int       `json:"airlock_tiers"`
+	RecentSignalCounts map[string]int       `json:"recent_signal_counts"`
+	TopAnomalies       []AdaptiveTopAnomaly `json:"top_anomalies"`
+	LockdownTTLSeconds int64                `json:"lockdown_ttl_seconds"`
+	Sessions           []SessionSnapshot    `json:"sessions,omitempty"`
+}
+
+type AdaptiveFlushResult struct {
+	Flushed              bool `json:"flushed"`
+	IdentitySessions     int  `json:"identity_sessions"`
+	SkippedInvocations   int  `json:"skipped_invocations"`
+	IPDomainStateCleared bool `json:"ip_domain_state_cleared"`
+}
+
+type AdaptiveWhoami struct {
+	ClientIP           string  `json:"client_ip"`
+	Agent              string  `json:"agent,omitempty"`
+	SessionKey         string  `json:"session_key"` //nolint:gosec // Operator-visible session identity, not a credential.
+	Exists             bool    `json:"exists"`
+	Classification     string  `json:"classification"`
+	EscalationLevel    string  `json:"escalation_level"`
+	EscalationLevelInt int     `json:"escalation_level_int"`
+	ThreatScore        float64 `json:"threat_score"`
+	BlockAll           bool    `json:"block_all"`
+	AirlockTier        string  `json:"airlock_tier"`
+	LockdownTTLSeconds int64   `json:"lockdown_ttl_seconds"`
 }
 
 // sessionAdminSnapshot is the internal operator-facing expansion of
@@ -1127,6 +1190,184 @@ func (sm *SessionManager) SnapshotAndResetIfResettable(key string) (preSnap sess
 	}
 
 	return preSnap, true, nil
+}
+
+// ResetAllIdentitySessions clears adaptive state for every identity session
+// and drops IP-domain burst windows. Invocation sessions are left alone
+// because they are ephemeral transport contexts.
+func (sm *SessionManager) ResetAllIdentitySessions() (reset, skipped int) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	for key, sess := range sm.sessions {
+		kind, _, _ := classifySessionKey(key)
+		if kind != sessionKindIdentity {
+			skipped++
+			continue
+		}
+		sess.mu.Lock()
+		sess.airlock.mu.Lock()
+		prevLevel := sess.escalationLevel
+		sess.resetWhileLocked()
+		sess.airlock.mu.Unlock()
+		sess.mu.Unlock()
+		if prevLevel > 0 && sm.metrics != nil {
+			sm.metrics.SetAdaptiveSessionLevel(session.EscalationLabel(prevLevel), -1)
+		}
+		reset++
+	}
+	sm.ipDomains = make(map[string][]domainEntry)
+	sm.ipBurstCooldown = make(map[string]time.Time)
+	return reset, skipped
+}
+
+func (sm *SessionManager) AdaptiveStatus() AdaptiveStatus {
+	sm.mu.RLock()
+	keys := make([]string, 0, len(sm.sessions))
+	sessions := make([]*SessionState, 0, len(sm.sessions))
+	for key, sess := range sm.sessions {
+		keys = append(keys, key)
+		sessions = append(sessions, sess)
+	}
+	sm.mu.RUnlock()
+
+	status := AdaptiveStatus{
+		SessionsByLevel:    make(map[string]int),
+		AirlockTiers:       make(map[string]int),
+		RecentSignalCounts: make(map[string]int),
+		Sessions:           make([]SessionSnapshot, 0, len(sessions)),
+	}
+	anomalyCounts := make(map[string]int)
+	airlockCfg := sm.AirlockConfig()
+
+	for i, sess := range sessions {
+		sess.mu.Lock()
+		key := keys[i]
+		kind, agent, ip := classifySessionKey(key)
+		levelInt := sess.escalationLevel
+		level := session.EscalationLabel(levelInt)
+		tier := sess.airlock.Tier()
+		enteredAt := sess.airlock.EnteredAt()
+		if tier == "" {
+			tier = config.AirlockTierNone
+		}
+		status.ActiveSessions++
+		status.SessionsByLevel[level]++
+		status.AirlockTiers[tier]++
+		if levelInt > status.MaxEscalationInt {
+			status.MaxEscalationInt = levelInt
+			status.MaxEscalationLevel = level
+		}
+		for _, evt := range sess.recentEvents {
+			if evt.Kind != "" {
+				status.RecentSignalCounts[evt.Kind]++
+			}
+			if evt.Kind == "anomaly" && evt.Type != "" {
+				anomalyCounts[evt.Type]++
+			}
+		}
+		status.Sessions = append(status.Sessions, SessionSnapshot{
+			Key:              key,
+			Agent:            agent,
+			ClientIP:         ip,
+			Kind:             kind,
+			CurrentTaskID:    sess.task.CurrentTaskID,
+			CurrentTaskLabel: sess.task.CurrentTaskLabel,
+			ThreatScore:      sess.threatScore,
+			EscalationLevel:  level,
+			BlockAll:         sess.atBlockAll,
+			AirlockTier:      tier,
+			TaintLevel:       sess.risk.Level.String(),
+			Contaminated:     sess.risk.Contaminated,
+			LastActivity:     sess.lastActivity,
+		})
+		ttl := adaptiveLockdownTTLSeconds(tier, enteredAt, airlockCfg)
+		if ttl > status.LockdownTTLSeconds {
+			status.LockdownTTLSeconds = ttl
+		}
+		sess.mu.Unlock()
+	}
+	if status.MaxEscalationLevel == "" {
+		status.MaxEscalationLevel = session.EscalationLabel(0)
+	}
+	status.TopAnomalies = topAdaptiveAnomalies(anomalyCounts)
+	return status
+}
+
+func (sm *SessionManager) AdaptiveWhoami(clientIP, agent string) AdaptiveWhoami {
+	key := clientIP
+	if agent != "" && agent != agentAnonymous {
+		key = agent + "|" + clientIP
+	}
+	out := AdaptiveWhoami{
+		ClientIP:        clientIP,
+		Agent:           agent,
+		SessionKey:      key,
+		Classification:  config.ActionAllow,
+		AirlockTier:     config.AirlockTierNone,
+		EscalationLevel: session.EscalationLabel(0),
+	}
+
+	sm.mu.RLock()
+	sess, ok := sm.sessions[key]
+	if !ok {
+		sm.mu.RUnlock()
+		return out
+	}
+	sm.mu.RUnlock()
+
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	out.Exists = true
+	out.EscalationLevelInt = sess.escalationLevel
+	out.EscalationLevel = session.EscalationLabel(sess.escalationLevel)
+	out.ThreatScore = sess.threatScore
+	out.BlockAll = sess.atBlockAll
+	tier := sess.airlock.Tier()
+	enteredAt := sess.airlock.EnteredAt()
+	if tier == "" {
+		tier = config.AirlockTierNone
+	}
+	out.AirlockTier = tier
+	if sess.atBlockAll || tier == config.AirlockTierHard || tier == config.AirlockTierDrain {
+		out.Classification = config.ActionBlock
+	} else if tier == config.AirlockTierSoft || sess.escalationLevel > 0 {
+		out.Classification = "observe"
+	}
+	out.LockdownTTLSeconds = adaptiveLockdownTTLSeconds(tier, enteredAt, sm.AirlockConfig())
+	return out
+}
+
+func adaptiveLockdownTTLSeconds(tier string, enteredAt time.Time, airlockCfg *config.Airlock) int64 {
+	if tier == "" || tier == config.AirlockTierNone || enteredAt.IsZero() || airlockCfg == nil {
+		return 0
+	}
+	d := deescalationDuration(tier, &airlockCfg.Timers)
+	if d <= 0 {
+		return 0
+	}
+	remaining := time.Until(enteredAt.Add(d))
+	if remaining <= 0 {
+		return 0
+	}
+	return int64(remaining.Seconds())
+}
+
+func topAdaptiveAnomalies(counts map[string]int) []AdaptiveTopAnomaly {
+	entries := make([]AdaptiveTopAnomaly, 0, len(counts))
+	for name, count := range counts {
+		entries = append(entries, AdaptiveTopAnomaly{Name: name, Count: count})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Count == entries[j].Count {
+			return entries[i].Name < entries[j].Name
+		}
+		return entries[i].Count > entries[j].Count
+	})
+	if len(entries) > 5 {
+		entries = entries[:5]
+	}
+	return entries
 }
 
 // withMutableIdentitySession looks up a resettable identity session and runs

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -1290,6 +1290,12 @@ func (sm *SessionManager) AdaptiveStatus() AdaptiveStatus {
 	if status.MaxEscalationLevel == "" {
 		status.MaxEscalationLevel = session.EscalationLabel(0)
 	}
+	sort.SliceStable(status.Sessions, func(i, j int) bool {
+		if status.Sessions[i].Kind != status.Sessions[j].Kind {
+			return status.Sessions[i].Kind < status.Sessions[j].Kind
+		}
+		return status.Sessions[i].Key < status.Sessions[j].Key
+	})
 	status.TopAnomalies = topAdaptiveAnomalies(anomalyCounts)
 	return status
 }

--- a/internal/proxy/session_api.go
+++ b/internal/proxy/session_api.go
@@ -83,6 +83,7 @@ const (
 	sessionAPIActionInspect   = "inspect"
 	sessionAPIActionExplain   = "explain"
 	sessionAPIActionTerminate = "terminate"
+	sessionAPIActionAdaptive  = "adaptive"
 )
 
 // tierNotQuarantinedReason is the explanation returned for sessions that
@@ -160,6 +161,7 @@ func NewSessionAPIHandler(opts SessionAPIOptions) *SessionAPIHandler {
 			sessionAPIActionInspect:   {windowStart: time.Now()},
 			sessionAPIActionExplain:   {windowStart: time.Now()},
 			sessionAPIActionTerminate: {windowStart: time.Now()},
+			sessionAPIActionAdaptive:  {windowStart: time.Now()},
 		},
 	}
 	// Seed the atomic token pointer from the constructor input. Stored via
@@ -1028,6 +1030,85 @@ func (h *SessionAPIHandler) HandleTerminate(w http.ResponseWriter, r *http.Reque
 		IPStateCleared:  ip != "",
 		CEEStateCleared: ceeCleared,
 	})
+}
+
+// HandleAdaptiveStatus handles GET /api/v1/adaptive/status.
+func (h *SessionAPIHandler) HandleAdaptiveStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !h.authenticate(w, r) {
+		return
+	}
+	sm := h.loadManager(w)
+	if sm == nil {
+		return
+	}
+	clientIP, _ := requestMeta(r)
+	h.logSessionAdmin("adaptive_status", clientIP, "", "ok", http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(sm.AdaptiveStatus())
+}
+
+// HandleAdaptiveFlush handles POST /api/v1/adaptive/flush.
+func (h *SessionAPIHandler) HandleAdaptiveFlush(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !h.authenticate(w, r) {
+		return
+	}
+	clientIP, _ := requestMeta(r)
+	if !h.checkRateLimit(sessionAPIActionAdaptive) {
+		h.logSessionAdmin("adaptive_flush_rate_limited", clientIP, "", "rate limit exceeded", http.StatusTooManyRequests)
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+	sm := h.loadManager(w)
+	if sm == nil {
+		return
+	}
+	var empty struct{}
+	if err := decodeJSONBody(r, &empty); err != nil {
+		h.logSessionAdmin("adaptive_flush_bad_body", clientIP, "", err.Error(), http.StatusBadRequest)
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	reset, skipped := sm.ResetAllIdentitySessions()
+	h.logSessionAdmin("adaptive_flush", clientIP, "", "ok", http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(AdaptiveFlushResult{
+		Flushed:              true,
+		IdentitySessions:     reset,
+		SkippedInvocations:   skipped,
+		IPDomainStateCleared: true,
+	})
+}
+
+// HandleAdaptiveWhoami handles GET /api/v1/adaptive/whoami.
+func (h *SessionAPIHandler) HandleAdaptiveWhoami(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !h.authenticate(w, r) {
+		return
+	}
+	sm := h.loadManager(w)
+	if sm == nil {
+		return
+	}
+	clientIP, _ := requestMeta(r)
+	agent := strings.TrimSpace(r.Header.Get("X-Pipelock-Agent"))
+	h.logSessionAdmin("adaptive_whoami", clientIP, "", "ok", http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(sm.AdaptiveWhoami(clientIP, agent))
 }
 
 // airlockCfgFromManager fetches the active airlock config from the manager

--- a/internal/proxy/shield_integration_test.go
+++ b/internal/proxy/shield_integration_test.go
@@ -5,6 +5,8 @@ package proxy
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
@@ -310,18 +312,30 @@ func TestProxy_ApplyShield_OversizeScanHead(t *testing.T) {
 	p := newTestProxy(t)
 	cfg := config.Defaults()
 	cfg.BrowserShield.Enabled = true
-	cfg.BrowserShield.MaxShieldBytes = 50
+	cfg.BrowserShield.MaxShieldBytes = 160
 	cfg.BrowserShield.OversizeAction = config.ShieldOversizeScanHead
 	actx := audit.LogContext{}
 
-	// Body larger than max, but the head portion is HTML.
-	body := []byte("<html><head></head><body>" + string(make([]byte, 100)) + "</body></html>")
-	result, _, blocked := p.applyShield(body, "text/html", "example.com", nil, cfg, actx, "127.0.0.1", "req1", TransportFetch, "act1")
+	tail := strings.Repeat("TAIL", 80)
+	body := []byte(`<html><head></head><body><script>fetch("chrome-extension://abcdefghijklmnopqrstuvwxyzabcdef/manifest.json")</script>` + tail + `</body></html>`)
+	result, summary, blocked := p.applyShield(body, "text/html", "example.com", nil, cfg, actx, "127.0.0.1", "req1", TransportFetch, "act1")
 	if blocked {
 		t.Error("scan_head should not block")
 	}
 	if result == nil {
 		t.Error("scan_head should return non-nil body")
+	}
+	if !strings.Contains(string(result), tail) {
+		t.Error("scan_head should pass the unscanned tail through")
+	}
+	if summary == nil || !summary.Partial || summary.ScannedBytes != cfg.BrowserShield.MaxShieldBytes || summary.BodyBytes != len(body) {
+		t.Fatalf("scan_head summary = %+v, want partial summary with body/scanned bytes", summary)
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	p.metrics.PrometheusHandler().ServeHTTP(w, req)
+	if !strings.Contains(w.Body.String(), `pipelock_shield_oversize_scan_head_total{transport="fetch"} 1`) {
+		t.Errorf("metrics output missing scan_head counter: %s", w.Body.String())
 	}
 }
 

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -247,7 +247,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Session profiling: record BEFORE the enforce-mode early return so adaptive
 	// signals (SignalBlock) fire even for blocked requests. Pass deferClean=true
 	// so header DLP findings on the same handshake don't get offset by early decay.
-	sr := p.recordSessionActivity(clientIP, agent, parsed.Hostname(), requestID, result, cfg, log, true)
+	sr := p.recordSessionActivityWithUserAgent(clientIP, agent, parsed.Hostname(), requestID, r.UserAgent(), result, cfg, log, true)
 	// wsHasFinding excludes IsAdaptiveNeutral (protective + infrastructure errors)
 	// so DNS resolver failures don't taint downstream "finding" behavior. Fail-closed
 	// enforcement still fires via !result.Allowed.
@@ -416,7 +416,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		})
 		wsHasFinding = true
 		// Record session activity so adaptive enforcement sees header-DLP hits.
-		headerSR := p.recordSessionActivity(clientIP, agent, parsed.Hostname(), requestID, scanner.Result{Allowed: false, Score: 0.9}, cfg, log, false)
+		headerSR := p.recordSessionActivityWithUserAgent(clientIP, agent, parsed.Hostname(), requestID, r.UserAgent(), scanner.Result{Allowed: false, Score: 0.9}, cfg, log, false)
 		if cfg.EnforceEnabled() {
 			log.LogWSBlocked(targetURL, audit.DirectionClientToServer, audit.ScannerDLP, reason, clientIP, requestID)
 			p.metrics.RecordWSBlocked()

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -247,7 +247,17 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Session profiling: record BEFORE the enforce-mode early return so adaptive
 	// signals (SignalBlock) fire even for blocked requests. Pass deferClean=true
 	// so header DLP findings on the same handshake don't get offset by early decay.
-	sr := p.recordSessionActivityWithUserAgent(clientIP, agent, parsed.Hostname(), requestID, r.UserAgent(), result, cfg, log, true)
+	sr := p.recordSessionActivityWithUserAgent(sessionActivityOptions{
+		ClientIP:   clientIP,
+		Agent:      agent,
+		Hostname:   parsed.Hostname(),
+		RequestID:  requestID,
+		UserAgent:  r.UserAgent(),
+		Result:     result,
+		Config:     cfg,
+		Logger:     log,
+		DeferClean: true,
+	})
 	// wsHasFinding excludes IsAdaptiveNeutral (protective + infrastructure errors)
 	// so DNS resolver failures don't taint downstream "finding" behavior. Fail-closed
 	// enforcement still fires via !result.Allowed.
@@ -416,7 +426,17 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		})
 		wsHasFinding = true
 		// Record session activity so adaptive enforcement sees header-DLP hits.
-		headerSR := p.recordSessionActivityWithUserAgent(clientIP, agent, parsed.Hostname(), requestID, r.UserAgent(), scanner.Result{Allowed: false, Score: 0.9}, cfg, log, false)
+		headerSR := p.recordSessionActivityWithUserAgent(sessionActivityOptions{
+			ClientIP:   clientIP,
+			Agent:      agent,
+			Hostname:   parsed.Hostname(),
+			RequestID:  requestID,
+			UserAgent:  r.UserAgent(),
+			Result:     scanner.Result{Allowed: false, Score: 0.9},
+			Config:     cfg,
+			Logger:     log,
+			DeferClean: false,
+		})
 		if cfg.EnforceEnabled() {
 			log.LogWSBlocked(targetURL, audit.DirectionClientToServer, audit.ScannerDLP, reason, clientIP, requestID)
 			p.metrics.RecordWSBlocked()

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -18,24 +18,30 @@ import (
 type SignalType int
 
 const (
-	SignalBlock         SignalType = iota // +3 — hard block from any scanner/transport
-	SignalNearMiss                        // +1 — warn-level finding from any scanner/transport
-	SignalDomainAnomaly                   // +2 — domain burst detection
-	SignalEntropyBudget                   // +2 — CEE entropy exceeded
-	SignalFragmentDLP                     // +3 — CEE fragment reassembly found secret
-	SignalStrip                           // +2 — active mitigation, repeated stripping = sustained attack
-	SignalShieldRewrite                   // +0.25 — Browser Shield rewrote browser-side probes/traps
+	SignalBlock                      SignalType = iota // +3 — hard block from any scanner/transport
+	SignalNearMiss                                     // +1 — warn-level finding from any scanner/transport
+	SignalDomainAnomaly                                // +2 — domain burst detection
+	SignalEntropyBudget                                // +2 — CEE entropy exceeded
+	SignalFragmentDLP                                  // +3 — CEE fragment reassembly found secret
+	SignalStrip                                        // +2 — active mitigation, repeated stripping = sustained attack
+	SignalShieldRewrite                                // +0.25 — Browser Shield rewrote browser-side probes/traps
+	SignalIPDomainAnomaly                              // +3 — IP-level domain burst across agent identities
+	SignalDomainAnomalyCooperative                     // +0.4 — downweighted domain burst from cooperative tool UA
+	SignalIPDomainAnomalyCooperative                   // +0.6 — downweighted IP burst from cooperative tool UA
 )
 
 // SignalPoints maps signal types to their score contribution.
 var SignalPoints = map[SignalType]float64{
-	SignalBlock:         3.0,
-	SignalNearMiss:      1.0,
-	SignalDomainAnomaly: 2.0,
-	SignalEntropyBudget: 2.0,
-	SignalFragmentDLP:   3.0,
-	SignalStrip:         2.0,
-	SignalShieldRewrite: 0.25,
+	SignalBlock:                      3.0,
+	SignalNearMiss:                   1.0,
+	SignalDomainAnomaly:              2.0,
+	SignalEntropyBudget:              2.0,
+	SignalFragmentDLP:                3.0,
+	SignalStrip:                      2.0,
+	SignalShieldRewrite:              0.25,
+	SignalIPDomainAnomaly:            3.0,
+	SignalDomainAnomalyCooperative:   0.4,
+	SignalIPDomainAnomalyCooperative: 0.6,
 }
 
 // escalationLabels maps escalation levels to human-readable names.

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -21,6 +21,9 @@ var allSignals = []session.SignalType{
 	session.SignalFragmentDLP,
 	session.SignalStrip,
 	session.SignalShieldRewrite,
+	session.SignalIPDomainAnomaly,
+	session.SignalDomainAnomalyCooperative,
+	session.SignalIPDomainAnomalyCooperative,
 }
 
 func TestSignalPoints_AllSignalsPresent(t *testing.T) {
@@ -49,6 +52,9 @@ func TestSignalPoints_Values(t *testing.T) {
 		{session.SignalFragmentDLP, 3.0, "SignalFragmentDLP"},
 		{session.SignalStrip, 2.0, "SignalStrip"},
 		{session.SignalShieldRewrite, 0.25, "SignalShieldRewrite"},
+		{session.SignalIPDomainAnomaly, 3.0, "SignalIPDomainAnomaly"},
+		{session.SignalDomainAnomalyCooperative, 0.4, "SignalDomainAnomalyCooperative"},
+		{session.SignalIPDomainAnomalyCooperative, 0.6, "SignalIPDomainAnomalyCooperative"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Default Browser Shield oversize handling to `scan_head`, add a metric for scan-head oversize handling, and document the production rollout posture.
- Add conservative defaults for Browser Shield exemptions and TLS passthrough for `*.googlevideo.com`.
- Add `adaptive_enforcement.cooperative_tool_downweight` and wire session domain-burst / IP-domain-burst anomalies into adaptive scoring with reduced weight for known cooperative tools.
- Add authenticated `pipelock adaptive status|flush|whoami` API and CLI surfaces for operator inspection and reset.

## Behavior note

This makes burst anomalies contribute to adaptive scoring in production for non-cooperative clients. Protective rate-limit and infrastructure-neutral results remain adaptive-neutral, and cooperative tools are downweighted to avoid escalating expected package/media fetch bursts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added top-level "pipelock adaptive" CLI (status, flush, whoami) and matching admin API endpoints to inspect/reset adaptive enforcement and identity-session/IP-domain state; cooperative-tool user-agent detection downweights benign burst activity.

* **Documentation**
  * Updated CLI, configuration, and production-readiness docs; Browser Shield now defaults to scan_head with expanded exempt domains; TLS passthrough example updated.

* **Metrics**
  * New metric for oversize "scan_head" shield events.

* **Tests**
  * Expanded tests for adaptive behavior, cooperative downweighting, defaults, CLI, API, and metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->