### PR TITLE
fix(mcp/provenance): domain-separate tool signatures and block duplicate names

### DIFF
--- a/internal/mcp/provenance/failclosed_test.go
+++ b/internal/mcp/provenance/failclosed_test.go
@@ -1,0 +1,240 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package provenance
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+)
+
+func newKeyPair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	return pub, priv
+}
+
+func signOne(t *testing.T, tool ToolDef, priv ed25519.PrivateKey, keyID string) Attestation {
+	t.Helper()
+	atts, err := SignPipelock([]ToolDef{tool}, priv, keyID)
+	if err != nil || len(atts) != 1 {
+		t.Fatalf("SignPipelock: atts=%d err=%v", len(atts), err)
+	}
+	return atts[0]
+}
+
+// TestVerifyPipelock_DomainSeparation proves the signing input is domain-bound:
+// a signature produced over the BARE digest (the pre-hardening scheme, and the
+// shape any other same-key SHA-256 signer would emit) must NOT verify under the
+// context-bound scheme. This closes cross-protocol signature replay.
+func TestVerifyPipelock_DomainSeparation(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	tool := ToolDef{Name: "send", Description: "send mail", InputSchema: []byte(`{"type":"object"}`)}
+	att := signOne(t, tool, priv, "k1")
+
+	// Context-bound signature verifies.
+	ok, err := VerifyPipelock(att, pub)
+	if err != nil || !ok {
+		t.Fatalf("context-bound signature must verify: ok=%v err=%v", ok, err)
+	}
+
+	// A signature over the bare digest (no context prefix) must be rejected.
+	bareSig := ed25519.Sign(priv, []byte(att.Digest.SHA256))
+	forged := att
+	forged.Bundle = base64.StdEncoding.EncodeToString(bareSig)
+	ok, err = VerifyPipelock(forged, pub)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("bare-digest signature must NOT verify under domain-separated scheme (replay vector open)")
+	}
+}
+
+// TestVerifyTool_FailClosed exercises every non-verified outcome of VerifyTool.
+// Each disguised/misconfigured input must yield Error or Failed, never Verified.
+func TestVerifyTool_FailClosed(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	keyID := "k1"
+	tool := ToolDef{Name: "exec", Description: "run a command", InputSchema: []byte(`{"type":"object"}`)}
+	good := signOne(t, tool, priv, keyID)
+	keys := map[string]ed25519.PublicKey{keyID: pub}
+
+	t.Run("happy path verifies", func(t *testing.T) {
+		r := VerifyTool(tool, good, VerifyConfig{TrustedKeys: keys, Mode: ModePipelock})
+		if r.Status != StatusVerified {
+			t.Fatalf("status=%q detail=%q, want verified", r.Status, r.Detail)
+		}
+	})
+	t.Run("mode mismatch blocks", func(t *testing.T) {
+		att := good
+		att.Mode = ModeSigstore
+		r := VerifyTool(tool, att, VerifyConfig{TrustedKeys: keys, Mode: ModePipelock})
+		if r.Status != StatusError {
+			t.Fatalf("status=%q, want error", r.Status)
+		}
+	})
+	t.Run("digest tamper fails", func(t *testing.T) {
+		tampered := ToolDef{Name: "exec", Description: "run a DIFFERENT command", InputSchema: tool.InputSchema}
+		r := VerifyTool(tampered, good, VerifyConfig{TrustedKeys: keys, Mode: ModePipelock})
+		if r.Status != StatusFailed {
+			t.Fatalf("status=%q, want failed", r.Status)
+		}
+	})
+	t.Run("sigstore offline blocks", func(t *testing.T) {
+		att := signOne(t, tool, priv, keyID)
+		att.Mode = ModeSigstore
+		// Recompute is unnecessary: digest still matches; mode switch path is the target.
+		r := VerifyTool(tool, att, VerifyConfig{TrustedKeys: keys, Mode: "any", OfflineOnly: true})
+		if r.Status != StatusError {
+			t.Fatalf("status=%q, want error", r.Status)
+		}
+	})
+	t.Run("sigstore online not implemented blocks", func(t *testing.T) {
+		att := signOne(t, tool, priv, keyID)
+		att.Mode = ModeSigstore
+		r := VerifyTool(tool, att, VerifyConfig{TrustedKeys: keys, Mode: "any", OfflineOnly: false})
+		if r.Status != StatusError {
+			t.Fatalf("status=%q, want error", r.Status)
+		}
+	})
+	t.Run("unknown mode blocks", func(t *testing.T) {
+		att := signOne(t, tool, priv, keyID)
+		att.Mode = "frobnicate"
+		r := VerifyTool(tool, att, VerifyConfig{TrustedKeys: keys, Mode: "any"})
+		if r.Status != StatusError {
+			t.Fatalf("status=%q, want error", r.Status)
+		}
+	})
+	t.Run("no trusted keys blocks", func(t *testing.T) {
+		r := VerifyTool(tool, good, VerifyConfig{Mode: ModePipelock})
+		if r.Status != StatusError {
+			t.Fatalf("status=%q, want error", r.Status)
+		}
+	})
+	t.Run("wrong key fails", func(t *testing.T) {
+		otherPub, _ := newKeyPair(t)
+		r := VerifyTool(tool, good, VerifyConfig{TrustedKeys: map[string]ed25519.PublicKey{keyID: otherPub}, Mode: ModePipelock})
+		if r.Status != StatusFailed {
+			t.Fatalf("status=%q, want failed", r.Status)
+		}
+	})
+}
+
+// TestShouldBlock_FailClosed locks the block-decision matrix, including the
+// unknown-action fail-closed default.
+func TestShouldBlock_FailClosed(t *testing.T) {
+	cases := []struct {
+		name      string
+		results   []VerificationResult
+		action    string
+		wantBlock bool
+		wantErr   bool
+	}{
+		{"unknown action fails closed", []VerificationResult{{Status: StatusVerified}}, "frobnicate", true, true},
+		{"failed always blocks even on allow", []VerificationResult{{Status: StatusFailed}}, "allow", true, true},
+		{"error always blocks even on warn", []VerificationResult{{Status: StatusError}}, "warn", true, true},
+		{"unsigned blocks on block", []VerificationResult{{Status: StatusUnsigned}}, "block", true, true},
+		{"unsigned allowed on warn", []VerificationResult{{Status: StatusUnsigned}}, "warn", false, false},
+		{"unsigned allowed on allow", []VerificationResult{{Status: StatusUnsigned}}, "allow", false, false},
+		{"verified does not block", []VerificationResult{{Status: StatusVerified}}, "block", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			block, err := ShouldBlock(tc.results, tc.action)
+			if block != tc.wantBlock {
+				t.Errorf("block=%v, want %v", block, tc.wantBlock)
+			}
+			if (err != nil) != tc.wantErr {
+				t.Errorf("err=%v, wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestVerifyToolsList_FailClosed covers the response-level structural attacks:
+// duplicate names, malformed provenance, and unparseable tools all become
+// Error (block), while a genuinely unsigned tool is distinguished as Unsigned.
+func TestVerifyToolsList_FailClosed(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	keyID := "k1"
+	keys := map[string]ed25519.PublicKey{keyID: pub}
+	cfg := VerifyConfig{TrustedKeys: keys, Mode: ModePipelock}
+
+	statusFor := func(t *testing.T, response []byte, toolName string) string {
+		t.Helper()
+		results, err := VerifyToolsList(response, cfg)
+		if err != nil {
+			t.Fatalf("VerifyToolsList error: %v", err)
+		}
+		for _, r := range results {
+			if r.ToolName == toolName {
+				return r.Status
+			}
+		}
+		t.Fatalf("no result for %q in %+v", toolName, results)
+		return ""
+	}
+
+	t.Run("verified end to end", func(t *testing.T) {
+		raw := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"t","description":"d","inputSchema":{"type":"object"}}]}}`)
+		att := signOne(t, ToolDef{Name: "t", Description: "d", InputSchema: []byte(`{"type":"object"}`)}, priv, keyID)
+		embedded, err := EmbedInToolsList(raw, []Attestation{att})
+		if err != nil {
+			t.Fatalf("embed: %v", err)
+		}
+		if got := statusFor(t, embedded, "t"); got != StatusVerified {
+			t.Fatalf("status=%q, want verified", got)
+		}
+	})
+	t.Run("unsigned tool distinguished", func(t *testing.T) {
+		raw := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"plain","description":"d","inputSchema":{}}]}}`)
+		if got := statusFor(t, raw, "plain"); got != StatusUnsigned {
+			t.Fatalf("status=%q, want unsigned", got)
+		}
+	})
+	t.Run("duplicate tool names block", func(t *testing.T) {
+		raw := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"dup","description":"a","inputSchema":{}},{"name":"dup","description":"b","inputSchema":{}}]}}`)
+		att1 := signOne(t, ToolDef{Name: "dup", Description: "a", InputSchema: []byte(`{}`)}, priv, keyID)
+		att2 := signOne(t, ToolDef{Name: "dup", Description: "b", InputSchema: []byte(`{}`)}, priv, keyID)
+		embedded, err := EmbedInToolsList(raw, []Attestation{att1, att2})
+		if err != nil {
+			t.Fatalf("embed: %v", err)
+		}
+		if got := statusFor(t, embedded, "dup"); got != StatusError {
+			t.Fatalf("status=%q, want error", got)
+		}
+	})
+	t.Run("unsigned duplicate tool names block", func(t *testing.T) {
+		raw := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"dup","description":"a","inputSchema":{}},{"name":"dup","description":"b","inputSchema":{}}]}}`)
+		if got := statusFor(t, raw, "dup"); got != StatusError {
+			t.Fatalf("status=%q, want error", got)
+		}
+	})
+	t.Run("malformed provenance is error not unsigned", func(t *testing.T) {
+		raw := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"m","description":"d","inputSchema":{},"_meta":{"com.pipelock/provenance":"not-an-object"}}]}}`)
+		if got := statusFor(t, raw, "m"); got != StatusError {
+			t.Fatalf("status=%q, want error (must not soften to unsigned)", got)
+		}
+	})
+	t.Run("unparseable tool entry blocks", func(t *testing.T) {
+		raw := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":["not-an-object"]}}`)
+		results, err := VerifyToolsList(raw, cfg)
+		if err != nil {
+			t.Fatalf("VerifyToolsList error: %v", err)
+		}
+		if len(results) != 1 || results[0].Status != StatusError {
+			t.Fatalf("results=%+v, want single error", results)
+		}
+	})
+	t.Run("whole response unparseable errors", func(t *testing.T) {
+		if _, err := VerifyToolsList([]byte(`{not json`), cfg); err == nil {
+			t.Fatal("expected error on unparseable response (caller fails closed)")
+		}
+	})
+}

