### PR TITLE
fix(proxy): redaction hardening (scanner lockstep + allowlist_unparseable passthrough)

### DIFF
--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -476,9 +476,18 @@ func sortedBodyTexts(texts []string) []string {
 }
 
 // applyRedaction is the pre-DLP content-transformation step. JSON bodies are
-// detected by declared media type or a valid JSON sniff. Operator-allowlisted
-// non-JSON bodies fall back to raw-text rewriting instead of passing through
-// unchanged. A fail-closed gate returns *redact.BlockError.
+// detected by declared media type or a valid JSON sniff and rewritten field-
+// by-field. Non-JSON bodies fail closed unless the request host (or a
+// configured route) appears on redaction.allowlist_unparseable, in which case
+// the body is forwarded UNMODIFIED. The passthrough is what makes OAuth token
+// exchanges work for hosts where the operator has declared the body trusted:
+// a form-urlencoded client_secret like Jobber's 64-hex value would otherwise
+// trip the broad hash-sha256 class matcher and be rewritten to a placeholder,
+// which the upstream then rejects as "client_id and secret do not match."
+// (Historical note: the legacy raw-text fallback used to apply class matchers
+// to allowlisted non-JSON bodies; that contract violated the operator-visible
+// promise of the allowlist and silently mangled OAuth credentials in transit.
+// The fail-closed gate for non-JSON on non-allowlisted hosts is unchanged.)
 func applyRedaction(buf []byte, req BodyScanRequest) ([]byte, *redact.Report, error) {
 	if bodyIsJSONForRedaction(buf, req.ContentType) {
 		rewritten, report, err := redact.RewriteRequestJSON(buf, req.RedactMatcher, redact.NewRedactor(), req.RedactLimits, redact.RequestMetadata{
@@ -497,7 +506,16 @@ func applyRedaction(buf []byte, req BodyScanRequest) ([]byte, *redact.Report, er
 			Detail: fmt.Sprintf("redaction enabled but body Content-Type %q is not JSON and request host %q/path %q is not allowed by redaction.allowlist_unparseable or redaction.allowlist_unparseable_routes", req.ContentType, req.Host, req.Path),
 		}
 	}
-	return rewriteRawTextBody(buf, req)
+	// Host is on allowlist_unparseable (or a matching route): pass the body
+	// to the upstream byte-for-byte. Body DLP scanning still runs on the
+	// downstream extraction path so operator-defined block/warn rules can
+	// still fire on outbound leaks; what we drop here is only the silent
+	// class-matcher rewrite that produced credential-mangling behavior.
+	return buf, &redact.Report{
+		Applied:  false,
+		Provider: redact.ProviderUnparseableAllowed,
+		Parser:   redact.ParserUnparseableAllowed,
+	}, nil
 }
 
 func bodyIsJSONForRedaction(buf []byte, contentType string) bool {
@@ -505,61 +523,6 @@ func bodyIsJSONForRedaction(buf []byte, contentType string) bool {
 		return true
 	}
 	return json.Valid(bytes.TrimSpace(buf))
-}
-
-func rewriteRawTextBody(buf []byte, req BodyScanRequest) ([]byte, *redact.Report, error) {
-	if req.RedactMatcher == nil {
-		return nil, nil, &redact.BlockError{
-			Reason: redact.ReasonInternalError,
-			Detail: "redaction matcher unavailable for raw-text fallback",
-		}
-	}
-	lim := req.RedactLimits
-	if lim.MaxBodyBytes <= 0 {
-		lim.MaxBodyBytes = redact.DefaultMaxBodyBytes
-	}
-	if lim.MaxRedactionsPerRequest <= 0 {
-		lim.MaxRedactionsPerRequest = redact.DefaultMaxRedactions
-	}
-	if lim.MaxBodyBytes > 0 && len(buf) > lim.MaxBodyBytes {
-		return nil, nil, &redact.BlockError{Reason: redact.ReasonBodyTooLarge}
-	}
-
-	body := string(buf)
-	matches := req.RedactMatcher.Scan(body)
-	if lim.MaxRedactionsPerRequest > 0 && countUniqueRawTextMatches(matches) > lim.MaxRedactionsPerRequest {
-		return nil, nil, &redact.BlockError{Reason: redact.ReasonOverflow}
-	}
-	redactor := redact.NewRedactor()
-	rewritten := redact.RewriteString(body, matches, redactor)
-	return []byte(rewritten), &redact.Report{
-		Applied:         true,
-		Provider:        redact.ProviderGenericRawText,
-		Parser:          redact.ParserRawText,
-		TotalRedactions: redactor.Total(),
-		ByClass:         redactor.ByClass(),
-	}, nil
-}
-
-func countUniqueRawTextMatches(matches []redact.Match) int {
-	if len(matches) == 0 {
-		return 0
-	}
-	seen := make(map[redact.Class]map[string]struct{})
-	total := 0
-	for _, match := range matches {
-		byOriginal, ok := seen[match.Class]
-		if !ok {
-			byOriginal = make(map[string]struct{})
-			seen[match.Class] = byOriginal
-		}
-		if _, ok := byOriginal[match.Original]; ok {
-			continue
-		}
-		byOriginal[match.Original] = struct{}{}
-		total++
-	}
-	return total
 }
 
 func unparseableBodyAllowlisted(req BodyScanRequest) bool {

--- a/internal/proxy/bodyscan_redact_test.go
+++ b/internal/proxy/bodyscan_redact_test.go
@@ -160,13 +160,23 @@ func TestScanRequestBody_Redaction_JSONSniffWrongContentType(t *testing.T) {
 	}
 }
 
-func TestScanRequestBody_Redaction_AllowlistedRawTextRewrites(t *testing.T) {
+// TestScanRequestBody_Redaction_AllowlistedNonJSONPassthrough is the
+// regression test for the allowlist_unparseable contract. Operators expect
+// a host on the list to have its non-JSON body forwarded UNMODIFIED so OAuth
+// token exchanges and other credential-bearing form-urlencoded requests
+// reach the upstream verbatim. The legacy raw-text-fallback path used to
+// run the class matcher on these bodies and silently rewrite individual
+// values, which broke OAuth flows whenever a credential happened to match
+// a broad class (hash-sha256 vs. a 64-hex client_secret, etc).
+func TestScanRequestBody_Redaction_AllowlistedNonJSONPassthrough(t *testing.T) {
 	cfg := testScannerConfig()
 	sc := scanner.New(cfg)
 	defer sc.Close()
 
-	secret := redactionE2ESecret()
-	body := `refresh_token=` + secret
+	// Opaque token value that does not match any DLP class, so we can
+	// observe the redaction passthrough without DLP-level interference.
+	const opaque = "opaque_refresh_token_value_not_dlp_shaped"
+	body := `grant_type=refresh_token&refresh_token=` + opaque
 	buf, result := scanRequestBody(context.Background(), BodyScanRequest{
 		Body:                       strings.NewReader(body),
 		Method:                     "POST",
@@ -178,20 +188,82 @@ func TestScanRequestBody_Redaction_AllowlistedRawTextRewrites(t *testing.T) {
 		Path:                       "/tenant-id/oauth2/v2.0/token",
 		RedactAllowlistUnparseable: []string{"login.microsoftonline.com"},
 	})
-	if strings.Contains(string(buf), secret) {
-		t.Fatalf("allowlisted raw-text body leaked unredacted secret: %s", buf)
+	if string(buf) != body {
+		t.Fatalf("body should pass through unmodified, got %q want %q", buf, body)
 	}
-	if !strings.Contains(string(buf), "<pl:") {
-		t.Fatalf("expected placeholder in rewritten raw-text body: %s", buf)
+	if strings.Contains(string(buf), "<pl:") {
+		t.Fatalf("body contains redaction placeholder despite allowlist passthrough: %s", buf)
 	}
 	if result.RedactionReport == nil {
-		t.Fatal("expected raw-text redaction report")
+		t.Fatal("expected passthrough redaction report")
 	}
-	if result.RedactionReport.Provider != redact.ProviderGenericRawText {
-		t.Fatalf("provider = %q, want %q", result.RedactionReport.Provider, redact.ProviderGenericRawText)
+	if result.RedactionReport.Applied {
+		t.Fatal("RedactionReport.Applied = true; allowlist_unparseable passthrough must not apply rewrites")
 	}
-	if result.RedactionReport.Parser != redact.ParserRawText {
-		t.Fatalf("parser = %q, want %q", result.RedactionReport.Parser, redact.ParserRawText)
+	if result.RedactionReport.Provider != redact.ProviderUnparseableAllowed {
+		t.Fatalf("provider = %q, want %q", result.RedactionReport.Provider, redact.ProviderUnparseableAllowed)
+	}
+	if result.RedactionReport.Parser != redact.ParserUnparseableAllowed {
+		t.Fatalf("parser = %q, want %q", result.RedactionReport.Parser, redact.ParserUnparseableAllowed)
+	}
+}
+
+// TestScanRequestBody_Redaction_AllowlistedPassthroughDoesNotMangleHashShapedSecret
+// is the direct regression test for the Jobber bug: a 64-hex client_secret
+// in a form-urlencoded body to an allowlist_unparseable host must reach
+// the upstream unmodified, even though the value matches the hash-sha256
+// redaction class. Pre-fix, the legacy raw-text fallback rewrote the value
+// to a placeholder and Jobber returned "client id and secret do not match
+// an existing application" because the upstream saw the placeholder, not
+// the real credential. The fix is the allowlist contract change in
+// applyRedaction.
+func TestScanRequestBody_Redaction_AllowlistedPassthroughDoesNotMangleHashShapedSecret(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	// 64 hex chars: shape matches the hash-sha256 redaction class. Not a
+	// real credential; this is a fixture pattern.
+	const hexSecret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	body := `grant_type=authorization_code&client_id=test-client-id&client_secret=` + hexSecret + `&code=test-code&redirect_uri=https%3A%2F%2Fexample.com%2Fcb`
+
+	// Compose a redaction matcher that explicitly includes hash-sha256 so
+	// the legacy path would have rewritten the secret if it still ran.
+	rcfg := redact.Config{
+		Enabled:        true,
+		DefaultProfile: "code",
+		Profiles: map[string]redact.ProfileSpec{
+			"code": {Classes: []string{string(redact.ClassHashSHA256)}},
+		},
+		Limits: redact.DefaultLimits(),
+	}
+	matcher, err := rcfg.BuildMatcher(rcfg.DefaultProfile)
+	if err != nil {
+		t.Fatalf("BuildMatcher: %v", err)
+	}
+
+	buf, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:                       strings.NewReader(body),
+		Method:                     "POST",
+		ContentType:                "application/x-www-form-urlencoded",
+		MaxBytes:                   2048,
+		Scanner:                    sc,
+		RedactMatcher:              matcher,
+		Host:                       "api.getjobber.com",
+		Path:                       "/api/oauth/token",
+		RedactAllowlistUnparseable: []string{"api.getjobber.com"},
+	})
+	if !strings.Contains(string(buf), hexSecret) {
+		t.Fatalf("hash-shaped client_secret was modified in transit despite allowlist passthrough: %s", buf)
+	}
+	if strings.Contains(string(buf), "<pl:hash-sha256") {
+		t.Fatalf("body contains hash-sha256 placeholder despite passthrough contract: %s", buf)
+	}
+	if result.RedactionReport == nil || result.RedactionReport.Applied {
+		t.Fatalf("RedactionReport must be present with Applied=false on passthrough, got %+v", result.RedactionReport)
+	}
+	if result.RedactionReport.Parser != redact.ParserUnparseableAllowed {
+		t.Fatalf("parser = %q, want %q", result.RedactionReport.Parser, redact.ParserUnparseableAllowed)
 	}
 }
 
@@ -264,14 +336,23 @@ func TestScanRequestBody_Redaction_RouteAllowlistRequiresFullMatch(t *testing.T)
 	}
 }
 
-func TestScanRequestBody_Redaction_RouteAllowlistRewritesBeforeDLP(t *testing.T) {
+// TestScanRequestBody_Redaction_RouteAllowlistPassthrough is the
+// route-scoped version of the allowlist passthrough contract. A matching
+// allowlist_unparseable_routes entry must produce the same byte-for-byte
+// forwarding behavior as the host-level allowlist (see
+// TestScanRequestBody_Redaction_AllowlistedNonJSONPassthrough). The legacy
+// raw-text fallback wrote the body via the redaction matcher; the fix
+// drops that rewrite so OAuth credential exchanges that match the route
+// reach the upstream verbatim.
+func TestScanRequestBody_Redaction_RouteAllowlistPassthrough(t *testing.T) {
 	cfg := testScannerConfig()
 	sc := scanner.New(cfg)
 	defer sc.Close()
 
-	secret := redactionE2ESecret()
+	const opaque = "opaque_refresh_token_value_not_dlp_shaped"
+	body := `grant_type=refresh_token&refresh_token=` + opaque
 	buf, result := scanRequestBody(context.Background(), BodyScanRequest{
-		Body:          strings.NewReader(`refresh_token=` + secret),
+		Body:          strings.NewReader(body),
 		Method:        "POST",
 		ContentType:   "application/x-www-form-urlencoded",
 		MaxBytes:      1024,
@@ -286,14 +367,20 @@ func TestScanRequestBody_Redaction_RouteAllowlistRewritesBeforeDLP(t *testing.T)
 			ContentTypes: []string{"application/x-www-form-urlencoded"},
 		}},
 	})
-	if strings.Contains(string(buf), secret) {
-		t.Fatalf("route-scoped raw-text fallback leaked unredacted secret: %s", buf)
+	if string(buf) != body {
+		t.Fatalf("route-scoped allowlist body should pass through unmodified, got %q want %q", buf, body)
 	}
-	if !result.RedactedDLPOnly {
-		t.Fatalf("expected RedactedDLPOnly=true after raw-text rewrite, got %+v", result)
+	if strings.Contains(string(buf), "<pl:") {
+		t.Fatalf("body contains redaction placeholder despite route-scoped passthrough: %s", buf)
 	}
-	if result.RedactionReport == nil || result.RedactionReport.Parser != redact.ParserRawText {
-		t.Fatalf("expected raw-text redaction report, got %+v", result.RedactionReport)
+	if result.RedactedDLPOnly {
+		t.Fatalf("RedactedDLPOnly = true; passthrough must not apply redaction rewrites, got %+v", result)
+	}
+	if result.RedactionReport == nil || result.RedactionReport.Applied {
+		t.Fatalf("expected passthrough redaction report with Applied=false, got %+v", result.RedactionReport)
+	}
+	if result.RedactionReport.Parser != redact.ParserUnparseableAllowed {
+		t.Fatalf("parser = %q, want %q", result.RedactionReport.Parser, redact.ParserUnparseableAllowed)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -527,7 +527,7 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 
 	p.setupCEE(&cfg.CrossRequestDetection)
 
-	if err := p.setupRedaction(cfg); err != nil {
+	if err := p.setupRedaction(cfg, sc); err != nil {
 		return nil, err
 	}
 
@@ -1654,8 +1654,8 @@ func addRedactionDictionaryChunks(matcher *redact.Matcher, class redact.Class, e
 // setupRedaction stores the compiled redaction runtime at startup. When
 // redaction is disabled, the pointers are cleared so request handlers fall
 // through without running the redaction step.
-func (p *Proxy) setupRedaction(cfg *config.Config) error {
-	rt, err := p.buildRedactionRuntime(cfg)
+func (p *Proxy) setupRedaction(cfg *config.Config, sc *scanner.Scanner) error {
+	rt, err := p.buildRedactionRuntimeWithScanner(cfg, sc)
 	if err != nil {
 		return fmt.Errorf("redaction runtime build: %w", err)
 	}

--- a/internal/proxy/redaction_runtime.go
+++ b/internal/proxy/redaction_runtime.go
@@ -26,11 +26,11 @@ type redactionRuntime struct {
 	allowlistUnparseableRoutes []redact.UnparseableRouteSpec
 	providers                  *redact.ProviderRegistry
 	configKey                  string
-	required                   bool
-}
-
-func (p *Proxy) buildRedactionRuntime(cfg *config.Config) (*redactionRuntime, error) {
-	return p.buildRedactionRuntimeWithScanner(cfg, p.scannerPtr.Load())
+	// previous keeps the last matching snapshot available during reload
+	// publication, so old cfg/scanner request snapshots do not spuriously
+	// fail closed after the new runtime is staged.
+	previous *redactionRuntime
+	required bool
 }
 
 func (p *Proxy) buildRedactionRuntimeWithScanner(cfg *config.Config, sc *scanner.Scanner) (*redactionRuntime, error) {
@@ -47,7 +47,7 @@ func (p *Proxy) buildRedactionRuntimeWithScanner(cfg *config.Config, sc *scanner
 	}
 	allowlist := append([]string(nil), cfg.Redaction.AllowlistUnparseable...)
 	routes := append([]redact.UnparseableRouteSpec(nil), cfg.Redaction.AllowlistUnparseableRoutes...)
-	return &redactionRuntime{
+	rt := &redactionRuntime{
 		matcher:                    matcher,
 		limits:                     cfg.Redaction.Limits.ToLimits(),
 		allowlistUnparseable:       allowlist,
@@ -55,7 +55,20 @@ func (p *Proxy) buildRedactionRuntimeWithScanner(cfg *config.Config, sc *scanner
 		providers:                  providers,
 		configKey:                  redactionConfigKeyForScanner(cfg, sc),
 		required:                   cfg.Redaction.Enabled,
-	}, nil
+	}
+	if previous := p.redactionRuntimePtr.Load(); previous != nil && previous.matcher != nil && previous.configKey != rt.configKey {
+		// Carry only the IMMEDIATE prior runtime as a one-hop fallback for the
+		// transient publish window between redactionRuntimePtr.Store and the
+		// scannerPtr swap in Reload. Shallow-copy and zero the predecessor's
+		// own .previous so chain depth stays bounded at 1 across many
+		// different-key reloads; otherwise long-running pods that rotate
+		// file/env secrets would accumulate every prior matcher in memory.
+		// The matcher and provider pointers are shared, so the copy is cheap.
+		snap := *previous
+		snap.previous = nil
+		rt.previous = &snap
+	}
+	return rt, nil
 }
 
 // RedactionRuntimePtr returns the atomic pointer to the redaction runtime
@@ -91,8 +104,13 @@ func currentRedactionRuntimeForConfig(cfg *config.Config, ptr *atomic.Pointer[re
 	}
 	if ptr != nil {
 		if rt := ptr.Load(); rt != nil && rt.matcher != nil {
-			if cfg != nil && rt.configKey == expectedKey {
-				return rt
+			for candidate := rt; candidate != nil; candidate = candidate.previous {
+				if candidate.matcher == nil {
+					continue
+				}
+				if cfg != nil && candidate.configKey == expectedKey {
+					return candidate
+				}
 			}
 		}
 	}

--- a/internal/proxy/redaction_runtime_test.go
+++ b/internal/proxy/redaction_runtime_test.go
@@ -4,12 +4,18 @@
 package proxy
 
 import (
+	"bytes"
+	"context"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
+	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
@@ -18,7 +24,7 @@ func TestBuildRedactionRuntime_DisabledReturnsNil(t *testing.T) {
 	cfg := config.Defaults()
 	p := &Proxy{}
 
-	rt, err := p.buildRedactionRuntime(cfg)
+	rt, err := p.buildRedactionRuntimeWithScanner(cfg, nil)
 	if err != nil {
 		t.Fatalf("buildRedactionRuntime: %v", err)
 	}
@@ -144,6 +150,175 @@ func TestCurrentRedactionRuntimeForConfig_ScannerSecretMismatchFailsClosed(t *te
 	}
 }
 
+func TestSetupRedaction_UsesInstalledScannerWithSecretRuntime(t *testing.T) {
+	cfg := config.Defaults()
+	applyKnownSecretRedactionTestProfile(cfg)
+
+	staleValue := redactionRuntimeFixtureValue("old")
+	startupValue := redactionRuntimeFixtureValue("startup")
+	staleScanner := redactionRuntimeScannerWithSecret(t, staleValue)
+	liveScanner := redactionRuntimeScannerWithSecret(t, startupValue)
+
+	p := &Proxy{}
+	p.scannerPtr.Store(staleScanner)
+	if err := p.setupRedaction(cfg, liveScanner); err != nil {
+		t.Fatalf("setupRedaction: %v", err)
+	}
+	p.scannerPtr.Store(liveScanner)
+
+	rt := p.currentRedactionRuntimeFor(cfg)
+	assertRedactionRuntimeMatchesScanner(t, cfg, liveScanner, rt)
+	assertKnownSecretBodyRedacted(t, liveScanner, rt, startupValue)
+}
+
+func TestCurrentRedactionRuntimeForConfig_ReloadWindowSelectsPreviousRuntimeForOldScanner(t *testing.T) {
+	cfg := config.Defaults()
+	applyKnownSecretRedactionTestProfile(cfg)
+
+	oldValue := redactionRuntimeFixtureValue("old")
+	newValue := redactionRuntimeFixtureValue("new")
+	oldScanner := redactionRuntimeScannerWithSecret(t, oldValue)
+	newScanner := redactionRuntimeScannerWithSecret(t, newValue)
+
+	p := &Proxy{}
+	oldRuntime, err := p.buildRedactionRuntimeWithScanner(cfg, oldScanner)
+	if err != nil {
+		t.Fatalf("build old redaction runtime: %v", err)
+	}
+	p.redactionRuntimePtr.Store(oldRuntime)
+
+	newRuntime, err := p.buildRedactionRuntimeWithScanner(cfg, newScanner)
+	if err != nil {
+		t.Fatalf("build new redaction runtime: %v", err)
+	}
+	p.redactionRuntimePtr.Store(newRuntime)
+
+	got := currentRedactionRuntimeForConfig(cfg, &p.redactionRuntimePtr, oldScanner)
+	if got == nil {
+		t.Fatal("reload window selected no runtime, want previous-runtime fallback")
+	}
+	if got.configKey != oldRuntime.configKey {
+		t.Fatalf("reload window selected runtime with configKey %q, want %q", got.configKey, oldRuntime.configKey)
+	}
+	// Shallow copy preserves matcher pointer identity so the old matcher is
+	// reused (no double-compile) even though the carrying struct is fresh.
+	if got.matcher != oldRuntime.matcher {
+		t.Fatal("reload window selected a different matcher than the previous runtime's")
+	}
+	// Chain depth must be bounded at 1 so long-running pods that rotate
+	// scanner secrets don't accumulate every prior matcher across reloads.
+	if newRuntime.previous == nil {
+		t.Fatal("new runtime did not chain the previous runtime as a one-hop fallback")
+	}
+	if newRuntime.previous.previous != nil {
+		t.Fatal("previous-chain depth > 1; expected bounded at 1 to prevent unbounded memory growth")
+	}
+	assertKnownSecretBodyRedacted(t, oldScanner, got, oldValue)
+}
+
+func TestProxyRedactionRuntime_ReloadStateMatrixMaintainsScannerInvariant(t *testing.T) {
+	oldValue := redactionRuntimeFixtureValue("old")
+	newValue := redactionRuntimeFixtureValue("new")
+	startupValue := redactionRuntimeFixtureValue("startup")
+
+	cfg := redactionRuntimeConfigWithSecret(t, oldValue, true)
+	initialScanner := scanner.New(cfg)
+	t.Cleanup(initialScanner.Close)
+
+	p, err := New(cfg, audit.NewNop(), initialScanner, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	assertProxyRedactionInvariant(t, p, cfg, initialScanner, true)
+
+	tests := []struct {
+		name             string
+		secret           string
+		redactionEnabled bool
+		expectRuntime    bool
+	}{
+		{
+			name:             "reload-with-change",
+			secret:           newValue,
+			redactionEnabled: true,
+			expectRuntime:    true,
+		},
+		{
+			name:             "reload-no-change",
+			secret:           newValue,
+			redactionEnabled: true,
+			expectRuntime:    true,
+		},
+		{
+			name:             "disable",
+			secret:           newValue,
+			redactionEnabled: false,
+			expectRuntime:    false,
+		},
+		{
+			name:             "re-enable",
+			secret:           startupValue,
+			redactionEnabled: true,
+			expectRuntime:    true,
+		},
+		{
+			name:             "downgrade",
+			secret:           oldValue,
+			redactionEnabled: true,
+			expectRuntime:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nextCfg := redactionRuntimeConfigWithSecret(t, tt.secret, tt.redactionEnabled)
+			nextScanner := scanner.New(nextCfg)
+			t.Cleanup(nextScanner.Close)
+
+			if ok := p.Reload(nextCfg, nextScanner); !ok {
+				t.Fatal("Reload returned false")
+			}
+			assertProxyRedactionInvariant(t, p, nextCfg, nextScanner, tt.expectRuntime)
+		})
+	}
+}
+
+func TestCurrentRedactionRuntimeForConfig_StaleScannerStillBlocksBodyScan(t *testing.T) {
+	cfg := config.Defaults()
+	applyKnownSecretRedactionTestProfile(cfg)
+
+	oldValue := redactionRuntimeFixtureValue("old")
+	newValue := redactionRuntimeFixtureValue("new")
+	oldScanner := redactionRuntimeScannerWithSecret(t, oldValue)
+	newScanner := redactionRuntimeScannerWithSecret(t, newValue)
+
+	p := &Proxy{}
+	oldRuntime, err := p.buildRedactionRuntimeWithScanner(cfg, oldScanner)
+	if err != nil {
+		t.Fatalf("build redaction runtime: %v", err)
+	}
+	p.redactionRuntimePtr.Store(oldRuntime)
+
+	got := currentRedactionRuntimeForConfig(cfg, &p.redactionRuntimePtr, newScanner)
+	if got == oldRuntime {
+		t.Fatal("stale scanner secret change returned old runtime")
+	}
+	if got == nil || got.matcher != nil || !got.required {
+		t.Fatalf("stale scanner mismatch returned %+v, want required nil-matcher sentinel", got)
+	}
+
+	_, result := scanKnownSecretBody(t, newScanner, got, newValue)
+	if result.Clean {
+		t.Fatal("stale scanner mismatch body scan was clean, want fail-closed block")
+	}
+	if result.Action != config.ActionBlock {
+		t.Fatalf("Action = %q, want %q", result.Action, config.ActionBlock)
+	}
+	if !strings.Contains(result.Reason, "redaction runtime unavailable") {
+		t.Fatalf("Reason = %q, want redaction runtime unavailable", result.Reason)
+	}
+}
+
 func writeRedactionRuntimeSecretFile(t *testing.T, secret string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "secrets.txt")
@@ -151,6 +326,98 @@ func writeRedactionRuntimeSecretFile(t *testing.T, secret string) string {
 		t.Fatalf("write secrets file: %v", err)
 	}
 	return path
+}
+
+func applyKnownSecretRedactionTestProfile(cfg *config.Config) {
+	cfg.Redaction = redact.Config{
+		Enabled:        true,
+		DefaultProfile: "known",
+		Profiles: map[string]redact.ProfileSpec{
+			"known": {Classes: []string{string(redact.ClassKnownSecret)}},
+		},
+		Limits: redact.DefaultLimits(),
+	}
+}
+
+func redactionRuntimeConfigWithSecret(t *testing.T, secret string, redactionEnabled bool) *config.Config {
+	t.Helper()
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.DLP.SecretsFile = writeRedactionRuntimeSecretFile(t, secret)
+	applyKnownSecretRedactionTestProfile(cfg)
+	cfg.Redaction.Enabled = redactionEnabled
+	return cfg
+}
+
+func redactionRuntimeScannerWithSecret(t *testing.T, secret string) *scanner.Scanner {
+	t.Helper()
+	cfg := redactionRuntimeConfigWithSecret(t, secret, true)
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+	return sc
+}
+
+func redactionRuntimeFixtureValue(label string) string {
+	return strings.Join([]string{label, "redaction", "runtime", "value", "1234"}, "-")
+}
+
+func assertProxyRedactionInvariant(t *testing.T, p *Proxy, cfg *config.Config, sc *scanner.Scanner, expectRuntime bool) {
+	t.Helper()
+	got := p.currentRedactionRuntimeFor(cfg)
+	if !expectRuntime {
+		if got != nil {
+			t.Fatalf("current redaction runtime = %+v, want nil when disabled", got)
+		}
+		return
+	}
+	assertRedactionRuntimeMatchesScanner(t, cfg, sc, got)
+}
+
+func assertRedactionRuntimeMatchesScanner(t *testing.T, cfg *config.Config, sc *scanner.Scanner, rt *redactionRuntime) {
+	t.Helper()
+	if rt == nil {
+		t.Fatal("current redaction runtime is nil")
+	}
+	if rt.matcher == nil {
+		t.Fatal("current redaction runtime has nil matcher")
+	}
+	want := redactionConfigKeyForScanner(cfg, sc)
+	if rt.configKey != want {
+		t.Fatalf("redaction runtime configKey = %q, want %q", rt.configKey, want)
+	}
+}
+
+func assertKnownSecretBodyRedacted(t *testing.T, sc *scanner.Scanner, rt *redactionRuntime, secret string) {
+	t.Helper()
+	buf, result := scanKnownSecretBody(t, sc, rt, secret)
+	if result.Action == config.ActionBlock {
+		t.Fatalf("body scan result = %+v, want redaction without fail-closed block", result)
+	}
+	if result.RedactionBlockReason != "" {
+		t.Fatalf("RedactionBlockReason = %q, want empty", result.RedactionBlockReason)
+	}
+	if result.RedactionReport == nil {
+		t.Fatal("RedactionReport is nil, want known secret redaction")
+	}
+	if bytes.Contains(buf, []byte(secret)) {
+		t.Fatalf("redacted body still contains known secret %q: %s", secret, string(buf))
+	}
+	if !bytes.Contains(buf, []byte("<pl:known-secret:1>")) {
+		t.Fatalf("redacted body = %s, want known-secret placeholder", string(buf))
+	}
+}
+
+func scanKnownSecretBody(t *testing.T, sc *scanner.Scanner, rt *redactionRuntime, secret string) ([]byte, BodyScanResult) {
+	t.Helper()
+	bodyReq := BodyScanRequest{
+		Body:        bytes.NewReader([]byte(`{"secret":"` + secret + `"}`)),
+		Method:      http.MethodPost,
+		ContentType: contentTypeJSON,
+		MaxBytes:    4096,
+		Scanner:     sc,
+	}
+	applyBodyScanRedaction(&bodyReq, rt)
+	return scanRequestBody(context.Background(), bodyReq)
 }
 
 // TestCurrentRedactionRuntimeForConfig_NoStoredRuntime_FailsClosed covers

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -2218,9 +2218,9 @@ func TestWSProxyRedaction_CrossMessageDLPFailClosedWhenEnforceDisabled(t *testin
 	enforceOff := false
 	cfg.Enforce = &enforceOff
 
-	rt, err := p.buildRedactionRuntime(cfg)
+	rt, err := p.buildRedactionRuntimeWithScanner(cfg, nil)
 	if err != nil {
-		t.Fatalf("buildRedactionRuntime: %v", err)
+		t.Fatalf("buildRedactionRuntimeWithScanner: %v", err)
 	}
 	if rt == nil {
 		t.Fatal("expected redaction runtime")

--- a/internal/redact/providers.go
+++ b/internal/redact/providers.go
@@ -22,13 +22,21 @@ const (
 	// known-provider allowlist.
 	ProviderGenericJSON = "generic-json"
 
-	// ParserRawText is used for operator-allowlisted non-JSON request bodies.
-	// It rewrites matcher spans in the raw text instead of forwarding the body
-	// unchanged.
-	ParserRawText = "raw-text"
+	// ParserUnparseableAllowed is used when a non-JSON request body targets
+	// a host on redaction.allowlist_unparseable (or matches a configured
+	// allowlist_unparseable_routes entry). The body is forwarded to the
+	// upstream UNMODIFIED. This is the contract operators expect from the
+	// allowlist: "trust this host's non-JSON body, do not rewrite it."
+	// Required for OAuth token exchanges whose form-urlencoded bodies carry
+	// client_secret values that may match broad redaction classes such as
+	// hash-sha256; rewriting the value would mangle the credential in
+	// transit and cause the upstream to reject the request.
+	ParserUnparseableAllowed = "unparseable-allowed"
 
-	// ProviderGenericRawText labels raw-text fallback redaction receipts.
-	ProviderGenericRawText = "generic-raw-text"
+	// ProviderUnparseableAllowed labels redaction reports emitted when the
+	// allowlist routed a non-JSON body straight through without applying
+	// any class matchers. Applied is always false for these reports.
+	ProviderUnparseableAllowed = "operator-allowlisted-unparseable"
 )
 
 // RequestMetadata identifies the upstream request enough to select a provider


### PR DESCRIPTION
Two related fixes in the request-body redaction layer. Both are long-standing contract mismatches between what the operator-visible config says the redaction subsystem will do and what the code actually does. The first hardens the scanner / redaction-runtime publish ordering across reloads; the second realigns the `allowlist_unparseable` semantic with its documented intent.

## 1. Keep redaction runtime in lockstep with scannerPtr across publish windows

The forward-proxy body-redaction runtime gates a fail-closed block at `bodyscan.go:290`: if redaction is required but no matcher is published, the request is blocked. The matcher selector at `currentRedactionRuntimeForConfig` returns the published runtime only when its frozen `configKey` matches the request-time `expectedKey`, otherwise a fail-closed nil-matcher sentinel.

`configKey` includes the scanner's detected env/file secret values, so a matcher built from one scanner is rejected for another scanner's request. That is correct: a stale matcher must not be used after the scanner's known secrets change. The fragility is when the published runtime and the live `scannerPtr` are accidentally built from different scanners, which surfaces as a permanent fail-close that a process restart cannot recover from.

**Pass the scanner to `setupRedaction` explicitly.** Startup used to re-load `p.scannerPtr.Load()` inside `setupRedaction` instead of taking the scanner being installed. Reordering startup, or adding a second scanner install in front of it, would silently desync the runtime's key from the live scanner. With this change, the startup runtime is built from the same scanner the caller stored into `scannerPtr`.

**Carry a one-hop previous runtime for the reload window.** `Reload` publishes the new redaction runtime before swapping `scannerPtr`. A request observed in that window sees the new runtime with the old live scanner, and if the scanners differ, the keys mismatch and the request fail-closes. To keep consistent old-snapshot requests serviceable across that window, the new runtime now carries the immediate prior runtime as a one-hop fallback. The selector walks the new runtime first; if its key does not match, it tries the previous. Mixed snapshots (new cfg with old scanner, or vice versa) still fail closed.

**Bound the previous-chain depth at 1.** The prior runtime is shallow-copied and its own `.previous` is nulled before being attached. Otherwise long-running processes that legitimately rotate scanner secrets would accumulate every prior matcher across reloads. The matcher and provider pointers are shared by the shallow copy, so the carry is cheap.

### Tests

- Startup: a scanner with non-empty `RedactionSecretValues` and redaction enabled does not fail-close on a body-scanned, redaction-required request.
- Reload publish window: a request bearing the prior scanner is served by the previous runtime via the one-hop fallback.
- Reload state matrix: first load, reload-with-change, reload-no-change, disable, re-enable, downgrade. After each, the published runtime's `configKey` matches `redactionConfigKeyForScanner(cfg, scannerPtr.Load())`.
- Stale scanner secret change: a request with a scanner that does not match any candidate in the chain returns the fail-closed nil-matcher sentinel (legitimate fail-close preserved).
- Chain-depth bound: after a reload, the new runtime's `previous.previous` is nil.

## 2. Honor `allowlist_unparseable` as true passthrough, not raw-text rewrite

`redaction.allowlist_unparseable` is documented and named as a trust mechanism for non-JSON request bodies. The implementation diverged from that contract: when a host appeared on the list, `applyRedaction` fell through to a raw-text fallback that still ran the redaction class matcher and silently rewrote individual values inside the body. For OAuth token-exchange requests whose form-urlencoded `client_secret` matched a broad class like `hash-sha256` (any 64-hex string), the legacy path mangled the credential in transit. The upstream then rejected the request with "client_id and secret do not match" even though the operator-visible state was correct.

The fix realigns the implementation with the contract: **allowlisted non-JSON bodies pass through to the upstream UNMODIFIED.** The fail-closed gate for non-JSON on non-allowlisted hosts is unchanged. Body DLP scanning still runs on the extracted text downstream, so operator-defined block/warn rules continue to catch genuine outbound leaks; only the silent class-matcher rewrite is gone.

Concretely:

- `applyRedaction` returns the body byte-for-byte plus a `Report` marked `Applied: false` and `Parser: ParserUnparseableAllowed` when the host is on `redaction.allowlist_unparseable` or matches a configured `allowlist_unparseable_routes` entry.
- The legacy `rewriteRawTextBody` + `countUniqueRawTextMatches` helpers are removed (unreachable after the contract fix).
- `ProviderGenericRawText` and `ParserRawText` constants are replaced by `ProviderUnparseableAllowed` and `ParserUnparseableAllowed`.

### Tests added or rewritten

- `TestScanRequestBody_Redaction_AllowlistedNonJSONPassthrough` asserts byte-identical forwarding when the host is on the allowlist.
- `TestScanRequestBody_Redaction_AllowlistedPassthroughDoesNotMangleHashShapedSecret` is the direct regression test: a 64-hex `client_secret` in a form-urlencoded body must reach the upstream verbatim even when `hash-sha256` is enabled in the redaction profile.
- `TestScanRequestBody_Redaction_RouteAllowlistPassthrough` is the route-scoped equivalent.
- Existing host:port-matches-allowlist, JSON sniff, non-JSON-blocked-when-not-allowlisted, route-requires-full-match, and route-normalizes-runtime-candidates tests continue to pass unchanged.

### Operational migration note

Deployments that relied on the legacy raw-text fallback to redact secrets on allowlisted hosts must add an equivalent `suppress` entry or remove the host from the allowlist. The documented intent of `allowlist_unparseable` was always "trust this host."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redaction reliability during configuration reloads with a bounded fallback to the previous runtime
  * Enhanced fail-closed behavior when scanner credentials change, blocking body scanning on config mismatch

* **Behavior Changes**
  * Allowlisted non-JSON/unparseable request bodies are now forwarded unchanged and reported as not applied (new unparseable-allowed report labels)

* **Tests**
  * Expanded coverage for redaction behavior across hot-reloads, scanner changes, allowlist passthrough, and configuration transitions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->