### PR TITLE
chart: polish pipelock helm chart for v2.5.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         # under check-yaml so accidental corruption is still caught.
         exclude: |
           (?x)^(
-            charts/.*/templates/|
+            charts/.*/templates/.*|
             internal/contract/testdata/invalid/duplicate_key\.yaml|
             internal/contract/testdata/invalid/yaml_alias\.yaml|
             internal/contract/testdata/invalid/yaml_anchor\.yaml|

--- a/charts/pipelock/Chart.yaml
+++ b/charts/pipelock/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pipelock
 description: Agent firewall for AI agents. Network scanning, process containment, and tool policy enforcement.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "2.5.0"
 home: https://pipelab.org
 sources:
@@ -15,4 +15,32 @@ keywords:
   - agent-firewall
   - mcp
   - dlp
+  - prompt-injection
+  - egress-control
 icon: https://raw.githubusercontent.com/luckyPipewrench/pipelock/main/assets/pipelock-logo.svg
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://pipelab.org/learn/
+    - name: Release notes
+      url: https://github.com/luckyPipewrench/pipelock/releases
+    - name: Audit Packet verifier
+      url: https://github.com/luckyPipewrench/pipelock-verify-python
+  artifacthub.io/changes: |
+    - kind: changed
+      description: Pin default image to v2.5.0 multi-arch digest.
+    - kind: added
+      description: Health-watchdog-backed liveness and readiness probes with timeout and threshold tuning.
+    - kind: added
+      description: License, Sentry DSN, and admin API token plumbing via Kubernetes Secrets.
+    - kind: added
+      description: Admin API port template and Service entry for pipelock adaptive and pipelock session.
+    - kind: added
+      description: PodDisruptionBudget template, topologySpreadConstraints, and priorityClassName support.
+    - kind: added
+      description: extraEnv, extraEnvFrom, extraVolumes, and extraVolumeMounts hooks.
+    - kind: added
+      description: values.schema.json type validation.
+    - kind: added
+      description: Example values files for Pro, MCP sidecar, and admin API configurations.

--- a/charts/pipelock/README.md
+++ b/charts/pipelock/README.md
@@ -1,0 +1,128 @@
+# Pipelock Helm chart
+
+Pipelock is an agent firewall: a network proxy that sits between AI agents and the internet and scans every HTTP, WebSocket, and MCP message for credential leaks, prompt injection, SSRF, and tool poisoning. This chart deploys Pipelock as a Kubernetes Deployment with a Service, optional PodMonitor for Prometheus, optional NetworkPolicy, and optional PodDisruptionBudget.
+
+## TL;DR
+
+```bash
+helm install pipelock ./charts/pipelock
+```
+
+Pipelock runs as a non-root container with a read-only root filesystem, drops all Linux capabilities, and binds the standard Pipelock proxy on port 8888.
+
+## Values
+
+The chart is configured by passing values to `helm install -f values.yaml`. The most commonly used values are listed below. See [`values.yaml`](values.yaml) for the full set.
+
+### Image
+
+| Key | Default | Description |
+|---|---|---|
+| `image.repository` | `ghcr.io/luckypipewrench/pipelock` | Image repository |
+| `image.tag` | digest of v2.5.0 multi-arch manifest | Tag used when `image.digest` is empty. Falls through to `.Chart.AppVersion` if also empty. |
+| `image.digest` | `""` | When set, the chart renders `repository@digest` for pinning |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy |
+
+### Ports
+
+| Key | Default | Description |
+|---|---|---|
+| `service.port` | `8888` | Main proxy port (HTTP, MCP, fetch, WebSocket) |
+| `service.mcpPort` | `8889` | MCP HTTP listener port. Only opened when `mcp.enabled=true` and `mcp.upstream` is set. |
+| `service.metricsPort` | `9091` | Prometheus metrics |
+| `service.adminPort` | `9090` | Authenticated admin API (`pipelock adaptive`, `pipelock session`). Only opened when `adminApi.enabled=true`. |
+
+### Health probes
+
+Liveness and readiness probes hit `/health`, which v2.5 backs with a subsystem watchdog. The endpoint returns 503 when scanner, config, kill switch, session, or watchdog liveness fails — Kubernetes will restart the pod automatically.
+
+| Key | Default | Description |
+|---|---|---|
+| `livenessProbe.httpGet.path` | `/health` | Probe path |
+| `livenessProbe.periodSeconds` | `30` | Probe interval |
+| `livenessProbe.failureThreshold` | `3` | Failures before restart |
+| `readinessProbe.httpGet.path` | `/health` | Probe path |
+| `readinessProbe.periodSeconds` | `10` | Probe interval |
+| `readinessProbe.failureThreshold` | `2` | Failures before pod is marked unready |
+
+### License (Pro / Enterprise)
+
+Community installs do not need a license. Pro features (per-agent profiles, CIDR matching, budgets) require a signed token.
+
+| Key | Default | Description |
+|---|---|---|
+| `license.enabled` | `false` | Mount the license token from a Secret |
+| `license.existingSecret` | `""` | Name of the Kubernetes Secret holding the token |
+| `license.secretKey` | `license.token` | Key within the Secret |
+| `license.mountPath` | `/etc/pipelock/license` | Where the Secret is mounted in the pod |
+
+When enabled, the chart also sets `PIPELOCK_LICENSE` from the same Secret as an env var.
+
+### Sentry
+
+| Key | Default | Description |
+|---|---|---|
+| `sentry.enabled` | `false` | Set `SENTRY_DSN` env from a Secret |
+| `sentry.dsnSecretRef.name` | `""` | Secret name |
+| `sentry.dsnSecretRef.key` | `dsn` | Key within the Secret |
+
+### Admin API
+
+| Key | Default | Description |
+|---|---|---|
+| `adminApi.enabled` | `false` | Open the admin port for `pipelock adaptive` / `pipelock session` |
+| `adminApi.tokenSecretRef.name` | `""` | Secret holding the bearer token. Required for authentication. |
+| `adminApi.tokenSecretRef.key` | `token` | Key within the Secret |
+| `adminApi.tokenMountPath` | `/etc/pipelock/admin` | Mount path. Pipelock reads the token from this file. |
+
+When enabled, the chart sets `kill_switch.api_listen` and `kill_switch.api_token_path` in the generated pipelock.yaml.
+
+### MCP sidecar
+
+| Key | Default | Description |
+|---|---|---|
+| `mcp.enabled` | `false` | Run as MCP HTTP listener bridging to `mcp.upstream` |
+| `mcp.upstream` | `""` | Upstream MCP server URL |
+| `mcp.listen` | `0.0.0.0:8889` | Listen address inside the pod |
+
+### Network policy
+
+| Key | Default | Description |
+|---|---|---|
+| `networkPolicy.enabled` | `false` | Apply a default-deny NetworkPolicy with explicit egress for DNS, 80, and 443 |
+
+### High availability
+
+| Key | Default | Description |
+|---|---|---|
+| `replicaCount` | `1` | Number of replicas |
+| `podDisruptionBudget.enabled` | `false` | Apply a PodDisruptionBudget |
+| `podDisruptionBudget.minAvailable` | `1` | Minimum replicas available during voluntary disruption |
+| `topologySpreadConstraints` | `[]` | Spread replicas across zones / hosts |
+| `priorityClassName` | `""` | PriorityClass for the pod |
+
+### Pipelock configuration
+
+The `.Values.pipelock` block is rendered into a ConfigMap as `pipelock.yaml` and mounted at `/etc/pipelock/pipelock.yaml`. Any v2.5 config section can be set under this key. See the [Pipelock learn guide](https://pipelab.org/learn/) for the full schema and [`values.yaml`](values.yaml) comments for common v2.5 sections.
+
+The chart automatically templates these into the config and they should not be set in `.Values.pipelock`:
+
+- `fetch_proxy.listen` (from `service.port`)
+- `metrics_listen` (from `service.metricsPort`)
+- `kill_switch.api_listen` (from `service.adminPort` when `adminApi.enabled`)
+- `kill_switch.api_token_path` (from `adminApi.tokenSecretRef`)
+- `license_token_path` (from `license.existingSecret`)
+
+## Examples
+
+See [`examples/`](examples/) for ready-to-use values configurations:
+
+- `values-pro.yaml` — Pro license mounted from a Secret, with admin API and Sentry
+- `values-mcp-sidecar.yaml` — MCP HTTP listener bridging to an upstream MCP server
+- `values-ha.yaml` — 3 replicas, PodDisruptionBudget, topology spread, NetworkPolicy
+
+## See also
+
+- [Pipelock docs](https://pipelab.org/learn/)
+- [Audit Packet schema](https://github.com/luckyPipewrench/pipelock/tree/main/sdk/audit-packet)
+- [pipelock-verifier CLI](https://github.com/luckyPipewrench/pipelock/tree/main/cmd/pipelock-verifier)

--- a/charts/pipelock/README.md
+++ b/charts/pipelock/README.md
@@ -19,8 +19,8 @@ The chart is configured by passing values to `helm install -f values.yaml`. The 
 | Key | Default | Description |
 |---|---|---|
 | `image.repository` | `ghcr.io/luckypipewrench/pipelock` | Image repository |
-| `image.tag` | digest of v2.5.0 multi-arch manifest | Tag used when `image.digest` is empty. Falls through to `.Chart.AppVersion` if also empty. |
-| `image.digest` | `""` | When set, the chart renders `repository@digest` for pinning |
+| `image.tag` | `""` | Tag used when `image.digest` is empty. Falls through to `.Chart.AppVersion` if also empty. |
+| `image.digest` | v2.5.0 multi-arch manifest digest | When set, the chart renders `repository@digest` for pinning |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
 
 ### Ports
@@ -56,7 +56,7 @@ Community installs do not need a license. Pro features (per-agent profiles, CIDR
 | `license.secretKey` | `license.token` | Key within the Secret |
 | `license.mountPath` | `/etc/pipelock/license` | Where the Secret is mounted in the pod |
 
-When enabled, the chart also sets `PIPELOCK_LICENSE` from the same Secret as an env var.
+When enabled, the chart sets `PIPELOCK_LICENSE_KEY` from the same Secret and renders `license_file` to the mounted Secret path.
 
 ### Sentry
 
@@ -73,9 +73,8 @@ When enabled, the chart also sets `PIPELOCK_LICENSE` from the same Secret as an 
 | `adminApi.enabled` | `false` | Open the admin port for `pipelock adaptive` / `pipelock session` |
 | `adminApi.tokenSecretRef.name` | `""` | Secret holding the bearer token. Required for authentication. |
 | `adminApi.tokenSecretRef.key` | `token` | Key within the Secret |
-| `adminApi.tokenMountPath` | `/etc/pipelock/admin` | Mount path. Pipelock reads the token from this file. |
 
-When enabled, the chart sets `kill_switch.api_listen` and `kill_switch.api_token_path` in the generated pipelock.yaml.
+When enabled, the chart sets `kill_switch.api_listen` in the generated pipelock.yaml and sources the bearer token from `PIPELOCK_KILLSWITCH_API_TOKEN`.
 
 ### MCP sidecar
 
@@ -110,8 +109,7 @@ The chart automatically templates these into the config and they should not be s
 - `fetch_proxy.listen` (from `service.port`)
 - `metrics_listen` (from `service.metricsPort`)
 - `kill_switch.api_listen` (from `service.adminPort` when `adminApi.enabled`)
-- `kill_switch.api_token_path` (from `adminApi.tokenSecretRef`)
-- `license_token_path` (from `license.existingSecret`)
+- `license_file` (from `license.existingSecret`)
 
 ## Examples
 

--- a/charts/pipelock/examples/values-ha.yaml
+++ b/charts/pipelock/examples/values-ha.yaml
@@ -1,8 +1,8 @@
 # High-availability install: 3 replicas, PodDisruptionBudget, topology spread,
 # NetworkPolicy, and Prometheus Operator PodMonitor.
 #
-# Install:
-#   helm install pipelock ./charts/pipelock -f values-ha.yaml
+# Install (from repo root):
+#   helm install pipelock ./charts/pipelock -f charts/pipelock/examples/values-ha.yaml
 
 replicaCount: 3
 

--- a/charts/pipelock/examples/values-ha.yaml
+++ b/charts/pipelock/examples/values-ha.yaml
@@ -1,0 +1,42 @@
+# High-availability install: 3 replicas, PodDisruptionBudget, topology spread,
+# NetworkPolicy, and Prometheus Operator PodMonitor.
+#
+# Install:
+#   helm install pipelock ./charts/pipelock -f values-ha.yaml
+
+replicaCount: 3
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: pipelock
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: pipelock
+
+priorityClassName: system-cluster-critical
+
+networkPolicy:
+  enabled: true
+
+podMonitor:
+  enabled: true
+  interval: 30s
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi

--- a/charts/pipelock/examples/values-mcp-sidecar.yaml
+++ b/charts/pipelock/examples/values-mcp-sidecar.yaml
@@ -1,0 +1,25 @@
+# MCP HTTP listener mode: bridges agent MCP traffic to an upstream MCP server.
+# The pod exposes both the standard fetch/forward proxy on 8888 AND an MCP
+# HTTP listener on 8889 that forwards to mcp.upstream.
+#
+# Install:
+#   helm install pipelock-mcp ./charts/pipelock -f values-mcp-sidecar.yaml
+
+mcp:
+  enabled: true
+  upstream: "http://your-mcp-server.namespace.svc.cluster.local:3000/mcp"
+  listen: "0.0.0.0:8889"
+
+pipelock:
+  mode: balanced
+  enforce: true
+  mcp_input_scanning:
+    enabled: true
+    action: block
+  mcp_tool_scanning:
+    enabled: true
+    detect_drift: true
+  mcp_tool_policy:
+    enabled: true
+  redaction:
+    enabled: true

--- a/charts/pipelock/examples/values-mcp-sidecar.yaml
+++ b/charts/pipelock/examples/values-mcp-sidecar.yaml
@@ -2,8 +2,8 @@
 # The pod exposes both the standard fetch/forward proxy on 8888 AND an MCP
 # HTTP listener on 8889 that forwards to mcp.upstream.
 #
-# Install:
-#   helm install pipelock-mcp ./charts/pipelock -f values-mcp-sidecar.yaml
+# Install (from repo root):
+#   helm install pipelock-mcp ./charts/pipelock -f charts/pipelock/examples/values-mcp-sidecar.yaml
 
 mcp:
   enabled: true

--- a/charts/pipelock/examples/values-pro.yaml
+++ b/charts/pipelock/examples/values-pro.yaml
@@ -1,0 +1,60 @@
+# Pro / Enterprise install: license token mounted from a Secret, admin API
+# enabled with bearer-token auth, Sentry DSN wired in, and per-agent profiles
+# configured under .pipelock.agents.
+#
+# Prerequisites:
+#   kubectl create secret generic pipelock-license \
+#     --from-file=license.token=./pipelab-master.token
+#   kubectl create secret generic pipelock-admin \
+#     --from-literal=token=$(openssl rand -hex 32)
+#   kubectl create secret generic pipelock-sentry \
+#     --from-literal=dsn=https://...@sentry.io/...
+#
+# Install:
+#   helm install pipelock ./charts/pipelock -f values-pro.yaml
+
+replicaCount: 2
+
+license:
+  enabled: true
+  existingSecret: pipelock-license
+
+sentry:
+  enabled: true
+  dsnSecretRef:
+    name: pipelock-sentry
+    key: dsn
+
+adminApi:
+  enabled: true
+  tokenSecretRef:
+    name: pipelock-admin
+    key: token
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: pipelock
+
+pipelock:
+  mode: strict
+  enforce: true
+  mediation_envelope:
+    actor_format: spiffe
+  health_watchdog:
+    enabled: true
+    expose_subsystems: false
+  agents:
+    - name: claude-code
+      cidr: "10.0.0.0/16"
+      mode: balanced
+    - name: cursor
+      cidr: "10.1.0.0/16"
+      mode: strict

--- a/charts/pipelock/examples/values-pro.yaml
+++ b/charts/pipelock/examples/values-pro.yaml
@@ -10,8 +10,8 @@
 #   kubectl create secret generic pipelock-sentry \
 #     --from-literal=dsn=https://...@sentry.io/...
 #
-# Install:
-#   helm install pipelock ./charts/pipelock -f values-pro.yaml
+# Install (from repo root):
+#   helm install pipelock ./charts/pipelock -f charts/pipelock/examples/values-pro.yaml
 
 replicaCount: 2
 

--- a/charts/pipelock/templates/NOTES.txt
+++ b/charts/pipelock/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Pipelock {{ .Chart.AppVersion }} deployed.
+Pipelock {{ .Chart.AppVersion }} deployed as release {{ .Release.Name }}.
 
 Proxy endpoint:
   kubectl port-forward svc/{{ include "pipelock.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
@@ -7,17 +7,45 @@ Test the scanner:
   export HTTPS_PROXY=http://127.0.0.1:{{ .Values.service.port }}
   pipelock simulate --config /etc/pipelock/pipelock.yaml
 
-Health check:
+Health watchdog (used by liveness + readiness):
   curl http://127.0.0.1:{{ .Values.service.port }}/health
+  # 200 = all subsystems healthy
+  # 503 = at least one subsystem wedged (Kubernetes will restart the pod)
 
 Logs:
   kubectl logs -l app.kubernetes.io/name={{ include "pipelock.name" . }},app.kubernetes.io/instance={{ .Release.Name }} --tail=50
+
 {{- if and .Values.mcp.enabled .Values.mcp.upstream }}
 
-MCP proxy:
+MCP proxy (upstream {{ .Values.mcp.upstream }}):
   kubectl port-forward svc/{{ include "pipelock.fullname" . }} {{ .Values.service.mcpPort }}:{{ .Values.service.mcpPort }}
 {{- end }}
 
-Metrics (Prometheus):
+Prometheus metrics:
   kubectl port-forward svc/{{ include "pipelock.fullname" . }} {{ .Values.service.metricsPort }}:{{ .Values.service.metricsPort }}
   curl http://127.0.0.1:{{ .Values.service.metricsPort }}/metrics
+{{- if .Values.podMonitor.enabled }}
+  # PodMonitor is enabled. Prometheus Operator scrapes this endpoint every {{ .Values.podMonitor.interval }} automatically.
+{{- end }}
+
+{{- if .Values.adminApi.enabled }}
+
+Admin API (port {{ .Values.service.adminPort }}):
+  kubectl port-forward svc/{{ include "pipelock.fullname" . }} {{ .Values.service.adminPort }}:{{ .Values.service.adminPort }}
+  pipelock adaptive status --api-url http://127.0.0.1:{{ .Values.service.adminPort }}
+  pipelock session list   --api-url http://127.0.0.1:{{ .Values.service.adminPort }}
+{{- if not .Values.adminApi.tokenSecretRef.name }}
+  # WARNING: adminApi.enabled is true but adminApi.tokenSecretRef.name is not set.
+  # The admin API is reachable without authentication. Provide a Secret holding the bearer token.
+{{- end }}
+{{- end }}
+
+{{- if and .Values.license.enabled (not .Values.license.existingSecret) }}
+
+WARNING: license.enabled is true but license.existingSecret is not set. Pro features will not activate.
+{{- end }}
+
+{{- if and (gt (int .Values.replicaCount) 1) (not .Values.podDisruptionBudget.enabled) }}
+
+NOTE: {{ .Values.replicaCount }} replicas running without a PodDisruptionBudget. A node drain or rollout can take all pods down at once. Set podDisruptionBudget.enabled=true to keep at least one replica available during voluntary disruptions.
+{{- end }}

--- a/charts/pipelock/templates/NOTES.txt
+++ b/charts/pipelock/templates/NOTES.txt
@@ -32,12 +32,9 @@ Prometheus metrics:
 
 Admin API (port {{ .Values.service.adminPort }}):
   kubectl port-forward svc/{{ include "pipelock.fullname" . }} {{ .Values.service.adminPort }}:{{ .Values.service.adminPort }}
+  export PIPELOCK_KILLSWITCH_API_TOKEN=$(kubectl get secret {{ required "adminApi.tokenSecretRef.name is required when adminApi.enabled=true" .Values.adminApi.tokenSecretRef.name }} -o jsonpath='{.data.{{ required "adminApi.tokenSecretRef.key is required when adminApi.enabled=true" .Values.adminApi.tokenSecretRef.key }}}' | base64 -d)
   pipelock adaptive status --api-url http://127.0.0.1:{{ .Values.service.adminPort }}
   pipelock session list   --api-url http://127.0.0.1:{{ .Values.service.adminPort }}
-{{- if not .Values.adminApi.tokenSecretRef.name }}
-  # WARNING: adminApi.enabled is true but adminApi.tokenSecretRef.name is not set.
-  # The admin API is reachable without authentication. Provide a Secret holding the bearer token.
-{{- end }}
 {{- end }}
 
 {{- if and .Values.license.enabled (not .Values.license.existingSecret) }}

--- a/charts/pipelock/templates/NOTES.txt
+++ b/charts/pipelock/templates/NOTES.txt
@@ -32,7 +32,8 @@ Prometheus metrics:
 
 Admin API (port {{ .Values.service.adminPort }}):
   kubectl port-forward svc/{{ include "pipelock.fullname" . }} {{ .Values.service.adminPort }}:{{ .Values.service.adminPort }}
-  export PIPELOCK_KILLSWITCH_API_TOKEN=$(kubectl get secret {{ required "adminApi.tokenSecretRef.name is required when adminApi.enabled=true" .Values.adminApi.tokenSecretRef.name }} -o jsonpath='{.data.{{ required "adminApi.tokenSecretRef.key is required when adminApi.enabled=true" .Values.adminApi.tokenSecretRef.key }}}' | base64 -d)
+  # The pod sources the bearer token from Secret {{ required "adminApi.tokenSecretRef.name is required when adminApi.enabled=true" .Values.adminApi.tokenSecretRef.name }} (key: {{ required "adminApi.tokenSecretRef.key is required when adminApi.enabled=true" .Values.adminApi.tokenSecretRef.key }}).
+  # Read it locally and pass with --api-token, or export it as your env (see pipelock adaptive --help).
   pipelock adaptive status --api-url http://127.0.0.1:{{ .Values.service.adminPort }}
   pipelock session list   --api-url http://127.0.0.1:{{ .Values.service.adminPort }}
 {{- end }}

--- a/charts/pipelock/templates/configmap.yaml
+++ b/charts/pipelock/templates/configmap.yaml
@@ -9,4 +9,14 @@ data:
     {{- $cfg := deepCopy .Values.pipelock }}
     {{- $_ := set $cfg "fetch_proxy" (merge (dict "listen" (printf "0.0.0.0:%d" (int .Values.service.port))) (default dict $cfg.fetch_proxy)) }}
     {{- $_ := set $cfg "metrics_listen" (printf "0.0.0.0:%d" (int .Values.service.metricsPort)) }}
+    {{- if .Values.adminApi.enabled }}
+    {{- $ks := merge (dict "api_listen" (printf "0.0.0.0:%d" (int .Values.service.adminPort))) (default dict $cfg.kill_switch) }}
+    {{- if .Values.adminApi.tokenSecretRef.name }}
+    {{- $_ := set $ks "api_token_path" (printf "%s/%s" .Values.adminApi.tokenMountPath .Values.adminApi.tokenSecretRef.key) }}
+    {{- end }}
+    {{- $_ := set $cfg "kill_switch" $ks }}
+    {{- end }}
+    {{- if and .Values.license.enabled .Values.license.existingSecret }}
+    {{- $_ := set $cfg "license_token_path" (printf "%s/%s" .Values.license.mountPath .Values.license.secretKey) }}
+    {{- end }}
     {{- toYaml $cfg | nindent 4 }}

--- a/charts/pipelock/templates/configmap.yaml
+++ b/charts/pipelock/templates/configmap.yaml
@@ -11,12 +11,9 @@ data:
     {{- $_ := set $cfg "metrics_listen" (printf "0.0.0.0:%d" (int .Values.service.metricsPort)) }}
     {{- if .Values.adminApi.enabled }}
     {{- $ks := merge (dict "api_listen" (printf "0.0.0.0:%d" (int .Values.service.adminPort))) (default dict $cfg.kill_switch) }}
-    {{- if .Values.adminApi.tokenSecretRef.name }}
-    {{- $_ := set $ks "api_token_path" (printf "%s/%s" .Values.adminApi.tokenMountPath .Values.adminApi.tokenSecretRef.key) }}
-    {{- end }}
     {{- $_ := set $cfg "kill_switch" $ks }}
     {{- end }}
     {{- if and .Values.license.enabled .Values.license.existingSecret }}
-    {{- $_ := set $cfg "license_token_path" (printf "%s/%s" .Values.license.mountPath .Values.license.secretKey) }}
+    {{- $_ := set $cfg "license_file" (printf "%s/%s" .Values.license.mountPath .Values.license.secretKey) }}
     {{- end }}
     {{- toYaml $cfg | nindent 4 }}

--- a/charts/pipelock/templates/deployment.yaml
+++ b/charts/pipelock/templates/deployment.yaml
@@ -77,11 +77,18 @@ spec:
           {{- end }}
           {{- $hasLicenseEnv := and .Values.license.enabled .Values.license.existingSecret }}
           {{- $hasSentryEnv := and .Values.sentry.enabled .Values.sentry.dsnSecretRef.name }}
+          {{- $adminTokenSecret := "" }}
+          {{- $adminTokenKey := "" }}
+          {{- if .Values.adminApi.enabled }}
+          {{- $adminTokenSecret = required "adminApi.tokenSecretRef.name is required when adminApi.enabled=true" .Values.adminApi.tokenSecretRef.name }}
+          {{- $adminTokenKey = required "adminApi.tokenSecretRef.key is required when adminApi.enabled=true" .Values.adminApi.tokenSecretRef.key }}
+          {{- end }}
+          {{- $hasAdminEnv := and .Values.adminApi.enabled $adminTokenSecret }}
           {{- $hasExtraEnv := gt (len .Values.extraEnv) 0 }}
-          {{- if or $hasLicenseEnv $hasSentryEnv $hasExtraEnv }}
+          {{- if or $hasLicenseEnv $hasSentryEnv $hasAdminEnv $hasExtraEnv }}
           env:
             {{- if $hasLicenseEnv }}
-            - name: PIPELOCK_LICENSE
+            - name: PIPELOCK_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.license.existingSecret | quote }}
@@ -93,6 +100,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.sentry.dsnSecretRef.name | quote }}
                   key: {{ .Values.sentry.dsnSecretRef.key | quote }}
+            {{- end }}
+            {{- if $hasAdminEnv }}
+            - name: PIPELOCK_KILLSWITCH_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $adminTokenSecret | quote }}
+                  key: {{ $adminTokenKey | quote }}
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
@@ -114,11 +128,6 @@ spec:
               mountPath: {{ .Values.license.mountPath | quote }}
               readOnly: true
             {{- end }}
-            {{- if and .Values.adminApi.enabled .Values.adminApi.tokenSecretRef.name }}
-            - name: admin-token
-              mountPath: {{ .Values.adminApi.tokenMountPath | quote }}
-              readOnly: true
-            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -130,12 +139,6 @@ spec:
         - name: license
           secret:
             secretName: {{ .Values.license.existingSecret | quote }}
-            defaultMode: 0400
-        {{- end }}
-        {{- if and .Values.adminApi.enabled .Values.adminApi.tokenSecretRef.name }}
-        - name: admin-token
-          secret:
-            secretName: {{ .Values.adminApi.tokenSecretRef.name | quote }}
             defaultMode: 0400
         {{- end }}
         {{- with .Values.extraVolumes }}

--- a/charts/pipelock/templates/deployment.yaml
+++ b/charts/pipelock/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "pipelock.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -59,12 +62,44 @@ spec:
             - name: metrics
               containerPort: {{ .Values.service.metricsPort }}
               protocol: TCP
+            {{- if .Values.adminApi.enabled }}
+            - name: admin
+              containerPort: {{ .Values.service.adminPort }}
+              protocol: TCP
+            {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.readinessProbe }}
           readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- $hasLicenseEnv := and .Values.license.enabled .Values.license.existingSecret }}
