### PR TITLE
Conductor: enqueue recorder audit batches

### DIFF
--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -407,9 +407,9 @@ internal/conductor/auditbatcher
 
 Responsibilities:
 
-- Accept sanitized audit/event/receipt references from runtime paths.
+- Observe recorder v2 entries after they are durably flushed.
 - Persist batches to a local durable queue.
-- Sign each batch with the follower audit key.
+- Sign each batch with the follower audit key at recorder checkpoint boundaries.
 - Send over follower mTLS transport.
 - Retry with bounded backoff.
 - Track drop reasons explicitly.
@@ -571,6 +571,8 @@ conductor:
   client_key_path: "/etc/pipelock/conductor/client.key"
   bundle_cache_dir: "/var/lib/pipelock/conductor/bundles"
   durable_audit_queue_dir: "/var/lib/pipelock/conductor/audit-queue"
+  audit_signing_key_id: "instance-audit-1"
+  recorder_key_id: "instance-recorder-1"
   poll_interval: "30s"
   honor_remote_kill_switch: false
   created_skew_seconds: 60
@@ -579,7 +581,17 @@ conductor:
   stale_policy:
     grace_multiplier: 1
     after_grace: strict_deny_all
+
+flight_recorder:
+  enabled: true
+  dir: "/var/lib/pipelock/recorder"
+  sign_checkpoints: true
+  signing_key_path: "/etc/pipelock/recorder.key"
 ```
+
+When `conductor.enabled` is true, the flight recorder must be enabled with
+signed checkpoints and a configured signing key. `audit_signing_key_id` and
+`recorder_key_id` default to `instance_id` when omitted.
 
 Config validation must reject:
 

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -88,20 +88,21 @@ type Server struct {
 	cfg          *config.Config
 	bundleResult *rules.LoadResult
 
-	sentry          *plsentry.Client
-	logger          *audit.Logger
-	emitter         *emit.Emitter
-	scanner         *scanner.Scanner
-	metrics         *metrics.Metrics
-	killswitch      *killswitch.Controller
-	ksAPI           *killswitch.APIHandler
-	proxy           *proxy.Proxy
-	receiptEmitter  *receipt.Emitter
-	envelopeEmitter *envelope.Emitter
-	captureWriter   *capture.Writer
-	recorder        *recorder.Recorder
-	conductorAudit  *auditbatcher.Transport
-	approver        *hitl.Approver
+	sentry            *plsentry.Client
+	logger            *audit.Logger
+	emitter           *emit.Emitter
+	scanner           *scanner.Scanner
+	metrics           *metrics.Metrics
+	killswitch        *killswitch.Controller
+	ksAPI             *killswitch.APIHandler
+	proxy             *proxy.Proxy
+	receiptEmitter    *receipt.Emitter
+	envelopeEmitter   *envelope.Emitter
+	captureWriter     *capture.Writer
+	recorder          *recorder.Recorder
+	conductorAudit    *auditbatcher.Transport
+	conductorProducer *auditbatcher.Producer
+	approver          *hitl.Approver
 
 	// lastReloadHash / lastReloadAt dedup fsnotify + SIGHUP stacking
 	// inside Reload. Two stacked Changes() events with the same hash
@@ -282,7 +283,7 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	s.scanner = sc
 	m := metrics.New()
 	s.metrics = m
-	_, conductorAudit, conductorErr := buildConductorAuditTransport(cfg, m)
+	conductorQueue, conductorAudit, conductorErr := buildConductorAuditTransport(cfg, m)
 	if conductorErr != nil {
 		s.cleanup()
 		return nil, conductorErr
@@ -354,6 +355,7 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	// separate code path (capture.Writer above). This path wires the
 	// YAML-config-driven recorder into the proxy so enforcement decisions
 	// are hash-chained to disk.
+	var recPrivKey ed25519.PrivateKey
 	if cfg.FlightRecorder.Enabled && cfg.FlightRecorder.Dir != "" {
 		recCfg := recorder.Config{
 			Enabled:            cfg.FlightRecorder.Enabled,
@@ -373,7 +375,6 @@ func NewServer(opts ServerOpts) (*Server, error) {
 			redactFn = sc.ScanTextForDLP
 		}
 
-		var recPrivKey ed25519.PrivateKey
 		if cfg.FlightRecorder.SigningKeyPath != "" {
 			k, kErr := signing.LoadPrivateKeyFile(cfg.FlightRecorder.SigningKeyPath)
 			if kErr != nil {
@@ -416,6 +417,29 @@ func NewServer(opts ServerOpts) (*Server, error) {
 		}
 
 		_, _ = fmt.Fprintf(opts.Stderr, "  Recorder: %s (flight recorder enabled)\n", cfg.FlightRecorder.Dir)
+	}
+	if conductorQueue != nil {
+		if s.recorder == nil {
+			s.cleanup()
+			return nil, errors.New("conductor audit producer requires flight recorder")
+		}
+		producer, producerErr := auditbatcher.NewProducer(auditbatcher.ProducerConfig{
+			Queue:            conductorQueue,
+			Metrics:          m,
+			OrgID:            cfg.Conductor.OrgID,
+			FleetID:          cfg.Conductor.FleetID,
+			InstanceID:       cfg.Conductor.InstanceID,
+			AuditSignerKeyID: cfg.Conductor.AuditSigningKeyID,
+			RecorderKeyID:    cfg.Conductor.RecorderKeyID,
+			AuditSigner:      recPrivKey,
+		})
+		if producerErr != nil {
+			s.cleanup()
+			return nil, fmt.Errorf("creating conductor audit producer: %w", producerErr)
+		}
+		s.conductorProducer = producer
+		s.recorder.SetObserver(producer)
+		_, _ = fmt.Fprintf(opts.Stderr, "  Conductor: audit producer enabled\n")
 	}
 
 	if cfg.MediationEnvelope.Enabled {

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -423,6 +423,11 @@ func NewServer(opts ServerOpts) (*Server, error) {
 			s.cleanup()
 			return nil, errors.New("conductor audit producer requires flight recorder")
 		}
+		recPubKey, ok := recPrivKey.Public().(ed25519.PublicKey)
+		if !ok || len(recPubKey) != ed25519.PublicKeySize {
+			s.cleanup()
+			return nil, errors.New("conductor audit producer requires recorder public key")
+		}
 		// The flight-recorder signing key doubles as the audit-batch
 		// signer. Reuse is safe because the two signing schemes operate on
 		// disjoint byte sets: the recorder signs a bare 64-char hex chain
@@ -431,14 +436,15 @@ func NewServer(opts ServerOpts) (*Server, error) {
 		// signature or vice versa. Key ids stay separate (audit_signing_key_id
 		// vs recorder_key_id) so the sink-side roster can distinguish purpose.
 		producer, producerErr := auditbatcher.NewProducer(auditbatcher.ProducerConfig{
-			Queue:            conductorQueue,
-			Metrics:          m,
-			OrgID:            cfg.Conductor.OrgID,
-			FleetID:          cfg.Conductor.FleetID,
-			InstanceID:       cfg.Conductor.InstanceID,
-			AuditSignerKeyID: cfg.Conductor.AuditSigningKeyID,
-			RecorderKeyID:    cfg.Conductor.RecorderKeyID,
-			AuditSigner:      recPrivKey,
+			Queue:             conductorQueue,
+			Metrics:           m,
+			OrgID:             cfg.Conductor.OrgID,
+			FleetID:           cfg.Conductor.FleetID,
+			InstanceID:        cfg.Conductor.InstanceID,
+			AuditSignerKeyID:  cfg.Conductor.AuditSigningKeyID,
+			RecorderKeyID:     cfg.Conductor.RecorderKeyID,
+			AuditSigner:       recPrivKey,
+			RecorderPublicKey: recPubKey,
 		})
 		if producerErr != nil {
 			s.cleanup()

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -423,6 +423,13 @@ func NewServer(opts ServerOpts) (*Server, error) {
 			s.cleanup()
 			return nil, errors.New("conductor audit producer requires flight recorder")
 		}
+		// The flight-recorder signing key doubles as the audit-batch
+		// signer. Reuse is safe because the two signing schemes operate on
+		// disjoint byte sets: the recorder signs a bare 64-char hex chain
+		// hash, while the audit batch signs canonical JSON (`{...}`). No
+		// recorder signature can be replayed as a valid audit-batch
+		// signature or vice versa. Key ids stay separate (audit_signing_key_id
+		// vs recorder_key_id) so the sink-side roster can distinguish purpose.
 		producer, producerErr := auditbatcher.NewProducer(auditbatcher.ProducerConfig{
 			Queue:            conductorQueue,
 			Metrics:          m,

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -423,10 +423,10 @@ func NewServer(opts ServerOpts) (*Server, error) {
 			s.cleanup()
 			return nil, errors.New("conductor audit producer requires flight recorder")
 		}
-		recPubKey, ok := recPrivKey.Public().(ed25519.PublicKey)
-		if !ok || len(recPubKey) != ed25519.PublicKeySize {
+		recPubKey, keyErr := conductorRecorderPublicKey(recPrivKey)
+		if keyErr != nil {
 			s.cleanup()
-			return nil, errors.New("conductor audit producer requires recorder public key")
+			return nil, keyErr
 		}
 		// The flight-recorder signing key doubles as the audit-batch
 		// signer. Reuse is safe because the two signing schemes operate on
@@ -483,6 +483,17 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	s.refreshRuntimeState(nil, cfg, bundleResult, sc)
 
 	return s, nil
+}
+
+func conductorRecorderPublicKey(priv ed25519.PrivateKey) (ed25519.PublicKey, error) {
+	if len(priv) != ed25519.PrivateKeySize {
+		return nil, errors.New("conductor audit producer requires flight recorder signing key")
+	}
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok || len(pub) != ed25519.PublicKeySize {
+		return nil, errors.New("conductor audit producer requires recorder public key")
+	}
+	return pub, nil
 }
 
 // Shutdown cancels Start's internal context so the serve loop unblocks.

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -277,6 +277,10 @@ func (s *Server) cleanup() {
 		_ = s.recorder.Close()
 		s.recorder = nil
 	}
+	if s.conductorProducer != nil {
+		_ = s.conductorProducer.Close()
+		s.conductorProducer = nil
+	}
 	if s.captureWriter != nil {
 		_ = s.captureWriter.Close()
 		s.captureWriter = nil

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -329,6 +329,79 @@ func TestNewServer_FlightRecorderAndEnvelopeFromConfig(t *testing.T) {
 	}
 }
 
+func TestNewServer_ConductorAuditProducerFromConfig(t *testing.T) {
+	tmp, err := os.MkdirTemp(".", ".runtime-conductor-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmp) })
+	tmp, err = filepath.Abs(tmp)
+	if err != nil {
+		t.Fatalf("Abs: %v", err)
+	}
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	keyPath := filepath.Join(tmp, "recorder.key")
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	clientPEM, clientKeyPEM := testTLSClientCert(t)
+	trustPath := filepath.Join(tmp, "trust-roster.json")
+	caPath := filepath.Join(tmp, "boss-ca.pem")
+	clientCertPath := filepath.Join(tmp, "client.crt")
+	clientKeyPath := filepath.Join(tmp, "client.key")
+	writePrivateTestFile(t, trustPath, []byte(`{"keys":[]}`))
+	writePrivateTestFile(t, caPath, clientPEM)
+	writePrivateTestFile(t, clientCertPath, clientPEM)
+	writePrivateTestFile(t, clientKeyPath, clientKeyPEM)
+
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"flight_recorder:",
+		"  enabled: true",
+		"  dir: " + strconv.Quote(filepath.Join(tmp, "recorder")),
+		"  checkpoint_interval: 1",
+		"  sign_checkpoints: true",
+		"  signing_key_path: " + strconv.Quote(keyPath),
+		"conductor:",
+		"  enabled: true",
+		"  conductor_url: https://conductor.example",
+		"  org_id: org-main",
+		"  fleet_id: prod",
+		"  instance_id: pl-prod-1",
+		"  trust_roster_path: " + strconv.Quote(trustPath),
+		"  server_ca_file: " + strconv.Quote(caPath),
+		"  client_cert_path: " + strconv.Quote(clientCertPath),
+		"  client_key_path: " + strconv.Quote(clientKeyPath),
+		"  bundle_cache_dir: " + strconv.Quote(filepath.Join(tmp, "bundles")),
+		"  durable_audit_queue_dir: " + strconv.Quote(filepath.Join(tmp, "audit-queue")),
+		"  audit_signing_key_id: audit-key-1",
+		"  recorder_key_id: recorder-key-1",
+		"",
+	}, "\n"))
+
+	buf := &syncBuffer{}
+	s, err := NewServer(ServerOpts{ConfigFile: cfgPath, Stdout: buf, Stderr: buf})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { s.cleanup() })
+
+	if s.conductorAudit == nil {
+		t.Fatal("conductor audit transport should be initialized")
+	}
+	if s.conductorProducer == nil {
+		t.Fatal("conductor audit producer should be initialized")
+	}
+	for _, want := range []string{"Recorder:", "Conductor: audit producer enabled"} {
+		if !buf.contains(want) {
+			t.Fatalf("stderr missing %q:\n%s", want, buf.String())
+		}
+	}
+}
+
 // TestNewServer_ResolveRuntimeRuns verifies the ResolveRuntime pipeline
 // wired through NewServer. With --mcp-listen the runtime mode is
 // RuntimeForwardWithMCPListener which WrapsMCP, so MCP input / tool /

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -5,6 +5,7 @@ package runtime
 
 import (
 	"context"
+	"crypto/ed25519"
 	"io"
 	"net"
 	"os"
@@ -399,6 +400,26 @@ func TestNewServer_ConductorAuditProducerFromConfig(t *testing.T) {
 		if !buf.contains(want) {
 			t.Fatalf("stderr missing %q:\n%s", want, buf.String())
 		}
+	}
+}
+
+func TestConductorRecorderPublicKey(t *testing.T) {
+	if _, err := conductorRecorderPublicKey(nil); err == nil || !strings.Contains(err.Error(), "flight recorder signing key") {
+		t.Fatalf("nil key error = %v, want signing key error", err)
+	}
+	if _, err := conductorRecorderPublicKey(ed25519.PrivateKey("short")); err == nil || !strings.Contains(err.Error(), "flight recorder signing key") {
+		t.Fatalf("short key error = %v, want signing key error", err)
+	}
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	got, err := conductorRecorderPublicKey(priv)
+	if err != nil {
+		t.Fatalf("conductorRecorderPublicKey(valid): %v", err)
+	}
+	if string(got) != string(pub) {
+		t.Fatal("public key mismatch")
 	}
 }
 

--- a/internal/conductor/auditbatcher/producer.go
+++ b/internal/conductor/auditbatcher/producer.go
@@ -25,6 +25,8 @@ import (
 const (
 	defaultProducerBuffer = 4096
 
+	checkpointEntryType = "checkpoint"
+
 	producerDropChannelFull       = "producer_channel_full"
 	producerDropEnqueueError      = "enqueue_error"
 	producerDropInvalidCheckpoint = "invalid_checkpoint"
@@ -79,14 +81,17 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 	if len(cfg.AuditSigner) != ed25519.PrivateKeySize {
 		return nil, fmt.Errorf("auditbatcher: producer private key length=%d want=%d", len(cfg.AuditSigner), ed25519.PrivateKeySize)
 	}
-	for field, value := range map[string]string{
-		"org_id":              cfg.OrgID,
-		"fleet_id":            cfg.FleetID,
-		"instance_id":         cfg.InstanceID,
-		"audit_signer_key_id": cfg.AuditSignerKeyID,
-		"recorder_key_id":     cfg.RecorderKeyID,
+	for _, id := range []struct {
+		field string
+		value string
+	}{
+		{field: "org_id", value: cfg.OrgID},
+		{field: "fleet_id", value: cfg.FleetID},
+		{field: "instance_id", value: cfg.InstanceID},
+		{field: "audit_signer_key_id", value: cfg.AuditSignerKeyID},
+		{field: "recorder_key_id", value: cfg.RecorderKeyID},
 	} {
-		if err := validateProducerIdentifier(field, value); err != nil {
+		if err := validateProducerIdentifier(id.field, id.value); err != nil {
 			return nil, err
 		}
 	}
@@ -134,8 +139,7 @@ func (p *Producer) ObserveRecorderEntry(entry recorder.Entry) {
 	select {
 	case p.entries <- entry:
 	default:
-		p.addDropped(producerDropChannelFull, 1)
-		p.recordDropMetric(producerDropChannelFull)
+		p.drop(producerDropChannelFull, 1)
 	}
 }
 
@@ -158,27 +162,24 @@ func (p *Producer) run() {
 	var pending []recorder.Entry
 	for entry := range p.entries {
 		if entry.Version != recorder.EntryVersion {
-			p.addDropped(producerDropInvalidCheckpoint, 1)
-			p.recordDropMetric(producerDropInvalidCheckpoint)
+			p.drop(producerDropInvalidCheckpoint, 1)
 			continue
 		}
 		if len(pending) > 0 && entry.Sequence != pending[len(pending)-1].Sequence+1 {
-			p.addDropped(producerDropSequenceGap, uint64(len(pending)))
-			p.recordDropMetric(producerDropSequenceGap)
+			p.drop(producerDropSequenceGap, uint64(len(pending)))
 			pending = nil
 		}
 		pending = append(pending, entry)
-		if entry.Type != "checkpoint" {
+		if entry.Type != checkpointEntryType {
 			continue
 		}
-		if err := p.enqueueSegment(pending); err != nil {
-			p.recordDropMetric(errorDropReason(err))
-		}
+		// enqueueSegment records its own drop accounting and metrics at
+		// each failure site, so the returned error is informational only.
+		_ = p.enqueueSegment(pending)
 		pending = nil
 	}
 	if len(pending) > 0 {
-		p.addDropped(producerDropShutdownPartial, uint64(len(pending)))
-		p.recordDropMetric(producerDropShutdownPartial)
+		p.drop(producerDropShutdownPartial, uint64(len(pending)))
 	}
 }
 
@@ -187,28 +188,38 @@ func (p *Producer) enqueueSegment(entries []recorder.Entry) error {
 		return nil
 	}
 	checkpoint := entries[len(entries)-1]
-	if checkpoint.Type != "checkpoint" {
+	if checkpoint.Type != checkpointEntryType {
 		return nil
 	}
+	// The recorder committed this checkpoint to its local hash chain before
+	// we observed it, so advance the chain tail unconditionally — even on a
+	// drop. The next segment's PreviousSegmentTail must reflect the true
+	// local chain; drops are accounted separately in DroppedAccounting. If a
+	// drop path left the tail un-advanced, the next segment would claim
+	// continuity across a checkpoint the recorder actually wrote, and a
+	// verifier replaying the local recorder file would reject the chain.
+	defer func() { p.previousSegmentTail = checkpoint.Hash }()
+
+	span := uint64(len(entries))
 	cp, err := checkpointDetail(checkpoint)
 	if err != nil {
-		p.addDropped(producerDropInvalidCheckpoint, uint64(len(entries)))
+		p.drop(producerDropInvalidCheckpoint, span)
 		return fmt.Errorf("%s: %w", producerDropInvalidCheckpoint, err)
 	}
 	payload, err := marshalEntriesJSONL(entries)
 	if err != nil {
-		p.addDropped(producerDropEnqueueError, uint64(len(entries)))
+		p.drop(producerDropEnqueueError, span)
 		return fmt.Errorf("%s: %w", producerDropEnqueueError, err)
 	}
 	if len(payload) > conductor.MaxAuditPayloadBytes {
-		p.addDropped(producerDropPayloadTooLarge, uint64(len(entries)))
-		p.previousSegmentTail = checkpoint.Hash
+		p.drop(producerDropPayloadTooLarge, span)
 		return fmt.Errorf("%s: payload=%d max=%d", producerDropPayloadTooLarge, len(payload), conductor.MaxAuditPayloadBytes)
 	}
-	envelope := p.envelope(entries, checkpoint, cp, payload)
+	includedDrops := p.droppedAccounting()
+	envelope := p.envelope(entries, checkpoint, cp, payload, includedDrops)
 	signed, err := SignEnvelope(envelope, p.auditSignerKeyID, p.auditSigner)
 	if err != nil {
-		p.addDropped(producerDropEnqueueError, uint64(len(entries)))
+		p.drop(producerDropEnqueueError, span)
 		return fmt.Errorf("%s: %w", producerDropEnqueueError, err)
 	}
 	if _, err := p.queue.Enqueue(Batch{Envelope: signed, Payload: payload}); err != nil {
@@ -216,16 +227,15 @@ func (p *Producer) enqueueSegment(entries []recorder.Entry) error {
 		if errors.Is(err, ErrQueueFull) {
 			reason = producerDropQueueFull
 		}
-		p.addDropped(reason, uint64(len(entries)))
+		p.drop(reason, span)
 		return fmt.Errorf("%s: %w", reason, err)
 	}
-	p.clearDropped()
-	p.previousSegmentTail = checkpoint.Hash
+	p.releaseDropped(includedDrops)
 	p.recordQueue()
 	return nil
 }
 
-func (p *Producer) envelope(entries []recorder.Entry, checkpoint recorder.Entry, cp recorder.CheckpointDetail, payload []byte) conductor.AuditBatchEnvelope {
+func (p *Producer) envelope(entries []recorder.Entry, checkpoint recorder.Entry, cp recorder.CheckpointDetail, payload []byte, dropped conductor.DroppedAccounting) conductor.AuditBatchEnvelope {
 	sum := sha256.Sum256(payload)
 	return conductor.AuditBatchEnvelope{
 		SchemaVersion:      conductor.SchemaVersion,
@@ -240,7 +250,7 @@ func (p *Producer) envelope(entries []recorder.Entry, checkpoint recorder.Entry,
 		EventCount:         uint64(len(entries)),
 		PayloadSHA256:      hex.EncodeToString(sum[:]),
 		PayloadBytes:       uint64(len(payload)),
-		Dropped:            p.droppedAccounting(),
+		Dropped:            dropped,
 		Chain: conductor.EvidenceChain{
 			EntryVersion:           recorder.EntryVersion,
 			SegmentID:              segmentID(entries[0].SessionID, entries[0].Sequence, checkpoint.Sequence),
@@ -265,6 +275,18 @@ func (p *Producer) nextBatchID() string {
 		return fmt.Sprintf("audit-%020d", p.now().UTC().UnixNano())
 	}
 	return fmt.Sprintf("audit-%020d-%s", p.now().UTC().UnixNano(), hex.EncodeToString(random[:]))
+}
+
+// drop records a dropped-span count in one place: the in-memory accounting
+// that feeds the next envelope's DroppedAccounting AND the Prometheus drop
+// metric. Keeping them together prevents the map and the metric from ever
+// disagreeing on the reason label.
+func (p *Producer) drop(reason string, count uint64) {
+	if count == 0 {
+		return
+	}
+	p.addDropped(reason, count)
+	p.recordDropMetric(reason)
 }
 
 func (p *Producer) addDropped(reason string, count uint64) {
@@ -297,10 +319,20 @@ func (p *Producer) droppedAccounting() conductor.DroppedAccounting {
 	return out
 }
 
-func (p *Producer) clearDropped() {
+func (p *Producer) releaseDropped(included conductor.DroppedAccounting) {
+	if included.Count == 0 {
+		return
+	}
 	p.dropMu.Lock()
 	defer p.dropMu.Unlock()
-	clear(p.dropped)
+	for _, reason := range included.Reasons {
+		current := p.dropped[reason.Reason]
+		if current <= reason.Count {
+			delete(p.dropped, reason.Reason)
+			continue
+		}
+		p.dropped[reason.Reason] = current - reason.Count
+	}
 }
 
 func (p *Producer) recordQueue() {
@@ -388,25 +420,4 @@ func validateProducerIdentifier(field, value string) error {
 		}
 	}
 	return nil
-}
-
-func errorDropReason(err error) string {
-	if err == nil {
-		return producerDropEnqueueError
-	}
-	text := err.Error()
-	for _, reason := range []string{
-		producerDropChannelFull,
-		producerDropEnqueueError,
-		producerDropInvalidCheckpoint,
-		producerDropPayloadTooLarge,
-		producerDropQueueFull,
-		producerDropSequenceGap,
-		producerDropShutdownPartial,
-	} {
-		if strings.Contains(text, reason) {
-			return reason
-		}
-	}
-	return producerDropEnqueueError
 }

--- a/internal/conductor/auditbatcher/producer.go
+++ b/internal/conductor/auditbatcher/producer.go
@@ -62,16 +62,17 @@ type Producer struct {
 }
 
 type ProducerConfig struct {
-	Queue            *Queue
-	Metrics          MetricsSink
-	OrgID            string
-	FleetID          string
-	InstanceID       string
-	AuditSignerKeyID string
-	RecorderKeyID    string
-	AuditSigner      ed25519.PrivateKey
-	BufferSize       int
-	Now              func() time.Time
+	Queue             *Queue
+	Metrics           MetricsSink
+	OrgID             string
+	FleetID           string
+	InstanceID        string
+	AuditSignerKeyID  string
+	RecorderKeyID     string
+	AuditSigner       ed25519.PrivateKey
+	RecorderPublicKey ed25519.PublicKey
+	BufferSize        int
+	Now               func() time.Time
 }
 
 func NewProducer(cfg ProducerConfig) (*Producer, error) {
@@ -80,6 +81,9 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 	}
 	if len(cfg.AuditSigner) != ed25519.PrivateKeySize {
 		return nil, fmt.Errorf("auditbatcher: producer private key length=%d want=%d", len(cfg.AuditSigner), ed25519.PrivateKeySize)
+	}
+	if len(cfg.RecorderPublicKey) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("auditbatcher: recorder public key length=%d want=%d", len(cfg.RecorderPublicKey), ed25519.PublicKeySize)
 	}
 	for _, id := range []struct {
 		field string
@@ -101,10 +105,6 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 	if cfg.Now == nil {
 		cfg.Now = func() time.Time { return time.Now().UTC() }
 	}
-	pub, ok := cfg.AuditSigner.Public().(ed25519.PublicKey)
-	if !ok || len(pub) != ed25519.PublicKeySize {
-		return nil, errors.New("auditbatcher: producer public key unavailable")
-	}
 	p := &Producer{
 		queue:            cfg.Queue,
 		metrics:          cfg.Metrics,
@@ -113,7 +113,7 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 		instanceID:       cfg.InstanceID,
 		auditSignerKeyID: cfg.AuditSignerKeyID,
 		recorderKeyID:    cfg.RecorderKeyID,
-		followerPubHex:   hex.EncodeToString(pub),
+		followerPubHex:   hex.EncodeToString(cfg.RecorderPublicKey),
 		auditSigner:      append(ed25519.PrivateKey(nil), cfg.AuditSigner...),
 		now:              cfg.Now,
 		entries:          make(chan recorder.Entry, cfg.BufferSize),

--- a/internal/conductor/auditbatcher/producer.go
+++ b/internal/conductor/auditbatcher/producer.go
@@ -1,0 +1,412 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package auditbatcher
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+const (
+	defaultProducerBuffer = 4096
+
+	producerDropChannelFull       = "producer_channel_full"
+	producerDropEnqueueError      = "enqueue_error"
+	producerDropInvalidCheckpoint = "invalid_checkpoint"
+	producerDropPayloadTooLarge   = "payload_too_large"
+	producerDropQueueFull         = "queue_full"
+	producerDropSequenceGap       = "producer_sequence_gap"
+	producerDropShutdownPartial   = "shutdown_without_checkpoint"
+)
+
+// Producer observes locally written recorder entries and turns checkpoint
+// spans into signed Conductor audit batches. It is intentionally outside
+// emit.Emitter: enqueue failures need durable drop accounting rather than
+// fire-and-forget sink behavior.
+type Producer struct {
+	queue               *Queue
+	metrics             MetricsSink
+	orgID               string
+	fleetID             string
+	instanceID          string
+	auditSignerKeyID    string
+	recorderKeyID       string
+	followerPubHex      string
+	auditSigner         ed25519.PrivateKey
+	now                 func() time.Time
+	entries             chan recorder.Entry
+	done                chan struct{}
+	closeOnce           sync.Once
+	sendMu              sync.RWMutex
+	closed              atomic.Bool
+	dropMu              sync.Mutex
+	dropped             map[string]uint64
+	previousSegmentTail string
+}
+
+type ProducerConfig struct {
+	Queue            *Queue
+	Metrics          MetricsSink
+	OrgID            string
+	FleetID          string
+	InstanceID       string
+	AuditSignerKeyID string
+	RecorderKeyID    string
+	AuditSigner      ed25519.PrivateKey
+	BufferSize       int
+	Now              func() time.Time
+}
+
+func NewProducer(cfg ProducerConfig) (*Producer, error) {
+	if cfg.Queue == nil {
+		return nil, errors.New("auditbatcher: producer queue required")
+	}
+	if len(cfg.AuditSigner) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("auditbatcher: producer private key length=%d want=%d", len(cfg.AuditSigner), ed25519.PrivateKeySize)
+	}
+	for field, value := range map[string]string{
+		"org_id":              cfg.OrgID,
+		"fleet_id":            cfg.FleetID,
+		"instance_id":         cfg.InstanceID,
+		"audit_signer_key_id": cfg.AuditSignerKeyID,
+		"recorder_key_id":     cfg.RecorderKeyID,
+	} {
+		if err := validateProducerIdentifier(field, value); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.BufferSize <= 0 {
+		cfg.BufferSize = defaultProducerBuffer
+	}
+	if cfg.Now == nil {
+		cfg.Now = func() time.Time { return time.Now().UTC() }
+	}
+	pub, ok := cfg.AuditSigner.Public().(ed25519.PublicKey)
+	if !ok || len(pub) != ed25519.PublicKeySize {
+		return nil, errors.New("auditbatcher: producer public key unavailable")
+	}
+	p := &Producer{
+		queue:            cfg.Queue,
+		metrics:          cfg.Metrics,
+		orgID:            cfg.OrgID,
+		fleetID:          cfg.FleetID,
+		instanceID:       cfg.InstanceID,
+		auditSignerKeyID: cfg.AuditSignerKeyID,
+		recorderKeyID:    cfg.RecorderKeyID,
+		followerPubHex:   hex.EncodeToString(pub),
+		auditSigner:      append(ed25519.PrivateKey(nil), cfg.AuditSigner...),
+		now:              cfg.Now,
+		entries:          make(chan recorder.Entry, cfg.BufferSize),
+		done:             make(chan struct{}),
+		dropped:          map[string]uint64{},
+	}
+	go p.run()
+	return p, nil
+}
+
+// ObserveRecorderEntry accepts a post-flush recorder entry without blocking
+// enforcement. If the producer falls behind, the dropped entry is accounted in
+// the next successfully enqueued signed batch.
+func (p *Producer) ObserveRecorderEntry(entry recorder.Entry) {
+	if p == nil || p.closed.Load() {
+		return
+	}
+	p.sendMu.RLock()
+	defer p.sendMu.RUnlock()
+	if p.closed.Load() {
+		return
+	}
+	select {
+	case p.entries <- entry:
+	default:
+		p.addDropped(producerDropChannelFull, 1)
+		p.recordDropMetric(producerDropChannelFull)
+	}
+}
+
+func (p *Producer) Close() error {
+	if p == nil {
+		return nil
+	}
+	p.closeOnce.Do(func() {
+		p.sendMu.Lock()
+		defer p.sendMu.Unlock()
+		p.closed.Store(true)
+		close(p.entries)
+		<-p.done
+	})
+	return nil
+}
+
+func (p *Producer) run() {
+	defer close(p.done)
+	var pending []recorder.Entry
+	for entry := range p.entries {
+		if entry.Version != recorder.EntryVersion {
+			p.addDropped(producerDropInvalidCheckpoint, 1)
+			p.recordDropMetric(producerDropInvalidCheckpoint)
+			continue
+		}
+		if len(pending) > 0 && entry.Sequence != pending[len(pending)-1].Sequence+1 {
+			p.addDropped(producerDropSequenceGap, uint64(len(pending)))
+			p.recordDropMetric(producerDropSequenceGap)
+			pending = nil
+		}
+		pending = append(pending, entry)
+		if entry.Type != "checkpoint" {
+			continue
+		}
+		if err := p.enqueueSegment(pending); err != nil {
+			p.recordDropMetric(errorDropReason(err))
+		}
+		pending = nil
+	}
+	if len(pending) > 0 {
+		p.addDropped(producerDropShutdownPartial, uint64(len(pending)))
+		p.recordDropMetric(producerDropShutdownPartial)
+	}
+}
+
+func (p *Producer) enqueueSegment(entries []recorder.Entry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	checkpoint := entries[len(entries)-1]
+	if checkpoint.Type != "checkpoint" {
+		return nil
+	}
+	cp, err := checkpointDetail(checkpoint)
+	if err != nil {
+		p.addDropped(producerDropInvalidCheckpoint, uint64(len(entries)))
+		return fmt.Errorf("%s: %w", producerDropInvalidCheckpoint, err)
+	}
+	payload, err := marshalEntriesJSONL(entries)
+	if err != nil {
+		p.addDropped(producerDropEnqueueError, uint64(len(entries)))
+		return fmt.Errorf("%s: %w", producerDropEnqueueError, err)
+	}
+	if len(payload) > conductor.MaxAuditPayloadBytes {
+		p.addDropped(producerDropPayloadTooLarge, uint64(len(entries)))
+		p.previousSegmentTail = checkpoint.Hash
+		return fmt.Errorf("%s: payload=%d max=%d", producerDropPayloadTooLarge, len(payload), conductor.MaxAuditPayloadBytes)
+	}
+	envelope := p.envelope(entries, checkpoint, cp, payload)
+	signed, err := SignEnvelope(envelope, p.auditSignerKeyID, p.auditSigner)
+	if err != nil {
+		p.addDropped(producerDropEnqueueError, uint64(len(entries)))
+		return fmt.Errorf("%s: %w", producerDropEnqueueError, err)
+	}
+	if _, err := p.queue.Enqueue(Batch{Envelope: signed, Payload: payload}); err != nil {
+		reason := producerDropEnqueueError
+		if errors.Is(err, ErrQueueFull) {
+			reason = producerDropQueueFull
+		}
+		p.addDropped(reason, uint64(len(entries)))
+		return fmt.Errorf("%s: %w", reason, err)
+	}
+	p.clearDropped()
+	p.previousSegmentTail = checkpoint.Hash
+	p.recordQueue()
+	return nil
+}
+
+func (p *Producer) envelope(entries []recorder.Entry, checkpoint recorder.Entry, cp recorder.CheckpointDetail, payload []byte) conductor.AuditBatchEnvelope {
+	sum := sha256.Sum256(payload)
+	return conductor.AuditBatchEnvelope{
+		SchemaVersion:      conductor.SchemaVersion,
+		BatchID:            p.nextBatchID(),
+		OrgID:              p.orgID,
+		FleetID:            p.fleetID,
+		InstanceID:         p.instanceID,
+		AuditSchemaVersion: recorder.EntryVersion,
+		EmittedAt:          p.now().UTC(),
+		SeqStart:           entries[0].Sequence,
+		SeqEnd:             checkpoint.Sequence,
+		EventCount:         uint64(len(entries)),
+		PayloadSHA256:      hex.EncodeToString(sum[:]),
+		PayloadBytes:       uint64(len(payload)),
+		Dropped:            p.droppedAccounting(),
+		Chain: conductor.EvidenceChain{
+			EntryVersion:           recorder.EntryVersion,
+			SegmentID:              segmentID(entries[0].SessionID, entries[0].Sequence, checkpoint.Sequence),
+			SeqStart:               entries[0].Sequence,
+			SeqEnd:                 checkpoint.Sequence,
+			PreviousSegmentTail:    p.previousSegmentTail,
+			SegmentHeadHash:        entries[0].Hash,
+			SegmentTailHash:        checkpoint.Hash,
+			CheckpointSeq:          checkpoint.Sequence,
+			CheckpointHash:         checkpoint.Hash,
+			CheckpointSignature:    ed25519SignatureString(cp.Signature),
+			CheckpointSignerKeyID:  p.recorderKeyID,
+			FollowerRecorderKeyID:  p.recorderKeyID,
+			FollowerRecorderPubHex: p.followerPubHex,
+		},
+	}
+}
+
+func (p *Producer) nextBatchID() string {
+	var random [8]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return fmt.Sprintf("audit-%020d", p.now().UTC().UnixNano())
+	}
+	return fmt.Sprintf("audit-%020d-%s", p.now().UTC().UnixNano(), hex.EncodeToString(random[:]))
+}
+
+func (p *Producer) addDropped(reason string, count uint64) {
+	if count == 0 {
+		return
+	}
+	reason = normalizeAccountingReason(reason)
+	p.dropMu.Lock()
+	defer p.dropMu.Unlock()
+	p.dropped[reason] += count
+}
+
+func (p *Producer) droppedAccounting() conductor.DroppedAccounting {
+	p.dropMu.Lock()
+	defer p.dropMu.Unlock()
+	if len(p.dropped) == 0 {
+		return conductor.DroppedAccounting{}
+	}
+	reasons := make([]string, 0, len(p.dropped))
+	for reason := range p.dropped {
+		reasons = append(reasons, reason)
+	}
+	sort.Strings(reasons)
+	out := conductor.DroppedAccounting{Reasons: make([]conductor.DroppedReason, 0, len(reasons))}
+	for _, reason := range reasons {
+		count := p.dropped[reason]
+		out.Count += count
+		out.Reasons = append(out.Reasons, conductor.DroppedReason{Reason: reason, Count: count})
+	}
+	return out
+}
+
+func (p *Producer) clearDropped() {
+	p.dropMu.Lock()
+	defer p.dropMu.Unlock()
+	clear(p.dropped)
+}
+
+func (p *Producer) recordQueue() {
+	if p.metrics == nil {
+		return
+	}
+	stats, err := p.queue.Stats()
+	if err == nil {
+		p.metrics.RecordConductorAuditQueue(stats)
+	}
+}
+
+func (p *Producer) recordDropMetric(reason string) {
+	if p.metrics != nil {
+		p.metrics.RecordConductorAuditDelivery(deliveryOutcomeDrop, normalizeAccountingReason(reason))
+	}
+}
+
+func marshalEntriesJSONL(entries []recorder.Entry) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for _, entry := range entries {
+		if err := enc.Encode(entry); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func checkpointDetail(entry recorder.Entry) (recorder.CheckpointDetail, error) {
+	data, err := json.Marshal(entry.Detail)
+	if err != nil {
+		return recorder.CheckpointDetail{}, err
+	}
+	var detail recorder.CheckpointDetail
+	if err := json.Unmarshal(data, &detail); err != nil {
+		return recorder.CheckpointDetail{}, err
+	}
+	if strings.TrimSpace(detail.Signature) == "" {
+		return recorder.CheckpointDetail{}, errors.New("checkpoint signature required")
+	}
+	return detail, nil
+}
+
+func ed25519SignatureString(hexSig string) string {
+	if strings.HasPrefix(hexSig, conductor.SignaturePrefixEd25519) {
+		return hexSig
+	}
+	return conductor.SignaturePrefixEd25519 + hexSig
+}
+
+func segmentID(sessionID string, start, end uint64) string {
+	if sessionID == "" {
+		sessionID = "recorder"
+	}
+	return fmt.Sprintf("segment-%s-%020d-%020d", safeSegmentPart(sessionID), start, end)
+}
+
+func safeSegmentPart(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r == '_' || r == '-' || r == '.' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() == 0 {
+		return "recorder"
+	}
+	return b.String()
+}
+
+func validateProducerIdentifier(field, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("auditbatcher: producer %s required", field)
+	}
+	if len(value) > conductor.MaxIDBytes {
+		return fmt.Errorf("auditbatcher: producer %s length=%d max=%d", field, len(value), conductor.MaxIDBytes)
+	}
+	for i, r := range value {
+		if r != '_' && r != '-' && r != '.' && (r < '0' || r > '9') && (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') {
+			return fmt.Errorf("auditbatcher: producer %s contains invalid character %q", field, r)
+		}
+		if i == 0 && (r == '_' || r == '-' || r == '.') {
+			return fmt.Errorf("auditbatcher: producer %s must start with an ASCII letter or digit", field)
+		}
+	}
+	return nil
+}
+
+func errorDropReason(err error) string {
+	if err == nil {
+		return producerDropEnqueueError
+	}
+	text := err.Error()
+	for _, reason := range []string{
+		producerDropChannelFull,
+		producerDropEnqueueError,
+		producerDropInvalidCheckpoint,
+		producerDropPayloadTooLarge,
+		producerDropQueueFull,
+		producerDropSequenceGap,
+		producerDropShutdownPartial,
+	} {
+		if strings.Contains(text, reason) {
+			return reason
+		}
+	}
+	return producerDropEnqueueError
+}

--- a/internal/conductor/auditbatcher/producer_test.go
+++ b/internal/conductor/auditbatcher/producer_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package auditbatcher
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestProducer_EnqueuesSignedCheckpointSegment(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	if err != nil {
+		t.Fatalf("Open queue: %v", err)
+	}
+	producer, err := NewProducer(ProducerConfig{
+		Queue:            q,
+		OrgID:            "org-main",
+		FleetID:          "prod",
+		InstanceID:       "pl-prod-1",
+		AuditSignerKeyID: "audit-key-1",
+		RecorderKeyID:    "recorder-key-1",
+		AuditSigner:      priv,
+		Now:              func() time.Time { return time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	defer func() { _ = producer.Close() }()
+
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                filepath.Join(t.TempDir(), "recorder"),
+		CheckpointInterval: 2,
+		SignCheckpoints:    true,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	rec.SetObserver(producer)
+	if err := rec.Record(testRecorderEntry("first")); err != nil {
+		t.Fatalf("Record first: %v", err)
+	}
+	if err := rec.Record(testRecorderEntry("second")); err != nil {
+		t.Fatalf("Record second: %v", err)
+	}
+
+	waitForPending(t, q, producer, 1)
+	lease, err := q.Claim()
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	batch := lease.Batch
+	if err := batch.Envelope.VerifySignatures(func(id string) (conductor.SignatureKey, error) {
+		if id != "audit-key-1" {
+			return conductor.SignatureKey{}, errors.New("unknown key")
+		}
+		return conductor.SignatureKey{PublicKey: pub, KeyPurpose: signing.PurposeAuditBatchSigning}, nil
+	}); err != nil {
+		t.Fatalf("VerifySignatures: %v", err)
+	}
+	if err := batch.Envelope.ValidatePayload(batch.Payload); err != nil {
+		t.Fatalf("ValidatePayload: %v", err)
+	}
+	if batch.Envelope.SeqStart != 0 || batch.Envelope.SeqEnd != 2 {
+		t.Fatalf("seq range = %d-%d, want 0-2", batch.Envelope.SeqStart, batch.Envelope.SeqEnd)
+	}
+	if batch.Envelope.EventCount != 3 {
+		t.Fatalf("event_count = %d, want 3", batch.Envelope.EventCount)
+	}
+	if batch.Envelope.Chain.CheckpointSeq != 2 {
+		t.Fatalf("checkpoint_seq = %d, want 2", batch.Envelope.Chain.CheckpointSeq)
+	}
+	if batch.Envelope.Chain.CheckpointSignerKeyID != "recorder-key-1" {
+		t.Fatalf("checkpoint signer = %q", batch.Envelope.Chain.CheckpointSignerKeyID)
+	}
+	if batch.Envelope.Chain.FollowerRecorderPubHex != hex.EncodeToString(pub) {
+		t.Fatalf("recorder public key mismatch")
+	}
+	var decoded []recorder.Entry
+	for _, line := range splitJSONLines(batch.Payload) {
+		var entry recorder.Entry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			t.Fatalf("payload entry decode: %v", err)
+		}
+		decoded = append(decoded, entry)
+	}
+	if len(decoded) != 3 || decoded[2].Type != "checkpoint" {
+		t.Fatalf("decoded entries = %#v, want two records plus checkpoint", decoded)
+	}
+}
+
+func TestProducer_CloseRacesWithObserver(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	if err != nil {
+		t.Fatalf("Open queue: %v", err)
+	}
+	producer, err := NewProducer(ProducerConfig{
+		Queue:            q,
+		OrgID:            "org-main",
+		FleetID:          "prod",
+		InstanceID:       "pl-prod-1",
+		AuditSignerKeyID: "audit-key-1",
+		RecorderKeyID:    "recorder-key-1",
+		AuditSigner:      priv,
+		BufferSize:       1,
+	})
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for !stop.Load() {
+				producer.ObserveRecorderEntry(recorder.Entry{Version: recorder.EntryVersion})
+			}
+		}()
+	}
+	time.Sleep(10 * time.Millisecond)
+	if err := producer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	stop.Store(true)
+	wg.Wait()
+}
+
+func testRecorderEntry(summary string) recorder.Entry {
+	return recorder.Entry{
+		SessionID: "proxy",
+		Type:      "action_receipt",
+		EventKind: "read",
+		Transport: "fetch",
+		Summary:   summary,
+		Detail: map[string]any{
+			"summary": summary,
+		},
+	}
+}
+
+func waitForPending(t *testing.T, q *Queue, producer *Producer, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		stats, err := q.Stats()
+		if err != nil {
+			t.Fatalf("Stats: %v", err)
+		}
+		if stats.Pending == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	stats, err := q.Stats()
+	if err != nil {
+		t.Fatalf("Stats after wait: %v", err)
+	}
+	t.Fatalf("pending = %d, want %d; dropped=%#v", stats.Pending, want, producer.droppedAccounting())
+}
+
+func splitJSONLines(payload []byte) [][]byte {
+	var lines [][]byte
+	start := 0
+	for i, b := range payload {
+		if b != '\n' {
+			continue
+		}
+		if i > start {
+			lines = append(lines, payload[start:i])
+		}
+		start = i + 1
+	}
+	return lines
+}

--- a/internal/conductor/auditbatcher/producer_test.go
+++ b/internal/conductor/auditbatcher/producer_test.go
@@ -23,23 +23,28 @@ import (
 )
 
 func TestProducer_EnqueuesSignedCheckpointSegment(t *testing.T) {
-	pub, priv, err := ed25519.GenerateKey(nil)
+	auditPub, auditPriv, err := ed25519.GenerateKey(nil)
 	if err != nil {
-		t.Fatalf("GenerateKey: %v", err)
+		t.Fatalf("GenerateKey audit: %v", err)
+	}
+	recorderPub, recorderPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey recorder: %v", err)
 	}
 	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
 	if err != nil {
 		t.Fatalf("Open queue: %v", err)
 	}
 	producer, err := NewProducer(ProducerConfig{
-		Queue:            q,
-		OrgID:            "org-main",
-		FleetID:          "prod",
-		InstanceID:       "pl-prod-1",
-		AuditSignerKeyID: "audit-key-1",
-		RecorderKeyID:    "recorder-key-1",
-		AuditSigner:      priv,
-		Now:              func() time.Time { return time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC) },
+		Queue:             q,
+		OrgID:             "org-main",
+		FleetID:           "prod",
+		InstanceID:        "pl-prod-1",
+		AuditSignerKeyID:  "audit-key-1",
+		RecorderKeyID:     "recorder-key-1",
+		AuditSigner:       auditPriv,
+		RecorderPublicKey: recorderPub,
+		Now:               func() time.Time { return time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC) },
 	})
 	if err != nil {
 		t.Fatalf("NewProducer: %v", err)
@@ -51,7 +56,7 @@ func TestProducer_EnqueuesSignedCheckpointSegment(t *testing.T) {
 		Dir:                filepath.Join(t.TempDir(), "recorder"),
 		CheckpointInterval: 2,
 		SignCheckpoints:    true,
-	}, nil, priv)
+	}, nil, recorderPriv)
 	if err != nil {
 		t.Fatalf("recorder.New: %v", err)
 	}
@@ -73,7 +78,7 @@ func TestProducer_EnqueuesSignedCheckpointSegment(t *testing.T) {
 		if id != "audit-key-1" {
 			return conductor.SignatureKey{}, errors.New("unknown key")
 		}
-		return conductor.SignatureKey{PublicKey: pub, KeyPurpose: signing.PurposeAuditBatchSigning}, nil
+		return conductor.SignatureKey{PublicKey: auditPub, KeyPurpose: signing.PurposeAuditBatchSigning}, nil
 	}); err != nil {
 		t.Fatalf("VerifySignatures: %v", err)
 	}
@@ -92,7 +97,7 @@ func TestProducer_EnqueuesSignedCheckpointSegment(t *testing.T) {
 	if batch.Envelope.Chain.CheckpointSignerKeyID != "recorder-key-1" {
 		t.Fatalf("checkpoint signer = %q", batch.Envelope.Chain.CheckpointSignerKeyID)
 	}
-	if batch.Envelope.Chain.FollowerRecorderPubHex != hex.EncodeToString(pub) {
+	if batch.Envelope.Chain.FollowerRecorderPubHex != hex.EncodeToString(recorderPub) {
 		t.Fatalf("recorder public key mismatch")
 	}
 	var decoded []recorder.Entry
@@ -118,14 +123,15 @@ func TestProducer_CloseRacesWithObserver(t *testing.T) {
 		t.Fatalf("Open queue: %v", err)
 	}
 	producer, err := NewProducer(ProducerConfig{
-		Queue:            q,
-		OrgID:            "org-main",
-		FleetID:          "prod",
-		InstanceID:       "pl-prod-1",
-		AuditSignerKeyID: "audit-key-1",
-		RecorderKeyID:    "recorder-key-1",
-		AuditSigner:      priv,
-		BufferSize:       1,
+		Queue:             q,
+		OrgID:             "org-main",
+		FleetID:           "prod",
+		InstanceID:        "pl-prod-1",
+		AuditSignerKeyID:  "audit-key-1",
+		RecorderKeyID:     "recorder-key-1",
+		AuditSigner:       priv,
+		RecorderPublicKey: priv.Public().(ed25519.PublicKey),
+		BufferSize:        1,
 	})
 	if err != nil {
 		t.Fatalf("NewProducer: %v", err)
@@ -148,6 +154,89 @@ func TestProducer_CloseRacesWithObserver(t *testing.T) {
 	}
 	stop.Store(true)
 	wg.Wait()
+}
+
+func TestNewProducer_RequiresRecorderPublicKey(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	if err != nil {
+		t.Fatalf("Open queue: %v", err)
+	}
+	_, err = NewProducer(ProducerConfig{
+		Queue:            q,
+		OrgID:            "org-main",
+		FleetID:          "prod",
+		InstanceID:       "pl-prod-1",
+		AuditSignerKeyID: "audit-key-1",
+		RecorderKeyID:    "recorder-key-1",
+		AuditSigner:      priv,
+	})
+	if err == nil || !strings.Contains(err.Error(), "recorder public key length=0") {
+		t.Fatalf("NewProducer() = %v, want recorder public key length error", err)
+	}
+}
+
+func TestNewProducer_RejectsInvalidConfig(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	if err != nil {
+		t.Fatalf("Open queue: %v", err)
+	}
+	tests := []struct {
+		name   string
+		mutate func(*ProducerConfig)
+		want   string
+	}{
+		{
+			name:   "missing_queue",
+			mutate: func(cfg *ProducerConfig) { cfg.Queue = nil },
+			want:   "queue required",
+		},
+		{
+			name:   "bad_audit_signer",
+			mutate: func(cfg *ProducerConfig) { cfg.AuditSigner = ed25519.PrivateKey("short") },
+			want:   "private key length",
+		},
+		{
+			name:   "bad_recorder_public_key",
+			mutate: func(cfg *ProducerConfig) { cfg.RecorderPublicKey = ed25519.PublicKey("short") },
+			want:   "recorder public key length",
+		},
+		{
+			name:   "bad_identifier",
+			mutate: func(cfg *ProducerConfig) { cfg.InstanceID = "-bad" },
+			want:   "instance_id must start",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := ProducerConfig{
+				Queue:             q,
+				OrgID:             "org-main",
+				FleetID:           "prod",
+				InstanceID:        "pl-prod-1",
+				AuditSignerKeyID:  "audit-key-1",
+				RecorderKeyID:     "recorder-key-1",
+				AuditSigner:       priv,
+				RecorderPublicKey: pub,
+			}
+			tc.mutate(&cfg)
+			producer, err := NewProducer(cfg)
+			if producer != nil {
+				_ = producer.Close()
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("NewProducer() = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
 }
 
 // TestProducer_AdvancesChainTailOnDroppedSegment proves the evidence chain
@@ -285,18 +374,103 @@ func TestProducer_ReleaseDroppedPreservesConcurrentDrops(t *testing.T) {
 	}
 }
 
+func TestProducer_EnqueueSegmentDropPaths(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tests := []struct {
+		name   string
+		mutate func([]recorder.Entry) []recorder.Entry
+		want   string
+	}{
+		{
+			name: "marshal_error",
+			mutate: func(seg []recorder.Entry) []recorder.Entry {
+				seg[0].Detail = map[string]any{"bad": make(chan int)}
+				return seg
+			},
+			want: producerDropEnqueueError,
+		},
+		{
+			name: "payload_too_large",
+			mutate: func(seg []recorder.Entry) []recorder.Entry {
+				seg[0].Detail = map[string]any{"large": strings.Repeat("x", conductor.MaxAuditPayloadBytes)}
+				return seg
+			},
+			want: producerDropPayloadTooLarge,
+		},
+		{
+			name: "non_checkpoint_tail",
+			mutate: func(seg []recorder.Entry) []recorder.Entry {
+				seg[1].Type = "action_receipt"
+				return seg
+			},
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+			if err != nil {
+				t.Fatalf("Open queue: %v", err)
+			}
+			p := newTestProducer(t, q, nil, priv)
+			defer func() { _ = p.Close() }()
+
+			seg := tc.mutate(checkpointSegment(0))
+			err = p.enqueueSegment(seg)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("enqueueSegment() = %v, want nil", err)
+				}
+				if got := p.droppedAccounting().Count; got != 0 {
+					t.Fatalf("dropped count = %d, want 0", got)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("enqueueSegment() = %v, want substring %q", err, tc.want)
+			}
+			accounting := p.droppedAccounting()
+			if accounting.Count != uint64(len(seg)) {
+				t.Fatalf("dropped count = %d, want %d", accounting.Count, len(seg))
+			}
+		})
+	}
+}
+
+func TestProducerHelpers(t *testing.T) {
+	if got := ed25519SignatureString("ed25519:abc"); got != "ed25519:abc" {
+		t.Fatalf("prefixed signature = %q", got)
+	}
+	if got := ed25519SignatureString("abc"); got != "ed25519:abc" {
+		t.Fatalf("unprefixed signature = %q", got)
+	}
+	if got := segmentID("", 1, 2); got != "segment-recorder-00000000000000000001-00000000000000000002" {
+		t.Fatalf("segmentID(empty) = %q", got)
+	}
+	if got := safeSegmentPart("a/b:c"); got != "abc" {
+		t.Fatalf("safeSegmentPart() = %q", got)
+	}
+	if got := safeSegmentPart("///"); got != "recorder" {
+		t.Fatalf("safeSegmentPart(empty) = %q", got)
+	}
+}
+
 func newTestProducer(t *testing.T, q *Queue, metrics MetricsSink, priv ed25519.PrivateKey) *Producer {
 	t.Helper()
 	p, err := NewProducer(ProducerConfig{
-		Queue:            q,
-		Metrics:          metrics,
-		OrgID:            "org-main",
-		FleetID:          "prod",
-		InstanceID:       "pl-prod-1",
-		AuditSignerKeyID: "audit-key-1",
-		RecorderKeyID:    "recorder-key-1",
-		AuditSigner:      priv,
-		Now:              func() time.Time { return time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC) },
+		Queue:             q,
+		Metrics:           metrics,
+		OrgID:             "org-main",
+		FleetID:           "prod",
+		InstanceID:        "pl-prod-1",
+		AuditSignerKeyID:  "audit-key-1",
+		RecorderKeyID:     "recorder-key-1",
+		AuditSigner:       priv,
+		RecorderPublicKey: priv.Public().(ed25519.PublicKey),
+		Now:               func() time.Time { return time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC) },
 	})
 	if err != nil {
 		t.Fatalf("NewProducer: %v", err)

--- a/internal/conductor/auditbatcher/producer_test.go
+++ b/internal/conductor/auditbatcher/producer_test.go
@@ -5,10 +5,13 @@ package auditbatcher
 
 import (
 	"crypto/ed25519"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -145,6 +148,193 @@ func TestProducer_CloseRacesWithObserver(t *testing.T) {
 	}
 	stop.Store(true)
 	wg.Wait()
+}
+
+// TestProducer_AdvancesChainTailOnDroppedSegment proves the evidence chain
+// stays continuous across a dropped segment. When a segment cannot ship (here:
+// a full durable queue) the recorder has already committed its checkpoint
+// locally, so previousSegmentTail must still advance — otherwise the next
+// segment would claim continuity across a checkpoint that actually exists in
+// the local recorder file, and a verifier replaying that file would reject the
+// chain.
+func TestProducer_AdvancesChainTailOnDroppedSegment(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue"), MaxPending: 1})
+	if err != nil {
+		t.Fatalf("Open queue: %v", err)
+	}
+	metrics := &transportMetricsRecorder{}
+	p := newTestProducer(t, q, metrics, priv)
+	defer func() { _ = p.Close() }()
+
+	// Segment A succeeds and fills the MaxPending=1 queue.
+	segA := checkpointSegment(0)
+	if err := p.enqueueSegment(segA); err != nil {
+		t.Fatalf("segA enqueue: %v", err)
+	}
+	if p.previousSegmentTail != segA[1].Hash {
+		t.Fatalf("tail after A = %q, want %q", p.previousSegmentTail, segA[1].Hash)
+	}
+
+	// Segment B is dropped because the queue is full, but its checkpoint was
+	// recorded locally — the tail must advance to B's checkpoint hash.
+	segB := checkpointSegment(2)
+	if err := p.enqueueSegment(segB); err == nil {
+		t.Fatal("segB enqueue: expected failure on full queue")
+	}
+	if p.previousSegmentTail != segB[1].Hash {
+		t.Fatalf("tail after dropped B = %q, want advanced to %q", p.previousSegmentTail, segB[1].Hash)
+	}
+	if got := metrics.delivery["drop:queue_full"]; got != 1 {
+		t.Fatalf("queue_full drop metric = %d, want 1", got)
+	}
+
+	// Free the queue and ship segment C. It must link back to dropped B's
+	// tail, demonstrating the chain is continuous across the gap.
+	if _, err := q.Claim(); err != nil {
+		t.Fatalf("Claim segA: %v", err)
+	}
+	segC := checkpointSegment(4)
+	if err := p.enqueueSegment(segC); err != nil {
+		t.Fatalf("segC enqueue: %v", err)
+	}
+	lease, err := q.Claim()
+	if err != nil {
+		t.Fatalf("Claim segC: %v", err)
+	}
+	if got := lease.Batch.Envelope.Chain.PreviousSegmentTail; got != segB[1].Hash {
+		t.Fatalf("segC PreviousSegmentTail = %q, want dropped-B tail %q", got, segB[1].Hash)
+	}
+	// The carried drop accounting from B must surface in C's signed envelope.
+	if lease.Batch.Envelope.Dropped.Count != uint64(len(segB)) {
+		t.Fatalf("segC dropped count = %d, want %d", lease.Batch.Envelope.Dropped.Count, len(segB))
+	}
+}
+
+// TestProducer_AdvancesTailAndRecordsMetricOnInvalidCheckpoint covers the
+// invalid-checkpoint drop path: the tail still advances (the recorder wrote
+// the checkpoint) and the drop metric carries the right reason. Nothing is
+// enqueued.
+func TestProducer_AdvancesTailAndRecordsMetricOnInvalidCheckpoint(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	if err != nil {
+		t.Fatalf("Open queue: %v", err)
+	}
+	metrics := &transportMetricsRecorder{}
+	p := newTestProducer(t, q, metrics, priv)
+	defer func() { _ = p.Close() }()
+
+	seg := checkpointSegment(0)
+	seg[1].Detail = recorder.CheckpointDetail{} // strip the checkpoint signature
+	if err := p.enqueueSegment(seg); err == nil {
+		t.Fatal("expected invalid checkpoint error")
+	}
+	if p.previousSegmentTail != seg[1].Hash {
+		t.Fatalf("tail not advanced on invalid checkpoint: %q", p.previousSegmentTail)
+	}
+	if got := metrics.delivery["drop:invalid_checkpoint"]; got != 1 {
+		t.Fatalf("invalid_checkpoint drop metric = %d, want 1", got)
+	}
+	stats, err := q.Stats()
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if stats.Pending != 0 {
+		t.Fatalf("pending = %d, want 0 (nothing enqueued)", stats.Pending)
+	}
+}
+
+func TestProducer_ReleaseDroppedPreservesConcurrentDrops(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	if err != nil {
+		t.Fatalf("Open queue: %v", err)
+	}
+	p := newTestProducer(t, q, nil, priv)
+	defer func() { _ = p.Close() }()
+
+	p.drop(producerDropQueueFull, 2)
+	included := p.droppedAccounting()
+	p.drop(producerDropQueueFull, 1)
+	p.drop(producerDropChannelFull, 1)
+
+	p.releaseDropped(included)
+	got := p.droppedAccounting()
+	if got.Count != 2 {
+		t.Fatalf("dropped count after release = %d, want 2", got.Count)
+	}
+	reasons := map[string]uint64{}
+	for _, reason := range got.Reasons {
+		reasons[reason.Reason] = reason.Count
+	}
+	if reasons[producerDropQueueFull] != 1 {
+		t.Fatalf("remaining queue_full drops = %d, want 1", reasons[producerDropQueueFull])
+	}
+	if reasons[producerDropChannelFull] != 1 {
+		t.Fatalf("remaining channel_full drops = %d, want 1", reasons[producerDropChannelFull])
+	}
+}
+
+func newTestProducer(t *testing.T, q *Queue, metrics MetricsSink, priv ed25519.PrivateKey) *Producer {
+	t.Helper()
+	p, err := NewProducer(ProducerConfig{
+		Queue:            q,
+		Metrics:          metrics,
+		OrgID:            "org-main",
+		FleetID:          "prod",
+		InstanceID:       "pl-prod-1",
+		AuditSignerKeyID: "audit-key-1",
+		RecorderKeyID:    "recorder-key-1",
+		AuditSigner:      priv,
+		Now:              func() time.Time { return time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	return p
+}
+
+// checkpointSegment builds a [regular, checkpoint] entry pair with valid
+// 64-hex chain hashes and a well-formed checkpoint signature so the producer
+// can construct and sign a valid envelope. start and start+1 are the two
+// sequence numbers.
+func checkpointSegment(start uint64) []recorder.Entry {
+	reg := recorder.Entry{
+		Version:   recorder.EntryVersion,
+		Sequence:  start,
+		SessionID: "proxy",
+		Type:      "action_receipt",
+		Hash:      segmentHashHex(fmt.Sprintf("head-%d", start)),
+	}
+	cp := recorder.Entry{
+		Version:   recorder.EntryVersion,
+		Sequence:  start + 1,
+		SessionID: "proxy",
+		Type:      "checkpoint",
+		Hash:      segmentHashHex(fmt.Sprintf("tail-%d", start+1)),
+		Detail: recorder.CheckpointDetail{
+			EntryCount: 2,
+			FirstSeq:   start,
+			LastSeq:    start + 1,
+			Signature:  strings.Repeat("ab", ed25519.SignatureSize),
+		},
+	}
+	return []recorder.Entry{reg, cp}
+}
+
+func segmentHashHex(seed string) string {
+	sum := sha256.Sum256([]byte(seed))
+	return hex.EncodeToString(sum[:])
 }
 
 func testRecorderEntry(summary string) recorder.Entry {

--- a/internal/conductor/messages.go
+++ b/internal/conductor/messages.go
@@ -1183,7 +1183,7 @@ func validateWindow(notBefore, expiresAt time.Time) error {
 }
 
 func validateSeqRange(start, end uint64) error {
-	if start == 0 || end == 0 || end < start {
+	if end < start {
 		return fmt.Errorf("%w: start=%d end=%d", ErrInvalidSequenceRange, start, end)
 	}
 	return nil

--- a/internal/config/conductor.go
+++ b/internal/config/conductor.go
@@ -49,14 +49,28 @@ func (c *Config) validateConductor(warnings *[]Warning) error {
 	if err := validateConductorURL(cfg.ConductorURL); err != nil {
 		return err
 	}
-	for field, value := range map[string]string{
-		"conductor.org_id":      cfg.OrgID,
-		"conductor.fleet_id":    cfg.FleetID,
-		"conductor.instance_id": cfg.InstanceID,
+	for _, id := range []struct {
+		field string
+		value string
+	}{
+		{field: "conductor.org_id", value: cfg.OrgID},
+		{field: "conductor.fleet_id", value: cfg.FleetID},
+		{field: "conductor.instance_id", value: cfg.InstanceID},
+		{field: "conductor.audit_signing_key_id", value: cfg.AuditSigningKeyID},
+		{field: "conductor.recorder_key_id", value: cfg.RecorderKeyID},
 	} {
-		if err := validateConductorIdentifier(field, value); err != nil {
+		if err := validateConductorIdentifier(id.field, id.value); err != nil {
 			return err
 		}
+	}
+	if !c.FlightRecorder.Enabled {
+		return fmt.Errorf("flight_recorder.enabled must be true when conductor.enabled is true")
+	}
+	if !c.FlightRecorder.SignCheckpoints {
+		return fmt.Errorf("flight_recorder.sign_checkpoints must be true when conductor.enabled is true")
+	}
+	if strings.TrimSpace(c.FlightRecorder.SigningKeyPath) == "" {
+		return fmt.Errorf("flight_recorder.signing_key_path required when conductor.enabled is true")
 	}
 	for field, value := range map[string]string{
 		"conductor.trust_roster_path":       cfg.TrustRosterPath,

--- a/internal/config/conductor_test.go
+++ b/internal/config/conductor_test.go
@@ -54,9 +54,47 @@ func TestValidateConductor_DisabledStillValidatesLocalSafetyKnobs(t *testing.T) 
 func TestValidateConductor_Enabled(t *testing.T) {
 	cfg := Defaults()
 	cfg.Conductor = validConductorConfig(t)
+	configureConductorRecorder(t, cfg)
 
 	if _, err := cfg.ValidateWithWarnings(); err != nil {
 		t.Fatalf("ValidateWithWarnings() error = %v", err)
+	}
+}
+
+func TestValidateConductor_RequiresSignedFlightRecorder(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+		want   string
+	}{
+		{
+			name:   "disabled",
+			mutate: func(cfg *Config) { cfg.FlightRecorder.Enabled = false },
+			want:   "flight_recorder.enabled must be true",
+		},
+		{
+			name:   "unsigned_checkpoints",
+			mutate: func(cfg *Config) { cfg.FlightRecorder.SignCheckpoints = false },
+			want:   "flight_recorder.sign_checkpoints must be true",
+		},
+		{
+			name:   "missing_signing_key",
+			mutate: func(cfg *Config) { cfg.FlightRecorder.SigningKeyPath = "" },
+			want:   "flight_recorder.signing_key_path required",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Defaults()
+			cfg.Conductor = validConductorConfig(t)
+			configureConductorRecorder(t, cfg)
+			tc.mutate(cfg)
+
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate() = %v, want substring %q", err, tc.want)
+			}
+		})
 	}
 }
 
@@ -137,6 +175,7 @@ func TestValidateConductor_RejectsInvalidEnabledConfig(t *testing.T) {
 			conductor := validConductorConfig(t)
 			tc.mutate(&conductor)
 			cfg.Conductor = conductor
+			configureConductorRecorder(t, cfg)
 
 			err := cfg.Validate()
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
@@ -189,6 +228,7 @@ func TestValidateConductor_RejectsWorldWritableParents(t *testing.T) {
 			conductor := validConductorConfig(t)
 			tc.mutate(&conductor)
 			cfg.Conductor = conductor
+			configureConductorRecorder(t, cfg)
 
 			err := cfg.Validate()
 			if err == nil || !strings.Contains(err.Error(), "world-writable parent") {
@@ -219,6 +259,7 @@ func TestValidateConductor_RejectsSymlinkResolvedWorldWritableParent(t *testing.
 	}
 	conductor.BundleCacheDir = filepath.Join(link, "bundles")
 	cfg.Conductor = conductor
+	configureConductorRecorder(t, cfg)
 
 	err := cfg.Validate()
 	if err == nil || !strings.Contains(err.Error(), "world-writable parent") {
@@ -231,6 +272,7 @@ func TestValidateConductor_StalePolicyOverrideWarns(t *testing.T) {
 	conductor := validConductorConfig(t)
 	conductor.StalePolicy.AfterGrace = ConductorStaleContinueLastKnownGood
 	cfg.Conductor = conductor
+	configureConductorRecorder(t, cfg)
 
 	warnings, err := cfg.ValidateWithWarnings()
 	if err != nil {
@@ -326,6 +368,15 @@ func validConductorConfig(t *testing.T) Conductor {
 		MaxCapabilityThreshold: 7,
 		StalePolicy:            ConductorStalePolicy{GraceMultiplier: 1, AfterGrace: ConductorStaleStrictDenyAll},
 	}
+}
+
+func configureConductorRecorder(t *testing.T, cfg *Config) {
+	t.Helper()
+	root := privateTempDir(t)
+	cfg.FlightRecorder.Enabled = true
+	cfg.FlightRecorder.Dir = filepath.Join(root, "recorder")
+	cfg.FlightRecorder.SignCheckpoints = true
+	cfg.FlightRecorder.SigningKeyPath = filepath.Join(root, "recorder.key")
 }
 
 func privateTempDir(t *testing.T) string {

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -35,6 +35,12 @@ func normalizeLearn(l *Learn) {
 }
 
 func normalizeConductor(c *Conductor) {
+	if c.AuditSigningKeyID == "" && c.InstanceID != "" {
+		c.AuditSigningKeyID = c.InstanceID
+	}
+	if c.RecorderKeyID == "" && c.InstanceID != "" {
+		c.RecorderKeyID = c.InstanceID
+	}
 	if c.PollInterval == "" {
 		c.PollInterval = "30s"
 	}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -331,6 +331,8 @@ type Conductor struct {
 	ClientKeyPath          string               `yaml:"client_key_path"`
 	BundleCacheDir         string               `yaml:"bundle_cache_dir"`
 	DurableAuditQueueDir   string               `yaml:"durable_audit_queue_dir"`
+	AuditSigningKeyID      string               `yaml:"audit_signing_key_id"`
+	RecorderKeyID          string               `yaml:"recorder_key_id"`
 	PollInterval           string               `yaml:"poll_interval"`
 	HonorRemoteKillSwitch  bool                 `yaml:"honor_remote_kill_switch"`
 	EmergencyStream        *bool                `yaml:"emergency_stream"`

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -83,12 +83,20 @@ func safeEvidenceFileMode(mode os.FileMode) bool {
 // RedactFunc is the signature for DLP redaction. Matches scanner.ScanTextForDLP.
 type RedactFunc func(ctx context.Context, text string) scanner.TextDLPResult
 
+// EntryObserver receives entries after they are durably flushed to the
+// recorder. Observer failures must be handled internally; recorder writes
+// cannot depend on optional downstream transports.
+type EntryObserver interface {
+	ObserveRecorderEntry(Entry)
+}
+
 // Recorder writes hash-chained evidence entries to JSONL files.
 type Recorder struct {
 	cfg       Config
 	redactFn  RedactFunc
 	privKey   ed25519.PrivateKey
 	escrowPub *[x25519KeySize]byte
+	observer  EntryObserver
 
 	mu             sync.Mutex
 	seq            uint64
@@ -176,6 +184,18 @@ func (r *Recorder) Dir() string {
 		return ""
 	}
 	return r.cfg.Dir
+}
+
+// SetObserver installs an optional post-write observer for newly recorded
+// entries. It is intended for durable audit fan-out that must see the same
+// recorder v2 entries written locally.
+func (r *Recorder) SetObserver(observer EntryObserver) {
+	if r == nil || r.nop {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.observer = observer
 }
 
 // Record writes an entry to the chain. Thread-safe. The caller provides the
@@ -708,7 +728,21 @@ func (r *Recorder) writeEntry(e Entry) error {
 	if _, err := r.writer.Write([]byte("\n")); err != nil {
 		return err
 	}
-	return r.writer.Flush()
+	if err := r.writer.Flush(); err != nil {
+		return err
+	}
+	r.notifyObserver(e)
+	return nil
+}
+
+func (r *Recorder) notifyObserver(e Entry) {
+	if r.observer == nil {
+		return
+	}
+	defer func() {
+		_ = recover()
+	}()
+	r.observer.ObserveRecorderEntry(e)
 }
 
 // closeFile flushes and closes the current file.

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -72,6 +72,76 @@ func TestRecorder_Dir(t *testing.T) {
 	})
 }
 
+func TestRecorder_EntryObserver(t *testing.T) {
+	t.Run("observes_flushed_entry", func(t *testing.T) {
+		rec, err := recorder.New(recorder.Config{
+			Enabled:            true,
+			Dir:                t.TempDir(),
+			CheckpointInterval: 100,
+		}, nil, nil)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		defer func() { _ = rec.Close() }()
+
+		observer := &testEntryObserver{}
+		rec.SetObserver(observer)
+		if err := rec.Record(recorder.Entry{
+			SessionID: testSessionID,
+			Type:      testType,
+			Transport: testTransport,
+			Summary:   "observer proof",
+		}); err != nil {
+			t.Fatalf("Record: %v", err)
+		}
+		observer.mu.Lock()
+		defer observer.mu.Unlock()
+		if len(observer.entries) != 1 {
+			t.Fatalf("observed entries = %d, want 1", len(observer.entries))
+		}
+		if observer.entries[0].Summary != "observer proof" {
+			t.Fatalf("observed summary = %q", observer.entries[0].Summary)
+		}
+	})
+
+	t.Run("observer_panic_isolated", func(t *testing.T) {
+		rec, err := recorder.New(recorder.Config{
+			Enabled:            true,
+			Dir:                t.TempDir(),
+			CheckpointInterval: 100,
+		}, nil, nil)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		defer func() { _ = rec.Close() }()
+
+		rec.SetObserver(panicEntryObserver{})
+		if err := rec.Record(recorder.Entry{
+			SessionID: testSessionID,
+			Type:      testType,
+			Transport: testTransport,
+			Summary:   "panic proof",
+		}); err != nil {
+			t.Fatalf("Record with panicking observer: %v", err)
+		}
+	})
+
+	t.Run("disabled_recorder_ignores_observer", func(t *testing.T) {
+		rec, err := recorder.New(recorder.Config{Enabled: false}, nil, nil)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		observer := &testEntryObserver{}
+		rec.SetObserver(observer)
+		if err := rec.Record(recorder.Entry{Summary: "nop"}); err != nil {
+			t.Fatalf("Record disabled: %v", err)
+		}
+		if len(observer.entries) != 0 {
+			t.Fatalf("disabled recorder observed %d entries, want 0", len(observer.entries))
+		}
+	})
+}
+
 func TestRecorder_FileMode(t *testing.T) {
 	t.Parallel()
 
@@ -2108,3 +2178,20 @@ func TestRecorder_ReceiptRedaction(t *testing.T) {
 
 // filePermissions for test file creation.
 const filePermissions = 0o600
+
+type testEntryObserver struct {
+	mu      sync.Mutex
+	entries []recorder.Entry
+}
+
+func (o *testEntryObserver) ObserveRecorderEntry(entry recorder.Entry) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.entries = append(o.entries, entry)
+}
+
+type panicEntryObserver struct{}
+
+func (panicEntryObserver) ObserveRecorderEntry(recorder.Entry) {
+	panic("observer panic")
+}


### PR DESCRIPTION
## Summary
- wires the flight recorder to a Conductor audit producer that batches recorder v2 checkpoint spans into the durable audit queue
- signs each audit batch envelope with bounded drop accounting and chain metadata
- requires signed flight-recorder evidence when Conductor is enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conductor audit batching: durably queued, cryptographically signed checkpoint batches; flight recorder integration and observer hook for post-flush entries.
* **Configuration**
  * New conductor audit and recorder key IDs (default to instance ID when omitted).
  * Enabling conductor now requires flight recorder with signed checkpoints and a configured signing key; stronger identifier validation.
* **Tests**
  * Expanded test coverage for producer, recorder observer, and conductor validation.
* **Documentation**
  * Updated conductor audit batcher design spec.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->