### PR TITLE
Conductor: add audit batch summary query

### DIFF
--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -246,9 +246,12 @@ that authenticate against that key. Optional `fleet=`/`instance=` narrow the
 scope further. Accepted audit batches are written to a local SQLite raw-evidence
 store with idempotency on `(org, fleet, instance, batch_id)` and fork rejection
 on overlapping sequence ranges with divergent payload or segment-tail hashes.
-The storage directory is sensitive operator-controlled state; HTTP query/export
-endpoints, retention policy, redacted indexing, and analytics remain later
-slices.
+The storage directory is sensitive operator-controlled state. The MVP exposes
+`GET /api/v1/conductor/audit/batches` as an operator/admin metadata query
+endpoint; it requires audit-query authorization and at least `org_id`, returns
+metadata-only batch summaries, and does not export raw payload bytes. Raw
+export endpoints, retention policy, redacted indexing, and analytics remain
+later slices.
 
 ### Bundle Envelope
 

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -471,6 +471,7 @@ MVP server endpoint:
 
 ```http
 POST /api/v1/conductor/audit/batches
+GET /api/v1/conductor/audit/batches?org_id=...
 ```
 
 The server derives follower identity from the authenticated transport, validates
@@ -480,6 +481,10 @@ then hands the accepted batch to the configured audit sink. The current runtime
 sink is a local SQLite raw-evidence store; redacted storage/search indexing,
 DLP-before-indexing, fork response workflow, and dashboard views are later
 slices.
+
+`GET /api/v1/conductor/audit/batches` is an operator/admin API endpoint. It
+requires audit-query authorization, requires at least `org_id`, and returns
+metadata-only batch summaries. It does not export raw payload bytes.
 
 ## Audit Batch Schema
 

--- a/internal/conductor/controlplane/audit_ingest.go
+++ b/internal/conductor/controlplane/audit_ingest.go
@@ -67,8 +67,13 @@ type ingestAuditBatchResponse struct {
 }
 
 func (h *Handler) handleAuditBatch(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeMethodNotAllowed(w, http.MethodPost)
+	switch r.Method {
+	case http.MethodGet:
+		h.handleListAuditBatches(w, r)
+		return
+	case http.MethodPost:
+	default:
+		writeMethodNotAllowed(w, http.MethodGet, http.MethodPost)
 		return
 	}
 	identity, err := h.followerIdentity(r)

--- a/internal/conductor/controlplane/audit_ingest_test.go
+++ b/internal/conductor/controlplane/audit_ingest_test.go
@@ -121,9 +121,9 @@ func TestHandlerAuditBatchStrictJSONAndMethod(t *testing.T) {
 	handler := newAuditIngestTestHandler(t, &captureAuditSink{}, auditKeyResolverFor(pub), 64)
 
 	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, AuditBatchesPath, nil))
-	if w.Code != http.StatusMethodNotAllowed || w.Header().Get("Allow") != http.MethodPost {
-		t.Fatalf("wrong method status=%d allow=%q, want 405 POST", w.Code, w.Header().Get("Allow"))
+	handler.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodDelete, AuditBatchesPath, nil))
+	if w.Code != http.StatusMethodNotAllowed || w.Header().Get("Allow") != "GET, POST" {
+		t.Fatalf("wrong method status=%d allow=%q, want 405 GET, POST", w.Code, w.Header().Get("Allow"))
 	}
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, AuditBatchesPath, strings.NewReader(`{"envelope":{},"payload":"","extra":true}`))

