### PR TITLE
fix(ci): avoid unpinned Python verifier install

### DIFF
--- a/.github/workflows/verifiers.yaml
+++ b/.github/workflows/verifiers.yaml
@@ -268,14 +268,15 @@ jobs:
         working-directory: sdk/verifiers/rust
         run: cargo build --release
 
-      - name: Install Python AARP verifier
+      - name: Install Python AARP verifier dependencies (hash-pinned)
         working-directory: sdk/verifiers/python
-        # Hash-pinned dependency install (Scorecard Pinned-Dependencies): the
-        # crypto dependency is locked with --require-hashes, then the verifier is
-        # installed with --no-deps so no unpinned package is ever fetched.
-        run: |
-          pip install --require-hashes -r requirements.txt
-          pip install --no-deps .
+        # Scorecard Pinned-Dependencies: every dependency installed here is
+        # locked with --require-hashes. The verifier package itself is NOT
+        # pip-installed: a local `pip install .` cannot be hash-pinned, so
+        # Scorecard flags it on every run regardless of --no-deps. Instead the
+        # pure-Python package is run from its pinned checkout via PYTHONPATH in
+        # the conformance gate below, so no unpinned install command ever runs.
+        run: pip install --require-hashes -r requirements.txt
 
       - name: Run AARP cross-language gate
         env:
@@ -286,5 +287,6 @@ jobs:
           GO_AARP: ${{ runner.temp }}/pipelock-verifier aarp
           TS_AARP: node ${{ github.workspace }}/sdk/verifiers/ts/dist/src/cli.js aarp
           RUST_AARP: ${{ github.workspace }}/sdk/verifiers/rust/target/release/pipelock-verifier-rs aarp
+          PYTHONPATH: ${{ github.workspace }}/sdk/verifiers/python/src
           PY_AARP: python -m pipelock_aarp_verify aarp
         run: bash sdk/conformance/aarp-corpus-gate.sh


### PR DESCRIPTION
## Summary
- remove the local `pip install --no-deps .` from the AARP verifier workflow
- run the Python verifier from the checked-out source tree via `PYTHONPATH`
- keep Python dependency installation limited to `--require-hashes`

## Why
Scorecard flags `pip install --no-deps .` as an unpinned pip install even though dependencies are pinned. The local package install itself cannot be hash-pinned, so the alert returns on every scan. Running the pure-Python verifier from the pinned checkout avoids the unpinned install command entirely.

## Validation
- `git diff --check`
- `bash scripts/check-python-pins.sh`
- `python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/verifiers.yaml').read_text()); print('verifiers workflow yaml ok')"`
- AARP four-language conformance gate: 56 fixtures, 0 failures
- pre-push hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration for Python verifier setup and execution.

---

**Note:** This release contains no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->