### PR TITLE
test(cli): harden run listener port allocation

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -127,25 +127,26 @@ func waitForRunHTTPWithinResult(
 	format string,
 	args ...any,
 ) error {
-	return waitForRunRequestWithinResult(timeout, errCh, func() *http.Request {
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	return waitForRunRequestWithinResult(ctx, timeout, errCh, func(reqCtx context.Context) *http.Request {
+		req, _ := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
 		return req
 	}, client, check, format, args...)
 }
 
 func waitForRunRequestWithin(
 	t *testing.T,
+	ctx context.Context,
 	timeout time.Duration,
 	errCh <-chan error,
 	cancel context.CancelFunc,
-	newReq func() *http.Request,
+	newReq func(context.Context) *http.Request,
 	client *http.Client,
 	check func(*http.Response) bool,
 	format string,
 	args ...any,
 ) {
 	t.Helper()
-	err := waitForRunRequestWithinResult(timeout, errCh, newReq, client, check, format, args...)
+	err := waitForRunRequestWithinResult(ctx, timeout, errCh, newReq, client, check, format, args...)
 	if err != nil {
 		cancel()
 		t.Fatalf("run did not become ready: %v", err)
@@ -153,15 +154,16 @@ func waitForRunRequestWithin(
 }
 
 func waitForRunRequestWithinResult(
+	parentCtx context.Context,
 	timeout time.Duration,
 	errCh <-chan error,
-	newReq func() *http.Request,
+	newReq func(context.Context) *http.Request,
 	client *http.Client,
 	check func(*http.Response) bool,
 	format string,
 	args ...any,
 ) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(parentCtx, timeout)
 	defer cancel()
 
 	ticker := time.NewTicker(5 * time.Millisecond)
@@ -176,7 +178,7 @@ func waitForRunRequestWithinResult(
 			return fmt.Errorf("timed out waiting for %s: %w", detail, ctx.Err())
 		default:
 		}
-		req := newReq()
+		req := newReq(ctx)
 		resp, err := client.Do(req) //nolint:gosec // G704: test-only URL built from loopback listener.
 		if err == nil {
 			ok := check(resp)
@@ -783,8 +785,8 @@ logging:
 		// Poll /health until the proxy is ready
 		client := &http.Client{Timeout: time.Second}
 		healthURL := "http://" + addr + "/health"
-		if err := waitForRunRequestWithinResult(5*time.Second, errCh, func() *http.Request {
-			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+		if err := waitForRunRequestWithinResult(ctx, 5*time.Second, errCh, func(reqCtx context.Context) *http.Request {
+			req, _ := http.NewRequestWithContext(reqCtx, http.MethodGet, healthURL, nil)
 			return req
 		}, client, func(resp *http.Response) bool {
 			return resp.StatusCode == http.StatusOK
@@ -956,8 +958,8 @@ func TestRunCmd_ListenFlagOverride(t *testing.T) {
 		// Poll /health until the proxy is ready
 		client := &http.Client{Timeout: time.Second}
 		healthURL := "http://" + addr + "/health"
-		if err := waitForRunRequestWithinResult(5*time.Second, errCh, func() *http.Request {
-			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+		if err := waitForRunRequestWithinResult(ctx, 5*time.Second, errCh, func(reqCtx context.Context) *http.Request {
+			req, _ := http.NewRequestWithContext(reqCtx, http.MethodGet, healthURL, nil)
 			return req
 		}, client, func(resp *http.Response) bool {
 			return resp.StatusCode == http.StatusOK
@@ -2004,8 +2006,8 @@ kill_switch:
 		}
 
 		lastReloadWrite := time.Now()
-		waitForRunRequestWithin(t, 15*time.Second, errCh, cancel, func() *http.Request {
-			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
+		waitForRunRequestWithin(t, ctx, 15*time.Second, errCh, cancel, func(reqCtx context.Context) *http.Request {
+			req, _ := http.NewRequestWithContext(reqCtx, http.MethodGet, statusURL, nil)
 			req.Header.Set("Authorization", "Bearer reload-token")
 			return req
 		}, client, func(resp *http.Response) bool {
@@ -2461,7 +2463,10 @@ websocket_proxy:
 
 		cancel()
 		select {
-		case <-errCh:
+		case err := <-errCh:
+			if err != nil {
+				t.Errorf("unexpected run error: %v", err)
+			}
 		case <-time.After(10 * time.Second):
 			t.Fatal("run did not shut down")
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
+	"github.com/luckyPipewrench/pipelock/internal/testport"
 	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
@@ -79,7 +80,21 @@ func waitForRunHTTP(
 	label string,
 ) {
 	t.Helper()
-	waitForRunHTTPWithin(t, 5*time.Second, ctx, client, errCh, cancel, url, check, "%s", label)
+	if err := waitForRunHTTPResult(ctx, client, errCh, url, check, label); err != nil {
+		cancel()
+		t.Fatalf("run did not become ready: %v", err)
+	}
+}
+
+func waitForRunHTTPResult(
+	ctx context.Context,
+	client *http.Client,
+	errCh <-chan error,
+	url string,
+	check func(*http.Response) bool,
+	label string,
+) error {
+	return waitForRunHTTPWithinResult(5*time.Second, ctx, client, errCh, url, check, "%s", label)
 }
 
 func waitForRunHTTPWithin(
@@ -95,7 +110,24 @@ func waitForRunHTTPWithin(
 	args ...any,
 ) {
 	t.Helper()
-	waitForRunRequestWithin(t, timeout, errCh, cancel, func() *http.Request {
+	err := waitForRunHTTPWithinResult(timeout, ctx, client, errCh, url, check, format, args...)
+	if err != nil {
+		cancel()
+		t.Fatalf("run did not become ready: %v", err)
+	}
+}
+
+func waitForRunHTTPWithinResult(
+	timeout time.Duration,
+	ctx context.Context,
+	client *http.Client,
+	errCh <-chan error,
+	url string,
+	check func(*http.Response) bool,
+	format string,
+	args ...any,
+) error {
+	return waitForRunRequestWithinResult(timeout, errCh, func() *http.Request {
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		return req
 	}, client, check, format, args...)
@@ -113,21 +145,55 @@ func waitForRunRequestWithin(
 	args ...any,
 ) {
 	t.Helper()
-	testwait.For(t, timeout, func() bool {
+	err := waitForRunRequestWithinResult(timeout, errCh, newReq, client, check, format, args...)
+	if err != nil {
+		cancel()
+		t.Fatalf("run did not become ready: %v", err)
+	}
+}
+
+func waitForRunRequestWithinResult(
+	timeout time.Duration,
+	errCh <-chan error,
+	newReq func() *http.Request,
+	client *http.Client,
+	check func(*http.Response) bool,
+	format string,
+	args ...any,
+) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+
+	detail := fmt.Sprintf(format, args...)
+	for {
 		select {
 		case cmdErr := <-errCh:
-			cancel()
-			t.Fatalf("run exited early: %v", cmdErr)
+			return fmt.Errorf("run exited early while waiting for %s: %w", detail, cmdErr)
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for %s: %w", detail, ctx.Err())
 		default:
 		}
 		req := newReq()
 		resp, err := client.Do(req) //nolint:gosec // G704: test-only URL built from loopback listener.
-		if err != nil {
-			return false
+		if err == nil {
+			ok := check(resp)
+			_ = resp.Body.Close()
+			if ok {
+				return nil
+			}
 		}
-		defer func() { _ = resp.Body.Close() }()
-		return check(resp)
-	}, format, args...)
+
+		select {
+		case cmdErr := <-errCh:
+			return fmt.Errorf("run exited early while waiting for %s: %w", detail, cmdErr)
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for %s: %w", detail, ctx.Err())
+		case <-ticker.C:
+		}
+	}
 }
 
 func TestRootCmd_Version(t *testing.T) {
@@ -676,20 +742,14 @@ func TestHealthcheckCmd_RegisteredInHelp(t *testing.T) {
 }
 
 func TestRunCmd_Integration(t *testing.T) {
-	// Find a free port
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		addr := addrs[0]
 
-	// Write a balanced config; the --mode flag will override to strict
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "test.yaml")
-	logPath := filepath.Join(dir, "audit.log")
-	cfgContent := fmt.Sprintf(`version: 1
+		// Write a balanced config; the --mode flag will override to strict
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "test.yaml")
+		logPath := filepath.Join(dir, "audit.log")
+		cfgContent := fmt.Sprintf(`version: 1
 mode: balanced
 api_allowlist:
   - "*.anthropic.com"
@@ -701,63 +761,71 @@ logging:
   output: file
   file: "%s"
 `, addr, logPath)
-	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	// Inject a cancellable context so we can shut down the server
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--config", cfgPath, "--mode", "strict"})
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
-
-	// Poll /health until the proxy is ready
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + addr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "proxy health")
-
-	// Verify the health response shows the flag override (strict, not balanced)
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-	resp, err := client.Do(req) //nolint:gosec // G704: test-only, URL from httptest server
-	if err != nil {
-		cancel()
-		t.Fatalf("health request failed: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var health map[string]any
-	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
-		cancel()
-		t.Fatalf("decoding health response: %v", err)
-	}
-	if health["mode"] != config.ModeStrict {
-		t.Errorf("expected mode=strict (flag override), got %v", health["mode"])
-	}
-	if health["status"] != "healthy" {
-		t.Errorf("expected status=healthy, got %v", health["status"])
-	}
-
-	// Trigger graceful shutdown
-	cancel()
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Errorf("unexpected run error: %v", err)
+		if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+			t.Fatal(err)
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run command did not shut down within timeout")
-	}
+
+		// Inject a cancellable context so we can shut down the server
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--config", cfgPath, "--mode", "strict"})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
+
+		// Poll /health until the proxy is ready
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + addr + "/health"
+		if err := waitForRunRequestWithinResult(5*time.Second, errCh, func() *http.Request {
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+			return req
+		}, client, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "proxy health"); err != nil {
+			cancel()
+			return err
+		}
+
+		// Verify the health response shows the flag override (strict, not balanced)
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+		resp, err := client.Do(req) //nolint:gosec // G704: test-only, URL from httptest server
+		if err != nil {
+			cancel()
+			t.Fatalf("health request failed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		var health map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+			cancel()
+			t.Fatalf("decoding health response: %v", err)
+		}
+		if health["mode"] != config.ModeStrict {
+			t.Errorf("expected mode=strict (flag override), got %v", health["mode"])
+		}
+		if health["status"] != "healthy" {
+			t.Errorf("expected status=healthy, got %v", health["status"])
+		}
+
+		// Trigger graceful shutdown
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Errorf("unexpected run error: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run command did not shut down within timeout")
+		}
+		return nil
+	})
 }
 
 func TestRunCmd_ListenFlag(t *testing.T) {
@@ -868,45 +936,47 @@ logging:
 }
 
 func TestRunCmd_ListenFlagOverride(t *testing.T) {
-	// Find a free port
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		addr := addrs[0]
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--listen", addr})
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--listen", addr})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	// Poll /health until the proxy is ready
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + addr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "proxy health")
-
-	cancel()
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Errorf("unexpected run error: %v", err)
+		// Poll /health until the proxy is ready
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + addr + "/health"
+		if err := waitForRunRequestWithinResult(5*time.Second, errCh, func() *http.Request {
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+			return req
+		}, client, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "proxy health"); err != nil {
+			cancel()
+			return err
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run command did not shut down within timeout")
-	}
+
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Errorf("unexpected run error: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run command did not shut down within timeout")
+		}
+		return nil
+	})
 }
 
 func TestHealthcheckCmd_Unhealthy(t *testing.T) {
@@ -1032,93 +1102,92 @@ func TestGenerateDockerCompose_OpenhandsToStdout(t *testing.T) {
 }
 
 func TestRunCmd_WithAgentArgs(t *testing.T) {
-	// Find a free port.
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		addr := addrs[0]
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--listen", addr, "--", "some-agent", "--flag"})
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--listen", addr, "--", "some-agent", "--flag"})
 
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	// Poll until healthy.
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + addr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "proxy health")
-
-	cancel()
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+		// Poll until healthy.
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + addr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "proxy health"); err != nil {
+			cancel()
+			return err
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
 
-	// The run command completed without error, which means the agent args
-	// parsing path (dashIdx >= 0) was exercised.
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
+		}
+
+		// The run command completed without error, which means the agent args
+		// parsing path (dashIdx >= 0) was exercised.
+		return nil
+	})
 }
 
 func TestRunCmd_DefaultMode(t *testing.T) {
 	// Run with no config, no flags - should use default balanced mode.
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		addr := addrs[0]
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--listen", addr})
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--listen", addr})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	// Wait until healthy, then check mode.
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + addr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		var health map[string]any
-		_ = json.NewDecoder(resp.Body).Decode(&health)
-		return health["mode"] == config.ModeBalanced
-	}, "balanced mode health")
-
-	cancel()
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+		// Wait until healthy, then check mode.
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + addr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			var health map[string]any
+			_ = json.NewDecoder(resp.Body).Decode(&health)
+			return health["mode"] == config.ModeBalanced
+		}, "balanced mode health"); err != nil {
+			cancel()
+			return err
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
+
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
+		}
+		return nil
+	})
 }
 
 func TestRunCmd_ConfigValidationError(t *testing.T) {
@@ -1148,93 +1217,91 @@ mode: "not-a-mode"
 
 func TestRunCmd_ModeFlag(t *testing.T) {
 	// Test that --mode strict works without a config file.
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		addr := addrs[0]
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--mode", "strict", "--listen", addr})
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--mode", "strict", "--listen", addr})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	// Wait for healthy.
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + addr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		var health map[string]any
-		_ = json.NewDecoder(resp.Body).Decode(&health)
-		return health["mode"] == config.ModeStrict
-	}, "strict mode health")
-
-	cancel()
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+		// Wait for healthy.
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + addr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			var health map[string]any
+			_ = json.NewDecoder(resp.Body).Decode(&health)
+			return health["mode"] == config.ModeStrict
+		}, "strict mode health"); err != nil {
+			cancel()
+			return err
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
+
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
+		}
+		return nil
+	})
 }
 
 func TestRunCmd_WithConfigHotReload(t *testing.T) {
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		addr := addrs[0]
 
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "test.yaml")
-	cfgContent := fmt.Sprintf(`version: 1
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "test.yaml")
+		cfgContent := fmt.Sprintf(`version: 1
 mode: balanced
 fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
 `, addr)
-	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
-		t.Fatal(err)
-	}
+		if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+			t.Fatal(err)
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	stderr := &cliTestBuffer{}
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(stderr)
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--config", cfgPath})
+		stderr := &cliTestBuffer{}
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(stderr)
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	// Wait for healthy.
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + addr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "proxy health")
+		// Wait for healthy.
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + addr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "proxy health"); err != nil {
+			cancel()
+			return err
+		}
 
-	// Modify the config to trigger hot-reload via fsnotify.
-	updatedCfg := fmt.Sprintf(`version: 1
+		// Modify the config to trigger hot-reload via fsnotify.
+		updatedCfg := fmt.Sprintf(`version: 1
 mode: strict
 api_allowlist:
   - "api.example.com"
@@ -1242,25 +1309,27 @@ fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
 `, addr)
-	if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		var health map[string]any
-		_ = json.NewDecoder(resp.Body).Decode(&health)
-		return health["mode"] == config.ModeStrict
-	}, "strict mode after hot reload")
-
-	cancel()
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+		if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
+			t.Fatal(err)
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
+
+		waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+			var health map[string]any
+			_ = json.NewDecoder(resp.Body).Decode(&health)
+			return health["mode"] == config.ModeStrict
+		}, "strict mode after hot reload")
+
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
+		}
+		return nil
+	})
 }
 
 func TestRunCmd_AuditLoggerError(t *testing.T) {
@@ -1291,52 +1360,50 @@ logging:
 }
 
 func TestRunCmd_ReloadToAskMode(t *testing.T) {
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		addr := addrs[0]
 
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "test.yaml")
-	// Start with balanced mode (no HITL approver created)
-	cfgContent := fmt.Sprintf(`version: 1
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "test.yaml")
+		// Start with balanced mode (no HITL approver created)
+		cfgContent := fmt.Sprintf(`version: 1
 mode: balanced
 fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
 `, addr)
-	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
-		t.Fatal(err)
-	}
+		if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+			t.Fatal(err)
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	stderr := &cliTestBuffer{}
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(stderr)
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--config", cfgPath})
+		stderr := &cliTestBuffer{}
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(stderr)
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	// Wait for healthy.
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + addr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "proxy health")
+		// Wait for healthy.
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + addr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "proxy health"); err != nil {
+			cancel()
+			return err
+		}
 
-	// Reload config to action: ask and audit mode. The mode change is the
-	// observable signal that the reload carrying ask-mode config landed.
-	updatedCfg := fmt.Sprintf(`version: 1
+		// Reload config to action: ask and audit mode. The mode change is the
+		// observable signal that the reload carrying ask-mode config landed.
+		updatedCfg := fmt.Sprintf(`version: 1
 mode: audit
 fetch_proxy:
   listen: "%s"
@@ -1345,45 +1412,42 @@ response_scanning:
   enabled: true
   action: ask
 `, addr)
-	if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	// Reload observation needs a longer deadline than the initial health
-	// check: fsnotify delivery plus the 100ms debounce plus the atomic config
-	// swap lag well past 5s under the heavy -race CI job (config+cli+mcp+proxy
-	// in one process). The startup wait above stays snappy; only this
-	// reload-to-take-effect wait gets the longer ceiling.
-	waitForRunHTTPWithin(t, 20*time.Second, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		var health map[string]any
-		_ = json.NewDecoder(resp.Body).Decode(&health)
-		return health["mode"] == config.ModeAudit
-	}, "%s", "audit ask-mode config after hot reload")
-
-	cancel()
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+		if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
+			t.Fatal(err)
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
+
+		// Reload observation needs a longer deadline than the initial health
+		// check: fsnotify delivery plus the 100ms debounce plus the atomic config
+		// swap lag well past 5s under the heavy -race CI job (config+cli+mcp+proxy
+		// in one process). The startup wait above stays snappy; only this
+		// reload-to-take-effect wait gets the longer ceiling.
+		waitForRunHTTPWithin(t, 20*time.Second, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+			var health map[string]any
+			_ = json.NewDecoder(resp.Body).Decode(&health)
+			return health["mode"] == config.ModeAudit
+		}, "%s", "audit ask-mode config after hot reload")
+
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
+		}
+		return nil
+	})
 }
 
 func TestRunCmd_WithAskModeApprover(t *testing.T) {
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		addr := addrs[0]
 
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "test.yaml")
-	// Start with ask mode so hasApprover=true and approver is created
-	cfgContent := fmt.Sprintf(`version: 1
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "test.yaml")
+		// Start with ask mode so hasApprover=true and approver is created
+		cfgContent := fmt.Sprintf(`version: 1
 mode: balanced
 fetch_proxy:
   listen: "%s"
@@ -1393,55 +1457,55 @@ response_scanning:
   action: ask
   ask_timeout_seconds: 1
 `, addr)
-	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
-
-	// Wait for healthy.
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + addr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "proxy health")
-
-	// Proxy started with ask mode - approver was created. Shut down cleanly.
-	cancel()
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+		if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+			t.Fatal(err)
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--config", cfgPath})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
+
+		// Wait for healthy.
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + addr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "proxy health"); err != nil {
+			cancel()
+			return err
+		}
+
+		// Proxy started with ask mode - approver was created. Shut down cleanly.
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
+		}
+		return nil
+	})
 }
 
 func TestRunCmd_ForwardProxyBanner(t *testing.T) {
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		addr := addrs[0]
 
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "test.yaml")
-	cfgContent := fmt.Sprintf(`version: 1
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "test.yaml")
+		cfgContent := fmt.Sprintf(`version: 1
 mode: balanced
 fetch_proxy:
   listen: "%s"
@@ -1451,76 +1515,76 @@ forward_proxy:
   max_tunnel_seconds: 10
   idle_timeout_seconds: 2
 `, addr)
-	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	var stderrBuf bytes.Buffer
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(&stderrBuf)
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
-
-	// Wait for healthy.
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + addr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "proxy health")
-
-	// Verify health shows forward_proxy_enabled=true
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-	resp, err := client.Do(req)
-	if err != nil {
-		cancel()
-		t.Fatalf("health request failed: %v", err)
-	}
-	var health map[string]any
-	_ = json.NewDecoder(resp.Body).Decode(&health)
-	_ = resp.Body.Close()
-	if health["forward_proxy_enabled"] != true {
-		t.Errorf("expected forward_proxy_enabled=true, got %v", health["forward_proxy_enabled"])
-	}
-
-	cancel()
-	select {
-	case cmdErr := <-errCh:
-		if cmdErr != nil {
-			t.Errorf("unexpected error: %v", cmdErr)
+		if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+			t.Fatal(err)
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
 
-	// Check stderr banner printed the forward proxy line
-	if !strings.Contains(stderrBuf.String(), "forward proxy enabled") {
-		t.Errorf("expected forward proxy banner in stderr, got: %s", stderrBuf.String())
-	}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var stderrBuf bytes.Buffer
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--config", cfgPath})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(&stderrBuf)
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
+
+		// Wait for healthy.
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + addr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "proxy health"); err != nil {
+			cancel()
+			return err
+		}
+
+		// Verify health shows forward_proxy_enabled=true
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+		resp, err := client.Do(req)
+		if err != nil {
+			cancel()
+			t.Fatalf("health request failed: %v", err)
+		}
+		var health map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&health)
+		_ = resp.Body.Close()
+		if health["forward_proxy_enabled"] != true {
+			t.Errorf("expected forward_proxy_enabled=true, got %v", health["forward_proxy_enabled"])
+		}
+
+		cancel()
+		select {
+		case cmdErr := <-errCh:
+			if cmdErr != nil {
+				t.Errorf("unexpected error: %v", cmdErr)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
+		}
+
+		// Check stderr banner printed the forward proxy line
+		if !strings.Contains(stderrBuf.String(), "forward proxy enabled") {
+			t.Errorf("expected forward proxy banner in stderr, got: %s", stderrBuf.String())
+		}
+		return nil
+	})
 }
 
 func TestRunCmd_ReloadRejectsForwardProxyEnable(t *testing.T) {
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		addr := addrs[0]
 
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "test.yaml")
-	logPath := filepath.Join(dir, "audit.log")
-	// Start with forward_proxy disabled
-	cfgContent := fmt.Sprintf(`version: 1
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "test.yaml")
+		logPath := filepath.Join(dir, "audit.log")
+		// Start with forward_proxy disabled
+		cfgContent := fmt.Sprintf(`version: 1
 mode: balanced
 fetch_proxy:
   listen: "%s"
@@ -1531,33 +1595,36 @@ logging:
   output: file
   file: "%s"
 `, addr, logPath)
-	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
-		t.Fatal(err)
-	}
+		if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+			t.Fatal(err)
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--config", cfgPath})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	// Wait for healthy.
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + addr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "proxy health")
+		// Wait for healthy.
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + addr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "proxy health"); err != nil {
+			cancel()
+			return err
+		}
 
-	// Hot-reload: enable forward_proxy (should be rejected)
-	updatedCfg := fmt.Sprintf(`version: 1
+		// Hot-reload: enable forward_proxy (should be rejected)
+		updatedCfg := fmt.Sprintf(`version: 1
 mode: balanced
 fetch_proxy:
   listen: "%s"
@@ -1570,39 +1637,41 @@ logging:
   output: file
   file: "%s"
 `, addr, logPath)
-	if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
-		t.Fatal(err)
-	}
+		if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
+			t.Fatal(err)
+		}
 
-	testwait.For(t, 5*time.Second, func() bool {
+		testwait.For(t, 5*time.Second, func() bool {
+			select {
+			case cmdErr := <-errCh:
+				cancel()
+				t.Fatalf("run exited before rejected reload log: %v", cmdErr)
+			default:
+			}
+			logBytes, err := os.ReadFile(filepath.Clean(logPath))
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("read audit log: %v", err)
+			}
+			return strings.Contains(string(logBytes), "forward proxy cannot be enabled via reload")
+		}, "rejected forward proxy reload log")
+
+		waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+			var health map[string]any
+			_ = json.NewDecoder(resp.Body).Decode(&health)
+			return health["forward_proxy_enabled"] == false
+		}, "forward proxy remains disabled after rejected reload")
+
+		cancel()
 		select {
 		case cmdErr := <-errCh:
-			cancel()
-			t.Fatalf("run exited before rejected reload log: %v", cmdErr)
-		default:
+			if cmdErr != nil {
+				t.Errorf("unexpected error: %v", cmdErr)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
 		}
-		logBytes, err := os.ReadFile(filepath.Clean(logPath))
-		if err != nil && !errors.Is(err, os.ErrNotExist) {
-			t.Fatalf("read audit log: %v", err)
-		}
-		return strings.Contains(string(logBytes), "forward proxy cannot be enabled via reload")
-	}, "rejected forward proxy reload log")
-
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		var health map[string]any
-		_ = json.NewDecoder(resp.Body).Decode(&health)
-		return health["forward_proxy_enabled"] == false
-	}, "forward proxy remains disabled after rejected reload")
-
-	cancel()
-	select {
-	case cmdErr := <-errCh:
-		if cmdErr != nil {
-			t.Errorf("unexpected error: %v", cmdErr)
-		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
+		return nil
+	})
 }
 
 func TestRunCmd_MCPListenRequiresUpstream(t *testing.T) {
@@ -1679,66 +1748,60 @@ func TestRunCmd_MCPListenInHelp(t *testing.T) {
 }
 
 func TestRunCmd_MCPListenBanner(t *testing.T) {
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	fetchAddr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 2, func(addrs []string) error {
+		fetchAddr := addrs[0]
+		mcpAddr := addrs[1]
 
-	ln2, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	mcpAddr := ln2.Addr().String()
-	_ = ln2.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{
+			"run",
+			"--listen", fetchAddr,
+			"--mcp-listen", mcpAddr,
+			"--mcp-upstream", "http://localhost:19999",
+		})
+		cmd.SetOut(io.Discard)
+		errBuf := &cliTestBuffer{}
+		cmd.SetErr(errBuf)
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{
-		"run",
-		"--listen", fetchAddr,
-		"--mcp-listen", mcpAddr,
-		"--mcp-upstream", "http://localhost:19999",
-	})
-	cmd.SetOut(io.Discard)
-	errBuf := &cliTestBuffer{}
-	cmd.SetErr(errBuf)
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
-
-	// Wait for fetch proxy health.
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + fetchAddr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "fetch proxy health")
-
-	// Verify MCP listener health endpoint.
-	mcpHealthURL := "http://" + mcpAddr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, mcpHealthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "MCP listener health")
-
-	// Verify banner mentions MCP.
-	waitForCLIOutput(t, errBuf, errCh, cancel, "MCP:")
-
-	cancel()
-	select {
-	case cmdErr := <-errCh:
-		if cmdErr != nil {
-			t.Errorf("unexpected error: %v", cmdErr)
+		// Wait for fetch proxy health.
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + fetchAddr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "fetch proxy health"); err != nil {
+			cancel()
+			return err
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
+
+		// Verify MCP listener health endpoint.
+		mcpHealthURL := "http://" + mcpAddr + "/health"
+		waitForRunHTTP(t, ctx, client, errCh, cancel, mcpHealthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "MCP listener health")
+
+		// Verify banner mentions MCP.
+		waitForCLIOutput(t, errBuf, errCh, cancel, "MCP:")
+
+		cancel()
+		select {
+		case cmdErr := <-errCh:
+			if cmdErr != nil {
+				t.Errorf("unexpected error: %v", cmdErr)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
+		}
+		return nil
+	})
 }
 
 func TestRunCmd_MCPListenStartupFailure(t *testing.T) {
@@ -1778,60 +1841,52 @@ func TestRunCmd_MCPListenStartupFailure(t *testing.T) {
 }
 
 func TestRunCmd_MCPListenReloadUsesResolvedConfigForWarnings(t *testing.T) {
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	fetchAddr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 2, func(addrs []string) error {
+		fetchAddr := addrs[0]
+		mcpAddr := addrs[1]
 
-	ln2, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	mcpAddr := ln2.Addr().String()
-	_ = ln2.Close()
-
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "test.yaml")
-	cfgContent := fmt.Sprintf(`version: 1
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "test.yaml")
+		cfgContent := fmt.Sprintf(`version: 1
 mode: balanced
 fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
 `, fetchAddr)
-	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
-		t.Fatal(err)
-	}
+		if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+			t.Fatal(err)
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{
-		"run",
-		"--config", cfgPath,
-		"--mcp-listen", mcpAddr,
-		"--mcp-upstream", "http://localhost:19999",
-	})
-	cmd.SetOut(io.Discard)
-	var stderr bytes.Buffer
-	cmd.SetErr(&stderr)
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{
+			"run",
+			"--config", cfgPath,
+			"--mcp-listen", mcpAddr,
+			"--mcp-upstream", "http://localhost:19999",
+		})
+		cmd.SetOut(io.Discard)
+		var stderr bytes.Buffer
+		cmd.SetErr(&stderr)
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + fetchAddr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "fetch proxy health")
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + fetchAddr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "fetch proxy health"); err != nil {
+			cancel()
+			return err
+		}
 
-	updatedCfg := fmt.Sprintf(`version: 1
+		updatedCfg := fmt.Sprintf(`version: 1
 mode: strict
 api_allowlist:
   - "api.example.com"
@@ -1839,57 +1894,48 @@ fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
 `, fetchAddr)
-	if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	waitForRunHTTPWithin(t, 15*time.Second, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		var health map[string]any
-		_ = json.NewDecoder(resp.Body).Decode(&health)
-		return health["mode"] == config.ModeStrict
-	}, "strict mode after hot reload")
-
-	cancel()
-	select {
-	case cmdErr := <-errCh:
-		if cmdErr != nil {
-			t.Errorf("unexpected error: %v", cmdErr)
+		if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
+			t.Fatal(err)
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
 
-	output := stderr.String()
-	for _, field := range []string{
-		"mcp_input_scanning.enabled",
-		"mcp_tool_scanning.enabled",
-		"mcp_tool_policy.enabled",
-	} {
-		if strings.Contains(output, field) {
-			t.Errorf("unexpected false-positive reload warning for %s:\n%s", field, output)
+		waitForRunHTTPWithin(t, 15*time.Second, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
+			var health map[string]any
+			_ = json.NewDecoder(resp.Body).Decode(&health)
+			return health["mode"] == config.ModeStrict
+		}, "strict mode after hot reload")
+
+		cancel()
+		select {
+		case cmdErr := <-errCh:
+			if cmdErr != nil {
+				t.Errorf("unexpected error: %v", cmdErr)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
 		}
-	}
+
+		output := stderr.String()
+		for _, field := range []string{
+			"mcp_input_scanning.enabled",
+			"mcp_tool_scanning.enabled",
+			"mcp_tool_policy.enabled",
+		} {
+			if strings.Contains(output, field) {
+				t.Errorf("unexpected false-positive reload warning for %s:\n%s", field, output)
+			}
+		}
+		return nil
+	})
 }
 
 func TestRunCmd_MCPListenReloadStrictAllowsKillSwitchAPIToken(t *testing.T) {
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	fetchAddr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 2, func(addrs []string) error {
+		fetchAddr := addrs[0]
+		mcpAddr := addrs[1]
 
-	ln2, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	mcpAddr := ln2.Addr().String()
-	_ = ln2.Close()
-
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "test.yaml")
-	cfgContent := fmt.Sprintf(`version: 1
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "test.yaml")
+		cfgContent := fmt.Sprintf(`version: 1
 mode: strict
 api_allowlist:
   - "api.example.com"
@@ -1897,50 +1943,53 @@ fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
 `, fetchAddr)
-	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
-		t.Fatal(err)
-	}
+		if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+			t.Fatal(err)
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{
-		"run",
-		"--config", cfgPath,
-		"--mcp-listen", mcpAddr,
-		"--mcp-upstream", "http://localhost:19999",
-	})
-	cmd.SetOut(io.Discard)
-	var stderr bytes.Buffer
-	cmd.SetErr(&stderr)
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{
+			"run",
+			"--config", cfgPath,
+			"--mcp-listen", mcpAddr,
+			"--mcp-upstream", "http://localhost:19999",
+		})
+		cmd.SetOut(io.Discard)
+		var stderr bytes.Buffer
+		cmd.SetErr(&stderr)
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + fetchAddr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "fetch proxy health")
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + fetchAddr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "fetch proxy health"); err != nil {
+			cancel()
+			return err
+		}
 
