### PR TITLE
Wire Conductor audit batch transport

### DIFF
--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -566,6 +566,7 @@ conductor:
   fleet_id: "prod"
   instance_id: "pl-prod-1"
   trust_roster_path: "/etc/pipelock/conductor/trust-roster.json"
+  server_ca_file: "/etc/pipelock/conductor/boss-ca.pem"
   client_cert_path: "/etc/pipelock/conductor/client.crt"
   client_key_path: "/etc/pipelock/conductor/client.key"
   bundle_cache_dir: "/var/lib/pipelock/conductor/bundles"
@@ -583,6 +584,7 @@ conductor:
 Config validation must reject:
 
 - missing mTLS paths when enabled
+- missing Boss server CA bundle when enabled
 - non-absolute cache paths
 - cache directory paths under world-writable parents
 - `created_skew_seconds > 300`

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/CycloneDX/cyclonedx-go v0.10.0 h1:7xyklU7YD+CUyGzSFIARG18NYLsKVn4QFg04qSsu+7Y=
-github.com/CycloneDX/cyclonedx-go v0.10.0/go.mod h1:vUvbCXQsEm48OI6oOlanxstwNByXjCZ2wuleUlwGEO8=
 github.com/CycloneDX/cyclonedx-go v0.11.0 h1:GokP8FiRC+foiuwWhSSLpSD5H4hSWtGnR3wo7apkBFI=
 github.com/CycloneDX/cyclonedx-go v0.11.0/go.mod h1:vUvbCXQsEm48OI6oOlanxstwNByXjCZ2wuleUlwGEO8=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=

