### PR TITLE
Conductor: add operator probes and telemetry

### DIFF
--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -160,6 +160,30 @@ Conductor uses separate listeners:
 | Operator Admin API | bearer/session auth plus IP allowlist | human/admin control |
 | Public Artifact API | public or CDN-gated | public verification keys and transparency artifacts |
 
+The server MVP exposes operator endpoints on a separate plain-HTTP probe
+listener configured by `pipelock conductor serve --probe-listen`:
+
+- `GET /health` and `GET /healthz` return a minimal liveness response.
+- `GET /readyz` reports policy store, audit sink, audit query, and audit-key
+  resolver state. Policy store, audit sink, and audit-key resolver are required
+  for readiness; audit query support is reported as a feature-presence flag.
+- `GET /metrics` returns Prometheus metrics, including
+  `pipelock_conductor_server_requests_total`,
+  `pipelock_conductor_server_request_duration_seconds`,
+  `pipelock_conductor_server_audit_ingest_total`, and
+  `pipelock_conductor_server_audit_queries_total`.
+
+These endpoints do not run application-level publisher or follower
+authorization and are not served by the mTLS follower listener. Deployments
+should bind `--probe-listen` to an operator-only interface or protect it with a
+pod NetworkPolicy, firewall rule, or IP allowlist. Kubernetes deployments often
+need the default wildcard bind so kubelet can reach the pod; non-Kubernetes
+deployments should prefer `--probe-listen=127.0.0.1:9092` unless a remote
+scraper requires otherwise. Conductor request logs are structured JSON on stderr
+with bounded fields (`event`, `route`, `method`, `status`, `status_class`,
+`duration`) and deliberately omit raw URLs, query strings, headers, and request
+bodies.
+
 Listener addresses are restart-only. This mirrors the existing Pipelock pattern
 for scan API, kill switch API, and metrics listeners.
 

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -175,14 +175,14 @@ listener configured by `pipelock conductor serve --probe-listen`:
 
 These endpoints do not run application-level publisher or follower
 authorization and are not served by the mTLS follower listener. Deployments
-should bind `--probe-listen` to an operator-only interface or protect it with a
-pod NetworkPolicy, firewall rule, or IP allowlist. Kubernetes deployments often
-need the default wildcard bind so kubelet can reach the pod; non-Kubernetes
-deployments should prefer `--probe-listen=127.0.0.1:9092` unless a remote
-scraper requires otherwise. Conductor request logs are structured JSON on stderr
-with bounded fields (`event`, `route`, `method`, `status`, `status_class`,
-`duration`) and deliberately omit raw URLs, query strings, headers, and request
-bodies.
+default to loopback-only binding at `127.0.0.1:9092`. Deployments should keep
+`--probe-listen` on an operator-only interface or protect it with a pod
+NetworkPolicy, firewall rule, or IP allowlist. Kubernetes deployments often
+need an explicit wildcard bind such as `--probe-listen=:9092` so kubelet can
+reach the pod. Conductor request logs are structured JSON on stderr with
+bounded fields (`event`, `route`, `method`, `status`, `status_class`,
+`duration`) and deliberately omit raw URLs, query strings, headers, and
+request bodies.
 
 Listener addresses are restart-only. This mirrors the existing Pipelock pattern
 for scan API, kill switch API, and metrics listeners.

--- a/internal/cli/conductor/cmd.go
+++ b/internal/cli/conductor/cmd.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	defaultListen       = "127.0.0.1:8895"
-	defaultProbeListen  = ":9092"
+	defaultProbeListen  = "127.0.0.1:9092"
 	defaultTrustDomain  = "pipelock.local"
 	serveShutdownPeriod = 10 * time.Second
 )

