### PR TITLE
Conductor: add enrollment and scoped admin auth

### DIFF
--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -120,17 +120,22 @@ Enrollment bootstraps follower identity. It is not optional.
 ### Recommended MVP
 
 1. Operator creates a one-shot enrollment token in Conductor.
-2. Token includes `org_id`, `fleet_id`, `instance_id`, allowed environment,
-   allowed IP/CIDR hint, expiry, nonce, and token ID.
-3. Token is signed by `enrollment-token-signing`.
+2. Token state binds `token_id`, `org_id`, `fleet_id`, `instance_id`,
+   `environment`, expiry, creation time, and a stored token hash.
+3. The raw token is returned once from
+   `POST /api/v1/conductor/enrollment-tokens`; Conductor persists only the
+   token hash and consumption metadata.
 4. Follower starts with the token and Conductor trust root.
 5. Follower generates local private keys:
    - mTLS leaf key
    - audit batch signing key
    - optional local receipt signing key if not already configured
-6. Follower calls `POST /api/v1/enroll` over TLS.
-7. Conductor verifies token, checks token unused, validates singleton
-   `instance_id`, and issues an mTLS leaf certificate.
+6. Follower calls `POST /api/v1/conductor/enroll` with the one-shot token,
+   audit key ID, and encoded audit public key.
+7. Conductor verifies the token, checks token unused, validates singleton
+   `instance_id`, and stores the active follower identity. Certificate
+   issuance remains an integration slice; the server-side MVP does not mint
+   mTLS leaf certificates.
 8. Conductor stores the follower audit public key and expected instance metadata.
 9. Token is marked consumed permanently.
 10. All future follower calls derive identity from the mTLS certificate, not
@@ -250,7 +255,9 @@ pipelock conductor serve \
   --tls-key /etc/pipelock/conductor/server.key \
   --client-ca /etc/pipelock/conductor/follower-ca.pem \
   --publisher-token-file /etc/pipelock/conductor/publisher-token \
-  --trusted-audit-key id=audit-key-1,file=/etc/pipelock/conductor/audit-key.pub,org=org-main,fleet=prod
+  --auditor-token-file /etc/pipelock/conductor/auditor-token \
+  --admin-token-file /etc/pipelock/conductor/admin-token \
+  --probe-listen 127.0.0.1:9092
 ```
 
 The command requires TLS 1.3 plus client-certificate verification. Follower
@@ -263,14 +270,21 @@ or `.`, and bounded length. SANs that unescape to a forbidden byte (null,
 slash, control character) are rejected at the transport boundary before
 reaching any store or sink.
 
-Policy publication uses a bearer token read from disk so the token does not
-appear in process arguments. Every `--trusted-audit-key` MUST carry `org=`;
-a cross-org audit key would let any enrolled follower in any org sign batches
-that authenticate against that key. Optional `fleet=`/`instance=` narrow the
-scope further. Accepted audit batches are written to a local SQLite raw-evidence
-store with idempotency on `(org, fleet, instance, batch_id)` and fork rejection
-on overlapping sequence ranges with divergent payload or segment-tail hashes.
-The storage directory is sensitive operator-controlled state. The MVP exposes
+Policy publication, audit metadata query, and enrollment-token creation use
+separate bearer tokens read from disk so tokens do not appear in process
+arguments. Enrollment state is stored in `enrollments.json` under
+`--storage-dir`; the file contains one-shot token hashes, consumption metadata,
+active follower identity records, and enrolled audit public keys. Static
+trusted audit keys are optional bootstrap/fallback inputs. When configured,
+every `--trusted-audit-key` MUST carry `org=`; a cross-org audit key would let
+any enrolled follower in any org sign batches that authenticate against that
+key. Optional `fleet=`/`instance=` narrow the scope further. Enrolled follower
+keys are resolved first by exact org/fleet/instance and key ID. Accepted audit
+batches are written to a
+local SQLite raw-evidence store with idempotency on `(org, fleet, instance,
+batch_id)` and fork rejection on overlapping sequence ranges with divergent
+payload or segment-tail hashes. The storage directory is sensitive
+operator-controlled state. The MVP exposes
 `GET /api/v1/conductor/audit/batches` as an operator/admin metadata query
 endpoint; it requires audit-query authorization and at least `org_id`, returns
 metadata-only batch summaries, and does not export raw payload bytes. Raw
@@ -497,17 +511,26 @@ Local audit batcher failures produce local recorder evidence and metrics.
 MVP server endpoint:
 
 ```http
+POST /api/v1/conductor/enrollment-tokens
+POST /api/v1/conductor/enroll
 POST /api/v1/conductor/audit/batches
 GET /api/v1/conductor/audit/batches?org_id=...
 ```
 
+`POST /api/v1/conductor/enrollment-tokens` is an admin endpoint that creates a
+one-shot token for a specific org/fleet/instance/environment and expiry.
+`POST /api/v1/conductor/enroll` consumes that token, records the follower audit
+public key, and rejects token reuse or a second enrollment for an already-active
+instance.
+
 The server derives follower identity from the authenticated transport, validates
 the signed audit batch envelope and payload together, verifies the follower
-audit-batch signature against the enrolled audit key for that identity, and only
-then hands the accepted batch to the configured audit sink. The current runtime
-sink is a local SQLite raw-evidence store; redacted storage/search indexing,
-DLP-before-indexing, fork response workflow, and dashboard views are later
-slices.
+audit-batch signature against the enrolled audit key for that identity, and
+only then hands the accepted batch to the configured audit sink. Static trusted
+audit keys remain available as a bootstrap fallback when no enrolled key matches
+the exact identity and key ID. The current runtime sink is a local SQLite
+raw-evidence store; redacted storage/search indexing, DLP-before-indexing, fork
+response workflow, and dashboard views are later slices.
 
 `GET /api/v1/conductor/audit/batches` is an operator/admin API endpoint. It
 requires audit-query authorization, requires at least `org_id`, and returns

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -147,14 +147,18 @@ The server-side MVP assumes follower mTLS certificates are provisioned by an
 external CA, manual issuance workflow, or separate PKI automation before the
 follower uses the mTLS listener. The certificate identity MUST use the same
 `org_id`, `fleet_id`, `instance_id`, and `environment` recorded during
-enrollment, encoded as the SPIFFE URI SAN described below. Enrollment records
-the audit public key and active instance binding; it does not prove possession
-of the eventual mTLS private key or issue the leaf certificate in this slice.
+enrollment, encoded as the SPIFFE URI SAN described below. On the first
+authenticated mTLS connection, the server MUST validate the verified SPIFFE URI
+SAN against that enrollment record and reject mismatched org, fleet, instance,
+or environment values. Enrollment records the audit public key and active
+instance binding; it does not prove possession of the eventual mTLS private key
+or issue the leaf certificate in this slice.
 
 ### Singleton Rule
 
-Conductor must prevent silent instance cloning. A second enrollment for an active
-`instance_id` fails unless an admin revokes or rotates the prior identity.
+Conductor must prevent silent instance cloning. A second enrollment for the same
+active `org_id`, `fleet_id`, `instance_id`, and `environment` fails unless an
+admin revokes or rotates the prior identity.
 
 ### Rotation
 
@@ -268,6 +272,8 @@ pipelock conductor serve \
   --auditor-token-file /etc/pipelock/conductor/auditor-token \
   --admin-token-file /etc/pipelock/conductor/admin-token \
   --probe-listen 127.0.0.1:9092
+# Optional bootstrap fallback; every trusted audit key must include org=.
+# --trusted-audit-key id=audit-key-1,file=/etc/pipelock/conductor/audit-key.pub,org=org-main,fleet=prod
 ```
 
 The command requires TLS 1.3 plus client-certificate verification. Follower

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -141,6 +141,16 @@ Enrollment bootstraps follower identity. It is not optional.
 10. All future follower calls derive identity from the mTLS certificate, not
     from request fields.
 
+### Out-of-band Certificate Provisioning
+
+The server-side MVP assumes follower mTLS certificates are provisioned by an
+external CA, manual issuance workflow, or separate PKI automation before the
+follower uses the mTLS listener. The certificate identity MUST use the same
+`org_id`, `fleet_id`, `instance_id`, and `environment` recorded during
+enrollment, encoded as the SPIFFE URI SAN described below. Enrollment records
+the audit public key and active instance binding; it does not prove possession
+of the eventual mTLS private key or issue the leaf certificate in this slice.
+
 ### Singleton Rule
 
 Conductor must prevent silent instance cloning. A second enrollment for an active

--- a/internal/cli/conductor/cmd.go
+++ b/internal/cli/conductor/cmd.go
@@ -42,6 +42,8 @@ type serveOptions struct {
 	conductorID         string
 	followerTrustDomain string
 	publisherTokenFile  string
+	auditorTokenFile    string
+	adminTokenFile      string
 	trustedAuditKeys    []string
 	tlsCert             string
 	tlsKey              string
@@ -88,6 +90,8 @@ func serveCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.conductorID, "conductor-id", opts.conductorID, "Conductor ID advertised in capabilities")
 	cmd.Flags().StringVar(&opts.followerTrustDomain, "follower-trust-domain", opts.followerTrustDomain, "SPIFFE trust domain for follower mTLS identities")
 	cmd.Flags().StringVar(&opts.publisherTokenFile, "publisher-token-file", "", "file containing bearer token required for policy publish requests")
+	cmd.Flags().StringVar(&opts.auditorTokenFile, "auditor-token-file", "", "file containing bearer token required for audit metadata query requests")
+	cmd.Flags().StringVar(&opts.adminTokenFile, "admin-token-file", "", "file containing bearer token required for Conductor admin requests")
 	cmd.Flags().StringArrayVar(&opts.trustedAuditKeys, "trusted-audit-key", nil,
 		"trusted audit signing key as comma-separated kv pairs: 'id=ID,(inline=BASE64|file=/path),org=ORG[,fleet=FLEET][,instance=INSTANCE]'; "+
 			"org= is required so a key cannot authenticate batches across orgs; repeatable")
@@ -195,7 +199,7 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, ht
 	if err := validateServeTLSFlags(opts); err != nil {
 		return nil, nil, nil, err
 	}
