### PR TITLE
feat(svid): offline X.509-SVID validation against pinned trust-bundle history

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2
+	github.com/spiffe/go-spiffe/v2 v2.6.0
 	go.opentelemetry.io/proto/otlp v1.10.0
 	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.55.0

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/getsentry/sentry-go v0.46.2 h1:1jhYwrKGa3sIpo/y5iDNXS5wDoT7I1KNzMHrnK
 github.com/getsentry/sentry-go v0.46.2/go.mod h1:evVbw2qotNUdYG8KxXbAdjOQWWvWIwKxpjdZZIvcIPw=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
+github.com/go-jose/go-jose/v4 v4.1.2 h1:TK/7NqRQZfgAh+Td8AlsrvtPoUyiHh0LqVvokh+1vHI=
+github.com/go-jose/go-jose/v4 v4.1.2/go.mod h1:22cg9HWM1pOlnRiY+9cQYJ9XHmya1bYW8OeDM6Ku6Oo=
 github.com/go-shiori/dom v0.0.0-20230515143342-73569d674e1c h1:wpkoddUomPfHiOziHZixGO5ZBS73cKqVzZipfrLmO1w=
 github.com/go-shiori/dom v0.0.0-20230515143342-73569d674e1c/go.mod h1:oVDCh3qjJMLVUSILBRwrm+Bc6RNXGZYtoh9xdvf1ffM=
 github.com/go-shiori/go-readability v0.0.0-20251205110129-5db1dc9836f0 h1:A3B75Yp163FAIf9nLlFMl4pwIj+T3uKxfI7mbvvY2Ls=
