### PR TITLE
Add signed MCP integrity manifest trust

### DIFF
--- a/docs/cli/mcp-integrity.md
+++ b/docs/cli/mcp-integrity.md
@@ -47,6 +47,54 @@ pipelock mcp integrity manifest verify \
 The command exits non-zero if any resolved binary or script hash is missing or
 mismatched. Use `--json` for automation.
 
+## Sign and Trust
+
+Sign the manifest after generating or merging entries:
+
+```sh
+pipelock mcp integrity manifest sign \
+  --manifest /etc/pipelock/binary-manifest.json \
+  --signer release
+```
+
+This writes `/etc/pipelock/binary-manifest.json.sig` by default. Verify that
+signature before using the manifest:
+
+```sh
+pipelock mcp integrity manifest verify-signature \
+  --manifest /etc/pipelock/binary-manifest.json \
+  --signer release
+```
+
+The signer is resolved from the Pipelock keystore. For a signer public key
+managed outside the local keystore, trust it first:
+
+```sh
+pipelock trust release /path/to/release.pub
+```
+
+To require a trusted manifest signature at runtime:
+
+```yaml
+mcp_binary_integrity:
+  enabled: true
+  manifest_path: /etc/pipelock/binary-manifest.json
+  action: block
+  require_signature: true
+  trusted_signer: release
+```
+
+`signature_path` defaults to `<manifest_path>.sig`. Set `keystore` only when
+the runtime should use a non-default Pipelock keystore.
+
+`require_signature: true` is fail-closed regardless of `action`. Once you
+assert manifest trust, an unverified, unsigned, or wrong-signer manifest
+blocks subprocess spawn even when `action: warn` is set. The `action` knob
+still governs the response to entry-hash mismatches for trusted manifests;
+it does not relax trust establishment itself. Runtime reads the manifest
+bytes once and verifies the signature against those exact bytes — no
+TOCTOU window between trust check and parse.
+
 ## Operator notes
 
 - **Prefer absolute script paths in your MCP launcher.** If a command uses a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2012,6 +2012,7 @@ mcp_binary_integrity:
   enabled: true
   manifest_path: /etc/pipelock/binary-manifest.json
   action: warn
+  require_signature: false
 ```
 
 | Field | Default | Description |
@@ -2019,8 +2020,12 @@ mcp_binary_integrity:
 | `enabled` | `false` | Enable binary hash verification before spawn |
 | `manifest_path` | (required if enabled) | Path to JSON hash manifest |
 | `action` | `warn` | Action on hash mismatch: `block` or `warn` |
+| `require_signature` | `false` | Verify a detached manifest signature before using the manifest |
+| `signature_path` | `<manifest_path>.sig` | Detached signature path when signatures are required |
+| `trusted_signer` | (required when signatures are required) | Keystore identity used to verify the manifest signature |
+| `keystore` | `~/.pipelock` | Keystore used for the trusted signer lookup |
 
-The manifest is a JSON file mapping binary paths to expected SHA-256 hashes. Pipelock resolves shebangs and versioned interpreters (e.g., `python3.11`) before hashing. Generate and preflight the manifest with `pipelock mcp integrity manifest generate|verify`; see [MCP integrity manifest tooling](cli/mcp-integrity.md).
+The manifest is a JSON file mapping binary paths to expected SHA-256 hashes. Pipelock resolves shebangs and versioned interpreters (e.g., `python3.11`) before hashing. Generate, preflight, and sign the manifest with `pipelock mcp integrity manifest`; see [MCP integrity manifest tooling](cli/mcp-integrity.md).
 
 ## Taint-Aware Policy Escalation (v2.1)
 

--- a/internal/cli/runtime/mcp_integrity.go
+++ b/internal/cli/runtime/mcp_integrity.go
@@ -297,22 +297,25 @@ func signMCPIntegrityManifest(manifestPath, sigPath, signer, keystoreDir string)
 }
 
 func verifyMCPIntegrityManifestSignature(manifestPath, sigPath, signer, keystoreDir string) (mcpIntegrityReport, error) {
-	signerName, err := resolveMCPIntegritySigner(signer)
-	if err != nil {
-		return mcpIntegrityReport{}, err
-	}
-	dir, err := cliutil.ResolveKeystoreDir(keystoreDir)
-	if err != nil {
-		return mcpIntegrityReport{}, err
-	}
 	if sigPath == "" {
 		sigPath = manifestPath + domsigning.SigExtension
 	}
 	report := mcpIntegrityReport{
 		Manifest:  manifestPath,
 		Signature: sigPath,
-		Signer:    signerName,
+		Signer:    signer,
 		Reasons:   []string{},
+	}
+	signerName, err := resolveMCPIntegritySigner(signer)
+	if err != nil {
+		report.Reasons = append(report.Reasons, err.Error())
+		return report, err
+	}
+	report.Signer = signerName
+	dir, err := cliutil.ResolveKeystoreDir(keystoreDir)
+	if err != nil {
+		report.Reasons = append(report.Reasons, err.Error())
+		return report, err
 	}
 	ks := domsigning.NewKeystore(dir)
 	pubKey, err := ks.ResolvePublicKey(signerName)

--- a/internal/cli/runtime/mcp_integrity.go
+++ b/internal/cli/runtime/mcp_integrity.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	mcpintegrity "github.com/luckyPipewrench/pipelock/internal/mcp/integrity"
+	domsigning "github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 var errMCPIntegrityViolation = errors.New("MCP binary integrity violation")
@@ -25,6 +26,8 @@ type mcpIntegrityReport struct {
 	OK         bool     `json:"ok"`
 	Command    []string `json:"command"`
 	Manifest   string   `json:"manifest,omitempty"`
+	Signature  string   `json:"signature,omitempty"`
+	Signer     string   `json:"signer,omitempty"`
 	WorkDir    string   `json:"workdir,omitempty"`
 	Entries    []string `json:"entries,omitempty"`
 	Reasons    []string `json:"reasons,omitempty"`
@@ -54,6 +57,8 @@ func mcpIntegrityManifestCmd() *cobra.Command {
 	}
 	cmd.AddCommand(mcpIntegrityManifestGenerateCmd())
 	cmd.AddCommand(mcpIntegrityManifestVerifyCmd())
+	cmd.AddCommand(mcpIntegrityManifestSignCmd())
+	cmd.AddCommand(mcpIntegrityManifestVerifySignatureCmd())
 	return cmd
 }
 
@@ -143,6 +148,84 @@ the configured manifest.`,
 	return cmd
 }
 
