### PR TITLE
Add cluster MCP proxy contract to sidecar init

### DIFF
--- a/docs/cli/init-sidecar.md
+++ b/docs/cli/init-sidecar.md
@@ -16,6 +16,7 @@ pipelock init sidecar --inject-spec <manifest>
   [--skip-verify]
   [--json]
   [--agent-identity <name>]
+  [--mcp-upstream <http-url>]
 ```
 
 ## Description
@@ -31,6 +32,8 @@ The generated bundle includes:
 - An agent NetworkPolicy that limits agent pod egress to DNS plus the pipelock proxy
 - A proxy NetworkPolicy that allows agent ingress and standard web egress for the pipelock proxy pods
 - A PodDisruptionBudget that keeps at least one proxy replica available during voluntary disruptions
+
+When `--mcp-upstream` is set, the bundle also exposes the companion proxy's MCP listener on port `8889`, injects `PIPELOCK_MCP_PROXY_URL` into the agent workload, and updates NetworkPolicies so the agent can reach only the Pipelock MCP listener while the proxy can reach the configured upstream MCP endpoint.
 
 This is not same-pod sidecar injection. The enforcement boundary comes from pod-scoped NetworkPolicies plus a separate pipelock proxy workload, not from trusting application containers to honor proxy environment variables on their own.
 
@@ -51,6 +54,7 @@ The command runs 7 phases: detect, generate, preview, emit, verify, canary, and 
 | `--skip-verify` | false | Skip static topology verification |
 | `--json` | false | Machine-readable JSON output (`--output` required unless `--dry-run`) |
 | `--agent-identity` | `<kind>/<name>` | Default agent identity for attribution |
+| `--mcp-upstream` | unset | Optional upstream MCP HTTP/SSE URL. When set, the companion proxy exposes `PIPELOCK_MCP_PROXY_URL=http://<proxy>:8889` for agent MCP client configuration. |
 
 ## Supported Workload Kinds
 
@@ -143,6 +147,17 @@ pipelock init sidecar --inject-spec statefulset.yaml --preset strict --output en
 pipelock init sidecar --inject-spec job.yaml --agent-identity ci-team/nightly-scan
 ```
 
+### OpenClaw or Cluster MCP Gateway
+
+```bash
+pipelock init sidecar \
+  --inject-spec deployment.yaml \
+  --mcp-upstream http://openclaw-gateway:3000/mcp \
+  --output enforced.yaml
+```
+
+The generated workload receives `PIPELOCK_MCP_PROXY_URL=http://<proxy-service>:8889`. Configure the agent's MCP client or launcher to use that URL. The NetworkPolicy limits the agent pod to DNS plus the Pipelock HTTP and MCP proxy ports, so direct HTTP egress to the upstream MCP gateway is not part of the generated agent boundary.
+
 ### CronJob with kustomize output
 
 ```bash
@@ -174,6 +189,7 @@ The verify phase is static. It confirms the generated topology has the expected 
 
 - forward proxy mode enabled
 - cluster-reachable proxy listeners
+- optional MCP listener and NetworkPolicy ports when `--mcp-upstream` is set
 - agent NetworkPolicy allows DNS plus the pipelock proxy port only
 - proxy NetworkPolicy allows agent ingress and standard web egress
 
@@ -189,11 +205,18 @@ Within a cluster that enforces egress NetworkPolicies, the agent pods are limite
 
 - DNS
 - The pipelock companion Service on port `8888`
+- The pipelock companion Service on port `8889` when `--mcp-upstream` is set
 
 Direct `80/443` web egress is reserved for the pipelock companion pods, not the agent workload.
 
 DNS egress is intentionally left unrestricted at the NetworkPolicy layer for cluster portability. This command does not block DNS tunneling by policy alone.
 
+`--mcp-upstream` does not rewrite arbitrary application MCP client settings by itself. It creates the enforced cluster path and exposes the `PIPELOCK_MCP_PROXY_URL` contract; the agent image, launcher, or config must consume that value for MCP traffic to traverse Pipelock.
+
+The proxy NetworkPolicy egress rule for the upstream port has no destination selector. Vanilla Kubernetes NetworkPolicies cannot express "only this hostname." If the upstream port is shared with unrelated services in any namespace the proxy can reach, the rule technically allows the proxy to talk to them too. For tighter scoping, edit the generated `proxy-network-policy.yaml` to add a `to:` clause matching the upstream namespace and pod labels.
+
 ## Idempotency
 
 Running `pipelock init sidecar` against a manifest already managed by this command is safe. The workload annotations preserve the generated proxy identity, the command reports the manifest as already patched, and verification can still be rerun against the derived topology.
+
+Re-running against a manifest previously generated with `--mcp-upstream`, but without the flag this time, scrubs the prior `PIPELOCK_MCP_PROXY_URL` env entry and the `pipelock.dev/mcp-proxy-service` / `pipelock.dev/mcp-upstream` annotations so the agent does not advertise a contract the regenerated Service no longer fulfills.

--- a/docs/guides/openclaw.md
+++ b/docs/guides/openclaw.md
@@ -155,7 +155,19 @@ The generator is idempotent. Running it twice produces identical output. Servers
 
 ## Kubernetes Sidecar Deployment
 
-Run pipelock as a sidecar container alongside your agent. The init container copies the pipelock binary into a shared volume so the agent can use it for MCP stdio wrapping:
+For enforced cluster deployments, generate a companion-proxy topology and point it at the OpenClaw MCP endpoint:
+
+```bash
+pipelock init sidecar \
+  --inject-spec agent-deployment.yaml \
+  --mcp-upstream http://openclaw-gateway:3000/mcp \
+  --output enforced.yaml
+kubectl apply -f enforced.yaml
+```
+
+The generated agent workload gets `HTTPS_PROXY` and `HTTP_PROXY` for HTTP egress plus `PIPELOCK_MCP_PROXY_URL=http://<pipelock-service>:8889` for MCP client configuration. Configure your agent or launcher to use that MCP URL. The generated NetworkPolicy limits the agent pod to DNS plus the Pipelock HTTP and MCP proxy ports, so direct egress to the OpenClaw gateway is outside the generated agent boundary.
+
+Same-pod sidecar wiring is still useful for local prototypes, but it relies on the agent honoring proxy settings and is not the generated enforced topology:
 
 ```yaml
 apiVersion: apps/v1

--- a/internal/cli/setup/sidecar.go
+++ b/internal/cli/setup/sidecar.go
@@ -311,6 +311,12 @@ func validateSidecarMCPUpstream(raw string) error {
 	default:
 		return fmt.Errorf("--mcp-upstream %q must use http:// or https://", raw)
 	}
+	if parsed.User != nil {
+		return fmt.Errorf("--mcp-upstream %q must not contain user info or credentials", raw)
+	}
+	if parsed.Hostname() == "" {
+		return fmt.Errorf("--mcp-upstream %q must include http:// or https:// and a host", raw)
+	}
 	// If an explicit port is present it must be a valid TCP port. Otherwise
 	// the rendered NetworkPolicy egress rule would silently drop the
 	// upstream port, the agent's MCP requests would reach the proxy fine,
@@ -321,8 +327,24 @@ func validateSidecarMCPUpstream(raw string) error {
 		if convErr != nil || n < 1 || n > 65535 {
 			return fmt.Errorf("--mcp-upstream %q has invalid port %q (must be 1-65535)", raw, port)
 		}
+	} else if mcpUpstreamHostHasMalformedPort(parsed.Host) {
+		return fmt.Errorf("--mcp-upstream %q has malformed host/port syntax", raw)
 	}
 	return nil
+}
+
+func mcpUpstreamHostHasMalformedPort(host string) bool {
+	if strings.HasSuffix(host, ":") {
+		return true
+	}
+	if strings.HasPrefix(host, "[") {
+		closing := strings.LastIndex(host, "]")
+		if closing == -1 {
+			return true
+		}
+		return strings.Contains(host[closing+1:], ":")
+	}
+	return strings.Contains(host, ":")
 }
 
 // renderDiff produces a simple before/after comparison.

--- a/internal/cli/setup/sidecar.go
+++ b/internal/cli/setup/sidecar.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -30,6 +32,7 @@ type sidecarOptions struct {
 	skipVerify    bool
 	jsonOutput    bool
 	agentIdentity string
+	mcpUpstream   string
 }
 
 // sidecarResult holds the outcome of each phase for JSON reporting.
@@ -50,6 +53,7 @@ type sidecarPatchSummary struct {
 	EmitFormat    string `json:"emit_format"`
 	OutputPath    string `json:"output_path,omitempty"`
 	AgentIdentity string `json:"agent_identity"`
+	MCPProxyURL   string `json:"mcp_proxy_url,omitempty"`
 	Written       bool   `json:"written"`
 	DryRun        bool   `json:"dry_run"`
 }
@@ -78,7 +82,8 @@ Examples:
   pipelock init sidecar --inject-spec deployment.yaml --dry-run
   pipelock init sidecar --inject-spec deployment.yaml --emit kustomize --output ./pipelock-overlay
   pipelock init sidecar --inject-spec statefulset.yaml --emit helm-values --output ./pipelock-helm-bundle
-  pipelock init sidecar --inject-spec cronjob.yaml --preset strict --agent-identity my-team/bot`,
+  pipelock init sidecar --inject-spec cronjob.yaml --preset strict --agent-identity my-team/bot
+  pipelock init sidecar --inject-spec deployment.yaml --mcp-upstream http://openclaw:3000/mcp`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -97,6 +102,7 @@ Examples:
 	cmd.Flags().BoolVar(&opts.skipVerify, "skip-verify", false, "skip static topology verification")
 	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "machine-readable JSON output")
 	cmd.Flags().StringVar(&opts.agentIdentity, "agent-identity", "", "default agent identity (default: <kind>/<name>)")
