### PR TITLE
feat: add request_policy operation-rails engine and config

### DIFF
--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -119,7 +119,11 @@ const (
 	// preserves current behavior; "block" causes the consumer to cancel
 	// the proxy ctx on agent-attributed findings, which is observably
 	// different enforcement.
-	goldenHashDefaults = "e167ea2ed69766c470bb7964e4163d6ad083d1d63719adc7e44752bced596041"
+	// Re-bumped for the request_policy section: adding the request_policy
+	// operation-rails config (allow-by-default deny/warn rules over outbound
+	// API operations) is a policy-semantics change. The field is present but
+	// empty (disabled, no rules) in Defaults(), so it shifts the baseline hash.
+	goldenHashDefaults = "c591ad369bde2755f41825b90f2486503c0d314d76295402f7771b173ea80d60"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -181,7 +185,10 @@ const (
 	// note. The rich fixture omits dns:, so the field is empty but still
 	// part of the canonical view.
 	// Re-bumped for file_sentry.action: same rationale as goldenHashDefaults.
-	goldenHashRichConfig = "e67707c35590ea0f4a6504bbadb13c3c2aa709778181e4edc6892c1c6dca0e3f"
+	// Re-bumped for the request_policy section: same rationale as
+	// goldenHashDefaults. The rich fixture omits request_policy, so the field
+	// is empty but still part of the canonical view; the hash shifts in lockstep.
+	goldenHashRichConfig = "36f684e7200b427c16c38e2dfeef3d7404760207b58bdfb9c2f191b1f4769a53"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/requestpolicy_validate_test.go
+++ b/internal/config/requestpolicy_validate_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func enabledPolicy(rules ...RequestPolicyRule) *Config {
+	c := Defaults()
+	c.RequestPolicy = RequestPolicy{Enabled: true, Rules: rules}
+	return c
+}
+
+func TestValidateRequestPolicy_ValidAndNormalizes(t *testing.T) {
+	c := enabledPolicy(RequestPolicyRule{
+		Name:   "api-writes",
+		Action: ActionBlock,
+		Route: RequestPolicyRoute{
+			Methods:      []string{"post"},
+			PathPrefixes: []string{"/api/write"},
+			ContentTypes: []string{"Application/JSON; Charset=UTF-8"},
+		},
+		Reason: "destructive operation",
+	})
+	if _, err := c.ValidateWithWarnings(); err != nil {
+		t.Fatalf("valid request_policy rejected: %v", err)
+	}
+	got := c.RequestPolicy.Rules[0].Route
+	if got.Methods[0] != "POST" {
+		t.Errorf("method not uppercased: %q", got.Methods[0])
+	}
+	if got.ContentTypes[0] != "application/json" {
+		t.Errorf("content type not lowercased: %q", got.ContentTypes[0])
+	}
+}
+
+func TestValidateRequestPolicy_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want string
+	}{
+		{
+			name: "enabled with no rules",
+			cfg:  enabledPolicy(),
+			want: "no rules",
+		},
+		{
+			name: "missing name",
+			cfg:  enabledPolicy(RequestPolicyRule{Action: ActionBlock, Route: RequestPolicyRoute{Hosts: []string{"api.service.example.com"}}}),
+			want: "missing name",
+		},
+		{
+			name: "bad name charset",
+			cfg:  enabledPolicy(RequestPolicyRule{Name: "bad name!", Action: ActionBlock, Route: RequestPolicyRoute{Methods: []string{"POST"}}}),
+			want: "metric label",
+		},
+		{
+			name: "invalid action",
+			cfg:  enabledPolicy(RequestPolicyRule{Name: "r", Action: "redirect", Route: RequestPolicyRoute{Methods: []string{"POST"}}}),
+			want: "must be block or warn",
+		},
+		{
+			name: "no route constraint",
+			cfg:  enabledPolicy(RequestPolicyRule{Name: "r", Action: ActionBlock}),
+			want: "no route constraints",
+		},
+		{
+			name: "invalid method",
+			cfg:  enabledPolicy(RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{Methods: []string{"FOO"}}}),
+			want: "not a valid HTTP method",
+		},
+		{
+			name: "invalid path pattern",
+			cfg:  enabledPolicy(RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{PathPatterns: []string{"("}}}),
+			want: "invalid path_pattern",
+		},
+		{
+			name: "empty path prefix",
+			cfg:  enabledPolicy(RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{PathPrefixes: []string{"  "}}}),
+			want: "empty path_prefix",
+		},
+		{
+			name: "empty path pattern",
+			cfg:  enabledPolicy(RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{PathPatterns: []string{"  "}}}),
+			want: "empty path_pattern",
+		},
+		{
+			name: "empty content type",
+			cfg:  enabledPolicy(RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{ContentTypes: []string{" ; charset=utf-8"}}}),
+			want: "empty content_type",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.cfg.ValidateWithWarnings()
+			if err == nil {
+				t.Fatalf("want error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// Disabled sections are still structurally validated so dormant bad config
+// cannot activate silently on reload.
+func TestValidateRequestPolicy_DormantValidation(t *testing.T) {
+	c := Defaults()
+	c.RequestPolicy = RequestPolicy{
+		Enabled: false,
+		Rules:   []RequestPolicyRule{{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{PathPatterns: []string{"("}}}},
+	}
+	if _, err := c.ValidateWithWarnings(); err == nil {
+		t.Fatal("disabled section with invalid regex should still error")
+	}
+}
+
+func TestValidateRequestPolicy_DisabledEmitsNoVisibilityWarning(t *testing.T) {
+	c := Defaults() // tls_interception disabled by default
+	c.RequestPolicy = RequestPolicy{
+		Enabled: false,
+		Rules:   []RequestPolicyRule{{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{Hosts: []string{"api.service.example.com"}, Methods: []string{"POST"}}}},
+	}
+	warnings, err := c.ValidateWithWarnings()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, w := range warnings {
+		if strings.Contains(w.Field, "request_policy") {
+			t.Fatalf("disabled section must not emit visibility warning, got %+v", w)
+		}
+	}
+}
+
+func TestWarnRequestPolicyVisibility(t *testing.T) {
+	rule := &RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{Hosts: []string{"api.service.example.com"}, Methods: []string{"POST"}}}
+
+	t.Run("tls interception off", func(t *testing.T) {
+		c := &Config{}
+		var warnings []Warning
+		c.warnRequestPolicyVisibility(rule, &warnings)
+		if len(warnings) != 1 || !strings.Contains(warnings[0].Message, "tls_interception is disabled") {
+			t.Fatalf("want tls-disabled warning, got %+v", warnings)
+		}
+	})
+
+	t.Run("hostless inner-http rule warns when tls interception off", func(t *testing.T) {
+		c := &Config{}
+		hostless := &RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{Methods: []string{"POST"}}}
+		var warnings []Warning
+		c.warnRequestPolicyVisibility(hostless, &warnings)
+		if len(warnings) != 1 || !strings.Contains(warnings[0].Message, "no host constraint") {
+			t.Fatalf("want hostless tls-disabled warning, got %+v", warnings)
+		}
+	})
+
+	t.Run("passthrough host", func(t *testing.T) {
+		c := &Config{}
+		c.TLSInterception.Enabled = true
+		c.TLSInterception.PassthroughDomains = []string{"api.service.example.com"}
+		var warnings []Warning
+		c.warnRequestPolicyVisibility(rule, &warnings)
+		if len(warnings) != 1 || !strings.Contains(warnings[0].Message, "passthrough_domains") {
+			t.Fatalf("want passthrough warning, got %+v", warnings)
+		}
+	})
+
+	t.Run("wildcard passthrough host", func(t *testing.T) {
+		c := &Config{}
+		c.TLSInterception.Enabled = true
+		c.TLSInterception.PassthroughDomains = []string{"*.service.example.com"}
+		var warnings []Warning
+		c.warnRequestPolicyVisibility(rule, &warnings)
+		if len(warnings) != 1 || !strings.Contains(warnings[0].Message, "passthrough_domains") {
+			t.Fatalf("want passthrough warning for wildcard match, got %+v", warnings)
+		}
+	})
+
+	t.Run("visible host emits nothing", func(t *testing.T) {
+		c := &Config{}
+		c.TLSInterception.Enabled = true
+		c.TLSInterception.PassthroughDomains = []string{"other.example.com"}
+		var warnings []Warning
+		c.warnRequestPolicyVisibility(rule, &warnings)
+		if len(warnings) != 0 {
+			t.Fatalf("visible host should emit no warning, got %+v", warnings)
+		}
+	})
+
+	t.Run("host-only rule emits nothing", func(t *testing.T) {
+		c := &Config{}
+		hostOnly := &RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{Hosts: []string{"api.service.example.com"}}}
+		var warnings []Warning
+		c.warnRequestPolicyVisibility(hostOnly, &warnings)
+		if len(warnings) != 0 {
+			t.Fatalf("host-only rule is visible at CONNECT boundary and should not warn, got %+v", warnings)
+		}
+	})
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -229,6 +229,41 @@ type SandboxFilesystem struct {
 	AllowWrite []string `yaml:"allow_write"`
 }
 
