### PR TITLE
Add MCP launcher config contract

### DIFF
--- a/docs/cli/init-sidecar.md
+++ b/docs/cli/init-sidecar.md
@@ -17,6 +17,7 @@ pipelock init sidecar --inject-spec <manifest>
   [--json]
   [--agent-identity <name>]
   [--mcp-upstream <http-url>]
+  [--mcp-server-name <name>]
 ```
 
 ## Description
@@ -33,7 +34,7 @@ The generated bundle includes:
 - A proxy NetworkPolicy that allows agent ingress and standard web egress for the pipelock proxy pods
 - A PodDisruptionBudget that keeps at least one proxy replica available during voluntary disruptions
 
-When `--mcp-upstream` is set, the bundle also exposes the companion proxy's MCP listener on port `8889`, injects `PIPELOCK_MCP_PROXY_URL` into the agent workload, and updates NetworkPolicies so the agent can reach only the Pipelock MCP listener while the proxy can reach the configured upstream MCP endpoint.
+When `--mcp-upstream` is set, the bundle also exposes the companion proxy's MCP listener on port `8889`, injects `PIPELOCK_MCP_PROXY_URL` and `PIPELOCK_MCP_CONFIG` into the agent workload, mounts a generated `mcp.json` file at `/etc/pipelock/mcp/mcp.json`, and updates NetworkPolicies so the agent can reach only the Pipelock MCP listener while the proxy can reach the configured upstream MCP endpoint.
 
 This is not same-pod sidecar injection. The enforcement boundary comes from pod-scoped NetworkPolicies plus a separate pipelock proxy workload, not from trusting application containers to honor proxy environment variables on their own.
 
@@ -54,7 +55,8 @@ The command runs 7 phases: detect, generate, preview, emit, verify, canary, and 
 | `--skip-verify` | false | Skip static topology verification |
 | `--json` | false | Machine-readable JSON output (`--output` required unless `--dry-run`) |
 | `--agent-identity` | `<kind>/<name>` | Default agent identity for attribution |
-| `--mcp-upstream` | unset | Optional upstream MCP HTTP/SSE URL. When set, the companion proxy exposes `PIPELOCK_MCP_PROXY_URL=http://<proxy>:8889` for agent MCP client configuration. |
+| `--mcp-upstream` | unset | Optional upstream MCP HTTP/SSE URL. When set, the companion proxy exposes `PIPELOCK_MCP_PROXY_URL=http://<proxy>:8889` and mounts a generated MCP client config. |
+| `--mcp-server-name` | `pipelock` | Server name used inside the generated `mcp.json` when `--mcp-upstream` is set. |
 
 ## Supported Workload Kinds
 
@@ -73,11 +75,12 @@ Writes the full enforced topology as multi-document YAML:
 
 1. Patched agent workload
 2. Pipelock ConfigMap
-3. Pipelock Deployment
-4. Pipelock Service
-5. Agent NetworkPolicy
-6. Pipelock NetworkPolicy
-7. Pipelock PodDisruptionBudget
+3. Optional MCP client ConfigMap when `--mcp-upstream` is set
+4. Pipelock Deployment
+5. Pipelock Service
+6. Agent NetworkPolicy
+7. Pipelock NetworkPolicy
+8. Pipelock PodDisruptionBudget
 
 ```bash
 pipelock init sidecar --inject-spec deployment.yaml --output enforced.yaml
@@ -92,6 +95,7 @@ Generated files:
 
 - `agent-workload.yaml`
 - `pipelock-configmap.yaml`
+- `pipelock-mcp-configmap.yaml` when `--mcp-upstream` is set
 - `pipelock-deployment.yaml`
 - `pipelock-service.yaml`
 - `agent-networkpolicy.yaml`
@@ -112,6 +116,7 @@ Generated files:
 
 - `values.yaml`
 - `agent-workload.yaml`
+- `pipelock-mcp-configmap.yaml` when `--mcp-upstream` is set
 - `agent-networkpolicy.yaml`
 - `pipelock-networkpolicy.yaml`
 - `pipelock-pdb.yaml`
@@ -153,10 +158,13 @@ pipelock init sidecar --inject-spec job.yaml --agent-identity ci-team/nightly-sc
 pipelock init sidecar \
   --inject-spec deployment.yaml \
   --mcp-upstream http://openclaw-gateway:3000/mcp \
+  --mcp-server-name openclaw \
   --output enforced.yaml
 ```
 
-The generated workload receives `PIPELOCK_MCP_PROXY_URL=http://<proxy-service>:8889`. Configure the agent's MCP client or launcher to use that URL. The NetworkPolicy limits the agent pod to DNS plus the Pipelock HTTP and MCP proxy ports, so direct HTTP egress to the upstream MCP gateway is not part of the generated agent boundary.
+The generated workload receives `PIPELOCK_MCP_PROXY_URL=http://<proxy-service>:8889` and `PIPELOCK_MCP_CONFIG=/etc/pipelock/mcp/mcp.json`. That file contains a top-level `mcpServers` object whose configured server URL points at the Pipelock MCP listener, not at the upstream gateway. Configure the agent launcher to read `PIPELOCK_MCP_CONFIG`, or configure the MCP client directly from `PIPELOCK_MCP_PROXY_URL`.
+
+The NetworkPolicy limits the agent pod to DNS plus the Pipelock HTTP and MCP proxy ports, so direct HTTP egress to the upstream MCP gateway is not part of the generated agent boundary.
 
 ### CronJob with kustomize output
 
@@ -189,7 +197,7 @@ The verify phase is static. It confirms the generated topology has the expected 
 
 - forward proxy mode enabled
 - cluster-reachable proxy listeners
-- optional MCP listener and NetworkPolicy ports when `--mcp-upstream` is set
+- optional MCP listener, mounted MCP client config, and NetworkPolicy ports when `--mcp-upstream` is set
 - agent NetworkPolicy allows DNS plus the pipelock proxy port only
 - proxy NetworkPolicy allows agent ingress and standard web egress
 
@@ -211,12 +219,12 @@ Direct `80/443` web egress is reserved for the pipelock companion pods, not the 
 
 DNS egress is intentionally left unrestricted at the NetworkPolicy layer for cluster portability. This command does not block DNS tunneling by policy alone.
 
-`--mcp-upstream` does not rewrite arbitrary application MCP client settings by itself. It creates the enforced cluster path and exposes the `PIPELOCK_MCP_PROXY_URL` contract; the agent image, launcher, or config must consume that value for MCP traffic to traverse Pipelock.
+`--mcp-upstream` does not rewrite arbitrary application MCP client settings by itself. It creates the enforced cluster path and exposes two launcher inputs: `PIPELOCK_MCP_CONFIG=/etc/pipelock/mcp/mcp.json` and `PIPELOCK_MCP_PROXY_URL=http://<proxy-service>:8889`. The agent image, launcher, or config must consume one of those values for MCP traffic to traverse Pipelock.
 
 The proxy NetworkPolicy egress rule for the upstream port has no destination selector. Vanilla Kubernetes NetworkPolicies cannot express "only this hostname." If the upstream port is shared with unrelated services in any namespace the proxy can reach, the rule technically allows the proxy to talk to them too. For tighter scoping, edit the generated `proxy-network-policy.yaml` to add a `to:` clause matching the upstream namespace and pod labels.
 
 ## Idempotency
 
-Running `pipelock init sidecar` against a manifest already managed by this command is safe. The workload annotations preserve the generated proxy identity, the command reports the manifest as already patched, and verification can still be rerun against the derived topology.
+Running `pipelock init sidecar` against a manifest already managed by this command is safe. The workload annotations preserve the generated proxy identity, the command reports the manifest as already patched, and verification can still be rerun against the derived topology. If the re-run changes the MCP contract, for example enabling or disabling `--mcp-upstream`, the command emits the updated workload instead of treating the manifest as a no-op.
 
-Re-running against a manifest previously generated with `--mcp-upstream`, but without the flag this time, scrubs the prior `PIPELOCK_MCP_PROXY_URL` env entry and the `pipelock.dev/mcp-proxy-service` / `pipelock.dev/mcp-upstream` annotations so the agent does not advertise a contract the regenerated Service no longer fulfills.
+Re-running against a manifest previously generated with `--mcp-upstream`, but without the flag this time, scrubs the prior `PIPELOCK_MCP_PROXY_URL` and `PIPELOCK_MCP_CONFIG` env entries, the generated MCP ConfigMap mount, and the MCP contract annotations so the agent does not advertise a contract the regenerated Service no longer fulfills.

--- a/docs/guides/openclaw.md
+++ b/docs/guides/openclaw.md
@@ -161,11 +161,17 @@ For enforced cluster deployments, generate a companion-proxy topology and point 
 pipelock init sidecar \
   --inject-spec agent-deployment.yaml \
   --mcp-upstream http://openclaw-gateway:3000/mcp \
+  --mcp-server-name openclaw \
   --output enforced.yaml
 kubectl apply -f enforced.yaml
 ```
 
-The generated agent workload gets `HTTPS_PROXY` and `HTTP_PROXY` for HTTP egress plus `PIPELOCK_MCP_PROXY_URL=http://<pipelock-service>:8889` for MCP client configuration. Configure your agent or launcher to use that MCP URL. The generated NetworkPolicy limits the agent pod to DNS plus the Pipelock HTTP and MCP proxy ports, so direct egress to the OpenClaw gateway is outside the generated agent boundary.
+The generated agent workload gets `HTTPS_PROXY` and `HTTP_PROXY` for HTTP egress, plus two MCP launcher inputs:
+
+- `PIPELOCK_MCP_PROXY_URL=http://<pipelock-service>:8889`
+- `PIPELOCK_MCP_CONFIG=/etc/pipelock/mcp/mcp.json`
+
+The mounted `mcp.json` contains an `mcpServers.openclaw` entry whose URL points at Pipelock's MCP listener. Configure your agent launcher to read `PIPELOCK_MCP_CONFIG`, or configure the MCP client directly from `PIPELOCK_MCP_PROXY_URL`. The generated NetworkPolicy limits the agent pod to DNS plus the Pipelock HTTP and MCP proxy ports, so direct egress to the OpenClaw gateway is outside the generated agent boundary.
 
 Same-pod sidecar wiring is still useful for local prototypes, but it relies on the agent honoring proxy settings and is not the generated enforced topology:
 

