### PR TITLE
feat(aarp): AARP v0.1 assurance envelope core

### DIFF
--- a/docs/specs/aarp-v0.1-envelope.md
+++ b/docs/specs/aarp-v0.1-envelope.md
@@ -1,0 +1,306 @@
+# AARP v0.1 — Assurance Envelope and Appraisal Profile
+
+> **Status:** Experimental. Pipelock owns the `aarp/v0.1` profile namespace.
+> **Implementation:** `internal/aarp/` (Go reference verifier and signer).
+> **Depends on:** the shipped RFC 8785 JCS canonicalization (`internal/contract`)
+> and the offline X.509-SVID substrate (`internal/svid`).
+> **Companion docs:** [in-toto agent-action-receipt v0.1](./in-toto-agent-action-receipt-v0.1.md),
+> [receipt prior-art mapping](./receipt-prior-art-mapping.md).
+
+## What AARP is
+
+AARP — Agent Action Receipt Profile — is **not a new receipt format**. It is an
+*appraisal profile*: a separate, independently-signed assurance artifact that
+sits **alongside** a frozen pipelock receipt and reports exactly what a verifier
+could cryptographically confirm versus what the producer merely claimed.
+
+The shipped receipts stay byte-for-byte frozen. AARP references them by digest
+and never rewrites them:
+
+| Receipt | Wire format | AARP relationship |
+|---|---|---|
+| **ActionReceipt v1** | flat JSON, Ed25519 over `SHA-256` of canonical bytes | immutable subject, referenced by digest |
+| **EvidenceReceipt v2** | typed payloads, RFC 8785 JCS | immutable subject, referenced by digest |
+
+The AARP verifier **never emits a `trusted` or `safe` verdict.** It emits a
+structured appraisal: verified claims grouped by axis, the producer's
+claimed-but-unverified set, and an explicit `does_not_assert` list.
+
+## Core principle: validity is not assurance
+
+A valid signature proves record integrity — these bytes were signed by this key
+and not altered. It proves nothing about whether the decision was correct,
+whether anything bypassed the mediator, or whether the receipt is the whole
+story. AARP's job is to make that distinction machine-readable.
+
+## The envelope
+
+```jsonc
+{
+  "profile": "aarp/v0.1",
+  "subject": {
+    "action_record_sha256": "<64 lowercase hex>",
+    "receipt_envelope_sha256": "<64 lowercase hex>",
+    "receipt_signer_key": "<64 lowercase hex; the receipt's Ed25519 public key>",
+    "receipt_type": "action_receipt_v1 | evidence_receipt_v2"
+  },
+  "assertion": {
+    "claimed": ["mediated", "complete-mediation"],
+    "mediator_id": "pipelock-prod-1",
+    "trust_domain": "example.org",
+    "complete_mediation": true,
+    "evidence_refs": ["spiffe_svid"],
+    "issued_at": "2026-06-01T00:00:00Z"
+  },
+  "chain": {
+    "issuer_id": "issuer-1",
+    "seq": "42",
+    "prior_hash": "<64 lowercase hex of the previous link's payload digest>"
+  },
+  "signatures": [
+    {
+      "protected": {
+        "profile": "aarp/v0.1",
+        "canon": "jcs-rfc8785-nfc",
+        "alg": "ed25519",
+        "key_type": "ed25519",
+        "key_id": "mediator-key-1",
+        "signer_role": "mediator",
+        "crit": []
+      },
+      "sig": "ed25519:<base64-std>"
+    }
+  ],
+  "crit_ext": [],
+  "ext": {}
+}
+```
+
+### Signed payload
+
+Every signature covers the **canonical payload**: the JCS bytes of
+`{profile, subject, assertion, crit_ext, chain}`. `crit_ext` is signed so a
+man-in-the-middle cannot strip a critical extension a producer flagged.
+Signatures never cover `signatures` (signatures do not sign each other) or `ext`
+(non-critical extensions are advisory and ignored safely). The canonical payload
+digest (lowercase-hex `SHA-256` of the canonical bytes) is the single value all
+parallel signatures bind, and is the value the SVID attestation binding
+references as `assurance_assertion_sha256`.
+
+### Signing input (domain separation)
+
+Each signature signs the JCS canonicalization of:
+
+```jsonc
+{
+  "context": "pipelock-aarp-v0.1/assurance-assertion",
+  "payload_sha256": "<canonical payload digest>",
+  "protected": { /* that signature's protected suite header */ }
+}
+```
+
+The `context` is a **signed field**, never a sibling label — real cryptographic
+domain separation. String concatenation is never used to form a signing input.
+Embedding the `protected` header in the signing input means each signature
+commits to its own suite, which defeats algorithm substitution; binding the
+shared `payload_sha256` means all signatures cover **identical payload bytes**.
+
+## Authenticated agility: the protected suite
+
+The `protected` header is the signature's agility descriptor, and it is covered
+by the signature. It carries the profile version, canonicalization id,
+algorithm, key type, key id, signer role, and the critical-extension list.
+
+**Fail-closed rule:** an unknown `signature_suite` (unrecognized algorithm,
+profile, or canonicalization) never verifies and is **never downgraded** to
+verification under a different suite. There is no fallback. A signature under an
+unknown suite is reported `unknown_suite`; one under a recognized-but-
+unimplemented suite (the post-quantum slot) is reported `unimplemented`. Neither
+ever counts as a verified signature.
+
+## Parallel multi-signature
+
+The envelope holds **N parallel protected signatures over identical canonical
+payload bytes**. They are parallel — each independently binds the same payload
+digest under its own suite — **not chained** over one another. Countersignature
+(continuity over a prior signature) is a deliberately distinct, separately-typed
+construct and is not mixed into the parallel set.
+
+v0.1 ships **Ed25519** as the default and only implemented suite. The
+**ML-DSA-65** post-quantum slot is typed and structurally first-class: a hybrid
+(`ed25519` + `ml-dsa-65`) or PQ-only envelope is a valid shape today, and adding
+a PQ signature slot requires **no format bump**. The PQ signer/verifier is
+deferred until FIPS 204 / ML-DSA errata settle; until then a PQ signature is
+reported `unimplemented`, never verified.
+
+## JCS number safety
+
+JSON numbers are interoperable across language verifiers only inside the I-JSON
+safe-integer range `[-(2^53-1), 2^53-1]`. Outside it, a JavaScript (or other)
+verifier silently rounds to the nearest `float64`, which changes the canonical
+bytes and breaks the signature.
+
+AARP therefore:
+
+- allows raw JSON numbers **only** inside the I-JSON safe-integer range;
+- forbids floats, exponent form, and negative zero outright;
+- requires every identity, digest, counter, nanosecond-timestamp, and amount
+  field to be a **typed string** with an explicit grammar:
+  - digest / key: exactly 64 lowercase hex characters;
+  - counter / sequence / ns-timestamp: unsigned decimal, no leading zeros,
+    within `uint64`;
+  - amount: fixed-point decimal, optional minus, no leading/trailing zeros, no
+    exponent, no negative zero;
+  - time: RFC 3339 with a mandatory zone (`RFC3339Nano`).
+
+A raw JSON number outside the safe range, anywhere in the envelope, is rejected
+at decode. The same value as the typed-string grammar verifies identically
+across every conforming verifier.
+
+## Schema, extensions, and exact digest targeting
+
+- **Strict decode.** Duplicate object keys are rejected at the raw-JSON layer at
+  any nesting depth (parser-differential smuggling guard). Unknown fields in
+  AARP-controlled objects are rejected — unlike legacy v1 receipt objects, where
+  unknown fields are ignored for backward compatibility and never counted as
+  signed.
+- **Extension governance.** `crit` (per signature) and `crit_ext` (envelope)
+  list critical-extension names the verifier **must** understand. An unknown
+  critical extension rejects the whole envelope, fail-closed: a producer that
+  flags something critical is asserting it must be processed, and a verifier that
+  cannot process it cannot safely appraise the envelope. Unknown **non-critical**
+  extensions (`ext`) are ignored safely and are not part of the signed payload.
+- **Exact digest targeting.** `subject.receipt_type` names which frozen receipt
+  format the digests target (`action_record_sha256` is the v1 canonical
+  ActionRecord digest or the v2 EvidenceReceipt signable-preimage digest, per
+  type). Every digest is a named, typed-string field — never an ambiguous "hash
+  of the thing".
+
+## Rung-1 timestamp trust: the chain primitive
+
+The optional `chain` object places an envelope in an issuer's append-only,
+hash-linked stream. It is **issuer-agnostic**: any issuer that maintains a
+monotonic `seq` and links each receipt's payload digest to the prior one
+(`prior_hash`) gets backdating detection, with no dependency on a specific
+issuer deployment.
+
+Because the chain link is part of the signed payload, `seq` and `prior_hash`
+cannot be altered after signing. A verifier checking a stream confirms a single
+issuer, a sequence incrementing by exactly one, and each link's `prior_hash`
+equal to the previous envelope's payload digest. Inserting, reordering, or
+backdating a receipt within the stream breaks the linkage and the signature, and
+is detected. The genesis link carries `seq` `"0"` and the all-zero `prior_hash`.
+
+## Key-time evidence
+
+A verified `mediated` claim binds a signing key to an **authority namespace**,
+never to a bare key: it requires a verifier-side trust entry naming the mediator
+identity (and, when set, the signer role and trust domain) that the verifying
+signature's key id matches. An attacker self-signing with `signer_role=mediator`
+and no matching trust entry gets `mediated` reported claim-only.
+
+Revocation status is **snapshotted at signing time** and is a distinct, additive
+artifact from any later-compromise evidence; a verifier never re-fetches live
+material to reinterpret an old receipt. (The signing-time SVID snapshot lands
+with the attestation binding.)
+
+## Appraisal vocabulary
+
+The verifier reports claims grouped by axis — `identity`, `authority`,
+`integrity`, `freshness`, `transparency`, `deployment` — never a single linear
+trust score, because the axes rest on orthogonal kinds of proof. "An appraisal
+was made" never implies "action allowed", "policy passed", or "human approved".
+
+The fixed `does_not_assert` list is reported verbatim on every appraisal:
+`efficacy`, `absence_of_bypass`, `complete_mediation`, `policy_correctness`,
+`action_safety`. `complete_mediation` is **always** claim-only in v0.1: there is
+no local evidence that proves the absence of an out-of-band path.
+
+## Not externally registry-verifiable by default
+
+The default `aarp/v0.1` receipt is JCS + Ed25519 and is independently verifiable
+by the AARP verifier offline. It is **deliberately not** verifiable by external
+registry-based runtime-control or audit standards by default: those registries
+do not bless Ed25519. Interop with such a standard is delivered, if and when
+needed, by a derivative **external-audit projection** — and a projection is a
+*lossy export of a stronger source*, never the source receipt itself:
+
+> AARP core receipts are independently verifiable but are not, by default,
+> verifiable under external registry-based audit standards. An external-audit
+> projection is a derivative export, not the source receipt.
+
+## v1 permanence
+
+v1 receipt verification is **permanent product surface**. The v1 fields, its
+`json.Marshal` canonicalization, and its Ed25519-over-SHA-256 signing are frozen
+forever, with published test vectors. AARP may optionally countersign an old v1
+receipt over the v1 receipt hash to add continuity, but it must **never** mutate
+or reinterpret v1 evidence.
+
+## Designed, not yet implemented
+
+These slots are designed here so they drop in additively with no breaking
+migration. Their implementations are gated on external foundations.
+
+### External-audit projection + anti-laundering invariants
+
+A projection re-expresses an AARP appraisal for a consumer of an external
+runtime-control or audit standard. The **format must carry**, and a verifier
+must enforce:
+
+- the **source canonical payload hash** (binds the projection to one receipt);
+- the source profile + version, and the source signature reference (key id +
+  alg) it derives from;
+- the projection **mapping version** and **projection issuer**, and a timestamp;
+- an explicit list of **dropped, narrowed, and renamed** fields.
+
+**Anti-laundering invariant:** a projected claim may **never** be stronger than
+its source claim. A projection that asserts a claim the source reported
+claim-only, or that drops the `does_not_assert` list, is invalid. Concrete
+field mappings to specific external standards are defined only once those
+standards publish a stable, testable version with a conformance story; the
+projection format and the anti-laundering invariants above are fixed now and are
+standard-agnostic.
+
+### Rung-2 external TSA slot
+
+An RFC 3161 Trusted Timestamping Authority token may be stapled to an envelope
+under a non-critical extension, with the TSA certificate bundled for offline
+verification. The slot is config-wired; the TSA is operated by an external party
+(no infrastructure for pipelock). Implementation may land later.
+
+### Rung-3 transparency log
+
+Self-hosted transparency log / SCITT / Rekor verification stays v0.2+ and
+document-only. The `transparency` axis is claim-only in v0.1. Pipelock does not
+operate a log.
+
+## Verifier result contract
+
+```jsonc
+{
+  "profile": "aarp/v0.1",
+  "assertion_signed": true,
+  "signatures": [ { "key_id": "...", "alg": "ed25519", "signer_role": "mediator", "status": "verified" } ],
+  "assurance_claimed": ["mediated", "complete-mediation"],
+  "verified_claims": ["assertion_signature_valid", "mediator_key_pinned"],
+  "claimed_unverified": ["complete-mediation"],
+  "axes": {
+    "identity": ["mediator_key_pinned"],
+    "integrity": ["assertion_signature_valid"]
+  },
+  "does_not_assert": ["efficacy", "absence_of_bypass", "complete_mediation", "policy_correctness", "action_safety"],
+  "warnings": []
+}
+```
+
+`assertion_signed` is the single cryptographic gate: true only when at least one
+parallel signature verified under a trusted key. A relying party applies its own
+claim policy to `verified_claims` and `axes`. There is no global threshold and
+no `trusted`/`safe` field.
+
+## Governance
+
+Pipelock maintains `aarp/v0.x` as an open implementation profile; governance can
+move once independent implementers exist. No foundation cosplay, no self-run
+transparency log, no certification mark.

--- a/docs/specs/aarp-v0.1-envelope.md
+++ b/docs/specs/aarp-v0.1-envelope.md
@@ -11,7 +11,7 @@
 
 AARP — Agent Action Receipt Profile — is **not a new receipt format**. It is an
 *appraisal profile*: a separate, independently-signed assurance artifact that
-sits **alongside** a frozen pipelock receipt and reports exactly what a verifier
+sits **alongside** a frozen Pipelock receipt and reports exactly what a verifier
 could cryptographically confirm versus what the producer merely claimed.
 
 The shipped receipts stay byte-for-byte frozen. AARP references them by digest
@@ -165,11 +165,19 @@ across every conforming verifier.
   unknown fields are ignored for backward compatibility and never counted as
   signed.
 - **Extension governance.** `crit` (per signature) and `crit_ext` (envelope)
