### PR TITLE
fix(runtime): join listener goroutines before cleanup nils shared fields

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1349,11 +1349,16 @@ response_scanning:
 		t.Fatal(err)
 	}
 
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+	// Reload observation needs a longer deadline than the initial health
+	// check: fsnotify delivery plus the 100ms debounce plus the atomic config
+	// swap lag well past 5s under the heavy -race CI job (config+cli+mcp+proxy
+	// in one process). The startup wait above stays snappy; only this
+	// reload-to-take-effect wait gets the longer ceiling.
+	waitForRunHTTPWithin(t, 20*time.Second, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
 		var health map[string]any
 		_ = json.NewDecoder(resp.Body).Decode(&health)
 		return health["mode"] == config.ModeAudit
-	}, "audit ask-mode config after hot reload")
+	}, "%s", "audit ask-mode config after hot reload")
 
 	cancel()
 	select {

--- a/internal/cli/runtime/run_test.go
+++ b/internal/cli/runtime/run_test.go
@@ -1183,3 +1183,72 @@ func TestRunCmd_ReverseUpstreamInvalidURL(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+// TestRunCmd_EarlyBindErrorJoinsListenerGoroutines guards the runtime shutdown
+// lifecycle. When the fetch proxy fails to bind (an early-error return) after
+// an MCP listener goroutine has already been spawned, Server.cleanup() must
+// not run before that goroutine is joined: the goroutine reads shared Server
+// fields (e.g. s.logger) while cleanup() closes and nils them. The MCP
+// listener binds and its serving goroutine starts before proxy.Start, so
+// pre-binding the fetch port reliably reaches the early return with a live
+// goroutine. Without the lifecycle join, the race detector reports a write to
+// s.logger in cleanup() racing the goroutine's read. This is a regression
+// guard: it must pass under -race.
+func TestRunCmd_EarlyBindErrorJoinsListenerGoroutines(t *testing.T) {
+	// Hold the fetch_proxy.listen port open so proxy.Start fails to bind and
+	// Start() takes the early-error return path.
+	blocker, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen blocker: %v", err)
+	}
+	defer func() { _ = blocker.Close() }()
+	mainAddr := blocker.Addr().String()
+
+	mcpUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mcpUpstream.Close()
+
+	mcpAddr := freePort(t)
+
+	cfgYAML := fmt.Sprintf(`version: 1
+mode: balanced
+fetch_proxy:
+  listen: %q
+  timeout_seconds: 5
+logging:
+  format: json
+  output: stdout
+`, mainAddr)
+
+	cfgPath := filepath.Join(t.TempDir(), "pipelock-earlybind.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := RunCmd()
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{
+		"--config", cfgPath,
+		"--mcp-listen", mcpAddr,
+		"--mcp-upstream", mcpUpstream.URL,
+	})
+	var stderr syncBuffer
+	cmd.SetErr(&stderr)
+	cmd.SetOut(&stderr)
+
+	// Synchronous run: the held fetch port forces a fast bind error. Start()
+	// must join the spawned MCP listener goroutine before cleanup() returns,
+	// so by the time Execute() returns there is no goroutine still reading the
+	// fields cleanup() nils.
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("expected fetch_proxy bind error, got nil")
+	}
+	if !strings.Contains(err.Error(), "proxy error") {
+		t.Errorf("expected proxy bind error, got: %v", err)
+	}
+}

--- a/internal/cli/runtime/run_test.go
+++ b/internal/cli/runtime/run_test.go
@@ -1209,8 +1209,6 @@ func TestRunCmd_EarlyBindErrorJoinsListenerGoroutines(t *testing.T) {
 	}))
 	defer mcpUpstream.Close()
 
