### PR TITLE
Fix receipt-chain rotation and operator evidence ACLs

### DIFF
--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -182,7 +182,21 @@ func migrateFlightRecorderSigningKey(ctx *configMigrationContext, root *yaml.Nod
 		if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("migrate %s: %w", field, err)
 		}
-		if err := ensureFlightRecorderSigningKey(ctx, dest); err != nil {
+		// The configured source key was not found at the resolved migratable
+		// path. Do NOT immediately generate a fresh key: regenerating churns
+		// the flight-recorder signing key, which orphans any existing receipt
+		// chain (the prior chain stays sealed under the old key and live
+		// emission opens a new segment). Prefer preserving the operator's
+		// existing key. ensureFlightRecorderSigningKeyWithRecovery reuses a
+		// valid key already at dest (e.g. from a prior install), else recovers
+		// the configured key resolved directly (recoverSrc) when it exists and
+		// is a valid key, and only generates fresh when there is genuinely no
+		// pre-existing key anywhere. recoverSrc is the original configured path
+		// resolved without the migratable-root restriction, so an operator key
+		// that lives outside the migratable root is still recovered rather than
+		// replaced.
+		recoverSrc := ctx.resolveExistingKeyPath(n.Value)
+		if err := ensureFlightRecorderSigningKeyWithRecovery(ctx, dest, recoverSrc); err != nil {
 			return fmt.Errorf("migrate %s: %w", field, err)
 		}
 	} else if _, err := signing.LoadPrivateKeyFile(dest); err != nil {
@@ -192,7 +206,24 @@ func migrateFlightRecorderSigningKey(ctx *configMigrationContext, root *yaml.Nod
 	return nil
 }
 
+// ensureFlightRecorderSigningKey makes dest hold a usable flight-recorder
+// signing key without needlessly rotating it. Preference order, to preserve any
+// existing receipt chain:
+//
+//  1. A valid key already at dest is reused as-is (re-permed only).
+//  2. recoverSrc, when non-empty and pointing at a valid existing key, is
+//     copied to dest. This recovers the operator's prior key when the migration
+//     source resolved to a different path than where the key actually lives.
+//  3. Only when neither exists is a fresh key generated.
+//
+// Generating a fresh key changes signer_key, which orphans the existing
+// chain; the live v1 emitter then opens a new chain segment rather than
+// resuming. So a fresh key is the last resort, not the default.
 func ensureFlightRecorderSigningKey(ctx *configMigrationContext, dest string) error {
+	return ensureFlightRecorderSigningKeyWithRecovery(ctx, dest, "")
+}
+
+func ensureFlightRecorderSigningKeyWithRecovery(ctx *configMigrationContext, dest, recoverSrc string) error {
 	if info, err := ctx.env.lstat(dest); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("existing target %s is a symlink; refusing to use as signing key", dest)
@@ -211,6 +242,17 @@ func ensureFlightRecorderSigningKey(ctx *configMigrationContext, dest string) er
 		return fmt.Errorf("stat existing target %s: %w", dest, err)
 	}
 
+	// No key at dest. Try to recover the operator's existing key before
+	// generating a new one, so re-running install does not churn the signing
+	// key and orphan the chain.
+	if recoverSrc != "" && recoverSrc != dest {
+		if recovered, err := recoverExistingSigningKey(ctx, recoverSrc, dest); err != nil {
+			return err
+		} else if recovered {
+			return nil
+		}
+	}
+
 	if err := ensureMigratedDir(ctx, filepath.Dir(dest), migrationDirMode(ctx.env, filepath.Dir(dest))); err != nil {
 		return err
 	}
@@ -224,6 +266,42 @@ func ensureFlightRecorderSigningKey(ctx *configMigrationContext, dest string) er
 		ctx.artifacts = append(ctx.artifacts, migratedConfigArtifact{path: dest})
 	}
 	return nil
+}
+
+// recoverExistingSigningKey copies a pre-existing valid signing key from src to
+// dest when src is a regular, non-symlink file holding a parseable key. It
+// reports (true, nil) on a successful recovery, (false, nil) when src is absent
+// or not a usable key (caller falls back to fresh generation), and a non-nil
+// error only for hard failures (bad symlink, write error). Recovering rather
+// than regenerating keeps the receipt chain's signer_key stable.
+func recoverExistingSigningKey(ctx *configMigrationContext, src, dest string) (bool, error) {
+	info, err := ctx.env.lstat(src)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat recovery source %s: %w", src, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return false, fmt.Errorf("recovery source %s is a symlink; refusing to copy as root", src)
+	}
+	if !info.Mode().IsRegular() {
+		// Not a regular file (directory, device, ...). Not recoverable; let
+		// the caller generate a fresh key.
+		return false, nil
+	}
+	// Validate it is a real signing key before adopting it. A non-key file at
+	// the old path must not be copied in and then fail to load at runtime.
+	if _, err := signing.LoadPrivateKeyFile(src); err != nil {
+		return false, nil
+	}
+	if err := copyConfigFile(ctx, src, dest, modePinSecret); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("recover signing key from %s: %w", src, err)
+	}
+	return true, nil
 }
 
 func migrateScalarDir(ctx *configMigrationContext, root *yaml.Node, path []string, dest string) error {
@@ -345,6 +423,36 @@ func migrateRedirectProfiles(ctx *configMigrationContext, root *yaml.Node) {
 			first.Value = ctx.env.pipelockTarget
 		}
 	}
+}
+
+// resolveExistingKeyPath resolves a configured path to a cleaned absolute path
+// for read-only recovery, WITHOUT the migratable-root containment check that
+// resolveMigratablePath enforces. It is used only to locate an operator's
+// pre-existing signing key so it can be copied (preserving signer_key) instead
+// of regenerated. Returns "" when the path cannot be resolved. The caller still
+// validates the file (regular, non-symlink, parseable key) before adopting it.
+func (ctx *configMigrationContext) resolveExistingKeyPath(raw string) string {
+	raw = strings.TrimSpace(strings.Trim(raw, `"`))
+	if raw == "" {
+		return ""
+	}
+	if strings.HasPrefix(raw, "~") {
+		if ctx.operatorHome == "" {
+			return ""
+		}
+		switch {
+		case raw == "~":
+			raw = ctx.operatorHome
+		case strings.HasPrefix(raw, "~/"):
+			raw = filepath.Join(ctx.operatorHome, strings.TrimPrefix(raw, "~/"))
+		default:
+			return ""
+		}
+	}
+	if !filepath.IsAbs(raw) {
+		raw = filepath.Join(ctx.configDir, raw)
+	}
+	return filepath.Clean(raw)
 }
 
 func (ctx *configMigrationContext) resolveMigratablePath(raw string) (string, bool) {

--- a/internal/cli/contain/config_migrate_recover_test.go
+++ b/internal/cli/contain/config_migrate_recover_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// TestEnsureSigningKey_RecoversExistingKeyInsteadOfGenerating proves that when
+// the dedicated dest has no key but the operator's configured key exists
+// elsewhere, the migration COPIES the existing key (preserving signer_key)
+// rather than generating a fresh one that would orphan the receipt chain.
+func TestEnsureSigningKey_RecoversExistingKeyInsteadOfGenerating(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	ctx := &configMigrationContext{env: env}
+
+	recoverSrc := filepath.Join(env.configDir, "old", "operator-signing.key")
+	mustWriteSigningKey(t, recoverSrc)
+	existing, err := signing.LoadPrivateKeyFile(recoverSrc)
+	if err != nil {
+		t.Fatalf("load existing key: %v", err)
+	}
+
+	dest := filepath.Join(env.configDir, "keys", "flight-recorder-signing.key")
+	if err := ensureFlightRecorderSigningKeyWithRecovery(ctx, dest, recoverSrc); err != nil {
+		t.Fatalf("ensure with recovery: %v", err)
+	}
+
+	got, err := signing.LoadPrivateKeyFile(dest)
+	if err != nil {
+		t.Fatalf("load dest key: %v", err)
+	}
+	if !existing.Equal(got) {
+		t.Fatal("dest key does not match recovered key - the chain would be orphaned")
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	if info.Mode().Perm() != modePinSecret {
+		t.Errorf("dest mode = %s, want %s", info.Mode().Perm(), modePinSecret)
+	}
+}
+
+// TestEnsureSigningKey_GeneratesWhenNoExistingKey confirms that when neither
+// dest nor a recoverable source exists, a fresh key IS generated (the legit
+// first-time path).
+func TestEnsureSigningKey_GeneratesWhenNoExistingKey(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	ctx := &configMigrationContext{env: env}
+
+	dest := filepath.Join(env.configDir, "keys", "flight-recorder-signing.key")
+	missing := filepath.Join(env.configDir, "old", "does-not-exist.key")
+	if err := ensureFlightRecorderSigningKeyWithRecovery(ctx, dest, missing); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if _, err := signing.LoadPrivateKeyFile(dest); err != nil {
+		t.Fatalf("generated key invalid: %v", err)
+	}
+	if len(ctx.artifacts) == 0 {
+		t.Fatal("expected a generated-key artifact")
+	}
+}
+
+// TestEnsureSigningKey_DoesNotRecoverNonKeyFile confirms a non-key file at the
+// recovery source is NOT adopted (it would fail to load at runtime); a fresh
+// key is generated instead.
+func TestEnsureSigningKey_DoesNotRecoverNonKeyFile(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	ctx := &configMigrationContext{env: env}
+
+	recoverSrc := filepath.Join(env.configDir, "old", "garbage")
+	mustWriteFile(t, recoverSrc, "not a signing key")
+
+	dest := filepath.Join(env.configDir, "keys", "flight-recorder-signing.key")
+	if err := ensureFlightRecorderSigningKeyWithRecovery(ctx, dest, recoverSrc); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	// A valid (freshly generated) key must be present, NOT the garbage bytes.
+	if _, err := signing.LoadPrivateKeyFile(dest); err != nil {
+		t.Fatalf("dest must hold a valid key after non-key recovery source: %v", err)
+	}
+}
+
+func TestResolveExistingKeyPath_Variants(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "pipelock")
+	ctx := &configMigrationContext{operatorHome: home, configDir: configDir}
+
+	if got := ctx.resolveExistingKeyPath(""); got != "" {
+		t.Errorf("empty -> %q, want \"\"", got)
+	}
+	if got := ctx.resolveExistingKeyPath(`""`); got != "" {
+		t.Errorf("quoted-empty -> %q, want \"\"", got)
+	}
+	if got := ctx.resolveExistingKeyPath("~"); got != filepath.Clean(home) {
+		t.Errorf("~ -> %q, want %q", got, home)
+	}
+	if got := ctx.resolveExistingKeyPath("~/keys/k.key"); got != filepath.Join(home, "keys", "k.key") {
+		t.Errorf("~/keys/k.key -> %q", got)
+	}
+	if got := ctx.resolveExistingKeyPath("~bob/x"); got != "" {
+		t.Errorf("~bob/x -> %q, want \"\" (other-user home unresolved)", got)
+	}
+	if got := ctx.resolveExistingKeyPath("rel/k.key"); got != filepath.Join(configDir, "rel", "k.key") {
+		t.Errorf("relative -> %q, want under configDir", got)
+	}
+	if got := ctx.resolveExistingKeyPath("/abs/k.key"); got != filepath.Clean("/abs/k.key") {
+		t.Errorf("abs -> %q", got)
+	}
+
+	// No operator home: ~ paths are unresolvable.
+	ctx.operatorHome = ""
+	if got := ctx.resolveExistingKeyPath("~/k"); got != "" {
+		t.Errorf("~ with empty home -> %q, want \"\"", got)
+	}
+}
+
+func TestRecoverExistingSigningKey_NonRegularSourceNotRecovered(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	ctx := &configMigrationContext{env: env}
+	srcDir := filepath.Join(env.configDir, "old", "as-dir")
+	if err := os.MkdirAll(srcDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	dest := filepath.Join(env.configDir, "keys", "flight-recorder-signing.key")
+	recovered, err := recoverExistingSigningKey(ctx, srcDir, dest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if recovered {
+		t.Fatal("a directory source must not be recovered")
+	}
+}
+
+// TestMigratePipelockConfigForContain_RecoversExistingKeyAtDest is the realistic
+// re-install case: the dedicated dest already holds the operator's key from a
+// prior install, and the configured source is now missing. Migration must KEEP
+// the existing dest key (stable signer_key), not regenerate.
+func TestMigratePipelockConfigForContain_RecoversExistingKeyAtDest(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	origLookup := env.lookupUser
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return origLookup(name)
+	}
+	configDir := filepath.Join(home, ".config", "pipelock")
+	dest := filepath.Join(env.configDir, "keys", "flight-recorder-signing.key")
+	mustWriteSigningKey(t, dest)
+	before, err := signing.LoadPrivateKeyFile(dest)
+	if err != nil {
+		t.Fatalf("load pre-existing dest key: %v", err)
+	}
+
+	missingKey := filepath.Join(home, ".pipelock", "agents", "official", "id_ed25519")
+	out, _, err := migratePipelockConfigForContain(env, filepath.Join(configDir, "pipelock.yaml"), []byte(`
+flight_recorder:
+  signing_key_path: `+missingKey+`
+`))
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if !strings.Contains(string(out), "signing_key_path: "+dest) {
+		t.Fatalf("config not repointed to dest:\n%s", out)
+	}
+	after, err := signing.LoadPrivateKeyFile(dest)
+	if err != nil {
+		t.Fatalf("load dest key after migrate: %v", err)
+	}
+	if !before.Equal(after) {
+		t.Fatal("dest signing key was regenerated - the receipt chain would orphan")
+	}
+}
+
+// TestRecoverExistingSigningKey_RejectsSymlinkSource confirms a symlinked
+// recovery source is rejected (refusing to copy as root), matching the
+// existing copy-path hardening.
+func TestRecoverExistingSigningKey_RejectsSymlinkSource(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	ctx := &configMigrationContext{env: env}
+
+	realKey := filepath.Join(env.configDir, "old", "real.key")
+	mustWriteSigningKey(t, realKey)
+	link := filepath.Join(env.configDir, "old", "link.key")
+	if err := os.Symlink(realKey, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	dest := filepath.Join(env.configDir, "keys", "flight-recorder-signing.key")
+	recovered, err := recoverExistingSigningKey(ctx, link, dest)
+	if err == nil {
+		t.Fatal("expected symlink recovery source to be rejected")
+	}
+	if recovered {
+		t.Fatal("symlink source must not be reported as recovered")
+	}
+}

--- a/internal/cli/contain/evidence_acl.go
+++ b/internal/cli/contain/evidence_acl.go
@@ -1,0 +1,276 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+)
+
+// Evidence ACL: durable, operator-only read access to pipelock's evidence dirs.
+//
+// The data dir (/var/lib/pipelock) is created 0o750 and chowned to
+// pipelock-proxy, so the human operator can only read the audit log and the
+// signed receipt chain with sudo. That opacity once hid a live receipt-chain
+// bug until it was dug out with sudo. This grants the resolved operator user a
+// minimal POSIX ACL so they can verify the receipt chain offline without sudo.
+//
+// SECURITY: the grant is a USER-scoped ACL for the resolved operator only.
+// It is deliberately NOT a group ACL: the contained agent (pipelock-agent,
+// uid 966) shares the operator's group (agentshare), so a group-read ACL would
+// hand the policed agent pipelock's own detection/block/receipt evidence —
+// evasion intel and a capability-separation break. The parent data dir gets
+// traverse-only (--x), never read, so siblings like captures/ are not broadly
+// exposed. If the operator cannot be resolved, the step fails CLOSED (skips
+// with a logged reason) rather than falling back to a group or world grant.
+
+// evidenceReadPerms is the operator access ACL on the evidence dirs and their
+// files: read + traverse (directory execute). Mirrors workspace ACL "rX".
+const evidenceReadPerms = "rX"
+
+// evidenceTraversePerms grants directory traversal only (no read/list) on the
+// data-dir parent, so the operator can descend into the evidence dirs without
+// gaining read/list of the whole tree (captures/, quarantine/, ...).
+const evidenceTraversePerms = "--x"
+
+// logsDir is the operator-evidence log directory (audit.log lives here).
+func (e *installEnv) logsDir() string {
+	return filepath.Join(e.dataDir, "logs")
+}
+
+// recorderDir is the flight-recorder directory holding the signed receipt
+// chain (flight_recorder.dir default). Mirrors config_migrate.go's default.
+func (e *installEnv) recorderDir() string {
+	return filepath.Join(e.dataDir, "recorder")
+}
+
+// evidenceACLDirs returns the evidence directories that receive an operator
+// read+traverse ACL: the logs dir (audit log) and the recorder dir (receipt
+// chain). Both hold operator evidence the product pitch says operators verify
+// offline with the public key.
+func (e *installEnv) evidenceACLDirs() []string {
+	return []string{e.logsDir(), e.recorderDir()}
+}
+
+// evidenceACLInventory tracks the operator evidence ACL grant so rollback can
+// revoke it (mirrors workspaceInventory). It records the resolved operator user
+// and the dirs that received the grant.
+type evidenceACLInventory struct {
+	Operator string   `json:"operator"`
+	Dirs     []string `json:"dirs"`
+}
+
+// evidenceACLCommands builds the operator-only setfacl plan:
+//   - traverse-only (--x) on the data-dir parent (no read/list),
+//   - recursive read+traverse (rX) access ACL on each evidence dir + its files,
+//   - a default ACL (d:) on each evidence dir (and its existing subdirs) so
+//     rotated logs and newly-written receipt files inherit operator-read.
+//
+// Every entry is u:<operator>: scoped. No group, no other, no agent.
+func evidenceACLCommands(operator, dataDir string, dirs []string) []workspaceCommand {
+	var commands []workspaceCommand
+
+	// Parent: traverse-only. The operator must be able to descend INTO the
+	// evidence dirs, but must not gain read/list of the whole data tree.
+	commands = append(commands, workspaceCommand{
+		name: "setfacl",
+		args: []string{"-m", "u:" + operator + ":" + evidenceTraversePerms, dataDir},
+	})
+
+	for _, dir := range dirs {
+		// Recursive access ACL: read+traverse on the dir and every existing
+		// file/subdir within it (so the current audit.log and receipt files
+		// become readable immediately).
+		commands = append(commands, workspaceCommand{
+			name: "setfacl",
+			args: []string{"-R", "-m", "u:" + operator + ":" + evidenceReadPerms, dir},
+		})
+		// Default ACL on the dir so NEW files (rotated logs, new receipts)
+		// inherit operator-read automatically.
+		commands = append(commands, workspaceCommand{
+			name: "setfacl",
+			args: []string{"-m", "d:u:" + operator + ":" + evidenceReadPerms, dir},
+		})
+		// Default ACL on existing subdirs too, so receipts written into nested
+		// recorder subdirs also inherit operator-read.
+		commands = append(commands, workspaceCommand{
+			name: "find",
+			args: []string{dir, "-mindepth", "1", "-type", "d", "-exec", "setfacl", "-m", "d:u:" + operator + ":" + evidenceReadPerms, "{}", "+"},
+		})
+	}
+	return commands
+}
+
+// evidenceACLRevokeCommands removes the operator ACL from the evidence dirs and
+// the traverse-only grant from the data-dir parent. Best-effort: dirs that no
+// longer exist are simply skipped by the caller.
+func evidenceACLRevokeCommands(operator, dataDir string, dirs []string) []workspaceCommand {
+	var commands []workspaceCommand
+	for _, dir := range dirs {
+		commands = append(commands,
+			workspaceCommand{name: "setfacl", args: []string{"-R", "-x", "u:" + operator, dir}},
+			workspaceCommand{name: "setfacl", args: []string{"-x", "d:u:" + operator, dir}},
+			workspaceCommand{name: "find", args: []string{dir, "-mindepth", "1", "-type", "d", "-exec", "setfacl", "-x", "d:u:" + operator, "{}", "+"}},
+		)
+	}
+	commands = append(commands, workspaceCommand{
+		name: "setfacl",
+		args: []string{"-x", "u:" + operator, dataDir},
+	})
+	return commands
+}
+
+// stepGrantEvidenceACLs is the install step that grants the resolved operator
+// user a durable read+traverse ACL on the evidence dirs. It runs after the data
+// dir is created and chowned to pipelock-proxy. Idempotent: re-running
+// re-asserts the same ACL and rewrites the same inventory.
+func stepGrantEvidenceACLs() step {
+	return step{
+		name: "grant-evidence-acls",
+		desc: "grant operator read+traverse ACL on logs + recorder evidence dirs",
+		apply: func(ctx context.Context, env *installEnv) (bool, error) {
+			operator, ok := resolveEvidenceOperator(env)
+			if !ok {
+				// FAIL CLOSED: never fall back to a group or world grant.
+				return false, nil
+			}
+
+			dirs := env.evidenceACLDirs()
+			// Ensure the evidence dirs exist before applying ACLs. They are
+			// created lazily by the running proxy otherwise, which would leave
+			// the operator without read access until the first write.
+			for _, dir := range dirs {
+				if err := ensureEvidenceDir(env, dir); err != nil {
+					return false, err
+				}
+			}
+
+			commands := evidenceACLCommands(operator, env.dataDir, dirs)
+			if err := runWorkspaceCommands(ctx, env, commands); err != nil {
+				return false, fmt.Errorf("apply operator evidence ACL: %w", err)
+			}
+			if err := writeEvidenceACLInventory(env, evidenceACLInventory{Operator: operator, Dirs: dirs}); err != nil {
+				return false, fmt.Errorf("record evidence ACL inventory: %w", err)
+			}
+			return true, nil
+		},
+		undo: func(ctx context.Context, env *installEnv) error {
+			return revokeEvidenceACLs(ctx, env, false)
+		},
+	}
+}
+
+// resolveEvidenceOperator returns the operator username if it is set AND
+// resolvable to a real account. A clear skip reason is logged when it cannot be
+// resolved; the caller treats !ok as a fail-closed skip (no group/world grant).
+func resolveEvidenceOperator(env *installEnv) (string, bool) {
+	if env.operatorUser == "" {
+		_, _ = fmt.Fprintln(env.out, "  [SKIP] operator evidence ACL: operator user not set (no group/world fallback)")
+		return "", false
+	}
+	if _, err := env.lookupUser(env.operatorUser); err != nil {
+		_, _ = fmt.Fprintf(env.out, "  [SKIP] operator evidence ACL: cannot resolve operator %q: %v (no group/world fallback)\n", env.operatorUser, err)
+		return "", false
+	}
+	return env.operatorUser, true
+}
+
+// ensureEvidenceDir creates dir (private mode) if it does not already exist,
+// refusing to follow a symlink in its place.
+func ensureEvidenceDir(env *installEnv, dir string) error {
+	info, err := env.lstat(dir)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s is a symlink; refusing to apply operator evidence ACL", dir)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%s exists and is not a directory", dir)
+		}
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat %s: %w", dir, err)
+	}
+	if err := env.mkdirAll(dir, modeDirPrivate); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	if err := env.chmod(dir, modeDirPrivate); err != nil {
+		return fmt.Errorf("chmod %s: %w", dir, err)
+	}
+	return nil
+}
+
+// revokeEvidenceACLs removes the operator evidence ACL recorded in the
+// inventory. keepData preserves the inventory file (parallels the workspace ACL
+// revoke). It is safe to call when nothing was granted.
+func revokeEvidenceACLs(ctx context.Context, env *installEnv, keepData bool) error {
+	inv, err := loadEvidenceACLInventory(env)
+	if err != nil {
+		return err
+	}
+	if inv.Operator == "" || len(inv.Dirs) == 0 {
+		return nil
+	}
+	// Only revoke from dirs that still exist; skip removed ones to avoid
+	// erroring on a half-removed install.
+	var dirs []string
+	for _, dir := range inv.Dirs {
+		if _, statErr := env.stat(dir); statErr == nil {
+			dirs = append(dirs, dir)
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return fmt.Errorf("stat %s: %w", dir, statErr)
+		}
+	}
+	if len(dirs) > 0 {
+		commands := evidenceACLRevokeCommands(inv.Operator, env.dataDir, dirs)
+		if err := runWorkspaceCommands(ctx, env, commands); err != nil {
+			return err
+		}
+	}
+	if keepData {
+		return nil
+	}
+	if err := env.removeFile(env.evidenceACLInvPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove %s: %w", env.evidenceACLInvPath, err)
+	}
+	_ = env.removeFile(env.evidenceACLInvPath + ".bak")
+	return nil
+}
+
+func loadEvidenceACLInventory(env *installEnv) (evidenceACLInventory, error) {
+	data, err := env.readFile(env.evidenceACLInvPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return evidenceACLInventory{}, nil
+		}
+		return evidenceACLInventory{}, err
+	}
+	var inv evidenceACLInventory
+	if err := json.Unmarshal(data, &inv); err != nil {
+		return evidenceACLInventory{}, fmt.Errorf("parse %s: %w", env.evidenceACLInvPath, err)
+	}
+	return inv, nil
+}
+
+func writeEvidenceACLInventory(env *installEnv, inv evidenceACLInventory) error {
+	if err := env.mkdirAll(filepath.Dir(env.evidenceACLInvPath), modeDirTraversable); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(env.evidenceACLInvPath), err)
+	}
+	if err := env.chmod(filepath.Dir(env.evidenceACLInvPath), modeDirTraversable); err != nil {
+		return fmt.Errorf("chmod %s: %w", filepath.Dir(env.evidenceACLInvPath), err)
+	}
+	// De-dupe and sort dirs so a re-run produces stable, non-duplicated output.
+	inv.Dirs = slices.Compact(slices.Sorted(slices.Values(inv.Dirs)))
+	data, err := json.MarshalIndent(inv, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal evidence ACL inventory: %w", err)
+	}
+	data = append(data, '\n')
+	return backupAndWrite(env, env.evidenceACLInvPath, data, modeAllowListReadable)
+}

