### PR TITLE
feat(license): wire intermediate license chain through runtime and service flows

### DIFF
--- a/cmd/license-service/main.go
+++ b/cmd/license-service/main.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/licenseservice"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 	"github.com/rs/zerolog"
 )
@@ -46,13 +47,30 @@ func run(log zerolog.Logger) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	// Load the Ed25519 private key for signing license tokens.
-	// Uses the same key format as `pipelock license keygen`.
+	// Load the Ed25519 intermediate private key for signing license tokens.
+	// Uses the same key format as `pipelock license keygen`; the offline root
+	// key signs only the intermediate certificate and never runs in this service.
 	privateKey, err := signing.LoadPrivateKeyFile(cfg.PrivateKeyPath)
 	if err != nil {
 		return fmt.Errorf("load signing key: %w", err)
 	}
 	log.Info().Str("key_path", cfg.PrivateKeyPath).Msg("signing key loaded")
+
+	intermediateCert, err := license.LoadIntermediateCertFile(cfg.IntermediateCertPath)
+	if err != nil {
+		return fmt.Errorf("load intermediate certificate: %w", err)
+	}
+	cfg.IntermediateCert = intermediateCert
+	log.Info().Str("cert_path", cfg.IntermediateCertPath).Msg("intermediate certificate loaded")
+
+	if cfg.CRLSigningKeyPath != "" {
+		crlKey, err := signing.LoadPrivateKeyFile(cfg.CRLSigningKeyPath)
+		if err != nil {
+			return fmt.Errorf("load CRL signing key: %w", err)
+		}
+		cfg.CRLPrivateKey = crlKey
+		log.Info().Str("key_path", cfg.CRLSigningKeyPath).Msg("CRL signing key loaded")
+	}
 
 	// Open SQLite entitlement database (runs migrations).
 	db, err := licenseservice.OpenEntitlementDB(context.Background(), cfg.DBPath)

