### PR TITLE
Conductor: add server runtime wiring

### DIFF
--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -216,6 +216,37 @@ server derives follower identity from the authenticated transport and returns
 the newest currently valid bundle whose org, fleet, environment, and audience
 match that follower, or `204 No Content` when no bundle applies.
 
+MVP runtime wiring is exposed as:
+
+```sh
+pipelock conductor serve \
+  --listen 127.0.0.1:8895 \
+  --storage-dir /var/lib/pipelock/conductor-server \
+  --tls-cert /etc/pipelock/conductor/server.crt \
+  --tls-key /etc/pipelock/conductor/server.key \
+  --client-ca /etc/pipelock/conductor/follower-ca.pem \
+  --publisher-token-file /etc/pipelock/conductor/publisher-token \
+  --trusted-audit-key id=audit-key-1,file=/etc/pipelock/conductor/audit-key.pub,org=org-main,fleet=prod
+```
+
+The command requires TLS 1.3 plus client-certificate verification. Follower
+identity is derived from a verified SPIFFE URI SAN in the client certificate:
+`spiffe://<trust-domain>/orgs/<org>/fleets/<fleet>/instances/<instance>/environments/<environment>`.
+The trust-domain match is case-insensitive (the SPIFFE spec restricts trust
+domains to lowercase ASCII), but each path component is validated as a
+canonical conductor identifier: only `[a-zA-Z0-9_.-]`, no leading `_`, `-`,
+or `.`, and bounded length. SANs that unescape to a forbidden byte (null,
+slash, control character) are rejected at the transport boundary before
+reaching any store or sink.
+
+Policy publication uses a bearer token read from disk so the token does not
+appear in process arguments. Every `--trusted-audit-key` MUST carry `org=`;
+a cross-org audit key would let any enrolled follower in any org sign batches
+that authenticate against that key. Optional `fleet=`/`instance=` narrow the
+scope further. Accepted audit batches are written to a durable local spool;
+indexed query, retention policy, and fork analytics remain a later storage
+layer.
+
 ### Bundle Envelope
 
 ```json

--- a/internal/cli/conductor/cmd.go
+++ b/internal/cli/conductor/cmd.go
@@ -1,0 +1,299 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package conductor
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	conductorcore "github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const (
+	defaultListen      = "127.0.0.1:8895"
+	defaultTrustDomain = "pipelock.local"
+)
+
+type serveOptions struct {
+	listen              string
+	storageDir          string
+	conductorID         string
+	followerTrustDomain string
+	publisherTokenFile  string
+	trustedAuditKeys    []string
+	tlsCert             string
+	tlsKey              string
+	clientCA            string
+}
+
+type auditKeySpec struct {
+	id         string
+	inline     string
+	file       string
+	orgID      string
+	fleetID    string
+	instanceID string
+}
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "conductor",
+		Short: "Run Conductor control-plane services",
+	}
+	cmd.AddCommand(serveCmd())
+	return cmd
+}
+
+func serveCmd() *cobra.Command {
+	opts := serveOptions{
+		listen:              defaultListen,
+		conductorID:         "conductor",
+		followerTrustDomain: defaultTrustDomain,
+	}
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Serve Conductor policy and audit ingest endpoints",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runServe(cmd, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.listen, "listen", opts.listen, "address for the Conductor HTTPS listener")
+	cmd.Flags().StringVar(&opts.storageDir, "storage-dir", "", "directory for Conductor policy bundles and audit spool")
+	cmd.Flags().StringVar(&opts.conductorID, "conductor-id", opts.conductorID, "Conductor ID advertised in capabilities")
+	cmd.Flags().StringVar(&opts.followerTrustDomain, "follower-trust-domain", opts.followerTrustDomain, "SPIFFE trust domain for follower mTLS identities")
+	cmd.Flags().StringVar(&opts.publisherTokenFile, "publisher-token-file", "", "file containing bearer token required for policy publish requests")
+	cmd.Flags().StringArrayVar(&opts.trustedAuditKeys, "trusted-audit-key", nil,
+		"trusted audit signing key as comma-separated kv pairs: 'id=ID,(inline=BASE64|file=/path),org=ORG[,fleet=FLEET][,instance=INSTANCE]'; "+
+			"org= is required so a key cannot authenticate batches across orgs; repeatable")
+	cmd.Flags().StringVar(&opts.tlsCert, "tls-cert", "", "TLS server certificate file")
+	cmd.Flags().StringVar(&opts.tlsKey, "tls-key", "", "TLS server private key file")
+	cmd.Flags().StringVar(&opts.clientCA, "client-ca", "", "client CA PEM bundle for follower mTLS")
+	return cmd
+}
+
+func runServe(cmd *cobra.Command, opts serveOptions) error {
+	handler, tlsConfig, err := buildServeHandler(cmd.Context(), opts)
+	if err != nil {
+		return err
+	}
+	server := &http.Server{
+		Addr:              opts.listen,
+		Handler:           handler,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    64 * 1024,
+	}
+	runCtx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	go func() {
+		<-runCtx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pipelock: conductor listening on %s\n", opts.listen)
+	if err := server.ListenAndServeTLS(opts.tlsCert, opts.tlsKey); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, *tls.Config, error) {
+	if strings.TrimSpace(opts.storageDir) == "" {
+		return nil, nil, errors.New("--storage-dir is required")
+	}
+	if err := validateServeTLSFlags(opts); err != nil {
+		return nil, nil, err
+	}
+	publisherToken, err := loadTokenFile(opts.publisherTokenFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	authorizer, err := controlplane.BearerPublisherAuthorizer(publisherToken)
+	if err != nil {
+		return nil, nil, err
+	}
+	identity, err := controlplane.MTLSFollowerIdentityResolver(opts.followerTrustDomain)
+	if err != nil {
+		return nil, nil, err
+	}
+	auditKeys, err := buildAuditKeyResolver(opts.trustedAuditKeys)
+	if err != nil {
+		return nil, nil, err
+	}
+	store, err := controlplane.OpenFileBundleStore(filepath.Join(opts.storageDir, "policy-bundles"))
+	if err != nil {
+		return nil, nil, err
+	}
+	spool, err := controlplane.OpenFileAuditSpool(filepath.Join(opts.storageDir, "audit-spool"))
+	if err != nil {
+		return nil, nil, err
+	}
+	handler, err := controlplane.NewHandler(controlplane.HandlerOptions{
+		Store:              store,
+		Capabilities:       controlplane.DefaultCapabilities(opts.conductorID),
+		FollowerIdentity:   identity,
+		AuthorizePublisher: authorizer,
+		AuditSink:          spool,
+		AuditKeys:          auditKeys,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	tlsConfig, err := serveTLSConfig(opts.clientCA)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	return handler, tlsConfig, nil
+}
+
+func validateServeTLSFlags(opts serveOptions) error {
+	switch {
+	case strings.TrimSpace(opts.tlsCert) == "":
+		return errors.New("--tls-cert is required")
+	case strings.TrimSpace(opts.tlsKey) == "":
+		return errors.New("--tls-key is required")
+	case strings.TrimSpace(opts.clientCA) == "":
+		return errors.New("--client-ca is required")
+	default:
+		return nil
+	}
+}
+
+func serveTLSConfig(clientCAPath string) (*tls.Config, error) {
+	pemBytes, err := os.ReadFile(filepath.Clean(clientCAPath))
+	if err != nil {
+		return nil, fmt.Errorf("read client CA bundle: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pemBytes) {
+		return nil, errors.New("client CA bundle contains no PEM certificates")
+	}
+	return &tls.Config{
+		MinVersion: tls.VersionTLS13,
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  pool,
+	}, nil
+}
+
+func loadTokenFile(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("--publisher-token-file is required")
+	}
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return "", fmt.Errorf("read publisher token file: %w", err)
+	}
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		return "", errors.New("publisher token file is empty")
+	}
+	return token, nil
+}
+
+func buildAuditKeyResolver(values []string) (controlplane.AuditKeyResolver, error) {
+	if len(values) == 0 {
+		return nil, controlplane.ErrAuditKeyRequired
+	}
+	keys := make([]controlplane.StaticAuditKey, 0, len(values))
+	for _, value := range values {
+		spec, err := parseAuditKeySpec(value)
+		if err != nil {
+			return nil, err
+		}
+		pub, err := loadAuditPublicKey(spec)
+		if err != nil {
+			return nil, fmt.Errorf("load trusted audit key %q: %w", spec.id, err)
+		}
+		keys = append(keys, controlplane.StaticAuditKey{
+			KeyID: spec.id,
+			Key: conductorcore.SignatureKey{
+				PublicKey:  pub,
+				KeyPurpose: signing.PurposeAuditBatchSigning,
+			},
+			OrgID:      spec.orgID,
+			FleetID:    spec.fleetID,
+			InstanceID: spec.instanceID,
+		})
+	}
+	return controlplane.StaticAuditKeyResolver(keys)
+}
+
+func parseAuditKeySpec(raw string) (auditKeySpec, error) {
+	if strings.TrimSpace(raw) == "" {
+		return auditKeySpec{}, errors.New("invalid --trusted-audit-key: empty")
+	}
+	spec := auditKeySpec{}
+	seen := make(map[string]struct{})
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(part, "=")
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if !ok || k == "" {
+			return auditKeySpec{}, fmt.Errorf("invalid --trusted-audit-key %q: expected k=v pairs", raw)
+		}
+		if _, dup := seen[k]; dup {
+			return auditKeySpec{}, fmt.Errorf("invalid --trusted-audit-key %q: duplicate key %q", raw, k)
+		}
+		seen[k] = struct{}{}
+		switch k {
+		case "id":
+			spec.id = v
+		case "inline":
+			spec.inline = v
+		case "file":
+			spec.file = v
+		case "org":
+			spec.orgID = v
+		case "fleet":
+			spec.fleetID = v
+		case "instance":
+			spec.instanceID = v
+		default:
+			return auditKeySpec{}, fmt.Errorf("invalid --trusted-audit-key %q: unknown field %q", raw, k)
+		}
+	}
+	if spec.id == "" {
+		return auditKeySpec{}, fmt.Errorf("invalid --trusted-audit-key %q: id= required", raw)
+	}
+	if (spec.inline == "" && spec.file == "") || (spec.inline != "" && spec.file != "") {
+		return auditKeySpec{}, fmt.Errorf("invalid --trusted-audit-key %q: exactly one of inline= or file= required", raw)
+	}
+	if spec.orgID == "" {
+		return auditKeySpec{}, fmt.Errorf("invalid --trusted-audit-key %q: org= required so an audit key cannot authenticate batches across orgs", raw)
+	}
+	return spec, nil
+}
+
+func loadAuditPublicKey(spec auditKeySpec) ([]byte, error) {
+	if spec.inline != "" {
+		return signing.ParsePublicKey(spec.inline)
+	}
+	return signing.LoadPublicKeyFile(filepath.Clean(spec.file))
+}

--- a/internal/cli/conductor/cmd.go
+++ b/internal/cli/conductor/cmd.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -88,7 +89,11 @@ func serveCmd() *cobra.Command {
 }
 
 func runServe(cmd *cobra.Command, opts serveOptions) error {
-	handler, tlsConfig, err := buildServeHandler(cmd.Context(), opts)
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	handler, tlsConfig, err := buildServeHandler(ctx, opts)
 	if err != nil {
 		return err
 	}
@@ -102,8 +107,13 @@ func runServe(cmd *cobra.Command, opts serveOptions) error {
 		IdleTimeout:       60 * time.Second,
 		MaxHeaderBytes:    64 * 1024,
 	}
-	runCtx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	runCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	ln, err := (&net.ListenConfig{}).Listen(runCtx, "tcp", opts.listen)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = ln.Close() }()
 	go func() {
 		<-runCtx.Done()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -111,7 +121,7 @@ func runServe(cmd *cobra.Command, opts serveOptions) error {
 		_ = server.Shutdown(shutdownCtx)
 	}()
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pipelock: conductor listening on %s\n", opts.listen)
-	if err := server.ListenAndServeTLS(opts.tlsCert, opts.tlsKey); err != nil && !errors.Is(err, http.ErrServerClosed) {
+	if err := server.ServeTLS(ln, opts.tlsCert, opts.tlsKey); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}
 	return nil

--- a/internal/cli/conductor/cmd_test.go
+++ b/internal/cli/conductor/cmd_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package conductor
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	conductorcore "github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestBuildServeHandlerWiresControlPlane(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "publisher-token")
+	if err := os.WriteFile(tokenPath, []byte("secret-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(token): %v", err)
+	}
+	caPath := filepath.Join(dir, "client-ca.pem")
+	if err := os.WriteFile(caPath, testCAPEM(t), 0o600); err != nil {
+		t.Fatalf("WriteFile(ca): %v", err)
+	}
+
+	handler, tlsConfig, err := buildServeHandler(context.Background(), serveOptions{
+		listen:              defaultListen,
+		storageDir:          filepath.Join(dir, "store"),
+		conductorID:         "conductor-test",
+		followerTrustDomain: defaultTrustDomain,
+		publisherTokenFile:  tokenPath,
+		trustedAuditKeys: []string{
+			"id=audit-key-1,inline=" + signing.EncodePublicKey(pub) + ",org=org-main",
+		},
+		tlsCert:  filepath.Join(dir, "server.pem"),
+		tlsKey:   filepath.Join(dir, "server.key"),
+		clientCA: caPath,
+	})
+	if err != nil {
+		t.Fatalf("buildServeHandler() error = %v", err)
+	}
+	if tlsConfig.ClientAuth != tls.RequireAndVerifyClientCert || tlsConfig.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("TLS config = %+v", tlsConfig)
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, conductorcore.CapabilitiesPath, nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("capabilities status = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+}
+
+func TestBuildServeHandlerRequiresAuthInputs(t *testing.T) {
+	_, _, err := buildServeHandler(context.Background(), serveOptions{
+		storageDir: "/tmp/store",
+		tlsCert:    "server.pem",
+		tlsKey:     "server.key",
+	})
+	if err == nil || err.Error() != "--client-ca is required" {
+		t.Fatalf("buildServeHandler() error = %v, want --client-ca required", err)
+	}
+
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "client-ca.pem")
+	if err := os.WriteFile(caPath, testCAPEM(t), 0o600); err != nil {
+		t.Fatalf("WriteFile(ca): %v", err)
+	}
+	tokenPath := filepath.Join(dir, "publisher-token")
+	if err := os.WriteFile(tokenPath, []byte("secret-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(token): %v", err)
+	}
+	_, _, err = buildServeHandler(context.Background(), serveOptions{
+		storageDir:          filepath.Join(dir, "store"),
+		followerTrustDomain: defaultTrustDomain,
+		tlsCert:             "server.pem",
+		tlsKey:              "server.key",
+		clientCA:            caPath,
+		publisherTokenFile:  tokenPath,
+	})
+	if !errors.Is(err, controlplane.ErrAuditKeyRequired) {
+		t.Fatalf("buildServeHandler() error = %v, want ErrAuditKeyRequired", err)
+	}
+}
+
+func TestParseAuditKeySpec(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		spec, err := parseAuditKeySpec("id=k1,inline=abc,org=o,fleet=f,instance=i")
+		if err != nil {
+			t.Fatalf("parseAuditKeySpec() error = %v", err)
+		}
+		if spec.id != "k1" || spec.inline != "abc" || spec.orgID != "o" || spec.fleetID != "f" || spec.instanceID != "i" {
+			t.Fatalf("spec = %+v", spec)
+		}
+	})
+
+	rejections := []struct {
+		name   string
+		input  string
+		errSub string
+	}{
+		{"missing id", "inline=abc,org=o", "id= required"},
+		{"missing org", "id=k1,inline=abc", "org= required"},
+		{"missing material", "id=k1,org=o", "exactly one of inline= or file="},
+		{"both inline and file", "id=k1,inline=abc,file=/tmp/x,org=o", "exactly one of inline= or file="},
+		{"duplicate field", "id=k1,id=k2,inline=abc,org=o", "duplicate key"},
+		{"unknown field", "id=k1,inline=abc,org=o,bogus=x", "unknown field"},
+		{"empty input", "", "empty"},
+		{"no equals", "id-k1,inline=abc", "expected k=v pairs"},
+	}
+	for _, c := range rejections {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := parseAuditKeySpec(c.input)
+			if err == nil {
+				t.Fatalf("parseAuditKeySpec(%q) error = nil, want %q", c.input, c.errSub)
+			}
+			if !strings.Contains(err.Error(), c.errSub) {
+				t.Fatalf("parseAuditKeySpec(%q) error = %v, want substring %q", c.input, err, c.errSub)
+			}
+		})
+	}
+}
+
+func TestLoadTokenFileRejectsMissingAndEmpty(t *testing.T) {
+	if _, err := loadTokenFile(""); err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("loadTokenFile(empty path) error = %v, want required", err)
+	}
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty")
+	if err := os.WriteFile(empty, []byte("  \n\t"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := loadTokenFile(empty); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("loadTokenFile(whitespace) error = %v, want empty", err)
+	}
+	tok := filepath.Join(dir, "tok")
+	if err := os.WriteFile(tok, []byte("  hello-token  \n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := loadTokenFile(tok)
+	if err != nil {
+		t.Fatalf("loadTokenFile() error = %v", err)
+	}
+	if got != "hello-token" {
+		t.Fatalf("loadTokenFile() = %q, want trimmed token", got)
+	}
+}
+
+func testCAPEM(t *testing.T) []byte {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(CA): %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test client CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}

--- a/internal/cli/conductor/cmd_test.go
+++ b/internal/cli/conductor/cmd_test.go
@@ -101,6 +101,44 @@ func TestBuildServeHandlerRequiresAuthInputs(t *testing.T) {
 	}
 }
 
+func TestRunServeReturnsTLSLoadError(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "publisher-token")
+	if err := os.WriteFile(tokenPath, []byte("secret-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(token): %v", err)
+	}
+	caPath := filepath.Join(dir, "client-ca.pem")
+	if err := os.WriteFile(caPath, testCAPEM(t), 0o600); err != nil {
+		t.Fatalf("WriteFile(ca): %v", err)
+	}
+	cmd := serveCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	err = runServe(cmd, serveOptions{
+		listen:              "127.0.0.1:0",
+		storageDir:          filepath.Join(dir, "store"),
+		conductorID:         "conductor-test",
+		followerTrustDomain: defaultTrustDomain,
+		publisherTokenFile:  tokenPath,
+		trustedAuditKeys: []string{
+			"id=audit-key-1,inline=" + signing.EncodePublicKey(pub) + ",org=org-main",
+		},
+		tlsCert:  filepath.Join(dir, "missing-server.pem"),
+		tlsKey:   filepath.Join(dir, "missing-server.key"),
+		clientCA: caPath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing-server.pem") {
+		t.Fatalf("runServe() error = %v, want missing TLS cert error", err)
+	}
+	if !strings.Contains(out.String(), "pipelock: conductor listening on 127.0.0.1:0") {
+		t.Fatalf("runServe() output = %q, want listening line", out.String())
+	}
+}
+
 func TestParseAuditKeySpec(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		spec, err := parseAuditKeySpec("id=k1,inline=abc,org=o,fleet=f,instance=i")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/cli/assess"
 	"github.com/luckyPipewrench/pipelock/internal/cli/audit"
 	"github.com/luckyPipewrench/pipelock/internal/cli/canary"
+	cliconductor "github.com/luckyPipewrench/pipelock/internal/cli/conductor"
 	"github.com/luckyPipewrench/pipelock/internal/cli/contain"
 	"github.com/luckyPipewrench/pipelock/internal/cli/diag"
 	clienvelope "github.com/luckyPipewrench/pipelock/internal/cli/envelope"
@@ -82,6 +83,8 @@ Quick start:
 		audit.Cmd(),
 		// Canary tokens
 		canary.Cmd(),
+		// Conductor control plane
+		cliconductor.Cmd(),
 		audit.ReportCmd(),
 		audit.SimulateCmd(),
 		// Containment (workstation-tier)

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -70,3 +70,19 @@ func TestFleetSinkHelpRegistered(t *testing.T) {
 		t.Fatalf("help output = %q, want trusted audit key flag", got)
 	}
 }
+
+func TestConductorServeHelpRegistered(t *testing.T) {
+	cmd := rootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"conductor", "serve", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("conductor serve help: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "--publisher-token-file") || !strings.Contains(got, "--client-ca") {
+		t.Fatalf("help output = %q, want conductor serve auth flags", got)
+	}
+}

--- a/internal/conductor/controlplane/audit_spool.go
+++ b/internal/conductor/controlplane/audit_spool.go
@@ -39,6 +39,9 @@ func (s *FileAuditSpool) IngestAuditBatch(ctx context.Context, batch AcceptedAud
 	if s == nil {
 		return ErrAuditSinkRequired
 	}
+	if ctx == nil {
+		return fmt.Errorf("%w: context", ErrAuditSinkRequired)
+	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -47,6 +50,13 @@ func (s *FileAuditSpool) IngestAuditBatch(ctx context.Context, batch AcceptedAud
 	}
 	if err := batch.Identity.Validate(); err != nil {
 		return err
+	}
+	actualHash, err := batch.Envelope.CanonicalHash()
+	if err != nil {
+		return err
+	}
+	if actualHash != batch.EnvelopeHash {
+		return fmt.Errorf("%w: envelope_hash mismatch", ErrInvalidStoreRecord)
 	}
 	record := spooledAuditBatch{
 		Identity:     batch.Identity,

--- a/internal/conductor/controlplane/audit_spool.go
+++ b/internal/conductor/controlplane/audit_spool.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package controlplane
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+)
+
+type FileAuditSpool struct {
+	dir string
+}
+
+type spooledAuditBatch struct {
+	Identity     FollowerIdentity             `json:"identity"`
+	Envelope     conductor.AuditBatchEnvelope `json:"envelope"`
+	EnvelopeHash string                       `json:"envelope_hash"`
+	Payload      []byte                       `json:"payload"`
+	ReceivedAt   time.Time                    `json:"received_at"`
+}
+
+func OpenFileAuditSpool(dir string) (*FileAuditSpool, error) {
+	resolved, err := secureDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	return &FileAuditSpool{dir: resolved}, nil
+}
+
+func (s *FileAuditSpool) IngestAuditBatch(ctx context.Context, batch AcceptedAuditBatch) error {
+	if s == nil {
+		return ErrAuditSinkRequired
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := validateSpoolEnvelopeHash(batch.EnvelopeHash); err != nil {
+		return err
+	}
+	if err := batch.Identity.Validate(); err != nil {
+		return err
+	}
+	record := spooledAuditBatch{
+		Identity:     batch.Identity,
+		Envelope:     batch.Envelope,
+		EnvelopeHash: batch.EnvelopeHash,
+		Payload:      append([]byte(nil), batch.Payload...),
+		ReceivedAt:   batch.ReceivedAt.UTC(),
+	}
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return fmt.Errorf("conductor audit spool marshal batch: %w", err)
+	}
+	data = append(data, '\n')
+	return durableWrite(filepath.Join(s.dir, batch.EnvelopeHash+".json"), data, bundleRecordFileMode)
+}
+
+func validateSpoolEnvelopeHash(hash string) error {
+	if len(hash) != sha256.Size*2 {
+		return fmt.Errorf("%w: envelope_hash", ErrInvalidStoreRecord)
+	}
+	if _, err := hex.DecodeString(hash); err != nil {
+		return fmt.Errorf("%w: envelope_hash", ErrInvalidStoreRecord)
+	}
+	return nil
+}

--- a/internal/conductor/controlplane/audit_spool_test.go
+++ b/internal/conductor/controlplane/audit_spool_test.go
@@ -20,31 +20,14 @@ func TestFileAuditSpoolPersistsAcceptedBatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenFileAuditSpool() error = %v", err)
 	}
-	hash := strings.Repeat("a", 64)
 	payload := []byte(`{"entry":"ok"}`)
-	batch := AcceptedAuditBatch{
-		Identity: FollowerIdentity{
-			OrgID:       "org-main",
-			FleetID:     "prod",
-			InstanceID:  "pl-prod-1",
-			Environment: "prod",
-		},
-		Envelope: conductor.AuditBatchEnvelope{
-			BatchID:    "batch-1",
-			OrgID:      "org-main",
-			FleetID:    "prod",
-			InstanceID: "pl-prod-1",
-		},
-		EnvelopeHash: hash,
-		Payload:      payload,
-		ReceivedAt:   testNow,
-	}
+	batch := acceptedSpoolBatch(t, "batch-1", payload)
 	if err := spool.IngestAuditBatch(context.Background(), batch); err != nil {
 		t.Fatalf("IngestAuditBatch() error = %v", err)
 	}
 	payload[0] = '['
 
-	data, err := os.ReadFile(filepath.Clean(filepath.Join(spool.dir, hash+".json"))) //nolint:gosec // Test reads from a temp dir plus fixed hash filename.
+	data, err := os.ReadFile(filepath.Clean(filepath.Join(spool.dir, batch.EnvelopeHash+".json"))) //nolint:gosec // Test reads from a temp dir plus fixed hash filename.
 	if err != nil {
 		t.Fatalf("ReadFile() error = %v", err)
 	}
@@ -65,8 +48,24 @@ func TestFileAuditSpoolRejectsInvalidInput(t *testing.T) {
 	if err := spool.IngestAuditBatch(context.Background(), AcceptedAuditBatch{EnvelopeHash: "bad"}); !errors.Is(err, ErrInvalidStoreRecord) {
 		t.Fatalf("IngestAuditBatch(bad hash) error = %v, want ErrInvalidStoreRecord", err)
 	}
+	var nilCtx context.Context
+	if err := spool.IngestAuditBatch(nilCtx, AcceptedAuditBatch{}); !errors.Is(err, ErrAuditSinkRequired) {
+		t.Fatalf("IngestAuditBatch(nil context) error = %v, want ErrAuditSinkRequired", err)
+	}
 	if err := (*FileAuditSpool)(nil).IngestAuditBatch(context.Background(), AcceptedAuditBatch{}); !errors.Is(err, ErrAuditSinkRequired) {
 		t.Fatalf("nil IngestAuditBatch error = %v, want ErrAuditSinkRequired", err)
+	}
+}
+
+func TestFileAuditSpoolRejectsEnvelopeHashMismatch(t *testing.T) {
+	spool, err := OpenFileAuditSpool(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileAuditSpool() error = %v", err)
+	}
+	batch := acceptedSpoolBatch(t, "batch-1", []byte(`{"entry":"ok"}`))
+	batch.EnvelopeHash = strings.Repeat("f", 64)
+	if err := spool.IngestAuditBatch(context.Background(), batch); !errors.Is(err, ErrInvalidStoreRecord) {
+		t.Fatalf("IngestAuditBatch(hash mismatch) error = %v, want ErrInvalidStoreRecord", err)
 	}
 }
 
@@ -110,26 +109,42 @@ func TestFileAuditSpoolFileMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenFileAuditSpool() error = %v", err)
 	}
-	hash := strings.Repeat("b", 64)
-	batch := AcceptedAuditBatch{
-		Identity: FollowerIdentity{
-			OrgID:       "org-main",
-			FleetID:     "prod",
-			InstanceID:  "pl-prod-1",
-			Environment: "prod",
-		},
-		EnvelopeHash: hash,
-		Payload:      []byte(`{"ok":true}`),
-		ReceivedAt:   testNow,
-	}
+	batch := acceptedSpoolBatch(t, "batch-1", []byte(`{"ok":true}`))
 	if err := spool.IngestAuditBatch(context.Background(), batch); err != nil {
 		t.Fatalf("IngestAuditBatch() error = %v", err)
 	}
-	info, err := os.Stat(filepath.Clean(filepath.Join(spool.dir, hash+".json"))) //nolint:gosec // Test reads from a temp dir plus fixed hash filename.
+	info, err := os.Stat(filepath.Clean(filepath.Join(spool.dir, batch.EnvelopeHash+".json"))) //nolint:gosec // Test reads from a temp dir plus fixed hash filename.
 	if err != nil {
 		t.Fatalf("Stat() error = %v", err)
 	}
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("spool file mode = %v, want 0o600", info.Mode().Perm())
+	}
+}
+
+func acceptedSpoolBatch(t *testing.T, batchID string, payload []byte) AcceptedAuditBatch {
+	t.Helper()
+	identity := FollowerIdentity{
+		OrgID:       "org-main",
+		FleetID:     "prod",
+		InstanceID:  "pl-prod-1",
+		Environment: "prod",
+	}
+	envelope := conductor.AuditBatchEnvelope{
+		BatchID:    batchID,
+		OrgID:      identity.OrgID,
+		FleetID:    identity.FleetID,
+		InstanceID: identity.InstanceID,
+	}
+	hash, err := envelope.CanonicalHash()
+	if err != nil {
+		t.Fatalf("CanonicalHash() error = %v", err)
+	}
+	return AcceptedAuditBatch{
+		Identity:     identity,
+		Envelope:     envelope,
+		EnvelopeHash: hash,
+		Payload:      payload,
+		ReceivedAt:   testNow,
 	}
 }

--- a/internal/conductor/controlplane/audit_spool_test.go
+++ b/internal/conductor/controlplane/audit_spool_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package controlplane
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+)
+
+func TestFileAuditSpoolPersistsAcceptedBatch(t *testing.T) {
+	spool, err := OpenFileAuditSpool(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileAuditSpool() error = %v", err)
+	}
+	hash := strings.Repeat("a", 64)
+	payload := []byte(`{"entry":"ok"}`)
+	batch := AcceptedAuditBatch{
+		Identity: FollowerIdentity{
+			OrgID:       "org-main",
+			FleetID:     "prod",
+			InstanceID:  "pl-prod-1",
+			Environment: "prod",
+		},
+		Envelope: conductor.AuditBatchEnvelope{
+			BatchID:    "batch-1",
+			OrgID:      "org-main",
+			FleetID:    "prod",
+			InstanceID: "pl-prod-1",
+		},
+		EnvelopeHash: hash,
+		Payload:      payload,
+		ReceivedAt:   testNow,
+	}
+	if err := spool.IngestAuditBatch(context.Background(), batch); err != nil {
+		t.Fatalf("IngestAuditBatch() error = %v", err)
+	}
+	payload[0] = '['
+
+	data, err := os.ReadFile(filepath.Clean(filepath.Join(spool.dir, hash+".json"))) //nolint:gosec // Test reads from a temp dir plus fixed hash filename.
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	var got spooledAuditBatch
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.Identity.InstanceID != "pl-prod-1" || string(got.Payload) != `{"entry":"ok"}` {
+		t.Fatalf("spooled batch = %+v payload=%q", got.Identity, string(got.Payload))
+	}
+}
+
+func TestFileAuditSpoolRejectsInvalidInput(t *testing.T) {
+	spool, err := OpenFileAuditSpool(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileAuditSpool() error = %v", err)
+	}
+	if err := spool.IngestAuditBatch(context.Background(), AcceptedAuditBatch{EnvelopeHash: "bad"}); !errors.Is(err, ErrInvalidStoreRecord) {
+		t.Fatalf("IngestAuditBatch(bad hash) error = %v, want ErrInvalidStoreRecord", err)
+	}
+	if err := (*FileAuditSpool)(nil).IngestAuditBatch(context.Background(), AcceptedAuditBatch{}); !errors.Is(err, ErrAuditSinkRequired) {
+		t.Fatalf("nil IngestAuditBatch error = %v, want ErrAuditSinkRequired", err)
+	}
+}
+
+// TestFileAuditSpoolRejectsCorruptedIdentity asserts the defensive identity
+// re-validation in IngestAuditBatch fires when an authenticated-then-validated
+// identity later carries forbidden bytes (defense-in-depth against a future
+// resolver that bypasses canonical identifier checks).
+func TestFileAuditSpoolRejectsCorruptedIdentity(t *testing.T) {
+	spool, err := OpenFileAuditSpool(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileAuditSpool() error = %v", err)
+	}
+	hash := strings.Repeat("a", 64)
+	for _, c := range []struct {
+		name     string
+		identity FollowerIdentity
+	}{
+		{"null byte in org", FollowerIdentity{OrgID: "org\x00main", FleetID: "prod", InstanceID: "pl-prod-1", Environment: "prod"}},
+		{"slash in instance", FollowerIdentity{OrgID: "org-main", FleetID: "prod", InstanceID: "pl/prod-1", Environment: "prod"}},
+		{"empty environment", FollowerIdentity{OrgID: "org-main", FleetID: "prod", InstanceID: "pl-prod-1"}},
+		{"leading dash on fleet", FollowerIdentity{OrgID: "org-main", FleetID: "-prod", InstanceID: "pl-prod-1", Environment: "prod"}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			err := spool.IngestAuditBatch(context.Background(), AcceptedAuditBatch{
+				Identity:     c.identity,
+				EnvelopeHash: hash,
+				Payload:      []byte("{}"),
+				ReceivedAt:   testNow,
+			})
+			if !errors.Is(err, ErrFollowerRequired) {
+				t.Fatalf("IngestAuditBatch(%s) error = %v, want ErrFollowerRequired", c.name, err)
+			}
+		})
+	}
+}
+
+// TestFileAuditSpoolFileMode asserts spool files land at 0o600 since they
+// contain audit payloads that may include sensitive follower telemetry.
+func TestFileAuditSpoolFileMode(t *testing.T) {
+	spool, err := OpenFileAuditSpool(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileAuditSpool() error = %v", err)
+	}
+	hash := strings.Repeat("b", 64)
+	batch := AcceptedAuditBatch{
+		Identity: FollowerIdentity{
+			OrgID:       "org-main",
+			FleetID:     "prod",
+			InstanceID:  "pl-prod-1",
+			Environment: "prod",
+		},
+		EnvelopeHash: hash,
+		Payload:      []byte(`{"ok":true}`),
+		ReceivedAt:   testNow,
+	}
+	if err := spool.IngestAuditBatch(context.Background(), batch); err != nil {
+		t.Fatalf("IngestAuditBatch() error = %v", err)
+	}
+	info, err := os.Stat(filepath.Clean(filepath.Join(spool.dir, hash+".json"))) //nolint:gosec // Test reads from a temp dir plus fixed hash filename.
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("spool file mode = %v, want 0o600", info.Mode().Perm())
+	}
+}

--- a/internal/conductor/controlplane/auth.go
+++ b/internal/conductor/controlplane/auth.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package controlplane
+
+import (
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+)
+
+const followerURIScheme = "spiffe"
+
+type StaticAuditKey struct {
+	KeyID      string
+	Key        conductor.SignatureKey
+	OrgID      string
+	FleetID    string
+	InstanceID string
+}
+
+func MTLSFollowerIdentityResolver(trustDomain string) (FollowerIdentityResolver, error) {
+	trustDomain = strings.TrimSpace(trustDomain)
+	if trustDomain == "" {
+		return nil, fmt.Errorf("%w: trust_domain", ErrFollowerRequired)
+	}
+	return func(r *http.Request) (FollowerIdentity, error) {
+		if r == nil || r.TLS == nil || len(r.TLS.PeerCertificates) == 0 || len(r.TLS.VerifiedChains) == 0 {
+			return FollowerIdentity{}, ErrFollowerRequired
+		}
+		for _, uri := range r.TLS.PeerCertificates[0].URIs {
+			identity, err := ParseFollowerIdentityURI(uri, trustDomain)
+			if err == nil {
+				return identity, nil
+			}
+		}
+		return FollowerIdentity{}, ErrFollowerRequired
+	}, nil
+}
+
+// ParseFollowerIdentityURI extracts a [FollowerIdentity] from a SPIFFE SAN URI
+// of the form
+//
+//	spiffe://<trust-domain>/orgs/<org>/fleets/<fleet>/instances/<instance>/environments/<environment>
+//
+// Trust domain comparison is case-insensitive per the SPIFFE spec (RFC: trust
+// domains are restricted to lowercase ASCII), so a peer cert that ships with a
+// non-conforming uppercase host still matches a lowercase configured trust
+// domain. Path components are case-sensitive and validated as conductor
+// identifiers via [FollowerIdentity.Validate].
+func ParseFollowerIdentityURI(uri *url.URL, trustDomain string) (FollowerIdentity, error) {
+	if uri == nil || uri.Scheme != followerURIScheme || !strings.EqualFold(uri.Host, trustDomain) {
+		return FollowerIdentity{}, ErrFollowerRequired
+	}
+	parts := strings.Split(strings.Trim(uri.EscapedPath(), "/"), "/")
+	if len(parts) != 8 ||
+		parts[0] != "orgs" ||
+		parts[2] != "fleets" ||
+		parts[4] != "instances" ||
+		parts[6] != "environments" {
+		return FollowerIdentity{}, ErrFollowerRequired
+	}
+	values := make([]string, 4)
+	for i, idx := range []int{1, 3, 5, 7} {
+		value, err := url.PathUnescape(parts[idx])
+		if err != nil {
+			return FollowerIdentity{}, ErrFollowerRequired
+		}
+		values[i] = value
+	}
+	identity := FollowerIdentity{
+		OrgID:       values[0],
+		FleetID:     values[1],
+		InstanceID:  values[2],
+		Environment: values[3],
+	}
+	if err := identity.Validate(); err != nil {
+		return FollowerIdentity{}, err
+	}
+	return identity, nil
+}
+
+func BearerPublisherAuthorizer(rawCredential string) (PublisherAuthorizer, error) {
+	expectedCredential := strings.TrimSpace(rawCredential)
+	if expectedCredential == "" {
+		return nil, ErrPublisherForbidden
+	}
+	return func(r *http.Request) error {
+		if r == nil {
+			return ErrPublisherForbidden
+		}
+		raw := r.Header.Get("Authorization")
+		prefix, got, ok := strings.Cut(raw, " ")
+		if !ok || prefix != "Bearer" || subtle.ConstantTimeCompare([]byte(got), []byte(expectedCredential)) != 1 {
+			return ErrPublisherForbidden
+		}
+		return nil
+	}, nil
+}
+
+// StaticAuditKeyResolver builds an [AuditKeyResolver] from a fixed roster of
+// trusted audit keys. Each key MUST be scoped to at least an OrgID. A key with
+// an empty OrgID would let any enrolled follower across any org sign audit
+// batches authenticated by that key — the per-batch
+// validateAuditBatchForIdentity check rejects envelopes that claim a different
+// identity than the authenticated transport, but it cannot detect a resolver
+// that hands out cross-org signing material. FleetID and InstanceID remain
+// optional so operators can scope keys to org-wide, fleet-wide, or
+// instance-specific use.
+func StaticAuditKeyResolver(keys []StaticAuditKey) (AuditKeyResolver, error) {
+	if len(keys) == 0 {
+		return nil, ErrAuditKeyRequired
+	}
+	byID := make(map[string]StaticAuditKey, len(keys))
+	for _, key := range keys {
+		key.KeyID = strings.TrimSpace(key.KeyID)
+		if key.KeyID == "" {
+			return nil, fmt.Errorf("%w: key_id", ErrAuditKeyRequired)
+		}
+		if len(key.Key.PublicKey) == 0 {
+			return nil, fmt.Errorf("%w: public_key", ErrAuditKeyRequired)
+		}
+		if strings.TrimSpace(key.OrgID) == "" {
+			return nil, fmt.Errorf("%w: org_id required for key %q (cross-org audit keys are not permitted)", ErrAuditKeyRequired, key.KeyID)
+		}
+		if _, exists := byID[key.KeyID]; exists {
+			return nil, fmt.Errorf("%w: duplicate key_id %q", ErrAuditKeyRequired, key.KeyID)
+		}
+		byID[key.KeyID] = key
+	}
+	return func(identity FollowerIdentity, signerKeyID string) (conductor.SignatureKey, error) {
+		key, ok := byID[signerKeyID]
+		if !ok || !staticAuditKeyMatches(key, identity) {
+			return conductor.SignatureKey{}, conductor.ErrSignatureVerification
+		}
+		return key.Key, nil
+	}, nil
+}
+
+func staticAuditKeyMatches(key StaticAuditKey, identity FollowerIdentity) bool {
+	switch {
+	case key.OrgID != "" && key.OrgID != identity.OrgID:
+		return false
+	case key.FleetID != "" && key.FleetID != identity.FleetID:
+		return false
+	case key.InstanceID != "" && key.InstanceID != identity.InstanceID:
+		return false
+	default:
+		return true
+	}
+}
+
+func IsAuthConfigError(err error) bool {
+	return errors.Is(err, ErrFollowerRequired) ||
+		errors.Is(err, ErrPublisherForbidden) ||
+		errors.Is(err, ErrAuditKeyRequired)
+}

--- a/internal/conductor/controlplane/auth.go
+++ b/internal/conductor/controlplane/auth.go
@@ -4,6 +4,7 @@
 package controlplane
 
 import (
+	"crypto/ed25519"
 	"crypto/subtle"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 const followerURIScheme = "spiffe"
@@ -96,7 +98,7 @@ func BearerPublisherAuthorizer(rawCredential string) (PublisherAuthorizer, error
 		}
 		raw := r.Header.Get("Authorization")
 		prefix, got, ok := strings.Cut(raw, " ")
-		if !ok || prefix != "Bearer" || subtle.ConstantTimeCompare([]byte(got), []byte(expectedCredential)) != 1 {
+		if !ok || !strings.EqualFold(prefix, "Bearer") || subtle.ConstantTimeCompare([]byte(got), []byte(expectedCredential)) != 1 {
 			return ErrPublisherForbidden
 		}
 		return nil
@@ -119,14 +121,30 @@ func StaticAuditKeyResolver(keys []StaticAuditKey) (AuditKeyResolver, error) {
 	byID := make(map[string]StaticAuditKey, len(keys))
 	for _, key := range keys {
 		key.KeyID = strings.TrimSpace(key.KeyID)
-		if key.KeyID == "" {
-			return nil, fmt.Errorf("%w: key_id", ErrAuditKeyRequired)
+		if err := conductor.ValidateIdentifier("key_id", key.KeyID); err != nil {
+			return nil, fmt.Errorf("%w: key_id %q", ErrAuditKeyRequired, key.KeyID)
 		}
-		if len(key.Key.PublicKey) == 0 {
-			return nil, fmt.Errorf("%w: public_key", ErrAuditKeyRequired)
+		if len(key.Key.PublicKey) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("%w: public_key for key %q", ErrAuditKeyRequired, key.KeyID)
+		}
+		if key.Key.KeyPurpose != signing.PurposeAuditBatchSigning {
+			return nil, fmt.Errorf("%w: key_purpose for key %q", ErrAuditKeyRequired, key.KeyID)
 		}
 		if strings.TrimSpace(key.OrgID) == "" {
 			return nil, fmt.Errorf("%w: org_id required for key %q (cross-org audit keys are not permitted)", ErrAuditKeyRequired, key.KeyID)
+		}
+		if err := conductor.ValidateIdentifier("org_id", key.OrgID); err != nil {
+			return nil, fmt.Errorf("%w: org_id for key %q", ErrAuditKeyRequired, key.KeyID)
+		}
+		if key.FleetID != "" {
+			if err := conductor.ValidateIdentifier("fleet_id", key.FleetID); err != nil {
+				return nil, fmt.Errorf("%w: fleet_id for key %q", ErrAuditKeyRequired, key.KeyID)
+			}
+		}
+		if key.InstanceID != "" {
+			if err := conductor.ValidateIdentifier("instance_id", key.InstanceID); err != nil {
+				return nil, fmt.Errorf("%w: instance_id for key %q", ErrAuditKeyRequired, key.KeyID)
+			}
 		}
 		if _, exists := byID[key.KeyID]; exists {
 			return nil, fmt.Errorf("%w: duplicate key_id %q", ErrAuditKeyRequired, key.KeyID)

--- a/internal/conductor/controlplane/auth_test.go
+++ b/internal/conductor/controlplane/auth_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package controlplane
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestParseFollowerIdentityURI(t *testing.T) {
+	uri, err := url.Parse("spiffe://pipelock.test/orgs/org-main/fleets/prod/instances/pl-prod-1/environments/prod")
+	if err != nil {
+		t.Fatalf("Parse URL: %v", err)
+	}
+	identity, err := ParseFollowerIdentityURI(uri, "pipelock.test")
+	if err != nil {
+		t.Fatalf("ParseFollowerIdentityURI() error = %v", err)
+	}
+	if identity.OrgID != "org-main" || identity.FleetID != "prod" || identity.InstanceID != "pl-prod-1" || identity.Environment != "prod" {
+		t.Fatalf("identity = %+v", identity)
+	}
+
+	// SPIFFE trust domains are restricted to lowercase ASCII per spec; a peer
+	// cert with a non-conforming uppercase host should still match a lowercase
+	// configured trust domain so operators can interop with non-conforming
+	// issuers without weakening the path-segment match.
+	upper, err := url.Parse("spiffe://Pipelock.test/orgs/org-main/fleets/prod/instances/pl-prod-1/environments/prod")
+	if err != nil {
+		t.Fatalf("Parse upper URL: %v", err)
+	}
+	if _, err := ParseFollowerIdentityURI(upper, "pipelock.test"); err != nil {
+		t.Fatalf("ParseFollowerIdentityURI(mixed-case trust domain) error = %v, want nil", err)
+	}
+}
+
+func TestParseFollowerIdentityURIRejectsMalformed(t *testing.T) {
+	rejections := []struct {
+		name string
+		raw  string
+	}{
+		{"wrong scheme", "https://pipelock.test/orgs/org-main/fleets/prod/instances/pl-prod-1/environments/prod"},
+		{"wrong trust domain", "spiffe://other.test/orgs/org-main/fleets/prod/instances/pl-prod-1/environments/prod"},
+		{"short path", "spiffe://pipelock.test/orgs/org-main"},
+		{"swapped segments", "spiffe://pipelock.test/orgs/org-main/instances/pl-prod-1/fleets/prod/environments/prod"},
+		{"embedded null byte", "spiffe://pipelock.test/orgs/org-main%00x/fleets/prod/instances/pl-prod-1/environments/prod"},
+		{"embedded slash", "spiffe://pipelock.test/orgs/org%2Fmain/fleets/prod/instances/pl-prod-1/environments/prod"},
+		{"empty segment", "spiffe://pipelock.test/orgs//fleets/prod/instances/pl-prod-1/environments/prod"},
+		{"leading dash", "spiffe://pipelock.test/orgs/-org/fleets/prod/instances/pl-prod-1/environments/prod"},
+	}
+	for _, c := range rejections {
+		t.Run(c.name, func(t *testing.T) {
+			uri, err := url.Parse(c.raw)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", c.raw, err)
+			}
+			if _, err := ParseFollowerIdentityURI(uri, "pipelock.test"); !errors.Is(err, ErrFollowerRequired) {
+				t.Fatalf("ParseFollowerIdentityURI(%q) error = %v, want ErrFollowerRequired", c.raw, err)
+			}
+		})
+	}
+}
+
+func TestMTLSFollowerIdentityResolverRequiresVerifiedClientCertificate(t *testing.T) {
+	resolver, err := MTLSFollowerIdentityResolver("pipelock.test")
+	if err != nil {
+		t.Fatalf("MTLSFollowerIdentityResolver() error = %v", err)
+	}
+	if _, err := resolver(httptestRequestWithTLS(nil)); !errors.Is(err, ErrFollowerRequired) {
+		t.Fatalf("resolver(no TLS) error = %v, want ErrFollowerRequired", err)
+	}
+
+	uri, err := url.Parse("spiffe://pipelock.test/orgs/org-main/fleets/prod/instances/pl-prod-1/environments/prod")
+	if err != nil {
+		t.Fatalf("Parse URL: %v", err)
+	}
+	req := httptestRequestWithTLS(&tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{{URIs: []*url.URL{uri}}},
+		VerifiedChains:   [][]*x509.Certificate{{&x509.Certificate{}}},
+	})
+	identity, err := resolver(req)
+	if err != nil {
+		t.Fatalf("resolver(valid TLS) error = %v", err)
+	}
+	if identity.InstanceID != "pl-prod-1" {
+		t.Fatalf("identity = %+v", identity)
+	}
+}
+
+func TestBearerPublisherAuthorizer(t *testing.T) {
+	if _, err := BearerPublisherAuthorizer(""); !errors.Is(err, ErrPublisherForbidden) {
+		t.Fatalf("BearerPublisherAuthorizer(empty) error = %v, want ErrPublisherForbidden", err)
+	}
+	authz, err := BearerPublisherAuthorizer("secret-token")
+	if err != nil {
+		t.Fatalf("BearerPublisherAuthorizer() error = %v", err)
+	}
+	cases := []struct {
+		name      string
+		header    string
+		setHeader bool
+		wantErr   bool
+	}{
+		{name: "no header", wantErr: true},
+		{name: "wrong scheme", setHeader: true, header: "Basic secret-token", wantErr: true},
+		{name: "wrong token", setHeader: true, header: "Bearer wrong", wantErr: true},
+		{name: "lowercase scheme", setHeader: true, header: "bearer secret-token", wantErr: true},
+		{name: "empty token", setHeader: true, header: "Bearer ", wantErr: true},
+		{name: "valid", setHeader: true, header: "Bearer secret-token"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, PublishPolicyBundlePath, nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			if c.setHeader {
+				req.Header.Set("Authorization", c.header)
+			}
+			err = authz(req)
+			if c.wantErr && !errors.Is(err, ErrPublisherForbidden) {
+				t.Fatalf("authz() error = %v, want ErrPublisherForbidden", err)
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("authz() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestStaticAuditKeyResolverHonorsIdentityBinding(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	resolver, err := StaticAuditKeyResolver([]StaticAuditKey{{
+		KeyID: "audit-key-1",
+		Key: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		OrgID: "org-main",
+	}})
+	if err != nil {
+		t.Fatalf("StaticAuditKeyResolver() error = %v", err)
+	}
+	key, err := resolver(FollowerIdentity{OrgID: "org-main"}, "audit-key-1")
+	if err != nil {
+		t.Fatalf("resolver(valid) error = %v", err)
+	}
+	if len(key.PublicKey) == 0 {
+		t.Fatal("resolver returned empty public key")
+	}
+	if _, err := resolver(FollowerIdentity{OrgID: "other"}, "audit-key-1"); !errors.Is(err, conductor.ErrSignatureVerification) {
+		t.Fatalf("resolver(wrong org) error = %v, want ErrSignatureVerification", err)
+	}
+	if _, err := resolver(FollowerIdentity{OrgID: "org-main"}, "unknown-key"); !errors.Is(err, conductor.ErrSignatureVerification) {
+		t.Fatalf("resolver(unknown keyID) error = %v, want ErrSignatureVerification", err)
+	}
+}
+
+func TestStaticAuditKeyResolverRejectsCrossOrgKey(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	key := conductor.SignatureKey{PublicKey: pub, KeyPurpose: signing.PurposeAuditBatchSigning}
+	cases := []struct {
+		name    string
+		keys    []StaticAuditKey
+		wantSub string
+	}{
+		{
+			name:    "empty org id",
+			keys:    []StaticAuditKey{{KeyID: "k1", Key: key}},
+			wantSub: "org_id required",
+		},
+		{
+			name:    "whitespace org id",
+			keys:    []StaticAuditKey{{KeyID: "k1", Key: key, OrgID: "   "}},
+			wantSub: "org_id required",
+		},
+		{
+			name:    "missing key id",
+			keys:    []StaticAuditKey{{Key: key, OrgID: "org-main"}},
+			wantSub: "key_id",
+		},
+		{
+			name:    "missing public key",
+			keys:    []StaticAuditKey{{KeyID: "k1", OrgID: "org-main"}},
+			wantSub: "public_key",
+		},
+		{
+			name: "duplicate key id",
+			keys: []StaticAuditKey{
+				{KeyID: "dup", Key: key, OrgID: "org-main"},
+				{KeyID: "dup", Key: key, OrgID: "org-main"},
+			},
+			wantSub: "duplicate key_id",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := StaticAuditKeyResolver(c.keys)
+			if !errors.Is(err, ErrAuditKeyRequired) {
+				t.Fatalf("StaticAuditKeyResolver() error = %v, want ErrAuditKeyRequired", err)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Fatalf("StaticAuditKeyResolver() error = %v, want substring %q", err, c.wantSub)
+			}
+		})
+	}
+}
+
+func httptestRequestWithTLS(state *tls.ConnectionState) *http.Request {
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, LatestPolicyBundlePath, nil)
+	if state != nil {
+		req.TLS = state
+	}
+	return req
+}

--- a/internal/conductor/controlplane/auth_test.go
+++ b/internal/conductor/controlplane/auth_test.go
@@ -114,7 +114,7 @@ func TestBearerPublisherAuthorizer(t *testing.T) {
 		{name: "no header", wantErr: true},
 		{name: "wrong scheme", setHeader: true, header: "Basic secret-token", wantErr: true},
 		{name: "wrong token", setHeader: true, header: "Bearer wrong", wantErr: true},
-		{name: "lowercase scheme", setHeader: true, header: "bearer secret-token", wantErr: true},
+		{name: "lowercase scheme", setHeader: true, header: "bearer secret-token"},
 		{name: "empty token", setHeader: true, header: "Bearer ", wantErr: true},
 		{name: "valid", setHeader: true, header: "Bearer secret-token"},
 	}
@@ -199,6 +199,36 @@ func TestStaticAuditKeyResolverRejectsCrossOrgKey(t *testing.T) {
 			name:    "missing public key",
 			keys:    []StaticAuditKey{{KeyID: "k1", OrgID: "org-main"}},
 			wantSub: "public_key",
+		},
+		{
+			name:    "short public key",
+			keys:    []StaticAuditKey{{KeyID: "k1", Key: conductor.SignatureKey{PublicKey: ed25519.PublicKey("short"), KeyPurpose: signing.PurposeAuditBatchSigning}, OrgID: "org-main"}},
+			wantSub: "public_key",
+		},
+		{
+			name:    "wrong purpose",
+			keys:    []StaticAuditKey{{KeyID: "k1", Key: conductor.SignatureKey{PublicKey: pub, KeyPurpose: signing.PurposePolicyBundleSigning}, OrgID: "org-main"}},
+			wantSub: "key_purpose",
+		},
+		{
+			name:    "invalid key id",
+			keys:    []StaticAuditKey{{KeyID: "-k1", Key: key, OrgID: "org-main"}},
+			wantSub: "key_id",
+		},
+		{
+			name:    "invalid org id",
+			keys:    []StaticAuditKey{{KeyID: "k1", Key: key, OrgID: "-org"}},
+			wantSub: "org_id",
+		},
+		{
+			name:    "invalid fleet id",
+			keys:    []StaticAuditKey{{KeyID: "k1", Key: key, OrgID: "org-main", FleetID: "fleet/prod"}},
+			wantSub: "fleet_id",
+		},
+		{
+			name:    "invalid instance id",
+			keys:    []StaticAuditKey{{KeyID: "k1", Key: key, OrgID: "org-main", InstanceID: "pl prod"}},
+			wantSub: "instance_id",
 		},
 		{
 			name: "duplicate key id",

--- a/internal/conductor/controlplane/store.go
+++ b/internal/conductor/controlplane/store.go
@@ -206,19 +206,32 @@ func (s *FileBundleStore) Latest(_ context.Context, follower FollowerIdentity, n
 	return best, nil
 }
 
+// Validate rejects identities whose components are empty OR contain anything
+// the canonical conductor identifier validator rejects: bytes outside
+// [a-zA-Z0-9_.-], leading '_'/'-'/'.', or anything longer than
+// [conductor.MaxIDBytes]. The SPIFFE URI parser unescapes SAN path components
+// with [url.PathUnescape], so without this check a SAN of
+// 'spiffe://td/orgs/a%00b/fleets/.../...' would deliver an OrgID containing a
+// null byte and bypass the '\x00'-separator invariant in streamKey.
+//
+// Identity errors map to HTTP 401 via writeStoreError. Wrapping the inner
+// detail with [ErrFollowerRequired] preserves that mapping; the inner
+// [conductor.ErrInvalidIdentifier] is kept in the chain for diagnostics but
+// is not surfaced to clients.
 func (f FollowerIdentity) Validate() error {
-	switch {
-	case strings.TrimSpace(f.OrgID) == "":
-		return fmt.Errorf("%w: org_id", ErrFollowerRequired)
-	case strings.TrimSpace(f.FleetID) == "":
-		return fmt.Errorf("%w: fleet_id", ErrFollowerRequired)
-	case strings.TrimSpace(f.InstanceID) == "":
-		return fmt.Errorf("%w: instance_id", ErrFollowerRequired)
-	case strings.TrimSpace(f.Environment) == "":
-		return fmt.Errorf("%w: environment", ErrFollowerRequired)
-	default:
-		return nil
+	for _, c := range []struct {
+		field, value string
+	}{
+		{"org_id", f.OrgID},
+		{"fleet_id", f.FleetID},
+		{"instance_id", f.InstanceID},
+		{"environment", f.Environment},
+	} {
+		if err := conductor.ValidateIdentifier(c.field, c.value); err != nil {
+			return fmt.Errorf("%w: %s", ErrFollowerRequired, c.field)
+		}
 	}
+	return nil
 }
 
 func (s *FileBundleStore) load() error {

--- a/internal/conductor/messages.go
+++ b/internal/conductor/messages.go
@@ -1129,6 +1129,16 @@ func requireNonEmpty(field, value string) error {
 	return nil
 }
 
+// ValidateIdentifier is the canonical conductor identifier check. Use it from
+// any package that receives operator- or transport-supplied identifiers
+// (org_id, fleet_id, instance_id, environment, bundle_id, ...). Diverging
+// identifier semantics between conductor base and conductor/controlplane risks
+// stream-key collisions when SPIFFE SANs unescape to bytes that the base layer
+// would reject (null bytes, slashes, control characters).
+func ValidateIdentifier(field, value string) error {
+	return validateIdentifier(field, value)
+}
+
 func validateIdentifier(field, value string) error {
 	if strings.TrimSpace(value) == "" {
 		return fmt.Errorf("%w: %s", ErrMissingField, field)

--- a/internal/conductor/messages_test.go
+++ b/internal/conductor/messages_test.go
@@ -714,6 +714,15 @@ func TestIsIdentifierRejectsEmpty(t *testing.T) {
 	}
 }
 
+func TestValidateIdentifierExport(t *testing.T) {
+	if err := ValidateIdentifier("org_id", "org-main"); err != nil {
+		t.Fatalf("ValidateIdentifier(valid) error = %v", err)
+	}
+	if err := ValidateIdentifier("org_id", "-org"); !errors.Is(err, ErrInvalidIdentifier) {
+		t.Fatalf("ValidateIdentifier(invalid) error = %v, want ErrInvalidIdentifier", err)
+	}
+}
+
 func TestRemoteKillMessage_RejectsSamePublicKeyAcrossSignerIDs(t *testing.T) {
 	// A roster that maps two distinct IDs to the same public key would
 	// otherwise satisfy threshold with one underlying signer. This is the


### PR DESCRIPTION
## Summary
- add `pipelock conductor serve` for the Conductor policy and audit ingest endpoints
- wire TLS 1.3/mTLS follower identity, bearer publisher auth, static audit keys, file bundle storage, and durable audit storage
- harden SPIFFE follower identity parsing and audit key scoping at the server boundary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New `conductor serve` command to run the control-plane HTTPS server with configurable address, storage location, publisher token auth, and trusted audit keys.
  * Durable file-backed audit spool to persist accepted audit batches.
  * Enforced mTLS client-certificate verification (TLS 1.3) and Bearer-token publisher auth.
  * Audit keys can be scoped by org/fleet/instance.

* **Documentation**
  * Conductor audit sink spec updated with runtime wiring, TLS/auth requirements, identity validation rules, and spool behavior.

* **Tests**
  * Added unit tests covering CLI, auth, spool, and identifier validation behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->