-	statusURL := "http://" + fetchAddr + "/api/v1/killswitch/status"
-	statusReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
-	statusReq.Header.Set("Authorization", "Bearer reload-token")
-	resp, err := client.Do(statusReq)
-	if err != nil {
-		cancel()
-		t.Fatalf("kill switch status request failed before reload: %v", err)
-	}
-	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503 before reload, got %d", resp.StatusCode)
-	}
+		statusURL := "http://" + fetchAddr + "/api/v1/killswitch/status"
+		statusReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
+		statusReq.Header.Set("Authorization", "Bearer reload-token")
+		resp, err := client.Do(statusReq)
+		if err != nil {
+			cancel()
+			t.Fatalf("kill switch status request failed before reload: %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503 before reload, got %d", resp.StatusCode)
+		}
 
-	updatedCfg := fmt.Sprintf(`version: 1
+		updatedCfg := fmt.Sprintf(`version: 1
 mode: strict
 api_allowlist:
   - "api.example.com"
@@ -1950,52 +1999,54 @@ fetch_proxy:
 kill_switch:
   api_token: "reload-token"
 `, fetchAddr)
-	if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	lastReloadWrite := time.Now()
-	waitForRunRequestWithin(t, 15*time.Second, errCh, cancel, func() *http.Request {
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
-		req.Header.Set("Authorization", "Bearer reload-token")
-		return req
-	}, client, func(resp *http.Response) bool {
-		if resp.StatusCode == http.StatusOK {
-			return true
+		if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
+			t.Fatal(err)
 		}
-		// /health can become reachable before the config watcher has armed.
-		// Rewriting the same target config gives the watcher another observable
-		// event without weakening the reload assertion.
-		if time.Since(lastReloadWrite) >= 250*time.Millisecond {
-			if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
-				cancel()
-				t.Fatalf("rewrite updated config: %v", err)
+
+		lastReloadWrite := time.Now()
+		waitForRunRequestWithin(t, 15*time.Second, errCh, cancel, func() *http.Request {
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
+			req.Header.Set("Authorization", "Bearer reload-token")
+			return req
+		}, client, func(resp *http.Response) bool {
+			if resp.StatusCode == http.StatusOK {
+				return true
 			}
-			lastReloadWrite = time.Now()
-		}
-		return false
-	}, "kill switch API token after strict-mode reload")
+			// /health can become reachable before the config watcher has armed.
+			// Rewriting the same target config gives the watcher another observable
+			// event without weakening the reload assertion.
+			if time.Since(lastReloadWrite) >= 250*time.Millisecond {
+				if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); err != nil {
+					cancel()
+					t.Fatalf("rewrite updated config: %v", err)
+				}
+				lastReloadWrite = time.Now()
+			}
+			return false
+		}, "kill switch API token after strict-mode reload")
 
-	cancel()
-	select {
-	case cmdErr := <-errCh:
-		if cmdErr != nil {
-			t.Errorf("unexpected error: %v", cmdErr)
+		cancel()
+		select {
+		case cmdErr := <-errCh:
+			if cmdErr != nil {
+				t.Errorf("unexpected error: %v", cmdErr)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
 
-	output := stderr.String()
-	for _, field := range []string{
-		"mcp_input_scanning.enabled",
-		"mcp_tool_scanning.enabled",
-		"mcp_tool_policy.enabled",
-	} {
-		if strings.Contains(output, field) {
-			t.Errorf("unexpected false-positive reload warning for %s:\n%s", field, output)
+		output := stderr.String()
+		for _, field := range []string{
+			"mcp_input_scanning.enabled",
+			"mcp_tool_scanning.enabled",
+			"mcp_tool_policy.enabled",
+		} {
+			if strings.Contains(output, field) {
+				t.Errorf("unexpected false-positive reload warning for %s:\n%s", field, output)
+			}
 		}
-	}
+		return nil
+	})
 }
 
 func TestGenerateCmd_WriteError(t *testing.T) {
@@ -2058,325 +2109,314 @@ func TestGenerateDockerComposeCmd_WriteError(t *testing.T) {
 }
 
 func TestRunCmd_ReloadRejectsMetricsListenChange(t *testing.T) {
-	lc := net.ListenConfig{}
-	ln, listenErr := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if listenErr != nil {
-		t.Fatal(listenErr)
-	}
-	ln2, listenErr2 := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if listenErr2 != nil {
-		_ = ln.Close()
-		t.Fatal(listenErr2)
-	}
-	mainAddr := ln.Addr().String()
-	metricsAddr := ln2.Addr().String()
-	_ = ln.Close()
-	_ = ln2.Close()
+	testport.WithRetry(t, 2, func(addrs []string) error {
+		mainAddr := addrs[0]
+		metricsAddr := addrs[1]
 
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "test.yaml")
-	cfgContent := fmt.Sprintf(`version: 1
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "test.yaml")
+		cfgContent := fmt.Sprintf(`version: 1
 mode: balanced
 metrics_listen: "%s"
 fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
 `, metricsAddr, mainAddr)
