### PR TITLE
helm: add enterprise deployment modes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,6 +170,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Helm
+        uses: Azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+          version: v3.20.0
+
       - name: Verify Helm chart
         run: bash scripts/check-helm-chart.sh
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,6 +161,18 @@ jobs:
       - name: Python pin policy
         run: bash scripts/check-python-pins.sh
 
+  helm:
+    needs: [security-scan]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Verify Helm chart
+        run: bash scripts/check-helm-chart.sh
+
   govulncheck:
     needs: [security-scan]
     runs-on: ubuntu-latest
@@ -188,7 +200,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [security-scan, test, lint]
+    needs: [security-scan, test, lint, helm]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/charts/pipelock/Chart.yaml
+++ b/charts/pipelock/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pipelock
 description: Agent firewall for AI agents. Network scanning, process containment, and tool policy enforcement.
 type: application
-version: 0.3.0
-appVersion: "2.6.0"
+version: 0.4.0
+appVersion: "2.7.0"
 home: https://pipelab.org
 sources:
   - https://github.com/luckyPipewrench/pipelock
@@ -20,6 +20,8 @@ keywords:
 icon: https://raw.githubusercontent.com/luckyPipewrench/pipelock/main/assets/pipelock-logo.svg
 annotations:
   artifacthub.io/license: Apache-2.0
+  artifacthub.io/containsSecurityUpdates: "false"
+  artifacthub.io/changesURL: https://github.com/luckyPipewrench/pipelock/releases
   artifacthub.io/links: |
     - name: Documentation
       url: https://pipelab.org/learn/
@@ -28,8 +30,14 @@ annotations:
     - name: Audit Packet verifier
       url: https://github.com/luckyPipewrench/pipelock-verify-python
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump default application version to v2.6.0 and let the chart follow .Chart.AppVersion unless image.digest is explicitly set.
+    - kind: added
+      description: Enterprise chart modes for Conductor, standalone fleet-sink, and Conductor follower wiring.
+    - kind: added
+      description: File-mounted Secret refs for Conductor publisher, auditor, admin, TLS, mTLS, trust roster, and license CRL inputs.
+    - kind: added
+      description: PersistentVolumeClaims for Conductor storage, fleet audit storage, follower bundle cache, and durable audit queue.
+    - kind: added
+      description: NetworkPolicy presets for dev, restricted, and airgapped deployments with explicit override hooks.
     - kind: added
       description: Health-watchdog-backed liveness and readiness probes with timeout and threshold tuning.
     - kind: added

--- a/charts/pipelock/README.md
+++ b/charts/pipelock/README.md
@@ -98,7 +98,7 @@ Enterprise server modes use the license Secret as `PIPELOCK_LICENSE_KEY` because
 |---|---|---|
 | `conductorFollower.conductorURL` | `""` | HTTPS URL of the Conductor follower API |
 | `conductorFollower.serverCASecretRef.name` | `""` | Existing Secret containing the Conductor server CA |
-| `conductorFollower.clientSecretRef.name` | `""` | Existing TLS Secret for follower mTLS client identity |
+| `conductorFollower.clientSecretRef.name` | `""` | Existing Kubernetes TLS Secret for follower mTLS client identity; must contain `tls.crt` and `tls.key`, mounted at `client_cert_path` and `client_key_path` |
 | `conductorFollower.trustRosterSecretRef.name` | `""` | Existing Secret containing the signed trust roster |
 | `conductorFollower.persistence.bundleCache.enabled` | `false` | PVC for signed policy bundle cache |
 | `conductorFollower.persistence.auditQueue.enabled` | `false` | PVC for durable audit queue |
@@ -108,6 +108,7 @@ Enterprise server modes use the license Secret as `PIPELOCK_LICENSE_KEY` because
 | Key | Default | Description |
 |---|---|---|
 | `fleetSink.service.port` | `8894` | Audit sink listener |
+| `fleetSink.service.probePort` | `9093` | Plain HTTP health probe listener |
 | `fleetSink.tls.serverSecretRef.name` | `""` | Existing TLS Secret with `tls.crt` and `tls.key` |
 | `fleetSink.tls.clientCASecretRef.name` | `""` | Existing Secret with follower client CA bundle |
 | `fleetSink.readerToken.secretRef.name` | `""` | Existing Secret for audit query reader token file |

--- a/charts/pipelock/README.md
+++ b/charts/pipelock/README.md
@@ -1,6 +1,6 @@
 # Pipelock Helm chart
 
-Pipelock is an agent firewall: a network proxy that sits between AI agents and the internet and scans every HTTP, WebSocket, and MCP message for credential leaks, prompt injection, SSRF, and tool poisoning. This chart deploys Pipelock as a Kubernetes Deployment with a Service, optional PodMonitor for Prometheus, optional NetworkPolicy, and optional PodDisruptionBudget.
+Pipelock is an agent firewall: a network proxy that sits between AI agents and the internet and scans every HTTP, WebSocket, and MCP message for credential leaks, prompt injection, SSRF, and tool poisoning. This chart deploys the proxy by default and also supports Enterprise Conductor, standalone fleet-sink, and Conductor follower topologies.
 
 ## TL;DR
 
