### PR TITLE
Add Conductor follower config and capabilities handshake

### DIFF
--- a/internal/conductor/capabilities.go
+++ b/internal/conductor/capabilities.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package conductor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	CapabilitiesPath           = "/api/v1/conductor/capabilities"
+	MaxCapabilitiesBodyBytes   = 64 * 1024
+	defaultCapabilitiesTimeout = 10 * time.Second
+)
+
+var ErrCapabilityNegotiation = errors.New("conductor capability negotiation failed")
+
+type LocalFollowerCapabilities struct {
+	MaxCreatedSkew       time.Duration
+	MaxThreshold         int
+	EmergencyStream      bool
+	MaxResponseBodyBytes int64
+}
+
+type NegotiatedCapabilities struct {
+	ConductorID            string
+	SchemaVersion          int
+	AuditSchemaVersion     int
+	CreatedSkew            time.Duration
+	EmergencyStream        bool
+	RemoteKillThreshold    int
+	RollbackThreshold      int
+	TrustRotationThreshold int
+}
+
+type CapabilitiesClient struct {
+	baseURL    *url.URL
+	httpClient *http.Client
+	local      LocalFollowerCapabilities
+}
+
+// NewCapabilitiesClient builds a Conductor capabilities client.
+//
+// SECURITY: callers must pass an httpClient whose Transport is configured for
+// mTLS against the Conductor trust roster. The Conductor audit-sink design
+// requires follower-to-Conductor transport to be mTLS; this constructor does
+// not enforce that requirement because transport plumbing lives in the runtime
+// wiring. Passing a default http.Client authenticates only the server
+// certificate against the system trust store and sends no client certificate.
+func NewCapabilitiesClient(rawBaseURL string, httpClient *http.Client, local LocalFollowerCapabilities) (*CapabilitiesClient, error) {
+	baseURL, err := parseConductorBaseURL(rawBaseURL)
+	if err != nil {
+		return nil, err
+	}
+	if httpClient == nil {
+		return nil, fmt.Errorf("%w: http client required", ErrCapabilityNegotiation)
+	}
+	return &CapabilitiesClient{
+		baseURL:    baseURL,
+		httpClient: httpClient,
+		local:      local.withDefaults(),
+	}, nil
+}
+
+func (c *CapabilitiesClient) Handshake(ctx context.Context) (NegotiatedCapabilities, error) {
+	if c == nil {
+		return NegotiatedCapabilities{}, fmt.Errorf("%w: nil client", ErrCapabilityNegotiation)
+	}
+	if ctx == nil {
+		return NegotiatedCapabilities{}, fmt.Errorf("%w: nil context", ErrCapabilityNegotiation)
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultCapabilitiesTimeout)
+		defer cancel()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.capabilitiesURL(), nil)
+	if err != nil {
+		return NegotiatedCapabilities{}, fmt.Errorf("%w: build request: %w", ErrCapabilityNegotiation, err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return NegotiatedCapabilities{}, fmt.Errorf("%w: fetch capabilities: %w", ErrCapabilityNegotiation, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	limit := c.local.MaxResponseBodyBytes
+	if limit <= 0 {
+		limit = MaxCapabilitiesBodyBytes
+	}
+	body := http.MaxBytesReader(nil, resp.Body, limit)
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(body, 1024))
+		return NegotiatedCapabilities{}, fmt.Errorf("%w: status=%d body=%q", ErrCapabilityNegotiation, resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	var capabilities CapabilitiesResponse
+	decoder := json.NewDecoder(body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&capabilities); err != nil {
+		return NegotiatedCapabilities{}, fmt.Errorf("%w: decode response: %w", ErrCapabilityNegotiation, err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return NegotiatedCapabilities{}, fmt.Errorf("%w: trailing JSON document", ErrCapabilityNegotiation)
+	}
+	return NegotiateCapabilities(capabilities, c.local)
+}
+
+func (c *CapabilitiesClient) capabilitiesURL() string {
+	u := *c.baseURL
+	u.Path = strings.TrimRight(u.Path, "/") + CapabilitiesPath
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+func NegotiateCapabilities(c CapabilitiesResponse, local LocalFollowerCapabilities) (NegotiatedCapabilities, error) {
+	local = local.withDefaults()
+	if err := c.ValidateWithLocalThresholdCap(local.MaxThreshold); err != nil {
+		return NegotiatedCapabilities{}, fmt.Errorf("%w: %w", ErrCapabilityNegotiation, err)
+	}
+	serverSkew := time.Duration(c.MaxCreatedSkewSeconds) * time.Second
+	createdSkew := serverSkew
+	if local.MaxCreatedSkew < createdSkew {
+		createdSkew = local.MaxCreatedSkew
+	}
+	// Audit envelope schema must be the highest version the FOLLOWER
+	// supports, capped by the server's advertised range. Using c.AuditBatch.Max
+	// directly would have the follower claim a version it cannot actually
+	// emit when Conductor advertises a forward-compat upper bound. Validation
+	// already ensures SchemaVersion ∈ [Min, Max], so the local constant is
+	// always inside the server's range.
+	auditSchemaVersion := SchemaVersion
+	if c.AuditBatch.Max < auditSchemaVersion {
+		auditSchemaVersion = c.AuditBatch.Max
+	}
+	return NegotiatedCapabilities{
+		ConductorID:        c.ConductorID,
+		SchemaVersion:      SchemaVersion,
+		AuditSchemaVersion: auditSchemaVersion,
+		CreatedSkew:        createdSkew,
+		// EmergencyStream is enabled iff BOTH Conductor advertises support and
+		// the follower has opted in locally. Either side disabled means polling
+		// fallback only.
+		EmergencyStream:        c.EmergencyStream && local.EmergencyStream,
+		RemoteKillThreshold:    c.RemoteKillThreshold,
+		RollbackThreshold:      c.RollbackThreshold,
+		TrustRotationThreshold: c.TrustRotationThreshold,
+	}, nil
+}
+
+func (l LocalFollowerCapabilities) withDefaults() LocalFollowerCapabilities {
+	if l.MaxCreatedSkew <= 0 {
+		l.MaxCreatedSkew = DefaultAuditMaxSkew
+	}
+	if l.MaxCreatedSkew > MaxAllowedAuditSkew {
+		l.MaxCreatedSkew = MaxAllowedAuditSkew
+	}
+	if l.MaxThreshold <= 0 {
+		l.MaxThreshold = MaxCapabilityThreshold
+	}
+	if l.MaxResponseBodyBytes <= 0 {
+		l.MaxResponseBodyBytes = MaxCapabilitiesBodyBytes
+	}
+	return l
+}
+
+func parseConductorBaseURL(raw string) (*url.URL, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("%w: base URL required", ErrCapabilityNegotiation)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: parse base URL: %w", ErrCapabilityNegotiation, err)
+	}
+	if u.Scheme != "https" || u.Host == "" {
+		return nil, fmt.Errorf("%w: base URL must be https with a host", ErrCapabilityNegotiation)
+	}
+	if u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return nil, fmt.Errorf("%w: base URL must not include userinfo, query, or fragment", ErrCapabilityNegotiation)
+	}
+	// Reject path components. The capabilities client appends CapabilitiesPath
+	// to the base, so a base of "https://host/admin" silently produces
+	// "https://host/admin/api/v1/conductor/capabilities" — almost always a
+	// misconfiguration where the operator confused base URL with a deep link.
+	// Same class of mistake as userinfo / query / fragment.
+	if u.Path != "" && u.Path != "/" {
+		return nil, fmt.Errorf("%w: base URL must not include a path component, got %q", ErrCapabilityNegotiation, u.Path)
+	}
+	return u, nil
+}

--- a/internal/conductor/capabilities.go
+++ b/internal/conductor/capabilities.go
@@ -74,6 +74,12 @@ func (c *CapabilitiesClient) Handshake(ctx context.Context) (NegotiatedCapabilit
 	if c == nil {
 		return NegotiatedCapabilities{}, fmt.Errorf("%w: nil client", ErrCapabilityNegotiation)
 	}
+	if c.baseURL == nil {
+		return NegotiatedCapabilities{}, fmt.Errorf("%w: uninitialized base URL", ErrCapabilityNegotiation)
+	}
+	if c.httpClient == nil {
+		return NegotiatedCapabilities{}, fmt.Errorf("%w: uninitialized http client", ErrCapabilityNegotiation)
+	}
 	if ctx == nil {
 		return NegotiatedCapabilities{}, fmt.Errorf("%w: nil context", ErrCapabilityNegotiation)
 	}

--- a/internal/conductor/capabilities_test.go
+++ b/internal/conductor/capabilities_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package conductor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+func TestNegotiateCapabilities(t *testing.T) {
+	resp := validHandshakeCapabilitiesResponse()
+	resp.MaxCreatedSkewSeconds = 120
+
+	got, err := NegotiateCapabilities(resp, LocalFollowerCapabilities{
+		MaxCreatedSkew:  60 * time.Second,
+		MaxThreshold:    3,
+		EmergencyStream: true,
+	})
+	if err != nil {
+		t.Fatalf("NegotiateCapabilities() error = %v", err)
+	}
+	if got.ConductorID != resp.ConductorID {
+		t.Fatalf("ConductorID = %q, want %q", got.ConductorID, resp.ConductorID)
+	}
+	if got.SchemaVersion != SchemaVersion {
+		t.Fatalf("SchemaVersion = %d, want %d", got.SchemaVersion, SchemaVersion)
+	}
+	if got.AuditSchemaVersion != SchemaVersion {
+		t.Fatalf("AuditSchemaVersion = %d, want %d", got.AuditSchemaVersion, SchemaVersion)
+	}
+	if got.CreatedSkew != 60*time.Second {
+		t.Fatalf("CreatedSkew = %s, want 60s", got.CreatedSkew)
+	}
+	if !got.EmergencyStream {
+		t.Fatal("EmergencyStream = false, want true")
+	}
+}
+
+func TestNegotiateCapabilitiesRejectsAboveLocalThresholdCap(t *testing.T) {
+	resp := validHandshakeCapabilitiesResponse()
+	resp.RemoteKillThreshold = 4
+
+	_, err := NegotiateCapabilities(resp, LocalFollowerCapabilities{MaxThreshold: 3})
+	if !errors.Is(err, ErrCapabilityNegotiation) {
+		t.Fatalf("NegotiateCapabilities() = %v, want ErrCapabilityNegotiation", err)
+	}
+	if !errors.Is(err, ErrThresholdRequired) {
+		t.Fatalf("NegotiateCapabilities() = %v, want ErrThresholdRequired", err)
+	}
+}
+
+func TestCapabilitiesClientHandshake(t *testing.T) {
+	resp := validHandshakeCapabilitiesResponse()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != CapabilitiesPath {
+			t.Errorf("path = %q, want %q", r.URL.Path, CapabilitiesPath)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client, err := NewCapabilitiesClient(srv.URL, srv.Client(), LocalFollowerCapabilities{EmergencyStream: true})
+	if err != nil {
+		t.Fatalf("NewCapabilitiesClient() error = %v", err)
+	}
+	got, err := client.Handshake(context.Background())
+	if err != nil {
+		t.Fatalf("Handshake() error = %v", err)
+	}
+	if got.ConductorID != resp.ConductorID {
+		t.Fatalf("ConductorID = %q, want %q", got.ConductorID, resp.ConductorID)
+	}
+}
+
+func TestNewCapabilitiesClientRejectsNilHTTPClient(t *testing.T) {
+	_, err := NewCapabilitiesClient("https://conductor.example", nil, LocalFollowerCapabilities{})
+	if !errors.Is(err, ErrCapabilityNegotiation) {
+		t.Fatalf("NewCapabilitiesClient() = %v, want ErrCapabilityNegotiation", err)
+	}
+}
+
+func TestCapabilitiesClientHandshakeAddsDeadline(t *testing.T) {
+	resp := validHandshakeCapabilitiesResponse()
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if _, ok := req.Context().Deadline(); !ok {
+			t.Fatal("request context has no deadline")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(mustJSON(t, resp))),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+	client, err := NewCapabilitiesClient("https://conductor.example", httpClient, LocalFollowerCapabilities{})
+	if err != nil {
+		t.Fatalf("NewCapabilitiesClient() error = %v", err)
+	}
+	if _, err := client.Handshake(context.Background()); err != nil {
+		t.Fatalf("Handshake() error = %v", err)
+	}
+}
+
+func TestCapabilitiesClientRejectsUnsafeBaseURL(t *testing.T) {
+	httpClient := &http.Client{Timeout: defaultCapabilitiesTimeout}
+	for _, raw := range []string{
+		"http://conductor.example",
+		"https://user:pass@conductor.example",
+		"https://conductor.example?token=x",
+		"https://conductor.example#fragment",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := NewCapabilitiesClient(raw, httpClient, LocalFollowerCapabilities{})
+			if !errors.Is(err, ErrCapabilityNegotiation) {
+				t.Fatalf("NewCapabilitiesClient() = %v, want ErrCapabilityNegotiation", err)
+			}
+		})
+	}
+}
+
+func TestCapabilitiesClientRejectsMalformedResponses(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "non_200", status: http.StatusForbidden, body: "nope"},
+		{name: "unknown_field", status: http.StatusOK, body: `{"schema_version":1,"unexpected":true}`},
+		{name: "trailing_document", status: http.StatusOK, body: mustJSON(t, validHandshakeCapabilitiesResponse()) + `{}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			client, err := NewCapabilitiesClient(srv.URL, srv.Client(), LocalFollowerCapabilities{})
+			if err != nil {
+				t.Fatalf("NewCapabilitiesClient() error = %v", err)
+			}
+			_, err = client.Handshake(context.Background())
+			if !errors.Is(err, ErrCapabilityNegotiation) {
+				t.Fatalf("Handshake() = %v, want ErrCapabilityNegotiation", err)
+			}
+		})
+	}
+}
+
+func TestNegotiateCapabilitiesCapsAuditSchemaAtFollowerSupported(t *testing.T) {
+	// Conductor advertises a forward-compat audit envelope range that exceeds
+	// what the follower can produce. The negotiated AuditSchemaVersion must
+	// equal the local SchemaVersion constant, not the server-advertised max,
+	// otherwise the audit batcher (next PR) will emit envelopes claiming a
+	// schema version it cannot actually produce.
+	resp := validHandshakeCapabilitiesResponse()
+	resp.AuditBatch = SchemaRange{Min: SchemaVersion, Max: SchemaVersion + 5}
+
+	got, err := NegotiateCapabilities(resp, LocalFollowerCapabilities{})
+	if err != nil {
+		t.Fatalf("NegotiateCapabilities() error = %v", err)
+	}
+	if got.AuditSchemaVersion != SchemaVersion {
+		t.Fatalf("AuditSchemaVersion = %d, want %d (capped at local supported)", got.AuditSchemaVersion, SchemaVersion)
+	}
+}
+
+func TestCapabilitiesClientRejectsBaseURLWithPath(t *testing.T) {
+	for _, raw := range []string{
+		"https://conductor.example/admin",
+		"https://conductor.example/api/v1/conductor/capabilities",
+		"https://conductor.example/a/b/c",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := NewCapabilitiesClient(raw, &http.Client{Timeout: defaultCapabilitiesTimeout}, LocalFollowerCapabilities{})
+			if !errors.Is(err, ErrCapabilityNegotiation) {
+				t.Fatalf("NewCapabilitiesClient() = %v, want ErrCapabilityNegotiation", err)
+			}
+		})
+	}
+	// Bare path component "/" is still allowed (matches the no-path case).
+	if _, err := NewCapabilitiesClient("https://conductor.example/", &http.Client{Timeout: defaultCapabilitiesTimeout}, LocalFollowerCapabilities{}); err != nil {
+		t.Fatalf("NewCapabilitiesClient(trailing slash) = %v, want nil", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func validHandshakeCapabilitiesResponse() CapabilitiesResponse {
+	r := SchemaRange{Min: SchemaVersion, Max: SchemaVersion}
+	return CapabilitiesResponse{
+		SchemaVersion:          SchemaVersion,
+		ConductorID:            "conductor-us-1",
+		RequiredMTLS:           true,
+		ConductorBundle:        r,
+		RemoteKill:             r,
+		RollbackAuthorization:  r,
+		AuditBatch:             r,
+		ReceiptEntryVersions:   []int{recorder.EntryVersion},
+		MaxCreatedSkewSeconds:  60,
+		EmergencyStream:        true,
+		RemoteKillThreshold:    2,
+		RollbackThreshold:      2,
+		TrustRotationThreshold: 2,
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return string(data)
+}

--- a/internal/conductor/capabilities_test.go
+++ b/internal/conductor/capabilities_test.go
@@ -114,6 +114,13 @@ func TestCapabilitiesClientHandshakeAddsDeadline(t *testing.T) {
 	}
 }
 
+func TestCapabilitiesClientHandshakeRejectsZeroValueClient(t *testing.T) {
+	_, err := new(CapabilitiesClient).Handshake(context.Background())
+	if !errors.Is(err, ErrCapabilityNegotiation) {
+		t.Fatalf("Handshake() = %v, want ErrCapabilityNegotiation", err)
+	}
+}
+
 func TestCapabilitiesClientRejectsUnsafeBaseURL(t *testing.T) {
 	httpClient := &http.Client{Timeout: defaultCapabilitiesTimeout}
 	for _, raw := range []string{

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -143,6 +143,7 @@ func (c *Config) policySemanticView() Config {
 	view.Sentry = SentryConfig{}
 	view.Emit = EmitConfig{}
 	view.FlightRecorder = FlightRecorder{}
+	view.Conductor = Conductor{}
 
 	// License metadata — determines whether a tier feature is available,
 	// but the effective per-agent config that the request-time path

--- a/internal/config/conductor.go
+++ b/internal/config/conductor.go
@@ -180,21 +180,71 @@ func validateConductorAbsolutePath(field, value string) error {
 
 func validateConductorPrivateParent(field, rawPath string) error {
 	clean := filepath.Clean(rawPath)
+	seen := make(map[string]struct{})
 	for dir := filepath.Dir(clean); ; dir = filepath.Dir(dir) {
-		info, err := os.Stat(dir)
-		if err == nil {
-			if !info.IsDir() {
-				return fmt.Errorf("%s parent %s is not a directory", field, dir)
-			}
-			if info.Mode().Perm()&0o002 != 0 {
-				return fmt.Errorf("%s must not be under world-writable parent %s", field, dir)
-			}
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("%s stat parent %s: %w", field, dir, err)
+		if err := validateConductorParentPath(field, dir, seen); err != nil {
+			return err
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
 			return nil
 		}
 	}
+}
+
+func validateConductorParentPath(field, dir string, seen map[string]struct{}) error {
+	dir = filepath.Clean(dir)
+	if _, ok := seen[dir]; ok {
+		return nil
+	}
+	seen[dir] = struct{}{}
+
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("%s resolve parent %s: %w", field, dir, err)
+	}
+	if err := validateConductorResolvedParent(field, dir, resolved); err != nil {
+		return err
+	}
+	if resolved == dir {
+		return nil
+	}
+
+	intendedParent := filepath.Dir(dir)
+	rel, err := filepath.Rel(intendedParent, resolved)
+	if err != nil {
+		return fmt.Errorf("%s compare resolved parent %s to %s: %w", field, resolved, intendedParent, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
+		return fmt.Errorf("%s parent %s resolves outside intended parent %s to %s", field, dir, intendedParent, resolved)
+	}
+	for realDir := resolved; ; realDir = filepath.Dir(realDir) {
+		if err := validateConductorParentPath(field, realDir, seen); err != nil {
+			return err
+		}
+		parent := filepath.Dir(realDir)
+		if parent == realDir {
+			return nil
+		}
+	}
+}
+
+func validateConductorResolvedParent(field, displayPath, resolved string) error {
+	info, err := os.Stat(resolved)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("%s stat parent %s: %w", field, resolved, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s parent %s is not a directory", field, displayPath)
+	}
+	if info.Mode().Perm()&0o002 != 0 {
+		return fmt.Errorf("%s must not be under world-writable parent %s", field, displayPath)
+	}
+	return nil
 }

--- a/internal/config/conductor.go
+++ b/internal/config/conductor.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const (
+	maxConductorCreatedSkewSeconds = 300
+	minConductorThreshold          = 2
+	// minConductorPollInterval bounds how aggressively a follower can poll
+	// Conductor. Sub-second intervals serve no purpose and turn a
+	// misconfigured follower (or a compromised one) into a trivial DoS lever
+	// against the control plane.
+	minConductorPollInterval = time.Second
+)
+
+func (c *Config) validateConductor(warnings *[]Warning) error {
+	cfg := c.Conductor
+	normalizeConductor(&cfg)
+	if err := validateConductorDurations(cfg); err != nil {
+		return err
+	}
+	if err := validateConductorStalePolicy(cfg, warnings); err != nil {
+		return err
+	}
+	if cfg.MaxMinVersionMajorSkew < 0 {
+		return fmt.Errorf("conductor.max_min_version_major_skew must be >= 0, got %d", cfg.MaxMinVersionMajorSkew)
+	}
+	if cfg.MaxMinVersionMinorSkew < 0 {
+		return fmt.Errorf("conductor.max_min_version_minor_skew must be >= 0, got %d", cfg.MaxMinVersionMinorSkew)
+	}
+	if cfg.MaxCapabilityThreshold < minConductorThreshold {
+		return fmt.Errorf("conductor.max_capability_threshold must be >= %d, got %d", minConductorThreshold, cfg.MaxCapabilityThreshold)
+	}
+	if !cfg.Enabled {
+		return nil
+	}
+
+	if err := validateConductorURL(cfg.ConductorURL); err != nil {
+		return err
+	}
+	for field, value := range map[string]string{
+		"conductor.org_id":      cfg.OrgID,
+		"conductor.fleet_id":    cfg.FleetID,
+		"conductor.instance_id": cfg.InstanceID,
+	} {
+		if err := validateConductorIdentifier(field, value); err != nil {
+			return err
+		}
+	}
+	for field, value := range map[string]string{
+		"conductor.trust_roster_path":       cfg.TrustRosterPath,
+		"conductor.client_cert_path":        cfg.ClientCertPath,
+		"conductor.client_key_path":         cfg.ClientKeyPath,
+		"conductor.bundle_cache_dir":        cfg.BundleCacheDir,
+		"conductor.durable_audit_queue_dir": cfg.DurableAuditQueueDir,
+	} {
+		if err := validateConductorAbsolutePath(field, value); err != nil {
+			return err
+		}
+	}
+	for field, value := range map[string]string{
+		"conductor.bundle_cache_dir":        cfg.BundleCacheDir,
+		"conductor.durable_audit_queue_dir": cfg.DurableAuditQueueDir,
+	} {
+		if err := validateConductorPrivateParent(field, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateConductorDurations(cfg Conductor) error {
+	interval, err := time.ParseDuration(cfg.PollInterval)
+	if err != nil {
+		return fmt.Errorf("conductor.poll_interval must be a duration: %w", err)
+	}
+	if interval <= 0 {
+		return fmt.Errorf("conductor.poll_interval must be > 0, got %q", cfg.PollInterval)
+	}
+	if interval < minConductorPollInterval {
+		return fmt.Errorf("conductor.poll_interval must be >= %s, got %q", minConductorPollInterval, cfg.PollInterval)
+	}
+	if cfg.CreatedSkewSeconds <= 0 {
+		return fmt.Errorf("conductor.created_skew_seconds must be > 0, got %d", cfg.CreatedSkewSeconds)
+	}
+	if cfg.CreatedSkewSeconds > maxConductorCreatedSkewSeconds {
+		return fmt.Errorf("conductor.created_skew_seconds must be <= %d, got %d", maxConductorCreatedSkewSeconds, cfg.CreatedSkewSeconds)
+	}
+	return nil
+}
+
+func validateConductorStalePolicy(cfg Conductor, warnings *[]Warning) error {
+	if cfg.StalePolicy.GraceMultiplier <= 0 {
+		return fmt.Errorf("conductor.stale_policy.grace_multiplier must be > 0, got %d", cfg.StalePolicy.GraceMultiplier)
+	}
+	switch cfg.StalePolicy.AfterGrace {
+	case ConductorStaleStrictDenyAll:
+	case ConductorStaleContinueLastKnownGood:
+		if cfg.Enabled {
+			*warnings = append(*warnings, Warning{
+				Field:   "conductor.stale_policy.after_grace",
+				Message: "continue_last_known_good weakens conductor fail-closed stale-bundle behavior",
+			})
+		}
+	default:
+		return fmt.Errorf("conductor.stale_policy.after_grace must be %q or %q, got %q",
+			ConductorStaleStrictDenyAll, ConductorStaleContinueLastKnownGood, cfg.StalePolicy.AfterGrace)
+	}
+	return nil
+}
+
+func validateConductorURL(raw string) error {
+	if strings.TrimSpace(raw) == "" {
+		return fmt.Errorf("conductor.conductor_url required when conductor.enabled is true")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("conductor.conductor_url: %w", err)
+	}
+	if u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("conductor.conductor_url must be an https URL with a host")
+	}
+	if u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("conductor.conductor_url must not include userinfo, query, or fragment")
+	}
+	if u.Path != "" && u.Path != "/" {
+		return fmt.Errorf("conductor.conductor_url must not include a path component, got %q", u.Path)
+	}
+	return nil
+}
+
+func (c Conductor) EmergencyStreamEnabled() bool {
+	return c.EmergencyStream == nil || *c.EmergencyStream
+}
+
+func validateConductorIdentifier(field, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s required when conductor.enabled is true", field)
+	}
+	if len(value) > 128 {
+		return fmt.Errorf("%s must be <= 128 bytes", field)
+	}
+	for i, r := range value {
+		if r > unicode.MaxASCII {
+			return fmt.Errorf("%s contains non-ASCII character %q", field, r)
+		}
+		if r != '_' && r != '-' && r != '.' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return fmt.Errorf("%s contains invalid character %q", field, r)
+		}
+		if i == 0 && (r == '_' || r == '-' || r == '.') {
+			return fmt.Errorf("%s must start with an ASCII letter or digit", field)
+		}
+	}
+	return nil
+}
+
+func validateConductorAbsolutePath(field, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s required when conductor.enabled is true", field)
+	}
+	if !filepath.IsAbs(value) {
+		return fmt.Errorf("%s must be an absolute path, got %q", field, value)
+	}
+	if filepath.Clean(value) != value {
+		return fmt.Errorf("%s must be in canonical form, got %q", field, value)
+	}
+	return nil
+}
+
+func validateConductorPrivateParent(field, rawPath string) error {
+	clean := filepath.Clean(rawPath)
+	for dir := filepath.Dir(clean); ; dir = filepath.Dir(dir) {
+		info, err := os.Stat(dir)
+		if err == nil {
+			if !info.IsDir() {
+				return fmt.Errorf("%s parent %s is not a directory", field, dir)
+			}
+			if info.Mode().Perm()&0o002 != 0 {
+				return fmt.Errorf("%s must not be under world-writable parent %s", field, dir)
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("%s stat parent %s: %w", field, dir, err)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil
+		}
+	}
+}

--- a/internal/config/conductor_test.go
+++ b/internal/config/conductor_test.go
@@ -155,6 +155,34 @@ func TestValidateConductor_RejectsWorldWritableParents(t *testing.T) {
 	}
 }
 
+func TestValidateConductor_RejectsSymlinkResolvedWorldWritableParent(t *testing.T) {
+	cfg := Defaults()
+	conductor := validConductorConfig(t)
+	root := privateTempDir(t)
+	world := filepath.Join(root, "world")
+	target := filepath.Join(world, "target")
+	if err := os.Mkdir(world, 0o700); err != nil {
+		t.Fatalf("Mkdir(world) error = %v", err)
+	}
+	if err := os.Chmod(world, 0o777); err != nil { //nolint:gosec // verifies rejection of unsafe resolved parent permissions.
+		t.Fatalf("Chmod(world) error = %v", err)
+	}
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("Mkdir(target) error = %v", err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	conductor.BundleCacheDir = filepath.Join(link, "bundles")
+	cfg.Conductor = conductor
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "world-writable parent") {
+		t.Fatalf("Validate() = %v, want world-writable parent error", err)
+	}
+}
+
 func TestValidateConductor_StalePolicyOverrideWarns(t *testing.T) {
 	cfg := Defaults()
 	conductor := validConductorConfig(t)

--- a/internal/config/conductor_test.go
+++ b/internal/config/conductor_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestApplyDefaults_Conductor(t *testing.T) {
+	cfg := &Config{}
+	cfg.ApplyDefaults()
+
+	if cfg.Conductor.Enabled {
+		t.Fatal("Conductor.Enabled = true, want false")
+	}
+	if cfg.Conductor.PollInterval != "30s" {
+		t.Fatalf("PollInterval = %q, want 30s", cfg.Conductor.PollInterval)
+	}
+	if cfg.Conductor.CreatedSkewSeconds != 60 {
+		t.Fatalf("CreatedSkewSeconds = %d, want 60", cfg.Conductor.CreatedSkewSeconds)
+	}
+	if cfg.Conductor.MaxMinVersionMinorSkew != 1 {
+		t.Fatalf("MaxMinVersionMinorSkew = %d, want 1", cfg.Conductor.MaxMinVersionMinorSkew)
+	}
+	if cfg.Conductor.MaxCapabilityThreshold != 7 {
+		t.Fatalf("MaxCapabilityThreshold = %d, want 7", cfg.Conductor.MaxCapabilityThreshold)
+	}
+	if !cfg.Conductor.EmergencyStreamEnabled() {
+		t.Fatal("EmergencyStreamEnabled() = false, want true")
+	}
+	if cfg.Conductor.StalePolicy.GraceMultiplier != 1 {
+		t.Fatalf("StalePolicy.GraceMultiplier = %d, want 1", cfg.Conductor.StalePolicy.GraceMultiplier)
+	}
+	if cfg.Conductor.StalePolicy.AfterGrace != ConductorStaleStrictDenyAll {
+		t.Fatalf("StalePolicy.AfterGrace = %q, want %q", cfg.Conductor.StalePolicy.AfterGrace, ConductorStaleStrictDenyAll)
+	}
+}
+
+func TestValidateConductor_DisabledStillValidatesLocalSafetyKnobs(t *testing.T) {
+	cfg := Defaults()
+	cfg.Conductor.CreatedSkewSeconds = 301
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "conductor.created_skew_seconds") {
+		t.Fatalf("Validate() = %v, want created_skew_seconds error", err)
+	}
+}
+
+func TestValidateConductor_Enabled(t *testing.T) {
+	cfg := Defaults()
+	cfg.Conductor = validConductorConfig(t)
+
+	if _, err := cfg.ValidateWithWarnings(); err != nil {
+		t.Fatalf("ValidateWithWarnings() error = %v", err)
+	}
+}
+
+func TestValidateConductor_RejectsInvalidEnabledConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Conductor)
+		want   string
+	}{
+		{
+			name:   "missing_url",
+			mutate: func(c *Conductor) { c.ConductorURL = "" },
+			want:   "conductor.conductor_url required",
+		},
+		{
+			name:   "http_url",
+			mutate: func(c *Conductor) { c.ConductorURL = "http://conductor.example" },
+			want:   "https URL",
+		},
+		{
+			name:   "url_userinfo",
+			mutate: func(c *Conductor) { c.ConductorURL = "https://user:pass@conductor.example" },
+			want:   "must not include userinfo",
+		},
+		{
+			name:   "url_path",
+			mutate: func(c *Conductor) { c.ConductorURL = "https://conductor.example/admin" },
+			want:   "must not include a path component",
+		},
+		{
+			name:   "bad_instance_id",
+			mutate: func(c *Conductor) { c.InstanceID = "-bad" },
+			want:   "conductor.instance_id must start",
+		},
+		{
+			name:   "relative_cert",
+			mutate: func(c *Conductor) { c.ClientCertPath = "client.crt" },
+			want:   "conductor.client_cert_path must be an absolute path",
+		},
+		{
+			name:   "bad_poll_interval",
+			mutate: func(c *Conductor) { c.PollInterval = "0s" },
+			want:   "conductor.poll_interval must be > 0",
+		},
+		{
+			// Sub-second poll interval is a trivial DoS lever. A
+			// misconfigured or compromised follower could flood Conductor with
+			// thousands of requests per second.
+			name:   "poll_interval_below_floor",
+			mutate: func(c *Conductor) { c.PollInterval = "10ms" },
+			want:   "conductor.poll_interval must be >=",
+		},
+		{
+			name:   "bad_stale_policy",
+			mutate: func(c *Conductor) { c.StalePolicy.AfterGrace = "permissive" },
+			want:   "conductor.stale_policy.after_grace",
+		},
+		{
+			name:   "threshold_too_low",
+			mutate: func(c *Conductor) { c.MaxCapabilityThreshold = 1 },
+			want:   "conductor.max_capability_threshold",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Defaults()
+			conductor := validConductorConfig(t)
+			tc.mutate(&conductor)
+			cfg.Conductor = conductor
+
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate() = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateConductor_RejectsWorldWritableParents(t *testing.T) {
+	cfg := Defaults()
+	conductor := validConductorConfig(t)
+	parent := filepath.Join(privateTempDir(t), "world")
+	if err := os.Mkdir(parent, 0o700); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	if err := os.Chmod(parent, 0o777); err != nil { //nolint:gosec // verifies rejection of unsafe parent permissions.
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	conductor.BundleCacheDir = filepath.Join(parent, "bundles")
+	cfg.Conductor = conductor
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "world-writable parent") {
+		t.Fatalf("Validate() = %v, want world-writable parent error", err)
+	}
+}
+
+func TestValidateConductor_StalePolicyOverrideWarns(t *testing.T) {
+	cfg := Defaults()
+	conductor := validConductorConfig(t)
+	conductor.StalePolicy.AfterGrace = ConductorStaleContinueLastKnownGood
+	cfg.Conductor = conductor
+
+	warnings, err := cfg.ValidateWithWarnings()
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings() error = %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %+v, want one warning", warnings)
+	}
+	if warnings[0].Field != "conductor.stale_policy.after_grace" {
+		t.Fatalf("warning field = %q", warnings[0].Field)
+	}
+}
+
+func TestCanonicalPolicyHash_ExcludesConductor(t *testing.T) {
+	base := Defaults()
+	withConductor := base.Clone()
+	withConductor.Conductor = validConductorConfig(t)
+
+	if got, want := withConductor.CanonicalPolicyHash(), base.CanonicalPolicyHash(); got != want {
+		t.Fatalf("CanonicalPolicyHash() changed with conductor config: got %s want %s", got, want)
+	}
+}
+
+func TestConductor_EmergencyStreamEnabled(t *testing.T) {
+	enabled := true
+	disabled := false
+	tests := []struct {
+		name string
+		cfg  Conductor
+		want bool
+	}{
+		{name: "nil_defaults_true", cfg: Conductor{}, want: true},
+		{name: "explicit_true", cfg: Conductor{EmergencyStream: &enabled}, want: true},
+		{name: "explicit_false", cfg: Conductor{EmergencyStream: &disabled}, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.EmergencyStreamEnabled(); got != tc.want {
+				t.Fatalf("EmergencyStreamEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoad_ConductorEmergencyStreamDefaulting(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{name: "omitted", yaml: "mode: balanced\n", want: true},
+		{name: "null", yaml: "mode: balanced\nconductor:\n  emergency_stream: null\n", want: true},
+		{name: "explicit_false", yaml: "mode: balanced\nconductor:\n  emergency_stream: false\n", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(tc.yaml), 0o600); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if got := cfg.Conductor.EmergencyStreamEnabled(); got != tc.want {
+				t.Fatalf("EmergencyStreamEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func validConductorConfig(t *testing.T) Conductor {
+	t.Helper()
+	root := privateTempDir(t)
+	return Conductor{
+		Enabled:                true,
+		ConductorURL:           "https://conductor.example",
+		OrgID:                  "org_main",
+		FleetID:                "prod",
+		InstanceID:             "pl-prod-1",
+		TrustRosterPath:        filepath.Join(root, "trust-roster.json"),
+		ClientCertPath:         filepath.Join(root, "client.crt"),
+		ClientKeyPath:          filepath.Join(root, "client.key"),
+		BundleCacheDir:         filepath.Join(root, "bundles"),
+		DurableAuditQueueDir:   filepath.Join(root, "audit-queue"),
+		PollInterval:           "30s",
+		HonorRemoteKillSwitch:  false,
+		EmergencyStream:        ptrBool(true),
+		CreatedSkewSeconds:     60,
+		MaxMinVersionMajorSkew: 0,
+		MaxMinVersionMinorSkew: 1,
+		MaxCapabilityThreshold: 7,
+		StalePolicy:            ConductorStalePolicy{GraceMultiplier: 1, AfterGrace: ConductorStaleStrictDenyAll},
+	}
+}
+
+func privateTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp(".", ".conductor-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil && !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("RemoveAll(%s) error = %v", dir, err)
+		}
+	})
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("Abs(%s) error = %v", dir, err)
+	}
+	return abs
+}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -526,6 +526,9 @@ func Defaults() *Config {
 			Mode:              LockModeShadow, // safe-by-default; live requires explicit opt-in
 			MinimumSignatures: 1,
 		},
+		Conductor: Conductor{
+			EmergencyStream: ptrBool(true),
+		},
 	}
 	// Mark all compiled defaults with provenance so the standard tier source
 	// selector can distinguish them from user-supplied patterns. Set at

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -34,6 +34,30 @@ func normalizeLearn(l *Learn) {
 	}
 }
 
+func normalizeConductor(c *Conductor) {
+	if c.PollInterval == "" {
+		c.PollInterval = "30s"
+	}
+	if c.CreatedSkewSeconds == 0 {
+		c.CreatedSkewSeconds = 60
+	}
+	if c.MaxMinVersionMinorSkew == 0 {
+		c.MaxMinVersionMinorSkew = 1
+	}
+	if c.MaxCapabilityThreshold == 0 {
+		c.MaxCapabilityThreshold = 7
+	}
+	if c.EmergencyStream == nil {
+		c.EmergencyStream = ptrBool(true)
+	}
+	if c.StalePolicy.GraceMultiplier == 0 {
+		c.StalePolicy.GraceMultiplier = 1
+	}
+	if c.StalePolicy.AfterGrace == "" {
+		c.StalePolicy.AfterGrace = ConductorStaleStrictDenyAll
+	}
+}
+
 // applySecurityDefaults sets security-sensitive booleans to true when they are
 // omitted or null in the config YAML. YAML unmarshal into a plain bool cannot
 // distinguish "field omitted" (should default to true, fail-closed) from "field
@@ -160,6 +184,7 @@ func applySecurityDefaults(rawYAML []byte, cfg *Config) {
 // ApplyDefaults fills in zero-value fields with sensible defaults.
 func (c *Config) ApplyDefaults() {
 	normalizeLearn(&c.Learn)
+	normalizeConductor(&c.Conductor)
 	if c.Version == 0 {
 		c.Version = 1
 	}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -256,6 +256,7 @@ type Config struct {
 	Redaction                redact.Config           `yaml:"redaction"`
 	Learn                    Learn                   `yaml:"learn"`
 	LearnLock                LearnLock               `yaml:"learn_lock" json:"-"` // operational lock-runtime config, excluded from canonical policy hash
+	Conductor                Conductor               `yaml:"conductor" json:"-"`  // follower control-plane config, excluded from canonical policy hash
 	Agents                   map[string]AgentProfile `yaml:"agents,omitempty"`
 	DefaultAgentIdentity     string                  `yaml:"default_agent_identity,omitempty"`      // operator-configured agent name used when no stronger identity source resolves the caller
 	BindDefaultAgentIdentity bool                    `yaml:"bind_default_agent_identity,omitempty"` // when true, ignore self-declared header/query identities and bind requests to default_agent_identity
@@ -296,6 +297,46 @@ type Config struct {
 	// instances are treated as immutable after Load(); any mutation after
 	// a hash has been computed will return a stale value.
 	canonicalHashCache *canonicalHashCacheHolder `yaml:"-"`
+}
+
+const (
+	// ConductorStaleStrictDenyAll is the fail-closed stale-bundle behavior.
+	ConductorStaleStrictDenyAll = "strict_deny_all"
+
+	// ConductorStaleContinueLastKnownGood is an operator override that keeps
+	// the last bundle active after the grace window. Validation permits it but
+	// emits an advisory warning because it weakens the fail-closed default.
+	ConductorStaleContinueLastKnownGood = "continue_last_known_good"
+)
+
+// Conductor configures follower-side participation in a Conductor-managed
+// fleet. It is local control-plane plumbing, not scanner policy, and is
+// excluded from CanonicalPolicyHash.
+type Conductor struct {
+	Enabled                bool                 `yaml:"enabled"`
+	ConductorURL           string               `yaml:"conductor_url"`
+	OrgID                  string               `yaml:"org_id"`
+	FleetID                string               `yaml:"fleet_id"`
+	InstanceID             string               `yaml:"instance_id"`
+	TrustRosterPath        string               `yaml:"trust_roster_path"`
+	ClientCertPath         string               `yaml:"client_cert_path"`
+	ClientKeyPath          string               `yaml:"client_key_path"`
+	BundleCacheDir         string               `yaml:"bundle_cache_dir"`
+	DurableAuditQueueDir   string               `yaml:"durable_audit_queue_dir"`
+	PollInterval           string               `yaml:"poll_interval"`
+	HonorRemoteKillSwitch  bool                 `yaml:"honor_remote_kill_switch"`
+	EmergencyStream        *bool                `yaml:"emergency_stream"`
+	CreatedSkewSeconds     int                  `yaml:"created_skew_seconds"`
+	MaxMinVersionMajorSkew int                  `yaml:"max_min_version_major_skew"`
+	MaxMinVersionMinorSkew int                  `yaml:"max_min_version_minor_skew"`
+	MaxCapabilityThreshold int                  `yaml:"max_capability_threshold"`
+	StalePolicy            ConductorStalePolicy `yaml:"stale_policy"`
+}
+
+// ConductorStalePolicy controls local behavior after the active bundle expires.
+type ConductorStalePolicy struct {
+	GraceMultiplier int    `yaml:"grace_multiplier"`
+	AfterGrace      string `yaml:"after_grace"`
 }
 
 // MCPInputScanning configures scanning of MCP JSON-RPC requests going from

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -216,6 +216,9 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 	if err := c.validateMediationEnvelope(); err != nil {
 		return warnings, err
 	}
+	if err := c.validateConductor(&warnings); err != nil {
+		return warnings, err
+	}
 	if err := c.validateMediaPolicy(); err != nil {
 		return warnings, err
 	}


### PR DESCRIPTION
## Summary
- add follower-side Conductor config defaults and validation
- keep local Conductor control-plane wiring out of canonical policy hashes
- add strict capabilities handshake and local negotiation caps for schema, skew, thresholds, and emergency stream support

## Hardening
- reject Conductor URLs with path components, userinfo, query, or fragment
- require an injected HTTP client for the capabilities handshake and add a bounded request deadline
- cap negotiated audit schema version at the follower-supported schema version
- enforce a minimum follower poll interval to reduce control-plane flood risk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Conductor configuration support (identifiers, URLs, polling, skews, and stream controls)
  * Implemented capabilities negotiation client and handshake with strict parsing and negotiated limits
  * Defaults and normalization for Conductor (EmergencyStream enabled by default)
  * Canonical policy hashing now ignores Conductor config

* **Chores**
  * Added extensive tests covering validation, defaults, handshake, and negotiation cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->