### PR TITLE
feat(runtime): close in-flight conductor apply window and add license-reload error precision

### DIFF
--- a/enterprise/conductor/applycache/boundary.go
+++ b/enterprise/conductor/applycache/boundary.go
@@ -25,6 +25,15 @@ type Boundary struct {
 	LoadConfig   ConfigLoader
 	Reload       ReloadFunc
 	Now          func() time.Time
+	// StillEntitled, when non-nil, is consulted immediately before the
+	// live-config Reload (the security-relevant commit point). It lets the
+	// caller abort an apply whose fleet entitlement was revoked/expired
+	// mid-flight: teardownConductor runs lock-free against the apply mutex, so a
+	// bundle already past the caller's pre-apply entitlement check could
+	// otherwise complete its Reload and activate one last policy after the fleet
+	// was torn down. Returning false here aborts with ErrEntitlementLost before
+	// anything reaches the running proxy. nil disables the check.
+	StillEntitled func() bool
 }
 
 type ApplyOptions struct {
@@ -62,6 +71,13 @@ func (b Boundary) Apply(bundle conductor.PolicyBundle, opts ApplyOptions) (Appli
 	cfg, err := loadConfig(verified.ConfigPath)
 	if err != nil {
 		return AppliedBundle{}, fmt.Errorf("loading verified conductor policy bundle config: %w", err)
+	}
+	// Last gate before the live-config swap: if the fleet entitlement was torn
+	// down while this bundle was staging/loading, abort now. Staging only wrote
+	// to the cache's staging area (not yet active), so returning here leaves the
+	// running proxy and the durable last-known-good pointer untouched.
+	if b.StillEntitled != nil && !b.StillEntitled() {
+		return AppliedBundle{}, ErrEntitlementLost
 	}
 	if err := b.Reload(cfg); err != nil {
 		return AppliedBundle{}, fmt.Errorf("reloading verified conductor policy bundle config: %w", err)

--- a/enterprise/conductor/applycache/boundary_entitlement_test.go
+++ b/enterprise/conductor/applycache/boundary_entitlement_test.go
@@ -1,0 +1,82 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package applycache
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// TestBoundaryApplyAbortsWhenEntitlementLostBeforeReload proves the in-flight
+// apply window is closed: a verified bundle that finishes staging AFTER the
+// fleet entitlement was torn down must not reach the live-config Reload and must
+// not activate. StillEntitled reporting false is the deterministic stand-in for
+// a teardownConductor that fired mid-apply.
+func TestBoundaryApplyAbortsWhenEntitlementLostBeforeReload(t *testing.T) {
+	key := newTestKey(t)
+	cache := openTestCache(t)
+	reloadCalled := false
+	boundary := Boundary{
+		Cache:        cache,
+		Identity:     testIdentity(),
+		Resolver:     testResolver(key),
+		LocalVersion: "1.2.3",
+		Now:          func() time.Time { return testNow },
+		Reload: func(_ *config.Config) error {
+			reloadCalled = true
+			return nil
+		},
+		StillEntitled: func() bool { return false },
+	}
+
+	_, err := boundary.Apply(signedTestBundle(t, key, "bundle-1", 1, ""), ApplyOptions{})
+	if !errors.Is(err, ErrEntitlementLost) {
+		t.Fatalf("Apply(entitlement lost) = %v, want ErrEntitlementLost", err)
+	}
+	if reloadCalled {
+		t.Fatal("Reload must not run once the fleet entitlement is lost mid-apply")
+	}
+	if _, activeErr := cache.Active(); !errors.Is(activeErr, ErrNoValidBundle) {
+		t.Fatalf("Active() after aborted apply = %v, want ErrNoValidBundle (nothing activated)", activeErr)
+	}
+}
+
+// TestBoundaryApplyProceedsWhenStillEntitled is the positive control: an apply
+// whose StillEntitled stays true reloads and activates normally, proving the
+// guard only blocks the lost-entitlement case.
+func TestBoundaryApplyProceedsWhenStillEntitled(t *testing.T) {
+	key := newTestKey(t)
+	cache := openTestCache(t)
+	reloadCalled := false
+	boundary := Boundary{
+		Cache:        cache,
+		Identity:     testIdentity(),
+		Resolver:     testResolver(key),
+		LocalVersion: "1.2.3",
+		Now:          func() time.Time { return testNow },
+		Reload: func(_ *config.Config) error {
+			reloadCalled = true
+			return nil
+		},
+		StillEntitled: func() bool { return true },
+	}
+
+	applied, err := boundary.Apply(signedTestBundle(t, key, "bundle-1", 1, ""), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply(still entitled) error = %v", err)
+	}
+	if !reloadCalled {
+		t.Fatal("Reload must run when the entitlement is intact")
+	}
+	if applied.ReloadedConfigHash == "" {
+		t.Fatal("ReloadedConfigHash = empty, want an activated bundle")
+	}
+	if _, activeErr := cache.Active(); activeErr != nil {
+		t.Fatalf("Active() after successful apply = %v, want activated bundle", activeErr)
+	}
+}

--- a/enterprise/conductor/applycache/cache.go
+++ b/enterprise/conductor/applycache/cache.go
@@ -40,6 +40,11 @@ var (
 	ErrRollbackRequired      = errors.New("conductor rollback authorization required")
 	ErrInvalidActiveRecord   = errors.New("conductor apply cache active record invalid")
 	ErrUnsupportedMinVersion = errors.New("conductor policy bundle requires unsupported pipelock version")
+	// ErrEntitlementLost aborts an in-flight policy-bundle apply when the fleet
+	// entitlement is revoked/expired/downgraded mid-apply (Boundary.StillEntitled
+	// reports false). It fires before the live-config Reload, so an aborted apply
+	// never reaches the running proxy and never activates a durable bundle.
+	ErrEntitlementLost = errors.New("conductor fleet entitlement lost during policy bundle apply")
 
 	hashPattern = regexp.MustCompile(`\A[a-fA-F0-9]{64}\z`)
 )

--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -110,6 +110,13 @@ func (s *Server) ApplyConductorPolicyBundle(bundle conductor.PolicyBundle, opts 
 		LocalVersion: cliutil.Version,
 		LoadConfig:   config.Load,
 		Reload:       s.Reload,
+		// Close the in-flight apply window: teardownConductor sets conductorDown
+		// without taking conductorApplyMu (that would deadlock the poller's own
+		// apply -> reload -> teardown path), so a bundle already past the
+		// under-lock conductorDown re-check could otherwise complete its Reload
+		// after a concurrent revocation/expiry teardown. Re-checking right before
+		// the boundary's live-config swap aborts that last bundle fail-closed.
+		StillEntitled: func() bool { return !s.conductorDown.Load() },
 	}
 	return boundary.Apply(bundle, applycache.ApplyOptions{
 		Rollback:      opts.Rollback,

--- a/internal/cli/runtime/conductor_teardown_test.go
+++ b/internal/cli/runtime/conductor_teardown_test.go
@@ -165,6 +165,51 @@ func TestApplyConductorPolicyBundle_FailsAfterTeardown(t *testing.T) {
 	}
 }
 
+// TestApplyConductorPolicyBundle_TeardownMidApplyAborts closes the in-flight
+// window the entry/under-lock conductorDown checks cannot: a bundle that passes
+// both guards and then loses its fleet entitlement WHILE staging must not reach
+// the live-config reload or activate. The signature resolver is the injection
+// seam — it runs during staging, after both guards, so flipping conductorDown
+// there reproduces "teardownConductor fired mid-apply" deterministically.
+func TestApplyConductorPolicyBundle_TeardownMidApplyAborts(t *testing.T) {
+	s, signer := newConductorApplyTestServer(t)
+	liveBefore := s.proxy.CurrentConfig()
+	bundle := signedRuntimePolicyBundle(t, signer, "bundle-1", 1, "", strings.Join([]string{
+		"mode: strict",
+		"api_allowlist:",
+		"  - api.example.com",
+		"",
+	}, "\n"))
+
+	// Real resolver, wrapped to tear down the fleet entitlement the first time
+	// it is consulted (i.e. during signature verification in staging).
+	base := signer.resolver()
+	teardownDuringStage := func(keyID string) (conductor.SignatureKey, error) {
+		s.teardownConductor("revoked mid-apply")
+		return base(keyID)
+	}
+
+	_, err := s.ApplyConductorPolicyBundle(bundle, ConductorApplyOptions{Resolver: teardownDuringStage})
+	if !errors.Is(err, applycache.ErrEntitlementLost) {
+		t.Fatalf("ApplyConductorPolicyBundle with mid-apply teardown = %v, want ErrEntitlementLost", err)
+	}
+	// The live proxy config must be untouched: the bundle never reloaded.
+	if live := s.proxy.CurrentConfig(); live == nil || live.Mode == config.ModeStrict {
+		t.Fatalf("live mode = %v, want the pre-apply mode (bundle must not have reloaded)", live)
+	}
+	if liveBefore != nil && s.proxy.CurrentConfig().Mode != liveBefore.Mode {
+		t.Fatal("live config changed despite aborted apply")
+	}
+	// Nothing activated in the durable cache.
+	cache, _ := s.conductorApply.(*applycache.Cache)
+	if cache == nil {
+		t.Fatalf("conductorApply: want *applycache.Cache, got %T", s.conductorApply)
+	}
+	if _, activeErr := cache.Active(); !errors.Is(activeErr, applycache.ErrNoValidBundle) {
+		t.Fatalf("Active() after aborted apply = %v, want ErrNoValidBundle", activeErr)
+	}
+}
+
 // TestRefreshLicenseCRL_RevokedTearsDownConductor proves gap 2 is closed: the
 // runtime CRL watcher tears down a running Conductor follower (not just agent
 // listeners) when the license is revoked, including the conductor-only case
@@ -237,6 +282,57 @@ func TestReload_NoLicenseChangeKeepsConductor(t *testing.T) {
 	}
 	if s.conductorDown.Load() {
 		t.Fatal("a reload that does not change license inputs must not tear down Conductor")
+	}
+}
+
+// TestReload_UnverifiableLicenseInputKeepsConductor proves the Item B fix on
+// the Conductor surface: a reload that introduces an UNVERIFIABLE new license
+// input (an unreadable CRL path) must NOT tear down a still-entitled follower.
+// License inputs are restart-only, so the effective fleet entitlement (the env
+// token installed by the fixture) is unchanged; tearing down on a typo would be
+// a denial-of-service, not fail-closed security.
+func TestReload_UnverifiableLicenseInputKeepsConductor(t *testing.T) {
+	s, _ := newConductorApplyTestServer(t)
+	_, cancel := context.WithCancel(context.Background())
+	s.setConductorCancel(cancel)
+
+	newCfg := s.proxy.CurrentConfig().Clone()
+	newCfg.LicenseCRLFile = filepath.Join(t.TempDir(), "missing.crl.json")
+
+	if err := s.Reload(newCfg); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if s.conductorDown.Load() {
+		t.Fatal("an unverifiable new CRL input must NOT tear down a still-entitled Conductor")
+	}
+	if s.proxy.CurrentConfig() == nil {
+		t.Fatal("proxy/detection must keep running")
+	}
+}
+
+// TestReload_RevokedLicenseTearsDownConductor proves the genuine-loss side of
+// the Item B classification: a reload whose new license inputs PROVE revocation
+// (a signed CRL revoking the token) tears the follower down fail-closed, exactly
+// like the fleet-downgrade case.
+func TestReload_RevokedLicenseTearsDownConductor(t *testing.T) {
+	s, _ := newConductorApplyTestServer(t)
+	_, cancel := context.WithCancel(context.Background())
+	s.setConductorCancel(cancel)
+
+	tok, pubHex, crlPath := revokedLicenseConfigFixture(t)
+	newCfg := s.proxy.CurrentConfig().Clone()
+	newCfg.LicenseKey = tok
+	newCfg.LicensePublicKey = pubHex
+	newCfg.LicenseCRLFile = crlPath
+
+	if err := s.Reload(newCfg); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if !s.conductorDown.Load() {
+		t.Fatal("a reload with a revoked license must tear down Conductor")
+	}
+	if s.proxy.CurrentConfig() == nil {
+		t.Fatal("proxy/detection must keep running after a revocation teardown")
 	}
 }
 

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -163,56 +163,71 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			!bytes.Equal(oldCfg.LicenseIntermediateCert, newCfg.LicenseIntermediateCert) ||
 			oldCfg.LicenseIntermediateLoadError != newCfg.LicenseIntermediateLoadError
 
-		// Parity with agents: re-verify the fleet entitlement on a
-		// license-input reload. EnforceLicenseGate (run during Load) strips
-		// agents when the new license is invalid, but it never touches the
-		// follower-side Conductor runtime. Without this, a reload pointing at a
-		// revoked, expired, or fleet-downgraded license would leave a running
-		// Conductor follower participating until restart. Evaluate against the
-		// NEW license inputs here, BEFORE the branch below preserves the old
-		// values as restart-only; tear down after the branch runs.
-		conductorFleetLost := false
-		if oldCfg.Conductor.Enabled && (agentsRevokedByLicense || licenseInputsChanged) {
-			if _, ferr := license.VerifyFleetWithIntermediate(
-				newCfg.LicenseKey, newCfg.LicensePublicKey, newCfg.LicenseCRLFile, newCfg.LicenseIntermediateFile,
-			); ferr != nil {
-				conductorFleetLost = true
-			}
+		// Re-verify the NEW license inputs ONCE and classify the result so both
+		// paid surfaces — agent listeners and the Conductor follower — make the
+		// SAME decision. License inputs are restart-only: a reload never
+		// activates a new license. So an UNVERIFIABLE new input (unreadable or
+		// malformed CRL, intermediate, public key, or token) leaves the effective
+		// entitlement intact and must NOT tear down a running surface — that would
+		// be a denial-of-service on an operator typo, not fail-closed security.
+		// Only PROVEN loss (revoked, expired, or a cleanly-verified token that no
+		// longer carries the feature) tears a surface down. Genuine runtime
+		// revocation/expiry of the ACTIVE license is still enforced independently
+		// by the CRL watcher and the expiry timer, against the effective license
+		// state. EnforceLicenseGate (run during Load) stays strictly fail-closed
+		// because at startup there is no prior entitlement to preserve; this
+		// reload-only precision is the only place an old-vs-new baseline exists.
+		reloadLicenseChecked := agentsRevokedByLicense || licenseInputsChanged
+		var (
+			reloadLic   license.License
+			reloadClass = license.ReloadVerified
+		)
+		if reloadLicenseChecked {
+			reloadLic, reloadClass = license.ClassifyReload(
+				newCfg.LicenseKey, newCfg.LicensePublicKey, newCfg.LicenseCRLFile, newCfg.LicenseIntermediateFile)
 		}
+		conductorFleetLost := oldCfg.Conductor.Enabled && reloadLicenseChecked &&
+			reloadClass.ProvesLoss(reloadLic, license.FeatureFleet)
 
-		if agentsRevokedByLicense {
-			// License gate disabled agents on reload. Shut down
-			// already-bound listener servers so the agent ports
-			// stop accepting traffic.
+		switch {
+		case agentsRevokedByLicense && reloadClass.ProvesLoss(reloadLic, license.FeatureAgents):
+			// License gate disabled agents on reload and the loss is PROVEN
+			// (revoked / expired / downgraded). Shut down already-bound listener
+			// servers so the agent ports stop accepting traffic.
 			s.proxy.ShutdownAgentServers()
 			_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: license revoked agents, shutting down agent listeners\n")
-		} else if licenseInputsChanged {
-			// License inputs changed but agents were not revoked.
-			// Preserve ALL old license state so a reload cannot
-			// activate licensed features without a restart. We
-			// must also preserve the old license input fields
-			// themselves; otherwise the new values get committed
-			// to the live config and a subsequent unrelated reload
-			// would see no diff, silently applying the staged
+		case agentsRevokedByLicense || licenseInputsChanged:
+			// Either the new license inputs are UNVERIFIABLE (agents were stripped
+			// at Load but the effective entitlement is unchanged — a fat-fingered
+			// path must not DoS a licensed surface) or the inputs simply changed.
+			// Both are restart-only: preserve ALL old license state and the old
+			// agents so a reload can neither activate nor deactivate licensed
+			// features without a restart. Preserving the input fields themselves is
+			// mandatory; otherwise the new values commit to the live config and a
+			// later unrelated reload sees no diff and silently applies the staged
 			// license.
-			newCfg.Agents = oldCfg.Agents
-			newCfg.LicenseKey = oldCfg.LicenseKey
-			newCfg.LicenseFile = oldCfg.LicenseFile
-			newCfg.LicenseCRLFile = oldCfg.LicenseCRLFile
-			newCfg.LicenseIntermediateFile = oldCfg.LicenseIntermediateFile
-			newCfg.LicenseIntermediateCert = append([]byte(nil), oldCfg.LicenseIntermediateCert...)
-			newCfg.LicenseIntermediateLoadError = oldCfg.LicenseIntermediateLoadError
-			newCfg.LicensePublicKey = oldCfg.LicensePublicKey
-			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: license key inputs changed (license_key, license_file, license_crl_file, license_intermediate_file, or license_public_key) - requires restart for license re-verification\n")
-		} else if AgentListenersChanged(oldCfg, newCfg) {
+			preserveLicenseInputsRestartOnly(newCfg, oldCfg)
+			if agentsRevokedByLicense {
+				_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: new license inputs could not be verified (unreadable/malformed CRL, intermediate, or token); effective license unchanged, preserving licensed surfaces — requires restart for license re-verification\n")
+			} else {
+				_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: license key inputs changed (license_key, license_file, license_crl_file, license_intermediate_file, or license_public_key) - requires restart for license re-verification\n")
+			}
+		case AgentListenersChanged(oldCfg, newCfg):
 			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: agents[*].listeners changed — requires restart, ignoring listener changes\n")
 			PreserveAgentListeners(oldCfg, newCfg)
 		}
+
 		if conductorFleetLost {
-			// New license inputs no longer carry a valid fleet entitlement:
-			// stop the running Conductor follower fail-closed. Detection keeps
-			// running; Conductor stays down until restart.
+			// New license inputs PROVE the fleet entitlement is gone: stop the
+			// running Conductor follower fail-closed. Detection keeps running;
+			// Conductor stays down until restart.
 			s.teardownConductor("reload revoked fleet entitlement")
+		} else if oldCfg.Conductor.Enabled && reloadLicenseChecked && reloadClass == license.ReloadUnverifiable {
+			// Conductor stays up: unverifiable new inputs cannot PROVE the fleet
+			// entitlement was lost, so tearing the follower down here would be a
+			// DoS on an operator typo. Warn for SOC visibility — the conductor
+			// analogue of the agents preserve path above.
+			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: new license inputs could not be verified; Conductor fleet entitlement unchanged, follower stays running — requires restart for license re-verification\n")
 		}
 		// Carry forward runtime-derived license expiry.
 		// LicenseExpiresAt is set by EnforceLicenseGate at startup,
@@ -311,6 +326,23 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 	s.logger.LogConfigReload("success", fmt.Sprintf("mode=%s", newCfg.Mode), reloadHash)
 	s.recordReloadSuccess(reloadHash)
 	return nil
+}
+
+// preserveLicenseInputsRestartOnly copies the old license inputs and agent
+// profiles onto newCfg so a reload cannot activate OR deactivate licensed
+// surfaces without a restart. Used for both a plain license-input change and an
+// unverifiable new input: in both cases the effective entitlement is the old,
+// already-verified one, and committing the new input fields would let a later
+// unrelated reload see no diff and silently apply the staged license.
+func preserveLicenseInputsRestartOnly(newCfg, oldCfg *config.Config) {
+	newCfg.Agents = oldCfg.Agents
+	newCfg.LicenseKey = oldCfg.LicenseKey
+	newCfg.LicenseFile = oldCfg.LicenseFile
+	newCfg.LicenseCRLFile = oldCfg.LicenseCRLFile
+	newCfg.LicenseIntermediateFile = oldCfg.LicenseIntermediateFile
+	newCfg.LicenseIntermediateCert = append([]byte(nil), oldCfg.LicenseIntermediateCert...)
+	newCfg.LicenseIntermediateLoadError = oldCfg.LicenseIntermediateLoadError
+	newCfg.LicensePublicKey = oldCfg.LicensePublicKey
 }
 
 // cleanup closes all owned resources. Safe to call multiple times: each

--- a/internal/cli/runtime/server_reload_license_test.go
+++ b/internal/cli/runtime/server_reload_license_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+// realValidAgentsLicense issues a genuine, currently-valid agents-feature token
+// and returns it with its verifier public key (hex). No CRL.
+func realValidAgentsLicense(t *testing.T) (token, pubHex string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	now := time.Now().UTC()
+	tok, err := license.Issue(license.License{
+		ID:        "reload-valid-agents",
+		Email:     "test@example.com",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(time.Hour).Unix(),
+		Features:  []string{license.FeatureAgents},
+	}, priv)
+	if err != nil {
+		t.Fatalf("license.Issue: %v", err)
+	}
+	return tok, hex.EncodeToString(pub)
+}
+
+// realRevokedAgentsLicense issues a genuine agents-feature token AND a signed
+// CRL that revokes it, writes the CRL to disk, and returns the token, its
+// verifier public key (hex), and the CRL path. Verifying the token against the
+// CRL yields a PROVEN revocation (ErrLicenseRevoked).
+func realRevokedAgentsLicense(t *testing.T) (token, pubHex, crlPath string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	now := time.Now().UTC()
+	const id = "reload-revoked-agents"
+	tok, err := license.Issue(license.License{
+		ID:        id,
+		Email:     "test@example.com",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(time.Hour).Unix(),
+		Features:  []string{license.FeatureAgents},
+	}, priv)
+	if err != nil {
+		t.Fatalf("license.Issue: %v", err)
+	}
+	crl, err := license.SignCRL(license.CRLPayload{
+		Version:   license.CRLVersion,
+		IssuedAt:  now.Add(-time.Minute).Unix(),
+		ExpiresAt: now.Add(time.Hour).Unix(),
+		Revoked: []license.RevokedLicense{{
+			ID:        id,
+			Reason:    "test revocation",
+			RevokedAt: now.Unix(),
+		}},
+	}, priv)
+	if err != nil {
+		t.Fatalf("license.SignCRL: %v", err)
+	}
+	data, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatalf("Marshal CRL: %v", err)
+	}
+	crlPath = filepath.Join(t.TempDir(), "revoke.crl.json")
+	if err := os.WriteFile(crlPath, data, 0o600); err != nil {
+		t.Fatalf("WriteFile(CRL): %v", err)
+	}
+	return tok, hex.EncodeToString(pub), crlPath
+}
+
+// TestServer_ReloadUnverifiableLicenseInputPreservesAgents proves the Item B
+// fix on the agent surface: a reload that introduces an UNVERIFIABLE new
+// license input (here a fat-fingered, unreadable CRL path) must NOT tear down a
+// legitimately-licensed agent surface. License inputs are restart-only, so the
+// effective entitlement is the old verified one; tearing down on a typo would be
+// a denial-of-service, not fail-closed security. The named agents are preserved
+// restart-only and a warning is surfaced.
+func TestServer_ReloadUnverifiableLicenseInputPreservesAgents(t *testing.T) {
+	s, buf := newTestServer(t, nil)
+	tok, pubHex := realValidAgentsLicense(t)
+	oldCfg := s.proxy.CurrentConfig()
+	oldCfg.Agents = map[string]config.AgentProfile{
+		"agent-a": {Mode: config.ModeStrict},
+	}
+	oldCfg.LicenseKey = tok
+	oldCfg.LicensePublicKey = pubHex
+	oldCfg.LicenseExpiresAt = time.Now().Add(time.Hour).Unix()
+
+	// Simulate EnforceLicenseGate's strip at reload-Load (no _default profile, so
+	// the failed verification leaves Agents nil) while the new CRL input is
+	// unreadable. The effective license is unchanged.
+	newCfg := oldCfg.Clone()
+	newCfg.Agents = nil
+	newCfg.LicenseCRLFile = filepath.Join(t.TempDir(), "missing.crl.json")
+
+	if err := s.Reload(newCfg); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	live := s.proxy.CurrentConfig()
+	if live.Agents == nil {
+		t.Fatal("unverifiable new license input tore down a still-entitled agent surface (DoS on typo)")
+	}
+	if _, ok := live.Agents["agent-a"]; !ok {
+		t.Fatalf("named agent not preserved restart-only: %+v", live.Agents)
+	}
+	if !buf.contains("new license inputs could not be verified") {
+		t.Fatalf("stderr missing unverifiable-input warning:\n%s", buf.String())
+	}
+	if buf.contains("license revoked agents, shutting down agent listeners") {
+		t.Fatalf("must not log a revocation shutdown for an unverifiable input:\n%s", buf.String())
+	}
+}

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -840,19 +840,24 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 
 func TestServer_ReloadLicenseRevocationStripsAgents(t *testing.T) {
 	s, buf := newTestServer(t, nil)
+	// A genuine revoked token: the reload path must CONFIRM the revocation by
+	// re-verifying the inputs (ProvesLoss), not just trust that the agents were
+	// stripped, before shutting the listeners down. Fake placeholder tokens
+	// would classify as unverifiable and be preserved restart-only instead.
+	tok, pubHex, crlPath := realRevokedAgentsLicense(t)
 	oldCfg := s.proxy.CurrentConfig()
 	oldCfg.Agents = map[string]config.AgentProfile{
 		"agent-a": {Mode: config.ModeStrict},
 	}
-	oldCfg.LicenseKey = "old-agents-token"
-	oldCfg.LicensePublicKey = "old-public-key"
+	oldCfg.LicenseKey = tok
+	oldCfg.LicensePublicKey = pubHex
+	oldCfg.LicenseCRLFile = crlPath
 	oldCfg.LicenseExpiresAt = time.Now().Add(time.Hour).Unix()
 
+	// Simulate EnforceLicenseGate's strip at reload-Load (the revoked token left
+	// no named agents); the license inputs are otherwise unchanged.
 	newCfg := oldCfg.Clone()
 	newCfg.Agents = nil
-	newCfg.LicenseKey = "revoked-agents-token"
-	newCfg.LicenseRevoked = true
-	newCfg.LicenseRevocationReason = "test revocation"
 
 	if err := s.Reload(newCfg); err != nil {
 		t.Fatalf("Reload: %v", err)

--- a/internal/license/fleet_gate.go
+++ b/internal/license/fleet_gate.go
@@ -69,16 +69,31 @@ func VerifyFleet(licenseKey, publicKeyHex, crlFile string) (License, error) {
 	return VerifyFleetWithIntermediate(licenseKey, publicKeyHex, crlFile, "")
 }
 
-// VerifyFleetWithIntermediate verifies the supplied fleet license, optionally
-// using a configured intermediate certificate file. Empty intermediateFile
-// falls back to PIPELOCK_LICENSE_INTERMEDIATE_FILE, then legacy direct-root
-// verification if neither is set.
-func VerifyFleetWithIntermediate(licenseKey, publicKeyHex, crlFile, intermediateFile string) (License, error) {
+// errNoLicenseToken and errNoVerifierKey are the unverifiable-input causes that
+// verifyLicenseInputs returns before any token verification can run. They are
+// unexported because callers classify by behavior (any non-revoked/non-expired
+// failure is "unverifiable"), not by these specific identities; VerifyFleet*
+// wraps them in ErrFleetLicenseRequired for the operator-facing message.
+var (
+	errNoLicenseToken = errors.New("no license token provided")
+	errNoVerifierKey  = errors.New("no verifier public key available " +
+		"(build-embedded key missing and PIPELOCK_LICENSE_PUBLIC_KEY unset)")
+)
+
+// verifyLicenseInputs resolves the verifier public key, loads the optional
+// signed CRL and intermediate certificate, and verifies the token signature,
+// expiry, and revocation — but performs NO feature check. The fleet gate
+// (VerifyFleetWithIntermediate) and the hot-reload classifier (ClassifyReload)
+// share this one input-handling path so they never drift on key resolution,
+// env fallback, or CRL/intermediate loading. The returned error preserves
+// ErrLicenseRevoked / ErrLicenseExpired in its chain so callers can distinguish
+// proven entitlement loss from an unverifiable/malformed input.
+func verifyLicenseInputs(licenseKey, publicKeyHex, crlFile, intermediateFile string) (License, error) {
 	if licenseKey == "" {
 		licenseKey = os.Getenv(EnvLicenseKey)
 	}
 	if licenseKey == "" {
-		return License{}, ErrFleetLicenseRequired
+		return License{}, errNoLicenseToken
 	}
 	pubKey := EmbeddedPublicKey()
 	if pubKey == nil {
@@ -93,9 +108,7 @@ func VerifyFleetWithIntermediate(licenseKey, publicKeyHex, crlFile, intermediate
 		}
 	}
 	if pubKey == nil {
-		return License{}, fmt.Errorf("%w: no verifier public key available "+
-			"(build-embedded key missing and PIPELOCK_LICENSE_PUBLIC_KEY unset)",
-			ErrFleetLicenseRequired)
+		return License{}, errNoVerifierKey
 	}
 	if crlFile == "" {
 		crlFile = os.Getenv(EnvLicenseCRLFile)
@@ -104,7 +117,7 @@ func VerifyFleetWithIntermediate(licenseKey, publicKeyHex, crlFile, intermediate
 	if crlFile != "" {
 		loaded, crlErr := LoadAndVerifyCRL(crlFile, pubKey, time.Now())
 		if crlErr != nil {
-			return License{}, fmt.Errorf("%w: loading license CRL: %w", ErrFleetLicenseRequired, crlErr)
+			return License{}, fmt.Errorf("loading license CRL: %w", crlErr)
 		}
 		crl = &loaded
 	}
@@ -115,12 +128,19 @@ func VerifyFleetWithIntermediate(licenseKey, publicKeyHex, crlFile, intermediate
 	if intermediateFile != "" {
 		data, loadErr := LoadIntermediateCertFile(intermediateFile)
 		if loadErr != nil {
-			return License{}, fmt.Errorf("%w: loading intermediate certificate: %w", ErrFleetLicenseRequired, loadErr)
+			return License{}, fmt.Errorf("loading intermediate certificate: %w", loadErr)
 		}
 		intermediateCert = data
 	}
+	return VerifyTokenWithOptionalIntermediate(licenseKey, intermediateCert, pubKey, crl, time.Now())
+}
 
-	lic, err := VerifyTokenWithOptionalIntermediate(licenseKey, intermediateCert, pubKey, crl, time.Now())
+// VerifyFleetWithIntermediate verifies the supplied fleet license, optionally
+// using a configured intermediate certificate file. Empty intermediateFile
+// falls back to PIPELOCK_LICENSE_INTERMEDIATE_FILE, then legacy direct-root
+// verification if neither is set.
+func VerifyFleetWithIntermediate(licenseKey, publicKeyHex, crlFile, intermediateFile string) (License, error) {
+	lic, err := verifyLicenseInputs(licenseKey, publicKeyHex, crlFile, intermediateFile)
 	if err != nil {
 		return License{}, fmt.Errorf("%w: %w", ErrFleetLicenseRequired, err)
 	}

--- a/internal/license/reload_class.go
+++ b/internal/license/reload_class.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import "errors"
+
+// ReloadClass classifies a license re-verification performed during a hot
+// config reload, so the paid-surface gates (agent listeners, the Conductor
+// follower) can distinguish PROVEN entitlement loss from an UNVERIFIABLE new
+// input.
+//
+// License inputs are restart-only: a reload never activates a new license, it
+// preserves the old verified entitlement and warns. So an unreadable or
+// malformed NEW input (a fat-fingered crl_file path, a corrupt intermediate, a
+// bad-signature token) does not change the effective entitlement and must NOT
+// tear down a running paid surface — tearing down there is a denial-of-service
+// on an operator typo, not fail-closed security. Only a NEW input that PROVES
+// the entitlement is gone (revoked, expired, or a cleanly-verified token that
+// no longer carries the feature) tears the surface down. Genuine runtime
+// revocation/expiry of the ACTIVE license is still enforced independently by
+// the CRL watcher and the expiry timer, against the effective license state.
+type ReloadClass int
+
+const (
+	// ReloadUnverifiable: the new license inputs could not be verified at all
+	// (no token, no verifier key, unreadable/malformed CRL or intermediate, or
+	// an invalid signature). The effective (restart-only) entitlement is
+	// unchanged — preserve the running surface and warn loudly.
+	ReloadUnverifiable ReloadClass = iota
+	// ReloadRevoked: the token verified but a loaded CRL revokes it. Proven
+	// loss — tear the surface down fail-closed.
+	ReloadRevoked
+	// ReloadExpired: the token verified but is past its expiry. Proven loss.
+	ReloadExpired
+	// ReloadVerified: the token verified cleanly. The caller must still check
+	// HasFeature on the returned License: a verified token that no longer
+	// carries the surface's feature is a genuine downgrade (proven loss); a
+	// verified token that still carries it means no loss at all.
+	ReloadVerified
+)
+
+// ClassifyReload verifies the supplied license inputs the same way the fleet
+// gate does (shared verifyLicenseInputs core: identical key resolution, env
+// fallback, and CRL/intermediate loading) but classifies the outcome for a
+// hot-reload teardown decision instead of checking a specific feature. On
+// ReloadVerified it returns the decoded License so the caller can apply its own
+// HasFeature test; otherwise the returned License is zero.
+func ClassifyReload(licenseKey, publicKeyHex, crlFile, intermediateFile string) (License, ReloadClass) {
+	lic, err := verifyLicenseInputs(licenseKey, publicKeyHex, crlFile, intermediateFile)
+	switch {
+	case err == nil:
+		return lic, ReloadVerified
+	case errors.Is(err, ErrLicenseRevoked):
+		return License{}, ReloadRevoked
+	case errors.Is(err, ErrLicenseExpired):
+		return License{}, ReloadExpired
+	default:
+		return License{}, ReloadUnverifiable
+	}
+}
+
+// ProvesLoss reports whether a reload classification (paired with the verified
+// license, when ReloadVerified) proves the named feature entitlement was lost
+// and the surface must be torn down. ReloadUnverifiable always returns false:
+// an input that cannot be verified cannot prove loss. This is the single
+// decision both gates (agents + Conductor) consult, so they stay in lockstep.
+func (c ReloadClass) ProvesLoss(lic License, feature string) bool {
+	switch c {
+	case ReloadRevoked, ReloadExpired:
+		return true
+	case ReloadVerified:
+		return !lic.HasFeature(feature)
+	default: // ReloadUnverifiable
+		return false
+	}
+}

--- a/internal/license/reload_class_test.go
+++ b/internal/license/reload_class_test.go
@@ -6,6 +6,7 @@ package license
 import (
 	"crypto/ed25519"
 	"encoding/hex"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -149,9 +150,11 @@ func TestClassifyReloadSharesFleetGateInputHandling(t *testing.T) {
 	tok := mustIssue(t, priv, "lic-shared", []string{FeatureFleet})
 	crl := writeTestCRLFile(t, priv, "lic-shared")
 
-	// Gate path: VerifyFleetWithIntermediate must still surface ErrLicenseRevoked.
-	if _, err := VerifyFleetWithIntermediate(tok, pubHex, crl, ""); err == nil {
-		t.Fatal("VerifyFleetWithIntermediate(revoked) = nil, want error")
+	// Gate path: VerifyFleetWithIntermediate must still surface ErrLicenseRevoked
+	// in its error chain (not merely return some error), proving the shared
+	// verifyLicenseInputs core propagates the sentinel both ways.
+	if _, err := VerifyFleetWithIntermediate(tok, pubHex, crl, ""); !errors.Is(err, ErrLicenseRevoked) {
+		t.Fatalf("VerifyFleetWithIntermediate(revoked) = %v, want ErrLicenseRevoked in chain", err)
 	}
 	// Classifier path: same inputs classify as revoked.
 	if _, class := ClassifyReload(tok, pubHex, crl, ""); class != ReloadRevoked {

--- a/internal/license/reload_class_test.go
+++ b/internal/license/reload_class_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// clearLicenseEnv neutralizes the env fallbacks verifyLicenseInputs consults so
+// the classifier tests are hermetic regardless of the ambient environment.
+func clearLicenseEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(EnvLicenseKey, "")
+	t.Setenv(EnvLicensePublicKey, "")
+	t.Setenv(EnvLicenseCRLFile, "")
+	t.Setenv(EnvLicenseIntermediateFile, "")
+}
+
+func issueWithExpiry(t *testing.T, priv ed25519.PrivateKey, id string, features []string, expiresAt time.Time) string {
+	t.Helper()
+	tok, err := Issue(License{
+		ID:        id,
+		Email:     "test@example.com",
+		IssuedAt:  time.Now().Add(-2 * time.Hour).Unix(),
+		ExpiresAt: expiresAt.Unix(),
+		Features:  features,
+	}, priv)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	return tok
+}
+
+func writeGarbageFile(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("}{ not valid json at all"), 0o600); err != nil {
+		t.Fatalf("WriteFile(garbage): %v", err)
+	}
+	return path
+}
+
+func TestClassifyReload(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	pubHex := hex.EncodeToString(pub)
+	otherPub, otherPriv := newKeyPair(t)
+	_ = otherPub
+
+	validBoth := mustIssue(t, priv, "lic-both", []string{FeatureAgents, FeatureFleet})
+	agentsOnly := mustIssue(t, priv, "lic-agents", []string{FeatureAgents})
+	revokedTok := mustIssue(t, priv, "lic-revoked", []string{FeatureAgents, FeatureFleet})
+	revokedCRL := writeTestCRLFile(t, priv, "lic-revoked")
+	expiredTok := issueWithExpiry(t, priv, "lic-expired", []string{FeatureAgents, FeatureFleet}, time.Now().Add(-time.Hour))
+	wrongKeyTok := mustIssue(t, otherPriv, "lic-wrongkey", []string{FeatureFleet})
+	garbageCRL := writeGarbageFile(t, "bad.crl.json")
+
+	tests := []struct {
+		name             string
+		licenseKey       string
+		crlFile          string
+		wantClass        ReloadClass
+		fleetProvesLoss  bool
+		agentsProvesLoss bool
+	}{
+		{
+			name:             "verified with both features",
+			licenseKey:       validBoth,
+			wantClass:        ReloadVerified,
+			fleetProvesLoss:  false,
+			agentsProvesLoss: false,
+		},
+		{
+			name:             "verified agents-only is a fleet downgrade",
+			licenseKey:       agentsOnly,
+			wantClass:        ReloadVerified,
+			fleetProvesLoss:  true, // lost fleet
+			agentsProvesLoss: false,
+		},
+		{
+			name:             "revoked proves loss of every feature",
+			licenseKey:       revokedTok,
+			crlFile:          revokedCRL,
+			wantClass:        ReloadRevoked,
+			fleetProvesLoss:  true,
+			agentsProvesLoss: true,
+		},
+		{
+			name:             "expired proves loss of every feature",
+			licenseKey:       expiredTok,
+			wantClass:        ReloadExpired,
+			fleetProvesLoss:  true,
+			agentsProvesLoss: true,
+		},
+		{
+			name:             "unreadable CRL is unverifiable, proves nothing",
+			licenseKey:       validBoth,
+			crlFile:          garbageCRL,
+			wantClass:        ReloadUnverifiable,
+			fleetProvesLoss:  false,
+			agentsProvesLoss: false,
+		},
+		{
+			name:             "bad signature is unverifiable, proves nothing",
+			licenseKey:       wrongKeyTok,
+			wantClass:        ReloadUnverifiable,
+			fleetProvesLoss:  false,
+			agentsProvesLoss: false,
+		},
+		{
+			name:             "empty token is unverifiable, proves nothing",
+			licenseKey:       "",
+			wantClass:        ReloadUnverifiable,
+			fleetProvesLoss:  false,
+			agentsProvesLoss: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clearLicenseEnv(t)
+			lic, class := ClassifyReload(tc.licenseKey, pubHex, tc.crlFile, "")
+			if class != tc.wantClass {
+				t.Fatalf("ClassifyReload class = %v, want %v", class, tc.wantClass)
+			}
+			if got := class.ProvesLoss(lic, FeatureFleet); got != tc.fleetProvesLoss {
+				t.Errorf("ProvesLoss(fleet) = %v, want %v", got, tc.fleetProvesLoss)
+			}
+			if got := class.ProvesLoss(lic, FeatureAgents); got != tc.agentsProvesLoss {
+				t.Errorf("ProvesLoss(agents) = %v, want %v", got, tc.agentsProvesLoss)
+			}
+		})
+	}
+}
+
+// TestClassifyReloadUnverifiableMatchesFleetGate proves the classifier and the
+// fleet gate share one input-handling path: every input shape the gate rejects
+// as a hard error is classified, and the genuine-loss shapes (revoked) surface
+// the same sentinel both ways.
+func TestClassifyReloadSharesFleetGateInputHandling(t *testing.T) {
+	clearLicenseEnv(t)
+	pub, priv := newKeyPair(t)
+	pubHex := hex.EncodeToString(pub)
+	tok := mustIssue(t, priv, "lic-shared", []string{FeatureFleet})
+	crl := writeTestCRLFile(t, priv, "lic-shared")
+
+	// Gate path: VerifyFleetWithIntermediate must still surface ErrLicenseRevoked.
+	if _, err := VerifyFleetWithIntermediate(tok, pubHex, crl, ""); err == nil {
+		t.Fatal("VerifyFleetWithIntermediate(revoked) = nil, want error")
+	}
+	// Classifier path: same inputs classify as revoked.
+	if _, class := ClassifyReload(tok, pubHex, crl, ""); class != ReloadRevoked {
+		t.Fatalf("ClassifyReload(revoked) = %v, want ReloadRevoked", class)
+	}
+}


### PR DESCRIPTION
Follow-up to #707 closing the two precision gaps deferred from its review.

## Item A: in-flight conductor apply window

`teardownConductor` sets `conductorDown` lock-free against the apply mutex (taking it would deadlock the poller's apply, reload, teardown path). A policy bundle already past the under-lock `conductorDown` re-check could otherwise complete its live-config reload and durable activate after a concurrent revocation/expiry teardown.

A `StillEntitled func() bool` is threaded into `applycache.Boundary.Apply` and checked immediately before the live-config reload (the commit point). If the fleet entitlement was lost mid-apply it aborts with `ErrEntitlementLost` before anything reaches the running proxy or the durable last-known-good pointer. Teardown stays lock-free.

## Item B: malformed input vs proven entitlement loss

License inputs are restart-only: a hot reload never activates a new license. The reload teardown previously treated every verification failure identically, so an unverifiable new input (an unreadable or malformed CRL, intermediate, or token, e.g. an operator typo in a file path) tore down a paid surface even though the effective (old) entitlement was intact. That is a denial-of-service on a typo, not fail-closed security.

`license.ClassifyReload` plus `ReloadClass.ProvesLoss(lic, feature)` now distinguish proven loss (revoked, expired, or cleanly-verified-but-missing-feature: tear down) from an unverifiable new input (preserve restart-only, warn). The same classification is applied to both the agent-listener and the Conductor follower reload paths so they stay in parity. Startup stays strictly fail-closed (no prior entitlement to preserve). Genuine runtime revocation/expiry of the active license is still enforced independently by the CRL watcher and the expiry timer. `verifyLicenseInputs` is extracted as the shared verification core for `VerifyFleetWithIntermediate` and the new classifier; its external error contract is unchanged.

Both gates have regression tests proving: malformed or unverifiable new input keeps the surface running; revoked/expired/missing-feature strips or tears down.

Tier: Free. Detection and enforcement precision is never license-gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Policy bundle applies now abort if fleet entitlement is lost mid-apply, preventing activation of invalid configs.

* **New Features**
  * Adds an entitlement re-check just before live-configuration activation.
  * Hot-reload classification now distinguishes revoked/expired/unverifiable license inputs and acts accordingly.

* **Refactor**
  * Centralized license input verification and clearer restart-vs-reload entitlement behavior.

* **Tests**
  * Expanded test coverage for entitlement, teardown, and reload-class scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->