### PR TITLE
feat(receipts): enable flight recorder by default and seal transcript root on shutdown

### DIFF
--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -549,3 +549,16 @@ airlock:
 taint:
   enabled: true
   policy: permissive
+
+# ---- flight_recorder (tamper-evident decision receipts) ----
+# On by default so you can "verify the boundary." Receipts are evidence, never
+# enforcement: a recorder failure never blocks traffic. Recording goes LIVE only
+# once `dir` and `signing_key_path` are set (run `pipelock init`, which generates
+# both); without them the recorder is inert and nothing is written. `redact`
+# scrubs secrets from receipt targets before they touch disk -- keep it on, since
+# receipts carry the destinations of mediated traffic.
+flight_recorder:
+  enabled: true
+  redact: true
+  # dir: /var/lib/pipelock/recorder
+  # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -620,3 +620,16 @@ airlock:
     hard_minutes: 15
     drain_minutes: 0
     drain_timeout_seconds: 30
+
+# ---- flight_recorder (tamper-evident decision receipts) ----
+# On by default so you can "verify the boundary." Receipts are evidence, never
+# enforcement: a recorder failure never blocks traffic. Recording goes LIVE only
+# once `dir` and `signing_key_path` are set (run `pipelock init`, which generates
+# both); without them the recorder is inert and nothing is written. `redact`
+# scrubs secrets from receipt targets before they touch disk -- keep it on, since
+# receipts carry the destinations of mediated traffic.
+flight_recorder:
+  enabled: true
+  redact: true
+  # dir: /var/lib/pipelock/recorder
+  # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -586,3 +586,16 @@ airlock:
     hard_minutes: 15
     drain_minutes: 0
     drain_timeout_seconds: 30
+
+# ---- flight_recorder (tamper-evident decision receipts) ----
+# On by default so you can "verify the boundary." Receipts are evidence, never
+# enforcement: a recorder failure never blocks traffic. Recording goes LIVE only
+# once `dir` and `signing_key_path` are set (run `pipelock init`, which generates
+# both); without them the recorder is inert and nothing is written. `redact`
+# scrubs secrets from receipt targets before they touch disk -- keep it on, since
+# receipts carry the destinations of mediated traffic.
+flight_recorder:
+  enabled: true
+  redact: true
+  # dir: /var/lib/pipelock/recorder
+  # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -587,3 +587,16 @@ airlock:
     hard_minutes: 15
     drain_minutes: 0
     drain_timeout_seconds: 30
+
+# ---- flight_recorder (tamper-evident decision receipts) ----
+# On by default so you can "verify the boundary." Receipts are evidence, never
+# enforcement: a recorder failure never blocks traffic. Recording goes LIVE only
+# once `dir` and `signing_key_path` are set (run `pipelock init`, which generates
+# both); without them the recorder is inert and nothing is written. `redact`
+# scrubs secrets from receipt targets before they touch disk -- keep it on, since
+# receipts carry the destinations of mediated traffic.
+flight_recorder:
+  enabled: true
+  redact: true
+  # dir: /var/lib/pipelock/recorder
+  # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -583,3 +583,16 @@ airlock:
     hard_minutes: 15
     drain_minutes: 0
     drain_timeout_seconds: 30
+
+# ---- flight_recorder (tamper-evident decision receipts) ----
+# On by default so you can "verify the boundary." Receipts are evidence, never
+# enforcement: a recorder failure never blocks traffic. Recording goes LIVE only
+# once `dir` and `signing_key_path` are set (run `pipelock init`, which generates
+# both); without them the recorder is inert and nothing is written. `redact`
+# scrubs secrets from receipt targets before they touch disk -- keep it on, since
+# receipts carry the destinations of mediated traffic.
+flight_recorder:
+  enabled: true
+  redact: true
+  # dir: /var/lib/pipelock/recorder
+  # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -615,3 +615,16 @@ media_policy:
   strip_images: true
   strip_audio: true
   strip_video: true
+
+# ---- flight_recorder (tamper-evident decision receipts) ----
+# On by default so you can "verify the boundary." Receipts are evidence, never
+# enforcement: a recorder failure never blocks traffic. Recording goes LIVE only
+# once `dir` and `signing_key_path` are set (run `pipelock init`, which generates
+# both); without them the recorder is inert and nothing is written. `redact`
+# scrubs secrets from receipt targets before they touch disk -- keep it on, since
+# receipts carry the destinations of mediated traffic.
+flight_recorder:
+  enabled: true
+  redact: true
+  # dir: /var/lib/pipelock/recorder
+  # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -620,3 +620,16 @@ airlock:
 taint:
   enabled: true
   policy: strict
+
+# ---- flight_recorder (tamper-evident decision receipts) ----
+# On by default so you can "verify the boundary." Receipts are evidence, never
+# enforcement: a recorder failure never blocks traffic. Recording goes LIVE only
+# once `dir` and `signing_key_path` are set (run `pipelock init`, which generates
+# both); without them the recorder is inert and nothing is written. `redact`
+# scrubs secrets from receipt targets before they touch disk -- keep it on, since
+# receipts carry the destinations of mediated traffic.
+flight_recorder:
+  enabled: true
+  redact: true
+  # dir: /var/lib/pipelock/recorder
+  # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2106,8 +2106,8 @@ flight_recorder:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `enabled` | `false` | Enable evidence recording |
-| `dir` | (required if enabled) | Directory for evidence files |
+| `enabled` | `true` | Enable evidence recording. **On by default**, but recording requires `dir` and a signing key — `enabled: true` with no `dir` is inert (nothing written), not an error. `pipelock init` provisions both. Set `enabled: false` to opt out. |
+| `dir` | (empty) | Directory for evidence files. Recorder is inert until set; `pipelock init` generates one. |
 | `checkpoint_interval` | `1000` | Entries between signed checkpoints |
 | `retention_days` | `0` | Auto-expire files after N days (0 = keep forever) |
 | `redact` | `true` | DLP-redact evidence content before writing. Receipt entries get field-level redaction (target/pattern scrubbed, signature preserved). |

--- a/docs/guides/flight-recorder.md
+++ b/docs/guides/flight-recorder.md
@@ -2,6 +2,8 @@
 
 The flight recorder writes every enforcement decision pipelock makes to a hash-chained, tamper-evident evidence log. Each entry is cryptographically linked to the one before it, so any deletion or modification breaks the chain. Signed checkpoints let auditors verify the chain was intact at specific points in time without replaying every entry. The recorder is designed for post-incident investigation, compliance evidence, and forensic replay.
 
+**On by default.** `enabled` defaults to `true` so receipts are available out of the box ("verify the boundary"). It only *records* once a `dir` and a signing key are configured, though: without them the recorder is inert and writes nothing, so the default flip never breaks an existing config. `pipelock init` generates a recorder directory and an Ed25519 signing key and writes them into the config, which is what makes receipts live. The recorder is **evidence, never enforcement** — a recorder failure never blocks traffic.
+
 ## What Gets Recorded
 
 The recorder captures two categories of evidence:
@@ -30,8 +32,8 @@ flight_recorder:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `enabled` | false | Master switch. Off by default. |
-| `dir` | (required) | Directory for evidence files. Created if absent. |
+| `enabled` | true | Master switch. **On by default.** Recording requires `dir` and a signing key too — `enabled: true` with no `dir` is inert (nothing is written), not an error. Set `enabled: false` to opt out. |
+| `dir` | (empty) | Directory for evidence files. The recorder stays inert until this is set; created if absent. `pipelock init` generates one. |
 | `checkpoint_interval` | 1000 | How many entries between signed checkpoints. |
 | `retention_days` | 0 | Auto-expire files after N days. 0 = never expire. |
 | `redact` | true | DLP scan each entry before writing. Replaces matched content with a redaction marker. |
@@ -42,6 +44,22 @@ flight_recorder:
 
 The receipt-signing private key is loaded from
 `flight_recorder.signing_key_path`.
+
+### Default-on footguns (handled)
+
+Because the recorder is on by default, two footguns are bounded by the defaults — keep them in mind if you change them:
+
+- **Disk growth.** Evidence files rotate at `max_entries_per_file` (default 10000) and can auto-expire with `retention_days`. Leave rotation on so a busy proxy cannot silently fill the disk; set `retention_days` for a hard cap.
+- **Privacy.** Receipts record the *targets* of mediated traffic. `redact` (default `true`) DLP-scrubs each entry before it touches disk so secrets are not persisted in the clear. Do not disable it unless you have a separate control around the evidence directory.
+
+### Completeness anchor (transcript root)
+
+On a **clean shutdown** the recorder seals the chain with a `transcript_root` entry: a single record naming the final sequence number and the chain's root hash. This is the completeness anchor — `verify-receipt --chain` can confirm the chain reached the sealed root rather than reporting a chain that was silently truncated at the tail as VALID.
+
+Scope and limits:
+
+- **Clean exit only.** The root is written during graceful shutdown, after in-flight receipt emits have drained (drain-then-seal). A `SIGKILL` (or power loss) terminates the process before the seal runs, so the tail is truncated with no root. Detecting that case requires an external/periodic anchor and is not closed here.
+- **Restart resumes cleanly.** A transcript root is a per-run checkpoint, not a permanent seal. The next start resumes emission into the same hash-linked chain (a continuous chain still verifies), so receipts are never silently bricked by a prior clean shutdown.
 
 ### Key-free evidence capture (`--capture-output`)
 

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -492,6 +492,16 @@ func NewServer(opts ServerOpts) (*Server, error) {
 		}
 
 		_, _ = fmt.Fprintf(opts.Stderr, "  Recorder: %s (flight recorder enabled)\n", cfg.FlightRecorder.Dir)