--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/conductor/auditbatcher"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+)
+
+const (
+	conductorHTTPTimeout           = 30 * time.Second
+	conductorTLSHandshakeTimeout   = 10 * time.Second
+	conductorResponseHeaderTimeout = 30 * time.Second
+	conductorIdleConnTimeout       = 90 * time.Second
+	conductorExpectContinueTimeout = time.Second
+	// conductorMaxResponseHeaderBytes caps Boss response headers. The default
+	// Go ceiling is 1 MiB, which is wasteful for an ingest endpoint that
+	// returns small JSON receipts; a tight cap also bounds memory under a
+	// hostile or misbehaving Boss.
+	conductorMaxResponseHeaderBytes = 64 * 1024
+)
+
+func buildConductorAuditTransport(cfg *config.Config, m *metrics.Metrics) (*auditbatcher.Queue, *auditbatcher.Transport, error) {
+	if cfg == nil || !cfg.Conductor.Enabled {
+		return nil, nil, nil
+	}
+	q, err := auditbatcher.Open(auditbatcher.Config{
+		Dir:             cfg.Conductor.DurableAuditQueueDir,
+		MaxPayloadBytes: conductor.MaxAuditPayloadBytes,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("opening conductor audit queue: %w", err)
+	}
+	stats, err := q.Stats()
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading conductor audit queue stats: %w", err)
+	}
+	if m != nil {
+		m.RecordConductorAuditQueue(stats)
+	}
+
+	client, err := newConductorMTLSClient(cfg.Conductor)
+	if err != nil {
+		return nil, nil, err
+	}
+	tr, err := auditbatcher.NewTransport(auditbatcher.TransportConfig{
+		BaseURL: cfg.Conductor.ConductorURL,
+		Client:  client,
+		Queue:   q,
+		Metrics: m,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating conductor audit transport: %w", err)
+	}
+	return q, tr, nil
+}
+
+func newConductorMTLSClient(cfg config.Conductor) (*http.Client, error) {
+	cert, err := tls.LoadX509KeyPair(filepath.Clean(cfg.ClientCertPath), filepath.Clean(cfg.ClientKeyPath))
+	if err != nil {
+		return nil, fmt.Errorf("loading conductor mTLS client certificate: %w", err)
+	}
+	roots, err := loadConductorServerCAs(cfg.ServerCAFile)
+	if err != nil {
+		return nil, err
+	}
+	serverName, err := conductorServerName(cfg.ConductorURL)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Client{
+		Timeout: conductorHTTPTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion:   tls.VersionTLS13,
+				Certificates: []tls.Certificate{cert},
+				RootCAs:      roots,
+				ServerName:   serverName,
+			},
+			TLSHandshakeTimeout:    conductorTLSHandshakeTimeout,
+			ResponseHeaderTimeout:  conductorResponseHeaderTimeout,
+			IdleConnTimeout:        conductorIdleConnTimeout,
+			ExpectContinueTimeout:  conductorExpectContinueTimeout,
+			MaxResponseHeaderBytes: conductorMaxResponseHeaderBytes,
+			ForceAttemptHTTP2:      true,
+		},
+	}, nil
+}
+
+// loadConductorServerCAs reads a PEM bundle and returns it as the only set of
+// roots that may validate the Boss server certificate. Mixing the system trust
+// store would let any public CA mint a MITM cert for the Boss host; the whole
+// point of a pinned roster is to keep that surface closed.
+func loadConductorServerCAs(path string) (*x509.CertPool, error) {
+	pem, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, fmt.Errorf("loading conductor server CA bundle: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, errors.New("conductor server CA bundle did not contain any PEM-encoded certificates")
+	}
+	return pool, nil
+}
+
+func conductorServerName(rawBaseURL string) (string, error) {
+	u, err := url.Parse(rawBaseURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing conductor base URL for ServerName: %w", err)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", errors.New("conductor base URL is missing a host for TLS ServerName")
+	}
+	// Normalize bracketed IPv6 literals: Hostname() already strips brackets and
+	// the port. net.SplitHostPort would only matter if a port slipped through
+	// without scheme; guard anyway.
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return host, nil
+}
+
+func conductorRuntimeChanged(oldCfg, newCfg *config.Config) bool {
+	if oldCfg == nil || newCfg == nil {
+		return false
+	}
+	return !reflect.DeepEqual(oldCfg.Conductor, newCfg.Conductor)
+}

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -1,0 +1,354 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestNewConductorMTLSClientConfiguresClientCertificate(t *testing.T) {
+	dir := t.TempDir()
+	clientPEM, clientKeyPEM := testTLSClientCert(t)
+	trustPath := filepath.Join(dir, "trust-roster.json")
+	caPath := filepath.Join(dir, "boss-ca.pem")
+	clientCertPath := filepath.Join(dir, "client.crt")
+	clientKeyPath := filepath.Join(dir, "client.key")
+	writePrivateTestFile(t, trustPath, []byte(`{"keys":[]}`))
+	writePrivateTestFile(t, caPath, clientPEM)
+	writePrivateTestFile(t, clientCertPath, clientPEM)
+	writePrivateTestFile(t, clientKeyPath, clientKeyPEM)
+
+	client, err := newConductorMTLSClient(config.Conductor{
+		ConductorURL:    "https://conductor.example",
+		TrustRosterPath: trustPath,
+		ServerCAFile:    caPath,
+		ClientCertPath:  clientCertPath,
+		ClientKeyPath:   clientKeyPath,
+	})
+	if err != nil {
+		t.Fatalf("newConductorMTLSClient() error = %v", err)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport type = %T, want *http.Transport", client.Transport)
+	}
+	if transport.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig = nil, want mTLS config")
+	}
+	if transport.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("MinVersion = %d, want TLS 1.3", transport.TLSClientConfig.MinVersion)
+	}
+	if len(transport.TLSClientConfig.Certificates) != 1 {
+		t.Fatalf("Certificates len = %d, want 1", len(transport.TLSClientConfig.Certificates))
+	}
+	if transport.TLSClientConfig.RootCAs == nil {
+		t.Fatal("RootCAs = nil; mTLS client must pin Boss server cert against roster, not system trust")
+	}
+	if transport.TLSClientConfig.ServerName != "conductor.example" {
+		t.Fatalf("ServerName = %q, want pinned host conductor.example", transport.TLSClientConfig.ServerName)
+	}
+	if transport.TLSHandshakeTimeout == 0 {
+		t.Fatal("TLSHandshakeTimeout = 0, want bounded handshake timeout")
+	}
+	if transport.ResponseHeaderTimeout == 0 {
+		t.Fatal("ResponseHeaderTimeout = 0, want bounded response header timeout")
+	}
+	if transport.MaxResponseHeaderBytes == 0 {
+		t.Fatal("MaxResponseHeaderBytes = 0, want explicit cap")
+	}
+}
+
+func TestNewConductorMTLSClientRejectsMissingClientCertificate(t *testing.T) {
+	dir := t.TempDir()
+	certPEM, _ := testTLSClientCert(t)
+	caPath := filepath.Join(dir, "boss-ca.pem")
+	writePrivateTestFile(t, caPath, certPEM)
+
+	_, err := newConductorMTLSClient(config.Conductor{
+		ConductorURL:    "https://conductor.example",
+		TrustRosterPath: filepath.Join(t.TempDir(), "trust.json"),
+		ServerCAFile:    caPath,
+		ClientCertPath:  filepath.Join(t.TempDir(), "missing.crt"),
+		ClientKeyPath:   filepath.Join(t.TempDir(), "missing.key"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "mTLS client certificate") {
+		t.Fatalf("newConductorMTLSClient() = %v, want certificate load error", err)
+	}
+}
+
+func TestNewConductorMTLSClientRejectsMissingServerCABundle(t *testing.T) {
+	dir := t.TempDir()
+	clientPEM, clientKeyPEM := testTLSClientCert(t)
+	clientCertPath := filepath.Join(dir, "client.crt")
+	clientKeyPath := filepath.Join(dir, "client.key")
+	writePrivateTestFile(t, clientCertPath, clientPEM)
+	writePrivateTestFile(t, clientKeyPath, clientKeyPEM)
+
+	_, err := newConductorMTLSClient(config.Conductor{
+		ConductorURL:    "https://conductor.example",
+		TrustRosterPath: filepath.Join(t.TempDir(), "trust.json"),
+		ServerCAFile:    filepath.Join(t.TempDir(), "missing.pem"),
+		ClientCertPath:  clientCertPath,
+		ClientKeyPath:   clientKeyPath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "server CA bundle") {
+		t.Fatalf("newConductorMTLSClient() = %v, want server CA bundle load error", err)
+	}
+}
+
+func TestNewConductorMTLSClientRejectsNonPEMServerCABundle(t *testing.T) {
+	dir := t.TempDir()
+	clientPEM, clientKeyPEM := testTLSClientCert(t)
+	caPath := filepath.Join(dir, "boss-ca.pem")
+	writePrivateTestFile(t, caPath, []byte("not a PEM bundle"))
+	clientCertPath := filepath.Join(dir, "client.crt")
+	clientKeyPath := filepath.Join(dir, "client.key")
+	writePrivateTestFile(t, clientCertPath, clientPEM)
+	writePrivateTestFile(t, clientKeyPath, clientKeyPEM)
+
+	_, err := newConductorMTLSClient(config.Conductor{
+		ConductorURL:    "https://conductor.example",
+		TrustRosterPath: filepath.Join(t.TempDir(), "trust.json"),
+		ServerCAFile:    caPath,
+		ClientCertPath:  clientCertPath,
+		ClientKeyPath:   clientKeyPath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "PEM-encoded certificates") {
+		t.Fatalf("newConductorMTLSClient() = %v, want PEM parse error", err)
+	}
+}
+
+// TestNewConductorMTLSClient_VerifiesAgainstPinnedRosterOnly is the "proves
+// the pin" test. Two test CAs sign two server certs. The follower's mTLS
+// client gets only one CA in its roster. A request to the matching server
+// succeeds; a request to the off-roster server is rejected at TLS verification
+// even though both certs are valid X.509 leaves with healthy chains.
+func TestNewConductorMTLSClient_VerifiesAgainstPinnedRosterOnly(t *testing.T) {
+	dir := t.TempDir()
+	pinnedCAPEM, pinnedServer := newTestTLSServer(t)
+	_, offRosterServer := newTestTLSServer(t)
+	defer pinnedServer.Close()
+	defer offRosterServer.Close()
+
+	caPath := filepath.Join(dir, "boss-ca.pem")
+	writePrivateTestFile(t, caPath, pinnedCAPEM)
+	clientPEM, clientKeyPEM := testTLSClientCert(t)
+	clientCertPath := filepath.Join(dir, "client.crt")
+	clientKeyPath := filepath.Join(dir, "client.key")
+	writePrivateTestFile(t, clientCertPath, clientPEM)
+	writePrivateTestFile(t, clientKeyPath, clientKeyPEM)
+
+	client, err := newConductorMTLSClient(config.Conductor{
+		ConductorURL:    pinnedServer.URL,
+		TrustRosterPath: filepath.Join(t.TempDir(), "trust.json"),
+		ServerCAFile:    caPath,
+		ClientCertPath:  clientCertPath,
+		ClientKeyPath:   clientKeyPath,
+	})
+	if err != nil {
+		t.Fatalf("newConductorMTLSClient() error = %v", err)
+	}
+
+	// Override ServerName because httptest servers bind 127.0.0.1 and the
+	// pinned-cert SAN below is also 127.0.0.1. The production code derives
+	// ServerName from the configured URL, so this test mirrors that path.
+	transport := client.Transport.(*http.Transport)
+	transport.TLSClientConfig.ServerName = mustHostname(t, pinnedServer.URL)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pinnedServer.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest(pinned) error = %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do(pinned) error = %v; pinned-CA chain must validate", err)
+	}
+	_ = resp.Body.Close()
+
+	transport.TLSClientConfig.ServerName = mustHostname(t, offRosterServer.URL)
+	transport.CloseIdleConnections()
+	offReq, err := http.NewRequestWithContext(ctx, http.MethodGet, offRosterServer.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest(off-roster) error = %v", err)
+	}
+	offResp, err := client.Do(offReq)
+	if err == nil {
+		_ = offResp.Body.Close()
+		t.Fatal("Do(off-roster) error = nil; off-roster CA must NOT be accepted")
+	}
+	if !strings.Contains(err.Error(), "unknown authority") &&
+		!strings.Contains(err.Error(), "x509") &&
+		!strings.Contains(err.Error(), "certificate") {
+		t.Fatalf("Do(off-roster) error = %v; want TLS verification error", err)
+	}
+}
+
+func TestConductorServerNameStripsPort(t *testing.T) {
+	got, err := conductorServerName("https://boss.example:8443")
+	if err != nil {
+		t.Fatalf("conductorServerName() error = %v", err)
+	}
+	if got != "boss.example" {
+		t.Fatalf("conductorServerName() = %q, want boss.example", got)
+	}
+}
+
+func TestConductorRuntimeChanged(t *testing.T) {
+	oldCfg := config.Defaults()
+	newCfg := oldCfg.Clone()
+	if conductorRuntimeChanged(oldCfg, newCfg) {
+		t.Fatal("conductorRuntimeChanged(equal) = true, want false")
+	}
+	newCfg.Conductor.Enabled = true
+	if !conductorRuntimeChanged(oldCfg, newCfg) {
+		t.Fatal("conductorRuntimeChanged(changed) = false, want true")
+	}
+}
+
+func mustHostname(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse(%s) error = %v", raw, err)
+	}
+	host := u.Hostname()
+	if host == "" {
+		t.Fatalf("url %s has no host", raw)
+	}
+	return host
+}
+
+// newTestTLSServer builds a single-leaf CA + server cert, starts an httptest
+// server, and returns the CA PEM bundle plus the server. The CA is unique per
+// call so two servers can't reuse the same chain.
+func newTestTLSServer(t *testing.T) ([]byte, *httptest.Server) {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey(ca) error = %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          mustSerial(t),
+		Subject:               pkix.Name{CommonName: "pipelock-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate(ca) error = %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("ParseCertificate(ca) error = %v", err)
+	}
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey(leaf) error = %v", err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: mustSerial(t),
+		Subject:      pkix.Name{CommonName: "pipelock-test-boss"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:     []string{"localhost"},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate(leaf) error = %v", err)
+	}
+	leafCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})
+	leafKeyBytes, err := x509.MarshalECPrivateKey(leafKey)
+	if err != nil {
+		t.Fatalf("MarshalECPrivateKey() error = %v", err)
+	}
+	leafKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: leafKeyBytes})
+	leafCert, err := tls.X509KeyPair(leafCertPEM, leafKeyPEM)
+	if err != nil {
+		t.Fatalf("X509KeyPair(leaf) error = %v", err)
+	}
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{leafCert},
+		MinVersion:   tls.VersionTLS13,
+	}
+	srv.StartTLS()
+	return caPEM, srv
+}
+
+// testTLSClientCert returns a self-signed client cert + key PEM pair. The cert
+// uses ECDSA P-256 to keep test setup cheap and reproducible.
+func testTLSClientCert(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey() error = %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: mustSerial(t),
+		Subject:      pkix.Name{CommonName: "pipelock-test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("CreateCertificate() error = %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalECPrivateKey() error = %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+	return certPEM, keyPEM
+}
+
+func mustSerial(t *testing.T) *big.Int {
+	t.Helper()
+	serial, err := rand.Int(rand.Reader, big.NewInt(1<<62))
+	if err != nil {
+		t.Fatalf("rand.Int() error = %v", err)
+	}
+	return serial
+}
+
+func writePrivateTestFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+}

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/conductor/auditbatcher"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/emit"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
@@ -99,6 +100,7 @@ type Server struct {
 	envelopeEmitter *envelope.Emitter
 	captureWriter   *capture.Writer
 	recorder        *recorder.Recorder
+	conductorAudit  *auditbatcher.Transport
 	approver        *hitl.Approver
 
 	// lastReloadHash / lastReloadAt dedup fsnotify + SIGHUP stacking
@@ -280,6 +282,12 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	s.scanner = sc
 	m := metrics.New()
 	s.metrics = m
+	_, conductorAudit, conductorErr := buildConductorAuditTransport(cfg, m)
+	if conductorErr != nil {
+		s.cleanup()
+		return nil, conductorErr
+	}
+	s.conductorAudit = conductorAudit
 	sc.SetDLPWarnHook(func(ctx context.Context, patternName, severity string) {
 		emitDLPWarn(s.logger, s.metrics, s.liveReceiptEmitter(), ctx, patternName, severity)
 	})

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -205,6 +205,9 @@ func (s *Server) Start(ctx context.Context) error {
 		_, _ = fmt.Fprintf(s.opts.Stderr, "  RevPx:  http://%s -> %s (reverse proxy with body scanning)\n",
 			cfg.ReverseProxy.Listen, RedactEndpoint(cfg.ReverseProxy.Upstream))
 	}
+	if s.conductorAudit != nil {
+		_, _ = fmt.Fprintf(s.opts.Stderr, "  Conductor: audit transport enabled -> %s\n", RedactEndpoint(cfg.Conductor.ConductorURL))
+	}
 	if s.opts.CaptureOutput != "" {
 		if s.opts.CaptureDuration > 0 {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "  Capture: %s (duration: %s)\n", s.opts.CaptureOutput, s.opts.CaptureDuration)
@@ -221,6 +224,27 @@ func (s *Server) Start(ctx context.Context) error {
 		_, _ = fmt.Fprintln(s.opts.Stderr, "\nNote: agent process launching is not yet implemented (Phase 2).")
 		_, _ = fmt.Fprintln(s.opts.Stderr, "The fetch proxy is running — configure your agent to use:")
 		_, _ = fmt.Fprintf(s.opts.Stderr, "  PIPELOCK_FETCH_URL=http://%s/fetch\n\n", cfg.FetchProxy.Listen)
+	}
+
+	var conductorWG sync.WaitGroup
+	if s.conductorAudit != nil {
+		conductorWG.Add(1)
+		go func() {
+			defer conductorWG.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: conductor audit transport panic: %v\n", r)
+				}
+			}()
+			if err := s.conductorAudit.Run(ctx); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+				s.logger.LogError(audit.NewResourceLogContext("conductor_audit_transport", cfg.Conductor.ConductorURL), err)
+				_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: conductor audit transport stopped: %v\n", err)
+			}
+		}()
+		defer func() {
+			cancel()
+			conductorWG.Wait()
+		}()
 	}
 
 	// Start kill switch API on a separate port if configured. Follows

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -78,6 +78,17 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			newCfg.ScanAPI.ConnectionLimit = oldCfg.ScanAPI.ConnectionLimit
 			newCfg.ScanAPI.Timeouts = oldCfg.ScanAPI.Timeouts
 		}