+	cmd.Flags().StringVar(&opts.mcpUpstream, "mcp-upstream", "", "upstream MCP HTTP/SSE URL to expose through the companion proxy")
 
 	_ = cmd.MarkFlagRequired("inject-spec")
 
@@ -122,6 +128,9 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 	default:
 		return cliutil.ExitCodeError(initExitError,
 			fmt.Errorf("unknown emit format %q: choose patch, kustomize, or helm-values", opts.emit))
+	}
+	if err := validateSidecarMCPUpstream(opts.mcpUpstream); err != nil {
+		return cliutil.ExitCodeError(initExitError, err)
 	}
 
 	result := &sidecarResult{}
@@ -170,6 +179,9 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 		_, _ = fmt.Fprintf(w, "  Agent identity: %s\n", patchResult.AgentIdentity)
 		_, _ = fmt.Fprintf(w, "  Proxy name: %s\n", patchResult.ProxyName)
 		_, _ = fmt.Fprintf(w, "  Proxy URL: %s\n", patchResult.ProxyURL)
+		if patchResult.MCPProxyURL != "" {
+			_, _ = fmt.Fprintf(w, "  MCP proxy URL: %s -> %s\n", patchResult.MCPProxyURL, patchResult.MCPUpstream)
+		}
 		_, _ = fmt.Fprintf(w, "  Image: %s\n", resolveImage(opts))
 		_, _ = fmt.Fprintf(w, "  Preset: %s\n\n", opts.preset)
 	}
@@ -199,6 +211,7 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 		EmitFormat:    opts.emit,
 		OutputPath:    opts.output,
 		AgentIdentity: patchResult.AgentIdentity,
+		MCPProxyURL:   patchResult.MCPProxyURL,
 		DryRun:        opts.dryRun,
 	}
 
@@ -285,6 +298,33 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 	return nil
 }
 