--- a/internal/cli/contain/evidence_acl.go
+++ b/internal/cli/contain/evidence_acl.go
@@ -142,11 +142,21 @@ func stepGrantEvidenceACLs() step {
 			}
 
 			dirs := env.evidenceACLDirs()
+			uid, gid, err := uidGidFor(env, env.proxyUserName)
+			if err != nil {
+				return false, err
+			}
 			// Ensure the evidence dirs exist before applying ACLs. They are
 			// created lazily by the running proxy otherwise, which would leave
-			// the operator without read access until the first write.
+			// the operator without read access until the first write. Because
+			// this step runs after chown-data, dirs created here must be
+			// explicitly re-owned by pipelock-proxy or the service cannot write
+			// its own evidence on a fresh install.
 			for _, dir := range dirs {
 				if err := ensureEvidenceDir(env, dir); err != nil {
+					return false, err
+				}
+				if err := walkAndChown(env, dir, uid, gid); err != nil {
 					return false, err
 				}
 			}

--- a/internal/cli/contain/evidence_acl.go
+++ b/internal/cli/contain/evidence_acl.go
@@ -282,5 +282,5 @@ func writeEvidenceACLInventory(env *installEnv, inv evidenceACLInventory) error 
 		return fmt.Errorf("marshal evidence ACL inventory: %w", err)
 	}
 	data = append(data, '\n')
-	return backupAndWrite(env, env.evidenceACLInvPath, data, modeAllowListReadable)
+	return backupAndWrite(env, env.evidenceACLInvPath, data, modePinSecret)
 }