-  list critical-extension names the verifier **must** understand. An unknown
-  critical extension rejects the whole envelope, fail-closed: a producer that
-  flags something critical is asserting it must be processed, and a verifier that
-  cannot process it cannot safely appraise the envelope. Unknown **non-critical**
-  extensions (`ext`) are ignored safely and are not part of the signed payload.
+  list critical-extension names the verifier **must** understand; an unknown one
+  fails closed. The *scope* of that failure follows what is signed. A per-
+  signature `crit` lives in one signature's protected header, and the signatures
+  array is not itself signed (it is appendable), so an unknown per-signature
+  `crit` makes only **that signature** unverifiable (`unknown_suite`) — it never
+  rejects an envelope that also carries a verifiable signature, so an appended
+  junk signature cannot deny a valid receipt. An unknown **envelope-level**
+  `crit_ext` is part of the signed payload (an attacker cannot append it without
+  breaking every signature), so it **rejects the whole envelope**. The same scope
+  rule applies to a signature's protected `profile`/`canon`: a mismatch is
+  per-signature `unknown_suite`, while the signed top-level `profile` is
+  envelope-fatal. Unknown **non-critical** extensions (`ext`) are ignored safely
+  and are not part of the signed payload.
 - **Exact digest targeting.** `subject.receipt_type` names which frozen receipt
   format the digests target (`action_record_sha256` is the v1 canonical
   ActionRecord digest or the v2 EvidenceReceipt signable-preimage digest, per
@@ -213,8 +221,14 @@ was made" never implies "action allowed", "policy passed", or "human approved".
 
 The fixed `does_not_assert` list is reported verbatim on every appraisal:
 `efficacy`, `absence_of_bypass`, `complete_mediation`, `policy_correctness`,
-`action_safety`. `complete_mediation` is **always** claim-only in v0.1: there is
+`action_safety`. Complete mediation is **always** claim-only in v0.1: there is
 no local evidence that proves the absence of an out-of-band path.
+
+Token spelling, to avoid confusion: the producer claim string placed in
+`assertion.claimed` is the hyphenated `complete-mediation`; the snake_case
+`complete_mediation` is the boolean field on the assertion and the entry in
+`does_not_assert`. All forms are claim-only; the verifier never moves complete
+mediation into `verified_claims`.
 
 ## Not externally registry-verifiable by default
 
@@ -267,7 +281,7 @@ standard-agnostic.
 An RFC 3161 Trusted Timestamping Authority token may be stapled to an envelope
 under a non-critical extension, with the TSA certificate bundled for offline
 verification. The slot is config-wired; the TSA is operated by an external party
-(no infrastructure for pipelock). Implementation may land later.
+(no infrastructure for Pipelock). Implementation may land later.
 
 ### Rung-3 transparency log
 

--- a/internal/aarp/aarp_test.go
+++ b/internal/aarp/aarp_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"strings"
+	"testing"
+)
+
+const (
+	testMediatorID  = "pipelock-prod-1"
+	testTrustDomain = "example.org"
+	testIssuedAt    = "2026-06-01T00:00:00Z"
+	testKeyID       = "mediator-key-1"
+)
+
+// digest64 returns a deterministic 64-hex string from a single seed byte, for
+// subject fields where the exact value is irrelevant to the test.
+func digest64(seed byte) string {
+	return strings.Repeat(string("0123456789abcdef"[seed%16]), 64)
+}
+
+// genKey returns a fresh Ed25519 keypair.
+func genKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return pub, priv
+}
+
+// baseEnvelope returns a structurally valid, unsigned envelope.
+func baseEnvelope() Envelope {
+	return Envelope{
+		Profile: Profile,
+		Subject: Subject{
+			ActionRecordSHA256:    digest64(1),
+			ReceiptEnvelopeSHA256: digest64(2),
+			ReceiptSignerKey:      digest64(3),
+			ReceiptType:           ReceiptTypeActionV1,
+		},
+		Assertion: Assertion{
+			Claimed:           []string{"mediated", "complete-mediation"},
+			MediatorID:        testMediatorID,
+			TrustDomain:       testTrustDomain,
+			CompleteMediation: true,
+			IssuedAt:          testIssuedAt,
+		},
+	}
+}
+
+// signedEnvelopeWithKey signs a base envelope with one Ed25519 mediator key and
+// returns the envelope plus that key's public half so tests can build their own
+// verify options.
+func signedEnvelopeWithKey(t *testing.T) (Envelope, ed25519.PublicKey) {
+	t.Helper()
+	pub, priv := genKey(t)
+	signer, err := NewEd25519Signer(testKeyID, "mediator", priv)
+	if err != nil {
+		t.Fatalf("NewEd25519Signer: %v", err)
+	}
+	env, err := Sign(baseEnvelope(), signer)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	return env, pub
+}
+
+// signedEnvelope returns a base envelope signed by one Ed25519 mediator key,
+// plus verify options trusting that key with a matching mediator trust entry.
+func signedEnvelope(t *testing.T) (Envelope, VerifyOptions) {
+	t.Helper()
+	env, pub := signedEnvelopeWithKey(t)
+	opts := VerifyOptions{
+		TrustedKeys: map[string]ed25519.PublicKey{testKeyID: pub},
+		Trust: map[string]TrustEntry{
+			testKeyID: {MediatorID: testMediatorID, Role: "mediator", TrustDomain: testTrustDomain},
+		},
+	}
+	return env, opts
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/aarp/appraise.go
+++ b/internal/aarp/appraise.go
@@ -25,9 +25,13 @@ const (
 	// ClaimMediatorKeyPinned: a verifying signature's key id is bound by a
 	// verifier-side trust entry to the asserted mediator identity (and role).
 	ClaimMediatorKeyPinned = "mediator_key_pinned"
-	// ClaimChainLinked: the envelope carries a well-formed Rung-1 chain link.
-	// Full stream linkage is confirmed by VerifyChain over the stream.
-	ClaimChainLinked = "chain_linked"
+	// ClaimChainLinkPresent: the envelope carries a signed, well-formed Rung-1
+	// chain link (a position in an issuer's stream). It does NOT assert that the
+	// stream is contiguous or untampered — single-envelope appraisal cannot prove
+	// that; contiguous-stream linkage is confirmed only by VerifyChain over the
+	// stream. The name says "present", not "linked/verified", to avoid implying a
+	// continuity guarantee a single envelope cannot give.
+	ClaimChainLinkPresent = "chain_link_present"
 )
 
 // docsNotAsserted is the fixed set of properties an AARP appraisal never

--- a/internal/aarp/appraise.go
+++ b/internal/aarp/appraise.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+// Axis names group verified claims by the kind of proof they rest on.
+// Transparency and attestation are orthogonal kinds of evidence; a linear trust
+// score would lie by collapsing them, so AARP reports claims per axis instead.
+const (
+	AxisIdentity     = "identity"
+	AxisAuthority    = "authority"
+	AxisIntegrity    = "integrity"
+	AxisFreshness    = "freshness"
+	AxisTransparency = "transparency"
+	AxisDeployment   = "deployment"
+)
+
+// Verified-claim names. A claim appears in Appraisal.VerifiedClaims only when
+// the verifier independently confirmed it; otherwise the producer's claim is
+// reported as claimed-but-unverified.
+const (
+	// ClaimAssertionSignatureValid: at least one parallel signature verified
+	// under a trusted key over the canonical assertion payload.
+	ClaimAssertionSignatureValid = "assertion_signature_valid"
+	// ClaimMediatorKeyPinned: a verifying signature's key id is bound by a
+	// verifier-side trust entry to the asserted mediator identity (and role).
+	ClaimMediatorKeyPinned = "mediator_key_pinned"
+	// ClaimChainLinked: the envelope carries a well-formed Rung-1 chain link.
+	// Full stream linkage is confirmed by VerifyChain over the stream.
+	ClaimChainLinked = "chain_linked"
+)
+
+// docsNotAsserted is the fixed set of properties an AARP appraisal never
+// asserts, regardless of which claims verified. It is reported verbatim so a
+// relying party can never read more into a receipt than it proves.
+var docsNotAsserted = []string{
+	"efficacy",
+	"absence_of_bypass",
+	"complete_mediation",
+	"policy_correctness",
+	"action_safety",
+}
+
+// SignatureStatus is the per-signature appraisal outcome. Only SigVerified
+// counts toward a confirmed claim; every other status leaves the signature
+// unverified, never "trusted by fallback".
+type SignatureStatus string
+
+const (
+	// SigVerified: the signature is valid under a trusted, implemented suite.
+	SigVerified SignatureStatus = "verified"
+	// SigFailed: the suite is implemented and the key trusted, but the signature
+	// does not verify over the canonical bytes.
+	SigFailed SignatureStatus = "failed"
+	// SigUnknownKey: the key id is not in the verifier's trusted set.
+	SigUnknownKey SignatureStatus = "unknown_key"
+	// SigUnimplemented: a recognized suite (the PQ slot) with no built verifier.
+	SigUnimplemented SignatureStatus = "unimplemented"
+	// SigUnknownSuite: an unrecognized algorithm; no fallback verification.
+	SigUnknownSuite SignatureStatus = "unknown_suite"
+	// SigMalformed: a structurally invalid signature (key-type mismatch, empty
+	// role, bad wire encoding).
+	SigMalformed SignatureStatus = "malformed"
+)
+
+// SignatureResult is the appraisal of one parallel signature.
+type SignatureResult struct {
+	KeyID  string          `json:"key_id"`
+	Alg    string          `json:"alg"`
+	Role   string          `json:"signer_role"`
+	Status SignatureStatus `json:"status"`
+	Reason string          `json:"reason,omitempty"`
+}
+
+// Appraisal is the AARP verifier result. It reports verified claims grouped by
+// axis plus an explicit does_not_assert list, and never carries a "trusted" or
+// "safe" boolean. AssertionSigned is the single cryptographic gate: it is true
+// only when at least one parallel signature verified under a trusted key.
+type Appraisal struct {
+	Profile           string              `json:"profile"`
+	AssertionSigned   bool                `json:"assertion_signed"`
+	Signatures        []SignatureResult   `json:"signatures"`
+	AssuranceClaimed  []string            `json:"assurance_claimed"`
+	VerifiedClaims    []string            `json:"verified_claims"`
+	ClaimedUnverified []string            `json:"claimed_unverified"`
+	Axes              map[string][]string `json:"axes"`
+	DoesNotAssert     []string            `json:"does_not_assert"`
+	Warnings          []string            `json:"warnings"`
+}
+
+// newAppraisal returns an Appraisal with the fixed does_not_assert list and
+// empty axis buckets, ready for the verifier to populate.
+func newAppraisal() *Appraisal {
+	return &Appraisal{
+		Profile:       Profile,
+		Axes:          map[string][]string{},
+		DoesNotAssert: append([]string(nil), docsNotAsserted...),
+		Warnings:      []string{},
+	}
+}
+
+// addVerified records a confirmed claim under an axis (and in VerifiedClaims).
+func (a *Appraisal) addVerified(claim, axis string) {
+	a.VerifiedClaims = append(a.VerifiedClaims, claim)
+	a.Axes[axis] = append(a.Axes[axis], claim)
+}

--- a/internal/aarp/chain.go
+++ b/internal/aarp/chain.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"errors"
+	"fmt"
+)
+
+// GenesisPriorHash is the prior-hash sentinel for the first link in a stream:
+// 64 hex zeros, meaning "no prior receipt". A genesis link carries seq "0".
+const GenesisPriorHash = "0000000000000000000000000000000000000000000000000000000000000000"
+
+// Chain failure classes. Compare with errors.Is.
+var (
+	// ErrChainSchema means a chain link is structurally invalid (bad issuer,
+	// seq, or prior-hash grammar).
+	ErrChainSchema = errors.New("aarp: chain link schema violation")
+
+	// ErrChainBroken means a sequence of links does not form a contiguous,
+	// hash-linked stream: a non-incrementing sequence, a mismatched prior hash,
+	// a mixed issuer, or a genesis link with a non-zero prior hash. This is the
+	// signal an insertion, reorder, or backdating attempt produces.
+	ErrChainBroken = errors.New("aarp: chain linkage broken")
+)
+
+// ChainLink places an envelope in an issuer's append-only, hash-chained stream
+// (Rung-1 timestamp trust). It is issuer-agnostic: any issuer that maintains a
+// monotonic sequence and links each receipt's payload digest to the prior one
+// gets backdating detection without depending on a specific issuer deployment.
+//
+// The link is part of the signed payload, so seq and prior_hash cannot be
+// altered after signing. Inserting, reordering, or backdating a receipt within
+// the stream breaks the signed linkage and is detected by VerifyChain.
+type ChainLink struct {
+	// IssuerID identifies the stream this link belongs to. All links in a
+	// verified stream must share one issuer.
+	IssuerID string `json:"issuer_id"`
+	// Seq is the monotonic position in the stream, a uint64 typed string
+	// (number-safety: sequence numbers routinely exceed the I-JSON safe range).
+	Seq string `json:"seq"`
+	// PriorHash is the lowercase-hex SHA-256 of the previous link's payload
+	// digest, or GenesisPriorHash for the first link.
+	PriorHash string `json:"prior_hash"`
+}
+
+func (c ChainLink) validate() error {
+	if c.IssuerID == "" {
+		return fmt.Errorf("%w: chain.issuer_id is required", ErrChainSchema)
+	}
+	if err := ValidateUint64String(c.Seq); err != nil {
+		return fmt.Errorf("%w: chain.seq: %w", ErrChainSchema, err)
+	}
+	if err := ValidateHex256(c.PriorHash); err != nil {
+		return fmt.Errorf("%w: chain.prior_hash: %w", ErrChainSchema, err)
+	}
+	if c.Seq == "0" && c.PriorHash != GenesisPriorHash {
+		return fmt.Errorf("%w: genesis link (seq 0) must carry the zero prior hash", ErrChainSchema)
+	}
+	if c.Seq != "0" && c.PriorHash == GenesisPriorHash {
+		return fmt.Errorf("%w: non-genesis link (seq %s) must not carry the genesis prior hash", ErrChainSchema, c.Seq)
+	}
+	return nil
+}
+
+// VerifyChain checks that envs form a contiguous, hash-linked stream from a
+// single issuer: every envelope carries a chain link, all links share one
+// issuer, the sequence increments by exactly 1 across the slice, and each
+// link's prior_hash equals the previous envelope's payload digest. The first
+// element may be a genesis link (seq 0, zero prior hash) but need not be — a
+// caller may verify a contiguous segment that starts mid-stream.
+//
+// VerifyChain does NOT check signatures; callers verify each envelope's
+// signatures separately. It checks only the linkage that makes backdating,
+// insertion, and reordering within the stream detectable. The slice must be in
+// ascending stream order.
+func VerifyChain(envs []Envelope) error {
+	if len(envs) == 0 {
+		return fmt.Errorf("%w: empty chain", ErrChainBroken)
+	}
+	var (
+		issuer   string
+		prevSeq  uint64
+		prevHash string
+	)
+	for i, e := range envs {
+		if e.Chain == nil {
+			return fmt.Errorf("%w: envelope[%d] has no chain link", ErrChainBroken, i)
+		}
+		if err := e.Chain.validate(); err != nil {
+			return err
+		}
+		seq, err := parseSeq(e.Chain.Seq)
+		if err != nil {
+			return fmt.Errorf("%w: envelope[%d]: %w", ErrChainBroken, i, err)
+		}
+		if i == 0 {
+			issuer = e.Chain.IssuerID
+		} else {
+			if e.Chain.IssuerID != issuer {
+				return fmt.Errorf("%w: envelope[%d] issuer %q != stream issuer %q", ErrChainBroken, i, e.Chain.IssuerID, issuer)
+			}
+			if seq != prevSeq+1 {
+				return fmt.Errorf("%w: envelope[%d] seq %d, expected %d", ErrChainBroken, i, seq, prevSeq+1)
+			}
+			// Both sides are lowercase hex: PriorHash passed ValidateHex256
+			// (rejects uppercase) and prevHash comes from hex.EncodeToString.
+			// Compare exactly — do not tolerate case the grammar already forbids.
+			if e.Chain.PriorHash != prevHash {
+				return fmt.Errorf("%w: envelope[%d] prior_hash does not match previous payload digest", ErrChainBroken, i)
+			}
+		}
+		digest, err := e.PayloadDigest()
+		if err != nil {
+			return fmt.Errorf("%w: envelope[%d]: %w", ErrChainBroken, i, err)
+		}
+		prevSeq = seq
+		prevHash = digest
+	}
+	return nil
+}
+
+// parseSeq converts a validated uint64 typed-string to its numeric value.
+func parseSeq(s string) (uint64, error) {
+	if err := ValidateUint64String(s); err != nil {
+		return 0, err
+	}
+	var n uint64
+	for i := 0; i < len(s); i++ {
+		n = n*10 + uint64(s[i]-'0')
+	}
+	return n, nil
+}

--- a/internal/aarp/chain_test.go
+++ b/internal/aarp/chain_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"strconv"
+	"testing"
+)
+
+// buildChain returns n envelopes forming a valid issuer stream starting at
+// genesis (seq 0), each signed and each link's prior_hash bound to the previous
+// envelope's payload digest, plus the public key they were signed with.
+func buildChain(t *testing.T, n int) ([]Envelope, ed25519.PublicKey) {
+	t.Helper()
+	pub, priv := genKey(t)
+	signer, err := NewEd25519Signer(testKeyID, "issuer", priv)
+	if err != nil {
+		t.Fatalf("NewEd25519Signer: %v", err)
+	}
+	stream := make([]Envelope, 0, n)
+	prior := GenesisPriorHash
+	for i := 0; i < n; i++ {
+		e := baseEnvelope()
+		e.Chain = &ChainLink{
+			IssuerID:  "issuer-1",
+			Seq:       strconv.Itoa(i),
+			PriorHash: prior,
+		}
+		signed, err := Sign(e, signer)
+		if err != nil {
+			t.Fatalf("Sign link %d: %v", i, err)
+		}
+		stream = append(stream, signed)
+		digest, err := signed.PayloadDigest()
+		if err != nil {
+			t.Fatalf("PayloadDigest link %d: %v", i, err)
+		}
+		prior = digest
+	}
+	return stream, pub
+}
+
+func TestVerifyChain_Valid(t *testing.T) {
+	stream, _ := buildChain(t, 4)
+	if err := VerifyChain(stream); err != nil {
+		t.Fatalf("VerifyChain(valid) = %v, want nil", err)
+	}
+}
+
+func TestVerifyChain_Segment(t *testing.T) {
+	// A contiguous segment that starts mid-stream is allowed (chain_scope:segment).
+	stream, _ := buildChain(t, 4)
+	if err := VerifyChain(stream[1:]); err != nil {
+		t.Fatalf("VerifyChain(segment) = %v, want nil", err)
+	}
+}
+
+func TestVerifyChain_ReorderDetected(t *testing.T) {
+	stream, _ := buildChain(t, 4)
+	stream[1], stream[2] = stream[2], stream[1]
+	if err := VerifyChain(stream); !errors.Is(err, ErrChainBroken) {
+		t.Fatalf("VerifyChain(reordered) = %v, want ErrChainBroken", err)
+	}
+}
+
+func TestVerifyChain_PriorHashTamperDetected(t *testing.T) {
+	stream, _ := buildChain(t, 3)
+	stream[2].Chain.PriorHash = digest64(7)
+	if err := VerifyChain(stream); !errors.Is(err, ErrChainBroken) {
+		t.Fatalf("VerifyChain(tampered prior_hash) = %v, want ErrChainBroken", err)
+	}
+}
+
+func TestVerifyChain_GapDetected(t *testing.T) {
+	stream, _ := buildChain(t, 3)
+	// Drop the middle element: seq jumps 0 -> 2, prior_hash no longer matches.
+	gapped := []Envelope{stream[0], stream[2]}
+	if err := VerifyChain(gapped); !errors.Is(err, ErrChainBroken) {
+		t.Fatalf("VerifyChain(gap) = %v, want ErrChainBroken", err)
+	}
+}
+
+func TestVerifyChain_MixedIssuerDetected(t *testing.T) {
+	stream, _ := buildChain(t, 2)
+	stream[1].Chain.IssuerID = "issuer-2"
+	if err := VerifyChain(stream); !errors.Is(err, ErrChainBroken) {
+		t.Fatalf("VerifyChain(mixed issuer) = %v, want ErrChainBroken", err)
+	}
+}
+
+func TestVerifyChain_Empty(t *testing.T) {
+	if err := VerifyChain(nil); !errors.Is(err, ErrChainBroken) {
+		t.Fatalf("VerifyChain(nil) = %v, want ErrChainBroken", err)
+	}
+}
+
+func TestVerifyChain_MissingLink(t *testing.T) {
+	stream, _ := buildChain(t, 2)
+	stream[1].Chain = nil
+	if err := VerifyChain(stream); !errors.Is(err, ErrChainBroken) {
+		t.Fatalf("VerifyChain(missing link) = %v, want ErrChainBroken", err)
+	}
+}
+
+func TestChainLink_Validate(t *testing.T) {
+	cases := []struct {
+		name string
+		link ChainLink
+		ok   bool
+	}{
+		{"genesis", ChainLink{IssuerID: "i", Seq: "0", PriorHash: GenesisPriorHash}, true},
+		{"normal", ChainLink{IssuerID: "i", Seq: "5", PriorHash: digest64(1)}, true},
+		{"empty_issuer", ChainLink{IssuerID: "", Seq: "0", PriorHash: GenesisPriorHash}, false},
+		{"bad_seq", ChainLink{IssuerID: "i", Seq: "-1", PriorHash: digest64(1)}, false},
+		{"bad_prior_hash", ChainLink{IssuerID: "i", Seq: "1", PriorHash: "short"}, false},
+		{"genesis_nonzero_prior", ChainLink{IssuerID: "i", Seq: "0", PriorHash: digest64(1)}, false},
+		{"nongenesis_zero_prior", ChainLink{IssuerID: "i", Seq: "1", PriorHash: GenesisPriorHash}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.link.validate()
+			if tc.ok && err != nil {
+				t.Fatalf("validate(%+v) = %v, want nil", tc.link, err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatalf("validate(%+v) = nil, want error", tc.link)
+			}
+		})
+	}
+}
+
+func TestVerifyChain_BindsIntoSignature(t *testing.T) {
+	// A chained envelope's link is part of the signed payload: tampering the seq
+	// after signing must break the signature, proving backdating is not just
+	// linkage-detectable but signature-detectable.
+	stream, pub := buildChain(t, 2)
+	env := stream[1]
+	// Tamper the signed chain seq.
+	env.Chain.Seq = "99"
+	ap, err := Verify(env, VerifyOptions{TrustedKeys: map[string]ed25519.PublicKey{testKeyID: pub}})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if ap.AssertionSigned {
+		t.Fatal("AssertionSigned = true after tampering signed chain seq")
+	}
+}

