### PR TITLE
Conductor: add fleet audit sink

### DIFF
--- a/internal/cli/fleet/sink.go
+++ b/internal/cli/fleet/sink.go
@@ -1,0 +1,322 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package fleet
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/fleet/sink"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func SinkCmd() *cobra.Command {
+	var listenAddr string
+	var storageDir string
+	var trustedKeys []string
+	var maxSkew time.Duration
+	var tlsCert string
+	var tlsKey string
+	var clientCA string
+	var readerTokenFile string
+
+	cmd := &cobra.Command{
+		Use:   "fleet-sink",
+		Short: "Run a Conductor audit batch sink",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if strings.TrimSpace(storageDir) == "" {
+				return errors.New("--storage-dir is required")
+			}
+			resolver, bindings, err := trustedAuditKeyResolver(trustedKeys)
+			if err != nil {
+				return err
+			}
+			readerToken, err := loadReaderToken(readerTokenFile)
+			if err != nil {
+				return err
+			}
+			if err := validateTLSFlags(tlsCert, tlsKey, clientCA); err != nil {
+				return err
+			}
+			if err := validateBindAddress(listenAddr, tlsCert, tlsKey, clientCA, readerToken); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			store, err := sink.OpenStore(ctx, filepath.Join(storageDir, "fleet-sink.db"))
+			if err != nil {
+				return err
+			}
+			defer func() { _ = store.Close() }()
+
+			sc := scanner.New(config.Defaults())
+			handler, err := sink.NewHandler(sink.Options{
+				Store:       store,
+				Resolver:    resolver,
+				DLPScanner:  sc,
+				MaxSkew:     maxSkew,
+				KeyBindings: bindings,
+				ReaderToken: readerToken,
+			})
+			if err != nil {
+				return err
+			}
+
+			server := &http.Server{
+				Addr:              listenAddr,
+				Handler:           handler,
+				ReadHeaderTimeout: 5 * time.Second,
+				ReadTimeout:       15 * time.Second,
+				WriteTimeout:      15 * time.Second,
+				IdleTimeout:       60 * time.Second,
+				MaxHeaderBytes:    64 * 1024,
+			}
+			tlsConfig, err := listenerTLSConfig(clientCA)
+			if err != nil {
+				return err
+			}
+			server.TLSConfig = tlsConfig
+
+			runCtx, stop := signalContext(ctx)
+			defer stop()
+			go func() {
+				<-runCtx.Done()
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				_ = server.Shutdown(shutdownCtx)
+			}()
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pipelock: fleet sink listening on %s\n", listenAddr)
+			if tlsCert != "" || tlsKey != "" {
+				if err := server.ListenAndServeTLS(tlsCert, tlsKey); err != nil && !errors.Is(err, http.ErrServerClosed) {
+					return err
+				}
+				return nil
+			}
+			if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&listenAddr, "listen", "127.0.0.1:8894", "address for the fleet sink HTTP listener")
+	cmd.Flags().StringVar(&storageDir, "storage-dir", "", "directory for the fleet sink SQLite store")
+	cmd.Flags().StringArrayVar(&trustedKeys, "trusted-audit-key", nil,
+		"trusted audit signing key as comma-separated kv pairs: 'id=ID,(inline=BASE64|file=/path)[,org=ORG][,fleet=FLEET][,instance=INSTANCE]'; repeatable")
+	cmd.Flags().DurationVar(&maxSkew, "max-skew", conductor.DefaultAuditMaxSkew, "maximum allowed audit batch clock skew")
+	cmd.Flags().StringVar(&tlsCert, "tls-cert", "", "TLS server certificate file")
+	cmd.Flags().StringVar(&tlsKey, "tls-key", "", "TLS server private key file")
+	cmd.Flags().StringVar(&clientCA, "client-ca", "", "client CA PEM bundle for mTLS")
+	cmd.Flags().StringVar(&readerTokenFile, "reader-token-file", "",
+		"path to a file containing the bearer token required for GET requests; required for non-loopback bind without --client-ca")
+	return cmd
+}
+
+// auditKeySpec is one parsed --trusted-audit-key value.
+type auditKeySpec struct {
+	id      string
+	inline  string
+	file    string
+	binding sink.KeyBinding
+}
+
+func trustedAuditKeyResolver(values []string) (conductor.SignatureKeyResolver, map[string]sink.KeyBinding, error) {
+	if len(values) == 0 {
+		return nil, nil, errors.New("at least one --trusted-audit-key is required")
+	}
+	keys := make(map[string]conductor.SignatureKey, len(values))
+	bindings := make(map[string]sink.KeyBinding, len(values))
+	for _, raw := range values {
+		spec, err := parseAuditKeySpec(raw)
+		if err != nil {
+			return nil, nil, err
+		}
+		pub, err := loadAuditPublicKey(spec)
+		if err != nil {
+			return nil, nil, fmt.Errorf("load trusted audit key %q: %w", spec.id, err)
+		}
+		if _, exists := keys[spec.id]; exists {
+			return nil, nil, fmt.Errorf("duplicate trusted audit key id %q", spec.id)
+		}
+		keys[spec.id] = conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		}
+		if !spec.binding.IsZero() {
+			bindings[spec.id] = spec.binding
+		}
+	}
+	resolver := func(signerKeyID string) (conductor.SignatureKey, error) {
+		key, ok := keys[signerKeyID]
+		if !ok {
+			return conductor.SignatureKey{}, fmt.Errorf("%w: key_id=%q", conductor.ErrInvalidSignature, signerKeyID)
+		}
+		return key, nil
+	}
+	return resolver, bindings, nil
+}
+
+// parseAuditKeySpec parses one --trusted-audit-key value. The expected
+// format is comma-separated key=value pairs with `id=` plus exactly one
+// of `inline=` or `file=` required, and optional `org=`, `fleet=`,
+// `instance=` tenant binding constraints. The kv format replaces an
+// earlier `key_id=value-or-path` shorthand whose parse-or-load fallback
+// silently opened files when the value didn't parse as a key.
+func parseAuditKeySpec(raw string) (auditKeySpec, error) {
+	if strings.TrimSpace(raw) == "" {
+		return auditKeySpec{}, errors.New("invalid --trusted-audit-key: empty")
+	}
+	spec := auditKeySpec{}
+	seen := make(map[string]struct{})
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(part, "=")
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if !ok || k == "" {
+			return auditKeySpec{}, fmt.Errorf("invalid --trusted-audit-key %q: expected k=v pairs", raw)
+		}
+		if _, dup := seen[k]; dup {
+			return auditKeySpec{}, fmt.Errorf("invalid --trusted-audit-key %q: duplicate key %q", raw, k)
+		}
+		seen[k] = struct{}{}
+		switch k {
+		case "id":
+			spec.id = v
+		case "inline":
+			spec.inline = v
+		case "file":
+			spec.file = v
+		case "org":
+			spec.binding.OrgID = v
+		case "fleet":
+			spec.binding.FleetID = v
+		case "instance":
+			spec.binding.InstanceID = v
+		default:
+			return auditKeySpec{}, fmt.Errorf("invalid --trusted-audit-key %q: unknown field %q", raw, k)
+		}
+	}
+	if spec.id == "" {
+		return auditKeySpec{}, fmt.Errorf("invalid --trusted-audit-key %q: id= required", raw)
+	}
+	if (spec.inline == "" && spec.file == "") || (spec.inline != "" && spec.file != "") {
+		return auditKeySpec{}, fmt.Errorf("invalid --trusted-audit-key %q: exactly one of inline= or file= required", raw)
+	}
+	return spec, nil
+}
+
+func loadAuditPublicKey(spec auditKeySpec) (ed25519.PublicKey, error) {
+	if spec.inline != "" {
+		return signing.ParsePublicKey(spec.inline)
+	}
+	return signing.LoadPublicKeyFile(filepath.Clean(spec.file))
+}
+
+// loadReaderToken reads a bearer token from disk. Reading from a file
+// keeps tokens out of process argv and shell history. Empty path
+// disables bearer auth.
+func loadReaderToken(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return "", fmt.Errorf("read reader token file: %w", err)
+	}
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		return "", errors.New("reader token file is empty")
+	}
+	return token, nil
+}
+
+// validateBindAddress refuses to bind non-loopback addresses without
+// some form of caller authentication. The audit signature authenticates
+// ingest; for read endpoints the listener itself MUST be authenticated
+// by mTLS (--client-ca) or the GET endpoints MUST be gated by a
+// bearer token (--reader-token-file). Allowing 0.0.0.0:8894 with no
+// auth is a production footgun that this check exists to prevent.
+func validateBindAddress(addr, tlsCert, tlsKey, clientCA, readerToken string) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("invalid --listen %q: %w", addr, err)
+	}
+	if isLoopbackHost(host) {
+		return nil
+	}
+	if tlsCert == "" || tlsKey == "" {
+		return fmt.Errorf("--listen %q is non-loopback; --tls-cert and --tls-key are required", addr)
+	}
+	if clientCA == "" && readerToken == "" {
+		return fmt.Errorf("--listen %q is non-loopback; --client-ca (mTLS) or --reader-token-file is required", addr)
+	}
+	return nil
+}
+
+func validateTLSFlags(tlsCert, tlsKey, clientCA string) error {
+	if (tlsCert == "") != (tlsKey == "") {
+		return errors.New("--tls-cert and --tls-key must be provided together")
+	}
+	if clientCA != "" && (tlsCert == "" || tlsKey == "") {
+		return errors.New("--client-ca requires --tls-cert and --tls-key")
+	}
+	return nil
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
+}
+
+func listenerTLSConfig(clientCAPath string) (*tls.Config, error) {
+	if strings.TrimSpace(clientCAPath) == "" {
+		return &tls.Config{MinVersion: tls.VersionTLS13}, nil
+	}
+	pemBytes, err := os.ReadFile(filepath.Clean(clientCAPath))
+	if err != nil {
+		return nil, fmt.Errorf("read client CA bundle: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pemBytes) {
+		return nil, errors.New("client CA bundle contains no PEM certificates")
+	}
+	return &tls.Config{
+		MinVersion: tls.VersionTLS13,
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  pool,
+	}, nil
+}
+
+func signalContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+}