-	if writeErr := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); writeErr != nil {
-		t.Fatal(writeErr)
-	}
+		if writeErr := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); writeErr != nil {
+			t.Fatal(writeErr)
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	stderr := &cliTestBuffer{}
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(stderr)
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--config", cfgPath})
+		stderr := &cliTestBuffer{}
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(stderr)
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	// Wait for healthy.
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + mainAddr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "proxy health")
+		// Wait for healthy.
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + mainAddr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "proxy health"); err != nil {
+			cancel()
+			return err
+		}
 
-	// Hot-reload: change metrics_listen (should be rejected).
-	updatedCfg := fmt.Sprintf(`version: 1
+		// Hot-reload: change metrics_listen (should be rejected).
+		updatedCfg := fmt.Sprintf(`version: 1
 mode: balanced
 metrics_listen: "127.0.0.1:19999"
 fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
 `, mainAddr)
-	if writeErr := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); writeErr != nil {
-		t.Fatal(writeErr)
-	}
-
-	waitForCLIOutput(t, stderr, errCh, cancel, "metrics_listen changed")
-
-	cancel()
-	select {
-	case cmdErr := <-errCh:
-		if cmdErr != nil {
-			t.Errorf("unexpected error: %v", cmdErr)
+		if writeErr := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); writeErr != nil {
+			t.Fatal(writeErr)
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
 
-	// Safe to read stderr now that the command has exited.
-	if !stderr.contains("metrics_listen changed") {
-		t.Errorf("expected metrics_listen reload warning, got:\n%s", stderr.String())
-	}
+		waitForCLIOutput(t, stderr, errCh, cancel, "metrics_listen changed")
+
+		cancel()
+		select {
+		case cmdErr := <-errCh:
+			if cmdErr != nil {
+				t.Errorf("unexpected error: %v", cmdErr)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
+		}
+
+		// Safe to read stderr now that the command has exited.
+		if !stderr.contains("metrics_listen changed") {
+			t.Errorf("expected metrics_listen reload warning, got:\n%s", stderr.String())
+		}
+		return nil
+	})
 }
 
 func TestRunCmd_ReloadLicenseKeyChange(t *testing.T) {
-	lc := net.ListenConfig{}
-	ln, listenErr := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if listenErr != nil {
-		t.Fatal(listenErr)
-	}
-	mainAddr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		mainAddr := addrs[0]
 
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "test.yaml")
-	cfgContent := fmt.Sprintf(`version: 1
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "test.yaml")
+		cfgContent := fmt.Sprintf(`version: 1
 mode: balanced
 license_key: "old-key"
 fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
 `, mainAddr)
