### PR TITLE
fix(scanner): direction-scope agent-secret exfil checks; skip path-shaped env values

### DIFF
--- a/docs/guides/hermes.md
+++ b/docs/guides/hermes.md
@@ -78,6 +78,10 @@ The original headers are retained in the `_pipelock` metadata so `rollback` rest
 
 The **full** column reflects what the plugin scans once enabled; the plugin path is proven end-to-end against a live Hermes by `make hermes-e2e`. The **mcp-only** column is the lighter opt-in path for MCP traffic only.
 
+### Direction-aware DLP
+
+The exfil-class DLP checks — environment-variable and file-secret **value** matching, which detect a secret the proxy holds appearing in text — run only on **outbound** surfaces, where a secret could actually leave: a tool call's arguments (`pre_tool_call`). On **inbound** surfaces — an operator→agent message (`pre_gateway_dispatch`) and a tool result flowing back to the agent (`transform_tool_result`) — those checks are skipped, because a value the agent is *receiving* is not exfiltration. Inbound surfaces still get full prompt-injection scanning plus the generic DLP detectors (regex patterns, seed phrases, canary tokens, hostname exfiltration); only the agent's-own-secret value match is direction-scoped. This prevents an operator message or a local file read that happens to contain an env value (a path, a config setting) from false-positively blocking the agent, without weakening exfiltration protection on the outbound path. Outbound exfil detection is unchanged.
+
 ## Verify and Roll Back
 
 ```bash

--- a/internal/cli/hermes/hook.go
+++ b/internal/cli/hermes/hook.go
@@ -188,14 +188,17 @@ func allowDecision() HookDecision {
 func evaluate(ctx context.Context, sc *scanner.Scanner, event *HookEvent) HookDecision {
 	switch event.HookEventName {
 	case HookPreToolCall:
+		// Outbound: the agent is invoking a tool; arguments may egress.
 		return scanCombined(ctx, sc, extractToolInputText(event.ToolInput),
-			fmt.Sprintf("tool %q arguments", event.ToolName))
+			fmt.Sprintf("tool %q arguments", event.ToolName), directionOutbound)
 	case HookTransformToolResult:
+		// Inbound: a tool result flowing back to the agent.
 		return scanCombined(ctx, sc, extractToolInputText(event.ToolInput),
-			fmt.Sprintf("tool %q result", event.ToolName))
+			fmt.Sprintf("tool %q result", event.ToolName), directionInbound)
 	case HookPreGatewayDispatch:
+		// Inbound: an operator->agent message being dispatched.
 		return scanCombined(ctx, sc, extractToolInputText(event.ToolInput),
-			"inbound gateway dispatch")
+			"inbound gateway dispatch", directionInbound)
 	case HookOnSessionStart, HookOnSessionEnd:
 		// Observer hooks. The current release emits no decision; a follow-up
 		// release may hook these to receipt emission.
@@ -207,16 +210,47 @@ func evaluate(ctx context.Context, sc *scanner.Scanner, event *HookEvent) HookDe
 	}
 }
 
+// scanDirection classifies a hook event for DLP scan selection.
+//
+//   - directionOutbound: text the agent is SENDING (a tool call's arguments may
+//     egress). Gets the full DLP scan, including the agent's-own-secret exfil
+//     checks (env-var and file-secret value matching) — this is the surface
+//     where a secret actually leaves.
+//   - directionInbound: text the agent is RECEIVING (an operator->agent gateway
+//     dispatch, or a tool result flowing back). Gets injection scanning plus DLP
+//     WITHOUT the exfil checks: a value the agent received is not something it
+//     exfiltrated, so running the exfil checks here only false-positives and
+//     gags normal operation. Generic detectors (regex patterns, seed phrases,
+//     canary, hostname-exfil) still run in both directions.
+type scanDirection int
+
+const (
+	directionOutbound scanDirection = iota
+	directionInbound
+)
+
 // scanCombined applies DLP and response/injection scans to text and returns a
-// block decision on the first finding. Empty text short-circuits to allow:
-// nothing to scan means nothing to flag, and a spurious block on an
-// empty-arguments tool call would be a denial of service.
-func scanCombined(ctx context.Context, sc *scanner.Scanner, text, surface string) HookDecision {
+// block decision on the first finding. The direction selects the DLP variant
+// (see scanDirection). Empty text short-circuits to allow: nothing to scan
+// means nothing to flag, and a spurious block on an empty-arguments tool call
+// would be a denial of service.
+func scanCombined(ctx context.Context, sc *scanner.Scanner, text, surface string, dir scanDirection) HookDecision {
 	if strings.TrimSpace(text) == "" {
 		return allowDecision()
 	}
 
-	if dlp := sc.ScanTextForDLP(ctx, text); !dlp.Clean && len(dlp.Matches) > 0 {
+	// Outbound runs the full exfil-aware scan; inbound skips the agent's-own-
+	// secret exfil checks. Exactly one variant runs — calling the full scan for
+	// an inbound event would run the exfil checks and emit warn telemetry before
+	// being discarded. Injection scanning (ScanResponse) runs regardless: a
+	// poisoned tool result or operator message is the real inbound threat.
+	var dlp scanner.TextDLPResult
+	if dir == directionInbound {
+		dlp = sc.ScanTextForDLPInbound(ctx, text)
+	} else {
+		dlp = sc.ScanTextForDLP(ctx, text)
+	}
+	if !dlp.Clean && len(dlp.Matches) > 0 {
 		first := dlp.Matches[0]
 		return blockDecision(fmt.Sprintf("pipelock DLP match on %s: %s (severity=%s)",
 			surface, first.PatternName, first.Severity))

--- a/internal/cli/hermes/hook_test.go
+++ b/internal/cli/hermes/hook_test.go
@@ -369,3 +369,70 @@ func TestEvaluate_EmptyToolInputAllows(t *testing.T) {
 		t.Fatalf("observer hook produced decision=%q, want allow", dec.Decision)
 	}
 }
+
+const (
+	// envLeakRegressionSecret is a high-entropy value that matches no DLP regex
+	// pattern and is not path-shaped, so the env-secret exfil check is the ONLY
+	// thing that can flag it. That makes the direction-aware behaviour
+	// observable: a block can only come from the exfil check.
+	envLeakRegressionSecret = "zQ8xR4kP2" + "mN7wL9vT3jH" // split to satisfy gosec G101
+	envLeakRegressionVar    = "PIPELOCK_HOOK_ENVLEAK"
+)
+
+// TestHook_EnvLeakBlocksOutboundToolCall is the OUTBOUND half of the
+// direction-aware regression: a tool call (the agent sending) carrying the
+// agent's own env secret must still block. This also guards that env scanning
+// is active on the hook path.
+func TestHook_EnvLeakBlocksOutboundToolCall(t *testing.T) {
+	// t.Setenv forbids t.Parallel. The scanner extracts os.Environ() at
+	// construction, so the value must be set before runHookCLI builds it.
+	t.Setenv(envLeakRegressionVar, envLeakRegressionSecret)
+
+	payload := `{"hook_event_name":"pre_tool_call","tool_name":"shell",` +
+		`"tool_input":{"command":"echo ` + envLeakRegressionSecret + `"}}`
+	decision, err := runHookCLI(t, payload)
+	if err != nil {
+		t.Fatalf("ExecuteContext: %v", err)
+	}
+	if decision.Decision != DecisionBlock {
+		t.Fatalf("outbound tool call leaking env secret: decision=%q, want block", decision.Decision)
+	}
+	if !strings.Contains(decision.Reason, "DLP") {
+		t.Fatalf("block reason missing DLP marker: %q", decision.Reason)
+	}
+}
+
+// TestHook_EnvLeakAllowedInboundGatewayDispatch is the INBOUND half: an
+// operator->agent message that happens to contain the env value (an operator
+// telling the agent a setting) is not exfiltration and must be allowed. Before the
+// direction-aware fix this false-positive blocked the agent.
+func TestHook_EnvLeakAllowedInboundGatewayDispatch(t *testing.T) {
+	t.Setenv(envLeakRegressionVar, envLeakRegressionSecret)
+
+	payload := `{"hook_event_name":"pre_gateway_dispatch","tool_name":"gateway",` +
+		`"tool_input":{"text":"the workspace value is ` + envLeakRegressionSecret + ` please proceed","sender":"@ops"}}`
+	decision, err := runHookCLI(t, payload)
+	if err != nil {
+		t.Fatalf("ExecuteContext: %v", err)
+	}
+	if decision.Decision != "" {
+		t.Fatalf("inbound gateway dispatch with received env value: decision=%q, want allow", decision.Decision)
+	}
+}
+
+// TestHook_EnvLeakAllowedInboundToolResult is the other INBOUND half: a tool
+// result flowing back to the agent (e.g. the agent read its own config) that
+// contains the env value is not exfiltration and must be allowed.
+func TestHook_EnvLeakAllowedInboundToolResult(t *testing.T) {
+	t.Setenv(envLeakRegressionVar, envLeakRegressionSecret)
+
+	payload := `{"hook_event_name":"transform_tool_result","tool_name":"read_file",` +
+		`"tool_input":{"result":"the agent read back ` + envLeakRegressionSecret + ` from its workspace file"}}`
+	decision, err := runHookCLI(t, payload)
+	if err != nil {
+		t.Fatalf("ExecuteContext: %v", err)
+	}
+	if decision.Decision != "" {
+		t.Fatalf("inbound tool result with received env value: decision=%q, want allow", decision.Decision)
+	}
+}

--- a/internal/scanner/scan_env_test.go
+++ b/internal/scanner/scan_env_test.go
@@ -162,6 +162,84 @@ func TestExtractEnvSecrets_FiltersCorrectly(t *testing.T) {
 	}
 }
 
+func TestIsPathShapedValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"empty", "", false},
+		{"absolute path", "/home/agent/.config/app/plugins/core", true},
+		{"ca bundle path", "/etc/ssl/certs/app-ca.pem", true},
+		{"home-relative path", "~/.config/app/state/cache", true},
+		{"path list (PATH-style)", "/opt/app/bin:/usr/local/bin:/usr/bin:/bin", true},
+		{"path list trailing colon", "/usr/bin:/bin:", false},
+		{"single short root path", "/etc", false},
+		{"slash-prefixed opaque token", "/" + "K7MDENGbPxRfiCYzQ", false},
+		// A base64 secret can begin with "/" and often carries '+' or '='
+		// artifacts, so it must NOT be treated as a path.
+		{"base64 secret starting with slash", "/K7MDENG+bPxRfiCYz=", false},
+		{"plain high-entropy secret", "sk-ant-abcdefghijklmnopqrstu1234567890", false},
+		{"token with slash mid-string", "AKIAIOSFODNN7/EXAMPLEKEY", false},
+		{"colon list with non-path segment", "host:sk-ant-abcdefghij12345", false},
+		{"leading colon (degenerate)", ":/usr/bin", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPathShapedValue(tt.value); got != tt.want {
+				t.Errorf("isPathShapedValue(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractEnvSecrets_SkipsPathShapedValues(t *testing.T) {
+	// Path-valued variables the name skip-list misses (HERMES_HOME, CA bundle
+	// vars, ...). Their deep-path values clear the length+entropy filters but
+	// are not secrets, so they must be excluded by value shape. Names use a
+	// non-skipped prefix (PIPELOCK_TEST is collected elsewhere) so the only
+	// thing keeping them out is isPathShapedValue.
+	appHome := "/home/agent/.config/app/plugins/core/x9k2qz"
+	caBundle := "/etc/ssl/certs/app-ca.pem"
+	pathList := "/opt/app/bin:/usr/local/bin:/usr/bin"
+	t.Setenv("PIPELOCK_TEST_APP_HOME", appHome)
+	t.Setenv("PIPELOCK_TEST_CA_BUNDLE", caBundle)
+	t.Setenv("PIPELOCK_TEST_PATHLIST", pathList)
+
+	// A genuine secret value must still be collected.
+	realSecret := "sk-" + "ant-realkey-abcdefghij12345"
+	t.Setenv("PIPELOCK_TEST_REAL", realSecret)
+	slashPrefixedSecret := "/" + "K7MDENGbPxRfiCYzQ"
+	t.Setenv("PIPELOCK_TEST_SLASH_SECRET", slashPrefixedSecret)
+
+	secrets := extractEnvSecrets(16)
+
+	pathShaped := map[string]string{
+		appHome:  "PIPELOCK_TEST_APP_HOME",
+		caBundle: "PIPELOCK_TEST_CA_BUNDLE",
+		pathList: "PIPELOCK_TEST_PATHLIST",
+	}
+	foundReal := false
+	foundSlashPrefixedSecret := false
+	for _, s := range secrets {
+		if name, ok := pathShaped[s]; ok {
+			t.Errorf("%s value %q should be skipped (path-shaped, not a secret)", name, s)
+		}
+		if s == realSecret {
+			foundReal = true
+		}
+		if s == slashPrefixedSecret {
+			foundSlashPrefixedSecret = true
+		}
+	}
+	if !foundReal {
+		t.Error("expected genuine secret value to still be collected after path-skip")
+	}
+	if !foundSlashPrefixedSecret {
+		t.Error("expected slash-prefixed opaque secret value to still be collected after path-skip")
+	}
+}
+
 func TestExtractEnvSecrets_SkipsNonSecretNames(t *testing.T) {
 	// Set well-known non-secret vars with values that would otherwise
 	// pass length and entropy filters.

--- a/internal/scanner/scan_env_test.go
+++ b/internal/scanner/scan_env_test.go
@@ -180,9 +180,16 @@ func TestIsPathShapedValue(t *testing.T) {
 		// artifacts, so it must NOT be treated as a path.
 		{"base64 secret starting with slash", "/K7MDENG+bPxRfiCYz=", false},
 		{"plain high-entropy secret", "sk-ant-abcdefghijklmnopqrstu1234567890", false},
-		{"token with slash mid-string", "AKIAIOSFODNN7/EXAMPLEKEY", false},
+		{"token with slash mid-string", "AKIA" + "IOSFODNN7" + "/EXAMPLEKEY", false},
 		{"colon list with non-path segment", "host:sk-ant-abcdefghij12345", false},
 		{"leading colon (degenerate)", ":/usr/bin", false},
+		// PATH wrapper smuggling a slash-prefixed opaque token must NOT be
+		// treated as path-shaped, or the token escapes the env-leak matcher
+		// set (the single-value branch keeps "/<token>" scannable).
+		{"path list smuggling slash-prefixed token", "/usr/bin:/" + "K7MDENGbPxRfiCYzQ", false},
+		// Real PATH lists, including short single-component dirs, stay skipped.
+		{"path list short single-component dirs", "/bin:/sbin:/usr/bin", true},
+		{"path list multi-component only", "/usr/bin:/usr/local/bin", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -212,6 +219,12 @@ func TestExtractEnvSecrets_SkipsPathShapedValues(t *testing.T) {
 	slashPrefixedSecret := "/" + "K7MDENGbPxRfiCYzQ"
 	t.Setenv("PIPELOCK_TEST_SLASH_SECRET", slashPrefixedSecret)
 
+	// A PATH-like wrapper smuggling a slash-prefixed opaque token must NOT be
+	// skipped as path-shaped; the whole value stays in the matcher set so the
+	// wrapper can't be used to evade env-leak detection.
+	pathWrappedSecret := "/usr/bin:/" + "K7MDENGbPxRfiCYzQ"
+	t.Setenv("PIPELOCK_TEST_PATH_WRAPPED_SECRET", pathWrappedSecret)
+
 	secrets := extractEnvSecrets(16)
 
 	pathShaped := map[string]string{
@@ -221,6 +234,7 @@ func TestExtractEnvSecrets_SkipsPathShapedValues(t *testing.T) {
 	}
 	foundReal := false
 	foundSlashPrefixedSecret := false
+	foundPathWrappedSecret := false
 	for _, s := range secrets {
 		if name, ok := pathShaped[s]; ok {
 			t.Errorf("%s value %q should be skipped (path-shaped, not a secret)", name, s)
@@ -231,12 +245,18 @@ func TestExtractEnvSecrets_SkipsPathShapedValues(t *testing.T) {
 		if s == slashPrefixedSecret {
 			foundSlashPrefixedSecret = true
 		}
+		if s == pathWrappedSecret {
+			foundPathWrappedSecret = true
+		}
 	}
 	if !foundReal {
 		t.Error("expected genuine secret value to still be collected after path-skip")
 	}
 	if !foundSlashPrefixedSecret {
 		t.Error("expected slash-prefixed opaque secret value to still be collected after path-skip")
+	}
+	if !foundPathWrappedSecret {
+		t.Error("expected PATH-wrapped opaque token to still be collected (no path-wrapper exfil bypass)")
 	}
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2149,6 +2149,32 @@ func isNonSecretEnvName(name string) bool {
 	return false
 }
 
+// envLeakMinEntropy is the Shannon-entropy floor (bits/char) above which an
+// env-variable value is treated as secret-shaped. Single source of truth shared
+// by extractEnvSecrets (whole-value filter) and looksLikeOpaqueToken (per-segment
+// guard) so the two stay consistent.
+const envLeakMinEntropy = 3.0
+
+// minOpaqueTokenLen is the component length at or above which a single-component,
+// slash-prefixed colon-list segment is treated as a possible opaque secret token
+// rather than a short directory name. Short PATH dirs (/bin, /sbin, /opt) fall
+// below it and stay recognised as path components.
+const minOpaqueTokenLen = 16
+
+// looksLikeOpaqueToken reports whether a colon-list segment (already known to
+// begin with "/") is shaped like an opaque secret token rather than a directory
+// component. A genuine directory entry is either multi-component (/usr/local/bin,
+// has an inner separator) or a short name (/bin, /sbin); a smuggled token is a
+// single long, high-entropy blob (/K7MDENGbPxRfiCYzQ). Used to stop a PATH-like
+// wrapper from skipping a value that the single-value branch would keep scannable.
+func looksLikeOpaqueToken(seg string) bool {
+	body := strings.TrimPrefix(seg, "/")
+	if strings.Contains(body, "/") {
+		return false // multi-component path, not a single opaque token
+	}
+	return len(body) >= minOpaqueTokenLen && ShannonEntropy(body) > envLeakMinEntropy
+}
+
 // isPathShapedValue reports whether an environment-variable value looks like a
 // multi-component filesystem path (or a colon-separated list of paths) rather
 // than a secret. extractEnvSecrets uses it to keep path-valued variables out of
@@ -2180,6 +2206,13 @@ func isPathShapedValue(value string) bool {
 			if seg == "" || !strings.HasPrefix(seg, "/") {
 				return false
 			}
+			// A slash-prefixed opaque token riding in a PATH-like wrapper
+			// (e.g. "/usr/bin:/K7MDENGbPxRfiCYzQ") must not be skipped: the
+			// single-value branch keeps such tokens scannable, so the list
+			// branch has to as well, or the wrapper becomes an exfil bypass.
+			if looksLikeOpaqueToken(seg) {
+				return false
+			}
 		}
 		return true
 	}
@@ -2202,8 +2235,6 @@ func isPathShapedValue(value string) bool {
 // path-shaped values (see isPathShapedValue) to avoid false positives on paths
 // and locale strings.
 func extractEnvSecrets(minLen int) []string {
-	const minEntropy = 3.0
-
 	if minLen <= 0 {
 		minLen = 16
 	}
@@ -2234,7 +2265,7 @@ func extractEnvSecrets(minLen int) []string {
 			continue
 		}
 
-		if ShannonEntropy(value) > minEntropy {
+		if ShannonEntropy(value) > envLeakMinEntropy {
 			secrets = append(secrets, value)
 		}
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2149,10 +2149,58 @@ func isNonSecretEnvName(name string) bool {
 	return false
 }
 
+// isPathShapedValue reports whether an environment-variable value looks like a
+// multi-component filesystem path (or a colon-separated list of paths) rather
+// than a secret. extractEnvSecrets uses it to keep path-valued variables out of
+// the env-leak matcher set: a path the agent references during normal operation
+// is not an exfiltrated secret, and a deep directory path carries enough Shannon
+// entropy to slip past the entropy filter and become a spurious matcher.
+// Matching is on value SHAPE, not variable name, because the name skip-list is
+// incomplete — it misses HERMES_HOME, NODE_EXTRA_CA_CERTS, SSL_CERT_FILE, and
+// any other path-valued variable a deployment introduces.
+//
+// Unix-path-shaped only: a multi-component value beginning with "/" or "~/", or
+// a "/"-prefixed colon list (PATH, LD_LIBRARY_PATH). Windows drive paths are
+// not recognised; pipelock's agent-containment target is Linux. Slash-prefixed
+// opaque tokens are left in the matcher set, as are values containing '+' or '='
+// because those are common in encoded secrets.
+func isPathShapedValue(value string) bool {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return false
+	}
+	if strings.ContainsAny(v, "+=") {
+		return false
+	}
+
+	// Colon-separated list where every element is an absolute path
+	// (PATH-style). Checked first so multi-path lists aren't missed.
+	if strings.Contains(v, ":") {
+		for _, seg := range strings.Split(v, ":") {
+			if seg == "" || !strings.HasPrefix(seg, "/") {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Single absolute or home-relative path. Require at least one directory
+	// separator after the prefix so "/opaque-token-value" stays scannable.
+	if strings.HasPrefix(v, "~/") {
+		rest := strings.TrimPrefix(v, "~/")
+		return strings.Contains(rest, "/") || strings.HasPrefix(rest, ".")
+	}
+	if strings.HasPrefix(v, "/") {
+		return strings.Contains(strings.TrimPrefix(v, "/"), "/")
+	}
+	return false
+}
+
 // extractEnvSecrets filters environment variables for likely secrets.
 // Returns values >= minLen chars with Shannon entropy >3.0.
-// Skips well-known non-secret variable names (PWD, PATH, HOME, etc.)
-// to avoid false positives on paths and locale strings.
+// Skips well-known non-secret variable names (PWD, PATH, HOME, etc.) and
+// path-shaped values (see isPathShapedValue) to avoid false positives on paths
+// and locale strings.
 func extractEnvSecrets(minLen int) []string {
 	const minEntropy = 3.0
 
@@ -2172,6 +2220,13 @@ func extractEnvSecrets(minLen int) []string {
 
 		// Skip well-known non-secret variables (paths, locale, shell config).
 		if isNonSecretEnvName(name) {
+			continue
+		}
+
+		// Skip path-shaped values regardless of variable name. Deep paths
+		// carry high entropy and would otherwise become spurious matchers
+		// that flag the agent's own normal path references as leaks.
+		if isPathShapedValue(value) {
 			continue
 		}
 

--- a/internal/scanner/text_dlp.go
+++ b/internal/scanner/text_dlp.go
@@ -161,19 +161,47 @@ type TextDLPResult struct {
 	InformationalMatches []TextDLPMatch `json:"informational_matches,omitempty"` // warn-mode matches (non-blocking)
 }
 
+// textDLPOptions tunes a text-DLP scan. emitWarns controls warn-hook telemetry.
+// scanSecretLeak controls whether the agent's-own-secret exfil checks run —
+// the environment-variable and file-secret value matchers. Those checks detect
+// a secret VALUE the proxy holds (env or secrets-file) appearing in the text,
+// which only indicates exfiltration when the text is OUTBOUND. Callers scanning
+// inbound content (operator->agent messages, tool results flowing back) set it
+// false: a value the agent is receiving is not a leak, and matching it there
+// produces false positives that gag normal operation. Generic detectors
+// (regex patterns, seed phrases, canary tokens, hostname-exfil) are unaffected
+// and run in both directions.
+type textDLPOptions struct {
+	emitWarns      bool
+	scanSecretLeak bool
+}
+
 // ScanTextForDLP checks arbitrary text for DLP pattern matches and env secret leaks.
 // Unlike checkDLP (which operates on URLs), this method works on raw text strings
 // from MCP tool arguments. It applies zero-width stripping, NFKC normalization,
 // and checks encoded variants (base64, hex, base32) of the text for patterns.
+// This is the full OUTBOUND scan: it runs the agent's-own-secret exfil checks.
 func (s *Scanner) ScanTextForDLP(ctx context.Context, text string) TextDLPResult {
-	return s.scanTextForDLP(ctx, text, true)
+	return s.scanTextForDLP(ctx, text, textDLPOptions{emitWarns: true, scanSecretLeak: true})
 }
 
 // ScanTextForDLPQuiet runs the same text-DLP detection logic as ScanTextForDLP
 // but suppresses warn-hook emission. Callers use this when they need to compare
 // multiple related scans without duplicating warn telemetry.
 func (s *Scanner) ScanTextForDLPQuiet(ctx context.Context, text string) TextDLPResult {
-	return s.scanTextForDLP(ctx, text, false)
+	return s.scanTextForDLP(ctx, text, textDLPOptions{emitWarns: false, scanSecretLeak: true})
+}
+
+// ScanTextForDLPInbound runs text DLP for INBOUND content — text the agent is
+// receiving rather than sending (operator->agent messages, tool results flowing
+// back). It runs the full pattern / seed / canary / hostname-exfil detection but
+// SKIPS the agent's-own-secret exfil checks (environment-variable and
+// file-secret value matching). Those only indicate exfiltration on an outbound
+// surface; on inbound content the same value appearing is legitimately-received
+// data, not a leak, and scanning for it false-positives. Exfil protection is
+// untouched: the outbound surfaces still call ScanTextForDLP.
+func (s *Scanner) ScanTextForDLPInbound(ctx context.Context, text string) TextDLPResult {
+	return s.scanTextForDLP(ctx, text, textDLPOptions{emitWarns: true, scanSecretLeak: false})
 }
 
 // EmitTextDLPWarnMatches replays the warn hook for the provided informational
@@ -197,7 +225,7 @@ func (s *Scanner) EmitTextDLPWarnMatches(ctx context.Context, matches []TextDLPM
 	s.emitDLPWarns(ctx, deduplicateWarnMatches(warns))
 }
 
-func (s *Scanner) scanTextForDLP(ctx context.Context, text string, emitWarns bool) TextDLPResult {
+func (s *Scanner) scanTextForDLP(ctx context.Context, text string, opts textDLPOptions) TextDLPResult {
 	text = redactOfficialAWSExampleCredentialsForDocs(text)
 
 	// Core DLP runs FIRST - immutable safety floor. Core matches are
@@ -367,11 +395,17 @@ func (s *Scanner) scanTextForDLP(ctx context.Context, text string, emitWarns boo
 		matches = append(matches, s.decodeTextSegments(cleaned)...)
 	}
 
-	// Check for env secret leaks (raw + encoded forms).
-	matches = append(matches, s.checkSecretsInText(s.envSecrets, cleaned, "Environment Variable Leak", "env")...)
-
-	// Check for file secret leaks (raw + encoded forms).
-	matches = append(matches, s.checkSecretsInText(s.fileSecrets, cleaned, "Known Secret Leak", "")...)
+	// Check for env + file secret leaks (raw + encoded forms). These detect a
+	// secret VALUE the proxy holds appearing in the text, i.e. exfiltration —
+	// meaningful only when the text is outbound. Inbound callers disable them
+	// (a received value is not a leak) to avoid gagging normal operation. The
+	// gate lives INSIDE the scan, not as a post-hoc filter on the result, so it
+	// cannot create a masking bypass: a disabled check never runs rather than
+	// running and being filtered away.
+	if opts.scanSecretLeak {
+		matches = append(matches, s.checkSecretsInText(s.envSecrets, cleaned, "Environment Variable Leak", "env")...)
+		matches = append(matches, s.checkSecretsInText(s.fileSecrets, cleaned, "Known Secret Leak", "")...)
+	}
 
 	// Deduplicate matches by pattern name + encoding.
 	matches = deduplicateMatches(matches)
@@ -399,7 +433,7 @@ func (s *Scanner) scanTextForDLP(ctx context.Context, text string, emitWarns boo
 	}
 
 	// Emit warn events through the shared helper so warn-hook behavior stays centralized.
-	if emitWarns && len(informational) > 0 {
+	if opts.emitWarns && len(informational) > 0 {
 		warns := make([]WarnMatch, 0, len(informational))
 		for _, m := range informational {
 			warns = append(warns, WarnMatch{

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -2514,3 +2514,54 @@ func TestScanTextForDLP_BlocksEncodedExfilHostname(t *testing.T) {
 		})
 	}
 }
+
+// TestScanTextForDLPInbound_SkipsEnvLeak proves the direction gate: the
+// agent's-own-secret exfil check fires outbound (ScanTextForDLP) but is skipped
+// inbound (ScanTextForDLPInbound), so a received env value is not a false leak.
+func TestScanTextForDLPInbound_SkipsEnvLeak(t *testing.T) {
+	cfg := testConfig()
+	cfg.DLP.ScanEnv = true
+	cfg.DLP.Patterns = nil // isolate env-leak: only the env-secret check can fire
+
+	// High-entropy value that matches no regex pattern and is not path-shaped,
+	// so the ONLY thing that could flag it is the env-secret exfil check.
+	secret := "zQ8xR4kP2" + "mN7wL9vT3jH" // split to satisfy gosec G101
+	t.Setenv("PIPELOCK_TEST_INBOUND_SECRET", secret)
+	s := New(cfg)
+
+	carrier := "operator note: the value is " + secret + " please proceed"
+	ctx := context.Background()
+
+	// Outbound: the exfil check runs and flags the leak.
+	if out := s.ScanTextForDLP(ctx, carrier); out.Clean || len(out.Matches) == 0 {
+		t.Fatalf("ScanTextForDLP (outbound) should flag the env-secret leak, got Clean=%v matches=%v", out.Clean, out.Matches)
+	}
+
+	// Inbound: the exfil check is skipped, so the same received value is clean.
+	if in := s.ScanTextForDLPInbound(ctx, carrier); !in.Clean {
+		t.Fatalf("ScanTextForDLPInbound must NOT flag a received env value, got matches=%v", in.Matches)
+	}
+}
+
+// TestScanTextForDLPInbound_StillCatchesGenericDLP proves the gate is narrow:
+// only the exfil-class env/file-secret checks are direction-scoped. Generic
+// regex pattern DLP still runs inbound (a real secret pattern in a tool result
+// is still caught).
+func TestScanTextForDLPInbound_StillCatchesGenericDLP(t *testing.T) {
+	s := New(testConfig()) // default DLP patterns enabled
+
+	// An Anthropic-key-shaped value (same construction as the existing pattern
+	// tests, so it reliably matches a default regex pattern and is not a
+	// redacted documentation example). This is a regex DLP pattern, not an
+	// exfil-class check, so it must fire on inbound too.
+	key := testAnthropicPrefix + strings.Repeat("A", 10)
+	carrier := "tool result payload: " + key
+	ctx := context.Background()
+
+	if out := s.ScanTextForDLP(ctx, carrier); out.Clean {
+		t.Fatalf("baseline: ScanTextForDLP should flag the Anthropic key pattern, got clean")
+	}
+	if in := s.ScanTextForDLPInbound(ctx, carrier); in.Clean {
+		t.Fatalf("ScanTextForDLPInbound must still run generic pattern DLP, got clean for key pattern")
+	}
+}


### PR DESCRIPTION
## What

The environment-variable and file-secret value matchers detect a secret pipelock holds (an env value or a secrets-file entry) appearing in scanned text. That signals exfiltration only when the text is leaving the agent. The Hermes hook ran those checks on every event, including inbound ones, so pipelock blocked an operator message or a tool result that merely contained such a value (a filesystem path, a config setting) as an "Environment Variable Leak". In a contained Hermes deployment this gagged normal operation: you could not tell the agent where its own tools live, and it could not read its own skill files that reference paths.

## Fix

1. Direction-aware DLP. A new `ScanTextForDLPInbound` runs the full pattern, seed-phrase, canary, and hostname-exfil detection but skips the agent's-own-secret value checks. The Hermes hook now routes events by direction: `pre_tool_call` (outbound) keeps the full scan; `transform_tool_result` and `pre_gateway_dispatch` (inbound) use the inbound scan. Prompt-injection scanning still runs on every event. The gate lives inside the scan rather than as a post-hoc filter on the result, so it cannot create a masking bypass.

2. Path-shaped env values are no longer treated as secrets. `extractEnvSecrets` now skips values shaped like a filesystem path (a multi-segment absolute path, a `~/` path, or a clean colon list of absolute paths), regardless of variable name. A deep directory path carries enough entropy to slip past the entropy filter and become a spurious matcher; matching on value shape closes the gap the name skip-list missed (HERMES_HOME, CA-bundle vars, and similar). Slash-prefixed opaque tokens and malformed colon lists stay scannable.

## Scope and safety

Outbound exfiltration detection is unchanged: a secret leaving through a tool call's arguments is still caught. Existing `ScanTextForDLP` callers (forward proxy, MCP, WebSocket) are untouched, since this adds a sibling method rather than changing the default. The path-shape skip is global and strictly removes false positives, never adds them.

## Coverage

Eight new tests covering each direction plus the path-shape behavior:

- env-leak fires outbound, allowed inbound on both `pre_gateway_dispatch` and `transform_tool_result`, proven end-to-end through the hook command
- `ScanTextForDLPInbound` skips the exfil check but still catches generic pattern DLP (a real key in a tool result is still flagged)
- `isPathShapedValue` and the `extractEnvSecrets` path-skip, including the cases that must stay scannable

A "Direction-aware DLP" note is added to the Hermes guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Direction-aware DLP: outbound tool calls enforce secret-value checks; inbound content (operator messages, tool results) skips value-matching checks while keeping prompt-injection and generic pattern detection.

* **Improvements**
  * Env-var secret detection now ignores path-shaped values (absolute/home-relative paths and path lists) to reduce false positives.

* **Documentation**
  * Hermes guide updated to describe direction-aware DLP behavior and scan scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->