### PR TITLE
feat(dns): add dns.host_overrides for hostname routing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1212,6 +1212,25 @@ trusted_domains:
 
 Per-agent `trusted_domains` overrides are available in agent profiles (Pro license).
 
+### DNS Host Overrides
+
+Static hostname-to-IP overrides used by SSRF DNS checks and the proxy dial path. Use this for reproducible local fixtures or controlled internal names when you cannot or do not want to modify system DNS.
+
+```yaml
+dns:
+  host_overrides:
+    fixture.example.test:
+      - "127.0.0.1"
+trusted_domains:
+  - "fixture.example.test"
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `dns.host_overrides` | `{}` | Map of exact hostnames to one or more IP addresses. Hostname keys are normalized case-insensitively with trailing DNS dots stripped. URL, wildcard, host:port, and IP-literal keys are rejected. |
+
+Host overrides do not exempt a destination from SSRF blocking by themselves. If an override resolves to an internal IP, the hostname must also be present in `trusted_domains` or the target IP must be covered by `ssrf.ip_allowlist`. Raw IP targets never use `dns.host_overrides`.
+
 ### SSRF IP Allowlist
 
 Exempt specific IP ranges from SSRF blocking. Use this when your internal services resolve to known IP ranges and you want to allow connections by IP rather than by hostname.

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -110,7 +110,11 @@ const (
 	// documented shapes and leading/trailing token boundaries.
 	// Re-bumped again after the Supabase right edge was adjusted to keep
 	// matching valid base64url checksums that end in '-'.
-	goldenHashDefaults = "b2a8779c2522d3046affc058c286fd3d78101e5d1c9026bd380f9bf2e8404c96"
+	// Re-bumped for the dns.host_overrides addition: dns is policy-relevant
+	// (it changes the destination IPs the SSRF check evaluates) and so it
+	// participates in the canonical view; the field is present but empty
+	// in Defaults().
+	goldenHashDefaults = "029a5449518889527136cdcb796b8746338d38a12ed0723b13ab24d7139c54a5"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -168,7 +172,10 @@ const (
 	// DLP pattern set, so the hash shifts in lockstep.
 	// Re-bumped again for the Supabase base64url checksum right-edge fix:
 	// see goldenHashDefaults note above.
-	goldenHashRichConfig = "4f0061858b23c6e7d389c2b88f5cbbb96c77898d2a62222bd1760c5e70042077"
+	// Re-bumped for the dns.host_overrides addition: see goldenHashDefaults
+	// note. The rich fixture omits dns:, so the field is empty but still
+	// part of the canonical view.
+	goldenHashRichConfig = "86666b12e6ce89ee16b749e4926444b8b10505bfcfb85ea8516d1d77d3118d68"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2097,6 +2097,73 @@ func TestValidate_SSRFIPAllowlist_Empty(t *testing.T) {
 	}
 }
 
+func TestValidate_DNSHostOverrides_Valid(t *testing.T) {
+	cfg := Defaults()
+	cfg.DNS.HostOverrides = map[string][]string{
+		"aeb-fixture.test": {"127.0.0.1"},
+		"internal.api":     {"10.0.0.5", "10.0.0.6"},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("valid dns.host_overrides should validate, got: %v", err)
+	}
+}
+
+func TestValidate_DNSHostOverrides_EmptyHost(t *testing.T) {
+	cfg := Defaults()
+	cfg.DNS.HostOverrides = map[string][]string{
+		"   ": {"127.0.0.1"},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for empty hostname key")
+	}
+	if !strings.Contains(err.Error(), "dns.host_overrides") {
+		t.Errorf("expected error to mention dns.host_overrides, got: %v", err)
+	}
+}
+
+func TestValidate_DNSHostOverrides_IPLiteralKeyRejected(t *testing.T) {
+	cfg := Defaults()
+	cfg.DNS.HostOverrides = map[string][]string{
+		"127.0.0.1": {"127.0.0.1"},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for IP-literal hostname key")
+	}
+	if !strings.Contains(err.Error(), "IP literal") {
+		t.Errorf("expected IP-literal error, got: %v", err)
+	}
+}
+
+func TestValidate_DNSHostOverrides_EmptyIPListRejected(t *testing.T) {
+	cfg := Defaults()
+	cfg.DNS.HostOverrides = map[string][]string{
+		"aeb-fixture.test": {},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for empty IP list")
+	}
+	if !strings.Contains(err.Error(), "at least one IP") {
+		t.Errorf("expected empty-IP-list error, got: %v", err)
+	}
+}
+
+func TestValidate_DNSHostOverrides_InvalidIPRejected(t *testing.T) {
+	cfg := Defaults()
+	cfg.DNS.HostOverrides = map[string][]string{
+		"aeb-fixture.test": {"not-an-ip"},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for invalid IP")
+	}
+	if !strings.Contains(err.Error(), "invalid IP") {
+		t.Errorf("expected invalid-IP error, got: %v", err)
+	}
+}
+
 func TestApplyDefaults_DoesNotOverwriteExistingValues(t *testing.T) {
 	cfg := &Config{
 		Version: 2,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2136,6 +2136,49 @@ func TestValidate_DNSHostOverrides_IPLiteralKeyRejected(t *testing.T) {
 	}
 }
 
+func TestValidate_DNSHostOverrides_TrailingDotIPLiteralKeyRejected(t *testing.T) {
+	cfg := Defaults()
+	cfg.DNS.HostOverrides = map[string][]string{
+		"127.0.0.1.": {"127.0.0.1"},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for trailing-dot IP-literal hostname key")
+	}
+	if !strings.Contains(err.Error(), "IP literal") {
+		t.Errorf("expected IP-literal error, got: %v", err)
+	}
+}
+
+func TestValidate_DNSHostOverrides_HostPortRejected(t *testing.T) {
+	cfg := Defaults()
+	cfg.DNS.HostOverrides = map[string][]string{
+		"aeb-fixture.test:8080": {"127.0.0.1"},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for host:port hostname key")
+	}
+	if !strings.Contains(err.Error(), "hostname") {
+		t.Errorf("expected hostname error, got: %v", err)
+	}
+}
+
+func TestValidate_DNSHostOverrides_DuplicateNormalizedHostRejected(t *testing.T) {
+	cfg := Defaults()
+	cfg.DNS.HostOverrides = map[string][]string{
+		"AEB-Fixture.Test.": {"127.0.0.1"},
+		"aeb-fixture.test":  {"127.0.0.2"},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for duplicate normalized hostname key")
+	}
+	if !strings.Contains(err.Error(), "duplicates") {
+		t.Errorf("expected duplicate-host error, got: %v", err)
+	}
+}
+
 func TestValidate_DNSHostOverrides_EmptyIPListRejected(t *testing.T) {
 	cfg := Defaults()
 	cfg.DNS.HostOverrides = map[string][]string{

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -265,6 +265,7 @@ type Config struct {
 	Internal                 []string                `yaml:"internal"`
 	TrustedDomains           []string                `yaml:"trusted_domains"` // domains exempt from SSRF internal-IP check (wildcard supported)
 	SSRF                     SSRF                    `yaml:"ssrf"`
+	DNS                      DNS                     `yaml:"dns"`
 
 	// LicenseExpiresAt is the Unix timestamp of the license expiry, populated
 	// by EnforceLicenseGate(). Zero means perpetual. Used for runtime expiry
@@ -520,6 +521,21 @@ type SSRF struct {
 	// operator. Complementary to trusted_domains: this is IP-based trust,
 	// trusted_domains is hostname-based trust.
 	IPAllowlist []string `yaml:"ip_allowlist"`
+}
+
+// DNS configures hostname resolution overrides applied to the SSRF DNS
+// check and the proxy's dial path. Each entry maps a hostname to one or
+// more static IPs; matching lookups bypass the system resolver and return
+// the configured IPs directly. Designed for reproducible test harnesses
+// (e.g. agent-egress-bench fixtures published on loopback): combined with
+// trusted_domains, an operator can let pipelock reach an internal fixture
+// at a stable hostname while raw-IP SSRF attacks targeting the same range
+// remain blocked, because the IP-literal path never consults this map.
+// HostOverrides is empty by default; configuring it does not weaken any
+// security check on its own — exemption still requires a trusted_domains
+// entry for the same hostname.
+type DNS struct {
+	HostOverrides map[string][]string `yaml:"host_overrides"`
 }
 
 // LoggingConfig configures audit logging.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -167,6 +167,9 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 	if err := c.validateTrustedDomains(); err != nil {
 		return warnings, err
 	}
+	if err := c.validateDNS(); err != nil {
+		return warnings, err
+	}
 	if err := c.validateRules(); err != nil {
 		return warnings, err
 	}
@@ -1408,6 +1411,29 @@ func (c *Config) validateSSRF() error {
 		// to avoid accidentally allowlisting a wider range than intended.
 		if !ip.Equal(ipNet.IP) {
 			return fmt.Errorf("ssrf.ip_allowlist CIDR %q has host bits set (did you mean %q?)", cidr, ipNet.String())
+		}
+	}
+	return nil
+}
+
+func (c *Config) validateDNS() error {
+	for host, ips := range c.DNS.HostOverrides {
+		if strings.TrimSpace(host) == "" {
+			return fmt.Errorf("dns.host_overrides: hostname key must be non-empty")
+		}
+		// Reject IP-literal keys: the override path is hostname-only, and
+		// allowing an IP-literal key would suggest the operator can rewrite
+		// "127.0.0.1" → some other IP, which the resolver does not do.
+		if net.ParseIP(host) != nil {
+			return fmt.Errorf("dns.host_overrides: %q is an IP literal; only hostnames may have overrides", host)
+		}
+		if len(ips) == 0 {
+			return fmt.Errorf("dns.host_overrides[%q]: must provide at least one IP", host)
+		}
+		for i, ip := range ips {
+			if net.ParseIP(ip) == nil {
+				return fmt.Errorf("dns.host_overrides[%q][%d]: invalid IP %q", host, i, ip)
+			}
 		}
 	}
 	return nil

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1417,16 +1417,25 @@ func (c *Config) validateSSRF() error {
 }
 
 func (c *Config) validateDNS() error {
+	seenHosts := make(map[string]string, len(c.DNS.HostOverrides))
 	for host, ips := range c.DNS.HostOverrides {
-		if strings.TrimSpace(host) == "" {
+		normalizedHost := strings.TrimSuffix(strings.TrimSpace(strings.ToLower(host)), ".")
+		if normalizedHost == "" {
 			return fmt.Errorf("dns.host_overrides: hostname key must be non-empty")
+		}
+		if strings.Contains(normalizedHost, "://") || strings.ContainsAny(normalizedHost, "/*?[]:") {
+			return fmt.Errorf("dns.host_overrides: %q must be a hostname, not a URL, wildcard, IP, or host:port", host)
 		}
 		// Reject IP-literal keys: the override path is hostname-only, and
 		// allowing an IP-literal key would suggest the operator can rewrite
 		// "127.0.0.1" → some other IP, which the resolver does not do.
-		if net.ParseIP(host) != nil {
+		if net.ParseIP(normalizedHost) != nil {
 			return fmt.Errorf("dns.host_overrides: %q is an IP literal; only hostnames may have overrides", host)
 		}
+		if previous, ok := seenHosts[normalizedHost]; ok {
+			return fmt.Errorf("dns.host_overrides: %q duplicates %q after hostname normalization", host, previous)
+		}
+		seenHosts[normalizedHost] = host
 		if len(ips) == 0 {
 			return fmt.Errorf("dns.host_overrides[%q]: must provide at least one IP", host)
 		}

--- a/internal/proxy/dns_overrides_e2e_test.go
+++ b/internal/proxy/dns_overrides_e2e_test.go
@@ -1,0 +1,173 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// TestProxy_DNSHostOverrides_WSFixtureRoutesViaTrustedHostname mirrors the
+// agent-egress-bench scenario where a local WebSocket fixture lives on
+// loopback but must be reachable via a stable hostname so SSRF attacks
+// targeting raw loopback IPs still get rejected.
+//
+// Setup:
+//   - WS echo backend on a random 127.0.0.1 port (acts like the bench fixture).
+//   - pipelock proxy with cfg.DNS.HostOverrides mapping the test hostname to
+//     the backend IP, and cfg.TrustedDomains adding the hostname to the
+//     SSRF-exempt list. ssrf.ip_allowlist is empty.
+//   - Client dials proxy's /ws endpoint with url=ws://aeb-fixture.test:<port>/echo.
+//
+// Expectations:
+//   - Connection succeeds (override + trusted_domains let pipelock dial the
+//     fixture's loopback IP without tripping SSRF).
+//   - A benign text frame round-trips through pipelock and the fixture.
+//   - A raw http://127.0.0.1/admin request through ssrfSafeDialContext still
+//     fails — trusted_domains explicitly rejects IP literals, and the
+//     override map never gets consulted for IP-literal targets.
+func TestProxy_DNSHostOverrides_WSFixtureRoutesViaTrustedHostname(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+
+	backendHost, backendPort, splitErr := net.SplitHostPort(backendAddr)
+	if splitErr != nil {
+		t.Fatalf("split backend addr: %v", splitErr)
+	}
+
+	const fixtureHostname = "aeb-fixture.test"
+	proxyAddr, proxyCleanup := setupWSProxy(t, func(cfg *config.Config) {
+		cfg.SSRF.IPAllowlist = nil
+		cfg.TrustedDomains = []string{fixtureHostname}
+		cfg.DNS.HostOverrides = map[string][]string{
+			fixtureHostname: {backendHost},
+		}
+	})
+	defer proxyCleanup()
+
+	// Dial pipelock's /ws endpoint with a target URL that uses the trusted
+	// hostname. pipelock should resolve via the override, see the hostname
+	// is trusted, skip the loopback SSRF block, and tunnel to the backend.
+	hostPort := net.JoinHostPort(fixtureHostname, backendPort)
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer dialCancel()
+	tcpConn, dialErr := (&net.Dialer{}).DialContext(dialCtx, "tcp", proxyAddr)
+	if dialErr != nil {
+		t.Fatalf("dial proxy: %v", dialErr)
+	}
+	defer tcpConn.Close() //nolint:errcheck // test cleanup
+	if deadlineErr := tcpConn.SetDeadline(time.Now().Add(5 * time.Second)); deadlineErr != nil {
+		t.Fatalf("set deadline: %v", deadlineErr)
+	}
+
+	// Manual WS upgrade — gobwas's dialer would re-resolve the hostname on
+	// the client side, which we can't intercept. We just need pipelock to
+	// see and honor the override; the runner-side path through the proxy
+	// is what counts.
+	upgrade := fmt.Sprintf(
+		"GET /ws?url=%s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGVzdHRlc3R0ZXN0dGVzdA==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		"ws://"+hostPort+"/echo", proxyAddr,
+	)
+	if _, writeErr := tcpConn.Write([]byte(upgrade)); writeErr != nil {
+		t.Fatalf("write upgrade: %v", writeErr)
+	}
+
+	// Read upgrade response.
+	respBuf := make([]byte, 512)
+	if _, readErr := tcpConn.Read(respBuf); readErr != nil {
+		t.Fatalf("read upgrade response: %v", readErr)
+	}
+	if string(respBuf[:12]) != "HTTP/1.1 101" {
+		t.Fatalf("expected 101 Switching Protocols upgrade; got: %q", string(respBuf[:60]))
+	}
+
+	// Write a single benign text frame and expect an echo.
+	if err := wsutil.WriteClientMessage(tcpConn, ws.OpText, []byte("hello via trusted host")); err != nil {
+		t.Fatalf("write frame: %v", err)
+	}
+	echo, _, err := wsutil.ReadServerData(tcpConn)
+	if err != nil {
+		t.Fatalf("read echo: %v — override + trusted_domains should let the connection round-trip", err)
+	}
+	if string(echo) != "hello via trusted host" {
+		t.Fatalf("echo = %q, want round-trip via fixture", echo)
+	}
+}
+
+// TestProxy_DNSHostOverrides_RawIPLiteralStillBlocked confirms the
+// security invariant: an SSRF attack that targets a raw loopback IP must
+// be blocked even when dns.host_overrides happens to map some hostname to
+// that same IP. Trusted_domains rejects IP literals at the matcher, and
+// the override map is hostname-only.
+func TestProxy_DNSHostOverrides_RawIPLiteralStillBlocked(t *testing.T) {
+	// We don't even need a backend — pipelock should reject before any
+	// connection attempt. But we'll bring one up to ensure failure is
+	// caused by SSRF policy, not by "nothing listening".
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+	backendHost, backendPort, splitErr := net.SplitHostPort(backendAddr)
+	if splitErr != nil {
+		t.Fatalf("split backend addr: %v", splitErr)
+	}
+
+	proxyAddr, proxyCleanup := setupWSProxy(t, func(cfg *config.Config) {
+		// Same operator setup as the trusted-hostname test: override +
+		// trusted_domains for a hostname. The attacker hits the IP
+		// directly, not the hostname.
+		cfg.SSRF.IPAllowlist = nil
+		cfg.TrustedDomains = []string{"aeb-fixture.test"}
+		cfg.DNS.HostOverrides = map[string][]string{
+			"aeb-fixture.test": {backendHost},
+		}
+	})
+	defer proxyCleanup()
+
+	// Sanity: the override port must be a number we can reuse.
+	if _, err := strconv.Atoi(backendPort); err != nil {
+		t.Fatalf("backend port %q is not an integer", backendPort)
+	}
+
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer dialCancel()
+	tcpConn, dialErr := (&net.Dialer{}).DialContext(dialCtx, "tcp", proxyAddr)
+	if dialErr != nil {
+		t.Fatalf("dial proxy: %v", dialErr)
+	}
+	defer tcpConn.Close() //nolint:errcheck // test cleanup
+	if deadlineErr := tcpConn.SetDeadline(time.Now().Add(5 * time.Second)); deadlineErr != nil {
+		t.Fatalf("set deadline: %v", deadlineErr)
+	}
+
+	// Direct attack: agent sends a /ws upgrade for raw 127.0.0.1:<port>.
+	// trusted_domains rejects IP literals, override map is hostname-only,
+	// RFC1918/loopback check still fires → block.
+	upgrade := fmt.Sprintf(
+		"GET /ws?url=ws://%s/admin HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGVzdHRlc3R0ZXN0dGVzdA==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		net.JoinHostPort(backendHost, backendPort), proxyAddr,
+	)
+	if _, writeErr := tcpConn.Write([]byte(upgrade)); writeErr != nil {
+		t.Fatalf("write upgrade: %v", writeErr)
+	}
+
+	respBuf := make([]byte, 1024)
+	n, readErr := tcpConn.Read(respBuf)
+	if readErr != nil {
+		t.Fatalf("read response: %v", readErr)
+	}
+	resp := string(respBuf[:n])
+	if len(resp) < 12 || resp[:8] != "HTTP/1.1" {
+		t.Fatalf("expected HTTP response, got: %q", resp)
+	}
+	// Must NOT be 101 Switching Protocols. Pipelock SSRF should produce
+	// a 4xx/5xx, signaling refusal.
+	if len(resp) >= 12 && resp[:12] == "HTTP/1.1 101" {
+		t.Fatalf("raw 127.0.0.1 WS upgrade was accepted; SSRF check did NOT reject — override map must not exempt IP literals")
+	}
+}

--- a/internal/proxy/dns_overrides_e2e_test.go
+++ b/internal/proxy/dns_overrides_e2e_test.go
@@ -62,7 +62,7 @@ func TestProxy_DNSHostOverrides_WSFixtureRoutesViaTrustedHostname(t *testing.T) 
 	if dialErr != nil {
 		t.Fatalf("dial proxy: %v", dialErr)
 	}
-	defer tcpConn.Close() //nolint:errcheck // test cleanup
+	defer func() { _ = tcpConn.Close() }()
 	if deadlineErr := tcpConn.SetDeadline(time.Now().Add(5 * time.Second)); deadlineErr != nil {
 		t.Fatalf("set deadline: %v", deadlineErr)
 	}
@@ -140,7 +140,7 @@ func TestProxy_DNSHostOverrides_RawIPLiteralStillBlocked(t *testing.T) {
 	if dialErr != nil {
 		t.Fatalf("dial proxy: %v", dialErr)
 	}
-	defer tcpConn.Close() //nolint:errcheck // test cleanup
+	defer func() { _ = tcpConn.Close() }()
 	if deadlineErr := tcpConn.SetDeadline(time.Now().Add(5 * time.Second)); deadlineErr != nil {
 		t.Fatalf("set deadline: %v", deadlineErr)
 	}

--- a/internal/proxy/dns_overrides_e2e_test.go
+++ b/internal/proxy/dns_overrides_e2e_test.go
@@ -1,9 +1,11 @@
 package proxy
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"strconv"
 	"testing"
 	"time"
@@ -67,34 +69,42 @@ func TestProxy_DNSHostOverrides_WSFixtureRoutesViaTrustedHostname(t *testing.T) 
 		t.Fatalf("set deadline: %v", deadlineErr)
 	}
 
-	// Manual WS upgrade — gobwas's dialer would re-resolve the hostname on
-	// the client side, which we can't intercept. We just need pipelock to
-	// see and honor the override; the runner-side path through the proxy
-	// is what counts.
+	// Manual WS upgrade. Gobwas's dialer would re-resolve the hostname on
+	// the client side, which we cannot intercept; we need pipelock to see
+	// and honor the override, so the runner-side path through the proxy
+	// is what counts. Use http.ReadResponse via bufio so a partial TCP
+	// read cannot fragment the status line or headers, and so any bytes
+	// pipelock buffers ahead of the WS frames stay accessible.
 	upgrade := fmt.Sprintf(
-		"GET /ws?url=%s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGVzdHRlc3R0ZXN0dGVzdA==\r\nSec-WebSocket-Version: 13\r\n\r\n",
-		"ws://"+hostPort+"/echo", proxyAddr,
+		"%s /ws?url=%s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGVzdHRlc3R0ZXN0dGVzdA==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		http.MethodGet, "ws://"+hostPort+"/echo", proxyAddr,
 	)
 	if _, writeErr := tcpConn.Write([]byte(upgrade)); writeErr != nil {
 		t.Fatalf("write upgrade: %v", writeErr)
 	}
 
-	// Read upgrade response.
-	respBuf := make([]byte, 512)
-	if _, readErr := tcpConn.Read(respBuf); readErr != nil {
-		t.Fatalf("read upgrade response: %v", readErr)
+	br := bufio.NewReader(tcpConn)
+	resp, respErr := http.ReadResponse(br, &http.Request{Method: http.MethodGet})
+	if respErr != nil {
+		t.Fatalf("read upgrade response: %v", respErr)
 	}
-	if string(respBuf[:12]) != "HTTP/1.1 101" {
-		t.Fatalf("expected 101 Switching Protocols upgrade; got: %q", string(respBuf[:60]))
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		_ = resp.Body.Close()
+		t.Fatalf("expected 101 Switching Protocols upgrade; got: %d %s", resp.StatusCode, resp.Status)
 	}
+	_ = resp.Body.Close()
 
-	// Write a single benign text frame and expect an echo.
-	if err := wsutil.WriteClientMessage(tcpConn, ws.OpText, []byte("hello via trusted host")); err != nil {
+	// Write a single benign text frame and expect an echo. Wrap the conn
+	// in the package-local bufferedConn so wsutil.ReadServerData consumes
+	// any frame bytes already buffered by http.ReadResponse rather than
+	// losing them past the bufio boundary.
+	rw := &bufferedConn{Conn: tcpConn, r: br}
+	if err := wsutil.WriteClientMessage(rw, ws.OpText, []byte("hello via trusted host")); err != nil {
 		t.Fatalf("write frame: %v", err)
 	}
-	echo, _, err := wsutil.ReadServerData(tcpConn)
+	echo, _, err := wsutil.ReadServerData(rw)
 	if err != nil {
-		t.Fatalf("read echo: %v — override + trusted_domains should let the connection round-trip", err)
+		t.Fatalf("read echo: %v - override + trusted_domains should let the connection round-trip", err)
 	}
 	if string(echo) != "hello via trusted host" {
 		t.Fatalf("echo = %q, want round-trip via fixture", echo)
@@ -147,27 +157,26 @@ func TestProxy_DNSHostOverrides_RawIPLiteralStillBlocked(t *testing.T) {
 
 	// Direct attack: agent sends a /ws upgrade for raw 127.0.0.1:<port>.
 	// trusted_domains rejects IP literals, override map is hostname-only,
-	// RFC1918/loopback check still fires → block.
+	// RFC1918/loopback check still fires so the upgrade is denied.
 	upgrade := fmt.Sprintf(
-		"GET /ws?url=ws://%s/admin HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGVzdHRlc3R0ZXN0dGVzdA==\r\nSec-WebSocket-Version: 13\r\n\r\n",
-		net.JoinHostPort(backendHost, backendPort), proxyAddr,
+		"%s /ws?url=ws://%s/admin HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGVzdHRlc3R0ZXN0dGVzdA==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		http.MethodGet, net.JoinHostPort(backendHost, backendPort), proxyAddr,
 	)
 	if _, writeErr := tcpConn.Write([]byte(upgrade)); writeErr != nil {
 		t.Fatalf("write upgrade: %v", writeErr)
 	}
 
-	respBuf := make([]byte, 1024)
-	n, readErr := tcpConn.Read(respBuf)
-	if readErr != nil {
-		t.Fatalf("read response: %v", readErr)
+	br := bufio.NewReader(tcpConn)
+	resp, respErr := http.ReadResponse(br, &http.Request{Method: http.MethodGet})
+	if respErr != nil {
+		t.Fatalf("read response: %v", respErr)
 	}
-	resp := string(respBuf[:n])
-	if len(resp) < 12 || resp[:8] != "HTTP/1.1" {
-		t.Fatalf("expected HTTP response, got: %q", resp)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusSwitchingProtocols {
+		t.Fatalf("raw 127.0.0.1 WS upgrade was accepted; SSRF check did NOT reject - override map must not exempt IP literals")
 	}
-	// Must NOT be 101 Switching Protocols. Pipelock SSRF should produce
-	// a 4xx/5xx, signaling refusal.
-	if len(resp) >= 12 && resp[:12] == "HTTP/1.1 101" {
-		t.Fatalf("raw 127.0.0.1 WS upgrade was accepted; SSRF check did NOT reject — override map must not exempt IP literals")
+	// Pipelock should signal refusal with a 4xx/5xx status.
+	if resp.StatusCode < 400 {
+		t.Fatalf("expected 4xx/5xx refusal, got: %d %s", resp.StatusCode, resp.Status)
 	}
 }

--- a/internal/proxy/dns_overrides_e2e_test.go
+++ b/internal/proxy/dns_overrides_e2e_test.go
@@ -3,6 +3,8 @@ package proxy
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"net/http"
@@ -15,6 +17,20 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 )
+
+// generateWSKey returns a base64-encoded random 16-byte value suitable for
+// the Sec-WebSocket-Key header. Built at runtime rather than hardcoded so
+// the value does not trip secret scanners on the repo (gosec G101) and to
+// match the same pattern the agent-egress-bench runner adapter uses for
+// its manual upgrade requests.
+func generateWSKey(t *testing.T) string {
+	t.Helper()
+	keyBytes := make([]byte, 16)
+	if _, err := rand.Read(keyBytes); err != nil {
+		t.Fatalf("generate websocket key: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(keyBytes)
+}
 
 // TestProxy_DNSHostOverrides_WSFixtureRoutesViaTrustedHostname mirrors the
 // agent-egress-bench scenario where a local WebSocket fixture lives on
@@ -76,8 +92,8 @@ func TestProxy_DNSHostOverrides_WSFixtureRoutesViaTrustedHostname(t *testing.T) 
 	// read cannot fragment the status line or headers, and so any bytes
 	// pipelock buffers ahead of the WS frames stay accessible.
 	upgrade := fmt.Sprintf(
-		"%s /ws?url=%s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGVzdHRlc3R0ZXN0dGVzdA==\r\nSec-WebSocket-Version: 13\r\n\r\n",
-		http.MethodGet, "ws://"+hostPort+"/echo", proxyAddr,
+		"%s /ws?url=%s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: %s\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		http.MethodGet, "ws://"+hostPort+"/echo", proxyAddr, generateWSKey(t),
 	)
 	if _, writeErr := tcpConn.Write([]byte(upgrade)); writeErr != nil {
 		t.Fatalf("write upgrade: %v", writeErr)
@@ -159,8 +175,8 @@ func TestProxy_DNSHostOverrides_RawIPLiteralStillBlocked(t *testing.T) {
 	// trusted_domains rejects IP literals, override map is hostname-only,
 	// RFC1918/loopback check still fires so the upgrade is denied.
 	upgrade := fmt.Sprintf(
-		"%s /ws?url=ws://%s/admin HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGVzdHRlc3R0ZXN0dGVzdA==\r\nSec-WebSocket-Version: 13\r\n\r\n",
-		http.MethodGet, net.JoinHostPort(backendHost, backendPort), proxyAddr,
+		"%s /ws?url=ws://%s/admin HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: %s\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		http.MethodGet, net.JoinHostPort(backendHost, backendPort), proxyAddr, generateWSKey(t),
 	)
 	if _, writeErr := tcpConn.Write([]byte(upgrade)); writeErr != nil {
 		t.Fatalf("write upgrade: %v", writeErr)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2604,8 +2604,10 @@ func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (
 		return p.dialer.DialContext(ctx, network, addr)
 	}
 
-	// Resolve DNS and validate every IP before connecting.
-	ips, err := net.DefaultResolver.LookupHost(ctx, host)
+	// Resolve DNS and validate every IP before connecting. Use the scanner's
+	// resolver so dns.host_overrides applies uniformly to both the SSRF
+	// scanner check and this dial-time check, preventing TOCTOU drift.
+	ips, err := p.scannerPtr.Load().HostResolver().LookupHost(ctx, host)
 	if err != nil {
 		return nil, fmt.Errorf("ssrfSafeDialContext: DNS lookup %q: %w", host, err)
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2607,7 +2607,8 @@ func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (
 	// Resolve DNS and validate every IP before connecting. Use the scanner's
 	// resolver so dns.host_overrides applies uniformly to both the SSRF
 	// scanner check and this dial-time check, preventing TOCTOU drift.
-	ips, err := p.scannerPtr.Load().HostResolver().LookupHost(ctx, host)
+	currentSc := p.scannerPtr.Load()
+	ips, err := currentSc.HostResolver().LookupHost(ctx, host)
 	if err != nil {
 		return nil, fmt.Errorf("ssrfSafeDialContext: DNS lookup %q: %w", host, err)
 	}
@@ -2616,7 +2617,6 @@ func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (
 		return nil, fmt.Errorf("SSRF blocked: DNS returned no addresses for %s", host)
 	}
 
-	currentSc := p.scannerPtr.Load()
 	isTrusted := currentSc.IsTrustedDomain(host)
 	for _, ipStr := range ips {
 		ip := net.ParseIP(ipStr)

--- a/internal/proxy/wsprobe_bench_test.go
+++ b/internal/proxy/wsprobe_bench_test.go
@@ -27,7 +27,7 @@ func TestWSProxy_BenchCrossMessage_GitHubToken(t *testing.T) {
 	defer proxyCleanup()
 
 	conn := dialWS(t, proxyAddr, backendAddr)
-	defer conn.Close() //nolint:errcheck // test
+	defer func() { _ = conn.Close() }()
 
 	// First frame: prefix, no pattern hit alone.
 	msg1 := []byte("part1: ghp_ABCDEFGHIJKLMN")

--- a/internal/proxy/wsprobe_bench_test.go
+++ b/internal/proxy/wsprobe_bench_test.go
@@ -1,0 +1,54 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// TestWSProxy_BenchCrossMessage_GitHubToken reproduces the exact gauntlet
+// payload for ws-dlp-cross-message-005: two text frames whose label-stripped
+// suffixes concatenate to a GitHub PAT matching the bench Benchmark GitHub
+// Token pattern (ghp_[A-Za-z0-9_]{30,}).
+func TestWSProxy_BenchCrossMessage_GitHubToken(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+
+	proxyAddr, proxyCleanup := setupWSProxy(t, func(cfg *config.Config) {
+		cfg.DLP.Patterns = append(cfg.DLP.Patterns, config.DLPPattern{
+			Name:     "Benchmark GitHub Token",
+			Regex:    `ghp_[A-Za-z0-9_]{30,}`,
+			Severity: "critical",
+		})
+	})
+	defer proxyCleanup()
+
+	conn := dialWS(t, proxyAddr, backendAddr)
+	defer conn.Close() //nolint:errcheck // test
+
+	// First frame: prefix, no pattern hit alone.
+	msg1 := []byte("part1: ghp_ABCDEFGHIJKLMN")
+	if err := wsutil.WriteClientMessage(conn, ws.OpText, msg1); err != nil {
+		t.Fatalf("write msg1: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(conn); err != nil {
+		t.Fatalf("read msg1 echo: %v (first half should pass)", err)
+	}
+
+	// Second frame: completes the secret when label-stripped suffixes are joined.
+	msg2 := []byte("part2: OPQRSTUVWXYZabcdef12")
+	if err := wsutil.WriteClientMessage(conn, ws.OpText, msg2); err != nil {
+		t.Fatalf("write msg2: %v", err)
+	}
+
+	// Expectation: pipelock should close the connection because
+	// joinLabeledWSCrossMessageSuffixes("part1: ghp_ABCDEFGHIJKLMN",
+	// "part2: OPQRSTUVWXYZabcdef12") yields "ghp_" + 34 alphanumeric chars,
+	// which matches the Benchmark GitHub Token pattern's {30,} length.
+	if _, _, err := wsutil.ReadServerData(conn); err == nil {
+		t.Fatal("expected connection closed on cross-message labeled GitHub PAT, got nil — pipelock allowed the split-key exfiltration")
+	}
+}

--- a/internal/scanner/dnsresolver.go
+++ b/internal/scanner/dnsresolver.go
@@ -54,6 +54,9 @@ func NewStaticOverrideResolver(overrides map[string][]string, upstream Resolver)
 		if key == "" {
 			continue
 		}
+		if net.ParseIP(key) != nil {
+			continue
+		}
 		// Defensive copy so caller mutations after construction do not
 		// leak into the resolver's state.
 		cp := make([]string, len(ips))
@@ -67,10 +70,11 @@ func NewStaticOverrideResolver(overrides map[string][]string, upstream Resolver)
 // the upstream resolver. IP literals are passed straight through to the
 // upstream so net.ParseIP-style fast paths remain unchanged.
 func (r *StaticOverrideResolver) LookupHost(ctx context.Context, host string) ([]string, error) {
-	if net.ParseIP(host) != nil {
+	key := normalizeHostKey(host)
+	if net.ParseIP(key) != nil {
 		return r.upstream.LookupHost(ctx, host)
 	}
-	if ips, ok := r.overrides[normalizeHostKey(host)]; ok {
+	if ips, ok := r.overrides[key]; ok {
 		out := make([]string, len(ips))
 		copy(out, ips)
 		return out, nil
@@ -79,6 +83,6 @@ func (r *StaticOverrideResolver) LookupHost(ctx context.Context, host string) ([
 }
 
 func normalizeHostKey(host string) string {
-	host = strings.TrimSuffix(host, ".")
+	host = strings.TrimSuffix(strings.TrimSpace(host), ".")
 	return strings.ToLower(host)
 }

--- a/internal/scanner/dnsresolver.go
+++ b/internal/scanner/dnsresolver.go
@@ -1,0 +1,84 @@
+// dnsresolver.go — host-level DNS resolver used by SSRF checks and the
+// proxy dial path. The default resolver is net.DefaultResolver. Operators
+// may configure dns.host_overrides to map specific hostnames to static IPs
+// without touching system /etc/hosts; this is used by reproducible test
+// harnesses (e.g. agent-egress-bench) so a benchmark fixture published on
+// loopback can be reached at a trusted hostname while raw-IP SSRF attacks
+// targeting the same range still get rejected.
+//
+// Semantics:
+//   - Lookup matches on the hostname only (lowercased, trailing dot stripped).
+//     IP literals never hit overrides — the IP path bypasses the resolver.
+//   - If a hostname is in the override map, the static IPs are returned and
+//     the upstream resolver is not consulted. A trusted_domains entry for
+//     the same hostname tells the SSRF check to permit those IPs even when
+//     they fall inside RFC1918 / loopback.
+//   - If a hostname is NOT in the override map, the upstream resolver runs
+//     normally — fail-closed behavior on DNS errors is preserved.
+
+package scanner
+
+import (
+	"context"
+	"net"
+	"strings"
+)
+
+// Resolver abstracts DNS hostname lookups so the scanner and proxy can be
+// driven by an override-aware implementation in tests and reproducible
+// benchmarks. The shape matches the subset of *net.Resolver that the
+// proxy and SSRF check actually consume.
+type Resolver interface {
+	LookupHost(ctx context.Context, host string) ([]string, error)
+}
+
+// StaticOverrideResolver answers static hostname-to-IP mappings before
+// delegating to an upstream resolver. The override map is built once at
+// construction and is safe for concurrent reads; constructors normalize
+// hostname keys to lowercase and strip a trailing dot.
+type StaticOverrideResolver struct {
+	overrides map[string][]string
+	upstream  Resolver
+}
+
+// NewStaticOverrideResolver builds a resolver that returns the configured
+// IPs for any matching hostname and delegates everything else to upstream.
+// If upstream is nil, net.DefaultResolver is used.
+func NewStaticOverrideResolver(overrides map[string][]string, upstream Resolver) *StaticOverrideResolver {
+	if upstream == nil {
+		upstream = net.DefaultResolver
+	}
+	norm := make(map[string][]string, len(overrides))
+	for host, ips := range overrides {
+		key := normalizeHostKey(host)
+		if key == "" {
+			continue
+		}
+		// Defensive copy so caller mutations after construction do not
+		// leak into the resolver's state.
+		cp := make([]string, len(ips))
+		copy(cp, ips)
+		norm[key] = cp
+	}
+	return &StaticOverrideResolver{overrides: norm, upstream: upstream}
+}
+
+// LookupHost returns the override IPs for known hostnames, falling back to
+// the upstream resolver. IP literals are passed straight through to the
+// upstream so net.ParseIP-style fast paths remain unchanged.
+func (r *StaticOverrideResolver) LookupHost(ctx context.Context, host string) ([]string, error) {
+	if net.ParseIP(host) != nil {
+		return r.upstream.LookupHost(ctx, host)
+	}
+	if ips, ok := r.overrides[normalizeHostKey(host)]; ok {
+		out := make([]string, len(ips))
+		copy(out, ips)
+		return out, nil
+	}
+	return r.upstream.LookupHost(ctx, host)
+}
+
+func normalizeHostKey(host string) string {
+	host = strings.TrimSuffix(host, ".")
+	return strings.ToLower(host)
+}

--- a/internal/scanner/dnsresolver_test.go
+++ b/internal/scanner/dnsresolver_test.go
@@ -97,6 +97,23 @@ func TestStaticOverrideResolver_IPLiteralBypassesOverride(t *testing.T) {
 	}
 }
 
+func TestStaticOverrideResolver_TrailingDotIPLiteralBypassesOverride(t *testing.T) {
+	upstream := &fakeResolver{hosts: map[string][]string{"127.0.0.1.": {"198.51.100.7"}}}
+	r := NewStaticOverrideResolver(
+		map[string][]string{
+			"127.0.0.1.": {"127.0.0.1"},
+		},
+		upstream,
+	)
+	got, err := r.LookupHost(context.Background(), "127.0.0.1.")
+	if err != nil {
+		t.Fatalf("LookupHost: %v", err)
+	}
+	if len(got) != 1 || got[0] != "198.51.100.7" {
+		t.Errorf("got %v, want upstream [198.51.100.7]; trailing-dot IP literal must not hit overrides", got)
+	}
+}
+
 func TestStaticOverrideResolver_EmptyOverridesPassesThrough(t *testing.T) {
 	upstream := &fakeResolver{hosts: map[string][]string{"example.com": {"93.184.216.34"}}}
 	r := NewStaticOverrideResolver(nil, upstream)

--- a/internal/scanner/dnsresolver_test.go
+++ b/internal/scanner/dnsresolver_test.go
@@ -1,0 +1,145 @@
+package scanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakeResolver struct {
+	hosts map[string][]string
+	err   error
+}
+
+func (f *fakeResolver) LookupHost(_ context.Context, host string) ([]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	ips, ok := f.hosts[host]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return ips, nil
+}
+
+func TestStaticOverrideResolver_HostnameOverrideReturnsConfiguredIPs(t *testing.T) {
+	upstream := &fakeResolver{hosts: map[string][]string{"upstream.test": {"203.0.113.7"}}}
+	r := NewStaticOverrideResolver(
+		map[string][]string{
+			"aeb-fixture.test": {"127.0.0.1"},
+		},
+		upstream,
+	)
+	got, err := r.LookupHost(context.Background(), "aeb-fixture.test")
+	if err != nil {
+		t.Fatalf("LookupHost: %v", err)
+	}
+	if len(got) != 1 || got[0] != "127.0.0.1" {
+		t.Errorf("got %v, want [127.0.0.1]", got)
+	}
+}
+
+func TestStaticOverrideResolver_HostnameNormalizationLowerAndTrailingDot(t *testing.T) {
+	upstream := &fakeResolver{}
+	r := NewStaticOverrideResolver(
+		map[string][]string{
+			"AEB-Fixture.Test.": {"127.0.0.1"},
+		},
+		upstream,
+	)
+	for _, q := range []string{"aeb-fixture.test", "AEB-FIXTURE.TEST", "aeb-fixture.test."} {
+		got, err := r.LookupHost(context.Background(), q)
+		if err != nil {
+			t.Fatalf("LookupHost(%q): %v", q, err)
+		}
+		if len(got) != 1 || got[0] != "127.0.0.1" {
+			t.Errorf("LookupHost(%q) = %v, want [127.0.0.1]", q, got)
+		}
+	}
+}
+
+func TestStaticOverrideResolver_UnknownHostnameDelegatesToUpstream(t *testing.T) {
+	upstream := &fakeResolver{hosts: map[string][]string{"real.test": {"203.0.113.9"}}}
+	r := NewStaticOverrideResolver(
+		map[string][]string{"aeb-fixture.test": {"127.0.0.1"}},
+		upstream,
+	)
+	got, err := r.LookupHost(context.Background(), "real.test")
+	if err != nil {
+		t.Fatalf("LookupHost: %v", err)
+	}
+	if len(got) != 1 || got[0] != "203.0.113.9" {
+		t.Errorf("got %v, want [203.0.113.9]", got)
+	}
+}
+
+func TestStaticOverrideResolver_IPLiteralBypassesOverride(t *testing.T) {
+	// Critical security property: IP literals must NEVER hit the override
+	// map. Otherwise an operator could accidentally exempt SSRF-relevant
+	// IPs through a hostname-targeted mapping. A request to "127.0.0.1"
+	// goes straight to the upstream resolver regardless of any override
+	// that happens to map to 127.0.0.1.
+	upstream := &fakeResolver{hosts: map[string][]string{"127.0.0.1": {"127.0.0.1"}}}
+	r := NewStaticOverrideResolver(
+		map[string][]string{
+			// This map has the IP as both a key and a value; only the
+			// upstream answer must be observed for an IP-literal lookup.
+			"aeb-fixture.test": {"127.0.0.1"},
+		},
+		upstream,
+	)
+	got, err := r.LookupHost(context.Background(), "127.0.0.1")
+	if err != nil {
+		t.Fatalf("LookupHost: %v", err)
+	}
+	if len(got) != 1 || got[0] != "127.0.0.1" {
+		t.Errorf("got %v, want [127.0.0.1]", got)
+	}
+}
+
+func TestStaticOverrideResolver_EmptyOverridesPassesThrough(t *testing.T) {
+	upstream := &fakeResolver{hosts: map[string][]string{"example.com": {"93.184.216.34"}}}
+	r := NewStaticOverrideResolver(nil, upstream)
+	got, err := r.LookupHost(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("LookupHost: %v", err)
+	}
+	if len(got) != 1 || got[0] != "93.184.216.34" {
+		t.Errorf("got %v, want [93.184.216.34]", got)
+	}
+}
+
+func TestStaticOverrideResolver_NilUpstreamDefaultsToSystem(t *testing.T) {
+	// Construction must not panic with a nil upstream; the resolver should
+	// quietly install net.DefaultResolver. We don't actually call
+	// LookupHost on the system resolver to keep the test hermetic.
+	r := NewStaticOverrideResolver(map[string][]string{"x.test": {"127.0.0.1"}}, nil)
+	if r.upstream == nil {
+		t.Fatal("upstream was nil after construction")
+	}
+	got, err := r.LookupHost(context.Background(), "x.test")
+	if err != nil {
+		t.Fatalf("LookupHost(override): %v", err)
+	}
+	if len(got) != 1 || got[0] != "127.0.0.1" {
+		t.Errorf("override lookup = %v, want [127.0.0.1]", got)
+	}
+}
+
+func TestStaticOverrideResolver_CallerMutationDoesNotLeak(t *testing.T) {
+	// If a caller mutates the IPs slice they passed in after construction,
+	// the resolver's stored values must remain unchanged.
+	ips := []string{"127.0.0.1"}
+	r := NewStaticOverrideResolver(
+		map[string][]string{"aeb-fixture.test": ips},
+		&fakeResolver{},
+	)
+	ips[0] = "8.8.8.8" // simulated post-construction mutation by caller
+	got, err := r.LookupHost(context.Background(), "aeb-fixture.test")
+	if err != nil {
+		t.Fatalf("LookupHost: %v", err)
+	}
+	if len(got) != 1 || got[0] != "127.0.0.1" {
+		t.Errorf("got %v, want [127.0.0.1] (caller mutation must not affect resolver state)", got)
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -573,13 +573,13 @@ func (s *Scanner) IsInternalIP(ip net.IP) bool {
 // instead of blocking. IP literals are always rejected — trusted domains
 // only match hostnames to prevent SSRF bypass via raw IP addresses.
 func (s *Scanner) IsTrustedDomain(hostname string) bool {
+	hostname = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(hostname), "."))
 	// Reject IP literals: trusted domains match hostnames only.
 	// Without this, an attacker could add a raw IP to trusted_domains
 	// and bypass SSRF protection entirely.
 	if net.ParseIP(hostname) != nil {
 		return false
 	}
-	hostname = strings.ToLower(strings.TrimSuffix(hostname, "."))
 	for _, pattern := range s.trustedDomains {
 		if MatchDomain(hostname, pattern) {
 			return true

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -232,6 +232,11 @@ type Scanner struct {
 	// wedge-detection watchdog. atomic.Pointer keeps SetHeartbeat
 	// race-safe even though production wires it before Start.
 	heartbeat atomic.Pointer[heartbeatFn]
+
+	// resolver answers SSRF DNS lookups and the proxy dial path. Default is
+	// net.DefaultResolver; populated from cfg.DNS.HostOverrides in New().
+	// Hostname-only overrides; IP literals bypass via the upstream resolver.
+	resolver Resolver
 }
 
 // heartbeatFn wraps a func() so it can live behind atomic.Pointer (which
@@ -405,6 +410,12 @@ func New(cfg *config.Config) *Scanner {
 	s.trustedDomains = cfg.TrustedDomains
 	s.rawAPIAllowlist = cfg.APIAllowlist
 
+	// Install the DNS resolver. When dns.host_overrides is empty the wrapper
+	// degrades to a plain delegation to net.DefaultResolver — this keeps a
+	// single code path through the rest of the scanner and proxy regardless
+	// of whether overrides are configured.
+	s.resolver = NewStaticOverrideResolver(cfg.DNS.HostOverrides, nil)
+
 	// Initialize data budget if configured
 	if cfg.FetchProxy.Monitoring.MaxDataPerMinute > 0 {
 		s.dataBudget = NewDataBudget(cfg.FetchProxy.Monitoring.MaxDataPerMinute)
@@ -575,6 +586,13 @@ func (s *Scanner) IsTrustedDomain(hostname string) bool {
 		}
 	}
 	return false
+}
+
+// HostResolver returns the resolver used for SSRF DNS lookups and the proxy
+// dial path. It honors dns.host_overrides if configured and falls back to
+// net.DefaultResolver otherwise. Always non-nil for a Scanner built via New().
+func (s *Scanner) HostResolver() Resolver {
+	return s.resolver
 }
 
 // IsIPAllowlisted checks if an IP is in the SSRF IP allowlist (ssrf.ip_allowlist).
@@ -1078,7 +1096,7 @@ func (s *Scanner) checkSSRF(ctx context.Context, hostname string) Result {
 	// Fail closed: if we can't resolve DNS, we can't verify the IP is safe.
 	dnsCtx, dnsCancel := context.WithTimeout(ctx, 5*time.Second) // 5s: DNS resolution ceiling; inherits caller cancellation
 	defer dnsCancel()
-	ips, err := net.DefaultResolver.LookupHost(dnsCtx, hostname)
+	ips, err := s.resolver.LookupHost(dnsCtx, hostname)
 	if err != nil {
 		// Caller cancellation or deadline must route through the normal
 		// fail-closed ScannerContext path. dnsCtx inherits ctx, so a

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1118,6 +1118,7 @@ func TestScanner_IsTrustedDomain(t *testing.T) {
 		{"no match example.com", "example.com", false},
 		{"no match notinternal.corp", "notinternal.corp", false},
 		{"IP not trusted", "192.168.1.1", false},
+		{"trailing-dot IP not trusted", "192.168.1.1.", false}, // OPSEC-OK: test fixture for trailing-dot IP literal rejection
 		{"uppercase normalized", "LOCALHOST", true},
 		{"trailing dot stripped", "localhost.", true},
 	}


### PR DESCRIPTION
Pipelock's SSRF check and the proxy dial path both resolve hostnames via `net.DefaultResolver`. There is no per-process knob to map a hostname to a static IP without touching `/etc/hosts`, and `ssrf.ip_allowlist` works on IP ranges rather than hostnames. That combination breaks reproducible test harnesses (e.g. agent-egress-bench). A benign fixture living on loopback can only be reached by raw IP, and exempting loopback widely would also exempt SSRF attacks that target loopback by IP literal.

This PR adds a hostname-scoped resolver layer.

`internal/scanner/Resolver` interface and `StaticOverrideResolver`. The override map is built once from `cfg.DNS.HostOverrides`, normalized to lowercased and trailing-dot-stripped keys, defensively copied. Hostnames in the map resolve to the configured IPs; everything else delegates to `net.DefaultResolver`. IP literals (including trailing-dot variants) bypass the override entirely so an attacker cannot smuggle exemption through an IP-shaped lookup key.

The resolver is wired through `Scanner.New()` and exposed via `Scanner.HostResolver()` so the proxy dial path uses the same resolver as the SSRF check, preventing TOCTOU drift between scan-time and dial-time resolution. `scanner.checkSSRF` and `proxy.ssrfSafeDialContext` both switch from `net.DefaultResolver.LookupHost` to the scanner's resolver. The dial path now loads the scanner pointer once and reuses it for both `LookupHost` and `IsTrustedDomain` so a hot reload between calls cannot mix old-resolver IPs against new-trusted-domains state.

`IsTrustedDomain` normalizes (trim whitespace, strip trailing dot, lowercase) before the IP-literal rejection so `"127.0.0.1."` is caught at the matcher. Previously `net.ParseIP` returned nil for the trailing-dot form and the subsequent normalization could pair it with a trusted-domains entry.

Config surface: new top-level `dns:` section with `host_overrides: map[string][]string`. Validation rejects empty keys, URL/wildcard/host:port shapes, IP-literal keys (including trailing-dot), empty IP lists, unparseable IPs, and hostnames that duplicate after normalization. The field is part of the canonical policy view because resolution rewrites change SSRF destinations; golden hash bumped accordingly.

The feature is exemption-by-composition: the override on its own provides no SSRF bypass. Pipelock still applies the RFC1918 and loopback check; the exemption only takes effect when the resolved hostname is also listed in `trusted_domains`. Operators must opt into both.

Operator docs in `docs/configuration.md` describe the pairing requirement and the explicit statement that raw IP targets never consult the override map.

Pre-push security suite: 0 branch-only failures (8 pre-existing failures on `origin/main` per `pentest-baseline-diff.sh`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DNS host overrides configuration for static hostname→IP resolution and ensured overrides are applied consistently during scanning and proxying.

* **Documentation**
  * Added "DNS Host Overrides" docs describing YAML shape, normalization (case/trim/trailing-dot) and validation constraints.

* **Behavior**
  * Clarified overrides do not bypass SSRF protections by themselves; raw IP targets remain blocked and trusted-domain/allowlist rules still apply.

* **Tests**
  * Added unit, e2e, and regression tests covering validation, resolver behavior, proxy/WebSocket scenarios, and a benchmark for cross-message DLP detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->