-	if writeErr := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); writeErr != nil {
-		t.Fatal(writeErr)
-	}
+		if writeErr := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); writeErr != nil {
+			t.Fatal(writeErr)
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	stderr := &cliTestBuffer{}
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(stderr)
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--config", cfgPath})
+		stderr := &cliTestBuffer{}
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(stderr)
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	// Wait for healthy.
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + mainAddr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "proxy health")
+		// Wait for healthy.
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + mainAddr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "proxy health"); err != nil {
+			cancel()
+			return err
+		}
 
-	// Hot-reload: change license_key (should warn).
-	updatedCfg := fmt.Sprintf(`version: 1
+		// Hot-reload: change license_key (should warn).
+		updatedCfg := fmt.Sprintf(`version: 1
 mode: balanced
 license_key: "new-key"
 fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
 `, mainAddr)
-	if writeErr := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); writeErr != nil {
-		t.Fatal(writeErr)
-	}
-
-	waitForCLIOutput(t, stderr, errCh, cancel, "license key inputs changed")
-
-	cancel()
-	select {
-	case cmdErr := <-errCh:
-		if cmdErr != nil {
-			t.Errorf("unexpected error: %v", cmdErr)
+		if writeErr := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); writeErr != nil {
+			t.Fatal(writeErr)
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
 
-	// Verify license change warning appeared.
-	if !stderr.contains("license key inputs changed") {
-		t.Errorf("expected license reload warning, got:\n%s", stderr.String())
-	}
+		waitForCLIOutput(t, stderr, errCh, cancel, "license key inputs changed")
+
+		cancel()
+		select {
+		case cmdErr := <-errCh:
+			if cmdErr != nil {
+				t.Errorf("unexpected error: %v", cmdErr)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
+		}
+
+		// Verify license change warning appeared.
+		if !stderr.contains("license key inputs changed") {
+			t.Errorf("expected license reload warning, got:\n%s", stderr.String())
+		}
+		return nil
+	})
 }
 
 func TestRunCmd_ReloadLicenseNoSpuriousWarning(t *testing.T) {
-	lc := net.ListenConfig{}
-	ln, listenErr := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if listenErr != nil {
-		t.Fatal(listenErr)
-	}
-	mainAddr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		mainAddr := addrs[0]
 
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "test.yaml")
-	cfgContent := fmt.Sprintf(`version: 1
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "test.yaml")
+		cfgContent := fmt.Sprintf(`version: 1
 mode: balanced
 license_key: "same-key"
 fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
 `, mainAddr)
