### PR TITLE
feat(proxy): enforce request_policy across transports

### DIFF
--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -606,6 +606,8 @@ func (s *Server) Start(ctx context.Context) error {
 		rpHandler.SetReceiptEmitter(s.proxy.ReceiptEmitterPtr())
 		rpHandler.SetContractLoader(s.proxy.ContractLoaderPtr())
 		rpHandler.SetReloadLock(s.proxy.ReloadLock())
+		rpHandler.SetRequestPolicyFn(s.proxy.ApplyRequestPolicy)
+		rpHandler.SetRequestPolicyPrepareFn(s.proxy.PrepareRequestPolicyBody)
 		rpHandler.SetRedactionRuntimePtr(s.proxy.RedactionRuntimePtr())
 		// Submit profile dials through the SSRF-safe dial path (resolve +
 		// validate every IP against internal CIDRs before connecting),

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -78,6 +78,9 @@ type Metrics struct {
 	airlockDrainCompleted prometheus.Counter
 	airlockDrainTimeout   prometheus.Counter
 
+	// Request policy operation safety rails (requestpolicy.go).
+	requestPolicyDecisions *prometheus.CounterVec
+
 	// Cross-request exfiltration detection (cross_request.go).
 	CrossRequestEntropyExceeded prometheus.Counter
 	CrossRequestDLPMatch        prometheus.Counter
@@ -183,6 +186,7 @@ func New() *Metrics {
 	m.registerSessionMetrics(reg)
 	m.registerTLSMetrics(reg)
 	m.registerAirlockMetrics(reg)
+	m.registerRequestPolicyMetrics(reg)
 	m.registerCrossRequestMetrics(reg)
 	m.registerScanAPIMetrics(reg)
 	m.registerKillSwitchMetrics(reg)

--- a/internal/metrics/requestpolicy.go
+++ b/internal/metrics/requestpolicy.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// registerRequestPolicyMetrics builds and registers the request_policy
+// decision counter. Labels are deliberately limited to the matched rule name
+// and the rule's action so cardinality stays bounded — never the request host,
+// operation name, or any attacker-influenced value.
+func (m *Metrics) registerRequestPolicyMetrics(reg *prometheus.Registry) {
+	m.requestPolicyDecisions = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "pipelock",
+		Name:      "request_policy_decisions_total",
+		Help:      "Total request_policy rule matches, by rule name and action.",
+	}, []string{"rule", "action"})
+
+	reg.MustRegister(m.requestPolicyDecisions)
+}
+
+// RecordRequestPolicyDecision increments the request_policy decision counter
+// for a matched rule. rule is the bounded, operator-defined rule name; action
+// is the rule's configured action (block or warn). Shadow matches are counted
+// the same as enforced ones — the shadow vs enforced distinction lives in the
+// audit log, not in metric cardinality.
+func (m *Metrics) RecordRequestPolicyDecision(rule, action string) {
+	if m == nil {
+		return
+	}
+	m.requestPolicyDecisions.WithLabelValues(rule, action).Inc()
+}

--- a/internal/metrics/requestpolicy.go
+++ b/internal/metrics/requestpolicy.go
@@ -25,7 +25,9 @@ func (m *Metrics) registerRequestPolicyMetrics(reg *prometheus.Registry) {
 // the same as enforced ones — the shadow vs enforced distinction lives in the
 // audit log, not in metric cardinality.
 func (m *Metrics) RecordRequestPolicyDecision(rule, action string) {
-	if m == nil {
+	// Guard the counter vec too: a zero-value &Metrics{} (no registry) leaves
+	// it nil, and this helper is documented nil-safe.
+	if m == nil || m.requestPolicyDecisions == nil {
 		return
 	}
 	m.requestPolicyDecisions.WithLabelValues(rule, action).Inc()

--- a/internal/metrics/requestpolicy_test.go
+++ b/internal/metrics/requestpolicy_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecordRequestPolicyDecision(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.RecordRequestPolicyDecision("destructive-mutations", "block")
+	m.RecordRequestPolicyDecision("destructive-mutations", "block")
+	m.RecordRequestPolicyDecision("outbound-send", "warn")
+
+	if got := testutil.ToFloat64(m.requestPolicyDecisions.WithLabelValues("destructive-mutations", "block")); got != 2 {
+		t.Errorf("block count = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(m.requestPolicyDecisions.WithLabelValues("outbound-send", "warn")); got != 1 {
+		t.Errorf("warn count = %v, want 1", got)
+	}
+}
+
+func TestRecordRequestPolicyDecision_NilSafe(t *testing.T) {
+	t.Parallel()
+	var m *Metrics
+	// Must not panic on a nil Metrics (matches the other Record* helpers).
+	m.RecordRequestPolicyDecision("rule", "block")
+}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -427,6 +427,28 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// request_policy runs before the contract gate so a contract allow can
+	// never suppress an operation-policy block.
+	connectRPInput := requestPolicyInput{
+		Host:        host,
+		Method:      http.MethodConnect,
+		Path:        "/",
+		ContentType: "",
+		Headers:     r.Header,
+		BodyRead:    true,
+		Transport:   TransportConnect,
+		Target:      syntheticURL,
+		RequestID:   requestID,
+		Agent:       agent,
+		AuditCtx:    targetCtx,
+		Emit:        p.emitReceipt,
+	}
+	if rp := p.applyRequestPolicy(connectRPInput); rp.Block {
+		p.metrics.RecordTunnelBlocked(agentLabel)
+		writeBlockedError(w, rp.Info, "CONNECT blocked by request policy: "+rp.Reason, http.StatusForbidden)
+		return
+	}
+
 	killSwitchActive := false
 	if p.ks != nil {
 		killSwitchActive = p.ks.IsActiveHTTP(r).Active
@@ -1419,6 +1441,34 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 				"blocked: "+ceeRes.Reason, http.StatusForbidden)
 			return
 		}
+	}
+
+	// request_policy runs before the contract gate so a contract allow can
+	// never suppress an operation-policy block.
+	rpInput := requestPolicyInput{
+		Host:        r.URL.Hostname(),
+		Method:      r.Method,
+		Path:        r.URL.EscapedPath(),
+		ContentType: r.Header.Get(headerContentType),
+		Headers:     r.Header,
+		Body:        forwardBodyBytes,
+		BodyRead:    forwardBodyBytes != nil || r.Body == nil || r.Body == http.NoBody,
+		Transport:   TransportForward,
+		Target:      targetURL,
+		RequestID:   requestID,
+		Agent:       agent,
+		AuditCtx:    actx,
+		Emit:        p.emitReceipt,
+	}
+	if rp := p.prepareRequestPolicyBody(r, &rpInput); rp.Block {
+		p.metrics.RecordBlocked(r.URL.Hostname(), blockLayerRequestPolicy, time.Since(start), agentLabel)
+		writeBlockedError(w, rp.Info, "blocked by request policy: "+rp.Reason, http.StatusForbidden)
+		return
+	}
+	if rp := p.applyRequestPolicy(rpInput); rp.Block {
+		p.metrics.RecordBlocked(r.URL.Hostname(), blockLayerRequestPolicy, time.Since(start), agentLabel)
+		writeBlockedError(w, rp.Info, "blocked by request policy: "+rp.Reason, http.StatusForbidden)
+		return
 	}
 
 	killSwitchActive := false

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -1140,6 +1140,36 @@ func newInterceptHandler(
 			return
 		}
 
+		// request_policy runs before the contract gate so a contract allow can
+		// never suppress an operation-policy block.
+		if ic.Proxy != nil {
+			rpInput := requestPolicyInput{
+				Host:        r.URL.Hostname(),
+				Method:      r.Method,
+				Path:        r.URL.EscapedPath(),
+				ContentType: r.Header.Get(headerContentType),
+				Headers:     r.Header,
+				Body:        interceptBodyBytes,
+				BodyRead:    interceptBodyBytes != nil || r.Body == nil || r.Body == http.NoBody,
+				Transport:   "intercept",
+				Target:      targetURL,
+				RequestID:   ic.RequestID,
+				Agent:       ic.Agent,
+				AuditCtx:    actx,
+				Emit:        func(o receipt.EmitOpts) { interceptEmitReceipt(ic, o) },
+			}
+			if rp := ic.Proxy.prepareRequestPolicyBody(r, &rpInput); rp.Block {
+				ic.Metrics.RecordTLSRequestBlocked(blockLayerRequestPolicy)
+				writeBlockedError(w, rp.Info, "blocked by request policy: "+rp.Reason, http.StatusForbidden)
+				return
+			}
+			if rp := ic.Proxy.applyRequestPolicy(rpInput); rp.Block {
+				ic.Metrics.RecordTLSRequestBlocked(blockLayerRequestPolicy)
+				writeBlockedError(w, rp.Info, "blocked by request policy: "+rp.Reason, http.StatusForbidden)
+				return
+			}
+		}
+
 		gate, gateErr := EvaluateGate(ContractGateInput{
 			Loader:          interceptContractLoader(ic),
 			Agent:           ic.Agent,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3616,19 +3616,21 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 
 	// request_policy runs before the contract gate so a contract allow can
 	// never suppress an operation-policy block.
+	// The outbound fetch is always a fixed plain GET with pipelock's own
+	// headers; the agent's inbound /fetch control-plane headers (Content-Type,
+	// X-HTTP-Method-Override) never reach the upstream, so they must not drive
+	// request_policy matching. Leave Headers/ContentType unset.
 	if rpRes := p.applyRequestPolicy(requestPolicyInput{
-		Host:        parsed.Hostname(),
-		Method:      http.MethodGet,
-		Path:        parsed.EscapedPath(),
-		ContentType: r.Header.Get(headerContentType),
-		Headers:     r.Header,
-		BodyRead:    true,
-		Transport:   TransportFetch,
-		Target:      displayURL,
-		RequestID:   requestID,
-		Agent:       agent,
-		AuditCtx:    actx,
-		Emit:        p.emitReceipt,
+		Host:      parsed.Hostname(),
+		Method:    http.MethodGet,
+		Path:      parsed.EscapedPath(),
+		BodyRead:  true,
+		Transport: TransportFetch,
+		Target:    displayURL,
+		RequestID: requestID,
+		Agent:     agent,
+		AuditCtx:  actx,
+		Emit:      p.emitReceipt,
 	}); rpRes.Block {
 		p.metrics.RecordBlocked(parsed.Hostname(), blockLayerRequestPolicy, time.Since(start), agentLabel)
 		writeBlockedJSON(w, rpRes.Info, http.StatusForbidden, FetchResponse{

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -45,6 +45,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
+	"github.com/luckyPipewrench/pipelock/internal/reqpolicy"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	"github.com/luckyPipewrench/pipelock/internal/session"
 	"github.com/luckyPipewrench/pipelock/internal/shield"
@@ -216,6 +217,12 @@ func redirectBlockedInfo(blockedErr *blockedRequestError) blockreason.Info {
 			return info
 		}
 	}
+	// A request_policy block on a redirect hop must surface its own reason
+	// code (and policy retry hint), not the generic redirect_scan_denied — the
+	// layer header alone would otherwise misreport the enforcing layer.
+	if blockedErr != nil && blockedErr.layer == blockLayerRequestPolicy {
+		return blockInfoFor(blockreason.RequestPolicyDeny, "")
+	}
 	layer := ""
 	if blockedErr != nil {
 		layer = blockedErr.layer
@@ -310,6 +317,7 @@ type Proxy struct {
 	fragmentBufferPtr   atomic.Pointer[scanner.FragmentBuffer] // nil when fragment reassembly disabled
 	redactionRuntimePtr atomic.Pointer[redactionRuntime]       // nil when redaction disabled
 	redactMatcherPtr    atomic.Pointer[redact.Matcher]         // nil when redaction disabled
+	reqPolicyPtr        atomic.Pointer[reqpolicy.Matcher]      // nil when request_policy disabled
 	contractLoaderPtr   atomic.Pointer[contractruntime.Loader] // nil when learn_lock is disabled
 	logger              *audit.Logger
 	metrics             *metrics.Metrics
@@ -523,6 +531,10 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 		return nil, err
 	}
 
+	if err := p.setupRequestPolicy(cfg); err != nil {
+		return nil, err
+	}
+
 	// Create session admin API handler when an API token is configured.
 	// Mirrors the kill switch env-var override: PIPELOCK_KILLSWITCH_API_TOKEN
 	// takes precedence over the YAML value.
@@ -625,6 +637,26 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 				logger.LogAnomaly(actx, result.Scanner, fmt.Sprintf("redirect from %s: %s", originalURL, result.Reason), result.Score)
 			}
 			scannerMatched := !result.Allowed
+
+			// request_policy runs before the contract gate so a contract
+			// allow can never suppress an operation-policy block.
+			if rpRes := p.applyRequestPolicy(requestPolicyInput{
+				Host:        req.URL.Hostname(),
+				Method:      req.Method,
+				Path:        req.URL.EscapedPath(),
+				ContentType: req.Header.Get(headerContentType),
+				Headers:     req.Header,
+				BodyRead:    false,
+				Transport:   redirectTransport,
+				Target:      redirectURL,
+				RequestID:   requestID,
+				Agent:       agentName,
+				AuditCtx:    newHTTPAuditContext(logger, req.Method, redirectURL, clientIP, requestID, agentName),
+				Emit:        p.emitReceipt,
+			}); rpRes.Block {
+				return newRedirectBlockedRequest(blockLayerRequestPolicy, rpRes.Reason)
+			}
+
 			contractLoader, _ := req.Context().Value(ctxKeyAgentContractLoader).(*contractruntime.Loader)
 			if contractLoader == nil {
 				contractLoader = p.currentContractLoader()
@@ -1209,6 +1241,19 @@ func (p *Proxy) RedactMatcherPtr() *atomic.Pointer[redact.Matcher] {
 	return &p.redactMatcherPtr
 }
 
+// ApplyRequestPolicy exposes the request_policy evaluation for use by
+// independently constructed handlers (e.g. ReverseProxyHandler) that
+// cannot call the unexported method directly.
+func (p *Proxy) ApplyRequestPolicy(in requestPolicyInput) requestPolicyResult {
+	return p.applyRequestPolicy(in)
+}
+
+// PrepareRequestPolicyBody reads and re-wraps a request body when an
+// operation predicate needs it and no earlier scanner buffered it.
+func (p *Proxy) PrepareRequestPolicyBody(r *http.Request, in *requestPolicyInput) requestPolicyResult {
+	return p.prepareRequestPolicyBody(r, in)
+}
+
 // Reload atomically swaps the config and scanner for hot-reload support.
 // The old scanner is closed to release its rate limiter goroutine.
 // Session manager lifecycle is toggled when session_profiling.enabled changes.
@@ -1299,6 +1344,19 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 		}
 		return false
 	}
+	// Stage the request_policy matcher before publication. Config validation
+	// already compiled these patterns, so an error here is defense in depth;
+	// fail closed by aborting the reload and keeping the old matcher.
+	newReqPolicy, reqPolicyErr := reqpolicy.NewMatcher(&cfg.RequestPolicy)
+	if reqPolicyErr != nil {
+		p.logger.LogError(audit.NewMethodLogContext("RELOAD"),
+			fmt.Errorf("request_policy matcher reload failed, keeping old config: %w", reqPolicyErr))
+		sc.Close()
+		if newEd != nil {
+			newEd.Close()
+		}
+		return false
+	}
 
 	// Publish both emitters now that staging has fully succeeded. The
 	// atomic.Pointer swaps are individually atomic; between them, a
@@ -1348,6 +1406,9 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 	} else {
 		p.redactMatcherPtr.Store(nil)
 	}
+	// Publish the staged request_policy matcher (always non-nil; a disabled
+	// section yields an allow-everything matcher).
+	p.reqPolicyPtr.Store(newReqPolicy)
 
 	if !publishCfgBeforeRedaction {
 		p.cfgPtr.Store(cfg)
@@ -3551,6 +3612,32 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 				})
 			return
 		}
+	}
+
+	// request_policy runs before the contract gate so a contract allow can
+	// never suppress an operation-policy block.
+	if rpRes := p.applyRequestPolicy(requestPolicyInput{
+		Host:        parsed.Hostname(),
+		Method:      http.MethodGet,
+		Path:        parsed.EscapedPath(),
+		ContentType: r.Header.Get(headerContentType),
+		Headers:     r.Header,
+		BodyRead:    true,
+		Transport:   TransportFetch,
+		Target:      displayURL,
+		RequestID:   requestID,
+		Agent:       agent,
+		AuditCtx:    actx,
+		Emit:        p.emitReceipt,
+	}); rpRes.Block {
+		p.metrics.RecordBlocked(parsed.Hostname(), blockLayerRequestPolicy, time.Since(start), agentLabel)
+		writeBlockedJSON(w, rpRes.Info, http.StatusForbidden, FetchResponse{
+			URL:         displayURL,
+			Agent:       agent,
+			Blocked:     true,
+			BlockReason: "blocked by request policy: " + rpRes.Reason,
+		})
+		return
 	}
 
 	killSwitchActive := false

--- a/internal/proxy/requestpolicy.go
+++ b/internal/proxy/requestpolicy.go
@@ -174,9 +174,20 @@ func (p *Proxy) prepareRequestPolicyBody(r *http.Request, in *requestPolicyInput
 	return requestPolicyResult{}
 }
 
+// requestPolicyReadBlocked maps a body-inspection failure (read error or
+// oversize) to the operator-configured on_parse_error action through the
+// standard decision flow, so a configured warn/allow is honored and the
+// decision is metered, audited, and receipted like any other match. The body
+// genuinely cannot be parsed, so it is treated as a parse error (default:
+// block). reason is logged as bounded audit context for the failure cause.
 func (p *Proxy) requestPolicyReadBlocked(in requestPolicyInput, reason string) requestPolicyResult {
-	p.logger.LogBlocked(in.AuditCtx, blockLayerRequestPolicy, reason)
-	return requestPolicyResult{Block: true, Info: p.requestPolicyBlockInfo(""), Reason: reason}
+	m := p.requestPolicyMatcher()
+	if m == nil {
+		return requestPolicyResult{}
+	}
+	p.logger.LogAnomaly(in.AuditCtx, blockLayerRequestPolicy, reason, 0)
+	d := p.evaluateRequestPolicyUninspectable(in, m.OnParseError())
+	return p.finalizeRequestPolicyDecision(in, d)
 }
 
 // applyRequestPolicy evaluates request_policy for a request and acts on the
@@ -205,6 +216,16 @@ func (p *Proxy) applyRequestPolicy(in requestPolicyInput) requestPolicyResult {
 			}
 		}
 	}
