### PR TITLE
fix(seedprotect): close Unicode evasion gaps in BIP-39 seed-phrase detection

### DIFF
--- a/internal/redact/seed_evasion_test.go
+++ b/internal/redact/seed_evasion_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+// redactSeed12 is a valid BIP-39 12-word mnemonic (abandon x11 + about).
+const redactSeed12 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+func homoglyphFoldSeed(s string) string {
+	return strings.NewReplacer(
+		"a", "а", "o", "о", "e", "е", "c", "с", "p", "р",
+		"t", "т", "x", "х", "k", "к", "m", "м", "y", "у",
+	).Replace(s)
+}
+
+// TestMatcher_SeedEvasionRedacted is a redaction-surface parity regression.
+// Before the seedprotect normalization hardening, a homoglyph- or
+// exotic-separator-disguised seed phrase evaded the redactor (matcher.go calls
+// seedprotect.DetectSpans), so it would pass through unredacted even when the
+// scanner flagged it elsewhere. The same evasion must now be redacted, keeping
+// the detection and redaction surfaces in parity.
+func TestMatcher_SeedEvasionRedacted(t *testing.T) {
+	m := NewDefaultMatcher()
+
+	cases := []struct {
+		name string
+		text string
+	}{
+		{"cyrillic-homoglyph", homoglyphFoldSeed(redactSeed12)},
+		{"nbsp-separator", strings.ReplaceAll(redactSeed12, " ", " ")},
+		{"combined-homoglyph-nbsp", strings.ReplaceAll(homoglyphFoldSeed(redactSeed12), " ", " ")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var found bool
+			for _, mt := range m.Scan(tc.text) {
+				if mt.Class == ClassSeedPhrase {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("%s: evaded seed phrase NOT redacted (no ClassSeedPhrase match)", tc.name)
+			}
+		})
+	}
+}

--- a/internal/scanner/seed_evasion_parity_test.go
+++ b/internal/scanner/seed_evasion_parity_test.go
@@ -61,3 +61,29 @@ func TestScanTextForDLP_SeedEvasionParity(t *testing.T) {
 		})
 	}
 }
+
+// TestScan_SeedEvasionURLTargetParity proves the third detection surface: the
+// URL/target scan path (Scan builds seed candidates from query values, hostname
+// labels, and path segments). An underscore-separated mnemonic in a path was a
+// single un-tokenizable blob before the separator hardening; "_" is now a
+// separator, so the segments tokenize into the 12 words and the phrase is
+// caught. ASCII-only, so there is no URL-encoding noise. Seed detection runs in
+// the DLP layer before SSRF/DNS, so Internal=nil keeps the test offline.
+func TestScan_SeedEvasionURLTargetParity(t *testing.T) {
+	cfg := testConfig()
+	cfg.Internal = nil
+	cfg.SeedPhraseDetection.Enabled = ptrBool(true)
+	cfg.SeedPhraseDetection.MinWords = 12
+	cfg.SeedPhraseDetection.VerifyChecksum = ptrBool(true)
+	s := New(cfg)
+	defer s.Close()
+
+	underscored := strings.ReplaceAll(testSeedPhrase12, " ", "_")
+	r := s.Scan(context.Background(), "https://evil.example/"+underscored)
+	if r.Allowed {
+		t.Fatalf("underscore-separated seed in URL path NOT blocked via Scan (URL/target parity gap): %+v", r)
+	}
+	if !strings.Contains(r.Reason, "Seed Phrase") {
+		t.Fatalf("blocked but not for a seed phrase: %q", r.Reason)
+	}
+}

