### PR TITLE
fix(dlp): require secret-plausible leading value char on credential patterns

### DIFF
--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -269,10 +269,10 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
       severity: high
     - name: "Environment Variable Secret"
-      regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'
+      regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'
       severity: high
     # Financial identifiers (validated with post-match checksums)
     - name: "Credit Card Number"

--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -269,7 +269,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -298,10 +298,10 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
       severity: high
     - name: "Environment Variable Secret"
-      regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'
+      regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'
       severity: high
     # Financial identifiers (validated with post-match checksums)
     - name: "Credit Card Number"

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -298,7 +298,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -301,10 +301,10 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
       severity: high
     - name: "Environment Variable Secret"
-      regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'
+      regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'
       severity: high
     # Financial identifiers (validated with post-match checksums)
     - name: "Credit Card Number"

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -301,7 +301,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -302,10 +302,10 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
       severity: high
     - name: "Environment Variable Secret"
-      regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'
+      regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'
       severity: high
     # Financial identifiers (validated with post-match checksums)
     - name: "Credit Card Number"

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -302,7 +302,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -309,10 +309,10 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
       severity: high
     - name: "Environment Variable Secret"
-      regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'
+      regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'
       severity: high
     # Financial identifiers (validated with post-match checksums)
     - name: "Credit Card Number"

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -309,7 +309,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -285,10 +285,10 @@ dlp:
       severity: critical
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
       severity: critical
     - name: "Environment Variable Secret"
-      regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'
+      regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'
       severity: high
     # Financial identifiers (validated with post-match checksums)
     - name: "Credit Card Number"

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -285,7 +285,7 @@ dlp:
       severity: critical
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
       severity: critical
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -283,7 +283,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -283,10 +283,10 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
       severity: high
     - name: "Environment Variable Secret"
-      regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}'
+      regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'
       severity: high
     # Financial identifiers (validated with post-match checksums)
     - name: "Credit Card Number"

--- a/examples/quickstart/pipelock.yaml
+++ b/examples/quickstart/pipelock.yaml
@@ -141,7 +141,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
       severity: high
 
 response_scanning:

--- a/examples/quickstart/pipelock.yaml
+++ b/examples/quickstart/pipelock.yaml
@@ -141,7 +141,7 @@ dlp:
       severity: medium
     # Generic credential patterns
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}'
+      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
       severity: high
 
 response_scanning:

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -157,7 +157,11 @@ const (
 	// Re-bumped for git_protection.allowed_push_repos. The field is
 	// policy-semantic because it changes whether visible git-receive-pack
 	// pushes are allowed at the proxy.
-	goldenHashDefaults = "f7e3ab7acc9d826a78f7a37fa8632cf4b65487953da6fa86fe112936d17ac8f4"
+	// Re-bumped for DLP precision: the "Environment Variable Secret" and
+	// "Credential in URL" default patterns now require a secret-plausible
+	// leading value character so the whitespace-collapsed DLP view cannot
+	// over-match benign shell env-var references. Detection-relevant change.
+	goldenHashDefaults = "a18a5af7d4b59fcd5ba9fff26dd01934b4ec56a65242d586f24a462c4f17999c"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -238,7 +242,9 @@ const (
 	// Re-bumped for git_protection.allowed_push_repos: see goldenHashDefaults
 	// note above. The rich fixture omits the field, but the empty allowlist is
 	// still part of the canonical policy view.
-	goldenHashRichConfig = "beaad218a234855e54ed273bce0bf674f9417f92c990319207bd0e37c62268c8"
+	// Re-bumped for DLP precision on the env-var-secret / credential-in-URL
+	// patterns: see goldenHashDefaults note above.
+	goldenHashRichConfig = "5540709ddd97410e9d51f09882b9e67d9f78df9b4ea1ad998f9d41c8bdcce5a9"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -160,8 +160,10 @@ const (
 	// Re-bumped for DLP precision: the "Environment Variable Secret" and
 	// "Credential in URL" default patterns now require a secret-plausible
 	// leading value character so the whitespace-collapsed DLP view cannot
-	// over-match benign shell env-var references. Detection-relevant change.
-	goldenHashDefaults = "a18a5af7d4b59fcd5ba9fff26dd01934b4ec56a65242d586f24a462c4f17999c"
+	// over-match benign shell env-var references; the "Credential in URL"
+	// value tail additionally excludes ';' so a semicolon-separated param
+	// does not bleed into the captured credential. Detection-relevant change.
+	goldenHashDefaults = "1b3034ef2fe75b621c1cde30aaad593a18a4e54a0c0505a8e8814d06f6b4aeba"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -244,7 +246,7 @@ const (
 	// still part of the canonical policy view.
 	// Re-bumped for DLP precision on the env-var-secret / credential-in-URL
 	// patterns: see goldenHashDefaults note above.
-	goldenHashRichConfig = "5540709ddd97410e9d51f09882b9e67d9f78df9b4ea1ad998f9d41c8bdcce5a9"
+	goldenHashRichConfig = "fdb19355c9ddcfe952f1652a882f495c56981501c8c794a8872669a50d44e653"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -286,7 +286,14 @@ func Defaults() *Config {
 				// (show-password) are still protected because the delimiter
 				// is always explicit.
 				// Case-insensitive matching is added automatically by scanner.New() via (?i) prefix.
-				{Name: "Credential in URL", Regex: `(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}`, Severity: "high"},
+				// The value must begin with a credential-plausible character
+				// ([A-Za-z0-9_+/=~%.-], covering common base64/base64url/hex/JWT
+				// and URL-encoded token forms). This rejects shell/template forms
+				// that the whitespace-collapsed DLP view (text_dlp.go) would
+				// otherwise turn into a spurious match by deleting the value's
+				// natural delimiter: command substitution (token=$(...)),
+				// backticks, and quoted variable refs (password="$VAR").
+				{Name: "Credential in URL", Regex: `(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}`, Severity: "high"},
 				// Environment variable credential patterns: catches env var dumps
 				// where the secret-bearing keyword is the terminal segment of an
 				// UPPER_CASE name (e.g., AWS_SECRET_ACCESS_KEY=..., STRIPE_SECRET_KEY=...,
@@ -297,8 +304,20 @@ func Defaults() *Config {
 				// name prefix - env vars are UPPER_CASE by convention, URL params
 				// are lower_case (next_token, csrf_token_id). This avoids FP on
 				// URL params while catching env var dumps.
-				// Min value length of 8 prevents FP on short config values.
-				{Name: "Environment Variable Secret", Regex: `(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*\S{8,}`, Severity: "high"},
+				// Min value length of 8 prevents FP on short config values. The
+				// value must begin with a secret-plausible character
+				// ([A-Za-z0-9_+/=~.-], covering common base64/base64url/hex/JWT
+				// token forms) followed by 7+ non-whitespace chars. The
+				// leading-character class is what makes this safe under the
+				// whitespace-collapsed DLP view (text_dlp.go), which strips all
+				// whitespace and would otherwise let the \S run absorb the rest of
+				// the document when a benign env-var NAME is followed by a shell
+				// example rather than a real value. It rejects command substitution
+				// (TOKEN=$(...)), backticks, quoted refs (TOKEN="$VAR"), and
+				// Authorization templates while still matching common real
+				// assignments and space-split evasions (PROVIDER _ TOKEN =
+				// realsecret).
+				{Name: "Environment Variable Secret", Regex: `(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}`, Severity: "high"},
 
 				// Financial identifiers - validated with post-match checksums to minimize
 				// false positives. Credit card regex is intentionally broad (any 15-19

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -293,7 +293,7 @@ func Defaults() *Config {
 				// otherwise turn into a spurious match by deleting the value's
 				// natural delimiter: command substitution (token=$(...)),
 				// backticks, and quoted variable refs (password="$VAR").
-				{Name: "Credential in URL", Regex: `(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}`, Severity: "high"},
+				{Name: "Credential in URL", Regex: `(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}`, Severity: "high"},
 				// Environment variable credential patterns: catches env var dumps
 				// where the secret-bearing keyword is the terminal segment of an
 				// UPPER_CASE name (e.g., AWS_SECRET_ACCESS_KEY=..., STRIPE_SECRET_KEY=...,

--- a/internal/mcp/input_test.go
+++ b/internal/mcp/input_test.go
@@ -4230,3 +4230,26 @@ func TestForwardScannedInput_NoEnvelopeOnNonToolCall(t *testing.T) {
 		t.Errorf("tools/list should not get mediation envelope, got: %s", output)
 	}
 }
+
+// TestScanRequest_EnvVarSecretShellExampleFP is the MCP-input (outbound,
+// agent->tool) regression for the env-var-secret precision fix. A wrapped
+// first-party tool (e.g. a code-assistant MCP) receiving a security-dense prompt that
+// quotes shell env-var usage must not be hard-blocked by the shared
+// "Environment Variable Secret" / "Credential in URL" DLP patterns, while a
+// real leaked secret in the same arg position must still block.
+func TestScanRequest_EnvVarSecretShellExampleFP(t *testing.T) {
+	sc := testInputScanner(t)
+
+	shellExample := `Review this snippet: PROVIDER_TOKEN=$(grep "^PROVIDER_TOKEN=" ~/.config/app/.env | cut -d= -f2); ` +
+		`curl -H "Authorization: Bearer $PROVIDER_TOKEN" https://api.vendor.example/user`
+	fpLine := makeRequest(1, "tools/call", map[string]string{"prompt": shellExample})
+	if v := ScanRequest(context.Background(), []byte(fpLine), sc, config.ActionBlock, config.ActionBlock); !v.Clean {
+		t.Errorf("security-review shell example must not be input-blocked, got: %v", v.Matches)
+	}
+
+	realLeak := "PROVIDER_TOKEN=" + "tok" + "_" + strings.Repeat("C", 36)
+	leakLine := makeRequest(2, "tools/call", map[string]string{"prompt": realLeak})
+	if v := ScanRequest(context.Background(), []byte(leakLine), sc, config.ActionBlock, config.ActionBlock); v.Clean {
+		t.Error("real leaked env-var secret in tool args must still block")
+	}
+}

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -67,6 +67,63 @@ func TestScanTextForDLP(t *testing.T) {
 			wantPattern: "AWS Secret Key",
 		},
 		{
+			// Real env-var assignment with a secret value still blocks.
+			name:        "env var secret - real value blocks",
+			text:        "PROVIDER_TOKEN=" + "tok" + "_" + strings.Repeat("A", 36),
+			wantClean:   false,
+			wantPattern: "Environment Variable Secret",
+		},
+		{
+			// Space-split evasion: the value delimiter is only removed by the
+			// whitespace-collapsed DLP view, so this asserts the env-var pattern
+			// still fires THROUGH that view (Encoded == "whitespace") because the
+			// collapsed value begins with a secret-plausible char.
+			name:        "env var secret - space-split evasion blocks via whitespace view",
+			text:        "PROVIDER _ TOKEN = " + "tok" + "_" + strings.Repeat("A", 36),
+			wantClean:   false,
+			wantPattern: "Environment Variable Secret",
+			wantEncoded: "whitespace",
+		},
+		{
+			// Regression: env-var NAME referenced in a shell guard (no value).
+			// Previously the collapsed view turned the trailing document into a
+			// giant \S run and matched "Environment Variable Secret".
+			name:      "env var secret FP - name reference in shell guard",
+			text:      `if [ -z "$PROVIDER_TOKEN" ]; then echo "set PROVIDER_TOKEN first"; fi`,
+			wantClean: true,
+		},
+		{
+			// Regression: assignment from command substitution, not a real value.
+			name:      "env var secret FP - command substitution assignment",
+			text:      `PROVIDER_TOKEN=$(grep "^PROVIDER_TOKEN=" ~/.config/app/.env | head -1 | cut -d= -f2)`,
+			wantClean: true,
+		},
+		{
+			// Regression: backtick command substitution, not a real value.
+			name:      "env var secret FP - backtick assignment",
+			text:      "PROVIDER_TOKEN=`security find-generic-password -w -s provider-token`",
+			wantClean: true,
+		},
+		{
+			// Regression: shell variable expansion, not a real value.
+			name:      "credential in url FP - braced variable expansion after delimiter",
+			text:      "run: deploy; token=${PROVIDER_TOKEN} && curl https://api.example/x",
+			wantClean: true,
+		},
+		{
+			// Regression: Authorization header template referencing an env var.
+			name:      "env var secret FP - authorization header template",
+			text:      `curl -H "Authorization: Bearer $PROVIDER_TOKEN" https://api.vendor.example/user`,
+			wantClean: true,
+		},
+		{
+			// Regression: Credential-in-URL sibling must not fire on a shell
+			// command-substitution token assignment after a ';' delimiter.
+			name:      "credential in url FP - command substitution after delimiter",
+			text:      "run: deploy; token=$(get_token) && curl https://api.example/x",
+			wantClean: true,
+		},
+		{
 			name:        "raw DLP pattern match - AWS Secret Key JSON format",
 			text:        `"SecretAccessKey": "` + "wJal" + "rXUt" + "nFEM" + "I/K7" + "MDEN" + "G/bP" + "xRfi" + "CYEXAMPLEKEY" + `"`,
 			wantClean:   false,
@@ -952,6 +1009,81 @@ func TestScanTextForDLP_AllowsOfficialAWSExampleCredentialDocs(t *testing.T) {
 	leak := "exfil key " + key
 	if result := s.ScanTextForDLP(context.Background(), leak); result.Clean {
 		t.Fatal("expected bare AWS example access key outside docs context to be detected")
+	}
+}
+
+// TestEnvVarSecret_WhitespaceViewMechanism locks the exact path that fired in
+// production. A wrapped tool RESULT and a wrapped first-party MCP tool's
+// security-review input both blocked on "Environment Variable Secret" because
+// the whitespace-collapsed DLP view (compactTextDLPWhitespace) deleted the
+// value delimiter, letting the value run absorb the rest of the document. The
+// value sub-pattern now requires a secret-plausible leading char, so the
+// collapsed view no longer matches benign env-var references while real
+// space-split assignments still do. Asserting against the collapsed view
+// directly (not raw text) covers the real mechanism.
+func TestEnvVarSecret_WhitespaceViewMechanism(t *testing.T) {
+	s := New(testConfig())
+	defer s.Close()
+
+	const envVarPattern = "Environment Variable Secret"
+
+	fps := []struct{ name, text string }{
+		{"name reference in guard", `if [ -z "$PROVIDER_TOKEN" ]; then echo "set PROVIDER_TOKEN first"; fi`},
+		{"command substitution", `PROVIDER_TOKEN=$(grep "^PROVIDER_TOKEN=" ~/.config/app/.env | cut -d= -f2)`},
+		{"backtick command substitution", "PROVIDER_TOKEN=`security find-generic-password -w -s provider-token`"},
+		{"authorization template", `curl -H "Authorization: Bearer $PROVIDER_TOKEN" https://api.vendor.example/user`},
+		{"credential-in-url command sub", `run: deploy; token=$(get_token) && push origin main`},
+		{"credential-in-url braced var", `run: deploy; token=${PROVIDER_TOKEN} && push origin main`},
+	}
+	for _, tt := range fps {
+		t.Run("fp/"+tt.name, func(t *testing.T) {
+			compacted := compactTextDLPWhitespace(tt.text)
+			for _, m := range s.matchDLPPatterns(compacted, "whitespace") {
+				if m.PatternName == envVarPattern || m.PatternName == "Credential in URL" {
+					t.Errorf("collapsed-view FP: %q matched on %q", m.PatternName, tt.text)
+				}
+			}
+		})
+	}
+
+	// A real space-split env-var assignment must STILL be caught by the
+	// collapsed view (detection preserved for the evasion case).
+	realSecret := "tok" + "_" + strings.Repeat("A", 36)
+	compacted := compactTextDLPWhitespace("PROVIDER _ TOKEN = " + realSecret)
+	if !hasTextDLPMatch(s.matchDLPPatterns(compacted, "whitespace"), envVarPattern, "whitespace") {
+		t.Error("collapsed view must still catch a space-split env-var secret assignment")
+	}
+}
+
+// TestEnvVarSecret_BothDirections proves the env-var-secret precision fix holds
+// on both the outbound (agent->tool / request) and inbound (tool result /
+// response) DLP scanning entry points, since both run the same shared pattern
+// set. The shell-example false positive must be clean and a real leaked value
+// must still block in each direction.
+func TestEnvVarSecret_BothDirections(t *testing.T) {
+	s := New(testConfig())
+	defer s.Close()
+
+	shellExample := `PROVIDER_TOKEN=$(grep "^PROVIDER_TOKEN=" ~/.config/app/.env | cut -d= -f2)` +
+		"\n" + `curl -H "Authorization: Bearer $PROVIDER_TOKEN" https://api.vendor.example/user`
+	realLeak := "PROVIDER_TOKEN=" + "tok" + "_" + strings.Repeat("B", 36)
+
+	directions := []struct {
+		name string
+		scan func(string) TextDLPResult
+	}{
+		{"outbound", func(text string) TextDLPResult { return s.ScanTextForDLP(context.Background(), text) }},
+		{"inbound", func(text string) TextDLPResult { return s.ScanTextForDLPInbound(context.Background(), text) }},
+	}
+	for _, d := range directions {
+		t.Run(d.name, func(t *testing.T) {
+			if res := d.scan(shellExample); !res.Clean {
+				t.Errorf("shell example should be clean, got matches: %v", res.Matches)
+			}
+			if res := d.scan(realLeak); res.Clean {
+				t.Error("real leaked env-var secret must still block")
+			}
+		})
 	}
 }
 
@@ -2500,7 +2632,7 @@ func TestScanTextForDLP_BlocksEncodedExfilHostname(t *testing.T) {
 		name string
 		text string
 	}{
-		{"benign api url", "https://api.github.com/v2/status"},
+		{"benign api url", "https://api.vendor.example/v2/status"},
 		{"benign cdn url in text", "load it from https://cdnjs.cloudflare.com/ajax/libs/x.js please"},
 		{"deep dictionary url in text", "fetch https://customer-production.us-east-1.api.example.com/v1/status"},
 		{"two short hash labels", "fetch https://deadbeef.cafebabe.preview.example.com/build"},

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -111,6 +111,22 @@ func TestScanTextForDLP(t *testing.T) {
 			wantClean: true,
 		},
 		{
+			// Regression: the ';' param separator must not extend the captured
+			// credential value, so a short token followed by ';next=...' params
+			// is not a secret (the prefix already treats ';' as a delimiter).
+			name:      "credential in url FP - semicolon-separated params",
+			text:      "GET /p?token=a;page=2;sort=asc",
+			wantClean: true,
+		},
+		{
+			// Detection preserved: a long credential value that is followed by a
+			// ';' param still blocks; only the bleed past ';' is removed.
+			name:        "credential in url - long value before semicolon blocks",
+			text:        "GET /p?token=abcdef123456;page=2",
+			wantClean:   false,
+			wantPattern: "Credential in URL",
+		},
+		{
 			// Regression: Authorization header template referencing an env var.
 			name:      "env var secret FP - authorization header template",
 			text:      `curl -H "Authorization: Bearer $PROVIDER_TOKEN" https://api.vendor.example/user`,


### PR DESCRIPTION
## Summary

Two default DLP patterns, `Environment Variable Secret` and `Credential in URL`, false-positived on legitimate shell/curl examples and hard-blocked content on both the inbound (tool-result) and outbound (MCP tool-call argument) scanning paths. This tightens both patterns so the matched value must begin with a secret-plausible character, eliminating the false positives without disabling any scanning view and without narrowing coverage of real secret formats.

## Root cause

The text-DLP scanner evaluates every pattern against a whitespace-collapsed view of the input (`compactTextDLPWhitespace` in `internal/scanner/text_dlp.go`). That view exists to catch high-confidence keys split by stray whitespace (for example an access key broken by a space).

For a structural `NAME=value` pattern, collapsing whitespace deletes the value's natural delimiter. So a benign line like:

    PROVIDER_TOKEN=$(grep "^PROVIDER_TOKEN=" ~/.config/app/.env | cut -d= -f2)

collapses into one contiguous non-whitespace run, and the pattern's greedy value (`\S{8,}` or `[^\s&]{4,}`) absorbs the rest of the document, matching as if a real secret had been assigned. The same class hit env-var name references (`$PROVIDER_TOKEN`), backtick and `${...}` substitution, and `Authorization: <scheme> $PROVIDER_TOKEN` header templates.

## Fix

The value must now begin with a secret-plausible character before the rest of the run:

| Pattern | Before | After |
|---|---|---|
| Environment Variable Secret | `…=\s*\S{8,}` | `…=\s*[A-Za-z0-9_+/=~.-]\S{7,}` |
| Credential in URL | `…=\s*[^\s&]{4,}` | `…=\s*[A-Za-z0-9_+/=~%.-][^\s&]{3,}` |

Common leaked token formats (base64, base64url, hex, JWT, and URL-encoded values for the URL form) begin with characters in this class, so detection is unchanged, including the space-split evasion case which is preserved through the collapsed view. Shell and template forms that begin with a metacharacter (`$`, backtick, quote, `(`, `<`) no longer match.

This is a pattern-precision change only. The collapsed-whitespace view is left intact so its space-split-key coverage is unaffected.

### Deliberate tradeoff

This heuristic now intentionally misses values that begin with an excluded shell or template metacharacter (for example a password literally starting with `!`, `@`, or `$`). That is acceptable: provider-specific exact-prefix patterns and entropy detection remain as defense-in-depth, and no common provider token format starts with an excluded character.

## Scope and parity

- Updated `internal/config/defaults.go`, all seven preset configs in `configs/`, and `examples/quickstart/pipelock.yaml`.
- The patterns are shared across every transport via a single chokepoint (`ScanTextForDLP`), so the fix applies uniformly to fetch, forward, CONNECT, WebSocket, and MCP stdio/HTTP/SSE input and result scanning.
- `internal/redact/classes.go` carries a structurally similar value shape but is unaffected: it never runs against the whitespace-collapsed view, so it has no blowup class and is intentionally left unchanged.
- Canonical policy golden hashes re-bumped for the detection-relevant change.

## Regression coverage

Added cases assert through the actual collapsed-view mechanism (not just raw text) and confirm detection is preserved on the inbound, outbound, and MCP tool-call-input surfaces, plus the space-split evasion case still matching.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined DLP detection rules for credentials-in-URLs and environment-variable secrets to reduce false positives while preserving blocking of real secrets.

* **Tests**
  * Added regression tests covering DLP scanning scenarios to validate accuracy across various encodings and shell snippets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->