### PR TITLE
fix: don't honor ambient HTTP_PROXY on upstream egress transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Conductor remains an enterprise preview in v2.6, not a GA feature. User-facing C
 
 ### Fixed
 
+- **Configured-upstream egress no longer honors an ambient `HTTP_PROXY`/`HTTPS_PROXY`.** The reverse-proxy, MCP HTTP client (`--upstream`), and MCP HTTP listener (`--mcp-listen`) transports were cloned from `http.DefaultTransport`, inheriting `Proxy: http.ProxyFromEnvironment`, so an environment proxy variable could silently redirect Pipelock's own egress to its configured upstream and route around the SSRF-safe dialer (reverse proxy) and the redirect-disabled SSRF posture (MCP HTTP). All three now dial the configured upstream directly with a nil `Proxy`, matching the forward, fetch, and TLS-interception transports. (#645)
 - **`pipelock hermes --mode full`** now loads, enables, and blocks under a real Hermes runtime. (#629)
 - **MCP HTTP listener strips inbound `com.pipelock/mediation`** metadata, closing the stdio-vs-HTTP parity gap so a forged mediation envelope cannot be laundered in on the HTTP listener path. (#601)
 - **`file_sentry` surfaces oversized / unreadable file skips instead of dropping them silently, and the size cap is now configurable.** A watched file larger than the scan cap (or one that fails to stat/read) was silently left uninspected, so an operator had no signal that content went unscanned. Skips now report through the watcher's error callback, and a new `file_sentry.max_file_bytes` knob overrides the built-in 10 MiB default (0 = default; negative rejected at validation).

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -25,6 +25,27 @@ import (
 	session "github.com/luckyPipewrench/pipelock/internal/session"
 )
 
+// newReverseUpstreamTransport builds the HTTP transport the MCP HTTP listener
+// uses to reach its configured upstream. It clones http.DefaultTransport for
+// sane pool/timeout defaults, then sets two invariants:
+//
+//   - DisableCompression: true so the upstream's Content-Encoding survives
+//     transparent-decompression stripping. The listener forwards bodies to the
+//     scanner, and a gzip'd upstream response would otherwise reach the
+//     scanner's compressed-content guard with the encoding header already
+//     removed (same root cause as the forward and reverse transport fixes).
+//   - Proxy: nil so an ambient HTTP_PROXY/HTTPS_PROXY cannot silently redirect
+//     egress to the configured upstream and route around the redirect-disabled
+//     SSRF posture at the call site. Matches the parity of the forward,
+//     reverse, and TLS-intercept transports, which all dial the configured
+//     upstream directly with a nil Proxy.
+func newReverseUpstreamTransport() *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.DisableCompression = true
+	t.Proxy = nil
+	return t
+}
+
 // RunHTTPListenerProxy starts an HTTP server that reverse-proxies MCP requests
 // to an upstream server with bidirectional scanning. Each inbound POST is
 // independently scanned and forwarded. Mcp-Session-Id and Authorization headers
@@ -161,18 +182,9 @@ func RunHTTPListenerProxy(
 	// CheckRedirect closure so signed envelopes do not flow with
 	// stale @target-uri / ph / hop values. The same applies to
 	// internal/mcp/transport/httpclient.go:45.
-	// Clone http.DefaultTransport with DisableCompression: true so the
-	// upstream's Content-Encoding survives transparent-decompression
-	// stripping. The MCP HTTP listener forwards bodies to the scanner,
-	// and a gzip'd upstream response would otherwise reach the
-	// scanner's compressed-content guard with the encoding header
-	// already removed. This has the same root cause as the forward
-	// and reverse transport fixes.
-	upstreamTransport := http.DefaultTransport.(*http.Transport).Clone()
-	upstreamTransport.DisableCompression = true
 	upstreamClient := &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: upstreamTransport,
+		Transport: newReverseUpstreamTransport(),
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
 		},

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -5714,6 +5714,23 @@ func TestHTTPListener_AuthWarnPreservesListenerWarnMetadata(t *testing.T) {
 	}
 }
 