@@ -100,6 +102,8 @@ github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
+github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/internal/svid/svid.go
+++ b/internal/svid/svid.go
@@ -1,0 +1,401 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package svid is a self-contained, vendor-neutral substrate for validating
+// X.509-SVIDs offline against a pinned history of trust bundles.
+//
+// It answers exactly one question, fail-closed: "Is this X.509-SVID a genuine
+// credential from a configured trust domain, valid at a given point in time,
+// chaining to a bundle we have pinned?" It knows nothing about receipts,
+// proof-of-possession, attestation payloads, or fleet membership; those are
+// built on top of it by separate packages.
+//
+// Three properties distinguish this from a plain SPIFFE Workload-API client:
+//
+//  1. Offline. Validation runs entirely against operator-pinned trust bundles.
+//     There is no live SPIRE / Workload-API fetch and no network access.
+//  2. Point-in-time. Validity is checked against a caller-supplied time, not
+//     "now". A historical credential that was valid when an action occurred
+//     still validates for that action time even though it is expired today.
+//  3. Bundle history. Trust domains rotate their bundles. An SVID issued under
+//     pinned generation N still validates against generation N after the
+//     domain rotates to N+1. The pinned history is append-only; validation is
+//     read-only and never auto-accepts a new root.
+package svid
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+)
+
+// Failure classes. Callers (e.g. an AARP verifier or Conductor membership
+// check) map these to their own result contracts. Compare with errors.Is.
+var (
+	// ErrMalformedInput covers structurally invalid input: bad PEM, a
+	// truncated or non-SVID X.509 certificate, an empty trust bundle, a zero
+	// validation time, an empty/invalid trust domain, or a nil history. None
+	// of these ever panic.
+	ErrMalformedInput = errors.New("svid: malformed input")
+
+	// ErrTrustDomainMismatch means the SVID's own trust domain does not match
+	// the trust domain the caller asked it to be validated against.
+	ErrTrustDomainMismatch = errors.New("svid: trust domain mismatch")
+
+	// ErrUntrustedChain means the SVID does not chain to the pinned bundle
+	// authoritative for the validation time (wrong key, forged or forked root).
+	ErrUntrustedChain = errors.New("svid: chain does not validate to a pinned bundle")
+
+	// ErrExpiredAtTime means the SVID (or its chain) is outside its validity
+	// window at the requested validation time — either expired or not yet
+	// valid relative to that time.
+	ErrExpiredAtTime = errors.New("svid: not valid at the requested time")
+
+	// ErrStaleOrForkedBundle means the pinned history does not authoritatively
+	// cover the validation time, or a pin attempt diverged from already-pinned
+	// history (no silent re-pin, no auto-accepted new root).
+	ErrStaleOrForkedBundle = errors.New("svid: bundle diverges from pinned history")
+)
+
+// Generation is one pinned trust-bundle generation: a set of X.509 authorities
+// that was authoritative for a trust domain during [NotBefore, NotAfter).
+// A zero NotAfter marks the current, open-ended generation.
+//
+// A Generation is trust-domain-agnostic; binding to a domain happens when it is
+// added to a TrustBundleHistory.
+type Generation struct {
+	NotBefore   time.Time
+	NotAfter    time.Time
+	authorities []*x509.Certificate
+}
+
+// NewGeneration builds a generation from parsed X.509 authorities. It rejects
+// an empty authority set and an inverted window. A zero notAfter is allowed and
+// means "open-ended / current".
+func NewGeneration(notBefore, notAfter time.Time, authorities []*x509.Certificate) (Generation, error) {
+	if err := validateGenerationWindow(notBefore, notAfter); err != nil {
+		return Generation{}, err
+	}
+	if len(authorities) == 0 {
+		return Generation{}, fmt.Errorf("%w: generation has no trust authorities", ErrMalformedInput)
+	}
+	cp := make([]*x509.Certificate, 0, len(authorities))
+	for _, c := range authorities {
+		if c == nil {
+			return Generation{}, fmt.Errorf("%w: nil authority certificate", ErrMalformedInput)
+		}
+		if err := validateAuthority(c); err != nil {
+			return Generation{}, err
+		}
+		clone, err := cloneCertificate(c)
+		if err != nil {
+			return Generation{}, err
+		}
+		cp = append(cp, clone)
+	}
+	// Defensive clone so later mutation of the caller's slice or certificate
+	// values cannot alter pinned state.
+	return Generation{NotBefore: notBefore, NotAfter: notAfter, authorities: cp}, nil
+}
+
+// NewGenerationPEM builds a generation from a PEM bundle of one or more
+// CERTIFICATE blocks (the common operator-pinned form).
+func NewGenerationPEM(notBefore, notAfter time.Time, authoritiesPEM []byte) (Generation, error) {
+	certs, err := parseCertChainPEM(authoritiesPEM)
+	if err != nil {
+		return Generation{}, err
+	}
+	return NewGeneration(notBefore, notAfter, certs)
+}
+
+// pinnedGen is a generation already bound to a trust domain and compiled into a
+// go-spiffe bundle for chain verification.
+type pinnedGen struct {
+	notBefore time.Time
+	notAfter  time.Time
+	bundle    *x509bundle.Bundle
+}
+
+// TrustBundleHistory is an append-only, time-ordered set of pinned bundle
+// generations for a single trust domain. It is the unit of pinned trust the
+// validator works against. Construction and Pin enforce that the timeline is
+// monotonic and non-overlapping; a divergent pin is rejected as a fork.
+//
+// It is safe for concurrent use: Pin (write) and validation reads are guarded,
+// so a fleet operator may rotate a domain's bundle at runtime while validations
+// are in flight. The trust domain itself is immutable after construction.
+type TrustBundleHistory struct {
+	td   spiffeid.TrustDomain
+	mu   sync.RWMutex
+	gens []pinnedGen
+}
+
+// NewTrustBundleHistory binds one or more generations to a trust domain in
+// chronological order. trustDomain is a SPIFFE trust domain name (e.g.
+// "example.org") — IP literals and malformed names are rejected.
+func NewTrustBundleHistory(trustDomain string, gens ...Generation) (*TrustBundleHistory, error) {
+	td, err := parseTrustDomain(trustDomain)
+	if err != nil {
+		return nil, err
+	}
+	if len(gens) == 0 {
+		return nil, fmt.Errorf("%w: trust bundle history needs at least one generation", ErrMalformedInput)
+	}
+	h := &TrustBundleHistory{td: td}
+	for i, g := range gens {
+		if err := h.appendGen(g); err != nil {
+			return nil, fmt.Errorf("generation %d: %w", i, err)
+		}
+	}
+	return h, nil
+}
+
+// Pin appends a new generation to the history. A legitimate forward rotation
+// closes the current open-ended generation at the new generation's NotBefore.
+// A generation that would rewrite or overlap already-pinned history is rejected
+// as a fork (ErrStaleOrForkedBundle) — the history never silently re-pins.
+func (h *TrustBundleHistory) Pin(g Generation) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.appendGen(g)
+}
+
+// appendGen appends one generation, enforcing the append-only/non-overlap
+// invariant. Callers must hold h.mu for writing (Pin does); NewTrustBundleHistory
+// calls it during construction before the value is shared.
+func (h *TrustBundleHistory) appendGen(g Generation) error {
+	// A Generation can only carry authorities via NewGeneration/NewGenerationPEM,
+	// which validate authorities. Its exported time fields can still be mutated
+	// after construction, so re-check the window at the append boundary.
+	if err := validateGenerationWindow(g.NotBefore, g.NotAfter); err != nil {
+		return err
+	}
+	if len(g.authorities) == 0 {
+		return fmt.Errorf("%w: generation has no trust authorities", ErrMalformedInput)
+	}
+
+	if len(h.gens) > 0 {
+		last := &h.gens[len(h.gens)-1]
+		// New generation must begin strictly after the previous one began.
+		if !g.NotBefore.After(last.notBefore) {
+			return fmt.Errorf("%w: generation starts at or before the previous generation", ErrStaleOrForkedBundle)
+		}
+		if last.notAfter.IsZero() {
+			// Previous generation was open-ended: legitimate rotation closes it
+			// at the new generation's start.
+			last.notAfter = g.NotBefore
+		} else if g.NotBefore.Before(last.notAfter) {
+			// Previous generation was already closed: a new generation starting
+			// before its end would overlap pinned history.
+			return fmt.Errorf("%w: generation overlaps a closed generation", ErrStaleOrForkedBundle)
+		}
+	}
+
+	h.gens = append(h.gens, pinnedGen{
+		notBefore: g.NotBefore,
+		notAfter:  g.NotAfter,
+		bundle:    x509bundle.FromX509Authorities(h.td, g.authorities),
+	})
+	return nil
+}
+
+func validateGenerationWindow(notBefore, notAfter time.Time) error {
+	if notBefore.IsZero() {
+		return fmt.Errorf("%w: generation notBefore must be set", ErrMalformedInput)
+	}
+	if !notAfter.IsZero() && !notAfter.After(notBefore) {
+		return fmt.Errorf("%w: generation notAfter must be after notBefore", ErrMalformedInput)
+	}
+	return nil
+}
+
+func validateAuthority(c *x509.Certificate) error {
+	if !c.IsCA {
+		return fmt.Errorf("%w: trust authority certificate is not a CA", ErrMalformedInput)
+	}
+	if c.KeyUsage != 0 && c.KeyUsage&x509.KeyUsageCertSign == 0 {
+		return fmt.Errorf("%w: trust authority certificate lacks cert-sign key usage", ErrMalformedInput)
+	}
+	return nil
+}
+
+func cloneCertificate(c *x509.Certificate) (*x509.Certificate, error) {
+	if len(c.Raw) == 0 {
+		return nil, fmt.Errorf("%w: trust authority certificate has no DER encoding", ErrMalformedInput)
+	}
+	raw := append([]byte(nil), c.Raw...)
+	clone, err := x509.ParseCertificate(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: trust authority certificate DER is invalid: %w", ErrMalformedInput, err)
+	}
+	return clone, nil
+}
+
+// TrustDomain returns the trust domain name this history is pinned for.
+func (h *TrustBundleHistory) TrustDomain() string {
+	return h.td.String()
+}
+
+// bundleAt returns the bundle authoritative at t, or false if no pinned
+// generation covers t.
+func (h *TrustBundleHistory) bundleAt(t time.Time) (*x509bundle.Bundle, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for i := range h.gens {
+		g := &h.gens[i]
+		if t.Before(g.notBefore) {
+			continue
+		}
+		if g.notAfter.IsZero() || t.Before(g.notAfter) {
+			return g.bundle, true
+		}
+	}
+	return nil, false
+}
+
+// Options configures a single ValidateSVID call.
+type Options struct {
+	// TrustDomain is the trust domain the SVID is expected to belong to. It
+	// must match History's trust domain and the SVID's own trust domain.
+	TrustDomain string
+	// History is the pinned trust-bundle history for TrustDomain.
+	History *TrustBundleHistory
+	// At is the point in time to validate against. It is REQUIRED and must be
+	// non-zero: a zero value would silently fall back to the wall clock inside
+	// crypto/x509, defeating point-in-time validation of historical credentials.
+	At time.Time
+}
+
+// Validated is the result of a successful validation.
+type Validated struct {
+	// SPIFFEID is the canonical SPIFFE ID from the SVID's URI SAN.
+	SPIFFEID string
+	// Leaf is the parsed leaf certificate (the SVID itself).
+	Leaf *x509.Certificate
+}
+
+// ValidateSVID validates an X.509-SVID (PEM, leaf first, optional intermediates)
+// against opts.History's pinned bundle authoritative at opts.At, for
+// opts.TrustDomain. It never reaches the network and never consults the wall
+// clock. Every failure returns one of the package's typed error classes and
+// never panics.
+func ValidateSVID(svidPEM []byte, opts Options) (Validated, error) {
+	if opts.At.IsZero() {
+		return Validated{}, fmt.Errorf("%w: validation time (At) is required and must be non-zero", ErrMalformedInput)
+	}
+	if opts.History == nil {
+		return Validated{}, fmt.Errorf("%w: pinned trust bundle history is required", ErrMalformedInput)
+	}
+	wantTD, err := parseTrustDomain(opts.TrustDomain)
+	if err != nil {
+		return Validated{}, err
+	}
+	if opts.History.td != wantTD {
+		return Validated{}, fmt.Errorf("%w: options trust domain %q does not match history trust domain %q",
+			ErrMalformedInput, wantTD.String(), opts.History.td.String())
+	}
+
+	certs, err := parseCertChainPEM(svidPEM)
+	if err != nil {
+		return Validated{}, err
+	}
+	leaf := certs[0]
+
+	// Extract the SPIFFE ID up front so we can return a precise trust-domain
+	// error before doing any chain work. A certificate without exactly one
+	// well-formed SPIFFE URI SAN is not an SVID at all.
+	id, err := x509svid.IDFromCert(leaf)
+	if err != nil {
+		return Validated{}, fmt.Errorf("%w: leaf is not an X.509-SVID: %w", ErrMalformedInput, err)
+	}
+	if id.TrustDomain() != wantTD {
+		return Validated{}, fmt.Errorf("%w: SVID trust domain %q, expected %q",
+			ErrTrustDomainMismatch, id.TrustDomain().String(), wantTD.String())
+	}
+
+	bundle, ok := opts.History.bundleAt(opts.At)
+	if !ok {
+		return Validated{}, fmt.Errorf("%w: no pinned bundle authoritative at %s", ErrStaleOrForkedBundle, opts.At.UTC().Format(time.RFC3339Nano))
+	}
+
+	if _, _, err := x509svid.Verify(certs, bundle, x509svid.WithTime(opts.At)); err != nil {
+		return Validated{}, classifyVerifyError(err)
+	}
+
+	return Validated{SPIFFEID: id.String(), Leaf: leaf}, nil
+}
+
+// classifyVerifyError maps a go-spiffe / crypto/x509 verification failure to a
+// typed error class. A validity-window failure (expired or not-yet-valid at the
+// requested time) becomes ErrExpiredAtTime; everything else (unknown authority,
+// CA-flagged or otherwise malformed leaf, key-usage violations) is treated as
+// an untrusted chain.
+func classifyVerifyError(err error) error {
+	var invalid x509.CertificateInvalidError
+	if errors.As(err, &invalid) && invalid.Reason == x509.Expired {
+		return fmt.Errorf("%w: %w", ErrExpiredAtTime, err)
+	}
+	return fmt.Errorf("%w: %w", ErrUntrustedChain, err)
+}
+
+// parseTrustDomain parses a SPIFFE trust domain name and rejects IP literals.
+// SPIFFE-ID §2 requires the trust domain to be a DNS name; go-spiffe's parser
+// accepts IP literals, so a numeric host could otherwise be used to impersonate
+// a domain. This mirrors internal/envelope's IsValidTrustDomain.
+func parseTrustDomain(s string) (spiffeid.TrustDomain, error) {
+	td, err := spiffeid.TrustDomainFromString(s)
+	if err != nil {
+		return spiffeid.TrustDomain{}, fmt.Errorf("%w: invalid trust domain %q: %w", ErrMalformedInput, s, err)
+	}
+	if net.ParseIP(td.String()) != nil {
+		return spiffeid.TrustDomain{}, fmt.Errorf("%w: trust domain must be a DNS name, not an IP address: %q", ErrMalformedInput, s)
+	}
+	return td, nil
+}
+
+// parseCertChainPEM decodes a PEM blob into an ordered certificate chain. The
+// input must be CERTIFICATE blocks only, with nothing but whitespace between or
+// after them. Any other block type, an unparseable body, trailing non-PEM data,
+// or zero certificates is ErrMalformedInput. Strict parsing matters here: an
+// operator who appended a second authority that failed to encode must learn the
+// bundle is malformed rather than have it silently truncated to what parsed.
+func parseCertChainPEM(data []byte) ([]*x509.Certificate, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("%w: empty SVID PEM", ErrMalformedInput)
+	}
+	var certs []*x509.Certificate
+	rest := data
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			// No further PEM block. Any non-whitespace remainder is junk that a
+			// lax parser would silently ignore — reject it.
+			if len(bytes.TrimSpace(rest)) > 0 {
+				return nil, fmt.Errorf("%w: trailing data after PEM block(s)", ErrMalformedInput)
+			}
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			return nil, fmt.Errorf("%w: unexpected PEM block type %q", ErrMalformedInput, block.Type)
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrMalformedInput, err)
+		}
+		certs = append(certs, cert)
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("%w: no certificates in PEM", ErrMalformedInput)
+	}
+	return certs, nil
+}

