### PR TITLE
feat(a2a): verify Agent Card signatures against trusted origin-scoped keys

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2200,12 +2200,19 @@ a2a_scanning:
   max_contexts: 1000
   scan_raw_parts: true
   max_raw_size: 1048576
+  # Agent Card signature verification (independent attestation). See below.
+  require_signed_agent_cards: false
+  trusted_agent_card_keys:
+    - key_id: vendor-agent-v1
+      public_key: pipelock-ed25519-public-v1...   # or raw hex
+      allowed_origins:
+        - https://agent.example.com
 ```
 
 | Field | Default | Description |
 |-------|---------|-------------|
 | `enabled` | `false` | Enable A2A protocol detection and scanning |
-| `action` | `block` | Action on findings: `block` or `warn` |
+| `action` | `warn` | Action on findings: `block` or `warn` |
 | `scan_agent_cards` | `true` | Scan Agent Card skill descriptions for injection |
 | `detect_card_drift` | `true` | Detect Agent Card modification mid-session (rug-pull) |
 | `session_smuggling_detection` | `true` | Track contextId to detect session smuggling |
@@ -2213,8 +2220,35 @@ a2a_scanning:
 | `max_contexts` | `1000` | Total tracked contexts |
 | `scan_raw_parts` | `true` | Decode and scan text-like `Part.raw` fields |
 | `max_raw_size` | `1048576` | Max encoded size for `Part.raw` decoding (bytes) |
+| `require_signed_agent_cards` | `false` | Treat an **unsigned** Agent Card as a finding (enforced at `action`). When `false`, unsigned cards keep their existing scan/drift behavior. |
+| `trusted_agent_card_keys` | _(none)_ | Operator-pinned Ed25519 signing keys, each scoped to one or more origins. When non-empty, signed cards are cryptographically verified. |
 
 A2A detection works on the forward proxy (CONNECT and plain HTTP) and MCP HTTP proxy paths. Agent Cards are scanned for skill description poisoning. Card drift detection tracks cards by URL + auth fingerprint and alerts on mid-session changes.
+
+### Agent Card Signature Verification
+
+An Agent Card may carry a JWS signature (RFC 7515) attesting that the card was published by a particular signer. Pipelock can independently verify that signature against keys **the operator trusts** — this is independent attestation, not vendor self-attestation. Detection and enforcement here are free-tier; no license is required.
+
+Configure one or more `trusted_agent_card_keys`:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `key_id` | yes | Operator label, unique. Matched against the JWS `kid` header as a lookup **hint only** — never as authority. |
+| `public_key` | yes | Ed25519 public key, `pipelock-ed25519-public-v1` form or raw hex. |
+| `allowed_origins` | yes | Origins (`scheme://host[:port]`, no path) this key may sign cards for. A signature is only accepted on a card fetched from a listed origin. |
+
+Behavior when at least one trusted key is configured:
+
+- **Signed card, signature verifies** against a trusted key scoped to the card's origin → allowed; a positive attestation receipt is emitted (`a2a_card_signature` layer).
+- **Signed card, no trusted-and-valid signature** (forged, wrong key, untrusted, substituted, origin mismatch, `alg: none`, non-EdDSA, empty/short signature, duplicate top-level keys, trailing tokens) → finding + receipt, **enforced at `a2a_scanning.action`**. Set `action: block` to reject. The preimage is the card with its `signatures` member removed, canonicalized per RFC 8785 (JCS).
+- **Unsigned card** → existing scan/drift behavior, unless `require_signed_agent_cards: true`, in which case it is a finding enforced at `action`.
+
+Notes and honest scope:
+
+- Only `EdDSA` (Ed25519) signatures are verified. Cards signed with other algorithms cannot match a trusted key and therefore fail verification when verification is active.
+- `require_signed_agent_cards: true` requires at least one trusted key (otherwise every card would be rejected); this combination is rejected at config load.
+- Verification fires on every surface that delivers an Agent Card as a single body: forward proxy (plain HTTP and CONNECT/TLS-intercept) and MCP HTTP. A2A SSE streams carry task/message events, not Agent Cards, so there is no card-signature step on the SSE path.
+- Revoking trust is a config edit: remove the key (or its origin) and reload. Hot reload swaps the trusted-key set atomically; a reduced key set logs a downgrade warning.
 
 ## MCP Binary Integrity (v2.1)
 

--- a/internal/config/a2a_signature_test.go
+++ b/internal/config/a2a_signature_test.go
@@ -439,6 +439,20 @@ func TestReloadWarnings_A2ASignature(t *testing.T) {
 	})
 }
 