--- a/internal/cli/conductor/cmd.go
+++ b/internal/cli/conductor/cmd.go
@@ -9,6 +9,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -22,16 +24,20 @@ import (
 
 	conductorcore "github.com/luckyPipewrench/pipelock/internal/conductor"
 	"github.com/luckyPipewrench/pipelock/internal/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 const (
-	defaultListen      = "127.0.0.1:8895"
-	defaultTrustDomain = "pipelock.local"
+	defaultListen       = "127.0.0.1:8895"
+	defaultProbeListen  = ":9092"
+	defaultTrustDomain  = "pipelock.local"
+	serveShutdownPeriod = 10 * time.Second
 )
 
 type serveOptions struct {
 	listen              string
+	probeListen         string
 	storageDir          string
 	conductorID         string
 	followerTrustDomain string
@@ -40,6 +46,7 @@ type serveOptions struct {
 	tlsCert             string
 	tlsKey              string
 	clientCA            string
+	logWriter           io.Writer
 }
 
 type auditKeySpec struct {
@@ -63,6 +70,7 @@ func Cmd() *cobra.Command {
 func serveCmd() *cobra.Command {
 	opts := serveOptions{
 		listen:              defaultListen,
+		probeListen:         defaultProbeListen,
 		conductorID:         "conductor",
 		followerTrustDomain: defaultTrustDomain,
 	}
@@ -75,6 +83,7 @@ func serveCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&opts.listen, "listen", opts.listen, "address for the Conductor HTTPS listener")
+	cmd.Flags().StringVar(&opts.probeListen, "probe-listen", opts.probeListen, "plain HTTP address for Conductor health, readiness, and metrics probes; empty disables the probe listener")
 	cmd.Flags().StringVar(&opts.storageDir, "storage-dir", "", "directory for Conductor policy bundles and audit store")
 	cmd.Flags().StringVar(&opts.conductorID, "conductor-id", opts.conductorID, "Conductor ID advertised in capabilities")
 	cmd.Flags().StringVar(&opts.followerTrustDomain, "follower-trust-domain", opts.followerTrustDomain, "SPIFFE trust domain for follower mTLS identities")
@@ -93,7 +102,10 @@ func runServe(cmd *cobra.Command, opts serveOptions) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	handler, tlsConfig, err := buildServeHandler(ctx, opts)
+	if opts.logWriter == nil {
+		opts.logWriter = cmd.ErrOrStderr()
+	}
+	handler, probeHandler, tlsConfig, err := buildServeHandler(ctx, opts)
 	if err != nil {
 		return err
 	}
@@ -107,57 +119,107 @@ func runServe(cmd *cobra.Command, opts serveOptions) error {
 		IdleTimeout:       60 * time.Second,
 		MaxHeaderBytes:    64 * 1024,
 	}
-	runCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	baseCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	runCtx, stop := signal.NotifyContext(baseCtx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	ln, err := (&net.ListenConfig{}).Listen(runCtx, "tcp", opts.listen)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = ln.Close() }()
+	var probeLn net.Listener
+	if strings.TrimSpace(opts.probeListen) != "" {
+		probeLn, err = (&net.ListenConfig{}).Listen(runCtx, "tcp", opts.probeListen)
+		if err != nil {
+			return fmt.Errorf("probe bind %s: %w", opts.probeListen, err)
+		}
+		defer func() { _ = probeLn.Close() }()
+	}
+	var probeServer *http.Server
+	if probeLn != nil {
+		probeServer = &http.Server{
+			Addr:              opts.probeListen,
+			Handler:           probeHandler,
+			ReadHeaderTimeout: 5 * time.Second,
+			ReadTimeout:       15 * time.Second,
+			WriteTimeout:      15 * time.Second,
+			IdleTimeout:       60 * time.Second,
+			MaxHeaderBytes:    64 * 1024,
+		}
+	}
 	go func() {
 		<-runCtx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
+		shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), serveShutdownPeriod)
+		defer cancelShutdown()
 		_ = server.Shutdown(shutdownCtx)
+		if probeServer != nil {
+			_ = probeServer.Shutdown(shutdownCtx)
+		}
 	}()
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pipelock: conductor listening on %s\n", opts.listen)
-	if err := server.ServeTLS(ln, opts.tlsCert, opts.tlsKey); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		return err
+	serverCount := 1
+	errCh := make(chan error, 2)
+	go func() {
+		if err := server.ServeTLS(ln, opts.tlsCert, opts.tlsKey); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+	if probeServer != nil {
+		serverCount++
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pipelock: conductor probes listening on %s\n", opts.probeListen)
+		go func() {
+			if err := probeServer.Serve(probeLn); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				errCh <- err
+				return
+			}
+			errCh <- nil
+		}()
 	}
-	return nil
+	var firstErr error
+	for range serverCount {
+		if err := <-errCh; err != nil && firstErr == nil {
+			firstErr = err
+			cancel()
+		}
+	}
+	return firstErr
 }
 