--- a/internal/svid/svid.go
+++ b/internal/svid/svid.go
@@ -32,6 +32,7 @@ import (
 	"net"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -376,14 +377,16 @@ func parseCertChainPEM(data []byte) ([]*x509.Certificate, error) {
 	rest := data
 	for {
 		var block *pem.Block
+		rest = bytes.TrimLeftFunc(rest, unicode.IsSpace)
+		if len(rest) == 0 {
+			break
+		}
+		if !bytes.HasPrefix(rest, []byte("-----BEGIN ")) {
+			return nil, fmt.Errorf("%w: leading non-whitespace before PEM block", ErrMalformedInput)
+		}
 		block, rest = pem.Decode(rest)
 		if block == nil {
-			// No further PEM block. Any non-whitespace remainder is junk that a
-			// lax parser would silently ignore — reject it.
-			if len(bytes.TrimSpace(rest)) > 0 {
-				return nil, fmt.Errorf("%w: trailing data after PEM block(s)", ErrMalformedInput)
-			}
-			break
+			return nil, fmt.Errorf("%w: malformed PEM block", ErrMalformedInput)
 		}
 		if block.Type != "CERTIFICATE" {
 			return nil, fmt.Errorf("%w: unexpected PEM block type %q", ErrMalformedInput, block.Type)

--- a/internal/svid/svid_test.go
+++ b/internal/svid/svid_test.go
@@ -1,0 +1,763 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package svid
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// ---- test PKI helpers (all in-memory; no key material ever touches disk) ----
+
+const (
+	tdExample = "example.test"
+	tdOther   = "other.test"
+	idAlpha   = "spiffe://example.test/agent/alpha"
+	idBeta    = "spiffe://other.test/agent/beta"
+)
+
+// base anchors every fixture window. Validation is driven exclusively by the
+// caller-supplied `At`, never time.Now(), so fixed dates here cannot time-bomb.
+var base = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+type testCA struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+}
+
+func mustSerial(t *testing.T) *big.Int {
+	t.Helper()
+	n, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("serial: %v", err)
+	}
+	return n
+}
+
+// newTestCA mints a self-signed CA. The CA window is deliberately wide so only
+// the leaf SVID's window drives expiry tests.
+func newTestCA(t *testing.T, commonName string) *testCA {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ca key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          mustSerial(t),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             base.Add(-10 * 365 * 24 * time.Hour),
+		NotAfter:              base.Add(10 * 365 * 24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("ca cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse ca: %v", err)
+	}
+	return &testCA{cert: cert, key: key}
+}
+
+// newIntermediate mints an intermediate CA signed by parent.
+func (ca *testCA) newIntermediate(t *testing.T, commonName string) *testCA {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("int key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          mustSerial(t),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             base.Add(-10 * 365 * 24 * time.Hour),
+		NotAfter:              base.Add(10 * 365 * 24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		MaxPathLenZero:        true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &key.PublicKey, ca.key)
+	if err != nil {
+		t.Fatalf("int cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse int: %v", err)
+	}
+	return &testCA{cert: cert, key: key}
+}
+
+// issueSVID returns the leaf SVID certificate DER, signed by ca, carrying
+// spiffeID as its sole URI SAN and the given validity window.
+func (ca *testCA) issueSVID(t *testing.T, spiffeID string, notBefore, notAfter time.Time) *x509.Certificate {
+	t.Helper()
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("leaf key: %v", err)
+	}
+	u, err := url.Parse(spiffeID)
+	if err != nil {
+		t.Fatalf("spiffe uri: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          mustSerial(t),
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		URIs:                  []*url.URL{u},
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &leafKey.PublicKey, ca.key)
+	if err != nil {
+		t.Fatalf("leaf cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	return cert
+}
+
+func certsToPEM(certs ...*x509.Certificate) []byte {
+	var buf bytes.Buffer
+	for _, c := range certs {
+		_ = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: c.Raw})
+	}
+	return buf.Bytes()
+}
+
+// openHistory builds a single open-ended-generation history for td pinned to ca.
+func openHistory(t *testing.T, td string, ca *testCA) *TrustBundleHistory {
+	t.Helper()
+	gen, err := NewGeneration(base.Add(-365*24*time.Hour), time.Time{}, []*x509.Certificate{ca.cert})
+	if err != nil {
+		t.Fatalf("NewGeneration: %v", err)
+	}
+	h, err := NewTrustBundleHistory(td, gen)
+	if err != nil {
+		t.Fatalf("NewTrustBundleHistory: %v", err)
+	}
+	return h
+}
+
+// ---- happy path ----
+
+func TestValidateSVID_GenuineSVID_ValidatesOffline(t *testing.T) {
+	ca := newTestCA(t, "example.test root")
+	at := base.Add(time.Hour)
+	leaf := ca.issueSVID(t, idAlpha, base, base.Add(2*time.Hour))
+	h := openHistory(t, tdExample, ca)
+
+	got, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: at})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if got.SPIFFEID != idAlpha {
+		t.Errorf("SPIFFEID = %q, want %q", got.SPIFFEID, idAlpha)
+	}
+	if got.Leaf == nil || !got.Leaf.Equal(leaf) {
+		t.Errorf("Leaf not returned correctly")
+	}
+}
+
+func TestValidateSVID_IntermediateChain(t *testing.T) {
+	root := newTestCA(t, "example.test root")
+	inter := root.newIntermediate(t, "example.test intermediate")
+	at := base.Add(time.Hour)
+	leaf := inter.issueSVID(t, idAlpha, base, base.Add(2*time.Hour))
+	h := openHistory(t, tdExample, root) // only the ROOT is pinned
+
+	got, err := ValidateSVID(
+		certsToPEM(leaf, inter.cert), // leaf first, intermediate follows
+		Options{TrustDomain: tdExample, History: h, At: at},
+	)
+	if err != nil {
+		t.Fatalf("expected success through intermediate, got %v", err)
+	}
+	if got.SPIFFEID != idAlpha {
+		t.Errorf("SPIFFEID = %q, want %q", got.SPIFFEID, idAlpha)
+	}
+}
+
+// ---- point-in-time / expiry (exact boundary) ----
+
+func TestValidateSVID_ExpiryBoundary(t *testing.T) {
+	ca := newTestCA(t, "example.test root")
+	notBefore := base
+	notAfter := base.Add(2 * time.Hour)
+	leaf := ca.issueSVID(t, idAlpha, notBefore, notAfter)
+	h := openHistory(t, tdExample, ca)
+
+	// Valid exactly at NotAfter (x509 uses After(NotAfter), so the boundary is valid).
+	if _, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: notAfter}); err != nil {
+		t.Fatalf("valid at exact NotAfter: unexpected error %v", err)
+	}
+	// One nanosecond past expiry must reject.
+	_, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: notAfter.Add(time.Nanosecond)})
+	if !errors.Is(err, ErrExpiredAtTime) {
+		t.Fatalf("at NotAfter+1ns: want ErrExpiredAtTime, got %v", err)
+	}
+	// Valid exactly at NotBefore.
+	if _, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: notBefore}); err != nil {
+		t.Fatalf("valid at exact NotBefore: unexpected error %v", err)
+	}
+	// One nanosecond before validity must reject (not-yet-valid).
+	_, err = ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: notBefore.Add(-time.Nanosecond)})
+	if !errors.Is(err, ErrExpiredAtTime) {
+		t.Fatalf("at NotBefore-1ns: want ErrExpiredAtTime, got %v", err)
+	}
+}
+
+// "Valid now but NOT valid at action time" — the audit-replay defense.
+func TestValidateSVID_ValidNowButNotAtActionTime(t *testing.T) {
+	ca := newTestCA(t, "example.test root")
+	// SVID window straddles base (would be "valid" if checked near base).
+	leaf := ca.issueSVID(t, idAlpha, base.Add(-time.Hour), base.Add(time.Hour))
+	h := openHistory(t, tdExample, ca)
+
+	// Action happened two hours before the SVID was even issued.
+	at := base.Add(-2 * time.Hour)
+	_, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: at})
+	if !errors.Is(err, ErrExpiredAtTime) {
+		t.Fatalf("want ErrExpiredAtTime for action before issuance, got %v", err)
+	}
+}
+
+// The zero-At guard: must never silently fall back to time.Now().
+func TestValidateSVID_ZeroAt_Rejects(t *testing.T) {
+	ca := newTestCA(t, "example.test root")
+	leaf := ca.issueSVID(t, idAlpha, base, base.Add(2*time.Hour))
+	h := openHistory(t, tdExample, ca)
+	_, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h}) // At zero
+	if !errors.Is(err, ErrMalformedInput) {
+		t.Fatalf("want ErrMalformedInput for zero At, got %v", err)
+	}
+}
+
+// ---- wrong key ----
+
+func TestValidateSVID_WrongKey_UntrustedChain(t *testing.T) {
+	pinned := newTestCA(t, "example.test root")
+	attacker := newTestCA(t, "attacker root")
+	at := base.Add(time.Hour)
+	// SVID with the right SPIFFE ID but signed by an unpinned root.
+	leaf := attacker.issueSVID(t, idAlpha, base, base.Add(2*time.Hour))
+	h := openHistory(t, tdExample, pinned)
+
+	_, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: at})
+	if !errors.Is(err, ErrUntrustedChain) {
+		t.Fatalf("want ErrUntrustedChain for unpinned signer, got %v", err)
+	}
+}
+
+// A CA-flagged leaf is not a valid SVID and must reject (not panic).
+func TestValidateSVID_CALeaf_Rejects(t *testing.T) {
+	ca := newTestCA(t, "example.test root")
+	at := base.Add(time.Hour)
+	// Re-use the CA itself (IsCA=true) as if it were a leaf SVID. It has no
+	// URI SAN, so it should classify as malformed (not a SVID).
+	h := openHistory(t, tdExample, ca)
+	_, err := ValidateSVID(certsToPEM(ca.cert), Options{TrustDomain: tdExample, History: h, At: at})
+	if err == nil {
+		t.Fatalf("CA-as-leaf must reject")
+	}
+	if !errors.Is(err, ErrMalformedInput) && !errors.Is(err, ErrUntrustedChain) {
+		t.Fatalf("CA-as-leaf: want malformed or untrusted, got %v", err)
+	}
+}
+
+// ---- trust-domain confusion ----
+
+func TestValidateSVID_TrustDomainConfusion(t *testing.T) {
+	caA := newTestCA(t, "example.test root")
+	caB := newTestCA(t, "other.test root")
+	at := base.Add(time.Hour)
+	// A genuine SVID for example.test...
+	leaf := caA.issueSVID(t, idAlpha, base, base.Add(2*time.Hour))
+	// ...presented for validation against other.test's pinned bundle.
+	hB := openHistory(t, tdOther, caB)
+
+	_, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdOther, History: hB, At: at})
+	if !errors.Is(err, ErrTrustDomainMismatch) {
+		t.Fatalf("want ErrTrustDomainMismatch, got %v", err)
+	}
+
+	// Symmetric: a genuine other.test SVID presented against example.test.
+	betaLeaf := caB.issueSVID(t, idBeta, base, base.Add(2*time.Hour))
+	hA := openHistory(t, tdExample, caA)
+	_, err = ValidateSVID(certsToPEM(betaLeaf), Options{TrustDomain: tdExample, History: hA, At: at})
+	if !errors.Is(err, ErrTrustDomainMismatch) {
+		t.Fatalf("symmetric: want ErrTrustDomainMismatch, got %v", err)
+	}
+}
+
+// Options.TrustDomain and History must agree; a mismatch is caller misconfig.
+func TestValidateSVID_OptionsHistoryDomainMismatch(t *testing.T) {
+	caA := newTestCA(t, "example.test root")
+	at := base.Add(time.Hour)
+	leaf := caA.issueSVID(t, idAlpha, base, base.Add(2*time.Hour))
+	hA := openHistory(t, tdExample, caA)
+	// History is for example.test, but caller claims other.test.
+	_, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdOther, History: hA, At: at})
+	if !errors.Is(err, ErrMalformedInput) {
+		t.Fatalf("want ErrMalformedInput for opts/history domain mismatch, got %v", err)
+	}
+}
+
+// ---- malformed input (no panic) ----
+
+func TestValidateSVID_MalformedInput(t *testing.T) {
+	ca := newTestCA(t, "example.test root")
+	h := openHistory(t, tdExample, ca)
+	at := base.Add(time.Hour)
+
+	// non-SVID X.509: a leaf with no URI SAN.
+	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	nonSVIDTmpl := &x509.Certificate{
+		SerialNumber: mustSerial(t),
+		NotBefore:    base,
+		NotAfter:     base.Add(2 * time.Hour),
+		Subject:      pkix.Name{CommonName: "no-uri.example"},
+	}
+	nonSVIDDER, err := x509.CreateCertificate(rand.Reader, nonSVIDTmpl, ca.cert, &leafKey.PublicKey, ca.key)
+	if err != nil {
+		t.Fatalf("non-svid cert: %v", err)
+	}
+	nonSVID, _ := x509.ParseCertificate(nonSVIDDER)
+
+	good := ca.issueSVID(t, idAlpha, base, base.Add(2*time.Hour))
+	truncated := certsToPEM(good)
+	truncated = truncated[:len(truncated)/2]
+
+	cases := []struct {
+		name string
+		pem  []byte
+	}{
+		{"garbage", []byte("this is not pem at all")},
+		{"whitespace only", []byte("   \n\t  \n ")},
+		{"empty", nil},
+		{"truncated cert", truncated},
+		{"non-svid x509 (no URI SAN)", certsToPEM(nonSVID)},
+		{"pem but wrong block type", pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("xx")})},
+		{"empty cert block body", pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: nil})},
+		{"valid cert then trailing garbage", append(certsToPEM(good), []byte("\nthis is trailing garbage that did not PEM-decode")...)},
+		{"valid cert then undecodable second block", append(certsToPEM(good), []byte("\n-----BEGIN CERTIFICATE-----\nnot base64!!!\n-----END CERTIFICATE-----\n")...)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ValidateSVID(tc.pem, Options{TrustDomain: tdExample, History: h, At: at})
+			if !errors.Is(err, ErrMalformedInput) {
+				t.Fatalf("want ErrMalformedInput, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateSVID_InvalidOptionsTrustDomain(t *testing.T) {
+	ca := newTestCA(t, "example.test root")
+	leaf := ca.issueSVID(t, idAlpha, base, base.Add(2*time.Hour))
+	h := openHistory(t, tdExample, ca)
+	// Empty opts.TrustDomain is not a parseable SPIFFE trust domain.
+	_, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: "", History: h, At: base.Add(time.Hour)})
+	if !errors.Is(err, ErrMalformedInput) {
+		t.Fatalf("want ErrMalformedInput for empty opts.TrustDomain, got %v", err)
+	}
+}
+
+func TestValidateSVID_NilHistory(t *testing.T) {
+	ca := newTestCA(t, "example.test root")
+	leaf := ca.issueSVID(t, idAlpha, base, base.Add(2*time.Hour))
+	_, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: nil, At: base.Add(time.Hour)})
+	if !errors.Is(err, ErrMalformedInput) {
+		t.Fatalf("want ErrMalformedInput for nil history, got %v", err)
+	}
+}
+
+// ---- trust bundle history / rotation ----
+
+func TestTrustBundleHistory_RotationValidatesPriorGeneration(t *testing.T) {
+	caGen0 := newTestCA(t, "example.test gen0")
+	caGen1 := newTestCA(t, "example.test gen1")
+	t0 := base
+	t1 := base.Add(24 * time.Hour)
+
+	gen0, err := NewGeneration(t0, t1, []*x509.Certificate{caGen0.cert})
+	if err != nil {
+		t.Fatalf("gen0: %v", err)
+	}
+	gen1, err := NewGeneration(t1, time.Time{}, []*x509.Certificate{caGen1.cert})
+	if err != nil {
+		t.Fatalf("gen1: %v", err)
+	}
+	h, err := NewTrustBundleHistory(tdExample, gen0, gen1)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+
+	// SVID issued under gen0, action time within gen0's window — validates even
+	// though the history has since rotated to gen1.
+	leaf := caGen0.issueSVID(t, idAlpha, t0, t0.Add(time.Hour))
+	at := t0.Add(30 * time.Minute)
+	if _, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: at}); err != nil {
+		t.Fatalf("gen0 SVID at gen0 time after rotation: %v", err)
+	}
+
+	// An SVID from gen0's CA, but action time in gen1's window, must NOT chain
+	// to gen1's (different) root.
+	atGen1 := t1.Add(time.Hour)
+	leaf2 := caGen0.issueSVID(t, idAlpha, t1, t1.Add(2*time.Hour))
+	_, err = ValidateSVID(certsToPEM(leaf2), Options{TrustDomain: tdExample, History: h, At: atGen1})
+	if !errors.Is(err, ErrUntrustedChain) {
+		t.Fatalf("gen0 root at gen1 time: want ErrUntrustedChain, got %v", err)
+	}
+}
+
+// During SPIFFE rotation overlap, the new generation's bundle carries BOTH
+// authorities; an SVID from the prior root still validates.
+func TestTrustBundleHistory_RotationOverlap(t *testing.T) {
+	caOld := newTestCA(t, "example.test old")
+	caNew := newTestCA(t, "example.test new")
+	t1 := base.Add(24 * time.Hour)
+
+	// gen1 (overlap) pins both old and new authorities.
+	gen, err := NewGeneration(t1, time.Time{}, []*x509.Certificate{caOld.cert, caNew.cert})
+	if err != nil {
+		t.Fatalf("overlap gen: %v", err)
+	}
+	h, err := NewTrustBundleHistory(tdExample, gen)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+
+	leaf := caOld.issueSVID(t, idAlpha, t1, t1.Add(time.Hour))
+	at := t1.Add(30 * time.Minute)
+	if _, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: at}); err != nil {
+		t.Fatalf("old-root SVID in overlap window: %v", err)
+	}
+}
+
+func TestTrustBundleHistory_NoGenerationForActionTime(t *testing.T) {
+	ca := newTestCA(t, "example.test root")
+	t0 := base
+	t1 := base.Add(24 * time.Hour)
+	gen, err := NewGeneration(t0, t1, []*x509.Certificate{ca.cert})
+	if err != nil {
+		t.Fatalf("gen: %v", err)
+	}
+	h, err := NewTrustBundleHistory(tdExample, gen)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	leaf := ca.issueSVID(t, idAlpha, t0, t1)
+
+	// Action time before the pinned generation begins → stale, no authoritative bundle.
+	_, err = ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: t0.Add(-time.Hour)})
+	if !errors.Is(err, ErrStaleOrForkedBundle) {
+		t.Fatalf("action before pinned window: want ErrStaleOrForkedBundle, got %v", err)
+	}
+	// Action time after the closed generation ends (gap) → stale.
+	_, err = ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: t1.Add(time.Hour)})
+	if !errors.Is(err, ErrStaleOrForkedBundle) {
+		t.Fatalf("action after pinned window: want ErrStaleOrForkedBundle, got %v", err)
+	}
+	// Boundary: half-open window [t0, t1). Exactly t1 is NOT covered.
+	_, err = ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: t1})
+	if !errors.Is(err, ErrStaleOrForkedBundle) {
+		t.Fatalf("action at exact NotAfter (half-open): want ErrStaleOrForkedBundle, got %v", err)
+	}
+	// Boundary: exactly t0 IS covered (so the SVID, valid then, validates).
+	if _, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: t0}); err != nil {
+		t.Fatalf("action at exact NotBefore: unexpected %v", err)
+	}
+}
+
+func TestTrustBundleHistory_Pin_ForkRejected(t *testing.T) {
+	caGen0 := newTestCA(t, "gen0")
+	caGen1 := newTestCA(t, "gen1")
+	t0 := base
+	t1 := base.Add(24 * time.Hour)
+	gen0, _ := NewGeneration(t0, time.Time{}, []*x509.Certificate{caGen0.cert})
+	h, err := NewTrustBundleHistory(tdExample, gen0)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+
+	// Legitimate forward rotation closes the open generation and appends.
+	gen1, _ := NewGeneration(t1, time.Time{}, []*x509.Certificate{caGen1.cert})
+	if err := h.Pin(gen1); err != nil {
+		t.Fatalf("legitimate forward pin: %v", err)
+	}
+
+	// Backward pin (rewriting already-pinned history) is a fork → reject.
+	backward, _ := NewGeneration(base.Add(-time.Hour), base.Add(time.Hour), []*x509.Certificate{caGen0.cert})
+	if err := h.Pin(backward); !errors.Is(err, ErrStaleOrForkedBundle) {
+		t.Fatalf("backward pin: want ErrStaleOrForkedBundle, got %v", err)
+	}
+
+	// Overlapping pin (inside an already-closed window) is a fork → reject.
+	overlap, _ := NewGeneration(t1.Add(time.Hour), time.Time{}, []*x509.Certificate{caGen1.cert})
+	// t1.Add(time.Hour) is after gen1.NotBefore (t1) which is now the open gen;
+	// a forward pin is fine, but a pin whose NotBefore <= current open gen's
+	// NotBefore must reject.
+	if err := h.Pin(overlap); err != nil {
+		t.Fatalf("forward pin after open gen should succeed: %v", err)
+	}
+	conflict, _ := NewGeneration(t1, time.Time{}, []*x509.Certificate{caGen0.cert})
+	if err := h.Pin(conflict); !errors.Is(err, ErrStaleOrForkedBundle) {
+		t.Fatalf("pin at/behind current open gen: want ErrStaleOrForkedBundle, got %v", err)
+	}
+}
+
+func TestTrustBundleHistory_ConstructionErrors(t *testing.T) {
+	ca := newTestCA(t, "root")
+	good := func() Generation {
+		g, _ := NewGeneration(base, time.Time{}, []*x509.Certificate{ca.cert})
+		return g
+	}
+
+	t.Run("empty trust domain", func(t *testing.T) {
+		if _, err := NewTrustBundleHistory("", good()); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("want ErrMalformedInput, got %v", err)
+		}
+	})
+	t.Run("ip trust domain", func(t *testing.T) {
+		if _, err := NewTrustBundleHistory("192.0.2.1", good()); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("want ErrMalformedInput, got %v", err)
+		}
+	})
+	t.Run("no generations", func(t *testing.T) {
+		if _, err := NewTrustBundleHistory(tdExample); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("want ErrMalformedInput, got %v", err)
+		}
+	})
+	t.Run("empty authorities", func(t *testing.T) {
+		if _, err := NewGeneration(base, time.Time{}, nil); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("want ErrMalformedInput, got %v", err)
+		}
+	})
+	t.Run("nil authority element", func(t *testing.T) {
+		if _, err := NewGeneration(base, time.Time{}, []*x509.Certificate{nil}); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("want ErrMalformedInput, got %v", err)
+		}
+	})
+	t.Run("non-ca authority", func(t *testing.T) {
+		leaf := ca.issueSVID(t, idAlpha, base, base.Add(time.Hour))
+		if _, err := NewGeneration(base, time.Time{}, []*x509.Certificate{leaf}); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("want ErrMalformedInput, got %v", err)
+		}
+	})
+	t.Run("ca authority lacking cert-sign usage", func(t *testing.T) {
+		// A cert flagged IsCA but whose KeyUsage is set without CertSign cannot
+		// actually sign certificates, so it must not be accepted as a trust authority.
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("key: %v", err)
+		}
+		tmpl := &x509.Certificate{
+			SerialNumber:          mustSerial(t),
+			Subject:               pkix.Name{CommonName: "ca without certsign"},
+			NotBefore:             base.Add(-time.Hour),
+			NotAfter:              base.Add(time.Hour),
+			IsCA:                  true,
+			KeyUsage:              x509.KeyUsageDigitalSignature, // non-zero, but no CertSign
+			BasicConstraintsValid: true,
+		}
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+		if err != nil {
+			t.Fatalf("cert: %v", err)
+		}
+		cert, err := x509.ParseCertificate(der)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if _, err := NewGeneration(base, time.Time{}, []*x509.Certificate{cert}); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("want ErrMalformedInput for CA lacking cert-sign usage, got %v", err)
+		}
+	})
+	t.Run("authority without DER", func(t *testing.T) {
+		if _, err := NewGeneration(base, time.Time{}, []*x509.Certificate{{
+			IsCA:     true,
+			KeyUsage: x509.KeyUsageCertSign,
+		}}); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("want ErrMalformedInput, got %v", err)
+		}
+	})
+	t.Run("authority with non-empty but unparseable DER", func(t *testing.T) {
+		if _, err := NewGeneration(base, time.Time{}, []*x509.Certificate{{
+			IsCA:     true,
+			KeyUsage: x509.KeyUsageCertSign,
+			Raw:      []byte{0x01, 0x02, 0x03}, // non-empty, not valid DER
+		}}); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("want ErrMalformedInput for unparseable DER, got %v", err)
+		}
+	})
+	t.Run("zero notBefore", func(t *testing.T) {
+		if _, err := NewGeneration(time.Time{}, time.Time{}, []*x509.Certificate{ca.cert}); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("want ErrMalformedInput, got %v", err)
+		}
+	})
+	t.Run("pin zero-value generation", func(t *testing.T) {
+		h := openHistory(t, tdExample, ca)
+		if err := h.Pin(Generation{}); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("Pin(zero-value): want ErrMalformedInput, got %v", err)
+		}
+	})
+	t.Run("pin generation with valid window but no authorities", func(t *testing.T) {
+		// A hand-built Generation can carry a valid window yet nil authorities;
+		// the append boundary must still reject it fail-closed.
+		h := openHistory(t, tdExample, ca)
+		if err := h.Pin(Generation{NotBefore: base.Add(time.Hour)}); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("Pin(no authorities): want ErrMalformedInput, got %v", err)
+		}
+	})
+	t.Run("notAfter before notBefore", func(t *testing.T) {
+		if _, err := NewGeneration(base.Add(time.Hour), base, []*x509.Certificate{ca.cert}); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("want ErrMalformedInput, got %v", err)
+		}
+	})
+	t.Run("mutated zero notBefore rejected at history append", func(t *testing.T) {
+		g := good()
+		g.NotBefore = time.Time{}
+		if _, err := NewTrustBundleHistory(tdExample, g); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("want ErrMalformedInput, got %v", err)
+		}
+	})
+	t.Run("mutated inverted window rejected at pin", func(t *testing.T) {
+		h := openHistory(t, tdExample, ca)
+		g := good()
+		g.NotBefore = base.Add(2 * time.Hour)
+		g.NotAfter = base.Add(time.Hour)
+		if err := h.Pin(g); !errors.Is(err, ErrMalformedInput) {
+			t.Fatalf("want ErrMalformedInput, got %v", err)
+		}
+	})
+	t.Run("overlapping generations", func(t *testing.T) {
+		g0, _ := NewGeneration(base, base.Add(2*time.Hour), []*x509.Certificate{ca.cert})
+		g1, _ := NewGeneration(base.Add(time.Hour), base.Add(3*time.Hour), []*x509.Certificate{ca.cert})
+		if _, err := NewTrustBundleHistory(tdExample, g0, g1); !errors.Is(err, ErrStaleOrForkedBundle) {
+			t.Fatalf("want ErrStaleOrForkedBundle, got %v", err)
+		}
+	})
+	t.Run("two open generations auto-close into a valid rotation", func(t *testing.T) {
+		// Passing two "open-ended" generations is the rotation case: the
+		// earlier one is closed at the later one's start. The result is a
+		// valid, queryable two-generation history.
+		caOld := newTestCA(t, "old")
+		caNew := newTestCA(t, "new")
+		g0, _ := NewGeneration(base, time.Time{}, []*x509.Certificate{caOld.cert})
+		g1, _ := NewGeneration(base.Add(time.Hour), time.Time{}, []*x509.Certificate{caNew.cert})
+		h, err := NewTrustBundleHistory(tdExample, g0, g1)
+		if err != nil {
+			t.Fatalf("two open generations should auto-close: %v", err)
+		}
+		// gen0 authoritative before the rotation point...
+		oldLeaf := caOld.issueSVID(t, idAlpha, base, base.Add(2*time.Hour))
+		if _, err := ValidateSVID(certsToPEM(oldLeaf), Options{TrustDomain: tdExample, History: h, At: base.Add(30 * time.Minute)}); err != nil {
+			t.Fatalf("gen0 SVID before rotation: %v", err)
+		}
+		// ...gen1 authoritative after it.
+		newLeaf := caNew.issueSVID(t, idAlpha, base.Add(time.Hour), base.Add(3*time.Hour))
+		if _, err := ValidateSVID(certsToPEM(newLeaf), Options{TrustDomain: tdExample, History: h, At: base.Add(2 * time.Hour)}); err != nil {
+			t.Fatalf("gen1 SVID after rotation: %v", err)
+		}
+	})
+}
+
+func TestNewGenerationPEM(t *testing.T) {
+	ca := newTestCA(t, "root")
+	gen, err := NewGenerationPEM(base, time.Time{}, certsToPEM(ca.cert))
+	if err != nil {
+		t.Fatalf("NewGenerationPEM: %v", err)
+	}
+	h, err := NewTrustBundleHistory(tdExample, gen)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	leaf := ca.issueSVID(t, idAlpha, base, base.Add(2*time.Hour))
+	if _, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: base.Add(time.Hour)}); err != nil {
+		t.Fatalf("validate with PEM-built generation: %v", err)
+	}
+
+	if _, err := NewGenerationPEM(base, time.Time{}, []byte("not pem")); !errors.Is(err, ErrMalformedInput) {
+		t.Fatalf("want ErrMalformedInput for bad PEM, got %v", err)
+	}
+}
+
+func TestTrustBundleHistory_AuthorityClonePreventsCallerMutation(t *testing.T) {
+	ca := newTestCA(t, "root")
+	leaf := ca.issueSVID(t, idAlpha, base, base.Add(2*time.Hour))
+	gen, err := NewGeneration(base, time.Time{}, []*x509.Certificate{ca.cert})
+	if err != nil {
+		t.Fatalf("NewGeneration: %v", err)
+	}
+	h, err := NewTrustBundleHistory(tdExample, gen)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+
+	ca.cert.IsCA = false
+	ca.cert.Raw = nil
+
+	if _, err := ValidateSVID(certsToPEM(leaf), Options{TrustDomain: tdExample, History: h, At: base.Add(time.Hour)}); err != nil {
+		t.Fatalf("source authority mutation affected pinned history: %v", err)
+	}
+}
+
+func TestTrustBundleHistory_TrustDomainAccessor(t *testing.T) {
+	ca := newTestCA(t, "root")
+	h := openHistory(t, tdExample, ca)
+	if h.TrustDomain() != tdExample {
+		t.Errorf("TrustDomain() = %q, want %q", h.TrustDomain(), tdExample)
+	}
+}
+
+// Conductor rotates trust bundles at runtime while validations are in flight.
+// Concurrent Pin + ValidateSVID must be race-free (run under -race).
+func TestTrustBundleHistory_ConcurrentPinAndValidate(t *testing.T) {
+	ca := newTestCA(t, "example.test gen0")
+	gen0, _ := NewGeneration(base, time.Time{}, []*x509.Certificate{ca.cert})
+	h, err := NewTrustBundleHistory(tdExample, gen0)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	leaf := ca.issueSVID(t, idAlpha, base, base.Add(100*24*time.Hour))
+	pemBytes := certsToPEM(leaf)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 1; i <= 50; i++ {
+			caN := newTestCA(t, "rotation")
+			g, gErr := NewGeneration(base.Add(time.Duration(i)*time.Hour), time.Time{}, []*x509.Certificate{caN.cert})
+			if gErr != nil {
+				t.Errorf("gen %d: %v", i, gErr)
+				return
+			}
+			if pErr := h.Pin(g); pErr != nil {
+				t.Errorf("pin %d: %v", i, pErr)
+				return
+			}
+		}
+	}()
+	for i := 0; i < 200; i++ {
+		// Validate at gen0's window; result may be valid or stale depending on
+		// interleaving, but it must never race or panic.
+		_, _ = ValidateSVID(pemBytes, Options{TrustDomain: tdExample, History: h, At: base.Add(30 * time.Minute)})
+	}
+	<-done
+}

