### PR TITLE
feat(receipt): dual-emit v2 proxy_decision receipts on the live proxy path

### DIFF
--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
 	"github.com/luckyPipewrench/pipelock/internal/emit"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/hitl"
@@ -454,6 +455,21 @@ func NewServer(opts ServerOpts) (*Server, error) {
 				proxyOpts = append(proxyOpts, proxy.WithReceiptKeyPath(cfg.FlightRecorder.SigningKeyPath))
 			}
 			_, _ = fmt.Fprintf(opts.Stderr, "  Receipts: enabled (action receipts signed)\n")
+
+			// v2 proxy_decision emitter: dual-emitted alongside the v1 action
+			// receipt on every proxy decision, signed with the same key and
+			// gated on the same receipt intent (no separate flag). Sanitizes
+			// targets with the recorder's redactor (#676) before signing.
+			if v2Emitter := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+				Recorder:  rec,
+				Signer:    proxydecision.NewKeyedSigner(recPrivKey),
+				Sanitize:  proxydecision.SanitizeFromRedactor(rec.ReceiptRedactor()),
+				Principal: "local",
+				Actor:     "pipelock",
+			}); v2Emitter != nil {
+				proxyOpts = append(proxyOpts, proxy.WithV2ReceiptEmitter(v2Emitter))
+				_, _ = fmt.Fprintf(opts.Stderr, "  Receipts: v2 proxy_decision dual-emit enabled\n")
+			}
 		}
 
 		_, _ = fmt.Fprintf(opts.Stderr, "  Recorder: %s (flight recorder enabled)\n", cfg.FlightRecorder.Dir)

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -663,6 +663,7 @@ func (s *Server) Start(ctx context.Context) error {
 		rpHandler.SetEnvelopeEmitter(s.proxy.EnvelopeEmitterPtr())
 		rpHandler.SetEnvelopeVerifier(s.proxy.EnvelopeVerifierPtr())
 		rpHandler.SetReceiptEmitter(s.proxy.ReceiptEmitterPtr())
+		rpHandler.SetV2ReceiptEmitter(s.proxy.V2EmitterPtr())
 		rpHandler.SetContractLoader(s.proxy.ContractLoaderPtr())
 		rpHandler.SetReloadLock(s.proxy.ReloadLock())
 		rpHandler.SetRequestPolicyFn(s.proxy.ApplyRequestPolicy)

--- a/internal/contract/proxydecision/emitter.go
+++ b/internal/contract/proxydecision/emitter.go
@@ -1,0 +1,341 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package proxydecision emits signed EvidenceReceipt v2 proxy_decision records
+// for live proxy enforcement decisions, alongside the legacy v1 ActionReceipt.
+//
+// It is the live emitter that BuildProxyDecisionReceipt was missing: the v2
+// receipt machinery (JCS canonical preimage, detached SignatureProof, strict
+// DisallowUnknownFields validation) already existed for shadow/activation
+// lifecycle records, but no production code emitted the proxy_decision payload
+// on the hot path. This package replicates the shadow emitter's signing
+// sequence for that payload.
+//
+// Chain model: this emitter maintains its OWN per-receipt chain (chain_seq /
+// chain_prev_hash), independent of the v1 ActionReceipt chain, both anchored at
+// recorder.GenesisHash. Both chains write into the same recorder, whose outer
+// hash chain spans every entry and provides the cross-record tamper-evidence;
+// the per-emitter chains are the in-band sequence the verifier walks. The v1
+// ActionReceipt chain is left untouched (expand-and-contract: v1 stays live).
+package proxydecision
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+const (
+	evidenceReceiptEntryType = "evidence_receipt"
+	recorderSessionID        = "proxy"
+	signatureAlgorithm       = "ed25519"
+	signaturePrefix          = "ed25519:"
+	keyPurposeReceiptSigning = "receipt-signing"
+
+	// Decision-source provenance labels. policy_sources / winning_source on the
+	// v2 proxy_decision payload are GENERIC decision provenance, not
+	// contract-only: a pure scanner block attributes to the scanner, a kill
+	// switch to itself, and a contract-participated decision adds the contract
+	// marker on top of the contract's own policy sources.
+	SourceScanner    = "scanner"
+	SourceKillSwitch = "kill_switch"
+	SourceContract   = "contract"
+)
+
+// ErrSignatureSize is returned when the signer produces a non-Ed25519-sized
+// signature. It is a programming/configuration error (wrong key type), never
+// agent-reachable input.
+var ErrSignatureSize = errors.New("proxydecision: signature size mismatch")
+
+// Signer signs EvidenceReceipt v2 preimages. Matches the interface used by the
+// shadow and activation emitters.
+type Signer interface {
+	KeyID() string
+	Sign([]byte) ([]byte, error)
+}
+
+// Recorder is the recorder subset used by Emitter.
+type Recorder interface {
+	Record(recorder.Entry) error
+}
+
+// SanitizeFunc reports whether text is free of DLP matches. It is built from
+// recorder.ReceiptRedactor at construction time and is nil when flight-recorder
+// redaction is off, in which case targets pass through unchanged.
+type SanitizeFunc func(string) bool
+
+// SanitizeFromRedactor adapts a recorder.RedactFunc into a SanitizeFunc so the
+// v2 emitter scrubs secrets with the exact function the recorder applies.
+// Returns nil when rf is nil (redaction disabled), leaving targets unchanged.
+// Both the startup and hot-reload construction paths use this so the v2
+// emitter's sanitization stays in lockstep with the recorder.
+func SanitizeFromRedactor(rf recorder.RedactFunc) SanitizeFunc {
+	if rf == nil {
+		return nil
+	}
+	return func(text string) bool { return rf(context.Background(), text).Clean }
+}
+
+// Decision is the per-call input describing one proxy enforcement decision.
+// The proxy derives it from its receipt.EmitOpts; this package is transport
+// agnostic and never sees agent-controlled structs directly.
+type Decision struct {
+	// ActionType labels the action class: "http_request", "mcp_tool_call",
+	// or "websocket_frame".
+	ActionType string
+	// Transport is the surface label: "forward", "intercept", "fetch",
+	// "websocket", "mcp_http", "mcp_stdio", "reverse".
+	Transport string
+	// Target is the RAW acted-upon target (URL / tool name / authority). It is
+	// sanitized (#676) before it enters the signed payload.
+	Target string
+	// Verdict is the enforcement verdict the proxy applied.
+	Verdict string
+	// LiveVerdict surfaces a contract live/shadow divergence; omitted from the
+	// wire payload when equal to Verdict.
+	LiveVerdict string
+	// WinningSource and PolicySources are generic decision provenance (see the
+	// Source* constants). Both are required by the v2 payload validator.
+	WinningSource string
+	PolicySources []string
+	// RuleID is the RAW matched rule / pattern label. It is sanitized before
+	// signing because a scanner pattern can echo matched bytes.
+	RuleID string
+
+	// Contract envelope fields, populated ONLY when a real resolved contract
+	// existed for this request. Empty for pure scanner / kill-switch decisions,
+	// in which case nothing is stamped.
+	ActiveManifestHash string
+	ContractHash       string
+	SelectorID         string
+	ContractGeneration uint64
+}
+
+// EmitterConfig configures live proxy_decision emission.
+type EmitterConfig struct {
+	Recorder  Recorder
+	Signer    Signer
+	Sanitize  SanitizeFunc
+	Principal string
+	Actor     string
+	Clock     func() time.Time
+	EventID   func() (string, error)
+
+	// ResumeSeq / ResumePrevHash carry the chain head forward across a hot
+	// reload so the v2 chain stays continuous within a process when the
+	// signing key (and therefore the emitter) is rebuilt. Leave both zero for
+	// a fresh chain (ResumePrevHash defaults to GenesisHash).
+	ResumeSeq      uint64
+	ResumePrevHash string
+}
+
+// Emitter signs proxy_decision receipts and records them.
+type Emitter struct {
+	recorder  Recorder
+	signer    Signer
+	sanitize  SanitizeFunc
+	principal string
+	actor     string
+	clock     func() time.Time
+	eventID   func() (string, error)
+
+	mu            sync.Mutex
+	chainSeq      uint64
+	chainPrevHash string
+}
+
+// NewEmitter returns nil when recorder or signer is missing, matching the
+// legacy receipt emitter's no-op-when-disabled behavior so callers can store a
+// nil pointer and call Emit unconditionally.
+func NewEmitter(cfg EmitterConfig) *Emitter {
+	if cfg.Recorder == nil || cfg.Signer == nil {
+		return nil
+	}
+	clock := cfg.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+	eventID := cfg.EventID
+	if eventID == nil {
+		eventID = newEventID
+	}
+	prev := cfg.ResumePrevHash
+	if prev == "" {
+		prev = recorder.GenesisHash
+	}
+	return &Emitter{
+		recorder:      cfg.Recorder,
+		signer:        cfg.Signer,
+		sanitize:      cfg.Sanitize,
+		principal:     cfg.Principal,
+		actor:         cfg.Actor,
+		clock:         clock,
+		eventID:       eventID,
+		chainSeq:      cfg.ResumeSeq,
+		chainPrevHash: prev,
+	}
+}
+
+func newEventID() (string, error) {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return "", err
+	}
+	return id.String(), nil
+}
+
+// ChainState returns the current chain head (next seq, prev hash). A reload
+// uses it to seed the replacement emitter's EmitterConfig so the v2 chain does
+// not reset to genesis mid-process. Safe on a nil receiver.
+func (e *Emitter) ChainState() (seq uint64, prevHash string) {
+	if e == nil {
+		return 0, recorder.GenesisHash
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.chainSeq, e.chainPrevHash
+}
+
+// Emit builds, signs, and records one v2 proxy_decision receipt. It is a no-op
+// on a nil receiver. The mutex spans the whole build→sign→hash→persist→advance
+// sequence so concurrent calls produce a well-ordered chain; chain state is
+// advanced only after a successful record, so a failed write leaves the chain
+// at its previous position (mirroring the v1 emitter and the shadow emitter).
+func (e *Emitter) Emit(d Decision) error {
+	if e == nil {
+		return nil
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Sanitize secret-bearing fields BEFORE signing, byte-identically to the v1
+	// emitter (#676). The signed target must never carry raw secret bytes.
+	target := d.Target
+	ruleID := d.RuleID
+	if e.sanitize != nil {
+		target = receipt.SanitizeTarget(target, e.sanitize)
+		ruleID = receipt.CleanOrRedacted(ruleID, e.sanitize)
+	}
+
+	eventID, err := e.eventID()
+	if err != nil {
+		return fmt.Errorf("generate proxy_decision event id: %w", err)
+	}
+
+	rcpt, err := contractruntime.BuildProxyDecisionReceipt(contractruntime.ProxyDecisionInput{
+		Decision: contractruntime.Decision{
+			Verdict:       d.Verdict,
+			LiveVerdict:   d.LiveVerdict,
+			PolicySources: d.PolicySources,
+			WinningSource: d.WinningSource,
+			RuleID:        ruleID,
+		},
+		ActionType:    d.ActionType,
+		Target:        target,
+		Transport:     d.Transport,
+		EventID:       eventID,
+		Timestamp:     e.clock().UTC(),
+		Principal:     e.principal,
+		Actor:         e.actor,
+		ChainSeq:      e.chainSeq,
+		ChainPrevHash: e.chainPrevHash,
+	})
+	if err != nil {
+		return fmt.Errorf("build proxy_decision receipt: %w", err)
+	}
+
+	// Stamp the contract envelope only when a real resolved contract existed.
+	// For scanner / kill-switch decisions these fields are empty, so the stamp
+	// is a no-op (the fields are omitempty in the wire form).
+	rcpt = contractruntime.ReceiptContext{
+		ActiveManifestHash: d.ActiveManifestHash,
+		ContractHash:       d.ContractHash,
+		SelectorID:         d.SelectorID,
+		ContractGeneration: d.ContractGeneration,
+	}.StampReceipt(rcpt)
+
+	preimage, err := rcpt.SignablePreimage()
+	if err != nil {
+		return fmt.Errorf("build proxy_decision preimage: %w", err)
+	}
+	signature, err := e.signer.Sign(preimage)
+	if err != nil {
+		return fmt.Errorf("sign proxy_decision receipt: %w", err)
+	}
+	if len(signature) != ed25519.SignatureSize {
+		return fmt.Errorf("%w: got %d want %d", ErrSignatureSize, len(signature), ed25519.SignatureSize)
+	}
+	rcpt.Signature = contractreceipt.SignatureProof{
+		SignerKeyID: e.signer.KeyID(),
+		KeyPurpose:  keyPurposeReceiptSigning,
+		Algorithm:   signatureAlgorithm,
+		Signature:   signaturePrefix + hex.EncodeToString(signature),
+	}
+	if err := rcpt.Validate(); err != nil {
+		return fmt.Errorf("validate proxy_decision receipt: %w", err)
+	}
+
+	rcptHash, err := contractreceipt.ReceiptHash(rcpt)
+	if err != nil {
+		return fmt.Errorf("hash proxy_decision receipt: %w", err)
+	}
+	rcptJSON, err := json.Marshal(rcpt)
+	if err != nil {
+		return fmt.Errorf("marshal proxy_decision receipt: %w", err)
+	}
+
+	if err := e.recorder.Record(recorder.Entry{
+		SessionID: recorderSessionID,
+		Type:      evidenceReceiptEntryType,
+		EventKind: string(contractreceipt.PayloadProxyDecision),
+		Transport: d.Transport,
+		Summary:   fmt.Sprintf("proxy_decision: %s %s via %s", d.ActionType, d.Verdict, d.WinningSource),
+		Detail:    json.RawMessage(rcptJSON),
+	}); err != nil {
+		return fmt.Errorf("record proxy_decision receipt: %w", err)
+	}
+	e.chainPrevHash = rcptHash
+	e.chainSeq++
+	return nil
+}
+
+// KeyedSigner wraps an Ed25519 private key as a Signer. KeyID is the
+// hex-encoded public key so any verifier holding the public key can match the
+// receipt's signer_key_id without an out-of-band key registry.
+type KeyedSigner struct {
+	keyID string
+	key   ed25519.PrivateKey
+}
+
+// NewKeyedSigner builds a KeyedSigner from an Ed25519 private key.
+func NewKeyedSigner(key ed25519.PrivateKey) KeyedSigner {
+	var keyID string
+	if pub, ok := key.Public().(ed25519.PublicKey); ok {
+		keyID = hex.EncodeToString(pub)
+	}
+	return KeyedSigner{keyID: keyID, key: key}
+}
+
+// KeyID returns the hex-encoded public key.
+func (s KeyedSigner) KeyID() string { return s.keyID }
+
+// Sign produces an Ed25519 signature over message.
+func (s KeyedSigner) Sign(message []byte) ([]byte, error) {
+	if len(s.key) != ed25519.PrivateKeySize {
+		return nil, errors.New("proxydecision: signer key not initialized")
+	}
+	return ed25519.Sign(s.key, message), nil
+}

--- a/internal/contract/proxydecision/emitter_test.go
+++ b/internal/contract/proxydecision/emitter_test.go
@@ -1,0 +1,458 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxydecision
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+// captureRecorder records entries in memory so tests can extract the signed
+// receipt JSON and verify it offline.
+type captureRecorder struct {
+	entries []recorder.Entry
+	err     error
+}
+
+func (c *captureRecorder) Record(e recorder.Entry) error {
+	if c.err != nil {
+		return c.err
+	}
+	c.entries = append(c.entries, e)
+	return nil
+}
+
+func newTestEmitter(t *testing.T, rec Recorder, sanitize SanitizeFunc) (*Emitter, ed25519.PublicKey, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	signer := NewKeyedSigner(priv)
+	em := NewEmitter(EmitterConfig{
+		Recorder:  rec,
+		Signer:    signer,
+		Sanitize:  sanitize,
+		Principal: "local",
+		Actor:     "pipelock",
+	})
+	if em == nil {
+		t.Fatal("NewEmitter returned nil for a valid config")
+	}
+	return em, pub, signer.KeyID()
+}
+
+// decodeReceipt extracts the signed EvidenceReceipt from a recorded entry.
+func decodeReceipt(t *testing.T, e recorder.Entry) contractreceipt.EvidenceReceipt {
+	t.Helper()
+	raw, ok := e.Detail.(json.RawMessage)
+	if !ok {
+		t.Fatalf("entry Detail is %T, want json.RawMessage", e.Detail)
+	}
+	var rcpt contractreceipt.EvidenceReceipt
+	if err := json.Unmarshal(raw, &rcpt); err != nil {
+		t.Fatalf("unmarshal receipt: %v", err)
+	}
+	return rcpt
+}
+
+func decodePayload(t *testing.T, rcpt contractreceipt.EvidenceReceipt) contractreceipt.PayloadProxyDecisionStruct {
+	t.Helper()
+	var p contractreceipt.PayloadProxyDecisionStruct
+	if err := json.Unmarshal(rcpt.Payload, &p); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	return p
+}
+
+func TestEmit_BuildsVerifiableReceipt(t *testing.T) {
+	rec := &captureRecorder{}
+	em, pub, keyID := newTestEmitter(t, rec, nil)
+
+	err := em.Emit(Decision{
+		ActionType:    "http_request",
+		Transport:     "forward",
+		Target:        "https://api.vendor.example/v1/things",
+		Verdict:       "block",
+		WinningSource: SourceScanner,
+		PolicySources: []string{SourceScanner},
+		RuleID:        "prompt_injection",
+	})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if len(rec.entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(rec.entries))
+	}
+	entry := rec.entries[0]
+	if entry.Type != evidenceReceiptEntryType {
+		t.Errorf("entry Type = %q, want %q", entry.Type, evidenceReceiptEntryType)
+	}
+	if entry.EventKind != string(contractreceipt.PayloadProxyDecision) {
+		t.Errorf("entry EventKind = %q, want %q", entry.EventKind, contractreceipt.PayloadProxyDecision)
+	}
+	if entry.Transport != "forward" {
+		t.Errorf("entry Transport = %q, want forward", entry.Transport)
+	}
+
+	rcpt := decodeReceipt(t, entry)
+	// The Bundle A done-state: v2 proxy_decision verifies offline in Go.
+	if err := contractreceipt.VerifyWithKey(rcpt, pub, keyID); err != nil {
+		t.Fatalf("VerifyWithKey: %v", err)
+	}
+	if rcpt.RecordType != contractreceipt.RecordTypeEvidenceV2 {
+		t.Errorf("RecordType = %q", rcpt.RecordType)
+	}
+	if rcpt.PayloadKind != contractreceipt.PayloadProxyDecision {
+		t.Errorf("PayloadKind = %q", rcpt.PayloadKind)
+	}
+	if rcpt.ChainSeq != 0 {
+		t.Errorf("ChainSeq = %d, want 0", rcpt.ChainSeq)
+	}
+	if rcpt.ChainPrevHash != recorder.GenesisHash {
+		t.Errorf("ChainPrevHash = %q, want %q", rcpt.ChainPrevHash, recorder.GenesisHash)
+	}
+
+	p := decodePayload(t, rcpt)
+	if p.ActionType != "http_request" || p.Verdict != "block" || p.Transport != "forward" {
+		t.Errorf("payload core fields wrong: %+v", p)
+	}
+	if p.WinningSource != SourceScanner || len(p.PolicySources) != 1 || p.PolicySources[0] != SourceScanner {
+		t.Errorf("payload provenance wrong: winning=%q sources=%v", p.WinningSource, p.PolicySources)
+	}
+	if p.RuleID != "prompt_injection" {
+		t.Errorf("payload RuleID = %q", p.RuleID)
+	}
+}
+
+func TestEmit_SanitizesTargetBeforeSigning(t *testing.T) {
+	const secret = "AKIA" + "IOSFODNN7EXAMPLE"
+	// clean reports false for any text containing the secret, mirroring a DLP
+	// hit. The emitter must scrub the secret out of the SIGNED target.
+	clean := func(text string) bool { return !strings.Contains(text, secret) }
+
+	rec := &captureRecorder{}
+	em, pub, keyID := newTestEmitter(t, rec, clean)
+
+	rawTarget := "https://api.vendor.example/v1/items?key=" + secret
+	err := em.Emit(Decision{
+		ActionType:    "http_request",
+		Transport:     "forward",
+		Target:        rawTarget,
+		Verdict:       "block",
+		WinningSource: SourceScanner,
+		PolicySources: []string{SourceScanner},
+		RuleID:        "dlp:" + secret, // rule label echoing the matched bytes
+	})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	rcpt := decodeReceipt(t, rec.entries[0])
+	if err := contractreceipt.VerifyWithKey(rcpt, pub, keyID); err != nil {
+		t.Fatalf("VerifyWithKey: %v", err)
+	}
+	p := decodePayload(t, rcpt)
+	if strings.Contains(p.Target, secret) {
+		t.Errorf("signed target leaks secret: %q", p.Target)
+	}
+	if strings.Contains(p.RuleID, secret) {
+		t.Errorf("signed rule_id leaks secret: %q", p.RuleID)
+	}
+	// The whole serialized receipt must be free of the secret.
+	if strings.Contains(string(rcpt.Payload), secret) {
+		t.Errorf("serialized payload leaks secret: %s", rcpt.Payload)
+	}
+}
+
+func TestEmit_ProvenanceShapes(t *testing.T) {
+	tests := []struct {
+		name        string
+		decision    Decision
+		wantWinning string
+		wantSources []string
+		wantStamped bool
+	}{
+		{
+			name: "scanner block",
+			decision: Decision{
+				ActionType: "http_request", Transport: "fetch", Target: "https://x.example/a",
+				Verdict: "block", WinningSource: SourceScanner, PolicySources: []string{SourceScanner},
+				RuleID: "ssrf",
+			},
+			wantWinning: SourceScanner, wantSources: []string{SourceScanner}, wantStamped: false,
+		},
+		{
+			name: "kill switch",
+			decision: Decision{
+				ActionType: "http_request", Transport: "intercept", Target: "https://x.example/b",
+				Verdict: "block", WinningSource: SourceKillSwitch, PolicySources: []string{SourceKillSwitch},
+				RuleID: "kill_switch_active",
+			},
+			wantWinning: SourceKillSwitch, wantSources: []string{SourceKillSwitch}, wantStamped: false,
+		},
+		{
+			name: "contract decision stamps envelope",
+			decision: Decision{
+				ActionType: "http_request", Transport: "forward", Target: "https://x.example/c",
+				Verdict: "block", WinningSource: SourceContract,
+				PolicySources:      []string{"observation", SourceContract},
+				RuleID:             "rule-42",
+				ActiveManifestHash: "sha256:manifest", ContractHash: "sha256:contract",
+				SelectorID: "sel-1", ContractGeneration: 7,
+			},
+			wantWinning: SourceContract, wantSources: []string{"observation", SourceContract}, wantStamped: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &captureRecorder{}
+			em, pub, keyID := newTestEmitter(t, rec, nil)
+			if err := em.Emit(tc.decision); err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			rcpt := decodeReceipt(t, rec.entries[0])
+			if err := contractreceipt.VerifyWithKey(rcpt, pub, keyID); err != nil {
+				t.Fatalf("VerifyWithKey: %v", err)
+			}
+			p := decodePayload(t, rcpt)
+			if p.WinningSource != tc.wantWinning {
+				t.Errorf("winning_source = %q, want %q", p.WinningSource, tc.wantWinning)
+			}
+			if strings.Join(p.PolicySources, ",") != strings.Join(tc.wantSources, ",") {
+				t.Errorf("policy_sources = %v, want %v", p.PolicySources, tc.wantSources)
+			}
+			gotStamped := rcpt.ActiveManifestHash != "" || rcpt.ContractHash != "" ||
+				rcpt.SelectorID != "" || rcpt.ContractGeneration != 0
+			if gotStamped != tc.wantStamped {
+				t.Errorf("envelope stamped = %v, want %v (manifest=%q contract=%q selector=%q gen=%d)",
+					gotStamped, tc.wantStamped, rcpt.ActiveManifestHash, rcpt.ContractHash,
+					rcpt.SelectorID, rcpt.ContractGeneration)
+			}
+			if tc.wantStamped {
+				if rcpt.ActiveManifestHash != tc.decision.ActiveManifestHash ||
+					rcpt.ContractHash != tc.decision.ContractHash ||
+					rcpt.SelectorID != tc.decision.SelectorID ||
+					rcpt.ContractGeneration != tc.decision.ContractGeneration {
+					t.Errorf("stamped envelope mismatch: %+v", rcpt)
+				}
+			}
+		})
+	}
+}
+
+func TestEmit_ChainAdvancesAndLinks(t *testing.T) {
+	rec := &captureRecorder{}
+	em, _, _ := newTestEmitter(t, rec, nil)
+	base := Decision{
+		ActionType: "http_request", Transport: "forward", Target: "https://x.example/a",
+		Verdict: "allow", WinningSource: SourceScanner, PolicySources: []string{SourceScanner},
+	}
+	for i := 0; i < 3; i++ {
+		if err := em.Emit(base); err != nil {
+			t.Fatalf("Emit %d: %v", i, err)
+		}
+	}
+	if len(rec.entries) != 3 {
+		t.Fatalf("got %d entries, want 3", len(rec.entries))
+	}
+	var prevHash string
+	for i, e := range rec.entries {
+		rcpt := decodeReceipt(t, e)
+		if rcpt.ChainSeq != uint64(i) {
+			t.Errorf("entry %d ChainSeq = %d, want %d", i, rcpt.ChainSeq, i)
+		}
+		if i == 0 {
+			if rcpt.ChainPrevHash != recorder.GenesisHash {
+				t.Errorf("first ChainPrevHash = %q, want genesis", rcpt.ChainPrevHash)
+			}
+		} else if rcpt.ChainPrevHash != prevHash {
+			t.Errorf("entry %d ChainPrevHash = %q, want %q", i, rcpt.ChainPrevHash, prevHash)
+		}
+		h, err := contractreceipt.ReceiptHash(rcpt)
+		if err != nil {
+			t.Fatalf("ReceiptHash: %v", err)
+		}
+		prevHash = h
+	}
+	seq, head := em.ChainState()
+	if seq != 3 || head != prevHash {
+		t.Errorf("ChainState = (%d,%q), want (3,%q)", seq, head, prevHash)
+	}
+}
+
+func TestEmit_ResumeContinuity(t *testing.T) {
+	// First emitter produces one receipt, then we capture its head and build a
+	// replacement (as a hot reload would) seeded with ResumeSeq/ResumePrevHash.
+	rec := &captureRecorder{}
+	em1, _, _ := newTestEmitter(t, rec, nil)
+	base := Decision{
+		ActionType: "http_request", Transport: "forward", Target: "https://x.example/a",
+		Verdict: "allow", WinningSource: SourceScanner, PolicySources: []string{SourceScanner},
+	}
+	if err := em1.Emit(base); err != nil {
+		t.Fatalf("Emit em1: %v", err)
+	}
+	seq, head := em1.ChainState()
+
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	signer := NewKeyedSigner(priv)
+	em2 := NewEmitter(EmitterConfig{
+		Recorder: rec, Signer: signer, Principal: "local", Actor: "pipelock",
+		ResumeSeq: seq, ResumePrevHash: head,
+	})
+	if err := em2.Emit(base); err != nil {
+		t.Fatalf("Emit em2: %v", err)
+	}
+	rcpt := decodeReceipt(t, rec.entries[1])
+	if err := contractreceipt.VerifyWithKey(rcpt, pub, signer.KeyID()); err != nil {
+		t.Fatalf("VerifyWithKey: %v", err)
+	}
+	if rcpt.ChainSeq != seq {
+		t.Errorf("resumed ChainSeq = %d, want %d", rcpt.ChainSeq, seq)
+	}
+	if rcpt.ChainPrevHash != head {
+		t.Errorf("resumed ChainPrevHash = %q, want %q", rcpt.ChainPrevHash, head)
+	}
+}
+
+func TestEmit_TamperBreaksSignature(t *testing.T) {
+	rec := &captureRecorder{}
+	em, pub, keyID := newTestEmitter(t, rec, nil)
+	if err := em.Emit(Decision{
+		ActionType: "http_request", Transport: "forward", Target: "https://x.example/a",
+		Verdict: "allow", WinningSource: SourceScanner, PolicySources: []string{SourceScanner},
+	}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	rcpt := decodeReceipt(t, rec.entries[0])
+	if err := contractreceipt.VerifyWithKey(rcpt, pub, keyID); err != nil {
+		t.Fatalf("baseline VerifyWithKey: %v", err)
+	}
+	// Flip a payload field; the JCS preimage changes, so verification must fail.
+	tampered := rcpt
+	tampered.Payload = json.RawMessage(strings.Replace(string(rcpt.Payload), `"allow"`, `"forward"`, 1))
+	if err := contractreceipt.VerifyWithKey(tampered, pub, keyID); err == nil {
+		t.Fatal("tampered receipt verified; signature did not bind payload")
+	}
+}
+
+func TestNewEmitter_DisabledWhenMissingDeps(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	if NewEmitter(EmitterConfig{Signer: NewKeyedSigner(priv)}) != nil {
+		t.Error("NewEmitter with nil recorder should return nil")
+	}
+	if NewEmitter(EmitterConfig{Recorder: &captureRecorder{}}) != nil {
+		t.Error("NewEmitter with nil signer should return nil")
+	}
+}
+
+func TestNilEmitter_IsNoOp(t *testing.T) {
+	var em *Emitter
+	if err := em.Emit(Decision{Verdict: "block"}); err != nil {
+		t.Errorf("nil Emit returned %v, want nil", err)
+	}
+	seq, head := em.ChainState()
+	if seq != 0 || head != recorder.GenesisHash {
+		t.Errorf("nil ChainState = (%d,%q), want (0,genesis)", seq, head)
+	}
+}
+
+func TestEmit_InvalidProvenanceFailsFast(t *testing.T) {
+	// Missing policy_sources / winning_source must fail at build time (the v2
+	// payload validator rejects them) rather than emit a malformed receipt.
+	rec := &captureRecorder{}
+	em, _, _ := newTestEmitter(t, rec, nil)
+	err := em.Emit(Decision{
+		ActionType: "http_request", Transport: "forward", Target: "https://x.example/a",
+		Verdict: "block", // no WinningSource / PolicySources
+	})
+	if err == nil {
+		t.Fatal("Emit with empty provenance succeeded; want build error")
+	}
+	if len(rec.entries) != 0 {
+		t.Errorf("recorded %d entries on failed build, want 0", len(rec.entries))
+	}
+	// Chain must not advance on a failed build.
+	if seq, head := em.ChainState(); seq != 0 || head != recorder.GenesisHash {
+		t.Errorf("chain advanced on failure: (%d,%q)", seq, head)
+	}
+}
+
+func TestKeyedSigner(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	s := NewKeyedSigner(priv)
+	if len(s.KeyID()) != ed25519.PublicKeySize*2 { // hex of 32-byte pubkey
+		t.Errorf("KeyID length = %d, want %d", len(s.KeyID()), ed25519.PublicKeySize*2)
+	}
+	msg := []byte("preimage bytes")
+	sig, err := s.Sign(msg)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if !ed25519.Verify(pub, msg, sig) {
+		t.Error("signature did not verify against the public key")
+	}
+	var zero KeyedSigner
+	if _, err := zero.Sign(msg); err == nil {
+		t.Error("zero-value signer should fail to sign")
+	}
+}
+
+func TestEmit_RecorderErrorPropagates(t *testing.T) {
+	rec := &captureRecorder{err: errTestRecorder}
+	em, _, _ := newTestEmitter(t, rec, nil)
+	err := em.Emit(Decision{
+		ActionType: "http_request", Transport: "forward", Target: "https://x.example/a",
+		Verdict: "allow", WinningSource: SourceScanner, PolicySources: []string{SourceScanner},
+	})
+	if err == nil {
+		t.Fatal("Emit succeeded despite recorder error")
+	}
+	// Chain must not advance when the record fails.
+	if seq, _ := em.ChainState(); seq != 0 {
+		t.Errorf("chain advanced to %d on record failure", seq)
+	}
+}
+
+var errTestRecorder = &recorderError{"boom"}
+
+type recorderError struct{ msg string }
+
+func (e *recorderError) Error() string { return e.msg }
+
+func newDeterministicClock() func() time.Time {
+	base := time.Date(2026, 6, 5, 22, 0, 0, 0, time.UTC)
+	return func() time.Time { return base }
+}
+
+func TestEmit_UsesInjectedClock(t *testing.T) {
+	rec := &captureRecorder{}
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	signer := NewKeyedSigner(priv)
+	em := NewEmitter(EmitterConfig{
+		Recorder: rec, Signer: signer, Principal: "local", Actor: "pipelock",
+		Clock: newDeterministicClock(),
+	})
+	if err := em.Emit(Decision{
+		ActionType: "http_request", Transport: "forward", Target: "https://x.example/a",
+		Verdict: "allow", WinningSource: SourceScanner, PolicySources: []string{SourceScanner},
+	}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	rcpt := decodeReceipt(t, rec.entries[0])
+	if err := contractreceipt.VerifyWithKey(rcpt, pub, signer.KeyID()); err != nil {
+		t.Fatalf("VerifyWithKey: %v", err)
+	}
+	if !rcpt.Timestamp.Equal(time.Date(2026, 6, 5, 22, 0, 0, 0, time.UTC)) {
+		t.Errorf("Timestamp = %v, want injected clock value", rcpt.Timestamp)
+	}
+}

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -145,12 +145,18 @@ func interceptEmitReceipt(ic *InterceptContext, opts receipt.EmitOpts) {
 	ic.Proxy.reloadMu.RLock()
 	e := ic.Proxy.receiptEmitterPtr.Load()
 	ic.Proxy.reloadMu.RUnlock()
-	if e == nil {
-		return
+	if e != nil {
+		if err := e.Emit(opts); err != nil && ic.Logger != nil {
+			ic.Logger.LogError(audit.NewRequestLogContext(opts.RequestID), err)
+		}
 	}
-	if err := e.Emit(opts); err != nil && ic.Logger != nil {
-		ic.Logger.LogError(audit.NewRequestLogContext(opts.RequestID), err)
-	}
+	// Dual-emit the v2 proxy_decision receipt. The atomic load is current at
+	// call time so long-lived tunnels pick up the post-reload emitter.
+	emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
+		if ic.Logger != nil {
+			ic.Logger.LogError(audit.NewRequestLogContext(opts.RequestID), err)
+		}
+	})
 }
 
 // interceptReadHeaderTimeout is the maximum time to read request headers on an

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -145,10 +145,15 @@ func interceptEmitReceipt(ic *InterceptContext, opts receipt.EmitOpts) {
 	ic.Proxy.reloadMu.RLock()
 	e := ic.Proxy.receiptEmitterPtr.Load()
 	ic.Proxy.reloadMu.RUnlock()
-	if e != nil {
-		if err := e.Emit(opts); err != nil && ic.Logger != nil {
+	if e == nil {
+		return
+	}
+	if err := e.Emit(opts); err != nil {
+		if ic.Logger != nil {
 			ic.Logger.LogError(audit.NewRequestLogContext(opts.RequestID), err)
 		}
+		// v1 stays authoritative: skip v2 when v1 failed to record.
+		return
 	}
 	// Dual-emit the v2 proxy_decision receipt. The atomic load is current at
 	// call time so long-lived tunnels pick up the post-reload emitter.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -33,6 +33,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/certgen"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
 	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
 	"github.com/luckyPipewrench/pipelock/internal/decide"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
@@ -334,15 +335,16 @@ type Proxy struct {
 	approver            *hitl.Approver
 	a2aCardBaseline     *mcp.CardBaseline // Agent Card drift detection across requests
 	captureObs          capture.CaptureObserver
-	recorder            *recorder.Recorder                // flight recorder for tamper-evident evidence (nil = disabled)
-	receiptEmitterPtr   atomic.Pointer[receipt.Emitter]   // action receipt emitter (nil = disabled)
-	receiptKeyPath      string                            // active signing key path, for reload comparison
-	envelopeEmitterPtr  atomic.Pointer[envelope.Emitter]  // mediation envelope emitter (nil = disabled)
-	envelopeVerifierPtr atomic.Pointer[envelope.Verifier] // inbound mediation envelope verifier (nil = disabled)
-	shieldEngine        *shield.Engine                    // browser shield HTML/JS rewriter (nil = not initialized)
-	frozenTools         *FrozenToolRegistry               // frozen tool inventories for airlock hard tier
-	wd                  *health.Watchdog                  // wedge-detection watchdog (nil = disabled)
-	probeInflight       atomic.Bool                       // singleflight guard for scannerProbe (prevents goroutine leak when scanner wedges)
+	recorder            *recorder.Recorder                    // flight recorder for tamper-evident evidence (nil = disabled)
+	receiptEmitterPtr   atomic.Pointer[receipt.Emitter]       // v1 action receipt emitter (nil = disabled)
+	v2EmitterPtr        atomic.Pointer[proxydecision.Emitter] // v2 proxy_decision emitter, dual-emitted with v1 (nil = disabled)
+	receiptKeyPath      string                                // active signing key path, for reload comparison
+	envelopeEmitterPtr  atomic.Pointer[envelope.Emitter]      // mediation envelope emitter (nil = disabled)
+	envelopeVerifierPtr atomic.Pointer[envelope.Verifier]     // inbound mediation envelope verifier (nil = disabled)
+	shieldEngine        *shield.Engine                        // browser shield HTML/JS rewriter (nil = not initialized)
+	frozenTools         *FrozenToolRegistry                   // frozen tool inventories for airlock hard tier
+	wd                  *health.Watchdog                      // wedge-detection watchdog (nil = disabled)
+	probeInflight       atomic.Bool                           // singleflight guard for scannerProbe (prevents goroutine leak when scanner wedges)
 }
 
 // Option configures optional Proxy behavior.
@@ -382,6 +384,18 @@ func WithRecorder(rec *recorder.Recorder) Option {
 // recorder. Pass nil to disable (default).
 func WithReceiptEmitter(e *receipt.Emitter) Option {
 	return func(p *Proxy) { p.receiptEmitterPtr.Store(e) }
+}
+
+// WithV2ReceiptEmitter sets the v2 proxy_decision emitter. When non-nil, the
+// proxy dual-emits a signed EvidenceReceipt v2 proxy_decision alongside every v1
+// action receipt the proxy emit path produces (fetch, forward, CONNECT,
+// intercept, WebSocket, reverse, and MCP-over-HTTP that transits the proxy).
+// The standalone MCP proxy emits v1 on a separate path (internal/mcp
+// EmitMCPDecision) that this does NOT cover; that surface is a follow-up. Pass
+// nil to disable (default). v2 emission is gated on the same receipt intent as
+// v1 (flight recorder + signing key); no separate config flag.
+func WithV2ReceiptEmitter(e *proxydecision.Emitter) Option {
+	return func(p *Proxy) { p.v2EmitterPtr.Store(e) }
 }
 
 // WithReceiptKeyPath sets the initial signing key path for reload comparison.
@@ -952,16 +966,16 @@ func (p *Proxy) recordDecision(verdict, layer, pattern, transport, requestID str
 // incident can correlate the audit log entry to the action that was
 // supposed to be attested.
 func (p *Proxy) emitReceipt(opts receipt.EmitOpts) {
-	e := p.receiptEmitterPtr.Load()
-	if e == nil {
-		return
+	if e := p.receiptEmitterPtr.Load(); e != nil {
+		if err := e.Emit(opts); err != nil {
+			p.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
+				fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s target=%s agent=%s: %w",
+					opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
+					opts.Transport, opts.Method, opts.Target, opts.Agent, err))
+		}
 	}
-	if err := e.Emit(opts); err != nil {
-		p.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
-			fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s target=%s agent=%s: %w",
-				opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
-				opts.Transport, opts.Method, opts.Target, opts.Agent, err))
-	}
+	// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
+	p.emitV2Receipt(opts)
 }
 
 // receiptEmitterStage is the staged result of a receipt-emitter reload.
@@ -975,6 +989,10 @@ type receiptEmitterStage struct {
 	// Store(nil) on publish in that case and also reset receiptKeyPath
 	// to "" via the keyPath field.
 	emitter *receipt.Emitter
+	// v2 is the new v2 proxy_decision emitter, built from the same signing
+	// key as emitter and dual-emitted with it. nil when receipts are
+	// disabled. Published to p.v2EmitterPtr alongside emitter.
+	v2 *proxydecision.Emitter
 	// keyPath is the signing key path that was actually loaded, or ""
 	// when receipts are disabled. The caller assigns this to
 	// p.receiptKeyPath at publish time.
@@ -1017,6 +1035,12 @@ func (p *Proxy) buildReceiptEmitter(cfg *config.Config) (receiptEmitterStage, er
 		return receiptEmitterStage{}, fmt.Errorf("loading receipt signing key %q: %w", keyPath, err)
 	}
 
+	// Carry the v2 chain head forward across reload so the v2 proxy_decision
+	// chain stays continuous within the process when the emitter is rebuilt
+	// (e.g. key rotation). Cross-restart the chain restarts at genesis; the
+	// recorder's outer hash chain provides tamper-evidence across restarts.
+	resumeSeq, resumePrev := p.v2EmitterPtr.Load().ChainState()
+
 	return receiptEmitterStage{
 		emitter: receipt.NewEmitter(receipt.EmitterConfig{
 			Recorder:   p.recorder,
@@ -1024,6 +1048,15 @@ func (p *Proxy) buildReceiptEmitter(cfg *config.Config) (receiptEmitterStage, er
 			ConfigHash: cfg.Hash(),
 			Principal:  "local",
 			Actor:      "pipelock",
+		}),
+		v2: proxydecision.NewEmitter(proxydecision.EmitterConfig{
+			Recorder:       p.recorder,
+			Signer:         proxydecision.NewKeyedSigner(privKey),
+			Sanitize:       proxydecision.SanitizeFromRedactor(p.recorder.ReceiptRedactor()),
+			Principal:      "local",
+			Actor:          "pipelock",
+			ResumeSeq:      resumeSeq,
+			ResumePrevHash: resumePrev,
 		}),
 		keyPath: keyPath,
 	}, nil
@@ -1227,6 +1260,13 @@ func (p *Proxy) ReceiptEmitterPtr() *atomic.Pointer[receipt.Emitter] {
 	return &p.receiptEmitterPtr
 }
 
+// V2EmitterPtr returns the atomic pointer to the v2 proxy_decision emitter.
+// The reverse proxy uses this to dual-emit v2 receipts and pick up hot-reload
+// changes in parity with ReceiptEmitterPtr.
+func (p *Proxy) V2EmitterPtr() *atomic.Pointer[proxydecision.Emitter] {
+	return &p.v2EmitterPtr
+}
+
 // ContractLoaderPtr returns the atomic pointer to the learn-lock loader.
 // Long-lived runtimes use this to pick up hot-reload contract state changes.
 func (p *Proxy) ContractLoaderPtr() *atomic.Pointer[contractruntime.Loader] {
@@ -1377,9 +1417,11 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 	// (receipts silently off when no recorder) is preserved.
 	if cfg.FlightRecorder.SigningKeyPath == "" {
 		p.receiptEmitterPtr.Store(nil)
+		p.v2EmitterPtr.Store(nil)
 		p.receiptKeyPath = ""
 	} else if p.recorder != nil {
 		p.receiptEmitterPtr.Store(receiptStage.emitter)
+		p.v2EmitterPtr.Store(receiptStage.v2)
 		p.receiptKeyPath = receiptStage.keyPath
 	}
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -972,10 +972,13 @@ func (p *Proxy) emitReceipt(opts receipt.EmitOpts) {
 				fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s target=%s agent=%s: %w",
 					opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
 					opts.Transport, opts.Method, opts.Target, opts.Agent, err))
+			// v1 stays authoritative: skip v2 when v1 failed to record, so a
+			// proxy_decision never outlives its action_receipt sibling.
+			return
 		}
+		// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
+		p.emitV2Receipt(opts)
 	}
-	// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
-	p.emitV2Receipt(opts)
 }
 
 // receiptEmitterStage is the staged result of a receipt-emitter reload.

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -249,6 +249,8 @@ func (rp *ReverseProxyHandler) emitReceipt(opts receipt.EmitOpts) {
 					fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s target=%s agent=%s: %w",
 						opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
 						opts.Transport, opts.Method, opts.Target, opts.Agent, err))
+				// v1 stays authoritative: skip v2 when v1 failed to record.
+				return
 			}
 		}
 	}

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -25,6 +25,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
 	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
