### PR TITLE
feat(scan): detect invisible-Unicode/bidi injection in files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,11 @@ jobs:
   test:
     needs: [security-scan]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Bumped 15 -> 20 after the mcp-only/mcpwrap test suite (PR #610) landed
+    # ~1300 lines of new tests; Go 1.26 was hitting the 15m wall on a clean
+    # ubuntu-latest runner. 1.25 still finishes in ~9m so the headroom is
+    # for the slower 1.26 cell, not a general slowdown.
+    timeout-minutes: 20
     strategy:
       matrix:
         go-version: ['1.25', '1.26']

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ brew install luckyPipewrench/tap/pipelock
 pipelock init
 
 # Test it
-pipelock check --url "https://example.com/?key=EXAMPLE-SECRET-VALUE-1234"  # blocked
-pipelock check --url "https://docs.python.org/3/"                            # allowed
+pipelock check --url "https://evil.com/?k=AKIAIOSFODNN7EXAMPLE"  # blocked: AWS Access ID
+pipelock check --url "https://docs.python.org/3/"                # allowed
 ```
 
 <details>

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/cli/policy"
 	"github.com/luckyPipewrench/pipelock/internal/cli/rules"
 	"github.com/luckyPipewrench/pipelock/internal/cli/runtime"
+	"github.com/luckyPipewrench/pipelock/internal/cli/scan"
 	"github.com/luckyPipewrench/pipelock/internal/cli/session"
 	"github.com/luckyPipewrench/pipelock/internal/cli/setup"
 	clisigning "github.com/luckyPipewrench/pipelock/internal/cli/signing"
@@ -115,6 +116,8 @@ Quick start:
 		runtime.SandboxCmd(),
 		runtime.InternalRedirectCmd(),
 		runtime.HealthcheckCmd(),
+		// File injection scanning (invisible-Unicode / bidi)
+		scan.Cmd(),
 		// Session admin (airlock recovery)
 		session.AdaptiveCmd(),
 		session.Cmd(),

--- a/internal/cli/scan/scan.go
+++ b/internal/cli/scan/scan.go
@@ -1,0 +1,164 @@
+// Package scan implements the `pipelock scan` command: it inspects files for
+// invisible-Unicode and bidi-control injection (the supply-chain vector that
+// hides instructions in agent-context files). It complements the network
+// scanner — pipelock the proxy never sees files at rest, so this surfaces the
+// local-file half of the attack and lets pre-commit hooks and CI gate on it.
+package scan
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/filescan"
+)
+
+// Exit codes (distinct so CI wrappers can tell findings from a broken scan):
+//
+//	0 = clean, 1 = findings at/above the gating severity, 2 = scan/IO/config error.
+const (
+	exitFindings = 1
+	exitError    = 2
+)
+
+// severityRank orders severities for threshold gating (higher = more severe).
+var severityRank = map[filescan.Severity]int{
+	filescan.SeverityLow:  1,
+	filescan.SeverityMed:  2,
+	filescan.SeverityHigh: 3,
+}
+
+// Cmd builds the `pipelock scan` command.
+func Cmd() *cobra.Command {
+	var (
+		jsonOutput  bool
+		maxBytes    int64
+		exclude     []string
+		minSeverity string
+		includeDeps bool
+		failOnSkip  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "scan [path...]",
+		Short: "Scan files for invisible-Unicode / bidi-control injection",
+		Long: `Scan files or directories for hidden Unicode characters used to inject
+instructions into agent-context files (CLAUDE.md, .cursorrules, AGENTS.md,
+skill definitions) — zero-width, bidi-override, tag, and control characters a
+human reviewer cannot see. This is the local-file half of supply-chain prompt
+injection; the network proxy cannot see files at rest.
+
+Findings carry a severity (high/medium/low) because not every invisible
+character is equally suspicious in a file: a leading BOM, an emoji ZWJ, or a
+soft hyphen in prose are low; a right-to-left override or tag character inside
+an instruction file is high. Use --min-severity to control what causes a
+non-zero exit. The default gates on high severity and reports lower severities.
+
+Exit codes: 0 = no gated findings; 1 = findings at/above --min-severity;
+2 = scan/config error, an explicitly named file was skipped (binary, symlink,
+oversized), or --fail-on-skip and any file was skipped.
+
+Examples:
+  pipelock scan                          # scan the current directory
+  pipelock scan CLAUDE.md .cursorrules
+  pipelock scan ~/.claude/skills --json
+  pipelock scan . --min-severity medium  # also gate on suspicious-but-contextual chars
+  pipelock scan . --fail-on-skip         # fail CI if anything went uninspected
+  pipelock scan . --include-deps         # also scan vendored/node_modules context`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			threshold, ok := severityRank[filescan.Severity(minSeverity)]
+			if !ok {
+				return cliutil.ExitCodeError(exitError,
+					fmt.Errorf("invalid --min-severity %q (want high, medium, or low)", minSeverity))
+			}
+			explicitArgs := len(args) > 0
+			if !explicitArgs {
+				args = []string{"."}
+			}
+
+			res, err := filescan.ScanPaths(args, filescan.Options{
+				MaxFileBytes:     maxBytes,
+				ExtraExcludeDirs: exclude,
+				IncludeDepDirs:   includeDeps,
+			})
+			if err != nil {
+				return cliutil.ExitCodeError(exitError, err)
+			}
+
+			if jsonOutput {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetEscapeHTML(false)
+				enc.SetIndent("", "  ")
+				if encErr := enc.Encode(res); encErr != nil {
+					return cliutil.ExitCodeError(exitError, encErr)
+				}
+			} else {
+				w := bufio.NewWriter(cmd.OutOrStdout())
+				res.WriteReport(w)
+			}
+
+			if failOnSkip && len(res.Skipped) > 0 {
+				return cliutil.ExitCodeError(exitError,
+					fmt.Errorf("scan skipped %d file(s); rerun without --fail-on-skip to allow skips", len(res.Skipped)))
+			}
+			if explicitSkipped := explicitlySkippedFiles(args, res.Skipped); explicitSkipped > 0 {
+				return cliutil.ExitCodeError(exitError,
+					fmt.Errorf("scan skipped %d explicitly requested file(s)", explicitSkipped))
+			}
+
+			gating := 0
+			for _, f := range res.Findings {
+				if severityRank[f.Severity] >= threshold {
+					gating++
+				}
+			}
+			if gating > 0 {
+				return cliutil.ExitCodeError(exitFindings,
+					fmt.Errorf("%w: %d at/above %s in %d file(s)",
+						filescan.ErrFindings, gating, minSeverity, res.FilesScanned))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit findings as JSON")
+	cmd.Flags().Int64Var(&maxBytes, "max-bytes", 0, "skip files larger than N bytes (default 5 MiB)")
+	cmd.Flags().StringSliceVar(&exclude, "exclude", nil, "additional directory names to skip")
+	cmd.Flags().StringVar(&minSeverity, "min-severity", "high", "minimum severity that causes a non-zero exit (high|medium|low)")
+	cmd.Flags().BoolVar(&includeDeps, "include-deps", false, "also scan dependency/VCS dirs (node_modules, vendor, .git, ...)")
+	cmd.Flags().BoolVar(&failOnSkip, "fail-on-skip", false, "exit 2 if any file is skipped")
+
+	return cmd
+}
+
+func explicitlySkippedFiles(args []string, skipped []filescan.Skip) int {
+	if len(skipped) == 0 {
+		return 0
+	}
+	explicitFiles := map[string]struct{}{}
+	for _, arg := range args {
+		clean := filepath.Clean(arg)
+		info, err := os.Lstat(clean)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		explicitFiles[clean] = struct{}{}
+	}
+	if len(explicitFiles) == 0 {
+		return 0
+	}
+	var n int
+	for _, sk := range skipped {
+		if _, ok := explicitFiles[filepath.Clean(sk.Path)]; ok {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/cli/scan/scan_test.go
+++ b/internal/cli/scan/scan_test.go
@@ -1,0 +1,181 @@
+package scan
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/filescan"
+)
+
+// zw builds a string with the given codepoint so this source stays pure ASCII.
+func zw(r rune) string { return string(r) }
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := Cmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestScanCmd_Clean(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "ok.md"), "clean content\n")
+	out, err := run(t, dir)
+	if err != nil {
+		t.Fatalf("clean dir should exit 0, got %v", err)
+	}
+	if !strings.Contains(out, "0 finding(s)") {
+		t.Errorf("expected zero-finding tally, got: %q", out)
+	}
+}
+
+func TestScanCmd_Planted(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "CLAUDE.md"), "hi"+zw(0x200B)+"dden")
+	out, err := run(t, dir)
+	if !errors.Is(err, filescan.ErrFindings) {
+		t.Fatalf("planted file should return ErrFindings, got %v", err)
+	}
+	if code := cliutil.ExitCodeOf(err); code != exitFindings {
+		t.Errorf("exit code = %d, want %d", code, exitFindings)
+	}
+	if !strings.Contains(out, "U+200B") || !strings.Contains(out, "high") {
+		t.Errorf("report should name codepoint + severity, got: %q", out)
+	}
+}
+
+func TestScanCmd_JSON(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "f.md"), "a"+zw(0x202E)+"b")
+	out, err := run(t, "--json", dir)
+	if !errors.Is(err, filescan.ErrFindings) {
+		t.Fatalf("expected findings error, got %v", err)
+	}
+	var parsed struct {
+		Findings []struct {
+			CodePoint string `json:"code_point"`
+			Category  string `json:"category"`
+			Severity  string `json:"severity"`
+		} `json:"findings"`
+	}
+	if jErr := json.Unmarshal([]byte(out), &parsed); jErr != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", jErr, out)
+	}
+	if len(parsed.Findings) != 1 || parsed.Findings[0].CodePoint != "U+202E" {
+		t.Errorf("unexpected JSON findings: %+v", parsed.Findings)
+	}
+	if parsed.Findings[0].Category != "bidi-control" || parsed.Findings[0].Severity != "high" {
+		t.Errorf("want bidi-control/high, got %s/%s", parsed.Findings[0].Category, parsed.Findings[0].Severity)
+	}
+}
+
+func TestScanCmd_MinSeverityGating(t *testing.T) {
+	dir := t.TempDir()
+	// soft hyphen = low severity only
+	mustWrite(t, filepath.Join(dir, "prose.md"), "co"+zw(0x00AD)+"op")
+
+	t.Run("low finding does not trip default high threshold", func(t *testing.T) {
+		out, err := run(t, dir)
+		if err != nil {
+			t.Fatalf("low-only finding should exit 0 by default, got %v", err)
+		}
+		if !strings.Contains(out, "U+00AD") {
+			t.Errorf("finding should still be reported: %q", out)
+		}
+	})
+	t.Run("low finding trips explicit low threshold", func(t *testing.T) {
+		_, err := run(t, "--min-severity", "low", dir)
+		if !errors.Is(err, filescan.ErrFindings) {
+			t.Fatalf("explicit min-severity low should gate on the soft hyphen, got %v", err)
+		}
+	})
+}
+
+func TestScanCmd_SkipPolicy(t *testing.T) {
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "blob.bin")
+	if err := os.WriteFile(binary, []byte{'a', 0, 'b'}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("explicit skipped file is exit 2", func(t *testing.T) {
+		out, err := run(t, binary)
+		if err == nil || errors.Is(err, filescan.ErrFindings) {
+			t.Fatalf("explicit skipped file should be scan error, got %v\n%s", err, out)
+		}
+		if code := cliutil.ExitCodeOf(err); code != exitError {
+			t.Errorf("exit code = %d, want %d", code, exitError)
+		}
+		if !strings.Contains(out, "skipped") {
+			t.Errorf("skip should be visible in output: %q", out)
+		}
+	})
+
+	t.Run("directory skip is allowed by default", func(t *testing.T) {
+		out, err := run(t, dir)
+		if err != nil {
+			t.Fatalf("directory skip should not fail by default, got %v\n%s", err, out)
+		}
+		if !strings.Contains(out, "blob.bin") {
+			t.Errorf("skip should be visible in output: %q", out)
+		}
+	})
+
+	t.Run("fail-on-skip fails directory skips", func(t *testing.T) {
+		_, err := run(t, "--fail-on-skip", dir)
+		if err == nil || errors.Is(err, filescan.ErrFindings) {
+			t.Fatalf("--fail-on-skip should return scan error, got %v", err)
+		}
+		if code := cliutil.ExitCodeOf(err); code != exitError {
+			t.Errorf("exit code = %d, want %d", code, exitError)
+		}
+	})
+}
+
+func TestScanCmd_DefaultCwd(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "AGENTS.md"), "x"+zw(0x200B)+"y")
+	t.Chdir(dir)
+	_, err := run(t)
+	if !errors.Is(err, filescan.ErrFindings) {
+		t.Fatalf("default cwd scan should find planted char, got %v", err)
+	}
+}
+
+func TestScanCmd_Errors(t *testing.T) {
+	t.Run("missing path is exit 2", func(t *testing.T) {
+		_, err := run(t, filepath.Join(t.TempDir(), "does-not-exist"))
+		if err == nil || errors.Is(err, filescan.ErrFindings) {
+			t.Fatalf("missing path should be a scan error, got %v", err)
+		}
+		if code := cliutil.ExitCodeOf(err); code != exitError {
+			t.Errorf("exit code = %d, want %d", code, exitError)
+		}
+	})
+	t.Run("invalid min-severity is exit 2", func(t *testing.T) {
+		_, err := run(t, "--min-severity", "bogus", t.TempDir())
+		if err == nil {
+			t.Fatal("expected error for invalid severity")
+		}
+		if code := cliutil.ExitCodeOf(err); code != exitError {
+			t.Errorf("exit code = %d, want %d", code, exitError)
+		}
+	})
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/filescan/filescan.go
+++ b/internal/filescan/filescan.go
@@ -1,0 +1,378 @@
+// Package filescan detects invisible-Unicode and bidi-control characters
+// embedded in files. This is the product surface for the supply-chain injection
+// vector where an attacker plants hidden instructions in agent-context files
+// (CLAUDE.md, .cursorrules, AGENTS.md, skill definitions) using zero-width or
+// bidi-override characters that a human reviewer cannot see — the technique used
+// by campaigns such as TrapDoor.
+//
+// Detection is seeded from normalize.InvisibleRanges (the set pipelock strips in
+// its scanning paths) but is NOT a flat reuse of it: stripping in network
+// traffic and gating on files at rest are different decisions. File gating
+// produces developer-facing failures, so each flagged rune carries a severity by
+// class and context (a leading BOM or an emoji ZWJ is far less alarming than a
+// right-to-left override inside an instruction file). Detection is free-tier.
+package filescan
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Category classifies an invisible-character finding by attack relevance.
+type Category string
+
+const (
+	// CategoryBidi covers directional embedding/override/isolate controls used
+	// to reorder displayed text so the rendered line differs from byte order.
+	CategoryBidi Category = "bidi-control"
+	// CategoryTag covers the Unicode Tags block, which can smuggle a hidden
+	// ASCII payload that renders as nothing.
+	CategoryTag Category = "tag-char"
+	// CategoryZeroWidth covers zero-width and other non-rendering characters.
+	CategoryZeroWidth Category = "zero-width"
+	// CategoryControl covers C0/C1/DEL control characters (excluding the
+	// whitespace controls \t \n \r) — pipelock strips these in DLP paths too.
+	CategoryControl Category = "control-char"
+)
+
+// Severity ranks how alarming a finding is for repo gating. Not every invisible
+// character is equally suspicious in a file: a leading BOM is routine, an RLO
+// inside an instruction file is an attack.
+type Severity string
+
+const (
+	SeverityHigh Severity = "high"
+	SeverityMed  Severity = "medium"
+	SeverityLow  Severity = "low"
+)
+
+// Finding is one invisible/control character located in a scanned file.
+type Finding struct {
+	Path      string   `json:"path"`
+	Line      int      `json:"line"`
+	Col       int      `json:"col"` // 1-based rune column within the line
+	CodePoint string   `json:"code_point"`
+	Name      string   `json:"name"`
+	Category  Category `json:"category"`
+	Severity  Severity `json:"severity"`
+}
+
+// Skip records a file that was not scanned, with the reason, so the operator can
+// see exactly what went uninspected rather than only a count.
+type Skip struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
+// Result aggregates a scan over one or more paths.
+type Result struct {
+	Findings     []Finding `json:"findings"`
+	Skipped      []Skip    `json:"skipped"`
+	FilesScanned int       `json:"files_scanned"`
+}
+
+// Options tune a path scan. The zero value scans every readable text file under
+// the given paths, skipping common dependency/VCS directories.
+type Options struct {
+	// MaxFileBytes skips files larger than this (0 = default 5 MiB). Oversized
+	// files are reported as skips so a padded agent-context file cannot silently
+	// evade scanning.
+	MaxFileBytes int64
+	// ExtraExcludeDirs are directory names skipped in addition to the defaults.
+	ExtraExcludeDirs []string
+	// IncludeDepDirs scans dependency/VCS dirs that are skipped by default
+	// (node_modules, vendor, .git, ...). Off by default for speed; on when a
+	// supply-chain audit must cover vendored context files.
+	IncludeDepDirs bool
+}
+
+const defaultMaxFileBytes = 5 << 20 // 5 MiB
+
+// defaultExcludeDirs are large/noisy and rarely injectable agent context.
+var defaultExcludeDirs = map[string]struct{}{
+	".git": {}, "node_modules": {}, "vendor": {}, "dist": {},
+	".venv": {}, "__pycache__": {}, ".cache": {},
+}
+
+// suspectRune holds the policy for one flagged code point.
+type suspectRune struct {
+	name string
+	cat  Category
+	sev  Severity
+}
+
+// suspects is the file-scan policy table. Seeded from normalize.InvisibleRanges
+// plus deceptive characters that set omits (U+061C, U+180E, U+034F, U+2800), with
+// a severity assigned per class. Built once at init from rune ranges.
+var suspects = buildSuspects()
+
+func buildSuspects() map[rune]suspectRune {
+	m := map[rune]suspectRune{}
+	put := func(lo, hi rune, name string, cat Category, sev Severity) {
+		for r := lo; r <= hi; r++ {
+			m[r] = suspectRune{name: name, cat: cat, sev: sev}
+		}
+	}
+	// High: zero-width splitters and bidi controls — the core injection set.
+	put(0x200B, 0x200B, "ZERO WIDTH SPACE", CategoryZeroWidth, SeverityHigh)
+	put(0x200C, 0x200C, "ZERO WIDTH NON-JOINER", CategoryZeroWidth, SeverityLow) // legit in Persian/Arabic
+	put(0x200D, 0x200D, "ZERO WIDTH JOINER", CategoryZeroWidth, SeverityLow)     // legit in emoji
+	put(0x200E, 0x200F, "DIRECTIONAL MARK", CategoryBidi, SeverityMed)           // legit in bilingual text
+	put(0x202A, 0x202E, "BIDI EMBEDDING/OVERRIDE", CategoryBidi, SeverityHigh)
+	put(0x2066, 0x2069, "BIDI ISOLATE", CategoryBidi, SeverityHigh)
+	put(0x2060, 0x2060, "WORD JOINER", CategoryZeroWidth, SeverityHigh)
+	put(0x2061, 0x2064, "INVISIBLE OPERATOR", CategoryZeroWidth, SeverityMed)
+	put(0xFEFF, 0xFEFF, "ZERO WIDTH NO-BREAK SPACE (BOM)", CategoryZeroWidth, SeverityMed)
+	put(0x00AD, 0x00AD, "SOFT HYPHEN", CategoryZeroWidth, SeverityLow) // legit in prose
+	put(0x061C, 0x061C, "ARABIC LETTER MARK", CategoryBidi, SeverityMed)
+	put(0x034F, 0x034F, "COMBINING GRAPHEME JOINER", CategoryZeroWidth, SeverityLow)
+	put(0x180E, 0x180E, "MONGOLIAN VOWEL SEPARATOR", CategoryZeroWidth, SeverityMed)
+	put(0x2800, 0x2800, "BRAILLE PATTERN BLANK", CategoryZeroWidth, SeverityLow)
+	put(0x115F, 0x1160, "HANGUL FILLER", CategoryZeroWidth, SeverityMed)
+	put(0x3164, 0x3164, "HANGUL FILLER", CategoryZeroWidth, SeverityMed)
+	put(0xFFF9, 0xFFFB, "INTERLINEAR ANNOTATION", CategoryZeroWidth, SeverityMed)
+	put(0xFE00, 0xFE0F, "VARIATION SELECTOR", CategoryZeroWidth, SeverityLow) // legit in emoji
+	put(0xE0100, 0xE01EF, "VARIATION SELECTOR SUPPLEMENT", CategoryZeroWidth, SeverityLow)
+	put(0xE0000, 0xE007F, "TAG CHARACTER", CategoryTag, SeverityHigh) // can smuggle hidden ASCII
+	return m
+}
+
+// classifyRune returns the policy for r, plus whether r is flagged at all.
+// C0/C1/DEL controls (excluding \t \n \r) are flagged as medium even though they
+// are outside the suspect table — pipelock strips them in DLP paths and they have
+// no business in agent-context files.
+func classifyRune(r rune) (suspectRune, bool) {
+	if s, ok := suspects[r]; ok {
+		return s, true
+	}
+	if isControl(r) {
+		return suspectRune{name: "CONTROL CHARACTER", cat: CategoryControl, sev: SeverityMed}, true
+	}
+	return suspectRune{}, false
+}
+
+func isControl(r rune) bool {
+	if r == '\t' || r == '\n' || r == '\r' {
+		return false
+	}
+	return r <= 0x1F || r == 0x7F || (r >= 0x80 && r <= 0x9F)
+}
+
+// ScanText finds suspect characters in content, attributing each to a line and
+// rune column. A newline (\n) advances the line and resets the column; every
+// other rune (including \t and \r) advances the column by one — column counts
+// are byte-accurate for locating the injection. A BOM (U+FEFF) at the very start
+// of a file is routine and downgraded to low severity.
+func ScanText(path, content string) []Finding {
+	var out []Finding
+	line, col := 1, 0
+	first := true
+	for _, r := range content {
+		if r == '\n' {
+			line++
+			col = 0
+			first = false
+			continue
+		}
+		col++
+		s, flagged := classifyRune(r)
+		isFirstRune := first && col == 1
+		first = false
+		if !flagged {
+			continue
+		}
+		sev := s.sev
+		if r == 0xFEFF && isFirstRune {
+			sev = SeverityLow // leading BOM is a routine encoding artifact
+		}
+		out = append(out, Finding{
+			Path:      path,
+			Line:      line,
+			Col:       col,
+			CodePoint: fmt.Sprintf("U+%04X", r),
+			Name:      s.name,
+			Category:  s.cat,
+			Severity:  sev,
+		})
+	}
+	return out
+}
+
+// readRegularFile safely reads a regular file, bounded to maxBytes. It rejects
+// symlinks, devices, FIFOs, sockets, and directories so a symlink to /dev/zero
+// cannot hang the scanner or exhaust memory, and refuses anything larger than
+// the cap by reading maxBytes+1 through an io.LimitReader. Returns a skip reason
+// (non-empty) instead of content when the file should not be scanned as text.
+func readRegularFile(path string, maxBytes int64) (content string, skipReason string, err error) {
+	clean := filepath.Clean(path)
+	info, err := os.Lstat(clean) // Lstat: do NOT follow symlinks
+	if err != nil {
+		return "", "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", "symlink (not followed)", nil
+	}
+	if !info.Mode().IsRegular() {
+		return "", "not a regular file", nil
+	}
+	if info.Size() > maxBytes {
+		return "", fmt.Sprintf("exceeds %d-byte limit (size %d)", maxBytes, info.Size()), nil
+	}
+	f, err := os.Open(clean)
+	if err != nil {
+		return "", "", err
+	}
+	defer func() { _ = f.Close() }()
+	// Read at most maxBytes+1 so a file that grew past the cap between Lstat and
+	// read (TOCTOU) is caught rather than read unbounded.
+	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	if err != nil {
+		return "", "", err
+	}
+	if int64(len(data)) > maxBytes {
+		return "", fmt.Sprintf("exceeds %d-byte limit (grew during read)", maxBytes), nil
+	}
+	if looksBinary(data) {
+		return "", "binary (NUL byte)", nil
+	}
+	return string(data), "", nil
+}
+
+// looksBinary reports whether b contains a NUL byte, the cheap heuristic for a
+// binary file we should not scan as text. Known limitations: (1) an attacker who
+// can write a NUL into an otherwise-text file suppresses scanning of that file —
+// this matches git's binary heuristic and an attacker planting NULs in tracked
+// text files is already past this control; (2) UTF-16 text is NUL-rich and is
+// therefore skipped (reported as a skip), since pipelock's context files are
+// UTF-8. Both are surfaced as skips, never silent.
+func looksBinary(b []byte) bool {
+	for _, c := range b {
+		if c == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// ScanFile scans a single file. scanned is false (with no error) when the file
+// was skipped; reason explains why so the caller can report it.
+func ScanFile(path string, maxBytes int64) (findings []Finding, scanned bool, reason string, err error) {
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxFileBytes
+	}
+	content, skipReason, err := readRegularFile(path, maxBytes)
+	if err != nil {
+		return nil, false, "", err
+	}
+	if skipReason != "" {
+		return nil, false, skipReason, nil
+	}
+	return ScanText(path, content), true, "", nil
+}
+
+// ScanPaths walks each path (file or directory) and scans every text file,
+// skipping dependency/VCS directories and binary/oversized/non-regular files. A
+// read error on an individual file is recorded as a skip with its reason, so one
+// unreadable file cannot abort a directory scan.
+func ScanPaths(paths []string, opts Options) (Result, error) {
+	excl := map[string]struct{}{}
+	if !opts.IncludeDepDirs {
+		for d := range defaultExcludeDirs {
+			excl[d] = struct{}{}
+		}
+	}
+	for _, d := range opts.ExtraExcludeDirs {
+		excl[d] = struct{}{}
+	}
+
+	var res Result
+	scanOne := func(p string) {
+		findings, scanned, reason, err := ScanFile(p, opts.MaxFileBytes)
+		if err != nil {
+			res.Skipped = append(res.Skipped, Skip{Path: p, Reason: "read error: " + err.Error()})
+			return
+		}
+		if !scanned {
+			res.Skipped = append(res.Skipped, Skip{Path: p, Reason: reason})
+			return
+		}
+		res.FilesScanned++
+		res.Findings = append(res.Findings, findings...)
+	}
+
+	for _, root := range paths {
+		info, err := os.Lstat(root)
+		if err != nil {
+			return res, fmt.Errorf("stat %s: %w", root, err)
+		}
+		if !info.IsDir() {
+			scanOne(root)
+			continue
+		}
+		walkErr := filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+			if err != nil {
+				res.Skipped = append(res.Skipped, Skip{Path: p, Reason: "walk error: " + err.Error()})
+				return nil
+			}
+			if d.IsDir() {
+				if _, skip := excl[d.Name()]; skip {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			scanOne(p)
+			return nil
+		})
+		if walkErr != nil {
+			return res, fmt.Errorf("walk %s: %w", root, walkErr)
+		}
+	}
+	return res, nil
+}
+
+// HighFindings returns only the high-severity findings, for callers that gate on
+// the alarming set rather than every routine BOM or emoji ZWJ.
+func (r Result) HighFindings() []Finding {
+	var out []Finding
+	for _, f := range r.Findings {
+		if f.Severity == SeverityHigh {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// Summary renders a one-line-per-finding human report. Empty when no findings.
+func (r Result) Summary() string {
+	if len(r.Findings) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, f := range r.Findings {
+		_, _ = fmt.Fprintf(&b, "%s:%d:%d  [%s] %s %s (%s)\n",
+			f.Path, f.Line, f.Col, f.Severity, f.CodePoint, f.Name, f.Category)
+	}
+	return b.String()
+}
+
+// WriteReport writes the human report, any skips, and a tally line to w.
+func (r Result) WriteReport(w *bufio.Writer) {
+	if s := r.Summary(); s != "" {
+		_, _ = w.WriteString(s)
+	}
+	for _, sk := range r.Skipped {
+		_, _ = fmt.Fprintf(w, "skipped %s: %s\n", sk.Path, sk.Reason)
+	}
+	_, _ = fmt.Fprintf(w, "scanned %d file(s), %d skipped, %d finding(s)\n",
+		r.FilesScanned, len(r.Skipped), len(r.Findings))
+	_ = w.Flush()
+}
+
+// ErrFindings is returned by callers (e.g. the CLI) to signal that findings were
+// detected, distinct from an operational error.
+var ErrFindings = errors.New("invisible-character findings detected")

--- a/internal/filescan/filescan_test.go
+++ b/internal/filescan/filescan_test.go
@@ -1,0 +1,353 @@
+package filescan
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// zw builds a string containing the given codepoint. Test inputs are assembled
+// from codepoints rather than literal invisible characters so this source file
+// stays pure ASCII — reviewable, and not flagged by the very scanner it tests.
+func zw(r rune) string { return string(r) }
+
+func TestScanText(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantCount int
+		wantFirst string // CodePoint of first finding
+		wantCat   Category
+		wantSev   Severity
+		wantLine  int
+		wantCol   int
+	}{
+		{name: "clean ascii", content: "hello world\nsecond line", wantCount: 0},
+		{name: "clean with tabs and cr", content: "a\tb\r\nc", wantCount: 0},
+		{
+			name: "zero-width space is high", content: "hel" + zw(0x200B) + "lo",
+			wantCount: 1, wantFirst: "U+200B", wantCat: CategoryZeroWidth, wantSev: SeverityHigh, wantLine: 1, wantCol: 4,
+		},
+		{
+			name: "bidi override is high", content: "abc" + zw(0x202E) + "def",
+			wantCount: 1, wantFirst: "U+202E", wantCat: CategoryBidi, wantSev: SeverityHigh, wantLine: 1, wantCol: 4,
+		},
+		{
+			name: "tag char is high", content: "x" + zw(0xE0041) + "y",
+			wantCount: 1, wantFirst: "U+E0041", wantCat: CategoryTag, wantSev: SeverityHigh, wantLine: 1, wantCol: 2,
+		},
+		{
+			name: "emoji ZWJ is low", content: "a" + zw(0x200D) + "b",
+			wantCount: 1, wantFirst: "U+200D", wantCat: CategoryZeroWidth, wantSev: SeverityLow, wantLine: 1, wantCol: 2,
+		},
+		{
+			name: "variation selector is low", content: "x" + zw(0xFE0F),
+			wantCount: 1, wantFirst: "U+FE0F", wantCat: CategoryZeroWidth, wantSev: SeverityLow, wantLine: 1, wantCol: 2,
+		},
+		{
+			name: "soft hyphen is low", content: "co" + zw(0x00AD) + "op",
+			wantCount: 1, wantFirst: "U+00AD", wantCat: CategoryZeroWidth, wantSev: SeverityLow, wantLine: 1, wantCol: 3,
+		},
+		{
+			name: "leading BOM downgraded to low", content: zw(0xFEFF) + "content",
+			wantCount: 1, wantFirst: "U+FEFF", wantCat: CategoryZeroWidth, wantSev: SeverityLow, wantLine: 1, wantCol: 1,
+		},
+		{
+			name: "non-leading BOM is medium", content: "x" + zw(0xFEFF),
+			wantCount: 1, wantFirst: "U+FEFF", wantCat: CategoryZeroWidth, wantSev: SeverityMed, wantLine: 1, wantCol: 2,
+		},
+		{
+			name: "arabic letter mark flagged (outside InvisibleRanges)", content: "a" + zw(0x061C) + "b",
+			wantCount: 1, wantFirst: "U+061C", wantCat: CategoryBidi, wantSev: SeverityMed, wantLine: 1, wantCol: 2,
+		},
+		{
+			name: "mongolian vowel sep flagged (outside InvisibleRanges)", content: "a" + zw(0x180E) + "b",
+			wantCount: 1, wantFirst: "U+180E", wantCat: CategoryZeroWidth, wantSev: SeverityMed, wantLine: 1, wantCol: 2,
+		},
+		{
+			name: "C1 control flagged", content: "a" + zw(0x0085) + "b",
+			wantCount: 1, wantFirst: "U+0085", wantCat: CategoryControl, wantSev: SeverityMed, wantLine: 1, wantCol: 2,
+		},
+		{
+			name: "position on second line", content: "line one\nli" + zw(0x200B) + "ne",
+			wantCount: 1, wantFirst: "U+200B", wantCat: CategoryZeroWidth, wantSev: SeverityHigh, wantLine: 2, wantCol: 3,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ScanText("f", tc.content)
+			if len(got) != tc.wantCount {
+				t.Fatalf("count = %d, want %d (%+v)", len(got), tc.wantCount, got)
+			}
+			if tc.wantCount == 0 {
+				return
+			}
+			f := got[0]
+			if f.CodePoint != tc.wantFirst {
+				t.Errorf("codepoint = %s, want %s", f.CodePoint, tc.wantFirst)
+			}
+			if f.Category != tc.wantCat {
+				t.Errorf("category = %s, want %s", f.Category, tc.wantCat)
+			}
+			if f.Severity != tc.wantSev {
+				t.Errorf("severity = %s, want %s", f.Severity, tc.wantSev)
+			}
+			if f.Line != tc.wantLine || f.Col != tc.wantCol {
+				t.Errorf("pos = %d:%d, want %d:%d", f.Line, f.Col, tc.wantLine, tc.wantCol)
+			}
+		})
+	}
+}
+
+func TestIsControl(t *testing.T) {
+	for _, r := range []rune{'\t', '\n', '\r', 'a', ' '} {
+		if isControl(r) {
+			t.Errorf("isControl(%#U) = true, want false", r)
+		}
+	}
+	for _, r := range []rune{0x00, 0x07, 0x1F, 0x7F, 0x85, 0x9F} {
+		if !isControl(r) {
+			t.Errorf("isControl(%#U) = false, want true", r)
+		}
+	}
+}
+
+func TestLooksBinary(t *testing.T) {
+	if !looksBinary([]byte{'a', 0, 'b'}) {
+		t.Error("NUL byte should be binary")
+	}
+	if looksBinary([]byte("plain text")) {
+		t.Error("plain text should not be binary")
+	}
+}
+
+func TestScanFile(t *testing.T) {
+	dir := t.TempDir()
+	clean := filepath.Join(dir, "clean.md")
+	mustWrite(t, clean, "no hidden chars\n")
+	planted := filepath.Join(dir, "planted.md")
+	mustWrite(t, planted, "inject"+zw(0x200B)+"ed")
+	binary := filepath.Join(dir, "bin.dat")
+	if err := os.WriteFile(binary, []byte{'a', 0, ' '}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	big := filepath.Join(dir, "big.txt")
+	mustWrite(t, big, "0123456789")
+
+	t.Run("clean file scanned", func(t *testing.T) {
+		f, scanned, reason, err := ScanFile(clean, 0)
+		if err != nil || !scanned || reason != "" || len(f) != 0 {
+			t.Fatalf("findings=%d scanned=%v reason=%q err=%v", len(f), scanned, reason, err)
+		}
+	})
+	t.Run("planted file flagged", func(t *testing.T) {
+		f, scanned, _, err := ScanFile(planted, 0)
+		if err != nil || !scanned || len(f) != 1 {
+			t.Fatalf("findings=%d scanned=%v err=%v", len(f), scanned, err)
+		}
+	})
+	t.Run("binary skipped with reason", func(t *testing.T) {
+		_, scanned, reason, err := ScanFile(binary, 0)
+		if err != nil || scanned || !strings.Contains(reason, "binary") {
+			t.Fatalf("scanned=%v reason=%q err=%v", scanned, reason, err)
+		}
+	})
+	t.Run("oversized skipped with reason", func(t *testing.T) {
+		_, scanned, reason, err := ScanFile(big, 1)
+		if err != nil || scanned || !strings.Contains(reason, "limit") {
+			t.Fatalf("scanned=%v reason=%q err=%v", scanned, reason, err)
+		}
+	})
+	t.Run("missing file errors", func(t *testing.T) {
+		if _, _, _, err := ScanFile(filepath.Join(dir, "nope.md"), 0); err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+	t.Run("symlink not followed", func(t *testing.T) {
+		link := filepath.Join(dir, "link.md")
+		if err := os.Symlink("/dev/zero", link); err != nil {
+			t.Skipf("symlink unsupported: %v", err)
+		}
+		_, scanned, reason, err := ScanFile(link, 0)
+		if err != nil || scanned || !strings.Contains(reason, "symlink") {
+			t.Fatalf("symlink to /dev/zero must be skipped unread: scanned=%v reason=%q err=%v", scanned, reason, err)
+		}
+	})
+	t.Run("device is not regular", func(t *testing.T) {
+		if _, err := os.Stat("/dev/null"); err != nil {
+			t.Skip("/dev/null unavailable")
+		}
+		_, scanned, reason, err := ScanFile("/dev/null", 0)
+		if err != nil || scanned || !strings.Contains(reason, "regular") {
+			t.Fatalf("device must be skipped: scanned=%v reason=%q err=%v", scanned, reason, err)
+		}
+	})
+}
+
+func TestScanPaths(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "CLAUDE.md"), "trust"+zw(0x200B)+"me")
+	mustWrite(t, filepath.Join(dir, "ok.txt"), "all good")
+	if err := os.WriteFile(filepath.Join(dir, "blob.bin"), []byte{0, 1, 2}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.MkdirAll(gitDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(gitDir, "config"), "hidden"+zw(0x202E)+"here")
+	skipDir := filepath.Join(dir, "testdata")
+	if err := os.MkdirAll(skipDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(skipDir, "fixture.md"), "fix"+zw(0x200B)+"ture")
+
+	t.Run("directory walk respects excludes and reports skips", func(t *testing.T) {
+		res, err := ScanPaths([]string{dir}, Options{ExtraExcludeDirs: []string{"testdata"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(res.Findings) != 1 {
+			t.Fatalf("findings = %d, want 1 (only CLAUDE.md); got %+v", len(res.Findings), res.Findings)
+		}
+		if len(res.Skipped) == 0 {
+			t.Error("expected the binary blob to be reported as a skip with a reason")
+		}
+		var sawBinSkip bool
+		for _, sk := range res.Skipped {
+			if strings.Contains(sk.Path, "blob.bin") && sk.Reason != "" {
+				sawBinSkip = true
+			}
+		}
+		if !sawBinSkip {
+			t.Errorf("binary skip not reported with path+reason: %+v", res.Skipped)
+		}
+	})
+
+	t.Run("include-deps scans .git", func(t *testing.T) {
+		res, err := ScanPaths([]string{dir}, Options{IncludeDepDirs: true, ExtraExcludeDirs: []string{"testdata"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(res.Findings) < 2 {
+			t.Errorf("expected CLAUDE.md + .git/config findings with include-deps, got %d", len(res.Findings))
+		}
+	})
+
+	t.Run("single file arg", func(t *testing.T) {
+		res, err := ScanPaths([]string{filepath.Join(dir, "CLAUDE.md")}, Options{})
+		if err != nil || len(res.Findings) != 1 || res.FilesScanned != 1 {
+			t.Fatalf("findings=%d scanned=%d err=%v", len(res.Findings), res.FilesScanned, err)
+		}
+	})
+
+	t.Run("missing root errors", func(t *testing.T) {
+		if _, err := ScanPaths([]string{filepath.Join(dir, "ghost")}, Options{}); err == nil {
+			t.Fatal("expected error for missing root")
+		}
+	})
+}
+
+func TestScanPaths_ReadErrors(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses permission denial")
+	}
+	t.Run("unreadable file reported as read-error skip", func(t *testing.T) {
+		dir := t.TempDir()
+		bad := filepath.Join(dir, "locked.md")
+		mustWrite(t, bad, "data")
+		if err := os.Chmod(bad, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(bad, 0o600) })
+		res, err := ScanPaths([]string{dir}, Options{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var saw bool
+		for _, sk := range res.Skipped {
+			if strings.Contains(sk.Path, "locked.md") && strings.Contains(sk.Reason, "read error") {
+				saw = true
+			}
+		}
+		if !saw {
+			t.Errorf("unreadable file not reported as read-error skip: %+v", res.Skipped)
+		}
+	})
+	t.Run("unreadable subdir reported as walk-error skip", func(t *testing.T) {
+		dir := t.TempDir()
+		sub := filepath.Join(dir, "locked")
+		if err := os.MkdirAll(sub, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		mustWrite(t, filepath.Join(sub, "x.md"), "data")
+		if err := os.Chmod(sub, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		// dir needs the exec bit restored so TempDir's RemoveAll can clean up.
+		t.Cleanup(func() { _ = os.Chmod(sub, 0o750) }) //nolint:gosec // test cleanup, dir requires exec bit
+		res, err := ScanPaths([]string{dir}, Options{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var saw bool
+		for _, sk := range res.Skipped {
+			if strings.Contains(sk.Reason, "walk error") {
+				saw = true
+			}
+		}
+		if !saw {
+			t.Errorf("unreadable subdir not reported as walk-error skip: %+v", res.Skipped)
+		}
+	})
+}
+
+func TestHighFindings(t *testing.T) {
+	// mix: ZWSP (high) + soft hyphen (low)
+	res := Result{Findings: ScanText("f", "a"+zw(0x200B)+"b"+zw(0x00AD)+"c")}
+	if len(res.Findings) != 2 {
+		t.Fatalf("setup: want 2 findings, got %d", len(res.Findings))
+	}
+	high := res.HighFindings()
+	if len(high) != 1 || high[0].Severity != SeverityHigh {
+		t.Errorf("HighFindings = %+v, want exactly the ZWSP", high)
+	}
+}
+
+func TestResultReporting(t *testing.T) {
+	t.Run("empty summary", func(t *testing.T) {
+		if s := (Result{}).Summary(); s != "" {
+			t.Errorf("empty summary = %q, want empty", s)
+		}
+	})
+	t.Run("summary lists findings with severity", func(t *testing.T) {
+		res := Result{Findings: ScanText("x.md", "a"+zw(0x200B)+"b"), FilesScanned: 1}
+		s := res.Summary()
+		if !strings.Contains(s, "U+200B") || !strings.Contains(s, "x.md:1:2") || !strings.Contains(s, "high") {
+			t.Errorf("summary missing detail: %q", s)
+		}
+	})
+	t.Run("write report includes skips and tally", func(t *testing.T) {
+		var sb strings.Builder
+		w := bufio.NewWriter(&sb)
+		res := Result{
+			Findings:     ScanText("y.md", "z"+zw(0x200B)+"z"),
+			Skipped:      []Skip{{Path: "big.md", Reason: "exceeds limit"}},
+			FilesScanned: 2,
+		}
+		res.WriteReport(w)
+		out := sb.String()
+		if !strings.Contains(out, "scanned 2 file(s)") || !strings.Contains(out, "skipped big.md: exceeds limit") {
+			t.Errorf("report missing skip/tally: %q", out)
+		}
+	})
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Adds `pipelock scan [paths]` to detect hidden Unicode embedded in files: zero-width, bidi-control, tag, and C0/C1 control characters used to inject instructions into agent-context files (CLAUDE.md, .cursorrules, AGENTS.md, skill definitions) that a human reviewer cannot see. This is the local-file half of supply-chain prompt injection (e.g. the TrapDoor campaign). The network proxy never sees files at rest, so this closes that gap and exits non-zero for pre-commit/CI gating.

## Design
New `internal/filescan` package. Detection is seeded from `normalize.InvisibleRanges` (the set the scanner already strips) so it never diverges from enforcement, but applies a per-rune severity/category policy rather than a flat reuse. File gating produces developer-facing failures, so a leading BOM, emoji ZWJ, or soft hyphen in prose is low severity, while a right-to-left override or tag character inside an instruction file is high.

Safe I/O: `Lstat` (no symlink follow), regular-file check, and a bounded `io.LimitReader` read. A symlink to `/dev/zero` is skipped, never read or hung on. Skips are reported with path and reason (never silent). Findings carry file:line:col, codepoint, name, category, and severity.

## Behavior
`pipelock scan [paths]` with `--json`, `--min-severity` (default high), `--fail-on-skip`, `--include-deps`, `--exclude`, `--max-bytes`.

Exit codes: 0 = no gated findings; 1 = findings at/above `--min-severity`; 2 = scan error, an explicitly named file skipped, or `--fail-on-skip` with any skip.

Free-tier (detection is always free). No new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new scan command to detect invisible Unicode (bidi, zero‑width, tags) and control characters in files, with severity filtering, JSON/text output, file-size limits, directory exclusions, and fail-on-skip behavior.
* **Tests**
  * Added comprehensive tests for the scan command and file-scanning logic covering detection, reporting, gating, skips, and error paths.
* **Chores**
  * Increased CI test timeout to accommodate expanded test suite.
* **Documentation**
  * Updated Quick Start examples in README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->