+          {{- $hasSentryEnv := and .Values.sentry.enabled .Values.sentry.dsnSecretRef.name }}
+          {{- $hasExtraEnv := gt (len .Values.extraEnv) 0 }}
+          {{- if or $hasLicenseEnv $hasSentryEnv $hasExtraEnv }}
+          env:
+            {{- if $hasLicenseEnv }}
+            - name: PIPELOCK_LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.license.existingSecret | quote }}
+                  key: {{ .Values.license.secretKey | quote }}
+            {{- end }}
+            {{- if $hasSentryEnv }}
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.sentry.dsnSecretRef.name | quote }}
+                  key: {{ .Values.sentry.dsnSecretRef.key | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
@@ -74,10 +109,38 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/pipelock
+            {{- if and .Values.license.enabled .Values.license.existingSecret }}
+            - name: license
+              mountPath: {{ .Values.license.mountPath | quote }}
+              readOnly: true
+            {{- end }}
+            {{- if and .Values.adminApi.enabled .Values.adminApi.tokenSecretRef.name }}
+            - name: admin-token
+              mountPath: {{ .Values.adminApi.tokenMountPath | quote }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ include "pipelock.fullname" . }}
+        {{- if and .Values.license.enabled .Values.license.existingSecret }}
+        - name: license
+          secret:
+            secretName: {{ .Values.license.existingSecret | quote }}
+            defaultMode: 0400
+        {{- end }}
+        {{- if and .Values.adminApi.enabled .Values.adminApi.tokenSecretRef.name }}
+        - name: admin-token
+          secret:
+            secretName: {{ .Values.adminApi.tokenSecretRef.name | quote }}
+            defaultMode: 0400
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -88,5 +151,9 @@ spec:
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/pipelock/templates/networkpolicy.yaml
+++ b/charts/pipelock/templates/networkpolicy.yaml
@@ -24,6 +24,10 @@ spec:
         {{- end }}
         - port: {{ .Values.service.metricsPort }}
           protocol: TCP
+        {{- if .Values.adminApi.enabled }}
+        - port: {{ .Values.service.adminPort }}
+          protocol: TCP
+        {{- end }}
   egress:
     # DNS resolution required for all proxy modes
     - ports:

--- a/charts/pipelock/templates/poddisruptionbudget.yaml
+++ b/charts/pipelock/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "pipelock.fullname" . }}
+  labels:
+    {{- include "pipelock.labels" . | nindent 4 }}
+spec:
+  {{- if hasKey .Values.podDisruptionBudget "minAvailable" }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "pipelock.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/pipelock/templates/poddisruptionbudget.yaml
+++ b/charts/pipelock/templates/poddisruptionbudget.yaml
@@ -6,7 +6,11 @@ metadata:
   labels:
     {{- include "pipelock.labels" . | nindent 4 }}
 spec:
-  {{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+  {{- $hasMin := hasKey .Values.podDisruptionBudget "minAvailable" }}
+  {{- $hasMax := hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+  {{- if and $hasMin $hasMax }}
+  {{- fail "podDisruptionBudget: set only one of minAvailable or maxUnavailable, not both" }}
+  {{- else if $hasMax }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- else }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}

--- a/charts/pipelock/templates/poddisruptionbudget.yaml
+++ b/charts/pipelock/templates/poddisruptionbudget.yaml
@@ -6,11 +6,10 @@ metadata:
   labels:
     {{- include "pipelock.labels" . | nindent 4 }}
 spec:
-  {{- if hasKey .Values.podDisruptionBudget "minAvailable" }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-  {{- end }}
   {{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/pipelock/templates/service.yaml
+++ b/charts/pipelock/templates/service.yaml
@@ -23,3 +23,9 @@ spec:
       targetPort: metrics
       protocol: TCP
       name: metrics
+    {{- if .Values.adminApi.enabled }}
+    - port: {{ .Values.service.adminPort }}
+      targetPort: admin
+      protocol: TCP
+      name: admin
+    {{- end }}

--- a/charts/pipelock/values.schema.json
+++ b/charts/pipelock/values.schema.json
@@ -46,7 +46,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
         },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "mcpPort": { "type": "integer", "minimum": 1, "maximum": 65535 },

--- a/charts/pipelock/values.schema.json
+++ b/charts/pipelock/values.schema.json
@@ -114,8 +114,7 @@
             "name": { "type": "string" },
             "key": { "type": "string" }
           }
-        },
-        "tokenMountPath": { "type": "string" }
+        }
       }
     },
     "pipelock": {

--- a/charts/pipelock/values.schema.json
+++ b/charts/pipelock/values.schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Pipelock Helm values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "image": {
+      "type": "object",
+      "required": ["repository", "pullPolicy"],
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" },
+        "digest": { "type": "string" },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "automount": { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "name": { "type": "string" }
+      }
+    },
+    "podAnnotations": { "type": "object" },
+    "podLabels": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "service": {
+      "type": "object",
+      "required": ["type", "port", "metricsPort"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+        },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "mcpPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "metricsPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "adminPort": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      }
+    },
+    "resources": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array" },
+    "priorityClassName": { "type": "string" },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string", "pattern": "^[0-9]+%$" }
+          ]
+        },
+        "maxUnavailable": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string", "pattern": "^[0-9]+%$" }
+          ]
+        }
+      }
+    },
+    "extraEnv": { "type": "array" },
+    "extraEnvFrom": { "type": "array" },
+    "extraVolumes": { "type": "array" },
+    "extraVolumeMounts": { "type": "array" },
+    "license": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "existingSecret": { "type": "string" },
+        "secretKey": { "type": "string" },
+        "mountPath": { "type": "string" }
+      }
+    },
+    "sentry": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "dsnSecretRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "key": { "type": "string" }
+          }
+        }
+      }
+    },
+    "adminApi": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "tokenSecretRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "key": { "type": "string" }
+          }
+        },
+        "tokenMountPath": { "type": "string" }
+      }
+    },
+    "pipelock": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "mcp": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "upstream": { "type": "string" },
+        "listen": { "type": "string" }
+      }
+    },
+    "podMonitor": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "interval": { "type": "string" },
+        "labels": { "type": "object" }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "livenessProbe": { "type": "object" },
+    "readinessProbe": { "type": "object" }
+  }
+}