+// RequestPolicy configures explicit outbound API operation safety rails. It is
+// an allow-by-default deny-list: a request forwards unless a rule matches.
+// Gated by its own Enabled flag, independent of request_body_scanning — it
+// composes with the learn-lock contract gate (a ratified allowlist) and with
+// DLP, and is neither. See the request-policy operation-rails design.
+type RequestPolicy struct {
+	Enabled bool                `yaml:"enabled"`
+	Rules   []RequestPolicyRule `yaml:"rules"`
+}
+
+// RequestPolicyRule is one operation safety rail. v1 matches on route only
+// (host / method / path / content type); GraphQL and JSON operation predicates
+// are reserved for later phases. Action is per-rule (block or warn) — there is
+// deliberately no section-level default_action knob, so the section can never
+// be configured into default-deny.
+type RequestPolicyRule struct {
+	Name   string             `yaml:"name"`   // bounded, metric-label-safe identifier
+	Action string             `yaml:"action"` // block | warn
+	Shadow bool               `yaml:"shadow"` // log the would-be action, forward anyway
+	Route  RequestPolicyRoute `yaml:"route"`
+	Reason string             `yaml:"reason"` // operator-facing explanation (never logged with content)
+}
+
+// RequestPolicyRoute selects which requests a rule applies to. An empty
+// constraint matches any value for that dimension; a request matches the route
+// only when every non-empty constraint is satisfied. Within a single dimension
+// (e.g. multiple hosts, or path_prefixes plus path_patterns) matching is OR.
+type RequestPolicyRoute struct {
+	Hosts        []string `yaml:"hosts"`         // exact host or *.suffix wildcard
+	Methods      []string `yaml:"methods"`       // HTTP verbs; normalized to uppercase
+	PathPrefixes []string `yaml:"path_prefixes"` // literal prefixes of the normalized path
+	PathPatterns []string `yaml:"path_patterns"` // RE2 patterns against the normalized path
+	ContentTypes []string `yaml:"content_types"` // media types (parameters stripped)
+}
+
 // Config is the top-level Pipelock configuration.
 type Config struct {
 	Version                  int                     `yaml:"version"`
@@ -252,6 +287,7 @@ type Config struct {
 	AdaptiveEnforcement      AdaptiveEnforcement     `yaml:"adaptive_enforcement"`
 	MCPSessionBinding        MCPSessionBinding       `yaml:"mcp_session_binding"`
 	RequestBodyScanning      RequestBodyScanning     `yaml:"request_body_scanning"`
+	RequestPolicy            RequestPolicy           `yaml:"request_policy"`
 	KillSwitch               KillSwitch              `yaml:"kill_switch"`
 	HealthWatchdog           HealthWatchdog          `yaml:"health_watchdog" json:"-"` // operational liveness, excluded from canonical policy hash
 	Sentry                   SentryConfig            `yaml:"sentry"`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -127,6 +127,9 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 	if err := c.validateRequestBodyScanning(); err != nil {
 		return warnings, err
 	}
+	if err := c.validateRequestPolicy(&warnings); err != nil {
+		return warnings, err
+	}
 	if err := c.validateSeedPhraseDetection(); err != nil {
 		return warnings, err
 	}
@@ -780,6 +783,153 @@ func (c *Config) validateMCPToolPolicy() error {
 		}
 	}
 	return nil
+}
+
+// validReqPolicyName bounds request_policy rule names to a metric-label-safe
+// charset and length so they can be used as Prometheus label values without
+// unbounded-cardinality risk.
+var validReqPolicyName = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+
+// validateRequestPolicy validates the request_policy section. Rules are
+// validated even when the section is disabled (regexes compiled, enums
+// checked) so dormant bad config cannot activate silently on reload. Hosts and
+// methods are normalized in place. Visibility advisories are emitted only when
+// the section is enabled, because they describe what enforcement an operator
+// will and will not actually get.
+func (c *Config) validateRequestPolicy(warnings *[]Warning) error {
+	rp := &c.RequestPolicy
+	if rp.Enabled && len(rp.Rules) == 0 {
+		return fmt.Errorf("request_policy is enabled but has no rules; add rules or set enabled: false")
+	}
+	for i := range rp.Rules {
+		r := &rp.Rules[i]
+		if r.Name == "" {
+			return fmt.Errorf("request_policy rule %d missing name", i)
+		}
+		if !validReqPolicyName.MatchString(r.Name) {
+			return fmt.Errorf("request_policy rule %q: name must be 1-64 chars of [A-Za-z0-9_-] (it is used as a metric label)", r.Name)
+		}
+		switch r.Action {
+		case ActionBlock, ActionWarn:
+			// valid
+		default:
+			return fmt.Errorf("request_policy rule %q has invalid action %q: must be block or warn", r.Name, r.Action)
+		}
+		route := &r.Route
+		if len(route.Hosts) == 0 && len(route.Methods) == 0 &&
+			len(route.PathPrefixes) == 0 && len(route.PathPatterns) == 0 &&
+			len(route.ContentTypes) == 0 {
+			return fmt.Errorf("request_policy rule %q has no route constraints; set at least one of hosts/methods/path_prefixes/path_patterns/content_types", r.Name)
+		}
+		if err := ValidateTrustedDomains(route.Hosts, fmt.Sprintf("request_policy rule %q hosts", r.Name)); err != nil {
+			return err
+		}
+		for j, m := range route.Methods {
+			up := strings.ToUpper(strings.TrimSpace(m))
+			if !validHTTPMethod(up) {
+				return fmt.Errorf("request_policy rule %q method %q is not a valid HTTP method", r.Name, m)
+			}
+			route.Methods[j] = up
+		}
+		for _, p := range route.PathPatterns {
+			if strings.TrimSpace(p) == "" {
+				return fmt.Errorf("request_policy rule %q has empty path_pattern", r.Name)
+			}
+			if _, err := regexp.Compile(p); err != nil {
+				return fmt.Errorf("request_policy rule %q has invalid path_pattern %q: %w", r.Name, p, err)
+			}
+		}
+		for _, p := range route.PathPrefixes {
+			if strings.TrimSpace(p) == "" {
+				return fmt.Errorf("request_policy rule %q has empty path_prefix", r.Name)
+			}
+		}
+		for j, ct := range route.ContentTypes {
+			normalized := normalizeRequestPolicyContentType(ct)
+			if normalized == "" {
+				return fmt.Errorf("request_policy rule %q has empty content_type", r.Name)
+			}
+			route.ContentTypes[j] = normalized
+		}
+		if rp.Enabled {
+			c.warnRequestPolicyVisibility(r, warnings)
+		}
+	}
+	return nil
+}
+
+func validHTTPMethod(m string) bool {
+	switch m {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodConnect,
+		http.MethodOptions, http.MethodTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeRequestPolicyContentType(ct string) string {
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	return strings.ToLower(strings.TrimSpace(ct))
+}
+
+// warnRequestPolicyVisibility advises when a rule targets a host whose inner
+// HTTP method/path/body pipelock cannot see - TLS interception off, or the host
+// in passthrough_domains. Host-only tunnel rules are still enforceable at the
+// CONNECT boundary, so warnings are emitted only when a rule needs inner HTTP
+// metadata.
+func (c *Config) warnRequestPolicyVisibility(r *RequestPolicyRule, warnings *[]Warning) {
+	if !requestPolicyRouteNeedsInnerHTTP(r.Route) {
+		return
+	}
+	if len(r.Route.Hosts) == 0 {
+		if !c.TLSInterception.Enabled {
+			*warnings = append(*warnings, Warning{
+				Field:   fmt.Sprintf("request_policy rule %q", r.Name),
+				Message: "has method/path/content-type constraints but no host constraint and tls_interception is disabled; pipelock cannot see inner HTTPS method/path/body on CONNECT - only the tunnel host/port are visible",
+			})
+		}
+		return
+	}
+	for _, h := range r.Route.Hosts {
+		if !c.TLSInterception.Enabled {
+			*warnings = append(*warnings, Warning{
+				Field:   fmt.Sprintf("request_policy rule %q", r.Name),
+				Message: fmt.Sprintf("targets host %q but tls_interception is disabled; pipelock cannot see inner HTTPS method/path/body on CONNECT - only the tunnel host/port are visible", h),
+			})
+			continue
+		}
+		if hostMatchesPassthrough(h, c.TLSInterception.PassthroughDomains) {
+			*warnings = append(*warnings, Warning{
+				Field:   fmt.Sprintf("request_policy rule %q", r.Name),
+				Message: fmt.Sprintf("targets host %q which is in tls_interception.passthrough_domains; pipelock cannot see inner method/path/body for passthrough hosts - only host/port", h),
+			})
+		}
+	}
+}
+
+func requestPolicyRouteNeedsInnerHTTP(route RequestPolicyRoute) bool {
+	return len(route.Methods) > 0 ||
+		len(route.PathPrefixes) > 0 ||
+		len(route.PathPatterns) > 0 ||
+		len(route.ContentTypes) > 0
+}
+
+func hostMatchesPassthrough(host string, patterns []string) bool {
+	host = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	for _, p := range patterns {
+		p = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(p), "."))
+		if p == host {
+			return true
+		}
+		if strings.HasPrefix(p, "*.") && (host == p[2:] || strings.HasSuffix(host, p[1:])) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Config) validateGitProtection() error {

--- a/internal/reqpolicy/metrics.go
+++ b/internal/reqpolicy/metrics.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package reqpolicy
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Metrics holds the request_policy Prometheus counters. Label cardinality is
+// deliberately bounded to rule name + action: rule names are validated to a
+// short fixed charset at config load, while request host, operation name, and
+// matched field values are attacker-influenced and must never become labels.
+type Metrics struct {
+	Decisions   *prometheus.CounterVec
+	ParseErrors *prometheus.CounterVec
+}
+
+// NewMetrics registers the request_policy counters on reg.
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	m := &Metrics{
+		Decisions: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "pipelock_request_policy_decisions_total",
+			Help: "request_policy matches by rule and action (action: block, warn, shadow_block, shadow_warn).",
+		}, []string{"rule", "action"}),
+		ParseErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "pipelock_request_policy_parse_errors_total",
+			Help: "request_policy operation parse/opaque failures by configured fail-closed reason.",
+		}, []string{"reason"}),
+	}
+	reg.MustRegister(m.Decisions, m.ParseErrors)
+	return m
+}
+
+// Record increments the decision counter for an enforced or shadow match.
+// Shadow matches are labeled "shadow_<action>" so operators can distinguish
+// would-have-blocked traffic from enforced blocks. A nil Metrics is a no-op.
+func (m *Metrics) Record(d Decision) {
+	if m == nil || !d.Matched() {
+		return
+	}
+	action := d.Action
+	if d.Shadow {
+		action = "shadow_" + action
+	}
+	m.Decisions.WithLabelValues(d.RuleName, action).Inc()
+}

