### PR TITLE
feat(receipt): support spanned proxy decision emission

### DIFF
--- a/internal/contract/proxydecision/emitter.go
+++ b/internal/contract/proxydecision/emitter.go
@@ -121,6 +121,13 @@ type Decision struct {
 	ContractHash       string
 	SelectorID         string
 	ContractGeneration uint64
+
+	// SourceSpanEvidence and SpanHMACKey opt this decision into the
+	// proxy_decision_with_spans payload. Callers must provide a dedicated
+	// source-span HMAC key and leak-safe match values; the emitter binds each
+	// span commitment to the generated envelope event_id before signing.
+	SourceSpanEvidence []contractruntime.SourceSpanEvidence
+	SpanHMACKey        []byte
 }
 
 // EmitterConfig configures live proxy_decision emission.
@@ -235,7 +242,7 @@ func (e *Emitter) Emit(d Decision) error {
 		return fmt.Errorf("generate proxy_decision event id: %w", err)
 	}
 
-	rcpt, err := contractruntime.BuildProxyDecisionReceipt(contractruntime.ProxyDecisionInput{
+	in := contractruntime.ProxyDecisionInput{
 		Decision: contractruntime.Decision{
 			Verdict:       d.Verdict,
 			LiveVerdict:   d.LiveVerdict,
@@ -252,7 +259,14 @@ func (e *Emitter) Emit(d Decision) error {
 		Actor:         e.actor,
 		ChainSeq:      e.chainSeq,
 		ChainPrevHash: e.chainPrevHash,
-	})
+	}
+	// Sanitize free-form span fields BEFORE the commitment is computed, for the
+	// same reason target/rule_id are scrubbed above (#676): these fields land in
+	// the SIGNED spanned payload. RuleID and MatchClass are also match_hash
+	// preimage inputs, so scrubbing must happen before buildReceipt computes the
+	// HMAC.
+	evidence := sanitizeSpanEvidence(d.SourceSpanEvidence, e.sanitize)
+	rcpt, err := buildReceipt(in, d.SpanHMACKey, evidence)
 	if err != nil {
 		return fmt.Errorf("build proxy_decision receipt: %w", err)
 	}
@@ -300,9 +314,9 @@ func (e *Emitter) Emit(d Decision) error {
 	if err := e.recorder.Record(recorder.Entry{
 		SessionID: recorderSessionID,
 		Type:      evidenceReceiptEntryType,
-		EventKind: string(contractreceipt.PayloadProxyDecision),
+		EventKind: string(rcpt.PayloadKind),
 		Transport: d.Transport,
-		Summary:   fmt.Sprintf("proxy_decision: %s %s via %s", d.ActionType, d.Verdict, d.WinningSource),
+		Summary:   fmt.Sprintf("%s: %s %s via %s", rcpt.PayloadKind, d.ActionType, d.Verdict, d.WinningSource),
 		Detail:    json.RawMessage(rcptJSON),
 	}); err != nil {
 		return fmt.Errorf("record proxy_decision receipt: %w", err)
@@ -310,6 +324,46 @@ func (e *Emitter) Emit(d Decision) error {
 	e.chainPrevHash = rcptHash
 	e.chainSeq++
 	return nil
+}
+
+func buildReceipt(
+	in contractruntime.ProxyDecisionInput,
+	spanHMACKey []byte,
+	evidence []contractruntime.SourceSpanEvidence,
+) (contractreceipt.EvidenceReceipt, error) {
+	if len(evidence) == 0 {
+		return contractruntime.BuildProxyDecisionReceipt(in)
+	}
+	return contractruntime.BuildProxyDecisionWithSpansReceipt(in, spanHMACKey, evidence)
+}
+
+// sanitizeSpanEvidence returns a copy of evidence with every free-form
+// serialized span field run through the same pre-sign sanitizer the emitter
+// applies to target and rule_id (#676). This covers the expected secret-bearing
+// fields (RedactedSample, RuleID) and fails safer if a future caller accidentally
+// puts matched bytes into metadata such as SourceID or MatchClass. RuleID and
+// MatchClass are also match_hash preimage inputs, so they are scrubbed BEFORE
+// the commitment is computed, keeping the hash self-consistent. MatchValue is
+// never serialized (only its keyed HMAC), so it is left intact. The caller's
+// slice and spans are not mutated; a nil sanitizer leaves evidence unchanged.
+func sanitizeSpanEvidence(evidence []contractruntime.SourceSpanEvidence, sanitize SanitizeFunc) []contractruntime.SourceSpanEvidence {
+	if sanitize == nil || len(evidence) == 0 {
+		return evidence
+	}
+	out := make([]contractruntime.SourceSpanEvidence, len(evidence))
+	for i, item := range evidence {
+		span := item.Span
+		span.SourceID = receipt.CleanOrRedacted(span.SourceID, sanitize)
+		span.TransformProfile = receipt.CleanOrRedacted(span.TransformProfile, sanitize)
+		span.RuleID = receipt.CleanOrRedacted(span.RuleID, sanitize)
+		span.Bundle = receipt.CleanOrRedacted(span.Bundle, sanitize)
+		span.BundleVersion = receipt.CleanOrRedacted(span.BundleVersion, sanitize)
+		span.MatchClass = receipt.CleanOrRedacted(span.MatchClass, sanitize)
+		span.RedactedSample = receipt.CleanOrRedacted(span.RedactedSample, sanitize)
+		item.Span = span
+		out[i] = item
+	}
+	return out
 }
 
 // KeyedSigner wraps an Ed25519 private key as a Signer. KeyID is the

--- a/internal/contract/proxydecision/emitter_test.go
+++ b/internal/contract/proxydecision/emitter_test.go
@@ -7,13 +7,20 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 )
+
+const testSpanDigest = "sha256:" +
+	"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+const testRedactedSourceSpanValue = "[redacted-value]"
 
 // captureRecorder records entries in memory so tests can extract the signed
 // receipt JSON and verify it offline.
@@ -73,6 +80,38 @@ func decodePayload(t *testing.T, rcpt contractreceipt.EvidenceReceipt) contractr
 	return p
 }
 
+func decodeSpannedPayload(t *testing.T, rcpt contractreceipt.EvidenceReceipt) contractreceipt.PayloadProxyDecisionWithSpansStruct {
+	t.Helper()
+	var p contractreceipt.PayloadProxyDecisionWithSpansStruct
+	if err := json.Unmarshal(rcpt.Payload, &p); err != nil {
+		t.Fatalf("unmarshal spanned payload: %v", err)
+	}
+	return p
+}
+
+func spannedEvidenceFixture() []contractruntime.SourceSpanEvidence {
+	offset, length := 9, len(testRedactedSourceSpanValue)
+	return []contractruntime.SourceSpanEvidence{{
+		Span: contractreceipt.SourceSpan{
+			SourceID:             "req-1",
+			SourceKind:           contractreceipt.SourceKindMCPToolArgs,
+			NormalizedView:       contractreceipt.NormalizedViewDLPNormalized,
+			PipelockBinaryDigest: testSpanDigest,
+			RulesBundleDigest:    testSpanDigest,
+			TransformProfile:     "nfkc+zero-width-strip",
+			PolicyHash:           testSpanDigest,
+			RuleID:               "aws_access_key",
+			Bundle:               "builtin",
+			BundleVersion:        "2026.06.05",
+			CharOffset:           &offset,
+			CharLength:           &length,
+			MatchClass:           "secret:aws_access_key",
+			RedactedSample:       testRedactedSourceSpanValue,
+		},
+		MatchValue: testRedactedSourceSpanValue,
+	}}
+}
+
 func TestEmit_BuildsVerifiableReceipt(t *testing.T) {
 	rec := &captureRecorder{}
 	em, pub, keyID := newTestEmitter(t, rec, nil)
@@ -130,6 +169,195 @@ func TestEmit_BuildsVerifiableReceipt(t *testing.T) {
 	}
 	if p.RuleID != "prompt_injection" {
 		t.Errorf("payload RuleID = %q", p.RuleID)
+	}
+}
+
+func TestEmit_WithSpansBuildsVerifiableReceipt(t *testing.T) {
+	rec := &captureRecorder{}
+	em, pub, keyID := newTestEmitter(t, rec, nil)
+
+	evidence := spannedEvidenceFixture()
+
+	err := em.Emit(Decision{
+		ActionType:         "mcp_tool_call",
+		Transport:          "mcp_stdio",
+		Target:             "tool://example/list",
+		Verdict:            "block",
+		WinningSource:      SourceScanner,
+		PolicySources:      []string{SourceScanner},
+		RuleID:             "aws_access_key",
+		SpanHMACKey:        []byte("span-mac-key"),
+		SourceSpanEvidence: evidence,
+	})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if len(rec.entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(rec.entries))
+	}
+	entry := rec.entries[0]
+	if entry.EventKind != string(contractreceipt.PayloadProxyDecisionWithSpans) {
+		t.Fatalf("entry EventKind = %q, want %q", entry.EventKind, contractreceipt.PayloadProxyDecisionWithSpans)
+	}
+	if !strings.HasPrefix(entry.Summary, string(contractreceipt.PayloadProxyDecisionWithSpans)+":") {
+		t.Fatalf("entry Summary = %q, want spanned payload kind prefix", entry.Summary)
+	}
+
+	rcpt := decodeReceipt(t, entry)
+	if rcpt.PayloadKind != contractreceipt.PayloadProxyDecisionWithSpans {
+		t.Fatalf("PayloadKind = %q, want %q", rcpt.PayloadKind, contractreceipt.PayloadProxyDecisionWithSpans)
+	}
+	if err := contractreceipt.VerifyWithKey(rcpt, pub, keyID); err != nil {
+		t.Fatalf("VerifyWithKey: %v", err)
+	}
+	payload := decodeSpannedPayload(t, rcpt)
+	if len(payload.SourceSpans) != 1 {
+		t.Fatalf("source_spans length = %d, want 1", len(payload.SourceSpans))
+	}
+	span := payload.SourceSpans[0]
+	wantHash, err := contractreceipt.SourceSpanMatchHash([]byte("span-mac-key"), rcpt.EventID, 0, span, testRedactedSourceSpanValue)
+	if err != nil {
+		t.Fatalf("SourceSpanMatchHash: %v", err)
+	}
+	if span.MatchHash != wantHash {
+		t.Fatalf("MatchHash = %q, want event_id-bound hash %q", span.MatchHash, wantHash)
+	}
+	if span.RedactedSample != testRedactedSourceSpanValue {
+		t.Fatalf("RedactedSample = %q, want %q", span.RedactedSample, testRedactedSourceSpanValue)
+	}
+}
+
+func TestEmit_WithSpansRejectsMalformedEvidenceBeforeRecording(t *testing.T) {
+	rec := &captureRecorder{}
+	em, _, _ := newTestEmitter(t, rec, nil)
+	evidence := spannedEvidenceFixture()
+	evidence[0].Span.SourceKind = "bogus"
+
+	err := em.Emit(Decision{
+		ActionType:         "mcp_tool_call",
+		Transport:          "mcp_stdio",
+		Target:             "tool://example/list",
+		Verdict:            "block",
+		WinningSource:      SourceScanner,
+		PolicySources:      []string{SourceScanner},
+		RuleID:             "aws_access_key",
+		SpanHMACKey:        []byte("span-mac-key"),
+		SourceSpanEvidence: evidence,
+	})
+	if !errors.Is(err, contractruntime.ErrInvalidProxyDecisionInput) {
+		t.Fatalf("Emit err = %v, want ErrInvalidProxyDecisionInput", err)
+	}
+	if len(rec.entries) != 0 {
+		t.Fatalf("recorded %d entries despite malformed source span", len(rec.entries))
+	}
+	if seq, _ := em.ChainState(); seq != 0 {
+		t.Fatalf("chain advanced to %d despite malformed source span", seq)
+	}
+}
+
+func TestEmit_WithSpansSanitizesSpanFieldsBeforeSigning(t *testing.T) {
+	const secret = "AKIA" + "IOSFODNN7EXAMPLE"
+	// Active DLP redaction: clean reports false for any text containing the
+	// secret. A caller mistake puts raw matched bytes into "redacted" span
+	// fields; the emitter must scrub them out of the SIGNED spanned payload,
+	// exactly as it does for target/rule_id (#676).
+	clean := func(text string) bool { return !strings.Contains(text, secret) }
+
+	rec := &captureRecorder{}
+	em, pub, keyID := newTestEmitter(t, rec, clean)
+
+	evidence := spannedEvidenceFixture()
+	evidence[0].Span.SourceID = "source:" + secret
+	evidence[0].Span.RedactedSample = "sample:" + secret
+	evidence[0].Span.RuleID = "dlp:" + secret
+	evidence[0].Span.MatchClass = "class:" + secret
+
+	err := em.Emit(Decision{
+		ActionType:         "mcp_tool_call",
+		Transport:          "mcp_stdio",
+		Target:             "tool://example/list",
+		Verdict:            "block",
+		WinningSource:      SourceScanner,
+		PolicySources:      []string{SourceScanner},
+		RuleID:             "aws_access_key",
+		SpanHMACKey:        []byte("span-mac-key"),
+		SourceSpanEvidence: evidence,
+	})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	rcpt := decodeReceipt(t, rec.entries[0])
+	if rcpt.PayloadKind != contractreceipt.PayloadProxyDecisionWithSpans {
+		t.Fatalf("PayloadKind = %q, want %q", rcpt.PayloadKind, contractreceipt.PayloadProxyDecisionWithSpans)
+	}
+	// The signed receipt must still verify after pre-sign sanitization.
+	if err := contractreceipt.VerifyWithKey(rcpt, pub, keyID); err != nil {
+		t.Fatalf("VerifyWithKey: %v", err)
+	}
+	// The whole serialized receipt must be free of the secret.
+	full, err := json.Marshal(rcpt)
+	if err != nil {
+		t.Fatalf("marshal receipt: %v", err)
+	}
+	if strings.Contains(string(full), secret) {
+		t.Fatalf("serialized spanned receipt leaks secret: %s", full)
+	}
+	span := decodeSpannedPayload(t, rcpt).SourceSpans[0]
+	if strings.Contains(span.RedactedSample, secret) {
+		t.Errorf("signed RedactedSample leaks secret: %q", span.RedactedSample)
+	}
+	if strings.Contains(span.RuleID, secret) {
+		t.Errorf("signed span RuleID leaks secret: %q", span.RuleID)
+	}
+	if strings.Contains(span.MatchClass, secret) {
+		t.Errorf("signed span MatchClass leaks secret: %q", span.MatchClass)
+	}
+	wantHash, err := contractreceipt.SourceSpanMatchHash([]byte("span-mac-key"), rcpt.EventID, 0, span, testRedactedSourceSpanValue)
+	if err != nil {
+		t.Fatalf("SourceSpanMatchHash: %v", err)
+	}
+	if span.MatchHash != wantHash {
+		t.Fatalf("MatchHash = %q, want sanitized RuleID-bound hash %q", span.MatchHash, wantHash)
+	}
+	// The caller's evidence slice must not be mutated by sanitization.
+	if evidence[0].Span.SourceID != "source:"+secret {
+		t.Errorf("emitter mutated caller evidence SourceID: %q", evidence[0].Span.SourceID)
+	}
+	if evidence[0].Span.RedactedSample != "sample:"+secret {
+		t.Errorf("emitter mutated caller evidence RedactedSample: %q", evidence[0].Span.RedactedSample)
+	}
+	if evidence[0].Span.RuleID != "dlp:"+secret {
+		t.Errorf("emitter mutated caller evidence RuleID: %q", evidence[0].Span.RuleID)
+	}
+	if evidence[0].Span.MatchClass != "class:"+secret {
+		t.Errorf("emitter mutated caller evidence MatchClass: %q", evidence[0].Span.MatchClass)
+	}
+}
+
+func TestEmit_WithSpansRejectsMissingHMACKey(t *testing.T) {
+	rec := &captureRecorder{}
+	em, _, _ := newTestEmitter(t, rec, nil)
+
+	err := em.Emit(Decision{
+		ActionType:         "mcp_tool_call",
+		Transport:          "mcp_stdio",
+		Target:             "tool://example/list",
+		Verdict:            "block",
+		WinningSource:      SourceScanner,
+		PolicySources:      []string{SourceScanner},
+		RuleID:             "aws_access_key",
+		SpanHMACKey:        nil, // evidence present but no key
+		SourceSpanEvidence: spannedEvidenceFixture(),
+	})
+	if !errors.Is(err, contractruntime.ErrInvalidProxyDecisionInput) {
+		t.Fatalf("Emit err = %v, want ErrInvalidProxyDecisionInput", err)
+	}
+	if len(rec.entries) != 0 {
+		t.Fatalf("recorded %d entries despite missing span HMAC key", len(rec.entries))
+	}
+	if seq, _ := em.ChainState(); seq != 0 {
+		t.Fatalf("chain advanced to %d despite missing span HMAC key", seq)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add optional source-span evidence inputs to the live proxy decision emitter.
- Emit `proxy_decision_with_spans` when span evidence is supplied, otherwise preserve existing `proxy_decision` emission.
- Sanitize free-form serialized span fields before signing and before computing match HMACs, so signed spanned receipts do not carry raw matched bytes.
- Record the evidence entry with the actual payload kind and reject malformed or unkeyed span evidence before recording or advancing the chain.

## Notes
- Stacked on #697.
- This adds the explicit emitter surface for spanned receipts; live scanner evidence/key configuration remains follow-up scope.