### PR TITLE
Harden test stability checks and remove sleep-based waits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,6 +161,12 @@ jobs:
       - name: Python pin policy
         run: bash scripts/check-python-pins.sh
 
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Test stability policy
+        run: bash scripts/check-test-stability.sh
+
   helm:
     needs: [security-scan]
     runs-on: ubuntu-latest

--- a/.github/workflows/verifiers.yaml
+++ b/.github/workflows/verifiers.yaml
@@ -193,12 +193,13 @@ jobs:
       - name: Install Python verifier
         working-directory: _pyverify
         # Hash-pinned dependency install (Scorecard Pinned-Dependencies):
-        # cryptography + its transitive deps are locked with --require-hashes,
-        # then the verifier itself is installed from its pinned checkout with
-        # --no-deps so no unpinned package is ever fetched.
+        # cryptography + its transitive deps are locked with --require-hashes.
+        # The verifier is installed from its pinned checkout with --no-deps and
+        # --no-build-isolation; its setuptools/wheel build backend is pinned in
+        # the requirements file so no isolated env fetches unpinned packages.
         run: |
           pip install --require-hashes -r "$GITHUB_WORKSPACE/sdk/conformance/pyverify-requirements.txt"
-          pip install --no-deps .
+          pip install --no-deps --no-build-isolation .
 
       - name: Run cross-language conformance gate
         env:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LDFLAGS := -ldflags "-s -w \
 	-X $(MODULE)/internal/license.PublicKeyHex=$(LICENSE_PUBLIC_KEY) \
 	-X $(MODULE)/internal/rules.KeyringHex=$(RULES_KEYRING_HEX)"
 
-.PHONY: all build build-verifier test bench bench-egress bench-egress-long bench-egress-release lint clean docker install fmt vet tidy-check fuzz stats docs-check \
+.PHONY: all build build-verifier test bench bench-egress bench-egress-long bench-egress-release lint test-stability-check clean docker install fmt vet tidy-check fuzz stats docs-check \
 	test-runtime-critical test-replay-harness release-audit runtime-policy-audit debt-check release-check hermes-e2e
 
 all: build
@@ -82,6 +82,10 @@ vet:
 
 lint: vet
 	golangci-lint run ./...
+	./scripts/check-test-stability.sh
+
+test-stability-check:
+	./scripts/check-test-stability.sh
 
 release-audit:
 	./scripts/release-audit.sh

