### PR TITLE
feat(assess): honor CRL in paid artifact gating

### DIFF
--- a/docs/security/tier-gating-audit-matrix.md
+++ b/docs/security/tier-gating-audit-matrix.md
@@ -1,0 +1,47 @@
+# Tier Gating Audit Matrix
+
+This matrix records the v2.7 runtime entitlement audit for paid Pipelock
+surfaces. It was audited against local `origin/main` at `521cdbbd`.
+
+Rule: detection, blocking, scanning, verification, and single-agent enforcement
+stay free. Paid code must fail closed at runtime with `License.HasFeature`, not
+only by living behind the `enterprise` build tag.
+
+## Entitlement Map
+
+| Entitlement | Tier | Runtime gate |
+|-------------|------|--------------|
+| `license.FeatureAgents` (`agents`) | Pro | `enterprise.EnforceLicenseGate` strips named agent profiles unless the verified license carries `agents`. |
+| `license.FeatureAssess` (`assess`) | Assess | `assess checkAssessLicense` emits full signed assessments only when the verified license carries `assess`. |
+| `license.FeatureFleet` (`fleet`) | Enterprise | `license.VerifyFleet` gates Conductor, fleet sink, bootstrap, and follower-side Conductor runtime. |
+
+## Paid Surface Matrix
+
+| Paid surface | Tier | Entitlement | Gate site | Tokenless deny | Under-tier deny | Correct allow | Malformed / expired / revoked deny | Reload / revocation parity |
+|--------------|------|-------------|-----------|----------------|-----------------|---------------|------------------------------------|----------------------------|
+| Named agent profiles | Pro | `FeatureAgents` | `enterprise/config.go` via `config.EnforceLicenseGateFunc` | `TestEnforceLicenseGate_NoLicenseKey`; `TestLicenseGateViaLoad` | `TestEnforceLicenseGate_MissingFeature` | `TestEnforceLicenseGate_ValidLicense`; `TestLicenseGateViaLoad_WithValidToken` | `TestEnforceLicenseGate_InvalidToken`; `TestEnforceLicenseGate_ExpiredLicense`; `TestEnforceLicenseGate_RevokedLicense` | `TestServer_ReloadLicenseRevocationStripsAgents` |
+| Per-agent listeners | Pro | `FeatureAgents` | Same `agents:` gate; listener sockets are derived from surviving named profiles | Same as named agent profiles | Same as named agent profiles | Same as named agent profiles plus `TestAgentRegistryPorts` | Same as named agent profiles | `TestServer_ReloadLicenseRevocationStripsAgents`; listener changes remain restart-only in `TestServer_Reload_PreservesRestartOnlyFields` |
+| Source CIDR to agent mapping | Pro | `FeatureAgents` | Same `agents:` gate | Same as named agent profiles | Same as named agent profiles | `TestAgentRegistryMatchCIDR`; `TestAgentRegistryResolveFromRequest_CIDR` | Same as named agent profiles | Same as named agent profiles |
+| Per-agent DLP, rate limits, budgets, mode, enforce, API allowlist, trusted domains, session thresholds, MCP tool policy, and sandbox profiles | Pro | `FeatureAgents` | Same `agents:` gate; values are applied only after profile resolution | Same as named agent profiles | Same as named agent profiles | `TestAgentRegistryProfiles`; `TestAgentRegistryBudgetIntegration`; `TestValidateMergedAgent_InvalidAnomalyAction` | Same as named agent profiles | Same as named agent profiles |
+| Full signed assessment artifacts (`assessment.json`, `assessment.html`, manifest signature, attestation/badge when requested) | Assess | `FeatureAssess` | `internal/cli/assess/finalize.go` | `TestCheckAssessLicenseFeatureGate/tokenless denies paid assessment` | `TestCheckAssessLicenseFeatureGate/under-tier agents token denies paid assessment` | `TestCheckAssessLicenseFeatureGate/assess feature allows paid assessment`; `TestAssessFinalize_Licensed_AutoSigns` | `TestCheckAssessLicenseFeatureGate/malformed token denies paid assessment`; expired, revoked, and unloadable-CRL subtests | Not a hot-reloaded service; every finalize invocation re-reads and verifies the current config/license/CRL |
+| Conductor signed policy distribution (follower bundle poller + apply cache) | Enterprise | `FeatureFleet` | `internal/cli/runtime/server.go` calls `license.VerifyFleet` when `conductor.enabled` is true | `TestNewServer_ConductorEnabledRequiresFleetLicense`; `TestRequireFleet_NoLicenseFailsClosed` | `TestRequireFleet_AgentsOnlyLicenseRejected`; `TestRequireFleet_AssessOnlyLicenseRejected` | `TestRequireFleet_FleetFeatureAccepted`; `TestNewServer_WiresConductorBundlePoller` | `TestRequireFleet_InvalidSignatureRejected`; `TestRequireFleet_ExpiredLicenseRejected`; `TestVerifyFleet_CRLRejectsRevokedFleetLicense`; `TestNewServer_ConductorEnabledRejectsRevokedFleetLicense` | `TestServer_ReloadCannotActivateConductorWithNewLicense`; conductor settings are restart-only in `TestServer_Reload_PreservesRestartOnlyFields` |
+| Conductor emergency remote kill | Enterprise | `FeatureFleet` | Same follower-side `conductor.enabled` gate | Same as Conductor signed policy distribution | Same as Conductor signed policy distribution | `TestServer_StartRunsConductorRemoteKillPoller` | Same as Conductor signed policy distribution | Same as Conductor signed policy distribution |
+| Conductor durable audit aggregation / audit batch producer | Enterprise | `FeatureFleet` | Same follower-side `conductor.enabled` gate for follower producer; server-side `pipelock conductor serve` gate for ingest | `TestNewServer_ConductorEnabledRequiresFleetLicense`; `TestServeCmd_NoFleetLicenseFailsClosed` | `TestRequireFleet_AgentsOnlyLicenseRejected` | `TestNewServer_ConductorAuditProducerFromConfig`; `TestRequireFleet_FleetFeatureAccepted` | Fleet malformed, expired, and revoked tests above | Same as Conductor signed policy distribution |
+| `pipelock conductor serve` control plane | Enterprise | `FeatureFleet` | `enterprise/cli/conductor/cmd.go` calls `license.VerifyFleet` before listener bind | `TestServeCmd_NoFleetLicenseFailsClosed` | `TestRequireFleet_AgentsOnlyLicenseRejected`; shared `VerifyFleet` gate | `TestRequireFleet_FleetFeatureAccepted`; command setup tests exercise post-gate server build with test licenses | `TestRequireFleet_InvalidSignatureRejected`; `TestRequireFleet_ExpiredLicenseRejected`; CRL revoked tests | Not hot-reloaded; command start verifies before serving |
+| `pipelock fleet-sink` standalone audit sink | Enterprise | `FeatureFleet` | `enterprise/cli/fleet/sink.go` calls `license.VerifyFleet` before listener bind or disk IO | `TestSinkCmd_NoFleetLicenseFailsClosed` | `TestRequireFleet_AgentsOnlyLicenseRejected`; shared `VerifyFleet` gate | `TestRequireFleet_FleetFeatureAccepted`; sink command tests exercise post-gate validation with test licenses | `TestRequireFleet_InvalidSignatureRejected`; `TestRequireFleet_ExpiredLicenseRejected`; CRL revoked tests | Not hot-reloaded; command start verifies before serving |
+| `pipelock conductor bootstrap` automation | Enterprise | `FeatureFleet` | `enterprise/cli/conductor/bootstrap.go` calls `license.VerifyFleet` before key/material generation | `TestBootstrapCmd_NoFleetLicenseFailsClosed` | `TestRequireFleet_AgentsOnlyLicenseRejected`; shared `VerifyFleet` gate | `TestBootstrapCmd_StandsUpFleet` | `TestRequireFleet_InvalidSignatureRejected`; `TestRequireFleet_ExpiredLicenseRejected`; CRL revoked tests | Not hot-reloaded; command start verifies before writing material |
+| Enterprise Eval fulfillment | Enterprise | `FeatureFleet` token minting | `enterprise/licenseservice` maps `enterprise_eval` to `agents` + `fleet` and rejects unconfigured or malformed eval orders | n/a: this is token issuance, not an end-user runtime surface | `TestTierToFeatures` ensures only Enterprise/Eval get `fleet` | `TestHandleOrderPaid_MintsEvalToken`; `TestHandleOrderPaid_MintedTokenVerifies` | `TestHandleOrderPaid_RejectsInvalidOrders`; `TestHandleOrderRefund_RevokesMintedEval` | Issued eval token expiry and refund revocation are tested by eval store/webhook tests |
+| License-service tier to feature minting | Entitlement authority | n/a | `enterprise/licenseservice/webhook.go:tierToFeatures` | Unknown tier returns nil in `TestTierToFeatures` | Pro/trial/founding Pro map only to `agents`; Assess maps only to `assess` | Enterprise and Enterprise Eval map to `agents` + `fleet` | Product metadata must be recognized by `mapProductToTier`; unknown tiers fail closed | n/a: license service persists entitlement state and revocations rather than hot-reloading runtime gates |
+
+## Free Surfaces Verified Ungated
+
+The audit found no license gate on core detection/enforcement surfaces. Scanner
+pipeline, proxy modes, TLS interception, WebSocket scanning, MCP scanning,
+tool poisoning detection, tool policy, session binding, chain detection, kill
+switch, audit logging, receipts/verification, metrics, sandbox default policy,
+and free CLI operational commands remain outside `HasFeature` gates.
+
+Free assessment summary artifacts are intentionally ungated: unlicensed or
+under-tiered users receive `summary.json`/`summary.html` without a paid signed
+assessment artifact. This is tested by `TestAssessFinalize_Unlicensed_Summary`
+and `TestAssess_EndToEnd_Unlicensed`.