--- a/cmd/license-service/main_test.go
+++ b/cmd/license-service/main_test.go
@@ -1,0 +1,110 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+	"github.com/rs/zerolog"
+)
+
+func writeServiceTestIntermediate(t *testing.T, intermediatePub ed25519.PublicKey) string {
+	t.Helper()
+	_, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(root): %v", err)
+	}
+	now := time.Now().UTC()
+	im, err := license.SignIntermediate(license.IntermediatePayload{
+		Serial:    "im_cmd_test",
+		Purpose:   license.PurposeLicenseSigning,
+		Algorithm: license.AlgorithmEd25519,
+		PublicKey: hex.EncodeToString(intermediatePub),
+		NotBefore: now.Add(-time.Minute).Unix(),
+		NotAfter:  now.Add(time.Hour).Unix(),
+		IssuedAt:  now.Add(-time.Minute).Unix(),
+	}, rootPriv)
+	if err != nil {
+		t.Fatalf("SignIntermediate: %v", err)
+	}
+	data, err := json.Marshal(im)
+	if err != nil {
+		t.Fatalf("Marshal intermediate: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "intermediate.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write intermediate: %v", err)
+	}
+	return path
+}
+
+func writeServiceTestKey(t *testing.T, name string) (ed25519.PublicKey, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(%s): %v", name, err)
+	}
+	path := filepath.Join(t.TempDir(), name+".key")
+	if err := signing.SavePrivateKey(priv, path); err != nil {
+		t.Fatalf("SavePrivateKey(%s): %v", name, err)
+	}
+	return pub, path
+}
+
+func setServiceRunEnv(t *testing.T, keyPath, certPath string) {
+	t.Helper()
+	t.Setenv("POLAR_WEBHOOK_SECRET", "whsec_"+"dGVzdA==")
+	t.Setenv("POLAR_API_TOKEN", "polar_"+"test")
+	t.Setenv("PIPELOCK_LICENSE_KEY_PATH", keyPath)
+	t.Setenv("PIPELOCK_LICENSE_INTERMEDIATE_FILE", certPath)
+	t.Setenv("RESEND_API_KEY", "re_"+"test")
+	t.Setenv("DB_PATH", filepath.Join(t.TempDir(), "missing-parent", "licenses.db"))
+}
+
+func TestRun_LoadsIntermediateAndCRLKeysBeforeDatabaseOpen(t *testing.T) {
+	pub, keyPath := writeServiceTestKey(t, "token")
+	certPath := writeServiceTestIntermediate(t, pub)
+	_, crlKeyPath := writeServiceTestKey(t, "crl")
+	setServiceRunEnv(t, keyPath, certPath)
+	t.Setenv("PIPELOCK_LICENSE_CRL_SIGNING_KEY_PATH", crlKeyPath)
+
+	err := run(zerolog.New(io.Discard))
+	if err == nil || !strings.Contains(err.Error(), "open database") {
+		t.Fatalf("run() error = %v, want database open failure after key/cert loading", err)
+	}
+}
+
+func TestRun_LoadIntermediateFailure(t *testing.T) {
+	_, keyPath := writeServiceTestKey(t, "token")
+	setServiceRunEnv(t, keyPath, filepath.Join(t.TempDir(), "missing-intermediate.json"))
+
+	err := run(zerolog.New(io.Discard))
+	if err == nil || !strings.Contains(err.Error(), "load intermediate certificate") {
+		t.Fatalf("run() error = %v, want intermediate load failure", err)
+	}
+}
+
+func TestRun_LoadCRLSigningKeyFailure(t *testing.T) {
+	pub, keyPath := writeServiceTestKey(t, "token")
+	certPath := writeServiceTestIntermediate(t, pub)
+	setServiceRunEnv(t, keyPath, certPath)
+	t.Setenv("PIPELOCK_LICENSE_CRL_SIGNING_KEY_PATH", filepath.Join(t.TempDir(), "missing-crl.key"))
+
+	err := run(zerolog.New(io.Discard))
+	if err == nil || !strings.Contains(err.Error(), "load CRL signing key") {
+		t.Fatalf("run() error = %v, want CRL key load failure", err)
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1651,6 +1651,8 @@ If defined, `_default` applies to any request that does not match a named agent.
 
 Multi-agent profiles (the `agents:` section) require a signed license token. The token is an Ed25519-signed JWT-like string issued by `pipelock license issue`. At startup, pipelock verifies the signature, checks expiration, and confirms the token includes the `agents` feature. If any check fails, agent profiles are disabled with a warning. All single-agent protection remains active.
 
+New deployments may receive a root-signed intermediate certificate alongside the token. When `license_intermediate_file` is configured, Pipelock verifies the token through `token -> intermediate -> embedded root public key` and fails closed if the intermediate is malformed, expired, signed by the wrong root, or revoked by the CRL. Omitting `license_intermediate_file` preserves legacy direct-root token verification.
+
 ### Loading Sources
 
 Pipelock checks three sources for the license token, in priority order:
@@ -1691,6 +1693,7 @@ license_key: "pipelock_lic_v1_eyJ..."
 license_key: "pipelock_lic_v1_eyJ..."        # inline token (lowest priority)
 license_file: "/etc/pipelock/license.token"  # file path (medium priority)
 license_crl_file: "/etc/pipelock/license.crl" # signed revocation list
+license_intermediate_file: "/etc/pipelock/license-intermediate.json" # root-signed intermediate cert
 license_public_key: "a1b2c3d4..."            # hex-encoded Ed25519 public key (dev builds only)
 ```
 
@@ -1711,6 +1714,7 @@ Or mount the Secret as a file and reference it in config:
 
 ```yaml
 license_file: /etc/pipelock/license/token
+license_intermediate_file: /etc/pipelock/license/intermediate.json
 ```
 
 ### Key Verification
@@ -1718,6 +1722,8 @@ license_file: /etc/pipelock/license/token
 Official release builds embed the signing public key at compile time via ldflags. The embedded key takes priority over `license_public_key` and cannot be overridden by config, preventing self-signing bypasses. The `license_public_key` config field is only used in development builds where no key is embedded.
 
 `license_crl_file` points at a signed license revocation list. It is read and verified at startup and on config reload; a revoked active license is disabled immediately. The CRL file should be mounted from trusted operator-controlled storage, not written by the agent.
+
+`license_intermediate_file` points at the root-signed intermediate license-signing certificate. It is public cert material, not a secret, but it controls the active signing chain and should still come from trusted operator-controlled storage. Relative paths resolve against the config file directory. A configured intermediate certificate is checked at startup: a missing, unreadable, malformed, expired, or wrong-root cert emits a startup warning and disables licensed features such as multi-agent profiles and Assess signing, rather than silently downgrading to direct-root verification. It never blocks startup or single-agent protection — a licensing-tier misconfiguration must not take the proxy down, and a short-lived intermediate's expiry must not crash-loop it. Changing this field requires a restart for the new license chain to take effect.
 
 ### CLI Commands
 

--- a/docs/security/key-rotation-runbook.md
+++ b/docs/security/key-rotation-runbook.md
@@ -107,6 +107,70 @@ Pre-revocation artifacts remain verifiable by parties who already trusted the co
 
 Root rotation is the highest-risk procedure in this runbook. Schedule it during a maintenance window, not on a calendar trigger. Test the transition document on a non-production instance before distributing.
 
+## Rotating the license intermediate
+
+Pipelock license tokens can be signed by a short-lived intermediate key instead of the offline root. This is product license-signing custody, not internet PKI: the root public key remains the sole trust anchor embedded in Pipelock releases or supplied by `license_public_key` in development builds.
+
+The license service should hold only the intermediate private key and the root-signed intermediate certificate. The USB/offline root is used only to sign a new intermediate certificate and to sign the CRL that revokes old intermediate serials.
+
+Procedure:
+
+1. On an offline machine with the USB root attached, generate a fresh Ed25519 intermediate keypair. Use the standard Pipelock key format and keep the private key on a 0o700 directory with a 0o600 key file.
+
+```bash
+pipelock license keygen --out /secure/license-intermediate-YYYYMM
+```
+
+2. Sign a root-issued intermediate certificate for `license-signing` with a deployment-controlled admin utility in the Pipelock repo/module. Use a validity window that matches your custody policy, typically 90 days or 1 year. Record the certificate serial in the change ticket.
+
+There is no public CLI wrapper for this operation yet. Use a deployment-controlled admin utility that loads the USB root private key and calls `internal/license.SignIntermediate` with:
+
+```go
+license.IntermediatePayload{
+    Serial:    "im-YYYYMM",
+    Purpose:   license.PurposeLicenseSigning,
+    Algorithm: license.AlgorithmEd25519,
+    PublicKey: hex.EncodeToString(intermediatePublicKey),
+    NotBefore: now.Unix(),
+    NotAfter:  now.Add(90 * 24 * time.Hour).Unix(),
+    IssuedAt:  now.Unix(),
+}
+```
+
+3. Deploy the new intermediate private key and certificate to the license service. The service signs tokens with `PIPELOCK_LICENSE_KEY_PATH` and serves the configured certificate from `PIPELOCK_LICENSE_INTERMEDIATE_FILE`.
+
+```bash
+export PIPELOCK_LICENSE_KEY_PATH=/etc/pipelock/license-intermediate.key
+export PIPELOCK_LICENSE_INTERMEDIATE_FILE=/etc/pipelock/license-intermediate.json
+```
+
+4. Revoke the prior intermediate serial in the root-signed license CRL. This invalidates every token signed by the old intermediate after clients load the updated CRL.
+
+Use the same deployment-controlled admin utility to call `internal/license.SignCRL` with `RevokedIntermediates` populated:
+
+```go
+license.CRLPayload{
+    Version:   license.CRLVersion,
+    IssuedAt:  now.Unix(),
+    ExpiresAt: now.Add(7 * 24 * time.Hour).Unix(),
+    RevokedIntermediates: []license.RevokedIntermediate{{
+        Serial:    "im-PRIOR",
+        Reason:    "rotation",
+        RevokedAt: now.Unix(),
+    }},
+}
+```
+
+5. Deploy the updated CRL to verifiers via `license_crl_file` or `PIPELOCK_LICENSE_CRL_FILE`. Restart services whose license inputs changed; config reload warns on changed license inputs and preserves the active chain until restart.
+
+6. Verify after rotation. A newly issued token must verify with the new intermediate and the root public key, and the old intermediate serial must be rejected when the CRL is present.
+
+```bash
+pipelock license status --config /etc/pipelock/pipelock.yaml
+```
+
+If verification fails, roll back by restoring the prior intermediate key/cert pair and CRL, then restart the affected license service or verifier. Do not reattach or deploy the root key to the service to work around a failed rotation.
+
 ## Verification checklist
 
 The operator confirms before considering the rotation complete:

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -770,6 +770,7 @@ Policy bundles must not carry:
 - `license_file`
 - `license_public_key`
 - `license_crl_file`
+- `license_intermediate_file`
 - runtime-derived license status fields
 
 Reason: current Pipelock canonical policy hashes intentionally exclude license

--- a/enterprise/cli/license.go
+++ b/enterprise/cli/license.go
@@ -272,6 +272,7 @@ type licenseStatusReport struct {
 	CRLConfigured  bool   `json:"crl_configured"`
 	CRLExpiresAt   string `json:"crl_expires_at,omitempty"`
 	CRLSHA256      string `json:"crl_sha256,omitempty"`
+	Intermediate   bool   `json:"intermediate_configured"`
 	Reason         string `json:"reason,omitempty"`
 }
 
@@ -328,6 +329,7 @@ func buildLicenseStatusReport(configFile, crlFile string) (licenseStatusReport, 
 	if crlFile == "" {
 		crlFile = cfg.LicenseCRLFile
 	}
+	report.Intermediate = len(cfg.LicenseIntermediateCert) > 0
 	var crl *license.CRL
 	if crlFile != "" {
 		report.CRLConfigured = true
@@ -342,7 +344,7 @@ func buildLicenseStatusReport(configFile, crlFile string) (licenseStatusReport, 
 		report.CRLSHA256 = loaded.SHA256
 	}
 
-	lic, err := license.VerifyWithCRL(cfg.LicenseKey, pubKey, crl)
+	lic, err := license.VerifyTokenWithOptionalIntermediate(cfg.LicenseKey, cfg.LicenseIntermediateCert, pubKey, crl, time.Now())
 	report.LicenseID = lic.ID
 	report.Tier = lic.Tier
 	report.SubscriptionID = lic.SubscriptionID
@@ -425,6 +427,9 @@ func printLicenseStatus(cmd *cobra.Command, report licenseStatusReport) {
 		if report.CRLSHA256 != "" {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  CRL SHA:  %s\n", report.CRLSHA256)
 		}
+	}
+	if report.Intermediate {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Chain:    intermediate certificate configured\n")
 	}
 	if report.Reason != "" {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Reason:   %s\n", report.Reason)

--- a/enterprise/cli/license_test.go
+++ b/enterprise/cli/license_test.go
@@ -297,12 +297,13 @@ func TestPrintLicenseStatusVariants(t *testing.T) {
 		DaysRemaining:  7,
 		WarningBand:    7,
 		Severity:       "warn",
+		Intermediate:   true,
 		CRLConfigured:  true,
 		CRLExpiresAt:   "2026-06-02",
 		CRLSHA256:      "abc123",
 	})
 	out := buf.String()
-	for _, want := range []string{"lic_print", "Warning:", "CRL SHA:"} {
+	for _, want := range []string{"lic_print", "Warning:", "Chain:", "CRL SHA:"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("output missing %q:\n%s", want, out)
 		}

--- a/enterprise/conductor/bootstrap/material.go
+++ b/enterprise/conductor/bootstrap/material.go
@@ -341,7 +341,7 @@ func generateLicense(layout Layout, opts Options, identity controlplane.Follower
 	// VerifyFleet, which prefers a build-embedded production key and would
 	// reject this dev token on an official binary). Proves the issued token
 	// is signature-valid and carries the fleet entitlement before we write it.
-	verified, err := license.Verify(token, pub)
+	verified, err := license.VerifyTokenWithOptionalIntermediate(token, nil, pub, nil, now)
 	if err != nil {
 		return "", fmt.Errorf("generated fleet license failed self-verification: %w", err)
 	}

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -140,6 +140,7 @@ var forbiddenLicenseFields = map[string]struct{}{
 	"license_key":               {},
 	"license_file":              {},
 	"license_crl_file":          {},
+	"license_intermediate_file": {},
 	"license_public_key":        {},
 	"license_expires_at":        {},
 	"license_id":                {},

--- a/enterprise/config.go
+++ b/enterprise/config.go
@@ -280,8 +280,9 @@ func EnforceLicenseGate(c *config.Config) {
 		return
 	}
 
-	// Verify the license token signature, expiration, and revocation status.
-	lic, err := license.VerifyWithCRL(c.LicenseKey, pubKey, crl)
+	// Verify the license token signature, expiration, optional intermediate
+	// chain, and revocation status.
+	lic, err := license.VerifyTokenWithOptionalIntermediate(c.LicenseKey, c.LicenseIntermediateCert, pubKey, crl, time.Now())
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "WARNING: license verification failed: %v\n"+
 			"Multi-agent profiles disabled. Single-agent protection is active.\n", err)

--- a/enterprise/config.go
+++ b/enterprise/config.go
@@ -279,6 +279,12 @@ func EnforceLicenseGate(c *config.Config) {
 		stripNamedAgents(c)
 		return
 	}
+	if c.LicenseIntermediateLoadError != "" {
+		_, _ = fmt.Fprintf(os.Stderr, "WARNING: license intermediate validation failed: %s\n"+
+			"Multi-agent profiles disabled. Single-agent protection is active.\n", c.LicenseIntermediateLoadError)
+		stripNamedAgents(c)
+		return
+	}
 
 	// Verify the license token signature, expiration, optional intermediate
 	// chain, and revocation status.

--- a/enterprise/config.go
+++ b/enterprise/config.go
@@ -499,6 +499,9 @@ func ValidateMergedAgent(name string, cfg *config.Config) error {
 // deepCopyConfig creates an independent deep copy of a Config via
 // YAML round-trip. This ensures no shared pointers between base and merged.
 func deepCopyConfig(cfg *config.Config) (*config.Config, error) {
+	licenseIntermediateCert := append([]byte(nil), cfg.LicenseIntermediateCert...)
+	licenseIntermediateLoadError := cfg.LicenseIntermediateLoadError
+
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("deep copy marshal: %w", err)
@@ -507,5 +510,7 @@ func deepCopyConfig(cfg *config.Config) (*config.Config, error) {
 	if err := yaml.Unmarshal(data, &out); err != nil {
 		return nil, fmt.Errorf("deep copy unmarshal: %w", err)
 	}
+	out.LicenseIntermediateCert = licenseIntermediateCert
+	out.LicenseIntermediateLoadError = licenseIntermediateLoadError
 	return &out, nil
 }

--- a/enterprise/config_test.go
+++ b/enterprise/config_test.go
@@ -707,6 +707,25 @@ func TestEnforceLicenseGate_IntermediateChain(t *testing.T) {
 		}
 	})
 
+	t.Run("load error denies without direct root fallback", func(t *testing.T) {
+		token, pubHex := testLicenseKeyPair(t)
+		cfg := testConfigWithNamedAgent()
+		cfg.LicenseKey = token
+		cfg.LicensePublicKey = pubHex
+		cfg.LicenseIntermediateLoadError = "stat license_intermediate_file: no such file"
+
+		EnforceLicenseGate(cfg)
+		if cfg.Agents != nil {
+			t.Fatal("expected agents disabled when configured intermediate failed to load")
+		}
+		if cfg.LicenseID != "" {
+			t.Fatalf("license ID = %q, want empty for rejected intermediate load", cfg.LicenseID)
+		}
+		if cfg.LicenseRevoked {
+			t.Fatal("license should not be marked revoked for intermediate load failure")
+		}
+	})
+
 	t.Run("wrong root intermediate denies", func(t *testing.T) {
 		_, _, token, cert := testIntermediateLicenseBundle(t, "im_agents_wrong_root", now.Add(-time.Minute), now.Add(time.Hour))
 		wrongRootPub, _, err := ed25519.GenerateKey(rand.Reader)

--- a/enterprise/config_test.go
+++ b/enterprise/config_test.go
@@ -548,6 +548,53 @@ func testLicenseKeyPair(t *testing.T) (token string, pubHex string) {
 	return tok, hex.EncodeToString(pub)
 }
 
+func testIntermediateLicenseBundle(t *testing.T, serial string, notBefore, notAfter time.Time) (rootPub ed25519.PublicKey, rootPriv ed25519.PrivateKey, token string, cert []byte) {
+	t.Helper()
+	rootPub, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	intermediatePub, intermediatePriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	im, err := license.SignIntermediate(license.IntermediatePayload{
+		Serial:    serial,
+		Purpose:   license.PurposeLicenseSigning,
+		Algorithm: license.AlgorithmEd25519,
+		PublicKey: hex.EncodeToString(intermediatePub),
+		NotBefore: notBefore.Unix(),
+		NotAfter:  notAfter.Unix(),
+		IssuedAt:  notBefore.Unix(),
+	}, rootPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err = json.Marshal(im)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lic := license.License{
+		ID:        "lic_" + serial,
+		Email:     "test@example.com",
+		Features:  []string{license.FeatureAgents},
+		ExpiresAt: time.Now().Add(24 * time.Hour).Unix(),
+	}
+	token, err = license.Issue(lic, intermediatePriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rootPub, rootPriv, token, cert
+}
+
+func testConfigWithNamedAgent() *config.Config {
+	cfg := testConfig()
+	cfg.Agents = map[string]config.AgentProfile{
+		"claude-code": {Mode: config.ModeStrict},
+	}
+	return cfg
+}
+
 func TestEnforceLicenseGate_NoAgents(t *testing.T) {
 	cfg := testConfig()
 	cfg.Agents = nil
@@ -616,6 +663,103 @@ func TestEnforceLicenseGate_ValidLicense(t *testing.T) {
 	if cfg.LicenseExpiresAt == 0 {
 		t.Error("expected non-zero LicenseExpiresAt after valid license")
 	}
+}
+
+func TestEnforceLicenseGate_IntermediateChain(t *testing.T) {
+	now := time.Now().UTC()
+
+	t.Run("valid chain allows agents", func(t *testing.T) {
+		rootPub, _, token, cert := testIntermediateLicenseBundle(t, "im_agents_valid", now.Add(-time.Minute), now.Add(time.Hour))
+		cfg := testConfigWithNamedAgent()
+		cfg.LicenseKey = token
+		cfg.LicensePublicKey = hex.EncodeToString(rootPub)
+		cfg.LicenseIntermediateCert = cert
+
+		EnforceLicenseGate(cfg)
+		if cfg.Agents == nil {
+			t.Fatal("expected agents to remain with valid intermediate chain")
+		}
+	})
+
+	t.Run("expired intermediate denies", func(t *testing.T) {
+		rootPub, _, token, cert := testIntermediateLicenseBundle(t, "im_agents_expired", now.Add(-2*time.Hour), now.Add(-time.Hour))
+		cfg := testConfigWithNamedAgent()
+		cfg.LicenseKey = token
+		cfg.LicensePublicKey = hex.EncodeToString(rootPub)
+		cfg.LicenseIntermediateCert = cert
+
+		EnforceLicenseGate(cfg)
+		if cfg.Agents != nil {
+			t.Fatal("expected agents disabled with expired intermediate")
+		}
+	})
+
+	t.Run("malformed intermediate denies", func(t *testing.T) {
+		token, pubHex := testLicenseKeyPair(t)
+		cfg := testConfigWithNamedAgent()
+		cfg.LicenseKey = token
+		cfg.LicensePublicKey = pubHex
+		cfg.LicenseIntermediateCert = []byte("{bad json")
+
+		EnforceLicenseGate(cfg)
+		if cfg.Agents != nil {
+			t.Fatal("expected agents disabled with malformed intermediate")
+		}
+	})
+
+	t.Run("wrong root intermediate denies", func(t *testing.T) {
+		_, _, token, cert := testIntermediateLicenseBundle(t, "im_agents_wrong_root", now.Add(-time.Minute), now.Add(time.Hour))
+		wrongRootPub, _, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg := testConfigWithNamedAgent()
+		cfg.LicenseKey = token
+		cfg.LicensePublicKey = hex.EncodeToString(wrongRootPub)
+		cfg.LicenseIntermediateCert = cert
+
+		EnforceLicenseGate(cfg)
+		if cfg.Agents != nil {
+			t.Fatal("expected agents disabled with wrong-root intermediate")
+		}
+	})
+
+	t.Run("revoked intermediate denies", func(t *testing.T) {
+		const serial = "im_agents_revoked"
+		rootPub, rootPriv, token, cert := testIntermediateLicenseBundle(t, serial, now.Add(-time.Minute), now.Add(time.Hour))
+		cfg := testConfigWithNamedAgent()
+		cfg.LicenseKey = token
+		cfg.LicensePublicKey = hex.EncodeToString(rootPub)
+		cfg.LicenseIntermediateCert = cert
+
+		crl, err := license.SignCRL(license.CRLPayload{
+			Version:   license.CRLVersion,
+			IssuedAt:  now.Add(-time.Minute).Unix(),
+			ExpiresAt: now.Add(time.Hour).Unix(),
+			RevokedIntermediates: []license.RevokedIntermediate{{
+				Serial:    serial,
+				Reason:    "rotation",
+				RevokedAt: now.Unix(),
+			}},
+		}, rootPriv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		crlData, err := json.Marshal(crl)
+		if err != nil {
+			t.Fatal(err)
+		}
+		crlPath := filepath.Join(t.TempDir(), "crl.json")
+		if err := os.WriteFile(crlPath, crlData, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg.LicenseCRLFile = crlPath
+
+		EnforceLicenseGate(cfg)
+		if cfg.Agents != nil {
+			t.Fatal("expected agents disabled with revoked intermediate")
+		}
+	})
 }
 
 func TestEnforceLicenseGate_RevokedLicense(t *testing.T) {

--- a/enterprise/config_test.go
+++ b/enterprise/config_test.go
@@ -1260,6 +1260,8 @@ func TestMergeAgentProfile_TrustedDomainsNilInherits(t *testing.T) {
 func TestDeepCopyConfig(t *testing.T) {
 	cfg := testConfig()
 	cfg.Mode = config.ModeStrict
+	cfg.LicenseIntermediateCert = []byte("intermediate-cert")
+	cfg.LicenseIntermediateLoadError = "load failed"
 
 	cloned, err := deepCopyConfig(cfg)
 	if err != nil {
@@ -1268,6 +1270,16 @@ func TestDeepCopyConfig(t *testing.T) {
 	cloned.Mode = config.ModeAudit
 	if cfg.Mode != config.ModeStrict {
 		t.Error("deep copy mutated original")
+	}
+	if string(cloned.LicenseIntermediateCert) != "intermediate-cert" {
+		t.Fatalf("runtime intermediate cert not preserved: %q", string(cloned.LicenseIntermediateCert))
+	}
+	if cloned.LicenseIntermediateLoadError != "load failed" {
+		t.Fatalf("runtime intermediate load error = %q", cloned.LicenseIntermediateLoadError)
+	}
+	cloned.LicenseIntermediateCert[0] = 'X'
+	if string(cfg.LicenseIntermediateCert) != "intermediate-cert" {
+		t.Fatal("deep copy aliased runtime intermediate cert bytes")
 	}
 }
 

--- a/enterprise/licenseservice/config.go
+++ b/enterprise/licenseservice/config.go
@@ -5,6 +5,7 @@
 package licenseservice
 
 import (
+	"crypto/ed25519"
 	"fmt"
 	"os"
 	"strconv"
@@ -22,9 +23,27 @@ type Config struct {
 	// PolarAPIToken is the bearer token for Polar API calls.
 	PolarAPIToken string
 
-	// PrivateKeyPath is the filesystem path to the Ed25519 private key
-	// used for signing license tokens.
+	// PrivateKeyPath is the filesystem path to the Ed25519 intermediate
+	// private key used for signing license tokens. The offline root key must
+	// never be deployed to the license service.
 	PrivateKeyPath string
+
+	// IntermediateCertPath is the filesystem path to the root-signed
+	// intermediate certificate served beside issued tokens.
+	IntermediateCertPath string
+
+	// IntermediateCert is populated by cmd/license-service after loading
+	// IntermediateCertPath. It is public certificate bytes, not a secret.
+	IntermediateCert []byte
+
+	// CRLSigningKeyPath optionally points at the root/private key used to sign
+	// dynamic CRLs. Leave empty when CRLs are signed offline and distributed as
+	// files. The token signing key must not be reused for CRLs.
+	CRLSigningKeyPath string
+
+	// CRLPrivateKey is populated by cmd/license-service when CRLSigningKeyPath
+	// is set. It is intentionally separate from PrivateKeyPath.
+	CRLPrivateKey ed25519.PrivateKey
 
 	// ResendAPIKey is the API key for the Resend email service.
 	ResendAPIKey string
@@ -87,12 +106,16 @@ func LoadConfig() (*Config, error) {
 		PolarWebhookSecret: os.Getenv("POLAR_WEBHOOK_SECRET"),
 		PolarAPIToken:      os.Getenv("POLAR_API_TOKEN"),
 		PrivateKeyPath:     os.Getenv("PIPELOCK_LICENSE_KEY_PATH"),
-		ResendAPIKey:       os.Getenv("RESEND_API_KEY"),
-		DBPath:             envOrDefault("DB_PATH", defaultDBPath),
-		LedgerPath:         envOrDefault("LEDGER_PATH", defaultLedgerPath),
-		ListenAddr:         envOrDefault("LISTEN_ADDR", defaultListenAddr),
-		FromEmail:          envOrDefault("FROM_EMAIL", defaultFromEmail),
-		PolarAPIBase:       envOrDefault("POLAR_API_BASE", defaultPolarAPIBase),
+		IntermediateCertPath: os.Getenv(
+			"PIPELOCK_LICENSE_INTERMEDIATE_FILE",
+		),
+		CRLSigningKeyPath: os.Getenv("PIPELOCK_LICENSE_CRL_SIGNING_KEY_PATH"),
+		ResendAPIKey:      os.Getenv("RESEND_API_KEY"),
+		DBPath:            envOrDefault("DB_PATH", defaultDBPath),
+		LedgerPath:        envOrDefault("LEDGER_PATH", defaultLedgerPath),
+		ListenAddr:        envOrDefault("LISTEN_ADDR", defaultListenAddr),
+		FromEmail:         envOrDefault("FROM_EMAIL", defaultFromEmail),
+		PolarAPIBase:      envOrDefault("POLAR_API_BASE", defaultPolarAPIBase),
 	}
 
 	// Parse founding pro cap.
@@ -142,7 +165,10 @@ func LoadConfig() (*Config, error) {
 		return nil, fmt.Errorf("POLAR_API_TOKEN is required")
 	}
 	if cfg.PrivateKeyPath == "" {
-		return nil, fmt.Errorf("PIPELOCK_LICENSE_KEY_PATH is required (path to Ed25519 private key file)")
+		return nil, fmt.Errorf("PIPELOCK_LICENSE_KEY_PATH is required (path to Ed25519 intermediate private key file)")
+	}
+	if cfg.IntermediateCertPath == "" {
+		return nil, fmt.Errorf("PIPELOCK_LICENSE_INTERMEDIATE_FILE is required (path to root-signed intermediate certificate)")
 	}
 	if cfg.ResendAPIKey == "" {
 		return nil, fmt.Errorf("RESEND_API_KEY is required")

--- a/enterprise/licenseservice/config_test.go
+++ b/enterprise/licenseservice/config_test.go
@@ -15,6 +15,7 @@ func setRequiredConfigEnv(t *testing.T) {
 	t.Setenv("POLAR_WEBHOOK_SECRET", "whsec_"+"dGVzdA==")
 	t.Setenv("POLAR_API_TOKEN", "polar_"+"test")
 	t.Setenv("PIPELOCK_LICENSE_KEY_PATH", "/tmp/test.key")
+	t.Setenv("PIPELOCK_LICENSE_INTERMEDIATE_FILE", "/tmp/intermediate.json")
 	t.Setenv("RESEND_API_KEY", "re_"+"test")
 }
 
@@ -48,6 +49,7 @@ func TestLoadConfig_MissingRequired(t *testing.T) {
 		{"missing POLAR_WEBHOOK_SECRET", "POLAR_WEBHOOK_SECRET"},
 		{"missing POLAR_API_TOKEN", "POLAR_API_TOKEN"},
 		{"missing PIPELOCK_LICENSE_KEY_PATH", "PIPELOCK_LICENSE_KEY_PATH"},
+		{"missing PIPELOCK_LICENSE_INTERMEDIATE_FILE", "PIPELOCK_LICENSE_INTERMEDIATE_FILE"},
 		{"missing RESEND_API_KEY", "RESEND_API_KEY"},
 	}
 

--- a/enterprise/licenseservice/email.go
+++ b/enterprise/licenseservice/email.go
@@ -23,11 +23,12 @@ const (
 
 // licenseEmailData is the render context for the license delivery email.
 type licenseEmailData struct {
-	DisplayName  string
-	Token        string
-	ValidityDays int
-	IsTrial      bool
-	IsEval       bool
+	DisplayName      string
+	Token            string
+	IntermediateCert string
+	ValidityDays     int
+	IsTrial          bool
+	IsEval           bool
 }
 
 // licenseEmailTmpl renders the license delivery email. html/template auto-escapes
@@ -38,6 +39,8 @@ var licenseEmailTmpl = template.Must(template.New("license").Parse(
 <p>Thanks for choosing Pipelock {{.DisplayName}}!</p>
 <p>Your license token (add this to your pipelock config as <code>license_key</code>):</p>
 <pre style="background:#f4f4f4;padding:16px;border-radius:4px;overflow-x:auto;font-size:13px;">{{.Token}}</pre>
+<p>Your intermediate certificate (save as a file and set <code>license_intermediate_file</code> to that path):</p>
+<pre style="background:#f4f4f4;padding:16px;border-radius:4px;overflow-x:auto;font-size:13px;">{{.IntermediateCert}}</pre>
 {{- if .IsTrial}}
 <p>This token is valid for {{.ValidityDays}} days. To continue using Pro features after the trial, subscribe at <a href="https://pipelab.org/pricing/">pipelab.org/pricing</a>.</p>
 {{- else if .IsEval}}
@@ -103,13 +106,13 @@ func tierDisplayName(tier string) string {
 
 // SendLicenseDelivery sends the license token to the customer via email.
 // Returns the Resend message ID on success.
-func (e *EmailSender) SendLicenseDelivery(ctx context.Context, to, licenseToken, tier string) (string, error) {
+func (e *EmailSender) SendLicenseDelivery(ctx context.Context, to, licenseToken, tier, intermediateCert string) (string, error) {
 	displayName := tierDisplayName(tier)
 	subject := fmt.Sprintf("Your Pipelock %s License", displayName)
 
 	// Validity days are derived from the same lifetime constants the issuer uses,
 	// so the email copy can never drift from the actual token lifetime.
-	data := licenseEmailData{DisplayName: displayName, Token: licenseToken}
+	data := licenseEmailData{DisplayName: displayName, Token: licenseToken, IntermediateCert: intermediateCert}
 	switch tier {
 	case tierTrial:
 		data.IsTrial = true

--- a/enterprise/licenseservice/email_test.go
+++ b/enterprise/licenseservice/email_test.go
@@ -32,7 +32,7 @@ func TestEmailSender_SendLicenseDelivery(t *testing.T) {
 		apiURL:    srv.URL,
 	}
 
-	msgID, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token123", tierPro)
+	msgID, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token123", tierPro, "test-intermediate-cert")
 	if err != nil {
 		t.Fatalf("SendLicenseDelivery: %v", err)
 	}
@@ -44,6 +44,9 @@ func TestEmailSender_SendLicenseDelivery(t *testing.T) {
 	}
 	if !strings.Contains(gotBody, testCustomerEmail) {
 		t.Errorf("body should contain recipient email")
+	}
+	if !strings.Contains(gotBody, "license_intermediate_file") || !strings.Contains(gotBody, "test-intermediate-cert") {
+		t.Errorf("body should include intermediate certificate setup")
 	}
 }
 
@@ -64,7 +67,7 @@ func TestEmailSender_SendLicenseDelivery_FoundingPro(t *testing.T) {
 		apiURL:    srv.URL,
 	}
 
-	_, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token456", tierFoundingPro)
+	_, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token456", tierFoundingPro, "test-intermediate-cert")
 	if err != nil {
 		t.Fatalf("SendLicenseDelivery founding: %v", err)
 	}
@@ -111,7 +114,7 @@ func TestEmailSender_Send_APIError(t *testing.T) {
 		apiURL:    srv.URL,
 	}
 
-	_, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token", tierPro)
+	_, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token", tierPro, "test-intermediate-cert")
 	if err == nil {
 		t.Fatal("expected error for 400 response, got nil")
 	}
@@ -134,7 +137,7 @@ func TestEmailSender_Send_InvalidJSON(t *testing.T) {
 		apiURL:    srv.URL,
 	}
 
-	_, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token", tierPro)
+	_, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token", tierPro, "test-intermediate-cert")
 	if err == nil {
 		t.Fatal("expected error for invalid JSON response, got nil")
 	}
@@ -154,7 +157,7 @@ func TestEmailSender_Send_NetworkError(t *testing.T) {
 		apiURL:    srv.URL,
 	}
 
-	_, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token", tierPro)
+	_, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token", tierPro, "test-intermediate-cert")
 	if err == nil {
 		t.Fatal("expected network error for closed server, got nil")
 	}
@@ -168,7 +171,7 @@ func TestEmailSender_Send_BadURL(t *testing.T) {
 		apiURL:    "://invalid-url", // will fail NewRequestWithContext
 	}
 
-	_, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token", tierPro)
+	_, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token", tierPro, "test-intermediate-cert")
 	if err == nil {
 		t.Fatal("expected error for invalid URL, got nil")
 	}
@@ -191,7 +194,7 @@ func TestEmailSender_Send_CanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel before sending
 
-	_, err := sender.SendLicenseDelivery(ctx, testCustomerEmail, "token", tierPro)
+	_, err := sender.SendLicenseDelivery(ctx, testCustomerEmail, "token", tierPro, "test-intermediate-cert")
 	if err == nil {
 		t.Fatal("expected error for canceled context, got nil")
 	}
@@ -218,7 +221,7 @@ func TestEmailSender_Send_EmptyAPIURL(t *testing.T) {
 		apiURL:    "", // empty, triggers fallback
 	}
 
-	msgID, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token", tierPro)
+	msgID, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token", tierPro, "test-intermediate-cert")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -277,7 +280,7 @@ func TestEmailSender_SendLicenseDelivery_TrialSubject(t *testing.T) {
 		apiURL:    srv.URL,
 	}
 
-	_, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token789", tierTrial)
+	_, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token789", tierTrial, "test-intermediate-cert")
 	if err != nil {
 		t.Fatalf("SendLicenseDelivery trial: %v", err)
 	}
@@ -306,7 +309,7 @@ func TestEmailSender_SendLicenseDelivery_EnterpriseEvalValidity(t *testing.T) {
 		apiURL:    srv.URL,
 	}
 
-	_, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token_eval", tierEnterpriseEval)
+	_, err := sender.SendLicenseDelivery(t.Context(), testCustomerEmail, "token_eval", tierEnterpriseEval, "test-intermediate-cert")
 	if err != nil {
 		t.Fatalf("SendLicenseDelivery enterprise eval: %v", err)
 	}
@@ -335,7 +338,7 @@ func TestEmailSender_SendLicenseDelivery_EscapesToken(t *testing.T) {
 
 	e := &EmailSender{apiKey: "k", fromEmail: "f@x.test", client: srv.Client(), apiURL: srv.URL}
 	maliciousToken := "pipelock_lic_" + "v1_" + `<script>alert(1)</script>` //nolint:gosec // not a credential, an XSS probe for the escaping test
-	if _, err := e.SendLicenseDelivery(t.Context(), "to@x.test", maliciousToken, tierEnterpriseEval); err != nil {
+	if _, err := e.SendLicenseDelivery(t.Context(), "to@x.test", maliciousToken, tierEnterpriseEval, "test-intermediate-cert"); err != nil {
 		t.Fatalf("SendLicenseDelivery: %v", err)
 	}
 	if strings.Contains(gotBody, "<script>alert(1)</script>") {

--- a/enterprise/licenseservice/eval.go
+++ b/enterprise/licenseservice/eval.go
@@ -317,7 +317,7 @@ func (h *WebhookHandler) revokeEvalForOrder(ctx context.Context, order *PolarOrd
 // retry resends the same token via resendEvalIfNeeded (no re-mint).
 func (h *WebhookHandler) deliverEvalToken(ctx context.Context, ent *Entitlement, token string) error {
 	now := time.Now()
-	msgID, emailErr := h.email.SendLicenseDelivery(ctx, ent.CustomerEmail, token, ent.Tier)
+	msgID, emailErr := h.email.SendLicenseDelivery(ctx, ent.CustomerEmail, token, ent.Tier, string(h.cfg.IntermediateCert))
 	if emailErr != nil {
 		if err := h.db.UpdateDeliveryStatus(ctx, ent.SubscriptionID, "failed", now); err != nil {
 			return fmt.Errorf("update delivery status after email failure: %w", err)

--- a/enterprise/licenseservice/eval_test.go
+++ b/enterprise/licenseservice/eval_test.go
@@ -76,7 +76,7 @@ func newEvalTestSetup(t *testing.T) *evalTestSetup {
 		PolarWebhookSecret:  "whsec_" + "dGVzdA==",
 		PolarAPIToken:       testPolarAPIToken,
 		PrivateKeyPath:      filepath.Join(t.TempDir(), "k"),
-		IntermediateCert:    []byte(`{"payload":"eval-test","signature":"eval-test"}`),
+		IntermediateCert:    testServiceIntermediateCert(t, pub),
 		ResendAPIKey:        "re_" + "test",
 		DBPath:              ":memory:",
 		LedgerPath:          filepath.Join(t.TempDir(), "l.jsonl"),

--- a/enterprise/licenseservice/eval_test.go
+++ b/enterprise/licenseservice/eval_test.go
@@ -76,6 +76,7 @@ func newEvalTestSetup(t *testing.T) *evalTestSetup {
 		PolarWebhookSecret:  "whsec_" + "dGVzdA==",
 		PolarAPIToken:       testPolarAPIToken,
 		PrivateKeyPath:      filepath.Join(t.TempDir(), "k"),
+		IntermediateCert:    []byte(`{"payload":"eval-test","signature":"eval-test"}`),
 		ResendAPIKey:        "re_" + "test",
 		DBPath:              ":memory:",
 		LedgerPath:          filepath.Join(t.TempDir(), "l.jsonl"),

--- a/enterprise/licenseservice/server.go
+++ b/enterprise/licenseservice/server.go
@@ -66,6 +66,7 @@ func NewServer(
 
 	s.mux.HandleFunc("POST /webhook/polar", s.handleWebhook)
 	s.mux.HandleFunc(http.MethodGet+" /crl.json", s.handleCRL)
+	s.mux.HandleFunc(http.MethodGet+" /intermediate.json", s.handleIntermediate)
 	s.mux.HandleFunc("GET /health", s.handleHealth)
 
 	s.srv = &http.Server{
@@ -78,6 +79,28 @@ func NewServer(
 	}
 
 	return s
+}
+
+// handleIntermediate returns the root-signed intermediate certificate used to
+// verify tokens minted by this service.
+func (s *Server) handleIntermediate(w http.ResponseWriter, _ *http.Request) {
+	if len(s.cfg.IntermediateCert) == 0 {
+		http.Error(w, "intermediate certificate not configured", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(s.cfg.IntermediateCert); err != nil {
+		s.log.Error().Err(err).Msg("write intermediate certificate")
+		return
+	}
+	// The early return above guarantees IntermediateCert is non-empty here.
+	if s.cfg.IntermediateCert[len(s.cfg.IntermediateCert)-1] != '\n' {
+		if _, err := w.Write([]byte("\n")); err != nil {
+			s.log.Error().Err(err).Msg("write intermediate certificate newline")
+		}
+	}
 }
 
 // ListenAndServe starts the HTTP server. Blocks until the server is shut down.

--- a/enterprise/licenseservice/server_test.go
+++ b/enterprise/licenseservice/server_test.go
@@ -39,7 +39,7 @@ func newTestServer(t *testing.T) *Server {
 	db := openTestDB(t)
 	ledger, _ := openTestLedger(t)
 
-	_, priv, err := ed25519.GenerateKey(nil)
+	pub, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("generate key: %v", err)
 	}
@@ -70,7 +70,7 @@ func newTestServer(t *testing.T) *Server {
 		PolarWebhookSecret:  "whsec_" + secret,
 		PolarAPIToken:       testPolarAPIToken,
 		PrivateKeyPath:      filepath.Join(t.TempDir(), "test.key"),
-		IntermediateCert:    []byte(`{"payload":"server-test","signature":"server-test"}`),
+		IntermediateCert:    testServiceIntermediateCert(t, pub),
 		CRLPrivateKey:       priv,
 		ResendAPIKey:        "re_" + "test_server_key",
 		DBPath:              ":memory:",
@@ -146,7 +146,7 @@ func TestServer_IntermediateEndpoint(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
 	}
-	if !strings.Contains(rr.Body.String(), "server-test") {
+	if strings.TrimSpace(rr.Body.String()) != string(srv.cfg.IntermediateCert) {
 		t.Fatalf("body should contain configured intermediate certificate, got %q", rr.Body.String())
 	}
 }

--- a/enterprise/licenseservice/server_test.go
+++ b/enterprise/licenseservice/server_test.go
@@ -70,6 +70,8 @@ func newTestServer(t *testing.T) *Server {
 		PolarWebhookSecret:  "whsec_" + secret,
 		PolarAPIToken:       testPolarAPIToken,
 		PrivateKeyPath:      filepath.Join(t.TempDir(), "test.key"),
+		IntermediateCert:    []byte(`{"payload":"server-test","signature":"server-test"}`),
+		CRLPrivateKey:       priv,
 		ResendAPIKey:        "re_" + "test_server_key",
 		DBPath:              ":memory:",
 		LedgerPath:          filepath.Join(t.TempDir(), "server-test.jsonl"),
@@ -131,6 +133,21 @@ func TestServer_HealthEndpoint(t *testing.T) {
 	ct := w.Header().Get("Content-Type")
 	if ct != testContentTypeJSON {
 		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+}
+
+func TestServer_IntermediateEndpoint(t *testing.T) {
+	srv := newTestServer(t)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/intermediate.json", nil)
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if !strings.Contains(rr.Body.String(), "server-test") {
+		t.Fatalf("body should contain configured intermediate certificate, got %q", rr.Body.String())
 	}
 }
 

--- a/enterprise/licenseservice/server_test.go
+++ b/enterprise/licenseservice/server_test.go
@@ -43,6 +43,10 @@ func newTestServer(t *testing.T) *Server {
 	if err != nil {
 		t.Fatalf("generate key: %v", err)
 	}
+	_, crlPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate CRL key: %v", err)
+	}
 
 	// Polar mock returns active pro subscription.
 	polarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -71,7 +75,7 @@ func newTestServer(t *testing.T) *Server {
 		PolarAPIToken:       testPolarAPIToken,
 		PrivateKeyPath:      filepath.Join(t.TempDir(), "test.key"),
 		IntermediateCert:    testServiceIntermediateCert(t, pub),
-		CRLPrivateKey:       priv,
+		CRLPrivateKey:       crlPriv,
 		ResendAPIKey:        "re_" + "test_server_key",
 		DBPath:              ":memory:",
 		LedgerPath:          filepath.Join(t.TempDir(), "server-test.jsonl"),
@@ -149,6 +153,50 @@ func TestServer_IntermediateEndpoint(t *testing.T) {
 	if strings.TrimSpace(rr.Body.String()) != string(srv.cfg.IntermediateCert) {
 		t.Fatalf("body should contain configured intermediate certificate, got %q", rr.Body.String())
 	}
+}
+
+func TestServer_IntermediateEndpointMissingCert(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.IntermediateCert = nil
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/intermediate.json", nil)
+	rr := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusInternalServerError)
+	}
+}
+
+type flakyIntermediateWriter struct {
+	header    http.Header
+	failOn    int
+	writeCall int
+}
+
+func (w *flakyIntermediateWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *flakyIntermediateWriter) WriteHeader(int) {}
+
+func (w *flakyIntermediateWriter) Write([]byte) (int, error) {
+	w.writeCall++
+	if w.writeCall == w.failOn {
+		return 0, errors.New("write failed")
+	}
+	return 1, nil
+}
+
+func TestServer_IntermediateEndpointWriteErrors(t *testing.T) {
+	srv := newTestServer(t)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/intermediate.json", nil)
+
+	srv.handleIntermediate(&flakyIntermediateWriter{failOn: 1}, req)
+	srv.handleIntermediate(&flakyIntermediateWriter{failOn: 2}, req)
 }
 
 func TestServer_CRLEndpoint(t *testing.T) {

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -5,6 +5,7 @@
 package licenseservice
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -105,6 +106,17 @@ func NewWebhookHandler(
 	privateKey ed25519.PrivateKey,
 	log zerolog.Logger,
 ) (*WebhookHandler, error) {
+	if len(cfg.IntermediateCert) > 0 {
+		certPub, err := license.ExtractIntermediatePublicKey(cfg.IntermediateCert)
+		if err != nil {
+			return nil, fmt.Errorf("parse intermediate certificate public key: %w", err)
+		}
+		signingPub, ok := privateKey.Public().(ed25519.PublicKey)
+		if !ok || !bytes.Equal(certPub, signingPub) {
+			return nil, errors.New("intermediate certificate public key does not match license signing private key")
+		}
+	}
+
 	// Load founding count from DB to initialize the in-memory counter.
 	count, err := db.CountFounding(context.Background())
 	if err != nil {

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -329,7 +329,7 @@ func (h *WebhookHandler) handleActive(ctx context.Context, ent *Entitlement, exi
 	_ = h.ledger.LogLicenseIssued(ent.SubscriptionID, ent.CustomerEmail, lic.ID, ent.Tier, expiresAt)
 
 	// Attempt email delivery, update delivery status after.
-	msgID, emailErr := h.email.SendLicenseDelivery(ctx, ent.CustomerEmail, token, ent.Tier)
+	msgID, emailErr := h.email.SendLicenseDelivery(ctx, ent.CustomerEmail, token, ent.Tier, string(h.cfg.IntermediateCert))
 	if emailErr != nil {
 		h.log.Error().Err(emailErr).
 			Str("subscription_id", ent.SubscriptionID).
@@ -453,6 +453,9 @@ func (h *WebhookHandler) revokeSubscriptionLicenses(ctx context.Context, ent, ex
 
 // SignedCRL returns the current signed license revocation list.
 func (h *WebhookHandler) SignedCRL(ctx context.Context, now time.Time) (license.CRL, error) {
+	if len(h.cfg.CRLPrivateKey) != ed25519.PrivateKeySize {
+		return license.CRL{}, errors.New("license CRL signing key not configured")
+	}
 	records, err := h.db.ListLicenseRevocations(ctx)
 	if err != nil {
 		return license.CRL{}, fmt.Errorf("list license revocations: %w", err)
@@ -469,7 +472,7 @@ func (h *WebhookHandler) SignedCRL(ctx context.Context, now time.Time) (license.
 		IssuedAt:  now.UTC().Unix(),
 		ExpiresAt: now.UTC().Add(7 * 24 * time.Hour).Unix(),
 		Revoked:   revoked,
-	}, h.privateKey)
+	}, h.cfg.CRLPrivateKey)
 }
 
 // HandleOrderEvent processes a Polar order.created webhook event for

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -77,6 +77,10 @@ func newTestSetup(t *testing.T) *testSetup {
 	if err != nil {
 		t.Fatalf("generate key: %v", err)
 	}
+	_, crlPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate CRL key: %v", err)
+	}
 
 	// Default Polar mock: returns an active pro subscription.
 	polarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -104,7 +108,7 @@ func newTestSetup(t *testing.T) *testSetup {
 		PolarAPIToken:       testPolarAPIToken,
 		PrivateKeyPath:      filepath.Join(t.TempDir(), "test.key"),
 		IntermediateCert:    testServiceIntermediateCert(t, pub),
-		CRLPrivateKey:       priv,
+		CRLPrivateKey:       crlPriv,
 		ResendAPIKey:        "re_" + "test_key",
 		DBPath:              ":memory:",
 		LedgerPath:          filepath.Join(t.TempDir(), "test.jsonl"),
@@ -1108,6 +1112,32 @@ func TestNewWebhookHandler_RejectsIntermediateSigningKeyMismatch(t *testing.T) {
 		t.Fatal("expected intermediate/signing key mismatch error")
 	}
 	if !strings.Contains(err.Error(), "intermediate certificate public key does not match") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewWebhookHandler_RejectsMalformedIntermediate(t *testing.T) {
+	db := openTestDB(t)
+	ledger, _ := openTestLedger(t)
+
+	_, signingPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(signing): %v", err)
+	}
+
+	cfg := &Config{
+		IntermediateCert:    []byte("{bad json"),
+		FoundingProCap:      50,
+		FoundingProDeadline: time.Date(2099, 6, 30, 0, 0, 0, 0, time.UTC),
+	}
+	polar := NewPolarClient("token", "http://localhost")
+	email := NewEmailSender("key", "from@test.com")
+
+	_, err = NewWebhookHandler(cfg, db, polar, email, ledger, signingPriv, zerolog.Nop())
+	if err == nil {
+		t.Fatal("expected malformed intermediate error")
+	}
+	if !strings.Contains(err.Error(), "parse intermediate certificate public key") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -36,6 +37,32 @@ type testSetup struct {
 	emailSrv   *httptest.Server
 	privateKey ed25519.PrivateKey
 	publicKey  ed25519.PublicKey
+}
+
+func testServiceIntermediateCert(t *testing.T, intermediatePub ed25519.PublicKey) []byte {
+	t.Helper()
+	_, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(root): %v", err)
+	}
+	now := time.Now().UTC()
+	im, err := license.SignIntermediate(license.IntermediatePayload{
+		Serial:    "im_service_test",
+		Purpose:   license.PurposeLicenseSigning,
+		Algorithm: license.AlgorithmEd25519,
+		PublicKey: hex.EncodeToString(intermediatePub),
+		NotBefore: now.Add(-time.Minute).Unix(),
+		NotAfter:  now.Add(time.Hour).Unix(),
+		IssuedAt:  now.Add(-time.Minute).Unix(),
+	}, rootPriv)
+	if err != nil {
+		t.Fatalf("SignIntermediate: %v", err)
+	}
+	data, err := json.Marshal(im)
+	if err != nil {
+		t.Fatalf("Marshal intermediate: %v", err)
+	}
+	return data
 }
 
 // newTestSetup creates a complete test environment. The Polar mock returns
@@ -76,7 +103,7 @@ func newTestSetup(t *testing.T) *testSetup {
 		PolarWebhookSecret:  "whsec_" + "dGVzdA==",
 		PolarAPIToken:       testPolarAPIToken,
 		PrivateKeyPath:      filepath.Join(t.TempDir(), "test.key"),
-		IntermediateCert:    []byte(`{"payload":"test","signature":"test"}`),
+		IntermediateCert:    testServiceIntermediateCert(t, pub),
 		CRLPrivateKey:       priv,
 		ResendAPIKey:        "re_" + "test_key",
 		DBPath:              ":memory:",
@@ -1052,6 +1079,36 @@ func TestNewWebhookHandler_InitializesFoundingCount(t *testing.T) {
 
 	if handler.foundingCount != 3 {
 		t.Errorf("foundingCount = %d, want 3", handler.foundingCount)
+	}
+}
+
+func TestNewWebhookHandler_RejectsIntermediateSigningKeyMismatch(t *testing.T) {
+	db := openTestDB(t)
+	ledger, _ := openTestLedger(t)
+
+	certPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(cert): %v", err)
+	}
+	_, signingPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(signing): %v", err)
+	}
+
+	cfg := &Config{
+		IntermediateCert:    testServiceIntermediateCert(t, certPub),
+		FoundingProCap:      50,
+		FoundingProDeadline: time.Date(2099, 6, 30, 0, 0, 0, 0, time.UTC),
+	}
+	polar := NewPolarClient("token", "http://localhost")
+	email := NewEmailSender("key", "from@test.com")
+
+	_, err = NewWebhookHandler(cfg, db, polar, email, ledger, signingPriv, zerolog.Nop())
+	if err == nil {
+		t.Fatal("expected intermediate/signing key mismatch error")
+	}
+	if !strings.Contains(err.Error(), "intermediate certificate public key does not match") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -7,6 +7,7 @@ package licenseservice
 import (
 	"context"
 	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -75,6 +76,8 @@ func newTestSetup(t *testing.T) *testSetup {
 		PolarWebhookSecret:  "whsec_" + "dGVzdA==",
 		PolarAPIToken:       testPolarAPIToken,
 		PrivateKeyPath:      filepath.Join(t.TempDir(), "test.key"),
+		IntermediateCert:    []byte(`{"payload":"test","signature":"test"}`),
+		CRLPrivateKey:       priv,
 		ResendAPIKey:        "re_" + "test_key",
 		DBPath:              ":memory:",
 		LedgerPath:          filepath.Join(t.TempDir(), "test.jsonl"),
@@ -1204,6 +1207,61 @@ func TestProcessSubscription_RevokesAllUnexpiredIssuedLicenses(t *testing.T) {
 		if revoked.Reason != "" {
 			t.Fatalf("public CRL should omit reason, got %+v", revoked)
 		}
+	}
+}
+
+// TestSignedCRL_NoSigningKeyFailsClosed proves SignedCRL refuses to produce a
+// CRL when the dedicated CRL signing key is absent. The token signing key
+// (h.privateKey, the intermediate key) must never be reused to sign CRLs:
+// clients verify CRLs against the ROOT key, so an intermediate-signed CRL would
+// be silently rejected. Failing closed here surfaces the misconfiguration
+// instead of emitting an unverifiable CRL.
+func TestSignedCRL_NoSigningKeyFailsClosed(t *testing.T) {
+	ts := newTestSetup(t)
+	ts.handler.cfg.CRLPrivateKey = nil
+
+	_, err := ts.handler.SignedCRL(t.Context(), time.Now())
+	if err == nil {
+		t.Fatal("SignedCRL must fail closed when CRL signing key is not configured")
+	}
+	if !strings.Contains(err.Error(), "CRL signing key not configured") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSignedCRL_UsesDedicatedSigningKey(t *testing.T) {
+	ts := newTestSetup(t)
+	ctx := t.Context()
+	now := time.Now().UTC()
+
+	crlPub, crlPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(CRL): %v", err)
+	}
+	ts.handler.cfg.CRLPrivateKey = crlPriv
+
+	if err := ts.db.UpsertLicenseRevocation(ctx, RevokedLicenseRecord{
+		LicenseID:      "lic_dedicated_crl_key",
+		SubscriptionID: "sub_dedicated_crl_key",
+		Reason:         "subscription_canceled",
+		RevokedAt:      now,
+	}); err != nil {
+		t.Fatalf("UpsertLicenseRevocation: %v", err)
+	}
+
+	crl, err := ts.handler.SignedCRL(ctx, now)
+	if err != nil {
+		t.Fatalf("SignedCRL: %v", err)
+	}
+	data, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatalf("Marshal CRL: %v", err)
+	}
+	if _, err := license.ParseAndVerifyCRL(data, crlPub, now); err != nil {
+		t.Fatalf("CRL should verify with dedicated CRL key: %v", err)
+	}
+	if _, err := license.ParseAndVerifyCRL(data, ts.publicKey, now); err == nil {
+		t.Fatal("CRL unexpectedly verified with token signing key")
 	}
 }
 

--- a/internal/cli/assess/finalize.go
+++ b/internal/cli/assess/finalize.go
@@ -65,7 +65,7 @@ func checkAssessLicense(runDir string) bool {
 		return false
 	}
 
-	lic, err := license.Verify(cfg.LicenseKey, pubKey)
+	lic, err := license.VerifyTokenWithOptionalIntermediate(cfg.LicenseKey, cfg.LicenseIntermediateCert, pubKey, nil, time.Now())
 	if err != nil {
 		return false
 	}

--- a/internal/cli/assess/finalize_test.go
+++ b/internal/cli/assess/finalize_test.go
@@ -6,6 +6,8 @@ package assess
 import (
 	"archive/tar"
 	"compress/gzip"
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -14,8 +16,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/cli/audit"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
@@ -126,6 +130,63 @@ func TestAssessFinalize_Licensed_AutoSigns(t *testing.T) {
 	// Assert: NO summary files.
 	if _, err := os.Stat(filepath.Join(runDir, "summary.json")); err == nil {
 		t.Error("summary.json should not exist on licensed finalize")
+	}
+}
+
+func TestCheckAssessLicense_IntermediateChain(t *testing.T) {
+	now := time.Now().UTC()
+	rootPub, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	intermediatePub, intermediatePriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	im, err := license.SignIntermediate(license.IntermediatePayload{
+		Serial:    "im_assess_valid",
+		Purpose:   license.PurposeLicenseSigning,
+		Algorithm: license.AlgorithmEd25519,
+		PublicKey: hex.EncodeToString(intermediatePub),
+		NotBefore: now.Add(-time.Minute).Unix(),
+		NotAfter:  now.Add(time.Hour).Unix(),
+		IssuedAt:  now.Add(-time.Minute).Unix(),
+	}, rootPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certData, err := json.Marshal(im)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runDir, cfgFile := initTestRun(t)
+	certPath := filepath.Join(filepath.Dir(cfgFile), "intermediate.json")
+	if err := os.WriteFile(certPath, certData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	token, err := license.Issue(license.License{
+		ID:        "lic_assess_intermediate",
+		Email:     "assess@example.com",
+		Features:  []string{license.FeatureAssess},
+		ExpiresAt: now.Add(time.Hour).Unix(),
+	}, intermediatePriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfgData := "mode: audit\nlicense_key: " + token + "\nlicense_public_key: " + hex.EncodeToString(rootPub) + "\nlicense_intermediate_file: intermediate.json\n"
+	if err := os.WriteFile(cfgFile, []byte(cfgData), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !checkAssessLicense(runDir) {
+		t.Fatal("expected intermediate-signed assess license to be accepted")
+	}
+
+	if err := os.WriteFile(certPath, []byte("{bad json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if checkAssessLicense(runDir) {
+		t.Fatal("expected malformed configured intermediate to deny assess license")
 	}
 }
 

--- a/internal/cli/diag/doctor.go
+++ b/internal/cli/diag/doctor.go
@@ -249,6 +249,9 @@ func checkDoctorLicense(cfg *config.Config) doctorReportCheck {
 	if cfg.LicenseCRLFile != "" {
 		detail += "; signed CRL configured"
 	}
+	if len(cfg.LicenseIntermediateCert) > 0 {
+		detail += "; intermediate certificate configured"
+	}
 	return doctorReportCheck{
 		Name:       "license_status",
 		Surface:    doctorSurfaceConfig,
@@ -280,7 +283,7 @@ func doctorVerifiedLicense(cfg *config.Config) (license.License, bool, error) {
 		}
 		crl = &loaded
 	}
-	lic, verifyErr := license.VerifyWithCRL(cfg.LicenseKey, pubKey, crl)
+	lic, verifyErr := license.VerifyTokenWithOptionalIntermediate(cfg.LicenseKey, cfg.LicenseIntermediateCert, pubKey, crl, time.Now())
 	return lic, true, verifyErr
 }
 

--- a/internal/cli/diag/doctor_test.go
+++ b/internal/cli/diag/doctor_test.go
@@ -288,6 +288,46 @@ func TestDoctorLicenseStatusBranches(t *testing.T) {
 		}
 	})
 
+	t.Run("valid intermediate detail", func(t *testing.T) {
+		rootPub, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		intermediatePub, intermediatePriv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		im, err := license.SignIntermediate(license.IntermediatePayload{
+			Serial:    "im_doctor",
+			Purpose:   license.PurposeLicenseSigning,
+			Algorithm: license.AlgorithmEd25519,
+			PublicKey: hex.EncodeToString(intermediatePub),
+			NotBefore: now.Add(-time.Minute).Unix(),
+			NotAfter:  now.Add(time.Hour).Unix(),
+			IssuedAt:  now.Add(-time.Minute).Unix(),
+		}, rootPriv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cert, err := json.Marshal(im)
+		if err != nil {
+			t.Fatal(err)
+		}
+		token, err := license.Issue(active, intermediatePriv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg := config.Defaults()
+		cfg.LicenseKey = token
+		cfg.LicensePublicKey = hex.EncodeToString(rootPub)
+		cfg.LicenseIntermediateCert = cert
+
+		check := checkDoctorLicense(cfg)
+		if check.Status != doctorStatusOK || !strings.Contains(check.Detail, "intermediate certificate configured") {
+			t.Fatalf("check = %+v, want ok intermediate detail", check)
+		}
+	})
+
 	t.Run("revoked from CRL", func(t *testing.T) {
 		crl, err := license.SignCRL(license.CRLPayload{
 			Version:   license.CRLVersion,

--- a/internal/cli/runtime/license_crl.go
+++ b/internal/cli/runtime/license_crl.go
@@ -65,7 +65,7 @@ func (s *Server) checkLicenseCRL() (bool, error) {
 	if err != nil {
 		return true, err
 	}
-	_, err = license.VerifyWithCRL(cfg.LicenseKey, pubKey, &crl)
+	_, err = license.VerifyTokenWithOptionalIntermediate(cfg.LicenseKey, cfg.LicenseIntermediateCert, pubKey, &crl, time.Now())
 	if err == nil {
 		return false, nil
 	}

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -309,7 +309,7 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	// process does not silently start a half-wired follower the operator
 	// expects to be participating.
 	if cfg.Conductor.Enabled {
-		lic, err := license.VerifyFleet(cfg.LicenseKey, cfg.LicensePublicKey, cfg.LicenseCRLFile)
+		lic, err := license.VerifyFleetWithIntermediate(cfg.LicenseKey, cfg.LicensePublicKey, cfg.LicenseCRLFile, cfg.LicenseIntermediateFile)
 		if err != nil {
 			s.cleanup()
 			return nil, err

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -156,7 +156,8 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 		licenseInputsChanged := oldCfg.LicenseKey != newCfg.LicenseKey ||
 			oldCfg.LicensePublicKey != newCfg.LicensePublicKey ||
 			oldCfg.LicenseFile != newCfg.LicenseFile ||
-			oldCfg.LicenseCRLFile != newCfg.LicenseCRLFile
+			oldCfg.LicenseCRLFile != newCfg.LicenseCRLFile ||
+			oldCfg.LicenseIntermediateFile != newCfg.LicenseIntermediateFile
 
 		if agentsRevokedByLicense {
 			// License gate disabled agents on reload. Shut down
@@ -177,8 +178,11 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			newCfg.LicenseKey = oldCfg.LicenseKey
 			newCfg.LicenseFile = oldCfg.LicenseFile
 			newCfg.LicenseCRLFile = oldCfg.LicenseCRLFile
+			newCfg.LicenseIntermediateFile = oldCfg.LicenseIntermediateFile
+			newCfg.LicenseIntermediateCert = append([]byte(nil), oldCfg.LicenseIntermediateCert...)
+			newCfg.LicenseIntermediateLoadError = oldCfg.LicenseIntermediateLoadError
 			newCfg.LicensePublicKey = oldCfg.LicensePublicKey
-			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: license key inputs changed (license_key, license_file, license_crl_file, or license_public_key) - requires restart for license re-verification\n")
+			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: license key inputs changed (license_key, license_file, license_crl_file, license_intermediate_file, or license_public_key) - requires restart for license re-verification\n")
 		} else if AgentListenersChanged(oldCfg, newCfg) {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: agents[*].listeners changed — requires restart, ignoring listener changes\n")
 			PreserveAgentListeners(oldCfg, newCfg)

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -4,6 +4,7 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -157,7 +158,9 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			oldCfg.LicensePublicKey != newCfg.LicensePublicKey ||
 			oldCfg.LicenseFile != newCfg.LicenseFile ||
 			oldCfg.LicenseCRLFile != newCfg.LicenseCRLFile ||
-			oldCfg.LicenseIntermediateFile != newCfg.LicenseIntermediateFile
+			oldCfg.LicenseIntermediateFile != newCfg.LicenseIntermediateFile ||
+			!bytes.Equal(oldCfg.LicenseIntermediateCert, newCfg.LicenseIntermediateCert) ||
+			oldCfg.LicenseIntermediateLoadError != newCfg.LicenseIntermediateLoadError
 
 		if agentsRevokedByLicense {
 			// License gate disabled agents on reload. Shut down

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -4,6 +4,7 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net"
@@ -656,6 +657,56 @@ func TestServer_Reload_DedupSkipsValidateWarnings(t *testing.T) {
 	}
 	if buf.contains("response_scanning.exempt_domains") {
 		t.Fatalf("deduped reload printed validation warning:\n%s", buf.String())
+	}
+}
+
+func TestServer_Reload_PreservesLicenseIntermediateOnContentChange(t *testing.T) {
+	s, buf := newTestServer(t, nil)
+	oldCfg := s.proxy.CurrentConfig()
+	oldCfg.LicenseIntermediateFile = "/tmp/license-intermediate.json"
+	oldCfg.LicenseIntermediateCert = []byte("cert-v1")
+	oldCfg.LicenseIntermediateLoadError = ""
+
+	for _, tt := range []struct {
+		name    string
+		mutate  func(*config.Config)
+		wantLog string
+	}{
+		{
+			name: "cert bytes changed",
+			mutate: func(c *config.Config) {
+				c.LicenseIntermediateCert = []byte("cert-v2")
+			},
+			wantLog: "license key inputs changed",
+		},
+		{
+			name: "cert load became stale",
+			mutate: func(c *config.Config) {
+				c.LicenseIntermediateCert = []byte("configured intermediate certificate unavailable")
+				c.LicenseIntermediateLoadError = "stat license_intermediate_file: missing"
+			},
+			wantLog: "license key inputs changed",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			buf.reset()
+			s.lastReloadAt = time.Time{}
+			newCfg := oldCfg.Clone()
+			tt.mutate(newCfg)
+			if err := s.Reload(newCfg); err != nil {
+				t.Fatalf("Reload: %v", err)
+			}
+			live := s.proxy.CurrentConfig()
+			if !bytes.Equal(live.LicenseIntermediateCert, []byte("cert-v1")) {
+				t.Fatalf("live intermediate cert = %q, want cert-v1", string(live.LicenseIntermediateCert))
+			}
+			if live.LicenseIntermediateLoadError != "" {
+				t.Fatalf("live intermediate load error = %q, want empty", live.LicenseIntermediateLoadError)
+			}
+			if !buf.contains(tt.wantLog) {
+				t.Fatalf("reload stderr missing %q:\n%s", tt.wantLog, buf.String())
+			}
+		})
 	}
 }
 

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -154,6 +154,9 @@ func (c *Config) policySemanticView() Config {
 	view.LicenseKey = ""
 	view.LicenseFile = ""
 	view.LicenseCRLFile = ""
+	view.LicenseIntermediateFile = ""
+	view.LicenseIntermediateCert = nil
+	view.LicenseIntermediateLoadError = ""
 	view.LicensePublicKey = ""
 	view.LicenseExpiresAt = 0
 	view.LicenseID = ""

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8756,7 +8756,7 @@ func TestLicenseIntermediateFileConfigStates(t *testing.T) {
 		if err != nil {
 			t.Fatalf("missing public key must not be a fatal validate error, got %v", err)
 		}
-		if license.EmbeddedPublicKey() == nil && !hasLicenseIntermediateWarning(warnings) {
+		if !hasLicenseIntermediateWarning(warnings) {
 			t.Fatalf("expected a license_intermediate_file warning, got %+v", warnings)
 		}
 	})

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8760,6 +8760,30 @@ func TestLicenseIntermediateFileConfigStates(t *testing.T) {
 			t.Fatalf("expected a license_intermediate_file warning, got %+v", warnings)
 		}
 	})
+
+	t.Run("invalid public key warns, does not block startup", func(t *testing.T) {
+		tmp := t.TempDir()
+		certPath := filepath.Join(tmp, "intermediate.json")
+		if err := os.WriteFile(certPath, cert, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfgPath := filepath.Join(tmp, "cfg.yaml")
+		cfgData := "mode: balanced\nlicense_public_key: not-hex\nlicense_intermediate_file: intermediate.json\n"
+		if err := os.WriteFile(cfgPath, []byte(cfgData), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load(cfgPath)
+		if err != nil {
+			t.Fatalf("invalid public key must not fail config load, got %v", err)
+		}
+		warnings, err := cfg.ValidateWithWarnings()
+		if err != nil {
+			t.Fatalf("invalid public key must not be a fatal validate error, got %v", err)
+		}
+		if !hasLicenseIntermediateWarning(warnings) {
+			t.Fatalf("expected a license_intermediate_file warning, got %+v", warnings)
+		}
+	})
 }
 
 func hasLicenseIntermediateWarning(warnings []Warning) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,10 @@ package config
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -16,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"gopkg.in/yaml.v3"
 )
@@ -8569,6 +8574,249 @@ func TestLicenseFileParsedFromYAML(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "/some/path/license.token") {
 		t.Errorf("error should reference the configured path, got: %v", err)
+	}
+}
+
+func writeTestIntermediateCert(t *testing.T, rootPriv ed25519.PrivateKey, intermediatePub ed25519.PublicKey, serial string, notBefore, notAfter time.Time) []byte {
+	t.Helper()
+	im, err := license.SignIntermediate(license.IntermediatePayload{
+		Serial:    serial,
+		Purpose:   license.PurposeLicenseSigning,
+		Algorithm: license.AlgorithmEd25519,
+		PublicKey: hex.EncodeToString(intermediatePub),
+		NotBefore: notBefore.Unix(),
+		NotAfter:  notAfter.Unix(),
+		IssuedAt:  notBefore.Unix(),
+	}, rootPriv)
+	if err != nil {
+		t.Fatalf("SignIntermediate: %v", err)
+	}
+	data, err := json.Marshal(im)
+	if err != nil {
+		t.Fatalf("Marshal intermediate: %v", err)
+	}
+	return data
+}
+
+func TestLicenseIntermediateFileConfigStates(t *testing.T) {
+	rootPub, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(root): %v", err)
+	}
+	intermediatePub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(intermediate): %v", err)
+	}
+	now := time.Now().UTC()
+	cert := writeTestIntermediateCert(t, rootPriv, intermediatePub, "im_config", now.Add(-time.Minute), now.Add(time.Hour))
+
+	t.Run("omitted", func(t *testing.T) {
+		tmp := t.TempDir()
+		cfgPath := filepath.Join(tmp, "cfg.yaml")
+		if err := os.WriteFile(cfgPath, []byte("mode: balanced\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load(cfgPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.LicenseIntermediateFile != "" || len(cfg.LicenseIntermediateCert) != 0 {
+			t.Fatalf("intermediate should be empty on omitted field, got file=%q bytes=%d", cfg.LicenseIntermediateFile, len(cfg.LicenseIntermediateCert))
+		}
+	})
+
+	t.Run("null", func(t *testing.T) {
+		tmp := t.TempDir()
+		cfgPath := filepath.Join(tmp, "cfg.yaml")
+		if err := os.WriteFile(cfgPath, []byte("mode: balanced\nlicense_intermediate_file:\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load(cfgPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.LicenseIntermediateFile != "" || len(cfg.LicenseIntermediateCert) != 0 {
+			t.Fatalf("intermediate should be empty on null field, got file=%q bytes=%d", cfg.LicenseIntermediateFile, len(cfg.LicenseIntermediateCert))
+		}
+	})
+
+	t.Run("blank", func(t *testing.T) {
+		tmp := t.TempDir()
+		cfgPath := filepath.Join(tmp, "cfg.yaml")
+		if err := os.WriteFile(cfgPath, []byte("mode: balanced\nlicense_intermediate_file: \"   \"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load(cfgPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.LicenseIntermediateFile != "" || len(cfg.LicenseIntermediateCert) != 0 {
+			t.Fatalf("intermediate should be empty on blank field, got file=%q bytes=%d", cfg.LicenseIntermediateFile, len(cfg.LicenseIntermediateCert))
+		}
+	})
+
+	t.Run("explicit", func(t *testing.T) {
+		tmp := t.TempDir()
+		certPath := filepath.Join(tmp, "intermediate.json")
+		if err := os.WriteFile(certPath, cert, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfgPath := filepath.Join(tmp, "cfg.yaml")
+		cfgData := "mode: balanced\nlicense_public_key: " + hex.EncodeToString(rootPub) + "\nlicense_intermediate_file: intermediate.json\n"
+		if err := os.WriteFile(cfgPath, []byte(cfgData), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load(cfgPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.LicenseIntermediateFile != certPath {
+			t.Fatalf("intermediate path = %q, want %q", cfg.LicenseIntermediateFile, certPath)
+		}
+		if string(cfg.LicenseIntermediateCert) != string(cert) {
+			t.Fatalf("intermediate cert bytes not loaded")
+		}
+	})
+
+	// A malformed configured intermediate must NOT block startup: it degrades to
+	// a warning so free single-agent detection keeps running and a short-lived
+	// intermediate's expiry can never crash-loop the proxy. The runtime license
+	// gate fails closed separately by disabling agent profiles.
+	t.Run("malformed warns, does not block startup", func(t *testing.T) {
+		tmp := t.TempDir()
+		certPath := filepath.Join(tmp, "intermediate.json")
+		if err := os.WriteFile(certPath, []byte("{bad json"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfgPath := filepath.Join(tmp, "cfg.yaml")
+		cfgData := "mode: balanced\nlicense_public_key: " + hex.EncodeToString(rootPub) + "\nlicense_intermediate_file: intermediate.json\n"
+		if err := os.WriteFile(cfgPath, []byte(cfgData), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load(cfgPath)
+		if err != nil {
+			t.Fatalf("malformed intermediate must not fail config load, got %v", err)
+		}
+		warnings, err := cfg.ValidateWithWarnings()
+		if err != nil {
+			t.Fatalf("malformed intermediate must not be a fatal validate error, got %v", err)
+		}
+		if !hasLicenseIntermediateWarning(warnings) {
+			t.Fatalf("expected a license_intermediate_file warning, got %+v", warnings)
+		}
+	})
+
+	// A configured-but-missing intermediate must behave like any other bad
+	// configured intermediate: boot with a warning, but keep cert bytes non-empty
+	// so license verification cannot silently downgrade to direct-root mode.
+	t.Run("missing file warns, does not downgrade", func(t *testing.T) {
+		tmp := t.TempDir()
+		cfgPath := filepath.Join(tmp, "cfg.yaml")
+		cfgData := "mode: balanced\nlicense_public_key: " + hex.EncodeToString(rootPub) + "\nlicense_intermediate_file: missing-intermediate.json\n"
+		if err := os.WriteFile(cfgPath, []byte(cfgData), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load(cfgPath)
+		if err != nil {
+			t.Fatalf("missing intermediate must not fail config load, got %v", err)
+		}
+		if cfg.LicenseIntermediateLoadError == "" {
+			t.Fatal("expected load error to be recorded")
+		}
+		if len(cfg.LicenseIntermediateCert) == 0 {
+			t.Fatal("missing intermediate must leave non-empty cert bytes to prevent root fallback")
+		}
+		warnings, err := cfg.ValidateWithWarnings()
+		if err != nil {
+			t.Fatalf("missing intermediate must not be a fatal validate error, got %v", err)
+		}
+		if !hasLicenseIntermediateWarning(warnings) {
+			t.Fatalf("expected a license_intermediate_file warning, got %+v", warnings)
+		}
+	})
+
+	// Configured intermediate but no usable public key: warn, do not block.
+	t.Run("no public key warns, does not block startup", func(t *testing.T) {
+		tmp := t.TempDir()
+		certPath := filepath.Join(tmp, "intermediate.json")
+		if err := os.WriteFile(certPath, cert, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfgPath := filepath.Join(tmp, "cfg.yaml")
+		// No license_public_key, and unit tests run without an embedded key.
+		cfgData := "mode: balanced\nlicense_intermediate_file: intermediate.json\n"
+		if err := os.WriteFile(cfgPath, []byte(cfgData), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load(cfgPath)
+		if err != nil {
+			t.Fatalf("missing public key must not fail config load, got %v", err)
+		}
+		warnings, err := cfg.ValidateWithWarnings()
+		if err != nil {
+			t.Fatalf("missing public key must not be a fatal validate error, got %v", err)
+		}
+		if license.EmbeddedPublicKey() == nil && !hasLicenseIntermediateWarning(warnings) {
+			t.Fatalf("expected a license_intermediate_file warning, got %+v", warnings)
+		}
+	})
+}
+
+func hasLicenseIntermediateWarning(warnings []Warning) bool {
+	for _, w := range warnings {
+		if w.Field == "license_intermediate_file" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestLicenseIntermediateFileReloadParity(t *testing.T) {
+	rootPub, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(root): %v", err)
+	}
+	intermediatePub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(intermediate): %v", err)
+	}
+	now := time.Now().UTC()
+	cert1 := writeTestIntermediateCert(t, rootPriv, intermediatePub, "im_reload_1", now.Add(-time.Minute), now.Add(time.Hour))
+	cert2 := writeTestIntermediateCert(t, rootPriv, intermediatePub, "im_reload_2", now.Add(-time.Minute), now.Add(time.Hour))
+
+	tmp := t.TempDir()
+	certPath := filepath.Join(tmp, "intermediate.json")
+	cfgPath := filepath.Join(tmp, "cfg.yaml")
+	cfgData := "mode: balanced\nlicense_public_key: " + hex.EncodeToString(rootPub) + "\nlicense_intermediate_file: intermediate.json\n"
+	if err := os.WriteFile(certPath, cert1, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(cfgData), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first.LicenseIntermediateCert) != string(cert1) {
+		t.Fatal("first load did not read cert1")
+	}
+	unchanged, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(unchanged.LicenseIntermediateCert) != string(cert1) {
+		t.Fatal("reload without file change did not preserve cert1 bytes")
+	}
+	if err := os.WriteFile(certPath, cert2, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(changed.LicenseIntermediateCert) != string(cert2) {
+		t.Fatal("reload with file change did not read cert2")
 	}
 }
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/luckyPipewrench/pipelock/internal/license"
 	"gopkg.in/yaml.v3"
 )
 
@@ -62,6 +63,7 @@ func Load(path string) (*Config, error) {
 	if err := cfg.resolveLicenseKey(filepath.Dir(path)); err != nil {
 		return nil, fmt.Errorf("license key: %w", err)
 	}
+	cfg.resolveLicenseIntermediate(filepath.Dir(path))
 
 	// Soft-gate premium features: disable agents section if no license key.
 	if EnforceLicenseGateFunc != nil {
@@ -126,6 +128,33 @@ func Load(path string) (*Config, error) {
 	_ = cfg.CanonicalPolicyHash()
 
 	return cfg, nil
+}
+
+// resolveLicenseIntermediate populates LicenseIntermediateCert from
+// license_intermediate_file, resolving relative paths against configDir.
+// Empty/omitted means legacy direct-root verification.
+func (c *Config) resolveLicenseIntermediate(configDir string) {
+	if strings.TrimSpace(c.LicenseIntermediateFile) == "" {
+		c.LicenseIntermediateFile = ""
+		c.LicenseIntermediateCert = nil
+		c.LicenseIntermediateLoadError = ""
+		return
+	}
+	p := c.LicenseIntermediateFile
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(configDir, p)
+	}
+	p = filepath.Clean(p)
+	data, err := license.LoadIntermediateCertFile(p)
+	if err != nil {
+		c.LicenseIntermediateFile = p
+		c.LicenseIntermediateLoadError = err.Error()
+		c.LicenseIntermediateCert = []byte("configured intermediate certificate unavailable")
+		return
+	}
+	c.LicenseIntermediateFile = p
+	c.LicenseIntermediateCert = data
+	c.LicenseIntermediateLoadError = ""
 }
 
 // resolveLicenseKey populates LicenseKey from the highest-priority source:

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -204,6 +204,9 @@ func (c *Config) Clone() *Config {
 		copy(buf, c.rawBytes)
 		clone.rawBytes = buf
 	}
+	if c.LicenseIntermediateCert != nil {
+		clone.LicenseIntermediateCert = append([]byte(nil), c.LicenseIntermediateCert...)
+	}
 
 	clone.DLP.Patterns = cloneDLPPatterns(c.DLP.Patterns)
 	clone.ResponseScanning.Patterns = cloneResponseScanPatterns(c.ResponseScanning.Patterns)

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -370,6 +370,18 @@ func TestClone_RawBytesCopiedNotAliased(t *testing.T) {
 	}
 }
 
+func TestClone_LicenseIntermediateCertCopiedNotAliased(t *testing.T) {
+	cfg := Defaults()
+	cfg.LicenseIntermediateCert = []byte("intermediate-cert")
+
+	clone := cfg.Clone()
+	clone.LicenseIntermediateCert[0] = 'X'
+
+	if got := string(cfg.LicenseIntermediateCert); got != "intermediate-cert" {
+		t.Fatalf("Clone aliased LicenseIntermediateCert; source changed to %q", got)
+	}
+}
+
 // TestClone_NilSafe: Clone on a nil receiver returns nil without panicking.
 // Defensive: some test paths pass optional configs as *Config.
 func TestClone_NilSafe(t *testing.T) {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -376,12 +376,13 @@ type Config struct {
 	LearnLock                LearnLock               `yaml:"learn_lock" json:"-"` // operational lock-runtime config, excluded from canonical policy hash
 	Conductor                Conductor               `yaml:"conductor" json:"-"`  // follower control-plane config, excluded from canonical policy hash
 	Agents                   map[string]AgentProfile `yaml:"agents,omitempty"`
-	DefaultAgentIdentity     string                  `yaml:"default_agent_identity,omitempty"`      // operator-configured agent name used when no stronger identity source resolves the caller
-	BindDefaultAgentIdentity bool                    `yaml:"bind_default_agent_identity,omitempty"` // when true, ignore self-declared header/query identities and bind requests to default_agent_identity
-	LicenseKey               string                  `yaml:"license_key,omitempty"`                 // signed license token (from pipelock license issue)
-	LicenseFile              string                  `yaml:"license_file,omitempty"`                // path to file containing the license token (read at startup)
-	LicenseCRLFile           string                  `yaml:"license_crl_file,omitempty" json:"-"`   // path to signed license revocation list (read at startup)
-	LicensePublicKey         string                  `yaml:"license_public_key,omitempty"`          // hex-encoded Ed25519 public key for license verification (dev builds only)
+	DefaultAgentIdentity     string                  `yaml:"default_agent_identity,omitempty"`             // operator-configured agent name used when no stronger identity source resolves the caller
+	BindDefaultAgentIdentity bool                    `yaml:"bind_default_agent_identity,omitempty"`        // when true, ignore self-declared header/query identities and bind requests to default_agent_identity
+	LicenseKey               string                  `yaml:"license_key,omitempty"`                        // signed license token (from pipelock license issue)
+	LicenseFile              string                  `yaml:"license_file,omitempty"`                       // path to file containing the license token (read at startup)
+	LicenseCRLFile           string                  `yaml:"license_crl_file,omitempty" json:"-"`          // path to signed license revocation list (read at startup)
+	LicenseIntermediateFile  string                  `yaml:"license_intermediate_file,omitempty" json:"-"` // path to root-signed intermediate license-signing certificate
+	LicensePublicKey         string                  `yaml:"license_public_key,omitempty"`                 // hex-encoded Ed25519 public key for license verification (dev builds only)
 	Internal                 []string                `yaml:"internal"`
 	TrustedDomains           []string                `yaml:"trusted_domains"` // domains exempt from SSRF internal-IP check (wildcard supported)
 	SSRF                     SSRF                    `yaml:"ssrf"`
@@ -398,6 +399,11 @@ type Config struct {
 	LicenseCRLSHA256        string `yaml:"-" json:"-"`
 	LicenseRevoked          bool   `yaml:"-" json:"-"`
 	LicenseRevocationReason string `yaml:"-" json:"-"`
+	LicenseIntermediateCert []byte `yaml:"-" json:"-"`
+	// LicenseIntermediateLoadError records a configured cert file that could
+	// not be loaded. LicenseIntermediateCert stays non-empty in that state so
+	// verification fails closed instead of silently downgrading to root-only.
+	LicenseIntermediateLoadError string `yaml:"-" json:"-"`
 
 	// rawBytes stores the original config file bytes for deterministic hashing.
 	// Not serialized to YAML. Set by Load(), nil for Defaults().

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"crypto/ed25519"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -20,6 +21,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
@@ -85,6 +87,7 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 	if err := c.validateLogging(); err != nil {
 		return warnings, err
 	}
+	c.validateLicenseIntermediate(&warnings)
 	if err := c.validateDLP(); err != nil {
 		return warnings, err
 	}
@@ -237,6 +240,53 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 		return warnings, err
 	}
 	return warnings, nil
+}
+
+// validateLicenseIntermediate surfaces a configured intermediate certificate
+// that cannot anchor the license chain as an advisory WARNING, never a fatal
+// error. A licensing-tier misconfiguration must not block proxy startup: doing
+// so would take down free single-agent detection (violating the "never gate
+// detection behind a license" rule) and would crash-loop on the next restart
+// once a short-lived intermediate expires. The runtime license gate
+// (EnforceLicenseGate -> VerifyTokenWithOptionalIntermediate) already fails
+// closed on a bad cert by disabling agent profiles, so the safe degraded state
+// is reached without the early hard rejection.
+func (c *Config) validateLicenseIntermediate(warnings *[]Warning) {
+	if len(c.LicenseIntermediateCert) == 0 {
+		return
+	}
+	if c.LicenseIntermediateLoadError != "" {
+		*warnings = append(*warnings, Warning{
+			Field:   "license_intermediate_file",
+			Message: fmt.Sprintf("could not be loaded (%s) — licensed features will be disabled until the certificate is available", c.LicenseIntermediateLoadError),
+		})
+		return
+	}
+	pubKey := license.EmbeddedPublicKey()
+	if pubKey == nil {
+		if c.LicensePublicKey == "" {
+			*warnings = append(*warnings, Warning{
+				Field:   "license_intermediate_file",
+				Message: "configured but no license public key is available — agent profiles will be disabled until a key is provided",
+			})
+			return
+		}
+		keyBytes, err := hex.DecodeString(c.LicensePublicKey)
+		if err != nil || len(keyBytes) != ed25519.PublicKeySize {
+			*warnings = append(*warnings, Warning{
+				Field:   "license_intermediate_file",
+				Message: "configured but license_public_key is not a valid hex Ed25519 key — agent profiles will be disabled",
+			})
+			return
+		}
+		pubKey = ed25519.PublicKey(keyBytes)
+	}
+	if _, err := license.ParseAndVerifyIntermediate(c.LicenseIntermediateCert, pubKey, time.Now()); err != nil {
+		*warnings = append(*warnings, Warning{
+			Field:   "license_intermediate_file",
+			Message: fmt.Sprintf("rejected (%v) — agent profiles will be disabled until the certificate is valid", err),
+		})
+	}
 }
 
 // validateLearnLock enforces the schema for the lock runtime. When

--- a/internal/license/fleet_gate.go
+++ b/internal/license/fleet_gate.go
@@ -28,6 +28,11 @@ const EnvLicensePublicKey = "PIPELOCK_LICENSE_PUBLIC_KEY"
 // this to fail closed on revoked licenses.
 const EnvLicenseCRLFile = "PIPELOCK_LICENSE_CRL_FILE"
 
+// EnvLicenseIntermediateFile points to a root-signed intermediate
+// license-signing certificate. When set, fleet verification uses the
+// token->intermediate->root chain and fails closed if the certificate is bad.
+const EnvLicenseIntermediateFile = "PIPELOCK_LICENSE_INTERMEDIATE_FILE"
+
 // ErrFleetLicenseRequired is returned by RequireFleet when the supplied
 // license does not carry the fleet feature (or no license is present).
 // Callers should refuse to start fleet work and surface this error verbatim
@@ -61,6 +66,14 @@ func RequireFleet(licenseKey, publicKeyHex string) error {
 // crlFile argument, or PIPELOCK_LICENSE_CRL_FILE when empty, enables fail-closed
 // revocation checks with a signed CRL.
 func VerifyFleet(licenseKey, publicKeyHex, crlFile string) (License, error) {
+	return VerifyFleetWithIntermediate(licenseKey, publicKeyHex, crlFile, "")
+}
+
+// VerifyFleetWithIntermediate verifies the supplied fleet license, optionally
+// using a configured intermediate certificate file. Empty intermediateFile
+// falls back to PIPELOCK_LICENSE_INTERMEDIATE_FILE, then legacy direct-root
+// verification if neither is set.
+func VerifyFleetWithIntermediate(licenseKey, publicKeyHex, crlFile, intermediateFile string) (License, error) {
 	if licenseKey == "" {
 		licenseKey = os.Getenv(EnvLicenseKey)
 	}
@@ -87,19 +100,27 @@ func VerifyFleet(licenseKey, publicKeyHex, crlFile string) (License, error) {
 	if crlFile == "" {
 		crlFile = os.Getenv(EnvLicenseCRLFile)
 	}
-	var (
-		lic License
-		err error
-	)
+	var crl *CRL
 	if crlFile != "" {
-		crl, crlErr := LoadAndVerifyCRL(crlFile, pubKey, time.Now())
+		loaded, crlErr := LoadAndVerifyCRL(crlFile, pubKey, time.Now())
 		if crlErr != nil {
 			return License{}, fmt.Errorf("%w: loading license CRL: %w", ErrFleetLicenseRequired, crlErr)
 		}
-		lic, err = VerifyWithCRL(licenseKey, pubKey, &crl)
-	} else {
-		lic, err = Verify(licenseKey, pubKey)
+		crl = &loaded
 	}
+	if intermediateFile == "" {
+		intermediateFile = os.Getenv(EnvLicenseIntermediateFile)
+	}
+	var intermediateCert []byte
+	if intermediateFile != "" {
+		data, loadErr := LoadIntermediateCertFile(intermediateFile)
+		if loadErr != nil {
+			return License{}, fmt.Errorf("%w: loading intermediate certificate: %w", ErrFleetLicenseRequired, loadErr)
+		}
+		intermediateCert = data
+	}
+
+	lic, err := VerifyTokenWithOptionalIntermediate(licenseKey, intermediateCert, pubKey, crl, time.Now())
 	if err != nil {
 		return License{}, fmt.Errorf("%w: %w", ErrFleetLicenseRequired, err)
 	}

--- a/internal/license/fleet_gate_test.go
+++ b/internal/license/fleet_gate_test.go
@@ -54,6 +54,31 @@ func writeTestCRLFile(t *testing.T, priv ed25519.PrivateKey, revokedID string) s
 	return path
 }
 
+func writeTestIntermediateFile(t *testing.T, rootPriv ed25519.PrivateKey, intermediatePub ed25519.PublicKey, serial string, notBefore, notAfter time.Time) string {
+	t.Helper()
+	im, err := SignIntermediate(IntermediatePayload{
+		Serial:    serial,
+		Purpose:   PurposeLicenseSigning,
+		Algorithm: AlgorithmEd25519,
+		PublicKey: hex.EncodeToString(intermediatePub),
+		NotBefore: notBefore.Unix(),
+		NotAfter:  notAfter.Unix(),
+		IssuedAt:  notBefore.Unix(),
+	}, rootPriv)
+	if err != nil {
+		t.Fatalf("SignIntermediate: %v", err)
+	}
+	data, err := json.Marshal(im)
+	if err != nil {
+		t.Fatalf("Marshal intermediate: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "intermediate.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile(intermediate): %v", err)
+	}
+	return path
+}
+
 func TestRequireFleet_NoLicenseFailsClosed(t *testing.T) {
 	t.Setenv(EnvLicenseKey, "")
 	t.Setenv(EnvLicensePublicKey, "")
@@ -181,5 +206,51 @@ func TestVerifyFleet_ReadsCRLFromEnv(t *testing.T) {
 	_, err := VerifyFleet(tok, hex.EncodeToString(pub), "")
 	if !errors.Is(err, ErrLicenseRevoked) {
 		t.Fatalf("env CRL revoked fleet license: want ErrLicenseRevoked, got %v", err)
+	}
+}
+
+func TestVerifyFleetWithIntermediate_ValidChainAccepted(t *testing.T) {
+	rootPub, rootPriv := newKeyPair(t)
+	intermediatePub, intermediatePriv := newKeyPair(t)
+	now := time.Now().UTC()
+	intermediateFile := writeTestIntermediateFile(t, rootPriv, intermediatePub, "im_fleet_valid", now.Add(-time.Minute), now.Add(time.Hour))
+	tok := mustIssue(t, intermediatePriv, "lic_fleet_intermediate", []string{FeatureFleet})
+
+	got, err := VerifyFleetWithIntermediate(tok, hex.EncodeToString(rootPub), "", intermediateFile)
+	if err != nil {
+		t.Fatalf("VerifyFleetWithIntermediate: %v", err)
+	}
+	if got.ID != "lic_fleet_intermediate" {
+		t.Fatalf("license ID = %q, want lic_fleet_intermediate", got.ID)
+	}
+}
+
+func TestVerifyFleetWithIntermediate_BadConfiguredCertFailsClosed(t *testing.T) {
+	rootPub, intermediatePriv := newKeyPair(t)
+	tok := mustIssue(t, intermediatePriv, "lic_fleet_bad_im", []string{FeatureFleet})
+	intermediateFile := filepath.Join(t.TempDir(), "intermediate.json")
+	if err := os.WriteFile(intermediateFile, []byte("{bad json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := VerifyFleetWithIntermediate(tok, hex.EncodeToString(rootPub), "", intermediateFile)
+	if !errors.Is(err, ErrFleetLicenseRequired) {
+		t.Fatalf("bad intermediate: want ErrFleetLicenseRequired, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "intermediate") {
+		t.Fatalf("error should mention intermediate, got %v", err)
+	}
+}
+
+func TestVerifyFleetWithIntermediate_ReadsIntermediateFromEnv(t *testing.T) {
+	rootPub, rootPriv := newKeyPair(t)
+	intermediatePub, intermediatePriv := newKeyPair(t)
+	now := time.Now().UTC()
+	intermediateFile := writeTestIntermediateFile(t, rootPriv, intermediatePub, "im_fleet_env", now.Add(-time.Minute), now.Add(time.Hour))
+	tok := mustIssue(t, intermediatePriv, "lic_fleet_env_im", []string{FeatureFleet})
+	t.Setenv(EnvLicenseIntermediateFile, intermediateFile)
+
+	if _, err := VerifyFleet(tok, hex.EncodeToString(rootPub), ""); err != nil {
+		t.Fatalf("env intermediate fleet license: %v", err)
 	}
 }

--- a/internal/license/fleet_gate_test.go
+++ b/internal/license/fleet_gate_test.go
@@ -242,6 +242,20 @@ func TestVerifyFleetWithIntermediate_BadConfiguredCertFailsClosed(t *testing.T) 
 	}
 }
 
+func TestVerifyFleetWithIntermediate_LoadIntermediateErrorFailsClosed(t *testing.T) {
+	rootPub, rootPriv := newKeyPair(t)
+	tok := mustIssue(t, rootPriv, "lic_fleet_missing_im", []string{FeatureFleet})
+	intermediateFile := filepath.Join(t.TempDir(), "missing-intermediate.json")
+
+	_, err := VerifyFleetWithIntermediate(tok, hex.EncodeToString(rootPub), "", intermediateFile)
+	if !errors.Is(err, ErrFleetLicenseRequired) {
+		t.Fatalf("missing intermediate: want ErrFleetLicenseRequired, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "loading intermediate certificate") {
+		t.Fatalf("error should mention intermediate load failure, got %v", err)
+	}
+}
+
 func TestVerifyFleetWithIntermediate_ReadsIntermediateFromEnv(t *testing.T) {
 	rootPub, rootPriv := newKeyPair(t)
 	intermediatePub, intermediatePriv := newKeyPair(t)

--- a/internal/license/intermediate.go
+++ b/internal/license/intermediate.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -193,6 +194,31 @@ func ParseAndVerifyIntermediate(data []byte, rootPub ed25519.PublicKey, now time
 		return Intermediate{}, fmt.Errorf("%w: decode payload: %w", ErrIntermediateMalformed, err)
 	}
 	return verifyIntermediateBytes(payloadBytes, wire.Signature, rootPub, now)
+}
+
+// ExtractIntermediatePublicKey decodes the public key carried by an
+// intermediate certificate without trusting the certificate. It exists for
+// local service configuration checks, such as confirming the configured token
+// signing private key matches the public key operators will distribute in the
+// intermediate cert. It does not verify the root signature or current validity;
+// callers must use ParseAndVerifyIntermediate for trust decisions.
+func ExtractIntermediatePublicKey(data []byte) (ed25519.PublicKey, error) {
+	if len(data) > maxIntermediateBytes {
+		return nil, fmt.Errorf("%w: exceeds maximum size", ErrIntermediateMalformed)
+	}
+	var wire intermediateWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrIntermediateMalformed, err)
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(wire.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("%w: decode payload: %w", ErrIntermediateMalformed, err)
+	}
+	var payload IntermediatePayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return nil, fmt.Errorf("%w: parse payload: %w", ErrIntermediateMalformed, err)
+	}
+	return validateIntermediatePayload(payload)
 }
 
 // verifyIntermediateObject defensively re-validates an already decoded
@@ -380,7 +406,13 @@ func VerifyTokenWithOptionalIntermediate(token string, intermediateCert []byte, 
 // FIFOs, and oversized files so startup cannot hang or allocate unboundedly.
 func LoadIntermediateCertFile(path string) ([]byte, error) {
 	cleanPath := filepath.Clean(path)
-	info, err := os.Stat(cleanPath)
+	f, err := os.Open(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat license_intermediate_file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
 	if err != nil {
 		return nil, fmt.Errorf("stat license_intermediate_file: %w", err)
 	}
@@ -390,9 +422,12 @@ func LoadIntermediateCertFile(path string) ([]byte, error) {
 	if info.Size() > maxIntermediateBytes {
 		return nil, errors.New("license_intermediate_file exceeds maximum size")
 	}
-	data, err := os.ReadFile(cleanPath)
+	data, err := io.ReadAll(io.LimitReader(f, maxIntermediateBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read license_intermediate_file: %w", err)
+	}
+	if len(data) > maxIntermediateBytes {
+		return nil, errors.New("license_intermediate_file exceeds maximum size")
 	}
 	if len(data) == 0 {
 		return nil, errors.New("license_intermediate_file is empty")

--- a/internal/license/intermediate.go
+++ b/internal/license/intermediate.go
@@ -10,6 +10,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -371,4 +373,29 @@ func VerifyTokenWithOptionalIntermediate(token string, intermediateCert []byte, 
 		}
 	}
 	return VerifyChain(token, &im, rootPub, crl, now)
+}
+
+// LoadIntermediateCertFile reads an operator-configured intermediate
+// certificate file. The certificate is public, but this still rejects devices,
+// FIFOs, and oversized files so startup cannot hang or allocate unboundedly.
+func LoadIntermediateCertFile(path string) ([]byte, error) {
+	cleanPath := filepath.Clean(path)
+	info, err := os.Stat(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat license_intermediate_file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("license_intermediate_file must be a regular file")
+	}
+	if info.Size() > maxIntermediateBytes {
+		return nil, errors.New("license_intermediate_file exceeds maximum size")
+	}
+	data, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("read license_intermediate_file: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, errors.New("license_intermediate_file is empty")
+	}
+	return data, nil
 }

--- a/internal/license/intermediate_test.go
+++ b/internal/license/intermediate_test.go
@@ -9,6 +9,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -139,6 +142,125 @@ func TestSignAndParseIntermediate_RoundTrip(t *testing.T) {
 	if got.Serial() != testSerial {
 		t.Fatalf("parsed Serial() = %q, want %q", got.Serial(), testSerial)
 	}
+}
+
+func TestExtractIntermediatePublicKey(t *testing.T) {
+	_, rootPriv := testKeyPair(t)
+	intPub, _ := testKeyPair(t)
+	now := time.Now().UTC()
+	_, data := testIntermediate(t, rootPriv, intPub, now.Add(-time.Hour), now.Add(time.Hour))
+
+	got, err := ExtractIntermediatePublicKey(data)
+	if err != nil {
+		t.Fatalf("ExtractIntermediatePublicKey: %v", err)
+	}
+	if !got.Equal(intPub) {
+		t.Fatal("extracted public key does not match intermediate payload")
+	}
+	got[0] ^= 0xff
+	if got2, err := ExtractIntermediatePublicKey(data); err != nil || !got2.Equal(intPub) {
+		t.Fatalf("extracted key should not expose mutable package state: key=%x err=%v", got2, err)
+	}
+
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"oversized", intermediateBytesOfLen(maxIntermediateBytes + 1)},
+		{"bad-wire-json", []byte("{bad json")},
+		{"bad-payload-base64", mustWire(t, "!!notb64", "")},
+		{"bad-payload-json", mustWire(t, base64.RawURLEncoding.EncodeToString([]byte("not json")), "")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ExtractIntermediatePublicKey(tc.data); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestLoadIntermediateCertFile(t *testing.T) {
+	_, rootPriv := testKeyPair(t)
+	intPub, _ := testKeyPair(t)
+	now := time.Now().UTC()
+	_, data := testIntermediate(t, rootPriv, intPub, now.Add(-time.Hour), now.Add(time.Hour))
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "intermediate.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadIntermediateCertFile(path)
+	if err != nil {
+		t.Fatalf("LoadIntermediateCertFile: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatal("loaded intermediate bytes do not match file")
+	}
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T) string
+		wantErr string
+	}{
+		{
+			name: "missing",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return filepath.Join(t.TempDir(), "missing.json")
+			},
+			wantErr: "stat license_intermediate_file",
+		},
+		{
+			name: "directory",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return t.TempDir()
+			},
+			wantErr: "regular file",
+		},
+		{
+			name: "oversized",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				path := filepath.Join(t.TempDir(), "oversized.json")
+				if err := os.WriteFile(path, intermediateBytesOfLen(maxIntermediateBytes+1), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			wantErr: "maximum size",
+		},
+		{
+			name: "empty",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				path := filepath.Join(t.TempDir(), "empty.json")
+				if err := os.WriteFile(path, nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			wantErr: "empty",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := LoadIntermediateCertFile(tc.setup(t))
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("LoadIntermediateCertFile error = %v, want contains %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func intermediateBytesOfLen(n int) []byte {
+	data := make([]byte, n)
+	for i := range data {
+		data[i] = 'x'
+	}
+	return data
 }
 
 func TestParseAndVerifyIntermediate_WrongRootRejected(t *testing.T) {


### PR DESCRIPTION
## Summary

- routes license verification through an optional root-signed intermediate certificate across runtime config, Assess, doctor/status, fleet gates, and enterprise license checks
- adds license-service support for loading and serving the intermediate certificate while keeping dynamic CRL signing on the dedicated root CRL key path
- makes configured-but-bad or unloadable intermediates warn and disable licensed features without blocking baseline protection or silently downgrading to direct-root verification
- documents intermediate deployment, CRL signing requirements, and rotation steps

## Deploy Notes

- `PIPELOCK_LICENSE_INTERMEDIATE_FILE` is now required for the license-service token issuance path so issued tokens can be distributed with the root-signed intermediate certificate.
- Dynamic `/crl.json` serving now requires `PIPELOCK_LICENSE_CRL_SIGNING_KEY_PATH`; CRLs must be signed by the root CRL key because clients verify CRLs against the root trust anchor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional intermediate-certificate support for license verification
  * Exposes intermediate certificate via GET /intermediate.json
  * Support for a dedicated CRL signing key
  * CLI/status now reports when an intermediate certificate is configured

* **Documentation**
  * Added `license_intermediate_file` config docs and rotation runbook
  * License delivery emails include intermediate setup instructions
  * Spec updated to forbid intermediate in policy bundles

* **Improvements**
  * Verification fails closed on intermediate/CRL errors; licensed features warn/disable
  * Intermediate config changes require service restart
<!-- end of auto-generated comment: release notes by coderabbit.ai -->