+	} else if cfg.FlightRecorder.Enabled {
+		// Flight recorder is on by default, but no dir is configured, so no
+		// recorder is built and no receipts are written. Surface this once so an
+		// operator who expects "verify the boundary" out of the box knows why the
+		// evidence directory is empty. `pipelock init` generates a dir + signing
+		// key and writes them into the config; setting flight_recorder.dir (and a
+		// signing_key_path) makes receipts live.
+		_, _ = fmt.Fprintf(opts.Stderr,
+			"  Recorder: enabled but inert - no flight_recorder.dir configured; "+
+				"no receipts will be written. Run 'pipelock init' or set flight_recorder.dir + signing_key_path.\n")
 	}
 	if err := s.initConductorProducer(cfg, m, recPrivKey, opts.Stderr); err != nil {
 		s.cleanup()

--- a/internal/cli/runtime/server_emitters.go
+++ b/internal/cli/runtime/server_emitters.go
@@ -6,11 +6,18 @@ package runtime
 import (
 	"context"
 
+	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
+
+// transcriptRootSessionID labels the shutdown transcript root. It matches the
+// flight recorder's single pinned session ("proxy"). Per-run/session binding of
+// the signed receipt set is tracked separately (run-nonce work) and intentionally
+// out of scope here.
+const transcriptRootSessionID = "proxy"
 
 type liveFileSentryScanner struct {
 	load func() *scanner.Scanner
@@ -34,6 +41,35 @@ func (s *Server) liveReceiptEmitter() *receipt.Emitter {
 		return s.proxy.ReceiptEmitterPtr().Load()
 	}
 	return s.receiptEmitter
+}
+
+// sealTranscriptRoot writes the transcript root for the live receipt chain at
+// graceful shutdown, anchoring the receipts emitted this run so a chain truncated
+// by a CLEAN exit becomes detectable: verify can see the sealed root instead of
+// reporting a silently-shortened chain as VALID. EmitTranscriptRoot has no other
+// production caller, so without this the completeness anchor never fires.
+//
+// Drain-then-seal contract: call this ONLY after every receipt-emitting listener
+// has drained. Once the root is written the chain is sealed and a racing Emit
+// returns ErrChainSealed; sealing after the listener WaitGroup join means no Emit
+// races the seal. Uses the LIVE emitter (hot reload swaps it) so the seal lands
+// on the emitter holding the current chain state.
+//
+// Best-effort and nil-safe at every layer (no recorder/key -> nil emitter -> the
+// EmitTranscriptRoot no-op; no receipts emitted -> no-op). A seal failure is
+// logged, never fatal: receipts are evidence, not enforcement. This closes ONLY
+// the clean-exit case - a SIGKILL still truncates the tail with no root, which
+// needs an external/periodic anchor (separate, deferred work).
+func (s *Server) sealTranscriptRoot() {
+	e := s.liveReceiptEmitter()
+	if e == nil {
+		return
+	}
+	if err := e.EmitTranscriptRoot(transcriptRootSessionID); err != nil {
+		if s.logger != nil {
+			s.logger.LogError(audit.NewResourceLogContext("SHUTDOWN", "transcript_root"), err)
+		}
+	}
 }
 
 func (s *Server) liveV2ReceiptEmitter() *proxydecision.Emitter {

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -166,6 +166,17 @@ func (s *Server) Start(ctx context.Context) error {
 			}
 		}()
 
+		// Block until the config file watch is established before continuing to
+		// bind and serve. Without this, the proxy can report healthy while the
+		// watch is not yet active, and a config edit made in that window is
+		// silently missed until the next write. Ready() also closes if the
+		// reloader exits without establishing the watch, so this never deadlocks
+		// on a watcher-setup failure (the error is logged above).
+		select {
+		case <-reloader.Ready():
+		case <-ctx.Done():
+		}
+
 		reloadWG.Add(1)
 		go func() {
 			defer reloadWG.Done()

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -128,6 +128,14 @@ func (s *Server) Start(ctx context.Context) error {
 		cancel()
 		s.proxy.ShutdownAgentServers()
 		lifecycleWG.Wait()
+		// Drain-then-seal: the main proxy server (s.proxy.Start below) has
+		// already returned and every auxiliary receipt-emitting listener has now
+		// joined lifecycleWG, so no Emit can race the seal. Write the transcript
+		// root here, before the deferred s.cleanup() (registered earlier, so it
+		// runs after this) closes the recorder. Sealing the completeness anchor
+		// on clean exit is the whole point of F4; it is a no-op when receipts are
+		// off or none were emitted.
+		s.sealTranscriptRoot()
 	}()
 
 	// Capture duration timer: cancel context after the specified capture

--- a/internal/cli/runtime/server_transcript_root_test.go
+++ b/internal/cli/runtime/server_transcript_root_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// evidenceDirContains reports whether any evidence file in dir contains the
+// given substring. Used to assert a transcript_root entry was written without
+// coupling the test to the recorder's on-disk entry schema.
+func evidenceDirContains(t *testing.T, dir, substr string) bool {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read evidence dir: %v", err)
+	}
+	for _, de := range entries {
+		if de.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Clean(filepath.Join(dir, de.Name())))
+		if err != nil {
+			t.Fatalf("read evidence file %s: %v", de.Name(), err)
+		}
+		if strings.Contains(string(data), substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestServer_SealTranscriptRoot_NoRecorderIsNoOp proves the seal is a safe no-op
+// when no recorder/emitter is wired (the on-by-default-but-inert case: enabled
+// with no dir). Shutdown must not panic or error when there is nothing to seal.
+func TestServer_SealTranscriptRoot_NoRecorderIsNoOp(t *testing.T) {
+	// Default config has flight_recorder enabled but no dir, so no emitter is
+	// built and liveReceiptEmitter() returns nil.
+	s, _ := newTestServer(t, func(o *ServerOpts) {
+		o.Listen = serverTestEphemeralListen
+		o.ListenChanged = true
+	})
+	if e := s.liveReceiptEmitter(); e != nil {
+		t.Fatalf("expected nil live emitter with no recorder dir, got %v", e)
+	}
+	// Must not panic.
+	s.sealTranscriptRoot()
+}
+
+// TestServer_GracefulShutdownSealsTranscriptRoot proves F4: a clean shutdown
+// wires EmitTranscriptRoot, sealing the receipt chain with a transcript_root
+// (the completeness anchor). Without this, a chain truncated by a clean exit
+// verifies as VALID with no signal that the tail is missing.
+//
+// Scope note (clean-exit-only): this covers the graceful path. A SIGKILL kills
+// the process before any deferred seal runs, so the tail is truncated with no
+// root - that case needs an external/periodic anchor and is intentionally not
+// closed here (and is not testable in-process, since killing the test process
+// would take the test with it).
+func TestServer_GracefulShutdownSealsTranscriptRoot(t *testing.T) {
+	recorderDir := t.TempDir()
+	keyPath := filepath.Join(t.TempDir(), "flight-recorder.key")
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate signing key: %v", err)
+	}
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("save signing key: %v", err)
+	}
+
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"flight_recorder:",
+		"  enabled: true",
+		"  dir: " + strconv.Quote(recorderDir),
+		"  signing_key_path: " + strconv.Quote(keyPath),
+		"",
+	}, "\n"))
+
+	s, buf := newTestServer(t, func(o *ServerOpts) {
+		o.ConfigFile = cfgPath
+		o.Listen = serverTestEphemeralListen
+		o.ListenChanged = true
+	})
+
+	errCh := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { errCh <- s.Start(ctx) }()
+
+	waitForServerCancel(t, s)
+	waitForServerOutput(t, buf, "flight recorder enabled")
+
+	// Seed at least one receipt so the transcript root is non-trivial
+	// (EmitTranscriptRoot is a no-op on an empty chain). Use the LIVE emitter -
+	// the same instance the proxy decision paths emit through.
+	e := s.liveReceiptEmitter()
+	if e == nil {
+		t.Fatal("live receipt emitter is nil; recorder did not wire a signed emitter")
+	}
+	if err := e.Emit(receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: "forward",
+		Method:    http.MethodGet,
+		Target:    "https://example.com/",
+	}); err != nil {
+		t.Fatalf("seed Emit: %v", err)
+	}
+
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	select {
+	case startErr := <-errCh:
+		if startErr != nil {
+			t.Fatalf("Start returned error after Shutdown: %v", startErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return within 5s of Shutdown")
+	}
+
+	if !evidenceDirContains(t, recorderDir, "transcript_root") {
+		t.Fatalf("graceful shutdown did not seal a transcript_root in %s", recorderDir)
+	}
+}

--- a/internal/cli/runtime/server_transcript_root_test.go
+++ b/internal/cli/runtime/server_transcript_root_test.go
@@ -59,6 +59,57 @@ func TestServer_SealTranscriptRoot_NoRecorderIsNoOp(t *testing.T) {
 	s.sealTranscriptRoot()
 }
 
+// TestServer_SealTranscriptRoot_SecondSealLogsError covers the error branch of
+// sealTranscriptRoot: once the chain is sealed, a second seal returns
+// ErrRootAlreadyEmitted, which must be logged (best-effort) rather than panic or
+// propagate. Uses the live emitter directly (no full shutdown needed).
+func TestServer_SealTranscriptRoot_SecondSealLogsError(t *testing.T) {
+	recorderDir := t.TempDir()
+	keyPath := filepath.Join(t.TempDir(), "flight-recorder.key")
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate signing key: %v", err)
+	}
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("save signing key: %v", err)
+	}
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"flight_recorder:",
+		"  enabled: true",
+		"  dir: " + strconv.Quote(recorderDir),
+		"  signing_key_path: " + strconv.Quote(keyPath),
+		"",
+	}, "\n"))
+
+	s, _ := newTestServer(t, func(o *ServerOpts) {
+		o.ConfigFile = cfgPath
+		o.Listen = serverTestEphemeralListen
+		o.ListenChanged = true
+	})
+
+	e := s.liveReceiptEmitter()
+	if e == nil {
+		t.Fatal("live receipt emitter is nil; recorder did not wire a signed emitter")
+	}
+	if err := e.Emit(receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: "forward",
+		Method:    http.MethodGet,
+		Target:    "https://example.com/",
+	}); err != nil {
+		t.Fatalf("seed Emit: %v", err)
+	}
+
+	s.sealTranscriptRoot() // first seal succeeds
+	s.sealTranscriptRoot() // second seal: ErrRootAlreadyEmitted -> logged, not fatal
+
+	if !evidenceDirContains(t, recorderDir, "transcript_root") {
+		t.Fatal("first seal did not write a transcript_root")
+	}
+}
+
 // TestServer_GracefulShutdownSealsTranscriptRoot proves F4: a clean shutdown
 // wires EmitTranscriptRoot, sealing the receipt chain with a transcript_root
 // (the completeness anchor). Without this, a chain truncated by a clean exit

--- a/internal/cli/setup/init.go
+++ b/internal/cli/setup/init.go
@@ -6,6 +6,7 @@ package setup
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -19,6 +20,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/discover"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 // Exit codes for init command.
@@ -202,6 +204,16 @@ func runInit(cmd *cobra.Command, opts initOptions) error {
 		configPath = filepath.Join(cfgDir, defaultConfigSubdir, "pipelock.yaml")
 	}
 