--- a/enterprise/conductor/auditbatcher/producer_test.go
+++ b/enterprise/conductor/auditbatcher/producer_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 func TestProducer_EnqueuesSignedCheckpointSegment(t *testing.T) {
@@ -139,6 +140,7 @@ func TestProducer_CloseRacesWithObserver(t *testing.T) {
 	}
 
 	var stop atomic.Bool
+	var observed atomic.Int64
 	var wg sync.WaitGroup
 	for i := 0; i < 16; i++ {
 		wg.Add(1)
@@ -146,10 +148,16 @@ func TestProducer_CloseRacesWithObserver(t *testing.T) {
 			defer wg.Done()
 			for !stop.Load() {
 				producer.ObserveRecorderEntry(recorder.Entry{Version: recorder.EntryVersion})
+				observed.Add(1)
 			}
 		}()
 	}
-	time.Sleep(10 * time.Millisecond)
+	// Close must race against Observe in flight, not before the goroutines are
+	// scheduled. Wait until contention is genuinely underway (observable, not a
+	// timing guess) so the -race coverage is deterministic.
+	testwait.For(t, time.Second, func() bool {
+		return observed.Load() >= 100
+	}, "producers to start observing under contention")
 	if err := producer.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -527,8 +535,13 @@ func testRecorderEntry(summary string) recorder.Entry {
 
 func waitForPending(t *testing.T, q *Queue, producer *Producer, want int) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
+	// Poll without time.Sleep. A ticker (not testwait.For) is used here so the
+	// failure diagnostic can include the live droppedAccounting() snapshot,
+	// which testwait.For's eagerly-evaluated format args cannot capture.
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	deadline := time.After(2 * time.Second)
+	for {
 		stats, err := q.Stats()
 		if err != nil {
 			t.Fatalf("Stats: %v", err)
@@ -536,13 +549,12 @@ func waitForPending(t *testing.T, q *Queue, producer *Producer, want int) {
 		if stats.Pending == want {
 			return
 		}
-		time.Sleep(10 * time.Millisecond)
+		select {
+		case <-deadline:
+			t.Fatalf("pending = %d, want %d; dropped=%#v", stats.Pending, want, producer.droppedAccounting())
+		case <-ticker.C:
+		}
 	}
-	stats, err := q.Stats()
-	if err != nil {
-		t.Fatalf("Stats after wait: %v", err)
-	}
-	t.Fatalf("pending = %d, want %d; dropped=%#v", stats.Pending, want, producer.droppedAccounting())
 }
 
 func splitJSONLines(payload []byte) [][]byte {

--- a/enterprise/conductor/auditbatcher/transport_test.go
+++ b/enterprise/conductor/auditbatcher/transport_test.go
@@ -16,8 +16,11 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 func TestTransportDeliverOnceSuccessAcksRecord(t *testing.T) {
@@ -258,7 +261,9 @@ func TestTransportRun_GracefulShutdown(t *testing.T) {
 	if _, err := q.Enqueue(signedTestBatch(t, "batch-shutdown", priv)); err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
+	var attempts atomic.Int64
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	defer srv.Close()
@@ -283,8 +288,12 @@ func TestTransportRun_GracefulShutdown(t *testing.T) {
 		runErrCh <- tr.Run(ctx)
 	}()
 
-	// Give the loop a turn so we exercise the retry-sleep path before cancel.
-	time.Sleep(25 * time.Millisecond)
+	// Wait until the transport has actually attempted a send (and hit the 503
+	// retry path) before cancelling, so the shutdown-mid-retry path is
+	// exercised deterministically instead of via a timing guess.
+	testwait.For(t, time.Second, func() bool {
+		return attempts.Load() >= 1
+	}, "transport to attempt at least one send before cancel")
 	cancel()
 
 	select {

--- a/enterprise/licenseservice/server_test.go
+++ b/enterprise/licenseservice/server_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -23,6 +24,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/luckyPipewrench/pipelock/internal/license"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 const (
@@ -352,21 +354,36 @@ func TestServer_WebhookProcessingError_Returns500(t *testing.T) {
 	}
 }
 
-func TestServer_ListenAndShutdown(t *testing.T) {
+func TestServer_ServeAndShutdown(t *testing.T) {
 	srv := newTestServer(t)
 
-	// Use a random port for this test.
-	srv.cfg.ListenAddr = "127.0.0.1:0"
-	srv.srv.Addr = "127.0.0.1:0"
+	// Bind an ephemeral loopback port and read the resolved address back so
+	// readiness is observable (dialable) without a startup sleep. The public
+	// ListenAndServe binds a :0 port it never surfaces, leaving nothing to
+	// poll. Serving the underlying http.Server with a test-owned listener
+	// exercises the graceful-shutdown path deterministically; the
+	// ListenAndServe wrapper only logs startup and delegates to this server.
+	var lc net.ListenConfig
+	ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	addr := ln.Addr().String()
 
-	// Start the server in a goroutine.
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- srv.ListenAndServe()
+		errCh <- srv.srv.Serve(ln)
 	}()
 
-	// Give the server a moment to start listening.
-	time.Sleep(50 * time.Millisecond)
+	// Wait until the server actually accepts connections before shutting down.
+	testwait.For(t, 2*time.Second, func() bool {
+		conn, derr := (&net.Dialer{Timeout: 100 * time.Millisecond}).DialContext(t.Context(), "tcp", addr)
+		if derr != nil {
+			return false
+		}
+		_ = conn.Close()
+		return true
+	}, "license server to accept connections")
 
 	// Gracefully shut down.
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
@@ -376,8 +393,8 @@ func TestServer_ListenAndShutdown(t *testing.T) {
 		t.Fatalf("Shutdown: %v", err)
 	}
 
-	// ListenAndServe should return http.ErrServerClosed.
+	// Serve should return http.ErrServerClosed after graceful shutdown.
 	if err := <-errCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
-		t.Errorf("ListenAndServe returned unexpected error: %v", err)
+		t.Errorf("Serve returned unexpected error: %v", err)
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 type cliTestBuffer struct {
@@ -53,10 +54,9 @@ func (b *cliTestBuffer) String() string {
 
 func waitForCLIOutput(t *testing.T, buf *cliTestBuffer, errCh <-chan error, cancel context.CancelFunc, want string) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
+	testwait.For(t, 5*time.Second, func() bool {
 		if buf.contains(want) {
-			return
+			return true
 		}
 		select {
 		case cmdErr := <-errCh:
@@ -64,9 +64,70 @@ func waitForCLIOutput(t *testing.T, buf *cliTestBuffer, errCh <-chan error, canc
 			t.Fatalf("run exited before output %q: %v\nstderr:\n%s", want, cmdErr, buf.String())
 		default:
 		}
-		time.Sleep(25 * time.Millisecond)
-	}
-	t.Fatalf("timed out waiting for output %q\nstderr:\n%s", want, buf.String())
+		return false
+	}, "CLI output %q\nstderr:\n%s", want, buf.String())
+}
+
+func waitForRunHTTP(
+	t *testing.T,
+	ctx context.Context,
+	client *http.Client,
+	errCh <-chan error,
+	cancel context.CancelFunc,
+	url string,
+	check func(*http.Response) bool,
+	label string,
+) {
+	t.Helper()
+	waitForRunHTTPWithin(t, 5*time.Second, ctx, client, errCh, cancel, url, check, "%s", label)
+}
+
+func waitForRunHTTPWithin(
+	t *testing.T,
+	timeout time.Duration,
+	ctx context.Context,
+	client *http.Client,
+	errCh <-chan error,
+	cancel context.CancelFunc,
+	url string,
+	check func(*http.Response) bool,
+	format string,
+	args ...any,
+) {
+	t.Helper()
+	waitForRunRequestWithin(t, timeout, errCh, cancel, func() *http.Request {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		return req
+	}, client, check, format, args...)
+}
+
+func waitForRunRequestWithin(
+	t *testing.T,
+	timeout time.Duration,
+	errCh <-chan error,
+	cancel context.CancelFunc,
+	newReq func() *http.Request,
+	client *http.Client,
+	check func(*http.Response) bool,
+	format string,
+	args ...any,
+) {
+	t.Helper()
+	testwait.For(t, timeout, func() bool {
+		select {
+		case cmdErr := <-errCh:
+			cancel()
+			t.Fatalf("run exited early: %v", cmdErr)
+		default:
+		}
+		req := newReq()
+		resp, err := client.Do(req) //nolint:gosec // G704: test-only URL built from loopback listener.
+		if err != nil {
+			return false
+		}
+		defer func() { _ = resp.Body.Close() }()
+		return check(resp)
+	}, format, args...)
 }
 
 func TestRootCmd_Version(t *testing.T) {
@@ -662,32 +723,9 @@ logging:
 	// Poll /health until the proxy is ready
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + addr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	var healthy bool
-	for time.Now().Before(deadline) {
-		// Check if the command already exited with an error
-		select {
-		case err := <-errCh:
-			cancel()
-			t.Fatalf("run command exited early: %v", err)
-		default:
-		}
-
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, err := client.Do(req) //nolint:gosec // G704: test-only, URL from httptest server
-		if err == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				healthy = true
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	if !healthy {
-		cancel()
-		t.Fatal("proxy did not become healthy within timeout")
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "proxy health")
 
 	// Verify the health response shows the flag override (strict, not balanced)
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
@@ -760,8 +798,9 @@ func TestRunCmd_InvalidConfig(t *testing.T) {
 	cmd := rootCmd()
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"run", "--config", cfgPath})
+	stderr := &cliTestBuffer{}
 	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
+	cmd.SetErr(stderr)
 
 	err := cmd.Execute()
 	if err == nil {
@@ -855,31 +894,9 @@ func TestRunCmd_ListenFlagOverride(t *testing.T) {
 	// Poll /health until the proxy is ready
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + addr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	var healthy bool
-	for time.Now().Before(deadline) {
-		select {
-		case err := <-errCh:
-			cancel()
-			t.Fatalf("run command exited early: %v", err)
-		default:
-		}
-
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, err := client.Do(req) //nolint:gosec // G704: test-only, URL from httptest server
-		if err == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				healthy = true
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	if !healthy {
-		cancel()
-		t.Fatal("proxy did not become healthy within timeout")
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "proxy health")
 
 	cancel()
 	select {
@@ -1042,24 +1059,9 @@ func TestRunCmd_WithAgentArgs(t *testing.T) {
 	// Poll until healthy.
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + addr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case err := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", err)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, err := client.Do(req) //nolint:gosec // G704: test-only, URL from httptest server
-		if err == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "proxy health")
 
 	cancel()
 	select {
@@ -1102,26 +1104,11 @@ func TestRunCmd_DefaultMode(t *testing.T) {
 	// Wait until healthy, then check mode.
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + addr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case err := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", err)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, err := client.Do(req) //nolint:gosec // G704: test-only, URL from httptest server
-		if err == nil {
-			var health map[string]any
-			_ = json.NewDecoder(resp.Body).Decode(&health)
-			_ = resp.Body.Close()
-			if health["mode"] == config.ModeBalanced {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		var health map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&health)
+		return health["mode"] == config.ModeBalanced
+	}, "balanced mode health")
 
 	cancel()
 	select {
@@ -1186,26 +1173,11 @@ func TestRunCmd_ModeFlag(t *testing.T) {
 	// Wait for healthy.
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + addr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case err := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", err)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // G704: test-only, URL from httptest server
-		if rerr == nil {
-			var health map[string]any
-			_ = json.NewDecoder(resp.Body).Decode(&health)
-			_ = resp.Body.Close()
-			if health["mode"] == config.ModeStrict {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		var health map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&health)
+		return health["mode"] == config.ModeStrict
+	}, "strict mode health")
 
 	cancel()
 	select {
@@ -1245,8 +1217,9 @@ fetch_proxy:
 	cmd := rootCmd()
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"run", "--config", cfgPath})
+	stderr := &cliTestBuffer{}
 	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
+	cmd.SetErr(stderr)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -1256,28 +1229,15 @@ fetch_proxy:
 	// Wait for healthy.
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + addr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case err := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", err)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // G704: test-only, URL from httptest server
-		if rerr == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "proxy health")
 
 	// Modify the config to trigger hot-reload via fsnotify.
 	updatedCfg := fmt.Sprintf(`version: 1
 mode: strict
+api_allowlist:
+  - "api.example.com"
 fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
@@ -1286,22 +1246,11 @@ fetch_proxy:
 		t.Fatal(err)
 	}
 
-	// Wait for reload to take effect.
-	time.Sleep(500 * time.Millisecond)
-
-	// Verify the mode changed.
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-	resp, err := client.Do(req) //nolint:gosec // G704: test-only, URL from httptest server
-	if err != nil {
-		cancel()
-		t.Fatalf("health request failed: %v", err)
-	}
-	var health map[string]any
-	_ = json.NewDecoder(resp.Body).Decode(&health)
-	_ = resp.Body.Close()
-	if health["mode"] != config.ModeStrict {
-		t.Logf("mode after reload: %v (hot-reload may not have completed yet)", health["mode"])
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		var health map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&health)
+		return health["mode"] == config.ModeStrict
+	}, "strict mode after hot reload")
 
 	cancel()
 	select {
@@ -1332,7 +1281,8 @@ logging:
 	cmd := rootCmd()
 	cmd.SetArgs([]string{"run", "--config", cfgPath})
 	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
+	stderr := &cliTestBuffer{}
+	cmd.SetErr(stderr)
 
 	err := cmd.Execute()
 	if err == nil {
@@ -1340,7 +1290,7 @@ logging:
 	}
 }
 
-func TestRunCmd_ReloadToAskModeWarning(t *testing.T) {
+func TestRunCmd_ReloadToAskMode(t *testing.T) {
 	lc := net.ListenConfig{}
 	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
@@ -1368,8 +1318,9 @@ fetch_proxy:
 	cmd := rootCmd()
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"run", "--config", cfgPath})
+	stderr := &cliTestBuffer{}
 	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
+	cmd.SetErr(stderr)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -1379,28 +1330,14 @@ fetch_proxy:
 	// Wait for healthy.
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + addr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case err := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", err)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // G704: test-only, URL from httptest server
-		if rerr == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "proxy health")
 
-	// Reload config to action: ask (triggers warning because no approver at startup).
+	// Reload config to action: ask and audit mode. The mode change is the
+	// observable signal that the reload carrying ask-mode config landed.
 	updatedCfg := fmt.Sprintf(`version: 1
-mode: balanced
+mode: audit
 fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
@@ -1412,8 +1349,11 @@ response_scanning:
 		t.Fatal(err)
 	}
 
-	// Wait for reload to take effect.
-	time.Sleep(500 * time.Millisecond)
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		var health map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&health)
+		return health["mode"] == config.ModeAudit
+	}, "audit ask-mode config after hot reload")
 
 	cancel()
 	select {
@@ -1469,24 +1409,9 @@ response_scanning:
 	// Wait for healthy.
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + addr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case err := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", err)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req) //nolint:gosec // G704: test-only, URL from httptest server
-		if rerr == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "proxy health")
 
 	// Proxy started with ask mode - approver was created. Shut down cleanly.
 	cancel()
@@ -1543,24 +1468,9 @@ forward_proxy:
 	// Wait for healthy.
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + addr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case cmdErr := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", cmdErr)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req)
-		if rerr == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "proxy health")
 
 	// Verify health shows forward_proxy_enabled=true
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
@@ -1603,6 +1513,7 @@ func TestRunCmd_ReloadRejectsForwardProxyEnable(t *testing.T) {
 
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "test.yaml")
+	logPath := filepath.Join(dir, "audit.log")
 	// Start with forward_proxy disabled
 	cfgContent := fmt.Sprintf(`version: 1
 mode: balanced
@@ -1611,7 +1522,10 @@ fetch_proxy:
   timeout_seconds: 5
 forward_proxy:
   enabled: false
-`, addr)
+logging:
+  output: file
+  file: "%s"
+`, addr, logPath)
 	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -1633,24 +1547,9 @@ forward_proxy:
 	// Wait for healthy.
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + addr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case cmdErr := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", cmdErr)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req)
-		if rerr == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "proxy health")
 
 	// Hot-reload: enable forward_proxy (should be rejected)
 	updatedCfg := fmt.Sprintf(`version: 1
@@ -1662,28 +1561,33 @@ forward_proxy:
   enabled: true
   max_tunnel_seconds: 10
   idle_timeout_seconds: 2
-`, addr)
+logging:
+  output: file
+  file: "%s"
+`, addr, logPath)
 	if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	// Wait for reload to process
-	time.Sleep(500 * time.Millisecond)
+	testwait.For(t, 5*time.Second, func() bool {
+		select {
+		case cmdErr := <-errCh:
+			cancel()
+			t.Fatalf("run exited before rejected reload log: %v", cmdErr)
+		default:
+		}
+		logBytes, err := os.ReadFile(filepath.Clean(logPath))
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("read audit log: %v", err)
+		}
+		return strings.Contains(string(logBytes), "forward proxy cannot be enabled via reload")
+	}, "rejected forward proxy reload log")
 
-	// Verify forward_proxy is still disabled (reload was rejected)
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-	resp, err := client.Do(req)
-	if err != nil {
-		cancel()
-		t.Fatalf("health request failed: %v", err)
-	}
-	var health map[string]any
-	_ = json.NewDecoder(resp.Body).Decode(&health)
-	_ = resp.Body.Close()
-
-	if health["forward_proxy_enabled"] == true {
-		t.Error("forward_proxy should remain disabled after rejected reload")
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		var health map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&health)
+		return health["forward_proxy_enabled"] == false
+	}, "forward proxy remains disabled after rejected reload")
 
 	cancel()
 	select {
@@ -1702,7 +1606,7 @@ func TestRunCmd_MCPListenRequiresUpstream(t *testing.T) {
 
 	cmd := rootCmd()
 	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--mcp-listen", "0.0.0.0:8889"})
+	cmd.SetArgs([]string{"run", "--mcp-listen", "127.0.0.1:0"})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 
@@ -1740,7 +1644,7 @@ func TestRunCmd_MCPUpstreamInvalidURL(t *testing.T) {
 
 	cmd := rootCmd()
 	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--mcp-listen", "0.0.0.0:8889", "--mcp-upstream", "not-a-url"})
+	cmd.SetArgs([]string{"run", "--mcp-listen", "127.0.0.1:0", "--mcp-upstream", "not-a-url"})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 
@@ -1797,8 +1701,8 @@ func TestRunCmd_MCPListenBanner(t *testing.T) {
 		"--mcp-upstream", "http://localhost:19999",
 	})
 	cmd.SetOut(io.Discard)
-	var errBuf bytes.Buffer
-	cmd.SetErr(&errBuf)
+	errBuf := &cliTestBuffer{}
+	cmd.SetErr(errBuf)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -1808,43 +1712,18 @@ func TestRunCmd_MCPListenBanner(t *testing.T) {
 	// Wait for fetch proxy health.
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + fetchAddr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case cmdErr := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", cmdErr)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req)
-		if rerr == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "fetch proxy health")
 
 	// Verify MCP listener health endpoint.
 	mcpHealthURL := "http://" + mcpAddr + "/health"
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, mcpHealthURL, nil)
-	resp, err := client.Do(req)
-	if err != nil {
-		cancel()
-		t.Fatalf("MCP health request failed: %v", err)
-	}
-	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("MCP health status = %d, want 200", resp.StatusCode)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, mcpHealthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "MCP listener health")
 
 	// Verify banner mentions MCP.
-	banner := errBuf.String()
-	if !strings.Contains(banner, "MCP:") {
-		t.Errorf("banner should mention MCP, got: %s", banner)
-	}
+	waitForCLIOutput(t, errBuf, errCh, cancel, "MCP:")
 
 	cancel()
 	select {
@@ -1943,24 +1822,9 @@ fetch_proxy:
 
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + fetchAddr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case cmdErr := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", cmdErr)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req)
-		if rerr == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "fetch proxy health")
 
 	updatedCfg := fmt.Sprintf(`version: 1
 mode: strict
@@ -1974,35 +1838,11 @@ fetch_proxy:
 		t.Fatal(err)
 	}
 
-	// 15s deadline keeps the test green on slow GitHub Actions
-	// runners under -race load. Local desktop sees the reload
-	// activate within 1s; 5s flaked under CI scheduling jitter.
-	// Test is still well under the package timeout.
-	reloadDeadline := time.Now().Add(15 * time.Second)
-	reloaded := false
-	for time.Now().Before(reloadDeadline) {
-		select {
-		case cmdErr := <-errCh:
-			cancel()
-			t.Fatalf("run exited early during reload: %v", cmdErr)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req)
-		if rerr == nil {
-			var health map[string]any
-			_ = json.NewDecoder(resp.Body).Decode(&health)
-			_ = resp.Body.Close()
-			if health["mode"] == config.ModeStrict {
-				reloaded = true
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	if !reloaded {
-		t.Fatal("hot reload did not apply strict mode before timeout")
-	}
+	waitForRunHTTPWithin(t, 15*time.Second, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		var health map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&health)
+		return health["mode"] == config.ModeStrict
+	}, "strict mode after hot reload")
 
 	cancel()
 	select {
@@ -2078,24 +1918,9 @@ fetch_proxy:
 
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + fetchAddr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case cmdErr := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", cmdErr)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req)
-		if rerr == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "fetch proxy health")
 
 	statusURL := "http://" + fetchAddr + "/api/v1/killswitch/status"
 	statusReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
@@ -2124,34 +1949,27 @@ kill_switch:
 		t.Fatal(err)
 	}
 
-	// 15s deadline keeps the test green on slow GitHub Actions
-	// runners under -race load. Local desktop sees the reload
-	// activate within 1s; 5s flaked under CI scheduling jitter.
-	// Test is still well under the package timeout.
-	reloadDeadline := time.Now().Add(15 * time.Second)
-	reloaded := false
-	for time.Now().Before(reloadDeadline) {
-		select {
-		case cmdErr := <-errCh:
-			cancel()
-			t.Fatalf("run exited early during reload: %v", cmdErr)
-		default:
-		}
+	lastReloadWrite := time.Now()
+	waitForRunRequestWithin(t, 15*time.Second, errCh, cancel, func() *http.Request {
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
 		req.Header.Set("Authorization", "Bearer reload-token")
-		resp, rerr := client.Do(req)
-		if rerr == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				reloaded = true
-				break
-			}
+		return req
+	}, client, func(resp *http.Response) bool {
+		if resp.StatusCode == http.StatusOK {
+			return true
 		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	if !reloaded {
-		t.Fatal("kill switch API token did not become active after strict-mode reload")
-	}
+		// /health can become reachable before the config watcher has armed.
+		// Rewriting the same target config gives the watcher another observable
+		// event without weakening the reload assertion.
+		if time.Since(lastReloadWrite) >= 250*time.Millisecond {
+			if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
+				cancel()
+				t.Fatalf("rewrite updated config: %v", err)
+			}
+			lastReloadWrite = time.Now()
+		}
+		return false
+	}, "kill switch API token after strict-mode reload")
 
 	cancel()
 	select {
@@ -2281,24 +2099,9 @@ fetch_proxy:
 	// Wait for healthy.
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + mainAddr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case cmdErr := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", cmdErr)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req)
-		if rerr == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "proxy health")
 
 	// Hot-reload: change metrics_listen (should be rejected).
 	updatedCfg := fmt.Sprintf(`version: 1
@@ -2370,24 +2173,9 @@ fetch_proxy:
 	// Wait for healthy.
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + mainAddr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case cmdErr := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", cmdErr)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req)
-		if rerr == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "proxy health")
 
 	// Hot-reload: change license_key (should warn).
 	updatedCfg := fmt.Sprintf(`version: 1
@@ -2459,24 +2247,9 @@ fetch_proxy:
 	// Wait for healthy.
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + mainAddr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case cmdErr := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", cmdErr)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req)
-		if rerr == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "proxy health")
 
 	// Hot-reload: same license_key, change something else (mode).
 	updatedCfg := fmt.Sprintf(`version: 1
@@ -2547,24 +2320,9 @@ fetch_proxy:
 	// Wait for healthy.
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + mainAddr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case cmdErr := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", cmdErr)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req)
-		if rerr == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "proxy health")
 
 	// Write a license token file so the config reload succeeds.
 	tokenPath := filepath.Join(dir, "license.token")
@@ -2632,9 +2390,9 @@ websocket_proxy:
 	cmd := rootCmd()
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	var stderr bytes.Buffer
+	stderr := &cliTestBuffer{}
 	cmd.SetOut(io.Discard)
-	cmd.SetErr(&stderr)
+	cmd.SetErr(stderr)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -2644,26 +2402,12 @@ websocket_proxy:
 	// Wait for healthy.
 	client := &http.Client{Timeout: time.Second}
 	healthURL := "http://" + addr + "/health"
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case cmdErr := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", cmdErr)
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, rerr := client.Do(req)
-		if rerr == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+		return resp.StatusCode == http.StatusOK
+	}, "proxy health")
 
-	if !bytes.Contains(stderr.Bytes(), []byte("WebSocket proxy enabled")) {
+	waitForCLIOutput(t, stderr, errCh, cancel, "WebSocket proxy enabled")
+	if !stderr.contains("WebSocket proxy enabled") {
 		t.Errorf("expected WS banner, got:\n%s", stderr.String())
 	}
 

--- a/internal/cli/diag/logs_test.go
+++ b/internal/cli/diag/logs_test.go
@@ -4,16 +4,58 @@
 package diag
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 	"github.com/spf13/cobra"
 )
+
+type lockedStringWriter struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (w *lockedStringWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *lockedStringWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+func (w *lockedStringWriter) contains(s string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return strings.Contains(w.buf.String(), s)
+}
+
+func waitForLogOutput(t *testing.T, buf *lockedStringWriter, errCh <-chan error, cancel context.CancelFunc, want string) {
+	t.Helper()
+	testwait.For(t, time.Second, func() bool {
+		if buf.contains(want) {
+			return true
+		}
+		select {
+		case err := <-errCh:
+			cancel()
+			t.Fatalf("logs --follow exited before output %q: %v\nstdout:\n%s", want, err, buf.String())
+		default:
+		}
+		return false
+	}, "log output %q", want)
+}
 
 // logsRoot creates a minimal root command with the logs subcommand registered.
 func logsRoot() *cobra.Command {
@@ -40,7 +82,7 @@ func TestLogsCmd_FollowMode(t *testing.T) {
 
 	cmd := logsRoot()
 	cmd.SetContext(ctx)
-	buf := &strings.Builder{}
+	buf := &lockedStringWriter{}
 	cmd.SetOut(buf)
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"logs", "--file", logPath, "--follow"})
@@ -50,8 +92,7 @@ func TestLogsCmd_FollowMode(t *testing.T) {
 		errCh <- cmd.Execute()
 	}()
 
-	// Give the command time to read initial content and enter follow mode
-	time.Sleep(200 * time.Millisecond)
+	waitForLogOutput(t, buf, errCh, cancel, "first.com")
 
 	// Append a new line while follow mode is active
 	f, err := os.OpenFile(filepath.Clean(logPath), os.O_APPEND|os.O_WRONLY, 0o600)
@@ -62,8 +103,7 @@ func TestLogsCmd_FollowMode(t *testing.T) {
 	_, _ = f.WriteString("{\"event\":\"blocked\",\"url\":\"https://appended.com\"}\n")
 	_ = f.Close()
 
-	// Give follow mode time to pick up the new line
-	time.Sleep(500 * time.Millisecond)
+	waitForLogOutput(t, buf, errCh, cancel, "appended.com")
 
 	// Cancel to break out via context
 	cancel()
@@ -99,7 +139,7 @@ func TestLogsCmd_FollowWithFilter(t *testing.T) {
 
 	cmd := logsRoot()
 	cmd.SetContext(ctx)
-	buf := &strings.Builder{}
+	buf := &lockedStringWriter{}
 	cmd.SetOut(buf)
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"logs", "--file", logPath, "--follow", "--filter", "blocked"})
@@ -108,8 +148,6 @@ func TestLogsCmd_FollowWithFilter(t *testing.T) {
 	go func() {
 		errCh <- cmd.Execute()
 	}()
-
-	time.Sleep(200 * time.Millisecond)
 
 	// Append lines: one allowed (filtered), one blocked (shown)
 	f, err := os.OpenFile(filepath.Clean(logPath), os.O_APPEND|os.O_WRONLY, 0o600)
@@ -121,7 +159,7 @@ func TestLogsCmd_FollowWithFilter(t *testing.T) {
 	_, _ = f.WriteString("{\"event\":\"blocked\",\"url\":\"https://caught.com\"}\n")
 	_ = f.Close()
 
-	time.Sleep(500 * time.Millisecond)
+	waitForLogOutput(t, buf, errCh, cancel, "caught.com")
 	cancel()
 
 	select {

--- a/internal/cli/runtime/run_test.go
+++ b/internal/cli/runtime/run_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/edition"
 	"github.com/luckyPipewrench/pipelock/internal/emit"
 	plsentry "github.com/luckyPipewrench/pipelock/internal/sentry"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 // syncBuffer is defined in helpers_test.go (no build constraint).
@@ -516,17 +517,15 @@ func freePort(t *testing.T) string {
 // waitForPort polls a TCP address until it accepts connections or times out.
 func waitForPort(t *testing.T, addr string) {
 	t.Helper()
-	deadline := time.Now().Add(15 * time.Second)
 	dialer := &net.Dialer{Timeout: 50 * time.Millisecond}
-	for time.Now().Before(deadline) {
+	testwait.For(t, 15*time.Second, func() bool {
 		conn, err := dialer.DialContext(context.Background(), "tcp4", addr)
 		if err == nil {
 			_ = conn.Close()
-			return
+			return true
 		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	t.Fatalf("port %s not ready within 15s", addr)
+		return false
+	}, "port %s to accept connections", addr)
 }
 
 // waitForPortOrCommandExit polls a TCP address while also surfacing early
@@ -534,9 +533,8 @@ func waitForPort(t *testing.T, addr string) {
 // generic readiness timeout.
 func waitForPortOrCommandExit(t *testing.T, addr string, cmdErr <-chan error, stderr fmt.Stringer) {
 	t.Helper()
-	deadline := time.Now().Add(15 * time.Second)
 	dialer := &net.Dialer{Timeout: 50 * time.Millisecond}
-	for time.Now().Before(deadline) {
+	testwait.For(t, 15*time.Second, func() bool {
 		select {
 		case err := <-cmdErr:
 			t.Fatalf("RunCmd exited before port %s was ready: %v\nstderr:\n%s", addr, err, stderr.String())
@@ -545,11 +543,10 @@ func waitForPortOrCommandExit(t *testing.T, addr string, cmdErr <-chan error, st
 		conn, err := dialer.DialContext(context.Background(), "tcp4", addr)
 		if err == nil {
 			_ = conn.Close()
-			return
+			return true
 		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	t.Fatalf("port %s not ready within 15s\nstderr:\n%s", addr, stderr.String())
+		return false
+	}, "port %s to accept connections\nstderr:\n%s", addr, stderr.String())
 }
 
 // doGet issues a context-aware GET and fails the test on error.

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -19,12 +19,17 @@ import (
 	mcptools "github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 const (
 	serverTestUpstreamURL     = "http://127.0.0.1:1"
 	serverTestEphemeralListen = "127.0.0.1:0"
 )
+
+type stringerFunc func() string
+
+func (f stringerFunc) String() string { return f() }
 
 // newServerTestFreePort returns a free 127.0.0.1 TCP port by binding and
 // releasing it, same pattern used in run_test.go:freePort.
@@ -73,29 +78,19 @@ func newTestServer(t *testing.T, mutate func(*ServerOpts)) (*Server, *syncBuffer
 
 func waitForServerCancel(t *testing.T, s *Server) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
+	testwait.For(t, 2*time.Second, func() bool {
 		s.cancelMu.Lock()
 		ready := s.internalCancel != nil
 		s.cancelMu.Unlock()
-		if ready {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatal("server did not publish internal cancel")
+		return ready
+	}, "server to publish internal cancel")
 }
 
 func waitForServerOutput(t *testing.T, buf *syncBuffer, want string) {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if buf.contains(want) {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("server output missing %q:\n%s", want, buf.String())
+	testwait.For(t, 3*time.Second, func() bool {
+		return buf.contains(want)
+	}, "server output %q:\n%s", want, stringerFunc(buf.String))
 }
 
 // TestNewServer_AppliesCLIOverrides verifies that ModeChanged / ListenChanged

--- a/internal/cli/runtime/signal_unix_test.go
+++ b/internal/cli/runtime/signal_unix_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 // syncBuffer is defined in helpers_test.go (no build constraint).
@@ -29,12 +30,9 @@ func TestRegisterKillSwitchSignal(t *testing.T) {
 		t.Fatalf("failed to send SIGUSR1: %v", err)
 	}
 
-	// Wait for the goroutine to process the signal.
-	time.Sleep(200 * time.Millisecond)
-
-	if !buf.contains("ACTIVATED") {
-		t.Error("expected ACTIVATED message after first SIGUSR1")
-	}
+	testwait.For(t, 2*time.Second, func() bool {
+		return buf.contains("ACTIVATED")
+	}, "ACTIVATED message after first SIGUSR1")
 
 	// Send SIGUSR1 again to toggle OFF.
 	buf.reset()
@@ -42,11 +40,9 @@ func TestRegisterKillSwitchSignal(t *testing.T) {
 		t.Fatalf("failed to send second SIGUSR1: %v", err)
 	}
 
-	time.Sleep(200 * time.Millisecond)
-
-	if !buf.contains("DEACTIVATED") {
-		t.Error("expected DEACTIVATED message after second SIGUSR1")
-	}
+	testwait.For(t, 2*time.Second, func() bool {
+		return buf.contains("DEACTIVATED")
+	}, "DEACTIVATED message after second SIGUSR1")
 }
 
 func TestReloadSignalHint(t *testing.T) {

--- a/internal/config/reload.go
+++ b/internal/config/reload.go
@@ -22,7 +22,11 @@ type Reloader struct {
 	path      string
 	onChange  chan *Config
 	done      chan struct{}
+	ready     chan struct{}
+	readyOnce sync.Once
 	closeOnce sync.Once
+	startMu   sync.Mutex
+	started   bool
 }
 
 // NewReloader creates a config reloader that watches path for changes.
@@ -32,6 +36,7 @@ func NewReloader(path string) *Reloader {
 		path:     path,
 		onChange: make(chan *Config, 1),
 		done:     make(chan struct{}),
+		ready:    make(chan struct{}),
 	}
 }
 
@@ -45,6 +50,14 @@ func (r *Reloader) Changes() <-chan *Config {
 // channel is closed. Reload failures are logged to stderr via tryReload;
 // the old config remains active.
 func (r *Reloader) Start(ctx context.Context) error {
+	r.startMu.Lock()
+	if r.started {
+		r.startMu.Unlock()
+		return fmt.Errorf("config reloader already started")
+	}
+	r.started = true
+	r.startMu.Unlock()
+
 	defer close(r.onChange)
 
 	watcher, err := fsnotify.NewWatcher()
@@ -63,6 +76,10 @@ func (r *Reloader) Start(ctx context.Context) error {
 	sigCh := make(chan os.Signal, 1)
 	notifyReloadSignal(sigCh) // SIGHUP on Unix, no-op on Windows
 	defer signal.Stop(sigCh)
+	// Readiness signaling is idempotent. Start itself is one-shot because it
+	// closes Changes() on return and rejects later calls before touching
+	// watcher/channel state.
+	r.readyOnce.Do(func() { close(r.ready) })
 
 	baseName := filepath.Base(r.path)
 

--- a/internal/config/reload_test.go
+++ b/internal/config/reload_test.go
@@ -19,6 +19,48 @@ func writeTestConfig(t *testing.T, path, mode string) {
 	}
 }
 
+func waitForReloaderReady(t *testing.T, r *Reloader) {
+	t.Helper()
+	select {
+	case <-r.ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reloader did not become ready")
+	}
+}
+
+func waitForReload(t *testing.T, r *Reloader, mode string) *Config {
+	t.Helper()
+	select {
+	case cfg, ok := <-r.Changes():
+		if !ok {
+			t.Fatal("changes channel closed before config reload")
+		}
+		if cfg.Mode != mode {
+			t.Fatalf("expected mode %s, got %s", mode, cfg.Mode)
+		}
+		return cfg
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for config reload to mode %s", mode)
+	}
+	return nil
+}
+
+func writeAndWaitForReload(t *testing.T, r *Reloader, path, mode string) {
+	t.Helper()
+	writeTestConfig(t, path, mode)
+	waitForReload(t, r, mode)
+}
+
+func renameUntilReload(t *testing.T, r *Reloader, dir, cfgPath, mode string) *Config {
+	t.Helper()
+	tmpPath := filepath.Join(dir, "pipelock.yaml.tmp")
+	writeTestConfig(t, tmpPath, mode)
+	if err := os.Rename(tmpPath, cfgPath); err != nil {
+		t.Fatal(err)
+	}
+	return waitForReload(t, r, mode)
+}
+
 func TestReloader_FileChange(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "pipelock.yaml")
@@ -36,20 +78,8 @@ func TestReloader_FileChange(t *testing.T) {
 		}
 	}()
 
-	// Give watcher time to start
-	time.Sleep(200 * time.Millisecond)
-
-	// Modify config
-	writeTestConfig(t, cfgPath, ModeAudit)
-
-	select {
-	case cfg := <-r.Changes():
-		if cfg.Mode != ModeAudit {
-			t.Errorf("expected mode audit, got %s", cfg.Mode)
-		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for config reload")
-	}
+	waitForReloaderReady(t, r)
+	writeAndWaitForReload(t, r, cfgPath, ModeAudit)
 }
 
 // TestReloader_CoalesceKeepsLatest proves the reload buffer coalesces to the
@@ -110,7 +140,8 @@ func TestReloader_InvalidConfig(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	waitForReloaderReady(t, r)
+	writeAndWaitForReload(t, r, cfgPath, ModeAudit)
 
 	// Write invalid config
 	if err := os.WriteFile(cfgPath, []byte("mode: invalid_mode\n"), 0o600); err != nil {
@@ -139,7 +170,7 @@ func TestReloader_CloseStopsStart(t *testing.T) {
 		close(done)
 	}()
 
-	time.Sleep(100 * time.Millisecond)
+	waitForReloaderReady(t, r)
 	r.Close()
 
 	select {
@@ -176,7 +207,7 @@ func TestReloader_ContextCancellation(t *testing.T) {
 		close(done)
 	}()
 
-	time.Sleep(100 * time.Millisecond)
+	waitForReloaderReady(t, r)
 	cancel()
 
 	select {
@@ -184,6 +215,37 @@ func TestReloader_ContextCancellation(t *testing.T) {
 		// Start returned after context cancelled
 	case <-time.After(2 * time.Second):
 		t.Fatal("Start did not return after context cancellation")
+	}
+}
+
+func TestReloader_StartIsOneShot(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	writeTestConfig(t, cfgPath, "balanced")
+
+	r := NewReloader(cfgPath)
+	defer r.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- r.Start(ctx)
+	}()
+
+	waitForReloaderReady(t, r)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("first Start returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("first Start did not return after context cancellation")
+	}
+
+	if err := r.Start(context.Background()); err == nil {
+		t.Fatal("second Start succeeded; expected one-shot error")
 	}
 }
 
@@ -204,8 +266,8 @@ func TestReloader_NonMatchingFileIgnored(t *testing.T) {
 		}
 	}()
 
-	// Give watcher time to start
-	time.Sleep(200 * time.Millisecond)
+	waitForReloaderReady(t, r)
+	writeAndWaitForReload(t, r, cfgPath, ModeAudit)
 
 	// Write a different file in the same directory - should be ignored
 	otherPath := filepath.Join(dir, "other.yaml")
@@ -237,7 +299,7 @@ func TestReloader_ChangesClosedAfterStart(t *testing.T) {
 		close(done)
 	}()
 
-	time.Sleep(100 * time.Millisecond)
+	waitForReloaderReady(t, r)
 	cancel()
 
 	<-done
@@ -267,21 +329,6 @@ func TestReloader_RenameReload(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(200 * time.Millisecond)
-
-	// Write to temp, then rename (vim pattern)
-	tmpPath := filepath.Join(dir, "pipelock.yaml.tmp")
-	writeTestConfig(t, tmpPath, ModeAudit)
-	if err := os.Rename(tmpPath, cfgPath); err != nil {
-		t.Fatal(err)
-	}
-
-	select {
-	case cfg := <-r.Changes():
-		if cfg.Mode != ModeAudit {
-			t.Errorf("expected mode audit, got %s", cfg.Mode)
-		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for rename-based reload")
-	}
+	waitForReloaderReady(t, r)
+	renameUntilReload(t, r, dir, cfgPath, ModeAudit)
 }

--- a/internal/config/reload_unix_test.go
+++ b/internal/config/reload_unix_test.go
@@ -13,6 +13,31 @@ import (
 	"time"
 )
 
+func signalUntilReload(t *testing.T, r *Reloader, mode string) *Config {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if err := syscall.Kill(syscall.Getpid(), syscall.SIGHUP); err != nil {
+			t.Fatalf("failed to send SIGHUP: %v", err)
+		}
+		select {
+		case cfg, ok := <-r.Changes():
+			if !ok {
+				t.Fatal("changes channel closed before SIGHUP-based reload")
+			}
+			if cfg.Mode == mode {
+				return cfg
+			}
+			t.Fatalf("expected mode %s after SIGHUP, got %s", mode, cfg.Mode)
+		case <-ticker.C:
+		case <-deadline:
+			t.Fatalf("timed out waiting for SIGHUP-based reload to mode %s", mode)
+		}
+	}
+}
+
 func TestReloader_SIGHUPReload(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "pipelock.yaml")
@@ -30,26 +55,10 @@ func TestReloader_SIGHUPReload(t *testing.T) {
 		}
 	}()
 
-	// Give watcher time to start
-	time.Sleep(200 * time.Millisecond)
+	waitForReloaderReady(t, r)
 
 	// Update config file (SIGHUP reloads from disk, so the file must change)
 	writeTestConfig(t, cfgPath, ModeAudit)
 
-	// Small delay so the file is written before signal
-	time.Sleep(50 * time.Millisecond)
-
-	// Send SIGHUP to ourselves
-	if err := syscall.Kill(syscall.Getpid(), syscall.SIGHUP); err != nil {
-		t.Fatalf("failed to send SIGHUP: %v", err)
-	}
-
-	select {
-	case cfg := <-r.Changes():
-		if cfg.Mode != ModeAudit {
-			t.Errorf("expected mode audit after SIGHUP, got %s", cfg.Mode)
-		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for SIGHUP-based reload")
-	}
+	signalUntilReload(t, r, ModeAudit)
 }

--- a/internal/contract/runtime/loader.go
+++ b/internal/contract/runtime/loader.go
@@ -139,6 +139,8 @@ type Loader struct {
 	storeOpts store.Options
 	reloadMu  sync.Mutex
 	current   atomic.Pointer[ActiveSet]
+	ready     chan struct{}
+	readyOnce sync.Once
 	mode      Mode
 	metrics   LoaderMetrics
 	now       func() time.Time
@@ -181,6 +183,7 @@ func NewLoader(opts LoaderOptions, metrics LoaderMetrics) (*Loader, error) {
 	l := &Loader{
 		store:    store.New(opts.StoreDir),
 		storeDir: filepath.Clean(opts.StoreDir),
+		ready:    make(chan struct{}),
 		mode:     opts.Mode,
 		metrics:  metrics,
 		now:      now,
@@ -380,6 +383,7 @@ func (l *Loader) Watch(ctx context.Context) error {
 	if err := watcher.Add(l.storeDir); err != nil {
 		return fmt.Errorf("contract runtime: watch %s: %w", l.storeDir, err)
 	}
+	l.readyOnce.Do(func() { close(l.ready) })
 
 	// debounce is reset on every relevant event. When it fires, a single
 	// Reload runs and debounce resets to nil so a quiescent loop does not

--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
 	contractstore "github.com/luckyPipewrench/pipelock/internal/contract/store"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 func TestNewLoader_RejectsMissingFields(t *testing.T) {
@@ -381,8 +382,7 @@ func TestLoader_Watch_CancelExitsCleanly(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- loader.Watch(ctx) }()
 
-	// Give Watch enough time to call fsnotify.NewWatcher + Add.
-	time.Sleep(50 * time.Millisecond)
+	waitForLoaderReady(t, loader)
 	cancel()
 
 	select {
@@ -419,7 +419,7 @@ func TestLoader_Watch_FileReplacementTriggersReload(t *testing.T) {
 		cancel()
 		<-done
 	})
-	time.Sleep(80 * time.Millisecond) // let watcher.Add complete
+	waitForLoaderReady(t, loader)
 
 	// Promote generation 2 with the correct prior-hash chain.
 	writeSignedActiveStore(t, fixture, storeDir, 2, priorHash, env)
@@ -455,7 +455,7 @@ func TestLoader_Watch_DebounceCoalescesBurstAndSameHashIsNoop(t *testing.T) {
 		cancel()
 		<-done
 	})
-	time.Sleep(80 * time.Millisecond)
+	waitForLoaderReady(t, loader)
 
 	// Fire a burst of WRITEs against the same content. fsnotify will emit
 	// multiple events; the 100ms debounce window should coalesce them
@@ -487,7 +487,24 @@ func TestLoader_Watch_DebounceCoalescesBurstAndSameHashIsNoop(t *testing.T) {
 
 	// Drain any trailing event for a hair longer than the debounce window
 	// so a coalesced second pass would have already fired.
-	time.Sleep(reloadDebounceWindow + 100*time.Millisecond)
+	quiet := time.NewTimer(reloadDebounceWindow + 100*time.Millisecond)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	for {
+		select {
+		case <-quiet.C:
+			ticker.Stop()
+			goto quietDone
+		case <-ticker.C:
+			if got := metrics.outcome("same_hash"); got > 2 {
+				ticker.Stop()
+				if !quiet.Stop() {
+					<-quiet.C
+				}
+				t.Fatalf("same_hash = %d, want <= 2 (5-event burst should coalesce)", got)
+			}
+		}
+	}
+quietDone:
 
 	// 5 burst writes should coalesce; tolerate up to 2 same_hash outcomes
 	// in case the OS spreads the burst across two debounce windows under
@@ -529,7 +546,7 @@ func TestLoader_Watch_RejectedReloadKeepsWatcherAlive(t *testing.T) {
 		cancel()
 		<-done
 	})
-	time.Sleep(80 * time.Millisecond)
+	waitForLoaderReady(t, loader)
 
 	// Generation downgrade: write generation 1 over generation 2.
 	writeSignedActiveStore(t, fixture, storeDir, 1, "sha256:older", env)
@@ -596,7 +613,7 @@ func TestLoader_Watch_DebounceMaxWaitFlushesUnderSustainedWrites(t *testing.T) {
 		cancel()
 		<-done
 	})
-	time.Sleep(80 * time.Millisecond)
+	waitForLoaderReady(t, loader)
 
 	// Producer that rewrites the same content every 40ms (well below
 	// the 100ms debounce window). Without the maxDebounceWait cap, the
@@ -638,16 +655,9 @@ func TestLoader_Watch_DebounceMaxWaitFlushesUnderSustainedWrites(t *testing.T) {
 	// flaked on CI while local runs always saw the flush within
 	// 200ms past maxDebounceWait. Five seconds keeps the test
 	// well under the package timeout.
-	deadline := time.Now().Add(maxDebounceWait + 5*time.Second)
-	for time.Now().Before(deadline) {
-		if metrics.outcome("same_hash") >= 1 {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if metrics.outcome("same_hash") < 1 {
-		t.Fatalf("debounce never flushed under sustained writes; metrics = %v", snapshotOutcomes(metrics))
-	}
+	testwait.For(t, maxDebounceWait+5*time.Second, func() bool {
+		return metrics.outcome("same_hash") >= 1
+	}, "debounce flush under sustained writes; metrics = %v", snapshotOutcomes(metrics))
 }
 
 func TestLoader_Watch_RemoveEventTriggersReload(t *testing.T) {
@@ -678,7 +688,7 @@ func TestLoader_Watch_RemoveEventTriggersReload(t *testing.T) {
 		cancel()
 		<-done
 	})
-	time.Sleep(80 * time.Millisecond)
+	waitForLoaderReady(t, loader)
 
 	// Remove active.json directly. The watcher should see Remove and
 	// trigger a Reload through the debounce. Reload then rejects the
@@ -923,7 +933,7 @@ func TestLoader_Watch_DirectoryDeletionEndsWatcher(t *testing.T) {
 	defer cancel()
 	done := make(chan error, 1)
 	go func() { done <- loader.Watch(ctx) }()
-	time.Sleep(80 * time.Millisecond)
+	waitForLoaderReady(t, loader)
 
 	// Drop the entire store directory. fsnotify fires a Remove event on
 	// the watched directory; Watch surfaces the loss to the caller so
@@ -954,19 +964,34 @@ func TestLoader_Watch_DirectoryDeletionEndsWatcher(t *testing.T) {
 // tight enough that a stuck watcher fails fast.
 const watchTestTimeout = 2 * time.Second
 
+func waitForLoaderReady(t *testing.T, loader *Loader) {
+	t.Helper()
+	select {
+	case <-loader.ready:
+	case <-time.After(watchTestTimeout):
+		t.Fatal("loader watcher did not report ready")
+	}
+}
+
 // waitFor polls cond until it returns true or watchTestTimeout elapses.
 // Returns true on success, false on timeout. Used by Watch tests where
 // the signal is the watcher goroutine landing a Reload outcome: poll
 // the metric to increment rather than guess a fixed sleep.
 func waitFor(cond func() bool) bool {
-	deadline := time.Now().Add(watchTestTimeout)
-	for time.Now().Before(deadline) {
+	timer := time.NewTimer(watchTestTimeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
 		if cond() {
 			return true
 		}
-		time.Sleep(10 * time.Millisecond)
+		select {
+		case <-timer.C:
+			return cond()
+		case <-ticker.C:
+		}
 	}
-	return cond()
 }
 
 // snapshotOutcomes returns a copy of the current outcome counters for

--- a/internal/emit/otlp_test.go
+++ b/internal/emit/otlp_test.go
@@ -19,6 +19,8 @@ import (
 	respb "go.opentelemetry.io/proto/otlp/resource/v1"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 const otlpLogsPath = "/v1/logs"
@@ -489,20 +491,21 @@ func TestOTLPSink_NetworkErrorRetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewOTLPSink: %v", err)
 	}
-	defer func() { _ = sink.Close() }()
-
-	// Close server immediately so retries hit network errors.
-	srv.Close()
 
 	_ = sink.Emit(context.Background(), Event{Severity: SeverityCritical, Type: testStr, Timestamp: time.Now()})
+	testwait.For(t, 5*time.Second, func() bool {
+		return attempts.Load() >= 2
+	}, "OTLP retry path to issue at least two requests")
 
-	// Wait for retry exhaustion (3 attempts * ~1-2s backoff each, but network
-	// errors return fast since server is closed).
-	time.Sleep(3 * time.Second)
+	// Close the server after observing the retry path so the remaining retry
+	// attempt exercises the network-error branch rather than proving nothing.
+	srv.Close()
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
 
-	// Should have attempted multiple times before giving up.
-	if attempts.Load() > 0 {
-		t.Log("server received requests before closing (expected)")
+	if got := attempts.Load(); got < 2 {
+		t.Errorf("expected at least 2 attempts before server close, got %d", got)
 	}
 }
 

--- a/internal/emit/webhook_test.go
+++ b/internal/emit/webhook_test.go
@@ -39,8 +39,9 @@ func TestWebhookSink_BelowMinSeverity(t *testing.T) {
 		t.Fatalf("expected nil error for dropped event, got %v", err)
 	}
 
-	// Give background goroutine a moment - no request should arrive.
-	time.Sleep(50 * time.Millisecond)
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
 }
 
 func TestWebhookSink_SuccessfulPost(t *testing.T) {
@@ -176,8 +177,11 @@ func TestWebhookSink_NoAuthHeaderWithoutToken(t *testing.T) {
 func TestWebhookSink_QueueFull(t *testing.T) {
 	// Server blocks long enough for the queue to fill.
 	blocker := make(chan struct{})
+	started := make(chan struct{})
+	var startedOnce sync.Once
 
 	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		startedOnce.Do(func() { close(started) })
 		<-blocker
 	}))
 	defer srv.Close()
@@ -201,8 +205,10 @@ func TestWebhookSink_QueueFull(t *testing.T) {
 			queueFullSeen = true
 			break
 		}
-		// Brief pause to let the goroutine pick up the first event and block on HTTP.
-		time.Sleep(time.Millisecond)
+		select {
+		case <-started:
+		default:
+		}
 	}
 
 	if !queueFullSeen {
@@ -499,7 +505,10 @@ func TestWebhookSink_SendConnectionRefused(t *testing.T) {
 func TestWebhookSink_EmitClosedDuringQueueWait(t *testing.T) {
 	// Create a sink with a tiny queue so the second select path is exercised.
 	blocker := make(chan struct{})
+	started := make(chan struct{})
+	var startedOnce sync.Once
 	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		startedOnce.Do(func() { close(started) })
 		<-blocker
 	}))
 	defer srv.Close()
@@ -517,16 +526,17 @@ func TestWebhookSink_EmitClosedDuringQueueWait(t *testing.T) {
 	if err := sink.Emit(context.Background(), event); err != nil {
 		t.Fatalf("first Emit: %v", err)
 	}
-	time.Sleep(10 * time.Millisecond) // let goroutine pick it up
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first webhook request")
+	}
 	if err := sink.Emit(context.Background(), event); err != nil {
 		t.Fatalf("second Emit: %v", err)
 	}
 
 	// Close while queue is full - exercises the <-w.done path in the second select.
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		close(blocker) // unblock the server so Close can finish
-	}()
+	close(blocker)
 	_ = sink.Close()
 
 	// Emit after close should return error

--- a/internal/filesentry/lineage_test.go
+++ b/internal/filesentry/lineage_test.go
@@ -12,6 +12,8 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 const testOSLinux = "linux"
@@ -79,15 +81,9 @@ func TestLineage_HasFileOpen(t *testing.T) {
 	l := NewLineage()
 	l.TrackPID(cmd.Process.Pid)
 
-	// Poll until tail opens the file (up to 2s). Avoids fixed sleep that
-	// races under CI load or the race detector.
-	deadline := time.Now().Add(2 * time.Second)
-	for !l.HasFileOpen(testFile) {
-		if time.Now().After(deadline) {
-			t.Fatal("timeout: tail did not open file within 2s")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	testwait.For(t, 2*time.Second, func() bool {
+		return l.HasFileOpen(testFile)
+	}, "tail opens test file")
 }
 
 func TestLineage_HasFileOpen_NotOpen(t *testing.T) {
@@ -130,17 +126,13 @@ func TestLineage_GrandchildDescendant(t *testing.T) {
 		t.Error("expected bash child to be a descendant")
 	}
 
-	// Poll until bash forks the sleep grandchild (up to 5s).
+	// Poll until bash forks the sleep grandchild.
 	// Under -race, process tree inspection is slower.
 	var descendants []int
-	deadline := time.Now().Add(10 * time.Second)
-	for len(descendants) == 0 {
-		if time.Now().After(deadline) {
-			t.Fatal("no grandchild found within 10s — collectDescendants may be broken")
-		}
-		time.Sleep(20 * time.Millisecond)
+	testwait.For(t, 10*time.Second, func() bool {
 		descendants = collectDescendants(cmd.Process.Pid)
-	}
+		return len(descendants) > 0
+	}, "bash forks sleep grandchild")
 	sleepPID := descendants[0]
 	if !l.IsDescendant(sleepPID) {
 		t.Errorf("expected grandchild PID %d to be a descendant", sleepPID)

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 func ptrBool(b bool) *bool { return &b }
@@ -37,6 +38,20 @@ func armAndStart(t *testing.T, w Watcher, ctx context.Context) {
 			t.Errorf("Start: %v", err)
 		}
 	})
+}
+
+func waitForPendingTimer(t *testing.T, w Watcher, path string) {
+	t.Helper()
+	fw, ok := w.(*fsWatcher)
+	if !ok {
+		t.Fatalf("watcher type %T is not *fsWatcher", w)
+	}
+	testwait.For(t, time.Second, func() bool {
+		fw.mu.Lock()
+		defer fw.mu.Unlock()
+		_, ok := fw.timers[path]
+		return ok
+	}, "pending file sentry timer for %s", path)
 }
 
 func TestWatcher_DetectsSecretWrite(t *testing.T) {
@@ -689,7 +704,6 @@ func TestWatcher_DebounceTimerRace(t *testing.T) {
 		if err := os.WriteFile(filePath, []byte(content), 0o600); err != nil {
 			t.Fatalf("WriteFile[%d]: %v", i, err)
 		}
-		time.Sleep(5 * time.Millisecond) // faster than debounce (50ms)
 	}
 
 	// Wait for the single debounced scan.
@@ -934,22 +948,17 @@ func TestWatcher_CloseFlushesLastWrite(t *testing.T) {
 		t.Fatalf("NewWatcher: %v", err)
 	}
 
-	if armErr := w.Arm(); armErr != nil {
-		t.Fatalf("Arm: %v", armErr)
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() { _ = w.Start(ctx) }()
+	armAndStart(t, w, ctx)
 
 	// Write a secret - this starts a debounce timer.
 	secret := "sk-ant-" + "api03-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-	if writeErr := os.WriteFile(filepath.Join(dir, "last-write.json"), []byte(secret), 0o600); writeErr != nil {
+	lastWritePath := filepath.Join(dir, "last-write.json")
+	if writeErr := os.WriteFile(lastWritePath, []byte(secret), 0o600); writeErr != nil {
 		t.Fatalf("WriteFile: %v", writeErr)
 	}
 
-	// Small delay to ensure the fsnotify event is delivered and the
-	// debounce timer is started, but NOT long enough for debounce to fire.
-	time.Sleep(10 * time.Millisecond)
+	waitForPendingTimer(t, w, lastWritePath)
 
 	// Close should flush the pending scan synchronously.
 	cancel()
@@ -986,18 +995,15 @@ func TestWatcher_CloseFlushScanDisabled(t *testing.T) {
 		t.Fatalf("NewWatcher: %v", err)
 	}
 
-	if armErr := w.Arm(); armErr != nil {
-		t.Fatalf("Arm: %v", armErr)
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() { _ = w.Start(ctx) }()
+	armAndStart(t, w, ctx)
 
 	secret := "sk-ant-" + "api03-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-	if writeErr := os.WriteFile(filepath.Join(dir, "no-scan.json"), []byte(secret), 0o600); writeErr != nil {
+	noScanPath := filepath.Join(dir, "no-scan.json")
+	if writeErr := os.WriteFile(noScanPath, []byte(secret), 0o600); writeErr != nil {
 		t.Fatalf("WriteFile: %v", writeErr)
 	}
-	time.Sleep(10 * time.Millisecond)
+	waitForPendingTimer(t, w, noScanPath)
 
 	cancel()
 	_ = w.Close()
@@ -1034,17 +1040,14 @@ func TestWatcher_CloseFlushEmptyFile(t *testing.T) {
 		t.Fatalf("NewWatcher: %v", err)
 	}
 
-	if armErr := w.Arm(); armErr != nil {
-		t.Fatalf("Arm: %v", armErr)
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() { _ = w.Start(ctx) }()
+	armAndStart(t, w, ctx)
 
-	if writeErr := os.WriteFile(filepath.Join(dir, "empty.txt"), []byte{}, 0o600); writeErr != nil {
+	emptyPath := filepath.Join(dir, "empty.txt")
+	if writeErr := os.WriteFile(emptyPath, []byte{}, 0o600); writeErr != nil {
 		t.Fatalf("WriteFile: %v", writeErr)
 	}
-	time.Sleep(10 * time.Millisecond)
+	waitForPendingTimer(t, w, emptyPath)
 
 	cancel()
 	_ = w.Close()

--- a/internal/hitl/approver_test.go
+++ b/internal/hitl/approver_test.go
@@ -5,12 +5,38 @@ package hitl
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) contains(s string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return strings.Contains(b.buf.String(), s)
+}
+
+func (b *lockedBuffer) count(s string) int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return strings.Count(b.buf.String(), s)
+}
 
 func testApprover(t *testing.T, input string, timeoutSec int) (*Approver, *bytes.Buffer) { //nolint:unparam // timeout varies in manual tests
 	t.Helper()
@@ -174,7 +200,7 @@ func TestApprover_CloseBlocksPending(t *testing.T) {
 		_ = r.Close()
 	})
 
-	output := &bytes.Buffer{}
+	output := &lockedBuffer{}
 	a := New(30,
 		WithInput(r),
 		WithOutput(output),
@@ -186,8 +212,9 @@ func TestApprover_CloseBlocksPending(t *testing.T) {
 		done <- a.Ask(&Request{URL: "https://test.com", Reason: "test"})
 	}()
 
-	// Give the goroutine time to submit the request.
-	time.Sleep(50 * time.Millisecond)
+	testwait.For(t, time.Second, func() bool {
+		return output.contains("PIPELOCK: THREAT DETECTED")
+	}, "pending HITL prompt")
 	a.Close()
 
 	d := <-done
@@ -305,40 +332,41 @@ func TestApprover_TimeoutThenSuccess(t *testing.T) {
 	// First request times out (no input within timeout).
 	// Stale input arrives AFTER timeout. Second request drains it, then
 	// receives fresh "y\n" and returns allow.
-	r, w := io.Pipe()
-	output := &bytes.Buffer{}
-	a := New(1, // 1 second timeout
-		WithInput(r),
-		WithOutput(output),
-		WithTerminal(true),
-	)
-	t.Cleanup(func() {
-		_ = w.Close()
-		a.Close()
-	})
+	output := &lockedBuffer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	a := &Approver{
+		timeout: 500 * time.Millisecond,
+		output:  output,
+		ctx:     ctx,
+	}
+	lines := make(chan string, 2)
 
 	// First request: no input → times out → sets lastPromptTimedOut = true.
-	d1 := a.Ask(&Request{URL: "https://test.com", Reason: "first"})
+	d1 := a.prompt(lines, &Request{URL: "https://test.com", Reason: "first"})
 	if d1 != DecisionBlock {
 		t.Fatalf("expected timeout block, got %d", d1)
 	}
 
-	// Write stale input that gets buffered in the lines channel.
-	// The readLines goroutine reads it and puts it in the channel.
+	lines <- "stale"
+	done := make(chan Decision, 1)
 	go func() {
-		_, _ = w.Write([]byte("stale\n"))
-		// Give time for readLines to buffer this, then write real response.
-		time.Sleep(200 * time.Millisecond)
-		_, _ = w.Write([]byte("y\n"))
+		done <- a.prompt(lines, &Request{URL: "https://test.com", Reason: "second"})
 	}()
 
-	// Give time for the stale line to be read into the channel.
-	time.Sleep(100 * time.Millisecond)
+	testwait.For(t, time.Second, func() bool {
+		return output.count("PIPELOCK: THREAT DETECTED") >= 2
+	}, "second HITL prompt after stale input drain")
+	lines <- "y"
 
 	// Second request: drainStaleLines removes "stale", then prompt reads "y".
-	d2 := a.Ask(&Request{URL: "https://test.com", Reason: "second"})
-	if d2 != DecisionAllow {
-		t.Fatalf("expected allow after drain, got %d", d2)
+	select {
+	case d2 := <-done:
+		if d2 != DecisionAllow {
+			t.Fatalf("expected allow after drain, got %d", d2)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for second HITL decision")
 	}
 }
 
@@ -349,20 +377,24 @@ func TestApprover_ContextCancel(t *testing.T) {
 		_ = w.Close()
 		_ = r.Close()
 	})
-	output := &bytes.Buffer{}
+	output := &lockedBuffer{}
 	a := New(30, // long timeout
 		WithInput(r),
 		WithOutput(output),
 		WithTerminal(true),
 	)
 
-	// Close the approver (cancels context) in background
+	done := make(chan Decision, 1)
 	go func() {
-		time.Sleep(200 * time.Millisecond)
-		a.Close()
+		done <- a.Ask(&Request{URL: "https://test.com", Reason: "test"})
 	}()
 
-	d := a.Ask(&Request{URL: "https://test.com", Reason: "test"})
+	testwait.For(t, time.Second, func() bool {
+		return output.contains("PIPELOCK: THREAT DETECTED")
+	}, "pending HITL prompt before context cancel")
+	a.Close()
+
+	d := <-done
 	if d != DecisionBlock {
 		t.Fatalf("expected block on context cancel, got %d", d)
 	}

--- a/internal/mcp/adaptive_test.go
+++ b/internal/mcp/adaptive_test.go
@@ -484,15 +484,7 @@ func startListenerProxyWithStore(
 	}()
 
 	baseURL := "http://" + addr
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		resp, connErr := http.Get(baseURL + "/health") //nolint:gosec,noctx // test helper
-		if connErr == nil {
-			_ = resp.Body.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForHTTPHealth(t, baseURL)
 
 	t.Cleanup(func() {
 		cancel()

--- a/internal/mcp/chains/matcher_test.go
+++ b/internal/mcp/chains/matcher_test.go
@@ -249,7 +249,16 @@ func TestMatcher_WindowEviction(t *testing.T) {
 	m2 := New(cfg2)
 
 	m2.Record("s2", "read_file")
-	time.Sleep(1100 * time.Millisecond) // Wait for window to expire
+	sh2, ok := m2.sessions.Load("s2")
+	if !ok {
+		t.Fatal("session s2 not found")
+	}
+	sess2 := sh2.(*sessionHistory)
+	sess2.mu.Lock()
+	for i := range sess2.records {
+		sess2.records[i].timestamp = time.Now().Add(-2 * time.Second)
+	}
+	sess2.mu.Unlock()
 
 	// The read should be evicted. New exec should not match read-then-exec.
 	v := m2.Record("s2", "bash_command")

--- a/internal/mcp/pipeline_parity_test.go
+++ b/internal/mcp/pipeline_parity_test.go
@@ -441,14 +441,7 @@ func TestRunWSProxy_ParityBase64EncodedSecretDLP(t *testing.T) {
 	// Server that accepts the connection but never expects a forwarded
 	// frame - the input scanner must block the base64-encoded secret
 	// before anything reaches upstream.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, _, _, err := ws.UpgradeHTTP(r, w)
-		if err != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		time.Sleep(200 * time.Millisecond)
-	}))
+	srv, upstreamFrames := wsDrainServer(t)
 	defer srv.Close()
 
 	cfg := config.Defaults()
@@ -482,6 +475,9 @@ func TestRunWSProxy_ParityBase64EncodedSecretDLP(t *testing.T) {
 	if !strings.Contains(out, parityErrInputBlockCode) {
 		t.Errorf("expected input block code %s on WS path, got: %s", parityErrInputBlockCode, out)
 	}
+	if got := upstreamFrames.Load(); got != 0 {
+		t.Errorf("base64 secret block forwarded %d frame(s) upstream, want 0", got)
+	}
 }
 
 // TestRunWSProxy_ParityRedactsToolCallArguments mirrors
@@ -495,6 +491,7 @@ func TestRunWSProxy_ParityRedactsToolCallArguments(t *testing.T) {
 	// (which would race under -race). Uses gobwasutil helpers for
 	// frame read/write, matching the rest of proxy_ws_test.go.
 	forwardedCh := make(chan []byte, 1)
+	responseSent := make(chan struct{})
 	cleanResponse := []byte(`{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"ok"}]}}`)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, _, _, err := ws.UpgradeHTTP(r, w)
@@ -514,7 +511,7 @@ func TestRunWSProxy_ParityRedactsToolCallArguments(t *testing.T) {
 			}
 		}
 		_ = gobwasutil.WriteServerMessage(conn, ws.OpText, cleanResponse)
-		time.Sleep(50 * time.Millisecond)
+		close(responseSent)
 	}))
 	defer srv.Close()
 
@@ -559,9 +556,7 @@ func TestRunWSProxy_ParityRedactsToolCallArguments(t *testing.T) {
 		t.Fatal("upstream never received the forwarded tool-call frame")
 	}
 
-	// Give the proxy a moment to complete the response loop, then close
-	// stdin so RunWSProxy returns cleanly.
-	time.Sleep(20 * time.Millisecond)
+	waitForResponse(t, responseSent)
 	_ = pw.Close()
 	wg.Wait()
 	if proxyErr != nil {

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -41,6 +42,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	"github.com/luckyPipewrench/pipelock/internal/session"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 const (
@@ -60,6 +62,29 @@ type recordingEmitSinkHTTP struct {
 	events []emit.Event
 }
 
+type lockedHTTPBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedHTTPBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedHTTPBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func (b *lockedHTTPBuffer) contains(s string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return strings.Contains(b.buf.String(), s)
+}
+
 func (s *recordingEmitSinkHTTP) Emit(_ context.Context, ev emit.Event) error {
 	s.events = append(s.events, ev)
 	return nil
@@ -71,6 +96,25 @@ func (s *recordingEmitSinkHTTP) Close() error {
 
 func testHTTPRedactionMatcher() *redact.Matcher {
 	return redact.NewDefaultMatcher()
+}
+
+func waitForHTTPHealth(t *testing.T, baseURL string) {
+	t.Helper()
+	client := &http.Client{Timeout: 250 * time.Millisecond}
+	testwait.For(t, 3*time.Second, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/health", nil)
+		if err != nil {
+			t.Fatalf("NewRequest /health: %v", err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode >= 200 && resp.StatusCode < 300
+	}, "HTTP listener health at %s", baseURL)
 }
 
 func newTestReceiptEmitter(t *testing.T) (*receipt.Emitter, *recorder.Recorder, string) {
@@ -470,7 +514,7 @@ func TestRunHTTPProxy_GETStreamReceivesServerNotifications(t *testing.T) {
 	// Use a pipe so we control when stdin EOF happens. This avoids a race where
 	// cancel() fires before the GET stream goroutine can deliver its notification.
 	stdinR, stdinW := io.Pipe()
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedHTTPBuffer
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -490,8 +534,9 @@ func TestRunHTTPProxy_GETStreamReceivesServerNotifications(t *testing.T) {
 		t.Fatal("timeout waiting for GET stream to be called")
 	}
 
-	// Small delay to let the GET notification be forwarded to stdout.
-	time.Sleep(50 * time.Millisecond)
+	testwait.For(t, 2*time.Second, func() bool {
+		return stdout.contains("notifications/resources/updated")
+	}, "GET notification forwarded to stdout")
 	_ = stdinW.Close()
 
 	err := <-done
@@ -952,7 +997,10 @@ func TestScanHTTPInput_Disabled(t *testing.T) {
 }
 
 func TestRunHTTPProxy_ContextCancellation(t *testing.T) {
+	requestSeen := make(chan struct{})
+	var requestSeenOnce sync.Once
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestSeenOnce.Do(func() { close(requestSeen) })
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
 	}))
@@ -971,7 +1019,11 @@ func TestRunHTTPProxy_ContextCancellation(t *testing.T) {
 
 	// Send one request so the proxy is active.
 	_, _ = stdinW.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"test"}` + "\n"))
-	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-requestSeen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for upstream request")
+	}
 
 	// Cancel context and close stdin - ReadMessage blocks on io.Reader,
 	// so we must close the pipe to unblock it after context cancellation.
@@ -1307,8 +1359,26 @@ func TestRunHTTPProxy_GETStream405PermanentStop(t *testing.T) {
 	// Send initialize to establish session.
 	_, _ = stdinW.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n"))
 
-	// Wait for the GET attempt and give time for potential retries.
-	time.Sleep(200 * time.Millisecond)
+	testwait.For(t, time.Second, func() bool {
+		return atomic.LoadInt32(&getCount) >= 1
+	}, "initial GET stream attempt")
+
+	initialGets := atomic.LoadInt32(&getCount)
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+stable:
+	for {
+		select {
+		case <-deadline.C:
+			break stable
+		case <-ticker.C:
+			if got := atomic.LoadInt32(&getCount); got != initialGets {
+				t.Fatalf("405 GET stream retried after permanent stop: got %d attempts, want %d", got, initialGets)
+			}
+		}
+	}
 
 	// Close stdin to stop the proxy.
 	_ = stdinW.Close()
@@ -1368,9 +1438,9 @@ func TestRunHTTPProxy_GETStreamTransientReconnect(t *testing.T) {
 	// Send initialize.
 	_, _ = stdinW.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n"))
 
-	// Wait for transient error, backoff (1s), and successful reconnect.
-	// The GET stream backoff starts at 1s, so we need to wait at least that long.
-	time.Sleep(2500 * time.Millisecond)
+	testwait.For(t, 3*time.Second, func() bool {
+		return atomic.LoadInt32(&getCount) >= 2
+	}, "transient GET stream retry")
 
 	_ = stdinW.Close()
 
@@ -1426,22 +1496,36 @@ func TestRunHTTPProxy_GETStreamKillSwitchPause(t *testing.T) {
 	_, _ = stdinW.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n"))
 
 	// Wait for at least one GET attempt.
-	time.Sleep(500 * time.Millisecond)
+	testwait.For(t, time.Second, func() bool {
+		return atomic.LoadInt32(&getCount) >= 1
+	}, "initial GET attempt before kill switch")
 	countBefore := atomic.LoadInt32(&getCount)
-	if countBefore < 1 {
-		_ = stdinW.Close()
-		<-done
-		t.Fatalf("expected at least 1 GET attempt before kill switch, got %d", countBefore)
-	}
 
 	// Activate kill switch - GET stream should pause.
 	ks.SetAPI(true)
-	time.Sleep(1500 * time.Millisecond)
+	pauseTimer := time.NewTimer(1500 * time.Millisecond)
+	pauseTicker := time.NewTicker(25 * time.Millisecond)
+	for {
+		select {
+		case <-pauseTimer.C:
+			pauseTicker.Stop()
+			goto pauseDone
+		case <-pauseTicker.C:
+			if got := atomic.LoadInt32(&getCount); got > countBefore+1 {
+				pauseTicker.Stop()
+				pauseTimer.Stop()
+				t.Fatalf("expected GET stream to pause during kill switch: before=%d during=%d", countBefore, got)
+			}
+		}
+	}
+pauseDone:
 	countDuring := atomic.LoadInt32(&getCount)
 
 	// Deactivate - should resume.
 	ks.SetAPI(false)
-	time.Sleep(1500 * time.Millisecond)
+	testwait.For(t, 3*time.Second, func() bool {
+		return atomic.LoadInt32(&getCount) > countDuring
+	}, "GET stream resumes after kill switch clears")
 	countAfter := atomic.LoadInt32(&getCount)
 
 	_ = stdinW.Close()
@@ -1620,9 +1704,15 @@ func TestScanHTTPInput_InjectionInArgs(t *testing.T) {
 
 func TestRunHTTPProxy_ContextCancelDuringRead(t *testing.T) {
 	// Exercise the ctx.Done path in the main loop (lines 67-71).
+	requestStarted := make(chan struct{})
+	unblockResponse := make(chan struct{})
+	var requestStartedOnce sync.Once
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// Slow response - gives time for context cancellation.
-		time.Sleep(200 * time.Millisecond)
+		requestStartedOnce.Do(func() { close(requestStarted) })
+		select {
+		case <-unblockResponse:
+		case <-time.After(2 * time.Second):
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
 	}))
@@ -1643,11 +1733,16 @@ func TestRunHTTPProxy_ContextCancelDuringRead(t *testing.T) {
 
 	// Write first message, wait for it to be consumed, then cancel.
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n"))
-	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for upstream request")
+	}
 
 	// Write a second message and immediately cancel context.
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}` + "\n"))
 	cancel()
+	close(unblockResponse)
 	_ = pw.Close()
 
 	err := <-done
@@ -1772,16 +1867,7 @@ func startListenerProxy(
 
 	// Wait for server to accept connections.
 	baseURL := "http://" + addr
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		hReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/health", nil)
-		resp, connErr := http.DefaultClient.Do(hReq)
-		if connErr == nil {
-			_ = resp.Body.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForHTTPHealth(t, baseURL)
 
 	t.Cleanup(func() {
 		cancel()
@@ -1960,16 +2046,7 @@ func TestRunHTTPListenerProxy_BlockedResponse_EmitsReceipt(t *testing.T) {
 	}()
 
 	baseURL := "http://" + ln.Addr().String()
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/health", nil)
-		resp, connErr := http.DefaultClient.Do(req)
-		if connErr == nil {
-			_ = resp.Body.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForHTTPHealth(t, baseURL)
 
 	body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}`)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, baseURL+"/", body)
@@ -2415,16 +2492,7 @@ func TestHTTPListener_ConfiguredSensitiveHeaderDLP(t *testing.T) {
 	}()
 
 	baseURL := "http://" + addr
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		hReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/health", nil)
-		resp, connErr := http.DefaultClient.Do(hReq)
-		if connErr == nil {
-			_ = resp.Body.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForHTTPHealth(t, baseURL)
 
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, baseURL+"/", strings.NewReader(jsonToolsList))
 	req.Header.Set("Content-Type", "application/json")
@@ -2586,15 +2654,7 @@ func TestHTTPListener_RedactsToolCallArguments(t *testing.T) {
 	})
 
 	baseURL := "http://" + addr
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		resp, connErr := http.Get(baseURL + "/health") //nolint:gosec,noctx // test
-		if connErr == nil {
-			_ = resp.Body.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForHTTPHealth(t, baseURL)
 
 	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"prompt":"use ` + secret + ` to deploy"}}}`
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, baseURL+"/", strings.NewReader(body))
@@ -3138,7 +3198,14 @@ func TestHTTPListener_GracefulShutdown(t *testing.T) {
 
 	// Cancel context to trigger shutdown.
 	cancel()
-	time.Sleep(200 * time.Millisecond)
+	testwait.For(t, 2*time.Second, func() bool {
+		resp, err := http.Get(baseURL + "/health") //nolint:gosec,noctx // test
+		if err == nil {
+			_ = resp.Body.Close()
+			return false
+		}
+		return true
+	}, "listener proxy shutdown")
 
 	// Should no longer accept connections.
 	resp2, err := http.Get(baseURL + "/health") //nolint:gosec,noctx // test
@@ -3554,16 +3621,7 @@ func startListenerProxyFull(
 	}()
 
 	baseURL := "http://" + addr
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		hReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/health", nil)
-		resp, connErr := http.DefaultClient.Do(hReq)
-		if connErr == nil {
-			_ = resp.Body.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForHTTPHealth(t, baseURL)
 
 	t.Cleanup(func() {
 		cancel()
@@ -4688,16 +4746,7 @@ func TestHTTPListener_StoreAdaptive(t *testing.T) {
 	}()
 
 	baseURL := "http://" + addr
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		hReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/health", nil)
-		resp, connErr := http.DefaultClient.Do(hReq)
-		if connErr == nil {
-			_ = resp.Body.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForHTTPHealth(t, baseURL)
 
 	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}`
 	resp, httpErr := http.Post(baseURL+"/", "application/json", strings.NewReader(body)) //nolint:gosec,noctx // test
@@ -4859,16 +4908,7 @@ func TestHTTPListener_DoWBlock(t *testing.T) {
 	})
 
 	baseURL := "http://" + addr
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		hReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/health", nil)
-		resp, connErr := http.DefaultClient.Do(hReq)
-		if connErr == nil {
-			_ = resp.Body.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForHTTPHealth(t, baseURL)
 
 	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + testDoWToolName + `","arguments":{"q":"hello"}}}`
 	postReq, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, baseURL+"/", strings.NewReader(body))
@@ -5007,16 +5047,7 @@ func TestHTTPListener_AdaptiveCfgFn_HotReload(t *testing.T) {
 	}()
 
 	baseURL := "http://" + addr
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		hReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/health", nil)
-		resp, connErr := http.DefaultClient.Do(hReq)
-		if connErr == nil {
-			_ = resp.Body.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForHTTPHealth(t, baseURL)
 
 	// First request: adaptive enabled.
 	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}`
@@ -5102,16 +5133,7 @@ func TestHTTPListener_PolicyCfgFn_HotReload(t *testing.T) {
 	})
 
 	baseURL := "http://" + addr
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		hReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/health", nil)
-		resp, connErr := http.DefaultClient.Do(hReq)
-		if connErr == nil {
-			_ = resp.Body.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForHTTPHealth(t, baseURL)
 
 	post := func() (int, string) {
 		body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dangerous_tool","arguments":{}}}`
@@ -5526,16 +5548,7 @@ func TestHTTPListener_A2AHeaderBlock(t *testing.T) {
 	}()
 
 	baseURL := "http://" + addr
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		hReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/health", nil)
-		resp, connErr := http.DefaultClient.Do(hReq)
-		if connErr == nil {
-			_ = resp.Body.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForHTTPHealth(t, baseURL)
 
 	// Send a request with a malicious A2A-Extensions header containing a
 	// disallowed scheme. The URL scanner blocks non-http/https schemes.
@@ -5595,16 +5608,7 @@ func TestHTTPListener_AuthDLPWithAdaptiveSignal(t *testing.T) {
 	}()
 
 	baseURL := "http://" + addr
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		hReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/health", nil)
-		resp, connErr := http.DefaultClient.Do(hReq)
-		if connErr == nil {
-			_ = resp.Body.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForHTTPHealth(t, baseURL)
 
 	// Send a request with a leaked secret in Authorization header.
 	secret := "sk-ant-" + strings.Repeat("z", 25)
@@ -5665,16 +5669,7 @@ func TestHTTPListener_AuthWarnPreservesListenerWarnMetadata(t *testing.T) {
 	}()
 
 	baseURL := "http://" + addr
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		hReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/health", nil)
-		resp, connErr := http.DefaultClient.Do(hReq)
-		if connErr == nil {
-			_ = resp.Body.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForHTTPHealth(t, baseURL)
 
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, baseURL+"/", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/mcp/proxy_ws_test.go
+++ b/internal/mcp/proxy_ws_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 func testScannerForWS(t *testing.T) *scanner.Scanner {
@@ -52,6 +54,18 @@ func waitForResponse(t *testing.T, ch <-chan struct{}) {
 	}
 }
 
+func waitForResponseNumber(t *testing.T, ch <-chan int, want int) {
+	t.Helper()
+	select {
+	case got := <-ch:
+		if got != want {
+			t.Fatalf("upstream response signal = %d, want %d", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for upstream response %d", want)
+	}
+}
+
 // wsRespondServer creates a test WS server that reads one client message,
 // sends the given response, then signals via responseSent before closing.
 func wsRespondServer(t *testing.T, response []byte, responseSent chan<- struct{}) *httptest.Server {
@@ -71,8 +85,32 @@ func wsRespondServer(t *testing.T, response []byte, responseSent chan<- struct{}
 		if responseSent != nil {
 			close(responseSent)
 		}
-		time.Sleep(50 * time.Millisecond)
 	}))
+}
+
+func wsDrainServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var frames atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, _, _, err := ws.UpgradeHTTP(r, w)
+		if err != nil {
+			t.Errorf("ws upgrade: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			msgs, err := gobwasutil.ReadClientMessage(conn, nil)
+			if err != nil {
+				return
+			}
+			for _, msg := range msgs {
+				if msg.OpCode == ws.OpText || msg.OpCode == ws.OpBinary {
+					frames.Add(1)
+				}
+			}
+		}
+	}))
+	return srv, &frames
 }
 
 func TestRunWSProxy_ForwardsCleanRequest(t *testing.T) {
@@ -85,7 +123,7 @@ func TestRunWSProxy_ForwardsCleanRequest(t *testing.T) {
 
 	// Use a pipe so we control when EOF arrives.
 	pr, pw := io.Pipe()
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedHTTPBuffer
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -98,10 +136,15 @@ func TestRunWSProxy_ForwardsCleanRequest(t *testing.T) {
 		proxyErr = RunWSProxy(ctx, pr, &stdout, &stderr, wsURL(srv), MCPProxyOpts{Scanner: sc})
 	}()
 
-	// Send request, wait for response to arrive, then close stdin.
+	// Send request, wait for the response to be written through the proxy, then
+	// close stdin. Waiting only for the upstream write is insufficient: closing
+	// stdin immediately afterward can close the WS before the response goroutine
+	// copies the frame to stdout.
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}` + "\n"))
 	waitForResponse(t, responseSent)
-	time.Sleep(20 * time.Millisecond) // Let ForwardScanned write to stdout.
+	testwait.For(t, time.Second, func() bool {
+		return stdout.contains("hello world")
+	}, "clean WS response forwarded to stdout")
 	_ = pw.Close()
 
 	wg.Wait()
@@ -140,7 +183,7 @@ func TestRunWSProxy_BlocksInjectedResponse(t *testing.T) {
 	t.Cleanup(sc.Close)
 
 	pr, pw := io.Pipe()
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedHTTPBuffer
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -155,7 +198,9 @@ func TestRunWSProxy_BlocksInjectedResponse(t *testing.T) {
 
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}` + "\n"))
 	waitForResponse(t, responseSent)
-	time.Sleep(20 * time.Millisecond)
+	testwait.For(t, time.Second, func() bool {
+		return stdout.contains("injection detected") && stderr.contains("injection detected")
+	}, "injected WS response blocked and logged")
 	_ = pw.Close()
 
 	wg.Wait()
@@ -187,7 +232,8 @@ func TestRunWSProxy_BlockedResponse_EmitsReceipt(t *testing.T) {
 
 	emitter, rec, dir, pubHex := newReceiptTestHarness(t)
 	pr, pw := io.Pipe()
-	var stdout, stderr bytes.Buffer
+	var stdout lockedHTTPBuffer
+	var stderr bytes.Buffer
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -202,7 +248,9 @@ func TestRunWSProxy_BlockedResponse_EmitsReceipt(t *testing.T) {
 
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}` + "\n"))
 	waitForResponse(t, responseSent)
-	time.Sleep(20 * time.Millisecond)
+	testwait.For(t, time.Second, func() bool {
+		return stdout.contains("-32000")
+	}, "blocked WS response forwarded to stdout")
 	_ = pw.Close()
 
 	wg.Wait()
@@ -232,15 +280,8 @@ func TestRunWSProxy_BlockedResponse_EmitsReceipt(t *testing.T) {
 }
 
 func TestRunWSProxy_InputDLPBlocking(t *testing.T) {
-	// Server that waits briefly then closes (no client message expected).
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, _, _, err := ws.UpgradeHTTP(r, w)
-		if err != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		time.Sleep(200 * time.Millisecond)
-	}))
+	// Server drains until the proxy closes the upstream connection.
+	srv, upstreamFrames := wsDrainServer(t)
 	defer srv.Close()
 
 	cfg := config.Defaults()
@@ -275,18 +316,13 @@ func TestRunWSProxy_InputDLPBlocking(t *testing.T) {
 	if !strings.Contains(output, "-32001") {
 		t.Errorf("expected input block error code -32001, got: %s", output)
 	}
+	if got := upstreamFrames.Load(); got != 0 {
+		t.Errorf("blocked input forwarded %d frame(s) upstream, want 0", got)
+	}
 }
 
 func TestRunWSProxy_KillSwitchDeniesAll(t *testing.T) {
-	// Server that waits briefly then closes.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, _, _, err := ws.UpgradeHTTP(r, w)
-		if err != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		time.Sleep(200 * time.Millisecond)
-	}))
+	srv, upstreamFrames := wsDrainServer(t)
 	defer srv.Close()
 
 	cfg := config.Defaults()
@@ -317,17 +353,13 @@ func TestRunWSProxy_KillSwitchDeniesAll(t *testing.T) {
 	if !strings.Contains(output, "-32004") {
 		t.Errorf("expected kill switch error code -32004, got: %s", output)
 	}
+	if got := upstreamFrames.Load(); got != 0 {
+		t.Errorf("kill switch forwarded %d frame(s) upstream, want 0", got)
+	}
 }
 
 func TestRunWSProxy_KillSwitchDropsNotification(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, _, _, err := ws.UpgradeHTTP(r, w)
-		if err != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		time.Sleep(200 * time.Millisecond)
-	}))
+	srv, upstreamFrames := wsDrainServer(t)
 	defer srv.Close()
 
 	cfg := config.Defaults()
@@ -358,18 +390,14 @@ func TestRunWSProxy_KillSwitchDropsNotification(t *testing.T) {
 	if !strings.Contains(stderr.String(), "kill switch dropped notification") {
 		t.Errorf("expected drop log on stderr, got: %s", stderr.String())
 	}
+	if got := upstreamFrames.Load(); got != 0 {
+		t.Errorf("dropped notification forwarded %d frame(s) upstream, want 0", got)
+	}
 }
 
 func TestRunWSProxy_ToolPolicyBlocks(t *testing.T) {
-	// Server waits (no message expected since policy blocks it).
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, _, _, err := ws.UpgradeHTTP(r, w)
-		if err != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		time.Sleep(200 * time.Millisecond)
-	}))
+	// Server drains until the proxy closes the upstream connection.
+	srv, upstreamFrames := wsDrainServer(t)
 	defer srv.Close()
 
 	cfg := config.Defaults()
@@ -410,6 +438,9 @@ func TestRunWSProxy_ToolPolicyBlocks(t *testing.T) {
 	output := strings.TrimSpace(stdout.String())
 	if !strings.Contains(output, "-32002") {
 		t.Errorf("expected policy block error code -32002, got: %s", output)
+	}
+	if got := upstreamFrames.Load(); got != 0 {
+		t.Errorf("tool policy block forwarded %d frame(s) upstream, want 0", got)
 	}
 }
 
@@ -460,7 +491,8 @@ func TestRunWSProxy_ChainDetectionBlocks(t *testing.T) {
 	}
 
 	pr, pw := io.Pipe()
-	var stdout, stderr bytes.Buffer
+	var stdout lockedHTTPBuffer
+	var stderr bytes.Buffer
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -475,10 +507,8 @@ func TestRunWSProxy_ChainDetectionBlocks(t *testing.T) {
 
 	// First tool call: read_file.
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_file","arguments":{}}}` + "\n"))
-	time.Sleep(50 * time.Millisecond)
 	// Second tool call: send_message (should trigger chain).
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"send_message","arguments":{}}}` + "\n"))
-	time.Sleep(50 * time.Millisecond)
 	_ = pw.Close()
 
 	wg.Wait()
@@ -493,14 +523,7 @@ func TestRunWSProxy_ChainDetectionBlocks(t *testing.T) {
 
 func TestRunWSProxy_InputDLPWithAuditLogger(t *testing.T) {
 	// Exercises the non-nil auditLogger path in scanHTTPInput via RunWSProxy.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, _, _, err := ws.UpgradeHTTP(r, w)
-		if err != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		time.Sleep(200 * time.Millisecond)
-	}))
+	srv, upstreamFrames := wsDrainServer(t)
 	defer srv.Close()
 
 	cfg := config.Defaults()
@@ -533,6 +556,9 @@ func TestRunWSProxy_InputDLPWithAuditLogger(t *testing.T) {
 	if !strings.Contains(output, "-32001") {
 		t.Errorf("expected input block error code -32001, got: %s", output)
 	}
+	if got := upstreamFrames.Load(); got != 0 {
+		t.Errorf("blocked audit-logged input forwarded %d frame(s) upstream, want 0", got)
+	}
 }
 
 func TestRunWSProxy_ToolScanningDetectsPoison(t *testing.T) {
@@ -554,7 +580,8 @@ func TestRunWSProxy_ToolScanningDetectsPoison(t *testing.T) {
 	}
 
 	pr, pw := io.Pipe()
-	var stdout, stderr bytes.Buffer
+	var stdout lockedHTTPBuffer
+	var stderr bytes.Buffer
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -569,7 +596,9 @@ func TestRunWSProxy_ToolScanningDetectsPoison(t *testing.T) {
 
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}` + "\n"))
 	waitForResponse(t, responseSent)
-	time.Sleep(20 * time.Millisecond)
+	testwait.For(t, time.Second, func() bool {
+		return stdout.contains("-32000")
+	}, "tool scan block response forwarded to stdout")
 	_ = pw.Close()
 
 	wg.Wait()
@@ -626,6 +655,7 @@ func TestRunWSProxy_MultipleMessages(t *testing.T) {
 	// Server sends a response for each received message.
 	var msgCount int
 	var mu sync.Mutex
+	responses := make(chan int, 2)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, _, _, err := ws.UpgradeHTTP(r, w)
 		if err != nil {
@@ -644,6 +674,7 @@ func TestRunWSProxy_MultipleMessages(t *testing.T) {
 				mu.Unlock()
 				resp := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"result":{"content":[{"type":"text","text":"resp"}]}}`, n))
 				_ = gobwasutil.WriteServerMessage(conn, ws.OpText, resp)
+				responses <- n
 			}
 		}
 	}))
@@ -652,7 +683,8 @@ func TestRunWSProxy_MultipleMessages(t *testing.T) {
 	sc := testScannerForWS(t)
 
 	pr, pw := io.Pipe()
-	var stdout, stderr bytes.Buffer
+	var stdout lockedHTTPBuffer
+	var stderr bytes.Buffer
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -666,9 +698,12 @@ func TestRunWSProxy_MultipleMessages(t *testing.T) {
 	}()
 
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"a","arguments":{}}}` + "\n"))
-	time.Sleep(50 * time.Millisecond)
+	waitForResponseNumber(t, responses, 1)
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"b","arguments":{}}}` + "\n"))
-	time.Sleep(50 * time.Millisecond)
+	waitForResponseNumber(t, responses, 2)
+	testwait.For(t, time.Second, func() bool {
+		return strings.Count(strings.TrimSpace(stdout.String()), "\n") >= 1
+	}, "two WS responses forwarded to stdout")
 	_ = pw.Close()
 
 	wg.Wait()
@@ -696,7 +731,7 @@ func TestRunWSProxy_InputScanWarnMode(t *testing.T) {
 
 	fakeKey := "AKIA" + "IOSFODNN7EXAMPLE"
 	pr, pw := io.Pipe()
-	var stdout, stderr bytes.Buffer
+	var stderr bytes.Buffer
 
 	inputCfg := &InputScanConfig{
 		Enabled:      true,
@@ -708,16 +743,19 @@ func TestRunWSProxy_InputScanWarnMode(t *testing.T) {
 	defer cancel()
 
 	var proxyErr error
+	var safeStdout lockedHTTPBuffer
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		proxyErr = RunWSProxy(ctx, pr, &stdout, &stderr, wsURL(srv), MCPProxyOpts{Scanner: sc, InputCfg: inputCfg})
+		proxyErr = RunWSProxy(ctx, pr, &safeStdout, &stderr, wsURL(srv), MCPProxyOpts{Scanner: sc, InputCfg: inputCfg})
 	}()
 
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"` + fakeKey + `"}}}` + "\n"))
 	waitForResponse(t, responseSent)
-	time.Sleep(20 * time.Millisecond)
+	testwait.For(t, time.Second, func() bool {
+		return safeStdout.contains(`"result"`)
+	}, "warn-mode WS response forwarded to stdout")
 	_ = pw.Close()
 
 	wg.Wait()
@@ -726,7 +764,7 @@ func TestRunWSProxy_InputScanWarnMode(t *testing.T) {
 	}
 
 	// Warn mode: response should be forwarded to stdout.
-	output := strings.TrimSpace(stdout.String())
+	output := strings.TrimSpace(safeStdout.String())
 	if output == "" {
 		t.Error("expected response forwarded in warn mode")
 	}
@@ -737,14 +775,7 @@ func TestRunWSProxy_InputScanWarnMode(t *testing.T) {
 }
 
 func TestRunWSProxy_BlockedNotificationSilent(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, _, _, err := ws.UpgradeHTTP(r, w)
-		if err != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		time.Sleep(200 * time.Millisecond)
-	}))
+	srv, upstreamFrames := wsDrainServer(t)
 	defer srv.Close()
 
 	cfg := config.Defaults()
@@ -773,6 +804,9 @@ func TestRunWSProxy_BlockedNotificationSilent(t *testing.T) {
 
 	if strings.TrimSpace(stdout.String()) != "" {
 		t.Errorf("expected no stdout for blocked notification, got: %s", stdout.String())
+	}
+	if got := upstreamFrames.Load(); got != 0 {
+		t.Errorf("blocked notification forwarded %d frame(s) upstream, want 0", got)
 	}
 }
 
@@ -811,7 +845,6 @@ func TestRunWSProxy_BindingConfigWired(t *testing.T) {
 
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}` + "\n"))
 	waitForResponse(t, responseSent)
-	time.Sleep(20 * time.Millisecond)
 	_ = pw.Close()
 
 	wg.Wait()
@@ -822,6 +855,7 @@ func TestRunWSProxy_BindingConfigWired(t *testing.T) {
 
 func TestRunWSProxy_UpstreamWriteError(t *testing.T) {
 	// Server accepts upgrade, reads one message, then closes.
+	firstRead := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, _, _, err := ws.UpgradeHTTP(r, w)
 		if err != nil {
@@ -829,6 +863,7 @@ func TestRunWSProxy_UpstreamWriteError(t *testing.T) {
 		}
 		// Read one message, then close to trigger write error on second.
 		_, _ = gobwasutil.ReadClientMessage(conn, nil)
+		close(firstRead)
 		_ = conn.Close()
 	}))
 	defer srv.Close()
@@ -851,10 +886,9 @@ func TestRunWSProxy_UpstreamWriteError(t *testing.T) {
 
 	// First message accepted by server.
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"test","params":{}}` + "\n"))
-	time.Sleep(100 * time.Millisecond)
+	waitForResponse(t, firstRead)
 	// Second message: server already closed, write should fail.
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":2,"method":"test","params":{}}` + "\n"))
-	time.Sleep(50 * time.Millisecond)
 	_ = pw.Close()
 
 	wg.Wait()
@@ -865,6 +899,7 @@ func TestRunWSProxy_ParentContextCancellation(t *testing.T) {
 	// Cancel the parent context while stdin is producing messages.
 	// This exercises the ctx.Done goroutine (lines 57-63) that force-closes
 	// the WS connection, plus the innerCtx check in the stdin loop (lines 110-120).
+	firstRead := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, _, _, err := ws.UpgradeHTTP(r, w)
 		if err != nil {
@@ -872,10 +907,12 @@ func TestRunWSProxy_ParentContextCancellation(t *testing.T) {
 		}
 		defer func() { _ = conn.Close() }()
 		// Keep reading to keep the connection open.
+		var once sync.Once
 		for {
 			if _, readErr := gobwasutil.ReadClientMessage(conn, nil); readErr != nil {
 				return
 			}
+			once.Do(func() { close(firstRead) })
 		}
 	}))
 	defer srv.Close()
@@ -898,9 +935,8 @@ func TestRunWSProxy_ParentContextCancellation(t *testing.T) {
 
 	// Send one message, let it forward, then cancel context.
 	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n"))
-	time.Sleep(100 * time.Millisecond)
+	waitForResponse(t, firstRead)
 	cancel()
-	time.Sleep(50 * time.Millisecond)
 	_ = pw.Close()
 
 	wg.Wait()
@@ -916,14 +952,7 @@ type errReaderWS struct{ err error }
 func (r *errReaderWS) Read([]byte) (int, error) { return 0, r.err }
 
 func TestRunWSProxy_StdinReadError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, _, _, err := ws.UpgradeHTTP(r, w)
-		if err != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		time.Sleep(500 * time.Millisecond)
-	}))
+	srv, _ := wsDrainServer(t)
 	defer srv.Close()
 
 	sc := testScannerForWS(t)

--- a/internal/mcp/reaper_linux_test.go
+++ b/internal/mcp/reaper_linux_test.go
@@ -135,14 +135,20 @@ func TestReaper_ProtectedDirectPIDRegistry(t *testing.T) {
 // deadline passes. Returns the final value of cond().
 func waitForCondition(t *testing.T, timeout time.Duration, cond func() bool) bool {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
 		if cond() {
 			return true
 		}
-		time.Sleep(25 * time.Millisecond)
+		select {
+		case <-timer.C:
+			return cond()
+		case <-ticker.C:
+		}
 	}
-	return cond()
 }
 
 // countAdoptedZombies returns the number of zombies under our PID
@@ -225,23 +231,26 @@ func TestReaper_DoneChannelStopsGoroutine(t *testing.T) {
 	warmDone := make(chan struct{})
 	startAdoptedReaper(0, warmDone)
 	close(warmDone)
-	// Drain any pre-existing goroutines (test infra, prior test leftovers,
-	// and the warm-up reaper) by sleeping and re-sampling - gives Go's
-	// scheduler a chance to settle.
-	time.Sleep(50 * time.Millisecond)
+	if !waitForCondition(t, time.Second, func() bool {
+		return !isProtectedDirectPID(0)
+	}) {
+		t.Fatal("warm-up reaper did not unregister protected direct PID")
+	}
 	before := runtime.NumGoroutine()
 
 	for range iterations {
 		done := make(chan struct{})
 		startAdoptedReaper(0, done) // directPID=0 is impossible - never matches
-		// Let the goroutine reach its select on done/sigCh.
-		time.Sleep(10 * time.Millisecond)
 		// Send a self-SIGCHLD to deterministically exercise the sigCh
 		// branch. The reaper sweep is a no-op (no adopted zombies under
 		// this test process) but the branch is hit, which is the goal.
 		_ = syscall.Kill(os.Getpid(), syscall.SIGCHLD)
-		time.Sleep(10 * time.Millisecond)
 		close(done)
+		if !waitForCondition(t, time.Second, func() bool {
+			return !isProtectedDirectPID(0)
+		}) {
+			t.Fatal("reaper did not unregister protected direct PID")
+		}
 	}
 	// Give all goroutines a chance to observe close(done) and exit.
 	var after int

--- a/internal/mcp/sse_generic_test.go
+++ b/internal/mcp/sse_generic_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 // fakeAWSKey returns an AWS-looking access key ID assembled at runtime so
@@ -845,17 +846,9 @@ func TestScanGenericSSEStream_StreamsIncrementally(t *testing.T) {
 	if _, err := pw.Write([]byte("data: first\n\n")); err != nil {
 		t.Fatalf("pw.Write: %v", err)
 	}
-	// Wait briefly for the scanner to consume the first event.
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		if flusher.Count() >= 1 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	if flusher.Count() < 1 {
-		t.Fatalf("expected first event flushed before second arrives, got %d", flusher.Count())
-	}
+	testwait.For(t, time.Second, func() bool {
+		return flusher.Count() >= 1
+	}, "first SSE event flushed before second arrives")
 	flushesAfterFirst := flusher.Count()
 
 	if _, err := pw.Write([]byte("data: second\n\n")); err != nil {
@@ -993,7 +986,7 @@ type slowWriter struct {
 
 func (s *slowWriter) Write(p []byte) (int, error) {
 	if s.blockPerWrite > 0 {
-		time.Sleep(s.blockPerWrite)
+		<-time.After(s.blockPerWrite)
 	}
 	atomic.AddInt32(&s.writes, 1)
 	return s.buf.Write(p)

--- a/internal/proxy/dow_test.go
+++ b/internal/proxy/dow_test.go
@@ -339,42 +339,86 @@ func TestDoW_ConcurrentLimit_Default(t *testing.T) {
 }
 
 func TestDoW_ConcurrentLimit_ThreadSafe(t *testing.T) {
+	const limit = 50
 	tracker := NewDoWTracker(DoWConfig{
-		MaxConcurrentToolCalls: 50,
+		MaxConcurrentToolCalls: limit,
 		Action:                 actionBlock,
 	})
 
 	var wg sync.WaitGroup
 	allowed := make(chan bool, 100)
+	releaseHolders := make(chan struct{})
+	holderResults := make(chan bool, limit)
+	contenderResults := make(chan bool, 50)
 
-	// Launch 100 goroutines trying to acquire.
-	for range 100 {
+	// Fill the concurrent-call limit with holders first, then launch
+	// contenders. That deterministically exercises both allowed and denied
+	// paths instead of depending on goroutine scheduling timing.
+	for range limit {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			result := tracker.AcquireConcurrent()
 			allowed <- result.Allowed
+			holderResults <- result.Allowed
 			if result.Allowed {
-				// Hold briefly then release.
-				time.Sleep(time.Millisecond)
+				<-releaseHolders
 				tracker.ReleaseConcurrent()
 			}
 		}()
 	}
 
+	for range limit {
+		select {
+		case ok := <-holderResults:
+			if !ok {
+				t.Fatal("holder acquire was denied before limit was full")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for holders to acquire concurrent slots")
+		}
+	}
+
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result := tracker.AcquireConcurrent()
+			allowed <- result.Allowed
+			contenderResults <- result.Allowed
+			if result.Allowed {
+				tracker.ReleaseConcurrent()
+			}
+		}()
+	}
+
+	for range 50 {
+		select {
+		case <-contenderResults:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for contenders to attempt concurrent acquire")
+		}
+	}
+
+	close(releaseHolders)
 	wg.Wait()
 	close(allowed)
 
 	allowedCount := 0
+	deniedCount := 0
 	for a := range allowed {
 		if a {
 			allowedCount++
+		} else {
+			deniedCount++
 		}
 	}
 
-	// At least some should succeed, and we should never exceed the limit.
-	if allowedCount == 0 {
-		t.Error("at least some concurrent acquires should succeed")
+	if allowedCount == 0 || allowedCount > limit {
+		t.Errorf("allowed concurrent acquires = %d, want 1..%d", allowedCount, limit)
+	}
+	if deniedCount == 0 {
+		t.Error("expected some concurrent acquires to be denied while holders occupied the limit")
 	}
 
 	// Final inflight should be 0 (all released).

--- a/internal/proxy/envelope_reload_test.go
+++ b/internal/proxy/envelope_reload_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -843,9 +844,8 @@ func TestProxy_ReloadEnvelopeEmitter_ConcurrentWithTraffic(t *testing.T) {
 			enableEnvelopeSigning(t, rotatedCfg, sharedPath)
 			p.Reload(rotatedCfg, scanner.New(rotatedCfg))
 			// Yield so traffic workers can make progress between
-			// reload churn cycles. Using time.Sleep rather than
-			// runtime.Gosched to give the scheduler a real chance.
-			time.Sleep(5 * time.Millisecond)
+			// reload churn cycles.
+			runtime.Gosched()
 		}
 	}()
 

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 // readerConn wraps a bufio.Reader and a net.Conn so that TLS can read
@@ -507,7 +508,7 @@ func listenHold(t *testing.T) net.Listener {
 			}
 			go func() {
 				defer func() { _ = conn.Close() }()
-				time.Sleep(10 * time.Second)
+				_, _ = io.Copy(io.Discard, conn)
 			}()
 		}
 	}()
@@ -1210,8 +1211,7 @@ func startProxyOnFreePort(t *testing.T, cfg *config.Config) (string, func()) {
 	}()
 
 	// Wait for server to be ready, draining errCh to detect startup failures.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
+	testwait.For(t, 2*time.Second, func() bool {
 		select {
 		case startErr := <-errCh:
 			t.Fatalf("proxy Start() failed: %v", startErr)
@@ -1221,10 +1221,10 @@ func startProxyOnFreePort(t *testing.T, cfg *config.Config) (string, func()) {
 		conn, dialErr := d.DialContext(context.Background(), "tcp", addr)
 		if dialErr == nil {
 			_ = conn.Close()
-			break
+			return true
 		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		return false
+	}, "forward proxy listens on %s", addr)
 
 	cleanup := func() {
 		cancel()

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -1366,9 +1366,8 @@ func TestInterceptTunnel_ContextDeadline(t *testing.T) {
 	t.Cleanup(func() { _ = clientConn.Close() })
 
 	// Already-expired context forces handshake to fail with deadline.
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(5 * time.Millisecond) // ensure deadline passes
 
 	// Start interceptTunnel with the expired context. The TLS handshake
 	// should fail because the context deadline constrains the handshake.

--- a/internal/proxy/killswitch_port_test.go
+++ b/internal/proxy/killswitch_port_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 // doReq is a test helper that creates and executes an HTTP request with context.
@@ -251,19 +252,18 @@ func TestKillSwitchPortIsolation_DefaultBehavior(t *testing.T) {
 	// Wait for the server to start by polling /health.
 	// Use raw client.Get (not doReq) because connection refused is expected during startup.
 	client := &http.Client{Timeout: 5 * time.Second}
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
+	testwait.For(t, 2*time.Second, func() bool {
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
 			fmt.Sprintf("http://%s/health", addr), nil)
 		resp, reqErr := client.Do(req)
 		if reqErr == nil {
 			resp.Body.Close() //nolint:errcheck,gosec // test
 			if resp.StatusCode == http.StatusOK {
-				break
+				return true
 			}
 		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		return false
+	}, "proxy health endpoint on %s", addr)
 
 	// API route should be reachable on the main port.
 	resp := doReq(t, client, http.MethodGet,

--- a/internal/proxy/proxy_enterprise_test.go
+++ b/internal/proxy/proxy_enterprise_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/edition"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 
 	_ "github.com/luckyPipewrench/pipelock/enterprise/testinit"
 )
@@ -412,12 +413,20 @@ func TestAgentIdentityEndToEnd(t *testing.T) {
 		t.Fatalf("proxy.New: %v", err)
 	}
 	t.Cleanup(func() { p.Close() })
+	p.client.Transport = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if strings.HasPrefix(addr, "pastebin.com:") {
+				return (&net.Dialer{}).DialContext(ctx, network, strings.TrimPrefix(backend.URL, "http://"))
+			}
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		},
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/fetch", p.handleFetch)
 
 	// blocklisted URL (*.pastebin.com is in the default blocklist).
-	blockedURL := "https://pastebin.com/raw/abc"
+	blockedURL := "http://pastebin.com/raw/abc"
 	// allowed URL (the test backend, which is not blocklisted).
 	allowedURL := backend.URL + "/text"
 
@@ -874,14 +883,12 @@ func TestAgentListenerBinding(t *testing.T) {
 func waitForListener(t *testing.T, addr string) {
 	t.Helper()
 	d := net.Dialer{Timeout: 100 * time.Millisecond}
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
+	testwait.For(t, 3*time.Second, func() bool {
 		conn, err := d.DialContext(context.Background(), "tcp", addr)
 		if err == nil {
 			_ = conn.Close()
-			return
+			return true
 		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("listener %s did not start within 3s", addr)
+		return false
+	}, "listener %s starts", addr)
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	"github.com/luckyPipewrench/pipelock/internal/session"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 const (
@@ -76,7 +77,11 @@ func setupTestProxy(t *testing.T) (*Proxy, *httptest.Server) {
 			w.Header().Set("Content-Type", "text/plain")
 			_, _ = fmt.Fprint(w, "Hello world")
 		case "/slow":
-			time.Sleep(5 * time.Second)
+			select {
+			case <-r.Context().Done():
+				return
+			case <-time.After(5 * time.Second):
+			}
 			_, _ = fmt.Fprint(w, "too slow")
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -2723,9 +2728,6 @@ func TestProxy_StartAndShutdown(t *testing.T) {
 		errCh <- p.Start(ctx)
 	}()
 
-	// Give the server a moment to start
-	time.Sleep(100 * time.Millisecond)
-
 	// Cancel context to trigger shutdown
 	cancel()
 
@@ -5070,14 +5072,14 @@ func TestProxy_RegisterAndShutdownAgentServers(t *testing.T) {
 	// Wait for server to be serving.
 	addr := ln.Addr().String()
 	dialer := &net.Dialer{Timeout: 50 * time.Millisecond}
-	for i := 0; i < 50; i++ {
+	testwait.For(t, time.Second, func() bool {
 		conn, dialErr := dialer.DialContext(context.Background(), "tcp4", addr)
 		if dialErr == nil {
 			_ = conn.Close()
-			break
+			return true
 		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		return false
+	}, "agent server listens on %s", addr)
 
 	// ShutdownAgentServers should cleanly stop it.
 	p.ShutdownAgentServers()

--- a/internal/proxy/receipt_coverage_test.go
+++ b/internal/proxy/receipt_coverage_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 // Test-scoped constants to avoid goconst triggers.
@@ -83,8 +84,7 @@ const waitForReceiptTimeout = 2 * time.Second
 // been persisted. Callers can then Close() the recorder and extract.
 func waitForReceiptOrTimeout(t *testing.T, dir string) {
 	t.Helper()
-	deadline := time.Now().Add(waitForReceiptTimeout)
-	for time.Now().Before(deadline) {
+	testwait.For(t, waitForReceiptTimeout, func() bool {
 		entries, _ := os.ReadDir(filepath.Clean(dir))
 		for _, e := range entries {
 			if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
@@ -92,11 +92,11 @@ func waitForReceiptOrTimeout(t *testing.T, dir string) {
 			}
 			info, err := e.Info()
 			if err == nil && info.Size() > 0 {
-				return
+				return true
 			}
 		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		return false
+	}, "receipt JSONL in %s", dir)
 }
 
 // newCoverageEmitter creates a recorder and emitter pair for coverage tests.

--- a/internal/proxy/reload_scanner_lifecycle_test.go
+++ b/internal/proxy/reload_scanner_lifecycle_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 // reloadStateMatrix exercises the five reload states required by
@@ -150,14 +151,9 @@ func TestProxy_Reload_DrainsBeforeClose(t *testing.T) {
 	// proves the close goroutine actually completed rather than relying
 	// solely on the earlier mid-drain BeginUse rejection.
 	release()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if initialSc.Drained() {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatal("Close goroutine did not finish draining initialSc within 2s of release")
+	testwait.For(t, 2*time.Second, func() bool {
+		return initialSc.Drained()
+	}, "initial scanner close goroutine to finish draining")
 }
 
 // waitForClosed polls Closed() until it returns true or the timeout
@@ -166,14 +162,9 @@ func TestProxy_Reload_DrainsBeforeClose(t *testing.T) {
 // drain begins, so this should resolve in microseconds for an idle test.
 func waitForClosed(t *testing.T, sc *scanner.Scanner, label string) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if sc.Closed() {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatalf("%s did not reach Closed=true within deadline", label)
+	testwait.For(t, 2*time.Second, func() bool {
+		return sc.Closed()
+	}, "%s to reach Closed=true", label)
 }
 
 // TestReverseProxy_EmitReceipt_NilGuards exercises the no-op paths of

--- a/internal/proxy/reverse_submit_test.go
+++ b/internal/proxy/reverse_submit_test.go
@@ -350,8 +350,12 @@ func TestSubmitProfile_CleanRequestForwards(t *testing.T) {
 }
 
 func TestSubmitProfile_RequestTimeoutApplied(t *testing.T) {
-	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(1500 * time.Millisecond)
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(1500 * time.Millisecond):
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer upstream.Close()

--- a/internal/proxy/session_operator_test.go
+++ b/internal/proxy/session_operator_test.go
@@ -54,13 +54,14 @@ func TestAirlockState_EnteredAt(t *testing.T) {
 	}
 
 	// Transition to hard updates enteredAt.
-	time.Sleep(5 * time.Millisecond)
+	beforeHard := time.Now()
 	if changed, _, _ := a.SetTier(config.AirlockTierHard); !changed {
 		t.Fatal("expected transition")
 	}
+	afterHard := time.Now()
 	newTs := a.EnteredAt()
-	if !newTs.After(got) {
-		t.Errorf("EnteredAt after hard transition should advance: got %v, prev %v", newTs, got)
+	if newTs.Before(beforeHard) || newTs.After(afterHard) {
+		t.Errorf("EnteredAt after hard transition: got %v, want within [%v, %v]", newTs, beforeHard, afterHard)
 	}
 }
 

--- a/internal/proxy/session_test.go
+++ b/internal/proxy/session_test.go
@@ -179,10 +179,11 @@ func TestSessionManager_MaxSessions_EvictsOldestIdle(t *testing.T) {
 	sm := NewSessionManager(cfg, nil, nil)
 	defer sm.Close()
 
-	// Create two sessions
-	sm.GetOrCreate("old")
-	time.Sleep(time.Millisecond) // ensure time difference
-	sm.GetOrCreate("new")
+	// Create two sessions with deterministic activity order.
+	oldSess := sm.GetOrCreate("old")
+	newSess := sm.GetOrCreate("new")
+	setSessionLastActivity(t, oldSess, time.Now().Add(-time.Minute))
+	setSessionLastActivity(t, newSess, time.Now())
 
 	// 3rd session evicts "old" (oldest lastActivity)
 	sm.GetOrCreate("newest")
@@ -897,9 +898,7 @@ func TestSessionManager_EvictOldest_EscalatedGaugeDecrement(t *testing.T) {
 	}
 
 	// Ensure "escalated-session" has older lastActivity than "second-session".
-	// RecordSignal doesn't update lastActivity, so we just need to ensure the
-	// second session is created after with a newer timestamp.
-	time.Sleep(time.Millisecond)
+	setSessionLastActivity(t, sess, time.Now().Add(-time.Minute))
 	sm.GetOrCreate("second-session")
 
 	// Adding a third session when at capacity evicts "escalated-session"
@@ -1122,14 +1121,13 @@ func TestSessionState_CriticalNoActivityRefresh(t *testing.T) {
 
 	// Simulate proxy setting block_all flag after escalation.
 	sess.SetBlockAll(true)
+	setSessionLastActivity(t, sess, time.Now().Add(-time.Minute))
 
 	// Record the last activity time.
 	sess.mu.Lock()
 	activityBefore := sess.lastActivity
 	sess.mu.Unlock()
 
-	// Wait a moment, then RecordRequest at block_all.
-	time.Sleep(10 * time.Millisecond)
 	sess.RecordRequest("example.com", cfg)
 
 	sess.mu.Lock()
@@ -1156,12 +1154,12 @@ func TestSessionState_SubCriticalActivityRefresh(t *testing.T) {
 	if sess.EscalationLevel() < 1 || sess.EscalationLevel() >= 3 {
 		t.Fatalf("expected level 1-2, got %d", sess.EscalationLevel())
 	}
+	setSessionLastActivity(t, sess, time.Now().Add(-time.Minute))
 
 	sess.mu.Lock()
 	activityBefore := sess.lastActivity
 	sess.mu.Unlock()
 
-	time.Sleep(10 * time.Millisecond)
 	sess.RecordRequest("example.com", cfg)
 
 	sess.mu.Lock()
@@ -1172,6 +1170,13 @@ func TestSessionState_SubCriticalActivityRefresh(t *testing.T) {
 	if !activityAfter.After(activityBefore) {
 		t.Error("lastActivity should be refreshed at sub-critical escalation levels")
 	}
+}
+
+func setSessionLastActivity(t *testing.T, sess *SessionState, at time.Time) {
+	t.Helper()
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	sess.lastActivity = at
 }
 
 func TestSessionManager_CleanupLoop_DoneStops(t *testing.T) {

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	"github.com/luckyPipewrench/pipelock/internal/session"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 	plwsutil "github.com/luckyPipewrench/pipelock/internal/wsutil"
 )
 
@@ -3557,28 +3558,20 @@ func TestWSRelay_KillSwitch_UpstreamToClient(t *testing.T) {
 	// relay→backend handshake can be slow under load.
 	var conn net.Conn
 	var reply []byte
-	const maxAttempts = 10
-	for attempt := range maxAttempts {
+	testwait.For(t, 10*time.Second, func() bool {
 		c, dialErr := dialWSConn(proxyAddr, backendAddr)
 		if dialErr != nil {
-			if attempt == maxAttempts-1 {
-				t.Fatalf("dial/read initial frame after %d attempts: dial error: %v", maxAttempts, dialErr)
-			}
-			time.Sleep(250 * time.Millisecond)
-			continue
+			return false
 		}
 		r, _, readErr := wsutil.ReadServerData(c)
 		if readErr == nil && string(r) == testWSHello {
 			conn = c
 			reply = r
-			break
+			return true
 		}
 		_ = c.Close()
-		if attempt == maxAttempts-1 {
-			t.Fatalf("read initial frame after %d attempts: last error: %v", maxAttempts, readErr)
-		}
-		time.Sleep(250 * time.Millisecond)
-	}
+		return false
+	}, "dial/read initial WebSocket frame from %s via %s", backendAddr, proxyAddr)
 	_ = reply // used in assertion above
 	defer func() { _ = conn.Close() }()
 

--- a/internal/sandbox/bridge.go
+++ b/internal/sandbox/bridge.go
@@ -32,6 +32,9 @@ type BridgeProxy struct {
 	listener   net.Listener
 	socketPath string // parent's Unix domain socket path
 	wg         sync.WaitGroup
+	mu         sync.Mutex
+	closed     bool
+	closeOnce  sync.Once
 }
 
 // NewBridgeProxy creates a bridge proxy inside the sandbox namespace.
@@ -70,7 +73,14 @@ func (bp *BridgeProxy) Serve(ctx context.Context) {
 		if err != nil {
 			return // listener closed
 		}
+		bp.mu.Lock()
+		if bp.closed {
+			bp.mu.Unlock()
+			_ = conn.Close()
+			return
+		}
 		bp.wg.Add(1)
+		bp.mu.Unlock()
 		go func() {
 			defer bp.wg.Done()
 			bp.handleConn(conn)
@@ -80,8 +90,13 @@ func (bp *BridgeProxy) Serve(ctx context.Context) {
 
 // Close shuts down the proxy and waits for active connections.
 func (bp *BridgeProxy) Close() {
-	_ = bp.listener.Close()
-	bp.wg.Wait()
+	bp.closeOnce.Do(func() {
+		bp.mu.Lock()
+		bp.closed = true
+		_ = bp.listener.Close()
+		bp.mu.Unlock()
+		bp.wg.Wait()
+	})
 }
 
 // handleConn bridges a single TCP connection from the sandbox to the

--- a/internal/sandbox/launcher_test.go
+++ b/internal/sandbox/launcher_test.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestLaunchSandboxed_EchoCommand(t *testing.T) {
@@ -244,9 +243,6 @@ func TestLaunchSandboxed_ChildCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LaunchSandboxed: %v", err)
 	}
-
-	// Give child time to start.
-	time.Sleep(100 * time.Millisecond)
 
 	// Kill the child process.
 	if cmd.Process != nil {

--- a/internal/scanner/entropy_tracker_test.go
+++ b/internal/scanner/entropy_tracker_test.go
@@ -137,8 +137,7 @@ func TestEntropyTrackerWindowExpiry(t *testing.T) {
 		t.Fatal("expected non-zero usage immediately after recording")
 	}
 
-	// Wait for the window to expire.
-	time.Sleep(1200 * time.Millisecond) // 1.2s: comfortably past the 1s window
+	expireEntropyEntries(t, et, testSessionKey)
 
 	usage = et.CurrentUsage(testSessionKey)
 	if usage != 0 {
@@ -273,8 +272,8 @@ func TestEntropyTrackerCleanup(t *testing.T) {
 		t.Fatal("expected non-zero usage for session 2 immediately after recording")
 	}
 
-	// Wait for the window to expire.
-	time.Sleep(1200 * time.Millisecond) // 1.2s: comfortably past the 1s window
+	expireEntropyEntries(t, et, testSessionKey)
+	expireEntropyEntries(t, et, testSessionKey2)
 
 	// Call cleanup directly to evict expired entries without waiting
 	// for the 60-second cleanup ticker.
@@ -299,7 +298,7 @@ func TestEntropyTrackerCleanup_RetainsValidEntries(t *testing.T) {
 
 	// Record old data, let it expire.
 	et.Record(testSessionKey, []byte("old data that will expire"))
-	time.Sleep(2200 * time.Millisecond) // 2.2s: past the 2s window
+	expireEntropyEntries(t, et, testSessionKey)
 
 	// Record fresh data for session 2 (still within window).
 	et.Record(testSessionKey2, []byte("fresh data still valid"))
@@ -395,8 +394,7 @@ func TestEntropyTrackerInlinePruning(t *testing.T) {
 	// Record initial data.
 	et.Record(testSessionKey, []byte("data that will expire"))
 
-	// Wait for expiry.
-	time.Sleep(1200 * time.Millisecond)
+	expireEntropyEntries(t, et, testSessionKey)
 
 	// Record again on same session. Inline pruning should remove expired entries.
 	et.Record(testSessionKey, []byte("fresh data"))
@@ -410,4 +408,19 @@ func TestEntropyTrackerInlinePruning(t *testing.T) {
 	if entryCount != 1 {
 		t.Fatalf("expected 1 entry after inline pruning, got %d", entryCount)
 	}
+}
+
+func expireEntropyEntries(t *testing.T, et *EntropyTracker, sessionKey string) {
+	t.Helper()
+	et.mu.Lock()
+	defer et.mu.Unlock()
+	sess := et.sessions[sessionKey]
+	if sess == nil {
+		t.Fatalf("session %q missing", sessionKey)
+	}
+	expiredAt := time.Now().Add(-time.Duration(et.windowSecs+1) * time.Second)
+	for i := range sess.entries {
+		sess.entries[i].timestamp = expiredAt
+	}
+	sess.lastAccess = expiredAt
 }

--- a/internal/scanner/lifecycle_test.go
+++ b/internal/scanner/lifecycle_test.go
@@ -4,12 +4,14 @@
 package scanner_test
 
 import (
+	"runtime"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 // TestScanner_BeginUse_OkBeforeClose verifies the happy path: BeginUse
@@ -150,14 +152,7 @@ func TestScanner_Close_DrainTimeoutDefersTeardown(t *testing.T) {
 	// Releasing the hung user lets the detached goroutine finish drain
 	// and run teardown; Drained flips shortly afterwards.
 	release()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if sc.Drained() {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatal("Drained() did not flip after hung user released")
+	testwait.For(t, 2*time.Second, sc.Drained, "scanner drained after hung user release")
 }
 
 // TestScanner_Close_Idempotent verifies repeated Close calls are safe
@@ -189,7 +184,7 @@ func TestScanner_BeginUse_RaceFree(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			if release, ok := sc.BeginUse(); ok {
-				time.Sleep(time.Microsecond)
+				runtime.Gosched()
 				release()
 			}
 		}()

--- a/internal/testwait/testwait.go
+++ b/internal/testwait/testwait.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package testwait
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+const defaultInterval = 5 * time.Millisecond
+
+// For polls cond until it returns true or timeout elapses.
+func For(t testing.TB, timeout time.Duration, cond func() bool, format string, args ...any) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ForContext(t, ctx, cond, format, args...)
+}
+
+// ForContext polls cond until it returns true or ctx is done.
+func ForContext(t testing.TB, ctx context.Context, cond func() bool, format string, args ...any) {
+	t.Helper()
+	if cond() {
+		return
+	}
+	ticker := time.NewTicker(defaultInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			if cond() {
+				return
+			}
+			t.Fatalf("timed out waiting for %s: %v", fmt.Sprintf(format, args...), ctx.Err())
+		case <-ticker.C:
+			if cond() {
+				return
+			}
+		}
+	}
+}

--- a/internal/testwait/testwait_test.go
+++ b/internal/testwait/testwait_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package testwait
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestForReturnsWhenConditionAlreadyTrue(t *testing.T) {
+	calls := 0
+	For(t, time.Second, func() bool {
+		calls++
+		return true
+	}, "already true")
+	if calls != 1 {
+		t.Fatalf("condition calls = %d, want 1", calls)
+	}
+}
+
+func TestForContextPollsUntilConditionTrue(t *testing.T) {
+	calls := 0
+	ForContext(t, context.Background(), func() bool {
+		calls++
+		return calls >= 2
+	}, "eventual true")
+	if calls < 2 {
+		t.Fatalf("condition calls = %d, want at least 2", calls)
+	}
+}
+
+func TestForContextChecksConditionAfterContextDone(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	ForContext(t, ctx, func() bool {
+		calls++
+		return calls >= 2
+	}, "true on final check")
+	if calls != 2 {
+		t.Fatalf("condition calls = %d, want 2", calls)
+	}
+}

--- a/scripts/check-test-stability.sh
+++ b/scripts/check-test-stability.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tripwire: forbid the two flaky-test root causes (fixed wall-clock sleeps and
+# fixed local ports) from re-entering the test suite. Runs in CI and via
+# `make lint`, so it must FAIL CLOSED: a runner that cannot actually scan has
+# to error loudly, never report "clean" by scanning nothing.
+
+# Fail closed if ripgrep is missing. The scans below would otherwise behave as
+# "no match" when `rg` is absent (exit 127 swallowed) and silently pass,
+# defeating the entire point of the gate. Mirrors scripts/release-audit.sh.
+if ! command -v rg >/dev/null 2>&1; then
+  echo "check-test-stability: ripgrep (rg) is required and is not on PATH." >&2
+  echo "Install ripgrep (e.g., apt-get install -y ripgrep) before running this check." >&2
+  exit 127
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Roots scanned for *_test.go. Repo-wide so the no-sleep / no-fixed-port rule
+# is not silently scoped to a subtree: enterprise/ is the highest-concurrency
+# code in the tree and must be covered.
+roots=(internal cmd enterprise sdk bench)
+
+allowlist="scripts/test-stability-allowlist.txt"
+status=0
+
+filter_allowlist() {
+  if [[ -f "$allowlist" ]]; then
+    grep -F -x -v -f <(grep -vE '^[[:space:]]*(#|$)' "$allowlist") || true
+  else
+    cat
+  fi
+}
+
+# scan runs ripgrep and leaves the allowlist-filtered matches in scan_result.
+# It distinguishes "no matches" (rg exit 1, clean) from a real search error
+# (exit >=2) and exits the whole script on the latter — `|| true` alone would
+# mask exit 2 as clean, the fail-open trap this gate exists to prevent. Called
+# as a statement (not in a $() subshell) so `exit` terminates the script.
+scan_result=""
+scan() {
+  local out rc
+  set +e
+  out="$(rg -n "$@" "${roots[@]}" --glob '*_test.go')"
+  rc=$?
+  set -e
+  if [[ "$rc" -gt 1 ]]; then
+    echo "check-test-stability: ripgrep exited with $rc while running: rg $* ${roots[*]}" >&2
+    echo "The stability gate must fail closed on scan errors, not pass with zero scans." >&2
+    exit "$rc"
+  fi
+  scan_result="$(printf '%s' "$out" | filter_allowlist)"
+}
+
+scan 'time\.Sleep\('
+if [[ -n "$scan_result" ]]; then
+  echo "check-test-stability: time.Sleep is forbidden in tests; use testwait, channels, or a fake clock." >&2
+  echo "$scan_result" >&2
+  status=1
+fi
+
+scan 'Listen(Context)?\([^)]*"(tcp|tcp4|tcp6)"[^)]*"(127\.0\.0\.1|0\.0\.0\.0|localhost|\[::1\]|:)[^"]*:[1-9][0-9]*"'
+if [[ -n "$scan_result" ]]; then
+  echo "check-test-stability: fixed local ports in test Listen calls are forbidden; bind :0 and read back the assigned address." >&2
+  echo "$scan_result" >&2
+  status=1
+fi
+
+exit "$status"

--- a/scripts/test-stability-allowlist.txt
+++ b/scripts/test-stability-allowlist.txt
@@ -1,0 +1,4 @@
+# Exact findings allowed by scripts/check-test-stability.sh.
+# Format: paste the full `path:line:source` finding emitted by the check.
+# Keep this empty unless a test genuinely validates elapsed wall-clock behavior
+# and cannot use a fake clock, channel, or observable condition wait.

--- a/sdk/conformance/pyverify-requirements.txt
+++ b/sdk/conformance/pyverify-requirements.txt
@@ -2,13 +2,14 @@
 # installed in the cross-language conformance gate (.github/workflows/verifiers.yaml).
 #
 # Scorecard "Pinned-Dependencies" requires CI pip installs to be hash-pinned.
-# The verifier itself is installed with `pip install --no-deps .` from its
-# pinned git checkout; its only runtime dependency is cryptography>=48.0.0,
-# whose transitive tree (cffi -> pycparser) is locked here with hashes.
+# Runtime dependency cryptography and its transitive tree are locked here.
+# The pinned verifier checkout is installed with --no-deps and
+# --no-build-isolation, so the setuptools build backend and wheel are also
+# pinned here instead of being fetched into an isolated build env.
 #
-# Regenerate after a cryptography bump:
-#   echo 'cryptography>=48.0.0' > req.in
-#   pip-compile --generate-hashes --no-header --strip-extras -o pyverify-requirements.txt req.in
+# Regenerate after a cryptography/build-backend bump:
+#   uv pip compile --generate-hashes --no-header --annotation-style split \
+#     -o pyverify-requirements.txt pyverify-requirements.in
 cffi==2.0.0 \
     --hash=sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb \
     --hash=sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b \
@@ -145,8 +146,20 @@ cryptography==48.0.0 \
     --hash=sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb \
     --hash=sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c \
     --hash=sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b
-    # via -r /tmp/pyverify-req.in
+    # via -r pyverify-requirements.in
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
+    # via wheel
 pycparser==3.0 \
     --hash=sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29 \
     --hash=sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
     # via cffi
+setuptools==82.0.1 \
+    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
+    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+    # via -r pyverify-requirements.in
+wheel==0.47.0 \
+    --hash=sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced \
+    --hash=sha256:cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3
+    # via -r pyverify-requirements.in


### PR DESCRIPTION
## Summary
- add a fail-closed test stability gate for `time.Sleep` and fixed local test ports, wired into CI and `make lint`
- add a shared `testwait` helper and convert sleep-based waits to observable readiness or condition waits across core and enterprise tests
- tighten config reloader lifecycle behavior so `Start` is explicitly one-shot and cannot reach double-close paths on a second call
- pin Python verifier build requirements and install with `--no-build-isolation` so CI does not fetch unpinned build dependencies

## Testing
- `bash scripts/check-test-stability.sh`
- `env PATH=/nonexistent /bin/bash scripts/check-test-stability.sh` exits `127` as expected
- `go test -race -count=1 ./internal/config`
- `go test -race -count=10 -tags enterprise ./enterprise/conductor/auditbatcher ./enterprise/licenseservice`
- `golangci-lint run ./...`
- `go test -race -count=1 ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now enforces a test-stability gate and new shared polling utilities for deterministic waits.

* **Bug Fixes**
  * Reduced test flakes and races; more reliable shutdowns, reloads, network paths, and hot-reload behaviors.

* **Refactor**
  * Replaced many sleep-based timings with event-driven polling across tests.
  * Added readiness and one-shot/startup/shutdown synchronization to improve concurrency safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->