--- a/internal/cli/setup/sidecar.go
+++ b/internal/cli/setup/sidecar.go
@@ -380,6 +380,7 @@ func validateSidecarMCPServerName(raw string) error {
 func sidecarMCPContractChanged(raw map[string]interface{}, opts sidecarOptions) bool {
 	existingProxy := extractAnnotation(raw, managedMCPProxyAnnotation)
 	existingUpstream := extractAnnotation(raw, managedMCPUpstreamAnnotation)
+	existingUpstreamHash := extractAnnotation(raw, managedMCPUpstreamHash)
 	existingConfig := extractAnnotation(raw, managedMCPConfigAnnotation)
 	existingServerName := extractAnnotation(raw, managedMCPServerAnnotation)
 	if opts.mcpUpstream == "" {
@@ -388,13 +389,14 @@ func sidecarMCPContractChanged(raw map[string]interface{}, opts sidecarOptions) 
 		// them. Fall back to inspecting env vars and the MCP ConfigMap
 		// volume so a disable run always emits a scrubbed manifest when
 		// MCP state is present, even if the annotations are gone.
-		if existingProxy != "" || existingUpstream != "" || existingConfig != "" || existingServerName != "" {
+		if existingProxy != "" || existingUpstream != "" || existingUpstreamHash != "" || existingConfig != "" || existingServerName != "" {
 			return true
 		}
 		return rawWorkloadHasMCPState(raw)
 	}
 	return existingProxy == "" ||
-		existingUpstream != opts.mcpUpstream ||
+		existingUpstream != managedAnnotationEnabled ||
+		existingUpstreamHash != mcpUpstreamFingerprint(opts.mcpUpstream) ||
 		existingConfig != sidecarMCPConfigPath() ||
 		existingServerName != resolveMCPServerName(opts.mcpServerName)
 }

--- a/internal/cli/setup/sidecar.go
+++ b/internal/cli/setup/sidecar.go
@@ -33,6 +33,7 @@ type sidecarOptions struct {
 	jsonOutput    bool
 	agentIdentity string
 	mcpUpstream   string
+	mcpServerName string
 }
 
 // sidecarResult holds the outcome of each phase for JSON reporting.
@@ -54,6 +55,8 @@ type sidecarPatchSummary struct {
 	OutputPath    string `json:"output_path,omitempty"`
 	AgentIdentity string `json:"agent_identity"`
 	MCPProxyURL   string `json:"mcp_proxy_url,omitempty"`
+	MCPConfigPath string `json:"mcp_config_path,omitempty"`
+	MCPServerName string `json:"mcp_server_name,omitempty"`
 	Written       bool   `json:"written"`
 	DryRun        bool   `json:"dry_run"`
 }
@@ -83,7 +86,7 @@ Examples:
   pipelock init sidecar --inject-spec deployment.yaml --emit kustomize --output ./pipelock-overlay
   pipelock init sidecar --inject-spec statefulset.yaml --emit helm-values --output ./pipelock-helm-bundle
   pipelock init sidecar --inject-spec cronjob.yaml --preset strict --agent-identity my-team/bot
-  pipelock init sidecar --inject-spec deployment.yaml --mcp-upstream http://openclaw:3000/mcp`,
+  pipelock init sidecar --inject-spec deployment.yaml --mcp-upstream http://openclaw:3000/mcp --mcp-server-name openclaw`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -103,6 +106,7 @@ Examples:
 	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "machine-readable JSON output")
 	cmd.Flags().StringVar(&opts.agentIdentity, "agent-identity", "", "default agent identity (default: <kind>/<name>)")
 	cmd.Flags().StringVar(&opts.mcpUpstream, "mcp-upstream", "", "upstream MCP HTTP/SSE URL to expose through the companion proxy")
+	cmd.Flags().StringVar(&opts.mcpServerName, "mcp-server-name", defaultMCPServerName, "server name for generated mcp.json when --mcp-upstream is set")
 
 	_ = cmd.MarkFlagRequired("inject-spec")
 
@@ -132,6 +136,9 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 	if err := validateSidecarMCPUpstream(opts.mcpUpstream); err != nil {
 		return cliutil.ExitCodeError(initExitError, err)
 	}
+	if err := validateSidecarMCPServerName(opts.mcpServerName); err != nil {
+		return cliutil.ExitCodeError(initExitError, err)
+	}
 
 	result := &sidecarResult{}
 
@@ -149,6 +156,7 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 	}
 
 	alreadyPatched := hasPipelockTopology(manifest.Raw)
+	mcpContractChanged := alreadyPatched && sidecarMCPContractChanged(manifest.Raw, opts)
 
 	result.Detect = &sidecarDetectResult{
 		Kind:           manifest.Kind,
@@ -160,7 +168,11 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 		_, _ = fmt.Fprintf(w, "  Kind: %s\n", manifest.Kind)
 		_, _ = fmt.Fprintf(w, "  Name: %s\n", manifest.Name)
 		if alreadyPatched {
-			_, _ = fmt.Fprintln(w, "  Status: already patched (companion proxy annotations found)")
+			if mcpContractChanged {
+				_, _ = fmt.Fprintln(w, "  Status: already patched (MCP contract update requested)")
+			} else {
+				_, _ = fmt.Fprintln(w, "  Status: already patched (companion proxy annotations found)")
+			}
 		}
 		_, _ = fmt.Fprintln(w)
 	}
@@ -181,6 +193,7 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 		_, _ = fmt.Fprintf(w, "  Proxy URL: %s\n", patchResult.ProxyURL)
 		if patchResult.MCPProxyURL != "" {
 			_, _ = fmt.Fprintf(w, "  MCP proxy URL: %s -> %s\n", patchResult.MCPProxyURL, patchResult.MCPUpstream)
+			_, _ = fmt.Fprintf(w, "  MCP config: %s (server %q)\n", patchResult.MCPConfigPath, patchResult.MCPServerName)
 		}
 		_, _ = fmt.Fprintf(w, "  Image: %s\n", resolveImage(opts))
 		_, _ = fmt.Fprintf(w, "  Preset: %s\n\n", opts.preset)
