### PR TITLE
fix(redaction): harden body redaction + tighten Databricks DLP pattern

### DIFF
--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -96,9 +96,13 @@ const (
 	// response-scanning corpus now includes mixed English/Spanish instruction
 	// override and system-prompt disclosure patterns.
 	// 2026-05-21: rotated for ToolChainDetection.SensitivityLabels (v2.6
-	// lethal-trifecta detection). Same justification as goldenHashRichConfig
-	// below — adds a policy-semantic field to the canonical hash surface.
-	goldenHashDefaults = "8dd85a3f9c0677deade039b9f23e18e4cb242c4feb656fae6896e5c0898ea536"
+	// lethal-trifecta detection). Adds a policy-semantic field to the
+	// canonical hash surface.
+	// Re-bumped on the Databricks PAT pattern tightening: the default DLP
+	// regex moves from `dapi[a-z0-9]{30,}` to `dapi[0-9a-f]{32,}`. This
+	// matches the documented 32-char hex Databricks token format and removes
+	// a false-positive surface that fired on random base64 image payloads.
+	goldenHashDefaults = "4a9d35253c4c78fc9ee555c3162bf30bf9fd5039c34f49c4b6c80986128c2f74"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -143,7 +147,11 @@ const (
 	// which tools classify into untrusted_source / sensitive_source /
 	// external_sink, which changes which sequences emit the lethal-
 	// trifecta verdict.
-	goldenHashRichConfig = "508d4a0ab6fcce41d9c8286f0df68dec49eff2eba381b07ccb85052ebb09b5a2"
+	// Re-bumped for the Databricks PAT pattern tightening from
+	// `dapi[a-z0-9]{30,}` to `dapi[0-9a-f]{32,}` (defaults.go DLP set), which
+	// closes a false-positive surface in random base64 image payloads while
+	// still matching the documented 32-char hex Databricks token format.
+	goldenHashRichConfig = "5a39175fdc619b47288bf74068a4e7beaeb6959f771e370d8e50a671620ac320"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -113,7 +113,7 @@ func Defaults() *Config {
 
 				// AI/ML provider keys
 				{Name: "Hugging Face Token", Regex: `hf_[A-Za-z0-9]{20,}`, Severity: SeverityCritical},
-				{Name: "Databricks Token", Regex: `dapi[a-z0-9]{30,}`, Severity: SeverityCritical},
+				{Name: "Databricks Token", Regex: `dapi[0-9a-f]{32,}`, Severity: SeverityCritical},
 				{Name: "Replicate API Token", Regex: `r8_[A-Za-z0-9]{20,}`, Severity: SeverityCritical},
 				{Name: "Together AI Key", Regex: `tok_[a-z0-9]{40,}`, Severity: SeverityCritical},
 				// Pinecone API keys: "pcsk_" prefix followed by alphanumeric.

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -206,13 +206,13 @@ type BodyScanRequest struct {
 	// body scan's MaxBytes. Zero values fall through to redact package
 	// defaults.
 	RedactLimits redact.Limits
-	// RedactAllowlistUnparseable lists hostnames whose non-JSON bodies are
-	// permitted through as-is. When the Host is not in this list and the
+	// RedactAllowlistUnparseable lists hostnames whose non-JSON bodies may use
+	// raw-text redaction fallback. When the Host is not in this list and the
 	// body is not JSON, redaction fails closed. Nil/empty = strict.
 	RedactAllowlistUnparseable []string
-	// RedactAllowlistUnparseableRoutes lists route-scoped exceptions for
-	// trusted non-JSON bodies. These are preferred over host-only entries
-	// for OAuth token and upload endpoints.
+	// RedactAllowlistUnparseableRoutes lists route-scoped raw-text fallback
+	// exceptions for trusted non-JSON bodies. These are preferred over
+	// host-only entries for OAuth token and upload endpoints.
 	RedactAllowlistUnparseableRoutes []redact.UnparseableRouteSpec
 	// RedactProviderRegistry selects the provider parser profile for JSON
 	// redaction. Nil falls back to the generic JSON parser.
@@ -274,7 +274,7 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 
 	var preRedactionDLP []scanner.TextDLPMatch
 	if req.RedactMatcher != nil {
-		texts, parseErr := extractBodyText(buf, req.ContentType, req.MaxBytes)
+		texts, parseErr := extractBodyText(buf, req)
 		if parseErr == "" {
 			preRedactionDLP = scanBodyTextsForDLP(ctx, req.Scanner, texts, req.suppressTarget(), req.Suppress)
 		}
@@ -287,7 +287,7 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 	// reported in v1b round 1 review (2026-04-19). DLP then scans the
 	// redacted buf and catches anything redaction did not cover.
 	var redactReport *redact.Report
-	if req.RedactionRequired && req.RedactMatcher == nil && !allowlistSkipsRedactionRewrite(req) {
+	if req.RedactionRequired && req.RedactMatcher == nil {
 		return buf, BodyScanResult{
 			Clean:                false,
 			Action:               config.ActionBlock,
@@ -326,7 +326,7 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 	}
 
 	// Extract text strings from body based on content type.
-	texts, parseErr := extractBodyText(buf, req.ContentType, req.MaxBytes)
+	texts, parseErr := extractBodyText(buf, req)
 	if parseErr != "" {
 		// Multipart limit exceeded: fail-closed block.
 		return nil, BodyScanResult{
@@ -475,36 +475,91 @@ func sortedBodyTexts(texts []string) []string {
 	return sorted
 }
 
-func allowlistSkipsRedactionRewrite(req BodyScanRequest) bool {
-	return !isJSONContentType(req.ContentType) && unparseableBodyAllowlisted(req)
+// applyRedaction is the pre-DLP content-transformation step. JSON bodies are
+// detected by declared media type or a valid JSON sniff. Operator-allowlisted
+// non-JSON bodies fall back to raw-text rewriting instead of passing through
+// unchanged. A fail-closed gate returns *redact.BlockError.
+func applyRedaction(buf []byte, req BodyScanRequest) ([]byte, *redact.Report, error) {
+	if bodyIsJSONForRedaction(buf, req.ContentType) {
+		rewritten, report, err := redact.RewriteRequestJSON(buf, req.RedactMatcher, redact.NewRedactor(), req.RedactLimits, redact.RequestMetadata{
+			Host: req.Host,
+			Path: req.Path,
+		}, req.RedactProviderRegistry)
+		if err != nil {
+			return nil, nil, err
+		}
+		return rewritten, report, nil
+	}
+
+	if !unparseableBodyAllowlisted(req) {
+		return nil, nil, &redact.BlockError{
+			Reason: redact.ReasonNonJSONBody,
+			Detail: fmt.Sprintf("redaction enabled but body Content-Type %q is not JSON and request host %q/path %q is not allowed by redaction.allowlist_unparseable or redaction.allowlist_unparseable_routes", req.ContentType, req.Host, req.Path),
+		}
+	}
+	return rewriteRawTextBody(buf, req)
 }
 
-// applyRedaction is the pre-DLP content-transformation step. Returns
-// (rewritten, nil, nil) when the body was redacted, (rewritten, nil, nil)
-// with rewritten==buf when the feature is a no-op for this body (non-JSON
-// host on the allowlist), and (_, _, *BlockError) when a fail-closed
-// redaction gate fired.
-func applyRedaction(buf []byte, req BodyScanRequest) ([]byte, *redact.Report, error) {
-	if !isJSONContentType(req.ContentType) {
-		if !unparseableBodyAllowlisted(req) {
-			return nil, nil, &redact.BlockError{
-				Reason: redact.ReasonNonJSONBody,
-				Detail: fmt.Sprintf("redaction enabled but body Content-Type %q is not JSON and request host %q/path %q is not allowed by redaction.allowlist_unparseable or redaction.allowlist_unparseable_routes", req.ContentType, req.Host, req.Path),
-			}
+func bodyIsJSONForRedaction(buf []byte, contentType string) bool {
+	if isJSONContentType(contentType) {
+		return true
+	}
+	return json.Valid(bytes.TrimSpace(buf))
+}
+
+func rewriteRawTextBody(buf []byte, req BodyScanRequest) ([]byte, *redact.Report, error) {
+	if req.RedactMatcher == nil {
+		return nil, nil, &redact.BlockError{
+			Reason: redact.ReasonInternalError,
+			Detail: "redaction matcher unavailable for raw-text fallback",
 		}
-		// Allowlisted host with non-JSON body: caller forwards as-is.
-		// Return nil report so the caller does not fabricate a redaction
-		// receipt summary for a body that was never scanned.
-		return buf, nil, nil
 	}
-	rewritten, report, err := redact.RewriteRequestJSON(buf, req.RedactMatcher, redact.NewRedactor(), req.RedactLimits, redact.RequestMetadata{
-		Host: req.Host,
-		Path: req.Path,
-	}, req.RedactProviderRegistry)
-	if err != nil {
-		return nil, nil, err
+	lim := req.RedactLimits
+	if lim.MaxBodyBytes <= 0 {
+		lim.MaxBodyBytes = redact.DefaultMaxBodyBytes
 	}
-	return rewritten, report, nil
+	if lim.MaxRedactionsPerRequest <= 0 {
+		lim.MaxRedactionsPerRequest = redact.DefaultMaxRedactions
+	}
+	if lim.MaxBodyBytes > 0 && len(buf) > lim.MaxBodyBytes {
+		return nil, nil, &redact.BlockError{Reason: redact.ReasonBodyTooLarge}
+	}
+
+	body := string(buf)
+	matches := req.RedactMatcher.Scan(body)
+	if lim.MaxRedactionsPerRequest > 0 && countUniqueRawTextMatches(matches) > lim.MaxRedactionsPerRequest {
+		return nil, nil, &redact.BlockError{Reason: redact.ReasonOverflow}
+	}
+	redactor := redact.NewRedactor()
+	rewritten := redact.RewriteString(body, matches, redactor)
+	return []byte(rewritten), &redact.Report{
+		Applied:         true,
+		Provider:        redact.ProviderGenericRawText,
+		Parser:          redact.ParserRawText,
+		TotalRedactions: redactor.Total(),
+		ByClass:         redactor.ByClass(),
+	}, nil
+}
+
+func countUniqueRawTextMatches(matches []redact.Match) int {
+	if len(matches) == 0 {
+		return 0
+	}
+	seen := make(map[redact.Class]map[string]struct{})
+	total := 0
+	for _, match := range matches {
+		byOriginal, ok := seen[match.Class]
+		if !ok {
+			byOriginal = make(map[string]struct{})
+			seen[match.Class] = byOriginal
+		}
+		if _, ok := byOriginal[match.Original]; ok {
+			continue
+		}
+		byOriginal[match.Original] = struct{}{}
+		total++
+	}
+	return total
 }
 
 func unparseableBodyAllowlisted(req BodyScanRequest) bool {
@@ -662,8 +717,8 @@ func hasNonIdentityEncoding(ce string) bool {
 // extractBodyText dispatches body text extraction by content type.
 // Returns extracted strings and an error string if parsing limits are exceeded
 // (multipart only). Empty error means success.
-func extractBodyText(body []byte, contentType string, maxBytes int) ([]string, string) {
-	mediaType, params, _ := mime.ParseMediaType(contentType)
+func extractBodyText(body []byte, req BodyScanRequest) ([]string, string) {
+	mediaType, params, _ := mime.ParseMediaType(req.ContentType)
 
 	switch {
 	case mediaType == contentTypeJSON || strings.HasSuffix(mediaType, "+json"):
@@ -679,15 +734,15 @@ func extractBodyText(body []byte, contentType string, maxBytes int) ([]string, s
 		if params["boundary"] == "" {
 			return nil, "multipart/form-data missing boundary"
 		}
-		return extractMultipart(body, params["boundary"], maxBytes)
+		return extractMultipart(body, params["boundary"], req.MaxBytes)
 
 	case strings.HasPrefix(mediaType, "text/") || strings.HasSuffix(mediaType, "+xml"):
 		return []string{string(body)}, ""
 
 	default:
-		// Fallback: raw text scan. Never skip unknown content types.
-		// An attacker can set Content-Type: application/octet-stream on a
-		// JSON body containing secrets. Raw scan catches plaintext patterns.
+		// Fallback: raw text scan. Never skip unknown content types. An
+		// attacker can set Content-Type: application/octet-stream on a body
+		// containing secrets. Raw scan catches plaintext patterns.
 		return []string{string(body)}, ""
 	}
 }

--- a/internal/proxy/bodyscan_redact_test.go
+++ b/internal/proxy/bodyscan_redact_test.go
@@ -136,6 +136,88 @@ func TestScanRequestBody_Redaction_HostPortMatchesAllowlist(t *testing.T) {
 	}
 }
 
+func TestScanRequestBody_Redaction_JSONSniffWrongContentType(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	secret := redactionE2ESecret()
+	body := `{"prompt":"use ` + secret + `"}`
+	buf, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:                       strings.NewReader(body),
+		ContentType:                "text/plain; charset=utf-8",
+		MaxBytes:                   1024,
+		Scanner:                    sc,
+		RedactMatcher:              redact.NewDefaultMatcher(),
+		Host:                       "api.example.com",
+		RedactAllowlistUnparseable: []string{"api.example.com"},
+	})
+	if strings.Contains(string(buf), secret) {
+		t.Fatalf("sniffed JSON body leaked unredacted secret: %s", buf)
+	}
+	if result.RedactionReport == nil || result.RedactionReport.Parser != redact.ParserJSON {
+		t.Fatalf("expected JSON redaction report for sniffed body, got %+v", result.RedactionReport)
+	}
+}
+
+func TestScanRequestBody_Redaction_AllowlistedRawTextRewrites(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	secret := redactionE2ESecret()
+	body := `refresh_token=` + secret
+	buf, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:                       strings.NewReader(body),
+		Method:                     "POST",
+		ContentType:                "application/x-www-form-urlencoded",
+		MaxBytes:                   1024,
+		Scanner:                    sc,
+		RedactMatcher:              redact.NewDefaultMatcher(),
+		Host:                       "login.microsoftonline.com",
+		Path:                       "/tenant-id/oauth2/v2.0/token",
+		RedactAllowlistUnparseable: []string{"login.microsoftonline.com"},
+	})
+	if strings.Contains(string(buf), secret) {
+		t.Fatalf("allowlisted raw-text body leaked unredacted secret: %s", buf)
+	}
+	if !strings.Contains(string(buf), "<pl:") {
+		t.Fatalf("expected placeholder in rewritten raw-text body: %s", buf)
+	}
+	if result.RedactionReport == nil {
+		t.Fatal("expected raw-text redaction report")
+	}
+	if result.RedactionReport.Provider != redact.ProviderGenericRawText {
+		t.Fatalf("provider = %q, want %q", result.RedactionReport.Provider, redact.ProviderGenericRawText)
+	}
+	if result.RedactionReport.Parser != redact.ParserRawText {
+		t.Fatalf("parser = %q, want %q", result.RedactionReport.Parser, redact.ParserRawText)
+	}
+}
+
+func TestScanRequestBody_Redaction_RequiredNilMatcherBlocksAllowlistedRawText(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:                       strings.NewReader(`refresh_token=` + redactionE2ESecret()),
+		Method:                     "POST",
+		ContentType:                "application/x-www-form-urlencoded",
+		MaxBytes:                   1024,
+		Scanner:                    sc,
+		RedactionRequired:          true,
+		Host:                       "login.microsoftonline.com",
+		RedactAllowlistUnparseable: []string{"login.microsoftonline.com"},
+	})
+	if result.Clean {
+		t.Fatal("expected fail-closed block when raw-text redaction matcher is unavailable")
+	}
+	if result.RedactionBlockReason != redact.ReasonInternalError {
+		t.Fatalf("RedactionBlockReason = %q, want %q", result.RedactionBlockReason, redact.ReasonInternalError)
+	}
+}
+
 func TestScanRequestBody_Redaction_RouteAllowlistRequiresFullMatch(t *testing.T) {
 	cfg := testScannerConfig()
 	sc := scanner.New(cfg)
@@ -182,13 +264,14 @@ func TestScanRequestBody_Redaction_RouteAllowlistRequiresFullMatch(t *testing.T)
 	}
 }
 
-func TestScanRequestBody_Redaction_RouteAllowlistStillRunsDLP(t *testing.T) {
+func TestScanRequestBody_Redaction_RouteAllowlistRewritesBeforeDLP(t *testing.T) {
 	cfg := testScannerConfig()
 	sc := scanner.New(cfg)
 	defer sc.Close()
 
-	_, result := scanRequestBody(context.Background(), BodyScanRequest{
-		Body:          strings.NewReader(`refresh_token=` + redactionE2ESecret()),
+	secret := redactionE2ESecret()
+	buf, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:          strings.NewReader(`refresh_token=` + secret),
 		Method:        "POST",
 		ContentType:   "application/x-www-form-urlencoded",
 		MaxBytes:      1024,
@@ -203,11 +286,14 @@ func TestScanRequestBody_Redaction_RouteAllowlistStillRunsDLP(t *testing.T) {
 			ContentTypes: []string{"application/x-www-form-urlencoded"},
 		}},
 	})
-	if result.Clean {
-		t.Fatal("route-scoped redaction exception skipped DLP; expected body DLP finding")
+	if strings.Contains(string(buf), secret) {
+		t.Fatalf("route-scoped raw-text fallback leaked unredacted secret: %s", buf)
 	}
-	if len(result.DLPMatches) == 0 {
-		t.Fatalf("expected DLP matches after route allowlist, got %+v", result)
+	if !result.RedactedDLPOnly {
+		t.Fatalf("expected RedactedDLPOnly=true after raw-text rewrite, got %+v", result)
+	}
+	if result.RedactionReport == nil || result.RedactionReport.Parser != redact.ParserRawText {
+		t.Fatalf("expected raw-text redaction report, got %+v", result.RedactionReport)
 	}
 }
 

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -295,6 +295,147 @@ func TestScanRequestBody_ContentTypeBypass_ImagePNG(t *testing.T) {
 	}
 }
 
+func TestScanRequestBody_JSONImageDataURLScansPayloadText(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	// A valid-looking image data URL must not become a DLP blind spot. A
+	// literal token-shaped substring after image magic still exits in the
+	// request body and must be scanned.
+	imageData := "/9j/" + "dapi" + strings.Repeat("a", 32)
+	body := `{"image_url":{"url":"data:image/jpeg;base64,` + imageData + `"}}`
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
+	if result.Clean {
+		t.Fatal("expected DLP match in image data URL payload text")
+	}
+	if len(result.DLPMatches) == 0 {
+		t.Fatal("expected non-empty DLP matches")
+	}
+}
+
+func TestScanRequestBody_JSONImageDataURLStillScansPromptText(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	imageData := "/9j/DAPI" + strings.Repeat("A", 32)
+	token := "dapi" + strings.Repeat("a", 32)
+	body := `{"text":"leak ` + token + `","image_url":{"url":"data:image/jpeg;base64,` + imageData + `"}}`
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
+	if result.Clean {
+		t.Fatal("expected DLP match in prompt text next to image data URL")
+	}
+	if len(result.DLPMatches) == 0 {
+		t.Fatal("expected non-empty DLP matches")
+	}
+}
+
+func TestScanRequestBody_JSONImageDataURLWithoutImageMagicStillScansPayloadText(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	token := "dapi" + strings.Repeat("a", 32)
+	payload := base64.StdEncoding.EncodeToString([]byte(token))
+	body := `{"image_url":{"url":"data:image/jpeg;base64,` + payload + `"}}`
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
+	if result.Clean {
+		t.Fatal("expected DLP match when image data URL lacks JPEG magic")
+	}
+}
+
+func TestScanRequestBody_ModelProviderOpaqueReasoningFieldsStillScanned(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	token := "fw_" + strings.Repeat("A", 24)
+	body := `{
+		"input": [{
+			"role": "assistant",
+			"content": [{
+				"type": "reasoning",
+				"encrypted_content": "` + token + `",
+				"thinkingSignature": "{\"encrypted_content\":\"` + token + `\"}"
+			}]
+		}]
+	}`
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		Host:        "chatgpt.com",
+		Path:        "/backend-api/codex/responses",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
+	if result.Clean {
+		t.Fatal("expected DLP match in provider opaque reasoning fields")
+	}
+	if len(result.DLPMatches) == 0 {
+		t.Fatal("expected non-empty DLP matches")
+	}
+}
+
+func TestScanRequestBody_ModelProviderStillScansPromptText(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	body := `{"input":"leak ` + "fw_" + strings.Repeat("A", 24) + `"}`
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		Host:        "chatgpt.com",
+		Path:        "/backend-api/codex/responses",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
+	if result.Clean {
+		t.Fatal("expected DLP match in prompt text for model provider request")
+	}
+}
+
+func TestScanRequestBody_OpaqueReasoningFieldNamesDoNotBypassOtherHosts(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	body := `{"encrypted_content":"` + "fw_" + strings.Repeat("A", 24) + `"}`
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		Host:        "example.com",
+		Path:        "/collect",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
+	if result.Clean {
+		t.Fatal("expected DLP match for opaque field name on non-provider host")
+	}
+}
+
 func TestScanRequestBody_CompressedGzip(t *testing.T) {
 	cfg := testScannerConfig()
 	sc := scanner.New(cfg)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1324,20 +1324,35 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 		p.receiptKeyPath = receiptStage.keyPath
 	}
 
+	oldCfg := p.cfgPtr.Load()
+	// When redaction is being disabled, publish the config before clearing the
+	// legacy matcher mirror. Enabling keeps the opposite order: runtime first,
+	// then cfg, so a cfg that requires redaction never appears before its
+	// matcher snapshot is available.
+	publishCfgBeforeRedaction := newRedactionRuntime == nil && oldCfg != nil && oldCfg.Redaction.Enabled && !cfg.Redaction.Enabled
+	if publishCfgBeforeRedaction {
+		p.cfgPtr.Store(cfg)
+		p.contractLoaderPtr.Store(contractLoader)
+	}
+
 	// Publish the staged redaction runtime as one snapshot so body-scan
 	// request paths cannot observe a new matcher with old limits/allowlist
-	// or vice versa. Keep redactMatcherPtr mirrored for non-request users
-	// that only need the compiled matcher.
-	p.redactionRuntimePtr.Store(newRedactionRuntime)
+	// or vice versa. When redaction is disabled, leave the old runtime
+	// pointer in place: new requests pass a disabled cfg and therefore ignore
+	// it, while in-flight requests that already captured the old enabled cfg
+	// can still complete with the matching matcher instead of failing closed
+	// during the disable reload.
 	if newRedactionRuntime != nil {
+		p.redactionRuntimePtr.Store(newRedactionRuntime)
 		p.redactMatcherPtr.Store(newRedactionRuntime.matcher)
 	} else {
 		p.redactMatcherPtr.Store(nil)
 	}
 
-	oldCfg := p.cfgPtr.Load()
-	p.cfgPtr.Store(cfg)
-	p.contractLoaderPtr.Store(contractLoader)
+	if !publishCfgBeforeRedaction {
+		p.cfgPtr.Store(cfg)
+		p.contractLoaderPtr.Store(contractLoader)
+	}
 	if p.wd != nil {
 		p.wd.BeatConfig()
 		p.installScannerHeartbeat(sc)

--- a/internal/redact/classes.go
+++ b/internal/redact/classes.go
@@ -60,6 +60,10 @@ func tokenClasses() []classPattern {
 		{class: ClassGitHubToken, pattern: regexp.MustCompile(`\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b`), priority: 100},
 		{class: ClassGitLabToken, pattern: regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{20,}\b`), priority: 100},
 		{class: ClassSlackToken, pattern: regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}\b`), priority: 100},
+		{class: ClassVercelToken, pattern: regexp.MustCompile(`\b(?:vercel|vc[piark])_[A-Za-z0-9]{24,}\b`), priority: 100},
+		// Databricks PATs use a 32-char hex suffix; requiring at least 32 hex
+		// chars rejects 30-character matches seen in random base64 payloads.
+		{class: ClassDatabricksPAT, pattern: regexp.MustCompile(`(?i)\bdapi[0-9a-f]{32,}\b`), priority: 100},
 		{class: ClassOpenAIAPIKey, pattern: regexp.MustCompile(`\bsk-(?:proj|svcacct)-[A-Za-z0-9_-]{10,}\b`), priority: 100},
 		{class: ClassAnthropicKey, pattern: regexp.MustCompile(`\bsk-ant-[A-Za-z0-9_-]{10,}\b`), priority: 100},
 		{class: ClassTelegramToken, pattern: regexp.MustCompile(`\b[0-9]{8,10}:[A-Za-z0-9_-]{35}\b`), priority: 100},

--- a/internal/redact/classes_test.go
+++ b/internal/redact/classes_test.go
@@ -37,6 +37,8 @@ func TestDefaultMatcher_StructuredClasses(t *testing.T) {
 		{"github-new", "token github_pat_" + strings.Repeat("B", 40), ClassGitHubToken},
 		{"gitlab-token", "token glpat-" + strings.Repeat("C", 24), ClassGitLabToken},
 		{"slack-bot", "use " + "xox" + "b-12345-67890-abcdefghijklmnopqrstuvwx", ClassSlackToken},
+		{"vercel-token", "deploy token vcp_" + strings.Repeat("A", 24), ClassVercelToken},
+		{"databricks-pat", "use dapi" + strings.Repeat("a", 32), ClassDatabricksPAT},
 		{"openai-api-key", "use sk-proj-" + strings.Repeat("D", 24), ClassOpenAIAPIKey},
 		{"anthropic-api-key", "use sk-ant-" + strings.Repeat("E", 24), ClassAnthropicKey},
 		{"telegram-token", "bot 1234567890:" + strings.Repeat("F", 35), ClassTelegramToken},

--- a/internal/redact/providers.go
+++ b/internal/redact/providers.go
@@ -21,6 +21,14 @@ const (
 	// unknown JSON providers fail-closed-and-redacted instead of depending on a
 	// known-provider allowlist.
 	ProviderGenericJSON = "generic-json"
+
+	// ParserRawText is used for operator-allowlisted non-JSON request bodies.
+	// It rewrites matcher spans in the raw text instead of forwarding the body
+	// unchanged.
+	ParserRawText = "raw-text"
+
+	// ProviderGenericRawText labels raw-text fallback redaction receipts.
+	ProviderGenericRawText = "generic-raw-text"
 )
 
 // RequestMetadata identifies the upstream request enough to select a provider

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -25,6 +25,8 @@ const (
 	ClassGitHubToken   Class = "github-token"
 	ClassGitLabToken   Class = "gitlab-token"
 	ClassSlackToken    Class = "slack-token"
+	ClassVercelToken   Class = "vercel-token"       //nolint:gosec // class label, not a secret value
+	ClassDatabricksPAT Class = "databricks-token"   //nolint:gosec // class label, not a secret value
 	ClassOpenAIAPIKey  Class = "openai-api-key"     //nolint:gosec // class label, not a secret value
 	ClassAnthropicKey  Class = "anthropic-api-key"  //nolint:gosec // class label, not a secret value
 	ClassTelegramToken Class = "telegram-bot-token" //nolint:gosec // class label, not a secret value

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -138,6 +138,7 @@ func TestRedactor_BuiltInClassesFormatCorrectly(t *testing.T) {
 		ClassIPv4, ClassIPv6, ClassCIDR, ClassFQDN, ClassEmail,
 		ClassAWSAccessKey, ClassGoogleAPIKey,
 		ClassGitHubToken, ClassGitLabToken, ClassSlackToken,
+		ClassVercelToken, ClassDatabricksPAT,
 		ClassOpenAIAPIKey, ClassAnthropicKey, ClassTelegramToken,
 		ClassDiscordToken, ClassJWT,
 		ClassHashMD5, ClassHashSHA1, ClassHashSHA256, ClassHashSHA512,

--- a/internal/scanner/prefilter_test.go
+++ b/internal/scanner/prefilter_test.go
@@ -25,7 +25,7 @@ func TestExtractLiteralPrefix(t *testing.T) {
 		{"sendgrid", `(?i)SG\.[a-zA-Z0-9_-]{22}`, "sg."},
 		{"mailgun", "(?i)key-[a-zA-Z0-9]{32}", "key-"},
 		{"hugging face", "(?i)hf_[A-Za-z0-9]{20,}", "hf_"},
-		{"databricks", "(?i)dapi[a-z0-9]{30,}", "dapi"},
+		{"databricks", "(?i)dapi[0-9a-f]{32,}", "dapi"},
 		{"replicate", "(?i)r8_[A-Za-z0-9]{20,}", "r8_"},
 		{"together", "(?i)tok_[a-z0-9]{40,}", "tok_"},
 		{"pinecone", "(?i)pcsk_[a-zA-Z0-9]{36,}", "pcsk_"},

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -3114,7 +3114,7 @@ func TestDLP_DatabricksToken(t *testing.T) {
 	s := New(testConfig())
 	defer s.Close()
 
-	token := "dapi" + "aabbccddeeff00112233445566778899"
+	token := "dapi" + strings.Repeat("a", 32)
 	result := s.Scan(context.Background(), "https://evil.com/collect?token="+token)
 	if result.Allowed {
 		t.Error("expected Databricks token to be blocked by DLP")

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -3114,7 +3114,7 @@ func TestDLP_DatabricksToken(t *testing.T) {
 	s := New(testConfig())
 	defer s.Close()
 
-	token := "dapi" + "aabbccddeeff001122334455667788"
+	token := "dapi" + "aabbccddeeff00112233445566778899"
 	result := s.Scan(context.Background(), "https://evil.com/collect?token="+token)
 	if result.Allowed {
 		t.Error("expected Databricks token to be blocked by DLP")


### PR DESCRIPTION
Closes redaction surface gaps in request body scanning, plus a Databricks DLP pattern tightening that removes a false-positive surface on image payloads.

## Redaction flow

**Content-type sniff.** Body is treated as JSON if Content-Type declares it OR `json.Valid(bytes.TrimSpace(buf))` passes. Closes the bypass where upstreams send JSON with `text/plain;charset=UTF-8`.

**Raw-text fallback.** Operator-allowlisted non-JSON bodies are no longer forwarded as-is. They go through the matcher and matched spans get rewritten in place. Receipts label this `ProviderGenericRawText` / `ParserRawText`.

**Hot reload during disable.** When redaction is being disabled, the new config is published before the legacy matcher mirror is cleared, and the runtime pointer is left in place so in-flight requests that already captured the old enabled config complete with the matching matcher instead of failing closed mid-reload.

## DLP pattern correction

Databricks PAT pattern tightened from `dapi[a-z0-9]{30,}` to `dapi[0-9a-f]{32,}`. Documented format is 32 hex chars; the old pattern also matched any 30-char run of lowercase-alphanumeric, which occurs in random base64 image payloads. The tighter pattern still matches real tokens and effectively never fires on random base64 (about 22 of 64 base64 chars are hex case-insensitive). Canonical policy hashes bumped with explanatory comments.

## New redact classes

- `ClassVercelToken`: `\b(?:vercel|vc[piark])_[A-Za-z0-9]{24,}\b`
- `ClassDatabricksPAT`: `(?i)\bdapi[0-9a-f]{32,}\b`

Both already in the scanner DLP set. Adding them to the redact class set lets the raw-text fallback substitute placeholders rather than blocking.

## Regression guards

Six new tests in `bodyscan_test.go` lock in scanning of image data URLs (with or without JPEG magic, with or without adjacent prompt text) and provider opaque-reasoning fields (`encrypted_content`, `thinkingSignature`). Three new redaction tests cover JSON sniff, raw-text fallback, and the fail-closed nil-matcher case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection of Vercel tokens.

* **Bug Fixes**
  * Stricter Databricks token detection to reduce false positives.
  * Improved request-body scanning (image data URLs and opaque provider fields).
  * Enhanced redaction for non-JSON bodies with a raw-text rewrite fallback and fail-closed behavior when redaction matcher is unavailable.
  * JSON sniffing so bodies are scanned correctly despite incorrect Content-Type.

* **Tests**
  * Expanded coverage for body scanning, redaction flows, and token detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->