### PR TITLE
fix(testdata): force LF line endings for test goldens on Windows checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# This file itself: text with LF (avoids a self-warning on Windows
+# checkouts where core.autocrlf would otherwise convert it to CRLF).
+.gitattributes text eol=lf
+
+# Test fixtures are byte-compared in golden tests. Force LF in the
+# working tree even when the user's core.autocrlf is true; otherwise
+# Windows checkouts get CRLF and tests fail byte-for-byte against
+# the LF-committed goldens without any real content drift.
+**/testdata/** text eol=lf


### PR DESCRIPTION
## Summary

Adds a `.gitattributes` rule pinning files under `testdata/` to LF line
endings so Windows users with the default `core.autocrlf=true` don't
get spurious golden-test failures.

Golden tests under `internal/capture/` and
`internal/capture/replay_harness/` compare bytes against checked-in
fixtures. The fixtures are committed as LF, but on a Windows checkout
Git rewrites the working tree as CRLF. The test regenerator (`-update`)
writes LF, so the byte-compare fails on Windows even when there's no
real content drift.

## Changes

- Add `.gitattributes` at repo root with one effective rule:
  `**/testdata/** text eol=lf`.
- Self-pin `.gitattributes` to LF on the first line so it doesn't trip
  the same warning on its own checkout.
- No test logic or fixture content changed — only the working-tree
  representation.

## Testing

- [x] `make test` passes (verified on Windows for the previously
  failing tests; see below)
- [x] `make vet` passes (no source changes; vet unchanged)
- [ ] New tests added for new functionality (N/A — pure
  test-infrastructure change)
- [x] Tested manually (describe below)

Verified on Windows that the four previously-failing tests now pass:
- `internal/capture`: `TestReplayHarness_CorpusJSONLMatchesGolden`
- `internal/capture`: `TestReplayHarness_CompileMatchesGolden`
- `internal/capture`: `TestReplayHarness_ReplayDiffMatchesGolden`
- `internal/capture/replay_harness`:
  `TestLiveLockReplayHarness_TransportMatrixMatchesGolden`

Verified `go build ./...` still clean and the rest of
`./internal/capture/...` still passes.

Safety check on the broad `testdata/**` glob:
no binary files under any `testdata/` path in the repo (no `.bin`,
`.exe`, `.so`, `.dll`, `.tar`, `.gz`, `.zip`, `.png`, `.jpg`, `.pdf`,
`.go`), so forcing text/LF semantics is safe and avoids needing
per-extension rules now or later.

## Security Considerations

No effect on the scanning pipeline, SSRF protection, DLP patterns, or
audit logging. The change is to working-tree representation of test
fixtures; the index and the runtime behavior of `pipelock` are
identical before and after.

One subtle note: golden tests are part of the *security verification*
surface (they verify replay determinism and live-lock matrix
correctness). Before this PR, those tests were silently skipped or
marked failed on Windows checkouts, meaning Windows contributors got
no real signal from them. After this PR, those tests run for real on
Windows. That's an improvement to the verification surface, not a
regression.

## Followups

This is the first of a series of small PRs to clear up Windows-only
test failures on `main` that aren't bugs in the product code — just
mismatches between Unix test assumptions and Windows semantics. The
remaining clusters (Unix file mode bits, symlink-privilege, procfs,
read-only-directory semantics) will follow as separate PRs with build
tags or platform-aware assertions as appropriate. I have a full
inventory if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated line ending configuration to ensure consistent file formatting across the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->