### PR TITLE
Conductor: wire follower remote kill polling

### DIFF
--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -417,14 +417,19 @@ Follower behavior:
   messages.
 - Followers poll the Conductor remote-kill endpoint over follower mTLS and
   apply signed messages through the local `conductor_remote` kill-switch source.
+  `conductor_remote` is the local kill-switch input that accepts signed
+  Conductor remote-kill messages after follower-side verification; when honoring
+  is disabled, the source rejects messages and leaves the existing local kill
+  state unchanged.
 - When disabled, followers reject remote kill messages locally and emit a
   structured rejection log.
 - When enabled, remote kill messages require `remote-kill-signing` threshold
   signatures verified against the pinned trust roster root fingerprint.
 - Accepted remote kill state is OR-composed as a separate kill source.
 - Accepted messages update a durable local replay-state file containing the last
-  applied counter and canonical message hash. Rejected, expired, superseded,
-  and disabled messages emit structured local logs.
+  applied counter and canonical message hash. The file is stored under the
+  Conductor bundle cache directory as `remote-kill-state.json`. Rejected,
+  expired, superseded, and disabled messages emit structured local logs.
 - The replay-state file is local follower trust state: it must remain writable
   only by the Pipelock process owner, and the other kill-switch sources
   (config, API, signal, sentinel) remain independently OR-composed.
@@ -792,11 +797,12 @@ When `conductor.enabled` is true, the flight recorder must be enabled with
 signed checkpoints and a configured signing key. `audit_signing_key_id` and
 `recorder_key_id` default to `instance_id` when omitted.
 
-Upgrade note: existing Conductor-enabled followers that only use audit batching
-must either set `trust_roster_root_fingerprint` and ship a roster containing
-`remote-kill-signing` keys, or explicitly set
-`honor_remote_kill_switch: false`. The default is to honor remote kills, so
-configs that omit both the fingerprint and the explicit opt-out fail validation.
+Upgrade note: `honor_remote_kill_switch` defaults to true. Existing
+Conductor-enabled followers that only use audit batching must either set
+`trust_roster_root_fingerprint` and ship a roster containing
+`remote-kill-signing` keys, or explicitly set `honor_remote_kill_switch: false`
+to opt out. Configs that omit `honor_remote_kill_switch`, or set it to true,
+without the fingerprint and roster fail validation.
 
 Config validation must reject:
 

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -412,15 +412,22 @@ must not contain control characters.
 
 Follower behavior:
 
-- Default `conductor.honor_remote_kill_switch` is false unless a managed-fleet
-  preset explicitly enables it.
-- When disabled, followers reject remote kill messages, emit local evidence, and
-  report the rejection to Conductor.
+- Default `conductor.honor_remote_kill_switch` is true; operators must
+  explicitly set it to false to opt out of applying otherwise valid remote kill
+  messages.
+- Followers poll the Conductor remote-kill endpoint over follower mTLS and
+  apply signed messages through the local `conductor_remote` kill-switch source.
+- When disabled, followers reject remote kill messages locally and emit a
+  structured rejection log.
 - When enabled, remote kill messages require `remote-kill-signing` threshold
-  signatures.
+  signatures verified against the pinned trust roster root fingerprint.
 - Accepted remote kill state is OR-composed as a separate kill source.
-- Every accepted, rejected, expired, and superseded remote kill message is
-  written to local recorder evidence with the full signed envelope.
+- Accepted messages update a durable local replay-state file containing the last
+  applied counter and canonical message hash. Rejected, expired, superseded,
+  and disabled messages emit structured local logs.
+- The replay-state file is local follower trust state: it must remain writable
+  only by the Pipelock process owner, and the other kill-switch sources
+  (config, API, signal, sentinel) remain independently OR-composed.
 
 MVP Conductor behavior:
 
@@ -441,8 +448,9 @@ MVP Conductor behavior:
 
 ## Emergency Stream
 