--- a/internal/scanner/seed_evasion_parity_test.go
+++ b/internal/scanner/seed_evasion_parity_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// homoglyphFoldSeed swaps Latin letters for visually identical Cyrillic code
+// points that the normalize package maps back to ASCII. Only letters with a
+// confirmed lowercase Cyrillic confusable are swapped.
+func homoglyphFoldSeed(s string) string {
+	return strings.NewReplacer(
+		"a", "а", "o", "о", "e", "е", "c", "с", "p", "р",
+		"t", "т", "x", "х", "k", "к", "m", "м", "y", "у",
+	).Replace(s)
+}
+
+// TestScanTextForDLP_SeedEvasionParity is a transport-parity regression. A
+// Unicode-evaded BIP-39 seed must be caught through the live ScanTextForDLP
+// path — the same path the offline `pipelock audit simulate` / scan harness
+// drives via scanner.New + Scan — not just by the seedprotect package in
+// isolation. This proves the normalization + separator hardening reaches the
+// scanner integration boundary (and therefore the audit surface) rather than
+// living only in the detector.
+func TestScanTextForDLP_SeedEvasionParity(t *testing.T) {
+	cfg := testConfig()
+	cfg.SeedPhraseDetection.Enabled = ptrBool(true)
+	cfg.SeedPhraseDetection.MinWords = 12
+	cfg.SeedPhraseDetection.VerifyChecksum = ptrBool(true)
+	s := New(cfg)
+
+	cases := []struct {
+		name string
+		text string
+	}{
+		{"cyrillic-homoglyph", homoglyphFoldSeed(testSeedPhrase12)},
+		{"nbsp-separator", strings.ReplaceAll(testSeedPhrase12, " ", " ")},
+		{"en-dash-separator", strings.ReplaceAll(testSeedPhrase12, " ", "–")},
+		{"line-separator", strings.ReplaceAll(testSeedPhrase12, " ", "\u2028")},
+		{"combined-homoglyph-nbsp", strings.ReplaceAll(homoglyphFoldSeed(testSeedPhrase12), " ", " ")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := s.ScanTextForDLP(context.Background(), tc.text)
+			if r.Clean {
+				t.Fatalf("%s: evaded seed phrase NOT detected via ScanTextForDLP (parity gap)", tc.name)
+			}
+			found := false
+			for _, m := range r.Matches {
+				if m.PatternName == "BIP-39 Seed Phrase" {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("%s: detected but not as BIP-39 Seed Phrase: %+v", tc.name, r.Matches)
+			}
+		})
+	}
+}

--- a/internal/seedprotect/detector.go
+++ b/internal/seedprotect/detector.go
@@ -5,15 +5,15 @@ package seedprotect
 
 import (
 	"crypto/sha256"
-	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/luckyPipewrench/pipelock/internal/normalize"
 )
 
 // validLengths are the BIP-39 mnemonic word counts (128-256 bits of entropy).
 var validLengths = []int{12, 15, 18, 21, 24}
-
-// separatorRE splits on whitespace and common seed phrase delimiters.
-var separatorRE = regexp.MustCompile(`[-\s,|;:]+`)
 
 // SeedMatch is the internal detection result. Package-internal only -
 // converted to TextDLPMatch at the scanner integration boundary.
@@ -95,14 +95,42 @@ func DetectSpans(text string, minWords int, verifyChecksum bool) []SeedSpan {
 	return matches
 }
 