-	if writeErr := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); writeErr != nil {
-		t.Fatal(writeErr)
-	}
+		if writeErr := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); writeErr != nil {
+			t.Fatal(writeErr)
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	stderr := &cliTestBuffer{}
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(stderr)
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--config", cfgPath})
+		stderr := &cliTestBuffer{}
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(stderr)
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	// Wait for healthy.
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + mainAddr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "proxy health")
+		// Wait for healthy.
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + mainAddr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "proxy health"); err != nil {
+			cancel()
+			return err
+		}
 
-	// Hot-reload: same license_key, change something else (mode).
-	updatedCfg := fmt.Sprintf(`version: 1
+		// Hot-reload: same license_key, change something else (mode).
+		updatedCfg := fmt.Sprintf(`version: 1
 mode: audit
 license_key: "same-key"
 fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
 `, mainAddr)
-	if writeErr := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); writeErr != nil {
-		t.Fatal(writeErr)
-	}
-
-	waitForCLIOutput(t, stderr, errCh, cancel, "mode downgraded from balanced to audit")
-
-	cancel()
-	select {
-	case cmdErr := <-errCh:
-		if cmdErr != nil {
-			t.Errorf("unexpected error: %v", cmdErr)
+		if writeErr := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); writeErr != nil {
+			t.Fatal(writeErr)
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
 
-	// Verify NO license warning appeared (same key, just mode change).
-	if stderr.contains("license") {
-		t.Errorf("unexpected license warning on non-license reload:\n%s", stderr.String())
-	}
+		waitForCLIOutput(t, stderr, errCh, cancel, "mode downgraded from balanced to audit")
+
+		cancel()
+		select {
+		case cmdErr := <-errCh:
+			if cmdErr != nil {
+				t.Errorf("unexpected error: %v", cmdErr)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
+		}
+
+		// Verify NO license warning appeared (same key, just mode change).
+		if stderr.contains("license") {
+			t.Errorf("unexpected license warning on non-license reload:\n%s", stderr.String())
+		}
+		return nil
+	})
 }
 
 func TestRunCmd_ReloadLicenseFileChange(t *testing.T) {
-	lc := net.ListenConfig{}
-	ln, listenErr := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if listenErr != nil {
-		t.Fatal(listenErr)
-	}
-	mainAddr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		mainAddr := addrs[0]
 
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "test.yaml")
-	cfgContent := fmt.Sprintf(`version: 1
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "test.yaml")
+		cfgContent := fmt.Sprintf(`version: 1
 mode: balanced
 fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
 `, mainAddr)
-	if writeErr := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); writeErr != nil {
-		t.Fatal(writeErr)
-	}
+		if writeErr := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); writeErr != nil {
+			t.Fatal(writeErr)
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	stderr := &cliTestBuffer{}
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(stderr)
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--config", cfgPath})
+		stderr := &cliTestBuffer{}
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(stderr)
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	// Wait for healthy.
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + mainAddr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "proxy health")
+		// Wait for healthy.
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + mainAddr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "proxy health"); err != nil {
+			cancel()
+			return err
+		}
 
-	// Write a license token file so the config reload succeeds.
-	tokenPath := filepath.Join(dir, "license.token")
-	if writeErr := os.WriteFile(tokenPath, []byte("some-token"), 0o600); writeErr != nil {
-		t.Fatal(writeErr)
-	}
+		// Write a license token file so the config reload succeeds.
+		tokenPath := filepath.Join(dir, "license.token")
+		if writeErr := os.WriteFile(tokenPath, []byte("some-token"), 0o600); writeErr != nil {
+			t.Fatal(writeErr)
+		}
 
-	// Hot-reload: add license_file (should warn about license inputs change).
-	updatedCfg := fmt.Sprintf(`version: 1
+		// Hot-reload: add license_file (should warn about license inputs change).
+		updatedCfg := fmt.Sprintf(`version: 1
 mode: balanced
 license_file: "license.token"
 fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
 `, mainAddr)
-	if writeErr := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); writeErr != nil {
-		t.Fatal(writeErr)
-	}
-
-	waitForCLIOutput(t, stderr, errCh, cancel, "license key inputs changed")
-
-	cancel()
-	select {
-	case cmdErr := <-errCh:
-		if cmdErr != nil {
-			t.Errorf("unexpected error: %v", cmdErr)
+		if writeErr := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); writeErr != nil {
+			t.Fatal(writeErr)
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
 
-	// Verify license change warning appeared from license_file addition.
-	if !stderr.contains("license key inputs changed") {
-		t.Errorf("expected license reload warning from license_file change, got:\n%s", stderr.String())
-	}
+		waitForCLIOutput(t, stderr, errCh, cancel, "license key inputs changed")
+
+		cancel()
+		select {
+		case cmdErr := <-errCh:
+			if cmdErr != nil {
+				t.Errorf("unexpected error: %v", cmdErr)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
+		}
+
+		// Verify license change warning appeared from license_file addition.
+		if !stderr.contains("license key inputs changed") {
+			t.Errorf("expected license reload warning from license_file change, got:\n%s", stderr.String())
+		}
+		return nil
+	})
 }
 
 func TestRunCmd_WebSocketBanner(t *testing.T) {
-	lc := net.ListenConfig{}
-	ln, listenErr := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if listenErr != nil {
-		t.Fatal(listenErr)
-	}
-	addr := ln.Addr().String()
-	_ = ln.Close()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		addr := addrs[0]
 
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "test.yaml")
-	cfgContent := fmt.Sprintf(`version: 1
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "test.yaml")
+		cfgContent := fmt.Sprintf(`version: 1
 mode: balanced
 fetch_proxy:
   listen: "%s"
@@ -2385,41 +2425,46 @@ websocket_proxy:
   enabled: true
   max_message_bytes: 65536
 `, addr)
-	if writeErr := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); writeErr != nil {
-		t.Fatal(writeErr)
-	}
+		if writeErr := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); writeErr != nil {
+			t.Fatal(writeErr)
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := rootCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"run", "--config", cfgPath})
-	stderr := &cliTestBuffer{}
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(stderr)
+		cmd := rootCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"run", "--config", cfgPath})
+		stderr := &cliTestBuffer{}
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(stderr)
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Execute()
-	}()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cmd.Execute()
+		}()
 
-	// Wait for healthy.
-	client := &http.Client{Timeout: time.Second}
-	healthURL := "http://" + addr + "/health"
-	waitForRunHTTP(t, ctx, client, errCh, cancel, healthURL, func(resp *http.Response) bool {
-		return resp.StatusCode == http.StatusOK
-	}, "proxy health")
+		// Wait for healthy.
+		client := &http.Client{Timeout: time.Second}
+		healthURL := "http://" + addr + "/health"
+		if err := waitForRunHTTPResult(ctx, client, errCh, healthURL, func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK
+		}, "proxy health"); err != nil {
+			cancel()
+			return err
+		}
 
-	waitForCLIOutput(t, stderr, errCh, cancel, "WebSocket proxy enabled")
-	if !stderr.contains("WebSocket proxy enabled") {
-		t.Errorf("expected WS banner, got:\n%s", stderr.String())
-	}
+		waitForCLIOutput(t, stderr, errCh, cancel, "WebSocket proxy enabled")
+		if !stderr.contains("WebSocket proxy enabled") {
+			t.Errorf("expected WS banner, got:\n%s", stderr.String())
+		}
 
-	cancel()
-	select {
-	case <-errCh:
-	case <-time.After(10 * time.Second):
-		t.Fatal("run did not shut down")
-	}
+		cancel()
+		select {
+		case <-errCh:
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not shut down")
+		}
+		return nil
+	})
 }

--- a/internal/cli/runtime/run_test.go
+++ b/internal/cli/runtime/run_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/edition"
 	"github.com/luckyPipewrench/pipelock/internal/emit"
 	plsentry "github.com/luckyPipewrench/pipelock/internal/sentry"
-	"github.com/luckyPipewrench/pipelock/internal/testwait"
+	"github.com/luckyPipewrench/pipelock/internal/testport"
 )
 
 // syncBuffer is defined in helpers_test.go (no build constraint).
@@ -502,51 +502,38 @@ func TestBuildEmitSinks_AllThreeSinks(t *testing.T) {
 	}
 }
 
-// freePort returns a free TCP port on localhost.
-func freePort(t *testing.T) string {
-	t.Helper()
-	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp4", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("free port: %v", err)
-	}
-	addr := ln.Addr().String()
-	_ = ln.Close()
-	return addr
-}
-
-// waitForPort polls a TCP address until it accepts connections or times out.
-func waitForPort(t *testing.T, addr string) {
-	t.Helper()
-	dialer := &net.Dialer{Timeout: 50 * time.Millisecond}
-	testwait.For(t, 15*time.Second, func() bool {
-		conn, err := dialer.DialContext(context.Background(), "tcp4", addr)
-		if err == nil {
-			_ = conn.Close()
-			return true
-		}
-		return false
-	}, "port %s to accept connections", addr)
-}
-
-// waitForPortOrCommandExit polls a TCP address while also surfacing early
+// waitForPortOrCommandExitResult polls a TCP address while also surfacing early
 // command failures. It avoids hiding startup bind/config errors behind a
 // generic readiness timeout.
-func waitForPortOrCommandExit(t *testing.T, addr string, cmdErr <-chan error, stderr fmt.Stringer) {
-	t.Helper()
+func waitForPortOrCommandExitResult(addr string, cmdErr <-chan error, stderr fmt.Stringer) error {
 	dialer := &net.Dialer{Timeout: 50 * time.Millisecond}
-	testwait.For(t, 15*time.Second, func() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
 		select {
 		case err := <-cmdErr:
-			t.Fatalf("RunCmd exited before port %s was ready: %v\nstderr:\n%s", addr, err, stderr.String())
+			return fmt.Errorf("RunCmd exited before port %s was ready: %w\nstderr:\n%s", addr, err, stderr.String())
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for port %s to accept connections: %w\nstderr:\n%s", addr, ctx.Err(), stderr.String())
 		default:
 		}
 		conn, err := dialer.DialContext(context.Background(), "tcp4", addr)
 		if err == nil {
 			_ = conn.Close()
-			return true
+			return nil
 		}
-		return false
-	}, "port %s to accept connections\nstderr:\n%s", addr, stderr.String())
+		select {
+		case err := <-cmdErr:
+			return fmt.Errorf("RunCmd exited before port %s was ready: %w\nstderr:\n%s", addr, err, stderr.String())
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for port %s to accept connections: %w\nstderr:\n%s", addr, ctx.Err(), stderr.String())
+		case <-ticker.C:
+		}
+	}
 }
 
 // doGet issues a context-aware GET and fails the test on error.