--- a/internal/svid/svid_test.go
+++ b/internal/svid/svid_test.go
@@ -12,6 +12,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"math/big"
 	"net/url"
 	"testing"
@@ -355,7 +356,9 @@ func TestValidateSVID_MalformedInput(t *testing.T) {
 		{"non-svid x509 (no URI SAN)", certsToPEM(nonSVID)},
 		{"pem but wrong block type", pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("xx")})},
 		{"empty cert block body", pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: nil})},
+		{"leading garbage before valid cert", append([]byte("junk before cert\n"), certsToPEM(good)...)},
 		{"valid cert then trailing garbage", append(certsToPEM(good), []byte("\nthis is trailing garbage that did not PEM-decode")...)},
+		{"junk between valid cert blocks", append(append(certsToPEM(good), []byte("\njunk between certs\n")...), certsToPEM(good)...)},
 		{"valid cert then undecodable second block", append(certsToPEM(good), []byte("\n-----BEGIN CERTIFICATE-----\nnot base64!!!\n-----END CERTIFICATE-----\n")...)},
 	}
 	for _, tc := range cases {
@@ -738,26 +741,32 @@ func TestTrustBundleHistory_ConcurrentPinAndValidate(t *testing.T) {
 	leaf := ca.issueSVID(t, idAlpha, base, base.Add(100*24*time.Hour))
 	pemBytes := certsToPEM(leaf)
 
-	done := make(chan struct{})
+	rotations := make([]Generation, 0, 50)
+	for i := 1; i <= 50; i++ {
+		caN := newTestCA(t, "rotation")
+		g, gErr := NewGeneration(base.Add(time.Duration(i)*time.Hour), time.Time{}, []*x509.Certificate{caN.cert})
+		if gErr != nil {
+			t.Fatalf("gen %d: %v", i, gErr)
+		}
+		rotations = append(rotations, g)
+	}
+
+	done := make(chan error, 1)
 	go func() {
-		defer close(done)
-		for i := 1; i <= 50; i++ {
-			caN := newTestCA(t, "rotation")
-			g, gErr := NewGeneration(base.Add(time.Duration(i)*time.Hour), time.Time{}, []*x509.Certificate{caN.cert})
-			if gErr != nil {
-				t.Errorf("gen %d: %v", i, gErr)
-				return
-			}
+		for i, g := range rotations {
 			if pErr := h.Pin(g); pErr != nil {
-				t.Errorf("pin %d: %v", i, pErr)
+				done <- fmt.Errorf("pin %d: %w", i+1, pErr)
 				return
 			}
 		}
+		done <- nil
 	}()
 	for i := 0; i < 200; i++ {
 		// Validate at gen0's window; result may be valid or stale depending on
 		// interleaving, but it must never race or panic.
 		_, _ = ValidateSVID(pemBytes, Options{TrustDomain: tdExample, History: h, At: base.Add(30 * time.Minute)})
 	}
-	<-done
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
## Summary

Adds `internal/svid`, a vendor-neutral substrate that validates X.509-SVIDs offline against operator-pinned trust bundles. It answers one question, fail-closed: is this SVID a genuine credential from a configured trust domain, valid at a caller-supplied point in time, chaining to a pinned bundle? It holds no knowledge of receipts, proof-of-possession, or fleet membership, so other packages can build on it unchanged.

## What it provides beyond go-spiffe

- **Offline validation** against a pinned `x509bundle` history. No Workload-API or SPIRE fetch, no network access.
- **Point-in-time validation.** `ValidateSVID` takes a caller-supplied `At` and checks the leaf and chain against that time, not `time.Now()`. A credential that was valid when an action occurred still validates for that action time. A zero `At` is rejected so validation can never silently fall back to the wall clock.
- **Append-only trust-bundle history with rotation.** An SVID issued under pinned generation N still validates after the domain rotates to N+1; a pin that diverges from pinned history is rejected with no silent re-pin and no auto-accepted new root. The history is safe for concurrent rotation while validations run.

Typed error classes (malformed, trust-domain-mismatch, untrusted-chain, expired-at-time, stale-or-forked-bundle) let callers map to their own result contracts.

## Hardening

Tests reject, at the exact boundary and fail-closed: replay and expiry relative to `At` (valid at T, rejected at T+1ns), not-yet-valid, wrong-key, stale and forked bundles, trust-domain confusion (including IP-literal trust domains), and malformed input (garbage PEM, truncated cert, non-SVID X.509, trailing junk, empty bundle). Pinned authorities are deep-cloned from DER and required to be CAs with cert-sign usage, so a caller cannot mutate pinned trust through a held certificate pointer. No input path panics.

## New dependency

`github.com/spiffe/go-spiffe/v2` (direct). Required for both fleet workload identity and verified attestation, two core upcoming capabilities. Hand-rolling X.509-SVID parsing and trust-bundle chain validation would be more attack surface, not less. Only the X.509-SVID packages are imported, so the JWT-SVID path that pulls in go-jose is not compiled into the binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline X.509-SVID validation with pinned trust-bundle history and rotation detection
  * Time-based validation at caller-specified timestamps with strict expiry enforcement
  * Explicit error classifications for malformed input, trust-domain mismatches, untrusted chains, expired SVIDs, and stale/forked bundles
  * Concurrency-safe trust-bundle handling for parallel validation and pinning

* **Tests**
  * Comprehensive test suite covering validation, rotation semantics, error cases, malformed input, and concurrency/race conditions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->