+	return p.finalizeRequestPolicyDecision(in, d)
+}
+
+// finalizeRequestPolicyDecision records the decision metric and audit event for
+// a matched rule and, for an enforced block, emits a correlated receipt and
+// returns the block Info. A no-match, warn, or shadow decision returns
+// Block=false so the request forwards. Both the route/operation path and the
+// body-inspection-failure path funnel through here so every matched decision is
+// metered, audited, and receipted identically.
+func (p *Proxy) finalizeRequestPolicyDecision(in requestPolicyInput, d reqpolicy.Decision) requestPolicyResult {
 	if !d.Matched() {
 		return requestPolicyResult{}
 	}

--- a/internal/proxy/requestpolicy.go
+++ b/internal/proxy/requestpolicy.go
@@ -4,8 +4,243 @@
 package proxy
 
 import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/reqpolicy"
 )
+
+// blockLayerRequestPolicy labels request_policy decisions on receipts and audit
+// events. It is the audit/receipt layer dimension only — distinct from the
+// X-Pipelock-Block-Reason-Layer HTTP header, which request_policy deliberately
+// leaves UNSET (request_policy is not a scanner.Scanner* pipeline layer, so the
+// reason code conveys the layer; see requestPolicyBlockInfo).
+const blockLayerRequestPolicy = "request_policy"
+
+// headerContentType is the request Content-Type header, used to populate
+// RequestMeta.ContentType for content_type-scoped rules.
+const headerContentType = "Content-Type"
+
+// setupRequestPolicy compiles the request_policy ruleset at startup and stores
+// the matcher. NewMatcher always returns a usable (possibly disabled) matcher,
+// so a nil pointer never reaches the request path. An error here means a
+// path_pattern failed to compile; config validation already compiles the same
+// patterns, so this is defense in depth and fails startup closed.
+func (p *Proxy) setupRequestPolicy(cfg *config.Config) error {
+	m, err := reqpolicy.NewMatcher(&cfg.RequestPolicy)
+	if err != nil {
+		return fmt.Errorf("request_policy matcher build: %w", err)
+	}
+	p.reqPolicyPtr.Store(m)
+	return nil
+}
+
+const defaultRequestPolicyMaxBodyBytes = 5 * 1024 * 1024
+
+// requestPolicyInput is the per-request data a transport hands to
+// applyRequestPolicy. BodyRead reports whether Body is a complete copy of the
+// request body after any in-path redaction. When BodyRead is false and a
+// route-matched operation predicate needs a body, applyRequestPolicy treats the
+// operation as opaque and applies request_policy.on_opaque_operation.
+type requestPolicyInput struct {
+	Host        string
+	Method      string // base HTTP method as seen on the wire
+	Path        string
+	ContentType string
+	Headers     http.Header // resolved for method-override detection
+	Body        []byte
+	BodyRead    bool
+
+	Transport string
+	Target    string // full URL or host:port, for receipt/audit correlation
+	RequestID string
+	Agent     string
+	AuditCtx  audit.LogContext
+	Emit      func(receipt.EmitOpts) // transport's receipt emitter (e.g. p.emitReceipt)
+}
+
+// requestPolicyResult tells the calling transport what to do. Block is true
+// only for an enforced (non-shadow) block; warn and shadow matches return
+// Block=false after being logged and counted, so the request forwards.
+type requestPolicyResult struct {
+	Block  bool
+	Info   blockreason.Info
+	Reason string // operator-facing reason from the matched rule, safe to surface
+}
+
+// evaluateRequestPolicy evaluates the active ruleset against a request. It
+// resolves method-override headers and evaluates against BOTH the base and the
+// overridden method, returning the stricter result, so a request cannot dodge
+// a method-scoped rule by tunnelling the real method through an override header
+// the upstream may ignore (per reqpolicy.EffectiveMethod's documented caveat).
+func (p *Proxy) requestPolicyMatcher() *reqpolicy.Matcher {
+	m := p.reqPolicyPtr.Load()
+	if m == nil {
+		return nil
+	}
+	return m
+}
+
+func requestPolicyMeta(host, method, path, contentType string, ops []reqpolicy.RequestOperation) reqpolicy.RequestMeta {
+	return reqpolicy.RequestMeta{Host: host, Method: method, Path: path, ContentType: contentType, Operations: ops}
+}
+
+func (p *Proxy) evaluateRequestPolicy(host, baseMethod string, headers http.Header, path, contentType string, ops []reqpolicy.RequestOperation) reqpolicy.Decision {
+	m := p.requestPolicyMatcher()
+	if m == nil {
+		return reqpolicy.Decision{}
+	}
+	eff := reqpolicy.EffectiveMethod(baseMethod, headers)
+	d := m.Evaluate(requestPolicyMeta(host, eff, path, contentType, ops))
+	base := strings.ToUpper(strings.TrimSpace(baseMethod))
+	if eff != base {
+		alt := m.Evaluate(requestPolicyMeta(host, base, path, contentType, ops))
+		d = reqpolicy.Stricter(d, alt)
+	}
+	return d
+}
+
+func (p *Proxy) requestPolicyNeedsOperations(in requestPolicyInput) bool {
+	m := p.requestPolicyMatcher()
+	if m == nil {
+		return false
+	}
+	eff := reqpolicy.EffectiveMethod(in.Method, in.Headers)
+	if m.NeedsOperations(requestPolicyMeta(in.Host, eff, in.Path, in.ContentType, nil)) {
+		return true
+	}
+	base := strings.ToUpper(strings.TrimSpace(in.Method))
+	return eff != base && m.NeedsOperations(requestPolicyMeta(in.Host, base, in.Path, in.ContentType, nil))
+}
+
+func (p *Proxy) evaluateRequestPolicyUninspectable(in requestPolicyInput, action string) reqpolicy.Decision {
+	m := p.requestPolicyMatcher()
+	if m == nil {
+		return reqpolicy.Decision{}
+	}
+	eff := reqpolicy.EffectiveMethod(in.Method, in.Headers)
+	d := m.EvaluateUninspectable(requestPolicyMeta(in.Host, eff, in.Path, in.ContentType, nil), action)
+	base := strings.ToUpper(strings.TrimSpace(in.Method))
+	if eff != base {
+		alt := m.EvaluateUninspectable(requestPolicyMeta(in.Host, base, in.Path, in.ContentType, nil), action)
+		d = reqpolicy.Stricter(d, alt)
+	}
+	return d
+}
+
+func (p *Proxy) requestPolicyBodyLimit() int {
+	cfg := p.cfgPtr.Load()
+	if cfg != nil && cfg.RequestBodyScanning.MaxBodyBytes > 0 {
+		return cfg.RequestBodyScanning.MaxBodyBytes
+	}
+	return defaultRequestPolicyMaxBodyBytes
+}
+
+// prepareRequestPolicyBody reads and re-wraps a request body only when a
+// route-matched operation predicate needs it and no earlier scanner already
+// buffered it. This keeps request_policy independent of
+// request_body_scanning.enabled without draining bodies for route-only rules.
+func (p *Proxy) prepareRequestPolicyBody(r *http.Request, in *requestPolicyInput) requestPolicyResult {
+	if in.BodyRead || !p.requestPolicyNeedsOperations(*in) {
+		return requestPolicyResult{}
+	}
+	if r.Body == nil || r.Body == http.NoBody {
+		in.BodyRead = true
+		return requestPolicyResult{}
+	}
+	limit := p.requestPolicyBodyLimit()
+	buf, err := io.ReadAll(io.LimitReader(r.Body, int64(limit)+1))
+	if err != nil {
+		return p.requestPolicyReadBlocked(*in, fmt.Sprintf("request body could not be inspected: %v", err))
+	}
+	if len(buf) > limit {
+		return p.requestPolicyReadBlocked(*in, fmt.Sprintf("request body exceeds max_body_bytes (%d)", limit))
+	}
+	r.Body = io.NopCloser(bytes.NewReader(buf))
+	r.ContentLength = int64(len(buf))
+	bufCopy := buf
+	r.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(bufCopy)), nil
+	}
+	in.Body = buf
+	in.BodyRead = true
+	return requestPolicyResult{}
+}
+
+func (p *Proxy) requestPolicyReadBlocked(in requestPolicyInput, reason string) requestPolicyResult {
+	p.logger.LogBlocked(in.AuditCtx, blockLayerRequestPolicy, reason)
+	return requestPolicyResult{Block: true, Info: p.requestPolicyBlockInfo(""), Reason: reason}
+}
+
+// applyRequestPolicy evaluates request_policy for a request and acts on the
+// outcome. On a matched rule it records the decision metric and an audit event;
+// on an enforced block it also emits a receipt (when an emitter is configured)
+// and returns Block=true with the block-reason Info for the transport to write.
+// Warn and shadow matches return Block=false so the request forwards.
+//
+// Transports MUST call this BEFORE EvaluateGate so a contract allow can never
+// suppress a request_policy block.
+func (p *Proxy) applyRequestPolicy(in requestPolicyInput) requestPolicyResult {
+	d := p.evaluateRequestPolicy(in.Host, in.Method, in.Headers, in.Path, in.ContentType, nil)
+	if p.requestPolicyNeedsOperations(in) {
+		m := p.requestPolicyMatcher()
+		if !in.BodyRead {
+			d = reqpolicy.Stricter(d, p.evaluateRequestPolicyUninspectable(in, m.OnOpaqueOperation()))
+		} else {
+			ops, parseOK, opaque := reqpolicy.ExtractGraphQL(in.Body)
+			if !parseOK {
+				d = reqpolicy.Stricter(d, p.evaluateRequestPolicyUninspectable(in, m.OnParseError()))
+			} else {
+				d = reqpolicy.Stricter(d, p.evaluateRequestPolicy(in.Host, in.Method, in.Headers, in.Path, in.ContentType, ops))
+				if opaque {
+					d = reqpolicy.Stricter(d, p.evaluateRequestPolicyUninspectable(in, m.OnOpaqueOperation()))
+				}
+			}
+		}
+	}
+	if !d.Matched() {
+		return requestPolicyResult{}
+	}
+	p.metrics.RecordRequestPolicyDecision(d.RuleName, d.Action)
+
+	if !d.Enforced() || d.Action != config.ActionBlock {
+		// Warn or shadow: log the would-be action and forward. Detail carries
+		// only bounded, operator-defined labels — never body or matched content.
+		p.logger.LogAnomaly(in.AuditCtx, blockLayerRequestPolicy,
+			fmt.Sprintf("rule=%s action=%s shadow=%t", d.RuleName, d.Action, d.Shadow), 0)
+		return requestPolicyResult{}
+	}
+
+	// Enforced block.
+	p.logger.LogBlocked(in.AuditCtx, blockLayerRequestPolicy, d.RuleName)
+	actionID := ""
+	if in.Emit != nil && p.receiptEmitterPtr.Load() != nil {
+		actionID = receipt.NewActionID()
+		in.Emit(receipt.EmitOpts{
+			ActionID:  actionID,
+			Verdict:   config.ActionBlock,
+			Layer:     blockLayerRequestPolicy,
+			Pattern:   d.RuleName,
+			Transport: in.Transport,
+			Method:    in.Method,
+			Target:    in.Target,
+			RequestID: in.RequestID,
+			Agent:     in.Agent,
+		})
+	}
+	reason := d.Reason
+	if reason == "" {
+		reason = d.RuleName
+	}
+	return requestPolicyResult{Block: true, Info: p.requestPolicyBlockInfo(actionID), Reason: reason}
+}
 
 // requestPolicyBlockInfo builds the X-Pipelock-Block-Reason metadata for a
 // request_policy_deny block — the operation safety rail's enforced-block path.