-	mcpAddr := freePort(t)
-
 	cfgYAML := fmt.Sprintf(`version: 1
 mode: balanced
 fetch_proxy:
@@ -1233,7 +1231,11 @@ logging:
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{
 		"--config", cfgPath,
-		"--mcp-listen", mcpAddr,
+		// Ephemeral MCP listen port: the test never dials it, it only needs
+		// the listener goroutine to spawn (and read s.logger) before the held
+		// fetch port forces the early-error return. :0 avoids the freePort
+		// close-then-reuse TOCTOU for a port that is never connected to.
+		"--mcp-listen", "127.0.0.1:0",
 		"--mcp-upstream", mcpUpstream.URL,
 	})
 	var stderr syncBuffer
@@ -1250,5 +1252,69 @@ logging:
 	}
 	if !strings.Contains(err.Error(), "proxy error") {
 		t.Errorf("expected proxy bind error, got: %v", err)
+	}
+}
+
+// TestRunCmd_MCPListenerAskModeShutdown exercises the MCP approver lifecycle.
+// With response_scanning action ask and an MCP listener configured, Start
+// creates a HITL approver and hands it to the MCP listener goroutine, which
+// closes it after the listener returns. This covers the approver creation and
+// its goroutine-scoped close on a clean shutdown (no approval is ever
+// triggered: the test only hits /health).
+func TestRunCmd_MCPListenerAskModeShutdown(t *testing.T) {
+	mainAddr := freePort(t)
+
+	mcpUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mcpUpstream.Close()
+
+	cfgYAML := fmt.Sprintf(`version: 1
+mode: balanced
+response_scanning:
+  enabled: true
+  action: ask
+fetch_proxy:
+  listen: %q
+  timeout_seconds: 5
+logging:
+  format: json
+  output: stdout
+`, mainAddr)
+
+	cfgPath := filepath.Join(t.TempDir(), "pipelock-askmode.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := RunCmd()
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{
+		"--config", cfgPath,
+		"--mcp-listen", "127.0.0.1:0",
+		"--mcp-upstream", mcpUpstream.URL,
+	})
+	var stderr syncBuffer
+	cmd.SetErr(&stderr)
+	cmd.SetOut(&stderr)
+
+	cmdErr := make(chan error, 1)
+	go func() {
+		cmdErr <- cmd.Execute()
+	}()
+
+	waitForPort(t, mainAddr)
+
+	cancel()
+	select {
+	case err := <-cmdErr:
+		if err != nil {
+			t.Errorf("RunCmd returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunCmd did not exit within 5s")
 	}
 }

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -111,6 +111,25 @@ func (s *Server) Start(ctx context.Context) error {
 	var reloadWG sync.WaitGroup
 	defer reloadWG.Wait()
 
+	// lifecycleWG joins every long-lived listener/watcher goroutine spawned
+	// below (kill-switch API, metrics, scan API, MCP, reverse proxy, agent
+	// listeners, license watchers). This deferred join is registered after
+	// s.cleanup(), so in LIFO order it runs BEFORE cleanup() closes and nils
+	// shared Server fields (s.logger, s.scanner, s.emitter, ...). Without it,
+	// an early-error return (e.g. a fetch_proxy bind failure) races cleanup()
+	// against an in-flight listener goroutine still reading those fields.
+	// Order matters: cancel() first so ctx-driven goroutines and the HTTP
+	// shutdown goroutines wake, then ShutdownAgentServers() to unblock agent
+	// listener Serve loops on early-error paths where proxy.Start never ran its
+	// own shutdown, then Wait() for every goroutine to finish (HTTP shutdown
+	// goroutines complete only after in-flight handlers drain).
+	var lifecycleWG sync.WaitGroup
+	defer func() {
+		cancel()
+		s.proxy.ShutdownAgentServers()
+		lifecycleWG.Wait()
+	}()
+
 	// Capture duration timer: cancel context after the specified capture
 	// duration so the proxy shuts down automatically.
 	if s.opts.CaptureOutput != "" && s.opts.CaptureDuration > 0 {
@@ -340,7 +359,9 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 
 		apiSrv := newHTTPServer(apiMux)
+		lifecycleWG.Add(1)
 		go func() { //nolint:gosec // G118: graceful shutdown after <-ctx.Done(); using ctx as parent would skip the grace period
+			defer lifecycleWG.Done()
 			<-ctx.Done()
 			shutdownCtx, shutCancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
 			defer shutCancel()
@@ -348,7 +369,9 @@ func (s *Server) Start(ctx context.Context) error {
 		}()
 
 		ksAPIErr = make(chan error, 1)
+		lifecycleWG.Add(1)
 		go func() {
+			defer lifecycleWG.Done()
 			err := apiSrv.Serve(apiLn)
 			if errors.Is(err, http.ErrServerClosed) {
 				err = nil
@@ -372,14 +395,18 @@ func (s *Server) Start(ctx context.Context) error {
 			return err
 		}
 		metricsSrv := newHTTPServer(metricsMux)
+		lifecycleWG.Add(1)
 		go func() { //nolint:gosec // G118: graceful shutdown after <-ctx.Done(); using ctx as parent would skip the grace period
+			defer lifecycleWG.Done()
 			<-ctx.Done()
 			shutdownCtx, shutCancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
 			defer shutCancel()
 			_ = metricsSrv.Shutdown(shutdownCtx)
 		}()
 		metricsErr = make(chan error, 1)
+		lifecycleWG.Add(1)
 		go func() {
+			defer lifecycleWG.Done()
 			srvErr := metricsSrv.Serve(metricsLn)
 			if errors.Is(srvErr, http.ErrServerClosed) {
 				srvErr = nil
@@ -428,7 +455,9 @@ func (s *Server) Start(ctx context.Context) error {
 		scanAPISrv.ReadTimeout = readTimeout
 		scanAPISrv.ReadHeaderTimeout = readTimeout
 		scanAPISrv.WriteTimeout = writeTimeout
+		lifecycleWG.Add(1)
 		go func() { //nolint:gosec // G118: graceful shutdown after <-ctx.Done(); using ctx as parent would skip the grace period
+			defer lifecycleWG.Done()
 			<-ctx.Done()
 			shutdownCtx, shutCancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
 			defer shutCancel()
@@ -436,7 +465,9 @@ func (s *Server) Start(ctx context.Context) error {
 		}()
 
 		scanAPIErr = make(chan error, 1)
+		lifecycleWG.Add(1)
 		go func() {
+			defer lifecycleWG.Done()
 			srvErr := scanAPISrv.Serve(scanAPILn)
 			if errors.Is(srvErr, http.ErrServerClosed) {
 				srvErr = nil
@@ -520,7 +551,10 @@ func (s *Server) Start(ctx context.Context) error {
 		var mcpApprover *hitl.Approver
 		if s.scanner.ResponseAction() == config.ActionAsk {
 			mcpApprover = hitl.New(cfg.ResponseScanning.AskTimeoutSeconds)
-			defer mcpApprover.Close()
+			// Closed inside the MCP listener goroutine below, after
+			// RunHTTPListenerProxy returns, so the approver outlives every
+			// request the listener hands it. A function-scoped defer would
+			// close it while the listener goroutine is still serving.
 		}
 
 		// Bind MCP listener synchronously so port conflicts are caught
@@ -568,7 +602,12 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 
 		mcpErr = make(chan error, 1)
+		lifecycleWG.Add(1)
 		go func() {
+			defer lifecycleWG.Done()
+			if mcpApprover != nil {
+				defer mcpApprover.Close()
+			}
 			var mcpCaptureObs capture.CaptureObserver
 			if s.captureWriter != nil {
 				mcpCaptureObs = s.captureWriter
@@ -648,7 +687,9 @@ func (s *Server) Start(ctx context.Context) error {
 
 		rpSrv := newHTTPServer(rpHandler)
 		rpSrv.WriteTimeout = 30 * time.Second // reverse proxy upstream requests need more time
-		go func() {                           //nolint:gosec // G118: graceful shutdown after <-ctx.Done(); using ctx as parent would skip the grace period
+		lifecycleWG.Add(1)
+		go func() { //nolint:gosec // G118: graceful shutdown after <-ctx.Done(); using ctx as parent would skip the grace period
+			defer lifecycleWG.Done()
 			<-ctx.Done()
 			shutdownCtx, shutCancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
 			defer shutCancel()
@@ -656,7 +697,9 @@ func (s *Server) Start(ctx context.Context) error {
 		}()
 
 		reverseProxyErr = make(chan error, 1)
+		lifecycleWG.Add(1)
 		go func() {
+			defer lifecycleWG.Done()
 			srvErr := rpSrv.Serve(rpLn)
 			if errors.Is(srvErr, http.ErrServerClosed) {
 				srvErr = nil
@@ -700,7 +743,9 @@ func (s *Server) Start(ctx context.Context) error {
 			// Register with proxy so its shutdown goroutine gracefully
 			// stops agent servers alongside the main server.
 			s.proxy.RegisterAgentServer(srv)
+			lifecycleWG.Add(1)
 			go func(srv *http.Server, listener net.Listener) {
+				defer lifecycleWG.Done()
 				srvErr := srv.Serve(listener)
 				if errors.Is(srvErr, http.ErrServerClosed) {
 					srvErr = nil
@@ -716,7 +761,9 @@ func (s *Server) Start(ctx context.Context) error {
 	// when listeners exist, but renewal warnings still emit for long-running
 	// proxy-only processes.
 	if agentListenerCount > 0 && cfg.LicenseExpiresAt > 0 {
+		lifecycleWG.Add(1)
 		go func() {
+			defer lifecycleWG.Done()
 			remaining := time.Until(time.Unix(cfg.LicenseExpiresAt, 0))
 			if remaining <= 0 {
 				_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: license expired, shutting down agent listeners\n")
@@ -734,10 +781,18 @@ func (s *Server) Start(ctx context.Context) error {
 		}()
 	}
 	if cfg.LicenseExpiresAt > 0 {
-		go s.startLicenseExpiryWatcher(ctx)
+		lifecycleWG.Add(1)
+		go func() {
+			defer lifecycleWG.Done()
+			s.startLicenseExpiryWatcher(ctx)
+		}()
 	}
 	if agentListenerCount > 0 && cfg.LicenseCRLFile != "" {
-		go s.startLicenseCRLWatcher(ctx)
+		lifecycleWG.Add(1)
+		go func() {
+			defer lifecycleWG.Done()
+			s.startLicenseCRLWatcher(ctx)
+		}()
 	}
 
 	// Start the fetch proxy (blocks until context cancelled or error).

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -922,3 +922,40 @@ func TestServer_MCPListener_ResponseScanningFallback(t *testing.T) {
 		t.Errorf("listener mode must NOT run the response-scanning fallback; stderr: %q", stderr)
 	}
 }
+
+// TestServer_StartJoinsLicenseExpiryWatcher exercises the lifecycle join for
+// the license expiry watcher goroutine, which Start spawns whenever
+// cfg.LicenseExpiresAt > 0. A future expiry keeps the watcher selecting on
+// ctx.Done(); the WaitGroup must join it during shutdown so cleanup() does not
+// race the watcher's read of s.logger/s.sentry.
+func TestServer_StartJoinsLicenseExpiryWatcher(t *testing.T) {
+	s, _ := newTestServer(t, func(o *ServerOpts) {
+		o.Listen = newServerTestFreePort(t)
+		o.ListenChanged = true
+	})
+	// Set before launching Start: goroutine creation establishes the
+	// happens-before edge, so currentConfig() reads this value.
+	s.cfg.LicenseExpiresAt = time.Now().Add(time.Hour).Unix()
+
+	errCh := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		errCh <- s.Start(ctx)
+	}()
+
+	waitForServerCancel(t, s)
+
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Start returned error after Shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Start did not return within 5s of Shutdown")
+	}
+}


### PR DESCRIPTION
## What
A latent data race in `internal/cli/runtime`. `Server.cleanup()` closed and nil'd shared fields (logger, scanner, emitter, sentry, approver, capture writer) while listener and watcher goroutines spawned by `Start()` were still reading them. On early-error returns (for example a fetch_proxy bind failure) the goroutines were never joined before cleanup ran, and `cancel()` was deferred to run after cleanup, so `-race` flagged the access whenever a listener was still in flight. The race lived on `main` and surfaced nondeterministically across unrelated PRs.

## Fix
- A lifecycle `WaitGroup` that every long-lived goroutine joins: kill-switch API, metrics, scan API, MCP listener, reverse proxy, agent listeners, license expiry and CRL watchers, plus the HTTP shutdown goroutines so in-flight handlers drain before fields are closed.
- One deferred join runs before `cleanup()` and, in order, cancels the context, shuts down agent servers (so their Serve loops unblock on early-error paths where the proxy never ran its own shutdown), then waits for every goroutine to finish.
- The MCP approver now closes inside its goroutine after the listener returns, rather than via a function-scoped defer that could fire while the listener was still serving.

## Verification
- A new regression test forces the early bind-error path with a live MCP listener. It fails under `-race` before the fix and passes after (`-race -count=5`).
- The two previously-flaking tests pass `-race -count=5`.
- The post-reload wait deadline in the reload-to-ask-mode test was raised, since fsnotify delivery lags under the heavy `-race` CI job.

## Follow-up
A port-allocation TOCTOU in the test helpers (a separate, repo-wide pattern) is tracked for a dedicated test-stability PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased robustness of hot-reload verification by allowing more time for health status to reflect configuration changes.
  * Improved shutdown sequencing so background listeners, license watchers, and proxy servers are reliably stopped to avoid leftover processes.
  * Ensured startup bind failures cleanly join and terminate related listener routines to prevent resource leaks.

* **Tests**
  * Added regression and lifecycle tests covering startup bind errors and watcher goroutine shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->