### PR TITLE
chore(renovate): hold TypeScript and jsonschema majors at known-good versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,20 @@
       "matchUpdateTypes": ["major"],
       "addLabels": ["major-update", "needs-review"],
       "automerge": false
+    },
+    {
+      "description": "Hold TypeScript at 5.x in the verifier. TS 6.0 needs tsconfig and source migrations we have not scoped.",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["sdk/verifiers/ts/**"],
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Hold jsonschema at 0.18.x in the Rust verifier. 0.19+ renames JSONSchema to Validator and changes the compile/validate API, needs manual migration.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["jsonschema"],
+      "allowedVersions": "<0.19"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -91,6 +91,7 @@
     {
       "description": "Hold jsonschema at 0.18.x in the Rust verifier. 0.19+ renames JSONSchema to Validator and changes the compile/validate API, needs manual migration.",
       "matchManagers": ["cargo"],
+      "matchFileNames": ["sdk/verifiers/rust/**"],
       "matchPackageNames": ["jsonschema"],
       "allowedVersions": "<0.19"
     }


### PR DESCRIPTION
Two Renovate PRs keep coming back broken because the upstream major bumps need manual API migration we haven't scoped:

- TypeScript 5.x → 6.0 in `sdk/verifiers/ts/` trips `TS2591: Cannot find name 'node:fs'` across `src/*`. Needs tsconfig types update plus source review.
- jsonschema 0.18 → 0.46 in `sdk/verifiers/rust/` renames `JSONSchema` to `Validator` and reshapes the `options().compile()` and `validate()` APIs in `schema.rs`. Needs a rewrite of `validate_schema()`.

Closing the PRs doesn't help; Renovate re-opens them on the next cycle. Pinning at the renovate.json layer is the durable fix.

Two new packageRules:

- typescript major bumps in `sdk/verifiers/ts/**` are disabled
- jsonschema in `sdk/verifiers/rust/**` is constrained to `<0.19`

Other deps in those manifests still update normally. When we're ready to migrate, drop the rule and the next Renovate scan will propose the bump again.

After merge, close #558 and #552.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added dependency update constraints for verifier scopes: disabled major-version updates for the TypeScript package within TypeScript verifier paths.
  * Restricted Rust verifier's jsonschema updates to versions below 0.19.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->