### PR TITLE
feat(blockreason): add request_policy_deny reason and accept UUIDv7 receipt ids

### DIFF
--- a/docs/specs/block-reason-header.md
+++ b/docs/specs/block-reason-header.md
@@ -15,7 +15,7 @@ This document is the canonical schema. Once an agent in production reads `dlp_ma
 | `X-Pipelock-Block-Reason-Severity` | yes (on every block) | `critical` | Matches pipelock's existing severity vocabulary: `info`, `warn`, `critical`. |
 | `X-Pipelock-Block-Reason-Retry` | yes (on every block) | `none` | Retry hint: `none` (permanent), `transient` (retry with backoff), `policy` (retry only after policy change). |
 | `X-Pipelock-Block-Reason-Layer` | optional | `dlp` | Scanner pipeline layer label. Uses `internal/scanner/` `Scanner*` constants verbatim so operators can correlate header-driven agent behavior with their existing audit logs and Prometheus labels. See the layer-label vocabulary below. |
-| `X-Pipelock-Block-Reason-Receipt` | optional | `01J0GNYZ7XSQRTQ8FPYM5BHX2K` | Receipt ID. Exactly 26 characters, Crockford-base32 (ULID alphabet: `0-9` plus `A-Z` minus `I`, `L`, `O`, `U`). Lets the agent fetch the matching receipt (via the receipt-transports endpoint) for additional context. The strict format keeps the slot opaque so attacker-controlled metadata cannot reach agent-visible response headers. |
+| `X-Pipelock-Block-Reason-Receipt` | optional | `0190a3c4-1234-7abc-89ab-0123456789ab` | Receipt ID for fetching the matching receipt (via the receipt-transports endpoint) for additional context. Either a 26-character Crockford-base32 ULID (`0-9` plus `A-Z` minus `I`, `L`, `O`, `U`) **or** a canonical 36-character hyphenated UUIDv7 — the receipt subsystem's correlation handle (`action_id`) uses that UUIDv7 form. Both accepted forms are fixed-length and drawn from a bounded alphabet, so the slot stays opaque and attacker-controlled metadata cannot reach agent-visible response headers. |
 
 Absent headers are treated as a generic block. Agents that don't read the headers continue to work unchanged — the headers are purely additive.
 
@@ -114,6 +114,16 @@ Emitted by the runtime evaluator when an active learn-and-lock contract claims j
 | `contract_invalid_path` | Active contract enforce rule matched the host but the request path failed RFC 3986 canonicalization. | `warn` | `retry-with-canonical-path` |
 | `contract_observed_only` | Shadow / capture annotation: contract path would have blocked under live mode but the configured mode did not enforce. Never emitted on a block surface. | `info` | `none` |
 
+### Request policy layer
+
+Emitted by the `request_policy` operation safety rail: even within otherwise-allowed traffic, an operator (or signed bundle) rule names a dangerous outbound API operation and denies it. The layer is default-allow; rules block or warn only. It is not a `Scanner*` pipeline layer, so blocks leave `X-Pipelock-Block-Reason-Layer` unset and the reason code conveys the layer (the same convention the MCP and contract layers follow).
+
+| Code | When | Severity | Retry |
+|---|---|---|---|
+| `request_policy_deny` | A `request_policy` rule denied a named-dangerous outbound API operation. | `critical` | `policy` |
+
+Warn/shadow `request_policy` telemetry is not a block surface and does not emit this header. Enforced `request_policy_deny` blocks carry `severity: critical`.
+
 ## Severity
 
 Aligns with `internal/config/schema.go` constants:
@@ -140,7 +150,7 @@ The header is **operational metadata only**. The following must never appear in 
 - Agent identifiers, session IDs, or any user-attributable data.
 - Internal IPs, private hostnames, or cluster-internal details.
 
-The optional `X-Pipelock-Block-Reason-Receipt` header carries an opaque ULID. The 26-character Crockford-base32 format is enforced by the emit package's `WithReceipt` validator; non-conforming receipts are rejected at construction so call sites cannot smuggle arbitrary strings into the slot. The receipt itself (fetched separately via the receipt-transports endpoint) may contain richer context, but the header value is just the opaque ID.
+The optional `X-Pipelock-Block-Reason-Receipt` header carries an opaque receipt ID — either a 26-character Crockford-base32 ULID or a canonical 36-character hyphenated UUIDv7 (the `action_id` form the receipt subsystem emits). The blockreason package's `WithReceipt` validator enforces both fixed-length, bounded-alphabet shapes; non-conforming receipts are rejected at construction so call sites cannot smuggle arbitrary strings into the slot. The receipt itself (fetched separately via the receipt-transports endpoint) may contain richer context, but the header value is just the opaque ID.
 
 The required header values (`Reason`, `Severity`, `Retry`) are validated against fixed allowlists at construction. The `Layer` value is restricted to ASCII alphanumeric and underscore (the shape of `internal/scanner/Scanner*` constants). Any value that does not match its validator is rejected before the header reaches the wire.
 

--- a/internal/blockreason/blockreason.go
+++ b/internal/blockreason/blockreason.go
@@ -49,6 +49,10 @@ const (
 	// receiptLen is the fixed Crockford-base32 ULID length. Receipts that
 	// don't match this length are rejected at WithReceipt time.
 	receiptLen = 26
+	// uuidReceiptLen is the canonical hyphenated UUID length (8-4-4-4-12).
+	// The receipt subsystem's correlation handle (receipt.NewActionID) is a
+	// UUIDv7 in this form, so the receipt header accepts it alongside ULIDs.
+	uuidReceiptLen = 36
 )
 
 // Reason is a machine-readable block-reason code. The full vocabulary is
@@ -113,6 +117,14 @@ const (
 	ContractInvalidPath    Reason = "contract_invalid_path"
 	ContractObservedOnly   Reason = "contract_observed_only"
 
+	// Request policy layer. Operator-defined outbound API operation safety
+	// rail (request_policy): even within otherwise-allowed traffic, a named
+	// dangerous provider operation is denied. Default-allow; rules block or
+	// warn only. Not a Scanner* pipeline layer, so blocks leave the
+	// X-Pipelock-Block-Reason-Layer header unset — the reason code conveys
+	// the layer (cf. the MCP and contract layers).
+	RequestPolicyDeny Reason = "request_policy_deny"
+
 	// BlockReasonOverflow is the dedicated sentinel CloseFramePayload uses
 	// when an Info has somehow accumulated a Reason value too long to fit
 	// the bare {block_reason: <code>} payload within RFC 6455's 123-byte
@@ -164,6 +176,7 @@ var validReasons = map[Reason]struct{}{
 	ContractNonDefaultPort: {},
 	ContractInvalidPath:    {},
 	ContractObservedOnly:   {},
+	RequestPolicyDeny:      {},
 }
 
 // AllReasons returns every Reason in the canonical allowlist. The returned
@@ -226,7 +239,7 @@ var (
 	ErrInvalidSeverity = errors.New("blockreason: severity is not in the v1 vocabulary")
 	ErrInvalidRetry    = errors.New("blockreason: retry is not in the v1 vocabulary")
 	ErrInvalidLayer    = errors.New("blockreason: layer must be ASCII alphanumeric/underscore and within length bound")
-	ErrInvalidReceipt  = errors.New("blockreason: receipt must be ULID-shaped (Crockford base32, 26 chars) or empty")
+	ErrInvalidReceipt  = errors.New("blockreason: receipt must be a 26-char Crockford-base32 ULID or a canonical 36-char UUIDv7 (the receipt action_id), or empty")
 )
 
 // Info is the operational metadata for a block.
@@ -287,10 +300,14 @@ func (i Info) WithLayer(layer string) (Info, error) {
 }
 
 // WithReceipt returns a copy of i with the Receipt set. Receipt MUST be
-// either empty or a 26-character Crockford-base32 ULID (the format the
-// receipt subsystem emits). The strict validation prevents arbitrary
-// strings — and therefore arbitrary attacker-controlled metadata — from
-// reaching agent-visible response headers via the Receipt slot.
+// empty, a 26-character Crockford-base32 ULID, or a canonical 36-character
+// hyphenated UUIDv7. The receipt subsystem's correlation handle
+// (receipt.NewActionID) is a UUIDv7 in the latter form, so a block path can
+// stamp the actual receipt action_id here for agent-side correlation. Both
+// accepted forms are fixed-length and drawn from a bounded alphabet, so the
+// strict validation still prevents arbitrary strings — and therefore
+// arbitrary attacker-controlled metadata — from reaching agent-visible
+// response headers via the Receipt slot.
 func (i Info) WithReceipt(receipt string) (Info, error) {
 	if !validReceipt(receipt) {
 		return Info{}, fmt.Errorf("%w: %q", ErrInvalidReceipt, receipt)
@@ -334,21 +351,65 @@ func isReceiptByte(c byte) bool {
 	return false
 }
 
-// validReceipt permits only the receipt byte alphabet at the fixed
-// receiptLen, or empty (clears the optional Receipt field).
+// validReceipt permits an empty receipt (clears the optional field), a
+// 26-char Crockford-base32 ULID, or a canonical 36-char hyphenated UUIDv7. The
+// two accepted forms are distinguished by length, so a value that is neither
+// (wrong length, or right length but malformed body) is rejected.
 func validReceipt(s string) bool {
-	if s == "" {
+	switch len(s) {
+	case 0:
 		return true
-	}
-	if len(s) != receiptLen {
+	case receiptLen:
+		return validULIDBody(s)
+	case uuidReceiptLen:
+		return validUUIDv7Body(s)
+	default:
 		return false
 	}
+}
+
+// validULIDBody reports whether every byte of s is in the Crockford-base32
+// ULID alphabet. Length is checked by the caller.
+func validULIDBody(s string) bool {
 	for i := 0; i < len(s); i++ {
 		if !isReceiptByte(s[i]) {
 			return false
 		}
 	}
 	return true
+}
+
+// validUUIDv7Body reports whether s is a canonical hyphenated UUIDv7: hex
+// digits with hyphens at positions 8, 13, 18, and 23 (the 8-4-4-4-12
+// grouping), version nibble 7, and RFC 4122 variant bits. Length is checked by
+// the caller. Hex is accepted case-insensitively to tolerate either textual
+// rendering; the receipt subsystem emits lowercase.
+func validUUIDv7Body(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if i == 8 || i == 13 || i == 18 || i == 23 {
+			if s[i] != '-' {
+				return false
+			}
+			continue
+		}
+		if !isHexByte(s[i]) {
+			return false
+		}
+	}
+	return s[14] == '7' && isRFC4122VariantByte(s[19])
+}
+
+// isHexByte returns true for ASCII hexadecimal digits in either case.
+func isHexByte(c byte) bool {
+	return (c >= '0' && c <= '9') ||
+		(c >= 'a' && c <= 'f') ||
+		(c >= 'A' && c <= 'F')
+}
+
+// isRFC4122VariantByte reports whether c is the variant nibble of an RFC 4122
+// UUID: the two most significant bits are 10, so the nibble is 8-b (either case).
+func isRFC4122VariantByte(c byte) bool {
+	return c == '8' || c == '9' || c == 'a' || c == 'A' || c == 'b' || c == 'B'
 }
 
 // SetHeaders writes all four required headers (reason, version, severity,
@@ -511,7 +572,8 @@ func RetryFor(reason Reason) Retry {
 		AuthorityMismatch,
 		NotEnabled,
 		CompressedResponse,
-		BrowserShieldOversize:
+		BrowserShieldOversize,
+		RequestPolicyDeny:
 		return RetryPolicy
 	case ContractInvalidPath:
 		return RetryCanonicalize

--- a/internal/blockreason/blockreason_test.go
+++ b/internal/blockreason/blockreason_test.go
@@ -14,6 +14,11 @@ import (
 // validULID is a 26-char Crockford-base32 string (no I, L, O, U).
 const validULID = "01J0GNYZ7XSQRTQ8FPYM5BHX2K"
 
+// validUUIDv7 is a canonical hyphenated UUIDv7 in the form receipt.NewActionID
+// emits. The receipt header accepts it so a block path can stamp the real
+// receipt action_id for agent-side correlation.
+const validUUIDv7 = "0190a3c4-1234-7abc-89ab-0123456789ab"
+
 func TestNew_AcceptsValidTriple(t *testing.T) {
 	t.Parallel()
 	info, err := New(DLPMatch, SeverityCritical, RetryNone)
@@ -134,6 +139,52 @@ func TestWithReceipt_AcceptsValidULID(t *testing.T) {
 	}
 	if got.Receipt != validULID {
 		t.Errorf("Receipt = %q, want %q", got.Receipt, validULID)
+	}
+}
+
+func TestWithReceipt_AcceptsValidUUIDv7(t *testing.T) {
+	t.Parallel()
+	base := MustNew(DLPMatch, SeverityCritical, RetryNone)
+	// Both the lowercase form receipt.NewActionID emits and an uppercase
+	// rendering are accepted (hex is case-insensitive).
+	for _, id := range []string{validUUIDv7, strings.ToUpper(validUUIDv7)} {
+		got, err := base.WithReceipt(id)
+		if err != nil {
+			t.Fatalf("WithReceipt(%q) error: %v", id, err)
+		}
+		if got.Receipt != id {
+			t.Errorf("Receipt = %q, want %q", got.Receipt, id)
+		}
+	}
+}
+
+func TestWithReceipt_RejectsMalformedUUIDv7(t *testing.T) {
+	t.Parallel()
+	base := MustNew(DLPMatch, SeverityCritical, RetryNone)
+	cases := []struct {
+		name    string
+		receipt string
+	}{
+		// 36 chars but hyphen displaced out of the 8-4-4-4-12 grouping.
+		{"hyphen wrong position", "0190a3c41-234-7abc-89ab-0123456789ab"},
+		// 36 chars but a body position carries a non-hex byte.
+		{"non-hex digit", "0190a3c4-1234-7abc-89ab-0123456789ag"},
+		// 36 chars of hex with no hyphens at all.
+		{"no hyphens", "0123456789abcdef0123456789abcdef0123"},
+		// Canonical UUID shape, but not the UUIDv7 version receipt.NewActionID emits.
+		{"wrong version", "0190a3c4-1234-4abc-89ab-0123456789ab"},
+		// Canonical UUIDv7 shape, but invalid RFC 4122 variant nibble.
+		{"wrong variant", "0190a3c4-1234-7abc-19ab-0123456789ab"},
+		// One char short of the canonical UUID length.
+		{"too short for uuid", validUUIDv7[:35]},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := base.WithReceipt(tc.receipt)
+			if !errors.Is(err, ErrInvalidReceipt) {
+				t.Errorf("WithReceipt(%q) error = %v, want wrap of ErrInvalidReceipt", tc.receipt, err)
+			}
+		})
 	}
 }
 
@@ -503,6 +554,9 @@ var specCanonicalPairs = map[Reason]struct {
 	ContractNonDefaultPort: {SeverityWarn, RetryNone},
 	ContractInvalidPath:    {SeverityWarn, RetryCanonicalize},
 	ContractObservedOnly:   {SeverityInfo, RetryNone},
+
+	// Request policy layer.
+	RequestPolicyDeny: {SeverityCritical, RetryPolicy},
 }
 
 // TestSpecCanonicalPairs_VocabularyCoverage asserts the test ground-truth

--- a/internal/blockreason/mappings_test.go
+++ b/internal/blockreason/mappings_test.go
@@ -53,6 +53,7 @@ func TestSeverityFor_FullVocabulary(t *testing.T) {
 		blockreason.EscalationLevel:        blockreason.SeverityCritical,
 		blockreason.SessionAnomaly:         blockreason.SeverityCritical,
 		blockreason.CrossRequestDeny:       blockreason.SeverityCritical,
+		blockreason.RequestPolicyDeny:      blockreason.SeverityCritical,
 	}
 	for r, want := range cases {
 		t.Run(string(r), func(t *testing.T) {
@@ -93,6 +94,7 @@ func TestRetryFor_FullVocabulary(t *testing.T) {
 		blockreason.NotEnabled:            blockreason.RetryPolicy,
 		blockreason.CompressedResponse:    blockreason.RetryPolicy,
 		blockreason.BrowserShieldOversize: blockreason.RetryPolicy,
+		blockreason.RequestPolicyDeny:     blockreason.RetryPolicy,
 		// none (default)
 		blockreason.DLPMatch:             blockreason.RetryNone,
 		blockreason.SSRFPrivateIP:        blockreason.RetryNone,

--- a/internal/blockreason/production_path_matrix_test.go
+++ b/internal/blockreason/production_path_matrix_test.go
@@ -216,6 +216,8 @@ func constNameForReason(r blockreason.Reason) string {
 		return "ContractInvalidPath"
 	case blockreason.ContractObservedOnly:
 		return "ContractObservedOnly"
+	case blockreason.RequestPolicyDeny:
+		return "RequestPolicyDeny"
 	}
 	return ""
 }

--- a/internal/proxy/requestpolicy.go
+++ b/internal/proxy/requestpolicy.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+)
+
+// requestPolicyBlockInfo builds the X-Pipelock-Block-Reason metadata for a
+// request_policy_deny block — the operation safety rail's enforced-block path.
+//
+// The request_policy layer is not a scanner.Scanner* pipeline constant, so the
+// X-Pipelock-Block-Reason-Layer header is intentionally left unset: per
+// docs/specs/block-reason-header.md non-scanner enforcement layers omit the
+// layer header and let the reason code convey the layer (the same convention
+// the MCP and contract layers follow).
+//
+// Receipt correlation is gated on a configured receipt emitter, mirroring
+// emitReceipt's nil check. When an emitter is configured, actionID — which MUST
+// be the real receipt action_id (receipt.NewActionID) recorded for this same
+// block — is stamped into the receipt header so the agent can fetch the
+// matching receipt. A decorrelated identifier must never be passed here: an
+// action_id that points at no emitted receipt would make the header lie. When
+// no emitter is configured, or actionID is empty or malformed, the receipt slot
+// stays unset and the block still emits its required headers — the receipt is
+// optional metadata, so dropping it never weakens the block itself.
+func (p *Proxy) requestPolicyBlockInfo(actionID string) blockreason.Info {
+	info := blockInfoFor(blockreason.RequestPolicyDeny, "")
+	if actionID == "" || p.receiptEmitterPtr.Load() == nil {
+		return info
+	}
+	withReceipt, err := info.WithReceipt(actionID)
+	if err != nil {
+		// Malformed action_id: keep the block, drop the optional receipt.
+		return info
+	}
+	return withReceipt
+}

--- a/internal/proxy/requestpolicy_test.go
+++ b/internal/proxy/requestpolicy_test.go
@@ -11,6 +11,15 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
 
+// Canonical request_policy_deny header values, derived from the blockreason
+// vocabulary so these assertions stay in sync with the contract instead of
+// repeating wire-string literals.
+const (
+	wantPolicyReason   = string(blockreason.RequestPolicyDeny)
+	wantPolicySeverity = string(blockreason.SeverityCritical)
+	wantPolicyRetry    = string(blockreason.RetryPolicy)
+)
+
 // TestRequestPolicyBlockInfo_HeaderShape asserts a request_policy_deny block
 // carries the canonical reason/severity/retry and intentionally omits the
 // layer header. request_policy is not a scanner.Scanner* pipeline layer, so
@@ -36,14 +45,14 @@ func TestRequestPolicyBlockInfo_HeaderShape(t *testing.T) {
 
 	h := make(http.Header)
 	info.SetHeaders(h)
-	if got := h.Get(blockreason.HeaderReason); got != "request_policy_deny" {
-		t.Errorf("%s = %q, want request_policy_deny", blockreason.HeaderReason, got)
+	if got := h.Get(blockreason.HeaderReason); got != wantPolicyReason {
+		t.Errorf("%s = %q, want %s", blockreason.HeaderReason, got, wantPolicyReason)
 	}
-	if got := h.Get(blockreason.HeaderSeverity); got != "critical" {
-		t.Errorf("%s = %q, want critical", blockreason.HeaderSeverity, got)
+	if got := h.Get(blockreason.HeaderSeverity); got != wantPolicySeverity {
+		t.Errorf("%s = %q, want %s", blockreason.HeaderSeverity, got, wantPolicySeverity)
 	}
-	if got := h.Get(blockreason.HeaderRetry); got != "policy" {
-		t.Errorf("%s = %q, want policy", blockreason.HeaderRetry, got)
+	if got := h.Get(blockreason.HeaderRetry); got != wantPolicyRetry {
+		t.Errorf("%s = %q, want %s", blockreason.HeaderRetry, got, wantPolicyRetry)
 	}
 	if got := h.Get(blockreason.HeaderLayer); got != "" {
 		t.Errorf("%s = %q, want empty (layer header omitted)", blockreason.HeaderLayer, got)
@@ -109,14 +118,14 @@ func TestRequestPolicyBlockInfo_ReceiptGatedOnEmitter(t *testing.T) {
 				t.Errorf("%s = %q, want %q", blockreason.HeaderReceipt, got, tc.wantReceipt)
 			}
 			// The block's required headers must always emit, receipt or not.
-			if got := h.Get(blockreason.HeaderReason); got != "request_policy_deny" {
-				t.Errorf("%s = %q, want request_policy_deny", blockreason.HeaderReason, got)
+			if got := h.Get(blockreason.HeaderReason); got != wantPolicyReason {
+				t.Errorf("%s = %q, want %s", blockreason.HeaderReason, got, wantPolicyReason)
 			}
-			if got := h.Get(blockreason.HeaderSeverity); got != "critical" {
-				t.Errorf("%s = %q, want critical", blockreason.HeaderSeverity, got)
+			if got := h.Get(blockreason.HeaderSeverity); got != wantPolicySeverity {
+				t.Errorf("%s = %q, want %s", blockreason.HeaderSeverity, got, wantPolicySeverity)
 			}
-			if got := h.Get(blockreason.HeaderRetry); got != "policy" {
-				t.Errorf("%s = %q, want policy", blockreason.HeaderRetry, got)
+			if got := h.Get(blockreason.HeaderRetry); got != wantPolicyRetry {
+				t.Errorf("%s = %q, want %s", blockreason.HeaderRetry, got, wantPolicyRetry)
 			}
 		})
 	}

--- a/internal/proxy/requestpolicy_test.go
+++ b/internal/proxy/requestpolicy_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+// TestRequestPolicyBlockInfo_HeaderShape asserts a request_policy_deny block
+// carries the canonical reason/severity/retry and intentionally omits the
+// layer header. request_policy is not a scanner.Scanner* pipeline layer, so
+// per docs/specs/block-reason-header.md the layer header stays unset and the
+// reason code conveys the layer.
+func TestRequestPolicyBlockInfo_HeaderShape(t *testing.T) {
+	t.Parallel()
+	p := &Proxy{} // no receipt emitter configured
+	info := p.requestPolicyBlockInfo("")
+
+	if info.Reason != blockreason.RequestPolicyDeny {
+		t.Errorf("Reason = %q, want %q", info.Reason, blockreason.RequestPolicyDeny)
+	}
+	if info.Severity != blockreason.SeverityCritical {
+		t.Errorf("Severity = %q, want critical", info.Severity)
+	}
+	if info.Retry != blockreason.RetryPolicy {
+		t.Errorf("Retry = %q, want policy", info.Retry)
+	}
+	if info.Layer != "" {
+		t.Errorf("Layer = %q, want unset (request_policy is not a Scanner* layer)", info.Layer)
+	}
+
+	h := make(http.Header)
+	info.SetHeaders(h)
+	if got := h.Get(blockreason.HeaderReason); got != "request_policy_deny" {
+		t.Errorf("%s = %q, want request_policy_deny", blockreason.HeaderReason, got)
+	}
+	if got := h.Get(blockreason.HeaderSeverity); got != "critical" {
+		t.Errorf("%s = %q, want critical", blockreason.HeaderSeverity, got)
+	}
+	if got := h.Get(blockreason.HeaderRetry); got != "policy" {
+		t.Errorf("%s = %q, want policy", blockreason.HeaderRetry, got)
+	}
+	if got := h.Get(blockreason.HeaderLayer); got != "" {
+		t.Errorf("%s = %q, want empty (layer header omitted)", blockreason.HeaderLayer, got)
+	}
+}
+
+// TestRequestPolicyBlockInfo_ReceiptGatedOnEmitter asserts the receipt header
+// is populated with the real receipt action_id iff a receipt emitter is
+// configured, and that a missing, empty, or malformed action_id leaves the
+// slot unset without dropping the block's required headers.
+//
+// The fixture uses a zero-value *receipt.Emitter because requestPolicyBlockInfo
+// only consults receiptEmitterPtr.Load() for non-nil presence (mirroring
+// emitReceipt's nil check) — it never calls Emit, so no recorder or signing key
+// is needed to exercise the gating.
+func TestRequestPolicyBlockInfo_ReceiptGatedOnEmitter(t *testing.T) {
+	t.Parallel()
+	realActionID := receipt.NewActionID() // UUIDv7, the form a live block path stamps
+
+	cases := []struct {
+		name        string
+		emitter     *receipt.Emitter
+		actionID    string
+		wantReceipt string
+	}{
+		{
+			name:        "emitter configured: real action_id surfaces in receipt header",
+			emitter:     &receipt.Emitter{},
+			actionID:    realActionID,
+			wantReceipt: realActionID,
+		},
+		{
+			name:        "no emitter: receipt header stays unset even with a valid id",
+			emitter:     nil,
+			actionID:    realActionID,
+			wantReceipt: "",
+		},
+		{
+			name:        "emitter configured but empty action_id: receipt header unset",
+			emitter:     &receipt.Emitter{},
+			actionID:    "",
+			wantReceipt: "",
+		},
+		{
+			name:        "emitter configured but malformed action_id: receipt dropped, block intact",
+			emitter:     &receipt.Emitter{},
+			actionID:    "not-a-valid-receipt-id",
+			wantReceipt: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Proxy{}
+			if tc.emitter != nil {
+				p.receiptEmitterPtr.Store(tc.emitter)
+			}
+			info := p.requestPolicyBlockInfo(tc.actionID)
+
+			h := make(http.Header)
+			info.SetHeaders(h)
+
+			if got := h.Get(blockreason.HeaderReceipt); got != tc.wantReceipt {
+				t.Errorf("%s = %q, want %q", blockreason.HeaderReceipt, got, tc.wantReceipt)
+			}
+			// The block's required headers must always emit, receipt or not.
+			if got := h.Get(blockreason.HeaderReason); got != "request_policy_deny" {
+				t.Errorf("%s = %q, want request_policy_deny", blockreason.HeaderReason, got)
+			}
+			if got := h.Get(blockreason.HeaderSeverity); got != "critical" {
+				t.Errorf("%s = %q, want critical", blockreason.HeaderSeverity, got)
+			}
+			if got := h.Get(blockreason.HeaderRetry); got != "policy" {
+				t.Errorf("%s = %q, want policy", blockreason.HeaderRetry, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Agents that read the X-Pipelock-Block-Reason headers get a dedicated code for operation safety-rail blocks, and the receipt header can now carry the actual receipt id for correlation.

## What changed

- New `request_policy_deny` reason code (severity `critical`, retry `policy`). The layer header is left unset because request_policy is not a scanner pipeline layer; the reason code conveys the layer, the same way the MCP and contract layers do.
- The `X-Pipelock-Block-Reason-Receipt` validator now accepts a canonical UUIDv7 in addition to a Crockford-base32 ULID. The receipt subsystem's correlation handle (`receipt.NewActionID`) is a UUIDv7, so before this the header could never hold a real receipt id. The check enforces the version nibble and RFC 4122 variant bits; both accepted forms are fixed-length with bounded alphabets, so the slot stays opaque.
- `Proxy.requestPolicyBlockInfo` builds the block metadata and stamps the real receipt action_id when a receipt emitter is configured, gated on the same check `emitReceipt` uses. With no emitter, or an empty or malformed id, the receipt slot stays empty and the block's required headers still emit. Only the emitted action_id is ever stamped.

This is vocabulary and receipt plumbing only. No request_policy enforcement path is wired yet; that is separate follow-up work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the request_policy_deny reason code and ensured corresponding block headers are always emitted; receipt header is included only when a valid action ID is available.

* **Documentation**
  * Updated block-reason header spec to document the request policy layer and accepted receipt formats (26-char Crockford-base32 ULID or canonical 36-char UUIDv7).

* **Tests**
  * Added tests covering request_policy_deny behavior and receipt acceptance/rejection for the new formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->