### PR TITLE
Add Conductor signed message foundation

### DIFF
--- a/docs/specs/boss-conductor-audit-sink.md
+++ b/docs/specs/boss-conductor-audit-sink.md
@@ -1,0 +1,767 @@
+# Boss Pipelock Conductor and Audit Sink Design
+
+**Status:** Draft, pre-implementation gate
+**Version:** 0.1.0
+**Date:** 2026-05-23
+
+This document defines the hardened design target for Boss Pipelock, the
+enterprise control plane for Pipelock fleets. It covers the conductor plane
+that distributes signed policy bundles to follower instances and the audit sink
+plane that ingests signed evidence from those instances.
+
+The architecture shape is:
+
+```text
+Boss control plane
+  -> signed policy / emergency control messages
+Pipelock follower instances
+  -> local enforcement, local recorder, local receipts
+  -> signed audit batches
+Boss audit sink
+  -> verification, DLP scanning, append-only ingest, indexed search
+```
+
+Boss is not a scanner and must not become an inline dependency for enforcement.
+Followers continue to enforce locally. Boss coordinates policy distribution,
+evidence operations, fleet visibility, and auditor workflows.
+
+## Goals
+
+- Distribute signed, audience-bound policy bundles to follower instances.
+- Preserve Pipelock capability separation: Boss must not hold agent secrets or
+  scan on behalf of followers.
+- Keep follower enforcement local and fail-closed.
+- Make bundle signing, enrollment, rollback, remote kill, and audit ingest
+  explicit security protocols, not implicit HTTP APIs.
+- Provide a central audit sink that verifies source, schema, chain continuity,
+  and content safety before indexing.
+- Dogfood Pro value through fleet coordination, per-agent budgets, source CIDR
+  binding, central audit search, and auditor export.
+
+## Non-Goals
+
+- No new scanner pipeline.
+- No replacement for local flight recorder or receipt verification.
+- No hosted dependency for local allow/block decisions.
+- No license metadata inside policy bundles in the MVP.
+- No bearer-only follower-to-Boss transport.
+- No single online signing key that can silently compromise the whole fleet.
+
+## Hard MVP Gates
+
+No implementation should start until these are accepted as product/security
+requirements:
+
+1. Bundle signing uses KMS/HSM-backed keys and never stores signing private keys
+   on Boss disk.
+2. Every signed bundle hash is written to an append-only transparency log.
+3. Catastrophic messages require threshold approval and a separate key purpose.
+4. Enrollment is concrete: one-shot token exchange for per-instance mTLS
+   identity and per-instance signing material.
+5. Bundle signed preimages include `org_id`, `fleet_id`, environment, and
+   audience selectors.
+6. Rollback is a first-class signed operation with its own key purpose.
+7. Remote kill switch state is not ordinary bundle state.
+8. License metadata is excluded from policy bundles.
+9. Audit payloads are treated as hostile input even after signature validation.
+10. Follower-to-Boss transport is mTLS.
+
+## Trust Model
+
+### Principals
+
+- `boss-admin`: manages Boss configuration and users.
+- `policy-publisher`: can create policy bundle candidates.
+- `policy-approver`: can countersign catastrophic operations.
+- `follower-instance`: a registered Pipelock deployment.
+- `auditor`: can query and export accepted evidence without changing policy.
+
+### Key Purposes
+
+Each signing key has one purpose. Verifiers reject signatures made with the
+wrong purpose.
+
+| Purpose | Used for | Threshold required |
+|---|---|---|
+| `policy-bundle-signing` | ordinary policy bundle publication | no |
+| `policy-bundle-rollback` | one-shot rollback authorization | yes |
+| `remote-kill-signing` | remote kill switch toggle | yes |
+| `trust-root-rotation` | Boss/fleet trust root changes | yes |
+| `audit-batch-signing` | follower audit batch signatures | no |
+| `receipt-signing` | local follower action receipts/checkpoints | no |
+| `enrollment-token-signing` | one-shot enrollment token minting | no |
+
+Wire form is lowercase-hyphenated. See `internal/signing/key_purpose.go` for the
+canonical KeyPurpose constants and `internal/conductor/messages.go` for use.
+
+Threshold means m-of-n approval with m >= 2. The MVP may implement this as two
+independent Ed25519 signatures over the same canonical preimage, but the schema
+must allow more signatures later.
+
+### Signing Key Lifecycle
+
+Boss signing keys must be backed by KMS/HSM or equivalent external signing
+service. Private key material must not be exportable to Boss process storage.
+
+Requirements:
+
+- Every key has `key_id`, `purpose`, `created_at`, `not_before`, `not_after`,
+  and `revoked_at`.
+- Follower trust rosters pin public keys and accepted purposes.
+- Key rotation is published as a signed trust-root or intermediate update.
+- Followers reject unknown key IDs, wrong-purpose signatures, expired keys, and
+  revoked keys.
+- CRL/trust roster age is exposed as a metric on both Boss and followers.
+
+## Enrollment Protocol
+
+Enrollment bootstraps follower identity. It is not optional.
+
+### Recommended MVP
+
+1. Operator creates a one-shot enrollment token in Boss.
+2. Token includes `org_id`, `fleet_id`, `instance_id`, allowed environment,
+   allowed IP/CIDR hint, expiry, nonce, and token ID.
+3. Token is signed by `enrollment-token-signing`.
+4. Follower starts with the token and Boss trust root.
+5. Follower generates local private keys:
+   - mTLS leaf key
+   - audit batch signing key
+   - optional local receipt signing key if not already configured
+6. Follower calls `POST /api/v1/enroll` over TLS.
+7. Boss verifies token, checks token unused, validates singleton
+   `instance_id`, and issues an mTLS leaf certificate.
+8. Boss stores the follower audit public key and expected instance metadata.
+9. Token is marked consumed permanently.
+10. All future follower calls derive identity from the mTLS certificate, not
+    from request fields.
+
+### Singleton Rule
+
+Boss must prevent silent instance cloning. A second enrollment for an active
+`instance_id` fails unless an admin revokes or rotates the prior identity.
+
+### Rotation
+
+Follower certificates and audit keys rotate through a signed re-enrollment flow:
+
+- Existing mTLS identity authenticates the rotation request.
+- Boss issues a new cert/key binding.
+- Old identity remains accepted for a short overlap window.
+- Both old and new identities are visible in audit logs.
+
+## Transport Surfaces
+
+Boss uses separate listeners:
+
+| Listener | Auth | Purpose |
+|---|---|---|
+| Follower API | mTLS per instance | poll, audit ingest, capabilities, emergency stream |
+| Operator Admin API | bearer/session auth plus IP allowlist | human/admin control |
+| Public Artifact API | public or CDN-gated | public verification keys and transparency artifacts |
+
+Listener addresses are restart-only. This mirrors the existing Pipelock pattern
+for scan API, kill switch API, and metrics listeners.
+
+All HTTP servers must set read header timeouts, read timeouts, write timeouts,
+connection limits, request body caps, and per-instance rate limits.
+
+## Capability Handshake
+
+Follower starts each Boss session with:
+
+```http
+GET /api/v1/conductor/capabilities
+```
+
+Boss returns supported schema ranges:
+
+```json
+{
+  "schema_version": 1,
+  "boss_id": "boss-us-1",
+  "required_mtls": true,
+  "conductor_bundle": {"min": 1, "max": 1},
+  "remote_kill": {"min": 1, "max": 1},
+  "rollback_authorization": {"min": 1, "max": 1},
+  "audit_batch": {"min": 1, "max": 1},
+  "receipt_entry_versions": [2],
+  "max_created_skew_seconds": 60,
+  "emergency_stream": true,
+  "remote_kill_threshold": 2,
+  "rollback_threshold": 2,
+  "trust_rotation_threshold": 2
+}
+```
+
+Follower selects the highest supported intersection. If no audit schema
+intersection exists, audit emission hard-fails locally and emits evidence. It
+must not silently drop Boss-bound audit.
+
+## Policy Bundle
+
+Policy bundles distribute policy content only. License fields are forbidden.
+
+### Bundle Envelope
+
+```json
+{
+  "schema_version": 1,
+  "bundle_id": "uuidv7",
+  "org_id": "org_...",
+  "fleet_id": "fleet_...",
+  "environment": "prod",
+  "audience": {
+    "instance_ids": ["pl-prod-1"],
+    "labels": {"ring": "canary"}
+  },
+  "version": 42,
+  "previous_bundle_hash": "hex",
+  "created_at": "2026-05-23T17:00:00Z",
+  "not_before": "2026-05-23T17:00:00Z",
+  "expires_at": "2026-05-23T18:00:00Z",
+  "min_pipelock_version": "2.6.0",
+  "policy_hash": "canonical-policy-hash",
+  "payload_sha256": "hex",
+  "payload": {
+    "config_yaml": "...",
+    "rules_bundles": []
+  },
+  "signatures": []
+}
+```
+
+### Validation Rules
+
+Follower rejects a bundle if:
+
+- Signature is missing or wrong-purpose.
+- Transparency log inclusion proof is missing or invalid.
+- `org_id`, `fleet_id`, environment, or audience do not match local enrollment.
+- Bundle is expired or not yet valid.
+- Version is lower than local freshness state and no rollback authorization is
+  present.
+- `previous_bundle_hash` does not match local freshness state, except for
+  initial enrollment or authorized rollback.
+- `min_pipelock_version` exceeds follower version by more than the configured
+  sanity window.
+- Payload contains forbidden fields, including license metadata.
+- Config validation fails.
+- Reload would violate restart-only constraints.
+
+### Min Version Sanity
+
+Follower config includes:
+
+```yaml
+conductor:
+  max_min_version_major_skew: 0
+  max_min_version_minor_skew: 1
+```
+
+If a bundle demands a version outside this window, the follower rejects it and
+continues last-known-good. This prevents a signed but mistaken bundle from
+bricking the fleet.
+
+## Remote Kill Switch Message
+
+Remote kill is separate from policy bundles.
+
+```json
+{
+  "schema_version": 1,
+  "message_id": "uuidv7",
+  "org_id": "org_...",
+  "fleet_id": "fleet_...",
+  "audience": {"labels": {"ring": "all"}},
+  "state": "active",
+  "reason": "operator emergency stop",
+  "created_at": "2026-05-23T17:05:00Z",
+  "not_before": "2026-05-23T17:05:00Z",
+  "expires_at": "2026-05-23T17:20:00Z",
+  "counter": 18,
+  "signatures": []
+}
+```
+
+`state` is `"active"` or `"inactive"` (see `KillSwitchState` in
+`internal/conductor/messages.go`). `reason` is capped at `MaxReasonBytes`.
+
+Follower behavior:
+
+- Default `conductor.honor_remote_kill_switch` is false unless a managed-fleet
+  preset explicitly enables it.
+- When disabled, followers reject remote kill messages, emit local evidence, and
+  report the rejection to Boss.
+- When enabled, remote kill messages require `remote-kill-signing` threshold
+  signatures.
+- Accepted remote kill state is OR-composed as a separate kill source.
+- Every accepted, rejected, expired, and superseded remote kill message is
+  written to local recorder evidence with the full signed envelope.
+
+## Emergency Stream
+
+Pure polling is insufficient for emergency state. Followers maintain an
+SSE/long-poll connection on the follower mTLS listener:
+
+```http
+GET /api/v1/conductor/emergency-stream
+```
+
+Only high-urgency message kinds flow through this stream:
+
+- remote kill toggle
+- rollback authorization
+- trust root revocation notice
+
+If the stream disconnects, follower falls back to pull. Pull remains the source
+of truth for ordinary policy bundles.
+
+## Rollback Authorization
+
+Rollback is an explicit operation, not a version exception.
+
+```json
+{
+  "schema_version": 1,
+  "authorization_id": "uuidv7",
+  "org_id": "org_...",
+  "fleet_id": "fleet_...",
+  "audience": {"labels": {"ring": "all"}},
+  "current_bundle_id": "bundle-current",
+  "current_version": 42,
+  "target_bundle_id": "bundle-target",
+  "target_version": 41,
+  "counter": 7,
+  "reason": "bad policy bundle",
+  "created_at": "2026-05-23T17:10:00Z",
+  "expires_at": "2026-05-23T17:25:00Z",
+  "signatures": []
+}
+```
+
+Field names match the `RollbackAuthorization` Go struct. `counter` is the
+single-use authorization counter. `target_version` must be strictly less than
+`current_version` (enforced by `Validate`).
+
+Follower accepts it once, then pins the lower bundle as the new freshness
+baseline. Reuse is rejected and logged as a security event.
+
+## Bundle Apply Pipeline
+
+Follower apply is all-or-nothing:
+
+1. Download bundle to memory under body cap.
+2. Verify canonical signature and transparency inclusion proof.
+3. Validate audience, freshness, TTL, version, and key purpose.
+4. Validate payload does not include forbidden sections.
+5. Write bundle to cache using temp file, fsync, and rename.
+6. Cache directory mode: `0o700`.
+7. Bundle file mode: `0o600`.
+8. Re-read staged bundle from disk.
+9. Re-run signature and payload hash verification.
+10. Write staged config candidate atomically.
+11. Run existing config validation and runtime resolve pipeline.
+12. Call the same reload path used by local config reload.
+13. Surface scanner construction panics and reload failures exactly like
+    file-driven reload.
+14. Record local evidence for accept or reject.
+
+Boss-driven reload must share the same dedup/reload guard as file-driven reload
+to avoid fsnotify and conductor races.
+
+## Stale Bundle Policy
+
+Fail-closed is the default.
+
+Follower config:
+
+```yaml
+conductor:
+  stale_policy:
+    grace_multiplier: 1
+    after_grace: strict_deny_all
+```
+
+Default behavior:
+
+- Before expiry: run active bundle.
+- Expired but within `1x bundle TTL` grace: continue last-known-good and page.
+- After grace: switch to strict fail-closed behavior for conductor-managed
+  policy gaps.
+
+Operators can override this, but overrides must warn at validation time and emit
+local evidence.
+
+## Audit Batcher
+
+Boss-bound audit cannot be a normal `emit.Sink`. The existing emitter ignores
+sink errors by design; a Boss audit transport needs durable retry state and
+explicit drop accounting.
+
+Implement a peer package:
+
+```text
+internal/conductor/auditbatcher
+```
+
+Responsibilities:
+
+- Accept sanitized audit/event/receipt references from runtime paths.
+- Persist batches to a local durable queue.
+- Sign each batch with the follower audit key.
+- Send over follower mTLS transport.
+- Retry with bounded backoff.
+- Track drop reasons explicitly.
+- Never block enforcement decisions.
+
+Local audit batcher failures produce local recorder evidence and metrics.
+
+## Audit Batch Schema
+
+Boss-bound batches require recorder v2 entries. v1 entries are not accepted for
+Boss-bound ingestion because v2 binds `event_kind` into the chain hash.
+
+```json
+{
+  "schema_version": 1,
+  "batch_id": "uuidv7",
+  "org_id": "org_...",
+  "fleet_id": "fleet_...",
+  "instance_id": "pl-prod-1",
+  "audit_schema_version": 2,
+  "emitted_at": "2026-05-23T17:12:01Z",
+  "seq_start": 1000,
+  "seq_end": 1200,
+  "event_count": 201,
+  "payload_sha256": "hex",
+  "payload_bytes": 32768,
+  "dropped": {
+    "count": 3,
+    "reasons": [
+      {"reason": "queue_full", "count": 2},
+      {"reason": "payload_too_large", "count": 1}
+    ]
+  },
+  "chain": {
+    "entry_version": 2,
+    "segment_id": "segment-2026-q2",
+    "seq_start": 1000,
+    "seq_end": 1200,
+    "previous_segment_tail": "hex",
+    "segment_head_hash": "hex",
+    "segment_tail_hash": "hex",
+    "checkpoint_seq": 1199,
+    "checkpoint_hash": "hex",
+    "checkpoint_signature": "ed25519:hex",
+    "checkpoint_signer_key_id": "receipt-key-2026-q2",
+    "follower_recorder_key_id": "instance-recorder-1",
+    "follower_recorder_public_key_hex": "hex"
+  },
+  "signatures": []
+}
+```
+
+Field names match the `AuditBatchEnvelope` Go struct. `payload_bytes` is capped
+at `MaxAuditPayloadBytes` (1 MiB). Boss enforces `|now - emitted_at|` against a
+configured skew via `ValidateForBoss` — see `DefaultAuditMaxSkew` (60s) and
+`MaxAllowedAuditSkew` (300s).
+
+`dropped` is part of the signed envelope so evidence gaps are captured
+cryptographically rather than inferred from Boss-side metrics. When `count` is
+zero, `reasons` must be empty. When `count` is non-zero, reason counts must sum
+exactly to `count`.
+
+### Boss Verification
+
+Boss must:
+
+- Authenticate follower identity from mTLS.
+- Verify batch signature with enrolled follower audit key.
+- Count only cryptographically verified distinct signer keys toward thresholds.
+- Reject instance ID mismatches between cert and payload.
+- Enforce created skew: default 60s, configurable max 300s with warning.
+- Verify schema version intersection.
+- Verify sequence range monotonicity.
+- Detect overlapping sequence ranges with different hashes as a compromise
+  indicator.
+- Verify v2 recorder entry hashes.
+- Verify checkpoint signature with enrolled receipt/checkpoint public key.
+- Stitch segment rotation using previous segment tail and current segment head.
+- DLP-scan payload contents before indexing.
+- Apply per-follower rate, size, and reputation limits.
+- Store raw accepted batch in per-follower namespace.
+- Index only redacted/safe fields into cross-fleet search.
+
+Fork detection is critical severity, not a soft reject.
+
+## Audit Sink as Hostile Input
+
+A compromised follower can produce signed malicious audit batches. Signatures
+prove source, not truth. Boss must treat every field as attacker-controlled.
+
+Controls:
+
+- Strict JSON decoding and unknown-field rejection.
+- Request body caps.
+- Batch entry count caps.
+- Per-follower namespace isolation.
+- DLP and prompt-injection scanning before indexing.
+- Escaping and query-safe indexing for all strings.
+- No cross-fleet query expansion from untrusted event fields.
+- Reputation scoring for malformed, oversized, forked, or DLP-positive batches.
+
+Audit batches are also potential exfiltration channels. Boss must scan for
+secrets before storing or indexing.
+
+## Privacy and Storage
+
+Default storage is redacted. Raw evidence escrow is separate and opt-in.
+
+Storage classes:
+
+- Accepted batch envelope: append-only, per follower.
+- Search index: redacted fields only.
+- Raw escrow: optional encrypted object storage, separate access controls.
+- Transparency log artifacts: public or auditor-visible hashes, no payloads.
+
+App-level append-only is not WORM. Production compliance deployments should use
+WORM-capable storage such as object lock. If unavailable, the system must report
+that immutability is app-enforced only.
+
+## License Boundary
+
+Policy bundles must not carry:
+
+- `license_key`
+- `license_file`
+- `license_public_key`
+- `license_crl_file`
+- runtime-derived license status fields
+
+Reason: current Pipelock canonical policy hashes intentionally exclude license
+metadata, and reload preserves license inputs until restart. Bundling license
+changes would create silent divergence.
+
+A future `LicenseBundle` requires:
+
+- separate schema
+- separate key purpose
+- explicit restart orchestration
+- follower report of pending restart
+- clear operator UX that license behavior has not changed until restart
+
+## Follower Configuration
+
+Draft YAML shape:
+
+```yaml
+conductor:
+  enabled: true
+  boss_url: "https://boss.example.internal"
+  org_id: "org_main"
+  fleet_id: "prod"
+  instance_id: "pl-prod-1"
+  trust_roster_path: "/etc/pipelock/conductor/trust-roster.json"
+  client_cert_path: "/etc/pipelock/conductor/client.crt"
+  client_key_path: "/etc/pipelock/conductor/client.key"
+  bundle_cache_dir: "/var/lib/pipelock/conductor/bundles"
+  durable_audit_queue_dir: "/var/lib/pipelock/conductor/audit-queue"
+  poll_interval: "30s"
+  honor_remote_kill_switch: false
+  created_skew_seconds: 60
+  max_min_version_major_skew: 0
+  max_min_version_minor_skew: 1
+  stale_policy:
+    grace_multiplier: 1
+    after_grace: strict_deny_all
+```
+
+Config validation must reject:
+
+- missing mTLS paths when enabled
+- non-absolute cache paths
+- cache directory paths under world-writable parents
+- `created_skew_seconds > 300`
+- remote kill enabled without trust roster support for threshold signatures
+
+## Boss RBAC
+
+MVP roles:
+
+| Role | Capabilities |
+|---|---|
+| `admin` | manage users, fleets, trust, storage, and listeners |
+| `publisher` | create and stage bundle candidates |
+| `approver` | countersign catastrophic operations |
+| `viewer` | view fleet state and non-sensitive metrics |
+| `auditor` | query/export accepted evidence |
+
+Catastrophic actions require approval by at least two distinct principals:
+
+- remote kill activation/deactivation
+- trust root rotation
+- rollback authorization
+- audit deletion or retention override
+- policy downgrade authorization
+
+## Observability
+
+Boss metrics:
+
+- `conductor_fleet_drift{policy_hash}`
+- `conductor_bundle_apply_latency_seconds`
+- `conductor_audit_lag_seconds`
+- `conductor_signature_verification_failures_total{kind}`
+- `conductor_crl_age_seconds`
+- `conductor_trust_roster_age_seconds`
+- `conductor_poll_last_success_seconds_ago`
+- `conductor_audit_drop_total{reason}`
+- `conductor_audit_fork_detected_total`
+- `conductor_enrollment_failures_total{reason}`
+- `conductor_remote_kill_messages_total{result}`
+
+Follower metrics:
+
+- `pipelock_conductor_active_bundle_age_seconds`
+- `pipelock_conductor_last_successful_poll_seconds_ago`
+- `pipelock_conductor_bundle_apply_total{result,reason}`
+- `pipelock_conductor_remote_kill_total{result}`
+- `pipelock_conductor_audit_queue_depth`
+- `pipelock_conductor_audit_durable_queue_bytes`
+- `pipelock_conductor_audit_drop_total{reason}`
+- `pipelock_conductor_emergency_stream_connected`
+
+Paging defaults:
+
+- follower poll stale beyond one poll interval plus jitter
+- active bundle expired
+- active bundle beyond grace
+- any signature verification failure
+- any audit fork detection
+- audit queue depth above threshold
+- CRL/trust roster too old
+
+## Regionalization
+
+Boss deployments are regional. Default design is no cross-region replication.
+
+- `Boss-US` handles US fleets and US evidence.
+- `Boss-EU` handles EU fleets and EU evidence.
+- Cross-region export requires explicit operator/auditor action.
+- Policy bundles include region/environment audience claims.
+
+## FIPS and Crypto Policy
+
+Default crypto is Ed25519, matching current Pipelock signing primitives. Some
+regulated environments require FIPS 140-3 acceptable algorithms. The MVP must
+document this limitation. A future FIPS build may add ECDSA-P256 key purposes
+and dual-algorithm trust rosters.
+
+## Boss Supply Chain
+
+Boss is the highest-value target in the product line. Its release provenance
+must be stronger than ordinary follower deployment:
+
+- signed container images
+- transparency log entry per release
+- SLSA L3 target
+- reproducible build story
+- SBOM
+- pinned dependencies
+- release attestation verified by deployment tooling
+
+## Implementation Phases
+
+### Phase 0: Spec and Schema
+
+- Define bundle, rollback, remote kill, enrollment, and audit batch schemas.
+- Add canonical preimage tests and golden vectors.
+- Add key-purpose validation.
+- Add explicit license-field rejection tests.
+- Add threat model docs.
+
+### Phase 1: Follower Skeleton
+
+- Add follower config schema and validation.
+- Implement capability handshake.
+- Implement bundle polling and verification without applying.
+- Implement local evidence for accepted/rejected messages.
+- Add metrics.
+
+### Phase 2: Atomic Apply
+
+- Add durable bundle cache.
+- Wire verified bundle payload into existing reload path.
+- Add stale bundle state machine.
+- Add rollback authorization support.
+
+### Phase 3: Boss Server MVP
+
+- Add follower mTLS listener.
+- Add admin listener with RBAC skeleton.
+- Add enrollment endpoint.
+- Add bundle publication and latest-bundle endpoint.
+- Add transparency log integration or local append-only transparency prototype.
+
+### Phase 4: Audit Batcher and Sink
+
+- Add durable follower audit batcher.
+- Add Boss audit ingest endpoint.
+- Add DLP-before-indexing.
+- Add fork detection.
+- Add per-follower storage namespace.
+
+### Phase 5: Emergency Stream and Catastrophic Actions
+
+- Add SSE/long-poll emergency stream.
+- Add threshold signatures for remote kill and rollback.
+- Add two-person approval workflow.
+
+## Test Matrix
+
+Required test coverage:
+
+- Wrong-purpose signatures are rejected.
+- Expired keys are rejected.
+- Revoked keys are rejected.
+- Bundle for staging is rejected by prod follower.
+- Bundle with license fields is rejected.
+- Rollback without authorization is rejected.
+- Rollback authorization is single-use.
+- Remote kill is rejected when `honor_remote_kill_switch` is false.
+- Remote kill without threshold signatures is rejected.
+- Bundle apply is atomic under partial write.
+- Bundle apply uses existing reload panic handling.
+- Boss audit ingest rejects v1 recorder entries.
+- Boss audit ingest detects sequence forks.
+- Boss audit ingest verifies checkpoint signatures.
+- Boss audit ingest DLP-scans payload before indexing.
+- Follower identity is derived from mTLS, not payload `instance_id`.
+- Enrollment token reuse fails.
+- Duplicate active `instance_id` enrollment fails.
+- Audit schema mismatch hard-fails.
+- Canonical preimage is byte-identical across producer timezones.
+- Canonical preimage changes when any policy-semantic field changes.
+- Nested license fields under any submap are rejected with a path-tagged error.
+- `MinPipelockVersion` is required and must be `major.minor.patch`.
+- `ValidateAtTime` rejects bundles outside `[NotBefore, ExpiresAt]`.
+- `ValidateForBoss` rejects audit batches outside `±DefaultAuditMaxSkew`.
+- `Audience` rejects `"*"` mixed with explicit instance IDs.
+- Capability handshake advertises all message schema ranges, mTLS requirement,
+  v2 receipt entries, skew ceiling, and catastrophic thresholds.
+- Audit batch dropped accounting is signed and internally consistent.
+- Signature verification rejects tampered preimages, wrong roster purposes, and
+  missing threshold signers.
+- Signed-message identifiers are bounded and restricted to a safe wire charset.
+
+## Open Decisions
+
+- Transparency log implementation: external Rekor-style service, embedded
+  append-only log, or both.
+- KMS/HSM provider abstraction and minimum supported provider.
+- Exact trust roster file format.
+- Whether local follower receipt signing key is reused for checkpoints or a
+  separate checkpoint key is required.
+- Whether FIPS support is a documented limitation or a near-term build target.
+- WORM storage backend for first enterprise deployment.

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -1,10 +1,10 @@
-# Boss Pipelock Conductor and Audit Sink Design
+# Pipelock Conductor and Audit Sink Design
 
 **Status:** Draft, pre-implementation gate
 **Version:** 0.1.0
 **Date:** 2026-05-23
 
