### PR TITLE
feat(proxy): SSRF-safe dial path for reverse_proxy.profile: submit

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2415,7 +2415,7 @@ reverse_proxy:
 | `max_body_bytes` | required | Positive listener body cap. The effective cap is the smaller of this value and `request_body_scanning.max_body_bytes`. |
 | `request_timeout_seconds` | required | Positive total request timeout for the submit listener, including scanning and upstream forwarding. |
 
-`profile: submit` does not by itself install the fetch/forward proxy dial-time SSRF-safe transport. The submit listener still constrains destination by exact configured host+port and runs the upstream URL through the scanner before forwarding.
+`profile: submit` dials the upstream through the same SSRF-safe dial path the fetch and forward proxies use: DNS is resolved and every resolved IP is validated against the internal CIDR blocks before the connection is made, closing the DNS-rebinding window. Generic reverse-proxy mode (no `profile`) keeps the default dialer, since the operator is presumed to have already chosen that upstream. In addition, the submit listener constrains the destination to the exact configured host+port and runs the upstream URL through the scanner before forwarding.
 
 ### CLI flags
 

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -583,6 +583,13 @@ func (s *Server) Start(ctx context.Context) error {
 		rpHandler.SetContractLoader(s.proxy.ContractLoaderPtr())
 		rpHandler.SetReloadLock(s.proxy.ReloadLock())
 		rpHandler.SetRedactionRuntimePtr(s.proxy.RedactionRuntimePtr())
+		// Submit profile dials through the SSRF-safe dial path (resolve +
+		// validate every IP against internal CIDRs before connecting),
+		// matching the fetch/forward transports. Generic reverse-proxy mode
+		// keeps the default dialer: the operator chose that upstream.
+		if cfg.ReverseProxy.Profile == config.ReverseProxyProfileSubmit {
+			rpHandler.SetSafeDialer(s.proxy.SafeDialer())
+		}
 
 		rpLn, lnErr := (&net.ListenConfig{}).Listen(ctx, "tcp", cfg.ReverseProxy.Listen)
 		if lnErr != nil {

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -513,6 +513,20 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 		})
 	}
 
+	// reverse_proxy.profile is startup-only: the listener binds once and the
+	// submit-profile SSRF-safe dialer is installed on the transport at init.
+	// A reload that flips the profile would leave the dial path stale (or
+	// leave safe dialing on after switching away), and reapplying it would
+	// race in-flight requests since it replaces the transport. Warn so the
+	// operator restarts rather than trusting a no-op reload. The listen/
+	// upstream addresses are already restart-only for the same reason.
+	if old.ReverseProxy.Profile != updated.ReverseProxy.Profile {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "reverse_proxy",
+			Message: "reverse_proxy.profile change requires restart — dial path and listener are fixed at startup, reload ignored",
+		})
+	}
+
 	// Media policy downgrades. Each toggle that weakens protection gets a
 	// dedicated warning so operators see the field-level cause of the
 	// downgrade rather than a generic "media_policy changed" message.