--- a/internal/mcp/provenance/provenance.go
+++ b/internal/mcp/provenance/provenance.go
@@ -232,13 +232,19 @@ func VerifyToolsList(response []byte, cfg VerifyConfig) ([]VerificationResult, e
 		malformedSet[name] = true
 	}
 
-	// Build attestation index, rejecting duplicate tool names.
-	attByName := make(map[string]Attestation, len(extraction.Attestations))
-	duplicates := make(map[string]bool)
-	for _, ta := range extraction.Attestations {
-		if _, exists := attByName[ta.ToolName]; exists {
-			duplicates[ta.ToolName] = true
+	// Build tool-name counts from the response itself. Duplicate names are
+	// ambiguous regardless of whether either entry carries provenance.
+	nameCounts := make(map[string]int, len(rpc.Result.Tools))
+	for _, raw := range rpc.Result.Tools {
+		var tool toolWithMeta
+		if err := json.Unmarshal(raw, &tool); err == nil {
+			nameCounts[tool.Name]++
 		}
+	}
+
+	// Build attestation index.
+	attByName := make(map[string]Attestation, len(extraction.Attestations))
+	for _, ta := range extraction.Attestations {
 		attByName[ta.ToolName] = ta.Attestation
 	}
 
@@ -255,7 +261,7 @@ func VerifyToolsList(response []byte, cfg VerifyConfig) ([]VerificationResult, e
 		}
 
 		// Duplicate tool names are ambiguous and unsafe.
-		if duplicates[tool.Name] {
+		if nameCounts[tool.Name] > 1 {
 			results = append(results, VerificationResult{
 				ToolName: tool.Name,
 				Status:   StatusError,

--- a/internal/mcp/provenance/sign.go
+++ b/internal/mcp/provenance/sign.go
@@ -125,6 +125,20 @@ func sortAndMarshal(v interface{}) interface{} {
 	}
 }
 
+// provenanceSigContext domain-separates pipelock-mode signatures. The signed
+// bytes are this context string followed by the tool digest, so a signature
+// produced here can never be replayed as evidence in another context that
+// signs a SHA-256 hex string with the same key (the JWT-style cross-protocol
+// reuse problem). The ":" delimiter is unambiguous because the digest is hex.
+// The "/v1" segment versions the scheme for future agility.
+const provenanceSigContext = "pipelock/provenance/v1:"
+
+// pipelockSigningInput returns the domain-separated bytes signed and verified
+// for a pipelock-mode attestation over the given tool digest.
+func pipelockSigningInput(digest string) []byte {
+	return []byte(provenanceSigContext + digest)
+}
+
 // SignPipelock signs tool definitions with an Ed25519 private key (offline, no network).
 // keyID identifies the signing key (typically the encoded public key or a fingerprint).
 // Returns one Attestation per tool.
@@ -140,8 +154,8 @@ func SignPipelock(tools []ToolDef, privKey ed25519.PrivateKey, keyID string) ([]
 			return nil, fmt.Errorf("failed to compute digest for tool %q", tool.Name)
 		}
 
-		// Sign the hex-encoded digest bytes.
-		sig := ed25519.Sign(privKey, []byte(digest))
+		// Sign the domain-separated digest (context-bound, see provenanceSigContext).
+		sig := ed25519.Sign(privKey, pipelockSigningInput(digest))
 		bundle := base64.StdEncoding.EncodeToString(sig)
 
 		attestations = append(attestations, Attestation{
@@ -177,7 +191,7 @@ func VerifyPipelock(att Attestation, pubKey ed25519.PublicKey) (bool, error) {
 		return false, errors.New("invalid Ed25519 public key size")
 	}
 
-	return ed25519.Verify(pubKey, []byte(att.Digest.SHA256), sig), nil
+	return ed25519.Verify(pubKey, pipelockSigningInput(att.Digest.SHA256), sig), nil
 }
 
 // SignSigstore signs tool definitions via Sigstore keyless signing.


### PR DESCRIPTION
## Domain separation

Pipelock-mode provenance signed the bare tool digest. A signature over a SHA-256 hex string is reusable in any other context that signs the same shape with the same key, the classic algorithm-confusion / cross-protocol reuse problem. The signed bytes are now bound to a versioned context (`pipelock/provenance/v1:` + digest) in both signing and verification, so a bare-digest signature no longer verifies.

This changes the signing format. Attestations are ephemeral: they are regenerated per `tools/list` response at proxy time and carry no stored or distributed corpus, so the change touches no persisted artifact.

## Duplicate tool names

Duplicate detection only covered tools that carried an attestation. Two tools sharing a name with no provenance took the softer "unsigned" path, so an ambiguous tool set could pass when the configured unsigned action was warn or allow. Duplicate names are now counted from the `tools/list` response itself and blocked regardless of provenance.

## Fail-closed coverage

Added a fail-closed audit suite for the verification decision logic, which had no direct tests before: mode mismatch, digest tamper, sigstore offline and not-implemented, unknown mode, missing or wrong key, the unknown-action default, and the duplicate / malformed / unparseable response cases. Each disguised or misconfigured input resolves to block, never allow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests covering signature domain separation, fail-closed verification behavior across many scenarios, and handling of malformed or ambiguous tool listings.

* **Bug Fixes**
  * Improved duplicate-tool detection so ambiguous/duplicate tool entries are consistently identified and rejected.

* **Chores**
  * Strengthened signature domain separation to make verification more robust and secure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->