### PR TITLE
fix(mcp): treat connection teardown as a clean stream end in ForwardScanned

### DIFF
--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	session "github.com/luckyPipewrench/pipelock/internal/session"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
+	"github.com/luckyPipewrench/pipelock/internal/wsutil"
 )
 
 // ErrSubprocessExit indicates the wrapped MCP server process exited with a
@@ -149,7 +150,12 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 	for {
 		line, err := reader.ReadMessage()
 		if err != nil {
-			if errors.Is(err, io.EOF) {
+			// A clean stream end is io.EOF; a proxy-initiated connection
+			// teardown surfaces net.ErrClosed ("use of closed network
+			// connection"), and a peer drop surfaces as reset/broken-pipe,
+			// from a blocked transport read. All mean "no more traffic to
+			// scan", not a fatal error. IsExpectedCloseErr covers io.EOF too.
+			if wsutil.IsExpectedCloseErr(err) {
 				break
 			}
 			return foundInjection, fmt.Errorf("reading input: %w", err)

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -2412,6 +2413,52 @@ func TestStripOrBlock_NonRedactable_FallsBackToBlock(t *testing.T) {
 }
 
 // makeResponse helper is defined in scan_test.go
+
+// wsTeardownReader simulates a WS upstream whose blocked read is interrupted by
+// a proxy-initiated connection teardown (cancel + Close): ReadMessage returns a
+// wrapped net.ErrClosed ("use of closed network connection") or a peer reset,
+// not io.EOF. This is the deterministic form of the race behind the flaky
+// TestRunWSProxy_ChainDetectionBlocks.
+type wsTeardownReader struct{ err error }
+
+func (r *wsTeardownReader) ReadMessage() ([]byte, error) { return nil, r.err }
+
+// A proxy-initiated teardown surfaces net.ErrClosed (not io.EOF) from a blocked
+// upstream read; ForwardScanned must treat expected-close errors as a clean
+// stream end, otherwise RunWSProxy returns a spurious error under load.
+func TestForwardScanned_ExpectedCloseTreatedAsCleanEOF(t *testing.T) {
+	sc := testScannerWithAction(t, "warn")
+	cases := []struct {
+		name string
+		err  error
+	}{
+		// Mirrors transport/wsclient.go's "reading ws payload: %w" wrap.
+		{"use of closed network connection", fmt.Errorf("reading ws payload: %w", net.ErrClosed)},
+		{"connection reset by peer", errors.New("reading ws payload: read tcp 127.0.0.1:1->127.0.0.1:2: connection reset by peer")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out, log bytes.Buffer
+			reader := &wsTeardownReader{err: tc.err}
+			_, err := ForwardScanned(reader, transport.NewStdioWriter(&out), &log, NewRequestTracker(), testOpts(sc))
+			if err != nil {
+				t.Fatalf("proxy-initiated teardown (%s) must be a clean exit, got %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// A genuine (non-close) read error must still surface, so the expected-close
+// handling does not swallow real failures.
+func TestForwardScanned_GenuineReadErrorStillSurfaces(t *testing.T) {
+	sc := testScannerWithAction(t, "warn")
+	var out, log bytes.Buffer
+	reader := &wsTeardownReader{err: errors.New("reading ws payload: malformed frame header")}
+	_, err := ForwardScanned(reader, transport.NewStdioWriter(&out), &log, NewRequestTracker(), testOpts(sc))
+	if err == nil {
+		t.Fatal("a genuine read error must surface, not be treated as clean EOF")
+	}
+}
 
 // --- Confused Deputy tests ---
 

--- a/internal/mcp/proxy_ws.go
+++ b/internal/mcp/proxy_ws.go
@@ -205,9 +205,10 @@ func RunWSProxy(
 		}
 	}
 
-	// Close the WS connection to unblock ForwardScanned's ReadMessage.
-	// WSClient.ReadMessage maps "use of closed network connection" to io.EOF
-	// via IsExpectedCloseErr, so ForwardScanned exits cleanly.
+	// Close the WS connection to unblock ForwardScanned's ReadMessage. The
+	// blocked read returns net.ErrClosed ("use of closed network connection"),
+	// which ForwardScanned treats as a clean stream end via
+	// wsutil.IsExpectedCloseErr, so it exits without a spurious error.
 	cancel()
 	_ = wsClient.Close()
 	wg.Wait()


### PR DESCRIPTION
`ForwardScanned` treated only `io.EOF` as a clean end of the response stream, so a proxy-initiated WebSocket teardown surfacing `net.ErrClosed` ("use of closed network connection") became a spurious error and intermittently failed `TestRunWSProxy_ChainDetectionBlocks`. It now treats expected-close errors (`wsutil.IsExpectedCloseErr`) as a clean stream end. A genuine read error still surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stream closure error handling in the proxy to properly recognize and treat expected connection teardowns as clean shutdowns rather than errors.

* **Tests**
  * Added test coverage for connection teardown and read error scenarios to verify robust proxy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->