### PR TITLE
Conductor: add audit retention pruning

### DIFF
--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -285,6 +285,7 @@ pipelock conductor serve \
   --trusted-control-key id=rollback-key-1,purpose=policy-bundle-rollback,file=/etc/pipelock/conductor/rollback.pub \
   --remote-kill-max-validity 72h \
   --rollback-max-validity 24h \
+  --audit-retention 2160h \
   --probe-listen 127.0.0.1:9092
 # Optional bootstrap fallback; every trusted audit key must include org=.
 # --trusted-audit-key id=audit-key-1,file=/etc/pipelock/conductor/audit-key.pub,org=org-main,fleet=prod
@@ -312,18 +313,20 @@ key. Optional `fleet=`/`instance=` narrow the scope further. Trusted control
 keys are required for emergency-control publication and are purpose-scoped to
 `remote-kill-signing` or `policy-bundle-rollback`; wrong-purpose signatures are
 rejected before storage. Conductor also rejects emergency-control messages whose
-validity windows exceed the configured maximums before storing them. Enrolled follower
-keys are resolved first by exact org/fleet/instance and key ID. Accepted audit
-batches are written to a
-local SQLite raw-evidence store with idempotency on `(org, fleet, instance,
+validity windows exceed the configured maximums before storing them. Enrolled
+follower keys are resolved first by exact org/fleet/instance and key ID.
+Accepted audit batches are written to a local SQLite raw-evidence store with
+idempotency on `(org, fleet, instance,
 batch_id)` and fork rejection on overlapping sequence ranges with divergent
 payload or segment-tail hashes. The storage directory is sensitive
 operator-controlled state. The MVP exposes
 `GET /api/v1/conductor/audit/batches` as an operator/admin metadata query
 endpoint; it requires audit-query authorization and at least `org_id`, returns
 metadata-only batch summaries, and does not export raw payload bytes. Raw
-export endpoints, retention policy, redacted indexing, and analytics remain
-later slices.
+payload export endpoints, redacted indexing/search, and analytics remain later
+slices. `--audit-retention` controls startup pruning for the local SQLite
+raw-evidence store; `0` keeps accepted rows until an operator removes or
+archives them.
 
 ### Bundle Envelope
 
@@ -597,8 +600,9 @@ audit-batch signature against the enrolled audit key for that identity, and
 only then hands the accepted batch to the configured audit sink. Static trusted
 audit keys remain available as a bootstrap fallback when no enrolled key matches
 the exact identity and key ID. The current runtime sink is a local SQLite
-raw-evidence store; redacted storage/search indexing, DLP-before-indexing, fork
-response workflow, and dashboard views are later slices.
+raw-evidence store. It supports startup retention pruning by `received_at` via
+`--audit-retention`; redacted storage/search indexing, fork response workflow,
+and dashboard views are later slices.
 
 `GET /api/v1/conductor/audit/batches` is an operator/admin API endpoint. It
 requires audit-query authorization, requires at least `org_id`, and returns
@@ -701,14 +705,27 @@ Controls:
 - No cross-fleet query expansion from untrusted event fields.
 - Reputation scoring for malformed, oversized, forked, or DLP-positive batches.
 
-Audit batches are also potential exfiltration channels. Conductor must scan for
-secrets before storing or indexing.
+Audit batches are also potential exfiltration channels. The current SQLite
+runtime sink stores accepted raw payloads as operator-controlled escrow and does
+not expose raw export or searchable indexes. Future export, indexing, or
+cross-fleet search paths must scan/redact before making payload-derived fields
+queryable or retrievable outside the raw-escrow boundary.
 
 ## Privacy and Storage
 
 Default indexed/queryable storage is redacted. The current local SQLite runtime
 store is the active raw-escrow path and must be treated as sensitive
-operator-controlled state until redacted storage/indexing lands.
+operator-controlled state until redacted storage/indexing lands. Operators can
+set `--audit-retention=<duration>` to prune SQLite rows whose `received_at`
+timestamp is older than the retention cutoff at process startup. The default
+`0` keeps raw escrow indefinitely. This is app-level deletion from the local
+store, not a WORM archive lifecycle.
+
+Retention pruning is destructive and truncates verifiable evidence continuity
+across the prune boundary. Retained batches remain signature-verifiable and
+internally chain-linked, but once earlier segments are pruned the local store
+can no longer prove continuity back to the chain origin. Operators who need
+full-history provenance must archive or retain the raw evidence before pruning.
 
 Storage classes:
 

--- a/internal/cli/conductor/cmd.go
+++ b/internal/cli/conductor/cmd.go
@@ -279,6 +279,7 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, ht
 	if opts.auditRetention > 0 {
 		result, err := auditStore.PruneAuditBatchesBefore(ctx, time.Now().UTC().Add(-opts.auditRetention))
 		if err != nil {
+			_ = auditStore.Close()
 			return nil, nil, nil, err
 		}
 		logAuditPruneResult(opts.logWriter, result)

--- a/internal/cli/conductor/cmd.go
+++ b/internal/cli/conductor/cmd.go
@@ -48,6 +48,7 @@ type serveOptions struct {
 	trustedControlKeys  []string
 	remoteKillMaxTTL    time.Duration
 	rollbackMaxTTL      time.Duration
+	auditRetention      time.Duration
 	tlsCert             string
 	tlsKey              string
 	clientCA            string
@@ -104,6 +105,7 @@ func serveCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.publisherTokenFile, "publisher-token-file", "", "file containing bearer token required for policy publish requests")
 	cmd.Flags().StringVar(&opts.auditorTokenFile, "auditor-token-file", "", "file containing bearer token required for audit metadata query requests")
 	cmd.Flags().StringVar(&opts.adminTokenFile, "admin-token-file", "", "file containing bearer token required for Conductor admin requests")
+	cmd.Flags().DurationVar(&opts.auditRetention, "audit-retention", 0, "duration to keep SQLite audit evidence; older batches are pruned at startup (0 = keep forever)")
 	cmd.Flags().StringArrayVar(&opts.trustedAuditKeys, "trusted-audit-key", nil,
 		"trusted audit signing key as comma-separated kv pairs: 'id=ID,(inline=BASE64|file=/path),org=ORG[,fleet=FLEET][,instance=INSTANCE]'; "+
 			"org= is required so a key cannot authenticate batches across orgs; repeatable")
@@ -215,6 +217,9 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, ht
 	if err := validateServeTLSFlags(opts); err != nil {
 		return nil, nil, nil, err
 	}
+	if opts.auditRetention < 0 {
+		return nil, nil, nil, errors.New("--audit-retention must be non-negative")
+	}
 	publisherToken, err := loadTokenFile("--publisher-token-file", opts.publisherTokenFile)
 	if err != nil {
 		return nil, nil, nil, err
@@ -271,6 +276,13 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, ht
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	if opts.auditRetention > 0 {
+		result, err := auditStore.PruneAuditBatchesBefore(ctx, time.Now().UTC().Add(-opts.auditRetention))
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		logAuditPruneResult(opts.logWriter, result)
+	}
 	enrollments, err := controlplane.OpenFileEnrollmentStore(filepath.Join(opts.storageDir, "enrollments.json"))
 	if err != nil {
 		return nil, nil, nil, err
@@ -320,6 +332,14 @@ func conductorRequestLogger(w io.Writer) *slog.Logger {
 		return nil
 	}
 	return slog.New(slog.NewJSONHandler(w, nil))
+}
+
+func logAuditPruneResult(w io.Writer, result controlplane.AuditPruneResult) {
+	if w == nil || result.Deleted == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "pipelock: conductor pruned %d audit batches received before %s\n",
+		result.Deleted, result.Before.Format(time.RFC3339))
 }
 
 func validateServeTLSFlags(opts serveOptions) error {

--- a/internal/cli/conductor/cmd_test.go
+++ b/internal/cli/conductor/cmd_test.go
@@ -232,6 +232,56 @@ func TestBuildServeHandlerRejectsNegativeAuditRetention(t *testing.T) {
 	}
 }
 
+func TestBuildServeHandlerPrunesAuditRetention(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "publisher-token")
+	if err := os.WriteFile(tokenPath, []byte("secret-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(token): %v", err)
+	}
+	auditorTokenPath := filepath.Join(dir, "auditor-token")
+	if err := os.WriteFile(auditorTokenPath, []byte("auditor-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(auditor token): %v", err)
+	}
+	adminTokenPath := filepath.Join(dir, "admin-token")
+	if err := os.WriteFile(adminTokenPath, []byte("admin-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(admin token): %v", err)
+	}
+	caPath := filepath.Join(dir, "client-ca.pem")
+	if err := os.WriteFile(caPath, testCAPEM(t), 0o600); err != nil {
+		t.Fatalf("WriteFile(ca): %v", err)
+	}
+	var logs strings.Builder
+	handler, _, _, err := buildServeHandler(context.Background(), serveOptions{
+		storageDir:          filepath.Join(dir, "store"),
+		followerTrustDomain: defaultTrustDomain,
+		tlsCert:             "server.pem",
+		tlsKey:              "server.key",
+		clientCA:            caPath,
+		publisherTokenFile:  tokenPath,
+		auditorTokenFile:    auditorTokenPath,
+		adminTokenFile:      adminTokenPath,
+		auditRetention:      time.Hour,
+		logWriter:           &logs,
+		trustedControlKeys: []string{
+			"id=remote-key-1,purpose=remote-kill-signing,inline=" + signing.EncodePublicKey(pub),
+			"id=rollback-key-1,purpose=policy-bundle-rollback,inline=" + signing.EncodePublicKey(pub),
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildServeHandler(retention) error = %v", err)
+	}
+	if handler == nil {
+		t.Fatal("buildServeHandler(retention) handler = nil")
+	}
+	if logs.Len() != 0 {
+		t.Fatalf("retention logs = %q, want empty for zero pruned rows", logs.String())
+	}
+}
+
 func TestLogAuditPruneResult(t *testing.T) {
 	var buf strings.Builder
 	logAuditPruneResult(&buf, controlplane.AuditPruneResult{

--- a/internal/cli/conductor/cmd_test.go
+++ b/internal/cli/conductor/cmd_test.go
@@ -191,6 +191,65 @@ func TestBuildServeHandlerRequiresAuthInputs(t *testing.T) {
 	}
 }
 
+func TestBuildServeHandlerRejectsNegativeAuditRetention(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "publisher-token")
+	if err := os.WriteFile(tokenPath, []byte("secret-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(token): %v", err)
+	}
+	auditorTokenPath := filepath.Join(dir, "auditor-token")
+	if err := os.WriteFile(auditorTokenPath, []byte("auditor-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(auditor token): %v", err)
+	}
+	adminTokenPath := filepath.Join(dir, "admin-token")
+	if err := os.WriteFile(adminTokenPath, []byte("admin-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(admin token): %v", err)
+	}
+	caPath := filepath.Join(dir, "client-ca.pem")
+	if err := os.WriteFile(caPath, testCAPEM(t), 0o600); err != nil {
+		t.Fatalf("WriteFile(ca): %v", err)
+	}
+	_, _, _, err = buildServeHandler(context.Background(), serveOptions{
+		storageDir:          filepath.Join(dir, "store"),
+		followerTrustDomain: defaultTrustDomain,
+		tlsCert:             "server.pem",
+		tlsKey:              "server.key",
+		clientCA:            caPath,
+		publisherTokenFile:  tokenPath,
+		auditorTokenFile:    auditorTokenPath,
+		adminTokenFile:      adminTokenPath,
+		auditRetention:      -time.Second,
+		trustedAuditKeys: []string{
+			"id=audit-key-1,inline=" + signing.EncodePublicKey(pub) + ",org=org-main",
+		},
+	})
+	if err == nil || err.Error() != "--audit-retention must be non-negative" {
+		t.Fatalf("buildServeHandler(negative retention) error = %v, want --audit-retention error", err)
+	}
+}
+
+func TestLogAuditPruneResult(t *testing.T) {
+	var buf strings.Builder
+	logAuditPruneResult(&buf, controlplane.AuditPruneResult{
+		Deleted: 3,
+		Before:  time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC),
+	})
+	want := "pipelock: conductor pruned 3 audit batches received before 2026-05-23T12:00:00Z\n"
+	if buf.String() != want {
+		t.Fatalf("logAuditPruneResult() = %q, want %q", buf.String(), want)
+	}
+
+	buf.Reset()
+	logAuditPruneResult(&buf, controlplane.AuditPruneResult{Before: time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)})
+	if buf.Len() != 0 {
+		t.Fatalf("logAuditPruneResult(zero deleted) = %q, want empty", buf.String())
+	}
+}
+
 func TestRunServeReturnsTLSLoadError(t *testing.T) {
 	pub, _, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/internal/conductor/controlplane/audit_store.go
+++ b/internal/conductor/controlplane/audit_store.go
@@ -60,6 +60,11 @@ type AuditBatchQuery struct {
 	Limit      int
 }
 
+type AuditPruneResult struct {
+	Deleted int64
+	Before  time.Time
+}
+
 func OpenSQLiteAuditStore(ctx context.Context, path string) (*SQLiteAuditStore, error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, errors.New("conductor audit store path is required")
@@ -420,6 +425,28 @@ func (s *SQLiteAuditStore) GetAuditBatch(ctx context.Context, orgID, fleetID, in
 		return AuditBatchSummary{}, false, err
 	}
 	return summary, true, nil
+}
+
+func (s *SQLiteAuditStore) PruneAuditBatchesBefore(ctx context.Context, before time.Time) (AuditPruneResult, error) {
+	if s == nil || s.db == nil {
+		return AuditPruneResult{}, ErrAuditSinkRequired
+	}
+	if ctx == nil {
+		return AuditPruneResult{}, fmt.Errorf("%w: context", ErrAuditSinkRequired)
+	}
+	if before.IsZero() {
+		return AuditPruneResult{}, fmt.Errorf("%w: audit retention cutoff", ErrInvalidStoreRecord)
+	}
+	cutoff := before.UTC()
+	result, err := s.db.ExecContext(ctx, `DELETE FROM audit_batches WHERE received_at < ?`, cutoff)
+	if err != nil {
+		return AuditPruneResult{}, fmt.Errorf("prune conductor audit batches: %w", err)
+	}
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return AuditPruneResult{}, fmt.Errorf("count pruned conductor audit batches: %w", err)
+	}
+	return AuditPruneResult{Deleted: deleted, Before: cutoff}, nil
 }
 
 type auditSummaryScanner interface {

--- a/internal/conductor/controlplane/audit_store_test.go
+++ b/internal/conductor/controlplane/audit_store_test.go
@@ -175,6 +175,43 @@ func TestSQLiteAuditStoreGetMissingBatch(t *testing.T) {
 	}
 }
 
+func TestSQLiteAuditStorePrunesBatchesBeforeCutoff(t *testing.T) {
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	defer func() { _ = store.Close() }()
+
+	identity := defaultFollowerIdentity()
+	oldBatch := signedAcceptedAuditBatch(t, identity, "audit-old", 10, 10, []byte(testAuditPayload), testNow.Add(-48*time.Hour))
+	recentBatch := signedAcceptedAuditBatch(t, identity, "audit-recent", 11, 11, []byte(testAuditPayload2), testNow.Add(-time.Hour))
+	if err := store.IngestAuditBatch(context.Background(), oldBatch); err != nil {
+		t.Fatalf("IngestAuditBatch(old) error = %v", err)
+	}
+	if err := store.IngestAuditBatch(context.Background(), recentBatch); err != nil {
+		t.Fatalf("IngestAuditBatch(recent) error = %v", err)
+	}
+
+	result, err := store.PruneAuditBatchesBefore(context.Background(), testNow.Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("PruneAuditBatchesBefore() error = %v", err)
+	}
+	if result.Deleted != 1 || !result.Before.Equal(testNow.Add(-24*time.Hour)) {
+		t.Fatalf("prune result = %+v, want one deleted before cutoff", result)
+	}
+	if _, ok, err := store.GetAuditBatch(context.Background(), identity.OrgID, identity.FleetID, identity.InstanceID, oldBatch.Envelope.BatchID); err != nil || ok {
+		t.Fatalf("GetAuditBatch(old) ok=%v err=%v, want pruned", ok, err)
+	}
+	if _, ok, err := store.GetAuditBatch(context.Background(), identity.OrgID, identity.FleetID, identity.InstanceID, recentBatch.Envelope.BatchID); err != nil || !ok {
+		t.Fatalf("GetAuditBatch(recent) ok=%v err=%v, want retained", ok, err)
+	}
+
+	result, err = store.PruneAuditBatchesBefore(context.Background(), testNow.Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("PruneAuditBatchesBefore(second) error = %v", err)
+	}
+	if result.Deleted != 0 {
+		t.Fatalf("second prune deleted = %d, want 0", result.Deleted)
+	}
+}
+
 func TestSQLiteAuditStoreRejectsNilContext(t *testing.T) {
 	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
 	defer func() { _ = store.Close() }()
@@ -192,6 +229,16 @@ func TestSQLiteAuditStoreRejectsNilContext(t *testing.T) {
 	}
 	if _, _, err := store.GetAuditBatch(nilCtx, batch.Identity.OrgID, batch.Identity.FleetID, batch.Identity.InstanceID, batch.Envelope.BatchID); !errors.Is(err, ErrAuditSinkRequired) {
 		t.Fatalf("GetAuditBatch(nil) error = %v, want ErrAuditSinkRequired", err)
+	}
+	if _, err := store.PruneAuditBatchesBefore(nilCtx, testNow); !errors.Is(err, ErrAuditSinkRequired) {
+		t.Fatalf("PruneAuditBatchesBefore(nil) error = %v, want ErrAuditSinkRequired", err)
+	}
+	var nilStore *SQLiteAuditStore
+	if _, err := nilStore.PruneAuditBatchesBefore(context.Background(), testNow); !errors.Is(err, ErrAuditSinkRequired) {
+		t.Fatalf("PruneAuditBatchesBefore(nil store) error = %v, want ErrAuditSinkRequired", err)
+	}
+	if _, err := store.PruneAuditBatchesBefore(context.Background(), time.Time{}); !errors.Is(err, ErrInvalidStoreRecord) {
+		t.Fatalf("PruneAuditBatchesBefore(zero cutoff) error = %v, want ErrInvalidStoreRecord", err)
 	}
 }
 

--- a/internal/conductor/controlplane/audit_store_test.go
+++ b/internal/conductor/controlplane/audit_store_test.go
@@ -242,6 +242,17 @@ func TestSQLiteAuditStoreRejectsNilContext(t *testing.T) {
 	}
 }
 
+func TestSQLiteAuditStorePruneReturnsExecError(t *testing.T) {
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	_, err := store.PruneAuditBatchesBefore(context.Background(), testNow)
+	if err == nil || !strings.Contains(err.Error(), "prune conductor audit batches") {
+		t.Fatalf("PruneAuditBatchesBefore(closed) error = %v, want prune error", err)
+	}
+}
+
 func TestSQLiteAuditStoreRevalidatesAcceptedBatchBoundary(t *testing.T) {
 	cases := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- Add SQLite audit-store retention pruning by `received_at`
- Wire `pipelock conductor serve --audit-retention` to prune raw evidence at startup (0 = keep forever); log the pruned count and cutoff
- Document raw-escrow retention and the evidence-chain truncation caveat: pruning breaks verifiable continuity back to chain origin; retained batches stay individually verifiable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an --audit-retention CLI option to control how long local raw audit data is kept; startup will prune older audit batches and report pruning results.

* **Documentation**
  * Clarified audit ingestion, local raw-escrow sensitivity, destructive/pruning semantics (0 = retain indefinitely), redaction/indexing expectations, fork/dashboard behavior, and export/search redaction requirements.

* **Tests**
  * Added tests covering validation, pruning behavior (including idempotence), error handling, and pruning logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->