--- a/charts/pipelock/values.yaml
+++ b/charts/pipelock/values.yaml
@@ -2,7 +2,10 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/luckypipewrench/pipelock
-  tag: "@sha256:3dcd7e8860a9868ad1849de2786c6dfa4e9180b66d91aa7bddcd1c6aca286983"  # defaults to .Chart.AppVersion
+  # Default tag tracks the chart appVersion. To pin by digest, set image.digest
+  # to a sha256 string and the chart will render repository@digest. The tag
+  # value below is the v2.5.0 multi-arch manifest digest.
+  tag: "@sha256:ea07c3b476829e0a9c13b8484aa9c71e60e811c5fdf07d35e17bcb889bb72446"  # defaults to .Chart.AppVersion
   digest: ""  # optional sha256 digest; when set, repository@digest is used
   pullPolicy: IfNotPresent
 
@@ -13,6 +16,9 @@ fullnameOverride: ""
 serviceAccount:
   create: true
   automount: false
+  # Annotations on the ServiceAccount. Useful for IRSA (AWS), Workload Identity
+  # (GCP/Azure), or Vault Agent injection patterns where the chart needs to
+  # bind a cloud identity for license fetch or Sentry DSN retrieval.
   annotations: {}
   # name: ""
 
@@ -37,6 +43,8 @@ service:
   port: 8888
   mcpPort: 8889
   metricsPort: 9091
