### PR TITLE
chore(verifiers): make TS + Rust reference verifiers publishable (npm + crates.io)

### DIFF
--- a/.github/workflows/publish-verifiers.yaml
+++ b/.github/workflows/publish-verifiers.yaml
@@ -1,0 +1,198 @@
+name: Publish verifiers
+
+# Auto-publishes the TypeScript verifier (npm: @pipelock/verifier-ts) and the
+# Rust verifier (crates.io: pipelock-verifier-rs) when a `verifier-v*` tag is
+# pushed (e.g. `verifier-v0.1.1`). The verifiers version independently of
+# pipelock, so a pipelock `v*` release tag does NOT trigger this workflow.
+#
+# Authentication is OIDC trusted publishing on both registries: no npm or
+# crates.io tokens are stored in the repository. A one-time trusted-publisher
+# configuration on each registry must point at THIS repo and THIS workflow file
+# (publish-verifiers.yaml); see sdk/verifiers/PUBLISHING.md.
+#
+# Supply-chain isolation: ALL third-party code (dependency install scripts, the
+# test suites, the TypeScript build, the Rust verification build) runs in the
+# UNPRIVILEGED `build` job, which has NO `id-token` and therefore cannot mint a
+# publish credential. The `id-token: write` publish jobs run no dependency or
+# build code: `publish-npm` publishes the tarball already packed by `build`
+# (npm only uploads, no install / no prepack), and `publish-crates` uses
+# `cargo publish --no-verify` (no dependency or build-script compilation). Both
+# publish jobs run in the `verifier-release` environment so a required reviewer
+# can gate every real publish.
+#
+# workflow_dispatch runs the build/verify path only (a dry run) by default; set
+# dry_run=false (or push a `verifier-v*` tag) to publish for real.
+#
+# Security note: no run: step consumes untrusted github.event.* input; the only
+# expression-derived values used in shell are passed through env and quoted.
+
+on:
+  push:
+    tags:
+      - 'verifier-v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run only (build + verify, do not publish)'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-verifiers-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Unprivileged: runs every piece of third-party code (dep install scripts,
+  # tests, the TS build, the Rust verification build) and produces the exact npm
+  # tarball that will be published. Has NO id-token, so nothing here can mint a
+  # publish credential even if a dependency is compromised.
+  build:
+    name: Build + verify verifiers
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: sdk/verifiers/ts/package-lock.json
+
+      - name: Build + test + pack TS verifier
+        working-directory: sdk/verifiers/ts
+        run: |
+          npm ci
+          npm test
+          # Pack to a clean dedicated dir so the uploaded artifact contains only
+          # the tarball at its root (avoids upload-artifact preserving the source
+          # path, which would nest the .tgz and break the publish glob).
+          mkdir -p "$RUNNER_TEMP/npmpkg"
+          npm pack --pack-destination "$RUNNER_TEMP/npmpkg"
+
+      - name: Upload npm tarball
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: npm-tarball
+          path: ${{ runner.temp }}/npmpkg/*.tgz
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Set up Rust 1.95.0
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+
+      - name: Schema vendor drift guard
+        working-directory: sdk/verifiers/rust
+        run: |
+          if ! cmp -s audit-packet-v0.json ../../audit-packet/v0.json; then
+            echo "::error::sdk/verifiers/rust/audit-packet-v0.json drifted from sdk/audit-packet/v0.json"
+            exit 1
+          fi
+
+      - name: Test + package Rust verifier
+        working-directory: sdk/verifiers/rust
+        run: |
+          cargo test --release --locked
+          cargo package --locked
+
+  # Privileged, no build: publishes the tarball produced by `build`. The only
+  # code that runs under id-token is npm uploading a pre-built artifact (no
+  # `npm ci`, no `prepack`, no third-party build). npm authenticates via OIDC
+  # (no NODE_AUTH_TOKEN) and generates provenance where supported.
+  publish-npm:
+    name: Publish TS verifier to npm
+    needs: build
+    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/verifier-v')) || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: verifier-release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      # OIDC trusted publishing needs npm >= 11.5.1. Fail closed (no global
+      # install of third-party tooling in this privileged job) if the runner's
+      # bundled npm is too old; bump the Node version if this ever fires.
+      - name: Assert OIDC-capable npm
+        run: |
+          ver="$(npm --version)"
+          if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::cannot parse npm version '$ver'"
+            exit 1
+          fi
+          IFS=. read -r maj min patch _ <<< "$ver"
+          # Need >= 11.5.1 for OIDC trusted publishing.
+          if [ "$maj" -lt 11 ] \
+            || { [ "$maj" -eq 11 ] && [ "$min" -lt 5 ]; } \
+            || { [ "$maj" -eq 11 ] && [ "$min" -eq 5 ] && [ "$patch" -lt 1 ]; }; then
+            echo "::error::npm $ver is too old for OIDC trusted publishing (need >= 11.5.1); bump node-version"
+            exit 1
+          fi
+          echo "npm $ver supports OIDC trusted publishing"
+
+      - name: Download npm tarball
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: npm-tarball
+          path: pkg
+
+      - name: Publish tarball to npm
+        # The ./ prefix is required: npm parses a bare `pkg/foo.tgz` as a git
+        # shortcut, while `./pkg/foo.tgz` is a local tarball file spec.
+        run: npm publish ./pkg/*.tgz
+
+  # Privileged, no build: cargo publish --no-verify skips the verification build
+  # (the build job already ran it), so no dependency or build-script code
+  # compiles here. The crates token is minted from OIDC at run time, not stored.
+  publish-crates:
+    name: Publish Rust verifier to crates.io
+    needs: build
+    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/verifier-v')) || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: verifier-release
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: sdk/verifiers/rust
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Rust 1.95.0
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+
+      - name: Schema vendor drift guard
+        run: |
+          if ! cmp -s audit-packet-v0.json ../../audit-packet/v0.json; then
+            echo "::error::sdk/verifiers/rust/audit-packet-v0.json drifted from sdk/audit-packet/v0.json"
+            exit 1
+          fi
+
+      - name: Authenticate to crates.io (trusted publishing)
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        id: auth
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --locked --no-verify

--- a/.github/workflows/publish-verifiers.yaml
+++ b/.github/workflows/publish-verifiers.yaml
@@ -110,7 +110,7 @@ jobs:
   publish-npm:
     name: Publish TS verifier to npm
     needs: build
-    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/verifier-v')) || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
+    if: ${{ startsWith(github.ref, 'refs/tags/verifier-v') && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: verifier-release
@@ -161,7 +161,7 @@ jobs:
   publish-crates:
     name: Publish Rust verifier to crates.io
     needs: build
-    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/verifier-v')) || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
+    if: ${{ startsWith(github.ref, 'refs/tags/verifier-v') && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: verifier-release

--- a/.github/workflows/publish-verifiers.yaml
+++ b/.github/workflows/publish-verifiers.yaml
@@ -130,7 +130,7 @@ jobs:
       - name: Assert OIDC-capable npm
         run: |
           ver="$(npm --version)"
-          if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+'; then
+          if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::cannot parse npm version '$ver'"
             exit 1
           fi

--- a/.github/workflows/verifiers.yaml
+++ b/.github/workflows/verifiers.yaml
@@ -75,6 +75,15 @@ jobs:
       - name: Test
         run: npm test
 
+      # Regression guard for the publish path: assert the npm tarball actually
+      # contains the CLI entrypoint and the bundled Audit Packet v0 schema, so a
+      # consumer's `npm install` yields a working offline verifier.
+      - name: Verify npm package contents
+        run: |
+          npm pack --dry-run --json > pack-manifest.json
+          node -e "const pkg=require('./package.json'); const m=require('./pack-manifest.json')[0].files.map(f=>f.path); for (const need of ['dist/src/cli.js','dist/src/v0.schema.json']) { if(!m.includes(need)){ console.error('MISSING from npm package:',need); process.exit(1);} } if(pkg.bin?.['pipelock-verifier-ts']!=='dist/src/cli.js'){ console.error('bad bin mapping (npm strips a leading ./):',JSON.stringify(pkg.bin)); process.exit(1);} console.log('npm package contains CLI + bundled schema + valid bin');"
+          rm -f pack-manifest.json
+
   rust:
     name: Rust verifier
     runs-on: ubuntu-latest
@@ -107,6 +116,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      # The crate embeds the Audit Packet v0 schema at compile time and must be
+      # self-contained for `cargo publish` (cargo only packages files inside the
+      # crate root). The schema is therefore vendored at sdk/verifiers/rust/
+      # audit-packet-v0.json. Fail if it drifts from the canonical source so the
+      # published crate can never verify against a stale schema.
+      - name: Schema vendor drift guard
+        run: |
+          if ! cmp -s audit-packet-v0.json ../../audit-packet/v0.json; then
+            echo "::error::sdk/verifiers/rust/audit-packet-v0.json drifted from sdk/audit-packet/v0.json"
+            echo "Re-vendor with: cp sdk/audit-packet/v0.json sdk/verifiers/rust/audit-packet-v0.json"
+            diff -u ../../audit-packet/v0.json audit-packet-v0.json || true
+            exit 1
+          fi
+
       - name: cargo fmt
         run: cargo fmt --check
 
@@ -118,6 +141,12 @@ jobs:
 
       - name: cargo build
         run: cargo build --release
+
+      # Regression guard for the publish path: `cargo package` builds the crate
+      # from the packaged tarball in isolation, proving it is self-contained for
+      # `cargo install` (would have caught the out-of-crate schema include_str!).
+      - name: cargo package (verify crate is publishable + self-contained)
+        run: cargo package --locked
 
   # Cross-language conformance gate: builds all four reference verifiers (Go,
   # TypeScript, Rust, Python) and runs them over the vendored conformance corpus

--- a/sdk/verifiers/PUBLISHING.md
+++ b/sdk/verifiers/PUBLISHING.md
@@ -98,31 +98,62 @@ The README install lines (`npm install -g …` / `cargo install …`) only becom
 true once the publish succeeds. Publish first, then merge / release the docs that
 point at the published packages, so the public docs are never ahead of reality.
 
-## Automating publish on release tag (recommended next step)
+## Auto-publish on release tag
 
-Once both names exist (from the first manual publish above), wire publishing into
-the release flow so a version tag ships the verifiers automatically:
+`.github/workflows/publish-verifiers.yaml` publishes both verifiers automatically
+when a `verifier-v*` tag is pushed (e.g. `verifier-v0.1.1`). The verifiers version
+independently of pipelock, so a pipelock `v*` release tag does NOT trigger it.
+Authentication is OIDC trusted publishing on both registries: no npm or crates.io
+tokens are stored in the repository. `workflow_dispatch` runs the build/verify path
+only (a dry run) by default; pushing a `verifier-v*` tag (or dispatching with "Dry
+run" unchecked) publishes for real.
 
-- **crates.io:** configure Trusted Publishing for `pipelock-verifier-rs` (GitHub
-  OIDC) so a release workflow with `id-token: write` publishes with no stored
-  token.
-- **npm:** configure the trusted publisher for `@pipelock/verifier-ts` and
-  publish with `npm publish --provenance` (signed provenance, no stored token).
+### One-time setup
 
-Gate the publish job on the `Verifiers` conformance workflow being green for the
-tagged commit. This keeps "tag a release → verifiers ship" hands-off and
-secret-free.
+Do this once, after the first manual publish. A trusted publisher can only be
+configured on a package/crate that already exists.
 
-**Release hardening (do this when wiring the workflow):**
+GitHub environment (gates real publishes behind a human approval): repo Settings,
+Environments, create `verifier-release`, add yourself as a Required reviewer. The
+two publish jobs already declare `environment: verifier-release`, so each real
+publish waits for your approval. Without a reviewer the environment exists but does
+not gate.
 
-- Bind the trusted publisher to the **exact** repo + workflow file + ref pattern
-  (`refs/tags/v*`); don't trust the whole repo or arbitrary branches.
-- Grant `permissions: id-token: write` **only** on the publish job, not workflow-wide.
-- Restrict who can push `v*` tags (protected tags / ruleset) — a tag is the trigger.
-- Use a GitHub **Environment** with a required reviewer for the publish job, at
-  least for the first few releases, so a tag can't auto-ship unreviewed.
-- npm: publish with `--provenance` so each release carries a signed build
-  attestation tied to the workflow.
+npm (`@pipelock/verifier-ts`): package page, Settings, Trusted Publisher, add a
+GitHub Actions publisher with:
+
+- Organization or user: `luckyPipewrench`
+- Repository: `pipelock`
+- Workflow filename: `publish-verifiers.yaml` (filename only, not a path)
+- Environment: `verifier-release`
+- Allowed actions: `npm publish`
+
+crates.io (`pipelock-verifier-rs`): crate page, Settings, Trusted Publishing, add
+a GitHub publisher with:
+
+- Repository owner: `luckyPipewrench`
+- Repository name: `pipelock`
+- Workflow filename: `publish-verifiers.yaml`
+- Environment: `verifier-release`
+
+### Cutting a release
+
+1. Bump the version in `sdk/verifiers/ts/package.json` and `sdk/verifiers/rust/Cargo.toml` (keep them in lockstep; re-vendor the schema if the canonical one changed) and merge it.
+2. Tag and push: `git tag verifier-v0.1.1 && git push origin verifier-v0.1.1`.
+3. The `build` job runs the tests and verification builds, then the two publish jobs wait for your environment approval and publish both packages. No tokens.
+
+Try it first with the `workflow_dispatch` dry run (Actions, Publish verifiers, Run
+workflow, leave "Dry run" checked): it runs only the unprivileged `build` job (tests
+plus `npm pack` and `cargo package`), so the path is exercised without publishing or
+minting any registry credential.
+
+### Hardening (built into the workflow)
+
+- OIDC only; no `CARGO_REGISTRY_TOKEN` / `NODE_AUTH_TOKEN` stored. npm emits build provenance where supported for a public repo + public package.
+- All third-party code (dependency install scripts, test suites, the TS build, the Rust verification build) runs in the unprivileged `build` job, which has no `id-token` and cannot mint a publish credential. The `id-token: write` publish jobs run no dependency or build code: `publish-npm` uploads the tarball already packed by `build` (no `npm ci`, no prepack), and `publish-crates` uses `cargo publish --no-verify` (no dependency or build-script compilation).
+- Both publish jobs run in the `verifier-release` environment, so a required reviewer gates every real publish.
+- The crates publish job re-checks schema drift before publishing.
+- Recommended: restrict who can push `verifier-v*` tags (protected tags / ruleset). The tag is the trigger.
 
 ## Related: GitHub Action `verify` mode
 

--- a/sdk/verifiers/PUBLISHING.md
+++ b/sdk/verifiers/PUBLISHING.md
@@ -1,0 +1,131 @@
+# Publishing the reference verifiers
+
+The TypeScript and Rust reference verifiers under `sdk/verifiers/` are published
+so third parties can install a Pipelock receipt verifier with one command:
+
+| Language   | Registry  | Package                  | Install                              |
+| ---------- | --------- | ------------------------ | ------------------------------------ |
+| TypeScript | npm       | `@pipelock/verifier-ts`  | `npm install -g @pipelock/verifier-ts` |
+| Rust       | crates.io | `pipelock-verifier-rs`   | `cargo install --locked pipelock-verifier-rs` |
+| Python     | PyPI      | `pipelock-verify`        | `pip install pipelock-verify` (separate repo) |
+| Go         | —         | `cmd/pipelock-verifier`  | built from this repo / release binaries |
+
+**Target: publish automatically when a release is tagged.** The goal is that
+cutting a Pipelock release also ships the verifiers, with no passwords stored in
+the repository (GitHub OIDC "trusted publishing" to both registries). Until that
+is wired, and to claim each package name the first time, use the one-time manual
+steps below.
+
+> Why automate: the Python verifier (`pipelock-verify`) was published once by
+> hand and then fell behind the receipt format because nobody re-ran the manual
+> step each release. Auto-publish-on-tag removes that drift risk.
+
+## One-time account setup
+
+You only do this once per registry.
+
+### npm (`@pipelock/verifier-ts`)
+
+1. Create / sign in to an npm account at <https://www.npmjs.com>.
+2. Create the **`pipelock` organization** (the `@pipelock` scope) at
+   <https://www.npmjs.com/org/create>. The first publish under the scope needs
+   the org to exist and you to be a member. (Scoped packages publish as
+   **public** because `publishConfig.access` is set to `public` in
+   `package.json` — without that, scoped publishes default to private/paid.)
+3. On the machine you publish from: `npm login`.
+
+### crates.io (`pipelock-verifier-rs`)
+
+1. Sign in to <https://crates.io> with GitHub.
+2. Go to <https://crates.io/me>, create an API token, then run
+   `cargo login <token>` once on your machine.
+3. The **first** `cargo publish` claims the crate name `pipelock-verifier-rs` for
+   your account. There is nothing to pre-reserve.
+
+## Before every publish
+
+1. **Version alignment.** Bump the package version to track the receipt schema
+   it verifies. Both packages currently verify Audit Packet v0 + ActionReceipt
+   v1 + EvidenceReceipt v2 (spanned). Keep `package.json` `version` and
+   `Cargo.toml` `version` in lockstep with each other and with the receipt
+   format they support; do not publish a verifier that cannot verify the current
+   receipts.
+2. **Conformance must be green.** The cross-language conformance gate
+   (`.github/workflows/verifiers.yaml`) must pass on the commit you publish from.
+   The published source must be the in-repo verifier — always publish from a
+   clean checkout via the build/publish commands below; never hand-edit a package
+   after building. (Note: registries don't pin a consumer's transitive deps for
+   you — npm `install` ignores `package-lock.json`, and `cargo install` only uses
+   the packaged `Cargo.lock` with `--locked`, which the install docs use.)
+3. **Rust schema drift guard.** `sdk/verifiers/rust/audit-packet-v0.json` is a
+   vendored copy of `sdk/audit-packet/v0.json` (the crate must be self-contained
+   for `cargo publish`). If the canonical schema changed, re-vendor and commit:
+   ```bash
+   cp sdk/audit-packet/v0.json sdk/verifiers/rust/audit-packet-v0.json
+   ```
+   The `Schema vendor drift guard` CI step fails the build if these diverge.
+
+## Publish: TypeScript → npm
+
+```bash
+cd sdk/verifiers/ts
+npm ci
+npm test                     # build + run the full suite
+npm publish --dry-run        # inspect tarball contents; confirm dist/ + v0.schema.json present
+npm publish                  # the real publish (prepack rebuilds; publishes as public)
+```
+
+Verify: `npm view @pipelock/verifier-ts version` shows the new version, and
+`npm install -g @pipelock/verifier-ts@<version>` then
+`pipelock-verifier-ts receipt <file> --key <hex>` works.
+
+## Publish: Rust → crates.io
+
+```bash
+cd sdk/verifiers/rust
+cargo test --release
+cargo package --list         # confirm audit-packet-v0.json is in the package
+cargo publish --dry-run      # builds the packaged crate in isolation
+cargo publish                # the real publish
+```
+
+Verify: the crate appears at <https://crates.io/crates/pipelock-verifier-rs>, and
+`cargo install --locked pipelock-verifier-rs` builds and runs offline.
+
+## Ordering note
+
+The README install lines (`npm install -g …` / `cargo install …`) only become
+true once the publish succeeds. Publish first, then merge / release the docs that
+point at the published packages, so the public docs are never ahead of reality.
+
+## Automating publish on release tag (recommended next step)
+
+Once both names exist (from the first manual publish above), wire publishing into
+the release flow so a version tag ships the verifiers automatically:
+
+- **crates.io:** configure Trusted Publishing for `pipelock-verifier-rs` (GitHub
+  OIDC) so a release workflow with `id-token: write` publishes with no stored
+  token.
+- **npm:** configure the trusted publisher for `@pipelock/verifier-ts` and
+  publish with `npm publish --provenance` (signed provenance, no stored token).
+
+Gate the publish job on the `Verifiers` conformance workflow being green for the
+tagged commit. This keeps "tag a release → verifiers ship" hands-off and
+secret-free.
+
+**Release hardening (do this when wiring the workflow):**
+
+- Bind the trusted publisher to the **exact** repo + workflow file + ref pattern
+  (`refs/tags/v*`); don't trust the whole repo or arbitrary branches.
+- Grant `permissions: id-token: write` **only** on the publish job, not workflow-wide.
+- Restrict who can push `v*` tags (protected tags / ruleset) — a tag is the trigger.
+- Use a GitHub **Environment** with a required reviewer for the publish job, at
+  least for the first few releases, so a tag can't auto-ship unreviewed.
+- npm: publish with `--provenance` so each release carries a signed build
+  attestation tied to the workflow.
+
+## Related: GitHub Action `verify` mode
+
+Documenting a `verify` mode on the existing security-scan Action (so a consumer's
+CI can gate on a verifying receipt) is a **separate follow-up** — it does not add
+a new Action, and it is not part of the distribution work above.

--- a/sdk/verifiers/PUBLISHING.md
+++ b/sdk/verifiers/PUBLISHING.md
@@ -105,8 +105,10 @@ when a `verifier-v*` tag is pushed (e.g. `verifier-v0.1.1`). The verifiers versi
 independently of pipelock, so a pipelock `v*` release tag does NOT trigger it.
 Authentication is OIDC trusted publishing on both registries: no npm or crates.io
 tokens are stored in the repository. `workflow_dispatch` runs the build/verify path
-only (a dry run) by default; pushing a `verifier-v*` tag (or dispatching with "Dry
-run" unchecked) publishes for real.
+only (a dry run) by default. Real publishes always require an immutable
+`verifier-v*` tag: pushing the tag publishes, and a manual dispatch only publishes
+when it is run from a `verifier-v*` tag with "Dry run" unchecked (a dispatch from a
+branch only ever runs the build/verify job).
 
 ### One-time setup
 

--- a/sdk/verifiers/rust/Cargo.toml
+++ b/sdk/verifiers/rust/Cargo.toml
@@ -2,8 +2,18 @@
 name = "pipelock-verifier-rs"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.95"
 license = "Apache-2.0"
-publish = false
+description = "Reference Rust verifier for Pipelock signed agent-egress receipts (Audit Packet v0, ActionReceipt v1, EvidenceReceipt v2)."
+repository = "https://github.com/luckyPipewrench/pipelock"
+homepage = "https://pipelab.org/learn/action-receipt-spec/"
+documentation = "https://docs.rs/pipelock-verifier-rs"
+readme = "README.md"
+keywords = ["pipelock", "verifier", "ed25519", "receipt", "attestation"]
+categories = ["command-line-utilities", "cryptography"]
+# Restrict publishing to crates.io only (was `publish = false` while in-repo;
+# now an explicit allowlist so a stray `cargo publish` can't target a wrong registry).
+publish = ["crates-io"]
 build = "build.rs"
 
 [[bin]]

--- a/sdk/verifiers/rust/README.md
+++ b/sdk/verifiers/rust/README.md
@@ -4,7 +4,30 @@
 v0, ActionReceipt v1, and the EvidenceReceipt v2 spanned proxy-decision
 conformance fixture.
 
-It provides three commands:
+## Install
+
+From crates.io (published as
+[`pipelock-verifier-rs`](https://crates.io/crates/pipelock-verifier-rs)):
+
+```bash
+# --locked uses the crate's pinned Cargo.lock for a reproducible build
+# (recommended for a security verifier).
+cargo install --locked pipelock-verifier-rs
+pipelock-verifier-rs receipt receipt.json --key <hex>
+```
+
+The Audit Packet v0 schema is embedded in the binary at compile time, so
+verification works fully offline with no network access.
+
+To build from source instead:
+
+```bash
+cargo build --release   # binary at target/release/pipelock-verifier-rs
+```
+
+## Usage
+
+It provides these commands:
 
 ```text
 pipelock-verifier-rs audit-packet PATH [--json] [--key HEX_OR_FILE] [--offline] [--allow-self-consistent-only] [--no-trust-required] [--expect-sha256 HEX]

--- a/sdk/verifiers/rust/audit-packet-v0.json
+++ b/sdk/verifiers/rust/audit-packet-v0.json
@@ -1,0 +1,404 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pipelab.org/schemas/audit-packet-v0.schema.json",
+  "title": "Pipelock Audit Packet v0",
+  "description": "Procurement-ready evidence bundle emitted after a Pipelock-mediated agent run. Pairs a verdict from a signed receipt chain with the enforcement posture claims that produced it. Versioned independently from pipelock binary releases.",
+  "$defs": {
+    "artifact_path": {
+      "type": "string",
+      "minLength": 1,
+      "allOf": [
+        { "not": { "const": "." } },
+        { "not": { "pattern": "^/" } },
+        { "not": { "pattern": ":" } },
+        { "not": { "pattern": "\\\\" } },
+        { "not": { "pattern": "(^|/)\\.\\.(/|$)" } }
+      ]
+    }
+  },
+  "type": "object",
+  "required": [
+    "schema_version",
+    "generated_at",
+    "run",
+    "policy",
+    "summary",
+    "verifier",
+    "posture",
+    "artifacts"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": "pipelock.audit_packet.v0",
+      "description": "Locked identifier for this packet shape. Producers MUST emit exactly this string."
+    },
+    "packet_id": {
+      "type": "string",
+      "description": "Optional opaque identifier for this packet. When omitted, consumers correlate by run.repository + run.sha + run.started_at."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC 3339 UTC timestamp recorded when the packet was assembled."
+    },
+    "run": {
+      "type": "object",
+      "description": "Identity of the agent run that produced the receipts. v0 targets GitHub Actions; future schema versions may add other providers.",
+      "required": ["provider", "agent_identity", "started_at"],
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["github_actions", "self_hosted", "local"],
+          "description": "Where the run executed. Other providers are accepted by registering a new enum value in a future schema version."
+        },
+        "repository": {
+          "type": "string",
+          "description": "Repository identifier from the provider (owner/name on GitHub). Optional for local runs."
+        },
+        "workflow": {
+          "type": "string",
+          "description": "Provider workflow name when applicable."
+        },
+        "run_id": {
+          "type": "string",
+          "description": "Provider run identifier when applicable."
+        },
+        "run_attempt": {
+          "type": "string",
+          "description": "Provider run attempt counter when applicable."
+        },
+        "ref": {
+          "type": "string",
+          "description": "Git ref at run start (refs/heads/main, refs/pull/N/merge, etc.)."
+        },
+        "sha": {
+          "type": "string",
+          "description": "Git commit SHA at run start."
+        },
+        "agent_identity": {
+          "type": "string",
+          "description": "Caller-supplied identity stamped into every receipt and the packet metadata. Maps to the action's agent-identity input."
+        },
+        "started_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 UTC timestamp recorded when the agent command started."
+        },
+        "completed_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 UTC timestamp recorded when the agent command exited (before verifier or packet assembly)."
+        },
+        "agent_exit_code": {
+          "type": "integer",
+          "description": "Exit code of the agent command. Captured even when receipt verification later fails."
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "description": "Pipelock policy state observed during the run. policy_hashes is plural because hot-reload across the run can produce multiple distinct hashes; the action records every hash that signed at least one receipt.",
+      "required": ["policy_hashes"],
+      "additionalProperties": false,
+      "properties": {
+        "policy_hashes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Sorted unique policy hashes observed across receipts. Empty array means no receipts carried a policy_hash, which is itself a signal."
+        },
+        "config_path": {
+          "type": "string",
+          "description": "Path on the runner to the user-supplied pipelock config file."
+        },
+        "runtime_config_path": {
+          "type": "string",
+          "description": "Path on the runner to the materialized runtime config (after action-owned overrides)."
+        },
+        "config_snapshot_sha256": {
+          "type": "string",
+          "description": "Optional SHA-256 of the runtime config file as fed to pipelock. Lets verifiers prove which config produced the receipts."
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "description": "Aggregated counts derived from the receipt chain. Counts are point-in-time: editing evidence.jsonl after the fact will not change them.",
+      "required": ["receipt_count", "totals"],
+      "additionalProperties": false,
+      "properties": {
+        "receipt_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of action_receipt entries in evidence.jsonl."
+        },
+        "totals": {
+          "type": "object",
+          "description": "One bucket per pipelock verdict. The eight buckets correspond to the seven config.Action* constants plus an other bucket for unrecognized verdicts. Producers MUST emit all eight keys, even when zero, so consumers can sum without nil-checks.",
+          "required": ["allow", "block", "warn", "ask", "strip", "forward", "redirect", "other"],
+          "additionalProperties": false,
+          "properties": {
+            "allow":    { "type": "integer", "minimum": 0 },
+            "block":    { "type": "integer", "minimum": 0 },
+            "warn":     { "type": "integer", "minimum": 0 },
+            "ask":      { "type": "integer", "minimum": 0 },
+            "strip":    { "type": "integer", "minimum": 0 },
+            "forward":  { "type": "integer", "minimum": 0 },
+            "redirect": { "type": "integer", "minimum": 0 },
+            "other":    { "type": "integer", "minimum": 0 }
+          }
+        },
+        "transports": {
+          "type": "object",
+          "description": "Counts of receipts grouped by transport label (https, http, ws, mcp_stdio, mcp_http, etc.). Keys are open-ended.",
+          "additionalProperties": { "type": "integer", "minimum": 0 }
+        },
+        "layers": {
+          "type": "object",
+          "description": "Counts of blocked receipts grouped by detection layer label. Optional in v0; producers MAY omit when no layer telemetry is captured.",
+          "additionalProperties": { "type": "integer", "minimum": 0 }
+        },
+        "domains_touched": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional sorted unique list of destination hosts seen in receipts. Producers MAY redact, omit, or hash entries; consumers MUST treat absence as no claim, not as zero hosts."
+        }
+      }
+    },
+    "verifier": {
+      "type": "object",
+      "description": "Verdict from the receipt chain verifier. The verdict alone is not the proof; consumers MUST cross-reference posture claims and the signer key when assigning trust.",
+      "required": ["verdict", "trusted"],
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "required": ["trusted"],
+            "properties": { "trusted": { "const": true } }
+          },
+          "then": {
+            "required": ["signer_key"],
+            "properties": { "verdict": { "const": "valid" } }
+          }
+        },
+        {
+          "if": {
+            "required": ["verdict"],
+            "properties": { "verdict": { "const": "valid" } }
+          },
+          "then": {
+            "required": ["signer_key"],
+            "properties": { "trusted": { "const": true } }
+          }
+        }
+      ],
+      "properties": {
+        "verdict": {
+          "type": "string",
+          "enum": ["valid", "invalid", "error", "not_run", "self_consistent_only"],
+          "description": "valid: chain verified against a pinned signer key. invalid: chain rejected. error: verifier could not run (config failure or empty chain). not_run: verifier was deliberately skipped. self_consistent_only: chain hashes are consistent but no signer key was pinned, so the chain proves internal consistency only, not Pipelock provenance."
+        },
+        "trusted": {
+          "type": "boolean",
+          "description": "true only when verdict is valid and a long-lived signer public key was pinned at verification time. self_consistent_only and not_run MUST set this to false."
+        },
+        "receipt_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Receipts the verifier examined. May differ from summary.receipt_count if the verifier filtered entries; producers SHOULD flag the divergence in verifier.error when it happens."
+        },
+        "root_hash": {
+          "type": "string",
+          "description": "Hash of the final receipt in the chain (sha256:hex), used by relying parties to anchor the chain in external transparency logs."
+        },
+        "final_seq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Sequence number of the final receipt examined."
+        },
+        "signer_key": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Signer public key in pipelock public-key text form. Omitted when no key was pinned."
+        },
+        "output_file": {
+          "type": "string",
+          "description": "Relative path inside the audit packet directory to the verifier's raw stdout/stderr capture. Defaults to verifier.txt."
+        },
+        "error": {
+          "type": "string",
+          "description": "Human-readable failure reason when verdict is error or invalid."
+        }
+      }
+    },
+    "receipts": {
+      "type": "array",
+      "description": "Optional inline copy of the receipt chain. Producers MAY omit and reference artifacts.evidence_jsonl instead. Consumers SHOULD prefer evidence.jsonl when present because it is the byte-for-byte signed input to the verifier.",
+      "items": {
+        "type": "object",
+        "required": ["action_id", "receipt_hash", "chain_seq", "chain_prev_hash", "verdict", "policy_hash"],
+        "additionalProperties": true,
+        "properties": {
+          "action_id":      { "type": "string" },
+          "receipt_hash":   { "type": "string" },
+          "chain_seq":      { "type": "integer", "minimum": 0 },
+          "chain_prev_hash": { "type": "string" },
+          "timestamp":      { "type": "string", "format": "date-time" },
+          "action_type":    { "type": "string" },
+          "verdict":        { "type": "string" },
+          "transport":      { "type": "string" },
+          "method":         { "type": "string" },
+          "target_redacted": { "type": "string" },
+          "layer":          { "type": "string" },
+          "pattern":        { "type": "string" },
+          "severity":       { "type": "string" },
+          "policy_hash":    { "type": "string" },
+          "signer_key":     { "type": "string" },
+          "source_spans": {
+            "type": "array",
+            "description": "Optional display copy of EvidenceReceipt v2 source_spans. The signed receipt remains the authoritative proof.",
+            "items": {
+              "type": "object",
+              "required": [
+                "source_id",
+                "source_kind",
+                "normalized_view",
+                "pipelock_binary_digest",
+                "rules_bundle_digest",
+                "transform_profile",
+                "policy_hash",
+                "rule_id",
+                "match_hash",
+                "match_hash_alg",
+                "match_class"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "source_id": { "type": "string" },
+                "source_kind": {
+                  "type": "string",
+                  "enum": ["http_request_url", "http_response", "mcp_tool_result", "mcp_tool_args"]
+                },
+                "normalized_view": { "type": "string" },
+                "pipelock_binary_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+                "rules_bundle_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+                "transform_profile": { "type": "string" },
+                "policy_hash": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+                "rule_id": { "type": "string" },
+                "bundle": { "type": "string" },
+                "bundle_version": { "type": "string" },
+                "char_offset": { "type": "integer", "minimum": 0 },
+                "char_length": { "type": "integer", "minimum": 1 },
+                "match_hash": { "type": "string", "pattern": "^hmac-sha256:[0-9a-f]{64}$" },
+                "match_hash_alg": { "const": "hmac-sha256" },
+                "match_class": { "type": "string" },
+                "redacted_sample": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "scanner_config_snapshot": {
+      "type": "object",
+      "description": "Optional summary of the pipelock config that produced the receipts. Producers MAY omit when no snapshot is available; consumers MUST NOT treat absence as a claim that scanning was disabled.",
+      "additionalProperties": false,
+      "properties": {
+        "mode":                    { "type": "string" },
+        "dlp_patterns_count":      { "type": "integer", "minimum": 0 },
+        "response_patterns_count": { "type": "integer", "minimum": 0 },
+        "ssrf_enabled":            { "type": "boolean" },
+        "redaction_enabled":       { "type": "boolean" },
+        "flight_recorder_enabled": { "type": "boolean" }
+      }
+    },
+    "posture": {
+      "type": "object",
+      "description": "Enforcement posture claimed by the producer. These fields document WHAT was enforced; the receipts in evidence.jsonl prove what happened under that posture. Both sides matter: a clean receipt chain under a posture that admits unsupported paths is weaker evidence than the same chain under stricter posture.",
+      "required": [
+        "enforcement_mode",
+        "runner_os",
+        "raw_socket_status",
+        "docker_socket_status",
+        "dns_udp_status",
+        "browser_proxy_status",
+        "websocket_frame_scanning",
+        "unsupported_paths"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "enforcement_mode": {
+          "type": "string",
+          "description": "Free-form identifier for the enforcement architecture. The action repo emits linux_netns_iptables_setpriv. Future modes (docker_container, host_proxy_only, self_hosted_runner) extend this enum."
+        },
+        "runner_os":   { "type": "string" },
+        "runner_arch": { "type": "string" },
+        "raw_socket_status": {
+          "type": "string",
+          "enum": ["denied", "allowed", "unknown"],
+          "description": "denied: agent could not open raw sockets. allowed: agent could (e.g., self-hosted runner with broader caps). unknown: producer did not probe."
+        },
+        "docker_socket_status": {
+          "type": "string",
+          "enum": ["denied", "masked", "allowed", "absent", "unknown"],
+          "description": "denied: explicit deny. masked: socket bind-mounted to /dev/null inside the boundary. allowed: agent had socket access. absent: socket not present on the runner. unknown: producer did not probe."
+        },
+        "dns_udp_status": {
+          "type": "string",
+          "enum": ["denied", "proxied", "allowed", "unknown"],
+          "description": "denied: agent UDP/53 dropped. proxied: DNS routed through pipelock. allowed: agent could resolve directly. unknown: producer did not probe."
+        },
+        "browser_proxy_status": {
+          "type": "string",
+          "enum": ["forced", "advisory", "absent", "unknown"],
+          "description": "forced: HTTPS_PROXY env var is set inside the boundary AND no path bypasses it. advisory: env var set but bypassable. absent: no browser-class workload. unknown: not probed."
+        },
+        "websocket_frame_scanning": {
+          "type": "string",
+          "enum": ["explicit_ws_proxy_path_required", "always_on", "off"],
+          "description": "Frame-level scanning is automatic for /ws?url= proxy path; for arbitrary wss:// destinations the boundary contains the destination but does not scan frames unless the agent uses the proxy path."
+        },
+        "network_namespace": { "type": "string" },
+        "agent_user":        { "type": "string", "description": "Linux UNIX user the agent command ran as (NOT the AI agent identity; see run.agent_identity for that)." },
+        "agent_uid":         { "type": "integer" },
+        "host_user":         { "type": "string" },
+        "host_uid":          { "type": "integer" },
+        "host_ip":           { "type": "string" },
+        "agent_ip":          { "type": "string" },
+        "proxy_url":         { "type": "string" },
+        "script_basename":   { "type": "string" },
+        "script_arg_count":  { "type": "integer", "minimum": 0 },
+        "unsupported_paths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Egress vectors the producer explicitly does not enforce in this mode (e.g., nested-docker, ssh-egress). Honest disclosure is part of the proof."
+        }
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "description": "Relative paths to sibling files in the audit packet directory. All paths are relative to the directory holding packet.json.",
+      "required": ["packet", "evidence", "verifier"],
+      "additionalProperties": false,
+      "properties": {
+        "packet": {
+          "$ref": "#/$defs/artifact_path",
+          "description": "Relative path to this packet.json."
+        },
+        "summary": {
+          "$ref": "#/$defs/artifact_path",
+          "description": "Relative path to the human-readable summary.md."
+        },
+        "evidence": {
+          "$ref": "#/$defs/artifact_path",
+          "description": "Relative path to evidence.jsonl, the byte-for-byte signed receipt chain."
+        },
+        "verifier": {
+          "$ref": "#/$defs/artifact_path",
+          "description": "Relative path to verifier.txt, the verifier's raw output."
+        }
+      }
+    }
+  }
+}

--- a/sdk/verifiers/rust/build.rs
+++ b/sdk/verifiers/rust/build.rs
@@ -1,3 +1,6 @@
 fn main() {
-    println!("cargo:rerun-if-changed=../../audit-packet/v0.json");
+    // The schema is vendored into the crate root so the crate is self-contained
+    // for `cargo publish`. Watch the in-crate copy, not the canonical source
+    // outside the crate (which is absent when building from a published crate).
+    println!("cargo:rerun-if-changed=audit-packet-v0.json");
 }

--- a/sdk/verifiers/rust/src/schema.rs
+++ b/sdk/verifiers/rust/src/schema.rs
@@ -3,7 +3,13 @@ use jsonschema::{Draft, JSONSchema};
 use serde_json::Value;
 use std::sync::LazyLock;
 
-static SCHEMA: &str = include_str!("../../../audit-packet/v0.json");
+// Embedded at compile time from the in-crate vendored copy of the canonical
+// Audit Packet v0 schema. The crate must be self-contained for `cargo publish`
+// (cargo only packages files inside the crate root), so the schema lives here
+// rather than at sdk/audit-packet/v0.json. The vendored copy is kept
+// byte-identical to the canonical source by the drift guard in verifiers.yaml
+// (re-vendor with: cp sdk/audit-packet/v0.json sdk/verifiers/rust/audit-packet-v0.json).
+static SCHEMA: &str = include_str!("../audit-packet-v0.json");
 static COMPILED_SCHEMA: LazyLock<JSONSchema> = LazyLock::new(|| {
     let schema: Value = serde_json::from_str(SCHEMA).expect("embedded schema parses");
     JSONSchema::options()

--- a/sdk/verifiers/ts/README.md
+++ b/sdk/verifiers/ts/README.md
@@ -6,6 +6,23 @@ fixture.
 
 ## Install
 
+From npm (published as [`@pipelock/verifier-ts`](https://www.npmjs.com/package/@pipelock/verifier-ts)):
+
+```bash
+# Global CLI:
+npm install -g @pipelock/verifier-ts
+pipelock-verifier-ts receipt receipt.json --key <hex>
+
+# Or as a project dependency (CLI available via npx):
+npm install @pipelock/verifier-ts
+npx pipelock-verifier-ts receipt receipt.json --key <hex>
+```
+
+The Audit Packet v0 schema is bundled in the package, so verification works
+fully offline with no network access.
+
+### Build from source
+
 ```bash
 npm install
 npm run build

--- a/sdk/verifiers/ts/package.json
+++ b/sdk/verifiers/ts/package.json
@@ -1,10 +1,27 @@
 {
   "name": "@pipelock/verifier-ts",
   "version": "0.1.0",
-  "description": "TypeScript reference verifier for Pipelock Audit Packet v0 receipts and chains.",
+  "description": "TypeScript reference verifier for Pipelock signed agent-egress receipts (Audit Packet v0, ActionReceipt v1, EvidenceReceipt v2).",
+  "license": "Apache-2.0",
+  "author": "Pipelab",
+  "homepage": "https://pipelab.org/learn/action-receipt-spec/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/luckyPipewrench/pipelock.git",
+    "directory": "sdk/verifiers/ts"
+  },
+  "bugs": "https://github.com/luckyPipewrench/pipelock/issues",
+  "keywords": [
+    "pipelock",
+    "verifier",
+    "ed25519",
+    "receipt",
+    "attestation",
+    "agent-security"
+  ],
   "type": "module",
   "bin": {
-    "pipelock-verifier-ts": "./dist/src/cli.js"
+    "pipelock-verifier-ts": "dist/src/cli.js"
   },
   "scripts": {
     "build": "tsc && node scripts/copy-schema.mjs",
@@ -27,10 +44,12 @@
   "engines": {
     "node": ">=20"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
-    "dist",
+    "dist/src",
     "README.md",
-    "package.json",
-    "package-lock.json"
+    "package.json"
   ]
 }


### PR DESCRIPTION
## What

Make the in-repo TypeScript (`sdk/verifiers/ts`) and Rust (`sdk/verifiers/rust`) reference verifiers installable from public registries, so anyone can verify a Pipelock receipt offline in their own stack. No new repos; the published artifact is the in-repo verifier.

- npm: `@pipelock/verifier-ts` (`npm install -g @pipelock/verifier-ts`)
- crates.io: `pipelock-verifier-rs` (`cargo install --locked pipelock-verifier-rs`)

Mirrors the existing Python verifier on PyPI. Both verify v1 and v2 spanned EvidenceReceipts.

## Key change: Rust crate self-containment

`src/schema.rs` embedded the Audit Packet v0 schema via `include_str!` from a path outside the crate root, so `cargo publish` (which only packages files inside the crate) would yield a crate that fails to compile on `cargo install`. Fixed by vendoring a byte-identical schema copy into the crate, repointing the include and `build.rs`, and adding a CI drift guard that keeps the vendored copy identical to the canonical source.

## Other changes

- npm `bin` fix: was `./dist/src/cli.js`. npm v11 silently strips a leading `./`, which would ship a CLI-less package. Now `dist/src/cli.js`. Package ships only `dist/src` and bundles the schema for offline use.
- Publish metadata on both (`Cargo.toml`: description/repository/keywords/categories, `publish = ["crates-io"]`; `package.json`: Apache-2.0, repository, public scoped access).
- CI regression guards: `cargo package --locked` plus an `npm pack` assertion (CLI, schema, and `bin` mapping present) so the publish path stays self-contained.
- Auto-publish on tag (`.github/workflows/publish-verifiers.yaml`): a `verifier-v*` tag publishes both packages via OIDC trusted publishing with no stored tokens. All dependency/test/build code runs in an unprivileged `build` job with no `id-token`; the publish jobs only upload pre-built artifacts (npm publishes the packed tarball; cargo uses `--no-verify`) and run in a `verifier-release` environment so a reviewer gates each release.
- `PUBLISHING.md`: first-publish runbook, one-time trusted-publisher + environment setup, and the release process.

## Notes

No new dependencies. Apache-2.0 on both packages. Cross-language conformance gate unchanged.

## Done-state

- [x] `npm i -g @pipelock/verifier-ts` installs a working v2-capable verifier (0.1.0 published)
- [x] `cargo install --locked pipelock-verifier-rs` likewise (0.1.0 published)
- [x] CI guards keep both packages self-contained
- [x] Auto-publish-on-tag wired (OIDC trusted publishing; needs one-time registry config per PUBLISHING.md)
- [ ] CI green on this PR
- [ ] (follow-up) GitHub Action `verify` mode


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated publishing workflow for verifiers to npm and crates.io
  * Added CI verification checks for package integrity and schema consistency

* **Documentation**
  * Added publishing guide for verifiers
  * Updated installation instructions for verifier packages

* **Chores**
  * Updated verifier package metadata for registries
  * Vendored schema support for offline verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->