### PR TITLE
feat(proxy): reverse_proxy.profile: submit + per-listener trusted_upstream

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2383,6 +2383,40 @@ reverse_proxy:
 | `listen` | (required) | Listen address for the reverse proxy |
 | `upstream` | (required) | Upstream service URL to forward to |
 
+### Submit Profile
+
+`profile: submit` narrows a reverse-proxy listener for controlled submission endpoints. It preserves the generic reverse-proxy body and response scanning, then adds method and path gates, a trusted upstream declaration, an explicit body cap, a per-request timeout, and a full upstream URL scan before forwarding.
+
+```yaml
+reverse_proxy:
+  enabled: true
+  listen: "127.0.0.1:8890"
+  upstream: "https://submit.example.com:443"
+  profile: submit
+  allowed_methods: ["POST"]
+  allowed_paths:
+    - exact: "/v1/batch"
+  trusted_upstream:
+    host: "submit.example.com"
+    port: 443
+    reason: "submission endpoint"
+    added: "2026-05-26"
+    expires: "2026-08-24"
+  max_body_bytes: 1048576
+  request_timeout_seconds: 10
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `profile` | `""` | Empty keeps generic reverse-proxy behavior. `submit` enables the constrained submission gate. |
+| `allowed_methods` | `["POST"]` | HTTP methods allowed by the submit listener. Values must be known methods. |
+| `allowed_paths` | required | Exact canonical paths allowed by the submit listener. Entries must start with `/`; encoded dot, slash, backslash, semicolon path parameters, and non-canonical request paths are rejected. |
+| `trusted_upstream` | required | Auditable host+port trust declaration. `host` and `port` must exactly match `upstream`; IP literals are rejected; `reason` and `added` are required; expired `expires` dates fail config load. |
+| `max_body_bytes` | required | Positive listener body cap. The effective cap is the smaller of this value and `request_body_scanning.max_body_bytes`. |
+| `request_timeout_seconds` | required | Positive total request timeout for the submit listener, including scanning and upstream forwarding. |
+
+`profile: submit` does not by itself install the fetch/forward proxy dial-time SSRF-safe transport. The submit listener still constrains destination by exact configured host+port and runs the upstream URL through the scanner before forwarding.
+
 ### CLI flags
 
 ```bash

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -875,7 +876,7 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 	if live.Conductor != oldCfg.Conductor {
 		t.Fatalf("conductor settings not preserved: %+v", live.Conductor)
 	}
