### PR TITLE
Add MCP integrity manifest tooling

### DIFF
--- a/docs/cli/mcp-integrity.md
+++ b/docs/cli/mcp-integrity.md
@@ -1,0 +1,81 @@
+# MCP Integrity Manifest Tooling
+
+`pipelock mcp integrity manifest` generates and verifies the JSON manifest used
+by `mcp_binary_integrity`.
+
+## Generate
+
+Pin one MCP server command before enabling enforcement:
+
+```sh
+pipelock mcp integrity manifest generate \
+  --output /etc/pipelock/binary-manifest.json \
+  -- node /opt/mcp/server.js
+```
+
+For interpreter commands, Pipelock pins both the resolved interpreter and the
+resolved script path. To add another command to an existing manifest, use
+`--merge`:
+
+```sh
+pipelock mcp integrity manifest generate \
+  --output /etc/pipelock/binary-manifest.json \
+  --merge \
+  -- python3 /opt/mcp/weather.py
+```
+
+Use `--workdir` when relative script arguments must be resolved from the MCP
+server's launch directory:
+
+```sh
+pipelock mcp integrity manifest generate \
+  --output ./binary-manifest.json \
+  --workdir /opt/mcp \
+  -- python3 server.py
+```
+
+## Verify
+
+Verify the manifest before wiring it into `pipelock mcp proxy`:
+
+```sh
+pipelock mcp integrity manifest verify \
+  --manifest /etc/pipelock/binary-manifest.json \
+  -- node /opt/mcp/server.js
+```
+
+The command exits non-zero if any resolved binary or script hash is missing or
+mismatched. Use `--json` for automation.
+
+## Operator notes
+
+- **Prefer absolute script paths in your MCP launcher.** If a command uses a
+  relative script argument, generate the manifest with the same working
+  directory that production will use. Unsandboxed `pipelock mcp proxy` inherits
+  the proxy process cwd; sandboxed mode resolves relative scripts against the
+  sandbox `--workspace`. Absolute paths (for example,
+  `python3 /opt/mcp/server.py`) avoid cwd drift entirely.
+- **Manifest file ownership.** The generate command writes the file with
+  mode `0o600` owned by whoever runs the CLI. If you generate as your
+  operator user and Pipelock runs as a service user (e.g.
+  `pipelock-proxy`), you must `chown` the manifest to the service user
+  (or place it in a group Pipelock can read) before enabling enforcement.
+  Otherwise the proxy will fail to load the manifest and fall back per the
+  configured `action`.
+- **`--merge` adds and updates entries; it never prunes.** Old entries for
+  paths you no longer use stay in the manifest. They are harmless unless
+  the binary at that path exists with content that matches an older pin
+  by coincidence (vanishingly unlikely). For routine maintenance, prefer
+  regenerating from scratch (omit `--merge`) when the set of MCP servers
+  changes.
+- **Package runners cannot be hashed.** Commands like `npx`, `bunx`, `uvx`,
+  and `pipx` resolve executables dynamically at runtime. Generating against
+  one of these pins only the runner itself, not the script it ultimately
+  invokes. Where strict integrity matters, replace the runner with a direct
+  interpreter + absolute script path.
+- **TOCTOU is partial, not full.** The manifest hashes the resolved binary
+  and any pinned script, then resolves symlinks again at exec time. Content
+  replacement of an already-opened path between hash and exec is not
+  detected (Go's `os/exec` cannot bind via `fexecve`). Pair the manifest
+  with deployment-layer controls such as read-only mounts, signed package
+  delivery, or container image immutability for the hash-to-exec window.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2015,7 +2015,7 @@ mcp_binary_integrity:
 | `manifest_path` | (required if enabled) | Path to JSON hash manifest |
 | `action` | `warn` | Action on hash mismatch: `block` or `warn` |
 
-The manifest is a JSON file mapping binary paths to expected SHA-256 hashes. Pipelock resolves shebangs and versioned interpreters (e.g., `python3.11`) before hashing.
+The manifest is a JSON file mapping binary paths to expected SHA-256 hashes. Pipelock resolves shebangs and versioned interpreters (e.g., `python3.11`) before hashing. Generate and preflight the manifest with `pipelock mcp integrity manifest generate|verify`; see [MCP integrity manifest tooling](cli/mcp-integrity.md).
 
 ## Taint-Aware Policy Escalation (v2.1)
 

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -268,6 +268,7 @@ Examples:
 
 	cmd.AddCommand(mcpScanCmd())
 	cmd.AddCommand(mcpProxyCmd())
+	cmd.AddCommand(mcpIntegrityCmd())
 	return cmd
 }
 