+	// Wire the flight recorder to disk so receipts ("verify the boundary") are
+	// live out of the box: a recorder directory and an Ed25519 signing key beside
+	// the config. Absolute paths so the generated config records regardless of
+	// the proxy's working directory (Load does not resolve flight_recorder paths
+	// relative to the config file). The key file is generated only on an actual
+	// write (below), never on --dry-run.
+	recorderDir, signingKeyPath := flightRecorderInitPaths(configPath)
+	cfg.FlightRecorder.Dir = recorderDir
+	cfg.FlightRecorder.SigningKeyPath = signingKeyPath
+
 	result.Setup = &initSetupResult{
 		ConfigPath: configPath,
 		Preset:     opts.preset,
@@ -224,6 +236,9 @@ func runInit(cmd *cobra.Command, opts initOptions) error {
 			result.Setup.Written = false
 			result.Setup.SkippedExsting = true
 		} else {
+			if err := ensureFlightRecorderSigningKey(signingKeyPath, recorderDir); err != nil {
+				return cliutil.ExitCodeError(initExitError, fmt.Errorf("provisioning flight recorder: %w", err))
+			}
 			if err := writeConfig(cfg, configPath, opts.preset); err != nil {
 				return cliutil.ExitCodeError(initExitError, fmt.Errorf("writing config: %w", err))
 			}
@@ -387,6 +402,48 @@ func writeConfig(cfg *config.Config, configPath, preset string) error {
 		return fmt.Errorf("writing %s: %w", configPath, err)
 	}
 
+	return nil
+}
+
+// flightRecorderInitPaths returns the recorder directory and signing-key path
+// that `pipelock init` provisions next to the generated config. Both are
+// absolute so the generated config records regardless of the proxy's working
+// directory. Mirrors the layout used by `pipelock contain` (recorder dir +
+// keys/ subdir) for consistency across setup paths.
+func flightRecorderInitPaths(configPath string) (dir, keyPath string) {
+	configDir := filepath.Dir(configPath)
+	if abs, err := filepath.Abs(configDir); err == nil {
+		configDir = abs
+	}
+	return filepath.Join(configDir, "recorder"),
+		filepath.Join(configDir, "keys", "flight-recorder-signing.key")
+}
+
+// ensureFlightRecorderSigningKey creates the recorder directory and an Ed25519
+// signing key used to sign decision receipts. An existing key is reused, never
+// overwritten: the signing key anchors the receipt chain, so clobbering it would
+// orphan any receipts already on disk under the old key (they fail to resume and
+// emission bricks). Directories use 0o750 and the key file 0o600 (via
+// signing.SavePrivateKey) so the agent side cannot read pipelock's signing key.
+func ensureFlightRecorderSigningKey(keyPath, recorderDir string) error {
+	if err := os.MkdirAll(recorderDir, 0o750); err != nil {
+		return fmt.Errorf("creating recorder directory %s: %w", recorderDir, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o750); err != nil {
+		return fmt.Errorf("creating signing key directory: %w", err)
+	}
+	if _, err := os.Stat(keyPath); err == nil {
+		return nil // reuse existing key; never orphan the prior receipt chain
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("checking signing key %s: %w", keyPath, err)
+	}
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		return fmt.Errorf("generating signing key: %w", err)
+	}
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		return fmt.Errorf("writing signing key %s: %w", keyPath, err)
+	}
 	return nil
 }
 