@@ -75,6 +76,7 @@ type ReverseProxyHandler struct {
 	envelopeEmitterPtr  *atomic.Pointer[envelope.Emitter]
 	envelopeVerifierPtr *atomic.Pointer[envelope.Verifier]
 	receiptEmitterPtr   *atomic.Pointer[receipt.Emitter]
+	v2EmitterPtr        *atomic.Pointer[proxydecision.Emitter]
 	contractLoaderPtr   *atomic.Pointer[contractruntime.Loader]
 	reqPolicyFn         func(requestPolicyInput) requestPolicyResult                 // nil = disabled
 	reqPolicyPrepareFn  func(*http.Request, *requestPolicyInput) requestPolicyResult // nil = no body pre-read
@@ -202,6 +204,13 @@ func (rp *ReverseProxyHandler) SetReceiptEmitter(ptr *atomic.Pointer[receipt.Emi
 	rp.receiptEmitterPtr = ptr
 }
 
+// SetV2ReceiptEmitter sets the atomic pointer to the v2 proxy_decision emitter
+// so reverse-proxy decisions dual-emit v2 receipts in parity with forward /
+// intercept. When unset (or pointing at nil), v2 emission is a no-op.
+func (rp *ReverseProxyHandler) SetV2ReceiptEmitter(ptr *atomic.Pointer[proxydecision.Emitter]) {
+	rp.v2EmitterPtr = ptr
+}
+
 // SetContractLoader sets the atomic pointer to the learn-lock loader.
 func (rp *ReverseProxyHandler) SetContractLoader(ptr *atomic.Pointer[contractruntime.Loader]) {
 	rp.contractLoaderPtr = ptr
@@ -233,19 +242,22 @@ func (rp *ReverseProxyHandler) SetRequestPolicyPrepareFn(fn func(*http.Request, 
 // incident can correlate the audit log entry to the action that was
 // supposed to be attested. Plain RequestID alone is too thin for that.
 func (rp *ReverseProxyHandler) emitReceipt(opts receipt.EmitOpts) {
-	if rp.receiptEmitterPtr == nil {
-		return
+	if rp.receiptEmitterPtr != nil {
+		if e := rp.receiptEmitterPtr.Load(); e != nil {
+			if err := e.Emit(opts); err != nil {
+				rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
+					fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s target=%s agent=%s: %w",
+						opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
+						opts.Transport, opts.Method, opts.Target, opts.Agent, err))
+			}
+		}
 	}
-	e := rp.receiptEmitterPtr.Load()
-	if e == nil {
-		return
-	}
-	if err := e.Emit(opts); err != nil {
+	// Dual-emit the v2 proxy_decision receipt.
+	emitV2(rp.v2EmitterPtr, opts, func(err error) {
 		rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
-			fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s target=%s agent=%s: %w",
-				opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
-				opts.Transport, opts.Method, opts.Target, opts.Agent, err))
-	}
+			fmt.Errorf("emit v2 proxy_decision action_id=%s verdict=%s transport=%s: %w",
+				opts.ActionID, opts.Verdict, opts.Transport, err))
+	})
 }
 
 func reverseTargetURL(upstream *url.URL, r *http.Request) string {

--- a/internal/proxy/v2receipt.go
+++ b/internal/proxy/v2receipt.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+// v2 action_type labels for the proxy_decision payload. They classify the
+// action surface and are distinct from the v1 ActionRecord's semantic action
+// class (read/write/...). Kept as constants so the mapping is auditable.
+const (
+	v2ActionHTTPRequest    = "http_request"
+	v2ActionMCPToolCall    = "mcp_tool_call"
+	v2ActionWebSocketFrame = "websocket_frame"
+)
+
+// v2DecisionFromOpts derives the v2 proxy_decision input from the v1 EmitOpts so
+// the dual-emit path reuses the exact decision context the v1 receipt records.
+//
+// policy_sources / winning_source are GENERIC decision provenance, not
+// contract-only: a contract-participated decision attributes to its real
+// contract sources plus the "contract" marker and stamps the manifest/contract
+// envelope; a kill-switch block attributes to the kill switch; everything else
+// is a scanner decision. The v2 payload validator requires both fields
+// non-empty, so every branch supplies them.
+//
+// The returned bool is false when the decision cannot form a valid v2 payload
+// (empty target). The caller skips emission rather than logging a build error,
+// keeping the v2 stream free of malformed receipts.
+func v2DecisionFromOpts(opts receipt.EmitOpts) (proxydecision.Decision, bool) {
+	if opts.Target == "" {
+		return proxydecision.Decision{}, false
+	}
+
+	d := proxydecision.Decision{
+		ActionType: v2ActionType(opts),
+		Transport:  opts.Transport,
+		Target:     opts.Target, // raw; the emitter sanitizes before signing (#676)
+		Verdict:    receipt.NormalizeVerdict(opts.Verdict),
+	}
+
+	switch {
+	case hasContractContext(opts):
+		d.WinningSource = opts.ContractWinningSource
+		if d.WinningSource == "" {
+			d.WinningSource = proxydecision.SourceContract
+		}
+		d.PolicySources = ensureSource(opts.ContractPolicySources, proxydecision.SourceContract)
+		d.RuleID = opts.ContractRuleID
+		d.LiveVerdict = receipt.NormalizeVerdict(opts.ContractLiveVerdict)
+		d.ActiveManifestHash = opts.ActiveManifestHash
+		d.ContractHash = opts.ContractHash
+		d.SelectorID = opts.ContractSelectorID
+		d.ContractGeneration = opts.ContractGeneration
+	case opts.Layer == killSwitchLayer:
+		d.WinningSource = proxydecision.SourceKillSwitch
+		d.PolicySources = []string{proxydecision.SourceKillSwitch}
+		d.RuleID = opts.Pattern
+	default:
+		d.WinningSource = proxydecision.SourceScanner
+		d.PolicySources = []string{proxydecision.SourceScanner}
+		d.RuleID = opts.Pattern
+	}
+	return d, true
+}
+
+// killSwitchLayer is the EmitOpts.Layer label used by kill-switch block sites
+// (forwardKillSwitchReceiptOpts and the per-transport kill-switch receipts).
+const killSwitchLayer = "kill_switch"
+
+// hasContractContext reports whether the contract evaluator participated in this
+// decision. Mirrors contractgate's HasContractContext: any contract provenance
+// or a stamped manifest/contract/selector means a real resolved contract
+// existed for the request.
+func hasContractContext(opts receipt.EmitOpts) bool {
+	return opts.ContractWinningSource != "" ||
+		len(opts.ContractPolicySources) > 0 ||
+		opts.ActiveManifestHash != "" ||
+		opts.ContractHash != "" ||
+		opts.ContractSelectorID != ""
+}
+
+// v2ActionType maps the v1 EmitOpts surface to the v2 action_type enum.
+func v2ActionType(opts receipt.EmitOpts) string {
+	switch {
+	case opts.MCPMethod != "" || opts.ToolName != "":
+		return v2ActionMCPToolCall
+	case opts.Transport == TransportWS:
+		return v2ActionWebSocketFrame
+	default:
+		return v2ActionHTTPRequest
+	}
+}
+
+// ensureSource returns sources with want appended when absent, preserving order
+// and the existing contract policy sources. A nil/empty input yields [want].
+func ensureSource(sources []string, want string) []string {
+	out := make([]string, 0, len(sources)+1)
+	for _, s := range sources {
+		if s == want {
+			out = append(out, sources...)
+			return out
+		}
+	}
+	out = append(out, sources...)
+	out = append(out, want)
+	return out
+}
+
+// emitV2 loads the v2 emitter from ptr and dual-emits a proxy_decision receipt
+// for opts. Safe when the emitter is nil (no-op). v2 emission failures are
+// logged via logErr and never propagate; the v1 receipt is the authoritative
+// audit record during the expand phase, so a v2 hiccup must not affect the
+// proxy decision.
+func emitV2(ptr *atomic.Pointer[proxydecision.Emitter], opts receipt.EmitOpts, logErr func(error)) {
+	if ptr == nil {
+		return
+	}
+	e := ptr.Load()
+	if e == nil {
+		return
+	}
+	d, ok := v2DecisionFromOpts(opts)
+	if !ok {
+		return
+	}
+	if err := e.Emit(d); err != nil && logErr != nil {
+		logErr(err)
+	}
+}
+
+// emitV2Receipt dual-emits the v2 proxy_decision for opts on the main proxy.
+func (p *Proxy) emitV2Receipt(opts receipt.EmitOpts) {
+	emitV2(&p.v2EmitterPtr, opts, func(err error) {
+		p.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
+			fmt.Errorf("emit v2 proxy_decision action_id=%s verdict=%s layer=%s transport=%s: %w",
+				opts.ActionID, opts.Verdict, opts.Layer, opts.Transport, err))
+	})
+}

--- a/internal/proxy/v2receipt_test.go
+++ b/internal/proxy/v2receipt_test.go
@@ -382,7 +382,9 @@ func TestDualEmit_HotReloadPreservesV2Chain(t *testing.T) {
 	reloadCfg := config.Defaults()
 	reloadCfg.Internal = nil
 	reloadCfg.FlightRecorder.SigningKeyPath = keyPath
-	p.Reload(reloadCfg, scanner.New(reloadCfg))
+	if !p.Reload(reloadCfg, scanner.New(reloadCfg)) {
+		t.Fatal("Reload returned false")
+	}
 
 	if p.v2EmitterPtr.Load() == nil {
 		t.Fatal("v2 emitter nil after reload with signing key")
@@ -420,5 +422,39 @@ func TestDualEmit_HotReloadPreservesV2Chain(t *testing.T) {
 	}
 	if v2s[1].ChainPrevHash != h0 {
 		t.Errorf("post-reload receipt ChainPrevHash = %q, want %q (chain broke across reload)", v2s[1].ChainPrevHash, h0)
+	}
+}
+
+// TestDualEmit_V1FailureSkipsV2 proves v1 stays authoritative: when the v1
+// emitter rejects (here, a sealed chain), no v2 proxy_decision is written, so a
+// v2 receipt never outlives its v1 action_receipt sibling.
+func TestDualEmit_V1FailureSkipsV2(t *testing.T) {
+	f := newDualEmitFixture(t, false)
+	v1 := f.p.receiptEmitterPtr.Load()
+	// Seed one v1 receipt directly (no v2) so the chain is non-empty, then seal
+	// it. A sealed chain makes the next v1 Emit return ErrChainSealed.
+	if err := v1.Emit(receipt.EmitOpts{
+		ActionID: "seed", Transport: TransportForward, Method: "GET",
+		Target: "https://x.example/seed", Verdict: "allow",
+	}); err != nil {
+		t.Fatalf("seed Emit: %v", err)
+	}
+	if err := v1.EmitTranscriptRoot("proxy"); err != nil {
+		t.Fatalf("EmitTranscriptRoot: %v", err)
+	}
+
+	// This decision's v1 Emit fails (sealed); v2 must be skipped.
+	f.p.emitReceipt(receipt.EmitOpts{
+		ActionID: "a1", Transport: TransportForward, Method: "GET",
+		Target: "https://x.example/a", Verdict: "block",
+		Layer: "dlp", Pattern: "inj", RequestID: "r1",
+	})
+	if err := f.rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	for _, e := range readRecorderEntries(t, f.dir) {
+		if e.Type == "evidence_receipt" && e.EventKind == string(contractreceipt.PayloadProxyDecision) {
+			t.Error("v2 proxy_decision emitted after v1 failed; v1 must stay authoritative")
+		}
 	}
 }

--- a/internal/proxy/v2receipt_test.go
+++ b/internal/proxy/v2receipt_test.go
@@ -1,0 +1,424 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// --- Unit tests for the EmitOpts -> v2 Decision derivation ---
+
+func TestV2DecisionFromOpts_Provenance(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        receipt.EmitOpts
+		wantOK      bool
+		wantAction  string
+		wantWinning string
+		wantSources []string
+		wantStamped bool
+	}{
+		{
+			name:        "scanner block",
+			opts:        receipt.EmitOpts{Transport: TransportFetch, Target: "https://x.example/a", Verdict: "block", Layer: "dlp", Pattern: "aws_key", Method: "GET"},
+			wantOK:      true,
+			wantAction:  v2ActionHTTPRequest,
+			wantWinning: proxydecision.SourceScanner,
+			wantSources: []string{proxydecision.SourceScanner},
+		},
+		{
+			name:        "kill switch block",
+			opts:        receipt.EmitOpts{Transport: TransportConnect, Target: "host:443", Verdict: "block", Layer: killSwitchLayer, Pattern: "kill_switch_active"},
+			wantOK:      true,
+			wantAction:  v2ActionHTTPRequest,
+			wantWinning: proxydecision.SourceKillSwitch,
+			wantSources: []string{proxydecision.SourceKillSwitch},
+		},
+		{
+			name: "contract decision stamps envelope and adds contract source",
+			opts: receipt.EmitOpts{
+				Transport: TransportForward, Target: "https://x.example/c", Verdict: "block", Method: "POST",
+				ContractWinningSource: "manifest", ContractPolicySources: []string{"observation"},
+				ContractRuleID: "rule-7", ActiveManifestHash: "sha256:m", ContractHash: "sha256:c",
+				ContractSelectorID: "sel", ContractGeneration: 4,
+			},
+			wantOK:      true,
+			wantAction:  v2ActionHTTPRequest,
+			wantWinning: "manifest",
+			wantSources: []string{"observation", proxydecision.SourceContract},
+			wantStamped: true,
+		},
+		{
+			name:        "mcp tool call action type",
+			opts:        receipt.EmitOpts{Transport: "mcp_http", Target: "tool://do_thing", Verdict: "block", ToolName: "do_thing", MCPMethod: "tools/call", Pattern: "poison"},
+			wantOK:      true,
+			wantAction:  v2ActionMCPToolCall,
+			wantWinning: proxydecision.SourceScanner,
+			wantSources: []string{proxydecision.SourceScanner},
+		},
+		{
+			name:        "websocket frame action type",
+			opts:        receipt.EmitOpts{Transport: TransportWS, Target: "wss://x.example/ws", Verdict: "block", Pattern: "inj"},
+			wantOK:      true,
+			wantAction:  v2ActionWebSocketFrame,
+			wantWinning: proxydecision.SourceScanner,
+			wantSources: []string{proxydecision.SourceScanner},
+		},
+		{
+			name:   "empty target is not emittable",
+			opts:   receipt.EmitOpts{Transport: TransportFetch, Target: "", Verdict: "block"},
+			wantOK: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, ok := v2DecisionFromOpts(tc.opts)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if d.ActionType != tc.wantAction {
+				t.Errorf("ActionType = %q, want %q", d.ActionType, tc.wantAction)
+			}
+			if d.WinningSource != tc.wantWinning {
+				t.Errorf("WinningSource = %q, want %q", d.WinningSource, tc.wantWinning)
+			}
+			if strings.Join(d.PolicySources, ",") != strings.Join(tc.wantSources, ",") {
+				t.Errorf("PolicySources = %v, want %v", d.PolicySources, tc.wantSources)
+			}
+			stamped := d.ActiveManifestHash != "" || d.ContractHash != "" || d.SelectorID != "" || d.ContractGeneration != 0
+			if stamped != tc.wantStamped {
+				t.Errorf("stamped = %v, want %v", stamped, tc.wantStamped)
+			}
+		})
+	}
+}
+
+func TestEnsureSource(t *testing.T) {
+	tests := []struct {
+		in   []string
+		want string
+		out  []string
+	}{
+		{nil, "contract", []string{"contract"}},
+		{[]string{"observation"}, "contract", []string{"observation", "contract"}},
+		{[]string{"contract"}, "contract", []string{"contract"}},
+		{[]string{"a", "contract", "b"}, "contract", []string{"a", "contract", "b"}},
+	}
+	for _, tc := range tests {
+		got := ensureSource(tc.in, tc.want)
+		if strings.Join(got, ",") != strings.Join(tc.out, ",") {
+			t.Errorf("ensureSource(%v,%q) = %v, want %v", tc.in, tc.want, got, tc.out)
+		}
+	}
+}
+
+// --- Integration: dual-emit through a real recorder ---
+
+// v2Entry is a minimal view of a recorder JSONL line for v2 assertions.
+type v2Entry struct {
+	Type      string          `json:"type"`
+	EventKind string          `json:"event_kind"`
+	Transport string          `json:"transport"`
+	Detail    json.RawMessage `json:"detail"`
+}
+
+func readRecorderEntries(t *testing.T, dir string) []v2Entry {
+	t.Helper()
+	des, err := os.ReadDir(filepath.Clean(dir))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var out []v2Entry
+	for _, de := range des {
+		if de.IsDir() || !strings.HasSuffix(de.Name(), ".jsonl") {
+			continue
+		}
+		data, rErr := os.ReadFile(filepath.Clean(filepath.Join(dir, de.Name())))
+		if rErr != nil {
+			t.Fatalf("ReadFile: %v", rErr)
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			if line == "" {
+				continue
+			}
+			var e v2Entry
+			if err := json.Unmarshal([]byte(line), &e); err != nil {
+				t.Fatalf("unmarshal entry: %v", err)
+			}
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// dualEmitFixture wires a recorder plus both emitters from one key, the way the
+// startup path does, and returns a proxy whose emitReceipt dual-emits.
+type dualEmitFixture struct {
+	p   *Proxy
+	rec *recorder.Recorder
+	dir string
+	pub ed25519.PublicKey
+	kid string
+}
+
+func newDualEmitFixture(t *testing.T, redact bool) *dualEmitFixture {
+	t.Helper()
+	dir := t.TempDir()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	sc := scanner.New(cfg)
+
+	var redactFn recorder.RedactFunc
+	if redact {
+		redactFn = sc.ScanTextForDLP
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled: true, Dir: dir, CheckpointInterval: 1000, Redact: redact,
+	}, redactFn, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+
+	v1 := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder: rec, PrivKey: priv, ConfigHash: "test-hash",
+		Principal: "local", Actor: "pipelock",
+	})
+	signer := proxydecision.NewKeyedSigner(priv)
+	v2 := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder: rec, Signer: signer,
+		Sanitize:  proxydecision.SanitizeFromRedactor(rec.ReceiptRedactor()),
+		Principal: "local", Actor: "pipelock",
+	})
+	if v1 == nil || v2 == nil {
+		t.Fatal("emitter construction returned nil")
+	}
+
+	p, err := New(cfg, audit.NewNop(), sc, metrics.New(),
+		WithRecorder(rec), WithReceiptEmitter(v1), WithV2ReceiptEmitter(v2))
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	t.Cleanup(p.Close)
+
+	return &dualEmitFixture{p: p, rec: rec, dir: dir, pub: pub, kid: signer.KeyID()}
+}
+
+func (f *dualEmitFixture) v2Receipt(t *testing.T) contractreceipt.EvidenceReceipt {
+	t.Helper()
+	if err := f.rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	var v1Count, v2Count int
+	var rcpt contractreceipt.EvidenceReceipt
+	for _, e := range readRecorderEntries(t, f.dir) {
+		switch e.Type {
+		case "action_receipt":
+			v1Count++
+		case "evidence_receipt":
+			if e.EventKind == string(contractreceipt.PayloadProxyDecision) {
+				v2Count++
+				if err := json.Unmarshal(e.Detail, &rcpt); err != nil {
+					t.Fatalf("unmarshal v2 receipt: %v", err)
+				}
+			}
+		}
+	}
+	if v1Count != 1 {
+		t.Errorf("v1 action_receipt count = %d, want 1 (dual-emit must keep v1)", v1Count)
+	}
+	if v2Count != 1 {
+		t.Fatalf("v2 proxy_decision count = %d, want 1", v2Count)
+	}
+	return rcpt
+}
+
+func TestDualEmit_ProducesVerifiableV2AlongsideV1(t *testing.T) {
+	f := newDualEmitFixture(t, false)
+	f.p.emitReceipt(receipt.EmitOpts{
+		ActionID: "a1", Transport: TransportForward, Method: "GET",
+		Target: "https://api.vendor.example/v1/x", Verdict: "block",
+		Layer: "dlp", Pattern: "prompt_injection", RequestID: "r1",
+	})
+
+	rcpt := f.v2Receipt(t)
+	if err := contractreceipt.VerifyWithKey(rcpt, f.pub, f.kid); err != nil {
+		t.Fatalf("v2 receipt failed offline verify: %v", err)
+	}
+	var p contractreceipt.PayloadProxyDecisionStruct
+	if err := json.Unmarshal(rcpt.Payload, &p); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if p.ActionType != v2ActionHTTPRequest || p.Transport != TransportForward {
+		t.Errorf("payload surface fields wrong: %+v", p)
+	}
+	if p.WinningSource != proxydecision.SourceScanner {
+		t.Errorf("winning_source = %q, want scanner", p.WinningSource)
+	}
+}
+
+func TestDualEmit_SanitizesV2TargetWithRedaction(t *testing.T) {
+	const secret = "AKIA" + "IOSFODNN7EXAMPLE"
+	f := newDualEmitFixture(t, true)
+	f.p.emitReceipt(receipt.EmitOpts{
+		ActionID: "a1", Transport: TransportForward, Method: "GET",
+		Target: "https://api.vendor.example/v1/x?key=" + secret, Verdict: "block",
+		Layer: "dlp", Pattern: "aws_access_key", RequestID: "r1",
+	})
+
+	rcpt := f.v2Receipt(t)
+	if err := contractreceipt.VerifyWithKey(rcpt, f.pub, f.kid); err != nil {
+		t.Fatalf("v2 receipt failed offline verify: %v", err)
+	}
+	if strings.Contains(string(rcpt.Payload), secret) {
+		t.Errorf("v2 receipt payload leaks secret: %s", rcpt.Payload)
+	}
+}
+
+func TestDualEmit_DisabledWhenNoV2Emitter(t *testing.T) {
+	// A proxy with only the v1 emitter must not panic and must emit no v2 entry.
+	dir := t.TempDir()
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	sc := scanner.New(cfg)
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+	v1 := receipt.NewEmitter(receipt.EmitterConfig{Recorder: rec, PrivKey: priv, Principal: "local", Actor: "pipelock"})
+	p, err := New(cfg, audit.NewNop(), sc, metrics.New(), WithRecorder(rec), WithReceiptEmitter(v1))
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	t.Cleanup(p.Close)
+
+	p.emitReceipt(receipt.EmitOpts{
+		ActionID: "a1", Transport: TransportFetch, Method: "GET",
+		Target: "https://x.example/a", Verdict: "allow", RequestID: "r1",
+	})
+	_ = rec.Close()
+	for _, e := range readRecorderEntries(t, dir) {
+		if e.Type == "evidence_receipt" && e.EventKind == string(contractreceipt.PayloadProxyDecision) {
+			t.Error("v2 proxy_decision emitted despite no v2 emitter configured")
+		}
+	}
+}
+
+// TestDualEmit_HotReloadPreservesV2Chain proves the v2 proxy_decision chain
+// stays continuous across a hot reload that rebuilds the emitter (e.g. key
+// rotation), satisfying the "hot reload preserves security state" invariant.
+func TestDualEmit_HotReloadPreservesV2Chain(t *testing.T) {
+	recDir := t.TempDir()
+	keyDir := t.TempDir()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	keyPath := filepath.Join(keyDir, "receipt.key")
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+
+	rec, err := recorder.New(recorder.Config{
+		Enabled: true, Dir: recDir, CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.FlightRecorder.SigningKeyPath = keyPath
+	sc := scanner.New(cfg)
+
+	v1 := receipt.NewEmitter(receipt.EmitterConfig{Recorder: rec, PrivKey: priv, Principal: "local", Actor: "pipelock"})
+	signer := proxydecision.NewKeyedSigner(priv)
+	v2 := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder: rec, Signer: signer, Principal: "local", Actor: "pipelock",
+	})
+	p, err := New(cfg, audit.NewNop(), sc, metrics.New(),
+		WithRecorder(rec), WithReceiptEmitter(v1), WithV2ReceiptEmitter(v2),
+		WithReceiptKeyPath(keyPath))
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	t.Cleanup(p.Close)
+
+	opts := receipt.EmitOpts{
+		ActionID: "a1", Transport: TransportForward, Method: "GET",
+		Target: "https://x.example/a", Verdict: "allow", RequestID: "r1",
+	}
+	p.emitReceipt(opts) // v2 seq 0
+
+	// Hot reload with the same signing key; buildReceiptEmitter must carry the
+	// v2 chain head forward instead of resetting to genesis.
+	reloadCfg := config.Defaults()
+	reloadCfg.Internal = nil
+	reloadCfg.FlightRecorder.SigningKeyPath = keyPath
+	p.Reload(reloadCfg, scanner.New(reloadCfg))
+
+	if p.v2EmitterPtr.Load() == nil {
+		t.Fatal("v2 emitter nil after reload with signing key")
+	}
+	p.emitReceipt(opts) // v2 seq 1, chained to seq 0
+
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	var v2s []contractreceipt.EvidenceReceipt
+	for _, e := range readRecorderEntries(t, recDir) {
+		if e.Type == "evidence_receipt" && e.EventKind == string(contractreceipt.PayloadProxyDecision) {
+			var r contractreceipt.EvidenceReceipt
+			if err := json.Unmarshal(e.Detail, &r); err != nil {
+				t.Fatalf("unmarshal v2 receipt: %v", err)
+			}
+			v2s = append(v2s, r)
+		}
+	}
+	if len(v2s) != 2 {
+		t.Fatalf("got %d v2 receipts across reload, want 2", len(v2s))
+	}
+	for i, r := range v2s {
+		if err := contractreceipt.VerifyWithKey(r, pub, signer.KeyID()); err != nil {
+			t.Fatalf("v2 receipt %d verify: %v", i, err)
+		}
+		if r.ChainSeq != uint64(i) {
+			t.Errorf("receipt %d ChainSeq = %d, want %d (chain reset on reload)", i, r.ChainSeq, i)
+		}
+	}
+	h0, err := contractreceipt.ReceiptHash(v2s[0])
+	if err != nil {
+		t.Fatalf("ReceiptHash: %v", err)
+	}
+	if v2s[1].ChainPrevHash != h0 {
+		t.Errorf("post-reload receipt ChainPrevHash = %q, want %q (chain broke across reload)", v2s[1].ChainPrevHash, h0)
+	}
+}