@@ -987,9 +988,11 @@ signed action receipts for MCP decisions.`,
 				// Binary integrity: verify before sandbox wraps the command.
 				// The sandbox re-execs pipelock as the parent, so checking
 				// after PrepareSandboxCmd would verify pipelock itself, not
-				// the MCP server binary.
+				// the MCP server binary. Pass workspace so relative script
+				// arguments resolve the same way the sandbox child resolves
+				// them after chdir(workspace).
 				if cfg.MCPBinaryIntegrity.Enabled {
-					if err := mcp.VerifyBinaryIntegrity(serverCmd, &cfg.MCPBinaryIntegrity, cmd.ErrOrStderr()); err != nil {
+					if err := mcp.VerifyBinaryIntegrity(serverCmd, &cfg.MCPBinaryIntegrity, cmd.ErrOrStderr(), workspace); err != nil {
 						return err
 					}
 				}

--- a/internal/cli/runtime/mcp_integrity.go
+++ b/internal/cli/runtime/mcp_integrity.go
@@ -1,0 +1,258 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	mcpintegrity "github.com/luckyPipewrench/pipelock/internal/mcp/integrity"
+)
+
+var errMCPIntegrityViolation = errors.New("MCP binary integrity violation")
+
+type mcpIntegrityReport struct {
+	OK         bool     `json:"ok"`
+	Command    []string `json:"command"`
+	Manifest   string   `json:"manifest,omitempty"`
+	WorkDir    string   `json:"workdir,omitempty"`
+	Entries    []string `json:"entries,omitempty"`
+	Reasons    []string `json:"reasons,omitempty"`
+	Binary     string   `json:"binary,omitempty"`
+	Script     string   `json:"script,omitempty"`
+	Suspicious bool     `json:"suspicious,omitempty"`
+}
+
+func mcpIntegrityCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "integrity",
+		Short: "MCP binary integrity manifest tooling",
+		Long: `Generate and verify the manifest consumed by mcp_binary_integrity.
+
+The manifest pins the resolved binary path Pipelock will spawn. For interpreter
+commands, it also pins the resolved script path so wrapper enforcement can catch
+both interpreter replacement and script drift before launch.`,
+	}
+	cmd.AddCommand(mcpIntegrityManifestCmd())
+	return cmd
+}
+
+func mcpIntegrityManifestCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "manifest",
+		Short: "Generate and verify MCP binary integrity manifests",
+	}
+	cmd.AddCommand(mcpIntegrityManifestGenerateCmd())
+	cmd.AddCommand(mcpIntegrityManifestVerifyCmd())
+	return cmd
+}
+
+func mcpIntegrityManifestGenerateCmd() *cobra.Command {
+	var outputPath string
+	var mergeExisting bool
+	var workDir string
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "generate --output manifest.json -- <command> [args...]",
+		Short: "Generate manifest entries for one MCP server command",
+		Long: `Resolve and hash the MCP server command exactly as Pipelock will before
+spawning it. The generated manifest pins the resolved executable. If the command
+uses a known interpreter or a shebang script, the script file is pinned too.
+
+By default this refuses to overwrite an existing manifest. Use --merge to update
+or add entries in an existing manifest.`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if outputPath == "" {
+				return fmt.Errorf("--output is required")
+			}
+			report, err := generateMCPIntegrityManifest(outputPath, args, workDir, mergeExisting)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return writeMCPIntegrityJSON(cmd.OutOrStdout(), report)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Manifest written: %s (%d %s)\n",
+				outputPath, len(report.Entries), pluralEntry(len(report.Entries)))
+			for _, entry := range report.Entries {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", entry)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "manifest output path")
+	cmd.Flags().BoolVar(&mergeExisting, "merge", false, "merge entries into an existing manifest instead of refusing to overwrite")
+	cmd.Flags().StringVar(&workDir, "workdir", "", "working directory for resolving relative script arguments")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output a machine-readable report")
+	return cmd
+}
+
+func mcpIntegrityManifestVerifyCmd() *cobra.Command {
+	var manifestPath string
+	var workDir string
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "verify --manifest manifest.json -- <command> [args...]",
+		Short: "Verify one MCP server command against a manifest",
+		Long: `Resolve and hash the MCP server command exactly as Pipelock will before
+spawning it, then compare the resolved executable and any resolved script against
+the configured manifest.`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if manifestPath == "" {
+				return fmt.Errorf("--manifest is required")
+			}
+			report, err := verifyMCPIntegrityManifest(manifestPath, args, workDir)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				if jsonErr := writeMCPIntegrityJSON(cmd.OutOrStdout(), report); jsonErr != nil {
+					return jsonErr
+				}
+			} else if report.OK {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "MCP binary integrity verified: %s\n", strings.Join(args, " "))
+			} else {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "MCP binary integrity check failed:")
+				for _, reason := range report.Reasons {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", reason)
+				}
+			}
+			if !report.OK {
+				return cliutil.ExitCodeError(1, errMCPIntegrityViolation)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&manifestPath, "manifest", "", "manifest file path")
+	cmd.Flags().StringVar(&workDir, "workdir", "", "working directory for resolving relative script arguments")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output a machine-readable report")
+	return cmd
+}
+
+func generateMCPIntegrityManifest(outputPath string, command []string, workDir string, mergeExisting bool) (mcpIntegrityReport, error) {
+	entries, result, err := manifestEntriesForCommand(command, workDir)
+	if err != nil {
+		return mcpIntegrityReport{}, err
+	}
+
+	manifest := &mcpintegrity.Manifest{
+		Version: mcpintegrity.ManifestVersion,
+		Entries: map[string]string{},
+	}
+	if mergeExisting {
+		existing, loadErr := mcpintegrity.LoadManifest(outputPath)
+		if loadErr != nil && !errors.Is(loadErr, os.ErrNotExist) {
+			return mcpIntegrityReport{}, fmt.Errorf("loading existing manifest: %w", loadErr)
+		}
+		if existing != nil {
+			manifest = existing
+		}
+	} else if _, err := os.Stat(filepath.Clean(outputPath)); err == nil {
+		return mcpIntegrityReport{}, fmt.Errorf("manifest already exists at %s (use --merge to update it)", outputPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return mcpIntegrityReport{}, fmt.Errorf("checking existing manifest: %w", err)
+	}
+
+	if manifest.Entries == nil {
+		manifest.Entries = map[string]string{}
+	}
+	for path, hash := range entries {
+		manifest.Entries[path] = hash
+	}
+	if err := mcpintegrity.SaveManifest(outputPath, manifest); err != nil {
+		return mcpIntegrityReport{}, err
+	}
+
+	return reportForResult(true, command, outputPath, workDir, result, sortedEntryPaths(entries), nil), nil
+}
+
+func verifyMCPIntegrityManifest(manifestPath string, command []string, workDir string) (mcpIntegrityReport, error) {
+	manifest, err := mcpintegrity.LoadManifest(manifestPath)
+	if err != nil {
+		return mcpIntegrityReport{}, err
+	}
+	cfg := &mcpintegrity.Config{Manifests: manifest.Entries}
+	result, err := mcpintegrity.Verify(command, cfg, workDir)
+	if err != nil {
+		return mcpIntegrityReport{}, err
+	}
+	return reportForResult(result.Verified, command, manifestPath, workDir, result, nil, result.Reasons), nil
+}
+
+func manifestEntriesForCommand(command []string, workDir string) (map[string]string, *mcpintegrity.VerifyResult, error) {
+	result, err := mcpintegrity.Verify(command, &mcpintegrity.Config{Manifests: map[string]string{}}, workDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	// The Suspicious flag in VerifyResult is meaningful only at runtime
+	// (the agent's spawn cwd matches workDir). At generate time the
+	// operator is intentionally pointing the tool at a binary they want
+	// to pin, so "binary lives inside workDir" is not a warning; it is
+	// the expected case. Surfacing it would train operators to ignore
+	// the flag, weakening the runtime signal. Zero it out here.
+	result.Suspicious = false
+	entries := map[string]string{
+		result.ResolvedPath: result.ActualHash,
+	}
+	if result.ScriptPath != "" {
+		entries[result.ScriptPath] = result.ScriptHash
+	}
+	return entries, result, nil
+}
+
+func reportForResult(ok bool, command []string, manifestPath string, workDir string, result *mcpintegrity.VerifyResult, entries []string, reasons []string) mcpIntegrityReport {
+	report := mcpIntegrityReport{
+		OK:         ok,
+		Command:    append([]string(nil), command...),
+		Manifest:   manifestPath,
+		WorkDir:    workDir,
+		Entries:    append([]string(nil), entries...),
+		Reasons:    append([]string(nil), reasons...),
+		Binary:     result.ResolvedPath,
+		Script:     result.ScriptPath,
+		Suspicious: result.Suspicious,
+	}
+	if report.Reasons == nil {
+		report.Reasons = []string{}
+	}
+	return report
+}
+
+func sortedEntryPaths(entries map[string]string) []string {
+	paths := make([]string, 0, len(entries))
+	for path := range entries {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func writeMCPIntegrityJSON(out io.Writer, report mcpIntegrityReport) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal MCP integrity report: %w", err)
+	}
+	_, _ = fmt.Fprintln(out, string(data))
+	return nil
+}
+
+func pluralEntry(n int) string {
+	if n == 1 {
+		return "entry"
+	}
+	return "entries"
+}

--- a/internal/cli/runtime/mcp_integrity_test.go
+++ b/internal/cli/runtime/mcp_integrity_test.go
@@ -1,0 +1,340 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	mcpintegrity "github.com/luckyPipewrench/pipelock/internal/mcp/integrity"
+)
+
+const osWindows = "windows"
+
+func testMCPRoot() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "pipelock",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.AddCommand(McpCmd())
+	return cmd
+}
+
+func TestMCPIntegrityManifestGenerateAndVerifyScript(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("test uses POSIX shebang script")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "server.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho mcp\n"), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	manifestPath := filepath.Join(dir, "manifest.json")
+
+	cmd := testMCPRoot()
+	var genOut bytes.Buffer
+	cmd.SetOut(&genOut)
+	cmd.SetArgs([]string{"mcp", "integrity", "manifest", "generate", "--output", manifestPath, "--", script})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if !strings.Contains(genOut.String(), "Manifest written") {
+		t.Fatalf("generate output = %q", genOut.String())
+	}
+
+	manifest, err := mcpintegrity.LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	resolvedScript, err := filepath.EvalSymlinks(script)
+	if err != nil {
+		t.Fatalf("resolve script: %v", err)
+	}
+	if _, ok := manifest.Entries[resolvedScript]; !ok {
+		t.Fatalf("manifest missing script entry %q: %+v", resolvedScript, manifest.Entries)
+	}
+	if len(manifest.Entries) != 2 {
+		t.Fatalf("manifest entries = %d, want interpreter + script: %+v", len(manifest.Entries), manifest.Entries)
+	}
+
+	verifyCmd := testMCPRoot()
+	var verifyOut bytes.Buffer
+	verifyCmd.SetOut(&verifyOut)
+	verifyCmd.SetArgs([]string{"mcp", "integrity", "manifest", "verify", "--manifest", manifestPath, "--", script})
+	if err := verifyCmd.Execute(); err != nil {
+		t.Fatalf("verify: %v\noutput: %s", err, verifyOut.String())
+	}
+	if !strings.Contains(verifyOut.String(), "verified") {
+		t.Fatalf("verify output = %q", verifyOut.String())
+	}
+}
+
+func TestMCPIntegrityManifestGenerateRefusesOverwriteUnlessMerge(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("test uses POSIX shell command")
+	}
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.json")
+
+	cmd := testMCPRoot()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"mcp", "integrity", "manifest", "generate", "--output", manifestPath, "--", "sh"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("initial generate: %v", err)
+	}
+
+	overwriteCmd := testMCPRoot()
+	overwriteCmd.SetOut(&bytes.Buffer{})
+	overwriteCmd.SetArgs([]string{"mcp", "integrity", "manifest", "generate", "--output", manifestPath, "--", "sh"})
+	if err := overwriteCmd.Execute(); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("overwrite err = %v, want already exists", err)
+	}
+
+	mergeCmd := testMCPRoot()
+	mergeCmd.SetOut(&bytes.Buffer{})
+	mergeCmd.SetArgs([]string{"mcp", "integrity", "manifest", "generate", "--output", manifestPath, "--merge", "--", "sh"})
+	if err := mergeCmd.Execute(); err != nil {
+		t.Fatalf("merge generate: %v", err)
+	}
+}
+
+func TestMCPIntegrityManifestUsesWorkdirForRelativeScript(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("test uses POSIX shell command")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "server.sh")
+	if err := os.WriteFile(script, []byte("echo mcp\n"), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	manifestPath := filepath.Join(dir, "manifest.json")
+
+	cmd := testMCPRoot()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"mcp", "integrity", "manifest", "generate",
+		"--output", manifestPath,
+		"--workdir", dir,
+		"--", "sh", "server.sh",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("generate with workdir: %v", err)
+	}
+
+	manifest, err := mcpintegrity.LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	resolvedScript, err := filepath.EvalSymlinks(script)
+	if err != nil {
+		t.Fatalf("resolve script: %v", err)
+	}
+	if _, ok := manifest.Entries[resolvedScript]; !ok {
+		t.Fatalf("manifest missing workdir-resolved script %q: %+v", resolvedScript, manifest.Entries)
+	}
+}
+
+func TestMCPIntegrityManifestVerifyReportsMismatch(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("test uses POSIX shell command")
+	}
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.json")
+	resolvedShell, _, err := mcpintegrity.ResolveAndHash("sh")
+	if err != nil {
+		t.Fatalf("resolve sh: %v", err)
+	}
+	manifest := &mcpintegrity.Manifest{
+		Version: mcpintegrity.ManifestVersion,
+		Entries: map[string]string{
+			resolvedShell: strings.Repeat("0", 64),
+		},
+	}
+	if err := mcpintegrity.SaveManifest(manifestPath, manifest); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+
+	cmd := testMCPRoot()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"mcp", "integrity", "manifest", "verify", "--manifest", manifestPath, "--json", "--", "sh"})
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("expected verify failure")
+	}
+
+	var report mcpIntegrityReport
+	if jsonErr := json.Unmarshal(out.Bytes(), &report); jsonErr != nil {
+		t.Fatalf("unmarshal report: %v\n%s", jsonErr, out.String())
+	}
+	if report.OK {
+		t.Fatalf("report OK = true, want false: %+v", report)
+	}
+	if len(report.Reasons) == 0 || !strings.Contains(report.Reasons[0], "hash mismatch") {
+		t.Fatalf("reasons = %+v, want hash mismatch", report.Reasons)
+	}
+}
+
+func TestMCPIntegrityManifestRequiresPaths(t *testing.T) {
+	genCmd := testMCPRoot()
+	genCmd.SetOut(&bytes.Buffer{})
+	genCmd.SetArgs([]string{"mcp", "integrity", "manifest", "generate", "--", "sh"})
+	if err := genCmd.Execute(); err == nil || !strings.Contains(err.Error(), "--output is required") {
+		t.Fatalf("generate err = %v, want output required", err)
+	}
+
+	verifyCmd := testMCPRoot()
+	verifyCmd.SetOut(&bytes.Buffer{})
+	verifyCmd.SetArgs([]string{"mcp", "integrity", "manifest", "verify", "--", "sh"})
+	if err := verifyCmd.Execute(); err == nil || !strings.Contains(err.Error(), "--manifest is required") {
+		t.Fatalf("verify err = %v, want manifest required", err)
+	}
+}
+
+func TestMCPIntegrityManifestGenerateSuppressesSuspiciousFlag(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("test uses POSIX shebang script")
+	}
+	// When the operator points generate at a script that lives inside the
+	// --workdir they passed (the expected case for relative resolution),
+	// the underlying VerifyResult.Suspicious flag goes true. That flag
+	// is meaningful at runtime, not at generate time; surfacing it would
+	// train operators to ignore it. Confirm the report omits it.
+	dir := t.TempDir()
+	script := filepath.Join(dir, "server.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho mcp\n"), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	manifestPath := filepath.Join(dir, "manifest.json")
+
+	cmd := testMCPRoot()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{
+		"mcp", "integrity", "manifest", "generate",
+		"--output", manifestPath,
+		"--workdir", dir,
+		"--json",
+		"--", script,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if strings.Contains(out.String(), "suspicious") {
+		t.Fatalf("generate JSON should omit suspicious, got:\n%s", out.String())
+	}
+	var report mcpIntegrityReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out.String())
+	}
+	if report.Suspicious {
+		t.Fatalf("generate report should suppress Suspicious flag, got %+v", report)
+	}
+	if !report.OK {
+		t.Fatalf("expected OK=true on successful generate, got %+v", report)
+	}
+}
+
+func TestMCPIntegrityManifestMergePreservesExistingEntries(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("test uses POSIX shell command")
+	}
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.json")
+
+	// First generate pins one command.
+	first := testMCPRoot()
+	first.SetOut(&bytes.Buffer{})
+	first.SetArgs([]string{"mcp", "integrity", "manifest", "generate", "--output", manifestPath, "--", "sh"})
+	if err := first.Execute(); err != nil {
+		t.Fatalf("first generate: %v", err)
+	}
+	before, err := mcpintegrity.LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("load before merge: %v", err)
+	}
+	if len(before.Entries) == 0 {
+		t.Fatalf("first generate produced empty manifest")
+	}
+
+	// Second generate adds another command via --merge.
+	second := testMCPRoot()
+	second.SetOut(&bytes.Buffer{})
+	second.SetArgs([]string{"mcp", "integrity", "manifest", "generate", "--output", manifestPath, "--merge", "--", "/bin/true"})
+	if err := second.Execute(); err != nil {
+		t.Fatalf("merge generate: %v", err)
+	}
+
+	after, err := mcpintegrity.LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("load after merge: %v", err)
+	}
+	for path, hash := range before.Entries {
+		got, ok := after.Entries[path]
+		if !ok {
+			t.Errorf("merge dropped pre-existing entry %s", path)
+			continue
+		}
+		if got != hash {
+			t.Errorf("merge mutated pre-existing entry %s: before=%s after=%s", path, hash, got)
+		}
+	}
+	if len(after.Entries) <= len(before.Entries) {
+		t.Errorf("merge should add at least one new entry: before=%d after=%d", len(before.Entries), len(after.Entries))
+	}
+}
+
+func TestMCPIntegrityManifestEnvShebangIsPinned(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("test uses POSIX shebang script")
+	}
+	// Validates the /usr/bin/env shebang path through the CLI surface.
+	// A shebang script that uses `#!/usr/bin/env sh` must result in BOTH
+	// the resolved interpreter and the resolved script being pinned, so a
+	// swap of either component is detected at verify time.
+	dir := t.TempDir()
+	script := filepath.Join(dir, "envscript.sh")
+	if err := os.WriteFile(script, []byte("#!/usr/bin/env sh\necho hello\n"), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	manifestPath := filepath.Join(dir, "manifest.json")
+
+	cmd := testMCPRoot()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"mcp", "integrity", "manifest", "generate", "--output", manifestPath, "--", script})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	manifest, err := mcpintegrity.LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	resolvedScript, err := filepath.EvalSymlinks(script)
+	if err != nil {
+		t.Fatalf("resolve script: %v", err)
+	}
+	if _, ok := manifest.Entries[resolvedScript]; !ok {
+		t.Fatalf("manifest missing script entry %q: %+v", resolvedScript, manifest.Entries)
+	}
+	// At least 2 entries: the resolved shebang interpreter + the script.
+	if len(manifest.Entries) < 2 {
+		t.Fatalf("expected interpreter + script pinned, got %d entries: %+v", len(manifest.Entries), manifest.Entries)
+	}
+
+	verifyCmd := testMCPRoot()
+	verifyCmd.SetOut(&bytes.Buffer{})
+	verifyCmd.SetArgs([]string{"mcp", "integrity", "manifest", "verify", "--manifest", manifestPath, "--", script})
+	if err := verifyCmd.Execute(); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+}

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -1266,7 +1266,11 @@ func safeEnv() []string {
 // VerifyBinaryIntegrity checks the command binary against a hash manifest.
 // Returns nil when verification passes or action is warn (logged only).
 // Returns an error when action is block and verification fails.
-func VerifyBinaryIntegrity(command []string, icfg *config.MCPBinaryIntegrity, logW io.Writer) error {
+func VerifyBinaryIntegrity(command []string, icfg *config.MCPBinaryIntegrity, logW io.Writer, workDir ...string) error {
+	agentWorkDir := ""
+	if len(workDir) > 0 {
+		agentWorkDir = workDir[0]
+	}
 	intCfg := &integrity.Config{
 		Enabled:      true,
 		ManifestPath: icfg.ManifestPath,
@@ -1287,7 +1291,7 @@ func VerifyBinaryIntegrity(command []string, icfg *config.MCPBinaryIntegrity, lo
 	}
 	intCfg.Manifests = manifest.Entries
 
-	result, verifyErr := integrity.Verify(command, intCfg, "")
+	result, verifyErr := integrity.Verify(command, intCfg, agentWorkDir)
 	if verifyErr != nil {
 		if icfg.Action == config.ActionBlock {
 			return fmt.Errorf("binary integrity: %w", verifyErr)

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -3134,6 +3135,47 @@ func TestVerifyBinaryIntegrity_WarnOnHashMismatch(t *testing.T) {
 	}
 	if !strings.Contains(logBuf.String(), "binary integrity warning") {
 		t.Errorf("expected warning log for hash mismatch, got: %s", logBuf.String())
+	}
+}
+
+func TestVerifyBinaryIntegrity_UsesWorkDirForRelativeScripts(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("hash test requires unix")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "server.sh")
+	if err := os.WriteFile(script, []byte("echo mcp\n"), 0o600); err != nil {
+		t.Fatalf("writing script: %v", err)
+	}
+
+	result, err := integrity.Verify([]string{"sh", "server.sh"}, &integrity.Config{Manifests: map[string]string{}}, dir)
+	if err != nil {
+		t.Fatalf("resolve command: %v", err)
+	}
+	m := &integrity.Manifest{
+		Version: integrity.ManifestVersion,
+		Entries: map[string]string{
+			result.ResolvedPath: result.ActualHash,
+			result.ScriptPath:   result.ScriptHash,
+		},
+	}
+	mpath := filepath.Join(t.TempDir(), "manifest.json")
+	if err := integrity.SaveManifest(mpath, m); err != nil {
+		t.Fatalf("writing manifest: %v", err)
+	}
+	icfg := &config.MCPBinaryIntegrity{
+		Enabled:      true,
+		ManifestPath: mpath,
+		Action:       config.ActionBlock,
+	}
+
+	var logBuf bytes.Buffer
+	if err := VerifyBinaryIntegrity([]string{"sh", "server.sh"}, icfg, &logBuf); err == nil {
+		t.Fatal("verify without workDir should fail for relative script outside proxy cwd")
+	}
+	logBuf.Reset()
+	if err := VerifyBinaryIntegrity([]string{"sh", "server.sh"}, icfg, &logBuf, dir); err != nil {
+		t.Fatalf("verify with workDir: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `pipelock mcp integrity manifest generate|verify`
- pin resolved MCP server binaries and interpreter scripts for `mcp_binary_integrity`
- pass sandbox workspace into runtime verification so relative script resolution matches sandbox launch behavior
- document ownership, merge, package-runner, and hash-to-exec caveats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI for generating and verifying MCP binary integrity manifests (generate/verify), with --merge, --workdir, and --json options.

* **Documentation**
  * New guide for MCP integrity manifest tooling and updated binary-integrity configuration docs with generation/verification guidance.

* **Behavioral Change**
  * Binary integrity verification now respects a provided working directory when resolving relative script paths.

* **Tests**
  * Added CLI and verification tests covering generation, merge, workdir resolution, JSON output, and mismatch reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->