@@ -564,10 +551,11 @@ func doGet(t *testing.T, client *http.Client, url string) *http.Response {
 }
 
 func TestRunCmd_MetricsPortIsolation(t *testing.T) {
-	mainAddr := freePort(t)
-	metricsAddr := freePort(t)
+	testport.WithRetry(t, 2, func(addrs []string) error {
+		mainAddr := addrs[0]
+		metricsAddr := addrs[1]
 
-	cfgYAML := fmt.Sprintf(`version: 1
+		cfgYAML := fmt.Sprintf(`version: 1
 mode: balanced
 metrics_listen: %q
 fetch_proxy:
@@ -579,129 +567,138 @@ logging:
   output: stdout
 `, metricsAddr, mainAddr)
 
-	tmpFile, err := os.CreateTemp(t.TempDir(), "pipelock-*.yaml")
-	if err != nil {
-		t.Fatalf("create temp config: %v", err)
-	}
-	if _, err := tmpFile.WriteString(cfgYAML); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	_ = tmpFile.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := RunCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"--config", tmpFile.Name()})
-	var stderr bytes.Buffer
-	cmd.SetErr(&stderr)
-	cmd.SetOut(&stderr)
-
-	cmdErr := make(chan error, 1)
-	go func() {
-		cmdErr <- cmd.Execute()
-	}()
-
-	// Wait for both ports.
-	waitForPort(t, mainAddr)
-	waitForPort(t, metricsAddr)
-
-	client := &http.Client{Timeout: 2 * time.Second}
-
-	// Main port: /health should work.
-	resp := doGet(t, client, "http://"+mainAddr+"/health")
-	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("/health: want 200, got %d", resp.StatusCode)
-	}
-
-	// Main port: /metrics should 404 (isolated to metrics port).
-	resp = doGet(t, client, "http://"+mainAddr+"/metrics")
-	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusNotFound {
-		t.Errorf("/metrics on main port: want 404, got %d", resp.StatusCode)
-	}
-
-	// Main port: /stats should 404.
-	resp = doGet(t, client, "http://"+mainAddr+"/stats")
-	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusNotFound {
-		t.Errorf("/stats on main port: want 404, got %d", resp.StatusCode)
-	}
-
-	// Metrics port: /metrics should 200.
-	resp = doGet(t, client, "http://"+metricsAddr+"/metrics")
-	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("/metrics on metrics port: want 200, got %d", resp.StatusCode)
-	}
-
-	// Metrics port: /stats should 200.
-	resp = doGet(t, client, "http://"+metricsAddr+"/stats")
-	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("/stats on metrics port: want 200, got %d", resp.StatusCode)
-	}
-
-	// Shut down.
-	cancel()
-	select {
-	case err := <-cmdErr:
+		tmpFile, err := os.CreateTemp(t.TempDir(), "pipelock-*.yaml")
 		if err != nil {
-			t.Errorf("RunCmd returned error: %v", err)
+			t.Fatalf("create temp config: %v", err)
 		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("RunCmd did not exit within 5s")
-	}
+		if _, err := tmpFile.WriteString(cfgYAML); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		_ = tmpFile.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		cmd := RunCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"--config", tmpFile.Name()})
+		var stderr bytes.Buffer
+		cmd.SetErr(&stderr)
+		cmd.SetOut(&stderr)
+
+		cmdErr := make(chan error, 1)
+		go func() {
+			cmdErr <- cmd.Execute()
+		}()
+
+		// Wait for both ports.
+		if err := waitForPortOrCommandExitResult(mainAddr, cmdErr, &stderr); err != nil {
+			cancel()
+			return err
+		}
+		if err := waitForPortOrCommandExitResult(metricsAddr, cmdErr, &stderr); err != nil {
+			cancel()
+			return err
+		}
+
+		client := &http.Client{Timeout: 2 * time.Second}
+
+		// Main port: /health should work.
+		resp := doGet(t, client, "http://"+mainAddr+"/health")
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("/health: want 200, got %d", resp.StatusCode)
+		}
+
+		// Main port: /metrics should 404 (isolated to metrics port).
+		resp = doGet(t, client, "http://"+mainAddr+"/metrics")
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("/metrics on main port: want 404, got %d", resp.StatusCode)
+		}
+
+		// Main port: /stats should 404.
+		resp = doGet(t, client, "http://"+mainAddr+"/stats")
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("/stats on main port: want 404, got %d", resp.StatusCode)
+		}
+
+		// Metrics port: /metrics should 200.
+		resp = doGet(t, client, "http://"+metricsAddr+"/metrics")
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("/metrics on metrics port: want 200, got %d", resp.StatusCode)
+		}
+
+		// Metrics port: /stats should 200.
+		resp = doGet(t, client, "http://"+metricsAddr+"/stats")
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("/stats on metrics port: want 200, got %d", resp.StatusCode)
+		}
+
+		// Shut down.
+		cancel()
+		select {
+		case err := <-cmdErr:
+			if err != nil {
+				t.Errorf("RunCmd returned error: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("RunCmd did not exit within 5s")
+		}
+		return nil
+	})
 }
 
 func TestRunCmd_RedactionWiresMCPListenerAndReverseProxy(t *testing.T) {
-	mainAddr := freePort(t)
-	reverseAddr := freePort(t)
-	mcpAddr := freePort(t)
-	secret := "AKIA" + "IOSFODNN7EXAMPLE"
+	testport.WithRetry(t, 3, func(addrs []string) error {
+		mainAddr := addrs[0]
+		reverseAddr := addrs[1]
+		mcpAddr := addrs[2]
+		secret := "AKIA" + "IOSFODNN7EXAMPLE"
 
-	var reverseBody atomic.Value
-	reverseUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		reverseBody.Store(string(body))
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"status":"ok"}`))
-	}))
-	defer reverseUpstream.Close()
+		var reverseBody atomic.Value
+		reverseUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			reverseBody.Store(string(body))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		}))
+		defer reverseUpstream.Close()
 
-	var mcpBody atomic.Value
-	mcpUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		mcpBody.Store(string(body))
+		var mcpBody atomic.Value
+		mcpUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			mcpBody.Store(string(body))
 
-		var request struct {
-			ID json.RawMessage `json:"id"`
-		}
-		if err := json.Unmarshal(body, &request); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
+			var request struct {
+				ID json.RawMessage `json:"id"`
+			}
+			if err := json.Unmarshal(body, &request); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 
-		w.Header().Set("Content-Type", "application/json")
-		response := map[string]any{
-			"jsonrpc": "2.0",
-			"id":      request.ID,
-			"result": map[string]any{
-				"content": []map[string]any{{
-					"type": "text",
-					"text": "ok",
-				}},
-			},
-		}
-		if err := json.NewEncoder(w).Encode(response); err != nil {
-			t.Fatalf("Encode(response): %v", err)
-		}
-	}))
-	defer mcpUpstream.Close()
+			w.Header().Set("Content-Type", "application/json")
+			response := map[string]any{
+				"jsonrpc": "2.0",
+				"id":      request.ID,
+				"result": map[string]any{
+					"content": []map[string]any{{
+						"type": "text",
+						"text": "ok",
+					}},
+				},
+			}
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				t.Fatalf("Encode(response): %v", err)
+			}
+		}))
+		defer mcpUpstream.Close()
 
