### PR TITLE
Harden enterprise license expiry warnings and CRL enforcement

### DIFF
--- a/enterprise/cli/license.go
+++ b/enterprise/cli/license.go
@@ -16,16 +16,21 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 	"github.com/spf13/cobra"
 )
 
 const (
-	licenseDefaultDir  = ".config/pipelock"
-	licensePrivKeyFile = "license.key"
-	licensePubKeyFile  = "license.pub"
-	licenseLedgerFile  = "licenses.jsonl"
+	licenseDefaultDir    = ".config/pipelock"
+	licensePrivKeyFile   = "license.key"
+	licensePubKeyFile    = "license.pub"
+	licenseLedgerFile    = "licenses.jsonl"
+	licenseStatusInvalid = "invalid"
+	licenseStatusMissing = "missing"
+	licenseStatusValid   = "valid"
 )
 
 // LicenseCmd returns the license command tree: keygen, issue, inspect, install.
@@ -39,6 +44,7 @@ func LicenseCmd() *cobra.Command {
 		licenseIssueCmd(),
 		licenseInspectCmd(),
 		licenseInstallCmd(),
+		licenseStatusCmd(),
 	)
 	return cmd
 }
@@ -252,6 +258,177 @@ func licenseInspectCmd() *cobra.Command {
 		},
 	}
 	return cmd
+}
+
+type licenseStatusReport struct {
+	Status         string `json:"status"`
+	LicenseID      string `json:"license_id,omitempty"`
+	Tier           string `json:"tier,omitempty"`
+	SubscriptionID string `json:"subscription_id,omitempty"`
+	ExpiresAt      string `json:"expires_at,omitempty"`
+	DaysRemaining  int    `json:"days_remaining,omitempty"`
+	WarningBand    int    `json:"warning_band,omitempty"`
+	Severity       string `json:"severity,omitempty"`
+	CRLConfigured  bool   `json:"crl_configured"`
+	CRLExpiresAt   string `json:"crl_expires_at,omitempty"`
+	CRLSHA256      string `json:"crl_sha256,omitempty"`
+	Reason         string `json:"reason,omitempty"`
+}
+
+func licenseStatusCmd() *cobra.Command {
+	var (
+		configFile string
+		crlFile    string
+		jsonOutput bool
+	)
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Verify the configured license and show renewal status",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			report, err := buildLicenseStatusReport(configFile, crlFile)
+			if jsonOutput {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				if encErr := enc.Encode(report); encErr != nil {
+					return fmt.Errorf("encode license status JSON: %w", encErr)
+				}
+			} else {
+				printLicenseStatus(cmd, report)
+			}
+			if err != nil {
+				return cliutil.ExitCodeError(1, err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&configFile, "config", "c", "", "config file (default: discovered config or built-in defaults)")
+	cmd.Flags().StringVar(&crlFile, "crl", "", "signed CRL file override")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output status as JSON")
+	return cmd
+}
+
+func buildLicenseStatusReport(configFile, crlFile string) (licenseStatusReport, error) {
+	cfg, err := loadLicenseStatusConfig(configFile)
+	if err != nil {
+		return licenseStatusReport{Status: licenseStatusInvalid, Reason: err.Error()}, err
+	}
+	report := licenseStatusReport{}
+	if cfg.LicenseKey == "" {
+		err := errors.New("no license key configured")
+		report.Status = licenseStatusMissing
+		report.Reason = err.Error()
+		return report, err
+	}
+	pubKey, err := licenseStatusPublicKey(cfg)
+	if err != nil {
+		report.Status = licenseStatusInvalid
+		report.Reason = err.Error()
+		return report, err
+	}
+	if crlFile == "" {
+		crlFile = cfg.LicenseCRLFile
+	}
+	var crl *license.CRL
+	if crlFile != "" {
+		report.CRLConfigured = true
+		loaded, crlErr := license.LoadAndVerifyCRL(crlFile, pubKey, time.Now())
+		if crlErr != nil {
+			report.Status = licenseStatusInvalid
+			report.Reason = crlErr.Error()
+			return report, crlErr
+		}
+		crl = &loaded
+		report.CRLExpiresAt = time.Unix(loaded.Payload.ExpiresAt, 0).UTC().Format(time.DateOnly)
+		report.CRLSHA256 = loaded.SHA256
+	}
+
+	lic, err := license.VerifyWithCRL(cfg.LicenseKey, pubKey, crl)
+	report.LicenseID = lic.ID
+	report.Tier = lic.Tier
+	report.SubscriptionID = lic.SubscriptionID
+	if lic.ExpiresAt > 0 {
+		report.ExpiresAt = time.Unix(lic.ExpiresAt, 0).UTC().Format(time.DateOnly)
+		warn := license.ExpiryStatus(lic, time.Now())
+		report.DaysRemaining = warn.DaysRemaining
+		report.WarningBand = warn.ThresholdDays
+		report.Severity = warn.Severity
+	}
+	if err != nil {
+		switch {
+		case errors.Is(err, license.ErrLicenseRevoked):
+			report.Status = "revoked"
+		case errors.Is(err, license.ErrLicenseExpired):
+			report.Status = "expired"
+		default:
+			report.Status = licenseStatusInvalid
+		}
+		report.Reason = err.Error()
+		return report, err
+	}
+	report.Status = licenseStatusValid
+	return report, nil
+}
+
+func loadLicenseStatusConfig(configFile string) (*config.Config, error) {
+	if configFile == "" {
+		configFile = cliutil.DiscoverConfigPath()
+	}
+	if configFile == "" {
+		return config.Defaults(), nil
+	}
+	cfg, err := config.Load(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("loading config %q: %w", configFile, err)
+	}
+	return cfg, nil
+}
+
+func licenseStatusPublicKey(cfg *config.Config) (ed25519.PublicKey, error) {
+	if key := license.EmbeddedPublicKey(); key != nil {
+		return key, nil
+	}
+	if cfg.LicensePublicKey == "" {
+		return nil, errors.New("no license public key available")
+	}
+	keyBytes, err := hex.DecodeString(cfg.LicensePublicKey)
+	if err != nil || len(keyBytes) != ed25519.PublicKeySize {
+		return nil, errors.New("invalid license public key")
+	}
+	return ed25519.PublicKey(keyBytes), nil
+}
+
+func printLicenseStatus(cmd *cobra.Command, report licenseStatusReport) {
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "License status: %s\n", report.Status)
+	if report.LicenseID != "" {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  ID:       %s\n", report.LicenseID)
+	}
+	if report.Tier != "" {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Tier:     %s\n", report.Tier)
+	}
+	if report.SubscriptionID != "" {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Sub ID:   %s\n", report.SubscriptionID)
+	}
+	if report.ExpiresAt != "" {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Expires:  %s (%d day(s) remaining)\n", report.ExpiresAt, report.DaysRemaining)
+		if report.WarningBand > 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Warning:  %d-day renewal band (%s)\n", report.WarningBand, report.Severity)
+		}
+	} else if report.Status == licenseStatusValid {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Expires:  never\n")
+	}
+	if report.CRLConfigured {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  CRL:      configured")
+		if report.CRLExpiresAt != "" {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), " (expires %s)", report.CRLExpiresAt)
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout())
+		if report.CRLSHA256 != "" {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  CRL SHA:  %s\n", report.CRLSHA256)
+		}
+	}
+	if report.Reason != "" {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Reason:   %s\n", report.Reason)
+	}
 }
 
 // licenseDefaultTokenFile is the default filename for installed license tokens.

--- a/enterprise/cli/license_test.go
+++ b/enterprise/cli/license_test.go
@@ -145,6 +145,179 @@ func TestLicenseStatusRevokedByCRL(t *testing.T) {
 	}
 }
 