-This document defines the hardened design target for Boss Pipelock, the
+This document defines the hardened design target for Pipelock Conductor, the
 enterprise control plane for Pipelock fleets. It covers the conductor plane
 that distributes signed policy bundles to follower instances and the audit sink
 plane that ingests signed evidence from those instances.
@@ -12,23 +12,23 @@ plane that ingests signed evidence from those instances.
 The architecture shape is:
 
 ```text
-Boss control plane
+Conductor control plane
   -> signed policy / emergency control messages
 Pipelock follower instances
   -> local enforcement, local recorder, local receipts
   -> signed audit batches
-Boss audit sink
+Conductor audit sink
   -> verification, DLP scanning, append-only ingest, indexed search
 ```
 
-Boss is not a scanner and must not become an inline dependency for enforcement.
-Followers continue to enforce locally. Boss coordinates policy distribution,
+Conductor is not a scanner and must not become an inline dependency for enforcement.
+Followers continue to enforce locally. Conductor coordinates policy distribution,
 evidence operations, fleet visibility, and auditor workflows.
 
 ## Goals
 
 - Distribute signed, audience-bound policy bundles to follower instances.
-- Preserve Pipelock capability separation: Boss must not hold agent secrets or
+- Preserve Pipelock capability separation: Conductor must not hold agent secrets or
   scan on behalf of followers.
 - Keep follower enforcement local and fail-closed.
 - Make bundle signing, enrollment, rollback, remote kill, and audit ingest
@@ -44,7 +44,7 @@ evidence operations, fleet visibility, and auditor workflows.
 - No replacement for local flight recorder or receipt verification.
 - No hosted dependency for local allow/block decisions.
 - No license metadata inside policy bundles in the MVP.
-- No bearer-only follower-to-Boss transport.
+- No bearer-only follower-to-Conductor transport.
 - No single online signing key that can silently compromise the whole fleet.
 
 ## Hard MVP Gates
@@ -53,7 +53,7 @@ No implementation should start until these are accepted as product/security
 requirements:
 
 1. Bundle signing uses KMS/HSM-backed keys and never stores signing private keys
-   on Boss disk.
+   on Conductor disk.
 2. Every signed bundle hash is written to an append-only transparency log.
 3. Catastrophic messages require threshold approval and a separate key purpose.
 4. Enrollment is concrete: one-shot token exchange for per-instance mTLS
@@ -64,13 +64,13 @@ requirements:
 7. Remote kill switch state is not ordinary bundle state.
 8. License metadata is excluded from policy bundles.
 9. Audit payloads are treated as hostile input even after signature validation.
-10. Follower-to-Boss transport is mTLS.
+10. Follower-to-Conductor transport is mTLS.
 
 ## Trust Model
 
 ### Principals
 
-- `boss-admin`: manages Boss configuration and users.
+- `conductor-admin`: manages Conductor configuration and users.
 - `policy-publisher`: can create policy bundle candidates.
 - `policy-approver`: can countersign catastrophic operations.
 - `follower-instance`: a registered Pipelock deployment.
@@ -86,7 +86,7 @@ wrong purpose.
 | `policy-bundle-signing` | ordinary policy bundle publication | no |
 | `policy-bundle-rollback` | one-shot rollback authorization | yes |
 | `remote-kill-signing` | remote kill switch toggle | yes |
-| `trust-root-rotation` | Boss/fleet trust root changes | yes |
+| `trust-root-rotation` | Conductor/fleet trust root changes | yes |
 | `audit-batch-signing` | follower audit batch signatures | no |
 | `receipt-signing` | local follower action receipts/checkpoints | no |
 | `enrollment-token-signing` | one-shot enrollment token minting | no |
@@ -100,8 +100,8 @@ must allow more signatures later.
 
 ### Signing Key Lifecycle
 
-Boss signing keys must be backed by KMS/HSM or equivalent external signing
-service. Private key material must not be exportable to Boss process storage.
+Conductor signing keys must be backed by KMS/HSM or equivalent external signing
+service. Private key material must not be exportable to Conductor process storage.
 
 Requirements:
 
@@ -111,7 +111,7 @@ Requirements:
 - Key rotation is published as a signed trust-root or intermediate update.
 - Followers reject unknown key IDs, wrong-purpose signatures, expired keys, and
   revoked keys.
-- CRL/trust roster age is exposed as a metric on both Boss and followers.
+- CRL/trust roster age is exposed as a metric on both Conductor and followers.
 
 ## Enrollment Protocol
 
@@ -119,26 +119,26 @@ Enrollment bootstraps follower identity. It is not optional.
 
 ### Recommended MVP
 
-1. Operator creates a one-shot enrollment token in Boss.
+1. Operator creates a one-shot enrollment token in Conductor.
 2. Token includes `org_id`, `fleet_id`, `instance_id`, allowed environment,
    allowed IP/CIDR hint, expiry, nonce, and token ID.
 3. Token is signed by `enrollment-token-signing`.
-4. Follower starts with the token and Boss trust root.
+4. Follower starts with the token and Conductor trust root.
 5. Follower generates local private keys:
    - mTLS leaf key
    - audit batch signing key
    - optional local receipt signing key if not already configured
 6. Follower calls `POST /api/v1/enroll` over TLS.
-7. Boss verifies token, checks token unused, validates singleton
+7. Conductor verifies token, checks token unused, validates singleton
    `instance_id`, and issues an mTLS leaf certificate.
-8. Boss stores the follower audit public key and expected instance metadata.
+8. Conductor stores the follower audit public key and expected instance metadata.
 9. Token is marked consumed permanently.
 10. All future follower calls derive identity from the mTLS certificate, not
     from request fields.
 
 ### Singleton Rule
 
-Boss must prevent silent instance cloning. A second enrollment for an active
+Conductor must prevent silent instance cloning. A second enrollment for an active
 `instance_id` fails unless an admin revokes or rotates the prior identity.
 
 ### Rotation
@@ -146,13 +146,13 @@ Boss must prevent silent instance cloning. A second enrollment for an active
 Follower certificates and audit keys rotate through a signed re-enrollment flow:
 
 - Existing mTLS identity authenticates the rotation request.
-- Boss issues a new cert/key binding.
+- Conductor issues a new cert/key binding.
 - Old identity remains accepted for a short overlap window.
 - Both old and new identities are visible in audit logs.
 
 ## Transport Surfaces
 
-Boss uses separate listeners:
+Conductor uses separate listeners:
 
 | Listener | Auth | Purpose |
 |---|---|---|
@@ -168,18 +168,18 @@ connection limits, request body caps, and per-instance rate limits.
 
 ## Capability Handshake
 
-Follower starts each Boss session with:
+Follower starts each Conductor session with:
 
 ```http
 GET /api/v1/conductor/capabilities
 ```
 
-Boss returns supported schema ranges:
+Conductor returns supported schema ranges:
 
 ```json
 {
   "schema_version": 1,
-  "boss_id": "boss-us-1",
+  "conductor_id": "conductor-us-1",
   "required_mtls": true,
   "conductor_bundle": {"min": 1, "max": 1},
   "remote_kill": {"min": 1, "max": 1},
@@ -196,7 +196,7 @@ Boss returns supported schema ranges:
 
 Follower selects the highest supported intersection. If no audit schema
 intersection exists, audit emission hard-fails locally and emits evidence. It
-must not silently drop Boss-bound audit.
+must not silently drop Conductor-bound audit.
 
 ## Policy Bundle
 
@@ -211,10 +211,7 @@ Policy bundles distribute policy content only. License fields are forbidden.
   "org_id": "org_...",
   "fleet_id": "fleet_...",
   "environment": "prod",
-  "audience": {
-    "instance_ids": ["pl-prod-1"],
-    "labels": {"ring": "canary"}
-  },
+  "audience": {"labels": {"ring": "canary"}},
   "version": 42,
   "previous_bundle_hash": "hex",
   "created_at": "2026-05-23T17:00:00Z",
@@ -225,7 +222,7 @@ Policy bundles distribute policy content only. License fields are forbidden.
   "payload_sha256": "hex",
   "payload": {
     "config_yaml": "...",
-    "rules_bundles": []
+    "rule_bundles": []
   },
   "signatures": []
 }
@@ -243,6 +240,8 @@ Follower rejects a bundle if:
   present.
 - `previous_bundle_hash` does not match local freshness state, except for
   initial enrollment or authorized rollback.
+- `payload_sha256` does not match the canonicalized `payload`.
+- `policy_hash` does not match the canonicalized policy representation.
 - `min_pipelock_version` exceeds follower version by more than the configured
   sanity window.
 - Payload contains forbidden fields, including license metadata.
@@ -285,14 +284,15 @@ Remote kill is separate from policy bundles.
 ```
 
 `state` is `"active"` or `"inactive"` (see `KillSwitchState` in
-`internal/conductor/messages.go`). `reason` is capped at `MaxReasonBytes`.
+`internal/conductor/messages.go`). `reason` is capped at `MaxReasonBytes` and
+must not contain control characters.
 
 Follower behavior:
 
 - Default `conductor.honor_remote_kill_switch` is false unless a managed-fleet
   preset explicitly enables it.
 - When disabled, followers reject remote kill messages, emit local evidence, and
-  report the rejection to Boss.
+  report the rejection to Conductor.
 - When enabled, remote kill messages require `remote-kill-signing` threshold
   signatures.
 - Accepted remote kill state is OR-composed as a separate kill source.
@@ -367,7 +367,7 @@ Follower apply is all-or-nothing:
     file-driven reload.
 14. Record local evidence for accept or reject.
 
-Boss-driven reload must share the same dedup/reload guard as file-driven reload
+Conductor-driven reload must share the same dedup/reload guard as file-driven reload
 to avoid fsnotify and conductor races.
 
 ## Stale Bundle Policy
@@ -395,8 +395,8 @@ local evidence.
 
 ## Audit Batcher
 
-Boss-bound audit cannot be a normal `emit.Sink`. The existing emitter ignores
-sink errors by design; a Boss audit transport needs durable retry state and
+Conductor-bound audit cannot be a normal `emit.Sink`. The existing emitter ignores
+sink errors by design; a Conductor audit transport needs durable retry state and
 explicit drop accounting.
 
 Implement a peer package:
@@ -419,8 +419,8 @@ Local audit batcher failures produce local recorder evidence and metrics.
 
 ## Audit Batch Schema
 
-Boss-bound batches require recorder v2 entries. v1 entries are not accepted for
-Boss-bound ingestion because v2 binds `event_kind` into the chain hash.
+Conductor-bound batches require recorder v2 entries. v1 entries are not accepted for
+Conductor-bound ingestion because v2 binds `event_kind` into the chain hash.
 
 ```json
 {
@@ -463,21 +463,24 @@ Boss-bound ingestion because v2 binds `event_kind` into the chain hash.
 ```
 
 Field names match the `AuditBatchEnvelope` Go struct. `payload_bytes` is capped
-at `MaxAuditPayloadBytes` (1 MiB). Boss enforces `|now - emitted_at|` against a
-configured skew via `ValidateForBoss` — see `DefaultAuditMaxSkew` (60s) and
-`MaxAllowedAuditSkew` (300s).
+at `MaxAuditPayloadBytes` (1 MiB). Conductor enforces `|now - emitted_at|` against a
+configured skew via `ValidateForConductor` — see `DefaultAuditMaxSkew` (60s) and
+`MaxAllowedAuditSkew` (300s). Ingest handlers must validate the envelope and
+payload together with `ValidateForConductorWithPayload` before DLP scanning,
+storage, or indexing.
 
 `dropped` is part of the signed envelope so evidence gaps are captured
-cryptographically rather than inferred from Boss-side metrics. When `count` is
+cryptographically rather than inferred from Conductor-side metrics. When `count` is
 zero, `reasons` must be empty. When `count` is non-zero, reason counts must sum
 exactly to `count`.
 
-### Boss Verification
+### Conductor Verification
 
-Boss must:
+Conductor must:
 
 - Authenticate follower identity from mTLS.
 - Verify batch signature with enrolled follower audit key.
+- Verify `len(payload) == payload_bytes` and `sha256(payload) == payload_sha256`.
 - Count only cryptographically verified distinct signer keys toward thresholds.
 - Reject instance ID mismatches between cert and payload.
 - Enforce created skew: default 60s, configurable max 300s with warning.
@@ -498,7 +501,7 @@ Fork detection is critical severity, not a soft reject.
 ## Audit Sink as Hostile Input
 
 A compromised follower can produce signed malicious audit batches. Signatures
-prove source, not truth. Boss must treat every field as attacker-controlled.
+prove source, not truth. Conductor must treat every field as attacker-controlled.
 
 Controls:
 
@@ -511,7 +514,7 @@ Controls:
 - No cross-fleet query expansion from untrusted event fields.
 - Reputation scoring for malformed, oversized, forked, or DLP-positive batches.
 
-Audit batches are also potential exfiltration channels. Boss must scan for
+Audit batches are also potential exfiltration channels. Conductor must scan for
 secrets before storing or indexing.
 
 ## Privacy and Storage