+  # Admin API port. Only exposed on the Service when adminApi.enabled is true.
+  adminPort: 9090
 
 resources:
   requests:
@@ -50,9 +58,96 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+# Spread replicas across topology domains. Most useful when replicaCount >= 2.
+topologySpreadConstraints: []
+priorityClassName: ""
+
+# PodDisruptionBudget. Strongly recommended when running multiple replicas
+# behind a single Service, because pipelock is on the agent's critical
+# traffic path and a single eviction takes the proxy down for that pod.
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1  # set only one of minAvailable / maxUnavailable
+
+# Additional environment variables passed to the pipelock container.
+# Used for license tokens (PIPELOCK_LICENSE), Sentry DSN, and admin API token.
+extraEnv: []
+# - name: PIPELOCK_LICENSE
+#   valueFrom:
+#     secretKeyRef:
+#       name: pipelock-license
+#       key: license.token
+
+extraEnvFrom: []
+# - secretRef:
+#     name: pipelock-secrets
+
+# Additional volumes and mounts. Useful for mounting a license token at a
+# specific path or providing extra CA bundles for TLS interception.
+extraVolumes: []
+# - name: pipelock-license
+#   secret:
+#     secretName: pipelock-license
+extraVolumeMounts: []
+# - name: pipelock-license
+#   mountPath: /etc/pipelock/license
+#   readOnly: true
+
+# Pipelock Pro / Enterprise license. Pro features (per-agent profiles,
+# CIDR matching, budgets) require a valid signed license token.
+license:
+  # Set to true to mount the license token into the pod. Community/free
+  # installs do not need this — all detection and enforcement layers ship
+  # in the open-source binary.
+  enabled: false
+  # Name of an existing Kubernetes Secret holding the license token. The
+  # Secret must contain the key named below (default: license.token).
+  existingSecret: ""
+  secretKey: "license.token"
+  # Path inside the container where the secret is mounted. Pipelock looks
+  # at ~/.config/pipelock/license.token by default; this path is documented
+  # for operators who set licenseTokenPath in pipelock.yaml.
+  mountPath: "/etc/pipelock/license"
+
+# Sentry error reporting. When enabled, sets SENTRY_DSN from a Secret.
+sentry:
+  enabled: false
+  dsnSecretRef:
+    name: ""
+    key: "dsn"
+
+# Authenticated admin API for `pipelock adaptive` and `pipelock session`
+# commands. When enabled, the chart renders kill_switch.api_listen into the
+# config and exposes the admin port on the Service.
+adminApi:
+  enabled: false
+  # Token Secret. Required when adminApi.enabled is true. The Secret must
+  # contain the key named below (default: token). Token is mounted at the
+  # path documented in pipelock.yaml as kill_switch.api_token_path.
+  tokenSecretRef:
+    name: ""
+    key: "token"
+  tokenMountPath: "/etc/pipelock/admin"
+
 # Pipelock configuration (rendered into ConfigMap as pipelock.yaml).
 # NOTE: fetch_proxy.listen and metrics_listen are templated from service.port
 # and service.metricsPort. Do not set them here; change the service values instead.