+func TestLicenseStatusCommandOutputs(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	lic := license.License{
+		ID:             "lic_status_cmd",
+		Email:          "status@example.com",
+		IssuedAt:       now.Unix(),
+		ExpiresAt:      now.Add(45 * 24 * time.Hour).Unix(),
+		Features:       []string{license.FeatureAgents},
+		Tier:           "enterprise",
+		SubscriptionID: "sub_status",
+	}
+	token, err := license.Issue(lic, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := writeLicenseStatusConfig(t, token, pub, "")
+
+	t.Run("human", func(t *testing.T) {
+		cmd := licenseStatusCmd()
+		cmd.SilenceUsage = true
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"--config", cfgPath})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("status: %v", err)
+		}
+		for _, want := range []string{"License status: valid", "lic_status_cmd", "enterprise", "sub_status"} {
+			if !strings.Contains(buf.String(), want) {
+				t.Fatalf("output missing %q:\n%s", want, buf.String())
+			}
+		}
+	})
+
+	t.Run("json missing", func(t *testing.T) {
+		cfgPath := writeLicenseStatusConfig(t, "", pub, "")
+		cmd := licenseStatusCmd()
+		cmd.SilenceUsage = true
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"--config", cfgPath, "--json"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected missing license error")
+		}
+		var report licenseStatusReport
+		if jsonErr := json.Unmarshal(buf.Bytes(), &report); jsonErr != nil {
+			t.Fatalf("invalid JSON: %v\n%s", jsonErr, buf.String())
+		}
+		if report.Status != licenseStatusMissing {
+			t.Fatalf("status = %q, want missing", report.Status)
+		}
+	})
+}
+
+func TestLicenseStatusReportErrors(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	lic := license.License{
+		ID:        "lic_status_errors",
+		Email:     "status@example.com",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(24 * time.Hour).Unix(),
+		Features:  []string{license.FeatureAgents},
+	}
+	token, err := license.Issue(lic, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("invalid config file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bad.yaml")
+		if err := os.WriteFile(path, []byte("mode: ["), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		report, err := buildLicenseStatusReport(path, "")
+		if err == nil || report.Status != licenseStatusInvalid {
+			t.Fatalf("report=%+v err=%v, want invalid", report, err)
+		}
+	})
+
+	t.Run("invalid public key", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "pipelock.yaml")
+		cfg := "mode: balanced\nlicense_key: " + token + "\nlicense_public_key: not-hex\n"
+		if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		report, err := buildLicenseStatusReport(path, "")
+		if err == nil || report.Status != licenseStatusInvalid {
+			t.Fatalf("report=%+v err=%v, want invalid", report, err)
+		}
+	})
+
+	t.Run("missing public key", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "pipelock.yaml")
+		cfg := "mode: balanced\nlicense_key: " + token + "\n"
+		if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		report, err := buildLicenseStatusReport(path, "")
+		if err == nil || report.Status != licenseStatusInvalid || !strings.Contains(report.Reason, "no license public key") {
+			t.Fatalf("report=%+v err=%v, want missing public key", report, err)
+		}
+	})
+
+	t.Run("expired license", func(t *testing.T) {
+		expired := lic
+		expired.ID = "lic_status_expired"
+		expired.ExpiresAt = now.Add(-time.Hour).Unix()
+		expiredToken, err := license.Issue(expired, priv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfgPath := writeLicenseStatusConfig(t, expiredToken, pub, "")
+		report, err := buildLicenseStatusReport(cfgPath, "")
+		if err == nil || report.Status != "expired" {
+			t.Fatalf("report=%+v err=%v, want expired", report, err)
+		}
+	})
+
+	t.Run("invalid CRL override", func(t *testing.T) {
+		cfgPath := writeLicenseStatusConfig(t, token, pub, "")
+		crlPath := filepath.Join(t.TempDir(), "bad-crl.json")
+		if err := os.WriteFile(crlPath, []byte("{"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		report, err := buildLicenseStatusReport(cfgPath, crlPath)
+		if err == nil || report.Status != licenseStatusInvalid || !report.CRLConfigured {
+			t.Fatalf("report=%+v err=%v, want invalid CRL", report, err)
+		}
+	})
+}
+
+func TestPrintLicenseStatusVariants(t *testing.T) {
+	cmd := licenseStatusCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	printLicenseStatus(cmd, licenseStatusReport{
+		Status:         licenseStatusValid,
+		LicenseID:      "lic_print",
+		Tier:           "pro",
+		SubscriptionID: "sub_print",
+		ExpiresAt:      "2026-06-01",
+		DaysRemaining:  7,
+		WarningBand:    7,
+		Severity:       "warn",
+		CRLConfigured:  true,
+		CRLExpiresAt:   "2026-06-02",
+		CRLSHA256:      "abc123",
+	})
+	out := buf.String()
+	for _, want := range []string{"lic_print", "Warning:", "CRL SHA:"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+
+	buf.Reset()
+	printLicenseStatus(cmd, licenseStatusReport{
+		Status: licenseStatusValid,
+		Reason: "because",
+	})
+	if !strings.Contains(buf.String(), "never") || !strings.Contains(buf.String(), "because") {
+		t.Fatalf("unexpected perpetual output:\n%s", buf.String())
+	}
+}
+
 func TestLicenseKeygen(t *testing.T) {
 	dir := t.TempDir()
 

--- a/enterprise/cli/license_test.go
+++ b/enterprise/cli/license_test.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -29,6 +31,20 @@ func setTestHome(t *testing.T, dir string) {
 	t.Setenv("USERPROFILE", dir)
 }
 
+func writeLicenseStatusConfig(t *testing.T, token string, pub ed25519.PublicKey, crlPath string) string {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := "mode: balanced\nlicense_key: " + token + "\nlicense_public_key: " + hex.EncodeToString(pub) + "\n"
+	if crlPath != "" {
+		cfg += "license_crl_file: " + crlPath + "\n"
+	}
+	path := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
 func TestLicenseCmd(t *testing.T) {
 	cmd := LicenseCmd()
 	if cmd.Use != "license" {
@@ -38,10 +54,94 @@ func TestLicenseCmd(t *testing.T) {
 	for _, sub := range cmd.Commands() {
 		got[strings.Fields(sub.Use)[0]] = true
 	}
-	for _, want := range []string{"keygen", "issue", "inspect", "install"} {
+	for _, want := range []string{"keygen", "issue", "inspect", "install", "status"} {
 		if !got[want] {
 			t.Errorf("missing %q subcommand", want)
 		}
+	}
+}
+
+func TestLicenseStatusValidWithWarningBand(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lic := license.License{
+		ID:        "lic_status",
+		Email:     "status@example.com",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresAt: time.Now().Add(7 * 24 * time.Hour).Unix(),
+		Features:  []string{license.FeatureAgents},
+		Tier:      "pro",
+	}
+	token, err := license.Issue(lic, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := writeLicenseStatusConfig(t, token, pub, "")
+
+	report, err := buildLicenseStatusReport(cfgPath, "")
+	if err != nil {
+		t.Fatalf("buildLicenseStatusReport: %v", err)
+	}
+	if report.Status != licenseStatusValid {
+		t.Fatalf("status = %q, want valid; report=%+v", report.Status, report)
+	}
+	if report.WarningBand != 7 {
+		t.Errorf("WarningBand = %d, want 7", report.WarningBand)
+	}
+	if report.Severity != license.ExpirySeverityWarn {
+		t.Errorf("Severity = %q, want warn", report.Severity)
+	}
+}
+
+func TestLicenseStatusRevokedByCRL(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	lic := license.License{
+		ID:        "lic_revoked_status",
+		Email:     "status@example.com",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(24 * time.Hour).Unix(),
+		Features:  []string{license.FeatureAgents},
+	}
+	token, err := license.Issue(lic, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crl, err := license.SignCRL(license.CRLPayload{
+		Version:   license.CRLVersion,
+		IssuedAt:  now.Add(-time.Hour).Unix(),
+		ExpiresAt: now.Add(24 * time.Hour).Unix(),
+		Revoked: []license.RevokedLicense{{
+			ID:        lic.ID,
+			Reason:    "subscription_canceled",
+			RevokedAt: now.Add(-time.Hour).Unix(),
+		}},
+	}, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crlData, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	crlPath := filepath.Join(dir, "crl.json")
+	if err := os.WriteFile(crlPath, crlData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := writeLicenseStatusConfig(t, token, pub, crlPath)
+
+	report, err := buildLicenseStatusReport(cfgPath, "")
+	if err == nil {
+		t.Fatal("expected revoked license error")
+	}
+	if report.Status != "revoked" {
+		t.Fatalf("status = %q, want revoked; report=%+v", report.Status, report)
 	}
 }
 

--- a/enterprise/config.go
+++ b/enterprise/config.go
@@ -7,11 +7,13 @@ package enterprise
 import (
 	"crypto/ed25519"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"regexp"
 	"slices"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
@@ -270,11 +272,26 @@ func EnforceLicenseGate(c *config.Config) {
 		return
 	}
 
-	// Verify the license token signature and expiration.
-	lic, err := license.Verify(c.LicenseKey, pubKey)
+	crl, crlLoaded, err := loadLicenseCRL(c, pubKey)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "WARNING: license CRL validation failed: %v\n"+
+			"Multi-agent profiles disabled. Single-agent protection is active.\n", err)
+		stripNamedAgents(c)
+		return
+	}
+
+	// Verify the license token signature, expiration, and revocation status.
+	lic, err := license.VerifyWithCRL(c.LicenseKey, pubKey, crl)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "WARNING: license verification failed: %v\n"+
 			"Multi-agent profiles disabled. Single-agent protection is active.\n", err)
+		if crlLoaded && errors.Is(err, license.ErrLicenseRevoked) {
+			c.LicenseRevoked = true
+			if revoked, ok := crl.RevocationFor(lic.ID); ok {
+				c.LicenseID = lic.ID
+				c.LicenseRevocationReason = revoked.Reason
+			}
+		}
 		stripNamedAgents(c)
 		return
 	}
@@ -289,6 +306,22 @@ func EnforceLicenseGate(c *config.Config) {
 
 	// Store expiry for runtime enforcement. Zero means perpetual.
 	c.LicenseExpiresAt = lic.ExpiresAt
+	c.LicenseID = lic.ID
+	if crlLoaded {
+		c.LicenseCRLExpiresAt = crl.Payload.ExpiresAt
+		c.LicenseCRLSHA256 = crl.SHA256
+	}
+}
+
+func loadLicenseCRL(c *config.Config, pubKey ed25519.PublicKey) (*license.CRL, bool, error) {
+	if c.LicenseCRLFile == "" {
+		return nil, false, nil
+	}
+	crl, err := license.LoadAndVerifyCRL(c.LicenseCRLFile, pubKey, time.Now())
+	if err != nil {
+		return nil, true, err
+	}
+	return &crl, true, nil
 }
 
 // stripNamedAgents removes all agent profiles except _default.

--- a/enterprise/config_test.go
+++ b/enterprise/config_test.go
@@ -8,6 +8,9 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -612,6 +615,64 @@ func TestEnforceLicenseGate_ValidLicense(t *testing.T) {
 	}
 	if cfg.LicenseExpiresAt == 0 {
 		t.Error("expected non-zero LicenseExpiresAt after valid license")
+	}
+}
+
+func TestEnforceLicenseGate_RevokedLicense(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	lic := license.License{
+		ID:        "lic_revoked_gate",
+		Email:     "test@example.com",
+		Features:  []string{license.FeatureAgents},
+		ExpiresAt: now.Add(24 * time.Hour).Unix(),
+	}
+	tok, err := license.Issue(lic, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crl, err := license.SignCRL(license.CRLPayload{
+		Version:   license.CRLVersion,
+		IssuedAt:  now.Add(-time.Hour).Unix(),
+		ExpiresAt: now.Add(24 * time.Hour).Unix(),
+		Revoked: []license.RevokedLicense{{
+			ID:        lic.ID,
+			Reason:    "subscription_canceled",
+			RevokedAt: now.Add(-time.Hour).Unix(),
+		}},
+	}, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crlPath := filepath.Join(t.TempDir(), "crl.json")
+	if err := os.WriteFile(crlPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := testConfig()
+	cfg.Agents = map[string]config.AgentProfile{
+		"claude-code": {Mode: config.ModeStrict},
+	}
+	cfg.LicenseKey = tok
+	cfg.LicensePublicKey = hex.EncodeToString(pub)
+	cfg.LicenseCRLFile = crlPath
+
+	EnforceLicenseGate(cfg)
+	if cfg.Agents != nil {
+		t.Error("expected agents disabled with revoked license")
+	}
+	if !cfg.LicenseRevoked {
+		t.Error("expected LicenseRevoked=true")
+	}
+	if cfg.LicenseRevocationReason != "subscription_canceled" {
+		t.Errorf("LicenseRevocationReason = %q", cfg.LicenseRevocationReason)
 	}
 }
 

--- a/enterprise/licenseservice/audit.go
+++ b/enterprise/licenseservice/audit.go
@@ -25,6 +25,7 @@ const (
 	AuditEmailFailed     = "email_failed"
 	AuditRefreshIssued   = "refresh_issued"
 	AuditSubscriptionEnd = "subscription_ended"
+	AuditLicenseRevoked  = "license_revoked"
 	AuditFoundingCapHit  = "founding_cap_hit"
 	AuditError           = "error"
 )
@@ -154,6 +155,17 @@ func (a *AuditLedger) LogLicenseIssued(subscriptionID, email, licenseID, tier st
 		LicenseID:      licenseID,
 		Tier:           tier,
 		ExpiresAt:      expiresAt.UTC().Format(time.DateOnly),
+	})
+}
+
+// LogLicenseRevoked records a license revocation added to the CRL.
+func (a *AuditLedger) LogLicenseRevoked(subscriptionID, email, licenseID, reason string) error {
+	return a.Log(AuditEntry{
+		Event:          AuditLicenseRevoked,
+		SubscriptionID: subscriptionID,
+		CustomerEmail:  email,
+		LicenseID:      licenseID,
+		Detail:         reason,
 	})
 }
 

--- a/enterprise/licenseservice/entitlement.go
+++ b/enterprise/licenseservice/entitlement.go
@@ -190,6 +190,9 @@ func (e *EntitlementDB) migrate(ctx context.Context) error {
 // Upsert inserts or updates an entitlement record. Updates the updated_at
 // timestamp automatically.
 func (e *EntitlementDB) Upsert(ctx context.Context, ent *Entitlement) error {
+	if ent == nil {
+		return errors.New("entitlement is nil")
+	}
 	if err := upsertEntitlement(ctx, e.db, ent); err != nil {
 		return fmt.Errorf("upsert entitlement %s: %w", ent.SubscriptionID, err)
 	}
@@ -440,6 +443,9 @@ func (e *EntitlementDB) InsertLicenseIssuance(ctx context.Context, issuance Lice
 // license issuance. It refuses stale active events when the current persisted
 // subscription state is already terminal.
 func (e *EntitlementDB) UpsertWithLicenseIssuance(ctx context.Context, ent *Entitlement, issuance LicenseIssuance) error {
+	if ent == nil {
+		return errors.New("entitlement is nil")
+	}
 	tx, err := e.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin entitlement issuance transaction: %w", err)

--- a/enterprise/licenseservice/entitlement.go
+++ b/enterprise/licenseservice/entitlement.go
@@ -52,9 +52,38 @@ type Entitlement struct {
 	UpdatedAt time.Time
 }
 
+// RevokedLicenseRecord is a license ID that must be included in the signed CRL.
+type RevokedLicenseRecord struct {
+	LicenseID      string
+	SubscriptionID string
+	Reason         string
+	RevokedAt      time.Time
+}
+
+// LicenseIssuance records each minted license token so subscription shutdown
+// can revoke still-valid older refresh tokens, not just the latest one.
+type LicenseIssuance struct {
+	LicenseID      string
+	SubscriptionID string
+	ExpiresAt      time.Time
+	IssuedAt       time.Time
+}
+
 // EntitlementDB manages the SQLite entitlement store.
 type EntitlementDB struct {
 	db *sql.DB
+}
+
+// ErrTerminalEntitlement means a stale active event tried to mint a license
+// after this subscription was already recorded in a terminal state.
+var ErrTerminalEntitlement = errors.New("entitlement is terminal")
+
+type entitlementExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+type entitlementQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 // OpenEntitlementDB opens (or creates) the SQLite database at path and
@@ -133,6 +162,26 @@ func (e *EntitlementDB) migrate(ctx context.Context) error {
 	CREATE INDEX IF NOT EXISTS idx_entitlements_next_refresh ON entitlements(next_refresh_at);
 	CREATE INDEX IF NOT EXISTS idx_entitlements_founding ON entitlements(founding);
 	CREATE INDEX IF NOT EXISTS idx_entitlements_founding_reserved ON entitlements(founding_reserved_at);
+
+	CREATE TABLE IF NOT EXISTS license_revocations (
+		license_id      TEXT PRIMARY KEY,
+		subscription_id TEXT NOT NULL,
+		reason          TEXT NOT NULL,
+		revoked_at      DATETIME NOT NULL,
+		created_at      DATETIME NOT NULL DEFAULT (datetime('now'))
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_license_revocations_subscription ON license_revocations(subscription_id);
+
+	CREATE TABLE IF NOT EXISTS license_issuances (
+		license_id      TEXT PRIMARY KEY,
+		subscription_id TEXT NOT NULL,
+		expires_at      DATETIME NOT NULL,
+		issued_at       DATETIME NOT NULL,
+		created_at      DATETIME NOT NULL DEFAULT (datetime('now'))
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_license_issuances_subscription ON license_issuances(subscription_id);
 	`
 	_, err := e.db.ExecContext(ctx, ddl)
 	return err
@@ -141,6 +190,13 @@ func (e *EntitlementDB) migrate(ctx context.Context) error {
 // Upsert inserts or updates an entitlement record. Updates the updated_at
 // timestamp automatically.
 func (e *EntitlementDB) Upsert(ctx context.Context, ent *Entitlement) error {
+	if err := upsertEntitlement(ctx, e.db, ent); err != nil {
+		return fmt.Errorf("upsert entitlement %s: %w", ent.SubscriptionID, err)
+	}
+	return nil
+}
+
+func upsertEntitlement(ctx context.Context, exec entitlementExecer, ent *Entitlement) error {
 	const query = `
 	INSERT INTO entitlements (
 		subscription_id, customer_email, product_id, tier, billing_interval,
@@ -183,7 +239,7 @@ func (e *EntitlementDB) Upsert(ctx context.Context, ent *Entitlement) error {
 	`
 
 	//nolint:gosec // G701 false positive: query is a const with parameterized placeholders, not concatenated
-	_, err := e.db.ExecContext(ctx, query,
+	_, err := exec.ExecContext(ctx, query,
 		ent.SubscriptionID, ent.CustomerEmail, ent.ProductID, ent.Tier, ent.BillingInterval,
 		ent.Status, ent.CurrentPeriodEnd, ent.Founding, ent.FoundingReservedAt, ent.Org,
 		ent.Features,
@@ -192,10 +248,7 @@ func (e *EntitlementDB) Upsert(ctx context.Context, ent *Entitlement) error {
 		ent.LastLicenseProductID, ent.LastDeliveryStatus, ent.LastDeliveryAttemptAt,
 		ent.NextRefreshAt,
 	)
-	if err != nil {
-		return fmt.Errorf("upsert entitlement %s: %w", ent.SubscriptionID, err)
-	}
-	return nil
+	return err
 }
 
 // GetBySubscriptionID retrieves a single entitlement by its Polar subscription ID.
@@ -318,4 +371,171 @@ func (e *EntitlementDB) UpdateNextRefresh(ctx context.Context, subID string, nex
 		return fmt.Errorf("update next refresh %s: %w", subID, err)
 	}
 	return nil
+}
+
+// UpsertLicenseRevocation records a revoked license ID for CRL publication.
+func (e *EntitlementDB) UpsertLicenseRevocation(ctx context.Context, rec RevokedLicenseRecord) error {
+	if rec.LicenseID == "" {
+		return errors.New("license_id is required")
+	}
+	if rec.SubscriptionID == "" {
+		return errors.New("subscription_id is required")
+	}
+	if rec.Reason == "" {
+		rec.Reason = "subscription_ended"
+	}
+	if rec.RevokedAt.IsZero() {
+		rec.RevokedAt = time.Now().UTC()
+	}
+	const query = `
+	INSERT INTO license_revocations (license_id, subscription_id, reason, revoked_at)
+	VALUES (?, ?, ?, ?)
+	ON CONFLICT(license_id) DO UPDATE SET
+		subscription_id = excluded.subscription_id,
+		reason = excluded.reason,
+		revoked_at = excluded.revoked_at
+	`
+	_, err := e.db.ExecContext(ctx, query, rec.LicenseID, rec.SubscriptionID, rec.Reason, rec.RevokedAt)
+	if err != nil {
+		return fmt.Errorf("upsert license revocation %s: %w", rec.LicenseID, err)
+	}
+	return nil
+}
+
+// ListLicenseRevocations returns all currently published license revocations.
+func (e *EntitlementDB) ListLicenseRevocations(ctx context.Context) ([]RevokedLicenseRecord, error) {
+	const query = `
+	SELECT r.license_id, r.subscription_id, r.reason, r.revoked_at
+	FROM license_revocations AS r
+	LEFT JOIN license_issuances i ON i.license_id = r.license_id
+	WHERE i.expires_at IS NULL OR i.expires_at > ?
+	ORDER BY r.license_id ASC
+	`
+	rows, err := e.db.QueryContext(ctx, query, time.Now().UTC())
+	if err != nil {
+		return nil, fmt.Errorf("list license revocations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []RevokedLicenseRecord
+	for rows.Next() {
+		var rec RevokedLicenseRecord
+		if err := rows.Scan(&rec.LicenseID, &rec.SubscriptionID, &rec.Reason, &rec.RevokedAt); err != nil {
+			return nil, fmt.Errorf("scan license revocation: %w", err)
+		}
+		results = append(results, rec)
+	}
+	return results, rows.Err()
+}
+
+// InsertLicenseIssuance records a minted license token for later revocation.
+func (e *EntitlementDB) InsertLicenseIssuance(ctx context.Context, issuance LicenseIssuance) error {
+	if err := insertLicenseIssuance(ctx, e.db, issuance); err != nil {
+		return fmt.Errorf("insert license issuance %s: %w", issuance.LicenseID, err)
+	}
+	return nil
+}
+
+// UpsertWithLicenseIssuance atomically records entitlement state and the
+// license issuance. It refuses stale active events when the current persisted
+// subscription state is already terminal.
+func (e *EntitlementDB) UpsertWithLicenseIssuance(ctx context.Context, ent *Entitlement, issuance LicenseIssuance) error {
+	tx, err := e.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin entitlement issuance transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	terminal, status, err := currentEntitlementTerminal(ctx, tx, ent.SubscriptionID)
+	if err != nil {
+		return err
+	}
+	if terminal {
+		return fmt.Errorf("%w: subscription %s status %s", ErrTerminalEntitlement, ent.SubscriptionID, status)
+	}
+	if err := upsertEntitlement(ctx, tx, ent); err != nil {
+		return fmt.Errorf("upsert entitlement %s: %w", ent.SubscriptionID, err)
+	}
+	if err := insertLicenseIssuance(ctx, tx, issuance); err != nil {
+		return fmt.Errorf("insert license issuance %s: %w", issuance.LicenseID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit entitlement issuance transaction: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func insertLicenseIssuance(ctx context.Context, exec entitlementExecer, issuance LicenseIssuance) error {
+	if issuance.LicenseID == "" {
+		return errors.New("license_id is required")
+	}
+	if issuance.SubscriptionID == "" {
+		return errors.New("subscription_id is required")
+	}
+	if issuance.ExpiresAt.IsZero() {
+		return errors.New("expires_at is required")
+	}
+	if issuance.IssuedAt.IsZero() {
+		issuance.IssuedAt = time.Now().UTC()
+	}
+	const query = `
+	INSERT INTO license_issuances (license_id, subscription_id, expires_at, issued_at)
+	VALUES (?, ?, ?, ?)
+	ON CONFLICT(license_id) DO NOTHING
+	`
+	_, err := exec.ExecContext(ctx, query, issuance.LicenseID, issuance.SubscriptionID, issuance.ExpiresAt, issuance.IssuedAt)
+	return err
+}
+
+// ListUnexpiredLicenseIssuances returns every still-valid license minted for a subscription.
+func (e *EntitlementDB) ListUnexpiredLicenseIssuances(ctx context.Context, subID string, now time.Time) ([]LicenseIssuance, error) {
+	const query = `
+	SELECT license_id, subscription_id, expires_at, issued_at
+	FROM license_issuances
+	WHERE subscription_id = ?
+	  AND expires_at > ?
+	ORDER BY issued_at ASC, license_id ASC
+	`
+	rows, err := e.db.QueryContext(ctx, query, subID, now.UTC())
+	if err != nil {
+		return nil, fmt.Errorf("list license issuances %s: %w", subID, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []LicenseIssuance
+	for rows.Next() {
+		var issuance LicenseIssuance
+		if err := rows.Scan(&issuance.LicenseID, &issuance.SubscriptionID, &issuance.ExpiresAt, &issuance.IssuedAt); err != nil {
+			return nil, fmt.Errorf("scan license issuance: %w", err)
+		}
+		results = append(results, issuance)
+	}
+	return results, rows.Err()
+}
+
+func currentEntitlementTerminal(ctx context.Context, q entitlementQueryer, subID string) (bool, string, error) {
+	var status string
+	err := q.QueryRowContext(ctx, "SELECT status FROM entitlements WHERE subscription_id = ?", subID).Scan(&status)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, "", nil
+	}
+	if err != nil {
+		return false, "", fmt.Errorf("read current entitlement status %s: %w", subID, err)
+	}
+	return isTerminalEntitlementStatus(status), status, nil
+}
+
+func isTerminalEntitlementStatus(status string) bool {
+	switch status {
+	case statusCanceled, statusRevoked, statusUnpaid:
+		return true
+	default:
+		return false
+	}
 }

--- a/enterprise/licenseservice/entitlement_test.go
+++ b/enterprise/licenseservice/entitlement_test.go
@@ -6,6 +6,7 @@ package licenseservice
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -81,6 +82,114 @@ func TestEntitlementDB_UpsertAndGet(t *testing.T) {
 	}
 	if got.CustomerEmail != "updated@example.com" {
 		t.Errorf("CustomerEmail after update = %q, want %q", got.CustomerEmail, "updated@example.com")
+	}
+}
+
+func TestEntitlementDB_LicenseRevocationAndIssuanceValidation(t *testing.T) {
+	db := openTestDB(t)
+	ctx := t.Context()
+	now := time.Now().UTC()
+
+	if err := db.Upsert(ctx, nil); err == nil {
+		t.Fatal("Upsert nil should error")
+	}
+	if err := db.UpsertWithLicenseIssuance(ctx, nil, LicenseIssuance{}); err == nil {
+		t.Fatal("UpsertWithLicenseIssuance nil entitlement should error")
+	}
+
+	for _, rec := range []RevokedLicenseRecord{
+		{SubscriptionID: testSubscriptionID},
+		{LicenseID: "lic_missing_sub"},
+	} {
+		if err := db.UpsertLicenseRevocation(ctx, rec); err == nil {
+			t.Fatalf("UpsertLicenseRevocation(%+v) should error", rec)
+		}
+	}
+
+	if err := db.UpsertLicenseRevocation(ctx, RevokedLicenseRecord{
+		LicenseID:      "lic_default_reason",
+		SubscriptionID: testSubscriptionID,
+	}); err != nil {
+		t.Fatalf("UpsertLicenseRevocation default fields: %v", err)
+	}
+	revoked, err := db.ListLicenseRevocations(ctx)
+	if err != nil {
+		t.Fatalf("ListLicenseRevocations: %v", err)
+	}
+	if len(revoked) != 1 || revoked[0].Reason != "subscription_ended" || revoked[0].RevokedAt.IsZero() {
+		t.Fatalf("revocations = %+v, want default reason and timestamp", revoked)
+	}
+
+	for _, issuance := range []LicenseIssuance{
+		{SubscriptionID: testSubscriptionID, ExpiresAt: now.Add(time.Hour)},
+		{LicenseID: "lic_missing_sub", ExpiresAt: now.Add(time.Hour)},
+		{LicenseID: "lic_missing_expiry", SubscriptionID: testSubscriptionID},
+	} {
+		if err := db.InsertLicenseIssuance(ctx, issuance); err == nil {
+			t.Fatalf("InsertLicenseIssuance(%+v) should error", issuance)
+		}
+	}
+
+	if err := db.InsertLicenseIssuance(ctx, LicenseIssuance{
+		LicenseID:      "lic_valid_issuance",
+		SubscriptionID: testSubscriptionID,
+		ExpiresAt:      now.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("InsertLicenseIssuance valid: %v", err)
+	}
+	issuances, err := db.ListUnexpiredLicenseIssuances(ctx, testSubscriptionID, now)
+	if err != nil {
+		t.Fatalf("ListUnexpiredLicenseIssuances: %v", err)
+	}
+	if len(issuances) != 1 || issuances[0].IssuedAt.IsZero() {
+		t.Fatalf("issuances = %+v, want default issued_at", issuances)
+	}
+}
+
+func TestEntitlementDB_UpsertWithLicenseIssuance(t *testing.T) {
+	db := openTestDB(t)
+	ctx := t.Context()
+	now := time.Now().UTC()
+
+	ent := testEntitlement("sub_atomic")
+	issuance := LicenseIssuance{
+		LicenseID:      "lic_atomic",
+		SubscriptionID: ent.SubscriptionID,
+		ExpiresAt:      now.Add(24 * time.Hour),
+		IssuedAt:       now,
+	}
+	if err := db.UpsertWithLicenseIssuance(ctx, ent, issuance); err != nil {
+		t.Fatalf("UpsertWithLicenseIssuance: %v", err)
+	}
+	got, err := db.GetBySubscriptionID(ctx, ent.SubscriptionID)
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID: %v", err)
+	}
+	if got == nil || got.SubscriptionID != ent.SubscriptionID {
+		t.Fatalf("entitlement = %+v, want %s", got, ent.SubscriptionID)
+	}
+	issuances, err := db.ListUnexpiredLicenseIssuances(ctx, ent.SubscriptionID, now.Add(-time.Second))
+	if err != nil {
+		t.Fatalf("ListUnexpiredLicenseIssuances: %v", err)
+	}
+	if len(issuances) != 1 || issuances[0].LicenseID != issuance.LicenseID {
+		t.Fatalf("issuances = %+v, want %s", issuances, issuance.LicenseID)
+	}
+
+	terminal := testEntitlement("sub_terminal")
+	terminal.Status = statusCanceled
+	if err := db.Upsert(ctx, terminal); err != nil {
+		t.Fatalf("Upsert terminal: %v", err)
+	}
+	terminal.Status = statusActive
+	err = db.UpsertWithLicenseIssuance(ctx, terminal, LicenseIssuance{
+		LicenseID:      "lic_terminal",
+		SubscriptionID: terminal.SubscriptionID,
+		ExpiresAt:      now.Add(24 * time.Hour),
+		IssuedAt:       now,
+	})
+	if !errors.Is(err, ErrTerminalEntitlement) {
+		t.Fatalf("err = %v, want ErrTerminalEntitlement", err)
 	}
 }
 

--- a/enterprise/licenseservice/server.go
+++ b/enterprise/licenseservice/server.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -64,7 +65,7 @@ func NewServer(
 	}
 
 	s.mux.HandleFunc("POST /webhook/polar", s.handleWebhook)
-	s.mux.HandleFunc("GET /crl.json", s.handleCRL)
+	s.mux.HandleFunc(http.MethodGet+" /crl.json", s.handleCRL)
 	s.mux.HandleFunc("GET /health", s.handleHealth)
 
 	s.srv = &http.Server{
@@ -186,7 +187,7 @@ func (s *Server) handleCRL(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "public, max-age=60")
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("ETag", etag)
-	if r.Header.Get("If-None-Match") == etag {
+	if ifNoneMatch(r.Header.Get("If-None-Match"), etag) {
 		w.WriteHeader(http.StatusNotModified)
 		return
 	}
@@ -217,6 +218,27 @@ func (s *Server) cachedCRL(ctx context.Context, now time.Time) ([]byte, string, 
 	s.crlCacheETag = `"` + hex.EncodeToString(sum[:]) + `"`
 	s.crlCacheUntil = now.Add(crlCacheTTL)
 	return s.crlCache, s.crlCacheETag, nil
+}
+
+func ifNoneMatch(header, etag string) bool {
+	if header == "" || etag == "" {
+		return false
+	}
+	normalizedETag := normalizeETag(etag)
+	for candidate := range strings.SplitSeq(header, ",") {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "*" || normalizeETag(candidate) == normalizedETag {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeETag(etag string) string {
+	etag = strings.TrimSpace(etag)
+	etag = strings.TrimPrefix(etag, "W/")
+	etag = strings.Trim(etag, `"`)
+	return etag
 }
 
 // handleHealth returns 200 if the service is running.

--- a/enterprise/licenseservice/server.go
+++ b/enterprise/licenseservice/server.go
@@ -18,9 +18,13 @@ package licenseservice
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -35,7 +39,14 @@ type Server struct {
 	log     zerolog.Logger
 	mux     *http.ServeMux
 	srv     *http.Server
+
+	crlMu         sync.Mutex
+	crlCache      []byte
+	crlCacheETag  string
+	crlCacheUntil time.Time
 }
+
+const crlCacheTTL = time.Minute
 
 // NewServer creates a license service server with all dependencies wired.
 func NewServer(
@@ -53,6 +64,7 @@ func NewServer(
 	}
 
 	s.mux.HandleFunc("POST /webhook/polar", s.handleWebhook)
+	s.mux.HandleFunc("GET /crl.json", s.handleCRL)
 	s.mux.HandleFunc("GET /health", s.handleHealth)
 
 	s.srv = &http.Server{
@@ -161,6 +173,50 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, _ = fmt.Fprintf(w, `{"status":"ok"}`)
+}
+
+// handleCRL returns the current signed license revocation list.
+func (s *Server) handleCRL(w http.ResponseWriter, r *http.Request) {
+	body, etag, err := s.cachedCRL(r.Context(), time.Now())
+	if err != nil {
+		s.log.Error().Err(err).Msg("build license CRL")
+		http.Error(w, "failed to build CRL", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Cache-Control", "public, max-age=60")
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("ETag", etag)
+	if r.Header.Get("If-None-Match") == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		s.log.Error().Err(err).Msg("write license CRL")
+	}
+}
+
+func (s *Server) cachedCRL(ctx context.Context, now time.Time) ([]byte, string, error) {
+	s.crlMu.Lock()
+	defer s.crlMu.Unlock()
+
+	if len(s.crlCache) > 0 && now.Before(s.crlCacheUntil) {
+		return s.crlCache, s.crlCacheETag, nil
+	}
+	crl, err := s.handler.SignedCRL(ctx, now)
+	if err != nil {
+		return nil, "", err
+	}
+	body, err := json.Marshal(crl)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal license CRL: %w", err)
+	}
+	body = append(body, '\n')
+	sum := sha256.Sum256(body)
+	s.crlCache = body
+	s.crlCacheETag = `"` + hex.EncodeToString(sum[:]) + `"`
+	s.crlCacheUntil = now.Add(crlCacheTTL)
+	return s.crlCache, s.crlCacheETag, nil
 }
 
 // handleHealth returns 200 if the service is running.

--- a/enterprise/licenseservice/server_test.go
+++ b/enterprise/licenseservice/server_test.go
@@ -144,7 +144,7 @@ func TestServer_CRLEndpoint(t *testing.T) {
 		t.Fatalf("UpsertLicenseRevocation: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/crl.json", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/crl.json", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
 
@@ -166,12 +166,43 @@ func TestServer_CRLEndpoint(t *testing.T) {
 		t.Fatalf("Cache-Control = %q, want max-age=60", cacheControl)
 	}
 
-	req = httptest.NewRequest(http.MethodGet, "/crl.json", nil)
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/crl.json", nil)
 	req.Header.Set("If-None-Match", etag)
 	w = httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusNotModified {
 		t.Fatalf("conditional status = %d, want 304", w.Code)
+	}
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/crl.json", nil)
+	req.Header.Set("If-None-Match", `W/`+etag+`, "other"`)
+	w = httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusNotModified {
+		t.Fatalf("weak conditional status = %d, want 304", w.Code)
+	}
+}
+
+func TestIfNoneMatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		etag   string
+		want   bool
+	}{
+		{name: "empty", header: "", etag: `"abc"`, want: false},
+		{name: "exact", header: `"abc"`, etag: `"abc"`, want: true},
+		{name: "weak", header: `W/"abc"`, etag: `"abc"`, want: true},
+		{name: "list", header: `"other", W/"abc"`, etag: `"abc"`, want: true},
+		{name: "wildcard", header: "*", etag: `"abc"`, want: true},
+		{name: "miss", header: `"other"`, etag: `"abc"`, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ifNoneMatch(tt.header, tt.etag); got != tt.want {
+				t.Fatalf("ifNoneMatch(%q, %q) = %v, want %v", tt.header, tt.etag, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/enterprise/licenseservice/server_test.go
+++ b/enterprise/licenseservice/server_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -20,6 +21,8 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
 )
 
 const (
@@ -126,6 +129,49 @@ func TestServer_HealthEndpoint(t *testing.T) {
 	ct := w.Header().Get("Content-Type")
 	if ct != testContentTypeJSON {
 		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+}
+
+func TestServer_CRLEndpoint(t *testing.T) {
+	srv := newTestServer(t)
+	now := time.Now().UTC()
+	if err := srv.handler.db.UpsertLicenseRevocation(t.Context(), RevokedLicenseRecord{
+		LicenseID:      "lic_crl_endpoint",
+		SubscriptionID: testSubscriptionID,
+		Reason:         "subscription_canceled",
+		RevokedAt:      now,
+	}); err != nil {
+		t.Fatalf("UpsertLicenseRevocation: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/crl.json", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var crl license.CRL
+	if err := json.Unmarshal(w.Body.Bytes(), &crl); err != nil {
+		t.Fatalf("decode CRL: %v", err)
+	}
+	if _, ok := crl.RevocationFor("lic_crl_endpoint"); !ok {
+		t.Fatalf("CRL missing revocation: %+v", crl.Payload.Revoked)
+	}
+	etag := w.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("expected ETag header")
+	}
+	if cacheControl := w.Header().Get("Cache-Control"); !strings.Contains(cacheControl, "max-age=60") {
+		t.Fatalf("Cache-Control = %q, want max-age=60", cacheControl)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/crl.json", nil)
+	req.Header.Set("If-None-Match", etag)
+	w = httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusNotModified {
+		t.Fatalf("conditional status = %d, want 304", w.Code)
 	}
 }
 

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -35,8 +36,13 @@ const refreshLeadDays = 15
 // billingIntervalOneTime identifies one-time purchases (trials).
 const billingIntervalOneTime = "one_time"
 
-// statusActive is the active subscription/entitlement status.
-const statusActive = "active"
+// Subscription/entitlement status values used by Polar.
+const (
+	statusActive   = "active"
+	statusCanceled = "canceled"
+	statusRevoked  = "revoked"
+	statusUnpaid   = "unpaid"
+)
 
 // Tier constants for Pipelock subscription levels.
 const (
@@ -174,7 +180,7 @@ func (h *WebhookHandler) processSubscription(ctx context.Context, sub *PolarSubs
 	switch sub.Status {
 	case statusActive:
 		return h.handleActive(ctx, ent, existing)
-	case "canceled", "revoked", "unpaid":
+	case statusCanceled, statusRevoked, statusUnpaid:
 		return h.handleEnded(ctx, ent, existing)
 	default:
 		h.log.Warn().
@@ -202,6 +208,16 @@ func (h *WebhookHandler) processSubscription(ctx context.Context, sub *PolarSubs
 // handleActive processes an active subscription: checks idempotency,
 // mints a license if needed, persists state, then attempts email delivery.
 func (h *WebhookHandler) handleActive(ctx context.Context, ent *Entitlement, existing *Entitlement) error {
+	if existing != nil && isTerminalEntitlementStatus(existing.Status) {
+		err := fmt.Errorf("%w: subscription %s status %s", ErrTerminalEntitlement, ent.SubscriptionID, existing.Status)
+		h.log.Warn().
+			Err(err).
+			Str("subscription_id", ent.SubscriptionID).
+			Msg("stale active subscription state ignored after terminal entitlement")
+		_ = h.ledger.LogError(ent.SubscriptionID, "ignore stale active subscription after terminal entitlement", err)
+		return nil
+	}
+
 	// Idempotency check: compare the full set of fields that affect the
 	// signed token (period, tier, interval, product, email, org). Also
 	// skip the fast path if delivery never succeeded (retry), or if the
@@ -262,8 +278,6 @@ func (h *WebhookHandler) handleActive(ctx context.Context, ent *Entitlement, exi
 		return fmt.Errorf("issue license token: %w", err)
 	}
 
-	_ = h.ledger.LogLicenseIssued(ent.SubscriptionID, ent.CustomerEmail, lic.ID, ent.Tier, expiresAt)
-
 	// Update entitlement with license state.
 	ent.LastLicenseID = lic.ID
 	issuedAt := now
@@ -288,9 +302,24 @@ func (h *WebhookHandler) handleActive(ctx context.Context, ent *Entitlement, exi
 	deliveryAttempt := now
 	ent.LastDeliveryAttemptAt = &deliveryAttempt
 
-	if err := h.db.Upsert(ctx, ent); err != nil {
-		return fmt.Errorf("persist entitlement: %w", err)
+	if err := h.db.UpsertWithLicenseIssuance(ctx, ent, LicenseIssuance{
+		LicenseID:      lic.ID,
+		SubscriptionID: ent.SubscriptionID,
+		ExpiresAt:      expiresAt,
+		IssuedAt:       now,
+	}); err != nil {
+		if errors.Is(err, ErrTerminalEntitlement) {
+			h.log.Warn().
+				Err(err).
+				Str("subscription_id", ent.SubscriptionID).
+				Msg("stale active subscription state ignored after terminal entitlement")
+			_ = h.ledger.LogError(ent.SubscriptionID, "ignore stale active subscription after terminal entitlement", err)
+			return nil
+		}
+		_ = h.ledger.LogError(ent.SubscriptionID, "persist entitlement and license issuance", err)
+		return fmt.Errorf("persist entitlement and license issuance: %w", err)
 	}
+	_ = h.ledger.LogLicenseIssued(ent.SubscriptionID, ent.CustomerEmail, lic.ID, ent.Tier, expiresAt)
 
 	// Attempt email delivery, update delivery status after.
 	msgID, emailErr := h.email.SendLicenseDelivery(ctx, ent.CustomerEmail, token, ent.Tier)
@@ -343,6 +372,13 @@ func (h *WebhookHandler) handleEnded(ctx context.Context, ent *Entitlement, exis
 		return fmt.Errorf("persist ended entitlement: %w", err)
 	}
 
+	if existing != nil {
+		reason := "subscription_" + ent.Status
+		if err := h.revokeSubscriptionLicenses(ctx, ent, existing, reason); err != nil {
+			return err
+		}
+	}
+
 	// Send cancellation email if we have a last-issued license.
 	if existing != nil && existing.LastLicenseExpiresAt != nil {
 		_, emailErr := h.email.SendSubscriptionEnded(ctx, ent.CustomerEmail, *existing.LastLicenseExpiresAt)
@@ -368,6 +404,65 @@ func (h *WebhookHandler) handleEnded(ctx context.Context, ent *Entitlement, exis
 		Msg("subscription ended")
 
 	return nil
+}
+
+func (h *WebhookHandler) revokeSubscriptionLicenses(ctx context.Context, ent, existing *Entitlement, reason string) error {
+	now := time.Now().UTC()
+	issuances, err := h.db.ListUnexpiredLicenseIssuances(ctx, ent.SubscriptionID, now)
+	if err != nil {
+		_ = h.ledger.LogError(ent.SubscriptionID, "list license issuances for revocation", err)
+		return fmt.Errorf("list license issuances for revocation: %w", err)
+	}
+	if existing.LastLicenseID != "" {
+		found := false
+		for _, issuance := range issuances {
+			if issuance.LicenseID == existing.LastLicenseID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			issuances = append(issuances, LicenseIssuance{
+				LicenseID:      existing.LastLicenseID,
+				SubscriptionID: ent.SubscriptionID,
+				IssuedAt:       now,
+			})
+		}
+	}
+	for _, issuance := range issuances {
+		if err := h.db.UpsertLicenseRevocation(ctx, RevokedLicenseRecord{
+			LicenseID:      issuance.LicenseID,
+			SubscriptionID: ent.SubscriptionID,
+			Reason:         reason,
+			RevokedAt:      now,
+		}); err != nil {
+			_ = h.ledger.LogError(ent.SubscriptionID, "record license revocation", err)
+			return fmt.Errorf("record license revocation: %w", err)
+		}
+		_ = h.ledger.LogLicenseRevoked(ent.SubscriptionID, ent.CustomerEmail, issuance.LicenseID, reason)
+	}
+	return nil
+}
+
+// SignedCRL returns the current signed license revocation list.
+func (h *WebhookHandler) SignedCRL(ctx context.Context, now time.Time) (license.CRL, error) {
+	records, err := h.db.ListLicenseRevocations(ctx)
+	if err != nil {
+		return license.CRL{}, err
+	}
+	revoked := make([]license.RevokedLicense, 0, len(records))
+	for _, rec := range records {
+		revoked = append(revoked, license.RevokedLicense{
+			ID:        rec.LicenseID,
+			RevokedAt: rec.RevokedAt.UTC().Unix(),
+		})
+	}
+	return license.SignCRL(license.CRLPayload{
+		Version:   license.CRLVersion,
+		IssuedAt:  now.UTC().Unix(),
+		ExpiresAt: now.UTC().Add(7 * 24 * time.Hour).Unix(),
+		Revoked:   revoked,
+	}, h.privateKey)
 }
 
 // HandleOrderEvent processes a Polar order.created webhook event for

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -448,7 +448,7 @@ func (h *WebhookHandler) revokeSubscriptionLicenses(ctx context.Context, ent, ex
 func (h *WebhookHandler) SignedCRL(ctx context.Context, now time.Time) (license.CRL, error) {
 	records, err := h.db.ListLicenseRevocations(ctx)
 	if err != nil {
-		return license.CRL{}, err
+		return license.CRL{}, fmt.Errorf("list license revocations: %w", err)
 	}
 	revoked := make([]license.RevokedLicense, 0, len(records))
 	for _, rec := range records {

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const testLicenseExisting = "lic_existing"
+
 // testSetup creates a fully wired test environment with in-memory DB,
 // temp ledger, mock Polar server, and mock email server.
 type testSetup struct {
@@ -559,7 +561,7 @@ func TestProcessSubscription_CanceledClearsRefresh(t *testing.T) {
 
 	sub := &PolarSubscription{
 		ID:                testSubscriptionID,
-		Status:            "canceled",
+		Status:            statusCanceled,
 		RecurringInterval: testIntervalMonth,
 		CurrentPeriodEnd:  time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
 	}
@@ -604,7 +606,7 @@ func TestProcessSubscription_IdempotentSkipsReissue(t *testing.T) {
 	now := time.Now().UTC()
 	existing := testEntitlement(testSubscriptionID)
 	existing.Org = "testcorp"
-	existing.LastLicenseID = "lic_existing"
+	existing.LastLicenseID = testLicenseExisting
 	existing.LastLicenseIssuedAt = &now
 	existing.LastLicensePeriodEnd = &periodEnd
 	existing.LastLicenseTier = tierPro
@@ -636,8 +638,8 @@ func TestProcessSubscription_IdempotentSkipsReissue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetBySubscriptionID: %v", err)
 	}
-	if ent.LastLicenseID != "lic_existing" {
-		t.Errorf("LastLicenseID = %q, want %q (should be preserved)", ent.LastLicenseID, "lic_existing")
+	if ent.LastLicenseID != testLicenseExisting {
+		t.Errorf("LastLicenseID = %q, want %q (should be preserved)", ent.LastLicenseID, testLicenseExisting)
 	}
 }
 
@@ -1107,7 +1109,7 @@ func TestProcessSubscription_RevokedClearsRefresh(t *testing.T) {
 
 	sub := &PolarSubscription{
 		ID:                testSubscriptionID,
-		Status:            "revoked",
+		Status:            statusRevoked,
 		RecurringInterval: testIntervalMonth,
 		CurrentPeriodEnd:  time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
 	}
@@ -1133,11 +1135,121 @@ func TestProcessSubscription_RevokedClearsRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetBySubscriptionID: %v", err)
 	}
-	if ent.Status != "revoked" {
-		t.Errorf("Status = %q, want %q", ent.Status, "revoked")
+	if ent.Status != statusRevoked {
+		t.Errorf("Status = %q, want %q", ent.Status, statusRevoked)
 	}
 	if ent.NextRefreshAt != nil {
 		t.Error("NextRefreshAt should be nil after revocation")
+	}
+}
+
+func TestProcessSubscription_RevokesAllUnexpiredIssuedLicenses(t *testing.T) {
+	ts := newTestSetup(t)
+	ctx := t.Context()
+
+	now := time.Now().UTC()
+	expires := now.Add(45 * 24 * time.Hour)
+	existing := testEntitlement(testSubscriptionID)
+	existing.LastLicenseID = "lic_latest"
+	existing.LastLicenseIssuedAt = &now
+	existing.LastLicenseExpiresAt = &expires
+	if err := ts.db.Upsert(ctx, existing); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	for _, id := range []string{"lic_prior", "lic_latest"} {
+		if err := ts.db.InsertLicenseIssuance(ctx, LicenseIssuance{
+			LicenseID:      id,
+			SubscriptionID: testSubscriptionID,
+			ExpiresAt:      expires,
+			IssuedAt:       now.Add(-time.Hour),
+		}); err != nil {
+			t.Fatalf("InsertLicenseIssuance %s: %v", id, err)
+		}
+	}
+
+	sub := &PolarSubscription{
+		ID:                testSubscriptionID,
+		Status:            statusRevoked,
+		RecurringInterval: testIntervalMonth,
+		CurrentPeriodEnd:  time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
+	}
+	sub.Customer.Email = testCustomerEmail
+	sub.Customer.Metadata = map[string]string{}
+	sub.Product.ID = testProductID
+	sub.Product.Name = testProductName
+	sub.Product.Metadata = map[string]string{"pipelock_tier": "pro"}
+
+	if err := ts.handler.processSubscription(ctx, sub); err != nil {
+		t.Fatalf("processSubscription revoked: %v", err)
+	}
+	records, err := ts.db.ListLicenseRevocations(ctx)
+	if err != nil {
+		t.Fatalf("ListLicenseRevocations: %v", err)
+	}
+	got := make(map[string]bool, len(records))
+	for _, rec := range records {
+		got[rec.LicenseID] = true
+	}
+	for _, want := range []string{"lic_prior", "lic_latest"} {
+		if !got[want] {
+			t.Fatalf("missing revocation for %s; records=%+v", want, records)
+		}
+	}
+	crl, err := ts.handler.SignedCRL(ctx, now)
+	if err != nil {
+		t.Fatalf("SignedCRL: %v", err)
+	}
+	for _, revoked := range crl.Payload.Revoked {
+		if revoked.Reason != "" {
+			t.Fatalf("public CRL should omit reason, got %+v", revoked)
+		}
+	}
+}
+
+func TestProcessSubscription_StaleActiveAfterTerminalDoesNotIssue(t *testing.T) {
+	ts := newTestSetup(t)
+	ctx := t.Context()
+
+	existing := testEntitlement(testSubscriptionID)
+	existing.Status = statusCanceled
+	existing.LastLicenseID = testLicenseExisting
+	existing.LastLicensePeriodEnd = &existing.CurrentPeriodEnd
+	existing.LastLicenseTier = existing.Tier
+	existing.LastLicenseInterval = existing.BillingInterval
+	existing.LastLicenseProductID = existing.ProductID
+	existing.LastDeliveryStatus = testDeliveryStatusSent
+	if err := ts.db.Upsert(ctx, existing); err != nil {
+		t.Fatalf("Upsert terminal entitlement: %v", err)
+	}
+
+	sub := &PolarSubscription{
+		ID:                testSubscriptionID,
+		Status:            statusActive,
+		RecurringInterval: testIntervalMonth,
+		CurrentPeriodEnd:  time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
+	}
+	sub.Customer.Email = testCustomerEmail
+	sub.Customer.Metadata = map[string]string{}
+	sub.Product.ID = testProductID
+	sub.Product.Name = testProductName
+	sub.Product.Metadata = map[string]string{"pipelock_tier": "pro"}
+
+	if err := ts.handler.processSubscription(ctx, sub); err != nil {
+		t.Fatalf("processSubscription stale active: %v", err)
+	}
+	issuances, err := ts.db.ListUnexpiredLicenseIssuances(ctx, testSubscriptionID, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("ListUnexpiredLicenseIssuances: %v", err)
+	}
+	if len(issuances) != 0 {
+		t.Fatalf("stale active event minted issuance: %+v", issuances)
+	}
+	ent, err := ts.db.GetBySubscriptionID(ctx, testSubscriptionID)
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID: %v", err)
+	}
+	if ent.Status != statusCanceled {
+		t.Fatalf("status changed to %q, want canceled", ent.Status)
 	}
 }
 
@@ -1195,7 +1307,7 @@ func TestProcessSubscription_HandleEndedNoExistingLicense(t *testing.T) {
 	// Canceled subscription with NO prior entitlement (no license to expire).
 	sub := &PolarSubscription{
 		ID:                "sub_cancel_fresh",
-		Status:            "canceled",
+		Status:            statusCanceled,
 		RecurringInterval: testIntervalMonth,
 		CurrentPeriodEnd:  time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
 	}
@@ -1257,7 +1369,7 @@ func TestProcessSubscription_EndedEmailFailure(t *testing.T) {
 
 	sub := &PolarSubscription{
 		ID:                testSubscriptionID,
-		Status:            "canceled",
+		Status:            statusCanceled,
 		RecurringInterval: testIntervalMonth,
 		CurrentPeriodEnd:  time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
 	}
@@ -1313,7 +1425,7 @@ func TestProcessSubscription_EndedPreservesLicenseFields(t *testing.T) {
 
 	sub := &PolarSubscription{
 		ID:                testSubscriptionID,
-		Status:            "canceled",
+		Status:            statusCanceled,
 		RecurringInterval: testIntervalMonth,
 		CurrentPeriodEnd:  periodEnd,
 	}
@@ -1459,7 +1571,7 @@ func TestProcessSubscription_UnpaidStatus(t *testing.T) {
 
 	sub := &PolarSubscription{
 		ID:                "sub_unpaid",
-		Status:            "unpaid",
+		Status:            statusUnpaid,
 		RecurringInterval: testIntervalMonth,
 		CurrentPeriodEnd:  time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
 	}
@@ -1484,8 +1596,8 @@ func TestProcessSubscription_UnpaidStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetBySubscriptionID: %v", err)
 	}
-	if ent.Status != "unpaid" {
-		t.Errorf("Status = %q, want %q", ent.Status, "unpaid")
+	if ent.Status != statusUnpaid {
+		t.Errorf("Status = %q, want %q", ent.Status, statusUnpaid)
 	}
 }
 

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -314,6 +314,7 @@ const (
 	EventAirlockDeescalate EventType = "airlock_deescalate"
 	EventShieldRewrite     EventType = "shield_rewrite"
 	EventMediaExposure     EventType = "media_exposure"
+	EventLicenseExpiry     EventType = "license_expiry"
 )
 
 // WebSocket frame direction constants used in audit log entries.
@@ -986,6 +987,31 @@ func (l *Logger) LogConfigReload(status, detail, configHash string) {
 
 	if l.emitter != nil {
 		l.emitter.Emit(context.Background(), string(EventConfigReload), e.fields)
+	}
+}
+
+// LogLicenseExpiry logs a renewal warning for the active enterprise license.
+func (l *Logger) LogLicenseExpiry(licenseID string, thresholdDays, daysRemaining int, severity, expiresAt string) {
+	level := l.zl.Info()
+	emitSeverity := emit.SeverityInfo
+	switch severity {
+	case severityCritical, "error":
+		level = l.zl.Error()
+		emitSeverity = emit.SeverityCritical
+	case severityWarn:
+		level = l.zl.Warn()
+		emitSeverity = emit.SeverityWarn
+	}
+	e := newLogEntry(level, EventLicenseExpiry).
+		str("license_id", licenseID).
+		intField("threshold_days", thresholdDays).
+		intField("days_remaining", daysRemaining).
+		str("severity", severity).
+		str("expires_at", expiresAt)
+	e.msg("license expiry warning")
+
+	if l.emitter != nil {
+		l.emitter.EmitWithSeverity(context.Background(), emitSeverity, string(EventLicenseExpiry), e.fields)
 	}
 }
 

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -2506,6 +2506,54 @@ func TestLogSNIMismatch_Emitter(t *testing.T) {
 	}
 }
 
+func TestLogLicenseExpiry(t *testing.T) {
+	tests := []struct {
+		name         string
+		severity     string
+		wantSeverity emit.Severity
+	}{
+		{name: "info", severity: "info", wantSeverity: emit.SeverityInfo},
+		{name: "warn", severity: "warn", wantSeverity: emit.SeverityWarn},
+		{name: "error", severity: "error", wantSeverity: emit.SeverityCritical},
+		{name: "critical", severity: "critical", wantSeverity: emit.SeverityCritical},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, sink := newLoggerWithEmitter(t)
+			defer logger.Close()
+
+			logger.LogLicenseExpiry("lic_expiry", 14, 13, tt.severity, "2026-06-01T00:00:00Z")
+
+			ev, ok := sink.lastEvent()
+			if !ok {
+				t.Fatal("expected emitted event")
+			}
+			if ev.Type != string(EventLicenseExpiry) {
+				t.Fatalf("type = %q, want %q", ev.Type, EventLicenseExpiry)
+			}
+			if ev.Severity != tt.wantSeverity {
+				t.Fatalf("severity = %v, want %v", ev.Severity, tt.wantSeverity)
+			}
+			if ev.Fields["license_id"] != "lic_expiry" {
+				t.Errorf("license_id = %v, want lic_expiry", ev.Fields["license_id"])
+			}
+			if ev.Fields["threshold_days"] != 14 {
+				t.Errorf("threshold_days = %v, want 14", ev.Fields["threshold_days"])
+			}
+			if ev.Fields["days_remaining"] != 13 {
+				t.Errorf("days_remaining = %v, want 13", ev.Fields["days_remaining"])
+			}
+			if ev.Fields["severity"] != tt.severity {
+				t.Errorf("severity field = %v, want %s", ev.Fields["severity"], tt.severity)
+			}
+			if ev.Fields["expires_at"] != "2026-06-01T00:00:00Z" {
+				t.Errorf("expires_at = %v, want timestamp", ev.Fields["expires_at"])
+			}
+		})
+	}
+}
+
 func TestLogChainDetection_JSONFormat(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.log")

--- a/internal/cli/diag/doctor.go
+++ b/internal/cli/diag/doctor.go
@@ -4,16 +4,21 @@
 package diag
 
 import (
+	"crypto/ed25519"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 )
 
 const (
@@ -124,6 +129,7 @@ func buildDoctorReport(cfg *config.Config, cfgLabel string) doctorReport {
 		checkDoctorMCPBinaryIntegrity(cfg),
 		checkDoctorMCPToolProvenance(cfg),
 		checkDoctorFileSentry(cfg),
+		checkDoctorLicense(cfg),
 		checkDoctorSentry(cfg),
 		checkDoctorDeploymentBoundary(cfg),
 	}
@@ -140,6 +146,131 @@ func buildDoctorReport(cfg *config.Config, cfgLabel string) doctorReport {
 		}
 	}
 	return report
+}
+
+func checkDoctorLicense(cfg *config.Config) doctorReportCheck {
+	if cfg.LicenseKey == "" {
+		return doctorReportCheck{
+			Name:    "license_status",
+			Surface: doctorSurfaceConfig,
+			Status:  doctorStatusInfo,
+			Detail:  "no enterprise license configured",
+		}
+	}
+	lic, verified, err := doctorVerifiedLicense(cfg)
+	if err != nil {
+		status := doctorStatusWarn
+		if errors.Is(err, license.ErrLicenseExpired) || errors.Is(err, license.ErrLicenseRevoked) {
+			status = doctorStatusFail
+		}
+		return doctorReportCheck{
+			Name:       "license_status",
+			Surface:    doctorSurfaceConfig,
+			Status:     status,
+			Configured: true,
+			Detail:     "license verification failed: " + err.Error(),
+			Next:       "run `pipelock license status` for details and install a valid license token",
+		}
+	}
+	if !verified {
+		return doctorReportCheck{
+			Name:       "license_status",
+			Surface:    doctorSurfaceConfig,
+			Status:     doctorStatusWarn,
+			Configured: true,
+			Detail:     fmt.Sprintf("license %s is present but signature could not be verified because no public key is available", lic.ID),
+			Next:       "set license_public_key in dev builds or use an official build with an embedded key",
+		}
+	}
+	if cfg.LicenseRevoked {
+		return doctorReportCheck{
+			Name:       "license_status",
+			Surface:    doctorSurfaceConfig,
+			Status:     doctorStatusFail,
+			Configured: true,
+			Detail:     fmt.Sprintf("license %s is revoked: %s", lic.ID, cfg.LicenseRevocationReason),
+			Next:       "install a renewed license token before relying on enterprise agent profiles",
+		}
+	}
+	if lic.ExpiresAt > 0 && time.Now().Unix() > lic.ExpiresAt {
+		return doctorReportCheck{
+			Name:       "license_status",
+			Surface:    doctorSurfaceConfig,
+			Status:     doctorStatusFail,
+			Configured: true,
+			Detail:     fmt.Sprintf("license %s expired on %s", lic.ID, time.Unix(lic.ExpiresAt, 0).UTC().Format(time.DateOnly)),
+			Next:       "install a renewed license token before relying on enterprise agent profiles",
+		}
+	}
+	warning := license.ExpiryStatus(lic, time.Now())
+	if warning.Active {
+		status := doctorStatusWarn
+		if warning.Severity == license.ExpirySeverityInfo {
+			status = doctorStatusInfo
+		}
+		return doctorReportCheck{
+			Name:       "license_status",
+			Surface:    doctorSurfaceConfig,
+			Status:     status,
+			Configured: true,
+			Reachable:  true,
+			Enforcing:  true,
+			Detail: fmt.Sprintf("license %s expires in %d day(s) on %s; %d-day renewal band severity=%s",
+				lic.ID, warning.DaysRemaining, warning.ExpiresAt.Format(time.DateOnly), warning.ThresholdDays, warning.Severity),
+			Next: "renew or refresh the license before expiry disables enterprise agent profiles",
+		}
+	}
+	detail := "license token is configured"
+	if lic.ExpiresAt > 0 {
+		detail = fmt.Sprintf("license %s expires on %s", lic.ID, time.Unix(lic.ExpiresAt, 0).UTC().Format(time.DateOnly))
+	}
+	if cfg.LicenseCRLFile != "" {
+		detail += "; signed CRL configured"
+	}
+	return doctorReportCheck{
+		Name:       "license_status",
+		Surface:    doctorSurfaceConfig,
+		Status:     doctorStatusOK,
+		Configured: true,
+		Reachable:  true,
+		Enforcing:  true,
+		Detail:     detail,
+	}
+}
+
+func doctorVerifiedLicense(cfg *config.Config) (license.License, bool, error) {
+	pubKey, err := doctorLicensePublicKey(cfg)
+	if err != nil {
+		lic, decodeErr := license.Decode(cfg.LicenseKey)
+		if decodeErr != nil {
+			return license.License{}, false, decodeErr
+		}
+		return lic, false, nil
+	}
+	var crl *license.CRL
+	if cfg.LicenseCRLFile != "" {
+		loaded, crlErr := license.LoadAndVerifyCRL(cfg.LicenseCRLFile, pubKey, time.Now())
+		if crlErr != nil {
+			return license.License{}, true, crlErr
+		}
+		crl = &loaded
+	}
+	lic, verifyErr := license.VerifyWithCRL(cfg.LicenseKey, pubKey, crl)
+	return lic, true, verifyErr
+}
+
+func doctorLicensePublicKey(cfg *config.Config) (ed25519.PublicKey, error) {
+	if key := license.EmbeddedPublicKey(); key != nil {
+		return key, nil
+	}
+	if cfg.LicensePublicKey == "" {
+		return nil, errors.New("no license public key available")
+	}
+	keyBytes, err := hex.DecodeString(cfg.LicensePublicKey)
+	if err != nil || len(keyBytes) != ed25519.PublicKeySize {
+		return nil, errors.New("invalid license public key")
+	}
+	return ed25519.PublicKey(keyBytes), nil
 }
 
 func checkDoctorHTTPProxy(cfg *config.Config) doctorReportCheck {

--- a/internal/cli/diag/doctor.go
+++ b/internal/cli/diag/doctor.go
@@ -241,6 +241,9 @@ func checkDoctorLicense(cfg *config.Config) doctorReportCheck {
 func doctorVerifiedLicense(cfg *config.Config) (license.License, bool, error) {
 	pubKey, err := doctorLicensePublicKey(cfg)
 	if err != nil {
+		if cfg.LicensePublicKey != "" {
+			return license.License{}, false, err
+		}
 		lic, decodeErr := license.Decode(cfg.LicenseKey)
 		if decodeErr != nil {
 			return license.License{}, false, decodeErr

--- a/internal/cli/diag/doctor_test.go
+++ b/internal/cli/diag/doctor_test.go
@@ -5,14 +5,19 @@ package diag
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 )
 
 func TestDoctorJSONReportsWarningsForDefaultTopology(t *testing.T) {
@@ -134,6 +139,37 @@ func TestBuildDoctorReportWarnsWhenGlobalEnforceDisabled(t *testing.T) {
 		if check := doctorCheckFor(report, name); check.Enforcing {
 			t.Errorf("expected %s Enforcing=false when enforce=false, got %+v", name, check)
 		}
+	}
+}
+
+func TestBuildDoctorReportShowsLicenseExpiryWarning(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	lic := license.License{
+		ID:        "lic_doctor_warning",
+		Email:     "doctor@example.com",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(7 * 24 * time.Hour).Unix(),
+		Features:  []string{license.FeatureAgents},
+	}
+	token, err := license.Issue(lic, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Defaults()
+	cfg.LicenseKey = token
+	cfg.LicensePublicKey = hex.EncodeToString(pub)
+
+	report := buildDoctorReport(cfg, configLabelDefaults)
+	check := doctorCheckFor(report, "license_status")
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("license status = %+v, want warning", check)
+	}
+	if !strings.Contains(check.Detail, "7-day renewal band") {
+		t.Fatalf("detail = %q, want renewal band", check.Detail)
 	}
 }
 

--- a/internal/cli/diag/doctor_test.go
+++ b/internal/cli/diag/doctor_test.go
@@ -173,6 +173,153 @@ func TestBuildDoctorReportShowsLicenseExpiryWarning(t *testing.T) {
 	}
 }
 
+func TestDoctorLicenseStatusBranches(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	active := license.License{
+		ID:        "lic_doctor_active",
+		Email:     "doctor@example.com",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(45 * 24 * time.Hour).Unix(),
+		Features:  []string{license.FeatureAgents},
+	}
+	activeToken, err := license.Issue(active, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("missing", func(t *testing.T) {
+		check := checkDoctorLicense(config.Defaults())
+		if check.Status != doctorStatusInfo {
+			t.Fatalf("check = %+v, want info", check)
+		}
+	})
+
+	t.Run("invalid configured public key fails verification", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.LicenseKey = activeToken
+		cfg.LicensePublicKey = "not-hex"
+		check := checkDoctorLicense(cfg)
+		if check.Status != doctorStatusWarn || !strings.Contains(check.Detail, "invalid license public key") {
+			t.Fatalf("check = %+v, want invalid key warning", check)
+		}
+	})
+
+	t.Run("decode fallback without public key", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.LicenseKey = activeToken
+		check := checkDoctorLicense(cfg)
+		if check.Status != doctorStatusWarn || !strings.Contains(check.Detail, "signature could not be verified") {
+			t.Fatalf("check = %+v, want no-key verification warning", check)
+		}
+	})
+
+	t.Run("configured revoked flag fails", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.LicenseKey = activeToken
+		cfg.LicensePublicKey = hex.EncodeToString(pub)
+		cfg.LicenseRevoked = true
+		cfg.LicenseRevocationReason = "revoked by issuer; contact billing"
+		check := checkDoctorLicense(cfg)
+		if check.Status != doctorStatusFail || !strings.Contains(check.Detail, "revoked") {
+			t.Fatalf("check = %+v, want revoked failure", check)
+		}
+	})
+
+	t.Run("thirty day expiry band is info", func(t *testing.T) {
+		lic := active
+		lic.ID = "lic_doctor_30"
+		lic.ExpiresAt = now.Add(29 * 24 * time.Hour).Unix()
+		token, err := license.Issue(lic, priv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg := config.Defaults()
+		cfg.LicenseKey = token
+		cfg.LicensePublicKey = hex.EncodeToString(pub)
+		check := checkDoctorLicense(cfg)
+		if check.Status != doctorStatusInfo || !strings.Contains(check.Detail, "30-day renewal band") {
+			t.Fatalf("check = %+v, want info renewal band", check)
+		}
+	})
+
+	t.Run("bad CRL path reports verification warning", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.LicenseKey = activeToken
+		cfg.LicensePublicKey = hex.EncodeToString(pub)
+		cfg.LicenseCRLFile = filepath.Join(t.TempDir(), "missing-crl.json")
+		check := checkDoctorLicense(cfg)
+		if check.Status != doctorStatusWarn || !strings.Contains(check.Detail, "license verification failed") {
+			t.Fatalf("check = %+v, want CRL verification warning", check)
+		}
+	})
+
+	t.Run("valid signed CRL", func(t *testing.T) {
+		crl, err := license.SignCRL(license.CRLPayload{
+			Version:   license.CRLVersion,
+			IssuedAt:  now.Add(-time.Hour).Unix(),
+			ExpiresAt: now.Add(24 * time.Hour).Unix(),
+			Revoked: []license.RevokedLicense{{
+				ID:        "lic_other",
+				RevokedAt: now.Add(-time.Hour).Unix(),
+			}},
+		}, priv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := json.Marshal(crl)
+		if err != nil {
+			t.Fatal(err)
+		}
+		crlPath := filepath.Join(t.TempDir(), "crl.json")
+		if err := os.WriteFile(crlPath, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg := config.Defaults()
+		cfg.LicenseKey = activeToken
+		cfg.LicensePublicKey = hex.EncodeToString(pub)
+		cfg.LicenseCRLFile = crlPath
+		check := checkDoctorLicense(cfg)
+		if check.Status != doctorStatusOK || !strings.Contains(check.Detail, "signed CRL configured") {
+			t.Fatalf("check = %+v, want ok CRL detail", check)
+		}
+	})
+
+	t.Run("revoked from CRL", func(t *testing.T) {
+		crl, err := license.SignCRL(license.CRLPayload{
+			Version:   license.CRLVersion,
+			IssuedAt:  now.Add(-time.Hour).Unix(),
+			ExpiresAt: now.Add(24 * time.Hour).Unix(),
+			Revoked: []license.RevokedLicense{{
+				ID:        active.ID,
+				RevokedAt: now.Add(-time.Hour).Unix(),
+			}},
+		}, priv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := json.Marshal(crl)
+		if err != nil {
+			t.Fatal(err)
+		}
+		crlPath := filepath.Join(t.TempDir(), "crl.json")
+		if err := os.WriteFile(crlPath, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg := config.Defaults()
+		cfg.LicenseKey = activeToken
+		cfg.LicensePublicKey = hex.EncodeToString(pub)
+		cfg.LicenseCRLFile = crlPath
+		check := checkDoctorLicense(cfg)
+		if check.Status != doctorStatusFail {
+			t.Fatalf("check = %+v, want fail", check)
+		}
+	})
+}
+
 func TestDoctorChecksCoverConfiguredBranches(t *testing.T) {
 	dir := t.TempDir()
 	caCert := filepath.Join(dir, "ca.pem")

--- a/internal/cli/runtime/license_crl.go
+++ b/internal/cli/runtime/license_crl.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+const licenseRuntimeCheckInterval = time.Minute
+
+func (s *Server) startLicenseCRLWatcher(ctx context.Context) {
+	if s.refreshLicenseCRLOnce() {
+		return
+	}
+	ticker := time.NewTicker(licenseRuntimeCheckInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if s.refreshLicenseCRLOnce() {
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *Server) refreshLicenseCRLOnce() bool {
+	failClosed, err := s.checkLicenseCRL()
+	if err != nil {
+		s.logger.LogError(auditLicenseCRLContext(), err)
+		_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: license CRL refresh failed closed: %v\n", err)
+	}
+	if failClosed {
+		s.proxy.ShutdownAgentServers()
+		return true
+	}
+	return false
+}
+
+func (s *Server) checkLicenseCRL() (bool, error) {
+	if s == nil || s.proxy == nil {
+		return false, nil
+	}
+	cfg := s.proxy.CurrentConfig()
+	if cfg == nil || cfg.LicenseCRLFile == "" || cfg.LicenseKey == "" {
+		return false, nil
+	}
+	pubKey, err := runtimeLicensePublicKey(cfg)
+	if err != nil {
+		return true, err
+	}
+	crl, err := license.LoadAndVerifyCRL(cfg.LicenseCRLFile, pubKey, time.Now())
+	if err != nil {
+		return true, err
+	}
+	_, err = license.VerifyWithCRL(cfg.LicenseKey, pubKey, &crl)
+	if err == nil {
+		return false, nil
+	}
+	if errors.Is(err, license.ErrLicenseRevoked) || errors.Is(err, license.ErrLicenseExpired) {
+		return true, err
+	}
+	return true, err
+}
+
+func runtimeLicensePublicKey(cfg *config.Config) (ed25519.PublicKey, error) {
+	if key := license.EmbeddedPublicKey(); key != nil {
+		return key, nil
+	}
+	if cfg.LicensePublicKey == "" {
+		return nil, errors.New("no license public key available")
+	}
+	keyBytes, err := hex.DecodeString(cfg.LicensePublicKey)
+	if err != nil || len(keyBytes) != ed25519.PublicKeySize {
+		return nil, errors.New("invalid license public key")
+	}
+	return ed25519.PublicKey(keyBytes), nil
+}
+
+func auditLicenseCRLContext() audit.LogContext {
+	return audit.NewMethodLogContext("LICENSE_CRL")
+}

--- a/internal/cli/runtime/license_crl_test.go
+++ b/internal/cli/runtime/license_crl_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+func TestCheckLicenseCRLRevokedFailsClosed(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	lic := license.License{
+		ID:        "lic_runtime_revoked",
+		Email:     "runtime@example.com",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(24 * time.Hour).Unix(),
+		Features:  []string{license.FeatureAgents},
+	}
+	token, err := license.Issue(lic, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crl, err := license.SignCRL(license.CRLPayload{
+		Version:   license.CRLVersion,
+		IssuedAt:  now.Add(-time.Hour).Unix(),
+		ExpiresAt: now.Add(24 * time.Hour).Unix(),
+		Revoked: []license.RevokedLicense{{
+			ID:        lic.ID,
+			RevokedAt: now.Add(-time.Hour).Unix(),
+		}},
+	}, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crlData, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	crlPath := filepath.Join(dir, "crl.json")
+	if err := os.WriteFile(crlPath, crlData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := writeServerTestConfig(t, "mode: balanced\nlicense_key: "+token+"\nlicense_public_key: "+hex.EncodeToString(pub)+"\nlicense_crl_file: "+crlPath+"\n")
+	s, _ := newTestServer(t, func(opts *ServerOpts) {
+		opts.ConfigFile = cfgPath
+	})
+
+	failClosed, err := s.checkLicenseCRL()
+	if err == nil {
+		t.Fatal("expected revoked license error")
+	}
+	if !failClosed {
+		t.Fatal("revoked license should fail closed")
+	}
+}
+
+func TestCheckLicenseCRLUnreadableFailsClosed(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	lic := license.License{
+		ID:        "lic_runtime_missing_crl",
+		Email:     "runtime@example.com",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(24 * time.Hour).Unix(),
+		Features:  []string{license.FeatureAgents},
+	}
+	token, err := license.Issue(lic, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crlPath := filepath.Join(t.TempDir(), "missing-crl.json")
+	cfgPath := writeServerTestConfig(t, "mode: balanced\nlicense_key: "+token+"\nlicense_public_key: "+hex.EncodeToString(pub)+"\nlicense_crl_file: "+crlPath+"\n")
+	s, _ := newTestServer(t, func(opts *ServerOpts) {
+		opts.ConfigFile = cfgPath
+	})
+
+	failClosed, err := s.checkLicenseCRL()
+	if err == nil {
+		t.Fatal("expected missing CRL error")
+	}
+	if !failClosed {
+		t.Fatal("unreadable configured CRL should fail closed")
+	}
+}

--- a/internal/cli/runtime/license_crl_test.go
+++ b/internal/cli/runtime/license_crl_test.go
@@ -4,6 +4,7 @@
 package runtime
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
@@ -13,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 )
 
@@ -98,4 +100,80 @@ func TestCheckLicenseCRLUnreadableFailsClosed(t *testing.T) {
 	if !failClosed {
 		t.Fatal("unreadable configured CRL should fail closed")
 	}
+}
+
+func TestCheckLicenseCRLAllowsValidUnrevokedLicense(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	lic := license.License{
+		ID:        "lic_runtime_active",
+		Email:     "runtime@example.com",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(24 * time.Hour).Unix(),
+		Features:  []string{license.FeatureAgents},
+	}
+	token, err := license.Issue(lic, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crl, err := license.SignCRL(license.CRLPayload{
+		Version:   license.CRLVersion,
+		IssuedAt:  now.Add(-time.Hour).Unix(),
+		ExpiresAt: now.Add(24 * time.Hour).Unix(),
+		Revoked: []license.RevokedLicense{{
+			ID:        "lic_other",
+			RevokedAt: now.Add(-time.Hour).Unix(),
+		}},
+	}, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crlData, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crlPath := filepath.Join(t.TempDir(), "crl.json")
+	if err := os.WriteFile(crlPath, crlData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := writeServerTestConfig(t, "mode: balanced\nlicense_key: "+token+"\nlicense_public_key: "+hex.EncodeToString(pub)+"\nlicense_crl_file: "+crlPath+"\n")
+	s, _ := newTestServer(t, func(opts *ServerOpts) {
+		opts.ConfigFile = cfgPath
+	})
+
+	failClosed, err := s.checkLicenseCRL()
+	if err != nil {
+		t.Fatalf("checkLicenseCRL: %v", err)
+	}
+	if failClosed {
+		t.Fatal("valid unrevoked license should not fail closed")
+	}
+}
+
+func TestRuntimeLicensePublicKeyErrors(t *testing.T) {
+	for _, cfg := range []*config.Config{
+		{},
+		{LicensePublicKey: "not-hex"},
+		{LicensePublicKey: hex.EncodeToString([]byte("short"))},
+	} {
+		if _, err := runtimeLicensePublicKey(cfg); err == nil {
+			t.Fatalf("runtimeLicensePublicKey(%+v) expected error", cfg)
+		}
+	}
+	if auditLicenseCRLContext().Method() != "LICENSE_CRL" {
+		t.Fatal("unexpected audit context")
+	}
+	if (&Server{}).refreshLicenseCRLOnce() {
+		t.Fatal("empty server should not fail closed")
+	}
+}
+
+func TestStartLicenseCRLWatcherReturnsOnCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	(&Server{}).startLicenseCRLWatcher(ctx)
 }

--- a/internal/cli/runtime/license_crl_test.go
+++ b/internal/cli/runtime/license_crl_test.go
@@ -154,14 +154,20 @@ func TestCheckLicenseCRLAllowsValidUnrevokedLicense(t *testing.T) {
 }
 
 func TestRuntimeLicensePublicKeyErrors(t *testing.T) {
-	for _, cfg := range []*config.Config{
-		{},
-		{LicensePublicKey: "not-hex"},
-		{LicensePublicKey: hex.EncodeToString([]byte("short"))},
-	} {
-		if _, err := runtimeLicensePublicKey(cfg); err == nil {
-			t.Fatalf("runtimeLicensePublicKey(%+v) expected error", cfg)
-		}
+	tests := []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{name: "empty-config", cfg: &config.Config{}},
+		{name: "not-hex", cfg: &config.Config{LicensePublicKey: "not-hex"}},
+		{name: "short-hex", cfg: &config.Config{LicensePublicKey: hex.EncodeToString([]byte("short"))}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := runtimeLicensePublicKey(tt.cfg); err == nil {
+				t.Fatalf("runtimeLicensePublicKey(%+v) expected error", tt.cfg)
+			}
+		})
 	}
 	if auditLicenseCRLContext().Method() != "LICENSE_CRL" {
 		t.Fatal("unexpected audit context")

--- a/internal/cli/runtime/license_expiry.go
+++ b/internal/cli/runtime/license_expiry.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+	plsentry "github.com/luckyPipewrench/pipelock/internal/sentry"
+)
+
+const licenseExpiryStateFile = "license-expiry-warning.json"
+
+func emitLicenseExpiryWarning(cfg *config.Config, logger *audit.Logger, sentryClient *plsentry.Client, stderr io.Writer) {
+	if cfg == nil || cfg.LicenseID == "" || cfg.LicenseExpiresAt <= 0 {
+		return
+	}
+	now := time.Now()
+	status := license.ExpiryStatus(license.License{
+		ID:        cfg.LicenseID,
+		ExpiresAt: cfg.LicenseExpiresAt,
+	}, now)
+	if !status.Active {
+		return
+	}
+
+	statePath := licenseExpiryStatePath()
+	previous, err := license.LoadExpiryWarningState(statePath)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "WARNING: license expiry state unavailable: %v\n", err)
+	}
+	if !license.ShouldEmitExpiryWarning(status, previous) {
+		return
+	}
+
+	expiresAt := status.ExpiresAt.Format(time.DateOnly)
+	if logger != nil {
+		logger.LogLicenseExpiry(status.LicenseID, status.ThresholdDays, status.DaysRemaining, status.Severity, expiresAt)
+	}
+	_, _ = fmt.Fprintf(stderr, "WARNING: license expires in %d day(s) on %s\n",
+		status.DaysRemaining, expiresAt)
+	if sentryClient != nil {
+		sentryClient.AddBreadcrumb("license", "license expiry warning", status.Severity, map[string]any{
+			"threshold_days": fmt.Sprintf("%d", status.ThresholdDays),
+			"days_remaining": fmt.Sprintf("%d", status.DaysRemaining),
+			"expires_at":     expiresAt,
+		})
+	}
+	if saveErr := license.SaveExpiryWarningState(statePath, license.NewExpiryWarningState(status, now)); saveErr != nil {
+		_, _ = fmt.Fprintf(stderr, "WARNING: license expiry state update failed: %v\n", saveErr)
+	}
+}
+
+func (s *Server) startLicenseExpiryWatcher(ctx context.Context) {
+	ticker := time.NewTicker(licenseRuntimeCheckInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			cfg := s.proxy.CurrentConfig()
+			emitLicenseExpiryWarning(cfg, s.logger, s.sentry, s.opts.Stderr)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func licenseExpiryStatePath() string {
+	home := cliutil.ResolvedHome()
+	if home == "" {
+		if userHome, err := os.UserHomeDir(); err == nil && userHome != "" {
+			home = filepath.Join(userHome, ".pipelock")
+		}
+	}
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, "state", licenseExpiryStateFile)
+}

--- a/internal/cli/runtime/license_expiry_test.go
+++ b/internal/cli/runtime/license_expiry_test.go
@@ -45,26 +45,32 @@ func TestEmitLicenseExpiryWarningIdempotent(t *testing.T) {
 }
 
 func TestEmitLicenseExpiryWarningNoops(t *testing.T) {
-	for _, cfg := range []*config.Config{
-		nil,
-		func() *config.Config { c := config.Defaults(); return c }(),
-		func() *config.Config {
+	tests := []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{name: "nil-config", cfg: nil},
+		{name: "no-license-id", cfg: func() *config.Config { c := config.Defaults(); return c }()},
+		{name: "no-expiry", cfg: func() *config.Config {
 			c := config.Defaults()
 			c.LicenseID = "lic_no_expiry"
 			return c
-		}(),
-		func() *config.Config {
+		}()},
+		{name: "far-expiry", cfg: func() *config.Config {
 			c := config.Defaults()
 			c.LicenseID = "lic_far"
 			c.LicenseExpiresAt = time.Now().Add(31 * 24 * time.Hour).Unix()
 			return c
-		}(),
-	} {
-		var stderr bytes.Buffer
-		emitLicenseExpiryWarning(cfg, audit.NewNop(), nil, &stderr)
-		if stderr.String() != "" {
-			t.Fatalf("unexpected warning for cfg %+v: %q", cfg, stderr.String())
-		}
+		}()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			emitLicenseExpiryWarning(tt.cfg, audit.NewNop(), nil, &stderr)
+			if stderr.String() != "" {
+				t.Fatalf("unexpected warning: %q", stderr.String())
+			}
+		})
 	}
 }
 

--- a/internal/cli/runtime/license_expiry_test.go
+++ b/internal/cli/runtime/license_expiry_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestEmitLicenseExpiryWarningIdempotent(t *testing.T) {
+	home := t.TempDir()
+	oldHome := cliutil.PipelockHome
+	cliutil.PipelockHome = home
+	t.Cleanup(func() { cliutil.PipelockHome = oldHome })
+
+	cfg := config.Defaults()
+	cfg.LicenseID = "lic_runtime"
+	cfg.LicenseExpiresAt = time.Now().Add(7 * 24 * time.Hour).Unix()
+
+	var stderr bytes.Buffer
+	emitLicenseExpiryWarning(cfg, audit.NewNop(), nil, &stderr)
+	first := stderr.String()
+	if !strings.Contains(first, "expires in") {
+		t.Fatalf("first warning missing: %q", first)
+	}
+	if _, err := os.Stat(filepath.Join(home, "state", licenseExpiryStateFile)); err != nil {
+		t.Fatalf("state file not written: %v", err)
+	}
+
+	stderr.Reset()
+	emitLicenseExpiryWarning(cfg, audit.NewNop(), nil, &stderr)
+	if stderr.String() != "" {
+		t.Fatalf("second warning should be suppressed, got %q", stderr.String())
+	}
+}
+
+func TestLicenseExpiryStatePathEmptyWhenNoHome(t *testing.T) {
+	oldHome := cliutil.PipelockHome
+	cliutil.PipelockHome = ""
+	t.Cleanup(func() { cliutil.PipelockHome = oldHome })
+	t.Setenv("HOME", "")
+
+	if got := licenseExpiryStatePath(); got != "" {
+		t.Fatalf("licenseExpiryStatePath() = %q", got)
+	}
+}

--- a/internal/cli/runtime/license_expiry_test.go
+++ b/internal/cli/runtime/license_expiry_test.go
@@ -5,6 +5,7 @@ package runtime
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,13 +44,45 @@ func TestEmitLicenseExpiryWarningIdempotent(t *testing.T) {
 	}
 }
 
+func TestEmitLicenseExpiryWarningNoops(t *testing.T) {
+	for _, cfg := range []*config.Config{
+		nil,
+		func() *config.Config { c := config.Defaults(); return c }(),
+		func() *config.Config {
+			c := config.Defaults()
+			c.LicenseID = "lic_no_expiry"
+			return c
+		}(),
+		func() *config.Config {
+			c := config.Defaults()
+			c.LicenseID = "lic_far"
+			c.LicenseExpiresAt = time.Now().Add(31 * 24 * time.Hour).Unix()
+			return c
+		}(),
+	} {
+		var stderr bytes.Buffer
+		emitLicenseExpiryWarning(cfg, audit.NewNop(), nil, &stderr)
+		if stderr.String() != "" {
+			t.Fatalf("unexpected warning for cfg %+v: %q", cfg, stderr.String())
+		}
+	}
+}
+
 func TestLicenseExpiryStatePathEmptyWhenNoHome(t *testing.T) {
 	oldHome := cliutil.PipelockHome
 	cliutil.PipelockHome = ""
 	t.Cleanup(func() { cliutil.PipelockHome = oldHome })
+	t.Setenv("PIPELOCK_HOME", "")
 	t.Setenv("HOME", "")
 
 	if got := licenseExpiryStatePath(); got != "" {
 		t.Fatalf("licenseExpiryStatePath() = %q", got)
 	}
+}
+
+func TestStartLicenseExpiryWatcherReturnsOnCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	(&Server{}).startLicenseExpiryWatcher(ctx)
 }

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -1228,8 +1228,9 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	// License expiry watchdog: shut down agent listeners when the
-	// enterprise license expires at runtime. Only active when agent
-	// listeners exist and the license has a non-zero expiry.
+	// enterprise license expires at runtime. Agent shutdown only matters
+	// when listeners exist, but renewal warnings still emit for long-running
+	// proxy-only processes.
 	if agentListenerCount > 0 && cfg.LicenseExpiresAt > 0 {
 		go func() {
 			remaining := time.Until(time.Unix(cfg.LicenseExpiresAt, 0))
@@ -1247,6 +1248,8 @@ func (s *Server) Start(ctx context.Context) error {
 			case <-ctx.Done():
 			}
 		}()
+	}
+	if cfg.LicenseExpiresAt > 0 {
 		go s.startLicenseExpiryWatcher(ctx)
 	}
 	if agentListenerCount > 0 && cfg.LicenseCRLFile != "" {

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -496,6 +496,7 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	emitter := emit.NewEmitter(instanceID, emitSinks...)
 	logger.SetEmitter(emitter)
 	s.emitter = emitter
+	emitLicenseExpiryWarning(cfg, logger, sentryClient, opts.Stderr)
 
 	runtimeMode := config.RuntimeForward
 	if hasMCPListen {
@@ -1246,6 +1247,10 @@ func (s *Server) Start(ctx context.Context) error {
 			case <-ctx.Done():
 			}
 		}()
+		go s.startLicenseExpiryWatcher(ctx)
+	}
+	if agentListenerCount > 0 && cfg.LicenseCRLFile != "" {
+		go s.startLicenseCRLWatcher(ctx)
 	}
 
 	// Start the fetch proxy (blocks until context cancelled or error).
@@ -1413,7 +1418,10 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 		// agents on reload, do not re-add them via listener
 		// preservation.
 		agentsRevokedByLicense := oldCfg.Agents != nil && newCfg.Agents == nil
-		licenseInputsChanged := oldCfg.LicenseKey != newCfg.LicenseKey || oldCfg.LicensePublicKey != newCfg.LicensePublicKey || oldCfg.LicenseFile != newCfg.LicenseFile
+		licenseInputsChanged := oldCfg.LicenseKey != newCfg.LicenseKey ||
+			oldCfg.LicensePublicKey != newCfg.LicensePublicKey ||
+			oldCfg.LicenseFile != newCfg.LicenseFile ||
+			oldCfg.LicenseCRLFile != newCfg.LicenseCRLFile
 
 		if agentsRevokedByLicense {
 			// License gate disabled agents on reload. Shut down
@@ -1433,8 +1441,9 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			newCfg.Agents = oldCfg.Agents
 			newCfg.LicenseKey = oldCfg.LicenseKey
 			newCfg.LicenseFile = oldCfg.LicenseFile
+			newCfg.LicenseCRLFile = oldCfg.LicenseCRLFile
 			newCfg.LicensePublicKey = oldCfg.LicensePublicKey
-			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: license key inputs changed (license_key, license_file, or license_public_key) - requires restart for license re-verification\n")
+			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: license key inputs changed (license_key, license_file, license_crl_file, or license_public_key) - requires restart for license re-verification\n")
 		} else if AgentListenersChanged(oldCfg, newCfg) {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: agents[*].listeners changed — requires restart, ignoring listener changes\n")
 			PreserveAgentListeners(oldCfg, newCfg)
@@ -1444,6 +1453,11 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 		// not parsed from YAML. Always preserve the old value until
 		// restart.
 		newCfg.LicenseExpiresAt = oldCfg.LicenseExpiresAt
+		newCfg.LicenseID = oldCfg.LicenseID
+		newCfg.LicenseCRLExpiresAt = oldCfg.LicenseCRLExpiresAt
+		newCfg.LicenseCRLSHA256 = oldCfg.LicenseCRLSHA256
+		newCfg.LicenseRevoked = oldCfg.LicenseRevoked
+		newCfg.LicenseRevocationReason = oldCfg.LicenseRevocationReason
 	}
 
 	// Surface advisory warnings on reload the same way NewServer does at

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -152,8 +152,14 @@ func (c *Config) policySemanticView() Config {
 	// identical effective policies across license refreshes.
 	view.LicenseKey = ""
 	view.LicenseFile = ""
+	view.LicenseCRLFile = ""
 	view.LicensePublicKey = ""
 	view.LicenseExpiresAt = 0
+	view.LicenseID = ""
+	view.LicenseCRLExpiresAt = 0
+	view.LicenseCRLSHA256 = ""
+	view.LicenseRevoked = false
+	view.LicenseRevocationReason = ""
 
 	// Envelope signing key path — infrastructure, not policy. The key
 	// material itself is never read here (we only hold a path), but

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -261,6 +261,7 @@ type Config struct {
 	BindDefaultAgentIdentity bool                    `yaml:"bind_default_agent_identity,omitempty"` // when true, ignore self-declared header/query identities and bind requests to default_agent_identity
 	LicenseKey               string                  `yaml:"license_key,omitempty"`                 // signed license token (from pipelock license issue)
 	LicenseFile              string                  `yaml:"license_file,omitempty"`                // path to file containing the license token (read at startup)
+	LicenseCRLFile           string                  `yaml:"license_crl_file,omitempty" json:"-"`   // path to signed license revocation list (read at startup)
 	LicensePublicKey         string                  `yaml:"license_public_key,omitempty"`          // hex-encoded Ed25519 public key for license verification (dev builds only)
 	Internal                 []string                `yaml:"internal"`
 	TrustedDomains           []string                `yaml:"trusted_domains"` // domains exempt from SSRF internal-IP check (wildcard supported)
@@ -271,6 +272,13 @@ type Config struct {
 	// by EnforceLicenseGate(). Zero means perpetual. Used for runtime expiry
 	// enforcement so agents are disabled even without a config reload.
 	LicenseExpiresAt int64 `yaml:"-"`
+	// LicenseID and CRL metadata are runtime-derived from the verified
+	// license token and CRL. They are excluded from policy serialization.
+	LicenseID               string `yaml:"-" json:"-"`
+	LicenseCRLExpiresAt     int64  `yaml:"-" json:"-"`
+	LicenseCRLSHA256        string `yaml:"-" json:"-"`
+	LicenseRevoked          bool   `yaml:"-" json:"-"`
+	LicenseRevocationReason string `yaml:"-" json:"-"`
 
 	// rawBytes stores the original config file bytes for deterministic hashing.
 	// Not serialized to YAML. Set by Load(), nil for Defaults().

--- a/internal/emit/event.go
+++ b/internal/emit/event.go
@@ -87,6 +87,10 @@ const EventMediaExposure = "media_exposure"
 // trigger. Fields include source URL, density, and a snippet hash.
 const EventTextStego = "text_stego_detected"
 
+// EventLicenseExpiry is emitted when the active enterprise license enters a
+// renewal warning band.
+const EventLicenseExpiry = "license_expiry"
+
 // actionBlock is the action string that indicates a request was blocked.
 // Used internally for severity mapping — block actions map to SeverityCritical.
 const actionBlock = "block"
@@ -154,6 +158,7 @@ var EventSeverity = map[string]Severity{
 	EventResponseScanExempt: SeverityWarn, // scanning was skipped; operators need visibility
 	EventMediaExposure:      SeverityWarn, // media reached agent; provenance signal for taint system
 	EventTextStego:          SeverityWarn, // suspicious combining-mark density; exposure signal
+	EventLicenseExpiry:      SeverityWarn, // overridden by caller with threshold-specific severity
 
 	// Info: normal operations
 	"allowed":         SeverityInfo,

--- a/internal/emit/event_test.go
+++ b/internal/emit/event_test.go
@@ -83,6 +83,7 @@ func TestEventSeverity_CoverExpectedTypes(t *testing.T) {
 
 		// Warn: security-relevant operational
 		{"response_scan_exempt", SeverityWarn},
+		{EventLicenseExpiry, SeverityWarn},
 
 		// Info
 		{verdictAllowed, SeverityInfo},
@@ -125,6 +126,7 @@ func TestEventSeverity_NoUnexpectedEntries(t *testing.T) {
 		"response_scan_exempt":  true,
 		EventMediaExposure:      true,
 		EventTextStego:          true,
+		EventLicenseExpiry:      true,
 		verdictAllowed:          true,
 		EventTunnelOpen:         true,
 		"tunnel_close":          true,

--- a/internal/license/crl.go
+++ b/internal/license/crl.go
@@ -1,0 +1,261 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+)
+
+const (
+	CRLVersion     = 1
+	maxCRLFileSize = 256 * 1024
+)
+
+var ErrLicenseRevoked = errors.New("license revoked")
+
+// RevokedLicense records one revoked license ID in a signed CRL.
+type RevokedLicense struct {
+	ID        string `json:"id"`
+	Reason    string `json:"reason,omitempty"`
+	RevokedAt int64  `json:"revoked_at"`
+}
+
+// CRLPayload is the signed revocation-list payload.
+type CRLPayload struct {
+	Version   int              `json:"version"`
+	IssuedAt  int64            `json:"issued_at"`
+	ExpiresAt int64            `json:"expires_at"`
+	Revoked   []RevokedLicense `json:"revoked"`
+}
+
+// CRL is a signed license revocation list. The wire format stores the exact
+// signed payload bytes as base64url JSON. Signature verification covers those
+// bytes, not a re-marshaled struct.
+type CRL struct {
+	Payload   CRLPayload     `json:"-"`
+	Signature string         `json:"-"`
+	SHA256    string         `json:"-"`
+	payload   []byte         `json:"-"`
+	index     map[string]int `json:"-"`
+}
+
+type crlWire struct {
+	Payload   string `json:"payload"`
+	Signature string `json:"signature"`
+}
+
+func SignCRL(payload CRLPayload, privateKey ed25519.PrivateKey) (CRL, error) {
+	if len(privateKey) != ed25519.PrivateKeySize {
+		return CRL{}, errors.New("invalid private key size")
+	}
+	if payload.Version == 0 {
+		payload.Version = CRLVersion
+	}
+	if err := validateCRLPayload(payload, time.Now()); err != nil {
+		return CRL{}, err
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return CRL{}, fmt.Errorf("marshal CRL payload: %w", err)
+	}
+	sig := ed25519.Sign(privateKey, data)
+	sum := sha256.Sum256(data)
+	crl := CRL{
+		Payload:   payload,
+		Signature: base64.RawURLEncoding.EncodeToString(sig),
+		SHA256:    hex.EncodeToString(sum[:]),
+		payload:   slices.Clone(data),
+	}
+	crl.buildIndex()
+	return crl, nil
+}
+
+func (c CRL) MarshalJSON() ([]byte, error) {
+	payload := c.payload
+	if len(payload) == 0 {
+		var err error
+		payload, err = json.Marshal(c.Payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal CRL payload: %w", err)
+		}
+	}
+	return json.Marshal(crlWire{
+		Payload:   base64.RawURLEncoding.EncodeToString(payload),
+		Signature: c.Signature,
+	})
+}
+
+func (c *CRL) UnmarshalJSON(data []byte) error {
+	var wire crlWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(wire.Payload)
+	if err != nil {
+		return fmt.Errorf("decode CRL payload: %w", err)
+	}
+	if err := json.Unmarshal(payload, &c.Payload); err != nil {
+		return fmt.Errorf("parse CRL payload: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	c.Signature = wire.Signature
+	c.SHA256 = hex.EncodeToString(sum[:])
+	c.payload = slices.Clone(payload)
+	c.buildIndex()
+	return nil
+}
+
+func ParseAndVerifyCRL(data []byte, publicKey ed25519.PublicKey, now time.Time) (CRL, error) {
+	if len(publicKey) != ed25519.PublicKeySize {
+		return CRL{}, errors.New("invalid public key")
+	}
+	if len(data) > maxCRLFileSize {
+		return CRL{}, errors.New("license CRL exceeds maximum size")
+	}
+	var wire crlWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return CRL{}, fmt.Errorf("parse license CRL: %w", err)
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(wire.Payload)
+	if err != nil {
+		return CRL{}, fmt.Errorf("decode CRL payload: %w", err)
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(wire.Signature)
+	if err != nil {
+		return CRL{}, fmt.Errorf("decode CRL signature: %w", err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return CRL{}, errors.New("invalid CRL signature size")
+	}
+	if !ed25519.Verify(publicKey, payload, sig) {
+		return CRL{}, errors.New("invalid CRL signature")
+	}
+	var payloadClaims CRLPayload
+	if err := json.Unmarshal(payload, &payloadClaims); err != nil {
+		return CRL{}, fmt.Errorf("parse CRL payload: %w", err)
+	}
+	if err := validateCRLPayload(payloadClaims, now); err != nil {
+		return CRL{}, err
+	}
+	sum := sha256.Sum256(payload)
+	crl := CRL{
+		Payload:   payloadClaims,
+		Signature: wire.Signature,
+		SHA256:    hex.EncodeToString(sum[:]),
+		payload:   slices.Clone(payload),
+	}
+	crl.buildIndex()
+	return crl, nil
+}
+
+func LoadAndVerifyCRL(path string, publicKey ed25519.PublicKey, now time.Time) (CRL, error) {
+	cleanPath := filepath.Clean(path)
+	info, err := os.Stat(cleanPath)
+	if err != nil {
+		return CRL{}, fmt.Errorf("stat license CRL: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return CRL{}, errors.New("license CRL must be a regular file")
+	}
+	if info.Size() > maxCRLFileSize {
+		return CRL{}, errors.New("license CRL exceeds maximum size")
+	}
+	data, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return CRL{}, fmt.Errorf("read license CRL: %w", err)
+	}
+	return ParseAndVerifyCRL(data, publicKey, now)
+}
+
+func (c CRL) RevocationFor(id string) (RevokedLicense, bool) {
+	if c.index != nil {
+		i, ok := c.index[id]
+		if !ok || i < 0 || i >= len(c.Payload.Revoked) {
+			return RevokedLicense{}, false
+		}
+		return c.Payload.Revoked[i], true
+	}
+	for _, revoked := range c.Payload.Revoked {
+		if revoked.ID == id {
+			return revoked, true
+		}
+	}
+	return RevokedLicense{}, false
+}
+
+func (c CRL) CheckLicense(lic License) error {
+	revoked, ok := c.RevocationFor(lic.ID)
+	if !ok {
+		return nil
+	}
+	if revoked.Reason == "" {
+		return fmt.Errorf("%w: %s", ErrLicenseRevoked, lic.ID)
+	}
+	return fmt.Errorf("%w: %s (%s)", ErrLicenseRevoked, lic.ID, revoked.Reason)
+}
+
+func VerifyWithCRL(token string, publicKey ed25519.PublicKey, crl *CRL) (License, error) {
+	lic, err := Verify(token, publicKey)
+	if err != nil {
+		return lic, err
+	}
+	if crl != nil {
+		if err := crl.CheckLicense(lic); err != nil {
+			return lic, err
+		}
+	}
+	return lic, nil
+}
+
+func validateCRLPayload(payload CRLPayload, now time.Time) error {
+	if payload.Version != CRLVersion {
+		return fmt.Errorf("unsupported CRL version %d", payload.Version)
+	}
+	if payload.IssuedAt <= 0 {
+		return errors.New("CRL missing issued_at")
+	}
+	if payload.ExpiresAt <= 0 {
+		return errors.New("CRL missing expires_at")
+	}
+	if payload.ExpiresAt <= payload.IssuedAt {
+		return errors.New("CRL expires_at must be after issued_at")
+	}
+	if now.Unix() > payload.ExpiresAt {
+		return fmt.Errorf("license CRL expired on %s", time.Unix(payload.ExpiresAt, 0).UTC().Format(time.DateOnly))
+	}
+	ids := make([]string, 0, len(payload.Revoked))
+	for _, revoked := range payload.Revoked {
+		if revoked.ID == "" {
+			return errors.New("CRL contains revoked license with empty id")
+		}
+		if revoked.RevokedAt <= 0 {
+			return fmt.Errorf("CRL revocation %s missing revoked_at", revoked.ID)
+		}
+		ids = append(ids, revoked.ID)
+	}
+	slices.Sort(ids)
+	for i := 1; i < len(ids); i++ {
+		if ids[i] == ids[i-1] {
+			return fmt.Errorf("CRL contains duplicate license id %s", ids[i])
+		}
+	}
+	return nil
+}
+
+func (c *CRL) buildIndex() {
+	c.index = make(map[string]int, len(c.Payload.Revoked))
+	for i, revoked := range c.Payload.Revoked {
+		c.index[revoked.ID] = i
+	}
+}

--- a/internal/license/crl_test.go
+++ b/internal/license/crl_test.go
@@ -256,6 +256,132 @@ func TestLoadAndVerifyCRL(t *testing.T) {
 	}
 }
 
+func TestCRLUnmarshalJSONBuildsIndex(t *testing.T) {
+	_, priv := testKeyPair(t)
+	now := time.Now().UTC()
+	crl := testCRL(t, priv, now, "lic_unmarshal")
+	data, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got CRL
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+	if got.SHA256 == "" {
+		t.Fatal("expected digest after unmarshal")
+	}
+	if revoked, ok := got.RevocationFor("lic_unmarshal"); !ok || revoked.ID != "lic_unmarshal" {
+		t.Fatalf("revocation lookup failed: %+v ok=%v", revoked, ok)
+	}
+}
+
+func TestCRLRevocationForFallbackAndReasonlessError(t *testing.T) {
+	crl := CRL{Payload: CRLPayload{Revoked: []RevokedLicense{{
+		ID:        "lic_reasonless",
+		RevokedAt: time.Now().UTC().Unix(),
+	}}}}
+	revoked, ok := crl.RevocationFor("lic_reasonless")
+	if !ok || revoked.ID != "lic_reasonless" {
+		t.Fatalf("RevocationFor = %+v, %v; want fallback match", revoked, ok)
+	}
+	if _, ok := crl.RevocationFor("lic_missing"); ok {
+		t.Fatal("missing license should not be revoked")
+	}
+	err := crl.CheckLicense(License{ID: "lic_reasonless"})
+	if !errors.Is(err, ErrLicenseRevoked) {
+		t.Fatalf("CheckLicense error = %v, want ErrLicenseRevoked", err)
+	}
+	if strings.Contains(err.Error(), "()") {
+		t.Fatalf("reasonless revocation should not render empty reason: %v", err)
+	}
+}
+
+func TestCRLRejectsMalformedInputs(t *testing.T) {
+	pub, priv := testKeyPair(t)
+	now := time.Now().UTC()
+	valid := testCRL(t, priv, now, "lic_valid")
+	validData, err := json.Marshal(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var validWire crlWire
+	if err := json.Unmarshal(validData, &validWire); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		data []byte
+		key  ed25519.PublicKey
+	}{
+		{name: "bad public key", data: validData, key: ed25519.PublicKey("short")},
+		{name: "too large", data: []byte(strings.Repeat("x", maxCRLFileSize+1)), key: pub},
+		{name: "bad json", data: []byte("{"), key: pub},
+		{name: "bad payload base64", data: []byte(`{"payload":"%%","signature":"` + validWire.Signature + `"}`), key: pub},
+		{name: "bad signature base64", data: []byte(`{"payload":"` + validWire.Payload + `","signature":"%%"}`), key: pub},
+		{name: "bad signature size", data: []byte(`{"payload":"` + validWire.Payload + `","signature":"` + base64.RawURLEncoding.EncodeToString([]byte("short")) + `"}`), key: pub},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ParseAndVerifyCRL(tt.data, tt.key, now); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestValidateCRLPayloadRejectsInvalidRecords(t *testing.T) {
+	now := time.Now().UTC()
+	base := CRLPayload{
+		Version:   CRLVersion,
+		IssuedAt:  now.Add(-time.Hour).Unix(),
+		ExpiresAt: now.Add(time.Hour).Unix(),
+		Revoked: []RevokedLicense{{
+			ID:        "lic_ok",
+			RevokedAt: now.Add(-time.Hour).Unix(),
+		}},
+	}
+	tests := []struct {
+		name   string
+		mutate func(*CRLPayload)
+	}{
+		{name: "version", mutate: func(p *CRLPayload) { p.Version = 99 }},
+		{name: "issued", mutate: func(p *CRLPayload) { p.IssuedAt = 0 }},
+		{name: "expires", mutate: func(p *CRLPayload) { p.ExpiresAt = 0 }},
+		{name: "empty id", mutate: func(p *CRLPayload) { p.Revoked[0].ID = "" }},
+		{name: "missing revoked_at", mutate: func(p *CRLPayload) { p.Revoked[0].RevokedAt = 0 }},
+		{name: "duplicate", mutate: func(p *CRLPayload) { p.Revoked = append(p.Revoked, p.Revoked[0]) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := base
+			payload.Revoked = append([]RevokedLicense(nil), base.Revoked...)
+			tt.mutate(&payload)
+			if err := validateCRLPayload(payload, now); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestLoadAndVerifyCRLRejectsBadPaths(t *testing.T) {
+	pub, _ := testKeyPair(t)
+	now := time.Now().UTC()
+	dir := t.TempDir()
+	large := filepath.Join(dir, "large.json")
+	if err := os.WriteFile(large, []byte(strings.Repeat("x", maxCRLFileSize+1)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{filepath.Join(dir, "missing.json"), dir, large} {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			if _, err := LoadAndVerifyCRL(path, pub, now); err == nil {
+				t.Fatal("expected load error")
+			}
+		})
+	}
+}
+
 func testCRL(t *testing.T, priv ed25519.PrivateKey, now time.Time, revokedID string) CRL {
 	t.Helper()
 	crl, err := SignCRL(CRLPayload{

--- a/internal/license/crl_test.go
+++ b/internal/license/crl_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSignParseAndVerifyCRL(t *testing.T) {
+	pub, priv := testKeyPair(t)
+	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	crl := testCRL(t, priv, now, "lic_revoked")
+
+	data, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ParseAndVerifyCRL(data, pub, now)
+	if err != nil {
+		t.Fatalf("ParseAndVerifyCRL: %v", err)
+	}
+	if _, ok := got.RevocationFor("lic_revoked"); !ok {
+		t.Fatal("expected revoked license in CRL")
+	}
+}
+
+func TestVerifyWithCRLRejectsRevokedLicense(t *testing.T) {
+	pub, priv := testKeyPair(t)
+	now := time.Now().UTC()
+	lic := License{
+		ID:        "lic_revoked",
+		Email:     "customer@example.com",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(24 * time.Hour).Unix(),
+		Features:  []string{FeatureAgents},
+	}
+	token, err := Issue(lic, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crl := testCRL(t, priv, now, lic.ID)
+
+	_, err = VerifyWithCRL(token, pub, &crl)
+	if !errors.Is(err, ErrLicenseRevoked) {
+		t.Fatalf("VerifyWithCRL error = %v, want ErrLicenseRevoked", err)
+	}
+}
+
+func TestVerifyWithCRLAllowsUnrevokedLicense(t *testing.T) {
+	pub, priv := testKeyPair(t)
+	now := time.Now().UTC()
+	lic := License{
+		ID:        "lic_active",
+		Email:     "customer@example.com",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(24 * time.Hour).Unix(),
+		Features:  []string{FeatureAgents},
+	}
+	token, err := Issue(lic, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crl := testCRL(t, priv, now, "lic_other")
+
+	got, err := VerifyWithCRL(token, pub, &crl)
+	if err != nil {
+		t.Fatalf("VerifyWithCRL: %v", err)
+	}
+	if got.ID != lic.ID {
+		t.Errorf("ID = %q, want %q", got.ID, lic.ID)
+	}
+}
+
+func TestParseAndVerifyCRLRejectsTampering(t *testing.T) {
+	pub, priv := testKeyPair(t)
+	now := time.Now().UTC()
+	crl := testCRL(t, priv, now, "lic_revoked")
+	data, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wire crlWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(wire.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload = []byte(strings.Replace(string(payload), "lic_revoked", "lic_active", 1))
+	wire.Payload = base64.RawURLEncoding.EncodeToString(payload)
+	tampered, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ParseAndVerifyCRL(tampered, pub, now)
+	if err == nil || !strings.Contains(err.Error(), "signature") {
+		t.Fatalf("expected signature error, got %v", err)
+	}
+}
+
+func TestCRLWirePayloadIsBase64AndDigestIsSet(t *testing.T) {
+	pub, priv := testKeyPair(t)
+	now := time.Now().UTC()
+	crl := testCRL(t, priv, now, "lic_digest")
+	data, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "lic_digest") {
+		t.Fatalf("wire CRL should carry base64 payload, got %s", string(data))
+	}
+	verified, err := ParseAndVerifyCRL(data, pub, now)
+	if err != nil {
+		t.Fatalf("ParseAndVerifyCRL: %v", err)
+	}
+	if verified.SHA256 == "" {
+		t.Fatal("expected CRL SHA256 digest")
+	}
+}
+
+func TestCRLMarshalPreservesVerifiedPayloadBytes(t *testing.T) {
+	pub, priv := testKeyPair(t)
+	now := time.Now().UTC()
+	issuedAt := now.Add(-time.Hour).Unix()
+	expiresAt := now.Add(24 * time.Hour).Unix()
+	payload := []byte(`{"revoked":[{"revoked_at":` +
+		strconv.FormatInt(issuedAt, 10) +
+		`,"id":"lic_preserve"}],"expires_at":` +
+		strconv.FormatInt(expiresAt, 10) +
+		`,"issued_at":` +
+		strconv.FormatInt(issuedAt, 10) +
+		`,"version":1}`)
+	sig := ed25519.Sign(priv, payload)
+	wire := crlWire{
+		Payload:   base64.RawURLEncoding.EncodeToString(payload),
+		Signature: base64.RawURLEncoding.EncodeToString(sig),
+	}
+	data, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crl, err := ParseAndVerifyCRL(data, pub, now)
+	if err != nil {
+		t.Fatalf("ParseAndVerifyCRL: %v", err)
+	}
+	remarshaled, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got crlWire
+	if err := json.Unmarshal(remarshaled, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Payload != wire.Payload {
+		t.Fatalf("MarshalJSON changed signed payload bytes\ngot  %s\nwant %s", got.Payload, wire.Payload)
+	}
+}
+
+func TestParseAndVerifyCRLVerifiesBeforePayloadValidation(t *testing.T) {
+	pub, _ := testKeyPair(t)
+	now := time.Now().UTC()
+	issuedAt := now.Add(-time.Hour).Unix()
+	expiresAt := now.Add(24 * time.Hour).Unix()
+	payload := []byte(`{"version":1,"issued_at":` +
+		strconv.FormatInt(issuedAt, 10) +
+		`,"expires_at":` +
+		strconv.FormatInt(expiresAt, 10) +
+		`,"revoked":[{"id":"lic_dup","revoked_at":` +
+		strconv.FormatInt(issuedAt, 10) +
+		`},{"id":"lic_dup","revoked_at":` +
+		strconv.FormatInt(issuedAt, 10) +
+		`}]}`)
+	wire := crlWire{
+		Payload:   base64.RawURLEncoding.EncodeToString(payload),
+		Signature: base64.RawURLEncoding.EncodeToString(make([]byte, ed25519.SignatureSize)),
+	}
+	data, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ParseAndVerifyCRL(data, pub, now)
+	if err == nil || !strings.Contains(err.Error(), "signature") {
+		t.Fatalf("expected signature error before payload validation, got %v", err)
+	}
+}
+
+func TestSignCRLRejectsInvertedTimestamps(t *testing.T) {
+	_, priv := testKeyPair(t)
+	now := time.Now().UTC()
+	_, err := SignCRL(CRLPayload{
+		Version:   CRLVersion,
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(-time.Hour).Unix(),
+	}, priv)
+	if err == nil || !strings.Contains(err.Error(), "expires_at") {
+		t.Fatalf("expected expires_at validation error, got %v", err)
+	}
+}
+
+func TestParseAndVerifyCRLRejectsExpiredList(t *testing.T) {
+	pub, priv := testKeyPair(t)
+	now := time.Now().UTC()
+	payload := CRLPayload{
+		Version:   CRLVersion,
+		IssuedAt:  now.Add(-48 * time.Hour).Unix(),
+		ExpiresAt: now.Add(-24 * time.Hour).Unix(),
+		Revoked: []RevokedLicense{{
+			ID:        "lic_revoked",
+			RevokedAt: now.Add(-48 * time.Hour).Unix(),
+		}},
+	}
+	payloadData, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crl := CRL{
+		Payload:   payload,
+		Signature: base64.RawURLEncoding.EncodeToString(ed25519.Sign(priv, payloadData)),
+	}
+	data, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ParseAndVerifyCRL(data, pub, now)
+	if err == nil || !strings.Contains(err.Error(), "expired") {
+		t.Fatalf("expected expired CRL error, got %v", err)
+	}
+}
+
+func TestLoadAndVerifyCRL(t *testing.T) {
+	pub, priv := testKeyPair(t)
+	now := time.Now().UTC()
+	crl := testCRL(t, priv, now, "lic_revoked")
+	data, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "crl.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadAndVerifyCRL(path, pub, now); err != nil {
+		t.Fatalf("LoadAndVerifyCRL: %v", err)
+	}
+}
+
+func testCRL(t *testing.T, priv ed25519.PrivateKey, now time.Time, revokedID string) CRL {
+	t.Helper()
+	crl, err := SignCRL(CRLPayload{
+		Version:   CRLVersion,
+		IssuedAt:  now.Add(-time.Hour).Unix(),
+		ExpiresAt: now.Add(7 * 24 * time.Hour).Unix(),
+		Revoked: []RevokedLicense{{
+			ID:        revokedID,
+			Reason:    "subscription_ended",
+			RevokedAt: now.Add(-time.Hour).Unix(),
+		}},
+	}, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return crl
+}

--- a/internal/license/expiry.go
+++ b/internal/license/expiry.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+)
+
+const (
+	ExpirySeverityInfo  = "info"
+	ExpirySeverityWarn  = "warn"
+	ExpirySeverityError = "error"
+
+	expiryDay = 24 * time.Hour
+)
+
+// ExpiryWarning describes the active renewal warning band for a license.
+type ExpiryWarning struct {
+	Active        bool
+	LicenseID     string
+	ThresholdDays int
+	DaysRemaining int
+	Severity      string
+	ExpiresAt     time.Time
+}
+
+// ExpiryWarningState records the last emitted renewal warning. It is safe to
+// persist locally because it contains only the opaque license ID and threshold.
+type ExpiryWarningState struct {
+	LicenseID      string    `json:"license_id"`
+	ThresholdDays  int       `json:"threshold_days"`
+	LastEmittedUTC time.Time `json:"last_emitted_utc"`
+}
+
+// ExpiryStatus returns the current warning band for lic at now. Perpetual and
+// already-expired licenses do not produce renewal warnings.
+func ExpiryStatus(lic License, now time.Time) ExpiryWarning {
+	if lic.ExpiresAt <= 0 {
+		return ExpiryWarning{LicenseID: lic.ID}
+	}
+	expiresAt := time.Unix(lic.ExpiresAt, 0).UTC()
+	remaining := expiresAt.Sub(now.UTC())
+	if remaining <= 0 {
+		return ExpiryWarning{
+			LicenseID:     lic.ID,
+			DaysRemaining: 0,
+			ExpiresAt:     expiresAt,
+		}
+	}
+	days := int(math.Ceil(float64(remaining) / float64(expiryDay)))
+	threshold := expiryThreshold(days)
+	if threshold == 0 {
+		return ExpiryWarning{
+			LicenseID:     lic.ID,
+			DaysRemaining: days,
+			ExpiresAt:     expiresAt,
+		}
+	}
+	return ExpiryWarning{
+		Active:        true,
+		LicenseID:     lic.ID,
+		ThresholdDays: threshold,
+		DaysRemaining: days,
+		Severity:      expirySeverity(threshold),
+		ExpiresAt:     expiresAt,
+	}
+}
+
+// ShouldEmitExpiryWarning returns true when a warning should be emitted for
+// the current band. The same license and threshold emits once; a new license
+// or a lower threshold emits again.
+func ShouldEmitExpiryWarning(current ExpiryWarning, previous ExpiryWarningState) bool {
+	if !current.Active {
+		return false
+	}
+	return previous.LicenseID != current.LicenseID ||
+		previous.ThresholdDays != current.ThresholdDays
+}
+
+func NewExpiryWarningState(current ExpiryWarning, now time.Time) ExpiryWarningState {
+	return ExpiryWarningState{
+		LicenseID:      current.LicenseID,
+		ThresholdDays:  current.ThresholdDays,
+		LastEmittedUTC: now.UTC(),
+	}
+}
+
+func LoadExpiryWarningState(path string) (ExpiryWarningState, error) {
+	if path == "" {
+		return ExpiryWarningState{}, nil
+	}
+	data, err := os.ReadFile(filepath.Clean(path))
+	if errors.Is(err, os.ErrNotExist) {
+		return ExpiryWarningState{}, nil
+	}
+	if err != nil {
+		return ExpiryWarningState{}, fmt.Errorf("read license expiry state: %w", err)
+	}
+	var state ExpiryWarningState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return ExpiryWarningState{}, fmt.Errorf("parse license expiry state: %w", err)
+	}
+	return state, nil
+}
+
+func SaveExpiryWarningState(path string, state ExpiryWarningState) error {
+	if path == "" {
+		return nil
+	}
+	cleanPath := filepath.Clean(path)
+	if err := os.MkdirAll(filepath.Dir(cleanPath), 0o750); err != nil {
+		return fmt.Errorf("create license expiry state dir: %w", err)
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal license expiry state: %w", err)
+	}
+	data = append(data, '\n')
+	if err := atomicfile.Write(cleanPath, data, 0o600); err != nil {
+		return fmt.Errorf("write license expiry state: %w", err)
+	}
+	return nil
+}
+
+func expiryThreshold(daysRemaining int) int {
+	switch {
+	case daysRemaining <= 1:
+		return 1
+	case daysRemaining <= 7:
+		return 7
+	case daysRemaining <= 14:
+		return 14
+	case daysRemaining <= 30:
+		return 30
+	default:
+		return 0
+	}
+}
+
+func expirySeverity(threshold int) string {
+	switch threshold {
+	case 1:
+		return ExpirySeverityError
+	case 7, 14:
+		return ExpirySeverityWarn
+	case 30:
+		return ExpirySeverityInfo
+	default:
+		return ""
+	}
+}

--- a/internal/license/expiry_test.go
+++ b/internal/license/expiry_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestExpiryStatusThresholdBands(t *testing.T) {
+	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name          string
+		expiresIn     time.Duration
+		wantActive    bool
+		wantThreshold int
+		wantSeverity  string
+	}{
+		{"outside warning window", 31 * expiryDay, false, 0, ""},
+		{"thirty days", 30 * expiryDay, true, 30, ExpirySeverityInfo},
+		{"fourteen days", 14 * expiryDay, true, 14, ExpirySeverityWarn},
+		{"seven days", 7 * expiryDay, true, 7, ExpirySeverityWarn},
+		{"one day", expiryDay, true, 1, ExpirySeverityError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status := ExpiryStatus(License{
+				ID:        "lic_test",
+				ExpiresAt: now.Add(tt.expiresIn).Unix(),
+			}, now)
+			if status.Active != tt.wantActive {
+				t.Fatalf("Active = %v, want %v; status=%+v", status.Active, tt.wantActive, status)
+			}
+			if status.ThresholdDays != tt.wantThreshold {
+				t.Errorf("ThresholdDays = %d, want %d", status.ThresholdDays, tt.wantThreshold)
+			}
+			if status.Severity != tt.wantSeverity {
+				t.Errorf("Severity = %q, want %q", status.Severity, tt.wantSeverity)
+			}
+		})
+	}
+}
+
+func TestExpiryStatusNoWarningForPerpetualOrExpired(t *testing.T) {
+	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	for _, lic := range []License{
+		{ID: "lic_perpetual"},
+		{ID: "lic_expired", ExpiresAt: now.Add(-time.Hour).Unix()},
+	} {
+		status := ExpiryStatus(lic, now)
+		if status.Active {
+			t.Fatalf("ExpiryStatus(%s).Active = true, want false", lic.ID)
+		}
+	}
+}
+
+func TestShouldEmitExpiryWarningIdempotentPerBand(t *testing.T) {
+	current := ExpiryWarning{Active: true, LicenseID: "lic_test", ThresholdDays: 14}
+	if !ShouldEmitExpiryWarning(current, ExpiryWarningState{}) {
+		t.Fatal("first warning should emit")
+	}
+	if ShouldEmitExpiryWarning(current, ExpiryWarningState{LicenseID: "lic_test", ThresholdDays: 14}) {
+		t.Fatal("same license and threshold should not emit twice")
+	}
+	if !ShouldEmitExpiryWarning(current, ExpiryWarningState{LicenseID: "lic_test", ThresholdDays: 30}) {
+		t.Fatal("threshold change should emit")
+	}
+	if !ShouldEmitExpiryWarning(current, ExpiryWarningState{LicenseID: "lic_other", ThresholdDays: 14}) {
+		t.Fatal("license change should emit")
+	}
+}
+
+func TestExpiryWarningStateRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "license-expiry.json")
+	want := NewExpiryWarningState(ExpiryWarning{
+		Active:        true,
+		LicenseID:     "lic_state",
+		ThresholdDays: 7,
+	}, time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC))
+	if err := SaveExpiryWarningState(path, want); err != nil {
+		t.Fatalf("SaveExpiryWarningState: %v", err)
+	}
+	got, err := LoadExpiryWarningState(path)
+	if err != nil {
+		t.Fatalf("LoadExpiryWarningState: %v", err)
+	}
+	if got.LicenseID != want.LicenseID || got.ThresholdDays != want.ThresholdDays || !got.LastEmittedUTC.Equal(want.LastEmittedUTC) {
+		t.Fatalf("state mismatch: got %+v want %+v", got, want)
+	}
+}

--- a/internal/license/expiry_test.go
+++ b/internal/license/expiry_test.go
@@ -4,6 +4,7 @@
 package license
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -89,5 +90,44 @@ func TestExpiryWarningStateRoundTrip(t *testing.T) {
 	}
 	if got.LicenseID != want.LicenseID || got.ThresholdDays != want.ThresholdDays || !got.LastEmittedUTC.Equal(want.LastEmittedUTC) {
 		t.Fatalf("state mismatch: got %+v want %+v", got, want)
+	}
+}
+
+func TestExpiryWarningStateErrorsAndNoopPaths(t *testing.T) {
+	if _, err := LoadExpiryWarningState(""); err != nil {
+		t.Fatalf("empty load path should be a no-op: %v", err)
+	}
+	if err := SaveExpiryWarningState("", ExpiryWarningState{}); err != nil {
+		t.Fatalf("empty save path should be a no-op: %v", err)
+	}
+	if _, err := LoadExpiryWarningState(filepath.Join(t.TempDir(), "missing.json")); err != nil {
+		t.Fatalf("missing state should be empty without error: %v", err)
+	}
+
+	dir := t.TempDir()
+	badJSON := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(badJSON, []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadExpiryWarningState(badJSON); err == nil {
+		t.Fatal("expected parse error")
+	}
+
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := SaveExpiryWarningState(filepath.Join(blocker, "state.json"), ExpiryWarningState{})
+	if err == nil {
+		t.Fatal("expected directory creation error")
+	}
+}
+
+func TestExpirySeverityDefault(t *testing.T) {
+	if got := expirySeverity(99); got != "" {
+		t.Fatalf("expirySeverity(99) = %q, want empty", got)
+	}
+	if ShouldEmitExpiryWarning(ExpiryWarning{}, ExpiryWarningState{}) {
+		t.Fatal("inactive warning should not emit")
 	}
 }

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -25,6 +25,8 @@ const maxTokenBytes = 64 * 1024
 // tokenPrefix identifies the license token format version.
 const tokenPrefix = "pipelock_lic_" + "v1_" //nolint:gosec // G101: not a credential, license format prefix
 
+var ErrLicenseExpired = errors.New("license expired")
+
 // Feature names for gating.
 const (
 	FeatureAgents = "agents"
@@ -113,7 +115,7 @@ func Verify(token string, publicKey ed25519.PublicKey) (License, error) {
 	}
 
 	if l.ExpiresAt > 0 && time.Now().Unix() > l.ExpiresAt {
-		return l, fmt.Errorf("license expired on %s", time.Unix(l.ExpiresAt, 0).UTC().Format(time.DateOnly))
+		return l, fmt.Errorf("%w on %s", ErrLicenseExpired, time.Unix(l.ExpiresAt, 0).UTC().Format(time.DateOnly))
 	}
 
 	return l, nil

--- a/internal/sandbox/bridge_test.go
+++ b/internal/sandbox/bridge_test.go
@@ -135,9 +135,16 @@ func TestBridgeProxy_HandleConnFailsGracefully(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go bp.Serve(ctx)
-	defer bp.Close()
+	serveDone := make(chan struct{})
+	go func() {
+		bp.Serve(ctx)
+		close(serveDone)
+	}()
+	defer func() {
+		cancel()
+		<-serveDone
+		bp.Close()
+	}()
 
 	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", bp.Addr())
 	if err != nil {

--- a/internal/sentry/client.go
+++ b/internal/sentry/client.go
@@ -120,6 +120,19 @@ func (c *Client) CaptureMessage(msg string) {
 	sentry.CaptureMessage(msg)
 }
 
+// AddBreadcrumb records local context for later Sentry events.
+func (c *Client) AddBreadcrumb(category, message, level string, data map[string]any) {
+	if c == nil || !c.enabled {
+		return
+	}
+	sentry.AddBreadcrumb(&sentry.Breadcrumb{
+		Category: category,
+		Message:  message,
+		Level:    sentry.Level(level),
+		Data:     data,
+	})
+}
+
 // Flush waits for queued events to be sent.
 func (c *Client) Flush(timeout time.Duration) bool {
 	if c == nil || !c.enabled {

--- a/internal/sentry/client_test.go
+++ b/internal/sentry/client_test.go
@@ -136,6 +136,7 @@ func TestNilClient_NoPanic(t *testing.T) {
 	// All methods should be safe no-ops on nil receiver.
 	c.CaptureError(errors.New("test"))
 	c.CaptureMessage("test")
+	c.AddBreadcrumb("license", "expiry", "warn", map[string]any{"days": "7"})
 	c.Close()
 	if !c.Flush(0) {
 		t.Error("expected Flush to return true on nil client")
@@ -146,9 +147,37 @@ func TestDisabledClient_NoPanic(t *testing.T) {
 	c := &Client{enabled: false}
 	c.CaptureError(errors.New("test"))
 	c.CaptureMessage("test")
+	c.AddBreadcrumb("license", "expiry", "warn", map[string]any{"days": "7"})
 	c.Close()
 	if !c.Flush(0) {
 		t.Error("expected Flush to return true on disabled client")
+	}
+}
+
+func TestAddBreadcrumbEnabledClient(t *testing.T) {
+	c, transport := initTestClient(t, nil)
+	defer c.Close()
+
+	c.AddBreadcrumb("license", "expiry warning", "warn", map[string]any{
+		"threshold_days": "7",
+		"days_remaining": "6",
+	})
+	c.CaptureMessage("license status changed")
+	_ = c.Flush(time.Second)
+
+	events := transport.Events()
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if len(events[0].Breadcrumbs) != 1 {
+		t.Fatalf("breadcrumbs = %d, want 1", len(events[0].Breadcrumbs))
+	}
+	crumb := events[0].Breadcrumbs[0]
+	if crumb.Category != "license" || crumb.Message != "expiry warning" || crumb.Level != sentry.Level("warn") {
+		t.Fatalf("breadcrumb = %+v, want license warning", crumb)
+	}
+	if crumb.Data["threshold_days"] != "7" || crumb.Data["days_remaining"] != "6" {
+		t.Fatalf("breadcrumb data = %+v, want warning band data", crumb.Data)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add license expiry warning events/output for 30/14/7/1 day renewal bands
- add signed CRL parsing, verification, runtime refresh, and license-status/doctor visibility
- preserve exact signed CRL payload bytes and verify signatures before payload validation
- record license issuance history and revoke all unexpired issued licenses on subscription end
- make issuance persistence atomic with entitlement state and guard stale active events after terminal status
- cache `/crl.json` responses with ETag and Cache-Control
- avoid exposing license IDs in expiry stderr/Sentry paths

## Follow-ups
- add URL-based CRL fetch/staging with jittered polling
- split CRL serving from webhook serving or add independent rate limits
- add CRL serial/transparency chain for rollback detection
- split license and CRL signing keys
- define unpaid/dunning grace policy
- add CRL age/expiry metrics and operator alerting
- document production CRL opt-in expectations and CRL outage behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pipelock license status` command — human and JSON output showing validity, expiry, renewal warnings, and CRL metadata
  * Public CRL endpoint (/crl.json) serving signed revocation lists with caching and ETag support
  * Automatic renewal-warning emitter that prints warnings and persists state

* **Improvements**
  * CRL-aware license verification and enforcement; runtime watcher can fail-closed and stop agent listeners
  * Entitlement store records issuances and revocations; ended subscriptions revoke issued licenses automatically
  * CLI doctor includes license checks and renewal warnings; audit events emitted for revocations and expiry warnings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->