### PR TITLE
feat: add GraphQL operation extractor for request_policy

### DIFF
--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -123,7 +123,9 @@ const (
 	// operation-rails config (allow-by-default deny/warn rules over outbound
 	// API operations) is a policy-semantics change. The field is present but
 	// empty (disabled, no rules) in Defaults(), so it shifts the baseline hash.
-	goldenHashDefaults = "c591ad369bde2755f41825b90f2486503c0d314d76295402f7771b173ea80d60"
+	// Re-bumped for request_policy fail-closed parse/opaque-operation actions:
+	// these control whether unreadable GraphQL operations block, warn, or pass.
+	goldenHashDefaults = "344efdd038f53fc8e52fa972cdd0ace2af88810a7c511fe85cffa3ac2a2d8744"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -188,7 +190,9 @@ const (
 	// Re-bumped for the request_policy section: same rationale as
 	// goldenHashDefaults. The rich fixture omits request_policy, so the field
 	// is empty but still part of the canonical view; the hash shifts in lockstep.
-	goldenHashRichConfig = "36f684e7200b427c16c38e2dfeef3d7404760207b58bdfb9c2f191b1f4769a53"
+	// Re-bumped for request_policy fail-closed parse/opaque-operation actions:
+	// see goldenHashDefaults note above.
+	goldenHashRichConfig = "5862750fda898003193bbcfeff4f7077da4a09ef33e038db72c88fedb3eacc2a"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -69,6 +69,10 @@ func Defaults() *Config {
 			IdleTimeoutSeconds:       300,
 			OriginPolicy:             OriginPolicyRewrite,
 		},
+		RequestPolicy: RequestPolicy{
+			OnParseError:      ActionBlock,
+			OnOpaqueOperation: ActionBlock,
+		},
 		DLP: DLP{
 			ScanEnv: true,
 			Patterns: []DLPPattern{

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -272,6 +272,12 @@ func (c *Config) ApplyDefaults() {
 	if c.MCPToolPolicy.Enabled && c.MCPToolPolicy.Action == "" {
 		c.MCPToolPolicy.Action = ActionWarn
 	}
+	if c.RequestPolicy.OnParseError == "" {
+		c.RequestPolicy.OnParseError = ActionBlock
+	}
+	if c.RequestPolicy.OnOpaqueOperation == "" {
+		c.RequestPolicy.OnOpaqueOperation = ActionBlock
+	}
 	if c.ForwardProxy.MaxTunnelSeconds <= 0 {
 		c.ForwardProxy.MaxTunnelSeconds = 300
 	}

--- a/internal/config/requestpolicy_validate_test.go
+++ b/internal/config/requestpolicy_validate_test.go
@@ -10,7 +10,12 @@ import (
 
 func enabledPolicy(rules ...RequestPolicyRule) *Config {
 	c := Defaults()
-	c.RequestPolicy = RequestPolicy{Enabled: true, Rules: rules}
+	c.RequestPolicy = RequestPolicy{
+		Enabled:           true,
+		OnParseError:      ActionBlock,
+		OnOpaqueOperation: ActionBlock,
+		Rules:             rules,
+	}
 	return c
 }
 
@@ -64,6 +69,24 @@ func TestValidateRequestPolicy_Errors(t *testing.T) {
 			want: "must be block or warn",
 		},
 		{
+			name: "invalid parse error action",
+			cfg: func() *Config {
+				c := enabledPolicy(RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{Methods: []string{"POST"}}})
+				c.RequestPolicy.OnParseError = "retry"
+				return c
+			}(),
+			want: "on_parse_error",
+		},
+		{
+			name: "invalid opaque operation action",
+			cfg: func() *Config {
+				c := enabledPolicy(RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{Methods: []string{"POST"}}})
+				c.RequestPolicy.OnOpaqueOperation = "retry"
+				return c
+			}(),
+			want: "on_opaque_operation",
+		},
+		{
 			name: "no route constraint",
 			cfg:  enabledPolicy(RequestPolicyRule{Name: "r", Action: ActionBlock}),
 			want: "no route constraints",
@@ -112,19 +135,36 @@ func TestValidateRequestPolicy_Errors(t *testing.T) {
 func TestValidateRequestPolicy_DormantValidation(t *testing.T) {
 	c := Defaults()
 	c.RequestPolicy = RequestPolicy{
-		Enabled: false,
-		Rules:   []RequestPolicyRule{{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{PathPatterns: []string{"("}}}},
+		Enabled:           false,
+		OnParseError:      ActionBlock,
+		OnOpaqueOperation: ActionBlock,
+		Rules:             []RequestPolicyRule{{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{PathPatterns: []string{"("}}}},
 	}
 	if _, err := c.ValidateWithWarnings(); err == nil {
 		t.Fatal("disabled section with invalid regex should still error")
 	}
 }
 
+func TestApplyDefaults_RequestPolicyFailureActions(t *testing.T) {
+	c := Defaults()
+	c.RequestPolicy.OnParseError = ""
+	c.RequestPolicy.OnOpaqueOperation = ""
+	c.ApplyDefaults()
+	if c.RequestPolicy.OnParseError != ActionBlock {
+		t.Fatalf("OnParseError = %q, want %q", c.RequestPolicy.OnParseError, ActionBlock)
+	}
+	if c.RequestPolicy.OnOpaqueOperation != ActionBlock {
+		t.Fatalf("OnOpaqueOperation = %q, want %q", c.RequestPolicy.OnOpaqueOperation, ActionBlock)
+	}
+}
+
 func TestValidateRequestPolicy_DisabledEmitsNoVisibilityWarning(t *testing.T) {
 	c := Defaults() // tls_interception disabled by default
 	c.RequestPolicy = RequestPolicy{
-		Enabled: false,
-		Rules:   []RequestPolicyRule{{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{Hosts: []string{"api.service.example.com"}, Methods: []string{"POST"}}}},
+		Enabled:           false,
+		OnParseError:      ActionBlock,
+		OnOpaqueOperation: ActionBlock,
+		Rules:             []RequestPolicyRule{{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{Hosts: []string{"api.service.example.com"}, Methods: []string{"POST"}}}},
 	}
 	warnings, err := c.ValidateWithWarnings()
 	if err != nil {
@@ -159,6 +199,21 @@ func TestWarnRequestPolicyVisibility(t *testing.T) {
 		}
 	})
 
+	t.Run("host-only graphql rule warns when tls interception off", func(t *testing.T) {
+		c := &Config{}
+		hostOnlyGraphQL := &RequestPolicyRule{
+			Name:    "r",
+			Action:  ActionBlock,
+			Route:   RequestPolicyRoute{Hosts: []string{"api.service.example.com"}},
+			GraphQL: &RequestPolicyGraphQL{OperationTypes: []string{"mutation"}},
+		}
+		var warnings []Warning
+		c.warnRequestPolicyVisibility(hostOnlyGraphQL, &warnings)
+		if len(warnings) != 1 || !strings.Contains(warnings[0].Message, "tls_interception is disabled") {
+			t.Fatalf("want graphql tls-disabled warning, got %+v", warnings)
+		}
+	})
+
 	t.Run("passthrough host", func(t *testing.T) {
 		c := &Config{}
 		c.TLSInterception.Enabled = true
@@ -178,6 +233,23 @@ func TestWarnRequestPolicyVisibility(t *testing.T) {
 		c.warnRequestPolicyVisibility(rule, &warnings)
 		if len(warnings) != 1 || !strings.Contains(warnings[0].Message, "passthrough_domains") {
 			t.Fatalf("want passthrough warning for wildcard match, got %+v", warnings)
+		}
+	})
+
+	t.Run("host-only graphql rule warns on passthrough host", func(t *testing.T) {
+		c := &Config{}
+		c.TLSInterception.Enabled = true
+		c.TLSInterception.PassthroughDomains = []string{"api.service.example.com"}
+		hostOnlyGraphQL := &RequestPolicyRule{
+			Name:    "r",
+			Action:  ActionBlock,
+			Route:   RequestPolicyRoute{Hosts: []string{"api.service.example.com"}},
+			GraphQL: &RequestPolicyGraphQL{RootFieldPatterns: []string{`(?i)delete`}},
+		}
+		var warnings []Warning
+		c.warnRequestPolicyVisibility(hostOnlyGraphQL, &warnings)
+		if len(warnings) != 1 || !strings.Contains(warnings[0].Message, "passthrough_domains") {
+			t.Fatalf("want graphql passthrough warning, got %+v", warnings)
 		}
 	})
 
@@ -201,4 +273,49 @@ func TestWarnRequestPolicyVisibility(t *testing.T) {
 			t.Fatalf("host-only rule is visible at CONNECT boundary and should not warn, got %+v", warnings)
 		}
 	})
+}
+
+func TestValidateRequestPolicy_GraphQL(t *testing.T) {
+	t.Run("valid predicate normalizes operation types", func(t *testing.T) {
+		c := enabledPolicy(RequestPolicyRule{
+			Name:   "gql",
+			Action: ActionBlock,
+			Route:  RequestPolicyRoute{Hosts: []string{"api.service.example.com"}},
+			GraphQL: &RequestPolicyGraphQL{
+				OperationTypes:    []string{"Mutation"},
+				RootFieldPatterns: []string{`(?i)delete`},
+			},
+		})
+		if _, err := c.ValidateWithWarnings(); err != nil {
+			t.Fatalf("valid graphql predicate rejected: %v", err)
+		}
+		if got := c.RequestPolicy.Rules[0].GraphQL.OperationTypes[0]; got != "mutation" {
+			t.Errorf("operation type not lowercased: %q", got)
+		}
+	})
+
+	tests := []struct {
+		name string
+		gql  *RequestPolicyGraphQL
+		want string
+	}{
+		{"empty predicate", &RequestPolicyGraphQL{}, "must set operation_types or root_field_patterns"},
+		{"bad operation type", &RequestPolicyGraphQL{OperationTypes: []string{"delete"}}, "must be query, mutation, or subscription"},
+		{"empty root field pattern", &RequestPolicyGraphQL{RootFieldPatterns: []string{"  "}}, "empty graphql root_field_pattern"},
+		{"invalid root field pattern", &RequestPolicyGraphQL{RootFieldPatterns: []string{"("}}, "invalid graphql root_field_pattern"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := enabledPolicy(RequestPolicyRule{
+				Name:    "gql",
+				Action:  ActionBlock,
+				Route:   RequestPolicyRoute{Hosts: []string{"api.service.example.com"}},
+				GraphQL: tc.gql,
+			})
+			_, err := c.ValidateWithWarnings()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
 }

--- a/internal/config/requestpolicy_validate_test.go
+++ b/internal/config/requestpolicy_validate_test.go
@@ -283,14 +283,18 @@ func TestValidateRequestPolicy_GraphQL(t *testing.T) {
 			Route:  RequestPolicyRoute{Hosts: []string{"api.service.example.com"}},
 			GraphQL: &RequestPolicyGraphQL{
 				OperationTypes:    []string{"Mutation"},
-				RootFieldPatterns: []string{`(?i)delete`},
+				RootFieldPatterns: []string{"  (?i)delete  "},
 			},
 		})
 		if _, err := c.ValidateWithWarnings(); err != nil {
 			t.Fatalf("valid graphql predicate rejected: %v", err)
 		}
-		if got := c.RequestPolicy.Rules[0].GraphQL.OperationTypes[0]; got != "mutation" {
+		gql := c.RequestPolicy.Rules[0].GraphQL
+		if got := gql.OperationTypes[0]; got != "mutation" {
 			t.Errorf("operation type not lowercased: %q", got)
+		}
+		if got := gql.RootFieldPatterns[0]; got != "(?i)delete" {
+			t.Errorf("root_field_pattern not trimmed/persisted: %q", got)
 		}
 	})
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -235,21 +235,24 @@ type SandboxFilesystem struct {
 // composes with the learn-lock contract gate (a ratified allowlist) and with
 // DLP, and is neither. See the request-policy operation-rails design.
 type RequestPolicy struct {
-	Enabled bool                `yaml:"enabled"`
-	Rules   []RequestPolicyRule `yaml:"rules"`
+	Enabled           bool                `yaml:"enabled"`
+	OnParseError      string              `yaml:"on_parse_error"`      // block (default) | warn | allow
+	OnOpaqueOperation string              `yaml:"on_opaque_operation"` // block (default) | warn | allow
+	Rules             []RequestPolicyRule `yaml:"rules"`
 }
 
-// RequestPolicyRule is one operation safety rail. v1 matches on route only
-// (host / method / path / content type); GraphQL and JSON operation predicates
-// are reserved for later phases. Action is per-rule (block or warn) — there is
-// deliberately no section-level default_action knob, so the section can never
-// be configured into default-deny.
+// RequestPolicyRule is one operation safety rail. It matches on route (host /
+// method / path / content type) and, optionally, on a GraphQL operation
+// predicate. Action is per-rule (block or warn) — there is deliberately no
+// section-level default_action knob, so the section can never be configured
+// into default-deny.
 type RequestPolicyRule struct {
-	Name   string             `yaml:"name"`   // bounded, metric-label-safe identifier
-	Action string             `yaml:"action"` // block | warn
-	Shadow bool               `yaml:"shadow"` // log the would-be action, forward anyway
-	Route  RequestPolicyRoute `yaml:"route"`
-	Reason string             `yaml:"reason"` // operator-facing explanation (never logged with content)
+	Name    string                `yaml:"name"`   // bounded, metric-label-safe identifier
+	Action  string                `yaml:"action"` // block | warn
+	Shadow  bool                  `yaml:"shadow"` // log the would-be action, forward anyway
+	Route   RequestPolicyRoute    `yaml:"route"`
+	GraphQL *RequestPolicyGraphQL `yaml:"graphql,omitempty"` // optional GraphQL operation predicate
+	Reason  string                `yaml:"reason"`            // operator-facing explanation (never logged with content)
 }
 
 // RequestPolicyRoute selects which requests a rule applies to. An empty
@@ -262,6 +265,17 @@ type RequestPolicyRoute struct {
 	PathPrefixes []string `yaml:"path_prefixes"` // literal prefixes of the normalized path
 	PathPatterns []string `yaml:"path_patterns"` // RE2 patterns against the normalized path
 	ContentTypes []string `yaml:"content_types"` // media types (parameters stripped)
+}
+
+// RequestPolicyGraphQL is an optional operation predicate applied after the
+// route matches. A request matches the predicate when any extracted operation
+// satisfies it: the operation kind is in OperationTypes (when set) and one of
+// its resolved root field names matches a RootFieldPatterns regex (when set).
+// At least one of the two must be set. Matching evaluates every operation in a
+// document or batch, never just the first.
+type RequestPolicyGraphQL struct {
+	OperationTypes    []string `yaml:"operation_types"`     // query | mutation | subscription
+	RootFieldPatterns []string `yaml:"root_field_patterns"` // RE2 patterns against resolved root field names
 }
 
 // Config is the top-level Pipelock configuration.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -884,13 +884,18 @@ func validateRequestPolicyGraphQL(rule string, g *RequestPolicyGraphQL) error {
 			return fmt.Errorf("request_policy rule %q graphql operation_type %q must be query, mutation, or subscription", rule, t)
 		}
 	}
-	for _, p := range g.RootFieldPatterns {
-		if strings.TrimSpace(p) == "" {
+	for i, p := range g.RootFieldPatterns {
+		pat := strings.TrimSpace(p)
+		if pat == "" {
 			return fmt.Errorf("request_policy rule %q has empty graphql root_field_pattern", rule)
 		}
-		if _, err := regexp.Compile(p); err != nil {
+		if _, err := regexp.Compile(pat); err != nil {
 			return fmt.Errorf("request_policy rule %q has invalid graphql root_field_pattern %q: %w", rule, p, err)
 		}
+		// Persist the trimmed pattern so the runtime predicate compiles the same
+		// value: surrounding whitespace would otherwise compile into the regex
+		// and silently under-match, weakening the rule.
+		g.RootFieldPatterns[i] = pat
 	}
 	return nil
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -798,6 +798,12 @@ var validReqPolicyName = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
 // will and will not actually get.
 func (c *Config) validateRequestPolicy(warnings *[]Warning) error {
 	rp := &c.RequestPolicy
+	if err := validateRequestPolicyFailureAction("on_parse_error", rp.OnParseError); err != nil {
+		return err
+	}
+	if err := validateRequestPolicyFailureAction("on_opaque_operation", rp.OnOpaqueOperation); err != nil {
+		return err
+	}
 	if rp.Enabled && len(rp.Rules) == 0 {
 		return fmt.Errorf("request_policy is enabled but has no rules; add rules or set enabled: false")
 	}
@@ -851,8 +857,39 @@ func (c *Config) validateRequestPolicy(warnings *[]Warning) error {
 			}
 			route.ContentTypes[j] = normalized
 		}
+		if r.GraphQL != nil {
+			if err := validateRequestPolicyGraphQL(r.Name, r.GraphQL); err != nil {
+				return err
+			}
+		}
 		if rp.Enabled {
 			c.warnRequestPolicyVisibility(r, warnings)
+		}
+	}
+	return nil
+}
+
+// validateRequestPolicyGraphQL validates and normalizes a rule's GraphQL
+// operation predicate. Operation types are lowercased in place so the runtime
+// predicate (which also lowercases) and validation agree.
+func validateRequestPolicyGraphQL(rule string, g *RequestPolicyGraphQL) error {
+	if len(g.OperationTypes) == 0 && len(g.RootFieldPatterns) == 0 {
+		return fmt.Errorf("request_policy rule %q graphql predicate must set operation_types or root_field_patterns", rule)
+	}
+	for i, t := range g.OperationTypes {
+		switch norm := strings.ToLower(strings.TrimSpace(t)); norm {
+		case "query", "mutation", "subscription":
+			g.OperationTypes[i] = norm
+		default:
+			return fmt.Errorf("request_policy rule %q graphql operation_type %q must be query, mutation, or subscription", rule, t)
+		}
+	}
+	for _, p := range g.RootFieldPatterns {
+		if strings.TrimSpace(p) == "" {
+			return fmt.Errorf("request_policy rule %q has empty graphql root_field_pattern", rule)
+		}
+		if _, err := regexp.Compile(p); err != nil {
+			return fmt.Errorf("request_policy rule %q has invalid graphql root_field_pattern %q: %w", rule, p, err)
 		}
 	}
 	return nil
@@ -882,14 +919,14 @@ func normalizeRequestPolicyContentType(ct string) string {
 // CONNECT boundary, so warnings are emitted only when a rule needs inner HTTP
 // metadata.
 func (c *Config) warnRequestPolicyVisibility(r *RequestPolicyRule, warnings *[]Warning) {
-	if !requestPolicyRouteNeedsInnerHTTP(r.Route) {
+	if !requestPolicyRuleNeedsInnerHTTP(r) {
 		return
 	}
 	if len(r.Route.Hosts) == 0 {
 		if !c.TLSInterception.Enabled {
 			*warnings = append(*warnings, Warning{
 				Field:   fmt.Sprintf("request_policy rule %q", r.Name),
-				Message: "has method/path/content-type constraints but no host constraint and tls_interception is disabled; pipelock cannot see inner HTTPS method/path/body on CONNECT - only the tunnel host/port are visible",
+				Message: "has method/path/content-type or operation constraints but no host constraint and tls_interception is disabled; pipelock cannot see inner HTTPS method/path/body on CONNECT - only the tunnel host/port are visible",
 			})
 		}
 		return
@@ -909,6 +946,22 @@ func (c *Config) warnRequestPolicyVisibility(r *RequestPolicyRule, warnings *[]W
 			})
 		}
 	}
+}
+
+func validateRequestPolicyFailureAction(field, action string) error {
+	switch action {
+	case ActionAllow, ActionWarn, ActionBlock:
+		return nil
+	default:
+		return fmt.Errorf("request_policy %s has invalid action %q: must be allow, warn, or block", field, action)
+	}
+}
+
+func requestPolicyRuleNeedsInnerHTTP(r *RequestPolicyRule) bool {
+	if r.GraphQL != nil {
+		return true
+	}
+	return requestPolicyRouteNeedsInnerHTTP(r.Route)
 }
 
 func requestPolicyRouteNeedsInnerHTTP(route RequestPolicyRoute) bool {

--- a/internal/reqpolicy/graphql.go
+++ b/internal/reqpolicy/graphql.go
@@ -1,0 +1,644 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package reqpolicy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// RequestOperation is a provider-neutral classification of one outbound API
+// operation extracted from a request body. A single GraphQL document can yield
+// multiple operations, and a batched request yields operations from every
+// element. RootFields are the operation's top-level selection field names with
+// aliases resolved to the real field and top-level fragment spreads / inline
+// fragments expanded, so a deny rule matches the field that actually executes
+// rather than a cosmetic alias or a field hidden inside a fragment.
+type RequestOperation struct {
+	Kind       string   // "query", "mutation", or "subscription"
+	Name       string   // operation name; "" for anonymous or shorthand operations
+	RootFields []string // resolved top-level field names
+	Aliased    bool     // any root field used an alias
+}
+
+// GraphQL operation kinds.
+const (
+	gqlQuery        = "query"
+	gqlMutation     = "mutation"
+	gqlSubscription = "subscription"
+)
+
+// Defense-in-depth limits. The request body is already capped upstream by
+// request_body_scanning.max_body_bytes; these bound parser work regardless.
+const (
+	maxGraphQLTokens     = 200000
+	maxSelectionDepth    = 64
+	maxFragmentExpansion = 5000
+)
+
+var errGraphQLParse = errors.New("reqpolicy: graphql parse error")
+
+// gqlRequest is the GraphQL-over-HTTP JSON envelope. Query is a pointer so a
+// missing "query" key (e.g. an Automatic Persisted Query that ships only a
+// hash) is distinguishable from an empty query string; both are treated as
+// opaque because there is no inline operation to inspect.
+type gqlRequest struct {
+	Query         *string `json:"query"`
+	OperationName string  `json:"operationName"`
+}
+
+// ExtractGraphQL parses a GraphQL-over-HTTP JSON request body (single object or
+// batched array) into operations. It returns:
+//
+//	parseOK=false: the body is not valid GraphQL-over-HTTP JSON, or a contained
+//	               query failed to parse. The caller fail-closes per on_parse_error.
+//	opaque=true:   a request element carries no inline query (e.g. an APQ hash),
+//	               so the operation cannot be inspected. The caller fail-closes
+//	               per on_opaque_operation.
+//
+// Every operation in a document and every element of a batch is returned;
+// callers must evaluate all of them, never just the first, so a dangerous
+// operation cannot hide behind a benign one.
+func ExtractGraphQL(body []byte) (ops []RequestOperation, parseOK, opaque bool) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return nil, false, false
+	}
+	switch trimmed[0] {
+	case '[':
+		var batch []gqlRequest
+		if err := json.Unmarshal(trimmed, &batch); err != nil || len(batch) == 0 {
+			return nil, false, false
+		}
+		for i := range batch {
+			eops, ok, op := extractOne(batch[i])
+			if !ok {
+				return nil, false, false
+			}
+			if op {
+				opaque = true
+			}
+			ops = append(ops, eops...)
+		}
+		return ops, true, opaque
+	case '{':
+		var req gqlRequest
+		if err := json.Unmarshal(trimmed, &req); err != nil {
+			return nil, false, false
+		}
+		return extractOne(req)
+	default:
+		return nil, false, false
+	}
+}
+
+func extractOne(req gqlRequest) (ops []RequestOperation, parseOK, opaque bool) {
+	if req.Query == nil || strings.TrimSpace(*req.Query) == "" {
+		// Valid JSON envelope but no inline operation to inspect.
+		return nil, true, true
+	}
+	parsed, err := parseGraphQLDocument(*req.Query)
+	if err != nil {
+		return nil, false, false
+	}
+	return parsed, true, false
+}
+
+// --- lexer ---
+
+type gqlTokKind uint8
+
+const (
+	tkName gqlTokKind = iota
+	tkPunct
+	tkOther // string or numeric value; consumed atomically, value not needed
+)
+
+type gqlToken struct {
+	kind gqlTokKind
+	val  string // set for tkName and tkPunct only
+}
+
+// lexGraphQL tokenizes a GraphQL document, discarding ignored tokens
+// (whitespace, commas, BOM, # comments) and consuming strings and block
+// strings atomically so brackets inside string values can never be mistaken
+// for structural punctuators.
+func lexGraphQL(src string) ([]gqlToken, error) {
+	src = strings.TrimPrefix(src, "\ufeff")
+	toks := make([]gqlToken, 0, 64)
+	for i, n := 0, len(src); i < n; {
+		if len(toks) >= maxGraphQLTokens {
+			return nil, errGraphQLParse
+		}
+		c := src[i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ',':
+			i++
+		case c == '#':
+			for i < n && src[i] != '\n' {
+				i++
+			}
+		case c == '"':
+			end := indexStringEnd(src, i)
+			if end < 0 {
+				return nil, errGraphQLParse
+			}
+			toks = append(toks, gqlToken{kind: tkOther})
+			i = end
+		case c == '.':
+			if strings.HasPrefix(src[i:], "...") {
+				toks = append(toks, gqlToken{kind: tkPunct, val: "..."})
+				i += 3
+			} else {
+				return nil, errGraphQLParse
+			}
+		case isPunctByte(c):
+			toks = append(toks, gqlToken{kind: tkPunct, val: string(c)})
+			i++
+		case isNameStart(c):
+			j := i + 1
+			for j < n && isNameCont(src[j]) {
+				j++
+			}
+			toks = append(toks, gqlToken{kind: tkName, val: src[i:j]})
+			i = j
+		case c == '-' || (c >= '0' && c <= '9'):
+			j := i + 1
+			for j < n && isNumberCont(src[j]) {
+				j++
+			}
+			toks = append(toks, gqlToken{kind: tkOther})
+			i = j
+		default:
+			// Any other byte (control chars, non-ASCII outside a string, a bare
+			// backslash from a "d"-style field-name evasion) is invalid
+			// GraphQL outside a string literal: fail closed.
+			return nil, errGraphQLParse
+		}
+	}
+	return toks, nil
+}
+
+// indexStringEnd returns the index just past the closing quote of the string
+// beginning at i (which must point at '"'), or -1 if unterminated. Handles both
+// ordinary strings (with backslash escapes) and """block strings""".
+func indexStringEnd(src string, i int) int {
+	n := len(src)
+	if strings.HasPrefix(src[i:], `"""`) {
+		i += 3
+		for i < n {
+			if src[i] == '\\' && strings.HasPrefix(src[i:], `\"""`) {
+				i += 4
+				continue
+			}
+			if strings.HasPrefix(src[i:], `"""`) {
+				return i + 3
+			}
+			i++
+		}
+		return -1
+	}
+	i++ // past opening quote
+	for i < n {
+		switch src[i] {
+		case '\\':
+			i += 2
+		case '"':
+			return i + 1
+		case '\n', '\r':
+			return -1 // ordinary strings cannot span lines
+		default:
+			i++
+		}
+	}
+	return -1
+}
+
+func isPunctByte(c byte) bool {
+	switch c {
+	case '!', '$', '(', ')', ':', '=', '@', '[', ']', '{', '}', '|', '&':
+		return true
+	default:
+		return false
+	}
+}
+
+func isNameStart(c byte) bool {
+	return c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+}
+
+func isNameCont(c byte) bool {
+	return isNameStart(c) || (c >= '0' && c <= '9')
+}
+
+func isNumberCont(c byte) bool {
+	return (c >= '0' && c <= '9') || c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-'
+}
+
+// --- parser ---
+
+// selItem is one entry in a selection set: a concrete field, a fragment spread
+// to expand, or an inline fragment whose items are spliced in at this level.
+type selItem struct {
+	field   string
+	aliased bool
+	spread  string
+	inline  []selItem
+}
+
+type gqlParser struct {
+	toks []gqlToken
+	pos  int
+}
+
+func (p *gqlParser) eof() bool { return p.pos >= len(p.toks) }
+
+func (p *gqlParser) peek() gqlToken {
+	if p.eof() {
+		return gqlToken{}
+	}
+	return p.toks[p.pos]
+}
+
+func (p *gqlParser) next() gqlToken {
+	t := p.peek()
+	p.pos++
+	return t
+}
+
+func (p *gqlParser) isPunct(v string) bool {
+	t := p.peek()
+	return t.kind == tkPunct && t.val == v
+}
+
+// skipBalanced consumes a bracketed group starting at the current token (which
+// must be an opening bracket), balancing (), [], and {} together until the
+// group closes. String and numeric values are single atomic tokens, so no
+// bracket inside a value is ever counted.
+func (p *gqlParser) skipBalanced() error {
+	var stack []string
+	for !p.eof() {
+		t := p.next()
+		if t.kind != tkPunct {
+			continue
+		}
+		if closer, ok := matchingCloser(t.val); ok {
+			stack = append(stack, closer)
+			continue
+		}
+		if isCloser(t.val) {
+			if len(stack) == 0 || stack[len(stack)-1] != t.val {
+				return errGraphQLParse
+			}
+			stack = stack[:len(stack)-1]
+			if len(stack) == 0 {
+				return nil
+			}
+		}
+	}
+	return errGraphQLParse
+}
+
+func matchingCloser(opener string) (string, bool) {
+	switch opener {
+	case "(":
+		return ")", true
+	case "[":
+		return "]", true
+	case "{":
+		return "}", true
+	default:
+		return "", false
+	}
+}
+
+func isCloser(v string) bool {
+	return v == ")" || v == "]" || v == "}"
+}
+
+func (p *gqlParser) skipDirectives() error {
+	for p.isPunct("@") {
+		p.next()
+		if p.peek().kind != tkName {
+			return errGraphQLParse
+		}
+		p.next()
+		if p.isPunct("(") {
+			if err := p.skipBalanced(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (p *gqlParser) parseSelectionSet(depth int) ([]selItem, error) {
+	if depth > maxSelectionDepth {
+		return nil, errGraphQLParse
+	}
+	if !p.isPunct("{") {
+		return nil, errGraphQLParse
+	}
+	p.next() // "{"
+	var items []selItem
+	for {
+		if p.eof() {
+			return nil, errGraphQLParse
+		}
+		t := p.peek()
+		if t.kind == tkPunct && t.val == "}" {
+			p.next()
+			if len(items) == 0 {
+				return nil, errGraphQLParse
+			}
+			return items, nil
+		}
+		if t.kind == tkPunct && t.val == "..." {
+			p.next()
+			item, err := p.parseFragment(depth)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, item)
+			continue
+		}
+		if t.kind != tkName {
+			return nil, errGraphQLParse
+		}
+		field, err := p.parseField()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, field)
+	}
+}
+
+// parseFragment parses a fragment spread (...Name) or inline fragment
+// (... [on Type] { ... }); the leading "..." has already been consumed.
+func (p *gqlParser) parseFragment(depth int) (selItem, error) {
+	nt := p.peek()
+	if nt.kind == tkName && nt.val != "on" {
+		p.next() // fragment name
+		if err := p.skipDirectives(); err != nil {
+			return selItem{}, err
+		}
+		return selItem{spread: nt.val}, nil
+	}
+	if nt.kind == tkName && nt.val == "on" {
+		p.next() // "on"
+		if p.peek().kind != tkName {
+			return selItem{}, errGraphQLParse
+		}
+		p.next() // type condition
+	}
+	if err := p.skipDirectives(); err != nil {
+		return selItem{}, err
+	}
+	inner, err := p.parseSelectionSet(depth + 1)
+	if err != nil {
+		return selItem{}, err
+	}
+	return selItem{inline: inner}, nil
+}
+
+// parseField parses [alias ":"] name [arguments] [directives] [selectionSet],
+// skipping arguments/directives and any nested selection set (only top-level
+// fields of the operation matter for root-field matching).
+func (p *gqlParser) parseField() (selItem, error) {
+	first := p.next().val
+	field := first
+	aliased := false
+	if p.isPunct(":") {
+		p.next()
+		if p.peek().kind != tkName {
+			return selItem{}, errGraphQLParse
+		}
+		field = p.next().val
+		aliased = true
+	}
+	if p.isPunct("(") {
+		if err := p.skipBalanced(); err != nil {
+			return selItem{}, err
+		}
+	}
+	if err := p.skipDirectives(); err != nil {
+		return selItem{}, err
+	}
+	if p.isPunct("{") {
+		if err := p.skipBalanced(); err != nil {
+			return selItem{}, err
+		}
+	}
+	return selItem{field: field, aliased: aliased}, nil
+}
+
+func parseGraphQLDocument(src string) ([]RequestOperation, error) {
+	toks, err := lexGraphQL(src)
+	if err != nil {
+		return nil, err
+	}
+	p := &gqlParser{toks: toks}
+	fragments := map[string][]selItem{}
+
+	type rawOp struct {
+		kind  string
+		name  string
+		items []selItem
+	}
+	var raws []rawOp
+
+	for !p.eof() {
+		t := p.peek()
+		if t.kind == tkPunct && t.val == "{" {
+			items, err := p.parseSelectionSet(0)
+			if err != nil {
+				return nil, err
+			}
+			raws = append(raws, rawOp{kind: gqlQuery, items: items})
+			continue
+		}
+		if t.kind != tkName {
+			return nil, errGraphQLParse
+		}
+		switch t.val {
+		case gqlQuery, gqlMutation, gqlSubscription:
+			kind := p.next().val
+			name := ""
+			if p.peek().kind == tkName {
+				name = p.next().val
+			}
+			if p.isPunct("(") { // variable definitions
+				if err := p.skipBalanced(); err != nil {
+					return nil, err
+				}
+			}
+			if err := p.skipDirectives(); err != nil {
+				return nil, err
+			}
+			items, err := p.parseSelectionSet(0)
+			if err != nil {
+				return nil, err
+			}
+			raws = append(raws, rawOp{kind: kind, name: name, items: items})
+		case "fragment":
+			p.next()
+			if p.peek().kind != tkName {
+				return nil, errGraphQLParse
+			}
+			fragName := p.next().val
+			if on := p.peek(); on.kind != tkName || on.val != "on" {
+				return nil, errGraphQLParse
+			}
+			p.next() // "on"
+			if p.peek().kind != tkName {
+				return nil, errGraphQLParse
+			}
+			p.next() // type condition
+			if err := p.skipDirectives(); err != nil {
+				return nil, err
+			}
+			items, err := p.parseSelectionSet(0)
+			if err != nil {
+				return nil, err
+			}
+			// Duplicate fragment names are spec-invalid, and servers disagree on
+			// whether the first or last definition wins. Fail closed rather than
+			// guess: a "last-wins" map would let a benign shadow fragment hide a
+			// dangerous first definition that a first-wins server executes.
+			if _, exists := fragments[fragName]; exists {
+				return nil, errGraphQLParse
+			}
+			fragments[fragName] = items
+		default:
+			return nil, errGraphQLParse
+		}
+	}
+
+	if len(raws) == 0 {
+		return nil, errGraphQLParse
+	}
+	ops := make([]RequestOperation, 0, len(raws))
+	for _, r := range raws {
+		fields, aliased, invalid := resolveRootFields(r.items, fragments)
+		if invalid {
+			return nil, errGraphQLParse
+		}
+		ops = append(ops, RequestOperation{Kind: r.kind, Name: r.name, RootFields: fields, Aliased: aliased})
+	}
+	return ops, nil
+}
+
+// resolveRootFields flattens a selection set into the field names that execute
+// at the operation root, expanding fragment spreads against the document's
+// fragments and inlining inline fragments. Unresolved spreads, fragment cycles,
+// and expansion-budget exhaustion make the document unclassifiable and are
+// reported to the caller so enforcement can fail closed.
+func resolveRootFields(items []selItem, fragments map[string][]selItem) (fields []string, aliased, invalid bool) {
+	count := 0
+	seen := map[string]bool{}
+	var walk func(items []selItem)
+	walk = func(items []selItem) {
+		for i := range items {
+			if invalid {
+				return
+			}
+			if count >= maxFragmentExpansion {
+				// Budget exhausted: signal invalid so the caller fails closed
+				// instead of returning a silently truncated field list that
+				// could drop a trailing dangerous field.
+				invalid = true
+				return
+			}
+			count++
+			it := items[i]
+			switch {
+			case it.field != "":
+				fields = append(fields, it.field)
+				if it.aliased {
+					aliased = true
+				}
+			case it.inline != nil:
+				walk(it.inline)
+			case it.spread != "":
+				if seen[it.spread] {
+					invalid = true
+					return
+				}
+				frag, ok := fragments[it.spread]
+				if !ok {
+					invalid = true
+					return
+				}
+				seen[it.spread] = true
+				walk(frag)
+				delete(seen, it.spread)
+			}
+		}
+	}
+	walk(items)
+	return fields, aliased, invalid
+}
+
+// --- predicate ---
+
+// gqlPredicate is the compiled form of a rule's GraphQL operation predicate.
+type gqlPredicate struct {
+	opTypes      map[string]struct{}
+	rootFieldRes []*regexp.Regexp
+}
+
+// compileGraphQLPredicate compiles a rule's GraphQL predicate, returning nil
+// when the rule has none. Patterns are validated at config load, so a compile
+// failure here is defense in depth.
+func compileGraphQLPredicate(g *config.RequestPolicyGraphQL) (*gqlPredicate, error) {
+	if g == nil {
+		return nil, nil
+	}
+	p := &gqlPredicate{}
+	if len(g.OperationTypes) > 0 {
+		p.opTypes = make(map[string]struct{}, len(g.OperationTypes))
+		for _, t := range g.OperationTypes {
+			p.opTypes[strings.ToLower(strings.TrimSpace(t))] = struct{}{}
+		}
+	}
+	for _, pat := range g.RootFieldPatterns {
+		re, err := regexp.Compile(pat)
+		if err != nil {
+			return nil, err
+		}
+		p.rootFieldRes = append(p.rootFieldRes, re)
+	}
+	return p, nil
+}
+
+// matches reports whether any operation satisfies the predicate. Every
+// operation is checked (never an early return on the first benign one) so a
+// dangerous operation cannot hide behind a harmless sibling in a multi-op
+// document or a batch.
+func (g *gqlPredicate) matches(ops []RequestOperation) bool {
+	for i := range ops {
+		op := ops[i]
+		if len(g.opTypes) > 0 {
+			if _, ok := g.opTypes[op.Kind]; !ok {
+				continue
+			}
+		}
+		if len(g.rootFieldRes) == 0 {
+			return true // operation-type-only predicate; kind matched
+		}
+		for _, f := range op.RootFields {
+			for _, re := range g.rootFieldRes {
+				if re.MatchString(f) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/internal/reqpolicy/graphql_test.go
+++ b/internal/reqpolicy/graphql_test.go
@@ -147,7 +147,7 @@ func TestExtractGraphQL_Evasions(t *testing.T) {
 	t.Run("json unicode-escaped field name decodes and is caught", func(t *testing.T) {
 		// The JSON layer decodes d -> 'd' before the GraphQL lexer sees it,
 		// so the real field name surfaces.
-		body := []byte(`{"query":"mutation { deleteRecord }"}`)
+		body := []byte(`{"query":"mutation { \u0064eleteRecord }"}`)
 		ops, ok, opaque := ExtractGraphQL(body)
 		if !ok || opaque {
 			t.Fatalf("expected parseOK non-opaque, got ok=%v opaque=%v", ok, opaque)

--- a/internal/reqpolicy/graphql_test.go
+++ b/internal/reqpolicy/graphql_test.go
@@ -1,0 +1,395 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package reqpolicy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// gqlBody wraps a query string in the GraphQL-over-HTTP JSON envelope.
+func gqlBody(t *testing.T, query string) []byte {
+	t.Helper()
+	b, err := json.Marshal(map[string]string{"query": query})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+func extractQuery(t *testing.T, query string) []RequestOperation {
+	t.Helper()
+	ops, parseOK, opaque := ExtractGraphQL(gqlBody(t, query))
+	if !parseOK {
+		t.Fatalf("query %q: expected parseOK, got parse error", query)
+	}
+	if opaque {
+		t.Fatalf("query %q: unexpected opaque", query)
+	}
+	return ops
+}
+
+func hasField(ops []RequestOperation, field string) bool {
+	for _, op := range ops {
+		for _, f := range op.RootFields {
+			if f == field {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestExtractGraphQL_RootFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantKind   string
+		wantFields []string
+		wantAlias  bool
+	}{
+		{"simple mutation", `mutation { deleteRecord(id: 1) { id } }`, gqlMutation, []string{"deleteRecord"}, false},
+		{"alias resolves to real field", `mutation { x: deleteRecord(id: 1) { id } }`, gqlMutation, []string{"deleteRecord"}, true},
+		{"shorthand query", `{ viewer { id } }`, gqlQuery, []string{"viewer"}, false},
+		{"named query", `query Me { viewer { id } }`, gqlQuery, []string{"viewer"}, false},
+		{"subscription", `subscription { recordUpdated { id } }`, gqlSubscription, []string{"recordUpdated"}, false},
+		{"multiple root fields", `mutation { a b c }`, gqlMutation, []string{"a", "b", "c"}, false},
+		{"args with nested object braces", `mutation { createNote(input: {body: "x", tags: ["a"]}) { id } }`, gqlMutation, []string{"createNote"}, false},
+		{"variables and directives skipped", `mutation Op($id: ID!) @dir(x: 1) { deleteRecord(id: $id) @include(if: true) { id } }`, gqlMutation, []string{"deleteRecord"}, false},
+		{"keyword-shaped field name stays a query", `query { mutationLog { id } }`, gqlQuery, []string{"mutationLog"}, false},
+		{"comma whitespace tolerant", `mutation{,a,,b,}`, gqlMutation, []string{"a", "b"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ops := extractQuery(t, tc.query)
+			if len(ops) != 1 {
+				t.Fatalf("want 1 op, got %d (%+v)", len(ops), ops)
+			}
+			op := ops[0]
+			if op.Kind != tc.wantKind {
+				t.Errorf("kind = %q, want %q", op.Kind, tc.wantKind)
+			}
+			if strings.Join(op.RootFields, ",") != strings.Join(tc.wantFields, ",") {
+				t.Errorf("root fields = %v, want %v", op.RootFields, tc.wantFields)
+			}
+			if op.Aliased != tc.wantAlias {
+				t.Errorf("aliased = %v, want %v", op.Aliased, tc.wantAlias)
+			}
+		})
+	}
+}
+
+// The core evasion cases: a dangerous root field must be discoverable no matter
+// how it is wrapped, while a keyword that only appears inside a string, comment,
+// or argument value must NOT be reported as a root field.
+func TestExtractGraphQL_Evasions(t *testing.T) {
+	t.Run("fragment spread hides root field", func(t *testing.T) {
+		ops := extractQuery(t, `mutation { ...f } fragment f on Mutation { deleteRecord(id: 1) { id } }`)
+		if !hasField(ops, "deleteRecord") {
+			t.Fatalf("deleteRecord hidden in fragment not surfaced: %+v", ops)
+		}
+	})
+	t.Run("inline fragment at root", func(t *testing.T) {
+		ops := extractQuery(t, `mutation { ... on Mutation { deleteRecord } }`)
+		if !hasField(ops, "deleteRecord") {
+			t.Fatalf("deleteRecord in inline fragment not surfaced: %+v", ops)
+		}
+	})
+	t.Run("nested fragment chain", func(t *testing.T) {
+		ops := extractQuery(t, `mutation { ...a } fragment a on M { ...b } fragment b on M { deleteRecord }`)
+		if !hasField(ops, "deleteRecord") {
+			t.Fatalf("deleteRecord in nested fragment not surfaced: %+v", ops)
+		}
+	})
+	t.Run("multi-op dangerous sibling surfaced", func(t *testing.T) {
+		ops := extractQuery(t, `query Safe { viewer { id } } mutation Bad { deleteRecord }`)
+		if len(ops) != 2 || !hasField(ops, "deleteRecord") {
+			t.Fatalf("dangerous sibling op not surfaced: %+v", ops)
+		}
+	})
+	t.Run("keyword in block string is not a field", func(t *testing.T) {
+		ops := extractQuery(t, `mutation { createNote(body: """please deleteRecord everything""") { id } }`)
+		if hasField(ops, "deleteRecord") {
+			t.Fatalf("block-string content leaked as field: %+v", ops)
+		}
+		if !hasField(ops, "createNote") {
+			t.Fatalf("createNote field missing: %+v", ops)
+		}
+	})
+	t.Run("keyword in line comment is not a field", func(t *testing.T) {
+		ops := extractQuery(t, "mutation {\n  # deleteRecord here\n  createNote { id }\n}")
+		if hasField(ops, "deleteRecord") {
+			t.Fatalf("comment content leaked as field: %+v", ops)
+		}
+	})
+	t.Run("keyword in argument string is not a field", func(t *testing.T) {
+		ops := extractQuery(t, `mutation { createNote(text: "deleteRecord") { id } }`)
+		if hasField(ops, "deleteRecord") {
+			t.Fatalf("argument string leaked as field: %+v", ops)
+		}
+	})
+	t.Run("brace inside string does not break selection", func(t *testing.T) {
+		ops := extractQuery(t, `mutation { createNote(body: "}{ deleteRecord }{") { id } }`)
+		if hasField(ops, "deleteRecord") || !hasField(ops, "createNote") {
+			t.Fatalf("string-embedded braces broke parsing: %+v", ops)
+		}
+	})
+	t.Run("BOM prefix tolerated", func(t *testing.T) {
+		ops := extractQuery(t, "\ufeffmutation { deleteRecord }")
+		if !hasField(ops, "deleteRecord") {
+			t.Fatalf("BOM-prefixed query not parsed: %+v", ops)
+		}
+	})
+	t.Run("json unicode-escaped field name decodes and is caught", func(t *testing.T) {
+		// The JSON layer decodes d -> 'd' before the GraphQL lexer sees it,
+		// so the real field name surfaces.
+		body := []byte(`{"query":"mutation { deleteRecord }"}`)
+		ops, ok, opaque := ExtractGraphQL(body)
+		if !ok || opaque {
+			t.Fatalf("expected parseOK non-opaque, got ok=%v opaque=%v", ok, opaque)
+		}
+		if !hasField(ops, "deleteRecord") {
+			t.Fatalf("json-unicode-escaped field not surfaced: %+v", ops)
+		}
+	})
+}
+
+func TestExtractGraphQL_Batch(t *testing.T) {
+	body := []byte(`[{"query":"query { viewer { id } }"},{"query":"mutation { deleteRecord }"}]`)
+	ops, ok, opaque := ExtractGraphQL(body)
+	if !ok || opaque {
+		t.Fatalf("batch: ok=%v opaque=%v", ok, opaque)
+	}
+	if len(ops) != 2 || !hasField(ops, "deleteRecord") {
+		t.Fatalf("batch did not surface all operations: %+v", ops)
+	}
+}
+
+func TestExtractGraphQL_OpaqueAndParseError(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantParseOK bool
+		wantOpaque  bool
+	}{
+		{"apq hash only", `{"extensions":{"persistedQuery":{"version":1,"sha256Hash":"abc"}}}`, true, true},
+		{"empty query string", `{"query":""}`, true, true},
+		{"whitespace query", `{"query":"   "}`, true, true},
+		{"unterminated selection", `{"query":"mutation { deleteRecord "}`, false, false},
+		{"unterminated string", `{"query":"mutation { x(a: \"oops) { id } }"}`, false, false},
+		{"graphql-level backslash escape fails closed", `{"query":"mutation { \\u0064eleteJob }"}`, false, false},
+		{"invalid json", `not json at all`, false, false},
+		{"empty body", ``, false, false},
+		{"json number top level", `42`, false, false},
+		{"stray top-level token", `{"query":"mutation deleteRecord"}`, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, parseOK, opaque := ExtractGraphQL([]byte(tc.body))
+			if parseOK != tc.wantParseOK || opaque != tc.wantOpaque {
+				t.Fatalf("ExtractGraphQL(%s) = parseOK %v, opaque %v; want %v, %v",
+					tc.body, parseOK, opaque, tc.wantParseOK, tc.wantOpaque)
+			}
+		})
+	}
+}
+
+// Regression: a duplicate fragment name must fail closed. A "last-wins" map
+// would let a benign shadow fragment hide a dangerous first definition that a
+// first-wins server (e.g. graphql-js) executes.
+func TestExtractGraphQL_DuplicateFragmentFailsClosed(t *testing.T) {
+	q := `mutation { ...f } fragment f on M { deleteRecord } fragment f on M { safeField }`
+	if _, parseOK, _ := ExtractGraphQL(gqlBody(t, q)); parseOK {
+		t.Fatal("duplicate fragment names must fail closed, not resolve last-wins")
+	}
+}
+
+// Regression: exhausting the fragment-expansion budget with benign fields must
+// fail closed, not silently truncate and drop a trailing dangerous field.
+func TestExtractGraphQL_ExpansionCapFailsClosed(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("mutation {")
+	for i := 0; i < maxFragmentExpansion+10; i++ {
+		b.WriteString(" f")
+	}
+	b.WriteString(" deleteRecord }")
+	if _, parseOK, _ := ExtractGraphQL(gqlBody(t, b.String())); parseOK {
+		t.Fatal("expansion-cap exhaustion must fail closed")
+	}
+}
+
+func TestExtractGraphQL_CyclicFragmentFailsClosed(t *testing.T) {
+	// Fragment cycles are spec-invalid. Fail closed rather than partially
+	// classifying a graph whose execution semantics depend on server behavior.
+	if _, parseOK, _ := ExtractGraphQL(gqlBody(t, `mutation { ...a } fragment a on M { ...b } fragment b on M { ...a deleteRecord }`)); parseOK {
+		t.Fatal("cyclic fragments must fail closed")
+	}
+}
+
+func TestExtractGraphQL_DeepNestingFailsClosed(t *testing.T) {
+	// Nested inline fragments recurse the selection-set parser, so exceeding
+	// the depth cap must fail closed. (Nested field selection sets are skipped
+	// by brace-balancing and are bounded by the token cap instead.)
+	n := maxSelectionDepth + 5
+	q := "mutation {" + strings.Repeat(" ... on T {", n) + " deleteRecord" + strings.Repeat(" }", n) + " }"
+	_, parseOK, _ := ExtractGraphQL(gqlBody(t, q))
+	if parseOK {
+		t.Fatal("excessively nested inline fragments should fail closed")
+	}
+}
+
+// End-to-end: a rule with a GraphQL predicate blocks a dangerous mutation and
+// allows a benign query, matching every operation in a multi-op document.
+func TestExtractGraphQL_ParserCoverage(t *testing.T) {
+	ok := []struct{ name, query, field string }{
+		{"escaped quote in arg string", `mutation { createNote(t: "a\"b") { id } }`, "createNote"},
+		{"escaped triple quote in block string", `mutation { createNote(t: """a\"""b""") { id } }`, "createNote"},
+		{"bare directives on op and field", `mutation @auth { deleteRecord @foo }`, "deleteRecord"},
+		{"fragment with directive", `mutation { ...f } fragment f on M @dir { deleteRecord }`, "deleteRecord"},
+		{"inline fragment without type condition", `query { ... { viewer } }`, "viewer"},
+		{"list argument balanced", `mutation { setTags(ids: [1, 2, 3]) { id } }`, "setTags"},
+		{"spread with directive", `query { ...f @include(if: true) } fragment f on Q { viewer }`, "viewer"},
+		{"multiple directives on op", `mutation @a @b { deleteRecord }`, "deleteRecord"},
+	}
+	for _, tc := range ok {
+		t.Run(tc.name, func(t *testing.T) {
+			if ops := extractQuery(t, tc.query); !hasField(ops, tc.field) {
+				t.Fatalf("expected field %q in %+v", tc.field, ops)
+			}
+		})
+	}
+
+	bad := []struct{ name, query string }{
+		{"unterminated block string", `mutation { x(a: """oops) }`},
+		{"unclosed arguments to EOF", `mutation { x(a: 1`},
+		{"alias without field name", `mutation { x: }`},
+		{"directive without name", `mutation { x @ }`},
+		{"string with raw newline", "mutation { x(a: \"line\nmore\") }"},
+		{"unknown top-level keyword", `frag x on Y { a }`},
+		{"lone dot not ellipsis", `query { a.b }`},
+		{"fragment missing name", `query { a } fragment { b }`},
+		{"fragment missing on keyword", `query { a } fragment f X { b }`},
+		{"fragment missing type condition", `query { a } fragment f on { b }`},
+		{"empty operation selection", `query { }`},
+		{"empty inline fragment selection", `query { ... on T { } }`},
+		{"mismatched argument brackets", `mutation { safe(arg: [1, 2}) deleteRecord }`},
+		{"document is only a comment", `# nothing here`},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, parseOK, _ := ExtractGraphQL(gqlBody(t, tc.query)); parseOK {
+				t.Fatalf("expected parse error for %q", tc.query)
+			}
+		})
+	}
+
+	t.Run("batch with parse-error element fails closed", func(t *testing.T) {
+		body := []byte(`[{"query":"query { a }"},{"query":"mutation { "}]`)
+		if _, parseOK, _ := ExtractGraphQL(body); parseOK {
+			t.Fatal("batch with a malformed element must fail closed")
+		}
+	})
+	t.Run("batch with opaque element marks opaque but surfaces the rest", func(t *testing.T) {
+		body := []byte(`[{"query":"mutation { deleteRecord }"},{"operationName":"x"}]`)
+		ops, parseOK, opaque := ExtractGraphQL(body)
+		if !parseOK || !opaque {
+			t.Fatalf("batch opaque element: parseOK=%v opaque=%v", parseOK, opaque)
+		}
+		if !hasField(ops, "deleteRecord") {
+			t.Fatalf("good element ops missing: %+v", ops)
+		}
+	})
+	t.Run("empty batch fails closed", func(t *testing.T) {
+		if _, parseOK, _ := ExtractGraphQL([]byte(`[]`)); parseOK {
+			t.Fatal("empty batch should fail closed")
+		}
+	})
+	t.Run("malformed batch element type fails closed", func(t *testing.T) {
+		if _, parseOK, _ := ExtractGraphQL([]byte(`[{"query":123}]`)); parseOK {
+			t.Fatal("non-string query should fail closed")
+		}
+	})
+	t.Run("unknown fragment spread fails closed", func(t *testing.T) {
+		if _, parseOK, _ := ExtractGraphQL(gqlBody(t, `query { ...doesNotExist }`)); parseOK {
+			t.Fatal("unknown spread should fail closed")
+		}
+	})
+}
+
+func TestNewMatcher_BadGraphQLPattern(t *testing.T) {
+	// Defense in depth: NewMatcher recompiles the predicate even though config
+	// validation already rejects a bad pattern upstream.
+	_, err := NewMatcher(&config.RequestPolicy{Enabled: true, Rules: []config.RequestPolicyRule{{
+		Name:    "bad",
+		Action:  config.ActionBlock,
+		Route:   config.RequestPolicyRoute{Hosts: []string{"api.example.com"}},
+		GraphQL: &config.RequestPolicyGraphQL{RootFieldPatterns: []string{"("}},
+	}}})
+	if err == nil {
+		t.Fatal("expected error for invalid graphql root_field_pattern")
+	}
+}
+
+func TestMatcher_GraphQLPredicate(t *testing.T) {
+	m, err := NewMatcher(&config.RequestPolicy{Enabled: true, Rules: []config.RequestPolicyRule{{
+		Name:   "block-destructive-mutations",
+		Action: config.ActionBlock,
+		Route:  config.RequestPolicyRoute{Hosts: []string{"api.example.com"}},
+		GraphQL: &config.RequestPolicyGraphQL{
+			OperationTypes:    []string{gqlMutation},
+			RootFieldPatterns: []string{`(?i)(delete|destroy|archive)`},
+		},
+	}}})
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+
+	block := func(q string) Decision {
+		return m.Evaluate(RequestMeta{Host: "api.example.com", Method: "POST", Operations: extractQuery(t, q)})
+	}
+
+	if d := block(`mutation { deleteRecord(id: 1) { id } }`); !d.Enforced() || d.Action != config.ActionBlock {
+		t.Fatalf("destructive mutation not blocked: %+v", d)
+	}
+	if d := block(`mutation { x: archiveAccount { id } }`); !d.Enforced() {
+		t.Fatalf("aliased destructive mutation not blocked: %+v", d)
+	}
+	if d := block(`query { viewer { id } }`); d.Matched() {
+		t.Fatalf("benign query should not match: %+v", d)
+	}
+	if d := block(`mutation { updateProfile(name: "x") { id } }`); d.Matched() {
+		t.Fatalf("non-destructive mutation should not match: %+v", d)
+	}
+	// Multi-op: a benign query alongside a destructive mutation must still block.
+	if d := block(`query Safe { viewer } mutation Bad { deleteRecord }`); !d.Enforced() {
+		t.Fatalf("destructive op in multi-op document not blocked: %+v", d)
+	}
+	// No operations (e.g. opaque/non-GraphQL) => predicate does not match.
+	if d := m.Evaluate(RequestMeta{Host: "api.example.com", Method: "POST"}); d.Matched() {
+		t.Fatalf("empty operations should not match graphql predicate: %+v", d)
+	}
+}
+
+func TestMatcher_GraphQLOperationTypeOnly(t *testing.T) {
+	m, err := NewMatcher(&config.RequestPolicy{Enabled: true, Rules: []config.RequestPolicyRule{{
+		Name:    "warn-all-mutations",
+		Action:  config.ActionWarn,
+		Route:   config.RequestPolicyRoute{Hosts: []string{"api.example.com"}},
+		GraphQL: &config.RequestPolicyGraphQL{OperationTypes: []string{gqlMutation}},
+	}}})
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+	d := m.Evaluate(RequestMeta{Host: "api.example.com", Operations: extractQuery(t, `mutation { anything }`)})
+	if d.Action != config.ActionWarn {
+		t.Fatalf("operation-type-only predicate should warn on any mutation: %+v", d)
+	}
+	d = m.Evaluate(RequestMeta{Host: "api.example.com", Operations: extractQuery(t, `query { viewer }`)})
+	if d.Matched() {
+		t.Fatalf("query should not match a mutation-only predicate: %+v", d)
+	}
+}

--- a/internal/reqpolicy/policy.go
+++ b/internal/reqpolicy/policy.go
@@ -44,6 +44,12 @@ type RequestMeta struct {
 	Method      string // effective HTTP method, uppercased
 	Path        string // normalized request path
 	ContentType string // media type only, lowercased, parameters stripped
+	// Operations are the request's extracted API operations (e.g. via
+	// ExtractGraphQL). A GraphQL rule predicate evaluates against these; an
+	// empty slice means no inspectable operations, so a GraphQL predicate does
+	// not match (fail-closed handling of parse errors / opaque requests is the
+	// caller's responsibility, driven by on_parse_error / on_opaque_operation).
+	Operations []RequestOperation
 }
 
 // Decision is the outcome of evaluating request policy against a request.
@@ -72,6 +78,7 @@ type compiledRule struct {
 	pathPrefixes []string
 	pathPatterns []*regexp.Regexp
 	contentTypes map[string]struct{}
+	graphql      *gqlPredicate
 }
 
 // Matcher holds the precompiled request_policy ruleset. Build one with
@@ -131,6 +138,11 @@ func NewMatcher(cfg *config.RequestPolicy) (*Matcher, error) {
 				cr.contentTypes[NormalizeContentType(ct)] = struct{}{}
 			}
 		}
+		pred, err := compileGraphQLPredicate(r.GraphQL)
+		if err != nil {
+			return nil, fmt.Errorf("request_policy rule %q: invalid graphql predicate: %w", r.Name, err)
+		}
+		cr.graphql = pred
 		m.rules = append(m.rules, cr)
 	}
 	return m, nil
@@ -198,6 +210,9 @@ func (cr *compiledRule) matches(meta RequestMeta) bool {
 		if _, ok := cr.contentTypes[NormalizeContentType(meta.ContentType)]; !ok {
 			return false
 		}
+	}
+	if cr.graphql != nil && !cr.graphql.matches(meta.Operations) {
+		return false
 	}
 	return true
 }


### PR DESCRIPTION
Adds a GraphQL operation extractor to request_policy so a rule can match on GraphQL operation type and root fields, not just route. Builds on the request_policy engine (already merged). This is the extractor plus the matcher predicate plus the fail-closed config knobs; transport wiring lands separately, so it changes no runtime traffic behavior yet.

- ExtractGraphQL parses GraphQL-over-HTTP JSON (single object or batched array) into operations: kind, name, and resolved root fields. Aliases resolve to the real field, and top-level fragment spreads and inline fragments are expanded, so a deny rule matches the field that actually executes rather than a cosmetic alias or a field hidden in a fragment.
- Fails closed on parse errors, opaque requests (persisted-query / no inline query), duplicate fragment names, unresolved or cyclic fragment spreads, empty selection sets, mismatched bracket groups, and expansion-budget exhaustion.
- request_policy gains on_parse_error and on_opaque_operation actions (block by default) for unreadable operations. A rule gains an optional graphql predicate (operation_types plus root_field_patterns); the matcher evaluates every operation in a document or batch and never short-circuits on a benign one.
- Validation rejects vacuous predicates, invalid operation types, invalid or empty root-field patterns, and invalid parse/opaque actions.

Dependency-free: a small hand-written lexer/parser, no GraphQL library added.

The request_policy parse/opaque actions are policy semantics, so they join the canonical policy hash; the golden hashes are bumped accordingly.

Tested against the bypass matrix (alias, fragment spread/inline/nested/cyclic, multi-op, directives, string/block-string/comment boundaries, brackets-in-strings, batch, persisted-query/opaque, parse-error fail-closed) plus validation. New-code coverage about 96%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New request-policy options: on_parse_error and on_opaque_operation (default to block).
  * GraphQL operation predicates for request policies: match by operation type and root-field patterns.

* **Behavior & Validation**
  * Validation and warnings updated for GraphQL rules and host/TLS visibility scenarios.
  * ApplyDefaults now ensures failure-action defaults are populated.

* **Tests**
  * Expanded tests covering GraphQL parsing, matching, validation, and visibility warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->