@@ -189,7 +202,7 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 	// Phase 3: Preview
 	if !opts.jsonOutput {
 		_, _ = fmt.Fprintln(w, "[3/7] Diff preview:")
-		if alreadyPatched {
+		if alreadyPatched && !mcpContractChanged {
 			_, _ = fmt.Fprintln(w, "  No changes (manifest already patched).")
 		} else {
 			diff, err := renderDiff(manifest, patchResult)
@@ -212,6 +225,8 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 		OutputPath:    opts.output,
 		AgentIdentity: patchResult.AgentIdentity,
 		MCPProxyURL:   patchResult.MCPProxyURL,
+		MCPConfigPath: patchResult.MCPConfigPath,
+		MCPServerName: patchResult.MCPServerName,
 		DryRun:        opts.dryRun,
 	}
 
@@ -220,7 +235,7 @@ func runSidecar(cmd *cobra.Command, opts sidecarOptions) error {
 		if !opts.jsonOutput {
 			_, _ = fmt.Fprintf(w, "  Dry run: would emit %s format\n\n", opts.emit)
 		}
-	} else if alreadyPatched {
+	} else if alreadyPatched && !mcpContractChanged {
 		patchSummary.Written = false
 		if !opts.jsonOutput {
 			_, _ = fmt.Fprintln(w, "  Skipped: manifest already patched.")
@@ -333,6 +348,112 @@ func validateSidecarMCPUpstream(raw string) error {
 	return nil
 }
 
+// maxMCPServerNameLen caps the operator-supplied mcpServers entry name.
+// Server names appear inside the generated mcp.json and as ConfigMap
+// annotations; pathologically long values would bloat the file and the
+// annotation set without serving any downstream client. 64 matches the
+// k8s DNS-label upper bound and is well beyond any real-world MCP server
+// identifier.
+const maxMCPServerNameLen = 64
+
+func validateSidecarMCPServerName(raw string) error {
+	name := strings.TrimSpace(raw)
+	if name == "" {
+		return fmt.Errorf("--mcp-server-name must not be empty")
+	}
+	if len(name) > maxMCPServerNameLen {
+		return fmt.Errorf("--mcp-server-name %q exceeds maximum length %d", raw, maxMCPServerNameLen)
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-', r == '_', r == '.':
+		default:
+			return fmt.Errorf("--mcp-server-name %q may contain only letters, digits, '.', '_' or '-'", raw)
+		}
+	}
+	return nil
+}
+
+func sidecarMCPContractChanged(raw map[string]interface{}, opts sidecarOptions) bool {
+	existingProxy := extractAnnotation(raw, managedMCPProxyAnnotation)
+	existingUpstream := extractAnnotation(raw, managedMCPUpstreamAnnotation)
+	existingConfig := extractAnnotation(raw, managedMCPConfigAnnotation)
+	existingServerName := extractAnnotation(raw, managedMCPServerAnnotation)
+	if opts.mcpUpstream == "" {
+		// Annotations are the primary source of truth, but they can drift
+		// from the actual workload state if an operator manually edits
+		// them. Fall back to inspecting env vars and the MCP ConfigMap
+		// volume so a disable run always emits a scrubbed manifest when
+		// MCP state is present, even if the annotations are gone.
+		if existingProxy != "" || existingUpstream != "" || existingConfig != "" || existingServerName != "" {
+			return true
+		}
+		return rawWorkloadHasMCPState(raw)
+	}
+	return existingProxy == "" ||
+		existingUpstream != opts.mcpUpstream ||
+		existingConfig != sidecarMCPConfigPath() ||
+		existingServerName != resolveMCPServerName(opts.mcpServerName)
+}
+
+// rawWorkloadHasMCPState reports whether the manifest's pod spec still
+// carries any MCP launcher-contract artifact: PIPELOCK_MCP_PROXY_URL or
+// PIPELOCK_MCP_CONFIG env entries, or the MCP client ConfigMap volume /
+// mount. Used as a safety net for annotation drift.
+func rawWorkloadHasMCPState(raw map[string]interface{}) bool {
+	kind, _ := raw["kind"].(string)
+	podSpec, err := getPodSpec(raw, kind)
+	if err != nil || podSpec == nil {
+		return false
+	}
+	if containers, ok := podSpec["containers"].([]interface{}); ok {
+		for _, item := range containers {
+			c, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if envList, ok := c["env"].([]interface{}); ok {
+				for _, envItem := range envList {
+					envMap, ok := envItem.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					name, _ := envMap["name"].(string)
+					if name == envMCPProxy || name == envMCPConfig {
+						return true
+					}
+				}
+			}
+			if mounts, ok := c["volumeMounts"].([]interface{}); ok {
+				for _, m := range mounts {
+					mountMap, ok := m.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					if n, _ := mountMap["name"].(string); n == sidecarMCPConfigVolume {
+						return true
+					}
+				}
+			}
+		}
+	}
+	if volumes, ok := podSpec["volumes"].([]interface{}); ok {
+		for _, v := range volumes {
+			vMap, ok := v.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if n, _ := vMap["name"].(string); n == sidecarMCPConfigVolume {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func mcpUpstreamHostHasMalformedPort(host string) bool {
 	if strings.HasSuffix(host, ":") {
 		return true
@@ -386,6 +507,7 @@ func renderDiff(manifest *workloadManifest, patchResult *sidecarPatchResult) (st
 		_, _ = fmt.Fprintln(&sb, "  + proxy NetworkPolicy: agent ingress + web-only egress")
 		if patchResult.MCPProxyURL != "" {
 			_, _ = fmt.Fprintf(&sb, "  + MCP proxy contract: PIPELOCK_MCP_PROXY_URL=%s\n", patchResult.MCPProxyURL)
+			_, _ = fmt.Fprintf(&sb, "  + MCP launcher config: %s (%s)\n", patchResult.MCPConfigPath, patchResult.MCPServerName)
 		}
 		_, _ = fmt.Fprintln(&sb, "  + companion PodDisruptionBudget: minAvailable=1")
 	}
@@ -405,6 +527,7 @@ func printSidecarSummary(w io.Writer, result *sidecarResult, opts sidecarOptions
 	_, _ = fmt.Fprintf(w, "  Agent identity:  %s\n", result.Patch.AgentIdentity)
 	if result.Patch.MCPProxyURL != "" {
 		_, _ = fmt.Fprintf(w, "  MCP proxy URL:   %s\n", result.Patch.MCPProxyURL)
+		_, _ = fmt.Fprintf(w, "  MCP config:      %s (%s)\n", result.Patch.MCPConfigPath, result.Patch.MCPServerName)
 	}
 	_, _ = fmt.Fprintf(w, "  Emit format:     %s\n", result.Patch.EmitFormat)
 
@@ -446,7 +569,7 @@ func printSidecarSummary(w io.Writer, result *sidecarResult, opts sidecarOptions
 		_, _ = fmt.Fprintf(w, "  pipelock init sidecar --inject-spec %s\n", opts.injectSpec)
 	}
 	if result.Patch.MCPProxyURL != "" {
-		_, _ = fmt.Fprintln(w, "  Configure the agent MCP client to use PIPELOCK_MCP_PROXY_URL for MCP traffic.")
+		_, _ = fmt.Fprintln(w, "  Configure the agent MCP launcher to read PIPELOCK_MCP_CONFIG, or use PIPELOCK_MCP_PROXY_URL directly.")
 	}
 	switch result.Patch.EmitFormat {
 	case emitKustomize:

--- a/internal/cli/setup/sidecar_emit.go
+++ b/internal/cli/setup/sidecar_emit.go
@@ -248,8 +248,9 @@ func emitHelmValuesFormat(w io.Writer, result *sidecarPatchResult, opts sidecarO
 		return err
 	}
 	if result.MCPConfigMapYAML != "" {
-		if err := writeOutput(nil, []byte(result.MCPConfigMapYAML), filepath.Join(cleanDir, "pipelock-mcp-configmap.yaml"), opts.force); err != nil {
-			return err
+		mcpConfigPath := filepath.Join(cleanDir, "pipelock-mcp-configmap.yaml")
+		if err := writeOutput(nil, []byte(result.MCPConfigMapYAML), mcpConfigPath, opts.force); err != nil {
+			return fmt.Errorf("writing %s: %w", mcpConfigPath, err)
 		}
 	}
 	if err := writeOutput(nil, []byte(result.AgentNetworkPolicyYAML), filepath.Join(cleanDir, "agent-networkpolicy.yaml"), opts.force); err != nil {

--- a/internal/cli/setup/sidecar_emit.go
+++ b/internal/cli/setup/sidecar_emit.go
@@ -49,13 +49,21 @@ func emitPatchFormat(w io.Writer, result *sidecarPatchResult, opts sidecarOption
 		return fmt.Errorf("marshaling patched manifest: %w", err)
 	}
 
-	output := string(data) +
-		"---\n" + result.ConfigMapYAML +
-		"---\n" + result.DeploymentYAML +
-		"---\n" + result.ServiceYAML +
-		"---\n" + result.AgentNetworkPolicyYAML +
-		"---\n" + result.ProxyNetworkPolicyYAML +
-		"---\n" + result.PodDisruptionBudgetYAML
+	parts := []string{
+		string(data),
+		result.ConfigMapYAML,
+	}
+	if result.MCPConfigMapYAML != "" {
+		parts = append(parts, result.MCPConfigMapYAML)
+	}
+	parts = append(parts,
+		result.DeploymentYAML,
+		result.ServiceYAML,
+		result.AgentNetworkPolicyYAML,
+		result.ProxyNetworkPolicyYAML,
+		result.PodDisruptionBudgetYAML,
+	)
+	output := strings.Join(parts, "---\n")
 
 	return writeOutput(w, []byte(output), opts.output, opts.force)
 }
@@ -85,44 +93,53 @@ func emitKustomizeFormat(result *sidecarPatchResult, opts sidecarOptions) error 
 	if err := writeOutput(nil, []byte(result.ConfigMapYAML), cmPath, opts.force); err != nil {
 		return fmt.Errorf("writing %s: %w", cmPath, err)
 	}
+	resources := []interface{}{
+		"agent-workload.yaml",
+		"pipelock-configmap.yaml",
+	}
+
+	if result.MCPConfigMapYAML != "" {
+		mcpConfigPath := filepath.Join(cleanDir, "pipelock-mcp-configmap.yaml")
+		if err := writeOutput(nil, []byte(result.MCPConfigMapYAML), mcpConfigPath, opts.force); err != nil {
+			return fmt.Errorf("writing %s: %w", mcpConfigPath, err)
+		}
+		resources = append(resources, "pipelock-mcp-configmap.yaml")
+	}
 
 	deployPath := filepath.Join(cleanDir, "pipelock-deployment.yaml")
 	if err := writeOutput(nil, []byte(result.DeploymentYAML), deployPath, opts.force); err != nil {
 		return fmt.Errorf("writing %s: %w", deployPath, err)
 	}
+	resources = append(resources, "pipelock-deployment.yaml")
 
 	servicePath := filepath.Join(cleanDir, "pipelock-service.yaml")
 	if err := writeOutput(nil, []byte(result.ServiceYAML), servicePath, opts.force); err != nil {
 		return fmt.Errorf("writing %s: %w", servicePath, err)
 	}
+	resources = append(resources, "pipelock-service.yaml")
 
 	agentPolicyPath := filepath.Join(cleanDir, "agent-networkpolicy.yaml")
 	if err := writeOutput(nil, []byte(result.AgentNetworkPolicyYAML), agentPolicyPath, opts.force); err != nil {
 		return fmt.Errorf("writing %s: %w", agentPolicyPath, err)
 	}
+	resources = append(resources, "agent-networkpolicy.yaml")
 
 	proxyPolicyPath := filepath.Join(cleanDir, "pipelock-networkpolicy.yaml")
 	if err := writeOutput(nil, []byte(result.ProxyNetworkPolicyYAML), proxyPolicyPath, opts.force); err != nil {
 		return fmt.Errorf("writing %s: %w", proxyPolicyPath, err)
 	}
+	resources = append(resources, "pipelock-networkpolicy.yaml")
 
 	pdbPath := filepath.Join(cleanDir, "pipelock-pdb.yaml")
 	if err := writeOutput(nil, []byte(result.PodDisruptionBudgetYAML), pdbPath, opts.force); err != nil {
 		return fmt.Errorf("writing %s: %w", pdbPath, err)
 	}
+	resources = append(resources, "pipelock-pdb.yaml")
 
 	kustomization := map[string]interface{}{
 		"apiVersion": "kustomize.config.k8s.io/v1beta1",
 		"kind":       "Kustomization",
-		"resources": []interface{}{
-			"agent-workload.yaml",
-			"pipelock-configmap.yaml",
-			"pipelock-deployment.yaml",
-			"pipelock-service.yaml",
-			"agent-networkpolicy.yaml",
-			"pipelock-networkpolicy.yaml",
-			"pipelock-pdb.yaml",
-		},
+		"resources":  resources,
 	}
 	kustomizationData, err := yaml.Marshal(kustomization)
 	if err != nil {
@@ -230,6 +247,11 @@ func emitHelmValuesFormat(w io.Writer, result *sidecarPatchResult, opts sidecarO
 	if err := writeOutput(nil, agentData, filepath.Join(cleanDir, "agent-workload.yaml"), opts.force); err != nil {
 		return err
 	}
+	if result.MCPConfigMapYAML != "" {
+		if err := writeOutput(nil, []byte(result.MCPConfigMapYAML), filepath.Join(cleanDir, "pipelock-mcp-configmap.yaml"), opts.force); err != nil {
+			return err
+		}
+	}
 	if err := writeOutput(nil, []byte(result.AgentNetworkPolicyYAML), filepath.Join(cleanDir, "agent-networkpolicy.yaml"), opts.force); err != nil {
 		return err
 	}
@@ -240,12 +262,17 @@ func emitHelmValuesFormat(w io.Writer, result *sidecarPatchResult, opts sidecarO
 		return err
 	}
 
-	readme := fmt.Sprintf("helm upgrade --install %s pipelock/pipelock -f %s\nkubectl rollout status deployment/%s\nkubectl apply -f %s -f %s\nkubectl apply -f %s\nkubectl apply -f %s\n",
+	mcpApply := ""
+	if result.MCPConfigMapYAML != "" {
+		mcpApply = fmt.Sprintf("kubectl apply -f %s\n", filepath.Join(cleanDir, "pipelock-mcp-configmap.yaml"))
+	}
+	readme := fmt.Sprintf("helm upgrade --install %s pipelock/pipelock -f %s\nkubectl rollout status deployment/%s\nkubectl apply -f %s -f %s\n%skubectl apply -f %s\nkubectl apply -f %s\n",
 		result.ProxyName,
 		filepath.Join(cleanDir, "values.yaml"),
 		result.ProxyName,
 		filepath.Join(cleanDir, "pipelock-networkpolicy.yaml"),
 		filepath.Join(cleanDir, "pipelock-pdb.yaml"),
+		mcpApply,
 		filepath.Join(cleanDir, "agent-networkpolicy.yaml"),
 		filepath.Join(cleanDir, "agent-workload.yaml"),
 	)

--- a/internal/cli/setup/sidecar_emit_test.go
+++ b/internal/cli/setup/sidecar_emit_test.go
@@ -187,6 +187,30 @@ func TestEmitPatchFormat(t *testing.T) {
 	}
 }
 
+func TestEmitPatchFormat_MCPConfigMap(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "patch-output.yaml")
+	result := mustPatchResult(t, sidecarOptions{preset: config.ModeBalanced, mcpUpstream: "http://openclaw:3000/mcp"})
+
+	if err := emitPatchFormat(nil, result, sidecarOptions{output: outPath, emit: emitPatch}); err != nil {
+		t.Fatalf("emitPatchFormat: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(outPath))
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "name: my-agent-pipelock-mcp-config") {
+		t.Fatalf("patch output missing MCP client ConfigMap:\n%s", content)
+	}
+	if !strings.Contains(content, sidecarMCPConfigFile+":") || !strings.Contains(content, result.MCPProxyURL) {
+		t.Fatalf("patch output missing MCP client config content:\n%s", content)
+	}
+}
+
 func TestEmitKustomizeFormat(t *testing.T) {
 	t.Parallel()
 
@@ -253,6 +277,29 @@ func TestEmitKustomizeFormat(t *testing.T) {
 		if !found {
 			t.Fatalf("kustomization resources missing %s", name)
 		}
+	}
+}
+
+func TestEmitKustomizeFormat_MCPConfigMap(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outDir := filepath.Join(dir, "kustomize-output")
+	result := mustPatchResult(t, sidecarOptions{preset: config.ModeBalanced, mcpUpstream: "http://openclaw:3000/mcp"})
+
+	if err := emitKustomizeFormat(result, sidecarOptions{output: outDir, emit: emitKustomize}); err != nil {
+		t.Fatalf("emitKustomizeFormat: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(outDir, "pipelock-mcp-configmap.yaml")); err != nil {
+		t.Fatalf("expected pipelock-mcp-configmap.yaml: %v", err)
+	}
+	kustomData, err := os.ReadFile(filepath.Clean(filepath.Join(outDir, "kustomization.yaml")))
+	if err != nil {
+		t.Fatalf("reading kustomization.yaml: %v", err)
+	}
+	if !strings.Contains(string(kustomData), "pipelock-mcp-configmap.yaml") {
+		t.Fatalf("kustomization missing MCP config resource:\n%s", kustomData)
 	}
 }
 
@@ -418,6 +465,16 @@ func TestEmitHelmValuesFormat_MCPUpstream(t *testing.T) {
 	}
 	if mcpMap["listen"] != proxyMCPListenAddr() {
 		t.Fatalf("mcp.listen = %v, want %s", mcpMap["listen"], proxyMCPListenAddr())
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "pipelock-mcp-configmap.yaml")); err != nil {
+		t.Fatalf("expected MCP config map in helm bundle: %v", err)
+	}
+	readme, err := os.ReadFile(filepath.Clean(filepath.Join(outDir, "README.txt")))
+	if err != nil {
+		t.Fatalf("reading README.txt: %v", err)
+	}
+	if !strings.Contains(string(readme), "pipelock-mcp-configmap.yaml") {
+		t.Fatalf("README.txt should apply MCP config map:\n%s", readme)
 	}
 }
 

--- a/internal/cli/setup/sidecar_patch.go
+++ b/internal/cli/setup/sidecar_patch.go
@@ -8,6 +8,8 @@
 package setup
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -59,10 +61,12 @@ const (
 	managedProxyServiceAnnotation = "pipelock.dev/proxy-service"
 	managedMCPProxyAnnotation     = "pipelock.dev/mcp-proxy-service"
 	managedMCPUpstreamAnnotation  = "pipelock.dev/mcp-upstream"
+	managedMCPUpstreamHash        = "pipelock.dev/mcp-upstream-sha256"
 	managedMCPConfigAnnotation    = "pipelock.dev/mcp-config"
 	managedMCPServerAnnotation    = "pipelock.dev/mcp-server-name"
 	managedTopologyCompanion      = "companion-proxy"
 	managedByLabelValue           = "pipelock-init-sidecar"
+	managedAnnotationEnabled      = "true"
 
 	defaultMCPServerName = "pipelock"
 )
@@ -539,7 +543,8 @@ func renderMCPClientConfigMap(namespace, configMapName string, proxyLabels map[s
 			"labels":    labelsToInterfaceMap(labels),
 			"annotations": map[string]interface{}{
 				managedMCPProxyAnnotation:    mcpProxyURL,
-				managedMCPUpstreamAnnotation: mcpUpstream,
+				managedMCPUpstreamAnnotation: managedAnnotationEnabled,
+				managedMCPUpstreamHash:       mcpUpstreamFingerprint(mcpUpstream),
 				managedMCPConfigAnnotation:   sidecarMCPConfigPath(),
 				managedMCPServerAnnotation:   serverName,
 			},
@@ -884,6 +889,11 @@ func resolveMCPServerName(name string) string {
 	return name
 }
 
+func mcpUpstreamFingerprint(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
 func mcpUpstreamPolicyPort(raw string) int {
 	if raw == "" {
 		return 0
@@ -947,11 +957,12 @@ func annotateManagedWorkload(raw map[string]interface{}, kind, proxyName, mcpPro
 	var removeKeys []string
 	if mcpProxyURL != "" {
 		annotations[managedMCPProxyAnnotation] = mcpProxyURL
-		annotations[managedMCPUpstreamAnnotation] = mcpUpstream
+		annotations[managedMCPUpstreamAnnotation] = managedAnnotationEnabled
+		annotations[managedMCPUpstreamHash] = mcpUpstreamFingerprint(mcpUpstream)
 		annotations[managedMCPConfigAnnotation] = mcpConfigPath
 		annotations[managedMCPServerAnnotation] = mcpServerName
 	} else {
-		removeKeys = append(removeKeys, managedMCPProxyAnnotation, managedMCPUpstreamAnnotation, managedMCPConfigAnnotation, managedMCPServerAnnotation)
+		removeKeys = append(removeKeys, managedMCPProxyAnnotation, managedMCPUpstreamAnnotation, managedMCPUpstreamHash, managedMCPConfigAnnotation, managedMCPServerAnnotation)
 	}
 	if err := setAnnotationsAtPath(raw, []string{"metadata", "annotations"}, annotations); err != nil {
 		return err

--- a/internal/cli/setup/sidecar_patch.go
+++ b/internal/cli/setup/sidecar_patch.go
@@ -8,6 +8,7 @@
 package setup
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -21,15 +22,18 @@ import (
 
 // Fixed names and values for companion-proxy generation.
 const (
-	proxyContainerName   = "pipelock"
-	sidecarContainerName = proxyContainerName // legacy alias for pre-companion tests/helpers
-	sidecarConfigVolume  = "pipelock-config"
-	sidecarConfigMount   = "/etc/pipelock"
-	sidecarConfigFile    = "pipelock.yaml"
-	sidecarHealthPath    = "/health"
-	sidecarHealthPort    = 8888
-	sidecarMCPPort       = 8889
-	sidecarMetricsPort   = 9091
+	proxyContainerName     = "pipelock"
+	sidecarContainerName   = proxyContainerName // legacy alias for pre-companion tests/helpers
+	sidecarConfigVolume    = "pipelock-config"
+	sidecarConfigMount     = "/etc/pipelock"
+	sidecarConfigFile      = "pipelock.yaml"
+	sidecarMCPConfigVolume = "pipelock-mcp-config"
+	sidecarMCPConfigMount  = "/etc/pipelock/mcp"
+	sidecarMCPConfigFile   = "mcp.json"
+	sidecarHealthPath      = "/health"
+	sidecarHealthPort      = 8888
+	sidecarMCPPort         = 8889
+	sidecarMetricsPort     = 9091
 
 	// defaultImage is the GHCR image with the current version tag.
 	// Overridden by --image flag.
@@ -40,6 +44,7 @@ const (
 	envHTTPProxy  = "HTTP_PROXY"
 	envNoProxy    = "NO_PROXY"
 	envMCPProxy   = "PIPELOCK_MCP_PROXY_URL"
+	envMCPConfig  = "PIPELOCK_MCP_CONFIG"
 	noProxyValue  = "localhost,127.0.0.1,.svc,.cluster.local"
 
 	proxyReplicaCount = 2
@@ -54,8 +59,12 @@ const (
 	managedProxyServiceAnnotation = "pipelock.dev/proxy-service"
 	managedMCPProxyAnnotation     = "pipelock.dev/mcp-proxy-service"
 	managedMCPUpstreamAnnotation  = "pipelock.dev/mcp-upstream"
+	managedMCPConfigAnnotation    = "pipelock.dev/mcp-config"
+	managedMCPServerAnnotation    = "pipelock.dev/mcp-server-name"
 	managedTopologyCompanion      = "companion-proxy"
 	managedByLabelValue           = "pipelock-init-sidecar"
+
+	defaultMCPServerName = "pipelock"
 )
 
 // sidecarPatchResult holds the generated patch and related artifacts.
@@ -68,6 +77,8 @@ type sidecarPatchResult struct {
 	Config *config.Config
 	// ConfigMapYAML is the standalone ConfigMap for the companion proxy.
 	ConfigMapYAML string
+	// MCPConfigMapYAML is the optional MCP client config mounted into the agent workload.
+	MCPConfigMapYAML string
 	// DeploymentYAML is the companion proxy Deployment.
 	DeploymentYAML string
 	// ServiceYAML is the companion proxy Service.
@@ -88,6 +99,10 @@ type sidecarPatchResult struct {
 	MCPUpstream string
 	// MCPProxyURL is the companion Service MCP URL injected into the agent workload.
 	MCPProxyURL string
+	// MCPConfigPath is the mounted MCP client config path exposed to launchers.
+	MCPConfigPath string
+	// MCPServerName is the generated mcpServers entry name.
+	MCPServerName string
 	// AgentSelectorLabels identify the protected agent pods.
 	AgentSelectorLabels map[string]string
 	// ProxySelectorLabels identify the companion proxy pods.
@@ -116,22 +131,38 @@ func generateSidecarPatch(manifest *workloadManifest, opts sidecarOptions) (*sid
 	proxyName := resolveProxyName(manifest.Raw, manifest.Name)
 	proxyURL := proxyServiceURL(proxyName)
 	mcpProxyURL := ""
+	mcpConfigPath := ""
+	mcpConfigName := ""
+	mcpServerName := ""
 	if opts.mcpUpstream != "" {
 		mcpProxyURL = proxyMCPServiceURL(proxyName)
+		mcpConfigPath = sidecarMCPConfigPath()
+		mcpConfigName = mcpClientConfigMapName(proxyName)
+		mcpServerName = resolveMCPServerName(opts.mcpServerName)
 	}
 	proxyLabels := proxySelectorLabels(proxyName)
 
-	if err := annotateManagedWorkload(patched, manifest.Kind, proxyName, mcpProxyURL, opts.mcpUpstream); err != nil {
+	if err := annotateManagedWorkload(patched, manifest.Kind, proxyName, mcpProxyURL, opts.mcpUpstream, mcpConfigPath, mcpServerName); err != nil {
 		return nil, fmt.Errorf("annotating workload: %w", err)
 	}
-	if err := injectProxyEnvs(podSpec, proxyURL, mcpProxyURL); err != nil {
+	if err := injectProxyEnvs(podSpec, proxyURL, mcpProxyURL, mcpConfigPath); err != nil {
 		return nil, fmt.Errorf("injecting proxy env: %w", err)
+	}
+	if err := configureMCPClientConfigMount(podSpec, mcpConfigName, mcpConfigPath); err != nil {
+		return nil, fmt.Errorf("configuring MCP client config mount: %w", err)
 	}
 
 	proxyCfg := buildProxyConfig(opts.preset, agentIdentity)
 	configMapYAML, err := renderConfigMap(proxyCfg, opts.preset, namespace, proxyName, proxyLabels)
 	if err != nil {
 		return nil, fmt.Errorf("rendering ConfigMap: %w", err)
+	}
+	mcpConfigMapYAML := ""
+	if opts.mcpUpstream != "" {
+		mcpConfigMapYAML, err = renderMCPClientConfigMap(namespace, mcpConfigName, proxyLabels, mcpServerName, mcpProxyURL, opts.mcpUpstream)
+		if err != nil {
+			return nil, fmt.Errorf("rendering MCP client ConfigMap: %w", err)
+		}
 	}
 	deploymentYAML, err := renderProxyDeployment(namespace, proxyName, resolveImage(opts), proxyLabels, opts.mcpUpstream)
 	if err != nil {
@@ -159,6 +190,7 @@ func generateSidecarPatch(manifest *workloadManifest, opts sidecarOptions) (*sid
 		PatchedManifest:         patched,
 		Config:                  proxyCfg,
 		ConfigMapYAML:           configMapYAML,
+		MCPConfigMapYAML:        mcpConfigMapYAML,
 		DeploymentYAML:          deploymentYAML,
 		ServiceYAML:             serviceYAML,
 		AgentNetworkPolicyYAML:  agentNetworkPolicyYAML,
@@ -169,6 +201,8 @@ func generateSidecarPatch(manifest *workloadManifest, opts sidecarOptions) (*sid
 		ProxyURL:                proxyURL,
 		MCPUpstream:             opts.mcpUpstream,
 		MCPProxyURL:             mcpProxyURL,
+		MCPConfigPath:           mcpConfigPath,
+		MCPServerName:           mcpServerName,
 		AgentSelectorLabels:     selectorLabels,
 		ProxySelectorLabels:     proxyLabels,
 	}, nil
@@ -184,9 +218,9 @@ func buildProxyConfig(preset, agentIdentity string) *config.Config {
 	return cfg
 }
 
-// injectProxyEnvs adds HTTPS_PROXY, HTTP_PROXY, NO_PROXY to agent containers.
+// injectProxyEnvs adds HTTP and MCP proxy contract env vars to agent containers.
 // Existing conflicting proxy env vars are rejected instead of silently preserved.
-func injectProxyEnvs(podSpec map[string]interface{}, proxyURL, mcpProxyURL string) error {
+func injectProxyEnvs(podSpec map[string]interface{}, proxyURL, mcpProxyURL, mcpConfigPath string) error {
 	containers, ok := podSpec["containers"].([]interface{})
 	if !ok {
 		return nil
@@ -218,16 +252,173 @@ func injectProxyEnvs(podSpec map[string]interface{}, proxyURL, mcpProxyURL strin
 			if err != nil {
 				return fmt.Errorf("container %q: %w", containerName, err)
 			}
+			existing, err = upsertProxyEnv(existing, envMCPConfig, mcpConfigPath)
+			if err != nil {
+				return fmt.Errorf("container %q: %w", containerName, err)
+			}
 		} else {
 			// Scrub stale MCP env when the operator re-runs without
 			// --mcp-upstream. Leaving it would point the agent at a Service
-			// port the regenerated companion no longer listens on, turning
-			// a feature disable into a runtime "connection refused" loop.
+			// port and config file the regenerated bundle no longer exposes.
 			existing = removeProxyEnv(existing, envMCPProxy)
+			existing = removeProxyEnv(existing, envMCPConfig)
 		}
 		cMap["env"] = existing
 	}
 	return nil
+}
+
+func configureMCPClientConfigMount(podSpec map[string]interface{}, configMapName, mcpConfigPath string) error {
+	if mcpConfigPath == "" {
+		removePodSpecVolume(podSpec, sidecarMCPConfigVolume)
+		removeContainerVolumeMounts(podSpec, sidecarMCPConfigVolume)
+		return nil
+	}
+	if err := upsertConfigMapVolume(podSpec, sidecarMCPConfigVolume, configMapName); err != nil {
+		return err
+	}
+	return upsertContainerVolumeMounts(podSpec, sidecarMCPConfigVolume, sidecarMCPConfigMount)
+}
+
+func upsertConfigMapVolume(podSpec map[string]interface{}, volumeName, configMapName string) error {
+	volumes, _ := podSpec["volumes"].([]interface{})
+	for i, item := range volumes {
+		volume, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := volume["name"].(string)
+		if name != volumeName {
+			continue
+		}
+		configMap, ok := volume["configMap"].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("volume %q already exists and is not a ConfigMap", volumeName)
+		}
+		existingName, _ := configMap["name"].(string)
+		if existingName != configMapName {
+			return fmt.Errorf("volume %q already uses ConfigMap %q, want %q", volumeName, existingName, configMapName)
+		}
+		volumes[i] = volume
+		podSpec["volumes"] = volumes
+		return nil
+	}
+	podSpec["volumes"] = append(volumes, map[string]interface{}{
+		"name": volumeName,
+		"configMap": map[string]interface{}{
+			"name": configMapName,
+		},
+	})
+	return nil
+}
+
+func removePodSpecVolume(podSpec map[string]interface{}, volumeName string) {
+	volumes, ok := podSpec["volumes"].([]interface{})
+	if !ok {
+		return
+	}
+	out := volumes[:0]
+	for _, item := range volumes {
+		volume, ok := item.(map[string]interface{})
+		if !ok {
+			out = append(out, item)
+			continue
+		}
+		if name, _ := volume["name"].(string); name == volumeName {
+			continue
+		}
+		out = append(out, item)
+	}
+	if len(out) == 0 {
+		delete(podSpec, "volumes")
+		return
+	}
+	podSpec["volumes"] = out
+}
+
+func upsertContainerVolumeMounts(podSpec map[string]interface{}, volumeName, mountPath string) error {
+	containers, ok := podSpec["containers"].([]interface{})
+	if !ok {
+		return nil
+	}
+	for _, item := range containers {
+		container, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		containerName, _ := container["name"].(string)
+		if containerName == proxyContainerName {
+			continue
+		}
+		mounts, _ := container["volumeMounts"].([]interface{})
+		updated, err := upsertVolumeMount(mounts, volumeName, mountPath)
+		if err != nil {
+			return fmt.Errorf("container %q: %w", containerName, err)
+		}
+		container["volumeMounts"] = updated
+	}
+	return nil
+}
+
+func upsertVolumeMount(mounts []interface{}, volumeName, mountPath string) ([]interface{}, error) {
+	for i, item := range mounts {
+		mount, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := mount["name"].(string)
+		existingPath, _ := mount["mountPath"].(string)
+		if name == volumeName {
+			if existingPath != mountPath {
+				return nil, fmt.Errorf("volumeMount %q already uses mountPath %q, want %q", volumeName, existingPath, mountPath)
+			}
+			mount["readOnly"] = true
+			mounts[i] = mount
+			return mounts, nil
+		}
+		if existingPath == mountPath {
+			return nil, fmt.Errorf("mountPath %q already used by volumeMount %q", mountPath, name)
+		}
+	}
+	return append(mounts, map[string]interface{}{
+		"name":      volumeName,
+		"mountPath": mountPath,
+		"readOnly":  true,
+	}), nil
+}
+
+func removeContainerVolumeMounts(podSpec map[string]interface{}, volumeName string) {
+	containers, ok := podSpec["containers"].([]interface{})
+	if !ok {
+		return
+	}
+	for _, item := range containers {
+		container, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		mounts, ok := container["volumeMounts"].([]interface{})
+		if !ok {
+			continue
+		}
+		out := mounts[:0]
+		for _, mountItem := range mounts {
+			mount, ok := mountItem.(map[string]interface{})
+			if !ok {
+				out = append(out, mountItem)
+				continue
+			}
+			if name, _ := mount["name"].(string); name == volumeName {
+				continue
+			}
+			out = append(out, mountItem)
+		}
+		if len(out) == 0 {
+			delete(container, "volumeMounts")
+			continue
+		}
+		container["volumeMounts"] = out
+	}
 }
 
 // removeProxyEnv strips an env entry by name. Returns the input unchanged
@@ -313,6 +504,48 @@ func renderConfigMap(cfg *config.Config, preset, namespace, proxyName string, pr
 		},
 		"data": map[string]interface{}{
 			sidecarConfigFile: header + string(configData),
+		},
+	}
+
+	out, err := yaml.Marshal(cm)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func renderMCPClientConfigMap(namespace, configMapName string, proxyLabels map[string]string, serverName, mcpProxyURL, mcpUpstream string) (string, error) {
+	config := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			serverName: map[string]interface{}{
+				"type": "http",
+				"url":  mcpProxyURL,
+			},
+		},
+	}
+	configData, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshaling MCP client config: %w", err)
+	}
+	configData = append(configData, '\n')
+
+	labels := managedProxyResourceLabels(proxyLabels, "mcp-client-config")
+	cm := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      configMapName,
+			"namespace": namespace,
+			"labels":    labelsToInterfaceMap(labels),
+			"annotations": map[string]interface{}{
+				managedMCPProxyAnnotation:    mcpProxyURL,
+				managedMCPUpstreamAnnotation: mcpUpstream,
+				managedMCPConfigAnnotation:   sidecarMCPConfigPath(),
+				managedMCPServerAnnotation:   serverName,
+			},
+		},
+		"data": map[string]interface{}{
+			sidecarMCPConfigFile: string(configData),
 		},
 	}
 
@@ -635,6 +868,22 @@ func proxyMCPListenAddr() string {
 	return fmt.Sprintf("0.0.0.0:%d", sidecarMCPPort)
 }
 
+func sidecarMCPConfigPath() string {
+	return sidecarMCPConfigMount + "/" + sidecarMCPConfigFile
+}
+
+func mcpClientConfigMapName(proxyName string) string {
+	return kubeResourceName(proxyName, "mcp-config")
+}
+
+func resolveMCPServerName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return defaultMCPServerName
+	}
+	return name
+}
+
 func mcpUpstreamPolicyPort(raw string) int {
 	if raw == "" {
 		return 0
@@ -685,7 +934,7 @@ func managedComponentLabels(component string) map[string]string {
 	}
 }
 
-func annotateManagedWorkload(raw map[string]interface{}, kind, proxyName, mcpProxyURL, mcpUpstream string) error {
+func annotateManagedWorkload(raw map[string]interface{}, kind, proxyName, mcpProxyURL, mcpUpstream, mcpConfigPath, mcpServerName string) error {
 	annotations := map[string]string{
 		managedTopologyAnnotation:     managedTopologyCompanion,
 		managedProxyNameAnnotation:    proxyName,
@@ -699,8 +948,10 @@ func annotateManagedWorkload(raw map[string]interface{}, kind, proxyName, mcpPro
 	if mcpProxyURL != "" {
 		annotations[managedMCPProxyAnnotation] = mcpProxyURL
 		annotations[managedMCPUpstreamAnnotation] = mcpUpstream
+		annotations[managedMCPConfigAnnotation] = mcpConfigPath
+		annotations[managedMCPServerAnnotation] = mcpServerName
 	} else {
-		removeKeys = append(removeKeys, managedMCPProxyAnnotation, managedMCPUpstreamAnnotation)
+		removeKeys = append(removeKeys, managedMCPProxyAnnotation, managedMCPUpstreamAnnotation, managedMCPConfigAnnotation, managedMCPServerAnnotation)
 	}
 	if err := setAnnotationsAtPath(raw, []string{"metadata", "annotations"}, annotations); err != nil {
 		return err

--- a/internal/cli/setup/sidecar_patch_test.go
+++ b/internal/cli/setup/sidecar_patch_test.go
@@ -396,10 +396,10 @@ func TestGenerateSidecarPatch_MCPUpstream(t *testing.T) {
 	if got := envValue(t, envList, envMCPConfig); got != result.MCPConfigPath {
 		t.Fatalf("%s = %q, want %q", envMCPConfig, got, result.MCPConfigPath)
 	}
-	if !podSpecHasConfigMapVolume(podSpec, sidecarMCPConfigVolume, mcpClientConfigMapName(result.ProxyName)) {
+	if !podSpecHasConfigMapVolume(podSpec, mcpClientConfigMapName(result.ProxyName)) {
 		t.Fatalf("podSpec missing %s ConfigMap volume: %+v", sidecarMCPConfigVolume, podSpec["volumes"])
 	}
-	if !podSpecHasVolumeMount(podSpec, sidecarMCPConfigVolume, sidecarMCPConfigMount) {
+	if !podSpecHasVolumeMount(podSpec) {
 		t.Fatalf("agent container missing %s volumeMount: %+v", sidecarMCPConfigVolume, agentContainer["volumeMounts"])
 	}
 
@@ -475,7 +475,7 @@ func TestGenerateSidecarPatch_MCPUpstreamRecordsAnnotation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("detectWorkload: %v", err)
 	}
-	const mcpUpstream = "http://openclaw:3000/mcp"
+	const mcpUpstream = "http://operator@openclaw:3000/mcp?opaque=value"
 	result, err := generateSidecarPatch(manifest, sidecarOptions{
 		preset:      config.ModeBalanced,
 		mcpUpstream: mcpUpstream,
@@ -485,9 +485,13 @@ func TestGenerateSidecarPatch_MCPUpstreamRecordsAnnotation(t *testing.T) {
 	}
 	metadata := result.PatchedManifest["metadata"].(map[string]interface{})
 	annotations := metadata["annotations"].(map[string]interface{})
-	if annotations[managedMCPUpstreamAnnotation] != mcpUpstream {
+	if annotations[managedMCPUpstreamAnnotation] != managedAnnotationEnabled {
 		t.Fatalf("annotations[%q] = %v, want %q",
-			managedMCPUpstreamAnnotation, annotations[managedMCPUpstreamAnnotation], mcpUpstream)
+			managedMCPUpstreamAnnotation, annotations[managedMCPUpstreamAnnotation], managedAnnotationEnabled)
+	}
+	if annotations[managedMCPUpstreamHash] != mcpUpstreamFingerprint(mcpUpstream) {
+		t.Fatalf("annotations[%q] = %v, want %q",
+			managedMCPUpstreamHash, annotations[managedMCPUpstreamHash], mcpUpstreamFingerprint(mcpUpstream))
 	}
 	if annotations[managedMCPConfigAnnotation] != sidecarMCPConfigPath() {
 		t.Fatalf("annotations[%q] = %v, want %q",
@@ -496,6 +500,9 @@ func TestGenerateSidecarPatch_MCPUpstreamRecordsAnnotation(t *testing.T) {
 	if annotations[managedMCPServerAnnotation] != defaultMCPServerName {
 		t.Fatalf("annotations[%q] = %v, want %q",
 			managedMCPServerAnnotation, annotations[managedMCPServerAnnotation], defaultMCPServerName)
+	}
+	if strings.Contains(result.MCPConfigMapYAML, mcpUpstream) {
+		t.Fatalf("MCP ConfigMap YAML should not persist raw upstream URL:\n%s", result.MCPConfigMapYAML)
 	}
 }
 
@@ -536,6 +543,9 @@ func TestGenerateSidecarPatch_MCPDisableScrubsAnnotationsAndEnv(t *testing.T) {
 	if _, ok := annotations[managedMCPUpstreamAnnotation]; ok {
 		t.Fatalf("expected %s annotation to be scrubbed on disable, got %+v", managedMCPUpstreamAnnotation, annotations)
 	}
+	if _, ok := annotations[managedMCPUpstreamHash]; ok {
+		t.Fatalf("expected %s annotation to be scrubbed on disable, got %+v", managedMCPUpstreamHash, annotations)
+	}
 	if _, ok := annotations[managedMCPConfigAnnotation]; ok {
 		t.Fatalf("expected %s annotation to be scrubbed on disable, got %+v", managedMCPConfigAnnotation, annotations)
 	}
@@ -555,10 +565,10 @@ func TestGenerateSidecarPatch_MCPDisableScrubsAnnotationsAndEnv(t *testing.T) {
 			t.Fatalf("expected MCP env to be scrubbed on disable: %+v", envList)
 		}
 	}
-	if podSpecHasConfigMapVolume(podSpec, sidecarMCPConfigVolume, mcpClientConfigMapName(second.ProxyName)) {
+	if podSpecHasConfigMapVolume(podSpec, mcpClientConfigMapName(second.ProxyName)) {
 		t.Fatalf("expected %s volume to be scrubbed on disable: %+v", sidecarMCPConfigVolume, podSpec["volumes"])
 	}
-	if podSpecHasVolumeMount(podSpec, sidecarMCPConfigVolume, sidecarMCPConfigMount) {
+	if podSpecHasVolumeMount(podSpec) {
 		t.Fatalf("expected %s volumeMount to be scrubbed on disable: %+v", sidecarMCPConfigVolume, containers[0].(map[string]interface{})["volumeMounts"])
 	}
 
@@ -572,6 +582,9 @@ func TestGenerateSidecarPatch_MCPDisableScrubsAnnotationsAndEnv(t *testing.T) {
 				t.Fatalf("template annotations not scrubbed: %+v", tmplAnn)
 			}
 			if _, ok := tmplAnn[managedMCPConfigAnnotation]; ok {
+				t.Fatalf("template annotations not scrubbed: %+v", tmplAnn)
+			}
+			if _, ok := tmplAnn[managedMCPUpstreamHash]; ok {
 				t.Fatalf("template annotations not scrubbed: %+v", tmplAnn)
 			}
 			if _, ok := tmplAnn[managedMCPServerAnnotation]; ok {
@@ -615,9 +628,113 @@ func TestGenerateSidecarPatch_MCPServerName(t *testing.T) {
 	}) {
 		t.Fatal("changed MCP server name should mark contract changed")
 	}
-	if !strings.Contains(result.MCPConfigMapYAML, `"openclaw"`) {
-		t.Fatalf("MCPConfigMapYAML missing custom server name:\n%s", result.MCPConfigMapYAML)
+	var mcpConfigMap map[string]interface{}
+	if err := yaml.Unmarshal([]byte(result.MCPConfigMapYAML), &mcpConfigMap); err != nil {
+		t.Fatalf("parsing MCPConfigMapYAML: %v", err)
 	}
+	mcpConfigData := mcpConfigMap["data"].(map[string]interface{})[sidecarMCPConfigFile].(string)
+	var mcpClientConfig map[string]map[string]map[string]string
+	if err := json.Unmarshal([]byte(mcpConfigData), &mcpClientConfig); err != nil {
+		t.Fatalf("MCP client config is not valid JSON: %v\n%s", err, mcpConfigData)
+	}
+	if _, ok := mcpClientConfig["mcpServers"]["openclaw"]; !ok {
+		t.Fatalf("MCP client config missing custom server name: %+v", mcpClientConfig["mcpServers"])
+	}
+}
+
+func TestConfigureMCPClientConfigMount_ConflictsAndDisable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("upsert and disable", func(t *testing.T) {
+		podSpec := map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{"name": "agent"},
+			},
+		}
+		if err := configureMCPClientConfigMount(podSpec, "agent-mcp-config", sidecarMCPConfigPath()); err != nil {
+			t.Fatalf("configureMCPClientConfigMount enable: %v", err)
+		}
+		if !podSpecHasConfigMapVolume(podSpec, "agent-mcp-config") {
+			t.Fatalf("missing MCP ConfigMap volume: %+v", podSpec["volumes"])
+		}
+		if !podSpecHasVolumeMount(podSpec) {
+			t.Fatalf("missing MCP ConfigMap volumeMount: %+v", podSpec["containers"])
+		}
+
+		if err := configureMCPClientConfigMount(podSpec, "", ""); err != nil {
+			t.Fatalf("configureMCPClientConfigMount disable: %v", err)
+		}
+		if _, ok := podSpec["volumes"]; ok {
+			t.Fatalf("disable should remove empty volumes list: %+v", podSpec["volumes"])
+		}
+		container := podSpec["containers"].([]interface{})[0].(map[string]interface{})
+		if _, ok := container["volumeMounts"]; ok {
+			t.Fatalf("disable should remove empty volumeMounts list: %+v", container["volumeMounts"])
+		}
+	})
+
+	t.Run("wrong existing volume shape", func(t *testing.T) {
+		podSpec := map[string]interface{}{
+			"containers": []interface{}{map[string]interface{}{"name": "agent"}},
+			"volumes": []interface{}{
+				map[string]interface{}{"name": sidecarMCPConfigVolume, "emptyDir": map[string]interface{}{}},
+			},
+		}
+		err := configureMCPClientConfigMount(podSpec, "agent-mcp-config", sidecarMCPConfigPath())
+		if err == nil || !strings.Contains(err.Error(), "is not a ConfigMap") {
+			t.Fatalf("expected non-ConfigMap volume error, got %v", err)
+		}
+	})
+
+	t.Run("wrong existing config map name", func(t *testing.T) {
+		podSpec := map[string]interface{}{
+			"containers": []interface{}{map[string]interface{}{"name": "agent"}},
+			"volumes": []interface{}{
+				map[string]interface{}{
+					"name":      sidecarMCPConfigVolume,
+					"configMap": map[string]interface{}{"name": "other-config"},
+				},
+			},
+		}
+		err := configureMCPClientConfigMount(podSpec, "agent-mcp-config", sidecarMCPConfigPath())
+		if err == nil || !strings.Contains(err.Error(), "already uses ConfigMap") {
+			t.Fatalf("expected wrong ConfigMap name error, got %v", err)
+		}
+	})
+
+	t.Run("mount path conflict", func(t *testing.T) {
+		podSpec := map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"name": "agent",
+					"volumeMounts": []interface{}{
+						map[string]interface{}{"name": "other", "mountPath": sidecarMCPConfigMount},
+					},
+				},
+			},
+		}
+		err := configureMCPClientConfigMount(podSpec, "agent-mcp-config", sidecarMCPConfigPath())
+		if err == nil || !strings.Contains(err.Error(), "mountPath") {
+			t.Fatalf("expected mountPath conflict error, got %v", err)
+		}
+	})
+
+	t.Run("existing mount wrong path", func(t *testing.T) {
+		podSpec := map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"name": "agent",
+					"volumeMounts": []interface{}{
+						map[string]interface{}{"name": sidecarMCPConfigVolume, "mountPath": "/other"},
+					},
+				},
+			},
+		}
+		err := configureMCPClientConfigMount(podSpec, "agent-mcp-config", sidecarMCPConfigPath())
+		if err == nil || !strings.Contains(err.Error(), "already uses mountPath") {
+			t.Fatalf("expected wrong mountPath error, got %v", err)
+		}
+	})
 }
 
 func TestGenerateSidecarPatch_CustomIdentity(t *testing.T) {

--- a/internal/cli/setup/sidecar_patch_test.go
+++ b/internal/cli/setup/sidecar_patch_test.go
@@ -4,6 +4,7 @@
 package setup
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -375,6 +376,12 @@ func TestGenerateSidecarPatch_MCPUpstream(t *testing.T) {
 	if result.MCPProxyURL != "http://my-agent-pipelock:8889" {
 		t.Fatalf("MCPProxyURL = %q, want %q", result.MCPProxyURL, "http://my-agent-pipelock:8889")
 	}
+	if result.MCPConfigPath != sidecarMCPConfigPath() {
+		t.Fatalf("MCPConfigPath = %q, want %q", result.MCPConfigPath, sidecarMCPConfigPath())
+	}
+	if result.MCPServerName != defaultMCPServerName {
+		t.Fatalf("MCPServerName = %q, want %q", result.MCPServerName, defaultMCPServerName)
+	}
 
 	podSpec, err := getPodSpec(result.PatchedManifest, kindDeployment)
 	if err != nil {
@@ -386,11 +393,43 @@ func TestGenerateSidecarPatch_MCPUpstream(t *testing.T) {
 	if got := envValue(t, envList, envMCPProxy); got != result.MCPProxyURL {
 		t.Fatalf("%s = %q, want %q", envMCPProxy, got, result.MCPProxyURL)
 	}
+	if got := envValue(t, envList, envMCPConfig); got != result.MCPConfigPath {
+		t.Fatalf("%s = %q, want %q", envMCPConfig, got, result.MCPConfigPath)
+	}
+	if !podSpecHasConfigMapVolume(podSpec, sidecarMCPConfigVolume, mcpClientConfigMapName(result.ProxyName)) {
+		t.Fatalf("podSpec missing %s ConfigMap volume: %+v", sidecarMCPConfigVolume, podSpec["volumes"])
+	}
+	if !podSpecHasVolumeMount(podSpec, sidecarMCPConfigVolume, sidecarMCPConfigMount) {
+		t.Fatalf("agent container missing %s volumeMount: %+v", sidecarMCPConfigVolume, agentContainer["volumeMounts"])
+	}
 
 	metadata := result.PatchedManifest["metadata"].(map[string]interface{})
 	annotations := metadata["annotations"].(map[string]interface{})
 	if annotations[managedMCPProxyAnnotation] != result.MCPProxyURL {
 		t.Fatalf("metadata.annotations[%q] = %v, want %q", managedMCPProxyAnnotation, annotations[managedMCPProxyAnnotation], result.MCPProxyURL)
+	}
+	if annotations[managedMCPConfigAnnotation] != result.MCPConfigPath {
+		t.Fatalf("metadata.annotations[%q] = %v, want %q", managedMCPConfigAnnotation, annotations[managedMCPConfigAnnotation], result.MCPConfigPath)
+	}
+	if annotations[managedMCPServerAnnotation] != result.MCPServerName {
+		t.Fatalf("metadata.annotations[%q] = %v, want %q", managedMCPServerAnnotation, annotations[managedMCPServerAnnotation], result.MCPServerName)
+	}
+
+	var mcpConfigMap map[string]interface{}
+	if err := yaml.Unmarshal([]byte(result.MCPConfigMapYAML), &mcpConfigMap); err != nil {
+		t.Fatalf("parsing MCPConfigMapYAML: %v", err)
+	}
+	if mcpConfigMap["kind"] != "ConfigMap" {
+		t.Fatalf("MCPConfigMapYAML kind = %v, want ConfigMap", mcpConfigMap["kind"])
+	}
+	mcpConfigData := mcpConfigMap["data"].(map[string]interface{})[sidecarMCPConfigFile].(string)
+	var mcpClientConfig map[string]map[string]map[string]string
+	if err := json.Unmarshal([]byte(mcpConfigData), &mcpClientConfig); err != nil {
+		t.Fatalf("MCP client config is not valid JSON: %v\n%s", err, mcpConfigData)
+	}
+	server := mcpClientConfig["mcpServers"][defaultMCPServerName]
+	if server["type"] != testTypeHTTP || server["url"] != result.MCPProxyURL {
+		t.Fatalf("generated MCP server = %+v, want type=http url=%s", server, result.MCPProxyURL)
 	}
 
 	var deployment map[string]interface{}
@@ -450,6 +489,14 @@ func TestGenerateSidecarPatch_MCPUpstreamRecordsAnnotation(t *testing.T) {
 		t.Fatalf("annotations[%q] = %v, want %q",
 			managedMCPUpstreamAnnotation, annotations[managedMCPUpstreamAnnotation], mcpUpstream)
 	}
+	if annotations[managedMCPConfigAnnotation] != sidecarMCPConfigPath() {
+		t.Fatalf("annotations[%q] = %v, want %q",
+			managedMCPConfigAnnotation, annotations[managedMCPConfigAnnotation], sidecarMCPConfigPath())
+	}
+	if annotations[managedMCPServerAnnotation] != defaultMCPServerName {
+		t.Fatalf("annotations[%q] = %v, want %q",
+			managedMCPServerAnnotation, annotations[managedMCPServerAnnotation], defaultMCPServerName)
+	}
 }
 
 func TestGenerateSidecarPatch_MCPDisableScrubsAnnotationsAndEnv(t *testing.T) {
@@ -489,6 +536,12 @@ func TestGenerateSidecarPatch_MCPDisableScrubsAnnotationsAndEnv(t *testing.T) {
 	if _, ok := annotations[managedMCPUpstreamAnnotation]; ok {
 		t.Fatalf("expected %s annotation to be scrubbed on disable, got %+v", managedMCPUpstreamAnnotation, annotations)
 	}
+	if _, ok := annotations[managedMCPConfigAnnotation]; ok {
+		t.Fatalf("expected %s annotation to be scrubbed on disable, got %+v", managedMCPConfigAnnotation, annotations)
+	}
+	if _, ok := annotations[managedMCPServerAnnotation]; ok {
+		t.Fatalf("expected %s annotation to be scrubbed on disable, got %+v", managedMCPServerAnnotation, annotations)
+	}
 
 	podSpec, err := getPodSpec(second.PatchedManifest, kindDeployment)
 	if err != nil {
@@ -498,9 +551,15 @@ func TestGenerateSidecarPatch_MCPDisableScrubsAnnotationsAndEnv(t *testing.T) {
 	envList := containers[0].(map[string]interface{})["env"].([]interface{})
 	for _, e := range envList {
 		eMap := e.(map[string]interface{})
-		if name, _ := eMap["name"].(string); name == envMCPProxy {
-			t.Fatalf("expected %s env to be scrubbed on disable: %+v", envMCPProxy, envList)
+		if name, _ := eMap["name"].(string); name == envMCPProxy || name == envMCPConfig {
+			t.Fatalf("expected MCP env to be scrubbed on disable: %+v", envList)
 		}
+	}
+	if podSpecHasConfigMapVolume(podSpec, sidecarMCPConfigVolume, mcpClientConfigMapName(second.ProxyName)) {
+		t.Fatalf("expected %s volume to be scrubbed on disable: %+v", sidecarMCPConfigVolume, podSpec["volumes"])
+	}
+	if podSpecHasVolumeMount(podSpec, sidecarMCPConfigVolume, sidecarMCPConfigMount) {
+		t.Fatalf("expected %s volumeMount to be scrubbed on disable: %+v", sidecarMCPConfigVolume, containers[0].(map[string]interface{})["volumeMounts"])
 	}
 
 	// Template annotations on the pod spec must also be scrubbed so newly
@@ -512,7 +571,52 @@ func TestGenerateSidecarPatch_MCPDisableScrubsAnnotationsAndEnv(t *testing.T) {
 			if _, ok := tmplAnn[managedMCPProxyAnnotation]; ok {
 				t.Fatalf("template annotations not scrubbed: %+v", tmplAnn)
 			}
+			if _, ok := tmplAnn[managedMCPConfigAnnotation]; ok {
+				t.Fatalf("template annotations not scrubbed: %+v", tmplAnn)
+			}
+			if _, ok := tmplAnn[managedMCPServerAnnotation]; ok {
+				t.Fatalf("template annotations not scrubbed: %+v", tmplAnn)
+			}
 		}
+	}
+}
+
+func TestGenerateSidecarPatch_MCPServerName(t *testing.T) {
+	manifest, err := detectWorkload(testdataPath(t, "deployment.yaml"))
+	if err != nil {
+		t.Fatalf("detectWorkload: %v", err)
+	}
+
+	result, err := generateSidecarPatch(manifest, sidecarOptions{
+		preset:        config.ModeBalanced,
+		mcpUpstream:   "http://openclaw:3000/mcp",
+		mcpServerName: "openclaw",
+	})
+	if err != nil {
+		t.Fatalf("generateSidecarPatch: %v", err)
+	}
+	if result.MCPServerName != "openclaw" {
+		t.Fatalf("MCPServerName = %q, want openclaw", result.MCPServerName)
+	}
+	metadata := result.PatchedManifest["metadata"].(map[string]interface{})
+	annotations := metadata["annotations"].(map[string]interface{})
+	if annotations[managedMCPServerAnnotation] != "openclaw" {
+		t.Fatalf("annotations[%q] = %v, want openclaw", managedMCPServerAnnotation, annotations[managedMCPServerAnnotation])
+	}
+	if sidecarMCPContractChanged(result.PatchedManifest, sidecarOptions{
+		mcpUpstream:   "http://openclaw:3000/mcp",
+		mcpServerName: "openclaw",
+	}) {
+		t.Fatal("same MCP server name should not mark contract changed")
+	}
+	if !sidecarMCPContractChanged(result.PatchedManifest, sidecarOptions{
+		mcpUpstream:   "http://openclaw:3000/mcp",
+		mcpServerName: "openclaw-v2",
+	}) {
+		t.Fatal("changed MCP server name should mark contract changed")
+	}
+	if !strings.Contains(result.MCPConfigMapYAML, `"openclaw"`) {
+		t.Fatalf("MCPConfigMapYAML missing custom server name:\n%s", result.MCPConfigMapYAML)
 	}
 }
 
@@ -570,7 +674,7 @@ func TestInjectProxyEnvs_RejectsConflictingProxy(t *testing.T) {
 		},
 	}
 
-	err := injectProxyEnvs(podSpec, "http://expected-proxy:8888", "")
+	err := injectProxyEnvs(podSpec, "http://expected-proxy:8888", "", "")
 	if err == nil {
 		t.Fatal("expected conflict error")
 	}

--- a/internal/cli/setup/sidecar_test.go
+++ b/internal/cli/setup/sidecar_test.go
@@ -480,7 +480,7 @@ func TestRunSidecar_MCPDisableRerunEmitsScrubbedWorkload(t *testing.T) {
 		t.Fatalf("reading disabled output: %v", err)
 	}
 	content := string(data)
-	for _, stale := range []string{envMCPProxy, envMCPConfig, managedMCPProxyAnnotation, managedMCPUpstreamAnnotation, managedMCPConfigAnnotation, managedMCPServerAnnotation, sidecarMCPConfigVolume} {
+	for _, stale := range []string{envMCPProxy, envMCPConfig, managedMCPProxyAnnotation, managedMCPUpstreamAnnotation, managedMCPUpstreamHash, managedMCPConfigAnnotation, managedMCPServerAnnotation, sidecarMCPConfigVolume} {
 		if strings.Contains(content, stale) {
 			t.Fatalf("disabled output still contains %q:\n%s", stale, content)
 		}

--- a/internal/cli/setup/sidecar_test.go
+++ b/internal/cli/setup/sidecar_test.go
@@ -120,6 +120,12 @@ func TestRunSidecar_JSONMCPUpstream(t *testing.T) {
 	if result.Patch.MCPProxyURL != "http://my-agent-pipelock:8889" {
 		t.Fatalf("patch.mcp_proxy_url = %q, want %q", result.Patch.MCPProxyURL, "http://my-agent-pipelock:8889")
 	}
+	if result.Patch.MCPConfigPath != sidecarMCPConfigPath() {
+		t.Fatalf("patch.mcp_config_path = %q, want %q", result.Patch.MCPConfigPath, sidecarMCPConfigPath())
+	}
+	if result.Patch.MCPServerName != defaultMCPServerName {
+		t.Fatalf("patch.mcp_server_name = %q, want %q", result.Patch.MCPServerName, defaultMCPServerName)
+	}
 }
 
 func TestRunSidecar_MCPUpstreamSummaryReminder(t *testing.T) {
@@ -143,7 +149,10 @@ func TestRunSidecar_MCPUpstreamSummaryReminder(t *testing.T) {
 	if !strings.Contains(output, "MCP proxy URL:") {
 		t.Fatalf("summary missing MCP proxy URL:\n%s", output)
 	}
-	if !strings.Contains(output, "Configure the agent MCP client to use PIPELOCK_MCP_PROXY_URL") {
+	if !strings.Contains(output, "MCP config:") {
+		t.Fatalf("summary missing MCP config path:\n%s", output)
+	}
+	if !strings.Contains(output, "Configure the agent MCP launcher to read PIPELOCK_MCP_CONFIG") {
 		t.Fatalf("summary missing agent MCP wiring reminder:\n%s", output)
 	}
 }
@@ -184,6 +193,96 @@ func TestRunSidecar_InvalidMCPUpstream(t *testing.T) {
 				t.Fatalf("err = %v, want substring %q", err, tc.wantSub)
 			}
 		})
+	}
+}
+
+func TestRunSidecar_InvalidMCPServerName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		raw     string
+		wantSub string
+	}{
+		{name: "bad chars", raw: "bad/name", wantSub: "may contain only"},
+		{name: "empty", raw: "   ", wantSub: "must not be empty"},
+		{name: "too long", raw: strings.Repeat("a", maxMCPServerNameLen+1), wantSub: "exceeds maximum length"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			cmd := SidecarCmd()
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs([]string{
+				"--inject-spec", testdataPath(t, "deployment.yaml"),
+				"--dry-run",
+				"--mcp-upstream", "http://openclaw:3000/mcp",
+				"--mcp-server-name", tc.raw,
+			})
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected invalid MCP server name error for %q", tc.raw)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("err = %v, want substring %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestSidecarMCPContractChanged_FallsBackToPodSpec verifies that annotation
+// drift does not silently leave stale MCP env/volume in the workload on a
+// disable run. If MCP annotations were stripped (e.g. by hand) but the env
+// var or ConfigMap mount remains, the contract-change detector must still
+// flag the workload for regeneration so the scrub fires.
+func TestSidecarMCPContractChanged_FallsBackToPodSpec(t *testing.T) {
+	t.Parallel()
+
+	// Build a fake patched-but-annotation-stripped workload. Only the
+	// PIPELOCK_MCP_PROXY_URL env entry remains.
+	raw := map[string]interface{}{
+		"kind":     kindDeployment,
+		"metadata": map[string]interface{}{"name": "agent", "annotations": map[string]interface{}{}},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name": "agent",
+							"env": []interface{}{
+								map[string]interface{}{"name": envMCPProxy, "value": "http://stale:8889"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Disable run: no --mcp-upstream. Annotations are empty so the
+	// annotation-only detector would have returned false. The fallback
+	// must catch the stale env and report a change.
+	if !sidecarMCPContractChanged(raw, sidecarOptions{}) {
+		t.Fatal("disable run with stale MCP env must trigger contract change")
+	}
+
+	// Same check via the volume path: empty env, but the MCP config
+	// volume is still mounted from a prior run.
+	raw["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["env"] = []interface{}{}
+	raw["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["volumes"] = []interface{}{
+		map[string]interface{}{"name": sidecarMCPConfigVolume},
+	}
+	if !sidecarMCPContractChanged(raw, sidecarOptions{}) {
+		t.Fatal("disable run with stale MCP volume must trigger contract change")
+	}
+
+	// Clean slate: no annotations, no env, no volume. Detector must NOT
+	// flag drift, otherwise non-MCP workloads would always re-emit.
+	raw["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["volumes"] = nil
+	if sidecarMCPContractChanged(raw, sidecarOptions{}) {
+		t.Fatal("clean workload must not trigger contract change on disable run")
 	}
 }
 
@@ -336,6 +435,55 @@ func TestRunSidecar_Idempotent(t *testing.T) {
 
 	if !result.Detect.AlreadyPatched {
 		t.Error("second run should detect already_patched=true")
+	}
+}
+
+func TestRunSidecar_MCPDisableRerunEmitsScrubbedWorkload(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outDir := filepath.Join(dir, "enabled")
+
+	var buf1 bytes.Buffer
+	cmd1 := SidecarCmd()
+	cmd1.SetOut(&buf1)
+	cmd1.SetErr(&buf1)
+	cmd1.SetArgs([]string{
+		"--inject-spec", testdataPath(t, "deployment.yaml"),
+		"--emit", "kustomize",
+		"--output", outDir,
+		"--mcp-upstream", "http://openclaw:3000/mcp",
+		"--skip-canary",
+		"--skip-verify",
+	})
+	if err := cmd1.Execute(); err != nil {
+		t.Fatalf("first run: %v\n%s", err, buf1.String())
+	}
+
+	disabledPath := filepath.Join(dir, "disabled.yaml")
+	var buf2 bytes.Buffer
+	cmd2 := SidecarCmd()
+	cmd2.SetOut(&buf2)
+	cmd2.SetErr(&buf2)
+	cmd2.SetArgs([]string{
+		"--inject-spec", filepath.Join(outDir, "agent-workload.yaml"),
+		"--output", disabledPath,
+		"--skip-canary",
+		"--skip-verify",
+	})
+	if err := cmd2.Execute(); err != nil {
+		t.Fatalf("disable run: %v\n%s", err, buf2.String())
+	}
+
+	data, err := os.ReadFile(filepath.Clean(disabledPath))
+	if err != nil {
+		t.Fatalf("reading disabled output: %v", err)
+	}
+	content := string(data)
+	for _, stale := range []string{envMCPProxy, envMCPConfig, managedMCPProxyAnnotation, managedMCPUpstreamAnnotation, managedMCPConfigAnnotation, managedMCPServerAnnotation, sidecarMCPConfigVolume} {
+		if strings.Contains(content, stale) {
+			t.Fatalf("disabled output still contains %q:\n%s", stale, content)
+		}
 	}
 }
 

--- a/internal/cli/setup/sidecar_verify.go
+++ b/internal/cli/setup/sidecar_verify.go
@@ -150,10 +150,10 @@ func verifyMCPLauncherContract(result *sidecarPatchResult, failed *[]string) {
 	if !podSpecHasEnv(podSpec, envMCPConfig, result.MCPConfigPath) {
 		*failed = append(*failed, fmt.Sprintf("agent workload does not set %s", envMCPConfig))
 	}
-	if !podSpecHasConfigMapVolume(podSpec, sidecarMCPConfigVolume, mcpClientConfigMapName(result.ProxyName)) {
+	if !podSpecHasConfigMapVolume(podSpec, mcpClientConfigMapName(result.ProxyName)) {
 		*failed = append(*failed, "agent workload does not mount the MCP client ConfigMap volume")
 	}
-	if !podSpecHasVolumeMount(podSpec, sidecarMCPConfigVolume, sidecarMCPConfigMount) {
+	if !podSpecHasVolumeMount(podSpec) {
 		*failed = append(*failed, "agent container does not mount the MCP client config directory")
 	}
 }
@@ -189,7 +189,7 @@ func podSpecHasEnv(podSpec map[string]interface{}, name, value string) bool {
 	return false
 }
 
-func podSpecHasConfigMapVolume(podSpec map[string]interface{}, volumeName, configMapName string) bool {
+func podSpecHasConfigMapVolume(podSpec map[string]interface{}, configMapName string) bool {
 	volumes, ok := podSpec["volumes"].([]interface{})
 	if !ok {
 		return false
@@ -199,7 +199,7 @@ func podSpecHasConfigMapVolume(podSpec map[string]interface{}, volumeName, confi
 		if !ok {
 			continue
 		}
-		if name, _ := volume["name"].(string); name != volumeName {
+		if name, _ := volume["name"].(string); name != sidecarMCPConfigVolume {
 			continue
 		}
 		configMap, _ := volume["configMap"].(map[string]interface{})
@@ -209,7 +209,7 @@ func podSpecHasConfigMapVolume(podSpec map[string]interface{}, volumeName, confi
 	return false
 }
 
-func podSpecHasVolumeMount(podSpec map[string]interface{}, volumeName, mountPath string) bool {
+func podSpecHasVolumeMount(podSpec map[string]interface{}) bool {
 	containers, ok := podSpec["containers"].([]interface{})
 	if !ok {
 		return false
@@ -230,7 +230,7 @@ func podSpecHasVolumeMount(podSpec map[string]interface{}, volumeName, mountPath
 			}
 			name, _ := mount["name"].(string)
 			path, _ := mount["mountPath"].(string)
-			if name == volumeName && path == mountPath {
+			if name == sidecarMCPConfigVolume && path == sidecarMCPConfigMount {
 				return true
 			}
 		}

--- a/internal/cli/setup/sidecar_verify.go
+++ b/internal/cli/setup/sidecar_verify.go
@@ -74,6 +74,9 @@ func runSidecarVerify(w io.Writer, result *sidecarPatchResult, opts sidecarOptio
 	if result.MCPUpstream != "" && !networkPolicyHasPort(result.AgentNetworkPolicyYAML, sidecarMCPPort) {
 		failed = append(failed, "agent NetworkPolicy does not allow MCP proxy port")
 	}
+	if result.MCPUpstream != "" {
+		verifyMCPLauncherContract(result, &failed)
+	}
 	if !networkPolicyHasPort(result.ProxyNetworkPolicyYAML, sidecarHealthPort) {
 		failed = append(failed, "proxy NetworkPolicy does not allow agent ingress on proxy port")
 	}
@@ -117,4 +120,120 @@ func runSidecarVerify(w io.Writer, result *sidecarPatchResult, opts sidecarOptio
 func networkPolicyHasPort(policyYAML string, port int) bool {
 	pattern := fmt.Sprintf(`(?m)^\s*-?\s*port:\s*%d\s*(?:#.*)?$`, port)
 	return regexp.MustCompile(pattern).MatchString(policyYAML)
+}
+
+func verifyMCPLauncherContract(result *sidecarPatchResult, failed *[]string) {
+	if result.MCPProxyURL == "" {
+		*failed = append(*failed, "MCP proxy URL is empty")
+	}
+	if result.MCPConfigPath != sidecarMCPConfigPath() {
+		*failed = append(*failed, fmt.Sprintf("MCP config path = %q", result.MCPConfigPath))
+	}
+	if result.MCPServerName == "" {
+		*failed = append(*failed, "MCP server name is empty")
+	}
+	if result.MCPConfigMapYAML == "" {
+		*failed = append(*failed, "MCP client ConfigMap YAML is empty")
+	} else if !strings.Contains(result.MCPConfigMapYAML, result.MCPProxyURL) {
+		*failed = append(*failed, "MCP client ConfigMap does not point at the MCP proxy URL")
+	}
+
+	kind, _ := result.PatchedManifest["kind"].(string)
+	podSpec, err := getPodSpec(result.PatchedManifest, kind)
+	if err != nil {
+		*failed = append(*failed, "patched workload pod spec is unavailable")
+		return
+	}
+	if !podSpecHasEnv(podSpec, envMCPProxy, result.MCPProxyURL) {
+		*failed = append(*failed, fmt.Sprintf("agent workload does not set %s", envMCPProxy))
+	}
+	if !podSpecHasEnv(podSpec, envMCPConfig, result.MCPConfigPath) {
+		*failed = append(*failed, fmt.Sprintf("agent workload does not set %s", envMCPConfig))
+	}
+	if !podSpecHasConfigMapVolume(podSpec, sidecarMCPConfigVolume, mcpClientConfigMapName(result.ProxyName)) {
+		*failed = append(*failed, "agent workload does not mount the MCP client ConfigMap volume")
+	}
+	if !podSpecHasVolumeMount(podSpec, sidecarMCPConfigVolume, sidecarMCPConfigMount) {
+		*failed = append(*failed, "agent container does not mount the MCP client config directory")
+	}
+}
+
+func podSpecHasEnv(podSpec map[string]interface{}, name, value string) bool {
+	containers, ok := podSpec["containers"].([]interface{})
+	if !ok {
+		return false
+	}
+	for _, item := range containers {
+		container, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if containerName, _ := container["name"].(string); containerName == proxyContainerName {
+			continue
+		}
+		envList, _ := container["env"].([]interface{})
+		for _, envItem := range envList {
+			envMap, ok := envItem.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if envName, _ := envMap["name"].(string); envName != name {
+				continue
+			}
+			envValue, _ := envMap["value"].(string)
+			if envValue == value {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func podSpecHasConfigMapVolume(podSpec map[string]interface{}, volumeName, configMapName string) bool {
+	volumes, ok := podSpec["volumes"].([]interface{})
+	if !ok {
+		return false
+	}
+	for _, item := range volumes {
+		volume, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, _ := volume["name"].(string); name != volumeName {
+			continue
+		}
+		configMap, _ := volume["configMap"].(map[string]interface{})
+		gotName, _ := configMap["name"].(string)
+		return gotName == configMapName
+	}
+	return false
+}
+
+func podSpecHasVolumeMount(podSpec map[string]interface{}, volumeName, mountPath string) bool {
+	containers, ok := podSpec["containers"].([]interface{})
+	if !ok {
+		return false
+	}
+	for _, item := range containers {
+		container, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if containerName, _ := container["name"].(string); containerName == proxyContainerName {
+			continue
+		}
+		mounts, _ := container["volumeMounts"].([]interface{})
+		for _, mountItem := range mounts {
+			mount, ok := mountItem.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			name, _ := mount["name"].(string)
+			path, _ := mount["mountPath"].(string)
+			if name == volumeName && path == mountPath {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/cli/setup/sidecar_verify_test.go
+++ b/internal/cli/setup/sidecar_verify_test.go
@@ -3,7 +3,13 @@
 
 package setup
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
 
 func TestNetworkPolicyHasPortExact(t *testing.T) {
 	t.Parallel()
@@ -32,4 +38,145 @@ spec:
 	if !networkPolicyHasPort(policy, 8889) {
 		t.Fatal("networkPolicyHasPort should match exact port line")
 	}
+}
+
+func TestRunSidecarVerify_MCPLauncherContract(t *testing.T) {
+	t.Parallel()
+
+	result := mustPatchResult(t, sidecarOptions{
+		preset:      config.ModeBalanced,
+		mcpUpstream: "http://openclaw:3000/mcp",
+	})
+
+	var buf bytes.Buffer
+	verify := runSidecarVerify(&buf, result, sidecarOptions{}, false)
+	if !verify.Healthy || !verify.Reachable {
+		t.Fatalf("verify = %+v, output:\n%s", verify, buf.String())
+	}
+	if !strings.Contains(buf.String(), "Static topology checks passed") {
+		t.Fatalf("verify output missing success message:\n%s", buf.String())
+	}
+}
+
+func TestVerifyMCPLauncherContractFailures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing generated fields", func(t *testing.T) {
+		result := mustPatchResult(t, sidecarOptions{
+			preset:      config.ModeBalanced,
+			mcpUpstream: "http://openclaw:3000/mcp",
+		})
+		result.MCPProxyURL = ""
+		result.MCPConfigPath = "/wrong/path.json"
+		result.MCPServerName = ""
+		result.MCPConfigMapYAML = ""
+
+		var failed []string
+		verifyMCPLauncherContract(result, &failed)
+		for _, want := range []string{
+			"MCP proxy URL is empty",
+			"MCP config path =",
+			"MCP server name is empty",
+			"MCP client ConfigMap YAML is empty",
+			"agent workload does not set " + envMCPProxy,
+			"agent workload does not set " + envMCPConfig,
+		} {
+			if !containsFailure(failed, want) {
+				t.Fatalf("failures missing %q: %+v", want, failed)
+			}
+		}
+	})
+
+	t.Run("config map does not point at proxy", func(t *testing.T) {
+		result := mustPatchResult(t, sidecarOptions{
+			preset:      config.ModeBalanced,
+			mcpUpstream: "http://openclaw:3000/mcp",
+		})
+		result.MCPConfigMapYAML = "kind: ConfigMap\ndata: {}\n"
+
+		var failed []string
+		verifyMCPLauncherContract(result, &failed)
+		if !containsFailure(failed, "MCP client ConfigMap does not point at the MCP proxy URL") {
+			t.Fatalf("failures missing ConfigMap proxy URL check: %+v", failed)
+		}
+	})
+
+	t.Run("missing pod spec", func(t *testing.T) {
+		result := mustPatchResult(t, sidecarOptions{
+			preset:      config.ModeBalanced,
+			mcpUpstream: "http://openclaw:3000/mcp",
+		})
+		result.PatchedManifest = map[string]interface{}{"kind": "Deployment"}
+
+		var failed []string
+		verifyMCPLauncherContract(result, &failed)
+		if !containsFailure(failed, "patched workload pod spec is unavailable") {
+			t.Fatalf("failures missing pod spec check: %+v", failed)
+		}
+	})
+
+	t.Run("missing volume wiring", func(t *testing.T) {
+		result := mustPatchResult(t, sidecarOptions{
+			preset:      config.ModeBalanced,
+			mcpUpstream: "http://openclaw:3000/mcp",
+		})
+		podSpec, err := getPodSpec(result.PatchedManifest, kindDeployment)
+		if err != nil {
+			t.Fatalf("getPodSpec: %v", err)
+		}
+		delete(podSpec, "volumes")
+		containers := podSpec["containers"].([]interface{})
+		delete(containers[0].(map[string]interface{}), "volumeMounts")
+
+		var failed []string
+		verifyMCPLauncherContract(result, &failed)
+		if !containsFailure(failed, "agent workload does not mount the MCP client ConfigMap volume") {
+			t.Fatalf("failures missing volume check: %+v", failed)
+		}
+		if !containsFailure(failed, "agent container does not mount the MCP client config directory") {
+			t.Fatalf("failures missing volumeMount check: %+v", failed)
+		}
+	})
+}
+
+func TestPodSpecHasEnvSkipsMalformedAndProxyContainer(t *testing.T) {
+	t.Parallel()
+
+	podSpec := map[string]interface{}{
+		"containers": []interface{}{
+			"bad container",
+			map[string]interface{}{
+				"name": proxyContainerName,
+				"env": []interface{}{
+					map[string]interface{}{"name": envMCPProxy, "value": "http://proxy:8889"},
+				},
+			},
+			map[string]interface{}{
+				"name": "agent",
+				"env": []interface{}{
+					"bad env",
+					map[string]interface{}{"name": envMCPProxy, "value": "http://proxy:8889"},
+				},
+			},
+		},
+	}
+
+	if !podSpecHasEnv(podSpec, envMCPProxy, "http://proxy:8889") {
+		t.Fatal("expected agent env to be found")
+	}
+	if podSpecHasEnv(podSpec, envMCPProxy, "http://wrong:8889") {
+		t.Fatal("unexpected env match for wrong value")
+	}
+	if podSpecHasEnv(map[string]interface{}{}, envMCPProxy, "http://proxy:8889") {
+		t.Fatal("unexpected env match without containers")
+	}
+}
+
+func containsFailure(failed []string, want string) bool {
+	for _, item := range failed {
+		if strings.Contains(item, want) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- generate a mounted MCP client config when sidecar MCP upstream is enabled
- inject PIPELOCK_MCP_CONFIG alongside PIPELOCK_MCP_PROXY_URL and scrub both on disable
- include the MCP config map in patch, kustomize, and helm-values outputs
- verify and document the launcher contract without claiming arbitrary clients auto-consume it

## Validation
- go test -race -count=1 ./internal/cli/setup
- go test -race -count=1 ./...
- golangci-lint run ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --mcp-server-name flag and named MCP server support.
  * Emits optional MCP client ConfigMap and mounts generated MCP client config for agent workloads.
  * Output formats (patch/kustomize/helm) now include optional MCP config artifacts when upstream is set.

* **Bug Fixes / Behavior**
  * Scrubs MCP env/annotations/volume when MCP upstream is removed and tightens agent/proxy reachability behavior.

* **Documentation**
  * Updated CLI and guides to reflect MCP config, env vars, outputs, and verification steps.

* **Tests**
  * Added extensive MCP-focused test coverage for emission, patching, verification, and scrub behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->