### PR TITLE
feat(proxy): enforce request_policy on GraphQL-over-GET and multipart

### DIFF
--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1449,6 +1449,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		Host:        r.URL.Hostname(),
 		Method:      r.Method,
 		Path:        r.URL.EscapedPath(),
+		Query:       r.URL.RawQuery,
 		ContentType: r.Header.Get(headerContentType),
 		Headers:     r.Header,
 		Body:        forwardBodyBytes,

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -1147,6 +1147,7 @@ func newInterceptHandler(
 				Host:        r.URL.Hostname(),
 				Method:      r.Method,
 				Path:        r.URL.EscapedPath(),
+				Query:       r.URL.RawQuery,
 				ContentType: r.Header.Get(headerContentType),
 				Headers:     r.Header,
 				Body:        interceptBodyBytes,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3624,6 +3624,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		Host:      parsed.Hostname(),
 		Method:    http.MethodGet,
 		Path:      parsed.EscapedPath(),
+		Query:     parsed.RawQuery,
 		BodyRead:  true,
 		Transport: TransportFetch,
 		Target:    displayURL,

--- a/internal/proxy/requestpolicy.go
+++ b/internal/proxy/requestpolicy.go
@@ -53,6 +53,7 @@ type requestPolicyInput struct {
 	Host        string
 	Method      string // base HTTP method as seen on the wire
 	Path        string
+	Query       string // URL raw query, for GraphQL-over-GET operation extraction
 	ContentType string
 	Headers     http.Header // resolved for method-override detection
 	Body        []byte
@@ -207,7 +208,7 @@ func (p *Proxy) applyRequestPolicy(in requestPolicyInput) requestPolicyResult {
 		if !in.BodyRead {
 			d = reqpolicy.Stricter(d, p.evaluateRequestPolicyUninspectable(in, m.OnOpaqueOperation()))
 		} else {
-			ops, parseOK, opaque := reqpolicy.ExtractGraphQL(in.Body)
+			ops, parseOK, opaque := extractRequestPolicyOperations(in)
 			if !parseOK {
 				d = reqpolicy.Stricter(d, p.evaluateRequestPolicyUninspectable(in, m.OnParseError()))
 			} else {

--- a/internal/proxy/requestpolicy_operations.go
+++ b/internal/proxy/requestpolicy_operations.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/url"
+
+	"github.com/luckyPipewrench/pipelock/internal/reqpolicy"
+)
+
+// multipartOperationsMaxBytes caps the bytes read from a multipart "operations"
+// field. That field carries only the GraphQL-over-HTTP JSON (the query and
+// variables map), never the uploaded files, so 1 MiB is generous. The cap
+// keeps a crafted multipart part from forcing an unbounded read.
+const multipartOperationsMaxBytes = 1 * 1024 * 1024
+
+// extractRequestPolicyOperations pulls the request's GraphQL operations from
+// whichever surface carries them, then classifies with the shared extractor:
+//
+//   - multipart/form-data: the graphql-multipart-request spec puts the
+//     GraphQL-over-HTTP JSON in the "operations" form field.
+//   - GraphQL-over-GET (no body, ?query=...): the document is a query parameter.
+//   - otherwise: the JSON request body (single object or batch array).
+//
+// The (parseOK, opaque) returns drive the caller's fail-closed handling exactly
+// as for a JSON body: a multipart request with no readable "operations" field,
+// or a GET whose query parameter is absent/unparseable, surfaces parseOK=false
+// so on_parse_error applies.
+func extractRequestPolicyOperations(in requestPolicyInput) (ops []reqpolicy.RequestOperation, parseOK, opaque bool) {
+	if isMultipartFormData(in.ContentType) {
+		opsJSON, ok := multipartOperationsField(in.ContentType, in.Body)
+		if !ok {
+			return nil, false, false
+		}
+		return reqpolicy.ExtractGraphQL(opsJSON)
+	}
+	if len(in.Body) == 0 {
+		if opsJSON, ok := graphqlOperationsFromQuery(in.Query); ok {
+			return reqpolicy.ExtractGraphQL(opsJSON)
+		}
+	}
+	return reqpolicy.ExtractGraphQL(in.Body)
+}
+
+// isMultipartFormData reports whether ct is a multipart/form-data media type,
+// ignoring parameters (boundary, charset) and case.
+func isMultipartFormData(ct string) bool {
+	mt, _, err := mime.ParseMediaType(ct)
+	return err == nil && mt == "multipart/form-data"
+}
+
+// multipartOperationsField returns the bytes of the "operations" form field of
+// a multipart/form-data body, or ok=false when the boundary is missing or no
+// such field is present. Only the operations field is read (bounded); file
+// parts are skipped without buffering.
+func multipartOperationsField(ct string, body []byte) ([]byte, bool) {
+	_, params, err := mime.ParseMediaType(ct)
+	if err != nil {
+		return nil, false
+	}
+	boundary := params["boundary"]
+	if boundary == "" {
+		return nil, false
+	}
+	mr := multipart.NewReader(bytes.NewReader(body), boundary)
+	for {
+		part, err := mr.NextPart()
+		if err != nil {
+			return nil, false
+		}
+		if part.FormName() == "operations" {
+			data, readErr := io.ReadAll(io.LimitReader(part, multipartOperationsMaxBytes))
+			_ = part.Close()
+			if readErr != nil {
+				return nil, false
+			}
+			return data, true
+		}
+		_ = part.Close()
+	}
+}
+
+// graphqlOperationsFromQuery builds the GraphQL-over-HTTP JSON from a URL query
+// string carrying a GraphQL-over-GET request (?query=...&operationName=...). It
+// returns ok=false when there is no query parameter. variables are ignored:
+// operation type and root-field classification never depend on them.
+func graphqlOperationsFromQuery(rawQuery string) ([]byte, bool) {
+	if rawQuery == "" {
+		return nil, false
+	}
+	vals, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return nil, false
+	}
+	q := vals.Get("query")
+	if q == "" {
+		return nil, false
+	}
+	doc := struct {
+		Query         string `json:"query"`
+		OperationName string `json:"operationName,omitempty"`
+	}{Query: q, OperationName: vals.Get("operationName")}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		return nil, false
+	}
+	return b, true
+}

--- a/internal/proxy/requestpolicy_operations.go
+++ b/internal/proxy/requestpolicy_operations.go
@@ -75,9 +75,15 @@ func multipartOperationsField(ct string, body []byte) ([]byte, bool) {
 			return nil, false
 		}
 		if part.FormName() == "operations" {
-			data, readErr := io.ReadAll(io.LimitReader(part, multipartOperationsMaxBytes))
+			// Read one past the cap so an over-cap field is detected and
+			// rejected rather than silently truncated: classifying a partial
+			// payload could miss a dangerous operation padded past the limit.
+			data, readErr := io.ReadAll(io.LimitReader(part, multipartOperationsMaxBytes+1))
 			_ = part.Close()
 			if readErr != nil {
+				return nil, false
+			}
+			if len(data) > multipartOperationsMaxBytes {
 				return nil, false
 			}
 			return data, true

--- a/internal/proxy/requestpolicy_operations_test.go
+++ b/internal/proxy/requestpolicy_operations_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
@@ -115,6 +116,28 @@ func TestMultipartOperationsField(t *testing.T) {
 	_ = w.Close()
 	if _, ok := multipartOperationsField(w.FormDataContentType(), nob.Bytes()); ok {
 		t.Error("body without an operations field should fail extraction")
+	}
+}
+
+func TestMultipartOperationsField_OverCapFailsClosed(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	fw, err := w.CreateFormField("operations")
+	if err != nil {
+		t.Fatalf("CreateFormField: %v", err)
+	}
+	// An operations field larger than the cap must be rejected, not truncated
+	// and classified — otherwise a dangerous op padded past the cap is hidden.
+	huge := gqlJSONBody("mutation { deleteRecord(pad: \"" + strings.Repeat("a", multipartOperationsMaxBytes) + "\") { id } }")
+	if _, err := fw.Write([]byte(huge)); err != nil {
+		t.Fatalf("write operations: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if _, ok := multipartOperationsField(w.FormDataContentType(), buf.Bytes()); ok {
+		t.Fatal("an over-cap multipart operations field must fail closed (ok=false)")
 	}
 }
 

--- a/internal/proxy/requestpolicy_operations_test.go
+++ b/internal/proxy/requestpolicy_operations_test.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const gqlDeleteMutation = "mutation { deleteRecord { id } }"
+
+// gqlJSONBody wraps a GraphQL document as a GraphQL-over-HTTP JSON request body.
+func gqlJSONBody(query string) string {
+	return `{"query":` + strconv.Quote(query) + `}`
+}
+
+// gqlOperationRule blocks a deleteRecord mutation regardless of HTTP method or
+// content type, so the GET and multipart surfaces both route-match. Operators
+// who want to catch every operation-bearing surface leave method/content_type
+// unconstrained, exactly as here.
+func gqlOperationRule() config.RequestPolicyRule {
+	return config.RequestPolicyRule{
+		Name:   rpRuleName,
+		Action: config.ActionBlock,
+		Route:  config.RequestPolicyRoute{Hosts: []string{rpTestHost}},
+		GraphQL: &config.RequestPolicyGraphQL{
+			OperationTypes:    []string{"mutation"},
+			RootFieldPatterns: []string{`^deleteRecord$`},
+		},
+		Reason: "dangerous operation requires operator approval",
+	}
+}
+
+// multipartGraphQLBody builds a graphql-multipart-request body: an "operations"
+// field carrying the GraphQL-over-HTTP JSON, plus a file part to mimic a real
+// upload. Returns the body and the content-type (with boundary).
+func multipartGraphQLBody(t *testing.T, query string) ([]byte, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	fw, err := w.CreateFormField("operations")
+	if err != nil {
+		t.Fatalf("CreateFormField: %v", err)
+	}
+	if _, err := fw.Write([]byte(gqlJSONBody(query))); err != nil {
+		t.Fatalf("write operations: %v", err)
+	}
+	file, err := w.CreateFormFile("0", "upload.bin")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := file.Write([]byte("file-contents")); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	return buf.Bytes(), w.FormDataContentType()
+}
+
+// --- Unit: surface extractors ----------------------------------------------
+
+func TestGraphqlOperationsFromQuery(t *testing.T) {
+	t.Parallel()
+	raw := "query=" + url.QueryEscape(gqlDeleteMutation) + "&operationName=Del"
+	got, ok := graphqlOperationsFromQuery(raw)
+	if !ok {
+		t.Fatal("expected ok for a query parameter")
+	}
+	// The result is GraphQL-over-HTTP JSON carrying the query and operationName;
+	// the dispatch test below proves it classifies as a mutation.
+	if !bytes.Contains(got, []byte("deleteRecord")) || !bytes.Contains(got, []byte(`"operationName":"Del"`)) {
+		t.Fatalf("query JSON = %s, want query + operationName", got)
+	}
+
+	if _, ok := graphqlOperationsFromQuery(""); ok {
+		t.Error("empty query string should not produce operations")
+	}
+	if _, ok := graphqlOperationsFromQuery("foo=bar"); ok {
+		t.Error("query string without a query param should not produce operations")
+	}
+	if _, ok := graphqlOperationsFromQuery("query=%zz"); ok {
+		t.Error("a malformed query string should not produce operations")
+	}
+}
+
+func TestMultipartOperationsField(t *testing.T) {
+	t.Parallel()
+	body, ct := multipartGraphQLBody(t, gqlDeleteMutation)
+	got, ok := multipartOperationsField(ct, body)
+	if !ok {
+		t.Fatal("expected to find the operations field")
+	}
+	if !bytes.Contains(got, []byte("deleteRecord")) {
+		t.Errorf("operations field missing query: %s", got)
+	}
+
+	// No boundary -> not parseable.
+	if _, ok := multipartOperationsField("multipart/form-data", body); ok {
+		t.Error("missing boundary should fail extraction")
+	}
+	// A multipart body with no operations field -> ok=false.
+	var nob bytes.Buffer
+	w := multipart.NewWriter(&nob)
+	_, _ = w.CreateFormField("other")
+	_ = w.Close()
+	if _, ok := multipartOperationsField(w.FormDataContentType(), nob.Bytes()); ok {
+		t.Error("body without an operations field should fail extraction")
+	}
+}
+
+func TestIsMultipartFormData(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"multipart/form-data; boundary=x": true,
+		"multipart/form-data":             true,
+		"MULTIPART/FORM-DATA; boundary=x": true,
+		"application/json":                false,
+		"multipart/mixed":                 false,
+		"":                                false,
+	}
+	for ct, want := range cases {
+		if got := isMultipartFormData(ct); got != want {
+			t.Errorf("isMultipartFormData(%q) = %v, want %v", ct, got, want)
+		}
+	}
+}
+
+func TestExtractRequestPolicyOperations_Dispatch(t *testing.T) {
+	t.Parallel()
+	// multipart surface
+	body, ct := multipartGraphQLBody(t, gqlDeleteMutation)
+	ops, parseOK, _ := extractRequestPolicyOperations(requestPolicyInput{ContentType: ct, Body: body})
+	if !parseOK || len(ops) != 1 || ops[0].Kind != "mutation" {
+		t.Fatalf("multipart dispatch: ops=%+v parseOK=%v", ops, parseOK)
+	}
+	// GET query surface (no body)
+	ops, parseOK, _ = extractRequestPolicyOperations(requestPolicyInput{
+		Query: "query=" + url.QueryEscape(gqlDeleteMutation),
+	})
+	if !parseOK || len(ops) != 1 || ops[0].Kind != "mutation" {
+		t.Fatalf("GET dispatch: ops=%+v parseOK=%v", ops, parseOK)
+	}
+	// JSON body surface
+	ops, parseOK, _ = extractRequestPolicyOperations(requestPolicyInput{
+		ContentType: "application/json", Body: []byte(gqlJSONBody(gqlDeleteMutation)),
+	})
+	if !parseOK || len(ops) != 1 || ops[0].Kind != "mutation" {
+		t.Fatalf("JSON dispatch: ops=%+v parseOK=%v", ops, parseOK)
+	}
+	// multipart with no operations field -> parseOK=false (fail closed upstream)
+	var nob bytes.Buffer
+	w := multipart.NewWriter(&nob)
+	_, _ = w.CreateFormField("other")
+	_ = w.Close()
+	if _, parseOK, _ := extractRequestPolicyOperations(requestPolicyInput{ContentType: w.FormDataContentType(), Body: nob.Bytes()}); parseOK {
+		t.Error("multipart without operations field should report parseOK=false")
+	}
+}
+
+// --- applyRequestPolicy: GET + multipart enforce ----------------------------
+
+func TestApplyRequestPolicy_GraphQLOverGETBlocks(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(gqlOperationRule()))
+	res := p.applyRequestPolicy(requestPolicyInput{
+		Host:      rpTestHost,
+		Method:    http.MethodGet,
+		Path:      "/graphql",
+		Query:     "query=" + url.QueryEscape(gqlDeleteMutation),
+		BodyRead:  true, // GET has no body
+		Transport: TransportFetch,
+		AuditCtx:  audit.LogContext{},
+	})
+	if !res.Block {
+		t.Fatal("GraphQL-over-GET deleteRecord mutation should block")
+	}
+}
+
+func TestApplyRequestPolicy_GraphQLOverGETBenignForwards(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(gqlOperationRule()))
+	res := p.applyRequestPolicy(requestPolicyInput{
+		Host:      rpTestHost,
+		Method:    http.MethodGet,
+		Path:      "/graphql",
+		Query:     "query=" + url.QueryEscape("query { record { id } }"),
+		BodyRead:  true,
+		Transport: TransportFetch,
+		AuditCtx:  audit.LogContext{},
+	})
+	if res.Block {
+		t.Fatal("a benign GraphQL-over-GET query must forward")
+	}
+}
+
+func TestApplyRequestPolicy_GraphQLMultipartBlocks(t *testing.T) {
+	t.Parallel()
+	body, ct := multipartGraphQLBody(t, gqlDeleteMutation)
+	p := newTestProxyWithConfig(t, reqPolicyConfig(gqlOperationRule()))
+	res := p.applyRequestPolicy(requestPolicyInput{
+		Host:        rpTestHost,
+		Method:      http.MethodPost,
+		Path:        "/graphql",
+		ContentType: ct,
+		Body:        body,
+		BodyRead:    true,
+		Transport:   TransportForward,
+		AuditCtx:    audit.LogContext{},
+	})
+	if !res.Block {
+		t.Fatal("multipart GraphQL deleteRecord mutation should block")
+	}
+}
+
+// --- Transport parity: GraphQL-over-GET through the fetch handler -----------
+
+func TestRequestPolicy_FetchGraphQLOverGET_Blocks(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(gqlOperationRule()))
+	handler := p.buildHandler(p.buildMux())
+
+	inner := "http://" + rpTestHost + "/graphql?query=" + url.QueryEscape(gqlDeleteMutation)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url="+url.QueryEscape(inner), nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assertRequestPolicyBlock(t, w)
+}

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -654,14 +654,17 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		// actual egress destination. targetURL is the canonical egress URL.
 		rpHost := rp.upstream.Hostname()
 		rpPath := r.URL.EscapedPath()