--- a/internal/cli/fleet/sink_test.go
+++ b/internal/cli/fleet/sink_test.go
@@ -1,0 +1,420 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package fleet
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/fleet/sink"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestTrustedAuditKeyResolver_InlineAndFile(t *testing.T) {
+	pub, _, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "audit.pub")
+	if err := os.WriteFile(keyPath, []byte(signing.EncodePublicKey(pub)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resolver, bindings, err := trustedAuditKeyResolver([]string{
+		"id=inline-key,inline=" + signing.EncodePublicKey(pub),
+		"id=file-key,file=" + keyPath,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bindings) != 0 {
+		t.Fatalf("expected no bindings, got %d", len(bindings))
+	}
+	for _, id := range []string{"inline-key", "file-key"} {
+		key, err := resolver(id)
+		if err != nil {
+			t.Fatalf("resolve %q: %v", id, err)
+		}
+		if key.KeyPurpose != signing.PurposeAuditBatchSigning {
+			t.Fatalf("key %q purpose = %q", id, key.KeyPurpose)
+		}
+	}
+	if _, err := resolver("missing"); !errors.Is(err, conductor.ErrInvalidSignature) {
+		t.Fatalf("missing key err = %v, want ErrInvalidSignature", err)
+	}
+}
+
+func TestTrustedAuditKeyResolver_TenantBinding(t *testing.T) {
+	pub, _, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, bindings, err := trustedAuditKeyResolver([]string{
+		"id=acme-fleet-a,inline=" + signing.EncodePublicKey(pub) +
+			",org=acme,fleet=prod,instance=pl-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding, ok := bindings["acme-fleet-a"]
+	if !ok {
+		t.Fatal("binding for acme-fleet-a missing")
+	}
+	if binding.OrgID != "acme" || binding.FleetID != "prod" || binding.InstanceID != "pl-1" {
+		t.Fatalf("binding = %+v", binding)
+	}
+}
+
+func TestParseAuditKeySpec_RejectsBadInputs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"empty", "", "empty"},
+		{"no_id", "inline=AAA", "id= required"},
+		{"missing_key_source", "id=x", "inline= or file= required"},
+		{"both_key_sources", "id=x,inline=AAA,file=/tmp/k", "inline= or file= required"},
+		{"duplicate_field", "id=x,inline=AAA,inline=BBB", "duplicate key"},
+		{"unknown_field", "id=x,inline=AAA,bogus=1", "unknown field"},
+		{"missing_eq", "id=x,inline", "expected k=v"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseAuditKeySpec(tc.raw)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("parseAuditKeySpec(%q) = %v, want substring %q", tc.raw, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestTrustedAuditKeyResolver_RejectsBadInputs(t *testing.T) {
+	pub, _, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name   string
+		values []string
+	}{
+		{"missing", nil},
+		{"bad_format", []string{"audit-signer"}},
+		{"duplicate", []string{
+			"id=audit-signer,inline=" + signing.EncodePublicKey(pub),
+			"id=audit-signer,inline=" + signing.EncodePublicKey(pub),
+		}},
+		{"bad_inline", []string{"id=audit-signer,inline=not-a-key"}},
+		{"missing_file", []string{"id=audit-signer,file=/nonexistent/key.pub"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, err := trustedAuditKeyResolver(tc.values); err == nil {
+				t.Fatal("trustedAuditKeyResolver accepted invalid input")
+			}
+		})
+	}
+}
+
+func TestLoadReaderToken(t *testing.T) {
+	if got, err := loadReaderToken(""); err != nil || got != "" {
+		t.Fatalf("empty path: got=%q err=%v", got, err)
+	}
+	path := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(path, []byte("  s3cret-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadReaderToken(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "s3cret-token" {
+		t.Fatalf("token = %q", got)
+	}
+	empty := filepath.Join(t.TempDir(), "empty")
+	if err := os.WriteFile(empty, []byte("   \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadReaderToken(empty); err == nil {
+		t.Fatal("empty token file accepted")
+	}
+	if _, err := loadReaderToken("/nonexistent/token"); err == nil {
+		t.Fatal("missing token file accepted")
+	}
+}
+
+func TestValidateBindAddress(t *testing.T) {
+	tmpCA := writeTestCA(t)
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("t"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		addr        string
+		tlsCert     string
+		tlsKey      string
+		clientCA    string
+		readerToken string
+		wantErr     string
+	}{
+		{"loopback_ipv4", "127.0.0.1:8894", "", "", "", "", ""},
+		{"loopback_ipv6", "[::1]:8894", "", "", "", "", ""},
+		{"loopback_name", "localhost:8894", "", "", "", "", ""},
+		{"empty_host", ":8894", "", "", "", "", "--tls-cert and --tls-key are required"},
+		{"public_no_tls", "10.0.0.1:8894", "", "", "", "", "--tls-cert and --tls-key are required"},
+		{"public_cert_no_key", "10.0.0.1:8894", "/tmp/c", "", tmpCA, "", "--tls-cert and --tls-key are required"},
+		{"public_tls_no_auth", "10.0.0.1:8894", "/tmp/c", "/tmp/k", "", "", "--client-ca (mTLS) or --reader-token-file is required"},
+		{"public_tls_with_ca", "10.0.0.1:8894", "/tmp/c", "/tmp/k", tmpCA, "", ""},
+		{"public_tls_with_token", "10.0.0.1:8894", "/tmp/c", "/tmp/k", "", "tok", ""},
+		{"invalid_addr", "not-an-addr", "", "", "", "", "invalid --listen"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateBindAddress(tc.addr, tc.tlsCert, tc.tlsKey, tc.clientCA, tc.readerToken)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected err = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("validateBindAddress = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestListenerTLSConfigRequiresTLS13AndClientCA(t *testing.T) {
+	cfg, err := listenerTLSConfig("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("MinVersion = %x, want TLS 1.3", cfg.MinVersion)
+	}
+
+	path := t.TempDir() + "/bad-ca.pem"
+	if err := os.WriteFile(path, []byte("not pem"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := listenerTLSConfig(path); err == nil {
+		t.Fatal("listenerTLSConfig accepted invalid client CA")
+	}
+	if _, err := listenerTLSConfig("/nonexistent/ca.pem"); err == nil {
+		t.Fatal("listenerTLSConfig accepted missing CA path")
+	}
+
+	caPath := writeTestCA(t)
+	cfg, err = listenerTLSConfig(caPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ClientAuth != tls.RequireAndVerifyClientCert {
+		t.Fatalf("ClientAuth = %v, want RequireAndVerifyClientCert", cfg.ClientAuth)
+	}
+	if cfg.ClientCAs == nil {
+		t.Fatal("ClientCAs is nil")
+	}
+}
+
+func TestSinkCmdValidatesArgsBeforeServing(t *testing.T) {
+	pub, _, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded := signing.EncodePublicKey(pub)
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"extra_arg", []string{"extra"}},
+		{"missing_storage", nil},
+		{"missing_key", []string{"--storage-dir", t.TempDir()}},
+		{"bad_key_spec", []string{
+			"--storage-dir", t.TempDir(),
+			"--trusted-audit-key", "audit-signer", // missing id=, inline= etc
+		}},
+		{"client_ca_without_tls", []string{
+			"--storage-dir", t.TempDir(),
+			"--trusted-audit-key", "id=audit-signer,inline=" + encoded,
+			"--client-ca", writeTestCA(t),
+		}},
+		{"non_loopback_no_tls", []string{
+			"--storage-dir", t.TempDir(),
+			"--trusted-audit-key", "id=audit-signer,inline=" + encoded,
+			"--listen", "10.0.0.1:9999",
+		}},
+		{"non_loopback_tls_no_auth", []string{
+			"--storage-dir", t.TempDir(),
+			"--trusted-audit-key", "id=audit-signer,inline=" + encoded,
+			"--listen", "10.0.0.1:9999",
+			"--tls-cert", "/tmp/cert.pem",
+			"--tls-key", "/tmp/key.pem",
+		}},
+		{"missing_token_file", []string{
+			"--storage-dir", t.TempDir(),
+			"--trusted-audit-key", "id=audit-signer,inline=" + encoded,
+			"--reader-token-file", "/nonexistent/tok",
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := SinkCmd()
+			cmd.SetArgs(tc.args)
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetContext(context.Background())
+			if err := cmd.Execute(); err == nil {
+				t.Fatal("SinkCmd accepted invalid invocation")
+			}
+		})
+	}
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	for _, tc := range []struct {
+		host string
+		want bool
+	}{
+		{"", false},
+		{"localhost", true},
+		{"127.0.0.1", true},
+		{"127.1.2.3", true}, // entire 127/8 is loopback
+		{"::1", true},
+		{"10.0.0.1", false},
+		{"example.com", false}, // non-IP hostname is not loopback
+		{"not-an-ip", false},
+	} {
+		t.Run(tc.host, func(t *testing.T) {
+			if got := isLoopbackHost(tc.host); got != tc.want {
+				t.Fatalf("isLoopbackHost(%q) = %v, want %v", tc.host, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSignalContextCancel(t *testing.T) {
+	ctx, cancel := signalContext(context.Background())
+	cancel()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("signal context did not cancel")
+	}
+}
+
+// TestSinkCmd_RunOnLoopback covers the happy-path RunE up to ListenAndServe
+// returning the harmless ErrServerClosed after we cancel the parent context.
+// This wires together the resolver, store, scanner, and handler so all of
+// SinkCmd's setup branches are exercised.
+func TestSinkCmd_RunOnLoopback(t *testing.T) {
+	pub, _, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := SinkCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{
+		"--storage-dir", t.TempDir(),
+		"--trusted-audit-key", "id=audit-signer,inline=" + signing.EncodePublicKey(pub),
+		"--listen", "127.0.0.1:0",
+	})
+	// Cancel almost immediately so the listener exits cleanly via Shutdown.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("SinkCmd.Execute() = %v", err)
+	}
+}
+
+// TestSinkCmd_TLSCertWithoutKey makes sure operators get a clear error when
+// they configure half the TLS pair. The check fires after the OS-level
+// startup chatter (resolver + store) so we exercise the deferred branches.
+func TestSinkCmd_TLSCertWithoutKey(t *testing.T) {
+	pub, _, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := SinkCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{
+		"--storage-dir", t.TempDir(),
+		"--trusted-audit-key", "id=audit-signer,inline=" + signing.EncodePublicKey(pub),
+		"--listen", "127.0.0.1:0",
+		"--tls-cert", "/tmp/cert.pem", // key intentionally missing
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("SinkCmd accepted --tls-cert without --tls-key")
+	}
+}
+
+// TestKeyBindingMatches covers the table of binding constraints used by
+// the ingest handler.
+func TestKeyBindingMatches(t *testing.T) {
+	env := conductor.AuditBatchEnvelope{OrgID: "acme", FleetID: "prod", InstanceID: "pl-1"}
+	for _, tc := range []struct {
+		name    string
+		binding sink.KeyBinding
+		want    bool
+	}{
+		{"unrestricted", sink.KeyBinding{}, true},
+		{"matching_org", sink.KeyBinding{OrgID: "acme"}, true},
+		{"wrong_org", sink.KeyBinding{OrgID: "globex"}, false},
+		{"matching_full", sink.KeyBinding{OrgID: "acme", FleetID: "prod", InstanceID: "pl-1"}, true},
+		{"wrong_instance", sink.KeyBinding{OrgID: "acme", FleetID: "prod", InstanceID: "pl-2"}, false},
+		{"matching_fleet_only", sink.KeyBinding{FleetID: "prod"}, true},
+		{"wrong_fleet", sink.KeyBinding{FleetID: "staging"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.binding.Matches(env); got != tc.want {
+				t.Fatalf("Matches = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func writeTestCA(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := t.TempDir() + "/ca.pem"
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/cli/contain"
 	"github.com/luckyPipewrench/pipelock/internal/cli/diag"
 	clienvelope "github.com/luckyPipewrench/pipelock/internal/cli/envelope"
+	"github.com/luckyPipewrench/pipelock/internal/cli/fleet"
 	"github.com/luckyPipewrench/pipelock/internal/cli/generate"
 	"github.com/luckyPipewrench/pipelock/internal/cli/git"
 	"github.com/luckyPipewrench/pipelock/internal/cli/learn"
@@ -85,6 +86,8 @@ Quick start:
 		contain.Cmd(),
 		// Mediation envelope trust management
 		clienvelope.Cmd(),
+		// Fleet operations
+		fleet.SinkCmd(),
 		// Diagnostics
 		diag.DoctorCmd(),
 		diag.DiagnoseCmd(),

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -55,3 +55,18 @@ func TestEnvelopeHelpRegistered(t *testing.T) {
 		t.Fatalf("help output = %q, want trust subcommand", got)
 	}
 }
+
+func TestFleetSinkHelpRegistered(t *testing.T) {
+	cmd := rootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"fleet-sink", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("fleet-sink help: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "--trusted-audit-key") {
+		t.Fatalf("help output = %q, want trusted audit key flag", got)
+	}
+}

--- a/internal/fleet/sink/doc.go
+++ b/internal/fleet/sink/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package sink implements Conductor audit batch ingest and query storage for
+// fleet operators.
+package sink

--- a/internal/fleet/sink/ingest.go
+++ b/internal/fleet/sink/ingest.go
@@ -1,0 +1,357 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package sink
+
+import (
+	"bytes"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+type Handler struct {
+	store           *Store
+	resolver        conductor.SignatureKeyResolver
+	dlpScanner      DLPScanner
+	now             func() time.Time
+	maxSkew         time.Duration
+	maxRequestBytes int64
+	keyBindings     map[string]KeyBinding
+	readerToken     string
+}
+
+func NewHandler(opts Options) (*Handler, error) {
+	if opts.Store == nil {
+		return nil, ErrMissingStore
+	}
+	if opts.Resolver == nil {
+		return nil, ErrMissingResolver
+	}
+	if opts.DLPScanner == nil {
+		return nil, ErrMissingDLPScanner
+	}
+	if opts.Now == nil {
+		opts.Now = func() time.Time { return time.Now().UTC() }
+	}
+	if opts.MaxSkew <= 0 {
+		opts.MaxSkew = conductor.DefaultAuditMaxSkew
+	}
+	if opts.MaxRequestBytes <= 0 {
+		opts.MaxRequestBytes = DefaultMaxRequestBytes
+	}
+	// Copy the binding map so the handler isn't mutated after construction.
+	bindings := make(map[string]KeyBinding, len(opts.KeyBindings))
+	for k, v := range opts.KeyBindings {
+		bindings[k] = v
+	}
+	return &Handler{
+		store:           opts.Store,
+		resolver:        opts.Resolver,
+		dlpScanner:      opts.DLPScanner,
+		now:             opts.Now,
+		maxSkew:         opts.MaxSkew,
+		maxRequestBytes: opts.MaxRequestBytes,
+		keyBindings:     bindings,
+		readerToken:     opts.ReaderToken,
+	}, nil
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/health":
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	case r.URL.Path == AuditBatchesPath && r.Method == http.MethodPost:
+		h.handleIngest(w, r)
+	case r.URL.Path == AuditBatchesPath && r.Method == http.MethodGet:
+		h.handleList(w, r)
+	case strings.HasPrefix(r.URL.Path, AuditBatchesPath+"/") && r.Method == http.MethodGet:
+		h.handleGet(w, r)
+	case r.URL.Path == AuditBatchesPath:
+		writeError(w, http.StatusMethodNotAllowed, ErrUnsupportedMethod)
+	default:
+		writeError(w, http.StatusNotFound, ErrUnsupportedPath)
+	}
+}
+
+func (h *Handler) handleIngest(w http.ResponseWriter, r *http.Request) {
+	if ct := r.Header.Get("Content-Type"); ct != "" && !strings.HasPrefix(strings.ToLower(ct), "application/json") {
+		writeError(w, http.StatusUnsupportedMediaType, fmt.Errorf("%w: content-type=%q", ErrInvalidRequestBody, ct))
+		return
+	}
+	upload, err := decodeUpload(w, r, h.maxRequestBytes)
+	if err != nil {
+		writeError(w, statusForError(err), err)
+		return
+	}
+
+	now := h.now().UTC()
+	if err := upload.Envelope.ValidateForConductorWithPayload(now, h.maxSkew, upload.Payload); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := upload.Envelope.VerifySignaturesAt(now, h.resolver); err != nil {
+		writeError(w, http.StatusUnauthorized, err)
+		return
+	}
+	// Binding enforcement runs AFTER signature verification: only
+	// keys that proved possession are checked, and we never leak
+	// information about binding constraints to clients who haven't
+	// passed the crypto gate.
+	if err := h.enforceBindings(upload.Envelope); err != nil {
+		writeError(w, http.StatusForbidden, err)
+		return
+	}
+
+	dlpResult := h.dlpScanner.ScanTextForDLP(r.Context(), string(upload.Payload))
+	if !dlpResult.Clean {
+		writeError(w, http.StatusUnprocessableEntity, fmt.Errorf("%w: %s", ErrDLPRejected, dlpPatternNames(dlpResult.Matches)))
+		return
+	}
+
+	canonicalHash, err := upload.Envelope.CanonicalHash()
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	result, err := h.store.Put(r.Context(), acceptedBatch{
+		Envelope:      upload.Envelope,
+		Payload:       upload.Payload,
+		ReceivedAt:    now,
+		CanonicalHash: canonicalHash,
+	}, dlpPatternNames(dlpResult.InformationalMatches))
+	if err != nil {
+		writeError(w, statusForError(err), err)
+		return
+	}
+
+	status := "accepted"
+	if result.Duplicate {
+		status = "duplicate"
+	}
+	writeJSON(w, http.StatusAccepted, map[string]any{
+		"status":         status,
+		"batch_id":       result.Summary.BatchID,
+		"canonical_hash": result.Summary.CanonicalHash,
+	})
+}
+
+func (h *Handler) handleList(w http.ResponseWriter, r *http.Request) {
+	if err := h.checkReaderAuth(r); err != nil {
+		writeError(w, http.StatusUnauthorized, err)
+		return
+	}
+	q := r.URL.Query()
+	orgID := q.Get("org_id")
+	fleetID := q.Get("fleet_id")
+	instanceID := q.Get("instance_id")
+	// Require the full namespace tuple on list. Without it, an
+	// authorized reader could enumerate every tenant's batches in
+	// one request — even on a single-tenant deployment that's
+	// information disclosure we don't need to grant.
+	if orgID == "" || fleetID == "" || instanceID == "" {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("%w: org_id, fleet_id, and instance_id are required", ErrInvalidRequestBody))
+		return
+	}
+	limit, err := parseLimit(q.Get("limit"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	results, err := h.store.List(r.Context(), Query{
+		OrgID:      orgID,
+		FleetID:    fleetID,
+		InstanceID: instanceID,
+		BatchID:    q.Get("batch_id"),
+		Limit:      limit,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"batches": results})
+}
+
+func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
+	if err := h.checkReaderAuth(r); err != nil {
+		writeError(w, http.StatusUnauthorized, err)
+		return
+	}
+	batchID := strings.TrimPrefix(r.URL.Path, AuditBatchesPath+"/")
+	if batchID == "" || strings.Contains(batchID, "/") {
+		writeError(w, http.StatusNotFound, ErrUnsupportedPath)
+		return
+	}
+	q := r.URL.Query()
+	if q.Get("org_id") == "" || q.Get("fleet_id") == "" || q.Get("instance_id") == "" {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("%w: org_id, fleet_id, and instance_id are required", ErrInvalidRequestBody))
+		return
+	}
+	summary, ok, err := h.store.Get(r.Context(), q.Get("org_id"), q.Get("fleet_id"), q.Get("instance_id"), batchID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	if !ok {
+		writeError(w, http.StatusNotFound, ErrUnsupportedPath)
+		return
+	}
+	writeJSON(w, http.StatusOK, summary)
+}
+
+// checkReaderAuth validates the bearer token on GET endpoints when one
+// is configured. The token comparison is constant-time to keep timing
+// oracles off the table even though leaking a few bits on length is
+// already known. When no token is configured the check is a no-op:
+// operators MUST gate non-loopback bindings on either mTLS or a
+// reader token, enforced at SinkCmd start.
+func (h *Handler) checkReaderAuth(r *http.Request) error {
+	if h.readerToken == "" {
+		return nil
+	}
+	header := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if !strings.HasPrefix(header, prefix) {
+		return ErrUnauthorized
+	}
+	provided := strings.TrimSpace(header[len(prefix):])
+	if subtle.ConstantTimeCompare([]byte(provided), []byte(h.readerToken)) != 1 {
+		return ErrUnauthorized
+	}
+	return nil
+}
+
+// enforceBindings rejects an envelope whose signers include any keys
+// whose configured binding does not match the envelope's namespace.
+// Every signature that contributed to verification is checked — not
+// just the threshold — so a single bound key being used outside its
+// scope rejects the entire batch even if other unbound keys also
+// signed. Keys with no binding entry are unrestricted.
+func (h *Handler) enforceBindings(env conductor.AuditBatchEnvelope) error {
+	if len(h.keyBindings) == 0 {
+		return nil
+	}
+	for _, sig := range env.Signatures {
+		binding, ok := h.keyBindings[sig.SignerKeyID]
+		if !ok {
+			continue
+		}
+		if !binding.Matches(env) {
+			return fmt.Errorf("%w: key_id=%q org=%q fleet=%q instance=%q",
+				ErrKeyBindingViolated, sig.SignerKeyID, env.OrgID, env.FleetID, env.InstanceID)
+		}
+	}
+	return nil
+}
+
+type uploadRequest struct {
+	Envelope conductor.AuditBatchEnvelope `json:"envelope"`
+	Payload  []byte                       `json:"payload"`
+}
+
+func decodeUpload(w http.ResponseWriter, r *http.Request, maxBytes int64) (uploadRequest, error) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxBytes))
+	if err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			return uploadRequest{}, ErrRequestTooLarge
+		}
+		return uploadRequest{}, fmt.Errorf("%w: %w", ErrInvalidRequestBody, err)
+	}
+
+	var top map[string]json.RawMessage
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&top); err != nil {
+		return uploadRequest{}, fmt.Errorf("%w: %w", ErrInvalidRequestBody, err)
+	}
+	if err := dec.Decode(new(struct{})); !errors.Is(err, io.EOF) {
+		return uploadRequest{}, fmt.Errorf("%w: trailing JSON token", ErrInvalidRequestBody)
+	}
+	// `json.RawMessage("null")` is a non-nil 4-byte value, so a `== nil`
+	// check happily passes when the client sends `{"envelope": null,
+	// "payload": null}`. Treat missing-key and explicit-null the same.
+	if len(top) != 2 || isMissingOrNull(top["envelope"]) || isMissingOrNull(top["payload"]) {
+		return uploadRequest{}, fmt.Errorf("%w: expected envelope and payload only", ErrInvalidRequestBody)
+	}
+
+	var req uploadRequest
+	if err := strictDecode(top["envelope"], &req.Envelope); err != nil {
+		return uploadRequest{}, fmt.Errorf("%w: envelope: %w", ErrInvalidRequestBody, err)
+	}
+	if err := strictDecode(top["payload"], &req.Payload); err != nil {
+		return uploadRequest{}, fmt.Errorf("%w: payload: %w", ErrInvalidRequestBody, err)
+	}
+	return req, nil
+}
+
+func isMissingOrNull(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return true
+	}
+	trimmed := bytes.TrimSpace(raw)
+	return bytes.Equal(trimmed, []byte("null"))
+}
+
+func strictDecode(raw json.RawMessage, dst any) error {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	if err := dec.Decode(new(struct{})); !errors.Is(err, io.EOF) {
+		return fmt.Errorf("trailing JSON token")
+	}
+	return nil
+}
+
+func dlpPatternNames(matches []scanner.TextDLPMatch) []string {
+	names := make([]string, 0, len(matches))
+	seen := make(map[string]struct{}, len(matches))
+	for _, match := range matches {
+		if match.PatternName == "" {
+			continue
+		}
+		if _, ok := seen[match.PatternName]; ok {
+			continue
+		}
+		seen[match.PatternName] = struct{}{}
+		names = append(names, match.PatternName)
+	}
+	return names
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeError(w http.ResponseWriter, status int, err error) {
+	writeJSON(w, status, map[string]string{"error": err.Error()})
+}
+
+func statusForError(err error) int {
+	switch {
+	case errors.Is(err, ErrRequestTooLarge):
+		return http.StatusRequestEntityTooLarge
+	case errors.Is(err, ErrInvalidRequestBody):
+		return http.StatusBadRequest
+	case errors.Is(err, ErrUnauthorized):
+		return http.StatusUnauthorized
+	case errors.Is(err, ErrKeyBindingViolated):
+		return http.StatusForbidden
+	case errors.Is(err, ErrBatchConflict), errors.Is(err, ErrForkDetected):
+		return http.StatusConflict
+	default:
+		return http.StatusInternalServerError
+	}
+}

--- a/internal/fleet/sink/ingest_auth_test.go
+++ b/internal/fleet/sink/ingest_auth_test.go
@@ -1,0 +1,683 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package sink
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// TestHandler_ReaderTokenRequired ensures GET endpoints reject requests
+// when --reader-token-file is configured and the caller does not supply
+// a matching Authorization header.
+func TestHandler_ReaderTokenRequired(t *testing.T) {
+	pub, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenStore(context.Background(), t.TempDir()+"/sink.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	const token = "s3cret-reader-token"
+	handler, err := NewHandler(Options{
+		Store:       store,
+		Resolver:    staticResolver(pub),
+		DLPScanner:  scanner.New(config.Defaults()),
+		Now:         func() time.Time { return sinkTestNow },
+		ReaderToken: token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`{"events":[{"message":"clean"}]}`)
+	env := signedEnvelope(t, "batch-auth", 1, 1, payload, priv)
+	if resp := postBatch(t, handler, env, payload); resp.Code != http.StatusAccepted {
+		t.Fatalf("post status = %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	cases := []struct {
+		name   string
+		header string
+		want   int
+	}{
+		{"no_header", "", http.StatusUnauthorized},
+		{"wrong_scheme", "Basic " + token, http.StatusUnauthorized},
+		{"wrong_token", "Bearer not-the-token", http.StatusUnauthorized},
+		{"correct_token", "Bearer " + token, http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run("list_"+tc.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+				AuditBatchesPath+"?org_id=org-test&fleet_id=fleet-prod&instance_id=instance-a", nil)
+			if tc.header != "" {
+				req.Header.Set("Authorization", tc.header)
+			}
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			if resp.Code != tc.want {
+				t.Fatalf("status = %d body=%s want=%d", resp.Code, resp.Body.String(), tc.want)
+			}
+		})
+		t.Run("get_"+tc.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+				AuditBatchesPath+"/batch-auth?org_id=org-test&fleet_id=fleet-prod&instance_id=instance-a", nil)
+			if tc.header != "" {
+				req.Header.Set("Authorization", tc.header)
+			}
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			if resp.Code != tc.want {
+				t.Fatalf("status = %d body=%s want=%d", resp.Code, resp.Body.String(), tc.want)
+			}
+		})
+	}
+
+	// Ingest is signature-authenticated regardless of reader token.
+	otherPayload := []byte(`{"events":[{"message":"clean2"}]}`)
+	otherEnv := signedEnvelope(t, "batch-auth-2", 2, 2, otherPayload, priv)
+	if resp := postBatch(t, handler, otherEnv, otherPayload); resp.Code != http.StatusAccepted {
+		t.Fatalf("ingest without Authorization should still succeed: %d %s", resp.Code, resp.Body.String())
+	}
+}
+
+// TestHandler_RequiresFullNamespaceOnList tightens enumeration scope:
+// even when reader auth is satisfied, the list endpoint requires all
+// three namespace fields. This prevents a single GET from sweeping
+// every tenant's batches in a multi-tenant deployment.
+func TestHandler_RequiresFullNamespaceOnList(t *testing.T) {
+	handler, _, priv := testHandler(t)
+	payload := []byte(`{"events":[{"message":"clean"}]}`)
+	env := signedEnvelope(t, "batch-1", 1, 1, payload, priv)
+	if resp := postBatch(t, handler, env, payload); resp.Code != http.StatusAccepted {
+		t.Fatalf("post = %d body=%s", resp.Code, resp.Body.String())
+	}
+	cases := []struct {
+		name string
+		path string
+		want int
+	}{
+		{"no_filters", AuditBatchesPath, http.StatusBadRequest},
+		{"only_org", AuditBatchesPath + "?org_id=org-test", http.StatusBadRequest},
+		{"org_fleet", AuditBatchesPath + "?org_id=org-test&fleet_id=fleet-prod", http.StatusBadRequest},
+		{"full", AuditBatchesPath + "?org_id=org-test&fleet_id=fleet-prod&instance_id=instance-a", http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.path, nil)
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			if resp.Code != tc.want {
+				t.Fatalf("status = %d body=%s want=%d", resp.Code, resp.Body.String(), tc.want)
+			}
+		})
+	}
+}
+
+// TestHandler_EnforcesKeyBinding rejects valid signatures whose signing
+// key is configured with a tenant binding that does not match the
+// envelope's namespace. Binding enforcement runs AFTER signature
+// verification — only proven-possession keys can trip it.
+func TestHandler_EnforcesKeyBinding(t *testing.T) {
+	pub, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenStore(context.Background(), t.TempDir()+"/sink.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	bindings := map[string]KeyBinding{
+		"audit-signer": {OrgID: "globex", FleetID: "prod", InstanceID: "pl-1"},
+	}
+	handler, err := NewHandler(Options{
+		Store:       store,
+		Resolver:    staticResolver(pub),
+		DLPScanner:  scanner.New(config.Defaults()),
+		Now:         func() time.Time { return sinkTestNow },
+		KeyBindings: bindings,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// signedEnvelope uses org-test/fleet-prod/instance-a — does NOT match the binding.
+	payload := []byte(`{"events":[{"message":"clean"}]}`)
+	mismatch := signedEnvelope(t, "batch-binding-fail", 1, 1, payload, priv)
+	resp := postBatch(t, handler, mismatch, payload)
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body=%s want=403", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "not authorized for batch namespace") {
+		t.Fatalf("response missing binding error: %s", resp.Body.String())
+	}
+}
+
+// TestHandler_AllowsMatchingKeyBinding accepts a batch whose envelope
+// namespace satisfies the configured binding for every signing key.
+func TestHandler_AllowsMatchingKeyBinding(t *testing.T) {
+	pub, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenStore(context.Background(), t.TempDir()+"/sink.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	bindings := map[string]KeyBinding{
+		// Bind to the namespace used by signedEnvelope().
+		"audit-signer": {OrgID: "org-test", FleetID: "fleet-prod", InstanceID: "instance-a"},
+	}
+	handler, err := NewHandler(Options{
+		Store:       store,
+		Resolver:    staticResolver(pub),
+		DLPScanner:  scanner.New(config.Defaults()),
+		Now:         func() time.Time { return sinkTestNow },
+		KeyBindings: bindings,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`{"events":[{"message":"clean"}]}`)
+	env := signedEnvelope(t, "batch-binding-ok", 1, 1, payload, priv)
+	if resp := postBatch(t, handler, env, payload); resp.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+// TestHandler_RejectsExplicitJSONNull covers the documented bypass
+// vector where `json.RawMessage("null")` slips past a `== nil` check.
+// Even though downstream validation eventually rejects zero-value
+// envelopes, the parser layer itself must reject explicit-null too.
+func TestHandler_RejectsExplicitJSONNull(t *testing.T) {
+	handler, _, priv := testHandler(t)
+	payload := []byte(`{"events":[{"message":"clean"}]}`)
+	env := signedEnvelope(t, "batch-null", 1, 1, payload, priv)
+	envelopeJSON, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"envelope_null", `{"envelope":null,"payload":` + string(payloadJSON) + `}`},
+		{"payload_null", `{"envelope":` + string(envelopeJSON) + `,"payload":null}`},
+		{"both_null", `{"envelope":null,"payload":null}`},
+		{"whitespace_null", `{"envelope": ` + "  null  " + `,"payload":null}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+				AuditBatchesPath, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			if resp.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d body=%s want=400", resp.Code, resp.Body.String())
+			}
+			if !strings.Contains(resp.Body.String(), "expected envelope and payload only") {
+				t.Fatalf("body did not surface the parser-layer rejection: %s", resp.Body.String())
+			}
+		})
+	}
+}
+
+// TestStore_DetectForkUsesSeqRangeOverlap exercises the SQL range
+// query path: a non-overlapping seq window must NOT trigger fork
+// detection (would be a false positive); an overlapping window with
+// different content MUST.
+func TestStore_DetectForkUsesSeqRangeOverlap(t *testing.T) {
+	handler, _, priv := testHandler(t)
+
+	// Seed two non-overlapping batches in the same namespace.
+	first := signedEnvelope(t, "batch-non-overlap-1", 1, 2, []byte(`{"events":[{"m":"a"}]}`), priv)
+	if resp := postBatch(t, handler, first, []byte(`{"events":[{"m":"a"}]}`)); resp.Code != http.StatusAccepted {
+		t.Fatalf("first = %d body=%s", resp.Code, resp.Body.String())
+	}
+	third := signedEnvelope(t, "batch-non-overlap-3", 5, 6, []byte(`{"events":[{"m":"c"}]}`), priv)
+	if resp := postBatch(t, handler, third, []byte(`{"events":[{"m":"c"}]}`)); resp.Code != http.StatusAccepted {
+		t.Fatalf("third = %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	// A new batch with seq [3,4] does NOT overlap either — must succeed.
+	middle := signedEnvelope(t, "batch-non-overlap-2", 3, 4, []byte(`{"events":[{"m":"b"}]}`), priv)
+	if resp := postBatch(t, handler, middle, []byte(`{"events":[{"m":"b"}]}`)); resp.Code != http.StatusAccepted {
+		t.Fatalf("middle = %d body=%s; non-overlapping seq window should not trigger fork", resp.Code, resp.Body.String())
+	}
+
+	// A batch with seq [2,3] DOES overlap [1,2] — must be flagged.
+	overlap := signedEnvelope(t, "batch-overlap", 2, 3, []byte(`{"events":[{"m":"z"}]}`), priv)
+	if resp := postBatch(t, handler, overlap, []byte(`{"events":[{"m":"z"}]}`)); resp.Code != http.StatusConflict {
+		t.Fatalf("overlap = %d body=%s; overlapping seq with different content must conflict", resp.Code, resp.Body.String())
+	}
+}
+
+// TestStore_DBFileIsOwnerOnly checks the owner-only store mode:
+// audit payloads sit in this file, so it must not be world- or
+// group-readable even if umask is permissive.
+func TestStore_DBFileIsOwnerOnly(t *testing.T) {
+	path := t.TempDir() + "/sink.db"
+	store, err := OpenStore(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("db file mode = %o, want 0600", mode)
+	}
+}
+
+func TestStore_RejectsSymlinkDBPath(t *testing.T) {
+	dir := t.TempDir()
+	target := dir + "/target.db"
+	link := dir + "/sink.db"
+	if err := os.WriteFile(target, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenStore(context.Background(), link); err == nil {
+		t.Fatal("OpenStore accepted symlink DB path")
+	}
+}
+
+// TestStore_FormatUintIsLexNumericSortable verifies the padding
+// behavior that fixes the lex-vs-numeric sort hazard on TEXT seq
+// columns. Without padding "9" > "100" lex-sorts wrong and the
+// namespace_sequence index becomes useless.
+func TestStore_FormatUintIsLexNumericSortable(t *testing.T) {
+	values := []uint64{0, 1, 9, 10, 100, 1000, 18446744073709551615}
+	encoded := make([]string, len(values))
+	for i, v := range values {
+		encoded[i] = formatUint(v)
+		if len(encoded[i]) != uintTextWidth {
+			t.Fatalf("formatUint(%d) = %q (len=%d), want width %d", v, encoded[i], len(encoded[i]), uintTextWidth)
+		}
+	}
+	// Strings should sort identically to the underlying uints.
+	for i := 1; i < len(encoded); i++ {
+		if encoded[i-1] >= encoded[i] {
+			t.Fatalf("encoded[%d]=%q !< encoded[%d]=%q; lex order != numeric order", i-1, encoded[i-1], i, encoded[i])
+		}
+	}
+}
+
+// TestStore_RecoveryRoundtripParsesPaddedSeq guards against a future
+// formatUint change that breaks parseUintField round-trip.
+func TestStore_RecoveryRoundtripParsesPaddedSeq(t *testing.T) {
+	for _, v := range []uint64{0, 1, 1000, 18446744073709551615} {
+		got, err := parseUintField("seq", formatUint(v))
+		if err != nil {
+			t.Fatalf("parseUintField(formatUint(%d)) error = %v", v, err)
+		}
+		if got != v {
+			t.Fatalf("round-trip mismatch: in=%d out=%d", v, got)
+		}
+	}
+}
+
+// TestNewHandler_CopiesKeyBindings makes sure post-construction
+// mutation of the caller's binding map cannot affect the handler.
+func TestNewHandler_CopiesKeyBindings(t *testing.T) {
+	pub, _, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenStore(context.Background(), t.TempDir()+"/sink.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	bindings := map[string]KeyBinding{"audit-signer": {OrgID: "acme"}}
+	handler, err := NewHandler(Options{
+		Store:       store,
+		Resolver:    staticResolver(pub),
+		DLPScanner:  scanner.New(config.Defaults()),
+		KeyBindings: bindings,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	delete(bindings, "audit-signer")
+	if _, ok := handler.keyBindings["audit-signer"]; !ok {
+		t.Fatal("handler.keyBindings was aliased to caller-supplied map")
+	}
+}
+
+// TestIsMissingOrNull exercises the documented bypass-pattern fix
+// directly so future regressions get caught in unit scope.
+func TestIsMissingOrNull(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  json.RawMessage
+		want bool
+	}{
+		{"nil", nil, true},
+		{"empty", json.RawMessage{}, true},
+		{"null_literal", json.RawMessage(`null`), true},
+		{"null_with_whitespace", json.RawMessage(` null `), true},
+		{"valid_object", json.RawMessage(`{}`), false},
+		{"valid_string", json.RawMessage(`"hi"`), false},
+		{"valid_number", json.RawMessage(`0`), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isMissingOrNull(tc.raw); got != tc.want {
+				t.Fatalf("isMissingOrNull(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestKeyBinding_IsZero covers the convenience predicate used by the
+// CLI to decide whether to populate the bindings map.
+func TestKeyBinding_IsZero(t *testing.T) {
+	if !(KeyBinding{}).IsZero() {
+		t.Fatal("empty binding reports non-zero")
+	}
+	if (KeyBinding{OrgID: "x"}).IsZero() {
+		t.Fatal("binding with org reports zero")
+	}
+	if (KeyBinding{FleetID: "x"}).IsZero() {
+		t.Fatal("binding with fleet reports zero")
+	}
+	if (KeyBinding{InstanceID: "x"}).IsZero() {
+		t.Fatal("binding with instance reports zero")
+	}
+}
+
+// TestEnforceBindings_SkipsUnboundKeys exercises the branch where a
+// signer key id has no binding configured: such keys are unrestricted
+// and must not be rejected even when the map has other entries.
+func TestEnforceBindings_SkipsUnboundKeys(t *testing.T) {
+	pub, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenStore(context.Background(), t.TempDir()+"/sink.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	// Bind a DIFFERENT key id; the signer "audit-signer" is unbound.
+	handler, err := NewHandler(Options{
+		Store:      store,
+		Resolver:   staticResolver(pub),
+		DLPScanner: scanner.New(config.Defaults()),
+		Now:        func() time.Time { return sinkTestNow },
+		KeyBindings: map[string]KeyBinding{
+			"other-signer": {OrgID: "anything"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`{"events":[{"message":"clean"}]}`)
+	env := signedEnvelope(t, "batch-unbound", 1, 1, payload, priv)
+	if resp := postBatch(t, handler, env, payload); resp.Code != http.StatusAccepted {
+		t.Fatalf("unbound signer should be accepted; got %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+// TestParseLimit_ExplicitValue covers the success branch of
+// parseLimit with a parseable integer, exercising the
+// normalizeLimit clamp from inside parseLimit too.
+func TestParseLimit_ExplicitValue(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want int
+	}{
+		{"", defaultQueryLimit},
+		{"  ", defaultQueryLimit},
+		{"5", 5},
+		{"99999", maxQueryLimit},
+		{"-1", defaultQueryLimit},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := parseLimit(tc.in)
+			if err != nil {
+				t.Fatalf("parseLimit(%q) err = %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseLimit(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOpenStore_RejectsBadPaths covers the early failure branches:
+// empty path is handled by an explicit error; using an existing
+// directory as the DB path causes sql.Open + migrate to fail.
+func TestOpenStore_RejectsBadPaths(t *testing.T) {
+	if _, err := OpenStore(context.Background(), ""); err == nil {
+		t.Fatal("empty path accepted")
+	}
+	if _, err := OpenStore(context.Background(), "   "); err == nil {
+		t.Fatal("whitespace path accepted")
+	}
+	dir := t.TempDir()
+	// Passing the directory itself to OpenStore should fail when SQLite
+	// or our chmod tries to operate on it as a file.
+	if _, err := OpenStore(context.Background(), dir); err == nil {
+		t.Fatal("directory-as-db-path accepted")
+	}
+}
+
+// TestStore_ListWithExplicitFilters exercises every WHERE-clause
+// branch in List so the conditional query builder is fully covered.
+func TestStore_ListWithExplicitFilters(t *testing.T) {
+	handler, store, priv := testHandler(t)
+	payload := []byte(`{"events":[{"m":"x"}]}`)
+	env := signedEnvelope(t, "batch-filters", 1, 1, payload, priv)
+	if resp := postBatch(t, handler, env, payload); resp.Code != http.StatusAccepted {
+		t.Fatalf("post = %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	cases := []struct {
+		name string
+		q    Query
+		want int
+	}{
+		{"all_filters", Query{OrgID: "org-test", FleetID: "fleet-prod", InstanceID: "instance-a", BatchID: "batch-filters"}, 1},
+		{"namespace_only", Query{OrgID: "org-test", FleetID: "fleet-prod", InstanceID: "instance-a"}, 1},
+		{"wrong_batch", Query{OrgID: "org-test", FleetID: "fleet-prod", InstanceID: "instance-a", BatchID: "missing"}, 0},
+		{"wrong_org", Query{OrgID: "globex", FleetID: "fleet-prod", InstanceID: "instance-a"}, 0},
+		{"only_fleet", Query{FleetID: "fleet-prod"}, 1},
+		{"only_instance", Query{InstanceID: "instance-a"}, 1},
+		{"unfiltered", Query{}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := store.List(context.Background(), tc.q)
+			if err != nil {
+				t.Fatalf("List err = %v", err)
+			}
+			if len(got) != tc.want {
+				t.Fatalf("len(List) = %d, want %d (%+v)", len(got), tc.want, got)
+			}
+		})
+	}
+}
+
+// TestStore_GetMissing covers the not-found branch (sql.ErrNoRows
+// mapped to ok=false) and the namespace-mismatch branch (same
+// batch id but different org).
+func TestStore_GetMissing(t *testing.T) {
+	handler, store, priv := testHandler(t)
+	payload := []byte(`{"events":[{"m":"x"}]}`)
+	env := signedEnvelope(t, "batch-get", 1, 1, payload, priv)
+	if resp := postBatch(t, handler, env, payload); resp.Code != http.StatusAccepted {
+		t.Fatalf("post = %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	_, ok, err := store.Get(context.Background(), "wrong-org", "fleet-prod", "instance-a", "batch-get")
+	if err != nil {
+		t.Fatalf("Get err = %v", err)
+	}
+	if ok {
+		t.Fatal("Get returned ok for mismatched org")
+	}
+
+	_, ok, err = store.Get(context.Background(), "org-test", "fleet-prod", "instance-a", "nope")
+	if err != nil {
+		t.Fatalf("Get err = %v", err)
+	}
+	if ok {
+		t.Fatal("Get returned ok for unknown batch")
+	}
+}
+
+// TestStore_OperationsAfterClose covers the error branches of List,
+// Get, and Put when the underlying DB has been closed. Mirrors what
+// happens during an unclean shutdown race.
+func TestStore_OperationsAfterClose(t *testing.T) {
+	store, err := OpenStore(context.Background(), t.TempDir()+"/sink.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.List(context.Background(), Query{OrgID: "any", FleetID: "f", InstanceID: "i"}); err == nil {
+		t.Fatal("List on closed store accepted")
+	}
+	if _, _, err := store.Get(context.Background(), "o", "f", "i", "b"); err == nil {
+		t.Fatal("Get on closed store accepted")
+	}
+}
+
+// TestHandler_StoreErrorsFromGetEndpoints exercises the handleList and
+// handleGet 500 branches: closing the store after handler construction
+// makes any DB call return an error, which the handlers must convert
+// to InternalServerError rather than leaking sql package details.
+func TestHandler_StoreErrorsFromGetEndpoints(t *testing.T) {
+	handler, store, _ := testHandler(t)
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	listReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		AuditBatchesPath+"?org_id=org-test&fleet_id=fleet-prod&instance_id=instance-a", nil)
+	listResp := httptest.NewRecorder()
+	handler.ServeHTTP(listResp, listReq)
+	if listResp.Code != http.StatusInternalServerError {
+		t.Fatalf("list after close: status = %d body=%s", listResp.Code, listResp.Body.String())
+	}
+
+	getReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		AuditBatchesPath+"/any-id?org_id=org-test&fleet_id=fleet-prod&instance_id=instance-a", nil)
+	getResp := httptest.NewRecorder()
+	handler.ServeHTTP(getResp, getReq)
+	if getResp.Code != http.StatusInternalServerError {
+		t.Fatalf("get after close: status = %d body=%s", getResp.Code, getResp.Body.String())
+	}
+}
+
+// TestHandler_IngestStoreErrorMapped covers the Put error path: closing
+// the store after handler construction causes Put to fail, which the
+// handler must convert via statusForError. This walks every line of
+// handleIngest after VerifySignaturesAt.
+func TestHandler_IngestStoreErrorMapped(t *testing.T) {
+	handler, store, priv := testHandler(t)
+	payload := []byte(`{"events":[{"m":"clean"}]}`)
+	env := signedEnvelope(t, "batch-store-err", 1, 1, payload, priv)
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	resp := postBatch(t, handler, env, payload)
+	if resp.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d body=%s want 500", resp.Code, resp.Body.String())
+	}
+}
+
+// TestHandler_RejectsMethodOnSubpath covers the path / method routing
+// fallthroughs that aren't hit by the simpler routing table test.
+func TestHandler_RejectsMethodOnSubpath(t *testing.T) {
+	handler, _, _ := testHandler(t)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
+		AuditBatchesPath+"/some-id?org_id=o&fleet_id=f&instance_id=i", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("DELETE on subpath status = %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+// TestHandler_RejectsTrailingSlashGet covers the empty-batch-id branch
+// when a client sends GET .../audit/batches/ (trailing slash, nothing
+// after). Without the explicit check this would fall into handleGet
+// with an empty id and may surface a misleading 404 from the store.
+func TestHandler_RejectsTrailingSlashGet(t *testing.T) {
+	handler, _, _ := testHandler(t)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		AuditBatchesPath+"/?org_id=o&fleet_id=f&instance_id=i", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("trailing-slash get status = %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+// TestHandler_RejectsNestedBatchID covers the slash-in-id rejection
+// inside handleGet (path traversal-shaped input).
+func TestHandler_RejectsNestedBatchID(t *testing.T) {
+	handler, _, _ := testHandler(t)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		AuditBatchesPath+"/foo/bar?org_id=o&fleet_id=f&instance_id=i", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("nested-id get status = %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+// TestStatusForError covers the new error mappings (Unauthorized,
+// KeyBindingViolated) added in this change. The default case is
+// covered elsewhere.
+func TestStatusForError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"unauthorized", ErrUnauthorized, http.StatusUnauthorized},
+		{"binding", ErrKeyBindingViolated, http.StatusForbidden},
+		{"conflict", ErrBatchConflict, http.StatusConflict},
+		{"fork", ErrForkDetected, http.StatusConflict},
+		{"too_large", ErrRequestTooLarge, http.StatusRequestEntityTooLarge},
+		{"bad_request", ErrInvalidRequestBody, http.StatusBadRequest},
+		{"wrapped_unauthorized", errors.New("wrap"), http.StatusInternalServerError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := statusForError(tc.err); got != tc.want {
+				t.Fatalf("statusForError(%v) = %d, want %d", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/fleet/sink/ingest_auth_test.go
+++ b/internal/fleet/sink/ingest_auth_test.go
@@ -6,10 +6,11 @@ package sink
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -303,6 +304,27 @@ func TestStore_RejectsSymlinkDBPath(t *testing.T) {
 	}
 	if _, err := OpenStore(context.Background(), link); err == nil {
 		t.Fatal("OpenStore accepted symlink DB path")
+	}
+}
+
+func TestStore_UsesResolvedParentPath(t *testing.T) {
+	dir := t.TempDir()
+	realParent := filepath.Join(dir, "real")
+	if err := os.Mkdir(realParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkParent := filepath.Join(dir, "link")
+	if err := os.Symlink(realParent, linkParent); err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenStore(context.Background(), filepath.Join(linkParent, "sink.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if _, err := os.Stat(filepath.Join(realParent, "sink.db")); err != nil {
+		t.Fatalf("resolved parent DB missing: %v", err)
 	}
 }
 
@@ -671,7 +693,7 @@ func TestStatusForError(t *testing.T) {
 		{"fork", ErrForkDetected, http.StatusConflict},
 		{"too_large", ErrRequestTooLarge, http.StatusRequestEntityTooLarge},
 		{"bad_request", ErrInvalidRequestBody, http.StatusBadRequest},
-		{"wrapped_unauthorized", errors.New("wrap"), http.StatusInternalServerError},
+		{"wrapped_unauthorized", fmt.Errorf("wrap: %w", ErrUnauthorized), http.StatusUnauthorized},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/fleet/sink/ingest_auth_test.go
+++ b/internal/fleet/sink/ingest_auth_test.go
@@ -310,7 +310,7 @@ func TestStore_RejectsSymlinkDBPath(t *testing.T) {
 func TestStore_UsesResolvedParentPath(t *testing.T) {
 	dir := t.TempDir()
 	realParent := filepath.Join(dir, "real")
-	if err := os.Mkdir(realParent, 0o700); err != nil {
+	if err := os.Mkdir(realParent, 0o750); err != nil {
 		t.Fatal(err)
 	}
 	linkParent := filepath.Join(dir, "link")

--- a/internal/fleet/sink/ingest_test.go
+++ b/internal/fleet/sink/ingest_test.go
@@ -1,0 +1,378 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package sink
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/conductor/auditbatcher"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+var sinkTestNow = time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+
+func TestHandler_AcceptsSignedBatchAndListsMetadata(t *testing.T) {
+	handler, _, priv := testHandler(t)
+	payload := []byte(`{"events":[{"message":"clean audit event"}]}`)
+	env := signedEnvelope(t, "batch-1", 1, 1, payload, priv)
+
+	resp := postBatch(t, handler, env, payload)
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	duplicate := postBatch(t, handler, env, payload)
+	if duplicate.Code != http.StatusAccepted {
+		t.Fatalf("duplicate status = %d body=%s", duplicate.Code, duplicate.Body.String())
+	}
+	if !strings.Contains(duplicate.Body.String(), `"status":"duplicate"`) {
+		t.Fatalf("duplicate response missing duplicate status: %s", duplicate.Body.String())
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, AuditBatchesPath+"?org_id=org-test&fleet_id=fleet-prod&instance_id=instance-a", nil)
+	list := httptest.NewRecorder()
+	handler.ServeHTTP(list, req)
+	if list.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s", list.Code, list.Body.String())
+	}
+	if strings.Contains(list.Body.String(), "clean audit event") {
+		t.Fatalf("query response leaked raw payload: %s", list.Body.String())
+	}
+	if !strings.Contains(list.Body.String(), `"batch_id":"batch-1"`) {
+		t.Fatalf("query response missing batch metadata: %s", list.Body.String())
+	}
+}
+
+func TestHandler_GetBatchMetadata(t *testing.T) {
+	handler, _, priv := testHandler(t)
+	payload := []byte(`{"events":[{"message":"clean audit event"}]}`)
+	env := signedEnvelope(t, "batch-1", 1, 1, payload, priv)
+	if resp := postBatch(t, handler, env, payload); resp.Code != http.StatusAccepted {
+		t.Fatalf("post status = %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, AuditBatchesPath+"/batch-1?org_id=org-test&fleet_id=fleet-prod&instance_id=instance-a", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("get status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), `"batch_id":"batch-1"`) {
+		t.Fatalf("get response missing batch metadata: %s", resp.Body.String())
+	}
+	if strings.Contains(resp.Body.String(), "clean audit event") {
+		t.Fatalf("get response leaked raw payload: %s", resp.Body.String())
+	}
+}
+
+func TestHandler_RoutesHealthAndErrors(t *testing.T) {
+	handler, _, _ := testHandler(t)
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+		want   int
+	}{
+		{"health", http.MethodGet, "/health", http.StatusOK},
+		{"method", http.MethodDelete, AuditBatchesPath, http.StatusMethodNotAllowed},
+		{"not_found", http.MethodGet, "/missing", http.StatusNotFound},
+		{"get_missing_namespace", http.MethodGet, AuditBatchesPath + "/batch-1", http.StatusBadRequest},
+		{"get_missing_batch", http.MethodGet, AuditBatchesPath + "/missing?org_id=org-test&fleet_id=fleet-prod&instance_id=instance-a", http.StatusNotFound},
+		{"bad_limit", http.MethodGet, AuditBatchesPath + "?org_id=org-test&fleet_id=fleet-prod&instance_id=instance-a&limit=not-int", http.StatusBadRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), tc.method, tc.path, nil)
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			if resp.Code != tc.want {
+				t.Fatalf("status = %d body=%s want=%d", resp.Code, resp.Body.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestHandler_RejectsUnsupportedContentType(t *testing.T) {
+	handler, _, _ := testHandler(t)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, AuditBatchesPath, strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "text/plain")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("status = %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestHandler_RejectsStrictWireFormatDrift(t *testing.T) {
+	handler, _, priv := testHandler(t)
+	payload := []byte(`{"events":[{"message":"clean audit event"}]}`)
+	env := signedEnvelope(t, "batch-1", 1, 1, payload, priv)
+	body, err := json.Marshal(map[string]any{
+		"envelope": env,
+		"payload":  payload,
+		"extra":    "drift",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, AuditBatchesPath, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestHandler_RejectsMalformedBodies(t *testing.T) {
+	handler, _, priv := testHandler(t)
+	payload := []byte(`{"events":[{"message":"clean audit event"}]}`)
+	env := signedEnvelope(t, "batch-1", 1, 1, payload, priv)
+	envelopeRaw, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		body string
+		want int
+	}{
+		{"trailing_top_level", `{"envelope":` + string(envelopeRaw) + `,"payload":"e30="}{}`, http.StatusBadRequest},
+		{"unknown_envelope_field", `{"envelope":{"schema_version":1,"extra":true},"payload":"e30="}`, http.StatusBadRequest},
+		{"oversize", `{"envelope":{},"payload":"` + strings.Repeat("A", 128) + `"}`, http.StatusRequestEntityTooLarge},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, AuditBatchesPath, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			if tc.name == "oversize" {
+				handler.maxRequestBytes = 32
+				t.Cleanup(func() { handler.maxRequestBytes = DefaultMaxRequestBytes })
+			}
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			if resp.Code != tc.want {
+				t.Fatalf("status = %d body=%s want=%d", resp.Code, resp.Body.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestHandler_RejectsOffRosterSignature(t *testing.T) {
+	handler, _, _ := testHandler(t)
+	_, roguePriv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`{"events":[{"message":"clean audit event"}]}`)
+	env := signedEnvelope(t, "batch-1", 1, 1, payload, roguePriv)
+
+	resp := postBatch(t, handler, env, payload)
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestHandler_DLPBeforeStore(t *testing.T) {
+	handler, store, priv := testHandler(t)
+	payload := []byte(`{"events":[{"message":"sk-proj-abcdefghijklmnopqrstuvwxyz123456"}]}`)
+	env := signedEnvelope(t, "batch-1", 1, 1, payload, priv)
+
+	resp := postBatch(t, handler, env, payload)
+	if resp.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	got, err := store.List(context.Background(), Query{OrgID: "org-test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("DLP-rejected payload was stored: %+v", got)
+	}
+}
+
+func TestHandler_DetectsSequenceFork(t *testing.T) {
+	handler, _, priv := testHandler(t)
+	firstPayload := []byte(`{"events":[{"message":"first"}]}`)
+	first := signedEnvelope(t, "batch-1", 1, 2, firstPayload, priv)
+	if resp := postBatch(t, handler, first, firstPayload); resp.Code != http.StatusAccepted {
+		t.Fatalf("first status = %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	forkPayload := []byte(`{"events":[{"message":"fork"}]}`)
+	fork := signedEnvelope(t, "batch-2", 2, 3, forkPayload, priv)
+	resp := postBatch(t, handler, fork, forkPayload)
+	if resp.Code != http.StatusConflict {
+		t.Fatalf("fork status = %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestHandler_DetectsBatchIDConflict(t *testing.T) {
+	handler, _, priv := testHandler(t)
+	firstPayload := []byte(`{"events":[{"message":"first"}]}`)
+	first := signedEnvelope(t, "batch-1", 1, 1, firstPayload, priv)
+	if resp := postBatch(t, handler, first, firstPayload); resp.Code != http.StatusAccepted {
+		t.Fatalf("first status = %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	secondPayload := []byte(`{"events":[{"message":"second"}]}`)
+	second := signedEnvelope(t, "batch-1", 3, 3, secondPayload, priv)
+	resp := postBatch(t, handler, second, secondPayload)
+	if resp.Code != http.StatusConflict {
+		t.Fatalf("conflict status = %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestNewHandlerRequiresDependencies(t *testing.T) {
+	_, store, _ := testHandler(t)
+	for _, tc := range []struct {
+		name string
+		opts Options
+		want error
+	}{
+		{"store", Options{}, ErrMissingStore},
+		{"resolver", Options{Store: store}, ErrMissingResolver},
+		{"dlp", Options{Store: store, Resolver: staticResolver(ed25519.PublicKey(make([]byte, ed25519.PublicKeySize)))}, ErrMissingDLPScanner},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewHandler(tc.opts)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("NewHandler() err = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestStoreOpenAndQueryEdgeCases(t *testing.T) {
+	if _, err := OpenStore(context.Background(), ""); err == nil {
+		t.Fatal("OpenStore accepted empty path")
+	}
+	var missing *Store
+	if _, err := missing.Put(context.Background(), acceptedBatch{}, nil); !errors.Is(err, ErrMissingStore) {
+		t.Fatalf("nil store Put err = %v, want ErrMissingStore", err)
+	}
+	if got := normalizeLimit(maxQueryLimit + 1); got != maxQueryLimit {
+		t.Fatalf("normalizeLimit cap = %d, want %d", got, maxQueryLimit)
+	}
+	if _, err := parseLimit("bad"); !errors.Is(err, ErrInvalidRequestBody) {
+		t.Fatalf("parseLimit bad err = %v", err)
+	}
+	if _, err := parseUintField("field", "not-uint"); err == nil {
+		t.Fatal("parseUintField accepted invalid value")
+	}
+	if got := dlpPatternNames([]scanner.TextDLPMatch{
+		{PatternName: "A"},
+		{PatternName: "A"},
+		{},
+		{PatternName: "B"},
+	}); strings.Join(got, ",") != "A,B" {
+		t.Fatalf("dlpPatternNames = %v, want A,B", got)
+	}
+	if statusForError(errors.New("other")) != http.StatusInternalServerError {
+		t.Fatal("statusForError default did not return 500")
+	}
+}
+
+func testHandler(t *testing.T) (*Handler, *Store, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenStore(context.Background(), t.TempDir()+"/sink.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	handler, err := NewHandler(Options{
+		Store:      store,
+		Resolver:   staticResolver(pub),
+		DLPScanner: scanner.New(config.Defaults()),
+		Now:        func() time.Time { return sinkTestNow },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return handler, store, priv
+}
+
+func postBatch(t *testing.T, handler *Handler, env conductor.AuditBatchEnvelope, payload []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(uploadRequest{Envelope: env, Payload: payload})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, AuditBatchesPath, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	return resp
+}
+
+func signedEnvelope(t *testing.T, batchID string, seqStart, seqEnd uint64, payload []byte, priv ed25519.PrivateKey) conductor.AuditBatchEnvelope {
+	t.Helper()
+	sum := sha256.Sum256(payload)
+	env := conductor.AuditBatchEnvelope{
+		SchemaVersion:      conductor.SchemaVersion,
+		BatchID:            batchID,
+		OrgID:              "org-test",
+		FleetID:            "fleet-prod",
+		InstanceID:         "instance-a",
+		AuditSchemaVersion: 2,
+		EmittedAt:          sinkTestNow,
+		SeqStart:           seqStart,
+		SeqEnd:             seqEnd,
+		EventCount:         1,
+		PayloadSHA256:      hex.EncodeToString(sum[:]),
+		PayloadBytes:       uint64(len(payload)),
+		Chain: conductor.EvidenceChain{
+			EntryVersion:           2,
+			SegmentID:              "segment-" + batchID,
+			SeqStart:               seqStart,
+			SeqEnd:                 seqEnd,
+			SegmentHeadHash:        hashHex("head-" + batchID),
+			SegmentTailHash:        hashHex("tail-" + batchID + string(payload)),
+			CheckpointSeq:          seqEnd,
+			CheckpointHash:         hashHex("checkpoint-" + batchID),
+			CheckpointSignature:    "ed25519:" + strings.Repeat("aa", ed25519.SignatureSize),
+			CheckpointSignerKeyID:  "checkpoint-signer",
+			FollowerRecorderKeyID:  "recorder-key",
+			FollowerRecorderPubHex: strings.Repeat("11", ed25519.PublicKeySize),
+		},
+	}
+	signed, err := auditbatcher.SignEnvelope(env, "audit-signer", priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signed
+}
+
+func staticResolver(pub ed25519.PublicKey) conductor.SignatureKeyResolver {
+	return func(signerKeyID string) (conductor.SignatureKey, error) {
+		if signerKeyID != "audit-signer" {
+			return conductor.SignatureKey{}, conductor.ErrInvalidSignature
+		}
+		return conductor.SignatureKey{PublicKey: pub, KeyPurpose: signing.PurposeAuditBatchSigning}, nil
+	}
+}
+
+func hashHex(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/fleet/sink/ingest_test.go
+++ b/internal/fleet/sink/ingest_test.go
@@ -190,8 +190,25 @@ func TestHandler_RejectsOffRosterSignature(t *testing.T) {
 }
 
 func TestHandler_DLPBeforeStore(t *testing.T) {
-	handler, store, priv := testHandler(t)
-	payload := []byte(`{"events":[{"message":"sk-proj-abcdefghijklmnopqrstuvwxyz123456"}]}`)
+	pub, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenStore(context.Background(), t.TempDir()+"/sink.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	handler, err := NewHandler(Options{
+		Store:      store,
+		Resolver:   staticResolver(pub),
+		DLPScanner: containsDLPScanner("fleet-sink-test-secret"),
+		Now:        func() time.Time { return sinkTestNow },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`{"events":[{"message":"fleet-sink-test-secret"}]}`)
 	env := signedEnvelope(t, "batch-1", 1, 1, payload, priv)
 
 	resp := postBatch(t, handler, env, payload)
@@ -204,6 +221,21 @@ func TestHandler_DLPBeforeStore(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Fatalf("DLP-rejected payload was stored: %+v", got)
+	}
+}
+
+type containsDLPScanner string
+
+func (s containsDLPScanner) ScanTextForDLP(_ context.Context, text string) scanner.TextDLPResult {
+	if !strings.Contains(text, string(s)) {
+		return scanner.TextDLPResult{Clean: true}
+	}
+	return scanner.TextDLPResult{
+		Clean: false,
+		Matches: []scanner.TextDLPMatch{{
+			PatternName: "Fleet Sink Test Secret",
+			Severity:    config.SeverityCritical,
+		}},
 	}
 }
 

--- a/internal/fleet/sink/query.go
+++ b/internal/fleet/sink/query.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package sink
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func parseLimit(raw string) (int, error) {
+	if strings.TrimSpace(raw) == "" {
+		return defaultQueryLimit, nil
+	}
+	limit, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%w: invalid limit", ErrInvalidRequestBody)
+	}
+	return normalizeLimit(limit), nil
+}

--- a/internal/fleet/sink/storage.go
+++ b/internal/fleet/sink/storage.go
@@ -44,11 +44,12 @@ func OpenStore(ctx context.Context, path string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(clean), 0o700); err != nil {
 		return nil, fmt.Errorf("create fleet sink store parent: %w", err)
 	}
-	if err := ensureStoreFile(clean); err != nil {
+	storePath, err := ensureStoreFile(clean)
+	if err != nil {
 		return nil, err
 	}
 
-	db, err := sql.Open("sqlite", clean)
+	db, err := sql.Open("sqlite", storePath)
 	if err != nil {
 		return nil, fmt.Errorf("open fleet sink store: %w", err)
 	}
@@ -71,30 +72,64 @@ func OpenStore(ctx context.Context, path string) (*Store, error) {
 	// SQLite may create sidecar files for WAL mode. Audit payloads
 	// contain raw evidence, so keep the database and any sidecars
 	// owner-only even under a permissive umask.
-	if err := chmodStoreFiles(clean); err != nil {
+	if err := chmodStoreFiles(storePath); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
 	return s, nil
 }
 
-func ensureStoreFile(path string) error {
-	if info, err := os.Lstat(path); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("fleet sink store path is a symlink: %s", path)
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("stat fleet sink store: %w", err)
-	}
-	//nolint:gosec // path is explicit operator configuration; caller cleaned it and existing symlinks are rejected above.
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+func ensureStoreFile(path string) (string, error) {
+	clean := filepath.Clean(path)
+	parent, err := filepath.EvalSymlinks(filepath.Dir(clean))
 	if err != nil {
-		return fmt.Errorf("create fleet sink store: %w", err)
+		return "", fmt.Errorf("resolve fleet sink store parent: %w", err)
 	}
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("close fleet sink store: %w", err)
+	storePath := filepath.Join(parent, filepath.Base(clean))
+	rel, err := filepath.Rel(parent, storePath)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
+		if err != nil {
+			return "", fmt.Errorf("validate fleet sink store containment: %w", err)
+		}
+		return "", fmt.Errorf("fleet sink store path escapes parent: %s", clean)
 	}
-	return chmodStorePath(path)
+
+	f, err := openStoreFileNoFollow(storePath, true)
+	if errors.Is(err, os.ErrExist) {
+		if info, statErr := os.Lstat(storePath); statErr == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return "", fmt.Errorf("fleet sink store path is a symlink: %s", storePath)
+			}
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return "", fmt.Errorf("stat fleet sink store: %w", statErr)
+		}
+		f, err = openStoreFileNoFollow(storePath, false)
+	}
+	if err != nil {
+		return "", fmt.Errorf("create fleet sink store: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return "", fmt.Errorf("stat opened fleet sink store: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("fleet sink store path is not a regular file: %s", storePath)
+	}
+	if err := chmodStorePath(storePath); err != nil {
+		return "", err
+	}
+	return storePath, nil
+}
+
+func openStoreFileNoFollow(path string, create bool) (*os.File, error) {
+	flags := os.O_RDWR | storeNoFollowFlag
+	if create {
+		flags |= os.O_CREATE | os.O_EXCL
+	}
+	//nolint:gosec // path is explicit operator configuration; parent is resolved and final component is opened with O_NOFOLLOW where available.
+	return os.OpenFile(path, flags, 0o600)
 }
 
 func chmodStoreFiles(path string) error {

--- a/internal/fleet/sink/storage.go
+++ b/internal/fleet/sink/storage.go
@@ -1,0 +1,427 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package sink
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+
+	// Pure-Go SQLite driver.
+	_ "modernc.org/sqlite"
+)
+
+const (
+	defaultQueryLimit = 100
+	maxQueryLimit     = 1000
+	// uintTextWidth zero-pads stored uint64s so SQLite's lexicographic
+	// TEXT comparison matches numeric order across different digit
+	// counts. Without padding, "9" > "100" lexically — that wrecks
+	// range queries on the namespace_sequence index and makes
+	// detectFork unsound the moment we use SQL overlap checks.
+	uintTextWidth = 20
+)
+
+type Store struct {
+	db *sql.DB
+}
+
+func OpenStore(ctx context.Context, path string) (*Store, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("fleet sink store path is required")
+	}
+	clean := filepath.Clean(path)
+	if err := os.MkdirAll(filepath.Dir(clean), 0o700); err != nil {
+		return nil, fmt.Errorf("create fleet sink store parent: %w", err)
+	}
+	if err := ensureStoreFile(clean); err != nil {
+		return nil, err
+	}
+
+	db, err := sql.Open("sqlite", clean)
+	if err != nil {
+		return nil, fmt.Errorf("open fleet sink store: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.ExecContext(ctx, "PRAGMA journal_mode=WAL"); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("set WAL mode: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, "PRAGMA foreign_keys=ON"); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("enable foreign keys: %w", err)
+	}
+
+	s := &Store{db: db}
+	if err := s.migrate(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	// SQLite may create sidecar files for WAL mode. Audit payloads
+	// contain raw evidence, so keep the database and any sidecars
+	// owner-only even under a permissive umask.
+	if err := chmodStoreFiles(clean); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return s, nil
+}
+
+func ensureStoreFile(path string) error {
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("fleet sink store path is a symlink: %s", path)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat fleet sink store: %w", err)
+	}
+	//nolint:gosec // path is explicit operator configuration; caller cleaned it and existing symlinks are rejected above.
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return fmt.Errorf("create fleet sink store: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close fleet sink store: %w", err)
+	}
+	return chmodStorePath(path)
+}
+
+func chmodStoreFiles(path string) error {
+	for _, candidate := range []string{path, path + "-wal", path + "-shm"} {
+		if err := chmodStorePath(candidate); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func chmodStorePath(path string) error {
+	if err := os.Chmod(path, 0o600); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("chmod fleet sink store %s: %w", path, err)
+	}
+	return nil
+}
+
+func (s *Store) Close() error {
+	return s.db.Close()
+}
+
+func (s *Store) migrate(ctx context.Context) error {
+	const ddl = `
+	CREATE TABLE IF NOT EXISTS audit_batches (
+		org_id               TEXT NOT NULL,
+		fleet_id             TEXT NOT NULL,
+		instance_id          TEXT NOT NULL,
+		batch_id             TEXT NOT NULL,
+		audit_schema_version INTEGER NOT NULL,
+		seq_start            TEXT NOT NULL,
+		seq_end              TEXT NOT NULL,
+		event_count          TEXT NOT NULL,
+		payload_sha256       TEXT NOT NULL,
+		payload_bytes        TEXT NOT NULL,
+		canonical_hash       TEXT NOT NULL,
+		segment_tail_hash    TEXT NOT NULL,
+		dropped_count        TEXT NOT NULL,
+		emitted_at           DATETIME NOT NULL,
+		received_at          DATETIME NOT NULL,
+		signature_key_ids    TEXT NOT NULL,
+		informational_dlp    TEXT NOT NULL DEFAULT '[]',
+		envelope_json        BLOB NOT NULL,
+		payload_blob         BLOB NOT NULL,
+		PRIMARY KEY (org_id, fleet_id, instance_id, batch_id)
+	);
+	CREATE INDEX IF NOT EXISTS idx_audit_batches_namespace_received
+		ON audit_batches(org_id, fleet_id, instance_id, received_at DESC);
+	CREATE INDEX IF NOT EXISTS idx_audit_batches_namespace_sequence
+		ON audit_batches(org_id, fleet_id, instance_id, seq_start, seq_end);
+	CREATE INDEX IF NOT EXISTS idx_audit_batches_batch_id
+		ON audit_batches(batch_id);
+	`
+	if _, err := s.db.ExecContext(ctx, ddl); err != nil {
+		return fmt.Errorf("migrate fleet sink store: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) Put(ctx context.Context, batch acceptedBatch, informational []string) (PutResult, error) {
+	if s == nil || s.db == nil {
+		return PutResult{}, ErrMissingStore
+	}
+	if err := batch.Envelope.Validate(); err != nil {
+		return PutResult{}, fmt.Errorf("validate audit batch before store: %w", err)
+	}
+	envelopeJSON, err := json.Marshal(batch.Envelope)
+	if err != nil {
+		return PutResult{}, fmt.Errorf("marshal audit batch envelope: %w", err)
+	}
+	keyIDsJSON, err := json.Marshal(signatureKeyIDs(batch.Envelope.Signatures))
+	if err != nil {
+		return PutResult{}, fmt.Errorf("marshal signature key ids: %w", err)
+	}
+	informationalJSON, err := json.Marshal(informational)
+	if err != nil {
+		return PutResult{}, fmt.Errorf("marshal informational DLP labels: %w", err)
+	}
+	if batch.ReceivedAt.IsZero() {
+		batch.ReceivedAt = time.Now().UTC()
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return PutResult{}, fmt.Errorf("begin fleet sink store transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var existingHash, existingPayloadHash string
+	err = tx.QueryRowContext(ctx, `
+		SELECT canonical_hash, payload_sha256
+		FROM audit_batches
+		WHERE org_id = ? AND fleet_id = ? AND instance_id = ? AND batch_id = ?
+	`, batch.Envelope.OrgID, batch.Envelope.FleetID, batch.Envelope.InstanceID, batch.Envelope.BatchID).
+		Scan(&existingHash, &existingPayloadHash)
+	switch {
+	case err == nil:
+		if existingHash == batch.CanonicalHash && strings.EqualFold(existingPayloadHash, batch.Envelope.PayloadSHA256) {
+			summary, getErr := summaryByKey(ctx, tx, batch.Envelope.OrgID, batch.Envelope.FleetID, batch.Envelope.InstanceID, batch.Envelope.BatchID)
+			if getErr != nil {
+				return PutResult{}, getErr
+			}
+			if commitErr := tx.Commit(); commitErr != nil {
+				return PutResult{}, fmt.Errorf("commit duplicate fleet sink transaction: %w", commitErr)
+			}
+			return PutResult{Summary: summary, Duplicate: true}, nil
+		}
+		return PutResult{}, ErrBatchConflict
+	case !errors.Is(err, sql.ErrNoRows):
+		return PutResult{}, fmt.Errorf("check duplicate audit batch: %w", err)
+	}
+
+	if err := detectFork(ctx, tx, batch.Envelope); err != nil {
+		return PutResult{}, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO audit_batches (
+			org_id, fleet_id, instance_id, batch_id, audit_schema_version,
+			seq_start, seq_end, event_count, payload_sha256, payload_bytes,
+			canonical_hash, segment_tail_hash, dropped_count, emitted_at,
+			received_at, signature_key_ids, informational_dlp, envelope_json, payload_blob
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, batch.Envelope.OrgID, batch.Envelope.FleetID, batch.Envelope.InstanceID, batch.Envelope.BatchID,
+		batch.Envelope.AuditSchemaVersion, formatUint(batch.Envelope.SeqStart), formatUint(batch.Envelope.SeqEnd),
+		formatUint(batch.Envelope.EventCount), batch.Envelope.PayloadSHA256, formatUint(batch.Envelope.PayloadBytes),
+		batch.CanonicalHash, batch.Envelope.Chain.SegmentTailHash, formatUint(batch.Envelope.Dropped.Count),
+		batch.Envelope.EmittedAt.UTC(), batch.ReceivedAt.UTC(), string(keyIDsJSON), string(informationalJSON),
+		envelopeJSON, batch.Payload); err != nil {
+		return PutResult{}, fmt.Errorf("insert audit batch: %w", err)
+	}
+
+	summary, err := summaryByKey(ctx, tx, batch.Envelope.OrgID, batch.Envelope.FleetID, batch.Envelope.InstanceID, batch.Envelope.BatchID)
+	if err != nil {
+		return PutResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return PutResult{}, fmt.Errorf("commit fleet sink store transaction: %w", err)
+	}
+	return PutResult{Summary: summary}, nil
+}
+
+func (s *Store) List(ctx context.Context, q Query) ([]BatchSummary, error) {
+	limit := normalizeLimit(q.Limit)
+	query := `
+		SELECT batch_id, org_id, fleet_id, instance_id, audit_schema_version,
+			seq_start, seq_end, event_count, payload_sha256, payload_bytes,
+			canonical_hash, segment_tail_hash, dropped_count, emitted_at,
+			received_at, signature_key_ids, informational_dlp
+		FROM audit_batches
+		WHERE 1 = 1`
+	args := make([]any, 0, 5)
+	if q.OrgID != "" {
+		query += " AND org_id = ?"
+		args = append(args, q.OrgID)
+	}
+	if q.FleetID != "" {
+		query += " AND fleet_id = ?"
+		args = append(args, q.FleetID)
+	}
+	if q.InstanceID != "" {
+		query += " AND instance_id = ?"
+		args = append(args, q.InstanceID)
+	}
+	if q.BatchID != "" {
+		query += " AND batch_id = ?"
+		args = append(args, q.BatchID)
+	}
+	query += " ORDER BY received_at DESC, org_id, fleet_id, instance_id, seq_start DESC LIMIT ?"
+	args = append(args, limit)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query audit batches: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []BatchSummary
+	for rows.Next() {
+		summary, err := scanSummary(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("scan audit batch rows: %w", err)
+	}
+	return out, nil
+}
+
+func (s *Store) Get(ctx context.Context, orgID, fleetID, instanceID, batchID string) (BatchSummary, bool, error) {
+	summary, err := summaryByKey(ctx, s.db, orgID, fleetID, instanceID, batchID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return BatchSummary{}, false, nil
+	}
+	if err != nil {
+		return BatchSummary{}, false, err
+	}
+	return summary, true, nil
+}
+
+type summaryScanner interface {
+	Scan(...any) error
+}
+
+type summaryQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func summaryByKey(ctx context.Context, q summaryQueryer, orgID, fleetID, instanceID, batchID string) (BatchSummary, error) {
+	return scanSummary(q.QueryRowContext(ctx, `
+		SELECT batch_id, org_id, fleet_id, instance_id, audit_schema_version,
+			seq_start, seq_end, event_count, payload_sha256, payload_bytes,
+			canonical_hash, segment_tail_hash, dropped_count, emitted_at,
+			received_at, signature_key_ids, informational_dlp
+		FROM audit_batches
+		WHERE org_id = ? AND fleet_id = ? AND instance_id = ? AND batch_id = ?
+	`, orgID, fleetID, instanceID, batchID))
+}
+
+func scanSummary(row summaryScanner) (BatchSummary, error) {
+	var summary BatchSummary
+	var seqStart, seqEnd, eventCount, payloadBytes, droppedCount string
+	var keyIDsJSON, informationalJSON string
+	if err := row.Scan(
+		&summary.BatchID, &summary.OrgID, &summary.FleetID, &summary.InstanceID,
+		&summary.AuditSchema, &seqStart, &seqEnd, &eventCount,
+		&summary.PayloadSHA256, &payloadBytes, &summary.CanonicalHash,
+		&summary.SegmentTailHash, &droppedCount, &summary.EmittedAt,
+		&summary.ReceivedAt, &keyIDsJSON, &informationalJSON,
+	); err != nil {
+		return BatchSummary{}, err
+	}
+	var err error
+	if summary.SeqStart, err = parseUintField("seq_start", seqStart); err != nil {
+		return BatchSummary{}, err
+	}
+	if summary.SeqEnd, err = parseUintField("seq_end", seqEnd); err != nil {
+		return BatchSummary{}, err
+	}
+	if summary.EventCount, err = parseUintField("event_count", eventCount); err != nil {
+		return BatchSummary{}, err
+	}
+	if summary.PayloadBytes, err = parseUintField("payload_bytes", payloadBytes); err != nil {
+		return BatchSummary{}, err
+	}
+	if summary.DroppedCount, err = parseUintField("dropped_count", droppedCount); err != nil {
+		return BatchSummary{}, err
+	}
+	if err := json.Unmarshal([]byte(keyIDsJSON), &summary.SignatureKeyIDs); err != nil {
+		return BatchSummary{}, fmt.Errorf("decode signature key ids: %w", err)
+	}
+	if err := json.Unmarshal([]byte(informationalJSON), &summary.InformationalDLP); err != nil {
+		return BatchSummary{}, fmt.Errorf("decode informational DLP labels: %w", err)
+	}
+	return summary, nil
+}
+
+// detectFork uses the namespace_sequence index to load only the rows
+// whose [seq_start, seq_end] overlaps the incoming envelope, then
+// unmarshals just those to call ForksWith for the (PayloadSHA256 OR
+// SegmentTailHash) equivocation check. Without the SQL-level overlap
+// filter this scans the entire namespace per ingest, which is an
+// unbounded DoS vector once an instance accumulates batches.
+func detectFork(ctx context.Context, tx *sql.Tx, env conductor.AuditBatchEnvelope) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT envelope_json
+		FROM audit_batches
+		WHERE org_id = ? AND fleet_id = ? AND instance_id = ?
+		  AND seq_end   >= ?
+		  AND seq_start <= ?
+	`, env.OrgID, env.FleetID, env.InstanceID,
+		formatUint(env.SeqStart), formatUint(env.SeqEnd))
+	if err != nil {
+		return fmt.Errorf("query audit sequence overlaps: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var raw []byte
+		if err := rows.Scan(&raw); err != nil {
+			return fmt.Errorf("scan audit overlap: %w", err)
+		}
+		var existing conductor.AuditBatchEnvelope
+		if err := json.Unmarshal(raw, &existing); err != nil {
+			return fmt.Errorf("decode stored audit envelope: %w", err)
+		}
+		if env.ForksWith(existing) {
+			return ErrForkDetected
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("scan audit overlaps: %w", err)
+	}
+	return nil
+}
+
+func signatureKeyIDs(signatures []conductor.SignatureProof) []string {
+	out := make([]string, 0, len(signatures))
+	for _, sig := range signatures {
+		out = append(out, sig.SignerKeyID)
+	}
+	return out
+}
+
+func normalizeLimit(limit int) int {
+	if limit <= 0 {
+		return defaultQueryLimit
+	}
+	if limit > maxQueryLimit {
+		return maxQueryLimit
+	}
+	return limit
+}
+
+func formatUint(value uint64) string {
+	return fmt.Sprintf("%0*d", uintTextWidth, value)
+}
+
+func parseUintField(name, value string) (uint64, error) {
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("decode %s: %w", name, err)
+	}
+	return parsed, nil
+}

--- a/internal/fleet/sink/storage_nofollow_unix.go
+++ b/internal/fleet/sink/storage_nofollow_unix.go
@@ -1,0 +1,10 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package sink
+
+import "syscall"
+
+const storeNoFollowFlag = syscall.O_NOFOLLOW

--- a/internal/fleet/sink/storage_nofollow_windows.go
+++ b/internal/fleet/sink/storage_nofollow_windows.go
@@ -1,0 +1,8 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package sink
+
+const storeNoFollowFlag = 0

--- a/internal/fleet/sink/types.go
+++ b/internal/fleet/sink/types.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package sink
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+const (
+	// AuditBatchesPath is the stable follower-to-sink ingest endpoint.
+	AuditBatchesPath = "/api/v1/conductor/audit/batches"
+
+	// DefaultMaxRequestBytes admits the maximum signed audit payload plus the
+	// envelope/signature wrapper while keeping hostile requests bounded.
+	DefaultMaxRequestBytes = int64(conductor.MaxAuditPayloadBytes + 128*1024)
+)
+
+var (
+	ErrMissingStore       = errors.New("fleet sink store is required")
+	ErrMissingResolver    = errors.New("fleet sink signature resolver is required")
+	ErrMissingDLPScanner  = errors.New("fleet sink DLP scanner is required")
+	ErrBatchConflict      = errors.New("fleet sink batch id conflict")
+	ErrForkDetected       = errors.New("fleet sink audit sequence fork detected")
+	ErrDLPRejected        = errors.New("fleet sink DLP rejected audit payload")
+	ErrUnsupportedMethod  = errors.New("fleet sink unsupported method")
+	ErrUnsupportedPath    = errors.New("fleet sink unsupported path")
+	ErrRequestTooLarge    = errors.New("fleet sink request body exceeds limit")
+	ErrInvalidRequestBody = errors.New("fleet sink invalid request body")
+	ErrUnauthorized       = errors.New("fleet sink unauthorized")
+	ErrKeyBindingViolated = errors.New("fleet sink signing key not authorized for batch namespace")
+)
+
+// DLPScanner is the scanner surface the sink needs before storing evidence.
+type DLPScanner interface {
+	ScanTextForDLP(ctx context.Context, text string) scanner.TextDLPResult
+}
+
+// KeyBinding constrains a trusted audit signing key to a specific
+// (OrgID, FleetID, InstanceID) namespace. Empty fields mean "any" —
+// e.g. a key bound only to OrgID="acme" can sign for any fleet or
+// instance within that org. A zero KeyBinding means the key is
+// unrestricted. Bindings are enforced AFTER signature verification:
+// a valid signature whose envelope namespace falls outside the
+// configured binding is rejected as unauthorized.
+type KeyBinding struct {
+	OrgID      string
+	FleetID    string
+	InstanceID string
+}
+
+// Matches reports whether env's namespace satisfies the binding.
+// A zero binding matches everything; otherwise each non-empty field
+// must equal the corresponding envelope field exactly.
+func (b KeyBinding) Matches(env conductor.AuditBatchEnvelope) bool {
+	if b.OrgID != "" && b.OrgID != env.OrgID {
+		return false
+	}
+	if b.FleetID != "" && b.FleetID != env.FleetID {
+		return false
+	}
+	if b.InstanceID != "" && b.InstanceID != env.InstanceID {
+		return false
+	}
+	return true
+}
+
+// IsZero reports whether the binding is unrestricted.
+func (b KeyBinding) IsZero() bool {
+	return b == KeyBinding{}
+}
+
+type Options struct {
+	Store           *Store
+	Resolver        conductor.SignatureKeyResolver
+	DLPScanner      DLPScanner
+	Now             func() time.Time
+	MaxSkew         time.Duration
+	MaxRequestBytes int64
+	// KeyBindings, when populated, restricts each trusted signer key
+	// id to a specific (org, fleet, instance) namespace. Map keys are
+	// SignerKeyID. Missing entries default to unrestricted — callers
+	// that want every key bound must populate the map for every id.
+	KeyBindings map[string]KeyBinding
+	// ReaderToken, when non-empty, requires a matching
+	// "Authorization: Bearer <token>" header on GET requests to the
+	// audit batches endpoints. Ingest is authenticated by the audit
+	// signature regardless. Empty disables bearer auth (acceptable
+	// only on loopback or behind mTLS).
+	ReaderToken string
+}
+
+type acceptedBatch struct {
+	Envelope      conductor.AuditBatchEnvelope `json:"envelope"`
+	Payload       []byte                       `json:"payload"`
+	ReceivedAt    time.Time                    `json:"received_at"`
+	CanonicalHash string                       `json:"canonical_hash"`
+}
+
+type BatchSummary struct {
+	BatchID          string    `json:"batch_id"`
+	OrgID            string    `json:"org_id"`
+	FleetID          string    `json:"fleet_id"`
+	InstanceID       string    `json:"instance_id"`
+	AuditSchema      int       `json:"audit_schema_version"`
+	SeqStart         uint64    `json:"seq_start"`
+	SeqEnd           uint64    `json:"seq_end"`
+	EventCount       uint64    `json:"event_count"`
+	PayloadSHA256    string    `json:"payload_sha256"`
+	PayloadBytes     uint64    `json:"payload_bytes"`
+	CanonicalHash    string    `json:"canonical_hash"`
+	SegmentTailHash  string    `json:"segment_tail_hash"`
+	DroppedCount     uint64    `json:"dropped_count"`
+	EmittedAt        time.Time `json:"emitted_at"`
+	ReceivedAt       time.Time `json:"received_at"`
+	SignatureKeyIDs  []string  `json:"signature_key_ids"`
+	InformationalDLP []string  `json:"informational_dlp,omitempty"`
+}
+
+type Query struct {
+	OrgID      string
+	FleetID    string
+	InstanceID string
+	BatchID    string
+	Limit      int
+}
+
+type PutResult struct {
+	Summary   BatchSummary
+	Duplicate bool
+}


### PR DESCRIPTION
## Summary
- add `pipelock fleet-sink` for signed Conductor audit batch ingest
- verify audit envelopes and signatures before DLP scanning and storage
- persist accepted batches in SQLite with duplicate handling, fork detection, and metadata query endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fleet sink CLI and HTTP service to ingest, verify, store, list, and retrieve Conductor audit batches; DLP scanning and strict JSON validation; secure reader access via bearer token, TLS 1.3+, and optional mTLS.

* **Storage**
  * SQLite-backed store with deduplication, fork/conflict detection, and owner-only DB file permissions.

* **Tests**
  * Extensive test coverage for CLI, handler auth/authorization, request validation, storage behavior, parsing, and routing.

* **Documentation**
  * Package-level documentation for the sink component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->