### PR TITLE
feat(reqpolicy): JSON discriminator rules + WebSocket per-frame policy

### DIFF
--- a/internal/config/canonical_test.go
+++ b/internal/config/canonical_test.go
@@ -262,6 +262,24 @@ func TestCanonicalPolicyHash_PolicyFieldsDoAffect(t *testing.T) {
 				c.ForwardProxy.SNIVerification = &f
 			},
 		},
+		{
+			// A request_policy discriminator predicate is policy: two
+			// configs differing only by it must produce different ph, or
+			// emitted receipts would not reflect the rail.
+			name: "request_policy discriminator rule added",
+			mut: func(c *Config) {
+				c.RequestPolicy.Enabled = true
+				c.RequestPolicy.Rules = []RequestPolicyRule{{
+					Name:   "json-destructive",
+					Action: ActionBlock,
+					Route:  RequestPolicyRoute{Hosts: []string{"api.example.com"}},
+					Discriminator: &RequestPolicyDiscriminator{
+						Field:         "action",
+						ValuePatterns: []string{"^delete"},
+					},
+				}}
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/config/requestpolicy_validate_test.go
+++ b/internal/config/requestpolicy_validate_test.go
@@ -323,3 +323,52 @@ func TestValidateRequestPolicy_GraphQL(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRequestPolicy_Discriminator(t *testing.T) {
+	t.Run("valid predicate trims field and patterns", func(t *testing.T) {
+		c := enabledPolicy(RequestPolicyRule{
+			Name:   "disc",
+			Action: ActionBlock,
+			Route:  RequestPolicyRoute{Hosts: []string{"api.service.example.com"}},
+			Discriminator: &RequestPolicyDiscriminator{
+				Field:         "  action  ",
+				ValuePatterns: []string{"  ^delete  "},
+			},
+		})
+		if _, err := c.ValidateWithWarnings(); err != nil {
+			t.Fatalf("valid discriminator predicate rejected: %v", err)
+		}
+		d := c.RequestPolicy.Rules[0].Discriminator
+		if d.Field != "action" {
+			t.Errorf("field not trimmed/persisted: %q", d.Field)
+		}
+		if d.ValuePatterns[0] != "^delete" {
+			t.Errorf("value_pattern not trimmed/persisted: %q", d.ValuePatterns[0])
+		}
+	})
+
+	tests := []struct {
+		name string
+		disc *RequestPolicyDiscriminator
+		want string
+	}{
+		{"empty field", &RequestPolicyDiscriminator{Field: "  ", ValuePatterns: []string{"x"}}, "discriminator field must be set"},
+		{"no value patterns", &RequestPolicyDiscriminator{Field: "action"}, "discriminator must set value_patterns"},
+		{"empty value pattern", &RequestPolicyDiscriminator{Field: "action", ValuePatterns: []string{"  "}}, "empty discriminator value_pattern"},
+		{"invalid value pattern", &RequestPolicyDiscriminator{Field: "action", ValuePatterns: []string{"("}}, "invalid discriminator value_pattern"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := enabledPolicy(RequestPolicyRule{
+				Name:          "disc",
+				Action:        ActionBlock,
+				Route:         RequestPolicyRoute{Hosts: []string{"api.service.example.com"}},
+				Discriminator: tc.disc,
+			})
+			_, err := c.ValidateWithWarnings()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -266,12 +266,13 @@ type RequestPolicyBatch struct {
 // section-level default_action knob, so the section can never be configured
 // into default-deny.
 type RequestPolicyRule struct {
-	Name    string                `yaml:"name"`   // bounded, metric-label-safe identifier
-	Action  string                `yaml:"action"` // block | warn
-	Shadow  bool                  `yaml:"shadow"` // log the would-be action, forward anyway
-	Route   RequestPolicyRoute    `yaml:"route"`
-	GraphQL *RequestPolicyGraphQL `yaml:"graphql,omitempty"` // optional GraphQL operation predicate
-	Reason  string                `yaml:"reason"`            // operator-facing explanation (never logged with content)
+	Name          string                      `yaml:"name"`   // bounded, metric-label-safe identifier
+	Action        string                      `yaml:"action"` // block | warn
+	Shadow        bool                        `yaml:"shadow"` // log the would-be action, forward anyway
+	Route         RequestPolicyRoute          `yaml:"route"`
+	GraphQL       *RequestPolicyGraphQL       `yaml:"graphql,omitempty"`       // optional GraphQL operation predicate
+	Discriminator *RequestPolicyDiscriminator `yaml:"discriminator,omitempty"` // optional JSON discriminator-field predicate
+	Reason        string                      `yaml:"reason"`                  // operator-facing explanation (never logged with content)
 }
 
 // RequestPolicyRoute selects which requests a rule applies to. An empty
@@ -295,6 +296,21 @@ type RequestPolicyRoute struct {
 type RequestPolicyGraphQL struct {
 	OperationTypes    []string `yaml:"operation_types"`     // query | mutation | subscription
 	RootFieldPatterns []string `yaml:"root_field_patterns"` // RE2 patterns against resolved root field names
+}
+
+// RequestPolicyDiscriminator is an optional JSON discriminator-field predicate
+// applied after the route matches. The request body is parsed as JSON and the
+// top-level Field is looked up: a string value is matched against ValuePatterns
+// (the predicate matches when any pattern matches); a present but non-string
+// value, or a non-object top-level body, is opaque and fails closed per
+// request_policy.on_opaque_operation; an absent field does not match (the
+// allow-by-default rail forwards unless another rule matches). Invalid JSON is
+// handled as a parse error per request_policy.on_parse_error. This first cut
+// addresses only top-level fields; nested paths are a deliberate future
+// extension and a dotted Field is treated as a single literal key today.
+type RequestPolicyDiscriminator struct {
+	Field         string   `yaml:"field"`          // top-level JSON object key carrying the operation discriminator
+	ValuePatterns []string `yaml:"value_patterns"` // RE2 patterns matched against the string value at Field
 }
 
 // Config is the top-level Pipelock configuration.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -829,6 +829,11 @@ func (c *Config) validateRequestPolicy(warnings *[]Warning) error {
 				return err
 			}
 		}
+		if r.Discriminator != nil {
+			if err := validateRequestPolicyDiscriminator(r.Name, r.Discriminator); err != nil {
+				return err
+			}
+		}
 		if rp.Enabled {
 			c.warnRequestPolicyVisibility(r, warnings)
 		}
@@ -917,6 +922,33 @@ func validateRequestPolicyGraphQL(rule string, g *RequestPolicyGraphQL) error {
 	return nil
 }
 
+// validateRequestPolicyDiscriminator validates and normalizes a rule's JSON
+// discriminator predicate. The field name and value patterns are trimmed in
+// place so the runtime predicate (which also trims) and validation agree;
+// surrounding whitespace would otherwise compile into a value regex and
+// silently under-match, weakening the rail. At least one value pattern is
+// required: a discriminator with no patterns can never match a string value.
+func validateRequestPolicyDiscriminator(rule string, d *RequestPolicyDiscriminator) error {
+	d.Field = strings.TrimSpace(d.Field)
+	if d.Field == "" {
+		return fmt.Errorf("request_policy rule %q discriminator field must be set", rule)
+	}
+	if len(d.ValuePatterns) == 0 {
+		return fmt.Errorf("request_policy rule %q discriminator must set value_patterns", rule)
+	}
+	for i, p := range d.ValuePatterns {
+		pat := strings.TrimSpace(p)
+		if pat == "" {
+			return fmt.Errorf("request_policy rule %q has empty discriminator value_pattern", rule)
+		}
+		if _, err := regexp.Compile(pat); err != nil {
+			return fmt.Errorf("request_policy rule %q has invalid discriminator value_pattern %q: %w", rule, p, err)
+		}
+		d.ValuePatterns[i] = pat
+	}
+	return nil
+}
+
 func validHTTPMethod(m string) bool {
 	switch m {
 	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
@@ -980,7 +1012,7 @@ func validateRequestPolicyFailureAction(field, action string) error {
 }
 
 func requestPolicyRuleNeedsInnerHTTP(r *RequestPolicyRule) bool {
-	if r.GraphQL != nil {
+	if r.GraphQL != nil || r.Discriminator != nil {
 		return true
 	}
 	return requestPolicyRouteNeedsInnerHTTP(r.Route)

--- a/internal/proxy/airlock.go
+++ b/internal/proxy/airlock.go
@@ -20,6 +20,7 @@ const (
 	TransportForward = "forward"
 	TransportConnect = "connect"
 	TransportWS      = "websocket"
+	TransportWSFrame = "websocket_frame" // per-message-frame request_policy operation evaluation
 	TransportMCP     = "mcp"
 	TransportScanAPI = "scan_api"
 	TransportReverse = "reverse"

--- a/internal/proxy/requestpolicy.go
+++ b/internal/proxy/requestpolicy.go
@@ -65,6 +65,13 @@ type requestPolicyInput struct {
 	Agent     string
 	AuditCtx  audit.LogContext
 	Emit      func(receipt.EmitOpts) // transport's receipt emitter (e.g. p.emitReceipt)
+
+	// DeferBodyPredicate evaluates route-only rules and skips body-predicate
+	// (GraphQL / discriminator) evaluation for this call. The WebSocket
+	// handshake sets it: the upgrade carries no operation body, so a body
+	// predicate must not fail-close the handshake on the empty body — the
+	// operations arrive in frames and are evaluated per frame instead.
+	DeferBodyPredicate bool
 }
 
 // requestPolicyResult tells the calling transport what to do. Block is true
@@ -89,48 +96,64 @@ func (p *Proxy) requestPolicyMatcher() *reqpolicy.Matcher {
 	return m
 }
 
-func requestPolicyMeta(host, method, path, contentType string, ops []reqpolicy.RequestOperation) reqpolicy.RequestMeta {
-	return reqpolicy.RequestMeta{Host: host, Method: method, Path: path, ContentType: contentType, Operations: ops}
+// requestPolicyBody carries the per-request body-predicate inputs the matcher
+// needs: extracted GraphQL operations and the body parsed as a generic JSON
+// value for discriminator-field predicates. A zero value (route-only pass)
+// matches no body predicate, so route-only rules fire while body predicates
+// wait for the body to be read and inspected.
+type requestPolicyBody struct {
+	ops         []reqpolicy.RequestOperation
+	jsonDoc     any
+	jsonDupKeys map[string]struct{}
+	jsonParsed  bool
 }
 
-func (p *Proxy) evaluateRequestPolicy(host, baseMethod string, headers http.Header, path, contentType string, ops []reqpolicy.RequestOperation) reqpolicy.Decision {
+func requestPolicyMeta(host, method, path, contentType string, body requestPolicyBody) reqpolicy.RequestMeta {
+	return reqpolicy.RequestMeta{
+		Host: host, Method: method, Path: path, ContentType: contentType,
+		Operations: body.ops, JSONBody: body.jsonDoc, JSONBodyParsed: body.jsonParsed,
+		JSONDupKeys: body.jsonDupKeys,
+	}
+}
+
+func (p *Proxy) evaluateRequestPolicy(host, baseMethod string, headers http.Header, path, contentType string, body requestPolicyBody) reqpolicy.Decision {
 	m := p.requestPolicyMatcher()
 	if m == nil {
 		return reqpolicy.Decision{}
 	}
 	eff := reqpolicy.EffectiveMethod(baseMethod, headers)
-	d := m.Evaluate(requestPolicyMeta(host, eff, path, contentType, ops))
+	d := m.Evaluate(requestPolicyMeta(host, eff, path, contentType, body))
 	base := strings.ToUpper(strings.TrimSpace(baseMethod))
 	if eff != base {
-		alt := m.Evaluate(requestPolicyMeta(host, base, path, contentType, ops))
+		alt := m.Evaluate(requestPolicyMeta(host, base, path, contentType, body))
 		d = reqpolicy.Stricter(d, alt)
 	}
 	return d
 }
 
-func (p *Proxy) requestPolicyNeedsOperations(in requestPolicyInput) bool {
+func (p *Proxy) requestPolicyNeedsBodyPredicate(in requestPolicyInput) bool {
 	m := p.requestPolicyMatcher()
 	if m == nil {
 		return false
 	}
 	eff := reqpolicy.EffectiveMethod(in.Method, in.Headers)
-	if m.NeedsOperations(requestPolicyMeta(in.Host, eff, in.Path, in.ContentType, nil)) {
+	if m.NeedsBodyPredicate(requestPolicyMeta(in.Host, eff, in.Path, in.ContentType, requestPolicyBody{})) {
 		return true
 	}
 	base := strings.ToUpper(strings.TrimSpace(in.Method))
-	return eff != base && m.NeedsOperations(requestPolicyMeta(in.Host, base, in.Path, in.ContentType, nil))
+	return eff != base && m.NeedsBodyPredicate(requestPolicyMeta(in.Host, base, in.Path, in.ContentType, requestPolicyBody{}))
 }
 
-func (p *Proxy) evaluateRequestPolicyUninspectable(in requestPolicyInput, action string) reqpolicy.Decision {
+func (p *Proxy) evaluateRequestPolicyUninspectable(in requestPolicyInput, action string, kind reqpolicy.BodyPredicateKind) reqpolicy.Decision {
 	m := p.requestPolicyMatcher()
 	if m == nil {
 		return reqpolicy.Decision{}
 	}
 	eff := reqpolicy.EffectiveMethod(in.Method, in.Headers)
-	d := m.EvaluateUninspectable(requestPolicyMeta(in.Host, eff, in.Path, in.ContentType, nil), action)
+	d := m.EvaluateUninspectable(requestPolicyMeta(in.Host, eff, in.Path, in.ContentType, requestPolicyBody{}), action, kind)
 	base := strings.ToUpper(strings.TrimSpace(in.Method))
 	if eff != base {
-		alt := m.EvaluateUninspectable(requestPolicyMeta(in.Host, base, in.Path, in.ContentType, nil), action)
+		alt := m.EvaluateUninspectable(requestPolicyMeta(in.Host, base, in.Path, in.ContentType, requestPolicyBody{}), action, kind)
 		d = reqpolicy.Stricter(d, alt)
 	}
 	return d
@@ -144,11 +167,11 @@ func (p *Proxy) requestPolicyMatchesBatch(in requestPolicyInput) bool {
 		return false
 	}
 	eff := reqpolicy.EffectiveMethod(in.Method, in.Headers)
-	if m.MatchesBatch(requestPolicyMeta(in.Host, eff, in.Path, in.ContentType, nil)) {
+	if m.MatchesBatch(requestPolicyMeta(in.Host, eff, in.Path, in.ContentType, requestPolicyBody{})) {
 		return true
 	}
 	base := strings.ToUpper(strings.TrimSpace(in.Method))
-	return eff != base && m.MatchesBatch(requestPolicyMeta(in.Host, base, in.Path, in.ContentType, nil))
+	return eff != base && m.MatchesBatch(requestPolicyMeta(in.Host, base, in.Path, in.ContentType, requestPolicyBody{}))
 }
 
 // evaluateRequestPolicyBatch parses the request body as a batch envelope and
@@ -161,10 +184,10 @@ func (p *Proxy) evaluateRequestPolicyBatch(in requestPolicyInput) (reqpolicy.Dec
 		return reqpolicy.Decision{}, true
 	}
 	eff := reqpolicy.EffectiveMethod(in.Method, in.Headers)
-	d, parseOK := m.EvaluateBatch(requestPolicyMeta(in.Host, eff, in.Path, in.ContentType, nil), in.Body)
+	d, parseOK := m.EvaluateBatch(requestPolicyMeta(in.Host, eff, in.Path, in.ContentType, requestPolicyBody{}), in.Body)
 	base := strings.ToUpper(strings.TrimSpace(in.Method))
 	if eff != base {
-		bd, ok := m.EvaluateBatch(requestPolicyMeta(in.Host, base, in.Path, in.ContentType, nil), in.Body)
+		bd, ok := m.EvaluateBatch(requestPolicyMeta(in.Host, base, in.Path, in.ContentType, requestPolicyBody{}), in.Body)
 		d = reqpolicy.Stricter(d, bd)
 		parseOK = parseOK && ok
 	}
@@ -181,10 +204,10 @@ func (p *Proxy) evaluateRequestPolicyUninspectableBatch(in requestPolicyInput, a
 		return reqpolicy.Decision{}
 	}
 	eff := reqpolicy.EffectiveMethod(in.Method, in.Headers)
-	d := m.UninspectableBatch(requestPolicyMeta(in.Host, eff, in.Path, in.ContentType, nil), action)
+	d := m.UninspectableBatch(requestPolicyMeta(in.Host, eff, in.Path, in.ContentType, requestPolicyBody{}), action)
 	base := strings.ToUpper(strings.TrimSpace(in.Method))
 	if eff != base {
-		d = reqpolicy.Stricter(d, m.UninspectableBatch(requestPolicyMeta(in.Host, base, in.Path, in.ContentType, nil), action))
+		d = reqpolicy.Stricter(d, m.UninspectableBatch(requestPolicyMeta(in.Host, base, in.Path, in.ContentType, requestPolicyBody{}), action))
 	}
 	return d
 }
@@ -202,7 +225,7 @@ func (p *Proxy) requestPolicyBodyLimit() int {
 // buffered it. This keeps request_policy independent of
 // request_body_scanning.enabled without draining bodies for route-only rules.
 func (p *Proxy) prepareRequestPolicyBody(r *http.Request, in *requestPolicyInput) requestPolicyResult {
-	if in.BodyRead || (!p.requestPolicyNeedsOperations(*in) && !p.requestPolicyMatchesBatch(*in)) {
+	if in.BodyRead || (!p.requestPolicyNeedsBodyPredicate(*in) && !p.requestPolicyMatchesBatch(*in)) {
 		return requestPolicyResult{}
 	}
 	if r.Body == nil || r.Body == http.NoBody {
@@ -242,7 +265,7 @@ func (p *Proxy) requestPolicyReadBlocked(in requestPolicyInput, reason string) r
 		return requestPolicyResult{}
 	}
 	p.logger.LogAnomaly(in.AuditCtx, blockLayerRequestPolicy, reason, 0)
-	d := p.evaluateRequestPolicyUninspectable(in, config.ActionBlock)
+	d := p.evaluateRequestPolicyUninspectable(in, config.ActionBlock, reqpolicy.PredAnyBody)
 	d = reqpolicy.Stricter(d, p.evaluateRequestPolicyUninspectableBatch(in, config.ActionBlock))
 	return p.finalizeRequestPolicyDecision(in, d)
 }
@@ -256,22 +279,9 @@ func (p *Proxy) requestPolicyReadBlocked(in requestPolicyInput, reason string) r
 // Transports MUST call this BEFORE EvaluateGate so a contract allow can never
 // suppress a request_policy block.
 func (p *Proxy) applyRequestPolicy(in requestPolicyInput) requestPolicyResult {
-	d := p.evaluateRequestPolicy(in.Host, in.Method, in.Headers, in.Path, in.ContentType, nil)
-	if p.requestPolicyNeedsOperations(in) {
-		m := p.requestPolicyMatcher()
-		if !in.BodyRead {
-			d = reqpolicy.Stricter(d, p.evaluateRequestPolicyUninspectable(in, m.OnOpaqueOperation()))
-		} else {
-			ops, parseOK, opaque := extractRequestPolicyOperations(in)
-			if !parseOK {
-				d = reqpolicy.Stricter(d, p.evaluateRequestPolicyUninspectable(in, m.OnParseError()))
-			} else {
-				d = reqpolicy.Stricter(d, p.evaluateRequestPolicy(in.Host, in.Method, in.Headers, in.Path, in.ContentType, ops))
-				if opaque {
-					d = reqpolicy.Stricter(d, p.evaluateRequestPolicyUninspectable(in, m.OnOpaqueOperation()))
-				}
-			}
-		}
+	d := p.evaluateRequestPolicy(in.Host, in.Method, in.Headers, in.Path, in.ContentType, requestPolicyBody{})
+	if !in.DeferBodyPredicate {
+		d = reqpolicy.Stricter(d, p.evaluateRequestPolicyBodyPredicates(in))
 	}
 	if p.requestPolicyMatchesBatch(in) {
 		m := p.requestPolicyMatcher()
@@ -289,6 +299,40 @@ func (p *Proxy) applyRequestPolicy(in requestPolicyInput) requestPolicyResult {
 		}
 	}
 	return p.finalizeRequestPolicyDecision(in, d)
+}
+
+// evaluateRequestPolicyBodyPredicates runs the GraphQL + discriminator
+// body-predicate evaluation for in and returns the strictest decision, or a
+// zero Decision when no body predicate route-matches. GraphQL and discriminator
+// extraction are independent surfaces over the same body: a body can be valid
+// JSON for a discriminator yet fail GraphQL parsing (e.g. a malformed inline
+// query), and vice versa. Each surface's parse/opaque fail-closed therefore
+// applies only to that surface's predicates, while a successful extraction for
+// either feeds the matcher in one pass.
+func (p *Proxy) evaluateRequestPolicyBodyPredicates(in requestPolicyInput) reqpolicy.Decision {
+	if !p.requestPolicyNeedsBodyPredicate(in) {
+		return reqpolicy.Decision{}
+	}
+	m := p.requestPolicyMatcher()
+	if !in.BodyRead {
+		// The body cannot be inspected at all: every body predicate (GraphQL
+		// and discriminator) is uninspectable.
+		return p.evaluateRequestPolicyUninspectable(in, m.OnOpaqueOperation(), reqpolicy.PredAnyBody)
+	}
+	ops, gqlParseOK, gqlOpaque := extractRequestPolicyOperations(in)
+	jsonDoc, jsonDupKeys, jsonParsed := parseRequestPolicyJSONBody(in)
+	d := p.evaluateRequestPolicy(in.Host, in.Method, in.Headers, in.Path, in.ContentType,
+		requestPolicyBody{ops: ops, jsonDoc: jsonDoc, jsonDupKeys: jsonDupKeys, jsonParsed: jsonParsed})
+	switch {
+	case !gqlParseOK:
+		d = reqpolicy.Stricter(d, p.evaluateRequestPolicyUninspectable(in, m.OnParseError(), reqpolicy.PredGraphQL))
+	case gqlOpaque:
+		d = reqpolicy.Stricter(d, p.evaluateRequestPolicyUninspectable(in, m.OnOpaqueOperation(), reqpolicy.PredGraphQL))
+	}
+	if !jsonParsed {
+		d = reqpolicy.Stricter(d, p.evaluateRequestPolicyUninspectable(in, m.OnParseError(), reqpolicy.PredDiscriminator))
+	}
+	return d
 }
 
 // finalizeRequestPolicyDecision records the decision metric and audit event for

--- a/internal/proxy/requestpolicy_discriminator_test.go
+++ b/internal/proxy/requestpolicy_discriminator_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// discriminatorBlockRule blocks a JSON POST to rpTestHost whose top-level
+// "action" field is a string matching ^delete.
+func discriminatorBlockRule() config.RequestPolicyRule {
+	return config.RequestPolicyRule{
+		Name:   rpRuleName,
+		Action: config.ActionBlock,
+		Route: config.RequestPolicyRoute{
+			Hosts:        []string{rpTestHost},
+			Methods:      []string{http.MethodPost},
+			ContentTypes: []string{"application/json"},
+		},
+		Discriminator: &config.RequestPolicyDiscriminator{
+			Field:         "action",
+			ValuePatterns: []string{`^delete`},
+		},
+		Reason: "dangerous operation requires operator approval",
+	}
+}
+
+func discriminatorInput(body string, bodyRead bool) requestPolicyInput {
+	in := requestPolicyInput{
+		Host:        rpTestHost,
+		Method:      http.MethodPost,
+		Path:        "/v1/ops",
+		ContentType: "application/json",
+		BodyRead:    bodyRead,
+		Transport:   TransportForward,
+		AuditCtx:    audit.LogContext{},
+	}
+	if body != "" {
+		in.Body = []byte(body)
+	}
+	return in
+}
+
+func TestApplyRequestPolicy_Discriminator(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		onOpaque  string
+		body      string
+		wantBlock bool
+	}{
+		{name: "string value matches", body: `{"action":"deleteAll"}`, wantBlock: true},
+		{name: "string value no match", body: `{"action":"list"}`, wantBlock: false},
+		{name: "field absent forwards", body: `{"other":"deleteAll"}`, wantBlock: false},
+		{name: "array value opaque blocks", body: `{"action":["delete","all"]}`, wantBlock: true},
+		{name: "object value opaque blocks", body: `{"action":{"op":"deleteAll"}}`, wantBlock: true},
+		{name: "number value opaque blocks", body: `{"action":7}`, wantBlock: true},
+		{name: "null value opaque blocks", body: `{"action":null}`, wantBlock: true},
+		{name: "non-object top level opaque blocks", body: `["action","deleteAll"]`, wantBlock: true},
+		{name: "invalid json parse error blocks", body: `{"action":"delete`, wantBlock: true},
+		{name: "trailing garbage parse error blocks", body: `{"action":"list"} evil`, wantBlock: true},
+		{name: "second json value parse error blocks", body: `{"action":"list"} {"action":"list"}`, wantBlock: true},
+		{name: "duplicate target field dangerous-first opaque blocks", body: `{"action":"deleteAll","action":"list"}`, wantBlock: true},
+		{name: "duplicate target field benign-first opaque blocks", body: `{"action":"list","action":"deleteAll"}`, wantBlock: true},
+		{name: "duplicate unrelated field still evaluates target", body: `{"foo":1,"foo":2,"action":"list"}`, wantBlock: false},
+		{name: "opaque warn forwards", onOpaque: config.ActionWarn, body: `{"action":["delete"]}`, wantBlock: false},
+		{name: "opaque allow forwards", onOpaque: config.ActionAllow, body: `{"action":["delete"]}`, wantBlock: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := reqPolicyConfig(discriminatorBlockRule())
+			if tt.onOpaque != "" {
+				cfg.RequestPolicy.OnOpaqueOperation = tt.onOpaque
+			}
+			p := newTestProxyWithConfig(t, cfg)
+			res := p.applyRequestPolicy(discriminatorInput(tt.body, true))
+			if res.Block != tt.wantBlock {
+				t.Fatalf("Block = %v, want %v (body %q)", res.Block, tt.wantBlock, tt.body)
+			}
+		})
+	}
+}
+
+// A discriminator rule with the body unavailable must fail closed: the rule's
+// route matched but no body could be inspected.
+func TestApplyRequestPolicy_DiscriminatorBodyUnavailableFailsClosed(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(discriminatorBlockRule()))
+	res := p.applyRequestPolicy(discriminatorInput("", false))
+	if !res.Block {
+		t.Fatal("route-matched discriminator request with unavailable body should fail closed")
+	}
+}
+
+// Cross-surface independence: a body that is valid JSON (so the discriminator
+// can classify it) but carries no inline GraphQL operation must be judged by
+// the discriminator predicate, not fail-closed by the GraphQL opaque path. The
+// GraphQL opaque signal applies only to GraphQL rules, of which there are none.
+func TestApplyRequestPolicy_DiscriminatorIndependentOfGraphQLOpaque(t *testing.T) {
+	t.Parallel()
+	p := newTestProxyWithConfig(t, reqPolicyConfig(discriminatorBlockRule()))
+
+	// No "query" key -> GraphQL extraction reports opaque -> but only the
+	// discriminator (string "list", no match) governs this disc-only rule.
+	if res := p.applyRequestPolicy(discriminatorInput(`{"action":"list"}`, true)); res.Block {
+		t.Fatal("disc-only rule must not inherit GraphQL opaque fail-closed on a benign value")
+	}
+	// Same body shape, dangerous value -> discriminator blocks.
+	if res := p.applyRequestPolicy(discriminatorInput(`{"action":"deleteEverything"}`, true)); !res.Block {
+		t.Fatal("discriminator should block a matching string value")
+	}
+}
+
+// End-to-end through the forward absolute-URI transport with request body
+// scanning disabled: request_policy must still read the body and block on a
+// matching discriminator.
+func TestRequestPolicy_ForwardDiscriminator_BlocksWithBodyScanningDisabled(t *testing.T) {
+	t.Parallel()
+	cfg := reqPolicyConfig(discriminatorBlockRule())
+	cfg.RequestBodyScanning.Enabled = false
+	p := newTestProxyWithConfig(t, cfg)
+	handler := p.buildHandler(p.buildMux())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost,
+		"http://"+rpTestHost+"/v1/ops", strings.NewReader(`{"action":"deleteAll"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assertRequestPolicyBlock(t, w)
+}

--- a/internal/proxy/requestpolicy_enforcement_test.go
+++ b/internal/proxy/requestpolicy_enforcement_test.go
@@ -78,14 +78,14 @@ func TestEvaluateRequestPolicy_MethodOverrideCannotDowngrade(t *testing.T) {
 
 	h := http.Header{}
 	h.Set("X-HTTP-Method-Override", http.MethodDelete)
-	d := p.evaluateRequestPolicy(rpTestHost, http.MethodPost, h, "/v1/jobs/1", "", nil)
+	d := p.evaluateRequestPolicy(rpTestHost, http.MethodPost, h, "/v1/jobs/1", "", requestPolicyBody{})
 	if d.Action != config.ActionBlock {
 		t.Fatalf("override DELETE via POST should block, got action=%q", d.Action)
 	}
 
 	// And the inverse: a bare POST with no override is not caught by a
 	// DELETE-only rule.
-	if d2 := p.evaluateRequestPolicy(rpTestHost, http.MethodPost, http.Header{}, "/v1/jobs/1", "", nil); d2.Matched() {
+	if d2 := p.evaluateRequestPolicy(rpTestHost, http.MethodPost, http.Header{}, "/v1/jobs/1", "", requestPolicyBody{}); d2.Matched() {
 		t.Fatalf("bare POST should not match a DELETE-only rule, got %+v", d2)
 	}
 }
@@ -772,7 +772,7 @@ func TestRequestPolicy_HotReloadAppliesRuleChange(t *testing.T) {
 	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
 	p := newTestProxyWithConfig(t, cfg)
 
-	if got := p.evaluateRequestPolicy(rpTestHost, http.MethodDelete, http.Header{}, "/v1/jobs/1", "", nil); got.Matched() {
+	if got := p.evaluateRequestPolicy(rpTestHost, http.MethodDelete, http.Header{}, "/v1/jobs/1", "", requestPolicyBody{}); got.Matched() {
 		t.Fatal("no rule configured: DELETE should not match")
 	}
 
@@ -781,7 +781,7 @@ func TestRequestPolicy_HotReloadAppliesRuleChange(t *testing.T) {
 	if !p.Reload(newCfg, scanner.New(newCfg)) {
 		t.Fatal("Reload returned false")
 	}
-	if got := p.evaluateRequestPolicy(rpTestHost, http.MethodDelete, http.Header{}, "/v1/jobs/1", "", nil); got.Action != config.ActionBlock {
+	if got := p.evaluateRequestPolicy(rpTestHost, http.MethodDelete, http.Header{}, "/v1/jobs/1", "", requestPolicyBody{}); got.Action != config.ActionBlock {
 		t.Fatalf("after reload, DELETE should block, got action=%q", got.Action)
 	}
 
@@ -790,7 +790,7 @@ func TestRequestPolicy_HotReloadAppliesRuleChange(t *testing.T) {
 	if !p.Reload(cfgOff, scanner.New(cfgOff)) {
 		t.Fatal("second Reload returned false")
 	}
-	if got := p.evaluateRequestPolicy(rpTestHost, http.MethodDelete, http.Header{}, "/v1/jobs/1", "", nil); got.Matched() {
+	if got := p.evaluateRequestPolicy(rpTestHost, http.MethodDelete, http.Header{}, "/v1/jobs/1", "", requestPolicyBody{}); got.Matched() {
 		t.Fatal("after rule removal, DELETE should not match")
 	}
 }

--- a/internal/proxy/requestpolicy_operations.go
+++ b/internal/proxy/requestpolicy_operations.go
@@ -5,6 +5,8 @@ package proxy
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -44,6 +46,76 @@ func extractRequestPolicyOperations(in requestPolicyInput) (ops []reqpolicy.Requ
 		}
 	}
 	return reqpolicy.ExtractGraphQL(in.Body)
+}
+
+// parseRequestPolicyJSONBody parses the request body as a single generic JSON
+// value for discriminator-field predicates, returning ok=false when there is no
+// body or it is not exactly one well-formed JSON value. UseNumber preserves
+// numeric fidelity (and keeps numbers out of the string type assertion the
+// discriminator predicate makes, so a numeric field reads as opaque). Trailing
+// non-whitespace after the value is rejected so a "{...}<garbage>" body a lax
+// upstream might still dispatch on cannot pass as parseable here.
+func parseRequestPolicyJSONBody(in requestPolicyInput) (doc any, dupKeys map[string]struct{}, ok bool) {
+	body := bytes.TrimSpace(in.Body)
+	if len(body) == 0 {
+		return nil, nil, false
+	}
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return nil, nil, false
+	}
+	var trailing json.RawMessage
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return nil, nil, false
+	}
+	if _, isObj := v.(map[string]any); isObj {
+		dupKeys = topLevelDuplicateJSONKeys(body)
+	}
+	return v, dupKeys, true
+}
+
+// topLevelDuplicateJSONKeys returns the set of keys that appear more than once
+// at the top level of a JSON object body. Go's decoder silently keeps the last
+// value for a duplicated key, but JSON parsers disagree on which value wins, so
+// a discriminator rule whose field is duplicated cannot be trusted and must
+// fail closed. Nested object keys are skipped (Decode consumes each value whole)
+// so only the top level is considered. body must already be validated as a
+// single JSON value by parseRequestPolicyJSONBody.
+func topLevelDuplicateJSONKeys(body []byte) map[string]struct{} {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil
+	}
+	if delim, isDelim := tok.(json.Delim); !isDelim || delim != '{' {
+		return nil
+	}
+	seen := make(map[string]int)
+	var dups map[string]struct{}
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return dups
+		}
+		key, isStr := keyTok.(string)
+		if !isStr {
+			return dups
+		}
+		seen[key]++
+		if seen[key] == 2 {
+			if dups == nil {
+				dups = make(map[string]struct{})
+			}
+			dups[key] = struct{}{}
+		}
+		var skip json.RawMessage
+		if err := dec.Decode(&skip); err != nil {
+			return dups
+		}
+	}
+	return dups
 }
 
 // isMultipartFormData reports whether ct is a multipart/form-data media type,

--- a/internal/proxy/requestpolicy_operations_test.go
+++ b/internal/proxy/requestpolicy_operations_test.go
@@ -258,3 +258,33 @@ func TestRequestPolicy_FetchGraphQLOverGET_Blocks(t *testing.T) {
 
 	assertRequestPolicyBlock(t, w)
 }
+
+func TestTopLevelDuplicateJSONKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{"no duplicate", `{"a":1,"b":2}`, nil},
+		{"single duplicate", `{"a":1,"a":2}`, []string{"a"}},
+		{"triple counts once", `{"a":1,"a":2,"a":3}`, []string{"a"}},
+		{"two distinct duplicates", `{"a":1,"a":2,"b":3,"b":4}`, []string{"a", "b"}},
+		{"nested duplicate not counted", `{"a":{"x":1,"x":2},"b":2}`, nil},
+		{"duplicate alongside nested", `{"a":{"x":1},"a":{"x":2}}`, []string{"a"}},
+		{"non-object array", `[1,2,3]`, nil},
+		{"non-object scalar", `"hello"`, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := topLevelDuplicateJSONKeys([]byte(tt.body))
+			if len(got) != len(tt.want) {
+				t.Fatalf("dup keys = %v, want %v", got, tt.want)
+			}
+			for _, k := range tt.want {
+				if _, ok := got[k]; !ok {
+					t.Fatalf("expected duplicate key %q in %v", k, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/proxy/requestpolicy_websocket_test.go
+++ b/internal/proxy/requestpolicy_websocket_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"testing"
+
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// wsDiscriminatorRule blocks a WebSocket text frame whose top-level JSON
+// "action" field is a string matching ^delete. It is host-scoped (no method)
+// so it applies to the GET-upgraded WebSocket route and its frames.
+func wsDiscriminatorRule(host string) config.RequestPolicyRule {
+	return config.RequestPolicyRule{
+		Name:   "ws-destructive-op",
+		Action: config.ActionBlock,
+		Route:  config.RequestPolicyRoute{Hosts: []string{host}},
+		Discriminator: &config.RequestPolicyDiscriminator{
+			Field:         "action",
+			ValuePatterns: []string{`^delete`},
+		},
+		Reason: "destructive websocket operation",
+	}
+}
+
+func wsDiscriminatorJSONRule(host string) config.RequestPolicyRule {
+	r := wsDiscriminatorRule(host)
+	r.Route.ContentTypes = []string{"application/json"}
+	return r
+}
+
+func wsReqPolicyConfig(cfg *config.Config) {
+	cfg.RequestPolicy.Enabled = true
+	cfg.RequestPolicy.OnParseError = config.ActionBlock
+	cfg.RequestPolicy.OnOpaqueOperation = config.ActionBlock
+	cfg.RequestPolicy.Rules = []config.RequestPolicyRule{wsDiscriminatorRule("127.0.0.1")}
+}
+
+// A benign frame on a route with a discriminator rule must still be relayed:
+// the handshake gates route-only, and a non-matching operation forwards.
+func TestWSProxyRequestPolicy_BenignFrameForwards(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+	proxyAddr, proxyCleanup := setupWSProxy(t, wsReqPolicyConfig)
+	defer proxyCleanup()
+
+	conn := dialWS(t, proxyAddr, backendAddr)
+	defer conn.Close() //nolint:errcheck // test
+
+	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte(`{"action":"list"}`)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	reply, op, err := wsutil.ReadServerData(conn)
+	if err != nil {
+		t.Fatalf("benign frame should be relayed and echoed, got error: %v", err)
+	}
+	if op != ws.OpText || string(reply) != `{"action":"list"}` {
+		t.Fatalf("expected echoed benign frame, got op=%v reply=%q", op, reply)
+	}
+}
+
+// A frame whose discriminator value matches a block rule must close the
+// connection (per-frame operation policy).
+func TestWSProxyRequestPolicy_MatchingFrameBlocks(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+	proxyAddr, proxyCleanup := setupWSProxy(t, wsReqPolicyConfig)
+	defer proxyCleanup()
+
+	conn := dialWS(t, proxyAddr, backendAddr)
+	defer conn.Close() //nolint:errcheck // test
+
+	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte(`{"action":"deleteAll"}`)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(conn); err == nil {
+		t.Fatal("matching discriminator frame should close the connection")
+	}
+}
+
+func TestWSProxyRequestPolicy_JSONContentTypeScopedFrameBlocks(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+	proxyAddr, proxyCleanup := setupWSProxy(t, func(cfg *config.Config) {
+		wsReqPolicyConfig(cfg)
+		cfg.RequestPolicy.Rules = []config.RequestPolicyRule{wsDiscriminatorJSONRule("127.0.0.1")}
+	})
+	defer proxyCleanup()
+
+	conn := dialWS(t, proxyAddr, backendAddr)
+	defer conn.Close() //nolint:errcheck // test
+
+	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte(`{"action":"deleteAll"}`)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(conn); err == nil {
+		t.Fatal("content_type-scoped discriminator frame should close the connection")
+	}
+}
+
+// A present-but-non-string discriminator value in a frame is opaque and must
+// fail closed (close) under the default on_opaque_operation=block.
+func TestWSProxyRequestPolicy_OpaqueFrameBlocks(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+	proxyAddr, proxyCleanup := setupWSProxy(t, wsReqPolicyConfig)
+	defer proxyCleanup()
+
+	conn := dialWS(t, proxyAddr, backendAddr)
+	defer conn.Close() //nolint:errcheck // test
+
+	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte(`{"action":["delete"]}`)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(conn); err == nil {
+		t.Fatal("opaque (non-string) discriminator frame should close the connection")
+	}
+}
+
+// A non-JSON text frame on a route with a body-predicate rule cannot be
+// classified, so it fails closed under the default on_parse_error=block. This
+// is the documented fragment/parse boundary: operators scope body-predicate
+// rules to JSON-operation routes (or relax on_parse_error).
+func TestWSProxyRequestPolicy_NonJSONFrameFailsClosed(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+	proxyAddr, proxyCleanup := setupWSProxy(t, wsReqPolicyConfig)
+	defer proxyCleanup()
+
+	conn := dialWS(t, proxyAddr, backendAddr)
+	defer conn.Close() //nolint:errcheck // test
+
+	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte("not json")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(conn); err == nil {
+		t.Fatal("non-JSON frame on a body-predicate route should fail closed")
+	}
+}
+
+// on_parse_error=warn relaxes the parse-error fail-closed: a non-JSON frame is
+// logged but forwarded. This also proves the handshake itself is not blocked by
+// a body-predicate rule on the route — the upgrade succeeds and the relay runs.
+func TestWSProxyRequestPolicy_NonJSONFrameForwardsWhenParseErrorWarn(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+	proxyAddr, proxyCleanup := setupWSProxy(t, func(cfg *config.Config) {
+		wsReqPolicyConfig(cfg)
+		cfg.RequestPolicy.OnParseError = config.ActionWarn
+	})
+	defer proxyCleanup()
+
+	conn := dialWS(t, proxyAddr, backendAddr)
+	defer conn.Close() //nolint:errcheck // test
+
+	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte("not json")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	reply, _, err := wsutil.ReadServerData(conn)
+	if err != nil {
+		t.Fatalf("on_parse_error=warn should forward a non-JSON frame; got %v", err)
+	}
+	if string(reply) != "not json" {
+		t.Fatalf("expected echo, got %q", reply)
+	}
+}

--- a/internal/proxy/requestpolicy_websocket_test.go
+++ b/internal/proxy/requestpolicy_websocket_test.go
@@ -50,7 +50,7 @@ func TestWSProxyRequestPolicy_BenignFrameForwards(t *testing.T) {
 	defer proxyCleanup()
 
 	conn := dialWS(t, proxyAddr, backendAddr)
-	defer conn.Close() //nolint:errcheck // test
+	defer func() { _ = conn.Close() }()
 
 	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte(`{"action":"list"}`)); err != nil {
 		t.Fatalf("write: %v", err)
@@ -73,7 +73,7 @@ func TestWSProxyRequestPolicy_MatchingFrameBlocks(t *testing.T) {
 	defer proxyCleanup()
 
 	conn := dialWS(t, proxyAddr, backendAddr)
-	defer conn.Close() //nolint:errcheck // test
+	defer func() { _ = conn.Close() }()
 
 	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte(`{"action":"deleteAll"}`)); err != nil {
 		t.Fatalf("write: %v", err)
@@ -93,7 +93,7 @@ func TestWSProxyRequestPolicy_JSONContentTypeScopedFrameBlocks(t *testing.T) {
 	defer proxyCleanup()
 
 	conn := dialWS(t, proxyAddr, backendAddr)
-	defer conn.Close() //nolint:errcheck // test
+	defer func() { _ = conn.Close() }()
 
 	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte(`{"action":"deleteAll"}`)); err != nil {
 		t.Fatalf("write: %v", err)
@@ -112,7 +112,7 @@ func TestWSProxyRequestPolicy_OpaqueFrameBlocks(t *testing.T) {
 	defer proxyCleanup()
 
 	conn := dialWS(t, proxyAddr, backendAddr)
-	defer conn.Close() //nolint:errcheck // test
+	defer func() { _ = conn.Close() }()
 
 	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte(`{"action":["delete"]}`)); err != nil {
 		t.Fatalf("write: %v", err)
@@ -133,7 +133,7 @@ func TestWSProxyRequestPolicy_NonJSONFrameFailsClosed(t *testing.T) {
 	defer proxyCleanup()
 
 	conn := dialWS(t, proxyAddr, backendAddr)
-	defer conn.Close() //nolint:errcheck // test
+	defer func() { _ = conn.Close() }()
 
 	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte("not json")); err != nil {
 		t.Fatalf("write: %v", err)
@@ -156,7 +156,7 @@ func TestWSProxyRequestPolicy_NonJSONFrameForwardsWhenParseErrorWarn(t *testing.
 	defer proxyCleanup()
 
 	conn := dialWS(t, proxyAddr, backendAddr)
-	defer conn.Close() //nolint:errcheck // test
+	defer func() { _ = conn.Close() }()
 
 	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte("not json")); err != nil {
 		t.Fatalf("write: %v", err)

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -52,24 +52,25 @@ func getWSSemaphore(capacity int) *tunnelSemaphore {
 
 // wsRelay holds per-connection state for a proxied WebSocket connection.
 type wsRelay struct {
-	clientConn   net.Conn
-	upstreamConn net.Conn
-	scanner      *scanner.Scanner
-	proxy        *Proxy
-	cfg          *config.Config
-	redaction    *redactionRuntime
-	agent        string
-	clientIP     string
-	requestID    string
-	targetURL    string
-	hostname     string
-	path         string
-	maxMsg       int
-	scanText     bool
-	allowBinary  bool
-	redactionLog *redact.Report
-	rec          session.Recorder // live escalation level for UpgradeAction; nil when profiling disabled
-	terminalOnce sync.Once        // ensures only one terminal receipt (kill_switch/session_deny) is emitted across concurrent relay goroutines
+	clientConn        net.Conn
+	upstreamConn      net.Conn
+	scanner           *scanner.Scanner
+	proxy             *Proxy
+	cfg               *config.Config
+	redaction         *redactionRuntime
+	agent             string
+	clientIP          string
+	requestID         string
+	targetURL         string
+	hostname          string
+	path              string
+	maxMsg            int
+	scanText          bool
+	allowBinary       bool
+	reqPolicyPerFrame bool // a request_policy body-predicate rule route-matches this WS route; evaluate each text frame as an operation
+	redactionLog      *redact.Report
+	rec               session.Recorder // live escalation level for UpgradeAction; nil when profiling disabled
+	terminalOnce      sync.Once        // ensures only one terminal receipt (kill_switch/session_deny) is emitted across concurrent relay goroutines
 }
 
 // escalationLevel returns the live escalation level from the session recorder.
@@ -487,20 +488,24 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// request_policy runs before the contract gate so a contract allow can
-	// never suppress an operation-policy block.
+	// never suppress an operation-policy block. The upgrade carries no
+	// operation body, so body-predicate (GraphQL / discriminator) rules defer
+	// to per-frame evaluation in the relay; only route-only rules gate the
+	// handshake here.
 	if rpRes := p.applyRequestPolicy(requestPolicyInput{
-		Host:        parsed.Hostname(),
-		Method:      http.MethodGet,
-		Path:        parsed.EscapedPath(),
-		ContentType: r.Header.Get(headerContentType),
-		Headers:     r.Header,
-		BodyRead:    true,
-		Transport:   TransportWS,
-		Target:      targetURL,
-		RequestID:   requestID,
-		Agent:       agent,
-		AuditCtx:    actx,
-		Emit:        p.emitReceipt,
+		Host:               parsed.Hostname(),
+		Method:             http.MethodGet,
+		Path:               parsed.EscapedPath(),
+		ContentType:        r.Header.Get(headerContentType),
+		Headers:            r.Header,
+		BodyRead:           true,
+		Transport:          TransportWS,
+		Target:             targetURL,
+		RequestID:          requestID,
+		Agent:              agent,
+		AuditCtx:           actx,
+		Emit:               p.emitReceipt,
+		DeferBodyPredicate: true,
 	}); rpRes.Block {
 		p.metrics.RecordWSBlocked()
 		writeBlockedError(w, rpRes.Info, "WebSocket blocked by request policy: "+rpRes.Reason, http.StatusForbidden)
@@ -726,6 +731,17 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		allowBinary:  cfg.WebSocketProxy.AllowBinaryFrames,
 		rec:          wsRec,
 	}
+	// A body-predicate (GraphQL / discriminator) rule that route-matches this
+	// WS route is evaluated per text frame: the operation lives in the frame,
+	// not the upgrade. Computed once here so benign connections pay no per-frame
+	// JSON-parse cost.
+	relay.reqPolicyPerFrame = p.requestPolicyNeedsBodyPredicate(requestPolicyInput{
+		Host:        relay.hostname,
+		Method:      http.MethodGet,
+		Path:        parsed.EscapedPath(),
+		ContentType: contentTypeJSON,
+		Headers:     r.Header,
+	})
 
 	if scanTextFrames && sc.ResponseScanningEnabled() && isResponseScanExempt(relay.hostname, cfg.ResponseScanning.ExemptDomains) {
 		log.LogResponseScanExempt(actx, relay.hostname)
@@ -937,6 +953,38 @@ func (r *wsRelay) run(ctx context.Context) wsRelayStats {
 		binaryFrames:   c2sBinary + s2cBinary,
 		blocked:        c2sBlocked || s2cBlocked,
 	}
+}
+
+// applyFrameRequestPolicy evaluates request_policy body predicates against a
+// complete client text frame, treating the frame payload as a JSON operation
+// body over the handshake route (the upgrade is a GET, so the effective method
+// is GET). On an enforced block it closes both ends with a policy-violation
+// close frame and reports blocked=true; the receipt, metric, and audit event
+// are emitted by applyRequestPolicy's shared finalizer. Only complete,
+// UTF-8-validated text frames reach here — the fragment-reassembly boundary
+// (and binary frames, which are not operation text) is a documented limit.
+func (r *wsRelay) applyFrameRequestPolicy(actx audit.LogContext, msg []byte) bool {
+	res := r.proxy.applyRequestPolicy(requestPolicyInput{
+		Host:        r.hostname,
+		Method:      http.MethodGet,
+		Path:        r.path,
+		ContentType: contentTypeJSON,
+		Body:        msg,
+		BodyRead:    true,
+		Transport:   TransportWSFrame,
+		Target:      r.targetURL,
+		RequestID:   r.requestID,
+		Agent:       r.agent,
+		AuditCtx:    actx,
+		Emit:        r.proxy.emitReceipt,
+	})
+	if !res.Block {
+		return false
+	}
+	payload := res.Info.CloseFramePayload()
+	plwsutil.WriteCloseFrame(r.clientConn, ws.StatusPolicyViolation, payload)
+	plwsutil.WriteClientCloseFrame(r.upstreamConn, ws.StatusPolicyViolation, payload)
+	return true
 }
 
 func (r *wsRelay) scanClientMessageBody(ctx context.Context, msg []byte) ([]byte, BodyScanResult) {
@@ -1772,6 +1820,17 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 				plwsutil.WriteClientCloseFrame(r.upstreamConn, ws.StatusInvalidFramePayloadData, "invalid UTF-8")
 				blocked = true
 				return
+			}
+
+			// request_policy per-frame operation evaluation: the frame payload
+			// is the operation body. Runs before content scanning, mirroring the
+			// HTTP order where request_policy precedes the contract gate.
+			if r.reqPolicyPerFrame {
+				actx := newHTTPAuditContext(log, "WS", r.targetURL, r.clientIP, r.requestID, r.agent)
+				if r.applyFrameRequestPolicy(actx, msg) {
+					blocked = true
+					return
+				}
 			}
 		}
 

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -52,25 +52,29 @@ func getWSSemaphore(capacity int) *tunnelSemaphore {
 
 // wsRelay holds per-connection state for a proxied WebSocket connection.
 type wsRelay struct {
-	clientConn        net.Conn
-	upstreamConn      net.Conn
-	scanner           *scanner.Scanner
-	proxy             *Proxy
-	cfg               *config.Config
-	redaction         *redactionRuntime
-	agent             string
-	clientIP          string
-	requestID         string
-	targetURL         string
-	hostname          string
-	path              string
-	maxMsg            int
-	scanText          bool
-	allowBinary       bool
-	reqPolicyPerFrame bool // a request_policy body-predicate rule route-matches this WS route; evaluate each text frame as an operation
-	redactionLog      *redact.Report
-	rec               session.Recorder // live escalation level for UpgradeAction; nil when profiling disabled
-	terminalOnce      sync.Once        // ensures only one terminal receipt (kill_switch/session_deny) is emitted across concurrent relay goroutines
+	clientConn   net.Conn
+	upstreamConn net.Conn
+	scanner      *scanner.Scanner
+	proxy        *Proxy
+	cfg          *config.Config
+	redaction    *redactionRuntime
+	agent        string
+	clientIP     string
+	requestID    string
+	targetURL    string
+	hostname     string
+	path         string
+	maxMsg       int
+	scanText     bool
+	allowBinary  bool
+	// reqPolicyHeaders and reqPolicyPath are the handshake route inputs reused
+	// for per-frame request_policy evaluation, so a frame is judged against the
+	// same escaped path and method-override headers as the handshake gate.
+	reqPolicyHeaders http.Header
+	reqPolicyPath    string
+	redactionLog     *redact.Report
+	rec              session.Recorder // live escalation level for UpgradeAction; nil when profiling disabled
+	terminalOnce     sync.Once        // ensures only one terminal receipt (kill_switch/session_deny) is emitted across concurrent relay goroutines
 }
 
 // escalationLevel returns the live escalation level from the session recorder.
@@ -731,17 +735,12 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		allowBinary:  cfg.WebSocketProxy.AllowBinaryFrames,
 		rec:          wsRec,
 	}
-	// A body-predicate (GraphQL / discriminator) rule that route-matches this
-	// WS route is evaluated per text frame: the operation lives in the frame,
-	// not the upgrade. Computed once here so benign connections pay no per-frame
-	// JSON-parse cost.
-	relay.reqPolicyPerFrame = p.requestPolicyNeedsBodyPredicate(requestPolicyInput{
-		Host:        relay.hostname,
-		Method:      http.MethodGet,
-		Path:        parsed.EscapedPath(),
-		ContentType: contentTypeJSON,
-		Headers:     r.Header,
-	})
+	// Per-frame request_policy reuses the handshake route inputs: the escaped
+	// path the handshake gate matched on and a clone of the upgrade headers (for
+	// method-override parity). The frame gate is re-checked against the live
+	// matcher each frame, so a hot-reloaded rule applies to open sockets.
+	relay.reqPolicyHeaders = r.Header.Clone()
+	relay.reqPolicyPath = parsed.EscapedPath()
 
 	if scanTextFrames && sc.ResponseScanningEnabled() && isResponseScanExempt(relay.hostname, cfg.ResponseScanning.ExemptDomains) {
 		log.LogResponseScanExempt(actx, relay.hostname)
@@ -958,26 +957,35 @@ func (r *wsRelay) run(ctx context.Context) wsRelayStats {
 // applyFrameRequestPolicy evaluates request_policy body predicates against a
 // complete client text frame, treating the frame payload as a JSON operation
 // body over the handshake route (the upgrade is a GET, so the effective method
-// is GET). On an enforced block it closes both ends with a policy-violation
-// close frame and reports blocked=true; the receipt, metric, and audit event
-// are emitted by applyRequestPolicy's shared finalizer. Only complete,
-// UTF-8-validated text frames reach here — the fragment-reassembly boundary
-// (and binary frames, which are not operation text) is a documented limit.
-func (r *wsRelay) applyFrameRequestPolicy(actx audit.LogContext, msg []byte) bool {
-	res := r.proxy.applyRequestPolicy(requestPolicyInput{
+// is GET). The body-predicate gate is checked against the live matcher each
+// frame — not cached at upgrade — so a hot-reloaded rule applies to open
+// sockets; benign routes still pay no JSON-parse cost. The route inputs
+// (escaped path, handshake headers) match the handshake gate. On an enforced
+// block it closes both ends with a policy-violation close frame and reports
+// blocked=true; the receipt, metric, and audit event are emitted by
+// applyRequestPolicy's shared finalizer. Only complete, UTF-8-validated text
+// frames reach here — the fragment-reassembly boundary (and binary frames,
+// which are not operation text) is a documented limit.
+func (r *wsRelay) applyFrameRequestPolicy(log *audit.Logger, msg []byte) bool {
+	in := requestPolicyInput{
 		Host:        r.hostname,
 		Method:      http.MethodGet,
-		Path:        r.path,
+		Path:        r.reqPolicyPath,
 		ContentType: contentTypeJSON,
-		Body:        msg,
-		BodyRead:    true,
-		Transport:   TransportWSFrame,
-		Target:      r.targetURL,
-		RequestID:   r.requestID,
-		Agent:       r.agent,
-		AuditCtx:    actx,
-		Emit:        r.proxy.emitReceipt,
-	})
+		Headers:     r.reqPolicyHeaders,
+	}
+	if !r.proxy.requestPolicyNeedsBodyPredicate(in) {
+		return false
+	}
+	in.Body = msg
+	in.BodyRead = true
+	in.Transport = TransportWSFrame
+	in.Target = r.targetURL
+	in.RequestID = r.requestID
+	in.Agent = r.agent
+	in.AuditCtx = newHTTPAuditContext(log, "WS", r.targetURL, r.clientIP, r.requestID, r.agent)
+	in.Emit = r.proxy.emitReceipt
+	res := r.proxy.applyRequestPolicy(in)
 	if !res.Block {
 		return false
 	}
@@ -1825,12 +1833,9 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 			// request_policy per-frame operation evaluation: the frame payload
 			// is the operation body. Runs before content scanning, mirroring the
 			// HTTP order where request_policy precedes the contract gate.
-			if r.reqPolicyPerFrame {
-				actx := newHTTPAuditContext(log, "WS", r.targetURL, r.clientIP, r.requestID, r.agent)
-				if r.applyFrameRequestPolicy(actx, msg) {
-					blocked = true
-					return
-				}
+			if r.applyFrameRequestPolicy(log, msg) {
+				blocked = true
+				return
 			}
 		}
 

--- a/internal/reqpolicy/batch.go
+++ b/internal/reqpolicy/batch.go
@@ -156,7 +156,7 @@ func (m *Matcher) evaluateSubRequest(host string, sub batchSubRequest, depth int
 // matches the sub are affected — a plain REST sub matched by a method/path rule
 // is unaffected (it was already decided by Evaluate above).
 func (m *Matcher) uninspectableSub(meta RequestMeta, action string) Decision {
-	return m.EvaluateUninspectable(meta, action)
+	return m.EvaluateUninspectable(meta, action, PredGraphQL)
 }
 
 func extractSubRequestGraphQL(sub batchSubRequest) (ops []RequestOperation, parseOK, opaque bool) {

--- a/internal/reqpolicy/discriminator.go
+++ b/internal/reqpolicy/discriminator.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package reqpolicy
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// discOutcome is the result of evaluating a discriminator predicate against a
+// parsed JSON body. It is intentionally three-valued: a present-but-unmatched
+// string and an absent field are both "no match" (the allow-by-default rail
+// forwards), but a present-but-non-string value — or a non-object body — is
+// opaque so the caller can fail closed per on_opaque_operation rather than let
+// a type the upstream might still dispatch on slip through unmatched.
+type discOutcome uint8
+
+const (
+	discNoMatch discOutcome = iota
+	discMatch
+	discOpaque
+)
+
+// discPredicate is the compiled form of a rule's JSON discriminator predicate:
+// a top-level object key and the RE2 patterns its string value must match.
+type discPredicate struct {
+	field    string
+	valueRes []*regexp.Regexp
+}
+
+// compileDiscriminatorPredicate compiles a rule's discriminator predicate,
+// returning nil when the rule has none. Field and patterns are validated at
+// config load, so a compile failure here is defense in depth.
+func compileDiscriminatorPredicate(d *config.RequestPolicyDiscriminator) (*discPredicate, error) {
+	if d == nil {
+		return nil, nil
+	}
+	p := &discPredicate{field: strings.TrimSpace(d.Field)}
+	for _, pat := range d.ValuePatterns {
+		re, err := regexp.Compile(strings.TrimSpace(pat))
+		if err != nil {
+			return nil, err
+		}
+		p.valueRes = append(p.valueRes, re)
+	}
+	return p, nil
+}
+
+// eval classifies the request body against the predicate. It is evaluated only
+// when meta.JSONBodyParsed is true; the not-read and invalid-JSON cases are the
+// caller's fail-closed responsibility (on_opaque_operation / on_parse_error),
+// so an unparsed body is reported as no match here and handled there.
+func (d *discPredicate) eval(meta RequestMeta) discOutcome {
+	if !meta.JSONBodyParsed {
+		return discNoMatch
+	}
+	obj, ok := meta.JSONBody.(map[string]any)
+	if !ok {
+		// Valid JSON but a non-object top level (array, scalar): the targeted
+		// field cannot exist, yet the upstream may still dispatch on the body,
+		// so treat it as opaque rather than a benign no-match.
+		return discOpaque
+	}
+	if _, dup := meta.JSONDupKeys[d.field]; dup {
+		// The targeted field appears more than once at the top level. Go keeps
+		// the last value, but a first-wins upstream could dispatch on a
+		// different one, so we cannot trust the collapsed value: fail closed.
+		return discOpaque
+	}
+	v, present := obj[d.field]
+	if !present {
+		return discNoMatch
+	}
+	s, ok := v.(string)
+	if !ok {
+		// Present but null / number / bool / array / object: unclassifiable
+		// against string value patterns. Fail closed via opaque.
+		return discOpaque
+	}
+	for _, re := range d.valueRes {
+		if re.MatchString(s) {
+			return discMatch
+		}
+	}
+	return discNoMatch
+}

--- a/internal/reqpolicy/discriminator_test.go
+++ b/internal/reqpolicy/discriminator_test.go
@@ -1,0 +1,277 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package reqpolicy
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// discRule blocks a POST to the host when the JSON body's top-level "action"
+// field is a string matching ^delete.
+func discRule() config.RequestPolicyRule {
+	return config.RequestPolicyRule{
+		Name:   "json-destructive-op",
+		Action: config.ActionBlock,
+		Route: config.RequestPolicyRoute{
+			Hosts:   []string{"api.service.example.com"},
+			Methods: []string{http.MethodPost},
+		},
+		Discriminator: &config.RequestPolicyDiscriminator{
+			Field:         "action",
+			ValuePatterns: []string{"^delete"},
+		},
+		Reason: "destructive JSON operation",
+	}
+}
+
+// jsonBody parses a JSON literal into the generic value the discriminator
+// predicate walks, asserting it parses so a test typo surfaces immediately.
+func jsonBody(t *testing.T, raw string) any {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		t.Fatalf("jsonBody: %v", err)
+	}
+	return v
+}
+
+func TestEvaluate_Discriminator(t *testing.T) {
+	host, method := "api.service.example.com", http.MethodPost
+
+	tests := []struct {
+		name       string
+		onOpaque   string // matcher OnOpaqueOperation; "" => default block
+		body       string
+		wantAction string // "" => allow
+	}{
+		{
+			name:       "field present string matches pattern",
+			body:       `{"action":"deleteAll"}`,
+			wantAction: config.ActionBlock,
+		},
+		{
+			name:       "field present string no pattern match",
+			body:       `{"action":"list"}`,
+			wantAction: "",
+		},
+		{
+			name:       "field absent",
+			body:       `{"other":"deleteAll"}`,
+			wantAction: "",
+		},
+		{
+			name:       "field present as array is opaque",
+			body:       `{"action":["delete","All"]}`,
+			wantAction: config.ActionBlock,
+		},
+		{
+			name:       "field present as object is opaque",
+			body:       `{"action":{"op":"deleteAll"}}`,
+			wantAction: config.ActionBlock,
+		},
+		{
+			name:       "field present as number is opaque",
+			body:       `{"action":7}`,
+			wantAction: config.ActionBlock,
+		},
+		{
+			name:       "field present as bool is opaque",
+			body:       `{"action":true}`,
+			wantAction: config.ActionBlock,
+		},
+		{
+			name:       "field present as null is opaque",
+			body:       `{"action":null}`,
+			wantAction: config.ActionBlock,
+		},
+		{
+			name:       "non-object top level is opaque",
+			body:       `["action","deleteAll"]`,
+			wantAction: config.ActionBlock,
+		},
+		{
+			name:       "opaque honors on_opaque_operation warn",
+			onOpaque:   config.ActionWarn,
+			body:       `{"action":["delete"]}`,
+			wantAction: config.ActionWarn,
+		},
+		{
+			name:       "opaque honors on_opaque_operation allow",
+			onOpaque:   config.ActionAllow,
+			body:       `{"action":["delete"]}`,
+			wantAction: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := NewMatcher(&config.RequestPolicy{
+				Enabled:           true,
+				OnOpaqueOperation: tt.onOpaque,
+				Rules:             []config.RequestPolicyRule{discRule()},
+			})
+			if err != nil {
+				t.Fatalf("NewMatcher: %v", err)
+			}
+			meta := RequestMeta{
+				Host: host, Method: method,
+				JSONBody:       jsonBody(t, tt.body),
+				JSONBodyParsed: true,
+			}
+			got := m.Evaluate(meta)
+			if got.Action != tt.wantAction {
+				t.Fatalf("Evaluate action = %q, want %q", got.Action, tt.wantAction)
+			}
+		})
+	}
+}
+
+func TestHasBodyPredicate(t *testing.T) {
+	graphqlOnly := compiledRule{graphql: &gqlPredicate{}}
+	discOnly := compiledRule{disc: &discPredicate{}}
+	both := compiledRule{graphql: &gqlPredicate{}, disc: &discPredicate{}}
+	routeOnly := compiledRule{}
+
+	tests := []struct {
+		name string
+		rule compiledRule
+		kind BodyPredicateKind
+		want bool
+	}{
+		{"any matches graphql", graphqlOnly, PredAnyBody, true},
+		{"any matches disc", discOnly, PredAnyBody, true},
+		{"any matches none", routeOnly, PredAnyBody, false},
+		{"graphql kind on graphql rule", graphqlOnly, PredGraphQL, true},
+		{"graphql kind on disc rule", discOnly, PredGraphQL, false},
+		{"disc kind on disc rule", discOnly, PredDiscriminator, true},
+		{"disc kind on graphql rule", graphqlOnly, PredDiscriminator, false},
+		{"any matches both", both, PredAnyBody, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.rule.hasBodyPredicate(tt.kind); got != tt.want {
+				t.Fatalf("hasBodyPredicate(%v) = %v, want %v", tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
+// A duplicated targeted field is unclassifiable (parsers disagree on which
+// value wins), so it is opaque regardless of the collapsed value; an unrelated
+// duplicated key does not affect the targeted field.
+func TestEvaluate_DiscriminatorDuplicateKey(t *testing.T) {
+	m, err := NewMatcher(&config.RequestPolicy{
+		Enabled: true,
+		Rules:   []config.RequestPolicyRule{discRule()},
+	})
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+	base := RequestMeta{Host: "api.service.example.com", Method: http.MethodPost, JSONBodyParsed: true}
+
+	// Targeted field "action" duplicated; collapsed value is benign "list".
+	dup := base
+	dup.JSONBody = map[string]any{"action": "list"}
+	dup.JSONDupKeys = map[string]struct{}{"action": {}}
+	if got := m.Evaluate(dup).Action; got != config.ActionBlock {
+		t.Fatalf("duplicate targeted field should be opaque (block), got %q", got)
+	}
+
+	// Unrelated key duplicated; targeted field is a benign string.
+	unrelated := base
+	unrelated.JSONBody = map[string]any{"action": "list"}
+	unrelated.JSONDupKeys = map[string]struct{}{"foo": {}}
+	if got := m.Evaluate(unrelated); got.Matched() {
+		t.Fatalf("unrelated duplicate key must not block, got %+v", got)
+	}
+}
+
+// A discriminator rule must not fire until the body has been parsed: the
+// route-only first pass (JSONBodyParsed=false) must never match, or a body
+// predicate would block before the body is inspected.
+func TestEvaluate_DiscriminatorRouteOnlyPassDoesNotMatch(t *testing.T) {
+	m, err := NewMatcher(&config.RequestPolicy{
+		Enabled: true,
+		Rules:   []config.RequestPolicyRule{discRule()},
+	})
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+	got := m.Evaluate(RequestMeta{Host: "api.service.example.com", Method: http.MethodPost})
+	if got.Matched() {
+		t.Fatalf("route-only pass matched a discriminator rule: %+v", got)
+	}
+}
+
+// NeedsBodyPredicate must be true for a route-matched discriminator rule so the
+// transport reads the body, and false when the route does not match.
+func TestNeedsBodyPredicate_Discriminator(t *testing.T) {
+	m, err := NewMatcher(&config.RequestPolicy{
+		Enabled: true,
+		Rules:   []config.RequestPolicyRule{discRule()},
+	})
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+	if !m.NeedsBodyPredicate(RequestMeta{Host: "api.service.example.com", Method: http.MethodPost}) {
+		t.Fatalf("NeedsBodyPredicate = false for route-matched discriminator rule")
+	}
+	if m.NeedsBodyPredicate(RequestMeta{Host: "other.example.com", Method: http.MethodPost}) {
+		t.Fatalf("NeedsBodyPredicate = true for non-matching route")
+	}
+}
+
+// A rule with both GraphQL and discriminator predicates fires only when BOTH
+// match (route AND graphql AND discriminator).
+func TestEvaluate_CompositeGraphQLAndDiscriminator(t *testing.T) {
+	rule := config.RequestPolicyRule{
+		Name:   "composite",
+		Action: config.ActionBlock,
+		Route:  config.RequestPolicyRoute{Hosts: []string{"api.service.example.com"}},
+		GraphQL: &config.RequestPolicyGraphQL{
+			OperationTypes: []string{gqlMutation},
+		},
+		Discriminator: &config.RequestPolicyDiscriminator{
+			Field:         "action",
+			ValuePatterns: []string{"^delete"},
+		},
+	}
+	m, err := NewMatcher(&config.RequestPolicy{Enabled: true, Rules: []config.RequestPolicyRule{rule}})
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+
+	mutationOp := []RequestOperation{{Kind: gqlMutation, RootFields: []string{"x"}}}
+	queryOp := []RequestOperation{{Kind: gqlQuery, RootFields: []string{"x"}}}
+
+	cases := []struct {
+		name       string
+		ops        []RequestOperation
+		body       string
+		wantAction string
+	}{
+		{"both match", mutationOp, `{"action":"deleteAll"}`, config.ActionBlock},
+		{"graphql matches discriminator does not", mutationOp, `{"action":"list"}`, ""},
+		{"discriminator matches graphql does not", queryOp, `{"action":"deleteAll"}`, ""},
+		{"neither matches", queryOp, `{"action":"list"}`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := RequestMeta{
+				Host:           "api.service.example.com",
+				Method:         http.MethodPost,
+				Operations:     tc.ops,
+				JSONBody:       jsonBody(t, tc.body),
+				JSONBodyParsed: true,
+			}
+			if got := m.Evaluate(meta).Action; got != tc.wantAction {
+				t.Fatalf("Evaluate action = %q, want %q", got, tc.wantAction)
+			}
+		})
+	}
+}

--- a/internal/reqpolicy/policy.go
+++ b/internal/reqpolicy/policy.go
@@ -50,6 +50,18 @@ type RequestMeta struct {
 	// not match (fail-closed handling of parse errors / opaque requests is the
 	// caller's responsibility, driven by on_parse_error / on_opaque_operation).
 	Operations []RequestOperation
+	// JSONBody is the request body parsed as a generic JSON value, for
+	// discriminator-field predicates. JSONBodyParsed reports whether a body was
+	// read and parsed as valid JSON; a discriminator predicate is evaluated only
+	// when it is true (the caller drives the not-read / parse-error fail-closed
+	// cases via on_opaque_operation / on_parse_error, exactly as for GraphQL).
+	JSONBody       any
+	JSONBodyParsed bool
+	// JSONDupKeys is the set of top-level object keys that appeared more than
+	// once in the raw body. Go's JSON decoder keeps only the last value, but
+	// parsers disagree (first-wins vs last-wins), so a discriminator whose field
+	// is duplicated is unclassifiable and fails closed as opaque.
+	JSONDupKeys map[string]struct{}
 }
 
 // Decision is the outcome of evaluating request policy against a request.
@@ -85,6 +97,7 @@ type compiledRule struct {
 	shadow bool
 	compiledRoute
 	graphql *gqlPredicate
+	disc    *discPredicate
 }
 
 // Matcher holds the precompiled request_policy ruleset. Build one with
@@ -126,6 +139,10 @@ func NewMatcher(cfg *config.RequestPolicy) (*Matcher, error) {
 		if err != nil {
 			return nil, fmt.Errorf("request_policy rule %q: invalid graphql predicate: %w", r.Name, err)
 		}
+		disc, err := compileDiscriminatorPredicate(r.Discriminator)
+		if err != nil {
+			return nil, fmt.Errorf("request_policy rule %q: invalid discriminator predicate: %w", r.Name, err)
+		}
 		m.rules = append(m.rules, compiledRule{
 			name:          r.Name,
 			action:        r.Action,
@@ -133,6 +150,7 @@ func NewMatcher(cfg *config.RequestPolicy) (*Matcher, error) {
 			shadow:        r.Shadow,
 			compiledRoute: route,
 			graphql:       pred,
+			disc:          disc,
 		})
 	}
 	for i := range cfg.Batch {
@@ -223,10 +241,11 @@ func (m *Matcher) Evaluate(meta RequestMeta) Decision {
 	var best Decision
 	for i := range m.rules {
 		cr := &m.rules[i]
-		if !cr.matches(meta) {
+		action, matched := m.ruleDecision(cr, meta)
+		if !matched {
 			continue
 		}
-		cand := Decision{Action: cr.action, RuleName: cr.name, Reason: cr.reason, Shadow: cr.shadow}
+		cand := Decision{Action: action, RuleName: cr.name, Reason: cr.reason, Shadow: cr.shadow}
 		if betterDecision(cand, best) {
 			best = cand
 		}
@@ -234,33 +253,90 @@ func (m *Matcher) Evaluate(meta RequestMeta) Decision {
 	return best
 }
 
-// NeedsOperations reports whether any operation predicate route matches this
-// request. Transports use this to decide whether they must read/parse a body
-// independently of request_body_scanning.
-func (m *Matcher) NeedsOperations(meta RequestMeta) bool {
+// ruleDecision evaluates one rule against meta and returns the action to apply
+// and whether the rule fired. Route, GraphQL, and discriminator predicates
+// compose with AND: a rule with several predicates fires only when all match.
+// A discriminator that is present-but-unclassifiable (opaque) fires the
+// matcher's on_opaque_operation action instead of the rule's own action so an
+// ambiguous value type cannot slip past a deny rail; opaque=allow yields no
+// match. GraphQL parse-error / opaque handling stays the caller's job (it is
+// body-global, not per-rule), so this only matches inspectable GraphQL here.
+func (m *Matcher) ruleDecision(cr *compiledRule, meta RequestMeta) (string, bool) {
+	if !cr.routeMatches(meta) {
+		return "", false
+	}
+	if cr.graphql != nil && !cr.graphql.matches(meta.Operations) {
+		return "", false
+	}
+	if cr.disc != nil {
+		switch cr.disc.eval(meta) {
+		case discNoMatch:
+			return "", false
+		case discOpaque:
+			if m.onOpaqueOperation == "" || m.onOpaqueOperation == config.ActionAllow {
+				return "", false
+			}
+			return m.onOpaqueOperation, true
+		case discMatch:
+			// fall through to the rule's own action
+		}
+	}
+	return cr.action, true
+}
+
+// BodyPredicateKind selects which body predicates an uninspectable evaluation
+// applies to. A request body that cannot be read at all blocks every body
+// predicate (PredAnyBody); a surface-specific parse failure or opaque request
+// blocks only that surface's predicates so a GraphQL parse error does not also
+// fail-close a discriminator rule on the same (validly JSON) body, and vice
+// versa.
+type BodyPredicateKind uint8
+
+const (
+	PredAnyBody BodyPredicateKind = iota
+	PredGraphQL
+	PredDiscriminator
+)
+
+func (cr *compiledRule) hasBodyPredicate(kind BodyPredicateKind) bool {
+	switch kind {
+	case PredGraphQL:
+		return cr.graphql != nil
+	case PredDiscriminator:
+		return cr.disc != nil
+	default:
+		return cr.graphql != nil || cr.disc != nil
+	}
+}
+
+// NeedsBodyPredicate reports whether any body-predicate rule (GraphQL or
+// discriminator) route-matches this request. Transports use this to decide
+// whether they must read/parse a body independently of request_body_scanning.
+func (m *Matcher) NeedsBodyPredicate(meta RequestMeta) bool {
 	if m == nil || !m.enabled {
 		return false
 	}
 	for i := range m.rules {
 		cr := &m.rules[i]
-		if cr.graphql != nil && cr.routeMatches(meta) {
+		if cr.hasBodyPredicate(PredAnyBody) && cr.routeMatches(meta) {
 			return true
 		}
 	}
 	return false
 }
 
-// EvaluateUninspectable returns the strictest route-matching operation rule
-// decision using action for parse-error or opaque-operation fail-closed cases.
-// A configured action=allow yields no decision.
-func (m *Matcher) EvaluateUninspectable(meta RequestMeta, action string) Decision {
+// EvaluateUninspectable returns the strictest route-matching body-predicate
+// decision using action for parse-error / opaque / unreadable fail-closed
+// cases, restricted to rules carrying a predicate of kind. A configured
+// action=allow yields no decision.
+func (m *Matcher) EvaluateUninspectable(meta RequestMeta, action string, kind BodyPredicateKind) Decision {
 	if m == nil || !m.enabled || action == "" || action == config.ActionAllow {
 		return Decision{}
 	}
 	var best Decision
 	for i := range m.rules {
 		cr := &m.rules[i]
-		if cr.graphql == nil || !cr.routeMatches(meta) {
+		if !cr.hasBodyPredicate(kind) || !cr.routeMatches(meta) {
 			continue
 		}
 		cand := Decision{Action: action, RuleName: cr.name, Reason: cr.reason, Shadow: cr.shadow}
@@ -306,16 +382,6 @@ func actionRank(a string) int {
 	default:
 		return 0
 	}
-}
-
-func (cr *compiledRule) matches(meta RequestMeta) bool {
-	if !cr.routeMatches(meta) {
-		return false
-	}
-	if cr.graphql != nil && !cr.graphql.matches(meta.Operations) {
-		return false
-	}
-	return true
 }
 
 func (cr *compiledRoute) routeMatches(meta RequestMeta) bool {

--- a/internal/reqpolicy/policy_test.go
+++ b/internal/reqpolicy/policy_test.go
@@ -224,10 +224,10 @@ func TestMatcher_OperationHelpers(t *testing.T) {
 		t.Fatalf("NewMatcher: %v", err)
 	}
 	meta := RequestMeta{Host: "api.service.example.com", Method: "POST", Path: "/api/write", ContentType: "application/json"}
-	if !m.NeedsOperations(meta) {
+	if !m.NeedsBodyPredicate(meta) {
 		t.Fatal("route-matched GraphQL rule should need operation extraction")
 	}
-	if m.NeedsOperations(RequestMeta{Host: "api.service.example.com", Method: "GET", Path: "/api/write", ContentType: "application/json"}) {
+	if m.NeedsBodyPredicate(RequestMeta{Host: "api.service.example.com", Method: "GET", Path: "/api/write", ContentType: "application/json"}) {
 		t.Fatal("non-route-matching request should not need operation extraction")
 	}
 	if got := m.OnParseError(); got != config.ActionWarn {
@@ -236,11 +236,11 @@ func TestMatcher_OperationHelpers(t *testing.T) {
 	if got := m.OnOpaqueOperation(); got != config.ActionBlock {
 		t.Fatalf("OnOpaqueOperation = %q, want block", got)
 	}
-	parseDecision := m.EvaluateUninspectable(meta, m.OnParseError())
+	parseDecision := m.EvaluateUninspectable(meta, m.OnParseError(), PredGraphQL)
 	if parseDecision.Action != config.ActionWarn || parseDecision.RuleName != "api-write" {
 		t.Fatalf("parse decision = %+v, want warn from api-write", parseDecision)
 	}
-	if got := m.EvaluateUninspectable(meta, config.ActionAllow); got.Matched() {
+	if got := m.EvaluateUninspectable(meta, config.ActionAllow, PredGraphQL); got.Matched() {
 		t.Fatalf("allow uninspectable action should produce no decision, got %+v", got)
 	}
 	var nilM *Matcher


### PR DESCRIPTION
Extends `request_policy` operation rails with two new extraction surfaces.

## JSON discriminator-field rules

A new optional `discriminator` predicate on a `request_policy` rule matches a top-level JSON body field against RE2 `value_patterns`, the same way the `graphql` predicate matches operations. Fail-closed semantics:

- invalid JSON / unreadable body → `on_parse_error`
- valid object, target field absent → no match (allow-by-default)
- field present as a string → matched against `value_patterns`
- field present as null / number / bool / array / object → `on_opaque_operation`
- non-object top-level body → `on_opaque_operation`
- duplicated target field (JSON parsers disagree which value wins) → `on_opaque_operation`

Top-level field only this cut; nested paths are a deliberate future extension. The predicate composes with `graphql` (a rule carrying both requires both to match), is folded into the canonical policy hash, and is wired through the shared request_policy path so all HTTP transports inherit it (forward, CONNECT, TLS-intercept, reverse, fetch, redirect-hop).

## WebSocket per-frame operation policy

request_policy is now evaluated per WebSocket text frame: each reassembled, UTF-8-validated frame is treated as a JSON operation body over the handshake route. The upgrade handshake gates route-only rules and defers body-predicate (GraphQL + discriminator) evaluation to the frames.

Behavior change: previously a body-predicate rule on a WebSocket host blocked the upgrade outright on the empty handshake body, so the frames it was meant to inspect were never seen. The handshake now forwards (route-only) and the frames are inspected. Non-JSON / opaque frames fail closed per `on_parse_error` / `on_opaque_operation`; the fragment-reassembly boundary is the documented limit.

Config docs for `request_policy` are tracked as a separate follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request policy discriminators: rules can match on JSON request body field values via regex.
  * Per-frame request policy enforcement for WebSocket text messages.
  * Body-predicate evaluation refined so route-only rules avoid unnecessary body reads.

* **Bug Fixes / Behavior**
  * Non-object or ambiguous JSON values are treated as opaque (fail-closed by default); parse/opaque handling is more consistent.

* **Tests**
  * Expanded tests covering discriminator matching, JSON parsing, duplicate keys, batches, and WebSocket scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->