--- a/internal/config/reloadwarn_test.go
+++ b/internal/config/reloadwarn_test.go
@@ -129,3 +129,32 @@ func TestValidateReload_AgentTrustedDomainsAdded(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateReload_ReverseProxyProfileChanged(t *testing.T) {
+	old := Defaults()
+	updated := Defaults()
+	updated.ReverseProxy.Profile = ReverseProxyProfileSubmit
+
+	warnings := ValidateReload(old, updated)
+	found := false
+	for _, w := range warnings {
+		if w.Field == "reverse_proxy" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected reload warning for reverse_proxy.profile change (restart-only)")
+	}
+}
+
+func TestValidateReload_ReverseProxyProfileUnchanged_NoWarning(t *testing.T) {
+	old := Defaults()
+	updated := Defaults()
+
+	for _, w := range ValidateReload(old, updated) {
+		if w.Field == "reverse_proxy" {
+			t.Fatalf("unexpected reverse_proxy warning when profile unchanged: %+v", w)
+		}
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2562,6 +2562,21 @@ func (p *Proxy) ShieldEngine() *shield.Engine {
 	return p.shieldEngine
 }
 
+// SafeDialer exposes the SSRF-safe DialContext function used by the fetch
+// and forward proxies (resolves DNS, validates every resolved IP against
+// internal CIDR blocks before dialing). Returned function has the standard
+// http.Transport.DialContext signature so callers can plug it into a
+// *http.Transport.DialContext field.
+//
+// Used by the reverse proxy's submit profile to swap its cloned default
+// dialer for the same hardened dial path the agent-facing transports use.
+// Generic reverse-proxy mode (Profile == "") continues to dial via the
+// default transport because the operator is presumed to have already
+// chosen the upstream — the trust model differs.
+func (p *Proxy) SafeDialer() func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return p.ssrfSafeDialContext
+}
+
 // isShieldExempt checks whether a hostname is in the browser shield exempt list.
 // Uses scanner.MatchDomain so wildcard patterns ("*.example.com") work the same
 // way they do for the SSRF trusted-domain list, the response-scan exempt list,

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -126,28 +126,49 @@ func NewReverseProxy(
 	// ErrorHandler returns a JSON error on upstream failures.
 	proxy.ErrorHandler = rp.errorHandler
 
-	// Signing transport: sits between httputil.ReverseProxy and a
-	// disable-compression base. Runs envelope injection + RFC 9421
-	// signing on the post-Director request so @target-uri matches the
-	// upstream URL the transport is actually about to dial. A nil
-	// envelope emitter short-circuits to the base transport.
-	//
-	// The base is a clone of http.DefaultTransport with
-	// DisableCompression: true so upstream Content-Encoding survives
-	// transparent-decompression stripping. Without this, the
-	// compressed-response guard in modifyResponse cannot fail-closed
-	// on gzip — Go auto-decompresses and removes the header before
-	// pipelock sees it. (external review C-2; same root cause as the forward
-	// transport fix in an earlier prerelease build.)
-	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
-	baseTransport.DisableCompression = true
-	proxy.Transport = &reverseSigningRoundTripper{
-		base: baseTransport,
-		rp:   rp,
-	}
+	proxy.Transport = newReverseProxyTransport(rp, nil)
 
 	rp.proxy = proxy
 	return rp
+}
+
+// SetSafeDialer swaps the reverse-proxy transport's dial path for the
+// supplied SSRF-safe DialContext (typically Proxy.SafeDialer()). It must be
+// called before serving requests; it is not safe to call concurrently with
+// ServeHTTP because it replaces proxy.Transport.
+//
+// The submit profile uses this so outbound dials resolve DNS and validate
+// every resolved IP against internal CIDR blocks before connecting, closing
+// the DNS-rebinding / TOCTOU gap the cloned default dialer leaves open. The
+// rebuilt base preserves DisableCompression (so the compressed-response
+// fail-closed guard in modifyResponse keeps working) and re-wraps in the
+// signing round tripper so RFC 9421 @target-uri signing is unaffected.
+//
+// A nil dialer is a no-op: the handler keeps its default transport. This
+// keeps generic reverse-proxy mode (Profile == "") on the default dialer,
+// where the operator is presumed to have chosen the upstream already.
+func (rp *ReverseProxyHandler) SetSafeDialer(dial func(ctx context.Context, network, addr string) (net.Conn, error)) {
+	if dial == nil {
+		return
+	}
+	rp.proxy.Transport = newReverseProxyTransport(rp, dial)
+}
+
+// newReverseProxyTransport builds the signing transport that sits between
+// httputil.ReverseProxy and the base HTTP transport. The base always disables
+// transparent decompression so modifyResponse can fail closed on compressed
+// upstream responses instead of seeing Go's auto-decompressed body with the
+// Content-Encoding header stripped.
+func newReverseProxyTransport(rp *ReverseProxyHandler, dial func(ctx context.Context, network, addr string) (net.Conn, error)) http.RoundTripper {
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.DisableCompression = true
+	if dial != nil {
+		base.DialContext = dial
+	}
+	return &reverseSigningRoundTripper{
+		base: base,
+		rp:   rp,
+	}
 }
 
 // SetEnvelopeEmitter sets the atomic pointer to the envelope emitter.

--- a/internal/proxy/reverse_submit_dialer_test.go
+++ b/internal/proxy/reverse_submit_dialer_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+// TestSubmitProfile_SetSafeDialerIsUsed proves that after SetSafeDialer,
+// the reverse proxy dials the upstream through the supplied dialer rather
+// than the default transport. A sentinel dialer records that it was
+// invoked and then delegates to a real dial so the request still
+// completes end-to-end.
+func TestSubmitProfile_SetSafeDialerIsUsed(t *testing.T) {
+	var upstreamHit atomic.Bool
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHit.Store(true)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	cfg, upstreamURL := submitProfileTestConfig(upstream.URL)
+
+	var dialerCalls atomic.Int32
+	sentinel := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dialerCalls.Add(1)
+		var d net.Dialer
+		return d.DialContext(ctx, network, addr)
+	}
+
+	handlerProxy := submitProfileReverseProxyWithDialer(t, cfg, upstreamURL, sentinel)
+
+	reqURL := handlerProxy.URL + "/v1/batch"
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, reqURL, strings.NewReader(`{"clean":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if !upstreamHit.Load() {
+		t.Error("upstream was not reached")
+	}
+	if dialerCalls.Load() == 0 {
+		t.Error("safe dialer was never invoked; SetSafeDialer did not take effect")
+	}
+}
+
+// TestSubmitProfile_SetSafeDialerNilIsNoop verifies a nil dialer leaves the
+// handler on its default transport (no panic, request still forwards).
+func TestSubmitProfile_SetSafeDialerNilIsNoop(t *testing.T) {
+	var upstreamHit atomic.Bool
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHit.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg, upstreamURL := submitProfileTestConfig(upstream.URL)
+	proxy := submitProfileReverseProxyWithDialer(t, cfg, upstreamURL, nil)
+
+	reqURL := proxy.URL + "/v1/batch"
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, reqURL, strings.NewReader(`{"clean":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 (nil dialer must be a no-op)", resp.StatusCode)
+	}
+	if !upstreamHit.Load() {
+		t.Error("upstream not reached with nil dialer")
+	}
+}
+
+func TestSubmitProfile_ProxySafeDialerUsesScannerResolver(t *testing.T) {
+	var upstreamHit atomic.Bool
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHit.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	upstreamURL := submitProfileHostOverrideURL(t, upstream.URL, "submit.test")
+	cfg, parsedUpstream := submitProfileTestConfig(upstreamURL)
+	cfg.Internal = []string{"127.0.0.0/8"}
+	cfg.TrustedDomains = []string{"submit.test"}
+	cfg.DNS.HostOverrides = map[string][]string{
+		"submit.test": {"127.0.0.1"},
+	}
+
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	logger := audit.NewNop()
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("New proxy: %v", err)
+	}
+
+	var cfgPtr atomic.Pointer[config.Config]
+	var scPtr atomic.Pointer[scanner.Scanner]
+	cfgPtr.Store(cfg)
+	scPtr.Store(sc)
+
+	handler := NewReverseProxy(parsedUpstream, &cfgPtr, &scPtr, logger, metrics.New(), nil, nil, nil)
+	handler.SetSafeDialer(p.SafeDialer())
+
+	proxy := newIPv4Server(t, handler)
+	t.Cleanup(proxy.Close)
+
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, proxy.URL+"/v1/batch", strings.NewReader(`{"clean":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post through reverse proxy: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if !upstreamHit.Load() {
+		t.Fatal("upstream was not reached through Proxy.SafeDialer")
+	}
+}
+
+func TestProxy_SafeDialerBlocksInternalIP(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = []string{"127.0.0.0/8"}
+
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	p, err := New(cfg, audit.NewNop(), sc, metrics.New())
+	if err != nil {
+		t.Fatalf("New proxy: %v", err)
+	}
+
+	dial := p.SafeDialer()
+	if dial == nil {
+		t.Fatal("SafeDialer returned nil")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	conn, err := dial(ctx, "tcp", "127.0.0.1:1")
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if err == nil {
+		t.Fatal("SafeDialer allowed internal IP dial")
+	}
+	if !strings.Contains(err.Error(), "SSRF blocked") {
+		t.Fatalf("SafeDialer error = %v, want SSRF blocked", err)
+	}
+}
+
+func submitProfileHostOverrideURL(t *testing.T, upstreamURL, host string) string {
+	t.Helper()
+
+	u, err := url.Parse(upstreamURL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+	_, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("split upstream host: %v", err)
+	}
+	u.Host = net.JoinHostPort(host, port)
+	return u.String()
+}

--- a/internal/proxy/reverse_submit_test.go
+++ b/internal/proxy/reverse_submit_test.go
@@ -77,34 +77,17 @@ func submitProfileTestConfig(upstreamURL string) (*config.Config, *url.URL) {
 }
 
 // submitProfileReverseProxy spins up a NewReverseProxy fronting a test
-// upstream, using the same wiring reverseTestSetup uses but parameterized
-// on cfg + upstream URL since submit-profile tests need to control both.
+// upstream, parameterized on cfg + upstream URL since submit-profile tests
+// need to control both. Equivalent to the dialer variant with a nil dialer.
 func submitProfileReverseProxy(t *testing.T, cfg *config.Config, upstreamURL *url.URL) *httptest.Server {
 	t.Helper()
-
-	sc := scanner.New(cfg)
-	t.Cleanup(sc.Close)
-
-	var cfgPtr atomic.Pointer[config.Config]
-	var scPtr atomic.Pointer[scanner.Scanner]
-	cfgPtr.Store(cfg)
-	scPtr.Store(sc)
-
-	logger, _ := audit.New("json", "stdout", "", false, false)
-	t.Cleanup(logger.Close)
-
-	m := metrics.New()
-	ks := killswitch.New(cfg)
-
-	handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, logger, m, ks, nil, nil)
-	proxy := newIPv4Server(t, handler)
-	t.Cleanup(proxy.Close)
-	return proxy
+	return submitProfileReverseProxyWithDialer(t, cfg, upstreamURL, nil)
 }
 
-// submitProfileReverseProxyWithDialer is submitProfileReverseProxy plus a
-// SetSafeDialer call, so dialer-path tests can inject a sentinel dial func.
-// A nil dialer exercises the no-op branch of SetSafeDialer.
+// submitProfileReverseProxyWithDialer builds the submit-profile reverse proxy
+// test server and applies SetSafeDialer(dial). A nil dialer leaves the handler
+// on its default transport (and exercises the no-op branch of SetSafeDialer),
+// which is why the plain submitProfileReverseProxy delegates here.
 func submitProfileReverseProxyWithDialer(t *testing.T, cfg *config.Config, upstreamURL *url.URL, dial func(ctx context.Context, network, addr string) (net.Conn, error)) *httptest.Server {
 	t.Helper()
 

--- a/internal/proxy/reverse_submit_test.go
+++ b/internal/proxy/reverse_submit_test.go
@@ -102,6 +102,33 @@ func submitProfileReverseProxy(t *testing.T, cfg *config.Config, upstreamURL *ur
 	return proxy
 }
 
+// submitProfileReverseProxyWithDialer is submitProfileReverseProxy plus a
+// SetSafeDialer call, so dialer-path tests can inject a sentinel dial func.
+// A nil dialer exercises the no-op branch of SetSafeDialer.
+func submitProfileReverseProxyWithDialer(t *testing.T, cfg *config.Config, upstreamURL *url.URL, dial func(ctx context.Context, network, addr string) (net.Conn, error)) *httptest.Server {
+	t.Helper()
+
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	var cfgPtr atomic.Pointer[config.Config]
+	var scPtr atomic.Pointer[scanner.Scanner]
+	cfgPtr.Store(cfg)
+	scPtr.Store(sc)
+
+	logger, _ := audit.New("json", "stdout", "", false, false)
+	t.Cleanup(logger.Close)
+
+	m := metrics.New()
+	ks := killswitch.New(cfg)
+
+	handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, logger, m, ks, nil, nil)
+	handler.SetSafeDialer(dial)
+	proxy := newIPv4Server(t, handler)
+	t.Cleanup(proxy.Close)
+	return proxy
+}
+
 // TestSubmitProfile_BodyDLPBlocksBeforeForward is the gating CI test
 // from the submit-mode design doc. A DLP-positive body sent to the
 // configured allowed path must:


### PR DESCRIPTION
## Summary

- Closes the deferred follow-up from the submit-profile PR (#622). Submit-profile outbound dials now go through the same SSRF-safe `DialContext` the fetch and forward proxies use: DNS is resolved and every resolved IP is validated against the internal CIDR blocks before connecting, closing the DNS-rebinding / TOCTOU window the cloned default dialer left open.
- `proxy.go`: `SafeDialer()` exposes the existing `ssrfSafeDialContext` with the `http.Transport.DialContext` signature so callers can plug it into a transport.
- `reverse.go`: `SetSafeDialer()` swaps the transport dial path. Transport construction is factored through a single `newReverseProxyTransport` helper so both the default and safe-dialer paths preserve `DisableCompression` (keeps the compressed-response fail-closed guard in `modifyResponse` working) and re-wrap in the RFC 9421 signing round tripper. A nil dialer is a no-op.
- `server_lifecycle.go`: wires `SetSafeDialer(proxy.SafeDialer())` only when `profile: submit`. Generic reverse-proxy mode keeps the default dialer because the operator chose that upstream; the trust model differs.

## Design note

Used a `SetSafeDialer` setter, matching the existing `SetEnvelopeEmitter` / `SetReceiptEmitter` extension pattern, rather than adding a parameter to the already-long `NewReverseProxy` signature, per the CLAUDE.md long-signature rule.

## Behavior coverage

- Sentinel-dialer test proves the supplied dialer is invoked on forward.
- Nil-dialer no-op test.
- Real `Proxy.SafeDialer()` coverage with a scanner DNS host-override so the resolve-then-validate path runs end-to-end through the reverse proxy.
- Direct internal-IP block test asserts `SafeDialer` refuses `127.0.0.1` with an "SSRF blocked" error.

## Docs

`docs/configuration.md` submit-profile section now describes dial-time SSRF protection as present, replacing the prior "does not install dial-time SSRF" note that shipped with #622.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Submit reverse-proxy now uses an SSRF-safe dialing path that validates resolved IPs and closes DNS-rebinding windows; changing the reverse-proxy profile now emits a restart-required reload warning.

* **Documentation**
  * Clarified submit-profile reverse-proxy docs to describe the SSRF-safe behavior and upstream constraints.

* **Tests**
  * Added tests for the SSRF-safe dialer, submit-profile dialing behavior, and reload-warning scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->