### PR TITLE
feat(filesentry): block action mode for agent-attributed DLP findings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1693,8 +1693,11 @@ file_sentry:
 | `watch_paths` | `[]` | Directories to monitor recursively. Relative paths are resolved against the config file directory (not CWD). Required when enabled. |
 | `scan_content` | `true` | Run DLP scanner on modified file content. |
 | `ignore_patterns` | `[]` | Glob patterns for files and directories to skip. |
+| `action` | `warn` | Enforcement response when an agent-attributed write matches a DLP pattern. `warn` logs the finding + records a metric (current default). `block` additionally cancels the proxy context so the MCP child terminates, preventing the agent from continuing after a detected leak. Non-agent writes (editor saves, build output) never trigger the block path. |
 
-File sentry is alert-only in the current release. Findings are reported as stderr warnings and Prometheus metrics (`pipelock_file_sentry_findings_total`). Structured audit log emission (`file_sentry_dlp` event type) is defined but not yet wired to the webhook/syslog pipeline. On Linux, process lineage tracking attributes file writes to the agent's process tree via `PR_SET_CHILD_SUBREAPER` and `/proc` walking.
+Findings are reported as stderr warnings and Prometheus metrics (`pipelock_file_sentry_findings_total`). Structured audit log emission (`file_sentry_dlp` event type) is defined but not yet wired to the webhook/syslog pipeline. On Linux, process lineage tracking attributes file writes to the agent's process tree via `PR_SET_CHILD_SUBREAPER` and `/proc` walking.
+
+`action: block` is the fail-closed enforcement boundary. The cancel fires from the consumer goroutine after the log line and metric emission, which means there is unavoidable latency between the kernel write and the proxy teardown: the file has already been written to disk by the time the scan completes. Block prevents the agent from continuing to act on the leak, it does not prevent the write itself. For write-time interception the operator must layer Landlock or a sandbox at the deployment level.
 
 Files larger than 10MB are skipped. Write events are debounced (50ms quiet window) to avoid scanning partial writes.
 

--- a/docs/guides/filesystem-sentinel.md
+++ b/docs/guides/filesystem-sentinel.md
@@ -13,13 +13,14 @@ This catches a class of exfiltration that the network proxy cannot see: an agent
 
 File sentry applies to **subprocess MCP mode only**. HTTP upstream, WebSocket, and listener modes have no local child process and are out of scope.
 
-This is **detection, not prevention**. File sentry alerts when secrets are written to disk. It does not block the write itself. Use the process sandbox (`--sandbox`) for filesystem restriction enforcement.
+File sentry detects writes; it does not intercept them. The write reaches disk before the scan completes. With `action: warn` (default), findings are alerted and the agent keeps running. With `action: block`, the proxy context is cancelled on the first agent-attributed finding, terminating the MCP child so the agent cannot continue acting on the leak. For write-time interception, layer Landlock or the process sandbox (`--sandbox`) on top.
 
 ## Configuration
 
 ```yaml
 file_sentry:
   enabled: true
+  action: warn               # warn (default) or block
   watch_paths:
     - "/workspace"           # agent working directory
     - "/tmp/agent-output"    # temp output directory
@@ -31,6 +32,11 @@ file_sentry:
     - "*.so"
     - "*.pyc"
 ```
