### PR TITLE
Harden conductor audit queue lifecycle and error mapping

### DIFF
--- a/charts/pipelock/README.md
+++ b/charts/pipelock/README.md
@@ -103,6 +103,11 @@ Enterprise server modes use the license Secret as `PIPELOCK_LICENSE_KEY` because
 | `conductorFollower.persistence.bundleCache.enabled` | `false` | PVC for signed policy bundle cache |
 | `conductorFollower.persistence.auditQueue.enabled` | `false` | PVC for durable audit queue |
 
+The follower audit queue is single-writer. Pipelock uses an advisory lock for
+one host / local-filesystem scope, but it is not a distributed lock for shared
+RWX, network, or overlay PVCs. Use ReadWriteOnce storage, leader election, or a
+separate audit queue per pod when running multiple followers.
+
 ### Fleet sink
 
 | Key | Default | Description |

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -825,6 +825,13 @@ When `conductor.enabled` is true, the flight recorder must be enabled with
 signed checkpoints and a configured signing key. `audit_signing_key_id` and
 `recorder_key_id` default to `instance_id` when omitted.
 
+`durable_audit_queue_dir` is a single-writer directory. Pipelock takes an
+advisory lock to prevent two writers in one host / local-filesystem scope from
+opening the same queue at the same time. That lock is not a distributed lock.
+Cross-host single-writer safety on shared RWX, network, or overlay PVCs is a
+deployment responsibility: use ReadWriteOnce storage, Kubernetes leader
+election, or give each pod its own durable audit queue.
+
 Upgrade note: `honor_remote_kill_switch` defaults to true. Existing
 Conductor-enabled followers that only use audit batching must either set
 `trust_roster_root_fingerprint` and ship a roster containing

--- a/enterprise/conductor/auditbatcher/queue.go
+++ b/enterprise/conductor/auditbatcher/queue.go
@@ -10,12 +10,11 @@
 // Concurrency model: a Queue is SINGLE-PROCESS per directory. The mutex
 // serializes access within one process; an exclusive advisory flock on a
 // .lock file under the queue root (taken at Open, released at Close or on