@@ -558,7 +561,7 @@ Draft YAML shape:
 ```yaml
 conductor:
   enabled: true
-  boss_url: "https://boss.example.internal"
+  conductor_url: "https://conductor.example.internal"
   org_id: "org_main"
   fleet_id: "prod"
   instance_id: "pl-prod-1"
@@ -585,7 +588,7 @@ Config validation must reject:
 - `created_skew_seconds > 300`
 - remote kill enabled without trust roster support for threshold signatures
 
-## Boss RBAC
+## Conductor RBAC
 
 MVP roles:
 
@@ -607,7 +610,7 @@ Catastrophic actions require approval by at least two distinct principals:
 
 ## Observability
 
-Boss metrics:
+Conductor metrics:
 
 - `conductor_fleet_drift{policy_hash}`
 - `conductor_bundle_apply_latency_seconds`
@@ -644,10 +647,10 @@ Paging defaults:
 
 ## Regionalization
 
-Boss deployments are regional. Default design is no cross-region replication.
+Conductor deployments are regional. Default design is no cross-region replication.
 
-- `Boss-US` handles US fleets and US evidence.
-- `Boss-EU` handles EU fleets and EU evidence.
+- `Conductor-US` handles US fleets and US evidence.
+- `Conductor-EU` handles EU fleets and EU evidence.
 - Cross-region export requires explicit operator/auditor action.
 - Policy bundles include region/environment audience claims.
 
@@ -658,9 +661,9 @@ regulated environments require FIPS 140-3 acceptable algorithms. The MVP must
 document this limitation. A future FIPS build may add ECDSA-P256 key purposes
 and dual-algorithm trust rosters.
 
-## Boss Supply Chain
+## Conductor Supply Chain
 
-Boss is the highest-value target in the product line. Its release provenance
+Conductor is the highest-value target in the product line. Its release provenance
 must be stronger than ordinary follower deployment:
 
 - signed container images
@@ -696,7 +699,7 @@ must be stronger than ordinary follower deployment:
 - Add stale bundle state machine.
 - Add rollback authorization support.
 
-### Phase 3: Boss Server MVP
+### Phase 3: Conductor Server MVP
 
 - Add follower mTLS listener.
 - Add admin listener with RBAC skeleton.
@@ -707,7 +710,7 @@ must be stronger than ordinary follower deployment:
 ### Phase 4: Audit Batcher and Sink
 
 - Add durable follower audit batcher.
-- Add Boss audit ingest endpoint.
+- Add Conductor audit ingest endpoint.
 - Add DLP-before-indexing.
 - Add fork detection.
 - Add per-follower storage namespace.
@@ -731,23 +734,27 @@ Required test coverage:
 - Rollback authorization is single-use.
 - Remote kill is rejected when `honor_remote_kill_switch` is false.
 - Remote kill without threshold signatures is rejected.
+- Remote kill and rollback reasons reject control characters.
 - Bundle apply is atomic under partial write.
 - Bundle apply uses existing reload panic handling.
-- Boss audit ingest rejects v1 recorder entries.
-- Boss audit ingest detects sequence forks.
-- Boss audit ingest verifies checkpoint signatures.
-- Boss audit ingest DLP-scans payload before indexing.
+- Conductor audit ingest rejects v1 recorder entries.
+- Conductor audit ingest detects sequence forks.
+- Conductor audit ingest verifies checkpoint signatures.
+- Conductor audit ingest DLP-scans payload before indexing.
 - Follower identity is derived from mTLS, not payload `instance_id`.
 - Enrollment token reuse fails.
 - Duplicate active `instance_id` enrollment fails.
 - Audit schema mismatch hard-fails.
 - Canonical preimage is byte-identical across producer timezones.
 - Canonical preimage changes when any policy-semantic field changes.
+- Policy bundles reject `policy_hash` and `payload_sha256` mismatches.
 - Nested license fields under any submap are rejected with a path-tagged error.
 - `MinPipelockVersion` is required and must be `major.minor.patch`.
 - `ValidateAtTime` rejects bundles outside `[NotBefore, ExpiresAt]`.
-- `ValidateForBoss` rejects audit batches outside `±DefaultAuditMaxSkew`.
+- `ValidateForConductor` rejects audit batches outside `±DefaultAuditMaxSkew`.
+- `ValidateForConductorWithPayload` rejects payload length/hash mismatches.
 - `Audience` rejects `"*"` mixed with explicit instance IDs.
+- `Audience` rejects mixed `instance_ids` and `labels`.
 - Capability handshake advertises all message schema ranges, mTLS requirement,
   v2 receipt entries, skew ceiling, and catastrophic thresholds.
 - Audit batch dropped accounting is signed and internally consistent.

--- a/internal/conductor/messages.go
+++ b/internal/conductor/messages.go
@@ -158,7 +158,9 @@ func (p PolicyBundlePayload) PolicyHash() (string, error) {
 	}
 	var extra yaml.Node
 	if err := decoder.Decode(&extra); err == nil {
-		return "", fmt.Errorf("%w: config_yaml has multiple YAML documents", ErrInvalidHash)
+		if !isEmptyYAMLDocument(extra) {
+			return "", fmt.Errorf("%w: config_yaml has multiple YAML documents", ErrInvalidHash)
+		}
 	} else if !errors.Is(err, io.EOF) {
 		return "", fmt.Errorf("parse policy bundle config_yaml trailing document: %w", err)
 	}
@@ -1290,8 +1292,19 @@ func rejectExtraYAMLDocuments(dec *yaml.Decoder) error {
 	if err != nil {
 		return fmt.Errorf("%w: parse config payload: %w", ErrForbiddenLicenseField, err)
 	}
-	if len(extra.Content) != 0 {
+	if !isEmptyYAMLDocument(extra) {
 		return fmt.Errorf("%w: multiple YAML documents", ErrForbiddenLicenseField)
 	}
 	return nil
+}
+
+func isEmptyYAMLDocument(n yaml.Node) bool {
+	if len(n.Content) == 0 {
+		return true
+	}
+	if n.Kind != yaml.DocumentNode || len(n.Content) != 1 {
+		return false
+	}
+	child := n.Content[0]
+	return child.Kind == yaml.ScalarNode && child.Tag == "!!null" && child.Value == ""
 }

--- a/internal/conductor/messages.go
+++ b/internal/conductor/messages.go
@@ -1,0 +1,1202 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package conductor defines Boss/Conductor signed message bodies.
+package conductor
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	SchemaVersion               = 1
+	SignatureAlgorithmEd25519   = "ed25519"
+	SignaturePrefixEd25519      = "ed25519:"
+	RequiredStandardSigners     = 1
+	RequiredCatastrophicSigners = 2
+	MaxAuditPayloadBytes        = 1024 * 1024
+	MaxConfigYAMLBytes          = 256 * 1024
+	MaxReasonBytes              = 4 * 1024
+	DefaultAuditMaxSkew         = 60 * time.Second
+	MaxAllowedAuditSkew         = 300 * time.Second
+	MaxIDBytes                  = 128
+	MaxLabelKeyBytes            = 128
+	MaxLabelValueBytes          = 256
+	MaxDropReasons              = 32
+	MaxDropReasonBytes          = 128
+	MaxCapabilityThreshold      = 7
+)
+
+// acceptedSchemaVersions mirrors internal/recorder/entry.go's v1+v2 coexistence
+// pattern. New writes use SchemaVersion; verifiers accept anything in the set so
+// rolling fleet upgrades survive a schema bump. Extend by adding the new version
+// key when the schema changes — never remove old keys without a release-note
+// gate on rollout.
+var acceptedSchemaVersions = map[int]bool{1: true}
+
+var (
+	ErrUnsupportedSchemaVersion = errors.New("unsupported conductor schema_version")
+	ErrMissingField             = errors.New("missing required conductor field")
+	ErrInvalidAudience          = errors.New("invalid conductor audience")
+	ErrAudienceMismatch         = errors.New("conductor audience does not match follower")
+	ErrInvalidHash              = errors.New("invalid conductor hash")
+	ErrInvalidSignature         = errors.New("invalid conductor signature")
+	ErrWrongKeyPurpose          = errors.New("conductor signature key_purpose mismatch")
+	ErrThresholdRequired        = errors.New("conductor signature threshold not met")
+	ErrForbiddenLicenseField    = errors.New("policy bundle contains forbidden license field")
+	ErrInvalidValidityWindow    = errors.New("invalid conductor validity window")
+	ErrInvalidSequenceRange     = errors.New("invalid conductor sequence range")
+	ErrInvalidState             = errors.New("invalid conductor state")
+	ErrInvalidRollback          = errors.New("invalid conductor rollback authorization")
+	ErrNotYetValid              = errors.New("conductor message not yet valid (not_before in future)")
+	ErrExpired                  = errors.New("conductor message expired")
+	ErrSkewExceeded             = errors.New("conductor message exceeds allowed clock skew")
+	ErrInvalidMinVersion        = errors.New("invalid min_pipelock_version")
+	ErrPayloadTooLarge          = errors.New("conductor payload exceeds size cap")
+	ErrInvalidAudienceWildcard  = errors.New("conductor audience cannot mix wildcard with explicit instance_ids")
+	ErrInvalidIdentifier        = errors.New("invalid conductor identifier")
+	ErrSignatureVerification    = errors.New("conductor signature verification failed")
+	ErrInvalidDroppedAccounting = errors.New("invalid conductor dropped accounting")
+)
+
+var forbiddenLicenseFields = map[string]struct{}{
+	"license_key":               {},
+	"license_file":              {},
+	"license_crl_file":          {},
+	"license_public_key":        {},
+	"license_expires_at":        {},
+	"license_id":                {},
+	"license_crl_expires_at":    {},
+	"license_crl_sha256":        {},
+	"license_revoked":           {},
+	"license_revocation_reason": {},
+}
+
+// SignatureKey carries the verification material plus the lifecycle metadata
+// the spec mandates ("key_id, purpose, created_at, not_before, not_after,
+// revoked_at"). The roster must populate NotBefore/NotAfter for every key; an
+// unset NotAfter is treated as never-expires. RevokedAt set to a non-nil
+// timestamp causes verification to reject regardless of the other windows.
+type SignatureKey struct {
+	PublicKey  ed25519.PublicKey
+	KeyPurpose signing.KeyPurpose
+	NotBefore  time.Time
+	NotAfter   time.Time
+	RevokedAt  *time.Time
+}
+
+// SignatureKeyResolver maps a signer key ID to its roster entry. Today the
+// verifier calls the resolver serially per signature, so simple map-based
+// resolvers without locks are safe. Implementations must remain safe under
+// concurrent invocation: future parallel-verify paths cannot break a resolver
+// that today assumes single-threaded calls.
+type SignatureKeyResolver func(signerKeyID string) (SignatureKey, error)
+
+type SignatureProof struct {
+	SignerKeyID string             `json:"signer_key_id"`
+	KeyPurpose  signing.KeyPurpose `json:"key_purpose"`
+	Algorithm   string             `json:"algorithm"`
+	Signature   string             `json:"signature"`
+}
+
+type Audience struct {
+	InstanceIDs []string          `json:"instance_ids,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+}
+
+type DroppedReason struct {
+	Reason string `json:"reason"`
+	Count  uint64 `json:"count"`
+}
+
+type DroppedAccounting struct {
+	Count   uint64          `json:"count"`
+	Reasons []DroppedReason `json:"reasons,omitempty"`
+}
+
+type RuleBundleRef struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	SHA256  string `json:"sha256"`
+}
+
+type PolicyBundlePayload struct {
+	ConfigYAML  string          `json:"config_yaml"`
+	RuleBundles []RuleBundleRef `json:"rule_bundles,omitempty"`
+}
+
+type PolicyBundle struct {
+	SchemaVersion      int                 `json:"schema_version"`
+	BundleID           string              `json:"bundle_id"`
+	OrgID              string              `json:"org_id"`
+	FleetID            string              `json:"fleet_id"`
+	Environment        string              `json:"environment"`
+	Audience           Audience            `json:"audience"`
+	Version            uint64              `json:"version"`
+	PreviousBundleHash string              `json:"previous_bundle_hash,omitempty"`
+	CreatedAt          time.Time           `json:"created_at"`
+	NotBefore          time.Time           `json:"not_before"`
+	ExpiresAt          time.Time           `json:"expires_at"`
+	MinPipelockVersion string              `json:"min_pipelock_version"`
+	PolicyHash         string              `json:"policy_hash"`
+	PayloadSHA256      string              `json:"payload_sha256"`
+	Payload            PolicyBundlePayload `json:"payload"`
+	Signatures         []SignatureProof    `json:"signatures,omitempty"`
+}
+
+type KillSwitchState string
+
+const (
+	KillSwitchInactive KillSwitchState = "inactive"
+	KillSwitchActive   KillSwitchState = "active"
+)
+
+type RemoteKillMessage struct {
+	SchemaVersion int              `json:"schema_version"`
+	MessageID     string           `json:"message_id"`
+	OrgID         string           `json:"org_id"`
+	FleetID       string           `json:"fleet_id"`
+	Audience      Audience         `json:"audience"`
+	State         KillSwitchState  `json:"state"`
+	Counter       uint64           `json:"counter"`
+	Reason        string           `json:"reason"`
+	CreatedAt     time.Time        `json:"created_at"`
+	NotBefore     time.Time        `json:"not_before"`
+	ExpiresAt     time.Time        `json:"expires_at"`
+	Signatures    []SignatureProof `json:"signatures,omitempty"`
+}
+
+type RollbackAuthorization struct {
+	SchemaVersion   int              `json:"schema_version"`
+	AuthorizationID string           `json:"authorization_id"`
+	OrgID           string           `json:"org_id"`
+	FleetID         string           `json:"fleet_id"`
+	Audience        Audience         `json:"audience"`
+	CurrentBundleID string           `json:"current_bundle_id"`
+	CurrentVersion  uint64           `json:"current_version"`
+	TargetBundleID  string           `json:"target_bundle_id"`
+	TargetVersion   uint64           `json:"target_version"`
+	Counter         uint64           `json:"counter"`
+	Reason          string           `json:"reason"`
+	CreatedAt       time.Time        `json:"created_at"`
+	ExpiresAt       time.Time        `json:"expires_at"`
+	Signatures      []SignatureProof `json:"signatures,omitempty"`
+}
+
+type EvidenceChain struct {
+	EntryVersion           int    `json:"entry_version"`
+	SegmentID              string `json:"segment_id"`
+	SeqStart               uint64 `json:"seq_start"`
+	SeqEnd                 uint64 `json:"seq_end"`
+	PreviousSegmentTail    string `json:"previous_segment_tail,omitempty"`
+	SegmentHeadHash        string `json:"segment_head_hash"`
+	SegmentTailHash        string `json:"segment_tail_hash"`
+	CheckpointSeq          uint64 `json:"checkpoint_seq"`
+	CheckpointHash         string `json:"checkpoint_hash"`
+	CheckpointSignature    string `json:"checkpoint_signature"`
+	CheckpointSignerKeyID  string `json:"checkpoint_signer_key_id"`
+	FollowerRecorderKeyID  string `json:"follower_recorder_key_id"`
+	FollowerRecorderPubHex string `json:"follower_recorder_public_key_hex"`
+}
+
+type AuditBatchEnvelope struct {
+	SchemaVersion      int               `json:"schema_version"`
+	BatchID            string            `json:"batch_id"`
+	OrgID              string            `json:"org_id"`
+	FleetID            string            `json:"fleet_id"`
+	InstanceID         string            `json:"instance_id"`
+	AuditSchemaVersion int               `json:"audit_schema_version"`
+	EmittedAt          time.Time         `json:"emitted_at"`
+	SeqStart           uint64            `json:"seq_start"`
+	SeqEnd             uint64            `json:"seq_end"`
+	EventCount         uint64            `json:"event_count"`
+	PayloadSHA256      string            `json:"payload_sha256"`
+	PayloadBytes       uint64            `json:"payload_bytes"`
+	Dropped            DroppedAccounting `json:"dropped"`
+	Chain              EvidenceChain     `json:"chain"`
+	Signatures         []SignatureProof  `json:"signatures,omitempty"`
+}
+
+type SchemaRange struct {
+	Min int `json:"min"`
+	Max int `json:"max"`
+}
+
+type CapabilitiesResponse struct {
+	SchemaVersion          int         `json:"schema_version"`
+	BossID                 string      `json:"boss_id"`
+	RequiredMTLS           bool        `json:"required_mtls"`
+	ConductorBundle        SchemaRange `json:"conductor_bundle"`
+	RemoteKill             SchemaRange `json:"remote_kill"`
+	RollbackAuthorization  SchemaRange `json:"rollback_authorization"`
+	AuditBatch             SchemaRange `json:"audit_batch"`
+	ReceiptEntryVersions   []int       `json:"receipt_entry_versions"`
+	MaxCreatedSkewSeconds  int         `json:"max_created_skew_seconds"`
+	EmergencyStream        bool        `json:"emergency_stream"`
+	RemoteKillThreshold    int         `json:"remote_kill_threshold"`
+	RollbackThreshold      int         `json:"rollback_threshold"`
+	TrustRotationThreshold int         `json:"trust_rotation_threshold"`
+}
+
+func (p SignatureProof) Validate(required signing.KeyPurpose) error {
+	if strings.TrimSpace(p.SignerKeyID) == "" {
+		return fmt.Errorf("%w: signature.signer_key_id", ErrMissingField)
+	}
+	if err := validateIdentifier("signature.signer_key_id", p.SignerKeyID); err != nil {
+		return err
+	}
+	if p.Algorithm != SignatureAlgorithmEd25519 {
+		return fmt.Errorf("%w: algorithm=%q", ErrInvalidSignature, p.Algorithm)
+	}
+	if err := p.KeyPurpose.Validate(); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidSignature, err)
+	}
+	if p.KeyPurpose != required {
+		return fmt.Errorf("%w: required=%q got=%q", ErrWrongKeyPurpose, required, p.KeyPurpose)
+	}
+	if err := validateEd25519SignatureString(p.Signature); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a Audience) Validate() error {
+	if len(a.InstanceIDs) == 0 && len(a.Labels) == 0 {
+		return fmt.Errorf("%w: empty audience", ErrInvalidAudience)
+	}
+	wildcard := false
+	for _, id := range a.InstanceIDs {
+		if strings.TrimSpace(id) == "" {
+			return fmt.Errorf("%w: empty instance_id", ErrInvalidAudience)
+		}
+		if id != "*" {
+			if err := validateIdentifier("audience.instance_ids", id); err != nil {
+				return fmt.Errorf("%w: %w", ErrInvalidAudience, err)
+			}
+		}
+		if id == "*" {
+			wildcard = true
+		}
+	}
+	if wildcard && len(a.InstanceIDs) > 1 {
+		// Mixing "*" with explicit IDs is always wildcard but the explicit
+		// entries imply scoped intent. Reject so operators don't ship a
+		// fleet-wide bundle thinking it was scoped.
+		return fmt.Errorf("%w: %w", ErrInvalidAudience, ErrInvalidAudienceWildcard)
+	}
+	for k, v := range a.Labels {
+		if strings.TrimSpace(k) == "" || strings.TrimSpace(v) == "" {
+			return fmt.Errorf("%w: empty label selector", ErrInvalidAudience)
+		}
+		if err := validateLabelSelector(k, v); err != nil {
+			return fmt.Errorf("%w: %w", ErrInvalidAudience, err)
+		}
+	}
+	return nil
+}
+
+func (d DroppedAccounting) Validate() error {
+	if d.Count == 0 {
+		if len(d.Reasons) != 0 {
+			return fmt.Errorf("%w: reasons present with zero count", ErrInvalidDroppedAccounting)
+		}
+		return nil
+	}
+	if len(d.Reasons) == 0 {
+		return fmt.Errorf("%w: count without reasons", ErrInvalidDroppedAccounting)
+	}
+	if len(d.Reasons) > MaxDropReasons {
+		return fmt.Errorf("%w: %d reasons > cap %d", ErrInvalidDroppedAccounting, len(d.Reasons), MaxDropReasons)
+	}
+	var total uint64
+	seen := make(map[string]struct{}, len(d.Reasons))
+	for _, r := range d.Reasons {
+		if err := r.Validate(); err != nil {
+			return err
+		}
+		if _, dup := seen[r.Reason]; dup {
+			return fmt.Errorf("%w: duplicate reason %q", ErrInvalidDroppedAccounting, r.Reason)
+		}
+		seen[r.Reason] = struct{}{}
+		// Detect overflow before accumulating. An attacker crafting a batch
+		// directly could otherwise pick Reason.Count values whose sum wraps
+		// uint64 to land back on d.Count, satisfying the equality check with
+		// an inconsistent payload.
+		if r.Count > math.MaxUint64-total {
+			return fmt.Errorf("%w: reason count sum overflows uint64", ErrInvalidDroppedAccounting)
+		}
+		total += r.Count
+	}
+	if total != d.Count {
+		return fmt.Errorf("%w: count=%d reason_total=%d", ErrInvalidDroppedAccounting, d.Count, total)
+	}
+	return nil
+}
+
+func (r DroppedReason) Validate() error {
+	if strings.TrimSpace(r.Reason) == "" {
+		return fmt.Errorf("%w: dropped.reason", ErrMissingField)
+	}
+	if len(r.Reason) > MaxDropReasonBytes {
+		return fmt.Errorf("%w: dropped.reason (%d bytes > cap %d)", ErrPayloadTooLarge, len(r.Reason), MaxDropReasonBytes)
+	}
+	if err := validateIdentifier("dropped.reason", r.Reason); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidDroppedAccounting, err)
+	}
+	if r.Count == 0 {
+		return fmt.Errorf("%w: dropped.reason.count", ErrMissingField)
+	}
+	return nil
+}
+
+func (a Audience) Matches(instanceID string, labels map[string]string) bool {
+	if slices.Contains(a.InstanceIDs, "*") || slices.Contains(a.InstanceIDs, instanceID) {
+		return true
+	}
+	if len(a.Labels) == 0 {
+		return false
+	}
+	for k, want := range a.Labels {
+		if labels[k] != want {
+			return false
+		}
+	}
+	return true
+}
+
+func (b PolicyBundle) SignablePreimage() ([]byte, error) {
+	unsigned := b
+	unsigned.Signatures = nil
+	// Force UTC + RFC3339Nano-compatible representation so two producers in
+	// different timezones canonicalize identically. Without this, the default
+	// time.Time JSON marshal embeds the source zone offset and breaks signature
+	// portability across regions / Boss replicas.
+	unsigned.CreatedAt = unsigned.CreatedAt.UTC()
+	unsigned.NotBefore = unsigned.NotBefore.UTC()
+	unsigned.ExpiresAt = unsigned.ExpiresAt.UTC()
+	return canonicalPreimage(unsigned, "policy_bundle")
+}
+
+func (b PolicyBundle) CanonicalHash() (string, error) {
+	return canonicalHash(b.SignablePreimage)
+}
+
+func (b PolicyBundle) Validate() error {
+	if err := validateSchemaVersion(b.SchemaVersion); err != nil {
+		return err
+	}
+	if err := validateIdentifier("bundle_id", b.BundleID); err != nil {
+		return err
+	}
+	if err := validateOrgFleet(b.OrgID, b.FleetID); err != nil {
+		return err
+	}
+	if err := validateIdentifier("environment", b.Environment); err != nil {
+		return err
+	}
+	if err := b.Audience.Validate(); err != nil {
+		return err
+	}
+	if b.Version == 0 {
+		return fmt.Errorf("%w: version", ErrMissingField)
+	}
+	if err := validateWindow(b.NotBefore, b.ExpiresAt); err != nil {
+		return err
+	}
+	if b.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: created_at", ErrMissingField)
+	}
+	if err := validateHash("policy_hash", b.PolicyHash); err != nil {
+		return err
+	}
+	if err := validateHash("payload_sha256", b.PayloadSHA256); err != nil {
+		return err
+	}
+	if b.PreviousBundleHash != "" {
+		if err := validateHash("previous_bundle_hash", b.PreviousBundleHash); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(b.Payload.ConfigYAML) == "" {
+		return fmt.Errorf("%w: payload.config_yaml", ErrMissingField)
+	}
+	if len(b.Payload.ConfigYAML) > MaxConfigYAMLBytes {
+		return fmt.Errorf("%w: payload.config_yaml (%d bytes > cap %d)", ErrPayloadTooLarge, len(b.Payload.ConfigYAML), MaxConfigYAMLBytes)
+	}
+	if err := validateMinPipelockVersion(b.MinPipelockVersion); err != nil {
+		return err
+	}
+	if err := rejectLicenseFields(b.Payload.ConfigYAML); err != nil {
+		return err
+	}
+	for _, rb := range b.Payload.RuleBundles {
+		if err := rb.Validate(); err != nil {
+			return err
+		}
+	}
+	return validateSignatureThreshold(b.Signatures, signing.PurposePolicyBundleSigning, RequiredStandardSigners)
+}
+
+// ValidateAtTime extends Validate with a freshness check: now must fall inside
+// [NotBefore, ExpiresAt]. Callers that apply the bundle must use this variant —
+// Validate alone passes a future-dated or already-expired bundle.
+func (b PolicyBundle) ValidateAtTime(now time.Time) error {
+	if err := b.Validate(); err != nil {
+		return err
+	}
+	return withinValidity(now, b.NotBefore, b.ExpiresAt)
+}
+
+// VerifySignatures is shorthand for VerifySignaturesAt(time.Now(), resolve).
+// Callers that already have a logical clock (e.g. apply pipelines that took
+// "now" once at the top of the operation) should prefer VerifySignaturesAt so
+// roster lifecycle checks use the same instant as freshness checks.
+func (b PolicyBundle) VerifySignatures(resolve SignatureKeyResolver) error {
+	return b.VerifySignaturesAt(time.Now(), resolve)
+}
+
+func (b PolicyBundle) VerifySignaturesAt(now time.Time, resolve SignatureKeyResolver) error {
+	preimage, err := b.SignablePreimage()
+	if err != nil {
+		return err
+	}
+	return verifySignatureThreshold(now, preimage, b.Signatures, signing.PurposePolicyBundleSigning, RequiredStandardSigners, resolve)
+}
+
+func (b PolicyBundle) ValidateForFollower(orgID, fleetID, instanceID string, labels map[string]string) error {
+	if b.OrgID != orgID || b.FleetID != fleetID {
+		return fmt.Errorf("%w: org_id/fleet_id", ErrAudienceMismatch)
+	}
+	if !b.Audience.Matches(instanceID, labels) {
+		return fmt.Errorf("%w: instance_id=%q", ErrAudienceMismatch, instanceID)
+	}
+	return nil
+}
+
+func (r RuleBundleRef) Validate() error {
+	if err := validateIdentifier("rule_bundles.name", r.Name); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("rule_bundles.version", r.Version); err != nil {
+		return err
+	}
+	return validateHash("rule_bundles.sha256", r.SHA256)
+}
+
+func (m RemoteKillMessage) SignablePreimage() ([]byte, error) {
+	unsigned := m
+	unsigned.Signatures = nil
+	unsigned.CreatedAt = unsigned.CreatedAt.UTC()
+	unsigned.NotBefore = unsigned.NotBefore.UTC()
+	unsigned.ExpiresAt = unsigned.ExpiresAt.UTC()
+	return canonicalPreimage(unsigned, "remote_kill")
+}
+
+func (m RemoteKillMessage) CanonicalHash() (string, error) {
+	return canonicalHash(m.SignablePreimage)
+}
+
+func (m RemoteKillMessage) Validate() error {
+	if err := validateSchemaVersion(m.SchemaVersion); err != nil {
+		return err
+	}
+	if err := validateIdentifier("message_id", m.MessageID); err != nil {
+		return err
+	}
+	if err := validateOrgFleet(m.OrgID, m.FleetID); err != nil {
+		return err
+	}
+	if err := m.Audience.Validate(); err != nil {
+		return err
+	}
+	if m.State != KillSwitchActive && m.State != KillSwitchInactive {
+		return fmt.Errorf("%w: state=%q", ErrInvalidState, m.State)
+	}
+	if m.Counter == 0 {
+		return fmt.Errorf("%w: counter", ErrMissingField)
+	}
+	if err := validateWindow(m.NotBefore, m.ExpiresAt); err != nil {
+		return err
+	}
+	if m.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: created_at", ErrMissingField)
+	}
+	if err := validateReason("reason", m.Reason); err != nil {
+		return err
+	}
+	return validateSignatureThreshold(m.Signatures, signing.PurposeRemoteKillSigning, RequiredCatastrophicSigners)
+}
+
+// ValidateAtTime extends Validate with a freshness check. Remote kill messages
+// have tight TTLs by design; an expired remote-kill must be rejected even if
+// signature, threshold, and audience all pass.
+func (m RemoteKillMessage) ValidateAtTime(now time.Time) error {
+	if err := m.Validate(); err != nil {
+		return err
+	}
+	return withinValidity(now, m.NotBefore, m.ExpiresAt)
+}
+
+func (m RemoteKillMessage) VerifySignatures(resolve SignatureKeyResolver) error {
+	return m.VerifySignaturesAt(time.Now(), resolve)
+}
+
+func (m RemoteKillMessage) VerifySignaturesAt(now time.Time, resolve SignatureKeyResolver) error {
+	preimage, err := m.SignablePreimage()
+	if err != nil {
+		return err
+	}
+	return verifySignatureThreshold(now, preimage, m.Signatures, signing.PurposeRemoteKillSigning, RequiredCatastrophicSigners, resolve)
+}
+
+func (m RemoteKillMessage) ValidateForFollower(orgID, fleetID, instanceID string, labels map[string]string) error {
+	if m.OrgID != orgID || m.FleetID != fleetID {
+		return fmt.Errorf("%w: org_id/fleet_id", ErrAudienceMismatch)
+	}
+	if !m.Audience.Matches(instanceID, labels) {
+		return fmt.Errorf("%w: instance_id=%q", ErrAudienceMismatch, instanceID)
+	}
+	return nil
+}
+
+func (r RollbackAuthorization) SignablePreimage() ([]byte, error) {
+	unsigned := r
+	unsigned.Signatures = nil
+	unsigned.CreatedAt = unsigned.CreatedAt.UTC()
+	unsigned.ExpiresAt = unsigned.ExpiresAt.UTC()
+	return canonicalPreimage(unsigned, "rollback_authorization")
+}
+
+func (r RollbackAuthorization) CanonicalHash() (string, error) {
+	return canonicalHash(r.SignablePreimage)
+}
+
+func (r RollbackAuthorization) Validate() error {
+	if err := validateSchemaVersion(r.SchemaVersion); err != nil {
+		return err
+	}
+	if err := validateIdentifier("authorization_id", r.AuthorizationID); err != nil {
+		return err
+	}
+	if err := validateOrgFleet(r.OrgID, r.FleetID); err != nil {
+		return err
+	}
+	if err := r.Audience.Validate(); err != nil {
+		return err
+	}
+	if err := validateIdentifier("current_bundle_id", r.CurrentBundleID); err != nil {
+		return err
+	}
+	if err := validateIdentifier("target_bundle_id", r.TargetBundleID); err != nil {
+		return err
+	}
+	if r.CurrentVersion == 0 || r.TargetVersion == 0 || r.Counter == 0 {
+		return fmt.Errorf("%w: rollback counters", ErrMissingField)
+	}
+	if r.TargetVersion >= r.CurrentVersion {
+		return fmt.Errorf("%w: target_version must be lower than current_version", ErrInvalidRollback)
+	}
+	if r.CreatedAt.IsZero() || r.ExpiresAt.IsZero() || !r.ExpiresAt.After(r.CreatedAt) {
+		return fmt.Errorf("%w: rollback validity", ErrInvalidValidityWindow)
+	}
+	if err := validateReason("reason", r.Reason); err != nil {
+		return err
+	}
+	return validateSignatureThreshold(r.Signatures, signing.PurposePolicyBundleRollback, RequiredCatastrophicSigners)
+}
+
+// ValidateAtTime extends Validate with a freshness check. Rollback
+// authorizations are single-shot; an expired authorization must not be
+// applicable even if the operator hasn't redacted it.
+func (r RollbackAuthorization) ValidateAtTime(now time.Time) error {
+	if err := r.Validate(); err != nil {
+		return err
+	}
+	return withinValidity(now, r.CreatedAt, r.ExpiresAt)
+}
+
+func (r RollbackAuthorization) VerifySignatures(resolve SignatureKeyResolver) error {
+	return r.VerifySignaturesAt(time.Now(), resolve)
+}
+
+func (r RollbackAuthorization) VerifySignaturesAt(now time.Time, resolve SignatureKeyResolver) error {
+	preimage, err := r.SignablePreimage()
+	if err != nil {
+		return err
+	}
+	return verifySignatureThreshold(now, preimage, r.Signatures, signing.PurposePolicyBundleRollback, RequiredCatastrophicSigners, resolve)
+}
+
+func (a AuditBatchEnvelope) SignablePreimage() ([]byte, error) {
+	unsigned := a
+	unsigned.Signatures = nil
+	unsigned.EmittedAt = unsigned.EmittedAt.UTC()
+	return canonicalPreimage(unsigned, "audit_batch")
+}
+
+func (a AuditBatchEnvelope) CanonicalHash() (string, error) {
+	return canonicalHash(a.SignablePreimage)
+}
+
+func (a AuditBatchEnvelope) Validate() error {
+	if err := validateSchemaVersion(a.SchemaVersion); err != nil {
+		return err
+	}
+	if err := validateIdentifier("batch_id", a.BatchID); err != nil {
+		return err
+	}
+	if err := validateOrgFleet(a.OrgID, a.FleetID); err != nil {
+		return err
+	}
+	if err := validateIdentifier("instance_id", a.InstanceID); err != nil {
+		return err
+	}
+	if a.AuditSchemaVersion <= 0 {
+		return fmt.Errorf("%w: audit_schema_version", ErrMissingField)
+	}
+	if a.EmittedAt.IsZero() {
+		return fmt.Errorf("%w: emitted_at", ErrMissingField)
+	}
+	if err := validateSeqRange(a.SeqStart, a.SeqEnd); err != nil {
+		return err
+	}
+	if a.EventCount == 0 {
+		return fmt.Errorf("%w: event_count", ErrMissingField)
+	}
+	if a.PayloadBytes == 0 {
+		return fmt.Errorf("%w: payload_bytes", ErrMissingField)
+	}
+	if a.PayloadBytes > MaxAuditPayloadBytes {
+		return fmt.Errorf("%w: payload_bytes=%d cap=%d", ErrPayloadTooLarge, a.PayloadBytes, MaxAuditPayloadBytes)
+	}
+	if err := validateHash("payload_sha256", a.PayloadSHA256); err != nil {
+		return err
+	}
+	if err := a.Dropped.Validate(); err != nil {
+		return err
+	}
+	if err := a.Chain.Validate(a.SeqStart, a.SeqEnd); err != nil {
+		return err
+	}
+	return validateSignatureThreshold(a.Signatures, signing.PurposeAuditBatchSigning, RequiredStandardSigners)
+}
+
+// ValidateForBoss extends Validate with skew enforcement against Boss's clock.
+// maxSkew bounds |now - EmittedAt|; replay protection requires this be tight
+// (default DefaultAuditMaxSkew, ceiling MaxAllowedAuditSkew). Callers that
+// configure a higher skew must do so consciously and log a warning at config
+// load time. Validate alone does NOT enforce skew — a captured signed batch
+// could otherwise be replayed at any future time.
+func (a AuditBatchEnvelope) ValidateForBoss(now time.Time, maxSkew time.Duration) error {
+	if err := a.Validate(); err != nil {
+		return err
+	}
+	if maxSkew <= 0 {
+		maxSkew = DefaultAuditMaxSkew
+	}
+	if maxSkew > MaxAllowedAuditSkew {
+		return fmt.Errorf("%w: max_skew %s exceeds ceiling %s", ErrSkewExceeded, maxSkew, MaxAllowedAuditSkew)
+	}
+	delta := now.Sub(a.EmittedAt)
+	if delta < 0 {
+		delta = -delta
+	}
+	if delta > maxSkew {
+		return fmt.Errorf("%w: |now-emitted_at|=%s max_skew=%s", ErrSkewExceeded, delta, maxSkew)
+	}
+	return nil
+}
+
+func (a AuditBatchEnvelope) VerifySignatures(resolve SignatureKeyResolver) error {
+	return a.VerifySignaturesAt(time.Now(), resolve)
+}
+
+func (a AuditBatchEnvelope) VerifySignaturesAt(now time.Time, resolve SignatureKeyResolver) error {
+	preimage, err := a.SignablePreimage()
+	if err != nil {
+		return err
+	}
+	return verifySignatureThreshold(now, preimage, a.Signatures, signing.PurposeAuditBatchSigning, RequiredStandardSigners, resolve)
+}
+
+func (a AuditBatchEnvelope) ForksWith(other AuditBatchEnvelope) bool {
+	if a.OrgID != other.OrgID || a.FleetID != other.FleetID || a.InstanceID != other.InstanceID {
+		return false
+	}
+	if a.SeqEnd < other.SeqStart || other.SeqEnd < a.SeqStart {
+		return false
+	}
+	return a.PayloadSHA256 != other.PayloadSHA256 || a.Chain.SegmentTailHash != other.Chain.SegmentTailHash
+}
+
+func (c EvidenceChain) Validate(seqStart, seqEnd uint64) error {
+	if c.EntryVersion != 2 {
+		return fmt.Errorf("%w: entry_version=%d", ErrInvalidSequenceRange, c.EntryVersion)
+	}
+	if err := validateIdentifier("chain.segment_id", c.SegmentID); err != nil {
+		return err
+	}
+	if c.SeqStart != seqStart || c.SeqEnd != seqEnd {
+		return fmt.Errorf("%w: chain seq range mismatch", ErrInvalidSequenceRange)
+	}
+	if err := validateSeqRange(c.SeqStart, c.SeqEnd); err != nil {
+		return err
+	}
+	for name, value := range map[string]string{
+		"chain.segment_head_hash": c.SegmentHeadHash,
+		"chain.segment_tail_hash": c.SegmentTailHash,
+		"chain.checkpoint_hash":   c.CheckpointHash,
+	} {
+		if err := validateHash(name, value); err != nil {
+			return err
+		}
+	}
+	if c.PreviousSegmentTail != "" {
+		if err := validateHash("chain.previous_segment_tail", c.PreviousSegmentTail); err != nil {
+			return err
+		}
+	}
+	if c.CheckpointSeq < c.SeqStart || c.CheckpointSeq > c.SeqEnd {
+		return fmt.Errorf("%w: checkpoint_seq", ErrInvalidSequenceRange)
+	}
+	if err := validateEd25519SignatureString(c.CheckpointSignature); err != nil {
+		return err
+	}
+	if err := validateIdentifier("chain.checkpoint_signer_key_id", c.CheckpointSignerKeyID); err != nil {
+		return err
+	}
+	if err := validateIdentifier("chain.follower_recorder_key_id", c.FollowerRecorderKeyID); err != nil {
+		return err
+	}
+	if err := validatePublicKeyHex("chain.follower_recorder_public_key_hex", c.FollowerRecorderPubHex); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c CapabilitiesResponse) Validate() error {
+	return c.ValidateWithLocalThresholdCap(MaxCapabilityThreshold)
+}
+
+func (c CapabilitiesResponse) ValidateWithLocalThresholdCap(maxThreshold int) error {
+	if err := validateSchemaVersion(c.SchemaVersion); err != nil {
+		return err
+	}
+	if err := validateIdentifier("boss_id", c.BossID); err != nil {
+		return err
+	}
+	if !c.RequiredMTLS {
+		return fmt.Errorf("%w: required_mtls must be true", ErrInvalidState)
+	}
+	for name, r := range map[string]SchemaRange{
+		"conductor_bundle":       c.ConductorBundle,
+		"remote_kill":            c.RemoteKill,
+		"rollback_authorization": c.RollbackAuthorization,
+		"audit_batch":            c.AuditBatch,
+	} {
+		if err := r.Validate(name); err != nil {
+			return err
+		}
+	}
+	// Couple to recorder.EntryVersion — the version the local recorder
+	// actively WRITES — so a recorder bump (v2→v3) automatically tightens
+	// the handshake instead of leaving this stranded on a hardcoded "2".
+	// Boss must advertise that version or the follower can never produce
+	// ingestable batches.
+	if !slices.Contains(c.ReceiptEntryVersions, recorder.EntryVersion) {
+		return fmt.Errorf("%w: receipt_entry_versions must include recorder write version %d", ErrInvalidState, recorder.EntryVersion)
+	}
+	if c.MaxCreatedSkewSeconds <= 0 || time.Duration(c.MaxCreatedSkewSeconds)*time.Second > MaxAllowedAuditSkew {
+		return fmt.Errorf("%w: max_created_skew_seconds=%d", ErrSkewExceeded, c.MaxCreatedSkewSeconds)
+	}
+	for name, value := range map[string]int{
+		"remote_kill_threshold":    c.RemoteKillThreshold,
+		"rollback_threshold":       c.RollbackThreshold,
+		"trust_rotation_threshold": c.TrustRotationThreshold,
+	} {
+		if value < RequiredCatastrophicSigners {
+			return fmt.Errorf("%w: %s=%d", ErrThresholdRequired, name, value)
+		}
+		if maxThreshold > 0 && value > maxThreshold {
+			return fmt.Errorf("%w: %s=%d exceeds local cap %d", ErrThresholdRequired, name, value, maxThreshold)
+		}
+	}
+	return nil
+}
+
+func (r SchemaRange) Validate(name string) error {
+	if r.Min <= 0 || r.Max < r.Min {
+		return fmt.Errorf("%w: %s schema range", ErrInvalidState, name)
+	}
+	if SchemaVersion < r.Min || SchemaVersion > r.Max {
+		return fmt.Errorf("%w: %s must include schema_version %d", ErrInvalidState, name, SchemaVersion)
+	}
+	return nil
+}
+
+func validateSignatureThreshold(signatures []SignatureProof, required signing.KeyPurpose, minSigners int) error {
+	if len(signatures) == 0 {
+		return fmt.Errorf("%w: signatures", ErrThresholdRequired)
+	}
+	seen := make(map[string]struct{}, len(signatures))
+	for _, sig := range signatures {
+		if err := sig.Validate(required); err != nil {
+			return err
+		}
+		seen[sig.SignerKeyID] = struct{}{}
+	}
+	if len(seen) < minSigners {
+		return fmt.Errorf("%w: got %d distinct signer(s), want %d", ErrThresholdRequired, len(seen), minSigners)
+	}
+	return nil
+}
+
+func verifySignatureThreshold(
+	now time.Time,
+	preimage []byte,
+	signatures []SignatureProof,
+	required signing.KeyPurpose,
+	minSigners int,
+	resolve SignatureKeyResolver,
+) error {
+	if resolve == nil {
+		return fmt.Errorf("%w: nil key resolver", ErrSignatureVerification)
+	}
+	if len(signatures) == 0 {
+		return fmt.Errorf("%w: signatures", ErrThresholdRequired)
+	}
+	now = now.UTC()
+	seenIDs := make(map[string]struct{}, len(signatures))
+	seenKeys := make(map[string]struct{}, len(signatures))
+	for _, sig := range signatures {
+		if err := sig.Validate(required); err != nil {
+			return err
+		}
+		key, err := resolve(sig.SignerKeyID)
+		if err != nil {
+			return fmt.Errorf("%w: key_id=%q: %w", ErrSignatureVerification, sig.SignerKeyID, err)
+		}
+		if key.KeyPurpose != required {
+			return fmt.Errorf("%w: key_id=%q roster purpose=%q required=%q", ErrWrongKeyPurpose, sig.SignerKeyID, key.KeyPurpose, required)
+		}
+		if len(key.PublicKey) != ed25519.PublicKeySize {
+			return fmt.Errorf("%w: key_id=%q public key length=%d", ErrSignatureVerification, sig.SignerKeyID, len(key.PublicKey))
+		}
+		if err := key.checkLifecycle(now); err != nil {
+			return fmt.Errorf("%w: key_id=%q: %w", ErrSignatureVerification, sig.SignerKeyID, err)
+		}
+		sigBytes, err := parseEd25519SignatureString(sig.Signature)
+		if err != nil {
+			return err
+		}
+		if !contract.VerifyEd25519PureEdDSA(key.PublicKey, preimage, sigBytes) {
+			return fmt.Errorf("%w: key_id=%q", ErrSignatureVerification, sig.SignerKeyID)
+		}
+		seenIDs[sig.SignerKeyID] = struct{}{}
+		// Track distinct PUBLIC KEYS, not just distinct IDs. A roster that
+		// (maliciously or by misconfiguration) maps two IDs to the same
+		// public key would otherwise satisfy the threshold with one
+		// underlying signer.
+		seenKeys[hex.EncodeToString(key.PublicKey)] = struct{}{}
+	}
+	if len(seenIDs) < minSigners {
+		return fmt.Errorf("%w: got %d distinct signer id(s), want %d", ErrThresholdRequired, len(seenIDs), minSigners)
+	}
+	if len(seenKeys) < minSigners {
+		return fmt.Errorf("%w: got %d distinct verified public key(s) across %d signer id(s), want %d", ErrThresholdRequired, len(seenKeys), len(seenIDs), minSigners)
+	}
+	return nil
+}
+
+// checkLifecycle rejects a roster key whose validity window has not begun, has
+// ended, or that has been revoked. NotBefore zero is treated as "always valid
+// from epoch", NotAfter zero as "never expires". RevokedAt non-nil rejects
+// unconditionally — revocation overrides any window check.
+func (k SignatureKey) checkLifecycle(now time.Time) error {
+	if k.RevokedAt != nil {
+		return fmt.Errorf("%w: revoked_at=%s", ErrSignatureVerification, k.RevokedAt.UTC().Format(time.RFC3339))
+	}
+	if !k.NotBefore.IsZero() && now.Before(k.NotBefore.UTC()) {
+		return fmt.Errorf("%w: not_before=%s", ErrNotYetValid, k.NotBefore.UTC().Format(time.RFC3339))
+	}
+	if !k.NotAfter.IsZero() && now.After(k.NotAfter.UTC()) {
+		return fmt.Errorf("%w: not_after=%s", ErrExpired, k.NotAfter.UTC().Format(time.RFC3339))
+	}
+	return nil
+}
+
+func canonicalPreimage(v any, name string) ([]byte, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s: %w", name, err)
+	}
+	tree, err := contract.ParseJSONStrict(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s for canonicalization: %w", name, err)
+	}
+	return contract.Canonicalize(tree)
+}
+
+func canonicalHash(preimage func() ([]byte, error)) (string, error) {
+	data, err := preimage()
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func validateSchemaVersion(v int) error {
+	if !acceptedSchemaVersions[v] {
+		return fmt.Errorf("%w: got %d", ErrUnsupportedSchemaVersion, v)
+	}
+	return nil
+}
+
+// withinValidity reports whether now ∈ [notBefore, expiresAt]. notBefore and
+// expiresAt are presumed already shape-checked by validateWindow.
+func withinValidity(now, notBefore, expiresAt time.Time) error {
+	now = now.UTC()
+	if now.Before(notBefore.UTC()) {
+		return fmt.Errorf("%w: now=%s not_before=%s", ErrNotYetValid, now.Format(time.RFC3339), notBefore.UTC().Format(time.RFC3339))
+	}
+	if now.After(expiresAt.UTC()) {
+		return fmt.Errorf("%w: now=%s expires_at=%s", ErrExpired, now.Format(time.RFC3339), expiresAt.UTC().Format(time.RFC3339))
+	}
+	return nil
+}
+
+// validateMinPipelockVersion accepts a non-empty major.minor.patch semver-like
+// shape. Full SemVer 2.0.0 (pre-release / build metadata) is intentionally not
+// supported in MVP — bundles target release versions only. The follower-side
+// sanity window (max_min_version_major_skew / minor_skew per spec) is enforced
+// at apply time with the follower's runtime version on hand, not here.
+func validateMinPipelockVersion(v string) error {
+	if strings.TrimSpace(v) == "" {
+		return fmt.Errorf("%w: min_pipelock_version", ErrMissingField)
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) != 3 {
+		return fmt.Errorf("%w: %q (want major.minor.patch)", ErrInvalidMinVersion, v)
+	}
+	for _, p := range parts {
+		if p == "" {
+			return fmt.Errorf("%w: %q (empty component)", ErrInvalidMinVersion, v)
+		}
+		if len(p) > 1 && p[0] == '0' {
+			return fmt.Errorf("%w: %q (leading zero component %q)", ErrInvalidMinVersion, v, p)
+		}
+		for _, r := range p {
+			if r < '0' || r > '9' {
+				return fmt.Errorf("%w: %q (non-numeric component %q)", ErrInvalidMinVersion, v, p)
+			}
+		}
+	}
+	return nil
+}
+
+// validateReason caps free-form reason strings used in remote-kill / rollback
+// messages. Caps protect verifier CPU against publisher-controlled payload
+// inflation. Empty is allowed; only oversized strings are rejected.
+func validateReason(field, reason string) error {
+	if len(reason) > MaxReasonBytes {
+		return fmt.Errorf("%w: %s (%d bytes > cap %d)", ErrPayloadTooLarge, field, len(reason), MaxReasonBytes)
+	}
+	return nil
+}
+
+func validateOrgFleet(orgID, fleetID string) error {
+	if err := validateIdentifier("org_id", orgID); err != nil {
+		return err
+	}
+	return validateIdentifier("fleet_id", fleetID)
+}
+
+func requireNonEmpty(field, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%w: %s", ErrMissingField, field)
+	}
+	return nil
+}
+
+func validateIdentifier(field, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%w: %s", ErrMissingField, field)
+	}
+	if len(value) > MaxIDBytes {
+		return fmt.Errorf("%w: %s (%d bytes > cap %d)", ErrInvalidIdentifier, field, len(value), MaxIDBytes)
+	}
+	if !isIdentifier(value) {
+		return fmt.Errorf("%w: %s=%q", ErrInvalidIdentifier, field, value)
+	}
+	return nil
+}
+
+func validateLabelSelector(key, value string) error {
+	if len(key) > MaxLabelKeyBytes {
+		return fmt.Errorf("%w: label key (%d bytes > cap %d)", ErrInvalidIdentifier, len(key), MaxLabelKeyBytes)
+	}
+	if len(value) > MaxLabelValueBytes {
+		return fmt.Errorf("%w: label value (%d bytes > cap %d)", ErrInvalidIdentifier, len(value), MaxLabelValueBytes)
+	}
+	if !isIdentifier(key) || !isIdentifier(value) {
+		return fmt.Errorf("%w: label %q=%q", ErrInvalidIdentifier, key, value)
+	}
+	return nil
+}
+
+func isIdentifier(value string) bool {
+	for i, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		switch r {
+		case '_', '-', '.':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func validateWindow(notBefore, expiresAt time.Time) error {
+	if notBefore.IsZero() || expiresAt.IsZero() || !expiresAt.After(notBefore) {
+		return ErrInvalidValidityWindow
+	}
+	return nil
+}
+
+func validateSeqRange(start, end uint64) error {
+	if start == 0 || end == 0 || end < start {
+		return fmt.Errorf("%w: start=%d end=%d", ErrInvalidSequenceRange, start, end)
+	}
+	return nil
+}
+
+func validateHash(field, value string) error {
+	decoded, err := hex.DecodeString(value)
+	if err != nil || len(decoded) != sha256.Size {
+		return fmt.Errorf("%w: %s", ErrInvalidHash, field)
+	}
+	return nil
+}
+
+func validatePublicKeyHex(field, value string) error {
+	decoded, err := hex.DecodeString(value)
+	if err != nil || len(decoded) != 32 {
+		return fmt.Errorf("%w: %s", ErrInvalidHash, field)
+	}
+	return nil
+}
+
+func validateEd25519SignatureString(value string) error {
+	_, err := parseEd25519SignatureString(value)
+	return err
+}
+
+func parseEd25519SignatureString(value string) ([]byte, error) {
+	if !strings.HasPrefix(value, SignaturePrefixEd25519) {
+		return nil, fmt.Errorf("%w: signature missing %q prefix", ErrInvalidSignature, SignaturePrefixEd25519)
+	}
+	hexPart := value[len(SignaturePrefixEd25519):]
+	decoded, err := hex.DecodeString(hexPart)
+	if err != nil || len(decoded) != 64 {
+		return nil, fmt.Errorf("%w: malformed ed25519 signature", ErrInvalidSignature)
+	}
+	return decoded, nil
+}
+
+func rejectLicenseFields(configYAML string) error {
+	dec := yaml.NewDecoder(bytes.NewReader([]byte(configYAML)))
+	var doc yaml.Node
+	if err := dec.Decode(&doc); err != nil {
+		return fmt.Errorf("%w: parse config payload: %w", ErrForbiddenLicenseField, err)
+	}
+	if err := rejectExtraYAMLDocuments(dec); err != nil {
+		return err
+	}
+	if len(doc.Content) == 0 {
+		return nil
+	}
+	return walkRejectLicenseFields(doc.Content[0])
+}
+
+// walkRejectLicenseFields recurses through MappingNode / SequenceNode children
+// and rejects any key that matches forbiddenLicenseFields at any depth. The
+// shallow root-only check it replaces missed nested license fields under
+// agents.<name> and any other future submap. Path is reported so an operator
+// can see exactly which subpath tripped the rejection.
+func walkRejectLicenseFields(n *yaml.Node) error {
+	return walkRejectLicenseFieldsAt(n, "")
+}
+
+func walkRejectLicenseFieldsAt(n *yaml.Node, path string) error {
+	if n == nil {
+		return nil
+	}
+	switch n.Kind {
+	case yaml.DocumentNode:
+		for _, c := range n.Content {
+			if err := walkRejectLicenseFieldsAt(c, path); err != nil {
+				return err
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			key := n.Content[i]
+			val := n.Content[i+1]
+			childPath := path + "." + key.Value
+			if path == "" {
+				childPath = key.Value
+			}
+			if _, forbidden := forbiddenLicenseFields[key.Value]; forbidden {
+				return fmt.Errorf("%w: %s", ErrForbiddenLicenseField, childPath)
+			}
+			if err := walkRejectLicenseFieldsAt(val, childPath); err != nil {
+				return err
+			}
+		}
+	case yaml.SequenceNode:
+		for i, c := range n.Content {
+			childPath := fmt.Sprintf("%s[%d]", path, i)
+			if err := walkRejectLicenseFieldsAt(c, childPath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func rejectExtraYAMLDocuments(dec *yaml.Decoder) error {
+	var extra yaml.Node
+	err := dec.Decode(&extra)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("%w: parse config payload: %w", ErrForbiddenLicenseField, err)
+	}
+	if len(extra.Content) != 0 {
+		return fmt.Errorf("%w: multiple YAML documents", ErrForbiddenLicenseField)
+	}
+	return nil
+}

--- a/internal/conductor/messages.go
+++ b/internal/conductor/messages.go
@@ -1,7 +1,7 @@
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0
 
-// Package conductor defines Boss/Conductor signed message bodies.
+// Package conductor defines Conductor signed message bodies.
 package conductor
 
 import (
@@ -17,6 +17,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
@@ -68,8 +70,11 @@ var (
 	ErrExpired                  = errors.New("conductor message expired")
 	ErrSkewExceeded             = errors.New("conductor message exceeds allowed clock skew")
 	ErrInvalidMinVersion        = errors.New("invalid min_pipelock_version")
+	ErrHashMismatch             = errors.New("conductor hash mismatch")
 	ErrPayloadTooLarge          = errors.New("conductor payload exceeds size cap")
 	ErrInvalidAudienceWildcard  = errors.New("conductor audience cannot mix wildcard with explicit instance_ids")
+	ErrInvalidAudienceSelectors = errors.New("conductor audience cannot mix instance_ids with labels")
+	ErrInvalidReason            = errors.New("invalid conductor reason")
 	ErrInvalidIdentifier        = errors.New("invalid conductor identifier")
 	ErrSignatureVerification    = errors.New("conductor signature verification failed")
 	ErrInvalidDroppedAccounting = errors.New("invalid conductor dropped accounting")
@@ -139,6 +144,32 @@ type RuleBundleRef struct {
 type PolicyBundlePayload struct {
 	ConfigYAML  string          `json:"config_yaml"`
 	RuleBundles []RuleBundleRef `json:"rule_bundles,omitempty"`
+}
+
+func (p PolicyBundlePayload) PayloadHash() (string, error) {
+	return canonicalValueHash(p, "policy_bundle_payload")
+}
+
+func (p PolicyBundlePayload) PolicyHash() (string, error) {
+	var cfg any
+	decoder := yaml.NewDecoder(strings.NewReader(p.ConfigYAML))
+	if err := decoder.Decode(&cfg); err != nil && !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("parse policy bundle config_yaml for policy hash: %w", err)
+	}
+	var extra yaml.Node
+	if err := decoder.Decode(&extra); err == nil {
+		return "", fmt.Errorf("%w: config_yaml has multiple YAML documents", ErrInvalidHash)
+	} else if !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("parse policy bundle config_yaml trailing document: %w", err)
+	}
+	view := struct {
+		ConfigYAML  any             `json:"config_yaml"`
+		RuleBundles []RuleBundleRef `json:"rule_bundles,omitempty"`
+	}{
+		ConfigYAML:  cfg,
+		RuleBundles: p.RuleBundles,
+	}
+	return canonicalValueHash(view, "policy_bundle_policy")
 }
 
 type PolicyBundle struct {
@@ -240,7 +271,7 @@ type SchemaRange struct {
 
 type CapabilitiesResponse struct {
 	SchemaVersion          int         `json:"schema_version"`
-	BossID                 string      `json:"boss_id"`
+	ConductorID            string      `json:"conductor_id"`
 	RequiredMTLS           bool        `json:"required_mtls"`
 	ConductorBundle        SchemaRange `json:"conductor_bundle"`
 	RemoteKill             SchemaRange `json:"remote_kill"`
@@ -279,6 +310,9 @@ func (p SignatureProof) Validate(required signing.KeyPurpose) error {
 func (a Audience) Validate() error {
 	if len(a.InstanceIDs) == 0 && len(a.Labels) == 0 {
 		return fmt.Errorf("%w: empty audience", ErrInvalidAudience)
+	}
+	if len(a.InstanceIDs) > 0 && len(a.Labels) > 0 {
+		return fmt.Errorf("%w: %w", ErrInvalidAudience, ErrInvalidAudienceSelectors)
 	}
 	wildcard := false
 	for _, id := range a.InstanceIDs {
@@ -386,7 +420,7 @@ func (b PolicyBundle) SignablePreimage() ([]byte, error) {
 	// Force UTC + RFC3339Nano-compatible representation so two producers in
 	// different timezones canonicalize identically. Without this, the default
 	// time.Time JSON marshal embeds the source zone offset and breaks signature
-	// portability across regions / Boss replicas.
+	// portability across regions / Conductor replicas.
 	unsigned.CreatedAt = unsigned.CreatedAt.UTC()
 	unsigned.NotBefore = unsigned.NotBefore.UTC()
 	unsigned.ExpiresAt = unsigned.ExpiresAt.UTC()
@@ -450,7 +484,28 @@ func (b PolicyBundle) Validate() error {
 			return err
 		}
 	}
+	if err := b.validateHashes(); err != nil {
+		return err
+	}
 	return validateSignatureThreshold(b.Signatures, signing.PurposePolicyBundleSigning, RequiredStandardSigners)
+}
+
+func (b PolicyBundle) validateHashes() error {
+	payloadHash, err := b.Payload.PayloadHash()
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(b.PayloadSHA256, payloadHash) {
+		return fmt.Errorf("%w: payload_sha256", ErrHashMismatch)
+	}
+	policyHash, err := b.Payload.PolicyHash()
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(b.PolicyHash, policyHash) {
+		return fmt.Errorf("%w: policy_hash", ErrHashMismatch)
+	}
+	return nil
 }
 
 // ValidateAtTime extends Validate with a freshness check: now must fall inside
@@ -697,13 +752,13 @@ func (a AuditBatchEnvelope) Validate() error {
 	return validateSignatureThreshold(a.Signatures, signing.PurposeAuditBatchSigning, RequiredStandardSigners)
 }
 
-// ValidateForBoss extends Validate with skew enforcement against Boss's clock.
+// ValidateForConductor extends Validate with skew enforcement against Conductor's clock.
 // maxSkew bounds |now - EmittedAt|; replay protection requires this be tight
 // (default DefaultAuditMaxSkew, ceiling MaxAllowedAuditSkew). Callers that
 // configure a higher skew must do so consciously and log a warning at config
 // load time. Validate alone does NOT enforce skew — a captured signed batch
 // could otherwise be replayed at any future time.
-func (a AuditBatchEnvelope) ValidateForBoss(now time.Time, maxSkew time.Duration) error {
+func (a AuditBatchEnvelope) ValidateForConductor(now time.Time, maxSkew time.Duration) error {
 	if err := a.Validate(); err != nil {
 		return err
 	}
@@ -721,6 +776,24 @@ func (a AuditBatchEnvelope) ValidateForBoss(now time.Time, maxSkew time.Duration
 		return fmt.Errorf("%w: |now-emitted_at|=%s max_skew=%s", ErrSkewExceeded, delta, maxSkew)
 	}
 	return nil
+}
+
+func (a AuditBatchEnvelope) ValidatePayload(payload []byte) error {
+	if uint64(len(payload)) != a.PayloadBytes {
+		return fmt.Errorf("%w: payload_bytes envelope=%d actual=%d", ErrHashMismatch, a.PayloadBytes, len(payload))
+	}
+	sum := sha256.Sum256(payload)
+	if !strings.EqualFold(hex.EncodeToString(sum[:]), a.PayloadSHA256) {
+		return fmt.Errorf("%w: payload_sha256", ErrHashMismatch)
+	}
+	return nil
+}
+
+func (a AuditBatchEnvelope) ValidateForConductorWithPayload(now time.Time, maxSkew time.Duration, payload []byte) error {
+	if err := a.ValidateForConductor(now, maxSkew); err != nil {
+		return err
+	}
+	return a.ValidatePayload(payload)
 }
 
 func (a AuditBatchEnvelope) VerifySignatures(resolve SignatureKeyResolver) error {
@@ -798,7 +871,7 @@ func (c CapabilitiesResponse) ValidateWithLocalThresholdCap(maxThreshold int) er
 	if err := validateSchemaVersion(c.SchemaVersion); err != nil {
 		return err
 	}
-	if err := validateIdentifier("boss_id", c.BossID); err != nil {
+	if err := validateIdentifier("conductor_id", c.ConductorID); err != nil {
 		return err
 	}
 	if !c.RequiredMTLS {
@@ -817,7 +890,7 @@ func (c CapabilitiesResponse) ValidateWithLocalThresholdCap(maxThreshold int) er
 	// Couple to recorder.EntryVersion — the version the local recorder
 	// actively WRITES — so a recorder bump (v2→v3) automatically tightens
 	// the handshake instead of leaving this stranded on a hardcoded "2".
-	// Boss must advertise that version or the follower can never produce
+	// Conductor must advertise that version or the follower can never produce
 	// ingestable batches.
 	if !slices.Contains(c.ReceiptEntryVersions, recorder.EntryVersion) {
 		return fmt.Errorf("%w: receipt_entry_versions must include recorder write version %d", ErrInvalidState, recorder.EntryVersion)
@@ -962,6 +1035,15 @@ func canonicalHash(preimage func() ([]byte, error)) (string, error) {
 	return hex.EncodeToString(sum[:]), nil
 }
 
+func canonicalValueHash(v any, name string) (string, error) {
+	data, err := canonicalPreimage(v, name)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
 func validateSchemaVersion(v int) error {
 	if !acceptedSchemaVersions[v] {
 		return fmt.Errorf("%w: got %d", ErrUnsupportedSchemaVersion, v)
@@ -1011,12 +1093,22 @@ func validateMinPipelockVersion(v string) error {
 	return nil
 }
 
-// validateReason caps free-form reason strings used in remote-kill / rollback
-// messages. Caps protect verifier CPU against publisher-controlled payload
-// inflation. Empty is allowed; only oversized strings are rejected.
+// validateReason caps and constrains free-form reason strings used in
+// remote-kill / rollback messages. Empty is allowed, but control characters
+// are rejected at the signed-message boundary so downstream logs, terminals,
+// web UIs, and pager paths do not all need to rediscover the same sanitization
+// rule.
 func validateReason(field, reason string) error {
 	if len(reason) > MaxReasonBytes {
 		return fmt.Errorf("%w: %s (%d bytes > cap %d)", ErrPayloadTooLarge, field, len(reason), MaxReasonBytes)
+	}
+	if !utf8.ValidString(reason) {
+		return fmt.Errorf("%w: %s contains invalid utf-8", ErrInvalidReason, field)
+	}
+	for _, r := range reason {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("%w: %s contains control character U+%04X", ErrInvalidReason, field, r)
+		}
 	}
 	return nil
 }
@@ -1062,6 +1154,9 @@ func validateLabelSelector(key, value string) error {
 }
 
 func isIdentifier(value string) bool {
+	if value == "" {
+		return false
+	}
 	for i, r := range value {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
 			continue

--- a/internal/conductor/messages.go
+++ b/internal/conductor/messages.go
@@ -1003,13 +1003,13 @@ func verifySignatureThreshold(
 // unconditionally — revocation overrides any window check.
 func (k SignatureKey) checkLifecycle(now time.Time) error {
 	if k.RevokedAt != nil {
-		return fmt.Errorf("%w: revoked_at=%s", ErrSignatureVerification, k.RevokedAt.UTC().Format(time.RFC3339))
+		return fmt.Errorf("%w: revoked_at=%s verification_time=%s", ErrSignatureVerification, k.RevokedAt.UTC().Format(time.RFC3339), now.Format(time.RFC3339))
 	}
 	if !k.NotBefore.IsZero() && now.Before(k.NotBefore.UTC()) {
-		return fmt.Errorf("%w: not_before=%s", ErrNotYetValid, k.NotBefore.UTC().Format(time.RFC3339))
+		return fmt.Errorf("%w: not_before=%s verification_time=%s", ErrNotYetValid, k.NotBefore.UTC().Format(time.RFC3339), now.Format(time.RFC3339))
 	}
 	if !k.NotAfter.IsZero() && now.After(k.NotAfter.UTC()) {
-		return fmt.Errorf("%w: not_after=%s", ErrExpired, k.NotAfter.UTC().Format(time.RFC3339))
+		return fmt.Errorf("%w: not_after=%s verification_time=%s", ErrExpired, k.NotAfter.UTC().Format(time.RFC3339), now.Format(time.RFC3339))
 	}
 	return nil
 }

--- a/internal/conductor/messages_test.go
+++ b/internal/conductor/messages_test.go
@@ -5,6 +5,7 @@ package conductor
 
 import (
 	"crypto/ed25519"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"math"
@@ -75,6 +76,24 @@ func TestPolicyBundle_Validate(t *testing.T) {
 		err := b.ValidateForFollower("org-test", "fleet-prod", "instance-other", map[string]string{"tier": "prod"})
 		if err != nil {
 			t.Fatalf("ValidateForFollower() = %v, want nil", err)
+		}
+	})
+
+	t.Run("payload_hash_mismatch", func(t *testing.T) {
+		b := testPolicyBundle()
+		b.PayloadSHA256 = testHash("03")
+		err := b.Validate()
+		if !errors.Is(err, ErrHashMismatch) {
+			t.Fatalf("Validate() = %v, want ErrHashMismatch", err)
+		}
+	})
+
+	t.Run("policy_hash_mismatch", func(t *testing.T) {
+		b := testPolicyBundle()
+		b.PolicyHash = testHash("02")
+		err := b.Validate()
+		if !errors.Is(err, ErrHashMismatch) {
+			t.Fatalf("Validate() = %v, want ErrHashMismatch", err)
 		}
 	})
 }
@@ -185,7 +204,7 @@ func TestAuditBatchEnvelope_DroppedAccounting(t *testing.T) {
 func TestCapabilitiesResponse_RequiresMTLSAndThresholds(t *testing.T) {
 	caps := CapabilitiesResponse{
 		SchemaVersion:          SchemaVersion,
-		BossID:                 "boss-us-1",
+		ConductorID:            "conductor-us-1",
 		RequiredMTLS:           true,
 		ConductorBundle:        SchemaRange{Min: 1, Max: 1},
 		RemoteKill:             SchemaRange{Min: 1, Max: 1},
@@ -292,6 +311,14 @@ func TestRemoteKillMessage_VerifySignaturesThreshold(t *testing.T) {
 }
 
 func testPolicyBundle() PolicyBundle {
+	payload := PolicyBundlePayload{
+		ConfigYAML: "mode: strict\nagents:\n  claude-code:\n    mode: strict\n",
+		RuleBundles: []RuleBundleRef{{
+			Name:    "official",
+			Version: "2026.05.23",
+			SHA256:  testHash("04"),
+		}},
+	}
 	return PolicyBundle{
 		SchemaVersion:      SchemaVersion,
 		BundleID:           "bundle-0001",
@@ -305,16 +332,9 @@ func testPolicyBundle() PolicyBundle {
 		NotBefore:          testNow.Add(-time.Minute),
 		ExpiresAt:          testNow.Add(time.Hour),
 		MinPipelockVersion: "1.2.3",
-		PolicyHash:         testHash("02"),
-		PayloadSHA256:      testHash("03"),
-		Payload: PolicyBundlePayload{
-			ConfigYAML: "mode: strict\nagents:\n  claude-code:\n    mode: strict\n",
-			RuleBundles: []RuleBundleRef{{
-				Name:    "official",
-				Version: "2026.05.23",
-				SHA256:  testHash("04"),
-			}},
-		},
+		PolicyHash:         mustPolicyHash(payload),
+		PayloadSHA256:      mustPayloadHash(payload),
+		Payload:            payload,
 		Signatures: []SignatureProof{
 			testProof("policy-signer-1", signing.PurposePolicyBundleSigning),
 		},
@@ -324,7 +344,7 @@ func testPolicyBundle() PolicyBundle {
 func validCapabilitiesResponse() CapabilitiesResponse {
 	return CapabilitiesResponse{
 		SchemaVersion:          SchemaVersion,
-		BossID:                 "boss-us-1",
+		ConductorID:            "conductor-us-1",
 		RequiredMTLS:           true,
 		ConductorBundle:        SchemaRange{Min: 1, Max: 1},
 		RemoteKill:             SchemaRange{Min: 1, Max: 1},
@@ -382,6 +402,7 @@ func testRollbackAuthorization() RollbackAuthorization {
 }
 
 func testAuditBatch() AuditBatchEnvelope {
+	payload := testAuditPayload()
 	return AuditBatchEnvelope{
 		SchemaVersion:      SchemaVersion,
 		BatchID:            "audit-batch-0001",
@@ -393,8 +414,8 @@ func testAuditBatch() AuditBatchEnvelope {
 		SeqStart:           10,
 		SeqEnd:             20,
 		EventCount:         11,
-		PayloadSHA256:      testHash("10"),
-		PayloadBytes:       4096,
+		PayloadSHA256:      testBytesHash(payload),
+		PayloadBytes:       uint64(len(payload)),
 		Chain: EvidenceChain{
 			EntryVersion:           2,
 			SegmentID:              "segment-1",
@@ -576,6 +597,12 @@ func TestRemoteKillMessage_ValidateAtTimeAndReasonCap(t *testing.T) {
 	if err := oversized.Validate(); !errors.Is(err, ErrPayloadTooLarge) {
 		t.Fatalf("Validate(oversized reason) = %v, want ErrPayloadTooLarge", err)
 	}
+
+	control := testRemoteKillMessage()
+	control.Reason = "incident\nsecond-line"
+	if err := control.Validate(); !errors.Is(err, ErrInvalidReason) {
+		t.Fatalf("Validate(control reason) = %v, want ErrInvalidReason", err)
+	}
 }
 
 func TestRollbackAuthorization_ValidateAtTime(t *testing.T) {
@@ -589,26 +616,46 @@ func TestRollbackAuthorization_ValidateAtTime(t *testing.T) {
 	}
 }
 
-func TestAuditBatchEnvelope_ValidateForBossSkew(t *testing.T) {
+func TestAuditBatchEnvelope_ValidateForConductorSkew(t *testing.T) {
 	batch := testAuditBatch()
 	// Inside default skew.
-	if err := batch.ValidateForBoss(testNow.Add(30*time.Second), DefaultAuditMaxSkew); err != nil {
-		t.Fatalf("ValidateForBoss(inside) = %v, want nil", err)
+	if err := batch.ValidateForConductor(testNow.Add(30*time.Second), DefaultAuditMaxSkew); err != nil {
+		t.Fatalf("ValidateForConductor(inside) = %v, want nil", err)
 	}
 	// Past default skew → ErrSkewExceeded.
-	err := batch.ValidateForBoss(testNow.Add(2*time.Minute), DefaultAuditMaxSkew)
+	err := batch.ValidateForConductor(testNow.Add(2*time.Minute), DefaultAuditMaxSkew)
 	if !errors.Is(err, ErrSkewExceeded) {
-		t.Fatalf("ValidateForBoss(past) = %v, want ErrSkewExceeded", err)
+		t.Fatalf("ValidateForConductor(past) = %v, want ErrSkewExceeded", err)
 	}
 	// Future emission > skew (clock drift) → ErrSkewExceeded.
-	err = batch.ValidateForBoss(testNow.Add(-2*time.Minute), DefaultAuditMaxSkew)
+	err = batch.ValidateForConductor(testNow.Add(-2*time.Minute), DefaultAuditMaxSkew)
 	if !errors.Is(err, ErrSkewExceeded) {
-		t.Fatalf("ValidateForBoss(future) = %v, want ErrSkewExceeded", err)
+		t.Fatalf("ValidateForConductor(future) = %v, want ErrSkewExceeded", err)
 	}
 	// Operator misconfig > MaxAllowedAuditSkew → ErrSkewExceeded.
-	err = batch.ValidateForBoss(testNow, MaxAllowedAuditSkew+time.Second)
+	err = batch.ValidateForConductor(testNow, MaxAllowedAuditSkew+time.Second)
 	if !errors.Is(err, ErrSkewExceeded) {
-		t.Fatalf("ValidateForBoss(over-cap config) = %v, want ErrSkewExceeded", err)
+		t.Fatalf("ValidateForConductor(over-cap config) = %v, want ErrSkewExceeded", err)
+	}
+}
+
+func TestAuditBatchEnvelope_ValidateForConductorWithPayload(t *testing.T) {
+	batch := testAuditBatch()
+	payload := testAuditPayload()
+	if err := batch.ValidateForConductorWithPayload(testNow, DefaultAuditMaxSkew, payload); err != nil {
+		t.Fatalf("ValidateForConductorWithPayload(valid) = %v, want nil", err)
+	}
+
+	err := batch.ValidateForConductorWithPayload(testNow, DefaultAuditMaxSkew, append(payload, 'x'))
+	if !errors.Is(err, ErrHashMismatch) {
+		t.Fatalf("ValidateForConductorWithPayload(size mismatch) = %v, want ErrHashMismatch", err)
+	}
+
+	sameSizeDifferentHash := append([]byte(nil), payload...)
+	sameSizeDifferentHash[0] ^= 0x01
+	err = batch.ValidateForConductorWithPayload(testNow, DefaultAuditMaxSkew, sameSizeDifferentHash)
+	if !errors.Is(err, ErrHashMismatch) {
+		t.Fatalf("ValidateForConductorWithPayload(hash mismatch) = %v, want ErrHashMismatch", err)
 	}
 }
 
@@ -644,6 +691,26 @@ func TestAudience_RejectsMixedWildcard(t *testing.T) {
 	// Pure wildcard still passes.
 	if err := (Audience{InstanceIDs: []string{"*"}}).Validate(); err != nil {
 		t.Fatalf("Validate(pure wildcard) = %v, want nil", err)
+	}
+}
+
+func TestAudience_RejectsMixedSelectorTypes(t *testing.T) {
+	a := Audience{
+		InstanceIDs: []string{"instance-1"},
+		Labels:      map[string]string{"ring": "canary"},
+	}
+	err := a.Validate()
+	if !errors.Is(err, ErrInvalidAudienceSelectors) {
+		t.Fatalf("Validate() = %v, want ErrInvalidAudienceSelectors", err)
+	}
+	if !errors.Is(err, ErrInvalidAudience) {
+		t.Fatalf("Validate() = %v, want ErrInvalidAudience classification", err)
+	}
+}
+
+func TestIsIdentifierRejectsEmpty(t *testing.T) {
+	if isIdentifier("") {
+		t.Fatal("isIdentifier(empty) = true, want false")
 	}
 }
 
@@ -800,6 +867,31 @@ func mapResolver(keys map[string]SignatureKey) SignatureKeyResolver {
 		}
 		return key, nil
 	}
+}
+
+func mustPayloadHash(payload PolicyBundlePayload) string {
+	hash, err := payload.PayloadHash()
+	if err != nil {
+		panic(err)
+	}
+	return hash
+}
+
+func mustPolicyHash(payload PolicyBundlePayload) string {
+	hash, err := payload.PolicyHash()
+	if err != nil {
+		panic(err)
+	}
+	return hash
+}
+
+func testAuditPayload() []byte {
+	return []byte(`{"events":[{"seq":10,"kind":"scan","verdict":"allow"},{"seq":11,"kind":"scan","verdict":"block"}]}`)
+}
+
+func testBytesHash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }
 
 func testHash(seed string) string {

--- a/internal/conductor/messages_test.go
+++ b/internal/conductor/messages_test.go
@@ -1,0 +1,811 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package conductor
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+var testNow = time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+
+func TestPolicyBundle_SignablePreimageExcludesSignatures(t *testing.T) {
+	a := testPolicyBundle()
+	b := testPolicyBundle()
+	b.Signatures[0].Signature = testSignature("ab")
+	b.Signatures[0].SignerKeyID = "different-signer"
+
+	preA, err := a.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage(a): %v", err)
+	}
+	preB, err := b.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage(b): %v", err)
+	}
+	if string(preA) != string(preB) {
+		t.Fatalf("preimage changed when detached signatures changed:\na=%s\nb=%s", preA, preB)
+	}
+}
+
+func TestPolicyBundle_Validate(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		if err := testPolicyBundle().Validate(); err != nil {
+			t.Fatalf("Validate() = %v, want nil", err)
+		}
+	})
+
+	t.Run("forbidden_license_field", func(t *testing.T) {
+		b := testPolicyBundle()
+		b.Payload.ConfigYAML = "mode: strict\nlicense_key: token\n"
+		err := b.Validate()
+		if !errors.Is(err, ErrForbiddenLicenseField) {
+			t.Fatalf("Validate() = %v, want ErrForbiddenLicenseField", err)
+		}
+	})
+
+	t.Run("wrong_signature_purpose", func(t *testing.T) {
+		b := testPolicyBundle()
+		b.Signatures[0].KeyPurpose = signing.PurposeRemoteKillSigning
+		err := b.Validate()
+		if !errors.Is(err, ErrWrongKeyPurpose) {
+			t.Fatalf("Validate() = %v, want ErrWrongKeyPurpose", err)
+		}
+	})
+
+	t.Run("audience_mismatch", func(t *testing.T) {
+		b := testPolicyBundle()
+		err := b.ValidateForFollower("org-test", "fleet-prod", "instance-other", map[string]string{"tier": "prod"})
+		if !errors.Is(err, ErrAudienceMismatch) {
+			t.Fatalf("ValidateForFollower() = %v, want ErrAudienceMismatch", err)
+		}
+	})
+
+	t.Run("label_audience_match", func(t *testing.T) {
+		b := testPolicyBundle()
+		b.Audience = Audience{Labels: map[string]string{"tier": "prod"}}
+		err := b.ValidateForFollower("org-test", "fleet-prod", "instance-other", map[string]string{"tier": "prod"})
+		if err != nil {
+			t.Fatalf("ValidateForFollower() = %v, want nil", err)
+		}
+	})
+}
+
+func TestRemoteKillMessage_RequiresTwoDistinctSigners(t *testing.T) {
+	msg := testRemoteKillMessage()
+	if err := msg.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+
+	msg.Signatures = msg.Signatures[:1]
+	err := msg.Validate()
+	if !errors.Is(err, ErrThresholdRequired) {
+		t.Fatalf("Validate() = %v, want ErrThresholdRequired", err)
+	}
+
+	msg = testRemoteKillMessage()
+	msg.Signatures[1].SignerKeyID = msg.Signatures[0].SignerKeyID
+	err = msg.Validate()
+	if !errors.Is(err, ErrThresholdRequired) {
+		t.Fatalf("Validate() duplicate signer = %v, want ErrThresholdRequired", err)
+	}
+}
+
+func TestRollbackAuthorization_RequiresLowerTargetVersion(t *testing.T) {
+	auth := testRollbackAuthorization()
+	if err := auth.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+
+	auth.TargetVersion = auth.CurrentVersion
+	err := auth.Validate()
+	if !errors.Is(err, ErrInvalidRollback) {
+		t.Fatalf("Validate() = %v, want ErrInvalidRollback", err)
+	}
+}
+
+func TestAuditBatchEnvelope_ValidateV2ChainAndForkDetection(t *testing.T) {
+	batch := testAuditBatch()
+	if err := batch.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+
+	v1 := batch
+	v1.Chain.EntryVersion = 1
+	err := v1.Validate()
+	if !errors.Is(err, ErrInvalidSequenceRange) {
+		t.Fatalf("Validate() with v1 chain = %v, want ErrInvalidSequenceRange", err)
+	}
+
+	other := batch
+	other.PayloadSHA256 = testHash("20")
+	if !batch.ForksWith(other) {
+		t.Fatal("ForksWith() = false for overlapping seq range with different payload hash")
+	}
+
+	nonOverlap := other
+	nonOverlap.SeqStart = batch.SeqEnd + 1
+	nonOverlap.SeqEnd = batch.SeqEnd + 10
+	if batch.ForksWith(nonOverlap) {
+		t.Fatal("ForksWith() = true for non-overlapping seq range")
+	}
+}
+
+func TestAuditBatchEnvelope_DroppedAccounting(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		batch := testAuditBatch()
+		batch.Dropped = DroppedAccounting{
+			Count: 3,
+			Reasons: []DroppedReason{
+				{Reason: "queue_full", Count: 2},
+				{Reason: "payload_too_large", Count: 1},
+			},
+		}
+		if err := batch.Validate(); err != nil {
+			t.Fatalf("Validate() = %v, want nil", err)
+		}
+	})
+
+	t.Run("count_mismatch", func(t *testing.T) {
+		batch := testAuditBatch()
+		batch.Dropped = DroppedAccounting{
+			Count:   3,
+			Reasons: []DroppedReason{{Reason: "queue_full", Count: 2}},
+		}
+		err := batch.Validate()
+		if !errors.Is(err, ErrInvalidDroppedAccounting) {
+			t.Fatalf("Validate() = %v, want ErrInvalidDroppedAccounting", err)
+		}
+	})
+
+	t.Run("duplicate_reason", func(t *testing.T) {
+		batch := testAuditBatch()
+		batch.Dropped = DroppedAccounting{
+			Count: 2,
+			Reasons: []DroppedReason{
+				{Reason: "queue_full", Count: 1},
+				{Reason: "queue_full", Count: 1},
+			},
+		}
+		err := batch.Validate()
+		if !errors.Is(err, ErrInvalidDroppedAccounting) {
+			t.Fatalf("Validate() = %v, want ErrInvalidDroppedAccounting", err)
+		}
+	})
+}
+
+func TestCapabilitiesResponse_RequiresMTLSAndThresholds(t *testing.T) {
+	caps := CapabilitiesResponse{
+		SchemaVersion:          SchemaVersion,
+		BossID:                 "boss-us-1",
+		RequiredMTLS:           true,
+		ConductorBundle:        SchemaRange{Min: 1, Max: 1},
+		RemoteKill:             SchemaRange{Min: 1, Max: 1},
+		RollbackAuthorization:  SchemaRange{Min: 1, Max: 1},
+		AuditBatch:             SchemaRange{Min: 1, Max: 3},
+		ReceiptEntryVersions:   []int{2},
+		MaxCreatedSkewSeconds:  int(DefaultAuditMaxSkew / time.Second),
+		EmergencyStream:        true,
+		RemoteKillThreshold:    RequiredCatastrophicSigners,
+		RollbackThreshold:      RequiredCatastrophicSigners,
+		TrustRotationThreshold: RequiredCatastrophicSigners,
+	}
+	if err := caps.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+
+	caps.RequiredMTLS = false
+	err := caps.Validate()
+	if !errors.Is(err, ErrInvalidState) {
+		t.Fatalf("Validate() = %v, want ErrInvalidState", err)
+	}
+
+	caps = validCapabilitiesResponse()
+	caps.ReceiptEntryVersions = []int{1}
+	err = caps.Validate()
+	if !errors.Is(err, ErrInvalidState) {
+		t.Fatalf("Validate() without v2 receipt entries = %v, want ErrInvalidState", err)
+	}
+
+	caps = validCapabilitiesResponse()
+	caps.MaxCreatedSkewSeconds = int(MaxAllowedAuditSkew/time.Second) + 1
+	err = caps.Validate()
+	if !errors.Is(err, ErrSkewExceeded) {
+		t.Fatalf("Validate() over skew cap = %v, want ErrSkewExceeded", err)
+	}
+
+	caps = validCapabilitiesResponse()
+	caps.RemoteKill = SchemaRange{Min: 2, Max: 3}
+	err = caps.Validate()
+	if !errors.Is(err, ErrInvalidState) {
+		t.Fatalf("Validate() range excluding current schema = %v, want ErrInvalidState", err)
+	}
+
+	caps = validCapabilitiesResponse()
+	caps.RemoteKillThreshold = MaxCapabilityThreshold + 1
+	err = caps.Validate()
+	if !errors.Is(err, ErrThresholdRequired) {
+		t.Fatalf("Validate() over local threshold cap = %v, want ErrThresholdRequired", err)
+	}
+
+	caps = validCapabilitiesResponse()
+	caps.RemoteKillThreshold = MaxCapabilityThreshold + 1
+	if err := caps.ValidateWithLocalThresholdCap(MaxCapabilityThreshold + 2); err != nil {
+		t.Fatalf("ValidateWithLocalThresholdCap(custom cap) = %v, want nil", err)
+	}
+}
+
+func TestPolicyBundle_VerifySignatures(t *testing.T) {
+	bundle := testPolicyBundle()
+	pub, proof := signedProof(t, bundle.SignablePreimage, "policy-signer-1", signing.PurposePolicyBundleSigning)
+	bundle.Signatures = []SignatureProof{proof}
+	resolver := mapResolver(map[string]SignatureKey{
+		"policy-signer-1": {PublicKey: pub, KeyPurpose: signing.PurposePolicyBundleSigning},
+	})
+
+	if err := bundle.VerifySignatures(resolver); err != nil {
+		t.Fatalf("VerifySignatures() = %v, want nil", err)
+	}
+
+	tampered := bundle
+	tampered.PolicyHash = testHash("09")
+	err := tampered.VerifySignatures(resolver)
+	if !errors.Is(err, ErrSignatureVerification) {
+		t.Fatalf("VerifySignatures(tampered) = %v, want ErrSignatureVerification", err)
+	}
+
+	err = bundle.VerifySignatures(mapResolver(map[string]SignatureKey{
+		"policy-signer-1": {PublicKey: pub, KeyPurpose: signing.PurposeRemoteKillSigning},
+	}))
+	if !errors.Is(err, ErrWrongKeyPurpose) {
+		t.Fatalf("VerifySignatures(wrong roster purpose) = %v, want ErrWrongKeyPurpose", err)
+	}
+}
+
+func TestRemoteKillMessage_VerifySignaturesThreshold(t *testing.T) {
+	msg := testRemoteKillMessage()
+	pub1, proof1 := signedProof(t, msg.SignablePreimage, "kill-signer-1", signing.PurposeRemoteKillSigning)
+	pub2, proof2 := signedProof(t, msg.SignablePreimage, "kill-signer-2", signing.PurposeRemoteKillSigning)
+	msg.Signatures = []SignatureProof{proof1, proof2}
+	resolver := mapResolver(map[string]SignatureKey{
+		"kill-signer-1": {PublicKey: pub1, KeyPurpose: signing.PurposeRemoteKillSigning},
+		"kill-signer-2": {PublicKey: pub2, KeyPurpose: signing.PurposeRemoteKillSigning},
+	})
+
+	if err := msg.VerifySignatures(resolver); err != nil {
+		t.Fatalf("VerifySignatures() = %v, want nil", err)
+	}
+
+	msg.Signatures = []SignatureProof{proof1}
+	err := msg.VerifySignatures(resolver)
+	if !errors.Is(err, ErrThresholdRequired) {
+		t.Fatalf("VerifySignatures(one signer) = %v, want ErrThresholdRequired", err)
+	}
+}
+
+func testPolicyBundle() PolicyBundle {
+	return PolicyBundle{
+		SchemaVersion:      SchemaVersion,
+		BundleID:           "bundle-0001",
+		OrgID:              "org-test",
+		FleetID:            "fleet-prod",
+		Environment:        "prod",
+		Audience:           Audience{InstanceIDs: []string{"instance-1"}},
+		Version:            1,
+		PreviousBundleHash: testHash("01"),
+		CreatedAt:          testNow,
+		NotBefore:          testNow.Add(-time.Minute),
+		ExpiresAt:          testNow.Add(time.Hour),
+		MinPipelockVersion: "1.2.3",
+		PolicyHash:         testHash("02"),
+		PayloadSHA256:      testHash("03"),
+		Payload: PolicyBundlePayload{
+			ConfigYAML: "mode: strict\nagents:\n  claude-code:\n    mode: strict\n",
+			RuleBundles: []RuleBundleRef{{
+				Name:    "official",
+				Version: "2026.05.23",
+				SHA256:  testHash("04"),
+			}},
+		},
+		Signatures: []SignatureProof{
+			testProof("policy-signer-1", signing.PurposePolicyBundleSigning),
+		},
+	}
+}
+
+func validCapabilitiesResponse() CapabilitiesResponse {
+	return CapabilitiesResponse{
+		SchemaVersion:          SchemaVersion,
+		BossID:                 "boss-us-1",
+		RequiredMTLS:           true,
+		ConductorBundle:        SchemaRange{Min: 1, Max: 1},
+		RemoteKill:             SchemaRange{Min: 1, Max: 1},
+		RollbackAuthorization:  SchemaRange{Min: 1, Max: 1},
+		AuditBatch:             SchemaRange{Min: 1, Max: 3},
+		ReceiptEntryVersions:   []int{2},
+		MaxCreatedSkewSeconds:  int(DefaultAuditMaxSkew / time.Second),
+		EmergencyStream:        true,
+		RemoteKillThreshold:    RequiredCatastrophicSigners,
+		RollbackThreshold:      RequiredCatastrophicSigners,
+		TrustRotationThreshold: RequiredCatastrophicSigners,
+	}
+}
+
+func testRemoteKillMessage() RemoteKillMessage {
+	return RemoteKillMessage{
+		SchemaVersion: SchemaVersion,
+		MessageID:     "kill-0001",
+		OrgID:         "org-test",
+		FleetID:       "fleet-prod",
+		Audience:      Audience{InstanceIDs: []string{"*"}},
+		State:         KillSwitchActive,
+		Counter:       42,
+		Reason:        "incident",
+		CreatedAt:     testNow,
+		NotBefore:     testNow.Add(-time.Minute),
+		ExpiresAt:     testNow.Add(5 * time.Minute),
+		Signatures: []SignatureProof{
+			testProof("kill-signer-1", signing.PurposeRemoteKillSigning),
+			testProof("kill-signer-2", signing.PurposeRemoteKillSigning),
+		},
+	}
+}
+
+func testRollbackAuthorization() RollbackAuthorization {
+	return RollbackAuthorization{
+		SchemaVersion:   SchemaVersion,
+		AuthorizationID: "rollback-0001",
+		OrgID:           "org-test",
+		FleetID:         "fleet-prod",
+		Audience:        Audience{Labels: map[string]string{"tier": "prod"}},
+		CurrentBundleID: "bundle-0002",
+		CurrentVersion:  2,
+		TargetBundleID:  "bundle-0001",
+		TargetVersion:   1,
+		Counter:         5,
+		Reason:          "bad bundle",
+		CreatedAt:       testNow,
+		ExpiresAt:       testNow.Add(10 * time.Minute),
+		Signatures: []SignatureProof{
+			testProof("rollback-signer-1", signing.PurposePolicyBundleRollback),
+			testProof("rollback-signer-2", signing.PurposePolicyBundleRollback),
+		},
+	}
+}
+
+func testAuditBatch() AuditBatchEnvelope {
+	return AuditBatchEnvelope{
+		SchemaVersion:      SchemaVersion,
+		BatchID:            "audit-batch-0001",
+		OrgID:              "org-test",
+		FleetID:            "fleet-prod",
+		InstanceID:         "instance-1",
+		AuditSchemaVersion: 2,
+		EmittedAt:          testNow,
+		SeqStart:           10,
+		SeqEnd:             20,
+		EventCount:         11,
+		PayloadSHA256:      testHash("10"),
+		PayloadBytes:       4096,
+		Chain: EvidenceChain{
+			EntryVersion:           2,
+			SegmentID:              "segment-1",
+			SeqStart:               10,
+			SeqEnd:                 20,
+			PreviousSegmentTail:    testHash("11"),
+			SegmentHeadHash:        testHash("12"),
+			SegmentTailHash:        testHash("13"),
+			CheckpointSeq:          20,
+			CheckpointHash:         testHash("14"),
+			CheckpointSignature:    testSignature("15"),
+			CheckpointSignerKeyID:  "recorder-signer-1",
+			FollowerRecorderKeyID:  "recorder-key-1",
+			FollowerRecorderPubHex: strings.Repeat("16", 32),
+		},
+		Signatures: []SignatureProof{
+			testProof("instance-audit-signer-1", signing.PurposeAuditBatchSigning),
+		},
+	}
+}
+
+func TestPolicyBundle_PreimageStableAcrossTimezones(t *testing.T) {
+	// Two bundles that describe the same logical instant but in different
+	// timezones must produce identical canonical preimages. Without the
+	// UTC normalization in SignablePreimage, Go's default time.Time JSON
+	// marshal embeds the source zone offset and the signed bytes diverge.
+	utc := testPolicyBundle()
+	utc.CreatedAt = utc.CreatedAt.UTC()
+	utc.NotBefore = utc.NotBefore.UTC()
+	utc.ExpiresAt = utc.ExpiresAt.UTC()
+
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Skipf("timezone data unavailable: %v", err)
+	}
+	jst := testPolicyBundle()
+	jst.CreatedAt = jst.CreatedAt.In(tokyo)
+	jst.NotBefore = jst.NotBefore.In(tokyo)
+	jst.ExpiresAt = jst.ExpiresAt.In(tokyo)
+
+	preUTC, err := utc.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage(utc): %v", err)
+	}
+	preJST, err := jst.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage(jst): %v", err)
+	}
+	if string(preUTC) != string(preJST) {
+		t.Fatalf("preimage diverged across timezones:\nutc=%s\njst=%s", preUTC, preJST)
+	}
+}
+
+func TestPolicyBundle_PreimageChangesWithPolicyFields(t *testing.T) {
+	// Detached-signature stability is one half of the contract; the other
+	// half is that changing actual policy content MUST change the preimage.
+	// A regression that drops a field from the canonicalization (refactor,
+	// json tag change, etc.) silently breaks the entire signing chain.
+	base := testPolicyBundle()
+	basePre, err := base.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage(base): %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*PolicyBundle)
+	}{
+		{"min_pipelock_version", func(b *PolicyBundle) { b.MinPipelockVersion = "9.9.9" }},
+		{"previous_bundle_hash", func(b *PolicyBundle) { b.PreviousBundleHash = testHash("ff") }},
+		{"environment", func(b *PolicyBundle) { b.Environment = "staging" }},
+		{"audience_instance", func(b *PolicyBundle) { b.Audience = Audience{InstanceIDs: []string{"instance-other"}} }},
+		{"version", func(b *PolicyBundle) { b.Version = 999 }},
+		{"config_yaml", func(b *PolicyBundle) { b.Payload.ConfigYAML = "mode: balanced\n" }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mut := testPolicyBundle()
+			tc.mutate(&mut)
+			pre, err := mut.SignablePreimage()
+			if err != nil {
+				t.Fatalf("SignablePreimage: %v", err)
+			}
+			if string(pre) == string(basePre) {
+				t.Fatalf("preimage unchanged after mutating %s — field is missing from canonicalization", tc.name)
+			}
+		})
+	}
+}
+
+func TestPolicyBundle_RejectsNestedLicenseField(t *testing.T) {
+	// Shallow rejection misses license keys smuggled under agents.<name>
+	// or any other submap. The recursive walker must surface the full path.
+	b := testPolicyBundle()
+	b.Payload.ConfigYAML = "mode: strict\nagents:\n  claude-code:\n    license_key: smuggled\n"
+	err := b.Validate()
+	if !errors.Is(err, ErrForbiddenLicenseField) {
+		t.Fatalf("Validate() = %v, want ErrForbiddenLicenseField", err)
+	}
+	if !strings.Contains(err.Error(), "agents.claude-code.license_key") {
+		t.Fatalf("error should name nested path; got %v", err)
+	}
+}
+
+func TestPolicyBundle_RequiresMinPipelockVersion(t *testing.T) {
+	t.Run("missing", func(t *testing.T) {
+		b := testPolicyBundle()
+		b.MinPipelockVersion = ""
+		err := b.Validate()
+		if !errors.Is(err, ErrMissingField) {
+			t.Fatalf("Validate() = %v, want ErrMissingField", err)
+		}
+	})
+	t.Run("malformed", func(t *testing.T) {
+		b := testPolicyBundle()
+		b.MinPipelockVersion = "1.2"
+		err := b.Validate()
+		if !errors.Is(err, ErrInvalidMinVersion) {
+			t.Fatalf("Validate() = %v, want ErrInvalidMinVersion", err)
+		}
+	})
+	t.Run("non_numeric_component", func(t *testing.T) {
+		b := testPolicyBundle()
+		b.MinPipelockVersion = "1.2.beta"
+		err := b.Validate()
+		if !errors.Is(err, ErrInvalidMinVersion) {
+			t.Fatalf("Validate() = %v, want ErrInvalidMinVersion", err)
+		}
+	})
+	t.Run("leading_zero_component", func(t *testing.T) {
+		b := testPolicyBundle()
+		b.MinPipelockVersion = "1.02.3"
+		err := b.Validate()
+		if !errors.Is(err, ErrInvalidMinVersion) {
+			t.Fatalf("Validate() = %v, want ErrInvalidMinVersion", err)
+		}
+	})
+}
+
+func TestPolicyBundle_ConfigYAMLSizeCap(t *testing.T) {
+	b := testPolicyBundle()
+	b.Payload.ConfigYAML = "mode: strict\n" + strings.Repeat("# noise\n", MaxConfigYAMLBytes)
+	err := b.Validate()
+	if !errors.Is(err, ErrPayloadTooLarge) {
+		t.Fatalf("Validate() = %v, want ErrPayloadTooLarge", err)
+	}
+}
+
+func TestPolicyBundle_ValidateAtTime(t *testing.T) {
+	b := testPolicyBundle()
+	// Inside window passes.
+	if err := b.ValidateAtTime(testNow); err != nil {
+		t.Fatalf("ValidateAtTime(inside) = %v, want nil", err)
+	}
+	// Before NotBefore → ErrNotYetValid.
+	err := b.ValidateAtTime(b.NotBefore.Add(-time.Hour))
+	if !errors.Is(err, ErrNotYetValid) {
+		t.Fatalf("ValidateAtTime(before) = %v, want ErrNotYetValid", err)
+	}
+	// After ExpiresAt → ErrExpired.
+	err = b.ValidateAtTime(b.ExpiresAt.Add(time.Hour))
+	if !errors.Is(err, ErrExpired) {
+		t.Fatalf("ValidateAtTime(after) = %v, want ErrExpired", err)
+	}
+}
+
+func TestRemoteKillMessage_ValidateAtTimeAndReasonCap(t *testing.T) {
+	m := testRemoteKillMessage()
+	if err := m.ValidateAtTime(testNow); err != nil {
+		t.Fatalf("ValidateAtTime(inside) = %v, want nil", err)
+	}
+	err := m.ValidateAtTime(m.ExpiresAt.Add(time.Minute))
+	if !errors.Is(err, ErrExpired) {
+		t.Fatalf("ValidateAtTime(after) = %v, want ErrExpired", err)
+	}
+
+	oversized := testRemoteKillMessage()
+	oversized.Reason = strings.Repeat("x", MaxReasonBytes+1)
+	if err := oversized.Validate(); !errors.Is(err, ErrPayloadTooLarge) {
+		t.Fatalf("Validate(oversized reason) = %v, want ErrPayloadTooLarge", err)
+	}
+}
+
+func TestRollbackAuthorization_ValidateAtTime(t *testing.T) {
+	r := testRollbackAuthorization()
+	if err := r.ValidateAtTime(testNow); err != nil {
+		t.Fatalf("ValidateAtTime(inside) = %v, want nil", err)
+	}
+	err := r.ValidateAtTime(r.ExpiresAt.Add(time.Second))
+	if !errors.Is(err, ErrExpired) {
+		t.Fatalf("ValidateAtTime(after) = %v, want ErrExpired", err)
+	}
+}
+
+func TestAuditBatchEnvelope_ValidateForBossSkew(t *testing.T) {
+	batch := testAuditBatch()
+	// Inside default skew.
+	if err := batch.ValidateForBoss(testNow.Add(30*time.Second), DefaultAuditMaxSkew); err != nil {
+		t.Fatalf("ValidateForBoss(inside) = %v, want nil", err)
+	}
+	// Past default skew → ErrSkewExceeded.
+	err := batch.ValidateForBoss(testNow.Add(2*time.Minute), DefaultAuditMaxSkew)
+	if !errors.Is(err, ErrSkewExceeded) {
+		t.Fatalf("ValidateForBoss(past) = %v, want ErrSkewExceeded", err)
+	}
+	// Future emission > skew (clock drift) → ErrSkewExceeded.
+	err = batch.ValidateForBoss(testNow.Add(-2*time.Minute), DefaultAuditMaxSkew)
+	if !errors.Is(err, ErrSkewExceeded) {
+		t.Fatalf("ValidateForBoss(future) = %v, want ErrSkewExceeded", err)
+	}
+	// Operator misconfig > MaxAllowedAuditSkew → ErrSkewExceeded.
+	err = batch.ValidateForBoss(testNow, MaxAllowedAuditSkew+time.Second)
+	if !errors.Is(err, ErrSkewExceeded) {
+		t.Fatalf("ValidateForBoss(over-cap config) = %v, want ErrSkewExceeded", err)
+	}
+}
+
+func TestAuditBatchEnvelope_PayloadBytesClassification(t *testing.T) {
+	t.Run("missing", func(t *testing.T) {
+		batch := testAuditBatch()
+		batch.PayloadBytes = 0
+		err := batch.Validate()
+		if !errors.Is(err, ErrMissingField) {
+			t.Fatalf("Validate() = %v, want ErrMissingField", err)
+		}
+	})
+
+	t.Run("too_large", func(t *testing.T) {
+		batch := testAuditBatch()
+		batch.PayloadBytes = MaxAuditPayloadBytes + 1
+		err := batch.Validate()
+		if !errors.Is(err, ErrPayloadTooLarge) {
+			t.Fatalf("Validate() = %v, want ErrPayloadTooLarge", err)
+		}
+	})
+}
+
+func TestAudience_RejectsMixedWildcard(t *testing.T) {
+	a := Audience{InstanceIDs: []string{"*", "instance-1"}}
+	err := a.Validate()
+	if !errors.Is(err, ErrInvalidAudienceWildcard) {
+		t.Fatalf("Validate() = %v, want ErrInvalidAudienceWildcard", err)
+	}
+	if !errors.Is(err, ErrInvalidAudience) {
+		t.Fatalf("Validate() = %v, want ErrInvalidAudience classification", err)
+	}
+	// Pure wildcard still passes.
+	if err := (Audience{InstanceIDs: []string{"*"}}).Validate(); err != nil {
+		t.Fatalf("Validate(pure wildcard) = %v, want nil", err)
+	}
+}
+
+func TestRemoteKillMessage_RejectsSamePublicKeyAcrossSignerIDs(t *testing.T) {
+	// A roster that maps two distinct IDs to the same public key would
+	// otherwise satisfy threshold with one underlying signer. This is the
+	// exact failure mode the catastrophic-threshold rule exists to prevent.
+	msg := testRemoteKillMessage()
+	pub, proof1 := signedProof(t, msg.SignablePreimage, "kill-signer-A", signing.PurposeRemoteKillSigning)
+	_, proof2 := signedProof(t, msg.SignablePreimage, "kill-signer-B", signing.PurposeRemoteKillSigning)
+	// Force proof2's signature to a valid sig produced by pub by re-signing
+	// is not possible without the priv key; instead simulate the roster
+	// trick: both IDs map to the SAME pub. Use proof1's signature for both
+	// IDs so verification passes per-signature.
+	proof2.Signature = proof1.Signature
+	msg.Signatures = []SignatureProof{proof1, proof2}
+
+	resolver := mapResolver(map[string]SignatureKey{
+		"kill-signer-A": {PublicKey: pub, KeyPurpose: signing.PurposeRemoteKillSigning},
+		"kill-signer-B": {PublicKey: pub, KeyPurpose: signing.PurposeRemoteKillSigning},
+	})
+	err := msg.VerifySignaturesAt(testNow, resolver)
+	if !errors.Is(err, ErrThresholdRequired) {
+		t.Fatalf("VerifySignaturesAt(same pubkey under different IDs) = %v, want ErrThresholdRequired", err)
+	}
+}
+
+func TestPolicyBundle_VerifySignaturesRejectsRevokedAndExpiredRoster(t *testing.T) {
+	bundle := testPolicyBundle()
+	pub, proof := signedProof(t, bundle.SignablePreimage, "policy-signer-1", signing.PurposePolicyBundleSigning)
+	bundle.Signatures = []SignatureProof{proof}
+
+	t.Run("revoked", func(t *testing.T) {
+		revoked := testNow.Add(-time.Hour)
+		resolver := mapResolver(map[string]SignatureKey{
+			"policy-signer-1": {
+				PublicKey:  pub,
+				KeyPurpose: signing.PurposePolicyBundleSigning,
+				RevokedAt:  &revoked,
+			},
+		})
+		err := bundle.VerifySignaturesAt(testNow, resolver)
+		if !errors.Is(err, ErrSignatureVerification) {
+			t.Fatalf("VerifySignaturesAt(revoked) = %v, want ErrSignatureVerification", err)
+		}
+	})
+
+	t.Run("not_yet_valid", func(t *testing.T) {
+		resolver := mapResolver(map[string]SignatureKey{
+			"policy-signer-1": {
+				PublicKey:  pub,
+				KeyPurpose: signing.PurposePolicyBundleSigning,
+				NotBefore:  testNow.Add(time.Hour),
+			},
+		})
+		err := bundle.VerifySignaturesAt(testNow, resolver)
+		if !errors.Is(err, ErrNotYetValid) {
+			t.Fatalf("VerifySignaturesAt(not yet valid) = %v, want ErrNotYetValid", err)
+		}
+	})
+
+	t.Run("expired_key", func(t *testing.T) {
+		resolver := mapResolver(map[string]SignatureKey{
+			"policy-signer-1": {
+				PublicKey:  pub,
+				KeyPurpose: signing.PurposePolicyBundleSigning,
+				NotAfter:   testNow.Add(-time.Hour),
+			},
+		})
+		err := bundle.VerifySignaturesAt(testNow, resolver)
+		if !errors.Is(err, ErrExpired) {
+			t.Fatalf("VerifySignaturesAt(expired) = %v, want ErrExpired", err)
+		}
+	})
+
+	t.Run("nil_resolver", func(t *testing.T) {
+		err := bundle.VerifySignaturesAt(testNow, nil)
+		if !errors.Is(err, ErrSignatureVerification) {
+			t.Fatalf("VerifySignaturesAt(nil resolver) = %v, want ErrSignatureVerification", err)
+		}
+	})
+}
+
+func TestDroppedAccounting_OverflowGuard(t *testing.T) {
+	// Crafted Reason.Count values whose sum wraps uint64 back to d.Count
+	// would otherwise pass the count==total equality check.
+	d := DroppedAccounting{
+		Count: 5,
+		Reasons: []DroppedReason{
+			{Reason: "queue_full", Count: math.MaxUint64 - 4},
+			{Reason: "payload_too_large", Count: 10}, // sum wraps to 5
+		},
+	}
+	err := d.Validate()
+	if !errors.Is(err, ErrInvalidDroppedAccounting) {
+		t.Fatalf("Validate(overflow) = %v, want ErrInvalidDroppedAccounting", err)
+	}
+}
+
+func TestMessageIdentifiersAreBounded(t *testing.T) {
+	b := testPolicyBundle()
+	b.BundleID = "bad id with spaces"
+	err := b.Validate()
+	if !errors.Is(err, ErrInvalidIdentifier) {
+		t.Fatalf("Validate() = %v, want ErrInvalidIdentifier", err)
+	}
+
+	b = testPolicyBundle()
+	b.BundleID = strings.Repeat("a", MaxIDBytes+1)
+	err = b.Validate()
+	if !errors.Is(err, ErrInvalidIdentifier) {
+		t.Fatalf("Validate(long id) = %v, want ErrInvalidIdentifier", err)
+	}
+}
+
+func testProof(keyID string, purpose signing.KeyPurpose) SignatureProof {
+	return SignatureProof{
+		SignerKeyID: keyID,
+		KeyPurpose:  purpose,
+		Algorithm:   SignatureAlgorithmEd25519,
+		Signature:   testSignature("aa"),
+	}
+}
+
+func signedProof(
+	t *testing.T,
+	preimage func() ([]byte, error),
+	keyID string,
+	purpose signing.KeyPurpose,
+) (ed25519.PublicKey, SignatureProof) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	msg, err := preimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage: %v", err)
+	}
+	sig := ed25519.Sign(priv, msg)
+	return pub, SignatureProof{
+		SignerKeyID: keyID,
+		KeyPurpose:  purpose,
+		Algorithm:   SignatureAlgorithmEd25519,
+		Signature:   SignaturePrefixEd25519 + hex.EncodeToString(sig),
+	}
+}
+
+func mapResolver(keys map[string]SignatureKey) SignatureKeyResolver {
+	return func(signerKeyID string) (SignatureKey, error) {
+		key, ok := keys[signerKeyID]
+		if !ok {
+			return SignatureKey{}, ErrSignatureVerification
+		}
+		return key, nil
+	}
+}
+
+func testHash(seed string) string {
+	return strings.Repeat(seed, 32)
+}
+
+func testSignature(seed string) string {
+	return SignaturePrefixEd25519 + strings.Repeat(seed, 64)
+}

--- a/internal/conductor/messages_test.go
+++ b/internal/conductor/messages_test.go
@@ -826,6 +826,309 @@ func TestMessageIdentifiersAreBounded(t *testing.T) {
 	}
 }
 
+func TestPolicyBundlePayload_PolicyHashYAMLDocumentHandling(t *testing.T) {
+	payload := PolicyBundlePayload{ConfigYAML: "mode: strict\n---\n"}
+	if _, err := payload.PolicyHash(); err != nil {
+		t.Fatalf("PolicyHash(empty trailing doc) = %v, want nil", err)
+	}
+
+	payload.ConfigYAML = "mode: strict\n---\nmode: balanced\n"
+	_, err := payload.PolicyHash()
+	if !errors.Is(err, ErrInvalidHash) {
+		t.Fatalf("PolicyHash(non-empty trailing doc) = %v, want ErrInvalidHash", err)
+	}
+
+	payload.ConfigYAML = "mode: [\n"
+	if _, err := payload.PolicyHash(); err == nil {
+		t.Fatal("PolicyHash(malformed yaml) = nil, want error")
+	}
+}
+
+func TestCanonicalHashMethods(t *testing.T) {
+	if got, err := testPolicyBundle().CanonicalHash(); err != nil || got == "" {
+		t.Fatalf("PolicyBundle.CanonicalHash() = %q, %v; want hash", got, err)
+	}
+	if got, err := testRemoteKillMessage().CanonicalHash(); err != nil || got == "" {
+		t.Fatalf("RemoteKillMessage.CanonicalHash() = %q, %v; want hash", got, err)
+	}
+	if got, err := testRollbackAuthorization().CanonicalHash(); err != nil || got == "" {
+		t.Fatalf("RollbackAuthorization.CanonicalHash() = %q, %v; want hash", got, err)
+	}
+	if got, err := testAuditBatch().CanonicalHash(); err != nil || got == "" {
+		t.Fatalf("AuditBatchEnvelope.CanonicalHash() = %q, %v; want hash", got, err)
+	}
+}
+
+func TestRemoteKillMessage_ValidateForFollower(t *testing.T) {
+	msg := testRemoteKillMessage()
+	if err := msg.ValidateForFollower("org-test", "fleet-prod", "instance-1", nil); err != nil {
+		t.Fatalf("ValidateForFollower(wildcard) = %v, want nil", err)
+	}
+	if err := msg.ValidateForFollower("org-other", "fleet-prod", "instance-1", nil); !errors.Is(err, ErrAudienceMismatch) {
+		t.Fatalf("ValidateForFollower(org mismatch) = %v, want ErrAudienceMismatch", err)
+	}
+
+	msg.Audience = Audience{Labels: map[string]string{"ring": "canary"}}
+	if err := msg.ValidateForFollower("org-test", "fleet-prod", "instance-2", map[string]string{"ring": "canary"}); err != nil {
+		t.Fatalf("ValidateForFollower(label match) = %v, want nil", err)
+	}
+	if err := msg.ValidateForFollower("org-test", "fleet-prod", "instance-2", map[string]string{"ring": "prod"}); !errors.Is(err, ErrAudienceMismatch) {
+		t.Fatalf("ValidateForFollower(label mismatch) = %v, want ErrAudienceMismatch", err)
+	}
+}
+
+func TestRollbackAuthorization_VerifySignatures(t *testing.T) {
+	auth := testRollbackAuthorization()
+	pub1, proof1 := signedProof(t, auth.SignablePreimage, "rollback-signer-1", signing.PurposePolicyBundleRollback)
+	pub2, proof2 := signedProof(t, auth.SignablePreimage, "rollback-signer-2", signing.PurposePolicyBundleRollback)
+	auth.Signatures = []SignatureProof{proof1, proof2}
+	resolver := mapResolver(map[string]SignatureKey{
+		"rollback-signer-1": {PublicKey: pub1, KeyPurpose: signing.PurposePolicyBundleRollback},
+		"rollback-signer-2": {PublicKey: pub2, KeyPurpose: signing.PurposePolicyBundleRollback},
+	})
+	if err := auth.VerifySignatures(resolver); err != nil {
+		t.Fatalf("VerifySignatures() = %v, want nil", err)
+	}
+
+	auth.TargetBundleID = "bundle-other"
+	if err := auth.VerifySignaturesAt(testNow, resolver); !errors.Is(err, ErrSignatureVerification) {
+		t.Fatalf("VerifySignaturesAt(tampered) = %v, want ErrSignatureVerification", err)
+	}
+}
+
+func TestAuditBatchEnvelope_VerifySignatures(t *testing.T) {
+	batch := testAuditBatch()
+	pub, proof := signedProof(t, batch.SignablePreimage, "audit-signer-1", signing.PurposeAuditBatchSigning)
+	batch.Signatures = []SignatureProof{proof}
+	resolver := mapResolver(map[string]SignatureKey{
+		"audit-signer-1": {PublicKey: pub, KeyPurpose: signing.PurposeAuditBatchSigning},
+	})
+	if err := batch.VerifySignatures(resolver); err != nil {
+		t.Fatalf("VerifySignatures() = %v, want nil", err)
+	}
+
+	batch.PayloadBytes++
+	if err := batch.VerifySignaturesAt(testNow, resolver); !errors.Is(err, ErrSignatureVerification) {
+		t.Fatalf("VerifySignaturesAt(tampered) = %v, want ErrSignatureVerification", err)
+	}
+}
+
+func TestValidationEdgeCases(t *testing.T) {
+	t.Run("signature_proof_missing_signer", func(t *testing.T) {
+		err := (SignatureProof{KeyPurpose: signing.PurposePolicyBundleSigning, Algorithm: SignatureAlgorithmEd25519, Signature: testSignature("aa")}).
+			Validate(signing.PurposePolicyBundleSigning)
+		if !errors.Is(err, ErrMissingField) {
+			t.Fatalf("Validate() = %v, want ErrMissingField", err)
+		}
+	})
+
+	t.Run("signature_proof_bad_algorithm", func(t *testing.T) {
+		proof := testProof("signer-1", signing.PurposePolicyBundleSigning)
+		proof.Algorithm = "ecdsa"
+		err := proof.Validate(signing.PurposePolicyBundleSigning)
+		if !errors.Is(err, ErrInvalidSignature) {
+			t.Fatalf("Validate() = %v, want ErrInvalidSignature", err)
+		}
+	})
+
+	t.Run("dropped_reasons_with_zero_count", func(t *testing.T) {
+		err := (DroppedAccounting{Reasons: []DroppedReason{{Reason: "queue_full", Count: 1}}}).Validate()
+		if !errors.Is(err, ErrInvalidDroppedAccounting) {
+			t.Fatalf("Validate() = %v, want ErrInvalidDroppedAccounting", err)
+		}
+	})
+
+	t.Run("dropped_count_without_reasons", func(t *testing.T) {
+		err := (DroppedAccounting{Count: 1}).Validate()
+		if !errors.Is(err, ErrInvalidDroppedAccounting) {
+			t.Fatalf("Validate() = %v, want ErrInvalidDroppedAccounting", err)
+		}
+	})
+
+	t.Run("dropped_reason_invalid_identifier", func(t *testing.T) {
+		err := (DroppedReason{Reason: "bad reason", Count: 1}).Validate()
+		if !errors.Is(err, ErrInvalidDroppedAccounting) {
+			t.Fatalf("Validate() = %v, want ErrInvalidDroppedAccounting", err)
+		}
+	})
+
+	t.Run("rule_bundle_missing_version", func(t *testing.T) {
+		err := (RuleBundleRef{Name: "official", SHA256: testHash("04")}).Validate()
+		if !errors.Is(err, ErrMissingField) {
+			t.Fatalf("Validate() = %v, want ErrMissingField", err)
+		}
+	})
+
+	t.Run("evidence_chain_checkpoint_out_of_range", func(t *testing.T) {
+		chain := testAuditBatch().Chain
+		chain.CheckpointSeq = chain.SeqEnd + 1
+		err := chain.Validate(chain.SeqStart, chain.SeqEnd)
+		if !errors.Is(err, ErrInvalidSequenceRange) {
+			t.Fatalf("Validate() = %v, want ErrInvalidSequenceRange", err)
+		}
+	})
+
+	t.Run("invalid_signature_string_prefix", func(t *testing.T) {
+		err := validateEd25519SignatureString("bad:" + strings.Repeat("aa", 64))
+		if !errors.Is(err, ErrInvalidSignature) {
+			t.Fatalf("validateEd25519SignatureString() = %v, want ErrInvalidSignature", err)
+		}
+	})
+
+	t.Run("invalid_public_key_hex", func(t *testing.T) {
+		err := validatePublicKeyHex("pub", "ff")
+		if !errors.Is(err, ErrInvalidHash) {
+			t.Fatalf("validatePublicKeyHex() = %v, want ErrInvalidHash", err)
+		}
+	})
+}
+
+func TestRemoteKillMessage_ValidateErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*RemoteKillMessage)
+		want error
+	}{
+		{"unsupported_schema", func(m *RemoteKillMessage) { m.SchemaVersion = 99 }, ErrUnsupportedSchemaVersion},
+		{"missing_message_id", func(m *RemoteKillMessage) { m.MessageID = "" }, ErrMissingField},
+		{"missing_org", func(m *RemoteKillMessage) { m.OrgID = "" }, ErrMissingField},
+		{"empty_audience", func(m *RemoteKillMessage) { m.Audience = Audience{} }, ErrInvalidAudience},
+		{"invalid_state", func(m *RemoteKillMessage) { m.State = "paused" }, ErrInvalidState},
+		{"missing_counter", func(m *RemoteKillMessage) { m.Counter = 0 }, ErrMissingField},
+		{"invalid_window", func(m *RemoteKillMessage) { m.ExpiresAt = m.NotBefore }, ErrInvalidValidityWindow},
+		{"missing_created_at", func(m *RemoteKillMessage) { m.CreatedAt = time.Time{} }, ErrMissingField},
+		{"invalid_utf8_reason", func(m *RemoteKillMessage) { m.Reason = string([]byte{0xff}) }, ErrInvalidReason},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := testRemoteKillMessage()
+			tt.edit(&msg)
+			if err := msg.Validate(); !errors.Is(err, tt.want) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRollbackAuthorization_ValidateErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*RollbackAuthorization)
+		want error
+	}{
+		{"unsupported_schema", func(r *RollbackAuthorization) { r.SchemaVersion = 99 }, ErrUnsupportedSchemaVersion},
+		{"missing_authorization_id", func(r *RollbackAuthorization) { r.AuthorizationID = "" }, ErrMissingField},
+		{"missing_fleet", func(r *RollbackAuthorization) { r.FleetID = "" }, ErrMissingField},
+		{"empty_audience", func(r *RollbackAuthorization) { r.Audience = Audience{} }, ErrInvalidAudience},
+		{"missing_current_bundle", func(r *RollbackAuthorization) { r.CurrentBundleID = "" }, ErrMissingField},
+		{"missing_target_bundle", func(r *RollbackAuthorization) { r.TargetBundleID = "" }, ErrMissingField},
+		{"missing_counter", func(r *RollbackAuthorization) { r.Counter = 0 }, ErrMissingField},
+		{"invalid_validity", func(r *RollbackAuthorization) { r.ExpiresAt = r.CreatedAt }, ErrInvalidValidityWindow},
+		{"control_reason", func(r *RollbackAuthorization) { r.Reason = "bad\tbundle" }, ErrInvalidReason},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth := testRollbackAuthorization()
+			tt.edit(&auth)
+			if err := auth.Validate(); !errors.Is(err, tt.want) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestAuditBatchEnvelope_ValidateErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*AuditBatchEnvelope)
+		want error
+	}{
+		{"unsupported_schema", func(a *AuditBatchEnvelope) { a.SchemaVersion = 99 }, ErrUnsupportedSchemaVersion},
+		{"missing_batch_id", func(a *AuditBatchEnvelope) { a.BatchID = "" }, ErrMissingField},
+		{"missing_instance_id", func(a *AuditBatchEnvelope) { a.InstanceID = "" }, ErrMissingField},
+		{"missing_audit_schema", func(a *AuditBatchEnvelope) { a.AuditSchemaVersion = 0 }, ErrMissingField},
+		{"missing_emitted_at", func(a *AuditBatchEnvelope) { a.EmittedAt = time.Time{} }, ErrMissingField},
+		{"invalid_seq", func(a *AuditBatchEnvelope) { a.SeqEnd = a.SeqStart - 1 }, ErrInvalidSequenceRange},
+		{"missing_event_count", func(a *AuditBatchEnvelope) { a.EventCount = 0 }, ErrMissingField},
+		{"invalid_payload_hash", func(a *AuditBatchEnvelope) { a.PayloadSHA256 = "not-hex" }, ErrInvalidHash},
+		{"invalid_dropped", func(a *AuditBatchEnvelope) { a.Dropped = DroppedAccounting{Count: 1} }, ErrInvalidDroppedAccounting},
+		{"invalid_chain", func(a *AuditBatchEnvelope) { a.Chain.SeqEnd++ }, ErrInvalidSequenceRange},
+		{"missing_signatures", func(a *AuditBatchEnvelope) { a.Signatures = nil }, ErrThresholdRequired},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			batch := testAuditBatch()
+			tt.edit(&batch)
+			if err := batch.Validate(); !errors.Is(err, tt.want) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvidenceChain_ValidateErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*EvidenceChain)
+		want error
+	}{
+		{"wrong_entry_version", func(c *EvidenceChain) { c.EntryVersion = 3 }, ErrInvalidSequenceRange},
+		{"missing_segment", func(c *EvidenceChain) { c.SegmentID = "" }, ErrMissingField},
+		{"seq_mismatch", func(c *EvidenceChain) { c.SeqStart++ }, ErrInvalidSequenceRange},
+		{"bad_hash", func(c *EvidenceChain) { c.CheckpointHash = "bad" }, ErrInvalidHash},
+		{"bad_previous_tail", func(c *EvidenceChain) { c.PreviousSegmentTail = "bad" }, ErrInvalidHash},
+		{"bad_checkpoint_signature", func(c *EvidenceChain) { c.CheckpointSignature = "bad" }, ErrInvalidSignature},
+		{"missing_checkpoint_key", func(c *EvidenceChain) { c.CheckpointSignerKeyID = "" }, ErrMissingField},
+		{"missing_recorder_key", func(c *EvidenceChain) { c.FollowerRecorderKeyID = "" }, ErrMissingField},
+		{"bad_recorder_pub", func(c *EvidenceChain) { c.FollowerRecorderPubHex = "bad" }, ErrInvalidHash},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain := testAuditBatch().Chain
+			tt.edit(&chain)
+			if err := chain.Validate(10, 20); !errors.Is(err, tt.want) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestAudienceAndLabelValidationErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		aud  Audience
+	}{
+		{"empty_instance", Audience{InstanceIDs: []string{""}}},
+		{"bad_instance", Audience{InstanceIDs: []string{"-bad"}}},
+		{"empty_label_value", Audience{Labels: map[string]string{"ring": ""}}},
+		{"long_label_key", Audience{Labels: map[string]string{strings.Repeat("a", MaxLabelKeyBytes+1): "v"}}},
+		{"long_label_value", Audience{Labels: map[string]string{"ring": strings.Repeat("a", MaxLabelValueBytes+1)}}},
+		{"bad_label_identifier", Audience{Labels: map[string]string{"-ring": "canary"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.aud.Validate(); !errors.Is(err, ErrInvalidAudience) {
+				t.Fatalf("Validate() = %v, want ErrInvalidAudience", err)
+			}
+		})
+	}
+}
+
+func TestRejectLicenseFieldsYAMLDocumentHandling(t *testing.T) {
+	if err := rejectLicenseFields(""); !errors.Is(err, ErrForbiddenLicenseField) {
+		t.Fatalf("rejectLicenseFields(empty) = %v, want ErrForbiddenLicenseField", err)
+	}
+	if err := rejectLicenseFields("mode: strict\n---\n"); err != nil {
+		t.Fatalf("rejectLicenseFields(empty trailing doc) = %v, want nil", err)
+	}
+	if err := rejectLicenseFields("mode: strict\n---\nmode: balanced\n"); !errors.Is(err, ErrForbiddenLicenseField) {
+		t.Fatalf("rejectLicenseFields(non-empty trailing doc) = %v, want ErrForbiddenLicenseField", err)
+	}
+	if err := rejectLicenseFields("mode: [\n"); !errors.Is(err, ErrForbiddenLicenseField) {
+		t.Fatalf("rejectLicenseFields(malformed) = %v, want ErrForbiddenLicenseField", err)
+	}
+}
+
 func testProof(keyID string, purpose signing.KeyPurpose) SignatureProof {
 	return SignatureProof{
 		SignerKeyID: keyID,

--- a/internal/signing/key_purpose.go
+++ b/internal/signing/key_purpose.go
@@ -15,7 +15,7 @@ import (
 // string representation; this typed wrapper centralises validation and helpers.
 //
 // Twelve values are defined, drawn from the design doc Key Management section
-// (lines 758-870) and the Boss/Conductor control-plane spec:
+// (lines 758-870) and the Conductor control-plane spec:
 //
 //   - PurposeReceiptSigning:            runtime receipt keys (hot-loadable)
 //   - PurposeContractCompileSigning:    compile-time contract keys (warm, operator-only)
@@ -63,27 +63,27 @@ const (
 	// used for recovery operations (root transition, emergency rotation).
 	PurposeRecoveryRoot KeyPurpose = "recovery-root"
 
-	// PurposePolicyBundleSigning identifies keys used to sign Boss/Conductor
+	// PurposePolicyBundleSigning identifies keys used to sign Conductor
 	// policy bundles distributed to followers.
 	PurposePolicyBundleSigning KeyPurpose = "policy-bundle-signing"
 
 	// PurposePolicyBundleRollback identifies keys used to authorize a one-shot
-	// rollback to a lower Boss/Conductor policy bundle version.
+	// rollback to a lower Conductor policy bundle version.
 	PurposePolicyBundleRollback KeyPurpose = "policy-bundle-rollback"
 
-	// PurposeRemoteKillSigning identifies keys used to sign Boss/Conductor
+	// PurposeRemoteKillSigning identifies keys used to sign Conductor
 	// remote kill-switch state messages.
 	PurposeRemoteKillSigning KeyPurpose = "remote-kill-signing"
 
-	// PurposeTrustRootRotation identifies keys used to sign Boss/Conductor
+	// PurposeTrustRootRotation identifies keys used to sign Conductor
 	// trust-root rotation artifacts.
 	PurposeTrustRootRotation KeyPurpose = "trust-root-rotation"
 
 	// PurposeAuditBatchSigning identifies follower instance keys used to sign
-	// Boss-bound audit batch envelopes.
+	// Conductor-bound audit batch envelopes.
 	PurposeAuditBatchSigning KeyPurpose = "audit-batch-signing"
 
-	// PurposeEnrollmentTokenSigning identifies Boss keys used to sign narrow,
+	// PurposeEnrollmentTokenSigning identifies Conductor keys used to sign narrow,
 	// one-shot enrollment tokens.
 	PurposeEnrollmentTokenSigning KeyPurpose = "enrollment-token-signing"
 )
@@ -157,7 +157,7 @@ func (p KeyPurpose) IsCompileTime() bool {
 	return p == PurposeContractCompileSigning
 }
 
-// IsConductorPurpose returns true for Boss/Conductor control-plane purposes.
+// IsConductorPurpose returns true for Conductor control-plane purposes.
 func (p KeyPurpose) IsConductorPurpose() bool {
 	switch p {
 	case PurposePolicyBundleSigning,

--- a/internal/signing/key_purpose.go
+++ b/internal/signing/key_purpose.go
@@ -14,8 +14,8 @@ import (
 // every signed-artifact key entry. The wire form is the lowercase hyphenated
 // string representation; this typed wrapper centralises validation and helpers.
 //
-// Six values are defined, drawn from the design doc Key Management section
-// (lines 758-870):
+// Twelve values are defined, drawn from the design doc Key Management section
+// (lines 758-870) and the Boss/Conductor control-plane spec:
 //
 //   - PurposeReceiptSigning:            runtime receipt keys (hot-loadable)
 //   - PurposeContractCompileSigning:    compile-time contract keys (warm, operator-only)
@@ -23,6 +23,12 @@ import (
 //   - PurposeRulesOfficialSigning:      official rules package signing keys
 //   - PurposeRosterRoot:                deployment-local trust root for key rosters
 //   - PurposeRecoveryRoot:              deployment-local trust root for recovery operations
+//   - PurposePolicyBundleSigning:       Conductor policy bundle signing keys
+//   - PurposePolicyBundleRollback:      Conductor rollback authorization keys
+//   - PurposeRemoteKillSigning:         Conductor remote kill-switch keys
+//   - PurposeTrustRootRotation:         Conductor trust-root rotation keys
+//   - PurposeAuditBatchSigning:         follower audit batch signing keys
+//   - PurposeEnrollmentTokenSigning:    Conductor enrollment-token signing keys
 //
 // Wire stability: these strings are part of the signed-artifact wire format
 // and will not change without a schema_version bump.
@@ -56,9 +62,33 @@ const (
 	// PurposeRecoveryRoot identifies the deployment-local trust root key
 	// used for recovery operations (root transition, emergency rotation).
 	PurposeRecoveryRoot KeyPurpose = "recovery-root"
+
+	// PurposePolicyBundleSigning identifies keys used to sign Boss/Conductor
+	// policy bundles distributed to followers.
+	PurposePolicyBundleSigning KeyPurpose = "policy-bundle-signing"
+
+	// PurposePolicyBundleRollback identifies keys used to authorize a one-shot
+	// rollback to a lower Boss/Conductor policy bundle version.
+	PurposePolicyBundleRollback KeyPurpose = "policy-bundle-rollback"
+
+	// PurposeRemoteKillSigning identifies keys used to sign Boss/Conductor
+	// remote kill-switch state messages.
+	PurposeRemoteKillSigning KeyPurpose = "remote-kill-signing"
+
+	// PurposeTrustRootRotation identifies keys used to sign Boss/Conductor
+	// trust-root rotation artifacts.
+	PurposeTrustRootRotation KeyPurpose = "trust-root-rotation"
+
+	// PurposeAuditBatchSigning identifies follower instance keys used to sign
+	// Boss-bound audit batch envelopes.
+	PurposeAuditBatchSigning KeyPurpose = "audit-batch-signing"
+
+	// PurposeEnrollmentTokenSigning identifies Boss keys used to sign narrow,
+	// one-shot enrollment tokens.
+	PurposeEnrollmentTokenSigning KeyPurpose = "enrollment-token-signing"
 )
 
-// ErrUnknownKeyPurpose indicates a key_purpose value is not one of the six
+// ErrUnknownKeyPurpose indicates a key_purpose value is not one of the
 // recognised purposes.
 var ErrUnknownKeyPurpose = errors.New("unknown key_purpose")
 
@@ -70,6 +100,12 @@ var knownPurposes = [...]KeyPurpose{
 	PurposeRulesOfficialSigning,
 	PurposeRosterRoot,
 	PurposeRecoveryRoot,
+	PurposePolicyBundleSigning,
+	PurposePolicyBundleRollback,
+	PurposeRemoteKillSigning,
+	PurposeTrustRootRotation,
+	PurposeAuditBatchSigning,
+	PurposeEnrollmentTokenSigning,
 }
 
 // knownSet provides O(1) validation lookup.
@@ -87,7 +123,7 @@ func (p KeyPurpose) String() string {
 	return string(p)
 }
 
-// Validate returns nil if p is one of the six known purposes. Otherwise it
+// Validate returns nil if p is one of the known purposes. Otherwise it
 // returns an error wrapping ErrUnknownKeyPurpose with the offending value.
 func (p KeyPurpose) Validate() error {
 	if _, ok := knownSet[p]; ok {
@@ -121,7 +157,33 @@ func (p KeyPurpose) IsCompileTime() bool {
 	return p == PurposeContractCompileSigning
 }
 
-// KnownPurposes returns a freshly-allocated slice of all six recognised key
+// IsConductorPurpose returns true for Boss/Conductor control-plane purposes.
+func (p KeyPurpose) IsConductorPurpose() bool {
+	switch p {
+	case PurposePolicyBundleSigning,
+		PurposePolicyBundleRollback,
+		PurposeRemoteKillSigning,
+		PurposeTrustRootRotation,
+		PurposeAuditBatchSigning,
+		PurposeEnrollmentTokenSigning:
+		return true
+	default:
+		return false
+	}
+}
+
+// RequiresConductorThreshold returns true for Conductor actions that are
+// catastrophic enough to require multi-approver signing policy.
+func (p KeyPurpose) RequiresConductorThreshold() bool {
+	switch p {
+	case PurposePolicyBundleRollback, PurposeRemoteKillSigning, PurposeTrustRootRotation:
+		return true
+	default:
+		return false
+	}
+}
+
+// KnownPurposes returns a freshly-allocated slice of all recognised key
 // purposes in stable order:
 //
 //  1. PurposeReceiptSigning
@@ -130,6 +192,12 @@ func (p KeyPurpose) IsCompileTime() bool {
 //  4. PurposeRulesOfficialSigning
 //  5. PurposeRosterRoot
 //  6. PurposeRecoveryRoot
+//  7. PurposePolicyBundleSigning
+//  8. PurposePolicyBundleRollback
+//  9. PurposeRemoteKillSigning
+//  10. PurposeTrustRootRotation
+//  11. PurposeAuditBatchSigning
+//  12. PurposeEnrollmentTokenSigning
 //
 // Tests rely on this order; it will not change without a major version bump.
 func KnownPurposes() []KeyPurpose {

--- a/internal/signing/key_purpose_test.go
+++ b/internal/signing/key_purpose_test.go
@@ -22,6 +22,12 @@ func TestKeyPurpose_String(t *testing.T) {
 		{"rules-official-signing", PurposeRulesOfficialSigning, "rules-official-signing"},
 		{"roster-root", PurposeRosterRoot, "roster-root"},
 		{"recovery-root", PurposeRecoveryRoot, "recovery-root"},
+		{"policy-bundle-signing", PurposePolicyBundleSigning, "policy-bundle-signing"},
+		{"policy-bundle-rollback", PurposePolicyBundleRollback, "policy-bundle-rollback"},
+		{"remote-kill-signing", PurposeRemoteKillSigning, "remote-kill-signing"},
+		{"trust-root-rotation", PurposeTrustRootRotation, "trust-root-rotation"},
+		{"audit-batch-signing", PurposeAuditBatchSigning, "audit-batch-signing"},
+		{"enrollment-token-signing", PurposeEnrollmentTokenSigning, "enrollment-token-signing"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -160,8 +166,8 @@ func TestKnownPurposes(t *testing.T) {
 	purposes := KnownPurposes()
 
 	t.Run("length", func(t *testing.T) {
-		if len(purposes) != 6 {
-			t.Fatalf("KnownPurposes() returned %d elements, want 6", len(purposes))
+		if len(purposes) != 12 {
+			t.Fatalf("KnownPurposes() returned %d elements, want 12", len(purposes))
 		}
 	})
 
@@ -173,6 +179,12 @@ func TestKnownPurposes(t *testing.T) {
 			PurposeRulesOfficialSigning,
 			PurposeRosterRoot,
 			PurposeRecoveryRoot,
+			PurposePolicyBundleSigning,
+			PurposePolicyBundleRollback,
+			PurposeRemoteKillSigning,
+			PurposeTrustRootRotation,
+			PurposeAuditBatchSigning,
+			PurposeEnrollmentTokenSigning,
 		}
 		for i, p := range purposes {
 			if p != expected[i] {
@@ -190,6 +202,57 @@ func TestKnownPurposes(t *testing.T) {
 			t.Fatal("KnownPurposes() returns shared backing array; expected independent slices")
 		}
 	})
+}
+
+func TestKeyPurpose_IsConductorPurpose(t *testing.T) {
+	tests := []struct {
+		purpose  KeyPurpose
+		expected bool
+	}{
+		{PurposeReceiptSigning, false},
+		{PurposeContractCompileSigning, false},
+		{PurposeContractActivationSigning, false},
+		{PurposeRulesOfficialSigning, false},
+		{PurposeRosterRoot, false},
+		{PurposeRecoveryRoot, false},
+		{PurposePolicyBundleSigning, true},
+		{PurposePolicyBundleRollback, true},
+		{PurposeRemoteKillSigning, true},
+		{PurposeTrustRootRotation, true},
+		{PurposeAuditBatchSigning, true},
+		{PurposeEnrollmentTokenSigning, true},
+		{KeyPurpose("unknown"), false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.purpose), func(t *testing.T) {
+			if got := tt.purpose.IsConductorPurpose(); got != tt.expected {
+				t.Errorf("IsConductorPurpose() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestKeyPurpose_RequiresConductorThreshold(t *testing.T) {
+	tests := []struct {
+		purpose  KeyPurpose
+		expected bool
+	}{
+		{PurposePolicyBundleSigning, false},
+		{PurposePolicyBundleRollback, true},
+		{PurposeRemoteKillSigning, true},
+		{PurposeTrustRootRotation, true},
+		{PurposeAuditBatchSigning, false},
+		{PurposeEnrollmentTokenSigning, false},
+		{PurposeReceiptSigning, false},
+		{KeyPurpose("unknown"), false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.purpose), func(t *testing.T) {
+			if got := tt.purpose.RequiresConductorThreshold(); got != tt.expected {
+				t.Errorf("RequiresConductorThreshold() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
 }
 
 func TestAuthorizePayload(t *testing.T) {


### PR DESCRIPTION
## Summary
- add Conductor key-purpose constants for policy bundles, rollback, remote kill, trust-root rotation, audit batches, and enrollment tokens
- add signed Conductor schemas for policy bundles, remote kill messages, rollback authorizations, audit batches, and capabilities
- add canonical preimages, UTC normalization, audience binding, validity/skew checks, dropped accounting, license-field rejection, payload hash binding, and Ed25519 verification hooks
- document the Pipelock Conductor and audit sink design

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added signed, canonicalized Conductor messages (policy bundles, remote-kill, rollback, audit batches, capability handshake) with multi-signer threshold verification, audience/freshness checks, fork/payload verification, and stricter signing-purpose handling.
  * Hardened policy YAML validation to reject forbidden license fields and enforce size/hash consistency.
  * Enrollment/handshake rules including mTLS and threshold caps.

* **Tests**
  * Expanded unit tests covering signing preimages, signature thresholds, validation windows, payload/fork checks, YAML edge cases, and many validation error paths.

* **Documentation**
  * Published Conductor control-plane and audit-sink design spec.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->