--- a/internal/proxy/requestpolicy.go
+++ b/internal/proxy/requestpolicy.go
@@ -174,19 +174,21 @@ func (p *Proxy) prepareRequestPolicyBody(r *http.Request, in *requestPolicyInput
 	return requestPolicyResult{}
 }
 
-// requestPolicyReadBlocked maps a body-inspection failure (read error or
-// oversize) to the operator-configured on_parse_error action through the
-// standard decision flow, so a configured warn/allow is honored and the
-// decision is metered, audited, and receipted like any other match. The body
-// genuinely cannot be parsed, so it is treated as a parse error (default:
-// block). reason is logged as bounded audit context for the failure cause.
+// requestPolicyReadBlocked handles a request body that cannot be read or
+// exceeds the size limit. The bounded read has already consumed — and thus
+// destroyed — the body stream, so the request can no longer be forwarded
+// intact. It is therefore always blocked, never downgraded by a configured
+// on_parse_error: warn/allow (those apply only to a fully-read body that
+// fails to parse, which is still forwardable). The block is routed through the
+// shared finalizer so it is metered, audited, and receipted like any other
+// match. reason is logged as bounded audit context for the failure cause.
 func (p *Proxy) requestPolicyReadBlocked(in requestPolicyInput, reason string) requestPolicyResult {
 	m := p.requestPolicyMatcher()
 	if m == nil {
 		return requestPolicyResult{}
 	}
 	p.logger.LogAnomaly(in.AuditCtx, blockLayerRequestPolicy, reason, 0)
-	d := p.evaluateRequestPolicyUninspectable(in, m.OnParseError())
+	d := p.evaluateRequestPolicyUninspectable(in, config.ActionBlock)
 	return p.finalizeRequestPolicyDecision(in, d)
 }
 