--- a/internal/receipt/sanitize.go
+++ b/internal/receipt/sanitize.go
@@ -136,3 +136,28 @@ func coarsenUntilClean(u *url.URL, clean dlpClean) string {
 	// Nothing structural is safe to keep.
 	return redactedTarget
 }
+
+// SanitizeTarget exposes the v1 emitter's pre-sign target sanitization to the
+// v2 proxy_decision emitter (internal/contract/proxydecision). The v2 receipt
+// stamps the same secret-bearing target field into a SIGNED payload, so it MUST
+// apply byte-identical sanitization (#676) rather than duplicate this
+// security-critical logic. clean is gated on flight-recorder redaction being
+// enabled; pass nil (or build it from recorder.ReceiptRedactor) to leave
+// targets unchanged when redaction is off.
+func SanitizeTarget(target string, clean func(string) bool) string {
+	if clean == nil {
+		return sanitizeTarget(target, nil)
+	}
+	return sanitizeTarget(target, dlpClean(clean))
+}
+
+// CleanOrRedacted exposes the v1 emitter's pre-sign field sanitization for
+// non-URL secret-bearing fields (e.g. a scanner pattern/rule label that may
+// echo matched bytes). Same rationale as SanitizeTarget: the v2 emitter signs
+// these fields, so it reuses this function instead of duplicating it.
+func CleanOrRedacted(s string, clean func(string) bool) string {
+	if clean == nil {
+		return s
+	}
+	return cleanOrRedacted(s, dlpClean(clean))
+}