--- a/internal/reqpolicy/metrics_test.go
+++ b/internal/reqpolicy/metrics_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package reqpolicy
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestMetricsRecord(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewMetrics(reg)
+
+	m.Record(Decision{Action: config.ActionBlock, RuleName: "api-write"})
+	m.Record(Decision{Action: config.ActionWarn, RuleName: "api-shadow", Shadow: true})
+	m.Record(Decision{}) // no match: no-op
+
+	if got := testutil.ToFloat64(m.Decisions.WithLabelValues("api-write", "block")); got != 1 {
+		t.Errorf("block count = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.Decisions.WithLabelValues("api-shadow", "shadow_warn")); got != 1 {
+		t.Errorf("shadow_warn count = %v, want 1", got)
+	}
+}
+
+func TestMetricsRecord_NilSafe(t *testing.T) {
+	var m *Metrics
+	// Must not panic on a nil receiver or an unmatched decision.
+	m.Record(Decision{Action: config.ActionBlock, RuleName: "x"})
+	live := NewMetrics(prometheus.NewRegistry())
+	live.Record(Decision{})
+}

--- a/internal/reqpolicy/policy.go
+++ b/internal/reqpolicy/policy.go
@@ -1,0 +1,343 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package reqpolicy implements Pipelock's request_policy layer: explicit,
+// allow-by-default deny/warn safety rails on outbound HTTP API operations.
+//
+// It is independent of request_body_scanning and complementary to the
+// learn-lock contract gate — it is neither a DLP scanner nor a behavioral
+// allowlist. v1 matches on route only (host / effective method / normalized
+// path / content type); GraphQL and JSON operation predicates are added in
+// later phases. The Matcher precompiles rule regexes once at config (re)load;
+// Evaluate is allocation-light and safe on the hot request path.
+package reqpolicy
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// methodOverrideHeaders are the headers some frameworks honor to tunnel a
+// different effective HTTP method through a POST. They must be resolved before
+// route matching, or "POST + X-HTTP-Method-Override: DELETE" trivially bypasses
+// a method-scoped rule.
+var methodOverrideHeaders = []string{"X-HTTP-Method-Override", "X-Method-Override", "X-HTTP-Method"}
+
+// maxUnescapeRounds bounds repeated percent-decoding during path normalization.
+// Bounded so a crafted deeply-encoded path cannot spin the normalizer, while
+// still collapsing multi-layer encodings (e.g. %252e%252e) that a downstream
+// server would decode more than once and act on as a dot segment.
+const maxUnescapeRounds = 5
+
+// RequestMeta is the transport-neutral view of an outbound request that
+// Evaluate needs. Transports build it once — after computing the effective
+// method and normalizing the path — and pass it in.
+type RequestMeta struct {
+	Host        string // lowercased hostname, no port
+	Method      string // effective HTTP method, uppercased
+	Path        string // normalized request path
+	ContentType string // media type only, lowercased, parameters stripped
+}
+
+// Decision is the outcome of evaluating request policy against a request.
+// A zero Decision (empty Action) means allow.
+type Decision struct {
+	Action   string // "" (allow), config.ActionWarn, or config.ActionBlock
+	RuleName string // matched rule name; safe as a bounded metric/audit label
+	Reason   string // operator-facing reason from the matched rule
+	Shadow   bool   // matched rule is shadow: log the would-be action, do not enforce
+}
+
+// Matched reports whether the decision selected a rule (enforced or shadow).
+func (d Decision) Matched() bool { return d.Action != "" }
+
+// Enforced reports whether the decision should block/warn the live request.
+// Shadow matches return false: they are logged but never enforced.
+func (d Decision) Enforced() bool { return d.Action != "" && !d.Shadow }
+
+type compiledRule struct {
+	name         string
+	action       string
+	reason       string
+	shadow       bool
+	hosts        []string
+	methods      map[string]struct{}
+	pathPrefixes []string
+	pathPatterns []*regexp.Regexp
+	contentTypes map[string]struct{}
+}
+
+// Matcher holds the precompiled request_policy ruleset. Build one with
+// NewMatcher at config (re)load and swap it atomically alongside the rest of
+// the runtime config.
+type Matcher struct {
+	enabled bool
+	rules   []compiledRule
+}
+
+// NewMatcher compiles cfg into a Matcher. It returns an error if any
+// path_pattern fails to compile; callers run config validation first (which
+// compiles the same patterns), so this is defense in depth. A nil cfg or a
+// disabled section yields a Matcher that allows everything.
+func NewMatcher(cfg *config.RequestPolicy) (*Matcher, error) {
+	m := &Matcher{}
+	if cfg == nil || !cfg.Enabled {
+		return m, nil
+	}
+	m.enabled = true
+	for i := range cfg.Rules {
+		r := &cfg.Rules[i]
+		cr := compiledRule{
+			name:   r.Name,
+			action: r.Action,
+			reason: r.Reason,
+			shadow: r.Shadow,
+		}
+		if len(r.Route.Hosts) > 0 {
+			cr.hosts = make([]string, len(r.Route.Hosts))
+			for j, h := range r.Route.Hosts {
+				cr.hosts[j] = NormalizeHost(h)
+			}
+		}
+		if len(r.Route.Methods) > 0 {
+			cr.methods = make(map[string]struct{}, len(r.Route.Methods))
+			for _, mth := range r.Route.Methods {
+				cr.methods[strings.ToUpper(strings.TrimSpace(mth))] = struct{}{}
+			}
+		}
+		for _, p := range r.Route.PathPatterns {
+			re, err := regexp.Compile(p)
+			if err != nil {
+				return nil, fmt.Errorf("request_policy rule %q: invalid path_pattern %q: %w", r.Name, p, err)
+			}
+			cr.pathPatterns = append(cr.pathPatterns, re)
+		}
+		if len(r.Route.PathPrefixes) > 0 {
+			cr.pathPrefixes = make([]string, len(r.Route.PathPrefixes))
+			for j, p := range r.Route.PathPrefixes {
+				cr.pathPrefixes[j] = NormalizePath(strings.TrimSpace(p))
+			}
+		}
+		if len(r.Route.ContentTypes) > 0 {
+			cr.contentTypes = make(map[string]struct{}, len(r.Route.ContentTypes))
+			for _, ct := range r.Route.ContentTypes {
+				cr.contentTypes[NormalizeContentType(ct)] = struct{}{}
+			}
+		}
+		m.rules = append(m.rules, cr)
+	}
+	return m, nil
+}
+
+// Evaluate runs meta against the ruleset and returns the strictest matching
+// Decision. Block beats warn; among equal-strictness matches an enforced rule
+// is preferred over a shadow rule so a real block is never masked by a shadow
+// entry. Returns a zero Decision (allow) when nothing matches.
+func (m *Matcher) Evaluate(meta RequestMeta) Decision {
+	if m == nil || !m.enabled {
+		return Decision{}
+	}
+	var best Decision
+	for i := range m.rules {
+		cr := &m.rules[i]
+		if !cr.matches(meta) {
+			continue
+		}
+		cand := Decision{Action: cr.action, RuleName: cr.name, Reason: cr.reason, Shadow: cr.shadow}
+		if betterDecision(cand, best) {
+			best = cand
+		}
+	}
+	return best
+}
+
+// betterDecision reports whether cand should replace cur as the selected
+// decision. Ordering: block > warn > none; within the same action, enforced
+// (non-shadow) beats shadow.
+func betterDecision(cand, cur Decision) bool {
+	if delta := actionRank(cand.Action) - actionRank(cur.Action); delta != 0 {
+		return delta > 0
+	}
+	if cand.Action == "" {
+		return false
+	}
+	return !cand.Shadow && cur.Shadow
+}
+
+func actionRank(a string) int {
+	switch a {
+	case config.ActionBlock:
+		return 2
+	case config.ActionWarn:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func (cr *compiledRule) matches(meta RequestMeta) bool {
+	if len(cr.hosts) > 0 && !hostMatches(NormalizeHost(meta.Host), cr.hosts) {
+		return false
+	}
+	if cr.methods != nil {
+		if _, ok := cr.methods[strings.ToUpper(strings.TrimSpace(meta.Method))]; !ok {
+			return false
+		}
+	}
+	if !cr.pathMatches(NormalizePath(meta.Path)) {
+		return false
+	}
+	if cr.contentTypes != nil {
+		if _, ok := cr.contentTypes[NormalizeContentType(meta.ContentType)]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (cr *compiledRule) pathMatches(p string) bool {
+	if len(cr.pathPrefixes) == 0 && len(cr.pathPatterns) == 0 {
+		return true
+	}
+	for _, pre := range cr.pathPrefixes {
+		if strings.HasPrefix(p, pre) {
+			return true
+		}
+	}
+	for _, re := range cr.pathPatterns {
+		if re.MatchString(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// hostMatches reports whether host matches any pattern. Patterns are exact
+// hosts or *.suffix wildcards (already lowercased/trim-dotted at compile time).
+func hostMatches(host string, patterns []string) bool {
+	host = NormalizeHost(host)
+	for _, p := range patterns {
+		if p == host {
+			return true
+		}
+		if strings.HasPrefix(p, "*.") {
+			// "*.example.com" matches the apex "example.com" and any subdomain.
+			if host == p[2:] || strings.HasSuffix(host, p[1:]) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// EffectiveMethod returns the method a downstream server would act on,
+// accounting for method-override headers. Only header-based overrides are
+// resolved here; form-field (_method) overrides require a parsed body and are
+// handled at the body hook. The result is uppercased.
+//
+// Caveat for the transport that builds RequestMeta: a valid override (e.g. GET)
+// can "downgrade" a real POST when the upstream ignores the override header. To
+// avoid evading a method-scoped deny rule that way, evaluate the ruleset
+// against both the base method and the override and block if either matches,
+// rather than trusting a single resolved method.
+func EffectiveMethod(method string, headers http.Header) string {
+	base := normalizeMethod(method)
+	for _, h := range methodOverrideHeaders {
+		if v := normalizeMethod(headers.Get(h)); isStandardMethod(v) {
+			return v
+		}
+	}
+	return base
+}
+
+func normalizeMethod(method string) string {
+	return strings.ToUpper(strings.TrimSpace(method))
+}
+
+func isStandardMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodConnect,
+		http.MethodOptions, http.MethodTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+// NormalizeHost lowercases a host and strips a DNS trailing dot, optional URL
+// scheme, and optional port. It is deliberately permissive because callers may
+// hand over r.Host, URL.Host, or URL.String-derived values at different hook
+// points.
+func NormalizeHost(raw string) string {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	if raw == "" {
+		return ""
+	}
+	if u, err := url.Parse(raw); err == nil && u.Host != "" {
+		raw = u.Host
+	}
+	if h, _, err := net.SplitHostPort(raw); err == nil {
+		raw = h
+	}
+	raw = strings.Trim(raw, "[]")
+	return strings.TrimSuffix(raw, ".")
+}
+
+// NormalizePath canonicalizes a request path for stable route matching:
+// repeated percent-decoding (bounded), per-segment removal of ;parameters, and
+// dot-segment / double-slash collapsing. Case is preserved because path IDs are
+// case-sensitive; rules needing case-insensitivity use a path_pattern.
+func NormalizePath(raw string) string {
+	if raw == "" {
+		return "/"
+	}
+	// Drop any query/fragment that slipped in.
+	if i := strings.IndexAny(raw, "?#"); i >= 0 {
+		raw = raw[:i]
+	}
+	// Repeatedly percent-decode until stable or the round cap is hit, so a
+	// multi-encoded ..%252e segment cannot hide from dot-segment removal.
+	for r := 0; r < maxUnescapeRounds; r++ {
+		dec, err := url.PathUnescape(raw)
+		if err != nil || dec == raw {
+			break
+		}
+		raw = dec
+	}
+	// Strip ;parameters from each segment.
+	segs := strings.Split(raw, "/")
+	for i, s := range segs {
+		if j := strings.IndexByte(s, ';'); j >= 0 {
+			segs[i] = s[:j]
+		}
+	}
+	raw = strings.Join(segs, "/")
+	// path.Clean collapses dot segments and double slashes but drops a trailing
+	// slash, so restore it when the input had one.
+	hadTrailingSlash := raw != "/" && strings.HasSuffix(raw, "/")
+	cleaned := path.Clean(raw)
+	if !strings.HasPrefix(cleaned, "/") {
+		cleaned = "/" + cleaned
+	}
+	if hadTrailingSlash && cleaned != "/" {
+		cleaned += "/"
+	}
+	return cleaned
+}
+
+// NormalizeContentType returns the lowercased media type with parameters
+// (charset, boundary, etc.) stripped, matching how rules declare content_types.
+func NormalizeContentType(ct string) string {
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	return strings.ToLower(strings.TrimSpace(ct))
+}

--- a/internal/reqpolicy/policy_test.go
+++ b/internal/reqpolicy/policy_test.go
@@ -1,0 +1,327 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package reqpolicy
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func mustMatcher(t *testing.T, rules ...config.RequestPolicyRule) *Matcher {
+	t.Helper()
+	m, err := NewMatcher(&config.RequestPolicy{Enabled: true, Rules: rules})
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+	return m
+}
+
+func apiWriteRule() config.RequestPolicyRule {
+	return config.RequestPolicyRule{
+		Name:   "api-write",
+		Action: config.ActionBlock,
+		Route: config.RequestPolicyRoute{
+			Hosts:        []string{"api.service.example.com"},
+			Methods:      []string{http.MethodPost},
+			PathPrefixes: []string{"/api/write"},
+			ContentTypes: []string{"application/json; charset=utf-8"},
+		},
+		Reason: "destructive API operation",
+	}
+}
+
+func TestEvaluate_RouteMatch(t *testing.T) {
+	m := mustMatcher(t, apiWriteRule())
+	tests := []struct {
+		name      string
+		meta      RequestMeta
+		wantBlock bool
+	}{
+		{
+			name:      "full match",
+			meta:      RequestMeta{Host: "api.service.example.com", Method: "POST", Path: "/api/write", ContentType: "application/json"},
+			wantBlock: true,
+		},
+		{
+			name:      "path prefix deeper still matches",
+			meta:      RequestMeta{Host: "api.service.example.com", Method: "POST", Path: "/api/write/v2", ContentType: "application/json"},
+			wantBlock: true,
+		},
+		{
+			name:      "host port normalized",
+			meta:      RequestMeta{Host: "api.service.example.com:443", Method: "POST", Path: "/api/write", ContentType: "application/json"},
+			wantBlock: true,
+		},
+		{
+			name:      "request path normalized before match",
+			meta:      RequestMeta{Host: "api.service.example.com", Method: "POST", Path: "/api//write/../write", ContentType: "application/json"},
+			wantBlock: true,
+		},
+		{
+			name:      "content type parameters normalized",
+			meta:      RequestMeta{Host: "api.service.example.com", Method: "POST", Path: "/api/write", ContentType: "Application/JSON; Charset=UTF-8"},
+			wantBlock: true,
+		},
+		{
+			name: "wrong host",
+			meta: RequestMeta{Host: "api.other.example.com", Method: "POST", Path: "/api/write", ContentType: "application/json"},
+		},
+		{
+			name: "wrong method",
+			meta: RequestMeta{Host: "api.service.example.com", Method: "GET", Path: "/api/write", ContentType: "application/json"},
+		},
+		{
+			name: "wrong path",
+			meta: RequestMeta{Host: "api.service.example.com", Method: "POST", Path: "/api/read", ContentType: "application/json"},
+		},
+		{
+			name: "wrong content type",
+			meta: RequestMeta{Host: "api.service.example.com", Method: "POST", Path: "/api/write", ContentType: "text/plain"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := m.Evaluate(tc.meta)
+			if tc.wantBlock {
+				if got.Action != config.ActionBlock || !got.Enforced() || got.RuleName != "api-write" {
+					t.Fatalf("want enforced block from api-write, got %+v", got)
+				}
+			} else if got.Matched() {
+				t.Fatalf("want allow (no match), got %+v", got)
+			}
+		})
+	}
+}
+
+func TestEvaluate_WildcardHostAndPathPattern(t *testing.T) {
+	m := mustMatcher(t, config.RequestPolicyRule{
+		Name:   "api-dangerous-path",
+		Action: config.ActionBlock,
+		Route: config.RequestPolicyRoute{
+			Hosts:        []string{"*.service.example.com"},
+			Methods:      []string{http.MethodPost, http.MethodDelete},
+			PathPatterns: []string{`^/v1/(accounts|users/[^/]+)/dangerous-action$`},
+		},
+	})
+	tests := []struct {
+		name      string
+		meta      RequestMeta
+		wantBlock bool
+	}{
+		{"subdomain + pattern", RequestMeta{Host: "api.service.example.com", Method: "POST", Path: "/v1/accounts/dangerous-action"}, true},
+		{"apex via wildcard", RequestMeta{Host: "service.example.com", Method: "DELETE", Path: "/v1/users/abc/dangerous-action"}, true},
+		{"pattern miss", RequestMeta{Host: "api.service.example.com", Method: "POST", Path: "/v1/accounts/messages"}, false},
+		{"unrelated host", RequestMeta{Host: "other.example.com", Method: "POST", Path: "/v1/accounts/dangerous-action"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := m.Evaluate(tc.meta)
+			if got.Enforced() != tc.wantBlock {
+				t.Fatalf("Enforced()=%v want %v (decision %+v)", got.Enforced(), tc.wantBlock, got)
+			}
+		})
+	}
+}
+
+func TestEvaluate_RouteOnlyMatchesAnyPath(t *testing.T) {
+	m := mustMatcher(t, config.RequestPolicyRule{
+		Name:   "host-only",
+		Action: config.ActionWarn,
+		Route:  config.RequestPolicyRoute{Hosts: []string{"api.service.example.com"}},
+	})
+	got := m.Evaluate(RequestMeta{Host: "api.service.example.com", Method: "GET", Path: "/anything/at/all"})
+	if got.Action != config.ActionWarn || !got.Enforced() {
+		t.Fatalf("want warn, got %+v", got)
+	}
+}
+
+func TestEvaluate_DisabledAllowsEverything(t *testing.T) {
+	m, err := NewMatcher(&config.RequestPolicy{Enabled: false, Rules: []config.RequestPolicyRule{apiWriteRule()}})
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+	if got := m.Evaluate(RequestMeta{Host: "api.service.example.com", Method: "POST", Path: "/api/write", ContentType: "application/json"}); got.Matched() {
+		t.Fatalf("disabled matcher should allow, got %+v", got)
+	}
+	// nil config and nil matcher both allow.
+	nilCfg, _ := NewMatcher(nil)
+	if nilCfg.Evaluate(RequestMeta{Host: "x"}).Matched() {
+		t.Fatal("nil-config matcher should allow")
+	}
+	var nilM *Matcher
+	if nilM.Evaluate(RequestMeta{Host: "x"}).Matched() {
+		t.Fatal("nil matcher should allow")
+	}
+}
+
+func TestEvaluate_Shadow(t *testing.T) {
+	r := apiWriteRule()
+	r.Shadow = true
+	m := mustMatcher(t, r)
+	got := m.Evaluate(RequestMeta{Host: "api.service.example.com", Method: "POST", Path: "/api/write", ContentType: "application/json"})
+	if !got.Matched() {
+		t.Fatal("shadow rule should match")
+	}
+	if got.Enforced() {
+		t.Fatalf("shadow rule must not enforce, got %+v", got)
+	}
+	if !got.Shadow || got.Action != config.ActionBlock {
+		t.Fatalf("want shadow block decision, got %+v", got)
+	}
+}
+
+func TestEvaluate_StrictestWins(t *testing.T) {
+	warnRule := config.RequestPolicyRule{
+		Name:   "warn-all-posts",
+		Action: config.ActionWarn,
+		Route:  config.RequestPolicyRoute{Hosts: []string{"api.service.example.com"}, Methods: []string{http.MethodPost}},
+	}
+	blockRule := apiWriteRule()
+	meta := RequestMeta{Host: "api.service.example.com", Method: "POST", Path: "/api/write", ContentType: "application/json"}
+
+	// Order must not matter: block wins regardless of which rule is first.
+	for _, order := range [][]config.RequestPolicyRule{
+		{warnRule, blockRule},
+		{blockRule, warnRule},
+	} {
+		m := mustMatcher(t, order...)
+		if got := m.Evaluate(meta); got.Action != config.ActionBlock || got.RuleName != "api-write" {
+			t.Fatalf("block must win over warn, got %+v", got)
+		}
+	}
+}
+
+func TestEvaluate_EnforcedPreferredOverShadow(t *testing.T) {
+	shadowBlock := apiWriteRule()
+	shadowBlock.Name = "shadow-block"
+	shadowBlock.Shadow = true
+	enforcedBlock := apiWriteRule()
+	enforcedBlock.Name = "enforced-block"
+	meta := RequestMeta{Host: "api.service.example.com", Method: "POST", Path: "/api/write", ContentType: "application/json"}
+	m := mustMatcher(t, shadowBlock, enforcedBlock)
+	got := m.Evaluate(meta)
+	if !got.Enforced() || got.RuleName != "enforced-block" {
+		t.Fatalf("enforced block must be preferred over shadow at same strictness, got %+v", got)
+	}
+}
+
+func TestNewMatcher_BadPattern(t *testing.T) {
+	_, err := NewMatcher(&config.RequestPolicy{Enabled: true, Rules: []config.RequestPolicyRule{{
+		Name:   "bad",
+		Action: config.ActionBlock,
+		Route:  config.RequestPolicyRoute{PathPatterns: []string{"("}},
+	}}})
+	if err == nil {
+		t.Fatal("expected compile error for invalid path_pattern")
+	}
+}
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"", "/"},
+		{"/a/b", "/a/b"},
+		{"/a//b", "/a/b"},
+		{"/a/../b", "/b"},
+		{"/a/%2e%2e/b", "/b"},     // single-encoded dot segment
+		{"/a/%252e%252e/b", "/b"}, // double-encoded dot segment
+		{"/v1/accounts/dangerous-action", "/v1/accounts/dangerous-action"},
+		{"/a/%zz/b", "/a/%zz/b"},          // invalid percent-encoding: decode aborts, left as-is
+		{"/seg;jsessionid=1/x", "/seg/x"}, // strip path params
+		{"/a/b?x=1", "/a/b"},              // drop query
+		{"/a/b#frag", "/a/b"},             // drop fragment
+		{"/a/b/", "/a/b/"},                // preserve trailing slash
+		{"/%2f/x", "/x"},                  // encoded slash revealed then collapsed
+	}
+	for _, tc := range tests {
+		if got := NormalizePath(tc.in); got != tc.want {
+			t.Errorf("NormalizePath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestEffectiveMethod(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   string
+		override map[string]string
+		want     string
+	}{
+		{"plain post", "POST", nil, "POST"},
+		{"lowercase normalized", "post", nil, "POST"},
+		{"x-http-method-override", "POST", map[string]string{"X-HTTP-Method-Override": "DELETE"}, "DELETE"},
+		{"x-method-override", "POST", map[string]string{"X-Method-Override": "delete"}, "DELETE"},
+		{"x-http-method", "POST", map[string]string{"X-HTTP-Method": "PATCH"}, "PATCH"},
+		{"invalid override falls back to base method", "POST", map[string]string{"X-HTTP-Method-Override": "DELETE, GET"}, "POST"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.Header{}
+			for k, v := range tc.override {
+				h.Set(k, v)
+			}
+			if got := EffectiveMethod(tc.method, h); got != tc.want {
+				t.Errorf("EffectiveMethod(%q, %v) = %q, want %q", tc.method, tc.override, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"", ""},
+		{"api.service.example.com", "api.service.example.com"},
+		{"API.Service.Example.com.", "api.service.example.com"},
+		{"api.service.example.com:443", "api.service.example.com"},
+		{"api.service.example.com:", "api.service.example.com"},
+		{"https://api.service.example.com:443/path", "api.service.example.com"},
+		{"[2001:db8::1]:443", "2001:db8::1"},
+		{"2001:db8::1", "2001:db8::1"},
+	}
+	for _, tc := range tests {
+		if got := NormalizeHost(tc.in); got != tc.want {
+			t.Errorf("NormalizeHost(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeContentType(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"application/json", "application/json"},
+		{"application/json; charset=utf-8", "application/json"},
+		{"  Application/JSON ; x=y", "application/json"},
+		{"multipart/form-data; boundary=abc", "multipart/form-data"},
+	}
+	for _, tc := range tests {
+		if got := NormalizeContentType(tc.in); got != tc.want {
+			t.Errorf("NormalizeContentType(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestBetterDecision(t *testing.T) {
+	block := Decision{Action: config.ActionBlock}
+	warn := Decision{Action: config.ActionWarn}
+	shadowBlock := Decision{Action: config.ActionBlock, Shadow: true}
+	none := Decision{}
+	tests := []struct {
+		name      string
+		cand, cur Decision
+		want      bool
+	}{
+		{"block over none", block, none, true},
+		{"none over none", none, none, false},
+		{"warn under block", warn, block, false},
+		{"block over warn", block, warn, true},
+		{"enforced over shadow, same action", block, shadowBlock, true},
+		{"shadow under enforced, same action", shadowBlock, block, false},
+		{"equal enforced does not replace", block, block, false},
+	}
+	for _, tc := range tests {
+		if got := betterDecision(tc.cand, tc.cur); got != tc.want {
+			t.Errorf("%s: betterDecision = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Adds `request_policy`: an allow-by-default deny/warn safety rail over outbound HTTP API operations. Independent of `request_body_scanning`, composes with the contract gate. It is neither a DLP scanner nor a behavioral allowlist.

This PR is the engine, config, and validation only. It is not yet wired into any transport and changes no runtime traffic behavior. The section stays dormant until the enforcement hooks land separately.

- `internal/reqpolicy`: precompiled matcher; strictest-wins evaluation (block over warn; enforced preferred over shadow); effective-method normalization (override headers, with an invalid override falling back to the base method); host normalization (scheme/port/IPv6/trailing-dot); bounded path normalization (percent-decode, dot-segment, semicolon-param, double-slash collapse); content-type normalization.
- `config.request_policy`: per-rule block/warn plus route constraints (hosts/methods/path_prefixes/path_patterns/content_types). No `default_action` knob, so the section is structurally default-allow.
- Validation: compile-at-load; rejects invalid action/method/name, empty route values, and rules with no constraint; warns when a rule needs inner-HTTP metadata it cannot see (TLS interception off, or a passthrough host).
- Metrics: `pipelock_request_policy_decisions_total` and `_parse_errors_total`, labeled by rule and action only (bounded cardinality).

`request_policy` is policy-semantic, so it joins the canonical policy hash; the golden hashes are bumped accordingly.

Tests cover matcher (route/wildcard/pattern/shadow/strictest), normalization (host, path including double-encoded, method-override, content-type), validation errors, and visibility warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `request_policy` configuration section with allow/warn/block rule actions.
  * Rules support matching on host, HTTP method, path, and content type.
  * Shadow rules log matches without enforcement.
  * Prometheus metrics track policy decision outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->