--- a/internal/cli/setup/init.go
+++ b/internal/cli/setup/init.go
@@ -434,15 +434,22 @@ func ensureFlightRecorderSigningKey(keyPath, recorderDir string) error {
 	}
 	switch _, statErr := os.Stat(keyPath); {
 	case statErr == nil:
-		// A key already exists. Reuse it ONLY if it is a loadable Ed25519 key:
-		// reusing preserves any receipt chain already signed under it, which is
-		// why we never blindly regenerate. But a file that does not parse as a
-		// key (zero-byte, truncated, wrong material) signed no valid chain, so
-		// regenerate over it rather than leaving init pointing at an unusable
-		// key that the recorder would only fail to load later at startup.
-		if _, loadErr := signing.LoadPrivateKeyFile(keyPath); loadErr == nil {
-			return nil
+		// A key already exists. Distinguish two failure modes so we never clobber
+		// a still-valid key (which would orphan its receipt chain):
+		//   - cannot READ the file (permission drift, I/O, symlink/read failure):
+		//     abort. The bytes may be a perfectly good key we just can't read.
+		//   - readable but the bytes do not PARSE as a key (zero-byte, truncated,
+		//     wrong material): that file signed no valid chain, so regenerate
+		//     over it rather than leaving init pointing at an unusable key the
+		//     recorder would only fail to load later.
+		data, readErr := os.ReadFile(filepath.Clean(keyPath))
+		if readErr != nil {
+			return fmt.Errorf("reading existing signing key %s: %w", keyPath, readErr)
 		}
+		if _, decodeErr := signing.DecodePrivateKey(string(data)); decodeErr == nil {
+			return nil // valid key on disk: reuse, never orphan its receipt chain
+		}
+		// fall through: corrupt/unparseable key material -> regenerate.
 	case !errors.Is(statErr, os.ErrNotExist):
 		return fmt.Errorf("checking signing key %s: %w", keyPath, statErr)
 	}

--- a/internal/cli/setup/init.go
+++ b/internal/cli/setup/init.go
@@ -432,10 +432,19 @@ func ensureFlightRecorderSigningKey(keyPath, recorderDir string) error {
 	if err := os.MkdirAll(filepath.Dir(keyPath), 0o750); err != nil {
 		return fmt.Errorf("creating signing key directory: %w", err)
 	}
-	if _, err := os.Stat(keyPath); err == nil {
-		return nil // reuse existing key; never orphan the prior receipt chain
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("checking signing key %s: %w", keyPath, err)
+	switch _, statErr := os.Stat(keyPath); {
+	case statErr == nil:
+		// A key already exists. Reuse it ONLY if it is a loadable Ed25519 key:
+		// reusing preserves any receipt chain already signed under it, which is
+		// why we never blindly regenerate. But a file that does not parse as a
+		// key (zero-byte, truncated, wrong material) signed no valid chain, so
+		// regenerate over it rather than leaving init pointing at an unusable
+		// key that the recorder would only fail to load later at startup.
+		if _, loadErr := signing.LoadPrivateKeyFile(keyPath); loadErr == nil {
+			return nil
+		}
+	case !errors.Is(statErr, os.ErrNotExist):
+		return fmt.Errorf("checking signing key %s: %w", keyPath, statErr)
 	}
 	_, priv, err := signing.GenerateKeyPair()
 	if err != nil {

--- a/internal/cli/setup/init_test.go
+++ b/internal/cli/setup/init_test.go
@@ -122,6 +122,53 @@ func TestEnsureFlightRecorderSigningKey_RegeneratesUnloadable(t *testing.T) {
 	}
 }
 
+// TestEnsureFlightRecorderSigningKey_ErrorPaths covers the abort branches that
+// guard against clobbering or misprovisioning, using deterministic filesystem
+// shapes (no permission tricks, so they behave the same under root and non-root
+// CI): a directory component that is actually a regular file makes MkdirAll
+// fail, and an existing key path that is a directory makes the read abort.
+func TestEnsureFlightRecorderSigningKey_ErrorPaths(t *testing.T) {
+	t.Run("recorder_dir_parent_is_file", func(t *testing.T) {
+		base := t.TempDir()
+		blocker := filepath.Join(base, "blocker")
+		if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		// recorderDir nested under a regular file -> first MkdirAll fails.
+		err := ensureFlightRecorderSigningKey(filepath.Join(base, "k", "key"), filepath.Join(blocker, "recorder"))
+		if err == nil {
+			t.Fatal("expected error when the recorder dir is nested under a regular file")
+		}
+	})
+	t.Run("key_dir_parent_is_file", func(t *testing.T) {
+		base := t.TempDir()
+		blocker := filepath.Join(base, "blocker")
+		if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		// recorderDir is fine, but the key dir is nested under a regular file ->
+		// the second MkdirAll fails.
+		err := ensureFlightRecorderSigningKey(filepath.Join(blocker, "keys", "key"), filepath.Join(base, "recorder"))
+		if err == nil {
+			t.Fatal("expected error when the key dir is nested under a regular file")
+		}
+	})
+	t.Run("existing_unreadable_key_aborts_without_clobber", func(t *testing.T) {
+		base := t.TempDir()
+		keyPath := filepath.Join(base, "keys", "key")
+		// Make the key path itself a directory: it exists (Stat succeeds) but is
+		// unreadable as a file (ReadFile returns EISDIR), so we must abort rather
+		// than regenerate over something we cannot read.
+		if err := os.MkdirAll(keyPath, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		err := ensureFlightRecorderSigningKey(keyPath, filepath.Join(base, "recorder"))
+		if err == nil {
+			t.Fatal("expected abort when the existing key path is unreadable (a directory)")
+		}
+	})
+}
+
 // TestInitCmd_DryRunProvisionsNoKey proves --dry-run never writes a signing key
 // (no side effects on disk) even though the previewed config names one.
 func TestInitCmd_DryRunProvisionsNoKey(t *testing.T) {

--- a/internal/cli/setup/init_test.go
+++ b/internal/cli/setup/init_test.go
@@ -12,7 +12,117 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/discover"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
+
+// TestInitCmd_ProvisionsFlightRecorder proves done-state #1: a stock `pipelock
+// init` writes a config with the flight recorder live (enabled + dir + signing
+// key), so receipts work out of the box. Validation runs (not skipped) to prove
+// the generated config is valid with the recorder on.
+func TestInitCmd_ProvisionsFlightRecorder(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, "cfg", "pipelock.yaml")
+
+	var buf bytes.Buffer
+	cmd := InitCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--scan-home", home,
+		"--output", configPath,
+		"--skip-canary",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v\noutput:\n%s", err, buf.String())
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("loading generated config: %v", err)
+	}
+	if !cfg.FlightRecorder.Enabled {
+		t.Error("generated config has flight_recorder.enabled = false, want true")
+	}
+	if cfg.FlightRecorder.Dir == "" {
+		t.Error("generated config has empty flight_recorder.dir; receipts would be inert")
+	}
+	if !filepath.IsAbs(cfg.FlightRecorder.Dir) {
+		t.Errorf("flight_recorder.dir = %q, want an absolute path", cfg.FlightRecorder.Dir)
+	}
+	if cfg.FlightRecorder.SigningKeyPath == "" {
+		t.Fatal("generated config has empty flight_recorder.signing_key_path; receipts cannot be signed")
+	}
+	if !cfg.FlightRecorder.Redact {
+		t.Error("generated config has flight_recorder.redact = false; receipts would persist targets in the clear")
+	}
+
+	// The signing key must exist on disk and load as a usable Ed25519 key.
+	if _, err := os.Stat(cfg.FlightRecorder.SigningKeyPath); err != nil {
+		t.Fatalf("signing key not on disk: %v", err)
+	}
+	if _, err := signing.LoadPrivateKeyFile(cfg.FlightRecorder.SigningKeyPath); err != nil {
+		t.Fatalf("generated signing key does not load: %v", err)
+	}
+
+	// The recorder directory must exist (created during provisioning).
+	if info, err := os.Stat(cfg.FlightRecorder.Dir); err != nil || !info.IsDir() {
+		t.Fatalf("recorder dir not provisioned: err=%v", err)
+	}
+}
+
+// TestEnsureFlightRecorderSigningKey_ReusesExisting proves an existing signing
+// key is never regenerated. Clobbering it would orphan any receipts already
+// signed under the old key (they fail to resume and emission bricks), so a
+// second provisioning pass (e.g. `pipelock init --force`) must keep the key.
+func TestEnsureFlightRecorderSigningKey_ReusesExisting(t *testing.T) {
+	base := t.TempDir()
+	keyPath := filepath.Join(base, "keys", "flight-recorder-signing.key")
+	recorderDir := filepath.Join(base, "recorder")
+
+	if err := ensureFlightRecorderSigningKey(keyPath, recorderDir); err != nil {
+		t.Fatalf("first provision: %v", err)
+	}
+	first, err := os.ReadFile(filepath.Clean(keyPath))
+	if err != nil {
+		t.Fatalf("reading first key: %v", err)
+	}
+	if err := ensureFlightRecorderSigningKey(keyPath, recorderDir); err != nil {
+		t.Fatalf("second provision: %v", err)
+	}
+	second, err := os.ReadFile(filepath.Clean(keyPath))
+	if err != nil {
+		t.Fatalf("reading second key: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Error("signing key was regenerated on the second pass; it must be reused to avoid orphaning the receipt chain")
+	}
+}
+
+// TestInitCmd_DryRunProvisionsNoKey proves --dry-run never writes a signing key
+// (no side effects on disk) even though the previewed config names one.
+func TestInitCmd_DryRunProvisionsNoKey(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, "cfg", "pipelock.yaml")
+
+	var buf bytes.Buffer
+	cmd := InitCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--scan-home", home,
+		"--output", configPath,
+		"--dry-run",
+		"--skip-canary",
+		"--skip-validate",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init --dry-run failed: %v", err)
+	}
+	_, keyPath := flightRecorderInitPaths(configPath)
+	if _, err := os.Stat(keyPath); err == nil {
+		t.Errorf("dry-run wrote a signing key at %s; it must not touch disk", keyPath)
+	}
+}
 
 func TestInitCmd_DryRun(t *testing.T) {
 	home := t.TempDir()

--- a/internal/cli/setup/init_test.go
+++ b/internal/cli/setup/init_test.go
@@ -98,6 +98,30 @@ func TestEnsureFlightRecorderSigningKey_ReusesExisting(t *testing.T) {
 	}
 }
 
+// TestEnsureFlightRecorderSigningKey_RegeneratesUnloadable proves a junk key
+// file (zero-byte / corrupt) is replaced with a valid one rather than reused.
+// Such a file signed no valid chain, so regenerating is safe and keeps init from
+// emitting a config that points at a key the recorder would fail to load.
+func TestEnsureFlightRecorderSigningKey_RegeneratesUnloadable(t *testing.T) {
+	base := t.TempDir()
+	keyPath := filepath.Join(base, "keys", "flight-recorder-signing.key")
+	recorderDir := filepath.Join(base, "recorder")
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Pre-seed a corrupt (non-key) file.
+	if err := os.WriteFile(keyPath, []byte("not a key"), 0o600); err != nil {
+		t.Fatalf("seed junk key: %v", err)
+	}
+
+	if err := ensureFlightRecorderSigningKey(keyPath, recorderDir); err != nil {
+		t.Fatalf("provision over junk key: %v", err)
+	}
+	if _, err := signing.LoadPrivateKeyFile(keyPath); err != nil {
+		t.Errorf("key was not regenerated to a loadable Ed25519 key: %v", err)
+	}
+}
+
 // TestInitCmd_DryRunProvisionsNoKey proves --dry-run never writes a signing key
 // (no side effects on disk) even though the previewed config names one.
 func TestInitCmd_DryRunProvisionsNoKey(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2149,6 +2149,41 @@ func TestLoad_PresetYAMLFiles(t *testing.T) {
 	}
 }
 
+// TestLoad_PresetsEnableFlightRecorder proves every shipped preset carries the
+// flight_recorder block consistent with the on-by-default invariant: the section
+// is present, parses, and resolves enabled=true. Presets cannot carry a
+// machine-specific dir/signing_key_path, so they stay inert until `pipelock init`
+// (or the operator) fills those in - this only asserts the consistency contract.
+func TestLoad_PresetsEnableFlightRecorder(t *testing.T) {
+	presets := []string{
+		"../../configs/balanced.yaml",
+		"../../configs/strict.yaml",
+		"../../configs/audit.yaml",
+		"../../configs/claude-code.yaml",
+		"../../configs/cursor.yaml",
+		"../../configs/generic-agent.yaml",
+		"../../configs/hostile-model.yaml",
+	}
+	for _, path := range presets {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			abs, err := filepath.Abs(path)
+			if err != nil {
+				t.Fatalf("resolving %s: %v", path, err)
+			}
+			cfg, err := Load(abs)
+			if err != nil {
+				t.Fatalf("loading preset %s: %v", abs, err)
+			}
+			if !cfg.FlightRecorder.Enabled {
+				t.Errorf("%s: flight_recorder.enabled = false, want true (preset inconsistent with default)", filepath.Base(path))
+			}
+			if !cfg.FlightRecorder.Redact {
+				t.Errorf("%s: flight_recorder.redact = false, want true (receipts would persist targets in the clear)", filepath.Base(path))
+			}
+		})
+	}
+}
+
 func TestLoad_ExampleYAMLFiles(t *testing.T) {
 	examples := []string{
 		"../../examples/quickstart/pipelock.yaml",
@@ -9624,6 +9659,7 @@ func TestLoad_PreservesSecurityBooleanDefaults(t *testing.T) {
 		{"ScanAPI.Kinds.DLP", cfg.ScanAPI.Kinds.DLP},
 		{"ScanAPI.Kinds.PromptInjection", cfg.ScanAPI.Kinds.PromptInjection},
 		{"ScanAPI.Kinds.ToolCall", cfg.ScanAPI.Kinds.ToolCall},
+		{"FlightRecorder.Enabled", cfg.FlightRecorder.Enabled},
 		{"FlightRecorder.Redact", cfg.FlightRecorder.Redact},
 		{"FlightRecorder.SignCheckpoints", cfg.FlightRecorder.SignCheckpoints},
 		{"MCPToolProvenance.OfflineOnly", cfg.MCPToolProvenance.OfflineOnly},
@@ -9682,6 +9718,46 @@ func TestLoad_FlightRecorderFileMode(t *testing.T) {
 	}
 	if cfg.FlightRecorder.FileMode != 0o640 {
 		t.Errorf("FileMode = %04o, want 0640", cfg.FlightRecorder.FileMode)
+	}
+}
+
+// TestLoad_FlightRecorderEnabledStates documents the security-default invariant
+// for the on-by-default flight_recorder.enabled flag across its load-time states.
+// Reload reuses Load(), so the same resolution applies on hot reload; the
+// reload-with-change / reload-no-change states are exercised at the server layer
+// (see the runtime reload tests). A recorder is only BUILT when a dir is set, so
+// enabled=true with no dir resolves to true but records nothing (inert) - that
+// is asserted in the validation and server tests, not here.
+func TestLoad_FlightRecorderEnabledStates(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		section string // YAML under the flight_recorder key, or "" to omit it
+		want    bool
+	}{
+		{name: "omitted_whole_section", section: "", want: true},
+		{name: "key_null", section: "flight_recorder:\n  enabled:\n", want: true},
+		{name: "key_blank", section: "flight_recorder:\n  enabled: \n", want: true},
+		{name: "explicit_false", section: "flight_recorder:\n  enabled: false\n", want: false},
+		{name: "explicit_true", section: "flight_recorder:\n  enabled: true\n", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "fr-enabled.yaml")
+			content := "mode: balanced\n" + tt.section
+			if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(cfgPath)
+			if err != nil {
+				t.Fatalf("Load() error: %v", err)
+			}
+			if cfg.FlightRecorder.Enabled != tt.want {
+				t.Errorf("FlightRecorder.Enabled = %v, want %v", cfg.FlightRecorder.Enabled, tt.want)
+			}
+		})
 	}
 }
 