-func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, *tls.Config, error) {
+func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, http.Handler, *tls.Config, error) {
 	if strings.TrimSpace(opts.storageDir) == "" {
-		return nil, nil, errors.New("--storage-dir is required")
+		return nil, nil, nil, errors.New("--storage-dir is required")
 	}
 	if err := validateServeTLSFlags(opts); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	publisherToken, err := loadTokenFile(opts.publisherTokenFile)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	authorizer, err := controlplane.BearerPublisherAuthorizer(publisherToken)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	identity, err := controlplane.MTLSFollowerIdentityResolver(opts.followerTrustDomain)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	auditKeys, err := buildAuditKeyResolver(opts.trustedAuditKeys)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	store, err := controlplane.OpenFileBundleStore(filepath.Join(opts.storageDir, "policy-bundles"))
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	auditStore, err := controlplane.OpenSQLiteAuditStore(ctx, filepath.Join(opts.storageDir, "audit.db"))
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
+	m := metrics.New()
 	handler, err := controlplane.NewHandler(controlplane.HandlerOptions{
 		Store:              store,
 		Capabilities:       controlplane.DefaultCapabilities(opts.conductorID),
@@ -165,18 +227,27 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, *t
 		AuthorizePublisher: authorizer,
 		AuditSink:          auditStore,
 		AuditKeys:          auditKeys,
+		Metrics:            m,
+		Logger:             conductorRequestLogger(opts.logWriter),
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	tlsConfig, err := serveTLSConfig(opts.clientCA)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return handler, tlsConfig, nil
+	return handler, handler.ProbeHandler(), tlsConfig, nil
+}
+
+func conductorRequestLogger(w io.Writer) *slog.Logger {
+	if w == nil {
+		return nil
+	}
+	return slog.New(slog.NewJSONHandler(w, nil))
 }
 
 func validateServeTLSFlags(opts serveOptions) error {

--- a/internal/cli/conductor/cmd_test.go
+++ b/internal/cli/conductor/cmd_test.go
@@ -41,7 +41,7 @@ func TestBuildServeHandlerWiresControlPlane(t *testing.T) {
 		t.Fatalf("WriteFile(ca): %v", err)
 	}
 
-	handler, tlsConfig, err := buildServeHandler(context.Background(), serveOptions{
+	handler, probeHandler, tlsConfig, err := buildServeHandler(context.Background(), serveOptions{
 		listen:              defaultListen,
 		storageDir:          filepath.Join(dir, "store"),
 		conductorID:         "conductor-test",
@@ -67,10 +67,31 @@ func TestBuildServeHandlerWiresControlPlane(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("capabilities status = %d body=%s, want 200", w.Code, w.Body.String())
 	}
+
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, controlplane.ReadyzPath, nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("main ready status = %d body=%s, want 404", w.Code, w.Body.String())
+	}
+
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, controlplane.ReadyzPath, nil)
+	w = httptest.NewRecorder()
+	probeHandler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), `"audit_query_supported":true`) {
+		t.Fatalf("ready status = %d body=%s, want audit query support", w.Code, w.Body.String())
+	}
+
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, controlplane.MetricsPath, nil)
+	w = httptest.NewRecorder()
+	probeHandler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "pipelock_conductor_server_requests_total") {
+		t.Fatalf("metrics status = %d body=%s, want conductor metrics", w.Code, w.Body.String())
+	}
 }
 
 func TestBuildServeHandlerRequiresAuthInputs(t *testing.T) {
-	_, _, err := buildServeHandler(context.Background(), serveOptions{
+	_, _, _, err := buildServeHandler(context.Background(), serveOptions{
 		storageDir: "/tmp/store",
 		tlsCert:    "server.pem",
 		tlsKey:     "server.key",
@@ -88,7 +109,7 @@ func TestBuildServeHandlerRequiresAuthInputs(t *testing.T) {
 	if err := os.WriteFile(tokenPath, []byte("secret-token\n"), 0o600); err != nil {
 		t.Fatalf("WriteFile(token): %v", err)
 	}
-	_, _, err = buildServeHandler(context.Background(), serveOptions{
+	_, _, _, err = buildServeHandler(context.Background(), serveOptions{
 		storageDir:          filepath.Join(dir, "store"),
 		followerTrustDomain: defaultTrustDomain,
 		tlsCert:             "server.pem",

--- a/internal/conductor/controlplane/handler.go
+++ b/internal/conductor/controlplane/handler.go
@@ -8,11 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
 )
 
 const (
@@ -21,6 +23,10 @@ const (
 	PublishPolicyBundlePath = "/api/v1/conductor/policy-bundles"
 	LatestPolicyBundlePath  = "/api/v1/conductor/policy/latest"
 	AuditBatchesPath        = conductor.AuditBatchesPath
+	HealthPath              = "/health"
+	HealthzPath             = "/healthz"
+	MetricsPath             = "/metrics"
+	ReadyzPath              = "/readyz"
 
 	defaultMaxRequestBodyBytes = conductor.MaxConfigYAMLBytes * 2
 	defaultMaxAuditBodyBytes   = conductor.MaxAuditPayloadBytes * 2
@@ -53,6 +59,8 @@ type HandlerOptions struct {
 	AuthorizeAuditQuery PublisherAuthorizer
 	AuditSink           AuditBatchSink
 	AuditKeys           AuditKeyResolver
+	Metrics             *metrics.Metrics
+	Logger              *slog.Logger
 }
 
 type Handler struct {
@@ -69,6 +77,8 @@ type Handler struct {
 	// [AuditBatchQuerier], so GET returns 501 rather than a retryable 500.
 	auditQuerier AuditBatchQuerier
 	auditKeys    AuditKeyResolver
+	metrics      *metrics.Metrics
+	logger       *slog.Logger
 }
 
 type publishPolicyBundleRequest struct {
@@ -81,6 +91,22 @@ type publishPolicyBundleResponse struct {
 	Version     uint64    `json:"version"`
 	PublishedAt time.Time `json:"published_at"`
 	Created     bool      `json:"created"`
+}
+
+type healthResponse struct {
+	Status string `json:"status"`
+}
+
+type readyResponse struct {
+	Status     string          `json:"status"`
+	Subsystems readySubsystems `json:"subsystems"`
+}
+
+type readySubsystems struct {
+	PolicyStore         bool `json:"policy_store"`
+	AuditSink           bool `json:"audit_sink"`
+	AuditQuerySupported bool `json:"audit_query_supported"`
+	AuditKeyResolver    bool `json:"audit_key_resolver"`
 }
 
 func NewHandler(opts HandlerOptions) (*Handler, error) {
@@ -135,6 +161,8 @@ func NewHandler(opts HandlerOptions) (*Handler, error) {
 		auditSink:           opts.AuditSink,
 		auditQuerier:        auditQuerier,
 		auditKeys:           opts.AuditKeys,
+		metrics:             opts.Metrics,
+		logger:              opts.Logger,
 	}, nil
 }
 
@@ -160,6 +188,28 @@ func DefaultCapabilities(conductorID string) conductor.CapabilitiesResponse {
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.serveMeasured(w, r, h.serveControlHTTP)
+}
+
+func (h *Handler) ProbeHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.serveMeasured(w, r, h.serveProbeHTTP)
+	})
+}
+
+func (h *Handler) serveMeasured(w http.ResponseWriter, r *http.Request, serve func(http.ResponseWriter, *http.Request)) {
+	route := conductorRoute(r.URL.Path)
+	rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		status := rec.status
+		h.recordRequest(r, route, status, duration)
+	}()
+	serve(rec, r)
+}
+
+func (h *Handler) serveControlHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case conductor.CapabilitiesPath:
 		h.handleCapabilities(w, r)
@@ -172,6 +222,160 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.NotFound(w, r)
 	}
+}
+
+func (h *Handler) serveProbeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case HealthPath, HealthzPath:
+		h.handleHealth(w, r)
+	case MetricsPath:
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w, http.MethodGet)
+			return
+		}
+		if h.metrics == nil {
+			http.NotFound(w, r)
+			return
+		}
+		h.metrics.PrometheusHandler().ServeHTTP(w, r)
+	case ReadyzPath:
+		h.handleReady(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *Handler) recordRequest(r *http.Request, route string, status int, duration time.Duration) {
+	h.metrics.RecordConductorServerRequest(route, r.Method, status, duration)
+	if route == AuditBatchesPath {
+		switch r.Method {
+		case http.MethodPost:
+			h.metrics.RecordConductorServerAuditIngest(conductorOperationOutcome(status, "accepted"), conductorStatusReason(status))
+		case http.MethodGet:
+			h.metrics.RecordConductorServerAuditQuery(conductorOperationOutcome(status, "listed"), conductorStatusReason(status))
+		}
+	}
+	if h.logger == nil {
+		return
+	}
+	h.logger.InfoContext(r.Context(), "conductor_request",
+		slog.String("event", "conductor_request"),
+		slog.String("route", route),
+		slog.String("method", r.Method),
+		slog.Int("status", status),
+		slog.String("status_class", statusClass(status)),
+		slog.Duration("duration", duration),
+	)
+}
+
+func conductorRoute(path string) string {
+	switch path {
+	case HealthPath, HealthzPath, MetricsPath, ReadyzPath, conductor.CapabilitiesPath, PublishPolicyBundlePath, LatestPolicyBundlePath, AuditBatchesPath:
+		return path
+	default:
+		return "unknown"
+	}
+}
+
+func conductorOperationOutcome(status int, success string) string {
+	switch {
+	case status >= 200 && status < 300:
+		return success
+	case status == http.StatusNotImplemented:
+		return "unsupported"
+	case status >= 400 && status < 500:
+		return "rejected"
+	default:
+		return "error"
+	}
+}
+
+func conductorStatusReason(status int) string {
+	switch status {
+	case http.StatusOK, http.StatusAccepted:
+		return "ok"
+	case http.StatusBadRequest:
+		return "bad_request"
+	case http.StatusUnauthorized:
+		return "unauthorized"
+	case http.StatusForbidden:
+		return "forbidden"
+	case http.StatusConflict:
+		return "conflict"
+	case http.StatusRequestEntityTooLarge:
+		return "payload_too_large"
+	case http.StatusUnprocessableEntity:
+		return "unprocessable_entity"
+	case http.StatusNotImplemented:
+		return "unsupported"
+	default:
+		return statusClass(status)
+	}
+}
+
+func statusClass(status int) string {
+	switch {
+	case status >= 100 && status < 200:
+		return "1xx"
+	case status >= 200 && status < 300:
+		return "2xx"
+	case status >= 300 && status < 400:
+		return "3xx"
+	case status >= 400 && status < 500:
+		return "4xx"
+	case status >= 500 && status < 600:
+		return "5xx"
+	default:
+		return "unknown"
+	}
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(status int) {
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
+}
+
+func (r *statusRecorder) Write(p []byte) (int, error) {
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+	return r.ResponseWriter.Write(p)
+}
+
+func (h *Handler) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+	writeJSON(w, http.StatusOK, healthResponse{Status: "ok"})
+}
+
+func (h *Handler) handleReady(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+	subsystems := readySubsystems{
+		PolicyStore:         h.store != nil,
+		AuditSink:           h.auditSink != nil,
+		AuditQuerySupported: h.auditQuerier != nil,
+		AuditKeyResolver:    h.auditKeys != nil,
+	}
+	status := http.StatusOK
+	state := "ready"
+	if !subsystems.PolicyStore || !subsystems.AuditSink || !subsystems.AuditKeyResolver {
+		status = http.StatusServiceUnavailable
+		state = "not_ready"
+	}
+	writeJSON(w, status, readyResponse{
+		Status:     state,
+		Subsystems: subsystems,
+	})
 }
 
 func (h *Handler) handleCapabilities(w http.ResponseWriter, r *http.Request) {

--- a/internal/conductor/controlplane/handler_test.go
+++ b/internal/conductor/controlplane/handler_test.go
@@ -4,8 +4,10 @@
 package controlplane
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,6 +15,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
 )
 
 func TestHandlerPublishesAndServesLatestBundle(t *testing.T) {
@@ -111,6 +114,142 @@ func TestHandlerCapabilities(t *testing.T) {
 	handler.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/missing", nil))
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("missing path status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandlerHealthAndReady(t *testing.T) {
+	handler := newTestHandler(t, mustStore(t), nil)
+	probes := handler.ProbeHandler()
+	for _, path := range []string{HealthPath, HealthzPath} {
+		t.Run(path, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			probes.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil))
+			if w.Code != http.StatusOK {
+				t.Fatalf("%s status = %d body=%s, want 200", path, w.Code, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), `"status":"ok"`) {
+				t.Fatalf("%s body = %s, want status ok", path, w.Body.String())
+			}
+		})
+	}
+
+	w := httptest.NewRecorder()
+	probes.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, ReadyzPath, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("ready status = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	var got readyResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode ready response: %v", err)
+	}
+	if got.Status != "ready" || !got.Subsystems.PolicyStore || !got.Subsystems.AuditSink || !got.Subsystems.AuditKeyResolver {
+		t.Fatalf("ready response = %+v", got)
+	}
+	if got.Subsystems.AuditQuerySupported {
+		t.Fatalf("ready audit_query_supported = true for discard sink, want false")
+	}
+
+	w = httptest.NewRecorder()
+	probes.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodPost, ReadyzPath, nil))
+	if w.Code != http.StatusMethodNotAllowed || w.Header().Get("Allow") != http.MethodGet {
+		t.Fatalf("ready wrong method status=%d allow=%q, want 405 GET", w.Code, w.Header().Get("Allow"))
+	}
+
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, HealthzPath, nil))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("main healthz status = %d body=%s, want 404", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlerMetricsAndRequestLogging(t *testing.T) {
+	var logs bytes.Buffer
+	m := metrics.New()
+	handler, err := NewHandler(HandlerOptions{
+		Store:        mustStore(t),
+		Capabilities: DefaultCapabilities("conductor-test"),
+		Now:          func() time.Time { return testNow },
+		FollowerIdentity: func(*http.Request) (FollowerIdentity, error) {
+			return FollowerIdentity{}, ErrFollowerRequired
+		},
+		AuthorizePublisher: func(*http.Request) error { return ErrPublisherForbidden },
+		AuditSink:          discardAuditSink{},
+		AuditKeys:          rejectingAuditKeyResolver,
+		Metrics:            m,
+		Logger:             slog.New(slog.NewJSONHandler(&logs, nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+	probes := handler.ProbeHandler()
+
+	w := httptest.NewRecorder()
+	probes.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, HealthzPath+"?probe_id=opaque", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("health status = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodPost, AuditBatchesPath, strings.NewReader(`{}`)))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("audit ingest status = %d body=%s, want 401", w.Code, w.Body.String())
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, AuditBatchesPath+"?org_id=org-main", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("audit query status = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	probes.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, MetricsPath, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("metrics status = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		`pipelock_conductor_server_requests_total{method="GET",route="/healthz",status="200"} 1`,
+		`pipelock_conductor_server_audit_ingest_total{outcome="rejected",reason="unauthorized"} 1`,
+		`pipelock_conductor_server_audit_queries_total{outcome="rejected",reason="forbidden"} 1`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metrics body missing %q:\n%s", want, body)
+		}
+	}
+	logBody := logs.String()
+	if !strings.Contains(logBody, `"event":"conductor_request"`) || !strings.Contains(logBody, `"route":"/healthz"`) {
+		t.Fatalf("logs = %s, want conductor request route", logBody)
+	}
+	if strings.Contains(logBody, "probe_id") || strings.Contains(logBody, "opaque") {
+		t.Fatalf("logs leaked query value: %s", logBody)
+	}
+
+	pub, priv := testAuditSigner(t)
+	successMetrics := metrics.New()
+	successHandler, err := NewHandler(HandlerOptions{
+		Store:        mustStore(t),
+		Capabilities: DefaultCapabilities("conductor-test"),
+		Now:          func() time.Time { return testNow },
+		FollowerIdentity: func(*http.Request) (FollowerIdentity, error) {
+			return defaultFollowerIdentity(), nil
+		},
+		AuthorizePublisher: func(*http.Request) error { return nil },
+		AuditSink:          &captureAuditSink{},
+		AuditKeys:          auditKeyResolverFor(pub),
+		Metrics:            successMetrics,
+	})
+	if err != nil {
+		t.Fatalf("NewHandler(success) error = %v", err)
+	}
+	w = postAuditBatch(t, successHandler, signedAuditIngestRequest(t, defaultFollowerIdentity(), []byte(`{"entry":"ok"}`), priv, testNow))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("successful audit ingest status = %d body=%s, want 202", w.Code, w.Body.String())
+	}
+	w = httptest.NewRecorder()
+	successHandler.ProbeHandler().ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, MetricsPath, nil))
+	if !strings.Contains(w.Body.String(), `pipelock_conductor_server_audit_ingest_total{outcome="accepted",reason="ok"} 1`) {
+		t.Fatalf("successful ingest metric missing:\n%s", w.Body.String())
 	}
 }
 

--- a/internal/metrics/conductor.go
+++ b/internal/metrics/conductor.go
@@ -4,6 +4,9 @@
 package metrics
 
 import (
+	"strconv"
+	"time"
+
 	"github.com/luckyPipewrench/pipelock/internal/conductor/auditbatcher"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -29,11 +32,36 @@ func (m *Metrics) registerConductorMetrics(reg *prometheus.Registry) {
 		Name:      "conductor_audit_deliveries_total",
 		Help:      "Total Conductor audit batch delivery outcomes.",
 	}, []string{"outcome", "reason"})
+	m.conductorServerRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "pipelock",
+		Name:      "conductor_server_requests_total",
+		Help:      "Total Conductor server HTTP requests by route, method, and status code.",
+	}, []string{"route", "method", "status"})
+	m.conductorServerDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "pipelock",
+		Name:      "conductor_server_request_duration_seconds",
+		Help:      "Conductor server HTTP request duration by route and method.",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"route", "method"})
+	m.conductorServerAuditIngest = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "pipelock",
+		Name:      "conductor_server_audit_ingest_total",
+		Help:      "Total Conductor server audit ingest outcomes.",
+	}, []string{"outcome", "reason"})
+	m.conductorServerAuditQueries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "pipelock",
+		Name:      "conductor_server_audit_queries_total",
+		Help:      "Total Conductor server audit query outcomes.",
+	}, []string{"outcome", "reason"})
 	reg.MustRegister(
 		m.conductorAuditQueuePending,
 		m.conductorAuditQueueInflight,
 		m.conductorAuditQueueDead,
 		m.conductorAuditDeliveries,
+		m.conductorServerRequests,
+		m.conductorServerDuration,
+		m.conductorServerAuditIngest,
+		m.conductorServerAuditQueries,
 	)
 }
 