@@ -9,6 +9,14 @@ helm install pipelock ./charts/pipelock
 ```
 
 Pipelock runs as a non-root container with a read-only root filesystem, drops all Linux capabilities, and binds the standard Pipelock proxy on port 8888.
+
+Enterprise examples:
+
+```bash
+helm install pipelock-conductor ./charts/pipelock -f charts/pipelock/examples/values-enterprise-conductor.yaml
+helm install pipelock-follower ./charts/pipelock -f charts/pipelock/examples/values-enterprise-follower.yaml
+helm install pipelock-fleet-sink ./charts/pipelock -f charts/pipelock/examples/values-enterprise-devfleet.yaml
+```
 
 ## Values
 
@@ -23,7 +31,7 @@ The chart is configured by passing values to `helm install -f values.yaml`. The 
 | `image.digest` | `""` | Optional multi-arch manifest digest. When set, the chart renders `repository@digest` for pinning |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
 
-> **Upgrading from chart 0.2.0:** the default `image.digest` was cleared, so the chart now follows `.Chart.AppVersion` (v2.6.0) by default instead of a pinned digest. Set `image.digest` explicitly in your values if you need an immutable image reference.
+> **Upgrading from chart 0.2.0:** the default `image.digest` was cleared, so the chart now follows `.Chart.AppVersion` by default instead of a pinned digest. Set `image.digest` explicitly in your values if you need an immutable image reference.
 
 ### Ports
 
@@ -33,6 +41,15 @@ The chart is configured by passing values to `helm install -f values.yaml`. The 
 | `service.mcpPort` | `8889` | MCP HTTP listener port. Only opened when `mcp.enabled=true` and `mcp.upstream` is set. |
 | `service.metricsPort` | `9091` | Prometheus metrics |
 | `service.adminPort` | `9090` | Authenticated admin API (`pipelock adaptive`, `pipelock session`). Only opened when `adminApi.enabled=true`. |
+
+### Deployment mode
+
+| Key | Default | Description |
+|---|---|---|
+| `mode` | `proxy` | Topology to render: `proxy`, `conductor`, or `fleetSink` |
+| `conductorFollower.enabled` | `false` | Enables follower-side Conductor polling/audit wiring while staying in `mode: proxy` |
+
+The default `proxy` mode runs `pipelock run`. `conductor` mode runs the verified Enterprise entrypoint `pipelock conductor serve` with separate follower mTLS and probe Services. `fleetSink` mode runs the standalone `pipelock fleet-sink` server; it is intentionally separate because the binary exposes independent listener, storage, auth, and mTLS flags.
 
 ### Health probes
 
@@ -59,6 +76,42 @@ Community installs do not need a license. Pro features (per-agent profiles, CIDR
 | `license.mountPath` | `/etc/pipelock/license` | Where the Secret is mounted in the pod |
 
 When enabled, the chart sets `PIPELOCK_LICENSE_KEY` from the same Secret and renders `license_file` to the mounted Secret path.
+
+Enterprise server modes use the license Secret as `PIPELOCK_LICENSE_KEY` because the current server commands do not accept a license-file flag. Conductor publisher, auditor, admin, reader, TLS, mTLS, trust roster, and CRL inputs are mounted as Secret files and never templated as plaintext values.
+
+### Enterprise Conductor
+
+| Key | Default | Description |
+|---|---|---|
+| `conductor.service.port` | `8895` | Follower mTLS API listener |
+| `conductor.service.probePort` | `9092` | Plain HTTP health/readiness/metrics probe listener |
+| `conductor.tls.serverSecretRef.name` | `""` | Existing TLS Secret with `tls.crt` and `tls.key` |
+| `conductor.tls.clientCASecretRef.name` | `""` | Existing Secret with the follower client CA bundle |
+| `conductor.tokens.publisher.secretRef.name` | `""` | Existing Secret for publisher bearer token file |
+| `conductor.tokens.auditor.secretRef.name` | `""` | Existing Secret for auditor bearer token file |
+| `conductor.tokens.admin.secretRef.name` | `""` | Existing Secret for admin bearer token file |
+| `conductor.persistence.size` | `20Gi` | PVC size for policy and audit state |
+
+### Enterprise follower
+
+| Key | Default | Description |
+|---|---|---|
+| `conductorFollower.conductorURL` | `""` | HTTPS URL of the Conductor follower API |
+| `conductorFollower.serverCASecretRef.name` | `""` | Existing Secret containing the Conductor server CA |
+| `conductorFollower.clientSecretRef.name` | `""` | Existing TLS Secret for follower mTLS client identity |
+| `conductorFollower.trustRosterSecretRef.name` | `""` | Existing Secret containing the signed trust roster |
+| `conductorFollower.persistence.bundleCache.enabled` | `false` | PVC for signed policy bundle cache |
+| `conductorFollower.persistence.auditQueue.enabled` | `false` | PVC for durable audit queue |
+
+### Fleet sink
+
+| Key | Default | Description |
+|---|---|---|
+| `fleetSink.service.port` | `8894` | Audit sink listener |
+| `fleetSink.tls.serverSecretRef.name` | `""` | Existing TLS Secret with `tls.crt` and `tls.key` |
+| `fleetSink.tls.clientCASecretRef.name` | `""` | Existing Secret with follower client CA bundle |
+| `fleetSink.readerToken.secretRef.name` | `""` | Existing Secret for audit query reader token file |
+| `fleetSink.persistence.size` | `20Gi` | PVC size for audit store |
 
 ### Sentry
 
@@ -91,6 +144,13 @@ When enabled, the chart sets `kill_switch.api_listen` in the generated pipelock.
 | Key | Default | Description |
 |---|---|---|
 | `networkPolicy.enabled` | `false` | Apply a default-deny NetworkPolicy with explicit egress for DNS, 80, and 443 |
+| `networkPolicy.preset` | `dev` | Preset: `dev`, `restricted`, or `airgapped` |
+| `networkPolicy.ingress` | `[]` | Full Kubernetes ingress rules override |
+| `networkPolicy.egress` | `[]` | Full Kubernetes egress rules override |
+
+Enterprise modes require `networkPolicy.enabled=true`. Use `networkPolicy.ingress` and `networkPolicy.egress` to name the allowed namespaces and pod selectors for followers, operators, DNS, KMS/HSM signing, and other deployment-local dependencies. The chart makes complete mediation deployable, but mediation completeness remains deployment-enforced: agents must not have a path around their local Pipelock follower.
+
+`podMonitor.enabled` is supported for proxy and Conductor modes. The standalone fleet-sink server exposes `/health` but not a Prometheus metrics endpoint, so the chart rejects `podMonitor.enabled=true` in `mode: fleetSink`.
 
 ### High availability
 
@@ -104,7 +164,7 @@ When enabled, the chart sets `kill_switch.api_listen` in the generated pipelock.
 
 ### Pipelock configuration
 
-The `.Values.pipelock` block is rendered into a ConfigMap as `pipelock.yaml` and mounted at `/etc/pipelock/pipelock.yaml`. Any v2.5 config section can be set under this key. See the [Pipelock learn guide](https://pipelab.org/learn/) for the full schema and [`values.yaml`](values.yaml) comments for common v2.5 sections.
+The `.Values.pipelock` block is rendered into a ConfigMap as `pipelock.yaml` and mounted at `/etc/pipelock/pipelock.yaml` in `mode: proxy`. Any supported config section can be set under this key. See the [Pipelock learn guide](https://pipelab.org/learn/) for the full schema and [`values.yaml`](values.yaml) comments for common sections.
 
 The chart automatically templates these into the config and they should not be set in `.Values.pipelock`:
 
@@ -120,6 +180,9 @@ See [`examples/`](examples/) for ready-to-use values configurations:
 - `values-pro.yaml` — Licensed per-agent profile example with optional admin API and Sentry Secret wiring
 - `values-mcp-sidecar.yaml` — MCP HTTP listener bridging to an upstream MCP server
 - `values-ha.yaml` — 3 replicas, PodDisruptionBudget, topology spread, NetworkPolicy
+- `values-enterprise-conductor.yaml` — Conductor control plane with separate follower and probe Services
+- `values-enterprise-follower.yaml` — Follower proxy with Conductor mTLS, trust roster, bundle cache, and durable audit queue
+- `values-enterprise-devfleet.yaml` — Standalone fleet-sink development deployment
 
 ## See also
 

--- a/charts/pipelock/examples/values-enterprise-conductor.yaml
+++ b/charts/pipelock/examples/values-enterprise-conductor.yaml
@@ -87,6 +87,9 @@ networkPolicy:
             matchLabels:
               pipelock.io/operator: "true"
       ports:
+        # Kubelet probe traffic is node-originated and may require CNI
+        # hostEndpoint or host-protection policy outside Kubernetes
+        # NetworkPolicy. This rule is for operator/Prometheus access.
         - port: 9092
           protocol: TCP
   egress:

--- a/charts/pipelock/examples/values-enterprise-conductor.yaml
+++ b/charts/pipelock/examples/values-enterprise-conductor.yaml
@@ -1,0 +1,114 @@
+# Enterprise Conductor control plane.
+#
+# The chart references existing Secrets only. Create TLS, token, license, CRL,
+# and trust-key Secrets out of band with your normal secret manager.
+
+mode: conductor
+
+license:
+  enabled: true
+  existingSecret: pipelock-enterprise-license
+  secretKey: license.token
+  crlSecretRef:
+    name: pipelock-license-crl
+    key: license.crl
+
+conductor:
+  conductorID: conductor-prod-1
+  followerTrustDomain: pipelock.local
+  service:
+    type: ClusterIP
+    port: 8895
+    probePort: 9092
+  tls:
+    serverSecretRef:
+      name: conductor-server-tls
+    clientCASecretRef:
+      name: conductor-follower-ca
+      key: ca.crt
+  tokens:
+    publisher:
+      secretRef:
+        name: conductor-publisher-token
+        key: token
+    auditor:
+      secretRef:
+        name: conductor-auditor-token
+        key: token
+    admin:
+      secretRef:
+        name: conductor-admin-token
+        key: token
+  trustedAuditKeys:
+    - id: audit-signer-prod
+      orgID: org-prod
+      fleetID: fleet-prod
+      instanceID: ""
+      secretRef:
+        name: conductor-audit-keys
+        key: audit-signer-prod.pub
+  trustedControlKeys:
+    - id: remote-kill-prod
+      purpose: remote-kill-signing
+      secretRef:
+        name: conductor-control-keys
+        key: remote-kill-prod.pub
+    - id: rollback-prod
+      purpose: policy-bundle-rollback
+      secretRef:
+        name: conductor-control-keys
+        key: rollback-prod.pub
+  persistence:
+    size: 50Gi
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+networkPolicy:
+  enabled: true
+  preset: restricted
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: pipelock-fleet
+          podSelector:
+            matchLabels:
+              pipelock.io/follower: "true"
+      ports:
+        - port: 8895
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: pipelock-ops
+          podSelector:
+            matchLabels:
+              pipelock.io/operator: "true"
+      ports:
+        - port: 9092
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: pipelock-kms
+          podSelector:
+            matchLabels:
+              pipelock.io/signing-service: "true"
+      ports:
+        - port: 443
+          protocol: TCP

--- a/charts/pipelock/examples/values-enterprise-devfleet.yaml
+++ b/charts/pipelock/examples/values-enterprise-devfleet.yaml
@@ -1,0 +1,78 @@
+# Single-cluster development fleet audit sink.
+#
+# Use this when testing Conductor audit ingestion separately from the full
+# control plane. Production installs should prefer the restricted Conductor and
+# follower examples with externally managed Secrets.
+
+mode: fleetSink
+
+license:
+  enabled: true
+  existingSecret: pipelock-enterprise-license
+  secretKey: license.token
+  crlSecretRef:
+    name: pipelock-license-crl
+    key: license.crl
+
+fleetSink:
+  service:
+    type: ClusterIP
+    port: 8894
+  tls:
+    serverSecretRef:
+      name: fleet-sink-server-tls
+    clientCASecretRef:
+      name: fleet-sink-follower-ca
+      key: ca.crt
+  readerToken:
+    secretRef:
+      name: fleet-sink-reader-token
+      key: token
+  trustedAuditKeys:
+    - id: audit-signer-dev
+      orgID: org-dev
+      fleetID: fleet-dev
+      instanceID: ""
+      secretRef:
+        name: fleet-sink-audit-keys
+        key: audit-signer-dev.pub
+  persistence:
+    size: 10Gi
+
+networkPolicy:
+  enabled: true
+  preset: dev
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: pipelock-dev
+          podSelector:
+            matchLabels:
+              pipelock.io/follower: "true"
+      ports:
+        - port: 8894
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: pipelock-dev
+          podSelector:
+            matchLabels:
+              pipelock.io/operator: "true"
+      ports:
+        - port: 8894
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP

--- a/charts/pipelock/examples/values-enterprise-devfleet.yaml
+++ b/charts/pipelock/examples/values-enterprise-devfleet.yaml
@@ -18,6 +18,7 @@ fleetSink:
   service:
     type: ClusterIP
     port: 8894
+    probePort: 9093
   tls:
     serverSecretRef:
       name: fleet-sink-server-tls
@@ -62,6 +63,11 @@ networkPolicy:
               pipelock.io/operator: "true"
       ports:
         - port: 8894
+          protocol: TCP
+        # Kubelet probe traffic is node-originated and may require CNI
+        # hostEndpoint or host-protection policy outside Kubernetes
+        # NetworkPolicy. This rule is for operator/Prometheus access.
+        - port: 9093
           protocol: TCP
   egress:
     - to:

--- a/charts/pipelock/examples/values-enterprise-follower.yaml
+++ b/charts/pipelock/examples/values-enterprise-follower.yaml
@@ -1,0 +1,111 @@
+# Enterprise follower deployment.
+#
+# This remains `mode: proxy`: the follower enforces locally and only uses
+# Conductor for signed bundle polling, remote kill state, and audit batching.
+
+mode: proxy
+replicaCount: 2
+
+license:
+  enabled: true
+  existingSecret: pipelock-enterprise-license
+  secretKey: license.token
+  crlSecretRef:
+    name: pipelock-license-crl
+    key: license.crl
+
+conductorFollower:
+  enabled: true
+  conductorURL: https://pipelock-conductor.pipelock-control.svc.cluster.local:8895
+  orgID: org-prod
+  fleetID: fleet-prod
+  instanceID: follower-a
+  trustRosterRootFingerprint: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  auditSigningKeyID: audit-signer-prod
+  recorderKeyID: recorder-prod
+  pollInterval: 30s
+  emergencyStream: true
+  honorRemoteKillSwitch: true
+  serverCASecretRef:
+    name: conductor-server-ca
+    key: ca.crt
+  clientSecretRef:
+    name: follower-client-tls
+  trustRosterSecretRef:
+    name: conductor-trust-roster
+    key: trust-roster.json
+  persistence:
+    bundleCache:
+      enabled: true
+      size: 2Gi
+    auditQueue:
+      enabled: true
+      size: 10Gi
+
+pipelock:
+  mode: strict
+  enforce: true
+  dlp:
+    include_defaults: true
+  response_scanning:
+    enabled: true
+    action: block
+  request_body_scanning:
+    enabled: true
+  flight_recorder:
+    enabled: true
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+networkPolicy:
+  enabled: true
+  preset: restricted
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: agent-workloads
+          podSelector:
+            matchLabels:
+              pipelock.io/agent-egress: "true"
+      ports:
+        - port: 8888
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: pipelock-ops
+          podSelector:
+            matchLabels:
+              pipelock.io/operator: "true"
+      ports:
+        - port: 9091
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: pipelock-control
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: conductor
+      ports:
+        - port: 8895
+          protocol: TCP
+    - ports:
+        - port: 443
+          protocol: TCP

--- a/charts/pipelock/examples/values-enterprise-follower.yaml
+++ b/charts/pipelock/examples/values-enterprise-follower.yaml
@@ -109,3 +109,5 @@ networkPolicy:
     - ports:
         - port: 443
           protocol: TCP
+        - port: 80
+          protocol: TCP

--- a/charts/pipelock/templates/NOTES.txt
+++ b/charts/pipelock/templates/NOTES.txt
@@ -1,5 +1,24 @@
 Pipelock {{ .Chart.AppVersion }} deployed as release {{ .Release.Name }}.
 
+{{- if eq (include "pipelock.mode" .) "conductor" }}
+Conductor follower mTLS endpoint:
+  kubectl port-forward svc/{{ include "pipelock.fullname" . }}-conductor {{ .Values.conductor.service.port }}:{{ .Values.conductor.service.port }}
+
+Conductor probe endpoint:
+  kubectl port-forward svc/{{ include "pipelock.fullname" . }}-conductor-probes {{ .Values.conductor.service.probePort }}:{{ .Values.conductor.service.probePort }}
+  curl http://127.0.0.1:{{ .Values.conductor.service.probePort }}/readyz
+
+This chart makes complete mediation deployable by wiring fleet control-plane
+storage, mTLS, and network boundaries. Mediation completeness is still
+deployment-enforced: agents must be prevented from bypassing their local
+Pipelock follower.
+{{- else if eq (include "pipelock.mode" .) "fleetSink" }}
+Fleet audit sink endpoint:
+  kubectl port-forward svc/{{ include "pipelock.fullname" . }}-fleet-sink {{ .Values.fleetSink.service.port }}:{{ .Values.fleetSink.service.port }}
+
+This mode runs the standalone `pipelock fleet-sink` server for signed audit
+batch ingest and query storage. It is not an inline enforcement dependency.
+{{- else }}
 Proxy endpoint:
   kubectl port-forward svc/{{ include "pipelock.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
 
@@ -36,6 +55,7 @@ Admin API (port {{ .Values.service.adminPort }}):
   # Read it locally and pass with --api-token, or export it as your env (see pipelock adaptive --help).
   pipelock adaptive status --api-url http://127.0.0.1:{{ .Values.service.adminPort }}
   pipelock session list   --api-url http://127.0.0.1:{{ .Values.service.adminPort }}
+{{- end }}
 {{- end }}
 
 {{- if and .Values.license.enabled (not .Values.license.existingSecret) }}

--- a/charts/pipelock/templates/NOTES.txt
+++ b/charts/pipelock/templates/NOTES.txt
@@ -16,6 +16,10 @@ Pipelock follower.
 Fleet audit sink endpoint:
   kubectl port-forward svc/{{ include "pipelock.fullname" . }}-fleet-sink {{ .Values.fleetSink.service.port }}:{{ .Values.fleetSink.service.port }}
 
+Fleet sink probe endpoint:
+  kubectl port-forward svc/{{ include "pipelock.fullname" . }}-fleet-sink-probes {{ .Values.fleetSink.service.probePort }}:{{ .Values.fleetSink.service.probePort }}
+  curl http://127.0.0.1:{{ .Values.fleetSink.service.probePort }}/health
+
 This mode runs the standalone `pipelock fleet-sink` server for signed audit
 batch ingest and query storage. It is not an inline enforcement dependency.
 {{- else }}

--- a/charts/pipelock/templates/_helpers.tpl
+++ b/charts/pipelock/templates/_helpers.tpl
@@ -58,3 +58,56 @@ Create the name of the service account to use.
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the chart deployment mode.
+*/}}
+{{- define "pipelock.mode" -}}
+{{- default "proxy" .Values.mode -}}
+{{- end }}
+
+{{/*
+Validate mode and security-critical enterprise chart requirements.
+*/}}
+{{- define "pipelock.validate" -}}
+{{- $mode := include "pipelock.mode" . -}}
+{{- $ingress := default list .Values.networkPolicy.ingress -}}
+{{- $egress := default list .Values.networkPolicy.egress -}}
+{{- if not (has $mode (list "proxy" "conductor" "fleetSink")) -}}
+{{- fail "mode must be one of proxy, conductor, or fleetSink" -}}
+{{- end -}}
+{{- if and (ne $mode "proxy") (not .Values.networkPolicy.enabled) -}}
+{{- fail "networkPolicy.enabled=true is required when mode is conductor or fleetSink" -}}
+{{- end -}}
+{{- if and (ne $mode "proxy") (ne (default "dev" .Values.networkPolicy.preset) "airgapped") (or (eq (len $ingress) 0) (eq (len $egress) 0)) -}}
+{{- fail "enterprise modes require explicit networkPolicy.ingress and networkPolicy.egress rules unless preset=airgapped" -}}
+{{- end -}}
+{{- if and (eq $mode "fleetSink") .Values.podMonitor.enabled -}}
+{{- fail "podMonitor.enabled is not supported in fleetSink mode because the standalone sink does not expose a Prometheus metrics endpoint" -}}
+{{- end -}}
+{{- if .Values.conductorFollower.enabled -}}
+{{- $_ := required "conductorFollower.conductorURL is required when conductorFollower.enabled=true" .Values.conductorFollower.conductorURL -}}
+{{- $_ := required "conductorFollower.serverCASecretRef.name is required when conductorFollower.enabled=true" .Values.conductorFollower.serverCASecretRef.name -}}
+{{- $_ := required "conductorFollower.clientSecretRef.name is required when conductorFollower.enabled=true" .Values.conductorFollower.clientSecretRef.name -}}
+{{- $_ := required "conductorFollower.trustRosterSecretRef.name is required when conductorFollower.enabled=true" .Values.conductorFollower.trustRosterSecretRef.name -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+PVC names.
+*/}}
+{{- define "pipelock.conductorStorageName" -}}
+{{- printf "%s-conductor-storage" (include "pipelock.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "pipelock.fleetSinkStorageName" -}}
+{{- printf "%s-fleet-sink-storage" (include "pipelock.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "pipelock.followerBundleCacheName" -}}
+{{- printf "%s-follower-bundles" (include "pipelock.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "pipelock.followerAuditQueueName" -}}
+{{- printf "%s-follower-audit-queue" (include "pipelock.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}

--- a/charts/pipelock/templates/_helpers.tpl
+++ b/charts/pipelock/templates/_helpers.tpl
@@ -85,6 +85,12 @@ Validate mode and security-critical enterprise chart requirements.
 {{- if and (eq $mode "fleetSink") .Values.podMonitor.enabled -}}
 {{- fail "podMonitor.enabled is not supported in fleetSink mode because the standalone sink does not expose a Prometheus metrics endpoint" -}}
 {{- end -}}
+{{- if and (eq $mode "conductor") .Values.conductor.persistence.enabled (gt (int .Values.conductor.replicaCount) 1) (has "ReadWriteOnce" (default list .Values.conductor.persistence.accessModes)) -}}
+{{- fail "conductor.replicaCount must be 1 when conductor.persistence.accessModes includes ReadWriteOnce" -}}
+{{- end -}}
+{{- if and (eq $mode "fleetSink") .Values.fleetSink.persistence.enabled (gt (int .Values.fleetSink.replicaCount) 1) (has "ReadWriteOnce" (default list .Values.fleetSink.persistence.accessModes)) -}}
+{{- fail "fleetSink.replicaCount must be 1 when fleetSink.persistence.accessModes includes ReadWriteOnce" -}}
+{{- end -}}
 {{- if .Values.conductorFollower.enabled -}}
 {{- $_ := required "conductorFollower.conductorURL is required when conductorFollower.enabled=true" .Values.conductorFollower.conductorURL -}}
 {{- $_ := required "conductorFollower.serverCASecretRef.name is required when conductorFollower.enabled=true" .Values.conductorFollower.serverCASecretRef.name -}}

--- a/charts/pipelock/templates/configmap.yaml
+++ b/charts/pipelock/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "pipelock.mode" .) "proxy" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,4 +17,30 @@ data:
     {{- if and .Values.license.enabled .Values.license.existingSecret }}
     {{- $_ := set $cfg "license_file" (printf "%s/%s" .Values.license.mountPath .Values.license.secretKey) }}
     {{- end }}
+    {{- if and .Values.license.crlSecretRef.name .Values.license.crlSecretRef.key }}
+    {{- $_ := set $cfg "license_crl_file" (printf "%s/%s" .Values.license.crlSecretRef.mountPath .Values.license.crlSecretRef.key) }}
+    {{- end }}
+    {{- if .Values.conductorFollower.enabled }}
+    {{- $conductor := merge (dict
+      "enabled" true
+      "conductor_url" .Values.conductorFollower.conductorURL
+      "org_id" .Values.conductorFollower.orgID
+      "fleet_id" .Values.conductorFollower.fleetID
+      "instance_id" .Values.conductorFollower.instanceID
+      "server_ca_file" (printf "%s/%s" .Values.conductorFollower.serverCASecretRef.mountPath .Values.conductorFollower.serverCASecretRef.key)
+      "client_cert_path" (printf "%s/tls.crt" .Values.conductorFollower.clientSecretRef.mountPath)
+      "client_key_path" (printf "%s/tls.key" .Values.conductorFollower.clientSecretRef.mountPath)
+      "trust_roster_path" (printf "%s/%s" .Values.conductorFollower.trustRosterSecretRef.mountPath .Values.conductorFollower.trustRosterSecretRef.key)
+      "bundle_cache_dir" .Values.conductorFollower.persistence.bundleCache.mountPath
+      "durable_audit_queue_dir" .Values.conductorFollower.persistence.auditQueue.mountPath
+      "trust_roster_root_fingerprint" .Values.conductorFollower.trustRosterRootFingerprint
+      "audit_signing_key_id" .Values.conductorFollower.auditSigningKeyID
+      "recorder_key_id" .Values.conductorFollower.recorderKeyID
+      "poll_interval" .Values.conductorFollower.pollInterval
+      "emergency_stream" .Values.conductorFollower.emergencyStream
+      "honor_remote_kill_switch" .Values.conductorFollower.honorRemoteKillSwitch
+    ) (default dict $cfg.conductor) }}
+    {{- $_ := set $cfg "conductor" $conductor }}
+    {{- end }}
     {{- toYaml $cfg | nindent 4 }}
+{{- end }}

--- a/charts/pipelock/templates/deployment-conductor.yaml
+++ b/charts/pipelock/templates/deployment-conductor.yaml
@@ -8,6 +8,8 @@ metadata:
     app.kubernetes.io/component: conductor
 spec:
   replicas: {{ .Values.conductor.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "pipelock.selectorLabels" . | nindent 6 }}

--- a/charts/pipelock/templates/deployment-conductor.yaml
+++ b/charts/pipelock/templates/deployment-conductor.yaml
@@ -1,0 +1,234 @@
+{{- if eq (include "pipelock.mode" .) "conductor" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pipelock.fullname" . }}-conductor
+  labels:
+    {{- include "pipelock.labels" . | nindent 4 }}
+    app.kubernetes.io/component: conductor
+spec:
+  replicas: {{ .Values.conductor.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "pipelock.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: conductor
+  template:
+    metadata:
+      labels:
+        {{- include "pipelock.labels" . | nindent 8 }}
+        app.kubernetes.io/component: conductor
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "pipelock.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: conductor
+          {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+          {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - conductor
+            - serve
+            - --listen
+            - {{ printf "0.0.0.0:%d" (int .Values.conductor.service.port) | quote }}
+            - --probe-listen
+            - {{ printf "0.0.0.0:%d" (int .Values.conductor.service.probePort) | quote }}
+            - --storage-dir
+            - {{ .Values.conductor.persistence.mountPath | quote }}
+            - --conductor-id
+            - {{ .Values.conductor.conductorID | quote }}
+            - --follower-trust-domain
+            - {{ .Values.conductor.followerTrustDomain | quote }}
+            - --tls-cert
+            - {{ printf "%s/tls.crt" .Values.conductor.tls.serverSecretRef.mountPath | quote }}
+            - --tls-key
+            - {{ printf "%s/tls.key" .Values.conductor.tls.serverSecretRef.mountPath | quote }}
+            - --client-ca
+            - {{ printf "%s/%s" .Values.conductor.tls.clientCASecretRef.mountPath .Values.conductor.tls.clientCASecretRef.key | quote }}
+            - --publisher-token-file
+            - {{ printf "%s/%s" .Values.conductor.tokens.publisher.mountPath .Values.conductor.tokens.publisher.secretRef.key | quote }}
+            - --auditor-token-file
+            - {{ printf "%s/%s" .Values.conductor.tokens.auditor.mountPath .Values.conductor.tokens.auditor.secretRef.key | quote }}
+            - --admin-token-file
+            - {{ printf "%s/%s" .Values.conductor.tokens.admin.mountPath .Values.conductor.tokens.admin.secretRef.key | quote }}
+            {{- if and .Values.license.crlSecretRef.name .Values.license.crlSecretRef.key }}
+            - --license-crl-file
+            - {{ printf "%s/%s" .Values.license.crlSecretRef.mountPath .Values.license.crlSecretRef.key | quote }}
+            {{- end }}
+            {{- range .Values.conductor.trustedAuditKeys }}
+            - --trusted-audit-key
+            - {{ printf "id=%s,file=/etc/pipelock/conductor/trust/audit/%s/%s,org=%s,fleet=%s,instance=%s" .id .id .secretRef.key .orgID .fleetID .instanceID | quote }}
+            {{- end }}
+            {{- range .Values.conductor.trustedControlKeys }}
+            - --trusted-control-key
+            - {{ printf "id=%s,purpose=%s,file=/etc/pipelock/conductor/trust/control/%s/%s" .id .purpose .id .secretRef.key | quote }}
+            {{- end }}
+          ports:
+            - name: follower
+              containerPort: {{ .Values.conductor.service.port }}
+              protocol: TCP
+            - name: probe
+              containerPort: {{ .Values.conductor.service.probePort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: probe
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: probe
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 2
+          {{- $hasLicense := and .Values.license.enabled .Values.license.existingSecret }}
+          {{- $hasLicensePub := and .Values.license.publicKeySecretRef.name .Values.license.publicKeySecretRef.key }}
+          {{- if or $hasLicense $hasLicensePub }}
+          env:
+            {{- if $hasLicense }}
+            - name: PIPELOCK_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.license.existingSecret | quote }}
+                  key: {{ .Values.license.secretKey | quote }}
+            {{- end }}
+            {{- if $hasLicensePub }}
+            - name: PIPELOCK_LICENSE_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.license.publicKeySecretRef.name | quote }}
+                  key: {{ .Values.license.publicKeySecretRef.key | quote }}
+            {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.conductor.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: conductor-storage
+              mountPath: {{ .Values.conductor.persistence.mountPath | quote }}
+            - name: conductor-server-tls
+              mountPath: {{ .Values.conductor.tls.serverSecretRef.mountPath | quote }}
+              readOnly: true
+            - name: conductor-client-ca
+              mountPath: {{ .Values.conductor.tls.clientCASecretRef.mountPath | quote }}
+              readOnly: true
+            - name: conductor-publisher-token
+              mountPath: {{ .Values.conductor.tokens.publisher.mountPath | quote }}
+              readOnly: true
+            - name: conductor-auditor-token
+              mountPath: {{ .Values.conductor.tokens.auditor.mountPath | quote }}
+              readOnly: true
+            - name: conductor-admin-token
+              mountPath: {{ .Values.conductor.tokens.admin.mountPath | quote }}
+              readOnly: true
+            {{- if and .Values.license.crlSecretRef.name .Values.license.crlSecretRef.key }}
+            - name: license-crl
+              mountPath: {{ .Values.license.crlSecretRef.mountPath | quote }}
+              readOnly: true
+            {{- end }}
+            {{- range .Values.conductor.trustedAuditKeys }}
+            - name: conductor-trusted-audit-{{ .id }}
+              mountPath: {{ printf "/etc/pipelock/conductor/trust/audit/%s" .id | quote }}
+              readOnly: true
+            {{- end }}
+            {{- range .Values.conductor.trustedControlKeys }}
+            - name: conductor-trusted-control-{{ .id }}
+              mountPath: {{ printf "/etc/pipelock/conductor/trust/control/%s" .id | quote }}
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: conductor-storage
+          persistentVolumeClaim:
+            claimName: {{ include "pipelock.conductorStorageName" . }}
+        - name: conductor-server-tls
+          secret:
+            secretName: {{ required "conductor.tls.serverSecretRef.name is required in conductor mode" .Values.conductor.tls.serverSecretRef.name | quote }}
+            defaultMode: 0440
+        - name: conductor-client-ca
+          secret:
+            secretName: {{ required "conductor.tls.clientCASecretRef.name is required in conductor mode" .Values.conductor.tls.clientCASecretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ required "conductor.tls.clientCASecretRef.key is required in conductor mode" .Values.conductor.tls.clientCASecretRef.key | quote }}
+                path: {{ .Values.conductor.tls.clientCASecretRef.key | quote }}
+        - name: conductor-publisher-token
+          secret:
+            secretName: {{ required "conductor.tokens.publisher.secretRef.name is required in conductor mode" .Values.conductor.tokens.publisher.secretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ required "conductor.tokens.publisher.secretRef.key is required in conductor mode" .Values.conductor.tokens.publisher.secretRef.key | quote }}
+                path: {{ .Values.conductor.tokens.publisher.secretRef.key | quote }}
+        - name: conductor-auditor-token
+          secret:
+            secretName: {{ required "conductor.tokens.auditor.secretRef.name is required in conductor mode" .Values.conductor.tokens.auditor.secretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ required "conductor.tokens.auditor.secretRef.key is required in conductor mode" .Values.conductor.tokens.auditor.secretRef.key | quote }}
+                path: {{ .Values.conductor.tokens.auditor.secretRef.key | quote }}
+        - name: conductor-admin-token
+          secret:
+            secretName: {{ required "conductor.tokens.admin.secretRef.name is required in conductor mode" .Values.conductor.tokens.admin.secretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ required "conductor.tokens.admin.secretRef.key is required in conductor mode" .Values.conductor.tokens.admin.secretRef.key | quote }}
+                path: {{ .Values.conductor.tokens.admin.secretRef.key | quote }}
+        {{- if and .Values.license.crlSecretRef.name .Values.license.crlSecretRef.key }}
+        - name: license-crl
+          secret:
+            secretName: {{ .Values.license.crlSecretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ .Values.license.crlSecretRef.key | quote }}
+                path: {{ .Values.license.crlSecretRef.key | quote }}
+        {{- end }}
+        {{- range .Values.conductor.trustedAuditKeys }}
+        - name: conductor-trusted-audit-{{ .id }}
+          secret:
+            secretName: {{ required "conductor.trustedAuditKeys[].secretRef.name is required" .secretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ required "conductor.trustedAuditKeys[].secretRef.key is required" .secretRef.key | quote }}
+                path: {{ .secretRef.key | quote }}
+        {{- end }}
+        {{- range .Values.conductor.trustedControlKeys }}
+        - name: conductor-trusted-control-{{ .id }}
+          secret:
+            secretName: {{ required "conductor.trustedControlKeys[].secretRef.name is required" .secretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ required "conductor.trustedControlKeys[].secretRef.key is required" .secretRef.key | quote }}
+                path: {{ .secretRef.key | quote }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/pipelock/templates/deployment-fleetsink.yaml
+++ b/charts/pipelock/templates/deployment-fleetsink.yaml
@@ -1,0 +1,190 @@
+{{- if eq (include "pipelock.mode" .) "fleetSink" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pipelock.fullname" . }}-fleet-sink
+  labels:
+    {{- include "pipelock.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet-sink
+spec:
+  replicas: {{ .Values.fleetSink.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "pipelock.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: fleet-sink
+  template:
+    metadata:
+      labels:
+        {{- include "pipelock.labels" . | nindent 8 }}
+        app.kubernetes.io/component: fleet-sink
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "pipelock.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: fleet-sink
+          {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+          {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - fleet-sink
+            - --listen
+            - {{ printf "0.0.0.0:%d" (int .Values.fleetSink.service.port) | quote }}
+            - --storage-dir
+            - {{ .Values.fleetSink.persistence.mountPath | quote }}
+            - --tls-cert
+            - {{ printf "%s/tls.crt" .Values.fleetSink.tls.serverSecretRef.mountPath | quote }}
+            - --tls-key
+            - {{ printf "%s/tls.key" .Values.fleetSink.tls.serverSecretRef.mountPath | quote }}
+            - --client-ca
+            - {{ printf "%s/%s" .Values.fleetSink.tls.clientCASecretRef.mountPath .Values.fleetSink.tls.clientCASecretRef.key | quote }}
+            {{- if and .Values.fleetSink.readerToken.secretRef.name .Values.fleetSink.readerToken.secretRef.key }}
+            - --reader-token-file
+            - {{ printf "%s/%s" .Values.fleetSink.readerToken.mountPath .Values.fleetSink.readerToken.secretRef.key | quote }}
+            {{- end }}
+            {{- if and .Values.license.crlSecretRef.name .Values.license.crlSecretRef.key }}
+            - --license-crl-file
+            - {{ printf "%s/%s" .Values.license.crlSecretRef.mountPath .Values.license.crlSecretRef.key | quote }}
+            {{- end }}
+            {{- range .Values.fleetSink.trustedAuditKeys }}
+            - --trusted-audit-key
+            - {{ printf "id=%s,file=/etc/pipelock/fleet-sink/trust/audit/%s/%s,org=%s,fleet=%s,instance=%s" .id .id .secretRef.key .orgID .fleetID .instanceID | quote }}
+            {{- end }}
+          ports:
+            - name: https
+              containerPort: {{ .Values.fleetSink.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /health
+              port: https
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /health
+              port: https
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 2
+          {{- $hasLicense := and .Values.license.enabled .Values.license.existingSecret }}
+          {{- $hasLicensePub := and .Values.license.publicKeySecretRef.name .Values.license.publicKeySecretRef.key }}
+          {{- if or $hasLicense $hasLicensePub }}
+          env:
+            {{- if $hasLicense }}
+            - name: PIPELOCK_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.license.existingSecret | quote }}
+                  key: {{ .Values.license.secretKey | quote }}
+            {{- end }}
+            {{- if $hasLicensePub }}
+            - name: PIPELOCK_LICENSE_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.license.publicKeySecretRef.name | quote }}
+                  key: {{ .Values.license.publicKeySecretRef.key | quote }}
+            {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.fleetSink.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: fleet-sink-storage
+              mountPath: {{ .Values.fleetSink.persistence.mountPath | quote }}
+            - name: fleet-sink-server-tls
+              mountPath: {{ .Values.fleetSink.tls.serverSecretRef.mountPath | quote }}
+              readOnly: true
+            - name: fleet-sink-client-ca
+              mountPath: {{ .Values.fleetSink.tls.clientCASecretRef.mountPath | quote }}
+              readOnly: true
+            {{- if and .Values.fleetSink.readerToken.secretRef.name .Values.fleetSink.readerToken.secretRef.key }}
+            - name: fleet-sink-reader-token
+              mountPath: {{ .Values.fleetSink.readerToken.mountPath | quote }}
+              readOnly: true
+            {{- end }}
+            {{- if and .Values.license.crlSecretRef.name .Values.license.crlSecretRef.key }}
+            - name: license-crl
+              mountPath: {{ .Values.license.crlSecretRef.mountPath | quote }}
+              readOnly: true
+            {{- end }}
+            {{- range .Values.fleetSink.trustedAuditKeys }}
+            - name: fleet-sink-trusted-audit-{{ .id }}
+              mountPath: {{ printf "/etc/pipelock/fleet-sink/trust/audit/%s" .id | quote }}
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: fleet-sink-storage
+          persistentVolumeClaim:
+            claimName: {{ include "pipelock.fleetSinkStorageName" . }}
+        - name: fleet-sink-server-tls
+          secret:
+            secretName: {{ required "fleetSink.tls.serverSecretRef.name is required in fleetSink mode" .Values.fleetSink.tls.serverSecretRef.name | quote }}
+            defaultMode: 0440
+        - name: fleet-sink-client-ca
+          secret:
+            secretName: {{ required "fleetSink.tls.clientCASecretRef.name is required in fleetSink mode" .Values.fleetSink.tls.clientCASecretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ required "fleetSink.tls.clientCASecretRef.key is required in fleetSink mode" .Values.fleetSink.tls.clientCASecretRef.key | quote }}
+                path: {{ .Values.fleetSink.tls.clientCASecretRef.key | quote }}
+        {{- if and .Values.fleetSink.readerToken.secretRef.name .Values.fleetSink.readerToken.secretRef.key }}
+        - name: fleet-sink-reader-token
+          secret:
+            secretName: {{ .Values.fleetSink.readerToken.secretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ .Values.fleetSink.readerToken.secretRef.key | quote }}
+                path: {{ .Values.fleetSink.readerToken.secretRef.key | quote }}
+        {{- end }}
+        {{- if and .Values.license.crlSecretRef.name .Values.license.crlSecretRef.key }}
+        - name: license-crl
+          secret:
+            secretName: {{ .Values.license.crlSecretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ .Values.license.crlSecretRef.key | quote }}
+                path: {{ .Values.license.crlSecretRef.key | quote }}
+        {{- end }}
+        {{- range .Values.fleetSink.trustedAuditKeys }}
+        - name: fleet-sink-trusted-audit-{{ .id }}
+          secret:
+            secretName: {{ required "fleetSink.trustedAuditKeys[].secretRef.name is required" .secretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ required "fleetSink.trustedAuditKeys[].secretRef.key is required" .secretRef.key | quote }}
+                path: {{ .secretRef.key | quote }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/pipelock/templates/deployment-fleetsink.yaml
+++ b/charts/pipelock/templates/deployment-fleetsink.yaml
@@ -8,6 +8,8 @@ metadata:
     app.kubernetes.io/component: fleet-sink
 spec:
   replicas: {{ .Values.fleetSink.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "pipelock.selectorLabels" . | nindent 6 }}
@@ -44,6 +46,8 @@ spec:
             - fleet-sink
             - --listen
             - {{ printf "0.0.0.0:%d" (int .Values.fleetSink.service.port) | quote }}
+            - --probe-listen
+            - {{ printf "0.0.0.0:%d" (int .Values.fleetSink.service.probePort) | quote }}
             - --storage-dir
             - {{ .Values.fleetSink.persistence.mountPath | quote }}
             - --tls-cert
@@ -68,20 +72,21 @@ spec:
             - name: https
               containerPort: {{ .Values.fleetSink.service.port }}
               protocol: TCP
+            - name: probe
+              containerPort: {{ .Values.fleetSink.service.probePort }}
+              protocol: TCP
           livenessProbe:
             httpGet:
-              scheme: HTTPS
               path: /health
-              port: https
+              port: probe
             initialDelaySeconds: 5
             periodSeconds: 30
             timeoutSeconds: 3
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              scheme: HTTPS
               path: /health
-              port: https
+              port: probe
             initialDelaySeconds: 2
             periodSeconds: 10
             timeoutSeconds: 2

--- a/charts/pipelock/templates/deployment.yaml
+++ b/charts/pipelock/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- include "pipelock.validate" . }}
+{{- if eq (include "pipelock.mode" .) "proxy" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -128,6 +130,34 @@ spec:
               mountPath: {{ .Values.license.mountPath | quote }}
               readOnly: true
             {{- end }}
+            {{- if and .Values.license.crlSecretRef.name .Values.license.crlSecretRef.key }}
+            - name: license-crl
+              mountPath: {{ .Values.license.crlSecretRef.mountPath | quote }}
+              readOnly: true
+            {{- end }}
+            {{- if and .Values.conductorFollower.enabled .Values.conductorFollower.serverCASecretRef.name }}
+            - name: conductor-server-ca
+              mountPath: {{ .Values.conductorFollower.serverCASecretRef.mountPath | quote }}
+              readOnly: true
+            {{- end }}
+            {{- if and .Values.conductorFollower.enabled .Values.conductorFollower.clientSecretRef.name }}
+            - name: conductor-client-tls
+              mountPath: {{ .Values.conductorFollower.clientSecretRef.mountPath | quote }}
+              readOnly: true
+            {{- end }}
+            {{- if and .Values.conductorFollower.enabled .Values.conductorFollower.trustRosterSecretRef.name }}
+            - name: conductor-trust-roster
+              mountPath: {{ .Values.conductorFollower.trustRosterSecretRef.mountPath | quote }}
+              readOnly: true
+            {{- end }}
+            {{- if and .Values.conductorFollower.enabled .Values.conductorFollower.persistence.bundleCache.enabled }}
+            - name: conductor-bundle-cache
+              mountPath: {{ .Values.conductorFollower.persistence.bundleCache.mountPath | quote }}
+            {{- end }}
+            {{- if and .Values.conductorFollower.enabled .Values.conductorFollower.persistence.auditQueue.enabled }}
+            - name: conductor-audit-queue
+              mountPath: {{ .Values.conductorFollower.persistence.auditQueue.mountPath | quote }}
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -139,10 +169,53 @@ spec:
         - name: license
           secret:
             secretName: {{ .Values.license.existingSecret | quote }}
-            defaultMode: 0400
+            defaultMode: 0440
+        {{- end }}
+        {{- if and .Values.license.crlSecretRef.name .Values.license.crlSecretRef.key }}
+        - name: license-crl
+          secret:
+            secretName: {{ .Values.license.crlSecretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ .Values.license.crlSecretRef.key | quote }}
+                path: {{ .Values.license.crlSecretRef.key | quote }}
+        {{- end }}
+        {{- if and .Values.conductorFollower.enabled .Values.conductorFollower.serverCASecretRef.name }}
+        - name: conductor-server-ca
+          secret:
+            secretName: {{ .Values.conductorFollower.serverCASecretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ .Values.conductorFollower.serverCASecretRef.key | quote }}
+                path: {{ .Values.conductorFollower.serverCASecretRef.key | quote }}
+        {{- end }}
+        {{- if and .Values.conductorFollower.enabled .Values.conductorFollower.clientSecretRef.name }}
+        - name: conductor-client-tls
+          secret:
+            secretName: {{ .Values.conductorFollower.clientSecretRef.name | quote }}
+            defaultMode: 0440
+        {{- end }}
+        {{- if and .Values.conductorFollower.enabled .Values.conductorFollower.trustRosterSecretRef.name }}
+        - name: conductor-trust-roster
+          secret:
+            secretName: {{ .Values.conductorFollower.trustRosterSecretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ .Values.conductorFollower.trustRosterSecretRef.key | quote }}
+                path: {{ .Values.conductorFollower.trustRosterSecretRef.key | quote }}
         {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.conductorFollower.enabled .Values.conductorFollower.persistence.bundleCache.enabled }}
+        - name: conductor-bundle-cache
+          persistentVolumeClaim:
+            claimName: {{ include "pipelock.followerBundleCacheName" . }}
+        {{- end }}
+        {{- if and .Values.conductorFollower.enabled .Values.conductorFollower.persistence.auditQueue.enabled }}
+        - name: conductor-audit-queue
+          persistentVolumeClaim:
+            claimName: {{ include "pipelock.followerAuditQueueName" . }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -160,3 +233,4 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/pipelock/templates/networkpolicy.yaml
+++ b/charts/pipelock/templates/networkpolicy.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.networkPolicy.enabled }}
+{{- $mode := include "pipelock.mode" . }}
+{{- $preset := default "dev" .Values.networkPolicy.preset }}
+{{- $ingress := default list .Values.networkPolicy.ingress }}
+{{- $egress := default list .Values.networkPolicy.egress }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -9,36 +13,85 @@ spec:
   podSelector:
     matchLabels:
       {{- include "pipelock.selectorLabels" . | nindent 6 }}
+      {{- if eq $mode "conductor" }}
+      app.kubernetes.io/component: conductor
+      {{- else if eq $mode "fleetSink" }}
+      app.kubernetes.io/component: fleet-sink
+      {{- end }}
   policyTypes:
     - Ingress
     - Egress
   ingress:
+    {{- if eq $preset "airgapped" }}
+    []
+    {{- else if gt (len $ingress) 0 }}
+    {{- toYaml $ingress | nindent 4 }}
+    {{- else }}
     - from:
-        - podSelector: {}
+        - podSelector:
+            matchLabels:
+              pipelock.io/agent-egress: "true"
       ports:
+        {{- if eq $mode "proxy" }}
         - port: {{ .Values.service.port }}
           protocol: TCP
-        {{- if .Values.mcp.enabled }}
+        {{- if and .Values.mcp.enabled .Values.mcp.upstream }}
         - port: {{ .Values.service.mcpPort }}
           protocol: TCP
         {{- end }}
+        {{- else if eq $mode "conductor" }}
+        - port: {{ .Values.conductor.service.port }}
+          protocol: TCP
+        {{- else if eq $mode "fleetSink" }}
+        - port: {{ .Values.fleetSink.service.port }}
+          protocol: TCP
+        {{- end }}
+    - from:
+        - podSelector:
+            matchLabels:
+              pipelock.io/operator: "true"
+      ports:
+        {{- if eq $mode "proxy" }}
         - port: {{ .Values.service.metricsPort }}
           protocol: TCP
         {{- if .Values.adminApi.enabled }}
         - port: {{ .Values.service.adminPort }}
           protocol: TCP
         {{- end }}
+        {{- else if eq $mode "conductor" }}
+        - port: {{ .Values.conductor.service.probePort }}
+          protocol: TCP
+        {{- else if eq $mode "fleetSink" }}
+        - port: {{ .Values.fleetSink.service.port }}
+          protocol: TCP
+        {{- end }}
+    {{- end }}
   egress:
-    # DNS resolution required for all proxy modes
-    - ports:
+    {{- if eq $preset "airgapped" }}
+    []
+    {{- else if gt (len $egress) 0 }}
+    {{- toYaml $egress | nindent 4 }}
+    {{- else }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
         - port: 53
           protocol: UDP
         - port: 53
           protocol: TCP
-    # HTTPS egress — pipelock proxies agent traffic to the internet
+    {{- if ne $mode "fleetSink" }}
     - ports:
         - port: 443
           protocol: TCP
+        {{- if eq $preset "dev" }}
         - port: 80
           protocol: TCP
+        {{- end }}
+    {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/pipelock/templates/networkpolicy.yaml
+++ b/charts/pipelock/templates/networkpolicy.yaml
@@ -45,6 +45,8 @@ spec:
         {{- else if eq $mode "fleetSink" }}
         - port: {{ .Values.fleetSink.service.port }}
           protocol: TCP
+        - port: {{ .Values.fleetSink.service.probePort }}
+          protocol: TCP
         {{- end }}
     - from:
         - podSelector:

--- a/charts/pipelock/templates/poddisruptionbudget.yaml
+++ b/charts/pipelock/templates/poddisruptionbudget.yaml
@@ -18,4 +18,9 @@ spec:
   selector:
     matchLabels:
       {{- include "pipelock.selectorLabels" . | nindent 6 }}
+      {{- if eq (include "pipelock.mode" .) "conductor" }}
+      app.kubernetes.io/component: conductor
+      {{- else if eq (include "pipelock.mode" .) "fleetSink" }}
+      app.kubernetes.io/component: fleet-sink
+      {{- end }}
 {{- end }}

--- a/charts/pipelock/templates/podmonitor.yaml
+++ b/charts/pipelock/templates/podmonitor.yaml
@@ -12,7 +12,12 @@ spec:
   selector:
     matchLabels:
       {{- include "pipelock.selectorLabels" . | nindent 6 }}
+      {{- if eq (include "pipelock.mode" .) "conductor" }}
+      app.kubernetes.io/component: conductor
+      {{- else if eq (include "pipelock.mode" .) "fleetSink" }}
+      app.kubernetes.io/component: fleet-sink
+      {{- end }}
   podMetricsEndpoints:
-    - port: metrics
+    - port: {{ if eq (include "pipelock.mode" .) "conductor" }}probe{{ else if eq (include "pipelock.mode" .) "fleetSink" }}https{{ else }}metrics{{ end }}
       interval: {{ .Values.podMonitor.interval }}
 {{- end }}

--- a/charts/pipelock/templates/pvc.yaml
+++ b/charts/pipelock/templates/pvc.yaml
@@ -1,0 +1,75 @@
+{{- if and (eq (include "pipelock.mode" .) "conductor") .Values.conductor.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "pipelock.conductorStorageName" . }}
+  labels:
+    {{- include "pipelock.labels" . | nindent 4 }}
+    app.kubernetes.io/component: conductor
+spec:
+  accessModes:
+    {{- toYaml .Values.conductor.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.conductor.persistence.size | quote }}
+  {{- with .Values.conductor.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- if and (eq (include "pipelock.mode" .) "fleetSink") .Values.fleetSink.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "pipelock.fleetSinkStorageName" . }}
+  labels:
+    {{- include "pipelock.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet-sink
+spec:
+  accessModes:
+    {{- toYaml .Values.fleetSink.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.fleetSink.persistence.size | quote }}
+  {{- with .Values.fleetSink.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- if and (eq (include "pipelock.mode" .) "proxy") .Values.conductorFollower.enabled .Values.conductorFollower.persistence.bundleCache.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "pipelock.followerBundleCacheName" . }}
+  labels:
+    {{- include "pipelock.labels" . | nindent 4 }}
+    app.kubernetes.io/component: follower
+spec:
+  accessModes:
+    {{- toYaml .Values.conductorFollower.persistence.bundleCache.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.conductorFollower.persistence.bundleCache.size | quote }}
+  {{- with .Values.conductorFollower.persistence.bundleCache.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- if and (eq (include "pipelock.mode" .) "proxy") .Values.conductorFollower.enabled .Values.conductorFollower.persistence.auditQueue.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "pipelock.followerAuditQueueName" . }}
+  labels:
+    {{- include "pipelock.labels" . | nindent 4 }}
+    app.kubernetes.io/component: follower
+spec:
+  accessModes:
+    {{- toYaml .Values.conductorFollower.persistence.auditQueue.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.conductorFollower.persistence.auditQueue.size | quote }}
+  {{- with .Values.conductorFollower.persistence.auditQueue.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/pipelock/templates/service.yaml
+++ b/charts/pipelock/templates/service.yaml
@@ -86,4 +86,22 @@ spec:
       targetPort: https
       protocol: TCP
       name: https
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pipelock.fullname" . }}-fleet-sink-probes
+  labels:
+    {{- include "pipelock.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet-sink
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "pipelock.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet-sink
+  ports:
+    - port: {{ .Values.fleetSink.service.probePort }}
+      targetPort: probe
+      protocol: TCP
+      name: probe
 {{- end }}

--- a/charts/pipelock/templates/service.yaml
+++ b/charts/pipelock/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "pipelock.mode" .) "proxy" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,3 +30,60 @@ spec:
       protocol: TCP
       name: admin
     {{- end }}
+{{- end }}
+{{- if eq (include "pipelock.mode" .) "conductor" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pipelock.fullname" . }}-conductor
+  labels:
+    {{- include "pipelock.labels" . | nindent 4 }}
+    app.kubernetes.io/component: conductor
+spec:
+  type: {{ .Values.conductor.service.type }}
+  selector:
+    {{- include "pipelock.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: conductor
+  ports:
+    - port: {{ .Values.conductor.service.port }}
+      targetPort: follower
+      protocol: TCP
+      name: follower
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pipelock.fullname" . }}-conductor-probes
+  labels:
+    {{- include "pipelock.labels" . | nindent 4 }}
+    app.kubernetes.io/component: conductor
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "pipelock.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: conductor
+  ports:
+    - port: {{ .Values.conductor.service.probePort }}
+      targetPort: probe
+      protocol: TCP
+      name: probe
+{{- end }}
+{{- if eq (include "pipelock.mode" .) "fleetSink" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pipelock.fullname" . }}-fleet-sink
+  labels:
+    {{- include "pipelock.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet-sink
+spec:
+  type: {{ .Values.fleetSink.service.type }}
+  selector:
+    {{- include "pipelock.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet-sink
+  ports:
+    - port: {{ .Values.fleetSink.service.port }}
+      targetPort: https
+      protocol: TCP
+      name: https
+{{- end }}

--- a/charts/pipelock/values.schema.json
+++ b/charts/pipelock/values.schema.json
@@ -163,7 +163,8 @@
           "type": "object",
           "properties": {
             "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
-            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "probePort": { "type": "integer", "minimum": 1, "maximum": 65535 }
           }
         },
         "tls": { "type": "object" },

--- a/charts/pipelock/values.schema.json
+++ b/charts/pipelock/values.schema.json
@@ -4,6 +4,10 @@
   "type": "object",
   "additionalProperties": true,
   "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["proxy", "conductor", "fleetSink"]
+    },
     "replicaCount": {
       "type": "integer",
       "minimum": 1
@@ -88,7 +92,85 @@
         "enabled": { "type": "boolean" },
         "existingSecret": { "type": "string" },
         "secretKey": { "type": "string" },
-        "mountPath": { "type": "string" }
+        "mountPath": { "type": "string" },
+        "crlSecretRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "key": { "type": "string" },
+            "mountPath": { "type": "string" }
+          }
+        },
+        "publicKeySecretRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "key": { "type": "string" }
+          }
+        }
+      }
+    },
+    "conductorFollower": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "conductorURL": { "type": "string" },
+        "orgID": { "type": "string" },
+        "fleetID": { "type": "string" },
+        "instanceID": { "type": "string" },
+        "trustRosterRootFingerprint": { "type": "string" },
+        "auditSigningKeyID": { "type": "string" },
+        "recorderKeyID": { "type": "string" },
+        "pollInterval": { "type": "string" },
+        "emergencyStream": { "type": "boolean" },
+        "honorRemoteKillSwitch": { "type": "boolean" },
+        "serverCASecretRef": { "type": "object" },
+        "clientSecretRef": { "type": "object" },
+        "trustRosterSecretRef": { "type": "object" },
+        "persistence": { "type": "object" }
+      }
+    },
+    "conductor": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "replicaCount": { "type": "integer", "minimum": 1 },
+        "conductorID": { "type": "string" },
+        "followerTrustDomain": { "type": "string" },
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "probePort": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        },
+        "tls": { "type": "object" },
+        "tokens": { "type": "object" },
+        "trustedAuditKeys": { "type": "array" },
+        "trustedControlKeys": { "type": "array" },
+        "persistence": { "type": "object" },
+        "resources": { "type": "object" }
+      }
+    },
+    "fleetSink": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "replicaCount": { "type": "integer", "minimum": 1 },
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        },
+        "tls": { "type": "object" },
+        "readerToken": { "type": "object" },
+        "trustedAuditKeys": { "type": "array" },
+        "persistence": { "type": "object" },
+        "resources": { "type": "object" }
       }
     },
     "sentry": {
@@ -140,7 +222,13 @@
     "networkPolicy": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" }
+        "enabled": { "type": "boolean" },
+        "preset": {
+          "type": "string",
+          "enum": ["dev", "restricted", "airgapped"]
+        },
+        "ingress": { "type": "array" },
+        "egress": { "type": "array" }
       }
     },
     "livenessProbe": { "type": "object" },

--- a/charts/pipelock/values.yaml
+++ b/charts/pipelock/values.yaml
@@ -238,6 +238,7 @@ fleetSink:
   service:
     type: ClusterIP
     port: 8894
+    probePort: 9093
   tls:
     serverSecretRef:
       name: ""

--- a/charts/pipelock/values.yaml
+++ b/charts/pipelock/values.yaml
@@ -1,3 +1,5 @@
+mode: proxy # proxy | conductor | fleetSink
+
 replicaCount: 1
 
 image:
@@ -28,6 +30,8 @@ podLabels: {}
 podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
+  fsGroup: 65534
+  fsGroupChangePolicy: OnRootMismatch
 
 securityContext:
   readOnlyRootFilesystem: true
@@ -105,10 +109,170 @@ license:
   # Secret must contain the key named below (default: license.token).
   existingSecret: ""
   secretKey: "license.token"
-  # Path inside the container where the secret is mounted. The chart also
-  # sets PIPELOCK_LICENSE_KEY from the Secret; license_file is rendered for
-  # operators who prefer file-based license loading.
+  # Path inside the container where the Secret is mounted. Proxy mode renders
+  # license_file to this path. Enterprise server modes still set
+  # PIPELOCK_LICENSE_KEY from the Secret because those commands do not accept
+  # a license-file flag.
   mountPath: "/etc/pipelock/license"
+  # Optional signed license CRL mounted as a file and referenced by config or
+  # Enterprise server flags. The chart never templates CRL contents.
+  crlSecretRef:
+    name: ""
+    key: "license.crl"
+    mountPath: "/etc/pipelock/license-crl"
+  # Optional verifier public key for self-hosted/unofficial builds.
+  publicKeySecretRef:
+    name: ""
+    key: "public-key-hex"
+
+# Follower wiring keeps Pipelock in proxy mode while enabling the Enterprise
+# conductor client runtime. Followers enforce locally; Conductor only
+# coordinates signed policy bundles, remote kill, and audit transport.
+conductorFollower:
+  enabled: false
+  conductorURL: ""
+  orgID: ""
+  fleetID: ""
+  instanceID: ""
+  trustRosterRootFingerprint: ""
+  auditSigningKeyID: ""
+  recorderKeyID: ""
+  pollInterval: 30s
+  emergencyStream: true
+  honorRemoteKillSwitch: true
+  serverCASecretRef:
+    name: ""
+    key: "ca.crt"
+    mountPath: "/etc/pipelock/conductor/server-ca"
+  clientSecretRef:
+    name: ""
+    mountPath: "/etc/pipelock/conductor/client"
+  trustRosterSecretRef:
+    name: ""
+    key: "trust-roster.json"
+    mountPath: "/etc/pipelock/conductor/trust"
+  persistence:
+    bundleCache:
+      enabled: false
+      mountPath: "/var/lib/pipelock/conductor/bundles"
+      size: 1Gi
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: ""
+    auditQueue:
+      enabled: false
+      mountPath: "/var/lib/pipelock/conductor/audit-queue"
+      size: 5Gi
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: ""
+
+# Enterprise Conductor control-plane mode. Requires an enterprise build image
+# and an Enterprise license with the fleet feature.
+conductor:
+  replicaCount: 1
+  conductorID: "conductor"
+  followerTrustDomain: "pipelock.local"
+  service:
+    type: ClusterIP
+    port: 8895
+    probePort: 9092
+  tls:
+    serverSecretRef:
+      name: ""
+      mountPath: "/etc/pipelock/conductor/tls/server"
+    clientCASecretRef:
+      name: ""
+      key: "ca.crt"
+      mountPath: "/etc/pipelock/conductor/tls/client-ca"
+  tokens:
+    publisher:
+      secretRef:
+        name: ""
+        key: "publisher.token"
+      mountPath: "/etc/pipelock/conductor/tokens/publisher"
+    auditor:
+      secretRef:
+        name: ""
+        key: "auditor.token"
+      mountPath: "/etc/pipelock/conductor/tokens/auditor"
+    admin:
+      secretRef:
+        name: ""
+        key: "admin.token"
+      mountPath: "/etc/pipelock/conductor/tokens/admin"
+  trustedAuditKeys: []
+  # - id: audit-signer-prod
+  #   orgID: org-prod
+  #   fleetID: fleet-prod
+  #   instanceID: ""
+  #   secretRef:
+  #     name: conductor-audit-keys
+  #     key: audit-signer-prod.pub
+  trustedControlKeys: []
+  # - id: remote-kill-1
+  #   purpose: remote-kill-signing
+  #   secretRef:
+  #     name: conductor-control-keys
+  #     key: remote-kill-1.pub
+  persistence:
+    enabled: true
+    mountPath: "/var/lib/pipelock/conductor"
+    size: 20Gi
+    accessModes:
+      - ReadWriteOnce
+    storageClassName: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+
+# Standalone fleet audit sink mode. It remains a separate chart mode because
+# the binary exposes a dedicated `pipelock fleet-sink` server with independent
+# listener, storage, auth, mTLS, and retention characteristics.
+fleetSink:
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 8894
+  tls:
+    serverSecretRef:
+      name: ""
+      mountPath: "/etc/pipelock/fleet-sink/tls/server"
+    clientCASecretRef:
+      name: ""
+      key: "ca.crt"
+      mountPath: "/etc/pipelock/fleet-sink/tls/client-ca"
+  readerToken:
+    secretRef:
+      name: ""
+      key: "reader.token"
+    mountPath: "/etc/pipelock/fleet-sink/tokens/reader"
+  trustedAuditKeys: []
+  # - id: audit-signer-prod
+  #   orgID: org-prod
+  #   fleetID: fleet-prod
+  #   instanceID: ""
+  #   secretRef:
+  #     name: fleet-sink-audit-keys
+  #     key: audit-signer-prod.pub
+  persistence:
+    enabled: true
+    mountPath: "/var/lib/pipelock/fleet-sink"
+    size: 20Gi
+    accessModes:
+      - ReadWriteOnce
+    storageClassName: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
 
 # Sentry error reporting. When enabled, sets SENTRY_DSN from a Secret.
 sentry:
@@ -136,7 +300,7 @@ adminApi:
 # When adminApi.enabled is true, kill_switch.api_listen is also templated from
 # service.adminPort and should not be set here.
 #
-# Common v2.5 sections you may want to add under pipelock: below:
+# Common sections you may want to add under pipelock: below:
 #   mediation_envelope:     SPIFFE actor format, inbound verification trust list
 #   health_watchdog:        wedge-detection liveness probe surface
 #   browser_shield:         oversize action, exempt domains, max bytes
@@ -185,6 +349,12 @@ podMonitor:
 # Network policy
 networkPolicy:
   enabled: false
+  preset: dev # dev | restricted | airgapped
+  # Override rendered ingress/egress rules with explicit Kubernetes
+  # NetworkPolicyPeer rules. Enterprise examples set these instead of relying
+  # on broad defaults.
+  ingress: []
+  egress: []
 
 livenessProbe:
   httpGet:

--- a/enterprise/cli/fleet/sink.go
+++ b/enterprise/cli/fleet/sink.go
@@ -39,6 +39,7 @@ var sinkReadyHook func()
 
 func SinkCmd() *cobra.Command {
 	var listenAddr string
+	var probeListen string
 	var storageDir string
 	var trustedKeys []string
 	var maxSkew time.Duration
@@ -112,37 +113,97 @@ func SinkCmd() *cobra.Command {
 			}
 			server.TLSConfig = tlsConfig
 
-			runCtx, stop := signalContext(ctx)
+			probeHandler := newProbeHandler()
+			baseCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			runCtx, stop := signalContext(baseCtx)
 			defer stop()
+
+			ln, err := (&net.ListenConfig{}).Listen(runCtx, "tcp", listenAddr)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = ln.Close() }()
+
+			var probeLn net.Listener
+			if strings.TrimSpace(probeListen) != "" {
+				probeLn, err = (&net.ListenConfig{}).Listen(runCtx, "tcp", probeListen)
+				if err != nil {
+					return fmt.Errorf("probe bind %s: %w", probeListen, err)
+				}
+				defer func() { _ = probeLn.Close() }()
+			}
+
+			var probeServer *http.Server
+			if probeLn != nil {
+				probeServer = &http.Server{
+					Addr:              probeListen,
+					Handler:           probeHandler,
+					ReadHeaderTimeout: 5 * time.Second,
+					ReadTimeout:       15 * time.Second,
+					WriteTimeout:      15 * time.Second,
+					IdleTimeout:       60 * time.Second,
+					MaxHeaderBytes:    64 * 1024,
+				}
+			}
 			go func() {
 				<-runCtx.Done()
 				shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 				_ = server.Shutdown(shutdownCtx)
+				if probeServer != nil {
+					_ = probeServer.Shutdown(shutdownCtx)
+				}
 			}()
 
 			// Setup is complete here (store migrated, handler built, shutdown
 			// wired). Tests use this seam to cancel at a deterministic point so
-			// ListenAndServe is exercised and exits cleanly via Shutdown.
+			// Serve is exercised and exits cleanly via Shutdown.
 			if sinkReadyHook != nil {
 				sinkReadyHook()
 			}
 
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pipelock: fleet sink listening on %s\n", listenAddr)
-			if tlsCert != "" || tlsKey != "" {
-				if err := server.ListenAndServeTLS(tlsCert, tlsKey); err != nil && !errors.Is(err, http.ErrServerClosed) {
-					return err
+			serverCount := 1
+			errCh := make(chan error, 2)
+			go func() {
+				var err error
+				if tlsCert != "" || tlsKey != "" {
+					err = server.ServeTLS(ln, tlsCert, tlsKey)
+				} else {
+					err = server.Serve(ln)
 				}
-				return nil
+				if err != nil && !errors.Is(err, http.ErrServerClosed) {
+					errCh <- err
+					return
+				}
+				errCh <- nil
+			}()
+			if probeServer != nil {
+				serverCount++
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pipelock: fleet sink probes listening on %s\n", probeListen)
+				go func() {
+					if err := probeServer.Serve(probeLn); err != nil && !errors.Is(err, http.ErrServerClosed) {
+						errCh <- err
+						return
+					}
+					errCh <- nil
+				}()
 			}
-			if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-				return err
+
+			var firstErr error
+			for range serverCount {
+				if err := <-errCh; err != nil && firstErr == nil {
+					firstErr = err
+					cancel()
+				}
 			}
-			return nil
+			return firstErr
 		},
 	}
 
 	cmd.Flags().StringVar(&listenAddr, "listen", "127.0.0.1:8894", "address for the fleet sink HTTP listener")
+	cmd.Flags().StringVar(&probeListen, "probe-listen", "", "plain HTTP address for fleet sink health probes; empty disables the probe listener")
 	cmd.Flags().StringVar(&storageDir, "storage-dir", "", "directory for the fleet sink SQLite store")
 	cmd.Flags().StringArrayVar(&trustedKeys, "trusted-audit-key", nil,
 		"trusted audit signing key as comma-separated kv pairs: 'id=ID,(inline=BASE64|file=/path)[,org=ORG][,fleet=FLEET][,instance=INSTANCE]'; repeatable")
@@ -154,6 +215,20 @@ func SinkCmd() *cobra.Command {
 		"path to a file containing the bearer token required for GET requests; required for non-loopback bind without --client-ca")
 	cmd.Flags().StringVar(&licenseCRLFile, "license-crl-file", "", "signed license revocation list file; falls back to PIPELOCK_LICENSE_CRL_FILE")
 	return cmd
+}
+
+func newProbeHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", http.MethodGet+", "+http.MethodHead)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+	return mux
 }
 
 // auditKeySpec is one parsed --trusted-audit-key value.

--- a/enterprise/cli/fleet/sink_test.go
+++ b/enterprise/cli/fleet/sink_test.go
@@ -15,6 +15,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -317,7 +319,32 @@ func TestSignalContextCancel(t *testing.T) {
 	}
 }
 
-// TestSinkCmd_RunOnLoopback covers the happy-path RunE up to ListenAndServe
+func TestProbeHandlerOnlyServesHealth(t *testing.T) {
+	handler := newProbeHandler()
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /health status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/health", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST /health status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, sink.AuditBatchesPath, nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("audit path status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+// TestSinkCmd_RunOnLoopback covers the happy-path RunE up to Serve
 // returning the harmless ErrServerClosed after we cancel the parent context.
 // This wires together the resolver, store, scanner, and handler so all of
 // SinkCmd's setup branches are exercised.

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -47,7 +47,7 @@ func testBundleV2(name, tier string, monotonic uint64, rules []Rule) *Bundle {
 		Tier:             tier,
 		MonotonicVersion: monotonic,
 		PublishedAt:      "2026-04-01T00:00:00Z",
-		ExpiresAt:        "2026-06-01T00:00:00Z",
+		ExpiresAt:        "2126-06-01T00:00:00Z",
 		KeyID:            "sha256:test-key-id",
 		Rules:            rules,
 	}

--- a/scripts/check-helm-chart.sh
+++ b/scripts/check-helm-chart.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart="charts/pipelock"
+render_dir="$(mktemp -d)"
+trap 'rm -rf "$render_dir"' EXIT
+
+helm lint "$chart"
+
+helm template pipelock "$chart" >"$render_dir/default.yaml"
+
+for values in "$chart"/examples/*.yaml; do
+  name="$(basename "$values" .yaml)"
+  helm lint "$chart" -f "$values"
+  helm template pipelock "$chart" -f "$values" >"$render_dir/$name.yaml"
+done
+
+expect_template_error() {
+  local want="$1"
+  shift
+  local out="$render_dir/negative.out"
+  if helm template pipelock "$chart" "$@" >"$out" 2>&1; then
+    echo "helm template unexpectedly succeeded for negative case: $want" >&2
+    exit 1
+  fi
+  if ! grep -q "$want" "$out"; then
+    echo "helm template negative case did not include expected error: $want" >&2
+    cat "$out" >&2
+    exit 1
+  fi
+}
+
+expect_template_error "conductorFollower.conductorURL is required" \
+  --set conductorFollower.enabled=true
+
+expect_template_error "enterprise modes require explicit networkPolicy.ingress and networkPolicy.egress rules" \
+  --set mode=conductor \
+  --set networkPolicy.enabled=true \
+  --set networkPolicy.ingress=null \
+  --set networkPolicy.egress=null
+
+grep -q -- "- run" "$render_dir/default.yaml"
+grep -q -- "conductor:" "$render_dir/values-enterprise-follower.yaml"
+grep -q -- "pipelock-follower-bundles" "$render_dir/values-enterprise-follower.yaml"
+grep -q -- "pipelock-follower-audit-queue" "$render_dir/values-enterprise-follower.yaml"
+
+grep -q -- "- conductor" "$render_dir/values-enterprise-conductor.yaml"
+grep -q -- "- serve" "$render_dir/values-enterprise-conductor.yaml"
+grep -q -- "--probe-listen" "$render_dir/values-enterprise-conductor.yaml"
+grep -q -- "--publisher-token-file" "$render_dir/values-enterprise-conductor.yaml"
+grep -q -- "pipelock-conductor-probes" "$render_dir/values-enterprise-conductor.yaml"
+
+grep -q -- "- fleet-sink" "$render_dir/values-enterprise-devfleet.yaml"
+grep -q -- "--reader-token-file" "$render_dir/values-enterprise-devfleet.yaml"
+grep -q -- "pipelock-fleet-sink-storage" "$render_dir/values-enterprise-devfleet.yaml"
+
+if grep -R "publisher.token:" "$render_dir" >/dev/null; then
+  echo "rendered manifests must not contain inline publisher token values" >&2
+  exit 1
+fi
+
+echo "helm chart checks passed"

--- a/scripts/check-helm-chart.sh
+++ b/scripts/check-helm-chart.sh
@@ -39,6 +39,14 @@ expect_template_error "enterprise modes require explicit networkPolicy.ingress a
   --set networkPolicy.ingress=null \
   --set networkPolicy.egress=null
 
+expect_template_error "conductor.replicaCount must be 1 when conductor.persistence.accessModes includes ReadWriteOnce" \
+  -f "$chart/examples/values-enterprise-conductor.yaml" \
+  --set conductor.replicaCount=2
+
+expect_template_error "fleetSink.replicaCount must be 1 when fleetSink.persistence.accessModes includes ReadWriteOnce" \
+  -f "$chart/examples/values-enterprise-devfleet.yaml" \
+  --set fleetSink.replicaCount=2
+
 grep -q -- "- run" "$render_dir/default.yaml"
 grep -q -- "conductor:" "$render_dir/values-enterprise-follower.yaml"
 grep -q -- "pipelock-follower-bundles" "$render_dir/values-enterprise-follower.yaml"
@@ -51,7 +59,9 @@ grep -q -- "--publisher-token-file" "$render_dir/values-enterprise-conductor.yam
 grep -q -- "pipelock-conductor-probes" "$render_dir/values-enterprise-conductor.yaml"
 
 grep -q -- "- fleet-sink" "$render_dir/values-enterprise-devfleet.yaml"
+grep -q -- "--probe-listen" "$render_dir/values-enterprise-devfleet.yaml"
 grep -q -- "--reader-token-file" "$render_dir/values-enterprise-devfleet.yaml"
+grep -q -- "pipelock-fleet-sink-probes" "$render_dir/values-enterprise-devfleet.yaml"
 grep -q -- "pipelock-fleet-sink-storage" "$render_dir/values-enterprise-devfleet.yaml"
 
 if grep -R "publisher.token:" "$render_dir" >/dev/null; then


### PR DESCRIPTION
## Summary
- add Helm chart modes for proxy, Conductor, and standalone fleet-sink deployments
- add Conductor follower wiring with Secret refs, PVC-backed bundle/audit storage, and fail-fast validation
- add Enterprise example values, NetworkPolicy guards, chart schema/docs updates, and Helm CI smoke checks

## Testing
- bash scripts/check-helm-chart.sh
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Enterprise Conductor and fleet-sink deployment modes alongside the default proxy mode.
  * Fleet-sink now includes an optional health probe listener for monitoring.

* **Documentation**
  * Expanded Helm chart documentation with Enterprise deployment guidance and options.
  * Added example values files for Conductor, Enterprise follower, and fleet-sink configurations.

* **Chores**
  * Helm chart version bumped to 0.4.0 (appVersion 2.7.0).
  * Added automated Helm chart validation to the CI pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->