+func mcpIntegrityManifestSignCmd() *cobra.Command {
+	var manifestPath string
+	var sigPath string
+	var signer string
+	var keystoreDir string
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "sign --manifest manifest.json --signer name",
+		Short: "Sign an MCP binary integrity manifest",
+		Long: `Create a detached Ed25519 signature for an MCP binary integrity
+manifest. The signer is resolved from the Pipelock keystore.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if manifestPath == "" {
+				return fmt.Errorf("--manifest is required")
+			}
+			report, err := signMCPIntegrityManifest(manifestPath, sigPath, signer, keystoreDir)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return writeMCPIntegrityJSON(cmd.OutOrStdout(), report)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "MCP integrity manifest signed: %s\n", report.Manifest)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Signature: %s\n", report.Signature)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&manifestPath, "manifest", "", "manifest file path")
+	cmd.Flags().StringVar(&sigPath, "sig", "", "signature file path (default <manifest>.sig)")
+	cmd.Flags().StringVar(&signer, "signer", "", "signer name (or set PIPELOCK_AGENT)")
+	cmd.Flags().StringVar(&keystoreDir, "keystore", "", "keystore directory (default ~/.pipelock)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output a machine-readable report")
+	return cmd
+}
+
+func mcpIntegrityManifestVerifySignatureCmd() *cobra.Command {
+	var manifestPath string
+	var sigPath string
+	var signer string
+	var keystoreDir string
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "verify-signature --manifest manifest.json --signer name",
+		Short: "Verify an MCP binary integrity manifest signature",
+		Long: `Verify a detached Ed25519 signature for an MCP binary integrity
+manifest using the configured Pipelock keystore.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if manifestPath == "" {
+				return fmt.Errorf("--manifest is required")
+			}
+			report, err := verifyMCPIntegrityManifestSignature(manifestPath, sigPath, signer, keystoreDir)
+			if jsonOutput {
+				if jsonErr := writeMCPIntegrityJSON(cmd.OutOrStdout(), report); jsonErr != nil {
+					return jsonErr
+				}
+			} else if report.OK {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "MCP integrity manifest signature verified: %s\n", report.Manifest)
+			} else {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "MCP integrity manifest signature failed: %s\n", strings.Join(report.Reasons, "; "))
+			}
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&manifestPath, "manifest", "", "manifest file path")
+	cmd.Flags().StringVar(&sigPath, "sig", "", "signature file path (default <manifest>.sig)")
+	cmd.Flags().StringVar(&signer, "signer", "", "signer name (or set PIPELOCK_AGENT)")
+	cmd.Flags().StringVar(&keystoreDir, "keystore", "", "keystore directory (default ~/.pipelock)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output a machine-readable report")
+	return cmd
+}
+
 func generateMCPIntegrityManifest(outputPath string, command []string, workDir string, mergeExisting bool) (mcpIntegrityReport, error) {
 	entries, result, err := manifestEntriesForCommand(command, workDir)
 	if err != nil {
@@ -180,6 +263,85 @@ func generateMCPIntegrityManifest(outputPath string, command []string, workDir s
 	return reportForResult(true, command, outputPath, workDir, result, sortedEntryPaths(entries), nil), nil
 }
 
+func signMCPIntegrityManifest(manifestPath, sigPath, signer, keystoreDir string) (mcpIntegrityReport, error) {
+	signerName, err := resolveMCPIntegritySigner(signer)
+	if err != nil {
+		return mcpIntegrityReport{}, err
+	}
+	dir, err := cliutil.ResolveKeystoreDir(keystoreDir)
+	if err != nil {
+		return mcpIntegrityReport{}, err
+	}
+	ks := domsigning.NewKeystore(dir)
+	privKey, err := ks.LoadPrivateKey(signerName)
+	if err != nil {
+		return mcpIntegrityReport{}, fmt.Errorf("loading key for signer %q: %w", signerName, err)
+	}
+	sig, err := domsigning.SignFile(manifestPath, privKey)
+	if err != nil {
+		return mcpIntegrityReport{}, err
+	}
+	if sigPath == "" {
+		sigPath = manifestPath + domsigning.SigExtension
+	}
+	if err := domsigning.SaveSignature(sig, sigPath); err != nil {
+		return mcpIntegrityReport{}, err
+	}
+	return mcpIntegrityReport{
+		OK:        true,
+		Manifest:  manifestPath,
+		Signature: sigPath,
+		Signer:    signerName,
+		Reasons:   []string{},
+	}, nil
+}
+
+func verifyMCPIntegrityManifestSignature(manifestPath, sigPath, signer, keystoreDir string) (mcpIntegrityReport, error) {
+	signerName, err := resolveMCPIntegritySigner(signer)
+	if err != nil {
+		return mcpIntegrityReport{}, err
+	}
+	dir, err := cliutil.ResolveKeystoreDir(keystoreDir)
+	if err != nil {
+		return mcpIntegrityReport{}, err
+	}
+	if sigPath == "" {
+		sigPath = manifestPath + domsigning.SigExtension
+	}
+	report := mcpIntegrityReport{
+		Manifest:  manifestPath,
+		Signature: sigPath,
+		Signer:    signerName,
+		Reasons:   []string{},
+	}
+	ks := domsigning.NewKeystore(dir)
+	pubKey, err := ks.ResolvePublicKey(signerName)
+	if err != nil {
+		report.Reasons = append(report.Reasons, err.Error())
+		return report, err
+	}
+	if err := domsigning.VerifyFile(manifestPath, sigPath, pubKey); err != nil {
+		report.Reasons = append(report.Reasons, err.Error())
+		return report, cliutil.ExitCodeError(1, errMCPIntegrityViolation)
+	}
+	report.OK = true
+	return report, nil
+}
+
+func resolveMCPIntegritySigner(explicit string) (string, error) {
+	name := explicit
+	if name == "" {
+		name = os.Getenv("PIPELOCK_AGENT")
+	}
+	if name == "" {
+		return "", fmt.Errorf("signer name required: use --signer or set PIPELOCK_AGENT")
+	}
+	if err := domsigning.ValidateAgentName(name); err != nil {
+		return "", err
+	}
+	return name, nil
+}
+
 func verifyMCPIntegrityManifest(manifestPath string, command []string, workDir string) (mcpIntegrityReport, error) {
 	manifest, err := mcpintegrity.LoadManifest(manifestPath)
 	if err != nil {
@@ -194,7 +356,7 @@ func verifyMCPIntegrityManifest(manifestPath string, command []string, workDir s
 }
 
 func manifestEntriesForCommand(command []string, workDir string) (map[string]string, *mcpintegrity.VerifyResult, error) {
-	result, err := mcpintegrity.Verify(command, &mcpintegrity.Config{Manifests: map[string]string{}}, workDir)
+	result, err := mcpintegrity.Resolve(command, workDir)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/cli/runtime/mcp_integrity_test.go
+++ b/internal/cli/runtime/mcp_integrity_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	mcpintegrity "github.com/luckyPipewrench/pipelock/internal/mcp/integrity"
+	domsigning "github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 const osWindows = "windows"
@@ -200,6 +201,112 @@ func TestMCPIntegrityManifestRequiresPaths(t *testing.T) {
 	}
 }
 
+func TestMCPIntegrityManifestSignAndVerifySignature(t *testing.T) {
+	dir := t.TempDir()
+	ksDir := filepath.Join(dir, "keys")
+	ks := domsigning.NewKeystore(ksDir)
+	if _, err := ks.GenerateAgent("signer"); err != nil {
+		t.Fatalf("generate signer: %v", err)
+	}
+	manifestPath := filepath.Join(dir, "manifest.json")
+	if err := mcpintegrity.SaveManifest(manifestPath, &mcpintegrity.Manifest{
+		Version: mcpintegrity.ManifestVersion,
+		Entries: map[string]string{
+			"/bin/example": strings.Repeat("a", 64),
+		},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+
+	signCmd := testMCPRoot()
+	var signOut bytes.Buffer
+	signCmd.SetOut(&signOut)
+	signCmd.SetArgs([]string{
+		"mcp", "integrity", "manifest", "sign",
+		"--manifest", manifestPath,
+		"--signer", "signer",
+		"--keystore", ksDir,
+	})
+	if err := signCmd.Execute(); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if !strings.Contains(signOut.String(), "Signature:") {
+		t.Fatalf("sign output = %q", signOut.String())
+	}
+
+	verifyCmd := testMCPRoot()
+	var verifyOut bytes.Buffer
+	verifyCmd.SetOut(&verifyOut)
+	verifyCmd.SetArgs([]string{
+		"mcp", "integrity", "manifest", "verify-signature",
+		"--manifest", manifestPath,
+		"--signer", "signer",
+		"--keystore", ksDir,
+	})
+	if err := verifyCmd.Execute(); err != nil {
+		t.Fatalf("verify signature: %v\noutput: %s", err, verifyOut.String())
+	}
+	if !strings.Contains(verifyOut.String(), "signature verified") {
+		t.Fatalf("verify output = %q", verifyOut.String())
+	}
+}
+
+func TestMCPIntegrityManifestVerifySignatureReportsTamper(t *testing.T) {
+	dir := t.TempDir()
+	ksDir := filepath.Join(dir, "keys")
+	ks := domsigning.NewKeystore(ksDir)
+	if _, err := ks.GenerateAgent("signer"); err != nil {
+		t.Fatalf("generate signer: %v", err)
+	}
+	manifestPath := filepath.Join(dir, "manifest.json")
+	if err := mcpintegrity.SaveManifest(manifestPath, &mcpintegrity.Manifest{
+		Version: mcpintegrity.ManifestVersion,
+		Entries: map[string]string{
+			"/bin/example": strings.Repeat("a", 64),
+		},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	signReport, err := signMCPIntegrityManifest(manifestPath, "", "signer", ksDir)
+	if err != nil {
+		t.Fatalf("sign manifest: %v", err)
+	}
+	if err := mcpintegrity.SaveManifest(manifestPath, &mcpintegrity.Manifest{
+		Version: mcpintegrity.ManifestVersion,
+		Entries: map[string]string{
+			"/bin/example": strings.Repeat("b", 64),
+		},
+	}); err != nil {
+		t.Fatalf("tamper manifest: %v", err)
+	}
+
+	verifyCmd := testMCPRoot()
+	var out bytes.Buffer
+	verifyCmd.SetOut(&out)
+	verifyCmd.SetArgs([]string{
+		"mcp", "integrity", "manifest", "verify-signature",
+		"--manifest", manifestPath,
+		"--sig", signReport.Signature,
+		"--signer", "signer",
+		"--keystore", ksDir,
+		"--json",
+	})
+	err = verifyCmd.Execute()
+	if err == nil {
+		t.Fatal("expected verify-signature failure for tampered manifest")
+	}
+	var report mcpIntegrityReport
+	if jsonErr := json.Unmarshal(out.Bytes(), &report); jsonErr != nil {
+		t.Fatalf("unmarshal report: %v\n%s", jsonErr, out.String())
+	}
+	if report.OK {
+		t.Fatalf("report OK = true, want false: %+v", report)
+	}
+	if len(report.Reasons) == 0 || !strings.Contains(report.Reasons[0], "signature verification failed") {
+		t.Fatalf("reasons = %+v, want signature verification failure", report.Reasons)
+	}
+}
+
 func TestMCPIntegrityManifestGenerateSuppressesSuspiciousFlag(t *testing.T) {
 	if runtime.GOOS == osWindows {
 		t.Skip("test uses POSIX shebang script")
@@ -241,6 +348,35 @@ func TestMCPIntegrityManifestGenerateSuppressesSuspiciousFlag(t *testing.T) {
 	}
 	if !report.OK {
 		t.Fatalf("expected OK=true on successful generate, got %+v", report)
+	}
+}
+
+func TestMCPIntegrityManifestEntriesUseResolveOnly(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("test uses POSIX shell command")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "server.sh")
+	if err := os.WriteFile(script, []byte("echo mcp\n"), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	entries, result, err := manifestEntriesForCommand([]string{"sh", "server.sh"}, dir)
+	if err != nil {
+		t.Fatalf("manifestEntriesForCommand: %v", err)
+	}
+	resolvedScript, err := filepath.EvalSymlinks(script)
+	if err != nil {
+		t.Fatalf("resolve script: %v", err)
+	}
+	if _, ok := entries[result.ResolvedPath]; !ok {
+		t.Fatalf("entries missing resolved interpreter %q: %+v", result.ResolvedPath, entries)
+	}
+	if _, ok := entries[resolvedScript]; !ok {
+		t.Fatalf("entries missing resolved script %q: %+v", resolvedScript, entries)
+	}
+	if result.Verified || result.Reason != "" || len(result.Reasons) != 0 {
+		t.Fatalf("manifest generation should not carry verify failure state: %+v", result)
 	}
 }
 

--- a/internal/cli/runtime/mcp_integrity_test.go
+++ b/internal/cli/runtime/mcp_integrity_test.go
@@ -307,6 +307,49 @@ func TestMCPIntegrityManifestVerifySignatureReportsTamper(t *testing.T) {
 	}
 }
 
+func TestMCPIntegrityManifestVerifySignatureReportsSetupError(t *testing.T) {
+	t.Setenv("PIPELOCK_AGENT", "")
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.json")
+	if err := mcpintegrity.SaveManifest(manifestPath, &mcpintegrity.Manifest{
+		Version: mcpintegrity.ManifestVersion,
+		Entries: map[string]string{
+			"/bin/example": strings.Repeat("a", 64),
+		},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+
+	verifyCmd := testMCPRoot()
+	var out bytes.Buffer
+	verifyCmd.SetOut(&out)
+	verifyCmd.SetArgs([]string{
+		"mcp", "integrity", "manifest", "verify-signature",
+		"--manifest", manifestPath,
+		"--json",
+	})
+	err := verifyCmd.Execute()
+	if err == nil {
+		t.Fatal("expected verify-signature failure without signer")
+	}
+	var report mcpIntegrityReport
+	if jsonErr := json.Unmarshal(out.Bytes(), &report); jsonErr != nil {
+		t.Fatalf("unmarshal report: %v\n%s", jsonErr, out.String())
+	}
+	if report.OK {
+		t.Fatalf("report OK = true, want false: %+v", report)
+	}
+	if report.Manifest != manifestPath {
+		t.Fatalf("Manifest = %q, want %q", report.Manifest, manifestPath)
+	}
+	if report.Signature != manifestPath+domsigning.SigExtension {
+		t.Fatalf("Signature = %q, want default signature path", report.Signature)
+	}
+	if len(report.Reasons) == 0 || !strings.Contains(report.Reasons[0], "signer name required") {
+		t.Fatalf("reasons = %+v, want signer setup error", report.Reasons)
+	}
+}
+
 func TestMCPIntegrityManifestGenerateSuppressesSuspiciousFlag(t *testing.T) {
 	if runtime.GOOS == osWindows {
 		t.Skip("test uses POSIX shebang script")

--- a/internal/cli/runtime/run_test.go
+++ b/internal/cli/runtime/run_test.go
@@ -516,7 +516,7 @@ func freePort(t *testing.T) string {
 // waitForPort polls a TCP address until it accepts connections or times out.
 func waitForPort(t *testing.T, addr string) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(15 * time.Second)
 	dialer := &net.Dialer{Timeout: 50 * time.Millisecond}
 	for time.Now().Before(deadline) {
 		conn, err := dialer.DialContext(context.Background(), "tcp4", addr)
@@ -526,7 +526,30 @@ func waitForPort(t *testing.T, addr string) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Fatalf("port %s not ready within 5s", addr)
+	t.Fatalf("port %s not ready within 15s", addr)
+}
+
+// waitForPortOrCommandExit polls a TCP address while also surfacing early
+// command failures. It avoids hiding startup bind/config errors behind a
+// generic readiness timeout.
+func waitForPortOrCommandExit(t *testing.T, addr string, cmdErr <-chan error, stderr fmt.Stringer) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	dialer := &net.Dialer{Timeout: 50 * time.Millisecond}
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-cmdErr:
+			t.Fatalf("RunCmd exited before port %s was ready: %v\nstderr:\n%s", addr, err, stderr.String())
+		default:
+		}
+		conn, err := dialer.DialContext(context.Background(), "tcp4", addr)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("port %s not ready within 15s\nstderr:\n%s", addr, stderr.String())
 }
 
 // doGet issues a context-aware GET and fails the test on error.
@@ -734,9 +757,9 @@ logging:
 		cmdErr <- cmd.Execute()
 	}()
 
-	waitForPort(t, mainAddr)
-	waitForPort(t, reverseAddr)
-	waitForPort(t, mcpAddr)
+	waitForPortOrCommandExit(t, mainAddr, cmdErr, &stderr)
+	waitForPortOrCommandExit(t, reverseAddr, cmdErr, &stderr)
+	waitForPortOrCommandExit(t, mcpAddr, cmdErr, &stderr)
 
 	reverseReq, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://"+reverseAddr+"/api",
 		strings.NewReader(`{"prompt":"use `+secret+` to deploy"}`))

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -86,7 +86,10 @@ const (
 	// Re-bumped to include the effective session-profiling defaults in
 	// Defaults() itself, so programmatic enablement gets the same domain
 	// burst/window/volume baselines as YAML-loaded configs.
-	goldenHashDefaults = "0bee03ac400bdca8104e0e4dc4921516580c25f471d848fbfa154a85c8963888"
+	// Re-bumped for signed MCP binary-integrity manifests:
+	// mcp_binary_integrity now carries signature trust settings that can
+	// make runtime launch fail closed before any MCP traffic is handled.
+	goldenHashDefaults = "f3f79a671fc28e0c2378865cc86d9c4f24aafee24f68bd6fff38daf170c25cd7"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -119,7 +122,9 @@ const (
 	// lockstep.
 	// Re-bumped for production-readiness tuning: see
 	// goldenHashDefaults note.
-	goldenHashRichConfig = "80e42dfc77b047fc1fc52a6086f4f07d87ef27471aebd297073d2f6a16db96e5"
+	// Re-bumped for signed MCP binary-integrity manifests: see
+	// goldenHashDefaults note above.
+	goldenHashRichConfig = "1a8ad9890a58f8af2b76fd4998e221bc5691d590c39b213370e75cec80c47209"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/canonical_test.go
+++ b/internal/config/canonical_test.go
@@ -246,6 +246,16 @@ func TestCanonicalPolicyHash_PolicyFieldsDoAffect(t *testing.T) {
 			mut:  func(c *Config) { c.FetchProxy.Monitoring.Blocklist = []string{"evil.example.com"} },
 		},
 		{
+			name: "mcp_binary_integrity.signature_required",
+			mut: func(c *Config) {
+				c.MCPBinaryIntegrity.Enabled = true
+				c.MCPBinaryIntegrity.ManifestPath = "/var/lib/pipelock/mcp-integrity.json"
+				c.MCPBinaryIntegrity.Action = ActionBlock
+				c.MCPBinaryIntegrity.RequireSignature = true
+				c.MCPBinaryIntegrity.TrustedSigner = "release"
+			},
+		},
+		{
 			name: "forward_proxy.sni_verification disabled",
 			mut: func(c *Config) {
 				f := false

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11489,6 +11489,8 @@ func TestValidate_A2AScanning(t *testing.T) {
 func TestValidate_MCPBinaryIntegrity(t *testing.T) {
 	t.Parallel()
 
+	const testMCPIntegrityManifestPath = "/tmp/manifest.json"
+
 	tests := []struct {
 		name    string
 		cfg     func() *Config
@@ -11518,8 +11520,32 @@ func TestValidate_MCPBinaryIntegrity(t *testing.T) {
 			cfg: func() *Config {
 				c := Defaults()
 				c.MCPBinaryIntegrity.Enabled = true
-				c.MCPBinaryIntegrity.ManifestPath = "/tmp/manifest.json"
+				c.MCPBinaryIntegrity.ManifestPath = testMCPIntegrityManifestPath
 				c.MCPBinaryIntegrity.Action = ActionBlock
+				return c
+			},
+		},
+		{
+			name: "signature_requires_trusted_signer",
+			cfg: func() *Config {
+				c := Defaults()
+				c.MCPBinaryIntegrity.Enabled = true
+				c.MCPBinaryIntegrity.ManifestPath = testMCPIntegrityManifestPath
+				c.MCPBinaryIntegrity.Action = ActionBlock
+				c.MCPBinaryIntegrity.RequireSignature = true
+				return c
+			},
+			wantErr: "trusted_signer is required",
+		},
+		{
+			name: "signature_with_trusted_signer",
+			cfg: func() *Config {
+				c := Defaults()
+				c.MCPBinaryIntegrity.Enabled = true
+				c.MCPBinaryIntegrity.ManifestPath = testMCPIntegrityManifestPath
+				c.MCPBinaryIntegrity.Action = ActionBlock
+				c.MCPBinaryIntegrity.RequireSignature = true
+				c.MCPBinaryIntegrity.TrustedSigner = "release"
 				return c
 			},
 		},
@@ -11528,7 +11554,7 @@ func TestValidate_MCPBinaryIntegrity(t *testing.T) {
 			cfg: func() *Config {
 				c := Defaults()
 				c.MCPBinaryIntegrity.Enabled = true
-				c.MCPBinaryIntegrity.ManifestPath = "/tmp/manifest.json"
+				c.MCPBinaryIntegrity.ManifestPath = testMCPIntegrityManifestPath
 				c.MCPBinaryIntegrity.Action = ActionAllow
 				return c
 			},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11538,6 +11538,19 @@ func TestValidate_MCPBinaryIntegrity(t *testing.T) {
 			wantErr: "trusted_signer is required",
 		},
 		{
+			name: "signature_rejects_whitespace_trusted_signer",
+			cfg: func() *Config {
+				c := Defaults()
+				c.MCPBinaryIntegrity.Enabled = true
+				c.MCPBinaryIntegrity.ManifestPath = testMCPIntegrityManifestPath
+				c.MCPBinaryIntegrity.Action = ActionBlock
+				c.MCPBinaryIntegrity.RequireSignature = true
+				c.MCPBinaryIntegrity.TrustedSigner = " \t\n"
+				return c
+			},
+			wantErr: "trusted_signer is required",
+		},
+		{
 			name: "signature_with_trusted_signer",
 			cfg: func() *Config {
 				c := Defaults()

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -975,9 +975,13 @@ type TaintTrustOverride struct {
 
 // MCPBinaryIntegrity configures pre-spawn hash verification for MCP subprocesses.
 type MCPBinaryIntegrity struct {
-	Enabled      bool   `yaml:"enabled"`
-	ManifestPath string `yaml:"manifest_path"` // path to hash manifest JSON
-	Action       string `yaml:"action"`        // "block" or "warn" (default "warn")
+	Enabled          bool   `yaml:"enabled"`
+	ManifestPath     string `yaml:"manifest_path"`     // path to hash manifest JSON
+	Action           string `yaml:"action"`            // "block" or "warn" (default "warn")
+	RequireSignature bool   `yaml:"require_signature"` // verify detached manifest signature before use
+	SignaturePath    string `yaml:"signature_path"`    // optional; default manifest_path + .sig
+	TrustedSigner    string `yaml:"trusted_signer"`    // keystore identity used to verify manifest signature
+	Keystore         string `yaml:"keystore"`          // optional; default ~/.pipelock
 }
 
 // MCPToolProvenance configures cryptographic provenance verification for MCP tools.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1605,6 +1605,9 @@ func (c *Config) validateMCPBinaryIntegrity() error {
 	if c.MCPBinaryIntegrity.ManifestPath == "" {
 		return fmt.Errorf("mcp_binary_integrity.manifest_path is required when enabled")
 	}
+	if c.MCPBinaryIntegrity.RequireSignature && c.MCPBinaryIntegrity.TrustedSigner == "" {
+		return fmt.Errorf("mcp_binary_integrity.trusted_signer is required when require_signature is true")
+	}
 	switch c.MCPBinaryIntegrity.Action {
 	case ActionWarn, ActionBlock:
 		// valid

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1605,7 +1605,7 @@ func (c *Config) validateMCPBinaryIntegrity() error {
 	if c.MCPBinaryIntegrity.ManifestPath == "" {
 		return fmt.Errorf("mcp_binary_integrity.manifest_path is required when enabled")
 	}
-	if c.MCPBinaryIntegrity.RequireSignature && c.MCPBinaryIntegrity.TrustedSigner == "" {
+	if c.MCPBinaryIntegrity.RequireSignature && strings.TrimSpace(c.MCPBinaryIntegrity.TrustedSigner) == "" {
 		return fmt.Errorf("mcp_binary_integrity.trusted_signer is required when require_signature is true")
 	}
 	switch c.MCPBinaryIntegrity.Action {

--- a/internal/mcp/integrity/integrity.go
+++ b/internal/mcp/integrity/integrity.go
@@ -114,7 +114,13 @@ func LoadManifest(path string) (*Manifest, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading manifest: %w", err)
 	}
+	return ParseManifest(data)
+}
 
+// ParseManifest unmarshals an in-memory manifest blob. Useful for callers
+// that have already read the bytes (e.g. after signature verification) and
+// must avoid a re-read TOCTOU window.
+func ParseManifest(data []byte) (*Manifest, error) {
 	var m Manifest
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, fmt.Errorf("parsing manifest: %w", err)
@@ -179,13 +185,14 @@ func SaveManifest(path string, m *Manifest) error {
 	return nil
 }
 
-// Verify resolves the command binary path, hashes the file, and checks
-// against the manifest. For interpreters it hashes both the interpreter
-// and the script. Returns a VerifyResult describing the outcome.
+// Resolve resolves the command binary path and hashes the file. For
+// interpreters it hashes both the interpreter and the script. It does not
+// compare against a manifest; callers that are building a manifest can use
+// this without manufacturing an empty verification policy.
 //
-// agentWorkDir, when non-empty, triggers suspicious-path detection:
-// a resolved binary inside the agent's working directory is flagged.
-func Verify(command []string, cfg *Config, agentWorkDir string) (*VerifyResult, error) {
+// workDir, when non-empty, is used for suspicious-path detection and for
+// resolving relative script arguments the same way the subprocess cwd will.
+func Resolve(command []string, workDir string) (*VerifyResult, error) {
 	if len(command) == 0 {
 		return nil, fmt.Errorf("empty command")
 	}
@@ -200,8 +207,8 @@ func Verify(command []string, cfg *Config, agentWorkDir string) (*VerifyResult, 
 	result.ResolvedPath = resolved
 
 	// Check if binary is inside the agent working directory.
-	if agentWorkDir != "" {
-		result.Suspicious = isInsideDir(resolved, agentWorkDir)
+	if workDir != "" {
+		result.Suspicious = isInsideDir(resolved, workDir)
 	}
 
 	// Hash the binary via fd (mitigates read-after-open races but not
@@ -247,7 +254,7 @@ func Verify(command []string, cfg *Config, agentWorkDir string) (*VerifyResult, 
 
 			// Hash the script argument (first arg after interpreter) if present.
 			if len(remaining) > 1 {
-				scriptPath, scriptHash, shebangErr := hashScript(remaining[1], agentWorkDir)
+				scriptPath, scriptHash, shebangErr := hashScript(remaining[1], workDir)
 				if shebangErr != nil {
 					return nil, fmt.Errorf("hashing script %q: %w", remaining[1], shebangErr)
 				}
@@ -257,7 +264,7 @@ func Verify(command []string, cfg *Config, agentWorkDir string) (*VerifyResult, 
 		}
 	} else if result.IsInterpreter && len(command) > 1 {
 		// Standard interpreter invocation: hash the script argument.
-		scriptPath, scriptHash, shebangErr := hashScript(command[1], agentWorkDir)
+		scriptPath, scriptHash, shebangErr := hashScript(command[1], workDir)
 		if shebangErr != nil {
 			return nil, fmt.Errorf("hashing script %q: %w", command[1], shebangErr)
 		}
@@ -288,8 +295,23 @@ func Verify(command []string, cfg *Config, agentWorkDir string) (*VerifyResult, 
 		}
 	}
 
+	return result, nil
+}
+
+// Verify resolves the command binary path, hashes the file, and checks
+// against the manifest. For interpreters it hashes both the interpreter
+// and the script. Returns a VerifyResult describing the outcome.
+//
+// agentWorkDir, when non-empty, triggers suspicious-path detection:
+// a resolved binary inside the agent's working directory is flagged.
+func Verify(command []string, cfg *Config, agentWorkDir string) (*VerifyResult, error) {
+	result, err := Resolve(command, agentWorkDir)
+	if err != nil {
+		return nil, err
+	}
+
 	// Verify against manifest. Fail-closed: no manifest = not verified.
-	if cfg.Manifests == nil {
+	if cfg == nil || cfg.Manifests == nil {
 		result.Verified = false
 		result.Reason = "no manifest loaded"
 		result.Reasons = append(result.Reasons, "no manifest loaded")

--- a/internal/mcp/integrity/integrity_test.go
+++ b/internal/mcp/integrity/integrity_test.go
@@ -803,6 +803,38 @@ func TestCheckSymlinkRace_BinaryRemoved(t *testing.T) {
 
 // --- ResolveAndHash Tests ---
 
+func TestResolve_InterpreterWithScriptNoManifestPolicy(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("test uses POSIX shell command")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "server.sh")
+	if err := os.WriteFile(script, []byte("echo mcp\n"), 0o600); err != nil {
+		t.Fatalf("writing script: %v", err)
+	}
+
+	result, err := Resolve([]string{"sh", "server.sh"}, dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if result.ResolvedPath == "" || result.ActualHash == "" {
+		t.Fatalf("Resolve should hash the interpreter: %+v", result)
+	}
+	resolvedScript, err := filepath.EvalSymlinks(script)
+	if err != nil {
+		t.Fatalf("resolving script: %v", err)
+	}
+	if result.ScriptPath != resolvedScript {
+		t.Fatalf("ScriptPath = %q, want %q", result.ScriptPath, resolvedScript)
+	}
+	if result.ScriptHash == "" {
+		t.Fatalf("Resolve should hash the script: %+v", result)
+	}
+	if result.Verified || result.Reason != "" || len(result.Reasons) != 0 {
+		t.Fatalf("Resolve should not perform manifest verification: %+v", result)
+	}
+}
+
 func TestResolveAndHash_ValidBinary(t *testing.T) {
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "bin")

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -5,6 +5,7 @@ package mcp
 
 import (
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,6 +28,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	session "github.com/luckyPipewrench/pipelock/internal/session"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 // ErrSubprocessExit indicates the wrapped MCP server process exited with a
@@ -1277,13 +1279,18 @@ func VerifyBinaryIntegrity(command []string, icfg *config.MCPBinaryIntegrity, lo
 		Action:       icfg.Action,
 	}
 
-	// Load the manifest from disk. Fail-closed: load errors are fatal
-	// when action is "block", logged as warnings otherwise. When the
-	// manifest fails to load, skip Verify (it would only repeat "no
-	// manifest loaded" with less context).
-	manifest, loadErr := integrity.LoadManifest(icfg.ManifestPath)
+	// Load the manifest. When require_signature is set, the manifest
+	// bytes are read once, the detached signature is verified against
+	// those exact bytes, and the in-memory bytes are parsed. Re-reading
+	// the file after verification would open a TOCTOU window where an
+	// attacker with write access to the manifest path could swap the
+	// file between sig-verify and parse. Fail-closed: load errors are
+	// fatal when action is "block", logged as warnings otherwise, EXCEPT
+	// when require_signature=true: trust-establishment failures always
+	// block regardless of action.
+	manifest, loadErr := loadMCPIntegrityManifest(icfg)
 	if loadErr != nil {
-		if icfg.Action == config.ActionBlock {
+		if icfg.RequireSignature || icfg.Action == config.ActionBlock {
 			return fmt.Errorf("binary integrity: loading manifest: %w", loadErr)
 		}
 		_, _ = fmt.Fprintf(logW, "pipelock: binary integrity warning: %v\n", loadErr)
@@ -1309,4 +1316,51 @@ func VerifyBinaryIntegrity(command []string, icfg *config.MCPBinaryIntegrity, lo
 	}
 
 	return nil
+}
+
+// loadMCPIntegrityManifest reads the manifest, optionally verifying its
+// detached signature, and returns the parsed manifest. When
+// RequireSignature is true the bytes used for parsing are the exact bytes
+// the signature was verified against — no second os.ReadFile, no TOCTOU
+// window between trust establishment and parse.
+func loadMCPIntegrityManifest(icfg *config.MCPBinaryIntegrity) (*integrity.Manifest, error) {
+	if icfg.RequireSignature {
+		pubKey, sigPath, err := resolveMCPManifestSigner(icfg)
+		if err != nil {
+			return nil, err
+		}
+		data, err := signing.LoadAndVerifyFile(icfg.ManifestPath, sigPath, pubKey)
+		if err != nil {
+			return nil, fmt.Errorf("verifying manifest signature: %w", err)
+		}
+		return integrity.ParseManifest(data)
+	}
+	return integrity.LoadManifest(icfg.ManifestPath)
+}
+
+// resolveMCPManifestSigner loads the trusted signer's public key and
+// resolves the signature path according to the integrity config. The
+// returned signature path is always non-empty.
+func resolveMCPManifestSigner(icfg *config.MCPBinaryIntegrity) (ed25519.PublicKey, string, error) {
+	if icfg.TrustedSigner == "" {
+		return nil, "", fmt.Errorf("trusted signer is required")
+	}
+	keystoreDir := icfg.Keystore
+	if keystoreDir == "" {
+		var err error
+		keystoreDir, err = signing.DefaultKeystorePath()
+		if err != nil {
+			return nil, "", err
+		}
+	}
+	sigPath := icfg.SignaturePath
+	if sigPath == "" {
+		sigPath = icfg.ManifestPath + signing.SigExtension
+	}
+	ks := signing.NewKeystore(keystoreDir)
+	pubKey, err := ks.ResolvePublicKey(icfg.TrustedSigner)
+	if err != nil {
+		return nil, "", fmt.Errorf("loading trusted signer %q: %w", icfg.TrustedSigner, err)
+	}
+	return pubKey, sigPath, nil
 }

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -1342,8 +1342,11 @@ func loadMCPIntegrityManifest(icfg *config.MCPBinaryIntegrity) (*integrity.Manif
 // resolves the signature path according to the integrity config. The
 // returned signature path is always non-empty.
 func resolveMCPManifestSigner(icfg *config.MCPBinaryIntegrity) (ed25519.PublicKey, string, error) {
-	if icfg.TrustedSigner == "" {
-		return nil, "", fmt.Errorf("trusted signer is required")
+	if err := signing.ValidateAgentName(icfg.TrustedSigner); err != nil {
+		if icfg.TrustedSigner == "" {
+			return nil, "", fmt.Errorf("trusted signer is required")
+		}
+		return nil, "", fmt.Errorf("invalid trusted signer %q: %w", icfg.TrustedSigner, err)
 	}
 	keystoreDir := icfg.Keystore
 	if keystoreDir == "" {

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -3179,6 +3179,218 @@ func TestVerifyBinaryIntegrity_UsesWorkDirForRelativeScripts(t *testing.T) {
 	}
 }
 
+func TestVerifyBinaryIntegrity_RequiresTrustedManifestSignature(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("hash test requires unix")
+	}
+	truePath, trueHash, err := integrity.ResolveAndHash("true")
+	if err != nil {
+		t.Fatalf("resolving true binary: %v", err)
+	}
+	dir := t.TempDir()
+	ksDir := filepath.Join(dir, "keys")
+	ks := signing.NewKeystore(ksDir)
+	if _, err := ks.GenerateAgent("signer"); err != nil {
+		t.Fatalf("generate signer: %v", err)
+	}
+	privKey, err := ks.LoadPrivateKey("signer")
+	if err != nil {
+		t.Fatalf("load signer key: %v", err)
+	}
+	mpath := filepath.Join(dir, "manifest.json")
+	if err := integrity.SaveManifest(mpath, &integrity.Manifest{
+		Version: integrity.ManifestVersion,
+		Entries: map[string]string{
+			truePath: trueHash,
+		},
+	}); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	sig, err := signing.SignFile(mpath, privKey)
+	if err != nil {
+		t.Fatalf("sign manifest: %v", err)
+	}
+	if err := signing.SaveSignature(sig, mpath+signing.SigExtension); err != nil {
+		t.Fatalf("save signature: %v", err)
+	}
+
+	icfg := &config.MCPBinaryIntegrity{
+		Enabled:          true,
+		ManifestPath:     mpath,
+		Action:           config.ActionBlock,
+		RequireSignature: true,
+		TrustedSigner:    "signer",
+		Keystore:         ksDir,
+	}
+	var logBuf bytes.Buffer
+	if err := VerifyBinaryIntegrity([]string{"true"}, icfg, &logBuf); err != nil {
+		t.Fatalf("verify signed manifest: %v", err)
+	}
+
+	if err := integrity.SaveManifest(mpath, &integrity.Manifest{
+		Version: integrity.ManifestVersion,
+		Entries: map[string]string{
+			truePath: strings.Repeat("0", 64),
+		},
+	}); err != nil {
+		t.Fatalf("tamper manifest: %v", err)
+	}
+	err = VerifyBinaryIntegrity([]string{"true"}, icfg, &logBuf)
+	if err == nil {
+		t.Fatal("expected signature verification failure for tampered manifest")
+	}
+	if !strings.Contains(err.Error(), "manifest signature") {
+		t.Fatalf("error = %v, want manifest signature", err)
+	}
+}
+
+func TestVerifyBinaryIntegrity_RequireSignatureBlocksInWarnMode(t *testing.T) {
+	// require_signature is fail-closed regardless of action. action=warn
+	// must not relax trust establishment: a tampered manifest under
+	// require_signature must block even when hash-mismatch handling
+	// would otherwise be a warning.
+	if runtime.GOOS == osWindows {
+		t.Skip("hash test requires unix")
+	}
+	truePath, trueHash, err := integrity.ResolveAndHash("true")
+	if err != nil {
+		t.Fatalf("resolving true binary: %v", err)
+	}
+	dir := t.TempDir()
+	ksDir := filepath.Join(dir, "keys")
+	ks := signing.NewKeystore(ksDir)
+	if _, err := ks.GenerateAgent("signer"); err != nil {
+		t.Fatalf("generate signer: %v", err)
+	}
+	privKey, err := ks.LoadPrivateKey("signer")
+	if err != nil {
+		t.Fatalf("load signer key: %v", err)
+	}
+	mpath := filepath.Join(dir, "manifest.json")
+	if err := integrity.SaveManifest(mpath, &integrity.Manifest{
+		Version: integrity.ManifestVersion,
+		Entries: map[string]string{truePath: trueHash},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	sig, err := signing.SignFile(mpath, privKey)
+	if err != nil {
+		t.Fatalf("sign manifest: %v", err)
+	}
+	if err := signing.SaveSignature(sig, mpath+signing.SigExtension); err != nil {
+		t.Fatalf("save signature: %v", err)
+	}
+
+	icfg := &config.MCPBinaryIntegrity{
+		Enabled:          true,
+		ManifestPath:     mpath,
+		Action:           config.ActionWarn, // warn — must NOT relax trust
+		RequireSignature: true,
+		TrustedSigner:    "signer",
+		Keystore:         ksDir,
+	}
+
+	// First: untampered manifest verifies fine even under warn.
+	var logBuf bytes.Buffer
+	if err := VerifyBinaryIntegrity([]string{"true"}, icfg, &logBuf); err != nil {
+		t.Fatalf("warn-mode signed manifest should verify: %v", err)
+	}
+
+	// Then: tamper the manifest and confirm warn-mode STILL blocks
+	// because require_signature is independent of action.
+	if err := integrity.SaveManifest(mpath, &integrity.Manifest{
+		Version: integrity.ManifestVersion,
+		Entries: map[string]string{truePath: strings.Repeat("0", 64)},
+	}); err != nil {
+		t.Fatalf("tamper manifest: %v", err)
+	}
+	if err := VerifyBinaryIntegrity([]string{"true"}, icfg, &logBuf); err == nil {
+		t.Fatal("expected warn-mode + require_signature to block on tampered manifest")
+	} else if !strings.Contains(err.Error(), "manifest signature") {
+		t.Fatalf("error = %v, want manifest signature failure", err)
+	}
+}
+
+func TestVerifyBinaryIntegrity_RequireSignatureMissingSigFile(t *testing.T) {
+	// Missing .sig file under require_signature is fail-closed regardless
+	// of action. Otherwise an operator could remove the signature file to
+	// implicitly downgrade trust without changing config.
+	if runtime.GOOS == osWindows {
+		t.Skip("hash test requires unix")
+	}
+	dir := t.TempDir()
+	ksDir := filepath.Join(dir, "keys")
+	ks := signing.NewKeystore(ksDir)
+	if _, err := ks.GenerateAgent("signer"); err != nil {
+		t.Fatalf("generate signer: %v", err)
+	}
+	mpath := filepath.Join(dir, "manifest.json")
+	if err := integrity.SaveManifest(mpath, &integrity.Manifest{
+		Version: integrity.ManifestVersion,
+		Entries: map[string]string{"/usr/bin/true": "deadbeef"},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	// Note: no signing.SaveSignature call — the .sig file is intentionally absent.
+
+	for _, action := range []string{config.ActionBlock, config.ActionWarn} {
+		icfg := &config.MCPBinaryIntegrity{
+			Enabled:          true,
+			ManifestPath:     mpath,
+			Action:           action,
+			RequireSignature: true,
+			TrustedSigner:    "signer",
+			Keystore:         ksDir,
+		}
+		var logBuf bytes.Buffer
+		err := VerifyBinaryIntegrity([]string{"true"}, icfg, &logBuf)
+		if err == nil {
+			t.Fatalf("action=%s: expected missing-signature failure", action)
+		}
+		if !strings.Contains(err.Error(), "manifest signature") {
+			t.Fatalf("action=%s: error = %v, want manifest signature", action, err)
+		}
+	}
+}
+
+func TestVerifyBinaryIntegrity_RequireSignatureUnknownSigner(t *testing.T) {
+	// Trusted signer not present in keystore must fail-closed regardless
+	// of action: an unresolvable signer cannot establish trust.
+	if runtime.GOOS == osWindows {
+		t.Skip("hash test requires unix")
+	}
+	dir := t.TempDir()
+	ksDir := filepath.Join(dir, "keys")
+	// Note: keystore exists but is empty — no key generated for "signer".
+	if err := os.MkdirAll(ksDir, 0o700); err != nil {
+		t.Fatalf("mkdir keystore: %v", err)
+	}
+	mpath := filepath.Join(dir, "manifest.json")
+	if err := integrity.SaveManifest(mpath, &integrity.Manifest{
+		Version: integrity.ManifestVersion,
+		Entries: map[string]string{"/usr/bin/true": "deadbeef"},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+
+	icfg := &config.MCPBinaryIntegrity{
+		Enabled:          true,
+		ManifestPath:     mpath,
+		Action:           config.ActionWarn,
+		RequireSignature: true,
+		TrustedSigner:    "signer-not-in-keystore",
+		Keystore:         ksDir,
+	}
+	var logBuf bytes.Buffer
+	err := VerifyBinaryIntegrity([]string{"true"}, icfg, &logBuf)
+	if err == nil {
+		t.Fatal("expected unknown-signer failure")
+	}
+	if !strings.Contains(err.Error(), "signer-not-in-keystore") {
+		t.Fatalf("error = %v, want signer name in error", err)
+	}
+}
+
 func TestVerifyBinaryIntegrity_BlockOnVerifyError(t *testing.T) {
 	// Create a valid manifest so LoadManifest succeeds, then pass a
 	// nonexistent binary so integrity.Verify returns an error.

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -3391,6 +3391,34 @@ func TestVerifyBinaryIntegrity_RequireSignatureUnknownSigner(t *testing.T) {
 	}
 }
 
+func TestVerifyBinaryIntegrity_RequireSignatureRejectsInvalidSignerName(t *testing.T) {
+	dir := t.TempDir()
+	mpath := filepath.Join(dir, "manifest.json")
+	if err := integrity.SaveManifest(mpath, &integrity.Manifest{
+		Version: integrity.ManifestVersion,
+		Entries: map[string]string{"/usr/bin/true": "deadbeef"},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+
+	icfg := &config.MCPBinaryIntegrity{
+		Enabled:          true,
+		ManifestPath:     mpath,
+		Action:           config.ActionWarn,
+		RequireSignature: true,
+		TrustedSigner:    "../signer",
+		Keystore:         filepath.Join(dir, "keys"),
+	}
+	var logBuf bytes.Buffer
+	err := VerifyBinaryIntegrity([]string{"true"}, icfg, &logBuf)
+	if err == nil {
+		t.Fatal("expected invalid-signer failure")
+	}
+	if !strings.Contains(err.Error(), "invalid trusted signer") {
+		t.Fatalf("error = %v, want invalid trusted signer", err)
+	}
+}
+
 func TestVerifyBinaryIntegrity_BlockOnVerifyError(t *testing.T) {
 	// Create a valid manifest so LoadManifest succeeds, then pass a
 	// nonexistent binary so integrity.Verify returns an error.

--- a/internal/signing/signing.go
+++ b/internal/signing/signing.go
@@ -49,24 +49,35 @@ func SignFile(path string, privKey ed25519.PrivateKey) ([]byte, error) {
 // VerifyFile reads a file and its detached signature, verifying against pubKey.
 // If sigPath is empty, it defaults to path + SigExtension.
 func VerifyFile(path, sigPath string, pubKey ed25519.PublicKey) error {
+	_, err := LoadAndVerifyFile(path, sigPath, pubKey)
+	return err
+}
+
+// LoadAndVerifyFile reads a file and its detached signature, verifies the
+// signature against pubKey, and returns the bytes that were verified.
+// Callers that intend to parse the file after verifying should use the
+// returned bytes rather than re-reading from disk: re-reading opens a
+// TOCTOU window where the file can be replaced between sig verify and
+// parse. If sigPath is empty, it defaults to path + SigExtension.
+func LoadAndVerifyFile(path, sigPath string, pubKey ed25519.PublicKey) ([]byte, error) {
 	if sigPath == "" {
 		sigPath = path + SigExtension
 	}
 
 	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
-		return fmt.Errorf("reading file to verify: %w", err)
+		return nil, fmt.Errorf("reading file to verify: %w", err)
 	}
 
 	sig, err := LoadSignature(sigPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !ed25519.Verify(pubKey, data, sig) {
-		return fmt.Errorf("signature verification failed")
+		return nil, fmt.Errorf("signature verification failed")
 	}
-	return nil
+	return data, nil
 }
 
 // SaveSignature writes a base64-encoded signature to a .sig file.


### PR DESCRIPTION
## Summary
- add `mcpintegrity.Resolve` for resolve/hash without manifest verification
- add `pipelock mcp integrity manifest sign|verify-signature`
- allow `mcp_binary_integrity` to require a trusted detached manifest signature before runtime use
- make required manifest signatures fail closed regardless of hash-mismatch action
- parse the exact manifest bytes verified by the signature check to avoid verify-then-read drift
- document the signed-manifest workflow and config fields
- intentionally bump canonical policy hashes for the new signed-manifest enforcement surface

## Validation
- go test -race -count=1 ./internal/signing ./internal/mcp/integrity ./internal/mcp ./internal/cli/runtime ./internal/config
- golangci-lint run ./...
- go test -race -count=1 ./...
- git diff --check origin/main...HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detached signature support for MCP binary integrity manifests, CLI sign/verify commands, and runtime signature enforcement that is fail-closed.

* **Configuration**
  * New options to require signatures, specify signature path, trusted signer, and keystore; enforcing trusted_signer when signatures are required.

* **Documentation**
  * Added "Sign and Trust" workflow and updated configuration guidance and tooling steps.

* **Tests**
  * Coverage for sign/verify, tamper detection, signer setup, and runtime enforcement scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->