-// process death) enforces single-writer ACROSS processes. A second Open on the
-// same dir fails closed with ErrQueueLocked rather than interleaving
-// Enqueue/Claim/Drop across two independent mutexes on a shared volume.
-// Operators should still scope one writer per durable_audit_queue_dir, but a
-// botched rollout that briefly runs two pods now fails closed instead of
-// corrupting the queue.
+// process death) enforces single-writer across processes on one host / local
+// filesystem. This is not a distributed lock: cross-host single-writer on a
+// shared RWX/network/overlay PVC is a deployment responsibility. Use a RWO
+// volume, leader election, or one durable_audit_queue_dir per pod for that
+// shape.
 package auditbatcher
 
 import (
@@ -55,6 +54,7 @@ var (
 	ErrQueueFull     = errors.New("auditbatcher: queue full")
 	ErrCorruptRecord = errors.New("auditbatcher: corrupt record")
 	ErrQueueLocked   = errors.New("auditbatcher: queue already locked by another process")
+	ErrQueueClosed   = errors.New("auditbatcher: queue closed")
 )
 
 type Config struct {
@@ -93,6 +93,7 @@ type Queue struct {
 	maxPayloadBytes uint64
 	now             func() time.Time
 	mu              sync.Mutex
+	closed          bool
 	// lockFile holds the exclusive advisory lock on the queue root for the
 	// Queue's lifetime. The OS releases the flock automatically when this fd is
 	// closed OR when the owning process dies, so a crashed prior owner never
@@ -168,11 +169,12 @@ func Open(cfg Config) (*Queue, error) {
 }
 
 // acquireQueueLock takes an exclusive, non-blocking advisory lock on a .lock
-// file under the queue root. A second process opening the same dir fails closed
-// with ErrQueueLocked rather than silently interleaving Enqueue/Claim/Drop
-// across two independent in-process mutexes (which loses or duplicates audit
-// batches on a shared volume). The flock is released when the fd is closed
-// (Close) or when the holding process dies, so a crash never deadlocks.
+// file under the queue root. A second process on the same host / local
+// filesystem opening the same dir fails closed with ErrQueueLocked rather than
+// silently interleaving Enqueue/Claim/Drop across two independent in-process
+// mutexes. This is not a distributed lock for cross-host shared PVCs. The flock
+// is released when the fd is closed (Close) or when the holding process dies, so
+// a crash never deadlocks.
 func acquireQueueLock(dir string) (*os.File, error) {
 	path := filepath.Join(filepath.Clean(dir), lockFileName)
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, fileMode)
@@ -189,16 +191,27 @@ func acquireQueueLock(dir string) (*os.File, error) {
 	return f, nil
 }
 
-// Close releases the exclusive queue lock so another process may Open the same
-// directory. It is safe to call once; subsequent calls are no-ops. In-flight
-// callers must stop using the Queue before Close.
+// Close marks the queue closed and releases the exclusive queue lock so another
+// process may Open the same directory. It is safe to call multiple times.
+// Subsequent queue operations fail closed with ErrQueueClosed.
 func (q *Queue) Close() error {
 	if q == nil {
 		return errors.New("auditbatcher: nil queue")
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	q.closed = true
 	return q.releaseLock()
+}
+
+func (q *Queue) checkOpenLocked() error {
+	if q.closed {
+		return ErrQueueClosed
+	}
+	if q.lockFile == nil {
+		return ErrQueueClosed
+	}
+	return nil
 }
 
 func (q *Queue) releaseLock() error {
@@ -225,6 +238,9 @@ func (q *Queue) Enqueue(batch Batch) (string, error) {
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	if err := q.checkOpenLocked(); err != nil {
+		return "", err
+	}
 
 	pending, err := listRecordFiles(q.pendingDir)
 	if err != nil {
@@ -260,6 +276,9 @@ func (q *Queue) Claim() (*Lease, error) {
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	if err := q.checkOpenLocked(); err != nil {
+		return nil, err
+	}
 
 	for {
 		files, err := listRecordFiles(q.pendingDir)
@@ -311,6 +330,9 @@ func (q *Queue) Ack(id string) error {
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	if err := q.checkOpenLocked(); err != nil {
+		return err
+	}
 	if err := os.Remove(filepath.Join(q.inflightDir, id)); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("auditbatcher: ack %s: %w", id, err)
 	}
@@ -326,6 +348,9 @@ func (q *Queue) Release(id string) error {
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	if err := q.checkOpenLocked(); err != nil {
+		return err
+	}
 	return q.releaseLocked(id)
 }
 
@@ -342,6 +367,9 @@ func (q *Queue) ReleaseWithRetry(id, reason string) error {
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	if err := q.checkOpenLocked(); err != nil {
+		return err
+	}
 	if err := q.updateInflightRecordLocked(id, func(record *diskRecord) {
 		now := q.now().UTC()
 		record.RetryCount++
@@ -364,6 +392,9 @@ func (q *Queue) Drop(id, reason string) error {
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	if err := q.checkOpenLocked(); err != nil {
+		return err
+	}
 	if err := q.updateInflightRecordLocked(id, func(record *diskRecord) {
 		now := q.now().UTC()
 		record.DroppedAt = &now
@@ -403,6 +434,9 @@ func (q *Queue) Stats() (Stats, error) {
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	if err := q.checkOpenLocked(); err != nil {
+		return Stats{}, err
+	}
 	pending, err := listRecordFiles(q.pendingDir)
 	if err != nil {
 		return Stats{}, err

--- a/enterprise/conductor/auditbatcher/queue.go
+++ b/enterprise/conductor/auditbatcher/queue.go
@@ -30,7 +30,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
@@ -168,29 +167,6 @@ func Open(cfg Config) (*Queue, error) {
 	return q, nil
 }
 
-// acquireQueueLock takes an exclusive, non-blocking advisory lock on a .lock
-// file under the queue root. A second process on the same host / local
-// filesystem opening the same dir fails closed with ErrQueueLocked rather than
-// silently interleaving Enqueue/Claim/Drop across two independent in-process
-// mutexes. This is not a distributed lock for cross-host shared PVCs. The flock
-// is released when the fd is closed (Close) or when the holding process dies, so
-// a crash never deadlocks.
-func acquireQueueLock(dir string) (*os.File, error) {
-	path := filepath.Join(filepath.Clean(dir), lockFileName)
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, fileMode)
-	if err != nil {
-		return nil, fmt.Errorf("auditbatcher: open queue lock %s: %w", path, err)
-	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		_ = f.Close()
-		if errors.Is(err, syscall.EWOULDBLOCK) {
-			return nil, fmt.Errorf("%w: %s", ErrQueueLocked, path)
-		}
-		return nil, fmt.Errorf("auditbatcher: lock queue %s: %w", path, err)
-	}
-	return f, nil
-}
-
 // Close marks the queue closed and releases the exclusive queue lock so another
 // process may Open the same directory. It is safe to call multiple times.
 // Subsequent queue operations fail closed with ErrQueueClosed.
@@ -214,31 +190,16 @@ func (q *Queue) checkOpenLocked() error {
 	return nil
 }
 
-func (q *Queue) releaseLock() error {
-	if q.lockFile == nil {
-		return nil
-	}
-	f := q.lockFile
-	q.lockFile = nil
-	// Closing the fd implicitly releases the flock; an explicit Flock(LOCK_UN)
-	// first makes the release deterministic even if the fd is later dup'd.
-	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("auditbatcher: close queue lock: %w", err)
-	}
-	return nil
-}
-
 func (q *Queue) Enqueue(batch Batch) (string, error) {
 	if q == nil {
 		return "", errors.New("auditbatcher: nil queue")
 	}
-	if err := validateBatch(batch, q.maxPayloadBytes); err != nil {
-		return "", err
-	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	if err := q.checkOpenLocked(); err != nil {
+		return "", err
+	}
+	if err := validateBatch(batch, q.maxPayloadBytes); err != nil {
 		return "", err
 	}
 
@@ -886,7 +847,7 @@ func fsyncDir(dir string) error {
 	}
 	defer func() { _ = f.Close() }()
 	if err := f.Sync(); err != nil {
-		if errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOTSUP) {
+		if ignoreDirSyncError(err) {
 			return nil
 		}
 		return fmt.Errorf("auditbatcher: fsync dir %s: %w", dir, err)

--- a/enterprise/conductor/auditbatcher/queue.go
+++ b/enterprise/conductor/auditbatcher/queue.go
@@ -8,10 +8,14 @@
 // being fire-and-forget.
 //
 // Concurrency model: a Queue is SINGLE-PROCESS per directory. The mutex
-// serializes access within one process; nothing prevents a second pipelock
-// process from opening the same dir and corrupting the queue via concurrent
-// renames. Operators must enforce one writer per durable_audit_queue_dir via
-// systemd, k8s leadership election, or simple deployment discipline.
+// serializes access within one process; an exclusive advisory flock on a
+// .lock file under the queue root (taken at Open, released at Close or on
+// process death) enforces single-writer ACROSS processes. A second Open on the
+// same dir fails closed with ErrQueueLocked rather than interleaving
+// Enqueue/Claim/Drop across two independent mutexes on a shared volume.
+// Operators should still scope one writer per durable_audit_queue_dir, but a
+// botched rollout that briefly runs two pods now fails closed instead of
+// corrupting the queue.
 package auditbatcher
 
 import (
@@ -44,10 +48,13 @@ const (
 	recordExt              = ".json"
 )
 
+const lockFileName = ".lock"
+
 var (
 	ErrQueueEmpty    = errors.New("auditbatcher: queue empty")
 	ErrQueueFull     = errors.New("auditbatcher: queue full")
 	ErrCorruptRecord = errors.New("auditbatcher: corrupt record")
+	ErrQueueLocked   = errors.New("auditbatcher: queue already locked by another process")
 )
 
 type Config struct {
@@ -64,6 +71,11 @@ type Batch struct {
 type Lease struct {
 	ID    string
 	Batch Batch
+	// RetryCount is the number of prior delivery attempts that released this
+	// record back to pending. A freshly enqueued record leases with 0. The
+	// transport uses it to enforce a max-delivery-attempts ceiling before
+	// dead-lettering a poison batch.
+	RetryCount uint64
 }
 
 type Stats struct {
@@ -81,6 +93,11 @@ type Queue struct {
 	maxPayloadBytes uint64
 	now             func() time.Time
 	mu              sync.Mutex
+	// lockFile holds the exclusive advisory lock on the queue root for the
+	// Queue's lifetime. The OS releases the flock automatically when this fd is
+	// closed OR when the owning process dies, so a crashed prior owner never
+	// deadlocks a fresh Open.
+	lockFile *os.File
 }
 
 type diskRecord struct {
@@ -110,6 +127,10 @@ func Open(cfg Config) (*Queue, error) {
 	if err != nil {
 		return nil, err
 	}
+	lockFile, err := acquireQueueLock(dir)
+	if err != nil {
+		return nil, err
+	}
 	q := &Queue{
 		dir:             dir,
 		pendingDir:      pendingDir,
@@ -118,7 +139,16 @@ func Open(cfg Config) (*Queue, error) {
 		maxPending:      cfg.MaxPending,
 		maxPayloadBytes: cfg.MaxPayloadBytes,
 		now:             func() time.Time { return time.Now().UTC() },
+		lockFile:        lockFile,
 	}
+	// Any failure after the lock is held must release it, otherwise a failed
+	// Open leaves the queue dir locked until process exit.
+	opened := false
+	defer func() {
+		if !opened {
+			_ = q.releaseLock()
+		}
+	}()
 	// Sweep .tmp-* debris from any prior crash mid-write. Live writes use
 	// CreateTemp+rename; only crashes leave .tmp-* files behind, and they
 	// otherwise accumulate forever (listRecordFiles correctly ignores them,
@@ -133,7 +163,57 @@ func Open(cfg Config) (*Queue, error) {
 	if err := q.recoverInflightLocked(); err != nil {
 		return nil, err
 	}
+	opened = true
 	return q, nil
+}
+
+// acquireQueueLock takes an exclusive, non-blocking advisory lock on a .lock
+// file under the queue root. A second process opening the same dir fails closed
+// with ErrQueueLocked rather than silently interleaving Enqueue/Claim/Drop
+// across two independent in-process mutexes (which loses or duplicates audit
+// batches on a shared volume). The flock is released when the fd is closed
+// (Close) or when the holding process dies, so a crash never deadlocks.
+func acquireQueueLock(dir string) (*os.File, error) {
+	path := filepath.Join(filepath.Clean(dir), lockFileName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, fileMode)
+	if err != nil {
+		return nil, fmt.Errorf("auditbatcher: open queue lock %s: %w", path, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, fmt.Errorf("%w: %s", ErrQueueLocked, path)
+		}
+		return nil, fmt.Errorf("auditbatcher: lock queue %s: %w", path, err)
+	}
+	return f, nil
+}
+
+// Close releases the exclusive queue lock so another process may Open the same
+// directory. It is safe to call once; subsequent calls are no-ops. In-flight
+// callers must stop using the Queue before Close.
+func (q *Queue) Close() error {
+	if q == nil {
+		return errors.New("auditbatcher: nil queue")
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.releaseLock()
+}
+
+func (q *Queue) releaseLock() error {
+	if q.lockFile == nil {
+		return nil
+	}
+	f := q.lockFile
+	q.lockFile = nil
+	// Closing the fd implicitly releases the flock; an explicit Flock(LOCK_UN)
+	// first makes the release deterministic even if the fd is later dup'd.
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("auditbatcher: close queue lock: %w", err)
+	}
+	return nil
 }
 
 func (q *Queue) Enqueue(batch Batch) (string, error) {
@@ -218,7 +298,7 @@ func (q *Queue) Claim() (*Lease, error) {
 			}
 			continue
 		}
-		return &Lease{ID: id, Batch: Batch{Envelope: record.Envelope, Payload: record.Payload}}, nil
+		return &Lease{ID: id, Batch: Batch{Envelope: record.Envelope, Payload: record.Payload}, RetryCount: record.RetryCount}, nil
 	}
 }
 

--- a/enterprise/conductor/auditbatcher/queue_lock_unix.go
+++ b/enterprise/conductor/auditbatcher/queue_lock_unix.go
@@ -1,0 +1,55 @@
+//go:build enterprise && !windows
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package auditbatcher
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// acquireQueueLock takes an exclusive, non-blocking advisory lock on a .lock
+// file under the queue root. A second process on the same host / local
+// filesystem opening the same dir fails closed with ErrQueueLocked rather than
+// silently interleaving Enqueue/Claim/Drop across two independent in-process
+// mutexes. This is not a distributed lock for cross-host shared PVCs. The flock
+// is released when the fd is closed (Close) or when the holding process dies, so
+// a crash never deadlocks.
+func acquireQueueLock(dir string) (*os.File, error) {
+	path := filepath.Join(filepath.Clean(dir), lockFileName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, fileMode)
+	if err != nil {
+		return nil, fmt.Errorf("auditbatcher: open queue lock %s: %w", path, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, fmt.Errorf("%w: %s", ErrQueueLocked, path)
+		}
+		return nil, fmt.Errorf("auditbatcher: lock queue %s: %w", path, err)
+	}
+	return f, nil
+}
+
+func (q *Queue) releaseLock() error {
+	if q.lockFile == nil {
+		return nil
+	}
+	f := q.lockFile
+	q.lockFile = nil
+	// Closing the fd implicitly releases the flock; an explicit Flock(LOCK_UN)
+	// first makes the release deterministic even if the fd is later dup'd.
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("auditbatcher: close queue lock: %w", err)
+	}
+	return nil
+}
+
+func ignoreDirSyncError(err error) bool {
+	return errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOTSUP)
+}

--- a/enterprise/conductor/auditbatcher/queue_lock_windows.go
+++ b/enterprise/conductor/auditbatcher/queue_lock_windows.go
@@ -1,0 +1,72 @@
+//go:build enterprise && windows
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package auditbatcher
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+const windowsLockAllBytes = ^uint32(0)
+
+// acquireQueueLock takes an exclusive, non-blocking advisory lock on a .lock
+// file under the queue root. On Windows this uses LockFileEx over the whole
+// file so a second process on the same host / local filesystem fails closed
+// with ErrQueueLocked. This is not a distributed lock for cross-host shared
+// PVCs.
+func acquireQueueLock(dir string) (*os.File, error) {
+	path := filepath.Join(filepath.Clean(dir), lockFileName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, fileMode)
+	if err != nil {
+		return nil, fmt.Errorf("auditbatcher: open queue lock %s: %w", path, err)
+	}
+	ol := new(windows.Overlapped)
+	err = windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		windowsLockAllBytes,
+		windowsLockAllBytes,
+		ol,
+	)
+	if err != nil {
+		_ = f.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+			return nil, fmt.Errorf("%w: %s", ErrQueueLocked, path)
+		}
+		return nil, fmt.Errorf("auditbatcher: lock queue %s: %w", path, err)
+	}
+	return f, nil
+}
+
+func (q *Queue) releaseLock() error {
+	if q.lockFile == nil {
+		return nil
+	}
+	f := q.lockFile
+	q.lockFile = nil
+	ol := new(windows.Overlapped)
+	_ = windows.UnlockFileEx(
+		windows.Handle(f.Fd()),
+		0,
+		windowsLockAllBytes,
+		windowsLockAllBytes,
+		ol,
+	)
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("auditbatcher: close queue lock: %w", err)
+	}
+	return nil
+}
+
+func ignoreDirSyncError(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_INVALID_FUNCTION) ||
+		errors.Is(err, windows.ERROR_INVALID_HANDLE)
+}

--- a/enterprise/conductor/auditbatcher/queue_test.go
+++ b/enterprise/conductor/auditbatcher/queue_test.go
@@ -159,6 +159,47 @@ func TestQueueCloseReleasesLock(t *testing.T) {
 	defer func() { _ = reopened.Close() }()
 }
 
+func TestQueueOperationsFailAfterClose(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	q := openTestQueue(t, Config{})
+	id, err := q.Enqueue(signedTestBatch(t, "batch-closed", priv))
+	if err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	if _, err := q.Claim(); err != nil {
+		t.Fatalf("Claim() error = %v", err)
+	}
+	if err := q.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	batch := signedTestBatch(t, "batch-closed-new", priv)
+	if _, err := q.Enqueue(batch); !errors.Is(err, ErrQueueClosed) {
+		t.Fatalf("Enqueue(after Close) = %v, want ErrQueueClosed", err)
+	}
+	if _, err := q.Claim(); !errors.Is(err, ErrQueueClosed) {
+		t.Fatalf("Claim(after Close) = %v, want ErrQueueClosed", err)
+	}
+	if err := q.Ack(id); !errors.Is(err, ErrQueueClosed) {
+		t.Fatalf("Ack(after Close) = %v, want ErrQueueClosed", err)
+	}
+	if err := q.Release(id); !errors.Is(err, ErrQueueClosed) {
+		t.Fatalf("Release(after Close) = %v, want ErrQueueClosed", err)
+	}
+	if err := q.ReleaseWithRetry(id, "retry"); !errors.Is(err, ErrQueueClosed) {
+		t.Fatalf("ReleaseWithRetry(after Close) = %v, want ErrQueueClosed", err)
+	}
+	if err := q.Drop(id, "drop"); !errors.Is(err, ErrQueueClosed) {
+		t.Fatalf("Drop(after Close) = %v, want ErrQueueClosed", err)
+	}
+	if _, err := q.Stats(); !errors.Is(err, ErrQueueClosed) {
+		t.Fatalf("Stats(after Close) = %v, want ErrQueueClosed", err)
+	}
+}
+
 // TestQueueLockFileNotTreatedAsRecord proves the .lock file lives under the
 // queue root but is invisible to Claim/Stats (it is not a .json record) and is
 // not swept as a stale temp.
@@ -1167,6 +1208,7 @@ func openTestQueue(t *testing.T, cfg Config) *Queue {
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
+	t.Cleanup(func() { _ = q.Close() })
 	return q
 }
 

--- a/enterprise/conductor/auditbatcher/queue_test.go
+++ b/enterprise/conductor/auditbatcher/queue_test.go
@@ -73,6 +73,9 @@ func TestNilQueueMethodsReturnErrors(t *testing.T) {
 	if _, err := q.Stats(); err == nil {
 		t.Fatal("Stats(nil) error = nil, want error")
 	}
+	if err := q.Close(); err == nil {
+		t.Fatal("Close(nil) error = nil, want error")
+	}
 }
 
 func TestQueueClaimEmpty(t *testing.T) {
@@ -97,17 +100,97 @@ func TestQueuePersistsAcrossOpen(t *testing.T) {
 	if _, err := q.Enqueue(batch); err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
+	// Release the single-writer lock before reopening (simulates restart).
+	if err := q.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
 
 	reopened, err := Open(Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open(reopen) error = %v", err)
 	}
+	defer func() { _ = reopened.Close() }()
 	lease, err := reopened.Claim()
 	if err != nil {
 		t.Fatalf("Claim() error = %v", err)
 	}
 	if lease.Batch.Envelope.BatchID != "batch-persist" {
 		t.Fatalf("BatchID = %q, want batch-persist", lease.Batch.Envelope.BatchID)
+	}
+}
+
+// TestQueueOpenLocksDirectory proves the cross-process single-writer guard: a
+// second Open on a dir already held by a live Queue fails closed with
+// ErrQueueLocked rather than silently allowing two writers.
+func TestQueueOpenLocksDirectory(t *testing.T) {
+	dir := t.TempDir()
+	q, err := Open(Config{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer func() { _ = q.Close() }()
+
+	if _, err := Open(Config{Dir: dir}); !errors.Is(err, ErrQueueLocked) {
+		t.Fatalf("Open(second) error = %v, want ErrQueueLocked", err)
+	}
+}
+
+// TestQueueCloseReleasesLock proves the lock is released on Close so a fresh
+// Open succeeds. flock auto-releases on process death, so a crashed prior owner
+// (fd gone) is indistinguishable from an explicit Close here.
+func TestQueueCloseReleasesLock(t *testing.T) {
+	dir := t.TempDir()
+	q, err := Open(Config{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	if err := q.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	// Idempotent: a second Close is a no-op.
+	if err := q.Close(); err != nil {
+		t.Fatalf("Close(second) error = %v", err)
+	}
+
+	reopened, err := Open(Config{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open(after close) error = %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+}
+
+// TestQueueLockFileNotTreatedAsRecord proves the .lock file lives under the
+// queue root but is invisible to Claim/Stats (it is not a .json record) and is
+// not swept as a stale temp.
+func TestQueueLockFileNotTreatedAsRecord(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	dir := t.TempDir()
+	q, err := Open(Config{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer func() { _ = q.Close() }()
+
+	// Lock file exists at the queue root.
+	if _, err := os.Stat(filepath.Join(q.dir, lockFileName)); err != nil {
+		t.Fatalf("Stat(lock file) error = %v, want present", err)
+	}
+	// Fresh queue is empty - the lock file must not count as a record.
+	assertStats(t, q, Stats{})
+
+	if _, err := q.Enqueue(signedTestBatch(t, "batch-lock", priv)); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	assertStats(t, q, Stats{Pending: 1})
+	lease, err := q.Claim()
+	if err != nil {
+		t.Fatalf("Claim() error = %v", err)
+	}
+	if lease.Batch.Envelope.BatchID != "batch-lock" {
+		t.Fatalf("BatchID = %q, want batch-lock", lease.Batch.Envelope.BatchID)
 	}
 }
 
@@ -136,10 +219,14 @@ func TestQueueReleaseAndRecoverInflight(t *testing.T) {
 	if _, err := q.Claim(); err != nil {
 		t.Fatalf("Claim(second) error = %v", err)
 	}
+	if err := q.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
 	reopened, err := Open(Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open(reopen) error = %v", err)
 	}
+	defer func() { _ = reopened.Close() }()
 	assertStats(t, reopened, Stats{Pending: 1})
 }
 
@@ -163,11 +250,15 @@ func TestQueueReleaseWithRetryPersistsAccounting(t *testing.T) {
 	if err := q.ReleaseWithRetry(id, "HTTP 503 temporary outage"); err != nil {
 		t.Fatalf("ReleaseWithRetry() error = %v", err)
 	}
+	if err := q.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
 
 	reopened, err := Open(Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open(reopen) error = %v", err)
 	}
+	defer func() { _ = reopened.Close() }()
 	record, err := readRecord(filepath.Join(reopened.pendingDir, id), conductor.MaxAuditPayloadBytes)
 	if err != nil {
 		t.Fatalf("readRecord() error = %v", err)
@@ -180,6 +271,15 @@ func TestQueueReleaseWithRetryPersistsAccounting(t *testing.T) {
 	}
 	if record.LastError != "http_503_temporary_outage" {
 		t.Fatalf("LastError = %q, want normalized retry reason", record.LastError)
+	}
+	// A claim after restart must surface the durable RetryCount on the lease so
+	// the transport's delivery-attempt ceiling survives a serve restart.
+	lease, err := reopened.Claim()
+	if err != nil {
+		t.Fatalf("Claim(after reopen) error = %v", err)
+	}
+	if lease.RetryCount != 1 {
+		t.Fatalf("lease.RetryCount = %d, want 1 (durable across restart)", lease.RetryCount)
 	}
 }
 
@@ -598,11 +698,15 @@ func TestOpenSweepsStaleTempFiles(t *testing.T) {
 			t.Fatalf("WriteFile(%s) error = %v", sub, err)
 		}
 	}
+	if err := q.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
 
 	reopened, err := Open(Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open(reopen) error = %v", err)
 	}
+	defer func() { _ = reopened.Close() }()
 	for _, sub := range []string{reopened.pendingDir, reopened.inflightDir, reopened.deadDir} {
 		entries, err := os.ReadDir(sub)
 		if err != nil {
@@ -681,10 +785,15 @@ func TestRecoverInflightHandlesNameCollision(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(q.pendingDir, recoveredID), originalContent, fileMode); err != nil {
 		t.Fatalf("WriteFile(pending/<id>-recovered) error = %v", err)
 	}
+	if err := q.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
 
-	if _, err := Open(Config{Dir: dir}); err != nil {
+	reopened, err := Open(Config{Dir: dir})
+	if err != nil {
 		t.Fatalf("Open(reopen) error = %v", err)
 	}
+	defer func() { _ = reopened.Close() }()
 	// Both originals must be intact; recovery must have landed under a
 	// fresh name (recovered-1-<id>).
 	for _, p := range []string{

--- a/enterprise/conductor/auditbatcher/queue_test.go
+++ b/enterprise/conductor/auditbatcher/queue_test.go
@@ -180,6 +180,9 @@ func TestQueueOperationsFailAfterClose(t *testing.T) {
 	if _, err := q.Enqueue(batch); !errors.Is(err, ErrQueueClosed) {
 		t.Fatalf("Enqueue(after Close) = %v, want ErrQueueClosed", err)
 	}
+	if _, err := q.Enqueue(Batch{}); !errors.Is(err, ErrQueueClosed) {
+		t.Fatalf("Enqueue(invalid batch after Close) = %v, want ErrQueueClosed", err)
+	}
 	if _, err := q.Claim(); !errors.Is(err, ErrQueueClosed) {
 		t.Fatalf("Claim(after Close) = %v, want ErrQueueClosed", err)
 	}

--- a/enterprise/conductor/auditbatcher/transport.go
+++ b/enterprise/conductor/auditbatcher/transport.go
@@ -23,6 +23,17 @@ const (
 	AuditBatchesPath         = conductor.AuditBatchesPath
 	defaultTransportDelay    = time.Second
 	maxTransportErrorSnippet = 1024
+
+	// defaultMaxDeliveryAttempts caps how many times a single audit batch may
+	// be attempted before it is dead-lettered instead of released for another
+	// retry. Without a ceiling a permanently-failing (e.g. 5xx) poison batch
+	// sits at the FIFO head forever and starves every batch behind it. The
+	// dead-letter is a durable, operator-inspectable quarantine - never a
+	// silent discard - so audit loss is surfaced via queue_dead + the
+	// max_retries drop reason. Operator knob deferred: this ships as a default
+	// constant; TransportConfig.MaxDeliveryAttempts allows runtime override
+	// without yet wiring a YAML config field.
+	defaultMaxDeliveryAttempts = 10
 )
 
 const (
@@ -34,6 +45,11 @@ const (
 	deliveryReasonClientError = "http_client_error"
 	deliveryReasonRateLimited = "http_rate_limited"
 	deliveryReasonServerError = "http_server_error"
+
+	// dropReasonMaxRetries stamps a batch that exhausted the delivery-attempt
+	// ceiling. It is the only drop reason produced from the otherwise-retryable
+	// path; all other drops come from terminal 4xx/marshal/request errors.
+	dropReasonMaxRetries = "max_retries"
 )
 
 // HTTPDoer is the narrow boundary between the durable queue and Conductor.
@@ -57,15 +73,19 @@ type TransportConfig struct {
 	Metrics    MetricsSink
 	RetryDelay time.Duration
 	EmptyDelay time.Duration
+	// MaxDeliveryAttempts caps total delivery attempts per batch before
+	// dead-lettering. <= 0 uses defaultMaxDeliveryAttempts.
+	MaxDeliveryAttempts int
 }
 
 type Transport struct {
-	endpoint   string
-	client     HTTPDoer
-	queue      *Queue
-	metrics    MetricsSink
-	retryDelay time.Duration
-	emptyDelay time.Duration
+	endpoint    string
+	client      HTTPDoer
+	queue       *Queue
+	metrics     MetricsSink
+	retryDelay  time.Duration
+	emptyDelay  time.Duration
+	maxAttempts uint64
 }
 
 type batchUpload struct {
@@ -96,13 +116,18 @@ func NewTransport(cfg TransportConfig) (*Transport, error) {
 	if cfg.EmptyDelay <= 0 {
 		cfg.EmptyDelay = defaultTransportDelay
 	}
+	maxAttempts := uint64(defaultMaxDeliveryAttempts)
+	if cfg.MaxDeliveryAttempts > 0 {
+		maxAttempts = uint64(cfg.MaxDeliveryAttempts)
+	}
 	return &Transport{
-		endpoint:   endpoint,
-		client:     cfg.Client,
-		queue:      cfg.Queue,
-		metrics:    cfg.Metrics,
-		retryDelay: cfg.RetryDelay,
-		emptyDelay: cfg.EmptyDelay,
+		endpoint:    endpoint,
+		client:      cfg.Client,
+		queue:       cfg.Queue,
+		metrics:     cfg.Metrics,
+		retryDelay:  cfg.RetryDelay,
+		emptyDelay:  cfg.EmptyDelay,
+		maxAttempts: maxAttempts,
 	}, nil
 }
 
@@ -158,6 +183,23 @@ func (t *Transport) DeliverOnce(ctx context.Context) error {
 			return err
 		}
 	case deliveryOutcomeRetry:
+		// The attempt that just failed is attempt number RetryCount+1. Once
+		// that number reaches the ceiling the batch is exhausted: escalate to
+		// the dead-letter directory instead of releasing it for another retry,
+		// so a permanently-failing poison batch cannot starve the FIFO head.
+		// ctx cancellation is not a delivery failure - never burn an attempt on
+		// shutdown, always release so the record survives.
+		if ctx.Err() == nil && lease.RetryCount+1 >= t.maxAttempts {
+			result = deliveryResult{
+				outcome: deliveryOutcomeDrop,
+				reason:  dropReasonMaxRetries,
+				err:     fmt.Errorf("auditbatcher: dropping batch after %d delivery attempts: %w", lease.RetryCount+1, result.err),
+			}
+			if err := t.queue.Drop(lease.ID, result.reason); err != nil {
+				return err
+			}
+			break
+		}
 		if err := t.queue.ReleaseWithRetry(lease.ID, result.reason); err != nil {
 			return err
 		}

--- a/enterprise/conductor/auditbatcher/transport.go
+++ b/enterprise/conductor/auditbatcher/transport.go
@@ -187,13 +187,19 @@ func (t *Transport) DeliverOnce(ctx context.Context) error {
 		// that number reaches the ceiling the batch is exhausted: escalate to
 		// the dead-letter directory instead of releasing it for another retry,
 		// so a permanently-failing poison batch cannot starve the FIFO head.
-		// ctx cancellation is not a delivery failure - never burn an attempt on
-		// shutdown, always release so the record survives.
-		if ctx.Err() == nil && lease.RetryCount+1 >= t.maxAttempts {
+		// Compare without RetryCount+1 to avoid overflow if a corrupt on-disk
+		// record carries retry_count=MaxUint64. ctx cancellation is not a
+		// delivery failure - never burn an attempt on shutdown, always release
+		// so the record survives.
+		if ctx.Err() == nil && t.maxAttempts > 0 && lease.RetryCount >= t.maxAttempts-1 {
+			attempts := lease.RetryCount
+			if attempts < ^uint64(0) {
+				attempts++
+			}
 			result = deliveryResult{
 				outcome: deliveryOutcomeDrop,
 				reason:  dropReasonMaxRetries,
-				err:     fmt.Errorf("auditbatcher: dropping batch after %d delivery attempts: %w", lease.RetryCount+1, result.err),
+				err:     fmt.Errorf("auditbatcher: dropping batch after %d delivery attempts: %w", attempts, result.err),
 			}
 			if err := t.queue.Drop(lease.ID, result.reason); err != nil {
 				return err

--- a/enterprise/conductor/auditbatcher/transport.go
+++ b/enterprise/conductor/auditbatcher/transport.go
@@ -191,7 +191,13 @@ func (t *Transport) DeliverOnce(ctx context.Context) error {
 		// record carries retry_count=MaxUint64. ctx cancellation is not a
 		// delivery failure - never burn an attempt on shutdown, always release
 		// so the record survives.
-		if ctx.Err() == nil && t.maxAttempts > 0 && lease.RetryCount >= t.maxAttempts-1 {
+		if ctx.Err() != nil {
+			if err := t.queue.Release(lease.ID); err != nil {
+				return err
+			}
+			break
+		}
+		if t.maxAttempts > 0 && lease.RetryCount >= t.maxAttempts-1 {
 			attempts := lease.RetryCount
 			if attempts < ^uint64(0) {
 				attempts++

--- a/enterprise/conductor/auditbatcher/transport_test.go
+++ b/enterprise/conductor/auditbatcher/transport_test.go
@@ -19,8 +19,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 func TestTransportDeliverOnceSuccessAcksRecord(t *testing.T) {
@@ -248,23 +246,30 @@ func TestTransportWireFormat_StableContract(t *testing.T) {
 	}
 }
 
-// TestTransportRun_GracefulShutdown spins Run on a server that returns 503
-// (forcing the retry path), cancels ctx, and asserts Run returns ctx.Err()
-// within a bounded window. Without this, a stuck transport could hang
-// pipelock shutdown indefinitely.
+// TestTransportRun_GracefulShutdown spins Run on a server that holds the
+// delivery request open until ctx cancellation, then asserts Run returns
+// ctx.Err() within a bounded window without burning a retry attempt. Without
+// this, a stuck transport could hang pipelock shutdown indefinitely or make
+// restarts consume retry budget.
 func TestTransportRun_GracefulShutdown(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("GenerateKey() error = %v", err)
 	}
 	q := openTestQueue(t, Config{})
-	if _, err := q.Enqueue(signedTestBatch(t, "batch-shutdown", priv)); err != nil {
+	id, err := q.Enqueue(signedTestBatch(t, "batch-shutdown", priv))
+	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
-	var attempts atomic.Int64
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		attempts.Add(1)
-		w.WriteHeader(http.StatusServiceUnavailable)
+	attempted := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	var attemptedOnce sync.Once
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		attemptedOnce.Do(func() { close(attempted) })
+		select {
+		case <-releaseHandler:
+		case <-r.Context().Done():
+		}
 	}))
 	defer srv.Close()
 
@@ -274,8 +279,9 @@ func TestTransportRun_GracefulShutdown(t *testing.T) {
 		Queue:      q,
 		RetryDelay: 10 * time.Millisecond,
 		EmptyDelay: 10 * time.Millisecond,
-		// High ceiling so the retry-loop-until-cancel path is exercised without
-		// the dead-letter escalation firing - this test asserts Dead == 0.
+		// High ceiling so any accidental retry-loop-until-cancel path is
+		// exercised without the dead-letter escalation firing - this test
+		// asserts Dead == 0 and RetryCount == 0.
 		MaxDeliveryAttempts: 1_000_000,
 	})
 	if err != nil {
@@ -291,13 +297,13 @@ func TestTransportRun_GracefulShutdown(t *testing.T) {
 		runErrCh <- tr.Run(ctx)
 	}()
 
-	// Wait until the transport has actually attempted a send (and hit the 503
-	// retry path) before cancelling, so the shutdown-mid-retry path is
-	// exercised deterministically instead of via a timing guess.
-	testwait.For(t, time.Second, func() bool {
-		return attempts.Load() >= 1
-	}, "transport to attempt at least one send before cancel")
+	select {
+	case <-attempted:
+	case <-time.After(time.Second):
+		t.Fatal("transport did not attempt send within 1s")
+	}
 	cancel()
+	close(releaseHandler)
 
 	select {
 	case err := <-runErrCh:
@@ -320,6 +326,22 @@ func TestTransportRun_GracefulShutdown(t *testing.T) {
 	}
 	if stats.Dead != 0 {
 		t.Fatalf("dead=%d, want 0 (5xx is retry, not dead-letter)", stats.Dead)
+	}
+	var recordPath string
+	switch {
+	case stats.Pending == 1:
+		recordPath = filepath.Join(q.pendingDir, id)
+	case stats.Inflight == 1:
+		recordPath = filepath.Join(q.inflightDir, id)
+	default:
+		t.Fatalf("stats=%+v, want one pending or inflight record", stats)
+	}
+	record, err := readRecord(recordPath, q.maxPayloadBytes)
+	if err != nil {
+		t.Fatalf("readRecord(%s) error = %v", recordPath, err)
+	}
+	if record.RetryCount != 0 {
+		t.Fatalf("retry_count after cancellation = %d, want 0", record.RetryCount)
 	}
 }
 

--- a/enterprise/conductor/auditbatcher/transport_test.go
+++ b/enterprise/conductor/auditbatcher/transport_test.go
@@ -274,6 +274,9 @@ func TestTransportRun_GracefulShutdown(t *testing.T) {
 		Queue:      q,
 		RetryDelay: 10 * time.Millisecond,
 		EmptyDelay: 10 * time.Millisecond,
+		// High ceiling so the retry-loop-until-cancel path is exercised without
+		// the dead-letter escalation firing - this test asserts Dead == 0.
+		MaxDeliveryAttempts: 1_000_000,
 	})
 	if err != nil {
 		t.Fatalf("NewTransport() error = %v", err)
@@ -317,6 +320,140 @@ func TestTransportRun_GracefulShutdown(t *testing.T) {
 	}
 	if stats.Dead != 0 {
 		t.Fatalf("dead=%d, want 0 (5xx is retry, not dead-letter)", stats.Dead)
+	}
+}
+
+// TestTransportDeliverOnceDropsAfterMaxAttempts proves the dead-letter ceiling:
+// a permanently-5xx (poison) batch must not be re-released for retry forever.
+// Once the configured max-delivery-attempts ceiling is reached, the record is
+// escalated to the dead-letter directory (reason max_retries) so the FIFO head
+// unblocks and a good batch behind it can be delivered.
+func TestTransportDeliverOnceDropsAfterMaxAttempts(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	q := openTestQueue(t, Config{})
+	poisonID, err := q.Enqueue(signedTestBatch(t, "batch-poison", priv))
+	if err != nil {
+		t.Fatalf("Enqueue(poison) error = %v", err)
+	}
+	if _, err := q.Enqueue(signedTestBatch(t, "batch-good", priv)); err != nil {
+		t.Fatalf("Enqueue(good) error = %v", err)
+	}
+
+	const maxAttempts = 3
+	var poisonStatus int32 = http.StatusInternalServerError
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var upload batchUpload
+		if err := json.NewDecoder(r.Body).Decode(&upload); err != nil {
+			t.Fatalf("Decode(upload) error = %v", err)
+		}
+		if upload.Envelope.BatchID == "batch-poison" {
+			w.WriteHeader(int(atomic.LoadInt32(&poisonStatus)))
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	metrics := &transportMetricsRecorder{}
+	tr, err := NewTransport(TransportConfig{
+		BaseURL:             srv.URL,
+		Client:              srv.Client(),
+		Queue:               q,
+		Metrics:             metrics,
+		MaxDeliveryAttempts: maxAttempts,
+	})
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+
+	// First maxAttempts-1 deliveries release the poison for retry (it stays the
+	// FIFO head); the maxAttempts-th delivery exhausts the ceiling and drops it.
+	for i := 0; i < maxAttempts; i++ {
+		if err := tr.DeliverOnce(t.Context()); err == nil {
+			t.Fatalf("DeliverOnce() attempt %d error = nil, want retry/drop error", i+1)
+		}
+	}
+
+	// Poison must now be dead-lettered with reason max_retries.
+	assertStats(t, q, Stats{Pending: 1, Dead: 1})
+	deadRecord, err := readRecord(filepath.Join(q.deadDir, poisonID), q.maxPayloadBytes)
+	if err != nil {
+		t.Fatalf("readRecord(dead) error = %v", err)
+	}
+	if deadRecord.DroppedReason != dropReasonMaxRetries {
+		t.Fatalf("DroppedReason = %q, want %q", deadRecord.DroppedReason, dropReasonMaxRetries)
+	}
+	if got := metrics.delivery["drop:"+dropReasonMaxRetries]; got != 1 {
+		t.Fatalf("drop:max_retries metric = %d, want 1", got)
+	}
+
+	// The good batch behind the poison must now deliver (head unblocked).
+	if err := tr.DeliverOnce(t.Context()); err != nil {
+		t.Fatalf("DeliverOnce(good) error = %v", err)
+	}
+	assertStats(t, q, Stats{Dead: 1})
+	if got := metrics.delivery["success:success"]; got != 1 {
+		t.Fatalf("success metric = %d, want 1", got)
+	}
+}
+
+// TestTransportDeliverOnceTransientRecoversBeforeCeiling proves no premature
+// drop: a batch that fails transiently and then recovers BEFORE the ceiling is
+// delivered successfully and never reaches the dead-letter directory.
+func TestTransportDeliverOnceTransientRecoversBeforeCeiling(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	q := openTestQueue(t, Config{})
+	if _, err := q.Enqueue(signedTestBatch(t, "batch-transient", priv)); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+
+	const maxAttempts = 5
+	var attempts int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Fail the first maxAttempts-1 attempts, then succeed exactly at the
+		// last permitted attempt - the boundary that must NOT drop.
+		if atomic.AddInt32(&attempts, 1) < maxAttempts {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	metrics := &transportMetricsRecorder{}
+	tr, err := NewTransport(TransportConfig{
+		BaseURL:             srv.URL,
+		Client:              srv.Client(),
+		Queue:               q,
+		Metrics:             metrics,
+		MaxDeliveryAttempts: maxAttempts,
+	})
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+
+	for i := 0; i < maxAttempts-1; i++ {
+		if err := tr.DeliverOnce(t.Context()); err == nil {
+			t.Fatalf("DeliverOnce() attempt %d error = nil, want retry error", i+1)
+		}
+		// Must stay pending for retry, never dead-lettered before the ceiling.
+		assertStats(t, q, Stats{Pending: 1})
+	}
+	if err := tr.DeliverOnce(t.Context()); err != nil {
+		t.Fatalf("DeliverOnce(recover) error = %v", err)
+	}
+	assertStats(t, q, Stats{})
+	if got := metrics.delivery["drop:"+dropReasonMaxRetries]; got != 0 {
+		t.Fatalf("drop:max_retries metric = %d, want 0 (no premature drop)", got)
+	}
+	if got := metrics.delivery["success:success"]; got != 1 {
+		t.Fatalf("success metric = %d, want 1", got)
 	}
 }
 

--- a/enterprise/conductor/auditbatcher/transport_test.go
+++ b/enterprise/conductor/auditbatcher/transport_test.go
@@ -457,6 +457,57 @@ func TestTransportDeliverOnceTransientRecoversBeforeCeiling(t *testing.T) {
 	}
 }
 
+func TestTransportDeliverOnceDropsCorruptMaxRetryCountWithoutOverflow(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	q := openTestQueue(t, Config{})
+	id, err := q.Enqueue(signedTestBatch(t, "batch-max-retry-corrupt", priv))
+	if err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	path := filepath.Join(q.pendingDir, id)
+	record, err := readRecord(path, q.maxPayloadBytes)
+	if err != nil {
+		t.Fatalf("readRecord() error = %v", err)
+	}
+	record.RetryCount = ^uint64(0)
+	data, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("Marshal(record) error = %v", err)
+	}
+	if err := durableWrite(path, data); err != nil {
+		t.Fatalf("durableWrite(record) error = %v", err)
+	}
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	tr, err := NewTransport(TransportConfig{
+		BaseURL:             srv.URL,
+		Client:              srv.Client(),
+		Queue:               q,
+		MaxDeliveryAttempts: 10,
+	})
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+	if err := tr.DeliverOnce(t.Context()); err == nil {
+		t.Fatal("DeliverOnce() error = nil, want drop error")
+	}
+	assertStats(t, q, Stats{Dead: 1})
+	deadRecord, err := readRecord(filepath.Join(q.deadDir, id), q.maxPayloadBytes)
+	if err != nil {
+		t.Fatalf("readRecord(dead) error = %v", err)
+	}
+	if deadRecord.DroppedReason != dropReasonMaxRetries {
+		t.Fatalf("DroppedReason = %q, want %q", deadRecord.DroppedReason, dropReasonMaxRetries)
+	}
+}
+
 func TestTransportRunRejectsNilContext(t *testing.T) {
 	q := openTestQueue(t, Config{})
 	tr, err := NewTransport(TransportConfig{BaseURL: "https://conductor.example", Client: http.DefaultClient, Queue: q})

--- a/enterprise/conductor/bootstrap/roundtrip.go
+++ b/enterprise/conductor/bootstrap/roundtrip.go
@@ -305,6 +305,10 @@ func produceSignedBatch(ctx context.Context, queueDir, recorderDir string, opts 
 	if err != nil {
 		return auditbatcher.Batch{}, fmt.Errorf("open audit queue: %w", err)
 	}
+	// Release the queue's single-writer lock when the bootstrap proof completes,
+	// so a repeated bootstrap (same process, same queue dir) does not fail with
+	// ErrQueueLocked.
+	defer func() { _ = queue.Close() }()
 	producer, err := auditbatcher.NewProducer(auditbatcher.ProducerConfig{
 		Queue:             queue,
 		OrgID:             identity.OrgID,

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -848,7 +848,19 @@ func writeStoreError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, err)
 	case errors.Is(err, conductor.ErrPayloadTooLarge):
 		writeError(w, http.StatusRequestEntityTooLarge, err)
-	case errors.Is(err, conductor.ErrExpired):
+	case errors.Is(err, conductor.ErrUnsupportedSchemaVersion), errors.Is(err, conductor.ErrInvalidHash),
+		errors.Is(err, conductor.ErrInvalidSequenceRange), errors.Is(err, conductor.ErrInvalidDroppedAccounting),
+		errors.Is(err, conductor.ErrInvalidMinVersion):
+		// Client-input validation sentinels for a malformed-but-well-formed
+		// bundle structure. PolicyBundle.Validate produces these on publish;
+		// they are caller faults, not internal errors. Mirrors the
+		// audit-ingest path (writeAuditIngestError) which maps the same
+		// structural sentinels to 400.
+		writeError(w, http.StatusBadRequest, err)
+	case errors.Is(err, conductor.ErrExpired), errors.Is(err, conductor.ErrHashMismatch):
+		// Semantically invalid but well-formed: an expired window or a hash
+		// that does not match the supplied payload. Mirrors the audit-ingest
+		// path which maps ErrHashMismatch to 422.
 		writeError(w, http.StatusUnprocessableEntity, err)
 	case errors.Is(err, conductor.ErrInvalidRollback), errors.Is(err, conductor.ErrInvalidState),
 		errors.Is(err, conductor.ErrInvalidAudience), errors.Is(err, conductor.ErrMissingField),

--- a/enterprise/conductor/controlplane/handler_errors_test.go
+++ b/enterprise/conductor/controlplane/handler_errors_test.go
@@ -146,6 +146,102 @@ func TestHandlerMapsStoreErrors(t *testing.T) {
 	}
 }
 
+func TestHandlerValidationSentinelsReachRealPublishHandlers(t *testing.T) {
+	signer := newTestSigner(t)
+	for _, tc := range []struct {
+		name   string
+		mutate func(*conductor.PolicyBundle)
+		code   int
+		body   string
+	}{
+		{
+			name:   "unsupported_schema_version",
+			mutate: func(b *conductor.PolicyBundle) { b.SchemaVersion = 99 },
+			code:   http.StatusBadRequest,
+			body:   conductor.ErrUnsupportedSchemaVersion.Error(),
+		},
+		{
+			name:   "invalid_hash",
+			mutate: func(b *conductor.PolicyBundle) { b.PayloadSHA256 = "not-hex" },
+			code:   http.StatusBadRequest,
+			body:   conductor.ErrInvalidHash.Error(),
+		},
+		{
+			name:   "invalid_min_version",
+			mutate: func(b *conductor.PolicyBundle) { b.MinPipelockVersion = "01.2.3" },
+			code:   http.StatusBadRequest,
+			body:   conductor.ErrInvalidMinVersion.Error(),
+		},
+		{
+			name: "hash_mismatch",
+			mutate: func(b *conductor.PolicyBundle) {
+				b.Payload.ConfigYAML = "mode: balanced\napi_allowlist:\n  - api.example.com\n"
+			},
+			code: http.StatusUnprocessableEntity,
+			body: conductor.ErrHashMismatch.Error(),
+		},
+	} {
+		t.Run("policy_"+tc.name, func(t *testing.T) {
+			bundle := signedControlBundle(t, signer, bundleSpec{
+				id:       "bundle-" + strings.ReplaceAll(tc.name, "_", "-"),
+				version:  1,
+				audience: conductor.Audience{InstanceIDs: []string{"pl-prod-1"}},
+			})
+			tc.mutate(&bundle)
+			data, err := json.Marshal(publishPolicyBundleRequest{Bundle: bundle})
+			if err != nil {
+				t.Fatalf("Marshal(bundle) error = %v", err)
+			}
+			handler := newTestHandler(t, mustStore(t), nil)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, PublishPolicyBundlePath, bytes.NewReader(data))
+			req.Header.Set("X-Pipelock-Publisher", "ok")
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code != tc.code {
+				t.Fatalf("status = %d body=%s, want %d", w.Code, w.Body.String(), tc.code)
+			}
+			if !strings.Contains(w.Body.String(), tc.body) {
+				t.Fatalf("body = %s, want %q", w.Body.String(), tc.body)
+			}
+		})
+	}
+
+	pub, priv := testAuditSigner(t)
+	for _, tc := range []struct {
+		name   string
+		mutate func(*ingestAuditBatchRequest)
+		body   string
+	}{
+		{
+			name: "invalid_sequence_range",
+			mutate: func(req *ingestAuditBatchRequest) {
+				req.Envelope.SeqEnd = req.Envelope.SeqStart - 1
+			},
+			body: conductor.ErrInvalidSequenceRange.Error(),
+		},
+		{
+			name: "invalid_dropped_accounting",
+			mutate: func(req *ingestAuditBatchRequest) {
+				req.Envelope.Dropped = conductor.DroppedAccounting{Count: 1}
+			},
+			body: conductor.ErrInvalidDroppedAccounting.Error(),
+		},
+	} {
+		t.Run("audit_"+tc.name, func(t *testing.T) {
+			req := signedAuditIngestRequest(t, defaultFollowerIdentity(), []byte(`{"entry":"ok"}`), priv, testNow)
+			tc.mutate(&req)
+			handler := newAuditIngestTestHandler(t, &captureAuditSink{}, auditKeyResolverFor(pub), 0)
+			w := postAuditBatch(t, handler, req)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d body=%s, want 400", w.Code, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), tc.body) {
+				t.Fatalf("body = %s, want %q", w.Body.String(), tc.body)
+			}
+		})
+	}
+}
+
 func TestHandlerLatestNoBundleAndStoreError(t *testing.T) {
 	handler := newTestHandler(t, fakeStore{latestErr: ErrBundleNotFound}, nil)
 	w := httptest.NewRecorder()

--- a/enterprise/conductor/controlplane/handler_errors_test.go
+++ b/enterprise/conductor/controlplane/handler_errors_test.go
@@ -116,6 +116,15 @@ func TestHandlerMapsStoreErrors(t *testing.T) {
 		{name: "rollback", err: ErrUnsupportedRollback, code: http.StatusConflict},
 		{name: "too-large", err: conductor.ErrPayloadTooLarge, code: http.StatusRequestEntityTooLarge},
 		{name: "expired", err: conductor.ErrExpired, code: http.StatusUnprocessableEntity},
+		// Client-input validation sentinels produced by PolicyBundle.Validate
+		// must map to 4xx, never fall through to 500. Mirrors the audit-ingest
+		// path's choices: malformed structure -> 400, hash mismatch -> 422.
+		{name: "schema-version", err: conductor.ErrUnsupportedSchemaVersion, code: http.StatusBadRequest, body: conductor.ErrUnsupportedSchemaVersion.Error()},
+		{name: "invalid-hash", err: conductor.ErrInvalidHash, code: http.StatusBadRequest, body: conductor.ErrInvalidHash.Error()},
+		{name: "invalid-sequence-range", err: conductor.ErrInvalidSequenceRange, code: http.StatusBadRequest, body: conductor.ErrInvalidSequenceRange.Error()},
+		{name: "invalid-dropped-accounting", err: conductor.ErrInvalidDroppedAccounting, code: http.StatusBadRequest, body: conductor.ErrInvalidDroppedAccounting.Error()},
+		{name: "invalid-min-version", err: conductor.ErrInvalidMinVersion, code: http.StatusBadRequest, body: conductor.ErrInvalidMinVersion.Error()},
+		{name: "hash-mismatch", err: conductor.ErrHashMismatch, code: http.StatusUnprocessableEntity, body: conductor.ErrHashMismatch.Error()},
 		{name: "internal", err: internalErr, code: http.StatusInternalServerError, body: "internal server error"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -135,6 +135,12 @@ func buildConductorAuditTransport(cfg *config.Config, m *metrics.Metrics) (*audi
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening conductor audit queue: %w", err)
 	}
+	opened := false
+	defer func() {
+		if !opened {
+			_ = q.Close()
+		}
+	}()
 	stats, err := q.Stats()
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading conductor audit queue stats: %w", err)
@@ -156,6 +162,7 @@ func buildConductorAuditTransport(cfg *config.Config, m *metrics.Metrics) (*audi
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating conductor audit transport: %w", err)
 	}
+	opened = true
 	return q, tr, nil
 }
 

--- a/internal/cli/runtime/conductor_lifecycle.go
+++ b/internal/cli/runtime/conductor_lifecycle.go
@@ -57,15 +57,25 @@ func (s *Server) setConductorCancel(cancel context.CancelFunc) {
 	}
 }
 
+func (s *Server) setConductorWait(wait func()) {
+	if s == nil {
+		return
+	}
+	s.conductorLifeMu.Lock()
+	s.conductorWait = wait
+	s.conductorLifeMu.Unlock()
+}
+
 // teardownConductor fail-closes the follower-side Conductor runtime when its
 // fleet entitlement is revoked, expires, or is downgraded at runtime. It cancels
-// the poller goroutines, detaches the durable-audit observer, and closes the
-// audit producer. The proxy/detection path is deliberately left running: losing
-// a paid fleet entitlement must never take down free detection (the product rule
-// is "sell coordination, not detection"). Idempotent and safe to call
-// concurrently from the runtime CRL watcher, the expiry timer, and the config
-// reload path. Conductor stays down until process restart, matching the
-// restart-only conductor invariant.
+// the poller goroutines, detaches the durable-audit observer, closes the audit
+// producer, waits for the pollers to stop, then releases the audit queue lock.
+// The proxy/detection path is deliberately left running: losing a paid fleet
+// entitlement must never take down free detection (the product rule is "sell
+// coordination, not detection"). Idempotent and safe to call concurrently from
+// the runtime CRL watcher, the expiry timer, and the config reload path.
+// Conductor stays down until process restart, matching the restart-only
+// conductor invariant.
 func (s *Server) teardownConductor(reason string) {
 	if s == nil {
 		return
@@ -81,6 +91,8 @@ func (s *Server) teardownConductor(reason string) {
 	}
 	s.conductorDown.Store(true)
 	cancel := s.conductorCancel
+	wait := s.conductorWait
+	s.conductorWait = nil
 	// Take ownership of the producer under the lock and clear the field so it is
 	// closed exactly once and never reused after teardown. conductorDown is
 	// already set, so a racing teardown bails at the guard above and a later
@@ -111,8 +123,15 @@ func (s *Server) teardownConductor(reason string) {
 	if producer != nil {
 		_ = producer.Close()
 	}
-	// Release the durable audit queue's single-writer lock after the producer
-	// stops writing to it.
+	// The audit transport owns Claim/Ack/Release/Drop. Wait for it to observe the
+	// cancelled conductor context before releasing the queue lock, otherwise a
+	// replacement process could Open the same dir while this process still has a
+	// leased record in flight.
+	if wait != nil {
+		wait()
+	}
+	// Release the durable audit queue's single-writer lock after producers and
+	// transports have stopped touching it.
 	if closer, ok := auditQueue.(interface{ Close() error }); ok && closer != nil {
 		_ = closer.Close()
 	}

--- a/internal/cli/runtime/conductor_lifecycle.go
+++ b/internal/cli/runtime/conductor_lifecycle.go
@@ -87,6 +87,13 @@ func (s *Server) teardownConductor(reason string) {
 	// hasConductorRuntime() check never sees the closed handle.
 	producer := s.conductorProducer
 	s.conductorProducer = nil
+	// Take ownership of the audit queue too so its single-writer lock is
+	// released on teardown (and only once). On the Apache-only core build the
+	// field is always nil; on enterprise it holds an *auditbatcher.Queue, which
+	// satisfies io.Closer. Asserting the interface keeps this untagged file free
+	// of an enterprise import.
+	auditQueue := s.conductorAuditQueue
+	s.conductorAuditQueue = nil
 	s.conductorLifeMu.Unlock()
 
 	// Stop the follower pollers. Their Run loops return context.Canceled, which
@@ -103,6 +110,11 @@ func (s *Server) teardownConductor(reason string) {
 	}
 	if producer != nil {
 		_ = producer.Close()
+	}
+	// Release the durable audit queue's single-writer lock after the producer
+	// stops writing to it.
+	if closer, ok := auditQueue.(interface{ Close() error }); ok && closer != nil {
+		_ = closer.Close()
 	}
 	if s.opts.Stderr != nil {
 		_, _ = fmt.Fprintf(s.opts.Stderr,

--- a/internal/cli/runtime/conductor_lifecycle.go
+++ b/internal/cli/runtime/conductor_lifecycle.go
@@ -132,12 +132,16 @@ func (s *Server) teardownConductor(reason string) {
 	}
 	// Release the durable audit queue's single-writer lock after producers and
 	// transports have stopped touching it.
-	if closer, ok := auditQueue.(interface{ Close() error }); ok && closer != nil {
-		_ = closer.Close()
-	}
+	closeConductorAuditQueue(auditQueue)
 	if s.opts.Stderr != nil {
 		_, _ = fmt.Fprintf(s.opts.Stderr,
 			"pipelock: fleet license %s; Conductor runtime stopped, detection continues\n", reason)
+	}
+}
+
+func closeConductorAuditQueue(auditQueue any) {
+	if closer, ok := auditQueue.(interface{ Close() error }); ok && closer != nil {
+		_ = closer.Close()
 	}
 }
 

--- a/internal/cli/runtime/conductor_teardown_test.go
+++ b/internal/cli/runtime/conductor_teardown_test.go
@@ -35,6 +35,20 @@ func (c *countingCloser) Close() error {
 	return nil
 }
 
+type orderedQueueCloser struct {
+	closes           atomic.Int32
+	waitDone         *atomic.Bool
+	closedBeforeWait atomic.Bool
+}
+
+func (c *orderedQueueCloser) Close() error {
+	c.closes.Add(1)
+	if c.waitDone != nil && !c.waitDone.Load() {
+		c.closedBeforeWait.Store(true)
+	}
+	return nil
+}
+
 // TestTeardownConductor_StopsRuntimeAndIsIdempotent locks in the core teardown
 // contract: cancel the poller sub-context, close the audit producer, flip the
 // conductorDown gate, and do all of it exactly once even under repeated calls
@@ -67,6 +81,47 @@ func TestTeardownConductor_StopsRuntimeAndIsIdempotent(t *testing.T) {
 	s.teardownConductor("test revoke again")
 	if got := closer.closes.Load(); got != 1 {
 		t.Fatalf("producer Close count after 2nd teardown = %d, want 1", got)
+	}
+}
+
+func TestTeardownConductor_WaitsBeforeClosingAuditQueue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var waitDone atomic.Bool
+	queue := &orderedQueueCloser{waitDone: &waitDone}
+	s := &Server{conductorAuditQueue: queue}
+	s.setConductorCancel(cancel)
+	s.setConductorWait(func() {
+		if ctx.Err() == nil {
+			t.Fatal("conductor wait ran before teardown cancelled the context")
+		}
+		waitDone.Store(true)
+	})
+
+	s.teardownConductor("test revoke")
+
+	if !waitDone.Load() {
+		t.Fatal("teardown must wait for conductor goroutines before closing the queue")
+	}
+	if got := queue.closes.Load(); got != 1 {
+		t.Fatalf("queue Close count = %d, want 1", got)
+	}
+	if queue.closedBeforeWait.Load() {
+		t.Fatal("queue lock was released before conductor goroutines stopped")
+	}
+}
+
+func TestCleanupClosesConductorAuditQueue(t *testing.T) {
+	queue := &countingCloser{}
+	s := &Server{conductorAuditQueue: queue}
+
+	s.cleanup()
+	s.cleanup()
+
+	if got := queue.closes.Load(); got != 1 {
+		t.Fatalf("queue Close count = %d, want 1", got)
+	}
+	if s.conductorAuditQueue != nil {
+		t.Fatalf("conductorAuditQueue = %T, want nil after cleanup", s.conductorAuditQueue)
 	}
 }
 

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/applycache"
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/auditbatcher"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
@@ -335,6 +336,32 @@ func TestBuildConductorBundlePollerRejectsBadRosterEvenWithHonorFalse(t *testing
 	if !strings.Contains(err.Error(), "trust resolver") && !strings.Contains(err.Error(), "trust roster") {
 		t.Fatalf("error = %v, want trust roster/resolver failure", err)
 	}
+}
+
+func TestBuildConductorAuditTransportReleasesQueueOnConstructorFailure(t *testing.T) {
+	dir := t.TempDir()
+	queueDir := filepath.Join(dir, "audit-queue")
+	caPath := filepath.Join(dir, "boss-ca.pem")
+	writePrivateTestFile(t, caPath, []byte("not a PEM bundle"))
+
+	cfg := &config.Config{
+		Conductor: config.Conductor{
+			Enabled:              true,
+			ConductorURL:         "https://conductor.example",
+			ServerCAFile:         caPath,
+			ClientCertPath:       filepath.Join(dir, "missing-client.crt"),
+			ClientKeyPath:        filepath.Join(dir, "missing-client.key"),
+			DurableAuditQueueDir: queueDir,
+		},
+	}
+	if _, _, err := buildConductorAuditTransport(cfg, nil); err == nil {
+		t.Fatal("buildConductorAuditTransport() error = nil, want mTLS constructor failure")
+	}
+	reopened, err := auditbatcher.Open(auditbatcher.Config{Dir: queueDir})
+	if err != nil {
+		t.Fatalf("Open(queue after failed build) error = %v, want lock released", err)
+	}
+	defer func() { _ = reopened.Close() }()
 }
 
 // TestBuildConductorBundlePollerDisabled confirms the poller is a no-op (nil,

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -116,11 +116,13 @@ type Server struct {
 	conductorBundle     conductorRunner
 	conductorProducer   conductorCloser
 
-	// conductorLifeMu guards conductorCancel. teardownConductor may be
-	// invoked concurrently from the runtime CRL watcher and the config
-	// reload path, so the cancel func is published and read under the lock.
+	// conductorLifeMu guards conductorCancel and conductorWait.
+	// teardownConductor may be invoked concurrently from the runtime CRL watcher
+	// and the config reload path, so lifecycle handles are published and read
+	// under the lock.
 	conductorLifeMu sync.Mutex
 	conductorCancel context.CancelFunc
+	conductorWait   func()
 	// conductorDown is set by teardownConductor when a runtime fleet-license
 	// revocation, expiry, or downgrade stops the follower-side Conductor
 	// runtime. It gates ApplyConductorPolicyBundle (no further policy bundles

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -262,10 +262,19 @@ func (s *Server) Start(ctx context.Context) error {
 		var conductorCancel context.CancelFunc
 		conductorCtx, conductorCancel = context.WithCancel(ctx)
 		s.setConductorCancel(conductorCancel)
+		if s.conductorRemoteKill != nil {
+			conductorWG.Add(1)
+		}
+		if s.conductorAudit != nil {
+			conductorWG.Add(1)
+		}
+		if s.conductorBundle != nil {
+			conductorWG.Add(1)
+		}
+		s.setConductorWait(conductorWG.Wait)
 	}
 	if s.conductorAudit != nil || s.conductorRemoteKill != nil || s.conductorBundle != nil {
 		if s.conductorRemoteKill != nil {
-			conductorWG.Add(1)
 			go func() {
 				defer conductorWG.Done()
 				defer func() {
@@ -283,7 +292,6 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}
 	if s.conductorAudit != nil {
-		conductorWG.Add(1)
 		go func() {
 			defer conductorWG.Done()
 			defer func() {
@@ -298,7 +306,6 @@ func (s *Server) Start(ctx context.Context) error {
 		}()
 	}
 	if s.conductorBundle != nil {
-		conductorWG.Add(1)
 		go func() {
 			defer conductorWG.Done()
 			defer func() {

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -374,6 +374,10 @@ func (s *Server) cleanup() {
 		_ = s.conductorProducer.Close()
 		s.conductorProducer = nil
 	}
+	if closer, ok := s.conductorAuditQueue.(interface{ Close() error }); ok && closer != nil {
+		_ = closer.Close()
+		s.conductorAuditQueue = nil
+	}
 	if s.captureWriter != nil {
 		_ = s.captureWriter.Close()
 		s.captureWriter = nil

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -374,10 +374,8 @@ func (s *Server) cleanup() {
 		_ = s.conductorProducer.Close()
 		s.conductorProducer = nil
 	}
-	if closer, ok := s.conductorAuditQueue.(interface{ Close() error }); ok && closer != nil {
-		_ = closer.Close()
-		s.conductorAuditQueue = nil
-	}
+	closeConductorAuditQueue(s.conductorAuditQueue)
+	s.conductorAuditQueue = nil
 	if s.captureWriter != nil {
 		_ = s.captureWriter.Close()
 		s.captureWriter = nil


### PR DESCRIPTION
## Summary

- Add an audit delivery attempt ceiling so permanently retryable batches move to dead letter instead of starving the FIFO head
- Scope audit queue locking to local host/filesystem guarantees and document shared PVC deployment requirements
- Harden queue lifecycle cleanup, teardown ordering, closed-queue behavior, and retry-count overflow handling
- Map conductor store validation errors to the intended 4xx statuses and cover real handler paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exclusive single-writer locking for audit queues.
  * Configurable per-batch delivery-attempt ceiling with dead-lettering for exhausted retries.
  * Explicit queue close/release behavior to free locked queues after use.

* **Bug Fixes**
  * Better error-to-HTTP-status mappings for validation failures.
  * Fixed resource-release issues during failed startup and shutdown; teardown now waits for conductor shutdown before closing queues.

* **Documentation**
  * Clarified single-writer queue semantics and recommended storage/leader-election patterns for multi-replica setups.

* **Tests**
  * Expanded tests for locking, lifecycle, retry/drop, and shutdown behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->