### PR TITLE
feat(license): add fleet feature flag and gate Conductor + fleet-sink

### DIFF
--- a/charts/pipelock/README.md
+++ b/charts/pipelock/README.md
@@ -115,7 +115,7 @@ The chart automatically templates these into the config and they should not be s
 
 See [`examples/`](examples/) for ready-to-use values configurations:
 
-- `values-pro.yaml` — Pro license mounted from a Secret, with admin API and Sentry
+- `values-pro.yaml` — Licensed per-agent profile example with optional admin API and Sentry Secret wiring
 - `values-mcp-sidecar.yaml` — MCP HTTP listener bridging to an upstream MCP server
 - `values-ha.yaml` — 3 replicas, PodDisruptionBudget, topology spread, NetworkPolicy
 

--- a/charts/pipelock/examples/values-pro.yaml
+++ b/charts/pipelock/examples/values-pro.yaml
@@ -1,6 +1,6 @@
-# Pro / Enterprise install: license token mounted from a Secret, admin API
-# enabled with bearer-token auth, Sentry DSN wired in, and per-agent profiles
-# configured under .pipelock.agents.
+# Licensed install example: mounts a Pro or Enterprise token from a Secret.
+# It also enables the free authenticated admin API and Sentry DSN wiring as
+# optional operational controls, plus per-agent profiles under .pipelock.agents.
 #
 # Prerequisites:
 #   kubectl create secret generic pipelock-license \

--- a/charts/pipelock/values.yaml
+++ b/charts/pipelock/values.yaml
@@ -119,7 +119,8 @@ sentry:
 
 # Authenticated admin API for `pipelock adaptive` and `pipelock session`
 # commands. When enabled, the chart renders kill_switch.api_listen into the