+# When adminApi.enabled is true, kill_switch.api_listen is also templated from
+# service.adminPort and should not be set here.
+#
+# Common v2.5 sections you may want to add under pipelock: below:
+#   mediation_envelope:     SPIFFE actor format, inbound verification trust list
+#   health_watchdog:        wedge-detection liveness probe surface
+#   browser_shield:         oversize action, exempt domains, max bytes
+#   redaction:              Anthropic / OpenAI / Gemini parser profile
+#   learn:                  observe / compile / shadow / promote contract pipeline
+#   agents:                 per-agent profiles (Pro license required)
+#   adaptive_enforcement:   signal weights, airlock thresholds
+#   kill_switch:            sources, api_token_path (auto-set when adminApi.enabled)
+#   request_body_scanning:  body-side DLP toggles
+#   file_sentry:            workspace file integrity monitoring
+#   sentry:                 DSN is set via the sentry block above
 pipelock:
   version: 1
   mode: balanced
@@ -96,6 +191,8 @@ livenessProbe:
     port: http
   initialDelaySeconds: 5
   periodSeconds: 30
+  timeoutSeconds: 3
+  failureThreshold: 3
 
 readinessProbe:
   httpGet:
@@ -103,3 +200,5 @@ readinessProbe:
     port: http
   initialDelaySeconds: 2
   periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 2