-// tokenize splits text into lowercase words using the separator pattern.
+// isSeedSeparator splits on whitespace and common seed-phrase delimiters. It
+// covers the full Go whitespace set (ASCII whitespace, NBSP, Unicode line and
+// paragraph separators, NEL), the historical Mongolian vowel separator used in
+// existing DLP whitespace normalization, Unicode dash punctuation (en/em/figure
+// dashes vs ASCII hyphen), and literal , _ / | ; : • · delimiters seen in
+// numbered or bulleted backups. Broadening this closes the "split words with a
+// glyph the tokenizer ignores" evasion class.
+//
+// "." is deliberately NOT a separator: the request-body scanner joins distinct
+// JSON field values with "." (proxy.bodyDLPJoinSeparator) so cross-field DLP
+// works without merging tokens. Treating "." as intra-phrase here would let the
+// detector synthesize a mnemonic across separate fields (a false positive that
+// proxy.TestScanRequestBody_SeedPhraseDoesNotSpanJSONFields guards against).
+func isSeedSeparator(r rune) bool {
+	if unicode.IsSpace(r) || unicode.Is(unicode.Pd, r) || r == '\u180E' {
+		return true
+	}
+	switch r {
+	case ',', '_', '/', '|', ';', ':', '•', '·':
+		return true
+	default:
+		return false
+	}
+}
+
+// tokenize splits text into lowercase words using seed phrase separators.
 func tokenizeWithSpans(text string) []tokenSpan {
-	sepLocs := separatorRE.FindAllStringIndex(text, -1)
-	tokens := make([]tokenSpan, 0, len(sepLocs)+1)
+	tokens := make([]tokenSpan, 0, 16)
 	start := 0
-	for _, loc := range sepLocs {
-		appendTokenSpan(&tokens, text, start, loc[0])
-		start = loc[1]
+	for i := 0; i < len(text); {
+		r, size := utf8.DecodeRuneInString(text[i:])
+		if isSeedSeparator(r) {
+			appendTokenSpan(&tokens, text, start, i)
+			start = i + size
+		}
+		i += size
 	}
 	appendTokenSpan(&tokens, text, start, len(text))
 	return tokens
@@ -113,7 +141,13 @@ func appendTokenSpan(tokens *[]tokenSpan, text string, start, end int) {
 		return
 	}
 	raw := text[start:end]
-	word := strings.ToLower(strings.TrimSpace(raw))
+	// Canonicalize the token for the wordlist lookup the same way the main DLP
+	// scanner canonicalizes secrets (normalize.ForDLP): strip control/invisible
+	// and exotic-whitespace characters, NFKC-fold compatibility forms (fullwidth),
+	// map cross-script homoglyphs (Cyrillic/Greek lookalikes) to ASCII, and strip
+	// combining marks. This is match-only: the span offsets below still index the
+	// ORIGINAL bytes, so redaction removes the real on-wire characters.
+	word := strings.ToLower(normalize.ForDLP(strings.TrimSpace(raw)))
 	if word == "" {
 		return
 	}

--- a/internal/seedprotect/evasion_test.go
+++ b/internal/seedprotect/evasion_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package seedprotect
+
+import (
+	"strings"
+	"testing"
+)
+
+// These are red-team regression tests for named seed-phrase evasion vectors.
+// Each constructs a phrase that is a valid BIP-39 12-word mnemonic (so the
+// checksum holds once the evasion is normalized away) but disguised with a
+// Unicode trick the detector historically ignored. Before the normalization +
+// separator hardening these all evaded detection; each must now be caught with
+// a valid checksum, proving the evasion was peeled rather than merely tokenized.
+
+// homoglyphFold replaces Latin letters in s with visually identical Cyrillic
+// code points that the normalize package maps back to ASCII. Only letters that
+// have a confirmed lowercase Cyrillic confusable are swapped.
+func homoglyphFold(s string) string {
+	repl := strings.NewReplacer(
+		"a", "а", // а
+		"o", "о", // о
+		"e", "е", // е
+		"c", "с", // с
+		"p", "р", // р
+		"t", "т", // т
+		"x", "х", // х
+		"k", "к", // к
+		"m", "м", // м
+		"y", "у", // у
+	)
+	return repl.Replace(s)
+}
+
+// fullwidthFold maps ASCII letters to their fullwidth (U+FF21..) equivalents,
+// which NFKC folds back to ASCII.
+func fullwidthFold(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r - 'a' + 0xFF41)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r - 'A' + 0xFF21)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// zwsp is a zero-width space (U+200B), built via rune to avoid an invisible
+// literal in source (staticcheck ST1018).
+var zwsp = string(rune(0x200B))
+
+// injectZeroWidth inserts a zero-width space inside every word (after the first
+// rune) without touching separators.
+func injectZeroWidth(phrase string) string {
+	words := strings.Split(phrase, " ")
+	for i, w := range words {
+		rs := []rune(w)
+		if len(rs) > 1 {
+			words[i] = string(rs[:1]) + zwsp + string(rs[1:])
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+func assertDetectedValid(t *testing.T, phrase, vector string) {
+	t.Helper()
+	matches := Detect(phrase, 12, true)
+	if len(matches) == 0 {
+		t.Fatalf("%s: evaded detection entirely (expected a checksum-valid 12-word match)", vector)
+	}
+	for _, m := range matches {
+		if m.WordCount == 12 && m.ChecksumValid {
+			return
+		}
+	}
+	t.Fatalf("%s: detected but no checksum-valid 12-word match: %+v", vector, matches)
+}
+
+func TestEvasion_CyrillicHomoglyph(t *testing.T) {
+	assertDetectedValid(t, homoglyphFold(valid12), "cyrillic-homoglyph")
+}
+
+func TestEvasion_FullwidthChars(t *testing.T) {
+	assertDetectedValid(t, fullwidthFold(valid12), "fullwidth-nfkc")
+}
+
+func TestEvasion_ZeroWidthInsideWords(t *testing.T) {
+	assertDetectedValid(t, injectZeroWidth(valid12), "zero-width-in-word")
+}
+
+func TestEvasion_SeparatorVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		sep  string
+	}{
+		{"non-breaking-space", " "},
+		{"ideographic-space", "　"},
+		{"en-dash", "–"},
+		{"em-dash", "—"},
+		{"figure-dash", "‒"},
+		{"slash", "/"},
+		{"underscore", "_"},
+		{"bullet", "•"},
+		{"middle-dot", "·"},
+		{"narrow-nbsp", " "},
+		{"line-separator", "\u2028"},
+		{"paragraph-separator", "\u2029"},
+		{"next-line", "\u0085"},
+		{"vertical-tab", "\u000B"},
+		{"mongolian-vowel-separator", "\u180E"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			phrase := strings.ReplaceAll(valid12, " ", tc.sep)
+			assertDetectedValid(t, phrase, "separator:"+tc.name)
+		})
+	}
+}
+
+// TestEvasion_CombinedHomoglyphAndSeparator stacks two evasions at once: a
+// homoglyph-folded phrase delimited by non-breaking spaces.
+func TestEvasion_CombinedHomoglyphAndSeparator(t *testing.T) {
+	phrase := strings.ReplaceAll(homoglyphFold(valid12), " ", " ")
+	assertDetectedValid(t, phrase, "combined-homoglyph+nbsp")
+}
+
+// TestEvasionSpans_HomoglyphPreservesOriginalOffsets confirms that normalization
+// is applied to the match decision only — the returned span still indexes the
+// ORIGINAL (evaded) bytes so redaction removes the real characters on the wire.
+func TestEvasionSpans_HomoglyphPreservesOriginalOffsets(t *testing.T) {
+	evaded := homoglyphFold(valid12)
+	text := "leak: " + evaded + " <-"
+	spans := DetectSpans(text, 12, true)
+	if len(spans) == 0 {
+		t.Fatal("expected a span for homoglyph-folded phrase")
+	}
+	got := text[spans[0].Start:spans[0].End]
+	if got != evaded {
+		t.Fatalf("span = %q, want the original evaded phrase %q", got, evaded)
+	}
+}
+
+// TestEvasion_StandaloneInvisibleTokenDropped covers a token that is non-empty
+// in the raw text but normalizes to nothing (a lone zero-width character used
+// as a fake "word" to break the consecutive-BIP-39 run). It must be dropped so
+// the surrounding real words stay contiguous and the phrase is still detected.
+func TestEvasion_StandaloneInvisibleTokenDropped(t *testing.T) {
+	words := strings.Split(valid12, " ")
+	// Splice a standalone zero-width token between word 6 and word 7.
+	injected := strings.Join(words[:6], " ") + " " + zwsp + " " + strings.Join(words[6:], " ")
+	assertDetectedValid(t, injected, "standalone-invisible-token")
+}
+
+// TestEvasion_DotIsNotASeparator pins "." as a field boundary, NOT an
+// intra-phrase separator. The request-body scanner joins distinct JSON field
+// values with "." (proxy.bodyDLPJoinSeparator) so cross-field DLP works without
+// merging tokens; if seedprotect treated "." as a separator it would synthesize
+// a mnemonic across separate fields. A full valid 12-word phrase joined by "."
+// must therefore NOT be detected as one phrase.
+func TestEvasion_DotIsNotASeparator(t *testing.T) {
+	dotted := strings.ReplaceAll(valid12, " ", ".")
+	if matches := Detect(dotted, 12, true); len(matches) != 0 {
+		t.Errorf(`"." must be a field boundary, not a separator; got cross-field match: %+v`, matches)
+	}
+}


### PR DESCRIPTION
## What

Seed-phrase detection lowercased each token and split on an ASCII-only separator set, so several Unicode disguises slipped past it while still pasting into a wallet as a working mnemonic:

- Cross-script homoglyphs (Cyrillic/Greek letters that render identically to Latin)
- NFKC-foldable forms such as fullwidth characters
- Zero-width characters inserted inside words
- Unicode space and dash separators that Go's `\s` and the ASCII hyphen never matched (NBSP, narrow/ideographic spaces, line/paragraph separators, NEL, en/em/figure dashes, Mongolian vowel separator)

## The fix

Each token is now canonicalized through the same normalization the DLP pattern path already applies (strip control/invisible characters, NFKC fold, map cross-script homoglyphs to ASCII, strip combining marks) before the wordlist lookup. Byte offsets are preserved against the original text, so redaction removes the real on-wire characters rather than the normalized form.

Tokenization uses a rune predicate covering the full Unicode whitespace set, the Unicode dash-punctuation category, the Mongolian vowel separator, and the literal `, _ / | ; :` delimiters seen in numbered or bulleted backups.

`.` is not a separator, by design. The request-body scanner joins distinct JSON field values with `.` so cross-field DLP works without merging tokens; treating `.` as intra-phrase here would synthesize a mnemonic across separate fields. A regression on both sides pins this.

## Parity

All three detection surfaces (URL/target scan, text scan, redaction matcher) call the detector, so the fix reaches each one. Tests confirm detection through the live text-scan path and redaction through the matcher, not the detector alone.

## Tests

Red-team regressions written bypass-first: every evasion vector fails on the old code and passes after. Includes a guard that a `.`-joined phrase is not synthesized across fields, and that a lone zero-width token between words is dropped rather than breaking the run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved seed-phrase detection: broader Unicode separator handling, canonical normalization aligned with DLP, preserved original character offsets for accurate redaction, and treating '.' as a field boundary to prevent cross-field matches.

* **Tests**
  * Added regression and parity tests covering homoglyphs, fullwidth/zero-width characters, alternate separators, URL/path-encoded seeds, and other evasion vectors to ensure reliable detection and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->