### PR TITLE
feat(aarp): verified X.509-SVID attestation binding

### DIFF
--- a/docs/specs/aarp-v0.1-envelope.md
+++ b/docs/specs/aarp-v0.1-envelope.md
@@ -209,8 +209,50 @@ and no matching trust entry gets `mediated` reported claim-only.
 
 Revocation status is **snapshotted at signing time** and is a distinct, additive
 artifact from any later-compromise evidence; a verifier never re-fetches live
-material to reinterpret an old receipt. (The signing-time SVID snapshot lands
-with the attestation binding.)
+material to reinterpret an old receipt.
+
+## SVID attestation binding (verified workload identity)
+
+A producer may attach **X.509-SVID** evidence that cryptographically proves the
+workload identity that mediated the action. Only X.509-SVID counts toward
+verified workload identity; JWT-SVID is a bearer token and stays claim-only.
+
+The SVID leaf's private key signs a **binding payload**, JCS-canonicalized, whose
+first field is the domain-separation context `pipelock-aarp-v0.1/svid-receipt-binding`:
+
+```jsonc
+{
+  "context": "pipelock-aarp-v0.1/svid-receipt-binding",
+  "profile": "aarp/v0.1",
+  "action_record_sha256": "<v1 ActionRecord digest>",
+  "receipt_envelope_sha256": "<receipt envelope digest>",
+  "assurance_assertion_sha256": "<the envelope's canonical payload digest>",
+  "receipt_signer_key": "<receipt Ed25519 public key>",
+  "mediator_id": "pipelock-prod-1",
+  "spiffe_id": "spiffe://example.org/mediators/pipelock-prod",
+  "issued_at": "RFC3339Nano",
+  "nonce": "<128-bit random, base64url>"
+}
+```
+
+The verifier confirms, all offline and fail-closed:
+
+- the SVID chain validates to a **pinned historical trust bundle** at the
+  **action time** (not "now"), via the shared `internal/svid` substrate;
+- the SVID's trust domain matches and its SPIFFE ID is permitted by policy;
+- the binding's `assurance_assertion_sha256` equals the envelope's canonical
+  payload digest, and `receipt_signer_key` matches the receipt — so the SVID is
+  bound to *this* receipt and assertion (the `nonce` defeats cross-action replay);
+- the proof-of-possession signature verifies under the SVID leaf key (ECDSA-P256
+  or Ed25519; a declared algorithm that disagrees with the leaf key type fails
+  closed).
+
+On success the verifier adds `workload_identity_verified` and `x509_svid_bound`
+to the **identity** axis and `svid_valid_at_action_time` to the **freshness**
+axis. Attestation is only considered on a **signed** assertion (the binding ties
+to the signed assertion digest); an SVID that fails any check never removes a
+core claim and never adds an attestation one — the producer's workload-identity
+claim is reported claimed-but-unverified, with a warning.
 
 ## Appraisal vocabulary
 

--- a/docs/specs/aarp-v0.1-envelope.md
+++ b/docs/specs/aarp-v0.1-envelope.md
@@ -217,8 +217,10 @@ A producer may attach **X.509-SVID** evidence that cryptographically proves the
 workload identity that mediated the action. Only X.509-SVID counts toward
 verified workload identity; JWT-SVID is a bearer token and stays claim-only.
 