--- a/internal/cli/contain/evidence_acl_test.go
+++ b/internal/cli/contain/evidence_acl_test.go
@@ -162,8 +162,24 @@ func TestStepGrantEvidenceACLs_Apply(t *testing.T) {
 	if inv.Operator != containInstallOperatorUser {
 		t.Fatalf("inventory operator = %q, want %q", inv.Operator, containInstallOperatorUser)
 	}
-	if len(inv.Dirs) == 0 {
-		t.Fatal("inventory recorded no dirs")
+	for _, dir := range []string{env.logsDir(), env.recorderDir()} {
+		if !containsString(inv.Dirs, dir) {
+			t.Fatalf("inventory dirs = %v, missing %s", inv.Dirs, dir)
+		}
+	}
+	info, err := os.Stat(env.evidenceACLInvPath)
+	if err != nil {
+		t.Fatalf("stat evidence ACL inventory: %v", err)
+	}
+	if got := info.Mode().Perm(); got != modePinSecret {
+		t.Fatalf("inventory mode = %s, want %s", got, modePinSecret)
+	}
+	parentInfo, err := os.Stat(filepath.Dir(env.evidenceACLInvPath))
+	if err != nil {
+		t.Fatalf("stat evidence ACL inventory parent: %v", err)
+	}
+	if got := parentInfo.Mode().Perm(); got != modeDirTraversable {
+		t.Fatalf("inventory parent mode = %s, want %s", got, modeDirTraversable)
 	}
 }
 
@@ -273,21 +289,27 @@ func TestRollbackActions_RevokesEvidenceACLs(t *testing.T) {
 	}
 
 	actions := rollbackActions(rollbackOpts{keepData: false})
-	var foundRevoke bool
-	for _, a := range actions {
-		if a.name == "revoke-evidence-acls" {
-			foundRevoke = true
-		}
-	}
-	if !foundRevoke {
+	revokeIdx := stepIndex(actions, "revoke-evidence-acls")
+	if revokeIdx == -1 {
 		t.Fatal("rollback actions missing revoke-evidence-acls")
+	}
+	for _, blocker := range []string{"remove-dir-data", "delete-proxy-user", "delete-agent-user"} {
+		blockerIdx := stepIndex(actions, blocker)
+		if blockerIdx == -1 {
+			t.Fatalf("rollback actions missing %s", blocker)
+		}
+		if revokeIdx <= blockerIdx {
+			t.Fatalf("revoke-evidence-acls index %d must be greater than %s index %d so reverse rollback runs revoke first", revokeIdx, blocker, blockerIdx)
+		}
 	}
 
 	for i := len(actions) - 1; i >= 0; i-- {
 		if actions[i].undo == nil {
 			continue
 		}
-		_ = actions[i].undo(context.Background(), env)
+		if err := actions[i].undo(context.Background(), env); err != nil {
+			t.Fatalf("undo %s: %v", actions[i].name, err)
+		}
 	}
 
 	var sawRevoke bool
@@ -330,11 +352,22 @@ func TestRollbackActions_KeepsEvidenceInventoryWithKeepData(t *testing.T) {
 		if actions[i].undo == nil {
 			continue
 		}
-		_ = actions[i].undo(context.Background(), env)
+		if err := actions[i].undo(context.Background(), env); err != nil {
+			t.Fatalf("undo %s: %v", actions[i].name, err)
+		}
 	}
 	if _, err := os.Stat(env.evidenceACLInvPath); err != nil {
 		t.Fatalf("evidence ACL inventory must be preserved with keep-data=true: %v", err)
 	}
+}
+
+func stepIndex(actions []step, name string) int {
+	for i, action := range actions {
+		if action.name == name {
+			return i
+		}
+	}
+	return -1
 }
 
 // TestEvidenceACL_DefaultInheritsToNewFile uses the REAL setfacl/getfacl to

--- a/internal/cli/contain/evidence_acl_test.go
+++ b/internal/cli/contain/evidence_acl_test.go
@@ -1,0 +1,538 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEvidenceACLCommands_OperatorOnly proves the evidence ACL plan grants the
+// resolved operator user read+traverse on the logs and recorder dirs, grants
+// only traverse on the data-dir parent, and NEVER references a group or the
+// contained agent user.
+func TestEvidenceACLCommands_OperatorOnly(t *testing.T) {
+	dataDir := "/var/lib/pipelock"
+	logs := filepath.Join(dataDir, "logs")
+	recorder := filepath.Join(dataDir, "recorder")
+	commands := evidenceACLCommands(containInstallOperatorUser, dataDir, []string{logs, recorder})
+
+	if len(commands) == 0 {
+		t.Fatal("evidenceACLCommands returned no commands")
+	}
+
+	joined := make([]string, 0, len(commands))
+	for _, c := range commands {
+		// Commands are either a direct setfacl, or a `find ... -exec setfacl`
+		// that applies the default ACL to existing nested subdirs.
+		if c.name != testSetfaclCmd && (c.name != "find" || !containsArg(c.args, testSetfaclCmd)) {
+			t.Fatalf("unexpected command %q (want setfacl or find -exec setfacl); cmd=%+v", c.name, c)
+		}
+		joined = append(joined, strings.Join(c.args, " "))
+	}
+	all := strings.Join(joined, "\n")
+
+	// SAFETY: no group ACL, no agent user, no world/other entry.
+	for _, banned := range []string{
+		"g:",             // group ACL
+		"d:g:",           // default group ACL
+		"pipelock-agent", // the policed agent
+		"u::",            // would touch owner perms unexpectedly
+		"o:",             // other/world
+	} {
+		if strings.Contains(all, banned) {
+			t.Fatalf("evidence ACL plan contains banned entry %q:\n%s", banned, all)
+		}
+	}
+
+	// Parent (data dir) must be traverse-only (--x), never read (r-x/rX).
+	var sawParentTraverse bool
+	for _, c := range commands {
+		argv := strings.Join(c.args, " ")
+		if containsArg(c.args, dataDir) && !containsArg(c.args, "-R") && strings.Contains(argv, "u:"+containInstallOperatorUser+":--x") {
+			sawParentTraverse = true
+		}
+		// The parent dir must NOT be granted read in any command.
+		if argTargetsDir(c.args, dataDir) && (strings.Contains(argv, ":r-x") || strings.Contains(argv, ":rX") || strings.Contains(argv, ":r--")) {
+			t.Fatalf("data-dir parent must be traverse-only, got read grant: %s", argv)
+		}
+	}
+	if !sawParentTraverse {
+		t.Fatalf("missing traverse-only (--x) grant on data-dir parent:\n%s", all)
+	}
+
+	// Logs + recorder must each get a recursive read+traverse access ACL and a
+	// default ACL for inheritance, scoped to the operator user.
+	for _, dir := range []string{logs, recorder} {
+		if !planHasAccessACL(commands, dir, containInstallOperatorUser) {
+			t.Fatalf("missing recursive operator read+traverse access ACL for %s:\n%s", dir, all)
+		}
+		if !planHasDefaultACL(commands, dir, containInstallOperatorUser) {
+			t.Fatalf("missing default (inheritance) operator ACL for %s:\n%s", dir, all)
+		}
+	}
+}
+
+// TestEvidenceACLCommands_NonOperatorIdentityNotGranted proves the plan is
+// scoped strictly to the resolved operator user. A different (non-operator /
+// agent) username must not appear anywhere in the plan.
+func TestEvidenceACLCommands_NonOperatorIdentityNotGranted(t *testing.T) {
+	dataDir := "/var/lib/pipelock"
+	logs := filepath.Join(dataDir, "logs")
+	recorder := filepath.Join(dataDir, "recorder")
+	commands := evidenceACLCommands(containInstallOperatorUser, dataDir, []string{logs, recorder})
+
+	all := joinCommands(commands)
+	for _, identity := range []string{"pipelock-agent", "pipelock-proxy", "root", "nobody"} {
+		if strings.Contains(all, "u:"+identity+":") || strings.Contains(all, "d:u:"+identity+":") {
+			t.Fatalf("plan grants access to non-operator identity %q:\n%s", identity, all)
+		}
+	}
+}
+
+// TestStepGrantEvidenceACLs_Apply exercises the install step end-to-end against
+// the fake env: it ensures the evidence dirs exist, runs the operator-only
+// setfacl commands, and records the inventory.
+func TestStepGrantEvidenceACLs_Apply(t *testing.T) {
+	if _, err := os.Stat("/usr/bin/setfacl"); err != nil {
+		// The step shells out via env.runCmd which is faked in tests, so we do
+		// NOT need a real setfacl here. This guard only documents that the
+		// production path requires it; the fake runner records argv regardless.
+		_ = err
+	}
+	env, runner, _ := newFakeEnv(t)
+
+	applied, err := stepGrantEvidenceACLs().apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatalf("expected step to apply on first run")
+	}
+
+	// Evidence dirs must now exist.
+	for _, dir := range []string{env.logsDir(), env.recorderDir()} {
+		info, statErr := os.Stat(dir)
+		if statErr != nil {
+			t.Fatalf("evidence dir %s not created: %v", dir, statErr)
+		}
+		if !info.IsDir() {
+			t.Fatalf("%s is not a directory", dir)
+		}
+	}
+
+	// setfacl must have been invoked for the operator user only.
+	var sawSetfacl bool
+	for _, call := range runner.calls {
+		if call.name != testSetfaclCmd {
+			continue
+		}
+		sawSetfacl = true
+		argv := strings.Join(call.args, " ")
+		if strings.Contains(argv, "pipelock-agent") || strings.Contains(argv, "g:") || strings.Contains(argv, "o:") {
+			t.Fatalf("setfacl call leaked group/agent access: %s", argv)
+		}
+	}
+	if !sawSetfacl {
+		t.Fatal("no setfacl call recorded")
+	}
+
+	// Inventory must be recorded with the operator user.
+	inv, loadErr := loadEvidenceACLInventory(env)
+	if loadErr != nil {
+		t.Fatalf("load evidence inventory: %v", loadErr)
+	}
+	if inv.Operator != containInstallOperatorUser {
+		t.Fatalf("inventory operator = %q, want %q", inv.Operator, containInstallOperatorUser)
+	}
+	if len(inv.Dirs) == 0 {
+		t.Fatal("inventory recorded no dirs")
+	}
+}
+
+// TestStepGrantEvidenceACLs_Idempotent re-runs the step and confirms it does not
+// error and does not duplicate inventory entries.
+func TestStepGrantEvidenceACLs_Idempotent(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	step := stepGrantEvidenceACLs()
+	if _, err := step.apply(context.Background(), env); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	if _, err := step.apply(context.Background(), env); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	inv, err := loadEvidenceACLInventory(env)
+	if err != nil {
+		t.Fatalf("load inventory: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, d := range inv.Dirs {
+		if seen[d] {
+			t.Fatalf("duplicate dir in inventory after re-run: %s", d)
+		}
+		seen[d] = true
+	}
+}
+
+// TestStepGrantEvidenceACLs_FailClosedOnUnresolvedOperator proves the ACL step
+// is skipped (no setfacl, no group/world fallback) when the operator user
+// cannot be resolved.
+func TestStepGrantEvidenceACLs_FailClosedOnUnresolvedOperator(t *testing.T) {
+	t.Run("empty operator user", func(t *testing.T) {
+		env, runner, buf := newFakeEnv(t)
+		env.operatorUser = ""
+		applied, err := stepGrantEvidenceACLs().apply(context.Background(), env)
+		if err != nil {
+			t.Fatalf("apply must not error on unresolved operator, got %v", err)
+		}
+		if applied {
+			t.Fatal("step must not report applied when operator unresolved")
+		}
+		for _, call := range runner.calls {
+			if call.name == testSetfaclCmd {
+				t.Fatalf("setfacl must not run when operator unresolved: %+v", call)
+			}
+		}
+		if !strings.Contains(buf.String(), "operator") {
+			t.Fatalf("expected a logged skip reason mentioning operator:\n%s", buf.String())
+		}
+	})
+
+	t.Run("unknown operator user", func(t *testing.T) {
+		env, runner, _ := newFakeEnv(t)
+		env.operatorUser = "ghost"
+		applied, err := stepGrantEvidenceACLs().apply(context.Background(), env)
+		if err != nil {
+			t.Fatalf("apply must not error on unknown operator, got %v", err)
+		}
+		if applied {
+			t.Fatal("step must not report applied when operator unknown")
+		}
+		for _, call := range runner.calls {
+			if call.name == testSetfaclCmd {
+				t.Fatalf("setfacl must not run when operator unknown: %+v", call)
+			}
+		}
+	})
+}
+
+// TestInstallSteps_IncludesEvidenceACLStep proves the install pipeline wires the
+// evidence ACL step after the data-dir is created and chowned to the proxy.
+func TestInstallSteps_IncludesEvidenceACLStep(t *testing.T) {
+	steps := installSteps(installOpts{})
+	dataChown, evidence := -1, -1
+	for i, s := range steps {
+		if s.name == "chown-data" {
+			dataChown = i
+		}
+		if s.name == "grant-evidence-acls" {
+			evidence = i
+		}
+	}
+	if evidence == -1 {
+		t.Fatal("install steps missing grant-evidence-acls")
+	}
+	if dataChown == -1 || evidence < dataChown {
+		t.Fatalf("evidence ACL step (%d) must run after data chown (%d)", evidence, dataChown)
+	}
+}
+
+// TestRollbackActions_RevokesEvidenceACLs proves rollback revokes the operator
+// evidence ACLs and runs before the data dir removal / user deletion.
+func TestRollbackActions_RevokesEvidenceACLs(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	// Seed an inventory as if install had granted the ACLs.
+	if err := writeEvidenceACLInventory(env, evidenceACLInventory{
+		Operator: containInstallOperatorUser,
+		Dirs:     []string{env.logsDir(), env.recorderDir()},
+	}); err != nil {
+		t.Fatalf("seed evidence inventory: %v", err)
+	}
+	if err := os.MkdirAll(env.logsDir(), 0o750); err != nil {
+		t.Fatalf("mkdir logs: %v", err)
+	}
+	if err := os.MkdirAll(env.recorderDir(), 0o750); err != nil {
+		t.Fatalf("mkdir recorder: %v", err)
+	}
+
+	actions := rollbackActions(rollbackOpts{keepData: false})
+	var foundRevoke bool
+	for _, a := range actions {
+		if a.name == "revoke-evidence-acls" {
+			foundRevoke = true
+		}
+	}
+	if !foundRevoke {
+		t.Fatal("rollback actions missing revoke-evidence-acls")
+	}
+
+	for i := len(actions) - 1; i >= 0; i-- {
+		if actions[i].undo == nil {
+			continue
+		}
+		_ = actions[i].undo(context.Background(), env)
+	}
+
+	var sawRevoke bool
+	for _, call := range runner.calls {
+		if call.name != testSetfaclCmd {
+			continue
+		}
+		argv := strings.Join(call.args, " ")
+		if strings.Contains(argv, "-x") && strings.Contains(argv, "u:"+containInstallOperatorUser) {
+			sawRevoke = true
+		}
+	}
+	if !sawRevoke {
+		t.Fatalf("rollback did not revoke operator evidence ACLs; calls=%+v", runner.calls)
+	}
+
+	// Inventory removed when keepData=false.
+	if _, err := os.Stat(env.evidenceACLInvPath); err == nil {
+		t.Fatal("evidence ACL inventory must be removed with keep-data=false")
+	}
+}
+
+func TestRollbackActions_KeepsEvidenceInventoryWithKeepData(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := writeEvidenceACLInventory(env, evidenceACLInventory{
+		Operator: containInstallOperatorUser,
+		Dirs:     []string{env.logsDir()},
+	}); err != nil {
+		t.Fatalf("seed evidence inventory: %v", err)
+	}
+	if err := os.MkdirAll(env.logsDir(), 0o750); err != nil {
+		t.Fatalf("mkdir logs: %v", err)
+	}
+	env.lookupUser = func(name string) (*user.User, error) {
+		return &user.User{Uid: "1000", Gid: "1000", Username: name}, nil
+	}
+
+	actions := rollbackActions(rollbackOpts{keepData: true})
+	for i := len(actions) - 1; i >= 0; i-- {
+		if actions[i].undo == nil {
+			continue
+		}
+		_ = actions[i].undo(context.Background(), env)
+	}
+	if _, err := os.Stat(env.evidenceACLInvPath); err != nil {
+		t.Fatalf("evidence ACL inventory must be preserved with keep-data=true: %v", err)
+	}
+}
+
+// TestEvidenceACL_DefaultInheritsToNewFile uses the REAL setfacl/getfacl to
+// prove (1) the operator gains read+traverse on the evidence dir, (2) a NEW
+// file created after the grant inherits the operator-read default ACL, and
+// (3) no group or agent entry is added. Skips cleanly if the platform lacks
+// ACL support.
+func TestEvidenceACL_DefaultInheritsToNewFile(t *testing.T) {
+	if _, err := exec.LookPath("setfacl"); err != nil {
+		t.Skip("setfacl not available; skipping real-ACL inheritance test")
+	}
+	if _, err := exec.LookPath("getfacl"); err != nil {
+		t.Skip("getfacl not available; skipping real-ACL inheritance test")
+	}
+
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "var", "lib", "pipelock")
+	logs := filepath.Join(dataDir, "logs")
+	if err := os.MkdirAll(logs, 0o750); err != nil {
+		t.Fatalf("mkdir logs: %v", err)
+	}
+
+	operator, err := user.Current()
+	if err != nil {
+		t.Fatalf("current user: %v", err)
+	}
+
+	// Probe: does this filesystem support ACLs at all?
+	if _, _, perr := realRunCommand(context.Background(), "setfacl", "-m", "u:"+operator.Username+":rX", dataDir); perr != nil {
+		t.Skipf("filesystem does not support ACLs: %v", perr)
+	}
+
+	commands := evidenceACLCommands(operator.Username, dataDir, []string{logs})
+	for _, c := range commands {
+		out, code, runErr := realRunCommand(context.Background(), c.name, c.args...)
+		if runErr != nil || code != 0 {
+			t.Skipf("ACL command %s %v failed (likely unsupported FS): code=%d err=%v out=%s", c.name, c.args, code, runErr, out)
+		}
+	}
+
+	// New file written into the logs dir AFTER the default ACL was applied.
+	newFile := filepath.Join(logs, "audit.log")
+	if err := os.WriteFile(newFile, []byte("entry\n"), 0o600); err != nil {
+		t.Fatalf("write new audit log: %v", err)
+	}
+
+	facl, _, err := realRunCommand(context.Background(), "getfacl", "-p", newFile)
+	if err != nil {
+		t.Fatalf("getfacl: %v", err)
+	}
+	if !strings.Contains(facl, "user:"+operator.Username+":r") {
+		t.Fatalf("new file did not inherit operator read ACL:\n%s", facl)
+	}
+	// Adversarial: our plan must not add a NAMED group ACL ("group:<name>:").
+	// The owning-group entry ("group::...") is normal and not our doing.
+	for _, line := range strings.Split(facl, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "group:") && !strings.HasPrefix(trimmed, "group::") {
+			t.Fatalf("unexpected named-group ACL on inherited file: %q\nfull:\n%s", trimmed, facl)
+		}
+	}
+}
+
+// TestEnsureEvidenceDir_RejectsSymlink proves the dir-ensure step refuses to
+// apply an ACL through a symlink standing in for the evidence dir.
+func TestEnsureEvidenceDir_RejectsSymlink(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	root := t.TempDir()
+	target := filepath.Join(root, "real")
+	if err := os.MkdirAll(target, 0o750); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if err := ensureEvidenceDir(env, link); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err = %v, want symlink rejection", err)
+	}
+}
+
+// TestEnsureEvidenceDir_RejectsNonDir proves a non-directory in the dir's place
+// is rejected.
+func TestEnsureEvidenceDir_RejectsNonDir(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	root := t.TempDir()
+	file := filepath.Join(root, "afile")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := ensureEvidenceDir(env, file); err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("err = %v, want non-directory rejection", err)
+	}
+}
+
+// TestStepGrantEvidenceACLs_PropagatesSetfaclFailure proves a failing setfacl
+// surfaces as an apply error (fail-closed, not silently applied).
+func TestStepGrantEvidenceACLs_PropagatesSetfaclFailure(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor("setfacl", "-m", "u:"+containInstallOperatorUser+":"+evidenceTraversePerms, env.dataDir), "boom", 1, nil)
+	applied, err := stepGrantEvidenceACLs().apply(context.Background(), env)
+	if err == nil || !strings.Contains(err.Error(), "operator evidence ACL") {
+		t.Fatalf("err = %v, want apply failure", err)
+	}
+	if applied {
+		t.Fatal("step must not report applied when setfacl fails")
+	}
+}
+
+// TestLoadEvidenceACLInventory_Malformed proves a corrupt inventory is a clear
+// parse error (not a silent empty).
+func TestLoadEvidenceACLInventory_Malformed(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.evidenceACLInvPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.evidenceACLInvPath, []byte("{nope"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := loadEvidenceACLInventory(env); err == nil || !strings.Contains(err.Error(), "evidence-acls.json") {
+		t.Fatalf("err = %v, want parse error", err)
+	}
+}
+
+// TestRevokeEvidenceACLs_SkipsRemovedDirs proves revoke tolerates a dir that no
+// longer exists (half-removed install) and still revokes the surviving one.
+func TestRevokeEvidenceACLs_SkipsRemovedDirs(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	gone := filepath.Join(env.dataDir, "recorder") // never created
+	present := env.logsDir()
+	if err := os.MkdirAll(present, 0o750); err != nil {
+		t.Fatalf("mkdir present: %v", err)
+	}
+	if err := writeEvidenceACLInventory(env, evidenceACLInventory{
+		Operator: containInstallOperatorUser,
+		Dirs:     []string{gone, present},
+	}); err != nil {
+		t.Fatalf("seed inventory: %v", err)
+	}
+	if err := revokeEvidenceACLs(context.Background(), env, true); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	for _, call := range runner.calls {
+		if call.name == testSetfaclCmd && containsArg(call.args, gone) {
+			t.Fatalf("revoke touched a removed dir: %+v", call)
+		}
+	}
+}
+
+// TestWriteEvidenceACLInventory_DedupesAndSorts proves repeated/unsorted dirs
+// are normalized on write.
+func TestWriteEvidenceACLInventory_DedupesAndSorts(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	if err := writeEvidenceACLInventory(env, evidenceACLInventory{
+		Operator: containInstallOperatorUser,
+		Dirs:     []string{env.recorderDir(), env.logsDir(), env.recorderDir()},
+	}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	inv, err := loadEvidenceACLInventory(env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(inv.Dirs) != 2 {
+		t.Fatalf("dirs = %v, want 2 deduped", inv.Dirs)
+	}
+	if inv.Dirs[0] >= inv.Dirs[1] {
+		t.Fatalf("dirs not sorted: %v", inv.Dirs)
+	}
+}
+
+// --- test helpers -----------------------------------------------------------
+
+func joinCommands(commands []workspaceCommand) string {
+	parts := make([]string, 0, len(commands))
+	for _, c := range commands {
+		parts = append(parts, c.name+" "+strings.Join(c.args, " "))
+	}
+	return strings.Join(parts, "\n")
+}
+
+// argTargetsDir reports whether dir is the last (target) positional argument of
+// the setfacl invocation, i.e. the command acts ON dir (not merely names it as
+// an ancestor in a -R recursion rooted elsewhere).
+func argTargetsDir(args []string, dir string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	return args[len(args)-1] == dir
+}
+
+func planHasAccessACL(commands []workspaceCommand, dir, operator string) bool {
+	for _, c := range commands {
+		argv := strings.Join(c.args, " ")
+		if containsArg(c.args, "-R") && containsArg(c.args, dir) &&
+			(strings.Contains(argv, "u:"+operator+":rX") || strings.Contains(argv, "u:"+operator+":r-x")) {
+			return true
+		}
+	}
+	return false
+}
+
+func planHasDefaultACL(commands []workspaceCommand, dir, operator string) bool {
+	for _, c := range commands {
+		argv := strings.Join(c.args, " ")
+		if containsArg(c.args, dir) &&
+			(strings.Contains(argv, "d:u:"+operator+":rX") || strings.Contains(argv, "d:u:"+operator+":r-x")) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/contain/evidence_acl_test.go
+++ b/internal/cli/contain/evidence_acl_test.go
@@ -107,6 +107,14 @@ func TestStepGrantEvidenceACLs_Apply(t *testing.T) {
 		_ = err
 	}
 	env, runner, _ := newFakeEnv(t)
+	var chowned []string
+	env.chown = func(path string, uid, gid int) error {
+		if uid != 988 || gid != 988 {
+			t.Fatalf("evidence dir chown = %d:%d, want pipelock-proxy 988:988", uid, gid)
+		}
+		chowned = append(chowned, filepath.Clean(path))
+		return nil
+	}
 
 	applied, err := stepGrantEvidenceACLs().apply(context.Background(), env)
 	if err != nil {
@@ -124,6 +132,9 @@ func TestStepGrantEvidenceACLs_Apply(t *testing.T) {
 		}
 		if !info.IsDir() {
 			t.Fatalf("%s is not a directory", dir)
+		}
+		if !containsString(chowned, filepath.Clean(dir)) {
+			t.Fatalf("evidence dir %s was not chowned to pipelock-proxy; chowned=%v", dir, chowned)
 		}
 	}
 

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -208,6 +208,12 @@ func installSteps(opts installOpts) []step {
 		stepWritePipelockConfig(opts),
 		stepChownToProxy("config", func(e *installEnv) string { return e.configDir }),
 		stepChownToProxy("data", func(e *installEnv) string { return e.dataDir }),
+		// Grant the human operator a user-scoped read+traverse ACL on the
+		// evidence dirs (logs + recorder) so they can verify the audit log and
+		// signed receipt chain offline without sudo. Runs after the data dir is
+		// created and proxy-owned. Fail-closed (skips) if the operator cannot
+		// be resolved; never grants a group/world ACL.
+		stepGrantEvidenceACLs(),
 		stepInstallPipelockBinary(),
 		stepWriteIntegrityPin(),
 		stepStopUserService(),

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -171,33 +171,34 @@ func newFakeEnv(t *testing.T) (*installEnv, *fakeRunner, *bytes.Buffer) {
 			h := sha256.Sum256(data)
 			return hex.EncodeToString(h[:]), nil
 		},
-		out:               out,
-		errOut:            out,
-		operatorUser:      containInstallOperatorUser,
-		proxyUserName:     "pipelock-proxy",
-		agentUserName:     "pipelock-agent",
-		configDir:         filepath.Join(root, "etc", "pipelock"),
-		dataDir:           filepath.Join(root, "var", "lib", "pipelock"),
-		wrapperDir:        filepath.Join(root, "usr", "local", "bin"),
-		systemUnitPath:    filepath.Join(root, "etc", "systemd", "system", "pipelock.service"),
-		nftRulesPath:      filepath.Join(root, "etc", "nftables.d", "50-pipelock-containment.nft"),
-		nftMainPath:       filepath.Join(root, "etc", "sysconfig", "nftables.conf"),
-		sudoersPath:       filepath.Join(root, "etc", "sudoers.d", "50-pipelock-agent"),
-		caBundlePath:      filepath.Join(root, "etc", "pipelock", "combined-ca.pem"),
-		caExportPath:      filepath.Join(root, "etc", "pipelock", "ca.pem"),
-		integrityDir:      filepath.Join(root, "etc", "pipelock", "integrity"),
-		integrityPin:      filepath.Join(root, "etc", "pipelock", "integrity", "binary-pin.sha256"),
-		wrapperInvPath:    filepath.Join(root, "etc", "pipelock", "contain", "wrappers.json"),
-		toolsListPath:     filepath.Join(root, "etc", "pipelock", "contain", "tools.list"),
-		workspaceInvPath:  filepath.Join(root, "etc", "pipelock", "contain", "workspaces.json"),
-		guardScriptPath:   filepath.Join(root, "usr", "local", "bin", "plk-cred-guard"),
-		guardServiceUnit:  filepath.Join(root, "etc", "systemd", "system", "pipelock-cred-guard.service"),
-		guardPathUnit:     filepath.Join(root, "etc", "systemd", "system", "pipelock-cred-guard.path"),
-		undiciShimPath:    filepath.Join(root, "etc", "pipelock", "contain", "undici-shim.cjs"),
-		profileScriptPath: filepath.Join(root, "etc", "profile.d", "pipelock-contain.sh"),
-		agentHome:         filepath.Join(root, "home", "pipelock-agent"),
-		pipelockTarget:    filepath.Join(root, "usr", "local", "bin", "pipelock"),
-		proxyPort:         8888,
+		out:                out,
+		errOut:             out,
+		operatorUser:       containInstallOperatorUser,
+		proxyUserName:      "pipelock-proxy",
+		agentUserName:      "pipelock-agent",
+		configDir:          filepath.Join(root, "etc", "pipelock"),
+		dataDir:            filepath.Join(root, "var", "lib", "pipelock"),
+		wrapperDir:         filepath.Join(root, "usr", "local", "bin"),
+		systemUnitPath:     filepath.Join(root, "etc", "systemd", "system", "pipelock.service"),
+		nftRulesPath:       filepath.Join(root, "etc", "nftables.d", "50-pipelock-containment.nft"),
+		nftMainPath:        filepath.Join(root, "etc", "sysconfig", "nftables.conf"),
+		sudoersPath:        filepath.Join(root, "etc", "sudoers.d", "50-pipelock-agent"),
+		caBundlePath:       filepath.Join(root, "etc", "pipelock", "combined-ca.pem"),
+		caExportPath:       filepath.Join(root, "etc", "pipelock", "ca.pem"),
+		integrityDir:       filepath.Join(root, "etc", "pipelock", "integrity"),
+		integrityPin:       filepath.Join(root, "etc", "pipelock", "integrity", "binary-pin.sha256"),
+		wrapperInvPath:     filepath.Join(root, "etc", "pipelock", "contain", "wrappers.json"),
+		toolsListPath:      filepath.Join(root, "etc", "pipelock", "contain", "tools.list"),
+		workspaceInvPath:   filepath.Join(root, "etc", "pipelock", "contain", "workspaces.json"),
+		evidenceACLInvPath: filepath.Join(root, "etc", "pipelock", "contain", "evidence-acls.json"),
+		guardScriptPath:    filepath.Join(root, "usr", "local", "bin", "plk-cred-guard"),
+		guardServiceUnit:   filepath.Join(root, "etc", "systemd", "system", "pipelock-cred-guard.service"),
+		guardPathUnit:      filepath.Join(root, "etc", "systemd", "system", "pipelock-cred-guard.path"),
+		undiciShimPath:     filepath.Join(root, "etc", "pipelock", "contain", "undici-shim.cjs"),
+		profileScriptPath:  filepath.Join(root, "etc", "profile.d", "pipelock-contain.sh"),
+		agentHome:          filepath.Join(root, "home", "pipelock-agent"),
+		pipelockTarget:     filepath.Join(root, "usr", "local", "bin", "pipelock"),
+		proxyPort:          8888,
 	}
 
 	// Plant the source binary the install will copy.
@@ -1517,12 +1518,13 @@ func TestStepCreateDirRejectsSymlinkParent(t *testing.T) {
 }
 
 func TestInstallSteps_Count(t *testing.T) {
-	// Sanity: the install flow has 27 steps total after combining the runtime
-	// contract steps with the credential guard. Changing this count is a
-	// documented breaking change for the dry-run / verify probe-4 inventory.
+	// Sanity: the install flow has 28 steps total after combining the runtime
+	// contract steps with the credential guard and the operator evidence ACL
+	// step. Changing this count is a documented breaking change for the
+	// dry-run / verify probe-4 inventory.
 	steps := installSteps(installOpts{})
-	if len(steps) != 27 {
-		t.Errorf("installSteps count: got %d, want 27", len(steps))
+	if len(steps) != 28 {
+		t.Errorf("installSteps count: got %d, want 28", len(steps))
 	}
 }
 

--- a/internal/cli/contain/osops.go
+++ b/internal/cli/contain/osops.go
@@ -67,32 +67,33 @@ type installEnv struct {
 	// Static configuration. These mirror the constants in verify.go so the
 	// two subsystems agree on filesystem layout. Made fields rather than
 	// constants so the install subcommand can accept flag overrides.
-	operatorUser      string
-	proxyUserName     string
-	agentUserName     string
-	configDir         string
-	dataDir           string
-	wrapperDir        string
-	systemUnitPath    string
-	nftRulesPath      string
-	nftMainPath       string
-	sudoersPath       string
-	caBundlePath      string
-	caExportPath      string
-	integrityDir      string
-	integrityPin      string
-	wrapperInvPath    string
-	toolsListPath     string // plk-launch's runtime allow-list (tab-separated NAME\tTARGET)
-	workspaceInvPath  string
-	guardScriptPath   string
-	guardServiceUnit  string
-	guardPathUnit     string
-	undiciShimPath    string // node undici proxy shim loaded via NODE_OPTIONS
-	profileScriptPath string // /etc/profile.d login-shell runtime contract
-	agentHome         string // contained agent home (per-tool config destination)
-	pipelockBinary    string // source binary path passed to --pipelock-binary
-	pipelockTarget    string // destination, default /usr/local/bin/pipelock
-	proxyPort         int
+	operatorUser       string
+	proxyUserName      string
+	agentUserName      string
+	configDir          string
+	dataDir            string
+	wrapperDir         string
+	systemUnitPath     string
+	nftRulesPath       string
+	nftMainPath        string
+	sudoersPath        string
+	caBundlePath       string
+	caExportPath       string
+	integrityDir       string
+	integrityPin       string
+	wrapperInvPath     string
+	toolsListPath      string // plk-launch's runtime allow-list (tab-separated NAME\tTARGET)
+	workspaceInvPath   string
+	evidenceACLInvPath string // operator evidence-read ACL inventory
+	guardScriptPath    string
+	guardServiceUnit   string
+	guardPathUnit      string
+	undiciShimPath     string // node undici proxy shim loaded via NODE_OPTIONS
+	profileScriptPath  string // /etc/profile.d login-shell runtime contract
+	agentHome          string // contained agent home (per-tool config destination)
+	pipelockBinary     string // source binary path passed to --pipelock-binary
+	pipelockTarget     string // destination, default /usr/local/bin/pipelock
+	proxyPort          int
 
 	prevNFTTableDump       string
 	prevNftablesEnabled    bool
@@ -107,48 +108,49 @@ type installEnv struct {
 // sudo (where $SUDO_USER is empty) and -- no override flag was passed.
 func defaultInstallEnv(out io.Writer) *installEnv {
 	return &installEnv{
-		runCmd:            realRunCommand,
-		stat:              os.Stat,
-		lstat:             os.Lstat,
-		readFile:          os.ReadFile,
-		writeFile:         writeFileAtomic,
-		removeFile:        os.Remove,
-		mkdirAll:          os.MkdirAll,
-		chown:             os.Chown,
-		lchown:            os.Lchown,
-		rename:            os.Rename,
-		chmod:             os.Chmod,
-		symlink:           os.Symlink,
-		lookupUser:        user.Lookup,
-		selfPath:          os.Executable,
-		hashFile:          sha256HexOfFile,
-		out:               out,
-		errOut:            os.Stderr,
-		operatorUser:      os.Getenv("SUDO_USER"),
-		proxyUserName:     defaultProxyUser,
-		agentUserName:     defaultAgentUser,
-		configDir:         defaultConfigDir,
-		dataDir:           defaultDataDir,
-		wrapperDir:        defaultWrapperDir,
-		systemUnitPath:    defaultSystemUnitPath,
-		nftRulesPath:      defaultNFTRulesPath,
-		nftMainPath:       defaultNFTMainConfigPath,
-		sudoersPath:       defaultSudoersPath,
-		caBundlePath:      defaultCABundlePath,
-		caExportPath:      defaultCAExportPath,
-		integrityDir:      defaultIntegrityDir,
-		integrityPin:      defaultIntegrityPin,
-		wrapperInvPath:    defaultWrapperInvPath,
-		toolsListPath:     defaultToolsListPath,
-		workspaceInvPath:  defaultWorkspaceInvPath,
-		guardScriptPath:   defaultGuardScriptPath,
-		guardServiceUnit:  defaultGuardServiceUnit,
-		guardPathUnit:     defaultGuardPathUnit,
-		undiciShimPath:    defaultUndiciShimPath,
-		profileScriptPath: defaultProfileScriptPath,
-		agentHome:         "/home/" + defaultAgentUser,
-		pipelockTarget:    defaultPipelockTarget,
-		proxyPort:         defaultProxyPort,
+		runCmd:             realRunCommand,
+		stat:               os.Stat,
+		lstat:              os.Lstat,
+		readFile:           os.ReadFile,
+		writeFile:          writeFileAtomic,
+		removeFile:         os.Remove,
+		mkdirAll:           os.MkdirAll,
+		chown:              os.Chown,
+		lchown:             os.Lchown,
+		rename:             os.Rename,
+		chmod:              os.Chmod,
+		symlink:            os.Symlink,
+		lookupUser:         user.Lookup,
+		selfPath:           os.Executable,
+		hashFile:           sha256HexOfFile,
+		out:                out,
+		errOut:             os.Stderr,
+		operatorUser:       os.Getenv("SUDO_USER"),
+		proxyUserName:      defaultProxyUser,
+		agentUserName:      defaultAgentUser,
+		configDir:          defaultConfigDir,
+		dataDir:            defaultDataDir,
+		wrapperDir:         defaultWrapperDir,
+		systemUnitPath:     defaultSystemUnitPath,
+		nftRulesPath:       defaultNFTRulesPath,
+		nftMainPath:        defaultNFTMainConfigPath,
+		sudoersPath:        defaultSudoersPath,
+		caBundlePath:       defaultCABundlePath,
+		caExportPath:       defaultCAExportPath,
+		integrityDir:       defaultIntegrityDir,
+		integrityPin:       defaultIntegrityPin,
+		wrapperInvPath:     defaultWrapperInvPath,
+		toolsListPath:      defaultToolsListPath,
+		workspaceInvPath:   defaultWorkspaceInvPath,
+		evidenceACLInvPath: defaultEvidenceACLInvPath,
+		guardScriptPath:    defaultGuardScriptPath,
+		guardServiceUnit:   defaultGuardServiceUnit,
+		guardPathUnit:      defaultGuardPathUnit,
+		undiciShimPath:     defaultUndiciShimPath,
+		profileScriptPath:  defaultProfileScriptPath,
+		agentHome:          "/home/" + defaultAgentUser,
+		pipelockTarget:     defaultPipelockTarget,
+		proxyPort:          defaultProxyPort,
 	}
 }
 
@@ -156,23 +158,24 @@ func defaultInstallEnv(out io.Writer) *installEnv {
 // so the two subsystems agree on filesystem layout. Names are picked to
 // avoid collision with verify.go constants.
 const (
-	defaultConfigDir         = "/etc/pipelock"
-	defaultDataDir           = "/var/lib/pipelock"
-	defaultSystemUnitPath    = "/etc/systemd/system/pipelock.service"
-	defaultNFTRulesPath      = "/etc/nftables.d/50-pipelock-containment.nft"
-	defaultNFTMainConfigPath = "/etc/sysconfig/nftables.conf"
-	defaultSudoersPath       = "/etc/sudoers.d/50-pipelock-agent"
-	defaultCAExportPath      = "/etc/pipelock/ca.pem"
-	defaultIntegrityDir      = "/etc/pipelock/integrity"
-	defaultIntegrityPin      = "/etc/pipelock/integrity/binary-pin.sha256"
-	defaultWrapperInvPath    = "/etc/pipelock/contain/wrappers.json"
-	defaultToolsListPath     = "/etc/pipelock/contain/tools.list"
-	defaultWorkspaceInvPath  = "/etc/pipelock/contain/workspaces.json"
-	defaultGuardScriptPath   = "/usr/local/bin/plk-cred-guard"                   //nolint:gosec // G101: executable filename, not a credential value.
-	defaultGuardServiceUnit  = "/etc/systemd/system/pipelock-cred-guard.service" //nolint:gosec // G101: unit filename, not a credential value.
-	defaultGuardPathUnit     = "/etc/systemd/system/pipelock-cred-guard.path"    //nolint:gosec // G101: unit filename, not a credential value.
-	defaultPipelockTarget    = "/usr/local/bin/pipelock"
-	defaultSystemCABundle    = "/etc/ssl/certs/ca-bundle.crt"
+	defaultConfigDir          = "/etc/pipelock"
+	defaultDataDir            = "/var/lib/pipelock"
+	defaultSystemUnitPath     = "/etc/systemd/system/pipelock.service"
+	defaultNFTRulesPath       = "/etc/nftables.d/50-pipelock-containment.nft"
+	defaultNFTMainConfigPath  = "/etc/sysconfig/nftables.conf"
+	defaultSudoersPath        = "/etc/sudoers.d/50-pipelock-agent"
+	defaultCAExportPath       = "/etc/pipelock/ca.pem"
+	defaultIntegrityDir       = "/etc/pipelock/integrity"
+	defaultIntegrityPin       = "/etc/pipelock/integrity/binary-pin.sha256"
+	defaultWrapperInvPath     = "/etc/pipelock/contain/wrappers.json"
+	defaultToolsListPath      = "/etc/pipelock/contain/tools.list"
+	defaultWorkspaceInvPath   = "/etc/pipelock/contain/workspaces.json"
+	defaultEvidenceACLInvPath = "/etc/pipelock/contain/evidence-acls.json"
+	defaultGuardScriptPath    = "/usr/local/bin/plk-cred-guard"                   //nolint:gosec // G101: executable filename, not a credential value.
+	defaultGuardServiceUnit   = "/etc/systemd/system/pipelock-cred-guard.service" //nolint:gosec // G101: unit filename, not a credential value.
+	defaultGuardPathUnit      = "/etc/systemd/system/pipelock-cred-guard.path"    //nolint:gosec // G101: unit filename, not a credential value.
+	defaultPipelockTarget     = "/usr/local/bin/pipelock"
+	defaultSystemCABundle     = "/etc/ssl/certs/ca-bundle.crt"
 
 	// File modes. The model is "pipelock-agent UID must be able to read every
 	// non-secret file the wrappers depend on at runtime, but cannot read

--- a/internal/cli/contain/rollback.go
+++ b/internal/cli/contain/rollback.go
@@ -122,6 +122,10 @@ func rollbackActions(opts rollbackOpts) []step {
 		// inventory file. List position controls reverse-walk priority,
 		// so revoke sits at a higher index than both blockers.
 		actionRevokeWorkspaceACLs(opts),
+		// Revoke operator evidence ACLs before the config dir removal wipes the
+		// inventory and before the data dir removal deletes the targets. Higher
+		// list index than both removals so the reverse walk runs it first.
+		actionRevokeEvidenceACLs(opts),
 		actionPreserve("pipelock.yaml (kept with --keep-data)"),
 		actionPreserve("config chown (resolved by dir removal)"),
 		actionPreserve("data chown (resolved by dir removal)"),
@@ -179,6 +183,20 @@ func actionRevokeWorkspaceACLs(opts rollbackOpts) step {
 			}
 			_ = env.removeFile(env.workspaceInvPath + ".bak")
 			return nil
+		},
+	}
+}
+
+// actionRevokeEvidenceACLs removes the operator read+traverse evidence ACL
+// granted at install time, tracked in /etc/pipelock/contain/evidence-acls.json.
+// It mirrors actionRevokeWorkspaceACLs: best-effort, idempotent, and preserves
+// the inventory file when --keep-data is set so a re-install can rebuild it.
+func actionRevokeEvidenceACLs(opts rollbackOpts) step {
+	return step{
+		name: "revoke-evidence-acls",
+		desc: "revoke operator evidence ACLs tracked in /etc/pipelock/contain/evidence-acls.json",
+		undo: func(ctx context.Context, env *installEnv) error {
+			return revokeEvidenceACLs(ctx, env, opts.keepData)
 		},
 	}
 }

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -751,14 +751,7 @@ Key-free evidence capture:
 					cmd.PrintErrf("  Receipts: ERROR - chain could not be resumed: %v\n"+
 						"            Receipt emission is DISABLED until resolved. Inspect the evidence\n"+
 						"            directory and flight_recorder.signing_key_path.\n", initErr)
-				}
-				// receipt.NewEmitter returns nil when no signing key is
-				// configured. Receipts must be signed - there is no
-				// "unsigned receipt" mode - so report the operator-facing
-				// status by signing-key presence, not by emitter identity.
-				// This is more honest than the prior branch which could
-				// never execute.
-				if len(recPrivKey) > 0 {
+				} else if len(recPrivKey) > 0 {
 					cmd.PrintErrf("  Receipts: enabled (action receipts signed)\n")
 					v2ReceiptEmitter = proxydecision.NewEmitter(proxydecision.EmitterConfig{
 						Recorder:  rec,
@@ -771,6 +764,10 @@ Key-free evidence capture:
 						cmd.PrintErrf("  Receipts: v2 proxy_decision dual-emit enabled\n")
 					}
 				} else {
+					// receipt.NewEmitter returns nil when no signing key is
+					// configured. Receipts must be signed - there is no
+					// "unsigned receipt" mode - so report the operator-facing
+					// status by signing-key presence, not by emitter identity.
 					cmd.PrintErrf("  Receipts: disabled — set flight_recorder.signing_key_path to enable signed action receipts\n")
 				}
 			}

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -730,15 +730,28 @@ Key-free evidence capture:
 				// refactor: the resolved cfg carries the original rawBytes
 				// so Hash() still reflects the on-disk YAML even after
 				// bundle merge and auto-enable.
+				// mcpMetrics is non-nil only when session profiling is on; a
+				// nil MetricsSink is a safe no-op in the emitter, so emit-
+				// failure counters are wired opportunistically here.
 				receiptEmitter = receipt.NewEmitter(receipt.EmitterConfig{
 					Recorder:   rec,
 					PrivKey:    recPrivKey,
 					ConfigHash: cfg.Hash(),
 					Principal:  "local",
 					Actor:      "pipelock",
+					Metrics:    mcpMetrics,
 				})
 
 				cmd.PrintErrf("  Recorder: %s (flight recorder enabled)\n", cfg.FlightRecorder.Dir)
+				// Loud, one-time startup signal when the chain could not be
+				// resumed (corrupt/tampered tail or an evidence read error).
+				// A legitimate key rotation no longer lands here - it opens a
+				// new chain segment instead of failing.
+				if initErr := receiptEmitter.InitError(); initErr != nil {
+					cmd.PrintErrf("  Receipts: ERROR - chain could not be resumed: %v\n"+
+						"            Receipt emission is DISABLED until resolved. Inspect the evidence\n"+
+						"            directory and flight_recorder.signing_key_path.\n", initErr)
+				}
 				// receipt.NewEmitter returns nil when no signing key is
 				// configured. Receipts must be signed - there is no
 				// "unsigned receipt" mode - so report the operator-facing

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -449,13 +449,29 @@ func NewServer(opts ServerOpts) (*Server, error) {
 			ConfigHash: cfg.Hash(),
 			Principal:  "local",
 			Actor:      "pipelock",
+			Metrics:    m,
 		})
 		if s.receiptEmitter != nil {
 			proxyOpts = append(proxyOpts, proxy.WithReceiptEmitter(s.receiptEmitter))
 			if cfg.FlightRecorder.SigningKeyPath != "" {
 				proxyOpts = append(proxyOpts, proxy.WithReceiptKeyPath(cfg.FlightRecorder.SigningKeyPath))
 			}
-			_, _ = fmt.Fprintf(opts.Stderr, "  Receipts: enabled (action receipts signed)\n")
+			// Loud, one-time startup signal when the chain could not be
+			// resumed. Without this an init failure was only an error log on
+			// each Emit (to a formerly root-only file), silent to operators.
+			// A non-nil InitError means every Emit will fail until resolved,
+			// so name the cause and the remediation here.
+			if initErr := s.receiptEmitter.InitError(); initErr != nil {
+				_, _ = fmt.Fprintf(opts.Stderr,
+					"  Receipts: ERROR - chain could not be resumed: %v\n"+
+						"            Receipt emission is DISABLED until resolved. If the flight-recorder\n"+
+						"            signing key was rotated, the prior chain is sealed under the old key;\n"+
+						"            a corrupt or tampered evidence tail fails closed. Inspect the evidence\n"+
+						"            directory and the configured signing_key_path.\n",
+					initErr)
+			} else {
+				_, _ = fmt.Fprintf(opts.Stderr, "  Receipts: enabled (action receipts signed)\n")
+			}
 
 			// v2 proxy_decision emitter: dual-emitted alongside the v1 action
 			// receipt on every proxy decision, signed with the same key and

--- a/internal/cli/signing/receipt.go
+++ b/internal/cli/signing/receipt.go
@@ -20,7 +20,7 @@ import (
 
 // VerifyReceiptCmd returns the "verify-receipt" cobra command.
 func VerifyReceiptCmd() *cobra.Command {
-	var expectedKey string
+	var expectedKeys []string
 	var chainDir string
 	var sessionID string
 
@@ -34,42 +34,57 @@ For a flight recorder JSONL file: extracts all receipts and verifies the
 full hash chain (prev_hash linkage, seq continuity, signatures). For a
 multi-file chain spanning restarts or rotations, pass --chain DIR.
 
+Signing-key rotation: a chain that rotated its signing key splits into
+segments. Each segment's key must be trusted. Pass --key once per trusted
+key to verify across a rotation; the offending key is named if a segment is
+signed by an untrusted key. With no --key, the first segment's key is trusted
+on first use and any rotation is flagged for you to confirm.
+
 Exit 0 = valid, exit 1 = invalid or malformed.
 
 Examples:
   pipelock verify-receipt receipt.json
   pipelock verify-receipt evidence-proxy-0.jsonl
   pipelock verify-receipt --chain /var/lib/pipelock/evidence
-  pipelock verify-receipt receipt.json --key 70b991eb...`,
+  pipelock verify-receipt receipt.json --key 70b991eb...
+  pipelock verify-receipt --chain DIR --key old.key --key new.key`,
 		Args: func(_ *cobra.Command, args []string) error {
 			return validateReceiptSourceArgs(args, chainDir)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
-			resolvedKey, err := resolveExpectedKeyHex(expectedKey)
+			trustedKeys, err := resolveExpectedKeyHexes(expectedKeys)
 			if err != nil {
 				return fmt.Errorf("loading public key: %w", err)
 			}
 			if chainDir != "" {
-				return verifyChainFromSessionDir(out, chainDir, sessionID, resolvedKey)
+				return verifyChainFromSessionDir(out, chainDir, sessionID, trustedKeys)
 			}
 
 			path := args[0]
 
 			// JSONL files: extract receipts and verify the full chain.
 			if strings.HasSuffix(path, ".jsonl") {
-				return verifyChainFromFile(out, path, resolvedKey)
+				return verifyChainFromFile(out, path, trustedKeys)
 			}
 
-			// Single receipt JSON file.
-			return verifySingleReceipt(out, path, resolvedKey)
+			// Single receipt JSON file: a lone receipt has no chain to walk,
+			// so it verifies against the first supplied key (or its own).
+			return verifySingleReceipt(out, path, firstOrEmpty(trustedKeys))
 		},
 	}
 
-	cmd.Flags().StringVar(&expectedKey, "key", "", "expected signer public key (hex or file path)")
+	cmd.Flags().StringArrayVar(&expectedKeys, "key", nil, "trusted signer public key (hex or file path); repeat for rotated chains")
 	cmd.Flags().StringVar(&chainDir, "chain", "", "verify the full receipt chain from an evidence directory")
 	cmd.Flags().StringVar(&sessionID, "session", "proxy", "receipt chain session ID inside the evidence directory")
 	return cmd
+}
+
+func firstOrEmpty(keys []string) string {
+	if len(keys) == 0 {
+		return ""
+	}
+	return keys[0]
 }
 
 func verifySingleReceipt(out io.Writer, path, expectedKey string) error {
@@ -93,34 +108,38 @@ func verifySingleReceipt(out io.Writer, path, expectedKey string) error {
 	return nil
 }
 
-func verifyChainFromFile(out io.Writer, path, expectedKey string) error {
+func verifyChainFromFile(out io.Writer, path string, trustedKeys []string) error {
 	receipts, err := receipt.ExtractReceipts(path)
 	if err != nil {
 		return fmt.Errorf("extracting receipts: %w", err)
 	}
-	return verifyChain(out, path, receipts, expectedKey)
+	return verifyChain(out, path, receipts, trustedKeys)
 }
 
-func verifyChainFromSessionDir(out io.Writer, dir, sessionID, expectedKey string) error {
+func verifyChainFromSessionDir(out io.Writer, dir, sessionID string, trustedKeys []string) error {
 	receipts, err := receipt.ExtractReceiptsFromSessionDir(dir, sessionID)
 	if err != nil {
 		return fmt.Errorf("extracting session receipts: %w", err)
 	}
 	label := fmt.Sprintf("%s (session %s)", dir, sessionID)
-	return verifyChain(out, label, receipts, expectedKey)
+	return verifyChain(out, label, receipts, trustedKeys)
 }
 
-func verifyChain(out io.Writer, label string, receipts []receipt.Receipt, expectedKey string) error {
+func verifyChain(out io.Writer, label string, receipts []receipt.Receipt, trustedKeys []string) error {
 	if len(receipts) == 0 {
 		_, _ = fmt.Fprintf(out, "No receipts found in %s\n", label)
 		return fmt.Errorf("no receipts in %s", label)
 	}
 
-	result := receipt.VerifyChain(receipts, expectedKey)
+	result := receipt.VerifyChainTrusted(receipts, trustedKeys)
 	if !result.Valid {
 		_, _ = fmt.Fprintf(out, "CHAIN BROKEN: %s\n", label)
 		_, _ = fmt.Fprintf(out, "  Error:    %s\n", result.Error)
 		_, _ = fmt.Fprintf(out, "  Broke at: seq %d\n", result.BrokenAtSeq)
+		if result.UntrustedSignerKey != "" {
+			_, _ = fmt.Fprintf(out, "  Untrusted signer key: %s\n", result.UntrustedSignerKey)
+			_, _ = fmt.Fprintf(out, "  If this is a legitimate key rotation, re-run with --key for each trusted key.\n")
+		}
 		return fmt.Errorf("chain verification failed at seq %d: %s", result.BrokenAtSeq, result.Error)
 	}
 
@@ -130,7 +149,36 @@ func verifyChain(out io.Writer, label string, receipts []receipt.Receipt, expect
 	_, _ = fmt.Fprintf(out, "  Root hash: %s\n", result.RootHash)
 	_, _ = fmt.Fprintf(out, "  Start:     %s\n", result.StartTime.Format("2006-01-02T15:04:05Z"))
 	_, _ = fmt.Fprintf(out, "  End:       %s\n", result.EndTime.Format("2006-01-02T15:04:05Z"))
+	printSignerKeys(out, result)
 	return nil
+}
+
+// printSignerKeys reports the per-segment signer keys for a verified chain. When
+// the chain rotated keys, this is the operator's confirmation surface: the
+// verifier proved the segments are cryptographically linked via valid
+// KeyTransition boundaries, but ONLY the operator knows whether every key is one
+// of theirs. A chain that verifies but lists an unexpected key is a signal to
+// investigate, not a pass.
+func printSignerKeys(out io.Writer, result receipt.ChainResult) {
+	if len(result.SignerKeys) <= 1 {
+		if len(result.SignerKeys) == 1 {
+			_, _ = fmt.Fprintf(out, "  Signer:    %s\n", result.SignerKeys[0])
+		}
+		return
+	}
+	_, _ = fmt.Fprintf(out, "  Segments:  %d (signing key rotated)\n", len(result.Segments))
+	_, _ = fmt.Fprintf(out, "  CONFIRM every signer key below is one of yours:\n")
+	for i, seg := range result.Segments {
+		_, _ = fmt.Fprintf(out, "    segment %d: seq %d-%d  signer %s%s\n",
+			i, seg.FirstSeq, seg.FinalSeq, seg.SignerKey, boundaryNote(seg.Boundary))
+	}
+}
+
+func boundaryNote(boundary bool) string {
+	if boundary {
+		return "  (key rotation)"
+	}
+	return ""
 }
 
 func printReceiptDetails(out io.Writer, r receipt.Receipt) {
@@ -164,7 +212,7 @@ func printReceiptDetails(out io.Writer, r receipt.Receipt) {
 
 // TranscriptRootCmd returns the "transcript-root" cobra command.
 func TranscriptRootCmd() *cobra.Command {
-	var expectedKey string
+	var expectedKeys []string
 	var chainDir string
 	var sessionID string
 
@@ -176,21 +224,26 @@ extracts all action receipts, verifies the hash chain, and prints the
 transcript root.
 
 The transcript root is the hash of the final receipt in the chain,
-serving as a tamper-evident summary of the entire session.
+serving as a tamper-evident summary of the entire session. For a chain that
+rotated its signing key, pass --key once per trusted segment key.
 
 Examples:
   pipelock transcript-root --chain /var/lib/pipelock/evidence --key pub.key
-  pipelock transcript-root evidence-proxy-0.jsonl --key 70b991eb...`,
+  pipelock transcript-root evidence-proxy-0.jsonl --key 70b991eb...
+  pipelock transcript-root --chain DIR --key old.key --key new.key`,
 		Args: func(_ *cobra.Command, args []string) error {
 			return validateReceiptSourceArgs(args, chainDir)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if expectedKey == "" {
+			if len(expectedKeys) == 0 {
 				return fmt.Errorf("--key is required: transcript roots must be verified against a trusted signer key")
 			}
-			resolvedKey, err := resolveExpectedKeyHex(expectedKey)
+			resolvedKeys, err := resolveExpectedKeyHexes(expectedKeys)
 			if err != nil {
 				return fmt.Errorf("loading public key: %w", err)
+			}
+			if len(resolvedKeys) == 0 {
+				return fmt.Errorf("--key is required: transcript roots must be verified against a trusted signer key")
 			}
 			out := cmd.OutOrStdout()
 			var label string
@@ -220,7 +273,7 @@ Examples:
 				return fmt.Errorf("no receipts found in %s", label)
 			}
 
-			root, err := receipt.ComputeTranscriptRoot(sessionID, receipts, resolvedKey)
+			root, err := receipt.ComputeTranscriptRootTrusted(sessionID, receipts, resolvedKeys)
 			if err != nil {
 				return fmt.Errorf("computing transcript root: %w", err)
 			}
@@ -236,7 +289,7 @@ Examples:
 		},
 	}
 
-	cmd.Flags().StringVar(&expectedKey, "key", "", "expected signer public key (hex or file path)")
+	cmd.Flags().StringArrayVar(&expectedKeys, "key", nil, "trusted signer public key (hex or file path); repeat for rotated chains")
 	cmd.Flags().StringVar(&chainDir, "chain", "", "read the receipt chain from an evidence directory")
 	cmd.Flags().StringVar(&sessionID, "session", "proxy", "receipt chain session ID inside the evidence directory")
 	return cmd
@@ -251,6 +304,23 @@ func resolveExpectedKeyHex(expectedKey string) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(key), nil
+}
+
+// resolveExpectedKeyHexes resolves each --key value (hex or file path) to a hex
+// signer key. Empty/blank entries are skipped. The order is preserved so the
+// first entry can serve as the single-receipt pin.
+func resolveExpectedKeyHexes(keys []string) ([]string, error) {
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		resolved, err := resolveExpectedKeyHex(k)
+		if err != nil {
+			return nil, err
+		}
+		if resolved != "" {
+			out = append(out, resolved)
+		}
+	}
+	return out, nil
 }
 
 func validateReceiptSourceArgs(args []string, chainDir string) error {

--- a/internal/cli/signing/receipt.go
+++ b/internal/cli/signing/receipt.go
@@ -57,6 +57,9 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("loading public key: %w", err)
 			}
+			if len(expectedKeys) > 0 && len(trustedKeys) == 0 {
+				return fmt.Errorf("--key was provided but no valid signer keys were resolved")
+			}
 			if chainDir != "" {
 				return verifyChainFromSessionDir(out, chainDir, sessionID, trustedKeys)
 			}

--- a/internal/cli/signing/receipt_rotation_test.go
+++ b/internal/cli/signing/receipt_rotation_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+// buildRotatedChainJSONL emits `aN` receipts under key A, then reopens the same
+// evidence dir with key B (which triggers the emitter's rotation -> new segment)
+// and emits `bN` more. Returns the evidence dir and both public keys.
+func buildRotatedChainJSONL(t *testing.T, aN, bN int) (dir string, pubA, pubB ed25519.PublicKey) {
+	t.Helper()
+	dir = t.TempDir()
+
+	pa, privA, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey A: %v", err)
+	}
+	pb, privB, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey B: %v", err)
+	}
+
+	emitInto(t, dir, privA, aN, 0)
+	emitInto(t, dir, privB, bN, aN)
+	return dir, pa, pb
+}
+
+func emitInto(t *testing.T, dir string, priv ed25519.PrivateKey, count, startIdx int) {
+	t.Helper()
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:  rec,
+		PrivKey:   priv,
+		Principal: "test",
+		Actor:     "test",
+	})
+	if err := emitter.InitError(); err != nil {
+		t.Fatalf("emitter init error: %v", err)
+	}
+	for i := range count {
+		if err := emitter.Emit(receipt.EmitOpts{
+			ActionID:  receipt.NewActionID(),
+			Verdict:   "allow",
+			Transport: "fetch",
+			Method:    "GET",
+			Target:    fmt.Sprintf("https://example.com/%d", startIdx+i),
+		}); err != nil {
+			t.Fatalf("Emit %d: %v", i, err)
+		}
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+}
+
+func TestVerifyReceiptCmd_RotatedChainNeedsBothKeys(t *testing.T) {
+	dir, pubA, pubB := buildRotatedChainJSONL(t, 3, 2)
+	keyA := hex.EncodeToString(pubA)
+	keyB := hex.EncodeToString(pubB)
+
+	// Only key A trusted: the rotation to B must be flagged.
+	var buf bytes.Buffer
+	cmd := VerifyReceiptCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--chain", dir, "--key", keyA})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected failure: rotation to an untrusted key must be flagged")
+	}
+	if !strings.Contains(buf.String(), "Untrusted signer key: "+keyB) {
+		t.Errorf("expected untrusted key %s in output, got: %s", keyB, buf.String())
+	}
+
+	// Both keys trusted: verifies end-to-end across the rotation.
+	buf.Reset()
+	cmd = VerifyReceiptCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--chain", dir, "--key", keyA, "--key", keyB})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("rotated chain with both keys trusted must verify: %v\n%s", err, buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "CHAIN VALID") {
+		t.Errorf("expected CHAIN VALID, got: %s", out)
+	}
+	if !strings.Contains(out, "signing key rotated") {
+		t.Errorf("expected rotation note, got: %s", out)
+	}
+	if !strings.Contains(out, keyA) || !strings.Contains(out, keyB) {
+		t.Errorf("expected both segment keys reported, got: %s", out)
+	}
+}
+
+func TestVerifyReceiptCmd_RotatedChainTrustOnFirstUseFlags(t *testing.T) {
+	dir, _, pubB := buildRotatedChainJSONL(t, 2, 2)
+	keyB := hex.EncodeToString(pubB)
+
+	var buf bytes.Buffer
+	cmd := VerifyReceiptCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	// No --key: trust-on-first-use adopts A; rotation to B must be flagged.
+	cmd.SetArgs([]string{"--chain", dir})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected failure: trust-on-first-use must flag the rotation")
+	}
+	if !strings.Contains(buf.String(), keyB) {
+		t.Errorf("expected the rotated-to key in output, got: %s", buf.String())
+	}
+}
+
+func TestTranscriptRootCmd_RotatedChainNeedsBothKeys(t *testing.T) {
+	dir, pubA, pubB := buildRotatedChainJSONL(t, 2, 3)
+	keyA := hex.EncodeToString(pubA)
+	keyB := hex.EncodeToString(pubB)
+
+	// Both keys: produces a transcript root over the full rotated chain.
+	var buf bytes.Buffer
+	cmd := TranscriptRootCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--chain", dir, "--key", keyA, "--key", keyB})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("transcript root over rotated chain must succeed with both keys: %v\n%s", err, buf.String())
+	}
+	if !strings.Contains(buf.String(), "Receipt count: 5") {
+		t.Errorf("expected 5 receipts in transcript root, got: %s", buf.String())
+	}
+
+	// Only key A: must fail (rotation key untrusted).
+	buf.Reset()
+	cmd = TranscriptRootCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--chain", dir, "--key", keyA})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("transcript root must fail when a segment key is untrusted")
+	}
+}

--- a/internal/cli/signing/receipt_rotation_test.go
+++ b/internal/cli/signing/receipt_rotation_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -61,7 +62,7 @@ func emitInto(t *testing.T, dir string, priv ed25519.PrivateKey, count, startIdx
 			ActionID:  receipt.NewActionID(),
 			Verdict:   "allow",
 			Transport: "fetch",
-			Method:    "GET",
+			Method:    http.MethodGet,
 			Target:    fmt.Sprintf("https://example.com/%d", startIdx+i),
 		}); err != nil {
 			t.Fatalf("Emit %d: %v", i, err)
@@ -69,6 +70,23 @@ func emitInto(t *testing.T, dir string, priv ed25519.PrivateKey, count, startIdx
 	}
 	if err := rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)
+	}
+}
+
+func TestVerifyReceiptCmd_BlankKeyDoesNotDowngradeToTOFU(t *testing.T) {
+	dir, _, _ := buildRotatedChainJSONL(t, 2, 2)
+
+	var buf bytes.Buffer
+	cmd := VerifyReceiptCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--chain", dir, "--key", " "})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected blank --key to fail instead of falling back to trust-on-first-use")
+	}
+	if !strings.Contains(err.Error(), "--key was provided but no valid signer keys were resolved") {
+		t.Fatalf("err = %v, want explicit blank-key rejection", err)
 	}
 }
 

