### PR TITLE
feat(license): intermediate signing certificates with CRL revocation

### DIFF
--- a/internal/license/crl.go
+++ b/internal/license/crl.go
@@ -22,7 +22,13 @@ const (
 	maxCRLFileSize = 256 * 1024
 )
 
-var ErrLicenseRevoked = errors.New("license revoked")
+var (
+	ErrLicenseRevoked = errors.New("license revoked")
+	// ErrIntermediateRevoked is returned when an intermediate signing
+	// certificate's serial appears in the CRL. Rotation revokes the prior
+	// intermediate, so any token signed by it must fail closed.
+	ErrIntermediateRevoked = errors.New("intermediate certificate revoked")
+)
 
 // RevokedLicense records one revoked license ID in a signed CRL.
 type RevokedLicense struct {
@@ -31,12 +37,26 @@ type RevokedLicense struct {
 	RevokedAt int64  `json:"revoked_at"`
 }
 
-// CRLPayload is the signed revocation-list payload.
+// RevokedIntermediate records one revoked intermediate signing certificate,
+// keyed by its serial / key id. Revoking an intermediate invalidates every
+// license token it signed - this is the rotation/compromise kill switch for the
+// intermediate-key PKI tier.
+type RevokedIntermediate struct {
+	Serial    string `json:"serial"`
+	Reason    string `json:"reason,omitempty"`
+	RevokedAt int64  `json:"revoked_at"`
+}
+
+// CRLPayload is the signed revocation-list payload. RevokedIntermediates is an
+// optional field added for the intermediate-key PKI tier; CRLs that predate it
+// simply carry an empty list, and the wire version stays 1 (a pre-PKI verifier
+// only does direct-root verification and never trusts an intermediate anyway).
 type CRLPayload struct {
-	Version   int              `json:"version"`
-	IssuedAt  int64            `json:"issued_at"`
-	ExpiresAt int64            `json:"expires_at"`
-	Revoked   []RevokedLicense `json:"revoked"`
+	Version              int                   `json:"version"`
+	IssuedAt             int64                 `json:"issued_at"`
+	ExpiresAt            int64                 `json:"expires_at"`
+	Revoked              []RevokedLicense      `json:"revoked"`
+	RevokedIntermediates []RevokedIntermediate `json:"revoked_intermediates,omitempty"`
 }
 
 // CRL is a signed license revocation list. The wire format stores the exact
@@ -48,6 +68,7 @@ type CRL struct {
 	SHA256    string         `json:"-"`
 	payload   []byte         `json:"-"`
 	index     map[string]int `json:"-"`
+	intIndex  map[string]int `json:"-"`
 }
 
 type crlWire struct {
@@ -205,6 +226,41 @@ func (c CRL) CheckLicense(lic License) error {
 	return fmt.Errorf("%w: %s (%s)", ErrLicenseRevoked, lic.ID, revoked.Reason)
 }
 
+// RevocationForIntermediate returns the revocation record for an intermediate
+// serial, if present.
+func (c CRL) RevocationForIntermediate(serial string) (RevokedIntermediate, bool) {
+	if c.intIndex != nil {
+		i, ok := c.intIndex[serial]
+		if !ok || i < 0 || i >= len(c.Payload.RevokedIntermediates) {
+			return RevokedIntermediate{}, false
+		}
+		return c.Payload.RevokedIntermediates[i], true
+	}
+	for _, revoked := range c.Payload.RevokedIntermediates {
+		if revoked.Serial == serial {
+			return revoked, true
+		}
+	}
+	return RevokedIntermediate{}, false
+}
+
+// CheckIntermediate returns ErrIntermediateRevoked when the given intermediate
+// serial is revoked. An empty serial is treated as revoked (fail closed): an
+// intermediate with no serial cannot be tracked for rotation.
+func (c CRL) CheckIntermediate(serial string) error {
+	if serial == "" {
+		return fmt.Errorf("%w: missing serial", ErrIntermediateRevoked)
+	}
+	revoked, ok := c.RevocationForIntermediate(serial)
+	if !ok {
+		return nil
+	}
+	if revoked.Reason == "" {
+		return fmt.Errorf("%w: %s", ErrIntermediateRevoked, serial)
+	}
+	return fmt.Errorf("%w: %s (%s)", ErrIntermediateRevoked, serial, revoked.Reason)
+}
+
 func VerifyWithCRL(token string, publicKey ed25519.PublicKey, crl *CRL) (License, error) {
 	lic, err := Verify(token, publicKey)
 	if err != nil {
@@ -250,6 +306,22 @@ func validateCRLPayload(payload CRLPayload, now time.Time) error {
 			return fmt.Errorf("CRL contains duplicate license id %s", ids[i])
 		}
 	}
+	serials := make([]string, 0, len(payload.RevokedIntermediates))
+	for _, revoked := range payload.RevokedIntermediates {
+		if revoked.Serial == "" {
+			return errors.New("CRL contains revoked intermediate with empty serial")
+		}
+		if revoked.RevokedAt <= 0 {
+			return fmt.Errorf("CRL intermediate revocation %s missing revoked_at", revoked.Serial)
+		}
+		serials = append(serials, revoked.Serial)
+	}
+	slices.Sort(serials)
+	for i := 1; i < len(serials); i++ {
+		if serials[i] == serials[i-1] {
+			return fmt.Errorf("CRL contains duplicate intermediate serial %s", serials[i])
+		}
+	}
 	return nil
 }
 
@@ -257,5 +329,9 @@ func (c *CRL) buildIndex() {
 	c.index = make(map[string]int, len(c.Payload.Revoked))
 	for i, revoked := range c.Payload.Revoked {
 		c.index[revoked.ID] = i
+	}
+	c.intIndex = make(map[string]int, len(c.Payload.RevokedIntermediates))
+	for i, revoked := range c.Payload.RevokedIntermediates {
+		c.intIndex[revoked.Serial] = i
 	}
 }

--- a/internal/license/intermediate.go
+++ b/internal/license/intermediate.go
@@ -1,0 +1,374 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Intermediate-key PKI primitive.
+//
+// The root key is the SOLE trust anchor. The root (kept offline, e.g. on a USB
+// token) signs a short-lived intermediate certificate; the cluster license
+// service then holds only the intermediate private key and signs license tokens
+// with it. A pod compromise loses the intermediate, never the root.
+//
+// Verification chain (offline):
+//
+//	verify(intermediate cert sig, root pubkey)
+//	   && intermediate within its validity window
+//	   && intermediate serial not revoked (CRL)
+//	   && verify(token sig, intermediate pubkey)
+//
+// The license token wire format (license.go) is UNCHANGED: a token is still
+// payload+Ed25519-signature. Which key signed it - root (legacy) or an
+// intermediate - is decided by the verifier from the configured intermediate
+// cert, not by anything in the token. This keeps the highest-blast-radius
+// surface (the token format) frozen while adding the new trust tier alongside
+// the existing CRL distribution channel.
+
+const (
+	// IntermediateVersion is the supported intermediate-cert payload version.
+	IntermediateVersion = 1
+
+	// PurposeLicenseSigning is the only purpose an intermediate cert may carry.
+	// Purpose is pinned: the verifier never accepts a root-signed cert for any
+	// other purpose, so the root signature alone is not a blank check.
+	PurposeLicenseSigning = "license-signing"
+
+	// AlgorithmEd25519 is the only signature algorithm accepted for the chain.
+	AlgorithmEd25519 = "ed25519"
+
+	// maxIntermediateBytes caps the decoded cert size before allocation.
+	maxIntermediateBytes = 64 * 1024
+
+	// maxIntermediateValidity caps how long the root may certify an
+	// intermediate. The spec calls for 90-day or 1-year intermediates; 400 days
+	// leaves slack for a 1-year cert plus clock skew while rejecting absurd,
+	// effectively-permanent intermediates at sign time.
+	maxIntermediateValidity = 400 * 24 * time.Hour
+)
+
+var (
+	// ErrIntermediateMalformed covers structural / pinned-field failures
+	// (bad version, empty serial, unparseable or wrong-size public key).
+	ErrIntermediateMalformed = errors.New("intermediate certificate malformed")
+	// ErrIntermediatePurpose is returned when the cert's purpose is not the
+	// pinned license-signing purpose.
+	ErrIntermediatePurpose = errors.New("intermediate certificate purpose not permitted")
+	// ErrIntermediateAlgorithm is returned when the cert's algorithm is not the
+	// pinned Ed25519 algorithm.
+	ErrIntermediateAlgorithm = errors.New("intermediate certificate algorithm not permitted")
+	// ErrIntermediateExpired is returned when verification time is past NotAfter.
+	ErrIntermediateExpired = errors.New("intermediate certificate expired")
+	// ErrIntermediateNotYetValid is returned when verification time precedes NotBefore.
+	ErrIntermediateNotYetValid = errors.New("intermediate certificate not yet valid")
+	// ErrIntermediateSignature is returned when the root signature over the
+	// cert does not verify.
+	ErrIntermediateSignature = errors.New("invalid intermediate certificate signature")
+)
+
+// IntermediatePayload is the signed claim set of an intermediate signing cert.
+type IntermediatePayload struct {
+	Version   int    `json:"version"`
+	Serial    string `json:"serial"`  // serial / key id; the CRL revocation key
+	Purpose   string `json:"purpose"` // pinned: license-signing
+	Algorithm string `json:"alg"`     // pinned: ed25519
+	PublicKey string `json:"pub"`     // hex-encoded intermediate Ed25519 public key
+	NotBefore int64  `json:"nbf"`     // unix seconds
+	NotAfter  int64  `json:"naf"`     // unix seconds
+	IssuedAt  int64  `json:"iat"`     // unix seconds
+}
+
+// Intermediate is a root-signed intermediate signing certificate. Like the CRL,
+// the wire format stores the exact signed payload bytes so signature
+// verification covers those bytes, not a re-marshaled struct.
+type Intermediate struct {
+	Payload   IntermediatePayload
+	Signature string
+
+	payload []byte            // canonical signed bytes
+	pub     ed25519.PublicKey // parsed intermediate public key
+}
+
+type intermediateWire struct {
+	Payload   string `json:"payload"`
+	Signature string `json:"signature"`
+}
+
+// PublicKey returns a copy of the intermediate's signing public key.
+func (i Intermediate) PublicKey() ed25519.PublicKey {
+	return append(ed25519.PublicKey(nil), i.pub...)
+}
+
+// Serial returns the intermediate's serial / key id (the CRL revocation key).
+func (i Intermediate) Serial() string { return i.Payload.Serial }
+
+// validAt enforces the cert's validity window at the supplied time.
+func (i Intermediate) validAt(now time.Time) error {
+	ts := now.Unix()
+	if ts < i.Payload.NotBefore {
+		return ErrIntermediateNotYetValid
+	}
+	if ts > i.Payload.NotAfter {
+		return ErrIntermediateExpired
+	}
+	return nil
+}
+
+// SignIntermediate signs an intermediate certificate payload with the ROOT
+// private key. This is the only operation in the chain that touches the root
+// key. It validates the pinned purpose/algorithm and the validity window before
+// signing so the root never issues a structurally invalid intermediate.
+func SignIntermediate(payload IntermediatePayload, rootPriv ed25519.PrivateKey) (Intermediate, error) {
+	if len(rootPriv) != ed25519.PrivateKeySize {
+		return Intermediate{}, errors.New("invalid root private key size")
+	}
+	if payload.Version == 0 {
+		payload.Version = IntermediateVersion
+	}
+	// validateIntermediatePayload enforces the pinned fields AND the full
+	// validity-window rules (issued_at/not_before/not_after presence, ordering,
+	// and max window), so the signer never emits a structurally invalid cert.
+	// The verifier shares this exact function, so no checks are duplicated here.
+	pub, err := validateIntermediatePayload(payload)
+	if err != nil {
+		return Intermediate{}, err
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return Intermediate{}, fmt.Errorf("marshal intermediate payload: %w", err)
+	}
+	sig := ed25519.Sign(rootPriv, data)
+	return Intermediate{
+		Payload:   payload,
+		Signature: base64.RawURLEncoding.EncodeToString(sig),
+		payload:   append([]byte(nil), data...),
+		pub:       pub,
+	}, nil
+}
+
+// MarshalJSON renders the cert as the CRL-style {payload, signature} wire blob,
+// preserving the exact signed payload bytes.
+func (i Intermediate) MarshalJSON() ([]byte, error) {
+	payload := i.payload
+	if len(payload) == 0 {
+		var err error
+		payload, err = json.Marshal(i.Payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal intermediate payload: %w", err)
+		}
+	}
+	return json.Marshal(intermediateWire{
+		Payload:   base64.RawURLEncoding.EncodeToString(payload),
+		Signature: i.Signature,
+	})
+}
+
+// ParseAndVerifyIntermediate decodes an intermediate cert, verifies its
+// signature against the ROOT public key, and enforces the pinned purpose +
+// algorithm and the validity window at `now`. It does NOT consult the CRL;
+// revocation is checked separately (CheckIntermediate) so the caller can supply
+// the loaded CRL. A returned Intermediate is always root-verified and
+// structurally valid.
+func ParseAndVerifyIntermediate(data []byte, rootPub ed25519.PublicKey, now time.Time) (Intermediate, error) {
+	if len(data) > maxIntermediateBytes {
+		return Intermediate{}, fmt.Errorf("%w: exceeds maximum size", ErrIntermediateMalformed)
+	}
+	var wire intermediateWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return Intermediate{}, fmt.Errorf("%w: %w", ErrIntermediateMalformed, err)
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(wire.Payload)
+	if err != nil {
+		return Intermediate{}, fmt.Errorf("%w: decode payload: %w", ErrIntermediateMalformed, err)
+	}
+	return verifyIntermediateBytes(payloadBytes, wire.Signature, rootPub, now)
+}
+
+// verifyIntermediateObject defensively re-validates an already decoded
+// Intermediate against the root trust anchor. VerifyChain calls this so future
+// wiring cannot accidentally trust a hand-built or stale Intermediate value.
+func verifyIntermediateObject(im Intermediate, rootPub ed25519.PublicKey, now time.Time) (Intermediate, error) {
+	payloadBytes := im.payload
+	if len(payloadBytes) == 0 {
+		var err error
+		payloadBytes, err = json.Marshal(im.Payload)
+		if err != nil {
+			return Intermediate{}, fmt.Errorf("marshal intermediate payload: %w", err)
+		}
+	}
+	return verifyIntermediateBytes(payloadBytes, im.Signature, rootPub, now)
+}
+
+// verifyIntermediateBytes is the shared verification core. It checks the root
+// signature over the exact payload bytes, enforces the pinned + structural
+// payload rules, and the validity window at now, returning a fully verified
+// Intermediate. Both ParseAndVerifyIntermediate (wire bytes off disk) and
+// verifyIntermediateObject (an already-decoded value) funnel through it so the
+// trust checks are identical and never duplicated.
+func verifyIntermediateBytes(payloadBytes []byte, signatureB64 string, rootPub ed25519.PublicKey, now time.Time) (Intermediate, error) {
+	if len(rootPub) != ed25519.PublicKeySize {
+		return Intermediate{}, errors.New("invalid root public key")
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(signatureB64)
+	if err != nil {
+		return Intermediate{}, fmt.Errorf("%w: decode signature: %w", ErrIntermediateMalformed, err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return Intermediate{}, fmt.Errorf("%w: bad signature size", ErrIntermediateMalformed)
+	}
+	if !ed25519.Verify(rootPub, payloadBytes, sig) {
+		return Intermediate{}, ErrIntermediateSignature
+	}
+	var payload IntermediatePayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return Intermediate{}, fmt.Errorf("%w: parse payload: %w", ErrIntermediateMalformed, err)
+	}
+	pub, err := validateIntermediatePayload(payload)
+	if err != nil {
+		return Intermediate{}, err
+	}
+	im := Intermediate{
+		Payload:   payload,
+		Signature: signatureB64,
+		payload:   append([]byte(nil), payloadBytes...),
+		pub:       pub,
+	}
+	if err := im.validAt(now); err != nil {
+		return Intermediate{}, err
+	}
+	return im, nil
+}
+
+// validateIntermediatePayload enforces version + pinned purpose/algorithm +
+// serial presence + public-key well-formedness, returning the parsed public
+// key. It is shared by sign and verify so both paths pin identically (the
+// verifier never trusts that the signer validated).
+func validateIntermediatePayload(payload IntermediatePayload) (ed25519.PublicKey, error) {
+	if payload.Version != IntermediateVersion {
+		return nil, fmt.Errorf("%w: unsupported version %d", ErrIntermediateMalformed, payload.Version)
+	}
+	if payload.Serial == "" {
+		return nil, fmt.Errorf("%w: empty serial", ErrIntermediateMalformed)
+	}
+	if payload.IssuedAt <= 0 {
+		return nil, fmt.Errorf("%w: missing issued_at", ErrIntermediateMalformed)
+	}
+	if payload.NotBefore <= 0 || payload.NotAfter <= 0 {
+		return nil, fmt.Errorf("%w: missing validity window", ErrIntermediateMalformed)
+	}
+	if payload.NotAfter <= payload.NotBefore {
+		return nil, fmt.Errorf("%w: not_after must be after not_before", ErrIntermediateMalformed)
+	}
+	if payload.IssuedAt > payload.NotAfter {
+		return nil, fmt.Errorf("%w: issued_at must not be after not_after", ErrIntermediateMalformed)
+	}
+	if payload.NotAfter-payload.NotBefore > int64(maxIntermediateValidity.Seconds()) {
+		return nil, fmt.Errorf("%w: validity window exceeds maximum %s", ErrIntermediateMalformed, maxIntermediateValidity)
+	}
+	if payload.Purpose != PurposeLicenseSigning {
+		return nil, fmt.Errorf("%w: %q", ErrIntermediatePurpose, payload.Purpose)
+	}
+	if payload.Algorithm != AlgorithmEd25519 {
+		return nil, fmt.Errorf("%w: %q", ErrIntermediateAlgorithm, payload.Algorithm)
+	}
+	return decodeIntermediatePublicKey(payload.PublicKey)
+}
+
+func decodeIntermediatePublicKey(hexKey string) (ed25519.PublicKey, error) {
+	raw, err := hex.DecodeString(hexKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: decode public key: %w", ErrIntermediateMalformed, err)
+	}
+	if len(raw) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("%w: public key wrong size", ErrIntermediateMalformed)
+	}
+	return ed25519.PublicKey(raw), nil
+}
+
+// VerifyChain verifies a license token using an OPTIONAL intermediate cert.
+// rootPub is the sole trust anchor.
+//
+//   - im == nil: legacy direct-root verification only (token signed by root),
+//     including CRL license-revocation.
+//   - im != nil: im MUST have come from ParseAndVerifyIntermediate (already
+//     root-verified). VerifyChain defensively re-checks the validity window at
+//     `now` and the intermediate's CRL status, then verifies the token against
+//     the intermediate public key, FALLING BACK to direct-root verification for
+//     legacy root-signed tokens. License-level CRL revocation is always
+//     enforced on either path.
+func VerifyChain(token string, im *Intermediate, rootPub ed25519.PublicKey, crl *CRL, now time.Time) (License, error) {
+	if im == nil {
+		return VerifyWithCRL(token, rootPub, crl)
+	}
+	verified, err := verifyIntermediateObject(*im, rootPub, now)
+	if err != nil {
+		return License{}, err
+	}
+	if crl != nil {
+		if err := crl.CheckIntermediate(verified.Serial()); err != nil {
+			return License{}, err
+		}
+	}
+	// Primary path: token signed by the active intermediate.
+	lic, err := VerifyWithCRL(token, verified.PublicKey(), crl)
+	if err == nil {
+		return lic, nil
+	}
+	// A definitive expiry/revocation on the intermediate path means the token IS
+	// intermediate-signed and must fail closed - never fall back to root.
+	if errors.Is(err, ErrLicenseExpired) || errors.Is(err, ErrLicenseRevoked) {
+		return License{}, err
+	}
+	// Otherwise the signature simply did not match the intermediate key: try the
+	// legacy direct-root path for old root-signed tokens.
+	legacyLic, legacyErr := VerifyWithCRL(token, rootPub, crl)
+	if legacyErr == nil {
+		return legacyLic, nil
+	}
+	// If the legacy path produced a definitive expiry/revocation, the token is
+	// root-signed; surface that specific reason rather than the intermediate
+	// signature-mismatch error.
+	if errors.Is(legacyErr, ErrLicenseExpired) || errors.Is(legacyErr, ErrLicenseRevoked) {
+		return License{}, legacyErr
+	}
+	return License{}, err
+}
+
+// VerifyTokenWithOptionalIntermediate is the single call-site entry point that
+// enforces the fail-closed contract for a CONFIGURED intermediate cert.
+//
+// intermediateCert is the raw configured cert bytes (nil/empty = not
+// configured):
+//
+//   - not configured: legacy direct-root verification only.
+//   - configured: the cert MUST parse, verify against root, be within its
+//     validity window, and not be revoked. ANY failure fails closed and is
+//     surfaced verbatim - a configured-but-invalid cert is never silently
+//     treated as "missing", and it blocks ALL verification (including legacy
+//     root-signed tokens) per the fail-closed doctrine. The operator reverts by
+//     explicitly removing the cert configuration. On a valid cert, the token is
+//     verified against the intermediate key with legacy direct-root fallback.
+func VerifyTokenWithOptionalIntermediate(token string, intermediateCert []byte, rootPub ed25519.PublicKey, crl *CRL, now time.Time) (License, error) {
+	if len(intermediateCert) == 0 {
+		return VerifyWithCRL(token, rootPub, crl)
+	}
+	im, err := ParseAndVerifyIntermediate(intermediateCert, rootPub, now)
+	if err != nil {
+		return License{}, fmt.Errorf("configured intermediate certificate rejected: %w", err)
+	}
+	if crl != nil {
+		if err := crl.CheckIntermediate(im.Serial()); err != nil {
+			return License{}, err
+		}
+	}
+	return VerifyChain(token, &im, rootPub, crl, now)
+}

--- a/internal/license/intermediate_test.go
+++ b/internal/license/intermediate_test.go
@@ -1,0 +1,791 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+const (
+	testSerial    = "int-2026-001"
+	testWrongAlg  = "rsa"
+	testWrongPurp = "code-signing"
+)
+
+// testIntermediate signs a well-formed intermediate certificate with rootPriv
+// certifying intPub, valid over [notBefore, notAfter], and returns both the
+// parsed cert and its wire bytes.
+func testIntermediate(t *testing.T, rootPriv ed25519.PrivateKey, intPub ed25519.PublicKey, notBefore, notAfter time.Time) (Intermediate, []byte) {
+	t.Helper()
+	cert, err := SignIntermediate(IntermediatePayload{
+		Serial:    testSerial,
+		Purpose:   PurposeLicenseSigning,
+		Algorithm: AlgorithmEd25519,
+		PublicKey: hex.EncodeToString(intPub),
+		NotBefore: notBefore.Unix(),
+		NotAfter:  notAfter.Unix(),
+		IssuedAt:  notBefore.Unix(),
+	}, rootPriv)
+	if err != nil {
+		t.Fatalf("SignIntermediate: %v", err)
+	}
+	data, err := json.Marshal(cert)
+	if err != nil {
+		t.Fatalf("marshal intermediate: %v", err)
+	}
+	return cert, data
+}
+
+// rawIntermediateWire builds a root-signed intermediate wire blob WITHOUT going
+// through SignIntermediate's validation, so negative tests can construct certs
+// with pinned-field violations and confirm ParseAndVerifyIntermediate enforces
+// them independently (defense in depth: the verifier never trusts that the
+// signer validated).
+func rawIntermediateWire(t *testing.T, rootPriv ed25519.PrivateKey, payload IntermediatePayload) []byte {
+	t.Helper()
+	if payload.Version == 0 {
+		payload.Version = IntermediateVersion
+	}
+	pb, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	sig := ed25519.Sign(rootPriv, pb)
+	data, err := json.Marshal(intermediateWire{
+		Payload:   base64.RawURLEncoding.EncodeToString(pb),
+		Signature: base64.RawURLEncoding.EncodeToString(sig),
+	})
+	if err != nil {
+		t.Fatalf("marshal wire: %v", err)
+	}
+	return data
+}
+
+// testIntermediateCRL signs a CRL revoking one intermediate serial.
+func testIntermediateCRL(t *testing.T, priv ed25519.PrivateKey, now time.Time, revokedSerial string) CRL {
+	t.Helper()
+	crl, err := SignCRL(CRLPayload{
+		Version:   CRLVersion,
+		IssuedAt:  now.Add(-time.Hour).Unix(),
+		ExpiresAt: now.Add(7 * 24 * time.Hour).Unix(),
+		RevokedIntermediates: []RevokedIntermediate{{
+			Serial:    revokedSerial,
+			Reason:    "key_rotation",
+			RevokedAt: now.Add(-time.Hour).Unix(),
+		}},
+	}, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return crl
+}
+
+func validIntermediatePayload(intPub ed25519.PublicKey, now time.Time) IntermediatePayload {
+	return IntermediatePayload{
+		Serial:    testSerial,
+		Purpose:   PurposeLicenseSigning,
+		Algorithm: AlgorithmEd25519,
+		PublicKey: hex.EncodeToString(intPub),
+		NotBefore: now.Add(-time.Hour).Unix(),
+		NotAfter:  now.Add(90 * 24 * time.Hour).Unix(),
+		IssuedAt:  now.Add(-time.Hour).Unix(),
+	}
+}
+
+func testLicenseToken(t *testing.T, signer ed25519.PrivateKey, id string, now time.Time) string {
+	t.Helper()
+	token, err := Issue(License{
+		ID:        id,
+		Email:     "customer@example.com",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(24 * time.Hour).Unix(),
+		Features:  []string{FeatureFleet},
+	}, signer)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	return token
+}
+
+func TestSignAndParseIntermediate_RoundTrip(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, _ := testKeyPair(t)
+	now := time.Now().UTC()
+
+	cert, data := testIntermediate(t, rootPriv, intPub, now.Add(-time.Hour), now.Add(90*24*time.Hour))
+	if cert.Serial() != testSerial {
+		t.Fatalf("Serial() = %q, want %q", cert.Serial(), testSerial)
+	}
+
+	got, err := ParseAndVerifyIntermediate(data, rootPub, now)
+	if err != nil {
+		t.Fatalf("ParseAndVerifyIntermediate: %v", err)
+	}
+	if !got.PublicKey().Equal(intPub) {
+		t.Fatal("parsed intermediate public key does not match signed key")
+	}
+	exposed := got.PublicKey()
+	exposed[0] ^= 0xff
+	if !got.PublicKey().Equal(intPub) {
+		t.Fatal("PublicKey() returned mutable internal key storage")
+	}
+	if got.Serial() != testSerial {
+		t.Fatalf("parsed Serial() = %q, want %q", got.Serial(), testSerial)
+	}
+}
+
+func TestParseAndVerifyIntermediate_WrongRootRejected(t *testing.T) {
+	_, rootPriv := testKeyPair(t)
+	wrongPub, _ := testKeyPair(t)
+	intPub, _ := testKeyPair(t)
+	now := time.Now().UTC()
+
+	_, data := testIntermediate(t, rootPriv, intPub, now.Add(-time.Hour), now.Add(90*24*time.Hour))
+
+	if _, err := ParseAndVerifyIntermediate(data, wrongPub, now); err == nil {
+		t.Fatal("expected error verifying intermediate against wrong root key")
+	}
+}
+
+func TestParseAndVerifyIntermediate_TamperedRejected(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, _ := testKeyPair(t)
+	now := time.Now().UTC()
+
+	_, data := testIntermediate(t, rootPriv, intPub, now.Add(-time.Hour), now.Add(90*24*time.Hour))
+
+	// Flip the payload by re-encoding a different serial under the same signature.
+	var wire intermediateWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatal(err)
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(wire.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p IntermediatePayload
+	if err := json.Unmarshal(payloadBytes, &p); err != nil {
+		t.Fatal(err)
+	}
+	p.Serial = "int-tampered"
+	tamperedPayload, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wire.Payload = base64.RawURLEncoding.EncodeToString(tamperedPayload)
+	tampered, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ParseAndVerifyIntermediate(tampered, rootPub, now); err == nil {
+		t.Fatal("expected error verifying tampered intermediate")
+	}
+}
+
+func TestParseAndVerifyIntermediate_ValidityWindow(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, _ := testKeyPair(t)
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name      string
+		notBefore time.Time
+		notAfter  time.Time
+		wantErr   error
+	}{
+		{"expired", now.Add(-48 * time.Hour), now.Add(-time.Hour), ErrIntermediateExpired},
+		{"not-yet-valid", now.Add(time.Hour), now.Add(48 * time.Hour), ErrIntermediateNotYetValid},
+		{"current", now.Add(-time.Hour), now.Add(48 * time.Hour), nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, data := testIntermediate(t, rootPriv, intPub, tc.notBefore, tc.notAfter)
+			_, err := ParseAndVerifyIntermediate(data, rootPub, now)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("ParseAndVerifyIntermediate: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseAndVerifyIntermediate_PinnedFields(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, _ := testKeyPair(t)
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name    string
+		mutate  func(p *IntermediatePayload)
+		wantErr error
+	}{
+		{
+			name:    "wrong-purpose",
+			mutate:  func(p *IntermediatePayload) { p.Purpose = testWrongPurp },
+			wantErr: ErrIntermediatePurpose,
+		},
+		{
+			name:    "wrong-algorithm",
+			mutate:  func(p *IntermediatePayload) { p.Algorithm = testWrongAlg },
+			wantErr: ErrIntermediateAlgorithm,
+		},
+		{
+			name:    "empty-serial",
+			mutate:  func(p *IntermediatePayload) { p.Serial = "" },
+			wantErr: ErrIntermediateMalformed,
+		},
+		{
+			name:    "missing-issued-at",
+			mutate:  func(p *IntermediatePayload) { p.IssuedAt = 0 },
+			wantErr: ErrIntermediateMalformed,
+		},
+		{
+			name:    "missing-not-before",
+			mutate:  func(p *IntermediatePayload) { p.NotBefore = 0 },
+			wantErr: ErrIntermediateMalformed,
+		},
+		{
+			name:    "missing-not-after",
+			mutate:  func(p *IntermediatePayload) { p.NotAfter = 0 },
+			wantErr: ErrIntermediateMalformed,
+		},
+		{
+			name:    "not-after-before-not-before",
+			mutate:  func(p *IntermediatePayload) { p.NotAfter = p.NotBefore - 1 },
+			wantErr: ErrIntermediateMalformed,
+		},
+		{
+			name: "issued-at-after-not-after",
+			mutate: func(p *IntermediatePayload) {
+				p.IssuedAt = p.NotAfter + 1
+			},
+			wantErr: ErrIntermediateMalformed,
+		},
+		{
+			name: "validity-window-too-long",
+			mutate: func(p *IntermediatePayload) {
+				p.NotAfter = p.NotBefore + int64((500 * 24 * time.Hour).Seconds())
+			},
+			wantErr: ErrIntermediateMalformed,
+		},
+		{
+			name:    "bad-pubkey-hex",
+			mutate:  func(p *IntermediatePayload) { p.PublicKey = "nothex!!" },
+			wantErr: ErrIntermediateMalformed,
+		},
+		{
+			name:    "wrong-pubkey-size",
+			mutate:  func(p *IntermediatePayload) { p.PublicKey = hex.EncodeToString([]byte("short")) },
+			wantErr: ErrIntermediateMalformed,
+		},
+		{
+			name:    "unsupported-version",
+			mutate:  func(p *IntermediatePayload) { p.Version = 99 },
+			wantErr: ErrIntermediateMalformed,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := validIntermediatePayload(intPub, now)
+			tc.mutate(&p)
+			data := rawIntermediateWire(t, rootPriv, p)
+			_, err := ParseAndVerifyIntermediate(data, rootPub, now)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestSignIntermediate_RejectsBadPayload(t *testing.T) {
+	_, rootPriv := testKeyPair(t)
+	intPub, _ := testKeyPair(t)
+	now := time.Now().UTC()
+
+	base := validIntermediatePayload(intPub, now)
+
+	tests := []struct {
+		name   string
+		mutate func(p *IntermediatePayload)
+	}{
+		{"wrong-purpose", func(p *IntermediatePayload) { p.Purpose = testWrongPurp }},
+		{"wrong-algorithm", func(p *IntermediatePayload) { p.Algorithm = testWrongAlg }},
+		{"empty-serial", func(p *IntermediatePayload) { p.Serial = "" }},
+		{"naf-before-nbf", func(p *IntermediatePayload) { p.NotAfter = p.NotBefore - 1 }},
+		{"validity-too-long", func(p *IntermediatePayload) { p.NotAfter = p.NotBefore + int64((500 * 24 * time.Hour).Seconds()) }},
+		{"bad-pubkey", func(p *IntermediatePayload) { p.PublicKey = "nothex" }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := base
+			tc.mutate(&p)
+			if _, err := SignIntermediate(p, rootPriv); err == nil {
+				t.Fatal("expected SignIntermediate to reject invalid payload")
+			}
+		})
+	}
+
+	t.Run("bad-root-key-size", func(t *testing.T) {
+		if _, err := SignIntermediate(base, ed25519.PrivateKey("short")); err == nil {
+			t.Fatal("expected error for invalid root private key size")
+		}
+	})
+}
+
+func TestVerifyChain_IntermediateSignedToken(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, intPriv := testKeyPair(t)
+	now := time.Now().UTC()
+
+	cert, _ := testIntermediate(t, rootPriv, intPub, now.Add(-time.Hour), now.Add(90*24*time.Hour))
+	token := testLicenseToken(t, intPriv, "lic_int_signed", now)
+
+	lic, err := VerifyChain(token, &cert, rootPub, nil, now)
+	if err != nil {
+		t.Fatalf("VerifyChain: %v", err)
+	}
+	if lic.ID != "lic_int_signed" {
+		t.Fatalf("lic.ID = %q, want lic_int_signed", lic.ID)
+	}
+	if !lic.HasFeature(FeatureFleet) {
+		t.Fatal("expected fleet feature on chain-verified license")
+	}
+}
+
+func TestVerifyChain_LegacyRootTokenFallback(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, _ := testKeyPair(t)
+	now := time.Now().UTC()
+
+	// Token signed directly by ROOT (legacy), verified with a valid intermediate
+	// configured: the chain must fall back to direct-root verification.
+	cert, _ := testIntermediate(t, rootPriv, intPub, now.Add(-time.Hour), now.Add(90*24*time.Hour))
+	token := testLicenseToken(t, rootPriv, "lic_legacy_root", now)
+
+	lic, err := VerifyChain(token, &cert, rootPub, nil, now)
+	if err != nil {
+		t.Fatalf("VerifyChain legacy fallback: %v", err)
+	}
+	if lic.ID != "lic_legacy_root" {
+		t.Fatalf("lic.ID = %q, want lic_legacy_root", lic.ID)
+	}
+}
+
+func TestVerifyChain_NilIntermediateIsDirectRoot(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	now := time.Now().UTC()
+
+	token := testLicenseToken(t, rootPriv, "lic_direct", now)
+	lic, err := VerifyChain(token, nil, rootPub, nil, now)
+	if err != nil {
+		t.Fatalf("VerifyChain nil intermediate: %v", err)
+	}
+	if lic.ID != "lic_direct" {
+		t.Fatalf("lic.ID = %q, want lic_direct", lic.ID)
+	}
+
+	// A token signed by some other key must NOT verify under direct-root.
+	_, otherPriv := testKeyPair(t)
+	bad := testLicenseToken(t, otherPriv, "lic_forged", now)
+	if _, err := VerifyChain(bad, nil, rootPub, nil, now); err == nil {
+		t.Fatal("expected forged token to fail direct-root verification")
+	}
+}
+
+func TestVerifyChain_RevokedIntermediateFailsClosed(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, intPriv := testKeyPair(t)
+	now := time.Now().UTC()
+
+	cert, _ := testIntermediate(t, rootPriv, intPub, now.Add(-time.Hour), now.Add(90*24*time.Hour))
+	token := testLicenseToken(t, intPriv, "lic_after_revoke", now)
+	crl := testIntermediateCRL(t, rootPriv, now, testSerial)
+
+	_, err := VerifyChain(token, &cert, rootPub, &crl, now)
+	if !errors.Is(err, ErrIntermediateRevoked) {
+		t.Fatalf("error = %v, want ErrIntermediateRevoked", err)
+	}
+}
+
+func TestVerifyChain_ExpiredIntermediateFailsClosed(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, intPriv := testKeyPair(t)
+	now := time.Now().UTC()
+
+	// Cert was valid when parsed but the verification `now` is past NotAfter.
+	cert, _ := testIntermediate(t, rootPriv, intPub, now.Add(-90*24*time.Hour), now.Add(-time.Hour))
+	token := testLicenseToken(t, intPriv, "lic_expired_chain", now)
+
+	_, err := VerifyChain(token, &cert, rootPub, nil, now)
+	if !errors.Is(err, ErrIntermediateExpired) {
+		t.Fatalf("error = %v, want ErrIntermediateExpired", err)
+	}
+}
+
+func TestVerifyChain_ReverifiesIntermediateObject(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, _ := testKeyPair(t)
+	now := time.Now().UTC()
+
+	validCert, _ := testIntermediate(t, rootPriv, intPub, now.Add(-time.Hour), now.Add(90*24*time.Hour))
+	legacyToken := testLicenseToken(t, rootPriv, "lic_legacy_root", now)
+
+	t.Run("missing-signature-fails-closed-before-legacy-fallback", func(t *testing.T) {
+		handBuilt := Intermediate{Payload: validCert.Payload}
+		if _, err := VerifyChain(legacyToken, &handBuilt, rootPub, nil, now); !errors.Is(err, ErrIntermediateMalformed) {
+			t.Fatalf("error = %v, want ErrIntermediateMalformed", err)
+		}
+	})
+
+	t.Run("tampered-payload-cache-fails-closed-before-legacy-fallback", func(t *testing.T) {
+		tampered := validCert
+		tampered.Payload.Serial = "tampered-public-field"
+		tampered.payload = []byte(`{"version":1,"serial":"tampered-signed-bytes"}`)
+		if _, err := VerifyChain(legacyToken, &tampered, rootPub, nil, now); !errors.Is(err, ErrIntermediateSignature) {
+			t.Fatalf("error = %v, want ErrIntermediateSignature", err)
+		}
+	})
+}
+
+func TestVerifyTokenWithOptionalIntermediate(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, intPriv := testKeyPair(t)
+	now := time.Now().UTC()
+
+	_, validCert := testIntermediate(t, rootPriv, intPub, now.Add(-time.Hour), now.Add(90*24*time.Hour))
+	_, expiredCert := testIntermediate(t, rootPriv, intPub, now.Add(-90*24*time.Hour), now.Add(-time.Hour))
+	intToken := testLicenseToken(t, intPriv, "lic_int", now)
+	rootToken := testLicenseToken(t, rootPriv, "lic_root", now)
+
+	t.Run("not-configured-legacy-only", func(t *testing.T) {
+		lic, err := VerifyTokenWithOptionalIntermediate(rootToken, nil, rootPub, nil, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if lic.ID != "lic_root" {
+			t.Fatalf("lic.ID = %q, want lic_root", lic.ID)
+		}
+		// Intermediate-signed token has no valid path without a configured cert.
+		if _, err := VerifyTokenWithOptionalIntermediate(intToken, nil, rootPub, nil, now); err == nil {
+			t.Fatal("expected intermediate-signed token to fail with no cert configured")
+		}
+	})
+
+	t.Run("valid-cert-intermediate-token", func(t *testing.T) {
+		lic, err := VerifyTokenWithOptionalIntermediate(intToken, validCert, rootPub, nil, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if lic.ID != "lic_int" {
+			t.Fatalf("lic.ID = %q, want lic_int", lic.ID)
+		}
+	})
+
+	t.Run("valid-cert-legacy-token-still-verifies", func(t *testing.T) {
+		lic, err := VerifyTokenWithOptionalIntermediate(rootToken, validCert, rootPub, nil, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if lic.ID != "lic_root" {
+			t.Fatalf("lic.ID = %q, want lic_root", lic.ID)
+		}
+	})
+
+	t.Run("configured-but-expired-fails-closed-even-for-legacy", func(t *testing.T) {
+		// Doctrine: a configured-but-invalid cert blocks ALL verification,
+		// including legacy root-signed tokens. Operator reverts by removing the
+		// cert config, never by silently falling through to root.
+		if _, err := VerifyTokenWithOptionalIntermediate(rootToken, expiredCert, rootPub, nil, now); err == nil {
+			t.Fatal("expected fail-closed on configured-but-expired cert")
+		}
+		if _, err := VerifyTokenWithOptionalIntermediate(intToken, expiredCert, rootPub, nil, now); err == nil {
+			t.Fatal("expected fail-closed on configured-but-expired cert for intermediate token")
+		}
+	})
+
+	t.Run("configured-but-revoked-fails-closed", func(t *testing.T) {
+		crl := testIntermediateCRL(t, rootPriv, now, testSerial)
+		if _, err := VerifyTokenWithOptionalIntermediate(intToken, validCert, rootPub, &crl, now); !errors.Is(err, ErrIntermediateRevoked) {
+			t.Fatalf("error = %v, want ErrIntermediateRevoked", err)
+		}
+		// Even a legacy root token is blocked while a revoked cert is configured.
+		if _, err := VerifyTokenWithOptionalIntermediate(rootToken, validCert, rootPub, &crl, now); !errors.Is(err, ErrIntermediateRevoked) {
+			t.Fatalf("legacy error = %v, want ErrIntermediateRevoked", err)
+		}
+	})
+
+	t.Run("configured-but-garbage-fails-closed", func(t *testing.T) {
+		if _, err := VerifyTokenWithOptionalIntermediate(rootToken, []byte("{not a cert}"), rootPub, nil, now); err == nil {
+			t.Fatal("expected fail-closed on garbage cert bytes")
+		}
+	})
+}
+
+func TestParseAndVerifyIntermediate_MalformedInputs(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, _ := testKeyPair(t)
+	now := time.Now().UTC()
+	_, good := testIntermediate(t, rootPriv, intPub, now.Add(-time.Hour), now.Add(48*time.Hour))
+
+	goodSig := func() string {
+		var w intermediateWire
+		_ = json.Unmarshal(good, &w)
+		return w.Signature
+	}()
+	goodPayload := func() string {
+		var w intermediateWire
+		_ = json.Unmarshal(good, &w)
+		return w.Payload
+	}()
+
+	tests := []struct {
+		name   string
+		rootPK ed25519.PublicKey
+		data   []byte
+	}{
+		{"wrong-root-pubkey-size", ed25519.PublicKey("short"), good},
+		{"oversized", rootPub, make([]byte, maxIntermediateBytes+1)},
+		{"not-json", rootPub, []byte("not json")},
+		{"bad-base64-payload", rootPub, mustWire(t, "!!notb64", goodSig)},
+		{"bad-base64-signature", rootPub, mustWire(t, goodPayload, "!!notb64")},
+		{"wrong-signature-size", rootPub, mustWire(t, goodPayload, base64.RawURLEncoding.EncodeToString([]byte("short")))},
+		{"payload-not-json", rootPub, mustWire(t, base64.RawURLEncoding.EncodeToString([]byte("xx")), goodSig)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParseAndVerifyIntermediate(tc.data, tc.rootPK, now); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func mustWire(t *testing.T, payload, sig string) []byte {
+	t.Helper()
+	data, err := json.Marshal(intermediateWire{Payload: payload, Signature: sig})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func TestIntermediate_MarshalJSONFallback(t *testing.T) {
+	intPub, _ := testKeyPair(t)
+	now := time.Now().UTC()
+	// An Intermediate with no cached canonical bytes (e.g. hand-built) must
+	// re-marshal Payload on the fly.
+	im := Intermediate{
+		Payload:   validIntermediatePayload(intPub, now),
+		Signature: base64.RawURLEncoding.EncodeToString(make([]byte, ed25519.SignatureSize)),
+	}
+	data, err := json.Marshal(im)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var w intermediateWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		t.Fatal(err)
+	}
+	if w.Payload == "" {
+		t.Fatal("expected payload to be re-marshaled from Payload struct")
+	}
+}
+
+func TestVerifyChain_SurfacesDefinitiveErrors(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, intPriv := testKeyPair(t)
+	now := time.Now().UTC()
+	cert, _ := testIntermediate(t, rootPriv, intPub, now.Add(-time.Hour), now.Add(90*24*time.Hour))
+
+	t.Run("intermediate-signed-but-license-expired", func(t *testing.T) {
+		expiredTok, err := Issue(License{
+			ID:        "lic_exp",
+			Email:     "customer@example.com",
+			IssuedAt:  now.Add(-48 * time.Hour).Unix(),
+			ExpiresAt: now.Add(-time.Hour).Unix(),
+			Features:  []string{FeatureFleet},
+		}, intPriv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := VerifyChain(expiredTok, &cert, rootPub, nil, now); !errors.Is(err, ErrLicenseExpired) {
+			t.Fatalf("error = %v, want ErrLicenseExpired", err)
+		}
+	})
+
+	t.Run("legacy-root-token-expired-surfaced-via-fallback", func(t *testing.T) {
+		expiredRoot, err := Issue(License{
+			ID:        "lic_root_exp",
+			Email:     "customer@example.com",
+			IssuedAt:  now.Add(-48 * time.Hour).Unix(),
+			ExpiresAt: now.Add(-time.Hour).Unix(),
+			Features:  []string{FeatureFleet},
+		}, rootPriv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := VerifyChain(expiredRoot, &cert, rootPub, nil, now); !errors.Is(err, ErrLicenseExpired) {
+			t.Fatalf("error = %v, want ErrLicenseExpired", err)
+		}
+	})
+
+	t.Run("forged-token-fails-both-paths", func(t *testing.T) {
+		_, otherPriv := testKeyPair(t)
+		forged := testLicenseToken(t, otherPriv, "lic_forged", now)
+		if _, err := VerifyChain(forged, &cert, rootPub, nil, now); err == nil {
+			t.Fatal("expected forged token to fail")
+		}
+	})
+}
+
+func TestCheckIntermediate(t *testing.T) {
+	_, rootPriv := testKeyPair(t)
+	now := time.Now().UTC()
+
+	withReason := testIntermediateCRL(t, rootPriv, now, testSerial)
+	if err := withReason.CheckIntermediate(testSerial); !errors.Is(err, ErrIntermediateRevoked) {
+		t.Fatalf("revoked-with-reason: %v", err)
+	}
+	if err := withReason.CheckIntermediate("other-serial"); err != nil {
+		t.Fatalf("unrevoked serial should pass: %v", err)
+	}
+	if err := withReason.CheckIntermediate(""); !errors.Is(err, ErrIntermediateRevoked) {
+		t.Fatalf("empty serial must fail closed: %v", err)
+	}
+
+	// Revoked with empty reason hits the no-reason branch.
+	noReason, err := SignCRL(CRLPayload{
+		Version:   CRLVersion,
+		IssuedAt:  now.Add(-time.Hour).Unix(),
+		ExpiresAt: now.Add(7 * 24 * time.Hour).Unix(),
+		RevokedIntermediates: []RevokedIntermediate{{
+			Serial:    testSerial,
+			RevokedAt: now.Add(-time.Hour).Unix(),
+		}},
+	}, rootPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := noReason.CheckIntermediate(testSerial); !errors.Is(err, ErrIntermediateRevoked) {
+		t.Fatalf("revoked-no-reason: %v", err)
+	}
+
+	// Linear-scan fallback when the index is absent (defensive parity path).
+	noIndex := CRL{Payload: CRLPayload{RevokedIntermediates: []RevokedIntermediate{{Serial: testSerial, RevokedAt: 1}}}}
+	if _, ok := noIndex.RevocationForIntermediate(testSerial); !ok {
+		t.Fatal("expected linear-scan hit without index")
+	}
+	if _, ok := noIndex.RevocationForIntermediate("missing"); ok {
+		t.Fatal("expected linear-scan miss without index")
+	}
+}
+
+func TestSignCRL_RejectsBadIntermediateList(t *testing.T) {
+	_, rootPriv := testKeyPair(t)
+	now := time.Now().UTC()
+	base := CRLPayload{
+		Version:   CRLVersion,
+		IssuedAt:  now.Add(-time.Hour).Unix(),
+		ExpiresAt: now.Add(7 * 24 * time.Hour).Unix(),
+	}
+	tests := []struct {
+		name string
+		ints []RevokedIntermediate
+	}{
+		{"empty-serial", []RevokedIntermediate{{Serial: "", RevokedAt: 1}}},
+		{"missing-revoked-at", []RevokedIntermediate{{Serial: "s1"}}},
+		{"duplicate-serial", []RevokedIntermediate{{Serial: "s1", RevokedAt: 1}, {Serial: "s1", RevokedAt: 2}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := base
+			p.RevokedIntermediates = tc.ints
+			if _, err := SignCRL(p, rootPriv); err == nil {
+				t.Fatal("expected SignCRL to reject invalid intermediate list")
+			}
+		})
+	}
+}
+
+func TestVerifyChain_HandBuiltIntermediateRevalidated(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, intPriv := testKeyPair(t)
+	now := time.Now().UTC()
+	p := validIntermediatePayload(intPub, now)
+	p.Version = IntermediateVersion
+	pb, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig := ed25519.Sign(rootPriv, pb)
+	token := testLicenseToken(t, intPriv, "lic_handbuilt", now)
+
+	// Hand-built Intermediate with NO cached canonical bytes: VerifyChain must
+	// re-marshal Payload, re-verify against root, and accept it.
+	im := Intermediate{
+		Payload:   p,
+		Signature: base64.RawURLEncoding.EncodeToString(sig),
+	}
+	lic, err := VerifyChain(token, &im, rootPub, nil, now)
+	if err != nil {
+		t.Fatalf("VerifyChain hand-built: %v", err)
+	}
+	if lic.ID != "lic_handbuilt" {
+		t.Fatalf("lic.ID = %q, want lic_handbuilt", lic.ID)
+	}
+
+	// A hand-built Intermediate whose Payload was mutated after signing must
+	// fail closed: the re-marshal no longer matches the root signature.
+	tampered := Intermediate{Payload: p, Signature: im.Signature}
+	tampered.Payload.Serial = "int-tampered"
+	if _, err := VerifyChain(token, &tampered, rootPub, nil, now); !errors.Is(err, ErrIntermediateSignature) {
+		t.Fatalf("tampered hand-built error = %v, want ErrIntermediateSignature", err)
+	}
+}
+
+func TestParseAndVerifyIntermediate_ValidSigNonJSONPayload(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	now := time.Now().UTC()
+	// A payload the root genuinely signed but that is not valid JSON: the
+	// signature passes, then the structural parse must fail closed.
+	raw := []byte("root-signed but not json")
+	sig := ed25519.Sign(rootPriv, raw)
+	data, err := json.Marshal(intermediateWire{
+		Payload:   base64.RawURLEncoding.EncodeToString(raw),
+		Signature: base64.RawURLEncoding.EncodeToString(sig),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseAndVerifyIntermediate(data, rootPub, now); !errors.Is(err, ErrIntermediateMalformed) {
+		t.Fatalf("error = %v, want ErrIntermediateMalformed", err)
+	}
+}
+
+func TestVerifyTokenWithOptionalIntermediate_LicenseRevocationStillApplies(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, intPriv := testKeyPair(t)
+	now := time.Now().UTC()
+
+	_, validCert := testIntermediate(t, rootPriv, intPub, now.Add(-time.Hour), now.Add(90*24*time.Hour))
+	token := testLicenseToken(t, intPriv, "lic_revoked_id", now)
+	// CRL revokes the LICENSE id (not the intermediate). Chain must still reject.
+	crl := testCRL(t, rootPriv, now, "lic_revoked_id")
+
+	if _, err := VerifyTokenWithOptionalIntermediate(token, validCert, rootPub, &crl, now); !errors.Is(err, ErrLicenseRevoked) {
+		t.Fatalf("error = %v, want ErrLicenseRevoked", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a tiered license-signing primitive: the root key signs a short-lived intermediate certificate, and the intermediate signs license tokens. The root stays the sole trust anchor and can remain offline, so a compromise of the signing service loses only the intermediate, never the root.

## What's in this change (core primitive only)

- `internal/license/intermediate.go`: root-signed intermediate certificates. Each cert carries a serial / key id, a pinned purpose and algorithm, the intermediate public key, and a validity window, with the exact signed bytes preserved on the wire (the same canonical-bytes approach as the CRL).
- Offline verification chain: verify the intermediate against the root, check its validity window and revocation status, then verify the token against the intermediate public key. Direct-root verification is preserved as a fallback for existing root-signed tokens.
- A configured-but-invalid, expired, or revoked intermediate fails closed for all tokens and is never silently treated as absent. An operator reverts by removing the cert configuration.
- `internal/license/crl.go`: the signed CRL now also revokes intermediate certificates by serial, so rotating or burning an intermediate invalidates every token it signed. The CRL wire stays at version 1 (the new revoked list is an optional field; existing CRLs load unchanged).
- Purpose and algorithm are pinned at both signing and verification, so a root signature alone is not a blank check.

The license token wire format is unchanged. Which key signed a token is decided by the verifier from the configured intermediate certificate, not by anything in the token, keeping the highest-blast-radius surface frozen while adding the new trust tier alongside the existing CRL distribution channel.

## Scope

Core crypto primitive, proven at the package level. Wiring into the verification call sites and the signing service is intentionally left to follow-up changes so this one stays small and the trust-root change is reviewable in isolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for intermediate certificate-based license verification with automatic fallback to direct root verification
  * Extended certificate revocation list (CRL) to support revoking intermediate certificates in addition to individual license IDs
  * Implemented license verification chain with fail-closed behavior for invalid or revoked intermediates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->