--- a/internal/aarp/coverage_test.go
+++ b/internal/aarp/coverage_test.go
@@ -1,0 +1,343 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSubjectValidate_Branches(t *testing.T) {
+	good := Subject{
+		ActionRecordSHA256:    digest64(1),
+		ReceiptEnvelopeSHA256: digest64(2),
+		ReceiptSignerKey:      digest64(3),
+		ReceiptType:           ReceiptTypeActionV1,
+	}
+	if err := good.validate(); err != nil {
+		t.Fatalf("good subject: %v", err)
+	}
+	mutate := []func(*Subject){
+		func(s *Subject) { s.ActionRecordSHA256 = "bad" },
+		func(s *Subject) { s.ReceiptEnvelopeSHA256 = "bad" },
+		func(s *Subject) { s.ReceiptSignerKey = "bad" },
+		func(s *Subject) { s.ReceiptType = "unknown_type" },
+	}
+	for i, m := range mutate {
+		s := good
+		m(&s)
+		if err := s.validate(); !errors.Is(err, ErrSchema) {
+			t.Errorf("mutation %d: got %v, want ErrSchema", i, err)
+		}
+	}
+}
+
+func TestAssertionValidate_Branches(t *testing.T) {
+	good := Assertion{MediatorID: testMediatorID, IssuedAt: testIssuedAt, TrustDomain: testTrustDomain}
+	if err := good.validate(); err != nil {
+		t.Fatalf("good assertion: %v", err)
+	}
+	mutate := []func(*Assertion){
+		func(a *Assertion) { a.MediatorID = "" },
+		func(a *Assertion) { a.IssuedAt = "not-a-time" },
+		func(a *Assertion) { a.TrustDomain = "10.0.0.1" }, // IP literal
+		func(a *Assertion) { a.TrustDomain = "bad domain with spaces" },
+	}
+	for i, m := range mutate {
+		a := good
+		m(&a)
+		if err := a.validate(); !errors.Is(err, ErrSchema) {
+			t.Errorf("mutation %d: got %v, want ErrSchema", i, err)
+		}
+	}
+	// Empty trust domain is allowed (optional in core).
+	a := good
+	a.TrustDomain = ""
+	if err := a.validate(); err != nil {
+		t.Errorf("empty trust domain should be allowed: %v", err)
+	}
+}
+
+func TestValidateSuiteShape_Branches(t *testing.T) {
+	good := ProtectedHeader{Profile: Profile, Canon: CanonID, Alg: string(AlgEd25519), KeyType: "ed25519", KeyID: "k", SignerRole: "mediator"}
+	if err := good.validateSuiteShape(); err != nil {
+		t.Fatalf("good header: %v", err)
+	}
+	cases := []struct {
+		name   string
+		mutate func(*ProtectedHeader)
+		errIs  error
+	}{
+		{"profile", func(h *ProtectedHeader) { h.Profile = "x" }, ErrUnknownSuite},
+		{"canon", func(h *ProtectedHeader) { h.Canon = "x" }, ErrUnknownSuite},
+		{"alg", func(h *ProtectedHeader) { h.Alg = "rsa" }, ErrUnknownSuite},
+		{"keytype", func(h *ProtectedHeader) { h.KeyType = "rsa" }, ErrMalformedSuite},
+		{"keyid", func(h *ProtectedHeader) { h.KeyID = "" }, ErrMalformedSuite},
+		{"role", func(h *ProtectedHeader) { h.SignerRole = "bogus" }, ErrMalformedSuite},
+		{"crit", func(h *ProtectedHeader) { h.Crit = []string{"unknown"} }, ErrUnknownCriticalExtension},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := good
+			tc.mutate(&h)
+			if err := h.validateSuiteShape(); !errors.Is(err, tc.errIs) {
+				t.Fatalf("got %v, want %v", err, tc.errIs)
+			}
+		})
+	}
+}
+
+func TestCheckCriticalExtensions_Branches(t *testing.T) {
+	if err := checkCriticalExtensions(nil); err != nil {
+		t.Errorf("nil crit: %v", err)
+	}
+	if err := checkCriticalExtensions([]string{""}); !errors.Is(err, ErrMalformedSuite) {
+		t.Errorf("empty name: got %v", err)
+	}
+	if err := checkCriticalExtensions([]string{"a", "a"}); !errors.Is(err, ErrMalformedSuite) {
+		t.Errorf("duplicate: got %v", err)
+	}
+	if err := checkCriticalExtensions([]string{"unknown"}); !errors.Is(err, ErrUnknownCriticalExtension) {
+		t.Errorf("unknown: got %v", err)
+	}
+}
+
+func TestValidateTrustDomainName_Branches(t *testing.T) {
+	if err := validateTrustDomainName("example.org"); err != nil {
+		t.Errorf("valid: %v", err)
+	}
+	if err := validateTrustDomainName("10.0.0.1"); err == nil {
+		t.Error("IP literal should be rejected")
+	}
+	if err := validateTrustDomainName("bad domain"); err == nil {
+		t.Error("malformed domain should be rejected")
+	}
+}
+
+func TestCheckSafeNumber_DefensiveBranches(t *testing.T) {
+	if err := checkSafeNumber("", "$"); !errors.Is(err, ErrUnsafeNumber) {
+		t.Errorf("empty: got %v", err)
+	}
+	if err := checkSafeNumber("12x", "$"); !errors.Is(err, ErrUnsafeNumber) {
+		t.Errorf("non-integer: got %v", err)
+	}
+	if err := checkSafeNumber("0", "$"); err != nil {
+		t.Errorf("zero: %v", err)
+	}
+}
+
+func TestParseSeq_Branches(t *testing.T) {
+	n, err := parseSeq("42")
+	if err != nil || n != 42 {
+		t.Fatalf("parseSeq(42) = %d, %v", n, err)
+	}
+	if _, err := parseSeq("-1"); !errors.Is(err, ErrBadGrammar) {
+		t.Errorf("parseSeq(-1) = %v, want ErrBadGrammar", err)
+	}
+}
+
+func TestDecodeSigWire_Branches(t *testing.T) {
+	if _, err := decodeSigWire("ed25519", "wrongprefix:AAAA"); !errors.Is(err, ErrSchema) {
+		t.Errorf("bad prefix: got %v", err)
+	}
+	if _, err := decodeSigWire("ed25519", "ed25519:not!base64"); !errors.Is(err, ErrSchema) {
+		t.Errorf("bad base64: got %v", err)
+	}
+	raw, err := decodeSigWire("ed25519", "ed25519:AAAA")
+	if err != nil || len(raw) == 0 {
+		t.Errorf("good wire: %v", err)
+	}
+}
+
+func TestMLDSA65Signer_DirectSignInputFailsClosed(t *testing.T) {
+	signer, err := NewMLDSA65Signer("pq-1", "mediator")
+	if err != nil {
+		t.Fatalf("NewMLDSA65Signer: %v", err)
+	}
+	if _, err := signer.signInput([]byte("x")); !errors.Is(err, ErrSuiteUnimplemented) {
+		t.Fatalf("signInput = %v, want ErrSuiteUnimplemented", err)
+	}
+	// Header is well-formed and shape-valid even though signing is unimplemented.
+	if err := signer.Header().validateSuiteShape(); err != nil {
+		t.Fatalf("PQ header shape: %v", err)
+	}
+}
+
+func TestNewMLDSA65Signer_Rejects(t *testing.T) {
+	if _, err := NewMLDSA65Signer("", "mediator"); !errors.Is(err, ErrMalformedSuite) {
+		t.Errorf("empty key_id: %v", err)
+	}
+	if _, err := NewMLDSA65Signer("k", "bogus"); !errors.Is(err, ErrMalformedSuite) {
+		t.Errorf("bad role: %v", err)
+	}
+}
+
+func TestValidateUint64String_Overflow(t *testing.T) {
+	// One past max uint64.
+	if err := ValidateUint64String("18446744073709551616"); !errors.Is(err, ErrBadGrammar) {
+		t.Fatalf("overflow: %v", err)
+	}
+	// A very long all-digit string also overflows.
+	if err := ValidateUint64String(strings.Repeat("9", 40)); !errors.Is(err, ErrBadGrammar) {
+		t.Fatalf("long overflow: %v", err)
+	}
+}
+
+func TestAppraiseSignature_WrongSizeTrustedKey(t *testing.T) {
+	env, _ := signedEnvelopeWithKey(t)
+	// Trusted key registered with a wrong size → malformed, never verified.
+	opts := VerifyOptions{TrustedKeys: map[string]ed25519.PublicKey{testKeyID: {1, 2, 3}}}
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if ap.Signatures[0].Status != SigMalformed {
+		t.Fatalf("status = %q, want malformed", ap.Signatures[0].Status)
+	}
+}
+
+func TestAppraiseSignature_WrongLengthSignature(t *testing.T) {
+	env, pub := signedEnvelopeWithKey(t)
+	// A correctly-prefixed but wrong-length signature must fail (not panic).
+	env.Signatures[0].Sig = "ed25519:AAAA"
+	opts := VerifyOptions{TrustedKeys: map[string]ed25519.PublicKey{testKeyID: pub}}
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if ap.Signatures[0].Status != SigFailed {
+		t.Fatalf("status = %q, want failed", ap.Signatures[0].Status)
+	}
+}
+
+func TestAppraiseSignature_BadWireEncoding(t *testing.T) {
+	env, pub := signedEnvelopeWithKey(t)
+	env.Signatures[0].Sig = "ed25519:not!base64!"
+	opts := VerifyOptions{TrustedKeys: map[string]ed25519.PublicKey{testKeyID: pub}}
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if ap.Signatures[0].Status != SigMalformed {
+		t.Fatalf("status = %q, want malformed", ap.Signatures[0].Status)
+	}
+}
+
+func TestSign_RejectsInvalidChain(t *testing.T) {
+	_, priv := genKey(t)
+	signer, _ := NewEd25519Signer(testKeyID, "issuer", priv)
+	e := baseEnvelope()
+	e.Chain = &ChainLink{IssuerID: "i", Seq: "-1", PriorHash: digest64(1)} // bad seq
+	if _, err := Sign(e, signer); !errors.Is(err, ErrChainSchema) {
+		t.Fatalf("Sign with bad chain = %v, want ErrChainSchema", err)
+	}
+}
+
+func TestVerify_EmptySignatureSetRejected(t *testing.T) {
+	e := baseEnvelope()
+	e.Signatures = nil
+	if _, err := Verify(e, VerifyOptions{}); !errors.Is(err, ErrSchema) {
+		t.Fatalf("Verify(no sigs) = %v, want ErrSchema", err)
+	}
+}
+
+func TestSign_AutoSetsProfile(t *testing.T) {
+	_, priv := genKey(t)
+	signer, _ := NewEd25519Signer(testKeyID, "mediator", priv)
+	e := baseEnvelope()
+	e.Profile = "" // Sign fills it with the package default.
+	signed, err := Sign(e, signer)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if signed.Profile != Profile {
+		t.Fatalf("profile = %q, want %q", signed.Profile, Profile)
+	}
+}
+
+func TestMediatorKeyPinned_TrustDomainMismatch(t *testing.T) {
+	env, pub := signedEnvelopeWithKey(t)
+	opts := VerifyOptions{
+		TrustedKeys: map[string]ed25519.PublicKey{testKeyID: pub},
+		// Trust entry pins a DIFFERENT trust domain than the assertion carries.
+		Trust: map[string]TrustEntry{testKeyID: {MediatorID: testMediatorID, TrustDomain: "other.example"}},
+	}
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if contains(ap.VerifiedClaims, ClaimMediatorKeyPinned) {
+		t.Error("mediator_key_pinned verified despite trust-domain mismatch")
+	}
+}
+
+func TestVerifyChain_InvalidGrammarLink(t *testing.T) {
+	e := baseEnvelope()
+	e.Chain = &ChainLink{IssuerID: "i", Seq: "01", PriorHash: digest64(1)} // leading-zero seq
+	if err := VerifyChain([]Envelope{e}); !errors.Is(err, ErrChainSchema) {
+		t.Fatalf("VerifyChain(bad grammar) = %v, want ErrChainSchema", err)
+	}
+}
+
+func TestVerify_EnvelopeProfileMismatch(t *testing.T) {
+	env, opts := signedEnvelope(t)
+	env.Profile = "aarp/v9.9"
+	if _, err := Verify(env, opts); !errors.Is(err, ErrSchema) {
+		t.Fatalf("Verify(envelope profile mismatch) = %v, want ErrSchema", err)
+	}
+}
+
+func TestSign_RejectsInvalidAssertion(t *testing.T) {
+	_, priv := genKey(t)
+	signer, _ := NewEd25519Signer(testKeyID, "mediator", priv)
+	e := baseEnvelope()
+	e.Assertion.MediatorID = "" // valid subject, invalid assertion
+	if _, err := Sign(e, signer); !errors.Is(err, ErrSchema) {
+		t.Fatalf("Sign with empty mediator_id = %v, want ErrSchema", err)
+	}
+}
+
+// TestAppraiseSignature_AttackerCraftedHeader proves a hand-crafted envelope
+// whose signature header has an empty key_id or an unknown role (which Sign
+// would never emit, but Unmarshal accepts structurally) is reported malformed,
+// never verified.
+func TestAppraiseSignature_AttackerCraftedHeader(t *testing.T) {
+	mk := func(mut func(*ProtectedHeader)) Envelope {
+		env, _ := signedEnvelope(t)
+		mut(&env.Signatures[0].Protected)
+		return env
+	}
+	t.Run("empty_key_id", func(t *testing.T) {
+		env := mk(func(h *ProtectedHeader) { h.KeyID = "" })
+		ap, err := Verify(env, VerifyOptions{})
+		if err != nil {
+			t.Fatalf("Verify: %v", err)
+		}
+		if ap.Signatures[0].Status != SigMalformed {
+			t.Fatalf("status = %q, want malformed", ap.Signatures[0].Status)
+		}
+	})
+	t.Run("unknown_role", func(t *testing.T) {
+		env := mk(func(h *ProtectedHeader) { h.SignerRole = "bogus-role" })
+		ap, err := Verify(env, VerifyOptions{})
+		if err != nil {
+			t.Fatalf("Verify: %v", err)
+		}
+		if ap.Signatures[0].Status != SigMalformed {
+			t.Fatalf("status = %q, want malformed", ap.Signatures[0].Status)
+		}
+	})
+}
+
+func TestAppraisalJSON_NoTrustedOrSafeKeys(t *testing.T) {
+	ap := newAppraisal()
+	if ap.Profile != Profile {
+		t.Fatalf("profile = %q", ap.Profile)
+	}
+	if len(ap.DoesNotAssert) == 0 {
+		t.Fatal("does_not_assert must not be empty")
+	}
+}

--- a/internal/aarp/doc.go
+++ b/internal/aarp/doc.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package aarp implements the Agent Action Receipt Profile (AARP) v0.1
+// assurance envelope: a separate, independently-signed appraisal artifact that
+// sits alongside a shipped pipelock receipt and reports exactly what a verifier
+// could cryptographically confirm versus what the producer merely claimed.
+//
+// AARP is not a new receipt format. The shipped v1 ActionReceipt
+// (internal/receipt) and the v2 EvidenceReceipt (internal/contract/receipt)
+// stay byte-for-byte frozen; AARP appraises them as immutable inputs referenced
+// by digest. It never rewrites a receipt and never emits a "trusted" or "safe"
+// verdict.
+//
+// # What this package provides
+//
+//   - A protected signature suite bound into every signed byte sequence, with
+//     fail-closed rejection of unknown suites and unknown critical extensions
+//     and no fallback verification (suite.go).
+//   - JCS number-safety: identity, digest, timestamp, counter, and amount
+//     fields are typed strings with explicit grammars; raw JSON numbers outside
+//     the I-JSON safe-integer range are rejected (numbers.go).
+//   - A parallel multi-signature envelope: N protected signatures over the same
+//     canonical assertion payload bytes, never chained over one another. Ed25519
+//     ships today; the post-quantum slot is typed-but-stubbed (envelope.go,
+//     sign.go, verify.go).
+//   - An issuer-agnostic Rung-1 timestamp-chain primitive (sequence number +
+//     prior hash) so backdating within an issuer's stream is detectable without
+//     depending on any particular issuer deployment (chain.go).
+//   - A claim-set appraisal result grouped by axis with an explicit
+//     does_not_assert list (appraise.go).
+//
+// # What it composes with (does not reinvent)
+//
+//   - internal/contract.Canonicalize / ParseJSONStrict for RFC 8785 JCS,
+//     NFC normalization, float rejection, and duplicate-key rejection.
+//   - internal/svid for offline X.509-SVID validation (consumed by the
+//     attestation binding built on top of this core).
+//
+// Every signing input in this package is the JCS canonicalization of a single
+// object that carries the domain-separation context as a signed field, so the
+// context is inside the signed bytes (JCS sorts object keys, so it is signed but
+// not necessarily first in canonical order). String concatenation is never used
+// to form a signing input.
+package aarp
+
+// Profile is the AARP profile identifier carried by every envelope and every
+// protected signature header. A mismatch is fatal: the verifier never appraises
+// an envelope whose profile it does not implement.
+const Profile = "aarp/v0.1"
+
+// CanonID names the canonicalization the signed bytes were produced with. It is
+// part of the protected suite so a verifier can never be tricked into matching
+// bytes produced under a different canonicalization.
+const CanonID = "jcs-rfc8785-nfc"