-	if live.ReverseProxy != oldCfg.ReverseProxy {
+	if !reflect.DeepEqual(live.ReverseProxy, oldCfg.ReverseProxy) {
 		t.Fatalf("reverse proxy settings not preserved: %+v", live.ReverseProxy)
 	}
 	for _, want := range []string{

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -119,7 +119,7 @@ const (
 	// preserves current behavior; "block" causes the consumer to cancel
 	// the proxy ctx on agent-attributed findings, which is observably
 	// different enforcement.
-	goldenHashDefaults = "de4d3761e1b0ca49ea4521c0ace44350282ae9c382e8e15dc36b450971c6777c"
+	goldenHashDefaults = "e167ea2ed69766c470bb7964e4163d6ad083d1d63719adc7e44752bced596041"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -181,7 +181,7 @@ const (
 	// note. The rich fixture omits dns:, so the field is empty but still
 	// part of the canonical view.
 	// Re-bumped for file_sentry.action: same rationale as goldenHashDefaults.
-	goldenHashRichConfig = "c17e20708f463010ee973574fcc7d763133aeb5845b13cba8fa389ce6fb85476"
+	goldenHashRichConfig = "e67707c35590ea0f4a6504bbadb13c3c2aa709778181e4edc6892c1c6dca0e3f"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/reverse_submit_validate_test.go
+++ b/internal/config/reverse_submit_validate_test.go
@@ -126,6 +126,28 @@ func TestValidate_ReverseProxySubmit_ReasonRequired(t *testing.T) {
 	}
 }
 
+func TestValidate_ReverseProxySubmit_ReasonWhitespaceRejected(t *testing.T) {
+	// A reason of "   \t  " satisfies the != "" check but provides no
+	// audit content. Validation must trim before evaluating the guard.
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.TrustedUpstream.Reason = "   \t  "
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "reason is required") {
+		t.Fatalf("got %v, want whitespace-only-reason rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_ReasonTrimmedOnAccept(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.TrustedUpstream.Reason = "   audit grant w/ trim   "
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("valid trimmed reason rejected: %v", err)
+	}
+	if got := cfg.ReverseProxy.TrustedUpstream.Reason; got != "audit grant w/ trim" {
+		t.Errorf("reason = %q, want trimmed value", got)
+	}
+}
+
 func TestValidate_ReverseProxySubmit_AddedRequired(t *testing.T) {
 	cfg := submitValidCfg()
 	cfg.ReverseProxy.TrustedUpstream.Added = ""

--- a/internal/config/reverse_submit_validate_test.go
+++ b/internal/config/reverse_submit_validate_test.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// submitValidCfg builds a config that satisfies every submit-profile
+// validation rule. Tests then mutate one field and assert the expected
+// rejection — the negative-test pattern from validate.go's existing tests.
+func submitValidCfg() *Config {
+	cfg := Defaults()
+	cfg.ReverseProxy.Enabled = true
+	cfg.ReverseProxy.Listen = "127.0.0.1:8892"
+	cfg.ReverseProxy.Upstream = "http://example.test:30891"
+	cfg.ReverseProxy.Profile = ReverseProxyProfileSubmit
+	cfg.ReverseProxy.AllowedMethods = []string{"POST"}
+	cfg.ReverseProxy.AllowedPaths = []ReverseProxyPathRule{{Exact: "/v1/batch"}}
+	cfg.ReverseProxy.MaxBodyBytes = 1024 * 1024
+	cfg.ReverseProxy.RequestTimeoutSeconds = 30
+	cfg.ReverseProxy.TrustedUpstream = ReverseProxyTrustedUpstream{
+		Host:   "example.test",
+		Port:   30891,
+		Reason: "test",
+		Added:  "2026-05-26",
+	}
+	cfg.ApplyDefaults()
+	return cfg
+}
+
+func TestValidate_ReverseProxySubmit_AcceptsValidConfig(t *testing.T) {
+	if err := submitValidCfg().Validate(); err != nil {
+		t.Fatalf("valid submit-profile config rejected: %v", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_UnknownProfileRejected(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.Profile = "lenient"
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "not a known profile") {
+		t.Fatalf("got %v, want unknown-profile rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_FieldsRequiredWithoutProfile(t *testing.T) {
+	// Setting submit-only fields without the profile selector must be
+	// rejected so an operator can't silently lose submit semantics by
+	// typo'ing the profile name.
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.Profile = ""
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "only valid when profile") {
+		t.Fatalf("got %v, want submit-only-fields rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_TrustedUpstreamRequired(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.TrustedUpstream = ReverseProxyTrustedUpstream{}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "trusted_upstream is required") {
+		t.Fatalf("got %v, want trusted_upstream-required rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_HostMismatchRejected(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.TrustedUpstream.Host = "other.test"
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "does not match upstream host") {
+		t.Fatalf("got %v, want host-mismatch rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_HostMatchNormalizesCaseAndTrailingDot(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.Upstream = "http://Example.Test.:30891"
+	cfg.ReverseProxy.TrustedUpstream.Host = " EXAMPLE.TEST. "
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("case/trailing-dot equivalent host rejected: %v", err)
+	}
+	if cfg.ReverseProxy.TrustedUpstream.Host != "example.test" {
+		t.Fatalf("trusted_upstream.host = %q, want normalized example.test", cfg.ReverseProxy.TrustedUpstream.Host)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_PortMismatchRejected(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.TrustedUpstream.Port = 12345
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "does not match upstream port") {
+		t.Fatalf("got %v, want port-mismatch rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_IPLiteralRejected(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.Upstream = "http://127.0.0.1:30891"
+	cfg.ReverseProxy.TrustedUpstream.Host = "127.0.0.1"
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "IP literal") {
+		t.Fatalf("got %v, want IP-literal rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_UpstreamWithoutPortRejected(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.Upstream = "http://example.test"
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "explicit port") {
+		t.Fatalf("got %v, want explicit-port rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_ReasonRequired(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.TrustedUpstream.Reason = ""
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "reason is required") {
+		t.Fatalf("got %v, want reason-required rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_AddedRequired(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.TrustedUpstream.Added = ""
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "added is required") {
+		t.Fatalf("got %v, want added-required rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_AddedFormatRejected(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.TrustedUpstream.Added = "May 26 2026"
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "must be YYYY-MM-DD") {
+		t.Fatalf("got %v, want added-format rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_ExpiresPastRejected(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.TrustedUpstream.Expires = time.Now().UTC().AddDate(0, 0, -2).Format("2006-01-02")
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "in the past") {
+		t.Fatalf("got %v, want expired rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_ExpiresFutureAccepted(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.TrustedUpstream.Expires = time.Now().UTC().AddDate(0, 0, 30).Format("2006-01-02")
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("future-expiry rejected: %v", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_AllowedPathsRequired(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.AllowedPaths = nil
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "allowed_paths is required") {
+		t.Fatalf("got %v, want allowed_paths-required rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_AllowedPathNonCanonical(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.AllowedPaths = []ReverseProxyPathRule{{Exact: "/v1//batch"}}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "not canonical") {
+		t.Fatalf("got %v, want non-canonical rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_AllowedPathMustStartWithSlash(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.AllowedPaths = []ReverseProxyPathRule{{Exact: "v1/batch"}}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "must start with /") {
+		t.Fatalf("got %v, want must-start-with-/ rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_UnknownMethodRejected(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.AllowedMethods = []string{"WHATEVER"}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "not a recognized HTTP method") {
+		t.Fatalf("got %v, want unknown-method rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_BodyBytesRequiredPositive(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.MaxBodyBytes = 0
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "max_body_bytes must be positive") {
+		t.Fatalf("got %v, want max_body_bytes rejection", err)
+	}
+}
+
+func TestValidate_ReverseProxySubmit_TimeoutRequiredPositive(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.RequestTimeoutSeconds = 0
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "request_timeout_seconds must be positive") {
+		t.Fatalf("got %v, want request_timeout_seconds rejection", err)
+	}
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -500,6 +500,70 @@ type ReverseProxy struct {
 	Enabled  bool   `yaml:"enabled"`
 	Listen   string `yaml:"listen"`   // listen address (e.g. ":8888")
 	Upstream string `yaml:"upstream"` // upstream URL (e.g. "http://localhost:7899")
+
+	// Profile selects a constrained reverse-proxy behavior. Empty (default)
+	// preserves the existing generic reverse proxy. "submit" tightens the
+	// listener for narrow internal POST submissions: method+path allowlist,
+	// per-listener trusted_upstream gate, body DLP enforced BEFORE
+	// forwarding, request timeout, and full upstream URL scan. Dial-time
+	// SSRF-safe transport is a follow-up hardening path, not part of this
+	// profile field by itself.
+	//
+	// `profile:` is distinct from top-level `mode:` (strict/balanced/audit).
+	// Top-level mode is enforcement posture; profile is listener shape.
+	Profile string `yaml:"profile"`
+
+	// AllowedMethods constrains which HTTP methods the listener accepts.
+	// Empty in submit profile means "POST only" at request time.
+	AllowedMethods []string `yaml:"allowed_methods"`
+
+	// AllowedPaths constrains which paths the listener accepts. v1 supports
+	// exact-match only. The matcher compares against the canonical decoded
+	// request path; raw paths containing encoded traversal (%2e%2e/),
+	// encoded slash/backslash (%2f, %5c), semicolon path params, or
+	// canonicalization changes are rejected at request time.
+	AllowedPaths []ReverseProxyPathRule `yaml:"allowed_paths"`
+
+	// TrustedUpstream declares that the configured upstream host+port is
+	// the only destination this listener will reach. The host+port must
+	// exact-match the host+port parsed from Upstream. Required when
+	// profile is "submit".
+	TrustedUpstream ReverseProxyTrustedUpstream `yaml:"trusted_upstream"`
+
+	// MaxBodyBytes caps request body size at the listener level. Effective
+	// cap when used with body scanning is
+	// min(MaxBodyBytes, request_body_scanning.max_body_bytes); requests
+	// exceeding the cap return 413 BEFORE forwarding.
+	MaxBodyBytes int64 `yaml:"max_body_bytes"`
+
+	// RequestTimeoutSeconds bounds total per-request time including upstream
+	// dial + body forwarding. Required positive when profile is "submit".
+	RequestTimeoutSeconds int `yaml:"request_timeout_seconds"`
+}
+
+// ReverseProxyPathRule is one entry under reverse_proxy.allowed_paths.
+// Only the exact form is supported in v1; the YAML decoder rejects
+// unknown fields so adding a future "prefix:" or "regex:" cannot be
+// silently misconfigured.
+type ReverseProxyPathRule struct {
+	Exact string `yaml:"exact"`
+}
+
+// ReverseProxyTrustedUpstream is a per-listener trust declaration that
+// scopes the SSRF allowlist to exactly the upstream this listener is
+// configured to talk to. It is intentionally narrower than the global
+// SSRF allowlist: a host listed here is trusted ONLY for the port also
+// listed here, and ONLY for this listener.
+//
+// Required fields when profile is "submit": Host, Port, Reason, Added.
+// Expires is optional but recommended; if present, an expired entry
+// fails the load.
+type ReverseProxyTrustedUpstream struct {
+	Host    string `yaml:"host"`
+	Port    int    `yaml:"port"`
+	Reason  string `yaml:"reason"`
+	Added   string `yaml:"added"`   // RFC 3339 date (YYYY-MM-DD)
+	Expires string `yaml:"expires"` // RFC 3339 date (YYYY-MM-DD), optional
 }
 
 // GitProtection configures git-aware security features.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1691,10 +1691,15 @@ func (c *Config) validateReverseProxySubmit(u *url.URL) error {
 	if tu.Port <= 0 || tu.Port > 65535 {
 		return fmt.Errorf("reverse_proxy.trusted_upstream.port must be 1-65535, got %d", tu.Port)
 	}
-	if tu.Reason == "" {
+	// Reason is required for auditability. Trim first so a config of
+	// "   " or "\t" cannot satisfy the required guard with no actual
+	// audit content. Persist the trimmed value so downstream callers
+	// (logs, doctor output) get the canonical form.
+	if strings.TrimSpace(tu.Reason) == "" {
 		return fmt.Errorf("reverse_proxy.trusted_upstream.reason is required so the trust grant is auditable")
 	}
-	if tu.Added == "" {
+	c.ReverseProxy.TrustedUpstream.Reason = strings.TrimSpace(tu.Reason)
+	if strings.TrimSpace(tu.Added) == "" {
 		return fmt.Errorf("reverse_proxy.trusted_upstream.added is required (date the entry was created)")
 	}
 	if _, err := time.Parse("2006-01-02", tu.Added); err != nil {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -9,11 +9,13 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1623,7 +1625,158 @@ func (c *Config) validateReverseProxy() error {
 	if c.ReverseProxy.Listen == "" {
 		return fmt.Errorf("reverse_proxy.listen is required when reverse_proxy is enabled")
 	}
+	return c.validateReverseProxyProfile(u)
+}
+
+// ReverseProxyProfileSubmit is the constrained profile selector for the
+// reverse proxy listener. Empty profile (the default) preserves the
+// generic behavior; "submit" enables the full submission-profile gate.
+const ReverseProxyProfileSubmit = "submit"
+
+// validateReverseProxyProfile enforces the per-profile config rules.
+// u is the already-parsed upstream URL from validateReverseProxy.
+func (c *Config) validateReverseProxyProfile(u *url.URL) error {
+	rp := c.ReverseProxy
+	switch rp.Profile {
+	case "":
+		// Generic reverse proxy. No additional fields required, but if any
+		// submit-profile-only fields ARE set, fail loudly rather than let
+		// the operator believe submit semantics are in effect.
+		if hasSubmitProfileFields(rp) {
+			return fmt.Errorf("reverse_proxy: allowed_methods/allowed_paths/trusted_upstream/max_body_bytes/request_timeout_seconds are only valid when profile is %q; set profile or remove these fields", ReverseProxyProfileSubmit)
+		}
+		return nil
+	case ReverseProxyProfileSubmit:
+		return c.validateReverseProxySubmit(u)
+	default:
+		return fmt.Errorf("reverse_proxy.profile %q is not a known profile (allowed: \"\" or %q)", rp.Profile, ReverseProxyProfileSubmit)
+	}
+}
+
+// hasSubmitProfileFields reports whether any submit-profile-only fields are
+// set on a generic reverse_proxy config. Used to reject silent misconfig
+// where an operator typo'd or removed `profile: submit` but left the
+// submit-only fields populated.
+func hasSubmitProfileFields(rp ReverseProxy) bool {
+	switch {
+	case len(rp.AllowedMethods) > 0:
+		return true
+	case len(rp.AllowedPaths) > 0:
+		return true
+	case rp.TrustedUpstream != (ReverseProxyTrustedUpstream{}):
+		return true
+	case rp.MaxBodyBytes != 0:
+		return true
+	case rp.RequestTimeoutSeconds != 0:
+		return true
+	}
+	return false
+}
+
+// validateReverseProxySubmit enforces submit-profile config rules. See the
+// design doc at projects/pipelock/sprints/pipelock-submit-mode-design.md
+// for the per-rule rationale.
+func (c *Config) validateReverseProxySubmit(u *url.URL) error {
+	rp := c.ReverseProxy
+	tu := rp.TrustedUpstream
+
+	if tu == (ReverseProxyTrustedUpstream{}) {
+		return fmt.Errorf("reverse_proxy.trusted_upstream is required when profile is %q", ReverseProxyProfileSubmit)
+	}
+	tu.Host = normalizeReverseProxySubmitHost(tu.Host)
+	if tu.Host == "" {
+		return fmt.Errorf("reverse_proxy.trusted_upstream.host is required when profile is %q", ReverseProxyProfileSubmit)
+	}
+	c.ReverseProxy.TrustedUpstream.Host = tu.Host
+	if tu.Port <= 0 || tu.Port > 65535 {
+		return fmt.Errorf("reverse_proxy.trusted_upstream.port must be 1-65535, got %d", tu.Port)
+	}
+	if tu.Reason == "" {
+		return fmt.Errorf("reverse_proxy.trusted_upstream.reason is required so the trust grant is auditable")
+	}
+	if tu.Added == "" {
+		return fmt.Errorf("reverse_proxy.trusted_upstream.added is required (date the entry was created)")
+	}
+	if _, err := time.Parse("2006-01-02", tu.Added); err != nil {
+		return fmt.Errorf("reverse_proxy.trusted_upstream.added %q must be YYYY-MM-DD: %w", tu.Added, err)
+	}
+	if tu.Expires != "" {
+		expiresAt, err := time.Parse("2006-01-02", tu.Expires)
+		if err != nil {
+			return fmt.Errorf("reverse_proxy.trusted_upstream.expires %q must be YYYY-MM-DD: %w", tu.Expires, err)
+		}
+		// End-of-day in UTC for the day named. An entry whose Expires is
+		// "2026-05-26" stays valid through 2026-05-26 23:59:59 UTC.
+		expiresEnd := expiresAt.Add(24*time.Hour - time.Second)
+		if expiresEnd.Before(time.Now().UTC()) {
+			return fmt.Errorf("reverse_proxy.trusted_upstream.expires %q is in the past", tu.Expires)
+		}
+	}
+
+	// IP literals on the trusted_upstream host defeat the "narrow,
+	// auditable, hostname-bound" intent. Match the existing scanner
+	// constraint that trusted destinations must be hostnames.
+	if net.ParseIP(tu.Host) != nil {
+		return fmt.Errorf("reverse_proxy.trusted_upstream.host %q is an IP literal; use a hostname", tu.Host)
+	}
+
+	upstreamHost, upstreamPortStr, splitErr := net.SplitHostPort(u.Host)
+	if splitErr != nil {
+		// No explicit port. Submit profile requires explicit port so the
+		// trusted_upstream binding is unambiguous.
+		return fmt.Errorf("reverse_proxy.upstream %q must include an explicit port for profile %q", rp.Upstream, ReverseProxyProfileSubmit)
+	}
+	upstreamHost = normalizeReverseProxySubmitHost(upstreamHost)
+	if upstreamHost != tu.Host {
+		return fmt.Errorf("reverse_proxy.trusted_upstream.host %q does not match upstream host %q", tu.Host, upstreamHost)
+	}
+	upstreamPort, portErr := strconv.Atoi(upstreamPortStr)
+	if portErr != nil {
+		return fmt.Errorf("reverse_proxy.upstream port %q is not a valid number: %w", upstreamPortStr, portErr)
+	}
+	if upstreamPort != tu.Port {
+		return fmt.Errorf("reverse_proxy.trusted_upstream.port %d does not match upstream port %d", tu.Port, upstreamPort)
+	}
+
+	if len(rp.AllowedPaths) == 0 {
+		return fmt.Errorf("reverse_proxy.allowed_paths is required when profile is %q", ReverseProxyProfileSubmit)
+	}
+	for i, p := range rp.AllowedPaths {
+		if p.Exact == "" {
+			return fmt.Errorf("reverse_proxy.allowed_paths[%d].exact is required (no other matcher kind supported in v1)", i)
+		}
+		if !strings.HasPrefix(p.Exact, "/") {
+			return fmt.Errorf("reverse_proxy.allowed_paths[%d].exact %q must start with /", i, p.Exact)
+		}
+		// Strict canonicality: reject path entries whose canonical decoded
+		// form differs from the operator's literal value, so the matcher
+		// at request time has only one shape to compare against.
+		if cleaned := path.Clean(p.Exact); cleaned != p.Exact {
+			return fmt.Errorf("reverse_proxy.allowed_paths[%d].exact %q is not canonical (use %q)", i, p.Exact, cleaned)
+		}
+	}
+
+	for i, m := range rp.AllowedMethods {
+		switch strings.ToUpper(m) {
+		case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+			http.MethodPatch, http.MethodDelete, http.MethodOptions:
+		default:
+			return fmt.Errorf("reverse_proxy.allowed_methods[%d] %q is not a recognized HTTP method", i, m)
+		}
+	}
+
+	if rp.MaxBodyBytes <= 0 {
+		return fmt.Errorf("reverse_proxy.max_body_bytes must be positive when profile is %q", ReverseProxyProfileSubmit)
+	}
+	if rp.RequestTimeoutSeconds <= 0 {
+		return fmt.Errorf("reverse_proxy.request_timeout_seconds must be positive when profile is %q", ReverseProxyProfileSubmit)
+	}
+
 	return nil
+}
+
+func normalizeReverseProxySubmitHost(host string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
 }
 
 func (c *Config) validateSandbox() error {

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/blockreason"
@@ -361,6 +362,11 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	ctx = context.WithValue(ctx, ctxKeyReverseEnvelopeCfg, cfg)
 	ctx = context.WithValue(ctx, ctxKeyReverseScanner, sc)
 	r = r.WithContext(ctx)
+	if cfg.ReverseProxy.Profile == config.ReverseProxyProfileSubmit && cfg.ReverseProxy.RequestTimeoutSeconds > 0 {
+		timeoutCtx, cancel := context.WithTimeout(r.Context(), time.Duration(cfg.ReverseProxy.RequestTimeoutSeconds)*time.Second)
+		defer cancel()
+		r = r.WithContext(timeoutCtx)
+	}
 
 	if err := verifyInboundEnvelope(r, cfg, snap.inboundVerifier); err != nil {
 		recordInboundEnvelopeVerify(rp.metrics, cfg, err)
@@ -435,6 +441,42 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			blockInfoFor(blockreason.KillSwitchActive, ""),
 			"kill switch active")
 		return
+	}
+
+	// Submit-profile gate (no-op when cfg.ReverseProxy.Profile == "").
+	// Runs BEFORE URL DLP and body scanning so denied requests do not
+	// consume scanner cycles and so the operator's tighter rules (method
+	// allowlist, exact-path match, raw-path canonicality, body cap) are
+	// applied before generic checks.
+	if gate := evaluateSubmitProfileGate(cfg, r); !gate.Allowed {
+		rp.metrics.RecordReverseProxyRequest(r.Method, http.StatusText(gate.Status))
+		rp.metrics.RecordReverseProxyScanBlocked(scanDirectionRequest, scannerLabelSubmitProfile)
+		writeReverseProxyBlock(w, gate.Status, gate.Block, gate.Reason)
+		return
+	}
+
+	// Submit-profile upstream-URL scan (no-op when profile is empty).
+	// The generic reverse proxy skips the full URL pipeline because the
+	// upstream is operator-configured; submit profile tightens this so
+	// the scanner still flags blocklist hits, rate-limit-blown
+	// destinations, or pattern-matching anomalies on the upstream URL
+	// before we forward. The target is the full upstream URL the
+	// request will actually reach, not the path-only r.URL the proxy
+	// sees from the client.
+	if cfg.ReverseProxy.Profile == config.ReverseProxyProfileSubmit {
+		urlResult := sc.Scan(r.Context(), targetURL)
+		if !urlResult.Allowed {
+			rp.metrics.RecordReverseProxyRequest(r.Method, "403")
+			rp.metrics.RecordReverseProxyScanBlocked(scanDirectionRequest, scannerLabelSubmitProfile)
+			reason := urlResult.Reason
+			if reason == "" {
+				reason = "submit profile: upstream URL scan denied"
+			}
+			writeReverseProxyBlock(w, http.StatusForbidden,
+				blockInfo(urlResult.Scanner),
+				reason)
+			return
+		}
 	}
 
 	// Scan request path and query for DLP patterns. Secrets embedded in

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -449,7 +449,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	// allowlist, exact-path match, raw-path canonicality, body cap) are
 	// applied before generic checks.
 	if gate := evaluateSubmitProfileGate(cfg, r); !gate.Allowed {
-		rp.metrics.RecordReverseProxyRequest(r.Method, http.StatusText(gate.Status))
+		rp.metrics.RecordReverseProxyRequest(r.Method, strconv.Itoa(gate.Status))
 		rp.metrics.RecordReverseProxyScanBlocked(scanDirectionRequest, scannerLabelSubmitProfile)
 		writeReverseProxyBlock(w, gate.Status, gate.Block, gate.Reason)
 		return

--- a/internal/proxy/reverse_submit.go
+++ b/internal/proxy/reverse_submit.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// submitProfileGateResult signals whether the request passed the submit
+// profile's per-request checks and what to do next.
+type submitProfileGateResult struct {
+	// Allowed is true when the request may continue down the existing
+	// reverse-proxy pipeline.
+	Allowed bool
+	// Status is the HTTP status to return when Allowed is false.
+	Status int
+	// Block carries the blockreason info (X-Pipelock-Block-Reason headers + body).
+	Block blockreason.Info
+	// Reason is the user-facing reason string for writeReverseProxyBlock.
+	Reason string
+}
+
+func submitProfileAllow() submitProfileGateResult {
+	return submitProfileGateResult{Allowed: true}
+}
+
+func submitProfileDeny(status int, info blockreason.Info, reason string) submitProfileGateResult {
+	return submitProfileGateResult{
+		Allowed: false,
+		Status:  status,
+		Block:   info,
+		Reason:  reason,
+	}
+}
+
+// evaluateSubmitProfileGate runs the per-request checks that the submit
+// profile adds on top of the generic reverse proxy. It is a no-op when
+// cfg.ReverseProxy.Profile is empty.
+//
+// Order of checks matches the threat model:
+//
+//  1. Method allowlist (cheapest, deterministic; rejects probe scans)
+//  2. Raw-path canonicality (catches encoded-traversal evasions before
+//     decoding shifts the path under us)
+//  3. Path allowlist against the canonical decoded path
+//  4. Body size against the listener cap (returns 413; never forwards)
+//
+// Body DLP, header DLP, and upstream URL scanning happen downstream in the
+// existing reverse-proxy pipeline. Dial-time SSRF hardening is intentionally
+// separate from this gate so the trust path can be audited independently.
+func evaluateSubmitProfileGate(cfg *config.Config, r *http.Request) submitProfileGateResult {
+	if cfg.ReverseProxy.Profile != config.ReverseProxyProfileSubmit {
+		return submitProfileAllow()
+	}
+
+	// 1. Method allowlist. Empty defaults to POST-only.
+	allowedMethods := cfg.ReverseProxy.AllowedMethods
+	if len(allowedMethods) == 0 {
+		allowedMethods = []string{http.MethodPost}
+	}
+	methodAllowed := false
+	for _, m := range allowedMethods {
+		if strings.EqualFold(m, r.Method) {
+			methodAllowed = true
+			break
+		}
+	}
+	if !methodAllowed {
+		return submitProfileDeny(
+			http.StatusMethodNotAllowed,
+			blockInfoFor(blockreason.BadRequest, scannerLabelSubmitProfile),
+			"submit profile: method "+r.Method+" not in allowed_methods",
+		)
+	}
+
+	// 2. Raw-path canonicality. The path string the client sent must not
+	// contain encoded traversal or encoded path separators; those would let
+	// a request match a different allowed_paths entry after decoding.
+	// We compare against r.URL.EscapedPath() (the literal path bytes as
+	// received) rather than r.URL.Path (already decoded).
+	if reason, ok := submitProfileRawPathRejection(r.URL.EscapedPath()); !ok {
+		return submitProfileDeny(
+			http.StatusBadRequest,
+			blockInfoFor(blockreason.BadRequest, scannerLabelSubmitProfile),
+			"submit profile: raw path rejected: "+reason,
+		)
+	}
+
+	// 3. Path allowlist against canonical decoded path. r.URL.Path is the
+	// already-decoded form; path.Clean drops any stray dot segments. The
+	// allowed_paths entries are validated at config load to be canonical
+	// and start with /, so this is an exact byte comparison.
+	canonicalPath := path.Clean(r.URL.Path)
+	if canonicalPath != r.URL.Path {
+		// Canonicalization changed the path, meaning the request contained
+		// `/.`, `//`, or `/..` segments. Reject before allowlist comparison.
+		return submitProfileDeny(
+			http.StatusBadRequest,
+			blockInfoFor(blockreason.BadRequest, scannerLabelSubmitProfile),
+			"submit profile: decoded path is not canonical",
+		)
+	}
+	pathAllowed := false
+	for _, p := range cfg.ReverseProxy.AllowedPaths {
+		if p.Exact == canonicalPath {
+			pathAllowed = true
+			break
+		}
+	}
+	if !pathAllowed {
+		return submitProfileDeny(
+			http.StatusNotFound,
+			blockInfoFor(blockreason.BadRequest, scannerLabelSubmitProfile),
+			"submit profile: path "+canonicalPath+" not in allowed_paths",
+		)
+	}
+
+	// 4. Body size cap. Effective cap = min(reverse_proxy.max_body_bytes,
+	// request_body_scanning.max_body_bytes). Compare r.ContentLength;
+	// chunked requests (ContentLength == -1) get a 411 because the cap
+	// cannot be enforced before reading.
+	bodyCap := effectiveSubmitBodyCap(cfg)
+	if bodyCap <= 0 {
+		// Should not happen — validateReverseProxySubmit requires positive.
+		// Defense in depth: fail closed if the operator's config slipped past.
+		return submitProfileDeny(
+			http.StatusInternalServerError,
+			blockInfoFor(blockreason.PatternUnavailable, scannerLabelSubmitProfile),
+			"submit profile: effective body cap is not configured",
+		)
+	}
+	if r.ContentLength < 0 {
+		return submitProfileDeny(
+			http.StatusLengthRequired,
+			blockInfoFor(blockreason.PatternUnavailable, scannerLabelSubmitProfile),
+			"submit profile: requests must declare Content-Length",
+		)
+	}
+	if r.ContentLength > bodyCap {
+		return submitProfileDeny(
+			http.StatusRequestEntityTooLarge,
+			blockInfoFor(blockreason.DataBudget, scannerLabelSubmitProfile),
+			"submit profile: body exceeds effective cap",
+		)
+	}
+
+	return submitProfileAllow()
+}
+
+// effectiveSubmitBodyCap returns min(reverse_proxy.max_body_bytes,
+// request_body_scanning.max_body_bytes), preferring whichever is positive
+// when only one is set. Returns 0 only when both are non-positive (an
+// invalid post-validation state). The scanner field is int; widen to int64
+// for the comparison.
+func effectiveSubmitBodyCap(cfg *config.Config) int64 {
+	listenerCap := cfg.ReverseProxy.MaxBodyBytes
+	scannerCap := int64(cfg.RequestBodyScanning.MaxBodyBytes)
+	switch {
+	case listenerCap > 0 && scannerCap > 0:
+		if listenerCap < scannerCap {
+			return listenerCap
+		}
+		return scannerCap
+	case listenerCap > 0:
+		return listenerCap
+	case scannerCap > 0:
+		return scannerCap
+	}
+	return 0
+}
+
+// submitProfileRawPathRejection inspects the request's raw (still-encoded)
+// path for evasion patterns that would let a request match a different
+// allowed_paths entry after decoding. Returns (reason, false) when the
+// raw path contains a forbidden pattern, ("", true) otherwise.
+//
+// Patterns rejected:
+//
+//   - %2e or %2E (encoded dot — would let "/%2e%2e/foo" canonicalize to "/foo")
+//   - %2f or %2F (encoded slash — would let "/api%2fsecret" appear as one segment)
+//   - %5c or %5C (encoded backslash — Windows path traversal in some parsers)
+//   - %25 (encoded percent — blocks double-encoded traversal like %252e%252e)
+//   - ; (semicolon path parameter — RFC 3986 leftover that some routers strip)
+func submitProfileRawPathRejection(rawPath string) (string, bool) {
+	upper := strings.ToUpper(rawPath)
+	switch {
+	case strings.Contains(upper, "%25"):
+		return "encoded percent (%25)", false
+	case strings.Contains(upper, "%2E"):
+		return "encoded dot (%2e)", false
+	case strings.Contains(upper, "%2F"):
+		return "encoded slash (%2f)", false
+	case strings.Contains(upper, "%5C"):
+		return "encoded backslash (%5c)", false
+	case strings.Contains(rawPath, ";"):
+		return "semicolon path parameter", false
+	}
+	return "", true
+}
+
+// scannerLabelSubmitProfile is the scanner-layer label used in receipts
+// and block headers for submit-profile-originated denials.
+const scannerLabelSubmitProfile = "reverse_proxy_submit"

--- a/internal/proxy/reverse_submit.go
+++ b/internal/proxy/reverse_submit.go
@@ -187,6 +187,8 @@ func effectiveSubmitBodyCap(cfg *config.Config) int64 {
 //   - %5c or %5C (encoded backslash — Windows path traversal in some parsers)
 //   - %25 (encoded percent — blocks double-encoded traversal like %252e%252e)
 //   - ; (semicolon path parameter — RFC 3986 leftover that some routers strip)
+//   - %3b or %3B (encoded semicolon — would decode to ; after the gate
+//     runs, defeating the literal-semicolon rejection above)
 func submitProfileRawPathRejection(rawPath string) (string, bool) {
 	upper := strings.ToUpper(rawPath)
 	switch {
@@ -198,6 +200,8 @@ func submitProfileRawPathRejection(rawPath string) (string, bool) {
 		return "encoded slash (%2f)", false
 	case strings.Contains(upper, "%5C"):
 		return "encoded backslash (%5c)", false
+	case strings.Contains(upper, "%3B"):
+		return "encoded semicolon (%3b)", false
 	case strings.Contains(rawPath, ";"):
 		return "semicolon path parameter", false
 	}

--- a/internal/proxy/reverse_submit_test.go
+++ b/internal/proxy/reverse_submit_test.go
@@ -255,8 +255,15 @@ func TestSubmitProfile_URLScanUsesScannerBlockReason(t *testing.T) {
 	cfg, upstreamURL := submitProfileTestConfig(upstream.URL)
 	proxy := submitProfileReverseProxy(t, cfg, upstreamURL)
 
+	// Build the DLP-tripping URL via variables so the source at the
+	// request call site does not display a credential-in-URL literal
+	// that the pipelock self-scan in CI would flag. The runtime URL
+	// is identical; only the source form changes.
+	tripValue := fakeAPIKey()
+	reqURL := proxy.URL + "/v1/batch?" + "token=" + tripValue
+
 	req, _ := http.NewRequestWithContext(context.Background(),
-		http.MethodPost, proxy.URL+"/v1/batch?token=AKIA"+"IOSFODNN7EXAMPLE", strings.NewReader(`{"clean":true}`))
+		http.MethodPost, reqURL, strings.NewReader(`{"clean":true}`))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/internal/proxy/reverse_submit_test.go
+++ b/internal/proxy/reverse_submit_test.go
@@ -1,0 +1,434 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/killswitch"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+// submitProfileTestConfig builds a config wired up for submit profile,
+// targeting the upstream URL passed in. Skips Validate() because httptest
+// URLs are IP literals (127.0.0.1) and submit profile rejects IP literals
+// on trusted_upstream.host by design — tests still exercise request-time
+// gating which doesn't care about the load-time hostname constraint.
+func submitProfileTestConfig(upstreamURL string) (*config.Config, *url.URL) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+
+	u, err := url.Parse(upstreamURL)
+	if err != nil {
+		panic("submitProfileTestConfig: parse upstream URL: " + err.Error())
+	}
+
+	cfg.ReverseProxy.Enabled = true
+	cfg.ReverseProxy.Profile = config.ReverseProxyProfileSubmit
+	cfg.ReverseProxy.Listen = "127.0.0.1:0" // tests use newIPv4Server
+	cfg.ReverseProxy.Upstream = upstreamURL
+	cfg.ReverseProxy.AllowedMethods = []string{http.MethodPost}
+	cfg.ReverseProxy.AllowedPaths = []config.ReverseProxyPathRule{
+		{Exact: "/v1/batch"},
+	}
+	cfg.ReverseProxy.MaxBodyBytes = 6 * 1024 * 1024
+	cfg.ReverseProxy.RequestTimeoutSeconds = 30
+
+	host, portStr, _ := net.SplitHostPort(u.Host)
+	port, _ := strconv.Atoi(portStr)
+	cfg.ReverseProxy.TrustedUpstream = config.ReverseProxyTrustedUpstream{
+		Host:   host,
+		Port:   port,
+		Reason: "test upstream",
+		Added:  "2026-05-26",
+	}
+
+	cfg.RequestBodyScanning.Enabled = true
+	cfg.RequestBodyScanning.Action = config.ActionBlock
+	cfg.RequestBodyScanning.MaxBodyBytes = 6 * 1024 * 1024
+
+	return cfg, u
+}
+
+// submitProfileReverseProxy spins up a NewReverseProxy fronting a test
+// upstream, using the same wiring reverseTestSetup uses but parameterized
+// on cfg + upstream URL since submit-profile tests need to control both.
+func submitProfileReverseProxy(t *testing.T, cfg *config.Config, upstreamURL *url.URL) *httptest.Server {
+	t.Helper()
+
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	var cfgPtr atomic.Pointer[config.Config]
+	var scPtr atomic.Pointer[scanner.Scanner]
+	cfgPtr.Store(cfg)
+	scPtr.Store(sc)
+
+	logger, _ := audit.New("json", "stdout", "", false, false)
+	t.Cleanup(logger.Close)
+
+	m := metrics.New()
+	ks := killswitch.New(cfg)
+
+	handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, logger, m, ks, nil, nil)
+	proxy := newIPv4Server(t, handler)
+	t.Cleanup(proxy.Close)
+	return proxy
+}
+
+// TestSubmitProfile_BodyDLPBlocksBeforeForward is the gating CI test
+// from the submit-mode design doc. A DLP-positive body sent to the
+// configured allowed path must:
+//
+//  1. Return 403 to the caller
+//  2. Carry X-Pipelock-Block-Reason: dlp_match
+//  3. Never reach the upstream handler (asserted via t.Fatalf)
+func TestSubmitProfile_BodyDLPBlocksBeforeForward(t *testing.T) {
+	var upstreamHit atomic.Bool
+	upstream := newIPv4Server(t, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		upstreamHit.Store(true)
+		t.Errorf("upstream MUST NOT be invoked when body trips DLP; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer upstream.Close()
+
+	cfg, upstreamURL := submitProfileTestConfig(upstream.URL)
+	proxy := submitProfileReverseProxy(t, cfg, upstreamURL)
+
+	body := `{"k":"AKIA` + `IOSFODNN7EXAMPLE"}`
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		proxy.URL+"/v1/batch",
+		strings.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (DLP body match must block)", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.DLPMatch) {
+		t.Errorf("block reason = %q, want %s", got, blockreason.DLPMatch)
+	}
+	if upstreamHit.Load() {
+		t.Error("upstream was invoked despite body DLP block — fail-closed contract violated")
+	}
+}
+
+// TestSubmitProfile_MethodNotAllowed verifies the per-listener method
+// allowlist rejects requests with a non-allowed method before any
+// scanning or upstream dial.
+func TestSubmitProfile_MethodNotAllowed(t *testing.T) {
+	var upstreamHit atomic.Bool
+	upstream := newIPv4Server(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		upstreamHit.Store(true)
+	}))
+	defer upstream.Close()
+
+	cfg, upstreamURL := submitProfileTestConfig(upstream.URL)
+	proxy := submitProfileReverseProxy(t, cfg, upstreamURL)
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, proxy.URL+"/v1/batch", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405 (GET not in allowed_methods)", resp.StatusCode)
+	}
+	if upstreamHit.Load() {
+		t.Error("upstream was invoked despite method allowlist denial")
+	}
+}
+
+// TestSubmitProfile_PathRejection verifies that paths outside the
+// allowed_paths exact-match list are rejected before any scanning.
+func TestSubmitProfile_PathRejection(t *testing.T) {
+	tests := []struct {
+		name           string
+		path           string
+		wantStatus     int
+		wantBlockedRaw bool
+	}{
+		{"path-not-in-allowlist", "/v1/other", http.StatusNotFound, false},
+		{"encoded-traversal", "/v1/%2e%2e/etc/passwd", http.StatusBadRequest, true},
+		{"double-encoded-traversal", "/v1/%252e%252e/etc/passwd", http.StatusBadRequest, true},
+		{"encoded-slash", "/v1%2fbatch", http.StatusBadRequest, true},
+		{"encoded-backslash", "/v1%5cbatch", http.StatusBadRequest, true},
+		{"semicolon-param", "/v1/batch;foo=bar", http.StatusBadRequest, true},
+		{"double-slash-canonicalizes", "//v1//batch", http.StatusBadRequest, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var upstreamHit atomic.Bool
+			upstream := newIPv4Server(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				upstreamHit.Store(true)
+			}))
+			defer upstream.Close()
+
+			cfg, upstreamURL := submitProfileTestConfig(upstream.URL)
+			proxy := submitProfileReverseProxy(t, cfg, upstreamURL)
+
+			req, _ := http.NewRequestWithContext(context.Background(),
+				http.MethodPost, proxy.URL+tc.path, strings.NewReader(`{}`))
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("post: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Errorf("status = %d, want %d for path %q", resp.StatusCode, tc.wantStatus, tc.path)
+			}
+			if upstreamHit.Load() {
+				t.Errorf("upstream invoked despite path rejection for %q", tc.path)
+			}
+		})
+	}
+}
+
+// TestSubmitProfile_BodyTooLarge verifies oversized bodies are rejected
+// with 413 BEFORE forwarding — body never reaches upstream.
+func TestSubmitProfile_BodyTooLarge(t *testing.T) {
+	var upstreamHit atomic.Bool
+	upstream := newIPv4Server(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		upstreamHit.Store(true)
+	}))
+	defer upstream.Close()
+
+	cfg, upstreamURL := submitProfileTestConfig(upstream.URL)
+	cfg.ReverseProxy.MaxBodyBytes = 1024 // tiny cap for test
+	cfg.RequestBodyScanning.MaxBodyBytes = 1024
+	proxy := submitProfileReverseProxy(t, cfg, upstreamURL)
+
+	oversized := strings.Repeat("a", 2048)
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, proxy.URL+"/v1/batch", strings.NewReader(oversized))
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = int64(len(oversized))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413 (body cap exceeded)", resp.StatusCode)
+	}
+	if upstreamHit.Load() {
+		t.Error("upstream invoked despite oversized body")
+	}
+}
+
+func TestSubmitProfile_URLScanUsesScannerBlockReason(t *testing.T) {
+	var upstreamHit atomic.Bool
+	upstream := newIPv4Server(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		upstreamHit.Store(true)
+	}))
+	defer upstream.Close()
+
+	cfg, upstreamURL := submitProfileTestConfig(upstream.URL)
+	proxy := submitProfileReverseProxy(t, cfg, upstreamURL)
+
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, proxy.URL+"/v1/batch?token=AKIA"+"IOSFODNN7EXAMPLE", strings.NewReader(`{"clean":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.DLPMatch) {
+		t.Errorf("block reason = %q, want %s", got, blockreason.DLPMatch)
+	}
+	if upstreamHit.Load() {
+		t.Error("upstream invoked despite upstream URL DLP denial")
+	}
+}
+
+// TestSubmitProfile_CleanRequestForwards verifies a request that satisfies
+// every gate (allowed method, allowed path, body within cap, no DLP) DOES
+// reach the upstream.
+func TestSubmitProfile_CleanRequestForwards(t *testing.T) {
+	var upstreamHit atomic.Bool
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHit.Store(true)
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/batch" {
+			t.Errorf("upstream got unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	cfg, upstreamURL := submitProfileTestConfig(upstream.URL)
+	proxy := submitProfileReverseProxy(t, cfg, upstreamURL)
+
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, proxy.URL+"/v1/batch", strings.NewReader(`{"clean":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if !upstreamHit.Load() {
+		t.Error("upstream was NOT invoked for a clean request that should forward")
+	}
+}
+
+func TestSubmitProfile_RequestTimeoutApplied(t *testing.T) {
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(1500 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg, upstreamURL := submitProfileTestConfig(upstream.URL)
+	cfg.ReverseProxy.RequestTimeoutSeconds = 1
+	proxy := submitProfileReverseProxy(t, cfg, upstreamURL)
+
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, proxy.URL+"/v1/batch", strings.NewReader(`{"clean":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	start := time.Now()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 from upstream timeout", resp.StatusCode)
+	}
+	if elapsed := time.Since(start); elapsed > 1400*time.Millisecond {
+		t.Errorf("request took %s, want timeout before upstream handler completes", elapsed)
+	}
+}
+
+// TestSubmitProfile_GenericProfileUnaffected verifies the gate is a no-op
+// when profile is empty (the default generic reverse proxy). A request
+// that would be denied under submit profile (wrong path) goes through
+// the existing generic pipeline unchanged.
+func TestSubmitProfile_GenericProfileUnaffected(t *testing.T) {
+	var upstreamHit atomic.Bool
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHit.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg, upstreamURL := submitProfileTestConfig(upstream.URL)
+	// Strip submit-profile selector — request path should now be allowed
+	// to reach upstream because the generic profile has no allowlist.
+	cfg.ReverseProxy.Profile = ""
+	cfg.ReverseProxy.AllowedMethods = nil
+	cfg.ReverseProxy.AllowedPaths = nil
+	cfg.ReverseProxy.TrustedUpstream = config.ReverseProxyTrustedUpstream{}
+	cfg.ReverseProxy.MaxBodyBytes = 0
+	cfg.ReverseProxy.RequestTimeoutSeconds = 0
+	proxy := submitProfileReverseProxy(t, cfg, upstreamURL)
+
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodGet, proxy.URL+"/anything", nil) // GET would be denied under submit
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if !upstreamHit.Load() {
+		t.Errorf("generic profile should not gate; upstream was not reached (status %d)", resp.StatusCode)
+	}
+}
+
+func TestSubmitProfileRawPathRejection(t *testing.T) {
+	tests := []struct {
+		path     string
+		wantBad  bool
+		wantWhat string
+	}{
+		{"/v1/batch", false, ""},
+		{"/v1/%2e%2e/etc", true, "encoded dot"},
+		{"/v1/%2E", true, "encoded dot"},
+		{"/v1/%252e%252e/etc", true, "encoded percent"},
+		{"/v1%2fbatch", true, "encoded slash"},
+		{"/v1%2Fbatch", true, "encoded slash"},
+		{"/v1%5cbatch", true, "encoded backslash"},
+		{"/v1/batch;foo=bar", true, "semicolon"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			reason, ok := submitProfileRawPathRejection(tc.path)
+			if tc.wantBad && ok {
+				t.Errorf("expected %q rejected, got ok", tc.path)
+			}
+			if !tc.wantBad && !ok {
+				t.Errorf("expected %q allowed, got rejected: %s", tc.path, reason)
+			}
+			if tc.wantBad && !strings.Contains(reason, tc.wantWhat) {
+				t.Errorf("reason %q does not mention %q", reason, tc.wantWhat)
+			}
+		})
+	}
+}
+
+func TestEffectiveSubmitBodyCap(t *testing.T) {
+	tests := []struct {
+		name        string
+		listenerCap int64
+		scannerCap  int
+		want        int64
+	}{
+		{"listener-smaller-wins", 1024, 4096, 1024},
+		{"scanner-smaller-wins", 4096, 1024, 1024},
+		{"only-listener-set", 1024, 0, 1024},
+		{"only-scanner-set", 0, 1024, 1024},
+		{"neither-set-returns-zero", 0, 0, 0},
+		{"equal-caps", 1024, 1024, 1024},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Defaults()
+			cfg.ReverseProxy.MaxBodyBytes = tc.listenerCap
+			cfg.RequestBodyScanning.MaxBodyBytes = tc.scannerCap
+			got := effectiveSubmitBodyCap(cfg)
+			if got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/proxy/reverse_submit_test.go
+++ b/internal/proxy/reverse_submit_test.go
@@ -23,6 +23,17 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
+// upstreamURLFromHTTPTest parses a host:port out of an httptest.Server URL
+// (e.g., "http://127.0.0.1:NNNN"). Used by the URL-scan isolation test
+// when configuring a blocklist entry that matches only the upstream host.
+func upstreamURLFromHTTPTest(httpURL string) string {
+	u, err := url.Parse(httpURL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
 // submitProfileTestConfig builds a config wired up for submit profile,
 // targeting the upstream URL passed in. Skips Validate() because httptest
 // URLs are IP literals (127.0.0.1) and submit profile rejects IP literals
@@ -180,6 +191,7 @@ func TestSubmitProfile_PathRejection(t *testing.T) {
 		{"encoded-slash", "/v1%2fbatch", http.StatusBadRequest, true},
 		{"encoded-backslash", "/v1%5cbatch", http.StatusBadRequest, true},
 		{"semicolon-param", "/v1/batch;foo=bar", http.StatusBadRequest, true},
+		{"encoded-semicolon", "/v1/batch%3bfoo=bar", http.StatusBadRequest, true},
 		{"double-slash-canonicalizes", "//v1//batch", http.StatusBadRequest, true},
 	}
 	for _, tc := range tests {
@@ -252,16 +264,22 @@ func TestSubmitProfile_URLScanUsesScannerBlockReason(t *testing.T) {
 	}))
 	defer upstream.Close()
 
+	// Isolate the NEW upstream-URL scan path from the pre-existing
+	// path+query DLP scan: use a blocklist trigger that only fires on
+	// the full upstream URL (which includes the upstream's host), not
+	// on the path-only r.URL.RequestURI() that the path-DLP scan sees.
+	// Without this isolation, a credential in ?token=... would also fire
+	// the path-DLP scan and the test could not tell which code path
+	// produced the 403.
+	upstreamHost, _, splitErr := net.SplitHostPort(upstreamURLFromHTTPTest(upstream.URL))
+	if splitErr != nil {
+		t.Fatalf("split upstream host: %v", splitErr)
+	}
 	cfg, upstreamURL := submitProfileTestConfig(upstream.URL)
+	cfg.FetchProxy.Monitoring.Blocklist = []string{upstreamHost}
 	proxy := submitProfileReverseProxy(t, cfg, upstreamURL)
 
-	// Build the DLP-tripping URL via variables so the source at the
-	// request call site does not display a credential-in-URL literal
-	// that the pipelock self-scan in CI would flag. The runtime URL
-	// is identical; only the source form changes.
-	tripValue := fakeAPIKey()
-	reqURL := proxy.URL + "/v1/batch?" + "token=" + tripValue
-
+	reqURL := proxy.URL + "/v1/batch"
 	req, _ := http.NewRequestWithContext(context.Background(),
 		http.MethodPost, reqURL, strings.NewReader(`{"clean":true}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -274,11 +292,15 @@ func TestSubmitProfile_URLScanUsesScannerBlockReason(t *testing.T) {
 	if resp.StatusCode != http.StatusForbidden {
 		t.Errorf("status = %d, want 403", resp.StatusCode)
 	}
-	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.DLPMatch) {
-		t.Errorf("block reason = %q, want %s", got, blockreason.DLPMatch)
+	// The upstream URL scan denies on domain_blocklist; this proves the
+	// submit-profile URL scan ran (the path-only DLP scan cannot trigger
+	// blocklist denials because it operates on r.URL.RequestURI() which
+	// has no host component).
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.DomainBlocklist) {
+		t.Errorf("block reason = %q, want %s", got, blockreason.DomainBlocklist)
 	}
 	if upstreamHit.Load() {
-		t.Error("upstream invoked despite upstream URL DLP denial")
+		t.Error("upstream invoked despite upstream URL scan denial")
 	}
 }
 
@@ -396,6 +418,8 @@ func TestSubmitProfileRawPathRejection(t *testing.T) {
 		{"/v1%2Fbatch", true, "encoded slash"},
 		{"/v1%5cbatch", true, "encoded backslash"},
 		{"/v1/batch;foo=bar", true, "semicolon"},
+		{"/v1/batch%3bfoo=bar", true, "encoded semicolon"},
+		{"/v1/batch%3Bfoo=bar", true, "encoded semicolon"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.path, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- New `reverse_proxy.profile: submit` selector adds a constrained listener mode for narrow internal-egress POST submissions. Empty profile (the default) preserves the existing generic reverse proxy unchanged.
- Load-time validation enforces: `trusted_upstream` host+port must exact-match the parsed upstream; no IP literals on `trusted_upstream.host`; `reason`+`added` required; `expires` (optional) not in past; `allowed_paths` required, every entry exact-match, canonical, starts with `/`; `allowed_methods` (if set) restricted to well-known HTTP methods; `max_body_bytes` and `request_timeout_seconds` must be positive. Submit-profile fields are rejected when profile is empty so an operator cannot silently lose semantics by typoing the selector. Host matching normalizes case, whitespace, and trailing dot.
- Per-request gate (runs before any scanning): method allowlist (defaults to POST-only when `allowed_methods` is empty); raw-path canonicality rejecting `%2e`, `%2f`, `%5c`, `%25` (blocks double-encoded traversal), and semicolon path params; exact-path match against the canonical decoded `r.URL.Path`; Content-Length cap = min(reverse_proxy.max_body_bytes, request_body_scanning.max_body_bytes), returning 413 BEFORE forwarding; chunked requests (no Content-Length) get 411.
- Post-gate, submit profile scans the FULL upstream URL through the scanner pipeline. The generic reverse proxy skipped this because the upstream is operator-configured; submit tightens it so blocklist hits and pattern anomalies still fire on the allowlisted upstream. Each request is wrapped in a context with the configured `request_timeout_seconds` deadline so a slow upstream cannot indefinitely hold a session.
- The CI gating assertion is `TestSubmitProfile_BodyDLPBlocksBeforeForward`. A DLP-positive body POSTed to an allowed path returns 403 with `X-Pipelock-Block-Reason: dlp_match`, and the upstream handler is asserted not-invoked. Path/method/body-cap/timeout behavioral tests plus 18 validation rules accompany it.

## YAML shape

```
reverse_proxy:
  enabled: true
  profile: submit
  listen: "127.0.0.1:8892"
  upstream: "http://receiver:30891"
  allowed_methods: [POST]
  allowed_paths:
    - exact: "/v1/batch"
  trusted_upstream:
    host: receiver
    port: 30891
    reason: "reflection receiver over tailnet"
    added: "2026-05-26"
    expires: "2026-11-25"
  max_body_bytes: 6291456
  request_timeout_seconds: 30
```

## Honest scope note

The reverse-proxy transport still uses the cloned default dialer. Wiring `p.ssrfSafeDialContext` into the listener is the explicit v1.5 follow-up. It needs a setter on `ReverseProxyHandler` and plumbing from `server_lifecycle.go`. Submit profile's other constraints (host/port allowlist, no IP literals, full URL scan) cover most of the SSRF surface, but this PR does NOT claim dial-time SSRF safety. Docs reflect this honestly.

## Other notes

- Canonical policy hash goldens bumped because the new policy fields (`profile`, `allowed_methods`, `allowed_paths`, `trusted_upstream`, `max_body_bytes`, `request_timeout_seconds`) enter the canonical view.
- `server_test.go` reverse-proxy reload check moved to `reflect.DeepEqual` because the struct now contains slices and is no longer `==`-comparable.
- Docs: `docs/configuration.md` gains a `reverse_proxy.profile` section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a constrained "submit" reverse‑proxy profile with method/path allowlisting, trusted upstream host:port gating, per‑request body size caps (listener vs scanner precedence), request timeouts, and upstream URL scanning before forwarding.

* **Documentation**
  * Documented the submit profile configuration, required fields, canonicalization rules, and validation behavior.

* **Tests**
  * Added comprehensive tests for validation and request handling (method/path gating, raw-path rejection, body limits, URL scanning, timeouts, and block reasons).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->