### PR TITLE
feat(hermes): Ed25519-signed integrity check for identity anchors

### DIFF
--- a/internal/cli/hermes/cmd.go
+++ b/internal/cli/hermes/cmd.go
@@ -40,5 +40,6 @@ The 'hook' subcommand is the per-event subprocess entrypoint; 'install',
 	cmd.AddCommand(verifyCmd())
 	cmd.AddCommand(rollbackCmd())
 	cmd.AddCommand(hookCmd())
+	cmd.AddCommand(anchorsCmd())
 	return cmd
 }

--- a/internal/cli/hermes/integrity.go
+++ b/internal/cli/hermes/integrity.go
@@ -1,0 +1,542 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package hermes
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// Hermes seeds identity-anchor files (SOUL.md, IDENTITY.md, AGENTS.md) onto the
+// agent's persistent workspace once, then never re-seeds them. An attacker who
+// can write that workspace can therefore overwrite the agent's identity and
+// have it persist across restarts, since the seed step only writes the files
+// when they are absent. The anchor-integrity primitive pins those files:
+// `seal` records a SHA-256 of each anchor and signs the manifest with an
+// operator-held Ed25519 key; `verify` (run by a startup/init step) refuses to
+// start when an anchor no longer matches or the manifest signature is invalid.
+//
+// Why a signature rather than a keyed MAC: verify needs only the PUBLIC key,
+// which can sit in the cluster (a Secret or ConfigMap) with no risk, while the
+// private signing key stays off-cluster and is used only at seal time. A fully
+// compromised agent or cluster therefore cannot forge a baseline at all. The
+// signature covers the whole {version, digest_algorithm, digests} manifest, so
+// an attacker who can write the baseline cannot add, drop, or alter an anchor
+// entry, downgrade the version, or swap in a baseline signed by another key.
+//
+// Coverage boundary: verify is a point-in-time check at startup. It detects
+// tampering that persisted from before boot and refuses to start; it does not
+// prevent writes to the workspace while the agent runs. Closing that window is
+// a deployment concern — mount the anchor files (and ideally the baseline)
+// read-only to the agent — handled by the cluster identity/topology layer, not
+// this command.
+
+const (
+	// defaultAnchorBaselineName is the baseline manifest filename written under
+	// the workspace by `seal` and read by `verify`. Override with --baseline to
+	// place it on a read-only mount the agent cannot delete.
+	defaultAnchorBaselineName = ".pipelock-anchors.json"
+	anchorBaselineVersion     = 1
+	anchorDigestAlgorithm     = "sha256"
+	anchorSignatureAlgorithm  = "ed25519"
+)
+
+// manifestDomainPrefix domain-separates the signed payload so an anchor
+// manifest signature can never be mistaken for a signature over any other
+// pipelock artifact.
+const manifestDomainPrefix = "pipelock hermes anchors manifest v1\n"
+
+// defaultAnchorFiles are the immutable Hermes identity files whose integrity is
+// pinned. MEMORY.md is intentionally excluded: it changes legitimately as the
+// agent curates memory across sessions, so it is not an identity anchor.
+var defaultAnchorFiles = []string{"SOUL.md", "IDENTITY.md", "AGENTS.md"}
+
+// maxAnchorSize caps an anchor file read. Identity anchors are small text
+// files; a multi-gigabyte anchor (or a symlink to a device) would otherwise OOM
+// or hang verify at startup. 16 MiB is far above any legitimate anchor. A
+// package var (not const) only so tests can lower it without writing a 16 MiB
+// fixture; production never reassigns it.
+var maxAnchorSize int64 = 16 << 20
+
+// anchorBaseline is the on-disk signed manifest. Digests maps each anchor file
+// name (relative to the workspace) to the hex SHA-256 of its content. Signature
+// is the hex Ed25519 signature over the canonical {version, digest_algorithm,
+// digests} payload.
+type anchorBaseline struct {
+	Version            int               `json:"version"`
+	DigestAlgorithm    string            `json:"digest_algorithm"`
+	SignatureAlgorithm string            `json:"signature_algorithm"`
+	Digests            map[string]string `json:"digests"`
+	Signature          string            `json:"signature"`
+}
+
+// anchorManifestPayload is the exact, signature-free structure that is signed
+// and verified. Field order and json tags are fixed; json.Marshal sorts map
+// keys, so the encoding is deterministic across seal and verify.
+type anchorManifestPayload struct {
+	Version         int               `json:"version"`
+	DigestAlgorithm string            `json:"digest_algorithm"`
+	Digests         map[string]string `json:"digests"`
+}
+
+// anchorOptions holds the flags for seal and verify. SigningKey is used by seal
+// (Ed25519 private key); PublicKey is used by verify (Ed25519 public key, path
+// or inline value).
+type anchorOptions struct {
+	Workspace  string
+	SigningKey string
+	PublicKey  string
+	Baseline   string
+	Anchors    []string
+	HomeDir    string
+}
+
+// resolvePaths fills Workspace, Baseline, and Anchors from HOME/defaults when
+// unset and validates the anchor names. Key validation is per-subcommand.
+func (o *anchorOptions) resolvePaths() error {
+	if o.Workspace == "" {
+		home := o.HomeDir
+		if home == "" {
+			detected, err := userHomeDir()
+			if err != nil {
+				return fmt.Errorf("hermes anchors: %w", err)
+			}
+			home = detected
+		}
+		o.Workspace = filepath.Join(home, ".hermes")
+	}
+	if o.Baseline == "" {
+		o.Baseline = filepath.Join(o.Workspace, defaultAnchorBaselineName)
+	}
+	if len(o.Anchors) == 0 {
+		o.Anchors = append([]string(nil), defaultAnchorFiles...)
+	}
+	return validateAnchorNames(o.Anchors)
+}
+
+// rejectKeyInsideWorkspace refuses a key path that lives (directly or via
+// symlink) under the agent-writable workspace. For the private signing key this
+// keeps the secret out of the agent's reach; for the public verify key it stops
+// an attacker from swapping the key the baseline is checked against.
+func rejectKeyInsideWorkspace(workspace, keyPath string) error {
+	workspaceAbs, err := filepath.Abs(filepath.Clean(workspace))
+	if err != nil {
+		return fmt.Errorf("hermes anchors: workspace: %w", err)
+	}
+	keyAbs, err := filepath.Abs(filepath.Clean(keyPath))
+	if err != nil {
+		return fmt.Errorf("hermes anchors: key file: %w", err)
+	}
+	if isSubpath(workspaceAbs, keyAbs) {
+		return fmt.Errorf("hermes anchors: key file %q must not live under workspace %q", keyPath, workspace)
+	}
+	resolvedWorkspace := workspaceAbs
+	if rw, err := filepath.EvalSymlinks(workspaceAbs); err == nil {
+		resolvedWorkspace = rw
+	}
+	if resolvedKey, err := filepath.EvalSymlinks(keyAbs); err == nil {
+		if isSubpath(workspaceAbs, resolvedKey) || isSubpath(resolvedWorkspace, resolvedKey) {
+			return fmt.Errorf("hermes anchors: key file %q resolves under workspace %q", keyPath, workspace)
+		}
+	}
+	if isSubpath(resolvedWorkspace, keyAbs) {
+		return fmt.Errorf("hermes anchors: key file %q must not live under workspace %q", keyPath, workspace)
+	}
+	return nil
+}
+
+func isSubpath(parent, child string) bool {
+	parent = filepath.Clean(parent)
+	child = filepath.Clean(child)
+	if parent == child {
+		return true
+	}
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func validateAnchorNames(anchors []string) error {
+	if len(anchors) == 0 {
+		return errors.New("hermes anchors: no anchors specified")
+	}
+	seen := make(map[string]struct{}, len(anchors))
+	for _, name := range anchors {
+		clean := filepath.Clean(name)
+		if name == "" || filepath.IsAbs(name) || clean == "." || clean != name ||
+			clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("hermes anchors: anchor %q must be a clean relative path under --workspace", name)
+		}
+		if _, ok := seen[name]; ok {
+			return fmt.Errorf("hermes anchors: duplicate anchor %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+	return nil
+}
+
+// computeAnchorDigest returns the hex SHA-256 of one anchor file's content. The
+// anchor must be a plain, bounded regular file: a missing, symlinked,
+// non-regular, or oversized anchor is an error so verify fails closed and a
+// tampered anchor cannot turn verify into a device read or an OOM.
+func computeAnchorDigest(workspace, name string) (string, error) {
+	path := filepath.Clean(filepath.Join(workspace, name))
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", fmt.Errorf("anchor %q: %w", name, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("anchor %q: is a symlink; identity anchors must be regular files", name)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("anchor %q: not a regular file (mode=%s)", name, info.Mode())
+	}
+	if info.Size() > maxAnchorSize {
+		return "", fmt.Errorf("anchor %q: %d bytes exceeds the %d-byte anchor limit", name, info.Size(), maxAnchorSize)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("anchor %q: %w", name, err)
+	}
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func computeAnchorDigests(workspace string, anchors []string) (map[string]string, error) {
+	digests := make(map[string]string, len(anchors))
+	names := append([]string(nil), anchors...)
+	sort.Strings(names)
+	for _, name := range names {
+		digest, err := computeAnchorDigest(workspace, name)
+		if err != nil {
+			return nil, err
+		}
+		digests[name] = digest
+	}
+	return digests, nil
+}
+
+// canonicalManifestBytes returns the deterministic, domain-prefixed bytes that
+// are signed at seal and verified at verify.
+func canonicalManifestBytes(version int, digestAlgorithm string, digests map[string]string) ([]byte, error) {
+	payload := anchorManifestPayload{
+		Version:         version,
+		DigestAlgorithm: digestAlgorithm,
+		Digests:         digests,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("encode anchor manifest payload: %w", err)
+	}
+	return append([]byte(manifestDomainPrefix), data...), nil
+}
+
+func anchorsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "anchors",
+		Short: "Pin and verify the integrity of Hermes identity-anchor files",
+		Long: `Protect the immutable Hermes identity files (SOUL.md, IDENTITY.md,
+AGENTS.md) against persistent tampering on a writable workspace.
+
+'seal' records a SHA-256 of each anchor and signs the manifest with an
+operator-held Ed25519 private key; 'verify' (run at startup, e.g. from a
+Kubernetes init container) recomputes the digests, checks the signature against
+the public key, and exits non-zero if any anchor has drifted, refusing to start
+the agent.
+
+Only the PUBLIC key is needed in-cluster to verify; keep the private signing key
+off-cluster and use it only at seal time, so a compromised agent cannot forge a
+baseline. The public key must come from a trusted, non-workspace location (a
+read-only Secret/ConfigMap), never the agent-writable workspace. Run 'verify'
+with the same --anchor set used for 'seal': verify requires the baseline to
+cover exactly the requested anchors.`,
+	}
+	cmd.AddCommand(anchorsSealCmd(), anchorsVerifyCmd())
+	return cmd
+}
+
+func anchorsSealCmd() *cobra.Command {
+	opts := &anchorOptions{}
+	cmd := &cobra.Command{
+		Use:   "seal",
+		Short: "Record and Ed25519-sign the baseline of the identity-anchor files",
+		Long: `Compute SHA-256(content) for each identity-anchor file and sign the manifest
+with an Ed25519 private key. Run once after the anchors are seeded and trusted;
+re-run after a deliberate, reviewed change to an anchor.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAnchorsSeal(cmd, opts)
+		},
+	}
+	bindCommonAnchorFlags(cmd, opts)
+	cmd.Flags().StringVar(&opts.SigningKey, "signing-key", "",
+		"path to the Ed25519 private signing key (0600/0640; keep off-cluster and off the workspace)")
+	return cmd
+}
+
+func anchorsVerifyCmd() *cobra.Command {
+	opts := &anchorOptions{}
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Verify the identity anchors against the signed baseline",
+		Long: `Recompute SHA-256(content) for each anchor in the baseline, verify the
+manifest's Ed25519 signature against the public key, and compare digests in
+constant time. Exits non-zero if the signature is invalid or any anchor is
+missing, unreadable, or altered, so a Kubernetes init container running this
+command refuses to start the agent on tampering.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAnchorsVerify(cmd, opts, jsonOut)
+		},
+	}
+	bindCommonAnchorFlags(cmd, opts)
+	cmd.Flags().StringVar(&opts.PublicKey, "public-key", "",
+		"Ed25519 public key to verify the baseline: a file path or an inline encoded key")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the verification report as JSON")
+	return cmd
+}
+
+func bindCommonAnchorFlags(cmd *cobra.Command, opts *anchorOptions) {
+	cmd.Flags().StringVar(&opts.Workspace, "workspace", "",
+		"directory holding the anchor files (default ~/.hermes)")
+	cmd.Flags().StringVar(&opts.Baseline, "baseline", "",
+		"path to the baseline manifest (default <workspace>/"+defaultAnchorBaselineName+")")
+	cmd.Flags().StringArrayVar(&opts.Anchors, "anchor", nil,
+		"anchor file name relative to --workspace (repeatable; default SOUL.md, IDENTITY.md, AGENTS.md)")
+}
+
+func runAnchorsSeal(cmd *cobra.Command, opts *anchorOptions) error {
+	if opts.SigningKey == "" {
+		return errors.New("hermes anchors seal: --signing-key is required")
+	}
+	if err := opts.resolvePaths(); err != nil {
+		return err
+	}
+	if err := rejectKeyInsideWorkspace(opts.Workspace, opts.SigningKey); err != nil {
+		return err
+	}
+	priv, err := signing.LoadPrivateKeyFile(opts.SigningKey)
+	if err != nil {
+		return fmt.Errorf("hermes anchors seal: signing key: %w", err)
+	}
+	digests, err := computeAnchorDigests(opts.Workspace, opts.Anchors)
+	if err != nil {
+		return fmt.Errorf("hermes anchors seal: %w", err)
+	}
+	payload, err := canonicalManifestBytes(anchorBaselineVersion, anchorDigestAlgorithm, digests)
+	if err != nil {
+		return fmt.Errorf("hermes anchors seal: %w", err)
+	}
+	baseline := anchorBaseline{
+		Version:            anchorBaselineVersion,
+		DigestAlgorithm:    anchorDigestAlgorithm,
+		SignatureAlgorithm: anchorSignatureAlgorithm,
+		Digests:            digests,
+		Signature:          hex.EncodeToString(ed25519.Sign(priv, payload)),
+	}
+	data, err := json.MarshalIndent(baseline, "", "  ")
+	if err != nil {
+		return fmt.Errorf("hermes anchors seal: encode baseline: %w", err)
+	}
+	if err := writeFileAtomic(opts.Baseline, append(data, '\n')); err != nil {
+		return fmt.Errorf("hermes anchors seal: %w", err)
+	}
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "pipelock: sealed and signed %d anchor(s) to %s\n", len(digests), opts.Baseline)
+	for _, name := range sortedDigestNames(digests) {
+		_, _ = fmt.Fprintf(out, "pipelock:   %s\n", name)
+	}
+	return nil
+}
+
+// anchorVerifyReport is the machine-readable result of `anchors verify`.
+type anchorVerifyReport struct {
+	OK       bool     `json:"ok"`
+	Baseline string   `json:"baseline"`
+	Checked  int      `json:"checked"`
+	Drifted  []string `json:"drifted,omitempty"`
+	Missing  []string `json:"missing,omitempty"`
+	Errors   []string `json:"errors,omitempty"`
+}
+
+func runAnchorsVerify(cmd *cobra.Command, opts *anchorOptions, jsonOut bool) error {
+	if opts.PublicKey == "" {
+		return errors.New("hermes anchors verify: --public-key is required")
+	}
+	if err := opts.resolvePaths(); err != nil {
+		return err
+	}
+	// When the public key is given as a file path, it must not be readable-and-
+	// replaceable from the agent-writable workspace, or an attacker could swap
+	// both the key and a baseline signed by their own key. An inline value
+	// (from trusted args/env) has no such path.
+	if info, statErr := os.Stat(opts.PublicKey); statErr == nil && !info.IsDir() {
+		if err := rejectKeyInsideWorkspace(opts.Workspace, opts.PublicKey); err != nil {
+			return err
+		}
+	}
+	pub, err := signing.LoadPublicKey(opts.PublicKey)
+	if err != nil {
+		return fmt.Errorf("hermes anchors verify: public key: %w", err)
+	}
+	baseline, err := loadAnchorBaseline(opts.Baseline)
+	if err != nil {
+		return err
+	}
+	if err := verifyAnchorSignature(baseline, opts.Anchors, pub); err != nil {
+		return err
+	}
+
+	report := anchorVerifyReport{Baseline: opts.Baseline}
+	for _, name := range sortedDigestNames(baseline.Digests) {
+		report.Checked++
+		want := baseline.Digests[name]
+		got, err := computeAnchorDigest(opts.Workspace, name)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				report.Missing = append(report.Missing, name)
+			} else {
+				report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", name, err))
+			}
+			continue
+		}
+		if subtle.ConstantTimeCompare([]byte(got), []byte(want)) != 1 {
+			report.Drifted = append(report.Drifted, name)
+		}
+	}
+	report.OK = len(report.Drifted) == 0 && len(report.Missing) == 0 && len(report.Errors) == 0
+
+	if jsonOut {
+		if err := emitAnchorJSON(cmd, report); err != nil {
+			return err
+		}
+	} else {
+		emitAnchorText(cmd, report)
+	}
+	if !report.OK {
+		// Non-zero exit so an init container refuses to start the agent.
+		return fmt.Errorf("hermes anchors verify: integrity check failed (%d drifted, %d missing, %d error)",
+			len(report.Drifted), len(report.Missing), len(report.Errors))
+	}
+	return nil
+}
+
+func loadAnchorBaseline(path string) (*anchorBaseline, error) {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, fmt.Errorf("hermes anchors verify: baseline: %w", err)
+	}
+	var b anchorBaseline
+	if err := json.Unmarshal(data, &b); err != nil {
+		return nil, fmt.Errorf("hermes anchors verify: parse baseline %q: %w", path, err)
+	}
+	if b.Version != anchorBaselineVersion {
+		return nil, fmt.Errorf("hermes anchors verify: baseline %q uses unsupported version %d", path, b.Version)
+	}
+	if b.DigestAlgorithm != anchorDigestAlgorithm {
+		return nil, fmt.Errorf("hermes anchors verify: baseline %q uses unsupported digest algorithm %q", path, b.DigestAlgorithm)
+	}
+	if b.SignatureAlgorithm != anchorSignatureAlgorithm {
+		return nil, fmt.Errorf("hermes anchors verify: baseline %q uses unsupported signature algorithm %q", path, b.SignatureAlgorithm)
+	}
+	if len(b.Digests) == 0 {
+		return nil, fmt.Errorf("hermes anchors verify: baseline %q has no anchors", path)
+	}
+	if err := validateAnchorNames(sortedDigestNames(b.Digests)); err != nil {
+		return nil, fmt.Errorf("hermes anchors verify: baseline %q: %w", path, err)
+	}
+	return &b, nil
+}
+
+// verifyAnchorSignature checks the manifest's Ed25519 signature against the
+// public key and confirms the baseline covers exactly the requested anchor set.
+// The signature already binds the digest set (an attacker without the private
+// key cannot drop or alter an entry); the set check is defense-in-depth and
+// also catches a baseline sealed with a different --anchor set than requested.
+func verifyAnchorSignature(b *anchorBaseline, expectedAnchors []string, pub ed25519.PublicKey) error {
+	if !sameAnchorSet(sortedDigestNames(b.Digests), expectedAnchors) {
+		return errors.New("hermes anchors verify: baseline anchor set does not match requested anchors")
+	}
+	sig, err := hex.DecodeString(b.Signature)
+	if err != nil {
+		return fmt.Errorf("hermes anchors verify: baseline signature is invalid: %w", err)
+	}
+	payload, err := canonicalManifestBytes(b.Version, b.DigestAlgorithm, b.Digests)
+	if err != nil {
+		return fmt.Errorf("hermes anchors verify: %w", err)
+	}
+	if !ed25519.Verify(pub, payload, sig) {
+		return errors.New("hermes anchors verify: baseline signature does not verify against the public key")
+	}
+	return nil
+}
+
+func sameAnchorSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	left := append([]string(nil), a...)
+	right := append([]string(nil), b...)
+	sort.Strings(left)
+	sort.Strings(right)
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func emitAnchorJSON(cmd *cobra.Command, r anchorVerifyReport) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+func emitAnchorText(cmd *cobra.Command, r anchorVerifyReport) {
+	out := cmd.OutOrStdout()
+	if r.OK {
+		_, _ = fmt.Fprintf(out, "pipelock: anchor integrity OK (%d verified) against %s\n", r.Checked, r.Baseline)
+		return
+	}
+	errOut := cmd.ErrOrStderr()
+	_, _ = fmt.Fprintf(errOut, "pipelock: ANCHOR INTEGRITY VIOLATION against %s\n", r.Baseline)
+	for _, name := range r.Drifted {
+		_, _ = fmt.Fprintf(errOut, "pipelock:   altered: %s\n", name)
+	}
+	for _, name := range r.Missing {
+		_, _ = fmt.Fprintf(errOut, "pipelock:   missing: %s\n", name)
+	}
+	for _, msg := range r.Errors {
+		_, _ = fmt.Fprintf(errOut, "pipelock:   error:   %s\n", msg)
+	}
+}
+
+func sortedDigestNames(digests map[string]string) []string {
+	names := make([]string, 0, len(digests))
+	for name := range digests {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/cli/hermes/integrity_extra_test.go
+++ b/internal/cli/hermes/integrity_extra_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package hermes
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAnchors_SealMissingAnchorFails(t *testing.T) {
+	e := newAnchorEnv(t)
+	for _, name := range defaultAnchorFiles {
+		_ = os.Remove(filepath.Join(e.ws, name))
+	}
+	if _, _, err := e.seal(t); err == nil {
+		t.Fatal("seal must fail when an anchor file is missing")
+	}
+}
+
+func TestAnchors_SigningKeyNonexistent(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := runAnchors(t, "seal", "--workspace", e.ws, "--signing-key", filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Fatal("seal must fail when the signing key does not exist")
+	}
+}
+
+func TestAnchors_SigningKeyIsDir(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := runAnchors(t, "seal", "--workspace", e.ws, "--signing-key", t.TempDir()); err == nil {
+		t.Fatal("seal must fail when the signing key is a directory")
+	}
+}
+
+func TestAnchors_BaselineMalformedJSON(t *testing.T) {
+	e := newAnchorEnv(t)
+	if err := os.WriteFile(filepath.Join(e.ws, defaultAnchorBaselineName), []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, _, err := e.verify(t)
+	if err == nil || !strings.Contains(err.Error(), "parse baseline") {
+		t.Fatalf("err = %v, want parse error", err)
+	}
+}
+
+func TestAnchors_BaselineEmptyDigests(t *testing.T) {
+	e := newAnchorEnv(t)
+	writeBaseline(t, e.ws, anchorBaseline{
+		Version:            anchorBaselineVersion,
+		DigestAlgorithm:    anchorDigestAlgorithm,
+		SignatureAlgorithm: anchorSignatureAlgorithm,
+		Digests:            map[string]string{},
+	})
+	_, _, err := e.verify(t)
+	if err == nil || !strings.Contains(err.Error(), "no anchors") {
+		t.Fatalf("err = %v, want no-anchors error", err)
+	}
+}
+
+// TestAnchors_VerifyUnreadableAnchor covers the read-error (not not-exist)
+// branch: an anchor path that became a directory cannot be read as a file.
+func TestAnchors_VerifyUnreadableAnchor(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := e.seal(t); err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	soul := filepath.Join(e.ws, "SOUL.md")
+	if err := os.Remove(soul); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := os.Mkdir(soul, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	_, errOut, err := e.verify(t)
+	if err == nil {
+		t.Fatal("verify must fail when an anchor is unreadable")
+	}
+	if !strings.Contains(errOut, "error:") {
+		t.Errorf("stderr = %q, want an error entry", errOut)
+	}
+}
+
+func TestAnchors_HomeDirError(t *testing.T) {
+	prev := userHomeDir
+	userHomeDir = func() (string, error) { return "", errors.New("test: no home") }
+	t.Cleanup(func() { userHomeDir = prev })
+
+	_, priv := newKeyPairFiles(t)
+	// No --workspace forces resolvePaths through userHomeDir, which errors.
+	if _, _, err := runAnchors(t, "seal", "--signing-key", priv); err == nil {
+		t.Fatal("seal must fail when the home directory cannot be resolved")
+	}
+}
+
+func TestAnchors_SealBaselineWriteError(t *testing.T) {
+	e := newAnchorEnv(t)
+	badBaseline := filepath.Join(e.ws, "missing-subdir", "baseline.json")
+	if _, _, err := e.seal(t, "--baseline", badBaseline); err == nil {
+		t.Fatal("seal must fail when the baseline path is unwritable")
+	}
+}
+
+// TestAnchors_VerifyRejectsSymlinkedAnchor covers the symlink guard: replacing
+// an anchor with a symlink (e.g. to a device or a huge file) is tampering and
+// must fail closed, never following the link.
+func TestAnchors_VerifyRejectsSymlinkedAnchor(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := e.seal(t); err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	soul := filepath.Join(e.ws, "SOUL.md")
+	if err := os.Remove(soul); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(e.ws, "IDENTITY.md"), soul); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	_, errOut, err := e.verify(t)
+	if err == nil {
+		t.Fatal("verify must fail when an anchor is a symlink")
+	}
+	if !strings.Contains(errOut, "symlink") {
+		t.Errorf("stderr = %q, want a symlink error", errOut)
+	}
+}
+
+// TestAnchors_VerifyRejectsOversizedAnchor covers the size cap: a maliciously
+// large anchor must be refused before it is read into memory.
+func TestAnchors_VerifyRejectsOversizedAnchor(t *testing.T) {
+	prev := maxAnchorSize
+	maxAnchorSize = 8 // tiny cap so the test needs no large fixture
+	t.Cleanup(func() { maxAnchorSize = prev })
+
+	e := newAnchorEnv(t) // default anchors are ~19 bytes, above the 8-byte cap
+	if _, _, err := e.seal(t); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("seal err = %v, want size-cap rejection", err)
+	}
+}
+
+// newKeyPairFiles writes an Ed25519 key pair to fresh temp files and returns
+// (publicPath, privatePath).
+func newKeyPairFiles(t *testing.T) (string, string) {
+	t.Helper()
+	e := newAnchorEnv(t)
+	return e.pubPath, e.privPath
+}

--- a/internal/cli/hermes/integrity_hardening_test.go
+++ b/internal/cli/hermes/integrity_hardening_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package hermes
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeBaseline(t *testing.T, ws string, b anchorBaseline) {
+	t.Helper()
+	data, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal baseline: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, defaultAnchorBaselineName), data, 0o600); err != nil {
+		t.Fatalf("write baseline: %v", err)
+	}
+}
+
+func loadBaselineForTest(t *testing.T, ws string) *anchorBaseline {
+	t.Helper()
+	b, err := loadAnchorBaseline(filepath.Join(ws, defaultAnchorBaselineName))
+	if err != nil {
+		t.Fatalf("load baseline: %v", err)
+	}
+	return b
+}
+
+func TestAnchors_InvalidSignatureHex(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := e.seal(t); err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	b := loadBaselineForTest(t, e.ws)
+	b.Signature = "nothex!!" // digest set intact, so the set check passes first
+	writeBaseline(t, e.ws, *b)
+	_, _, err := e.verify(t)
+	if err == nil || !strings.Contains(err.Error(), "signature is invalid") {
+		t.Fatalf("verify err = %v, want invalid-signature-hex", err)
+	}
+}
+
+// TestAnchors_TamperedDigestFailsSignature: altering a digest without the
+// private key leaves a stale signature that no longer verifies.
+func TestAnchors_TamperedDigestFailsSignature(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := e.seal(t); err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	b := loadBaselineForTest(t, e.ws)
+	b.Digests["SOUL.md"] = strings.Repeat("0", 64) // same key set, changed value
+	writeBaseline(t, e.ws, *b)                     // signature NOT recomputed
+	_, _, err := e.verify(t)
+	if err == nil || !strings.Contains(err.Error(), "signature does not verify") {
+		t.Fatalf("verify err = %v, want signature failure", err)
+	}
+}
+
+func TestAnchors_BadBaselineVersion(t *testing.T) {
+	e := newAnchorEnv(t)
+	writeBaseline(t, e.ws, anchorBaseline{
+		Version:            99,
+		DigestAlgorithm:    anchorDigestAlgorithm,
+		SignatureAlgorithm: anchorSignatureAlgorithm,
+		Digests:            map[string]string{"SOUL.md": strings.Repeat("0", 64)},
+		Signature:          "00",
+	})
+	_, _, err := e.verify(t)
+	if err == nil || !strings.Contains(err.Error(), "unsupported version") {
+		t.Fatalf("verify err = %v, want unsupported-version", err)
+	}
+}
+
+func TestAnchors_BaselineTraversalKeyRejected(t *testing.T) {
+	e := newAnchorEnv(t)
+	writeBaseline(t, e.ws, anchorBaseline{
+		Version:            anchorBaselineVersion,
+		DigestAlgorithm:    anchorDigestAlgorithm,
+		SignatureAlgorithm: anchorSignatureAlgorithm,
+		Digests:            map[string]string{"../escape": strings.Repeat("0", 64)},
+		Signature:          "00",
+	})
+	_, _, err := e.verify(t)
+	if err == nil || !strings.Contains(err.Error(), "clean relative path") {
+		t.Fatalf("verify err = %v, want traversal rejection", err)
+	}
+}
+
+// TestAnchors_VerifyRejectsReducedBaseline: an attacker drops SOUL.md from the
+// baseline so verify never checks it. Even re-signed with the private key
+// (worst case: key compromise), the expected-set check still rejects it.
+func TestAnchors_VerifyRejectsReducedBaseline(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := e.seal(t); err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	b := loadBaselineForTest(t, e.ws)
+	delete(b.Digests, "SOUL.md")
+	e.reSign(t, b) // valid signature over the reduced set
+	writeBaseline(t, e.ws, *b)
+	_, _, err := e.verify(t)
+	if err == nil || !strings.Contains(err.Error(), "anchor set") {
+		t.Fatalf("verify err = %v, want anchor-set rejection", err)
+	}
+}
+
+// TestAnchors_VerifyRejectsRenamedAnchorSet: same count, different member, with
+// a valid signature; the set-equality check must still reject it.
+func TestAnchors_VerifyRejectsRenamedAnchorSet(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := e.seal(t); err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	b := loadBaselineForTest(t, e.ws)
+	digest := b.Digests["AGENTS.md"]
+	delete(b.Digests, "AGENTS.md")
+	b.Digests["CHARTER.md"] = digest
+	e.reSign(t, b)
+	writeBaseline(t, e.ws, *b)
+	_, _, err := e.verify(t)
+	if err == nil || !strings.Contains(err.Error(), "anchor set") {
+		t.Fatalf("verify err = %v, want anchor-set rejection", err)
+	}
+}
+
+func TestAnchors_AbsoluteAnchorRejected(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := e.seal(t, "--anchor", "/etc/passwd"); err == nil ||
+		!strings.Contains(err.Error(), "clean relative path") {
+		t.Fatalf("seal err = %v, want absolute-anchor rejection", err)
+	}
+}
+
+// TestAnchors_SigningKeySymlinkIntoWorkspaceRejected covers the symlink branch
+// of rejectKeyInsideWorkspace: a signing-key path outside the workspace that is
+// a symlink pointing back inside it must be rejected.
+func TestAnchors_SigningKeySymlinkIntoWorkspaceRejected(t *testing.T) {
+	e := newAnchorEnv(t)
+	realKey := filepath.Join(e.ws, "secret.key")
+	if err := copyFileForTest(t, e.privPath, realKey); err != nil {
+		t.Fatalf("copy key into ws: %v", err)
+	}
+	link := filepath.Join(t.TempDir(), "key-link")
+	if err := os.Symlink(realKey, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	_, _, err := runAnchors(t, "seal", "--workspace", e.ws, "--signing-key", link)
+	if err == nil || !strings.Contains(err.Error(), "workspace") {
+		t.Fatalf("seal err = %v, want key-resolves-under-workspace rejection", err)
+	}
+}
+
+func copyFileForTest(t *testing.T, src, dst string) error {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(src))
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0o600)
+}
+
+func TestAnchors_BaselineUnsupportedDigestAlgorithm(t *testing.T) {
+	e := newAnchorEnv(t)
+	writeBaseline(t, e.ws, anchorBaseline{
+		Version:            anchorBaselineVersion,
+		DigestAlgorithm:    "md5",
+		SignatureAlgorithm: anchorSignatureAlgorithm,
+		Digests:            map[string]string{"SOUL.md": strings.Repeat("0", 64)},
+		Signature:          "00",
+	})
+	_, _, err := e.verify(t)
+	if err == nil || !strings.Contains(err.Error(), "unsupported digest algorithm") {
+		t.Fatalf("verify err = %v, want unsupported-digest-algorithm", err)
+	}
+}
+
+func TestAnchors_BaselineUnsupportedSignatureAlgorithm(t *testing.T) {
+	e := newAnchorEnv(t)
+	writeBaseline(t, e.ws, anchorBaseline{
+		Version:            anchorBaselineVersion,
+		DigestAlgorithm:    anchorDigestAlgorithm,
+		SignatureAlgorithm: "rsa",
+		Digests:            map[string]string{"SOUL.md": strings.Repeat("0", 64)},
+		Signature:          "00",
+	})
+	_, _, err := e.verify(t)
+	if err == nil || !strings.Contains(err.Error(), "unsupported signature algorithm") {
+		t.Fatalf("verify err = %v, want unsupported-signature-algorithm", err)
+	}
+}
+
+// TestAnchors_PublicKeyUnderWorkspaceRejected: a public key read from the
+// agent-writable workspace could be swapped with a baseline signed by the
+// attacker's own key, so verify must refuse it.
+func TestAnchors_PublicKeyUnderWorkspaceRejected(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := e.seal(t); err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	pubInWS := filepath.Join(e.ws, "anchor.pub")
+	if err := copyFileForTest(t, e.pubPath, pubInWS); err != nil {
+		t.Fatalf("copy pub into ws: %v", err)
+	}
+	_, _, err := runAnchors(t, "verify", "--workspace", e.ws, "--public-key", pubInWS)
+	if err == nil || !strings.Contains(err.Error(), "workspace") {
+		t.Fatalf("verify err = %v, want public-key-under-workspace rejection", err)
+	}
+}
+
+func TestValidateAnchorNames(t *testing.T) {
+	t.Parallel()
+	if err := validateAnchorNames(nil); err == nil {
+		t.Error("empty anchor list must be rejected")
+	}
+	bad := []string{"/abs", "..", "../up", "a/../b", ".", "dir/"}
+	for _, name := range bad {
+		if err := validateAnchorNames([]string{name}); err == nil {
+			t.Errorf("anchor %q must be rejected", name)
+		}
+	}
+	if err := validateAnchorNames([]string{"SOUL.md", "sub/IDENTITY.md"}); err != nil {
+		t.Errorf("clean relative anchors rejected: %v", err)
+	}
+	if err := validateAnchorNames([]string{"X.md", "X.md"}); err == nil {
+		t.Error("duplicate anchor must be rejected")
+	}
+}