+// TestNewReverseUpstreamTransport_IgnoresAmbientProxyEnv locks the two
+// invariants of the MCP HTTP listener's upstream transport: Proxy must be nil
+// so an ambient HTTP_PROXY/HTTPS_PROXY cannot silently redirect egress to the
+// configured upstream and route around the redirect-disabled SSRF posture, and
+// DisableCompression must stay set so the compressed-stream guard cannot
+// regress. Matches the parity of the forward, reverse, and TLS-intercept
+// transports.
+func TestNewReverseUpstreamTransport_IgnoresAmbientProxyEnv(t *testing.T) {
+	tr := newReverseUpstreamTransport()
+	if tr.Proxy != nil {
+		t.Error("reverse upstream transport Proxy must be nil (no ambient HTTP_PROXY chaining)")
+	}
+	if !tr.DisableCompression {
+		t.Error("DisableCompression must stay set (compressed-stream guard)")
+	}
+}
+
 // TestHTTPListener_CompressedUpstreamResponseBlocked locks down the MCP HTTP
 // listener path. The listener's upstreamClient sets
 // DisableCompression: true (proxy_http.go:1057) so the upstream

--- a/internal/mcp/transport/httpclient.go
+++ b/internal/mcp/transport/httpclient.go
@@ -68,6 +68,14 @@ func NewHTTPClient(url string, headers http.Header) *HTTPClient {
 	// same root cause as the forward and reverse transport fixes.
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.DisableCompression = true
+	// Clone() inherits Proxy: http.ProxyFromEnvironment, which would let an
+	// ambient HTTP_PROXY/HTTPS_PROXY silently redirect this client's egress to
+	// the configured MCP upstream. The upstream URL is validated at the CLI
+	// layer and redirects are disabled below for the same SSRF reason; honoring
+	// an env proxy would route around both. Match the parity of the forward,
+	// reverse, and TLS-intercept transports, which all dial the configured
+	// upstream directly with a nil Proxy.
+	transport.Proxy = nil
 	return &HTTPClient{
 		url:     url,
 		headers: headers.Clone(),

--- a/internal/mcp/transport/httpclient_test.go
+++ b/internal/mcp/transport/httpclient_test.go
@@ -279,6 +279,25 @@ func TestHTTPClient_HeaderImmutability(t *testing.T) {
 	}
 }
 
+// TestNewHTTPClient_IgnoresAmbientProxyEnv locks the transport invariant that
+// the MCP HTTP client dials its configured upstream directly: a nil Proxy so an
+// ambient HTTP_PROXY/HTTPS_PROXY cannot silently redirect egress around the
+// CLI-validated upstream and the redirect-disabled SSRF posture. Also asserts
+// DisableCompression stays set so the compressed-stream guard cannot regress.
+func TestNewHTTPClient_IgnoresAmbientProxyEnv(t *testing.T) {
+	c := NewHTTPClient("https://upstream.example/mcp", nil)
+	tr, ok := c.client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", c.client.Transport)
+	}
+	if tr.Proxy != nil {
+		t.Error("HTTP client transport Proxy must be nil (no ambient HTTP_PROXY chaining)")
+	}
+	if !tr.DisableCompression {
+		t.Error("DisableCompression must stay set (compressed-stream guard)")
+	}
+}
+
 func TestHTTPClient_ExtraHeadersCannotOverrideTransport(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Extra headers should NOT override Content-Type or Accept.

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -164,6 +164,15 @@ func (rp *ReverseProxyHandler) SetSafeDialer(dial func(ctx context.Context, netw
 func newReverseProxyTransport(rp *ReverseProxyHandler, dial func(ctx context.Context, network, addr string) (net.Conn, error)) http.RoundTripper {
 	base := http.DefaultTransport.(*http.Transport).Clone()
 	base.DisableCompression = true
+	// Clone() inherits Proxy: http.ProxyFromEnvironment from
+	// http.DefaultTransport, which would let an ambient HTTP_PROXY /
+	// HTTPS_PROXY silently redirect pipelock's own upstream egress. Every
+	// other egress transport (fetch proxy.go, intercept.go,
+	// newTLSInterceptTransport) builds a fresh http.Transport with a nil
+	// Proxy and dials the configured upstream directly. Match that parity
+	// here so reverse-proxy egress is not env-steerable and always traverses
+	// the SSRF-safe dialer below.
+	base.Proxy = nil
 	if dial != nil {
 		base.DialContext = dial
 	}

--- a/internal/proxy/reverse_submit_dialer_test.go
+++ b/internal/proxy/reverse_submit_dialer_test.go
@@ -180,6 +180,35 @@ func TestProxy_SafeDialerBlocksInternalIP(t *testing.T) {
 	}
 }
 
+// TestReverseProxyTransport_IgnoresAmbientProxyEnv locks the transport-parity
+// invariant: the reverse-proxy base transport must not honor an ambient
+// HTTP_PROXY/HTTPS_PROXY. The base is cloned from http.DefaultTransport for
+// sane pool/timeout defaults, which would otherwise inherit
+// Proxy: http.ProxyFromEnvironment and let an env var silently redirect
+// pipelock's own upstream egress (and make submit-profile tests fail in a
+// pipelock-proxied shell). Fetch, intercept, and TLS transports all build a
+// fresh transport with a nil Proxy; this asserts the reverse proxy matches.
+func TestReverseProxyTransport_IgnoresAmbientProxyEnv(t *testing.T) {
+	dialers := []func(context.Context, string, string) (net.Conn, error){
+		nil,
+		func(context.Context, string, string) (net.Conn, error) { return nil, nil },
+	}
+	for _, dial := range dialers {
+		rt := newReverseProxyTransport(nil, dial)
+		srt, ok := rt.(*reverseSigningRoundTripper)
+		if !ok {
+			t.Fatalf("transport type = %T, want *reverseSigningRoundTripper", rt)
+		}
+		base, ok := srt.base.(*http.Transport)
+		if !ok {
+			t.Fatalf("base type = %T, want *http.Transport", srt.base)
+		}
+		if base.Proxy != nil {
+			t.Error("reverse-proxy base transport Proxy must be nil (no ambient HTTP_PROXY chaining)")
+		}
+	}
+}
+
 func submitProfileHostOverrideURL(t *testing.T, upstreamURL, host string) string {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

pipelock's reverse-proxy, MCP HTTP client, and MCP HTTP listener transports were cloned from `http.DefaultTransport`, inheriting `Proxy: http.ProxyFromEnvironment`. An ambient `HTTP_PROXY`/`HTTPS_PROXY` could therefore silently redirect pipelock's own egress to its configured upstream, bypassing the SSRF-safe dialer (reverse proxy) and the redirect-disabled SSRF posture (MCP HTTP upstream). The forward, fetch, and TLS-intercept transports already build a fresh transport with a nil `Proxy` and dial the configured upstream directly, so this brings the remaining three to parity.

## Changes

- `internal/proxy/reverse.go`: `base.Proxy = nil` in `newReverseProxyTransport`
- `internal/mcp/transport/httpclient.go`: `transport.Proxy = nil` in `NewHTTPClient`
- `internal/mcp/mcp_http_reverse.go`: extract `newReverseUpstreamTransport` (nil `Proxy` plus `DisableCompression`)
- Regression tests locking `Proxy == nil` on all three (and `DisableCompression` on the MCP transports)

## Behavior change

In `--upstream` / `--mcp-listen` modes the MCP HTTP path now connects to the configured upstream directly instead of chaining through an ambient `HTTP_PROXY`/`HTTPS_PROXY`. MCP input/response/tool scanning is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed upstream/reverse-proxy and MCP client requests inheriting ambient proxy environment variables so they now ignore HTTP_PROXY/HTTPS_PROXY and use configured egress paths.

* **Tests**
  * Added tests verifying HTTP clients and reverse-proxy transports ignore ambient proxy settings and preserve compression behavior.

* **Documentation**
  * Updated changelog to document the proxy-handling fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->