-	publisherToken, err := loadTokenFile(opts.publisherTokenFile)
+	publisherToken, err := loadTokenFile("--publisher-token-file", opts.publisherTokenFile)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -203,13 +207,45 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, ht
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	auditorToken, err := loadTokenFile("--auditor-token-file", opts.auditorTokenFile)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	adminToken, err := loadTokenFile("--admin-token-file", opts.adminTokenFile)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	publishAuthorizer, err := controlplane.ScopedBearerBundleAuthorizer([]controlplane.ScopedBearerCredential{{
+		Token: publisherToken,
+		Role:  controlplane.RolePublisher,
+	}})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	auditQueryAuthorizer, err := controlplane.ScopedBearerAuditQueryAuthorizer([]controlplane.ScopedBearerCredential{
+		{Token: auditorToken, Role: controlplane.RoleAuditor},
+		{Token: adminToken, Role: controlplane.RoleAdmin},
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	adminAuthorizer, err := controlplane.ScopedBearerAdminAuthorizer([]controlplane.ScopedBearerCredential{{
+		Token: adminToken,
+		Role:  controlplane.RoleAdmin,
+	}})
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	identity, err := controlplane.MTLSFollowerIdentityResolver(opts.followerTrustDomain)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	auditKeys, err := buildAuditKeyResolver(opts.trustedAuditKeys)
-	if err != nil {
-		return nil, nil, nil, err
+	var auditKeys controlplane.AuditKeyResolver
+	if len(opts.trustedAuditKeys) > 0 {
+		auditKeys, err = buildAuditKeyResolver(opts.trustedAuditKeys)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 	}
 	store, err := controlplane.OpenFileBundleStore(filepath.Join(opts.storageDir, "policy-bundles"))
 	if err != nil {
@@ -219,16 +255,24 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, ht
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	enrollments, err := controlplane.OpenFileEnrollmentStore(filepath.Join(opts.storageDir, "enrollments.json"))
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	m := metrics.New()
 	handler, err := controlplane.NewHandler(controlplane.HandlerOptions{
-		Store:              store,
-		Capabilities:       controlplane.DefaultCapabilities(opts.conductorID),
-		FollowerIdentity:   identity,
-		AuthorizePublisher: authorizer,
-		AuditSink:          auditStore,
-		AuditKeys:          auditKeys,
-		Metrics:            m,
-		Logger:             conductorRequestLogger(opts.logWriter),
+		Store:               store,
+		Capabilities:        controlplane.DefaultCapabilities(opts.conductorID),
+		FollowerIdentity:    identity,
+		AuthorizePublisher:  authorizer,
+		AuthorizeBundle:     publishAuthorizer,
+		AuthorizeAuditQuery: auditQueryAuthorizer,
+		AuthorizeAdmin:      adminAuthorizer,
+		AuditSink:           auditStore,
+		AuditKeys:           controlplane.CompositeAuditKeyResolver(enrollments, auditKeys),
+		Enrollments:         enrollments,
+		Metrics:             m,
+		Logger:              conductorRequestLogger(opts.logWriter),
 	})
 	if err != nil {
 		return nil, nil, nil, err
@@ -279,17 +323,17 @@ func serveTLSConfig(clientCAPath string) (*tls.Config, error) {
 	}, nil
 }
 
-func loadTokenFile(path string) (string, error) {
+func loadTokenFile(flag, path string) (string, error) {
 	if strings.TrimSpace(path) == "" {
-		return "", errors.New("--publisher-token-file is required")
+		return "", fmt.Errorf("%s is required", flag)
 	}
 	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
-		return "", fmt.Errorf("read publisher token file: %w", err)
+		return "", fmt.Errorf("read %s: %w", flag, err)
 	}
 	token := strings.TrimSpace(string(data))
 	if token == "" {
-		return "", errors.New("publisher token file is empty")
+		return "", fmt.Errorf("%s is empty", flag)
 	}
 	return token, nil
 }

--- a/internal/cli/conductor/cmd_test.go
+++ b/internal/cli/conductor/cmd_test.go
@@ -11,7 +11,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"errors"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -36,6 +35,14 @@ func TestBuildServeHandlerWiresControlPlane(t *testing.T) {
 	if err := os.WriteFile(tokenPath, []byte("secret-token\n"), 0o600); err != nil {
 		t.Fatalf("WriteFile(token): %v", err)
 	}
+	auditorTokenPath := filepath.Join(dir, "auditor-token")
+	if err := os.WriteFile(auditorTokenPath, []byte("auditor-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(auditor token): %v", err)
+	}
+	adminTokenPath := filepath.Join(dir, "admin-token")
+	if err := os.WriteFile(adminTokenPath, []byte("admin-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(admin token): %v", err)
+	}
 	caPath := filepath.Join(dir, "client-ca.pem")
 	if err := os.WriteFile(caPath, testCAPEM(t), 0o600); err != nil {
 		t.Fatalf("WriteFile(ca): %v", err)
@@ -47,6 +54,8 @@ func TestBuildServeHandlerWiresControlPlane(t *testing.T) {
 		conductorID:         "conductor-test",
 		followerTrustDomain: defaultTrustDomain,
 		publisherTokenFile:  tokenPath,
+		auditorTokenFile:    auditorTokenPath,
+		adminTokenFile:      adminTokenPath,
 		trustedAuditKeys: []string{
 			"id=audit-key-1,inline=" + signing.EncodePublicKey(pub) + ",org=org-main",
 		},
@@ -117,8 +126,41 @@ func TestBuildServeHandlerRequiresAuthInputs(t *testing.T) {
 		clientCA:            caPath,
 		publisherTokenFile:  tokenPath,
 	})
-	if !errors.Is(err, controlplane.ErrAuditKeyRequired) {
-		t.Fatalf("buildServeHandler() error = %v, want ErrAuditKeyRequired", err)
+	if err == nil || err.Error() != "--auditor-token-file is required" {
+		t.Fatalf("buildServeHandler() error = %v, want --auditor-token-file required", err)
+	}
+	auditorTokenPath := filepath.Join(dir, "auditor-token")
+	if err := os.WriteFile(auditorTokenPath, []byte("auditor-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(auditor token): %v", err)
+	}
+	_, _, _, err = buildServeHandler(context.Background(), serveOptions{
+		storageDir:          filepath.Join(dir, "store"),
+		followerTrustDomain: defaultTrustDomain,
+		tlsCert:             "server.pem",
+		tlsKey:              "server.key",
+		clientCA:            caPath,
+		publisherTokenFile:  tokenPath,
+		auditorTokenFile:    auditorTokenPath,
+	})
+	if err == nil || err.Error() != "--admin-token-file is required" {
+		t.Fatalf("buildServeHandler() error = %v, want --admin-token-file required", err)
+	}
+	adminTokenPath := filepath.Join(dir, "admin-token")
+	if err := os.WriteFile(adminTokenPath, []byte("admin-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(admin token): %v", err)
+	}
+	_, _, _, err = buildServeHandler(context.Background(), serveOptions{
+		storageDir:          filepath.Join(dir, "store"),
+		followerTrustDomain: defaultTrustDomain,
+		tlsCert:             "server.pem",
+		tlsKey:              "server.key",
+		clientCA:            caPath,
+		publisherTokenFile:  tokenPath,
+		auditorTokenFile:    auditorTokenPath,
+		adminTokenFile:      adminTokenPath,
+	})
+	if err != nil {
+		t.Fatalf("buildServeHandler(no trusted audit keys) error = %v, want nil", err)
 	}
 }
 
@@ -131,6 +173,14 @@ func TestRunServeReturnsTLSLoadError(t *testing.T) {
 	tokenPath := filepath.Join(dir, "publisher-token")
 	if err := os.WriteFile(tokenPath, []byte("secret-token\n"), 0o600); err != nil {
 		t.Fatalf("WriteFile(token): %v", err)
+	}
+	auditorTokenPath := filepath.Join(dir, "auditor-token")
+	if err := os.WriteFile(auditorTokenPath, []byte("auditor-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(auditor token): %v", err)
+	}
+	adminTokenPath := filepath.Join(dir, "admin-token")
+	if err := os.WriteFile(adminTokenPath, []byte("admin-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(admin token): %v", err)
 	}
 	caPath := filepath.Join(dir, "client-ca.pem")
 	if err := os.WriteFile(caPath, testCAPEM(t), 0o600); err != nil {
@@ -145,6 +195,8 @@ func TestRunServeReturnsTLSLoadError(t *testing.T) {
 		conductorID:         "conductor-test",
 		followerTrustDomain: defaultTrustDomain,
 		publisherTokenFile:  tokenPath,
+		auditorTokenFile:    auditorTokenPath,
+		adminTokenFile:      adminTokenPath,
 		trustedAuditKeys: []string{
 			"id=audit-key-1,inline=" + signing.EncodePublicKey(pub) + ",org=org-main",
 		},
@@ -199,7 +251,7 @@ func TestParseAuditKeySpec(t *testing.T) {
 }
 
 func TestLoadTokenFileRejectsMissingAndEmpty(t *testing.T) {
-	if _, err := loadTokenFile(""); err == nil || !strings.Contains(err.Error(), "required") {
+	if _, err := loadTokenFile("--token-file", ""); err == nil || !strings.Contains(err.Error(), "required") {
 		t.Fatalf("loadTokenFile(empty path) error = %v, want required", err)
 	}
 	dir := t.TempDir()
@@ -207,14 +259,14 @@ func TestLoadTokenFileRejectsMissingAndEmpty(t *testing.T) {
 	if err := os.WriteFile(empty, []byte("  \n\t"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	if _, err := loadTokenFile(empty); err == nil || !strings.Contains(err.Error(), "empty") {
+	if _, err := loadTokenFile("--token-file", empty); err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("loadTokenFile(whitespace) error = %v, want empty", err)
 	}
 	tok := filepath.Join(dir, "tok")
 	if err := os.WriteFile(tok, []byte("  hello-token  \n"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	got, err := loadTokenFile(tok)
+	got, err := loadTokenFile("--token-file", tok)
 	if err != nil {
 		t.Fatalf("loadTokenFile() error = %v", err)
 	}

--- a/internal/conductor/controlplane/audit_query.go
+++ b/internal/conductor/controlplane/audit_query.go
@@ -27,10 +27,6 @@ type listAuditBatchesResponse struct {
 
 // handleListAuditBatches serves operator/admin audit-metadata reads.
 func (h *Handler) handleListAuditBatches(w http.ResponseWriter, r *http.Request) {
-	if err := h.authorizeAuditQuery(r); err != nil {
-		writeError(w, http.StatusForbidden, ErrAuditQueryForbidden)
-		return
-	}
 	if h.auditQuerier == nil {
 		writeError(w, http.StatusNotImplemented, errors.New("audit query not supported by configured audit sink"))
 		return
@@ -38,6 +34,10 @@ func (h *Handler) handleListAuditBatches(w http.ResponseWriter, r *http.Request)
 	query, err := parseAuditBatchQuery(r)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := h.authorizeAuditQuery(r, query); err != nil {
+		writeError(w, http.StatusForbidden, ErrAuditQueryForbidden)
 		return
 	}
 	batches, err := h.auditQuerier.ListAuditBatches(r.Context(), query)

--- a/internal/conductor/controlplane/audit_store_test.go
+++ b/internal/conductor/controlplane/audit_store_test.go
@@ -420,7 +420,7 @@ func TestHandlerListAuditBatchSurfacesSinkError(t *testing.T) {
 			return defaultFollowerIdentity(), nil
 		},
 		AuthorizePublisher:  func(*http.Request) error { return nil },
-		AuthorizeAuditQuery: func(*http.Request) error { return nil },
+		AuthorizeAuditQuery: func(*http.Request, AuditBatchQuery) error { return nil },
 		AuditSink:           failingAuditQuerySink{err: ErrAuditBatchConflict},
 		AuditKeys:           rejectingAuditKeyResolver,
 	})
@@ -459,7 +459,7 @@ func newAuditQueryTestHandler(t *testing.T, auditStore *SQLiteAuditStore) *Handl
 		AuthorizePublisher: func(*http.Request) error {
 			return errors.New("publisher authorizer must not authorize audit query")
 		},
-		AuthorizeAuditQuery: func(r *http.Request) error {
+		AuthorizeAuditQuery: func(r *http.Request, _ AuditBatchQuery) error {
 			if r.Header.Get("X-Pipelock-Auditor") == "ok" {
 				return nil
 			}

--- a/internal/conductor/controlplane/auth.go
+++ b/internal/conductor/controlplane/auth.go
@@ -18,12 +18,27 @@ import (
 
 const followerURIScheme = "spiffe"
 
+type PrincipalRole string
+
+const (
+	RoleAdmin     PrincipalRole = "admin"
+	RolePublisher PrincipalRole = "publisher"
+	RoleAuditor   PrincipalRole = "auditor"
+)
+
 type StaticAuditKey struct {
 	KeyID      string
 	Key        conductor.SignatureKey
 	OrgID      string
 	FleetID    string
 	InstanceID string
+}
+
+type ScopedBearerCredential struct {
+	Token   string
+	Role    PrincipalRole
+	OrgID   string
+	FleetID string
 }
 
 func MTLSFollowerIdentityResolver(trustDomain string) (FollowerIdentityResolver, error) {
@@ -103,6 +118,114 @@ func BearerPublisherAuthorizer(rawCredential string) (PublisherAuthorizer, error
 		}
 		return nil
 	}, nil
+}
+
+func ScopedBearerAdminAuthorizer(creds []ScopedBearerCredential) (PublisherAuthorizer, error) {
+	normalized, err := normalizeScopedBearerCredentials(creds)
+	if err != nil {
+		return nil, err
+	}
+	return func(r *http.Request) error {
+		cred, ok := matchBearerCredential(r, normalized)
+		if !ok || cred.Role != RoleAdmin {
+			return ErrPublisherForbidden
+		}
+		return nil
+	}, nil
+}
+
+func ScopedBearerBundleAuthorizer(creds []ScopedBearerCredential) (BundleAuthorizer, error) {
+	normalized, err := normalizeScopedBearerCredentials(creds)
+	if err != nil {
+		return nil, err
+	}
+	return func(r *http.Request, bundle conductor.PolicyBundle) error {
+		cred, ok := matchBearerCredential(r, normalized)
+		if !ok || cred.Role != RolePublisher || !scopedCredentialAllows(cred, bundle.OrgID, bundle.FleetID) {
+			return ErrPublisherForbidden
+		}
+		return nil
+	}, nil
+}
+
+func ScopedBearerAuditQueryAuthorizer(creds []ScopedBearerCredential) (AuditQueryAuthorizer, error) {
+	normalized, err := normalizeScopedBearerCredentials(creds)
+	if err != nil {
+		return nil, err
+	}
+	return func(r *http.Request, q AuditBatchQuery) error {
+		cred, ok := matchBearerCredential(r, normalized)
+		if !ok {
+			return ErrAuditQueryForbidden
+		}
+		switch cred.Role {
+		case RoleAdmin, RoleAuditor:
+			if scopedCredentialAllows(cred, q.OrgID, q.FleetID) {
+				return nil
+			}
+		}
+		return ErrAuditQueryForbidden
+	}, nil
+}
+
+func normalizeScopedBearerCredentials(creds []ScopedBearerCredential) ([]ScopedBearerCredential, error) {
+	if len(creds) == 0 {
+		return nil, ErrPublisherForbidden
+	}
+	out := make([]ScopedBearerCredential, 0, len(creds))
+	for _, cred := range creds {
+		cred.Token = strings.TrimSpace(cred.Token)
+		cred.Role = PrincipalRole(strings.TrimSpace(string(cred.Role)))
+		cred.OrgID = strings.TrimSpace(cred.OrgID)
+		cred.FleetID = strings.TrimSpace(cred.FleetID)
+		if cred.Token == "" {
+			return nil, ErrPublisherForbidden
+		}
+		switch cred.Role {
+		case RoleAdmin, RolePublisher, RoleAuditor:
+		default:
+			return nil, ErrPublisherForbidden
+		}
+		if cred.OrgID != "" {
+			if err := conductor.ValidateIdentifier("org_id", cred.OrgID); err != nil {
+				return nil, fmt.Errorf("%w: org_id", ErrPublisherForbidden)
+			}
+		}
+		if cred.FleetID != "" {
+			if err := conductor.ValidateIdentifier("fleet_id", cred.FleetID); err != nil {
+				return nil, fmt.Errorf("%w: fleet_id", ErrPublisherForbidden)
+			}
+		}
+		out = append(out, cred)
+	}
+	return out, nil
+}
+
+func matchBearerCredential(r *http.Request, creds []ScopedBearerCredential) (ScopedBearerCredential, bool) {
+	if r == nil {
+		return ScopedBearerCredential{}, false
+	}
+	raw := r.Header.Get("Authorization")
+	prefix, got, ok := strings.Cut(raw, " ")
+	if !ok || !strings.EqualFold(prefix, "Bearer") {
+		return ScopedBearerCredential{}, false
+	}
+	for _, cred := range creds {
+		if subtle.ConstantTimeCompare([]byte(got), []byte(cred.Token)) == 1 {
+			return cred, true
+		}
+	}
+	return ScopedBearerCredential{}, false
+}
+
+func scopedCredentialAllows(cred ScopedBearerCredential, orgID, fleetID string) bool {
+	if cred.OrgID != "" && cred.OrgID != orgID {
+		return false
+	}
+	if cred.FleetID != "" && cred.FleetID != fleetID {
+		return false
+	}
+	return true
 }
 
 // StaticAuditKeyResolver builds an [AuditKeyResolver] from a fixed roster of

--- a/internal/conductor/controlplane/auth.go
+++ b/internal/conductor/controlplane/auth.go
@@ -192,6 +192,9 @@ func normalizeScopedBearerCredentials(creds []ScopedBearerCredential) ([]ScopedB
 			}
 		}
 		if cred.FleetID != "" {
+			if cred.OrgID == "" {
+				return nil, fmt.Errorf("%w: org_id required when fleet_id is scoped", ErrPublisherForbidden)
+			}
 			if err := conductor.ValidateIdentifier("fleet_id", cred.FleetID); err != nil {
 				return nil, fmt.Errorf("%w: fleet_id", ErrPublisherForbidden)
 			}

--- a/internal/conductor/controlplane/auth_test.go
+++ b/internal/conductor/controlplane/auth_test.go
@@ -209,6 +209,7 @@ func TestScopedBearerAuthorizersRejectInvalidConfigAndHeaders(t *testing.T) {
 		{name: "bad role", creds: []ScopedBearerCredential{{Token: "token", Role: PrincipalRole("owner")}}},
 		{name: "bad org", creds: []ScopedBearerCredential{{Token: "token", Role: RoleAuditor, OrgID: "-org"}}},
 		{name: "bad fleet", creds: []ScopedBearerCredential{{Token: "token", Role: RoleAuditor, FleetID: "fleet/prod"}}},
+		{name: "fleet without org", creds: []ScopedBearerCredential{{Token: "token", Role: RoleAuditor, FleetID: "prod"}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if _, err := ScopedBearerAdminAuthorizer(tc.creds); !errors.Is(err, ErrPublisherForbidden) {

--- a/internal/conductor/controlplane/auth_test.go
+++ b/internal/conductor/controlplane/auth_test.go
@@ -138,6 +138,67 @@ func TestBearerPublisherAuthorizer(t *testing.T) {
 	}
 }
 
+func TestScopedBearerAuthorizersEnforceRoleAndScope(t *testing.T) {
+	publisher, err := ScopedBearerBundleAuthorizer([]ScopedBearerCredential{{
+		Token:   "publish-token",
+		Role:    RolePublisher,
+		OrgID:   "org-main",
+		FleetID: "prod",
+	}})
+	if err != nil {
+		t.Fatalf("ScopedBearerBundleAuthorizer() error = %v", err)
+	}
+	auditor, err := ScopedBearerAuditQueryAuthorizer([]ScopedBearerCredential{
+		{Token: "audit-token", Role: RoleAuditor, OrgID: "org-main", FleetID: "prod"},
+		{Token: "admin-token", Role: RoleAdmin},
+	})
+	if err != nil {
+		t.Fatalf("ScopedBearerAuditQueryAuthorizer() error = %v", err)
+	}
+	admin, err := ScopedBearerAdminAuthorizer([]ScopedBearerCredential{{
+		Token: "admin-token",
+		Role:  RoleAdmin,
+	}})
+	if err != nil {
+		t.Fatalf("ScopedBearerAdminAuthorizer() error = %v", err)
+	}
+
+	bundle := signedControlBundle(t, newTestSigner(t), bundleSpec{
+		id:       "bundle-1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"pl-prod-1"}},
+	})
+	if err := publisher(bearerRequest(t, PublishPolicyBundlePath, "publish-token"), bundle); err != nil {
+		t.Fatalf("publisher(valid) error = %v", err)
+	}
+	wrongFleet := bundle
+	wrongFleet.FleetID = "dev"
+	if err := publisher(bearerRequest(t, PublishPolicyBundlePath, "publish-token"), wrongFleet); !errors.Is(err, ErrPublisherForbidden) {
+		t.Fatalf("publisher(wrong fleet) error = %v, want ErrPublisherForbidden", err)
+	}
+	if err := publisher(bearerRequest(t, PublishPolicyBundlePath, "audit-token"), bundle); !errors.Is(err, ErrPublisherForbidden) {
+		t.Fatalf("publisher(auditor token) error = %v, want ErrPublisherForbidden", err)
+	}
+
+	query := AuditBatchQuery{OrgID: "org-main", FleetID: "prod"}
+	if err := auditor(bearerRequest(t, AuditBatchesPath, "audit-token"), query); err != nil {
+		t.Fatalf("auditor(valid) error = %v", err)
+	}
+	query.FleetID = "dev"
+	if err := auditor(bearerRequest(t, AuditBatchesPath, "audit-token"), query); !errors.Is(err, ErrAuditQueryForbidden) {
+		t.Fatalf("auditor(wrong fleet) error = %v, want ErrAuditQueryForbidden", err)
+	}
+	if err := auditor(bearerRequest(t, AuditBatchesPath, "admin-token"), query); err != nil {
+		t.Fatalf("auditor(admin override) error = %v", err)
+	}
+	if err := admin(bearerRequest(t, EnrollmentTokensPath, "publish-token")); !errors.Is(err, ErrPublisherForbidden) {
+		t.Fatalf("admin(publisher token) error = %v, want ErrPublisherForbidden", err)
+	}
+	if err := admin(bearerRequest(t, EnrollmentTokensPath, "admin-token")); err != nil {
+		t.Fatalf("admin(valid) error = %v", err)
+	}
+}
+
 func TestStaticAuditKeyResolverHonorsIdentityBinding(t *testing.T) {
 	pub, _, err := ed25519.GenerateKey(nil)
 	if err != nil {
@@ -250,6 +311,16 @@ func TestStaticAuditKeyResolverRejectsCrossOrgKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func bearerRequest(t *testing.T, path, token string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	return req
 }
 
 func httptestRequestWithTLS(state *tls.ConnectionState) *http.Request {

--- a/internal/conductor/controlplane/auth_test.go
+++ b/internal/conductor/controlplane/auth_test.go
@@ -199,6 +199,46 @@ func TestScopedBearerAuthorizersEnforceRoleAndScope(t *testing.T) {
 	}
 }
 
+func TestScopedBearerAuthorizersRejectInvalidConfigAndHeaders(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		creds []ScopedBearerCredential
+	}{
+		{name: "empty"},
+		{name: "empty token", creds: []ScopedBearerCredential{{Role: RoleAdmin}}},
+		{name: "bad role", creds: []ScopedBearerCredential{{Token: "token", Role: PrincipalRole("owner")}}},
+		{name: "bad org", creds: []ScopedBearerCredential{{Token: "token", Role: RoleAuditor, OrgID: "-org"}}},
+		{name: "bad fleet", creds: []ScopedBearerCredential{{Token: "token", Role: RoleAuditor, FleetID: "fleet/prod"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ScopedBearerAdminAuthorizer(tc.creds); !errors.Is(err, ErrPublisherForbidden) {
+				t.Fatalf("ScopedBearerAdminAuthorizer() error = %v, want ErrPublisherForbidden", err)
+			}
+		})
+	}
+
+	admin, err := ScopedBearerAdminAuthorizer([]ScopedBearerCredential{{Token: "admin-token", Role: RoleAdmin}})
+	if err != nil {
+		t.Fatalf("ScopedBearerAdminAuthorizer() error = %v", err)
+	}
+	for _, req := range []*http.Request{
+		nil,
+		bearerRequestWithRawAuthorization(t, ""),
+		bearerRequestWithRawAuthorization(t, "Basic admin-token"),
+	} {
+		if err := admin(req); !errors.Is(err, ErrPublisherForbidden) {
+			t.Fatalf("admin(%v) error = %v, want ErrPublisherForbidden", req, err)
+		}
+	}
+
+	if !IsAuthConfigError(ErrFollowerRequired) || !IsAuthConfigError(ErrPublisherForbidden) || !IsAuthConfigError(ErrAuditQueryForbidden) || !IsAuthConfigError(ErrAuditKeyRequired) {
+		t.Fatal("IsAuthConfigError() returned false for known auth config errors")
+	}
+	if IsAuthConfigError(errors.New("other")) {
+		t.Fatal("IsAuthConfigError(other) = true, want false")
+	}
+}
+
 func TestStaticAuditKeyResolverHonorsIdentityBinding(t *testing.T) {
 	pub, _, err := ed25519.GenerateKey(nil)
 	if err != nil {
@@ -320,6 +360,18 @@ func bearerRequest(t *testing.T, path, token string) *http.Request {
 		t.Fatalf("NewRequest: %v", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
+	return req
+}
+
+func bearerRequestWithRawAuthorization(t *testing.T, raw string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, EnrollmentTokensPath, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if raw != "" {
+		req.Header.Set("Authorization", raw)
+	}
 	return req
 }
 

--- a/internal/conductor/controlplane/enrollment.go
+++ b/internal/conductor/controlplane/enrollment.go
@@ -1,0 +1,432 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package controlplane
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const (
+	enrollmentStoreFileMode = 0o600
+	enrollmentTokenBytes    = 32
+	enrollmentTokenPrefix   = "pl_enroll_"
+)
+
+var (
+	ErrEnrollmentStoreRequired  = errors.New("conductor enrollment store required")
+	ErrEnrollmentTokenInvalid   = errors.New("conductor enrollment token invalid")
+	ErrEnrollmentTokenConsumed  = errors.New("conductor enrollment token consumed")
+	ErrEnrollmentTokenExpired   = errors.New("conductor enrollment token expired")
+	ErrEnrollmentActiveInstance = errors.New("conductor follower instance already enrolled")
+)
+
+type EnrollmentStore interface {
+	CreateEnrollmentToken(context.Context, EnrollmentTokenSpec) (IssuedEnrollmentToken, error)
+	ConsumeEnrollmentToken(context.Context, ConsumeEnrollmentTokenRequest) (EnrolledFollower, error)
+	ResolveEnrolledAuditKey(FollowerIdentity, string) (conductor.SignatureKey, error)
+}
+
+type EnrollmentTokenSpec struct {
+	TokenID  string
+	Identity FollowerIdentity
+	Expires  time.Time
+	Now      time.Time
+}
+
+type IssuedEnrollmentToken struct {
+	TokenID   string
+	Token     string
+	ExpiresAt time.Time
+}
+
+type ConsumeEnrollmentTokenRequest struct {
+	Token      string
+	AuditKeyID string
+	AuditKey   conductor.SignatureKey
+	Now        time.Time
+}
+
+type EnrolledFollower struct {
+	Identity   FollowerIdentity
+	AuditKeyID string
+	AuditKey   conductor.SignatureKey
+	EnrolledAt time.Time
+}
+
+type FileEnrollmentStore struct {
+	path string
+	mu   sync.Mutex
+	data enrollmentDiskState
+}
+
+type enrollmentDiskState struct {
+	Tokens    map[string]enrollmentTokenRecord  `json:"tokens"`
+	Followers map[string]enrolledFollowerRecord `json:"followers"`
+}
+
+type enrollmentTokenRecord struct {
+	TokenID      string           `json:"token_id"`
+	TokenHash    string           `json:"token_hash"`
+	Identity     FollowerIdentity `json:"identity"`
+	CreatedAt    time.Time        `json:"created_at"`
+	ExpiresAt    time.Time        `json:"expires_at"`
+	ConsumedAt   *time.Time       `json:"consumed_at,omitempty"`
+	ConsumedByID string           `json:"consumed_by_instance_id,omitempty"`
+}
+
+type enrolledFollowerRecord struct {
+	Identity   FollowerIdentity       `json:"identity"`
+	AuditKeyID string                 `json:"audit_key_id"`
+	AuditKey   conductor.SignatureKey `json:"audit_key"`
+	EnrolledAt time.Time              `json:"enrolled_at"`
+	Active     bool                   `json:"active"`
+}
+
+func OpenFileEnrollmentStore(path string) (*FileEnrollmentStore, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("conductor enrollment store path required")
+	}
+	clean := filepath.Clean(path)
+	dir, err := secureDir(filepath.Dir(clean))
+	if err != nil {
+		return nil, err
+	}
+	store := &FileEnrollmentStore{
+		path: filepath.Join(dir, filepath.Base(clean)),
+		data: enrollmentDiskState{
+			Tokens:    make(map[string]enrollmentTokenRecord),
+			Followers: make(map[string]enrolledFollowerRecord),
+		},
+	}
+	if err := store.load(); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *FileEnrollmentStore) CreateEnrollmentToken(_ context.Context, spec EnrollmentTokenSpec) (IssuedEnrollmentToken, error) {
+	if s == nil {
+		return IssuedEnrollmentToken{}, ErrEnrollmentStoreRequired
+	}
+	spec.TokenID = strings.TrimSpace(spec.TokenID)
+	if err := conductor.ValidateIdentifier("token_id", spec.TokenID); err != nil {
+		return IssuedEnrollmentToken{}, err
+	}
+	if err := spec.Identity.Validate(); err != nil {
+		return IssuedEnrollmentToken{}, err
+	}
+	now := spec.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+	expires := spec.Expires.UTC()
+	if expires.IsZero() || !expires.After(now) {
+		return IssuedEnrollmentToken{}, conductor.ErrInvalidValidityWindow
+	}
+	token, err := newEnrollmentToken()
+	if err != nil {
+		return IssuedEnrollmentToken{}, err
+	}
+	record := enrollmentTokenRecord{
+		TokenID:   spec.TokenID,
+		TokenHash: hashEnrollmentToken(token),
+		Identity:  spec.Identity,
+		CreatedAt: now,
+		ExpiresAt: expires,
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.data.Tokens[spec.TokenID]; exists {
+		return IssuedEnrollmentToken{}, ErrBundleConflict
+	}
+	s.data.Tokens[spec.TokenID] = record
+	if err := s.saveLocked(); err != nil {
+		delete(s.data.Tokens, spec.TokenID)
+		return IssuedEnrollmentToken{}, err
+	}
+	return IssuedEnrollmentToken{TokenID: spec.TokenID, Token: token, ExpiresAt: expires}, nil
+}
+
+func (s *FileEnrollmentStore) ConsumeEnrollmentToken(_ context.Context, req ConsumeEnrollmentTokenRequest) (EnrolledFollower, error) {
+	if s == nil {
+		return EnrolledFollower{}, ErrEnrollmentStoreRequired
+	}
+	req.Token = strings.TrimSpace(req.Token)
+	req.AuditKeyID = strings.TrimSpace(req.AuditKeyID)
+	if req.Token == "" {
+		return EnrolledFollower{}, ErrEnrollmentTokenInvalid
+	}
+	if err := conductor.ValidateIdentifier("audit_key_id", req.AuditKeyID); err != nil {
+		return EnrolledFollower{}, err
+	}
+	if len(req.AuditKey.PublicKey) != ed25519.PublicKeySize || req.AuditKey.KeyPurpose != signing.PurposeAuditBatchSigning {
+		return EnrolledFollower{}, ErrAuditKeyRequired
+	}
+	now := req.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+	tokenHash := hashEnrollmentToken(req.Token)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tokenID, token, ok := s.findTokenByHashLocked(tokenHash)
+	if !ok {
+		return EnrolledFollower{}, ErrEnrollmentTokenInvalid
+	}
+	if token.ConsumedAt != nil {
+		return EnrolledFollower{}, ErrEnrollmentTokenConsumed
+	}
+	if !now.Before(token.ExpiresAt) {
+		return EnrolledFollower{}, ErrEnrollmentTokenExpired
+	}
+	followerKey := followerEnrollmentKey(token.Identity)
+	if follower, ok := s.data.Followers[followerKey]; ok && follower.Active {
+		return EnrolledFollower{}, ErrEnrollmentActiveInstance
+	}
+	previousFollower, hadPreviousFollower := s.data.Followers[followerKey]
+	enrolled := enrolledFollowerRecord{
+		Identity:   token.Identity,
+		AuditKeyID: req.AuditKeyID,
+		AuditKey:   req.AuditKey,
+		EnrolledAt: now,
+		Active:     true,
+	}
+	token.ConsumedAt = &now
+	token.ConsumedByID = token.Identity.InstanceID
+	s.data.Tokens[tokenID] = token
+	s.data.Followers[followerKey] = enrolled
+	if err := s.saveLocked(); err != nil {
+		token.ConsumedAt = nil
+		token.ConsumedByID = ""
+		s.data.Tokens[tokenID] = token
+		if hadPreviousFollower {
+			s.data.Followers[followerKey] = previousFollower
+		} else {
+			delete(s.data.Followers, followerKey)
+		}
+		return EnrolledFollower{}, err
+	}
+	return EnrolledFollower{
+		Identity:   enrolled.Identity,
+		AuditKeyID: enrolled.AuditKeyID,
+		AuditKey:   enrolled.AuditKey,
+		EnrolledAt: enrolled.EnrolledAt,
+	}, nil
+}
+
+func (s *FileEnrollmentStore) ResolveEnrolledAuditKey(identity FollowerIdentity, signerKeyID string) (conductor.SignatureKey, error) {
+	if s == nil {
+		return conductor.SignatureKey{}, conductor.ErrSignatureVerification
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	follower, ok := s.data.Followers[followerEnrollmentKey(identity)]
+	if !ok || !follower.Active || follower.AuditKeyID != signerKeyID {
+		return conductor.SignatureKey{}, conductor.ErrSignatureVerification
+	}
+	return follower.AuditKey, nil
+}
+
+func (s *FileEnrollmentStore) load() error {
+	data, err := os.ReadFile(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read enrollment store: %w", err)
+	}
+	var state enrollmentDiskState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Errorf("decode enrollment store: %w", err)
+	}
+	if state.Tokens == nil {
+		state.Tokens = make(map[string]enrollmentTokenRecord)
+	}
+	if state.Followers == nil {
+		state.Followers = make(map[string]enrolledFollowerRecord)
+	}
+	s.data = state
+	return nil
+}
+
+func (s *FileEnrollmentStore) saveLocked() error {
+	data, err := json.MarshalIndent(s.data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode enrollment store: %w", err)
+	}
+	data = append(data, '\n')
+	if err := durableWrite(s.path, data, enrollmentStoreFileMode); err != nil {
+		return fmt.Errorf("write enrollment store: %w", err)
+	}
+	return nil
+}
+
+func (s *FileEnrollmentStore) findTokenByHashLocked(tokenHash string) (string, enrollmentTokenRecord, bool) {
+	for id, token := range s.data.Tokens {
+		if subtle.ConstantTimeCompare([]byte(token.TokenHash), []byte(tokenHash)) == 1 {
+			return id, token, true
+		}
+	}
+	return "", enrollmentTokenRecord{}, false
+}
+
+func CompositeAuditKeyResolver(primary EnrollmentStore, fallback AuditKeyResolver) AuditKeyResolver {
+	return func(identity FollowerIdentity, signerKeyID string) (conductor.SignatureKey, error) {
+		if primary != nil {
+			key, err := primary.ResolveEnrolledAuditKey(identity, signerKeyID)
+			if err == nil {
+				return key, nil
+			}
+		}
+		if fallback != nil {
+			return fallback(identity, signerKeyID)
+		}
+		return conductor.SignatureKey{}, conductor.ErrSignatureVerification
+	}
+}
+
+func (h *Handler) handleEnrollmentTokens(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w, http.MethodPost)
+		return
+	}
+	if h.enrollments == nil {
+		writeError(w, http.StatusNotImplemented, ErrEnrollmentStoreRequired)
+		return
+	}
+	if err := h.authorizeAdmin(r); err != nil {
+		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
+		return
+	}
+	var req createEnrollmentTokenRequest
+	if err := decodeStrictJSON(w, r, h.maxRequestBody, &req); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, conductor.ErrPayloadTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	issued, err := h.enrollments.CreateEnrollmentToken(r.Context(), EnrollmentTokenSpec{
+		TokenID: req.TokenID,
+		Identity: FollowerIdentity{
+			OrgID:       req.OrgID,
+			FleetID:     req.FleetID,
+			InstanceID:  req.InstanceID,
+			Environment: req.Environment,
+		},
+		Expires: req.ExpiresAt,
+		Now:     h.now(),
+	})
+	if err != nil {
+		writeEnrollmentError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, createEnrollmentTokenResponse(issued))
+}
+
+func (h *Handler) handleEnroll(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w, http.MethodPost)
+		return
+	}
+	if h.enrollments == nil {
+		writeError(w, http.StatusNotImplemented, ErrEnrollmentStoreRequired)
+		return
+	}
+	var req enrollRequest
+	if err := decodeStrictJSON(w, r, h.maxRequestBody, &req); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, conductor.ErrPayloadTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	pub, err := signing.ParsePublicKey(req.AuditPublicKey)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrAuditKeyRequired)
+		return
+	}
+	enrolled, err := h.enrollments.ConsumeEnrollmentToken(r.Context(), ConsumeEnrollmentTokenRequest{
+		Token:      req.Token,
+		AuditKeyID: req.AuditKeyID,
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		Now: h.now(),
+	})
+	if err != nil {
+		writeEnrollmentError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, enrollResponse{
+		OrgID:       enrolled.Identity.OrgID,
+		FleetID:     enrolled.Identity.FleetID,
+		InstanceID:  enrolled.Identity.InstanceID,
+		Environment: enrolled.Identity.Environment,
+		AuditKeyID:  enrolled.AuditKeyID,
+		EnrolledAt:  enrolled.EnrolledAt,
+	})
+}
+
+func writeEnrollmentError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrEnrollmentTokenInvalid), errors.Is(err, ErrEnrollmentTokenConsumed), errors.Is(err, ErrEnrollmentTokenExpired):
+		writeError(w, http.StatusUnauthorized, ErrEnrollmentTokenInvalid)
+	case errors.Is(err, ErrEnrollmentActiveInstance), errors.Is(err, ErrBundleConflict):
+		writeError(w, http.StatusConflict, err)
+	case errors.Is(err, conductor.ErrInvalidValidityWindow),
+		errors.Is(err, conductor.ErrInvalidIdentifier),
+		errors.Is(err, ErrFollowerRequired),
+		errors.Is(err, ErrAuditKeyRequired):
+		writeError(w, http.StatusBadRequest, err)
+	default:
+		writeError(w, http.StatusInternalServerError, errors.New("internal server error"))
+	}
+}
+
+func newEnrollmentToken() (string, error) {
+	var raw [enrollmentTokenBytes]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate enrollment token: %w", err)
+	}
+	return enrollmentTokenPrefix + base64.RawURLEncoding.EncodeToString(raw[:]), nil
+}
+
+func hashEnrollmentToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+func followerEnrollmentKey(identity FollowerIdentity) string {
+	return identity.OrgID + "\x00" + identity.FleetID + "\x00" + identity.InstanceID
+}

--- a/internal/conductor/controlplane/enrollment.go
+++ b/internal/conductor/controlplane/enrollment.go
@@ -34,6 +34,7 @@ const (
 var (
 	ErrEnrollmentStoreRequired  = errors.New("conductor enrollment store required")
 	ErrEnrollmentTokenInvalid   = errors.New("conductor enrollment token invalid")
+	ErrEnrollmentTokenConflict  = errors.New("conductor enrollment token conflicts with existing token")
 	ErrEnrollmentTokenConsumed  = errors.New("conductor enrollment token consumed")
 	ErrEnrollmentTokenExpired   = errors.New("conductor enrollment token expired")
 	ErrEnrollmentActiveInstance = errors.New("conductor follower instance already enrolled")
@@ -159,7 +160,7 @@ func (s *FileEnrollmentStore) CreateEnrollmentToken(_ context.Context, spec Enro
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, exists := s.data.Tokens[spec.TokenID]; exists {
-		return IssuedEnrollmentToken{}, ErrBundleConflict
+		return IssuedEnrollmentToken{}, ErrEnrollmentTokenConflict
 	}
 	s.data.Tokens[spec.TokenID] = record
 	if err := s.saveLocked(); err != nil {
@@ -402,7 +403,7 @@ func writeEnrollmentError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, ErrEnrollmentTokenInvalid), errors.Is(err, ErrEnrollmentTokenConsumed), errors.Is(err, ErrEnrollmentTokenExpired):
 		writeError(w, http.StatusUnauthorized, ErrEnrollmentTokenInvalid)
-	case errors.Is(err, ErrEnrollmentActiveInstance), errors.Is(err, ErrBundleConflict):
+	case errors.Is(err, ErrEnrollmentActiveInstance), errors.Is(err, ErrEnrollmentTokenConflict):
 		writeError(w, http.StatusConflict, err)
 	case errors.Is(err, conductor.ErrInvalidValidityWindow),
 		errors.Is(err, conductor.ErrInvalidIdentifier),

--- a/internal/conductor/controlplane/enrollment.go
+++ b/internal/conductor/controlplane/enrollment.go
@@ -429,5 +429,5 @@ func hashEnrollmentToken(token string) string {
 }
 
 func followerEnrollmentKey(identity FollowerIdentity) string {
-	return identity.OrgID + "\x00" + identity.FleetID + "\x00" + identity.InstanceID
+	return identity.OrgID + "\x00" + identity.FleetID + "\x00" + identity.InstanceID + "\x00" + identity.Environment
 }

--- a/internal/conductor/controlplane/enrollment_test.go
+++ b/internal/conductor/controlplane/enrollment_test.go
@@ -153,3 +153,250 @@ func TestFileEnrollmentStoreRejectsDuplicateActiveInstance(t *testing.T) {
 		t.Fatalf("ConsumeEnrollmentToken(second) error = %v, want ErrEnrollmentActiveInstance", err)
 	}
 }
+
+func TestFileEnrollmentStoreValidatesInputsAndPersists(t *testing.T) {
+	if _, err := OpenFileEnrollmentStore(""); err == nil {
+		t.Fatal("OpenFileEnrollmentStore(empty) error = nil, want error")
+	}
+	path := filepath.Join(t.TempDir(), "enrollments.json")
+	store, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	if _, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "-bad",
+		Identity: defaultFollowerIdentity(),
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	}); !errors.Is(err, conductor.ErrInvalidIdentifier) {
+		t.Fatalf("CreateEnrollmentToken(invalid id) error = %v, want ErrInvalidIdentifier", err)
+	}
+	if _, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "token-expired",
+		Identity: defaultFollowerIdentity(),
+		Expires:  testNow,
+		Now:      testNow,
+	}); !errors.Is(err, conductor.ErrInvalidValidityWindow) {
+		t.Fatalf("CreateEnrollmentToken(expired) error = %v, want ErrInvalidValidityWindow", err)
+	}
+	issued, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "token-1",
+		Identity: defaultFollowerIdentity(),
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	})
+	if err != nil {
+		t.Fatalf("CreateEnrollmentToken(valid) error = %v", err)
+	}
+	if _, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "token-1",
+		Identity: defaultFollowerIdentity(),
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	}); !errors.Is(err, ErrEnrollmentTokenConflict) {
+		t.Fatalf("CreateEnrollmentToken(duplicate) error = %v, want ErrEnrollmentTokenConflict", err)
+	}
+	pub, _ := testAuditSigner(t)
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), ConsumeEnrollmentTokenRequest{}); !errors.Is(err, ErrEnrollmentTokenInvalid) {
+		t.Fatalf("ConsumeEnrollmentToken(empty) error = %v, want ErrEnrollmentTokenInvalid", err)
+	}
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), ConsumeEnrollmentTokenRequest{
+		Token:      issued.Token,
+		AuditKeyID: "-bad",
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		Now: testNow,
+	}); !errors.Is(err, conductor.ErrInvalidIdentifier) {
+		t.Fatalf("ConsumeEnrollmentToken(invalid key id) error = %v, want ErrInvalidIdentifier", err)
+	}
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), ConsumeEnrollmentTokenRequest{
+		Token:      issued.Token,
+		AuditKeyID: "audit-key-1",
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposePolicyBundleSigning,
+		},
+		Now: testNow,
+	}); !errors.Is(err, ErrAuditKeyRequired) {
+		t.Fatalf("ConsumeEnrollmentToken(wrong purpose) error = %v, want ErrAuditKeyRequired", err)
+	}
+	enrolled, err := store.ConsumeEnrollmentToken(context.Background(), ConsumeEnrollmentTokenRequest{
+		Token:      issued.Token,
+		AuditKeyID: "audit-key-1",
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		Now: testNow,
+	})
+	if err != nil {
+		t.Fatalf("ConsumeEnrollmentToken(valid) error = %v", err)
+	}
+	if enrolled.Identity.InstanceID != defaultFollowerIdentity().InstanceID {
+		t.Fatalf("enrolled identity = %+v", enrolled.Identity)
+	}
+	reopened, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore(reopen) error = %v", err)
+	}
+	if _, err := reopened.ResolveEnrolledAuditKey(defaultFollowerIdentity(), "audit-key-1"); err != nil {
+		t.Fatalf("ResolveEnrolledAuditKey(reopened) error = %v", err)
+	}
+	if _, err := reopened.ResolveEnrolledAuditKey(FollowerIdentity{OrgID: "org-main", FleetID: "prod", InstanceID: "other"}, "audit-key-1"); !errors.Is(err, conductor.ErrSignatureVerification) {
+		t.Fatalf("ResolveEnrolledAuditKey(wrong identity) error = %v, want ErrSignatureVerification", err)
+	}
+}
+
+func TestFileEnrollmentStoreRejectsExpiredToken(t *testing.T) {
+	store, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	issued, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "token-1",
+		Identity: defaultFollowerIdentity(),
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	})
+	if err != nil {
+		t.Fatalf("CreateEnrollmentToken() error = %v", err)
+	}
+	pub, _ := testAuditSigner(t)
+	_, err = store.ConsumeEnrollmentToken(context.Background(), ConsumeEnrollmentTokenRequest{
+		Token:      issued.Token,
+		AuditKeyID: "audit-key-1",
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		Now: testNow.Add(time.Hour),
+	})
+	if !errors.Is(err, ErrEnrollmentTokenExpired) {
+		t.Fatalf("ConsumeEnrollmentToken(expired) error = %v, want ErrEnrollmentTokenExpired", err)
+	}
+}
+
+func TestCompositeAuditKeyResolverFallsBack(t *testing.T) {
+	pub, _ := testAuditSigner(t)
+	fallback := auditKeyResolverFor(pub)
+	resolver := CompositeAuditKeyResolver(nil, fallback)
+	if _, err := resolver(defaultFollowerIdentity(), "audit-key-1"); err != nil {
+		t.Fatalf("resolver(fallback) error = %v", err)
+	}
+	resolver = CompositeAuditKeyResolver(nil, nil)
+	if _, err := resolver(defaultFollowerIdentity(), "audit-key-1"); !errors.Is(err, conductor.ErrSignatureVerification) {
+		t.Fatalf("resolver(no sources) error = %v, want ErrSignatureVerification", err)
+	}
+}
+
+func TestHandlerEnrollmentEndpointErrors(t *testing.T) {
+	store, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	handler := newEnrollmentTestHandler(t, store)
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+		want   int
+	}{
+		{"token wrong method", http.MethodGet, EnrollmentTokensPath, http.StatusMethodNotAllowed},
+		{"enroll wrong method", http.MethodGet, EnrollPath, http.StatusMethodNotAllowed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), tc.method, tc.path, nil))
+			if w.Code != tc.want {
+				t.Fatalf("status = %d body=%s, want %d", w.Code, w.Body.String(), tc.want)
+			}
+		})
+	}
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollmentTokensPath, strings.NewReader(`{}`)))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("create without admin status = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollmentTokensPath, strings.NewReader(`{"token_id":"bad","expires_at":"not-time"}`))
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("create invalid JSON status = %d body=%s, want 400", w.Code, w.Body.String())
+	}
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollmentTokensPath, strings.NewReader(`{"token_id":"token-1","org_id":"org-main","fleet_id":"prod","instance_id":"pl-prod-1","environment":"prod","expires_at":"`+testNow.Format(time.RFC3339Nano)+`"}`))
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("create expired status = %d body=%s, want 400", w.Code, w.Body.String())
+	}
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollPath, strings.NewReader(`{"token":"missing","audit_key_id":"audit-key-1","audit_public_key":"not-a-key"}`))
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("enroll invalid key status = %d body=%s, want 400", w.Code, w.Body.String())
+	}
+	body, err := json.Marshal(enrollRequest{
+		Token:          "missing",
+		AuditKeyID:     "audit-key-1",
+		AuditPublicKey: signing.EncodePublicKey(mustAuditPublicKey(t)),
+	})
+	if err != nil {
+		t.Fatalf("Marshal(enroll missing token) error = %v", err)
+	}
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollPath, bytes.NewReader(body))
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("enroll missing token status = %d body=%s, want 401", w.Code, w.Body.String())
+	}
+
+	noStore := newEnrollmentTestHandler(t, nil)
+	w = httptest.NewRecorder()
+	noStore.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollmentTokensPath, nil))
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("create without store status = %d body=%s, want 501", w.Code, w.Body.String())
+	}
+	w = httptest.NewRecorder()
+	noStore.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollPath, nil))
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("enroll without store status = %d body=%s, want 501", w.Code, w.Body.String())
+	}
+}
+
+func newEnrollmentTestHandler(t *testing.T, enrollments EnrollmentStore) *Handler {
+	t.Helper()
+	handler, err := NewHandler(HandlerOptions{
+		Store:        mustStore(t),
+		Capabilities: DefaultCapabilities("conductor-test"),
+		Now:          func() time.Time { return testNow },
+		FollowerIdentity: func(*http.Request) (FollowerIdentity, error) {
+			return defaultFollowerIdentity(), nil
+		},
+		AuthorizePublisher: func(*http.Request) error { return nil },
+		AuthorizeAdmin: func(r *http.Request) error {
+			if r.Header.Get("Authorization") == "Bearer admin-token" {
+				return nil
+			}
+			return ErrPublisherForbidden
+		},
+		AuditSink:   discardAuditSink{},
+		AuditKeys:   rejectingAuditKeyResolver,
+		Enrollments: enrollments,
+	})
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+	return handler
+}
+
+func mustAuditPublicKey(t *testing.T) []byte {
+	t.Helper()
+	pub, _ := testAuditSigner(t)
+	return pub
+}