+// TestValidateA2ATrustedCardKeys_RunsWhenDisabled proves trusted-key validation
+// is fail-fast at load even when a2a_scanning.enabled is false, so a bad key
+// config does not slip through to only fail on a later enabling reload.
+func TestValidateA2ATrustedCardKeys_RunsWhenDisabled(t *testing.T) {
+	cfg := Defaults()
+	cfg.A2AScanning.Enabled = false
+	cfg.A2AScanning.TrustedAgentCardKeys = []A2ATrustedCardKey{
+		{KeyID: "k1", PublicKey: "not-a-key", AllowedOrigins: []string{"https://agent.example.com"}},
+	}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "invalid public_key") {
+		t.Fatalf("disabled A2A must still reject a malformed trusted key, got %v", err)
+	}
+}
+
 func hasWarning(warns []ReloadWarning, field string) bool {
 	for _, w := range warns {
 		if w.Field == field {

--- a/internal/config/a2a_signature_test.go
+++ b/internal/config/a2a_signature_test.go
@@ -401,10 +401,33 @@ func TestReloadWarnings_A2ASignature(t *testing.T) {
 		}
 	})
 
-	t.Run("keys_reduced", func(t *testing.T) {
-		warns := ValidateReload(mk(false, 2), mk(false, 1))
+	t.Run("keys_removed_to_zero_warns", func(t *testing.T) {
+		// Verification turning off (non-empty -> empty) is the genuine downgrade.
+		warns := ValidateReload(mk(false, 2), mk(false, 0))
 		if !hasWarning(warns, "a2a_scanning.trusted_agent_card_keys") {
-			t.Fatalf("expected trusted-keys-reduced warning, got %+v", warns)
+			t.Fatalf("expected trusted-keys-removed warning, got %+v", warns)
+		}
+	})
+
+	t.Run("keys_reduced_revocation_no_warning", func(t *testing.T) {
+		// Removing one of several keys is revocation (stricter), not a downgrade.
+		// Flagging it would block emergency revocation under strict-mode reload.
+		warns := ValidateReload(mk(false, 2), mk(false, 1))
+		if hasWarning(warns, "a2a_scanning.trusted_agent_card_keys") {
+			t.Fatalf("key revocation must NOT warn, got %+v", warns)
+		}
+	})
+
+	t.Run("disabled_no_signature_warnings", func(t *testing.T) {
+		// When A2A scanning is off in the new config, signature sub-warnings are
+		// suppressed (the top-level "A2A scanning disabled" warning covers it) so
+		// strict-mode reload is not rejected for an unrelated downgrade.
+		oldCfg := mk(true, 2)
+		newCfg := mk(false, 0)
+		newCfg.A2AScanning.Enabled = false
+		warns := ValidateReload(oldCfg, newCfg)
+		if hasWarning(warns, "a2a_scanning.require_signed_agent_cards") || hasWarning(warns, "a2a_scanning.trusted_agent_card_keys") {
+			t.Fatalf("disabled A2A must not emit signature sub-warnings, got %+v", warns)
 		}
 	})
 

--- a/internal/config/a2a_signature_test.go
+++ b/internal/config/a2a_signature_test.go
@@ -1,0 +1,426 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func genPubHex(t *testing.T) string {
+	t.Helper()
+	pub, _, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	return hex.EncodeToString(pub)
+}
+
+// a2aSigYAML builds a config enabling A2A scanning with one trusted key and an
+// optional require_signed_agent_cards line.
+func a2aSigYAML(pubHex, requireLine string) string {
+	return "version: 1\n" +
+		"a2a_scanning:\n" +
+		"  enabled: true\n" +
+		"  action: block\n" +
+		requireLine +
+		"  trusted_agent_card_keys:\n" +
+		"    - key_id: k1\n" +
+		"      public_key: " + pubHex + "\n" +
+		"      allowed_origins:\n" +
+		"        - https://agent.example.com\n"
+}
+
+func loadA2ASig(t *testing.T, body string) *Config {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return cfg
+}
+
+// --- require_signed_agent_cards: the 6 mandated config-boolean states ---
+
+// State 1: omitted -> false (unsigned cards keep existing behavior by default).
+func TestRequireSignedCards_Omitted(t *testing.T) {
+	cfg := loadA2ASig(t, a2aSigYAML(genPubHex(t), ""))
+	if cfg.A2AScanning.RequireSignedAgentCards {
+		t.Fatal("omitted require_signed_agent_cards must default to false")
+	}
+}
+
+// State 2: YAML null/blank -> false.
+func TestRequireSignedCards_YAMLNull(t *testing.T) {
+	cfg := loadA2ASig(t, a2aSigYAML(genPubHex(t), "  require_signed_agent_cards:\n"))
+	if cfg.A2AScanning.RequireSignedAgentCards {
+		t.Fatal("YAML null require_signed_agent_cards must be false")
+	}
+}
+
+// State 3: explicit false -> false.
+func TestRequireSignedCards_ExplicitFalse(t *testing.T) {
+	cfg := loadA2ASig(t, a2aSigYAML(genPubHex(t), "  require_signed_agent_cards: false\n"))
+	if cfg.A2AScanning.RequireSignedAgentCards {
+		t.Fatal("explicit false must be preserved")
+	}
+}
+
+// State 4: explicit true -> true.
+func TestRequireSignedCards_ExplicitTrue(t *testing.T) {
+	cfg := loadA2ASig(t, a2aSigYAML(genPubHex(t), "  require_signed_agent_cards: true\n"))
+	if !cfg.A2AScanning.RequireSignedAgentCards {
+		t.Fatal("explicit true must be preserved")
+	}
+}
+
+// State 5: reload with change (false -> true).
+func TestRequireSignedCards_ReloadWithChange(t *testing.T) {
+	pubHex := genPubHex(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(path, []byte(a2aSigYAML(pubHex, "  require_signed_agent_cards: false\n")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load #1: %v", err)
+	}
+	if first.A2AScanning.RequireSignedAgentCards {
+		t.Fatal("first load should be false")
+	}
+	if err := os.WriteFile(path, []byte(a2aSigYAML(pubHex, "  require_signed_agent_cards: true\n")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	second, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load #2: %v", err)
+	}
+	if !second.A2AScanning.RequireSignedAgentCards {
+		t.Fatal("reload with change should observe true")
+	}
+}
+
+// State 6: reload without change preserves the value.
+func TestRequireSignedCards_ReloadWithoutChange(t *testing.T) {
+	pubHex := genPubHex(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pipelock.yaml")
+	body := a2aSigYAML(pubHex, "  require_signed_agent_cards: true\n")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load #1: %v", err)
+	}
+	second, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load #2: %v", err)
+	}
+	if first.A2AScanning.RequireSignedAgentCards != second.A2AScanning.RequireSignedAgentCards {
+		t.Fatal("reload without change must preserve value")
+	}
+	if !first.A2AScanning.RequireSignedAgentCards {
+		t.Fatal("value should remain true across reloads")
+	}
+}
+
+// --- Trusted key validation ---
+
+func validateA2A(t *testing.T, require bool, keys []A2ATrustedCardKey) error {
+	t.Helper()
+	cfg := Defaults()
+	cfg.A2AScanning.Enabled = true
+	cfg.A2AScanning.Action = ActionBlock
+	cfg.A2AScanning.RequireSignedAgentCards = require
+	cfg.A2AScanning.TrustedAgentCardKeys = keys
+	return cfg.Validate()
+}
+
+func TestValidateA2ATrustedCardKeys(t *testing.T) {
+	pub1 := genPubHex(t)
+	pub2 := genPubHex(t)
+	origins := []string{"https://agent.example.com"}
+
+	cases := []struct {
+		name    string
+		require bool
+		keys    []A2ATrustedCardKey
+		wantErr string
+	}{
+		{
+			name: "valid",
+			keys: []A2ATrustedCardKey{{KeyID: "k1", PublicKey: pub1, AllowedOrigins: origins}},
+		},
+		{
+			name:    "empty_key_id",
+			keys:    []A2ATrustedCardKey{{KeyID: "", PublicKey: pub1, AllowedOrigins: origins}},
+			wantErr: "key_id is required",
+		},
+		{
+			name: "duplicate_key_id",
+			keys: []A2ATrustedCardKey{
+				{KeyID: "dup", PublicKey: pub1, AllowedOrigins: origins},
+				{KeyID: "dup", PublicKey: pub2, AllowedOrigins: origins},
+			},
+			wantErr: "duplicate key_id",
+		},
+		{
+			name:    "invalid_public_key",
+			keys:    []A2ATrustedCardKey{{KeyID: "k1", PublicKey: "not-a-key", AllowedOrigins: origins}},
+			wantErr: "invalid public_key",
+		},
+		{
+			name: "duplicate_fingerprint",
+			keys: []A2ATrustedCardKey{
+				{KeyID: "k1", PublicKey: pub1, AllowedOrigins: origins},
+				{KeyID: "k2", PublicKey: pub1, AllowedOrigins: origins},
+			},
+			wantErr: "share the same public key",
+		},
+		{
+			name:    "empty_origins",
+			keys:    []A2ATrustedCardKey{{KeyID: "k1", PublicKey: pub1, AllowedOrigins: nil}},
+			wantErr: "allowed_origins is required",
+		},
+		{
+			name:    "origin_with_path",
+			keys:    []A2ATrustedCardKey{{KeyID: "k1", PublicKey: pub1, AllowedOrigins: []string{"https://agent.example.com/path"}}},
+			wantErr: "invalid origin",
+		},
+		{
+			name:    "origin_no_scheme",
+			keys:    []A2ATrustedCardKey{{KeyID: "k1", PublicKey: pub1, AllowedOrigins: []string{"agent.example.com"}}},
+			wantErr: "invalid origin",
+		},
+		{
+			name:    "origin_with_userinfo",
+			keys:    []A2ATrustedCardKey{{KeyID: "k1", PublicKey: pub1, AllowedOrigins: []string{"https://user:pass@agent.example.com"}}},
+			wantErr: "invalid origin",
+		},
+		{
+			name:    "origin_with_query",
+			keys:    []A2ATrustedCardKey{{KeyID: "k1", PublicKey: pub1, AllowedOrigins: []string{"https://agent.example.com?x=1"}}},
+			wantErr: "invalid origin",
+		},
+		{
+			name:    "origin_empty_string",
+			keys:    []A2ATrustedCardKey{{KeyID: "k1", PublicKey: pub1, AllowedOrigins: []string{""}}},
+			wantErr: "invalid origin",
+		},
+		{
+			name:    "origin_empty_host",
+			keys:    []A2ATrustedCardKey{{KeyID: "k1", PublicKey: pub1, AllowedOrigins: []string{"https://:443"}}},
+			wantErr: "invalid origin",
+		},
+		{
+			name:    "origin_bad_port",
+			keys:    []A2ATrustedCardKey{{KeyID: "k1", PublicKey: pub1, AllowedOrigins: []string{"https://agent.example.com:99999"}}},
+			wantErr: "invalid origin",
+		},
+		{
+			name:    "origin_named_bad_port",
+			keys:    []A2ATrustedCardKey{{KeyID: "k1", PublicKey: pub1, AllowedOrigins: []string{"https://agent.example.com:https"}}},
+			wantErr: "invalid origin",
+		},
+		{
+			name:    "origin_empty_port",
+			keys:    []A2ATrustedCardKey{{KeyID: "k1", PublicKey: pub1, AllowedOrigins: []string{"https://agent.example.com:"}}},
+			wantErr: "invalid origin",
+		},
+		{
+			name:    "origin_with_trailing_slash_ok",
+			keys:    []A2ATrustedCardKey{{KeyID: "k1", PublicKey: pub1, AllowedOrigins: []string{"https://agent.example.com/"}}},
+			wantErr: "",
+		},
+		{
+			name:    "require_signed_without_keys",
+			require: true,
+			keys:    nil,
+			wantErr: "requires at least one trusted_agent_card_keys",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateA2A(t, tc.require, tc.keys)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateA2ATrustedCardKeysNormalizesAcceptedValues(t *testing.T) {
+	pubHex := genPubHex(t)
+	pub, err := signing.ParsePublicKey(pubHex)
+	if err != nil {
+		t.Fatalf("ParsePublicKey: %v", err)
+	}
+	cfg := Defaults()
+	cfg.A2AScanning.Enabled = true
+	cfg.A2AScanning.Action = ActionBlock
+	cfg.A2AScanning.TrustedAgentCardKeys = []A2ATrustedCardKey{{
+		KeyID:     " k1 ",
+		PublicKey: pubHex,
+		AllowedOrigins: []string{
+			"HTTPS://Agent.Example.Com:443/",
+			"http://[2001:DB8::1]:80",
+			"https://agent.example.com:8443",
+		},
+	}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	got := cfg.A2AScanning.TrustedAgentCardKeys[0]
+	if got.KeyID != "k1" {
+		t.Fatalf("KeyID not normalized: %q", got.KeyID)
+	}
+	if want := signing.EncodePublicKey(pub); got.PublicKey != want {
+		t.Fatalf("PublicKey not normalized:\n got %q\nwant %q", got.PublicKey, want)
+	}
+	wantOrigins := []string{
+		"https://agent.example.com",
+		"http://[2001:db8::1]",
+		"https://agent.example.com:8443",
+	}
+	if strings.Join(got.AllowedOrigins, "\n") != strings.Join(wantOrigins, "\n") {
+		t.Fatalf("AllowedOrigins not normalized:\n got %#v\nwant %#v", got.AllowedOrigins, wantOrigins)
+	}
+}
+
+func TestCanonicalPolicyHash_A2ATrustedCardKeysCanonical(t *testing.T) {
+	pub1 := genPubHex(t)
+	pub2 := genPubHex(t)
+
+	hashA := canonicalA2AHash(t, []A2ATrustedCardKey{
+		{
+			KeyID:     " beta ",
+			PublicKey: pub2,
+			AllowedOrigins: []string{
+				"https://beta.example.com:8443",
+				"https://beta.example.com:443/",
+			},
+		},
+		{
+			KeyID:     "alpha",
+			PublicKey: pub1,
+			AllowedOrigins: []string{
+				"HTTPS://Agent.Example.Com:443/",
+				"http://[2001:DB8::1]:80",
+			},
+		},
+	})
+	hashB := canonicalA2AHash(t, []A2ATrustedCardKey{
+		{
+			KeyID:     "alpha",
+			PublicKey: encodedPublicKey(t, pub1),
+			AllowedOrigins: []string{
+				"http://[2001:db8::1]",
+				"https://agent.example.com",
+			},
+		},
+		{
+			KeyID:     "beta",
+			PublicKey: encodedPublicKey(t, pub2),
+			AllowedOrigins: []string{
+				"https://beta.example.com",
+				"https://beta.example.com:8443",
+			},
+		},
+	})
+	if hashA != hashB {
+		t.Fatalf("equivalent A2A trusted key policy should hash equally:\n  a = %s\n  b = %s", hashA, hashB)
+	}
+}
+
+func canonicalA2AHash(t *testing.T, keys []A2ATrustedCardKey) string {
+	t.Helper()
+	cfg := Defaults()
+	cfg.A2AScanning.Enabled = true
+	cfg.A2AScanning.Action = ActionBlock
+	cfg.A2AScanning.TrustedAgentCardKeys = keys
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	return cfg.CanonicalPolicyHash()
+}
+
+func encodedPublicKey(t *testing.T, key string) string {
+	t.Helper()
+	pub, err := signing.ParsePublicKey(key)
+	if err != nil {
+		t.Fatalf("ParsePublicKey: %v", err)
+	}
+	return signing.EncodePublicKey(pub)
+}
+
+// --- Reload warnings ---
+
+func TestReloadWarnings_A2ASignature(t *testing.T) {
+	pub := genPubHex(t)
+	mk := func(require bool, keyCount int) *Config {
+		cfg := Defaults()
+		cfg.A2AScanning.Enabled = true
+		cfg.A2AScanning.Action = ActionBlock
+		cfg.A2AScanning.RequireSignedAgentCards = require
+		var keys []A2ATrustedCardKey
+		for i := 0; i < keyCount; i++ {
+			keys = append(keys, A2ATrustedCardKey{
+				KeyID:          "k" + strings.Repeat("x", i+1),
+				PublicKey:      pub, // same key bytes are fine here; reload warnings don't validate
+				AllowedOrigins: []string{"https://agent.example.com"},
+			})
+		}
+		cfg.A2AScanning.TrustedAgentCardKeys = keys
+		return cfg
+	}
+
+	t.Run("require_disabled", func(t *testing.T) {
+		warns := ValidateReload(mk(true, 1), mk(false, 1))
+		if !hasWarning(warns, "a2a_scanning.require_signed_agent_cards") {
+			t.Fatalf("expected require_signed downgrade warning, got %+v", warns)
+		}
+	})
+
+	t.Run("keys_reduced", func(t *testing.T) {
+		warns := ValidateReload(mk(false, 2), mk(false, 1))
+		if !hasWarning(warns, "a2a_scanning.trusted_agent_card_keys") {
+			t.Fatalf("expected trusted-keys-reduced warning, got %+v", warns)
+		}
+	})
+
+	t.Run("no_change_no_warning", func(t *testing.T) {
+		warns := ValidateReload(mk(true, 1), mk(true, 1))
+		if hasWarning(warns, "a2a_scanning.require_signed_agent_cards") || hasWarning(warns, "a2a_scanning.trusted_agent_card_keys") {
+			t.Fatalf("unexpected A2A signature warnings: %+v", warns)
+		}
+	})
+}
+
+func hasWarning(warns []ReloadWarning, field string) bool {
+	for _, w := range warns {
+		if w.Field == field {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -199,6 +199,7 @@ func (c *Config) policySemanticView() Config {
 	view.APIAllowlist = sortedCopy(view.APIAllowlist)
 	view.Internal = sortedCopy(view.Internal)
 	view.TrustedDomains = sortedCopy(view.TrustedDomains)
+	view.A2AScanning.TrustedAgentCardKeys = canonicalA2ATrustedCardKeys(view.A2AScanning.TrustedAgentCardKeys)
 	if view.Redaction.Enabled {
 		view.Redaction.AllowlistUnparseable = sortedCopy(view.Redaction.AllowlistUnparseable)
 	} else {
@@ -218,6 +219,29 @@ func (c *Config) policySemanticView() Config {
 	view.Learn.Inference.Normalization = view.Learn.Inference.Normalization.Resolved()
 
 	return view
+}
+
+func canonicalA2ATrustedCardKeys(keys []A2ATrustedCardKey) []A2ATrustedCardKey {
+	if len(keys) == 0 {
+		return nil
+	}
+	out := make([]A2ATrustedCardKey, len(keys))
+	for i, key := range keys {
+		out[i] = key
+		out[i].AllowedOrigins = sortedCopy(key.AllowedOrigins)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].KeyID != out[j].KeyID {
+			return out[i].KeyID < out[j].KeyID
+		}
+		if out[i].PublicKey != out[j].PublicKey {
+			return out[i].PublicKey < out[j].PublicKey
+		}
+		left, _ := json.Marshal(out[i].AllowedOrigins)
+		right, _ := json.Marshal(out[j].AllowedOrigins)
+		return string(left) < string(right)
+	})
+	return out
 }
 
 func canonicalUnparseableRoutes(enabled bool, routes []redact.UnparseableRouteSpec) []redact.UnparseableRouteSpec {

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -149,7 +149,10 @@ const (
 	// Re-bumped again: the "Private Key Header" pattern now also matches PGP
 	// armor and the trailing BLOCK keyword, aligning DLP detection with the
 	// ssh-private-key redaction class.
-	goldenHashDefaults = "52a2300320f93c54c5304770196e95fad6e79663d96826f0e812aedcd5cc9822"
+	// Re-bumped for A2A Agent Card signature verification: a2a_scanning gained
+	// the require_signed_agent_cards and trusted_agent_card_keys policy fields,
+	// which are enforcement-relevant and so belong in the canonical policy hash.
+	goldenHashDefaults = "5a09097c241be07f591ed6bfd822cf697b95759d2c5c057177f8a789f1fc99e7"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -220,10 +223,12 @@ const (
 	// Bumped for fetch_proxy.monitoring.query_entropy_exclusions: see the
 	// goldenHashDefaults note above.
 	// Re-bumped for the file_sentry max_file_bytes field: see goldenHashDefaults note.
+	// Re-bumped for A2A Agent Card signature verification fields: see
+	// goldenHashDefaults note above.
 	// Re-bumped for the Twilio + Mailgun DLP boundary tightening and again for
 	// the secret-pattern expansion: see goldenHashDefaults note above. The rich
 	// fixture inherits the default DLP pattern set, so the hash shifts in lockstep.
-	goldenHashRichConfig = "67fed6b23291883c5b63ceb0c63726b8579e79d13d3171f549144426f0feb925"
+	goldenHashRichConfig = "8f23eec150093d1b246cdfe54336faa5ec652602d4c63f6db80aadce1b1af22b"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -245,17 +245,25 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 			Message: "A2A Agent Card drift detection disabled",
 		})
 	}
-	if old.A2AScanning.RequireSignedAgentCards && !updated.A2AScanning.RequireSignedAgentCards {
-		warnings = append(warnings, ReloadWarning{
-			Field:   "a2a_scanning.require_signed_agent_cards",
-			Message: "A2A require-signed-agent-cards disabled",
-		})
-	}
-	if len(updated.A2AScanning.TrustedAgentCardKeys) < len(old.A2AScanning.TrustedAgentCardKeys) {
-		warnings = append(warnings, ReloadWarning{
-			Field:   "a2a_scanning.trusted_agent_card_keys",
-			Message: "A2A trusted Agent Card keys reduced (signature verification weakened)",
-		})
+	// Signature-verification downgrades only matter while A2A scanning is on; if
+	// it is being disabled the top-level "A2A scanning disabled" warning covers it.
+	if updated.A2AScanning.Enabled {
+		if old.A2AScanning.RequireSignedAgentCards && !updated.A2AScanning.RequireSignedAgentCards {
+			warnings = append(warnings, ReloadWarning{
+				Field:   "a2a_scanning.require_signed_agent_cards",
+				Message: "A2A require-signed-agent-cards disabled",
+			})
+		}
+		// Removing a trusted key is revocation (stricter), not a downgrade, so a
+		// count decrease must NOT warn — that would block emergency key revocation
+		// under strict-mode reload. The genuine weakening is verification turning
+		// off: the trusted-key set going from non-empty to empty.
+		if len(old.A2AScanning.TrustedAgentCardKeys) > 0 && len(updated.A2AScanning.TrustedAgentCardKeys) == 0 {
+			warnings = append(warnings, ReloadWarning{
+				Field:   "a2a_scanning.trusted_agent_card_keys",
+				Message: "A2A trusted Agent Card keys removed (signature verification disabled)",
+			})
+		}
 	}
 	if old.A2AScanning.SessionSmugglingDetection && !updated.A2AScanning.SessionSmugglingDetection {
 		warnings = append(warnings, ReloadWarning{

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -245,6 +245,18 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 			Message: "A2A Agent Card drift detection disabled",
 		})
 	}
+	if old.A2AScanning.RequireSignedAgentCards && !updated.A2AScanning.RequireSignedAgentCards {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "a2a_scanning.require_signed_agent_cards",
+			Message: "A2A require-signed-agent-cards disabled",
+		})
+	}
+	if len(updated.A2AScanning.TrustedAgentCardKeys) < len(old.A2AScanning.TrustedAgentCardKeys) {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "a2a_scanning.trusted_agent_card_keys",
+			Message: "A2A trusted Agent Card keys reduced (signature verification weakened)",
+		})
+	}
 	if old.A2AScanning.SessionSmugglingDetection && !updated.A2AScanning.SessionSmugglingDetection {
 		warnings = append(warnings, ReloadWarning{
 			Field:   "a2a_scanning.session_smuggling_detection",

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -857,6 +857,36 @@ type A2AScanning struct {
 	MaxContexts               int    `yaml:"max_contexts"`                // total tracked contexts (default 1000)
 	ScanRawParts              bool   `yaml:"scan_raw_parts"`              // decode text-like Part.raw
 	MaxRawSize                int    `yaml:"max_raw_size"`                // encoded size cap for Part.raw decode (default 1MB)
+
+	// RequireSignedAgentCards, when true, treats an UNSIGNED Agent Card as a
+	// finding (enforced at Action). Default false: unsigned cards keep their
+	// existing scan/drift behavior. A card that carries a signature is always
+	// verified when TrustedAgentCardKeys is non-empty, regardless of this flag.
+	RequireSignedAgentCards bool `yaml:"require_signed_agent_cards"`
+
+	// TrustedAgentCardKeys lists the Ed25519 public keys pipelock will accept as
+	// authoritative signers of Agent Cards, each scoped to one or more origins.
+	// When non-empty, Agent Cards carrying a JWS signature are cryptographically
+	// verified against these keys; a card whose signature does not verify against
+	// a trusted key scoped to the card's origin fails closed at Action.
+	TrustedAgentCardKeys []A2ATrustedCardKey `yaml:"trusted_agent_card_keys"`
+}
+
+// A2ATrustedCardKey is one operator-pinned Agent Card signing key. A pinned key
+// authorizes a specific signer for specific card origins; it is not globally
+// trusted to sign any Agent Card. The JWS "kid" header is treated as a lookup
+// hint only — never as authority — so a card cannot select which key verifies it.
+type A2ATrustedCardKey struct {
+	// KeyID is the operator's label for this key. It is matched against the JWS
+	// "kid" header as a lookup hint. Must be non-empty and unique.
+	KeyID string `yaml:"key_id"`
+	// PublicKey is the Ed25519 public key, either pipelock-encoded
+	// (pipelock-ed25519-public-v1) or raw hex.
+	PublicKey string `yaml:"public_key"`
+	// AllowedOrigins scopes this key to specific card origins (scheme://host[:port]).
+	// A signature by this key is only accepted on a card fetched from a listed
+	// origin. Must be non-empty.
+	AllowedOrigins []string `yaml:"allowed_origins"`
 }
 
 // RequestBodyScanning configures DLP scanning of request bodies and headers

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1234,7 +1234,12 @@ func (c *Config) validateMCPSessionBinding() error {
 }
 
 func (c *Config) validateA2AScanning() error {
-	// Validate A2A scanning config
+	// Validate trusted keys regardless of Enabled so malformed entries and
+	// require_signed_agent_cards-without-keys fail fast at load, not only on a
+	// later reload that turns A2A on. This also normalizes accepted entries.
+	if err := c.validateA2ATrustedCardKeys(); err != nil {
+		return err
+	}
 	if !c.A2AScanning.Enabled {
 		return nil
 	}
@@ -1252,9 +1257,6 @@ func (c *Config) validateA2AScanning() error {
 	}
 	if c.A2AScanning.MaxRawSize <= 0 {
 		c.A2AScanning.MaxRawSize = 1 << 20
-	}
-	if err := c.validateA2ATrustedCardKeys(); err != nil {
-		return err
 	}
 	return nil
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1253,7 +1253,128 @@ func (c *Config) validateA2AScanning() error {
 	if c.A2AScanning.MaxRawSize <= 0 {
 		c.A2AScanning.MaxRawSize = 1 << 20
 	}
+	if err := c.validateA2ATrustedCardKeys(); err != nil {
+		return err
+	}
 	return nil
+}
+
+// validateA2ATrustedCardKeys enforces the trust shape for Agent Card signature
+// verification: every pinned key needs a unique non-empty key_id, a parseable
+// Ed25519 public key, at least one well-formed origin, and no two keys may share
+// the same public key. require_signed_agent_cards is meaningless (it would block
+// every card) without at least one trusted key, so that combination is rejected.
+func (c *Config) validateA2ATrustedCardKeys() error {
+	keys := c.A2AScanning.TrustedAgentCardKeys
+	if c.A2AScanning.RequireSignedAgentCards && len(keys) == 0 {
+		return fmt.Errorf("a2a_scanning.require_signed_agent_cards requires at least one trusted_agent_card_keys entry")
+	}
+	seenID := make(map[string]struct{}, len(keys))
+	seenFP := make(map[string]string, len(keys))
+	for i, k := range keys {
+		id := strings.TrimSpace(k.KeyID)
+		if id == "" {
+			return fmt.Errorf("a2a_scanning.trusted_agent_card_keys[%d]: key_id is required", i)
+		}
+		c.A2AScanning.TrustedAgentCardKeys[i].KeyID = id
+		if _, dup := seenID[id]; dup {
+			return fmt.Errorf("a2a_scanning.trusted_agent_card_keys: duplicate key_id %q", id)
+		}
+		seenID[id] = struct{}{}
+
+		pub, err := signing.ParsePublicKey(k.PublicKey)
+		if err != nil {
+			return fmt.Errorf("a2a_scanning.trusted_agent_card_keys[%q]: invalid public_key: %w", id, err)
+		}
+		fp, err := signing.Fingerprint(pub)
+		if err != nil {
+			return fmt.Errorf("a2a_scanning.trusted_agent_card_keys[%q]: %w", id, err)
+		}
+		c.A2AScanning.TrustedAgentCardKeys[i].PublicKey = signing.EncodePublicKey(pub)
+		if other, dup := seenFP[fp]; dup {
+			return fmt.Errorf("a2a_scanning.trusted_agent_card_keys: key_id %q and %q share the same public key", other, id)
+		}
+		seenFP[fp] = id
+
+		if len(k.AllowedOrigins) == 0 {
+			return fmt.Errorf("a2a_scanning.trusted_agent_card_keys[%q]: allowed_origins is required", id)
+		}
+		for j, o := range k.AllowedOrigins {
+			origin, ok := canonicalCardOrigin(o)
+			if !ok {
+				return fmt.Errorf("a2a_scanning.trusted_agent_card_keys[%q]: invalid origin %q (want scheme://host[:port], no path)", id, o)
+			}
+			c.A2AScanning.TrustedAgentCardKeys[i].AllowedOrigins[j] = origin
+		}
+	}
+	return nil
+}
+
+// canonicalCardOrigin reports whether s is a well-formed Agent Card origin and
+// returns its normalized scheme://host[:port] form.
+//
+// This is intentionally STRICTER than mcp.CardOriginFromURL (which normalizes an
+// arbitrary fetch URL down to its origin by discarding the path). A configured
+// allowed_origins entry must already BE an origin, so anything carrying a path,
+// query, fragment, or userinfo is a likely operator mistake and is rejected here
+// rather than silently normalized away.
+func canonicalCardOrigin(s string) (string, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", false
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", false
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", false
+	}
+	if u.Host == "" || u.Hostname() == "" || u.User != nil {
+		return "", false
+	}
+	if !validOptionalCardOriginPort(u.Host, u.Port()) {
+		return "", false
+	}
+	if port := u.Port(); port != "" {
+		n, err := strconv.Atoi(port)
+		if err != nil || n < 1 || n > 65535 {
+			return "", false
+		}
+	}
+	if (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.Fragment != "" {
+		return "", false
+	}
+
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+	if (scheme == "https" && port == "443") || (scheme == "http" && port == "80") {
+		port = ""
+	}
+	if port != "" {
+		host = net.JoinHostPort(host, port)
+	} else if strings.Contains(host, ":") {
+		host = "[" + host + "]"
+	}
+	return scheme + "://" + host, true
+}
+
+func validOptionalCardOriginPort(hostport, port string) bool {
+	if strings.HasPrefix(hostport, "[") {
+		end := strings.LastIndex(hostport, "]")
+		if end < 0 || end == len(hostport)-1 {
+			return end == len(hostport)-1
+		}
+		return strings.HasPrefix(hostport[end+1:], ":") && port != ""
+	}
+	if strings.Count(hostport, ":") == 0 {
+		return true
+	}
+	if strings.Count(hostport, ":") > 1 {
+		return false
+	}
+	return port != ""
 }
 
 func (c *Config) validateRequestBodyScanning() error {

--- a/internal/jcs/jcs.go
+++ b/internal/jcs/jcs.go
@@ -1,0 +1,390 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package jcs implements RFC 8785 JSON Canonicalization Scheme (JCS) exactly,
+// using only the standard library.
+//
+// It exists as a standalone, dependency-free implementation because it is used
+// to reconstruct the byte-exact preimage that a THIRD PARTY signed when it
+// produced an A2A Agent Card JWS signature. A canonicalizer that diverges by a
+// single byte would false-reject legitimately signed cards, so this package
+// deliberately does NOT reuse internal/contract's canonicalizer, which:
+//
+//   - NFC-normalizes strings (RFC 8785 requires string data to be preserved),
+//   - rejects non-integer numbers (JCS cards may carry decimals/exponents), and
+//   - sorts object members by Go code-point order rather than UTF-16 code units.
+//
+// The three RFC 8785 rules that bite are all handled here: UTF-16 code-unit key
+// ordering (§3.2.3), minimal string escaping with no normalization (§3.2.2.2),
+// and ES6 number serialization (§3.2.2.3).
+package jcs
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// ErrDuplicateKey indicates a duplicate member name in a JSON object. A signed
+// card with duplicate keys is ambiguous, so canonicalization fails closed.
+var ErrDuplicateKey = errors.New("duplicate key in JSON object")
+
+// ErrTrailingTokens indicates non-whitespace content followed the JSON value.
+// Trailing tokens are an injection/ambiguity vector in signed payloads.
+var ErrTrailingTokens = errors.New("trailing tokens after JSON value")
+
+// ErrInvalidNumber indicates a number that cannot be represented as a finite
+// IEEE-754 double (NaN/Infinity), which JSON/JCS does not permit.
+var ErrInvalidNumber = errors.New("invalid JSON number")
+
+// ErrInvalidUnicode indicates JSON string data that cannot be represented as
+// valid Unicode. RFC 8785 requires this to fail instead of being repaired.
+var ErrInvalidUnicode = errors.New("invalid Unicode in JSON string data")
+
+// Canonicalize parses raw JSON strictly and returns its RFC 8785 canonical form.
+func Canonicalize(raw []byte) ([]byte, error) {
+	v, err := Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	return Marshal(v)
+}
+
+// Parse strictly decodes JSON into a tree of map[string]any / []any / string /
+// bool / nil / json.Number. It rejects duplicate object keys and trailing
+// tokens. Numbers are preserved as json.Number so Marshal can apply the ES6
+// serialization rule rather than Go's default float formatting.
+func Parse(raw []byte) (any, error) {
+	if !utf8.Valid(raw) {
+		return nil, fmt.Errorf("%w: input is not valid UTF-8", ErrInvalidUnicode)
+	}
+	if err := rejectInvalidEscapedSurrogates(raw); err != nil {
+		return nil, err
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	v, err := parseValue(dec)
+	if err != nil {
+		return nil, err
+	}
+	// Reject anything other than trailing whitespace. dec.Token returns io.EOF
+	// once only whitespace remains.
+	if tok, terr := dec.Token(); !errors.Is(terr, io.EOF) {
+		if terr != nil {
+			return nil, fmt.Errorf("%w: %w", ErrTrailingTokens, terr)
+		}
+		return nil, fmt.Errorf("%w: %v", ErrTrailingTokens, tok)
+	}
+	return v, nil
+}
+
+func rejectInvalidEscapedSurrogates(raw []byte) error {
+	inString := false
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		if !inString {
+			if c == '"' {
+				inString = true
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = false
+		case '\\':
+			if i+1 >= len(raw) {
+				return nil // JSON decoder reports the malformed escape.
+			}
+			if raw[i+1] != 'u' {
+				i++
+				continue
+			}
+			r, ok := parseHex4(raw[i+2:])
+			if !ok {
+				return nil // JSON decoder reports the malformed escape.
+			}
+			i += 5
+			if r >= 0xD800 && r <= 0xDBFF {
+				if i+6 >= len(raw) || raw[i+1] != '\\' || raw[i+2] != 'u' {
+					return fmt.Errorf("%w: unpaired high surrogate", ErrInvalidUnicode)
+				}
+				low, ok := parseHex4(raw[i+3:])
+				if !ok {
+					return nil // JSON decoder reports the malformed escape.
+				}
+				if low < 0xDC00 || low > 0xDFFF {
+					return fmt.Errorf("%w: high surrogate not followed by low surrogate", ErrInvalidUnicode)
+				}
+				i += 6
+				continue
+			}
+			if r >= 0xDC00 && r <= 0xDFFF {
+				return fmt.Errorf("%w: unpaired low surrogate", ErrInvalidUnicode)
+			}
+		}
+	}
+	return nil
+}
+
+func parseHex4(b []byte) (rune, bool) {
+	if len(b) < 4 {
+		return 0, false
+	}
+	var v rune
+	for i := 0; i < 4; i++ {
+		c := b[i]
+		switch {
+		case c >= '0' && c <= '9':
+			v = v*16 + rune(c-'0')
+		case c >= 'a' && c <= 'f':
+			v = v*16 + rune(c-'a'+10)
+		case c >= 'A' && c <= 'F':
+			v = v*16 + rune(c-'A'+10)
+		default:
+			return 0, false
+		}
+	}
+	return v, true
+}
+
+func parseValue(dec *json.Decoder) (any, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	return parseFrom(dec, tok)
+}
+
+func parseFrom(dec *json.Decoder, tok json.Token) (any, error) {
+	switch t := tok.(type) {
+	case json.Delim:
+		switch t {
+		case '{':
+			obj := map[string]any{}
+			for dec.More() {
+				ktok, err := dec.Token()
+				if err != nil {
+					return nil, err
+				}
+				key, ok := ktok.(string)
+				if !ok {
+					return nil, fmt.Errorf("expected string object key, got %T", ktok)
+				}
+				if _, exists := obj[key]; exists {
+					return nil, fmt.Errorf("%w: %q", ErrDuplicateKey, key)
+				}
+				val, err := parseValue(dec)
+				if err != nil {
+					return nil, err
+				}
+				obj[key] = val
+			}
+			if _, err := dec.Token(); err != nil { // consume '}'
+				return nil, err
+			}
+			return obj, nil
+		case '[':
+			arr := []any{}
+			for dec.More() {
+				val, err := parseValue(dec)
+				if err != nil {
+					return nil, err
+				}
+				arr = append(arr, val)
+			}
+			if _, err := dec.Token(); err != nil { // consume ']'
+				return nil, err
+			}
+			return arr, nil
+		default:
+			return nil, fmt.Errorf("unexpected delimiter %v", t)
+		}
+	case json.Number, string, bool, nil:
+		return t, nil
+	default:
+		return nil, fmt.Errorf("unexpected token %T", tok)
+	}
+}
+
+// Marshal serializes a parsed JSON tree to its RFC 8785 canonical form.
+func Marshal(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := marshalInto(&buf, v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func marshalInto(buf *bytes.Buffer, v any) error {
+	switch x := v.(type) {
+	case nil:
+		buf.WriteString("null")
+		return nil
+	case bool:
+		if x {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+		return nil
+	case string:
+		if !utf8.ValidString(x) {
+			return fmt.Errorf("%w: invalid UTF-8 string", ErrInvalidUnicode)
+		}
+		writeJCSString(buf, x)
+		return nil
+	case json.Number:
+		f, err := strconv.ParseFloat(x.String(), 64)
+		if err != nil {
+			return fmt.Errorf("%w: %q: %w", ErrInvalidNumber, x.String(), err)
+		}
+		s, err := formatNumber(f)
+		if err != nil {
+			return err
+		}
+		buf.WriteString(s)
+		return nil
+	case float64:
+		s, err := formatNumber(x)
+		if err != nil {
+			return err
+		}
+		buf.WriteString(s)
+		return nil
+	case []any:
+		buf.WriteByte('[')
+		for i, item := range x {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := marshalInto(buf, item); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte(']')
+		return nil
+	case map[string]any:
+		keys := make([]string, 0, len(x))
+		for k := range x {
+			if !utf8.ValidString(k) {
+				return fmt.Errorf("%w: invalid UTF-8 object key", ErrInvalidUnicode)
+			}
+			keys = append(keys, k)
+		}
+		sort.Slice(keys, func(i, j int) bool { return lessUTF16(keys[i], keys[j]) })
+		buf.WriteByte('{')
+		for i, k := range keys {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			writeJCSString(buf, k)
+			buf.WriteByte(':')
+			if err := marshalInto(buf, x[k]); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte('}')
+		return nil
+	default:
+		return fmt.Errorf("jcs: unsupported type %T", v)
+	}
+}
+
+// lessUTF16 reports whether a sorts before b by UTF-16 code-unit sequence, as
+// required by RFC 8785 §3.2.3. This differs from Go's default string comparison
+// for code points above U+FFFF: an astral character is a high surrogate
+// (0xD800-0xDBFF) in UTF-16, so it sorts before BMP characters U+E000-U+FFFF,
+// the opposite of code-point order.
+func lessUTF16(a, b string) bool {
+	ua := utf16.Encode([]rune(a))
+	ub := utf16.Encode([]rune(b))
+	for i := 0; i < len(ua) && i < len(ub); i++ {
+		if ua[i] != ub[i] {
+			return ua[i] < ub[i]
+		}
+	}
+	return len(ua) < len(ub)
+}
+
+// writeJCSString writes s as a canonical JSON string per RFC 8785 §3.2.2.2.
+// Only the mandatory escapes are emitted; all other characters (including every
+// non-ASCII code point) are written as literal UTF-8 with no normalization.
+// Notably this does NOT escape U+2028/U+2029, which Go's encoding/json escapes
+// even with HTML escaping disabled — a real divergence that would break parity.
+func writeJCSString(buf *bytes.Buffer, s string) {
+	buf.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			buf.WriteString(`\"`)
+		case '\\':
+			buf.WriteString(`\\`)
+		case '\b':
+			buf.WriteString(`\b`)
+		case '\t':
+			buf.WriteString(`\t`)
+		case '\n':
+			buf.WriteString(`\n`)
+		case '\f':
+			buf.WriteString(`\f`)
+		case '\r':
+			buf.WriteString(`\r`)
+		default:
+			if r < 0x20 {
+				buf.WriteString(`\u00`)
+				const hexdigits = "0123456789abcdef"
+				buf.WriteByte(hexdigits[(r>>4)&0xf])
+				buf.WriteByte(hexdigits[r&0xf])
+			} else {
+				buf.WriteRune(r)
+			}
+		}
+	}
+	buf.WriteByte('"')
+}
+
+// formatNumber serializes a float64 per RFC 8785 §3.2.2.3 (the ECMAScript
+// Number-to-string algorithm). The implementation follows the RFC 8785
+// reference algorithm from cyberphone/json-canonicalization (Apache-2.0):
+// select fixed-point notation for magnitudes in [1e-6, 1e21) and exponential
+// otherwise, take Go's shortest round-trippable representation, then strip the
+// single padding zero Go adds to two-digit exponents (Go emits "1e+09" where
+// ES6 wants "1e+9").
+func formatNumber(f float64) (string, error) {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return "", fmt.Errorf("%w: non-finite", ErrInvalidNumber)
+	}
+	if f == 0 { // also normalizes -0 to "0"
+		return "0", nil
+	}
+
+	sign := ""
+	if f < 0 {
+		f = -f
+		sign = "-"
+	}
+
+	format := byte('e')
+	if f < 1e21 && f >= 1e-6 {
+		format = 'f'
+	}
+	s := strconv.FormatFloat(f, format, -1, 64)
+
+	if e := strings.IndexByte(s, 'e'); e > 0 {
+		// s[e+1] is the exponent sign ('+'/'-'); s[e+2] is the first digit.
+		// Go pads to a minimum of two exponent digits, so a leading '0' here
+		// is padding that ES6 omits.
+		if e+2 < len(s) && s[e+2] == '0' {
+			s = s[:e+2] + s[e+3:]
+		}
+	}
+	return sign + s, nil
+}

--- a/internal/jcs/jcs.go
+++ b/internal/jcs/jcs.go
@@ -49,6 +49,15 @@ var ErrInvalidNumber = errors.New("invalid JSON number")
 // valid Unicode. RFC 8785 requires this to fail instead of being repaired.
 var ErrInvalidUnicode = errors.New("invalid Unicode in JSON string data")
 
+// ErrMaxDepth indicates JSON nesting exceeded maxParseDepth. Bounding recursion
+// keeps a deeply nested attacker payload from overflowing the stack (callers
+// feed untrusted input; a panic would violate the never-panic-on-input rule).
+var ErrMaxDepth = errors.New("JSON nesting too deep")
+
+// maxParseDepth bounds object/array recursion depth. Far deeper than any real
+// Agent Card or JWS header.
+const maxParseDepth = 512
+
 // Canonicalize parses raw JSON strictly and returns its RFC 8785 canonical form.
 func Canonicalize(raw []byte) ([]byte, error) {
 	v, err := Parse(raw)
@@ -71,7 +80,7 @@ func Parse(raw []byte) (any, error) {
 	}
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()
-	v, err := parseValue(dec)
+	v, err := parseValue(dec, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -155,15 +164,18 @@ func parseHex4(b []byte) (rune, bool) {
 	return v, true
 }
 
-func parseValue(dec *json.Decoder) (any, error) {
+func parseValue(dec *json.Decoder, depth int) (any, error) {
+	if depth > maxParseDepth {
+		return nil, fmt.Errorf("%w: exceeds %d", ErrMaxDepth, maxParseDepth)
+	}
 	tok, err := dec.Token()
 	if err != nil {
 		return nil, err
 	}
-	return parseFrom(dec, tok)
+	return parseFrom(dec, tok, depth)
 }
 
-func parseFrom(dec *json.Decoder, tok json.Token) (any, error) {
+func parseFrom(dec *json.Decoder, tok json.Token, depth int) (any, error) {
 	switch t := tok.(type) {
 	case json.Delim:
 		switch t {
@@ -181,7 +193,7 @@ func parseFrom(dec *json.Decoder, tok json.Token) (any, error) {
 				if _, exists := obj[key]; exists {
 					return nil, fmt.Errorf("%w: %q", ErrDuplicateKey, key)
 				}
-				val, err := parseValue(dec)
+				val, err := parseValue(dec, depth+1)
 				if err != nil {
 					return nil, err
 				}
@@ -194,7 +206,7 @@ func parseFrom(dec *json.Decoder, tok json.Token) (any, error) {
 		case '[':
 			arr := []any{}
 			for dec.More() {
-				val, err := parseValue(dec)
+				val, err := parseValue(dec, depth+1)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/jcs/jcs_cover_test.go
+++ b/internal/jcs/jcs_cover_test.go
@@ -105,6 +105,20 @@ func TestParseAcceptsEscapedBackslashThenU(t *testing.T) {
 	}
 }
 
+// TestParseRejectsDeepNesting proves recursion is bounded: a payload nested past
+// maxParseDepth returns ErrMaxDepth instead of overflowing the stack.
+func TestParseRejectsDeepNesting(t *testing.T) {
+	deep := strings.Repeat("[", 600) + strings.Repeat("]", 600)
+	if _, err := Canonicalize([]byte(deep)); !errors.Is(err, ErrMaxDepth) {
+		t.Fatalf("expected ErrMaxDepth, got %v", err)
+	}
+	// A nesting depth within the bound still parses.
+	ok := strings.Repeat("[", 100) + strings.Repeat("]", 100)
+	if _, err := Canonicalize([]byte(ok)); err != nil {
+		t.Fatalf("within-bound nesting should parse: %v", err)
+	}
+}
+
 // TestKeyOrderingPrefix covers the lessUTF16 length tiebreak ("a" < "ab").
 func TestKeyOrderingPrefix(t *testing.T) {
 	got, err := Canonicalize([]byte(`{"ab":1,"a":2}`))

--- a/internal/jcs/jcs_cover_test.go
+++ b/internal/jcs/jcs_cover_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package jcs
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestParseRejectsMalformed covers the parser error branches: truncated input,
+// a stray closing delimiter, and an incomplete value.
+func TestParseRejectsMalformed(t *testing.T) {
+	for _, in := range []string{
+		`}`,            // stray delimiter as first token
+		`{`,            // unterminated object
+		`{"a":}`,       // missing value
+		`{"a":1,}`,     // trailing comma
+		`[1,2`,         // unterminated array
+		``,             // empty input
+		`nul`,          // invalid literal
+		`{"a" 1}`,      // missing colon
+		`[1 2]`,        // missing comma
+		`{"a":[1,]}`,   // trailing comma in nested array
+		`{"a":1} @bad`, // trailing non-whitespace that fails to tokenize
+	} {
+		t.Run(in, func(t *testing.T) {
+			if _, err := Canonicalize([]byte(in)); err == nil {
+				t.Fatalf("Canonicalize(%q) should error", in)
+			}
+		})
+	}
+}
+
+// TestMarshalUnsupportedType covers the marshalInto default branch.
+func TestMarshalUnsupportedType(t *testing.T) {
+	if _, err := Marshal(struct{ X int }{X: 1}); err == nil {
+		t.Fatal("Marshal of unsupported type should error")
+	}
+	// Unsupported value nested in a container also errors.
+	if _, err := Marshal([]any{struct{}{}}); err == nil {
+		t.Fatal("Marshal of unsupported nested type should error")
+	}
+	if _, err := Marshal(map[string]any{"k": struct{}{}}); err == nil {
+		t.Fatal("Marshal of unsupported map value should error")
+	}
+}
+
+// TestMarshalFloat64 covers the float64 marshalInto branch (Parse yields
+// json.Number, but Marshal accepts raw float64 too).
+func TestMarshalFloat64(t *testing.T) {
+	got, err := Marshal(map[string]any{"a": float64(1.5), "b": float64(100)})
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if string(got) != `{"a":1.5,"b":100}` {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// TestMarshalInvalidNumber covers the json.Number ParseFloat error branch.
+func TestMarshalInvalidNumber(t *testing.T) {
+	if _, err := Marshal(json.Number("not-a-number")); !errors.Is(err, ErrInvalidNumber) {
+		t.Fatalf("expected ErrInvalidNumber, got %v", err)
+	}
+	// Non-finite values cannot be represented in JSON.
+	if _, err := Marshal(json.Number("1e999")); !errors.Is(err, ErrInvalidNumber) {
+		t.Fatalf("expected ErrInvalidNumber for overflow, got %v", err)
+	}
+}
+
+// TestStringAllEscapes exercises every short-escape branch and a high code point.
+func TestStringAllEscapes(t *testing.T) {
+	in := "{\"k\":\"\\b\\f\\r\\n\\t\\\"\\\\\\u0000\\u001f\"}"
+	got, err := Canonicalize([]byte(in))
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	want := "{\"k\":\"\\b\\f\\r\\n\\t\\\"\\\\\\u0000\\u001f\"}"
+	if string(got) != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+	// A high (non-ASCII, non-control) code point passes through literally.
+	g2, err := Canonicalize([]byte(`{"k":"日本語"}`))
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !strings.Contains(string(g2), "日本語") {
+		t.Fatalf("non-ASCII should pass through literally: %q", g2)
+	}
+}
+
+// TestParseAcceptsEscapedBackslashThenU covers the escaped-backslash path in the
+// surrogate scanner (\\u is a literal backslash + 'u', not an escape sequence,
+// so the high-surrogate bytes here are plain data and must NOT be rejected).
+func TestParseAcceptsEscapedBackslashThenU(t *testing.T) {
+	got, err := Canonicalize([]byte(`{"k":"\\uD83D"}`))
+	if err != nil {
+		t.Fatalf("escaped backslash before u must be fine: %v", err)
+	}
+	if string(got) != `{"k":"\\uD83D"}` {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// TestKeyOrderingPrefix covers the lessUTF16 length tiebreak ("a" < "ab").
+func TestKeyOrderingPrefix(t *testing.T) {
+	got, err := Canonicalize([]byte(`{"ab":1,"a":2}`))
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if string(got) != `{"a":2,"ab":1}` {
+		t.Fatalf("prefix ordering wrong: %q", got)
+	}
+}

--- a/internal/jcs/jcs_test.go
+++ b/internal/jcs/jcs_test.go
@@ -1,0 +1,313 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package jcs
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestFormatNumber covers the RFC 8785 / ES6 number serialization boundary
+// vectors. These are the cases where a naive strconv.FormatFloat diverges from
+// the canonical form, so getting them exactly right is what proves parity with
+// a third-party JCS signer.
+func TestFormatNumber(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{0, "0"},
+		{math.Copysign(0, -1), "0"}, // negative zero normalizes to "0"
+		{1, "1"},
+		{-1, "-1"},
+		{1.5, "1.5"},
+		{-1.5, "-1.5"},
+		{0.5, "0.5"},
+		{10, "10"},
+		{100, "100"},
+		{100000, "100000"},
+		{0.1, "0.1"},
+		{2, "2"},
+		{2.5, "2.5"},
+		// Fixed/exponential threshold: [1e-6, 1e21) is fixed, else exponential.
+		{1e-6, "0.000001"},
+		{1e-7, "1e-7"}, // below 1e-6 -> exponential, padded exponent zero stripped
+		{4.5e-6, "0.0000045"},
+		{1e20, "100000000000000000000"}, // below 1e21 -> fixed
+		{1e21, "1e+21"},                 // at threshold -> exponential
+		{1e22, "1e+22"},
+		// Integer precision at the IEEE754 boundary.
+		{9007199254740992, "9007199254740992"}, // 2^53
+		{9007199254740994, "9007199254740994"}, // 2^53 + 2
+		// Extremes.
+		{5e-324, "5e-324"}, // smallest positive subnormal
+		{1.7976931348623157e308, "1.7976931348623157e+308"}, // max float64
+		{-1.7976931348623157e308, "-1.7976931348623157e+308"},
+		// Exponent leading-zero strip (Go emits 1e-09, ES6 wants 1e-9).
+		{1e-9, "1e-9"},
+		{1e23, "1e+23"},
+		// RFC 8785 Appendix-B-style ES6 edge vectors.
+		{-5e-324, "-5e-324"},
+		{333333333.33333329, "333333333.3333333"},
+		{1e30, "1e+30"},
+		{4.5, "4.5"},
+		{2e-3, "0.002"},
+		{1e-27, "1e-27"},
+		{9.999999999999997e-7, "9.999999999999997e-7"},
+		{999999999999999700000, "999999999999999700000"},
+		{295147905179352830000, "295147905179352830000"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			got, err := formatNumber(tc.in)
+			if err != nil {
+				t.Fatalf("formatNumber(%v) error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("formatNumber(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+			// Round-trip property: the canonical string must parse back to the
+			// exact same float64 bit pattern (skip the -0 normalization case,
+			// whose canonical form "0" intentionally changes the sign bit).
+			if tc.want != "0" {
+				rt, perr := strconv.ParseFloat(got, 64)
+				if perr != nil {
+					t.Fatalf("canonical %q does not parse: %v", got, perr)
+				}
+				if math.Float64bits(rt) != math.Float64bits(tc.in) {
+					t.Fatalf("round-trip %q -> bits %x != input bits %x", got, math.Float64bits(rt), math.Float64bits(tc.in))
+				}
+			}
+		})
+	}
+}
+
+func TestFormatNumberRejectsNonFinite(t *testing.T) {
+	for _, f := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		if _, err := formatNumber(f); err == nil {
+			t.Fatalf("formatNumber(%v) should reject non-finite", f)
+		}
+	}
+}
+
+// TestCanonicalizeStringPreservation proves we do NOT NFC-normalize strings.
+// An NFD-composed key/value must survive byte-for-byte (decoded), unlike the
+// contract package canonicalizer which NFC-folds.
+func TestCanonicalizeStringPreservation(t *testing.T) {
+	// U+00E9 (precomposed) vs U+0065 U+0301 (e + combining acute). These are
+	// distinct Unicode strings; JCS must keep them distinct.
+	precomposed := "é"
+	decomposed := "é"
+	in := `{"` + decomposed + `":1,"` + precomposed + `":2}`
+	got, err := Canonicalize([]byte(in))
+	if err != nil {
+		t.Fatalf("Canonicalize error: %v", err)
+	}
+	if !strings.Contains(string(got), decomposed) {
+		t.Fatalf("decomposed form was altered (NFC applied?): %q", got)
+	}
+	if !strings.Contains(string(got), precomposed) {
+		t.Fatalf("precomposed form was altered: %q", got)
+	}
+}
+
+// TestCanonicalizeKeyOrderingUTF16 proves keys are ordered by UTF-16 code units
+// (RFC 8785 §3.2.3), NOT by Unicode code point. An astral character (U+1F600,
+// high surrogate 0xD83D) must sort BEFORE U+FFFF (single code unit 0xFFFF),
+// which is the opposite of code-point ordering.
+func TestCanonicalizeKeyOrderingUTF16(t *testing.T) {
+	emoji := "\U0001F600"
+	bmp := "￿"
+	in := `{"` + bmp + `":1,"` + emoji + `":2}`
+	got, err := Canonicalize([]byte(in))
+	if err != nil {
+		t.Fatalf("Canonicalize error: %v", err)
+	}
+	iEmoji := strings.Index(string(got), emoji)
+	iBMP := strings.Index(string(got), bmp)
+	if iEmoji < 0 || iBMP < 0 {
+		t.Fatalf("keys missing from output: %q", got)
+	}
+	if iEmoji > iBMP {
+		t.Fatalf("UTF-16 ordering violated: emoji should precede U+FFFF, got %q", got)
+	}
+}
+
+// TestCanonicalizeBasicOrdering covers ASCII key sorting and value passthrough.
+func TestCanonicalizeBasicOrdering(t *testing.T) {
+	in := `{"b":1,"a":2,"c":{"z":true,"y":null}}`
+	want := `{"a":2,"b":1,"c":{"y":null,"z":true}}`
+	got, err := Canonicalize([]byte(in))
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("Canonicalize = %q, want %q", got, want)
+	}
+}
+
+// TestCanonicalizeNumbersInStructure verifies numbers are re-serialized per ES6
+// inside a structure (1.0 -> 1, 1e2 -> 100).
+func TestCanonicalizeNumbersInStructure(t *testing.T) {
+	in := `{"a":1.0,"b":1e2,"c":[0.1,1e-7]}`
+	want := `{"a":1,"b":100,"c":[0.1,1e-7]}`
+	got, err := Canonicalize([]byte(in))
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("Canonicalize = %q, want %q", got, want)
+	}
+}
+
+// TestCanonicalizeControlCharEscaping verifies RFC 8785 §3.2.2.2 escaping: tab
+// uses the short \t escape, U+0001 uses , quote and backslash are escaped.
+func TestCanonicalizeControlCharEscaping(t *testing.T) {
+	// in (interpreted) is the JSON  {"k":"a\tbc\"d\\e"}
+	in := "{\"k\":\"a\\tb\\u0001c\\\"d\\\\e\"}"
+	// want (interpreted) is the canonical {"k":"a\tbc\"d\\e"}
+	want := "{\"k\":\"a\\tb\\u0001c\\\"d\\\\e\"}"
+	got, err := Canonicalize([]byte(in))
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("Canonicalize = %q, want %q", got, want)
+	}
+}
+
+func TestParseRejectsDuplicateKeys(t *testing.T) {
+	_, err := Canonicalize([]byte(`{"a":1,"a":2}`))
+	if !errors.Is(err, ErrDuplicateKey) {
+		t.Fatalf("expected ErrDuplicateKey, got %v", err)
+	}
+}
+
+func TestParseRejectsTrailingTokens(t *testing.T) {
+	_, err := Canonicalize([]byte(`{"a":1} {"b":2}`))
+	if !errors.Is(err, ErrTrailingTokens) {
+		t.Fatalf("expected ErrTrailingTokens, got %v", err)
+	}
+}
+
+func TestParseRejectsNestedDuplicateKeys(t *testing.T) {
+	_, err := Canonicalize([]byte(`{"a":{"x":1,"x":2}}`))
+	if !errors.Is(err, ErrDuplicateKey) {
+		t.Fatalf("expected ErrDuplicateKey for nested dup, got %v", err)
+	}
+}
+
+func TestParseRejectsInvalidUnicode(t *testing.T) {
+	cases := map[string][]byte{
+		"invalid utf8":         {'"', 0xff, '"'},
+		"unpaired high":        []byte(`"\uD834"`),
+		"unpaired low":         []byte(`"\uDD1E"`),
+		"high followed by x":   []byte(`"\uD834\u0041"`),
+		"high followed by eof": []byte(`"\uD834\u"`),
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := Canonicalize(input)
+			if !errors.Is(err, ErrInvalidUnicode) {
+				t.Fatalf("expected ErrInvalidUnicode, got %v", err)
+			}
+		})
+	}
+}
+
+func TestParseAllowsValidSurrogatePair(t *testing.T) {
+	got, err := Canonicalize([]byte(`{"music":"\uD834\uDD1E"}`))
+	if err != nil {
+		t.Fatalf("valid surrogate pair should be accepted: %v", err)
+	}
+	if string(got) != `{"music":"𝄞"}` {
+		t.Fatalf("Canonicalize = %q, want musical symbol", got)
+	}
+}
+
+func TestMarshalRejectsInvalidUTF8Strings(t *testing.T) {
+	_, err := Marshal(string([]byte{0xff}))
+	if !errors.Is(err, ErrInvalidUnicode) {
+		t.Fatalf("invalid UTF-8 string should return ErrInvalidUnicode, got %v", err)
+	}
+	_, err = Marshal(map[string]any{string([]byte{0xff}): 1})
+	if !errors.Is(err, ErrInvalidUnicode) {
+		t.Fatalf("invalid UTF-8 key should return ErrInvalidUnicode, got %v", err)
+	}
+}
+
+func TestParseAllowsTrailingWhitespace(t *testing.T) {
+	got, err := Canonicalize([]byte("{\"a\":1}\n  \t"))
+	if err != nil {
+		t.Fatalf("trailing whitespace should be allowed: %v", err)
+	}
+	if string(got) != `{"a":1}` {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// TestMarshalAfterSignatureRemoval is the verifier's core need: parse a card,
+// drop the top-level "signatures" member, canonicalize the rest deterministically.
+func TestMarshalAfterSignatureRemoval(t *testing.T) {
+	raw := `{"name":"agent","signatures":[{"protected":"x","signature":"y"}],"version":"1.0"}`
+	v, err := Parse([]byte(raw))
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("expected object, got %T", v)
+	}
+	delete(m, "signatures")
+	got, err := Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	want := `{"name":"agent","version":"1.0"}`
+	if string(got) != want {
+		t.Fatalf("Marshal after removal = %q, want %q", got, want)
+	}
+}
+
+// TestCanonicalizeTopLevelScalar verifies non-object top-level values work.
+func TestCanonicalizeTopLevelScalar(t *testing.T) {
+	for in, want := range map[string]string{
+		`"hi"`:  `"hi"`,
+		`true`:  `true`,
+		`null`:  `null`,
+		`42`:    `42`,
+		`[3,1]`: `[3,1]`,
+	} {
+		got, err := Canonicalize([]byte(in))
+		if err != nil {
+			t.Fatalf("Canonicalize(%s) error: %v", in, err)
+		}
+		if string(got) != want {
+			t.Fatalf("Canonicalize(%s) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestCanonicalizeIdempotent: canonicalizing canonical output is a no-op.
+func TestCanonicalizeIdempotent(t *testing.T) {
+	in := `{"z":{"b":[1,2,3],"a":"x"},"a":1.50}`
+	once, err := Canonicalize([]byte(in))
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	twice, err := Canonicalize(once)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if string(once) != string(twice) {
+		t.Fatalf("not idempotent: %q vs %q", once, twice)
+	}
+	var a, b any
+	_ = json.Unmarshal(once, &a)
+	_ = json.Unmarshal(twice, &b)
+}

--- a/internal/mcp/a2a_scan.go
+++ b/internal/mcp/a2a_scan.go
@@ -325,6 +325,13 @@ type AgentCardScanResult struct {
 	DriftDetected bool
 	FirstSeen     bool
 	Findings      A2AScanResult // field-level scan findings
+
+	// SignatureVerified is true when the card carried a signature that verified
+	// against a trusted key scoped to the card's origin. SignatureKeyID is the
+	// verifying key_id, for the positive attestation receipt. A signature that
+	// failed to verify is reported via Clean=false + Reason, not these fields.
+	SignatureVerified bool
+	SignatureKeyID    string
 }
 
 // ScanAgentCard parses and scans an Agent Card response for skill poisoning
@@ -339,12 +346,18 @@ func ScanAgentCard(ctx context.Context, body []byte, sc *scanner.Scanner, baseli
 		// Unparseable card: fail closed for card-specific checks,
 		// but still run generic field scanning.
 		findings := scanA2ABody(ctx, body, sc, cfg)
-		return AgentCardScanResult{
+		unparseable := AgentCardScanResult{
 			Clean:    findings.Clean,
 			Action:   findings.Action,
 			Reason:   "a2a: unparseable Agent Card",
 			Findings: findings,
 		}
+		// Still enforce signature policy: an unparseable body is not a validly
+		// signed card, so require_signed_agent_cards (and any claimed-but-
+		// invalid signature) must fail closed here too, not be skipped by the
+		// early return.
+		applyCardSignatureVerification(&unparseable, body, key, cfg)
+		return unparseable
 	}
 
 	result := AgentCardScanResult{Clean: true}
@@ -378,7 +391,47 @@ func ScanAgentCard(ctx context.Context, body []byte, sc *scanner.Scanner, baseli
 		}
 	}
 
+	// Independent attestation: cryptographically verify the card's signature
+	// against the operator's trusted, origin-scoped keys. This runs in addition
+	// to (not instead of) content scanning and drift detection.
+	applyCardSignatureVerification(&result, body, key, cfg)
+
 	return result
+}
+
+// applyCardSignatureVerification verifies the card's signature (when verification
+// is active) and updates result in place. It is fail-closed: a claimed-but-
+// invalid signature blocks; an unsigned card blocks only when
+// require_signed_agent_cards is set; a verified signature records the attesting
+// key_id. Called from both the normal and unparseable-card paths so the
+// require-signed invariant cannot be skipped by an early return.
+func applyCardSignatureVerification(result *AgentCardScanResult, body []byte, key cardCacheKey, cfg *config.A2AScanning) {
+	if !CardSignatureVerificationActive(cfg) {
+		return
+	}
+	switch sig := VerifyAgentCardSignatures(body, CardOriginFromURL(key.cardURL), cfg); sig.Outcome {
+	case SigOutcomeVerified:
+		result.SignatureVerified = true
+		result.SignatureKeyID = sig.KeyID
+	case SigOutcomeFailed:
+		result.Clean = false
+		if result.Action == "" {
+			result.Action = cfg.Action
+		}
+		if result.Reason == "" {
+			result.Reason = sig.Reason
+		}
+	case SigOutcomeUnsigned:
+		if cfg.RequireSignedAgentCards {
+			result.Clean = false
+			if result.Action == "" {
+				result.Action = cfg.Action
+			}
+			if result.Reason == "" {
+				result.Reason = "a2a: unsigned Agent Card rejected (require_signed_agent_cards)"
+			}
+		}
+	}
 }
 
 // --- Context Tracking (Session Smuggling Detection) ---

--- a/internal/mcp/a2a_signature.go
+++ b/internal/mcp/a2a_signature.go
@@ -57,6 +57,13 @@ const (
 	// malicious card cannot force unbounded Ed25519 verifications. Real cards
 	// carry one or two signatures.
 	maxCardSignatures = 16
+
+	// maxJSONNesting bounds recursion depth while skipping nested JSON during
+	// signature-claim detection, so a deeply nested attacker payload returns an
+	// error instead of overflowing the stack (cards are runtime input; a panic
+	// would violate the never-panic-on-input rule). 512 is far deeper than any
+	// real Agent Card.
+	maxJSONNesting = 512
 )
 
 // trustedCardKey is a parsed, origin-scoped trusted signing key.
@@ -184,14 +191,20 @@ func topLevelHasSignaturesField(rawCard []byte) bool {
 		if key == a2aSignaturesField {
 			return true
 		}
-		if err := skipJSONValue(dec); err != nil {
+		if err := skipJSONValue(dec, 0); err != nil {
 			return false
 		}
 	}
 	return false
 }
 
-func skipJSONValue(dec *json.Decoder) error {
+// skipJSONValue consumes one JSON value from the decoder without materializing
+// it. depth bounds recursion (maxJSONNesting) so deeply nested input returns an
+// error rather than overflowing the stack.
+func skipJSONValue(dec *json.Decoder, depth int) error {
+	if depth > maxJSONNesting {
+		return fmt.Errorf("json nesting exceeds %d", maxJSONNesting)
+	}
 	tok, err := dec.Token()
 	if err != nil {
 		return err
@@ -206,7 +219,7 @@ func skipJSONValue(dec *json.Decoder) error {
 			if _, err := dec.Token(); err != nil {
 				return err
 			}
-			if err := skipJSONValue(dec); err != nil {
+			if err := skipJSONValue(dec, depth+1); err != nil {
 				return err
 			}
 		}
@@ -214,7 +227,7 @@ func skipJSONValue(dec *json.Decoder) error {
 		return err
 	case '[':
 		for dec.More() {
-			if err := skipJSONValue(dec); err != nil {
+			if err := skipJSONValue(dec, depth+1); err != nil {
 				return err
 			}
 		}

--- a/internal/mcp/a2a_signature.go
+++ b/internal/mcp/a2a_signature.go
@@ -1,0 +1,468 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/jcs"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// CardSigOutcome is the result of evaluating an Agent Card's signatures.
+type CardSigOutcome int
+
+const (
+	// SigOutcomeUnsigned means the card carried no signatures. The caller
+	// applies require_signed_agent_cards policy.
+	SigOutcomeUnsigned CardSigOutcome = iota
+	// SigOutcomeVerified means at least one signature verified against a trusted
+	// key scoped to the card's origin.
+	SigOutcomeVerified
+	// SigOutcomeFailed means the card claimed a signature but none verified
+	// against a trusted, origin-scoped key, or the card structure was ambiguous.
+	// This always fails closed.
+	SigOutcomeFailed
+)
+
+// CardSignatureResult reports the verification outcome plus context for receipts.
+type CardSignatureResult struct {
+	Outcome CardSigOutcome
+	KeyID   string // verifying key_id, set when Outcome == SigOutcomeVerified
+	Reason  string // failure detail, set when Outcome == SigOutcomeFailed
+}
+
+const (
+	// a2aSignaturesField is the Agent Card member excluded from the signed
+	// preimage (RFC 8785 canonicalization of "card minus signatures").
+	a2aSignaturesField = "signatures"
+
+	// jwsAlgEdDSA is the only JWS "alg" pipelock will verify. Anything else —
+	// "none", RS256, ES256, header-selected algorithms — is rejected. Trusted
+	// keys are Ed25519, and the verifier never lets the card's header choose the
+	// algorithm or key (algorithm-confusion defense).
+	jwsAlgEdDSA = "EdDSA"
+
+	// maxCardSignatures bounds how many signature entries are evaluated, so a
+	// malicious card cannot force unbounded Ed25519 verifications. Real cards
+	// carry one or two signatures.
+	maxCardSignatures = 16
+)
+
+// trustedCardKey is a parsed, origin-scoped trusted signing key.
+type trustedCardKey struct {
+	keyID   string
+	pub     ed25519.PublicKey
+	origins map[string]struct{}
+}
+
+// jwsSignature is one entry of the Agent Card "signatures" array (RFC 7515 JWS
+// flattened JSON, detached payload).
+type jwsSignature struct {
+	Protected string
+	Signature string
+}
+
+type protectedHeader struct {
+	Alg  string
+	Kid  string
+	B64  bool
+	Crit []string
+}
+
+// CardSignatureVerificationActive reports whether signature verification should
+// run: A2A scanning enabled and at least one trusted key configured.
+func CardSignatureVerificationActive(cfg *config.A2AScanning) bool {
+	return cfg != nil && cfg.Enabled && len(cfg.TrustedAgentCardKeys) > 0
+}
+
+// VerifyAgentCardSignatures evaluates the JWS signatures on a raw Agent Card
+// against the configured trusted, origin-scoped keys. It is fail-closed: once a
+// card claims a signature, every path other than a genuine trusted-and-valid
+// signature returns SigOutcomeFailed.
+func VerifyAgentCardSignatures(rawCard []byte, cardOrigin string, cfg *config.A2AScanning) CardSignatureResult {
+	// Lenient top-level detection of a signature claim first. It tolerates
+	// trailing bytes, so a card that claims a signature AND carries trailing
+	// tokens is still recognized as signed here; the strict JCS parse below is
+	// what rejects the ambiguity and fails closed.
+	if !topLevelHasSignaturesField(rawCard) {
+		return CardSignatureResult{Outcome: SigOutcomeUnsigned}
+	}
+
+	tree, err := jcs.Parse(rawCard)
+	if err != nil {
+		return CardSignatureResult{Outcome: SigOutcomeFailed, Reason: "a2a: ambiguous card structure: " + err.Error()}
+	}
+	top, ok := tree.(map[string]any)
+	if !ok {
+		return CardSignatureResult{Outcome: SigOutcomeFailed, Reason: "a2a: ambiguous card structure: card is not a JSON object"}
+	}
+	sigEntries, err := parseJWSSignatureEntries(top[a2aSignaturesField])
+	if err != nil {
+		return CardSignatureResult{Outcome: SigOutcomeFailed, Reason: "a2a: malformed signatures container"}
+	}
+	if len(sigEntries) == 0 {
+		return CardSignatureResult{Outcome: SigOutcomeUnsigned}
+	}
+
+	// The card claims a signature. Compute the unambiguous JCS preimage (card
+	// minus signatures).
+	delete(top, a2aSignaturesField)
+	preimage, err := jcs.Marshal(top)
+	if err != nil {
+		return CardSignatureResult{Outcome: SigOutcomeFailed, Reason: "a2a: ambiguous card structure: " + err.Error()}
+	}
+
+	keys := prepareTrustedCardKeys(cfg)
+	origin := CardOriginFromURL(cardOrigin)
+
+	limit := len(sigEntries)
+	if limit > maxCardSignatures {
+		limit = maxCardSignatures
+	}
+	for _, entry := range sigEntries[:limit] {
+		if keyID, ok := verifyOneSignature(entry, preimage, origin, keys); ok {
+			return CardSignatureResult{Outcome: SigOutcomeVerified, KeyID: keyID}
+		}
+	}
+	return CardSignatureResult{
+		Outcome: SigOutcomeFailed,
+		Reason:  fmt.Sprintf("a2a: no trusted signature for origin %s", originForReason(origin)),
+	}
+}
+
+// prepareTrustedCardKeys parses configured trusted keys into verification form.
+// Invalid entries are skipped (config validation rejects them at load; this is
+// defense in depth so a bad entry can never widen trust).
+func prepareTrustedCardKeys(cfg *config.A2AScanning) []trustedCardKey {
+	out := make([]trustedCardKey, 0, len(cfg.TrustedAgentCardKeys))
+	for _, k := range cfg.TrustedAgentCardKeys {
+		pub, err := signing.ParsePublicKey(k.PublicKey)
+		if err != nil {
+			continue
+		}
+		origins := make(map[string]struct{}, len(k.AllowedOrigins))
+		for _, o := range k.AllowedOrigins {
+			if norm := CardOriginFromURL(o); norm != "" {
+				origins[norm] = struct{}{}
+			}
+		}
+		out = append(out, trustedCardKey{keyID: k.KeyID, pub: pub, origins: origins})
+	}
+	return out
+}
+
+func topLevelHasSignaturesField(rawCard []byte) bool {
+	dec := json.NewDecoder(bytes.NewReader(rawCard))
+	dec.UseNumber()
+	tok, err := dec.Token()
+	if err != nil {
+		return false
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		return false
+	}
+	for dec.More() {
+		ktok, err := dec.Token()
+		if err != nil {
+			return false
+		}
+		key, ok := ktok.(string)
+		if !ok {
+			return false
+		}
+		if key == a2aSignaturesField {
+			return true
+		}
+		if err := skipJSONValue(dec); err != nil {
+			return false
+		}
+	}
+	return false
+}
+
+func skipJSONValue(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		for dec.More() {
+			if _, err := dec.Token(); err != nil {
+				return err
+			}
+			if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+		}
+		_, err := dec.Token()
+		return err
+	case '[':
+		for dec.More() {
+			if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+		}
+		_, err := dec.Token()
+		return err
+	default:
+		return nil
+	}
+}
+
+func parseJWSSignatureEntries(v any) ([]jwsSignature, error) {
+	if v == nil {
+		return nil, nil
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf("signatures is %T, want array", v)
+	}
+	out := make([]jwsSignature, 0, len(arr))
+	for i, item := range arr {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("signatures[%d] is %T, want object", i, item)
+		}
+		var entry jwsSignature
+		for k, val := range obj {
+			switch k {
+			case "protected":
+				s, ok := val.(string)
+				if !ok {
+					return nil, fmt.Errorf("signatures[%d].protected is %T, want string", i, val)
+				}
+				entry.Protected = s
+			case "signature":
+				s, ok := val.(string)
+				if !ok {
+					return nil, fmt.Errorf("signatures[%d].signature is %T, want string", i, val)
+				}
+				entry.Signature = s
+			case "header":
+				if _, ok := val.(map[string]any); !ok {
+					return nil, fmt.Errorf("signatures[%d].header is %T, want object", i, val)
+				}
+			default:
+				return nil, fmt.Errorf("signatures[%d] has unsupported field %q", i, k)
+			}
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+// verifyOneSignature attempts to verify a single JWS signature. It returns the
+// verifying key_id and true only if the signature is EdDSA, decodes to a
+// 64-byte Ed25519 signature, and verifies against a trusted key whose allowed
+// origins include the card origin. kid is a lookup hint only.
+func verifyOneSignature(entry jwsSignature, preimage []byte, origin string, keys []trustedCardKey) (string, bool) {
+	if entry.Protected == "" || entry.Signature == "" {
+		return "", false
+	}
+	protJSON, err := base64.RawURLEncoding.DecodeString(entry.Protected)
+	if err != nil {
+		return "", false
+	}
+	hdr, err := parseProtectedHeader(protJSON)
+	if err != nil {
+		return "", false
+	}
+	if hdr.Alg != jwsAlgEdDSA {
+		return "", false
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(entry.Signature)
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		return "", false
+	}
+
+	var signingInput []byte
+	if hdr.B64 {
+		signingInput = []byte(entry.Protected + "." + base64.RawURLEncoding.EncodeToString(preimage))
+	} else {
+		signingInput = append([]byte(entry.Protected+"."), preimage...)
+	}
+
+	// Empty origin (card origin could not be derived) matches no trusted key, so
+	// verification fails closed. kid only reorders candidate keys; it never grants
+	// trust, so an unknown kid still verifies if some origin-scoped key matches.
+	if origin == "" {
+		return "", false
+	}
+	for _, k := range orderByKidHint(keys, hdr.Kid) {
+		if _, ok := k.origins[origin]; !ok {
+			continue
+		}
+		if ed25519.Verify(k.pub, signingInput, sig) {
+			return k.keyID, true
+		}
+	}
+	return "", false
+}
+
+func parseProtectedHeader(raw []byte) (protectedHeader, error) {
+	tree, err := jcs.Parse(raw)
+	if err != nil {
+		return protectedHeader{}, err
+	}
+	obj, ok := tree.(map[string]any)
+	if !ok {
+		return protectedHeader{}, fmt.Errorf("protected header is %T, want object", tree)
+	}
+	hdr := protectedHeader{B64: true}
+	critSeen := map[string]struct{}{}
+	b64Present := false
+	for k, val := range obj {
+		switch k {
+		case "alg":
+			s, ok := val.(string)
+			if !ok {
+				return protectedHeader{}, fmt.Errorf("protected alg is %T, want string", val)
+			}
+			hdr.Alg = s
+		case "kid":
+			s, ok := val.(string)
+			if !ok {
+				return protectedHeader{}, fmt.Errorf("protected kid is %T, want string", val)
+			}
+			hdr.Kid = s
+		case "b64":
+			b, ok := val.(bool)
+			if !ok {
+				return protectedHeader{}, fmt.Errorf("protected b64 is %T, want bool", val)
+			}
+			hdr.B64 = b
+			b64Present = true
+		case "crit":
+			arr, ok := val.([]any)
+			if !ok {
+				return protectedHeader{}, fmt.Errorf("protected crit is %T, want array", val)
+			}
+			for _, item := range arr {
+				name, ok := item.(string)
+				if !ok {
+					return protectedHeader{}, fmt.Errorf("protected crit entry is %T, want string", item)
+				}
+				if _, dup := critSeen[name]; dup {
+					return protectedHeader{}, fmt.Errorf("duplicate crit entry %q", name)
+				}
+				critSeen[name] = struct{}{}
+				// RFC 7515 critical headers: every listed extension must be
+				// understood. This verifier only understands RFC 7797 b64.
+				if name != "b64" {
+					return protectedHeader{}, fmt.Errorf("unsupported critical header %q", name)
+				}
+				hdr.Crit = append(hdr.Crit, name)
+			}
+		}
+	}
+	if _, critical := critSeen["b64"]; critical && !b64Present {
+		return protectedHeader{}, fmt.Errorf("critical b64 header is not present")
+	}
+	if !hdr.B64 && !jwsCritContains(hdr.Crit, "b64") {
+		return protectedHeader{}, fmt.Errorf("b64:false missing critical b64 header")
+	}
+	return hdr, nil
+}
+
+// orderByKidHint returns keys with the kid-matching key first (a hint to reduce
+// Ed25519 verifications), preserving the rest in order. It never filters keys —
+// kid is not authority.
+func orderByKidHint(keys []trustedCardKey, kid string) []trustedCardKey {
+	if kid == "" {
+		return keys
+	}
+	ordered := make([]trustedCardKey, 0, len(keys))
+	var rest []trustedCardKey
+	for _, k := range keys {
+		if k.keyID == kid {
+			ordered = append(ordered, k)
+		} else {
+			rest = append(rest, k)
+		}
+	}
+	return append(ordered, rest...)
+}
+
+// CardOriginFromURL returns the origin (scheme://host[:port]) of a URL, lowercased,
+// or "" if the URL is not an absolute http(s) URL. Used both to scope a card to
+// the origin it was fetched from and to normalize configured allowed_origins.
+//
+// Its output MUST stay byte-identical to config.canonicalCardOrigin's: config
+// validation normalizes and stores allowed_origins via that function, and this
+// function re-normalizes them (and the card's fetch URL) at match time. Any
+// divergence in host-casing, default-port stripping, or IPv6 bracketing would
+// silently break origin matching. Keep the two in sync.
+func CardOriginFromURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return ""
+	}
+	host := u.Hostname()
+	if host == "" {
+		return ""
+	}
+	port := u.Port()
+	if port != "" && !validTCPPort(port) {
+		return ""
+	}
+	// Normalize default ports per RFC 6454 origin semantics so that
+	// https://h and https://h:443 (and http://h / http://h:80) compare equal.
+	// Clients usually omit the default port in the proxied URL, so without this
+	// an operator who pins "https://h:443" would never match a card served at
+	// "https://h" — a false-reject, not a security gap, but a real FP class.
+	if (scheme == "https" && port == "443") || (scheme == "http" && port == "80") {
+		port = ""
+	}
+	originHost := strings.ToLower(host)
+	if port != "" {
+		originHost = net.JoinHostPort(originHost, port)
+	} else if strings.Contains(originHost, ":") {
+		originHost = "[" + originHost + "]"
+	}
+	return scheme + "://" + originHost
+}
+
+func validTCPPort(port string) bool {
+	n, err := strconv.Atoi(port)
+	return err == nil && n >= 1 && n <= 65535
+}
+
+func jwsCritContains(crit []string, want string) bool {
+	for _, c := range crit {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+func originForReason(origin string) string {
+	if origin == "" {
+		return "(unknown)"
+	}
+	return origin
+}

--- a/internal/mcp/a2a_signature_cover_test.go
+++ b/internal/mcp/a2a_signature_cover_test.go
@@ -1,0 +1,324 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestCardSignatureVerificationActive(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	cases := []struct {
+		name string
+		cfg  *config.A2AScanning
+		want bool
+	}{
+		{"nil", nil, false},
+		{"disabled", &config.A2AScanning{Enabled: false, TrustedAgentCardKeys: trustCfg(t, pub).TrustedAgentCardKeys}, false},
+		{"no_keys", &config.A2AScanning{Enabled: true}, false},
+		{"active", trustCfg(t, pub), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CardSignatureVerificationActive(tc.cfg); got != tc.want {
+				t.Fatalf("CardSignatureVerificationActive = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCardOriginFromURL_Invalid(t *testing.T) {
+	for _, in := range []string{
+		"",
+		"   ",
+		"not a url",
+		"ftp://host/x",       // non-http scheme
+		"/relative/path",     // no host
+		"agent.example.com",  // no scheme
+		"file:///etc/passwd", // no host, non-http
+		"://noscheme",        // malformed
+		"https://h:0",        // port out of range
+		"https://h:99999",    // port out of range
+		"https://h:notaport", // non-numeric port
+		"https://:443",       // empty host
+	} {
+		if got := CardOriginFromURL(in); got != "" {
+			t.Fatalf("CardOriginFromURL(%q) = %q, want empty", in, got)
+		}
+	}
+}
+
+func TestCardOriginFromURL_IPv6(t *testing.T) {
+	cases := map[string]string{
+		"https://[::1]/.well-known/agent-card.json": "https://[::1]",
+		"https://[2001:db8::1]:8443/x":              "https://[2001:db8::1]:8443",
+		"https://[2001:DB8::1]/x":                   "https://[2001:db8::1]",
+		"http://[::1]:80/x":                         "http://[::1]", // default port stripped
+	}
+	for in, want := range cases {
+		if got := CardOriginFromURL(in); got != want {
+			t.Fatalf("CardOriginFromURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestVerify_ExceedsSignatureCap proves the maxCardSignatures DoS bound: a card
+// stuffed with > 16 invalid signatures still fails closed (and only the first 16
+// are evaluated).
+func TestVerify_ExceedsSignatureCap(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	card := baseCard()
+	sigs := make([]any, 0, 20)
+	for i := 0; i < 20; i++ {
+		sigs = append(sigs, map[string]any{
+			"protected": b64u([]byte(`{"alg":"EdDSA"}`)),
+			"signature": b64u(make([]byte, ed25519.SignatureSize)),
+		})
+	}
+	card["signatures"] = sigs
+	body, _ := json.Marshal(card)
+	if res := VerifyAgentCardSignatures(body, testCardOrigin, trustCfg(t, pub)); res.Outcome != SigOutcomeFailed {
+		t.Fatalf("oversized signature set must fail closed, got %v", res.Outcome)
+	}
+}
+
+// TestVerify_KidRoutesAcrossMultipleKeys covers orderByKidHint with several
+// trusted keys: the card is signed by the second key and its kid points there.
+func TestVerify_KidRoutesAcrossMultipleKeys(t *testing.T) {
+	pub1, _, _ := ed25519.GenerateKey(nil)
+	pub2, priv2, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv2, map[string]any{"alg": "EdDSA", "kid": "second"})
+	cfg := &config.A2AScanning{
+		Enabled: true,
+		Action:  config.ActionBlock,
+		TrustedAgentCardKeys: []config.A2ATrustedCardKey{
+			{KeyID: "first", PublicKey: signing.EncodePublicKey(pub1), AllowedOrigins: []string{testCardOrigin}},
+			{KeyID: "second", PublicKey: signing.EncodePublicKey(pub2), AllowedOrigins: []string{testCardOrigin}},
+		},
+	}
+	res := VerifyAgentCardSignatures(card, testCardOrigin, cfg)
+	if res.Outcome != SigOutcomeVerified || res.KeyID != "second" {
+		t.Fatalf("expected verification by 'second', got %v/%q", res.Outcome, res.KeyID)
+	}
+}
+
+// TestVerify_MalformedDetection covers the streaming detector / value-skipper on
+// truncated cards: detection fails safely (treated as unsigned, handed to the
+// caller's unparseable path).
+func TestVerify_MalformedDetection(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	for _, body := range []string{
+		`{"a":[1,2`,   // truncated nested array
+		`{"a":{"b":1`, // truncated nested object
+		`{"a":1,`,     // truncated after value
+		`[1,2,3]`,     // not an object
+	} {
+		res := VerifyAgentCardSignatures([]byte(body), testCardOrigin, trustCfg(t, pub))
+		if res.Outcome != SigOutcomeUnsigned {
+			t.Fatalf("malformed/non-object %q should report Unsigned, got %v", body, res.Outcome)
+		}
+	}
+}
+
+// cardWithProtected builds a card whose single signature carries the given
+// protected header object (signature bytes are a zero placeholder).
+func cardWithProtected(t *testing.T, hdr map[string]any) []byte {
+	t.Helper()
+	pb, err := json.Marshal(hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	card := baseCard()
+	card["signatures"] = []any{map[string]any{
+		"protected": b64u(pb),
+		"signature": b64u(make([]byte, ed25519.SignatureSize)),
+	}}
+	out, _ := json.Marshal(card)
+	return out
+}
+
+// TestVerify_ProtectedHeaderRejections covers the strict protected-header parser:
+// every malformed header must fail closed (the signature never verifies).
+func TestVerify_ProtectedHeaderRejections(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	cases := map[string]map[string]any{
+		"alg_not_string":     {"alg": 1},
+		"kid_not_string":     {"alg": "EdDSA", "kid": 5},
+		"b64_not_bool":       {"alg": "EdDSA", "b64": "false"},
+		"crit_not_array":     {"alg": "EdDSA", "crit": "b64"},
+		"crit_entry_not_str": {"alg": "EdDSA", "crit": []any{1}},
+		"crit_unknown":       {"alg": "EdDSA", "crit": []any{"x5u"}},
+		"crit_duplicate":     {"alg": "EdDSA", "b64": false, "crit": []any{"b64", "b64"}},
+	}
+	for name, hdr := range cases {
+		t.Run(name, func(t *testing.T) {
+			body := cardWithProtected(t, hdr)
+			if res := VerifyAgentCardSignatures(body, testCardOrigin, trustCfg(t, pub)); res.Outcome != SigOutcomeFailed {
+				t.Fatalf("malformed protected header must fail, got %v", res.Outcome)
+			}
+		})
+	}
+}
+
+// TestVerify_SignatureEntryRejections covers the strict signatures-array parser.
+func TestVerify_SignatureEntryRejections(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	cases := map[string]string{
+		"unknown_field":     `{"name":"x","signatures":[{"protected":"a","signature":"b","payload":"c"}]}`,
+		"entry_not_object":  `{"name":"x","signatures":["nope"]}`,
+		"protected_not_str": `{"name":"x","signatures":[{"protected":1,"signature":"b"}]}`,
+		"signature_not_str": `{"name":"x","signatures":[{"protected":"a","signature":2}]}`,
+		"header_not_object": `{"name":"x","signatures":[{"protected":"a","signature":"b","header":"nope"}]}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			if res := VerifyAgentCardSignatures([]byte(body), testCardOrigin, trustCfg(t, pub)); res.Outcome != SigOutcomeFailed {
+				t.Fatalf("malformed signature entry must fail, got %v", res.Outcome)
+			}
+		})
+	}
+}
+
+// TestVerify_DetectionSkipsNestedStructures exercises the streaming signatures
+// detector across nested object/array values that precede the signatures key.
+func TestVerify_DetectionSkipsNestedStructures(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	// "artifacts" (array) and "capabilities" (object) sort before "signatures";
+	// the detector must skip their nested values and still find the signature.
+	body := `{"artifacts":[1,[2,3],{"x":4}],"capabilities":{"a":{"b":1}},"signatures":[{"protected":"YQ","signature":"Yg"}]}`
+	res := VerifyAgentCardSignatures([]byte(body), testCardOrigin, trustCfg(t, pub))
+	// Detected as signed (not Unsigned); the placeholder signature is invalid -> Failed.
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("nested-structure card with a signature must be detected and fail, got %v", res.Outcome)
+	}
+}
+
+// TestVerify_B64FalseWithoutCrit covers the RFC 7797 rule: an unencoded payload
+// is only valid if "b64" is listed in "crit". Omitting crit must reject.
+func TestVerify_B64FalseWithoutCrit(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := baseCard()
+	pre := preimageOf(t, card)
+	hdr := map[string]any{"alg": "EdDSA", "kid": testKeyID, "b64": false} // no crit
+	pb, _ := json.Marshal(hdr)
+	protectedB64 := b64u(pb)
+	signingInput := append([]byte(protectedB64+"."), pre...)
+	sig := ed25519.Sign(priv, signingInput)
+	card["signatures"] = []any{map[string]any{"protected": protectedB64, "signature": b64u(sig)}}
+	body, _ := json.Marshal(card)
+	res := VerifyAgentCardSignatures(body, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("b64:false without crit must fail, got %v", res.Outcome)
+	}
+}
+
+// TestVerify_UnknownOriginReason exercises the "(unknown)" reason path when the
+// card origin cannot be derived.
+func TestVerify_UnknownOriginReason(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, edHeader())
+	res := VerifyAgentCardSignatures(card, "not-a-url", trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("unknown origin must fail, got %v", res.Outcome)
+	}
+	if !strings.Contains(res.Reason, "(unknown)") {
+		t.Fatalf("reason should mention unknown origin, got %q", res.Reason)
+	}
+}
+
+// TestVerify_MalformedSignaturesContainer covers a signatures field that is not
+// a JSON array.
+func TestVerify_MalformedSignaturesContainer(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	body := []byte(`{"name":"x","signatures":"not-an-array"}`)
+	res := VerifyAgentCardSignatures(body, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("malformed signatures container must fail, got %v", res.Outcome)
+	}
+}
+
+// TestVerify_NotAJSONObject covers a non-object top-level body (left to the
+// caller's unparseable path -> reported Unsigned here).
+func TestVerify_NotAJSONObject(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	res := VerifyAgentCardSignatures([]byte(`["array","card"]`), testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeUnsigned {
+		t.Fatalf("non-object body should report Unsigned, got %v", res.Outcome)
+	}
+}
+
+// TestVerify_NullSignatures covers an explicit JSON null signatures member.
+func TestVerify_NullSignatures(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	res := VerifyAgentCardSignatures([]byte(`{"name":"x","signatures":null}`), testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeUnsigned {
+		t.Fatalf("null signatures should report Unsigned, got %v", res.Outcome)
+	}
+}
+
+// TestVerify_DefaultPortNormalization proves RFC 6454 origin semantics: a key
+// pinned to "https://host:443" verifies a card served at "https://host" (and
+// vice versa), since the default port is not a distinct origin.
+func TestVerify_DefaultPortNormalization(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, edHeader())
+
+	// Key pinned WITH explicit :443; card fetched WITHOUT a port.
+	cfg443 := trustCfg(t, pub, "https://agent.example.com:443")
+	if res := VerifyAgentCardSignatures(card, "https://agent.example.com", cfg443); res.Outcome != SigOutcomeVerified {
+		t.Fatalf(":443 key should verify a no-port card, got %v (%s)", res.Outcome, res.Reason)
+	}
+
+	// Key pinned WITHOUT a port; card fetched WITH explicit :443.
+	cfgBare := trustCfg(t, pub, "https://agent.example.com")
+	if res := VerifyAgentCardSignatures(card, "https://agent.example.com:443", cfgBare); res.Outcome != SigOutcomeVerified {
+		t.Fatalf("no-port key should verify a :443 card, got %v (%s)", res.Outcome, res.Reason)
+	}
+
+	// A NON-default port stays distinct (no spurious match).
+	cfg8443 := trustCfg(t, pub, "https://agent.example.com:8443")
+	if res := VerifyAgentCardSignatures(card, "https://agent.example.com", cfg8443); res.Outcome != SigOutcomeFailed {
+		t.Fatalf(":8443 key must NOT match a no-port card, got %v", res.Outcome)
+	}
+}
+
+// TestVerify_RevocationByKeyRemoval proves that removing a key from the trusted
+// set (the hot-reload revocation path) makes a previously-trusted signature fail.
+func TestVerify_RevocationByKeyRemoval(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, edHeader())
+
+	// Before revocation: the signing key is trusted -> verifies.
+	if res := VerifyAgentCardSignatures(card, testCardOrigin, trustCfg(t, pub)); res.Outcome != SigOutcomeVerified {
+		t.Fatalf("pre-revocation should verify, got %v (%s)", res.Outcome, res.Reason)
+	}
+
+	// After revocation: config reloaded with a different key for the same origin;
+	// the old signature no longer maps to any trusted key -> fails closed.
+	otherPub, _, _ := ed25519.GenerateKey(nil)
+	if res := VerifyAgentCardSignatures(card, testCardOrigin, trustCfg(t, otherPub)); res.Outcome != SigOutcomeFailed {
+		t.Fatalf("post-revocation should fail closed, got %v", res.Outcome)
+	}
+}
+
+// TestVerify_SkipsUnparseableTrustedKey verifies a malformed trusted key entry
+// is skipped without widening trust (a valid entry still verifies).
+func TestVerify_SkipsUnparseableTrustedKey(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	cfg := trustCfg(t, pub)
+	cfg.TrustedAgentCardKeys = append([]config.A2ATrustedCardKey{
+		{KeyID: "broken", PublicKey: "not-a-key", AllowedOrigins: []string{testCardOrigin}},
+	}, cfg.TrustedAgentCardKeys...)
+	card := signCard(t, baseCard(), priv, edHeader())
+	res := VerifyAgentCardSignatures(card, testCardOrigin, cfg)
+	if res.Outcome != SigOutcomeVerified {
+		t.Fatalf("valid key alongside a broken entry must still verify, got %v (%s)", res.Outcome, res.Reason)
+	}
+}

--- a/internal/mcp/a2a_signature_cover_test.go
+++ b/internal/mcp/a2a_signature_cover_test.go
@@ -127,6 +127,20 @@ func TestVerify_MalformedDetection(t *testing.T) {
 	}
 }
 
+// TestVerify_DeeplyNestedCardNoPanic proves the signature-claim detector bounds
+// recursion: a card with deeply nested JSON before the signatures key returns a
+// safe outcome (no stack-overflow panic).
+func TestVerify_DeeplyNestedCardNoPanic(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	deep := strings.Repeat("[", 2000) + strings.Repeat("]", 2000)
+	body := `{"a":` + deep + `,"signatures":[{"protected":"YQ","signature":"Yg"}]}`
+	// Must not panic; detection bails out safely on the over-deep field.
+	res := VerifyAgentCardSignatures([]byte(body), testCardOrigin, trustCfg(t, pub))
+	if res.Outcome == SigOutcomeVerified {
+		t.Fatalf("deeply nested card must not verify, got %v", res.Outcome)
+	}
+}
+
 // cardWithProtected builds a card whose single signature carries the given
 // protected header object (signature bytes are a zero placeholder).
 func cardWithProtected(t *testing.T, hdr map[string]any) []byte {

--- a/internal/mcp/a2a_signature_integration_test.go
+++ b/internal/mcp/a2a_signature_integration_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const testCardURL = "https://agent.example.com/.well-known/agent-card.json"
+
+// sigScanCfg builds an A2AScanning config that isolates signature verification:
+// content scanning and drift are off so only the signature outcome moves Clean.
+func sigScanCfg(pub ed25519.PublicKey, require bool) *config.A2AScanning {
+	cfg := &config.A2AScanning{
+		Enabled:                 true,
+		Action:                  config.ActionBlock,
+		ScanAgentCards:          false,
+		DetectCardDrift:         false,
+		RequireSignedAgentCards: require,
+	}
+	if pub != nil {
+		cfg.TrustedAgentCardKeys = []config.A2ATrustedCardKey{
+			{KeyID: testKeyID, PublicKey: signing.EncodePublicKey(pub), AllowedOrigins: []string{testCardOrigin}},
+		}
+	}
+	return cfg
+}
+
+func TestScanAgentCard_ValidSignatureVerified(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, edHeader())
+	key := CardCacheKeyFromRequest(testCardURL, "")
+	res := ScanAgentCard(context.Background(), card, testA2AScanner(t), nil, key, sigScanCfg(pub, false))
+	if !res.Clean {
+		t.Fatalf("valid signature should keep card clean, got reason %q", res.Reason)
+	}
+	if !res.SignatureVerified || res.SignatureKeyID != testKeyID {
+		t.Fatalf("expected SignatureVerified with key %q, got %v/%q", testKeyID, res.SignatureVerified, res.SignatureKeyID)
+	}
+}
+
+func TestScanAgentCard_ForgedSignatureBlocks(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, edHeader())
+	card = replaceSig(t, card, b64u(make([]byte, ed25519.SignatureSize)))
+	key := CardCacheKeyFromRequest(testCardURL, "")
+	res := ScanAgentCard(context.Background(), card, testA2AScanner(t), nil, key, sigScanCfg(pub, false))
+	if res.Clean {
+		t.Fatal("forged signature must make the card not clean")
+	}
+	if res.Action != config.ActionBlock {
+		t.Fatalf("expected block action, got %q", res.Action)
+	}
+}
+
+func TestScanAgentCard_UnsignedRequiredBlocks(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	body := []byte(`{"name":"Vendor Agent","description":"does things"}`)
+	key := CardCacheKeyFromRequest(testCardURL, "")
+	res := ScanAgentCard(context.Background(), body, testA2AScanner(t), nil, key, sigScanCfg(pub, true))
+	if res.Clean {
+		t.Fatal("unsigned card must be blocked when require_signed_agent_cards is set")
+	}
+}
+
+// TestScanAgentCard_UnparseableRequiredBlocks proves the unparseable-card early
+// return still enforces require_signed_agent_cards (regression for the fail-open
+// gap an independent review found: a malformed body must not skip the signature
+// requirement).
+func TestScanAgentCard_UnparseableRequiredBlocks(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	body := []byte(`{"name":"x" TRAILING GARBAGE`) // fails struct unmarshal
+	key := CardCacheKeyFromRequest(testCardURL, "")
+	res := ScanAgentCard(context.Background(), body, testA2AScanner(t), nil, key, sigScanCfg(pub, true))
+	if res.Clean {
+		t.Fatal("unparseable card must be blocked when require_signed_agent_cards is set")
+	}
+}
+
+func TestScanAgentCard_UnsignedNotRequiredClean(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	body := []byte(`{"name":"Vendor Agent","description":"does things"}`)
+	key := CardCacheKeyFromRequest(testCardURL, "")
+	res := ScanAgentCard(context.Background(), body, testA2AScanner(t), nil, key, sigScanCfg(pub, false))
+	if !res.Clean {
+		t.Fatalf("unsigned card must be clean when require_signed is off, got %q", res.Reason)
+	}
+	if res.SignatureVerified {
+		t.Fatal("unsigned card must not report SignatureVerified")
+	}
+}
+
+func TestScanAgentCard_NoTrustedKeysSkipsVerification(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, edHeader())
+	key := CardCacheKeyFromRequest(testCardURL, "")
+	// No trusted keys -> verification inactive -> signed card not verified, not blocked.
+	res := ScanAgentCard(context.Background(), card, testA2AScanner(t), nil, key, sigScanCfg(nil, false))
+	if !res.Clean {
+		t.Fatalf("with no trusted keys, a signed card must not be blocked, got %q", res.Reason)
+	}
+	if res.SignatureVerified {
+		t.Fatal("verification should not run without trusted keys")
+	}
+}

--- a/internal/mcp/a2a_signature_test.go
+++ b/internal/mcp/a2a_signature_test.go
@@ -1,0 +1,402 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/jcs"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const (
+	testCardOrigin = "https://agent.example.com"
+	testKeyID      = "vendor-agent-v1"
+)
+
+// baseCard returns a minimal Agent Card object (no signatures) for signing.
+func baseCard() map[string]any {
+	return map[string]any{
+		"name":        "Vendor Agent",
+		"description": "does things",
+		"version":     "1.0.0",
+		"skills": []any{
+			map[string]any{"id": "s1", "name": "search"},
+		},
+	}
+}
+
+func preimageOf(t *testing.T, card map[string]any) []byte {
+	t.Helper()
+	cp := map[string]any{}
+	for k, v := range card {
+		if k == "signatures" {
+			continue
+		}
+		cp[k] = v
+	}
+	b, err := jcs.Marshal(cp)
+	if err != nil {
+		t.Fatalf("jcs.Marshal preimage: %v", err)
+	}
+	return b
+}
+
+func b64u(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+
+// signingInputEncoded builds the JWS signing input for the default (b64=true) case.
+func signingInputEncoded(protectedB64 string, preimage []byte) []byte {
+	return []byte(protectedB64 + "." + b64u(preimage))
+}
+
+// signCard signs card with priv using the given protected header and returns the
+// full signed card JSON. extraSigs are appended verbatim after the real signature.
+func signCard(t *testing.T, card map[string]any, priv ed25519.PrivateKey, protectedHdr map[string]any, extraSigs ...map[string]any) []byte {
+	t.Helper()
+	pre := preimageOf(t, card)
+	pb, err := json.Marshal(protectedHdr)
+	if err != nil {
+		t.Fatalf("marshal protected: %v", err)
+	}
+	protectedB64 := b64u(pb)
+	sig := ed25519.Sign(priv, signingInputEncoded(protectedB64, pre))
+	sigs := []any{map[string]any{"protected": protectedB64, "signature": b64u(sig)}}
+	for _, e := range extraSigs {
+		sigs = append(sigs, e)
+	}
+	card["signatures"] = sigs
+	out, err := json.Marshal(card)
+	if err != nil {
+		t.Fatalf("marshal card: %v", err)
+	}
+	return out
+}
+
+func trustCfg(t *testing.T, pub ed25519.PublicKey, origins ...string) *config.A2AScanning {
+	t.Helper()
+	if len(origins) == 0 {
+		origins = []string{testCardOrigin}
+	}
+	return &config.A2AScanning{
+		Enabled: true,
+		Action:  config.ActionBlock,
+		TrustedAgentCardKeys: []config.A2ATrustedCardKey{
+			{KeyID: testKeyID, PublicKey: signing.EncodePublicKey(pub), AllowedOrigins: origins},
+		},
+	}
+}
+
+func edHeader() map[string]any { return map[string]any{"alg": "EdDSA", "kid": testKeyID} }
+
+// --- Happy path ---
+
+func TestVerify_ValidSignature(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, edHeader())
+	res := VerifyAgentCardSignatures(card, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeVerified {
+		t.Fatalf("want Verified, got %v (%s)", res.Outcome, res.Reason)
+	}
+	if res.KeyID != testKeyID {
+		t.Fatalf("want KeyID %q, got %q", testKeyID, res.KeyID)
+	}
+}
+
+func TestVerify_ValidSignature_NoKidStillVerifies(t *testing.T) {
+	// kid is a hint only: omit it entirely and the origin-scoped key must still verify.
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, map[string]any{"alg": "EdDSA"})
+	res := VerifyAgentCardSignatures(card, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeVerified {
+		t.Fatalf("want Verified with no kid, got %v (%s)", res.Outcome, res.Reason)
+	}
+}
+
+// --- Adversarial: each MUST fail closed (SigOutcomeFailed) ---
+
+func TestVerify_ForgedSignature(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, edHeader())
+	// Replace the signature with random-but-correct-length bytes.
+	forged := make([]byte, ed25519.SignatureSize)
+	for i := range forged {
+		forged[i] = byte(i)
+	}
+	card = replaceSig(t, card, b64u(forged))
+	res := VerifyAgentCardSignatures(card, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("forged signature must fail closed, got %v", res.Outcome)
+	}
+}
+
+func TestVerify_SubstitutedSignature(t *testing.T) {
+	// Sign card A, then present a DIFFERENT card B carrying A's signature.
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	signed := signCard(t, baseCard(), priv, edHeader())
+	var cardA map[string]any
+	if err := json.Unmarshal(signed, &cardA); err != nil {
+		t.Fatal(err)
+	}
+	// Tamper: change a scanned field, keep the (now stale) signature.
+	cardB := baseCard()
+	cardB["description"] = "ELEVATED PRIVILEGES"
+	cardB["signatures"] = cardA["signatures"]
+	body, _ := json.Marshal(cardB)
+	res := VerifyAgentCardSignatures(body, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("substituted signature must fail, got %v", res.Outcome)
+	}
+}
+
+func TestVerify_UntrustedKey(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)       // signer
+	pubTrusted, _, _ := ed25519.GenerateKey(nil) // unrelated trusted key
+	card := signCard(t, baseCard(), priv, edHeader())
+	res := VerifyAgentCardSignatures(card, testCardOrigin, trustCfg(t, pubTrusted))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("untrusted signing key must fail, got %v", res.Outcome)
+	}
+}
+
+func TestVerify_AlgNone(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, map[string]any{"alg": "none", "kid": testKeyID})
+	res := VerifyAgentCardSignatures(card, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("alg:none must fail, got %v", res.Outcome)
+	}
+}
+
+func TestVerify_AlgConfusionRS256(t *testing.T) {
+	// Header claims RS256; even though the bytes were ed25519-signed, we must
+	// refuse to verify anything but EdDSA.
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, map[string]any{"alg": "RS256", "kid": testKeyID})
+	res := VerifyAgentCardSignatures(card, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("alg confusion (RS256) must fail, got %v", res.Outcome)
+	}
+}
+
+func TestVerify_EmptySignatureField(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, edHeader())
+	card = replaceSig(t, card, "")
+	res := VerifyAgentCardSignatures(card, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("empty signature must fail, got %v", res.Outcome)
+	}
+}
+
+func TestVerify_ShortSignature(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, edHeader())
+	card = replaceSig(t, card, b64u(make([]byte, 32))) // wrong length
+	res := VerifyAgentCardSignatures(card, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("short signature must fail, got %v", res.Outcome)
+	}
+}
+
+func TestVerify_OriginMismatch(t *testing.T) {
+	// Valid signature by a key scoped to origin A; card fetched from origin B.
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, edHeader())
+	res := VerifyAgentCardSignatures(card, "https://evil.example.net", trustCfg(t, pub, testCardOrigin))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("origin mismatch must fail, got %v", res.Outcome)
+	}
+}
+
+func TestVerify_DuplicateTopLevelKeys(t *testing.T) {
+	// A card with duplicate top-level keys has an ambiguous preimage and must fail.
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	signed := signCard(t, baseCard(), priv, edHeader())
+	// Inject a duplicate "name" key by string surgery (json.Marshal won't make one).
+	dup := `{"name":"x",` + string(signed[1:])
+	res := VerifyAgentCardSignatures([]byte(dup), testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("duplicate keys must fail closed, got %v (%s)", res.Outcome, res.Reason)
+	}
+}
+
+func TestVerify_TrailingTokens(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	signed := signCard(t, baseCard(), priv, edHeader())
+	withTrailer := append(append([]byte{}, signed...), []byte(" {}")...)
+	res := VerifyAgentCardSignatures(withTrailer, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("trailing tokens must fail closed, got %v", res.Outcome)
+	}
+}
+
+func TestVerify_DuplicateSignaturesField(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	signed := signCard(t, baseCard(), priv, edHeader())
+	dup := append([]byte(`{"signatures":null,`), signed[1:]...)
+	res := VerifyAgentCardSignatures(dup, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("duplicate signatures field must fail closed, got %v (%s)", res.Outcome, res.Reason)
+	}
+}
+
+func TestVerify_TamperedBody(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := baseCard()
+	signed := signCard(t, card, priv, edHeader())
+	var m map[string]any
+	_ = json.Unmarshal(signed, &m)
+	m["description"] = "tampered after signing"
+	body, _ := json.Marshal(m)
+	res := VerifyAgentCardSignatures(body, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("tampered body must fail, got %v", res.Outcome)
+	}
+}
+
+func TestVerify_DuplicateProtectedHeaderField(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := baseCard()
+	pre := preimageOf(t, card)
+	protectedB64 := b64u([]byte(`{"alg":"none","alg":"EdDSA","kid":"` + testKeyID + `"}`))
+	sig := ed25519.Sign(priv, signingInputEncoded(protectedB64, pre))
+	card["signatures"] = []any{map[string]any{"protected": protectedB64, "signature": b64u(sig)}}
+	body, _ := json.Marshal(card)
+	res := VerifyAgentCardSignatures(body, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("duplicate protected header must fail closed, got %v", res.Outcome)
+	}
+}
+
+func TestVerify_UnknownCriticalProtectedHeader(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, map[string]any{
+		"alg":  "EdDSA",
+		"kid":  testKeyID,
+		"crit": []any{"exp"},
+		"exp":  true,
+	})
+	res := VerifyAgentCardSignatures(card, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("unknown critical header must fail closed, got %v", res.Outcome)
+	}
+}
+
+func TestVerify_UnsupportedSignatureEntryField(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, edHeader())
+	var m map[string]any
+	if err := json.Unmarshal(card, &m); err != nil {
+		t.Fatal(err)
+	}
+	sigs := m["signatures"].([]any)
+	sigs[0].(map[string]any)["payload"] = "unsigned-payload-confuser"
+	body, _ := json.Marshal(m)
+	res := VerifyAgentCardSignatures(body, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("unsupported signature entry field must fail closed, got %v", res.Outcome)
+	}
+}
+
+// --- Adversarial: must NOT block (Verified/Unsigned as appropriate) ---
+
+func TestVerify_UnknownKidButAnotherValid(t *testing.T) {
+	// One signature has an unknown kid + garbage; a second is genuinely valid.
+	// kid is a hint, so the valid signature must carry the card.
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	garbage := map[string]any{
+		"protected": b64u([]byte(`{"alg":"EdDSA","kid":"who-knows"}`)),
+		"signature": b64u(make([]byte, ed25519.SignatureSize)),
+	}
+	card := signCard(t, baseCard(), priv, edHeader(), garbage)
+	res := VerifyAgentCardSignatures(card, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeVerified {
+		t.Fatalf("a valid sig alongside an unknown-kid sig must verify, got %v (%s)", res.Outcome, res.Reason)
+	}
+}
+
+func TestVerify_Unsigned(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	body, _ := json.Marshal(baseCard())
+	res := VerifyAgentCardSignatures(body, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeUnsigned {
+		t.Fatalf("unsigned card must report Unsigned, got %v", res.Outcome)
+	}
+}
+
+func TestVerify_EmptySignaturesArray(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	card := baseCard()
+	card["signatures"] = []any{}
+	body, _ := json.Marshal(card)
+	res := VerifyAgentCardSignatures(body, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeUnsigned {
+		t.Fatalf("empty signatures array must report Unsigned, got %v", res.Outcome)
+	}
+}
+
+func TestVerify_B64FalsePayload(t *testing.T) {
+	// RFC 7797 unencoded payload (b64:false with crit) must verify.
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := baseCard()
+	pre := preimageOf(t, card)
+	hdr := map[string]any{"alg": "EdDSA", "kid": testKeyID, "b64": false, "crit": []any{"b64"}}
+	pb, _ := json.Marshal(hdr)
+	protectedB64 := b64u(pb)
+	signingInput := append([]byte(protectedB64+"."), pre...)
+	sig := ed25519.Sign(priv, signingInput)
+	card["signatures"] = []any{map[string]any{"protected": protectedB64, "signature": b64u(sig)}}
+	body, _ := json.Marshal(card)
+	res := VerifyAgentCardSignatures(body, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeVerified {
+		t.Fatalf("b64:false payload must verify, got %v (%s)", res.Outcome, res.Reason)
+	}
+}
+
+func TestVerify_MalformedProtectedHeader(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	card := signCard(t, baseCard(), priv, edHeader())
+	var m map[string]any
+	_ = json.Unmarshal(card, &m)
+	sigs := m["signatures"].([]any)
+	sigs[0].(map[string]any)["protected"] = "!!!not base64url!!!"
+	body, _ := json.Marshal(m)
+	res := VerifyAgentCardSignatures(body, testCardOrigin, trustCfg(t, pub))
+	if res.Outcome != SigOutcomeFailed {
+		t.Fatalf("malformed protected header must fail, got %v", res.Outcome)
+	}
+}
+
+// --- Origin helper ---
+
+func TestCardOriginFromURL(t *testing.T) {
+	cases := map[string]string{
+		"https://agent.example.com/.well-known/agent-card.json": "https://agent.example.com",
+		"https://agent.example.com:8443/extendedAgentCard":      "https://agent.example.com:8443",
+		"https://[2001:db8::1]:8443/card":                       "https://[2001:db8::1]:8443",
+		"http://h/x":                                            "http://h",
+	}
+	for in, want := range cases {
+		if got := CardOriginFromURL(in); got != want {
+			t.Fatalf("CardOriginFromURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// replaceSig swaps the signature value of the first signature entry.
+func replaceSig(t *testing.T, card []byte, newSig string) []byte {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(card, &m); err != nil {
+		t.Fatal(err)
+	}
+	sigs := m["signatures"].([]any)
+	sigs[0].(map[string]any)["signature"] = newSig
+	out, _ := json.Marshal(m)
+	return out
+}

--- a/internal/proxy/a2a_card_signature_e2e_test.go
+++ b/internal/proxy/a2a_card_signature_e2e_test.go
@@ -4,17 +4,103 @@
 package proxy
 
 import (
+	"bytes"
+	"context"
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
+	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/jcs"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
+
+const interceptCardHost = "agent.example.com"
+
+// interceptCardCfg builds a config that verifies Agent Card signatures, scoped
+// to the intercept test host.
+func interceptCardCfg(pub ed25519.PublicKey) *config.Config {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.A2AScanning.Enabled = true
+	cfg.A2AScanning.Action = config.ActionBlock
+	cfg.A2AScanning.ScanAgentCards = false
+	cfg.A2AScanning.DetectCardDrift = false
+	cfg.A2AScanning.TrustedAgentCardKeys = []config.A2ATrustedCardKey{{
+		KeyID:          "k1",
+		PublicKey:      signing.EncodePublicKey(pub),
+		AllowedOrigins: []string{"https://" + interceptCardHost},
+	}}
+	return cfg
+}
+
+// runInterceptCard drives a card body back through the TLS-intercept handler and
+// returns the status code the agent would see.
+func runInterceptCard(t *testing.T, cfg *config.Config, card []byte) int {
+	t.Helper()
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+	logger := audit.NewNop()
+	m := metrics.New()
+	p, err := New(cfg, logger, sc, m)
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	t.Cleanup(p.Close)
+
+	rt := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Header:        http.Header{"Content-Type": []string{"application/a2a+json"}},
+			Body:          io.NopCloser(bytes.NewReader(card)),
+			ContentLength: int64(len(card)),
+		}, nil
+	})
+	handler := newInterceptHandler(&InterceptContext{
+		TargetHost: interceptCardHost,
+		TargetPort: "443",
+		Config:     cfg,
+		Scanner:    sc,
+		Logger:     logger,
+		Metrics:    m,
+		ClientIP:   testLoopbackIP,
+		RequestID:  "intercept-card",
+		Agent:      "test-agent",
+		Proxy:      p,
+	}, rt)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"https://"+interceptCardHost+agentCardPath, nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w.Code
+}
+
+// TestIntercept_AgentCardSignature_ForgedBlocked proves CONNECT/TLS-intercept
+// parity with the forward path: a forged Agent Card signature is blocked (403).
+func TestIntercept_AgentCardSignature_ForgedBlocked(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	if code := runInterceptCard(t, interceptCardCfg(pub), e2eSignedCard(t, priv, true)); code != http.StatusForbidden {
+		t.Fatalf("forged Agent Card over intercept must be blocked (403), got %d", code)
+	}
+}
+
+// TestIntercept_AgentCardSignature_ValidAllowed proves a validly signed card
+// passes through the intercept path (200).
+func TestIntercept_AgentCardSignature_ValidAllowed(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	if code := runInterceptCard(t, interceptCardCfg(pub), e2eSignedCard(t, priv, false)); code != http.StatusOK {
+		t.Fatalf("validly signed Agent Card over intercept must pass (200), got %d", code)
+	}
+}
 
 const agentCardPath = "/.well-known/agent-card.json"
 

--- a/internal/proxy/a2a_card_signature_e2e_test.go
+++ b/internal/proxy/a2a_card_signature_e2e_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/jcs"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const agentCardPath = "/.well-known/agent-card.json"
+
+func e2ePreimage(t *testing.T, card map[string]any) []byte {
+	t.Helper()
+	cp := map[string]any{}
+	for k, v := range card {
+		if k != "signatures" {
+			cp[k] = v
+		}
+	}
+	b, err := jcs.Marshal(cp)
+	if err != nil {
+		t.Fatalf("jcs.Marshal: %v", err)
+	}
+	return b
+}
+
+// e2eSignedCard returns a JWS-signed Agent Card. When forged is true the
+// signature bytes are replaced with zeros (valid length, wrong value).
+func e2eSignedCard(t *testing.T, priv ed25519.PrivateKey, forged bool) []byte {
+	t.Helper()
+	card := map[string]any{"name": "Vendor Agent", "description": "ok", "version": "1.0"}
+	pre := e2ePreimage(t, card)
+	hdr, _ := json.Marshal(map[string]any{"alg": "EdDSA", "kid": "k1"})
+	pb := base64.RawURLEncoding.EncodeToString(hdr)
+	sig := ed25519.Sign(priv, []byte(pb+"."+base64.RawURLEncoding.EncodeToString(pre)))
+	if forged {
+		sig = make([]byte, ed25519.SignatureSize)
+	}
+	card["signatures"] = []any{map[string]any{
+		"protected": pb,
+		"signature": base64.RawURLEncoding.EncodeToString(sig),
+	}}
+	b, _ := json.Marshal(card)
+	return b
+}
+
+func originOf(t *testing.T, rawURL string) string {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+	return u.Scheme + "://" + u.Host
+}
+
+// TestForwardHTTP_AgentCardSignature_ForgedBlocked proves the forward proxy
+// surface verifies Agent Card signatures end-to-end: a forged signature yields 403.
+func TestForwardHTTP_AgentCardSignature_ForgedBlocked(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	forged := e2eSignedCard(t, priv, true)
+
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/a2a+json")
+		_, _ = w.Write(forged)
+	}))
+	defer backend.Close()
+
+	proxyAddr, cleanup := setupForwardProxy(t, func(cfg *config.Config) {
+		cfg.A2AScanning.Enabled = true
+		cfg.A2AScanning.Action = config.ActionBlock
+		cfg.A2AScanning.ScanAgentCards = false
+		cfg.A2AScanning.DetectCardDrift = false
+		cfg.A2AScanning.TrustedAgentCardKeys = []config.A2ATrustedCardKey{{
+			KeyID:          "k1",
+			PublicKey:      signing.EncodePublicKey(pub),
+			AllowedOrigins: []string{originOf(t, backend.URL)},
+		}}
+	})
+	defer cleanup()
+
+	resp := doGet(t, proxyClient(proxyAddr), backend.URL+agentCardPath)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("forged Agent Card signature must be blocked (403), got %d", resp.StatusCode)
+	}
+}
+
+// TestForwardHTTP_AgentCardSignature_ValidAllowed proves a genuinely signed card
+// passes through the forward proxy.
+func TestForwardHTTP_AgentCardSignature_ValidAllowed(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	valid := e2eSignedCard(t, priv, false)
+
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/a2a+json")
+		_, _ = w.Write(valid)
+	}))
+	defer backend.Close()
+
+	proxyAddr, cleanup := setupForwardProxy(t, func(cfg *config.Config) {
+		cfg.A2AScanning.Enabled = true
+		cfg.A2AScanning.Action = config.ActionBlock
+		cfg.A2AScanning.ScanAgentCards = false
+		cfg.A2AScanning.DetectCardDrift = false
+		cfg.A2AScanning.TrustedAgentCardKeys = []config.A2ATrustedCardKey{{
+			KeyID:          "k1",
+			PublicKey:      signing.EncodePublicKey(pub),
+			AllowedOrigins: []string{originOf(t, backend.URL)},
+		}}
+	})
+	defer cleanup()
+
+	resp := doGet(t, proxyClient(proxyAddr), backend.URL+agentCardPath)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("validly signed Agent Card must pass (200), got %d", resp.StatusCode)
+	}
+}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1993,6 +1993,23 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 						a2aResult.Reason = cardResult.Reason
 					}
 				}
+				// Positive attestation: emit an allow receipt when the card's
+				// signature verified against a trusted, origin-scoped key.
+				if cardResult.SignatureVerified {
+					pattern := "verified key_id=" + cardResult.SignatureKeyID
+					p.logger.LogAnomaly(actx, scannerLabelA2ACardSignature, pattern, 0)
+					p.emitReceipt(withForwardRedaction(receipt.EmitOpts{
+						ActionID:  actionID,
+						Verdict:   config.ActionAllow,
+						Layer:     scannerLabelA2ACardSignature,
+						Pattern:   pattern,
+						Transport: "forward",
+						Method:    r.Method,
+						Target:    targetURL,
+						RequestID: requestID,
+						Agent:     agent,
+					}))
+				}
 			} else {
 				a2aResult = mcp.ScanA2AResponseBody(r.Context(), respBody, sc, &cfg.A2AScanning)
 			}

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -162,6 +162,11 @@ const interceptReadHeaderTimeout = 30 * time.Second
 // response_scan findings.
 const scannerLabelA2A = "a2a_scan"
 
+// scannerLabelA2ACardSignature is the receipt/log layer for Agent Card
+// signature attestation outcomes (positive verification and verification
+// failures distinct from generic A2A content findings).
+const scannerLabelA2ACardSignature = "a2a_card_signature"
+
 // interceptHandshakeTimeout is the maximum time for the client-side TLS
 // handshake during interception. Prevents goroutine/semaphore exhaustion
 // from malicious clients that stall during the handshake.
@@ -1634,6 +1639,23 @@ func newInterceptHandler(
 					if a2aRespResult.Reason == "" {
 						a2aRespResult.Reason = cardResult.Reason
 					}
+				}
+				// Positive attestation: emit an allow receipt when the card's
+				// signature verified against a trusted, origin-scoped key.
+				if cardResult.SignatureVerified {
+					pattern := "verified key_id=" + cardResult.SignatureKeyID
+					ic.Logger.LogAnomaly(actx, scannerLabelA2ACardSignature, pattern, 0)
+					interceptEmitReceipt(ic, withInterceptRedaction(receipt.EmitOpts{
+						ActionID:  actionID,
+						Verdict:   config.ActionAllow,
+						Layer:     scannerLabelA2ACardSignature,
+						Pattern:   pattern,
+						Transport: "intercept",
+						Method:    r.Method,
+						Target:    targetURL,
+						RequestID: ic.RequestID,
+						Agent:     ic.Agent,
+					}))
 				}
 			} else {
 				a2aRespResult = mcp.ScanA2AResponseBody(r.Context(), respBody, ic.Scanner, &ic.Config.A2AScanning)


### PR DESCRIPTION
## What

Pipelock can now cryptographically verify the JWS signature on an A2A Agent Card against signing keys the operator trusts, instead of ignoring it. A card whose signature does not verify against a trusted key scoped to the card's origin fails closed.

Today pipelock baselines Agent Cards for drift and can ignore self-declared identity headers, but it never checked the card's own signature. This closes that gap and backs the "independent attestation, not vendor self-attestation" model: the operator decides which keys are authoritative, and pipelock proves the card was signed by one of them.

## Trust model

Operators pin keys under `a2a_scanning`:

```yaml
a2a_scanning:
  enabled: true
  action: block
  trusted_agent_card_keys:
    - key_id: vendor-agent-v1
      public_key: pipelock-ed25519-public-v1...   # or raw hex
      allowed_origins:
        - https://agent.example.com
```

Each key is scoped to one or more origins. A pinned key may sign cards for those origins, not any card anywhere. The JWS `kid` header is a lookup hint, never authority, so a card cannot pick which key verifies it.

## How verification works

- Signature format is RFC 7515 JWS. Only `EdDSA` (Ed25519) is accepted. `alg: none`, RSA/ECDSA, and any header-selected algorithm are rejected.
- The signed preimage is the card with its `signatures` member removed, canonicalized per RFC 8785 (JCS). This PR adds `internal/jcs`, a standalone standard-library RFC 8785 implementation. It does not reuse the existing internal canonicalizer, which NFC-folds strings, rejects non-integer numbers, and orders keys by code point instead of UTF-16 code unit. Any of those would false-reject legitimately signed cards.
- Verification succeeds when at least one signature verifies against a trusted, origin-scoped key. An unknown `kid` on one signature does not block a card that another signature validates.

## Fail-closed behavior

Once a card claims a signature, every path other than a genuine trusted-and-valid signature is a finding, enforced at `a2a_scanning.action` (set `block` to reject). The adversarial test suite proves each of these blocks under `action: block`:

- forged signature
- signature lifted from a different card (substitution)
- key not in the trusted set
- signature scoped to a different origin than the card was served from
- `alg: none` and algorithm confusion (header claims RS256 over Ed25519 bytes)
- empty or wrong-length signature
- `b64:false` without the required `crit` declaration
- duplicate top-level keys or trailing tokens (ambiguous preimage)
- unsupported signature-entry fields, malformed protected header

An unsigned card keeps its existing scan and drift behavior, unless `require_signed_agent_cards: true`, which makes an unsigned card a finding. That flag requires at least one trusted key, or config load fails.

## Scope and surfaces

Verification runs wherever a card is delivered as a single body: the forward proxy (plain HTTP and CONNECT/TLS interception) and MCP HTTP. A2A SSE streams carry task and message events, not Agent Cards, so there is no card-signature step on the SSE path. A successful verification emits a positive attestation receipt; a failure emits a finding receipt.

## Notes

- Free tier. Detection and enforcement are never gated behind a license.
- No new dependencies. The JCS implementation is standard library only.
- Hot reload swaps the trusted-key set atomically and warns on a reduced key set. The canonical policy hash treats keys and origins as set-like, so reordering them does not churn the hash.
- The new config boolean `require_signed_agent_cards` is covered across all six load and reload states. Docs updated in `docs/configuration.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator-configurable Agent Card signature verification (Ed25519), origin-scoped trusted keys, and enforcement to block unsigned/invalid cards; verified cards record allow receipts and signature metadata.
  * Deterministic JSON canonicalization to support reliable signature checks.

* **Documentation**
  * Configuration docs updated with signature verification settings, validation rules, failure cases, and operational notes (hot-reload trust revocation, surface support).

* **Tests**
  * Extensive unit, integration, and end-to-end tests covering verification, canonicalization, gating, and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->