+		if conductorRuntimeChanged(oldCfg, newCfg) {
+			attemptedHash := newCfg.Hash()
+			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: conductor settings changed — requires restart, ignoring\n")
+			// Surface to the audit channel as well as stderr. Conductor
+			// settings sit on the trust boundary with Boss: silently
+			// preserving them on reload is the right choice, but an
+			// operator (or attacker with config write) attempting the
+			// change should leave a record an SOC tool can find.
+			s.logger.LogConfigReload("ignored", "conductor settings restart-only", attemptedHash)
+			newCfg.Conductor = oldCfg.Conductor
+		}
 		// Block signing key rotation via reload. The receipt chain
 		// state is anchored to the current signing key; rotation
 		// mid-chain causes tail-signature verification to fail on

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -747,6 +747,7 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 	oldCfg.ScanAPI.ConnectionLimit = 2
 	oldCfg.ScanAPI.Timeouts = config.ScanAPITimeouts{Read: "1s", Write: "1s"}
 	oldCfg.FlightRecorder.SigningKeyPath = "/tmp/old-signing-key"
+	oldCfg.Conductor.ConductorURL = "https://boss-old.example"
 
 	newCfg := oldCfg.Clone()
 	newCfg.KillSwitch.APIListen = "127.0.0.1:28081"
@@ -755,6 +756,7 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 	newCfg.ScanAPI.ConnectionLimit = 4
 	newCfg.ScanAPI.Timeouts = config.ScanAPITimeouts{Read: "2s", Write: "2s"}
 	newCfg.FlightRecorder.SigningKeyPath = "/tmp/new-signing-key"
+	newCfg.Conductor.ConductorURL = "https://boss-new.example"
 	newCfg.ReverseProxy.Listen = "127.0.0.1:28084"
 	newCfg.ReverseProxy.Upstream = "http://127.0.0.1:2"
 
@@ -776,6 +778,9 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 	if live.FlightRecorder.SigningKeyPath != oldCfg.FlightRecorder.SigningKeyPath {
 		t.Fatalf("signing key path = %q, want %q", live.FlightRecorder.SigningKeyPath, oldCfg.FlightRecorder.SigningKeyPath)
 	}
+	if live.Conductor != oldCfg.Conductor {
+		t.Fatalf("conductor settings not preserved: %+v", live.Conductor)
+	}
 	if live.ReverseProxy != oldCfg.ReverseProxy {
 		t.Fatalf("reverse proxy settings not preserved: %+v", live.ReverseProxy)
 	}
@@ -783,6 +788,7 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 		"kill_switch.api_listen changed",
 		"metrics_listen changed",
 		"scan_api listener settings changed",