-Pure polling is insufficient for emergency state. Followers maintain an
-SSE/long-poll connection on the follower mTLS listener:
+MVP followers poll emergency-control endpoints on the configured
+`poll_interval`. For lower-latency emergency fanout, followers may maintain an
+SSE/long-poll connection on the follower mTLS listener in a follow-up:
 
 ```http
 GET /api/v1/conductor/emergency-stream
@@ -756,6 +764,7 @@ conductor:
   fleet_id: "prod"
   instance_id: "pl-prod-1"
   trust_roster_path: "/etc/pipelock/conductor/trust-roster.json"
+  trust_roster_root_fingerprint: "sha256:<64 lowercase hex chars>"
   server_ca_file: "/etc/pipelock/conductor/boss-ca.pem"
   client_cert_path: "/etc/pipelock/conductor/client.crt"
   client_key_path: "/etc/pipelock/conductor/client.key"
@@ -764,7 +773,7 @@ conductor:
   audit_signing_key_id: "instance-audit-1"
   recorder_key_id: "instance-recorder-1"
   poll_interval: "30s"
-  honor_remote_kill_switch: false
+  honor_remote_kill_switch: true
   created_skew_seconds: 60
   max_min_version_major_skew: 0
   max_min_version_minor_skew: 1
@@ -782,6 +791,12 @@ flight_recorder:
 When `conductor.enabled` is true, the flight recorder must be enabled with
 signed checkpoints and a configured signing key. `audit_signing_key_id` and
 `recorder_key_id` default to `instance_id` when omitted.
+
+Upgrade note: existing Conductor-enabled followers that only use audit batching
+must either set `trust_roster_root_fingerprint` and ship a roster containing
+`remote-kill-signing` keys, or explicitly set
+`honor_remote_kill_switch: false`. The default is to honor remote kills, so
+configs that omit both the fingerprint and the explicit opt-out fail validation.
 
 Config validation must reject:
 
@@ -936,7 +951,7 @@ Required test coverage:
 - Bundle with license fields is rejected.
 - Rollback without authorization is rejected.
 - Rollback authorization is single-use.
-- Remote kill is rejected when `honor_remote_kill_switch` is false.
+- Remote kill is rejected when `honor_remote_kill_switch` is explicitly false.
 - Remote kill without threshold signatures is rejected.
 - Remote kill and rollback reasons reject control characters.
 - Bundle apply is atomic under partial write.

--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -171,8 +171,10 @@ func buildConductorRemoteKillPoller(cfg *config.Config, ks emergency.KillSwitchS
 		Now:               time.Now,
 		Logger:            logger,
 	}
-	if err := applier.RestorePersistedState(); err != nil {
-		return nil, fmt.Errorf("restoring conductor remote kill state: %w", err)
+	if !applier.DisableRemoteKill {
+		if err := applier.RestorePersistedState(); err != nil {
+			return nil, fmt.Errorf("restoring conductor remote kill state: %w", err)
+		}
 	}
 	return emergency.NewRemoteKillPoller(emergency.RemoteKillPollerConfig{
 		BaseURL:      cfg.Conductor.ConductorURL,

--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -6,8 +6,11 @@ package runtime
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -20,8 +23,10 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/conductor"
 	"github.com/luckyPipewrench/pipelock/internal/conductor/applycache"
 	"github.com/luckyPipewrench/pipelock/internal/conductor/auditbatcher"
+	"github.com/luckyPipewrench/pipelock/internal/conductor/emergency"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 const (
@@ -125,6 +130,94 @@ func buildConductorAuditTransport(cfg *config.Config, m *metrics.Metrics) (*audi
 		return nil, nil, fmt.Errorf("creating conductor audit transport: %w", err)
 	}
 	return q, tr, nil
+}
+
+func buildConductorRemoteKillPoller(cfg *config.Config, ks emergency.KillSwitchSetter, logWriter io.Writer) (*emergency.RemoteKillPoller, error) {
+	if cfg == nil || !cfg.Conductor.Enabled {
+		return nil, nil
+	}
+	client, err := newConductorMTLSClient(cfg.Conductor)
+	if err != nil {
+		return nil, err
+	}
+	var resolver conductor.SignatureKeyResolver
+	if cfg.Conductor.HonorRemoteKillSwitch {
+		resolver, err = buildConductorTrustResolver(cfg.Conductor, time.Now)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		resolver = func(string) (conductor.SignatureKey, error) {
+			return conductor.SignatureKey{}, conductor.ErrSignatureVerification
+		}
+	}
+	interval, err := time.ParseDuration(cfg.Conductor.PollInterval)
+	if err != nil {
+		return nil, fmt.Errorf("parsing conductor remote kill poll interval: %w", err)
+	}
+	if logWriter == nil {
+		logWriter = io.Discard
+	}
+	logger := slog.New(slog.NewJSONHandler(logWriter, &slog.HandlerOptions{Level: slog.LevelInfo})).
+		With("service", "pipelock", "component", "conductor_remote_kill")
+	applier := &emergency.RemoteKillApplier{
+		OrgID:             cfg.Conductor.OrgID,
+		FleetID:           cfg.Conductor.FleetID,
+		InstanceID:        cfg.Conductor.InstanceID,
+		Resolver:          resolver,
+		KillSwitch:        ks,
+		StatePath:         filepath.Join(cfg.Conductor.BundleCacheDir, emergency.RemoteKillStateFileName),
+		DisableRemoteKill: !cfg.Conductor.HonorRemoteKillSwitch,
+		Now:               time.Now,
+		Logger:            logger,
+	}
+	if err := applier.RestorePersistedState(); err != nil {
+		return nil, fmt.Errorf("restoring conductor remote kill state: %w", err)
+	}
+	return emergency.NewRemoteKillPoller(emergency.RemoteKillPollerConfig{
+		BaseURL:      cfg.Conductor.ConductorURL,
+		Client:       client,
+		Applier:      applier,
+		PollInterval: interval,
+		Logger:       logger,
+	})
+}
+
+func buildConductorTrustResolver(cfg config.Conductor, now func() time.Time) (conductor.SignatureKeyResolver, error) {
+	if now == nil {
+		now = time.Now
+	}
+	roster, err := signing.LoadRoster(cfg.TrustRosterPath, cfg.TrustRosterRootFingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("loading conductor trust roster: %w", err)
+	}
+	return func(signerKeyID string) (conductor.SignatureKey, error) {
+		key, err := roster.ResolveKey(signerKeyID, now().UTC())
+		if err != nil {
+			return conductor.SignatureKey{}, fmt.Errorf("%w: %w", conductor.ErrSignatureVerification, err)
+		}
+		pub, err := hex.DecodeString(key.PublicKeyHex)
+		if err != nil {
+			return conductor.SignatureKey{}, fmt.Errorf("%w: public_key_hex: %w", conductor.ErrSignatureVerification, err)
+		}
+		notBefore, err := time.Parse(time.RFC3339, key.ValidFrom)
+		if err != nil {
+			return conductor.SignatureKey{}, fmt.Errorf("%w: valid_from: %w", conductor.ErrSignatureVerification, err)
+		}
+		var notAfter time.Time
+		if key.ValidUntil != nil {
+			notAfter, err = time.Parse(time.RFC3339, *key.ValidUntil)
+			if err != nil {
+				return conductor.SignatureKey{}, fmt.Errorf("%w: valid_until: %w", conductor.ErrSignatureVerification, err)
+			}
+		}
+		return conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.KeyPurpose(key.KeyPurpose),
+			NotBefore:  notBefore,
+			NotAfter:   notAfter,
+		}, nil
+	}, nil
 }
 
 func newConductorMTLSClient(cfg config.Conductor) (*http.Client, error) {

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -284,12 +284,69 @@ func TestBuildConductorRemoteKillPollerHonorsDisableWithoutRoster(t *testing.T) 
 			PollInterval:          "30s",
 			HonorRemoteKillSwitch: false,
 		},
-	}, &testRuntimeKillSwitch{}, io.Discard)
+	}, &testRuntimeKillSwitch{}, nil)
 	if err != nil {
 		t.Fatalf("buildConductorRemoteKillPoller() error = %v", err)
 	}
 	if poller == nil {
 		t.Fatal("poller = nil, want disabled-mode poller for visible rejected messages")
+	}
+}
+
+func TestBuildConductorRemoteKillPollerRejectsInvalidConfig(t *testing.T) {
+	dir := t.TempDir()
+	clientPEM, clientKeyPEM := testTLSClientCert(t)
+	caPath := filepath.Join(dir, "boss-ca.pem")
+	clientCertPath := filepath.Join(dir, "client.crt")
+	clientKeyPath := filepath.Join(dir, "client.key")
+	writePrivateTestFile(t, caPath, clientPEM)
+	writePrivateTestFile(t, clientCertPath, clientPEM)
+	writePrivateTestFile(t, clientKeyPath, clientKeyPEM)
+	base := config.Conductor{
+		Enabled:                    true,
+		ConductorURL:               "https://conductor.example",
+		OrgID:                      "org-main",
+		FleetID:                    "prod",
+		InstanceID:                 "pl-prod-1",
+		TrustRosterPath:            filepath.Join(dir, "missing-roster.json"),
+		TrustRosterRootFingerprint: strings.Repeat("a", 64),
+		ServerCAFile:               caPath,
+		ClientCertPath:             clientCertPath,
+		ClientKeyPath:              clientKeyPath,
+		BundleCacheDir:             filepath.Join(dir, "bundles"),
+		PollInterval:               "30s",
+		HonorRemoteKillSwitch:      false,
+	}
+	tests := []struct {
+		name string
+		edit func(*config.Conductor)
+		want string
+	}{
+		{
+			name: "mtls_client_error",
+			edit: func(c *config.Conductor) { c.ClientCertPath = filepath.Join(dir, "missing-client.crt") },
+			want: "loading conductor mTLS client certificate",
+		},
+		{
+			name: "trust_resolver_error",
+			edit: func(c *config.Conductor) { c.HonorRemoteKillSwitch = true },
+			want: "loading conductor trust roster",
+		},
+		{
+			name: "poll_interval_error",
+			edit: func(c *config.Conductor) { c.PollInterval = "not-a-duration" },
+			want: "parsing conductor remote kill poll interval",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			tc.edit(&cfg)
+			_, err := buildConductorRemoteKillPoller(&config.Config{Conductor: cfg}, &testRuntimeKillSwitch{}, io.Discard)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("buildConductorRemoteKillPoller() error = %v, want substring %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -13,8 +13,10 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/hex"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
@@ -30,6 +32,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/conductor"
 	"github.com/luckyPipewrench/pipelock/internal/conductor/applycache"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
@@ -222,6 +225,130 @@ func TestConductorServerNameStripsPort(t *testing.T) {
 	}
 }
 
+func TestBuildConductorTrustResolverLoadsPinnedRoster(t *testing.T) {
+	dir := t.TempDir()
+	remotePub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rosterPath := filepath.Join(dir, "trust-roster.json")
+	rootFingerprint := writeRuntimeTrustRoster(t, rosterPath, remotePub, "remote-kill-1", signing.PurposeRemoteKillSigning)
+
+	resolver, err := buildConductorTrustResolver(config.Conductor{
+		TrustRosterPath:            rosterPath,
+		TrustRosterRootFingerprint: rootFingerprint,
+	}, func() time.Time { return time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC) })
+	if err != nil {
+		t.Fatalf("buildConductorTrustResolver() error = %v", err)
+	}
+	key, err := resolver("remote-kill-1")
+	if err != nil {
+		t.Fatalf("resolver(remote-kill-1) error = %v", err)
+	}
+	if key.KeyPurpose != signing.PurposeRemoteKillSigning {
+		t.Fatalf("KeyPurpose = %q, want %q", key.KeyPurpose, signing.PurposeRemoteKillSigning)
+	}
+	if !key.NotBefore.Equal(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) || !key.NotAfter.IsZero() {
+		t.Fatalf("key windows = not_before=%s not_after=%s", key.NotBefore, key.NotAfter)
+	}
+	if string(key.PublicKey) != string(remotePub) {
+		t.Fatal("resolver returned wrong public key")
+	}
+	if _, err := resolver("missing"); !errors.Is(err, conductor.ErrSignatureVerification) {
+		t.Fatalf("resolver(missing) error = %v, want ErrSignatureVerification", err)
+	}
+}
+
+func TestBuildConductorRemoteKillPollerHonorsDisableWithoutRoster(t *testing.T) {
+	dir := t.TempDir()
+	clientPEM, clientKeyPEM := testTLSClientCert(t)
+	caPath := filepath.Join(dir, "boss-ca.pem")
+	clientCertPath := filepath.Join(dir, "client.crt")
+	clientKeyPath := filepath.Join(dir, "client.key")
+	writePrivateTestFile(t, caPath, clientPEM)
+	writePrivateTestFile(t, clientCertPath, clientPEM)
+	writePrivateTestFile(t, clientKeyPath, clientKeyPEM)
+
+	poller, err := buildConductorRemoteKillPoller(&config.Config{
+		Conductor: config.Conductor{
+			Enabled:               true,
+			ConductorURL:          "https://conductor.example",
+			OrgID:                 "org-main",
+			FleetID:               "prod",
+			InstanceID:            "pl-prod-1",
+			TrustRosterPath:       filepath.Join(dir, "missing-roster.json"),
+			ServerCAFile:          caPath,
+			ClientCertPath:        clientCertPath,
+			ClientKeyPath:         clientKeyPath,
+			BundleCacheDir:        filepath.Join(dir, "bundles"),
+			PollInterval:          "30s",
+			HonorRemoteKillSwitch: false,
+		},
+	}, &testRuntimeKillSwitch{}, io.Discard)
+	if err != nil {
+		t.Fatalf("buildConductorRemoteKillPoller() error = %v", err)
+	}
+	if poller == nil {
+		t.Fatal("poller = nil, want disabled-mode poller for visible rejected messages")
+	}
+}
+
+func TestBuildConductorRemoteKillPollerRestoresPersistedState(t *testing.T) {
+	dir := t.TempDir()
+	remotePub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	trustPath := filepath.Join(dir, "trust-roster.json")
+	rootFingerprint := writeRuntimeTrustRoster(t, trustPath, remotePub, "remote-kill-1", signing.PurposeRemoteKillSigning)
+	clientPEM, clientKeyPEM := testTLSClientCert(t)
+	caPath := filepath.Join(dir, "boss-ca.pem")
+	clientCertPath := filepath.Join(dir, "client.crt")
+	clientKeyPath := filepath.Join(dir, "client.key")
+	bundleCacheDir := filepath.Join(dir, "bundles")
+	writePrivateTestFile(t, caPath, clientPEM)
+	writePrivateTestFile(t, clientCertPath, clientPEM)
+	writePrivateTestFile(t, clientKeyPath, clientKeyPEM)
+	statePath := filepath.Join(bundleCacheDir, "remote-kill-state.json")
+	if err := os.MkdirAll(bundleCacheDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll(bundle cache): %v", err)
+	}
+	writePrivateTestFile(t, statePath, []byte(`{
+  "last_counter": 7,
+  "last_message_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "state": "active",
+  "reason": "persisted emergency stop",
+  "applied_at": "2026-05-23T12:00:00Z"
+}`))
+	ks := &testRuntimeKillSwitch{}
+	poller, err := buildConductorRemoteKillPoller(&config.Config{
+		Conductor: config.Conductor{
+			Enabled:                    true,
+			ConductorURL:               "https://conductor.example",
+			OrgID:                      "org-main",
+			FleetID:                    "prod",
+			InstanceID:                 "pl-prod-1",
+			TrustRosterPath:            trustPath,
+			TrustRosterRootFingerprint: rootFingerprint,
+			ServerCAFile:               caPath,
+			ClientCertPath:             clientCertPath,
+			ClientKeyPath:              clientKeyPath,
+			BundleCacheDir:             bundleCacheDir,
+			PollInterval:               "30s",
+			HonorRemoteKillSwitch:      true,
+		},
+	}, ks, io.Discard)
+	if err != nil {
+		t.Fatalf("buildConductorRemoteKillPoller() error = %v", err)
+	}
+	if poller == nil {
+		t.Fatal("poller = nil")
+	}
+	if !ks.active || ks.message != "persisted emergency stop" {
+		t.Fatalf("kill switch = active=%v message=%q, want restored active", ks.active, ks.message)
+	}
+}
+
 func TestConductorRuntimeChanged(t *testing.T) {
 	oldCfg := config.Defaults()
 	newCfg := oldCfg.Clone()
@@ -385,6 +512,7 @@ func newConductorApplyTestServer(t *testing.T) (*Server, runtimePolicySigner, st
 		"  durable_audit_queue_dir: " + strconv.Quote(filepath.Join(tmp, "audit-queue")),
 		"  audit_signing_key_id: audit-key-1",
 		"  recorder_key_id: recorder-key-1",
+		"  honor_remote_kill_switch: false",
 		"",
 	}, "\n"))
 
@@ -453,6 +581,63 @@ func mustHostname(t *testing.T, raw string) string {
 		t.Fatalf("url %s has no host", raw)
 	}
 	return host
+}
+
+type testRuntimeKillSwitch struct {
+	active  bool
+	message string
+}
+
+func (t *testRuntimeKillSwitch) SetConductorRemote(active bool, message string) {
+	t.active = active
+	t.message = message
+}
+
+func writeRuntimeTrustRoster(t *testing.T, path string, pub ed25519.PublicKey, keyID string, purpose signing.KeyPurpose) string {
+	t.Helper()
+	rootPub, rootPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey(root): %v", err)
+	}
+	rootFingerprint, err := signing.Fingerprint(rootPub)
+	if err != nil {
+		t.Fatalf("Fingerprint(root): %v", err)
+	}
+	body := contract.KeyRoster{
+		SchemaVersion:  1,
+		RosterSignedBy: "roster-root-1",
+		DataClassRoot:  string(contract.DataClassInternal),
+		Keys: []contract.KeyInfo{
+			{
+				KeyID:        "roster-root-1",
+				KeyPurpose:   signing.PurposeRosterRoot.String(),
+				PublicKeyHex: hex.EncodeToString(rootPub),
+				ValidFrom:    "2026-01-01T00:00:00Z",
+				Status:       contract.KeyStatusRoot,
+			},
+			{
+				KeyID:        keyID,
+				KeyPurpose:   purpose.String(),
+				PublicKeyHex: hex.EncodeToString(pub),
+				ValidFrom:    "2026-01-01T00:00:00Z",
+				Status:       contract.KeyStatusActive,
+			},
+		},
+	}
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage(roster): %v", err)
+	}
+	envelope := contract.RosterEnvelope{
+		Body:      body,
+		Signature: "ed25519:" + hex.EncodeToString(ed25519.Sign(rootPriv, preimage)),
+	}
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("Marshal(roster): %v", err)
+	}
+	writePrivateTestFile(t, path, data)
+	return rootFingerprint
 }
 
 // newTestTLSServer builds a single-leaf CA + server cert, starts an httptest

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/conductor/applycache"
 	"github.com/luckyPipewrench/pipelock/internal/conductor/auditbatcher"
+	"github.com/luckyPipewrench/pipelock/internal/conductor/emergency"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/emit"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
@@ -89,22 +90,23 @@ type Server struct {
 	cfg          *config.Config
 	bundleResult *rules.LoadResult
 
-	sentry            *plsentry.Client
-	logger            *audit.Logger
-	emitter           *emit.Emitter
-	scanner           *scanner.Scanner
-	metrics           *metrics.Metrics
-	killswitch        *killswitch.Controller
-	ksAPI             *killswitch.APIHandler
-	proxy             *proxy.Proxy
-	receiptEmitter    *receipt.Emitter
-	envelopeEmitter   *envelope.Emitter
-	captureWriter     *capture.Writer
-	recorder          *recorder.Recorder
-	conductorApply    *applycache.Cache
-	conductorAudit    *auditbatcher.Transport
-	conductorProducer *auditbatcher.Producer
-	approver          *hitl.Approver
+	sentry              *plsentry.Client
+	logger              *audit.Logger
+	emitter             *emit.Emitter
+	scanner             *scanner.Scanner
+	metrics             *metrics.Metrics
+	killswitch          *killswitch.Controller
+	ksAPI               *killswitch.APIHandler
+	proxy               *proxy.Proxy
+	receiptEmitter      *receipt.Emitter
+	envelopeEmitter     *envelope.Emitter
+	captureWriter       *capture.Writer
+	recorder            *recorder.Recorder
+	conductorApply      *applycache.Cache
+	conductorAudit      *auditbatcher.Transport
+	conductorRemoteKill *emergency.RemoteKillPoller
+	conductorProducer   *auditbatcher.Producer
+	approver            *hitl.Approver
 
 	// lastReloadHash / lastReloadAt dedup fsnotify + SIGHUP stacking
 	// inside Reload. Two stacked Changes() events with the same hash
@@ -315,6 +317,12 @@ func NewServer(opts ServerOpts) (*Server, error) {
 
 	ksAPI := killswitch.NewAPIHandler(ks)
 	s.ksAPI = ksAPI
+	conductorRemoteKill, conductorRemoteKillErr := buildConductorRemoteKillPoller(cfg, ks, opts.Stderr)
+	if conductorRemoteKillErr != nil {
+		s.cleanup()
+		return nil, conductorRemoteKillErr
+	}
+	s.conductorRemoteKill = conductorRemoteKill
 
 	var proxyOpts []proxy.Option
 	s.hasApprover = cfg.ResponseScanning.Action == config.ActionAsk

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -203,6 +203,9 @@ func (s *Server) Start(ctx context.Context) error {
 	if s.conductorAudit != nil {
 		_, _ = fmt.Fprintf(s.opts.Stderr, "  Conductor: audit transport enabled -> %s\n", RedactEndpoint(cfg.Conductor.ConductorURL))
 	}
+	if s.conductorRemoteKill != nil {
+		_, _ = fmt.Fprintf(s.opts.Stderr, "  Conductor: remote kill polling enabled -> %s\n", RedactEndpoint(cfg.Conductor.ConductorURL))
+	}
 	if s.opts.CaptureOutput != "" {
 		if s.opts.CaptureDuration > 0 {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "  Capture: %s (duration: %s)\n", s.opts.CaptureOutput, s.opts.CaptureDuration)
@@ -222,6 +225,23 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	var conductorWG sync.WaitGroup
+	if s.conductorAudit != nil || s.conductorRemoteKill != nil {
+		if s.conductorRemoteKill != nil {
+			conductorWG.Add(1)
+			go func() {
+				defer conductorWG.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: conductor remote kill poller panic: %v\n", r)
+					}
+				}()
+				if err := s.conductorRemoteKill.Run(ctx); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+					s.logger.LogError(audit.NewResourceLogContext("conductor_remote_kill_poller", cfg.Conductor.ConductorURL), err)
+					_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: conductor remote kill poller stopped: %v\n", err)
+				}
+			}()
+		}
+	}
 	if s.conductorAudit != nil {
 		conductorWG.Add(1)
 		go func() {
@@ -236,6 +256,8 @@ func (s *Server) Start(ctx context.Context) error {
 				_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: conductor audit transport stopped: %v\n", err)
 			}
 		}()
+	}
+	if s.conductorAudit != nil || s.conductorRemoteKill != nil {
 		defer func() {
 			cancel()
 			conductorWG.Wait()

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -233,11 +233,13 @@ func (s *Server) Start(ctx context.Context) error {
 				defer func() {
 					if r := recover(); r != nil {
 						_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: conductor remote kill poller panic: %v\n", r)
+						cancel()
 					}
 				}()
 				if err := s.conductorRemoteKill.Run(ctx); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 					s.logger.LogError(audit.NewResourceLogContext("conductor_remote_kill_poller", cfg.Conductor.ConductorURL), err)
 					_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: conductor remote kill poller stopped: %v\n", err)
+					cancel()
 				}
 			}()
 		}

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/ed25519"
 	"io"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -16,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/conductor/emergency"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	mcptools "github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
@@ -455,6 +457,17 @@ func TestNewServer_ResolveRuntimeRuns(t *testing.T) {
 	}
 }
 
+type serverRemoteKillNoopClient struct{}
+
+func (serverRemoteKillNoopClient) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusNoContent,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
 // TestServer_StartShutdown verifies that Start blocks, Shutdown releases
 // it, and Start returns nil on clean shutdown. Uses an ephemeral listen
 // address so nothing conflicts with a developer's already-running
@@ -486,6 +499,46 @@ func TestServer_StartShutdown(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("Start did not return within 5s of Shutdown")
+	}
+}
+
+func TestServer_StartRunsConductorRemoteKillPoller(t *testing.T) {
+	s, buf := newTestServer(t, func(o *ServerOpts) {
+		o.Listen = newServerTestFreePort(t)
+		o.ListenChanged = true
+	})
+	poller, err := emergency.NewRemoteKillPoller(emergency.RemoteKillPollerConfig{
+		BaseURL:      "https://conductor.example",
+		Client:       serverRemoteKillNoopClient{},
+		Applier:      &emergency.RemoteKillApplier{},
+		PollInterval: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewRemoteKillPoller: %v", err)
+	}
+	s.conductorRemoteKill = poller
+	s.cfg.Conductor.ConductorURL = "https://conductor.example"
+
+	errCh := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		errCh <- s.Start(ctx)
+	}()
+
+	waitForServerCancel(t, s)
+	waitForServerOutput(t, buf, "Conductor: remote kill polling enabled -> https://conductor.example")
+
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Start returned error after Shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return within 5s of Shutdown")
 	}
 }
 

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -381,6 +381,7 @@ func TestNewServer_ConductorAuditProducerFromConfig(t *testing.T) {
 		"  durable_audit_queue_dir: " + strconv.Quote(filepath.Join(tmp, "audit-queue")),
 		"  audit_signing_key_id: audit-key-1",
 		"  recorder_key_id: recorder-key-1",
+		"  honor_remote_kill_switch: false",
 		"",
 	}, "\n"))
 

--- a/internal/conductor/emergency/poller.go
+++ b/internal/conductor/emergency/poller.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package emergency
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+)
+
+const (
+	RemoteKillPath                 = "/api/v1/conductor/remote-kill"
+	defaultRemoteKillPollInterval  = 30 * time.Second
+	defaultRemoteKillResponseBytes = 64 * 1024
+	remoteKillPollerUserAgent      = "pipelock-conductor-remote-kill/1.0"
+	remoteKillPollerAcceptedCT     = "application/json"
+)
+
+var (
+	ErrRemoteKillPollerRequired = errors.New("conductor remote kill poller required")
+	ErrRemoteKillPollResponse   = errors.New("invalid conductor remote kill poll response")
+)
+
+type HTTPDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type RemoteKillPollerConfig struct {
+	BaseURL          string
+	Client           HTTPDoer
+	Applier          *RemoteKillApplier
+	PollInterval     time.Duration
+	MaxResponseBytes int64
+	Logger           *slog.Logger
+}
+
+type RemoteKillPoller struct {
+	client           HTTPDoer
+	applier          *RemoteKillApplier
+	endpoint         string
+	pollInterval     time.Duration
+	maxResponseBytes int64
+	logger           *slog.Logger
+}
+
+func NewRemoteKillPoller(cfg RemoteKillPollerConfig) (*RemoteKillPoller, error) {
+	if cfg.Client == nil {
+		return nil, fmt.Errorf("%w: HTTP client", ErrRemoteKillPollerRequired)
+	}
+	if cfg.Applier == nil {
+		return nil, fmt.Errorf("%w: applier", ErrRemoteKillPollerRequired)
+	}
+	endpoint, err := remoteKillEndpoint(cfg.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+	interval := cfg.PollInterval
+	if interval == 0 {
+		interval = defaultRemoteKillPollInterval
+	}
+	if interval < time.Second {
+		return nil, fmt.Errorf("conductor remote kill poll interval must be >= 1s, got %s", interval)
+	}
+	maxBytes := cfg.MaxResponseBytes
+	if maxBytes == 0 {
+		maxBytes = defaultRemoteKillResponseBytes
+	}
+	if maxBytes <= 0 {
+		return nil, fmt.Errorf("conductor remote kill max response bytes must be > 0, got %d", maxBytes)
+	}
+	return &RemoteKillPoller{
+		client:           cfg.Client,
+		applier:          cfg.Applier,
+		endpoint:         endpoint,
+		pollInterval:     interval,
+		maxResponseBytes: maxBytes,
+		logger:           cfg.Logger,
+	}, nil
+}
+
+func (p *RemoteKillPoller) Run(ctx context.Context) error {
+	if p == nil {
+		return ErrRemoteKillPollerRequired
+	}
+	for {
+		if err := p.PollOnce(ctx); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
+			p.logPollError(err)
+		}
+		timer := time.NewTimer(p.pollInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (p *RemoteKillPoller) PollOnce(ctx context.Context) error {
+	if p == nil {
+		return ErrRemoteKillPollerRequired
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("create conductor remote kill poll request: %w", err)
+	}
+	req.Header.Set("Accept", remoteKillPollerAcceptedCT)
+	req.Header.Set("User-Agent", remoteKillPollerUserAgent)
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("poll conductor remote kill: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return nil
+	case http.StatusOK:
+	default:
+		return fmt.Errorf("%w: status=%d", ErrRemoteKillPollResponse, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, p.maxResponseBytes+1))
+	if err != nil {
+		return fmt.Errorf("read conductor remote kill response: %w", err)
+	}
+	if int64(len(body)) > p.maxResponseBytes {
+		return fmt.Errorf("%w: body exceeds %d bytes", ErrRemoteKillPollResponse, p.maxResponseBytes)
+	}
+	var msg conductor.RemoteKillMessage
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&msg); err != nil {
+		return fmt.Errorf("%w: decode: %w", ErrRemoteKillPollResponse, err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return fmt.Errorf("%w: trailing JSON document", ErrRemoteKillPollResponse)
+	}
+	return p.applier.Apply(msg)
+}
+
+func (p *RemoteKillPoller) logPollError(err error) {
+	if p.logger == nil {
+		return
+	}
+	p.logger.Warn("conductor_remote_kill_poll_error",
+		slog.String("event", "conductor_remote_kill_poll_error"),
+		slog.String("error", err.Error()),
+	)
+}
+
+func remoteKillEndpoint(rawBaseURL string) (string, error) {
+	u, err := url.Parse(rawBaseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse conductor remote kill base URL: %w", err)
+	}
+	if u.Scheme != "https" || u.Host == "" {
+		return "", fmt.Errorf("conductor remote kill base URL must be https with a host")
+	}
+	if u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("conductor remote kill base URL must not include userinfo, query, or fragment")
+	}
+	if u.Path != "" && u.Path != "/" {
+		return "", fmt.Errorf("conductor remote kill base URL must not include a path component")
+	}
+	u.Path = RemoteKillPath
+	u.RawPath = ""
+	return u.String(), nil
+}

--- a/internal/conductor/emergency/poller.go
+++ b/internal/conductor/emergency/poller.go
@@ -94,7 +94,7 @@ func (p *RemoteKillPoller) Run(ctx context.Context) error {
 	}
 	for {
 		if err := p.PollOnce(ctx); err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			if errors.Is(err, context.Canceled) || (errors.Is(err, context.DeadlineExceeded) && ctx.Err() != nil) {
 				return err
 			}
 			p.logPollError(err)

--- a/internal/conductor/emergency/poller_test.go
+++ b/internal/conductor/emergency/poller_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package emergency
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/conductor"
+)
+
+type fakeRemoteKillClient struct {
+	status  int
+	body    string
+	request *http.Request
+	err     error
+}
+
+func (f *fakeRemoteKillClient) Do(req *http.Request) (*http.Response, error) {
+	f.request = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &http.Response{
+		StatusCode: f.status,
+		Body:       io.NopCloser(strings.NewReader(f.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestRemoteKillPollerAppliesMessage(t *testing.T) {
+	msg, resolver := signedRemoteKill(t, 11, conductor.KillSwitchActive)
+	body, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Marshal(msg): %v", err)
+	}
+	ks := &captureKillSwitch{}
+	client := &fakeRemoteKillClient{status: http.StatusOK, body: string(body)}
+	poller := newTestRemoteKillPoller(t, client, resolver, ks)
+
+	if err := poller.PollOnce(t.Context()); err != nil {
+		t.Fatalf("PollOnce() error = %v", err)
+	}
+	if client.request == nil {
+		t.Fatal("client request = nil")
+	}
+	if got := client.request.URL.Path; got != RemoteKillPath {
+		t.Fatalf("request path = %q, want %q", got, RemoteKillPath)
+	}
+	if got := client.request.Method; got != http.MethodGet {
+		t.Fatalf("request method = %q, want GET", got)
+	}
+	if got := client.request.Header.Get("Accept"); got != remoteKillPollerAcceptedCT {
+		t.Fatalf("Accept = %q, want %q", got, remoteKillPollerAcceptedCT)
+	}
+	if !ks.active || ks.message != msg.Reason {
+		t.Fatalf("kill switch = active=%v message=%q, want applied active message", ks.active, ks.message)
+	}
+}
+
+func TestRemoteKillPollerNoContentIsNoop(t *testing.T) {
+	_, resolver := signedRemoteKill(t, 11, conductor.KillSwitchActive)
+	ks := &captureKillSwitch{}
+	poller := newTestRemoteKillPoller(t, &fakeRemoteKillClient{status: http.StatusNoContent}, resolver, ks)
+
+	if err := poller.PollOnce(t.Context()); err != nil {
+		t.Fatalf("PollOnce(204) error = %v", err)
+	}
+	if ks.active || ks.message != "" {
+		t.Fatalf("kill switch changed on 204: active=%v message=%q", ks.active, ks.message)
+	}
+}
+
+func TestRemoteKillPollerRejectsBadResponses(t *testing.T) {
+	_, resolver := signedRemoteKill(t, 11, conductor.KillSwitchActive)
+	tests := []struct {
+		name    string
+		status  int
+		body    string
+		maxBody int64
+		want    string
+	}{
+		{name: "non_200", status: http.StatusForbidden, want: "status=403"},
+		{name: "bad_json", status: http.StatusOK, body: "{", want: "decode"},
+		{name: "trailing_json", status: http.StatusOK, body: `{"schema_version":1}{}`, want: "trailing JSON document"},
+		{name: "too_large", status: http.StatusOK, body: strings.Repeat("x", 9), maxBody: 8, want: "body exceeds"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			poller := newTestRemoteKillPoller(t, &fakeRemoteKillClient{status: tc.status, body: tc.body}, resolver, &captureKillSwitch{})
+			if tc.maxBody > 0 {
+				poller.maxResponseBytes = tc.maxBody
+			}
+			err := poller.PollOnce(t.Context())
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("PollOnce() error = %v, want substring %q", err, tc.want)
+			}
+			if !errors.Is(err, ErrRemoteKillPollResponse) && tc.status != http.StatusOK {
+				t.Fatalf("PollOnce() error = %v, want ErrRemoteKillPollResponse", err)
+			}
+		})
+	}
+}
+
+func TestRemoteKillPollerEndpointValidation(t *testing.T) {
+	msg, resolver := signedRemoteKill(t, 11, conductor.KillSwitchActive)
+	applier := &RemoteKillApplier{
+		OrgID:      msg.OrgID,
+		FleetID:    msg.FleetID,
+		InstanceID: "pl-prod-1",
+		Resolver:   resolver,
+		KillSwitch: &captureKillSwitch{},
+		StatePath:  filepath.Join(t.TempDir(), "state.json"),
+		Now:        func() time.Time { return testNow },
+	}
+	tests := []struct {
+		name string
+		base string
+		ok   bool
+	}{
+		{name: "valid", base: "https://conductor.example", ok: true},
+		{name: "valid_slash", base: "https://conductor.example/", ok: true},
+		{name: "http", base: "http://conductor.example"},
+		{name: "path", base: "https://conductor.example/base"},
+		{name: "query", base: "https://conductor.example?token=x"},
+		{name: "userinfo", base: "https://user@conductor.example"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			poller, err := NewRemoteKillPoller(RemoteKillPollerConfig{
+				BaseURL:      tc.base,
+				Client:       &fakeRemoteKillClient{status: http.StatusNoContent},
+				Applier:      applier,
+				PollInterval: time.Second,
+			})
+			if tc.ok {
+				if err != nil {
+					t.Fatalf("NewRemoteKillPoller() error = %v", err)
+				}
+				if poller.endpoint != "https://conductor.example"+RemoteKillPath {
+					t.Fatalf("endpoint = %q", poller.endpoint)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("NewRemoteKillPoller() error = nil, want error")
+			}
+		})
+	}
+}
+
+func TestRemoteKillPollerRunStopsOnContextCancel(t *testing.T) {
+	_, resolver := signedRemoteKill(t, 11, conductor.KillSwitchActive)
+	poller := newTestRemoteKillPoller(t, &fakeRemoteKillClient{status: http.StatusNoContent}, resolver, &captureKillSwitch{})
+	poller.pollInterval = time.Hour
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		done <- poller.Run(ctx)
+	}()
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not stop after context cancel")
+	}
+}
+
+func newTestRemoteKillPoller(t *testing.T, client HTTPDoer, resolver conductor.SignatureKeyResolver, ks *captureKillSwitch) *RemoteKillPoller {
+	t.Helper()
+	poller, err := NewRemoteKillPoller(RemoteKillPollerConfig{
+		BaseURL: "https://conductor.example",
+		Client:  client,
+		Applier: &RemoteKillApplier{
+			OrgID:      "org-main",
+			FleetID:    "prod",
+			InstanceID: "pl-prod-1",
+			Resolver:   resolver,
+			KillSwitch: ks,
+			StatePath:  filepath.Join(t.TempDir(), "state.json"),
+			Now:        func() time.Time { return testNow },
+		},
+		PollInterval: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewRemoteKillPoller() error = %v", err)
+	}
+	return poller
+}

--- a/internal/conductor/emergency/poller_test.go
+++ b/internal/conductor/emergency/poller_test.go
@@ -131,7 +131,7 @@ func TestRemoteKillPollerEndpointValidation(t *testing.T) {
 		{name: "valid_slash", base: "https://conductor.example/", ok: true},
 		{name: "http", base: "http://conductor.example"},
 		{name: "path", base: "https://conductor.example/base"},
-		{name: "query", base: "https://conductor.example?token=x"},
+		{name: "query", base: "https://conductor.example?debug=true"},
 		{name: "userinfo", base: "https://user@conductor.example"},
 	}
 	for _, tc := range tests {
@@ -155,6 +155,45 @@ func TestRemoteKillPollerEndpointValidation(t *testing.T) {
 				t.Fatal("NewRemoteKillPoller() error = nil, want error")
 			}
 		})
+	}
+}
+
+type retryDeadlineRemoteKillClient struct {
+	cancel context.CancelFunc
+	calls  int
+}
+
+func (c *retryDeadlineRemoteKillClient) Do(req *http.Request) (*http.Response, error) {
+	c.calls++
+	if c.calls == 1 {
+		return nil, context.DeadlineExceeded
+	}
+	c.cancel()
+	return &http.Response{
+		StatusCode: http.StatusNoContent,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestRemoteKillPollerRetriesTransientDeadlineExceeded(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	client := &retryDeadlineRemoteKillClient{cancel: cancel}
+	poller := &RemoteKillPoller{
+		client:           client,
+		applier:          &RemoteKillApplier{},
+		endpoint:         "https://conductor.example" + RemoteKillPath,
+		pollInterval:     time.Millisecond,
+		maxResponseBytes: defaultRemoteKillResponseBytes,
+	}
+
+	err := poller.Run(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want context.Canceled", err)
+	}
+	if client.calls < 2 {
+		t.Fatalf("client calls = %d, want retry after transient deadline", client.calls)
 	}
 }
 

--- a/internal/conductor/emergency/poller_test.go
+++ b/internal/conductor/emergency/poller_test.go
@@ -4,10 +4,12 @@
 package emergency
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -111,6 +113,45 @@ func TestRemoteKillPollerRejectsBadResponses(t *testing.T) {
 	}
 }
 
+func TestNewRemoteKillPollerValidationAndDefaults(t *testing.T) {
+	applier := &RemoteKillApplier{}
+	client := &fakeRemoteKillClient{status: http.StatusNoContent}
+	poller, err := NewRemoteKillPoller(RemoteKillPollerConfig{
+		BaseURL: "https://conductor.example",
+		Client:  client,
+		Applier: applier,
+	})
+	if err != nil {
+		t.Fatalf("NewRemoteKillPoller(defaults) error = %v", err)
+	}
+	if poller.pollInterval != defaultRemoteKillPollInterval {
+		t.Fatalf("pollInterval = %s, want %s", poller.pollInterval, defaultRemoteKillPollInterval)
+	}
+	if poller.maxResponseBytes != defaultRemoteKillResponseBytes {
+		t.Fatalf("maxResponseBytes = %d, want %d", poller.maxResponseBytes, defaultRemoteKillResponseBytes)
+	}
+
+	tests := []struct {
+		name string
+		cfg  RemoteKillPollerConfig
+		want string
+	}{
+		{name: "nil_client", cfg: RemoteKillPollerConfig{BaseURL: "https://conductor.example", Applier: applier}, want: "HTTP client"},
+		{name: "nil_applier", cfg: RemoteKillPollerConfig{BaseURL: "https://conductor.example", Client: client}, want: "applier"},
+		{name: "short_interval", cfg: RemoteKillPollerConfig{BaseURL: "https://conductor.example", Client: client, Applier: applier, PollInterval: time.Millisecond}, want: "poll interval"},
+		{name: "negative_max_response", cfg: RemoteKillPollerConfig{BaseURL: "https://conductor.example", Client: client, Applier: applier, MaxResponseBytes: -1}, want: "max response bytes"},
+		{name: "bad_url_parse", cfg: RemoteKillPollerConfig{BaseURL: "://bad", Client: client, Applier: applier}, want: "parse conductor remote kill base URL"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewRemoteKillPoller(tc.cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("NewRemoteKillPoller() error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestRemoteKillPollerEndpointValidation(t *testing.T) {
 	msg, resolver := signedRemoteKill(t, 11, conductor.KillSwitchActive)
 	applier := &RemoteKillApplier{
@@ -155,6 +196,37 @@ func TestRemoteKillPollerEndpointValidation(t *testing.T) {
 				t.Fatal("NewRemoteKillPoller() error = nil, want error")
 			}
 		})
+	}
+}
+
+func TestRemoteKillPollerNilAndRequestErrors(t *testing.T) {
+	var nilPoller *RemoteKillPoller
+	if err := nilPoller.Run(t.Context()); !errors.Is(err, ErrRemoteKillPollerRequired) {
+		t.Fatalf("Run(nil) error = %v, want ErrRemoteKillPollerRequired", err)
+	}
+	if err := nilPoller.PollOnce(t.Context()); !errors.Is(err, ErrRemoteKillPollerRequired) {
+		t.Fatalf("PollOnce(nil) error = %v, want ErrRemoteKillPollerRequired", err)
+	}
+	poller := &RemoteKillPoller{
+		client:           &fakeRemoteKillClient{status: http.StatusNoContent},
+		applier:          &RemoteKillApplier{},
+		endpoint:         "http://[::1",
+		pollInterval:     time.Second,
+		maxResponseBytes: defaultRemoteKillResponseBytes,
+	}
+	if err := poller.PollOnce(t.Context()); err == nil || !strings.Contains(err.Error(), "create conductor remote kill poll request") {
+		t.Fatalf("PollOnce(bad endpoint) error = %v, want request creation error", err)
+	}
+}
+
+func TestRemoteKillPollerLogsErrors(t *testing.T) {
+	var logs bytes.Buffer
+	poller := &RemoteKillPoller{
+		logger: slog.New(slog.NewJSONHandler(&logs, nil)),
+	}
+	poller.logPollError(errors.New("boom"))
+	if !strings.Contains(logs.String(), "conductor_remote_kill_poll_error") || !strings.Contains(logs.String(), "boom") {
+		t.Fatalf("logs = %s, want poll error event", logs.String())
 	}
 }
 

--- a/internal/conductor/emergency/poller_test.go
+++ b/internal/conductor/emergency/poller_test.go
@@ -132,12 +132,13 @@ func TestNewRemoteKillPollerValidationAndDefaults(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		cfg  RemoteKillPollerConfig
-		want string
+		name         string
+		cfg          RemoteKillPollerConfig
+		want         string
+		wantRequired bool
 	}{
-		{name: "nil_client", cfg: RemoteKillPollerConfig{BaseURL: "https://conductor.example", Applier: applier}, want: "HTTP client"},
-		{name: "nil_applier", cfg: RemoteKillPollerConfig{BaseURL: "https://conductor.example", Client: client}, want: "applier"},
+		{name: "nil_client", cfg: RemoteKillPollerConfig{BaseURL: "https://conductor.example", Applier: applier}, want: "HTTP client", wantRequired: true},
+		{name: "nil_applier", cfg: RemoteKillPollerConfig{BaseURL: "https://conductor.example", Client: client}, want: "applier", wantRequired: true},
 		{name: "short_interval", cfg: RemoteKillPollerConfig{BaseURL: "https://conductor.example", Client: client, Applier: applier, PollInterval: time.Millisecond}, want: "poll interval"},
 		{name: "negative_max_response", cfg: RemoteKillPollerConfig{BaseURL: "https://conductor.example", Client: client, Applier: applier, MaxResponseBytes: -1}, want: "max response bytes"},
 		{name: "bad_url_parse", cfg: RemoteKillPollerConfig{BaseURL: "://bad", Client: client, Applier: applier}, want: "parse conductor remote kill base URL"},
@@ -147,6 +148,9 @@ func TestNewRemoteKillPollerValidationAndDefaults(t *testing.T) {
 			_, err := NewRemoteKillPoller(tc.cfg)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("NewRemoteKillPoller() error = %v, want substring %q", err, tc.want)
+			}
+			if tc.wantRequired && !errors.Is(err, ErrRemoteKillPollerRequired) {
+				t.Fatalf("NewRemoteKillPoller() error = %v, want ErrRemoteKillPollerRequired", err)
 			}
 		})
 	}

--- a/internal/conductor/emergency/remote_kill.go
+++ b/internal/conductor/emergency/remote_kill.go
@@ -24,16 +24,21 @@ var (
 	ErrRemoteKillStateRequired = errors.New("conductor remote kill replay state path required")
 )
 
-const maxRemoteKillStateBytes = 16 * 1024
+const (
+	RemoteKillStateFileName = "remote-kill-state.json"
+	maxRemoteKillStateBytes = 16 * 1024
+)
 
 type KillSwitchSetter interface {
 	SetConductorRemote(active bool, message string)
 }
 
 type remoteKillState struct {
-	LastCounter     uint64    `json:"last_counter"`
-	LastMessageHash string    `json:"last_message_hash"`
-	AppliedAt       time.Time `json:"applied_at"`
+	LastCounter     uint64                    `json:"last_counter"`
+	LastMessageHash string                    `json:"last_message_hash"`
+	State           conductor.KillSwitchState `json:"state"`
+	Reason          string                    `json:"reason"`
+	AppliedAt       time.Time                 `json:"applied_at"`
 }
 
 type RemoteKillApplier struct {
@@ -96,21 +101,59 @@ func (a *RemoteKillApplier) Apply(msg conductor.RemoteKillMessage) error {
 		return err
 	}
 	if hash == state.LastMessageHash {
-		err := fmt.Errorf("%w: duplicate message_hash=%s", ErrRemoteKillSuperseded, hash)
-		a.logReject("counter", err)
-		return err
+		return a.applyPersistedDecisionLocked(state)
 	}
 	if msg.Counter <= state.LastCounter {
 		err := fmt.Errorf("%w: counter=%d last=%d", ErrRemoteKillSuperseded, msg.Counter, state.LastCounter)
-		a.logReject("counter", err)
+		a.logReject("stale_counter", err)
 		return err
 	}
 	a.KillSwitch.SetConductorRemote(msg.State == conductor.KillSwitchActive, msg.Reason)
 	return writeRemoteKillState(a.StatePath, remoteKillState{
 		LastCounter:     msg.Counter,
 		LastMessageHash: hash,
+		State:           msg.State,
+		Reason:          msg.Reason,
 		AppliedAt:       now,
 	})
+}
+
+func (a *RemoteKillApplier) RestorePersistedState() error {
+	if a == nil {
+		return errors.New("conductor remote kill applier required")
+	}
+	if a.KillSwitch == nil {
+		return errors.New("conductor remote kill applier kill switch required")
+	}
+	if a.StatePath == "" {
+		return ErrRemoteKillStateRequired
+	}
+	if a.DisableRemoteKill {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	state, err := readRemoteKillState(a.StatePath)
+	if err != nil {
+		return err
+	}
+	if state.LastMessageHash == "" {
+		return nil
+	}
+	return a.applyPersistedDecisionLocked(state)
+}
+
+func (a *RemoteKillApplier) applyPersistedDecisionLocked(state remoteKillState) error {
+	switch state.State {
+	case conductor.KillSwitchActive, conductor.KillSwitchInactive:
+	default:
+		return fmt.Errorf("invalid conductor remote kill persisted state %q", state.State)
+	}
+	if len(state.Reason) > conductor.MaxReasonBytes {
+		return fmt.Errorf("invalid conductor remote kill persisted reason: %d bytes > cap %d", len(state.Reason), conductor.MaxReasonBytes)
+	}
+	a.KillSwitch.SetConductorRemote(state.State == conductor.KillSwitchActive, state.Reason)
+	return nil
 }
 
 func (a *RemoteKillApplier) logReject(reason string, err error) {

--- a/internal/conductor/emergency/remote_kill.go
+++ b/internal/conductor/emergency/remote_kill.go
@@ -101,7 +101,19 @@ func (a *RemoteKillApplier) Apply(msg conductor.RemoteKillMessage) error {
 		return err
 	}
 	if hash == state.LastMessageHash {
-		return a.applyPersistedDecisionLocked(state)
+		switch state.State {
+		case conductor.KillSwitchActive, conductor.KillSwitchInactive:
+			return a.applyPersistedDecisionLocked(state)
+		default:
+			a.KillSwitch.SetConductorRemote(msg.State == conductor.KillSwitchActive, msg.Reason)
+			return writeRemoteKillState(a.StatePath, remoteKillState{
+				LastCounter:     msg.Counter,
+				LastMessageHash: hash,
+				State:           msg.State,
+				Reason:          msg.Reason,
+				AppliedAt:       now,
+			})
+		}
 	}
 	if msg.Counter <= state.LastCounter {
 		err := fmt.Errorf("%w: counter=%d last=%d", ErrRemoteKillSuperseded, msg.Counter, state.LastCounter)

--- a/internal/conductor/emergency/remote_kill_test.go
+++ b/internal/conductor/emergency/remote_kill_test.go
@@ -371,6 +371,49 @@ func TestRemoteKillApplierRejectsStaleCounter(t *testing.T) {
 	}
 }
 
+func TestRemoteKillApplierBackfillsLegacyStateOnDuplicateHash(t *testing.T) {
+	msg, resolver := signedRemoteKill(t, 9, conductor.KillSwitchActive)
+	hash, err := msg.CanonicalHash()
+	if err != nil {
+		t.Fatalf("CanonicalHash() error = %v", err)
+	}
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	legacyState, err := json.Marshal(map[string]any{
+		"last_counter":      msg.Counter,
+		"last_message_hash": hash,
+		"applied_at":        testNow.Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Marshal(legacy state) error = %v", err)
+	}
+	if err := os.WriteFile(statePath, legacyState, 0o600); err != nil {
+		t.Fatalf("WriteFile(legacy state) error = %v", err)
+	}
+	ks := &captureKillSwitch{}
+	applier := &RemoteKillApplier{
+		OrgID:      "org-main",
+		FleetID:    "prod",
+		InstanceID: "pl-prod-1",
+		Resolver:   resolver,
+		KillSwitch: ks,
+		StatePath:  statePath,
+		Now:        func() time.Time { return testNow },
+	}
+	if err := applier.Apply(msg); err != nil {
+		t.Fatalf("Apply(legacy duplicate hash) error = %v", err)
+	}
+	if !ks.active || ks.message != msg.Reason {
+		t.Fatalf("kill switch = active=%v message=%q, want active reason", ks.active, ks.message)
+	}
+	state, err := readRemoteKillState(statePath)
+	if err != nil {
+		t.Fatalf("readRemoteKillState(backfilled) error = %v", err)
+	}
+	if state.State != msg.State || state.Reason != msg.Reason || state.LastMessageHash != hash {
+		t.Fatalf("backfilled state = %+v, want state/reason/hash from verified message", state)
+	}
+}
+
 func signedRemoteKill(t *testing.T, counter uint64, state conductor.KillSwitchState) (conductor.RemoteKillMessage, conductor.SignatureKeyResolver) {
 	t.Helper()
 	pub1, priv1, err := ed25519.GenerateKey(nil)

--- a/internal/conductor/emergency/remote_kill_test.go
+++ b/internal/conductor/emergency/remote_kill_test.go
@@ -50,8 +50,8 @@ func TestRemoteKillApplier(t *testing.T) {
 	if !ks.active || ks.message != msg.Reason {
 		t.Fatalf("kill switch = active=%v message=%q, want active reason", ks.active, ks.message)
 	}
-	if err := applier.Apply(msg); !errors.Is(err, ErrRemoteKillSuperseded) {
-		t.Fatalf("Apply(reuse) error = %v, want ErrRemoteKillSuperseded", err)
+	if err := applier.Apply(msg); err != nil {
+		t.Fatalf("Apply(reuse) error = %v, want idempotent re-apply", err)
 	}
 
 	var state remoteKillState
@@ -65,18 +65,25 @@ func TestRemoteKillApplier(t *testing.T) {
 	if state.LastCounter != msg.Counter || state.LastMessageHash == "" || !state.AppliedAt.Equal(testNow) {
 		t.Fatalf("state = %+v, want counter/hash/applied_at", state)
 	}
+	if state.State != conductor.KillSwitchActive || state.Reason != msg.Reason {
+		t.Fatalf("state decision = state=%q reason=%q, want active reason", state.State, state.Reason)
+	}
 
+	restartedKS := &captureKillSwitch{}
 	restarted := &RemoteKillApplier{
 		OrgID:      "org-main",
 		FleetID:    "prod",
 		InstanceID: "pl-prod-1",
 		Resolver:   resolver,
-		KillSwitch: &captureKillSwitch{},
+		KillSwitch: restartedKS,
 		StatePath:  applier.StatePath,
 		Now:        func() time.Time { return testNow },
 	}
-	if err := restarted.Apply(msg); !errors.Is(err, ErrRemoteKillSuperseded) {
-		t.Fatalf("Apply(after restart) error = %v, want ErrRemoteKillSuperseded", err)
+	if err := restarted.Apply(msg); err != nil {
+		t.Fatalf("Apply(after restart same message) error = %v, want idempotent re-apply", err)
+	}
+	if !restartedKS.active || restartedKS.message != msg.Reason {
+		t.Fatalf("restarted kill switch = active=%v message=%q, want active reason", restartedKS.active, restartedKS.message)
 	}
 }
 
@@ -239,12 +246,38 @@ func TestRemoteKillApplierInactiveClearsSource(t *testing.T) {
 	}
 }
 
+func TestRemoteKillApplierRestoresPersistedState(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	if err := writeRemoteKillState(statePath, remoteKillState{
+		LastCounter:     12,
+		LastMessageHash: strings.Repeat("a", 64),
+		State:           conductor.KillSwitchActive,
+		Reason:          "persisted emergency stop",
+		AppliedAt:       testNow.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("writeRemoteKillState: %v", err)
+	}
+	ks := &captureKillSwitch{}
+	applier := &RemoteKillApplier{
+		KillSwitch: ks,
+		StatePath:  statePath,
+	}
+	if err := applier.RestorePersistedState(); err != nil {
+		t.Fatalf("RestorePersistedState() error = %v", err)
+	}
+	if !ks.active || ks.message != "persisted emergency stop" {
+		t.Fatalf("kill switch = active=%v message=%q, want restored active", ks.active, ks.message)
+	}
+}
+
 func TestRemoteKillApplierRejectsStaleCounter(t *testing.T) {
 	msg, resolver := signedRemoteKill(t, 9, conductor.KillSwitchActive)
 	statePath := filepath.Join(t.TempDir(), "state.json")
 	if err := writeRemoteKillState(statePath, remoteKillState{
 		LastCounter:     msg.Counter + 1,
 		LastMessageHash: "older-hash",
+		State:           conductor.KillSwitchActive,
+		Reason:          "older active kill",
 		AppliedAt:       testNow.Add(-time.Minute),
 	}); err != nil {
 		t.Fatalf("writeRemoteKillState: %v", err)

--- a/internal/conductor/emergency/remote_kill_test.go
+++ b/internal/conductor/emergency/remote_kill_test.go
@@ -270,6 +270,81 @@ func TestRemoteKillApplierRestoresPersistedState(t *testing.T) {
 	}
 }
 
+func TestRemoteKillApplierRestorePersistedStateValidation(t *testing.T) {
+	var nilApplier *RemoteKillApplier
+	if err := nilApplier.RestorePersistedState(); err == nil || !strings.Contains(err.Error(), "applier required") {
+		t.Fatalf("RestorePersistedState(nil) error = %v, want applier required", err)
+	}
+	if err := (&RemoteKillApplier{StatePath: filepath.Join(t.TempDir(), "state.json")}).RestorePersistedState(); err == nil ||
+		!strings.Contains(err.Error(), "kill switch required") {
+		t.Fatalf("RestorePersistedState(no kill switch) error = %v, want kill switch required", err)
+	}
+	if err := (&RemoteKillApplier{KillSwitch: &captureKillSwitch{}}).RestorePersistedState(); !errors.Is(err, ErrRemoteKillStateRequired) {
+		t.Fatalf("RestorePersistedState(no state path) error = %v, want ErrRemoteKillStateRequired", err)
+	}
+	if err := (&RemoteKillApplier{
+		KillSwitch:        &captureKillSwitch{},
+		StatePath:         filepath.Join(t.TempDir(), "missing.json"),
+		DisableRemoteKill: true,
+	}).RestorePersistedState(); err != nil {
+		t.Fatalf("RestorePersistedState(disabled) error = %v, want nil", err)
+	}
+	if err := (&RemoteKillApplier{
+		KillSwitch: &captureKillSwitch{},
+		StatePath:  filepath.Join(t.TempDir(), "missing.json"),
+	}).RestorePersistedState(); err != nil {
+		t.Fatalf("RestorePersistedState(empty missing state) error = %v, want nil", err)
+	}
+
+	blockedPath := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blockedPath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile(blocked path): %v", err)
+	}
+	if err := (&RemoteKillApplier{
+		KillSwitch: &captureKillSwitch{},
+		StatePath:  filepath.Join(blockedPath, "state.json"),
+	}).RestorePersistedState(); err == nil {
+		t.Fatal("RestorePersistedState(blocked path) error = nil, want read error")
+	}
+
+	for _, tc := range []struct {
+		name  string
+		state remoteKillState
+		want  string
+	}{
+		{
+			name: "invalid_state",
+			state: remoteKillState{
+				LastCounter:     1,
+				LastMessageHash: strings.Repeat("a", 64),
+				State:           conductor.KillSwitchState("paused"),
+			},
+			want: "invalid conductor remote kill persisted state",
+		},
+		{
+			name: "reason_too_long",
+			state: remoteKillState{
+				LastCounter:     1,
+				LastMessageHash: strings.Repeat("a", 64),
+				State:           conductor.KillSwitchActive,
+				Reason:          strings.Repeat("x", conductor.MaxReasonBytes+1),
+			},
+			want: "invalid conductor remote kill persisted reason",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			statePath := filepath.Join(t.TempDir(), "state.json")
+			if err := writeRemoteKillState(statePath, tc.state); err != nil {
+				t.Fatalf("writeRemoteKillState: %v", err)
+			}
+			err := (&RemoteKillApplier{KillSwitch: &captureKillSwitch{}, StatePath: statePath}).RestorePersistedState()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("RestorePersistedState() error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestRemoteKillApplierRejectsStaleCounter(t *testing.T) {
 	msg, resolver := signedRemoteKill(t, 9, conductor.KillSwitchActive)
 	statePath := filepath.Join(t.TempDir(), "state.json")

--- a/internal/config/conductor.go
+++ b/internal/config/conductor.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 const (
@@ -71,6 +73,14 @@ func (c *Config) validateConductor(warnings *[]Warning) error {
 	}
 	if strings.TrimSpace(c.FlightRecorder.SigningKeyPath) == "" {
 		return fmt.Errorf("flight_recorder.signing_key_path required when conductor.enabled is true")
+	}
+	if cfg.HonorRemoteKillSwitch {
+		if strings.TrimSpace(cfg.TrustRosterRootFingerprint) == "" {
+			return fmt.Errorf("conductor.trust_roster_root_fingerprint required when conductor.enabled and honor_remote_kill_switch are true")
+		}
+		if _, _, err := signing.ParseFingerprint(cfg.TrustRosterRootFingerprint); err != nil {
+			return fmt.Errorf("conductor.trust_roster_root_fingerprint: %w", err)
+		}
 	}
 	for field, value := range map[string]string{
 		"conductor.trust_roster_path":       cfg.TrustRosterPath,

--- a/internal/config/conductor_test.go
+++ b/internal/config/conductor_test.go
@@ -140,6 +140,16 @@ func TestValidateConductor_RejectsInvalidEnabledConfig(t *testing.T) {
 			want:   "conductor.server_ca_file required",
 		},
 		{
+			name:   "missing_trust_roster_root_fingerprint",
+			mutate: func(c *Conductor) { c.TrustRosterRootFingerprint = "" },
+			want:   "conductor.trust_roster_root_fingerprint required",
+		},
+		{
+			name:   "bad_trust_roster_root_fingerprint",
+			mutate: func(c *Conductor) { c.TrustRosterRootFingerprint = "bad" },
+			want:   "conductor.trust_roster_root_fingerprint",
+		},
+		{
 			name:   "relative_server_ca",
 			mutate: func(c *Conductor) { c.ServerCAFile = "boss-ca.pem" },
 			want:   "conductor.server_ca_file must be an absolute path",
@@ -344,29 +354,60 @@ func TestLoad_ConductorEmergencyStreamDefaulting(t *testing.T) {
 	}
 }
 
+func TestLoad_ConductorHonorRemoteKillSwitchDefaulting(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{name: "conductor_section_omitted", yaml: "mode: balanced\n", want: true},
+		{name: "conductor_section_null", yaml: "mode: balanced\nconductor: null\n", want: true},
+		{name: "field_omitted", yaml: "mode: balanced\nconductor: {}\n", want: true},
+		{name: "null", yaml: "mode: balanced\nconductor:\n  honor_remote_kill_switch: null\n", want: true},
+		{name: "explicit_true", yaml: "mode: balanced\nconductor:\n  honor_remote_kill_switch: true\n", want: true},
+		{name: "explicit_false", yaml: "mode: balanced\nconductor:\n  honor_remote_kill_switch: false\n", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(tc.yaml), 0o600); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if got := cfg.Conductor.HonorRemoteKillSwitch; got != tc.want {
+				t.Fatalf("HonorRemoteKillSwitch = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func validConductorConfig(t *testing.T) Conductor {
 	t.Helper()
 	root := privateTempDir(t)
 	return Conductor{
-		Enabled:                true,
-		ConductorURL:           "https://conductor.example",
-		OrgID:                  "org_main",
-		FleetID:                "prod",
-		InstanceID:             "pl-prod-1",
-		TrustRosterPath:        filepath.Join(root, "trust-roster.json"),
-		ServerCAFile:           filepath.Join(root, "boss-ca.pem"),
-		ClientCertPath:         filepath.Join(root, "client.crt"),
-		ClientKeyPath:          filepath.Join(root, "client.key"),
-		BundleCacheDir:         filepath.Join(root, "bundles"),
-		DurableAuditQueueDir:   filepath.Join(root, "audit-queue"),
-		PollInterval:           "30s",
-		HonorRemoteKillSwitch:  false,
-		EmergencyStream:        ptrBool(true),
-		CreatedSkewSeconds:     60,
-		MaxMinVersionMajorSkew: 0,
-		MaxMinVersionMinorSkew: 1,
-		MaxCapabilityThreshold: 7,
-		StalePolicy:            ConductorStalePolicy{GraceMultiplier: 1, AfterGrace: ConductorStaleStrictDenyAll},
+		Enabled:                    true,
+		ConductorURL:               "https://conductor.example",
+		OrgID:                      "org_main",
+		FleetID:                    "prod",
+		InstanceID:                 "pl-prod-1",
+		TrustRosterPath:            filepath.Join(root, "trust-roster.json"),
+		TrustRosterRootFingerprint: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ServerCAFile:               filepath.Join(root, "boss-ca.pem"),
+		ClientCertPath:             filepath.Join(root, "client.crt"),
+		ClientKeyPath:              filepath.Join(root, "client.key"),
+		BundleCacheDir:             filepath.Join(root, "bundles"),
+		DurableAuditQueueDir:       filepath.Join(root, "audit-queue"),
+		PollInterval:               "30s",
+		HonorRemoteKillSwitch:      true,
+		EmergencyStream:            ptrBool(true),
+		CreatedSkewSeconds:         60,
+		MaxMinVersionMajorSkew:     0,
+		MaxMinVersionMinorSkew:     1,
+		MaxCapabilityThreshold:     7,
+		StalePolicy:                ConductorStalePolicy{GraceMultiplier: 1, AfterGrace: ConductorStaleStrictDenyAll},
 	}
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -527,7 +527,8 @@ func Defaults() *Config {
 			MinimumSignatures: 1,
 		},
 		Conductor: Conductor{
-			EmergencyStream: ptrBool(true),
+			HonorRemoteKillSwitch: true,
+			EmergencyStream:       ptrBool(true),
 		},
 	}
 	// Mark all compiled defaults with provenance so the standard tier source

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -88,6 +88,7 @@ func applySecurityDefaults(rawYAML []byte, cfg *Config) {
 		cfg.Taint.Enabled = true
 		cfg.Learn.Privacy.PublicAllowlistDefault = true
 		cfg.HealthWatchdog.Enabled = true
+		cfg.Conductor.HonorRemoteKillSwitch = true
 		return
 	}
 
@@ -185,6 +186,9 @@ func applySecurityDefaults(rawYAML []byte, cfg *Config) {
 	// gets the watchdog; explicit `enabled: false` is required to opt out.
 	hw, _ := raw["health_watchdog"].(map[string]interface{})
 	setBoolDefault(hw, "enabled", &cfg.HealthWatchdog.Enabled)
+
+	conductor, _ := raw["conductor"].(map[string]interface{})
+	setBoolDefault(conductor, "honor_remote_kill_switch", &cfg.Conductor.HonorRemoteKillSwitch)
 }
 
 // ApplyDefaults fills in zero-value fields with sensible defaults.

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -338,27 +338,28 @@ const (
 // fleet. It is local control-plane plumbing, not scanner policy, and is
 // excluded from CanonicalPolicyHash.
 type Conductor struct {
-	Enabled                bool                 `yaml:"enabled"`
-	ConductorURL           string               `yaml:"conductor_url"`
-	OrgID                  string               `yaml:"org_id"`
-	FleetID                string               `yaml:"fleet_id"`
-	InstanceID             string               `yaml:"instance_id"`
-	TrustRosterPath        string               `yaml:"trust_roster_path"`
-	ServerCAFile           string               `yaml:"server_ca_file"`
-	ClientCertPath         string               `yaml:"client_cert_path"`
-	ClientKeyPath          string               `yaml:"client_key_path"`
-	BundleCacheDir         string               `yaml:"bundle_cache_dir"`
-	DurableAuditQueueDir   string               `yaml:"durable_audit_queue_dir"`
-	AuditSigningKeyID      string               `yaml:"audit_signing_key_id"`
-	RecorderKeyID          string               `yaml:"recorder_key_id"`
-	PollInterval           string               `yaml:"poll_interval"`
-	HonorRemoteKillSwitch  bool                 `yaml:"honor_remote_kill_switch"`
-	EmergencyStream        *bool                `yaml:"emergency_stream"`
-	CreatedSkewSeconds     int                  `yaml:"created_skew_seconds"`
-	MaxMinVersionMajorSkew int                  `yaml:"max_min_version_major_skew"`
-	MaxMinVersionMinorSkew int                  `yaml:"max_min_version_minor_skew"`
-	MaxCapabilityThreshold int                  `yaml:"max_capability_threshold"`
-	StalePolicy            ConductorStalePolicy `yaml:"stale_policy"`
+	Enabled                    bool                 `yaml:"enabled"`
+	ConductorURL               string               `yaml:"conductor_url"`
+	OrgID                      string               `yaml:"org_id"`
+	FleetID                    string               `yaml:"fleet_id"`
+	InstanceID                 string               `yaml:"instance_id"`
+	TrustRosterPath            string               `yaml:"trust_roster_path"`
+	TrustRosterRootFingerprint string               `yaml:"trust_roster_root_fingerprint"`
+	ServerCAFile               string               `yaml:"server_ca_file"`
+	ClientCertPath             string               `yaml:"client_cert_path"`
+	ClientKeyPath              string               `yaml:"client_key_path"`
+	BundleCacheDir             string               `yaml:"bundle_cache_dir"`
+	DurableAuditQueueDir       string               `yaml:"durable_audit_queue_dir"`
+	AuditSigningKeyID          string               `yaml:"audit_signing_key_id"`
+	RecorderKeyID              string               `yaml:"recorder_key_id"`
+	PollInterval               string               `yaml:"poll_interval"`
+	HonorRemoteKillSwitch      bool                 `yaml:"honor_remote_kill_switch"`
+	EmergencyStream            *bool                `yaml:"emergency_stream"`
+	CreatedSkewSeconds         int                  `yaml:"created_skew_seconds"`
+	MaxMinVersionMajorSkew     int                  `yaml:"max_min_version_major_skew"`
+	MaxMinVersionMinorSkew     int                  `yaml:"max_min_version_minor_skew"`
+	MaxCapabilityThreshold     int                  `yaml:"max_capability_threshold"`
+	StalePolicy                ConductorStalePolicy `yaml:"stale_policy"`
 }
 
 // ConductorStalePolicy controls local behavior after the active bundle expires.


### PR DESCRIPTION
## Summary
- Add follower-side remote-kill polling over the existing Conductor mTLS client, with strict bounded JSON decoding and `RemoteKillApplier` application
- Wire `pipelock run` to start the poller, resolve emergency signing keys from the pinned trust roster, restore persisted remote-kill state before serving, and persist replay/decision state under the Conductor cache directory
- Default `conductor.honor_remote_kill_switch` to true on YAML load, require `trust_roster_root_fingerprint` when honoring remote kills, and document the production polling behavior

## Upgrade note
Conductor-enabled followers that only use audit batching must either configure `trust_roster_root_fingerprint` with a roster containing `remote-kill-signing` keys, or explicitly set `honor_remote_kill_switch: false`. The secure default is to honor remote kills.

## Tests
- `go test -race -count=1 ./...`
- `golangci-lint run ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote kill switch is honored by default; followers persist and replay applied remote‑kill decisions across restarts and reboots.

* **Configuration Changes**
  * Added conductor.trust_roster_root_fingerprint (required when honoring remote kill).
  * honor_remote_kill_switch now defaults to true.

* **Updated Behavior**
  * Followers poll configured emergency/control endpoints (MVP polling with optional lower‑latency follow‑up).
  * Rejected/expired/superseded/disabled remote‑kill messages emit structured local logs; replay state is stored locally.

* **Migration Required**
  * Provide fingerprint + trust roster with signing keys or set honor_remote_kill_switch: false.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->