+
+### Action
+
+- `warn` (default): every finding is logged to stderr and recorded as a Prometheus metric. The MCP child keeps running.
+- `block`: same logging + metrics, AND on the first finding attributed to a process in the agent tree (`IsAgent=true`), the proxy context is cancelled, which terminates the MCP child. Non-agent writes (editor saves, build output, other system processes touching the watched directory) never trigger the block path. The cancel fires exactly once per session.
 
 ### Watch Paths
 

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -1086,32 +1086,30 @@ signed action receipts for MCP decisions.`,
 				}
 
 				if watcher != nil {
-					// Consume findings: log to stderr and record metrics.
-					// The consumer runs until Close() closes the findings channel.
-					consumerDone := make(chan struct{})
-					go func() {
-						defer close(consumerDone)
-						for f := range watcher.Findings() {
-							agent := ""
-							if f.IsAgent {
-								agent = " (agent process)"
-							}
-							_, _ = fmt.Fprintf(logW,
-								"pipelock: [file_sentry] DLP match in %s: %s (severity=%s)%s\n",
-								f.Path, f.PatternName, f.Severity, agent)
-							if mcpMetrics != nil {
-								mcpMetrics.RecordFileSentryFinding(f.PatternName, f.Severity, f.IsAgent)
-							}
-						}
-					}()
+					// Consume findings: log to stderr, record metrics, and
+					// (in block action mode) cancel the proxy ctx on the
+					// first agent-attributed finding so the MCP child fails
+					// closed after a detected leak. See filesentry.ConsumeFindings
+					// for the full enforcement matrix.
+					var findingHook filesentry.FindingHook
+					if mcpMetrics != nil {
+						findingHook = mcpMetrics.RecordFileSentryFinding
+					}
+					waitConsumer := filesentry.ConsumeFindings(filesentry.ConsumerOpts{
+						Watcher:   watcher,
+						Action:    cfg.FileSentry.Action,
+						Log:       logW,
+						OnFinding: findingHook,
+						Cancel:    cancel,
+					})
 					// Single defer: close watcher (flushes + closes channel),
 					// then wait for consumer to finish processing.
 					defer func() {
 						_ = watcher.Close()
-						<-consumerDone
+						waitConsumer()
 					}()
-					_, _ = fmt.Fprintf(logW, "pipelock: file sentry watching %d path(s)\n",
-						len(cfg.FileSentry.WatchPaths))
+					_, _ = fmt.Fprintf(logW, "pipelock: file sentry watching %d path(s) (action=%s)\n",
+						len(cfg.FileSentry.WatchPaths), cfg.FileSentry.Action)
 
 					// onChildReady: called by RunProxy after cmd.Start() + TrackPID.
 					// Starts the file sentry event loop AFTER the child PID is registered,

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -63,22 +63,17 @@ func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel
 		return nil, fmt.Errorf("file sentry failed to arm watches (feature is enabled): %w", err)
 	}
 
-	consumerDone := make(chan struct{})
-	go func() {
-		defer close(consumerDone)
-		for f := range watcher.Findings() {
-			agent := ""
-			if f.IsAgent {
-				agent = " (agent process)"
-			}
-			_, _ = fmt.Fprintf(s.opts.Stderr,
-				"pipelock: [file_sentry] DLP match in %s: %s (severity=%s)%s\n",
-				f.Path, f.PatternName, f.Severity, agent)
-			if s.metrics != nil {
-				s.metrics.RecordFileSentryFinding(f.PatternName, f.Severity, f.IsAgent)
-			}
-		}
-	}()
+	var findingHook filesentry.FindingHook
+	if s.metrics != nil {
+		findingHook = s.metrics.RecordFileSentryFinding
+	}
+	waitConsumer := filesentry.ConsumeFindings(filesentry.ConsumerOpts{
+		Watcher:   watcher,
+		Action:    cfg.FileSentry.Action,
+		Log:       s.opts.Stderr,
+		OnFinding: findingHook,
+		Cancel:    cancel,
+	})
 
 	go func() {
 		if err := watcher.Start(ctx); err != nil {
@@ -87,12 +82,12 @@ func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel
 		}
 	}()
 
-	_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: file sentry watching %d path(s)\n",
-		len(cfg.FileSentry.WatchPaths))
+	_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: file sentry watching %d path(s) (action=%s)\n",
+		len(cfg.FileSentry.WatchPaths), cfg.FileSentry.Action)
 
 	return func() {
 		_ = watcher.Close()
-		<-consumerDone
+		waitConsumer()
 	}, nil
 }
 

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -114,7 +114,12 @@ const (
 	// (it changes the destination IPs the SSRF check evaluates) and so it
 	// participates in the canonical view; the field is present but empty
 	// in Defaults().
-	goldenHashDefaults = "029a5449518889527136cdcb796b8746338d38a12ed0723b13ab24d7139c54a5"
+	// Re-bumped for file_sentry.action: adding the warn/block enforcement
+	// enum to FileSentry is a policy-semantics change. The default "warn"
+	// preserves current behavior; "block" causes the consumer to cancel
+	// the proxy ctx on agent-attributed findings, which is observably
+	// different enforcement.
+	goldenHashDefaults = "de4d3761e1b0ca49ea4521c0ace44350282ae9c382e8e15dc36b450971c6777c"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -175,7 +180,8 @@ const (
 	// Re-bumped for the dns.host_overrides addition: see goldenHashDefaults
 	// note. The rich fixture omits dns:, so the field is empty but still
 	// part of the canonical view.
-	goldenHashRichConfig = "86666b12e6ce89ee16b749e4926444b8b10505bfcfb85ea8516d1d77d3118d68"
+	// Re-bumped for file_sentry.action: same rationale as goldenHashDefaults.
+	goldenHashRichConfig = "c17e20708f463010ee973574fcc7d763133aeb5845b13cba8fa389ce6fb85476"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -762,6 +762,96 @@ func TestValidate_FileSentryEmptyStringInWatchPaths(t *testing.T) {
 	}
 }
 
+func TestValidate_FileSentryActionInvalid(t *testing.T) {
+	cfg := Defaults()
+	cfg.FileSentry.Enabled = true
+	cfg.FileSentry.WatchPaths = []string{"."}
+	cfg.FileSentry.Action = "panic"
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for invalid file_sentry.action")
+	}
+}
+
+func TestValidate_FileSentryActionWarnOrBlockOrEmpty(t *testing.T) {
+	for _, action := range []string{"", ActionWarn, ActionBlock} {
+		cfg := Defaults()
+		cfg.FileSentry.Enabled = true
+		cfg.FileSentry.WatchPaths = []string{"."}
+		cfg.FileSentry.Action = action
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("action %q should be valid: %v", action, err)
+		}
+	}
+}
+
+func TestApplyDefaults_FileSentryActionDefaultsToWarn(t *testing.T) {
+	cfg := Defaults()
+	cfg.FileSentry.Action = "" // user omitted
+	cfg.ApplyDefaults()
+	if cfg.FileSentry.Action != ActionWarn {
+		t.Errorf("FileSentry.Action default should be warn, got %q", cfg.FileSentry.Action)
+	}
+}
+
+func TestApplyDefaults_FileSentryActionPreservesBlock(t *testing.T) {
+	cfg := Defaults()
+	cfg.FileSentry.Action = ActionBlock
+	cfg.ApplyDefaults()
+	if cfg.FileSentry.Action != ActionBlock {
+		t.Errorf("FileSentry.Action=block should be preserved by ApplyDefaults, got %q", cfg.FileSentry.Action)
+	}
+}
+
+func TestLoad_FileSentryActionDefaultNullAndBlock(t *testing.T) {
+	tests := []struct {
+		name       string
+		actionLine string
+		want       string
+	}{
+		{
+			name: "omitted",
+			want: ActionWarn,
+		},
+		{
+			name:       "null",
+			actionLine: "  action: null\n",
+			want:       ActionWarn,
+		},
+		{
+			name:       "block",
+			actionLine: "  action: block\n",
+			want:       ActionBlock,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(dir, "src"), 0o750); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			cfgContent := `
+version: 1
+file_sentry:
+  enabled: true
+` + tt.actionLine + `  watch_paths:
+    - "src"
+`
+			cfgPath := filepath.Join(dir, "pipelock.yaml")
+			if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			cfg, err := Load(cfgPath)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.FileSentry.Action != tt.want {
+				t.Errorf("FileSentry.Action = %q, want %q", cfg.FileSentry.Action, tt.want)
+			}
+		})
+	}
+}
+
 func TestApplyDefaults_FileSentryScanContent(t *testing.T) {
 	cfg := Defaults()
 	cfg.ApplyDefaults()
@@ -9839,10 +9929,12 @@ func TestValidateReload_FileSentryChanged(t *testing.T) {
 func TestValidateReload_FileSentryBestEffortChanged(t *testing.T) {
 	old := Defaults()
 	old.FileSentry.Enabled = true
+	old.FileSentry.Action = ActionWarn
 	old.FileSentry.WatchPaths = []string{"/tmp"}
 	updated := Defaults()
 	updated.FileSentry.Enabled = true
 	updated.FileSentry.BestEffort = true
+	updated.FileSentry.Action = ActionWarn
 	updated.FileSentry.WatchPaths = []string{"/tmp"}
 	warnings := ValidateReload(old, updated)
 	found := false
@@ -9857,12 +9949,36 @@ func TestValidateReload_FileSentryBestEffortChanged(t *testing.T) {
 	}
 }
 
-func TestValidateReload_FileSentryWatchPathsChanged(t *testing.T) {
+func TestValidateReload_FileSentryActionChanged(t *testing.T) {
 	old := Defaults()
 	old.FileSentry.Enabled = true
+	old.FileSentry.Action = ActionWarn
 	old.FileSentry.WatchPaths = []string{"/tmp"}
 	updated := Defaults()
 	updated.FileSentry.Enabled = true
+	updated.FileSentry.Action = ActionBlock
+	updated.FileSentry.WatchPaths = []string{"/tmp"}
+	warnings := ValidateReload(old, updated)
+	found := false
+	for _, w := range warnings {
+		if w.Field == fieldFileSentry {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected file_sentry reload warning when action changes")
+	}
+}
+
+func TestValidateReload_FileSentryWatchPathsChanged(t *testing.T) {
+	old := Defaults()
+	old.FileSentry.Enabled = true
+	old.FileSentry.Action = ActionWarn
+	old.FileSentry.WatchPaths = []string{"/tmp"}
+	updated := Defaults()
+	updated.FileSentry.Enabled = true
+	updated.FileSentry.Action = ActionWarn
 	updated.FileSentry.WatchPaths = []string{"/tmp", "/var"}
 	warnings := ValidateReload(old, updated)
 	found := false
@@ -9880,9 +9996,11 @@ func TestValidateReload_FileSentryWatchPathsChanged(t *testing.T) {
 func TestValidateReload_FileSentryUnchanged_NoWarning(t *testing.T) {
 	old := Defaults()
 	old.FileSentry.Enabled = true
+	old.FileSentry.Action = ActionWarn
 	old.FileSentry.WatchPaths = []string{"/tmp"}
 	updated := Defaults()
 	updated.FileSentry.Enabled = true
+	updated.FileSentry.Action = ActionWarn
 	updated.FileSentry.WatchPaths = []string{"/tmp"}
 	warnings := ValidateReload(old, updated)
 	for _, w := range warnings {

--- a/internal/config/filesentry_changed_test.go
+++ b/internal/config/filesentry_changed_test.go
@@ -14,6 +14,7 @@ func TestFileSentryChanged(t *testing.T) {
 		c := Defaults()
 		c.FileSentry.Enabled = true
 		c.FileSentry.BestEffort = false
+		c.FileSentry.Action = ActionWarn
 		c.FileSentry.WatchPaths = []string{"/tmp/watch"}
 		c.FileSentry.ScanContent = boolPtrCfg(true)
 		c.FileSentry.IgnorePatterns = []string{"*.log"}
@@ -38,6 +39,11 @@ func TestFileSentryChanged(t *testing.T) {
 		{
 			name:    "best_effort changed",
 			modify:  func(c *Config) { c.FileSentry.BestEffort = true },
+			changed: true,
+		},
+		{
+			name:    "action changed",
+			modify:  func(c *Config) { c.FileSentry.Action = ActionBlock },
 			changed: true,
 		},
 		{

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -598,6 +598,9 @@ func (c *Config) ApplyDefaults() {
 	if c.FileSentry.ScanContent == nil {
 		c.FileSentry.ScanContent = ptrBool(true)
 	}
+	if c.FileSentry.Action == "" {
+		c.FileSentry.Action = ActionWarn
+	}
 
 	// A2A scanning defaults
 	if c.A2AScanning.Enabled {

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -679,6 +679,9 @@ func fileSentryChanged(old, updated *Config) bool {
 	if old.FileSentry.BestEffort != updated.FileSentry.BestEffort {
 		return true
 	}
+	if old.FileSentry.Action != updated.FileSentry.Action {
+		return true
+	}
 	if !slices.Equal(old.FileSentry.WatchPaths, updated.FileSentry.WatchPaths) {
 		return true
 	}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -168,6 +168,13 @@ type FileSentry struct {
 	WatchPaths     []string `yaml:"watch_paths"`
 	ScanContent    *bool    `yaml:"scan_content"`    // nil = default true
 	IgnorePatterns []string `yaml:"ignore_patterns"` // glob patterns to skip
+	// Action selects the enforcement response when an agent-attributed write
+	// matches a DLP pattern. "warn" logs the finding and records a metric
+	// (current default). "block" additionally cancels the proxy context so the
+	// MCP child terminates, preventing the agent from continuing after a
+	// detected leak. Non-agent writes (editor saves, build output) never
+	// trigger the block path. Empty normalizes to "warn".
+	Action string `yaml:"action"`
 }
 
 // Sandbox configures process containment for child processes.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1513,6 +1513,11 @@ func (c *Config) validateFileSentry() error {
 			return fmt.Errorf("file_sentry: watch_paths[%d] must not be empty", i)
 		}
 	}
+	switch c.FileSentry.Action {
+	case "", ActionWarn, ActionBlock:
+	default:
+		return fmt.Errorf("invalid file_sentry.action %q: must be warn or block", c.FileSentry.Action)
+	}
 	return nil
 }
 

--- a/internal/filesentry/consumer.go
+++ b/internal/filesentry/consumer.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package filesentry
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// FindingHook is the callback signature for metric / audit emission.
+// Called for every finding regardless of action mode. Implementations
+// must be safe for concurrent use; the consumer invokes the hook from
+// a single goroutine but downstream callers may run in parallel.
+type FindingHook func(patternName, severity string, isAgent bool)
+
+// ConsumerOpts configures ConsumeFindings.
+//
+// The enforcement decision is intentionally split from the watcher: the
+// Watcher is a pure observer that emits Finding values on a channel; the
+// consumer reads that channel, logs each finding, records the metric, and
+// then decides whether to escalate by calling Cancel.
+//
+// Cancel is only invoked when Action == config.ActionBlock AND the finding
+// is attributed to a process in the agent tree (Finding.IsAgent). Non-agent
+// writes (editor saves, build output, other system processes touching the
+// watched directory) never trigger the block path. This matches the rule
+// that file_sentry is a fail-closed boundary on the agent subprocess, not
+// a general filesystem guard.
+type ConsumerOpts struct {
+	// Watcher is the watcher whose Findings() channel will be drained.
+	// Required.
+	Watcher Watcher
+	// Action is the enforcement mode. Empty defaults to warn. Validated by
+	// the config layer so values other than warn / block never reach here.
+	Action string
+	// Log is the human-readable sink (typically the proxy stderr). May be
+	// nil — log lines are then dropped.
+	Log io.Writer
+	// OnFinding is invoked once per finding for metric / audit emission.
+	// May be nil.
+	OnFinding FindingHook
+	// Cancel is the proxy context cancel function. Called once on the first
+	// block-action + IsAgent finding. May be nil — Cancel == nil means
+	// "block degrades to warn" (used by tests + diag paths that do not own
+	// the proxy lifecycle).
+	Cancel func()
+	// OnBlock is an optional callback invoked just before Cancel is called.
+	// Used by tests to observe the enforcement decision; production callers
+	// typically pass nil. Always invoked synchronously from the consumer
+	// goroutine before Cancel.
+	OnBlock func(Finding)
+}
+
+// ConsumeFindings drains opts.Watcher.Findings() in a background goroutine,
+// logging each finding and emitting metrics. Returns a function that blocks
+// until the consumer goroutine has finished draining (typically called from
+// a defer after Watcher.Close()).
+//
+// Behavior matrix:
+//
+//	Action="warn" or "" → log + metric for every finding; Cancel never fires
+//	Action="block"      → log + metric for every finding; on the first finding
+//	                       with IsAgent=true, Cancel is invoked exactly once
+//	                       AFTER the log/metric for that finding. Subsequent
+//	                       findings keep emitting logs/metrics but Cancel is
+//	                       not called again (it's already fired; ctx is gone).
+//
+// Logging is fire-and-forget; write errors on the Log writer are ignored.
+func ConsumeFindings(opts ConsumerOpts) func() {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		blockMode := opts.Action == config.ActionBlock
+		cancelled := false
+		for f := range opts.Watcher.Findings() {
+			writeFindingLog(opts.Log, f)
+			if opts.OnFinding != nil {
+				opts.OnFinding(f.PatternName, f.Severity, f.IsAgent)
+			}
+			if blockMode && f.IsAgent && !cancelled {
+				cancelled = true
+				if opts.OnBlock != nil {
+					opts.OnBlock(f)
+				}
+				if opts.Cancel != nil {
+					opts.Cancel()
+				}
+			}
+		}
+	}()
+	return func() { <-done }
+}
+
+// writeFindingLog writes the human-readable log line for one finding. Split
+// out so the format is exercised by a small dedicated test and matches the
+// previous in-line format byte-for-byte.
+func writeFindingLog(w io.Writer, f Finding) {
+	if w == nil {
+		return
+	}
+	agent := ""
+	if f.IsAgent {
+		agent = " (agent process)"
+	}
+	_, _ = fmt.Fprintf(w,
+		"pipelock: [file_sentry] DLP match in %s: %s (severity=%s)%s\n",
+		f.Path, f.PatternName, f.Severity, agent)
+}

--- a/internal/filesentry/consumer.go
+++ b/internal/filesentry/consumer.go
@@ -80,14 +80,12 @@ func ConsumeFindings(opts ConsumerOpts) func() {
 			if opts.OnFinding != nil {
 				opts.OnFinding(f.PatternName, f.Severity, f.IsAgent)
 			}
-			if blockMode && f.IsAgent && !cancelled {
+			if blockMode && f.IsAgent && opts.Cancel != nil && !cancelled {
 				cancelled = true
 				if opts.OnBlock != nil {
 					opts.OnBlock(f)
 				}
-				if opts.Cancel != nil {
-					opts.Cancel()
-				}
+				opts.Cancel()
 			}
 		}
 	}()

--- a/internal/filesentry/consumer_test.go
+++ b/internal/filesentry/consumer_test.go
@@ -134,6 +134,7 @@ func TestConsumeFindings_BlockMode_NonAgentOnly_NoCancel(t *testing.T) {
 
 func TestConsumeFindings_BlockMode_NilCancel_DegradesToWarn(t *testing.T) {
 	var buf bytes.Buffer
+	var blockFired atomic.Bool
 	w := makeWatcher(t,
 		Finding{Path: "/tmp/x", PatternName: "AWS", Severity: "critical", IsAgent: true},
 	)
@@ -142,11 +143,17 @@ func TestConsumeFindings_BlockMode_NilCancel_DegradesToWarn(t *testing.T) {
 		Action:  config.ActionBlock,
 		Log:     &buf,
 		Cancel:  nil,
+		// OnBlock observes the enforcement decision. With Cancel == nil
+		// there is no enforcement to observe, so OnBlock must not fire.
+		OnBlock: func(_ Finding) { blockFired.Store(true) },
 	})
 	wait()
 
 	if !strings.Contains(buf.String(), "DLP match in /tmp/x") {
 		t.Errorf("log line missing: %q", buf.String())
+	}
+	if blockFired.Load() {
+		t.Error("OnBlock must not fire when Cancel is nil (no enforcement actually happens)")
 	}
 }
 

--- a/internal/filesentry/consumer_test.go
+++ b/internal/filesentry/consumer_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package filesentry
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// stubWatcher is a Watcher that drives Findings() from a pre-seeded
+// channel. Arm / Start / Close are no-ops sufficient for testing the
+// consumer's enforcement decisions in isolation from fsnotify.
+type stubWatcher struct{ ch chan Finding }
+
+func (s *stubWatcher) Arm() error                    { return nil }
+func (s *stubWatcher) Start(_ context.Context) error { return nil }
+func (s *stubWatcher) Findings() <-chan Finding      { return s.ch }
+func (s *stubWatcher) Close() error                  { return nil }
+
+// makeWatcher seeds a buffered channel with the given findings and closes
+// it. The returned Watcher emits each finding once and then terminates,
+// so ConsumeFindings exits cleanly after draining.
+func makeWatcher(t *testing.T, findings ...Finding) Watcher {
+	t.Helper()
+	ch := make(chan Finding, len(findings))
+	for _, f := range findings {
+		ch <- f
+	}
+	close(ch)
+	return &stubWatcher{ch: ch}
+}
+
+func TestConsumeFindings_WarnMode_NoCancel(t *testing.T) {
+	var buf bytes.Buffer
+	var cancelCount atomic.Int32
+	var hookCalls atomic.Int32
+
+	w := makeWatcher(t,
+		Finding{Path: "/tmp/x", PatternName: "AWS", Severity: "critical", IsAgent: true},
+		Finding{Path: "/tmp/y", PatternName: "OpenAI", Severity: "high", IsAgent: false},
+	)
+
+	wait := ConsumeFindings(ConsumerOpts{
+		Watcher:   w,
+		Action:    config.ActionWarn,
+		Log:       &buf,
+		OnFinding: func(_, _ string, _ bool) { hookCalls.Add(1) },
+		Cancel:    func() { cancelCount.Add(1) },
+	})
+	wait()
+
+	if cancelCount.Load() != 0 {
+		t.Errorf("cancel must not fire in warn mode, got %d calls", cancelCount.Load())
+	}
+	if hookCalls.Load() != 2 {
+		t.Errorf("OnFinding should be called once per finding, got %d", hookCalls.Load())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "DLP match in /tmp/x: AWS") {
+		t.Errorf("missing log for first finding: %q", out)
+	}
+	if !strings.Contains(out, "DLP match in /tmp/y: OpenAI") {
+		t.Errorf("missing log for second finding: %q", out)
+	}
+	if !strings.Contains(out, "(agent process)") {
+		t.Errorf("agent suffix missing on agent finding: %q", out)
+	}
+}
+
+func TestConsumeFindings_BlockMode_AgentFinding_CancelsOnce(t *testing.T) {
+	var buf bytes.Buffer
+	var cancelCount atomic.Int32
+	var blockSeen Finding
+	var blockSeenMu sync.Mutex
+
+	w := makeWatcher(t,
+		Finding{Path: "/tmp/x", PatternName: "AWS", Severity: "critical", IsAgent: true},
+		Finding{Path: "/tmp/y", PatternName: "Stripe", Severity: "critical", IsAgent: true},
+		Finding{Path: "/tmp/z", PatternName: "Slack", Severity: "high", IsAgent: false},
+	)
+
+	wait := ConsumeFindings(ConsumerOpts{
+		Watcher: w,
+		Action:  config.ActionBlock,
+		Log:     &buf,
+		Cancel:  func() { cancelCount.Add(1) },
+		OnBlock: func(f Finding) {
+			blockSeenMu.Lock()
+			defer blockSeenMu.Unlock()
+			blockSeen = f
+		},
+	})
+	wait()
+
+	if cancelCount.Load() != 1 {
+		t.Errorf("cancel must fire exactly once in block mode (first agent finding); got %d", cancelCount.Load())
+	}
+	blockSeenMu.Lock()
+	got := blockSeen
+	blockSeenMu.Unlock()
+	if got.Path != "/tmp/x" {
+		t.Errorf("OnBlock should see the FIRST agent finding (/tmp/x), got %q", got.Path)
+	}
+}
+
+func TestConsumeFindings_BlockMode_NonAgentOnly_NoCancel(t *testing.T) {
+	var buf bytes.Buffer
+	var cancelCount atomic.Int32
+
+	w := makeWatcher(t,
+		Finding{Path: "/tmp/editor", PatternName: "AWS", Severity: "critical", IsAgent: false},
+		Finding{Path: "/tmp/build", PatternName: "Stripe", Severity: "high", IsAgent: false},
+	)
+
+	wait := ConsumeFindings(ConsumerOpts{
+		Watcher: w,
+		Action:  config.ActionBlock,
+		Log:     &buf,
+		Cancel:  func() { cancelCount.Add(1) },
+	})
+	wait()
+
+	if cancelCount.Load() != 0 {
+		t.Errorf("cancel must not fire on non-agent findings (editor saves / build output); got %d", cancelCount.Load())
+	}
+}
+
+func TestConsumeFindings_BlockMode_NilCancel_DegradesToWarn(t *testing.T) {
+	var buf bytes.Buffer
+	w := makeWatcher(t,
+		Finding{Path: "/tmp/x", PatternName: "AWS", Severity: "critical", IsAgent: true},
+	)
+	wait := ConsumeFindings(ConsumerOpts{
+		Watcher: w,
+		Action:  config.ActionBlock,
+		Log:     &buf,
+		Cancel:  nil,
+	})
+	wait()
+
+	if !strings.Contains(buf.String(), "DLP match in /tmp/x") {
+		t.Errorf("log line missing: %q", buf.String())
+	}
+}
+
+func TestConsumeFindings_EmptyAction_DefaultsToWarn(t *testing.T) {
+	var cancelCount atomic.Int32
+	w := makeWatcher(t, Finding{Path: "/tmp/x", PatternName: "AWS", Severity: "critical", IsAgent: true})
+	wait := ConsumeFindings(ConsumerOpts{
+		Watcher: w,
+		Action:  "", // normalize sets this to warn; the consumer must be conservative even if validate is bypassed
+		Cancel:  func() { cancelCount.Add(1) },
+	})
+	wait()
+
+	if cancelCount.Load() != 0 {
+		t.Errorf("empty action must not trigger cancel (defensive); got %d", cancelCount.Load())
+	}
+}
+
+func TestConsumeFindings_NilLog_NoPanic(t *testing.T) {
+	w := makeWatcher(t, Finding{Path: "/tmp/x", PatternName: "AWS", Severity: "critical", IsAgent: true})
+	wait := ConsumeFindings(ConsumerOpts{
+		Watcher: w,
+		Action:  config.ActionBlock,
+		Log:     nil,
+		Cancel:  func() {},
+	})
+	wait()
+}
+
+func TestWriteFindingLog_AgentSuffix(t *testing.T) {
+	var buf bytes.Buffer
+	writeFindingLog(&buf, Finding{Path: "/tmp/x", PatternName: "AWS", Severity: "critical", IsAgent: true})
+	got := buf.String()
+	want := "pipelock: [file_sentry] DLP match in /tmp/x: AWS (severity=critical) (agent process)\n"
+	if got != want {
+		t.Errorf("agent log format drifted:\n  got:  %q\n  want: %q", got, want)
+	}
+}
+
+func TestWriteFindingLog_NonAgentNoSuffix(t *testing.T) {
+	var buf bytes.Buffer
+	writeFindingLog(&buf, Finding{Path: "/tmp/x", PatternName: "AWS", Severity: "high", IsAgent: false})
+	got := buf.String()
+	want := "pipelock: [file_sentry] DLP match in /tmp/x: AWS (severity=high)\n"
+	if got != want {
+		t.Errorf("non-agent log format drifted:\n  got:  %q\n  want: %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

file_sentry has been alert-only since it shipped. This adds an `action` enum to `file_sentry`: `warn` (default, current behavior) or `block`. In block mode, the first DLP finding attributed to a process in the agent tree cancels the proxy context, terminating the MCP child so the agent cannot continue acting on the leak.

## Behavior

`action: warn` (default): every finding is logged to stderr and recorded as a Prometheus metric. The MCP child keeps running. Identical to the current release.

`action: block`: same logging + metrics, AND on the first finding with `IsAgent=true`, the proxy context is cancelled exactly once. Non-agent writes (editor saves, build output, system processes touching the watched directory) never trigger the block path.

## Boundary scope

The file reaches disk before the scan completes. Block prevents the agent from continuing to act on the leak, not from writing it. Operators who need write-time interception layer Landlock or `--sandbox`. Documented in both the configuration reference and the filesystem-sentinel guide.

## Consumer extraction

The inline finding consumer that lived in `internal/cli/runtime/mcp.go` AND `internal/cli/runtime/server_lifecycle.go` is now `filesentry.ConsumeFindings(opts)`, unit-testable in isolation from fsnotify and shared by both call sites. Eight new tests cover the warn / block-agent / block-non-agent / nil-cancel / empty-action / nil-log / log-format paths.

## Reload semantics

`config.fileSentryChanged` now compares `Action` so reload diagnostics catch a startup-only enforcement-mode change. The action is read once when the watcher arms before the MCP child launches; changing it via hot-reload triggers the standard restart-required reload warning.

## Policy hash

Canonical policy hash bumped for both `goldenHashDefaults` and `goldenHashRichConfig`. The new field is observable enforcement, not noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File Sentry adds a configurable action: warn (default) or block; block cancels the proxy session on the first agent-attributed finding to stop the child process.

* **Behavior Changes**
  * Clarified: File Sentry detects after writes reach disk (detection, not real-time interception).

* **Observability**
  * Findings are emitted as stderr warnings and Prometheus metrics; structured audit events described.

* **Docs & Validation**
  * Documentation updated and config validation/reload tests added; empty action defaults to warn.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->