+		"conductor settings changed",
 		"flight_recorder.signing_key_path changed",
 		"reverse_proxy settings changed",
 	} {

--- a/internal/conductor/auditbatcher/queue.go
+++ b/internal/conductor/auditbatcher/queue.go
@@ -83,10 +83,15 @@ type Queue struct {
 }
 
 type diskRecord struct {
-	Version    int                          `json:"version"`
-	EnqueuedAt time.Time                    `json:"enqueued_at"`
-	Envelope   conductor.AuditBatchEnvelope `json:"envelope"`
-	Payload    []byte                       `json:"payload"`
+	Version       int                          `json:"version"`
+	EnqueuedAt    time.Time                    `json:"enqueued_at"`
+	Envelope      conductor.AuditBatchEnvelope `json:"envelope"`
+	Payload       []byte                       `json:"payload"`
+	RetryCount    uint64                       `json:"retry_count,omitempty"`
+	LastAttemptAt *time.Time                   `json:"last_attempt_at,omitempty"`
+	LastError     string                       `json:"last_error,omitempty"`
+	DroppedAt     *time.Time                   `json:"dropped_at,omitempty"`
+	DroppedReason string                       `json:"dropped_reason,omitempty"`
 }
 
 func Open(cfg Config) (*Queue, error) {
@@ -162,7 +167,7 @@ func (q *Queue) Enqueue(batch Batch) (string, error) {
 		return "", fmt.Errorf("auditbatcher: marshal record: %w", err)
 	}
 	path := filepath.Join(q.pendingDir, id)
-	if err := durableWrite(path, data, fileMode); err != nil {
+	if err := durableWrite(path, data); err != nil {
 		return "", err
 	}
 	return id, nil
@@ -240,6 +245,61 @@ func (q *Queue) Release(id string) error {
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	return q.releaseLocked(id)
+}
+
+// ReleaseWithRetry returns an inflight record to pending and durably annotates
+// the retry count/reason before the rename. If the process crashes after the
+// annotation but before the rename, Open's inflight recovery preserves the
+// updated accounting when it moves the record back to pending.
+func (q *Queue) ReleaseWithRetry(id, reason string) error {
+	if q == nil {
+		return errors.New("auditbatcher: nil queue")
+	}
+	if err := validateRecordID(id); err != nil {
+		return err
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if err := q.updateInflightRecordLocked(id, func(record *diskRecord) {
+		now := q.now().UTC()
+		record.RetryCount++
+		record.LastAttemptAt = &now
+		record.LastError = normalizeAccountingReason(reason)
+	}); err != nil {
+		return err
+	}
+	return q.releaseLocked(id)
+}
+
+// Drop moves an inflight record to the dead-letter directory and durably stamps
+// the terminal drop reason first. Dead records remain inspectable by operators.
+func (q *Queue) Drop(id, reason string) error {
+	if q == nil {
+		return errors.New("auditbatcher: nil queue")
+	}
+	if err := validateRecordID(id); err != nil {
+		return err
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if err := q.updateInflightRecordLocked(id, func(record *diskRecord) {
+		now := q.now().UTC()
+		record.DroppedAt = &now
+		record.DroppedReason = normalizeAccountingReason(reason)
+		record.LastError = record.DroppedReason
+	}); err != nil {
+		return err
+	}
+	src := filepath.Join(q.inflightDir, id)
+	dst, err := uniqueDeadPath(q.deadDir, id)
+	if err != nil {
+		return err
+	}
+	return moveToDead(src, dst)
+}
+
+func (q *Queue) releaseLocked(id string) error {
 	src := filepath.Join(q.inflightDir, id)
 	dst := filepath.Join(q.pendingDir, id)
 	if _, err := os.Stat(dst); err == nil {
@@ -478,6 +538,62 @@ func uint64ToInt64(value uint64) (int64, error) {
 	return converted, nil
 }
 
+func (q *Queue) updateInflightRecordLocked(id string, mutate func(*diskRecord)) error {
+	path := filepath.Join(q.inflightDir, id)
+	record, err := readRecord(path, q.maxPayloadBytes)
+	if err != nil {
+		return fmt.Errorf("auditbatcher: annotate inflight %s: %w", id, err)
+	}
+	mutate(&record)
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("auditbatcher: marshal annotated record %s: %w", id, err)
+	}
+	if err := durableWrite(path, data); err != nil {
+		return fmt.Errorf("auditbatcher: write annotated record %s: %w", id, err)
+	}
+	return nil
+}
+
+func normalizeAccountingReason(reason string) string {
+	reason = strings.ToLower(strings.TrimSpace(reason))
+	if reason == "" {
+		return "unspecified"
+	}
+	var b strings.Builder
+	b.Grow(len(reason))
+	lastUnderscore := false
+	for _, r := range reason {
+		ok := r >= 'a' && r <= 'z' || r >= '0' && r <= '9'
+		if ok {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if (r == '_' || r == '-' || r == '.') && b.Len() > 0 {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore && b.Len() > 0 {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	normalized := strings.Trim(b.String(), "_-.")
+	if normalized == "" {
+		return "unspecified"
+	}
+	if len(normalized) > conductor.MaxDropReasonBytes {
+		normalized = normalized[:conductor.MaxDropReasonBytes]
+		normalized = strings.TrimRight(normalized, "_-.")
+	}
+	if normalized == "" {
+		return "unspecified"
+	}
+	return normalized
+}
+
 func listRecordFiles(dir string) ([]string, error) {
 	entries, err := os.ReadDir(filepath.Clean(dir))
 	if err != nil {
@@ -602,7 +718,7 @@ func ensurePathContained(root, path string) error {
 	return nil
 }
 
-func durableWrite(path string, data []byte, perm os.FileMode) error {
+func durableWrite(path string, data []byte) error {
 	path = filepath.Clean(path)
 	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, ".tmp-*")
@@ -620,7 +736,7 @@ func durableWrite(path string, data []byte, perm os.FileMode) error {
 		_ = tmp.Close()
 		return fmt.Errorf("auditbatcher: write temp: %w", err)
 	}
-	if err := tmp.Chmod(perm); err != nil {
+	if err := tmp.Chmod(fileMode); err != nil {
 		_ = tmp.Close()
 		return fmt.Errorf("auditbatcher: chmod temp: %w", err)
 	}

--- a/internal/conductor/auditbatcher/queue_test.go
+++ b/internal/conductor/auditbatcher/queue_test.go
@@ -142,6 +142,76 @@ func TestQueueReleaseAndRecoverInflight(t *testing.T) {
 	assertStats(t, reopened, Stats{Pending: 1})
 }
 
+func TestQueueReleaseWithRetryPersistsAccounting(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	dir := t.TempDir()
+	q, err := Open(Config{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	id, err := q.Enqueue(signedTestBatch(t, "batch-retry", priv))
+	if err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	if _, err := q.Claim(); err != nil {
+		t.Fatalf("Claim() error = %v", err)
+	}
+	if err := q.ReleaseWithRetry(id, "HTTP 503 temporary outage"); err != nil {
+		t.Fatalf("ReleaseWithRetry() error = %v", err)
+	}
+
+	reopened, err := Open(Config{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open(reopen) error = %v", err)
+	}
+	record, err := readRecord(filepath.Join(reopened.pendingDir, id), conductor.MaxAuditPayloadBytes)
+	if err != nil {
+		t.Fatalf("readRecord() error = %v", err)
+	}
+	if record.RetryCount != 1 {
+		t.Fatalf("RetryCount = %d, want 1", record.RetryCount)
+	}
+	if record.LastAttemptAt == nil {
+		t.Fatal("LastAttemptAt = nil, want timestamp")
+	}
+	if record.LastError != "http_503_temporary_outage" {
+		t.Fatalf("LastError = %q, want normalized retry reason", record.LastError)
+	}
+}
+
+func TestQueueDropMovesInflightToDeadWithReason(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	q := openTestQueue(t, Config{})
+	id, err := q.Enqueue(signedTestBatch(t, "batch-drop", priv))
+	if err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	if _, err := q.Claim(); err != nil {
+		t.Fatalf("Claim() error = %v", err)
+	}
+	if err := q.Drop(id, "HTTP 400 rejected"); err != nil {
+		t.Fatalf("Drop() error = %v", err)
+	}
+	assertStats(t, q, Stats{Dead: 1})
+
+	record, err := readRecord(filepath.Join(q.deadDir, id), conductor.MaxAuditPayloadBytes)
+	if err != nil {
+		t.Fatalf("readRecord(dead) error = %v", err)
+	}
+	if record.DroppedReason != "http_400_rejected" {
+		t.Fatalf("DroppedReason = %q, want normalized drop reason", record.DroppedReason)
+	}
+	if record.DroppedAt == nil {
+		t.Fatal("DroppedAt = nil, want timestamp")
+	}
+}
+
 func TestQueueReleaseRejectsExistingPendingTarget(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
@@ -965,14 +1035,14 @@ func TestFsyncDirMissingPath(t *testing.T) {
 }
 
 func TestDurableWriteAndMoveToDeadErrorPaths(t *testing.T) {
-	if err := durableWrite(filepath.Join(t.TempDir(), "missing", "record.json"), []byte("record"), fileMode); err == nil {
+	if err := durableWrite(filepath.Join(t.TempDir(), "missing", "record.json"), []byte("record")); err == nil {
 		t.Fatal("durableWrite(missing parent) error = nil, want create temp error")
 	}
 	existingDir := filepath.Join(t.TempDir(), "existing-dir")
 	if err := os.Mkdir(existingDir, dirMode); err != nil {
 		t.Fatalf("Mkdir(existingDir) error = %v", err)
 	}
-	if err := durableWrite(existingDir, []byte("record"), fileMode); err == nil || !strings.Contains(err.Error(), "rename temp") {
+	if err := durableWrite(existingDir, []byte("record")); err == nil || !strings.Contains(err.Error(), "rename temp") {
 		t.Fatalf("durableWrite(existing dir) = %v, want rename error", err)
 	}
 	if err := moveToDead(filepath.Join(t.TempDir(), "missing.json"), filepath.Join(t.TempDir(), "dead.json")); err == nil {

--- a/internal/conductor/auditbatcher/transport.go
+++ b/internal/conductor/auditbatcher/transport.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package auditbatcher
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+)
+
+const (
+	AuditBatchesPath         = "/api/v1/conductor/audit/batches"
+	defaultTransportDelay    = time.Second
+	maxTransportErrorSnippet = 1024
+)
+
+const (
+	deliveryOutcomeSuccess = "success"
+	deliveryOutcomeRetry   = "retry"
+	deliveryOutcomeDrop    = "drop"
+
+	deliveryReasonNetwork     = "network_error"
+	deliveryReasonClientError = "http_client_error"
+	deliveryReasonRateLimited = "http_rate_limited"
+	deliveryReasonServerError = "http_server_error"
+)
+
+// HTTPDoer is the narrow boundary between the durable queue and Conductor.
+// Runtime wiring must pass a dedicated mTLS-capable client; this package never
+// constructs or falls back to a default network client.
+type HTTPDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// MetricsSink records transport observability without coupling this package to
+// the Prometheus implementation.
+type MetricsSink interface {
+	RecordConductorAuditQueue(stats Stats)
+	RecordConductorAuditDelivery(outcome, reason string)
+}
+
+type TransportConfig struct {
+	BaseURL    string
+	Client     HTTPDoer
+	Queue      *Queue
+	Metrics    MetricsSink
+	RetryDelay time.Duration
+	EmptyDelay time.Duration
+}
+
+type Transport struct {
+	endpoint   string
+	client     HTTPDoer
+	queue      *Queue
+	metrics    MetricsSink
+	retryDelay time.Duration
+	emptyDelay time.Duration
+}
+
+type batchUpload struct {
+	Envelope conductor.AuditBatchEnvelope `json:"envelope"`
+	Payload  []byte                       `json:"payload"`
+}
+
+type deliveryResult struct {
+	outcome string
+	reason  string
+	err     error
+}
+
+func NewTransport(cfg TransportConfig) (*Transport, error) {
+	if cfg.Queue == nil {
+		return nil, errors.New("auditbatcher: transport queue required")
+	}
+	if cfg.Client == nil {
+		return nil, errors.New("auditbatcher: transport http client required")
+	}
+	endpoint, err := auditEndpoint(cfg.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.RetryDelay <= 0 {
+		cfg.RetryDelay = defaultTransportDelay
+	}
+	if cfg.EmptyDelay <= 0 {
+		cfg.EmptyDelay = defaultTransportDelay
+	}
+	return &Transport{
+		endpoint:   endpoint,
+		client:     cfg.Client,
+		queue:      cfg.Queue,
+		metrics:    cfg.Metrics,
+		retryDelay: cfg.RetryDelay,
+		emptyDelay: cfg.EmptyDelay,
+	}, nil
+}
+
+// Run drains queued audit batches until ctx is cancelled. Delivery is
+// fail-closed with respect to durability: retryable failures are released back
+// to pending, terminal failures are dead-lettered, and network errors never
+// delete a queue record.
+func (t *Transport) Run(ctx context.Context) error {
+	if t == nil {
+		return errors.New("auditbatcher: nil transport")
+	}
+	if ctx == nil {
+		return errors.New("auditbatcher: nil context")
+	}
+	for {
+		err := t.DeliverOnce(ctx)
+		switch {
+		case err == nil:
+			continue
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			return err
+		case errors.Is(err, ErrQueueEmpty):
+			if !t.sleep(ctx, t.emptyDelay) {
+				return ctx.Err()
+			}
+		default:
+			if !t.sleep(ctx, t.retryDelay) {
+				return ctx.Err()
+			}
+		}
+	}
+}
+
+func (t *Transport) DeliverOnce(ctx context.Context) error {
+	if t == nil {
+		return errors.New("auditbatcher: nil transport")
+	}
+	if ctx == nil {
+		return errors.New("auditbatcher: nil context")
+	}
+	lease, err := t.queue.Claim()
+	if err != nil {
+		if errors.Is(err, ErrQueueEmpty) {
+			t.recordQueue()
+		}
+		return err
+	}
+
+	result := t.send(ctx, lease.Batch)
+	switch result.outcome {
+	case deliveryOutcomeSuccess:
+		if err := t.queue.Ack(lease.ID); err != nil {
+			return err
+		}
+	case deliveryOutcomeRetry:
+		if err := t.queue.ReleaseWithRetry(lease.ID, result.reason); err != nil {
+			return err
+		}
+	case deliveryOutcomeDrop:
+		if err := t.queue.Drop(lease.ID, result.reason); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("auditbatcher: unknown delivery outcome %q", result.outcome)
+	}
+	t.recordDelivery(result.outcome, result.reason)
+	t.recordQueue()
+	return result.err
+}
+
+func (t *Transport) send(ctx context.Context, batch Batch) deliveryResult {
+	body, err := json.Marshal(batchUpload(batch))
+	if err != nil {
+		return deliveryResult{outcome: deliveryOutcomeDrop, reason: "marshal_error", err: err}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return deliveryResult{outcome: deliveryOutcomeDrop, reason: "request_error", err: err}
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return deliveryResult{outcome: deliveryOutcomeRetry, reason: deliveryReasonNetwork, err: ctx.Err()}
+		}
+		return deliveryResult{outcome: deliveryOutcomeRetry, reason: deliveryReasonNetwork, err: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxTransportErrorSnippet))
+
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return deliveryResult{outcome: deliveryOutcomeSuccess, reason: deliveryOutcomeSuccess}
+	}
+	reason := statusReason(resp.StatusCode)
+	err = fmt.Errorf("conductor audit batch upload status=%d", resp.StatusCode)
+	if isRetryableStatus(resp.StatusCode) {
+		return deliveryResult{outcome: deliveryOutcomeRetry, reason: reason, err: err}
+	}
+	return deliveryResult{outcome: deliveryOutcomeDrop, reason: reason, err: err}
+}
+
+func (t *Transport) sleep(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (t *Transport) recordQueue() {
+	if t.metrics == nil {
+		return
+	}
+	stats, err := t.queue.Stats()
+	if err != nil {
+		return
+	}
+	t.metrics.RecordConductorAuditQueue(stats)
+}
+
+func (t *Transport) recordDelivery(outcome, reason string) {
+	if t.metrics != nil {
+		t.metrics.RecordConductorAuditDelivery(outcome, normalizeAccountingReason(reason))
+	}
+}
+
+func auditEndpoint(rawBaseURL string) (string, error) {
+	if strings.TrimSpace(rawBaseURL) == "" {
+		return "", errors.New("auditbatcher: conductor base URL required")
+	}
+	u, err := url.Parse(rawBaseURL)
+	if err != nil {
+		return "", fmt.Errorf("auditbatcher: parse conductor base URL: %w", err)
+	}
+	if u.Scheme != "https" || u.Host == "" {
+		return "", errors.New("auditbatcher: conductor base URL must be https with a host")
+	}
+	if u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return "", errors.New("auditbatcher: conductor base URL must not include userinfo, query, or fragment")
+	}
+	if u.Path != "" && u.Path != "/" {
+		return "", fmt.Errorf("auditbatcher: conductor base URL must not include a path component, got %q", u.Path)
+	}
+	u.Path = AuditBatchesPath
+	return u.String(), nil
+}
+
+func isRetryableStatus(status int) bool {
+	return status == http.StatusRequestTimeout ||
+		status == http.StatusTooEarly ||
+		status == http.StatusTooManyRequests ||
+		status >= http.StatusInternalServerError
+}
+
+func statusReason(status int) string {
+	switch {
+	case status == http.StatusTooManyRequests:
+		return deliveryReasonRateLimited
+	case status >= http.StatusInternalServerError:
+		return deliveryReasonServerError
+	case status >= http.StatusBadRequest:
+		return deliveryReasonClientError
+	default:
+		return fmt.Sprintf("http_status_%d", status)
+	}
+}

--- a/internal/conductor/auditbatcher/transport_test.go
+++ b/internal/conductor/auditbatcher/transport_test.go
@@ -1,0 +1,342 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package auditbatcher
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTransportDeliverOnceSuccessAcksRecord(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	q := openTestQueue(t, Config{})
+	if _, err := q.Enqueue(signedTestBatch(t, "batch-transport-success", priv)); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+
+	var sawPath, sawMethod bool
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawPath = r.URL.Path == AuditBatchesPath
+		sawMethod = r.Method == http.MethodPost
+		var upload batchUpload
+		if err := json.NewDecoder(r.Body).Decode(&upload); err != nil {
+			t.Fatalf("Decode(upload) error = %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	metrics := &transportMetricsRecorder{}
+	tr, err := NewTransport(TransportConfig{
+		BaseURL: srv.URL,
+		Client:  srv.Client(),
+		Queue:   q,
+		Metrics: metrics,
+	})
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+	if err := tr.DeliverOnce(t.Context()); err != nil {
+		t.Fatalf("DeliverOnce() error = %v", err)
+	}
+	if !sawPath || !sawMethod {
+		t.Fatalf("request path/method mismatch: sawPath=%v sawMethod=%v", sawPath, sawMethod)
+	}
+	assertStats(t, q, Stats{})
+	if got := metrics.delivery["success:success"]; got != 1 {
+		t.Fatalf("success metric = %d, want 1", got)
+	}
+	if metrics.lastStats != (Stats{}) {
+		t.Fatalf("last queue stats = %+v, want empty", metrics.lastStats)
+	}
+}
+
+func TestTransportDeliverOnceRetryReleasesRecord(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	q := openTestQueue(t, Config{})
+	id, err := q.Enqueue(signedTestBatch(t, "batch-transport-retry", priv))
+	if err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	metrics := &transportMetricsRecorder{}
+	tr, err := NewTransport(TransportConfig{BaseURL: srv.URL, Client: srv.Client(), Queue: q, Metrics: metrics})
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+	if err := tr.DeliverOnce(t.Context()); err == nil {
+		t.Fatal("DeliverOnce() error = nil, want retry error")
+	}
+	assertStats(t, q, Stats{Pending: 1})
+
+	record, err := readRecord(filepath.Join(q.pendingDir, id), q.maxPayloadBytes)
+	if err != nil {
+		t.Fatalf("readRecord(pending) error = %v", err)
+	}
+	if record.RetryCount != 1 {
+		t.Fatalf("RetryCount = %d, want 1", record.RetryCount)
+	}
+	if got := metrics.delivery["retry:http_server_error"]; got != 1 {
+		t.Fatalf("retry metric = %d, want 1", got)
+	}
+}
+
+func TestTransportDeliverOnceClientErrorDropsRecord(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	q := openTestQueue(t, Config{})
+	id, err := q.Enqueue(signedTestBatch(t, "batch-transport-drop", priv))
+	if err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	metrics := &transportMetricsRecorder{}
+	tr, err := NewTransport(TransportConfig{BaseURL: srv.URL, Client: srv.Client(), Queue: q, Metrics: metrics})
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+	if err := tr.DeliverOnce(t.Context()); err == nil {
+		t.Fatal("DeliverOnce() error = nil, want terminal delivery error")
+	}
+	assertStats(t, q, Stats{Dead: 1})
+
+	record, err := readRecord(filepath.Join(q.deadDir, id), q.maxPayloadBytes)
+	if err != nil {
+		t.Fatalf("readRecord(dead) error = %v", err)
+	}
+	if record.DroppedReason != deliveryReasonClientError {
+		t.Fatalf("DroppedReason = %q, want %q", record.DroppedReason, deliveryReasonClientError)
+	}
+	if got := metrics.delivery["drop:http_client_error"]; got != 1 {
+		t.Fatalf("drop metric = %d, want 1", got)
+	}
+}
+
+func TestTransportDeliverOnceQueueEmpty(t *testing.T) {
+	q := openTestQueue(t, Config{})
+	srv := httptest.NewTLSServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	tr, err := NewTransport(TransportConfig{BaseURL: srv.URL, Client: srv.Client(), Queue: q})
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+	if err := tr.DeliverOnce(t.Context()); !errors.Is(err, ErrQueueEmpty) {
+		t.Fatalf("DeliverOnce() = %v, want ErrQueueEmpty", err)
+	}
+}
+
+func TestNewTransportRequiresHTTPSBaseURL(t *testing.T) {
+	q := openTestQueue(t, Config{})
+	_, err := NewTransport(TransportConfig{BaseURL: "http://conductor.example", Client: http.DefaultClient, Queue: q})
+	if err == nil {
+		t.Fatal("NewTransport() error = nil, want HTTPS requirement")
+	}
+}
+
+// TestTransportWireFormat_StableContract pins the JSON contract Boss-side
+// ingest will need to honor. Drift in field names or shape breaks every
+// deployed follower the moment Boss is built. Decode-side checks are
+// intentionally strict: top-level keys are exactly {envelope, payload};
+// payload is a base64-encoded string of the raw bytes; envelope round-trips
+// to the same AuditBatchEnvelope the queue stored.
+func TestTransportWireFormat_StableContract(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	q := openTestQueue(t, Config{})
+	batch := signedTestBatch(t, "batch-wire-format", priv)
+	if _, err := q.Enqueue(batch); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+
+	type wireShape struct {
+		Envelope json.RawMessage `json:"envelope"`
+		Payload  string          `json:"payload"`
+	}
+	var capturedRaw json.RawMessage
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll(body) error = %v", err)
+		}
+		capturedRaw = body
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	tr, err := NewTransport(TransportConfig{BaseURL: srv.URL, Client: srv.Client(), Queue: q})
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+	if err := tr.DeliverOnce(t.Context()); err != nil {
+		t.Fatalf("DeliverOnce() error = %v", err)
+	}
+
+	// Top-level shape: exactly {envelope, payload}.
+	var topLevel map[string]json.RawMessage
+	if err := json.Unmarshal(capturedRaw, &topLevel); err != nil {
+		t.Fatalf("Unmarshal(topLevel) error = %v", err)
+	}
+	if len(topLevel) != 2 {
+		t.Fatalf("top-level keys = %d, want exactly 2 (envelope, payload). got=%v", len(topLevel), topLevel)
+	}
+	if _, ok := topLevel["envelope"]; !ok {
+		t.Fatal(`top-level missing "envelope" key`)
+	}
+	if _, ok := topLevel["payload"]; !ok {
+		t.Fatal(`top-level missing "payload" key`)
+	}
+
+	// Strict decode against the contract.
+	var wire wireShape
+	dec := json.NewDecoder(bytes.NewReader(capturedRaw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&wire); err != nil {
+		t.Fatalf("strict decode error = %v; wire format must be {envelope, payload} with no extra keys", err)
+	}
+	decodedPayload, err := base64.StdEncoding.DecodeString(wire.Payload)
+	if err != nil {
+		t.Fatalf("payload not standard base64: %v", err)
+	}
+	if string(decodedPayload) != string(batch.Payload) {
+		t.Fatalf("payload round-trip mismatch: got=%q want=%q", decodedPayload, batch.Payload)
+	}
+	// Envelope must include the signed BatchID — proves the producer envelope
+	// was forwarded, not a sanitized copy.
+	var envCheck struct {
+		BatchID string `json:"batch_id"`
+	}
+	if err := json.Unmarshal(wire.Envelope, &envCheck); err != nil {
+		t.Fatalf("envelope decode error = %v", err)
+	}
+	if envCheck.BatchID != "batch-wire-format" {
+		t.Fatalf("envelope.batch_id = %q, want batch-wire-format", envCheck.BatchID)
+	}
+}
+
+// TestTransportRun_GracefulShutdown spins Run on a server that returns 503
+// (forcing the retry path), cancels ctx, and asserts Run returns ctx.Err()
+// within a bounded window. Without this, a stuck transport could hang
+// pipelock shutdown indefinitely.
+func TestTransportRun_GracefulShutdown(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	q := openTestQueue(t, Config{})
+	if _, err := q.Enqueue(signedTestBatch(t, "batch-shutdown", priv)); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	tr, err := NewTransport(TransportConfig{
+		BaseURL:    srv.URL,
+		Client:     srv.Client(),
+		Queue:      q,
+		RetryDelay: 10 * time.Millisecond,
+		EmptyDelay: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var wg sync.WaitGroup
+	runErrCh := make(chan error, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runErrCh <- tr.Run(ctx)
+	}()
+
+	// Give the loop a turn so we exercise the retry-sleep path before cancel.
+	time.Sleep(25 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-runErrCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run() = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run() did not return within 1s after context cancellation")
+	}
+	wg.Wait()
+
+	// Record must still be present (retry kept it pending) or back in pending.
+	// Either way, no data loss on shutdown.
+	stats, err := q.Stats()
+	if err != nil {
+		t.Fatalf("Stats() error = %v", err)
+	}
+	if stats.Pending+stats.Inflight+stats.Dead != 1 {
+		t.Fatalf("total records = %d, want 1 (no loss on shutdown). stats=%+v", stats.Pending+stats.Inflight+stats.Dead, stats)
+	}
+	if stats.Dead != 0 {
+		t.Fatalf("dead=%d, want 0 (5xx is retry, not dead-letter)", stats.Dead)
+	}
+}
+
+func TestTransportRunRejectsNilContext(t *testing.T) {
+	q := openTestQueue(t, Config{})
+	tr, err := NewTransport(TransportConfig{BaseURL: "https://conductor.example", Client: http.DefaultClient, Queue: q})
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+	if err := tr.Run(nilTestContext()); err == nil || err.Error() != "auditbatcher: nil context" {
+		t.Fatalf("Run(nil) = %v, want nil context error", err)
+	}
+}
+
+func nilTestContext() context.Context {
+	return nil
+}
+
+type transportMetricsRecorder struct {
+	delivery  map[string]int
+	lastStats Stats
+}
+
+func (r *transportMetricsRecorder) RecordConductorAuditQueue(stats Stats) {
+	r.lastStats = stats
+}
+
+func (r *transportMetricsRecorder) RecordConductorAuditDelivery(outcome, reason string) {
+	if r.delivery == nil {
+		r.delivery = make(map[string]int)
+	}
+	r.delivery[outcome+":"+reason]++
+}

--- a/internal/config/conductor.go
+++ b/internal/config/conductor.go
@@ -60,6 +60,7 @@ func (c *Config) validateConductor(warnings *[]Warning) error {
 	}
 	for field, value := range map[string]string{
 		"conductor.trust_roster_path":       cfg.TrustRosterPath,
+		"conductor.server_ca_file":          cfg.ServerCAFile,
 		"conductor.client_cert_path":        cfg.ClientCertPath,
 		"conductor.client_key_path":         cfg.ClientKeyPath,
 		"conductor.bundle_cache_dir":        cfg.BundleCacheDir,
@@ -72,6 +73,16 @@ func (c *Config) validateConductor(warnings *[]Warning) error {
 	for field, value := range map[string]string{
 		"conductor.bundle_cache_dir":        cfg.BundleCacheDir,
 		"conductor.durable_audit_queue_dir": cfg.DurableAuditQueueDir,
+	} {
+		if err := validateConductorPrivateParent(field, value); err != nil {
+			return err
+		}
+	}
+	for field, value := range map[string]string{
+		"conductor.trust_roster_path": cfg.TrustRosterPath,
+		"conductor.server_ca_file":    cfg.ServerCAFile,
+		"conductor.client_cert_path":  cfg.ClientCertPath,
+		"conductor.client_key_path":   cfg.ClientKeyPath,
 	} {
 		if err := validateConductorPrivateParent(field, value); err != nil {
 			return err

--- a/internal/config/conductor_test.go
+++ b/internal/config/conductor_test.go
@@ -97,6 +97,16 @@ func TestValidateConductor_RejectsInvalidEnabledConfig(t *testing.T) {
 			want:   "conductor.client_cert_path must be an absolute path",
 		},
 		{
+			name:   "missing_server_ca",
+			mutate: func(c *Conductor) { c.ServerCAFile = "" },
+			want:   "conductor.server_ca_file required",
+		},
+		{
+			name:   "relative_server_ca",
+			mutate: func(c *Conductor) { c.ServerCAFile = "boss-ca.pem" },
+			want:   "conductor.server_ca_file must be an absolute path",
+		},
+		{
 			name:   "bad_poll_interval",
 			mutate: func(c *Conductor) { c.PollInterval = "0s" },
 			want:   "conductor.poll_interval must be > 0",
@@ -137,8 +147,6 @@ func TestValidateConductor_RejectsInvalidEnabledConfig(t *testing.T) {
 }
 
 func TestValidateConductor_RejectsWorldWritableParents(t *testing.T) {
-	cfg := Defaults()
-	conductor := validConductorConfig(t)
 	parent := filepath.Join(privateTempDir(t), "world")
 	if err := os.Mkdir(parent, 0o700); err != nil {
 		t.Fatalf("Mkdir() error = %v", err)
@@ -146,12 +154,47 @@ func TestValidateConductor_RejectsWorldWritableParents(t *testing.T) {
 	if err := os.Chmod(parent, 0o777); err != nil { //nolint:gosec // verifies rejection of unsafe parent permissions.
 		t.Fatalf("Chmod() error = %v", err)
 	}
-	conductor.BundleCacheDir = filepath.Join(parent, "bundles")
-	cfg.Conductor = conductor
+	tests := []struct {
+		name   string
+		mutate func(*Conductor)
+	}{
+		{
+			name:   "bundle_cache_dir",
+			mutate: func(c *Conductor) { c.BundleCacheDir = filepath.Join(parent, "bundles") },
+		},
+		{
+			name:   "durable_audit_queue_dir",
+			mutate: func(c *Conductor) { c.DurableAuditQueueDir = filepath.Join(parent, "audit-queue") },
+		},
+		{
+			name:   "trust_roster_path",
+			mutate: func(c *Conductor) { c.TrustRosterPath = filepath.Join(parent, "trust-roster.json") },
+		},
+		{
+			name:   "server_ca_file",
+			mutate: func(c *Conductor) { c.ServerCAFile = filepath.Join(parent, "boss-ca.pem") },
+		},
+		{
+			name:   "client_cert_path",
+			mutate: func(c *Conductor) { c.ClientCertPath = filepath.Join(parent, "client.crt") },
+		},
+		{
+			name:   "client_key_path",
+			mutate: func(c *Conductor) { c.ClientKeyPath = filepath.Join(parent, "client.key") },
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Defaults()
+			conductor := validConductorConfig(t)
+			tc.mutate(&conductor)
+			cfg.Conductor = conductor
 
-	err := cfg.Validate()
-	if err == nil || !strings.Contains(err.Error(), "world-writable parent") {
-		t.Fatalf("Validate() = %v, want world-writable parent error", err)
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), "world-writable parent") {
+				t.Fatalf("Validate() = %v, want world-writable parent error", err)
+			}
+		})
 	}
 }
 
@@ -269,6 +312,7 @@ func validConductorConfig(t *testing.T) Conductor {
 		FleetID:                "prod",
 		InstanceID:             "pl-prod-1",
 		TrustRosterPath:        filepath.Join(root, "trust-roster.json"),
+		ServerCAFile:           filepath.Join(root, "boss-ca.pem"),
 		ClientCertPath:         filepath.Join(root, "client.crt"),
 		ClientKeyPath:          filepath.Join(root, "client.key"),
 		BundleCacheDir:         filepath.Join(root, "bundles"),

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -319,6 +319,7 @@ type Conductor struct {
 	FleetID                string               `yaml:"fleet_id"`
 	InstanceID             string               `yaml:"instance_id"`
 	TrustRosterPath        string               `yaml:"trust_roster_path"`
+	ServerCAFile           string               `yaml:"server_ca_file"`
 	ClientCertPath         string               `yaml:"client_cert_path"`
 	ClientKeyPath          string               `yaml:"client_key_path"`
 	BundleCacheDir         string               `yaml:"bundle_cache_dir"`

--- a/internal/metrics/conductor.go
+++ b/internal/metrics/conductor.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"github.com/luckyPipewrench/pipelock/internal/conductor/auditbatcher"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func (m *Metrics) registerConductorMetrics(reg *prometheus.Registry) {
+	m.conductorAuditQueuePending = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "pipelock",
+		Name:      "conductor_audit_queue_pending",
+		Help:      "Current pending Conductor audit batches in the durable queue.",
+	})
+	m.conductorAuditQueueInflight = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "pipelock",
+		Name:      "conductor_audit_queue_inflight",
+		Help:      "Current claimed Conductor audit batches awaiting ack, retry, or drop.",
+	})
+	m.conductorAuditQueueDead = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "pipelock",
+		Name:      "conductor_audit_queue_dead",
+		Help:      "Current dead-lettered Conductor audit batches.",
+	})
+	m.conductorAuditDeliveries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "pipelock",
+		Name:      "conductor_audit_deliveries_total",
+		Help:      "Total Conductor audit batch delivery outcomes.",
+	}, []string{"outcome", "reason"})
+	reg.MustRegister(
+		m.conductorAuditQueuePending,
+		m.conductorAuditQueueInflight,
+		m.conductorAuditQueueDead,
+		m.conductorAuditDeliveries,
+	)
+}
+
+func (m *Metrics) RecordConductorAuditQueue(stats auditbatcher.Stats) {
+	if m == nil {
+		return
+	}
+	m.conductorAuditQueuePending.Set(float64(stats.Pending))
+	m.conductorAuditQueueInflight.Set(float64(stats.Inflight))
+	m.conductorAuditQueueDead.Set(float64(stats.Dead))
+}
+
+func (m *Metrics) RecordConductorAuditDelivery(outcome, reason string) {
+	if m == nil {
+		return
+	}
+	m.conductorAuditDeliveries.WithLabelValues(outcome, reason).Inc()
+}

--- a/internal/metrics/conductor_test.go
+++ b/internal/metrics/conductor_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor/auditbatcher"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestConductorAuditMetrics(t *testing.T) {
+	m := New()
+	m.RecordConductorAuditQueue(auditbatcher.Stats{Pending: 2, Inflight: 1, Dead: 3})
+	m.RecordConductorAuditDelivery("retry", "http_server_error")
+	m.RecordConductorAuditDelivery("retry", "http_server_error")
+	m.RecordConductorAuditDelivery("drop", "http_client_error")
+
+	if got := testutil.ToFloat64(m.conductorAuditQueuePending); got != 2 {
+		t.Fatalf("pending gauge = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(m.conductorAuditQueueInflight); got != 1 {
+		t.Fatalf("inflight gauge = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.conductorAuditQueueDead); got != 3 {
+		t.Fatalf("dead gauge = %v, want 3", got)
+	}
+	if got := testutil.ToFloat64(m.conductorAuditDeliveries.WithLabelValues("retry", "http_server_error")); got != 2 {
+		t.Fatalf("retry counter = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(m.conductorAuditDeliveries.WithLabelValues("drop", "http_client_error")); got != 1 {
+		t.Fatalf("drop counter = %v, want 1", got)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -107,6 +107,12 @@ type Metrics struct {
 	captureSessionIDSanitized   *prometheus.CounterVec
 	captureActionClassSanitized *prometheus.CounterVec
 
+	// Conductor audit transport (conductor.go).
+	conductorAuditQueuePending  prometheus.Gauge
+	conductorAuditQueueInflight prometheus.Gauge
+	conductorAuditQueueDead     prometheus.Gauge
+	conductorAuditDeliveries    *prometheus.CounterVec
+
 	// Learn-and-lock observation pipeline (learn.go).
 	learnObservationEvents        *prometheus.CounterVec
 	learnRegulatedDataBlocked     *prometheus.CounterVec
@@ -178,6 +184,7 @@ func New() *Metrics {
 	m.registerKillSwitchMetrics(reg)
 	m.registerShieldMetrics(reg)
 	m.registerCaptureMetrics(reg)
+	m.registerConductorMetrics(reg)
 	m.registerLearnMetrics(reg)
 	m.registerEnvelopeMetrics(reg)
 


### PR DESCRIPTION
## Summary
- wire the follower runtime to open the durable Conductor audit queue and drain it through a dedicated mTLS client
- pin Boss server trust with `conductor.server_ca_file` and preserve Conductor runtime settings across reload
- add durable retry/drop accounting on queue records plus Prometheus queue depth and delivery outcome metrics
- keep audit batch production as a separate follow-up integration point

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Conductor audit transport for durable delivery of audit batches with retry and dead-letter tracking.
  * Added Prometheus metrics for monitoring audit queue state and delivery outcomes.

* **Documentation**
  * Updated Conductor configuration specification to require server CA bundle path.

* **Configuration**
  * Added `server_ca_file` configuration option for Conductor.
  * Conductor settings now require server restart to apply changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->