--- a/charts/pipelock/values.yaml
+++ b/charts/pipelock/values.yaml
@@ -4,9 +4,9 @@ image:
   repository: ghcr.io/luckypipewrench/pipelock
   # Default tag tracks the chart appVersion. To pin by digest, set image.digest
   # to a sha256 string and the chart will render repository@digest. The tag
-  # value below is the v2.5.0 multi-arch manifest digest.
-  tag: "@sha256:ea07c3b476829e0a9c13b8484aa9c71e60e811c5fdf07d35e17bcb889bb72446"  # defaults to .Chart.AppVersion
-  digest: ""  # optional sha256 digest; when set, repository@digest is used
+  # value falls through to .Chart.AppVersion when empty.
+  tag: ""  # defaults to .Chart.AppVersion
+  digest: "sha256:ea07c3b476829e0a9c13b8484aa9c71e60e811c5fdf07d35e17bcb889bb72446"  # v2.5.0 multi-arch manifest digest
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -71,9 +71,9 @@ podDisruptionBudget:
   # maxUnavailable: 1  # set only one of minAvailable / maxUnavailable
 
 # Additional environment variables passed to the pipelock container.
-# Used for license tokens (PIPELOCK_LICENSE), Sentry DSN, and admin API token.
+# Used for license tokens (PIPELOCK_LICENSE_KEY), Sentry DSN, and admin API token.
 extraEnv: []