-# config and exposes the admin port on the Service.
+# config and exposes the admin port on the Service. This is an operational
+# control, not a paid entitlement.
 adminApi:
   enabled: false
   # Token Secret. Required when adminApi.enabled is true. The Secret must

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -608,8 +608,11 @@ func (h *WebhookHandler) tierToFeatures(tier string) []string {
 	case tierFoundingPro, tierPro, tierTrial:
 		return []string{license.FeatureAgents}
 	case tierEnterprise:
-		// TODO: Define enterprise-specific features as they're built.
-		return []string{license.FeatureAgents}
+		// Enterprise tier carries the fleet control plane (Conductor + audit
+		// sink) on top of the Pro multi-agent profile feature. Add additional
+		// Enterprise-only features (hosted services, transparency log, …) to
+		// this slice as they ship.
+		return []string{license.FeatureAgents, license.FeatureFleet}
 	case tierAssess:
 		return []string{license.FeatureAssess}
 	default:

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -214,7 +214,7 @@ func TestTierToFeatures(t *testing.T) {
 	}{
 		{"pro", tierPro, []string{license.FeatureAgents}},
 		{"founding pro", tierFoundingPro, []string{license.FeatureAgents}},
-		{"enterprise", tierEnterprise, []string{license.FeatureAgents}},
+		{"enterprise", tierEnterprise, []string{license.FeatureAgents, license.FeatureFleet}},
 		{"trial", tierTrial, []string{license.FeatureAgents}},
 		{"assess", tierAssess, []string{license.FeatureAssess}},
 		{"unknown returns nil (fail-closed)", "unknown", nil},

--- a/internal/cli/conductor/cmd.go
+++ b/internal/cli/conductor/cmd.go
@@ -50,6 +50,7 @@ type serveOptions struct {
 	remoteKillMaxTTL    time.Duration
 	rollbackMaxTTL      time.Duration
 	auditRetention      time.Duration
+	licenseCRLFile      string
 	tlsCert             string
 	tlsKey              string
 	clientCA            string
@@ -99,7 +100,7 @@ func serveCmd() *cobra.Command {
 			// Fail-closed before any listener bind or file IO so an unlicensed
 			// invocation produces a clear entitlement error instead of a
 			// half-started server with leaked sockets.
-			if err := license.RequireFleet("", ""); err != nil {
+			if _, err := license.VerifyFleet("", "", opts.licenseCRLFile); err != nil {
 				return err
 			}
 			return runServe(cmd, opts)
@@ -121,6 +122,7 @@ func serveCmd() *cobra.Command {
 		"trusted emergency control key as comma-separated kv pairs: 'id=ID,purpose=(remote-kill-signing|policy-bundle-rollback),(inline=BASE64|file=/path)'; repeatable")
 	cmd.Flags().DurationVar(&opts.remoteKillMaxTTL, "remote-kill-max-validity", opts.remoteKillMaxTTL, "maximum validity window for published Conductor remote-kill messages")
 	cmd.Flags().DurationVar(&opts.rollbackMaxTTL, "rollback-max-validity", opts.rollbackMaxTTL, "maximum validity window for published Conductor rollback authorizations")
+	cmd.Flags().StringVar(&opts.licenseCRLFile, "license-crl-file", "", "signed license revocation list file; falls back to PIPELOCK_LICENSE_CRL_FILE")
 	cmd.Flags().StringVar(&opts.tlsCert, "tls-cert", "", "TLS server certificate file")
 	cmd.Flags().StringVar(&opts.tlsKey, "tls-key", "", "TLS server private key file")
 	cmd.Flags().StringVar(&opts.clientCA, "client-ca", "", "client CA PEM bundle for follower mTLS")

--- a/internal/cli/conductor/cmd.go
+++ b/internal/cli/conductor/cmd.go
@@ -24,6 +24,7 @@ import (
 
 	conductorcore "github.com/luckyPipewrench/pipelock/internal/conductor"
 	"github.com/luckyPipewrench/pipelock/internal/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
@@ -94,6 +95,13 @@ func serveCmd() *cobra.Command {
 		Short: "Serve Conductor policy and audit ingest endpoints",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// License gate: Conductor is the Enterprise fleet control plane.
+			// Fail-closed before any listener bind or file IO so an unlicensed
+			// invocation produces a clear entitlement error instead of a
+			// half-started server with leaked sockets.
+			if err := license.RequireFleet("", ""); err != nil {
+				return err
+			}
 			return runServe(cmd, opts)
 		},
 	}

--- a/internal/cli/conductor/cmd_test.go
+++ b/internal/cli/conductor/cmd_test.go
@@ -24,8 +24,26 @@ import (
 
 	conductorcore "github.com/luckyPipewrench/pipelock/internal/conductor"
 	"github.com/luckyPipewrench/pipelock/internal/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
+
+func TestServeCmd_NoFleetLicenseFailsClosed(t *testing.T) {
+	t.Setenv(license.EnvLicenseKey, "")
+	t.Setenv(license.EnvLicensePublicKey, "")
+	t.Setenv(license.EnvLicenseCRLFile, "")
+	cmd := Cmd()
+	cmd.SetArgs([]string{"serve"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("conductor serve without fleet license: want error, got nil")
+	}
+	if !errors.Is(err, license.ErrFleetLicenseRequired) {
+		t.Fatalf("want ErrFleetLicenseRequired, got %v", err)
+	}
+}
 
 func TestBuildServeHandlerWiresControlPlane(t *testing.T) {
 	pub, _, err := ed25519.GenerateKey(rand.Reader)

--- a/internal/cli/fleet/license_test.go
+++ b/internal/cli/fleet/license_test.go
@@ -39,6 +39,7 @@ func setTestFleetLicense(t *testing.T) {
 	}
 	t.Setenv(license.EnvLicenseKey, tok)
 	t.Setenv(license.EnvLicensePublicKey, hex.EncodeToString(pub))
+	t.Setenv(license.EnvLicenseCRLFile, "")
 }
 
 // TestSinkCmd_NoFleetLicenseFailsClosed locks in that `pipelock fleet-sink`
@@ -47,6 +48,7 @@ func setTestFleetLicense(t *testing.T) {
 func TestSinkCmd_NoFleetLicenseFailsClosed(t *testing.T) {
 	t.Setenv(license.EnvLicenseKey, "")
 	t.Setenv(license.EnvLicensePublicKey, "")
+	t.Setenv(license.EnvLicenseCRLFile, "")
 	cmd := SinkCmd()
 	cmd.SetArgs([]string{"--storage-dir", t.TempDir()})
 	err := cmd.Execute()

--- a/internal/cli/fleet/license_test.go
+++ b/internal/cli/fleet/license_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package fleet
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+// setTestFleetLicense issues a fresh Enterprise-tier license (with the fleet
+// feature) and installs it via PIPELOCK_LICENSE_KEY +
+// PIPELOCK_LICENSE_PUBLIC_KEY env vars for the test's lifetime, so the
+// production fleet-license gate in SinkCmd's RunE fires against real signed
+// tokens during tests that exercise the running sink. t.Setenv restores
+// previous values automatically.
+func setTestFleetLicense(t *testing.T) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tok, err := license.Issue(license.License{
+		ID:        "test-fleet-license",
+		Email:     "test@example.com",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		Features:  []string{license.FeatureAgents, license.FeatureFleet},
+		Tier:      "enterprise",
+	}, priv)
+	if err != nil {
+		t.Fatalf("license.Issue: %v", err)
+	}
+	t.Setenv(license.EnvLicenseKey, tok)
+	t.Setenv(license.EnvLicensePublicKey, hex.EncodeToString(pub))
+}
+
+// TestSinkCmd_NoFleetLicenseFailsClosed locks in that `pipelock fleet-sink`
+// refuses to start when the supplied license does not grant the fleet
+// feature, even with otherwise valid arguments.
+func TestSinkCmd_NoFleetLicenseFailsClosed(t *testing.T) {
+	t.Setenv(license.EnvLicenseKey, "")
+	t.Setenv(license.EnvLicensePublicKey, "")
+	cmd := SinkCmd()
+	cmd.SetArgs([]string{"--storage-dir", t.TempDir()})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("SinkCmd without fleet license: want error, got nil")
+	}
+	if !errors.Is(err, license.ErrFleetLicenseRequired) {
+		t.Fatalf("want ErrFleetLicenseRequired, got: %v", err)
+	}
+}

--- a/internal/cli/fleet/sink.go
+++ b/internal/cli/fleet/sink.go
@@ -45,6 +45,7 @@ func SinkCmd() *cobra.Command {
 	var tlsKey string
 	var clientCA string
 	var readerTokenFile string
+	var licenseCRLFile string
 
 	cmd := &cobra.Command{
 		Use:   "fleet-sink",
@@ -52,9 +53,9 @@ func SinkCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// License gate: fleet-sink is the Enterprise audit-sink server.
-			// Fail-closed before any flag parsing / listener bind / disk IO
-			// so an unlicensed invocation produces a clear entitlement error.
-			if err := license.RequireFleet("", ""); err != nil {
+			// Fail-closed before any listener bind / disk IO so an unlicensed
+			// invocation produces a clear entitlement error.
+			if _, err := license.VerifyFleet("", "", licenseCRLFile); err != nil {
 				return err
 			}
 			if strings.TrimSpace(storageDir) == "" {
@@ -150,6 +151,7 @@ func SinkCmd() *cobra.Command {
 	cmd.Flags().StringVar(&clientCA, "client-ca", "", "client CA PEM bundle for mTLS")
 	cmd.Flags().StringVar(&readerTokenFile, "reader-token-file", "",
 		"path to a file containing the bearer token required for GET requests; required for non-loopback bind without --client-ca")
+	cmd.Flags().StringVar(&licenseCRLFile, "license-crl-file", "", "signed license revocation list file; falls back to PIPELOCK_LICENSE_CRL_FILE")
 	return cmd
 }
 

--- a/internal/cli/fleet/sink.go
+++ b/internal/cli/fleet/sink.go
@@ -24,6 +24,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/conductor"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/fleet/sink"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
@@ -50,6 +51,12 @@ func SinkCmd() *cobra.Command {
 		Short: "Run a Conductor audit batch sink",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// License gate: fleet-sink is the Enterprise audit-sink server.
+			// Fail-closed before any flag parsing / listener bind / disk IO
+			// so an unlicensed invocation produces a clear entitlement error.
+			if err := license.RequireFleet("", ""); err != nil {
+				return err
+			}
 			if strings.TrimSpace(storageDir) == "" {
 				return errors.New("--storage-dir is required")
 			}

--- a/internal/cli/fleet/sink_test.go
+++ b/internal/cli/fleet/sink_test.go
@@ -320,6 +320,7 @@ func TestSignalContextCancel(t *testing.T) {
 // This wires together the resolver, store, scanner, and handler so all of
 // SinkCmd's setup branches are exercised.
 func TestSinkCmd_RunOnLoopback(t *testing.T) {
+	setTestFleetLicense(t)
 	pub, _, err := signing.GenerateKeyPair()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/fleet/sink_test.go
+++ b/internal/cli/fleet/sink_test.go
@@ -271,6 +271,7 @@ func TestSinkCmdValidatesArgsBeforeServing(t *testing.T) {
 		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			setTestFleetLicense(t)
 			cmd := SinkCmd()
 			cmd.SetArgs(tc.args)
 			cmd.SetOut(&bytes.Buffer{})
@@ -351,6 +352,7 @@ func TestSinkCmd_RunOnLoopback(t *testing.T) {
 // they configure half the TLS pair. The check fires after the OS-level
 // startup chatter (resolver + store) so we exercise the deferred branches.
 func TestSinkCmd_TLSCertWithoutKey(t *testing.T) {
+	setTestFleetLicense(t)
 	pub, _, err := signing.GenerateKeyPair()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/runtime/conductor_license_test.go
+++ b/internal/cli/runtime/conductor_license_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+// setTestFleetLicense issues a fresh Enterprise-tier license token (with the
+// `fleet` feature) and installs it via PIPELOCK_LICENSE_KEY +
+// PIPELOCK_LICENSE_PUBLIC_KEY env vars for the lifetime of t. Tests that
+// enable conductor.enabled use this so the production license gate fires
+// against real signed tokens — not a bypass — while still letting the test
+// proceed without depending on a build-embedded key. t.Cleanup unsets the
+// env vars via t.Setenv's normal restoration.
+func setTestFleetLicense(t *testing.T) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tok, err := license.Issue(license.License{
+		ID:        "test-fleet-license",
+		Email:     "test@example.com",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		Features:  []string{license.FeatureAgents, license.FeatureFleet},
+		Tier:      "enterprise",
+	}, priv)
+	if err != nil {
+		t.Fatalf("license.Issue: %v", err)
+	}
+	t.Setenv(license.EnvLicenseKey, tok)
+	t.Setenv(license.EnvLicensePublicKey, hex.EncodeToString(pub))
+}
+
+// TestNewServer_ConductorEnabledRequiresFleetLicense locks in the runtime
+// fleet-license gate: a config with conductor.enabled=true MUST fail to
+// start when no fleet license is present, even if every other config field
+// is valid. Otherwise an operator (or a misconfigured fleet) could activate
+// central governance without an entitlement.
+func TestNewServer_ConductorEnabledRequiresFleetLicense(t *testing.T) {
+	t.Setenv(license.EnvLicenseKey, "")
+	t.Setenv(license.EnvLicensePublicKey, "")
+	// We don't need conductor to fully start; just reach the gate. A minimal
+	// invalid config still fails validation BEFORE the gate, so we use the
+	// existing conductor-enabled test fixture and assert the gate's error.
+	// The fixture sets up flight_recorder + conductor; without a fleet
+	// license env, NewServer must error with ErrFleetLicenseRequired.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unexpected panic: %v", r)
+		}
+	}()
+	// newConductorApplyTestServer asserts NewServer succeeds. We want it to
+	// FAIL, so we replicate just enough config setup to trigger the gate.
+	cfgYAML := "conductor:\n  enabled: true\n  conductor_url: https://conductor.example\n  org_id: o\n  fleet_id: f\n  instance_id: i\n"
+	cfgPath := writeServerTestConfig(t, cfgYAML)
+	_, err := NewServer(ServerOpts{ConfigFile: cfgPath, Stdout: &syncBuffer{}, Stderr: &syncBuffer{}})
+	if err == nil {
+		t.Fatal("NewServer with conductor.enabled and no fleet license: want error, got nil")
+	}
+}

--- a/internal/cli/runtime/conductor_license_test.go
+++ b/internal/cli/runtime/conductor_license_test.go
@@ -7,10 +7,16 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/license"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 // setTestFleetLicense issues a fresh Enterprise-tier license token (with the
@@ -39,6 +45,112 @@ func setTestFleetLicense(t *testing.T) {
 	}
 	t.Setenv(license.EnvLicenseKey, tok)
 	t.Setenv(license.EnvLicensePublicKey, hex.EncodeToString(pub))
+	t.Setenv(license.EnvLicenseCRLFile, "")
+}
+
+func setRevokedTestFleetLicense(t *testing.T) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	now := time.Now().UTC()
+	tok, err := license.Issue(license.License{
+		ID:        "revoked-fleet-license",
+		Email:     "test@example.com",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(time.Hour).Unix(),
+		Features:  []string{license.FeatureAgents, license.FeatureFleet},
+		Tier:      "enterprise",
+	}, priv)
+	if err != nil {
+		t.Fatalf("license.Issue: %v", err)
+	}
+	crl, err := license.SignCRL(license.CRLPayload{
+		Version:   license.CRLVersion,
+		IssuedAt:  now.Add(-time.Minute).Unix(),
+		ExpiresAt: now.Add(time.Hour).Unix(),
+		Revoked: []license.RevokedLicense{{
+			ID:        "revoked-fleet-license",
+			Reason:    "test revocation",
+			RevokedAt: now.Unix(),
+		}},
+	}, priv)
+	if err != nil {
+		t.Fatalf("license.SignCRL: %v", err)
+	}
+	data, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatalf("Marshal CRL: %v", err)
+	}
+	crlPath := filepath.Join(t.TempDir(), "license.crl.json")
+	if err := os.WriteFile(crlPath, data, 0o600); err != nil {
+		t.Fatalf("WriteFile(CRL): %v", err)
+	}
+	t.Setenv(license.EnvLicenseKey, tok)
+	t.Setenv(license.EnvLicensePublicKey, hex.EncodeToString(pub))
+	t.Setenv(license.EnvLicenseCRLFile, crlPath)
+}
+
+func conductorLicenseGateConfigYAML(t *testing.T) string {
+	t.Helper()
+	tmp, err := os.MkdirTemp(".", ".runtime-license-gate-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmp) })
+	tmp, err = filepath.Abs(tmp)
+	if err != nil {
+		t.Fatalf("Abs: %v", err)
+	}
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	keyPath := filepath.Join(tmp, "recorder.key")
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	clientPEM, clientKeyPEM := testTLSClientCert(t)
+	certDir := filepath.Join(tmp, "tls")
+	if err := os.Mkdir(certDir, 0o750); err != nil {
+		t.Fatalf("Mkdir(tls): %v", err)
+	}
+	caPath := filepath.Join(certDir, "boss-ca.pem")
+	clientCertPath := filepath.Join(certDir, "client.crt")
+	clientKeyPath := filepath.Join(certDir, "client.key")
+	trustPath := filepath.Join(certDir, "trust-roster.json")
+	bundleCacheDir := filepath.Join(certDir, "bundles")
+	auditQueueDir := filepath.Join(certDir, "audit-queue")
+	if err := os.WriteFile(caPath, clientPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile(ca): %v", err)
+	}
+	if err := os.WriteFile(clientCertPath, clientPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile(client cert): %v", err)
+	}
+	if err := os.WriteFile(clientKeyPath, clientKeyPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile(client key): %v", err)
+	}
+	if err := os.WriteFile(trustPath, []byte(`{"keys":[]}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(trust roster): %v", err)
+	}
+	return "flight_recorder:\n" +
+		"  enabled: true\n" +
+		"  dir: " + strconv.Quote(filepath.Join(tmp, "recorder")) + "\n" +
+		"  signing_key_path: " + strconv.Quote(keyPath) + "\n" +
+		"conductor:\n" +
+		"  enabled: true\n" +
+		"  conductor_url: https://conductor.example\n" +
+		"  org_id: o\n" +
+		"  fleet_id: f\n" +
+		"  instance_id: i\n" +
+		"  server_ca_file: " + strconv.Quote(caPath) + "\n" +
+		"  client_cert_path: " + strconv.Quote(clientCertPath) + "\n" +
+		"  client_key_path: " + strconv.Quote(clientKeyPath) + "\n" +
+		"  trust_roster_path: " + strconv.Quote(trustPath) + "\n" +
+		"  bundle_cache_dir: " + strconv.Quote(bundleCacheDir) + "\n" +
+		"  durable_audit_queue_dir: " + strconv.Quote(auditQueueDir) + "\n" +
+		"  honor_remote_kill_switch: false\n"
 }
 
 // TestNewServer_ConductorEnabledRequiresFleetLicense locks in the runtime
@@ -61,10 +173,50 @@ func TestNewServer_ConductorEnabledRequiresFleetLicense(t *testing.T) {
 	}()
 	// newConductorApplyTestServer asserts NewServer succeeds. We want it to
 	// FAIL, so we replicate just enough config setup to trigger the gate.
-	cfgYAML := "conductor:\n  enabled: true\n  conductor_url: https://conductor.example\n  org_id: o\n  fleet_id: f\n  instance_id: i\n"
-	cfgPath := writeServerTestConfig(t, cfgYAML)
+	cfgPath := writeServerTestConfig(t, conductorLicenseGateConfigYAML(t))
 	_, err := NewServer(ServerOpts{ConfigFile: cfgPath, Stdout: &syncBuffer{}, Stderr: &syncBuffer{}})
 	if err == nil {
 		t.Fatal("NewServer with conductor.enabled and no fleet license: want error, got nil")
+	}
+	if !errors.Is(err, license.ErrFleetLicenseRequired) {
+		t.Fatalf("want ErrFleetLicenseRequired, got %v", err)
+	}
+}
+
+func TestNewServer_ConductorEnabledRejectsRevokedFleetLicense(t *testing.T) {
+	setRevokedTestFleetLicense(t)
+	cfgPath := writeServerTestConfig(t, conductorLicenseGateConfigYAML(t))
+	_, err := NewServer(ServerOpts{ConfigFile: cfgPath, Stdout: &syncBuffer{}, Stderr: &syncBuffer{}})
+	if err == nil {
+		t.Fatal("NewServer with revoked fleet license: want error, got nil")
+	}
+	if !errors.Is(err, license.ErrFleetLicenseRequired) {
+		t.Fatalf("want ErrFleetLicenseRequired, got %v", err)
+	}
+	if !errors.Is(err, license.ErrLicenseRevoked) {
+		t.Fatalf("want ErrLicenseRevoked in error chain, got %v", err)
+	}
+}
+
+func TestServer_ReloadCannotActivateConductorWithNewLicense(t *testing.T) {
+	setTestFleetLicense(t)
+	s, _ := newTestServer(t, nil)
+	newCfg := s.proxy.CurrentConfig().Clone()
+	newCfg.Conductor.Enabled = true
+	newCfg.Conductor.ConductorURL = "https://conductor.example"
+	newCfg.Conductor.OrgID = "o"
+	newCfg.Conductor.FleetID = "f"
+	newCfg.Conductor.InstanceID = "i"
+
+	if err := s.Reload(newCfg); err != nil {
+		t.Fatalf("Reload enabling conductor: %v", err)
+	}
+	live := s.proxy.CurrentConfig()
+	if live.Conductor.Enabled {
+		t.Fatalf("reload activated conductor.enabled; live conductor = %+v", live.Conductor)
+	}
+	if s.conductorApply != nil || s.conductorAudit != nil || s.conductorProducer != nil || s.conductorRemoteKill != nil {
+		t.Fatalf("reload initialized conductor runtime wiring: apply=%v audit=%v producer=%v remoteKill=%v",
+			s.conductorApply, s.conductorAudit, s.conductorProducer, s.conductorRemoteKill)
 	}
 }

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -519,6 +519,9 @@ func (s runtimePolicySigner) resolver() conductor.SignatureKeyResolver {
 
 func newConductorApplyTestServer(t *testing.T) (*Server, runtimePolicySigner, string, string) {
 	t.Helper()
+	// conductor.enabled triggers the fleet-license gate; install a real
+	// Enterprise token for the test so the production gate path is exercised.
+	setTestFleetLicense(t)
 	tmp, err := os.MkdirTemp(".", ".runtime-conductor-apply-*")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -302,10 +302,13 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	// process does not silently start a half-wired follower the operator
 	// expects to be participating.
 	if cfg.Conductor.Enabled {
-		if err := license.RequireFleet(cfg.LicenseKey, cfg.LicensePublicKey); err != nil {
+		lic, err := license.VerifyFleet(cfg.LicenseKey, cfg.LicensePublicKey, cfg.LicenseCRLFile)
+		if err != nil {
 			s.cleanup()
 			return nil, err
 		}
+		cfg.LicenseID = lic.ID
+		cfg.LicenseExpiresAt = lic.ExpiresAt
 	}
 	conductorApply, conductorApplyErr := buildConductorApplyCache(cfg)
 	if conductorApplyErr != nil {

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/hitl"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/mcp"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/chains"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/policy"
@@ -294,6 +295,18 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	s.scanner = sc
 	m := metrics.New()
 	s.metrics = m
+	// License gate for the follower-side Conductor runtime. When
+	// conductor.enabled is true the operator has explicitly opted into
+	// central governance (remote kill, audit ingest, policy distribution);
+	// fail-closed if the license does not grant the fleet feature, so the
+	// process does not silently start a half-wired follower the operator
+	// expects to be participating.
+	if cfg.Conductor.Enabled {
+		if err := license.RequireFleet(cfg.LicenseKey, cfg.LicensePublicKey); err != nil {
+			s.cleanup()
+			return nil, err
+		}
+	}
 	conductorApply, conductorApplyErr := buildConductorApplyCache(cfg)
 	if conductorApplyErr != nil {
 		s.cleanup()

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -334,6 +334,7 @@ func TestNewServer_FlightRecorderAndEnvelopeFromConfig(t *testing.T) {
 }
 
 func TestNewServer_ConductorAuditProducerFromConfig(t *testing.T) {
+	setTestFleetLicense(t)
 	tmp, err := os.MkdirTemp(".", ".runtime-conductor-*")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)

--- a/internal/license/fleet_gate.go
+++ b/internal/license/fleet_gate.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// EnvLicenseKey is the env variable carrying the signed license token. The
+// conductor / fleet-sink server commands resolve their license from this
+// because they do not take a config file flag; the follower runtime resolves
+// the token from `cfg.LicenseKey` first and falls back to this env variable.
+const EnvLicenseKey = "PIPELOCK_LICENSE_KEY"
+
+// EnvLicensePublicKey is the optional env override for the verifier public key
+// in hex. Official builds embed the production key at build time; this env
+// variable is for development and self-hosted issuance.
+const EnvLicensePublicKey = "PIPELOCK_LICENSE_PUBLIC_KEY"
+
+// ErrFleetLicenseRequired is returned by RequireFleet when the supplied
+// license does not carry the fleet feature (or no license is present).
+// Callers should refuse to start fleet work and surface this error verbatim
+// so the operator sees the missing-entitlement message.
+var ErrFleetLicenseRequired = errors.New(
+	"fleet control plane (Conductor) requires an Enterprise license " +
+		"that grants the \"fleet\" feature; set PIPELOCK_LICENSE_KEY (and " +
+		"PIPELOCK_LICENSE_PUBLIC_KEY on unofficial builds) or contact your " +
+		"administrator",
+)
+
+// RequireFleet verifies the supplied license and returns nil only when it
+// carries the FeatureFleet entitlement. Pass licenseKey="" and publicKeyHex=""
+// to use the environment variables + the build-embedded public key.
+//
+// The function is intentionally narrow and fail-closed: any failure mode —
+// missing token, missing verifier key, expired/invalid signature, missing
+// feature — returns a wrapped ErrFleetLicenseRequired so call sites can keep
+// the error path uniform without branching on individual failure reasons.
+//
+// Callers (`pipelock conductor serve`, `pipelock fleet-sink`, and the
+// `pipelock run` follower runtime when `conductor.enabled: true`) invoke this
+// before doing any fleet work and abort fail-closed on a non-nil error.
+func RequireFleet(licenseKey, publicKeyHex string) error {
+	if licenseKey == "" {
+		licenseKey = os.Getenv(EnvLicenseKey)
+	}
+	if licenseKey == "" {
+		return ErrFleetLicenseRequired
+	}
+	pubKey := EmbeddedPublicKey()
+	if pubKey == nil {
+		if publicKeyHex == "" {
+			publicKeyHex = os.Getenv(EnvLicensePublicKey)
+		}
+		if publicKeyHex != "" {
+			keyBytes, decErr := hex.DecodeString(publicKeyHex)
+			if decErr == nil && len(keyBytes) == ed25519.PublicKeySize {
+				pubKey = keyBytes
+			}
+		}
+	}
+	if pubKey == nil {
+		return fmt.Errorf("%w: no verifier public key available "+
+			"(build-embedded key missing and PIPELOCK_LICENSE_PUBLIC_KEY unset)",
+			ErrFleetLicenseRequired)
+	}
+	lic, err := Verify(licenseKey, pubKey)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrFleetLicenseRequired, err)
+	}
+	if !lic.HasFeature(FeatureFleet) {
+		return fmt.Errorf("%w: license %s does not include the fleet feature "+
+			"(present features: %v)",
+			ErrFleetLicenseRequired, lic.ID, lic.Features)
+	}
+	return nil
+}

--- a/internal/license/fleet_gate.go
+++ b/internal/license/fleet_gate.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 )
 
 // EnvLicenseKey is the env variable carrying the signed license token. The
@@ -21,6 +22,11 @@ const EnvLicenseKey = "PIPELOCK_LICENSE_KEY"
 // in hex. Official builds embed the production key at build time; this env
 // variable is for development and self-hosted issuance.
 const EnvLicensePublicKey = "PIPELOCK_LICENSE_PUBLIC_KEY"
+
+// EnvLicenseCRLFile is the optional env variable pointing to a signed license
+// revocation list. Server commands that do not take a full config file can use
+// this to fail closed on revoked licenses.
+const EnvLicenseCRLFile = "PIPELOCK_LICENSE_CRL_FILE"
 
 // ErrFleetLicenseRequired is returned by RequireFleet when the supplied
 // license does not carry the fleet feature (or no license is present).
@@ -46,11 +52,20 @@ var ErrFleetLicenseRequired = errors.New(
 // `pipelock run` follower runtime when `conductor.enabled: true`) invoke this
 // before doing any fleet work and abort fail-closed on a non-nil error.
 func RequireFleet(licenseKey, publicKeyHex string) error {
+	_, err := VerifyFleet(licenseKey, publicKeyHex, "")
+	return err
+}
+
+// VerifyFleet verifies the supplied license token and returns the decoded
+// license only when it carries the FeatureFleet entitlement. The optional
+// crlFile argument, or PIPELOCK_LICENSE_CRL_FILE when empty, enables fail-closed
+// revocation checks with a signed CRL.
+func VerifyFleet(licenseKey, publicKeyHex, crlFile string) (License, error) {
 	if licenseKey == "" {
 		licenseKey = os.Getenv(EnvLicenseKey)
 	}
 	if licenseKey == "" {
-		return ErrFleetLicenseRequired
+		return License{}, ErrFleetLicenseRequired
 	}
 	pubKey := EmbeddedPublicKey()
 	if pubKey == nil {
@@ -65,18 +80,33 @@ func RequireFleet(licenseKey, publicKeyHex string) error {
 		}
 	}
 	if pubKey == nil {
-		return fmt.Errorf("%w: no verifier public key available "+
+		return License{}, fmt.Errorf("%w: no verifier public key available "+
 			"(build-embedded key missing and PIPELOCK_LICENSE_PUBLIC_KEY unset)",
 			ErrFleetLicenseRequired)
 	}
-	lic, err := Verify(licenseKey, pubKey)
+	if crlFile == "" {
+		crlFile = os.Getenv(EnvLicenseCRLFile)
+	}
+	var (
+		lic License
+		err error
+	)
+	if crlFile != "" {
+		crl, crlErr := LoadAndVerifyCRL(crlFile, pubKey, time.Now())
+		if crlErr != nil {
+			return License{}, fmt.Errorf("%w: loading license CRL: %w", ErrFleetLicenseRequired, crlErr)
+		}
+		lic, err = VerifyWithCRL(licenseKey, pubKey, &crl)
+	} else {
+		lic, err = Verify(licenseKey, pubKey)
+	}
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrFleetLicenseRequired, err)
+		return License{}, fmt.Errorf("%w: %w", ErrFleetLicenseRequired, err)
 	}
 	if !lic.HasFeature(FeatureFleet) {
-		return fmt.Errorf("%w: license %s does not include the fleet feature "+
+		return License{}, fmt.Errorf("%w: license %s does not include the fleet feature "+
 			"(present features: %v)",
 			ErrFleetLicenseRequired, lic.ID, lic.Features)
 	}
-	return nil
+	return lic, nil
 }

--- a/internal/license/fleet_gate_test.go
+++ b/internal/license/fleet_gate_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func mustIssue(t *testing.T, priv ed25519.PrivateKey, features []string) string {
+	t.Helper()
+	tok, err := Issue(License{
+		ID:        "test-license",
+		Email:     "test@example.com",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		Features:  features,
+	}, priv)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	return tok
+}
+
+func newKeyPair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return pub, priv
+}
+
+func TestRequireFleet_NoLicenseFailsClosed(t *testing.T) {
+	t.Setenv(EnvLicenseKey, "")
+	t.Setenv(EnvLicensePublicKey, "")
+	err := RequireFleet("", "")
+	if !errors.Is(err, ErrFleetLicenseRequired) {
+		t.Fatalf("RequireFleet with no license: want ErrFleetLicenseRequired, got %v", err)
+	}
+}
+
+func TestRequireFleet_AgentsOnlyLicenseRejected(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	tok := mustIssue(t, priv, []string{FeatureAgents}) // Pro tier — no fleet
+	err := RequireFleet(tok, hex.EncodeToString(pub))
+	if !errors.Is(err, ErrFleetLicenseRequired) {
+		t.Fatalf("RequireFleet with Pro license: want ErrFleetLicenseRequired, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "does not include the fleet feature") {
+		t.Errorf("error should explain missing feature; got %v", err)
+	}
+}
+
+func TestRequireFleet_FleetFeatureAccepted(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	tok := mustIssue(t, priv, []string{FeatureAgents, FeatureFleet}) // Enterprise
+	if err := RequireFleet(tok, hex.EncodeToString(pub)); err != nil {
+		t.Fatalf("RequireFleet with Enterprise license: want nil, got %v", err)
+	}
+}
+
+func TestRequireFleet_AssessOnlyLicenseRejected(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	tok := mustIssue(t, priv, []string{FeatureAssess}) // Assess product — not fleet
+	err := RequireFleet(tok, hex.EncodeToString(pub))
+	if !errors.Is(err, ErrFleetLicenseRequired) {
+		t.Fatalf("RequireFleet with Assess license: want ErrFleetLicenseRequired, got %v", err)
+	}
+}
+
+func TestRequireFleet_ExpiredLicenseRejected(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	expired, err := Issue(License{
+		ID:        "expired",
+		Email:     "test@example.com",
+		IssuedAt:  time.Now().Add(-2 * time.Hour).Unix(),
+		ExpiresAt: time.Now().Add(-time.Hour).Unix(),
+		Features:  []string{FeatureAgents, FeatureFleet},
+	}, priv)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	gotErr := RequireFleet(expired, hex.EncodeToString(pub))
+	if !errors.Is(gotErr, ErrFleetLicenseRequired) {
+		t.Fatalf("expired fleet license: want ErrFleetLicenseRequired, got %v", gotErr)
+	}
+}
+
+func TestRequireFleet_MissingPublicKeyFailsClosed(t *testing.T) {
+	_, priv := newKeyPair(t)
+	tok := mustIssue(t, priv, []string{FeatureFleet})
+	// EmbeddedPublicKey() returns nil in dev builds; with no env override
+	// and no caller-supplied key, fail closed.
+	t.Setenv(EnvLicensePublicKey, "")
+	err := RequireFleet(tok, "")
+	if !errors.Is(err, ErrFleetLicenseRequired) {
+		t.Fatalf("missing pubkey: want ErrFleetLicenseRequired, got %v", err)
+	}
+}
+
+func TestRequireFleet_ReadsLicenseFromEnv(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	tok := mustIssue(t, priv, []string{FeatureFleet})
+	t.Setenv(EnvLicenseKey, tok)
+	t.Setenv(EnvLicensePublicKey, hex.EncodeToString(pub))
+	if err := RequireFleet("", ""); err != nil {
+		t.Fatalf("env-supplied fleet license: want nil, got %v", err)
+	}
+}
+
+func TestRequireFleet_InvalidSignatureRejected(t *testing.T) {
+	pub1, _ := newKeyPair(t)
+	_, priv2 := newKeyPair(t)
+	tok := mustIssue(t, priv2, []string{FeatureFleet}) // signed by key 2
+	// Verify with key 1 -> signature mismatch.
+	err := RequireFleet(tok, hex.EncodeToString(pub1))
+	if !errors.Is(err, ErrFleetLicenseRequired) {
+		t.Fatalf("wrong-key signature: want ErrFleetLicenseRequired, got %v", err)
+	}
+}

--- a/internal/license/fleet_gate_test.go
+++ b/internal/license/fleet_gate_test.go
@@ -7,16 +7,19 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
 
-func mustIssue(t *testing.T, priv ed25519.PrivateKey, features []string) string {
+func mustIssue(t *testing.T, priv ed25519.PrivateKey, id string, features []string) string {
 	t.Helper()
 	tok, err := Issue(License{
-		ID:        "test-license",
+		ID:        id,
 		Email:     "test@example.com",
 		IssuedAt:  time.Now().Unix(),
 		ExpiresAt: time.Now().Add(time.Hour).Unix(),
@@ -37,9 +40,24 @@ func newKeyPair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
 	return pub, priv
 }
 
+func writeTestCRLFile(t *testing.T, priv ed25519.PrivateKey, revokedID string) string {
+	t.Helper()
+	crl := testCRL(t, priv, time.Now().UTC(), revokedID)
+	data, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatalf("Marshal CRL: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "license.crl.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile(CRL): %v", err)
+	}
+	return path
+}
+
 func TestRequireFleet_NoLicenseFailsClosed(t *testing.T) {
 	t.Setenv(EnvLicenseKey, "")
 	t.Setenv(EnvLicensePublicKey, "")
+	t.Setenv(EnvLicenseCRLFile, "")
 	err := RequireFleet("", "")
 	if !errors.Is(err, ErrFleetLicenseRequired) {
 		t.Fatalf("RequireFleet with no license: want ErrFleetLicenseRequired, got %v", err)
@@ -48,7 +66,7 @@ func TestRequireFleet_NoLicenseFailsClosed(t *testing.T) {
 
 func TestRequireFleet_AgentsOnlyLicenseRejected(t *testing.T) {
 	pub, priv := newKeyPair(t)
-	tok := mustIssue(t, priv, []string{FeatureAgents}) // Pro tier — no fleet
+	tok := mustIssue(t, priv, "test-license", []string{FeatureAgents}) // Pro tier — no fleet
 	err := RequireFleet(tok, hex.EncodeToString(pub))
 	if !errors.Is(err, ErrFleetLicenseRequired) {
 		t.Fatalf("RequireFleet with Pro license: want ErrFleetLicenseRequired, got %v", err)
@@ -60,7 +78,7 @@ func TestRequireFleet_AgentsOnlyLicenseRejected(t *testing.T) {
 
 func TestRequireFleet_FleetFeatureAccepted(t *testing.T) {
 	pub, priv := newKeyPair(t)
-	tok := mustIssue(t, priv, []string{FeatureAgents, FeatureFleet}) // Enterprise
+	tok := mustIssue(t, priv, "test-license", []string{FeatureAgents, FeatureFleet}) // Enterprise
 	if err := RequireFleet(tok, hex.EncodeToString(pub)); err != nil {
 		t.Fatalf("RequireFleet with Enterprise license: want nil, got %v", err)
 	}
@@ -68,7 +86,7 @@ func TestRequireFleet_FleetFeatureAccepted(t *testing.T) {
 
 func TestRequireFleet_AssessOnlyLicenseRejected(t *testing.T) {
 	pub, priv := newKeyPair(t)
-	tok := mustIssue(t, priv, []string{FeatureAssess}) // Assess product — not fleet
+	tok := mustIssue(t, priv, "test-license", []string{FeatureAssess}) // Assess product — not fleet
 	err := RequireFleet(tok, hex.EncodeToString(pub))
 	if !errors.Is(err, ErrFleetLicenseRequired) {
 		t.Fatalf("RequireFleet with Assess license: want ErrFleetLicenseRequired, got %v", err)
@@ -95,7 +113,7 @@ func TestRequireFleet_ExpiredLicenseRejected(t *testing.T) {
 
 func TestRequireFleet_MissingPublicKeyFailsClosed(t *testing.T) {
 	_, priv := newKeyPair(t)
-	tok := mustIssue(t, priv, []string{FeatureFleet})
+	tok := mustIssue(t, priv, "test-license", []string{FeatureFleet})
 	// EmbeddedPublicKey() returns nil in dev builds; with no env override
 	// and no caller-supplied key, fail closed.
 	t.Setenv(EnvLicensePublicKey, "")
@@ -107,9 +125,10 @@ func TestRequireFleet_MissingPublicKeyFailsClosed(t *testing.T) {
 
 func TestRequireFleet_ReadsLicenseFromEnv(t *testing.T) {
 	pub, priv := newKeyPair(t)
-	tok := mustIssue(t, priv, []string{FeatureFleet})
+	tok := mustIssue(t, priv, "test-license", []string{FeatureFleet})
 	t.Setenv(EnvLicenseKey, tok)
 	t.Setenv(EnvLicensePublicKey, hex.EncodeToString(pub))
+	t.Setenv(EnvLicenseCRLFile, "")
 	if err := RequireFleet("", ""); err != nil {
 		t.Fatalf("env-supplied fleet license: want nil, got %v", err)
 	}
@@ -118,10 +137,49 @@ func TestRequireFleet_ReadsLicenseFromEnv(t *testing.T) {
 func TestRequireFleet_InvalidSignatureRejected(t *testing.T) {
 	pub1, _ := newKeyPair(t)
 	_, priv2 := newKeyPair(t)
-	tok := mustIssue(t, priv2, []string{FeatureFleet}) // signed by key 2
+	tok := mustIssue(t, priv2, "test-license", []string{FeatureFleet}) // signed by key 2
 	// Verify with key 1 -> signature mismatch.
 	err := RequireFleet(tok, hex.EncodeToString(pub1))
 	if !errors.Is(err, ErrFleetLicenseRequired) {
 		t.Fatalf("wrong-key signature: want ErrFleetLicenseRequired, got %v", err)
+	}
+}
+
+func TestVerifyFleet_CRLRejectsRevokedFleetLicense(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	tok := mustIssue(t, priv, "lic_revoked", []string{FeatureAgents, FeatureFleet})
+	crlFile := writeTestCRLFile(t, priv, "lic_revoked")
+
+	_, err := VerifyFleet(tok, hex.EncodeToString(pub), crlFile)
+	if !errors.Is(err, ErrFleetLicenseRequired) {
+		t.Fatalf("revoked fleet license: want ErrFleetLicenseRequired, got %v", err)
+	}
+	if !errors.Is(err, ErrLicenseRevoked) {
+		t.Fatalf("revoked fleet license: want ErrLicenseRevoked in chain, got %v", err)
+	}
+}
+
+func TestVerifyFleet_CRLAllowsUnrevokedFleetLicense(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	tok := mustIssue(t, priv, "lic_active", []string{FeatureAgents, FeatureFleet})
+	crlFile := writeTestCRLFile(t, priv, "lic_other")
+
+	got, err := VerifyFleet(tok, hex.EncodeToString(pub), crlFile)
+	if err != nil {
+		t.Fatalf("unrevoked fleet license with CRL: %v", err)
+	}
+	if got.ID != "lic_active" {
+		t.Fatalf("license ID = %q, want lic_active", got.ID)
+	}
+}
+
+func TestVerifyFleet_ReadsCRLFromEnv(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	tok := mustIssue(t, priv, "lic_revoked", []string{FeatureAgents, FeatureFleet})
+	t.Setenv(EnvLicenseCRLFile, writeTestCRLFile(t, priv, "lic_revoked"))
+
+	_, err := VerifyFleet(tok, hex.EncodeToString(pub), "")
+	if !errors.Is(err, ErrLicenseRevoked) {
+		t.Fatalf("env CRL revoked fleet license: want ErrLicenseRevoked, got %v", err)
 	}
 }

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -31,6 +31,12 @@ var ErrLicenseExpired = errors.New("license expired")
 const (
 	FeatureAgents = "agents"
 	FeatureAssess = "assess"
+	// FeatureFleet gates Pipelock's fleet control plane (the conductor
+	// subsystem and the standalone audit sink). Conductor coordinates policy
+	// distribution and signed audit ingest across multiple Pipelock instances —
+	// central governance — which is the Enterprise tier per the
+	// "sell coordination, not detection" doctrine.
+	FeatureFleet = "fleet"
 )
 
 // License represents the claims in a signed license token.


### PR DESCRIPTION
Adds a new `fleet` license feature flag. The fleet control plane (`pipelock conductor serve`, `pipelock fleet-sink`, and the follower-side conductor runtime activated by `conductor.enabled`) now requires this feature in the license token.

- New `license.FeatureFleet` constant.
- `tierToFeatures()` grants `fleet` to the Enterprise tier. Pro, founding, trial, and Assess slices are unchanged.
- New `license.RequireFleet` and `license.VerifyFleet` helpers (same shape as the existing assess gate). License resolves from the caller argument, then `PIPELOCK_LICENSE_KEY`. CRL is opt-in via a new `--license-crl-file` flag on both standalone commands (with `PIPELOCK_LICENSE_CRL_FILE` env fallback); the follower runtime threads `cfg.LicenseCRLFile`.
- Gates fire fail-closed at command and runtime startup. Reload cannot activate `conductor.enabled` after startup (existing restart-only behavior, now locked by a regression test).

## Tests

- 8 unit tests covering the no-license, wrong-tier, expired, wrong-key, env-supplied, and missing-pubkey matrix.
- Integration tests for: revoked-license rejected, `conductor serve` fails closed without license, `fleet-sink` fails closed without license, reload does not activate Conductor wiring.

## Helm

Chart copy clarified: the admin API used by `pipelock adaptive` and `pipelock session` is an operational control, not part of the license gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enterprise tier now includes Fleet entitlement alongside Pro agents.

* **Changes**
  * Conductor and Fleet-sink startup now enforce a fail-closed Fleet license check; services will refuse to start without valid Fleet credentials or if revoked.

* **Documentation**
  * Charts and example values updated to clarify license mounting, admin API, Sentry wiring, and per-agent profile usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/pipelock/pull/636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->