### PR TITLE
Harden conductor audit ingest idempotency and lookup

### DIFF
--- a/enterprise/conductor/controlplane/audit_ingest.go
+++ b/enterprise/conductor/controlplane/audit_ingest.go
@@ -128,13 +128,17 @@ func (h *Handler) handleAuditBatch(w http.ResponseWriter, r *http.Request) {
 	if status == "" {
 		status = AuditIngestStatusAccepted
 	}
+	responseAcceptedAt := acceptedAt
+	if !result.Summary.ReceivedAt.IsZero() {
+		responseAcceptedAt = result.Summary.ReceivedAt
+	}
 	writeJSON(w, http.StatusAccepted, ingestAuditBatchResponse{
 		Status:       string(status),
 		BatchID:      req.Envelope.BatchID,
 		EnvelopeHash: envelopeHash,
 		SeqStart:     req.Envelope.SeqStart,
 		SeqEnd:       req.Envelope.SeqEnd,
-		AcceptedAt:   acceptedAt,
+		AcceptedAt:   responseAcceptedAt,
 	})
 }
 

--- a/enterprise/conductor/controlplane/audit_ingest.go
+++ b/enterprise/conductor/controlplane/audit_ingest.go
@@ -32,18 +32,24 @@ type AuditKeyResolver func(FollowerIdentity, string) (conductor.SignatureKey, er
 
 // AuditBatchSink receives audit batches after transport identity, payload hash,
 // clock skew, and follower audit-batch signature checks have all passed.
-//
-// This MVP layer does NOT deduplicate batches. A previously accepted signed
-// envelope presented again with the same authenticated follower identity can be
-// accepted up to [conductor.DefaultAuditMaxSkew] after its EmittedAt timestamp
-// (skew is the only at-this-layer replay defense).
-// Sinks that need exactly-once semantics, such as durable central storage, fork
-// detection, or indexing, MUST implement their own idempotency on
-// (BatchID, EnvelopeHash) or (OrgID, FleetID, InstanceID, SeqStart, SeqEnd).
+// Durable sinks MUST keep ingest idempotent for byte-identical retries while
+// rejecting same-identity divergent content as a fork or conflict.
 // Each accepted batch arrives with a fresh Payload copy detached from the
 // request body, so sinks may retain the slice without further copying.
 type AuditBatchSink interface {
-	IngestAuditBatch(context.Context, AcceptedAuditBatch) error
+	IngestAuditBatch(context.Context, AcceptedAuditBatch) (AuditIngestResult, error)
+}
+
+type AuditIngestStatus string
+
+const (
+	AuditIngestStatusAccepted  AuditIngestStatus = "accepted"
+	AuditIngestStatusDuplicate AuditIngestStatus = "duplicate"
+)
+
+type AuditIngestResult struct {
+	Status  AuditIngestStatus
+	Summary AuditBatchSummary
 }
 
 type AcceptedAuditBatch struct {
@@ -60,6 +66,7 @@ type ingestAuditBatchRequest struct {
 }
 
 type ingestAuditBatchResponse struct {
+	Status       string    `json:"status"`
 	BatchID      string    `json:"batch_id"`
 	EnvelopeHash string    `json:"envelope_hash"`
 	SeqStart     uint64    `json:"seq_start"`
@@ -106,17 +113,23 @@ func (h *Handler) handleAuditBatch(w http.ResponseWriter, r *http.Request) {
 		writeAuditIngestError(w, err)
 		return
 	}
-	if err := h.auditSink.IngestAuditBatch(r.Context(), AcceptedAuditBatch{
+	result, err := h.auditSink.IngestAuditBatch(r.Context(), AcceptedAuditBatch{
 		Identity:     identity,
 		Envelope:     req.Envelope,
 		EnvelopeHash: envelopeHash,
 		Payload:      append([]byte(nil), req.Payload...),
 		ReceivedAt:   acceptedAt,
-	}); err != nil {
+	})
+	if err != nil {
 		writeAuditSinkError(w, err)
 		return
 	}
+	status := result.Status
+	if status == "" {
+		status = AuditIngestStatusAccepted
+	}
 	writeJSON(w, http.StatusAccepted, ingestAuditBatchResponse{
+		Status:       string(status),
 		BatchID:      req.Envelope.BatchID,
 		EnvelopeHash: envelopeHash,
 		SeqStart:     req.Envelope.SeqStart,

--- a/enterprise/conductor/controlplane/audit_ingest_test.go
+++ b/enterprise/conductor/controlplane/audit_ingest_test.go
@@ -367,16 +367,26 @@ func TestAuditIngestIncompleteIdentityReturns401(t *testing.T) {
 func TestAuditIngestReplayWithinSkewWindowReportsDuplicate(t *testing.T) {
 	payload := []byte(`{"entry":"ok"}`)
 	pub, priv := testAuditSigner(t)
+	storedAt := testNow.Add(-time.Minute)
 	sink := &captureAuditSink{
 		results: []AuditIngestResult{
 			{Status: AuditIngestStatusAccepted},
-			{Status: AuditIngestStatusDuplicate},
+			{
+				Status:  AuditIngestStatusDuplicate,
+				Summary: AuditBatchSummary{ReceivedAt: storedAt},
+			},
 		},
 	}
 	handler := newAuditIngestTestHandler(t, sink, auditKeyResolverFor(pub), 0)
 	req := signedAuditIngestRequest(t, defaultFollowerIdentity(), payload, priv, testNow)
 
-	for i, wantStatus := range []AuditIngestStatus{AuditIngestStatusAccepted, AuditIngestStatusDuplicate} {
+	for i, want := range []struct {
+		status     AuditIngestStatus
+		acceptedAt time.Time
+	}{
+		{status: AuditIngestStatusAccepted, acceptedAt: testNow},
+		{status: AuditIngestStatusDuplicate, acceptedAt: storedAt},
+	} {
 		w := postAuditBatch(t, handler, req)
 		if w.Code != http.StatusAccepted {
 			t.Fatalf("replay #%d status = %d body=%s, want 202", i, w.Code, w.Body.String())
@@ -385,8 +395,11 @@ func TestAuditIngestReplayWithinSkewWindowReportsDuplicate(t *testing.T) {
 		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
 			t.Fatalf("decode replay response: %v", err)
 		}
-		if got.Status != string(wantStatus) {
-			t.Fatalf("replay #%d status = %q, want %q", i, got.Status, wantStatus)
+		if got.Status != string(want.status) {
+			t.Fatalf("replay #%d status = %q, want %q", i, got.Status, want.status)
+		}
+		if !got.AcceptedAt.Equal(want.acceptedAt) {
+			t.Fatalf("replay #%d accepted_at = %s, want %s", i, got.AcceptedAt, want.acceptedAt)
 		}
 	}
 	if len(sink.batches) != 2 {

--- a/enterprise/conductor/controlplane/audit_ingest_test.go
+++ b/enterprise/conductor/controlplane/audit_ingest_test.go
@@ -53,6 +53,9 @@ func TestHandlerIngestsSignedAuditBatch(t *testing.T) {
 	if resp.BatchID != got.Envelope.BatchID || resp.EnvelopeHash != got.EnvelopeHash || resp.SeqStart != 10 || resp.SeqEnd != 10 {
 		t.Fatalf("response = %+v, sink hash=%q", resp, got.EnvelopeHash)
 	}
+	if resp.Status != "accepted" {
+		t.Fatalf("response status = %q, want accepted", resp.Status)
+	}
 }
 
 func TestHandlerRejectsInvalidAuditBatch(t *testing.T) {
@@ -361,27 +364,33 @@ func TestAuditIngestIncompleteIdentityReturns401(t *testing.T) {
 	}
 }
 
-// TestAuditIngestReplayWithinSkewWindowSucceeds locks in the documented
-// behavior that this MVP layer does NOT deduplicate. Two identical signed
-// batches within the skew window both result in 202 + sink ingest. If a
-// future change ever wires per-handler dedup, that change must also revise
-// the AuditBatchSink doc comment (which currently tells sinks to handle
-// idempotency themselves).
-func TestAuditIngestReplayWithinSkewWindowSucceeds(t *testing.T) {
+func TestAuditIngestReplayWithinSkewWindowReportsDuplicate(t *testing.T) {
 	payload := []byte(`{"entry":"ok"}`)
 	pub, priv := testAuditSigner(t)
-	sink := &captureAuditSink{}
+	sink := &captureAuditSink{
+		results: []AuditIngestResult{
+			{Status: AuditIngestStatusAccepted},
+			{Status: AuditIngestStatusDuplicate},
+		},
+	}
 	handler := newAuditIngestTestHandler(t, sink, auditKeyResolverFor(pub), 0)
 	req := signedAuditIngestRequest(t, defaultFollowerIdentity(), payload, priv, testNow)
 
-	for i := range 3 {
+	for i, wantStatus := range []AuditIngestStatus{AuditIngestStatusAccepted, AuditIngestStatusDuplicate} {
 		w := postAuditBatch(t, handler, req)
 		if w.Code != http.StatusAccepted {
 			t.Fatalf("replay #%d status = %d body=%s, want 202", i, w.Code, w.Body.String())
 		}
+		var got ingestAuditBatchResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode replay response: %v", err)
+		}
+		if got.Status != string(wantStatus) {
+			t.Fatalf("replay #%d status = %q, want %q", i, got.Status, wantStatus)
+		}
 	}
-	if len(sink.batches) != 3 {
-		t.Fatalf("sink batch count after replays = %d, want 3 (this layer does not dedup)", len(sink.batches))
+	if len(sink.batches) != 2 {
+		t.Fatalf("sink batch count after replays = %d, want 2", len(sink.batches))
 	}
 }
 
@@ -438,29 +447,35 @@ func TestAuditIngestSinkCanRetainPayload(t *testing.T) {
 
 type nonCopyingAuditSink struct{ batches []AcceptedAuditBatch }
 
-func (s *nonCopyingAuditSink) IngestAuditBatch(_ context.Context, batch AcceptedAuditBatch) error {
+func (s *nonCopyingAuditSink) IngestAuditBatch(_ context.Context, batch AcceptedAuditBatch) (AuditIngestResult, error) {
 	s.batches = append(s.batches, batch)
-	return nil
+	return AuditIngestResult{Status: AuditIngestStatusAccepted}, nil
 }
 
 type discardAuditSink struct{}
 
-func (discardAuditSink) IngestAuditBatch(context.Context, AcceptedAuditBatch) error {
-	return nil
+func (discardAuditSink) IngestAuditBatch(context.Context, AcceptedAuditBatch) (AuditIngestResult, error) {
+	return AuditIngestResult{Status: AuditIngestStatusAccepted}, nil
 }
 
 type captureAuditSink struct {
 	batches []AcceptedAuditBatch
+	results []AuditIngestResult
 	err     error
 }
 
-func (s *captureAuditSink) IngestAuditBatch(_ context.Context, batch AcceptedAuditBatch) error {
+func (s *captureAuditSink) IngestAuditBatch(_ context.Context, batch AcceptedAuditBatch) (AuditIngestResult, error) {
 	if s.err != nil {
-		return s.err
+		return AuditIngestResult{}, s.err
 	}
 	batch.Payload = append([]byte(nil), batch.Payload...)
 	s.batches = append(s.batches, batch)
-	return nil
+	if len(s.results) > 0 {
+		result := s.results[0]
+		s.results = s.results[1:]
+		return result, nil
+	}
+	return AuditIngestResult{Status: AuditIngestStatusAccepted}, nil
 }
 
 func rejectingAuditKeyResolver(FollowerIdentity, string) (conductor.SignatureKey, error) {

--- a/enterprise/conductor/controlplane/audit_query.go
+++ b/enterprise/conductor/controlplane/audit_query.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
 )
@@ -19,6 +20,7 @@ import (
 // behind the storage backend's operator-controlled access boundary.
 type AuditBatchQuerier interface {
 	ListAuditBatches(ctx context.Context, q AuditBatchQuery) ([]AuditBatchSummary, error)
+	GetAuditBatch(ctx context.Context, orgID, fleetID, instanceID, batchID string) (AuditBatchSummary, bool, error)
 }
 
 type listAuditBatchesResponse struct {
@@ -53,6 +55,40 @@ func (h *Handler) handleListAuditBatches(w http.ResponseWriter, r *http.Request)
 		Batches: batches,
 		Count:   len(batches),
 	})
+}
+
+func (h *Handler) handleGetAuditBatch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+	if h.auditQuerier == nil {
+		writeError(w, http.StatusNotImplemented, errors.New("audit query not supported by configured audit sink"))
+		return
+	}
+	query, err := parseAuditBatchGetQuery(r)
+	if err != nil {
+		if errors.Is(err, ErrAuditBatchNotFound) {
+			writeError(w, http.StatusNotFound, ErrAuditBatchNotFound)
+			return
+		}
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := h.authorizeAuditQuery(r, query); err != nil {
+		writeError(w, http.StatusForbidden, ErrAuditQueryForbidden)
+		return
+	}
+	batch, ok, err := h.auditQuerier.GetAuditBatch(r.Context(), query.OrgID, query.FleetID, query.InstanceID, query.BatchID)
+	if err != nil {
+		writeAuditSinkError(w, err)
+		return
+	}
+	if !ok {
+		writeError(w, http.StatusNotFound, ErrAuditBatchNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, batch)
 }
 
 func parseAuditBatchQuery(r *http.Request) (AuditBatchQuery, error) {
@@ -97,6 +133,46 @@ func parseAuditBatchQuery(r *http.Request) (AuditBatchQuery, error) {
 			return AuditBatchQuery{}, fmt.Errorf("invalid limit query parameter: %q", rawLimit)
 		}
 		q.Limit = limit
+	}
+	return q, nil
+}
+
+func parseAuditBatchGetQuery(r *http.Request) (AuditBatchQuery, error) {
+	batchID := strings.TrimPrefix(r.URL.Path, AuditBatchesPath+"/")
+	if batchID == "" || strings.Contains(batchID, "/") {
+		return AuditBatchQuery{}, ErrAuditBatchNotFound
+	}
+	values := r.URL.Query()
+	for key, got := range values {
+		switch key {
+		case "org_id", "fleet_id", "instance_id":
+		default:
+			return AuditBatchQuery{}, fmt.Errorf("unknown query parameter: %s", key)
+		}
+		if len(got) > 1 {
+			return AuditBatchQuery{}, fmt.Errorf("duplicate query parameter: %s", key)
+		}
+	}
+	q := AuditBatchQuery{
+		OrgID:      values.Get("org_id"),
+		FleetID:    values.Get("fleet_id"),
+		InstanceID: values.Get("instance_id"),
+		BatchID:    batchID,
+	}
+	if q.OrgID == "" || q.FleetID == "" || q.InstanceID == "" {
+		return AuditBatchQuery{}, errors.New("org_id, fleet_id, and instance_id query parameters required")
+	}
+	for _, c := range []struct {
+		field, value string
+	}{
+		{"org_id", q.OrgID},
+		{"fleet_id", q.FleetID},
+		{"instance_id", q.InstanceID},
+		{"batch_id", q.BatchID},
+	} {
+		if err := conductor.ValidateIdentifier(c.field, c.value); err != nil {
+			return AuditBatchQuery{}, err
+		}
 	}
 	return q, nil
 }

--- a/enterprise/conductor/controlplane/audit_query.go
+++ b/enterprise/conductor/controlplane/audit_query.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -93,15 +94,8 @@ func (h *Handler) handleGetAuditBatch(w http.ResponseWriter, r *http.Request) {
 
 func parseAuditBatchQuery(r *http.Request) (AuditBatchQuery, error) {
 	values := r.URL.Query()
-	for key, got := range values {
-		switch key {
-		case "org_id", "fleet_id", "instance_id", "batch_id", "limit":
-		default:
-			return AuditBatchQuery{}, fmt.Errorf("unknown query parameter: %s", key)
-		}
-		if len(got) > 1 {
-			return AuditBatchQuery{}, fmt.Errorf("duplicate query parameter: %s", key)
-		}
+	if err := validateAuditQueryValues(values, "org_id", "fleet_id", "instance_id", "batch_id", "limit"); err != nil {
+		return AuditBatchQuery{}, err
 	}
 	q := AuditBatchQuery{
 		OrgID:      values.Get("org_id"),
@@ -112,20 +106,8 @@ func parseAuditBatchQuery(r *http.Request) (AuditBatchQuery, error) {
 	if q.OrgID == "" {
 		return AuditBatchQuery{}, errors.New("org_id query parameter required")
 	}
-	for _, c := range []struct {
-		field, value string
-	}{
-		{"org_id", q.OrgID},
-		{"fleet_id", q.FleetID},
-		{"instance_id", q.InstanceID},
-		{"batch_id", q.BatchID},
-	} {
-		if c.value == "" {
-			continue
-		}
-		if err := conductor.ValidateIdentifier(c.field, c.value); err != nil {
-			return AuditBatchQuery{}, err
-		}
+	if err := validateAuditQueryIdentifiers(q); err != nil {
+		return AuditBatchQuery{}, err
 	}
 	if rawLimit := values.Get("limit"); rawLimit != "" {
 		limit, err := strconv.Atoi(rawLimit)
@@ -143,15 +125,8 @@ func parseAuditBatchGetQuery(r *http.Request) (AuditBatchQuery, error) {
 		return AuditBatchQuery{}, ErrAuditBatchNotFound
 	}
 	values := r.URL.Query()
-	for key, got := range values {
-		switch key {
-		case "org_id", "fleet_id", "instance_id":
-		default:
-			return AuditBatchQuery{}, fmt.Errorf("unknown query parameter: %s", key)
-		}
-		if len(got) > 1 {
-			return AuditBatchQuery{}, fmt.Errorf("duplicate query parameter: %s", key)
-		}
+	if err := validateAuditQueryValues(values, "org_id", "fleet_id", "instance_id"); err != nil {
+		return AuditBatchQuery{}, err
 	}
 	q := AuditBatchQuery{
 		OrgID:      values.Get("org_id"),
@@ -162,6 +137,29 @@ func parseAuditBatchGetQuery(r *http.Request) (AuditBatchQuery, error) {
 	if q.OrgID == "" || q.FleetID == "" || q.InstanceID == "" {
 		return AuditBatchQuery{}, errors.New("org_id, fleet_id, and instance_id query parameters required")
 	}
+	if err := validateAuditQueryIdentifiers(q); err != nil {
+		return AuditBatchQuery{}, err
+	}
+	return q, nil
+}
+
+func validateAuditQueryValues(values url.Values, allowedKeys ...string) error {
+	allowed := make(map[string]struct{}, len(allowedKeys))
+	for _, key := range allowedKeys {
+		allowed[key] = struct{}{}
+	}
+	for key, got := range values {
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("unknown query parameter: %s", key)
+		}
+		if len(got) > 1 {
+			return fmt.Errorf("duplicate query parameter: %s", key)
+		}
+	}
+	return nil
+}
+
+func validateAuditQueryIdentifiers(q AuditBatchQuery) error {
 	for _, c := range []struct {
 		field, value string
 	}{
@@ -170,9 +168,12 @@ func parseAuditBatchGetQuery(r *http.Request) (AuditBatchQuery, error) {
 		{"instance_id", q.InstanceID},
 		{"batch_id", q.BatchID},
 	} {
+		if c.value == "" {
+			continue
+		}
 		if err := conductor.ValidateIdentifier(c.field, c.value); err != nil {
-			return AuditBatchQuery{}, err
+			return err
 		}
 	}
-	return q, nil
+	return nil
 }

--- a/enterprise/conductor/controlplane/audit_store.go
+++ b/enterprise/conductor/controlplane/audit_store.go
@@ -231,31 +231,35 @@ func (s *SQLiteAuditStore) migrate(ctx context.Context) error {
 	return nil
 }
 
-func (s *SQLiteAuditStore) IngestAuditBatch(ctx context.Context, batch AcceptedAuditBatch) error {
-	_, err := s.put(ctx, batch)
-	return err
+func (s *SQLiteAuditStore) IngestAuditBatch(ctx context.Context, batch AcceptedAuditBatch) (AuditIngestResult, error) {
+	return s.putResult(ctx, batch)
 }
 
 func (s *SQLiteAuditStore) put(ctx context.Context, batch AcceptedAuditBatch) (AuditBatchSummary, error) {
+	result, err := s.putResult(ctx, batch)
+	return result.Summary, err
+}
+
+func (s *SQLiteAuditStore) putResult(ctx context.Context, batch AcceptedAuditBatch) (AuditIngestResult, error) {
 	if s == nil || s.db == nil {
-		return AuditBatchSummary{}, ErrAuditSinkRequired
+		return AuditIngestResult{}, ErrAuditSinkRequired
 	}
 	if ctx == nil {
-		return AuditBatchSummary{}, fmt.Errorf("%w: context", ErrAuditSinkRequired)
+		return AuditIngestResult{}, fmt.Errorf("%w: context", ErrAuditSinkRequired)
 	}
 	if err := ctx.Err(); err != nil {
-		return AuditBatchSummary{}, err
+		return AuditIngestResult{}, err
 	}
 	if err := validateAcceptedAuditBatch(batch); err != nil {
-		return AuditBatchSummary{}, err
+		return AuditIngestResult{}, err
 	}
 	envelopeJSON, err := json.Marshal(batch.Envelope)
 	if err != nil {
-		return AuditBatchSummary{}, fmt.Errorf("marshal conductor audit envelope: %w", err)
+		return AuditIngestResult{}, fmt.Errorf("marshal conductor audit envelope: %w", err)
 	}
 	keyIDsJSON, err := json.Marshal(signatureKeyIDs(batch.Envelope.Signatures))
 	if err != nil {
-		return AuditBatchSummary{}, fmt.Errorf("marshal conductor audit signature key ids: %w", err)
+		return AuditIngestResult{}, fmt.Errorf("marshal conductor audit signature key ids: %w", err)
 	}
 	if batch.ReceivedAt.IsZero() {
 		batch.ReceivedAt = time.Now().UTC()
@@ -263,60 +267,49 @@ func (s *SQLiteAuditStore) put(ctx context.Context, batch AcceptedAuditBatch) (A
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return AuditBatchSummary{}, fmt.Errorf("begin conductor audit store transaction: %w", err)
+		return AuditIngestResult{}, fmt.Errorf("begin conductor audit store transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	var existingEnvelopeHash, existingPayloadHash string
-	err = tx.QueryRowContext(ctx, `
-		SELECT envelope_hash, payload_sha256
-		FROM audit_batches
-		WHERE org_id = ? AND fleet_id = ? AND instance_id = ? AND batch_id = ?
-	`, batch.Envelope.OrgID, batch.Envelope.FleetID, batch.Envelope.InstanceID, batch.Envelope.BatchID).
-		Scan(&existingEnvelopeHash, &existingPayloadHash)
-	switch {
-	case err == nil:
-		if existingEnvelopeHash == batch.EnvelopeHash && strings.EqualFold(existingPayloadHash, batch.Envelope.PayloadSHA256) {
-			summary, getErr := auditSummaryByKey(ctx, tx, batch.Envelope.OrgID, batch.Envelope.FleetID, batch.Envelope.InstanceID, batch.Envelope.BatchID)
-			if getErr != nil {
-				return AuditBatchSummary{}, getErr
-			}
-			if commitErr := tx.Commit(); commitErr != nil {
-				return AuditBatchSummary{}, fmt.Errorf("commit duplicate conductor audit store transaction: %w", commitErr)
-			}
-			return summary, nil
-		}
-		return AuditBatchSummary{}, ErrAuditBatchConflict
-	case !errors.Is(err, sql.ErrNoRows):
-		return AuditBatchSummary{}, fmt.Errorf("check conductor audit duplicate: %w", err)
-	}
-
 	if err := detectAuditFork(ctx, tx, batch.Envelope); err != nil {
-		return AuditBatchSummary{}, err
+		return AuditIngestResult{}, err
 	}
-	if _, err := tx.ExecContext(ctx, `
+	insertResult, err := tx.ExecContext(ctx, `
 		INSERT INTO audit_batches (
 			org_id, fleet_id, instance_id, batch_id, audit_schema_version,
 			seq_start, seq_end, event_count, payload_sha256, payload_bytes,
 			envelope_hash, segment_tail_hash, dropped_count, emitted_at,
 			received_at, signature_key_ids, envelope_json, payload_blob
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(org_id, fleet_id, instance_id, batch_id) DO NOTHING
 	`, batch.Envelope.OrgID, batch.Envelope.FleetID, batch.Envelope.InstanceID, batch.Envelope.BatchID,
 		batch.Envelope.AuditSchemaVersion, formatAuditUint(batch.Envelope.SeqStart), formatAuditUint(batch.Envelope.SeqEnd),
 		formatAuditUint(batch.Envelope.EventCount), batch.Envelope.PayloadSHA256, formatAuditUint(batch.Envelope.PayloadBytes),
 		batch.EnvelopeHash, batch.Envelope.Chain.SegmentTailHash, formatAuditUint(batch.Envelope.Dropped.Count),
 		batch.Envelope.EmittedAt.UTC(), batch.ReceivedAt.UTC(), string(keyIDsJSON), envelopeJSON,
-		append([]byte(nil), batch.Payload...)); err != nil {
-		return AuditBatchSummary{}, fmt.Errorf("insert conductor audit batch: %w", err)
+		append([]byte(nil), batch.Payload...))
+	if err != nil {
+		return AuditIngestResult{}, fmt.Errorf("insert conductor audit batch: %w", err)
+	}
+	rows, err := insertResult.RowsAffected()
+	if err != nil {
+		return AuditIngestResult{}, fmt.Errorf("count inserted conductor audit batch: %w", err)
 	}
 	summary, err := auditSummaryByKey(ctx, tx, batch.Envelope.OrgID, batch.Envelope.FleetID, batch.Envelope.InstanceID, batch.Envelope.BatchID)
 	if err != nil {
-		return AuditBatchSummary{}, err
+		return AuditIngestResult{}, err
+	}
+	status := AuditIngestStatusAccepted
+	if rows == 0 {
+		if summary.EnvelopeHash != batch.EnvelopeHash || !strings.EqualFold(summary.PayloadSHA256, batch.Envelope.PayloadSHA256) {
+			return AuditIngestResult{}, ErrAuditForkDetected
+		}
+		status = AuditIngestStatusDuplicate
 	}
 	if err := tx.Commit(); err != nil {
-		return AuditBatchSummary{}, fmt.Errorf("commit conductor audit store transaction: %w", err)
+		return AuditIngestResult{}, fmt.Errorf("commit conductor audit store transaction: %w", err)
 	}
-	return summary, nil
+	return AuditIngestResult{Status: status, Summary: summary}, nil
 }
 
 func validateAcceptedAuditBatch(batch AcceptedAuditBatch) error {

--- a/enterprise/conductor/controlplane/audit_store_test.go
+++ b/enterprise/conductor/controlplane/audit_store_test.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -90,8 +91,26 @@ func TestSQLiteAuditStoreRejectsConflictingBatchID(t *testing.T) {
 		t.Fatalf("first put() error = %v", err)
 	}
 	conflict := signedAcceptedAuditBatch(t, defaultFollowerIdentity(), testAuditBatchID, 10, 10, []byte(testAuditPayload2), testNow)
-	if _, err := store.put(context.Background(), conflict); !errors.Is(err, ErrAuditBatchConflict) {
-		t.Fatalf("conflicting put() error = %v, want ErrAuditBatchConflict", err)
+	if _, err := store.put(context.Background(), conflict); !errors.Is(err, ErrAuditForkDetected) {
+		t.Fatalf("conflicting put() error = %v, want ErrAuditForkDetected", err)
+	}
+}
+
+func TestSQLiteAuditStoreRejectsReusedBatchIDAcrossSeqRange(t *testing.T) {
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	defer func() { _ = store.Close() }()
+
+	first := signedAcceptedAuditBatch(t, defaultFollowerIdentity(), testAuditBatchID, 10, 10, []byte(`{"event":"one"}`), testNow)
+	if _, err := store.put(context.Background(), first); err != nil {
+		t.Fatalf("first put() error = %v", err)
+	}
+
+	// detectAuditFork only sees sequence overlaps, so this non-overlap
+	// reaches the insert-conflict branch. The stored hash must still be
+	// compared before a reused batch_id can be treated as a duplicate.
+	reused := signedAcceptedAuditBatch(t, defaultFollowerIdentity(), testAuditBatchID, 20, 20, []byte(testAuditPayload2), testNow.Add(time.Second))
+	if _, err := store.put(context.Background(), reused); !errors.Is(err, ErrAuditForkDetected) {
+		t.Fatalf("reused batch id put() error = %v, want ErrAuditForkDetected", err)
 	}
 }
 
@@ -128,6 +147,46 @@ func TestSQLiteAuditStoreReturnsExistingSummaryOnIdempotentRetry(t *testing.T) {
 	}
 	if second.BatchID != first.BatchID || second.EnvelopeHash != first.EnvelopeHash || second.SeqStart != first.SeqStart {
 		t.Fatalf("idempotent summary diverged: first=%+v second=%+v", first, second)
+	}
+}
+
+func TestSQLiteAuditStoreConcurrentIdenticalRetryStoresOneRow(t *testing.T) {
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	defer func() { _ = store.Close() }()
+
+	batch := signedAcceptedAuditBatch(t, defaultFollowerIdentity(), testAuditBatchID, 10, 10, []byte(testAuditPayload), testNow)
+	const workers = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	start := make(chan struct{})
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := store.put(context.Background(), batch)
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent put() error = %v", err)
+		}
+	}
+	results, err := store.ListAuditBatches(context.Background(), AuditBatchQuery{
+		OrgID:      batch.Identity.OrgID,
+		FleetID:    batch.Identity.FleetID,
+		InstanceID: batch.Identity.InstanceID,
+		Limit:      workers,
+	})
+	if err != nil {
+		t.Fatalf("ListAuditBatches() error = %v", err)
+	}
+	if len(results) != 1 || results[0].EnvelopeHash != batch.EnvelopeHash {
+		t.Fatalf("stored rows = %+v, want one duplicate-collapsed row", results)
 	}
 }
 
@@ -183,10 +242,10 @@ func TestSQLiteAuditStorePrunesBatchesBeforeCutoff(t *testing.T) {
 	identity := defaultFollowerIdentity()
 	oldBatch := signedAcceptedAuditBatch(t, identity, "audit-old", 10, 10, []byte(testAuditPayload), testNow.Add(-48*time.Hour))
 	recentBatch := signedAcceptedAuditBatch(t, identity, "audit-recent", 11, 11, []byte(testAuditPayload2), testNow.Add(-time.Hour))
-	if err := store.IngestAuditBatch(context.Background(), oldBatch); err != nil {
+	if _, err := store.IngestAuditBatch(context.Background(), oldBatch); err != nil {
 		t.Fatalf("IngestAuditBatch(old) error = %v", err)
 	}
-	if err := store.IngestAuditBatch(context.Background(), recentBatch); err != nil {
+	if _, err := store.IngestAuditBatch(context.Background(), recentBatch); err != nil {
 		t.Fatalf("IngestAuditBatch(recent) error = %v", err)
 	}
 
@@ -222,7 +281,7 @@ func TestSQLiteAuditStoreRejectsNilContext(t *testing.T) {
 	if _, err := OpenSQLiteAuditStore(nilCtx, filepath.Join(t.TempDir(), "audit.db")); !errors.Is(err, ErrAuditSinkRequired) {
 		t.Fatalf("OpenSQLiteAuditStore(nil) error = %v, want ErrAuditSinkRequired", err)
 	}
-	if err := store.IngestAuditBatch(nilCtx, batch); !errors.Is(err, ErrAuditSinkRequired) {
+	if _, err := store.IngestAuditBatch(nilCtx, batch); !errors.Is(err, ErrAuditSinkRequired) {
 		t.Fatalf("IngestAuditBatch(nil) error = %v, want ErrAuditSinkRequired", err)
 	}
 	if _, err := store.ListAuditBatches(nilCtx, AuditBatchQuery{}); !errors.Is(err, ErrAuditSinkRequired) {
@@ -296,7 +355,7 @@ func TestSQLiteAuditStoreRevalidatesAcceptedBatchBoundary(t *testing.T) {
 
 			batch := signedAcceptedAuditBatch(t, defaultFollowerIdentity(), testAuditBatchID, 10, 10, []byte(testAuditPayload), testNow)
 			c.mutate(&batch)
-			if err := store.IngestAuditBatch(context.Background(), batch); !errors.Is(err, c.wantErr) {
+			if _, err := store.IngestAuditBatch(context.Background(), batch); !errors.Is(err, c.wantErr) {
 				t.Fatalf("IngestAuditBatch() error = %v, want %v", err, c.wantErr)
 			}
 		})
@@ -345,10 +404,10 @@ func TestHandlerListsAuditBatchSummaries(t *testing.T) {
 	identity := defaultFollowerIdentity()
 	first := signedAcceptedAuditBatch(t, identity, testAuditBatchID, 10, 10, []byte(testAuditPayload), testNow)
 	second := signedAcceptedAuditBatch(t, identity, "audit-batch-2", 11, 11, []byte(testAuditPayload2), testNow.Add(time.Second))
-	if err := store.IngestAuditBatch(context.Background(), first); err != nil {
+	if _, err := store.IngestAuditBatch(context.Background(), first); err != nil {
 		t.Fatalf("IngestAuditBatch(first) error = %v", err)
 	}
-	if err := store.IngestAuditBatch(context.Background(), second); err != nil {
+	if _, err := store.IngestAuditBatch(context.Background(), second); err != nil {
 		t.Fatalf("IngestAuditBatch(second) error = %v", err)
 	}
 	handler := newAuditQueryTestHandler(t, store)
@@ -372,6 +431,93 @@ func TestHandlerListsAuditBatchSummaries(t *testing.T) {
 	}
 	if got.Batches[0].BatchID != "audit-batch-2" || got.Batches[0].OrgID != identity.OrgID {
 		t.Fatalf("list batch = %+v", got.Batches[0])
+	}
+}
+
+func TestHandlerAuditBatchQueryRoundTrip(t *testing.T) {
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	defer func() { _ = store.Close() }()
+
+	identity := defaultFollowerIdentity()
+	first := signedAcceptedAuditBatch(t, identity, testAuditBatchID, 10, 10, []byte(testAuditPayload), testNow)
+	second := signedAcceptedAuditBatch(t, identity, "audit-batch-2", 11, 11, []byte(testAuditPayload2), testNow.Add(time.Second))
+	if _, err := store.IngestAuditBatch(context.Background(), first); err != nil {
+		t.Fatalf("IngestAuditBatch(first) error = %v", err)
+	}
+	if _, err := store.IngestAuditBatch(context.Background(), second); err != nil {
+		t.Fatalf("IngestAuditBatch(second) error = %v", err)
+	}
+	handler := newAuditQueryTestHandler(t, store)
+
+	listReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, AuditBatchesPath+"?org_id=org-main&fleet_id=prod&instance_id=pl-prod-1&limit=2", nil)
+	listReq.Header.Set("X-Pipelock-Auditor", "ok")
+	listResp := httptest.NewRecorder()
+	handler.ServeHTTP(listResp, listReq)
+	if listResp.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s, want 200", listResp.Code, listResp.Body.String())
+	}
+	var listed listAuditBatchesResponse
+	if err := json.Unmarshal(listResp.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed.Batches) != 2 || listed.Batches[0].BatchID != "audit-batch-2" || listed.Batches[1].BatchID != testAuditBatchID {
+		t.Fatalf("list order = %+v, want newest first", listed.Batches)
+	}
+
+	getReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, AuditBatchesPath+"/"+testAuditBatchID+"?org_id=org-main&fleet_id=prod&instance_id=pl-prod-1", nil)
+	getReq.Header.Set("X-Pipelock-Auditor", "ok")
+	getResp := httptest.NewRecorder()
+	handler.ServeHTTP(getResp, getReq)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("get status = %d body=%s, want 200", getResp.Code, getResp.Body.String())
+	}
+	var got AuditBatchSummary
+	if err := json.Unmarshal(getResp.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if got.BatchID != testAuditBatchID || got.EnvelopeHash != first.EnvelopeHash {
+		t.Fatalf("get summary = %+v, want first batch", got)
+	}
+	if strings.Contains(getResp.Body.String(), testAuditPayload) {
+		t.Fatalf("get response leaked raw payload: %s", getResp.Body.String())
+	}
+}
+
+func TestHandlerGetAuditBatchValidationAndErrors(t *testing.T) {
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	defer func() { _ = store.Close() }()
+	handler := newAuditQueryTestHandler(t, store)
+
+	cases := []struct {
+		name       string
+		method     string
+		target     string
+		auditor    string
+		wantStatus int
+		wantBody   string
+	}{
+		{name: "wrong method", method: http.MethodDelete, target: AuditBatchesPath + "/missing?org_id=org-main&fleet_id=prod&instance_id=pl-prod-1", wantStatus: http.StatusMethodNotAllowed},
+		{name: "auditor required", method: http.MethodGet, target: AuditBatchesPath + "/missing?org_id=org-main&fleet_id=prod&instance_id=pl-prod-1", wantStatus: http.StatusForbidden, wantBody: ErrAuditQueryForbidden.Error()},
+		{name: "namespace required", method: http.MethodGet, target: AuditBatchesPath + "/missing?org_id=org-main", auditor: "ok", wantStatus: http.StatusBadRequest},
+		{name: "unknown parameter", method: http.MethodGet, target: AuditBatchesPath + "/missing?org_id=org-main&fleet_id=prod&instance_id=pl-prod-1&limit=1", auditor: "ok", wantStatus: http.StatusBadRequest},
+		{name: "nested id", method: http.MethodGet, target: AuditBatchesPath + "/missing/nested?org_id=org-main&fleet_id=prod&instance_id=pl-prod-1", auditor: "ok", wantStatus: http.StatusNotFound, wantBody: ErrAuditBatchNotFound.Error()},
+		{name: "not found", method: http.MethodGet, target: AuditBatchesPath + "/missing?org_id=org-main&fleet_id=prod&instance_id=pl-prod-1", auditor: "ok", wantStatus: http.StatusNotFound, wantBody: ErrAuditBatchNotFound.Error()},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), c.method, c.target, nil)
+			if c.auditor != "" {
+				req.Header.Set("X-Pipelock-Auditor", c.auditor)
+			}
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code != c.wantStatus {
+				t.Fatalf("status = %d body=%s, want %d", w.Code, w.Body.String(), c.wantStatus)
+			}
+			if c.wantBody != "" && !strings.Contains(w.Body.String(), c.wantBody) {
+				t.Fatalf("body = %s, want substring %q", w.Body.String(), c.wantBody)
+			}
+		})
 	}
 }
 
@@ -495,6 +641,13 @@ func TestHandlerListAuditBatchSurfacesSinkError(t *testing.T) {
 	if !strings.Contains(w.Body.String(), ErrAuditBatchConflict.Error()) {
 		t.Fatalf("body = %s, want sink error", w.Body.String())
 	}
+
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, AuditBatchesPath+"/audit-batch-1?org_id=org-main&fleet_id=prod&instance_id=pl-prod-1", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("get status = %d body=%s, want 409", w.Code, w.Body.String())
+	}
 }
 
 func openTestSQLiteAuditStore(t *testing.T, path string) *SQLiteAuditStore {
@@ -537,12 +690,16 @@ type failingAuditQuerySink struct {
 	err error
 }
 
-func (s failingAuditQuerySink) IngestAuditBatch(context.Context, AcceptedAuditBatch) error {
-	return nil
+func (s failingAuditQuerySink) IngestAuditBatch(context.Context, AcceptedAuditBatch) (AuditIngestResult, error) {
+	return AuditIngestResult{Status: AuditIngestStatusAccepted}, nil
 }
 
 func (s failingAuditQuerySink) ListAuditBatches(context.Context, AuditBatchQuery) ([]AuditBatchSummary, error) {
 	return nil, s.err
+}
+
+func (s failingAuditQuerySink) GetAuditBatch(context.Context, string, string, string, string) (AuditBatchSummary, bool, error) {
+	return AuditBatchSummary{}, false, s.err
 }
 
 func signedAcceptedAuditBatch(

--- a/enterprise/conductor/controlplane/audit_store_test.go
+++ b/enterprise/conductor/controlplane/audit_store_test.go
@@ -157,24 +157,33 @@ func TestSQLiteAuditStoreConcurrentIdenticalRetryStoresOneRow(t *testing.T) {
 	batch := signedAcceptedAuditBatch(t, defaultFollowerIdentity(), testAuditBatchID, 10, 10, []byte(testAuditPayload), testNow)
 	const workers = 16
 	var wg sync.WaitGroup
-	errs := make(chan error, workers)
+	type ingestResult struct {
+		result AuditIngestResult
+		err    error
+	}
+	ingests := make(chan ingestResult, workers)
 	start := make(chan struct{})
 	for range workers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			<-start
-			_, err := store.put(context.Background(), batch)
-			errs <- err
+			result, err := store.IngestAuditBatch(context.Background(), batch)
+			ingests <- ingestResult{result: result, err: err}
 		}()
 	}
 	close(start)
 	wg.Wait()
-	close(errs)
-	for err := range errs {
-		if err != nil {
-			t.Fatalf("concurrent put() error = %v", err)
+	close(ingests)
+	statusCounts := map[AuditIngestStatus]int{}
+	for ingest := range ingests {
+		if ingest.err != nil {
+			t.Fatalf("concurrent IngestAuditBatch() error = %v", ingest.err)
 		}
+		statusCounts[ingest.result.Status]++
+	}
+	if statusCounts[AuditIngestStatusAccepted] != 1 || statusCounts[AuditIngestStatusDuplicate] != workers-1 {
+		t.Fatalf("status counts = %+v, want one accepted and %d duplicates", statusCounts, workers-1)
 	}
 	results, err := store.ListAuditBatches(context.Background(), AuditBatchQuery{
 		OrgID:      batch.Identity.OrgID,

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -344,7 +344,7 @@ func (h *Handler) serveControlHTTP(w http.ResponseWriter, r *http.Request) {
 	case AuditBatchesPath:
 		h.handleAuditBatch(w, r)
 	default:
-		if strings.HasPrefix(r.URL.Path, AuditBatchesPath+"/") {
+		if isAuditBatchSubroute(r.URL.Path) {
 			h.handleGetAuditBatch(w, r)
 			return
 		}
@@ -397,7 +397,7 @@ func (h *Handler) recordRequest(r *http.Request, route string, status int, durat
 }
 
 func conductorRoute(path string) string {
-	if strings.HasPrefix(path, AuditBatchesPath+"/") {
+	if isAuditBatchSubroute(path) {
 		return AuditBatchesPath
 	}
 	switch path {
@@ -406,6 +406,10 @@ func conductorRoute(path string) string {
 	default:
 		return "unknown"
 	}
+}
+
+func isAuditBatchSubroute(path string) bool {
+	return strings.HasPrefix(path, AuditBatchesPath+"/")
 }
 
 func conductorOperationOutcome(status int, success string) string {

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -344,6 +344,10 @@ func (h *Handler) serveControlHTTP(w http.ResponseWriter, r *http.Request) {
 	case AuditBatchesPath:
 		h.handleAuditBatch(w, r)
 	default:
+		if strings.HasPrefix(r.URL.Path, AuditBatchesPath+"/") {
+			h.handleGetAuditBatch(w, r)
+			return
+		}
 		http.NotFound(w, r)
 	}
 }
@@ -393,6 +397,9 @@ func (h *Handler) recordRequest(r *http.Request, route string, status int, durat
 }
 
 func conductorRoute(path string) string {
+	if strings.HasPrefix(path, AuditBatchesPath+"/") {
+		return AuditBatchesPath
+	}
 	switch path {
 	case HealthPath, HealthzPath, MetricsPath, ReadyzPath, conductor.CapabilitiesPath, EnrollmentTokensPath, EnrollPath, RemoteKillPath, RollbackAuthorizationsPath, PublishPolicyBundlePath, LatestPolicyBundlePath, AuditBatchesPath:
 		return path

--- a/enterprise/conductor/controlplane/store.go
+++ b/enterprise/conductor/controlplane/store.go
@@ -66,6 +66,7 @@ var (
 	ErrAuditQueryForbidden  = errors.New("conductor audit query authorization failed")
 	ErrAuditSinkRequired    = errors.New("conductor audit sink required")
 	ErrAuditKeyRequired     = errors.New("conductor audit key resolver required")
+	ErrAuditBatchNotFound   = errors.New("conductor audit batch not found")
 	ErrAuditBatchConflict   = errors.New("conductor audit batch conflicts with accepted batch")
 	ErrAuditForkDetected    = errors.New("conductor audit sequence fork detected")
 	ErrUnsupportedRollback  = errors.New("conductor control plane rollback publication not implemented")

--- a/enterprise/fleet/sink/ingest_test.go
+++ b/enterprise/fleet/sink/ingest_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -269,6 +270,59 @@ func TestHandler_DetectsBatchIDConflict(t *testing.T) {
 	resp := postBatch(t, handler, second, secondPayload)
 	if resp.Code != http.StatusConflict {
 		t.Fatalf("conflict status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), ErrForkDetected.Error()) {
+		t.Fatalf("conflict body = %s, want fork error", resp.Body.String())
+	}
+}
+
+func TestStore_ConcurrentIdenticalRetryStoresOneRow(t *testing.T) {
+	_, store, priv := testHandler(t)
+	payload := []byte(`{"events":[{"message":"clean audit event"}]}`)
+	env := signedEnvelope(t, "batch-race", 1, 1, payload, priv)
+	canonicalHash, err := env.CanonicalHash()
+	if err != nil {
+		t.Fatalf("CanonicalHash() error = %v", err)
+	}
+	batch := acceptedBatch{
+		Envelope:      env,
+		Payload:       payload,
+		ReceivedAt:    sinkTestNow,
+		CanonicalHash: canonicalHash,
+	}
+
+	const workers = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	start := make(chan struct{})
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := store.Put(context.Background(), batch, nil)
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Put() error = %v", err)
+		}
+	}
+	results, err := store.List(context.Background(), Query{
+		OrgID:      env.OrgID,
+		FleetID:    env.FleetID,
+		InstanceID: env.InstanceID,
+		Limit:      workers,
+	})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(results) != 1 || results[0].CanonicalHash != canonicalHash {
+		t.Fatalf("stored rows = %+v, want one duplicate-collapsed row", results)
 	}
 }
 

--- a/enterprise/fleet/sink/storage.go
+++ b/enterprise/fleet/sink/storage.go
@@ -186,6 +186,8 @@ func (s *Store) migrate(ctx context.Context) error {
 		ON audit_batches(org_id, fleet_id, instance_id, seq_start, seq_end);
 	CREATE INDEX IF NOT EXISTS idx_audit_batches_batch_id
 		ON audit_batches(batch_id);
+	CREATE UNIQUE INDEX IF NOT EXISTS idx_audit_batches_canonical_hash
+		ON audit_batches(canonical_hash);
 	`
 	if _, err := s.db.ExecContext(ctx, ddl); err != nil {
 		return fmt.Errorf("migrate fleet sink store: %w", err)
@@ -222,58 +224,47 @@ func (s *Store) Put(ctx context.Context, batch acceptedBatch, informational []st
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	var existingHash, existingPayloadHash string
-	err = tx.QueryRowContext(ctx, `
-		SELECT canonical_hash, payload_sha256
-		FROM audit_batches
-		WHERE org_id = ? AND fleet_id = ? AND instance_id = ? AND batch_id = ?
-	`, batch.Envelope.OrgID, batch.Envelope.FleetID, batch.Envelope.InstanceID, batch.Envelope.BatchID).
-		Scan(&existingHash, &existingPayloadHash)
-	switch {
-	case err == nil:
-		if existingHash == batch.CanonicalHash && strings.EqualFold(existingPayloadHash, batch.Envelope.PayloadSHA256) {
-			summary, getErr := summaryByKey(ctx, tx, batch.Envelope.OrgID, batch.Envelope.FleetID, batch.Envelope.InstanceID, batch.Envelope.BatchID)
-			if getErr != nil {
-				return PutResult{}, getErr
-			}
-			if commitErr := tx.Commit(); commitErr != nil {
-				return PutResult{}, fmt.Errorf("commit duplicate fleet sink transaction: %w", commitErr)
-			}
-			return PutResult{Summary: summary, Duplicate: true}, nil
-		}
-		return PutResult{}, ErrBatchConflict
-	case !errors.Is(err, sql.ErrNoRows):
-		return PutResult{}, fmt.Errorf("check duplicate audit batch: %w", err)
-	}
-
 	if err := detectFork(ctx, tx, batch.Envelope); err != nil {
 		return PutResult{}, err
 	}
 
-	if _, err := tx.ExecContext(ctx, `
+	insertResult, err := tx.ExecContext(ctx, `
 		INSERT INTO audit_batches (
 			org_id, fleet_id, instance_id, batch_id, audit_schema_version,
 			seq_start, seq_end, event_count, payload_sha256, payload_bytes,
 			canonical_hash, segment_tail_hash, dropped_count, emitted_at,
 			received_at, signature_key_ids, informational_dlp, envelope_json, payload_blob
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(org_id, fleet_id, instance_id, batch_id) DO NOTHING
 	`, batch.Envelope.OrgID, batch.Envelope.FleetID, batch.Envelope.InstanceID, batch.Envelope.BatchID,
 		batch.Envelope.AuditSchemaVersion, formatUint(batch.Envelope.SeqStart), formatUint(batch.Envelope.SeqEnd),
 		formatUint(batch.Envelope.EventCount), batch.Envelope.PayloadSHA256, formatUint(batch.Envelope.PayloadBytes),
 		batch.CanonicalHash, batch.Envelope.Chain.SegmentTailHash, formatUint(batch.Envelope.Dropped.Count),
 		batch.Envelope.EmittedAt.UTC(), batch.ReceivedAt.UTC(), string(keyIDsJSON), string(informationalJSON),
-		envelopeJSON, batch.Payload); err != nil {
+		envelopeJSON, batch.Payload)
+	if err != nil {
 		return PutResult{}, fmt.Errorf("insert audit batch: %w", err)
+	}
+	rows, err := insertResult.RowsAffected()
+	if err != nil {
+		return PutResult{}, fmt.Errorf("count inserted audit batch: %w", err)
 	}
 
 	summary, err := summaryByKey(ctx, tx, batch.Envelope.OrgID, batch.Envelope.FleetID, batch.Envelope.InstanceID, batch.Envelope.BatchID)
 	if err != nil {
 		return PutResult{}, err
 	}
+	duplicate := false
+	if rows == 0 {
+		if summary.CanonicalHash != batch.CanonicalHash || !strings.EqualFold(summary.PayloadSHA256, batch.Envelope.PayloadSHA256) {
+			return PutResult{}, ErrForkDetected
+		}
+		duplicate = true
+	}
 	if err := tx.Commit(); err != nil {
 		return PutResult{}, fmt.Errorf("commit fleet sink store transaction: %w", err)
 	}
-	return PutResult{Summary: summary}, nil
+	return PutResult{Summary: summary, Duplicate: duplicate}, nil
 }
 
 func (s *Store) List(ctx context.Context, q Query) ([]BatchSummary, error) {


### PR DESCRIPTION
## Summary

- make conductor audit batch ingest idempotent for byte-identical retries while rejecting divergent reuse as a fork
- return an ingest `status` of `accepted` or `duplicate` from audit batch ingest
- add authorized GET-by-batch-id lookup for conductor audit batch summaries without returning raw payloads
- align fleet sink storage with the same insert-conflict duplicate/fork behavior
- add regression coverage for concurrent retries, reused batch IDs across sequence ranges, query validation, and no-payload-leak lookup

## Security Notes

- divergent audit content under the same follower identity is rejected as `ErrAuditForkDetected`
- byte-identical concurrent retries collapse to one stored row
- audit batch lookup reuses audit query authorization and requires org/fleet/instance scope
- batch-id paths reject nested or encoded-slash traversal shapes
- per-batch GET routes are recorded under the base audit route to avoid metrics cardinality growth

## Validation

- `go test -race -count=1 ./...`
- `go test -race -count=1 -tags enterprise ./enterprise/...`
- `golangci-lint run ./...`
- `PATH=/tmp/pipelock-test-bin:$PATH bash tests/run-all-security.sh`
  - `1017 passed, 0 failed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve individual audit batch details via a new GET endpoint.
  * Ingest responses now include status and accepted timestamp info (accepted/duplicate).

* **Improvements**
  * Stronger idempotency and duplicate reporting across ingest/store paths.
  * Store/ingest now reliably collapse concurrent identical submissions into one stored batch.

* **Bug Fixes**
  * Conflicting reuses of a batch ID with different content are detected and reported as a fork conflict.

* **Tests**
  * Expanded coverage for ingest semantics, duplicates, concurrency, and GET validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->