@@ -9889,6 +9965,7 @@ func TestLoad_PartialSubsectionPreservesBoolDefaults(t *testing.T) {
 		{"ScanAPI.Kinds.DLP", cfg.ScanAPI.Kinds.DLP},
 		{"ScanAPI.Kinds.PromptInjection", cfg.ScanAPI.Kinds.PromptInjection},
 		{"ScanAPI.Kinds.ToolCall", cfg.ScanAPI.Kinds.ToolCall},
+		{"FlightRecorder.Enabled", cfg.FlightRecorder.Enabled},
 		{"FlightRecorder.Redact", cfg.FlightRecorder.Redact},
 		{"FlightRecorder.SignCheckpoints", cfg.FlightRecorder.SignCheckpoints},
 		{"MCPToolProvenance.OfflineOnly", cfg.MCPToolProvenance.OfflineOnly},
@@ -9923,6 +10000,7 @@ func TestLoad_ExplicitFalseOverridesDefaults(t *testing.T) {
 		"  include_allowed: false\n" +
 		"  include_blocked: false\n" +
 		"flight_recorder:\n" +
+		"  enabled: false\n" +
 		"  redact: false\n" +
 		"  sign_checkpoints: false\n" +
 		"mcp_tool_provenance:\n" +
@@ -9954,6 +10032,7 @@ func TestLoad_ExplicitFalseOverridesDefaults(t *testing.T) {
 		{"GitProtection.PrePushScan", cfg.GitProtection.PrePushScan},
 		{"Logging.IncludeAllowed", cfg.Logging.IncludeAllowed},
 		{"Logging.IncludeBlocked", cfg.Logging.IncludeBlocked},
+		{"FlightRecorder.Enabled", cfg.FlightRecorder.Enabled},
 		{"FlightRecorder.Redact", cfg.FlightRecorder.Redact},
 		{"FlightRecorder.SignCheckpoints", cfg.FlightRecorder.SignCheckpoints},
 		{"MCPToolProvenance.OfflineOnly", cfg.MCPToolProvenance.OfflineOnly},
@@ -12779,14 +12858,16 @@ func TestValidate_FlightRecorder(t *testing.T) {
 			},
 		},
 		{
-			name: "enabled_without_dir",
+			// Enabled is on by default; without a dir the recorder is inert
+			// (no recorder built) rather than a validation error, so the
+			// default-on flip cannot break configs that omit a recorder dir.
+			name: "enabled_without_dir_is_inert_not_an_error",
 			cfg: func() *Config {
 				c := Defaults()
 				c.FlightRecorder.Enabled = true
 				c.FlightRecorder.Dir = ""
 				return c
 			},
-			wantErr: "flight_recorder.dir is required",
 		},
 		{
 			name: "negative_checkpoint_interval",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2170,6 +2170,22 @@ func TestLoad_PresetsEnableFlightRecorder(t *testing.T) {
 			if err != nil {
 				t.Fatalf("resolving %s: %v", path, err)
 			}
+			// Assert the block is actually IN the file. enabled defaults to true
+			// even when the section is omitted, so a post-Load() check alone would
+			// pass for a preset missing the block - read the raw YAML and require
+			// the top-level flight_recorder key (a comment mentioning it does not
+			// count, which is why this unmarshals rather than substring-matches).
+			raw, err := os.ReadFile(filepath.Clean(abs))
+			if err != nil {
+				t.Fatalf("reading preset %s: %v", abs, err)
+			}
+			var doc map[string]any
+			if err := yaml.Unmarshal(raw, &doc); err != nil {
+				t.Fatalf("unmarshaling preset %s: %v", abs, err)
+			}
+			if _, ok := doc["flight_recorder"]; !ok {
+				t.Fatalf("%s: missing top-level flight_recorder block", filepath.Base(path))
+			}
 			cfg, err := Load(abs)
 			if err != nil {
 				t.Fatalf("loading preset %s: %v", abs, err)

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -507,6 +507,17 @@ func Defaults() *Config {
 			Action: ActionWarn, // default action when hash verification fails
 		},
 		FlightRecorder: FlightRecorder{
+			// Enabled by default so receipts ("verify the boundary") are on out
+			// of the box. Emission still requires Dir != "" AND a signing key
+			// (see server.go), so the default flip alone records nothing: a bare
+			// Defaults() with no dir/key is inert. `pipelock init` generates both
+			// and writes them into the config, which is what makes receipts live.
+			// Footguns handled here: Redact stays on (receipts carry targets, so
+			// without scrubbing they would persist secrets in the clear) and
+			// MaxEntriesPerFile caps file growth (rotation), so default-on cannot
+			// silently fill the disk or leak. Evidence, not enforcement: a
+			// recorder failure never blocks traffic.
+			Enabled:            true,
 			CheckpointInterval: 1000,  // entries between signed checkpoints
 			Redact:             true,  // DLP-scrub evidence before commit
 			SignCheckpoints:    true,  // Ed25519 sign checkpoints

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -149,8 +149,14 @@ func applySecurityDefaults(rawYAML []byte, cfg *Config) {
 	}
 	setBoolDefault(sse, "enabled", &cfg.ResponseScanning.SSEStreaming.Enabled)
 
-	// Flight recorder: redact and sign default to true (fail-closed for forensics).
+	// Flight recorder: enabled, redact, and sign default to true. enabled is
+	// default-on so receipts are available out of the box (omitting the section
+	// must produce enabled=true, per the security-default invariant); redact and
+	// sign default true for fail-closed forensics. enabled=true with no dir is
+	// inert (no recorder is built), so the default cannot break configs that omit
+	// a recorder dir - validateFlightRecorder treats that case as a no-op.
 	fr, _ := raw["flight_recorder"].(map[string]interface{})
+	setBoolDefault(fr, "enabled", &cfg.FlightRecorder.Enabled)
 	setBoolDefault(fr, "redact", &cfg.FlightRecorder.Redact)
 	setBoolDefault(fr, "sign_checkpoints", &cfg.FlightRecorder.SignCheckpoints)
 

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -89,6 +89,7 @@ func applySecurityDefaults(rawYAML []byte, cfg *Config) {
 		cfg.Learn.Privacy.PublicAllowlistDefault = true
 		cfg.HealthWatchdog.Enabled = true
 		cfg.Conductor.HonorRemoteKillSwitch = true
+		cfg.FlightRecorder.Enabled = true
 		return
 	}
 

--- a/internal/config/reload.go
+++ b/internal/config/reload.go
@@ -45,6 +45,15 @@ func (r *Reloader) Changes() <-chan *Config {
 	return r.onChange
 }
 
+// Ready returns a channel closed once the file watch is established (or once
+// Start has exited without establishing it, so a waiter never deadlocks on a
+// watcher-setup failure). Callers that mutate the config after observing the
+// process as live should wait on this first: otherwise an edit made in the
+// window before the watch is active is silently missed until the next write.
+func (r *Reloader) Ready() <-chan struct{} {
+	return r.ready
+}
+
 // Start watches the config file and listens for reload signals (SIGHUP on Unix). It blocks until
 // ctx is cancelled or Close is called. When Start returns, the onChange
 // channel is closed. Reload failures are logged to stderr via tryReload;
@@ -59,6 +68,11 @@ func (r *Reloader) Start(ctx context.Context) error {
 	r.startMu.Unlock()
 
 	defer close(r.onChange)
+	// Guarantee Ready() resolves on every exit path. The success path closes it
+	// below once watcher.Add succeeds; this backstop closes it if Start returns
+	// first (e.g. watcher creation/Add failure) so a Ready() waiter cannot
+	// deadlock when the watch never came up. Idempotent via readyOnce.
+	defer r.readyOnce.Do(func() { close(r.ready) })
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {

--- a/internal/config/reload_test.go
+++ b/internal/config/reload_test.go
@@ -61,6 +61,31 @@ func renameUntilReload(t *testing.T, r *Reloader, dir, cfgPath, mode string) *Co
 	return waitForReload(t, r, mode)
 }
 
+// TestReloader_ReadyAccessorResolves locks the exported Ready() contract that
+// the server's startup uses to avoid serving before the config watch is live.
+func TestReloader_ReadyAccessorResolves(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	writeTestConfig(t, cfgPath, "balanced")
+
+	r := NewReloader(cfgPath)
+	defer r.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go func() {
+		if err := r.Start(ctx); err != nil {
+			t.Errorf("reloader error: %v", err)
+		}
+	}()
+
+	select {
+	case <-r.Ready():
+	case <-time.After(2 * time.Second):
+		t.Fatal("Ready() did not resolve after the watch was established")
+	}
+}
+
 func TestReloader_FileChange(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "pipelock.yaml")

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2293,7 +2293,14 @@ func (c *Config) validateFlightRecorder() error {
 		return nil
 	}
 	if c.FlightRecorder.Dir == "" {
-		return fmt.Errorf("flight_recorder.dir is required when enabled")
+		// Enabled is on by default, but a recorder is only built when a dir is
+		// configured (server.go gates on Dir != ""). Treat enabled-without-dir
+		// as an inert no-op rather than a hard error: making it fatal would
+		// break every config that omits flight_recorder.dir the moment the
+		// default flipped on, and the recorder is evidence, never enforcement.
+		// `pipelock init` populates dir + signing key; without them the server
+		// prints a one-time notice that receipts are inert.
+		return nil
 	}
 	if c.FlightRecorder.CheckpointInterval < 0 {
 		return fmt.Errorf("flight_recorder.checkpoint_interval must be non-negative")

--- a/internal/receipt/chain_test.go
+++ b/internal/receipt/chain_test.go
@@ -456,6 +456,87 @@ func TestEmitTranscriptRoot_NoReceipts(t *testing.T) {
 	}
 }
 
+// TestResume_AfterTranscriptRoot_DoesNotBrick is the FIX-TRAP B regression. Once
+// EmitTranscriptRoot has a production caller (graceful shutdown), a transcript
+// root lands as the newest evidence entry on clean exit. A resume that treated
+// the root as a permanent on-disk seal would set rootEmitted and make every Emit
+// after the first clean shutdown return ErrChainSealed - silently killing
+// receipts. This proves a restart after a sealed shutdown resumes emitting into
+// one continuous, verifiable chain.
+func TestResume_AfterTranscriptRoot_DoesNotBrick(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+
+	emit := func(e *Emitter) error {
+		return e.Emit(EmitOpts{
+			ActionID:  NewActionID(),
+			Target:    chainTestTarget,
+			Verdict:   config.ActionAllow,
+			Transport: chainTestTransport,
+			Method:    http.MethodGet,
+		})
+	}
+
+	// Run 1: emit 2 receipts, seal with a transcript root, shut down.
+	rec1 := newTestRecorder(t, dir, priv)
+	e1 := NewEmitter(EmitterConfig{Recorder: rec1, PrivKey: priv, ConfigHash: testConfigHash, Principal: testPrincipal, Actor: testActor})
+	for range 2 {
+		if err := emit(e1); err != nil {
+			t.Fatalf("run1 Emit: %v", err)
+		}
+	}
+	if err := e1.EmitTranscriptRoot(chainTestSession); err != nil {
+		t.Fatalf("EmitTranscriptRoot: %v", err)
+	}
+	if err := rec1.Close(); err != nil {
+		t.Fatalf("close rec1: %v", err)
+	}
+
+	// Run 2: restart against the SAME evidence dir (sealed tail on disk).
+	rec2 := newTestRecorder(t, dir, priv)
+	e2 := NewEmitter(EmitterConfig{Recorder: rec2, PrivKey: priv, ConfigHash: testConfigHash, Principal: testPrincipal, Actor: testActor})
+	if e2 == nil {
+		t.Fatal("emitter nil after resume")
+	}
+	if err := e2.InitError(); err != nil {
+		t.Fatalf("resume after sealed shutdown errored (should resume cleanly): %v", err)
+	}
+	// The post-seal restart MUST emit (not be bricked by ErrChainSealed).
+	for range 2 {
+		if err := emit(e2); err != nil {
+			t.Fatalf("post-seal restart Emit bricked: %v", err)
+		}
+	}
+	if err := rec2.Close(); err != nil {
+		t.Fatalf("close rec2: %v", err)
+	}
+
+	// All 4 action receipts (2 per run) form one continuous, verifiable chain.
+	entries := readAllEntriesFromDir(t, dir)
+	var receipts []Receipt
+	for i := range entries {
+		if entries[i].Type != recorderEntryType {
+			continue
+		}
+		r, err := receiptFromEntry(entries[i])
+		if err != nil {
+			t.Fatalf("parse receipt: %v", err)
+		}
+		receipts = append(receipts, *r)
+	}
+	if len(receipts) != 4 {
+		t.Fatalf("expected 4 action receipts across both runs, got %d", len(receipts))
+	}
+	res := VerifyChain(receipts, "")
+	if !res.Valid {
+		t.Fatalf("post-seal chain failed to verify: %s", res.Error)
+	}
+	if res.ReceiptCount != 4 {
+		t.Errorf("ReceiptCount = %d, want 4 (seq must continue across the seal, not reset)", res.ReceiptCount)
+	}
+}
+
 func TestEmitTranscriptRoot_HappyPath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -488,8 +488,19 @@ func (e *Emitter) resumeChain() error {
 		for j := len(entries) - 1; j >= 0; j-- {
 			switch entries[j].Type {
 			case transcriptRootEntryType:
-				e.rootEmitted = true
-				return nil
+				// A transcript root is a clean-shutdown checkpoint that seals the
+				// receipts emitted up to that point IN THIS PROCESS. It is not a
+				// permanent on-disk seal: skip it and keep scanning back for the
+				// last action receipt so the next start resumes emission into the
+				// same hash-linked chain (a continuous chain still verifies, and
+				// the root's historical claim over seq 0..N stays true). The old
+				// behavior set rootEmitted=true here, which made every subsequent
+				// Emit return ErrChainSealed - silently bricking receipts after
+				// the first clean shutdown once EmitTranscriptRoot has a caller.
+				// Skipping it is also evidence-suppression-resistant: an attacker
+				// who appends a transcript_root to the evidence file cannot use it
+				// to stop the proxy from recording (the tail action receipt is
+				// still signature-verified below before we trust its chain state).
 			case recorderEntryType:
 				rcpt, unmarshalErr := receiptFromEntry(entries[j])
 				if unmarshalErr != nil {


### PR DESCRIPTION
## Why

The product pitch is "verify the boundary," but two gaps undercut it on a stock install.

The flight recorder was off by default, so a fresh `pipelock init` produced no receipts (nothing to verify). And `EmitTranscriptRoot` (the chain completeness anchor) had zero production callers, so a receipt chain truncated by a clean shutdown verified as `VALID` with no signal that the tail was missing.

This makes the evidence real and complete by default.

## F2: receipts on by default

- `flight_recorder.enabled` now defaults to `true` (in `Defaults()` and the load-time presence path), so omitting the section yields `enabled=true` per the security-default invariant.
- Recording still requires a `dir` AND a signing key, so the flip alone is inert and cannot break existing configs. `validateFlightRecorder` treats `enabled` with no `dir` as a no-op (with a startup notice) rather than a hard error.
- `pipelock init` provisions a recorder directory plus an Ed25519 signing key and writes both into the generated config, so receipts are live out of the box. An existing key is reused, never regenerated, to avoid orphaning a prior receipt chain.
- All shipped presets carry a `flight_recorder` block consistent with the default.
- Footguns bounded by the defaults: file rotation (`max_entries_per_file`) caps disk growth, and `redact` stays on so receipt targets are scrubbed before they touch disk.

## F4: seal the transcript root on clean shutdown

- Graceful shutdown emits the transcript root after every receipt-emitting listener has drained (drain-then-seal), via the live emitter, before the recorder closes. Clean-exit only: a `SIGKILL` still truncates the tail with no root, which needs an external anchor (separate work).
- `resumeChain` treats an on-disk transcript root as a non-terminal checkpoint. The next start resumes emission into the same hash-linked, verifiable chain instead of re-sealing and silently bricking receipts after the first clean shutdown. This is also more resistant to evidence suppression: appending a root to the evidence file cannot stop the proxy from recording.

## Scope

Config, init, presets, emitter, and lifecycle only. No `internal/mcp`, `internal/cli/signing`, or `sdk/` changes. 6-state config parity for the `enabled` flag; docs updated for default-on, footguns, and the clean-exit-only scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flight recorder enabled by default (redacts secrets); init now provisions recorder directory and signing key, recording absolute paths.
  * Server reports when recorder is “enabled but inert”; startup waits for config-watch readiness before serving.

* **Bug Fixes**
  * Graceful shutdown writes a transcript-root completeness anchor; resume logic avoids being bricked by checkpoints.
  * Enabled-without-dir is inert (no error).

* **Documentation**
  * Guides updated for default-on/inert behavior, redaction, and integrity notes.

* **Tests**
  * Added tests for provisioning, key lifecycle, sealing, reload readiness, and resume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->