### PR TITLE
Make receipt verification safe by default

### DIFF
--- a/cmd/pipelock-verifier/chain.go
+++ b/cmd/pipelock-verifier/chain.go
@@ -23,8 +23,9 @@ type chainOptions struct {
 	signerKey string
 	sessionID string
 	evidenceBindingOptions
-	jsonOutput bool
-	asDir      bool
+	jsonOutput    bool
+	asDir         bool
+	allowUnpinned bool
 }
 
 func newChainCmd() *cobra.Command {
@@ -37,15 +38,9 @@ func newChainCmd() *cobra.Command {
 		Long: `Verifies the hash linkage of a Pipelock receipt chain. PATH may be a
 single .jsonl evidence file or a session directory when --dir is set.
 
-Legacy ActionReceipt v1 chains verify signatures against the embedded signer
-key unless --key is supplied. EvidenceReceipt v2 chains do not embed a public
-key, so without --key the verifier checks structure, signer-id consistency,
-seq monotonicity, and hash linkage only; with --key it verifies every Ed25519
-signature against the pinned key.
-
-Without --key the verifier confirms self-consistency: every receipt's
-signer must match the first receipt's signer, and prev-hash linkage must
-hold. Self-consistency does not prove provenance.
+Legacy ActionReceipt v1 and EvidenceReceipt v2 chains require --key for
+trusted provenance. Pass --allow-unpinned for loud structural-only
+verification. Self-consistency does not prove provenance.
 
 With --key the verifier requires every receipt to be signed by the named
 key.`,
@@ -66,6 +61,7 @@ key.`,
 	cmd.Flags().StringVar(&opts.expectPayloadKind, "expect-payload-kind", "", "EvidenceReceipt v2: require payload_kind")
 	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit a structured JSON verdict on stdout")
 	cmd.Flags().BoolVar(&opts.asDir, "dir", false, "treat PATH as a session directory rather than a single file")
+	cmd.Flags().BoolVar(&opts.allowUnpinned, "allow-unpinned", false, "allow structural-only verification without a trusted signer key")
 
 	return cmd
 }
@@ -80,6 +76,7 @@ type chainReport struct {
 	FinalSeq           uint64 `json:"final_seq"`
 	RootHash           string `json:"root_hash,omitempty"`
 	SignaturesVerified bool   `json:"signatures_verified"`
+	Unpinned           bool   `json:"unpinned,omitempty"`
 	SignerKeyID        string `json:"signer_key_id,omitempty"`
 	Error              string `json:"error,omitempty"`
 	BrokenAtSeq        uint64 `json:"broken_at_seq,omitempty"`
@@ -145,12 +142,20 @@ func verifyActionChain(stdout, stderr io.Writer, label string, receipts []action
 		// Provenance only when an out-of-band key is pinned AND every
 		// signature verified; an empty key is self-consistency only.
 		SignaturesVerified: res.Valid && keyHex != "",
+		Unpinned:           res.Valid && keyHex == "",
 		Error:              res.Error,
 		BrokenAtSeq:        res.BrokenAtSeq,
+	}
+	if res.Valid && keyHex == "" {
+		report.Error = unpinnedReceiptBanner
+		report.Valid = opts.allowUnpinned
 	}
 	emitChainReport(stdout, stderr, report, opts.jsonOutput)
 	if !res.Valid {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("chain rejected at seq %d: %s", res.BrokenAtSeq, res.Error))
+	}
+	if keyHex == "" && !opts.allowUnpinned {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("chain verification unpinned"))
 	}
 	return nil
 }
@@ -196,13 +201,21 @@ func verifyEvidenceChain(stdout, stderr io.Writer, label string, receipts []cont
 		FinalSeq:           res.FinalSeq,
 		RootHash:           res.RootHash,
 		SignaturesVerified: res.SignaturesVerified,
+		Unpinned:           res.Valid && !res.SignaturesVerified,
 		SignerKeyID:        res.SignerKeyID,
 		Error:              res.Error,
 		BrokenAtSeq:        res.BrokenAtSeq,
 	}
+	if res.Valid && !res.SignaturesVerified {
+		report.Error = unpinnedReceiptBanner
+		report.Valid = opts.allowUnpinned
+	}
 	emitChainReport(stdout, stderr, report, opts.jsonOutput)
 	if !res.Valid {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("evidence chain rejected at seq %d: %s", res.BrokenAtSeq, res.Error))
+	}
+	if !res.SignaturesVerified && !opts.allowUnpinned {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("evidence chain verification unpinned"))
 	}
 	return nil
 }

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -590,6 +590,44 @@ func TestChain_Valid(t *testing.T) {
 	}
 }
 
+func TestChain_ActionWithoutKeyFailsUnpinned(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+	evidence := filepath.Join(dir, "evidence.jsonl")
+
+	stdout, stderr, code := runRoot(t, "chain", evidence)
+	if code == cliutil.ExitOK {
+		t.Fatalf("unpinned action chain should fail, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "CHAIN UNPINNED") {
+		t.Fatalf("stderr = %q, want CHAIN UNPINNED", stderr)
+	}
+	if !strings.Contains(stderr, unpinnedReceiptBanner) {
+		t.Fatalf("stderr = %q, want unpinned warning", stderr)
+	}
+}
+
+func TestChain_ActionAllowUnpinned(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+	evidence := filepath.Join(dir, "evidence.jsonl")
+
+	stdout, stderr, code := runRoot(t, "chain", "--allow-unpinned", evidence)
+	if code != cliutil.ExitOK {
+		t.Fatalf("allow-unpinned action chain should pass, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "CHAIN UNPINNED") {
+		t.Fatalf("stdout = %q, want CHAIN UNPINNED", stdout)
+	}
+	if !strings.Contains(stdout, "warning:") {
+		t.Fatalf("stdout = %q, want warning", stdout)
+	}
+}
+
 func TestChain_TamperedSignature(t *testing.T) {
 	t.Parallel()
 	fix := newFixture(t, 2)
@@ -756,6 +794,31 @@ func TestReceipt_V1WithoutKeyIsNotProvenance(t *testing.T) {
 	}
 }
 
+func TestReceipt_V1AllowUnpinned(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 1)
+	dir := t.TempDir()
+	rPath := filepath.Join(dir, "r.json")
+	data, err := receipt.Marshal(fix.receipts[0])
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(rPath, data, 0o600); err != nil {
+		t.Fatalf("write receipt: %v", err)
+	}
+
+	stdout, stderr, code := runRoot(t, "receipt", "--allow-unpinned", rPath)
+	if code != cliutil.ExitOK {
+		t.Fatalf("allow-unpinned receipt should pass, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "RECEIPT UNPINNED") {
+		t.Fatalf("stdout = %q, want RECEIPT UNPINNED", stdout)
+	}
+	if !strings.Contains(stdout, "signature is self-consistent") {
+		t.Fatalf("stdout = %q, want unpinned warning", stdout)
+	}
+}
+
 func TestReceipt_EvidenceV2PinnedKey(t *testing.T) {
 	t.Parallel()
 	fix := newEvidenceFixture(t, 1)
@@ -803,6 +866,55 @@ func TestReceipt_EvidenceV2WithoutKeyIsNotProvenance(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "RECEIPT UNPINNED") {
 		t.Fatalf("stderr = %q, want unpinned trust boundary", stderr)
+	}
+}
+
+func TestReceipt_EvidenceV2AllowUnpinned(t *testing.T) {
+	t.Parallel()
+	fix := newEvidenceFixture(t, 1)
+	dir := t.TempDir()
+	rPath := filepath.Join(dir, "shadow-delta.json")
+	data, err := json.Marshal(fix.receipts[0])
+	if err != nil {
+		t.Fatalf("Marshal evidence receipt: %v", err)
+	}
+	if err := os.WriteFile(rPath, data, 0o600); err != nil {
+		t.Fatalf("write evidence receipt: %v", err)
+	}
+
+	stdout, stderr, code := runRoot(t, "receipt", "--allow-unpinned", rPath)
+	if code != cliutil.ExitOK {
+		t.Fatalf("allow-unpinned v2 receipt should pass, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "RECEIPT UNPINNED") {
+		t.Fatalf("stdout = %q, want RECEIPT UNPINNED", stdout)
+	}
+	if !strings.Contains(stdout, "signature:    not checked") {
+		t.Fatalf("stdout = %q, want signature not checked", stdout)
+	}
+}
+
+func TestReceipt_EvidenceV2WithoutKeyValidationFailure(t *testing.T) {
+	t.Parallel()
+	fix := newEvidenceFixture(t, 1)
+	bad := fix.receipts[0]
+	bad.ReceiptVersion = 99
+	dir := t.TempDir()
+	rPath := filepath.Join(dir, "shadow-delta.json")
+	data, err := json.Marshal(bad)
+	if err != nil {
+		t.Fatalf("Marshal evidence receipt: %v", err)
+	}
+	if err := os.WriteFile(rPath, data, 0o600); err != nil {
+		t.Fatalf("write evidence receipt: %v", err)
+	}
+
+	_, stderr, code := runRoot(t, "receipt", rPath)
+	if code == cliutil.ExitOK {
+		t.Fatalf("invalid v2 receipt should fail, stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "RECEIPT INVALID") {
+		t.Fatalf("stderr = %q, want RECEIPT INVALID", stderr)
 	}
 }
 
@@ -880,6 +992,27 @@ func TestReceipt_EvidenceV2RecheckSourceSpanMismatchReportsInvalid(t *testing.T)
 	}
 	if !strings.Contains(rpt.Error, "redacted_sample mismatch") {
 		t.Fatalf("error=%q", rpt.Error)
+	}
+}
+
+func TestReceipt_EvidenceV2RecheckSourceSpanMismatchWithoutKey(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.txt")
+	if err := os.WriteFile(sourcePath, []byte("https://example.com/xxxxxxxxxxxxxxxx"), 0o600); err != nil {
+		t.Fatalf("write recheck source: %v", err)
+	}
+	receiptPath := filepath.Clean(filepath.Join("..", "..", "internal", "contract", "testdata", "golden", "valid_evidence_receipt_proxy_decision_with_spans.json"))
+	_, stderr, code := runRoot(t,
+		"receipt",
+		"--recheck-source", sourcePath,
+		receiptPath,
+	)
+	if code == cliutil.ExitOK {
+		t.Fatalf("v2 recheck mismatch without key should fail, stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "redacted_sample mismatch") {
+		t.Fatalf("stderr=%q, want redacted_sample mismatch", stderr)
 	}
 }
 
@@ -1231,6 +1364,41 @@ func TestChain_EvidenceV2PinnedKey(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "signatures: verified") {
 		t.Fatalf("stdout = %q, want signatures verified", stdout)
+	}
+}
+
+func TestChain_EvidenceV2WithoutKeyFailsUnpinned(t *testing.T) {
+	t.Parallel()
+	fix := newEvidenceFixture(t, 2)
+	dir := t.TempDir()
+	evidence := filepath.Join(dir, "evidence.jsonl")
+	fix.writeEvidenceJSONL(t, evidence)
+
+	stdout, stderr, code := runRoot(t, "chain", evidence)
+	if code == cliutil.ExitOK {
+		t.Fatalf("unpinned v2 chain should fail, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "CHAIN UNPINNED") {
+		t.Fatalf("stderr = %q, want CHAIN UNPINNED", stderr)
+	}
+}
+
+func TestChain_EvidenceV2AllowUnpinned(t *testing.T) {
+	t.Parallel()
+	fix := newEvidenceFixture(t, 2)
+	dir := t.TempDir()
+	evidence := filepath.Join(dir, "evidence.jsonl")
+	fix.writeEvidenceJSONL(t, evidence)
+
+	stdout, stderr, code := runRoot(t, "chain", "--allow-unpinned", evidence)
+	if code != cliutil.ExitOK {
+		t.Fatalf("allow-unpinned v2 chain should pass, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "CHAIN UNPINNED") {
+		t.Fatalf("stdout = %q, want CHAIN UNPINNED", stdout)
+	}
+	if !strings.Contains(stdout, "signatures: not checked") {
+		t.Fatalf("stdout = %q, want signatures not checked", stdout)
 	}
 }
 

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -581,7 +581,7 @@ func TestChain_Valid(t *testing.T) {
 	_ = pkt
 	evidence := filepath.Join(dir, "evidence.jsonl")
 
-	stdout, _, code := runRoot(t, "chain", evidence)
+	stdout, _, code := runRoot(t, "chain", "--key", fix.keyHex, evidence)
 	if code != cliutil.ExitOK {
 		t.Fatalf("valid chain should pass, stdout=%q", stdout)
 	}
@@ -626,7 +626,7 @@ func TestChain_JSONOutput(t *testing.T) {
 	fix.writePacketDir(t, dir, nil)
 	evidence := filepath.Join(dir, "evidence.jsonl")
 
-	stdout, _, code := runRoot(t, "chain", "--json", evidence)
+	stdout, _, code := runRoot(t, "chain", "--key", fix.keyHex, "--json", evidence)
 	if code != cliutil.ExitOK {
 		t.Fatalf("valid chain --json should pass")
 	}
@@ -669,7 +669,7 @@ func TestReceipt_Valid(t *testing.T) {
 		t.Fatalf("write receipt: %v", err)
 	}
 
-	stdout, _, code := runRoot(t, "receipt", rPath)
+	stdout, _, code := runRoot(t, "receipt", "--key", fix.keyHex, rPath)
 	if code != cliutil.ExitOK {
 		t.Fatalf("valid receipt should pass, stdout=%q", stdout)
 	}
@@ -690,7 +690,7 @@ func TestReceipt_TamperedSignature(t *testing.T) {
 		t.Fatalf("write tampered: %v", err)
 	}
 
-	_, stderr, code := runRoot(t, "receipt", rPath)
+	_, stderr, code := runRoot(t, "receipt", "--allow-unpinned", rPath)
 	if code == cliutil.ExitOK {
 		t.Fatalf("tampered receipt should fail, stderr=%q", stderr)
 	}
@@ -709,7 +709,7 @@ func TestReceipt_JSONOutput(t *testing.T) {
 		t.Fatalf("write receipt: %v", err)
 	}
 
-	stdout, _, code := runRoot(t, "receipt", "--json", rPath)
+	stdout, _, code := runRoot(t, "receipt", "--key", fix.keyHex, "--json", rPath)
 	if code != cliutil.ExitOK {
 		t.Fatalf("valid receipt --json should pass")
 	}
@@ -736,15 +736,18 @@ func TestReceipt_V1WithoutKeyIsNotProvenance(t *testing.T) {
 	}
 
 	stdout, _, code := runRoot(t, "receipt", "--json", rPath)
-	if code != cliutil.ExitOK {
-		t.Fatalf("valid v1 receipt should pass without a key")
+	if code == cliutil.ExitOK {
+		t.Fatalf("unpinned v1 receipt should exit non-zero")
 	}
 	var rpt receiptReport
 	if err := json.Unmarshal([]byte(stdout), &rpt); err != nil {
 		t.Fatalf("parse json: %v", err)
 	}
-	if !rpt.Valid {
-		t.Fatalf("expected valid=true, got %+v", rpt)
+	if rpt.Valid {
+		t.Fatalf("expected valid=false, got %+v", rpt)
+	}
+	if !rpt.Unpinned {
+		t.Fatalf("expected unpinned=true, got %+v", rpt)
 	}
 	// Without a pinned --key, v1 verifies against the embedded signer key
 	// (self-consistency), which is not provenance — mirror the v2 contract.
@@ -795,11 +798,11 @@ func TestReceipt_EvidenceV2WithoutKeyIsNotProvenance(t *testing.T) {
 	}
 
 	stdout, stderr, code := runRoot(t, "receipt", rPath)
-	if code != cliutil.ExitOK {
-		t.Fatalf("v2 receipt structure check should pass, stdout=%q stderr=%q", stdout, stderr)
+	if code == cliutil.ExitOK {
+		t.Fatalf("v2 receipt without key should exit non-zero, stdout=%q stderr=%q", stdout, stderr)
 	}
-	if !strings.Contains(stdout, "not checked") {
-		t.Fatalf("stdout = %q, want not checked trust boundary", stdout)
+	if !strings.Contains(stderr, "RECEIPT UNPINNED") {
+		t.Fatalf("stderr = %q, want unpinned trust boundary", stderr)
 	}
 }
 
@@ -1183,7 +1186,7 @@ func TestChain_DirMode(t *testing.T) {
 	if err := os.Rename(src, dst); err != nil {
 		t.Fatalf("rename: %v", err)
 	}
-	stdout, _, code := runRoot(t, "chain", "--dir", dir)
+	stdout, _, code := runRoot(t, "chain", "--key", fix.keyHex, "--dir", dir)
 	if code != cliutil.ExitOK {
 		t.Fatalf("--dir mode should pass, stdout=%q", stdout)
 	}

--- a/cmd/pipelock-verifier/output.go
+++ b/cmd/pipelock-verifier/output.go
@@ -16,6 +16,8 @@ import (
 	sigutil "github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
+const unpinnedReceiptBanner = "UNPINNED — signature is self-consistent but the signer was NOT checked against a trusted key"
+
 // emitReport writes the audit-packet report to stdout in either JSON or
 // human-readable form. The human form is loosely structured so script
 // consumers should prefer --json.
@@ -73,7 +75,12 @@ func emitChainReport(stdout, stderr io.Writer, r chainReport, jsonMode bool) {
 		return
 	}
 	if r.Valid {
-		_, _ = fmt.Fprintf(stdout, "CHAIN VALID: %s\n", r.Path)
+		if r.Unpinned {
+			_, _ = fmt.Fprintf(stdout, "CHAIN UNPINNED: %s\n", r.Path)
+			_, _ = fmt.Fprintf(stdout, "  warning:    %s\n", unpinnedReceiptBanner)
+		} else {
+			_, _ = fmt.Fprintf(stdout, "CHAIN VALID: %s\n", r.Path)
+		}
 		if r.RecordType != "" {
 			_, _ = fmt.Fprintf(stdout, "  record_type: %s\n", r.RecordType)
 		}
@@ -88,6 +95,11 @@ func emitChainReport(stdout, stderr io.Writer, r chainReport, jsonMode bool) {
 				_, _ = fmt.Fprintln(stdout, "  signatures: not checked (self-consistency only; pass --key for provenance)")
 			}
 		}
+		return
+	}
+	if r.Unpinned {
+		_, _ = fmt.Fprintf(stderr, "CHAIN UNPINNED: %s\n", r.Path)
+		_, _ = fmt.Fprintf(stderr, "  warning:    %s\n", unpinnedReceiptBanner)
 		return
 	}
 	_, _ = fmt.Fprintf(stderr, "CHAIN BROKEN: %s\n", r.Path)
@@ -106,7 +118,12 @@ func emitReceiptReport(stdout, stderr io.Writer, r receiptReport, jsonMode bool)
 		return
 	}
 	if r.Valid {
-		_, _ = fmt.Fprintf(stdout, "RECEIPT VALID: %s\n", r.Path)
+		if r.Unpinned {
+			_, _ = fmt.Fprintf(stdout, "RECEIPT UNPINNED: %s\n", r.Path)
+			_, _ = fmt.Fprintf(stdout, "  warning:      %s\n", unpinnedReceiptBanner)
+		} else {
+			_, _ = fmt.Fprintf(stdout, "RECEIPT VALID: %s\n", r.Path)
+		}
 		if r.RecordType != "" {
 			_, _ = fmt.Fprintf(stdout, "  record_type:  %s\n", r.RecordType)
 		}
@@ -136,6 +153,11 @@ func emitReceiptReport(stdout, stderr io.Writer, r receiptReport, jsonMode bool)
 		_, _ = fmt.Fprintf(stdout, "  signer:       %s\n", r.SignerKey)
 		_, _ = fmt.Fprintf(stdout, "  policy_hash:  %s\n", r.PolicyHash)
 		_, _ = fmt.Fprintf(stdout, "  chain_seq:    %d\n", r.ChainSeq)
+		return
+	}
+	if r.Unpinned {
+		_, _ = fmt.Fprintf(stderr, "RECEIPT UNPINNED: %s\n", r.Path)
+		_, _ = fmt.Fprintf(stderr, "  warning: %s\n", unpinnedReceiptBanner)
 		return
 	}
 	_, _ = fmt.Fprintf(stderr, "RECEIPT INVALID: %s\n", r.Path)

--- a/cmd/pipelock-verifier/receipt.go
+++ b/cmd/pipelock-verifier/receipt.go
@@ -20,6 +20,7 @@ type receiptOptions struct {
 	signerKey string
 	evidenceBindingOptions
 	jsonOutput       bool
+	allowUnpinned    bool
 	recheckSource    string
 	recheckSpanIndex int
 }
@@ -32,10 +33,10 @@ func newReceiptCmd() *cobra.Command {
 		Short: "Verify a single Pipelock receipt",
 		Long: `Verifies a single Pipelock receipt written as JSON.
 
-Legacy ActionReceipt v1 files verify against their embedded signer_key unless
---key is supplied. EvidenceReceipt v2 files do not embed a public key, so
-without --key the verifier checks structure and canonical hashability only;
-with --key it verifies the Ed25519 signature against the pinned key.`,
+Legacy ActionReceipt v1 files require --key for trusted provenance. Pass
+--allow-unpinned for loud structural-only verification against the embedded
+signer key. EvidenceReceipt v2 files do not embed a public key, so --key is
+required unless --allow-unpinned is used for structural checks only.`,
 		Args:          exactOneArg,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -53,6 +54,7 @@ with --key it verifies the Ed25519 signature against the pinned key.`,
 	cmd.Flags().StringVar(&opts.recheckSource, "recheck-source", "", "EvidenceReceipt v2 spans: source file containing the normalized/redacted source view input")
 	cmd.Flags().IntVar(&opts.recheckSpanIndex, "recheck-span-index", 0, "EvidenceReceipt v2 spans: source_spans index to recheck")
 	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit a structured JSON verdict on stdout")
+	cmd.Flags().BoolVar(&opts.allowUnpinned, "allow-unpinned", false, "allow structural-only verification without a trusted signer key")
 
 	return cmd
 }
@@ -62,6 +64,7 @@ type receiptReport struct {
 	RecordType         string `json:"record_type,omitempty"`
 	Valid              bool   `json:"valid"`
 	SignaturesVerified bool   `json:"signatures_verified"`
+	Unpinned           bool   `json:"unpinned,omitempty"`
 	ActionID           string `json:"action_id,omitempty"`
 	Verdict            string `json:"verdict,omitempty"`
 	Transport          string `json:"transport,omitempty"`
@@ -136,10 +139,18 @@ func runActionReceipt(stdout, stderr io.Writer, clean string, data []byte, keyHe
 		emitReceiptReport(stdout, stderr, report, opts.jsonOutput)
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("verify: %w", err))
 	}
+	if keyHex == "" {
+		report.Unpinned = true
+		report.Error = unpinnedReceiptBanner
+		report.Valid = opts.allowUnpinned
+		emitReceiptReport(stdout, stderr, report, opts.jsonOutput)
+		if !opts.allowUnpinned {
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("verify: unpinned receipt"))
+		}
+		return nil
+	}
 	report.Valid = true
-	// Provenance only when an out-of-band key is pinned; an empty key
-	// verifies against the receipt's embedded signer (self-consistency).
-	report.SignaturesVerified = keyHex != ""
+	report.SignaturesVerified = true
 	emitReceiptReport(stdout, stderr, report, opts.jsonOutput)
 	return nil
 }
@@ -160,6 +171,33 @@ func runEvidenceReceipt(stdout, stderr io.Writer, clean string, data []byte, key
 		ActiveManifestHash: r.ActiveManifestHash,
 		PolicyHash:         r.PolicyHash,
 		ChainSeq:           r.ChainSeq,
+	}
+	if keyHex == "" {
+		if err := r.Validate(); err != nil {
+			report.Valid = false
+			report.Error = err.Error()
+			emitReceiptReport(stdout, stderr, report, opts.jsonOutput)
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("validate evidence receipt: %w", err))
+		}
+		if opts.recheckSource != "" {
+			result, recheckErr := recheckEvidenceReceiptSpan(r, opts.recheckSource, opts.recheckSpanIndex)
+			report.RecheckValid = &result.Valid
+			report.RecheckView = result.View
+			if recheckErr != nil {
+				report.Valid = false
+				report.Error = recheckErr.Error()
+				emitReceiptReport(stdout, stderr, report, opts.jsonOutput)
+				return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("recheck evidence receipt: %w", recheckErr))
+			}
+		}
+		report.Unpinned = true
+		report.Error = unpinnedReceiptBanner
+		report.Valid = opts.allowUnpinned
+		emitReceiptReport(stdout, stderr, report, opts.jsonOutput)
+		if !opts.allowUnpinned {
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("verify evidence receipt: unpinned receipt"))
+		}
+		return nil
 	}
 	sigVerified, err := verifyEvidenceReceipt(r, keyHex, opts.evidenceBindingOptions)
 	if err != nil {

--- a/internal/cli/signing/receipt.go
+++ b/internal/cli/signing/receipt.go
@@ -352,7 +352,7 @@ func resolveExpectedKeyHexes(keys []string) ([]string, error) {
 	for _, k := range keys {
 		resolved, err := resolveExpectedKeyHex(k)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("resolving --key %q: %w", k, err)
 		}
 		if resolved != "" {
 			out = append(out, resolved)

--- a/internal/cli/signing/receipt.go
+++ b/internal/cli/signing/receipt.go
@@ -18,11 +18,14 @@ import (
 	sigutil "github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
+const unpinnedReceiptBanner = "UNPINNED — signature is self-consistent but the signer was NOT checked against a trusted key"
+
 // VerifyReceiptCmd returns the "verify-receipt" cobra command.
 func VerifyReceiptCmd() *cobra.Command {
 	var expectedKey string
 	var chainDir string
 	var sessionID string
+	var allowUnpinned bool
 
 	cmd := &cobra.Command{
 		Use:   "verify-receipt [file]",
@@ -51,28 +54,29 @@ Examples:
 				return fmt.Errorf("loading public key: %w", err)
 			}
 			if chainDir != "" {
-				return verifyChainFromSessionDir(out, chainDir, sessionID, resolvedKey)
+				return verifyChainFromSessionDirWithOptions(out, chainDir, sessionID, resolvedKey, allowUnpinned)
 			}
 
 			path := args[0]
 
 			// JSONL files: extract receipts and verify the full chain.
 			if strings.HasSuffix(path, ".jsonl") {
-				return verifyChainFromFile(out, path, resolvedKey)
+				return verifyChainFromFileWithOptions(out, path, resolvedKey, allowUnpinned)
 			}
 
 			// Single receipt JSON file.
-			return verifySingleReceipt(out, path, resolvedKey)
+			return verifySingleReceiptWithOptions(out, path, resolvedKey, allowUnpinned)
 		},
 	}
 
 	cmd.Flags().StringVar(&expectedKey, "key", "", "expected signer public key (hex or file path)")
 	cmd.Flags().StringVar(&chainDir, "chain", "", "verify the full receipt chain from an evidence directory")
 	cmd.Flags().StringVar(&sessionID, "session", "proxy", "receipt chain session ID inside the evidence directory")
+	cmd.Flags().BoolVar(&allowUnpinned, "allow-unpinned", false, "allow structural-only verification without a trusted signer key")
 	return cmd
 }
 
-func verifySingleReceipt(out io.Writer, path, expectedKey string) error {
+func verifySingleReceiptWithOptions(out io.Writer, path, expectedKey string, allowUnpinned bool) error {
 	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return fmt.Errorf("reading receipt: %w", err)
@@ -88,29 +92,46 @@ func verifySingleReceipt(out io.Writer, path, expectedKey string) error {
 		return fmt.Errorf("verification failed: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(out, "OK: %s\n", path)
+	if expectedKey == "" {
+		_, _ = fmt.Fprintf(out, "UNPINNED: %s\n", path)
+		_, _ = fmt.Fprintln(out, unpinnedReceiptBanner)
+		if !allowUnpinned {
+			printReceiptDetails(out, r)
+			return fmt.Errorf("verification unpinned: pass --key for provenance or --allow-unpinned for structural-only verification")
+		}
+	} else {
+		_, _ = fmt.Fprintf(out, "OK: %s\n", path)
+	}
 	printReceiptDetails(out, r)
 	return nil
 }
 
 func verifyChainFromFile(out io.Writer, path, expectedKey string) error {
+	return verifyChainFromFileWithOptions(out, path, expectedKey, false)
+}
+
+func verifyChainFromFileWithOptions(out io.Writer, path, expectedKey string, allowUnpinned bool) error {
 	receipts, err := receipt.ExtractReceipts(path)
 	if err != nil {
 		return fmt.Errorf("extracting receipts: %w", err)
 	}
-	return verifyChain(out, path, receipts, expectedKey)
+	return verifyChainWithOptions(out, path, receipts, expectedKey, allowUnpinned)
 }
 
-func verifyChainFromSessionDir(out io.Writer, dir, sessionID, expectedKey string) error {
+func verifyChainFromSessionDirWithOptions(out io.Writer, dir, sessionID, expectedKey string, allowUnpinned bool) error {
 	receipts, err := receipt.ExtractReceiptsFromSessionDir(dir, sessionID)
 	if err != nil {
 		return fmt.Errorf("extracting session receipts: %w", err)
 	}
 	label := fmt.Sprintf("%s (session %s)", dir, sessionID)
-	return verifyChain(out, label, receipts, expectedKey)
+	return verifyChainWithOptions(out, label, receipts, expectedKey, allowUnpinned)
 }
 
 func verifyChain(out io.Writer, label string, receipts []receipt.Receipt, expectedKey string) error {
+	return verifyChainWithOptions(out, label, receipts, expectedKey, false)
+}
+
+func verifyChainWithOptions(out io.Writer, label string, receipts []receipt.Receipt, expectedKey string, allowUnpinned bool) error {
 	if len(receipts) == 0 {
 		_, _ = fmt.Fprintf(out, "No receipts found in %s\n", label)
 		return fmt.Errorf("no receipts in %s", label)
@@ -124,12 +145,22 @@ func verifyChain(out io.Writer, label string, receipts []receipt.Receipt, expect
 		return fmt.Errorf("chain verification failed at seq %d: %s", result.BrokenAtSeq, result.Error)
 	}
 
-	_, _ = fmt.Fprintf(out, "CHAIN VALID: %s\n", label)
+	if expectedKey == "" {
+		_, _ = fmt.Fprintf(out, "CHAIN UNPINNED: %s\n", label)
+	} else {
+		_, _ = fmt.Fprintf(out, "CHAIN VALID: %s\n", label)
+	}
 	_, _ = fmt.Fprintf(out, "  Receipts:  %d\n", result.ReceiptCount)
 	_, _ = fmt.Fprintf(out, "  Final seq: %d\n", result.FinalSeq)
 	_, _ = fmt.Fprintf(out, "  Root hash: %s\n", result.RootHash)
 	_, _ = fmt.Fprintf(out, "  Start:     %s\n", result.StartTime.Format("2006-01-02T15:04:05Z"))
 	_, _ = fmt.Fprintf(out, "  End:       %s\n", result.EndTime.Format("2006-01-02T15:04:05Z"))
+	if expectedKey == "" {
+		_, _ = fmt.Fprintln(out, unpinnedReceiptBanner)
+		if !allowUnpinned {
+			return fmt.Errorf("chain verification unpinned: pass --key for provenance or --allow-unpinned for structural-only verification")
+		}
+	}
 	return nil
 }
 

--- a/internal/cli/signing/receipt_test.go
+++ b/internal/cli/signing/receipt_test.go
@@ -840,3 +840,15 @@ func TestVerifyChain_WrongKeyBreaksChain(t *testing.T) {
 		t.Errorf("expected 'Broke at' detail, got: %s", buf.String())
 	}
 }
+
+func TestResolveExpectedKeyHexesWrapsFailedKey(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveExpectedKeyHexes([]string{"not-a-key"})
+	if err == nil {
+		t.Fatal("expected invalid key to fail")
+	}
+	if !strings.Contains(err.Error(), `resolving --key "not-a-key"`) {
+		t.Fatalf("expected failing key in error, got %v", err)
+	}
+}

--- a/internal/cli/signing/receipt_test.go
+++ b/internal/cli/signing/receipt_test.go
@@ -57,16 +57,66 @@ func TestVerifyReceiptCmd_ValidReceipt(t *testing.T) {
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	cmd.SetArgs([]string{path})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected unpinned receipt verification to exit non-zero")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "UNPINNED:") {
+		t.Errorf("expected UNPINNED in output, got: %s", output)
+	}
+	if !strings.Contains(output, unpinnedReceiptBanner) {
+		t.Errorf("expected unpinned banner in output, got: %s", output)
+	}
+	if !strings.Contains(output, ar.ActionID) {
+		t.Errorf("expected action_id in output, got: %s", output)
+	}
+}
+
+func TestVerifyReceiptCmd_AllowUnpinnedValidReceipt(t *testing.T) {
+	t.Parallel()
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	ar := receipt.ActionRecord{
+		Version:         receipt.ActionRecordVersion,
+		ActionID:        receipt.NewActionID(),
+		ActionType:      receipt.ActionRead,
+		Timestamp:       time.Now().UTC(),
+		Target:          "https://example.com/api",
+		Verdict:         "block",
+		Transport:       "fetch",
+		SideEffectClass: receipt.SideEffectExternalRead,
+		Reversibility:   receipt.ReversibilityFull,
+	}
+	r, err := receipt.Sign(ar, priv)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	data, err := receipt.Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "receipt.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := VerifyReceiptCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{path, "--allow-unpinned"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 
-	output := buf.String()
-	if !strings.Contains(output, "OK:") {
-		t.Errorf("expected OK in output, got: %s", output)
-	}
-	if !strings.Contains(output, ar.ActionID) {
-		t.Errorf("expected action_id in output, got: %s", output)
+	if !strings.Contains(buf.String(), "UNPINNED:") {
+		t.Errorf("expected UNPINNED in output, got: %s", buf.String())
 	}
 }
 
@@ -236,7 +286,7 @@ func TestVerifyReceiptCmd_InvalidFile(t *testing.T) {
 	cmd := VerifyReceiptCmd()
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{path})
+	cmd.SetArgs([]string{path, "--allow-unpinned"})
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("expected error for invalid JSON")
 	}
@@ -305,7 +355,7 @@ func TestVerifyReceiptCmd_ReceiptWithMethodShowsFullRecord(t *testing.T) {
 	cmd := VerifyReceiptCmd()
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{path})
+	cmd.SetArgs([]string{path, "--allow-unpinned"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -433,13 +483,38 @@ func TestVerifyReceiptCmd_ChainValid(t *testing.T) {
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	cmd.SetArgs([]string{path})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected unpinned chain verification to exit non-zero")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "CHAIN UNPINNED") {
+		t.Errorf("expected CHAIN UNPINNED, got: %s", output)
+	}
+	if !strings.Contains(output, unpinnedReceiptBanner) {
+		t.Errorf("expected unpinned banner, got: %s", output)
+	}
+	if !strings.Contains(output, "Receipts:  5") {
+		t.Errorf("expected 5 receipts, got: %s", output)
+	}
+}
+
+func TestVerifyReceiptCmd_ChainAllowUnpinned(t *testing.T) {
+	t.Parallel()
+
+	path, _ := buildChainJSONL(t, 5)
+
+	cmd := VerifyReceiptCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{path, "--allow-unpinned"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "CHAIN VALID") {
-		t.Errorf("expected CHAIN VALID, got: %s", output)
+	if !strings.Contains(output, "CHAIN UNPINNED") {
+		t.Errorf("expected CHAIN UNPINNED, got: %s", output)
 	}
 	if !strings.Contains(output, "Receipts:  5") {
 		t.Errorf("expected 5 receipts, got: %s", output)
@@ -692,14 +767,23 @@ func TestVerifyChain_ValidReceiptsNoKey(t *testing.T) {
 
 	var buf bytes.Buffer
 	err = verifyChain(&buf, "test-chain", receipts, "")
-	if err != nil {
-		t.Fatalf("verifyChain: %v", err)
+	if err == nil {
+		t.Fatal("expected unpinned chain verification to fail closed")
 	}
-	if !strings.Contains(buf.String(), "CHAIN VALID") {
-		t.Errorf("expected CHAIN VALID, got: %s", buf.String())
+	if !strings.Contains(buf.String(), "CHAIN UNPINNED") {
+		t.Errorf("expected CHAIN UNPINNED, got: %s", buf.String())
 	}
 	if !strings.Contains(buf.String(), "Receipts:  4") {
 		t.Errorf("expected 4 receipts, got: %s", buf.String())
+	}
+
+	buf.Reset()
+	err = verifyChainWithOptions(&buf, "test-chain", receipts, "", true)
+	if err != nil {
+		t.Fatalf("verifyChainWithOptions allow unpinned: %v", err)
+	}
+	if !strings.Contains(buf.String(), "CHAIN UNPINNED") {
+		t.Errorf("expected CHAIN UNPINNED, got: %s", buf.String())
 	}
 }
 

--- a/sdk/verifiers/python/src/pipelock_aarp_verify/cli.py
+++ b/sdk/verifiers/python/src/pipelock_aarp_verify/cli.py
@@ -34,7 +34,7 @@ from .appraise import (
 )
 from .chain import comparable_chain, verify_chain
 from .envelope import unmarshal
-from .receipt import verify_receipt_file
+from .receipt import UNPINNED_RECEIPT_BANNER, verify_evidence_chain_file, verify_receipt_file
 from .svid import SVIDConfigError, appraise_with_svid, load_svid_file
 
 ED25519_PUBLIC_KEY_SIZE = 32
@@ -280,14 +280,31 @@ def _emit_human(stdout: IO[str], ap: Any) -> None:
         stdout.write(f"  signature {s.key_id}/{s.alg}: {s.status}\n")
 
 
-def _run_receipt(stdout: IO[str], target: str, key_hex: str, json_mode: bool) -> int:
-    report = verify_receipt_file(target, key_hex)
+def _run_receipt(
+    stdout: IO[str],
+    target: str,
+    key_hex: str,
+    json_mode: bool,
+    chain_mode: bool,
+    allow_unpinned: bool,
+) -> int:
+    report = (
+        verify_evidence_chain_file(target, key_hex, allow_unpinned)
+        if chain_mode
+        else verify_receipt_file(target, key_hex, allow_unpinned)
+    )
     if json_mode:
         stdout.write(json.dumps(report, separators=(",", ":"), ensure_ascii=False))
         stdout.write("\n")
     else:
-        status = "valid" if report.get("valid") else "invalid"
-        stdout.write(f"EvidenceReceipt v2: {status}\n")
+        if report.get("unpinned"):
+            status = "UNPINNED"
+        else:
+            status = "valid" if report.get("valid") else "invalid"
+        label = "EvidenceReceipt v2 chain" if chain_mode else "EvidenceReceipt v2"
+        stdout.write(f"{label}: {status}\n")
+        if report.get("unpinned"):
+            stdout.write(f"  warning: {UNPINNED_RECEIPT_BANNER}\n")
         if report.get("error"):
             stdout.write(f"  error: {report['error']}\n")
     return EXIT_OK if report.get("valid") else EXIT_GENERAL
@@ -322,8 +339,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     receipt_p = sub.add_parser("receipt", help="verify an EvidenceReceipt v2 receipt")
     receipt_p.add_argument("path", help="path to an EvidenceReceipt v2 JSON file")
-    receipt_p.add_argument("--key", required=True, help="pinned Ed25519 public key hex")
+    receipt_p.add_argument("--key", default="", help="pinned Ed25519 public key hex")
     receipt_p.add_argument("--json", action="store_true", help="emit JSON report")
+    receipt_p.add_argument(
+        "--chain", action="store_true", help="PATH is an EvidenceReceipt v2 JSONL chain"
+    )
+    receipt_p.add_argument(
+        "--allow-unpinned",
+        action="store_true",
+        help="allow structural-only verification without a trusted signer key",
+    )
 
     try:
         args = parser.parse_args(argv)
@@ -332,7 +357,14 @@ def main(argv: list[str] | None = None) -> int:
         return EXIT_USAGE
 
     if args.command == "receipt":
-        return _run_receipt(sys.stdout, args.path, args.key, args.json)
+        return _run_receipt(
+            sys.stdout,
+            args.path,
+            args.key,
+            args.json,
+            args.chain,
+            args.allow_unpinned,
+        )
 
     if args.command != "aarp":
         parser.print_usage(sys.stderr)

--- a/sdk/verifiers/python/src/pipelock_aarp_verify/receipt.py
+++ b/sdk/verifiers/python/src/pipelock_aarp_verify/receipt.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import binascii
+import hashlib
 import json
 from pathlib import Path
 from typing import Any
@@ -28,6 +29,12 @@ V2_REDACTION_RULESET_HASH = (
 )
 CRIT_CANONICALIZATION = "canonicalization"
 CRIT_SOURCE_SPANS = "source_spans"
+GENESIS_HASH = "genesis"
+EVIDENCE_ENTRY_TYPE = "evidence_receipt"
+UNPINNED_RECEIPT_BANNER = (
+    "UNPINNED — signature is self-consistent but the signer was NOT checked "
+    "against a trusted key"
+)
 
 _PAYLOAD_KINDS = {
     "proxy_decision",
@@ -151,7 +158,9 @@ def load_receipt(path: str | Path) -> dict[str, Any]:
     return value
 
 
-def verify_receipt_file(path: str | Path, key_hex: str = "") -> dict[str, Any]:
+def verify_receipt_file(
+    path: str | Path, key_hex: str = "", allow_unpinned: bool = False
+) -> dict[str, Any]:
     clean = str(Path(path))
     report: dict[str, Any] = {"path": clean, "valid": False}
     try:
@@ -166,11 +175,126 @@ def verify_receipt_file(path: str | Path, key_hex: str = "") -> dict[str, Any]:
         report["signer_key"] = key_hex
         report["policy_hash"] = receipt.get("policy_hash")
         report["chain_seq"] = receipt.get("chain_seq")
-        verify_evidence_receipt(receipt, key_hex)
+        if key_hex:
+            verify_evidence_receipt(receipt, key_hex)
+        else:
+            normalize_evidence_receipt(receipt)
+            report["unpinned"] = True
+            report["error"] = UNPINNED_RECEIPT_BANNER
+            report["valid"] = allow_unpinned
+            return report
         report["valid"] = True
     except Exception as exc:  # noqa: BLE001 - verifier report captures cause
         report["error"] = str(exc)
     return report
+
+
+def verify_evidence_chain_file(
+    path: str | Path, key_hex: str = "", allow_unpinned: bool = False
+) -> dict[str, Any]:
+    clean = str(Path(path))
+    report: dict[str, Any] = {
+        "path": clean,
+        "valid": False,
+        "receipt_count": 0,
+        "final_seq": 0,
+    }
+    try:
+        receipts = load_evidence_chain(clean)
+        if not receipts:
+            raise ReceiptError("empty chain")
+        result = verify_evidence_chain(receipts, key_hex, allow_unpinned)
+        report.update(result)
+    except Exception as exc:  # noqa: BLE001 - verifier report captures cause
+        report["error"] = str(exc)
+    return report
+
+
+def load_evidence_chain(path: str | Path) -> list[dict[str, Any]]:
+    receipts: list[dict[str, Any]] = []
+    for index, line in enumerate(Path(path).read_text(encoding="utf-8").splitlines(), start=1):
+        raw = line.strip()
+        if raw == "":
+            continue
+        try:
+            entry = json.loads(raw, object_pairs_hook=_reject_duplicate_pairs)
+        except ReceiptError:
+            raise
+        except json.JSONDecodeError as exc:
+            raise ReceiptError(f"line {index}: malformed JSON: {exc}") from exc
+        if not isinstance(entry, dict):
+            raise ReceiptError(f"line {index}: recorder entry must be an object")
+        if entry.get("type") != EVIDENCE_ENTRY_TYPE:
+            continue
+        detail = entry.get("detail")
+        if not isinstance(detail, dict):
+            raise ReceiptError(f"line {index}: evidence entry has empty detail")
+        receipts.append(detail)
+    return receipts
+
+
+def verify_evidence_chain(
+    receipts: list[dict[str, Any]], key_hex: str = "", allow_unpinned: bool = False
+) -> dict[str, Any]:
+    if not receipts:
+        raise ReceiptError("empty chain")
+    if not key_hex and not allow_unpinned:
+        return {
+            "valid": False,
+            "unpinned": True,
+            "receipt_count": 0,
+            "final_seq": 0,
+            "error": UNPINNED_RECEIPT_BANNER,
+            "broken_at_seq": 0,
+        }
+    signer_id = _signature_signer_key_id(receipts[0])
+    prev_hash = GENESIS_HASH
+    for index, receipt in enumerate(receipts):
+        seq = receipt.get("chain_seq", index)
+        if not isinstance(seq, int) or isinstance(seq, bool) or seq < 0:
+            raise ReceiptError(f"seq {index}: missing or invalid chain_seq")
+        try:
+            if key_hex:
+                verify_evidence_receipt(receipt, key_hex)
+            else:
+                normalize_evidence_receipt(receipt)
+        except ReceiptError as exc:
+            return _broken_chain(seq, f"seq {seq}: signature: {exc}")
+        if _signature_signer_key_id(receipt) != signer_id:
+            return _broken_chain(
+                seq, f"seq {seq}: signer_key_id breaks chain signer {signer_id}"
+            )
+        if seq != index:
+            return _broken_chain(seq, f"seq gap: expected {index}, got {seq}")
+        if receipt.get("chain_prev_hash") != prev_hash:
+            return _broken_chain(seq, f"seq {seq}: chain_prev_hash mismatch")
+        prev_hash = receipt_hash(receipt)
+    return {
+        "valid": True,
+        "unpinned": (not key_hex) or None,
+        "receipt_count": len(receipts),
+        "final_seq": receipts[-1].get("chain_seq", 0),
+        "root_hash": prev_hash,
+    }
+
+
+def receipt_hash(receipt: dict[str, Any]) -> str:
+    return hashlib.sha256(canonicalize(receipt)).hexdigest()
+
+
+def _broken_chain(seq: int, error: str) -> dict[str, Any]:
+    return {
+        "valid": False,
+        "receipt_count": 0,
+        "final_seq": 0,
+        "error": error,
+        "broken_at_seq": seq,
+    }
+
+
+def _signature_signer_key_id(receipt: dict[str, Any]) -> str:
+    signature = _require_object(receipt.get("signature"), "signature")
+    return _require_string(signature.get("signer_key_id"), "signature.signer_key_id")
 
 
 def verify_evidence_receipt(receipt: dict[str, Any], expected_key_hex: str = "") -> None:

--- a/sdk/verifiers/python/tests/test_receipt_v2.py
+++ b/sdk/verifiers/python/tests/test_receipt_v2.py
@@ -6,8 +6,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
 from pipelock_aarp_verify.cli import main
-from pipelock_aarp_verify.receipt import verify_receipt_file
+from pipelock_aarp_verify.receipt import (
+    receipt_hash,
+    verify_evidence_chain,
+    verify_receipt_file,
+)
 
 ROOT = Path(__file__).resolve().parents[4]
 VALID_SPANNED_V2 = (
@@ -22,6 +28,16 @@ VALID_PLAIN_V2 = (
 )
 V2_GOLDEN_PUBLIC_KEY = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
 V2_GOLDEN_POLICY_HASH = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+V2_PRIVATE_SEED_HEX = (
+    "9d61b19d"
+    "effd5a60"
+    "ba844af4"
+    "92ec2cc4"
+    "4449c569"
+    "7b326919"
+    "703bac03"
+    "1cae7f60"
+)
 
 
 def test_valid_spanned_v2_receipt_verifies() -> None:
@@ -166,7 +182,78 @@ def test_receipt_cli_json(capsys) -> None:  # type: ignore[no-untyped-def]
     assert body["valid"] is True
 
 
-def test_receipt_cli_requires_key(capsys) -> None:  # type: ignore[no-untyped-def]
+def test_receipt_cli_without_key_is_unpinned_nonzero(capsys) -> None:  # type: ignore[no-untyped-def]
     code = main(["receipt", str(VALID_SPANNED_V2), "--json"])
-    capsys.readouterr()
-    assert code == 64  # EXIT_USAGE
+    captured = capsys.readouterr()
+    assert code == 1
+    body = json.loads(captured.out)
+    assert body["valid"] is False
+    assert body["unpinned"] is True
+
+
+def test_receipt_cli_allow_unpinned_exits_zero(capsys) -> None:  # type: ignore[no-untyped-def]
+    code = main(["receipt", str(VALID_SPANNED_V2), "--allow-unpinned", "--json"])
+    captured = capsys.readouterr()
+    assert code == 0
+    body = json.loads(captured.out)
+    assert body["valid"] is True
+    assert body["unpinned"] is True
+
+
+def test_v2_multi_receipt_chain_verifies() -> None:
+    report = verify_evidence_chain(_build_v2_chain(2), V2_GOLDEN_PUBLIC_KEY)
+    assert report["valid"] is True, report.get("error")
+    assert report["receipt_count"] == 2
+    assert report["final_seq"] == 1
+
+
+def test_v2_tampered_chain_fails_closed() -> None:
+    receipts = _build_v2_chain(2)
+    receipts[1]["chain_prev_hash"] = "sha256:0"
+    report = verify_evidence_chain(receipts, V2_GOLDEN_PUBLIC_KEY)
+    assert report["valid"] is False
+    assert "signature" in report["error"] or "chain_prev_hash" in report["error"]
+
+
+def test_v2_truncated_middle_receipt_fails_closed() -> None:
+    receipts = _build_v2_chain(3)
+    del receipts[1]
+    report = verify_evidence_chain(receipts, V2_GOLDEN_PUBLIC_KEY)
+    assert report["valid"] is False
+    assert "signature" in report["error"] or "seq gap" in report["error"]
+
+
+def _build_v2_chain(count: int) -> list[dict[str, object]]:
+    base = json.loads(VALID_PLAIN_V2.read_text())
+    receipts: list[dict[str, object]] = []
+    prev_hash = "genesis"
+    for i in range(count):
+        receipt = json.loads(json.dumps(base))
+        receipt["event_id"] = f"01F8MECHZX3TBDSZ7XRADM79V{i}"
+        receipt["chain_seq"] = i
+        receipt["chain_prev_hash"] = prev_hash
+        _sign_v2_receipt(receipt)
+        receipts.append(receipt)
+        prev_hash = receipt_hash(receipt)
+    return receipts
+
+
+def _sign_v2_receipt(receipt: dict[str, object]) -> None:
+    from pipelock_aarp_verify.canonical import canonicalize
+
+    signature = receipt["signature"]
+    assert isinstance(signature, dict)
+    receipt["signature"] = {
+        "signer_key_id": "",
+        "key_purpose": "",
+        "algorithm": "",
+        "signature": "",
+    }
+    key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(V2_PRIVATE_SEED_HEX))
+    sig = key.sign(canonicalize(receipt))
+    receipt["signature"] = {
+        "signer_key_id": signature.get("signer_key_id", "receipt-signing-test"),
+        "key_purpose": "receipt-signing",
+        "algorithm": "ed25519",
+        "signature": f"ed25519:{sig.hex()}",
+    }

--- a/sdk/verifiers/rust/src/audit_packet.rs
+++ b/sdk/verifiers/rust/src/audit_packet.rs
@@ -1,4 +1,4 @@
-use crate::chain::{compute_totals, verify_chain};
+use crate::chain::{compute_totals, verify_chain_with_options};
 use crate::recorder::extract_receipts;
 use crate::schema::validate_audit_packet;
 use crate::types::{
@@ -96,7 +96,7 @@ pub fn verify_audit_packet(target: &str, opts: &AuditPacketOptions) -> Result<Au
             return Ok(report);
         }
     };
-    let chain = verify_chain(&receipts, &key_hex);
+    let chain = verify_chain_with_options(&receipts, &key_hex, opts.allow_self_consistent_only);
     report.chain_check = if chain.valid { "pass" } else { "fail" }.to_string();
     if !chain.valid {
         push_error(

--- a/sdk/verifiers/rust/src/chain.rs
+++ b/sdk/verifiers/rust/src/chain.rs
@@ -1,11 +1,24 @@
-use crate::canonical::canonicalize_receipt;
-use crate::signing::verify_receipt;
+use crate::canonical::{canonicalize_jcs_value, canonicalize_receipt};
+use crate::signing::{
+    normalize_evidence_receipt, verify_receipt, verify_receipt_with_options,
+    UNPINNED_RECEIPT_BANNER,
+};
 use crate::types::{ChainResult, Receipt, Totals};
 use crate::util::sha256_hex;
 
 pub const GENESIS_HASH: &str = "genesis";
+const EVIDENCE_RECORD_TYPE: &str = "evidence_receipt_v2";
 
 pub fn receipt_hash(receipt: &Receipt) -> String {
+    if receipt
+        .get("record_type")
+        .and_then(serde_json::Value::as_str)
+        == Some(EVIDENCE_RECORD_TYPE)
+    {
+        return sha256_hex(
+            &canonicalize_jcs_value(receipt).expect("validated evidence receipt canonicalizes"),
+        );
+    }
     sha256_hex(&canonicalize_receipt(receipt))
 }
 
@@ -14,6 +27,14 @@ pub fn receipt_hash(receipt: &Receipt) -> String {
 /// When expected_key_hex is empty, the first receipt's signer_key pins the chain key.
 /// Callers that require external trust must pass a non-empty expected key.
 pub fn verify_chain(receipts: &[Receipt], expected_key_hex: &str) -> ChainResult {
+    verify_chain_with_options(receipts, expected_key_hex, false)
+}
+
+pub fn verify_chain_with_options(
+    receipts: &[Receipt],
+    expected_key_hex: &str,
+    allow_unpinned: bool,
+) -> ChainResult {
     if receipts.is_empty() {
         return ChainResult {
             valid: true,
@@ -25,7 +46,18 @@ pub fn verify_chain(receipts: &[Receipt], expected_key_hex: &str) -> ChainResult
         };
     }
 
+    if receipts[0]
+        .get("record_type")
+        .and_then(serde_json::Value::as_str)
+        == Some(EVIDENCE_RECORD_TYPE)
+    {
+        return verify_evidence_chain(receipts, expected_key_hex, allow_unpinned);
+    }
+
     let mut key_hex = expected_key_hex.to_string();
+    if key_hex.is_empty() && !allow_unpinned {
+        return broken(0, UNPINNED_RECEIPT_BANNER.to_string());
+    }
     if key_hex.is_empty() {
         key_hex = receipts[0]
             .get("signer_key")
@@ -46,7 +78,7 @@ pub fn verify_chain(receipts: &[Receipt], expected_key_hex: &str) -> ChainResult
                 format!("seq {index}: missing or invalid chain_seq"),
             );
         };
-        if let Err(err) = verify_receipt(receipt, &key_hex) {
+        if let Err(err) = verify_receipt_with_options(receipt, &key_hex, allow_unpinned) {
             return broken(seq, format!("seq {seq}: signature: {err}"));
         }
         if seq != index as u64 {
@@ -70,6 +102,78 @@ pub fn verify_chain(receipts: &[Receipt], expected_key_hex: &str) -> ChainResult
         error: None,
         broken_at_seq: None,
     }
+}
+
+fn verify_evidence_chain(
+    receipts: &[Receipt],
+    expected_key_hex: &str,
+    allow_unpinned: bool,
+) -> ChainResult {
+    let key_hex = expected_key_hex.to_ascii_lowercase();
+    if key_hex.is_empty() && !allow_unpinned {
+        return broken(0, UNPINNED_RECEIPT_BANNER.to_string());
+    }
+    let signer_id = signer_key_id(&receipts[0]);
+    let mut prev_hash = GENESIS_HASH.to_string();
+    for (index, receipt) in receipts.iter().enumerate() {
+        let seq = receipt
+            .get("chain_seq")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(index as u64);
+        if receipt
+            .get("record_type")
+            .and_then(serde_json::Value::as_str)
+            != Some(EVIDENCE_RECORD_TYPE)
+        {
+            return broken(seq, format!("seq {seq}: mixed receipt record_type"));
+        }
+        let verify_result = if key_hex.is_empty() {
+            normalize_evidence_receipt(receipt)
+        } else {
+            verify_receipt(receipt, &key_hex)
+        };
+        if let Err(err) = verify_result {
+            return broken(seq, format!("seq {seq}: signature: {err}"));
+        }
+        if signer_key_id(receipt) != signer_id {
+            return broken(
+                seq,
+                format!("seq {seq}: signer_key_id breaks chain signer {signer_id}"),
+            );
+        }
+        if seq != index as u64 {
+            return broken(seq, format!("seq gap: expected {index}, got {seq}"));
+        }
+        let chain_prev_hash = receipt
+            .get("chain_prev_hash")
+            .and_then(serde_json::Value::as_str);
+        if chain_prev_hash != Some(prev_hash.as_str()) {
+            return broken(seq, format!("seq {seq}: chain_prev_hash mismatch"));
+        }
+        prev_hash = receipt_hash(receipt);
+    }
+
+    ChainResult {
+        valid: true,
+        receipt_count: receipts.len(),
+        final_seq: receipts
+            .last()
+            .and_then(|receipt| receipt.get("chain_seq"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0),
+        root_hash: prev_hash,
+        error: None,
+        broken_at_seq: None,
+    }
+}
+
+fn signer_key_id(receipt: &Receipt) -> String {
+    receipt
+        .get("signature")
+        .and_then(|value| value.get("signer_key_id"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("")
+        .to_string()
 }
 
 pub fn compute_totals(receipts: &[Receipt]) -> Totals {

--- a/sdk/verifiers/rust/src/cli.rs
+++ b/sdk/verifiers/rust/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::audit_packet::{verify_audit_packet, AuditPacketOptions};
-use crate::chain::verify_chain;
+use crate::chain::verify_chain_with_options;
 use crate::output::{emit_audit_packet, emit_chain, emit_receipt};
 use crate::receipt::run_receipt;
 use crate::recorder::{extract_receipts, extract_receipts_from_session_dir};
@@ -15,6 +15,7 @@ struct ParsedArgs {
     key: String,
     offline: bool,
     allow_self_consistent_only: bool,
+    allow_unpinned: bool,
     no_trust_required: bool,
     expect_sha256: String,
     dir: bool,
@@ -85,6 +86,7 @@ fn run_chain_command(args: &[String]) -> Result<i32> {
         let report = ChainCommandReport {
             path: label,
             valid: false,
+            unpinned: None,
             receipt_count: 0,
             final_seq: 0,
             root_hash: None,
@@ -95,10 +97,13 @@ fn run_chain_command(args: &[String]) -> Result<i32> {
         return Ok(1);
     }
 
-    let result = verify_chain(&receipts, &key_hex);
+    let result = verify_chain_with_options(&receipts, &key_hex, parsed.allow_unpinned);
     let report = ChainCommandReport {
         path: label,
         valid: result.valid,
+        unpinned: (key_hex.is_empty()
+            && (result.valid || result.error.as_deref().unwrap_or("").contains("UNPINNED")))
+        .then_some(true),
         receipt_count: result.receipt_count,
         final_seq: result.final_seq,
         root_hash: (!result.root_hash.is_empty()).then_some(result.root_hash),
@@ -112,7 +117,7 @@ fn run_chain_command(args: &[String]) -> Result<i32> {
 fn run_receipt_command(args: &[String]) -> Result<i32> {
     let parsed = parse_args(args, "receipt")?;
     let target = require_one_arg(&parsed.positionals, "receipt")?;
-    let report = run_receipt(target, &parsed.key)?;
+    let report = run_receipt(target, &parsed.key, parsed.allow_unpinned)?;
     emit_receipt(&report, parsed.json)?;
     Ok(if report.valid { 0 } else { 1 })
 }
@@ -136,6 +141,9 @@ fn parse_args(args: &[String], command: &str) -> Result<ParsedArgs> {
             "--offline" if command == "audit-packet" => parsed.offline = true,
             "--allow-self-consistent-only" if command == "audit-packet" => {
                 parsed.allow_self_consistent_only = true;
+            }
+            "--allow-unpinned" if command == "chain" || command == "receipt" => {
+                parsed.allow_unpinned = true;
             }
             "--no-trust-required" if command == "audit-packet" => parsed.no_trust_required = true,
             "--dir" if command == "chain" => parsed.dir = true,
@@ -219,8 +227,8 @@ fn require_one_arg<'a>(positionals: &'a [String], command: &str) -> Result<&'a s
 fn usage(command: Option<&str>) -> String {
     match command {
         Some("audit-packet") => "Usage: pipelock-verifier-rs audit-packet PATH [--json] [--key HEX_OR_FILE] [--offline] [--allow-self-consistent-only] [--no-trust-required] [--expect-sha256 HEX]".to_string(),
-        Some("chain") => "Usage: pipelock-verifier-rs chain PATH [--json] [--key HEX_OR_FILE] [--dir] [--session-id ID]".to_string(),
-        Some("receipt") => "Usage: pipelock-verifier-rs receipt PATH [--json] [--key HEX_OR_FILE]".to_string(),
+        Some("chain") => "Usage: pipelock-verifier-rs chain PATH [--json] [--key HEX_OR_FILE] [--allow-unpinned] [--dir] [--session-id ID]".to_string(),
+        Some("receipt") => "Usage: pipelock-verifier-rs receipt PATH [--json] [--key HEX_OR_FILE] [--allow-unpinned]".to_string(),
         _ => "Usage: pipelock-verifier-rs {aarp|audit-packet|chain|receipt} PATH [flags]"
             .to_string(),
     }

--- a/sdk/verifiers/rust/src/output.rs
+++ b/sdk/verifiers/rust/src/output.rs
@@ -67,7 +67,14 @@ pub fn emit_receipt(report: &ReceiptReport, json: bool) -> Result<()> {
         return write_json(report);
     }
     if report.valid {
-        println!("RECEIPT VALID: {}", report.path);
+        if report.unpinned == Some(true) {
+            println!("RECEIPT UNPINNED: {}", report.path);
+            if let Some(error) = &report.error {
+                println!("  warning:      {error}");
+            }
+        } else {
+            println!("RECEIPT VALID: {}", report.path);
+        }
         println!(
             "  action_id:    {}",
             report.action_id.as_deref().unwrap_or("")
@@ -91,6 +98,13 @@ pub fn emit_receipt(report: &ReceiptReport, json: bool) -> Result<()> {
         println!("  chain_seq:    {}", report.chain_seq.unwrap_or(0));
         return Ok(());
     }
+    if report.unpinned == Some(true) {
+        eprintln!("RECEIPT UNPINNED: {}", report.path);
+        if let Some(error) = &report.error {
+            eprintln!("  warning: {error}");
+        }
+        return Ok(());
+    }
     eprintln!("RECEIPT INVALID: {}", report.path);
     if let Some(error) = &report.error {
         eprintln!("  error: {error}");
@@ -103,13 +117,27 @@ pub fn emit_chain(report: &ChainCommandReport, json: bool) -> Result<()> {
         return write_json(report);
     }
     if report.valid {
-        println!("CHAIN VALID: {}", report.path);
+        if report.unpinned == Some(true) {
+            println!("CHAIN UNPINNED: {}", report.path);
+            if let Some(error) = &report.error {
+                println!("  warning:    {error}");
+            }
+        } else {
+            println!("CHAIN VALID: {}", report.path);
+        }
         println!("  receipts:   {}", report.receipt_count);
         println!("  final seq:  {}", report.final_seq);
         println!(
             "  root hash:  {}",
             report.root_hash.as_deref().unwrap_or("")
         );
+        return Ok(());
+    }
+    if report.unpinned == Some(true) {
+        eprintln!("CHAIN UNPINNED: {}", report.path);
+        if let Some(error) = &report.error {
+            eprintln!("  warning:    {error}");
+        }
         return Ok(());
     }
     eprintln!("CHAIN BROKEN: {}", report.path);

--- a/sdk/verifiers/rust/src/receipt.rs
+++ b/sdk/verifiers/rust/src/receipt.rs
@@ -1,4 +1,6 @@
-use crate::signing::verify_receipt;
+use crate::signing::{
+    normalize_evidence_receipt, verify_receipt_with_options, UNPINNED_RECEIPT_BANNER,
+};
 use crate::types::ReceiptReport;
 use crate::util::{
     parse_json_text, reject_duplicate_keys, resolve_signer_key, string_at, u64_at, Result,
@@ -8,7 +10,11 @@ use serde_json::Value;
 use std::fs;
 use std::path::PathBuf;
 
-pub fn run_receipt(pathname: &str, signer_key: &str) -> Result<ReceiptReport> {
+pub fn run_receipt(
+    pathname: &str,
+    signer_key: &str,
+    allow_unpinned: bool,
+) -> Result<ReceiptReport> {
     let clean = PathBuf::from(pathname);
     let key_hex = resolve_signer_key(signer_key)?;
     // Read the raw text so duplicate-key detection sees every key occurrence,
@@ -18,6 +24,7 @@ pub fn run_receipt(pathname: &str, signer_key: &str) -> Result<ReceiptReport> {
     let mut report = ReceiptReport {
         path: clean.display().to_string(),
         valid: false,
+        unpinned: None,
         action_id: None,
         verdict: None,
         transport: None,
@@ -50,8 +57,26 @@ pub fn run_receipt(pathname: &str, signer_key: &str) -> Result<ReceiptReport> {
             string_at(&receipt, &["action_record", "policy_hash"]).map(str::to_string);
         report.chain_seq = u64_at(&receipt, &["action_record", "chain_seq"]);
     }
-    match verify_receipt(&receipt, &key_hex) {
-        Ok(()) => report.valid = true,
+    let is_v2 = string_at(&receipt, &["record_type"]) == Some("evidence_receipt_v2");
+    if key_hex.is_empty() && is_v2 {
+        match normalize_evidence_receipt(&receipt) {
+            Ok(()) => {
+                report.valid = allow_unpinned;
+                report.unpinned = Some(true);
+                report.error = Some(UNPINNED_RECEIPT_BANNER.to_string());
+            }
+            Err(err) => report.error = Some(err),
+        }
+        return Ok(report);
+    }
+    match verify_receipt_with_options(&receipt, &key_hex, allow_unpinned) {
+        Ok(()) => {
+            report.valid = true;
+            if key_hex.is_empty() {
+                report.unpinned = Some(true);
+                report.error = Some(UNPINNED_RECEIPT_BANNER.to_string());
+            }
+        }
         Err(err) => report.error = Some(err),
     }
     Ok(report)

--- a/sdk/verifiers/rust/src/recorder.rs
+++ b/sdk/verifiers/rust/src/recorder.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::path::Path;
 
 const ACTION_RECEIPT_TYPE: &str = "action_receipt";
+const EVIDENCE_RECEIPT_TYPE: &str = "evidence_receipt";
 
 pub fn read_entries(path: &Path) -> Result<Vec<serde_json::Value>> {
     let text = fs::read_to_string(path)
@@ -29,7 +30,8 @@ pub fn read_entries(path: &Path) -> Result<Vec<serde_json::Value>> {
 pub fn extract_receipts(path: &Path) -> Result<Vec<Receipt>> {
     let mut receipts = Vec::new();
     for entry in read_entries(path)? {
-        if entry.get("type").and_then(serde_json::Value::as_str) != Some(ACTION_RECEIPT_TYPE) {
+        let entry_type = entry.get("type").and_then(serde_json::Value::as_str);
+        if entry_type != Some(ACTION_RECEIPT_TYPE) && entry_type != Some(EVIDENCE_RECEIPT_TYPE) {
             continue;
         }
         let detail = entry.get("detail").ok_or_else(|| {

--- a/sdk/verifiers/rust/src/signing.rs
+++ b/sdk/verifiers/rust/src/signing.rs
@@ -5,6 +5,8 @@ use ed25519_dalek::{Signature, VerifyingKey};
 use sha2::{Digest, Sha256};
 
 const SIGNATURE_PREFIX: &str = "ed25519:";
+pub const UNPINNED_RECEIPT_BANNER: &str =
+    "UNPINNED — signature is self-consistent but the signer was NOT checked against a trusted key";
 const V2_RECORD_TYPE: &str = "evidence_receipt_v2";
 const V2_SIGNATURE_ALGORITHM: &str = "ed25519";
 const V2_KEY_PURPOSE: &str = "receipt-signing";
@@ -33,6 +35,14 @@ pub fn verify_receipt(
     receipt: &Receipt,
     expected_key_hex: &str,
 ) -> std::result::Result<(), String> {
+    verify_receipt_with_options(receipt, expected_key_hex, false)
+}
+
+pub fn verify_receipt_with_options(
+    receipt: &Receipt,
+    expected_key_hex: &str,
+    allow_unpinned: bool,
+) -> std::result::Result<(), String> {
     if receipt.get("record_type").and_then(|value| value.as_str()) == Some(V2_RECORD_TYPE) {
         return verify_evidence_receipt(receipt, expected_key_hex);
     }
@@ -43,6 +53,9 @@ pub fn verify_receipt(
         .unwrap_or("")
         .to_ascii_lowercase();
     let expected = expected_key_hex.to_ascii_lowercase();
+    if expected.is_empty() && !allow_unpinned {
+        return Err(UNPINNED_RECEIPT_BANNER.to_string());
+    }
     let key_hex = if expected.is_empty() {
         signer_key.as_str()
     } else {

--- a/sdk/verifiers/rust/src/types.rs
+++ b/sdk/verifiers/rust/src/types.rs
@@ -132,6 +132,8 @@ pub struct ReceiptReport {
     pub path: String,
     pub valid: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub unpinned: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub action_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verdict: Option<String>,
@@ -151,6 +153,8 @@ pub struct ReceiptReport {
 pub struct ChainCommandReport {
     pub path: String,
     pub valid: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unpinned: Option<bool>,
     pub receipt_count: usize,
     pub final_seq: u64,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/sdk/verifiers/rust/tests/canonical.rs
+++ b/sdk/verifiers/rust/tests/canonical.rs
@@ -1,7 +1,7 @@
 #![recursion_limit = "256"]
 
 use pipelock_verifier_rs::canonical::{canonicalize_action_record, canonicalize_receipt};
-use pipelock_verifier_rs::signing::verify_receipt;
+use pipelock_verifier_rs::signing::verify_receipt_with_options;
 use serde_json::json;
 use sha2::{Digest, Sha256};
 
@@ -101,5 +101,5 @@ fn canonical_receipt_envelope_matches_go_hash() {
 #[test]
 fn full_field_receipt_signature_verifies() {
     let receipt = full_receipt();
-    verify_receipt(&receipt, "").expect("signature verifies");
+    verify_receipt_with_options(&receipt, "", true).expect("signature verifies");
 }

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -1,10 +1,18 @@
 mod common;
 
-use pipelock_verifier_rs::chain::verify_chain;
+use ed25519_dalek::{Signer, SigningKey};
+use pipelock_verifier_rs::canonical::canonicalize_jcs_value;
+use pipelock_verifier_rs::chain::{receipt_hash, verify_chain, verify_chain_with_options};
 use pipelock_verifier_rs::recorder::extract_receipts;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+const V2_GOLDEN_PUBLIC_KEY: &str =
+    "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+const V2_PRIVATE_SEED_HEX: &str = concat!(
+    "9d61b19d", "effd5a60", "ba844af4", "92ec2cc4", "4449c569", "7b326919", "703bac03", "1cae7f60"
+);
 
 #[test]
 fn valid_go_generated_chain_verifies() {
@@ -12,6 +20,16 @@ fn valid_go_generated_chain_verifies() {
     let receipts =
         extract_receipts(&root.join("sdk/conformance/testdata/valid-chain.jsonl")).unwrap();
     let result = verify_chain(&receipts, "");
+    assert!(!result.valid);
+    assert!(result.error.unwrap_or_default().contains("UNPINNED"));
+}
+
+#[test]
+fn valid_go_generated_chain_allows_explicit_unpinned_structural_verification() {
+    let root = common::repo_root();
+    let receipts =
+        extract_receipts(&root.join("sdk/conformance/testdata/valid-chain.jsonl")).unwrap();
+    let result = verify_chain_with_options(&receipts, "", true);
     assert!(result.valid, "{:?}", result.error);
     assert_eq!(result.receipt_count, 5);
     assert_eq!(result.final_seq, 4);
@@ -26,7 +44,7 @@ fn broken_chain_prev_hash_is_rejected() {
     let root = common::repo_root();
     let receipts =
         extract_receipts(&root.join("sdk/conformance/testdata/broken-chain.jsonl")).unwrap();
-    let result = verify_chain(&receipts, "");
+    let result = verify_chain_with_options(&receipts, "", true);
     assert!(!result.valid);
     assert_eq!(result.broken_at_seq, Some(3));
     assert!(result
@@ -43,13 +61,42 @@ fn missing_chain_seq_is_rejected_before_signature_check() {
     if let Some(Value::Object(action_record)) = receipts[0].get_mut("action_record") {
         action_record.remove("chain_seq");
     }
-    let result = verify_chain(&receipts, "");
+    let result = verify_chain_with_options(&receipts, "", true);
     assert!(!result.valid);
     assert_eq!(result.broken_at_seq, Some(0));
     assert!(result
         .error
         .unwrap_or_default()
         .contains("missing or invalid chain_seq"));
+}
+
+#[test]
+fn evidence_v2_multi_receipt_chain_verifies() {
+    let receipts = build_evidence_chain(2);
+    let result = verify_chain(&receipts, V2_GOLDEN_PUBLIC_KEY);
+    assert!(result.valid, "{:?}", result.error);
+    assert_eq!(result.receipt_count, 2);
+    assert_eq!(result.final_seq, 1);
+}
+
+#[test]
+fn evidence_v2_tampered_chain_fails_closed() {
+    let mut receipts = build_evidence_chain(2);
+    receipts[1]["chain_prev_hash"] = json!("sha256:0");
+    let result = verify_chain(&receipts, V2_GOLDEN_PUBLIC_KEY);
+    assert!(!result.valid);
+    let error = result.error.unwrap_or_default();
+    assert!(error.contains("signature") || error.contains("chain_prev_hash"));
+}
+
+#[test]
+fn evidence_v2_truncated_middle_receipt_fails_closed() {
+    let mut receipts = build_evidence_chain(3);
+    receipts.remove(1);
+    let result = verify_chain(&receipts, V2_GOLDEN_PUBLIC_KEY);
+    assert!(!result.valid);
+    let error = result.error.unwrap_or_default();
+    assert!(error.contains("signature") || error.contains("seq gap"));
 }
 
 #[test]
@@ -67,4 +114,54 @@ fn recorder_extraction_rejects_duplicate_keys_inside_receipt_detail() {
     let err = extract_receipts(&path).expect_err("duplicate key should reject");
     let _ = fs::remove_file(&path);
     assert!(err.to_string().contains("duplicate object key"));
+}
+
+fn build_evidence_chain(count: usize) -> Vec<Value> {
+    let root = common::repo_root();
+    let base: Value =
+        serde_json::from_str(
+            &fs::read_to_string(root.join(
+                "internal/contract/testdata/golden/valid_evidence_receipt_proxy_decision.json",
+            ))
+            .expect("read v2 fixture"),
+        )
+        .expect("parse v2 fixture");
+    let mut receipts = Vec::new();
+    let mut prev_hash = "genesis".to_string();
+    for i in 0..count {
+        let mut receipt = base.clone();
+        receipt["event_id"] = json!(format!("01F8MECHZX3TBDSZ7XRADM79V{i}"));
+        receipt["chain_seq"] = json!(i);
+        receipt["chain_prev_hash"] = json!(prev_hash);
+        sign_evidence_receipt(&mut receipt);
+        prev_hash = receipt_hash(&receipt);
+        receipts.push(receipt);
+    }
+    receipts
+}
+
+fn sign_evidence_receipt(receipt: &mut Value) {
+    let signer_key_id = receipt["signature"]["signer_key_id"]
+        .as_str()
+        .unwrap_or("receipt-signing-test")
+        .to_string();
+    let mut clone = receipt.clone();
+    clone["signature"] = json!({
+        "signer_key_id": "",
+        "key_purpose": "",
+        "algorithm": "",
+        "signature": ""
+    });
+    let seed: [u8; 32] = hex::decode(V2_PRIVATE_SEED_HEX)
+        .expect("decode seed")
+        .try_into()
+        .expect("seed length");
+    let key = SigningKey::from_bytes(&seed);
+    let signature = key.sign(&canonicalize_jcs_value(&clone).expect("canonicalize receipt"));
+    receipt["signature"] = json!({
+        "signer_key_id": signer_key_id,
+        "key_purpose": "receipt-signing",
+        "algorithm": "ed25519",
+        "signature": format!("ed25519:{}", hex::encode(signature.to_bytes()))
+    });
 }

--- a/sdk/verifiers/rust/tests/conformance_corpus.rs
+++ b/sdk/verifiers/rust/tests/conformance_corpus.rs
@@ -23,6 +23,7 @@ fn shield_bearing_corpus_receipt_verifies() {
     let report = run_receipt(
         &format!("{CORPUS}/golden/09-allow-shield-summary.json"),
         &key,
+        false,
     )
     .expect("run receipt");
     assert!(report.valid, "{:?}", report.error);
@@ -34,6 +35,7 @@ fn full_field_differential_corpus_receipt_verifies() {
     let report = run_receipt(
         &format!("{CORPUS}/golden/10-full-field-differential.json"),
         &key,
+        false,
     )
     .expect("run receipt");
     assert!(report.valid, "{:?}", report.error);
@@ -45,6 +47,7 @@ fn duplicate_key_corpus_receipt_rejected() {
     let report = run_receipt(
         &format!("{CORPUS}/malicious/m13-duplicate-key-verdict.json"),
         &key,
+        false,
     )
     .expect("run receipt");
     assert!(!report.valid);

--- a/sdk/verifiers/rust/tests/receipt.rs
+++ b/sdk/verifiers/rust/tests/receipt.rs
@@ -23,6 +23,7 @@ fn valid_single_receipt_verifies_with_shared_key() {
             .to_str()
             .unwrap(),
         key["public_key_hex"].as_str().unwrap(),
+        false,
     )
     .unwrap();
     assert!(report.valid, "{:?}", report.error);
@@ -40,6 +41,7 @@ fn invalid_signature_is_rejected() {
             .to_str()
             .unwrap(),
         key["public_key_hex"].as_str().unwrap(),
+        false,
     )
     .unwrap();
     assert!(!report.valid);
@@ -61,7 +63,7 @@ fn duplicate_key_rejected_before_metadata_population() {
         r#"{"version":1,"action_record":{"version":1,"action_id":"x","action_type":"write","timestamp":"2026-04-15T12:00:00Z","verdict":"allow","verdict":"block","target":"https://e.example","transport":"https","chain_prev_hash":"genesis","chain_seq":0},"signature":"ed25519:00","signer_key":"00"}"#,
     )
     .unwrap();
-    let report = run_receipt(path.to_str().unwrap(), "").unwrap();
+    let report = run_receipt(path.to_str().unwrap(), "", false).unwrap();
     let _ = fs::remove_file(path);
     assert!(!report.valid);
     assert!(report
@@ -98,6 +100,7 @@ fn armored_public_key_file_accepts_crlf_line_endings() {
             .to_str()
             .unwrap(),
         key_path.to_str().unwrap(),
+        false,
     )
     .unwrap();
     assert!(report.valid, "{:?}", report.error);
@@ -134,6 +137,7 @@ fn valid_spanned_v2_receipt_verifies_with_shared_key() {
             .to_str()
             .unwrap(),
         V2_GOLDEN_PUBLIC_KEY,
+    false,
     )
     .unwrap();
     assert!(report.valid, "{:?}", report.error);
@@ -155,6 +159,7 @@ fn valid_plain_v2_receipt_verifies_with_shared_key() {
             .to_str()
             .unwrap(),
         V2_GOLDEN_PUBLIC_KEY,
+        false,
     )
     .unwrap();
     assert!(report.valid, "{:?}", report.error);
@@ -173,7 +178,7 @@ fn missing_v2_policy_hash_is_rejected() {
         std::process::id()
     ));
     fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();
-    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY).unwrap();
+    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY, false).unwrap();
     let _ = fs::remove_file(path);
     assert!(!report.valid);
     assert!(report
@@ -195,7 +200,7 @@ fn reserved_defer_v2_payload_kind_is_rejected() {
         std::process::id()
     ));
     fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();
-    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY).unwrap();
+    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY, false).unwrap();
     let _ = fs::remove_file(path);
     assert!(!report.valid);
     assert!(report
@@ -219,7 +224,7 @@ fn tampered_spanned_v2_receipt_is_rejected() {
         std::process::id()
     ));
     fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();
-    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY).unwrap();
+    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY, false).unwrap();
     let _ = fs::remove_file(path);
     assert!(!report.valid);
     assert!(report
@@ -242,7 +247,7 @@ fn unknown_spanned_v2_field_is_rejected() {
         std::process::id()
     ));
     fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();
-    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY).unwrap();
+    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY, false).unwrap();
     let _ = fs::remove_file(path);
     assert!(!report.valid);
     assert!(report
@@ -266,7 +271,7 @@ fn empty_dlp_normalized_suffix_is_rejected() {
         std::process::id()
     ));
     fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();
-    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY).unwrap();
+    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY, false).unwrap();
     let _ = fs::remove_file(path);
     assert!(!report.valid);
     assert!(report
@@ -289,7 +294,7 @@ fn unsupported_canonicalization_is_rejected() {
         std::process::id()
     ));
     fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();
-    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY).unwrap();
+    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY, false).unwrap();
     let _ = fs::remove_file(path);
     assert!(!report.valid);
     assert!(report
@@ -312,7 +317,7 @@ fn missing_source_spans_crit_is_rejected() {
         std::process::id()
     ));
     fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();
-    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY).unwrap();
+    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY, false).unwrap();
     let _ = fs::remove_file(path);
     assert!(!report.valid);
     assert!(report
@@ -335,7 +340,7 @@ fn unknown_crit_is_rejected() {
         std::process::id()
     ));
     fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();
-    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY).unwrap();
+    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY, false).unwrap();
     let _ = fs::remove_file(path);
     assert!(!report.valid);
     assert!(report
@@ -357,7 +362,7 @@ fn source_spans_crit_on_plain_payload_is_rejected() {
         std::process::id()
     ));
     fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();
-    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY).unwrap();
+    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY, false).unwrap();
     let _ = fs::remove_file(path);
     assert!(!report.valid);
     assert!(report

--- a/sdk/verifiers/ts/src/audit-packet.ts
+++ b/sdk/verifiers/ts/src/audit-packet.ts
@@ -149,7 +149,9 @@ export async function verifyAuditPacket(
     receipts = extractReceipts(evidencePath);
     const keyInput =
       opts.signerKey.trim() === "" ? (packet.verifier?.signer_key ?? "") : opts.signerKey;
-    chain = await verifyChain(receipts, resolveSignerKey(keyInput));
+    chain = await verifyChain(receipts, resolveSignerKey(keyInput), {
+      allowUnpinned: opts.allowSelfConsistentOnly,
+    });
   } catch (err) {
     report.chain_check = "fail";
     pushError(report, `chain: ${(err as Error).message}`);

--- a/sdk/verifiers/ts/src/chain.ts
+++ b/sdk/verifiers/ts/src/chain.ts
@@ -94,10 +94,17 @@ async function verifyEvidenceChain(
   if (keyHex === "" && options.allowUnpinned !== true) {
     return unpinnedChainResult(0);
   }
-  const signerID = signerKeyID(receipts[0] as Receipt);
+  const first = receipts[0];
+  if (first === undefined) {
+    return broken(0, "empty chain");
+  }
+  const signerID = signerKeyID(first);
   let prevHash = genesisHash;
   for (let i = 0; i < receipts.length; i++) {
-    const receipt = receipts[i] as Receipt;
+    const receipt = receipts[i];
+    if (receipt === undefined) {
+      return broken(i, `seq gap: expected ${i}, got missing receipt`);
+    }
     const seq = receipt.chain_seq ?? 0;
     if (receipt.record_type !== evidenceRecordType) {
       return broken(seq, `seq ${seq}: mixed receipt record_type`);
@@ -122,7 +129,10 @@ async function verifyEvidenceChain(
     }
     prevHash = receiptHash(receipt);
   }
-  const last = receipts[receipts.length - 1] as Receipt;
+  const last = receipts[receipts.length - 1];
+  if (last === undefined) {
+    return broken(0, "empty chain");
+  }
   return {
     valid: true,
     receipt_count: receipts.length,

--- a/sdk/verifiers/ts/src/chain.ts
+++ b/sdk/verifiers/ts/src/chain.ts
@@ -1,20 +1,40 @@
 import type { ChainResult, Receipt } from "./types.js";
 import { canonicalizeReceipt } from "./canonical.js";
+import { canonicalizeBytes } from "./aarp/canonical.js";
 import { sha256Hex } from "./util.js";
-import { verifyReceipt } from "./signing.js";
+import { normalizeEvidenceReceipt, unpinnedReceiptBanner, verifyReceipt } from "./signing.js";
 
 export const genesisHash = "genesis";
+const evidenceRecordType = "evidence_receipt_v2";
 
 export function receiptHash(receipt: Receipt): string {
+  if (receipt.record_type === evidenceRecordType) {
+    return sha256Hex(canonicalizeBytes(receipt as Record<string, unknown>));
+  }
   return sha256Hex(canonicalizeReceipt(receipt));
 }
 
-export async function verifyChain(receipts: Receipt[], expectedKeyHex = ""): Promise<ChainResult> {
+export interface VerifyChainOptions {
+  allowUnpinned?: boolean;
+}
+
+export async function verifyChain(
+  receipts: Receipt[],
+  expectedKeyHex = "",
+  options: VerifyChainOptions = {},
+): Promise<ChainResult> {
   if (receipts.length === 0) {
     return { valid: true, receipt_count: 0, final_seq: 0, root_hash: "" };
   }
 
+  if (receipts[0]?.record_type === evidenceRecordType) {
+    return verifyEvidenceChain(receipts, expectedKeyHex, options);
+  }
+
   let keyHex = expectedKeyHex;
+  if (keyHex === "" && options.allowUnpinned !== true) {
+    return unpinnedChainResult(0);
+  }
   if (keyHex === "") keyHex = receipts[0]?.signer_key ?? "";
 
   let prevHash = genesisHash;
@@ -22,7 +42,7 @@ export async function verifyChain(receipts: Receipt[], expectedKeyHex = ""): Pro
     const receipt = receipts[i] as Receipt;
     const seq = receipt.action_record?.chain_seq ?? 0;
     try {
-      await verifyReceipt(receipt, keyHex);
+      await verifyReceipt(receipt, keyHex, { allowUnpinned: options.allowUnpinned });
     } catch (err) {
       return {
         valid: false,
@@ -62,6 +82,76 @@ export async function verifyChain(receipts: Receipt[], expectedKeyHex = ""): Pro
     receipt_count: receipts.length,
     final_seq: last.action_record?.chain_seq ?? 0,
     root_hash: prevHash,
+  };
+}
+
+async function verifyEvidenceChain(
+  receipts: Receipt[],
+  expectedKeyHex: string,
+  options: VerifyChainOptions,
+): Promise<ChainResult> {
+  const keyHex = expectedKeyHex.toLowerCase();
+  if (keyHex === "" && options.allowUnpinned !== true) {
+    return unpinnedChainResult(0);
+  }
+  const signerID = signerKeyID(receipts[0] as Receipt);
+  let prevHash = genesisHash;
+  for (let i = 0; i < receipts.length; i++) {
+    const receipt = receipts[i] as Receipt;
+    const seq = receipt.chain_seq ?? 0;
+    if (receipt.record_type !== evidenceRecordType) {
+      return broken(seq, `seq ${seq}: mixed receipt record_type`);
+    }
+    try {
+      if (keyHex === "") {
+        normalizeEvidenceReceipt(receipt);
+      } else {
+        await verifyReceipt(receipt, keyHex);
+      }
+    } catch (err) {
+      return broken(seq, `seq ${seq}: signature: ${(err as Error).message}`);
+    }
+    if (signerKeyID(receipt) !== signerID) {
+      return broken(seq, `seq ${seq}: signer_key_id breaks chain signer ${signerID}`);
+    }
+    if (seq !== i) {
+      return broken(seq, `seq gap: expected ${i}, got ${seq}`);
+    }
+    if (receipt.chain_prev_hash !== prevHash) {
+      return broken(seq, `seq ${seq}: chain_prev_hash mismatch`);
+    }
+    prevHash = receiptHash(receipt);
+  }
+  const last = receipts[receipts.length - 1] as Receipt;
+  return {
+    valid: true,
+    receipt_count: receipts.length,
+    final_seq: last.chain_seq ?? 0,
+    root_hash: prevHash,
+  };
+}
+
+function signerKeyID(receipt: Receipt): string {
+  const signature = receipt.signature;
+  if (typeof signature === "object" && signature !== null) {
+    const signer = signature["signer_key_id"];
+    return typeof signer === "string" ? signer : "";
+  }
+  return "";
+}
+
+function unpinnedChainResult(seq: number): ChainResult {
+  return broken(seq, unpinnedReceiptBanner);
+}
+
+function broken(seq: number, error: string): ChainResult {
+  return {
+    valid: false,
+    receipt_count: 0,
+    final_seq: 0,
+    root_hash: "",
+    broken_at_seq: seq,
+    error,
   };
 }
 

--- a/sdk/verifiers/ts/src/cli.ts
+++ b/sdk/verifiers/ts/src/cli.ts
@@ -13,6 +13,7 @@ import { RuntimeError, UsageError, errorMessage, resolveSignerKey } from "./util
 export interface ChainCommandReport {
   path: string;
   valid: boolean;
+  unpinned?: boolean;
   receipt_count: number;
   final_seq: number;
   root_hash?: string;
@@ -25,10 +26,10 @@ function usage(command?: string): string {
     return "Usage: pipelock-verifier-ts audit-packet PATH [--json] [--key HEX_OR_FILE] [--offline] [--allow-self-consistent-only] [--no-trust-required] [--expect-sha256 HEX]";
   }
   if (command === "chain") {
-    return "Usage: pipelock-verifier-ts chain PATH [--json] [--key HEX_OR_FILE] [--dir] [--session-id ID]";
+    return "Usage: pipelock-verifier-ts chain PATH [--json] [--key HEX_OR_FILE] [--allow-unpinned] [--dir] [--session-id ID]";
   }
   if (command === "receipt") {
-    return "Usage: pipelock-verifier-ts receipt PATH [--json] [--key HEX_OR_FILE]";
+    return "Usage: pipelock-verifier-ts receipt PATH [--json] [--key HEX_OR_FILE] [--allow-unpinned]";
   }
   if (command === "aarp") {
     return "Usage: pipelock-verifier-ts aarp PATH --trust TRUST_JSON [--chain] [--json]";
@@ -74,6 +75,7 @@ async function runChainCommand(args: string[]): Promise<number> {
     options: {
       json: { type: "boolean", default: false },
       key: { type: "string", default: "" },
+      "allow-unpinned": { type: "boolean", default: false },
       dir: { type: "boolean", default: false },
       "session-id": { type: "string", default: "proxy" },
     },
@@ -113,10 +115,12 @@ async function runChainCommand(args: string[]): Promise<number> {
     emitChain(report, parsed.values.json === true);
     return 1;
   }
-  const result = await verifyChain(receipts, keyHex);
+  const allowUnpinned = parsed.values["allow-unpinned"] === true;
+  const result = await verifyChain(receipts, keyHex, { allowUnpinned });
   const report: ChainCommandReport = {
     path: label,
     valid: result.valid,
+    unpinned: keyHex === "" && (result.valid || result.error?.includes("UNPINNED")),
     receipt_count: result.receipt_count,
     final_seq: result.final_seq,
     root_hash: result.root_hash || undefined,
@@ -134,10 +138,15 @@ async function runReceiptCommand(args: string[]): Promise<number> {
     options: {
       json: { type: "boolean", default: false },
       key: { type: "string", default: "" },
+      "allow-unpinned": { type: "boolean", default: false },
     },
   });
   const target = requireOneArg(parsed.positionals, "receipt");
-  const report = await runReceipt(target, parsed.values.key ?? "");
+  const report = await runReceipt(
+    target,
+    parsed.values.key ?? "",
+    parsed.values["allow-unpinned"] === true,
+  );
   emitReceipt(report, parsed.values.json === true);
   return report.valid ? 0 : 1;
 }

--- a/sdk/verifiers/ts/src/output.ts
+++ b/sdk/verifiers/ts/src/output.ts
@@ -40,13 +40,19 @@ export function emitReceipt(report: ReceiptReport, json: boolean): void {
     return;
   }
   if (report.valid) {
-    process.stdout.write(`RECEIPT VALID: ${report.path}\n`);
+    process.stdout.write(`RECEIPT ${report.unpinned ? "UNPINNED" : "VALID"}: ${report.path}\n`);
+    if (report.unpinned && report.error) process.stdout.write(`  warning:      ${report.error}\n`);
     process.stdout.write(`  action_id:    ${report.action_id ?? ""}\n`);
     process.stdout.write(`  verdict:      ${report.verdict ?? ""}\n`);
     process.stdout.write(`  transport:    ${report.transport ?? ""}\n`);
     process.stdout.write(`  signer:       ${report.signer_key ?? ""}\n`);
     process.stdout.write(`  policy_hash:  ${report.policy_hash ?? ""}\n`);
     process.stdout.write(`  chain_seq:    ${report.chain_seq ?? 0}\n`);
+    return;
+  }
+  if (report.unpinned) {
+    process.stderr.write(`RECEIPT UNPINNED: ${report.path}\n`);
+    if (report.error) process.stderr.write(`  warning: ${report.error}\n`);
     return;
   }
   process.stderr.write(`RECEIPT INVALID: ${report.path}\n`);
@@ -59,10 +65,16 @@ export function emitChain(report: ChainCommandReport, json: boolean): void {
     return;
   }
   if (report.valid) {
-    process.stdout.write(`CHAIN VALID: ${report.path}\n`);
+    process.stdout.write(`CHAIN ${report.unpinned ? "UNPINNED" : "VALID"}: ${report.path}\n`);
+    if (report.unpinned && report.error) process.stdout.write(`  warning:    ${report.error}\n`);
     process.stdout.write(`  receipts:   ${report.receipt_count}\n`);
     process.stdout.write(`  final seq:  ${report.final_seq}\n`);
     process.stdout.write(`  root hash:  ${report.root_hash}\n`);
+    return;
+  }
+  if (report.unpinned) {
+    process.stderr.write(`CHAIN UNPINNED: ${report.path}\n`);
+    if (report.error) process.stderr.write(`  warning:    ${report.error}\n`);
     return;
   }
   process.stderr.write(`CHAIN BROKEN: ${report.path}\n`);

--- a/sdk/verifiers/ts/src/receipt.ts
+++ b/sdk/verifiers/ts/src/receipt.ts
@@ -1,12 +1,13 @@
 import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import type { Receipt } from "./types.js";
-import { verifyReceipt } from "./signing.js";
+import { normalizeEvidenceReceipt, unpinnedReceiptBanner, verifyReceipt } from "./signing.js";
 import { parseJSON, rejectDuplicateKeys, resolveSignerKey } from "./util.js";
 
 export interface ReceiptReport {
   path: string;
   valid: boolean;
+  unpinned?: boolean;
   action_id?: string;
   verdict?: string;
   transport?: string;
@@ -16,7 +17,11 @@ export interface ReceiptReport {
   error?: string;
 }
 
-export async function runReceipt(pathname: string, signerKey: string): Promise<ReceiptReport> {
+export async function runReceipt(
+  pathname: string,
+  signerKey: string,
+  allowUnpinned = false,
+): Promise<ReceiptReport> {
   const clean = path.normalize(pathname);
   const keyHex = resolveSignerKey(signerKey);
   const text = readFileSync(clean, "utf8");
@@ -51,10 +56,24 @@ export async function runReceipt(pathname: string, signerKey: string): Promise<R
     report.chain_seq = receipt.action_record?.chain_seq;
   }
   try {
-    await verifyReceipt(receipt, keyHex);
+    if (keyHex === "" && receipt.record_type === "evidence_receipt_v2") {
+      normalizeEvidenceReceipt(receipt);
+      report.unpinned = true;
+      report.error = unpinnedReceiptBanner;
+      report.valid = allowUnpinned;
+      return report;
+    }
+    await verifyReceipt(receipt, keyHex, { allowUnpinned });
+    if (keyHex === "") {
+      report.unpinned = true;
+      report.error = unpinnedReceiptBanner;
+    }
     report.valid = true;
   } catch (err) {
     report.error = (err as Error).message;
+    if (keyHex === "" && report.error === unpinnedReceiptBanner) {
+      report.unpinned = true;
+    }
   }
   return report;
 }

--- a/sdk/verifiers/ts/src/recorder.ts
+++ b/sdk/verifiers/ts/src/recorder.ts
@@ -4,6 +4,7 @@ import type { Receipt, RecorderEntry } from "./types.js";
 import { RuntimeError, parseJSON, rejectDuplicateKeys } from "./util.js";
 
 const actionReceiptType = "action_receipt";
+const evidenceReceiptType = "evidence_receipt";
 
 export function readEntries(file: string): RecorderEntry[] {
   const text = readFileSync(path.normalize(file), "utf8");
@@ -26,7 +27,7 @@ export function readEntries(file: string): RecorderEntry[] {
 
 export function extractReceipts(file: string): Receipt[] {
   return readEntries(file)
-    .filter((entry) => entry.type === actionReceiptType)
+    .filter((entry) => entry.type === actionReceiptType || entry.type === evidenceReceiptType)
     .map((entry) => {
       if (typeof entry.detail !== "object" || entry.detail === null) {
         throw new RuntimeError(`entry seq ${String(entry.seq)}: receipt detail is not an object`);

--- a/sdk/verifiers/ts/src/signing.ts
+++ b/sdk/verifiers/ts/src/signing.ts
@@ -6,6 +6,8 @@ import { canonicalizeBytes } from "./aarp/canonical.js";
 import { decodeHex } from "./util.js";
 
 const signaturePrefix = "ed25519:";
+export const unpinnedReceiptBanner =
+  "UNPINNED — signature is self-consistent but the signer was NOT checked against a trusted key";
 const v2RecordType = "evidence_receipt_v2";
 const v2ReceiptVersion = 2;
 const v2SignatureAlgorithm = "ed25519";
@@ -409,13 +411,24 @@ export function normalizeReceipt(receipt: Receipt): Receipt {
   return receipt;
 }
 
-export async function verifyReceipt(receipt: Receipt, expectedKeyHex = ""): Promise<void> {
+export interface VerifyReceiptOptions {
+  allowUnpinned?: boolean;
+}
+
+export async function verifyReceipt(
+  receipt: Receipt,
+  expectedKeyHex = "",
+  options: VerifyReceiptOptions = {},
+): Promise<void> {
   if (receipt.record_type === v2RecordType) {
     return verifyEvidenceReceipt(receipt, expectedKeyHex);
   }
   normalizeReceipt(receipt);
   const signerKey = (receipt.signer_key ?? "").toLowerCase();
   const expected = expectedKeyHex.toLowerCase();
+  if (expected === "" && options.allowUnpinned !== true) {
+    throw new Error(unpinnedReceiptBanner);
+  }
   const keyHex = expected === "" ? signerKey : expected;
   if (expected !== "" && signerKey !== expected) {
     throw new Error(`signer_key ${signerKey} does not match expected key ${expected}`);

--- a/sdk/verifiers/ts/tests/canonical.test.ts
+++ b/sdk/verifiers/ts/tests/canonical.test.ts
@@ -96,5 +96,5 @@ test("canonical Receipt envelope matches Go hash", () => {
 });
 
 test("full-field receipt signature verifies", async () => {
-  await assert.doesNotReject(verifyReceipt(fullReceipt));
+  await assert.doesNotReject(verifyReceipt(fullReceipt, "", { allowUnpinned: true }));
 });

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -1,16 +1,38 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
+import * as ed25519 from "@noble/ed25519";
+import { canonicalizeBytes } from "../src/aarp/canonical.js";
 import { extractReceipts } from "../src/recorder.js";
-import { verifyChain } from "../src/chain.js";
+import { receiptHash, verifyChain } from "../src/chain.js";
+import type { JSONObject, Receipt } from "../src/types.js";
 
 const validChain = "../../conformance/testdata/valid-chain.jsonl";
 const brokenChain = "../../conformance/testdata/broken-chain.jsonl";
+const validPlainV2 =
+  "../../../internal/contract/testdata/golden/valid_evidence_receipt_proxy_decision.json";
+const v2GoldenPublicKey = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+const v2PrivateSeedHex =
+  "9d61b19d" +
+  "effd5a60" +
+  "ba844af4" +
+  "92ec2cc4" +
+  "4449c569" +
+  "7b326919" +
+  "703bac03" +
+  "1cae7f60";
 
 test("valid Go-generated chain verifies", async () => {
   const result = await verifyChain(extractReceipts(validChain));
+  assert.equal(result.valid, false);
+  assert.match(result.error ?? "", /UNPINNED/u);
+});
+
+test("valid Go-generated chain allows explicit unpinned structural verification", async () => {
+  const result = await verifyChain(extractReceipts(validChain), "", { allowUnpinned: true });
   assert.equal(result.valid, true);
   assert.equal(result.receipt_count, 5);
   assert.equal(result.final_seq, 4);
@@ -21,7 +43,7 @@ test("valid Go-generated chain verifies", async () => {
 });
 
 test("broken chain_prev_hash is rejected", async () => {
-  const result = await verifyChain(extractReceipts(brokenChain));
+  const result = await verifyChain(extractReceipts(brokenChain), "", { allowUnpinned: true });
   assert.equal(result.valid, false);
   assert.match(result.error ?? "", /chain_prev_hash mismatch/u);
 });
@@ -29,7 +51,7 @@ test("broken chain_prev_hash is rejected", async () => {
 test("chain_seq gap is rejected", async () => {
   const receipts = extractReceipts(validChain);
   receipts.splice(2, 1);
-  const result = await verifyChain(receipts);
+  const result = await verifyChain(receipts, "", { allowUnpinned: true });
   assert.equal(result.valid, false);
   assert.match(result.error ?? "", /seq gap/u);
 });
@@ -37,17 +59,46 @@ test("chain_seq gap is rejected", async () => {
 test("first receipt must link to genesis", async () => {
   const receipts = extractReceipts(validChain);
   receipts[0]!.action_record!.chain_prev_hash = "not-genesis";
-  const result = await verifyChain(receipts);
+  const result = await verifyChain(receipts, "", { allowUnpinned: true });
   assert.equal(result.valid, false);
-  assert.match(result.error ?? "", /signature/u);
+  assert.match(result.error ?? "", /signature|chain_prev_hash/u);
 });
 
 test("mixed signer keys are rejected without pinned key", async () => {
   const receipts = extractReceipts(validChain);
   receipts[1]!.signer_key = "0".repeat(64);
-  const result = await verifyChain(receipts);
+  const result = await verifyChain(receipts, "", { allowUnpinned: true });
   assert.equal(result.valid, false);
   assert.match(result.error ?? "", /does not match expected key/u);
+});
+
+test("EvidenceReceipt v2 multi-receipt chain verifies with pinned key", async () => {
+  const receipts = await buildEvidenceChain(2);
+  const result = await verifyChain(receipts, v2GoldenPublicKey);
+  assert.equal(result.valid, true, result.error);
+  assert.equal(result.receipt_count, 2);
+  assert.equal(result.final_seq, 1);
+});
+
+test("EvidenceReceipt v2 tampered chain fails closed", async () => {
+  const receipts = await buildEvidenceChain(2);
+  receipts.pop();
+  const result = await verifyChain(receipts, v2GoldenPublicKey);
+  assert.equal(result.valid, true, result.error);
+
+  const tampered = await buildEvidenceChain(2);
+  tampered[1]!.chain_prev_hash = "sha256:0";
+  const broken = await verifyChain(tampered, v2GoldenPublicKey);
+  assert.equal(broken.valid, false);
+  assert.match(broken.error ?? "", /signature|chain_prev_hash/u);
+});
+
+test("EvidenceReceipt v2 truncated middle receipt fails closed", async () => {
+  const receipts = await buildEvidenceChain(3);
+  receipts.splice(1, 1);
+  const result = await verifyChain(receipts, v2GoldenPublicKey);
+  assert.equal(result.valid, false);
+  assert.match(result.error ?? "", /signature|seq gap/u);
 });
 
 test("malformed JSONL raises an error", () => {
@@ -79,3 +130,39 @@ test("JSONL recorder extraction rejects duplicate keys inside receipt detail", (
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+async function buildEvidenceChain(count: number): Promise<Receipt[]> {
+  const base = JSON.parse(readFileSync(validPlainV2, "utf8")) as Receipt;
+  const receipts: Receipt[] = [];
+  let prevHash = "genesis";
+  for (let i = 0; i < count; i++) {
+    const receipt = JSON.parse(JSON.stringify(base)) as Receipt;
+    receipt.event_id = `01F8MECHZX3TBDSZ7XRADM79V${i}`;
+    receipt.chain_seq = i;
+    receipt.chain_prev_hash = prevHash;
+    await signEvidenceReceipt(receipt);
+    receipts.push(receipt);
+    prevHash = receiptHash(receipt);
+  }
+  return receipts;
+}
+
+async function signEvidenceReceipt(receipt: Receipt): Promise<void> {
+  const signature = receipt.signature as JSONObject;
+  receipt.signature = {
+    signer_key_id: "",
+    key_purpose: "",
+    algorithm: "",
+    signature: "",
+  };
+  const sig = await ed25519.signAsync(
+    canonicalizeBytes(receipt),
+    Buffer.from(v2PrivateSeedHex, "hex"),
+  );
+  receipt.signature = {
+    signer_key_id: signature["signer_key_id"] ?? "receipt-signing-test",
+    key_purpose: "receipt-signing",
+    algorithm: "ed25519",
+    signature: `ed25519:${Buffer.from(sig).toString("hex")}`,
+  };
+}

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -1,5 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -80,12 +79,14 @@ test("EvidenceReceipt v2 multi-receipt chain verifies with pinned key", async ()
   assert.equal(result.final_seq, 1);
 });
 
-test("EvidenceReceipt v2 tampered chain fails closed", async () => {
+test("EvidenceReceipt v2 valid 1-receipt chain after pop", async () => {
   const receipts = await buildEvidenceChain(2);
   receipts.pop();
   const result = await verifyChain(receipts, v2GoldenPublicKey);
   assert.equal(result.valid, true, result.error);
+});
 
+test("EvidenceReceipt v2 tampered chain fails closed", async () => {
   const tampered = await buildEvidenceChain(2);
   tampered[1]!.chain_prev_hash = "sha256:0";
   const broken = await verifyChain(tampered, v2GoldenPublicKey);

--- a/sdk/verifiers/ts/tests/receipt.test.ts
+++ b/sdk/verifiers/ts/tests/receipt.test.ts
@@ -18,12 +18,21 @@ const v2GoldenPolicyHash =
 
 test("receipt command accepts a valid Go-generated receipt", async () => {
   const report = await runReceipt(validSingle, "");
+  assert.equal(report.valid, false);
+  assert.equal(report.unpinned, true);
+  assert.match(report.error ?? "", /UNPINNED/u);
+});
+
+test("receipt command explicitly allows unpinned structural verification", async () => {
+  const report = await runReceipt(validSingle, "", true);
   assert.equal(report.valid, true);
+  assert.equal(report.unpinned, true);
   assert.equal(report.action_id, "conformance-00000");
 });
 
 test("receipt command rejects a tampered signature", async () => {
-  const report = await runReceipt(invalidSignature, "");
+  const receipt = JSON.parse(readFileSync(invalidSignature, "utf8")) as Receipt;
+  const report = await runReceipt(invalidSignature, receipt.signer_key ?? "");
   assert.equal(report.valid, false);
   assert.match(report.error ?? "", /signature verification failed/u);
 });


### PR DESCRIPTION
## Summary
- Require trusted key pinning for clean receipt and chain verification across the Go CLI, standalone verifier, and SDK verifier paths
- Add explicit `--allow-unpinned` structural-only verification with loud UNPINNED reporting and non-zero default behavior
- Add EvidenceReceipt v2 chain verification to the TypeScript, Rust, and Python verifier implementations

## Notes
- Keeps structural-only verification available as an explicit opt-in
- Aligns SDK verifier behavior with the Go verifier trust boundary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --allow-unpinned flag to allow structural-only verification when no trusted signer key is provided
  * Human output now prints “RECEIPT UNPINNED” / “CHAIN UNPINNED” banners; JSON reports include an unpinned boolean and signer_key_id for v2 evidence
  * EvidenceReceipt v2 chain verification supported across CLIs and SDKs

* **Documentation**
  * CLI help updated to describe provenance / unpinned behavior

* **Tests**
  * Test suites extended to cover unpinned workflows and v2 chain scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->