--- a/internal/conductor/controlplane/audit_query.go
+++ b/internal/conductor/controlplane/audit_query.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+)
+
+// AuditBatchQuerier exposes metadata-only audit batch queries. Implementations
+// MUST NOT return raw payload bytes through this interface; raw evidence stays
+// behind the storage backend's operator-controlled access boundary.
+type AuditBatchQuerier interface {
+	ListAuditBatches(ctx context.Context, q AuditBatchQuery) ([]AuditBatchSummary, error)
+}
+
+type listAuditBatchesResponse struct {
+	Batches []AuditBatchSummary `json:"batches"`
+	Count   int                 `json:"count"`
+}
+
+// handleListAuditBatches serves operator/admin audit-metadata reads.
+func (h *Handler) handleListAuditBatches(w http.ResponseWriter, r *http.Request) {
+	if err := h.authorizeAuditQuery(r); err != nil {
+		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
+		return
+	}
+	if h.auditQuerier == nil {
+		writeError(w, http.StatusNotImplemented, errors.New("audit query not supported by configured audit sink"))
+		return
+	}
+	query, err := parseAuditBatchQuery(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	batches, err := h.auditQuerier.ListAuditBatches(r.Context(), query)
+	if err != nil {
+		writeAuditSinkError(w, err)
+		return
+	}
+	if batches == nil {
+		batches = []AuditBatchSummary{}
+	}
+	writeJSON(w, http.StatusOK, listAuditBatchesResponse{
+		Batches: batches,
+		Count:   len(batches),
+	})
+}
+
+func parseAuditBatchQuery(r *http.Request) (AuditBatchQuery, error) {
+	values := r.URL.Query()
+	for key, got := range values {
+		switch key {
+		case "org_id", "fleet_id", "instance_id", "batch_id", "limit":
+		default:
+			return AuditBatchQuery{}, fmt.Errorf("unknown query parameter: %s", key)
+		}
+		if len(got) > 1 {
+			return AuditBatchQuery{}, fmt.Errorf("duplicate query parameter: %s", key)
+		}
+	}
+	q := AuditBatchQuery{
+		OrgID:      values.Get("org_id"),
+		FleetID:    values.Get("fleet_id"),
+		InstanceID: values.Get("instance_id"),
+		BatchID:    values.Get("batch_id"),
+	}
+	if q.OrgID == "" {
+		return AuditBatchQuery{}, errors.New("org_id query parameter required")
+	}
+	for _, c := range []struct {
+		field, value string
+	}{
+		{"org_id", q.OrgID},
+		{"fleet_id", q.FleetID},
+		{"instance_id", q.InstanceID},
+		{"batch_id", q.BatchID},
+	} {
+		if c.value == "" {
+			continue
+		}
+		if err := conductor.ValidateIdentifier(c.field, c.value); err != nil {
+			return AuditBatchQuery{}, err
+		}
+	}
+	if rawLimit := values.Get("limit"); rawLimit != "" {
+		limit, err := strconv.Atoi(rawLimit)
+		if err != nil || limit <= 0 {
+			return AuditBatchQuery{}, fmt.Errorf("invalid limit query parameter: %q", rawLimit)
+		}
+		q.Limit = limit
+	}
+	return q, nil
+}

--- a/internal/conductor/controlplane/audit_query.go
+++ b/internal/conductor/controlplane/audit_query.go
@@ -28,7 +28,7 @@ type listAuditBatchesResponse struct {
 // handleListAuditBatches serves operator/admin audit-metadata reads.
 func (h *Handler) handleListAuditBatches(w http.ResponseWriter, r *http.Request) {
 	if err := h.authorizeAuditQuery(r); err != nil {
-		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
+		writeError(w, http.StatusForbidden, ErrAuditQueryForbidden)
 		return
 	}
 	if h.auditQuerier == nil {

--- a/internal/conductor/controlplane/audit_store_test.go
+++ b/internal/conductor/controlplane/audit_store_test.go
@@ -9,7 +9,10 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -276,6 +279,134 @@ func TestAuditIngestSurfacesSinkErrorsAsHTTP(t *testing.T) {
 	}
 }
 
+func TestHandlerListsAuditBatchSummaries(t *testing.T) {
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	defer func() { _ = store.Close() }()
+
+	identity := defaultFollowerIdentity()
+	first := signedAcceptedAuditBatch(t, identity, testAuditBatchID, 10, 10, []byte(testAuditPayload), testNow)
+	second := signedAcceptedAuditBatch(t, identity, "audit-batch-2", 11, 11, []byte(testAuditPayload2), testNow.Add(time.Second))
+	if err := store.IngestAuditBatch(context.Background(), first); err != nil {
+		t.Fatalf("IngestAuditBatch(first) error = %v", err)
+	}
+	if err := store.IngestAuditBatch(context.Background(), second); err != nil {
+		t.Fatalf("IngestAuditBatch(second) error = %v", err)
+	}
+	handler := newAuditQueryTestHandler(t, store)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, AuditBatchesPath+"?org_id=org-main&fleet_id=prod&limit=1", nil)
+	req.Header.Set("X-Pipelock-Auditor", "ok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "payload_blob") || strings.Contains(w.Body.String(), testAuditPayload) {
+		t.Fatalf("list response leaked raw payload data: %s", w.Body.String())
+	}
+	var got listAuditBatchesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if got.Count != 1 || len(got.Batches) != 1 {
+		t.Fatalf("list count=%d len=%d, want 1", got.Count, len(got.Batches))
+	}
+	if got.Batches[0].BatchID != "audit-batch-2" || got.Batches[0].OrgID != identity.OrgID {
+		t.Fatalf("list batch = %+v", got.Batches[0])
+	}
+}
+
+// TestHandlerListsEmptyResultAsEmptyArray defends against future regressions
+// where ListAuditBatches returns nil instead of an empty slice. Clients
+// (operator UIs, CLI) parse the JSON `batches` field as an array; a `null`
+// value crashes naive consumers. Pin the contract here.
+func TestHandlerListsEmptyResultAsEmptyArray(t *testing.T) {
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	defer func() { _ = store.Close() }()
+	handler := newAuditQueryTestHandler(t, store)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, AuditBatchesPath+"?org_id=org-empty", nil)
+	req.Header.Set("X-Pipelock-Auditor", "ok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("empty list status = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), `"batches":null`) {
+		t.Fatalf("empty list emitted batches=null instead of []: %s", w.Body.String())
+	}
+	var got listAuditBatchesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode empty list: %v", err)
+	}
+	if got.Count != 0 || len(got.Batches) != 0 {
+		t.Fatalf("empty list = %+v, want count=0", got)
+	}
+}
+
+// TestHandlerListReturns501WhenSinkLacksQuerier locks the contract that a
+// sink which only implements ingest and not query surfaces a permanent 501
+// rather than a transient-looking 500. Operators learn it's a config gap,
+// not a server-side fault to retry.
+func TestHandlerListReturns501WhenSinkLacksQuerier(t *testing.T) {
+	handler, err := NewHandler(HandlerOptions{
+		Store:        mustStore(t),
+		Capabilities: DefaultCapabilities("conductor-test"),
+		Now:          func() time.Time { return testNow },
+		FollowerIdentity: func(*http.Request) (FollowerIdentity, error) {
+			return defaultFollowerIdentity(), nil
+		},
+		AuthorizePublisher: func(*http.Request) error { return nil },
+		AuditSink:          discardAuditSink{},
+		AuditKeys:          rejectingAuditKeyResolver,
+	})
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, AuditBatchesPath+"?org_id=org-main", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d body=%s, want 501", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "audit query not supported") {
+		t.Fatalf("501 body missing capability message: %s", w.Body.String())
+	}
+}
+
+func TestHandlerListAuditBatchQueryValidation(t *testing.T) {
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	defer func() { _ = store.Close() }()
+	handler := newAuditQueryTestHandler(t, store)
+
+	cases := []struct {
+		name       string
+		target     string
+		auditor    string
+		wantStatus int
+	}{
+		{name: "auditor required", target: AuditBatchesPath + "?org_id=org-main", wantStatus: http.StatusForbidden},
+		{name: "org required", target: AuditBatchesPath, auditor: "ok", wantStatus: http.StatusBadRequest},
+		{name: "invalid org", target: AuditBatchesPath + "?org_id=-org", auditor: "ok", wantStatus: http.StatusBadRequest},
+		{name: "invalid limit", target: AuditBatchesPath + "?org_id=org-main&limit=0", auditor: "ok", wantStatus: http.StatusBadRequest},
+		{name: "duplicate org", target: AuditBatchesPath + "?org_id=org-main&org_id=other", auditor: "ok", wantStatus: http.StatusBadRequest},
+		{name: "unknown parameter", target: AuditBatchesPath + "?org_id=org-main&payload=true", auditor: "ok", wantStatus: http.StatusBadRequest},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, c.target, nil)
+			if c.auditor != "" {
+				req.Header.Set("X-Pipelock-Auditor", c.auditor)
+			}
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code != c.wantStatus {
+				t.Fatalf("status = %d body=%s, want %d", w.Code, w.Body.String(), c.wantStatus)
+			}
+		})
+	}
+}
+
 func openTestSQLiteAuditStore(t *testing.T, path string) *SQLiteAuditStore {
 	t.Helper()
 	store, err := OpenSQLiteAuditStore(context.Background(), path)
@@ -283,6 +414,33 @@ func openTestSQLiteAuditStore(t *testing.T, path string) *SQLiteAuditStore {
 		t.Fatalf("OpenSQLiteAuditStore() error = %v", err)
 	}
 	return store
+}
+
+func newAuditQueryTestHandler(t *testing.T, auditStore *SQLiteAuditStore) *Handler {
+	t.Helper()
+	handler, err := NewHandler(HandlerOptions{
+		Store:        mustStore(t),
+		Capabilities: DefaultCapabilities("conductor-test"),
+		Now:          func() time.Time { return testNow },
+		FollowerIdentity: func(*http.Request) (FollowerIdentity, error) {
+			return defaultFollowerIdentity(), nil
+		},
+		AuthorizePublisher: func(*http.Request) error {
+			return errors.New("publisher authorizer must not authorize audit query")
+		},
+		AuthorizeAuditQuery: func(r *http.Request) error {
+			if r.Header.Get("X-Pipelock-Auditor") == "ok" {
+				return nil
+			}
+			return ErrPublisherForbidden
+		},
+		AuditSink: auditStore,
+		AuditKeys: rejectingAuditKeyResolver,
+	})
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+	return handler
 }
 
 func signedAcceptedAuditBatch(

--- a/internal/conductor/controlplane/audit_store_test.go
+++ b/internal/conductor/controlplane/audit_store_test.go
@@ -384,8 +384,9 @@ func TestHandlerListAuditBatchQueryValidation(t *testing.T) {
 		target     string
 		auditor    string
 		wantStatus int
+		wantBody   string
 	}{
-		{name: "auditor required", target: AuditBatchesPath + "?org_id=org-main", wantStatus: http.StatusForbidden},
+		{name: "auditor required", target: AuditBatchesPath + "?org_id=org-main", wantStatus: http.StatusForbidden, wantBody: ErrAuditQueryForbidden.Error()},
 		{name: "org required", target: AuditBatchesPath, auditor: "ok", wantStatus: http.StatusBadRequest},
 		{name: "invalid org", target: AuditBatchesPath + "?org_id=-org", auditor: "ok", wantStatus: http.StatusBadRequest},
 		{name: "invalid limit", target: AuditBatchesPath + "?org_id=org-main&limit=0", auditor: "ok", wantStatus: http.StatusBadRequest},
@@ -402,6 +403,9 @@ func TestHandlerListAuditBatchQueryValidation(t *testing.T) {
 			handler.ServeHTTP(w, req)
 			if w.Code != c.wantStatus {
 				t.Fatalf("status = %d body=%s, want %d", w.Code, w.Body.String(), c.wantStatus)
+			}
+			if c.wantBody != "" && !strings.Contains(w.Body.String(), c.wantBody) {
+				t.Fatalf("body = %s, want substring %q", w.Body.String(), c.wantBody)
 			}
 		})
 	}