--- a/internal/proxy/requestpolicy_enforcement_test.go
+++ b/internal/proxy/requestpolicy_enforcement_test.go
@@ -260,11 +260,12 @@ func TestPrepareRequestPolicyBody_OversizeBlocks(t *testing.T) {
 	}
 }
 
-func TestPrepareRequestPolicyBody_OversizeHonorsOnParseErrorWarn(t *testing.T) {
+func TestPrepareRequestPolicyBody_OversizeAlwaysBlocks(t *testing.T) {
 	t.Parallel()
-	// With on_parse_error=warn, an oversize (uninspectable) operation body must
-	// forward, not block — the configured action is honored rather than an
-	// unconditional fail-closed block.
+	// An oversize body is destroyed by the bounded read and cannot be forwarded
+	// intact, so it must block even when on_parse_error is warn/allow. The
+	// configured on_parse_error downgrade applies only to a fully-read body
+	// that fails to parse, not to an unreadable/oversize one.
 	cfg := reqPolicyConfig(graphqlBlockRule())
 	cfg.RequestPolicy.OnParseError = config.ActionWarn
 	cfg.RequestBodyScanning.MaxBodyBytes = 8
@@ -281,8 +282,8 @@ func TestPrepareRequestPolicyBody_OversizeHonorsOnParseErrorWarn(t *testing.T) {
 		Transport:   TransportForward,
 		AuditCtx:    audit.LogContext{},
 	}
-	if res := p.prepareRequestPolicyBody(req, &in); res.Block {
-		t.Fatal("on_parse_error=warn must forward an oversize operation body, not block")
+	if res := p.prepareRequestPolicyBody(req, &in); !res.Block {
+		t.Fatal("an oversize operation body must block even with on_parse_error=warn (it cannot be forwarded intact)")
 	}
 }
 

--- a/internal/proxy/requestpolicy_enforcement_test.go
+++ b/internal/proxy/requestpolicy_enforcement_test.go
@@ -1,0 +1,661 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+const (
+	rpTestHost = "api.example.com"
+	rpRuleName = "block-dangerous"
+)
+
+// reqPolicyConfig returns a Defaults config with SSRF disabled (no DNS in unit
+// tests) and request_policy enabled with the given rules.
+func reqPolicyConfig(rules ...config.RequestPolicyRule) *config.Config {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	// Forward proxy gates the absolute-URI and CONNECT dispatch in buildHandler.
+	cfg.ForwardProxy.Enabled = true
+	cfg.RequestPolicy.Enabled = true
+	cfg.RequestPolicy.Rules = rules
+	return cfg
+}
+
+// blockRule blocks the given method(s) to rpTestHost.
+func blockRule(methods ...string) config.RequestPolicyRule {
+	return config.RequestPolicyRule{
+		Name:   rpRuleName,
+		Action: config.ActionBlock,
+		Route:  config.RequestPolicyRoute{Hosts: []string{rpTestHost}, Methods: methods},
+		Reason: "dangerous operation requires operator approval",
+	}
+}
+
+func graphqlBlockRule() config.RequestPolicyRule {
+	return config.RequestPolicyRule{
+		Name:   rpRuleName,
+		Action: config.ActionBlock,
+		Route: config.RequestPolicyRoute{
+			Hosts:        []string{rpTestHost},
+			Methods:      []string{http.MethodPost},
+			ContentTypes: []string{"application/json"},
+		},
+		GraphQL: &config.RequestPolicyGraphQL{
+			OperationTypes:    []string{"mutation"},
+			RootFieldPatterns: []string{`^deleteRecord$`},
+		},
+		Reason: "dangerous operation requires operator approval",
+	}
+}
+
+func deleteRecordGraphQLBody() string {
+	return `{"query":` + strconv.Quote(`mutation { deleteRecord { id } }`) + `}`
+}
+
+// --- Shared helper: method-override double-evaluation -----------------------
+
+func TestEvaluateRequestPolicy_MethodOverrideCannotDowngrade(t *testing.T) {
+	t.Parallel()
+	// Rule blocks DELETE. An attacker sends POST but tunnels the real verb via
+	// X-HTTP-Method-Override: DELETE. The double-evaluation must still block.
+	p := newTestProxyWithConfig(t, reqPolicyConfig(blockRule(http.MethodDelete)))
+
+	h := http.Header{}
+	h.Set("X-HTTP-Method-Override", http.MethodDelete)
+	d := p.evaluateRequestPolicy(rpTestHost, http.MethodPost, h, "/v1/jobs/1", "", nil)
+	if d.Action != config.ActionBlock {
+		t.Fatalf("override DELETE via POST should block, got action=%q", d.Action)
+	}
+
+	// And the inverse: a bare POST with no override is not caught by a
+	// DELETE-only rule.
+	if d2 := p.evaluateRequestPolicy(rpTestHost, http.MethodPost, http.Header{}, "/v1/jobs/1", "", nil); d2.Matched() {
+		t.Fatalf("bare POST should not match a DELETE-only rule, got %+v", d2)
+	}
+}
+
+// --- Shared helper: block / warn / shadow + metric + receipt ----------------
+
+func TestApplyRequestPolicy_Outcomes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		rule      config.RequestPolicyRule
+		wantBlock bool
+	}{
+		{
+			name:      "block enforces",
+			rule:      blockRule(http.MethodDelete),
+			wantBlock: true,
+		},
+		{
+			name: "warn forwards",
+			rule: config.RequestPolicyRule{
+				Name: rpRuleName, Action: config.ActionWarn,
+				Route: config.RequestPolicyRoute{Hosts: []string{rpTestHost}, Methods: []string{http.MethodDelete}},
+			},
+			wantBlock: false,
+		},
+		{
+			name: "shadow block forwards",
+			rule: config.RequestPolicyRule{
+				Name: rpRuleName, Action: config.ActionBlock, Shadow: true,
+				Route: config.RequestPolicyRoute{Hosts: []string{rpTestHost}, Methods: []string{http.MethodDelete}},
+			},
+			wantBlock: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newTestProxyWithConfig(t, reqPolicyConfig(tc.rule))
+			res := p.applyRequestPolicy(requestPolicyInput{
+				Host:      rpTestHost,
+				Method:    http.MethodDelete,
+				Path:      "/v1/jobs/1",
+				Transport: TransportForward,
+				Target:    "http://" + rpTestHost + "/v1/jobs/1",
+				AuditCtx:  audit.LogContext{},
+			})
+			if res.Block != tc.wantBlock {
+				t.Fatalf("Block = %v, want %v", res.Block, tc.wantBlock)
+			}
+			if tc.wantBlock {
+				if res.Info.Reason != "request_policy_deny" {
+					t.Errorf("block Info.Reason = %q, want request_policy_deny", res.Info.Reason)
+				}
+				if res.Reason == "" {
+					t.Error("block result should carry a non-empty operator reason")
+				}
+			}
+		})
+	}
+}
+
+func TestApplyRequestPolicy_NoMatchForwards(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(blockRule(http.MethodDelete)))
+	res := p.applyRequestPolicy(requestPolicyInput{
+		Host: rpTestHost, Method: http.MethodGet, Path: "/v1/jobs/1",
+		Transport: TransportForward, AuditCtx: audit.LogContext{},
+	})
+	if res.Block {
+		t.Fatal("GET should not match a DELETE rule")
+	}
+}
+
+func TestApplyRequestPolicy_GraphQLPredicateBlocks(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(graphqlBlockRule()))
+	res := p.applyRequestPolicy(requestPolicyInput{
+		Host:        rpTestHost,
+		Method:      http.MethodPost,
+		Path:        "/graphql",
+		ContentType: "application/json",
+		Body:        []byte(deleteRecordGraphQLBody()),
+		BodyRead:    true,
+		Transport:   TransportForward,
+		AuditCtx:    audit.LogContext{},
+	})
+	if !res.Block {
+		t.Fatal("GraphQL deleteRecord mutation should block")
+	}
+}
+
+func TestApplyRequestPolicy_GraphQLParseErrorFailsClosed(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(graphqlBlockRule()))
+	res := p.applyRequestPolicy(requestPolicyInput{
+		Host:        rpTestHost,
+		Method:      http.MethodPost,
+		Path:        "/graphql",
+		ContentType: "application/json",
+		Body:        []byte(`{"query":"mutation { deleteRecord "`),
+		BodyRead:    true,
+		Transport:   TransportForward,
+		AuditCtx:    audit.LogContext{},
+	})
+	if !res.Block {
+		t.Fatal("unparseable route-matched GraphQL body should fail closed")
+	}
+}
+
+func TestApplyRequestPolicy_GraphQLOpaqueFailsClosed(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(graphqlBlockRule()))
+	res := p.applyRequestPolicy(requestPolicyInput{
+		Host:        rpTestHost,
+		Method:      http.MethodPost,
+		Path:        "/graphql",
+		ContentType: "application/json",
+		BodyRead:    false,
+		Transport:   TransportForward,
+		AuditCtx:    audit.LogContext{},
+	})
+	if !res.Block {
+		t.Fatal("route-matched GraphQL request with unavailable body should fail closed")
+	}
+}
+
+func TestApplyRequestPolicy_GraphQLOpaqueWarnForwards(t *testing.T) {
+	t.Parallel()
+	cfg := reqPolicyConfig(graphqlBlockRule())
+	cfg.RequestPolicy.OnOpaqueOperation = config.ActionWarn
+	p := newTestProxyWithConfig(t, cfg)
+	res := p.applyRequestPolicy(requestPolicyInput{
+		Host:        rpTestHost,
+		Method:      http.MethodPost,
+		Path:        "/graphql",
+		ContentType: "application/json",
+		BodyRead:    false,
+		Transport:   TransportForward,
+		AuditCtx:    audit.LogContext{},
+	})
+	if res.Block {
+		t.Fatal("on_opaque_operation=warn should log and forward")
+	}
+}
+
+func TestPrepareRequestPolicyBody_OversizeBlocks(t *testing.T) {
+	t.Parallel()
+	cfg := reqPolicyConfig(graphqlBlockRule())
+	cfg.RequestBodyScanning.MaxBodyBytes = 8
+	p := newTestProxyWithConfig(t, cfg)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://"+rpTestHost+"/graphql",
+		strings.NewReader(deleteRecordGraphQLBody()))
+	req.Header.Set("Content-Type", "application/json")
+	in := requestPolicyInput{
+		Host:        rpTestHost,
+		Method:      http.MethodPost,
+		Path:        "/graphql",
+		ContentType: "application/json",
+		Headers:     req.Header,
+		Transport:   TransportForward,
+		AuditCtx:    audit.LogContext{},
+	}
+	res := p.prepareRequestPolicyBody(req, &in)
+	if !res.Block {
+		t.Fatal("oversize request_policy operation body should block fail-closed")
+	}
+	if !strings.Contains(res.Reason, "max_body_bytes") {
+		t.Fatalf("block reason = %q, want max_body_bytes", res.Reason)
+	}
+}
+
+func TestPrepareRequestPolicyBody_ReadsAndRewrapsOnlyWhenNeeded(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(graphqlBlockRule()))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://"+rpTestHost+"/graphql",
+		strings.NewReader(deleteRecordGraphQLBody()))
+	req.Header.Set("Content-Type", "application/json")
+	in := requestPolicyInput{
+		Host:        rpTestHost,
+		Method:      http.MethodPost,
+		Path:        "/graphql",
+		ContentType: "application/json",
+		Headers:     req.Header,
+	}
+	if res := p.prepareRequestPolicyBody(req, &in); res.Block {
+		t.Fatalf("prepare blocked valid body: %+v", res)
+	}
+	if !in.BodyRead || len(in.Body) == 0 {
+		t.Fatalf("body not buffered: BodyRead=%v len=%d", in.BodyRead, len(in.Body))
+	}
+	rewrapped, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read rewrapped body: %v", err)
+	}
+	if string(rewrapped) != string(in.Body) {
+		t.Fatalf("rewrapped body mismatch")
+	}
+
+	routeOnly := newTestProxyWithConfig(t, reqPolicyConfig(blockRule(http.MethodPost)))
+	req2 := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://"+rpTestHost+"/graphql",
+		strings.NewReader("not read"))
+	in2 := requestPolicyInput{Host: rpTestHost, Method: http.MethodPost, Path: "/graphql", Headers: req2.Header}
+	if res := routeOnly.prepareRequestPolicyBody(req2, &in2); res.Block || in2.BodyRead {
+		t.Fatalf("route-only rule should not force body read, res=%+v BodyRead=%v", res, in2.BodyRead)
+	}
+}
+
+func TestRequestPolicyBodyLimit_DefaultFallback(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(graphqlBlockRule()))
+	p.cfgPtr.Store(&config.Config{})
+	if got := p.requestPolicyBodyLimit(); got != defaultRequestPolicyMaxBodyBytes {
+		t.Fatalf("default limit = %d, want %d", got, defaultRequestPolicyMaxBodyBytes)
+	}
+}
+
+// rpErrBody is a request body that errors on read, to exercise the
+// fail-closed branch of prepareRequestPolicyBody.
+type rpErrBody struct{}
+
+func (rpErrBody) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+func (rpErrBody) Close() error             { return nil }
+
+func TestPrepareRequestPolicyBody_ReadErrorFailsClosed(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(graphqlBlockRule()))
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://"+rpTestHost+"/graphql", nil)
+	r.Header.Set(headerContentType, "application/json")
+	r.Body = rpErrBody{}
+	in := requestPolicyInput{
+		Host: rpTestHost, Method: http.MethodPost, Path: "/graphql",
+		ContentType: "application/json", Headers: r.Header, AuditCtx: audit.LogContext{},
+	}
+	if rp := p.prepareRequestPolicyBody(r, &in); !rp.Block {
+		t.Fatal("a body read error on a route-matched GraphQL request must fail closed")
+	}
+}
+
+func TestPrepareRequestPolicyBody_NilBodyMarksRead(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(graphqlBlockRule()))
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://"+rpTestHost+"/graphql", nil)
+	r.Header.Set(headerContentType, "application/json")
+	r.Body = nil
+	in := requestPolicyInput{
+		Host: rpTestHost, Method: http.MethodPost, Path: "/graphql",
+		ContentType: "application/json", Headers: r.Header, AuditCtx: audit.LogContext{},
+	}
+	rp := p.prepareRequestPolicyBody(r, &in)
+	if rp.Block {
+		t.Fatal("prepare should not itself block on a nil body; apply handles opaque")
+	}
+	if !in.BodyRead {
+		t.Fatal("a nil body must mark BodyRead so apply treats the operation as opaque")
+	}
+}
+
+func TestApplyRequestPolicy_OpaqueWithMethodOverrideFailsClosed(t *testing.T) {
+	t.Parallel()
+	// Base GET, override POST: the override makes the GraphQL (POST) rule's
+	// route match, and the unread body is opaque, so it must fail closed. This
+	// exercises the base-vs-override path of the uninspectable evaluator.
+	p := newTestProxyWithConfig(t, reqPolicyConfig(graphqlBlockRule()))
+	h := http.Header{}
+	h.Set(headerContentType, "application/json")
+	h.Set("X-HTTP-Method-Override", http.MethodPost)
+	res := p.applyRequestPolicy(requestPolicyInput{
+		Host: rpTestHost, Method: http.MethodGet, Path: "/graphql",
+		ContentType: "application/json", Headers: h, BodyRead: false,
+		Transport: TransportForward, AuditCtx: audit.LogContext{},
+	})
+	if !res.Block {
+		t.Fatal("opaque GraphQL reached via method override must fail closed")
+	}
+}
+
+func TestApplyRequestPolicy_BlockCarriesReceiptWhenEmitterConfigured(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(blockRule(http.MethodDelete)))
+	// A configured receipt emitter makes the block stamp the real action_id
+	// into the receipt header and emit a correlated receipt. The gating only
+	// reads the pointer for non-nil presence, so a zero-value emitter suffices.
+	p.receiptEmitterPtr.Store(&receipt.Emitter{})
+
+	emitted := 0
+	res := p.applyRequestPolicy(requestPolicyInput{
+		Host: rpTestHost, Method: http.MethodDelete, Path: "/v1/jobs/1",
+		Transport: TransportForward, AuditCtx: audit.LogContext{},
+		Emit: func(receipt.EmitOpts) { emitted++ },
+	})
+	if !res.Block {
+		t.Fatal("expected block")
+	}
+	if emitted != 1 {
+		t.Fatalf("expected exactly one receipt emission, got %d", emitted)
+	}
+	if res.Info.Receipt == "" {
+		t.Error("receipt header should be populated when an emitter is configured")
+	}
+}
+
+func TestSetupRequestPolicy_InvalidPatternFailsStartup(t *testing.T) {
+	t.Parallel()
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.RequestPolicy.Enabled = true
+	cfg.RequestPolicy.Rules = []config.RequestPolicyRule{{
+		Name:   "bad",
+		Action: config.ActionBlock,
+		Route:  config.RequestPolicyRoute{Hosts: []string{rpTestHost}, PathPatterns: []string{"("}},
+	}}
+	sc := scanner.New(cfg)
+	logger, _ := audit.New("json", "stdout", "", false, false)
+	if _, err := New(cfg, logger, sc, metrics.New()); err == nil {
+		t.Fatal("New must fail closed when a request_policy path_pattern does not compile")
+	}
+}
+
+func TestApplyRequestPolicy_DisabledForwards(t *testing.T) {
+	t.Parallel()
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.RequestPolicy.Enabled = false
+	cfg.RequestPolicy.Rules = []config.RequestPolicyRule{blockRule(http.MethodDelete)}
+	p := newTestProxyWithConfig(t, cfg)
+	res := p.applyRequestPolicy(requestPolicyInput{
+		Host: rpTestHost, Method: http.MethodDelete, Path: "/v1/jobs/1",
+		Transport: TransportForward, AuditCtx: audit.LogContext{},
+	})
+	if res.Block {
+		t.Fatal("disabled request_policy must not block")
+	}
+}
+
+// --- Transport parity: HTTP-surface block emission --------------------------
+
+// assertRequestPolicyBlock checks a recorded response is a request_policy 403.
+func assertRequestPolicyBlock(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	if got := w.Header().Get("X-Pipelock-Block-Reason"); got != "request_policy_deny" {
+		t.Fatalf("X-Pipelock-Block-Reason = %q, want request_policy_deny", got)
+	}
+	if got := w.Header().Get("X-Pipelock-Block-Reason-Retry"); got != "policy" {
+		t.Errorf("retry hint = %q, want policy", got)
+	}
+}
+
+func TestRequestPolicy_ForwardAbsoluteURI_Blocks(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(blockRule(http.MethodDelete)))
+	handler := p.buildHandler(p.buildMux())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete,
+		"http://"+rpTestHost+"/v1/jobs/123", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assertRequestPolicyBlock(t, w)
+}
+
+func TestRequestPolicy_ForwardGraphQL_BlocksWithBodyScanningDisabled(t *testing.T) {
+	t.Parallel()
+	cfg := reqPolicyConfig(graphqlBlockRule())
+	cfg.RequestBodyScanning.Enabled = false
+	p := newTestProxyWithConfig(t, cfg)
+	handler := p.buildHandler(p.buildMux())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost,
+		"http://"+rpTestHost+"/graphql", strings.NewReader(deleteRecordGraphQLBody()))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assertRequestPolicyBlock(t, w)
+}
+
+func TestRequestPolicy_Fetch_Blocks(t *testing.T) {
+	t.Parallel()
+	// Fetch is GET-only; block GET to the host.
+	p := newTestProxyWithConfig(t, reqPolicyConfig(blockRule(http.MethodGet)))
+	handler := p.buildHandler(p.buildMux())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet,
+		"/fetch?url=http://"+rpTestHost+"/v1/secret", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assertRequestPolicyBlock(t, w)
+}
+
+func TestRequestPolicy_Connect_HostRuleBlocks(t *testing.T) {
+	t.Parallel()
+	// CONNECT setup sees host + method CONNECT only. A host-scoped rule (no
+	// path) blocks the tunnel before it opens.
+	rule := config.RequestPolicyRule{
+		Name:   rpRuleName,
+		Action: config.ActionBlock,
+		Route:  config.RequestPolicyRoute{Hosts: []string{rpTestHost}},
+		Reason: "host blocked for agent runtime",
+	}
+	p := newTestProxyWithConfig(t, reqPolicyConfig(rule))
+	handler := p.buildHandler(p.buildMux())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodConnect, "//"+rpTestHost+":443", nil)
+	req.Host = rpTestHost + ":443"
+	req.RequestURI = rpTestHost + ":443"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assertRequestPolicyBlock(t, w)
+}
+
+func TestRequestPolicy_WebSocketHandshake_Blocks(t *testing.T) {
+	t.Parallel()
+	// WebSocket handshake is a GET upgrade; a host+GET rule blocks it before
+	// the upgrade completes.
+	cfg := reqPolicyConfig(blockRule(http.MethodGet))
+	cfg.WebSocketProxy.Enabled = true
+	p := newTestProxyWithConfig(t, cfg)
+	handler := p.buildHandler(p.buildMux())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet,
+		"/ws?url=ws://"+rpTestHost+"/socket", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	if got := w.Header().Get("X-Pipelock-Block-Reason"); got != "request_policy_deny" {
+		t.Fatalf("X-Pipelock-Block-Reason = %q, want request_policy_deny", got)
+	}
+}
+
+func TestRequestPolicy_Reverse_Blocks(t *testing.T) {
+	t.Parallel()
+	cfg := reqPolicyConfig(blockRule(http.MethodDelete))
+	p := newTestProxyWithConfig(t, cfg)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream: %v", err)
+	}
+	rpHandler := NewReverseProxy(upstreamURL, &p.cfgPtr, &p.scannerPtr, p.logger, p.metrics, nil, nil, nil)
+	// Production wires this in server_lifecycle; a reverse handler without it
+	// would silently skip request_policy, so the test mirrors production.
+	rpHandler.SetRequestPolicyFn(p.ApplyRequestPolicy)
+	rpHandler.SetRequestPolicyPrepareFn(p.PrepareRequestPolicyBody)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "http://"+rpTestHost+"/v1/jobs/1", nil)
+	req.Host = rpTestHost
+	w := httptest.NewRecorder()
+	rpHandler.ServeHTTP(w, req)
+
+	assertRequestPolicyBlock(t, w)
+}
+
+func TestRequestPolicy_ReverseGraphQL_BlocksWithBodyScanningDisabled(t *testing.T) {
+	t.Parallel()
+	cfg := reqPolicyConfig(graphqlBlockRule())
+	cfg.RequestBodyScanning.Enabled = false
+	p := newTestProxyWithConfig(t, cfg)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream: %v", err)
+	}
+	rpHandler := NewReverseProxy(upstreamURL, &p.cfgPtr, &p.scannerPtr, p.logger, p.metrics, nil, nil, nil)
+	rpHandler.SetRequestPolicyFn(p.ApplyRequestPolicy)
+	rpHandler.SetRequestPolicyPrepareFn(p.PrepareRequestPolicyBody)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://"+rpTestHost+"/graphql",
+		strings.NewReader(deleteRecordGraphQLBody()))
+	req.Host = rpTestHost
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	rpHandler.ServeHTTP(w, req)
+
+	assertRequestPolicyBlock(t, w)
+}
+
+func TestRequestPolicy_RedirectHopReportsRequestPolicyReason(t *testing.T) {
+	t.Parallel()
+	// An origin redirects to a host that request_policy blocks for GET. The
+	// redirect-hop block must surface request_policy_deny (with policy retry),
+	// not the generic redirect_scan_denied.
+	p := newTestProxyWithConfig(t, reqPolicyConfig(blockRule(http.MethodGet)))
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://"+rpTestHost+"/v1/secret", http.StatusFound)
+	}))
+	t.Cleanup(origin.Close)
+
+	handler := p.buildHandler(p.buildMux())
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet,
+		"/fetch?url="+url.QueryEscape(origin.URL), nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if got := w.Header().Get("X-Pipelock-Block-Reason"); got != "request_policy_deny" {
+		t.Fatalf("redirect-hop block reason = %q, want request_policy_deny", got)
+	}
+	if got := w.Header().Get("X-Pipelock-Block-Reason-Retry"); got != "policy" {
+		t.Errorf("retry hint = %q, want policy", got)
+	}
+}
+
+// --- Before-gate ordering: request_policy blocks with no contract -----------
+
+func TestRequestPolicy_EnforcesWithoutContract(t *testing.T) {
+	t.Parallel()
+	// No learn_lock contract is configured, so EvaluateGate would allow. The
+	// request_policy block must still fire — proving it runs independently and
+	// before the contract gate, not gated behind it.
+	p := newTestProxyWithConfig(t, reqPolicyConfig(blockRule(http.MethodDelete)))
+	if p.currentContractLoader() != nil {
+		t.Fatal("test precondition: no contract loader expected")
+	}
+	handler := p.buildHandler(p.buildMux())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete,
+		"http://"+rpTestHost+"/v1/jobs/123", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assertRequestPolicyBlock(t, w)
+}
+
+// --- Hot reload: rule changes take effect -----------------------------------
+
+func TestRequestPolicy_HotReloadAppliesRuleChange(t *testing.T) {
+	t.Parallel()
+	// Start with request_policy disabled: a DELETE forwards (no block).
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	p := newTestProxyWithConfig(t, cfg)
+
+	if got := p.evaluateRequestPolicy(rpTestHost, http.MethodDelete, http.Header{}, "/v1/jobs/1", "", nil); got.Matched() {
+		t.Fatal("no rule configured: DELETE should not match")
+	}
+
+	// Reload with a blocking rule.
+	newCfg := reqPolicyConfig(blockRule(http.MethodDelete))
+	if !p.Reload(newCfg, scanner.New(newCfg)) {
+		t.Fatal("Reload returned false")
+	}
+	if got := p.evaluateRequestPolicy(rpTestHost, http.MethodDelete, http.Header{}, "/v1/jobs/1", "", nil); got.Action != config.ActionBlock {
+		t.Fatalf("after reload, DELETE should block, got action=%q", got.Action)
+	}
+
+	// Reload again removing the rule: enforcement clears.
+	cfgOff := reqPolicyConfig()
+	if !p.Reload(cfgOff, scanner.New(cfgOff)) {
+		t.Fatal("second Reload returned false")
+	}
+	if got := p.evaluateRequestPolicy(rpTestHost, http.MethodDelete, http.Header{}, "/v1/jobs/1", "", nil); got.Matched() {
+		t.Fatal("after rule removal, DELETE should not match")
+	}
+}