+		rpQuery := r.URL.RawQuery
 		if u, err := url.Parse(targetURL); err == nil {
 			rpHost = u.Hostname()
 			rpPath = u.EscapedPath()
+			rpQuery = u.RawQuery
 		}
 		rpInput := requestPolicyInput{
 			Host:        rpHost,
 			Method:      r.Method,
 			Path:        rpPath,
+			Query:       rpQuery,
 			ContentType: r.Header.Get(headerContentType),
 			Headers:     r.Header,
 			Body:        reverseBodyBytes,


### PR DESCRIPTION
## Summary

Extends request_policy operation extraction (merged for the JSON request body in #631) to the two remaining GraphQL-over-HTTP request shapes, so a rule that blocks a mutation on the POST-body path cannot be dodged by re-encoding it.

## What changed

- **GraphQL-over-GET:** a `?query=` URL parameter is wrapped and classified by the existing extractor.
- **multipart GraphQL upload** (graphql-multipart-request spec): the GraphQL JSON in the `operations` form field is extracted; only that field is read (bounded), file parts are skipped without buffering.
- A shared dispatch picks the surface by content type and method, then feeds the existing dependency-free extractor, so parse-error and opaque fail-closed handling are unchanged. Transports populate the URL query for the GET path (reverse proxy uses the upstream query).

## Known limitations

JSON discriminator-field rules, Microsoft Graph `$batch` recursion, and WebSocket per-frame operation policy remain later slices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request policies now consider URL query strings for all proxy flows (forwarded, intercepted, outbound fetches and reverse-proxied requests).
  * GraphQL-over-HTTP handling improved: policies correctly inspect operations from JSON body, query-string (GET), and multipart form-data; oversized/malformed multipart operations fail closed.

* **Tests**
  * Added end-to-end tests covering GraphQL operation extraction and policy enforcement across those surfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/632?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->