-# - name: PIPELOCK_LICENSE
+# - name: PIPELOCK_LICENSE_KEY
 #   valueFrom:
 #     secretKeyRef:
 #       name: pipelock-license
@@ -97,7 +97,7 @@ extraVolumeMounts: []
 # Pipelock Pro / Enterprise license. Pro features (per-agent profiles,
 # CIDR matching, budgets) require a valid signed license token.
 license:
-  # Set to true to mount the license token into the pod. Community/free
+  # Set to true to source the license token from a Secret. Community/free
   # installs do not need this — all detection and enforcement layers ship
   # in the open-source binary.
   enabled: false
@@ -105,9 +105,9 @@ license:
   # Secret must contain the key named below (default: license.token).
   existingSecret: ""
   secretKey: "license.token"
-  # Path inside the container where the secret is mounted. Pipelock looks
-  # at ~/.config/pipelock/license.token by default; this path is documented
-  # for operators who set licenseTokenPath in pipelock.yaml.
+  # Path inside the container where the secret is mounted. The chart also
+  # sets PIPELOCK_LICENSE_KEY from the Secret; license_file is rendered for
+  # operators who prefer file-based license loading.
   mountPath: "/etc/pipelock/license"
 
 # Sentry error reporting. When enabled, sets SENTRY_DSN from a Secret.
@@ -123,12 +123,11 @@ sentry:
 adminApi:
   enabled: false
   # Token Secret. Required when adminApi.enabled is true. The Secret must
-  # contain the key named below (default: token). Token is mounted at the
-  # path documented in pipelock.yaml as kill_switch.api_token_path.
+  # contain the key named below (default: token). The chart exposes the token
+  # via PIPELOCK_KILLSWITCH_API_TOKEN so it does not land in the ConfigMap.
   tokenSecretRef:
     name: ""
     key: "token"
-  tokenMountPath: "/etc/pipelock/admin"
 
 # Pipelock configuration (rendered into ConfigMap as pipelock.yaml).
 # NOTE: fetch_proxy.listen and metrics_listen are templated from service.port
@@ -144,10 +143,11 @@ adminApi:
 #   learn:                  observe / compile / shadow / promote contract pipeline
 #   agents:                 per-agent profiles (Pro license required)
 #   adaptive_enforcement:   signal weights, airlock thresholds
-#   kill_switch:            sources, api_token_path (auto-set when adminApi.enabled)
+#   kill_switch:            sources, api_listen (auto-set when adminApi.enabled)
 #   request_body_scanning:  body-side DLP toggles
 #   file_sentry:            workspace file integrity monitoring
 #   sentry:                 DSN is set via the sentry block above