--- a/internal/proxy/requestpolicy_enforcement_test.go
+++ b/internal/proxy/requestpolicy_enforcement_test.go
@@ -252,8 +252,75 @@ func TestPrepareRequestPolicyBody_OversizeBlocks(t *testing.T) {
 	if !res.Block {
 		t.Fatal("oversize request_policy operation body should block fail-closed")
 	}
-	if !strings.Contains(res.Reason, "max_body_bytes") {
-		t.Fatalf("block reason = %q, want max_body_bytes", res.Reason)
+	// The client-facing reason is the matched rule's reason (the max_body_bytes
+	// detail is recorded in the audit log); the block honors on_parse_error,
+	// which defaults to block.
+	if res.Reason == "" {
+		t.Fatal("oversize block should carry the rule's operator-facing reason")
+	}
+}
+
+func TestPrepareRequestPolicyBody_OversizeHonorsOnParseErrorWarn(t *testing.T) {
+	t.Parallel()
+	// With on_parse_error=warn, an oversize (uninspectable) operation body must
+	// forward, not block — the configured action is honored rather than an
+	// unconditional fail-closed block.
+	cfg := reqPolicyConfig(graphqlBlockRule())
+	cfg.RequestPolicy.OnParseError = config.ActionWarn
+	cfg.RequestBodyScanning.MaxBodyBytes = 8
+	p := newTestProxyWithConfig(t, cfg)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://"+rpTestHost+"/graphql",
+		strings.NewReader(deleteRecordGraphQLBody()))
+	req.Header.Set("Content-Type", "application/json")
+	in := requestPolicyInput{
+		Host:        rpTestHost,
+		Method:      http.MethodPost,
+		Path:        "/graphql",
+		ContentType: "application/json",
+		Headers:     req.Header,
+		Transport:   TransportForward,
+		AuditCtx:    audit.LogContext{},
+	}
+	if res := p.prepareRequestPolicyBody(req, &in); res.Block {
+		t.Fatal("on_parse_error=warn must forward an oversize operation body, not block")
+	}
+}
+
+func TestRequestPolicy_FetchIgnoresInboundControlPlaneHeaders(t *testing.T) {
+	t.Parallel()
+	// A rule that would match a POST/application/json request must NOT fire on
+	// a /fetch call merely because the agent set those headers on the inbound
+	// control-plane request — the outbound fetch is always a plain GET.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream: %v", err)
+	}
+	rule := config.RequestPolicyRule{
+		Name:   rpRuleName,
+		Action: config.ActionBlock,
+		Route: config.RequestPolicyRoute{
+			Hosts:        []string{upstreamURL.Hostname()},
+			Methods:      []string{http.MethodPost},
+			ContentTypes: []string{"application/json"},
+		},
+		Reason: "dangerous operation requires operator approval",
+	}
+	p := newTestProxyWithConfig(t, reqPolicyConfig(rule))
+	handler := p.buildHandler(p.buildMux())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url="+url.QueryEscape(upstream.URL), nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-HTTP-Method-Override", http.MethodPost)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if got := w.Header().Get("X-Pipelock-Block-Reason"); got == "request_policy_deny" {
+		t.Fatal("inbound /fetch control-plane headers must not drive request_policy matching")
 	}
 }
 
