### PR TITLE
fix(deps): bump golang.org/x/crypto to v0.52.0 (13 SSH CVE fixes)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2
 	go.opentelemetry.io/proto/otlp v1.10.0
-	golang.org/x/crypto v0.51.0
+	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.55.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/text v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliY
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=


### PR DESCRIPTION
Resolves the 13 govulncheck-flagged SSH vulnerabilities in golang.org/x/crypto@v0.51.0, all fixed in v0.52.0. These are the CVEs OpenSSF Scorecard alert #37 has been re-filing on every cron run. Pipelock does not import any x/crypto/ssh subpackage, so the vulns are unreachable from pipelock code, but Scorecard counts unreachable transitive vulns the same as reachable ones. Bumping the dep removes the vulnerable versions from go.sum and the alert clears.

Fixed in this PR:

- GO-2026-5005: key constraints not enforced in x/crypto/ssh/agent
- GO-2026-5006: agent constraints dropped when forwarding keys
- GO-2026-5013: byte arithmetic causes underflow and panic in x/crypto/ssh
- GO-2026-5014: bypass of certificate restrictions in x/crypto/ssh
- GO-2026-5015: server panic during CheckHostKey/Authenticate
- GO-2026-5016: memory leak when rejecting channels can lead to DoS
- GO-2026-5017: client can cause server deadlock on unexpected responses
- GO-2026-5018: pathological RSA/DSA parameters may cause DoS
- GO-2026-5019: bypass of FIDO/U2F security keys physical interaction
- GO-2026-5020: infinite loop on large channel writes
- GO-2026-5021: auth bypass via unenforced @revoked status in knownhosts
- GO-2026-5023: VerifiedPublicKeyCallback permissions skip enforcement
- GO-2026-5033: pathological inputs can lead to client panic in ssh/agent

Verified locally: govulncheck no longer reports any x/crypto findings; golangci-lint clean; go test -race -count=1 ./... pass.

No code changes. go.mod + go.sum only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to maintain security and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->