+#   license_file:           auto-set when license.enabled and existingSecret are set
 pipelock:
   version: 1
   mode: balanced

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6641,6 +6641,19 @@ func TestValidate_KillSwitchAPIListen_Valid(t *testing.T) {
 	}
 }
 
+func TestValidate_KillSwitchAPIListen_EnvTokenValid(t *testing.T) {
+	t.Setenv(EnvKillSwitchAPIToken, testToken)
+
+	cfg := Defaults()
+	cfg.ApplyDefaults()
+	cfg.KillSwitch.APIListen = testAPIListen
+	cfg.KillSwitch.APIToken = ""
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("api_listen with %s should pass validation: %v", EnvKillSwitchAPIToken, err)
+	}
+}
+
 func TestValidate_KillSwitchAPIListen_Empty(t *testing.T) {
 	cfg := Defaults()
 	cfg.ApplyDefaults()

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -127,6 +127,10 @@ const (
 	// EnvLicenseKey is the environment variable for license token override.
 	// Takes highest priority over license_file and license_key config fields.
 	EnvLicenseKey = "PIPELOCK_LICENSE_KEY"
+
+	// EnvKillSwitchAPIToken is the environment variable for admin API bearer
+	// token override. Takes priority over kill_switch.api_token.
+	EnvKillSwitchAPIToken = "PIPELOCK_KILLSWITCH_API_TOKEN" //nolint:gosec // env var name, not a credential
 )
 
 // SuppressEntry defines a finding suppression rule for false positives.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1199,8 +1199,8 @@ func (c *Config) validateKillSwitch() error {
 		if apiPort == proxyPort {
 			return fmt.Errorf("kill_switch.api_listen port %s collides with fetch_proxy.listen port %s", apiPort, proxyPort)
 		}
-		if c.KillSwitch.APIToken == "" {
-			return fmt.Errorf("kill_switch.api_listen requires kill_switch.api_token to be set")
+		if c.KillSwitch.APIToken == "" && os.Getenv(EnvKillSwitchAPIToken) == "" {
+			return fmt.Errorf("kill_switch.api_listen requires kill_switch.api_token or %s to be set", EnvKillSwitchAPIToken)
 		}
 	}
 	return nil

--- a/internal/killswitch/killswitch.go
+++ b/internal/killswitch/killswitch.go
@@ -23,7 +23,7 @@ import (
 // from the config file. When set to a non-empty value, it takes priority over
 // the config file value. This allows Kubernetes deployments to source the token
 // from a Secret (via env[].valueFrom.secretKeyRef) instead of a ConfigMap.
-const EnvAPIToken = "PIPELOCK_" + "KILLSWITCH_API_TOKEN" //nolint:gosec // env var name, not a credential
+const EnvAPIToken = config.EnvKillSwitchAPIToken
 
 // Decision describes the outcome of a kill switch check.
 type Decision struct {


### PR DESCRIPTION
Bumps the pipelock helm chart to 0.2.0, pins the default image to the v2.5.0 multi-arch manifest digest, and adds the plumbing that v2.5 deployments need but the previous chart did not provide.

Image and digest pinning

`image.digest` now carries the v2.5.0 sha256 (`ea07c3b...`) and renders as `repository@digest`. The previous shape put the digest in `image.tag` with a leading `@` and rendered as `repository:@sha256:...`, which is not a valid image reference. Leaving `image.tag` empty lets it fall through to `.Chart.AppVersion` for tag-based installs.

Admin API authentication

When `adminApi.enabled` is true, the chart now sources the bearer token from a Kubernetes Secret via `PIPELOCK_KILLSWITCH_API_TOKEN`. The Go side accepts this env var as an equivalent source to `kill_switch.api_token` so validation passes when the config field is empty but the env is set. The token never lands on disk and never appears in the ConfigMap.

Helm rendering fails fast (via `required`) when `adminApi.enabled` is true without a Secret reference, so you cannot accidentally expose an unauthenticated admin port.

License and Sentry plumbing

`license.*` mounts a Secret as a volume, exports `PIPELOCK_LICENSE_KEY` from the same Secret, and writes the correct `license_file` config key into the ConfigMap. `sentry.dsnSecretRef` sets `SENTRY_DSN` from a Secret.

`extraEnv`, `extraEnvFrom`, `extraVolumes`, and `extraVolumeMounts` hooks land for anything outside the first-class shape.

Availability and topology

New `poddisruptionbudget.yaml` template protects multi-replica installs from node-drain wipeout. The PDB picks one of `maxUnavailable` / `minAvailable` (Kubernetes rejects PDBs with both). `topologySpreadConstraints` and `priorityClassName` parameters land in values.

Health probes

`/health` probes gain `timeoutSeconds` and `failureThreshold` so the v2.5 health watchdog drives pod restart instead of just returning a status. Existing probe behavior is unchanged at defaults.

Operator UX

`NOTES.txt` documents the admin port, license, and HA warnings. New chart `README.md` covers values for ArtifactHub. New `examples/` ships `values-pro.yaml`, `values-mcp-sidecar.yaml`, and `values-ha.yaml` as ready-to-use starting points. `Chart.yaml` gains `artifacthub.io/*` annotations.

Schema

`values.schema.json` catches type errors at install time (bad `image.pullPolicy` enum, bad `service.port` type, bad `podDisruptionBudget.minAvailable` string format) while leaving the open-ended `.Values.pipelock` block permissive.

CI

The pre-commit `check-yaml` exclude regex was missing a trailing `.*` so new files under `charts/*/templates/` would fail the YAML parser on Helm template syntax. Fixed so new chart files commit cleanly.

Backwards compatibility

At default values the rendered ConfigMap `pipelock.yaml` is byte-identical to the 0.1.0 chart and no new resources are emitted beyond what the previous chart shipped. New behavior is opt-in.

Validation

`helm lint` passes against default and each example. `helm template` renders cleanly for default, `values-pro`, `values-mcp-sidecar`, and `values-ha`. `values.schema.json` rejects bad input. `adminApi.enabled=true` without a token Secret fails Helm rendering as intended. `go vet`, `go test -race`, and `golangci-lint` pass on the touched packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin API with authenticated token support (env or secret), admin port exposure, and related service/network rules
  * License mounting and Sentry DSN support
  * Optional PodDisruptionBudget, topology spread, priority class, PodMonitor and MCP sidecar options
  * High-availability defaults and example configurations

* **Documentation**
  * Comprehensive chart README, updated release/notes guidance, and a Helm values JSON Schema for validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->