### PR TITLE
feat(filesentry,doctor): per-path watch required: flag + doctor port-collision check

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -5,6 +5,7 @@
 ```sh
 pipelock doctor --config /etc/pipelock/pipelock.yaml
 pipelock doctor --config /etc/pipelock/pipelock.yaml --json
+pipelock doctor --config /etc/pipelock/pipelock.yaml --check-ports
 ```
 
 The command does not make network requests. It checks local config, file readability, selected environment variables, and deployment prerequisites that can be inferred from the current process.
@@ -23,6 +24,7 @@ The command does not make network requests. It checks local config, file readabi
 | `file_sentry` | MCP | Whether file_sentry is enabled and its watch paths are readable by the process arming the watcher. |
 | `sentry` | Host | Whether Sentry telemetry is enabled and a DSN is present without printing the DSN value. |
 | `direct_egress_boundary` | Host | Reminder that proxy env vars are not a wall; direct egress requires `pipelock contain`, sandboxing, NetworkPolicy, firewalling, or equivalent controls. |
+| `port_collisions:*` | Host | With `--check-ports`, whether configured listener ports are already held by another process. On Linux, this uses `/proc/net/tcp*` plus `/proc/<pid>/fd`; run as root when cross-user process ownership hides PID details. Non-Linux hosts report the check as unavailable. |
 
 ## Exit Codes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1678,7 +1678,9 @@ Real-time filesystem monitoring for agent subprocesses. Detects secrets written 
 file_sentry:
   enabled: false
   watch_paths:
-    - "."
+    - "."                         # required:false; degraded if unavailable
+    - path: "/var/agent-secrets"  # required:true; startup fails if unavailable
+      required: true
   scan_content: true
   ignore_patterns:
     - "node_modules/**"
@@ -1690,10 +1692,12 @@ file_sentry:
 | Field | Default | Description |
 |-------|---------|-------------|
 | `enabled` | `false` | Enable filesystem monitoring. Opt-in. |
-| `watch_paths` | `[]` | Directories to monitor recursively. Relative paths are resolved against the config file directory (not CWD). Required when enabled. |
+| `watch_paths` | `[]` | Directories to monitor recursively. Relative paths are resolved against the config file directory (not CWD). Required when enabled. Entries may be bare strings or `{path, required}` mappings. Bare strings default to `required: false`. |
 | `scan_content` | `true` | Run DLP scanner on modified file content. |
 | `ignore_patterns` | `[]` | Glob patterns for files and directories to skip. |
 | `action` | `warn` | Enforcement response when an agent-attributed write matches a DLP pattern. `warn` logs the finding + records a metric (current default). `block` additionally cancels the proxy context so the MCP child terminates, preventing the agent from continuing after a detected leak. Non-agent writes (editor saves, build output) never trigger the block path. |
+
+When a `watch_paths` entry is `required: false`, startup records a degraded path and continues if that watch cannot be installed. Set `required: true` on paths that are part of the security boundary; startup fails closed if those watches cannot be installed. Unknown fields in mapping entries are rejected so typos such as `require: true` do not silently disable the hard-fail opt-in.
 
 Findings are reported as stderr warnings and Prometheus metrics (`pipelock_file_sentry_findings_total`). Structured audit log emission (`file_sentry_dlp` event type) is defined but not yet wired to the webhook/syslog pipeline. On Linux, process lineage tracking attributes file writes to the agent's process tree via `PR_SET_CHILD_SUBREAPER` and `/proc` walking.
 

--- a/docs/guides/filesystem-sentinel.md
+++ b/docs/guides/filesystem-sentinel.md
@@ -22,8 +22,9 @@ file_sentry:
   enabled: true
   action: warn               # warn (default) or block
   watch_paths:
-    - "/workspace"           # agent working directory
-    - "/tmp/agent-output"    # temp output directory
+    - "/workspace"           # optional by default; degraded if unavailable
+    - path: "/tmp/agent-output"
+      required: true         # startup fails if this watch cannot be installed
   scan_content: true
   ignore_patterns:
     - "node_modules/**"
@@ -41,6 +42,17 @@ file_sentry:
 ### Watch Paths
 
 Directories are watched recursively. New subdirectories created after startup are automatically added to the watch. Paths are resolved to absolute paths at startup.
+
+Each entry can be either a bare string or a mapping:
+
+```yaml
+watch_paths:
+  - "/workspace"             # required:false
+  - path: "/var/agent-secrets"
+    required: true
+```
+
+Bare string entries default to `required: false`. If a non-required watch cannot be installed, pipelock logs a degraded path and continues arming the remaining paths. Use `required: true` for directories whose monitoring is part of the security boundary; startup fails closed if that watch cannot be installed. Unknown mapping fields are rejected so typos do not silently disable the hard-fail opt-in.
 
 ### Ignore Patterns
 

