### PR TITLE
fix(proxy): consult cfg.Suppress before hard-block in request header DLP

### DIFF
--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -956,7 +956,28 @@ func isNoisyHeaderName(name string) bool {
 // (no allowlist skip) because agents can exfiltrate secrets in auth headers
 // to any host.
 func scanRequestHeaders(ctx context.Context, headers http.Header, cfg *config.Config, sc *scanner.Scanner) *BodyScanResult {
+	return scanRequestHeadersWithSuppress(ctx, headers, cfg, sc, "", nil)
+}
+
+func scanRequestHeadersForTarget(ctx context.Context, headers http.Header, cfg *config.Config, sc *scanner.Scanner, target string) *BodyScanResult {
+	return scanRequestHeadersWithSuppress(ctx, headers, cfg, sc, target, cfg.Suppress)
+}
+
+func scanRequestHeadersWithSuppress(ctx context.Context, headers http.Header, cfg *config.Config, sc *scanner.Scanner, target string, suppress []config.SuppressEntry) *BodyScanResult {
 	bodyCfg := cfg.RequestBodyScanning
+	resultForMatches := func(headerName string, matches []scanner.TextDLPMatch) *BodyScanResult {
+		if len(suppress) > 0 {
+			matches = unsuppressedDLPMatches(matches, target, suppress)
+			if len(matches) == 0 {
+				return nil
+			}
+		}
+		return &BodyScanResult{
+			Clean:      false,
+			DLPMatches: matches,
+			HeaderName: headerName,
+		}
+	}
 
 	// Build the set of headers to scan based on mode.
 	var headersToScan map[string][]string
@@ -1000,10 +1021,8 @@ func scanRequestHeaders(ctx context.Context, headers http.Header, cfg *config.Co
 		if bodyCfg.HeaderMode == config.HeaderModeAll {
 			result := sc.ScanTextForDLP(ctx, name)
 			if !result.Clean {
-				return &BodyScanResult{
-					Clean:      false,
-					DLPMatches: result.Matches,
-					HeaderName: name,
+				if headerResult := resultForMatches(name, result.Matches); headerResult != nil {
+					return headerResult
 				}
 			}
 			// Include header name in joined scan to catch secrets split
@@ -1015,10 +1034,8 @@ func scanRequestHeaders(ctx context.Context, headers http.Header, cfg *config.Co
 			allValues = append(allValues, v)
 			result := sc.ScanTextForDLP(ctx, v)
 			if !result.Clean {
-				return &BodyScanResult{
-					Clean:      false,
-					DLPMatches: result.Matches,
-					HeaderName: name,
+				if headerResult := resultForMatches(name, result.Matches); headerResult != nil {
+					return headerResult
 				}
 			}
 			// In "all" mode, scan name+value concatenation to catch secrets
@@ -1027,10 +1044,8 @@ func scanRequestHeaders(ctx context.Context, headers http.Header, cfg *config.Co
 				combined := name + v
 				combinedResult := sc.ScanTextForDLP(ctx, combined)
 				if !combinedResult.Clean {
-					return &BodyScanResult{
-						Clean:      false,
-						DLPMatches: combinedResult.Matches,
-						HeaderName: name,
+					if headerResult := resultForMatches(name, combinedResult.Matches); headerResult != nil {
+						return headerResult
 					}
 				}
 			}
@@ -1045,10 +1060,8 @@ func scanRequestHeaders(ctx context.Context, headers http.Header, cfg *config.Co
 		joined := strings.Join(allValues, "\n")
 		result := sc.ScanTextForDLP(ctx, joined)
 		if !result.Clean {
-			return &BodyScanResult{
-				Clean:      false,
-				DLPMatches: result.Matches,
-				HeaderName: "(joined)",
+			if headerResult := resultForMatches("(joined)", result.Matches); headerResult != nil {
+				return headerResult
 			}
 		}
 	}
@@ -1063,12 +1076,12 @@ func scanRequestHeaders(ctx context.Context, headers http.Header, cfg *config.Co
 // handles the response format (http.Error vs writeJSON) since it differs
 // between forward proxy and fetch handler.
 func (p *Proxy) evalHeaderDLP(ctx context.Context, headers http.Header, cfg *config.Config, sc *scanner.Scanner,
-	logger *audit.Logger, actx audit.LogContext, hostname string, start time.Time,
+	logger *audit.Logger, actx audit.LogContext, hostname, target string, start time.Time,
 ) (blocked bool, hadFinding bool) {
 	if !cfg.RequestBodyScanning.Enabled || !cfg.RequestBodyScanning.ScanHeaders {
 		return false, false
 	}
-	headerResult := scanRequestHeaders(ctx, headers, cfg, sc)
+	headerResult := scanRequestHeadersForTarget(ctx, headers, cfg, sc, target)
 	if headerResult == nil {
 		return false, false
 	}

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -833,6 +833,29 @@ func TestScanRequestHeaders_SplitSecretRepeatedValues(t *testing.T) {
 	}
 }
 
+func TestScanRequestHeadersForTarget_SuppressedValueDoesNotMaskLaterUnsuppressedValue(t *testing.T) {
+	cfg := testScannerConfig()
+	cfg.Suppress = []config.SuppressEntry{{
+		Rule:   "AWS Access ID",
+		Path:   "https://api.example.com/*",
+		Reason: "allow scoped provider credential",
+	}}
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	headers := http.Header{}
+	headers.Add("Authorization", "Bearer "+fakeAPIKey())
+	headers.Add("Authorization", "Bearer "+fakeAnthropicKey())
+
+	result := scanRequestHeadersForTarget(context.Background(), headers, cfg, sc, "https://api.example.com/v1/messages")
+	if result == nil || result.Clean {
+		t.Fatal("expected unsuppressed DLP match after suppressed header value")
+	}
+	if got := result.DLPMatches[0].PatternName; got != "Anthropic API Key" {
+		t.Fatalf("pattern = %q, want Anthropic API Key", got)
+	}
+}
+
 // TestScanRequestHeaders_AllowlistedHost verifies that header scanning applies
 // regardless of destination host. The allowlist controls URL-level blocking, not
 // header DLP bypass.
@@ -1270,6 +1293,51 @@ func TestForwardProxy_HeaderScan_SecretInAuth(t *testing.T) {
 
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403 for header with secret, got %d", resp.StatusCode)
+	}
+}
+
+func TestForwardProxy_HeaderScan_SuppressedCriticalHeaderAllowed(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	proxyAddr, cleanup := setupForwardProxy(t, func(cfg *config.Config) {
+		cfg.RequestBodyScanning.Enabled = true
+		cfg.RequestBodyScanning.Action = config.ActionWarn
+		cfg.RequestBodyScanning.ScanHeaders = true
+		cfg.RequestBodyScanning.MaxBodyBytes = 1024 * 1024
+		cfg.Suppress = []config.SuppressEntry{{
+			Rule:   "AWS Access ID",
+			Path:   upstream.URL + "/*",
+			Reason: "trusted destination auth header",
+		}}
+	})
+	defer cleanup()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, upstream.URL+"/test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+fakeAPIKey())
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: func(_ *http.Request) (*url.URL, error) {
+				return &url.URL{Scheme: "http", Host: proxyAddr}, nil
+			},
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for destination-suppressed header DLP, got %d", resp.StatusCode)
 	}
 }
 

--- a/internal/proxy/dlp_warn_context_test.go
+++ b/internal/proxy/dlp_warn_context_test.go
@@ -125,7 +125,8 @@ func TestDLPScanWSHeaders_PropagatesWarnContext(t *testing.T) {
 
 	headers := http.Header{}
 	headers.Set("Authorization", "Bearer "+fakeAPIKey()+" "+testWarnHookToken)
-	blocked, _, reason := (&Proxy{}).dlpScanWSHeaders(ctx, headers, sc, true)
+	cfg := testScannerConfig()
+	blocked, _, reason := (&Proxy{}).dlpScanWSHeaders(ctx, headers, sc, cfg, testWSURL)
 	if !blocked {
 		t.Fatal("expected DLP match in websocket headers")
 	}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -209,7 +209,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// can carry Proxy-Authorization, Authorization, or custom headers that
 	// may contain secrets. Tunneled HTTP headers are only visible with TLS
 	// interception; this covers the handshake itself.
-	connectHeaderBlocked, connectHeaderHadFinding := p.evalHeaderDLP(r.Context(), r.Header, cfg, sc, p.logger, headerCtx, host, "https://"+host, start)
+	connectHeaderBlocked, connectHeaderHadFinding := p.evalHeaderDLP(r.Context(), r.Header, cfg, sc, p.logger, headerCtx, host, syntheticURL, start)
 	if connectHeaderHadFinding && !connectHeaderBlocked && cfg.AdaptiveEnforcement.Enabled {
 		// Audit/warn mode: header DLP found something but did not block.
 		// Record a near-miss signal. Blocked findings go through

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -209,7 +209,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// can carry Proxy-Authorization, Authorization, or custom headers that
 	// may contain secrets. Tunneled HTTP headers are only visible with TLS
 	// interception; this covers the handshake itself.
-	connectHeaderBlocked, connectHeaderHadFinding := p.evalHeaderDLP(r.Context(), r.Header, cfg, sc, p.logger, headerCtx, host, start)
+	connectHeaderBlocked, connectHeaderHadFinding := p.evalHeaderDLP(r.Context(), r.Header, cfg, sc, p.logger, headerCtx, host, "https://"+host, start)
 	if connectHeaderHadFinding && !connectHeaderBlocked && cfg.AdaptiveEnforcement.Enabled {
 		// Audit/warn mode: header DLP found something but did not block.
 		// Record a near-miss signal. Blocked findings go through
@@ -1284,7 +1284,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Request header DLP scanning.
 	// hadFinding is true even in audit/warn mode so near-miss signals are recorded.
-	forwardHeaderBlocked, forwardHeaderHadFinding := p.evalHeaderDLP(r.Context(), r.Header, cfg, sc, p.logger, actx, r.URL.Hostname(), start)
+	forwardHeaderBlocked, forwardHeaderHadFinding := p.evalHeaderDLP(r.Context(), r.Header, cfg, sc, p.logger, actx, r.URL.Hostname(), targetURL, start)
 
 	// Capture observer: record forward header DLP verdict for policy replay.
 	{

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -961,7 +961,7 @@ func newInterceptHandler(
 
 		// Request header DLP scanning.
 		if ic.Config.RequestBodyScanning.Enabled && ic.Config.RequestBodyScanning.ScanHeaders {
-			headerResult := scanRequestHeaders(r.Context(), r.Header, ic.Config, ic.Scanner)
+			headerResult := scanRequestHeadersForTarget(r.Context(), r.Header, ic.Config, ic.Scanner, targetURL)
 
 			// Capture observer: record intercept header DLP verdict for policy replay.
 			if ic.Proxy != nil {

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -1100,6 +1100,39 @@ func TestInterceptTunnel_HeaderDLPBlocked(t *testing.T) {
 	}
 }
 
+func TestInterceptTunnel_HeaderDLPSuppressedCriticalAllowed(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer upstream.Close()
+
+	cache, pool, cfg, _, logger, m := testInterceptSetup(t)
+	cfg.RequestBodyScanning.Enabled = true
+	cfg.RequestBodyScanning.ScanHeaders = true
+	cfg.RequestBodyScanning.Action = config.ActionWarn
+	cfg.RequestBodyScanning.HeaderMode = config.HeaderModeSensitive
+	cfg.RequestBodyScanning.SensitiveHeaders = []string{"Authorization"}
+	addr := upstream.Listener.Addr().String()
+	cfg.Suppress = []config.SuppressEntry{{
+		Rule:   "Anthropic API Key",
+		Path:   "https://" + addr + "/*",
+		Reason: "trusted destination auth header",
+	}}
+	sc := scanner.New(cfg)
+	t.Cleanup(func() { sc.Close() })
+
+	secret := "sk-ant-" + "api03-test123456789abcdef"
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://"+addr+"/api", nil)
+	req.Header.Set("Authorization", "Bearer "+secret)
+
+	resp := interceptAndRequest(t, upstream, cache, pool, cfg, sc, logger, m, req)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 (suppressed critical header DLP should forward)", resp.StatusCode)
+	}
+}
+
 func TestInterceptTunnel_UpstreamError(t *testing.T) {
 	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3272,7 +3272,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	// Request header DLP scanning (fetch is GET-only, no body to scan).
 	// hadFinding is true even in audit/warn mode so RecordClean is not applied
 	// when a header DLP match was detected.
-	headerBlocked, headerHadFinding := p.evalHeaderDLP(r.Context(), r.Header, cfg, sc, log, actx, parsed.Hostname(), start)
+	headerBlocked, headerHadFinding := p.evalHeaderDLP(r.Context(), r.Header, cfg, sc, log, actx, parsed.Hostname(), displayURL, start)
 
 	// Capture observer: record header DLP verdict for policy replay.
 	{

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -503,7 +503,14 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	// Scan request headers for DLP patterns (secret exfiltration via headers).
 	if cfg.RequestBodyScanning.Enabled && cfg.RequestBodyScanning.ScanHeaders {
-		headerResult := scanRequestHeadersForTarget(r.Context(), r.Header, cfg, sc, r.URL.String())
+		// Pass the full upstream destination (scheme://host[:port]/path) so
+		// destination-scoped suppress globs (e.g. "https://api.example.com/*")
+		// resolve against the URL the request will actually reach, not the
+		// path-only r.URL.String() the reverse proxy sees from the client.
+		dlpTarget := *rp.upstream
+		dlpTarget.Path = joinReversePaths(rp.upstream.Path, r.URL.Path)
+		dlpTarget.RawPath = ""
+		headerResult := scanRequestHeadersForTarget(r.Context(), r.Header, cfg, sc, dlpTarget.String())
 		if headerResult != nil {
 			hasFinding = true
 			action := cfg.RequestBodyScanning.Action

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -503,7 +503,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	// Scan request headers for DLP patterns (secret exfiltration via headers).
 	if cfg.RequestBodyScanning.Enabled && cfg.RequestBodyScanning.ScanHeaders {
-		headerResult := scanRequestHeaders(r.Context(), r.Header, cfg, sc)
+		headerResult := scanRequestHeadersForTarget(r.Context(), r.Header, cfg, sc, r.URL.String())
 		if headerResult != nil {
 			hasFinding = true
 			action := cfg.RequestBodyScanning.Action

--- a/internal/proxy/reverse_test.go
+++ b/internal/proxy/reverse_test.go
@@ -1376,6 +1376,42 @@ func TestReverseProxy_HeaderDLPBlocked(t *testing.T) {
 	}
 }
 
+func TestReverseProxy_HeaderDLPSuppressedCriticalAllowed(t *testing.T) {
+	cfg := reverseTestConfig()
+	cfg.RequestBodyScanning.ScanHeaders = true
+	cfg.RequestBodyScanning.HeaderMode = "all"
+	cfg.Suppress = []config.SuppressEntry{{
+		Rule:   "AWS Access ID",
+		Path:   "/api/*",
+		Reason: "trusted destination auth header",
+	}}
+
+	var upstreamHit atomic.Bool
+	upstream := func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHit.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}
+
+	proxy := reverseTestSetup(t, cfg, upstream)
+
+	apiKey := "AKIA" + "IOSFODNN7EXAMPLE"
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, proxy.URL+"/api/data", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 (suppressed critical header DLP should forward), got %d", resp.StatusCode)
+	}
+	if !upstreamHit.Load() {
+		t.Fatal("upstream not reached — suppressed header DLP must forward to upstream")
+	}
+}
+
 func TestReverseProxy_OversizedResponseBlocked(t *testing.T) {
 	cfg := reverseTestConfig()
 

--- a/internal/proxy/reverse_test.go
+++ b/internal/proxy/reverse_test.go
@@ -1381,8 +1381,12 @@ func TestReverseProxy_HeaderDLPSuppressedCriticalAllowed(t *testing.T) {
 	cfg.RequestBodyScanning.ScanHeaders = true
 	cfg.RequestBodyScanning.HeaderMode = "all"
 	cfg.Suppress = []config.SuppressEntry{{
-		Rule:   "AWS Access ID",
-		Path:   "/api/*",
+		Rule: "AWS Access ID",
+		// Destination-style glob (scheme + host + path) exercises the
+		// upstream target the reverse-proxy header DLP now passes to the
+		// suppress filter, not the relative-path r.URL.String() that the
+		// proxy sees from the client.
+		Path:   "http://*/api/*",
 		Reason: "trusted destination auth header",
 	}}
 

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -404,7 +404,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	// DLP-scan forwarded header values regardless of destination or enforce mode.
 	// In audit mode, findings are logged as anomalies but traffic is allowed.
-	if blocked, hardBlock, reason := p.dlpScanWSHeaders(r.Context(), fwdHeaders, sc, cfg.EnforceEnabled()); blocked {
+	if blocked, hardBlock, reason := p.dlpScanWSHeaders(r.Context(), fwdHeaders, sc, cfg, targetURL); blocked {
 		// Capture observer: record WS header DLP verdict for policy replay.
 		p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 			Subsurface:        "dlp_ws_header",
@@ -819,7 +819,7 @@ func (p *Proxy) buildWSForwardHeaders(r *http.Request, parsed *url.URL, cfg *con
 // dlpScanWSHeaders runs DLP scanning on all forwarded header values before the
 // upstream handshake. Headers are scanned regardless of destination (no
 // allowlist skip) because agents can exfiltrate secrets in any header value.
-func (p *Proxy) dlpScanWSHeaders(ctx context.Context, headers http.Header, sc *scanner.Scanner, enforceEnabled bool) (blocked bool, hardBlock bool, reason string) {
+func (p *Proxy) dlpScanWSHeaders(ctx context.Context, headers http.Header, sc *scanner.Scanner, cfg *config.Config, targetURL string) (blocked bool, hardBlock bool, reason string) {
 	// Scan all headers that buildWSForwardHeaders may forward. This covers
 	// auth headers, cookies, origin, subprotocol, and user-agent. An agent
 	// can exfiltrate data in any of these values.
@@ -833,11 +833,15 @@ func (p *Proxy) dlpScanWSHeaders(ctx context.Context, headers http.Header, sc *s
 		}
 		result := sc.ScanTextForDLP(ctx, val)
 		if !result.Clean {
-			names := make([]string, len(result.Matches))
-			for i, m := range result.Matches {
+			matches := unsuppressedDLPMatches(result.Matches, targetURL, cfg.Suppress)
+			if len(matches) == 0 {
+				continue
+			}
+			names := make([]string, len(matches))
+			for i, m := range matches {
 				names[i] = m.PatternName
 			}
-			return true, shouldHardBlockCriticalDLP(result.Matches, enforceEnabled), fmt.Sprintf("DLP match in %s header: %s", key, strings.Join(names, ", "))
+			return true, shouldHardBlockCriticalDLP(matches, cfg.EnforceEnabled()), fmt.Sprintf("DLP match in %s header: %s", key, strings.Join(names, ", "))
 		}
 	}
 	return false, false, ""

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -1411,6 +1411,50 @@ func TestWSProxyHeaderDLPBlocksAllowlistedHost(t *testing.T) {
 	// Connection should be rejected with DLP match.
 }
 
+func TestWSProxyHeaderDLPSuppressedCriticalAllowed(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+
+	proxyAddr, proxyCleanup := setupWSProxy(t, func(cfg *config.Config) {
+		cfg.Suppress = []config.SuppressEntry{{
+			Rule:   "Anthropic API Key",
+			Path:   "ws://" + backendAddr,
+			Reason: "trusted websocket auth header",
+		}}
+	})
+	defer proxyCleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	secret := "sk-ant-" + "IOSFODNN7EXAMPLE1234567890abcdef"
+	wsURL := fmt.Sprintf("ws://%s/ws?url=ws://%s", proxyAddr, backendAddr)
+
+	dialer := ws.Dialer{
+		Header: ws.HandshakeHeaderHTTP(http.Header{
+			"Authorization": []string{"Bearer " + secret},
+		}),
+		Timeout: 5 * time.Second,
+	}
+
+	conn, _, _, err := dialer.Dial(ctx, wsURL)
+	if err != nil {
+		t.Fatalf("expected suppressed header DLP to allow websocket dial: %v", err)
+	}
+	defer conn.Close() //nolint:errcheck // test
+
+	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte(testWSHello)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	reply, _, err := wsutil.ReadServerData(conn)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(reply) != testWSHello {
+		t.Fatalf("reply = %q, want %q", reply, testWSHello)
+	}
+}
+
 func TestWSProxyHeaderDLPBlockCookie(t *testing.T) {
 	// Cookies containing secrets should be blocked when ForwardCookies is enabled.
 	proxyAddr, cleanup := setupWSProxy(t, func(cfg *config.Config) {


### PR DESCRIPTION
## Summary
- Request header DLP now consults `cfg.Suppress` before hard-block, matching request body DLP behavior.
- Suppression is applied INSIDE the header scan loop, so a suppressed value cannot mask a later unsuppressed credential.
- Applied at all 6 header DLP entry points: forward CONNECT, forward HTTP, fetch, TLS-intercepted, reverse-proxy, WebSocket upgrade.
- 5 regression tests cover all transports plus the masking case.

## Why
- Critical header DLP hard-blocked first-party auth headers to provider APIs whose token formats match DLP regexes, even when `cfg.Suppress` listed the destination.
- Previous behavior was a parity gap: body DLP consulted `suppress`, header DLP didn't.

## Invariant preserved
- Header DLP still scans every destination.
- Header DLP still hard-blocks unsuppressed critical credentials.
- Only explicit `cfg.Suppress` `path:` globs prevent the block.
- A suppressed match in one header does not mask an unsuppressed match in another header (suppression filters per-match; scanning continues past fully-suppressed matches).
- No global trust-destination or model-sink bypass.

## Known follow-up
- When all matches are suppressed, `evalHeaderDLP` returns `hadFinding=false`, so the capture observer cannot distinguish "no matches" from "matches all suppressed." Telemetry only; enforcement is correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DLP suppression rules now support target-scoped filtering, letting you suppress specific header DLP findings for particular destination URLs.
  * Target-aware suppression is applied consistently across forward, reverse, CONNECT tunneling, and WebSocket header scanning.

* **Tests**
  * Added unit and integration tests validating that suppressed header matches do not mask later unsuppressed values and that suppressed critical findings allow requests when configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->