+func validateSidecarMCPUpstream(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return fmt.Errorf("--mcp-upstream %q must include http:// or https:// and a host", raw)
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+	default:
+		return fmt.Errorf("--mcp-upstream %q must use http:// or https://", raw)
+	}
+	// If an explicit port is present it must be a valid TCP port. Otherwise
+	// the rendered NetworkPolicy egress rule would silently drop the
+	// upstream port, the agent's MCP requests would reach the proxy fine,
+	// and the proxy's egress to the upstream would fail with a network
+	// policy rejection: operator-visible only as a runtime symptom.
+	if port := parsed.Port(); port != "" {
+		n, convErr := strconv.Atoi(port)
+		if convErr != nil || n < 1 || n > 65535 {
+			return fmt.Errorf("--mcp-upstream %q has invalid port %q (must be 1-65535)", raw, port)
+		}
+	}
+	return nil
+}
+
 // renderDiff produces a simple before/after comparison.
 func renderDiff(manifest *workloadManifest, patchResult *sidecarPatchResult) (string, error) {
 	patched, err := yaml.Marshal(patchResult.PatchedManifest)
@@ -322,6 +362,9 @@ func renderDiff(manifest *workloadManifest, patchResult *sidecarPatchResult) (st
 		_, _ = fmt.Fprintf(&sb, "  + companion Service: %s\n", patchResult.ProxyName)
 		_, _ = fmt.Fprintln(&sb, "  + agent NetworkPolicy: DNS + proxy-only egress")
 		_, _ = fmt.Fprintln(&sb, "  + proxy NetworkPolicy: agent ingress + web-only egress")
+		if patchResult.MCPProxyURL != "" {
+			_, _ = fmt.Fprintf(&sb, "  + MCP proxy contract: PIPELOCK_MCP_PROXY_URL=%s\n", patchResult.MCPProxyURL)
+		}
 		_, _ = fmt.Fprintln(&sb, "  + companion PodDisruptionBudget: minAvailable=1")
 	}
 
@@ -338,6 +381,9 @@ func printSidecarSummary(w io.Writer, result *sidecarResult, opts sidecarOptions
 
 	_, _ = fmt.Fprintf(w, "  Workload:        %s/%s\n", result.Detect.Kind, result.Detect.Name)
 	_, _ = fmt.Fprintf(w, "  Agent identity:  %s\n", result.Patch.AgentIdentity)
+	if result.Patch.MCPProxyURL != "" {
+		_, _ = fmt.Fprintf(w, "  MCP proxy URL:   %s\n", result.Patch.MCPProxyURL)
+	}
 	_, _ = fmt.Fprintf(w, "  Emit format:     %s\n", result.Patch.EmitFormat)
 
 	if result.Patch.DryRun {
@@ -376,6 +422,9 @@ func printSidecarSummary(w io.Writer, result *sidecarResult, opts sidecarOptions
 	_, _ = fmt.Fprintln(w, "Next steps:")
 	if !result.Patch.Written && !result.Detect.AlreadyPatched {
 		_, _ = fmt.Fprintf(w, "  pipelock init sidecar --inject-spec %s\n", opts.injectSpec)
+	}
+	if result.Patch.MCPProxyURL != "" {
+		_, _ = fmt.Fprintln(w, "  Configure the agent MCP client to use PIPELOCK_MCP_PROXY_URL for MCP traffic.")
 	}
 	switch result.Patch.EmitFormat {
 	case emitKustomize:

--- a/internal/cli/setup/sidecar_emit.go
+++ b/internal/cli/setup/sidecar_emit.go
@@ -190,6 +190,11 @@ func emitHelmValuesFormat(w io.Writer, result *sidecarPatchResult, opts sidecarO
 			"default_agent_identity":      result.AgentIdentity,
 			"bind_default_agent_identity": true,
 		},
+		"mcp": map[string]interface{}{
+			"enabled":  result.MCPUpstream != "",
+			"upstream": result.MCPUpstream,
+			"listen":   proxyMCPListenAddr(),
+		},
 		"networkPolicy": map[string]interface{}{
 			"enabled": false,
 		},

--- a/internal/cli/setup/sidecar_emit_test.go
+++ b/internal/cli/setup/sidecar_emit_test.go
@@ -369,6 +369,10 @@ func TestEmitHelmValuesFormat(t *testing.T) {
 	if enabled, _ := forwardProxy["enabled"].(bool); !enabled {
 		t.Fatal("pipelock.forward_proxy.enabled should be true")
 	}
+	mcpMap := values["mcp"].(map[string]interface{})
+	if enabled, _ := mcpMap["enabled"].(bool); enabled {
+		t.Fatal("mcp.enabled should default to false")
+	}
 
 	readme, err := os.ReadFile(filepath.Clean(filepath.Join(outDir, "README.txt")))
 	if err != nil {
@@ -382,6 +386,38 @@ func TestEmitHelmValuesFormat(t *testing.T) {
 	}
 	if !strings.Contains(string(readme), "pipelock-pdb.yaml") {
 		t.Fatal("README.txt should include the PDB apply command")
+	}
+}
+
+func TestEmitHelmValuesFormat_MCPUpstream(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outDir := filepath.Join(dir, "helm-bundle")
+	const mcpUpstream = "http://openclaw:3000/mcp"
+	result := mustPatchResult(t, sidecarOptions{preset: config.ModeBalanced, mcpUpstream: mcpUpstream})
+
+	if err := emitHelmValuesFormat(nil, result, sidecarOptions{output: outDir, emit: emitHelmValues, preset: config.ModeBalanced}); err != nil {
+		t.Fatalf("emitHelmValuesFormat: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(filepath.Join(outDir, "values.yaml")))
+	if err != nil {
+		t.Fatalf("reading values.yaml: %v", err)
+	}
+	var values map[string]interface{}
+	if err := yaml.Unmarshal(data, &values); err != nil {
+		t.Fatalf("parsing helm values: %v", err)
+	}
+	mcpMap := values["mcp"].(map[string]interface{})
+	if enabled, _ := mcpMap["enabled"].(bool); !enabled {
+		t.Fatal("mcp.enabled should be true")
+	}
+	if mcpMap["upstream"] != mcpUpstream {
+		t.Fatalf("mcp.upstream = %v, want %q", mcpMap["upstream"], mcpUpstream)
+	}
+	if mcpMap["listen"] != proxyMCPListenAddr() {
+		t.Fatalf("mcp.listen = %v, want %s", mcpMap["listen"], proxyMCPListenAddr())
 	}
 }
 

--- a/internal/cli/setup/sidecar_patch.go
+++ b/internal/cli/setup/sidecar_patch.go
@@ -9,6 +9,8 @@ package setup
 
 import (
 	"fmt"
+	"net/url"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -26,6 +28,7 @@ const (
 	sidecarConfigFile    = "pipelock.yaml"
 	sidecarHealthPath    = "/health"
 	sidecarHealthPort    = 8888
+	sidecarMCPPort       = 8889
 	sidecarMetricsPort   = 9091
 
 	// defaultImage is the GHCR image with the current version tag.
@@ -36,6 +39,7 @@ const (
 	envHTTPSProxy = "HTTPS_PROXY"
 	envHTTPProxy  = "HTTP_PROXY"
 	envNoProxy    = "NO_PROXY"
+	envMCPProxy   = "PIPELOCK_MCP_PROXY_URL"
 	noProxyValue  = "localhost,127.0.0.1,.svc,.cluster.local"
 
 	proxyReplicaCount = 2
@@ -48,6 +52,8 @@ const (
 	managedTopologyAnnotation     = "pipelock.dev/topology"
 	managedProxyNameAnnotation    = "pipelock.dev/proxy-name"
 	managedProxyServiceAnnotation = "pipelock.dev/proxy-service"
+	managedMCPProxyAnnotation     = "pipelock.dev/mcp-proxy-service"
+	managedMCPUpstreamAnnotation  = "pipelock.dev/mcp-upstream"
 	managedTopologyCompanion      = "companion-proxy"
 	managedByLabelValue           = "pipelock-init-sidecar"
 )
@@ -78,6 +84,10 @@ type sidecarPatchResult struct {
 	ProxyName string
 	// ProxyURL is the Service URL injected into the agent workload.
 	ProxyURL string
+	// MCPUpstream is the operator-configured upstream MCP endpoint, if enabled.
+	MCPUpstream string
+	// MCPProxyURL is the companion Service MCP URL injected into the agent workload.
+	MCPProxyURL string
 	// AgentSelectorLabels identify the protected agent pods.
 	AgentSelectorLabels map[string]string
 	// ProxySelectorLabels identify the companion proxy pods.
@@ -105,12 +115,16 @@ func generateSidecarPatch(manifest *workloadManifest, opts sidecarOptions) (*sid
 
 	proxyName := resolveProxyName(manifest.Raw, manifest.Name)
 	proxyURL := proxyServiceURL(proxyName)
+	mcpProxyURL := ""
+	if opts.mcpUpstream != "" {
+		mcpProxyURL = proxyMCPServiceURL(proxyName)
+	}
 	proxyLabels := proxySelectorLabels(proxyName)
 
-	if err := annotateManagedWorkload(patched, manifest.Kind, proxyName); err != nil {
+	if err := annotateManagedWorkload(patched, manifest.Kind, proxyName, mcpProxyURL, opts.mcpUpstream); err != nil {
 		return nil, fmt.Errorf("annotating workload: %w", err)
 	}
-	if err := injectProxyEnvs(podSpec, proxyURL); err != nil {
+	if err := injectProxyEnvs(podSpec, proxyURL, mcpProxyURL); err != nil {
 		return nil, fmt.Errorf("injecting proxy env: %w", err)
 	}
 
@@ -119,19 +133,19 @@ func generateSidecarPatch(manifest *workloadManifest, opts sidecarOptions) (*sid
 	if err != nil {
 		return nil, fmt.Errorf("rendering ConfigMap: %w", err)
 	}
-	deploymentYAML, err := renderProxyDeployment(namespace, proxyName, resolveImage(opts), proxyLabels)
+	deploymentYAML, err := renderProxyDeployment(namespace, proxyName, resolveImage(opts), proxyLabels, opts.mcpUpstream)
 	if err != nil {
 		return nil, fmt.Errorf("rendering Deployment: %w", err)
 	}
-	serviceYAML, err := renderProxyService(namespace, proxyName, proxyLabels)
+	serviceYAML, err := renderProxyService(namespace, proxyName, proxyLabels, opts.mcpUpstream != "")
 	if err != nil {
 		return nil, fmt.Errorf("rendering Service: %w", err)
 	}
-	agentNetworkPolicyYAML, err := renderAgentNetworkPolicy(namespace, manifest.Name, selectorLabels, proxyLabels)
+	agentNetworkPolicyYAML, err := renderAgentNetworkPolicy(namespace, manifest.Name, selectorLabels, proxyLabels, opts.mcpUpstream != "")
 	if err != nil {
 		return nil, fmt.Errorf("rendering agent NetworkPolicy: %w", err)
 	}
-	proxyNetworkPolicyYAML, err := renderProxyNetworkPolicy(namespace, proxyName, proxyLabels, selectorLabels)
+	proxyNetworkPolicyYAML, err := renderProxyNetworkPolicy(namespace, proxyName, proxyLabels, selectorLabels, opts.mcpUpstream)
 	if err != nil {
 		return nil, fmt.Errorf("rendering proxy NetworkPolicy: %w", err)
 	}
@@ -153,6 +167,8 @@ func generateSidecarPatch(manifest *workloadManifest, opts sidecarOptions) (*sid
 		AgentIdentity:           agentIdentity,
 		ProxyName:               proxyName,
 		ProxyURL:                proxyURL,
+		MCPUpstream:             opts.mcpUpstream,
+		MCPProxyURL:             mcpProxyURL,
 		AgentSelectorLabels:     selectorLabels,
 		ProxySelectorLabels:     proxyLabels,
 	}, nil
@@ -170,7 +186,7 @@ func buildProxyConfig(preset, agentIdentity string) *config.Config {
 
 // injectProxyEnvs adds HTTPS_PROXY, HTTP_PROXY, NO_PROXY to agent containers.
 // Existing conflicting proxy env vars are rejected instead of silently preserved.
-func injectProxyEnvs(podSpec map[string]interface{}, proxyURL string) error {
+func injectProxyEnvs(podSpec map[string]interface{}, proxyURL, mcpProxyURL string) error {
 	containers, ok := podSpec["containers"].([]interface{})
 	if !ok {
 		return nil
@@ -197,9 +213,41 @@ func injectProxyEnvs(podSpec map[string]interface{}, proxyURL string) error {
 		if err != nil {
 			return fmt.Errorf("container %q: %w", containerName, err)
 		}
+		if mcpProxyURL != "" {
+			existing, err = upsertProxyEnv(existing, envMCPProxy, mcpProxyURL)
+			if err != nil {
+				return fmt.Errorf("container %q: %w", containerName, err)
+			}
+		} else {
+			// Scrub stale MCP env when the operator re-runs without
+			// --mcp-upstream. Leaving it would point the agent at a Service
+			// port the regenerated companion no longer listens on, turning
+			// a feature disable into a runtime "connection refused" loop.
+			existing = removeProxyEnv(existing, envMCPProxy)
+		}
 		cMap["env"] = existing
 	}
 	return nil
+}
+
+// removeProxyEnv strips an env entry by name. Returns the input unchanged
+// when the entry is absent. valueFrom entries are also removed so the
+// disable path is total: the operator does not need to inspect the
+// patched manifest to confirm the contract is gone.
+func removeProxyEnv(envList []interface{}, name string) []interface{} {
+	out := envList[:0]
+	for _, e := range envList {
+		eMap, ok := e.(map[string]interface{})
+		if !ok {
+			out = append(out, e)
+			continue
+		}
+		if n, _ := eMap["name"].(string); n == name {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
 }
 
 func upsertProxyEnv(envList []interface{}, name, value string) ([]interface{}, error) {
@@ -275,7 +323,20 @@ func renderConfigMap(cfg *config.Config, preset, namespace, proxyName string, pr
 	return string(out), nil
 }
 
-func renderProxyDeployment(namespace, proxyName, image string, proxyLabels map[string]string) (string, error) {
+func renderProxyDeployment(namespace, proxyName, image string, proxyLabels map[string]string, mcpUpstream string) (string, error) {
+	args := []interface{}{"run", "--config", sidecarConfigMount + "/" + sidecarConfigFile}
+	ports := []interface{}{
+		map[string]interface{}{"name": "http", "containerPort": sidecarHealthPort, "protocol": "TCP"},
+	}
+	if mcpUpstream != "" {
+		args = append(args,
+			"--mcp-listen", proxyMCPListenAddr(),
+			"--mcp-upstream", mcpUpstream,
+		)
+		ports = append(ports, map[string]interface{}{"name": "mcp", "containerPort": sidecarMCPPort, "protocol": "TCP"})
+	}
+	ports = append(ports, map[string]interface{}{"name": "metrics", "containerPort": sidecarMetricsPort, "protocol": "TCP"})
+
 	deploy := map[string]interface{}{
 		"apiVersion": "apps/v1",
 		"kind":       "Deployment",
@@ -319,12 +380,9 @@ func renderProxyDeployment(namespace, proxyName, image string, proxyLabels map[s
 						map[string]interface{}{
 							"name":            proxyContainerName,
 							"image":           image,
-							"args":            []interface{}{"run", "--config", sidecarConfigMount + "/" + sidecarConfigFile},
+							"args":            args,
 							"imagePullPolicy": "IfNotPresent",
-							"ports": []interface{}{
-								map[string]interface{}{"name": "http", "containerPort": sidecarHealthPort, "protocol": "TCP"},
-								map[string]interface{}{"name": "metrics", "containerPort": sidecarMetricsPort, "protocol": "TCP"},
-							},
+							"ports":           ports,
 							"volumeMounts": []interface{}{
 								map[string]interface{}{
 									"name":      sidecarConfigVolume,
@@ -376,7 +434,15 @@ func renderProxyDeployment(namespace, proxyName, image string, proxyLabels map[s
 	return string(out), nil
 }
 
-func renderProxyService(namespace, proxyName string, proxyLabels map[string]string) (string, error) {
+func renderProxyService(namespace, proxyName string, proxyLabels map[string]string, mcpEnabled bool) (string, error) {
+	ports := []interface{}{
+		map[string]interface{}{"name": "http", "port": sidecarHealthPort, "targetPort": "http", "protocol": "TCP"},
+	}
+	if mcpEnabled {
+		ports = append(ports, map[string]interface{}{"name": "mcp", "port": sidecarMCPPort, "targetPort": "mcp", "protocol": "TCP"})
+	}
+	ports = append(ports, map[string]interface{}{"name": "metrics", "port": sidecarMetricsPort, "targetPort": "metrics", "protocol": "TCP"})
+
 	svc := map[string]interface{}{
 		"apiVersion": "v1",
 		"kind":       "Service",
@@ -388,10 +454,7 @@ func renderProxyService(namespace, proxyName string, proxyLabels map[string]stri
 		"spec": map[string]interface{}{
 			"type":     "ClusterIP",
 			"selector": labelsToInterfaceMap(proxyLabels),
-			"ports": []interface{}{
-				map[string]interface{}{"name": "http", "port": sidecarHealthPort, "targetPort": "http", "protocol": "TCP"},
-				map[string]interface{}{"name": "metrics", "port": sidecarMetricsPort, "targetPort": "metrics", "protocol": "TCP"},
-			},
+			"ports":    ports,
 		},
 	}
 	out, err := yaml.Marshal(svc)
@@ -401,9 +464,15 @@ func renderProxyService(namespace, proxyName string, proxyLabels map[string]stri
 	return string(out), nil
 }
 
-func renderAgentNetworkPolicy(namespace, workloadName string, agentLabels, proxyLabels map[string]string) (string, error) {
+func renderAgentNetworkPolicy(namespace, workloadName string, agentLabels, proxyLabels map[string]string, mcpEnabled bool) (string, error) {
 	if len(agentLabels) == 0 || len(proxyLabels) == 0 {
 		return "", fmt.Errorf("agent and proxy selector labels must not be empty")
+	}
+	proxyPorts := []interface{}{
+		map[string]interface{}{"port": sidecarHealthPort, "protocol": "TCP"},
+	}
+	if mcpEnabled {
+		proxyPorts = append(proxyPorts, map[string]interface{}{"port": sidecarMCPPort, "protocol": "TCP"})
 	}
 	np := map[string]interface{}{
 		"apiVersion": "networking.k8s.io/v1",
@@ -433,9 +502,7 @@ func renderAgentNetworkPolicy(namespace, workloadName string, agentLabels, proxy
 							},
 						},
 					},
-					"ports": []interface{}{
-						map[string]interface{}{"port": sidecarHealthPort, "protocol": "TCP"},
-					},
+					"ports": proxyPorts,
 				},
 			},
 		},
@@ -447,9 +514,22 @@ func renderAgentNetworkPolicy(namespace, workloadName string, agentLabels, proxy
 	return string(out), nil
 }
 
-func renderProxyNetworkPolicy(namespace, proxyName string, proxyLabels, agentLabels map[string]string) (string, error) {
+func renderProxyNetworkPolicy(namespace, proxyName string, proxyLabels, agentLabels map[string]string, mcpUpstream string) (string, error) {
 	if len(agentLabels) == 0 || len(proxyLabels) == 0 {
 		return "", fmt.Errorf("agent and proxy selector labels must not be empty")
+	}
+	ingressPorts := []interface{}{
+		map[string]interface{}{"port": sidecarHealthPort, "protocol": "TCP"},
+	}
+	if mcpUpstream != "" {
+		ingressPorts = append(ingressPorts, map[string]interface{}{"port": sidecarMCPPort, "protocol": "TCP"})
+	}
+	webPorts := []interface{}{
+		map[string]interface{}{"port": 80, "protocol": "TCP"},
+		map[string]interface{}{"port": 443, "protocol": "TCP"},
+	}
+	if upstreamPort := mcpUpstreamPolicyPort(mcpUpstream); upstreamPort != 0 && upstreamPort != 80 && upstreamPort != 443 {
+		webPorts = append(webPorts, map[string]interface{}{"port": upstreamPort, "protocol": "TCP"})
 	}
 	np := map[string]interface{}{
 		"apiVersion": "networking.k8s.io/v1",
@@ -473,9 +553,7 @@ func renderProxyNetworkPolicy(namespace, proxyName string, proxyLabels, agentLab
 							},
 						},
 					},
-					"ports": []interface{}{
-						map[string]interface{}{"port": sidecarHealthPort, "protocol": "TCP"},
-					},
+					"ports": ingressPorts,
 				},
 			},
 			"egress": []interface{}{
@@ -486,10 +564,7 @@ func renderProxyNetworkPolicy(namespace, proxyName string, proxyLabels, agentLab
 					},
 				},
 				map[string]interface{}{
-					"ports": []interface{}{
-						map[string]interface{}{"port": 80, "protocol": "TCP"},
-						map[string]interface{}{"port": 443, "protocol": "TCP"},
-					},
+					"ports": webPorts,
 				},
 			},
 		},
@@ -552,6 +627,39 @@ func proxyServiceURL(proxyName string) string {
 	return fmt.Sprintf("http://%s:%d", proxyName, sidecarHealthPort)
 }
 
+func proxyMCPServiceURL(proxyName string) string {
+	return fmt.Sprintf("http://%s:%d", proxyName, sidecarMCPPort)
+}
+
+func proxyMCPListenAddr() string {
+	return fmt.Sprintf("0.0.0.0:%d", sidecarMCPPort)
+}
+
+func mcpUpstreamPolicyPort(raw string) int {
+	if raw == "" {
+		return 0
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return 0
+	}
+	if parsed.Port() != "" {
+		port, err := strconv.Atoi(parsed.Port())
+		if err != nil {
+			return 0
+		}
+		return port
+	}
+	switch parsed.Scheme {
+	case "http":
+		return 80
+	case "https":
+		return 443
+	default:
+		return 0
+	}
+}
+
 func proxySelectorLabels(proxyName string) map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":      "pipelock",
@@ -577,20 +685,58 @@ func managedComponentLabels(component string) map[string]string {
 	}
 }
 
-func annotateManagedWorkload(raw map[string]interface{}, kind, proxyName string) error {
+func annotateManagedWorkload(raw map[string]interface{}, kind, proxyName, mcpProxyURL, mcpUpstream string) error {
 	annotations := map[string]string{
 		managedTopologyAnnotation:     managedTopologyCompanion,
 		managedProxyNameAnnotation:    proxyName,
 		managedProxyServiceAnnotation: proxyServiceURL(proxyName),
 	}
+	// Remove any prior MCP annotations when this generation has no upstream
+	// configured. Otherwise re-running without --mcp-upstream after a prior
+	// run with it would leave the agent advertising a proxy URL that the
+	// regenerated Service no longer exposes: a silent contract drift.
+	var removeKeys []string
+	if mcpProxyURL != "" {
+		annotations[managedMCPProxyAnnotation] = mcpProxyURL
+		annotations[managedMCPUpstreamAnnotation] = mcpUpstream
+	} else {
+		removeKeys = append(removeKeys, managedMCPProxyAnnotation, managedMCPUpstreamAnnotation)
+	}
 	if err := setAnnotationsAtPath(raw, []string{"metadata", "annotations"}, annotations); err != nil {
 		return err
+	}
+	if len(removeKeys) > 0 {
+		if err := removeAnnotationsAtPath(raw, []string{"metadata", "annotations"}, removeKeys); err != nil {
+			return err
+		}
 	}
 	templatePath := []string{"spec", "template", "metadata", "annotations"}
 	if kind == kindCronJob {
 		templatePath = []string{"spec", "jobTemplate", "spec", "template", "metadata", "annotations"}
 	}
-	return setAnnotationsAtPath(raw, templatePath, annotations)
+	if err := setAnnotationsAtPath(raw, templatePath, annotations); err != nil {
+		return err
+	}
+	if len(removeKeys) > 0 {
+		return removeAnnotationsAtPath(raw, templatePath, removeKeys)
+	}
+	return nil
+}
+
+// removeAnnotationsAtPath deletes the named annotation keys from the
+// annotations map at the given workload path. It is a no-op if the path
+// or the keys are absent. Used to scrub MCP-proxy annotations when an
+// operator re-runs init sidecar without --mcp-upstream after a prior
+// run had it enabled.
+func removeAnnotationsAtPath(raw map[string]interface{}, path []string, keys []string) error {
+	current, err := ensureMapAtPath(raw, path)
+	if err != nil {
+		return err
+	}
+	for _, key := range keys {
+		delete(current, key)
+	}
+	return nil
 }
 
 func setAnnotationsAtPath(raw map[string]interface{}, path []string, annotations map[string]string) error {

--- a/internal/cli/setup/sidecar_patch_test.go
+++ b/internal/cli/setup/sidecar_patch_test.go
@@ -354,6 +354,168 @@ func TestGenerateSidecarPatch_CustomImage(t *testing.T) {
 	}
 }
 
+func TestGenerateSidecarPatch_MCPUpstream(t *testing.T) {
+	manifest, err := detectWorkload(testdataPath(t, "deployment.yaml"))
+	if err != nil {
+		t.Fatalf("detectWorkload: %v", err)
+	}
+
+	const mcpUpstream = "http://openclaw:3000/mcp"
+	result, err := generateSidecarPatch(manifest, sidecarOptions{
+		preset:      config.ModeBalanced,
+		mcpUpstream: mcpUpstream,
+	})
+	if err != nil {
+		t.Fatalf("generateSidecarPatch: %v", err)
+	}
+
+	if result.MCPUpstream != mcpUpstream {
+		t.Fatalf("MCPUpstream = %q, want %q", result.MCPUpstream, mcpUpstream)
+	}
+	if result.MCPProxyURL != "http://my-agent-pipelock:8889" {
+		t.Fatalf("MCPProxyURL = %q, want %q", result.MCPProxyURL, "http://my-agent-pipelock:8889")
+	}
+
+	podSpec, err := getPodSpec(result.PatchedManifest, kindDeployment)
+	if err != nil {
+		t.Fatalf("getPodSpec: %v", err)
+	}
+	containers := podSpec["containers"].([]interface{})
+	agentContainer := containers[0].(map[string]interface{})
+	envList := agentContainer["env"].([]interface{})
+	if got := envValue(t, envList, envMCPProxy); got != result.MCPProxyURL {
+		t.Fatalf("%s = %q, want %q", envMCPProxy, got, result.MCPProxyURL)
+	}
+
+	metadata := result.PatchedManifest["metadata"].(map[string]interface{})
+	annotations := metadata["annotations"].(map[string]interface{})
+	if annotations[managedMCPProxyAnnotation] != result.MCPProxyURL {
+		t.Fatalf("metadata.annotations[%q] = %v, want %q", managedMCPProxyAnnotation, annotations[managedMCPProxyAnnotation], result.MCPProxyURL)
+	}
+
+	var deployment map[string]interface{}
+	if err := yaml.Unmarshal([]byte(result.DeploymentYAML), &deployment); err != nil {
+		t.Fatalf("parsing DeploymentYAML: %v", err)
+	}
+	deploySpec := deployment["spec"].(map[string]interface{})
+	template := deploySpec["template"].(map[string]interface{})
+	templateSpec := template["spec"].(map[string]interface{})
+	proxyContainer := templateSpec["containers"].([]interface{})[0].(map[string]interface{})
+	args := proxyContainer["args"].([]interface{})
+	if !containsInterfaceString(args, "--mcp-listen") || !containsInterfaceString(args, proxyMCPListenAddr()) ||
+		!containsInterfaceString(args, "--mcp-upstream") || !containsInterfaceString(args, mcpUpstream) {
+		t.Fatalf("proxy args missing MCP listener contract: %v", args)
+	}
+	ports := proxyContainer["ports"].([]interface{})
+	if !portsContainName(ports, "mcp") {
+		t.Fatalf("proxy container ports missing mcp: %v", ports)
+	}
+
+	var service map[string]interface{}
+	if err := yaml.Unmarshal([]byte(result.ServiceYAML), &service); err != nil {
+		t.Fatalf("parsing ServiceYAML: %v", err)
+	}
+	serviceSpec := service["spec"].(map[string]interface{})
+	if !portsContainName(serviceSpec["ports"].([]interface{}), "mcp") {
+		t.Fatalf("service ports missing mcp: %v", serviceSpec["ports"])
+	}
+
+	if !strings.Contains(result.AgentNetworkPolicyYAML, "port: 8889") {
+		t.Fatal("agent NetworkPolicy should allow egress to the MCP proxy port")
+	}
+	if !strings.Contains(result.ProxyNetworkPolicyYAML, "port: 8889") {
+		t.Fatal("proxy NetworkPolicy should allow agent ingress on the MCP proxy port")
+	}
+	if !strings.Contains(result.ProxyNetworkPolicyYAML, "port: 3000") {
+		t.Fatal("proxy NetworkPolicy should allow the configured MCP upstream port")
+	}
+}
+
+func TestGenerateSidecarPatch_MCPUpstreamRecordsAnnotation(t *testing.T) {
+	manifest, err := detectWorkload(testdataPath(t, "deployment.yaml"))
+	if err != nil {
+		t.Fatalf("detectWorkload: %v", err)
+	}
+	const mcpUpstream = "http://openclaw:3000/mcp"
+	result, err := generateSidecarPatch(manifest, sidecarOptions{
+		preset:      config.ModeBalanced,
+		mcpUpstream: mcpUpstream,
+	})
+	if err != nil {
+		t.Fatalf("generateSidecarPatch: %v", err)
+	}
+	metadata := result.PatchedManifest["metadata"].(map[string]interface{})
+	annotations := metadata["annotations"].(map[string]interface{})
+	if annotations[managedMCPUpstreamAnnotation] != mcpUpstream {
+		t.Fatalf("annotations[%q] = %v, want %q",
+			managedMCPUpstreamAnnotation, annotations[managedMCPUpstreamAnnotation], mcpUpstream)
+	}
+}
+
+func TestGenerateSidecarPatch_MCPDisableScrubsAnnotationsAndEnv(t *testing.T) {
+	// Re-running init sidecar without --mcp-upstream after a prior run with
+	// it must remove the agent-side contract entirely. Otherwise the agent
+	// keeps PIPELOCK_MCP_PROXY_URL pointed at a Service port the
+	// regenerated companion no longer exposes — a silent feature drift.
+	manifest, err := detectWorkload(testdataPath(t, "deployment.yaml"))
+	if err != nil {
+		t.Fatalf("detectWorkload: %v", err)
+	}
+	first, err := generateSidecarPatch(manifest, sidecarOptions{
+		preset:      config.ModeBalanced,
+		mcpUpstream: "http://openclaw:3000/mcp",
+	})
+	if err != nil {
+		t.Fatalf("first generate: %v", err)
+	}
+
+	// Treat the already-patched manifest as fresh input for the disable run.
+	second, err := generateSidecarPatch(&workloadManifest{
+		Raw:  first.PatchedManifest,
+		Kind: manifest.Kind,
+		Name: manifest.Name,
+	}, sidecarOptions{
+		preset: config.ModeBalanced,
+	})
+	if err != nil {
+		t.Fatalf("disable generate: %v", err)
+	}
+
+	metadata := second.PatchedManifest["metadata"].(map[string]interface{})
+	annotations, _ := metadata["annotations"].(map[string]interface{})
+	if _, ok := annotations[managedMCPProxyAnnotation]; ok {
+		t.Fatalf("expected %s annotation to be scrubbed on disable, got %+v", managedMCPProxyAnnotation, annotations)
+	}
+	if _, ok := annotations[managedMCPUpstreamAnnotation]; ok {
+		t.Fatalf("expected %s annotation to be scrubbed on disable, got %+v", managedMCPUpstreamAnnotation, annotations)
+	}
+
+	podSpec, err := getPodSpec(second.PatchedManifest, kindDeployment)
+	if err != nil {
+		t.Fatalf("getPodSpec: %v", err)
+	}
+	containers := podSpec["containers"].([]interface{})
+	envList := containers[0].(map[string]interface{})["env"].([]interface{})
+	for _, e := range envList {
+		eMap := e.(map[string]interface{})
+		if name, _ := eMap["name"].(string); name == envMCPProxy {
+			t.Fatalf("expected %s env to be scrubbed on disable: %+v", envMCPProxy, envList)
+		}
+	}
+
+	// Template annotations on the pod spec must also be scrubbed so newly
+	// rolled pods do not inherit the stale contract.
+	template := second.PatchedManifest["spec"].(map[string]interface{})["template"].(map[string]interface{})
+	tmplMeta, _ := template["metadata"].(map[string]interface{})
+	if tmplMeta != nil {
+		if tmplAnn, _ := tmplMeta["annotations"].(map[string]interface{}); tmplAnn != nil {
+			if _, ok := tmplAnn[managedMCPProxyAnnotation]; ok {
+				t.Fatalf("template annotations not scrubbed: %+v", tmplAnn)
+			}
+		}
+	}
+}
+
 func TestGenerateSidecarPatch_CustomIdentity(t *testing.T) {
 	manifest, err := detectWorkload(testdataPath(t, "deployment.yaml"))
 	if err != nil {
@@ -374,6 +536,28 @@ func TestGenerateSidecarPatch_CustomIdentity(t *testing.T) {
 	}
 }
 
+func containsInterfaceString(items []interface{}, want string) bool {
+	for _, item := range items {
+		if got, ok := item.(string); ok && got == want {
+			return true
+		}
+	}
+	return false
+}
+
+func portsContainName(ports []interface{}, want string) bool {
+	for _, port := range ports {
+		portMap, ok := port.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, _ := portMap["name"].(string); name == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestInjectProxyEnvs_RejectsConflictingProxy(t *testing.T) {
 	podSpec := map[string]interface{}{
 		"containers": []interface{}{
@@ -386,7 +570,7 @@ func TestInjectProxyEnvs_RejectsConflictingProxy(t *testing.T) {
 		},
 	}
 
-	err := injectProxyEnvs(podSpec, "http://expected-proxy:8888")
+	err := injectProxyEnvs(podSpec, "http://expected-proxy:8888", "")
 	if err == nil {
 		t.Fatal("expected conflict error")
 	}
@@ -493,13 +677,13 @@ func TestNetworkPolicySelectorLabels_FallsBackToTemplateLabels(t *testing.T) {
 }
 
 func TestRenderAgentNetworkPolicy_EmptySelectorError(t *testing.T) {
-	if _, err := renderAgentNetworkPolicy("default", "agent", nil, map[string]string{"app": "proxy"}); err == nil {
+	if _, err := renderAgentNetworkPolicy("default", "agent", nil, map[string]string{"app": "proxy"}, false); err == nil {
 		t.Fatal("expected error for empty agent selector labels")
 	}
 }
 
 func TestRenderProxyNetworkPolicy_EmptySelectorError(t *testing.T) {
-	if _, err := renderProxyNetworkPolicy("default", "proxy", map[string]string{"app": "proxy"}, nil); err == nil {
+	if _, err := renderProxyNetworkPolicy("default", "proxy", map[string]string{"app": "proxy"}, nil, ""); err == nil {
 		t.Fatal("expected error for empty agent selector labels")
 	}
 }

--- a/internal/cli/setup/sidecar_test.go
+++ b/internal/cli/setup/sidecar_test.go
@@ -158,8 +158,11 @@ func TestRunSidecar_InvalidMCPUpstream(t *testing.T) {
 	}{
 		{name: "bad scheme", raw: "ws://openclaw:3000/mcp", wantSub: "must use http:// or https://"},
 		{name: "no host", raw: "http:///mcp", wantSub: "must include http:// or https:// and a host"},
+		{name: "userinfo", raw: "http://user@openclaw:3000/mcp", wantSub: "must not contain user info or credentials"},
 		{name: "port out of range high", raw: "http://openclaw:99999/mcp", wantSub: "must be 1-65535"},
 		{name: "port zero", raw: "http://openclaw:0/mcp", wantSub: "must be 1-65535"},
+		{name: "trailing colon", raw: "http://openclaw:/mcp", wantSub: "malformed host/port syntax"},
+		{name: "extra port fragment", raw: "http://openclaw:65536:/mcp", wantSub: "malformed host/port syntax"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/setup/sidecar_test.go
+++ b/internal/cli/setup/sidecar_test.go
@@ -92,6 +92,98 @@ func TestRunSidecar_JSON(t *testing.T) {
 	}
 }
 
+func TestRunSidecar_JSONMCPUpstream(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--dry-run",
+		"--json",
+		"--mcp-upstream", "http://openclaw:3000/mcp",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result sidecarResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, buf.String())
+	}
+	if result.Patch == nil {
+		t.Fatal("patch field should not be nil")
+	}
+	if result.Patch.MCPProxyURL != "http://my-agent-pipelock:8889" {
+		t.Fatalf("patch.mcp_proxy_url = %q, want %q", result.Patch.MCPProxyURL, "http://my-agent-pipelock:8889")
+	}
+}
+
+func TestRunSidecar_MCPUpstreamSummaryReminder(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	cmd := SidecarCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--dry-run",
+		"--mcp-upstream", "http://openclaw:3000/mcp",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "MCP proxy URL:") {
+		t.Fatalf("summary missing MCP proxy URL:\n%s", output)
+	}
+	if !strings.Contains(output, "Configure the agent MCP client to use PIPELOCK_MCP_PROXY_URL") {
+		t.Fatalf("summary missing agent MCP wiring reminder:\n%s", output)
+	}
+}
+
+func TestRunSidecar_InvalidMCPUpstream(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		raw     string
+		wantSub string
+	}{
+		{name: "bad scheme", raw: "ws://openclaw:3000/mcp", wantSub: "must use http:// or https://"},
+		{name: "no host", raw: "http:///mcp", wantSub: "must include http:// or https:// and a host"},
+		{name: "port out of range high", raw: "http://openclaw:99999/mcp", wantSub: "must be 1-65535"},
+		{name: "port zero", raw: "http://openclaw:0/mcp", wantSub: "must be 1-65535"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			cmd := SidecarCmd()
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs([]string{
+				"--inject-spec", testdataPath(t, "deployment.yaml"),
+				"--dry-run",
+				"--mcp-upstream", tc.raw,
+			})
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected invalid --mcp-upstream error for %q", tc.raw)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("err = %v, want substring %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
 func TestRunSidecar_AllKinds(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/setup/sidecar_verify.go
+++ b/internal/cli/setup/sidecar_verify.go
@@ -70,8 +70,20 @@ func runSidecarVerify(w io.Writer, result *sidecarPatchResult, opts sidecarOptio
 	if !strings.Contains(result.AgentNetworkPolicyYAML, fmt.Sprintf("port: %d", sidecarHealthPort)) {
 		failed = append(failed, "agent NetworkPolicy does not allow proxy port")
 	}
+	if result.MCPUpstream != "" && !strings.Contains(result.AgentNetworkPolicyYAML, fmt.Sprintf("port: %d", sidecarMCPPort)) {
+		failed = append(failed, "agent NetworkPolicy does not allow MCP proxy port")
+	}
 	if !strings.Contains(result.ProxyNetworkPolicyYAML, fmt.Sprintf("port: %d", sidecarHealthPort)) {
 		failed = append(failed, "proxy NetworkPolicy does not allow agent ingress on proxy port")
+	}
+	if result.MCPUpstream != "" {
+		if !strings.Contains(result.ProxyNetworkPolicyYAML, fmt.Sprintf("port: %d", sidecarMCPPort)) {
+			failed = append(failed, "proxy NetworkPolicy does not allow agent ingress on MCP proxy port")
+		}
+		if upstreamPort := mcpUpstreamPolicyPort(result.MCPUpstream); upstreamPort != 0 &&
+			!strings.Contains(result.ProxyNetworkPolicyYAML, fmt.Sprintf("port: %d", upstreamPort)) {
+			failed = append(failed, fmt.Sprintf("proxy NetworkPolicy does not allow MCP upstream port %d", upstreamPort))
+		}
 	}
 	if !strings.Contains(result.ProxyNetworkPolicyYAML, "port: 80") || !strings.Contains(result.ProxyNetworkPolicyYAML, "port: 443") {
 		failed = append(failed, "proxy NetworkPolicy does not allow web egress")

--- a/internal/cli/setup/sidecar_verify.go
+++ b/internal/cli/setup/sidecar_verify.go
@@ -6,6 +6,7 @@ package setup
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 )
 
@@ -64,28 +65,28 @@ func runSidecarVerify(w io.Writer, result *sidecarPatchResult, opts sidecarOptio
 	if !strings.Contains(result.AgentNetworkPolicyYAML, "matchLabels") || !strings.Contains(result.AgentNetworkPolicyYAML, "podSelector") {
 		failed = append(failed, "agent NetworkPolicy missing selectors")
 	}
-	if strings.Contains(result.AgentNetworkPolicyYAML, "port: 80") || strings.Contains(result.AgentNetworkPolicyYAML, "port: 443") {
+	if networkPolicyHasPort(result.AgentNetworkPolicyYAML, 80) || networkPolicyHasPort(result.AgentNetworkPolicyYAML, 443) {
 		failed = append(failed, "agent NetworkPolicy still allows direct web egress")
 	}
-	if !strings.Contains(result.AgentNetworkPolicyYAML, fmt.Sprintf("port: %d", sidecarHealthPort)) {
+	if !networkPolicyHasPort(result.AgentNetworkPolicyYAML, sidecarHealthPort) {
 		failed = append(failed, "agent NetworkPolicy does not allow proxy port")
 	}
-	if result.MCPUpstream != "" && !strings.Contains(result.AgentNetworkPolicyYAML, fmt.Sprintf("port: %d", sidecarMCPPort)) {
+	if result.MCPUpstream != "" && !networkPolicyHasPort(result.AgentNetworkPolicyYAML, sidecarMCPPort) {
 		failed = append(failed, "agent NetworkPolicy does not allow MCP proxy port")
 	}
-	if !strings.Contains(result.ProxyNetworkPolicyYAML, fmt.Sprintf("port: %d", sidecarHealthPort)) {
+	if !networkPolicyHasPort(result.ProxyNetworkPolicyYAML, sidecarHealthPort) {
 		failed = append(failed, "proxy NetworkPolicy does not allow agent ingress on proxy port")
 	}
 	if result.MCPUpstream != "" {
-		if !strings.Contains(result.ProxyNetworkPolicyYAML, fmt.Sprintf("port: %d", sidecarMCPPort)) {
+		if !networkPolicyHasPort(result.ProxyNetworkPolicyYAML, sidecarMCPPort) {
 			failed = append(failed, "proxy NetworkPolicy does not allow agent ingress on MCP proxy port")
 		}
 		if upstreamPort := mcpUpstreamPolicyPort(result.MCPUpstream); upstreamPort != 0 &&
-			!strings.Contains(result.ProxyNetworkPolicyYAML, fmt.Sprintf("port: %d", upstreamPort)) {
+			!networkPolicyHasPort(result.ProxyNetworkPolicyYAML, upstreamPort) {
 			failed = append(failed, fmt.Sprintf("proxy NetworkPolicy does not allow MCP upstream port %d", upstreamPort))
 		}
 	}
-	if !strings.Contains(result.ProxyNetworkPolicyYAML, "port: 80") || !strings.Contains(result.ProxyNetworkPolicyYAML, "port: 443") {
+	if !networkPolicyHasPort(result.ProxyNetworkPolicyYAML, 80) || !networkPolicyHasPort(result.ProxyNetworkPolicyYAML, 443) {
 		failed = append(failed, "proxy NetworkPolicy does not allow web egress")
 	}
 
@@ -111,4 +112,9 @@ func runSidecarVerify(w io.Writer, result *sidecarPatchResult, opts sidecarOptio
 		Healthy: false,
 		Detail:  detail,
 	}
+}
+
+func networkPolicyHasPort(policyYAML string, port int) bool {
+	pattern := fmt.Sprintf(`(?m)^\s*-?\s*port:\s*%d\s*(?:#.*)?$`, port)
+	return regexp.MustCompile(pattern).MatchString(policyYAML)
 }

--- a/internal/cli/setup/sidecar_verify_test.go
+++ b/internal/cli/setup/sidecar_verify_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import "testing"
+
+func TestNetworkPolicyHasPortExact(t *testing.T) {
+	t.Parallel()
+
+	policy := `
+spec:
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 4430
+        - protocol: TCP
+          port: 88890
+        - protocol: TCP
+          port: 30000
+        - protocol: TCP
+          port: 8889 # mcp
+`
+
+	for _, port := range []int{80, 443, 8888, 3000} {
+		if networkPolicyHasPort(policy, port) {
+			t.Fatalf("networkPolicyHasPort matched substring port %d", port)
+		}
+	}
+	if !networkPolicyHasPort(policy, 8889) {
+		t.Fatal("networkPolicyHasPort should match exact port line")
+	}
+}


### PR DESCRIPTION
## Summary
- add `pipelock init sidecar --mcp-upstream` for companion-proxy MCP listener generation
- expose `PIPELOCK_MCP_PROXY_URL` to protected workload containers and scrub it when MCP is disabled
- wire MCP listener ports through generated Deployment, Service, NetworkPolicies, and Helm values
- record the configured MCP upstream in managed annotations
- document Kubernetes NetworkPolicy destination-scoping limits for upstream MCP egress

## Validation
- go test -race -count=1 ./internal/cli/setup
- go test -race -count=1 ./internal/cli/runtime ./internal/cli
- golangci-lint run ./...
- go test -race -count=1 ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --mcp-upstream flag to sidecar init to configure an MCP proxy endpoint; generator exposes an MCP listener (port 8889) and wires PIPELOCK_MCP_PROXY_URL into workloads; re-running without the flag removes prior MCP wiring.

* **Documentation**
  * Updated sidecar init and OpenClaw guides with flag usage, proxy wiring, NetworkPolicy semantics, verification steps and examples.

* **Tests**
  * Added tests for MCP upstream validation, Helm values output, patching/idempotency, and NetworkPolicy port checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->