--- a/internal/conductor/controlplane/enrollment_test.go
+++ b/internal/conductor/controlplane/enrollment_test.go
@@ -154,6 +154,54 @@ func TestFileEnrollmentStoreRejectsDuplicateActiveInstance(t *testing.T) {
 	}
 }
 
+func TestFileEnrollmentStoreSeparatesEnvironments(t *testing.T) {
+	store, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	prod := defaultFollowerIdentity()
+	dev := prod
+	dev.Environment = "dev"
+	first, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "token-prod",
+		Identity: prod,
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	})
+	if err != nil {
+		t.Fatalf("CreateEnrollmentToken(prod) error = %v", err)
+	}
+	second, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "token-dev",
+		Identity: dev,
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	})
+	if err != nil {
+		t.Fatalf("CreateEnrollmentToken(dev) error = %v", err)
+	}
+	pub, _ := testAuditSigner(t)
+	consume := ConsumeEnrollmentTokenRequest{
+		AuditKeyID: "audit-key-1",
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		Now: testNow,
+	}
+	consume.Token = first.Token
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), consume); err != nil {
+		t.Fatalf("ConsumeEnrollmentToken(prod) error = %v", err)
+	}
+	consume.Token = second.Token
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), consume); err != nil {
+		t.Fatalf("ConsumeEnrollmentToken(dev) error = %v", err)
+	}
+	if _, err := store.ResolveEnrolledAuditKey(dev, "audit-key-1"); err != nil {
+		t.Fatalf("ResolveEnrolledAuditKey(dev) error = %v", err)
+	}
+}
+
 func TestFileEnrollmentStoreValidatesInputsAndPersists(t *testing.T) {
 	if _, err := OpenFileEnrollmentStore(""); err == nil {
 		t.Fatal("OpenFileEnrollmentStore(empty) error = nil, want error")

--- a/internal/conductor/controlplane/enrollment_test.go
+++ b/internal/conductor/controlplane/enrollment_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package controlplane
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestHandlerEnrollmentTokenIssuesEnrollsAndAuthenticatesAuditKey(t *testing.T) {
+	enrollments, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	pub, priv := testAuditSigner(t)
+	sink := &captureAuditSink{}
+	handler, err := NewHandler(HandlerOptions{
+		Store:        mustStore(t),
+		Capabilities: DefaultCapabilities("conductor-test"),
+		Now:          func() time.Time { return testNow },
+		FollowerIdentity: func(*http.Request) (FollowerIdentity, error) {
+			return defaultFollowerIdentity(), nil
+		},
+		AuthorizePublisher: func(*http.Request) error { return nil },
+		AuthorizeAdmin: func(r *http.Request) error {
+			if r.Header.Get("Authorization") != "Bearer admin-token" {
+				return ErrPublisherForbidden
+			}
+			return nil
+		},
+		AuditSink:   sink,
+		AuditKeys:   CompositeAuditKeyResolver(enrollments, nil),
+		Enrollments: enrollments,
+	})
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+
+	createBody := createEnrollmentTokenRequest{
+		TokenID:     "enroll-token-1",
+		OrgID:       "org-main",
+		FleetID:     "prod",
+		InstanceID:  "pl-prod-1",
+		Environment: "prod",
+		ExpiresAt:   testNow.Add(time.Hour),
+	}
+	body, err := json.Marshal(createBody)
+	if err != nil {
+		t.Fatalf("Marshal(create) error = %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollmentTokensPath, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create enrollment token status = %d body=%s, want 201", w.Code, w.Body.String())
+	}
+	var issued createEnrollmentTokenResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &issued); err != nil {
+		t.Fatalf("decode issued token: %v", err)
+	}
+	if issued.TokenID != "enroll-token-1" || !strings.HasPrefix(issued.Token, enrollmentTokenPrefix) {
+		t.Fatalf("issued token = %+v", issued)
+	}
+
+	enrollBody, err := json.Marshal(enrollRequest{
+		Token:          issued.Token,
+		AuditKeyID:     "audit-key-1",
+		AuditPublicKey: signing.EncodePublicKey(pub),
+	})
+	if err != nil {
+		t.Fatalf("Marshal(enroll) error = %v", err)
+	}
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollPath, bytes.NewReader(enrollBody)))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("enroll status = %d body=%s, want 201", w.Code, w.Body.String())
+	}
+	var enrolled enrollResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &enrolled); err != nil {
+		t.Fatalf("decode enrolled: %v", err)
+	}
+	if enrolled.OrgID != "org-main" || enrolled.FleetID != "prod" || enrolled.InstanceID != "pl-prod-1" || enrolled.AuditKeyID != "audit-key-1" {
+		t.Fatalf("enrolled = %+v", enrolled)
+	}
+
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollPath, bytes.NewReader(enrollBody)))
+	if w.Code != http.StatusUnauthorized || strings.Contains(w.Body.String(), "consumed") {
+		t.Fatalf("reused token status = %d body=%s, want generic 401", w.Code, w.Body.String())
+	}
+
+	payload := []byte(`{"entry":"from-enrolled-key"}`)
+	w = postAuditBatch(t, handler, signedAuditIngestRequest(t, defaultFollowerIdentity(), payload, priv, testNow))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("audit ingest with enrolled key status = %d body=%s, want 202", w.Code, w.Body.String())
+	}
+	if len(sink.batches) != 1 || string(sink.batches[0].Payload) != string(payload) {
+		t.Fatalf("sink batches = %+v", sink.batches)
+	}
+}
+
+func TestFileEnrollmentStoreRejectsDuplicateActiveInstance(t *testing.T) {
+	store, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	first, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "token-1",
+		Identity: defaultFollowerIdentity(),
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	})
+	if err != nil {
+		t.Fatalf("CreateEnrollmentToken(first) error = %v", err)
+	}
+	second, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "token-2",
+		Identity: defaultFollowerIdentity(),
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	})
+	if err != nil {
+		t.Fatalf("CreateEnrollmentToken(second) error = %v", err)
+	}
+	pub, _ := testAuditSigner(t)
+	consume := ConsumeEnrollmentTokenRequest{
+		AuditKeyID: "audit-key-1",
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		Now: testNow,
+	}
+	consume.Token = first.Token
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), consume); err != nil {
+		t.Fatalf("ConsumeEnrollmentToken(first) error = %v", err)
+	}
+	consume.Token = second.Token
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), consume); !errors.Is(err, ErrEnrollmentActiveInstance) {
+		t.Fatalf("ConsumeEnrollmentToken(second) error = %v, want ErrEnrollmentActiveInstance", err)
+	}
+}