--- a/internal/cli/signing/receipt_test.go
+++ b/internal/cli/signing/receipt_test.go
@@ -628,7 +628,7 @@ func TestVerifyChainFromFile_ValidChain(t *testing.T) {
 	keyHex := hex.EncodeToString(pubKey)
 
 	var buf bytes.Buffer
-	err := verifyChainFromFile(&buf, path, keyHex)
+	err := verifyChainFromFile(&buf, path, []string{keyHex})
 	if err != nil {
 		t.Fatalf("verifyChainFromFile: %v", err)
 	}
@@ -653,7 +653,7 @@ func TestVerifyChainFromFile_BadSignature(t *testing.T) {
 	wrongKeyHex := hex.EncodeToString(otherPub)
 
 	var buf bytes.Buffer
-	err = verifyChainFromFile(&buf, path, wrongKeyHex)
+	err = verifyChainFromFile(&buf, path, []string{wrongKeyHex})
 	if err == nil {
 		t.Fatal("expected error for wrong key")
 	}
@@ -672,7 +672,7 @@ func TestVerifyChainFromFile_EmptyFile(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := verifyChainFromFile(&buf, emptyPath, "")
+	err := verifyChainFromFile(&buf, emptyPath, nil)
 	if err == nil {
 		t.Fatal("expected error for empty file")
 	}
@@ -691,7 +691,7 @@ func TestVerifyChain_ValidReceiptsNoKey(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err = verifyChain(&buf, "test-chain", receipts, "")
+	err = verifyChain(&buf, "test-chain", receipts, nil)
 	if err != nil {
 		t.Fatalf("verifyChain: %v", err)
 	}
@@ -707,7 +707,7 @@ func TestVerifyChain_EmptySlice(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	err := verifyChain(&buf, "empty-chain", nil, "")
+	err := verifyChain(&buf, "empty-chain", nil, nil)
 	if err == nil {
 		t.Fatal("expected error for empty receipt slice")
 	}
@@ -720,7 +720,7 @@ func TestVerifyChainFromFile_NonexistentFile(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	err := verifyChainFromFile(&buf, "/nonexistent/path/receipt.jsonl", "")
+	err := verifyChainFromFile(&buf, "/nonexistent/path/receipt.jsonl", nil)
 	if err == nil {
 		t.Fatal("expected error for nonexistent file")
 	}
@@ -745,7 +745,7 @@ func TestVerifyChain_WrongKeyBreaksChain(t *testing.T) {
 	wrongKeyHex := hex.EncodeToString(otherPub)
 
 	var buf bytes.Buffer
-	err = verifyChain(&buf, "wrong-key-chain", receipts, wrongKeyHex)
+	err = verifyChain(&buf, "wrong-key-chain", receipts, []string{wrongKeyHex})
 	if err == nil {
 		t.Fatal("expected error for wrong key")
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -133,6 +133,9 @@ type Metrics struct {
 	// Mediation envelope verification (envelope.go).
 	envelopeVerifyTotal *prometheus.CounterVec
 
+	// Signed action-receipt emission (receipt.go).
+	receiptEmitFailures *prometheus.CounterVec
+
 	// Stats endpoint state (stats_handler.go).
 	mu                     sync.Mutex
 	startTime              time.Time
@@ -195,6 +198,7 @@ func New() *Metrics {
 	m.registerConductorMetrics(reg)
 	m.registerLearnMetrics(reg)
 	m.registerEnvelopeMetrics(reg)
+	m.registerReceiptMetrics(reg)
 
 	// Built-in Go runtime + process collectors. These expose
 	// go_memstats_heap_alloc_bytes, go_goroutines, process_resident_memory_bytes,

--- a/internal/metrics/receipt.go
+++ b/internal/metrics/receipt.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// receiptEmitFailureReasons is the closed label domain for
+// pipelock_receipt_emit_failures_total. Bounding the label set prevents
+// unbounded cardinality from arbitrary reason strings.
+var receiptEmitFailureReasons = map[string]bool{
+	"chain_init": true,
+	"sign":       true,
+	"hash":       true,
+	"marshal":    true,
+	"record":     true,
+	"sealed":     true,
+}
+
+func (m *Metrics) registerReceiptMetrics(reg *prometheus.Registry) {
+	m.receiptEmitFailures = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "pipelock",
+		Name:      "receipt_emit_failures_total",
+		Help:      "Total signed action-receipt emission failures, labeled by reason. A non-zero rate means receipts are not being recorded; investigate the flight-recorder signing key and chain state.",
+	}, []string{"reason"})
+
+	reg.MustRegister(m.receiptEmitFailures)
+}
+
+// RecordEmitFailure increments the receipt-emit-failure counter for a
+// closed-domain reason label. Implements receipt.MetricsSink. Non-canonical
+// reasons are mapped to "unknown" to avoid unbounded cardinality while still
+// surfacing the failure.
+func (m *Metrics) RecordEmitFailure(reason string) {
+	if m == nil {
+		return
+	}
+	if !receiptEmitFailureReasons[reason] {
+		reason = "unknown"
+	}
+	m.receiptEmitFailures.WithLabelValues(reason).Inc()
+}

--- a/internal/metrics/receipt_test.go
+++ b/internal/metrics/receipt_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecordEmitFailure_CanonicalReasons(t *testing.T) {
+	m := New()
+	m.RecordEmitFailure("chain_init")
+	m.RecordEmitFailure("chain_init")
+	m.RecordEmitFailure("record")
+
+	if got := testutil.ToFloat64(m.receiptEmitFailures.WithLabelValues("chain_init")); got != 2 {
+		t.Errorf("chain_init = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(m.receiptEmitFailures.WithLabelValues("record")); got != 1 {
+		t.Errorf("record = %v, want 1", got)
+	}
+}
+
+func TestRecordEmitFailure_NonCanonicalMappedToUnknown(t *testing.T) {
+	m := New()
+	m.RecordEmitFailure("arbitrary attacker controlled text")
+	m.RecordEmitFailure("another one")
+
+	if got := testutil.ToFloat64(m.receiptEmitFailures.WithLabelValues("unknown")); got != 2 {
+		t.Errorf("unknown = %v, want 2 (non-canonical reasons collapsed)", got)
+	}
+}
+
+func TestRecordEmitFailure_NilSafe(t *testing.T) {
+	var m *Metrics
+	m.RecordEmitFailure("chain_init") // must not panic
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1054,6 +1054,7 @@ func (p *Proxy) buildReceiptEmitter(cfg *config.Config) (receiptEmitterStage, er
 			ConfigHash: cfg.Hash(),
 			Principal:  "local",
 			Actor:      "pipelock",
+			Metrics:    p.metrics,
 		}),
 		v2: proxydecision.NewEmitter(proxydecision.EmitterConfig{
 			Recorder:       p.recorder,

--- a/internal/receipt/action.go
+++ b/internal/receipt/action.go
@@ -168,6 +168,17 @@ type ActionRecord struct {
 	ChainPrevHash string `json:"chain_prev_hash"`
 	ChainSeq      uint64 `json:"chain_seq"`
 
+	// KeyTransition is present ONLY on the first receipt of a new chain
+	// segment that begins after a legitimate signing-key rotation. It binds
+	// the new segment to the prior segment's tail (prior signer key, final
+	// seq, and tail hash) so the segment boundary is auditable and the
+	// transition is provable from the evidence file alone. Absent (nil) on
+	// every other receipt. See receipt/emitter.go resumeChain for the trust
+	// model: the new segment's ChainPrevHash equals the prior tail's hash,
+	// and the recorder's outer hash chain remains the cross-segment
+	// tamper-evidence layer.
+	KeyTransition *KeyTransition `json:"key_transition,omitempty"`
+
 	// Jurisdictional fields - present in schema for forward compatibility.
 	// Empty in v1; populated when jurisdiction engine ships.
 	Venue              string   `json:"venue,omitempty"`
@@ -176,6 +187,26 @@ type ActionRecord struct {
 	RemedyClass        string   `json:"remedy_class,omitempty"`
 	ContestationWindow string   `json:"contestation_window,omitempty"`
 	PrecedentRefs      []string `json:"precedent_refs,omitempty"`
+}
+
+// KeyTransition records the boundary between two chain segments signed by
+// different keys. It is stamped on the first receipt of the new segment after a
+// legitimate signing-key rotation, binding that segment to the prior segment's
+// tail. A verifier walking the segments can confirm the new segment was
+// intentionally anchored to the prior tail (PriorChainHash) rather than forked.
+// The signing key itself rotates as an operator action; this marker makes the
+// rotation visible in-band, while the recorder's outer hash chain provides the
+// authoritative cross-segment tamper-evidence.
+type KeyTransition struct {
+	// PriorSignerKey is the hex-encoded public key that signed the prior
+	// segment's tail receipt.
+	PriorSignerKey string `json:"prior_signer_key"`
+	// PriorChainSeq is the chain_seq of the prior segment's tail receipt.
+	PriorChainSeq uint64 `json:"prior_chain_seq"`
+	// PriorChainHash is the receipt hash of the prior segment's tail. This
+	// equals the new segment's first-receipt ChainPrevHash, linking the two
+	// segments.
+	PriorChainHash string `json:"prior_chain_hash"`
 }
 
 // RedactionSummary captures the request-side redaction outcome for a mediated

--- a/internal/receipt/chain.go
+++ b/internal/receipt/chain.go
@@ -117,9 +117,8 @@ func VerifyChain(receipts []Receipt, expectedKeyHex string) ChainResult {
 // Structural rules (independent of trust), all fail-closed:
 //
 //   - The genesis (first) receipt must have chain_prev_hash == genesis with no
-//     KeyTransition marker, UNLESS it is itself a segment genesis carrying a
-//     marker (verifying one rotated segment in isolation against its embedded
-//     anchor - the marker's PriorChainHash).
+//     KeyTransition marker. A rotated segment cannot be verified as a complete
+//     chain in isolation because its embedded marker is not the actual prior tail.
 //   - A new segment mid-chain is introduced ONLY by a seq-0 receipt carrying a
 //     marker whose PriorChainHash equals both this receipt's chain_prev_hash and
 //     the actual prior tail hash, whose PriorSignerKey equals the prior
@@ -195,8 +194,8 @@ func (v *chainVerifier) run(receipts []Receipt) ChainResult {
 	}
 }
 
-// startFirstSegment establishes the anchor and key for the genesis (or
-// isolated) segment. Returns ok=false with a failing result on violation.
+// startFirstSegment establishes the anchor and key for the genesis segment.
+// Returns ok=false with a failing result on violation.
 func (v *chainVerifier) startFirstSegment(r Receipt) (ChainResult, bool) {
 	marker := r.ActionRecord.KeyTransition
 	// Trust-on-first-use: when no trusted set was supplied, adopt the first
@@ -212,17 +211,11 @@ func (v *chainVerifier) startFirstSegment(r Receipt) (ChainResult, bool) {
 
 	switch {
 	case marker != nil:
-		// Single rotated segment verified in isolation against its embedded
-		// anchor. seq must be 0 (segment genesis) and prev_hash must equal the
-		// marker's PriorChainHash.
-		if r.ActionRecord.ChainSeq != 0 {
-			return v.brokenAt(r, "key_transition marker on a non-genesis receipt (seq != 0)"), false
-		}
-		if r.ActionRecord.ChainPrevHash != marker.PriorChainHash {
-			return v.brokenAt(r, "segment-genesis chain_prev_hash does not match key_transition prior_chain_hash"), false
-		}
-		v.prevHash = marker.PriorChainHash
-		v.beginSegment(r, true)
+		// A KeyTransition marker is continuity metadata for a boundary to a
+		// prior tail that must be present in the chain being verified. Accepting
+		// a marker on the first receipt would allow deletion/truncation of the
+		// prior segment while still returning CHAIN VALID for the suffix.
+		return v.brokenAt(r, "chain starts at a key_transition segment without the prior segment"), false
 	default:
 		// Ordinary genesis: prev_hash must be the genesis sentinel.
 		v.prevHash = GenesisHash

--- a/internal/receipt/chain.go
+++ b/internal/receipt/chain.go
@@ -46,75 +46,324 @@ type ChainResult struct {
 	EndTime      time.Time
 	Error        string // empty if valid
 	BrokenAtSeq  uint64 // set when chain breaks
+
+	// SignerKeys is the ordered, de-duplicated set of signer public keys
+	// (hex) observed across the chain's segments, in segment order. A
+	// single-key chain has one entry. A rotated chain has one entry per
+	// segment. Always populated, even on failure, so the operator can see
+	// which keys appeared.
+	SignerKeys []string
+	// Segments describes each contiguous single-key run in the chain.
+	Segments []ChainSegment
+	// UntrustedSignerKey is set (and Valid=false) when a segment is signed by
+	// a key that is not in the supplied trusted set (trust-on-first-use mode:
+	// not equal to the genesis key). It names the offending key so the
+	// operator can decide whether it is a legitimate rotation to add to the
+	// trusted set or an attacker-introduced key to investigate.
+	UntrustedSignerKey string
 }
 
-// VerifyChain verifies hash-chain integrity of a sequence of receipts.
-// Receipts must be in chain order (ascending chain_seq).
-// Checks: signature valid, chain_seq increments by 1, chain_prev_hash
-// matches previous receipt's hash, first receipt has "genesis" prev_hash.
+// ChainSegment summarizes one single-key run within a (possibly rotated) chain.
+type ChainSegment struct {
+	SignerKey string
+	FirstSeq  uint64
+	FinalSeq  uint64
+	Count     uint64
+	// Boundary is true when this segment began at a KeyTransition (i.e. it is
+	// not the genesis segment). The genesis segment has Boundary=false.
+	Boundary bool
+}
+
+// VerifyChain verifies hash-chain integrity of a sequence of receipts, with
+// support for signing-key rotation boundaries. expectedKeyHex is the single
+// trusted signer key; pass "" for trust-on-first-use (the genesis segment's
+// key becomes the sole trusted key). It is a thin wrapper over
+// VerifyChainTrusted; see that function for the full trust model.
 func VerifyChain(receipts []Receipt, expectedKeyHex string) ChainResult {
+	if expectedKeyHex == "" {
+		return VerifyChainTrusted(receipts, nil)
+	}
+	return VerifyChainTrusted(receipts, []string{expectedKeyHex})
+}
+
+// VerifyChainTrusted verifies hash-chain integrity across signing-key rotation
+// boundaries against an explicit set of trusted signer keys (hex).
+//
+// Receipts must be in chain order. Within a segment: signatures verify under
+// that segment's key, chain_seq increments by 1 from the segment's baseline,
+// and chain_prev_hash matches the previous receipt's hash.
+//
+// TRUST MODEL (the crux). A signing-key rotation opens a new chain segment
+// whose genesis receipt carries a KeyTransition marker (prior key + seq + tail
+// hash) and whose chain_prev_hash equals the prior tail hash. The marker is
+// signed by the NEW key, so it proves continuity (the boundary references the
+// real prior tail and is internally consistent) but it does NOT prove the
+// holder of the OLD key authorized the rotation - an attacker with write access
+// to the evidence file can read the real prior tail and fabricate a consistent
+// marker, then sign a new segment with their own key. Therefore the marker is
+// continuity/audit metadata, NOT trust delegation. Trust comes ONLY from the
+// caller-supplied trusted key set:
+//
+//   - trustedKeys non-empty: EVERY segment must be signed by a key in the set.
+//     A segment signed by any other key fails (UntrustedSignerKey is set),
+//     regardless of how well-formed its KeyTransition marker is. This is how a
+//     forged attacker-key segment is rejected: the attacker key is not in the
+//     operator's trusted set.
+//   - trustedKeys empty (trust-on-first-use): the genesis segment's key becomes
+//     the sole trusted key. Any rotation to a DIFFERENT key fails with
+//     UntrustedSignerKey set - the operator must re-run with the new key in the
+//     trusted set to confirm it is theirs. A single-key chain still verifies.
+//
+// Structural rules (independent of trust), all fail-closed:
+//
+//   - The genesis (first) receipt must have chain_prev_hash == genesis with no
+//     KeyTransition marker, UNLESS it is itself a segment genesis carrying a
+//     marker (verifying one rotated segment in isolation against its embedded
+//     anchor - the marker's PriorChainHash).
+//   - A new segment mid-chain is introduced ONLY by a seq-0 receipt carrying a
+//     marker whose PriorChainHash equals both this receipt's chain_prev_hash and
+//     the actual prior tail hash, whose PriorSignerKey equals the prior
+//     segment's key, and whose PriorChainSeq equals the prior segment's final
+//     seq. A tampered prior tail breaks this (hash mismatch).
+//   - A KeyTransition marker on a non-seq-0 receipt, or an ordinary seq-0
+//     receipt mid-chain (no marker, prev_hash != genesis), is rejected. This
+//     preserves the genesis check for ordinary receipts (no weakening).
+func VerifyChainTrusted(receipts []Receipt, trustedKeys []string) ChainResult {
 	if len(receipts) == 0 {
 		return ChainResult{Valid: true}
 	}
 
-	// When no key is pinned, enforce signer consistency: all receipts
-	// must share the same signer_key. Prevents forged chains where an
-	// attacker generates receipts with their own key.
-	if expectedKeyHex == "" && len(receipts) > 0 {
-		expectedKeyHex = receipts[0].SignerKey
+	trusted := make(map[string]struct{}, len(trustedKeys))
+	for _, k := range trustedKeys {
+		if k != "" {
+			trusted[k] = struct{}{}
+		}
+	}
+	v := &chainVerifier{trusted: trusted}
+	return v.run(receipts)
+}
+
+// chainVerifier carries the walking state for VerifyChain.
+type chainVerifier struct {
+	// trusted is the set of trusted signer keys. Empty means trust-on-first-
+	// use: the genesis key is adopted as the sole trusted key.
+	trusted map[string]struct{}
+
+	curKey     string // expected signer key for the current segment
+	segBaseSeq uint64 // chain_seq of the current segment's first receipt
+	prevHash   string // expected chain_prev_hash for the next receipt
+
+	signerKeys []string
+	segments   []ChainSegment
+	curSeg     *ChainSegment
+}
+
+func (v *chainVerifier) run(receipts []Receipt) ChainResult {
+	for i := range receipts {
+		r := receipts[i]
+		marker := r.ActionRecord.KeyTransition
+
+		if i == 0 {
+			if res, ok := v.startFirstSegment(r); !ok {
+				return res
+			}
+		} else if marker != nil {
+			if res, ok := v.startRotatedSegment(r, marker); !ok {
+				return res
+			}
+		} else if res, ok := v.checkContinuation(r); !ok {
+			return res
+		}
+
+		if res, ok := v.verifyReceipt(r, uint64(i)); !ok {
+			return res
+		}
 	}
 
-	prevHash := GenesisHash
-	for i, r := range receipts {
-		// Verify signature against pinned or first-receipt key
-		if err := VerifyWithKey(r, expectedKeyHex); err != nil {
-			return ChainResult{
-				Valid:       false,
-				BrokenAtSeq: r.ActionRecord.ChainSeq,
-				Error:       fmt.Sprintf("seq %d: signature: %v", r.ActionRecord.ChainSeq, err),
-			}
-		}
-
-		// Verify seq
-		expectedSeq := uint64(i)
-		if r.ActionRecord.ChainSeq != expectedSeq {
-			return ChainResult{
-				Valid:       false,
-				BrokenAtSeq: r.ActionRecord.ChainSeq,
-				Error:       fmt.Sprintf("seq gap: expected %d, got %d", expectedSeq, r.ActionRecord.ChainSeq),
-			}
-		}
-
-		// Verify prev_hash
-		if r.ActionRecord.ChainPrevHash != prevHash {
-			return ChainResult{
-				Valid:       false,
-				BrokenAtSeq: r.ActionRecord.ChainSeq,
-				Error:       fmt.Sprintf("seq %d: chain_prev_hash mismatch", r.ActionRecord.ChainSeq),
-			}
-		}
-
-		// Compute this receipt's hash for next iteration
-		hash, err := ReceiptHash(r)
-		if err != nil {
-			return ChainResult{
-				Valid:       false,
-				BrokenAtSeq: r.ActionRecord.ChainSeq,
-				Error:       fmt.Sprintf("seq %d: hash computation: %v", r.ActionRecord.ChainSeq, err),
-			}
-		}
-		prevHash = hash
-	}
-
+	v.closeSegment()
 	first := receipts[0].ActionRecord
 	last := receipts[len(receipts)-1].ActionRecord
 	return ChainResult{
 		Valid:        true,
 		ReceiptCount: uint64(len(receipts)),
 		FinalSeq:     last.ChainSeq,
-		RootHash:     prevHash,
+		RootHash:     v.prevHash,
 		StartTime:    first.Timestamp,
 		EndTime:      last.Timestamp,
+		SignerKeys:   v.signerKeys,
+		Segments:     v.segments,
+	}
+}
+
+// startFirstSegment establishes the anchor and key for the genesis (or
+// isolated) segment. Returns ok=false with a failing result on violation.
+func (v *chainVerifier) startFirstSegment(r Receipt) (ChainResult, bool) {
+	marker := r.ActionRecord.KeyTransition
+	// Trust-on-first-use: when no trusted set was supplied, adopt the first
+	// receipt's signer_key as the sole trusted key. Otherwise the first
+	// segment's key must already be in the trusted set.
+	if len(v.trusted) == 0 {
+		v.trusted = map[string]struct{}{r.SignerKey: {}}
+	}
+	if !v.keyTrusted(r.SignerKey) {
+		return v.untrusted(r), false
+	}
+	v.curKey = r.SignerKey
+
+	switch {
+	case marker != nil:
+		// Single rotated segment verified in isolation against its embedded
+		// anchor. seq must be 0 (segment genesis) and prev_hash must equal the
+		// marker's PriorChainHash.
+		if r.ActionRecord.ChainSeq != 0 {
+			return v.brokenAt(r, "key_transition marker on a non-genesis receipt (seq != 0)"), false
+		}
+		if r.ActionRecord.ChainPrevHash != marker.PriorChainHash {
+			return v.brokenAt(r, "segment-genesis chain_prev_hash does not match key_transition prior_chain_hash"), false
+		}
+		v.prevHash = marker.PriorChainHash
+		v.beginSegment(r, true)
+	default:
+		// Ordinary genesis: prev_hash must be the genesis sentinel.
+		v.prevHash = GenesisHash
+		v.beginSegment(r, false)
+	}
+	v.segBaseSeq = r.ActionRecord.ChainSeq
+	return ChainResult{}, true
+}
+
+// startRotatedSegment validates a KeyTransition boundary mid-chain and switches
+// the expected key to the new segment.
+func (v *chainVerifier) startRotatedSegment(r Receipt, marker *KeyTransition) (ChainResult, bool) {
+	// Markers are only valid at a segment genesis (seq 0).
+	if r.ActionRecord.ChainSeq != 0 {
+		return v.brokenAt(r, "key_transition marker on a non-genesis receipt (seq != 0)"), false
+	}
+	// The boundary must reference the actual prior tail: prev_hash, the
+	// marker's prior hash, and the real prior-tail hash must all agree, and
+	// the marker must name the prior segment's key and final seq. v.prevHash
+	// holds the prior tail's hash (set by verifyReceipt on the prior receipt).
+	if marker.PriorChainHash != v.prevHash {
+		return v.brokenAt(r, "key_transition prior_chain_hash does not match actual prior tail hash"), false
+	}
+	if r.ActionRecord.ChainPrevHash != v.prevHash {
+		return v.brokenAt(r, "segment-genesis chain_prev_hash does not match prior tail hash"), false
+	}
+	if marker.PriorSignerKey != v.curKey {
+		return v.brokenAt(r, "key_transition prior_signer_key does not match prior segment key"), false
+	}
+	if v.curSeg != nil && marker.PriorChainSeq != v.curSeg.FinalSeq {
+		return v.brokenAt(r, "key_transition prior_chain_seq does not match prior segment final seq"), false
+	}
+	// The boundary is structurally valid, but trust is NOT delegated by the
+	// marker (it is signed by the new key, which an attacker with write access
+	// could mint). The new segment's key must be in the operator's trusted set.
+	if !v.keyTrusted(r.SignerKey) {
+		v.beginSegment(r, true) // record the offending key in SignerKeys/Segments
+		return v.untrusted(r), false
+	}
+	v.closeSegment()
+	v.curKey = r.SignerKey
+	v.segBaseSeq = 0
+	v.beginSegment(r, true)
+	return ChainResult{}, true
+}
+
+func (v *chainVerifier) keyTrusted(key string) bool {
+	_, ok := v.trusted[key]
+	return ok
+}
+
+// untrusted records the offending key and returns a failing result that names
+// it, so the operator can decide whether it is a legitimate rotation (re-run
+// with the key added to the trusted set) or an attacker key.
+func (v *chainVerifier) untrusted(r Receipt) ChainResult {
+	res := v.brokenAt(r, fmt.Sprintf("signer key %s is not in the trusted set", r.SignerKey))
+	res.UntrustedSignerKey = r.SignerKey
+	res.SignerKeys = v.signerKeys
+	return res
+}
+
+// checkContinuation enforces seq + prev_hash continuity within a segment for a
+// non-boundary receipt.
+func (v *chainVerifier) checkContinuation(r Receipt) (ChainResult, bool) {
+	// An ordinary seq-0 receipt mid-chain (no marker) is a fork/duplicate, not
+	// a valid boundary - reject. This also preserves the genesis check: only
+	// the first receipt may legitimately be seq 0 without a marker.
+	if r.ActionRecord.ChainSeq == 0 {
+		return v.brokenAt(r, "unexpected seq 0 without a key_transition boundary"), false
+	}
+	return ChainResult{}, true
+}
+
+func (v *chainVerifier) verifyReceipt(r Receipt, index uint64) (ChainResult, bool) {
+	if err := VerifyWithKey(r, v.curKey); err != nil {
+		return v.brokenAt(r, fmt.Sprintf("signature: %v", err)), false
+	}
+
+	expectedSeq := v.segBaseSeq + (index - v.curSegStartIndex())
+	if r.ActionRecord.ChainSeq != expectedSeq {
+		return v.brokenAt(r, fmt.Sprintf("seq gap: expected %d, got %d", expectedSeq, r.ActionRecord.ChainSeq)), false
+	}
+
+	if r.ActionRecord.ChainPrevHash != v.prevHash {
+		return v.brokenAt(r, "chain_prev_hash mismatch"), false
+	}
+
+	hash, err := ReceiptHash(r)
+	if err != nil {
+		return v.brokenAt(r, fmt.Sprintf("hash computation: %v", err)), false
+	}
+	v.prevHash = hash
+	if v.curSeg != nil {
+		v.curSeg.FinalSeq = r.ActionRecord.ChainSeq
+		v.curSeg.Count++
+	}
+	return ChainResult{}, true
+}
+
+// curSegStartIndex returns the slice index at which the current segment began,
+// derived from segments already closed plus the count of the open segment.
+func (v *chainVerifier) curSegStartIndex() uint64 {
+	var n uint64
+	for _, s := range v.segments {
+		n += s.Count
+	}
+	return n
+}
+
+func (v *chainVerifier) beginSegment(r Receipt, boundary bool) {
+	v.curSeg = &ChainSegment{
+		SignerKey: r.SignerKey,
+		FirstSeq:  r.ActionRecord.ChainSeq,
+		FinalSeq:  r.ActionRecord.ChainSeq,
+		Boundary:  boundary,
+	}
+	v.appendSignerKey(r.SignerKey)
+}
+
+func (v *chainVerifier) closeSegment() {
+	if v.curSeg != nil {
+		v.segments = append(v.segments, *v.curSeg)
+		v.curSeg = nil
+	}
+}
+
+func (v *chainVerifier) appendSignerKey(key string) {
+	for _, k := range v.signerKeys {
+		if k == key {
+			return
+		}
+	}
+	v.signerKeys = append(v.signerKeys, key)
+}
+
+func (v *chainVerifier) brokenAt(r Receipt, msg string) ChainResult {
+	return ChainResult{
+		Valid:       false,
+		BrokenAtSeq: r.ActionRecord.ChainSeq,
+		Error:       fmt.Sprintf("seq %d: %s", r.ActionRecord.ChainSeq, msg),
+		SignerKeys:  v.signerKeys,
 	}
 }
 
@@ -172,16 +421,29 @@ func extractReceiptsFromEntries(entries []recorder.Entry) ([]Receipt, error) {
 	return receipts, nil
 }
 
-// ComputeTranscriptRoot builds a TranscriptRoot from a valid chain.
+// ComputeTranscriptRoot builds a TranscriptRoot from a valid single-key chain.
+// It requires a non-empty trust anchor. For rotated chains, use
+// ComputeTranscriptRootTrusted with every trusted segment key.
 func ComputeTranscriptRoot(sessionID string, receipts []Receipt, expectedKeyHex string) (TranscriptRoot, error) {
-	if len(receipts) == 0 {
-		return TranscriptRoot{}, fmt.Errorf("empty receipt chain")
-	}
 	if expectedKeyHex == "" {
 		return TranscriptRoot{}, fmt.Errorf("trust anchor required: pass expected signer key hex")
 	}
+	return ComputeTranscriptRootTrusted(sessionID, receipts, []string{expectedKeyHex})
+}
 
-	result := VerifyChain(receipts, expectedKeyHex)
+// ComputeTranscriptRootTrusted builds a TranscriptRoot from a chain verified
+// against an explicit trusted key set (supports rotation). At least one trusted
+// key is required - transcript roots must be verified against a trust anchor,
+// never trust-on-first-use.
+func ComputeTranscriptRootTrusted(sessionID string, receipts []Receipt, trustedKeys []string) (TranscriptRoot, error) {
+	if len(receipts) == 0 {
+		return TranscriptRoot{}, fmt.Errorf("empty receipt chain")
+	}
+	if len(trustedKeys) == 0 {
+		return TranscriptRoot{}, fmt.Errorf("trust anchor required: pass expected signer key hex")
+	}
+
+	result := VerifyChainTrusted(receipts, trustedKeys)
 	if !result.Valid {
 		return TranscriptRoot{}, fmt.Errorf("invalid chain: %s", result.Error)
 	}

--- a/internal/receipt/chain.go
+++ b/internal/receipt/chain.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
@@ -132,14 +133,36 @@ func VerifyChainTrusted(receipts []Receipt, trustedKeys []string) ChainResult {
 		return ChainResult{Valid: true}
 	}
 
-	trusted := make(map[string]struct{}, len(trustedKeys))
-	for _, k := range trustedKeys {
-		if k != "" {
-			trusted[k] = struct{}{}
+	normalizedKeys, err := normalizeTrustedKeys(trustedKeys)
+	if err != nil {
+		return ChainResult{
+			Valid:       false,
+			BrokenAtSeq: receipts[0].ActionRecord.ChainSeq,
+			Error:       fmt.Sprintf("seq %d: trusted key set: %v", receipts[0].ActionRecord.ChainSeq, err),
 		}
+	}
+
+	trusted := make(map[string]struct{}, len(normalizedKeys))
+	for _, k := range normalizedKeys {
+		trusted[k] = struct{}{}
 	}
 	v := &chainVerifier{trusted: trusted}
 	return v.run(receipts)
+}
+
+func normalizeTrustedKeys(trustedKeys []string) ([]string, error) {
+	if len(trustedKeys) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(trustedKeys))
+	for _, key := range trustedKeys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("trusted signer key cannot be empty")
+		}
+		out = append(out, key)
+	}
+	return out, nil
 }
 
 // chainVerifier carries the walking state for VerifyChain.
@@ -432,11 +455,15 @@ func ComputeTranscriptRootTrusted(sessionID string, receipts []Receipt, trustedK
 	if len(receipts) == 0 {
 		return TranscriptRoot{}, fmt.Errorf("empty receipt chain")
 	}
-	if len(trustedKeys) == 0 {
+	normalizedKeys, err := normalizeTrustedKeys(trustedKeys)
+	if err != nil {
+		return TranscriptRoot{}, fmt.Errorf("trusted key set: %w", err)
+	}
+	if len(normalizedKeys) == 0 {
 		return TranscriptRoot{}, fmt.Errorf("trust anchor required: pass expected signer key hex")
 	}
 
-	result := VerifyChainTrusted(receipts, trustedKeys)
+	result := VerifyChainTrusted(receipts, normalizedKeys)
 	if !result.Valid {
 		return TranscriptRoot{}, fmt.Errorf("invalid chain: %s", result.Error)
 	}

--- a/internal/receipt/chain_rotation_test.go
+++ b/internal/receipt/chain_rotation_test.go
@@ -145,7 +145,7 @@ func TestVerifyChain_RotationToUnconfirmedKeyIsFlagged(t *testing.T) {
 	}
 }
 
-func TestVerifyChain_SingleRotatedSegmentVerifiesGivenAnchor(t *testing.T) {
+func TestVerifyChain_RotatedSegmentWithoutPriorSegmentRejected(t *testing.T) {
 	t.Parallel()
 	_, privA := generateTestKey(t)
 	pubB, privB := generateTestKey(t)
@@ -160,17 +160,23 @@ func TestVerifyChain_SingleRotatedSegmentVerifiesGivenAnchor(t *testing.T) {
 	}
 	segB, _ := buildSegment(t, privB, 3, tailA, base.Add(time.Hour), marker)
 
-	// Verify segment B alone: its anchor is the marker's PriorChainHash.
+	// A rotated segment cannot verify as a COMPLETE chain by itself. The marker
+	// is signed by the new key and embeds only a claimed prior hash; the actual
+	// prior tail must be present so deletion/truncation is detected.
 	res := VerifyChain(segB, "")
-	if !res.Valid {
-		t.Fatalf("isolated rotated segment must verify given its anchor, got: %s", res.Error)
+	if res.Valid {
+		t.Fatal("rotated segment without its prior segment must be rejected")
 	}
-	if len(res.Segments) != 1 || !res.Segments[0].Boundary {
-		t.Fatalf("expected one boundary segment, got %+v", res.Segments)
+	if res.Error == "" {
+		t.Fatal("rejected isolated rotated segment should explain the missing prior segment")
 	}
-	// Pinned to B (the isolated segment's own key) verifies.
-	if res := VerifyChain(segB, hex.EncodeToString(pubB)); !res.Valid {
-		t.Fatalf("isolated segment pinned to its own key must verify, got: %s", res.Error)
+	// Pinned to B (the isolated segment's own key) still rejects: key trust
+	// cannot substitute for the missing prior tail.
+	if res := VerifyChain(segB, hex.EncodeToString(pubB)); res.Valid {
+		t.Fatal("isolated rotated segment pinned to its own key must still be rejected")
+	}
+	if _, err := ComputeTranscriptRootTrusted("proxy", segB, []string{hex.EncodeToString(pubB)}); err == nil {
+		t.Fatal("transcript root must reject a rotated suffix missing its prior segment")
 	}
 }
 
@@ -348,7 +354,8 @@ func TestVerifyChain_IsolatedSegmentStructuralRejections(t *testing.T) {
 	_, priv := generateTestKey(t)
 	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 
-	// Isolated first receipt carrying a marker but with seq != 0 is rejected.
+	// First receipt carrying a marker is rejected before it can be treated as
+	// a complete chain, including when seq != 0.
 	t.Run("marker_seq_not_zero", func(t *testing.T) {
 		t.Parallel()
 		marker := &KeyTransition{PriorSignerKey: "k", PriorChainSeq: 1, PriorChainHash: "anchor"}
@@ -358,7 +365,8 @@ func TestVerifyChain_IsolatedSegmentStructuralRejections(t *testing.T) {
 		}
 	})
 
-	// Isolated first receipt whose prev_hash != marker.PriorChainHash is rejected.
+	// First receipt carrying a marker is rejected before it can be treated as
+	// a complete chain, including when prev_hash != marker.PriorChainHash.
 	t.Run("prev_hash_not_marker_anchor", func(t *testing.T) {
 		t.Parallel()
 		marker := &KeyTransition{PriorSignerKey: "k", PriorChainSeq: 1, PriorChainHash: "anchor"}

--- a/internal/receipt/chain_rotation_test.go
+++ b/internal/receipt/chain_rotation_test.go
@@ -145,6 +145,32 @@ func TestVerifyChain_RotationToUnconfirmedKeyIsFlagged(t *testing.T) {
 	}
 }
 
+func TestVerifyChain_ExplicitEmptyTrustedKeyFailsClosed(t *testing.T) {
+	t.Parallel()
+	pub, priv := generateTestKey(t)
+	key := hex.EncodeToString(pub)
+	chain := buildChain(t, priv, 2)
+
+	res := VerifyChainTrusted(chain, []string{" "})
+	if res.Valid {
+		t.Fatal("explicit blank trusted key must not fall back to trust-on-first-use")
+	}
+	if res.Error == "" {
+		t.Fatal("blank trusted key rejection should explain the trust-anchor error")
+	}
+
+	root, err := ComputeTranscriptRootTrusted("proxy", chain, []string{" "})
+	if err == nil {
+		t.Fatalf("transcript root with blank trusted key must fail, got root %+v", root)
+	}
+
+	if root, err := ComputeTranscriptRootTrusted("proxy", chain, []string{" " + key + " "}); err != nil {
+		t.Fatalf("transcript root should trim valid trusted keys: %v", err)
+	} else if root.ReceiptCount != uint64(len(chain)) {
+		t.Fatalf("ReceiptCount = %d, want %d", root.ReceiptCount, len(chain))
+	}
+}
+
 func TestVerifyChain_RotatedSegmentWithoutPriorSegmentRejected(t *testing.T) {
 	t.Parallel()
 	_, privA := generateTestKey(t)

--- a/internal/receipt/chain_rotation_test.go
+++ b/internal/receipt/chain_rotation_test.go
@@ -1,0 +1,389 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"testing"
+	"time"
+)
+
+// signSegmentReceipt signs a receipt for a segment, optionally carrying a
+// KeyTransition marker (for the segment-genesis receipt of a rotated segment).
+func signSegmentReceipt(t *testing.T, priv ed25519.PrivateKey, seq uint64, prevHash string, ts time.Time, marker *KeyTransition) Receipt {
+	t.Helper()
+	ar := ActionRecord{
+		Version:       ActionRecordVersion,
+		ActionID:      NewActionID(),
+		ActionType:    ActionRead,
+		Timestamp:     ts,
+		Target:        chainTestTarget,
+		Verdict:       testVerdict,
+		Transport:     chainTestTransport,
+		ChainPrevHash: prevHash,
+		ChainSeq:      seq,
+		KeyTransition: marker,
+	}
+	r, err := Sign(ar, priv)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	return r
+}
+
+func mustHash(t *testing.T, r Receipt) string {
+	t.Helper()
+	h, err := ReceiptHash(r)
+	if err != nil {
+		t.Fatalf("ReceiptHash: %v", err)
+	}
+	return h
+}
+
+// buildSegment appends n receipts to an existing chain under priv, starting at
+// segment seq 0 with the given prevHash, and returns the appended receipts plus
+// the new tail hash. The first receipt carries marker (nil for the genesis
+// segment). Each segment's seq baseline is 0 - that is the rotation model: a new
+// segment restarts seq at its own genesis.
+func buildSegment(t *testing.T, priv ed25519.PrivateKey, n int, prevHash string, base time.Time, marker *KeyTransition) ([]Receipt, string) {
+	t.Helper()
+	out := make([]Receipt, 0, n)
+	for i := range n {
+		var m *KeyTransition
+		if i == 0 {
+			m = marker
+		}
+		r := signSegmentReceipt(t, priv, uint64(i), prevHash, base.Add(time.Duration(i)*time.Second), m)
+		prevHash = mustHash(t, r)
+		out = append(out, r)
+	}
+	return out, prevHash
+}
+
+// buildRotatedChain builds a 2-segment chain: aN receipts under keyA (genesis),
+// then bN receipts under keyB introduced by a valid KeyTransition.
+func buildRotatedChain(t *testing.T, privA, privB ed25519.PrivateKey, aN, bN int) []Receipt {
+	t.Helper()
+	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	segA, tailA := buildSegment(t, privA, aN, GenesisHash, base, nil)
+	priorTail := segA[len(segA)-1]
+	marker := &KeyTransition{
+		PriorSignerKey: hex.EncodeToString(privA.Public().(ed25519.PublicKey)),
+		PriorChainSeq:  priorTail.ActionRecord.ChainSeq,
+		PriorChainHash: tailA,
+	}
+	segB, _ := buildSegment(t, privB, bN, tailA, base.Add(time.Hour), marker)
+	return append(segA, segB...)
+}
+
+func TestVerifyChain_RotatedChainVerifiesEndToEndWithBothKeysTrusted(t *testing.T) {
+	t.Parallel()
+	pubA, privA := generateTestKey(t)
+	pubB, privB := generateTestKey(t)
+
+	chain := buildRotatedChain(t, privA, privB, 3, 2)
+	keyA := hex.EncodeToString(pubA)
+	keyB := hex.EncodeToString(pubB)
+
+	// Both keys trusted (operator confirmed the rotation): verifies end-to-end.
+	res := VerifyChainTrusted(chain, []string{keyA, keyB})
+	if !res.Valid {
+		t.Fatalf("rotated chain with both keys trusted must verify end-to-end, got: %s", res.Error)
+	}
+	if res.ReceiptCount != 5 {
+		t.Errorf("ReceiptCount = %d, want 5", res.ReceiptCount)
+	}
+	if len(res.Segments) != 2 {
+		t.Fatalf("Segments = %d, want 2", len(res.Segments))
+	}
+	wantKeys := []string{keyA, keyB}
+	if len(res.SignerKeys) != 2 || res.SignerKeys[0] != wantKeys[0] || res.SignerKeys[1] != wantKeys[1] {
+		t.Errorf("SignerKeys = %v, want %v", res.SignerKeys, wantKeys)
+	}
+	if res.Segments[0].Boundary {
+		t.Error("genesis segment must not be marked as a boundary")
+	}
+	if !res.Segments[1].Boundary {
+		t.Error("rotated segment must be marked as a boundary")
+	}
+	if res.Segments[1].FirstSeq != 0 {
+		t.Errorf("rotated segment FirstSeq = %d, want 0", res.Segments[1].FirstSeq)
+	}
+}
+
+func TestVerifyChain_RotationToUnconfirmedKeyIsFlagged(t *testing.T) {
+	t.Parallel()
+	pubA, privA := generateTestKey(t)
+	pubB, privB := generateTestKey(t)
+
+	chain := buildRotatedChain(t, privA, privB, 3, 2)
+	keyB := hex.EncodeToString(pubB)
+
+	// Trust-on-first-use (no key): genesis key A is adopted; the rotation to B
+	// is NOT silently trusted - it is flagged so the operator confirms it.
+	res := VerifyChain(chain, "")
+	if res.Valid {
+		t.Fatal("rotation to an unconfirmed key must NOT be silently trusted")
+	}
+	if res.UntrustedSignerKey != keyB {
+		t.Errorf("UntrustedSignerKey = %q, want %q", res.UntrustedSignerKey, keyB)
+	}
+	if res.BrokenAtSeq != 0 {
+		t.Errorf("BrokenAtSeq = %d, want 0 (the rotated segment genesis)", res.BrokenAtSeq)
+	}
+
+	// Pinned ONLY to genesis key A: the rotation to B is likewise flagged,
+	// because the marker does not delegate trust.
+	res = VerifyChain(chain, hex.EncodeToString(pubA))
+	if res.Valid {
+		t.Fatal("rotation to a key outside the trusted set must be flagged even when pinned to genesis")
+	}
+	if res.UntrustedSignerKey != keyB {
+		t.Errorf("pinned UntrustedSignerKey = %q, want %q", res.UntrustedSignerKey, keyB)
+	}
+}
+
+func TestVerifyChain_SingleRotatedSegmentVerifiesGivenAnchor(t *testing.T) {
+	t.Parallel()
+	_, privA := generateTestKey(t)
+	pubB, privB := generateTestKey(t)
+
+	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	segA, tailA := buildSegment(t, privA, 2, GenesisHash, base, nil)
+	priorTail := segA[len(segA)-1]
+	marker := &KeyTransition{
+		PriorSignerKey: hex.EncodeToString(privA.Public().(ed25519.PublicKey)),
+		PriorChainSeq:  priorTail.ActionRecord.ChainSeq,
+		PriorChainHash: tailA,
+	}
+	segB, _ := buildSegment(t, privB, 3, tailA, base.Add(time.Hour), marker)
+
+	// Verify segment B alone: its anchor is the marker's PriorChainHash.
+	res := VerifyChain(segB, "")
+	if !res.Valid {
+		t.Fatalf("isolated rotated segment must verify given its anchor, got: %s", res.Error)
+	}
+	if len(res.Segments) != 1 || !res.Segments[0].Boundary {
+		t.Fatalf("expected one boundary segment, got %+v", res.Segments)
+	}
+	// Pinned to B (the isolated segment's own key) verifies.
+	if res := VerifyChain(segB, hex.EncodeToString(pubB)); !res.Valid {
+		t.Fatalf("isolated segment pinned to its own key must verify, got: %s", res.Error)
+	}
+}
+
+func TestVerifyChain_OrdinarySeqZeroWithoutMarkerStillFails(t *testing.T) {
+	t.Parallel()
+	_, priv := generateTestKey(t)
+	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	// A seq-0 receipt with a non-genesis prev_hash and NO marker must fail.
+	bad := signSegmentReceipt(t, priv, 0, "not-genesis-hash", base, nil)
+	res := VerifyChain([]Receipt{bad}, "")
+	if res.Valid {
+		t.Fatal("seq-0 receipt with non-genesis prev_hash and no marker must FAIL")
+	}
+
+	// A mid-chain ordinary seq-0 (fork attempt, no marker) must fail.
+	good := buildChain(t, priv, 2)
+	forced := signSegmentReceipt(t, priv, 0, mustHash(t, good[1]), base.Add(2*time.Second), nil)
+	res = VerifyChain(append(good, forced), "")
+	if res.Valid {
+		t.Fatal("mid-chain seq-0 without a key_transition boundary must FAIL")
+	}
+}
+
+func TestVerifyChain_ForgedSegmentAttackerKeyRejected(t *testing.T) {
+	t.Parallel()
+	pubA, privA := generateTestKey(t)
+	_, privAttacker := generateTestKey(t)
+
+	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	segA, tailA := buildSegment(t, privA, 3, GenesisHash, base, nil)
+	priorTail := segA[len(segA)-1]
+	keyA := hex.EncodeToString(pubA)
+	attackerHex := hex.EncodeToString(privAttacker.Public().(ed25519.PublicKey))
+
+	// Attacker forges a new segment under THEIR key with a marker that
+	// correctly references the real prior tail (they can READ the file). The
+	// marker is structurally consistent, BUT it is signed by the attacker key,
+	// not key A - the marker does NOT prove key A authorized the rotation.
+	// Because the attacker key is not in the trusted set, the segment is
+	// REJECTED and the offending key is named.
+	marker := &KeyTransition{
+		PriorSignerKey: keyA,
+		PriorChainSeq:  priorTail.ActionRecord.ChainSeq,
+		PriorChainHash: tailA,
+	}
+	segAttacker, _ := buildSegment(t, privAttacker, 2, tailA, base.Add(time.Hour), marker)
+	chain := append(segA, segAttacker...)
+
+	// Trust-on-first-use: only key A is trusted; attacker segment rejected.
+	res := VerifyChain(chain, "")
+	if res.Valid {
+		t.Fatal("forged attacker-key segment with a consistent marker must be REJECTED")
+	}
+	if res.UntrustedSignerKey != attackerHex {
+		t.Errorf("UntrustedSignerKey = %q, want attacker key %q", res.UntrustedSignerKey, attackerHex)
+	}
+
+	// Even pinned to key A: rejected (attacker key not trusted).
+	if res := VerifyChain(chain, keyA); res.Valid {
+		t.Fatal("forged attacker-key segment must be REJECTED when pinned to key A")
+	}
+
+	// And a marker that does NOT reference the real prior tail is rejected at
+	// the structural-boundary check, before the trust check.
+	badMarker := &KeyTransition{
+		PriorSignerKey: keyA,
+		PriorChainSeq:  priorTail.ActionRecord.ChainSeq,
+		PriorChainHash: "attacker-fabricated-prior-hash",
+	}
+	segBad, _ := buildSegment(t, privAttacker, 2, "attacker-fabricated-prior-hash", base.Add(2*time.Hour), badMarker)
+	badChain := append(append([]Receipt{}, segA...), segBad...)
+	if res := VerifyChain(badChain, ""); res.Valid {
+		t.Fatal("forged segment whose marker does not reference the real prior tail must be REJECTED")
+	}
+}
+
+func TestVerifyChain_PinnedKeyRejectsForgedGenesisSegment(t *testing.T) {
+	t.Parallel()
+	pubA, _ := generateTestKey(t)
+	_, privAttacker := generateTestKey(t)
+
+	// Attacker builds a chain entirely under their own key. Pinned to the
+	// operator's real key A, the FIRST receipt's signature must fail (it is
+	// signed by the attacker, not key A).
+	chain := buildChain(t, privAttacker, 3)
+	res := VerifyChain(chain, hex.EncodeToString(pubA))
+	if res.Valid {
+		t.Fatal("chain signed entirely by attacker must FAIL when pinned to operator key")
+	}
+}
+
+func TestVerifyChain_TamperedPriorTailBreaksBoundary(t *testing.T) {
+	t.Parallel()
+	_, privA := generateTestKey(t)
+	_, privB := generateTestKey(t)
+
+	chain := buildRotatedChain(t, privA, privB, 3, 2)
+	// Tamper the prior segment's tail (last receipt of segment A, index 2):
+	// flip its verdict and re-sign under A so its OWN signature is valid but
+	// its hash changes -> the boundary marker's PriorChainHash no longer
+	// matches the actual prior tail hash.
+	tail := chain[2]
+	tail.ActionRecord.Verdict = "allow"
+	resigned, err := Sign(tail.ActionRecord, privA)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	chain[2] = resigned
+
+	res := VerifyChain(chain, "")
+	if res.Valid {
+		t.Fatal("tampering the prior tail must break the boundary validation")
+	}
+}
+
+func TestVerifyChain_BoundaryFieldMismatchesRejected(t *testing.T) {
+	t.Parallel()
+	pubA, privA := generateTestKey(t)
+	pubB, privB := generateTestKey(t)
+	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	keyA := hex.EncodeToString(pubA)
+	keyB := hex.EncodeToString(pubB)
+	trusted := []string{keyA, keyB}
+
+	segA, tailA := buildSegment(t, privA, 3, GenesisHash, base, nil)
+	priorTail := segA[len(segA)-1]
+
+	// Wrong prior_signer_key in the marker (does not name the prior segment).
+	t.Run("wrong_prior_signer_key", func(t *testing.T) {
+		t.Parallel()
+		marker := &KeyTransition{
+			PriorSignerKey: keyB, // should be keyA
+			PriorChainSeq:  priorTail.ActionRecord.ChainSeq,
+			PriorChainHash: tailA,
+		}
+		segB, _ := buildSegment(t, privB, 2, tailA, base.Add(time.Hour), marker)
+		if res := VerifyChainTrusted(append(append([]Receipt{}, segA...), segB...), trusted); res.Valid {
+			t.Fatal("marker with wrong prior_signer_key must be rejected")
+		}
+	})
+
+	// Wrong prior_chain_seq in the marker.
+	t.Run("wrong_prior_chain_seq", func(t *testing.T) {
+		t.Parallel()
+		marker := &KeyTransition{
+			PriorSignerKey: keyA,
+			PriorChainSeq:  priorTail.ActionRecord.ChainSeq + 99,
+			PriorChainHash: tailA,
+		}
+		segB, _ := buildSegment(t, privB, 2, tailA, base.Add(time.Hour), marker)
+		if res := VerifyChainTrusted(append(append([]Receipt{}, segA...), segB...), trusted); res.Valid {
+			t.Fatal("marker with wrong prior_chain_seq must be rejected")
+		}
+	})
+
+	// chain_prev_hash on the boundary receipt disagrees with the marker hash.
+	t.Run("prev_hash_disagrees_with_marker", func(t *testing.T) {
+		t.Parallel()
+		marker := &KeyTransition{
+			PriorSignerKey: keyA,
+			PriorChainSeq:  priorTail.ActionRecord.ChainSeq,
+			PriorChainHash: tailA,
+		}
+		// Sign the boundary receipt with a prev_hash that does NOT match tailA.
+		bad := signSegmentReceipt(t, privB, 0, "different-prev-hash", base.Add(time.Hour), marker)
+		if res := VerifyChainTrusted(append(append([]Receipt{}, segA...), bad), trusted); res.Valid {
+			t.Fatal("boundary receipt whose prev_hash disagrees with the marker must be rejected")
+		}
+	})
+}
+
+func TestVerifyChain_IsolatedSegmentStructuralRejections(t *testing.T) {
+	t.Parallel()
+	_, priv := generateTestKey(t)
+	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	// Isolated first receipt carrying a marker but with seq != 0 is rejected.
+	t.Run("marker_seq_not_zero", func(t *testing.T) {
+		t.Parallel()
+		marker := &KeyTransition{PriorSignerKey: "k", PriorChainSeq: 1, PriorChainHash: "anchor"}
+		r := signSegmentReceipt(t, priv, 5, "anchor", base, marker)
+		if res := VerifyChain([]Receipt{r}, ""); res.Valid {
+			t.Fatal("isolated marker receipt with seq != 0 must be rejected")
+		}
+	})
+
+	// Isolated first receipt whose prev_hash != marker.PriorChainHash is rejected.
+	t.Run("prev_hash_not_marker_anchor", func(t *testing.T) {
+		t.Parallel()
+		marker := &KeyTransition{PriorSignerKey: "k", PriorChainSeq: 1, PriorChainHash: "anchor"}
+		r := signSegmentReceipt(t, priv, 0, "different-anchor", base, marker)
+		if res := VerifyChain([]Receipt{r}, ""); res.Valid {
+			t.Fatal("isolated marker receipt whose prev_hash != marker anchor must be rejected")
+		}
+	})
+}
+
+func TestVerifyChain_MarkerOnNonGenesisReceiptRejected(t *testing.T) {
+	t.Parallel()
+	_, priv := generateTestKey(t)
+	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	seg, tail := buildSegment(t, priv, 2, GenesisHash, base, nil)
+	// Append a receipt at seq 2 that wrongly carries a KeyTransition marker.
+	marker := &KeyTransition{
+		PriorSignerKey: hex.EncodeToString(priv.Public().(ed25519.PublicKey)),
+		PriorChainSeq:  1,
+		PriorChainHash: tail,
+	}
+	bad := signSegmentReceipt(t, priv, 2, tail, base.Add(2*time.Second), marker)
+	res := VerifyChain(append(seg, bad), "")
+	if res.Valid {
+		t.Fatal("a key_transition marker on a non-genesis (seq != 0) receipt must be REJECTED")
+	}
+}

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -29,6 +29,32 @@ const recorderEntryType = "action_receipt"
 // The recorder pins to the first session ID it sees, so all entries must use the same value.
 const recorderSessionID = "proxy"
 
+// MetricsSink receives receipt-emission observability signals. The proxy's
+// metrics package implements it; tests can supply a stub. A nil sink is a
+// no-op so the emitter never depends on metrics being wired.
+type MetricsSink interface {
+	// RecordEmitFailure increments the receipt-emit-failure counter, labeled
+	// by a bounded-cardinality reason string.
+	RecordEmitFailure(reason string)
+}
+
+// Emit-failure reason labels. Closed domain to keep metric cardinality bounded.
+const (
+	// FailReasonChainInit is the reason for failures that originate from a
+	// chain that could not be initialized or resumed at construction time.
+	FailReasonChainInit = "chain_init"
+	// FailReasonSign is a signing failure.
+	FailReasonSign = "sign"
+	// FailReasonHash is a receipt-hash computation failure.
+	FailReasonHash = "hash"
+	// FailReasonMarshal is a receipt-marshal failure.
+	FailReasonMarshal = "marshal"
+	// FailReasonRecord is a recorder-write failure.
+	FailReasonRecord = "record"
+	// FailReasonSealed is an emit attempt after the transcript root was emitted.
+	FailReasonSealed = "sealed"
+)
+
 // Emitter produces signed action receipts and writes them to the flight recorder.
 // It is safe for concurrent use - the underlying recorder handles its own locking.
 type Emitter struct {
@@ -37,6 +63,7 @@ type Emitter struct {
 	configHash atomic.Value // stores string; updated on hot reload
 	principal  string
 	actor      string
+	metrics    MetricsSink
 	initErr    error
 
 	// Chain state - mutex-protected, updated on each Emit.
@@ -46,6 +73,13 @@ type Emitter struct {
 	chainStart    time.Time // timestamp of first receipt
 	chainEnd      time.Time // timestamp of most recent receipt
 	rootEmitted   bool      // true after EmitTranscriptRoot; prevents duplicate roots
+
+	// pendingTransition is set by resumeChain when the on-disk tail was
+	// signed by a DIFFERENT (but self-valid) key, meaning a legitimate key
+	// rotation occurred. It is stamped onto the first receipt of the new
+	// segment by the next Emit, then cleared. nil when there is no pending
+	// segment boundary.
+	pendingTransition *KeyTransition
 }
 
 // EmitterConfig holds the configuration for creating an Emitter.
@@ -55,6 +89,8 @@ type EmitterConfig struct {
 	ConfigHash string
 	Principal  string
 	Actor      string
+	// Metrics, when non-nil, receives emit-failure observability signals.
+	Metrics MetricsSink
 }
 
 // NewEmitter creates a receipt emitter. Returns nil if the recorder is nil
@@ -71,11 +107,24 @@ func NewEmitter(cfg EmitterConfig) *Emitter {
 		privKey:       cfg.PrivKey,
 		principal:     cfg.Principal,
 		actor:         cfg.Actor,
+		metrics:       cfg.Metrics,
 		chainPrevHash: GenesisHash,
 	}
 	e.configHash.Store(cfg.ConfigHash)
 	e.initErr = e.resumeChain()
 	return e
+}
+
+// InitError returns the error (if any) that occurred while resuming the chain
+// at construction time. A non-nil result means receipt emission is bricked for
+// this emitter and Emit will return the wrapped error on every call. Callers
+// should log this loudly once at startup with remediation guidance. Safe on a
+// nil emitter.
+func (e *Emitter) InitError() error {
+	if e == nil {
+		return nil
+	}
+	return e.initErr
 }
 
 // EmitOpts holds the per-decision context for emitting a receipt.
@@ -130,6 +179,7 @@ func (e *Emitter) Emit(opts EmitOpts) error {
 		return nil
 	}
 	if e.initErr != nil {
+		e.recordFailure(FailReasonChainInit)
 		return fmt.Errorf("resume receipt chain: %w", e.initErr)
 	}
 
@@ -152,6 +202,7 @@ func (e *Emitter) Emit(opts EmitOpts) error {
 	defer e.chainMu.Unlock()
 
 	if e.rootEmitted {
+		e.recordFailure(FailReasonSealed)
 		return ErrChainSealed
 	}
 
@@ -213,20 +264,28 @@ func (e *Emitter) Emit(opts EmitOpts) error {
 		RequestID:             opts.RequestID,
 		ChainPrevHash:         e.chainPrevHash,
 		ChainSeq:              e.chainSeq,
+		// pendingTransition is non-nil only on the first receipt of a new
+		// segment opened by resumeChain after a legitimate key rotation. It
+		// is bound into the signed record so the segment boundary is provable
+		// from this receipt alone, then cleared after a successful write.
+		KeyTransition: e.pendingTransition,
 	}
 
 	rcpt, err := Sign(ar, e.privKey)
 	if err != nil {
+		e.recordFailure(FailReasonSign)
 		return fmt.Errorf("signing receipt: %w", err)
 	}
 
 	receiptHash, err := ReceiptHash(rcpt)
 	if err != nil {
+		e.recordFailure(FailReasonHash)
 		return fmt.Errorf("hashing receipt: %w", err)
 	}
 
 	receiptJSON, err := Marshal(rcpt)
 	if err != nil {
+		e.recordFailure(FailReasonMarshal)
 		return fmt.Errorf("marshaling receipt: %w", err)
 	}
 
@@ -242,6 +301,11 @@ func (e *Emitter) Emit(opts EmitOpts) error {
 	}
 	e.chainEnd = ar.Timestamp
 	e.chainSeq++
+	// The transition marker was bound into the receipt just signed; clear it
+	// so it is never re-stamped onto a later receipt (which would falsely
+	// claim a second segment boundary). Cleared with the rest of the
+	// advance-before-persist state for the same fork-avoidance reason.
+	e.pendingTransition = nil
 
 	if err := e.recorder.Record(recorder.Entry{
 		SessionID: recorderSessionID,
@@ -251,10 +315,20 @@ func (e *Emitter) Emit(opts EmitOpts) error {
 		Summary:   fmt.Sprintf("receipt: %s %s %s", ar.Verdict, ar.ActionType, ar.Transport),
 		Detail:    json.RawMessage(receiptJSON),
 	}); err != nil {
+		e.recordFailure(FailReasonRecord)
 		return fmt.Errorf("recording receipt: %w", err)
 	}
 
 	return nil
+}
+
+// recordFailure increments the emit-failure metric for reason when a sink is
+// wired. Safe with a nil sink.
+func (e *Emitter) recordFailure(reason string) {
+	if e == nil || e.metrics == nil {
+		return
+	}
+	e.metrics.RecordEmitFailure(reason)
 }
 
 // UpdateConfigHash sets the config hash for new receipts. Called on hot reload.
@@ -321,6 +395,7 @@ func (e *Emitter) EmitTranscriptRoot(sessionID string) error {
 		return nil
 	}
 	if e.initErr != nil {
+		e.recordFailure(FailReasonChainInit)
 		return fmt.Errorf("resume receipt chain: %w", e.initErr)
 	}
 
@@ -453,15 +528,62 @@ func (e *Emitter) resumeChain() error {
 		}
 	}
 
-	// Verify the tail receipt's signature before trusting its chain state.
-	// A tampered or partial evidence file must not silently corrupt the chain.
+	// Trust model for resuming an on-disk chain across a possible signing-key
+	// change. Three cases, distinguished by verifying the tail BEFORE
+	// trusting its chain state:
+	//
+	//  1. Tail signed by the CURRENT key, signature valid  -> resume the
+	//     same chain segment (the common case).
+	//  2. Tail signed by a DIFFERENT key, but self-valid under its OWN
+	//     embedded signer_key -> a legitimate signing-key rotation. The
+	//     operator regenerated the key (e.g. `contain install`); the prior
+	//     chain is intact, it is simply sealed under the old key. Open a NEW
+	//     segment anchored to the prior tail's hash and stamp a transition
+	//     marker on the next receipt, instead of bricking emission forever.
+	//  3. Tail's OWN signature is INVALID (corrupt / tampered, regardless of
+	//     key) -> FAIL CLOSED. This is the tamper case and must never be
+	//     weakened into a silent reset.
+	//
+	// Why case 2 is safe: we require the tail to be self-consistently signed
+	// by the key embedded in it (Verify). An attacker who can only write a
+	// forged tail with a bad signature lands in case 3 and is rejected, so a
+	// forged tail cannot force a silent segment reset that hides history. A
+	// rotation reset preserves continuity two ways: the new segment's first
+	// receipt carries the prior tail's hash as its ChainPrevHash plus an
+	// explicit KeyTransition marker (prior signer key + prior seq + prior
+	// hash), and the recorder's outer hash chain still spans every entry on
+	// disk and remains the authoritative cross-segment tamper-evidence
+	// layer. This mirrors the v2 proxy_decision emitter, which restarts at
+	// genesis across process restarts and likewise leans on the recorder's
+	// outer chain for cross-segment evidence.
 	if e.privKey != nil {
-		keyHex := fmt.Sprintf("%x", e.privKey.Public().(ed25519.PublicKey))
-		if verifyErr := VerifyWithKey(*lastReceipt, keyHex); verifyErr != nil {
+		// Case 3 first: self-signature must be valid no matter the key.
+		if verifyErr := Verify(*lastReceipt); verifyErr != nil {
 			return fmt.Errorf("tail receipt signature invalid (seq %d): %w", lastReceipt.ActionRecord.ChainSeq, verifyErr)
+		}
+
+		currentKeyHex := fmt.Sprintf("%x", e.privKey.Public().(ed25519.PublicKey))
+		if lastReceipt.SignerKey != currentKeyHex {
+			// Case 2: legitimate rotation. Open a new segment.
+			hash, err := ReceiptHash(*lastReceipt)
+			if err != nil {
+				return fmt.Errorf("hashing prior segment tail: %w", err)
+			}
+			e.chainSeq = 0
+			e.chainPrevHash = hash
+			e.pendingTransition = &KeyTransition{
+				PriorSignerKey: lastReceipt.SignerKey,
+				PriorChainSeq:  lastReceipt.ActionRecord.ChainSeq,
+				PriorChainHash: hash,
+			}
+			// Carry the prior segment's start timestamp forward only if the
+			// new segment has no receipts yet (it does not). chainStart is
+			// set on the first Emit of the new segment, so leave it zero.
+			return nil
 		}
 	}
 
+	// Case 1: same key (or no key configured) - resume the same segment.
 	hash, err := ReceiptHash(*lastReceipt)
 	if err != nil {
 		return fmt.Errorf("hashing existing receipt chain: %w", err)

--- a/internal/receipt/emitter_resume_test.go
+++ b/internal/receipt/emitter_resume_test.go
@@ -1,0 +1,464 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+// stubMetrics records emit-failure reasons for assertion.
+type stubMetrics struct {
+	mu      sync.Mutex
+	reasons []string
+}
+
+func (s *stubMetrics) RecordEmitFailure(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reasons = append(s.reasons, reason)
+}
+
+func (s *stubMetrics) snapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.reasons...)
+}
+
+// emitOne signs and records a single happy-path receipt through e.
+func emitOne(t *testing.T, e *Emitter) {
+	t.Helper()
+	if err := e.Emit(EmitOpts{
+		ActionID:  NewActionID(),
+		Target:    testTarget,
+		Verdict:   config.ActionBlock,
+		Transport: testTransport,
+		Method:    http.MethodGet,
+	}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+}
+
+// allReceiptsRaw reads every action_receipt entry from dir WITHOUT verifying
+// signatures, so we can inspect chains signed by mixed keys (rotation).
+func allReceiptsRaw(t *testing.T, dir string) []Receipt {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Clean(dir))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var out []Receipt
+	for _, de := range entries {
+		if de.IsDir() || !strings.HasSuffix(de.Name(), ".jsonl") {
+			continue
+		}
+		fileEntries, err := recorder.ReadEntries(filepath.Join(dir, de.Name()))
+		if err != nil {
+			t.Fatalf("ReadEntries: %v", err)
+		}
+		for _, entry := range fileEntries {
+			if entry.Type != recorderEntryType {
+				continue
+			}
+			detailJSON, err := json.Marshal(entry.Detail)
+			if err != nil {
+				t.Fatalf("marshal detail: %v", err)
+			}
+			r, err := Unmarshal(detailJSON)
+			if err != nil {
+				t.Fatalf("unmarshal receipt: %v", err)
+			}
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func TestInitError_NilEmitter(t *testing.T) {
+	t.Parallel()
+	var e *Emitter
+	if err := e.InitError(); err != nil {
+		t.Errorf("nil emitter InitError = %v, want nil", err)
+	}
+}
+
+func TestInitError_CleanResumeIsNil(t *testing.T) {
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	defer func() { _ = rec.Close() }()
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, Principal: testPrincipal, Actor: testActor})
+	if err := e.InitError(); err != nil {
+		t.Errorf("fresh emitter InitError = %v, want nil", err)
+	}
+}
+
+// TestResume_SameKeyValidTail_ResumesUnchanged is case 1: a tail signed by the
+// current key with a valid signature resumes the same chain segment.
+func TestResume_SameKeyValidTail_ResumesUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+
+	rec1 := newTestRecorder(t, dir, priv)
+	e1 := NewEmitter(EmitterConfig{Recorder: rec1, PrivKey: priv, Principal: testPrincipal, Actor: testActor})
+	emitOne(t, e1)
+	emitOne(t, e1)
+	if err := rec1.Close(); err != nil {
+		t.Fatalf("close rec1: %v", err)
+	}
+
+	// Reopen with the SAME key. Resume should continue the chain.
+	rec2 := newTestRecorder(t, dir, priv)
+	e2 := NewEmitter(EmitterConfig{Recorder: rec2, PrivKey: priv, Principal: testPrincipal, Actor: testActor})
+	if err := e2.InitError(); err != nil {
+		t.Fatalf("InitError after same-key reopen: %v", err)
+	}
+	if e2.chainSeq != 2 {
+		t.Fatalf("chainSeq = %d, want 2 (resumed)", e2.chainSeq)
+	}
+	if e2.pendingTransition != nil {
+		t.Fatalf("same-key resume must not set a transition marker: %+v", e2.pendingTransition)
+	}
+	emitOne(t, e2)
+	if err := rec2.Close(); err != nil {
+		t.Fatalf("close rec2: %v", err)
+	}
+
+	receipts := allReceiptsRaw(t, dir)
+	if len(receipts) != 3 {
+		t.Fatalf("receipt count = %d, want 3", len(receipts))
+	}
+	// Seq monotonic 0,1,2 and no transition markers anywhere.
+	for i, r := range receipts {
+		if r.ActionRecord.ChainSeq != uint64(i) {
+			t.Errorf("receipt %d chain_seq = %d, want %d", i, r.ActionRecord.ChainSeq, i)
+		}
+		if r.ActionRecord.KeyTransition != nil {
+			t.Errorf("receipt %d unexpectedly carries a key transition marker", i)
+		}
+	}
+}
+
+// TestResume_RotatedKeySelfValidTail_OpensNewSegment is case 2: a tail signed
+// by a DIFFERENT key whose own signature is valid is treated as a legitimate
+// rotation. A new segment opens, no error, and the new segment's genesis
+// receipt carries the prior tail hash + a transition marker.
+func TestResume_RotatedKeySelfValidTail_OpensNewSegment(t *testing.T) {
+	dir := t.TempDir()
+	pubA, privA := generateTestKey(t)
+
+	// Segment under key A.
+	recA := newTestRecorder(t, dir, privA)
+	eA := NewEmitter(EmitterConfig{Recorder: recA, PrivKey: privA, Principal: testPrincipal, Actor: testActor})
+	emitOne(t, eA)
+	emitOne(t, eA)
+	if err := recA.Close(); err != nil {
+		t.Fatalf("close recA: %v", err)
+	}
+
+	tailA := allReceiptsRaw(t, dir)
+	priorTail := tailA[len(tailA)-1]
+	priorTailHash, err := ReceiptHash(priorTail)
+	if err != nil {
+		t.Fatalf("hash prior tail: %v", err)
+	}
+
+	// Rotate the signing key to B and reopen. The recorder uses B too (the
+	// recorder's own outer chain resumes by file content, key-agnostic).
+	pubB, privB := generateTestKey(t)
+	_ = pubA
+	recB := newTestRecorder(t, dir, privB)
+	metrics := &stubMetrics{}
+	eB := NewEmitter(EmitterConfig{Recorder: recB, PrivKey: privB, Principal: testPrincipal, Actor: testActor, Metrics: metrics})
+	if err := eB.InitError(); err != nil {
+		t.Fatalf("rotation must NOT brick the chain, got InitError: %v", err)
+	}
+	if eB.chainSeq != 0 {
+		t.Fatalf("new segment chainSeq = %d, want 0 (genesis of new segment)", eB.chainSeq)
+	}
+	if eB.chainPrevHash != priorTailHash {
+		t.Fatalf("new segment chainPrevHash = %q, want prior tail hash %q", eB.chainPrevHash, priorTailHash)
+	}
+	if eB.pendingTransition == nil {
+		t.Fatal("expected a pending key-transition marker after rotation")
+	}
+	if eB.pendingTransition.PriorSignerKey != hex.EncodeToString(pubA) {
+		t.Errorf("transition prior_signer_key = %q, want %q", eB.pendingTransition.PriorSignerKey, hex.EncodeToString(pubA))
+	}
+	if eB.pendingTransition.PriorChainSeq != priorTail.ActionRecord.ChainSeq {
+		t.Errorf("transition prior_chain_seq = %d, want %d", eB.pendingTransition.PriorChainSeq, priorTail.ActionRecord.ChainSeq)
+	}
+	if eB.pendingTransition.PriorChainHash != priorTailHash {
+		t.Errorf("transition prior_chain_hash = %q, want %q", eB.pendingTransition.PriorChainHash, priorTailHash)
+	}
+
+	// First emit of the new segment must carry the marker; the second must not.
+	emitOne(t, eB)
+	emitOne(t, eB)
+	if err := recB.Close(); err != nil {
+		t.Fatalf("close recB: %v", err)
+	}
+
+	all := allReceiptsRaw(t, dir)
+	if len(all) != 4 {
+		t.Fatalf("total receipts = %d, want 4 (2 under A, 2 under B)", len(all))
+	}
+	segB := all[2:] // new segment
+	if segB[0].ActionRecord.KeyTransition == nil {
+		t.Fatal("first receipt of new segment must carry a transition marker")
+	}
+	if segB[0].ActionRecord.ChainPrevHash != priorTailHash {
+		t.Errorf("new segment genesis chain_prev_hash = %q, want prior tail hash %q",
+			segB[0].ActionRecord.ChainPrevHash, priorTailHash)
+	}
+	if segB[0].ActionRecord.ChainSeq != 0 {
+		t.Errorf("new segment genesis chain_seq = %d, want 0", segB[0].ActionRecord.ChainSeq)
+	}
+	if segB[1].ActionRecord.KeyTransition != nil {
+		t.Error("only the first receipt of the new segment may carry a transition marker")
+	}
+	if segB[1].ActionRecord.ChainSeq != 1 {
+		t.Errorf("second new-segment receipt chain_seq = %d, want 1", segB[1].ActionRecord.ChainSeq)
+	}
+	// New-segment receipts are signed by B and self-verify.
+	for i, r := range segB {
+		if err := VerifyWithKey(r, hex.EncodeToString(pubB)); err != nil {
+			t.Errorf("new segment receipt %d does not verify under key B: %v", i, err)
+		}
+	}
+	// No emit failures recorded - rotation is not a failure.
+	if got := metrics.snapshot(); len(got) != 0 {
+		t.Errorf("rotation recorded emit failures %v, want none", got)
+	}
+}
+
+// TestResume_TamperedTailSameKey_FailsClosed is case 3: a tail whose own
+// signature is invalid fails closed even when the signer_key matches the
+// current key. Tamper-detection must NOT be weakened by the rotation fix.
+func TestResume_TamperedTailSameKey_FailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, Principal: testPrincipal, Actor: testActor})
+	emitOne(t, e)
+	if err := rec.Close(); err != nil {
+		t.Fatalf("close rec: %v", err)
+	}
+
+	corruptTailSignaturePayload(t, dir)
+
+	rec2 := newTestRecorder(t, dir, priv)
+	defer func() { _ = rec2.Close() }()
+	metrics := &stubMetrics{}
+	e2 := NewEmitter(EmitterConfig{Recorder: rec2, PrivKey: priv, Principal: testPrincipal, Actor: testActor, Metrics: metrics})
+	if e2.InitError() == nil {
+		t.Fatal("tampered tail (same key) must fail closed, got nil InitError")
+	}
+	if e2.pendingTransition != nil {
+		t.Fatal("a tampered tail must NOT be treated as a rotation")
+	}
+	// Emit must keep failing and record the chain_init reason.
+	if err := e2.Emit(EmitOpts{
+		ActionID: NewActionID(), Target: testTarget, Verdict: config.ActionBlock,
+		Transport: testTransport, Method: http.MethodGet,
+	}); err == nil {
+		t.Fatal("Emit after fail-closed init must return an error")
+	}
+	if got := metrics.snapshot(); len(got) == 0 || got[len(got)-1] != FailReasonChainInit {
+		t.Errorf("emit failure reasons = %v, want last = %q", got, FailReasonChainInit)
+	}
+}
+
+// TestResume_ForgedTailDifferentKey_CannotForceSilentReset proves an attacker
+// who substitutes a DIFFERENT signer_key but cannot produce a valid signature
+// (case 3 under a foreign key) is rejected - they cannot force a silent chain
+// reset that hides history.
+func TestResume_ForgedTailDifferentKey_CannotForceSilentReset(t *testing.T) {
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, Principal: testPrincipal, Actor: testActor})
+	emitOne(t, e)
+	if err := rec.Close(); err != nil {
+		t.Fatalf("close rec: %v", err)
+	}
+
+	// Forge: replace the embedded signer_key with an attacker key but leave
+	// the (now mismatched) signature in place. Verify(tail) must fail.
+	forgeTailSignerKeyOnly(t, dir)
+
+	rec2 := newTestRecorder(t, dir, priv)
+	defer func() { _ = rec2.Close() }()
+	e2 := NewEmitter(EmitterConfig{Recorder: rec2, PrivKey: priv, Principal: testPrincipal, Actor: testActor})
+	if e2.InitError() == nil {
+		t.Fatal("forged tail (foreign key, bad signature) must fail closed, not silently reset")
+	}
+	if e2.pendingTransition != nil {
+		t.Fatal("a forged tail must NOT be accepted as a legitimate rotation")
+	}
+}
+
+// TestResume_EmitFailureIncrementsMetric covers the sealed and chain_init
+// failure label paths through the metric sink.
+func TestResume_EmitFailureIncrementsMetric(t *testing.T) {
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	defer func() { _ = rec.Close() }()
+	metrics := &stubMetrics{}
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, Principal: testPrincipal, Actor: testActor, Metrics: metrics})
+	emitOne(t, e)
+	if err := e.EmitTranscriptRoot("session"); err != nil {
+		t.Fatalf("EmitTranscriptRoot: %v", err)
+	}
+	// Chain sealed: a further Emit fails with the sealed reason.
+	if err := e.Emit(EmitOpts{
+		ActionID: NewActionID(), Target: testTarget, Verdict: config.ActionBlock,
+		Transport: testTransport, Method: http.MethodGet,
+	}); err == nil {
+		t.Fatal("Emit after transcript root must fail (chain sealed)")
+	}
+	found := false
+	for _, r := range metrics.snapshot() {
+		if r == FailReasonSealed {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a %q emit-failure metric, got %v", FailReasonSealed, metrics.snapshot())
+	}
+}
+
+// TestEmitTranscriptRoot_ChainInitFailureRecordsMetric proves that an emitter
+// bricked at construction (tampered tail) also records the chain_init failure
+// metric when EmitTranscriptRoot is called, not just on Emit.
+func TestEmitTranscriptRoot_ChainInitFailureRecordsMetric(t *testing.T) {
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, Principal: testPrincipal, Actor: testActor})
+	emitOne(t, e)
+	if err := rec.Close(); err != nil {
+		t.Fatalf("close rec: %v", err)
+	}
+	corruptTailSignaturePayload(t, dir)
+
+	rec2 := newTestRecorder(t, dir, priv)
+	defer func() { _ = rec2.Close() }()
+	metrics := &stubMetrics{}
+	e2 := NewEmitter(EmitterConfig{Recorder: rec2, PrivKey: priv, Principal: testPrincipal, Actor: testActor, Metrics: metrics})
+	if err := e2.EmitTranscriptRoot("session"); err == nil {
+		t.Fatal("EmitTranscriptRoot on a bricked emitter must return an error")
+	}
+	got := metrics.snapshot()
+	if len(got) == 0 || got[len(got)-1] != FailReasonChainInit {
+		t.Errorf("metric reasons = %v, want last = %q", got, FailReasonChainInit)
+	}
+}
+
+// corruptTailSignaturePayload mutates the tail receipt's action record on disk
+// so its embedded signature no longer matches (tamper), without changing the
+// signer_key. The recorder's outer chain is left intact (we rewrite the entry
+// detail in place via a fresh recorder write would re-sign; instead we edit the
+// JSONL bytes directly).
+func corruptTailSignaturePayload(t *testing.T, dir string) {
+	t.Helper()
+	mutateTailReceipt(t, dir, func(r *Receipt) {
+		// Flip the verdict in the signed record without re-signing: the
+		// signature now covers different canonical bytes -> Verify fails.
+		if r.ActionRecord.Verdict == "block" {
+			r.ActionRecord.Verdict = "allow"
+		} else {
+			r.ActionRecord.Verdict = "block"
+		}
+	})
+}
+
+// forgeTailSignerKeyOnly swaps the embedded signer_key to a fresh attacker key
+// while leaving the original signature bytes, so Verify(tail) fails.
+func forgeTailSignerKeyOnly(t *testing.T, dir string) {
+	t.Helper()
+	attackerPub, _ := generateTestKey(t)
+	mutateTailReceipt(t, dir, func(r *Receipt) {
+		r.SignerKey = hex.EncodeToString(attackerPub)
+	})
+}
+
+// mutateTailReceipt rewrites the last action_receipt entry's Detail in the
+// newest evidence file using mutate, preserving everything else. It edits the
+// recorder JSONL line in place so the recorder's outer hash chain is not
+// re-computed (simulating on-disk tampering of the inner receipt).
+func mutateTailReceipt(t *testing.T, dir string, mutate func(*Receipt)) {
+	t.Helper()
+	dirEntries, err := os.ReadDir(filepath.Clean(dir))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var target string
+	for _, de := range dirEntries {
+		if !de.IsDir() && strings.HasSuffix(de.Name(), ".jsonl") {
+			target = filepath.Join(dir, de.Name())
+		}
+	}
+	if target == "" {
+		t.Fatal("no evidence file found to mutate")
+	}
+	raw, err := os.ReadFile(filepath.Clean(target)) //nolint:gosec // test file under t.TempDir
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	// Find the last line that is an action_receipt entry.
+	idx := -1
+	for i := len(lines) - 1; i >= 0; i-- {
+		var entry recorder.Entry
+		if err := json.Unmarshal([]byte(lines[i]), &entry); err != nil {
+			continue
+		}
+		if entry.Type == recorderEntryType {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		t.Fatal("no action_receipt line found")
+	}
+	var entry map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(lines[idx]), &entry); err != nil {
+		t.Fatalf("unmarshal entry: %v", err)
+	}
+	rcpt, err := Unmarshal(entry["detail"])
+	if err != nil {
+		t.Fatalf("unmarshal detail: %v", err)
+	}
+	mutate(&rcpt)
+	newDetail, err := Marshal(rcpt)
+	if err != nil {
+		t.Fatalf("marshal mutated receipt: %v", err)
+	}
+	entry["detail"] = newDetail
+	newLine, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	lines[idx] = string(newLine)
+	if err := os.WriteFile(filepath.Clean(target), []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+// ed25519 import kept meaningful.
+var _ = ed25519.PublicKeySize

--- a/internal/replaycapture/allowlist.go
+++ b/internal/replaycapture/allowlist.go
@@ -201,6 +201,12 @@ func validateDisallowedEmpty(ar receipt.ActionRecord) error {
 		{"contract_generation", ar.ContractGeneration != 0},
 		{"redaction", ar.Redaction != nil},
 		{"shield", ar.Shield != nil},
+		// key_transition is stamped only on a chain segment boundary after a
+		// signing-key rotation. The synthetic lab captures clean genesis
+		// chains under a single key and never rotates mid-capture, so a
+		// populated marker means an unexpected rotation path leaked into a
+		// published packet. Fail closed.
+		{"key_transition", ar.KeyTransition != nil},
 		{"venue", ar.Venue != ""},
 		{"jurisdiction", ar.Jurisdiction != ""},
 		{"rulebook_id", ar.RulebookID != ""},

--- a/internal/replaycapture/allowlist_test.go
+++ b/internal/replaycapture/allowlist_test.go
@@ -159,6 +159,7 @@ func TestValidateReceiptPublicSafe_ActionRecordFieldCoverage(t *testing.T) {
 		"RequestID":             {},
 		"ChainPrevHash":         {},
 		"ChainSeq":              {},
+		"KeyTransition":         {},
 		"Venue":                 {},
 		"Jurisdiction":          {},
 		"RulebookID":            {},

--- a/sdk/verifiers/rust/src/canonical.rs
+++ b/sdk/verifiers/rust/src/canonical.rs
@@ -177,9 +177,6 @@ fn order_struct(value: &Value, fields: &[FieldSpec]) -> Value {
             field_value = Some(zero_value(spec.name, spec.nested));
         }
         let mut field_value = field_value.expect("field value set");
-        if spec.omitempty && is_go_zero(&field_value) {
-            continue;
-        }
         field_value = match spec.nested {
             Some(NestedKind::ActionRecord) if field_value.is_object() => {
                 order_struct(&field_value, ACTION_RECORD_FIELDS)
@@ -209,6 +206,9 @@ fn order_struct(value: &Value, fields: &[FieldSpec]) -> Value {
             }
             _ => normalize_maps(&field_value),
         };
+        if spec.omitempty && is_go_zero(&field_value) {
+            continue;
+        }
         out.insert(spec.name.to_string(), field_value);
     }
     Value::Object(out)

--- a/sdk/verifiers/rust/src/canonical.rs
+++ b/sdk/verifiers/rust/src/canonical.rs
@@ -7,6 +7,7 @@ enum NestedKind {
     Redaction,
     Shield,
     TaintSource,
+    KeyTransition,
 }
 
 #[derive(Clone, Copy)]
@@ -60,6 +61,7 @@ const ACTION_RECORD_FIELDS: &[FieldSpec] = &[
     field("request_id", true),
     field("chain_prev_hash", false),
     field("chain_seq", false),
+    nested_field("key_transition", true, NestedKind::KeyTransition),
     field("venue", true),
     field("jurisdiction", true),
     field("rulebook_id", true),
@@ -113,6 +115,16 @@ const TAINT_SOURCE_FIELDS: &[FieldSpec] = &[
     field("timestamp", false),
     field("receipt_id", true),
     field("match_reason", true),
+];
+
+// KEY_TRANSITION_FIELDS mirrors receipt.KeyTransition in Go struct-declaration
+// order. Stamped on a segment-genesis receipt after a signing-key rotation; the
+// nested object MUST be reordered to this exact order or a rotated-segment
+// receipt recomputes a different signing hash than the Go signer produced.
+const KEY_TRANSITION_FIELDS: &[FieldSpec] = &[
+    field("prior_signer_key", false),
+    field("prior_chain_seq", false),
+    field("prior_chain_hash", false),
 ];
 
 const fn field(name: &'static str, omitempty: bool) -> FieldSpec {
@@ -192,6 +204,9 @@ fn order_struct(value: &Value, fields: &[FieldSpec]) -> Value {
                     })
                     .collect(),
             ),
+            Some(NestedKind::KeyTransition) if field_value.is_object() => {
+                order_struct(&field_value, KEY_TRANSITION_FIELDS)
+            }
             _ => normalize_maps(&field_value),
         };
         out.insert(spec.name.to_string(), field_value);
@@ -204,7 +219,7 @@ fn zero_value(name: &str, nested: Option<NestedKind>) -> Value {
         return Value::Object(Map::new());
     }
     match name {
-        "version" | "chain_seq" | "level" => Value::Number(Number::from(0)),
+        "version" | "chain_seq" | "level" | "prior_chain_seq" => Value::Number(Number::from(0)),
         "delegation_chain" => Value::Null,
         "timestamp" => Value::String("0001-01-01T00:00:00Z".to_string()),
         _ => Value::String(String::new()),

--- a/sdk/verifiers/rust/tests/canonical.rs
+++ b/sdk/verifiers/rust/tests/canonical.rs
@@ -136,3 +136,32 @@ fn canonical_action_record_with_key_transition_matches_go_hash() {
         "e50a5512f6571afdd0196315580707451ec81e9637e9fb51d988bb6c175b1b40"
     );
 }
+
+#[test]
+fn canonical_action_record_preserves_explicit_empty_key_transition() {
+    let record = json!({
+        "version": 1,
+        "action_id": "ts-kt-empty",
+        "action_type": "read",
+        "timestamp": "2026-05-10T12:34:56.789Z",
+        "principal": "org:test",
+        "actor": "agent:test",
+        "target": "https://example.com/x",
+        "side_effect_class": "external_read",
+        "reversibility": "full",
+        "policy_hash": "sha256:abc",
+        "verdict": "allow",
+        "transport": "fetch",
+        "chain_prev_hash": "priortail",
+        "chain_seq": 0,
+        "key_transition": {}
+    });
+    let canonical =
+        String::from_utf8(canonicalize_action_record(&record)).expect("canonical UTF-8");
+    assert!(
+        canonical.contains(
+            r#""key_transition":{"prior_signer_key":"","prior_chain_seq":0,"prior_chain_hash":""}"#
+        ),
+        "canonical bytes should preserve and normalize explicit empty key_transition: {canonical}"
+    );
+}

--- a/sdk/verifiers/rust/tests/canonical.rs
+++ b/sdk/verifiers/rust/tests/canonical.rs
@@ -103,3 +103,36 @@ fn full_field_receipt_signature_verifies() {
     let receipt = full_receipt();
     verify_receipt(&receipt, "").expect("signature verifies");
 }
+
+// A segment-genesis receipt after a signing-key rotation carries a
+// key_transition marker that the Go signer includes in the canonical preimage
+// (after chain_seq, before venue). The verifier MUST reproduce it byte-for-byte
+// or a rotated receipt fails to verify. Pinned to the Go-produced hash.
+#[test]
+fn canonical_action_record_with_key_transition_matches_go_hash() {
+    let record = json!({
+        "version": 1,
+        "action_id": "ts-kt-0001",
+        "action_type": "read",
+        "timestamp": "2026-05-10T12:34:56.789Z",
+        "principal": "org:test",
+        "actor": "agent:test",
+        "target": "https://example.com/x",
+        "side_effect_class": "external_read",
+        "reversibility": "full",
+        "policy_hash": "sha256:abc",
+        "verdict": "allow",
+        "transport": "fetch",
+        "chain_prev_hash": "priortail",
+        "chain_seq": 0,
+        "key_transition": {
+            "prior_signer_key": "7de2d117b21faaa0f1d9d3d02fcba13838bef0c75caddf71de376f0bb837bfbc",
+            "prior_chain_seq": 41,
+            "prior_chain_hash": "priortail"
+        }
+    });
+    assert_eq!(
+        sha256(&canonicalize_action_record(&record)),
+        "e50a5512f6571afdd0196315580707451ec81e9637e9fb51d988bb6c175b1b40"
+    );
+}

--- a/sdk/verifiers/ts/src/canonical.ts
+++ b/sdk/verifiers/ts/src/canonical.ts
@@ -1,7 +1,7 @@
 import type { ActionRecord, Receipt, JSONValue } from "./types.js";
 
 type FieldSpec = readonly [name: string, omitempty: boolean, nested?: NestedKind];
-type NestedKind = "action_record" | "redaction" | "shield" | "taint_source";
+type NestedKind = "action_record" | "redaction" | "shield" | "taint_source" | "key_transition";
 
 const actionRecordFields: readonly FieldSpec[] = [
   ["version", false],
@@ -47,6 +47,7 @@ const actionRecordFields: readonly FieldSpec[] = [
   ["request_id", true],
   ["chain_prev_hash", false],
   ["chain_seq", false],
+  ["key_transition", true, "key_transition"],
   ["venue", true],
   ["jurisdiction", true],
   ["rulebook_id", true],
@@ -103,6 +104,18 @@ const taintSourceFields: readonly FieldSpec[] = [
   ["match_reason", true],
 ];
 
+// keyTransitionFields mirrors receipt.KeyTransition in Go struct-declaration
+// order. Stamped on a segment-genesis receipt after a signing-key rotation; the
+// nested object MUST be reordered to this exact order before serialization or a
+// rotated-segment receipt recomputes a different signing hash than the Go signer
+// produced. All three fields are required (no omitempty) - the marker is only
+// present as a whole when a rotation occurred.
+const keyTransitionFields: readonly FieldSpec[] = [
+  ["prior_signer_key", false],
+  ["prior_chain_seq", false],
+  ["prior_chain_hash", false],
+];
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -139,6 +152,8 @@ function orderStruct(
       fieldValue = fieldValue.map((item) =>
         isPlainObject(item) ? orderStruct(item, taintSourceFields) : item,
       );
+    } else if (nested === "key_transition" && isPlainObject(fieldValue)) {
+      fieldValue = orderStruct(fieldValue, keyTransitionFields);
     } else {
       fieldValue = normalizeMaps(fieldValue);
     }
@@ -149,7 +164,8 @@ function orderStruct(
 
 function zeroValue(name: string, nested?: NestedKind): unknown {
   if (nested === "action_record") return {};
-  if (name === "version" || name === "chain_seq" || name === "level") return 0;
+  if (name === "version" || name === "chain_seq" || name === "level" || name === "prior_chain_seq")
+    return 0;
   if (name === "delegation_chain") return null;
   if (name === "timestamp") return "0001-01-01T00:00:00Z";
   return "";

--- a/sdk/verifiers/ts/src/canonical.ts
+++ b/sdk/verifiers/ts/src/canonical.ts
@@ -141,7 +141,6 @@ function orderStruct(
       if (omitempty) continue;
       fieldValue = zeroValue(name, nested);
     }
-    if (omitempty && isGoZero(fieldValue)) continue;
     if (nested === "action_record" && isPlainObject(fieldValue)) {
       fieldValue = orderStruct(fieldValue, actionRecordFields);
     } else if (nested === "redaction" && isPlainObject(fieldValue)) {
@@ -157,6 +156,7 @@ function orderStruct(
     } else {
       fieldValue = normalizeMaps(fieldValue);
     }
+    if (omitempty && isGoZero(fieldValue)) continue;
     out[name] = fieldValue;
   }
   return out;

--- a/sdk/verifiers/ts/tests/canonical.test.ts
+++ b/sdk/verifiers/ts/tests/canonical.test.ts
@@ -98,3 +98,37 @@ test("canonical Receipt envelope matches Go hash", () => {
 test("full-field receipt signature verifies", async () => {
   await assert.doesNotReject(verifyReceipt(fullReceipt));
 });
+
+// A segment-genesis receipt after a signing-key rotation carries a
+// key_transition marker. The Go signer includes it in the canonical preimage
+// (json.Marshal struct order, after chain_seq, before venue), so the verifier's
+// reconstructed preimage MUST include it byte-for-byte or a rotated receipt
+// fails to verify. This pins the canonical hash to the Go-produced value.
+const keyTransitionRecord = {
+  version: 1,
+  action_id: "ts-kt-0001",
+  action_type: "read",
+  timestamp: "2026-05-10T12:34:56.789Z",
+  principal: "org:test",
+  actor: "agent:test",
+  target: "https://example.com/x",
+  side_effect_class: "external_read",
+  reversibility: "full",
+  policy_hash: "sha256:abc",
+  verdict: "allow",
+  transport: "fetch",
+  chain_prev_hash: "priortail",
+  chain_seq: 0,
+  key_transition: {
+    prior_signer_key: "7de2d117b21faaa0f1d9d3d02fcba13838bef0c75caddf71de376f0bb837bfbc",
+    prior_chain_seq: 41,
+    prior_chain_hash: "priortail",
+  },
+} as unknown as NonNullable<Receipt["action_record"]>;
+
+test("canonical ActionRecord with key_transition matches Go hash", () => {
+  assert.equal(
+    sha256(canonicalizeActionRecord(keyTransitionRecord)),
+    "e50a5512f6571afdd0196315580707451ec81e9637e9fb51d988bb6c175b1b40",
+  );
+});

--- a/sdk/verifiers/ts/tests/canonical.test.ts
+++ b/sdk/verifiers/ts/tests/canonical.test.ts
@@ -132,3 +132,15 @@ test("canonical ActionRecord with key_transition matches Go hash", () => {
     "e50a5512f6571afdd0196315580707451ec81e9637e9fb51d988bb6c175b1b40",
   );
 });
+
+test("canonical ActionRecord preserves explicitly present empty key_transition", () => {
+  const record = {
+    ...keyTransitionRecord,
+    key_transition: {},
+  } as unknown as NonNullable<Receipt["action_record"]>;
+
+  assert.match(
+    canonicalizeActionRecord(record).toString("utf8"),
+    /"key_transition":\{"prior_signer_key":"","prior_chain_seq":0,"prior_chain_hash":""\}/,
+  );
+});


### PR DESCRIPTION
## Summary

- allow receipt emission to continue after legitimate signing-key rotation by opening a new linked chain segment
- make receipt-chain verification segment-aware while requiring every segment signer to be explicitly trusted
- reject rotated segment suffixes as complete chains so deleted prior segments cannot produce a valid transcript root
- grant operator-only read ACLs on contain evidence directories without granting group access
- preserve pipelock-proxy ownership for evidence directories created during ACL setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-key (rotation-aware) receipt verification and transcript root computation; CLI accepts repeatable --key and prints rotation-aware diagnostics
  * Operator-scoped ACL grant/revoke for evidence dirs to allow offline verification
  * Receipt-emission failure metrics and startup/init diagnostics when receipt emission is disabled

* **Improvements**
  * Preserve/recover existing flight-recorder signing keys during migration instead of always generating replacements
  * Chain resume records key-transition boundaries for rotated segments
  * Canonicalization updated to include key-transition fields

* **Tests**
  * Extensive new tests covering recovery, ACLs, rotation, emitter resume, canonicalization and metrics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->