@@ -51,4 +79,26 @@ func (m *Metrics) RecordConductorAuditDelivery(outcome, reason string) {
 		return
 	}
 	m.conductorAuditDeliveries.WithLabelValues(outcome, reason).Inc()
+}
+
+func (m *Metrics) RecordConductorServerRequest(route, method string, status int, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.conductorServerRequests.WithLabelValues(route, method, strconv.Itoa(status)).Inc()
+	m.conductorServerDuration.WithLabelValues(route, method).Observe(duration.Seconds())
+}
+
+func (m *Metrics) RecordConductorServerAuditIngest(outcome, reason string) {
+	if m == nil {
+		return
+	}
+	m.conductorServerAuditIngest.WithLabelValues(outcome, reason).Inc()
+}
+
+func (m *Metrics) RecordConductorServerAuditQuery(outcome, reason string) {
+	if m == nil {
+		return
+	}
+	m.conductorServerAuditQueries.WithLabelValues(outcome, reason).Inc()
 }

--- a/internal/metrics/conductor_test.go
+++ b/internal/metrics/conductor_test.go
@@ -5,6 +5,7 @@ package metrics
 
 import (
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/conductor/auditbatcher"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -31,5 +32,26 @@ func TestConductorAuditMetrics(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(m.conductorAuditDeliveries.WithLabelValues("drop", "http_client_error")); got != 1 {
 		t.Fatalf("drop counter = %v, want 1", got)
+	}
+}
+
+func TestConductorServerMetrics(t *testing.T) {
+	m := New()
+	m.RecordConductorServerRequest("/readyz", "GET", 200, 25*time.Millisecond)
+	m.RecordConductorServerAuditIngest("accepted", "ok")
+	m.RecordConductorServerAuditIngest("rejected", "bad_request")
+	m.RecordConductorServerAuditQuery("listed", "ok")
+
+	if got := testutil.ToFloat64(m.conductorServerRequests.WithLabelValues("/readyz", "GET", "200")); got != 1 {
+		t.Fatalf("server request counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.conductorServerAuditIngest.WithLabelValues("accepted", "ok")); got != 1 {
+		t.Fatalf("audit ingest accepted counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.conductorServerAuditIngest.WithLabelValues("rejected", "bad_request")); got != 1 {
+		t.Fatalf("audit ingest rejected counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.conductorServerAuditQueries.WithLabelValues("listed", "ok")); got != 1 {
+		t.Fatalf("audit query counter = %v, want 1", got)
 	}
 }

--- a/internal/metrics/conductor_test.go
+++ b/internal/metrics/conductor_test.go
@@ -4,6 +4,7 @@
 package metrics
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -37,12 +38,12 @@ func TestConductorAuditMetrics(t *testing.T) {
 
 func TestConductorServerMetrics(t *testing.T) {
 	m := New()
-	m.RecordConductorServerRequest("/readyz", "GET", 200, 25*time.Millisecond)
+	m.RecordConductorServerRequest("/readyz", http.MethodGet, 200, 25*time.Millisecond)
 	m.RecordConductorServerAuditIngest("accepted", "ok")
 	m.RecordConductorServerAuditIngest("rejected", "bad_request")
 	m.RecordConductorServerAuditQuery("listed", "ok")
 
-	if got := testutil.ToFloat64(m.conductorServerRequests.WithLabelValues("/readyz", "GET", "200")); got != 1 {
+	if got := testutil.ToFloat64(m.conductorServerRequests.WithLabelValues("/readyz", http.MethodGet, "200")); got != 1 {
 		t.Fatalf("server request counter = %v, want 1", got)
 	}
 	if got := testutil.ToFloat64(m.conductorServerAuditIngest.WithLabelValues("accepted", "ok")); got != 1 {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -112,6 +112,10 @@ type Metrics struct {
 	conductorAuditQueueInflight prometheus.Gauge
 	conductorAuditQueueDead     prometheus.Gauge
 	conductorAuditDeliveries    *prometheus.CounterVec
+	conductorServerRequests     *prometheus.CounterVec
+	conductorServerDuration     *prometheus.HistogramVec
+	conductorServerAuditIngest  *prometheus.CounterVec
+	conductorServerAuditQueries *prometheus.CounterVec
 
 	// Learn-and-lock observation pipeline (learn.go).
 	learnObservationEvents        *prometheus.CounterVec


### PR DESCRIPTION
## Summary
- Add Conductor probe listener (`--probe-listen`) hosting `/health`, `/healthz`, `/readyz`, and `/metrics` in plain HTTP, separate from the mTLS follower listener
- Record bounded Prometheus counters and a duration histogram for server requests, audit ingest, and audit query, with sanitized structured JSON request logs (route, method, status, duration only)
- Document probe, scrape, and log behavior in the audit sink spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conductor exposes plain-HTTP probe endpoints (/health, /healthz, /readyz, /metrics) on a configurable probe listener; readiness shows subsystem flags.
  * Prometheus metrics for server requests, durations, and audit ingest/query outcomes.
  * Structured JSON request logging for probe/control requests.

* **Documentation**
  * Spec updated with deployment guidance for binding/protecting the probe interface and probe logging/metrics behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->