-The SVID leaf's private key signs a **binding payload**, JCS-canonicalized, whose
-first field is the domain-separation context `pipelock-aarp-v0.1/svid-receipt-binding`:
+The SVID leaf's private key signs a **binding payload**, JCS-canonicalized, which
+carries a signed domain-separation context field
+`pipelock-aarp-v0.1/svid-receipt-binding` (JCS sorts object keys, so the context
+is part of the signed bytes but not necessarily first in canonical order):
 
 ```jsonc
 {

--- a/internal/aarp/appraise.go
+++ b/internal/aarp/appraise.go
@@ -32,6 +32,15 @@ const (
 	// stream. The name says "present", not "linked/verified", to avoid implying a
 	// continuity guarantee a single envelope cannot give.
 	ClaimChainLinkPresent = "chain_link_present"
+	// ClaimWorkloadIdentityVerified: a receipt-bound X.509-SVID proof-of-
+	// possession verified against a pinned trust bundle (Wave 1.3 attestation).
+	ClaimWorkloadIdentityVerified = "workload_identity_verified"
+	// ClaimX509SVIDBound: the SVID leaf key signed a binding tying it to this
+	// receipt and assurance assertion digest.
+	ClaimX509SVIDBound = "x509_svid_bound"
+	// ClaimSVIDValidAtActionTime: the SVID validated at the action time (offline,
+	// point-in-time), not merely at "now".
+	ClaimSVIDValidAtActionTime = "svid_valid_at_action_time"
 )
 
 // docsNotAsserted is the fixed set of properties an AARP appraisal never

--- a/internal/aarp/appraise.go
+++ b/internal/aarp/appraise.go
@@ -33,7 +33,7 @@ const (
 	// continuity guarantee a single envelope cannot give.
 	ClaimChainLinkPresent = "chain_link_present"
 	// ClaimWorkloadIdentityVerified: a receipt-bound X.509-SVID proof-of-
-	// possession verified against a pinned trust bundle (Wave 1.3 attestation).
+	// possession verified against a pinned trust bundle (attestation layer).
 	ClaimWorkloadIdentityVerified = "workload_identity_verified"
 	// ClaimX509SVIDBound: the SVID leaf key signed a binding tying it to this
 	// receipt and assurance assertion digest.

--- a/internal/aarp/attest.go
+++ b/internal/aarp/attest.go
@@ -1,0 +1,326 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/svid"
+)
+
+// ContextSVIDBinding is the domain separator for the SVID proof-of-possession
+// binding. It is a signed field of the binding payload, never a sibling label,
+// so an SVID signature made to bind one receipt can never be replayed as
+// evidence for another.
+const ContextSVIDBinding = "pipelock-aarp-v0.1/svid-receipt-binding"
+
+// minNonceBytes is the minimum SVID-binding nonce size: 128 bits.
+const minNonceBytes = 16
+
+// SVID binding algorithm identifiers. The binding signature is made by the SVID
+// leaf's private key, so the algorithm follows the leaf key type.
+const (
+	// BindingAlgECDSAP256SHA256 signs SHA-256(canonical binding payload) with
+	// ECDSA P-256 (ASN.1 signature). This is the common SPIFFE leaf key type.
+	BindingAlgECDSAP256SHA256 = "ecdsa-p256-sha256"
+	// BindingAlgEd25519 signs the canonical binding payload with Ed25519
+	// PureEdDSA.
+	BindingAlgEd25519 = "ed25519"
+)
+
+// Attestation failure classes. Compare with errors.Is.
+var (
+	// ErrSVIDEvidence means the evidence object is structurally invalid (bad
+	// base64/DER, missing fields, malformed binding).
+	ErrSVIDEvidence = errors.New("aarp: malformed SVID evidence")
+
+	// ErrSVIDBinding means the proof-of-possession binding does not tie the SVID
+	// to this receipt and assertion: a context mismatch, a digest mismatch, a
+	// signer-key mismatch, a spiffe-id mismatch, or a binding signature that does
+	// not verify under the SVID leaf key.
+	ErrSVIDBinding = errors.New("aarp: SVID binding does not verify against this receipt")
+
+	// ErrSVIDNotPermitted means the SVID validated cryptographically but its
+	// SPIFFE ID is not permitted by the verifier's allowed set/prefixes.
+	ErrSVIDNotPermitted = errors.New("aarp: SVID spiffe_id not permitted by trust policy")
+)
+
+// SVIDBinding is the proof-of-possession signature tying an SVID to a receipt.
+type SVIDBinding struct {
+	Alg string `json:"alg"`
+	// Context must equal ContextSVIDBinding.
+	Context string `json:"context"`
+	// PayloadSHA256 is the lowercase-hex SHA-256 of the canonical binding
+	// payload (display/reference; the verifier recomputes it).
+	PayloadSHA256 string `json:"payload_sha256"`
+	// SignatureB64 is the standard-base64 leaf-key signature over the binding.
+	SignatureB64 string `json:"signature_b64"`
+}
+
+// SVIDEvidence is the X.509-SVID workload-identity evidence attached to an AARP
+// envelope. Only X.509-SVID counts toward verified workload identity; JWT-SVID
+// is a bearer token and is claim-only in v0.1.
+type SVIDEvidence struct {
+	Type string `json:"type"` // must be "x509"
+	// SPIFFEID is the claimed SPIFFE ID; it must match the SVID's URI SAN.
+	SPIFFEID string `json:"spiffe_id"`
+	// LeafDERB64 is the standard-base64 DER of the leaf SVID certificate.
+	LeafDERB64 string `json:"leaf_der_b64"`
+	// ChainDERB64 holds any intermediate certificates, leaf-to-root order.
+	ChainDERB64 []string `json:"chain_der_b64,omitempty"`
+	// Nonce is a >=128-bit random value (base64url, no padding) defeating
+	// cross-action replay; it is part of the signed binding payload.
+	Nonce string `json:"nonce"`
+	// IssuedAt is the binding issuance time (RFC3339Nano typed string).
+	IssuedAt string `json:"issued_at"`
+	// Binding is the proof-of-possession signature.
+	Binding SVIDBinding `json:"binding"`
+}
+
+// bindingPayload is the exact object the SVID leaf key signs. Its first field is
+// the domain-separation context; every numeric-like field is a typed string.
+type bindingPayload struct {
+	Context                  string `json:"context"`
+	Profile                  string `json:"profile"`
+	ActionRecordSHA256       string `json:"action_record_sha256"`
+	ReceiptEnvelopeSHA256    string `json:"receipt_envelope_sha256"`
+	AssuranceAssertionSHA256 string `json:"assurance_assertion_sha256"`
+	ReceiptSignerKey         string `json:"receipt_signer_key"`
+	MediatorID               string `json:"mediator_id"`
+	SPIFFEID                 string `json:"spiffe_id"`
+	IssuedAt                 string `json:"issued_at"`
+	Nonce                    string `json:"nonce"`
+}
+
+// SVIDVerifyOptions carries the verifier's pinned trust for an SVID binding.
+type SVIDVerifyOptions struct {
+	// TrustDomain is the SPIFFE trust domain the SVID must belong to.
+	TrustDomain string
+	// History is the pinned trust-bundle history for TrustDomain.
+	History *svid.TrustBundleHistory
+	// ActionTime is the time the appraised action occurred. The SVID is
+	// validated at this time (offline, point-in-time), not at "now", so a
+	// historical short-lived credential still validates for its action.
+	ActionTime time.Time
+	// AllowedSPIFFEIDs, when non-empty, is the exact set of SPIFFE IDs permitted.
+	AllowedSPIFFEIDs []string
+}
+
+// bindingCanonical returns the JCS-canonical bytes of the binding payload built
+// from the envelope and evidence. It is the message the SVID leaf key signs.
+func bindingCanonical(e Envelope, ev SVIDEvidence) ([]byte, error) {
+	assertionDigest, err := e.PayloadDigest()
+	if err != nil {
+		return nil, err
+	}
+	bp := bindingPayload{
+		Context:                  ContextSVIDBinding,
+		Profile:                  Profile,
+		ActionRecordSHA256:       e.Subject.ActionRecordSHA256,
+		ReceiptEnvelopeSHA256:    e.Subject.ReceiptEnvelopeSHA256,
+		AssuranceAssertionSHA256: assertionDigest,
+		ReceiptSignerKey:         e.Subject.ReceiptSignerKey,
+		MediatorID:               e.Assertion.MediatorID,
+		SPIFFEID:                 ev.SPIFFEID,
+		IssuedAt:                 ev.IssuedAt,
+		Nonce:                    ev.Nonce,
+	}
+	raw, err := json.Marshal(bp)
+	if err != nil {
+		return nil, fmt.Errorf("marshal binding payload: %w", err)
+	}
+	tree, err := contract.ParseJSONStrict(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse binding payload: %w", err)
+	}
+	return contract.Canonicalize(tree)
+}
+
+// VerifySVIDBinding verifies that the SVID evidence is a genuine, receipt-bound
+// X.509-SVID workload-identity proof. It fails closed: any structural problem,
+// chain-validation failure, digest/signer/spiffe mismatch, or bad
+// proof-of-possession signature returns an error and confirms nothing.
+//
+// On success it returns the validated SPIFFE ID. The caller maps that to the
+// workload_identity_verified / x509_svid_bound / svid_valid_at_action_time
+// claims via AppraiseWithSVID.
+func VerifySVIDBinding(e Envelope, ev SVIDEvidence, opts SVIDVerifyOptions) (string, error) {
+	if ev.Type != "x509" {
+		return "", fmt.Errorf("%w: evidence type %q (only x509 counts as verified attestation)", ErrSVIDEvidence, ev.Type)
+	}
+	if err := ValidateTimestamp(ev.IssuedAt); err != nil {
+		return "", fmt.Errorf("%w: issued_at: %w", ErrSVIDEvidence, err)
+	}
+	// The nonce defeats cross-action replay; require at least 128 bits of
+	// base64url so a producer can't weaken replay resistance with a tiny nonce.
+	nonceBytes, err := base64.RawURLEncoding.DecodeString(ev.Nonce)
+	if err != nil {
+		return "", fmt.Errorf("%w: nonce not base64url: %w", ErrSVIDEvidence, err)
+	}
+	if len(nonceBytes) < minNonceBytes {
+		return "", fmt.Errorf("%w: nonce %d bytes, want >= %d", ErrSVIDEvidence, len(nonceBytes), minNonceBytes)
+	}
+	if ev.Binding.Context != ContextSVIDBinding {
+		return "", fmt.Errorf("%w: binding context %q", ErrSVIDBinding, ev.Binding.Context)
+	}
+
+	leafPEM, err := svidPEM(ev)
+	if err != nil {
+		return "", err
+	}
+
+	// Validate the SVID offline, at ACTION time, against the pinned bundle.
+	validated, err := svid.ValidateSVID(leafPEM, svid.Options{
+		TrustDomain: opts.TrustDomain,
+		History:     opts.History,
+		At:          opts.ActionTime,
+	})
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrSVIDBinding, err)
+	}
+
+	// The claimed spiffe_id and the binding spiffe_id must match the validated
+	// URI SAN — no substitution.
+	if ev.SPIFFEID != validated.SPIFFEID {
+		return "", fmt.Errorf("%w: evidence spiffe_id %q != validated %q", ErrSVIDBinding, ev.SPIFFEID, validated.SPIFFEID)
+	}
+	if !spiffeIDPermitted(validated.SPIFFEID, opts.AllowedSPIFFEIDs) {
+		return "", fmt.Errorf("%w: %q", ErrSVIDNotPermitted, validated.SPIFFEID)
+	}
+
+	// Recompute the canonical binding payload and verify the proof-of-possession
+	// signature under the SVID leaf public key.
+	canonical, err := bindingCanonical(e, ev)
+	if err != nil {
+		return "", err
+	}
+	if want := hexSHA256(canonical); ev.Binding.PayloadSHA256 != "" && ev.Binding.PayloadSHA256 != want {
+		return "", fmt.Errorf("%w: binding payload_sha256 mismatch", ErrSVIDBinding)
+	}
+	sig, err := base64.StdEncoding.DecodeString(ev.Binding.SignatureB64)
+	if err != nil {
+		return "", fmt.Errorf("%w: binding signature base64: %w", ErrSVIDEvidence, err)
+	}
+	if err := verifyLeafSignature(validated.Leaf, ev.Binding.Alg, canonical, sig); err != nil {
+		return "", err
+	}
+	return validated.SPIFFEID, nil
+}
+
+// verifyLeafSignature verifies a proof-of-possession signature under the SVID
+// leaf public key, dispatching on the declared algorithm and the actual key
+// type. A declared algorithm that does not match the key type fails closed.
+func verifyLeafSignature(leaf *x509.Certificate, alg string, msg, sig []byte) error {
+	switch pub := leaf.PublicKey.(type) {
+	case *ecdsa.PublicKey:
+		if alg != BindingAlgECDSAP256SHA256 {
+			return fmt.Errorf("%w: binding alg %q does not match ECDSA leaf key", ErrSVIDBinding, alg)
+		}
+		// The alg id names P-256; ecdsa.VerifyASN1 is curve-agnostic, so without
+		// this check a P-384/P-521 leaf would verify under a name that promises
+		// P-256 — a display-vs-reality divergence for curve-scoped policy.
+		if pub.Curve != elliptic.P256() {
+			return fmt.Errorf("%w: ECDSA leaf curve %s, binding alg requires P-256", ErrSVIDBinding, pub.Curve.Params().Name)
+		}
+		sum := sha256.Sum256(msg)
+		if !ecdsa.VerifyASN1(pub, sum[:], sig) {
+			return fmt.Errorf("%w: ECDSA proof-of-possession does not verify", ErrSVIDBinding)
+		}
+		return nil
+	case ed25519.PublicKey:
+		if alg != BindingAlgEd25519 {
+			return fmt.Errorf("%w: binding alg %q does not match Ed25519 leaf key", ErrSVIDBinding, alg)
+		}
+		if len(sig) != ed25519.SignatureSize || !ed25519.Verify(pub, msg, sig) {
+			return fmt.Errorf("%w: Ed25519 proof-of-possession does not verify", ErrSVIDBinding)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%w: unsupported SVID leaf key type %T", ErrSVIDBinding, leaf.PublicKey)
+	}
+}
+
+// svidPEM assembles the leaf-first certificate chain PEM from the evidence DER
+// fields, the form internal/svid.ValidateSVID expects.
+func svidPEM(ev SVIDEvidence) ([]byte, error) {
+	leafDER, err := base64.StdEncoding.DecodeString(ev.LeafDERB64)
+	if err != nil {
+		return nil, fmt.Errorf("%w: leaf_der_b64: %w", ErrSVIDEvidence, err)
+	}
+	if len(leafDER) == 0 {
+		return nil, fmt.Errorf("%w: empty leaf certificate DER", ErrSVIDEvidence)
+	}
+	out := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})
+	for i, c := range ev.ChainDERB64 {
+		der, err := base64.StdEncoding.DecodeString(c)
+		if err != nil {
+			return nil, fmt.Errorf("%w: chain_der_b64[%d]: %w", ErrSVIDEvidence, i, err)
+		}
+		out = append(out, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})...)
+	}
+	return out, nil
+}
+
+// spiffeIDPermitted reports whether id is in the allowed set. An empty allowed
+// set permits any validated SPIFFE ID in the (already verified) trust domain.
+func spiffeIDPermitted(id string, allowed []string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	for _, a := range allowed {
+		if a == id {
+			return true
+		}
+	}
+	return false
+}
+
+func hexSHA256(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// AppraiseWithSVID runs the core appraisal and, when SVID evidence is present
+// AND verifies against the pinned trust, adds the workload-identity claims. An
+// SVID that fails to verify never removes a core claim and never adds an
+// attestation one: the producer's workload-identity claim is simply reported
+// claimed-but-unverified, with a warning. Attestation is only considered on a
+// signed assertion, since the binding ties to the signed assertion digest.
+func AppraiseWithSVID(e Envelope, ev *SVIDEvidence, opts VerifyOptions, svidOpts SVIDVerifyOptions) (*Appraisal, error) {
+	ap, err := appraiseCore(e, opts)
+	if err != nil {
+		return nil, err
+	}
+	if ev != nil {
+		addSVIDClaims(ap, e, *ev, svidOpts)
+	}
+	classifyClaims(ap)
+	return ap, nil
+}
+
+func addSVIDClaims(ap *Appraisal, e Envelope, ev SVIDEvidence, svidOpts SVIDVerifyOptions) {
+	if !ap.AssertionSigned {
+		ap.Warnings = append(ap.Warnings, "SVID evidence present but assertion not signed; workload identity reported claim-only")
+		return
+	}
+	if _, err := VerifySVIDBinding(e, ev, svidOpts); err != nil {
+		ap.Warnings = append(ap.Warnings, "SVID attestation did not verify: "+err.Error())
+		return
+	}
+	ap.addVerified(ClaimWorkloadIdentityVerified, AxisIdentity)
+	ap.addVerified(ClaimX509SVIDBound, AxisIdentity)
+	ap.addVerified(ClaimSVIDValidAtActionTime, AxisFreshness)
+}

--- a/internal/aarp/attest.go
+++ b/internal/aarp/attest.go
@@ -90,8 +90,10 @@ type SVIDEvidence struct {
 	Binding SVIDBinding `json:"binding"`
 }
 
-// bindingPayload is the exact object the SVID leaf key signs. Its first field is
-// the domain-separation context; every numeric-like field is a typed string.
+// bindingPayload is the exact object the SVID leaf key signs. It carries a
+// signed domain-separation context field (JCS sorts keys, so "context" is part
+// of the signed bytes but not necessarily first in canonical order); every
+// numeric-like field is a typed string.
 type bindingPayload struct {
 	Context                  string `json:"context"`
 	Profile                  string `json:"profile"`
@@ -199,6 +201,32 @@ func VerifySVIDBinding(e Envelope, ev SVIDEvidence, opts SVIDVerifyOptions) (str
 	}
 	if !spiffeIDPermitted(validated.SPIFFEID, opts.AllowedSPIFFEIDs) {
 		return "", fmt.Errorf("%w: %q", ErrSVIDNotPermitted, validated.SPIFFEID)
+	}
+
+	// The signed assertion must declare the same trust domain the SVID validated
+	// against (ValidateSVID already pins the SVID to opts.TrustDomain). Without
+	// this, a valid SVID from one trust domain could back an assertion claiming
+	// another — trust-domain confusion. trust_domain is required when an SVID
+	// binding is present.
+	if e.Assertion.TrustDomain == "" {
+		return "", fmt.Errorf("%w: assertion.trust_domain is required with an SVID binding", ErrSVIDBinding)
+	}
+	if e.Assertion.TrustDomain != opts.TrustDomain {
+		return "", fmt.Errorf("%w: assertion trust_domain %q != validated SVID trust domain %q", ErrSVIDBinding, e.Assertion.TrustDomain, opts.TrustDomain)
+	}
+
+	// The proof-of-possession must have been issued while the SVID was valid: a
+	// binding stamped after the leaf expired (or before it was issued) signals
+	// post-expiry key use, not a fresh possession proof. issued_at is producer-
+	// asserted (there is no trusted timestamp without a TSA, Rung-2), so this is
+	// a fail-closed sanity bound on top of the action-time chain validation, not
+	// a substitute for it.
+	issuedAt, perr := time.Parse(time.RFC3339Nano, ev.IssuedAt)
+	if perr != nil {
+		return "", fmt.Errorf("%w: issued_at: %w", ErrSVIDEvidence, perr)
+	}
+	if issuedAt.Before(validated.Leaf.NotBefore) || issuedAt.After(validated.Leaf.NotAfter) {
+		return "", fmt.Errorf("%w: binding issued_at %s outside the SVID leaf validity window", ErrSVIDBinding, ev.IssuedAt)
 	}
 
 	// Recompute the canonical binding payload and verify the proof-of-possession

--- a/internal/aarp/attest_coverage_test.go
+++ b/internal/aarp/attest_coverage_test.go
@@ -1,0 +1,243 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"errors"
+	"math/big"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/svid"
+)
+
+func TestSVID_P384CurveConfusion(t *testing.T) {
+	// A P-384 leaf declared under ecdsa-p256-sha256 must fail closed: the alg id
+	// names P-256 and ecdsa.VerifyASN1 is curve-agnostic.
+	env, _, _, _ := signedEnvelopeForAttest(t)
+	now := time.Now().UTC()
+	caKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	caTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "ca"},
+		NotBefore: now.Add(-time.Hour), NotAfter: now.Add(time.Hour),
+		IsCA: true, KeyUsage: x509.KeyUsageCertSign, BasicConstraintsValid: true,
+	}
+	caDER, _ := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	caCert, _ := x509.ParseCertificate(caDER)
+	p384Key, _ := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	u, _ := url.Parse(testSPIFFEID)
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2), NotBefore: now.Add(-time.Hour), NotAfter: now.Add(time.Hour),
+		URIs: []*url.URL{u}, KeyUsage: x509.KeyUsageDigitalSignature,
+	}
+	leafDER, _ := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &p384Key.PublicKey, caKey)
+	gen, _ := svid.NewGeneration(now.Add(-2*time.Hour), time.Time{}, []*x509.Certificate{caCert})
+	hist, _ := svid.NewTrustBundleHistory(testTrustDomain, gen)
+
+	ev := SVIDEvidence{
+		Type: "x509", SPIFFEID: testSPIFFEID,
+		LeafDERB64: base64.StdEncoding.EncodeToString(leafDER),
+		Nonce:      testNonce, IssuedAt: bindingIssued,
+		Binding: SVIDBinding{Alg: BindingAlgECDSAP256SHA256, Context: ContextSVIDBinding},
+	}
+	canonical, _ := bindingCanonical(env, ev)
+	sum := sha256.Sum256(canonical)
+	sig, _ := ecdsa.SignASN1(rand.Reader, p384Key, sum[:])
+	ev.Binding.SignatureB64 = base64.StdEncoding.EncodeToString(sig)
+
+	svopts := SVIDVerifyOptions{TrustDomain: testTrustDomain, History: hist, ActionTime: now}
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("P-384 leaf under ecdsa-p256-sha256 = %v, want ErrSVIDBinding", err)
+	}
+}
+
+func TestSVID_ShortNonceRejected(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	ev.Nonce = base64.RawURLEncoding.EncodeToString([]byte{1, 2, 3}) // 3 bytes < 16
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDEvidence) {
+		t.Fatalf("short nonce = %v, want ErrSVIDEvidence", err)
+	}
+}
+
+func TestSVID_NonBase64URLNonceRejected(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	ev.Nonce = "not valid base64url!!"
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDEvidence) {
+		t.Fatalf("bad nonce encoding = %v, want ErrSVIDEvidence", err)
+	}
+}
+
+func TestSVID_EmptyLeafDERRejected(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	ev.LeafDERB64 = "" // decodes to empty
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDEvidence) {
+		t.Fatalf("empty leaf DER = %v, want ErrSVIDEvidence", err)
+	}
+}
+
+func TestUnmarshal_TypeMismatchIsSchemaError(t *testing.T) {
+	// A decode error that is NOT an unknown field (here, a type mismatch) must
+	// classify as ErrSchema, not ErrUnknownField.
+	raw := []byte(`{"profile":"aarp/v0.1","subject":{},"assertion":{},"signatures":"should-be-array"}`)
+	_, err := Unmarshal(raw)
+	if !errors.Is(err, ErrSchema) {
+		t.Fatalf("Unmarshal(type mismatch) = %v, want ErrSchema", err)
+	}
+	if errors.Is(err, ErrUnknownField) {
+		t.Fatal("type mismatch misclassified as ErrUnknownField")
+	}
+}
+
+func TestAppraiseWithSVID_InvalidEnvelopeErrors(t *testing.T) {
+	// A structurally invalid envelope must error out of AppraiseWithSVID (the
+	// core appraisal rejects it), regardless of evidence.
+	bad := baseEnvelope() // unsigned: no signatures
+	if _, err := AppraiseWithSVID(bad, nil, VerifyOptions{}, SVIDVerifyOptions{}); !errors.Is(err, ErrSchema) {
+		t.Fatalf("AppraiseWithSVID(invalid) = %v, want ErrSchema", err)
+	}
+}
+
+func TestSVID_EmptyNonceRejected(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	ev.Nonce = ""
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDEvidence) {
+		t.Fatalf("empty nonce: got %v", err)
+	}
+}
+
+func TestSVID_BadIssuedAtRejected(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	ev.IssuedAt = "not-a-time"
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDEvidence) {
+		t.Fatalf("bad issued_at: got %v", err)
+	}
+}
+
+func TestSVID_PayloadSHA256Mismatch(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	ev.Binding.PayloadSHA256 = digest64(5) // wrong digest
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("payload sha mismatch: got %v", err)
+	}
+}
+
+func TestSVID_BadBindingSignatureBase64(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	ev.Binding.SignatureB64 = "not!base64!"
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDEvidence) {
+		t.Fatalf("bad sig b64: got %v", err)
+	}
+}
+
+func TestSVID_AllowedSPIFFEIDMatch(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	svopts.AllowedSPIFFEIDs = []string{"spiffe://example.org/other", testSPIFFEID}
+	if _, err := VerifySVIDBinding(env, ev, svopts); err != nil {
+		t.Fatalf("allowed id should pass: %v", err)
+	}
+}
+
+func TestSVID_ChainDEREncoded(t *testing.T) {
+	// Exercise the chain-encoding branch of svidPEM by including an extra cert.
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	ev.ChainDERB64 = []string{base64.StdEncoding.EncodeToString(fx.leafDER)}
+	// Re-sign: the chain field is not part of the binding payload, so the
+	// existing signature still verifies; this just drives the PEM assembly path.
+	if _, err := VerifySVIDBinding(env, ev, svopts); err != nil {
+		t.Fatalf("chain-encoded evidence: %v", err)
+	}
+}
+
+func TestSVID_BadChainBase64(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	ev.ChainDERB64 = []string{"not!base64!"}
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDEvidence) {
+		t.Fatalf("bad chain b64: got %v", err)
+	}
+}
+
+func TestSVID_UnsupportedLeafKeyType(t *testing.T) {
+	// An RSA SVID leaf: the chain validates, but the PoP path has no RSA branch,
+	// so it fails closed with ErrSVIDBinding (unsupported key type).
+	env, _, _, _ := signedEnvelopeForAttest(t)
+	now := time.Now().UTC()
+	caKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	caTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "ca"},
+		NotBefore: now.Add(-time.Hour), NotAfter: now.Add(time.Hour),
+		IsCA: true, KeyUsage: x509.KeyUsageCertSign, BasicConstraintsValid: true,
+	}
+	caDER, _ := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	caCert, _ := x509.ParseCertificate(caDER)
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa key: %v", err)
+	}
+	u, _ := url.Parse(testSPIFFEID)
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2), NotBefore: now.Add(-time.Hour), NotAfter: now.Add(time.Hour),
+		URIs: []*url.URL{u}, KeyUsage: x509.KeyUsageDigitalSignature,
+	}
+	leafDER, _ := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &rsaKey.PublicKey, caKey)
+	gen, _ := svid.NewGeneration(now.Add(-2*time.Hour), time.Time{}, []*x509.Certificate{caCert})
+	hist, _ := svid.NewTrustBundleHistory(testTrustDomain, gen)
+
+	ev := SVIDEvidence{
+		Type: "x509", SPIFFEID: testSPIFFEID,
+		LeafDERB64: base64.StdEncoding.EncodeToString(leafDER),
+		Nonce:      testNonce, IssuedAt: bindingIssued,
+		Binding: SVIDBinding{Alg: BindingAlgECDSAP256SHA256, Context: ContextSVIDBinding},
+	}
+	canonical, _ := bindingCanonical(env, ev)
+	sum := sha256.Sum256(canonical)
+	sig, _ := rsa.SignPKCS1v15(rand.Reader, rsaKey, 0, sum[:])
+	ev.Binding.SignatureB64 = base64.StdEncoding.EncodeToString(sig)
+
+	svopts := SVIDVerifyOptions{TrustDomain: testTrustDomain, History: hist, ActionTime: now}
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("rsa leaf: got %v, want ErrSVIDBinding (unsupported key type)", err)
+	}
+}
+
+func TestAppraiseWithSVID_FailedBindingWarns(t *testing.T) {
+	env, vopts, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	ev.Binding.Context = "wrong" // make the binding fail
+	ap, err := AppraiseWithSVID(env, &ev, vopts, svopts)
+	if err != nil {
+		t.Fatalf("AppraiseWithSVID: %v", err)
+	}
+	if contains(ap.VerifiedClaims, ClaimWorkloadIdentityVerified) {
+		t.Error("workload identity verified despite failed binding")
+	}
+	var warned bool
+	for _, w := range ap.Warnings {
+		if strings.Contains(w, "SVID attestation did not verify") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("expected a failed-attestation warning, got %v", ap.Warnings)
+	}
+}

--- a/internal/aarp/attest_coverage_test.go
+++ b/internal/aarp/attest_coverage_test.go
@@ -5,6 +5,7 @@ package aarp
 
 import (
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -48,7 +49,7 @@ func TestSVID_P384CurveConfusion(t *testing.T) {
 	ev := SVIDEvidence{
 		Type: "x509", SPIFFEID: testSPIFFEID,
 		LeafDERB64: base64.StdEncoding.EncodeToString(leafDER),
-		Nonce:      testNonce, IssuedAt: bindingIssued,
+		Nonce:      testNonce, IssuedAt: now.UTC().Format(time.RFC3339Nano),
 		Binding: SVIDBinding{Alg: BindingAlgECDSAP256SHA256, Context: ContextSVIDBinding},
 	}
 	canonical, _ := bindingCanonical(env, ev)
@@ -86,6 +87,62 @@ func TestSVID_EmptyLeafDERRejected(t *testing.T) {
 	ev.LeafDERB64 = "" // decodes to empty
 	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDEvidence) {
 		t.Fatalf("empty leaf DER = %v, want ErrSVIDEvidence", err)
+	}
+}
+
+func TestSVID_AssertionTrustDomainMismatch(t *testing.T) {
+	// A valid example.org SVID must NOT back an assertion claiming a different
+	// trust domain (trust-domain confusion at the appraisal layer).
+	fx := mintSVID(t, testTrustDomain, testSPIFFEID)
+	pub, priv := genKey(t)
+	signer, _ := NewEd25519Signer(testKeyID, "mediator", priv)
+	e := baseEnvelope()
+	e.Assertion.TrustDomain = "other.example" // claims a domain the SVID is not in
+	e.Assertion.EvidenceRefs = []string{"spiffe_svid"}
+	env, err := Sign(e, signer)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	svopts := SVIDVerifyOptions{TrustDomain: testTrustDomain, History: fx.history, ActionTime: fx.actionTime}
+
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("trust-domain confusion: got %v, want ErrSVIDBinding", err)
+	}
+	ap, err := AppraiseWithSVID(env, &ev, VerifyOptions{TrustedKeys: map[string]ed25519.PublicKey{testKeyID: pub}}, svopts)
+	if err != nil {
+		t.Fatalf("AppraiseWithSVID: %v", err)
+	}
+	if contains(ap.VerifiedClaims, ClaimWorkloadIdentityVerified) {
+		t.Fatal("workload_identity_verified despite trust-domain confusion")
+	}
+}
+
+func TestSVID_AssertionTrustDomainRequired(t *testing.T) {
+	fx := mintSVID(t, testTrustDomain, testSPIFFEID)
+	_, priv := genKey(t)
+	signer, _ := NewEd25519Signer(testKeyID, "mediator", priv)
+	e := baseEnvelope()
+	e.Assertion.TrustDomain = "" // missing with an SVID binding present
+	env, err := Sign(e, signer)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	svopts := SVIDVerifyOptions{TrustDomain: testTrustDomain, History: fx.history, ActionTime: fx.actionTime}
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("empty trust_domain: got %v, want ErrSVIDBinding", err)
+	}
+}
+
+func TestSVID_IssuedAtOutsideLeafWindow(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	// Sign a binding stamped 48h out — past the leaf NotAfter (action+24h) —
+	// modeling post-expiry use of a later-obtained leaf key.
+	future := fx.actionTime.Add(48 * time.Hour).UTC().Format(time.RFC3339Nano)
+	ev := signedEvidenceAt(t, env, fx, testSPIFFEID, future)
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("issued_at after expiry: got %v, want ErrSVIDBinding", err)
 	}
 }
 
@@ -206,7 +263,7 @@ func TestSVID_UnsupportedLeafKeyType(t *testing.T) {
 	ev := SVIDEvidence{
 		Type: "x509", SPIFFEID: testSPIFFEID,
 		LeafDERB64: base64.StdEncoding.EncodeToString(leafDER),
-		Nonce:      testNonce, IssuedAt: bindingIssued,
+		Nonce:      testNonce, IssuedAt: now.UTC().Format(time.RFC3339Nano),
 		Binding: SVIDBinding{Alg: BindingAlgECDSAP256SHA256, Context: ContextSVIDBinding},
 	}
 	canonical, _ := bindingCanonical(env, ev)

--- a/internal/aarp/attest_test.go
+++ b/internal/aarp/attest_test.go
@@ -22,9 +22,8 @@ import (
 )
 
 const (
-	testSPIFFEID  = "spiffe://example.org/mediators/pipelock-prod"
-	testNonce     = "Zm9vYmFyYmF6cXV4MTIzNA"
-	bindingIssued = "2026-06-01T00:00:00Z"
+	testSPIFFEID = "spiffe://example.org/mediators/pipelock-prod"
+	testNonce    = "Zm9vYmFyYmF6cXV4MTIzNA"
 )
 
 // svidFixture is a minted ECDSA SVID leaf, its CA, and a pinned trust-bundle
@@ -97,12 +96,19 @@ func mintSVID(t *testing.T, trustDomain, spiffeID string) svidFixture {
 // the binding payload derived from env.
 func signedEvidence(t *testing.T, env Envelope, fx svidFixture, spiffeID string) SVIDEvidence {
 	t.Helper()
+	// issued_at must fall within the SVID leaf validity window; the action time
+	// (= leaf midpoint in the fixture) always does.
+	return signedEvidenceAt(t, env, fx, spiffeID, fx.actionTime.UTC().Format(time.RFC3339Nano))
+}
+
+func signedEvidenceAt(t *testing.T, env Envelope, fx svidFixture, spiffeID, issuedAt string) SVIDEvidence {
+	t.Helper()
 	ev := SVIDEvidence{
 		Type:       "x509",
 		SPIFFEID:   spiffeID,
 		LeafDERB64: base64.StdEncoding.EncodeToString(fx.leafDER),
 		Nonce:      testNonce,
-		IssuedAt:   bindingIssued,
+		IssuedAt:   issuedAt,
 		Binding:    SVIDBinding{Alg: BindingAlgECDSAP256SHA256, Context: ContextSVIDBinding},
 	}
 	canonical, err := bindingCanonical(env, ev)
@@ -351,7 +357,7 @@ func TestSVID_Ed25519LeafPoP(t *testing.T) {
 	ev := SVIDEvidence{
 		Type: "x509", SPIFFEID: testSPIFFEID,
 		LeafDERB64: base64.StdEncoding.EncodeToString(leafDER),
-		Nonce:      testNonce, IssuedAt: bindingIssued,
+		Nonce:      testNonce, IssuedAt: now.UTC().Format(time.RFC3339Nano),
 		Binding: SVIDBinding{Alg: BindingAlgEd25519, Context: ContextSVIDBinding},
 	}
 	canonical, _ := bindingCanonical(env, ev)

--- a/internal/aarp/attest_test.go
+++ b/internal/aarp/attest_test.go
@@ -1,0 +1,372 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package aarp
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"errors"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/svid"
+)
+
+const (
+	testSPIFFEID  = "spiffe://example.org/mediators/pipelock-prod"
+	testNonce     = "Zm9vYmFyYmF6cXV4MTIzNA"
+	bindingIssued = "2026-06-01T00:00:00Z"
+)
+
+// svidFixture is a minted ECDSA SVID leaf, its CA, and a pinned trust-bundle
+// history covering a wide window around the action time.
+type svidFixture struct {
+	leafKey    *ecdsa.PrivateKey
+	leafDER    []byte
+	history    *svid.TrustBundleHistory
+	actionTime time.Time
+}
+
+func mintSVID(t *testing.T, trustDomain, spiffeID string) svidFixture {
+	t.Helper()
+	now := time.Now().UTC()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ca key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             now.Add(-365 * 24 * time.Hour),
+		NotAfter:              now.Add(365 * 24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("ca cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse ca: %v", err)
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("leaf key: %v", err)
+	}
+	u, err := url.Parse(spiffeID)
+	if err != nil {
+		t.Fatalf("spiffe url: %v", err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		NotBefore:    now.Add(-1 * time.Hour),
+		NotAfter:     now.Add(24 * time.Hour),
+		URIs:         []*url.URL{u},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("leaf cert: %v", err)
+	}
+
+	gen, err := svid.NewGeneration(now.Add(-365*24*time.Hour), time.Time{}, []*x509.Certificate{caCert})
+	if err != nil {
+		t.Fatalf("generation: %v", err)
+	}
+	hist, err := svid.NewTrustBundleHistory(trustDomain, gen)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	return svidFixture{leafKey: leafKey, leafDER: leafDER, history: hist, actionTime: now}
+}
+
+// signedEvidence builds SVIDEvidence with a valid ECDSA proof-of-possession over
+// the binding payload derived from env.
+func signedEvidence(t *testing.T, env Envelope, fx svidFixture, spiffeID string) SVIDEvidence {
+	t.Helper()
+	ev := SVIDEvidence{
+		Type:       "x509",
+		SPIFFEID:   spiffeID,
+		LeafDERB64: base64.StdEncoding.EncodeToString(fx.leafDER),
+		Nonce:      testNonce,
+		IssuedAt:   bindingIssued,
+		Binding:    SVIDBinding{Alg: BindingAlgECDSAP256SHA256, Context: ContextSVIDBinding},
+	}
+	canonical, err := bindingCanonical(env, ev)
+	if err != nil {
+		t.Fatalf("bindingCanonical: %v", err)
+	}
+	sum := sha256.Sum256(canonical)
+	sig, err := ecdsa.SignASN1(rand.Reader, fx.leafKey, sum[:])
+	if err != nil {
+		t.Fatalf("sign binding: %v", err)
+	}
+	ev.Binding.SignatureB64 = base64.StdEncoding.EncodeToString(sig)
+	ev.Binding.PayloadSHA256 = hexSHA256(canonical)
+	return ev
+}
+
+// signedEnvelopeForAttest returns a signed envelope whose trust_domain matches
+// the SVID fixture, plus verify options trusting the assertion key.
+func signedEnvelopeForAttest(t *testing.T) (Envelope, VerifyOptions, svidFixture, SVIDVerifyOptions) {
+	t.Helper()
+	fx := mintSVID(t, testTrustDomain, testSPIFFEID)
+	pub, priv := genKey(t)
+	signer, err := NewEd25519Signer(testKeyID, "mediator", priv)
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+	e := baseEnvelope()
+	e.Assertion.EvidenceRefs = []string{"spiffe_svid"}
+	env, err := Sign(e, signer)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	vopts := VerifyOptions{
+		TrustedKeys: map[string]ed25519.PublicKey{testKeyID: pub},
+		Trust:       map[string]TrustEntry{testKeyID: {MediatorID: testMediatorID, Role: "mediator", TrustDomain: testTrustDomain}},
+	}
+	svopts := SVIDVerifyOptions{TrustDomain: testTrustDomain, History: fx.history, ActionTime: fx.actionTime}
+	return env, vopts, fx, svopts
+}
+
+func TestSVID_ValidBindingVerifies(t *testing.T) {
+	env, vopts, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+
+	spiffeID, err := VerifySVIDBinding(env, ev, svopts)
+	if err != nil {
+		t.Fatalf("VerifySVIDBinding: %v", err)
+	}
+	if spiffeID != testSPIFFEID {
+		t.Fatalf("spiffe id = %q", spiffeID)
+	}
+
+	ap, err := AppraiseWithSVID(env, &ev, vopts, svopts)
+	if err != nil {
+		t.Fatalf("AppraiseWithSVID: %v", err)
+	}
+	for _, want := range []string{ClaimWorkloadIdentityVerified, ClaimX509SVIDBound, ClaimSVIDValidAtActionTime} {
+		if !contains(ap.VerifiedClaims, want) {
+			t.Errorf("missing verified claim %q in %v", want, ap.VerifiedClaims)
+		}
+	}
+	if !contains(ap.Axes[AxisIdentity], ClaimWorkloadIdentityVerified) {
+		t.Error("workload_identity_verified not on identity axis")
+	}
+	if !contains(ap.Axes[AxisFreshness], ClaimSVIDValidAtActionTime) {
+		t.Error("svid_valid_at_action_time not on freshness axis")
+	}
+}
+
+func TestSVID_ExpiredAtActionTime(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	svopts.ActionTime = fx.actionTime.Add(48 * time.Hour) // past leaf NotAfter (+24h)
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("expired: got %v, want ErrSVIDBinding", err)
+	}
+}
+
+func TestSVID_NotYetValidAtActionTime(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	svopts.ActionTime = fx.actionTime.Add(-2 * time.Hour) // before leaf NotBefore (-1h)
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("not-yet-valid: got %v, want ErrSVIDBinding", err)
+	}
+}
+
+func TestSVID_ReplayAcrossActions(t *testing.T) {
+	// Evidence signed for envelope A is presented with envelope B (different
+	// receipt digests). The binding payload digest changes, so the PoP fails.
+	envA, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, envA, fx, testSPIFFEID)
+
+	envB := envA
+	envB.Subject.ActionRecordSHA256 = digest64(9) // different action
+	if _, err := VerifySVIDBinding(envB, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("replay: got %v, want ErrSVIDBinding", err)
+	}
+}
+
+func TestSVID_WrongLeafKeySignature(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	// Re-sign the binding with a DIFFERENT (attacker) key but keep the real SVID
+	// cert. The PoP must fail under the cert's real public key.
+	attackerKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	canonical, _ := bindingCanonical(env, ev)
+	sum := sha256.Sum256(canonical)
+	sig, _ := ecdsa.SignASN1(rand.Reader, attackerKey, sum[:])
+	ev.Binding.SignatureB64 = base64.StdEncoding.EncodeToString(sig)
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("wrong key: got %v, want ErrSVIDBinding", err)
+	}
+}
+
+func TestSVID_TrustDomainConfusion(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	// Validate the example.org SVID against a different trust domain's history.
+	otherFx := mintSVID(t, "staging.example", "spiffe://staging.example/x")
+	svopts.TrustDomain = "staging.example"
+	svopts.History = otherFx.history
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("trust-domain confusion: got %v, want ErrSVIDBinding", err)
+	}
+}
+
+func TestSVID_StaleOrForkedBundle(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	// A history for example.org pinned to a DIFFERENT CA (not the SVID's issuer).
+	forked := mintSVID(t, testTrustDomain, testSPIFFEID)
+	svopts.History = forked.history
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("forked bundle: got %v, want ErrSVIDBinding", err)
+	}
+}
+
+func TestSVID_SPIFFEIDNotPermitted(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	svopts.AllowedSPIFFEIDs = []string{"spiffe://example.org/some/other/id"}
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDNotPermitted) {
+		t.Fatalf("not permitted: got %v, want ErrSVIDNotPermitted", err)
+	}
+}
+
+func TestSVID_SPIFFEIDMismatch(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	// Claim a different spiffe_id than the SVID's URI SAN.
+	ev := signedEvidence(t, env, fx, "spiffe://example.org/wrong")
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("spiffe mismatch: got %v, want ErrSVIDBinding", err)
+	}
+}
+
+func TestSVID_ContextMismatch(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	ev.Binding.Context = "wrong/context"
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("context mismatch: got %v, want ErrSVIDBinding", err)
+	}
+}
+
+func TestSVID_NonX509Rejected(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	ev.Type = "jwt"
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDEvidence) {
+		t.Fatalf("jwt: got %v, want ErrSVIDEvidence", err)
+	}
+}
+
+func TestSVID_AlgKeyTypeMismatch(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	ev.Binding.Alg = BindingAlgEd25519 // ECDSA leaf, declared ed25519
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("alg mismatch: got %v, want ErrSVIDBinding", err)
+	}
+}
+
+func TestAppraiseWithSVID_UnsignedAssertionClaimOnly(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	// Verify with an empty trust set → assertion not signed.
+	ap, err := AppraiseWithSVID(env, &ev, VerifyOptions{}, svopts)
+	if err != nil {
+		t.Fatalf("AppraiseWithSVID: %v", err)
+	}
+	if ap.AssertionSigned {
+		t.Fatal("AssertionSigned true with empty trust set")
+	}
+	if contains(ap.VerifiedClaims, ClaimWorkloadIdentityVerified) {
+		t.Error("workload identity verified on an unsigned assertion")
+	}
+}
+
+func TestAppraiseWithSVID_NilEvidence(t *testing.T) {
+	env, vopts, _, svopts := signedEnvelopeForAttest(t)
+	ap, err := AppraiseWithSVID(env, nil, vopts, svopts)
+	if err != nil {
+		t.Fatalf("AppraiseWithSVID(nil): %v", err)
+	}
+	if contains(ap.VerifiedClaims, ClaimWorkloadIdentityVerified) {
+		t.Error("workload identity verified with nil evidence")
+	}
+}
+
+func TestSVID_BadBase64Leaf(t *testing.T) {
+	env, _, fx, svopts := signedEnvelopeForAttest(t)
+	ev := signedEvidence(t, env, fx, testSPIFFEID)
+	ev.LeafDERB64 = "not!base64!"
+	if _, err := VerifySVIDBinding(env, ev, svopts); !errors.Is(err, ErrSVIDEvidence) {
+		t.Fatalf("bad b64: got %v, want ErrSVIDEvidence", err)
+	}
+}
+
+func TestSVID_Ed25519LeafPoP(t *testing.T) {
+	// Exercise the Ed25519 leaf PoP path (verifyLeafSignature ed25519 branch)
+	// via a direct cert+key, independent of the ECDSA fixture.
+	env, _, _, _ := signedEnvelopeForAttest(t)
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	now := time.Now().UTC()
+	u, _ := url.Parse(testSPIFFEID)
+	caKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	caTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "ca"},
+		NotBefore: now.Add(-time.Hour), NotAfter: now.Add(time.Hour),
+		IsCA: true, KeyUsage: x509.KeyUsageCertSign, BasicConstraintsValid: true,
+	}
+	caDER, _ := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	caCert, _ := x509.ParseCertificate(caDER)
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2), NotBefore: now.Add(-time.Hour), NotAfter: now.Add(time.Hour),
+		URIs: []*url.URL{u}, KeyUsage: x509.KeyUsageDigitalSignature,
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, pub, caKey)
+	if err != nil {
+		t.Fatalf("ed25519 leaf: %v", err)
+	}
+	gen, _ := svid.NewGeneration(now.Add(-2*time.Hour), time.Time{}, []*x509.Certificate{caCert})
+	hist, _ := svid.NewTrustBundleHistory(testTrustDomain, gen)
+
+	ev := SVIDEvidence{
+		Type: "x509", SPIFFEID: testSPIFFEID,
+		LeafDERB64: base64.StdEncoding.EncodeToString(leafDER),
+		Nonce:      testNonce, IssuedAt: bindingIssued,
+		Binding: SVIDBinding{Alg: BindingAlgEd25519, Context: ContextSVIDBinding},
+	}
+	canonical, _ := bindingCanonical(env, ev)
+	ev.Binding.SignatureB64 = base64.StdEncoding.EncodeToString(ed25519.Sign(priv, canonical))
+	ev.Binding.PayloadSHA256 = hexSHA256(canonical)
+
+	svopts := SVIDVerifyOptions{TrustDomain: testTrustDomain, History: hist, ActionTime: now}
+	if _, err := VerifySVIDBinding(env, ev, svopts); err != nil {
+		t.Fatalf("ed25519 PoP: %v", err)
+	}
+
+	// Wrong-length signature on an Ed25519 leaf fails closed (no panic).
+	bad := ev
+	bad.Binding.SignatureB64 = base64.StdEncoding.EncodeToString([]byte{1, 2, 3})
+	if _, err := VerifySVIDBinding(env, bad, svopts); !errors.Is(err, ErrSVIDBinding) {
+		t.Fatalf("ed25519 short sig: got %v, want ErrSVIDBinding", err)
+	}
+}

--- a/internal/aarp/verify.go
+++ b/internal/aarp/verify.go
@@ -40,13 +40,13 @@ type VerifyOptions struct {
 // A nil value means the claim is structurally claim-only in v0.1 (never
 // verifiable), so it is always reported unverified.
 var claimVerifiedBy = map[string][]string{
-	"mediated":                   {ClaimMediatorKeyPinned},
-	"complete-mediation":         nil,
-	"complete_mediation":         nil,
-	"workload_identity_verified": {"workload_identity_verified"},
-	"x509_svid_bound":            {"x509_svid_bound"},
-	"svid_valid_at_action_time":  {"svid_valid_at_action_time"},
-	"transparency_inclusion":     nil,
+	"mediated":                    {ClaimMediatorKeyPinned},
+	"complete-mediation":          nil,
+	"complete_mediation":          nil,
+	ClaimWorkloadIdentityVerified: {ClaimWorkloadIdentityVerified},
+	ClaimX509SVIDBound:            {ClaimX509SVIDBound},
+	ClaimSVIDValidAtActionTime:    {ClaimSVIDValidAtActionTime},
+	"transparency_inclusion":      nil,
 }
 
 // Verify appraises an AARP envelope and returns a structured result. It rejects
@@ -59,6 +59,20 @@ var claimVerifiedBy = map[string][]string{
 // The appraisal never reports "trusted" or "safe". A relying party applies its
 // own claim policy to the verified_claims and axes.
 func Verify(e Envelope, opts VerifyOptions) (*Appraisal, error) {
+	ap, err := appraiseCore(e, opts)
+	if err != nil {
+		return nil, err
+	}
+	classifyClaims(ap)
+	return ap, nil
+}
+
+// appraiseCore runs the full envelope appraisal EXCEPT the final claim
+// classification, returning an appraisal whose verified claims are populated.
+// Verify finishes it with classifyClaims; AppraiseWithSVID adds the
+// workload-identity claims first, then classifies, so an attestation claim moves
+// from claimed-unverified to verified in one consistent pass.
+func appraiseCore(e Envelope, opts VerifyOptions) (*Appraisal, error) {
 	if err := e.validateStructure(); err != nil {
 		return nil, err
 	}
@@ -96,8 +110,6 @@ func Verify(e Envelope, opts VerifyOptions) (*Appraisal, error) {
 		// input, not a producer-authored claim.
 		ap.Warnings = append(ap.Warnings, "no signature verified under a trusted key; all assurance claims are untrusted input")
 	}
-
-	classifyClaims(ap)
 	return ap, nil
 }
 


### PR DESCRIPTION
Adds the SVID attestation layer on the assurance envelope (stacks on the AARP core PR): a proof-of-possession binding that cryptographically ties a workload's X.509-SVID to a specific receipt and assertion, verified offline and point-in-time against a pinned trust-bundle history.

- The SVID leaf key signs a domain-separated binding payload over the envelope's canonical payload digest, the receipt signer key, the SPIFFE id, and a 128-bit-or-larger nonce, so a binding cannot be replayed across actions.
- Verification reuses the offline X.509-SVID substrate, validating at the action time (not "now"), requiring the signed assertion's trust domain to match the validated SVID, requiring the binding's `issued_at` to fall within the SVID validity window, and verifying the proof-of-possession under the leaf key (ECDSA P-256 with curve enforcement, or Ed25519; JWT-SVID stays claim-only).
- On success the appraisal gains `workload_identity_verified` and `x509_svid_bound` on the identity axis and `svid_valid_at_action_time` on the freshness axis; a failed or absent binding never removes a core claim and never adds an attestation one.

Hostile corpus: replay, expiry, not-yet-valid, wrong key, forked bundle, trust-domain confusion (assertion plus SVID), spiffe-id mismatch, curve confusion, algorithm mismatch, short nonce, issued-at-outside-window, and unsigned-assertion attestation all reject.

Stacked on the AARP core PR; review and merge that one first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added X.509-SVID workload identity attestation binding verification with proof-of-possession checks and offline validation
  * Extended appraisal reporting with verified claims for workload identity binding, SVID validity assessment, and related identity assertions

* **Documentation**
  * Updated specification to detail X.509-SVID binding payload structure, offline fail-closed verification requirements, and appraisal impact
<!-- end of auto-generated comment: release notes by coderabbit.ai -->