### PR TITLE
Emit decision receipts on A2A block paths

### DIFF
--- a/internal/mcp/a2a_receipt_parity_test.go
+++ b/internal/mcp/a2a_receipt_parity_test.go
@@ -1,0 +1,386 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+// A2A (agent-to-agent) decision points block traffic on multiple paths. Every
+// block must leave a policy-hash-bearing receipt, the same as the other
+// applicable transports (forward/CONNECT/WS/MCP tools-call). These tests lock
+// in the A2A listener/header and non-tools/call body paths that previously
+// returned without evidence.
+//
+// Transport-attribution note: the receipt convention is Transport = the wire
+// (forward / mcp_http / mcp_http_listener) and Layer = the A2A scanner
+// (mcp_a2a_scanning), mirroring the forward A2A path which already ships
+// Transport="forward" + Layer="a2a_header". A2A is a protocol that rides over a
+// transport, so it is attributed via Layer/method, not by overloading
+// Transport. See internal/proxy/receipt_coverage_test.go for the established
+// shape.
+
+const (
+	a2aReceiptListenerTrans = "mcp_http_listener"
+	// fakeGHTokenA2A is a synthetic GitHub PAT (prefix + 36 chars) kept split
+	// across literals so gitleaks/gosec G101 do not flag it. It trips the DLP
+	// scanner the same way a real leaked token would.
+	fakeGHTokenA2A = "ghp_" + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+	// a2aEmitterConfigHash is the configHash the test emitter stamps onto every
+	// v1 receipt. In production this is cfg.CanonicalPolicyHash(); pinning it
+	// lets the tests assert the receipt is bound to a non-empty policy hash.
+	a2aEmitterConfigHash = "test-config-hash"
+)
+
+// a2aBlockReceipts returns the v1 action receipts in dir whose verdict is block.
+func a2aBlockReceipts(t *testing.T, dir string) []receipt.Receipt {
+	t.Helper()
+	var out []receipt.Receipt
+	for _, r := range decisionReceiptLogFor(t, dir) {
+		if r.ActionRecord.Verdict == config.ActionBlock {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// a2aSendMessageWithToken builds an A2A SendMessage frame whose text part
+// carries a leaked token, tripping the DLP scanner.
+func a2aSendMessageWithToken(id int) string {
+	return makeRequest(id, "SendMessage", map[string]any{
+		"message": map[string]any{
+			"parts": []map[string]any{{"text": "exfil " + fakeGHTokenA2A}},
+		},
+	})
+}
+
+// startA2AReceiptListener boots RunHTTPListenerProxy wired with the supplied
+// opts (carrying a capturing receipt emitter), returning the base URL.
+func startA2AReceiptListener(t *testing.T, upstreamURL string, opts MCPProxyOpts) string {
+	t.Helper()
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+
+	var logBuf lockedHTTPBuffer
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- RunHTTPListenerProxy(ctx, ln, upstreamURL, &logBuf, opts)
+	}()
+
+	baseURL := "http://" + addr
+	waitForHTTPHealth(t, baseURL)
+
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("RunHTTPListenerProxy: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("timeout waiting for listener proxy to stop")
+		}
+	})
+	return baseURL
+}
+
+func postA2A(t *testing.T, baseURL, body string, headers map[string]string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, baseURL+"/", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
+// 5a: a blocked A2A *header* request (an A2A-Extensions URI the URL scanner
+// rejects) must emit a signed block receipt bound to the policy hash. Pre-fix
+// the header block wrote the JSON-RPC error and returned with no receipt.
+func TestA2AHeaderBlock_EmitsReceiptWithPolicyHash(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream called: A2A header block must prevent forwarding")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	h := newMCPDecisionReceiptHarness(t)
+	sc := testScannerForHTTP(t)
+
+	baseURL := startA2AReceiptListener(t, upstream.URL, MCPProxyOpts{
+		Scanner:          sc,
+		A2ACfg:           &config.A2AScanning{Enabled: true, Action: config.ActionBlock},
+		ReceiptEmitter:   h.v1,
+		V2ReceiptEmitter: h.v2,
+		PolicyHash:       mcpTestPolicyHash,
+	})
+
+	// Benign body; the malicious signal is in the A2A-Extensions header. The
+	// ftp:// scheme is rejected by the URL scanner without needing DNS.
+	postA2A(t, baseURL, jsonToolsList, map[string]string{
+		"A2A-Extensions": "ftp://evil.example.com/exfil",
+	})
+
+	blocks := a2aBlockReceipts(t, h.dir)
+	if len(blocks) != 1 {
+		t.Fatalf("expected exactly 1 block receipt for A2A header block, got %d", len(blocks))
+	}
+	r := blocks[0]
+	if err := receipt.VerifyWithKey(r, hex.EncodeToString(h.pub)); err != nil {
+		t.Fatalf("receipt verify: %v", err)
+	}
+	ar := r.ActionRecord
+	if ar.PolicyHash != a2aEmitterConfigHash {
+		t.Errorf("PolicyHash = %q, want non-empty %q", ar.PolicyHash, a2aEmitterConfigHash)
+	}
+	if ar.Transport != a2aReceiptListenerTrans {
+		t.Errorf("Transport = %q, want %q", ar.Transport, a2aReceiptListenerTrans)
+	}
+	if ar.Layer != mcpReceiptLayerA2A {
+		t.Errorf("Layer = %q, want %q", ar.Layer, mcpReceiptLayerA2A)
+	}
+	if ar.Target != mcpReceiptA2AHeaderTarget {
+		t.Errorf("Target = %q, want %q", ar.Target, mcpReceiptA2AHeaderTarget)
+	}
+
+	// The listener header path uses the same decision helper as body blocks, so
+	// it should also produce a signed v2 decision when a v2 emitter is present.
+	v2s := mcpV2Receipts(t, h)
+	if len(v2s) != 1 {
+		t.Fatalf("expected exactly 1 v2 decision for A2A header block, got %d", len(v2s))
+	}
+	if err := contractreceipt.VerifyWithKey(v2s[0], h.pub, h.kid); err != nil {
+		t.Fatalf("v2 verify: %v", err)
+	}
+	if v2s[0].PolicyHash != mcpTestPolicyHash {
+		t.Errorf("v2 PolicyHash = %q, want %q", v2s[0].PolicyHash, mcpTestPolicyHash)
+	}
+}
+
+// 5b (A2A body gate): a non-tools/call A2A method whose A2A body scan finds a
+// secret (Action=block) short-circuits via blockingGateA2ABody. That block must
+// emit BOTH a v1 receipt and a v2 decision, policy-hash bound. Pre-fix actionID
+// was empty (not a tools/call) so the deferred emitter suppressed both.
+func TestA2ABodyBlock_A2AGate_DualEmitsWithPolicyHash(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	h := newMCPDecisionReceiptHarness(t)
+
+	opts := MCPProxyOpts{
+		Scanner:          sc,
+		InputCfg:         &InputScanConfig{Enabled: true, Action: config.ActionBlock, OnParseError: config.ActionBlock},
+		A2ACfg:           &config.A2AScanning{Enabled: true, Action: config.ActionBlock},
+		ReceiptEmitter:   h.v1,
+		V2ReceiptEmitter: h.v2,
+		PolicyHash:       mcpTestPolicyHash,
+		Transport:        a2aReceiptListenerTrans,
+	}
+	var logBuf bytes.Buffer
+	decision := scanHTTPInputDecision([]byte(a2aSendMessageWithToken(7)), &logBuf, "s", "s", opts)
+	if decision.Blocked == nil {
+		t.Fatalf("expected A2A body block, got forward; log=%s", logBuf.String())
+	}
+
+	// v1 receipt: signed, block, A2A layer, target = the A2A method.
+	v1s := a2aBlockReceipts(t, h.dir)
+	if len(v1s) != 1 {
+		t.Fatalf("expected exactly 1 v1 block receipt, got %d", len(v1s))
+	}
+	if err := receipt.VerifyWithKey(v1s[0], hex.EncodeToString(h.pub)); err != nil {
+		t.Fatalf("v1 verify: %v", err)
+	}
+	ar := v1s[0].ActionRecord
+	if ar.PolicyHash != a2aEmitterConfigHash {
+		t.Errorf("v1 PolicyHash = %q, want %q", ar.PolicyHash, a2aEmitterConfigHash)
+	}
+	if ar.Layer != mcpReceiptLayerA2A {
+		t.Errorf("v1 Layer = %q, want %q", ar.Layer, mcpReceiptLayerA2A)
+	}
+	if ar.Target != "SendMessage" {
+		t.Errorf("v1 Target = %q, want SendMessage", ar.Target)
+	}
+
+	// v2 decision: signed, policy-hash bound (closes the recorder — call last).
+	v2s := mcpV2Receipts(t, h)
+	if len(v2s) != 1 {
+		t.Fatalf("expected exactly 1 v2 decision, got %d", len(v2s))
+	}
+	if err := contractreceipt.VerifyWithKey(v2s[0], h.pub, h.kid); err != nil {
+		t.Fatalf("v2 verify: %v", err)
+	}
+	if v2s[0].PolicyHash != mcpTestPolicyHash {
+		t.Errorf("v2 PolicyHash = %q, want %q", v2s[0].PolicyHash, mcpTestPolicyHash)
+	}
+	var payload struct {
+		Target  string `json:"target"`
+		Verdict string `json:"verdict"`
+	}
+	if err := json.Unmarshal(v2s[0].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal v2 payload: %v", err)
+	}
+	if payload.Target != "SendMessage" {
+		t.Errorf("v2 target = %q, want SendMessage", payload.Target)
+	}
+}
+
+// 5b (general content path): a non-tools/call A2A method with a DLP hit caught
+// by the general content scan (A2A body scan disabled) is blocked at the
+// effective-action switch, not the A2A gate. That block must ALSO emit a
+// receipt — pre-fix actionID was empty so it was suppressed. This is the path
+// the brief's "DLP hit on SendMessage" test exercises.
+func TestA2ABodyBlock_ContentScan_EmitsReceiptWithPolicyHash(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	h := newMCPDecisionReceiptHarness(t)
+
+	opts := MCPProxyOpts{
+		Scanner:  sc,
+		InputCfg: &InputScanConfig{Enabled: true, Action: config.ActionBlock, OnParseError: config.ActionBlock},
+		// A2A scanning OFF: the block must come from the general content scan.
+		ReceiptEmitter: h.v1,
+		PolicyHash:     mcpTestPolicyHash,
+		Transport:      a2aReceiptListenerTrans,
+	}
+	var logBuf bytes.Buffer
+	decision := scanHTTPInputDecision([]byte(a2aSendMessageWithToken(8)), &logBuf, "s", "s", opts)
+	if decision.Blocked == nil {
+		t.Fatalf("expected content-scan block on A2A method, got forward; log=%s", logBuf.String())
+	}
+
+	blocks := a2aBlockReceipts(t, h.dir)
+	if len(blocks) != 1 {
+		t.Fatalf("expected exactly 1 block receipt for A2A content-scan block, got %d", len(blocks))
+	}
+	ar := blocks[0].ActionRecord
+	if ar.PolicyHash != a2aEmitterConfigHash {
+		t.Errorf("PolicyHash = %q, want %q", ar.PolicyHash, a2aEmitterConfigHash)
+	}
+	if ar.Verdict != config.ActionBlock {
+		t.Errorf("Verdict = %q, want %q", ar.Verdict, config.ActionBlock)
+	}
+	if ar.Target != "SendMessage" {
+		t.Errorf("Target = %q, want SendMessage", ar.Target)
+	}
+}
+
+// 5b (pre-redaction path): with a redaction matcher configured, an A2A method
+// carrying a DLP secret is blocked by the pre-redaction content scan, which
+// returns BEFORE the gate-evaluation step that normally sets mcpMethod. This
+// proves the early A2A-method capture is load-bearing: without it the deferred
+// emitter could not see this is an A2A frame and would suppress the receipt.
+func TestA2ABodyBlock_PreRedaction_EmitsReceipt(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	h := newMCPDecisionReceiptHarness(t)
+
+	opts := MCPProxyOpts{
+		Scanner:        sc,
+		InputCfg:       &InputScanConfig{Enabled: true, Action: config.ActionBlock, OnParseError: config.ActionBlock},
+		RedactMatcher:  testHTTPRedactionMatcher(),
+		ReceiptEmitter: h.v1,
+		PolicyHash:     mcpTestPolicyHash,
+		Transport:      a2aReceiptListenerTrans,
+	}
+	var logBuf bytes.Buffer
+	decision := scanHTTPInputDecision([]byte(a2aSendMessageWithToken(11)), &logBuf, "s", "s", opts)
+	if decision.Blocked == nil {
+		t.Fatalf("expected pre-redaction block on A2A method, got forward; log=%s", logBuf.String())
+	}
+
+	blocks := a2aBlockReceipts(t, h.dir)
+	if len(blocks) != 1 {
+		t.Fatalf("expected exactly 1 block receipt for pre-redaction A2A block, got %d", len(blocks))
+	}
+	if blocks[0].ActionRecord.PolicyHash != a2aEmitterConfigHash {
+		t.Errorf("PolicyHash = %q, want %q", blocks[0].ActionRecord.PolicyHash, a2aEmitterConfigHash)
+	}
+}
+
+// Regression: a clean/allowed A2A request must NOT emit a receipt (block-parity
+// only — we do not add allow receipts for A2A in this change).
+func TestA2ACleanRequest_EmitsNoReceipt(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	h := newMCPDecisionReceiptHarness(t)
+
+	body := makeRequest(9, "SendMessage", map[string]any{
+		"message": map[string]any{"parts": []map[string]any{{"text": "hello peer"}}},
+	})
+	opts := MCPProxyOpts{
+		Scanner:          sc,
+		InputCfg:         &InputScanConfig{Enabled: true, Action: config.ActionBlock, OnParseError: config.ActionBlock},
+		A2ACfg:           &config.A2AScanning{Enabled: true, Action: config.ActionBlock},
+		ReceiptEmitter:   h.v1,
+		V2ReceiptEmitter: h.v2,
+		PolicyHash:       mcpTestPolicyHash,
+		Transport:        a2aReceiptListenerTrans,
+	}
+	var logBuf bytes.Buffer
+	decision := scanHTTPInputDecision([]byte(body), &logBuf, "s", "s", opts)
+	if decision.Blocked != nil {
+		t.Fatalf("expected clean A2A request to pass, got blocked: %+v", decision.Blocked)
+	}
+
+	// A clean request emits nothing, so the recorder never creates an evidence
+	// file. readReceiptEntriesHTTP scans the dir and tolerates its absence.
+	for _, e := range readReceiptEntriesHTTP(t, h.dir) {
+		if e.Type == actionReceiptEntryType {
+			t.Fatal("expected no action receipt for clean A2A request, found one")
+		}
+	}
+}
+
+// Regression: a blocked tools/call still emits exactly one block receipt with a
+// real actionID. The A2A fix must not change tools/call.
+func TestToolsCallBlock_ReceiptUnchanged(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	h := newMCPDecisionReceiptHarness(t)
+
+	body := makeRequest(10, "tools/call", map[string]any{
+		"name":      "run",
+		"arguments": map[string]any{"code": "echo " + fakeGHTokenA2A},
+	})
+	opts := MCPProxyOpts{
+		Scanner:        sc,
+		InputCfg:       &InputScanConfig{Enabled: true, Action: config.ActionBlock, OnParseError: config.ActionBlock},
+		ReceiptEmitter: h.v1,
+		PolicyHash:     mcpTestPolicyHash,
+		Transport:      a2aReceiptListenerTrans,
+	}
+	var logBuf bytes.Buffer
+	decision := scanHTTPInputDecision([]byte(body), &logBuf, "s", "s", opts)
+	if decision.Blocked == nil {
+		t.Fatalf("expected tools/call block, got forward; log=%s", logBuf.String())
+	}
+
+	blocks := a2aBlockReceipts(t, h.dir)
+	if len(blocks) != 1 {
+		t.Fatalf("expected exactly 1 block receipt for tools/call, got %d", len(blocks))
+	}
+	if blocks[0].ActionRecord.ActionID == "" {
+		t.Error("tools/call block receipt has empty ActionID")
+	}
+}

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -78,6 +78,25 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	receiptSeverity := ""
 	var receiptContractGate *mcpContractGateOutput
 	defer func() {
+		// A2A methods are not tools/call, so actionID stays empty on the
+		// tools/call path above. When such a request is BLOCKED (receiptVerdict
+		// set), mint an actionID here so the block still leaves a
+		// policy-hash-bearing receipt, matching the other applicable block
+		// surfaces. Clean or allowed A2A requests leave receiptVerdict empty and
+		// emit nothing, and tools/call already carries its own actionID, so
+		// neither path changes.
+		emitActionID := actionID
+		emitTarget := toolName
+		if emitActionID == "" && receiptVerdict != "" && IsA2AMethod(mcpMethod) {
+			emitActionID = receipt.NewActionID()
+			// A2A frames carry no tool name, but the receipt record requires a
+			// non-empty target. Use the A2A method name (e.g. SendMessage) as
+			// the action target. ClassifyMCPTool only consults the tool name
+			// for tools/call, so this leaves the action type unaffected.
+			if emitTarget == "" {
+				emitTarget = mcpMethod
+			}
+		}
 		receiptOpts := mcpToolReceiptOpts{
 			Emitter:          receiptEmitter,
 			V2Emitter:        v2ReceiptEmitter,
@@ -85,9 +104,9 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			Log:              logW,
 			Transport:        opts.Transport,
 			RedactionProfile: redactionCfg.Profile,
-			ActionID:         actionID,
+			ActionID:         emitActionID,
 			MCPMethod:        mcpMethod,
-			ToolName:         toolName,
+			ToolName:         emitTarget,
 			Verdict:          receiptVerdict,
 			Layer:            receiptLayer,
 			Pattern:          receiptPattern,
@@ -169,6 +188,13 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		toolName = pendingToolName
 		mcpMethod = methodToolsCall
 		actionID = receipt.NewActionID()
+	} else if IsA2AMethod(frame.Method) {
+		// A2A methods (SendMessage, GetTask, ...) are not tools/call, so they
+		// carry no actionID up front. Record the method now so an early-return
+		// block path (pre-redaction content scan, redaction error) still
+		// attributes the receipt to the A2A method; the deferred emitter
+		// assigns the actionID lazily when the request is actually blocked.
+		mcpMethod = frame.Method
 	}
 	if scanEnabled && redactionCfg.Matcher != nil {
 		originalVerdict := scanRequestForAgent(inputScanCtx, msg, sc, action, onParseError, opts.addressProtectionAgent())

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -21,6 +21,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/mcp/jsonrpc"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/transport"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	session "github.com/luckyPipewrench/pipelock/internal/session"
 )
@@ -399,6 +400,31 @@ func RunHTTPListenerProxy(
 						decide.RecordSignal(reqRec, session.SignalNearMiss, ep)
 					default:
 						decide.RecordSignal(reqRec, session.SignalBlock, ep)
+					}
+				}
+				// Emit a block receipt so an A2A header block leaves the same
+				// policy-hash-bearing evidence as every other applicable
+				// surface. Forward proxy A2A headers already did this; the
+				// listener header block previously returned silently with no
+				// receipt. Transport is the wire (mcp_http_listener); A2A
+				// attribution lives in the layer.
+				if emitter := baseOpts.receiptEmitter(); emitter != nil {
+					if _, emitErr := EmitMCPDecision(emitter, baseOpts.v2ReceiptEmitter(), nil, MCPDecision{
+						Receipt: baseOpts.withReceiptPolicyHash(receipt.EmitOpts{
+							ActionID:  receipt.NewActionID(),
+							Verdict:   config.ActionBlock,
+							Layer:     mcpReceiptLayerA2A,
+							Pattern:   firstNonEmpty(headerResult.Reason, mcpReceiptA2AHeaderPattern),
+							Severity:  config.SeverityHigh,
+							Transport: baseOpts.Transport,
+							// The block is on the A2A-Extensions header, not the
+							// body method, so MCPMethod is left empty and the
+							// target names the header surface. Layer + Pattern
+							// carry the A2A-header attribution.
+							Target: mcpReceiptA2AHeaderTarget,
+						}),
+					}); emitErr != nil {
+						_, _ = fmt.Fprintf(safeLogW, "pipelock: receipt emission failed: %v\n", emitErr)
 					}
 				}
 				w.Header().Set("Content-Type", "application/json")

--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -44,6 +44,16 @@ const (
 	// whitespace. Concrete rule names override this. Extracted as a const
 	// so production and tests share the same string (goconst).
 	mcpReceiptPatternPolicyDefault = "policy"
+
+	// mcpReceiptA2AHeaderPattern is the fallback Pattern for an A2A
+	// header-scan block receipt when the scan result carries no reason.
+	mcpReceiptA2AHeaderPattern = "a2a_header"
+
+	// mcpReceiptA2AHeaderTarget is the receipt Target for an A2A header
+	// block. The block is on the A2A-Extensions header surface rather than a
+	// named tool or body method, so a stable label stands in for the target
+	// the receipt record requires.
+	mcpReceiptA2AHeaderTarget = "a2a:extensions-header"
 )
 
 type taintDecision struct {


### PR DESCRIPTION
Pipelock records a signed decision receipt for every blocked action across the forward proxy, CONNECT, WebSocket, and MCP tool calls. Two agent-to-agent (A2A) block paths skipped that step, so a blocked A2A request left no evidence behind.

The MCP HTTP listener blocked A2A-Extensions header URIs that fail URL scanning, wrote the JSON-RPC error, and returned without a receipt. A2A method bodies (SendMessage, GetTask, and the rest) blocked on an embedded secret or SSRF finding never produced one either: the body emitter keys off an action ID that only tools/call frames carry, and A2A methods are not tools/call.

Both paths now emit a policy-hash-bearing block receipt. Transport stays the wire the request rode in on (mcp_http_listener), and the A2A attribution lives in the layer (mcp_a2a_scanning) and method, matching the receipt shape the forward proxy already uses for A2A headers. The body path mints an action ID only when the request is actually blocked, so clean and allowed A2A traffic and every tools/call path behave as before.

Scope stays inside internal/mcp. No receipt format, signing, or config defaults change.

Tests cover the header block, both A2A body block paths (the field-scan gate and the general content scan), the pre-redaction block, and the dual v1/v2 decision emission, plus regressions proving clean A2A emits nothing and tools/call is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt tracking for blocked A2A requests to ensure proper action attribution and policy hash binding.
  * Fixed receipt emission for A2A header-based blocks to include complete audit information.

* **Tests**
  * Added comprehensive test suite validating receipt accuracy across various block scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->