-	cfgYAML := fmt.Sprintf(`version: 1
+		cfgYAML := fmt.Sprintf(`version: 1
 mode: balanced
 enforce: false
 fetch_proxy:
@@ -732,93 +729,104 @@ logging:
   output: stdout
 `, mainAddr, reverseAddr, reverseUpstream.URL)
 
-	tmpFile, err := os.CreateTemp(t.TempDir(), "pipelock-redaction-*.yaml")
-	if err != nil {
-		t.Fatalf("create temp config: %v", err)
-	}
-	if _, err := tmpFile.WriteString(cfgYAML); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	_ = tmpFile.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := RunCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{
-		"--config", tmpFile.Name(),
-		"--mcp-listen", mcpAddr,
-		"--mcp-upstream", mcpUpstream.URL,
-	})
-	var stderr syncBuffer
-	cmd.SetErr(&stderr)
-	cmd.SetOut(&stderr)
-
-	cmdErr := make(chan error, 1)
-	go func() {
-		cmdErr <- cmd.Execute()
-	}()
-
-	waitForPortOrCommandExit(t, mainAddr, cmdErr, &stderr)
-	waitForPortOrCommandExit(t, reverseAddr, cmdErr, &stderr)
-	waitForPortOrCommandExit(t, mcpAddr, cmdErr, &stderr)
-
-	reverseReq, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://"+reverseAddr+"/api",
-		strings.NewReader(`{"prompt":"use `+secret+` to deploy"}`))
-	if err != nil {
-		t.Fatalf("new reverse request: %v", err)
-	}
-	reverseReq.Header.Set("Content-Type", "application/json")
-	reverseResp, err := http.DefaultClient.Do(reverseReq)
-	if err != nil {
-		t.Fatalf("reverse proxy POST: %v", err)
-	}
-	_ = reverseResp.Body.Close()
-	if reverseResp.StatusCode != http.StatusOK {
-		t.Fatalf("reverse proxy status = %d, want 200", reverseResp.StatusCode)
-	}
-
-	mcpReq, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://"+mcpAddr+"/",
-		strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"prompt":"use `+secret+` to deploy"}}}`))
-	if err != nil {
-		t.Fatalf("new mcp request: %v", err)
-	}
-	mcpReq.Header.Set("Content-Type", "application/json")
-	mcpResp, err := http.DefaultClient.Do(mcpReq)
-	if err != nil {
-		t.Fatalf("mcp listener POST: %v", err)
-	}
-	_ = mcpResp.Body.Close()
-	if mcpResp.StatusCode != http.StatusOK {
-		t.Fatalf("mcp listener status = %d, want 200", mcpResp.StatusCode)
-	}
-
-	gotReverse, _ := reverseBody.Load().(string)
-	if strings.Contains(gotReverse, secret) {
-		t.Fatalf("reverse upstream leaked secret: %s", gotReverse)
-	}
-	if !strings.Contains(gotReverse, "<pl:aws-access-key:1>") {
-		t.Fatalf("reverse upstream missing placeholder: %s", gotReverse)
-	}
-
-	gotMCP, _ := mcpBody.Load().(string)
-	if strings.Contains(gotMCP, secret) {
-		t.Fatalf("mcp upstream leaked secret: %s", gotMCP)
-	}
-	if !strings.Contains(gotMCP, "<pl:aws-access-key:1>") {
-		t.Fatalf("mcp upstream missing placeholder: %s", gotMCP)
-	}
-
-	cancel()
-	select {
-	case err := <-cmdErr:
+		tmpFile, err := os.CreateTemp(t.TempDir(), "pipelock-redaction-*.yaml")
 		if err != nil {
-			t.Errorf("RunCmd returned error: %v\nstderr:\n%s", err, stderr.String())
+			t.Fatalf("create temp config: %v", err)
 		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("RunCmd did not exit within 5s")
-	}
+		if _, err := tmpFile.WriteString(cfgYAML); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		_ = tmpFile.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		cmd := RunCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{
+			"--config", tmpFile.Name(),
+			"--mcp-listen", mcpAddr,
+			"--mcp-upstream", mcpUpstream.URL,
+		})
+		var stderr syncBuffer
+		cmd.SetErr(&stderr)
+		cmd.SetOut(&stderr)
+
+		cmdErr := make(chan error, 1)
+		go func() {
+			cmdErr <- cmd.Execute()
+		}()
+
+		if err := waitForPortOrCommandExitResult(mainAddr, cmdErr, &stderr); err != nil {
+			cancel()
+			return err
+		}
+		if err := waitForPortOrCommandExitResult(reverseAddr, cmdErr, &stderr); err != nil {
+			cancel()
+			return err
+		}
+		if err := waitForPortOrCommandExitResult(mcpAddr, cmdErr, &stderr); err != nil {
+			cancel()
+			return err
+		}
+
+		reverseReq, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://"+reverseAddr+"/api",
+			strings.NewReader(`{"prompt":"use `+secret+` to deploy"}`))
+		if err != nil {
+			t.Fatalf("new reverse request: %v", err)
+		}
+		reverseReq.Header.Set("Content-Type", "application/json")
+		reverseResp, err := http.DefaultClient.Do(reverseReq)
+		if err != nil {
+			t.Fatalf("reverse proxy POST: %v", err)
+		}
+		_ = reverseResp.Body.Close()
+		if reverseResp.StatusCode != http.StatusOK {
+			t.Fatalf("reverse proxy status = %d, want 200", reverseResp.StatusCode)
+		}
+
+		mcpReq, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://"+mcpAddr+"/",
+			strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"prompt":"use `+secret+` to deploy"}}}`))
+		if err != nil {
+			t.Fatalf("new mcp request: %v", err)
+		}
+		mcpReq.Header.Set("Content-Type", "application/json")
+		mcpResp, err := http.DefaultClient.Do(mcpReq)
+		if err != nil {
+			t.Fatalf("mcp listener POST: %v", err)
+		}
+		_ = mcpResp.Body.Close()
+		if mcpResp.StatusCode != http.StatusOK {
+			t.Fatalf("mcp listener status = %d, want 200", mcpResp.StatusCode)
+		}
+
+		gotReverse, _ := reverseBody.Load().(string)
+		if strings.Contains(gotReverse, secret) {
+			t.Fatalf("reverse upstream leaked secret: %s", gotReverse)
+		}
+		if !strings.Contains(gotReverse, "<pl:aws-access-key:1>") {
+			t.Fatalf("reverse upstream missing placeholder: %s", gotReverse)
+		}
+
+		gotMCP, _ := mcpBody.Load().(string)
+		if strings.Contains(gotMCP, secret) {
+			t.Fatalf("mcp upstream leaked secret: %s", gotMCP)
+		}
+		if !strings.Contains(gotMCP, "<pl:aws-access-key:1>") {
+			t.Fatalf("mcp upstream missing placeholder: %s", gotMCP)
+		}
+
+		cancel()
+		select {
+		case err := <-cmdErr:
+			if err != nil {
+				t.Errorf("RunCmd returned error: %v\nstderr:\n%s", err, stderr.String())
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("RunCmd did not exit within 5s")
+		}
+		return nil
+	})
 }
 
 func TestAgentHandler(t *testing.T) {
@@ -1233,8 +1241,8 @@ logging:
 		"--config", cfgPath,
 		// Ephemeral MCP listen port: the test never dials it, it only needs
 		// the listener goroutine to spawn (and read s.logger) before the held
-		// fetch port forces the early-error return. :0 avoids the freePort
-		// close-then-reuse TOCTOU for a port that is never connected to.
+		// fetch port forces the early-error return. :0 avoids close-then-reuse
+		// TOCTOU for a port that is never connected to.
 		"--mcp-listen", "127.0.0.1:0",
 		"--mcp-upstream", mcpUpstream.URL,
 	})
@@ -1262,14 +1270,15 @@ logging:
 // its goroutine-scoped close on a clean shutdown (no approval is ever
 // triggered: the test only hits /health).
 func TestRunCmd_MCPListenerAskModeShutdown(t *testing.T) {
-	mainAddr := freePort(t)
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		mainAddr := addrs[0]
 
-	mcpUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer mcpUpstream.Close()
+		mcpUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer mcpUpstream.Close()
 
-	cfgYAML := fmt.Sprintf(`version: 1
+		cfgYAML := fmt.Sprintf(`version: 1
 mode: balanced
 response_scanning:
   enabled: true
@@ -1282,39 +1291,44 @@ logging:
   output: stdout
 `, mainAddr)
 
-	cfgPath := filepath.Join(t.TempDir(), "pipelock-askmode.yaml")
-	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := RunCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{
-		"--config", cfgPath,
-		"--mcp-listen", "127.0.0.1:0",
-		"--mcp-upstream", mcpUpstream.URL,
-	})
-	var stderr syncBuffer
-	cmd.SetErr(&stderr)
-	cmd.SetOut(&stderr)
-
-	cmdErr := make(chan error, 1)
-	go func() {
-		cmdErr <- cmd.Execute()
-	}()
-
-	waitForPort(t, mainAddr)
-
-	cancel()
-	select {
-	case err := <-cmdErr:
-		if err != nil {
-			t.Errorf("RunCmd returned error: %v", err)
+		cfgPath := filepath.Join(t.TempDir(), "pipelock-askmode.yaml")
+		if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
 		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("RunCmd did not exit within 5s")
-	}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		cmd := RunCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{
+			"--config", cfgPath,
+			"--mcp-listen", "127.0.0.1:0",
+			"--mcp-upstream", mcpUpstream.URL,
+		})
+		var stderr syncBuffer
+		cmd.SetErr(&stderr)
+		cmd.SetOut(&stderr)
+
+		cmdErr := make(chan error, 1)
+		go func() {
+			cmdErr <- cmd.Execute()
+		}()
+
+		if err := waitForPortOrCommandExitResult(mainAddr, cmdErr, &stderr); err != nil {
+			cancel()
+			return err
+		}
+
+		cancel()
+		select {
+		case err := <-cmdErr:
+			if err != nil {
+				t.Errorf("RunCmd returned error: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("RunCmd did not exit within 5s")
+		}
+		return nil
+	})
 }