--- a/internal/aarp/envelope.go
+++ b/internal/aarp/envelope.go
@@ -161,19 +161,30 @@ type Envelope struct {
 // Signatures (signatures never sign each other) and Ext (non-critical
 // extensions are advisory and ignored safely).
 type payload struct {
-	Profile   string     `json:"profile"`
-	Subject   Subject    `json:"subject"`
-	Assertion Assertion  `json:"assertion"`
-	CritExt   []string   `json:"crit_ext,omitempty"`
-	Chain     *ChainLink `json:"chain,omitempty"`
+	Profile   string    `json:"profile"`
+	Subject   Subject   `json:"subject"`
+	Assertion Assertion `json:"assertion"`
+	// CritExt is NOT omitempty: an empty critical-extension list must serialize
+	// as "crit_ext": [] so the signed canonical bytes match an external
+	// implementation that faithfully emits []. With omitempty, a nil and an
+	// explicit [] would canonicalize differently across languages and break
+	// cross-implementation signature agreement.
+	CritExt []string   `json:"crit_ext"`
+	Chain   *ChainLink `json:"chain,omitempty"`
 }
 
 func (e Envelope) payload() payload {
+	// Normalize a nil critical-extension list to an empty slice so it always
+	// serializes as [] (never null) in the signed payload.
+	critExt := e.CritExt
+	if critExt == nil {
+		critExt = []string{}
+	}
 	return payload{
 		Profile:   e.Profile,
 		Subject:   e.Subject,
 		Assertion: e.Assertion,
-		CritExt:   e.CritExt,
+		CritExt:   critExt,
 		Chain:     e.Chain,
 	}
 }
@@ -260,32 +271,25 @@ func (e Envelope) validatePayloadParts() error {
 }
 
 // validateStructure runs the envelope-fatal schema checks that must hold before
-// any per-signature appraisal: the payload parts, a non-empty signature set, and
-// the envelope-wide invariants each protected header must satisfy (matching
-// profile and canonicalization, and only understood critical extensions).
+// any per-signature appraisal: the payload parts (which include the top-level
+// profile and the envelope-level critical-extension list) and a non-empty
+// signature set.
 //
-// Algorithm recognition, key trust, and signature validity are deliberately NOT
-// checked here: those are per-signature outcomes (a single unknown-suite or
-// untrusted signature must not reject an envelope that also carries a verifiable
-// one). An unknown critical extension or a profile/canon mismatch, by contrast,
-// means the verifier cannot safely interpret the envelope at all — fail closed.
+// Only fields inside the SIGNED payload are envelope-fatal here. Per-signature
+// suite fields (a signature's protected profile, canon, alg, key trust, and its
+// own critical-extension list) are deliberately NOT checked here: they are
+// per-signature outcomes appraised in appraiseSignature. The signatures array
+// is not itself signed, so a man-in-the-middle can append a junk signature; if a
+// bad protected header were envelope-fatal, that append would deny a
+// legitimately-signed envelope. Per-signature handling makes one unverifiable
+// signature inert instead of fatal, while the signed top-level profile and
+// crit_ext (which an append cannot forge) stay fatal.
 func (e Envelope) validateStructure() error {
 	if err := e.validatePayloadParts(); err != nil {
 		return err
 	}
 	if len(e.Signatures) == 0 {
 		return fmt.Errorf("%w: envelope has no signatures", ErrSchema)
-	}
-	for i, s := range e.Signatures {
-		if s.Protected.Profile != Profile {
-			return fmt.Errorf("%w: signature[%d] profile %q, want %q", ErrUnknownSuite, i, s.Protected.Profile, Profile)
-		}
-		if s.Protected.Canon != CanonID {
-			return fmt.Errorf("%w: signature[%d] canon %q, want %q", ErrUnknownSuite, i, s.Protected.Canon, CanonID)
-		}
-		if err := checkCriticalExtensions(s.Protected.Crit); err != nil {
-			return fmt.Errorf("signature[%d]: %w", i, err)
-		}
 	}
 	return nil
 }

--- a/internal/aarp/envelope.go
+++ b/internal/aarp/envelope.go
@@ -1,0 +1,328 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+)
+
+// Domain-separation contexts. Every signing input is the JCS canonicalization of
+// an object that carries one of these as a signed field, so a signature made for
+// one purpose can never be replayed as evidence for another.
+const (
+	// ContextAssertion is the domain separator for the assurance-assertion
+	// signature (the parallel multi-signatures in Envelope.Signatures).
+	ContextAssertion = "pipelock-aarp-v0.1/assurance-assertion"
+)
+
+// Envelope errors. Compare with errors.Is.
+var (
+	// ErrSchema means the envelope is structurally invalid: a missing required
+	// field, a profile mismatch, an empty signature set, or a typed-string
+	// grammar violation.
+	ErrSchema = errors.New("aarp: envelope schema violation")
+
+	// ErrUnknownField means an AARP-controlled object carried a field outside
+	// the registered schema. Unlike legacy v1 receipts (where unknown fields are
+	// ignored for backward compatibility), AARP objects reject unknown fields so
+	// a producer cannot smuggle unsigned-but-meaningful content past appraisal.
+	ErrUnknownField = errors.New("aarp: unknown field in AARP-controlled object")
+)
+
+// Subject names the immutable receipt this assurance envelope appraises, by
+// digest. Every field is a typed string (number-safety): digests are lowercase
+// hex, the signer key is the receipt's Ed25519 public key in hex.
+type Subject struct {
+	// ActionRecordSHA256 is the SHA-256 of the v1 canonical ActionRecord, or of
+	// the v2 EvidenceReceipt SignablePreimage, depending on ReceiptType.
+	ActionRecordSHA256 string `json:"action_record_sha256"`
+	// ReceiptEnvelopeSHA256 is the SHA-256 of the canonical, unchanged receipt
+	// envelope this assurance appraises.
+	ReceiptEnvelopeSHA256 string `json:"receipt_envelope_sha256"`
+	// ReceiptSignerKey is the hex Ed25519 public key that signed the receipt. An
+	// Ed25519 public key is 32 bytes = 64 lowercase hex chars, which is why the
+	// 64-hex grammar (ValidateHex256) applies; a future receipt type using a
+	// different key size would need a key-length-aware validator.
+	ReceiptSignerKey string `json:"receipt_signer_key"`
+	// ReceiptType names which frozen receipt format the digests target. This is
+	// the exact "hash-of-what" disambiguation.
+	ReceiptType string `json:"receipt_type"`
+}
+
+// Receipt type constants for Subject.ReceiptType.
+const (
+	// ReceiptTypeActionV1 targets the legacy ActionReceipt v1 (json.Marshal +
+	// SHA-256 of canonical bytes).
+	ReceiptTypeActionV1 = "action_receipt_v1"
+	// ReceiptTypeEvidenceV2 targets the EvidenceReceipt v2 (JCS SignablePreimage).
+	ReceiptTypeEvidenceV2 = "evidence_receipt_v2"
+)
+
+var knownReceiptTypes = map[string]bool{
+	ReceiptTypeActionV1:   true,
+	ReceiptTypeEvidenceV2: true,
+}
+
+func (s Subject) validate() error {
+	if err := ValidateHex256(s.ActionRecordSHA256); err != nil {
+		return fmt.Errorf("%w: subject.action_record_sha256: %w", ErrSchema, err)
+	}
+	if err := ValidateHex256(s.ReceiptEnvelopeSHA256); err != nil {
+		return fmt.Errorf("%w: subject.receipt_envelope_sha256: %w", ErrSchema, err)
+	}
+	if err := ValidateHex256(s.ReceiptSignerKey); err != nil {
+		return fmt.Errorf("%w: subject.receipt_signer_key: %w", ErrSchema, err)
+	}
+	if !knownReceiptTypes[s.ReceiptType] {
+		return fmt.Errorf("%w: unknown subject.receipt_type %q", ErrSchema, s.ReceiptType)
+	}
+	return nil
+}
+
+// Assertion is the producer's claim set about the subject. It is the shared
+// payload bound (by digest) by every parallel signature.
+type Assertion struct {
+	// Claimed lists the claim names the producer asserts. They are producer
+	// claims, not verified facts; the verifier confirms each one independently.
+	Claimed []string `json:"claimed"`
+	// MediatorID is the producer's self-declared mediator identity. It is only
+	// trusted insofar as it matches a verifier-side trust entry.
+	MediatorID string `json:"mediator_id"`
+	// TrustDomain is the producer's SPIFFE trust domain (optional in core;
+	// required when an SVID binding is present in the attestation layer).
+	TrustDomain string `json:"trust_domain,omitempty"`
+	// CompleteMediation is a claim-only field. v0.1 never verifies it: there is
+	// no local evidence that proves the absence of an out-of-band path.
+	CompleteMediation bool `json:"complete_mediation"`
+	// EvidenceRefs names evidence objects (e.g. "spiffe_svid") that an upper
+	// layer attaches and verifies.
+	EvidenceRefs []string `json:"evidence_refs,omitempty"`
+	// IssuedAt is the assertion issuance time as an RFC3339Nano typed string.
+	IssuedAt string `json:"issued_at"`
+}
+
+func (a Assertion) validate() error {
+	if a.MediatorID == "" {
+		return fmt.Errorf("%w: assertion.mediator_id is required", ErrSchema)
+	}
+	if err := ValidateTimestamp(a.IssuedAt); err != nil {
+		return fmt.Errorf("%w: assertion.issued_at: %w", ErrSchema, err)
+	}
+	if a.TrustDomain != "" {
+		if err := validateTrustDomainName(a.TrustDomain); err != nil {
+			return fmt.Errorf("%w: assertion.trust_domain: %w", ErrSchema, err)
+		}
+	}
+	return nil
+}
+
+// Signature is one parallel protected signature over the shared canonical
+// payload digest. Signatures are parallel (each independently binds the same
+// payload digest under its own suite), never chained over one another.
+type Signature struct {
+	Protected ProtectedHeader `json:"protected"`
+	// Sig is "<alg>:<base64-std>" over the canonical signing input.
+	Sig string `json:"sig"`
+}
+
+// Envelope is the top-level AARP assurance artifact. It sits alongside a frozen
+// receipt and carries its own parallel signatures; it never mutates the receipt.
+type Envelope struct {
+	Profile   string    `json:"profile"`
+	Subject   Subject   `json:"subject"`
+	Assertion Assertion `json:"assertion"`
+	// Chain optionally places this envelope in an issuer's append-only,
+	// hash-chained stream (Rung-1 timestamp trust). When present it is part of
+	// the signed payload, so backdating within a stream is signature-detectable.
+	Chain *ChainLink `json:"chain,omitempty"`
+	// Signatures holds N parallel protected signatures over the payload digest.
+	Signatures []Signature `json:"signatures"`
+	// CritExt lists envelope-level critical extension names. Any name not in the
+	// known registry rejects the whole envelope (fail closed).
+	CritExt []string `json:"crit_ext,omitempty"`
+	// Ext carries non-critical extensions. Unknown non-critical extensions are
+	// ignored safely; they are not part of the signed payload.
+	Ext map[string]json.RawMessage `json:"ext,omitempty"`
+}
+
+// payload is the exact set of fields covered by every signature: the profile,
+// subject, assertion, the envelope-level critical-extension list, and (when
+// present) the chain link. CritExt is signed so a man-in-the-middle cannot
+// strip a critical extension a producer flagged. It deliberately excludes
+// Signatures (signatures never sign each other) and Ext (non-critical
+// extensions are advisory and ignored safely).
+type payload struct {
+	Profile   string     `json:"profile"`
+	Subject   Subject    `json:"subject"`
+	Assertion Assertion  `json:"assertion"`
+	CritExt   []string   `json:"crit_ext,omitempty"`
+	Chain     *ChainLink `json:"chain,omitempty"`
+}
+
+func (e Envelope) payload() payload {
+	return payload{
+		Profile:   e.Profile,
+		Subject:   e.Subject,
+		Assertion: e.Assertion,
+		CritExt:   e.CritExt,
+		Chain:     e.Chain,
+	}
+}
+
+// CanonicalPayload returns the JCS-canonical bytes of the signed payload (the
+// "identical canonical payload bytes" all parallel signatures bind). Recipe:
+// marshal → ParseJSONStrict → EnforceSafeNumbers → Canonicalize.
+func (e Envelope) CanonicalPayload() ([]byte, error) {
+	raw, err := json.Marshal(e.payload())
+	if err != nil {
+		return nil, fmt.Errorf("marshal payload: %w", err)
+	}
+	tree, err := contract.ParseJSONStrict(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: parse payload: %w", ErrSchema, err)
+	}
+	if err := EnforceSafeNumbers(tree); err != nil {
+		return nil, err
+	}
+	return contract.Canonicalize(tree)
+}
+
+// PayloadDigest returns the lowercase-hex SHA-256 of the canonical payload. It
+// is the value every signature binds and the value an SVID binding references
+// as assurance_assertion_sha256.
+func (e Envelope) PayloadDigest() (string, error) {
+	canonical, err := e.CanonicalPayload()
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// signingInput builds the canonical bytes one signature signs: the domain
+// context, the shared payload digest, and that signature's protected header.
+// Embedding the protected header means each signature commits to its own suite
+// (alg, key, canon, profile, critical extensions), defeating algorithm
+// substitution; binding the payload digest means all signatures cover identical
+// payload bytes.
+func signingInput(payloadDigest string, h ProtectedHeader) ([]byte, error) {
+	obj := signingInputObject{
+		Context:       ContextAssertion,
+		PayloadSHA256: payloadDigest,
+		Protected:     h,
+	}
+	raw, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("marshal signing input: %w", err)
+	}
+	tree, err := contract.ParseJSONStrict(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse signing input: %w", err)
+	}
+	return contract.Canonicalize(tree)
+}
+
+type signingInputObject struct {
+	Context       string          `json:"context"`
+	PayloadSHA256 string          `json:"payload_sha256"`
+	Protected     ProtectedHeader `json:"protected"`
+}
+
+// validatePayloadParts validates the signed payload-bearing fields (profile,
+// subject, assertion, chain) plus envelope-level critical extensions. It does
+// NOT require signatures, so it is the structural gate the signer runs before
+// producing them.
+func (e Envelope) validatePayloadParts() error {
+	if e.Profile != Profile {
+		return fmt.Errorf("%w: profile %q, want %q", ErrSchema, e.Profile, Profile)
+	}
+	if err := e.Subject.validate(); err != nil {
+		return err
+	}
+	if err := e.Assertion.validate(); err != nil {
+		return err
+	}
+	if e.Chain != nil {
+		if err := e.Chain.validate(); err != nil {
+			return err
+		}
+	}
+	return checkCriticalExtensions(e.CritExt)
+}
+
+// validateStructure runs the envelope-fatal schema checks that must hold before
+// any per-signature appraisal: the payload parts, a non-empty signature set, and
+// the envelope-wide invariants each protected header must satisfy (matching
+// profile and canonicalization, and only understood critical extensions).
+//
+// Algorithm recognition, key trust, and signature validity are deliberately NOT
+// checked here: those are per-signature outcomes (a single unknown-suite or
+// untrusted signature must not reject an envelope that also carries a verifiable
+// one). An unknown critical extension or a profile/canon mismatch, by contrast,
+// means the verifier cannot safely interpret the envelope at all — fail closed.
+func (e Envelope) validateStructure() error {
+	if err := e.validatePayloadParts(); err != nil {
+		return err
+	}
+	if len(e.Signatures) == 0 {
+		return fmt.Errorf("%w: envelope has no signatures", ErrSchema)
+	}
+	for i, s := range e.Signatures {
+		if s.Protected.Profile != Profile {
+			return fmt.Errorf("%w: signature[%d] profile %q, want %q", ErrUnknownSuite, i, s.Protected.Profile, Profile)
+		}
+		if s.Protected.Canon != CanonID {
+			return fmt.Errorf("%w: signature[%d] canon %q, want %q", ErrUnknownSuite, i, s.Protected.Canon, CanonID)
+		}
+		if err := checkCriticalExtensions(s.Protected.Crit); err != nil {
+			return fmt.Errorf("signature[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// Marshal returns the JSON encoding of an envelope.
+func Marshal(e Envelope) ([]byte, error) {
+	return json.Marshal(e)
+}
+
+// Unmarshal parses a JSON-encoded envelope, rejecting duplicate keys at any
+// nesting depth (parser-differential smuggling guard) and unknown fields in
+// AARP-controlled objects. The receipt subject digests, not the receipt bytes,
+// are what AARP signs, so strict decoding here cannot affect frozen receipts.
+func Unmarshal(data []byte) (Envelope, error) {
+	tree, err := contract.ParseJSONStrict(data)
+	if err != nil {
+		return Envelope{}, fmt.Errorf("%w: %w", ErrSchema, err)
+	}
+	// Reject any raw JSON number outside the I-JSON safe range anywhere in the
+	// envelope before decoding. Identity, digest, counter, timestamp, and amount
+	// fields must arrive as typed strings; a raw number in any position is a
+	// cross-language canonicalization hazard and is refused here.
+	if err := EnforceSafeNumbers(tree); err != nil {
+		return Envelope{}, err
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	dec.UseNumber() // future-proof: preserve integers if a numeric field is ever added
+	var e Envelope
+	if err := dec.Decode(&e); err != nil {
+		// Distinguish an unknown AARP field (a smuggling attempt) from an
+		// ordinary type/shape decode error, so errors.Is(err, ErrUnknownField)
+		// is not a false positive on, e.g., a type mismatch.
+		if strings.Contains(err.Error(), "unknown field") {
+			return Envelope{}, fmt.Errorf("%w: %w", ErrUnknownField, err)
+		}
+		return Envelope{}, fmt.Errorf("%w: %w", ErrSchema, err)
+	}
+	return e, nil
+}

--- a/internal/aarp/envelope.go
+++ b/internal/aarp/envelope.go
@@ -148,7 +148,7 @@ type Envelope struct {
 	Signatures []Signature `json:"signatures"`
 	// CritExt lists envelope-level critical extension names. Any name not in the
 	// known registry rejects the whole envelope (fail closed).
-	CritExt []string `json:"crit_ext,omitempty"`
+	CritExt []string `json:"crit_ext"`
 	// Ext carries non-critical extensions. Unknown non-critical extensions are
 	// ignored safely; they are not part of the signed payload.
 	Ext map[string]json.RawMessage `json:"ext,omitempty"`
@@ -294,8 +294,14 @@ func (e Envelope) validateStructure() error {
 	return nil
 }
 
-// Marshal returns the JSON encoding of an envelope.
+// Marshal returns the JSON encoding of an envelope. An empty critical-extension
+// list is emitted as "crit_ext": [] (never omitted), matching the signed payload
+// and the spec wire form so strict external implementations and golden vectors
+// agree byte-for-byte.
 func Marshal(e Envelope) ([]byte, error) {
+	if e.CritExt == nil {
+		e.CritExt = []string{}
+	}
 	return json.Marshal(e)
 }
 

--- a/internal/aarp/envelope_test.go
+++ b/internal/aarp/envelope_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSignVerify_RoundTrip(t *testing.T) {
+	env, opts := signedEnvelope(t)
+
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !ap.AssertionSigned {
+		t.Fatal("AssertionSigned = false, want true")
+	}
+	if !contains(ap.VerifiedClaims, ClaimAssertionSignatureValid) {
+		t.Errorf("missing %s in %v", ClaimAssertionSignatureValid, ap.VerifiedClaims)
+	}
+	if !contains(ap.VerifiedClaims, ClaimMediatorKeyPinned) {
+		t.Errorf("missing %s in %v", ClaimMediatorKeyPinned, ap.VerifiedClaims)
+	}
+	// complete-mediation is always claim-only and must never be verified.
+	if contains(ap.VerifiedClaims, "complete_mediation") || contains(ap.VerifiedClaims, "complete-mediation") {
+		t.Error("complete_mediation must never be verified")
+	}
+	if !contains(ap.ClaimedUnverified, "complete-mediation") {
+		t.Errorf("complete-mediation should be claimed-unverified, got %v", ap.ClaimedUnverified)
+	}
+	// does_not_assert must be present and never empty.
+	for _, want := range []string{"complete_mediation", "absence_of_bypass", "action_safety"} {
+		if !contains(ap.DoesNotAssert, want) {
+			t.Errorf("does_not_assert missing %q", want)
+		}
+	}
+	// The result must never carry a "trusted"/"safe" notion: the struct has no
+	// such field by construction. Sanity-check the JSON has no such key.
+	raw, _ := json.Marshal(ap)
+	for _, banned := range []string{`"trusted"`, `"safe"`} {
+		if strings.Contains(string(raw), banned) {
+			t.Errorf("appraisal JSON contains banned key %s", banned)
+		}
+	}
+}
+
+func TestVerify_MarshalRoundTripThenVerify(t *testing.T) {
+	env, opts := signedEnvelope(t)
+	data, err := Marshal(env)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got, err := Unmarshal(data)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	ap, err := Verify(got, opts)
+	if err != nil {
+		t.Fatalf("Verify after round-trip: %v", err)
+	}
+	if !ap.AssertionSigned {
+		t.Fatal("AssertionSigned = false after marshal round-trip")
+	}
+}
+
+func TestVerify_TamperedPayloadFails(t *testing.T) {
+	env, opts := signedEnvelope(t)
+	// Mutate the assertion AFTER signing: the signature covers the payload
+	// digest, so verification must fail.
+	env.Assertion.MediatorID = "attacker"
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("Verify returned error (want appraisal with failed sig): %v", err)
+	}
+	if ap.AssertionSigned {
+		t.Fatal("AssertionSigned = true after payload tamper")
+	}
+	if ap.Signatures[0].Status != SigFailed {
+		t.Errorf("signature status = %q, want %q", ap.Signatures[0].Status, SigFailed)
+	}
+}
+
+func TestVerify_UntrustedKey(t *testing.T) {
+	env, _ := signedEnvelope(t)
+	ap, err := Verify(env, VerifyOptions{TrustedKeys: map[string]ed25519.PublicKey{}})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if ap.AssertionSigned {
+		t.Fatal("AssertionSigned = true with empty trust set")
+	}
+	if ap.Signatures[0].Status != SigUnknownKey {
+		t.Errorf("status = %q, want %q", ap.Signatures[0].Status, SigUnknownKey)
+	}
+	// With no verified signature, even a claim like mediated is unverified.
+	if contains(ap.VerifiedClaims, ClaimMediatorKeyPinned) {
+		t.Error("mediator_key_pinned verified without a verified signature")
+	}
+}
+
+func TestVerify_WrongKeyForKeyID(t *testing.T) {
+	env, _ := signedEnvelope(t)
+	otherPub, _ := genKey(t)
+	ap, err := Verify(env, VerifyOptions{TrustedKeys: map[string]ed25519.PublicKey{testKeyID: otherPub}})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if ap.Signatures[0].Status != SigFailed {
+		t.Errorf("status = %q, want %q", ap.Signatures[0].Status, SigFailed)
+	}
+}
+
+func TestVerify_MediatorPinnedRequiresMatchingTrustEntry(t *testing.T) {
+	env, pub := signedEnvelopeWithKey(t)
+	// Trusted key but NO trust entry → signature verifies but mediated is not pinned.
+	ap, err := Verify(env, VerifyOptions{TrustedKeys: map[string]ed25519.PublicKey{testKeyID: pub}})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !ap.AssertionSigned {
+		t.Fatal("AssertionSigned = false with trusted key")
+	}
+	if contains(ap.VerifiedClaims, ClaimMediatorKeyPinned) {
+		t.Error("mediator_key_pinned verified without a trust entry")
+	}
+	if !contains(ap.ClaimedUnverified, "mediated") {
+		t.Errorf("mediated should be claimed-unverified, got %v", ap.ClaimedUnverified)
+	}
+}
+
+func TestVerify_MediatorIDMismatchRejectsPin(t *testing.T) {
+	env, pub := signedEnvelopeWithKey(t)
+	opts := VerifyOptions{
+		TrustedKeys: map[string]ed25519.PublicKey{testKeyID: pub},
+		// Trust entry names a DIFFERENT mediator than the assertion.
+		Trust: map[string]TrustEntry{testKeyID: {MediatorID: "other-mediator"}},
+	}
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if contains(ap.VerifiedClaims, ClaimMediatorKeyPinned) {
+		t.Error("mediator_key_pinned verified despite mediator_id mismatch")
+	}
+}
+
+func TestSign_RejectsNoSigners(t *testing.T) {
+	if _, err := Sign(baseEnvelope()); !errors.Is(err, ErrSchema) {
+		t.Fatalf("Sign with no signers = %v, want ErrSchema", err)
+	}
+}
+
+func TestSign_RejectsDuplicateKeyID(t *testing.T) {
+	_, priv := genKey(t)
+	s1, _ := NewEd25519Signer(testKeyID, "mediator", priv)
+	s2, _ := NewEd25519Signer(testKeyID, "issuer", priv)
+	if _, err := Sign(baseEnvelope(), s1, s2); !errors.Is(err, ErrSchema) {
+		t.Fatalf("Sign with duplicate key_id = %v, want ErrSchema", err)
+	}
+}
+
+func TestSign_RejectsInvalidPayload(t *testing.T) {
+	_, priv := genKey(t)
+	signer, _ := NewEd25519Signer(testKeyID, "mediator", priv)
+	bad := baseEnvelope()
+	bad.Subject.ActionRecordSHA256 = "not-a-digest"
+	if _, err := Sign(bad, signer); !errors.Is(err, ErrSchema) {
+		t.Fatalf("Sign with invalid subject = %v, want ErrSchema", err)
+	}
+}

--- a/internal/aarp/envelope_test.go
+++ b/internal/aarp/envelope_test.go
@@ -158,8 +158,14 @@ func TestSign_RejectsNoSigners(t *testing.T) {
 
 func TestSign_RejectsDuplicateKeyID(t *testing.T) {
 	_, priv := genKey(t)
-	s1, _ := NewEd25519Signer(testKeyID, "mediator", priv)
-	s2, _ := NewEd25519Signer(testKeyID, "issuer", priv)
+	s1, err := NewEd25519Signer(testKeyID, "mediator", priv)
+	if err != nil {
+		t.Fatalf("NewEd25519Signer s1: %v", err)
+	}
+	s2, err := NewEd25519Signer(testKeyID, "issuer", priv)
+	if err != nil {
+		t.Fatalf("NewEd25519Signer s2: %v", err)
+	}
 	if _, err := Sign(baseEnvelope(), s1, s2); !errors.Is(err, ErrSchema) {
 		t.Fatalf("Sign with duplicate key_id = %v, want ErrSchema", err)
 	}
@@ -167,7 +173,10 @@ func TestSign_RejectsDuplicateKeyID(t *testing.T) {
 
 func TestSign_RejectsInvalidPayload(t *testing.T) {
 	_, priv := genKey(t)
-	signer, _ := NewEd25519Signer(testKeyID, "mediator", priv)
+	signer, err := NewEd25519Signer(testKeyID, "mediator", priv)
+	if err != nil {
+		t.Fatalf("NewEd25519Signer: %v", err)
+	}
 	bad := baseEnvelope()
 	bad.Subject.ActionRecordSHA256 = "not-a-digest"
 	if _, err := Sign(bad, signer); !errors.Is(err, ErrSchema) {

--- a/internal/aarp/json_test.go
+++ b/internal/aarp/json_test.go
@@ -102,7 +102,10 @@ func TestUnmarshal_RejectsUnknownFieldInNestedObject(t *testing.T) {
 
 func TestUnmarshal_RejectsTrailingTokens(t *testing.T) {
 	env, _ := signedEnvelope(t)
-	raw, _ := Marshal(env)
+	raw, err := Marshal(env)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
 	withTrailer := append(append([]byte(nil), raw...), []byte(` {"x":1}`)...)
 	if _, err := Unmarshal(withTrailer); !errors.Is(err, ErrSchema) {
 		t.Fatalf("Unmarshal(trailing tokens) = %v, want ErrSchema", err)

--- a/internal/aarp/json_test.go
+++ b/internal/aarp/json_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// validEnvelopeJSON returns the JSON of a signed, structurally valid envelope as
+// a generic map so tests can splice hostile fields into specific positions.
+func validEnvelopeJSON(t *testing.T) map[string]any {
+	t.Helper()
+	env, _ := signedEnvelope(t)
+	raw, err := Marshal(env)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal to map: %v", err)
+	}
+	return m
+}
+
+func TestUnmarshal_RejectsRawUnsafeNumber(t *testing.T) {
+	// done-state item 2: an unsafe integer as a RAW JSON number is rejected. The
+	// same value as a typed string is fine (the chain seq field below).
+	m := validEnvelopeJSON(t)
+	m["chain"] = map[string]any{
+		"issuer_id":  "issuer-1",
+		"seq":        json.Number("9007199254740992"), // 2^53 as a raw number
+		"prior_hash": GenesisPriorHash,
+	}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := Unmarshal(raw); !errors.Is(err, ErrUnsafeNumber) {
+		t.Fatalf("Unmarshal(raw unsafe number) = %v, want ErrUnsafeNumber", err)
+	}
+}
+
+func TestUnmarshal_AcceptsTypedStringForSameValue(t *testing.T) {
+	// The same large value as a typed string passes number-safety and decodes.
+	m := validEnvelopeJSON(t)
+	m["chain"] = map[string]any{
+		"issuer_id":  "issuer-1",
+		"seq":        "9007199254740992", // typed string: allowed
+		"prior_hash": strings.Repeat("a", 64),
+	}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got, err := Unmarshal(raw)
+	if err != nil {
+		t.Fatalf("Unmarshal(typed string) = %v, want nil", err)
+	}
+	if got.Chain == nil || got.Chain.Seq != "9007199254740992" {
+		t.Fatalf("chain seq not decoded: %+v", got.Chain)
+	}
+}
+
+func TestUnmarshal_RejectsDuplicateKeys(t *testing.T) {
+	// A duplicate key is a parser-differential smuggling vector; reject at the
+	// raw layer before any struct decode.
+	raw := []byte(`{"profile":"aarp/v0.1","profile":"aarp/v9.9","subject":{},"assertion":{},"signatures":[]}`)
+	if _, err := Unmarshal(raw); !errors.Is(err, ErrSchema) {
+		t.Fatalf("Unmarshal(duplicate key) = %v, want ErrSchema", err)
+	}
+}
+
+func TestUnmarshal_RejectsUnknownField(t *testing.T) {
+	m := validEnvelopeJSON(t)
+	m["x_attacker_field"] = "smuggled"
+	raw, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := Unmarshal(raw); !errors.Is(err, ErrUnknownField) {
+		t.Fatalf("Unmarshal(unknown field) = %v, want ErrUnknownField", err)
+	}
+}
+
+func TestUnmarshal_RejectsUnknownFieldInNestedObject(t *testing.T) {
+	m := validEnvelopeJSON(t)
+	subj := m["subject"].(map[string]any)
+	subj["x_extra"] = "smuggled"
+	raw, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := Unmarshal(raw); !errors.Is(err, ErrUnknownField) {
+		t.Fatalf("Unmarshal(unknown nested field) = %v, want ErrUnknownField", err)
+	}
+}
+
+func TestUnmarshal_RejectsTrailingTokens(t *testing.T) {
+	env, _ := signedEnvelope(t)
+	raw, _ := Marshal(env)
+	withTrailer := append(append([]byte(nil), raw...), []byte(` {"x":1}`)...)
+	if _, err := Unmarshal(withTrailer); !errors.Is(err, ErrSchema) {
+		t.Fatalf("Unmarshal(trailing tokens) = %v, want ErrSchema", err)
+	}
+}
+
+// TestCanonicalPayload_Deterministic proves the canonical payload bytes are
+// stable across re-marshaling (the property all parallel signatures rely on).
+func TestCanonicalPayload_Deterministic(t *testing.T) {
+	env, _ := signedEnvelope(t)
+	d1, err := env.PayloadDigest()
+	if err != nil {
+		t.Fatalf("PayloadDigest: %v", err)
+	}
+	// Round-trip through JSON and recompute.
+	raw, _ := Marshal(env)
+	got, err := Unmarshal(raw)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	d2, err := got.PayloadDigest()
+	if err != nil {
+		t.Fatalf("PayloadDigest after round-trip: %v", err)
+	}
+	if d1 != d2 {
+		t.Fatalf("payload digest changed across round-trip: %s != %s", d1, d2)
+	}
+}
+
+func TestUnknownClaim_ReportedClaimOnly(t *testing.T) {
+	pub, priv := genKey(t)
+	signer, _ := NewEd25519Signer(testKeyID, "mediator", priv)
+	e := baseEnvelope()
+	e.Assertion.Claimed = []string{"some_future_claim"}
+	env, _ := Sign(e, signer)
+	ap, err := Verify(env, VerifyOptions{TrustedKeys: map[string]ed25519.PublicKey{testKeyID: pub}})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !contains(ap.ClaimedUnverified, "some_future_claim") {
+		t.Errorf("unknown claim not reported claim-only: %v", ap.ClaimedUnverified)
+	}
+}

--- a/internal/aarp/numbers.go
+++ b/internal/aarp/numbers.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+)
+
+// The I-JSON safe-integer range. JSON numbers are interoperable across
+// languages only inside [-(2^53-1), 2^53-1]; outside it, a JavaScript or
+// other-language verifier silently rounds to the nearest float64, which changes
+// the canonical bytes and breaks the signature. AARP therefore allows raw JSON
+// numbers ONLY inside this range and requires every identity, digest, counter,
+// timestamp, or amount field to be a typed string instead.
+const (
+	maxSafeInteger = (1 << 53) - 1
+	minSafeInteger = -((1 << 53) - 1)
+)
+
+// Number-safety failure classes. Callers map these to their result contracts;
+// compare with errors.Is.
+var (
+	// ErrUnsafeNumber means a raw JSON number is a float, uses exponent form,
+	// is negative zero, or falls outside the I-JSON safe-integer range.
+	ErrUnsafeNumber = errors.New("aarp: unsafe JSON number; identity/digest/amount/timestamp fields must be typed strings")
+
+	// ErrBadGrammar means a typed-string field does not match its declared
+	// grammar (hex digest, decimal amount, unsigned counter, RFC3339Nano time).
+	ErrBadGrammar = errors.New("aarp: typed-string field violates its grammar")
+)
+
+// EnforceSafeNumbers walks a parsed JSON tree (as produced by
+// contract.ParseJSONStrict, which decodes numbers as json.Number) and rejects
+// any number that is not a safe integer. It is the structural guard that makes
+// an AARP envelope canonicalize identically across languages.
+//
+// A safe number is an integer with no fractional part, no exponent, not
+// negative zero, and within [minSafeInteger, maxSafeInteger]. Everything else
+// belongs in a typed string and is rejected here so it can never reach the
+// canonical signing input.
+func EnforceSafeNumbers(tree any) error {
+	return enforceSafeNumbers(tree, "$")
+}
+
+func enforceSafeNumbers(v any, path string) error {
+	switch x := v.(type) {
+	case json.Number:
+		return checkSafeNumber(string(x), path)
+	case map[string]any:
+		for k, val := range x {
+			if err := enforceSafeNumbers(val, path+"."+k); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for i, val := range x {
+			if err := enforceSafeNumbers(val, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+	}
+	// Strings, bools, and nil carry no numeric interoperability hazard.
+	return nil
+}
+
+// checkSafeNumber validates a single raw JSON number literal. The literal is the
+// exact source text json.Number preserves, so float/exponent/negative-zero
+// detection is done on the text before any lossy conversion.
+func checkSafeNumber(lit, path string) error {
+	if lit == "" {
+		return fmt.Errorf("%w: empty number at %s", ErrUnsafeNumber, path)
+	}
+	// Float and exponent forms are forbidden outright: their value-vs-text
+	// relationship is what diverges across language parsers.
+	if strings.ContainsAny(lit, ".eE") {
+		return fmt.Errorf("%w: float or exponent form %q at %s", ErrUnsafeNumber, lit, path)
+	}
+	// Negative zero is a distinct text with an ambiguous canonical form.
+	if lit == "-0" {
+		return fmt.Errorf("%w: negative zero at %s", ErrUnsafeNumber, path)
+	}
+	n, ok := new(big.Int).SetString(lit, 10)
+	if !ok {
+		return fmt.Errorf("%w: non-integer literal %q at %s", ErrUnsafeNumber, lit, path)
+	}
+	if n.Cmp(big.NewInt(maxSafeInteger)) > 0 || n.Cmp(big.NewInt(minSafeInteger)) < 0 {
+		return fmt.Errorf("%w: %q outside I-JSON safe range at %s", ErrUnsafeNumber, lit, path)
+	}
+	return nil
+}
+
+// hexDigestLen is the lowercase-hex length of a SHA-256 digest.
+const hexDigestLen = 64
+
+// ValidateHex256 checks a lowercase-hex SHA-256 digest grammar: exactly 64
+// characters drawn from [0-9a-f]. Uppercase is rejected so the canonical bytes
+// are stable (a digest is identity, not free text).
+func ValidateHex256(s string) error {
+	if len(s) != hexDigestLen {
+		return fmt.Errorf("%w: digest length %d, want %d", ErrBadGrammar, len(s), hexDigestLen)
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return fmt.Errorf("%w: digest contains non-lowercase-hex byte %q", ErrBadGrammar, c)
+		}
+	}
+	return nil
+}
+
+// ValidateUint64String checks an unsigned decimal counter grammar: one or more
+// digits, no sign, no leading zeros (except the single literal "0"), within
+// uint64. Sequence numbers, nanosecond timestamps, and large counters use this
+// because their values routinely exceed the I-JSON safe range.
+func ValidateUint64String(s string) error {
+	if s == "" {
+		return fmt.Errorf("%w: empty unsigned counter", ErrBadGrammar)
+	}
+	if s == "0" {
+		return nil
+	}
+	if s[0] == '0' {
+		return fmt.Errorf("%w: leading zero in counter %q", ErrBadGrammar, s)
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return fmt.Errorf("%w: non-digit in counter %q", ErrBadGrammar, s)
+		}
+	}
+	n, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		return fmt.Errorf("%w: unparseable counter %q", ErrBadGrammar, s)
+	}
+	// Range-check against uint64 without overflow.
+	maxU64 := new(big.Int).SetUint64(^uint64(0))
+	if n.Cmp(maxU64) > 0 {
+		return fmt.Errorf("%w: counter %q exceeds uint64", ErrBadGrammar, s)
+	}
+	return nil
+}
+
+// ValidateDecimalAmount checks a fixed-point decimal amount grammar: an optional
+// leading minus, an integer part with no leading zeros (except a single "0"), an
+// optional fractional part with at least one digit and no trailing zeros, no
+// exponent, and no negative zero. Amounts are typed strings so currency and
+// quantity values never ride through a float.
+func ValidateDecimalAmount(s string) error {
+	if s == "" {
+		return fmt.Errorf("%w: empty amount", ErrBadGrammar)
+	}
+	neg := false
+	body := s
+	if body[0] == '-' {
+		neg = true
+		body = body[1:]
+	}
+	if body == "" {
+		return fmt.Errorf("%w: amount has sign but no digits", ErrBadGrammar)
+	}
+	intPart, fracPart, hasFrac := strings.Cut(body, ".")
+	if intPart == "" {
+		return fmt.Errorf("%w: amount missing integer part in %q", ErrBadGrammar, s)
+	}
+	if len(intPart) > 1 && intPart[0] == '0' {
+		return fmt.Errorf("%w: leading zero in amount %q", ErrBadGrammar, s)
+	}
+	if !allDigits(intPart) {
+		return fmt.Errorf("%w: non-digit in amount integer part %q", ErrBadGrammar, s)
+	}
+	allZeroInt := strings.Trim(intPart, "0") == ""
+	allZeroFrac := true
+	if hasFrac {
+		if fracPart == "" {
+			return fmt.Errorf("%w: amount has decimal point but no fraction in %q", ErrBadGrammar, s)
+		}
+		if !allDigits(fracPart) {
+			return fmt.Errorf("%w: non-digit in amount fraction %q", ErrBadGrammar, s)
+		}
+		if fracPart[len(fracPart)-1] == '0' {
+			return fmt.Errorf("%w: trailing zero in amount fraction %q", ErrBadGrammar, s)
+		}
+		allZeroFrac = strings.Trim(fracPart, "0") == ""
+	}
+	if neg && allZeroInt && allZeroFrac {
+		return fmt.Errorf("%w: negative zero amount %q", ErrBadGrammar, s)
+	}
+	return nil
+}
+
+// ValidateTimestamp checks an RFC 3339 timestamp with nanosecond precision and a
+// mandatory zone. Times are typed strings (never epoch numbers) so a verifier in
+// any language parses the same instant from the same bytes.
+func ValidateTimestamp(s string) error {
+	if s == "" {
+		return fmt.Errorf("%w: empty timestamp", ErrBadGrammar)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, s); err != nil {
+		return fmt.Errorf("%w: timestamp %q is not RFC3339Nano: %w", ErrBadGrammar, s, err)
+	}
+	return nil
+}
+
+func allDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
+}

--- a/internal/aarp/numbers_test.go
+++ b/internal/aarp/numbers_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+)
+
+// parseTree decodes JSON the same way the envelope path does: strict (duplicate
+// keys rejected, integers preserved as json.Number).
+func parseTree(t *testing.T, s string) any {
+	t.Helper()
+	tree, err := contract.ParseJSONStrict([]byte(s))
+	if err != nil {
+		t.Fatalf("ParseJSONStrict(%q): %v", s, err)
+	}
+	return tree
+}
+
+func TestEnforceSafeNumbers_RejectsUnsafe(t *testing.T) {
+	// Each input carries a number that must be rejected. These are the
+	// cross-language signature-mismatch vectors: a JS verifier would round or
+	// reinterpret them, so they must never reach the canonical signing input.
+	cases := []struct {
+		name string
+		json string
+	}{
+		{"float", `{"x": 1.5}`},
+		{"exponent_lower", `{"x": 1e3}`},
+		{"exponent_upper", `{"x": 1E3}`},
+		{"exponent_negative", `{"x": 1e-3}`},
+		{"negative_zero", `{"x": -0}`},
+		{"above_safe_range", `{"x": 9007199254740992}`}, // 2^53
+		{"far_above_safe_range", `{"x": 18446744073709551615}`},
+		{"below_safe_range", `{"x": -9007199254740992}`}, // -(2^53)
+		{"nested_in_array", `{"a": [1, 2, 9007199254740993]}`},
+		{"nested_in_object", `{"a": {"b": {"c": 1.0}}}`},
+		{"fractional_zero", `{"x": 0.0}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := parseTree(t, tc.json)
+			err := EnforceSafeNumbers(tree)
+			if !errors.Is(err, ErrUnsafeNumber) {
+				t.Fatalf("EnforceSafeNumbers(%s) = %v, want ErrUnsafeNumber", tc.json, err)
+			}
+		})
+	}
+}
+
+func TestEnforceSafeNumbers_AllowsSafe(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+	}{
+		{"zero", `{"x": 0}`},
+		{"small_positive", `{"x": 42}`},
+		{"small_negative", `{"x": -42}`},
+		{"max_safe", `{"x": 9007199254740991}`},  // 2^53-1
+		{"min_safe", `{"x": -9007199254740991}`}, // -(2^53-1)
+		{"strings_unaffected", `{"x": "9007199254740992", "y": "1.5"}`},
+		{"bools_and_null", `{"a": true, "b": false, "c": null}`},
+		{"safe_in_array", `{"a": [0, 1, -1, 9007199254740991]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := parseTree(t, tc.json)
+			if err := EnforceSafeNumbers(tree); err != nil {
+				t.Fatalf("EnforceSafeNumbers(%s) = %v, want nil", tc.json, err)
+			}
+		})
+	}
+}
+
+func TestValidateHex256(t *testing.T) {
+	good := strings.Repeat("a", 64)
+	if err := ValidateHex256(good); err != nil {
+		t.Fatalf("ValidateHex256(64 a) = %v, want nil", err)
+	}
+	bad := []struct {
+		name, in string
+	}{
+		{"too_short", strings.Repeat("a", 63)},
+		{"too_long", strings.Repeat("a", 65)},
+		{"uppercase", strings.Repeat("A", 64)},
+		{"non_hex", strings.Repeat("g", 64)},
+		{"empty", ""},
+		{"mixed_case", strings.Repeat("a", 63) + "B"},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateHex256(tc.in); !errors.Is(err, ErrBadGrammar) {
+				t.Fatalf("ValidateHex256(%q) = %v, want ErrBadGrammar", tc.in, err)
+			}
+		})
+	}
+}
+
+func TestValidateUint64String(t *testing.T) {
+	good := []string{"0", "1", "42", "18446744073709551615"} // max uint64
+	for _, s := range good {
+		if err := ValidateUint64String(s); err != nil {
+			t.Errorf("ValidateUint64String(%q) = %v, want nil", s, err)
+		}
+	}
+	bad := []struct {
+		name, in string
+	}{
+		{"empty", ""},
+		{"leading_zero", "01"},
+		{"negative", "-1"},
+		{"plus", "+1"},
+		{"float", "1.0"},
+		{"hex", "0x10"},
+		{"overflow_uint64", "18446744073709551616"},
+		{"letters", "12a"},
+		{"space", "1 "},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateUint64String(tc.in); !errors.Is(err, ErrBadGrammar) {
+				t.Fatalf("ValidateUint64String(%q) = %v, want ErrBadGrammar", tc.in, err)
+			}
+		})
+	}
+}
+
+func TestValidateDecimalAmount(t *testing.T) {
+	good := []string{"0", "1", "-1", "0.5", "-0.5", "123.456", "1000000", "-1000000.01"}
+	for _, s := range good {
+		if err := ValidateDecimalAmount(s); err != nil {
+			t.Errorf("ValidateDecimalAmount(%q) = %v, want nil", s, err)
+		}
+	}
+	bad := []struct {
+		name, in string
+	}{
+		{"empty", ""},
+		{"sign_only", "-"},
+		{"leading_zero_int", "01"},
+		{"trailing_zero_frac", "1.50"},
+		{"trailing_zero_frac_only", "0.0"},
+		{"negative_zero", "-0"},
+		{"negative_zero_frac", "-0.0"},
+		{"exponent", "1e3"},
+		{"no_int_part", ".5"},
+		{"empty_frac", "1."},
+		{"double_dot", "1.2.3"},
+		{"letters", "1.2a"},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateDecimalAmount(tc.in); !errors.Is(err, ErrBadGrammar) {
+				t.Fatalf("ValidateDecimalAmount(%q) = %v, want ErrBadGrammar", tc.in, err)
+			}
+		})
+	}
+}
+
+func TestValidateTimestamp(t *testing.T) {
+	good := []string{
+		"2026-06-01T00:00:00Z",
+		"2026-06-01T00:00:00.123456789Z",
+		"2026-06-01T00:00:00+02:00",
+	}
+	for _, s := range good {
+		if err := ValidateTimestamp(s); err != nil {
+			t.Errorf("ValidateTimestamp(%q) = %v, want nil", s, err)
+		}
+	}
+	bad := []struct {
+		name, in string
+	}{
+		{"empty", ""},
+		{"no_zone", "2026-06-01T00:00:00"},
+		{"date_only", "2026-06-01"},
+		{"epoch_number_as_string", "1748736000"},
+		{"garbage", "not-a-time"},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateTimestamp(tc.in); !errors.Is(err, ErrBadGrammar) {
+				t.Fatalf("ValidateTimestamp(%q) = %v, want ErrBadGrammar", tc.in, err)
+			}
+		})
+	}
+}

--- a/internal/aarp/sign.go
+++ b/internal/aarp/sign.go
@@ -104,6 +104,22 @@ func (s *MLDSA65Signer) signInput([]byte) (string, error) {
 // optional Chain) must already be set and valid; existing Signatures are
 // replaced. At least one signer is required, and every signer's suite must be
 // shape-valid and implemented.
+// isNilSigner reports whether s is nil, including a typed-nil pointer wrapped in
+// the Signer interface (a non-nil interface holding a nil *Ed25519Signer or
+// *MLDSA65Signer). Calling a method on such a value would dereference nil.
+func isNilSigner(s Signer) bool {
+	switch v := s.(type) {
+	case nil:
+		return true
+	case *Ed25519Signer:
+		return v == nil
+	case *MLDSA65Signer:
+		return v == nil
+	default:
+		return false
+	}
+}
+
 func Sign(e Envelope, signers ...Signer) (Envelope, error) {
 	if len(signers) == 0 {
 		return Envelope{}, fmt.Errorf("%w: at least one signer is required", ErrSchema)
@@ -121,6 +137,11 @@ func Sign(e Envelope, signers ...Signer) (Envelope, error) {
 	sigs := make([]Signature, 0, len(signers))
 	seenKeyIDs := make(map[string]struct{}, len(signers))
 	for i, signer := range signers {
+		// Guard typed-nil and untyped-nil signers before any method call: a
+		// nil *Ed25519Signer / *MLDSA65Signer would panic on Header().
+		if isNilSigner(signer) {
+			return Envelope{}, fmt.Errorf("%w: signer[%d] is nil", ErrSchema, i)
+		}
 		h := signer.Header()
 		if err := h.validateSuiteShape(); err != nil {
 			return Envelope{}, fmt.Errorf("signer[%d]: %w", i, err)

--- a/internal/aarp/sign.go
+++ b/internal/aarp/sign.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+// Signer produces one parallel signature under a fixed protected suite. Each
+// signer binds the same shared payload digest under its own suite, so adding a
+// signer adds a parallel signature and never re-signs another signer's output.
+type Signer interface {
+	// Header returns the protected suite header this signer emits. It is covered
+	// by the signature, so the verifier learns the exact suite from signed bytes.
+	Header() ProtectedHeader
+	// signInput signs the canonical signing-input bytes and returns the
+	// "<alg>:<base64-std>" wire form.
+	signInput(input []byte) (string, error)
+}
+
+// Ed25519Signer signs the assurance assertion with Ed25519 PureEdDSA, the
+// default and only implemented suite.
+type Ed25519Signer struct {
+	keyID      string
+	signerRole string
+	priv       ed25519.PrivateKey
+}
+
+// NewEd25519Signer builds an Ed25519 signer for the given key id and signer
+// role. The role must be in the known role vocabulary.
+func NewEd25519Signer(keyID, signerRole string, priv ed25519.PrivateKey) (*Ed25519Signer, error) {
+	if keyID == "" {
+		return nil, fmt.Errorf("%w: empty key_id", ErrMalformedSuite)
+	}
+	if !knownSignerRoles[signerRole] {
+		return nil, fmt.Errorf("%w: unknown signer_role %q", ErrMalformedSuite, signerRole)
+	}
+	if len(priv) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("%w: ed25519 private key size %d, want %d", ErrMalformedSuite, len(priv), ed25519.PrivateKeySize)
+	}
+	return &Ed25519Signer{keyID: keyID, signerRole: signerRole, priv: priv}, nil
+}
+
+// Header returns the protected suite for this Ed25519 signer.
+func (s *Ed25519Signer) Header() ProtectedHeader {
+	return ProtectedHeader{
+		Profile:    Profile,
+		Canon:      CanonID,
+		Alg:        string(AlgEd25519),
+		KeyType:    keyTypeForAlg[AlgEd25519],
+		KeyID:      s.keyID,
+		SignerRole: s.signerRole,
+	}
+}
+
+func (s *Ed25519Signer) signInput(input []byte) (string, error) {
+	sig := ed25519.Sign(s.priv, input)
+	return string(AlgEd25519) + ":" + base64.StdEncoding.EncodeToString(sig), nil
+}
+
+// MLDSA65Signer is the typed-but-unimplemented post-quantum signer slot. Its
+// header makes a PQ or hybrid envelope structurally first-class today; signing
+// fails closed with ErrSuiteUnimplemented until FIPS 204 / ML-DSA errata settle.
+type MLDSA65Signer struct {
+	keyID      string
+	signerRole string
+}
+
+// NewMLDSA65Signer builds the typed PQ signer slot. Calling Sign with it returns
+// ErrSuiteUnimplemented; it exists so the multi-signature envelope shape is
+// proven against a real second suite without shipping unsettled PQ crypto.
+func NewMLDSA65Signer(keyID, signerRole string) (*MLDSA65Signer, error) {
+	if keyID == "" {
+		return nil, fmt.Errorf("%w: empty key_id", ErrMalformedSuite)
+	}
+	if !knownSignerRoles[signerRole] {
+		return nil, fmt.Errorf("%w: unknown signer_role %q", ErrMalformedSuite, signerRole)
+	}
+	return &MLDSA65Signer{keyID: keyID, signerRole: signerRole}, nil
+}
+
+// Header returns the protected suite for the PQ slot.
+func (s *MLDSA65Signer) Header() ProtectedHeader {
+	return ProtectedHeader{
+		Profile:    Profile,
+		Canon:      CanonID,
+		Alg:        string(AlgMLDSA65),
+		KeyType:    keyTypeForAlg[AlgMLDSA65],
+		KeyID:      s.keyID,
+		SignerRole: s.signerRole,
+	}
+}
+
+func (s *MLDSA65Signer) signInput([]byte) (string, error) {
+	return "", fmt.Errorf("%w: alg %q", ErrSuiteUnimplemented, AlgMLDSA65)
+}
+
+// Sign populates an envelope's Signatures by signing the shared payload digest
+// with each signer in parallel. The envelope's Profile/Subject/Assertion (and
+// optional Chain) must already be set and valid; existing Signatures are
+// replaced. At least one signer is required, and every signer's suite must be
+// shape-valid and implemented.
+func Sign(e Envelope, signers ...Signer) (Envelope, error) {
+	if len(signers) == 0 {
+		return Envelope{}, fmt.Errorf("%w: at least one signer is required", ErrSchema)
+	}
+	if e.Profile == "" {
+		e.Profile = Profile
+	}
+	if err := e.validatePayloadParts(); err != nil {
+		return Envelope{}, err
+	}
+	digest, err := e.PayloadDigest()
+	if err != nil {
+		return Envelope{}, err
+	}
+	sigs := make([]Signature, 0, len(signers))
+	seenKeyIDs := make(map[string]struct{}, len(signers))
+	for i, signer := range signers {
+		h := signer.Header()
+		if err := h.validateSuiteShape(); err != nil {
+			return Envelope{}, fmt.Errorf("signer[%d]: %w", i, err)
+		}
+		if err := h.checkImplemented(); err != nil {
+			return Envelope{}, fmt.Errorf("signer[%d]: %w", i, err)
+		}
+		// Two signatures under the same key id would be redundant and ambiguous
+		// for per-signature appraisal; require distinct key ids in one envelope.
+		if _, dup := seenKeyIDs[h.KeyID]; dup {
+			return Envelope{}, fmt.Errorf("%w: duplicate signer key_id %q", ErrSchema, h.KeyID)
+		}
+		seenKeyIDs[h.KeyID] = struct{}{}
+
+		input, err := signingInput(digest, h)
+		if err != nil {
+			return Envelope{}, err
+		}
+		wire, err := signer.signInput(input)
+		if err != nil {
+			return Envelope{}, fmt.Errorf("signer[%d]: %w", i, err)
+		}
+		sigs = append(sigs, Signature{Protected: h, Sig: wire})
+	}
+	e.Signatures = sigs
+	return e, nil
+}
+
+// decodeSigWire splits an "<alg>:<base64-std>" signature into its algorithm and
+// raw bytes. A wrong prefix or bad base64 is a malformed signature.
+func decodeSigWire(alg, wire string) ([]byte, error) {
+	prefix := alg + ":"
+	if !strings.HasPrefix(wire, prefix) {
+		return nil, fmt.Errorf("%w: signature wire missing %q prefix", ErrSchema, prefix)
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(wire, prefix))
+	if err != nil {
+		return nil, fmt.Errorf("%w: signature base64: %w", ErrSchema, err)
+	}
+	return raw, nil
+}

--- a/internal/aarp/suite.go
+++ b/internal/aarp/suite.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Suite failure classes. Compare with errors.Is.
+var (
+	// ErrUnknownSuite means a protected signature header names a profile,
+	// canonicalization, or algorithm this verifier does not implement. Such a
+	// signature never verifies and is never "downgraded" to verification under
+	// a different suite — there is no fallback.
+	ErrUnknownSuite = errors.New("aarp: unknown signature suite; fail closed, no fallback")
+
+	// ErrSuiteUnimplemented means the suite is a recognized, typed slot whose
+	// signing/verification is not yet built (the post-quantum slot). A signature
+	// under such a suite is reported as unverified, never as valid.
+	ErrSuiteUnimplemented = errors.New("aarp: signature suite recognized but not implemented")
+
+	// ErrMalformedSuite means the protected header is structurally invalid: a
+	// missing key id, an empty role, or an algorithm/key-type mismatch.
+	ErrMalformedSuite = errors.New("aarp: malformed signature suite")
+
+	// ErrUnknownCriticalExtension means a signature or envelope marks an
+	// extension critical that this verifier does not understand. The whole
+	// envelope is rejected: a producer that flags something critical is
+	// asserting it must be processed, and a verifier that cannot process it
+	// cannot safely appraise the envelope. Fail closed.
+	ErrUnknownCriticalExtension = errors.New("aarp: unknown critical extension; cannot appraise, fail closed")
+)
+
+// AlgID identifies a signature algorithm in a protected suite.
+type AlgID string
+
+const (
+	// AlgEd25519 is Ed25519 PureEdDSA, the default and only implemented suite.
+	AlgEd25519 AlgID = "ed25519"
+	// AlgMLDSA65 is the FIPS 204 ML-DSA-65 post-quantum slot. It is a recognized,
+	// typed suite so a hybrid or PQ-only envelope is structurally first-class
+	// today, but its signer/verifier is deferred until the standard's errata
+	// settle. Verification of an ML-DSA-65 signature returns ErrSuiteUnimplemented.
+	AlgMLDSA65 AlgID = "ml-dsa-65"
+)
+
+// keyTypeForAlg maps each recognized algorithm to its required key type. A
+// protected header whose key_type disagrees with its alg is malformed.
+var keyTypeForAlg = map[AlgID]string{
+	AlgEd25519: "ed25519",
+	AlgMLDSA65: "ml-dsa",
+}
+
+// implementedAlgs is the set of algorithms whose verification is built. An alg
+// that is recognized (in keyTypeForAlg) but not implemented here is a typed
+// stub: it fails closed with ErrSuiteUnimplemented, never a fallback verify.
+var implementedAlgs = map[AlgID]bool{
+	AlgEd25519: true,
+}
+
+// knownSignerRoles is the closed set of signer roles a protected header may
+// claim. The role is advisory for display and policy; an unknown role is a
+// malformed suite (the producer is outside the agreed vocabulary).
+var knownSignerRoles = map[string]bool{
+	"mediator":   true,
+	"issuer":     true,
+	"countersig": true,
+}
+
+// knownCriticalExtensions is the registry of critical-extension names this
+// verifier understands. It is empty in v0.1: no critical extension is defined
+// yet, so any name flagged critical fails the envelope closed. New critical
+// extensions are added here as they are specified and implemented.
+var knownCriticalExtensions = map[string]bool{}
+
+// ProtectedHeader is the per-signature suite descriptor. It is covered by its
+// own signature's bytes (it is part of the canonical signing input), so a
+// verifier can never be tricked into matching bytes produced under a different
+// algorithm, canonicalization, or profile version. This is authenticated
+// agility: agility lives inside the signed envelope, not in an unprotected
+// sibling label.
+type ProtectedHeader struct {
+	Profile    string   `json:"profile"`
+	Canon      string   `json:"canon"`
+	Alg        string   `json:"alg"`
+	KeyType    string   `json:"key_type"`
+	KeyID      string   `json:"key_id"`
+	SignerRole string   `json:"signer_role"`
+	Crit       []string `json:"crit,omitempty"`
+}
+
+// validateSuiteShape checks structural suite validity that applies regardless of
+// whether the alg is implemented: profile/canon match, key id and role present,
+// alg recognized, key_type consistent with alg, and all critical extensions
+// understood. It does NOT decide implementability — that is checkImplemented.
+func (h ProtectedHeader) validateSuiteShape() error {
+	if h.Profile != Profile {
+		return fmt.Errorf("%w: profile %q, want %q", ErrUnknownSuite, h.Profile, Profile)
+	}
+	if h.Canon != CanonID {
+		return fmt.Errorf("%w: canon %q, want %q", ErrUnknownSuite, h.Canon, CanonID)
+	}
+	wantKeyType, ok := keyTypeForAlg[AlgID(h.Alg)]
+	if !ok {
+		return fmt.Errorf("%w: alg %q", ErrUnknownSuite, h.Alg)
+	}
+	if h.KeyType != wantKeyType {
+		return fmt.Errorf("%w: alg %q requires key_type %q, got %q", ErrMalformedSuite, h.Alg, wantKeyType, h.KeyType)
+	}
+	if h.KeyID == "" {
+		return fmt.Errorf("%w: empty key_id", ErrMalformedSuite)
+	}
+	if !knownSignerRoles[h.SignerRole] {
+		return fmt.Errorf("%w: unknown signer_role %q", ErrMalformedSuite, h.SignerRole)
+	}
+	if err := checkCriticalExtensions(h.Crit); err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkImplemented reports whether the (already shape-valid) suite's algorithm
+// has a built verifier. A recognized-but-unimplemented alg returns
+// ErrSuiteUnimplemented so the caller reports the signature unverified.
+func (h ProtectedHeader) checkImplemented() error {
+	if !implementedAlgs[AlgID(h.Alg)] {
+		return fmt.Errorf("%w: alg %q", ErrSuiteUnimplemented, h.Alg)
+	}
+	return nil
+}
+
+// checkCriticalExtensions rejects any critical-extension name not in the known
+// registry. Duplicate and empty names are also rejected as malformed: a
+// critical-extension list must be an unambiguous set of understood names.
+//
+// Structural validity (no empty, no duplicate) is checked first, then
+// known-ness, so a duplicated unknown name is reported as the duplicate it is
+// rather than masked by the unknown check. Both outcomes fail the envelope
+// closed; the ordering only sharpens the error.
+func checkCriticalExtensions(crit []string) error {
+	seen := make(map[string]struct{}, len(crit))
+	for _, name := range crit {
+		if name == "" {
+			return fmt.Errorf("%w: empty critical extension name", ErrMalformedSuite)
+		}
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf("%w: duplicate critical extension %q", ErrMalformedSuite, name)
+		}
+		seen[name] = struct{}{}
+	}
+	for name := range seen {
+		if !knownCriticalExtensions[name] {
+			return fmt.Errorf("%w: %q", ErrUnknownCriticalExtension, name)
+		}
+	}
+	return nil
+}

--- a/internal/aarp/suite_test.go
+++ b/internal/aarp/suite_test.go
@@ -152,16 +152,27 @@ func TestAlgSubstitution_Fails(t *testing.T) {
 	}
 }
 
-func TestUnknownCriticalExtension_RejectsEnvelope(t *testing.T) {
+// TestUnknownCriticalExtension_PerSignature: an unknown critical extension in a
+// signature's protected header makes only that signature unverifiable, not the
+// whole envelope (the signatures array is appendable, so it must not be fatal).
+func TestUnknownCriticalExtension_PerSignature(t *testing.T) {
 	env, opts := signedEnvelope(t)
-	// Mark an extension critical that the verifier does not understand.
 	env.Signatures[0].Protected.Crit = []string{"x-attacker-ext"}
-	_, err := Verify(env, opts)
-	if !errors.Is(err, ErrUnknownCriticalExtension) {
-		t.Fatalf("Verify = %v, want ErrUnknownCriticalExtension", err)
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("Verify returned envelope error (want per-signature status): %v", err)
+	}
+	if ap.AssertionSigned {
+		t.Fatal("AssertionSigned = true despite the only signature having an unknown critical extension")
+	}
+	if ap.Signatures[0].Status != SigUnknownSuite {
+		t.Fatalf("status = %q, want unknown_suite", ap.Signatures[0].Status)
 	}
 }
 
+// TestEnvelopeLevelUnknownCriticalExtension_Rejects: an unknown ENVELOPE-level
+// critical extension is in the signed payload (not appendable) and stays
+// envelope-fatal.
 func TestEnvelopeLevelUnknownCriticalExtension_Rejects(t *testing.T) {
 	env, opts := signedEnvelope(t)
 	env.CritExt = []string{"x-envelope-crit"}
@@ -171,19 +182,54 @@ func TestEnvelopeLevelUnknownCriticalExtension_Rejects(t *testing.T) {
 	}
 }
 
-func TestProfileMismatch_Rejects(t *testing.T) {
+func TestProfileMismatch_PerSignature(t *testing.T) {
 	env, opts := signedEnvelope(t)
 	env.Signatures[0].Protected.Profile = "aarp/v9.9"
-	if _, err := Verify(env, opts); !errors.Is(err, ErrUnknownSuite) {
-		t.Fatalf("Verify = %v, want ErrUnknownSuite", err)
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("Verify returned envelope error (want per-signature status): %v", err)
+	}
+	if ap.AssertionSigned || ap.Signatures[0].Status != SigUnknownSuite {
+		t.Fatalf("profile mismatch: signed=%v status=%q, want signed=false status=unknown_suite", ap.AssertionSigned, ap.Signatures[0].Status)
 	}
 }
 
-func TestCanonMismatch_Rejects(t *testing.T) {
+func TestCanonMismatch_PerSignature(t *testing.T) {
 	env, opts := signedEnvelope(t)
 	env.Signatures[0].Protected.Canon = "weird-canon"
-	if _, err := Verify(env, opts); !errors.Is(err, ErrUnknownSuite) {
-		t.Fatalf("Verify = %v, want ErrUnknownSuite", err)
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("Verify returned envelope error (want per-signature status): %v", err)
+	}
+	if ap.AssertionSigned || ap.Signatures[0].Status != SigUnknownSuite {
+		t.Fatalf("canon mismatch: signed=%v status=%q, want signed=false status=unknown_suite", ap.AssertionSigned, ap.Signatures[0].Status)
+	}
+}
+
+// TestAppendedJunkSignature_DoesNotPoisonValidSig is the availability regression
+// for the per-signature rule: a MITM can append a signature (the array is not
+// signed), but a junk appended signature with a bogus protected suite must NOT
+// deny an envelope that carries a verifiable signature.
+func TestAppendedJunkSignature_DoesNotPoisonValidSig(t *testing.T) {
+	env, opts := signedEnvelope(t) // one valid mediator signature
+	env.Signatures = append(env.Signatures, Signature{
+		Protected: ProtectedHeader{
+			Profile: "aarp/v9.9", Canon: "weird-canon",
+			Alg: string(AlgEd25519), KeyType: "ed25519",
+			KeyID: "attacker", SignerRole: "mediator",
+			Crit: []string{"x-attacker-ext"},
+		},
+		Sig: "ed25519:AAAA",
+	})
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("appended junk signature rejected the envelope: %v", err)
+	}
+	if !ap.AssertionSigned {
+		t.Fatal("valid signature no longer verifies after a junk signature was appended")
+	}
+	if ap.Signatures[1].Status != SigUnknownSuite {
+		t.Errorf("appended junk signature status = %q, want unknown_suite", ap.Signatures[1].Status)
 	}
 }
 
@@ -275,6 +321,35 @@ func TestCritExtIsSigned(t *testing.T) {
 	}
 	if ap2.AssertionSigned {
 		t.Fatal("stripping signed crit_ext did not break the signature")
+	}
+}
+
+func TestSign_RejectsNilSigner(t *testing.T) {
+	// Untyped nil and a typed-nil *Ed25519Signer must both fail closed, not panic.
+	if _, err := Sign(baseEnvelope(), nil); !errors.Is(err, ErrSchema) {
+		t.Fatalf("Sign(nil) = %v, want ErrSchema", err)
+	}
+	var typedNil *Ed25519Signer
+	if _, err := Sign(baseEnvelope(), typedNil); !errors.Is(err, ErrSchema) {
+		t.Fatalf("Sign(typed-nil ed25519) = %v, want ErrSchema", err)
+	}
+	var pqNil *MLDSA65Signer
+	if _, err := Sign(baseEnvelope(), pqNil); !errors.Is(err, ErrSchema) {
+		t.Fatalf("Sign(typed-nil ml-dsa) = %v, want ErrSchema", err)
+	}
+}
+
+// TestMalformedCritPerSignature: a malformed per-signature crit list (duplicate
+// names) is reported SigMalformed for that signature, not envelope-fatal.
+func TestMalformedCritPerSignature(t *testing.T) {
+	env, opts := signedEnvelope(t)
+	env.Signatures[0].Protected.Crit = []string{"dup", "dup"}
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("Verify returned envelope error (want per-signature status): %v", err)
+	}
+	if ap.Signatures[0].Status != SigMalformed {
+		t.Fatalf("status = %q, want malformed", ap.Signatures[0].Status)
 	}
 }
 

--- a/internal/aarp/suite_test.go
+++ b/internal/aarp/suite_test.go
@@ -1,0 +1,289 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"testing"
+)
+
+func TestMultiSig_TwoEd25519BothVerify(t *testing.T) {
+	pubA, privA := genKey(t)
+	pubB, privB := genKey(t)
+	sA, _ := NewEd25519Signer("key-a", "mediator", privA)
+	sB, _ := NewEd25519Signer("key-b", "issuer", privB)
+	env, err := Sign(baseEnvelope(), sA, sB)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if len(env.Signatures) != 2 {
+		t.Fatalf("got %d signatures, want 2", len(env.Signatures))
+	}
+	ap, err := Verify(env, VerifyOptions{TrustedKeys: map[string]ed25519.PublicKey{"key-a": pubA, "key-b": pubB}})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !ap.AssertionSigned {
+		t.Fatal("AssertionSigned = false with two valid sigs")
+	}
+	for i, sr := range ap.Signatures {
+		if sr.Status != SigVerified {
+			t.Errorf("signature[%d] status = %q, want verified", i, sr.Status)
+		}
+	}
+}
+
+// TestMultiSig_PQStubSlotDoesNotBreakEd25519 proves the envelope shape is
+// first-class for a second suite: a typed PQ signature can sit alongside an
+// Ed25519 one. The PQ slot is reported unimplemented (never verified, never a
+// fallback), and the Ed25519 signature still verifies.
+func TestMultiSig_PQStubSlotDoesNotBreakEd25519(t *testing.T) {
+	pub, priv := genKey(t)
+	signer, _ := NewEd25519Signer("key-a", "mediator", priv)
+	env, err := Sign(baseEnvelope(), signer)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	// Manually attach a typed PQ signature slot (its signer is unimplemented, so
+	// it cannot be produced via Sign; an envelope may still carry one from a
+	// future producer). It must not require a format bump or break verification.
+	env.Signatures = append(env.Signatures, Signature{
+		Protected: ProtectedHeader{
+			Profile: Profile, Canon: CanonID,
+			Alg: string(AlgMLDSA65), KeyType: "ml-dsa",
+			KeyID: "pq-key-1", SignerRole: "mediator",
+		},
+		Sig: "ml-dsa-65:AAAA",
+	})
+	ap, err := Verify(env, VerifyOptions{TrustedKeys: map[string]ed25519.PublicKey{"key-a": pub}})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !ap.AssertionSigned {
+		t.Fatal("AssertionSigned = false; PQ slot broke Ed25519 verification")
+	}
+	var sawUnimplemented bool
+	for _, sr := range ap.Signatures {
+		if sr.Alg == string(AlgMLDSA65) {
+			sawUnimplemented = sr.Status == SigUnimplemented
+		}
+	}
+	if !sawUnimplemented {
+		t.Error("PQ signature not reported unimplemented")
+	}
+}
+
+// TestPQOnly_FailsClosed proves an envelope with ONLY a recognized-but-
+// unimplemented suite produces no verified signature (no fallback verify).
+func TestPQOnly_FailsClosed(t *testing.T) {
+	env := baseEnvelope()
+	env.Signatures = []Signature{{
+		Protected: ProtectedHeader{
+			Profile: Profile, Canon: CanonID,
+			Alg: string(AlgMLDSA65), KeyType: "ml-dsa",
+			KeyID: "pq-key-1", SignerRole: "mediator",
+		},
+		Sig: "ml-dsa-65:AAAA",
+	}}
+	ap, err := Verify(env, VerifyOptions{})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if ap.AssertionSigned {
+		t.Fatal("AssertionSigned = true for a PQ-only (unimplemented) envelope")
+	}
+	if ap.Signatures[0].Status != SigUnimplemented {
+		t.Errorf("status = %q, want unimplemented", ap.Signatures[0].Status)
+	}
+}
+
+// TestUnknownSuite_DoesNotPoisonValidSig proves a parallel signature under an
+// unrecognized algorithm is reported unknown_suite but does not reject an
+// envelope that also carries a verifiable Ed25519 signature.
+func TestUnknownSuite_DoesNotPoisonValidSig(t *testing.T) {
+	pub, priv := genKey(t)
+	signer, _ := NewEd25519Signer("key-a", "mediator", priv)
+	env, _ := Sign(baseEnvelope(), signer)
+	env.Signatures = append(env.Signatures, Signature{
+		Protected: ProtectedHeader{
+			Profile: Profile, Canon: CanonID,
+			Alg: "rsa-pkcs1", KeyType: "rsa",
+			KeyID: "rsa-key", SignerRole: "mediator",
+		},
+		Sig: "rsa-pkcs1:AAAA",
+	})
+	ap, err := Verify(env, VerifyOptions{TrustedKeys: map[string]ed25519.PublicKey{"key-a": pub}})
+	if err != nil {
+		t.Fatalf("Verify rejected envelope with one unknown suite: %v", err)
+	}
+	if !ap.AssertionSigned {
+		t.Fatal("valid Ed25519 sig did not verify alongside unknown suite")
+	}
+	var sawUnknown bool
+	for _, sr := range ap.Signatures {
+		if sr.Alg == "rsa-pkcs1" {
+			sawUnknown = sr.Status == SigUnknownSuite
+		}
+	}
+	if !sawUnknown {
+		t.Error("unknown suite not reported unknown_suite")
+	}
+}
+
+// TestAlgSubstitution_Fails proves relabeling an Ed25519 signature as a
+// different suite cannot make it verify: the alg label is in the signed bytes
+// and the verifier dispatches on it before any verify attempt.
+func TestAlgSubstitution_Fails(t *testing.T) {
+	pub, priv := genKey(t)
+	signer, _ := NewEd25519Signer("key-a", "mediator", priv)
+	env, _ := Sign(baseEnvelope(), signer)
+	// Relabel the alg to the PQ suite but keep the Ed25519 signature bytes and a
+	// mismatched key_type. The verifier sees key_type != ml-dsa → malformed,
+	// never a verify.
+	env.Signatures[0].Protected.Alg = string(AlgMLDSA65)
+	ap, err := Verify(env, VerifyOptions{TrustedKeys: map[string]ed25519.PublicKey{"key-a": pub}})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if ap.AssertionSigned {
+		t.Fatal("alg substitution produced a verified signature")
+	}
+}
+
+func TestUnknownCriticalExtension_RejectsEnvelope(t *testing.T) {
+	env, opts := signedEnvelope(t)
+	// Mark an extension critical that the verifier does not understand.
+	env.Signatures[0].Protected.Crit = []string{"x-attacker-ext"}
+	_, err := Verify(env, opts)
+	if !errors.Is(err, ErrUnknownCriticalExtension) {
+		t.Fatalf("Verify = %v, want ErrUnknownCriticalExtension", err)
+	}
+}
+
+func TestEnvelopeLevelUnknownCriticalExtension_Rejects(t *testing.T) {
+	env, opts := signedEnvelope(t)
+	env.CritExt = []string{"x-envelope-crit"}
+	_, err := Verify(env, opts)
+	if !errors.Is(err, ErrUnknownCriticalExtension) {
+		t.Fatalf("Verify = %v, want ErrUnknownCriticalExtension", err)
+	}
+}
+
+func TestProfileMismatch_Rejects(t *testing.T) {
+	env, opts := signedEnvelope(t)
+	env.Signatures[0].Protected.Profile = "aarp/v9.9"
+	if _, err := Verify(env, opts); !errors.Is(err, ErrUnknownSuite) {
+		t.Fatalf("Verify = %v, want ErrUnknownSuite", err)
+	}
+}
+
+func TestCanonMismatch_Rejects(t *testing.T) {
+	env, opts := signedEnvelope(t)
+	env.Signatures[0].Protected.Canon = "weird-canon"
+	if _, err := Verify(env, opts); !errors.Is(err, ErrUnknownSuite) {
+		t.Fatalf("Verify = %v, want ErrUnknownSuite", err)
+	}
+}
+
+func TestNewEd25519Signer_Rejects(t *testing.T) {
+	_, priv := genKey(t)
+	if _, err := NewEd25519Signer("", "mediator", priv); !errors.Is(err, ErrMalformedSuite) {
+		t.Errorf("empty key_id: got %v", err)
+	}
+	if _, err := NewEd25519Signer("k", "bogus-role", priv); !errors.Is(err, ErrMalformedSuite) {
+		t.Errorf("bad role: got %v", err)
+	}
+	if _, err := NewEd25519Signer("k", "mediator", ed25519.PrivateKey{1, 2, 3}); !errors.Is(err, ErrMalformedSuite) {
+		t.Errorf("bad key size: got %v", err)
+	}
+}
+
+// TestTrustEntryRole_Enforced proves a trust entry scoped to a role does NOT
+// confirm mediator_key_pinned for a signature carrying a different role.
+func TestTrustEntryRole_Enforced(t *testing.T) {
+	env, pub := signedEnvelopeWithKey(t) // signed with signer_role "mediator"
+	opts := VerifyOptions{
+		TrustedKeys: map[string]ed25519.PublicKey{testKeyID: pub},
+		// Entry authorizes this key only for the "issuer" role.
+		Trust: map[string]TrustEntry{testKeyID: {MediatorID: testMediatorID, Role: "issuer", TrustDomain: testTrustDomain}},
+	}
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !ap.AssertionSigned {
+		t.Fatal("AssertionSigned = false; signature should still verify")
+	}
+	if contains(ap.VerifiedClaims, ClaimMediatorKeyPinned) {
+		t.Error("mediator_key_pinned verified despite role mismatch (role scoping not enforced)")
+	}
+}
+
+// TestTrustEntryRole_MatchVerifies confirms the matching-role path still pins.
+func TestTrustEntryRole_MatchVerifies(t *testing.T) {
+	env, pub := signedEnvelopeWithKey(t) // signer_role "mediator"
+	opts := VerifyOptions{
+		TrustedKeys: map[string]ed25519.PublicKey{testKeyID: pub},
+		Trust:       map[string]TrustEntry{testKeyID: {MediatorID: testMediatorID, Role: "mediator"}},
+	}
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !contains(ap.VerifiedClaims, ClaimMediatorKeyPinned) {
+		t.Error("mediator_key_pinned not verified despite matching role")
+	}
+}
+
+// TestCritExtIsSigned proves the envelope-level crit_ext is covered by the
+// signature: changing it after signing breaks verification (a MITM cannot strip
+// or alter a flagged critical extension). Uses a hand-set known extension so the
+// envelope is not rejected outright for an unknown critical extension.
+func TestCritExtIsSigned(t *testing.T) {
+	_, priv := genKey(t)
+	pub := priv.Public().(ed25519.PublicKey)
+	signer, _ := NewEd25519Signer(testKeyID, "mediator", priv)
+	// Temporarily register a known critical extension for this test only.
+	knownCriticalExtensions["x-test-crit"] = true
+	defer delete(knownCriticalExtensions, "x-test-crit")
+
+	e := baseEnvelope()
+	e.CritExt = []string{"x-test-crit"}
+	env, err := Sign(e, signer)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	opts := VerifyOptions{TrustedKeys: map[string]ed25519.PublicKey{testKeyID: pub}}
+
+	// Signed as-is: verifies.
+	ap, err := Verify(env, opts)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !ap.AssertionSigned {
+		t.Fatal("AssertionSigned = false for valid crit_ext envelope")
+	}
+
+	// MITM strips the critical extension after signing → signature must break.
+	stripped := env
+	stripped.CritExt = nil
+	ap2, err := Verify(stripped, opts)
+	if err != nil {
+		t.Fatalf("Verify(stripped): %v", err)
+	}
+	if ap2.AssertionSigned {
+		t.Fatal("stripping signed crit_ext did not break the signature")
+	}
+}
+
+func TestMLDSA65Signer_SignFailsClosed(t *testing.T) {
+	signer, err := NewMLDSA65Signer("pq-1", "mediator")
+	if err != nil {
+		t.Fatalf("NewMLDSA65Signer: %v", err)
+	}
+	if _, err := Sign(baseEnvelope(), signer); !errors.Is(err, ErrSuiteUnimplemented) {
+		t.Fatalf("Sign with PQ signer = %v, want ErrSuiteUnimplemented", err)
+	}
+}

--- a/internal/aarp/trustdomain.go
+++ b/internal/aarp/trustdomain.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+)
+
+// validateTrustDomainName checks that s is a syntactically valid SPIFFE trust
+// domain name and not an IP literal. SPIFFE-ID §2 requires a DNS name;
+// go-spiffe's parser accepts IP literals, so a numeric host could otherwise be
+// used to impersonate a domain. This mirrors internal/svid.parseTrustDomain.
+//
+// Core only checks syntax here; the authoritative SVID-bound trust-domain match
+// happens in the attestation layer against pinned bundle history.
+func validateTrustDomainName(s string) error {
+	td, err := spiffeid.TrustDomainFromString(s)
+	if err != nil {
+		return fmt.Errorf("invalid trust domain %q: %w", s, err)
+	}
+	if net.ParseIP(td.String()) != nil {
+		return fmt.Errorf("trust domain must be a DNS name, not an IP address: %q", s)
+	}
+	return nil
+}

--- a/internal/aarp/verify.go
+++ b/internal/aarp/verify.go
@@ -5,6 +5,7 @@ package aarp
 
 import (
 	"crypto/ed25519"
+	"errors"
 	"fmt"
 )
 
@@ -85,7 +86,10 @@ func Verify(e Envelope, opts VerifyOptions) (*Appraisal, error) {
 			ap.addVerified(ClaimMediatorKeyPinned, AxisIdentity)
 		}
 		if e.Chain != nil {
-			ap.addVerified(ClaimChainLinked, AxisIntegrity)
+			// A signed chain link is present (its position is authenticated by
+			// the verified signature). Stream continuity is NOT asserted here;
+			// VerifyChain over the stream is the authority for that.
+			ap.addVerified(ClaimChainLinkPresent, AxisIntegrity)
 		}
 	} else {
 		// Without any verified signature, every producer claim is untrusted
@@ -102,6 +106,28 @@ func Verify(e Envelope, opts VerifyOptions) (*Appraisal, error) {
 // an untrusted key, or an invalid signature all yield verified=false.
 func appraiseSignature(s Signature, digest string, opts VerifyOptions) (SignatureResult, bool) {
 	res := SignatureResult{KeyID: s.Protected.KeyID, Alg: s.Protected.Alg, Role: s.Protected.SignerRole}
+
+	// Per-signature suite identity. A wrong profile/canon or an unknown critical
+	// extension in THIS signature's protected header makes only this signature
+	// unverifiable — it never rejects the envelope, so an appended junk signature
+	// cannot deny a verifiable sibling. (The signed top-level profile and
+	// crit_ext are checked envelope-fatal in validateStructure.)
+	if s.Protected.Profile != Profile {
+		res.Status, res.Reason = SigUnknownSuite, fmt.Sprintf("profile %q != %q", s.Protected.Profile, Profile)
+		return res, false
+	}
+	if s.Protected.Canon != CanonID {
+		res.Status, res.Reason = SigUnknownSuite, fmt.Sprintf("canon %q != %q", s.Protected.Canon, CanonID)
+		return res, false
+	}
+	if err := checkCriticalExtensions(s.Protected.Crit); err != nil {
+		if errors.Is(err, ErrUnknownCriticalExtension) {
+			res.Status, res.Reason = SigUnknownSuite, err.Error()
+		} else {
+			res.Status, res.Reason = SigMalformed, err.Error()
+		}
+		return res, false
+	}
 
 	if s.Protected.KeyID == "" {
 		res.Status, res.Reason = SigMalformed, "empty key_id"

--- a/internal/aarp/verify.go
+++ b/internal/aarp/verify.go
@@ -1,0 +1,230 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"crypto/ed25519"
+	"fmt"
+)
+
+// TrustEntry binds a signing key id to an authority namespace, never to a bare
+// key. A verified mediated claim requires the verifying signature's key id to
+// match a TrustEntry whose mediator id (and, when set, signer role and trust
+// domain) agree with the assertion. An attacker self-signing with
+// signer_role=mediator and no matching entry gets mediated reported claim-only.
+type TrustEntry struct {
+	// MediatorID is the mediator identity this key is authorized to assert.
+	MediatorID string
+	// Role, when non-empty, is the signer_role the key is authorized to use.
+	Role string
+	// TrustDomain, when non-empty, is the trust domain the assertion must carry.
+	TrustDomain string
+}
+
+// VerifyOptions configures appraisal. It carries the verifier's pinned trust,
+// never anything fetched live.
+type VerifyOptions struct {
+	// TrustedKeys maps a key id to its Ed25519 public key. A signature whose key
+	// id is absent is reported unknown_key and never counts as verified.
+	TrustedKeys map[string]ed25519.PublicKey
+	// Trust maps a key id to its authority-namespace binding. A key id present
+	// in TrustedKeys but absent from Trust can still verify a signature, but
+	// cannot confirm the mediator_key_pinned claim.
+	Trust map[string]TrustEntry
+}
+
+// claimVerifiedBy maps each producer claim name to the set of verified-claim
+// names that must all be present for the producer claim to count as confirmed.
+// A nil value means the claim is structurally claim-only in v0.1 (never
+// verifiable), so it is always reported unverified.
+var claimVerifiedBy = map[string][]string{
+	"mediated":                   {ClaimMediatorKeyPinned},
+	"complete-mediation":         nil,
+	"complete_mediation":         nil,
+	"workload_identity_verified": {"workload_identity_verified"},
+	"x509_svid_bound":            {"x509_svid_bound"},
+	"svid_valid_at_action_time":  {"svid_valid_at_action_time"},
+	"transparency_inclusion":     nil,
+}
+
+// Verify appraises an AARP envelope and returns a structured result. It rejects
+// the envelope (returns a nil appraisal and an error) only for envelope-fatal
+// conditions: a schema violation, a profile/canon mismatch, or an unknown
+// critical extension. Per-signature problems (unknown or unimplemented suite,
+// untrusted key, invalid signature) are reported in the appraisal, never as a
+// hard rejection, so one bad parallel signature cannot mask a good one.
+//
+// The appraisal never reports "trusted" or "safe". A relying party applies its
+// own claim policy to the verified_claims and axes.
+func Verify(e Envelope, opts VerifyOptions) (*Appraisal, error) {
+	if err := e.validateStructure(); err != nil {
+		return nil, err
+	}
+	digest, err := e.PayloadDigest()
+	if err != nil {
+		return nil, err
+	}
+
+	ap := newAppraisal()
+	ap.AssuranceClaimed = append([]string(nil), e.Assertion.Claimed...)
+
+	var verified []verifiedSigner
+	for _, s := range e.Signatures {
+		res, ok := appraiseSignature(s, digest, opts)
+		ap.Signatures = append(ap.Signatures, res)
+		if ok {
+			verified = append(verified, verifiedSigner{keyID: s.Protected.KeyID, role: s.Protected.SignerRole})
+		}
+	}
+
+	if len(verified) > 0 {
+		ap.AssertionSigned = true
+		ap.addVerified(ClaimAssertionSignatureValid, AxisIntegrity)
+		if mediatorKeyPinned(e.Assertion, verified, opts.Trust) {
+			ap.addVerified(ClaimMediatorKeyPinned, AxisIdentity)
+		}
+		if e.Chain != nil {
+			ap.addVerified(ClaimChainLinked, AxisIntegrity)
+		}
+	} else {
+		// Without any verified signature, every producer claim is untrusted
+		// input, not a producer-authored claim.
+		ap.Warnings = append(ap.Warnings, "no signature verified under a trusted key; all assurance claims are untrusted input")
+	}
+
+	classifyClaims(ap)
+	return ap, nil
+}
+
+// appraiseSignature verifies one parallel signature and returns its result plus
+// whether it verified. It never falls back: an unknown or unimplemented suite,
+// an untrusted key, or an invalid signature all yield verified=false.
+func appraiseSignature(s Signature, digest string, opts VerifyOptions) (SignatureResult, bool) {
+	res := SignatureResult{KeyID: s.Protected.KeyID, Alg: s.Protected.Alg, Role: s.Protected.SignerRole}
+
+	if s.Protected.KeyID == "" {
+		res.Status, res.Reason = SigMalformed, "empty key_id"
+		return res, false
+	}
+	if !knownSignerRoles[s.Protected.SignerRole] {
+		res.Status, res.Reason = SigMalformed, "unknown signer_role"
+		return res, false
+	}
+	wantKeyType, known := keyTypeForAlg[AlgID(s.Protected.Alg)]
+	if !known {
+		res.Status, res.Reason = SigUnknownSuite, "unrecognized algorithm; no fallback"
+		return res, false
+	}
+	if s.Protected.KeyType != wantKeyType {
+		res.Status, res.Reason = SigMalformed, fmt.Sprintf("key_type %q != %q required by alg", s.Protected.KeyType, wantKeyType)
+		return res, false
+	}
+	if !implementedAlgs[AlgID(s.Protected.Alg)] {
+		res.Status, res.Reason = SigUnimplemented, "recognized suite, verifier not yet built"
+		return res, false
+	}
+
+	// Implemented suite: Ed25519.
+	pub, ok := opts.TrustedKeys[s.Protected.KeyID]
+	if !ok {
+		res.Status, res.Reason = SigUnknownKey, "key_id not in trusted set"
+		return res, false
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		res.Status, res.Reason = SigMalformed, "trusted key has wrong size"
+		return res, false
+	}
+	input, err := signingInput(digest, s.Protected)
+	if err != nil {
+		res.Status, res.Reason = SigMalformed, "signing input: "+err.Error()
+		return res, false
+	}
+	raw, err := decodeSigWire(s.Protected.Alg, s.Sig)
+	if err != nil {
+		res.Status, res.Reason = SigMalformed, err.Error()
+		return res, false
+	}
+	if len(raw) != ed25519.SignatureSize || !ed25519.Verify(pub, input, raw) {
+		res.Status, res.Reason = SigFailed, "signature does not verify over canonical bytes"
+		return res, false
+	}
+	res.Status = SigVerified
+	return res, true
+}
+
+// verifiedSigner is a signature that verified under a trusted key, carrying the
+// key id and the signer role from its protected header so the trust-entry check
+// can enforce role scoping.
+type verifiedSigner struct {
+	keyID string
+	role  string
+}
+
+// mediatorKeyPinned reports whether any verifying signature is bound by a trust
+// entry to the asserted mediator identity, and (when the entry sets them) the
+// signer role and trust domain. The role is checked against the role carried by
+// the verifying signature, so a key scoped to e.g. "countersig" cannot satisfy
+// a mediated claim made under "mediator".
+func mediatorKeyPinned(a Assertion, verified []verifiedSigner, trust map[string]TrustEntry) bool {
+	for _, vs := range verified {
+		entry, ok := trust[vs.keyID]
+		if !ok {
+			continue
+		}
+		if entry.MediatorID != a.MediatorID {
+			continue
+		}
+		if entry.TrustDomain != "" && entry.TrustDomain != a.TrustDomain {
+			continue
+		}
+		if entry.Role != "" && entry.Role != vs.role {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// classifyClaims fills ClaimedUnverified from the producer claims that the
+// verifier did not confirm. A claim whose required verified-claims are all
+// present is satisfied; everything else (claim-only, unknown, or unmet) is
+// reported unverified.
+func classifyClaims(ap *Appraisal) {
+	verified := make(map[string]struct{}, len(ap.VerifiedClaims))
+	for _, c := range ap.VerifiedClaims {
+		verified[c] = struct{}{}
+	}
+	// Deduplicate producer claims so a repeated claim name does not inflate the
+	// claimed-unverified list a relying party might count.
+	seenClaim := make(map[string]struct{}, len(ap.AssuranceClaimed))
+	for _, claimed := range ap.AssuranceClaimed {
+		if _, dup := seenClaim[claimed]; dup {
+			continue
+		}
+		seenClaim[claimed] = struct{}{}
+		required, known := claimVerifiedBy[claimed]
+		if !known {
+			ap.ClaimedUnverified = append(ap.ClaimedUnverified, claimed)
+			ap.Warnings = append(ap.Warnings, "unknown assurance claim reported claim-only: "+claimed)
+			continue
+		}
+		if len(required) == 0 {
+			ap.ClaimedUnverified = append(ap.ClaimedUnverified, claimed)
+			continue
+		}
+		if allPresent(required, verified) {
+			continue
+		}
+		ap.ClaimedUnverified = append(ap.ClaimedUnverified, claimed)
+	}
+}
+
+func allPresent(required []string, have map[string]struct{}) bool {
+	for _, r := range required {
+		if _, ok := have[r]; !ok {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Adds `internal/aarp`, the Agent Action Receipt Profile (AARP) v0.1 assurance envelope: a separate, independently-signed appraisal artifact that sits beside a frozen receipt and reports verified claims grouped by axis, never a "trusted" or "safe" verdict. The shipped v1 ActionReceipt and v2 EvidenceReceipt stay byte-for-byte frozen; AARP references them by digest and never rewrites them.

- Protected signature suite bound into the signed bytes; an unknown suite or an unknown critical extension fails closed with no fallback verification.
- JCS number safety: ids, digests, counters, timestamps, and amounts are typed strings with explicit grammars; raw JSON numbers outside the I-JSON safe-integer range are rejected at decode.
- Parallel multi-signature envelope: N protected signatures over one shared canonical payload digest, each binding its own suite (defeats algorithm substitution). Ed25519 ships; the ML-DSA-65 post-quantum slot is typed but stubbed, so a hybrid or PQ envelope needs no format bump.
- Issuer-agnostic timestamp-chain primitive (sequence plus prior hash) carried in the signed payload, so insertion, reordering, and backdating within a stream are signature-detectable.
- Claim-set appraisal grouped by axis with an explicit `does_not_assert` list; a mediated claim binds to an authority-namespace trust entry (mediator id, signer role, trust domain), never a bare key.

Composes with the existing RFC 8785 JCS canonicalization and strict JSON parsing (duplicate-key and unknown-field rejection); no new dependency. Public spec at `docs/specs/aarp-v0.1-envelope.md`, including the designed-deferred external-audit projection format with anti-laundering invariants and the RFC 3161 timestamp-authority slot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AARP v0.1 envelopes: canonical payloads, domain-separated signing input, parallel multi-signature model, Ed25519 signing/verification, hash-linked chain semantics, critical-extension handling, and structured verifier appraisals with signature/status axes and claim classification.
  * Typed-string grammars and strict numeric safety for cross-language canonicalization.

* **Documentation**
  * Added full AARP v0.1 specification covering envelope shape, signing/verifier semantics, canonicalization, and governance.

* **Tests**
  * Extensive tests for signing, verification, chain linkage, suite behaviors, JSON schema, and numeric grammar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->