--- a/internal/conductor/controlplane/handler.go
+++ b/internal/conductor/controlplane/handler.go
@@ -194,19 +194,21 @@ func NewHandler(opts HandlerOptions) (*Handler, error) {
 	}
 	authorizeAuditQuery := opts.AuthorizeAuditQuery
 	if authorizeAuditQuery == nil {
-		authorizeAuditQuery = func(r *http.Request, _ AuditBatchQuery) error {
-			return opts.AuthorizePublisher(r)
+		authorizeAuditQuery = func(*http.Request, AuditBatchQuery) error {
+			return ErrAuditQueryForbidden
 		}
 	}
 	authorizeBundle := opts.AuthorizeBundle
 	if authorizeBundle == nil {
-		authorizeBundle = func(r *http.Request, _ conductor.PolicyBundle) error {
-			return opts.AuthorizePublisher(r)
+		authorizeBundle = func(*http.Request, conductor.PolicyBundle) error {
+			return ErrPublisherForbidden
 		}
 	}
 	authorizeAdmin := opts.AuthorizeAdmin
 	if authorizeAdmin == nil {
-		authorizeAdmin = opts.AuthorizePublisher
+		authorizeAdmin = func(*http.Request) error {
+			return ErrPublisherForbidden
+		}
 	}
 	auditQuerier, _ := opts.AuditSink.(AuditBatchQuerier)
 	return &Handler{

--- a/internal/conductor/controlplane/handler.go
+++ b/internal/conductor/controlplane/handler.go
@@ -23,6 +23,8 @@ const (
 	PublishPolicyBundlePath = "/api/v1/conductor/policy-bundles"
 	LatestPolicyBundlePath  = "/api/v1/conductor/policy/latest"
 	AuditBatchesPath        = conductor.AuditBatchesPath
+	EnrollPath              = "/api/v1/conductor/enroll"
+	EnrollmentTokensPath    = "/api/v1/conductor/enrollment-tokens" //nolint:gosec // route constant, not a credential
 	HealthPath              = "/health"
 	HealthzPath             = "/healthz"
 	MetricsPath             = "/metrics"
@@ -48,6 +50,16 @@ type FollowerIdentityResolver func(*http.Request) (FollowerIdentity, error)
 // a non-nil error causes the publish endpoint to respond with HTTP 403.
 type PublisherAuthorizer func(*http.Request) error
 
+// BundleAuthorizer authorizes a parsed policy bundle after transport/client
+// authentication has already succeeded. It exists so production wiring can
+// enforce org/fleet scoped publisher credentials instead of treating bearer
+// possession as global publish authority.
+type BundleAuthorizer func(*http.Request, conductor.PolicyBundle) error
+
+// AuditQueryAuthorizer authorizes a parsed metadata query. It MUST scope
+// callers to the org/fleet they are permitted to inspect.
+type AuditQueryAuthorizer func(*http.Request, AuditBatchQuery) error
+
 type HandlerOptions struct {
 	Store               BundleStore
 	Capabilities        conductor.CapabilitiesResponse
@@ -56,9 +68,12 @@ type HandlerOptions struct {
 	MaxAuditBodyBytes   int64
 	FollowerIdentity    FollowerIdentityResolver
 	AuthorizePublisher  PublisherAuthorizer
-	AuthorizeAuditQuery PublisherAuthorizer
+	AuthorizeBundle     BundleAuthorizer
+	AuthorizeAuditQuery AuditQueryAuthorizer
+	AuthorizeAdmin      PublisherAuthorizer
 	AuditSink           AuditBatchSink
 	AuditKeys           AuditKeyResolver
+	Enrollments         EnrollmentStore
 	Metrics             *metrics.Metrics
 	Logger              *slog.Logger
 }
@@ -71,12 +86,15 @@ type Handler struct {
 	maxAuditBody        int64
 	followerIdentity    FollowerIdentityResolver
 	authorizePublisher  PublisherAuthorizer
-	authorizeAuditQuery PublisherAuthorizer
+	authorizeBundle     BundleAuthorizer
+	authorizeAuditQuery AuditQueryAuthorizer
+	authorizeAdmin      PublisherAuthorizer
 	auditSink           AuditBatchSink
 	// nil auditQuerier means the configured sink does not implement
 	// [AuditBatchQuerier], so GET returns 501 rather than a retryable 500.
 	auditQuerier AuditBatchQuerier
 	auditKeys    AuditKeyResolver
+	enrollments  EnrollmentStore
 	metrics      *metrics.Metrics
 	logger       *slog.Logger
 }
@@ -91,6 +109,36 @@ type publishPolicyBundleResponse struct {
 	Version     uint64    `json:"version"`
 	PublishedAt time.Time `json:"published_at"`
 	Created     bool      `json:"created"`
+}
+
+type createEnrollmentTokenRequest struct {
+	TokenID     string    `json:"token_id"`
+	OrgID       string    `json:"org_id"`
+	FleetID     string    `json:"fleet_id"`
+	InstanceID  string    `json:"instance_id"`
+	Environment string    `json:"environment"`
+	ExpiresAt   time.Time `json:"expires_at"`
+}
+
+type createEnrollmentTokenResponse struct {
+	TokenID   string    `json:"token_id"`
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+type enrollRequest struct {
+	Token          string `json:"token"`
+	AuditKeyID     string `json:"audit_key_id"`
+	AuditPublicKey string `json:"audit_public_key"`
+}
+
+type enrollResponse struct {
+	OrgID       string    `json:"org_id"`
+	FleetID     string    `json:"fleet_id"`
+	InstanceID  string    `json:"instance_id"`
+	Environment string    `json:"environment"`
+	AuditKeyID  string    `json:"audit_key_id"`
+	EnrolledAt  time.Time `json:"enrolled_at"`
 }
 
 type healthResponse struct {
@@ -146,7 +194,19 @@ func NewHandler(opts HandlerOptions) (*Handler, error) {
 	}
 	authorizeAuditQuery := opts.AuthorizeAuditQuery
 	if authorizeAuditQuery == nil {
-		authorizeAuditQuery = opts.AuthorizePublisher
+		authorizeAuditQuery = func(r *http.Request, _ AuditBatchQuery) error {
+			return opts.AuthorizePublisher(r)
+		}
+	}
+	authorizeBundle := opts.AuthorizeBundle
+	if authorizeBundle == nil {
+		authorizeBundle = func(r *http.Request, _ conductor.PolicyBundle) error {
+			return opts.AuthorizePublisher(r)
+		}
+	}
+	authorizeAdmin := opts.AuthorizeAdmin
+	if authorizeAdmin == nil {
+		authorizeAdmin = opts.AuthorizePublisher
 	}
 	auditQuerier, _ := opts.AuditSink.(AuditBatchQuerier)
 	return &Handler{
@@ -157,10 +217,13 @@ func NewHandler(opts HandlerOptions) (*Handler, error) {
 		maxAuditBody:        maxAuditBody,
 		followerIdentity:    opts.FollowerIdentity,
 		authorizePublisher:  opts.AuthorizePublisher,
+		authorizeBundle:     authorizeBundle,
 		authorizeAuditQuery: authorizeAuditQuery,
+		authorizeAdmin:      authorizeAdmin,
 		auditSink:           opts.AuditSink,
 		auditQuerier:        auditQuerier,
 		auditKeys:           opts.AuditKeys,
+		enrollments:         opts.Enrollments,
 		metrics:             opts.Metrics,
 		logger:              opts.Logger,
 	}, nil
@@ -213,6 +276,10 @@ func (h *Handler) serveControlHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case conductor.CapabilitiesPath:
 		h.handleCapabilities(w, r)
+	case EnrollmentTokensPath:
+		h.handleEnrollmentTokens(w, r)
+	case EnrollPath:
+		h.handleEnroll(w, r)
 	case PublishPolicyBundlePath:
 		h.handlePublishPolicyBundle(w, r)
 	case LatestPolicyBundlePath:
@@ -270,7 +337,7 @@ func (h *Handler) recordRequest(r *http.Request, route string, status int, durat
 
 func conductorRoute(path string) string {
 	switch path {
-	case HealthPath, HealthzPath, MetricsPath, ReadyzPath, conductor.CapabilitiesPath, PublishPolicyBundlePath, LatestPolicyBundlePath, AuditBatchesPath:
+	case HealthPath, HealthzPath, MetricsPath, ReadyzPath, conductor.CapabilitiesPath, EnrollmentTokensPath, EnrollPath, PublishPolicyBundlePath, LatestPolicyBundlePath, AuditBatchesPath:
 		return path
 	default:
 		return "unknown"
@@ -403,6 +470,10 @@ func (h *Handler) handlePublishPolicyBundle(w http.ResponseWriter, r *http.Reque
 			return
 		}
 		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := h.authorizeBundle(r, req.Bundle); err != nil {
+		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return
 	}
 	record, created, err := h.store.Publish(r.Context(), req.Bundle, PublishOptions{Now: h.now()})

--- a/internal/conductor/controlplane/handler_errors_test.go
+++ b/internal/conductor/controlplane/handler_errors_test.go
@@ -4,10 +4,13 @@
 package controlplane
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -46,6 +49,57 @@ func TestNewHandlerValidation(t *testing.T) {
 		Capabilities:       conductor.CapabilitiesResponse{SchemaVersion: conductor.SchemaVersion},
 	}); err == nil {
 		t.Fatal("NewHandler(invalid capabilities) error = nil, want error")
+	}
+}
+
+func TestHandlerDefaultAuthorizersDenyNewScopedOperations(t *testing.T) {
+	enrollments, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	auditStore := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	defer func() { _ = auditStore.Close() }()
+	handler, err := NewHandler(HandlerOptions{
+		Store:        mustStore(t),
+		Capabilities: DefaultCapabilities("conductor-test"),
+		Now:          func() time.Time { return testNow },
+		FollowerIdentity: func(*http.Request) (FollowerIdentity, error) {
+			return defaultFollowerIdentity(), nil
+		},
+		AuthorizePublisher: func(*http.Request) error { return nil },
+		AuditSink:          auditStore,
+		AuditKeys:          rejectingAuditKeyResolver,
+		Enrollments:        enrollments,
+	})
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+
+	bundle := signedControlBundle(t, newTestSigner(t), bundleSpec{
+		id:       "bundle-1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"pl-prod-1"}},
+	})
+	body, err := json.Marshal(publishPolicyBundleRequest{Bundle: bundle})
+	if err != nil {
+		t.Fatalf("Marshal(bundle) error = %v", err)
+	}
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodPut, PublishPolicyBundlePath, bytes.NewReader(body)))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("publish status = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, AuditBatchesPath+"?org_id=org-main", nil))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("audit query status = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollmentTokensPath, strings.NewReader(`{}`)))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("enrollment token status = %d body=%s, want 403", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/conductor/controlplane/handler_test.go
+++ b/internal/conductor/controlplane/handler_test.go
@@ -319,16 +319,20 @@ func newTestHandler(t *testing.T, store BundleStore, identity FollowerIdentityRe
 			}, nil
 		}
 	}
+	publisher := func(r *http.Request) error {
+		if r.Header.Get("X-Pipelock-Publisher") != "ok" {
+			return ErrPublisherForbidden
+		}
+		return nil
+	}
 	handler, err := NewHandler(HandlerOptions{
-		Store:            store,
-		Capabilities:     DefaultCapabilities("conductor-test"),
-		Now:              func() time.Time { return testNow },
-		FollowerIdentity: identity,
-		AuthorizePublisher: func(r *http.Request) error {
-			if r.Header.Get("X-Pipelock-Publisher") != "ok" {
-				return ErrPublisherForbidden
-			}
-			return nil
+		Store:              store,
+		Capabilities:       DefaultCapabilities("conductor-test"),
+		Now:                func() time.Time { return testNow },
+		FollowerIdentity:   identity,
+		AuthorizePublisher: publisher,
+		AuthorizeBundle: func(r *http.Request, _ conductor.PolicyBundle) error {
+			return publisher(r)
 		},
 		AuditSink: discardAuditSink{},
 		AuditKeys: rejectingAuditKeyResolver,

--- a/internal/conductor/controlplane/handler_test.go
+++ b/internal/conductor/controlplane/handler_test.go
@@ -173,7 +173,7 @@ func TestHandlerMetricsAndRequestLogging(t *testing.T) {
 			return FollowerIdentity{}, ErrFollowerRequired
 		},
 		AuthorizePublisher: func(*http.Request) error { return ErrPublisherForbidden },
-		AuditSink:          discardAuditSink{},
+		AuditSink:          failingAuditQuerySink{},
 		AuditKeys:          rejectingAuditKeyResolver,
 		Metrics:            m,
 		Logger:             slog.New(slog.NewJSONHandler(&logs, nil)),


### PR DESCRIPTION
## Summary
- Add one-shot Conductor enrollment token issue/use endpoints with durable token state and active-instance duplicate protection
- Store enrolled follower audit keys and resolve them for audit ingest, with static trusted audit keys preserved as an optional fallback
- Add scoped bearer authorizers for publisher, auditor, and admin paths and wire CLI token files for each role
- Document enrollment, admin auth, and enrolled audit-key behavior in the audit sink spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scoped role-based bearer tokens for admin, publisher and auditor roles with optional org/fleet constraints.
  * One-shot enrollment token issuance and enrollment endpoints for follower onboarding.
  * Followers now generate local keys; conductor stops minting follower leaf certificates.
  * Expanded audit-ingest endpoints and stricter validation of signed audit batches.
  * CLI serve options to provide auditor and admin token files.

* **Documentation**
  * Spec updated with enrollment protocol and audit-ingest MVP details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->