@@ -432,7 +436,7 @@ func newAuditQueryTestHandler(t *testing.T, auditStore *SQLiteAuditStore) *Handl
 			if r.Header.Get("X-Pipelock-Auditor") == "ok" {
 				return nil
 			}
-			return ErrPublisherForbidden
+			return ErrAuditQueryForbidden
 		},
 		AuditSink: auditStore,
 		AuditKeys: rejectingAuditKeyResolver,

--- a/internal/conductor/controlplane/audit_store_test.go
+++ b/internal/conductor/controlplane/audit_store_test.go
@@ -411,6 +411,33 @@ func TestHandlerListAuditBatchQueryValidation(t *testing.T) {
 	}
 }
 
+func TestHandlerListAuditBatchSurfacesSinkError(t *testing.T) {
+	handler, err := NewHandler(HandlerOptions{
+		Store:        mustStore(t),
+		Capabilities: DefaultCapabilities("conductor-test"),
+		Now:          func() time.Time { return testNow },
+		FollowerIdentity: func(*http.Request) (FollowerIdentity, error) {
+			return defaultFollowerIdentity(), nil
+		},
+		AuthorizePublisher:  func(*http.Request) error { return nil },
+		AuthorizeAuditQuery: func(*http.Request) error { return nil },
+		AuditSink:           failingAuditQuerySink{err: ErrAuditBatchConflict},
+		AuditKeys:           rejectingAuditKeyResolver,
+	})
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, AuditBatchesPath+"?org_id=org-main", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d body=%s, want 409", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), ErrAuditBatchConflict.Error()) {
+		t.Fatalf("body = %s, want sink error", w.Body.String())
+	}
+}
+
 func openTestSQLiteAuditStore(t *testing.T, path string) *SQLiteAuditStore {
 	t.Helper()
 	store, err := OpenSQLiteAuditStore(context.Background(), path)
@@ -445,6 +472,18 @@ func newAuditQueryTestHandler(t *testing.T, auditStore *SQLiteAuditStore) *Handl
 		t.Fatalf("NewHandler() error = %v", err)
 	}
 	return handler