--- a/internal/cli/runtime/server_conductor_test.go
+++ b/internal/cli/runtime/server_conductor_test.go
@@ -140,7 +140,7 @@ func (serverConductorBlockingRunner) Run(ctx context.Context) error {
 
 func TestServer_StartRunsConductorRemoteKillPoller(t *testing.T) {
 	s, buf := newTestServer(t, func(o *ServerOpts) {
-		o.Listen = newServerTestFreePort(t)
+		o.Listen = serverTestEphemeralListen
 		o.ListenChanged = true
 	})
 	poller, err := emergency.NewRemoteKillPoller(emergency.RemoteKillPollerConfig{
@@ -180,7 +180,7 @@ func TestServer_StartRunsConductorRemoteKillPoller(t *testing.T) {
 
 func TestServer_StartRunsConductorBundlePoller(t *testing.T) {
 	s, buf := newTestServer(t, func(o *ServerOpts) {
-		o.Listen = newServerTestFreePort(t)
+		o.Listen = serverTestEphemeralListen
 		o.ListenChanged = true
 	})
 	s.conductorBundle = serverConductorBlockingRunner{}

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -6,7 +6,6 @@ package runtime
 import (
 	"context"
 	"io"
-	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -30,19 +29,6 @@ const (
 type stringerFunc func() string
 
 func (f stringerFunc) String() string { return f() }
-
-// newServerTestFreePort returns a free 127.0.0.1 TCP port by binding and
-// releasing it, same pattern used in run_test.go:freePort.
-func newServerTestFreePort(t *testing.T) string {
-	t.Helper()
-	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp4", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("free port: %v", err)
-	}
-	addr := ln.Addr().String()
-	_ = ln.Close()
-	return addr
-}
 
 func writeServerTestConfig(t *testing.T, content string) string {
 	t.Helper()
@@ -97,7 +83,7 @@ func waitForServerOutput(t *testing.T, buf *syncBuffer, want string) {
 // drive Mode and FetchProxy.Listen overrides on the loaded config. This is
 // the behavior RunCmd used to implement via cobra.Flag.Changed().
 func TestNewServer_AppliesCLIOverrides(t *testing.T) {
-	listenAddr := newServerTestFreePort(t)
+	listenAddr := serverTestEphemeralListen
 	s, _ := newTestServer(t, func(o *ServerOpts) {
 		o.Mode = config.ModeAudit
 		o.ModeChanged = true
@@ -142,7 +128,7 @@ func TestNewServer_ValidatesListenerFlagPairs(t *testing.T) {
 	}{
 		{
 			name: "mcp listen without upstream",
-			opts: ServerOpts{MCPListen: newServerTestFreePort(t)},
+			opts: ServerOpts{MCPListen: serverTestEphemeralListen},
 			want: "--mcp-listen requires --mcp-upstream",
 		},
 		{
@@ -152,7 +138,7 @@ func TestNewServer_ValidatesListenerFlagPairs(t *testing.T) {
 		},
 		{
 			name: "invalid mcp upstream",
-			opts: ServerOpts{MCPListen: newServerTestFreePort(t), MCPUpstream: "ftp://127.0.0.1:1"},
+			opts: ServerOpts{MCPListen: serverTestEphemeralListen, MCPUpstream: "ftp://127.0.0.1:1"},
 			want: "invalid --mcp-upstream",
 		},
 		{
@@ -332,7 +318,7 @@ func TestNewServer_FlightRecorderAndEnvelopeFromConfig(t *testing.T) {
 // "listener mode" notices to stderr.
 func TestNewServer_ResolveRuntimeRuns(t *testing.T) {
 	s, buf := newTestServer(t, func(o *ServerOpts) {
-		o.MCPListen = newServerTestFreePort(t)
+		o.MCPListen = serverTestEphemeralListen
 		o.MCPUpstream = serverTestUpstreamURL
 	})
 	if s.runtimeMode != config.RuntimeForwardWithMCPListener {
@@ -361,7 +347,7 @@ func TestNewServer_ResolveRuntimeRuns(t *testing.T) {
 // pipelock instance.
 func TestServer_StartShutdown(t *testing.T) {
 	s, _ := newTestServer(t, func(o *ServerOpts) {
-		o.Listen = newServerTestFreePort(t)
+		o.Listen = serverTestEphemeralListen
 		o.ListenChanged = true
 	})
 
@@ -404,7 +390,7 @@ func TestServer_StartArmsFileSentry(t *testing.T) {
 
 	s, buf := newTestServer(t, func(o *ServerOpts) {
 		o.ConfigFile = cfgPath
-		o.Listen = newServerTestFreePort(t)
+		o.Listen = serverTestEphemeralListen
 		o.ListenChanged = true
 	})
 
@@ -905,7 +891,7 @@ func TestServer_MCPListener_ResponseScanningFallback(t *testing.T) {
 	// can verify listener mode does NOT silently re-enable it (that is
 	// MCP proxy mode's responsibility).
 	s, buf := newTestServer(t, func(o *ServerOpts) {
-		o.MCPListen = newServerTestFreePort(t)
+		o.MCPListen = serverTestEphemeralListen
 		o.MCPUpstream = serverTestUpstreamURL
 	})
 
@@ -930,7 +916,7 @@ func TestServer_MCPListener_ResponseScanningFallback(t *testing.T) {
 // race the watcher's read of s.logger/s.sentry.
 func TestServer_StartJoinsLicenseExpiryWatcher(t *testing.T) {
 	s, _ := newTestServer(t, func(o *ServerOpts) {
-		o.Listen = newServerTestFreePort(t)
+		o.Listen = serverTestEphemeralListen
 		o.ListenChanged = true
 	})
 	// Set before launching Start: goroutine creation establishes the

--- a/internal/testport/testport.go
+++ b/internal/testport/testport.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package testport provides TOCTOU-tolerant TCP port selection for tests that
+// must hand a concrete listen address to a server they then start.
+//
+// Servers like `pipelock run` bind from an address string rather than an
+// inherited listener fd, so a test cannot pass an already-open listener; it
+// must pick a free port, close it, and let the server re-bind it. That
+// close-then-rebind window is an unavoidable TOCTOU: another process — or a
+// sibling test under `go test -count=N` or parallel packages — can grab the
+// port in between. WithRetry tolerates that by re-running the attempt with a
+// fresh port whenever the server reports the address is already in use.
+//
+// For listeners the test never dials, prefer "127.0.0.1:0" directly: the
+// server binds an ephemeral port itself and there is no window to lose.
+package testport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// maxAttempts bounds the retry loop. A genuine collision is rare and clears
+// within one retry; a persistent bind failure (e.g. the ephemeral range
+// exhausted) should surface quickly rather than spin, so the ceiling stays low.
+const maxAttempts = 5
+
+// ListenAddrs returns count distinct free loopback TCP addresses. All listeners
+// are opened simultaneously so the returned addresses are guaranteed distinct
+// from each other, then closed before returning so the caller can rebind them.
+func ListenAddrs(t testing.TB, count int) []string {
+	t.Helper()
+	if count < 0 {
+		t.Fatalf("listen address count must be non-negative, got %d", count)
+	}
+
+	lc := net.ListenConfig{}
+	listeners := make([]net.Listener, 0, count)
+	defer func() {
+		for _, ln := range listeners {
+			_ = ln.Close()
+		}
+	}()
+
+	addrs := make([]string, 0, count)
+	for range count {
+		ln, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		listeners = append(listeners, ln)
+		addrs = append(addrs, ln.Addr().String())
+	}
+	return addrs
+}
+
+// IsBindCollision reports whether err is an "address already in use" bind
+// failure — the only error WithRetry retries. It checks both the typed syscall
+// errno and the string form, since the error is usually wrapped through several
+// layers (cmd.Execute, the wait helper) before reaching the test.
+func IsBindCollision(err error) bool {
+	return err != nil && (errors.Is(err, syscall.EADDRINUSE) ||
+		strings.Contains(err.Error(), "address already in use"))
+}
+
+// WithRetry runs fn with portCount fresh addresses, retrying up to maxAttempts
+// times when fn returns a bind-collision error. Any other error fails the test
+// immediately so real bugs (config errors, genuine startup timeouts) surface
+// fast instead of being masked as a retryable collision. Exhausting the retries
+// also fails the test.
+func WithRetry(t testing.TB, portCount int, fn func(addrs []string) error) {
+	t.Helper()
+	if err := retry(func() []string { return ListenAddrs(t, portCount) }, fn); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+// retry holds the pure retry policy so it is unit-testable without a real
+// *testing.T: testing.TB cannot be faked (it has an unexported method), so the
+// loop is separated from the t.Fatalf wrapper above. addrs supplies a fresh
+// address set per attempt.
+func retry(addrs func() []string, fn func(addrs []string) error) error {
+	var lastErr error
+	for range maxAttempts {
+		err := fn(addrs())
+		if err == nil {
+			return nil
+		}
+		if !IsBindCollision(err) {
+			return fmt.Errorf("test run failed: %w", err)
+		}
+		lastErr = err
+	}
+	return fmt.Errorf("hit port bind collisions after %d attempts: %w", maxAttempts, lastErr)
+}

--- a/internal/testport/testport_test.go
+++ b/internal/testport/testport_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package testport
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+)
+
+func TestListenAddrsReturnsDistinctFreeAddrs(t *testing.T) {
+	const count = 4
+	addrs := ListenAddrs(t, count)
+	if len(addrs) != count {
+		t.Fatalf("ListenAddrs returned %d addrs, want %d", len(addrs), count)
+	}
+
+	seen := make(map[string]struct{}, count)
+	for _, addr := range addrs {
+		if _, _, err := net.SplitHostPort(addr); err != nil {
+			t.Errorf("addr %q is not host:port: %v", addr, err)
+		}
+		if _, dup := seen[addr]; dup {
+			t.Errorf("duplicate addr %q", addr)
+		}
+		seen[addr] = struct{}{}
+
+		// Closed before return, so each addr must be bindable again.
+		ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp4", addr)
+		if err != nil {
+			t.Errorf("addr %q not rebindable: %v", addr, err)
+			continue
+		}
+		_ = ln.Close()
+	}
+}
+
+func TestWithRetrySucceeds(t *testing.T) {
+	const portCount = 2
+	calls := 0
+	WithRetry(t, portCount, func(addrs []string) error {
+		calls++
+		if len(addrs) != portCount {
+			t.Errorf("fn got %d addrs, want %d", len(addrs), portCount)
+		}
+		return nil
+	})
+	if calls != 1 {
+		t.Errorf("fn called %d times, want 1", calls)
+	}
+}
+
+func TestIsBindCollision(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"typed errno", syscall.EADDRINUSE, true},
+		{"wrapped errno", fmt.Errorf("run exited early: %w", syscall.EADDRINUSE), true},
+		{"string form", errors.New("listen tcp 127.0.0.1:8080: bind: address already in use"), true},
+		{"unrelated", errors.New("config validation failed"), false},
+		{"connection refused", syscall.ECONNREFUSED, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsBindCollision(tc.err); got != tc.want {
+				t.Errorf("IsBindCollision(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRetrySucceedsFirstAttempt(t *testing.T) {
+	calls := 0
+	err := retry(stubAddrs, func([]string) error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("retry returned %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Errorf("fn called %d times, want 1", calls)
+	}
+}
+
+func TestRetryRetriesOnCollisionThenSucceeds(t *testing.T) {
+	calls := 0
+	err := retry(stubAddrs, func([]string) error {
+		calls++
+		if calls < 3 {
+			return fmt.Errorf("startup: %w", syscall.EADDRINUSE)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("retry returned %v, want nil", err)
+	}
+	if calls != 3 {
+		t.Errorf("fn called %d times, want 3", calls)
+	}
+}
+
+func TestRetryFailsFastOnNonCollision(t *testing.T) {
+	calls := 0
+	sentinel := errors.New("config validation failed")
+	err := retry(stubAddrs, func([]string) error {
+		calls++
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("retry error = %v, want wrapped %v", err, sentinel)
+	}
+	if calls != 1 {
+		t.Errorf("fn called %d times, want 1 (no retry on real failure)", calls)
+	}
+}
+
+func TestRetryExhaustsOnPersistentCollision(t *testing.T) {
+	calls := 0
+	err := retry(stubAddrs, func([]string) error {
+		calls++
+		return fmt.Errorf("startup: %w", syscall.EADDRINUSE)
+	})
+	if !errors.Is(err, syscall.EADDRINUSE) {
+		t.Fatalf("retry error = %v, want wrapped EADDRINUSE", err)
+	}
+	if calls != maxAttempts {
+		t.Errorf("fn called %d times, want %d", calls, maxAttempts)
+	}
+}
+
+// stubAddrs supplies addresses without touching the network so the retry policy
+// can be exercised independently of real port allocation.
+func stubAddrs() []string { return []string{"127.0.0.1:1"} }


### PR DESCRIPTION
## Summary

- add internal/testport for bounded retry-on-bind-collision test helpers
- replace close-then-reuse listener address patterns in CLI run tests with retry-on-collision
- use 127.0.0.1:0 directly in server tests that never dial the listener address
- cover the helper retry policy and bind-collision detection with focused tests

## Why

Several CLI/runtime tests selected a free port by binding 127.0.0.1:0, closing the listener, then passing that address into pipelock run. Because the actual server bind happens later, another parallel test process can claim the port in between and cause intermittent address already in use failures.

Tests that need to dial the selected address now retry only on bind collisions with a fresh port set. Tests that only need the server to bind a listener use 127.0.0.1:0 directly, which avoids the close/rebind window entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test stability with TOCTOU‑tolerant port selection and retrying.
  * Replaced brittle readiness checks with result-based polling and early-exit helpers for clearer failures.
  * Tightened reload, health, metrics, proxy and websocket assertions to reduce flakiness and suppress spurious warnings.

* **Chores**
  * Consolidated test infrastructure for more maintainable, repeatable integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->