@@ -525,9 +592,6 @@ func TestRequestPolicy_WebSocketHandshake_Blocks(t *testing.T) {
 
 func TestRequestPolicy_Reverse_Blocks(t *testing.T) {
 	t.Parallel()
-	cfg := reqPolicyConfig(blockRule(http.MethodDelete))
-	p := newTestProxyWithConfig(t, cfg)
-
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -537,6 +601,15 @@ func TestRequestPolicy_Reverse_Blocks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse upstream: %v", err)
 	}
+	// The reverse proxy forwards to a fixed upstream, so request_policy matches
+	// the upstream (egress) host, not the inbound Host header.
+	rule := config.RequestPolicyRule{
+		Name:   rpRuleName,
+		Action: config.ActionBlock,
+		Route:  config.RequestPolicyRoute{Hosts: []string{upstreamURL.Hostname()}, Methods: []string{http.MethodDelete}},
+		Reason: "dangerous operation requires operator approval",
+	}
+	p := newTestProxyWithConfig(t, reqPolicyConfig(rule))
 	rpHandler := NewReverseProxy(upstreamURL, &p.cfgPtr, &p.scannerPtr, p.logger, p.metrics, nil, nil, nil)
 	// Production wires this in server_lifecycle; a reverse handler without it
 	// would silently skip request_policy, so the test mirrors production.
@@ -553,10 +626,6 @@ func TestRequestPolicy_Reverse_Blocks(t *testing.T) {
 
 func TestRequestPolicy_ReverseGraphQL_BlocksWithBodyScanningDisabled(t *testing.T) {
 	t.Parallel()
-	cfg := reqPolicyConfig(graphqlBlockRule())
-	cfg.RequestBodyScanning.Enabled = false
-	p := newTestProxyWithConfig(t, cfg)
-
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -566,6 +635,25 @@ func TestRequestPolicy_ReverseGraphQL_BlocksWithBodyScanningDisabled(t *testing.
 	if err != nil {
 		t.Fatalf("parse upstream: %v", err)
 	}
+	// Rule scoped to the upstream (egress) host, mirroring real reverse traffic
+	// where the inbound URL carries no host.
+	rule := config.RequestPolicyRule{
+		Name:   rpRuleName,
+		Action: config.ActionBlock,
+		Route: config.RequestPolicyRoute{
+			Hosts:        []string{upstreamURL.Hostname()},
+			Methods:      []string{http.MethodPost},
+			ContentTypes: []string{"application/json"},
+		},
+		GraphQL: &config.RequestPolicyGraphQL{
+			OperationTypes:    []string{"mutation"},
+			RootFieldPatterns: []string{`^deleteRecord$`},
+		},
+		Reason: "dangerous operation requires operator approval",
+	}
+	cfg := reqPolicyConfig(rule)
+	cfg.RequestBodyScanning.Enabled = false
+	p := newTestProxyWithConfig(t, cfg)
 	rpHandler := NewReverseProxy(upstreamURL, &p.cfgPtr, &p.scannerPtr, p.logger, p.metrics, nil, nil, nil)
 	rpHandler.SetRequestPolicyFn(p.ApplyRequestPolicy)
 	rpHandler.SetRequestPolicyPrepareFn(p.PrepareRequestPolicyBody)

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -648,10 +648,20 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	// request_policy runs before the contract gate so a contract allow can
 	// never suppress an operation-policy block.
 	if rp.reqPolicyFn != nil {
+		// Evaluate against the rewritten upstream route, not the inbound URL:
+		// on the reverse path r.URL carries no host and omits the upstream
+		// base-path prefix, so host- and path-scoped rules would miss the
+		// actual egress destination. targetURL is the canonical egress URL.
+		rpHost := rp.upstream.Hostname()
+		rpPath := r.URL.EscapedPath()
+		if u, err := url.Parse(targetURL); err == nil {
+			rpHost = u.Hostname()
+			rpPath = u.EscapedPath()
+		}
 		rpInput := requestPolicyInput{
-			Host:        r.URL.Hostname(),
+			Host:        rpHost,
 			Method:      r.Method,
-			Path:        r.URL.EscapedPath(),
+			Path:        rpPath,
 			ContentType: r.Header.Get(headerContentType),
 			Headers:     r.Header,
 			Body:        reverseBodyBytes,

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -76,6 +76,8 @@ type ReverseProxyHandler struct {
 	envelopeVerifierPtr *atomic.Pointer[envelope.Verifier]
 	receiptEmitterPtr   *atomic.Pointer[receipt.Emitter]
 	contractLoaderPtr   *atomic.Pointer[contractruntime.Loader]
+	reqPolicyFn         func(requestPolicyInput) requestPolicyResult                 // nil = disabled
+	reqPolicyPrepareFn  func(*http.Request, *requestPolicyInput) requestPolicyResult // nil = no body pre-read
 	reloadMu            *sync.RWMutex
 }
 
@@ -194,6 +196,21 @@ func (rp *ReverseProxyHandler) SetReceiptEmitter(ptr *atomic.Pointer[receipt.Emi
 // SetContractLoader sets the atomic pointer to the learn-lock loader.
 func (rp *ReverseProxyHandler) SetContractLoader(ptr *atomic.Pointer[contractruntime.Loader]) {
 	rp.contractLoaderPtr = ptr
+}
+
+// SetRequestPolicyFn wires the request_policy evaluation into the
+// reverse-proxy handler. The function is typically Proxy.applyRequestPolicy
+// (a method value). When nil, request_policy is a no-op and the handler
+// proceeds directly to the contract gate.
+func (rp *ReverseProxyHandler) SetRequestPolicyFn(fn func(requestPolicyInput) requestPolicyResult) {
+	rp.reqPolicyFn = fn
+}
+
+// SetRequestPolicyPrepareFn wires the optional request_policy body pre-reader.
+// It is needed only when request_body_scanning did not already buffer a body
+// and an operation predicate requires body inspection.
+func (rp *ReverseProxyHandler) SetRequestPolicyPrepareFn(fn func(*http.Request, *requestPolicyInput) requestPolicyResult) {
+	rp.reqPolicyPrepareFn = fn
 }
 
 // emitReceipt records a signed action receipt for a reverse-proxy
@@ -626,6 +643,41 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			requestScannerVerdict = scannerVerdictForContinuingAction(verdict, cfg.EnforceEnabled())
 		}
 		reverseBodyBytes = bodyBytes
+	}
+
+	// request_policy runs before the contract gate so a contract allow can
+	// never suppress an operation-policy block.
+	if rp.reqPolicyFn != nil {
+		rpInput := requestPolicyInput{
+			Host:        r.URL.Hostname(),
+			Method:      r.Method,
+			Path:        r.URL.EscapedPath(),
+			ContentType: r.Header.Get(headerContentType),
+			Headers:     r.Header,
+			Body:        reverseBodyBytes,
+			BodyRead:    reverseBodyBytes != nil || r.Body == nil || r.Body == http.NoBody,
+			Transport:   TransportReverse,
+			Target:      targetURL,
+			RequestID:   requestID,
+			Agent:       agent,
+			AuditCtx:    newHTTPAuditContext(rp.logger, r.Method, targetURL, clientIP, requestID, agent),
+			Emit:        rp.emitReceipt,
+		}
+		if rp.reqPolicyPrepareFn != nil {
+			if rpRes := rp.reqPolicyPrepareFn(r, &rpInput); rpRes.Block {
+				rp.metrics.RecordReverseProxyRequest(r.Method, "403")
+				rp.metrics.RecordReverseProxyScanBlocked(scanDirectionRequest, blockLayerRequestPolicy)
+				writeReverseProxyBlock(w, http.StatusForbidden, rpRes.Info, "blocked by request policy: "+rpRes.Reason)
+				return
+			}
+			reverseBodyBytes = rpInput.Body
+		}
+		if rpRes := rp.reqPolicyFn(rpInput); rpRes.Block {
+			rp.metrics.RecordReverseProxyRequest(r.Method, "403")
+			rp.metrics.RecordReverseProxyScanBlocked(scanDirectionRequest, blockLayerRequestPolicy)
+			writeReverseProxyBlock(w, http.StatusForbidden, rpRes.Info, "blocked by request policy: "+rpRes.Reason)
+			return
+		}
 	}
 
 	gate, gateErr := EvaluateGate(ContractGateInput{

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -486,6 +486,27 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// request_policy runs before the contract gate so a contract allow can
+	// never suppress an operation-policy block.
+	if rpRes := p.applyRequestPolicy(requestPolicyInput{
+		Host:        parsed.Hostname(),
+		Method:      http.MethodGet,
+		Path:        parsed.EscapedPath(),
+		ContentType: r.Header.Get(headerContentType),
+		Headers:     r.Header,
+		BodyRead:    true,
+		Transport:   TransportWS,
+		Target:      targetURL,
+		RequestID:   requestID,
+		Agent:       agent,
+		AuditCtx:    actx,
+		Emit:        p.emitReceipt,
+	}); rpRes.Block {
+		p.metrics.RecordWSBlocked()
+		writeBlockedError(w, rpRes.Info, "WebSocket blocked by request policy: "+rpRes.Reason, http.StatusForbidden)
+		return
+	}
+
 	killSwitchActive := false
 	if p.ks != nil {
 		killSwitchActive = p.ks.IsActiveHTTP(r).Active

--- a/internal/reqpolicy/policy.go
+++ b/internal/reqpolicy/policy.go
@@ -6,10 +6,10 @@
 //
 // It is independent of request_body_scanning and complementary to the
 // learn-lock contract gate — it is neither a DLP scanner nor a behavioral
-// allowlist. v1 matches on route only (host / effective method / normalized
-// path / content type); GraphQL and JSON operation predicates are added in
-// later phases. The Matcher precompiles rule regexes once at config (re)load;
-// Evaluate is allocation-light and safe on the hot request path.
+// allowlist. It matches on route (host / effective method / normalized path /
+// content type) and optional extracted operations such as GraphQL root fields.
+// The Matcher precompiles rule regexes once at config (re)load; Evaluate is
+// allocation-light and safe on the hot request path.
 package reqpolicy
 
 import (
@@ -85,8 +85,10 @@ type compiledRule struct {
 // NewMatcher at config (re)load and swap it atomically alongside the rest of
 // the runtime config.
 type Matcher struct {
-	enabled bool
-	rules   []compiledRule
+	enabled           bool
+	onParseError      string
+	onOpaqueOperation string
+	rules             []compiledRule
 }
 
 // NewMatcher compiles cfg into a Matcher. It returns an error if any
@@ -99,6 +101,14 @@ func NewMatcher(cfg *config.RequestPolicy) (*Matcher, error) {
 		return m, nil
 	}
 	m.enabled = true
+	m.onParseError = cfg.OnParseError
+	if m.onParseError == "" {
+		m.onParseError = config.ActionBlock
+	}
+	m.onOpaqueOperation = cfg.OnOpaqueOperation
+	if m.onOpaqueOperation == "" {
+		m.onOpaqueOperation = config.ActionBlock
+	}
 	for i := range cfg.Rules {
 		r := &cfg.Rules[i]
 		cr := compiledRule{
@@ -148,6 +158,24 @@ func NewMatcher(cfg *config.RequestPolicy) (*Matcher, error) {
 	return m, nil
 }
 
+// OnParseError returns the configured action when an operation predicate's
+// route matches but the request body cannot be parsed.
+func (m *Matcher) OnParseError() string {
+	if m == nil || m.onParseError == "" {
+		return config.ActionBlock
+	}
+	return m.onParseError
+}
+
+// OnOpaqueOperation returns the configured action when an operation predicate's
+// route matches but the operation is opaque (for example APQ hash-only).
+func (m *Matcher) OnOpaqueOperation() string {
+	if m == nil || m.onOpaqueOperation == "" {
+		return config.ActionBlock
+	}
+	return m.onOpaqueOperation
+}
+
 // Evaluate runs meta against the ruleset and returns the strictest matching
 // Decision. Block beats warn; among equal-strictness matches an enforced rule
 // is preferred over a shadow rule so a real block is never masked by a shadow
@@ -168,6 +196,56 @@ func (m *Matcher) Evaluate(meta RequestMeta) Decision {
 		}
 	}
 	return best
+}
+
+// NeedsOperations reports whether any operation predicate route matches this
+// request. Transports use this to decide whether they must read/parse a body
+// independently of request_body_scanning.
+func (m *Matcher) NeedsOperations(meta RequestMeta) bool {
+	if m == nil || !m.enabled {
+		return false
+	}
+	for i := range m.rules {
+		cr := &m.rules[i]
+		if cr.graphql != nil && cr.routeMatches(meta) {
+			return true
+		}
+	}
+	return false
+}
+
+// EvaluateUninspectable returns the strictest route-matching operation rule
+// decision using action for parse-error or opaque-operation fail-closed cases.
+// A configured action=allow yields no decision.
+func (m *Matcher) EvaluateUninspectable(meta RequestMeta, action string) Decision {
+	if m == nil || !m.enabled || action == "" || action == config.ActionAllow {
+		return Decision{}
+	}
+	var best Decision
+	for i := range m.rules {
+		cr := &m.rules[i]
+		if cr.graphql == nil || !cr.routeMatches(meta) {
+			continue
+		}
+		cand := Decision{Action: action, RuleName: cr.name, Reason: cr.reason, Shadow: cr.shadow}
+		if betterDecision(cand, best) {
+			best = cand
+		}
+	}
+	return best
+}
+
+// Stricter returns the stricter of two decisions using the same ordering
+// Evaluate applies internally: block > warn > allow, and at equal action an
+// enforced decision beats a shadow one. A transport that evaluates the same
+// request under more than one effective method — to stop a method-override
+// header from downgrading a method-scoped rule, per EffectiveMethod's caveat —
+// combines the per-method results with this.
+func Stricter(a, b Decision) Decision {
+	if betterDecision(a, b) {
+		return a
+	}
+	return b
 }
 
 // betterDecision reports whether cand should replace cur as the selected
@@ -195,6 +273,16 @@ func actionRank(a string) int {
 }
 
 func (cr *compiledRule) matches(meta RequestMeta) bool {
+	if !cr.routeMatches(meta) {
+		return false
+	}
+	if cr.graphql != nil && !cr.graphql.matches(meta.Operations) {
+		return false
+	}
+	return true
+}
+
+func (cr *compiledRule) routeMatches(meta RequestMeta) bool {
 	if len(cr.hosts) > 0 && !hostMatches(NormalizeHost(meta.Host), cr.hosts) {
 		return false
 	}
@@ -210,9 +298,6 @@ func (cr *compiledRule) matches(meta RequestMeta) bool {
 		if _, ok := cr.contentTypes[NormalizeContentType(meta.ContentType)]; !ok {
 			return false
 		}
-	}
-	if cr.graphql != nil && !cr.graphql.matches(meta.Operations) {
-		return false
 	}
 	return true
 }

--- a/internal/reqpolicy/policy_test.go
+++ b/internal/reqpolicy/policy_test.go
@@ -208,6 +208,58 @@ func TestEvaluate_EnforcedPreferredOverShadow(t *testing.T) {
 	}
 }
 
+func TestMatcher_OperationHelpers(t *testing.T) {
+	r := apiWriteRule()
+	r.GraphQL = &config.RequestPolicyGraphQL{
+		OperationTypes:    []string{gqlMutation},
+		RootFieldPatterns: []string{`^deleteRecord$`},
+	}
+	m, err := NewMatcher(&config.RequestPolicy{
+		Enabled:           true,
+		OnParseError:      config.ActionWarn,
+		OnOpaqueOperation: config.ActionBlock,
+		Rules:             []config.RequestPolicyRule{r},
+	})
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+	meta := RequestMeta{Host: "api.service.example.com", Method: "POST", Path: "/api/write", ContentType: "application/json"}
+	if !m.NeedsOperations(meta) {
+		t.Fatal("route-matched GraphQL rule should need operation extraction")
+	}
+	if m.NeedsOperations(RequestMeta{Host: "api.service.example.com", Method: "GET", Path: "/api/write", ContentType: "application/json"}) {
+		t.Fatal("non-route-matching request should not need operation extraction")
+	}
+	if got := m.OnParseError(); got != config.ActionWarn {
+		t.Fatalf("OnParseError = %q, want warn", got)
+	}
+	if got := m.OnOpaqueOperation(); got != config.ActionBlock {
+		t.Fatalf("OnOpaqueOperation = %q, want block", got)
+	}
+	parseDecision := m.EvaluateUninspectable(meta, m.OnParseError())
+	if parseDecision.Action != config.ActionWarn || parseDecision.RuleName != "api-write" {
+		t.Fatalf("parse decision = %+v, want warn from api-write", parseDecision)
+	}
+	if got := m.EvaluateUninspectable(meta, config.ActionAllow); got.Matched() {
+		t.Fatalf("allow uninspectable action should produce no decision, got %+v", got)
+	}
+	var nilM *Matcher
+	if nilM.OnParseError() != config.ActionBlock || nilM.OnOpaqueOperation() != config.ActionBlock {
+		t.Fatal("nil matcher should default fail-closed actions to block")
+	}
+}
+
+func TestStricter(t *testing.T) {
+	block := Decision{Action: config.ActionBlock, RuleName: "block"}
+	warn := Decision{Action: config.ActionWarn, RuleName: "warn"}
+	if got := Stricter(warn, block); got.RuleName != "block" {
+		t.Fatalf("Stricter(warn, block) = %+v, want block", got)
+	}
+	if got := Stricter(block, warn); got.RuleName != "block" {
+		t.Fatalf("Stricter(block, warn) = %+v, want block", got)
+	}
+}
+
 func TestNewMatcher_BadPattern(t *testing.T) {
 	_, err := NewMatcher(&config.RequestPolicy{Enabled: true, Rules: []config.RequestPolicyRule{{
 		Name:   "bad",


### PR DESCRIPTION
## Summary

request_policy shipped as engine + config + GraphQL extractor, but nothing in the proxy called it, so it never enforced. This wires it into every agent-egress transport.

## What changed

- A precompiled request_policy matcher is built at startup and re-staged fail-closed on hot reload.
- Each transport evaluates request_policy before its contract gate so a contract allow can never suppress an operation-policy block: forward absolute-URI, forward CONNECT (host-only), TLS-intercept inner request, reverse proxy, fetch, followed-redirect hops, and the WebSocket handshake. Kill-switch-only gates are left alone (they block unconditionally).
- Route rules match host / effective method / normalized path / content type. The evaluator checks both the base and any method-override header, so `X-HTTP-Method-Override` cannot downgrade a method-scoped rule.
- GraphQL operation predicates enforce: when such a rule's route matches, the body is read (and re-wrapped so the upstream still gets it) and classified, independent of `request_body_scanning`. Unreadable, oversized, unparseable, opaque, or absent bodies fail closed to `on_parse_error` / `on_opaque_operation` (both default block).
- Enforced blocks emit `request_policy_deny` headers and a correlated receipt when an emitter is configured. New metric `pipelock_request_policy_decisions_total{rule,action}`.

## Known limitations

- WebSocket per-frame operation policy and JSON discriminator-field rules are later slices. The WS handshake is covered.
- Method-preserving redirects (307/308) to a GraphQL endpoint are treated as opaque (fail closed) rather than having their body inspected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request-policy enforcement added across forwarding, reverse proxy, CONNECT tunneling, WebSocket and redirect flows — GraphQL-aware rules, fail-closed handling for uninspectable payloads, live hot-reload of rules, and policy-provided deny reasons returned as 403 JSON responses; blocked requests can emit correlated receipts when configured.

* **Chores**
  * New metrics tracking request-policy decisions by rule and action.

* **Tests**
  * Extensive end-to-end and unit tests covering policy evaluation, GraphQL behavior, body handling, hot-reload, and deny reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/631?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->