--- a/internal/cli/assess/finalize.go
+++ b/internal/cli/assess/finalize.go
@@ -65,7 +65,16 @@ func checkAssessLicense(runDir string) bool {
 		return false
 	}
 
-	lic, err := license.Verify(cfg.LicenseKey, pubKey)
+	var lic license.License
+	if cfg.LicenseCRLFile != "" {
+		crl, crlErr := license.LoadAndVerifyCRL(cfg.LicenseCRLFile, pubKey, time.Now())
+		if crlErr != nil {
+			return false
+		}
+		lic, err = license.VerifyWithCRL(cfg.LicenseKey, pubKey, &crl)
+	} else {
+		lic, err = license.Verify(cfg.LicenseKey, pubKey)
+	}
 	if err != nil {
 		return false
 	}

--- a/internal/cli/assess/finalize_test.go
+++ b/internal/cli/assess/finalize_test.go
@@ -6,16 +6,21 @@ package assess
 import (
 	"archive/tar"
 	"compress/gzip"
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/cli/audit"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
@@ -65,6 +70,154 @@ func generateTestKeys(t *testing.T) (keystoreDir, agentName string) {
 	}
 
 	return keystoreDir, agentName
+}
+
+func TestCheckAssessLicenseFeatureGate(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey: %v", err)
+	}
+
+	t.Run("tokenless denies paid assessment", func(t *testing.T) {
+		runDir, _ := initTestRun(t)
+
+		if checkAssessLicense(runDir) {
+			t.Fatal("tokenless assess gate returned true")
+		}
+	})
+
+	t.Run("malformed token denies paid assessment", func(t *testing.T) {
+		runDir, cfgFile := initTestRun(t)
+		writeAssessLicenseConfig(t, cfgFile, "not-a-license-token", hex.EncodeToString(pub), "")
+
+		if checkAssessLicense(runDir) {
+			t.Fatal("malformed assess token returned true")
+		}
+	})
+
+	t.Run("unloadable CRL denies otherwise-valid assessment", func(t *testing.T) {
+		// A configured-but-broken CRL must fail closed: an unreadable
+		// revocation list means we cannot prove the license is unrevoked,
+		// so the paid path is denied rather than silently falling back to
+		// a no-revocation Verify.
+		runDir, cfgFile := initTestRun(t)
+		token, _ := issueAssessGateToken(t, priv, []string{license.FeatureAssess}, time.Now().Add(time.Hour), false)
+		missingCRL := filepath.Join(t.TempDir(), "nonexistent.crl.json")
+		writeAssessLicenseConfig(t, cfgFile, token, hex.EncodeToString(pub), missingCRL)
+
+		if checkAssessLicense(runDir) {
+			t.Fatal("assess gate returned true with an unloadable CRL; CRL-load failure must fail closed")
+		}
+	})
+
+	cases := []struct {
+		name      string
+		features  []string
+		expiresAt time.Time
+		revoked   bool
+		want      bool
+	}{
+		{
+			name:      "under-tier agents token denies paid assessment",
+			features:  []string{license.FeatureAgents},
+			expiresAt: time.Now().Add(time.Hour),
+			want:      false,
+		},
+		{
+			name:      "expired assess token denies paid assessment",
+			features:  []string{license.FeatureAssess},
+			expiresAt: time.Now().Add(-time.Hour),
+			want:      false,
+		},
+		{
+			name:      "revoked assess token denies paid assessment",
+			features:  []string{license.FeatureAssess},
+			expiresAt: time.Now().Add(time.Hour),
+			revoked:   true,
+			want:      false,
+		},
+		{
+			name:      "assess feature allows paid assessment",
+			features:  []string{license.FeatureAssess},
+			expiresAt: time.Now().Add(time.Hour),
+			want:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runDir, cfgFile := initTestRun(t)
+			token, crlFile := issueAssessGateToken(t, priv, tc.features, tc.expiresAt, tc.revoked)
+			writeAssessLicenseConfig(t, cfgFile, token, hex.EncodeToString(pub), crlFile)
+
+			if got := checkAssessLicense(runDir); got != tc.want {
+				t.Fatalf("checkAssessLicense() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func issueAssessGateToken(
+	t *testing.T,
+	priv ed25519.PrivateKey,
+	features []string,
+	expiresAt time.Time,
+	revoked bool,
+) (token, crlFile string) {
+	t.Helper()
+	now := time.Now().UTC()
+	lic := license.License{
+		ID:        "assess-gate-test",
+		Email:     "test@example.com",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: expiresAt.Unix(),
+		Features:  features,
+		Tier:      "test",
+	}
+	token, err := license.Issue(lic, priv)
+	if err != nil {
+		t.Fatalf("license.Issue: %v", err)
+	}
+	if !revoked {
+		return token, ""
+	}
+	crl, err := license.SignCRL(license.CRLPayload{
+		Version:   license.CRLVersion,
+		IssuedAt:  now.Add(-time.Minute).Unix(),
+		ExpiresAt: now.Add(time.Hour).Unix(),
+		Revoked: []license.RevokedLicense{{
+			ID:        lic.ID,
+			Reason:    "test revocation",
+			RevokedAt: now.Unix(),
+		}},
+	}, priv)
+	if err != nil {
+		t.Fatalf("license.SignCRL: %v", err)
+	}
+	data, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatalf("json.Marshal(CRL): %v", err)
+	}
+	crlFile = filepath.Join(t.TempDir(), "license.crl.json")
+	if err := os.WriteFile(crlFile, data, 0o600); err != nil {
+		t.Fatalf("os.WriteFile(CRL): %v", err)
+	}
+	return token, crlFile
+}
+
+func writeAssessLicenseConfig(t *testing.T, cfgFile, token, publicKey, crlFile string) {
+	t.Helper()
+	lines := []string{
+		"mode: audit",
+		"license_key: " + strconv.Quote(token),
+		"license_public_key: " + strconv.Quote(publicKey),
+	}
+	if crlFile != "" {
+		lines = append(lines, "license_crl_file: "+strconv.Quote(crlFile))
+	}
+	if err := os.WriteFile(cfgFile, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(config): %v", err)
+	}
 }
 
 func TestAssessFinalize_Licensed_AutoSigns(t *testing.T) {

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -801,6 +801,34 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 	}
 }
 
+func TestServer_ReloadLicenseRevocationStripsAgents(t *testing.T) {
+	s, buf := newTestServer(t, nil)
+	oldCfg := s.proxy.CurrentConfig()
+	oldCfg.Agents = map[string]config.AgentProfile{
+		"agent-a": {Mode: config.ModeStrict},
+	}
+	oldCfg.LicenseKey = "old-agents-token"
+	oldCfg.LicensePublicKey = "old-public-key"
+	oldCfg.LicenseExpiresAt = time.Now().Add(time.Hour).Unix()
+
+	newCfg := oldCfg.Clone()
+	newCfg.Agents = nil
+	newCfg.LicenseKey = "revoked-agents-token"
+	newCfg.LicenseRevoked = true
+	newCfg.LicenseRevocationReason = "test revocation"
+
+	if err := s.Reload(newCfg); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	live := s.proxy.CurrentConfig()
+	if live.Agents != nil {
+		t.Fatalf("agents survived license revocation reload: %+v", live.Agents)
+	}
+	if !buf.contains("license revoked agents, shutting down agent listeners") {
+		t.Fatalf("stderr missing agents revocation warning:\n%s", buf.String())
+	}
+}
+
 // TestServer_Reload_ReverseProxyProfileOnlyIgnored isolates the profile-only
 // reload case. The previous field-by-field guard only preserved ReverseProxy
 // when listen/enabled/upstream changed, so a reload that flipped ONLY the


### PR DESCRIPTION
## Summary
- honor configured license CRLs when deciding whether Assess can emit paid signed artifacts
- add fail-closed coverage for tokenless, malformed, under-tier, expired, revoked, and unreadable-CRL Assess licenses
- add a tier-gating audit matrix covering paid surfaces and runtime entitlement tests

## Tests
- go test -race -count=1 ./...
- go test -race -count=1 -tags enterprise ./...
- golangci-lint run ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved license verification to honor certificate revocation lists and ensure revoked, expired, or malformed licenses block gated features and remove agent access on configuration reload.

* **Tests**
  * Added comprehensive tests covering license feature gating, revocation/CRL handling, malformed/expired tokens, under-tier behavior, and reload-time revocation effects.

* **Documentation**
  * Added a tier-gating audit matrix detailing entitlement-to-tier mappings, gate behaviors, and expected allow/deny scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->