+}
+
+type failingAuditQuerySink struct {
+	err error
+}
+
+func (s failingAuditQuerySink) IngestAuditBatch(context.Context, AcceptedAuditBatch) error {
+	return nil
+}
+
+func (s failingAuditQuerySink) ListAuditBatches(context.Context, AuditBatchQuery) ([]AuditBatchSummary, error) {
+	return nil, s.err
 }
 
 func signedAcceptedAuditBatch(

--- a/internal/conductor/controlplane/auth.go
+++ b/internal/conductor/controlplane/auth.go
@@ -176,5 +176,6 @@ func staticAuditKeyMatches(key StaticAuditKey, identity FollowerIdentity) bool {
 func IsAuthConfigError(err error) bool {
 	return errors.Is(err, ErrFollowerRequired) ||
 		errors.Is(err, ErrPublisherForbidden) ||
+		errors.Is(err, ErrAuditQueryForbidden) ||
 		errors.Is(err, ErrAuditKeyRequired)
 }

--- a/internal/conductor/controlplane/handler.go
+++ b/internal/conductor/controlplane/handler.go
@@ -50,20 +50,25 @@ type HandlerOptions struct {
 	MaxAuditBodyBytes   int64
 	FollowerIdentity    FollowerIdentityResolver
 	AuthorizePublisher  PublisherAuthorizer
+	AuthorizeAuditQuery PublisherAuthorizer
 	AuditSink           AuditBatchSink
 	AuditKeys           AuditKeyResolver
 }
 
 type Handler struct {
-	store              BundleStore
-	capabilities       conductor.CapabilitiesResponse
-	now                func() time.Time
-	maxRequestBody     int64
-	maxAuditBody       int64
-	followerIdentity   FollowerIdentityResolver
-	authorizePublisher PublisherAuthorizer
-	auditSink          AuditBatchSink
-	auditKeys          AuditKeyResolver
+	store               BundleStore
+	capabilities        conductor.CapabilitiesResponse
+	now                 func() time.Time
+	maxRequestBody      int64
+	maxAuditBody        int64
+	followerIdentity    FollowerIdentityResolver
+	authorizePublisher  PublisherAuthorizer
+	authorizeAuditQuery PublisherAuthorizer
+	auditSink           AuditBatchSink
+	// nil auditQuerier means the configured sink does not implement
+	// [AuditBatchQuerier], so GET returns 501 rather than a retryable 500.
+	auditQuerier AuditBatchQuerier
+	auditKeys    AuditKeyResolver
 }
 
 type publishPolicyBundleRequest struct {
@@ -113,16 +118,23 @@ func NewHandler(opts HandlerOptions) (*Handler, error) {
 	if maxAuditBody <= 0 {
 		maxAuditBody = defaultMaxAuditBodyBytes
 	}
+	authorizeAuditQuery := opts.AuthorizeAuditQuery
+	if authorizeAuditQuery == nil {
+		authorizeAuditQuery = opts.AuthorizePublisher
+	}
+	auditQuerier, _ := opts.AuditSink.(AuditBatchQuerier)
 	return &Handler{
-		store:              opts.Store,
-		capabilities:       capabilities,
-		now:                now,
-		maxRequestBody:     maxBody,
-		maxAuditBody:       maxAuditBody,
-		followerIdentity:   opts.FollowerIdentity,
-		authorizePublisher: opts.AuthorizePublisher,
-		auditSink:          opts.AuditSink,
-		auditKeys:          opts.AuditKeys,
+		store:               opts.Store,
+		capabilities:        capabilities,
+		now:                 now,
+		maxRequestBody:      maxBody,
+		maxAuditBody:        maxAuditBody,
+		followerIdentity:    opts.FollowerIdentity,
+		authorizePublisher:  opts.AuthorizePublisher,
+		authorizeAuditQuery: authorizeAuditQuery,
+		auditSink:           opts.AuditSink,
+		auditQuerier:        auditQuerier,
+		auditKeys:           opts.AuditKeys,
 	}, nil
 }
 

--- a/internal/conductor/controlplane/store.go
+++ b/internal/conductor/controlplane/store.go
@@ -62,6 +62,7 @@ var (
 	ErrInvalidStoreRecord  = errors.New("conductor control plane store record invalid")
 	ErrFollowerRequired    = errors.New("conductor follower identity required")
 	ErrPublisherForbidden  = errors.New("conductor publisher authorization failed")
+	ErrAuditQueryForbidden = errors.New("conductor audit query authorization failed")
 	ErrAuditSinkRequired   = errors.New("conductor audit sink required")
 	ErrAuditKeyRequired    = errors.New("conductor audit key resolver required")
 	ErrAuditBatchConflict  = errors.New("conductor audit batch conflicts with accepted batch")


### PR DESCRIPTION
## Summary
- add an authorized metadata-only audit batch list endpoint
- require scoped query parameters and reject duplicate or unknown filters
- keep raw audit payload bytes out of the query response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GET endpoint to retrieve audit batch metadata summaries with filtering (org, identifiers) and optional limit
  * Introduced a separate authorization hook for audit-query operations

* **Bug Fixes**
  * Improved HTTP method handling to return 405 Method Not Allowed with correct Allow header for unsupported methods

* **Documentation**
  * Added design spec detailing the audit-query metadata endpoint and expected behaviors (no raw payload export)

* **Tests**
  * Added tests for listing behavior, empty-result serialization, capability responses, query validation, and error surfacing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->