### PR DESCRIPTION
The v2 EvidenceReceipt family (JCS-canonical preimage, detached signature, strict field validation) already shipped for contract lifecycle and shadow records, but the `proxy_decision` payload had a builder with zero live callers. Every real proxy decision emitted only the v1 ActionReceipt. This wires the live proxy to emit a signed v2 `proxy_decision` alongside the v1 receipt, standing up the portable receipt spine that re-checkable source-span provenance will build on.

v1 stays the authoritative record. This is the expand half of expand-and-contract: nothing migrates off v1, and the v1 ActionReceipt chain plus Audit Packet v0 are untouched.

## What it covers

All decisions on the proxy emit path: fetch, forward, CONNECT, TLS-intercept, WebSocket, reverse proxy, and MCP-over-HTTP that transits the proxy. Those sites funnel through three emit wrappers, so dual-emit lives at three points instead of every call site.

The standalone MCP proxy (stdio and streamable-HTTP) emits v1 on a separate path (`EmitMCPDecision`) that this does not touch. That surface is a follow-up, called out so the coverage claim stays honest.

## Decision provenance

`policy_sources` and `winning_source` are generic decision provenance, not contract-only. A scanner block attributes to `scanner`, a kill switch to `kill_switch`, and a contract-participated decision carries its real contract sources plus a `contract` marker, with the manifest and contract hashes stamped only when a resolved contract existed.