--- a/internal/cli/hermes/integrity_test.go
+++ b/internal/cli/hermes/integrity_test.go
@@ -1,0 +1,271 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package hermes
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// anchorEnv is a test fixture: a workspace seeded with the default anchor files
+// and an Ed25519 key pair written outside the workspace (private key for seal,
+// public key for verify).
+type anchorEnv struct {
+	ws       string
+	privPath string
+	pubPath  string
+	priv     ed25519.PrivateKey
+	pub      ed25519.PublicKey
+}
+
+func newAnchorEnv(t *testing.T) anchorEnv {
+	t.Helper()
+	ws := t.TempDir()
+	for _, name := range defaultAnchorFiles {
+		if err := os.WriteFile(filepath.Join(ws, name), []byte("content of "+name+"\n"), 0o600); err != nil {
+			t.Fatalf("seed anchor %s: %v", name, err)
+		}
+	}
+	pub, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate key pair: %v", err)
+	}
+	keyDir := t.TempDir() // keys live outside the workspace, as in production
+	privPath := filepath.Join(keyDir, "anchor.key")
+	if err := os.WriteFile(privPath, []byte(signing.EncodePrivateKey(priv)), 0o600); err != nil {
+		t.Fatalf("write private key: %v", err)
+	}
+	pubPath := filepath.Join(keyDir, "anchor.pub")
+	if err := os.WriteFile(pubPath, []byte(signing.EncodePublicKey(pub)), 0o600); err != nil {
+		t.Fatalf("write public key: %v", err)
+	}
+	return anchorEnv{ws: ws, privPath: privPath, pubPath: pubPath, priv: priv, pub: pub}
+}
+
+// reSign recomputes the manifest signature with the fixture's private key, used
+// by adversarial tests that craft a tampered-but-validly-signed baseline.
+func (e anchorEnv) reSign(t *testing.T, b *anchorBaseline) {
+	t.Helper()
+	payload, err := canonicalManifestBytes(b.Version, b.DigestAlgorithm, b.Digests)
+	if err != nil {
+		t.Fatalf("canonical payload: %v", err)
+	}
+	b.Signature = hex.EncodeToString(ed25519.Sign(e.priv, payload))
+}
+
+func (e anchorEnv) seal(t *testing.T, extra ...string) (string, string, error) {
+	t.Helper()
+	args := append([]string{"--workspace", e.ws, "--signing-key", e.privPath}, extra...)
+	return runAnchors(t, "seal", args...)
+}
+
+func (e anchorEnv) verify(t *testing.T, extra ...string) (string, string, error) {
+	t.Helper()
+	args := append([]string{"--workspace", e.ws, "--public-key", e.pubPath}, extra...)
+	return runAnchors(t, "verify", args...)
+}
+
+// chmodForTest sets path's mode through an os.FileMode variable so gosec G302
+// (which flags >0o600 literals at the os.Chmod call site) does not fire on an
+// intentional loose-permission negative test.
+func chmodForTest(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+}
+
+// runAnchors executes `hermes anchors <sub> <args...>` and returns stdout,
+// stderr, and the command error (non-nil = non-zero exit).
+func runAnchors(t *testing.T, sub string, args ...string) (string, string, error) {
+	t.Helper()
+	c := anchorsCmd()
+	c.SetArgs(append([]string{sub}, args...))
+	var out, errb bytes.Buffer
+	c.SetOut(&out)
+	c.SetErr(&errb)
+	err := c.Execute()
+	return out.String(), errb.String(), err
+}
+
+func TestAnchors_SealThenVerifyOK(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := e.seal(t); err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(e.ws, defaultAnchorBaselineName)); err != nil {
+		t.Fatalf("baseline not written: %v", err)
+	}
+	out, _, err := e.verify(t)
+	if err != nil {
+		t.Fatalf("verify after seal should pass: %v", err)
+	}
+	if !strings.Contains(out, "anchor integrity OK") {
+		t.Errorf("verify output = %q, want OK", out)
+	}
+}
+
+func TestAnchors_VerifyDetectsTamper(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := e.seal(t); err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(e.ws, "SOUL.md"), []byte("malicious identity\n"), 0o600); err != nil {
+		t.Fatalf("tamper: %v", err)
+	}
+	_, errOut, err := e.verify(t)
+	if err == nil {
+		t.Fatal("verify must fail on a tampered anchor")
+	}
+	if !strings.Contains(errOut, "ANCHOR INTEGRITY VIOLATION") || !strings.Contains(errOut, "altered: SOUL.md") {
+		t.Errorf("stderr = %q, want violation naming SOUL.md", errOut)
+	}
+}
+
+func TestAnchors_VerifyDetectsMissingAnchor(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := e.seal(t); err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if err := os.Remove(filepath.Join(e.ws, "IDENTITY.md")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	_, errOut, err := e.verify(t)
+	if err == nil {
+		t.Fatal("verify must fail when an anchor is missing")
+	}
+	if !strings.Contains(errOut, "missing: IDENTITY.md") {
+		t.Errorf("stderr = %q, want missing IDENTITY.md", errOut)
+	}
+}
+
+func TestAnchors_VerifyWrongKeyFails(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := e.seal(t); err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	// A different public key cannot verify the operator's signature.
+	otherPub, _, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("gen: %v", err)
+	}
+	otherPath := filepath.Join(t.TempDir(), "other.pub")
+	if err := os.WriteFile(otherPath, []byte(signing.EncodePublicKey(otherPub)), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, _, err = runAnchors(t, "verify", "--workspace", e.ws, "--public-key", otherPath)
+	if err == nil || !strings.Contains(err.Error(), "signature does not verify") {
+		t.Fatalf("verify err = %v, want signature failure", err)
+	}
+}
+
+func TestAnchors_VerifyMissingBaselineFailsClosed(t *testing.T) {
+	e := newAnchorEnv(t)
+	// No seal: baseline absent. Verify must fail, not pass.
+	if _, _, err := e.verify(t); err == nil {
+		t.Fatal("verify must fail closed when the baseline is absent")
+	}
+}
+
+func TestAnchors_SigningKeyPermissionGate(t *testing.T) {
+	e := newAnchorEnv(t)
+	chmodForTest(t, e.privPath, 0o644) // world-readable private key
+	_, _, err := e.seal(t)
+	if err == nil || !strings.Contains(err.Error(), "signing key") {
+		t.Fatalf("seal err = %v, want permission rejection on the private key", err)
+	}
+}
+
+func TestAnchors_GarbageSigningKey(t *testing.T) {
+	e := newAnchorEnv(t)
+	if err := os.WriteFile(e.privPath, []byte("not a key"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := e.seal(t); err == nil {
+		t.Fatal("seal must fail on an undecodable signing key")
+	}
+}
+
+func TestAnchors_KeyFlagsRequired(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := runAnchors(t, "seal", "--workspace", e.ws); err == nil ||
+		!strings.Contains(err.Error(), "--signing-key is required") {
+		t.Fatalf("seal err = %v, want signing-key-required", err)
+	}
+	if _, _, err := runAnchors(t, "verify", "--workspace", e.ws); err == nil ||
+		!strings.Contains(err.Error(), "--public-key is required") {
+		t.Fatalf("verify err = %v, want public-key-required", err)
+	}
+}
+
+func TestAnchors_CustomAnchorSet(t *testing.T) {
+	e := newAnchorEnv(t)
+	if err := os.WriteFile(filepath.Join(e.ws, "CHARTER.md"), []byte("charter\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, _, err := e.seal(t, "--anchor", "CHARTER.md"); err != nil {
+		t.Fatalf("seal custom: %v", err)
+	}
+	if _, _, err := e.verify(t, "--anchor", "CHARTER.md"); err != nil {
+		t.Fatalf("verify custom: %v", err)
+	}
+}
+
+func TestAnchors_VerifyJSON(t *testing.T) {
+	e := newAnchorEnv(t)
+	if _, _, err := e.seal(t); err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	out, _, err := e.verify(t, "--json")
+	if err != nil {
+		t.Fatalf("verify --json: %v", err)
+	}
+	var report anchorVerifyReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("parse json %q: %v", out, err)
+	}
+	if !report.OK || report.Checked != len(defaultAnchorFiles) {
+		t.Errorf("report = %+v, want OK with %d checked", report, len(defaultAnchorFiles))
+	}
+}
+
+func TestAnchors_DefaultWorkspaceFromHome(t *testing.T) {
+	home := t.TempDir()
+	prev := userHomeDir
+	userHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { userHomeDir = prev })
+
+	hermesDir := filepath.Join(home, ".hermes")
+	if err := os.MkdirAll(hermesDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, name := range defaultAnchorFiles {
+		if err := os.WriteFile(filepath.Join(hermesDir, name), []byte("x"), 0o600); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("gen: %v", err)
+	}
+	privPath := filepath.Join(t.TempDir(), "k") // outside ~/.hermes
+	if err := os.WriteFile(privPath, []byte(signing.EncodePrivateKey(priv)), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// No --workspace: resolves to ~/.hermes via the stubbed userHomeDir.
+	if _, _, err := runAnchors(t, "seal", "--signing-key", privPath); err != nil {
+		t.Fatalf("seal default workspace: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(hermesDir, defaultAnchorBaselineName)); err != nil {
+		t.Fatalf("baseline not in ~/.hermes: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `pipelock hermes anchors seal` and `pipelock hermes anchors verify`, an integrity check for Hermes' seeded identity-anchor files (SOUL.md, IDENTITY.md, AGENTS.md). Hermes seeds these once and never re-seeds, so an attacker who can write the agent's persistent workspace can overwrite the agent's identity and have it persist across restarts.

- `seal` records SHA-256 of each anchor and signs the manifest with an Ed25519 private key.
- `verify` (run at startup, e.g. a Kubernetes init container) recomputes the digests, checks the signature against the public key, and exits non-zero on any drifted, missing, or unreadable anchor, refusing to start the agent.

## Why a signature, not a keyed MAC

Verify needs only the public key, which can sit in-cluster with no risk; the private signing key stays off-cluster and is used only at seal time. A compromised agent or cluster therefore cannot forge a baseline. This reuses pipelock's existing Ed25519 signing primitives (`internal/signing`).

## Hardening

The signature covers the whole `{version, digest_algorithm, digests}` manifest, so an attacker who can write the baseline cannot drop, add, or alter an entry, downgrade the version, or swap in a baseline signed by another key. Verify also requires the baseline to cover exactly the requested anchor set as defense in depth. Anchor reads reject symlinks and oversized files so a tampered anchor cannot turn verify into a device read or an OOM. Anchor names and baseline keys are validated as clean relative paths (no traversal). The private signing key is permission-gated and rejected if it lives under the workspace, as is a path-based public key. Fail-closed throughout.

## Scope

Verify is a point-in-time startup check: it detects tampering that persisted from before boot and refuses to start, but it does not prevent writes while the agent runs. Closing that window is a deployment concern (mount the anchor files read-only), handled by the separate cluster identity and topology work. `MEMORY.md` is intentionally not an anchor (it changes legitimately as the agent curates memory).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hermes anchors seal` command to create integrity baselines for anchor files using cryptographic signatures.
  * Added `hermes anchors verify` command to validate anchor files against baselines and detect tampering or missing files.
  * Supports custom anchor sets, workspace paths, and JSON-formatted verification reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->