--- a/internal/cli/audit/audit_score_test.go
+++ b/internal/cli/audit/audit_score_test.go
@@ -95,7 +95,7 @@ func TestScoreConfig_FullyConfigured(t *testing.T) {
 	cfg.GitProtection.PrePushScan = true
 	cfg.GitProtection.BlockedCommands = []string{"force-push"}
 	cfg.FileSentry.Enabled = true
-	cfg.FileSentry.WatchPaths = []string{"/etc/secrets"}
+	cfg.FileSentry.WatchPaths = []config.WatchPath{{Path: "/etc/secrets"}}
 
 	result := ScoreConfig(cfg, "test.yaml")
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1888,8 +1888,8 @@ func TestRunCmd_MCPListenStartupFailure(t *testing.T) {
 		cancel()
 		t.Fatal("expected bind error, but run succeeded")
 	}
-	if !strings.Contains(cmdErr.Error(), "MCP listener bind") {
-		t.Errorf("expected 'MCP listener bind' error, got: %v", cmdErr)
+	if !strings.Contains(cmdErr.Error(), "mcp_listen bind") {
+		t.Errorf("expected 'mcp_listen bind' error, got: %v", cmdErr)
 	}
 }
 

--- a/internal/cli/diag/doctor.go
+++ b/internal/cli/diag/doctor.go
@@ -65,6 +65,7 @@ func DoctorCmd() *cobra.Command {
 	var configFile string
 	var jsonOutput bool
 	var noColor bool
+	var checkPorts bool
 
 	cmd := &cobra.Command{
 		Use:   "doctor",
@@ -87,6 +88,26 @@ this" report.`,
 				return cliutil.ExitCodeError(2, err)
 			}
 			report := buildDoctorReport(cfg, cfgLabel)
+			if checkPorts {
+				report.Checks = append(report.Checks, checkPortsReport(cfg)...)
+				// Rebuild summary tallies so the appended port checks count
+				// against pass/warn/fail exit codes alongside the built-in
+				// checks. Re-tally rather than incremental-add so the same
+				// code path produces summary either way.
+				report.Summary = doctorSummary{}
+				for _, check := range report.Checks {
+					switch check.Status {
+					case doctorStatusOK:
+						report.Summary.OK++
+					case doctorStatusWarn:
+						report.Summary.Warnings++
+					case doctorStatusFail:
+						report.Summary.Failures++
+					default:
+						report.Summary.Info++
+					}
+				}
+			}
 			if jsonOutput {
 				report.RootRunBanner = doctorRootBannerMessage()
 				enc := json.NewEncoder(cmd.OutOrStdout())
@@ -110,6 +131,7 @@ this" report.`,
 	cmd.Flags().StringVarP(&configFile, "config", "c", "", "config file (default: built-in defaults)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output report as JSON")
 	cmd.Flags().BoolVar(&noColor, "no-color", false, "disable color output")
+	cmd.Flags().BoolVar(&checkPorts, "check-ports", false, "report which process holds each configured listener port (Linux /proc; run as root for cross-user visibility)")
 
 	return cmd
 }
@@ -531,7 +553,11 @@ func checkDoctorFileSentry(cfg *config.Config) doctorReportCheck {
 			Next:    "enable with reachable watch_paths where workspace drift should be detected",
 		}
 	}
-	missing := missingReadablePaths(cfg.FileSentry.WatchPaths...)
+	watchStrings := make([]string, len(cfg.FileSentry.WatchPaths))
+	for i, wp := range cfg.FileSentry.WatchPaths {
+		watchStrings[i] = wp.Path
+	}
+	missing := missingReadablePaths(watchStrings...)
 	check := doctorReportCheck{
 		Name:       "file_sentry",
 		Surface:    doctorSurfaceMCP,

--- a/internal/cli/diag/doctor.go
+++ b/internal/cli/diag/doctor.go
@@ -553,11 +553,18 @@ func checkDoctorFileSentry(cfg *config.Config) doctorReportCheck {
 			Next:    "enable with reachable watch_paths where workspace drift should be detected",
 		}
 	}
-	watchStrings := make([]string, len(cfg.FileSentry.WatchPaths))
-	for i, wp := range cfg.FileSentry.WatchPaths {
-		watchStrings[i] = wp.Path
+	// Split required vs optional paths so the doctor exit code aligns with
+	// runtime behavior: optional (required:false) misses degrade at startup,
+	// they should not turn doctor into a hard failure. Required misses still
+	// fail.
+	var requiredPaths, optionalPaths []string
+	for _, wp := range cfg.FileSentry.WatchPaths {
+		if wp.Required {
+			requiredPaths = append(requiredPaths, wp.Path)
+		} else {
+			optionalPaths = append(optionalPaths, wp.Path)
+		}
 	}
-	missing := missingReadablePaths(watchStrings...)
 	check := doctorReportCheck{
 		Name:       "file_sentry",
 		Surface:    doctorSurfaceMCP,
@@ -570,9 +577,18 @@ func checkDoctorFileSentry(cfg *config.Config) doctorReportCheck {
 		check.Detail = "enabled but no watch_paths are configured"
 		return check
 	}
-	if len(missing) > 0 {
+	requiredMissing := missingReadablePaths(requiredPaths...)
+	optionalMissing := missingReadablePaths(optionalPaths...)
+	if len(requiredMissing) > 0 {
 		check.Status = doctorStatusFail
-		check.Detail = "watch path(s) not readable: " + strings.Join(missing, ", ")
+		check.Detail = "required watch path(s) not readable: " + strings.Join(requiredMissing, ", ")
+		return check
+	}
+	if len(optionalMissing) > 0 {
+		check.Status = doctorStatusWarn
+		check.Reachable = true
+		check.Detail = "optional watch path(s) not readable (will degrade at startup, not fail): " + strings.Join(optionalMissing, ", ")
+		check.Next = "either mark these required:true to fail-fast, or remove them from watch_paths"
 		return check
 	}
 	check.Status = doctorStatusWarn

--- a/internal/cli/diag/doctor_test.go
+++ b/internal/cli/diag/doctor_test.go
@@ -431,9 +431,17 @@ func TestDoctorChecksCoverConfiguredBranches(t *testing.T) {
 		if check := checkDoctorFileSentry(cfg); check.Status != doctorStatusFail {
 			t.Fatalf("empty paths check = %+v, want fail", check)
 		}
+		// required:false missing path: degrades to warn (matches the new
+		// startup behavior where non-required misses log degraded and
+		// continue rather than crash-loop).
 		cfg.FileSentry.WatchPaths = []config.WatchPath{{Path: filepath.Join(dir, "missing")}}
+		if check := checkDoctorFileSentry(cfg); check.Status != doctorStatusWarn {
+			t.Fatalf("missing optional path check = %+v, want warn (degraded)", check)
+		}
+		// required:true missing path: hard fail.
+		cfg.FileSentry.WatchPaths = []config.WatchPath{{Path: filepath.Join(dir, "missing"), Required: true}}
 		if check := checkDoctorFileSentry(cfg); check.Status != doctorStatusFail {
-			t.Fatalf("missing path check = %+v, want fail", check)
+			t.Fatalf("missing required path check = %+v, want fail", check)
 		}
 		cfg.FileSentry.WatchPaths = []config.WatchPath{{Path: watchDir}}
 		check := checkDoctorFileSentry(cfg)

--- a/internal/cli/diag/doctor_test.go
+++ b/internal/cli/diag/doctor_test.go
@@ -431,11 +431,11 @@ func TestDoctorChecksCoverConfiguredBranches(t *testing.T) {
 		if check := checkDoctorFileSentry(cfg); check.Status != doctorStatusFail {
 			t.Fatalf("empty paths check = %+v, want fail", check)
 		}
-		cfg.FileSentry.WatchPaths = []string{filepath.Join(dir, "missing")}
+		cfg.FileSentry.WatchPaths = []config.WatchPath{{Path: filepath.Join(dir, "missing")}}
 		if check := checkDoctorFileSentry(cfg); check.Status != doctorStatusFail {
 			t.Fatalf("missing path check = %+v, want fail", check)
 		}
-		cfg.FileSentry.WatchPaths = []string{watchDir}
+		cfg.FileSentry.WatchPaths = []config.WatchPath{{Path: watchDir}}
 		check := checkDoctorFileSentry(cfg)
 		if check.Status != doctorStatusWarn || !check.Reachable {
 			t.Fatalf("readable path check = %+v, want reachable warning", check)

--- a/internal/cli/diag/portcheck.go
+++ b/internal/cli/diag/portcheck.go
@@ -1,0 +1,239 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package diag
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// configuredListener describes a single listen address the operator configured
+// in pipelock.yaml. The label is used in doctor output so an operator can
+// tell which config field a collision came from. Address is preserved
+// verbatim from the config (e.g. ":8888", "127.0.0.1:9090", "[::1]:8080")
+// so the collision-detection logic can distinguish wildcard vs explicit
+// bind addresses without re-parsing.
+type configuredListener struct {
+	Label   string // e.g. "fetch_proxy.listen"
+	Address string // e.g. ":8888" or "127.0.0.1:9090"
+}
+
+// collectConfiguredListeners walks the pipelock config and returns every
+// configured listen address with a stable label. Empty addresses are skipped
+// (an unset listen field is not a collision risk).
+func collectConfiguredListeners(cfg *config.Config) []configuredListener {
+	out := make([]configuredListener, 0, 8)
+	add := func(label, addr string) {
+		if strings.TrimSpace(addr) != "" {
+			out = append(out, configuredListener{Label: label, Address: addr})
+		}
+	}
+	if cfg == nil {
+		return out
+	}
+	add("fetch_proxy.listen", cfg.FetchProxy.Listen)
+	add("kill_switch.api_listen", cfg.KillSwitch.APIListen)
+	add("metrics_listen", cfg.MetricsListen)
+	add("scan_api.listen", cfg.ScanAPI.Listen)
+	add("reverse_proxy.listen", cfg.ReverseProxy.Listen)
+	return out
+}
+
+// portFromListenAddr extracts the TCP port from a listen-address string
+// (":8888", "127.0.0.1:9090", "[::1]:8080"). Returns 0 when the address has
+// no explicit port (e.g. a plain hostname). The port-collision check skips
+// zero ports because /proc only enumerates bound listeners.
+func portFromListenAddr(addr string) (uint16, error) {
+	if addr == "" {
+		return 0, fmt.Errorf("empty listen address")
+	}
+	// Bare ":NNNN" is valid for net.SplitHostPort.
+	_, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return 0, fmt.Errorf("split host/port %q: %w", addr, err)
+	}
+	if portStr == "" {
+		return 0, nil
+	}
+	n, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return 0, fmt.Errorf("parse port %q: %w", portStr, err)
+	}
+	return uint16(n), nil
+}
+
+// procListener identifies the process holding a TCP listen on a given port.
+type procListener struct {
+	Port    uint16
+	IP      net.IP
+	PID     int
+	Cmdline string
+}
+
+// checkPortsReportLinesFromCfg builds the doctor checks for port collisions
+// against every configured listener in cfg. The platform implementation
+// lives in portcheck_{linux,other}.go.
+func checkPortsReport(cfg *config.Config) []doctorReportCheck {
+	listeners := collectConfiguredListeners(cfg)
+	if len(listeners) == 0 {
+		return []doctorReportCheck{{
+			Name:    "port_collisions",
+			Surface: doctorSurfaceHost,
+			Status:  doctorStatusInfo,
+			Detail:  "no listener addresses configured; nothing to check",
+		}}
+	}
+
+	holders, err := enumerateListenerHolders()
+	if err != nil {
+		// Non-Linux or /proc unreadable: emit info, not failure. Operators
+		// running on macOS/Windows still get a clear "we didn't check" line
+		// rather than a spurious pass.
+		return []doctorReportCheck{{
+			Name:    "port_collisions",
+			Surface: doctorSurfaceHost,
+			Status:  doctorStatusInfo,
+			Detail:  "port-collision check unavailable: " + err.Error(),
+			Next:    "run pipelock doctor --check-ports on a Linux host with /proc to identify processes holding configured listener ports",
+		}}
+	}
+
+	checks := make([]doctorReportCheck, 0, len(listeners))
+	for _, l := range listeners {
+		port, perr := portFromListenAddr(l.Address)
+		switch {
+		case perr != nil:
+			checks = append(checks, doctorReportCheck{
+				Name:       "port_collisions:" + l.Label,
+				Surface:    doctorSurfaceHost,
+				Status:     doctorStatusWarn,
+				Configured: true,
+				Detail:     fmt.Sprintf("could not parse listen address %q: %v", l.Address, perr),
+			})
+		case port == 0:
+			checks = append(checks, doctorReportCheck{
+				Name:       "port_collisions:" + l.Label,
+				Surface:    doctorSurfaceHost,
+				Status:     doctorStatusInfo,
+				Configured: true,
+				Detail:     fmt.Sprintf("listen address %q has no explicit port; skipped", l.Address),
+			})
+		default:
+			checks = append(checks, evaluateListenerCollision(l, port, holders))
+		}
+	}
+	return checks
+}
+
+// evaluateListenerCollision compares one configured listener against the
+// per-port holder map. Returns an OK check when no other process holds the
+// port, or a warn check naming the conflicting PID + cmdline.
+func evaluateListenerCollision(l configuredListener, port uint16, holders map[uint16][]procListener) doctorReportCheck {
+	check := doctorReportCheck{
+		Name:       "port_collisions:" + l.Label,
+		Surface:    doctorSurfaceHost,
+		Configured: true,
+	}
+	holder, ok := firstCollidingHolder(l.Address, holders[port])
+	if !ok {
+		check.Status = doctorStatusOK
+		check.Detail = fmt.Sprintf("port %d (%s) is free", port, l.Address)
+		return check
+	}
+	check.Status = doctorStatusWarn
+	if holder.PID == os.Getpid() {
+		// pipelock itself is holding the port — this is the doctor running
+		// against a live process. Surface as OK, not a collision.
+		check.Status = doctorStatusOK
+		check.Detail = fmt.Sprintf("port %d (%s) held by this pipelock process (pid %d)", port, l.Address, holder.PID)
+		return check
+	}
+	if holder.PID == 0 {
+		// Holder identified by inode in /proc/net/tcp but no /proc/<pid>/fd
+		// entry pointed to that inode — typical when the holder runs as a
+		// different user and the doctor wasn't run as root.
+		check.Detail = fmt.Sprintf("port %d (%s) is held by another process; run as root to identify it", port, l.Address)
+		check.Next = "rerun `pipelock doctor --check-ports` as root, OR use `ss -tlnp | grep :" + strconv.Itoa(int(port)) + "` to identify the holder"
+		return check
+	}
+	check.Detail = fmt.Sprintf("port %d (%s) already in use by pid %d (%s)", port, l.Address, holder.PID, truncateCmdline(holder.Cmdline))
+	check.Next = "stop the conflicting process or move pipelock's " + l.Label + " to a free port"
+	return check
+}
+
+func firstCollidingHolder(configuredAddr string, holders []procListener) (procListener, bool) {
+	for _, holder := range holders {
+		if listenerAddressesMayCollide(configuredAddr, holder.IP) {
+			return holder, true
+		}
+	}
+	return procListener{}, false
+}
+
+func listenerAddressesMayCollide(configuredAddr string, holderIP net.IP) bool {
+	host, _, err := net.SplitHostPort(configuredAddr)
+	if err != nil {
+		// portFromListenAddr already parsed this address. If that changes,
+		// be conservative and surface the possible collision.
+		return true
+	}
+	if host == "" {
+		return true
+	}
+	configuredIP := net.ParseIP(host)
+	if configuredIP == nil {
+		// Hostnames can resolve to the holder address. Avoid a false "free".
+		return true
+	}
+	if holderIP == nil {
+		return true
+	}
+	configuredIs4 := configuredIP.To4() != nil
+	holderIs4 := holderIP.To4() != nil
+	if configuredIP.IsUnspecified() {
+		// 0.0.0.0 only overlaps IPv4 holders. :: may overlap IPv4 holders
+		// on dual-stack sockets, so keep that side conservative.
+		return !configuredIs4 || holderIs4
+	}
+	if holderIP.IsUnspecified() {
+		// An existing 0.0.0.0 listener does not block a later explicit IPv6
+		// loopback bind; an existing :: listener might be dual-stack.
+		return !holderIs4 || configuredIs4
+	}
+	if configuredIs4 != holderIs4 {
+		return false
+	}
+	return configuredIP.Equal(holderIP)
+}
+
+// truncateCmdline keeps doctor output readable when the conflicting process
+// has a long argv.
+func truncateCmdline(s string) string {
+	const maxLen = 120
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "(empty)"
+	}
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "…"
+}
+
+// readProcCmdline reads /proc/<pid>/cmdline and converts NUL separators back
+// to spaces. Returns "" on error.
+func readProcCmdline(pid int) string {
+	path := filepath.Join("/proc", strconv.Itoa(pid), "cmdline")
+	data, err := os.ReadFile(path) // #nosec G304 -- /proc path constructed from numeric PID
+	if err != nil {
+		return ""
+	}
+	return strings.ReplaceAll(strings.TrimRight(string(data), "\x00"), "\x00", " ")
+}

--- a/internal/cli/diag/portcheck_linux.go
+++ b/internal/cli/diag/portcheck_linux.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package diag
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// enumerateListenerHolders builds a map of TCP listen port -> holding
+// process by reading /proc/net/tcp and /proc/net/tcp6 (the inode column),
+// then walking /proc/<pid>/fd/ to map inodes back to PIDs.
+//
+// The check is best-effort. Running without privileges to read another
+// user's /proc/<pid>/fd entries leaves those holders identified by inode
+// but unmapped (PID=0); callers surface that as "another process — re-run
+// as root to identify".
+func enumerateListenerHolders() (map[uint16][]procListener, error) {
+	holders := make(map[uint16][]procListener)
+
+	// First pass: read /proc/net/tcp[6] for ports in LISTEN state with
+	// their backing socket inodes. The kernel format documented in
+	// proc(5): hex remote/local addresses, state column at index 3,
+	// inode column at index 9.
+	for _, file := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
+		if err := parseProcNetTCP(file, holders); err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("parse %s: %w", file, err)
+		}
+	}
+	if len(holders) == 0 {
+		// No listen sockets in /proc/net/tcp[6] — unusual but possible in
+		// minimal containers. Return empty map (callers treat as "no
+		// holder," not as an error) so configured listeners are reported
+		// as free.
+		return holders, nil
+	}
+
+	// Second pass: invert /proc/<pid>/fd/ symlinks to map socket inode -> PID.
+	// Skipping unreadable entries is intentional; running without root
+	// privileges restricts visibility to PIDs the calling user owns.
+	matchInodeToPID(holders)
+	return holders, nil
+}
+
+// parseProcNetTCP appends listening sockets from one /proc/net/tcp* file
+// into holders. The local-port column (split[1]) is in the form
+// "ADDR:PORT" with port encoded as 4 uppercase hex digits.
+func parseProcNetTCP(path string, holders map[uint16][]procListener) error {
+	const tcpStateListen = "0A" // hex 10, LISTEN per include/net/tcp_states.h
+	f, err := os.Open(path)     // #nosec G304 -- /proc path is constant
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	first := true
+	for scanner.Scan() {
+		if first {
+			first = false // header row
+			continue
+		}
+		fields := strings.Fields(scanner.Text())
+		// Required columns: local_address, state (index 3), inode (index 9).
+		if len(fields) < 10 {
+			continue
+		}
+		if fields[3] != tcpStateListen {
+			continue
+		}
+		// fields[1] is "ADDR:PORT" hex. Take last 4 chars (port).
+		localCol := fields[1]
+		idx := strings.LastIndex(localCol, ":")
+		if idx < 0 || idx+1 >= len(localCol) {
+			continue
+		}
+		ip := parseProcNetIP(localCol[:idx], strings.HasSuffix(path, "tcp6"))
+		port64, err := strconv.ParseUint(localCol[idx+1:], 16, 16)
+		if err != nil {
+			continue
+		}
+		inode, err := strconv.ParseUint(fields[9], 10, 64)
+		if err != nil || inode == 0 {
+			continue
+		}
+		// Record the inode keyed under the holder slot. PID is filled in
+		// by the second pass; we encode the inode in Cmdline temporarily
+		// so the inode->PID step can find it back.
+		port := uint16(port64)
+		holders[port] = append(holders[port], procListener{Port: port, IP: ip, Cmdline: "inode:" + strconv.FormatUint(inode, 10)})
+	}
+	return scanner.Err()
+}
+
+func parseProcNetIP(hexAddr string, isIPv6 bool) net.IP {
+	raw, err := hex.DecodeString(hexAddr)
+	if err != nil {
+		return nil
+	}
+	if !isIPv6 {
+		if len(raw) != net.IPv4len {
+			return nil
+		}
+		return net.IPv4(raw[3], raw[2], raw[1], raw[0])
+	}
+	if len(raw) != net.IPv6len {
+		return nil
+	}
+	// /proc/net/tcp6 prints each 32-bit word in host byte order. Convert
+	// little-endian host words back to network byte order for net.IP.
+	if binary.NativeEndian.Uint16([]byte{1, 0}) == 1 {
+		for i := 0; i < len(raw); i += 4 {
+			raw[i], raw[i+3] = raw[i+3], raw[i]
+			raw[i+1], raw[i+2] = raw[i+2], raw[i+1]
+		}
+	}
+	return net.IP(raw)
+}
+
+// matchInodeToPID walks /proc/<pid>/fd/ and looks for symlink targets of
+// the form "socket:[INODE]". When we find one whose inode matches a
+// holder we recorded from /proc/net/tcp, we replace the placeholder
+// Cmdline with the real PID + cmdline. PIDs the calling user cannot
+// readdir on are silently skipped.
+func matchInodeToPID(holders map[uint16][]procListener) {
+	// Build inverse map: inode -> port for the holders we still need PIDs for.
+	type holderRef struct {
+		port uint16
+		idx  int
+	}
+	pending := make(map[uint64]holderRef, len(holders))
+	for port, portHolders := range holders {
+		for i, h := range portHolders {
+			if strings.HasPrefix(h.Cmdline, "inode:") {
+				inodeStr := strings.TrimPrefix(h.Cmdline, "inode:")
+				n, err := strconv.ParseUint(inodeStr, 10, 64)
+				if err == nil {
+					pending[n] = holderRef{port: port, idx: i}
+				}
+			}
+		}
+	}
+	if len(pending) == 0 {
+		return
+	}
+
+	procEntries, err := os.ReadDir("/proc")
+	if err != nil {
+		return
+	}
+	for _, ent := range procEntries {
+		if !ent.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(ent.Name())
+		if err != nil {
+			continue
+		}
+		fdDir := filepath.Join("/proc", ent.Name(), "fd")
+		fdEntries, err := os.ReadDir(fdDir)
+		if err != nil {
+			continue // typical when run as non-root against another user's process
+		}
+		for _, fd := range fdEntries {
+			link, err := os.Readlink(filepath.Join(fdDir, fd.Name()))
+			if err != nil {
+				continue
+			}
+			if !strings.HasPrefix(link, "socket:[") {
+				continue
+			}
+			inodeStr := strings.TrimSuffix(strings.TrimPrefix(link, "socket:["), "]")
+			inode, err := strconv.ParseUint(inodeStr, 10, 64)
+			if err != nil {
+				continue
+			}
+			if ref, ok := pending[inode]; ok {
+				cmdline := readProcCmdline(pid)
+				holders[ref.port][ref.idx].PID = pid
+				holders[ref.port][ref.idx].Cmdline = cmdline
+				delete(pending, inode)
+			}
+		}
+		if len(pending) == 0 {
+			return
+		}
+	}
+	// Any holder still keyed by inode is one whose PID we couldn't see —
+	// reset its Cmdline to empty so callers surface "unknown holder (PID 0)"
+	// rather than the internal inode marker.
+	for port, portHolders := range holders {
+		for i, h := range portHolders {
+			if strings.HasPrefix(h.Cmdline, "inode:") {
+				holders[port][i].PID = 0
+				holders[port][i].Cmdline = ""
+			}
+		}
+	}
+}

--- a/internal/cli/diag/portcheck_linux_test.go
+++ b/internal/cli/diag/portcheck_linux_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package diag
+
+import (
+	"net"
+	"testing"
+)
+
+func TestParseProcNetIP_IPv4(t *testing.T) {
+	// /proc/net/tcp encodes IPv4 as 8 uppercase hex digits in REVERSE
+	// host byte order: 127.0.0.1 -> 0100007F, 0.0.0.0 -> 00000000.
+	tests := []struct {
+		hex  string
+		want string // dotted-quad
+	}{
+		{"0100007F", "127.0.0.1"},
+		{"00000000", "0.0.0.0"},
+		// 203.0.113.1 is RFC 5737 TEST-NET-3 (documentation block).
+		// Bytes CB.00.71.01 stored in /proc's little-endian form become 017100CB.
+		{"017100CB", "203.0.113.1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.hex, func(t *testing.T) {
+			got := parseProcNetIP(tc.hex, false)
+			if got == nil {
+				t.Fatalf("got nil IP for %q", tc.hex)
+			}
+			if got.String() != tc.want {
+				t.Errorf("parseProcNetIP(%q) = %s, want %s", tc.hex, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseProcNetIP_IPv4_BadHex(t *testing.T) {
+	// Wrong length must return nil (not panic, not stretched).
+	if got := parseProcNetIP("FF", false); got != nil {
+		t.Errorf("short hex got %v, want nil", got)
+	}
+	if got := parseProcNetIP("XYZ12345", false); got != nil {
+		t.Errorf("non-hex got %v, want nil", got)
+	}
+}
+
+func TestParseProcNetIP_IPv6_BadLength(t *testing.T) {
+	if got := parseProcNetIP("DEADBEEF", true); got != nil {
+		t.Errorf("short IPv6 hex got %v, want nil", got)
+	}
+}
+
+func TestParseProcNetIP_IPv6_AnyAddr(t *testing.T) {
+	// All-zero IPv6 = :: (the unspecified address).
+	got := parseProcNetIP("00000000000000000000000000000000", true)
+	if got == nil {
+		t.Fatal("got nil for all-zero IPv6")
+	}
+	if !got.IsUnspecified() {
+		t.Errorf("got %v, want unspecified (::)", got)
+	}
+}
+
+func TestEnumerateListenerHolders_Smoke(t *testing.T) {
+	// Smoke test: on a real Linux host the function should succeed and
+	// return some holders (the test process inherits a bunch of inherited
+	// listeners normally, but a fresh runner may have none — both are valid).
+	holders, err := enumerateListenerHolders()
+	if err != nil {
+		t.Fatalf("enumerateListenerHolders: %v", err)
+	}
+	// Every entry should have a valid Port; PIDs may be 0 when running
+	// without privilege to readdir /proc/<other-uid-pid>/fd.
+	for port, list := range holders {
+		if port == 0 {
+			t.Errorf("holder at port 0 is invalid")
+		}
+		for _, h := range list {
+			if h.Port != port {
+				t.Errorf("holder Port=%d under map key %d", h.Port, port)
+			}
+		}
+	}
+}
+
+func TestListenerAddressesMayCollide(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfgAddr  string
+		holderIP net.IP
+		want     bool
+	}{
+		{"unparseable-address-conservative", "not-a-host-port", net.ParseIP("127.0.0.1"), true},
+		{"empty-host-conservative", ":8888", net.ParseIP("127.0.0.1"), true},
+		{"hostname-cant-resolve-conservative", "localhost:8888", net.ParseIP("127.0.0.1"), true},
+		{"nil-holder-conservative", "127.0.0.1:8888", nil, true},
+		{"ipv4-loopback-explicit-match", "127.0.0.1:8888", net.ParseIP("127.0.0.1"), true},
+		{"ipv4-loopback-explicit-mismatch", "127.0.0.1:8888", net.ParseIP("127.0.0.2"), false},
+		{"ipv4-wildcard-collides-with-loopback", "0.0.0.0:8888", net.ParseIP("127.0.0.1"), true},
+		{"ipv4-wildcard-does-not-collide-with-ipv6-explicit", "0.0.0.0:8888", net.ParseIP("::1"), false},
+		{"ipv6-wildcard-may-collide-with-ipv4-explicit", "[::]:8888", net.ParseIP("127.0.0.1"), true},
+		{"ipv6-explicit-no-collide-with-ipv4-wildcard", "[::1]:8888", net.ParseIP("0.0.0.0"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := listenerAddressesMayCollide(tc.cfgAddr, tc.holderIP)
+			if got != tc.want {
+				t.Errorf("listenerAddressesMayCollide(%q, %v) = %v, want %v", tc.cfgAddr, tc.holderIP, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/diag/portcheck_other.go
+++ b/internal/cli/diag/portcheck_other.go
@@ -1,0 +1,16 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package diag
+
+import "errors"
+
+// enumerateListenerHolders is a no-op on non-Linux platforms because the
+// implementation reads /proc/net/tcp + /proc/<pid>/fd, neither of which
+// exists on macOS or Windows. Doctor surfaces this as an info-tier
+// "unavailable on this platform" check rather than a failure.
+func enumerateListenerHolders() (map[uint16][]procListener, error) {
+	return nil, errors.New("port-collision check requires Linux /proc; not available on this platform")
+}

--- a/internal/cli/diag/portcheck_test.go
+++ b/internal/cli/diag/portcheck_test.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package diag
+
+import (
+	"context"
+	"net"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestPortFromListenAddr(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		want    uint16
+		wantErr bool
+	}{
+		{"bare-port", ":8888", 8888, false},
+		{"loopback-port", "127.0.0.1:9090", 9090, false},
+		{"ipv6-loopback", "[::1]:8080", 8080, false},
+		{"empty", "", 0, true},
+		{"bad-format", "not-a-host-port", 0, true},
+		{"non-numeric-port", "127.0.0.1:abc", 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := portFromListenAddr(tc.addr)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("port = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCollectConfiguredListeners(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.FetchProxy.Listen = ":8888"
+	cfg.KillSwitch.APIListen = "127.0.0.1:9090"
+	cfg.MetricsListen = "" // skipped because empty
+	cfg.ReverseProxy.Listen = "127.0.0.1:8892"
+
+	got := collectConfiguredListeners(cfg)
+	labels := make([]string, len(got))
+	for i, l := range got {
+		labels[i] = l.Label
+	}
+	wantLabels := []string{"fetch_proxy.listen", "kill_switch.api_listen", "reverse_proxy.listen"}
+	if len(labels) != len(wantLabels) {
+		t.Fatalf("labels = %v, want %v", labels, wantLabels)
+	}
+	for i, l := range labels {
+		if l != wantLabels[i] {
+			t.Errorf("labels[%d] = %q, want %q", i, l, wantLabels[i])
+		}
+	}
+}
+
+func TestCheckPortsReport_NoListeners(t *testing.T) {
+	report := checkPortsReport(&config.Config{})
+	if len(report) != 1 {
+		t.Fatalf("len(report) = %d, want 1", len(report))
+	}
+	if report[0].Status != doctorStatusInfo {
+		t.Errorf("status = %q, want %q", report[0].Status, doctorStatusInfo)
+	}
+}
+
+// TestCheckPortsReport_DetectsOwnListener verifies that when this test process
+// holds a TCP listener on a port that the cfg references, the port check
+// surfaces an OK status (because the holding PID matches os.Getpid()) rather
+// than a collision warning. Linux-only because /proc is the data source.
+func TestCheckPortsReport_DetectsOwnListener(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("requires Linux /proc; current GOOS=%s", runtime.GOOS)
+	}
+	// Bind a real listener so /proc/net/tcp will show us in LISTEN state.
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	host, portStr, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	if _, err := strconv.Atoi(portStr); err != nil {
+		t.Fatalf("port not numeric: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.FetchProxy.Listen = net.JoinHostPort(host, portStr)
+	checks := checkPortsReport(cfg)
+
+	var found bool
+	for _, c := range checks {
+		if !strings.HasPrefix(c.Name, "port_collisions:fetch_proxy.listen") {
+			continue
+		}
+		found = true
+		// Either OK (own process) or warn (when /proc enumerates a different
+		// PID first, e.g. when running as a different uid). Both are valid
+		// signals that the check is functioning. A "free" report would mean
+		// the kernel didn't see our listener, which is the test failure mode.
+		if c.Status == doctorStatusOK && strings.Contains(c.Detail, "held by this pipelock process") {
+			return
+		}
+		if c.Status == doctorStatusWarn && strings.Contains(c.Detail, "is held by another process") {
+			// Acceptable: /proc-restricted execution can't tie the inode to
+			// our own PID. The check still surfaces the collision.
+			return
+		}
+		t.Errorf("unexpected check for fetch_proxy.listen: status=%q detail=%q", c.Status, c.Detail)
+	}
+	if !found {
+		t.Errorf("no port_collisions check for fetch_proxy.listen; got %d checks", len(checks))
+	}
+}
+
+func TestEvaluateListenerCollision_RespectsListenAddress(t *testing.T) {
+	tests := []struct {
+		name           string
+		configuredAddr string
+		holderIP       net.IP
+		wantStatus     string
+	}{
+		{
+			name:           "different loopback address is free",
+			configuredAddr: "127.0.0.1:8888",
+			holderIP:       net.ParseIP("127.0.0.2"),
+			wantStatus:     doctorStatusOK,
+		},
+		{
+			name:           "holder wildcard collides with specific address",
+			configuredAddr: "127.0.0.1:8888",
+			holderIP:       net.ParseIP("0.0.0.0"),
+			wantStatus:     doctorStatusWarn,
+		},
+		{
+			name:           "configured wildcard collides with specific holder",
+			configuredAddr: ":8888",
+			holderIP:       net.ParseIP("127.0.0.2"),
+			wantStatus:     doctorStatusWarn,
+		},
+		{
+			name:           "same specific address collides",
+			configuredAddr: "127.0.0.1:8888",
+			holderIP:       net.ParseIP("127.0.0.1"),
+			wantStatus:     doctorStatusWarn,
+		},
+		{
+			name:           "different IP families are free",
+			configuredAddr: "[::1]:8888",
+			holderIP:       net.ParseIP("127.0.0.1"),
+			wantStatus:     doctorStatusOK,
+		},
+		{
+			name:           "ipv4 wildcard does not collide with explicit ipv6",
+			configuredAddr: "[::1]:8888",
+			holderIP:       net.ParseIP("0.0.0.0"),
+			wantStatus:     doctorStatusOK,
+		},
+		{
+			name:           "ipv6 wildcard may collide with explicit ipv4",
+			configuredAddr: "127.0.0.1:8888",
+			holderIP:       net.ParseIP("::"),
+			wantStatus:     doctorStatusWarn,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			check := evaluateListenerCollision(
+				configuredListener{Label: "fetch_proxy.listen", Address: tc.configuredAddr},
+				8888,
+				map[uint16][]procListener{
+					8888: {{Port: 8888, IP: tc.holderIP, PID: os.Getpid() + 1000000, Cmdline: "holder"}},
+				},
+			)
+			if check.Status != tc.wantStatus {
+				t.Fatalf("status = %q, want %q; detail=%q", check.Status, tc.wantStatus, check.Detail)
+			}
+		})
+	}
+}
+
+func TestTruncateCmdline(t *testing.T) {
+	short := "/usr/bin/short-cmd --flag"
+	if got := truncateCmdline(short); got != short {
+		t.Errorf("short cmd was truncated: %q", got)
+	}
+	long := strings.Repeat("argument ", 30)
+	got := truncateCmdline(long)
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("long cmd was not truncated with ellipsis: %q", got)
+	}
+	if got := truncateCmdline("   "); got != "(empty)" {
+		t.Errorf("whitespace cmd = %q, want (empty)", got)
+	}
+}
+
+func TestReadProcCmdline_NonexistentPID(t *testing.T) {
+	// PID 0 is the swapper/idle thread and its cmdline is unreadable.
+	// readProcCmdline returns "" on any read error.
+	got := readProcCmdline(0)
+	if got != "" {
+		t.Errorf("readProcCmdline(0) = %q, want empty", got)
+	}
+	// Also check a clearly-bogus PID.
+	got = readProcCmdline(os.Getpid() + 999999)
+	if got != "" {
+		t.Errorf("readProcCmdline(huge) = %q, want empty", got)
+	}
+}

--- a/internal/cli/diag/verify_install.go
+++ b/internal/cli/diag/verify_install.go
@@ -343,7 +343,7 @@ func EnableDefaultVerifyProofs(cfg *config.Config) (func(), error) {
 	// anything else operators might drop here.
 	scanContent := true
 	cfg.FileSentry.Enabled = true
-	cfg.FileSentry.WatchPaths = []string{verifyDir}
+	cfg.FileSentry.WatchPaths = []config.WatchPath{{Path: verifyDir}}
 	cfg.FileSentry.ScanContent = &scanContent
 
 	exe, err := os.Executable()
@@ -613,7 +613,7 @@ func checkFileSentry(env *VerifyEnv) VerifyResult {
 	defer func() { _ = os.RemoveAll(dir) }()
 
 	fsCfg := env.Cfg.FileSentry
-	fsCfg.WatchPaths = []string{dir}
+	fsCfg.WatchPaths = []config.WatchPath{{Path: dir}}
 	if fsCfg.ScanContent == nil {
 		scanContent := true
 		fsCfg.ScanContent = &scanContent

--- a/internal/cli/diag/verify_install.go
+++ b/internal/cli/diag/verify_install.go
@@ -343,7 +343,7 @@ func EnableDefaultVerifyProofs(cfg *config.Config) (func(), error) {
 	// anything else operators might drop here.
 	scanContent := true
 	cfg.FileSentry.Enabled = true
-	cfg.FileSentry.WatchPaths = []config.WatchPath{{Path: verifyDir}}
+	cfg.FileSentry.WatchPaths = []config.WatchPath{{Path: verifyDir, Required: true}}
 	cfg.FileSentry.ScanContent = &scanContent
 
 	exe, err := os.Executable()
@@ -613,7 +613,7 @@ func checkFileSentry(env *VerifyEnv) VerifyResult {
 	defer func() { _ = os.RemoveAll(dir) }()
 
 	fsCfg := env.Cfg.FileSentry
-	fsCfg.WatchPaths = []config.WatchPath{{Path: dir}}
+	fsCfg.WatchPaths = []config.WatchPath{{Path: dir, Required: true}}
 	if fsCfg.ScanContent == nil {
 		scanContent := true
 		fsCfg.ScanContent = &scanContent

--- a/internal/cli/runtime/bind_hint.go
+++ b/internal/cli/runtime/bind_hint.go
@@ -15,6 +15,12 @@ import (
 // fd exhaustion) get the original wrap unchanged because the doctor port
 // check would not help diagnose them.
 //
+// Use this only for listeners that are reachable from *config.Config (and
+// therefore from diag's collectConfiguredListeners). Listeners constructed
+// purely from runtime/CLI state (mcp_listen, agents[*].listen) should call
+// wrapBindErrorNoDoctorHint instead, because doctor --check-ports cannot
+// inspect them; pointing operators at it would be a dead-end hint.
+//
 // label is the config knob name the operator wrote ("fetch_proxy.listen",
 // "kill_switch.api_listen", ...) so they can see which knob to retune.
 // addr is the literal listen address that failed.
@@ -24,6 +30,18 @@ func wrapBindError(label, addr string, cause error) error {
 	}
 	if errors.Is(cause, syscall.EADDRINUSE) {
 		return fmt.Errorf("%s bind %s: %w\nhint: run `pipelock doctor --check-ports --config <path>` to identify which process holds %s", label, addr, cause, addr)
+	}
+	return fmt.Errorf("%s bind %s: %w", label, addr, cause)
+}
+
+// wrapBindErrorNoDoctorHint mirrors wrapBindError without the doctor
+// port-check hint. Use this for runtime-only listeners (mcp_listen,
+// agents[*].listen) that diag.collectConfiguredListeners does not look at,
+// so the doctor cannot actually identify the conflicting process there.
+// Hinting operators at a tool that will report no info is dead-end UX.
+func wrapBindErrorNoDoctorHint(label, addr string, cause error) error {
+	if cause == nil {
+		return nil
 	}
 	return fmt.Errorf("%s bind %s: %w", label, addr, cause)
 }

--- a/internal/cli/runtime/bind_hint.go
+++ b/internal/cli/runtime/bind_hint.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+)
+
+// wrapBindError annotates a bind/listen failure with a hint pointing at the
+// pipelock doctor port-check flag, but only when the underlying cause is
+// EADDRINUSE. Other listen errors (permission denied, address unavailable,
+// fd exhaustion) get the original wrap unchanged because the doctor port
+// check would not help diagnose them.
+//
+// label is the config knob name the operator wrote ("fetch_proxy.listen",
+// "kill_switch.api_listen", ...) so they can see which knob to retune.
+// addr is the literal listen address that failed.
+func wrapBindError(label, addr string, cause error) error {
+	if cause == nil {
+		return nil
+	}
+	if errors.Is(cause, syscall.EADDRINUSE) {
+		return fmt.Errorf("%s bind %s: %w\nhint: run `pipelock doctor --check-ports --config <path>` to identify which process holds %s", label, addr, cause, addr)
+	}
+	return fmt.Errorf("%s bind %s: %w", label, addr, cause)
+}

--- a/internal/cli/runtime/bind_hint_test.go
+++ b/internal/cli/runtime/bind_hint_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestWrapBindError(t *testing.T) {
+	tests := []struct {
+		name       string
+		label      string
+		addr       string
+		cause      error
+		wantNil    bool
+		wantSubstr []string
+		wantHint   bool
+	}{
+		{
+			name:    "nil-cause-returns-nil",
+			label:   "fetch_proxy.listen",
+			addr:    ":8888",
+			cause:   nil,
+			wantNil: true,
+		},
+		{
+			name:       "eaddrinuse-appends-doctor-hint",
+			label:      "fetch_proxy.listen",
+			addr:       "127.0.0.1:8888",
+			cause:      fmt.Errorf("wrapper: %w", syscall.EADDRINUSE),
+			wantSubstr: []string{"fetch_proxy.listen bind 127.0.0.1:8888", "doctor --check-ports"},
+			wantHint:   true,
+		},
+		{
+			name:       "permission-denied-no-hint",
+			label:      "metrics_listen",
+			addr:       ":9090",
+			cause:      syscall.EACCES,
+			wantSubstr: []string{"metrics_listen bind :9090"},
+			wantHint:   false,
+		},
+		{
+			name:       "wrapped-eaddrinuse-still-recognized",
+			label:      "scan_api.listen",
+			addr:       "[::1]:7777",
+			cause:      fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", syscall.EADDRINUSE)),
+			wantSubstr: []string{"scan_api.listen bind [::1]:7777", "doctor --check-ports"},
+			wantHint:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := wrapBindError(tc.label, tc.addr, tc.cause)
+			if tc.wantNil {
+				if err != nil {
+					t.Fatalf("got err=%v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("got nil error, want wrapped")
+			}
+			// EADDRINUSE must remain unwrappable so callers can errors.Is it.
+			if tc.wantHint && !errors.Is(err, syscall.EADDRINUSE) {
+				t.Errorf("errors.Is(err, EADDRINUSE) = false; want true so callers can still detect the cause")
+			}
+			for _, s := range tc.wantSubstr {
+				if !strings.Contains(err.Error(), s) {
+					t.Errorf("error %q does not contain %q", err.Error(), s)
+				}
+			}
+			hasHint := strings.Contains(err.Error(), "doctor --check-ports")
+			if hasHint != tc.wantHint {
+				t.Errorf("hint present = %v, want %v; err=%q", hasHint, tc.wantHint, err.Error())
+			}
+		})
+	}
+}
+
+func TestWrapBindErrorNoDoctorHint(t *testing.T) {
+	// Runtime-only listeners (mcp_listen, agents[*].listen) get the wrap
+	// without the doctor hint, since doctor --check-ports cannot inspect
+	// them. Verify both EADDRINUSE and other causes get the same format
+	// (no hint either way).
+	tests := []struct {
+		name    string
+		cause   error
+		wantNil bool
+	}{
+		{"nil-cause", nil, true},
+		{"eaddrinuse", syscall.EADDRINUSE, false},
+		{"permission-denied", syscall.EACCES, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := wrapBindErrorNoDoctorHint("mcp_listen", "127.0.0.1:12345", tc.cause)
+			if tc.wantNil {
+				if err != nil {
+					t.Fatalf("got err=%v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("got nil error, want wrapped")
+			}
+			if !strings.Contains(err.Error(), "mcp_listen bind 127.0.0.1:12345") {
+				t.Errorf("error %q missing label/addr prefix", err.Error())
+			}
+			if strings.Contains(err.Error(), "doctor --check-ports") {
+				t.Errorf("error %q must NOT contain doctor hint; doctor cannot inspect runtime-only listeners", err.Error())
+			}
+		})
+	}
+}

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -288,7 +288,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 		apiLn, lnErr := (&net.ListenConfig{}).Listen(ctx, "tcp", cfg.KillSwitch.APIListen)
 		if lnErr != nil {
-			err := fmt.Errorf("kill switch API bind %s: %w", cfg.KillSwitch.APIListen, lnErr)
+			err := wrapBindError("kill_switch.api_listen", cfg.KillSwitch.APIListen, lnErr)
 			if s.sentry != nil {
 				s.sentry.CaptureError(err)
 			}
@@ -321,7 +321,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 		metricsLn, lnErr := (&net.ListenConfig{}).Listen(ctx, "tcp", cfg.MetricsListen)
 		if lnErr != nil {
-			err := fmt.Errorf("metrics bind %s: %w", cfg.MetricsListen, lnErr)
+			err := wrapBindError("metrics_listen", cfg.MetricsListen, lnErr)
 			if s.sentry != nil {
 				s.sentry.CaptureError(err)
 			}
@@ -361,7 +361,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 		scanAPILn, lnErr := (&net.ListenConfig{}).Listen(ctx, "tcp", cfg.ScanAPI.Listen)
 		if lnErr != nil {
-			return fmt.Errorf("scan API bind %s: %w", cfg.ScanAPI.Listen, lnErr)
+			return wrapBindError("scan_api.listen", cfg.ScanAPI.Listen, lnErr)
 		}
 		if cfg.ScanAPI.ConnectionLimit > 0 {
 			scanAPILn = netutil.LimitListener(scanAPILn, cfg.ScanAPI.ConnectionLimit)
@@ -480,7 +480,7 @@ func (s *Server) Start(ctx context.Context) error {
 		// would be silently swallowed until shutdown.
 		mcpLn, lnErr := (&net.ListenConfig{}).Listen(ctx, "tcp", s.opts.MCPListen)
 		if lnErr != nil {
-			err := fmt.Errorf("MCP listener bind %s: %w", s.opts.MCPListen, lnErr)
+			err := wrapBindError("mcp_listen", s.opts.MCPListen, lnErr)
 			if s.sentry != nil {
 				s.sentry.CaptureError(err)
 			}
@@ -582,7 +582,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 		rpLn, lnErr := (&net.ListenConfig{}).Listen(ctx, "tcp", cfg.ReverseProxy.Listen)
 		if lnErr != nil {
-			err := fmt.Errorf("reverse proxy bind %s: %w", cfg.ReverseProxy.Listen, lnErr)
+			err := wrapBindError("reverse_proxy.listen", cfg.ReverseProxy.Listen, lnErr)
 			if s.sentry != nil {
 				s.sentry.CaptureError(err)
 			}
@@ -632,7 +632,7 @@ func (s *Server) Start(ctx context.Context) error {
 		for addr, name := range agentPorts {
 			ln, lnErr := (&net.ListenConfig{}).Listen(ctx, "tcp", addr)
 			if lnErr != nil {
-				err := fmt.Errorf("agent %q listener bind %s: %w", name, addr, lnErr)
+				err := wrapBindError(fmt.Sprintf("agents[%s].listen", name), addr, lnErr)
 				if s.sentry != nil {
 					s.sentry.CaptureError(err)
 				}
@@ -685,6 +685,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Start the fetch proxy (blocks until context cancelled or error).
 	if err := s.proxy.Start(ctx); err != nil {
+		err = wrapBindError("fetch_proxy.listen", cfg.FetchProxy.Listen, err)
 		if s.sentry != nil {
 			s.sentry.CaptureError(err)
 		}

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -361,7 +361,11 @@ func (s *Server) Start(ctx context.Context) error {
 
 		scanAPILn, lnErr := (&net.ListenConfig{}).Listen(ctx, "tcp", cfg.ScanAPI.Listen)
 		if lnErr != nil {
-			return wrapBindError("scan_api.listen", cfg.ScanAPI.Listen, lnErr)
+			err := wrapBindError("scan_api.listen", cfg.ScanAPI.Listen, lnErr)
+			if s.sentry != nil {
+				s.sentry.CaptureError(err)
+			}
+			return err
 		}
 		if cfg.ScanAPI.ConnectionLimit > 0 {
 			scanAPILn = netutil.LimitListener(scanAPILn, cfg.ScanAPI.ConnectionLimit)
@@ -480,7 +484,7 @@ func (s *Server) Start(ctx context.Context) error {
 		// would be silently swallowed until shutdown.
 		mcpLn, lnErr := (&net.ListenConfig{}).Listen(ctx, "tcp", s.opts.MCPListen)
 		if lnErr != nil {
-			err := wrapBindError("mcp_listen", s.opts.MCPListen, lnErr)
+			err := wrapBindErrorNoDoctorHint("mcp_listen", s.opts.MCPListen, lnErr)
 			if s.sentry != nil {
 				s.sentry.CaptureError(err)
 			}
@@ -632,7 +636,7 @@ func (s *Server) Start(ctx context.Context) error {
 		for addr, name := range agentPorts {
 			ln, lnErr := (&net.ListenConfig{}).Listen(ctx, "tcp", addr)
 			if lnErr != nil {
-				err := wrapBindError(fmt.Sprintf("agents[%s].listen", name), addr, lnErr)
+				err := wrapBindErrorNoDoctorHint(fmt.Sprintf("agents[%s].listen", name), addr, lnErr)
 				if s.sentry != nil {
 					s.sentry.CaptureError(err)
 				}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -738,7 +738,7 @@ func TestValidate_FileSentryEmptyWatchPaths(t *testing.T) {
 func TestValidate_FileSentryValid(t *testing.T) {
 	cfg := Defaults()
 	cfg.FileSentry.Enabled = true
-	cfg.FileSentry.WatchPaths = []string{"."}
+	cfg.FileSentry.WatchPaths = []WatchPath{{Path: "."}}
 	if err := cfg.Validate(); err != nil {
 		t.Errorf("valid file_sentry should not error: %v", err)
 	}
@@ -756,7 +756,7 @@ func TestValidate_FileSentryDisabledNoWatchPaths(t *testing.T) {
 func TestValidate_FileSentryEmptyStringInWatchPaths(t *testing.T) {
 	cfg := Defaults()
 	cfg.FileSentry.Enabled = true
-	cfg.FileSentry.WatchPaths = []string{""}
+	cfg.FileSentry.WatchPaths = []WatchPath{{Path: ""}}
 	if err := cfg.Validate(); err == nil {
 		t.Error("expected error for empty string in watch_paths")
 	}
@@ -765,7 +765,7 @@ func TestValidate_FileSentryEmptyStringInWatchPaths(t *testing.T) {
 func TestValidate_FileSentryActionInvalid(t *testing.T) {
 	cfg := Defaults()
 	cfg.FileSentry.Enabled = true
-	cfg.FileSentry.WatchPaths = []string{"."}
+	cfg.FileSentry.WatchPaths = []WatchPath{{Path: "."}}
 	cfg.FileSentry.Action = "panic"
 	if err := cfg.Validate(); err == nil {
 		t.Error("expected error for invalid file_sentry.action")
@@ -776,7 +776,7 @@ func TestValidate_FileSentryActionWarnOrBlockOrEmpty(t *testing.T) {
 	for _, action := range []string{"", ActionWarn, ActionBlock} {
 		cfg := Defaults()
 		cfg.FileSentry.Enabled = true
-		cfg.FileSentry.WatchPaths = []string{"."}
+		cfg.FileSentry.WatchPaths = []WatchPath{{Path: "."}}
 		cfg.FileSentry.Action = action
 		if err := cfg.Validate(); err != nil {
 			t.Errorf("action %q should be valid: %v", action, err)
@@ -988,13 +988,13 @@ file_sentry:
 	}
 
 	for _, wp := range cfg.FileSentry.WatchPaths {
-		if !filepath.IsAbs(wp) {
-			t.Errorf("watch_path %q should be absolute after Load", wp)
+		if !filepath.IsAbs(wp.Path) {
+			t.Errorf("watch_path %q should be absolute after Load", wp.Path)
 		}
 		// Must be rooted under the config directory, not CWD.
-		rel, relErr := filepath.Rel(dir, wp)
+		rel, relErr := filepath.Rel(dir, wp.Path)
 		if relErr != nil || strings.HasPrefix(rel, "..") {
-			t.Errorf("watch_path %q is not under config dir %q (rel=%q)", wp, dir, rel)
+			t.Errorf("watch_path %q is not under config dir %q (rel=%q)", wp.Path, dir, rel)
 		}
 	}
 }
@@ -1047,8 +1047,8 @@ file_sentry:
 	if err != nil {
 		t.Fatalf("Load: absolute path should be allowed, got: %v", err)
 	}
-	if cfg.FileSentry.WatchPaths[0] != outsideDir {
-		t.Errorf("expected %q, got %q", outsideDir, cfg.FileSentry.WatchPaths[0])
+	if cfg.FileSentry.WatchPaths[0].Path != outsideDir {
+		t.Errorf("expected %q, got %q", outsideDir, cfg.FileSentry.WatchPaths[0].Path)
 	}
 }
 
@@ -1084,8 +1084,8 @@ file_sentry:
 		t.Fatalf("Load: %v", err)
 	}
 	for _, wp := range cfg.FileSentry.WatchPaths {
-		if !filepath.IsAbs(wp) {
-			t.Errorf("watch_path %q should be absolute", wp)
+		if !filepath.IsAbs(wp.Path) {
+			t.Errorf("watch_path %q should be absolute", wp.Path)
 		}
 	}
 }
@@ -9912,7 +9912,7 @@ func TestValidateReload_FileSentryChanged(t *testing.T) {
 	old := Defaults()
 	updated := Defaults()
 	updated.FileSentry.Enabled = true
-	updated.FileSentry.WatchPaths = []string{"/tmp"}
+	updated.FileSentry.WatchPaths = []WatchPath{{Path: "/tmp"}}
 	warnings := ValidateReload(old, updated)
 	found := false
 	for _, w := range warnings {
@@ -9930,12 +9930,12 @@ func TestValidateReload_FileSentryBestEffortChanged(t *testing.T) {
 	old := Defaults()
 	old.FileSentry.Enabled = true
 	old.FileSentry.Action = ActionWarn
-	old.FileSentry.WatchPaths = []string{"/tmp"}
+	old.FileSentry.WatchPaths = []WatchPath{{Path: "/tmp"}}
 	updated := Defaults()
 	updated.FileSentry.Enabled = true
 	updated.FileSentry.BestEffort = true
 	updated.FileSentry.Action = ActionWarn
-	updated.FileSentry.WatchPaths = []string{"/tmp"}
+	updated.FileSentry.WatchPaths = []WatchPath{{Path: "/tmp"}}
 	warnings := ValidateReload(old, updated)
 	found := false
 	for _, w := range warnings {
@@ -9953,11 +9953,11 @@ func TestValidateReload_FileSentryActionChanged(t *testing.T) {
 	old := Defaults()
 	old.FileSentry.Enabled = true
 	old.FileSentry.Action = ActionWarn
-	old.FileSentry.WatchPaths = []string{"/tmp"}
+	old.FileSentry.WatchPaths = []WatchPath{{Path: "/tmp"}}
 	updated := Defaults()
 	updated.FileSentry.Enabled = true
 	updated.FileSentry.Action = ActionBlock
-	updated.FileSentry.WatchPaths = []string{"/tmp"}
+	updated.FileSentry.WatchPaths = []WatchPath{{Path: "/tmp"}}
 	warnings := ValidateReload(old, updated)
 	found := false
 	for _, w := range warnings {
@@ -9975,11 +9975,11 @@ func TestValidateReload_FileSentryWatchPathsChanged(t *testing.T) {
 	old := Defaults()
 	old.FileSentry.Enabled = true
 	old.FileSentry.Action = ActionWarn
-	old.FileSentry.WatchPaths = []string{"/tmp"}
+	old.FileSentry.WatchPaths = []WatchPath{{Path: "/tmp"}}
 	updated := Defaults()
 	updated.FileSentry.Enabled = true
 	updated.FileSentry.Action = ActionWarn
-	updated.FileSentry.WatchPaths = []string{"/tmp", "/var"}
+	updated.FileSentry.WatchPaths = []WatchPath{{Path: "/tmp"}, {Path: "/var"}}
 	warnings := ValidateReload(old, updated)
 	found := false
 	for _, w := range warnings {
@@ -9997,11 +9997,11 @@ func TestValidateReload_FileSentryUnchanged_NoWarning(t *testing.T) {
 	old := Defaults()
 	old.FileSentry.Enabled = true
 	old.FileSentry.Action = ActionWarn
-	old.FileSentry.WatchPaths = []string{"/tmp"}
+	old.FileSentry.WatchPaths = []WatchPath{{Path: "/tmp"}}
 	updated := Defaults()
 	updated.FileSentry.Enabled = true
 	updated.FileSentry.Action = ActionWarn
-	updated.FileSentry.WatchPaths = []string{"/tmp"}
+	updated.FileSentry.WatchPaths = []WatchPath{{Path: "/tmp"}}
 	warnings := ValidateReload(old, updated)
 	for _, w := range warnings {
 		if w.Field == fieldFileSentry {

--- a/internal/config/filesentry_changed_test.go
+++ b/internal/config/filesentry_changed_test.go
@@ -15,7 +15,7 @@ func TestFileSentryChanged(t *testing.T) {
 		c.FileSentry.Enabled = true
 		c.FileSentry.BestEffort = false
 		c.FileSentry.Action = ActionWarn
-		c.FileSentry.WatchPaths = []string{"/tmp/watch"}
+		c.FileSentry.WatchPaths = []WatchPath{{Path: "/tmp/watch"}}
 		c.FileSentry.ScanContent = boolPtrCfg(true)
 		c.FileSentry.IgnorePatterns = []string{"*.log"}
 		return c
@@ -48,12 +48,14 @@ func TestFileSentryChanged(t *testing.T) {
 		},
 		{
 			name:    "watch_paths changed",
-			modify:  func(c *Config) { c.FileSentry.WatchPaths = []string{"/tmp/other"} },
+			modify:  func(c *Config) { c.FileSentry.WatchPaths = []WatchPath{{Path: "/tmp/other"}} },
 			changed: true,
 		},
 		{
-			name:    "watch_paths added",
-			modify:  func(c *Config) { c.FileSentry.WatchPaths = append(c.FileSentry.WatchPaths, "/tmp/extra") },
+			name: "watch_paths added",
+			modify: func(c *Config) {
+				c.FileSentry.WatchPaths = append(c.FileSentry.WatchPaths, WatchPath{Path: "/tmp/extra"})
+			},
 			changed: true,
 		},
 		{

--- a/internal/config/filesentry_yaml.go
+++ b/internal/config/filesentry_yaml.go
@@ -32,6 +32,12 @@ func (w *WatchPath) UnmarshalYAML(value *yaml.Node) error {
 		if value.Tag != "" && value.Tag != "!!str" {
 			return fmt.Errorf("file_sentry.watch_paths entry must be a string or {path, required} mapping (got YAML tag %s)", value.Tag)
 		}
+		// Empty scalar ("- "" "") would later be resolved against the config
+		// directory by load.go's relative-path normalization and silently
+		// watch the wrong location. Reject at decode time instead.
+		if value.Value == "" {
+			return fmt.Errorf("file_sentry.watch_paths entry must not be an empty string")
+		}
 		w.Path = value.Value
 		w.Required = false
 		return nil

--- a/internal/config/filesentry_yaml.go
+++ b/internal/config/filesentry_yaml.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// UnmarshalYAML accepts a WatchPath in either of two YAML shapes. The bare
+// string form is the legacy shape and is equivalent to a mapping with
+// required:false. The mapping form lets the operator opt a path in to
+// hard-fail-on-arm with required:true. Mixed lists are allowed.
+//
+// Legacy / default form:
+//
+//	watch_paths:
+//	  - /etc/secrets
+//
+// Mapping form with explicit fields:
+//
+//	watch_paths:
+//	  - path: /etc/secrets
+//	    required: true
+func (w *WatchPath) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		// Strict: tag must be a string so a bare boolean/integer is rejected
+		// rather than coerced to its decimal/literal text.
+		if value.Tag != "" && value.Tag != "!!str" {
+			return fmt.Errorf("file_sentry.watch_paths entry must be a string or {path, required} mapping (got YAML tag %s)", value.Tag)
+		}
+		w.Path = value.Value
+		w.Required = false
+		return nil
+	case yaml.MappingNode:
+		// Enforce the field set explicitly; typos like "require: true" would
+		// otherwise silently leave Required=false and defeat the opt-in.
+		// value.Content is [key0, val0, key1, val1, ...].
+		for i := 0; i < len(value.Content); i += 2 {
+			key := value.Content[i]
+			switch key.Value {
+			case "path", "required":
+			default:
+				return fmt.Errorf("file_sentry.watch_paths entry has unsupported field %q (allowed: path, required)", key.Value)
+			}
+		}
+		raw := struct {
+			Path     *string `yaml:"path"`
+			Required *bool   `yaml:"required"`
+		}{}
+		if err := value.Decode(&raw); err != nil {
+			return fmt.Errorf("file_sentry.watch_paths entry: %w", err)
+		}
+		if raw.Path == nil || *raw.Path == "" {
+			return fmt.Errorf("file_sentry.watch_paths entry missing required field 'path'")
+		}
+		w.Path = *raw.Path
+		if raw.Required != nil {
+			w.Required = *raw.Required
+		}
+		return nil
+	default:
+		return fmt.Errorf("file_sentry.watch_paths entry must be a string or mapping (got YAML kind %d)", value.Kind)
+	}
+}

--- a/internal/config/filesentry_yaml_test.go
+++ b/internal/config/filesentry_yaml_test.go
@@ -129,6 +129,22 @@ func TestWatchPath_UnmarshalYAML_RejectsEmptyPath(t *testing.T) {
 	}
 }
 
+func TestWatchPath_UnmarshalYAML_RejectsEmptyScalar(t *testing.T) {
+	// Empty scalar would silently resolve to the config directory via
+	// load.go's relative-path normalization. Reject at decode time.
+	input := []byte(`
+- ""
+`)
+	var paths []WatchPath
+	err := yaml.Unmarshal(input, &paths)
+	if err == nil {
+		t.Fatal("expected error for empty scalar watch_paths entry")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error %q does not mention emptiness", err.Error())
+	}
+}
+
 func TestWatchPath_UnmarshalYAML_RejectsNonStringScalar(t *testing.T) {
 	// A bare boolean or integer is not a valid path; reject rather than
 	// coerce to its literal representation.

--- a/internal/config/filesentry_yaml_test.go
+++ b/internal/config/filesentry_yaml_test.go
@@ -79,6 +79,9 @@ func TestWatchPath_UnmarshalYAML_MixedList(t *testing.T) {
 		{Path: "/new/required/path", Required: true},
 		{Path: "/another/legacy", Required: false},
 	}
+	if len(paths) != len(want) {
+		t.Fatalf("len = %d, want %d", len(paths), len(want))
+	}
 	for i, p := range paths {
 		if p.Path != want[i].Path || p.Required != want[i].Required {
 			t.Errorf("[%d] = %+v, want %+v", i, p, want[i])

--- a/internal/config/filesentry_yaml_test.go
+++ b/internal/config/filesentry_yaml_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestWatchPath_UnmarshalYAML_StringForm(t *testing.T) {
+	input := []byte(`
+- "/etc/secrets"
+- "/var/lib/app"
+`)
+	var paths []WatchPath
+	if err := yaml.Unmarshal(input, &paths); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	want := []WatchPath{
+		{Path: "/etc/secrets", Required: false},
+		{Path: "/var/lib/app", Required: false},
+	}
+	if len(paths) != len(want) {
+		t.Fatalf("len = %d, want %d", len(paths), len(want))
+	}
+	for i, p := range paths {
+		if p.Path != want[i].Path {
+			t.Errorf("[%d].Path = %q, want %q", i, p.Path, want[i].Path)
+		}
+		if p.Required != want[i].Required {
+			t.Errorf("[%d].Required = %v, want %v", i, p.Required, want[i].Required)
+		}
+	}
+}
+
+func TestWatchPath_UnmarshalYAML_MappingForm(t *testing.T) {
+	input := []byte(`
+- path: "/etc/secrets"
+  required: true
+- path: "/var/optional"
+  required: false
+- path: "/var/default"
+`)
+	var paths []WatchPath
+	if err := yaml.Unmarshal(input, &paths); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	want := []WatchPath{
+		{Path: "/etc/secrets", Required: true},
+		{Path: "/var/optional", Required: false},
+		{Path: "/var/default", Required: false},
+	}
+	if len(paths) != len(want) {
+		t.Fatalf("len = %d, want %d", len(paths), len(want))
+	}
+	for i, p := range paths {
+		if p.Path != want[i].Path || p.Required != want[i].Required {
+			t.Errorf("[%d] = %+v, want %+v", i, p, want[i])
+		}
+	}
+}
+
+func TestWatchPath_UnmarshalYAML_MixedList(t *testing.T) {
+	input := []byte(`
+- "/legacy/path"
+- path: "/new/required/path"
+  required: true
+- "/another/legacy"
+`)
+	var paths []WatchPath
+	if err := yaml.Unmarshal(input, &paths); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	want := []WatchPath{
+		{Path: "/legacy/path", Required: false},
+		{Path: "/new/required/path", Required: true},
+		{Path: "/another/legacy", Required: false},
+	}
+	for i, p := range paths {
+		if p.Path != want[i].Path || p.Required != want[i].Required {
+			t.Errorf("[%d] = %+v, want %+v", i, p, want[i])
+		}
+	}
+}
+
+func TestWatchPath_UnmarshalYAML_RejectsTypoedField(t *testing.T) {
+	// Typo like "require" instead of "required" must reject loudly so the
+	// operator doesn't silently lose the required:true opt-in.
+	input := []byte(`
+- path: "/etc/secrets"
+  require: true
+`)
+	var paths []WatchPath
+	err := yaml.Unmarshal(input, &paths)
+	if err == nil {
+		t.Fatal("expected error for unknown field 'require'")
+	}
+	if !strings.Contains(err.Error(), "require") {
+		t.Errorf("error %q does not mention the offending field name", err.Error())
+	}
+}
+
+func TestWatchPath_UnmarshalYAML_RejectsMissingPath(t *testing.T) {
+	input := []byte(`
+- required: true
+`)
+	var paths []WatchPath
+	err := yaml.Unmarshal(input, &paths)
+	if err == nil {
+		t.Fatal("expected error for mapping form missing 'path'")
+	}
+	if !strings.Contains(err.Error(), "path") {
+		t.Errorf("error %q does not mention the missing 'path' field", err.Error())
+	}
+}
+
+func TestWatchPath_UnmarshalYAML_RejectsEmptyPath(t *testing.T) {
+	input := []byte(`
+- path: ""
+  required: true
+`)
+	var paths []WatchPath
+	err := yaml.Unmarshal(input, &paths)
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestWatchPath_UnmarshalYAML_RejectsNonStringScalar(t *testing.T) {
+	// A bare boolean or integer is not a valid path; reject rather than
+	// coerce to its literal representation.
+	input := []byte(`
+- true
+`)
+	var paths []WatchPath
+	err := yaml.Unmarshal(input, &paths)
+	if err == nil {
+		t.Fatal("expected error for non-string scalar")
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -91,7 +91,8 @@ func Load(path string) (*Config, error) {
 	// Relative paths with ".." traversal are rejected to prevent
 	// unintentional escapes. Absolute paths are allowed as-is since the
 	// user explicitly chose the target directory.
-	for i, p := range cfg.FileSentry.WatchPaths {
+	for i, wp := range cfg.FileSentry.WatchPaths {
+		p := wp.Path
 		if !filepath.IsAbs(p) {
 			resolved := filepath.Clean(filepath.Join(configDir, p))
 			// Verify the resolved path is still under the config directory.
@@ -103,9 +104,9 @@ func Load(path string) (*Config, error) {
 			if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 				return nil, fmt.Errorf("file_sentry: watch_paths[%d] %q escapes config directory (use absolute path instead)", i, p)
 			}
-			cfg.FileSentry.WatchPaths[i] = resolved
+			cfg.FileSentry.WatchPaths[i].Path = resolved
 		} else {
-			cfg.FileSentry.WatchPaths[i] = filepath.Clean(cfg.FileSentry.WatchPaths[i])
+			cfg.FileSentry.WatchPaths[i].Path = filepath.Clean(p)
 		}
 	}
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -159,15 +159,33 @@ type TrustedKey struct {
 	Tier      string `yaml:"tier,omitempty"`
 }
 
+// WatchPath is a single file_sentry watch entry. YAML accepts either a bare
+// string ("/foo") for legacy/default behavior, or a mapping
+// ({path: "/foo", required: true}) when the operator wants to opt that path
+// into hard-fail-on-arm semantics.
+//
+// Required=false (the default) means a failure to install the watch (missing
+// path, permission denied, inotify exhaustion on that specific subtree) is
+// recorded as degraded health but does not abort startup. Other paths still
+// arm. This is the soft-fail path operators get for free.
+//
+// Required=true means the watch MUST install. If Arm() cannot install it,
+// startup fails closed. Use this for paths whose monitoring is part of the
+// security boundary (e.g. credential stores under your control).
+type WatchPath struct {
+	Path     string `yaml:"path"`
+	Required bool   `yaml:"required"`
+}
+
 // FileSentry configures real-time filesystem monitoring for agent processes.
 // Detects secrets written to disk by agent subprocesses that bypass
 // the MCP tool call path. Applies to subprocess MCP mode only.
 type FileSentry struct {
-	Enabled        bool     `yaml:"enabled"`
-	BestEffort     bool     `yaml:"best_effort"` // degrade gracefully when watch setup fails (e.g. inotify exhaustion)
-	WatchPaths     []string `yaml:"watch_paths"`
-	ScanContent    *bool    `yaml:"scan_content"`    // nil = default true
-	IgnorePatterns []string `yaml:"ignore_patterns"` // glob patterns to skip
+	Enabled        bool        `yaml:"enabled"`
+	BestEffort     bool        `yaml:"best_effort"` // degrade gracefully when watch setup fails (e.g. inotify exhaustion)
+	WatchPaths     []WatchPath `yaml:"watch_paths"`
+	ScanContent    *bool       `yaml:"scan_content"`    // nil = default true
+	IgnorePatterns []string    `yaml:"ignore_patterns"` // glob patterns to skip
 	// Action selects the enforcement response when an agent-attributed write
 	// matches a DLP pattern. "warn" logs the finding and records a metric
 	// (current default). "block" additionally cancels the proxy context so the

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1508,8 +1508,8 @@ func (c *Config) validateFileSentry() error {
 	if len(c.FileSentry.WatchPaths) == 0 {
 		return fmt.Errorf("file_sentry: watch_paths must be non-empty when enabled")
 	}
-	for i, p := range c.FileSentry.WatchPaths {
-		if p == "" {
+	for i, wp := range c.FileSentry.WatchPaths {
+		if wp.Path == "" {
 			return fmt.Errorf("file_sentry: watch_paths[%d] must not be empty", i)
 		}
 	}

--- a/internal/filesentry/consumer_test.go
+++ b/internal/filesentry/consumer_test.go
@@ -22,6 +22,7 @@ type stubWatcher struct{ ch chan Finding }
 func (s *stubWatcher) Arm() error                    { return nil }
 func (s *stubWatcher) Start(_ context.Context) error { return nil }
 func (s *stubWatcher) Findings() <-chan Finding      { return s.ch }
+func (s *stubWatcher) DegradedPaths() []DegradedPath { return nil }
 func (s *stubWatcher) Close() error                  { return nil }
 
 // makeWatcher seeds a buffered channel with the given findings and closes

--- a/internal/filesentry/watcher.go
+++ b/internal/filesentry/watcher.go
@@ -27,13 +27,19 @@ type DLPScanner interface {
 // Watcher monitors directories for file writes and scans content for secrets.
 type Watcher interface {
 	// Arm installs watches on all configured directories synchronously.
-	// Must be called before launching the child process.
+	// Must be called before launching the child process. Returns an error
+	// only if a required:true entry cannot be installed; non-required
+	// failures are recorded via DegradedPaths and the onError callback.
 	Arm() error
 	// Start processes filesystem events. Blocks until ctx is cancelled.
 	// Call Arm() first to install watches.
 	Start(ctx context.Context) error
 	// Findings returns a channel that receives DLP findings as they are detected.
 	Findings() <-chan Finding
+	// DegradedPaths returns the configured watch_paths entries whose Arm()
+	// install failed and whose entry was not marked required:true. Empty
+	// when the watcher is fully armed. Safe to call concurrently.
+	DegradedPaths() []DegradedPath
 	// Close stops the watcher and releases resources.
 	Close() error
 }

--- a/internal/filesentry/watcher_impl.go
+++ b/internal/filesentry/watcher_impl.go
@@ -47,6 +47,20 @@ type fsWatcher struct {
 	timers   map[string]*time.Timer // per-path debounce timers
 	pidSnap  map[string]bool        // per-path agent attribution snapshot at event time
 	closed   bool
+	// degradedPaths records configured watch_paths whose Arm() install failed
+	// when the path was not marked required:true. Populated by Arm() and
+	// exposed via DegradedPaths() so health endpoints can surface "armed but
+	// degraded" without lying about coverage.
+	degradedPaths []DegradedPath
+}
+
+// DegradedPath records a configured watch_paths entry whose install failed
+// during Arm() but was not marked required:true. Operators see these via
+// the watcher's DegradedPaths() / health surface so degraded coverage is
+// visible, not silent.
+type DegradedPath struct {
+	Path  string
+	Error string
 }
 
 // NewWatcher creates a file watcher that monitors configured directories for
@@ -81,17 +95,62 @@ func (w *fsWatcher) logError(err error) {
 // Arm installs watches on all configured directories synchronously.
 // Call this before launching the child process to ensure no writes
 // are missed during the startup window.
+//
+// Per-path failure semantics:
+//   - WatchPath.Required=true: install failure aborts Arm with a wrapped error.
+//     Use for paths whose monitoring is part of the security boundary.
+//   - WatchPath.Required=false (default): install failure is recorded as a
+//     degraded path (visible via DegradedPaths) and reported through the
+//     optional onError callback, but Arm continues installing the remaining
+//     paths. This lets a missing or transiently-inaccessible aux path stop
+//     crash-looping the proxy when the primary watch is still healthy.
+//
+// Required:false matches the operator expectation that an optional watch
+// path that "happens to be unreadable today" should not crash-loop the
+// proxy. Operators who want hard-fail behavior for a specific path opt in
+// with required:true on that entry.
 func (w *fsWatcher) Arm() error {
-	for _, p := range w.cfg.WatchPaths {
-		abs, err := filepath.Abs(p)
+	w.mu.Lock()
+	w.degradedPaths = w.degradedPaths[:0]
+	w.mu.Unlock()
+	for _, wp := range w.cfg.WatchPaths {
+		abs, err := filepath.Abs(wp.Path)
 		if err != nil {
-			return fmt.Errorf("filesentry: resolve path %q: %w", p, err)
+			if wp.Required {
+				return fmt.Errorf("filesentry: resolve path %q: %w", wp.Path, err)
+			}
+			w.recordDegraded(wp.Path, err)
+			continue
 		}
 		if err := w.addRecursive(abs); err != nil {
-			return fmt.Errorf("filesentry: watch %q: %w", abs, err)
+			if wp.Required {
+				return fmt.Errorf("filesentry: watch %q: %w", abs, err)
+			}
+			w.recordDegraded(wp.Path, err)
+			continue
 		}
 	}
 	return nil
+}
+
+// recordDegraded captures a non-required Arm-time install failure for later
+// visibility through DegradedPaths() and the optional onError callback.
+func (w *fsWatcher) recordDegraded(path string, cause error) {
+	w.mu.Lock()
+	w.degradedPaths = append(w.degradedPaths, DegradedPath{Path: path, Error: cause.Error()})
+	w.mu.Unlock()
+	w.logError(fmt.Errorf("filesentry: watch %q failed (degraded, required:false): %w", path, cause))
+}
+
+// DegradedPaths returns watch_paths entries whose Arm() install failed and
+// whose entry was not marked required:true. Returned slice is a copy safe
+// for concurrent inspection from a health endpoint.
+func (w *fsWatcher) DegradedPaths() []DegradedPath {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]DegradedPath, len(w.degradedPaths))
+	copy(out, w.degradedPaths)
+	return out
 }
 
 // Start processes filesystem events until ctx is cancelled. Blocks until done.

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -42,7 +42,7 @@ func TestWatcher_DetectsSecretWrite(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -88,7 +88,7 @@ func TestWatcher_CleanFileNoFinding(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -134,7 +134,7 @@ func TestWatcher_IgnoredPatterns(t *testing.T) {
 
 	cfg := &config.FileSentry{
 		Enabled:        true,
-		WatchPaths:     []string{dir},
+		WatchPaths:     []config.WatchPath{{Path: dir}},
 		ScanContent:    ptrBool(true),
 		IgnorePatterns: []string{"node_modules/**"},
 	}
@@ -174,7 +174,7 @@ func TestWatcher_SubdirCreation(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -231,7 +231,7 @@ func TestWatcher_ScanContentDisabled(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(false),
 	}
 
@@ -270,7 +270,7 @@ func TestWatcher_CloseIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -297,7 +297,7 @@ func TestWatcher_OversizedFileSkipped(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -346,7 +346,7 @@ func TestWatcher_EmptyFileSkipped(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -384,7 +384,7 @@ func TestWatcher_WithLineageAttribution(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -439,7 +439,7 @@ func TestWatcher_DebounceTimerRace(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -495,7 +495,7 @@ func TestWatcher_ErrorHandlerInvoked(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -526,7 +526,7 @@ func TestWatcher_NilErrorHandler(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -552,7 +552,7 @@ func TestWatcher_PIDSnapshotAtEventTime(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -595,7 +595,7 @@ func TestWatcher_NilLineageNoSnapshot(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -637,7 +637,7 @@ func TestWatcher_ScanContentNilDefaultsTrue(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: nil, // omitted
 	}
 
@@ -699,7 +699,7 @@ func TestWatcher_CloseFlushesLastWrite(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -751,7 +751,7 @@ func TestWatcher_CloseFlushScanDisabled(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(false),
 	}
 
@@ -799,7 +799,7 @@ func TestWatcher_CloseFlushEmptyFile(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -844,7 +844,7 @@ func TestWatcher_StartContextCancelled(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -885,7 +885,7 @@ func TestWatcher_FindingsChannelFull(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -943,7 +943,10 @@ done:
 }
 
 func TestWatcher_PermissionDeniedSubdir(t *testing.T) {
-	// Arm should fail closed when a subdirectory is unreadable.
+	// Arm should fail closed when a subdirectory under a required:true
+	// watch path is unreadable. Required:true preserves the historical
+	// hard-fail; the non-required variant is covered separately and is
+	// expected to soft-fail (degraded) on the same input.
 	dir := t.TempDir()
 	if os.Geteuid() == 0 {
 		t.Skip("chmod 000 does not restrict root")
@@ -961,7 +964,7 @@ func TestWatcher_PermissionDeniedSubdir(t *testing.T) {
 
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir, Required: true}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -988,7 +991,7 @@ func TestWatcher_StartReturnsOnClose(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -1017,9 +1020,12 @@ func TestWatcher_StartReturnsOnClose(t *testing.T) {
 }
 
 func TestWatcher_ArmNonexistentPath(t *testing.T) {
+	// Required:true preserves the historical "Arm errors on missing path"
+	// semantic that operators got automatically before per-path opt-in.
+	// The soft-fail behavior for required:false is covered separately.
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{"/nonexistent/path/that/does/not/exist"},
+		WatchPaths:  []config.WatchPath{{Path: "/nonexistent/path/that/does/not/exist", Required: true}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -1036,7 +1042,90 @@ func TestWatcher_ArmNonexistentPath(t *testing.T) {
 	defer func() { _ = w.Close() }()
 
 	if err := w.Arm(); err == nil {
-		t.Error("expected error for nonexistent watch path")
+		t.Error("expected error for nonexistent required watch path")
+	}
+}
+
+// TestWatcher_ArmNonexistentPathSoftFail verifies that a non-required
+// watch path that cannot install is recorded as degraded rather than
+// aborting Arm(). This is the per-path soft-fail semantic that prevents
+// one missing or transiently-unreadable aux path from crash-looping the
+// proxy. The required:true variant is covered by TestWatcher_ArmNonexistentPath.
+func TestWatcher_ArmNonexistentPathSoftFail(t *testing.T) {
+	cfg := &config.FileSentry{
+		Enabled:     true,
+		WatchPaths:  []config.WatchPath{{Path: "/nonexistent/path/that/does/not/exist"}},
+		ScanContent: ptrBool(true),
+	}
+
+	defaults := config.Defaults()
+	defaults.Internal = nil
+	defaults.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	sc := scanner.New(defaults)
+	defer sc.Close()
+
+	var errCallbacks int
+	onError := func(error) { errCallbacks++ }
+	w, err := NewWatcher(cfg, sc, nil, onError)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	if err := w.Arm(); err != nil {
+		t.Fatalf("Arm: non-required path should soft-fail, got error: %v", err)
+	}
+	degraded := w.DegradedPaths()
+	if len(degraded) != 1 {
+		t.Fatalf("expected 1 degraded path, got %d", len(degraded))
+	}
+	if degraded[0].Path != "/nonexistent/path/that/does/not/exist" {
+		t.Errorf("degraded path = %q, want /nonexistent/...", degraded[0].Path)
+	}
+	if degraded[0].Error == "" {
+		t.Error("expected non-empty error message on degraded path")
+	}
+	if errCallbacks != 1 {
+		t.Errorf("expected exactly one onError callback, got %d", errCallbacks)
+	}
+}
+
+// TestWatcher_ArmMixedPathsArmsTheArmable verifies that an Arm() with a
+// healthy path AND a non-required missing path arms the healthy one and
+// records the missing one as degraded — neither failing the whole proxy
+// nor silently swallowing the missing path.
+func TestWatcher_ArmMixedPathsArmsTheArmable(t *testing.T) {
+	healthy := t.TempDir()
+	cfg := &config.FileSentry{
+		Enabled: true,
+		WatchPaths: []config.WatchPath{
+			{Path: healthy},
+			{Path: "/nonexistent/aux"},
+		},
+		ScanContent: ptrBool(true),
+	}
+
+	defaults := config.Defaults()
+	defaults.Internal = nil
+	defaults.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	sc := scanner.New(defaults)
+	defer sc.Close()
+
+	w, err := NewWatcher(cfg, sc, nil, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	if err := w.Arm(); err != nil {
+		t.Fatalf("Arm: mixed paths should not error, got: %v", err)
+	}
+	degraded := w.DegradedPaths()
+	if len(degraded) != 1 {
+		t.Fatalf("expected 1 degraded entry (the missing aux), got %d", len(degraded))
+	}
+	if degraded[0].Path != "/nonexistent/aux" {
+		t.Errorf("degraded path = %q, want /nonexistent/aux", degraded[0].Path)
 	}
 }
 
@@ -1049,7 +1138,7 @@ func TestWatcher_ArmRejectsFilePath(t *testing.T) {
 
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{filePath},
+		WatchPaths:  []config.WatchPath{{Path: filePath, Required: true}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -1074,7 +1163,7 @@ func TestWatcher_RenameIntoPlace(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 
@@ -1125,7 +1214,7 @@ func TestWatcher_FileRemovalNoFinding(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
-		WatchPaths:  []string{dir},
+		WatchPaths:  []config.WatchPath{{Path: dir}},
 		ScanContent: ptrBool(true),
 	}
 

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -1117,15 +1117,37 @@ func TestWatcher_ArmMixedPathsArmsTheArmable(t *testing.T) {
 	}
 	defer func() { _ = w.Close() }()
 
-	if err := w.Arm(); err != nil {
-		t.Fatalf("Arm: mixed paths should not error, got: %v", err)
-	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	armAndStart(t, w, ctx)
+
 	degraded := w.DegradedPaths()
 	if len(degraded) != 1 {
 		t.Fatalf("expected 1 degraded entry (the missing aux), got %d", len(degraded))
 	}
 	if degraded[0].Path != "/nonexistent/aux" {
 		t.Errorf("degraded path = %q, want /nonexistent/aux", degraded[0].Path)
+	}
+
+	// Prove the healthy path is actually armed: writing a secret to it
+	// must produce a finding on the channel. Without this assertion, a
+	// regression that silently dropped the armable path would still pass
+	// the degraded-bookkeeping check above.
+	secret := "sk-ant-" + "api03-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+	if err := os.WriteFile(filepath.Join(healthy, "leak.json"), []byte(secret), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	select {
+	case f := <-w.Findings():
+		if f.PatternName == "" {
+			t.Error("healthy path was armed but produced finding with empty PatternName")
+		}
+		if f.Path != filepath.Join(healthy, "leak.json") {
+			t.Errorf("finding path = %q, want %q", f.Path, filepath.Join(healthy, "leak.json"))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for finding from healthy path (was it actually armed?)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `file_sentry.watch_paths` accepts per-path `required:` opt-in. Default `required:false` records install failures as degraded (visible via `Watcher.DegradedPaths()` and the existing onError log) instead of crash-looping the proxy. `required:true` preserves the old hard-fail on the specific paths an operator marks security-critical.
- `pipelock doctor --check-ports` reports which process holds each configured listener port. Linux-only via `/proc/net/tcp[6]` + `/proc/<pid>/fd`. Address-aware: `127.0.0.1:8888` does not falsely warn about a holder on `127.0.0.2:8888`; wildcard `0.0.0.0:8888` correctly collides with an IPv4 listener.
- Startup `EADDRINUSE` bind errors append a hint pointing at the new flag. Applied at all six bind sites: fetch_proxy, kill_switch.api, metrics, scan_api, mcp_listen, reverse_proxy, and per-agent listeners.

## Schema (`watch_paths`)

```
# YAML
watch_paths:
  - /etc/secrets                       # legacy bare string, required:false
  - path: /var/agent-credentials       # mapping form
    required: true
```

YAML decoder rejects unknown fields (typo'd `require: true` no longer silently leaves Required=false), missing path, empty path, and non-string scalars.

## Behavior change to flag

Existing configs with a non-existent or unreadable aux watch path used to crash-loop. They now log degraded and continue. Operators who want the old hard-fail set `required: true` on that path. Documented in `docs/guides/filesystem-sentinel.md`.

## Known follow-up

- `Watcher.DegradedPaths()` is exposed on the interface; no `/health` surface wiring in this PR.
- `mcp_ws_listener` is not in the port-check list because the current schema has no `Listen` field on `MCPWSListener`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New doctor flag --check-ports to detect listener port collisions and identify holding processes
  * file_sentry.watch_paths accepts per-path required/optional entries (required:true can fail startup)

* **Improvements**
  * Bind-failure messages include guidance to run the doctor port check
  * Non-required watch failures are reported as degraded (do not abort startup)

* **Documentation**
  * Clarified watch_paths formats, required vs optional semantics, and port-check behavior (Linux-only noted)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/620?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->