## Chain model

The v2 emitter keeps its own per-receipt chain (seq + prev hash), shares the recorder with v1, and writes its own `evidence_receipt` / `proxy_decision` entry kind. The recorder's outer hash chain spans both families. Hot reload carries the v2 chain head forward in process, so a key rotation does not reset the chain to genesis. Across a full restart the per-emitter chain restarts at genesis while the recorder's outer chain stays continuous, matching the existing shadow emitter.

## Security

The v2 `target` field gets the same pre-sign sanitization as v1, reusing exported `SanitizeTarget` / `CleanOrRedacted` helpers instead of duplicating the logic. A secret in a request URL never reaches the signed payload. v2 emission is gated on the same receipt intent as v1 (flight recorder plus signing key), with no new config knob.

## Follow-up

Source-span fields and the non-Go EvidenceReceipt v2 verifiers land in a separate, larger change. Standalone MCP-proxy v2 dual-emit is a small separate pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dual-emits signed v2 proxy-decision receipts alongside existing v1 action receipts (v1 remains authoritative; v2 skipped on v1 failure)
  * Preserves v2 receipt chain continuity across hot reloads
  * Optional sanitization of sensitive targets/rule IDs before signing; startup logs when v2 dual-emit is enabled
* **Tests**
  * Extensive unit and integration tests covering v2 decision derivation, sanitization, signature verification, chain linking, reload continuity, and failure handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->