### PR TITLE
Fail closed when signed receipts are required

### DIFF
--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -551,14 +551,16 @@ taint:
   policy: permissive
 
 # ---- flight_recorder (tamper-evident decision receipts) ----
-# On by default so you can "verify the boundary." Receipts are evidence, never
-# enforcement: a recorder failure never blocks traffic. Recording goes LIVE only
-# once `dir` and `signing_key_path` are set (run `pipelock init`, which generates
-# both); without them the recorder is inert and nothing is written. `redact`
-# scrubs secrets from receipt targets before they touch disk -- keep it on, since
-# receipts carry the destinations of mediated traffic.
+# On by default so you can "verify the boundary." Receipt emission is best-effort
+# unless `require_receipts` is true, which blocks allow-path traffic when a receipt
+# cannot be emitted. Recording goes LIVE only once `dir` and `signing_key_path`
+# are set (run `pipelock init`, which generates both); without them the recorder
+# is inert and nothing is written. `redact` scrubs secrets from receipt targets
+# before they touch disk -- keep it on, since receipts carry the destinations of
+# mediated traffic.
 flight_recorder:
   enabled: true
+  require_receipts: false
   redact: true
   # dir: /var/lib/pipelock/recorder
   # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -622,14 +622,16 @@ airlock:
     drain_timeout_seconds: 30
 
 # ---- flight_recorder (tamper-evident decision receipts) ----
-# On by default so you can "verify the boundary." Receipts are evidence, never
-# enforcement: a recorder failure never blocks traffic. Recording goes LIVE only
-# once `dir` and `signing_key_path` are set (run `pipelock init`, which generates
-# both); without them the recorder is inert and nothing is written. `redact`
-# scrubs secrets from receipt targets before they touch disk -- keep it on, since
-# receipts carry the destinations of mediated traffic.
+# On by default so you can "verify the boundary." Receipt emission is best-effort
+# unless `require_receipts` is true, which blocks allow-path traffic when a receipt
+# cannot be emitted. Recording goes LIVE only once `dir` and `signing_key_path`
+# are set (run `pipelock init`, which generates both); without them the recorder
+# is inert and nothing is written. `redact` scrubs secrets from receipt targets
+# before they touch disk -- keep it on, since receipts carry the destinations of
+# mediated traffic.
 flight_recorder:
   enabled: true
+  require_receipts: false
   redact: true
   # dir: /var/lib/pipelock/recorder
   # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -588,14 +588,16 @@ airlock:
     drain_timeout_seconds: 30
 
 # ---- flight_recorder (tamper-evident decision receipts) ----
-# On by default so you can "verify the boundary." Receipts are evidence, never
-# enforcement: a recorder failure never blocks traffic. Recording goes LIVE only
-# once `dir` and `signing_key_path` are set (run `pipelock init`, which generates
-# both); without them the recorder is inert and nothing is written. `redact`
-# scrubs secrets from receipt targets before they touch disk -- keep it on, since
-# receipts carry the destinations of mediated traffic.
+# On by default so you can "verify the boundary." Receipt emission is best-effort
+# unless `require_receipts` is true, which blocks allow-path traffic when a receipt
+# cannot be emitted. Recording goes LIVE only once `dir` and `signing_key_path`
+# are set (run `pipelock init`, which generates both); without them the recorder
+# is inert and nothing is written. `redact` scrubs secrets from receipt targets
+# before they touch disk -- keep it on, since receipts carry the destinations of
+# mediated traffic.
 flight_recorder:
   enabled: true
+  require_receipts: false
   redact: true
   # dir: /var/lib/pipelock/recorder
   # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -589,14 +589,16 @@ airlock:
     drain_timeout_seconds: 30
 
 # ---- flight_recorder (tamper-evident decision receipts) ----
-# On by default so you can "verify the boundary." Receipts are evidence, never
-# enforcement: a recorder failure never blocks traffic. Recording goes LIVE only
-# once `dir` and `signing_key_path` are set (run `pipelock init`, which generates
-# both); without them the recorder is inert and nothing is written. `redact`
-# scrubs secrets from receipt targets before they touch disk -- keep it on, since
-# receipts carry the destinations of mediated traffic.
+# On by default so you can "verify the boundary." Receipt emission is best-effort
+# unless `require_receipts` is true, which blocks allow-path traffic when a receipt
+# cannot be emitted. Recording goes LIVE only once `dir` and `signing_key_path`
+# are set (run `pipelock init`, which generates both); without them the recorder
+# is inert and nothing is written. `redact` scrubs secrets from receipt targets
+# before they touch disk -- keep it on, since receipts carry the destinations of
+# mediated traffic.
 flight_recorder:
   enabled: true
+  require_receipts: false
   redact: true
   # dir: /var/lib/pipelock/recorder
   # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -585,14 +585,16 @@ airlock:
     drain_timeout_seconds: 30
 
 # ---- flight_recorder (tamper-evident decision receipts) ----
-# On by default so you can "verify the boundary." Receipts are evidence, never
-# enforcement: a recorder failure never blocks traffic. Recording goes LIVE only
-# once `dir` and `signing_key_path` are set (run `pipelock init`, which generates
-# both); without them the recorder is inert and nothing is written. `redact`
-# scrubs secrets from receipt targets before they touch disk -- keep it on, since
-# receipts carry the destinations of mediated traffic.
+# On by default so you can "verify the boundary." Receipt emission is best-effort
+# unless `require_receipts` is true, which blocks allow-path traffic when a receipt
+# cannot be emitted. Recording goes LIVE only once `dir` and `signing_key_path`
+# are set (run `pipelock init`, which generates both); without them the recorder
+# is inert and nothing is written. `redact` scrubs secrets from receipt targets
+# before they touch disk -- keep it on, since receipts carry the destinations of
+# mediated traffic.
 flight_recorder:
   enabled: true
+  require_receipts: false
   redact: true
   # dir: /var/lib/pipelock/recorder
   # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -617,14 +617,16 @@ media_policy:
   strip_video: true
 
 # ---- flight_recorder (tamper-evident decision receipts) ----
-# On by default so you can "verify the boundary." Receipts are evidence, never
-# enforcement: a recorder failure never blocks traffic. Recording goes LIVE only
-# once `dir` and `signing_key_path` are set (run `pipelock init`, which generates
-# both); without them the recorder is inert and nothing is written. `redact`
-# scrubs secrets from receipt targets before they touch disk -- keep it on, since
-# receipts carry the destinations of mediated traffic.
+# On by default so you can "verify the boundary." Receipt emission is best-effort
+# unless `require_receipts` is true, which blocks allow-path traffic when a receipt
+# cannot be emitted. Recording goes LIVE only once `dir` and `signing_key_path`
+# are set (run `pipelock init`, which generates both); without them the recorder
+# is inert and nothing is written. `redact` scrubs secrets from receipt targets
+# before they touch disk -- keep it on, since receipts carry the destinations of
+# mediated traffic.
 flight_recorder:
   enabled: true
+  require_receipts: false
   redact: true
   # dir: /var/lib/pipelock/recorder
   # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -622,14 +622,16 @@ taint:
   policy: strict
 
 # ---- flight_recorder (tamper-evident decision receipts) ----
-# On by default so you can "verify the boundary." Receipts are evidence, never
-# enforcement: a recorder failure never blocks traffic. Recording goes LIVE only
-# once `dir` and `signing_key_path` are set (run `pipelock init`, which generates
-# both); without them the recorder is inert and nothing is written. `redact`
-# scrubs secrets from receipt targets before they touch disk -- keep it on, since
-# receipts carry the destinations of mediated traffic.
+# On by default so you can "verify the boundary." Receipt emission is best-effort
+# unless `require_receipts` is true, which blocks allow-path traffic when a receipt
+# cannot be emitted. Recording goes LIVE only once `dir` and `signing_key_path`
+# are set (run `pipelock init`, which generates both); without them the recorder
+# is inert and nothing is written. `redact` scrubs secrets from receipt targets
+# before they touch disk -- keep it on, since receipts carry the destinations of
+# mediated traffic.
 flight_recorder:
   enabled: true
+  require_receipts: false
   redact: true
   # dir: /var/lib/pipelock/recorder
   # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2097,6 +2097,7 @@ flight_recorder:
   checkpoint_interval: 1000
   retention_days: 90
   redact: true
+  require_receipts: false
   sign_checkpoints: true
   signing_key_path: "/path/to/signing-key"
   max_entries_per_file: 10000
@@ -2111,6 +2112,7 @@ flight_recorder:
 | `checkpoint_interval` | `1000` | Entries between signed checkpoints |
 | `retention_days` | `0` | Auto-expire files after N days (0 = keep forever) |
 | `redact` | `true` | DLP-redact evidence content before writing. Receipt entries get field-level redaction (target/pattern scrubbed, signature preserved). |
+| `require_receipts` | `false` | Require allow-path receipt emission before forwarding traffic. When true, signing/recorder failures block with `receipt_emission_failed`; block-path receipts remain best-effort because the action is already denied. |
 | `sign_checkpoints` | `true` | Ed25519 sign checkpoint entries |
 | `signing_key_path` | (empty) | Ed25519 private key for signed action receipts. When set, every proxy decision produces a signed receipt. Without it, the flight recorder can still write non-receipt evidence entries. Generate a key with `pipelock keygen <name>`. Verify receipts with `pipelock verify-receipt <file>`. In `pipelock run`, changing the configured path requires restart; reload re-reads updated key bytes only when the same path stays configured. |
 | `max_entries_per_file` | `10000` | Rotate to a new file after this many entries |

--- a/docs/guides/block-reason-header.md
+++ b/docs/guides/block-reason-header.md
@@ -63,6 +63,7 @@ Pipelock's block reasons are grouped by layer. The values are stable strings; ag
 | `kill_switch_active` | The four-source kill switch is asserted (config, API, SIGUSR1, or sentinel file). |
 | `envelope_verify_failed` | Inbound mediation envelope verification failed. |
 | `outbound_envelope_failed` | Outbound envelope injection, refresh, or signing failed before forwarding. |
+| `receipt_emission_failed` | `flight_recorder.require_receipts` is enabled and the required allow-path receipt could not be emitted before forwarding. |
 | `redirect_scan_denied` | A followed redirect target was denied by the scanner pipeline. |
 | `authority_mismatch` | Operator authority for the requested action is missing or below threshold. |
 | `escalation_level` | Adaptive enforcement raised an escalation tier that blocks the requested action class. |

--- a/docs/guides/flight-recorder.md
+++ b/docs/guides/flight-recorder.md
@@ -2,7 +2,7 @@
 
 The flight recorder writes every enforcement decision pipelock makes to a hash-chained, tamper-evident evidence log. Each entry is cryptographically linked to the one before it, so any deletion or modification breaks the chain. Signed checkpoints let auditors verify the chain was intact at specific points in time without replaying every entry. The recorder is designed for post-incident investigation, compliance evidence, and forensic replay.
 
-**On by default.** `enabled` defaults to `true` so receipts are available out of the box ("verify the boundary"). It only *records* once a `dir` and a signing key are configured, though: without them the recorder is inert and writes nothing, so the default flip never breaks an existing config. `pipelock init` generates a recorder directory and an Ed25519 signing key and writes them into the config, which is what makes receipts live. The recorder is **evidence, never enforcement** — a recorder failure never blocks traffic.
+**On by default.** `enabled` defaults to `true` so receipts are available out of the box ("verify the boundary"). It only *records* once a `dir` and a signing key are configured, though: without them the recorder is inert and writes nothing, so the default flip never breaks an existing config. `pipelock init` generates a recorder directory and an Ed25519 signing key and writes them into the config, which is what makes receipts live. Receipt emission is best-effort by default; set `require_receipts: true` when allow-path receipt failures must fail closed before traffic is forwarded.
 
 ## What Gets Recorded
 
@@ -24,6 +24,7 @@ flight_recorder:
   checkpoint_interval: 1000      # entries between signed checkpoints
   retention_days: 90             # auto-expire files older than 90 days (0 = forever)
   redact: true                   # DLP redaction before commit (recommended)
+  require_receipts: false        # fail closed before forwarding when allow receipts cannot be emitted
   sign_checkpoints: true         # Ed25519 signed checkpoints
   max_entries_per_file: 10000    # rotate to a new file after this many entries
   raw_escrow: false              # encrypted raw sidecar (see below)
@@ -37,6 +38,7 @@ flight_recorder:
 | `checkpoint_interval` | 1000 | How many entries between signed checkpoints. |
 | `retention_days` | 0 | Auto-expire files after N days. 0 = never expire. |
 | `redact` | true | DLP scan each entry before writing. Replaces matched content with a redaction marker. |
+| `require_receipts` | false | Require receipt emission before allow-path traffic is forwarded. When true, missing or failed receipt emission blocks the action with `receipt_emission_failed`; block-path receipts remain best-effort because the action is already denied. |
 | `sign_checkpoints` | true | Sign each checkpoint with the agent's Ed25519 private key. |
 | `max_entries_per_file` | 10000 | Rotate to a new JSONL file after this many entries. |
 | `raw_escrow` | false | Write an encrypted sidecar with the unredacted detail for each entry. |
@@ -44,6 +46,34 @@ flight_recorder:
 
 The receipt-signing private key is loaded from
 `flight_recorder.signing_key_path`.
+
+### Fail-closed receipts (`require_receipts`)
+
+By default receipt emission is best-effort: if signing or the recorder fails,
+the decision is logged and traffic still flows (evidence, not enforcement). Set
+`require_receipts: true` to make an *allow-path* receipt a precondition for
+forwarding. When it is on, pipelock emits the allow receipt **before** the
+request leaves the proxy; if that emission fails it blocks with
+`receipt_emission_failed` instead of egressing. This is enforced on every
+egress transport — forward proxy, CONNECT, WebSocket, `/fetch`, MCP stdio, and
+MCP HTTP. Block-path receipts stay best-effort because the action is already
+denied.
+
+Two operational notes:
+
+- **It needs a live signed recorder.** `require_receipts` has nothing to emit
+  unless `enabled`, `dir`, and `signing_key_path` are all set. With no live
+  emitter every request would fail closed, so `pipelock run` and
+  `pipelock mcp proxy` **refuse to start** in that state rather than serve an
+  all-blocked proxy. `require_receipts` is hot-reloadable, but because the
+  recorder is built once at startup, enabling it via reload without a recorder
+  only logs a warning — restart with a recorder configured to actually use it.
+- **An allowed request that is later blocked carries two receipts.** The
+  pre-egress allow receipt attests the egress *decision*; if response scanning
+  then blocks the reply, a block receipt is emitted under the **same
+  `action_id`**. Under `require_receipts` you will therefore see an allow
+  followed by a block for one action — the request did egress, and the response
+  was blocked separately.
 
 ### Default-on footguns (handled)
 

--- a/docs/guides/receipt-transports.md
+++ b/docs/guides/receipt-transports.md
@@ -97,6 +97,6 @@ All receipts from a single proxy instance share a hash chain. The first receipt 
 
 Verify a single file with `pipelock verify-receipt evidence-proxy-0.jsonl`. Verify chain integrity across rotated or restarted evidence files with `pipelock verify-receipt --chain <evidence-dir>`.
 
-## Fail-Open on Emit
+## Emit Failure Behavior
 
-Receipt emission failures are logged but never fail the request. The receipt is evidence, not enforcement. If signing fails or the recorder is unavailable, the proxy decision still completes normally.
+Receipt emission failures are logged and do not fail requests by default. Set `flight_recorder.require_receipts: true` to require allow-path receipts before forwarding traffic; if signing fails or the recorder is unavailable, Pipelock blocks the action with `receipt_emission_failed` instead of sending it upstream. Block-path receipts remain best-effort because the underlying action has already been denied.

--- a/docs/guides/transport-modes.md
+++ b/docs/guides/transport-modes.md
@@ -230,7 +230,7 @@ Every block or allow decision produces a signed action receipt. The table below 
 | MCP HTTP / SSE | Input scan, tool scan, policy | Response injection, chain detection, session binding drift | Tool call, tool response, policy decision | Full content receipts, stream-aware |
 | MCP HTTP reverse proxy | Input scan, tool scan, policy | Response injection, chain detection, session binding drift | Tool call, tool response, policy decision | Full content receipts |
 
-All receipt emission is fire-and-forget on the async flight-recorder channel and survives config reload across all transports. Receipts chain via `chain_prev_hash` / `chain_seq` for tamper-evidence. See [`docs/guides/receipt-verification.md`](receipt-verification.md) for the verify CLI and the cross-implementation conformance suite.
+Receipt emission is best-effort by default on the async flight-recorder channel and survives config reload across all transports. Set `flight_recorder.require_receipts: true` to fail closed before allow-path proxy/MCP traffic is forwarded when the required receipt cannot be emitted; block-path receipts stay best-effort because the action is already denied. Receipts chain via `chain_prev_hash` / `chain_seq` for tamper-evidence. See [`docs/guides/receipt-verification.md`](receipt-verification.md) for the verify CLI and the cross-implementation conformance suite.
 
 ## See Also
 

--- a/docs/specs/block-reason-header.md
+++ b/docs/specs/block-reason-header.md
@@ -84,6 +84,7 @@ Reason codes are lowercase snake_case. The v1 set is derived from existing pipel
 | `kill_switch_active` | One of the four kill-switch sources is active. | `critical` | `transient` |
 | `envelope_verify_failed` | Inbound mediation envelope did not verify (signature / replay / trust). | `critical` | `none` |
 | `outbound_envelope_failed` | Outbound envelope injection / refresh / signing failed before the request left pipelock. Distinct from `envelope_verify_failed` so agents can tell inbound verification from outbound emission. | `critical` | `transient` |
+| `receipt_emission_failed` | `flight_recorder.require_receipts` is enabled and Pipelock could not emit the allow-path receipt before forwarding. The action is denied so there is no unreceipted upstream traffic. | `critical` | `transient` |
 | `redirect_scan_denied` | A followed redirect target was denied by the scanner pipeline (SSRF, blocklist, etc.). Distinct from the same scanner firing pre-redirect so clients can detect open-redirect probes. | `critical` | `none` |
 | `authority_mismatch` | Posture-capsule authority did not match the request's claimed authority. | `critical` | `policy` |
 | `escalation_level` | Per-session escalation level exceeded the configured ceiling. | `critical` | `transient` |

--- a/internal/blockreason/blockreason.go
+++ b/internal/blockreason/blockreason.go
@@ -90,6 +90,7 @@ const (
 	KillSwitchActive       Reason = "kill_switch_active"
 	EnvelopeVerifyFailed   Reason = "envelope_verify_failed"
 	OutboundEnvelopeFailed Reason = "outbound_envelope_failed"
+	ReceiptEmissionFailed  Reason = "receipt_emission_failed"
 	RedirectScanDenied     Reason = "redirect_scan_denied"
 	AuthorityMismatch      Reason = "authority_mismatch"
 	EscalationLevel        Reason = "escalation_level"
@@ -160,6 +161,7 @@ var validReasons = map[Reason]struct{}{
 	KillSwitchActive:       {},
 	EnvelopeVerifyFailed:   {},
 	OutboundEnvelopeFailed: {},
+	ReceiptEmissionFailed:  {},
 	RedirectScanDenied:     {},
 	AuthorityMismatch:      {},
 	EscalationLevel:        {},
@@ -561,6 +563,7 @@ func RetryFor(reason Reason) Retry {
 		Timeout,
 		PatternUnavailable,
 		OutboundEnvelopeFailed,
+		ReceiptEmissionFailed,
 		SessionAnomaly,
 		BlockReasonOverflow:
 		return RetryTransient

--- a/internal/blockreason/blockreason_test.go
+++ b/internal/blockreason/blockreason_test.go
@@ -531,6 +531,7 @@ var specCanonicalPairs = map[Reason]struct {
 	KillSwitchActive:       {SeverityCritical, RetryTransient},
 	EnvelopeVerifyFailed:   {SeverityCritical, RetryNone},
 	OutboundEnvelopeFailed: {SeverityCritical, RetryTransient},
+	ReceiptEmissionFailed:  {SeverityCritical, RetryTransient},
 	RedirectScanDenied:     {SeverityCritical, RetryNone},
 	AuthorityMismatch:      {SeverityCritical, RetryPolicy},
 	EscalationLevel:        {SeverityCritical, RetryTransient},

--- a/internal/blockreason/production_path_matrix_test.go
+++ b/internal/blockreason/production_path_matrix_test.go
@@ -182,6 +182,8 @@ func constNameForReason(r blockreason.Reason) string {
 		return "EnvelopeVerifyFailed"
 	case blockreason.OutboundEnvelopeFailed:
 		return "OutboundEnvelopeFailed"
+	case blockreason.ReceiptEmissionFailed:
+		return "ReceiptEmissionFailed"
 	case blockreason.RedirectScanDenied:
 		return "RedirectScanDenied"
 	case blockreason.AuthorityMismatch:

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -222,10 +222,12 @@ func mcpReceiptParityOpts(
 	receiptEmitter *receipt.Emitter,
 	v2ReceiptEmitter *proxydecision.Emitter,
 	policyHash string,
+	requireReceipts bool,
 ) mcp.MCPProxyOpts {
 	opts.ReceiptEmitter = receiptEmitter
 	opts.V2ReceiptEmitter = v2ReceiptEmitter
 	opts.PolicyHash = policyHash
+	opts.RequireReceipts = requireReceipts
 	return opts
 }
 
@@ -771,6 +773,15 @@ Key-free evidence capture:
 					cmd.PrintErrf("  Receipts: disabled — set flight_recorder.signing_key_path to enable signed action receipts\n")
 				}
 			}
+			// require_receipts escalates a missing receipt to a block. With no
+			// live signed emitter (recorder disabled, no dir, or no signing
+			// key) every tools/call would fail closed with
+			// receipt_emission_failed - a silent, total block. Refuse to start
+			// so the misconfiguration surfaces here, not as an all-blocked
+			// proxy at runtime.
+			if cfg.FlightRecorder.RequireReceipts && !receiptEmitterReady(receiptEmitter) {
+				return fmt.Errorf("flight_recorder.require_receipts is enabled but no healthy signed receipt emitter is active: set flight_recorder.enabled, flight_recorder.dir, and flight_recorder.signing_key_path (run 'pipelock init'), fix any receipt-chain resume error, or disable require_receipts")
+			}
 			sc.SetDLPWarnHook(func(ctx context.Context, patternName, severity string) {
 				emitDLPWarn(auditLogger, nil, receiptEmitter, ctx, patternName, severity)
 			})
@@ -903,7 +914,7 @@ Key-free evidence capture:
 						TaintCfg:               &cfg.Taint,
 						ContractLoader:         contractLoader,
 						ContractAgent:          contractAgent,
-					}, receiptEmitter, v2ReceiptEmitter, captureConfigHash)
+					}, receiptEmitter, v2ReceiptEmitter, captureConfigHash, cfg.FlightRecorder.RequireReceipts)
 					if err := mcp.RunHTTPListenerProxy(ctx, mcpLn, upstreamURL, cmd.ErrOrStderr(), listenerOpts); err != nil {
 						if sentryClient != nil {
 							sentryClient.CaptureError(err)
@@ -938,7 +949,7 @@ Key-free evidence capture:
 						TaintCfg:               &cfg.Taint,
 						ContractLoader:         contractLoader,
 						ContractAgent:          contractAgent,
-					}, receiptEmitter, v2ReceiptEmitter, captureConfigHash)
+					}, receiptEmitter, v2ReceiptEmitter, captureConfigHash, cfg.FlightRecorder.RequireReceipts)
 					if err := mcp.RunWSProxy(ctx, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), upstreamURL, wsOpts); err != nil {
 						if sentryClient != nil {
 							sentryClient.CaptureError(err)
@@ -972,7 +983,7 @@ Key-free evidence capture:
 					TaintCfg:               &cfg.Taint,
 					ContractLoader:         contractLoader,
 					ContractAgent:          contractAgent,
-				}, receiptEmitter, v2ReceiptEmitter, captureConfigHash)
+				}, receiptEmitter, v2ReceiptEmitter, captureConfigHash, cfg.FlightRecorder.RequireReceipts)
 				if err := mcp.RunHTTPProxy(ctx, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), upstreamURL, extraHeaders, httpOpts); err != nil {
 					if sentryClient != nil {
 						sentryClient.CaptureError(err)
@@ -1131,7 +1142,7 @@ Key-free evidence capture:
 					TaintCfg:        &cfg.Taint,
 					ContractLoader:  contractLoader,
 					ContractAgent:   contractAgent,
-				}, receiptEmitter, v2ReceiptEmitter, captureConfigHash)
+				}, receiptEmitter, v2ReceiptEmitter, captureConfigHash, cfg.FlightRecorder.RequireReceipts)
 				if err := mcp.RunProxyWithSandbox(ctx, sandboxCmd, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), proxyOpts, mcpStrict); err != nil {
 					return handleProxyError(err, cmd.ErrOrStderr(), sentryClient)
 				}
@@ -1242,7 +1253,7 @@ Key-free evidence capture:
 				Lineage:         lin, OnChildReady: onChildReady,
 				ContractLoader: contractLoader,
 				ContractAgent:  contractAgent,
-			}, receiptEmitter, v2ReceiptEmitter, captureConfigHash)
+			}, receiptEmitter, v2ReceiptEmitter, captureConfigHash, cfg.FlightRecorder.RequireReceipts)
 			if err := mcp.RunProxy(ctx, cmd.InOrStdin(), cmd.OutOrStdout(), logW, serverCmd, proxyOpts, extraEnv...); err != nil {
 				return handleProxyError(err, logW, sentryClient)
 			}

--- a/internal/cli/runtime/mcp_capture_test.go
+++ b/internal/cli/runtime/mcp_capture_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -65,19 +66,35 @@ mcp_tool_policy:
 func runMCPProxyStdin(t *testing.T, stdin string, args []string) (string, error) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	cmd := McpCmd()
-	var stdout, stderr bytes.Buffer
+	var stderr bytes.Buffer
 	cmd.SetContext(ctx)
-	cmd.SetOut(&stdout)
+	cmd.SetOut(io.Discard)
 	cmd.SetErr(&stderr)
 	cmd.SetIn(strings.NewReader(stdin))
 	cmd.SetArgs(args)
 
-	err := cmd.Execute()
-	return stderr.String(), err
+	done := make(chan error, 1)
+	go func() { done <- cmd.Execute() }()
+
+	select {
+	case err := <-done:
+		return stderr.String(), err
+	case <-time.After(mcpProxyRunHangBackstop):
+		cancel()
+		select {
+		case err := <-done:
+			t.Fatalf("mcp proxy command did not complete within %s (hang backstop); Execute returned after cancellation with: %v",
+				mcpProxyRunHangBackstop, err)
+		case <-time.After(mcpProxyCancelGrace):
+			t.Fatalf("mcp proxy command did not complete within %s and did not stop within %s after cancellation",
+				mcpProxyRunHangBackstop, mcpProxyCancelGrace)
+		}
+		return "", nil
+	}
 }
 
 // collectCaptureSurfaces walks the per-session subdirectories the capture

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -74,7 +74,7 @@ func TestMCPReceiptParityOpts(t *testing.T) {
 	opts := mcpReceiptParityOpts(mcp.MCPProxyOpts{
 		ConfigHash: "config-hash",
 		PolicyHash: "old-policy-hash",
-	}, r, v2, "policy-hash")
+	}, r, v2, "policy-hash", true)
 
 	if opts.ReceiptEmitter != r {
 		t.Fatal("receipt emitter not threaded")
@@ -84,6 +84,9 @@ func TestMCPReceiptParityOpts(t *testing.T) {
 	}
 	if opts.PolicyHash != "policy-hash" {
 		t.Fatalf("PolicyHash = %q, want policy-hash", opts.PolicyHash)
+	}
+	if !opts.RequireReceipts {
+		t.Fatal("RequireReceipts not threaded")
 	}
 	if opts.ConfigHash != "config-hash" {
 		t.Fatalf("ConfigHash = %q, want config-hash", opts.ConfigHash)

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -503,6 +503,17 @@ func NewServer(opts ServerOpts) (*Server, error) {
 			"  Recorder: enabled but inert - no flight_recorder.dir configured; "+
 				"no receipts will be written. Run 'pipelock init' or set flight_recorder.dir + signing_key_path.\n")
 	}
+	// require_receipts escalates a missing receipt to a block. With no live
+	// signed emitter (no recorder dir or no signing key) EVERY request would
+	// fail closed with receipt_emission_failed - a silent, total egress
+	// black-hole. Refuse to start so the misconfiguration surfaces here
+	// instead of as an all-403 outage at runtime. (Restart-only recorder
+	// fields are preserved across reload, so a live emitter built here stays
+	// live; this check intentionally lives at build time, not in Validate.)
+	if cfg.FlightRecorder.RequireReceipts && !receiptEmitterReady(s.receiptEmitter) {
+		s.cleanup()
+		return nil, fmt.Errorf("flight_recorder.require_receipts is enabled but no healthy signed receipt emitter is active: set flight_recorder.enabled, flight_recorder.dir, and flight_recorder.signing_key_path (run 'pipelock init'), fix any receipt-chain resume error, or disable require_receipts")
+	}
 	if err := s.initConductorProducer(cfg, m, recPrivKey, opts.Stderr); err != nil {
 		s.cleanup()
 		return nil, err

--- a/internal/cli/runtime/server_emitters.go
+++ b/internal/cli/runtime/server_emitters.go
@@ -43,6 +43,14 @@ func (s *Server) liveReceiptEmitter() *receipt.Emitter {
 	return s.receiptEmitter
 }
 
+func receiptEmitterReady(e *receipt.Emitter) bool {
+	return e != nil && e.InitError() == nil
+}
+
+func (s *Server) liveReceiptEmitterReady() bool {
+	return receiptEmitterReady(s.liveReceiptEmitter())
+}
+
 // sealTranscriptRoot writes the transcript root for the live receipt chain at
 // graceful shutdown, anchoring the receipts emitted this run so a chain truncated
 // by a CLEAN exit becomes detectable: verify can see the sealed root instead of

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -642,6 +642,10 @@ func (s *Server) Start(ctx context.Context) error {
 			}
 			return &c.RequestBodyScanning
 		}
+		mcpRequireReceiptsFn := func() bool {
+			c := s.proxy.CurrentConfig()
+			return c != nil && c.FlightRecorder.RequireReceipts
+		}
 
 		mcpErr = make(chan error, 1)
 		lifecycleWG.Add(1)
@@ -675,6 +679,7 @@ func (s *Server) Start(ctx context.Context) error {
 				AddressProtectionAgent: edition.ProfileDefault,
 				ProvenanceCfgFn:        mcpProvenanceCfgFn,
 				ReceiptEmitterFn:       s.liveReceiptEmitter,
+				RequireReceiptsFn:      mcpRequireReceiptsFn,
 				V2ReceiptEmitterFn:     s.liveV2ReceiptEmitter,
 				PolicyHashFn:           mcpConfigHashFn,
 				EnvelopeEmitterFn:      s.liveEnvelopeEmitter,

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -91,28 +91,41 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			s.logger.LogConfigReload("ignored", "conductor settings restart-only", attemptedHash)
 			newCfg.Conductor = oldCfg.Conductor
 		}
-		// Block flight_recorder changes via reload. The recorder (and its
+		// Block recorder-binding changes via reload. The recorder (and its
 		// receipt/audit chain) is built once at Start; reload swaps config and
-		// scanner but never rebuilds the recorder, so any flight_recorder change
-		// would leave the live config disagreeing with the running recorder.
-		// Signing-key rotation is the sharpest case - the receipt chain is
-		// anchored to the current key, and rotating mid-chain breaks tail-
-		// signature verification on resume - but every field is restart-only for
-		// the same build-once reason. Preserve the whole block and warn.
+		// scanner but never rebuilds the recorder, so path/key/retention/etc.
+		// changes would leave the live config disagreeing with the running
+		// recorder. require_receipts is the exception: it changes only whether
+		// an emit failure escalates an otherwise-allowed request to a block, so
+		// it is safe and intentionally reloadable.
 		//
 		// This also keeps Conductor policy-bundle apply working: a signed bundle
 		// carries enforcement-only config (flight_recorder is not an allowlisted
 		// bundle section), so the bundle's loaded config omits flight_recorder.
 		// Preserving the follower's existing block means conductor.enabled - which
 		// requires a signed flight recorder - still validates after the apply.
-		if !reflect.DeepEqual(oldCfg.FlightRecorder, newCfg.FlightRecorder) {
+		oldFR := oldCfg.FlightRecorder
+		newFR := newCfg.FlightRecorder
+		oldFR.RequireReceipts = newFR.RequireReceipts
+		if !reflect.DeepEqual(oldFR, newFR) {
 			if oldCfg.FlightRecorder.SigningKeyPath != newCfg.FlightRecorder.SigningKeyPath {
 				_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: flight_recorder.signing_key_path changed from %q to %q — receipt chain cannot rotate at runtime, ignoring (restart required)\n",
 					oldCfg.FlightRecorder.SigningKeyPath, newCfg.FlightRecorder.SigningKeyPath)
 			} else {
 				_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: flight_recorder settings changed — recorder is built at startup and cannot rebind at runtime, ignoring (restart required)\n")
 			}
+			requireReceipts := newCfg.FlightRecorder.RequireReceipts
 			newCfg.FlightRecorder = oldCfg.FlightRecorder
+			newCfg.FlightRecorder.RequireReceipts = requireReceipts
+		}
+		// require_receipts reloads freely, but it only has a live emitter to
+		// gate on when one was built at Start (the recorder is restart-only).
+		// Enabling it without one fails every request closed with
+		// receipt_emission_failed. Warn loudly; the value still applies so the
+		// posture is honest (fail-closed), but restart with a configured
+		// recorder is the real fix.
+		if newCfg.FlightRecorder.RequireReceipts && !s.liveReceiptEmitterReady() {
+			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: flight_recorder.require_receipts is enabled but no healthy live signed receipt emitter exists — every request will fail closed with receipt_emission_failed. Configure flight_recorder.dir + signing_key_path, fix any receipt-chain resume error, and restart.\n")
 		}
 		// Block file_sentry changes via reload. The watcher is built
 		// once at Start from the startup snapshot; reloading would

--- a/internal/cli/runtime/server_require_receipts_test.go
+++ b/internal/cli/runtime/server_require_receipts_test.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// TestNewServer_RequireReceiptsWithoutEmitterFailsClosed pins the startup
+// guard: require_receipts escalates a missing receipt to a block, so an
+// inert recorder (no dir / no signing key) would fail-close every request
+// with receipt_emission_failed. NewServer must refuse to start instead of
+// bringing up a silently all-blocking proxy.
+func TestNewServer_RequireReceiptsWithoutEmitterFailsClosed(t *testing.T) {
+	cases := []struct {
+		name    string
+		section []string
+	}{
+		{
+			name: "no_dir",
+			section: []string{
+				"flight_recorder:",
+				"  enabled: true",
+				"  require_receipts: true",
+			},
+		},
+		{
+			name: "dir_without_signing_key",
+			section: []string{
+				"flight_recorder:",
+				"  enabled: true",
+				"  require_receipts: true",
+				"  dir: " + strconv.Quote(t.TempDir()),
+			},
+		},
+		{
+			name: "recorder_disabled",
+			section: []string{
+				"flight_recorder:",
+				"  enabled: false",
+				"  require_receipts: true",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfgPath := writeServerTestConfig(t, strings.Join(append([]string{"mode: balanced"}, tc.section...), "\n")+"\n")
+			s, err := NewServer(ServerOpts{ConfigFile: cfgPath, Stdout: &syncBuffer{}, Stderr: &syncBuffer{}})
+			if err == nil {
+				s.cleanup()
+				t.Fatal("expected NewServer to fail when require_receipts is set without a live signed emitter")
+			}
+			if !strings.Contains(err.Error(), "require_receipts") {
+				t.Fatalf("error = %q, want it to mention require_receipts", err)
+			}
+		})
+	}
+}
+
+// TestNewServer_RequireReceiptsWithLiveEmitterStarts proves the guard is not
+// over-broad: with a real recorder dir + signing key the emitter is live, so
+// require_receipts is a valid configuration and NewServer succeeds.
+func TestNewServer_RequireReceiptsWithLiveEmitterStarts(t *testing.T) {
+	recorderDir := t.TempDir()
+	keyPath := filepath.Join(t.TempDir(), "flight-recorder.key")
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate signing key: %v", err)
+	}
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("save signing key: %v", err)
+	}
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"flight_recorder:",
+		"  enabled: true",
+		"  require_receipts: true",
+		"  dir: " + strconv.Quote(recorderDir),
+		"  signing_key_path: " + strconv.Quote(keyPath),
+		"",
+	}, "\n"))
+
+	s, err := NewServer(ServerOpts{ConfigFile: cfgPath, Stdout: &syncBuffer{}, Stderr: &syncBuffer{}})
+	if err != nil {
+		t.Fatalf("NewServer with live signed emitter and require_receipts: %v", err)
+	}
+	t.Cleanup(func() { s.cleanup() })
+	if s.receiptEmitter == nil {
+		t.Fatal("receiptEmitter nil despite configured recorder + signing key")
+	}
+}
+
+func TestNewServer_RequireReceiptsWithBrickedEmitterFails(t *testing.T) {
+	recorderDir := t.TempDir()
+	keyPath := filepath.Join(t.TempDir(), "flight-recorder.key")
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate signing key: %v", err)
+	}
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("save signing key: %v", err)
+	}
+	seedTamperedReceiptTail(t, recorderDir, priv)
+
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"flight_recorder:",
+		"  enabled: true",
+		"  require_receipts: true",
+		"  dir: " + strconv.Quote(recorderDir),
+		"  signing_key_path: " + strconv.Quote(keyPath),
+		"",
+	}, "\n"))
+
+	s, err := NewServer(ServerOpts{ConfigFile: cfgPath, Stdout: &syncBuffer{}, Stderr: &syncBuffer{}})
+	if err == nil {
+		s.cleanup()
+		t.Fatal("expected NewServer to fail when require_receipts has a bricked emitter")
+	}
+	if !strings.Contains(err.Error(), "require_receipts") || !strings.Contains(err.Error(), "resume") {
+		t.Fatalf("error = %q, want require_receipts and resume context", err)
+	}
+}
+
+func seedTamperedReceiptTail(t *testing.T, dir string, priv ed25519.PrivateKey) {
+	t.Helper()
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: "test",
+		Principal:  "test",
+		Actor:      "test",
+	})
+	if err := emitter.Emit(receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   "allow",
+		Transport: "fetch",
+		Method:    http.MethodGet,
+		Target:    "https://example.com",
+	}); err != nil {
+		t.Fatalf("seed Emit: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	tamperLastActionReceipt(t, dir)
+}
+
+func tamperLastActionReceipt(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var target string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".jsonl") {
+			target = filepath.Join(dir, entry.Name())
+		}
+	}
+	if target == "" {
+		t.Fatal("no evidence file found")
+	}
+	raw, err := os.ReadFile(filepath.Clean(target))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		var entry map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(lines[i]), &entry); err != nil {
+			continue
+		}
+		var entryType string
+		if err := json.Unmarshal(entry["type"], &entryType); err != nil || entryType != "action_receipt" {
+			continue
+		}
+		rcpt, err := receipt.Unmarshal(entry["detail"])
+		if err != nil {
+			t.Fatalf("receipt.Unmarshal: %v", err)
+		}
+		rcpt.ActionRecord.Verdict = "block"
+		detail, err := receipt.Marshal(rcpt)
+		if err != nil {
+			t.Fatalf("receipt.Marshal: %v", err)
+		}
+		entry["detail"] = detail
+		line, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("json.Marshal: %v", err)
+		}
+		lines[i] = string(line)
+		if err := os.WriteFile(filepath.Clean(target), []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		return
+	}
+	t.Fatal("no action_receipt entry found")
+}

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -783,6 +783,7 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 	oldCfg.ScanAPI.ConnectionLimit = 2
 	oldCfg.ScanAPI.Timeouts = config.ScanAPITimeouts{Read: "1s", Write: "1s"}
 	oldCfg.FlightRecorder.SigningKeyPath = "/tmp/old-signing-key"
+	oldCfg.FlightRecorder.RequireReceipts = false
 	oldCfg.Conductor.ConductorURL = "https://boss-old.example"
 	oldCfg.FileSentry.Enabled = true
 	oldCfg.FileSentry.Action = config.ActionWarn
@@ -794,6 +795,7 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 	newCfg.ScanAPI.ConnectionLimit = 4
 	newCfg.ScanAPI.Timeouts = config.ScanAPITimeouts{Read: "2s", Write: "2s"}
 	newCfg.FlightRecorder.SigningKeyPath = "/tmp/new-signing-key"
+	newCfg.FlightRecorder.RequireReceipts = true
 	newCfg.Conductor.ConductorURL = "https://boss-new.example"
 	newCfg.FileSentry.Action = config.ActionBlock // file_sentry is restart-only; this change must be ignored
 	newCfg.ReverseProxy.Listen = "127.0.0.1:28084"
@@ -816,6 +818,9 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 	}
 	if live.FlightRecorder.SigningKeyPath != oldCfg.FlightRecorder.SigningKeyPath {
 		t.Fatalf("signing key path = %q, want %q", live.FlightRecorder.SigningKeyPath, oldCfg.FlightRecorder.SigningKeyPath)
+	}
+	if !live.FlightRecorder.RequireReceipts {
+		t.Fatal("flight_recorder.require_receipts reload change was not applied")
 	}
 	if live.Conductor != oldCfg.Conductor {
 		t.Fatalf("conductor settings not preserved: %+v", live.Conductor)

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -137,12 +137,15 @@ func (c *Config) policySemanticView() Config {
 	view.ReverseProxy.Upstream = ""
 
 	// Telemetry and operational outputs - emit destinations, log
-	// formatting, Sentry DSN, flight recorder path. None of these
-	// affect detection decisions; they affect where observations go.
+	// formatting, Sentry DSN, flight recorder path/key/retention. None of
+	// these affect detection decisions; they affect where observations go.
+	// flight_recorder.require_receipts is intentionally preserved below:
+	// it changes enforcement posture by escalating receipt-emission failure
+	// from warn-and-forward to block.
 	view.Logging = LoggingConfig{}
 	view.Sentry = SentryConfig{}
 	view.Emit = EmitConfig{}
-	view.FlightRecorder = FlightRecorder{}
+	view.FlightRecorder = FlightRecorder{RequireReceipts: view.FlightRecorder.RequireReceipts}
 	view.Conductor = Conductor{}
 
 	// License metadata - determines whether a tier feature is available,

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -163,7 +163,10 @@ const (
 	// over-match benign shell env-var references; the "Credential in URL"
 	// value tail additionally excludes ';' so a semicolon-separated param
 	// does not bleed into the captured credential. Detection-relevant change.
-	goldenHashDefaults = "1b3034ef2fe75b621c1cde30aaad593a18a4e54a0c0505a8e8814d06f6b4aeba"
+	// Re-bumped for flight_recorder.require_receipts: the default is false,
+	// but explicit true changes enforcement by blocking otherwise-allowed
+	// requests when a required receipt cannot be emitted.
+	goldenHashDefaults = "68802d0f2366afa9ca612d55b9186245b897cf8a321ab7fb8523635b07c5529d"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -246,7 +249,9 @@ const (
 	// still part of the canonical policy view.
 	// Re-bumped for DLP precision on the env-var-secret / credential-in-URL
 	// patterns: see goldenHashDefaults note above.
-	goldenHashRichConfig = "fdb19355c9ddcfe952f1652a882f495c56981501c8c794a8872669a50d44e653"
+	// Re-bumped for flight_recorder.require_receipts: see goldenHashDefaults
+	// note above.
+	goldenHashRichConfig = "8c6e749eff3408990afc9a91926ac1b60b9e0958d919afd2d1c383dd54d777b0"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/canonical_test.go
+++ b/internal/config/canonical_test.go
@@ -205,6 +205,10 @@ func TestCanonicalPolicyHash_PolicyFieldsDoAffect(t *testing.T) {
 			},
 		},
 		{
+			name: "flight_recorder.require_receipts enabled",
+			mut:  func(c *Config) { c.FlightRecorder.RequireReceipts = true },
+		},
+		{
 			name: "mediation_envelope.sign enabled",
 			mut: func(c *Config) {
 				c.MediationEnvelope.Enabled = true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9777,6 +9777,81 @@ func TestLoad_FlightRecorderEnabledStates(t *testing.T) {
 	}
 }
 
+// TestLoad_FlightRecorderRequireReceiptsStates documents the default-false
+// invariant for the opt-in fail-closed receipt mode across its load-time
+// states. Reload reuses Load(), and the reload-with-change / reload-no-change
+// cases below exercise the same parsing path a hot reload receives before
+// runtime applies restart-only field preservation.
+func TestLoad_FlightRecorderRequireReceiptsStates(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		section string
+		want    bool
+	}{
+		{name: "omitted_whole_section", section: "", want: false},
+		{name: "key_null", section: "flight_recorder:\n  require_receipts:\n", want: false},
+		{name: "key_blank", section: "flight_recorder:\n  require_receipts: \n", want: false},
+		{name: "explicit_false", section: "flight_recorder:\n  require_receipts: false\n", want: false},
+		{name: "explicit_true", section: "flight_recorder:\n  require_receipts: true\n", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "fr-require.yaml")
+			content := "mode: balanced\n" + tt.section
+			if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(cfgPath)
+			if err != nil {
+				t.Fatalf("Load() error: %v", err)
+			}
+			if cfg.FlightRecorder.RequireReceipts != tt.want {
+				t.Errorf("FlightRecorder.RequireReceipts = %v, want %v", cfg.FlightRecorder.RequireReceipts, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoad_FlightRecorderRequireReceiptsReloadStates(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "fr-require-reload.yaml")
+
+	if err := os.WriteFile(cfgPath, []byte("mode: balanced\nflight_recorder:\n  require_receipts: false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load #1: %v", err)
+	}
+	if first.FlightRecorder.RequireReceipts {
+		t.Fatal("first load RequireReceipts = true, want false")
+	}
+
+	if err := os.WriteFile(cfgPath, []byte("mode: balanced\nflight_recorder:\n  require_receipts: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	second, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load #2: %v", err)
+	}
+	if !second.FlightRecorder.RequireReceipts {
+		t.Fatal("reload with change RequireReceipts = false, want true")
+	}
+
+	third, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load #3: %v", err)
+	}
+	if third.FlightRecorder.RequireReceipts != second.FlightRecorder.RequireReceipts {
+		t.Fatalf("reload without change RequireReceipts = %v, want %v",
+			third.FlightRecorder.RequireReceipts, second.FlightRecorder.RequireReceipts)
+	}
+}
+
 func TestLoad_MCPToolProvenanceDefaults(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "prov.yaml")

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -515,9 +515,11 @@ func Defaults() *Config {
 			// Footguns handled here: Redact stays on (receipts carry targets, so
 			// without scrubbing they would persist secrets in the clear) and
 			// MaxEntriesPerFile caps file growth (rotation), so default-on cannot
-			// silently fill the disk or leak. Evidence, not enforcement: a
-			// recorder failure never blocks traffic.
+			// silently fill the disk or leak. Evidence, not enforcement by default:
+			// a recorder failure never blocks traffic unless RequireReceipts is
+			// explicitly enabled by the operator.
 			Enabled:            true,
+			RequireReceipts:    false,
 			CheckpointInterval: 1000,  // entries between signed checkpoints
 			Redact:             true,  // DLP-scrub evidence before commit
 			SignCheckpoints:    true,  // Ed25519 sign checkpoints

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1175,6 +1175,7 @@ type FlightRecorder struct {
 	RawEscrow          bool        `yaml:"raw_escrow"`           // encrypted raw detail sidecar (default false)
 	EscrowPublicKey    string      `yaml:"escrow_public_key"`    // X25519 public key for raw escrow encryption
 	SigningKeyPath     string      `yaml:"signing_key_path"`     // Ed25519 private key for checkpoint signing and action receipts
+	RequireReceipts    bool        `yaml:"require_receipts"`     // fail closed when a required receipt cannot be emitted (default false)
 }
 
 // MediationEnvelope configures sideband metadata on proxied requests.

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/addressprotect"
 	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	decide "github.com/luckyPipewrench/pipelock/internal/decide"
@@ -467,8 +468,9 @@ func ForwardScannedInput(
 				actionID = receipt.NewActionID()
 			}
 		}
+		receiptEmitted := false
 
-		emitToolReceipt := func(receiptVerdict string, contractGate ...mcpContractGateOutput) {
+		emitToolReceipt := func(receiptVerdict string, contractGate ...mcpContractGateOutput) error {
 			// Delegate to the shared helper so stdio and HTTP/WS emit
 			// tool receipts through the same EmitMCPDecision entry.
 			layer, pattern, severity := pickAttribution(eval)
@@ -488,11 +490,12 @@ func ForwardScannedInput(
 				Severity:         severity,
 				Decision:         taintDecision,
 				Report:           redactionReport,
+				RequireReceipt:   opts.requireReceipts() && receiptVerdict != config.ActionBlock,
 			}
 			if len(contractGate) > 0 {
 				receiptOpts.ContractGate = &contractGate[0]
 			}
-			emitMCPToolReceipt(receiptOpts)
+			return emitMCPToolReceipt(receiptOpts)
 		}
 
 		logTaintDecision := func() {
@@ -548,7 +551,7 @@ func ForwardScannedInput(
 				ErrorCode:      -32600,
 				ErrorMessage:   "pipelock: " + eval.DoWReason,
 			}
-			emitToolReceipt(config.ActionBlock)
+			_ = emitToolReceipt(config.ActionBlock)
 			continue
 		case blockingGateFrozenTool:
 			frozenMsg := fmt.Sprintf("pipelock: input line %d: tools/call %q blocked by frozen tool inventory", lineNum, eval.FrozenToolName)
@@ -567,7 +570,7 @@ func ForwardScannedInput(
 				ErrorCode:      -32600,
 				ErrorMessage:   "pipelock: tool not in frozen inventory",
 			}
-			emitToolReceipt(config.ActionBlock)
+			_ = emitToolReceipt(config.ActionBlock)
 			continue
 		case blockingGateChain:
 			recordAdaptiveSignal(session.SignalBlock)
@@ -578,7 +581,7 @@ func ForwardScannedInput(
 				ErrorCode:      -32004,
 				ErrorMessage:   fmt.Sprintf("tool call blocked: chain pattern %q detected", eval.ChainPatternName),
 			}
-			emitToolReceipt(config.ActionBlock)
+			_ = emitToolReceipt(config.ActionBlock)
 			continue
 		case blockingGateParseError:
 			_, _ = fmt.Fprintf(logW, "pipelock: input line %d: %s\n", lineNum, verdict.Error)
@@ -587,7 +590,7 @@ func ForwardScannedInput(
 				IsNotification: isRPCNotification(verdict.ID),
 				LogMessage:     fmt.Sprintf("pipelock: input line %d: blocked (parse error)", lineNum),
 			}
-			emitToolReceipt(config.ActionBlock)
+			_ = emitToolReceipt(config.ActionBlock)
 			continue
 		case blockingGateTaintBlock, blockingGateTaintAskDenied:
 			logTaintDecision()
@@ -598,7 +601,7 @@ func ForwardScannedInput(
 				ErrorCode:      -32002,
 				ErrorMessage:   "pipelock: " + taintDecision.Result.Reason,
 			}
-			emitToolReceipt(config.ActionBlock)
+			_ = emitToolReceipt(config.ActionBlock)
 			continue
 		}
 
@@ -673,19 +676,15 @@ func ForwardScannedInput(
 					ErrorCode:      -32006,
 					ErrorMessage:   "pipelock: contract tool-call evaluation failed",
 				}
-				emitToolReceipt(config.ActionBlock)
+				_ = emitToolReceipt(config.ActionBlock)
 				continue
 			}
 			if contractGate.Verdict == config.ActionBlock {
 				_, _ = fmt.Fprintf(logW, "pipelock: input line %d: contract blocked tools/call %q (%s)\n", lineNum, toolCallName, contractGate.Reason)
 				blockedCh <- mcpContractBlockRequest(verdict.ID, contractGate, "pipelock: request blocked by live-lock contract")
-				emitToolReceipt(config.ActionBlock, contractGate)
+				_ = emitToolReceipt(config.ActionBlock, contractGate)
 				continue
 			}
-			// Track request ID before forwarding so response-side can validate.
-			// Must happen before write to prevent race: response could arrive
-			// before Track completes in concurrent stdio paths.
-			tracker.Track(verdict.ID)
 			fwdLine := line
 			if verdict.Method == methodToolsCall {
 				buildOpts := envelope.BuildOpts{
@@ -713,11 +712,25 @@ func ForwardScannedInput(
 					continue
 				}
 			}
+			if err := emitToolReceipt(config.ActionAllow, contractGate); err != nil {
+				blockedCh <- BlockedRequest{
+					ID:             verdict.ID,
+					IsNotification: isRPCNotification(verdict.ID),
+					LogMessage:     "receipt emission failed",
+					ErrorCode:      -32007,
+					ErrorMessage:   "pipelock: receipt emission failed",
+					ErrorData:      mcpBlockReasonData(blockreason.ReceiptEmissionFailed),
+				}
+				continue
+			}
+			// Track request ID immediately before forwarding so response-side
+			// can validate without leaving stale state when a required
+			// receipt fails before the request is written.
+			tracker.Track(verdict.ID)
 			if err := writer.WriteMessage(fwdLine); err != nil {
 				_, _ = fmt.Fprintf(logW, "pipelock: input forward error: %v\n", err)
 				return
 			}
-			emitToolReceipt(config.ActionAllow, contractGate)
 			if rec != nil && adaptiveCfg != nil && adaptiveCfg.Enabled {
 				rec.RecordClean(adaptiveCfg.DecayPerCleanRequest)
 			}
@@ -983,18 +996,16 @@ func ForwardScannedInput(
 					ErrorCode:      -32006,
 					ErrorMessage:   "pipelock: contract tool-call evaluation failed",
 				}
-				emitToolReceipt(config.ActionBlock)
+				_ = emitToolReceipt(config.ActionBlock)
 				continue
 			}
 			if contractGate.Verdict == config.ActionBlock {
 				_, _ = fmt.Fprintf(logW, "pipelock: input line %d: contract blocked tools/call %q (%s)\n", lineNum, toolCallName, contractGate.Reason)
 				blockedCh <- mcpContractBlockRequest(verdict.ID, contractGate, "pipelock: request blocked by live-lock contract")
-				emitToolReceipt(config.ActionBlock, contractGate)
+				_ = emitToolReceipt(config.ActionBlock, contractGate)
 				continue
 			}
 			contractGateForReceipt = &contractGate
-			// Track ID before forwarding (warn mode still sends the request).
-			tracker.Track(verdict.ID)
 			// Inject envelope for warn-mode tool calls before forwarding.
 			fwdLine := line
 			if verdict.Method == methodToolsCall {
@@ -1023,7 +1034,20 @@ func ForwardScannedInput(
 					continue
 				}
 			}
+			if err := emitToolReceipt(effectiveAction, contractGate); err != nil {
+				blockedCh <- BlockedRequest{
+					ID:             verdict.ID,
+					IsNotification: isRPCNotification(verdict.ID),
+					LogMessage:     "receipt emission failed",
+					ErrorCode:      -32007,
+					ErrorMessage:   "pipelock: receipt emission failed",
+					ErrorData:      mcpBlockReasonData(blockreason.ReceiptEmissionFailed),
+				}
+				continue
+			}
+			receiptEmitted = true
 			// Forward anyway (warn mode).
+			tracker.Track(verdict.ID)
 			if err := writer.WriteMessage(fwdLine); err != nil {
 				_, _ = fmt.Fprintf(logW, "pipelock: input forward error: %v\n", err)
 				return
@@ -1046,10 +1070,12 @@ func ForwardScannedInput(
 		}
 
 		// Action receipt: emit for tools/call decisions only.
-		if contractGateForReceipt != nil {
-			emitToolReceipt(effectiveAction, *contractGateForReceipt)
-		} else {
-			emitToolReceipt(effectiveAction)
+		if !receiptEmitted {
+			if contractGateForReceipt != nil {
+				_ = emitToolReceipt(effectiveAction, *contractGateForReceipt)
+			} else {
+				_ = emitToolReceipt(effectiveAction)
+			}
 		}
 
 		// Capture: record DLP/injection input verdict.

--- a/internal/mcp/input_require_receipts_test.go
+++ b/internal/mcp/input_require_receipts_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/transport"
+)
+
+// runStdioToolCall drives ForwardScannedInput for a single clean tools/call
+// against an emitter whose recorder is already closed, so every receipt emit
+// fails. It returns whether the request was forwarded to the upstream and any
+// block request that was raised.
+func runStdioToolCall(t *testing.T, requireReceipts bool) (forwarded bool, blocked *BlockedRequest) {
+	t.Helper()
+	sc := testInputScanner(t)
+	msg := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"/tmp/readme.md"}}}`
+
+	emitter, rec, _, _ := newReceiptTestHarness(t)
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	var serverBuf, logBuf bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 10)
+	opts := MCPProxyOpts{
+		Scanner:         sc,
+		Transport:       "mcp_stdio",
+		ReceiptEmitter:  emitter,
+		RequireReceipts: requireReceipts,
+	}
+
+	ForwardScannedInput(
+		transport.NewStdioReader(strings.NewReader(msg)),
+		transport.NewStdioWriter(&serverBuf),
+		&logBuf,
+		config.ActionWarn,
+		config.ActionBlock,
+		blockedCh,
+		nil,
+		nil,
+		opts,
+	)
+	// ForwardScannedInput closes blockedCh on reader EOF; drain it.
+	for b := range blockedCh {
+		b := b
+		blocked = &b
+	}
+	return strings.Contains(serverBuf.String(), "read_file"), blocked
+}
+
+// TestForwardScannedInput_ReceiptFailureWithoutRequireStillForwards is the
+// stdio counterpart to the HTTP test of the same name. With require_receipts
+// off (the default), a recorder/emit failure must stay best-effort and never
+// block an otherwise-clean tools/call. Regression guard: the allow path
+// briefly coupled the block decision to any emit error, fail-closing the
+// default config on a transient recorder hiccup.
+func TestForwardScannedInput_ReceiptFailureWithoutRequireStillForwards(t *testing.T) {
+	forwarded, blocked := runStdioToolCall(t, false)
+	if blocked != nil {
+		t.Fatalf("require_receipts off: clean tools/call must forward, got block: %+v", blocked)
+	}
+	if !forwarded {
+		t.Fatal("expected clean tools/call to be forwarded when require_receipts is off")
+	}
+}
+
+// TestForwardScannedInput_RequireReceiptsBlocksEmissionFailure pins the
+// fail-closed side: with require_receipts on, a failed authoritative receipt
+// emission blocks the forward with the receipt_emission_failed reason.
+func TestForwardScannedInput_RequireReceiptsBlocksEmissionFailure(t *testing.T) {
+	forwarded, blocked := runStdioToolCall(t, true)
+	if forwarded {
+		t.Fatal("require_receipts on: request must not forward when the required receipt fails")
+	}
+	if blocked == nil {
+		t.Fatal("expected require_receipts to block the failed receipt emission")
+	}
+	if blocked.ErrorCode != -32007 {
+		t.Fatalf("error code = %d, want -32007", blocked.ErrorCode)
+	}
+	if !strings.Contains(string(blocked.ErrorData), string(blockreason.ReceiptEmissionFailed)) {
+		t.Fatalf("error data = %s, want %s", blocked.ErrorData, blockreason.ReceiptEmissionFailed)
+	}
+}

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -39,7 +39,7 @@ func scanHTTPInput(msg []byte, logW io.Writer, sessionKey, auditSessionKey strin
 // per-message logic, but returns the block verdict plus the message to forward.
 // When cee is non-nil, outbound payloads are recorded for cross-request
 // exfiltration detection after content scanning passes.
-func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionKey string, opts MCPProxyOpts) httpInputDecision {
+func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionKey string, opts MCPProxyOpts) (result httpInputDecision) {
 	// Strip any inbound com.pipelock/mediation from _meta before
 	// parsing, scanning, or forwarding. Prevents an agent (or compromised
 	// upstream that managed to send back through the listener) from
@@ -63,7 +63,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	v2ReceiptEmitter := opts.v2ReceiptEmitter()
 	envelopeEmitter := opts.envelopeEmitter()
 	redirectRT := opts.redirectRT()
-	result := httpInputDecision{ForwardMessage: msg}
+	result = httpInputDecision{ForwardMessage: msg}
 	mcpMethod := ""
 	toolName := ""
 	actionID := ""
@@ -77,6 +77,14 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	receiptPattern := ""
 	receiptSeverity := ""
 	var receiptContractGate *mcpContractGateOutput
+	requireReceipts := opts.requireReceipts()
+
+	// Parse the inbound frame once. Every gate below reads ID / Method /
+	// tool fields from this frame instead of re-parsing. Redaction may
+	// rewrite argument values; the frame is re-parsed after redaction so
+	// downstream gates (DoW, taint) see the redacted args while
+	// ID / Method / ToolCallName stay stable.
+	frame := ParseMCPFrame(msg)
 	defer func() {
 		// A2A methods are not tools/call, so actionID stays empty on the
 		// tools/call path above. When such a request is BLOCKED (receiptVerdict
@@ -114,16 +122,19 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			Decision:         taintEval,
 			Report:           redactionReport,
 			ContractGate:     receiptContractGate,
+			RequireReceipt:   requireReceipts && result.Blocked == nil,
 		}
-		emitMCPToolReceipt(receiptOpts)
+		if err := emitMCPToolReceipt(receiptOpts); err != nil && requireReceipts && result.Blocked == nil {
+			result.Blocked = &BlockedRequest{
+				ID:             frame.ID,
+				IsNotification: isRPCNotification(frame.ID),
+				LogMessage:     "receipt emission failed",
+				ErrorCode:      -32007,
+				ErrorMessage:   "pipelock: receipt emission failed",
+				ErrorData:      mcpBlockReasonData(blockreason.ReceiptEmissionFailed),
+			}
+		}
 	}()
-
-	// Parse the inbound frame once. Every gate below reads ID / Method /
-	// tool fields from this frame instead of re-parsing. Redaction may
-	// rewrite argument values; the frame is re-parsed after redaction so
-	// downstream gates (DoW, taint) see the redacted args while
-	// ID / Method / ToolCallName stay stable.
-	frame := ParseMCPFrame(msg)
 
 	// Helper: record an adaptive signal and handle escalation side-effects.
 	// Eliminates repeated nil/enabled guards at every call site.
@@ -506,9 +517,9 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			result.Blocked = ptrMCPBlockedRequest(mcpContractBlockRequest(verdict.ID, contractGate, "pipelock: request blocked by live-lock contract"))
 			return result
 		}
-		if verdict.Method == methodToolsCall {
+		if actionID != "" {
 			var decorateErr error
-			result.ForwardMessage, decorateErr = decorateMCPToolMessage(msg, envelopeEmitter, actionID, verdict.Method, toolName, config.ActionAllow, taintEval)
+			result.ForwardMessage, decorateErr = decorateMCPToolMessage(msg, envelopeEmitter, actionID, mcpMethod, toolName, config.ActionAllow, taintEval)
 			if decorateErr != nil {
 				result.Blocked = &BlockedRequest{
 					ID:             verdict.ID,

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -141,6 +141,8 @@ func RunHTTPListenerProxy(
 		Transport:                "mcp_http_listener",
 		ReceiptEmitter:           opts.receiptEmitter(),
 		ReceiptEmitterFn:         opts.ReceiptEmitterFn,
+		RequireReceipts:          opts.requireReceipts(),
+		RequireReceiptsFn:        opts.RequireReceiptsFn,
 		V2ReceiptEmitter:         opts.v2ReceiptEmitter(),
 		V2ReceiptEmitterFn:       opts.V2ReceiptEmitterFn,
 		PolicyHash:               opts.receiptPolicyHash(),

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -151,8 +151,10 @@ type MCPProxyOpts struct {
 
 	// ReceiptEmitter emits signed action receipts for MCP decisions.
 	// Nil-safe (no-op when nil).
-	ReceiptEmitter   *receipt.Emitter
-	ReceiptEmitterFn func() *receipt.Emitter
+	ReceiptEmitter    *receipt.Emitter
+	ReceiptEmitterFn  func() *receipt.Emitter
+	RequireReceipts   bool
+	RequireReceiptsFn func() bool
 	// V2ReceiptEmitter emits EvidenceReceipt v2 proxy_decision records in
 	// parity with ReceiptEmitter. Nil-safe (no-op when nil).
 	V2ReceiptEmitter   *proxydecision.Emitter
@@ -335,6 +337,13 @@ func (o MCPProxyOpts) receiptEmitter() *receipt.Emitter {
 		return o.ReceiptEmitterFn()
 	}
 	return o.ReceiptEmitter
+}
+
+func (o MCPProxyOpts) requireReceipts() bool {
+	if o.RequireReceiptsFn != nil {
+		return o.RequireReceiptsFn()
+	}
+	return o.RequireReceipts
 }
 
 func (o MCPProxyOpts) v2ReceiptEmitter() *proxydecision.Emitter {

--- a/internal/mcp/pipeline_decision.go
+++ b/internal/mcp/pipeline_decision.go
@@ -4,10 +4,15 @@
 package mcp
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
+
+var ErrReceiptRequired = errors.New("receipt required but not emitted")
 
 // MCPDecision bundles the per-decision state a gate in the inbound
 // MCP pipeline needs to emit. Today each gate calls
@@ -46,6 +51,12 @@ type MCPDecision struct {
 	// Callers that do not need envelope injection (block, strip,
 	// redirect) can set this to nil and ignore the returned bytes.
 	InboundMsg []byte
+
+	// RequireReceipt escalates a missing or failed receipt into an error.
+	// Callers use this only for otherwise-forwardable decisions so an
+	// operator can opt into "no receipt, no traffic" without changing the
+	// default warn-and-forward behavior.
+	RequireReceipt bool
 }
 
 // EmitMCPDecision emits the receipt and (optionally) injects the
@@ -84,12 +95,18 @@ func EmitMCPDecision(
 	outbound = d.InboundMsg
 
 	v1Emitted := false
-	if receiptEmitter != nil && d.Receipt.ActionID != "" {
+	receiptRequired := d.RequireReceipt && d.Receipt.ActionID != ""
+	if receiptRequired && receiptEmitter == nil {
+		err = fmt.Errorf("%w: emitter unavailable", ErrReceiptRequired)
+	} else if receiptEmitter != nil && d.Receipt.ActionID != "" {
 		err = receiptEmitter.Emit(d.Receipt)
 		v1Emitted = err == nil
 		// Intentional: continue to envelope injection even on receipt
 		// error. The two stages are independent at today's callsites
 		// and coupling them here would break parity.
+	}
+	if receiptRequired && err != nil {
+		err = fmt.Errorf("%w: %w", ErrReceiptRequired, err)
 	}
 	if v1Emitted && v2Emitter != nil {
 		if v2Decision, ok := mcpV2DecisionFromReceipt(d.Receipt); ok {

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -5487,6 +5487,52 @@ func TestScanHTTPInputDecision_EnvelopeMetadataBackfillWhenInputScanningDisabled
 	}
 }
 
+func TestScanHTTPInputDecision_ReceiptFailureWithoutRequireStillForwards(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	msg := []byte(`{"jsonrpc":"2.0","id":17,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"/tmp/readme.md"}}}`)
+	receiptEmitter, receiptRecorder, _ := newTestReceiptEmitter(t)
+	if err := receiptRecorder.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	decision := scanHTTPInputDecision(msg, io.Discard, "sess", "sess", MCPProxyOpts{
+		Scanner:        sc,
+		ReceiptEmitter: receiptEmitter,
+		Transport:      "mcp_http",
+	})
+	if decision.Blocked != nil {
+		t.Fatalf("expected request to pass when require_receipts is false, got block: %+v", decision.Blocked)
+	}
+	if !bytes.Equal(decision.ForwardMessage, msg) {
+		t.Fatalf("forward message changed unexpectedly: %s", decision.ForwardMessage)
+	}
+}
+
+func TestScanHTTPInputDecision_RequireReceiptsBlocksEmissionFailure(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	msg := []byte(`{"jsonrpc":"2.0","id":18,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"/tmp/readme.md"}}}`)
+	receiptEmitter, receiptRecorder, _ := newTestReceiptEmitter(t)
+	if err := receiptRecorder.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	decision := scanHTTPInputDecision(msg, io.Discard, "sess", "sess", MCPProxyOpts{
+		Scanner:         sc,
+		ReceiptEmitter:  receiptEmitter,
+		RequireReceipts: true,
+		Transport:       "mcp_http",
+	})
+	if decision.Blocked == nil {
+		t.Fatal("expected require_receipts to block failed receipt emission")
+	}
+	if decision.Blocked.ErrorCode != -32007 {
+		t.Fatalf("error code = %d, want -32007", decision.Blocked.ErrorCode)
+	}
+	if !strings.Contains(string(decision.Blocked.ErrorData), string(blockreason.ReceiptEmissionFailed)) {
+		t.Fatalf("error data = %s, want %s", decision.Blocked.ErrorData, blockreason.ReceiptEmissionFailed)
+	}
+}
+
 func TestScanHTTPInputDecision_ReceiptBackfillWhenInputScanningDisabledAndBlocked(t *testing.T) {
 	sc := testScannerForHTTP(t)
 	msg := []byte(`{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"expensive_tool","arguments":{"path":"/tmp/readme.md"}}}`)

--- a/internal/mcp/receipt_attribution_test.go
+++ b/internal/mcp/receipt_attribution_test.go
@@ -243,7 +243,7 @@ func TestRedactionBlockAttribution(t *testing.T) {
 
 func TestEmitMCPToolReceiptIncludesAttribution(t *testing.T) {
 	emitter, _, dir, _ := newReceiptTestHarness(t)
-	emitMCPToolReceipt(mcpToolReceiptOpts{
+	_ = emitMCPToolReceipt(mcpToolReceiptOpts{
 		Emitter:   emitter,
 		Transport: transportMCPStdio,
 		ActionID:  "mcp-tool-attribution-1",
@@ -293,7 +293,7 @@ func TestEmitMCPToolReceiptLogsV2EmitError(t *testing.T) {
 	}
 
 	var log bytes.Buffer
-	emitMCPToolReceipt(mcpToolReceiptOpts{
+	_ = emitMCPToolReceipt(mcpToolReceiptOpts{
 		Emitter:    emitter,
 		V2Emitter:  v2,
 		Log:        &log,

--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -280,6 +280,7 @@ type mcpToolReceiptOpts struct {
 	Decision         taintDecision
 	Report           *redact.Report
 	ContractGate     *mcpContractGateOutput
+	RequireReceipt   bool
 }
 
 // emitMCPToolReceipt emits the post-decision tool receipt for an MCP
@@ -287,9 +288,9 @@ type mcpToolReceiptOpts struct {
 // transport, scanner attribution, and the full taint snapshot. Routed
 // through EmitMCPDecision so every tool receipt in the MCP inbound
 // pipeline goes through a single emission entry point.
-func emitMCPToolReceipt(opts mcpToolReceiptOpts) {
-	if opts.ActionID == "" || opts.Emitter == nil {
-		return
+func emitMCPToolReceipt(opts mcpToolReceiptOpts) error {
+	if opts.ActionID == "" {
+		return nil
 	}
 	emitOpts := receipt.EmitOpts{
 		ActionID:            opts.ActionID,
@@ -318,10 +319,23 @@ func emitMCPToolReceipt(opts mcpToolReceiptOpts) {
 		emitOpts = mcpWithContractReceipt(emitOpts, *opts.ContractGate)
 	}
 	if _, err := EmitMCPDecision(opts.Emitter, opts.V2Emitter, nil, MCPDecision{
-		Receipt: emitOpts,
-	}); err != nil && opts.Log != nil {
-		_, _ = fmt.Fprintf(opts.Log, "pipelock: receipt emission failed: %v\n", err)
+		Receipt:        emitOpts,
+		RequireReceipt: opts.RequireReceipt,
+	}); err != nil {
+		if opts.Log != nil {
+			_, _ = fmt.Fprintf(opts.Log, "pipelock: receipt emission failed: %v\n", err)
+		}
+		// Only a failure of the authoritative v1 action receipt under
+		// RequireReceipt escalates to a block (ErrReceiptRequired). A
+		// best-effort emit failure (require off) or a v2-only failure
+		// stays non-blocking, preserving the default warn-and-forward
+		// posture and matching the forward proxy, which fails closed on
+		// v1 emission only.
+		if errors.Is(err, ErrReceiptRequired) {
+			return err
+		}
 	}
+	return nil
 }
 
 // pickAttribution derives the receipt Layer / Pattern / Severity for a

--- a/internal/proxy/fetch_require_receipts_test.go
+++ b/internal/proxy/fetch_require_receipts_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+// fetchRequireReceiptsProxy builds a fetch-capable proxy with a receipt
+// emitter whose recorder is already closed (every emit fails), so the test
+// exercises the emit-failure branch deterministically.
+func fetchRequireReceiptsProxy(t *testing.T, require bool) *Proxy {
+	t.Helper()
+	cfg := testScannerConfig()
+	cfg.Internal = nil // disable SSRF so the loopback upstream is reachable
+	cfg.ResponseScanning.Enabled = false
+	cfg.FlightRecorder.RequireReceipts = require
+
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+	p, err := New(cfg, audit.NewNop(), sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	rph := newReceiptProxyHelper(t)
+	if err := rph.rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	p.receiptEmitterPtr.Store(rph.emitter)
+	return p
+}
+
+func fetchRequireReceiptsLiveProxy(t *testing.T, cfgMod func(*config.Config)) (*Proxy, *receiptProxyHelper) {
+	t.Helper()
+	cfg := testScannerConfig()
+	cfg.Internal = nil
+	cfg.FlightRecorder.RequireReceipts = true
+	if cfgMod != nil {
+		cfgMod(cfg)
+	}
+
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+	p, err := New(cfg, audit.NewNop(), sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	rph := newReceiptProxyHelper(t)
+	p.receiptEmitterPtr.Store(rph.emitter)
+	return p, rph
+}
+
+// TestHandleFetch_RequireReceiptsBlocksEmissionFailure proves fetch transport
+// parity: with require_receipts on, a failed allow-receipt emission blocks the
+// fetch BEFORE egress (0 upstream hits) with the receipt_emission_failed
+// reason — matching forward / CONNECT / WebSocket / MCP.
+func TestHandleFetch_RequireReceiptsBlocksEmissionFailure(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	p := fetchRequireReceiptsProxy(t, true)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url="+upstream.URL, nil)
+	rec := httptest.NewRecorder()
+	p.handleFetch(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	if got := rec.Header().Get(blockreason.HeaderReason); got != string(blockreason.ReceiptEmissionFailed) {
+		t.Fatalf("block reason header = %q, want %s", got, blockreason.ReceiptEmissionFailed)
+	}
+	var resp FetchResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode FetchResponse: %v", err)
+	}
+	if !resp.Blocked {
+		t.Fatalf("FetchResponse.Blocked = false, want true: %+v", resp)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0 (must block before egress)", got)
+	}
+}
+
+// TestHandleFetch_ReceiptFailureWithoutRequireStillForwards pins the default:
+// with require_receipts off, a receipt-emit failure stays best-effort and the
+// fetch still egresses and returns 200.
+func TestHandleFetch_ReceiptFailureWithoutRequireStillForwards(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	p := fetchRequireReceiptsProxy(t, false)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url="+upstream.URL, nil)
+	rec := httptest.NewRecorder()
+	p.handleFetch(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", rec.Code, rec.Body.String())
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream hits = %d, want 1", got)
+	}
+}
+
+func TestHandleFetch_RequireReceiptsResponseBlockReusesActionID(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write([]byte("compressed bytes"))
+	}))
+	defer upstream.Close()
+
+	p, rph := fetchRequireReceiptsLiveProxy(t, func(cfg *config.Config) {
+		cfg.ResponseScanning.Enabled = false
+	})
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url="+upstream.URL, nil)
+	rec := httptest.NewRecorder()
+	p.handleFetch(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get(blockreason.HeaderReason); got != string(blockreason.CompressedResponse) {
+		t.Fatalf("block reason header = %q, want %s", got, blockreason.CompressedResponse)
+	}
+	if err := rph.rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	var actionReceipts []receipt.Receipt
+	for _, entry := range readAllEntries(t, rph.dir) {
+		if entry.Type != receiptEntryType {
+			continue
+		}
+		detail, err := json.Marshal(entry.Detail)
+		if err != nil {
+			t.Fatalf("json.Marshal detail: %v", err)
+		}
+		rcpt, err := receipt.Unmarshal(detail)
+		if err != nil {
+			t.Fatalf("receipt.Unmarshal: %v", err)
+		}
+		actionReceipts = append(actionReceipts, rcpt)
+	}
+	if len(actionReceipts) != 2 {
+		t.Fatalf("action receipt count = %d, want 2", len(actionReceipts))
+	}
+	if actionReceipts[0].ActionRecord.Verdict != config.ActionAllow {
+		t.Fatalf("first verdict = %q, want allow", actionReceipts[0].ActionRecord.Verdict)
+	}
+	if actionReceipts[1].ActionRecord.Verdict != config.ActionBlock {
+		t.Fatalf("second verdict = %q, want block", actionReceipts[1].ActionRecord.Verdict)
+	}
+	if actionReceipts[0].ActionRecord.ActionID != actionReceipts[1].ActionRecord.ActionID {
+		t.Fatalf("action IDs differ: allow=%s block=%s",
+			actionReceipts[0].ActionRecord.ActionID, actionReceipts[1].ActionRecord.ActionID)
+	}
+}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1656,6 +1656,11 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	emitForwardAllowReceipt := func() {
+		if !cfg.FlightRecorder.RequireReceipts {
+			emitForwardReceipt(forwardAllowReceipt)
+		}
+	}
 
 	resp, err := p.client.Do(outReq)
 	if err != nil {
@@ -1848,24 +1853,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			duration := time.Since(start)
 			p.metrics.RecordAllowed(duration, agentLabel)
-			emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{
-				ActionID:            actionID,
-				Verdict:             config.ActionAllow,
-				Transport:           "forward",
-				Method:              r.Method,
-				Target:              targetURL,
-				RequestID:           requestID,
-				Agent:               agent,
-				SessionTaintLevel:   forwardTaint.Risk.Level.String(),
-				SessionContaminated: forwardTaint.Risk.Contaminated,
-				RecentTaintSources:  forwardTaint.Risk.Sources,
-				SessionTaskID:       forwardTaint.Task.CurrentTaskID,
-				SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
-				AuthorityKind:       forwardTaint.Authority.String(),
-				TaintDecision:       forwardTaint.Result.Decision.String(),
-				TaintDecisionReason: forwardTaint.Result.Reason,
-				TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
-			}))
+			emitForwardAllowReceipt()
 			p.logger.LogForwardHTTP(actx, resp.StatusCode, 0, duration)
 			if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
 				recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), cfg.AdaptiveEnforcement.DecayPerCleanRequest)
@@ -1994,24 +1982,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 					_ = resolved.Budget.RecordBytes(totalWritten)
 					duration := time.Since(start)
 					p.metrics.RecordAllowed(duration, agentLabel)
-					emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{
-						ActionID:            actionID,
-						Verdict:             config.ActionAllow,
-						Transport:           "forward",
-						Method:              r.Method,
-						Target:              targetURL,
-						RequestID:           requestID,
-						Agent:               agent,
-						SessionTaintLevel:   forwardTaint.Risk.Level.String(),
-						SessionContaminated: forwardTaint.Risk.Contaminated,
-						RecentTaintSources:  forwardTaint.Risk.Sources,
-						SessionTaskID:       forwardTaint.Task.CurrentTaskID,
-						SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
-						AuthorityKind:       forwardTaint.Authority.String(),
-						TaintDecision:       forwardTaint.Result.Decision.String(),
-						TaintDecisionReason: forwardTaint.Result.Reason,
-						TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
-					}))
+					emitForwardAllowReceipt()
 					p.logger.LogForwardHTTP(actx, resp.StatusCode, int(totalWritten), duration)
 					if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
 						forwardRec.RecordClean(cfg.AdaptiveEnforcement.DecayPerCleanRequest)
@@ -2308,24 +2279,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 
 		duration := time.Since(start)
 		p.metrics.RecordAllowed(duration, agentLabel)
-		emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{
-			ActionID:            actionID,
-			Verdict:             config.ActionAllow,
-			Transport:           "forward",
-			Method:              r.Method,
-			Target:              targetURL,
-			RequestID:           requestID,
-			Agent:               agent,
-			SessionTaintLevel:   forwardTaint.Risk.Level.String(),
-			SessionContaminated: forwardTaint.Risk.Contaminated,
-			RecentTaintSources:  forwardTaint.Risk.Sources,
-			SessionTaskID:       forwardTaint.Task.CurrentTaskID,
-			SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
-			AuthorityKind:       forwardTaint.Authority.String(),
-			TaintDecision:       forwardTaint.Result.Decision.String(),
-			TaintDecisionReason: forwardTaint.Result.Reason,
-			TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
-		}))
+		emitForwardAllowReceipt()
 		p.logger.LogForwardHTTP(actx, resp.StatusCode, int(written), duration)
 		if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
 			recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), cfg.AdaptiveEnforcement.DecayPerCleanRequest)
@@ -2359,9 +2313,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 
 	duration := time.Since(start)
 	p.metrics.RecordAllowed(duration, agentLabel)
-	if !cfg.FlightRecorder.RequireReceipts {
-		emitForwardReceipt(forwardAllowReceipt)
-	}
+	emitForwardAllowReceipt()
 	p.logger.LogForwardHTTP(actx, resp.StatusCode, int(written), duration)
 	if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
 		recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), cfg.AdaptiveEnforcement.DecayPerCleanRequest)

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -90,7 +90,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// Pre-generate a single ActionID for correlation between envelope and receipt.
 	actionID := receipt.NewActionID()
 	emitConnectReceipt := func(opts receipt.EmitOpts) {
-		p.emitReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
+		_ = p.emitReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
 	}
 
 	if err := p.verifyInboundEnvelope(r, cfg); err != nil {
@@ -526,6 +526,30 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	allowReceipt := receipt.EmitOpts{
+		ActionID:  actionID,
+		Verdict:   config.ActionAllow,
+		Transport: "connect",
+		Method:    http.MethodConnect,
+		Target:    syntheticURL,
+		RequestID: requestID,
+		Agent:     agent,
+	}
+	if connectGate.HasContractContext() {
+		allowReceipt = withContractReceipt(connectGate, allowReceipt)
+	}
+	if cfg.FlightRecorder.RequireReceipts {
+		if err := p.emitRequiredReceipt(withReceiptPolicyHash(allowReceipt, cfg.CanonicalPolicyHash())); err != nil {
+			blockedErr := newReceiptEmissionBlockedRequest(err)
+			p.logger.LogBlocked(targetCtx, blockedErr.layer, blockedErr.detail)
+			p.metrics.RecordTunnelBlocked(agentLabel)
+			writeBlockedError(w,
+				blockInfoFor(blockreason.ReceiptEmissionFailed, blockedErr.layer),
+				"CONNECT blocked: "+blockedErr.reason, http.StatusForbidden)
+			return
+		}
+	}
+
 	// Bound the outbound dial, then let the established tunnel live until it
 	// goes idle. Long-poll, SSE, and WebSocket control-plane streams must not
 	// be cut by a fixed wall-clock lifetime while bytes are still flowing.
@@ -673,19 +697,9 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	p.metrics.RecordTunnel(duration, totalBytes, agentLabel)
 	// Count successful tunnels in request totals so /stats reflects CONNECT traffic.
 	p.metrics.RecordAllowed(duration, agentLabel)
-	allowReceipt := receipt.EmitOpts{
-		ActionID:  actionID,
-		Verdict:   config.ActionAllow,
-		Transport: "connect",
-		Method:    http.MethodConnect,
-		Target:    syntheticURL,
-		RequestID: requestID,
-		Agent:     agent,
+	if !cfg.FlightRecorder.RequireReceipts {
+		emitConnectReceipt(allowReceipt)
 	}
-	if connectGate.HasContractContext() {
-		allowReceipt = withContractReceipt(connectGate, allowReceipt)
-	}
-	emitConnectReceipt(allowReceipt)
 	p.logger.LogTunnelClose(targetCtx, totalBytes, duration)
 
 	// Record data budget for the target domain
@@ -721,7 +735,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		agent = agentAnonymous
 	}
 	emitForwardReceipt := func(opts receipt.EmitOpts) {
-		p.emitReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
+		_ = p.emitReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
 	}
 	if err := p.verifyInboundEnvelope(r, cfg); err != nil {
 		pattern := inboundEnvelopeFailurePattern(err)
@@ -1610,6 +1624,39 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	forwardAllowReceipt := withForwardRedaction(receipt.EmitOpts{
+		ActionID:            actionID,
+		Verdict:             config.ActionAllow,
+		Transport:           "forward",
+		Method:              r.Method,
+		Target:              targetURL,
+		RequestID:           requestID,
+		Agent:               agent,
+		SessionTaintLevel:   forwardTaint.Risk.Level.String(),
+		SessionContaminated: forwardTaint.Risk.Contaminated,
+		RecentTaintSources:  forwardTaint.Risk.Sources,
+		SessionTaskID:       forwardTaint.Task.CurrentTaskID,
+		SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
+		AuthorityKind:       forwardTaint.Authority.String(),
+		TaintDecision:       forwardTaint.Result.Decision.String(),
+		TaintDecisionReason: forwardTaint.Result.Reason,
+		TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
+	})
+	if forwardGate.HasContractContext() {
+		forwardAllowReceipt = withContractReceipt(forwardGate, forwardAllowReceipt)
+	}
+	if cfg.FlightRecorder.RequireReceipts {
+		if err := p.emitRequiredReceipt(withReceiptPolicyHash(forwardAllowReceipt, cfg.CanonicalPolicyHash())); err != nil {
+			blockedErr := newReceiptEmissionBlockedRequest(err)
+			p.logger.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
+			p.metrics.RecordBlocked(r.URL.Hostname(), blockedErr.layer, time.Since(start), agentLabel)
+			writeBlockedError(w,
+				blockInfoFor(blockreason.ReceiptEmissionFailed, blockedErr.layer),
+				"blocked: "+blockedErr.reason, http.StatusForbidden)
+			return
+		}
+	}
+
 	resp, err := p.client.Do(outReq)
 	if err != nil {
 		if blockedErr, ok := blockedRequestErrorFrom(err); ok {
@@ -1873,24 +1920,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			EffectiveAction:   config.ActionAllow,
 			Outcome:           captureOutcome(config.ActionAllow, true),
 		})
-		emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{
-			ActionID:            actionID,
-			Verdict:             config.ActionAllow,
-			Transport:           "forward",
-			Method:              r.Method,
-			Target:              targetURL,
-			RequestID:           requestID,
-			Agent:               agent,
-			SessionTaintLevel:   forwardTaint.Risk.Level.String(),
-			SessionContaminated: forwardTaint.Risk.Contaminated,
-			RecentTaintSources:  forwardTaint.Risk.Sources,
-			SessionTaskID:       forwardTaint.Task.CurrentTaskID,
-			SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
-			AuthorityKind:       forwardTaint.Authority.String(),
-			TaintDecision:       forwardTaint.Result.Decision.String(),
-			TaintDecisionReason: forwardTaint.Result.Reason,
-			TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
-		}))
+		if !cfg.FlightRecorder.RequireReceipts {
+			emitForwardReceipt(forwardAllowReceipt)
+		}
 		p.logger.LogForwardHTTP(actx, resp.StatusCode, int(written), duration)
 		if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
 			recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), cfg.AdaptiveEnforcement.DecayPerCleanRequest)
@@ -2327,24 +2359,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 
 	duration := time.Since(start)
 	p.metrics.RecordAllowed(duration, agentLabel)
-	emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{
-		ActionID:            actionID,
-		Verdict:             config.ActionAllow,
-		Transport:           "forward",
-		Method:              r.Method,
-		Target:              targetURL,
-		RequestID:           requestID,
-		Agent:               agent,
-		SessionTaintLevel:   forwardTaint.Risk.Level.String(),
-		SessionContaminated: forwardTaint.Risk.Contaminated,
-		RecentTaintSources:  forwardTaint.Risk.Sources,
-		SessionTaskID:       forwardTaint.Task.CurrentTaskID,
-		SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
-		AuthorityKind:       forwardTaint.Authority.String(),
-		TaintDecision:       forwardTaint.Result.Decision.String(),
-		TaintDecisionReason: forwardTaint.Result.Reason,
-		TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
-	}))
+	if !cfg.FlightRecorder.RequireReceipts {
+		emitForwardReceipt(forwardAllowReceipt)
+	}
 	p.logger.LogForwardHTTP(actx, resp.StatusCode, int(written), duration)
 	if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
 		recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), cfg.AdaptiveEnforcement.DecayPerCleanRequest)

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -542,6 +542,67 @@ func proxyClient(proxyAddr string) *http.Client {
 	}
 }
 
+func TestForwardProxy_RequireReceiptsBlocksEmissionFailure(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+		cfg.ResponseScanning.Enabled = false
+	})
+	defer cleanup()
+	rph := newReceiptProxyHelper(t)
+	if err := rph.rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	resp := doGet(t, forwardHTTPClient(t, proxyAddr), upstream.URL)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.ReceiptEmissionFailed) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.ReceiptEmissionFailed)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0", got)
+	}
+}
+
+func TestForwardProxy_ReceiptFailureWithoutRequireStillForwards(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = false
+		cfg.ResponseScanning.Enabled = false
+	})
+	defer cleanup()
+	rph := newReceiptProxyHelper(t)
+	if err := rph.rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	resp := doGet(t, forwardHTTPClient(t, proxyAddr), upstream.URL)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream hits = %d, want 1", got)
+	}
+}
+
 // TestForwardProxy_ResponseScanCapOverrunBlocks proves the forward proxy blocks
 // a response that exceeds the configured scan cap instead of forwarding a
 // silently-truncated prefix as an apparently-successful, scanned response. This

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -603,6 +603,40 @@ func TestForwardProxy_ReceiptFailureWithoutRequireStillForwards(t *testing.T) {
 	}
 }
 
+func TestForwardProxy_RequireReceiptsSuccessEmitsSingleAllow(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+		cfg.ResponseScanning.Enabled = false
+	})
+	defer cleanup()
+	rph := newReceiptProxyHelper(t)
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	resp := doGet(t, forwardHTTPClient(t, proxyAddr), upstream.URL)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream hits = %d, want 1", got)
+	}
+
+	receipts := rph.findReceipts(t)
+	if len(receipts) != 1 {
+		t.Fatalf("receipt count = %d, want exactly one pre-egress allow receipt", len(receipts))
+	}
+	if receipts[0].ActionRecord.Verdict != config.ActionAllow {
+		t.Fatalf("receipt verdict = %q, want allow", receipts[0].ActionRecord.Verdict)
+	}
+}
+
 // TestForwardProxy_ResponseScanCapOverrunBlocks proves the forward proxy blocks
 // a response that exceeds the configured scan cap instead of forwarding a
 // silently-truncated prefix as an apparently-successful, scanned response. This

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -981,27 +981,36 @@ func (p *Proxy) emitReceipt(opts receipt.EmitOpts) error {
 	if cfg := p.cfgPtr.Load(); cfg != nil {
 		opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
 	}
-	if e := p.receiptEmitterPtr.Load(); e != nil {
-		if err := e.Emit(opts); err != nil {
-			p.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
-				fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s target=%s agent=%s: %w",
-					opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
-					opts.Transport, opts.Method, opts.Target, opts.Agent, err))
-			// v1 stays authoritative: skip v2 when v1 failed to record, so a
-			// proxy_decision never outlives its action_receipt sibling.
-			return err
-		}
-		// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
-		p.emitV2Receipt(opts)
-	}
-	return nil
+	return p.emitReceiptWithEmitter(opts, p.receiptEmitterPtr.Load())
 }
 
 func (p *Proxy) emitRequiredReceipt(opts receipt.EmitOpts) error {
-	if p.receiptEmitterPtr.Load() == nil {
+	if cfg := p.cfgPtr.Load(); cfg != nil {
+		opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
+	}
+	e := p.receiptEmitterPtr.Load()
+	if e == nil {
 		return fmt.Errorf("receipt emitter unavailable")
 	}
-	return p.emitReceipt(opts)
+	return p.emitReceiptWithEmitter(opts, e)
+}
+
+func (p *Proxy) emitReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter) error {
+	if e == nil {
+		return nil
+	}
+	if err := e.Emit(opts); err != nil {
+		p.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
+			fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s target=%s agent=%s: %w",
+				opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
+				opts.Transport, opts.Method, opts.Target, opts.Agent, err))
+		// v1 stays authoritative: skip v2 when v1 failed to record, so a
+		// proxy_decision never outlives its action_receipt sibling.
+		return err
+	}
+	// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
+	p.emitV2Receipt(opts)
+	return nil
 }
 
 // receiptEmitterStage is the staged result of a receipt-emitter reload.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -140,6 +140,8 @@ var requestCounter atomic.Uint64
 const (
 	blockLayerMediationEnvelope  = "mediation_envelope"
 	mediationEnvelopeBlockReason = "mediation envelope signing failed"
+	blockLayerReceiptEmission    = "receipt_emission"
+	receiptEmissionBlockReason   = "receipt emission failed"
 )
 
 // blockedRequestError signals a fail-closed block in a request path that still
@@ -208,6 +210,14 @@ func newRedirectEnvelopeBlockedRequest(err error) *blockedRequestError {
 		blockLayerMediationEnvelope,
 		reason,
 		reason+": "+err.Error(),
+	)
+}
+
+func newReceiptEmissionBlockedRequest(err error) *blockedRequestError {
+	return newBlockedRequestError(
+		blockLayerReceiptEmission,
+		receiptEmissionBlockReason,
+		receiptEmissionBlockReason+": "+err.Error(),
 	)
 }
 
@@ -667,7 +677,9 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 				RequestID:   requestID,
 				Agent:       agentName,
 				AuditCtx:    newHTTPAuditContext(logger, req.Method, redirectURL, clientIP, requestID, agentName),
-				Emit:        p.emitReceipt,
+				Emit: func(opts receipt.EmitOpts) {
+					_ = p.emitReceipt(opts)
+				},
 			}); rpRes.Block {
 				return newRedirectBlockedRequest(blockLayerRequestPolicy, rpRes.Reason)
 			}
@@ -965,7 +977,7 @@ func (p *Proxy) recordDecision(verdict, layer, pattern, transport, requestID str
 // operator reconstructing the enforcement decision after a missing-receipt
 // incident can correlate the audit log entry to the action that was
 // supposed to be attested.
-func (p *Proxy) emitReceipt(opts receipt.EmitOpts) {
+func (p *Proxy) emitReceipt(opts receipt.EmitOpts) error {
 	if cfg := p.cfgPtr.Load(); cfg != nil {
 		opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
 	}
@@ -977,11 +989,19 @@ func (p *Proxy) emitReceipt(opts receipt.EmitOpts) {
 					opts.Transport, opts.Method, opts.Target, opts.Agent, err))
 			// v1 stays authoritative: skip v2 when v1 failed to record, so a
 			// proxy_decision never outlives its action_receipt sibling.
-			return
+			return err
 		}
 		// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
 		p.emitV2Receipt(opts)
 	}
+	return nil
+}
+
+func (p *Proxy) emitRequiredReceipt(opts receipt.EmitOpts) error {
+	if p.receiptEmitterPtr.Load() == nil {
+		return fmt.Errorf("receipt emitter unavailable")
+	}
+	return p.emitReceipt(opts)
 }
 
 // receiptEmitterStage is the staged result of a receipt-emitter reload.
@@ -1046,16 +1066,22 @@ func (p *Proxy) buildReceiptEmitter(cfg *config.Config) (receiptEmitterStage, er
 	// (e.g. key rotation). Cross-restart the chain restarts at genesis; the
 	// recorder's outer hash chain provides tamper-evidence across restarts.
 	resumeSeq, resumePrev := p.v2EmitterPtr.Load().ChainState()
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   p.recorder,
+		PrivKey:    privKey,
+		ConfigHash: cfg.Hash(),
+		Principal:  "local",
+		Actor:      "pipelock",
+		Metrics:    p.metrics,
+	})
+	if emitter != nil {
+		if initErr := emitter.InitError(); initErr != nil {
+			return receiptEmitterStage{}, fmt.Errorf("resuming receipt chain: %w", initErr)
+		}
+	}
 
 	return receiptEmitterStage{
-		emitter: receipt.NewEmitter(receipt.EmitterConfig{
-			Recorder:   p.recorder,
-			PrivKey:    privKey,
-			ConfigHash: cfg.Hash(),
-			Principal:  "local",
-			Actor:      "pipelock",
-			Metrics:    p.metrics,
-		}),
+		emitter: emitter,
 		v2: proxydecision.NewEmitter(proxydecision.EmitterConfig{
 			Recorder:       p.recorder,
 			Signer:         proxydecision.NewKeyedSigner(privKey),
@@ -2578,7 +2604,7 @@ func (p *Proxy) recordShieldIntervention(summary *receipt.ShieldSummary, cfg *co
 		target = hostname
 	}
 	target = shieldReceiptTarget(target)
-	p.emitReceipt(receipt.EmitOpts{
+	_ = p.emitReceipt(receipt.EmitOpts{
 		ActionID:       receipt.NewActionID(),
 		ParentActionID: parentActionID,
 		Verdict:        config.ActionAllow,
@@ -2843,7 +2869,7 @@ func (p *Proxy) buildHandler(mux *http.ServeMux) http.Handler {
 					// so emit a forward receipt here to keep the
 					// audit chain unbroken.
 					requestID, _ := r.Context().Value(ctxKeyRequestID).(string)
-					p.emitReceipt(forwardKillSwitchReceiptOpts(
+					_ = p.emitReceipt(forwardKillSwitchReceiptOpts(
 						receipt.NewActionID(),
 						requestID,
 						r.Method,
@@ -3084,7 +3110,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		agent = agentAnonymous
 	}
 	emitFetchReceipt := func(opts receipt.EmitOpts) {
-		p.emitReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
+		_ = p.emitReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
 	}
 	if err := p.verifyInboundEnvelope(r, cfg); err != nil {
 		pattern := inboundEnvelopeFailurePattern(err)
@@ -3886,6 +3912,49 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Build the allow receipt once, before egress, so require_receipts can
+	// fail closed BEFORE the fetch leaves the proxy (parity with forward /
+	// CONNECT / WebSocket / MCP). Every field here is request-side, so the
+	// pre-egress receipt is identical to the terminal one below; the terminal
+	// emit is skipped when require_receipts is on to avoid a duplicate.
+	fetchAllowReceipt := receipt.EmitOpts{
+		ActionID:            actionID,
+		Verdict:             config.ActionAllow,
+		Transport:           "fetch",
+		Method:              http.MethodGet,
+		Target:              displayURL,
+		RequestID:           requestID,
+		Agent:               agent,
+		SessionTaintLevel:   fetchTaint.Risk.Level.String(),
+		SessionContaminated: fetchTaint.Risk.Contaminated,
+		RecentTaintSources:  fetchTaint.Risk.Sources,
+		SessionTaskID:       fetchTaint.Task.CurrentTaskID,
+		SessionTaskLabel:    fetchTaint.Task.CurrentTaskLabel,
+		AuthorityKind:       fetchTaint.Authority.String(),
+		TaintDecision:       fetchTaint.Result.Decision.String(),
+		TaintDecisionReason: fetchTaint.Result.Reason,
+		TaskOverrideApplied: fetchTaint.TaskOverrideApplied,
+	}
+	if fetchGate.HasContractContext() {
+		fetchAllowReceipt = withContractReceipt(fetchGate, fetchAllowReceipt)
+	}
+	if cfg.FlightRecorder.RequireReceipts {
+		if rcptErr := p.emitRequiredReceipt(withReceiptPolicyHash(fetchAllowReceipt, cfg.CanonicalPolicyHash())); rcptErr != nil {
+			blockedErr := newReceiptEmissionBlockedRequest(rcptErr)
+			log.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
+			p.metrics.RecordBlocked(parsed.Hostname(), blockedErr.layer, time.Since(start), agentLabel)
+			writeBlockedJSON(w,
+				blockInfoFor(blockreason.ReceiptEmissionFailed, blockedErr.layer),
+				http.StatusForbidden, FetchResponse{
+					URL:         displayURL,
+					Agent:       agent,
+					Blocked:     true,
+					BlockReason: blockedErr.reason,
+				})
+			return
+		}
+	}
+
 	resp, err := p.client.Do(req) //nolint:gosec // G704: URL validated by scanner pipeline before reaching here
 	if err != nil {
 		// Detect fail-closed blocks from CheckRedirect and report them as blocked.
@@ -3998,7 +4067,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			log.LogBlocked(actx, "response_size", reason)
 			p.metrics.RecordBlocked(parsed.Hostname(), "response_size", time.Since(start), agentLabel)
 			emitFetchReceipt(receipt.EmitOpts{
-				ActionID:  receipt.NewActionID(),
+				ActionID:  actionID,
 				Verdict:   config.ActionBlock,
 				Layer:     "response_size",
 				Pattern:   reason,
@@ -4024,7 +4093,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		p.metrics.RecordBlocked(parsed.Hostname(), "budget", time.Since(start), agentLabel)
 		_ = resolved.Budget.RecordBytes(int64(len(body)))
 		emitFetchReceipt(receipt.EmitOpts{
-			ActionID:  receipt.NewActionID(),
+			ActionID:  actionID,
 			Verdict:   config.ActionBlock,
 			Layer:     "budget",
 			Pattern:   reason,
@@ -4059,7 +4128,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	if shieldBlocked {
 		p.metrics.RecordBlocked(parsed.Hostname(), "shield_oversize", time.Since(start), agentLabel)
 		emitFetchReceipt(receipt.EmitOpts{
-			ActionID:  receipt.NewActionID(),
+			ActionID:  actionID,
 			Verdict:   config.ActionBlock,
 			Layer:     "shield_oversize",
 			Pattern:   "response body exceeds browser shield size limit",
@@ -4134,7 +4203,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			rawResult := sc.ScanResponse(r.Context(), hidden)
 			// Use live escalation level so mid-request CEE escalations are reflected.
 			// Exempt domains: scan for visibility but pin to warn, no adaptive scoring.
-			blocked, _, found := p.filterAndActOnResponseScan(w, rawResult, content, displayURL, agent, clientIP, requestID, sc, cfg, log, recEscalationLevel(fetchRec), responseScanExempt)
+			blocked, _, found := p.filterAndActOnResponseScan(w, rawResult, content, displayURL, agent, clientIP, requestID, actionID, sc, cfg, log, recEscalationLevel(fetchRec), responseScanExempt)
 			if blocked {
 				return
 			}
@@ -4170,7 +4239,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		log.LogBlocked(actx, "response_scan", reason)
 		p.metrics.RecordBlocked(parsed.Hostname(), "response_scan", time.Since(start), agentLabel)
 		emitFetchReceipt(receipt.EmitOpts{
-			ActionID:  receipt.NewActionID(),
+			ActionID:  actionID,
 			Verdict:   config.ActionBlock,
 			Layer:     "response_scan",
 			Pattern:   reason,
@@ -4238,7 +4307,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 
 		// Use live escalation level so mid-request CEE escalations are reflected.
 		// Exempt domains: scan for visibility but pin to warn, no adaptive scoring.
-		blocked, newContent, found := p.filterAndActOnResponseScan(w, scanResult, content, displayURL, agent, clientIP, requestID, sc, cfg, log, recEscalationLevel(fetchRec), responseScanExempt)
+		blocked, newContent, found := p.filterAndActOnResponseScan(w, scanResult, content, displayURL, agent, clientIP, requestID, actionID, sc, cfg, log, recEscalationLevel(fetchRec), responseScanExempt)
 		if found {
 			hasFinding = true
 		}
@@ -4266,28 +4335,13 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 
 	duration := time.Since(start)
 	p.metrics.RecordAllowed(duration, agentLabel)
-	allowReceipt := receipt.EmitOpts{
-		ActionID:            actionID,
-		Verdict:             config.ActionAllow,
-		Transport:           "fetch",
-		Method:              http.MethodGet,
-		Target:              displayURL,
-		RequestID:           requestID,
-		Agent:               agent,
-		SessionTaintLevel:   fetchTaint.Risk.Level.String(),
-		SessionContaminated: fetchTaint.Risk.Contaminated,
-		RecentTaintSources:  fetchTaint.Risk.Sources,
-		SessionTaskID:       fetchTaint.Task.CurrentTaskID,
-		SessionTaskLabel:    fetchTaint.Task.CurrentTaskLabel,
-		AuthorityKind:       fetchTaint.Authority.String(),
-		TaintDecision:       fetchTaint.Result.Decision.String(),
-		TaintDecisionReason: fetchTaint.Result.Reason,
-		TaskOverrideApplied: fetchTaint.TaskOverrideApplied,
+	// fetchAllowReceipt was built (and, under require_receipts, already
+	// emitted before egress) above. Emit it here only in the best-effort
+	// path; require_receipts mode has the pre-egress emit as its single
+	// authoritative allow receipt.
+	if !cfg.FlightRecorder.RequireReceipts {
+		emitFetchReceipt(fetchAllowReceipt)
 	}
-	if fetchGate.HasContractContext() {
-		allowReceipt = withContractReceipt(fetchGate, allowReceipt)
-	}
-	emitFetchReceipt(allowReceipt)
 	log.LogAllowed(actx, resp.StatusCode, len(body), duration)
 
 	writeJSON(w, http.StatusOK, FetchResponse{
@@ -4312,7 +4366,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 func (p *Proxy) filterAndActOnResponseScan(
 	w http.ResponseWriter,
 	result scanner.ResponseScanResult,
-	content, displayURL, agent, clientIP, requestID string,
+	content, displayURL, agent, clientIP, requestID, actionID string,
 	sc *scanner.Scanner,
 	cfg *config.Config,
 	log *audit.Logger,
@@ -4321,7 +4375,7 @@ func (p *Proxy) filterAndActOnResponseScan(
 ) (blocked bool, out string, found bool) {
 	out = content
 	emitResponseReceipt := func(opts receipt.EmitOpts) {
-		p.emitReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
+		_ = p.emitReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
 	}
 
 	// Suppress filter: serves both the main response scan path (where the caller's
@@ -4399,7 +4453,7 @@ func (p *Proxy) filterAndActOnResponseScan(
 		reason := fmt.Sprintf("response contains prompt injection: %s", strings.Join(patternNames, ", "))
 		log.LogBlocked(newHTTPAuditContext(p.logger, http.MethodGet, displayURL, clientIP, requestID, agent), "response_scan", reason)
 		emitResponseReceipt(receipt.EmitOpts{
-			ActionID:  receipt.NewActionID(),
+			ActionID:  actionID,
 			Verdict:   config.ActionBlock,
 			Layer:     "response_scan",
 			Pattern:   reason,
@@ -4420,7 +4474,7 @@ func (p *Proxy) filterAndActOnResponseScan(
 			reason := fmt.Sprintf("response contains prompt injection: %s (no HITL approver)", strings.Join(patternNames, ", "))
 			log.LogBlocked(newHTTPAuditContext(p.logger, http.MethodGet, displayURL, clientIP, requestID, agent), "response_scan", reason)
 			emitResponseReceipt(receipt.EmitOpts{
-				ActionID:  receipt.NewActionID(),
+				ActionID:  actionID,
 				Verdict:   config.ActionBlock,
 				Layer:     "response_scan",
 				Pattern:   reason,
@@ -4458,7 +4512,7 @@ func (p *Proxy) filterAndActOnResponseScan(
 			reason := fmt.Sprintf("response blocked by operator: %s", strings.Join(patternNames, ", "))
 			log.LogBlocked(newHTTPAuditContext(p.logger, http.MethodGet, displayURL, clientIP, requestID, agent), "response_scan", reason)
 			emitResponseReceipt(receipt.EmitOpts{
-				ActionID:  receipt.NewActionID(),
+				ActionID:  actionID,
 				Verdict:   config.ActionBlock,
 				Layer:     "response_scan",
 				Pattern:   reason,

--- a/internal/proxy/v2receipt_test.go
+++ b/internal/proxy/v2receipt_test.go
@@ -276,7 +276,7 @@ func (f *dualEmitFixture) v2Receipt(t *testing.T) contractreceipt.EvidenceReceip
 
 func TestDualEmit_ProducesVerifiableV2AlongsideV1(t *testing.T) {
 	f := newDualEmitFixture(t, false)
-	f.p.emitReceipt(receipt.EmitOpts{
+	_ = f.p.emitReceipt(receipt.EmitOpts{
 		ActionID: "a1", Transport: TransportForward, Method: "GET",
 		Target: "https://api.vendor.example/v1/x", Verdict: "block",
 		Layer: "dlp", Pattern: "prompt_injection", RequestID: "r1",
@@ -306,7 +306,7 @@ func TestDualEmit_ProducesVerifiableV2AlongsideV1(t *testing.T) {
 func TestDualEmit_SanitizesV2TargetWithRedaction(t *testing.T) {
 	const secret = "AKIA" + "IOSFODNN7EXAMPLE"
 	f := newDualEmitFixture(t, true)
-	f.p.emitReceipt(receipt.EmitOpts{
+	_ = f.p.emitReceipt(receipt.EmitOpts{
 		ActionID: "a1", Transport: TransportForward, Method: "GET",
 		Target: "https://api.vendor.example/v1/x?key=" + secret, Verdict: "block",
 		Layer: "dlp", Pattern: "aws_access_key", RequestID: "r1",
@@ -340,7 +340,7 @@ func TestDualEmit_DisabledWhenNoV2Emitter(t *testing.T) {
 	}
 	t.Cleanup(p.Close)
 
-	p.emitReceipt(receipt.EmitOpts{
+	_ = p.emitReceipt(receipt.EmitOpts{
 		ActionID: "a1", Transport: TransportFetch, Method: "GET",
 		Target: "https://x.example/a", Verdict: "allow", RequestID: "r1",
 	})
@@ -397,7 +397,7 @@ func TestDualEmit_HotReloadPreservesV2Chain(t *testing.T) {
 		ActionID: "a1", Transport: TransportForward, Method: "GET",
 		Target: "https://x.example/a", Verdict: "allow", RequestID: "r1",
 	}
-	p.emitReceipt(opts) // v2 seq 0
+	_ = p.emitReceipt(opts) // v2 seq 0
 
 	// Hot reload with the same signing key; buildReceiptEmitter must carry the
 	// v2 chain head forward instead of resetting to genesis.
@@ -411,7 +411,7 @@ func TestDualEmit_HotReloadPreservesV2Chain(t *testing.T) {
 	if p.v2EmitterPtr.Load() == nil {
 		t.Fatal("v2 emitter nil after reload with signing key")
 	}
-	p.emitReceipt(opts) // v2 seq 1, chained to seq 0
+	_ = p.emitReceipt(opts) // v2 seq 1, chained to seq 0
 
 	if err := rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)
@@ -466,7 +466,7 @@ func TestDualEmit_V1FailureSkipsV2(t *testing.T) {
 	}
 
 	// This decision's v1 Emit fails (sealed); v2 must be skipped.
-	f.p.emitReceipt(receipt.EmitOpts{
+	_ = f.p.emitReceipt(receipt.EmitOpts{
 		ActionID: "a1", Transport: TransportForward, Method: "GET",
 		Target: "https://x.example/a", Verdict: "block",
 		Layer: "dlp", Pattern: "inj", RequestID: "r1",

--- a/internal/proxy/v2receipt_test.go
+++ b/internal/proxy/v2receipt_test.go
@@ -245,6 +245,13 @@ func newDualEmitFixture(t *testing.T, redact bool) *dualEmitFixture {
 	return &dualEmitFixture{p: p, rec: rec, dir: dir, pub: pub, kid: signer.KeyID()}
 }
 
+func mustEmitReceipt(t *testing.T, p *Proxy, opts receipt.EmitOpts) {
+	t.Helper()
+	if err := p.emitReceipt(opts); err != nil {
+		t.Fatalf("emitReceipt: %v", err)
+	}
+}
+
 func (f *dualEmitFixture) v2Receipt(t *testing.T) contractreceipt.EvidenceReceipt {
 	t.Helper()
 	if err := f.rec.Close(); err != nil {
@@ -276,7 +283,7 @@ func (f *dualEmitFixture) v2Receipt(t *testing.T) contractreceipt.EvidenceReceip
 
 func TestDualEmit_ProducesVerifiableV2AlongsideV1(t *testing.T) {
 	f := newDualEmitFixture(t, false)
-	_ = f.p.emitReceipt(receipt.EmitOpts{
+	mustEmitReceipt(t, f.p, receipt.EmitOpts{
 		ActionID: "a1", Transport: TransportForward, Method: "GET",
 		Target: "https://api.vendor.example/v1/x", Verdict: "block",
 		Layer: "dlp", Pattern: "prompt_injection", RequestID: "r1",
@@ -306,7 +313,7 @@ func TestDualEmit_ProducesVerifiableV2AlongsideV1(t *testing.T) {
 func TestDualEmit_SanitizesV2TargetWithRedaction(t *testing.T) {
 	const secret = "AKIA" + "IOSFODNN7EXAMPLE"
 	f := newDualEmitFixture(t, true)
-	_ = f.p.emitReceipt(receipt.EmitOpts{
+	mustEmitReceipt(t, f.p, receipt.EmitOpts{
 		ActionID: "a1", Transport: TransportForward, Method: "GET",
 		Target: "https://api.vendor.example/v1/x?key=" + secret, Verdict: "block",
 		Layer: "dlp", Pattern: "aws_access_key", RequestID: "r1",
@@ -340,7 +347,7 @@ func TestDualEmit_DisabledWhenNoV2Emitter(t *testing.T) {
 	}
 	t.Cleanup(p.Close)
 
-	_ = p.emitReceipt(receipt.EmitOpts{
+	mustEmitReceipt(t, p, receipt.EmitOpts{
 		ActionID: "a1", Transport: TransportFetch, Method: "GET",
 		Target: "https://x.example/a", Verdict: "allow", RequestID: "r1",
 	})
@@ -397,7 +404,7 @@ func TestDualEmit_HotReloadPreservesV2Chain(t *testing.T) {
 		ActionID: "a1", Transport: TransportForward, Method: "GET",
 		Target: "https://x.example/a", Verdict: "allow", RequestID: "r1",
 	}
-	_ = p.emitReceipt(opts) // v2 seq 0
+	mustEmitReceipt(t, p, opts) // v2 seq 0
 
 	// Hot reload with the same signing key; buildReceiptEmitter must carry the
 	// v2 chain head forward instead of resetting to genesis.
@@ -411,7 +418,7 @@ func TestDualEmit_HotReloadPreservesV2Chain(t *testing.T) {
 	if p.v2EmitterPtr.Load() == nil {
 		t.Fatal("v2 emitter nil after reload with signing key")
 	}
-	_ = p.emitReceipt(opts) // v2 seq 1, chained to seq 0
+	mustEmitReceipt(t, p, opts) // v2 seq 1, chained to seq 0
 
 	if err := rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)
@@ -466,11 +473,13 @@ func TestDualEmit_V1FailureSkipsV2(t *testing.T) {
 	}
 
 	// This decision's v1 Emit fails (sealed); v2 must be skipped.
-	_ = f.p.emitReceipt(receipt.EmitOpts{
+	if err := f.p.emitReceipt(receipt.EmitOpts{
 		ActionID: "a1", Transport: TransportForward, Method: "GET",
 		Target: "https://x.example/a", Verdict: "block",
 		Layer: "dlp", Pattern: "inj", RequestID: "r1",
-	})
+	}); err == nil {
+		t.Fatal("emitReceipt after sealed v1 chain returned nil, want error")
+	}
 	if err := f.rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)
 	}

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -134,7 +134,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		agent = agentAnonymous
 	}
 	emitWebSocketReceipt := func(opts receipt.EmitOpts) {
-		p.emitReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
+		_ = p.emitReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
 	}
 	if err := p.verifyInboundEnvelope(r, cfg); err != nil {
 		pattern := inboundEnvelopeFailurePattern(err)
@@ -546,6 +546,31 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	actionID := receipt.NewActionID()
+	admissionReceipt := receipt.EmitOpts{
+		ActionID:  actionID,
+		Verdict:   config.ActionAllow,
+		Transport: TransportWS,
+		Method:    "WS",
+		Target:    targetURL,
+		RequestID: requestID,
+		Agent:     agent,
+	}
+	if wsGate.HasContractContext() {
+		admissionReceipt = withContractReceipt(wsGate, admissionReceipt)
+	}
+	if cfg.FlightRecorder.RequireReceipts {
+		if err := p.emitRequiredReceipt(withReceiptPolicyHash(admissionReceipt, cfg.CanonicalPolicyHash())); err != nil {
+			blockedErr := newReceiptEmissionBlockedRequest(err)
+			log.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
+			p.metrics.RecordWSBlocked()
+			writeBlockedError(w,
+				blockInfoFor(blockreason.ReceiptEmissionFailed, blockedErr.layer),
+				"WebSocket blocked: "+blockedErr.reason, http.StatusForbidden)
+			return
+		}
+	}
+
 	// Upgrade the client connection.
 	upgrader := ws.HTTPUpgrader{
 		Timeout: 10 * time.Second,
@@ -616,7 +641,6 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// targetURL through this path must still fail closed on malformed
 	// input. A deliberately unreachable branch is cheaper than a
 	// silent unsigned envelope on a future regression.
-	actionID := receipt.NewActionID()
 	if envEmitter != nil {
 		parsedTarget, parseErr := url.Parse(targetURL)
 		if parseErr != nil {
@@ -778,7 +802,9 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	if wsGate.HasContractContext() {
 		closeReceipt = withContractReceipt(wsGate, closeReceipt)
 	}
-	emitWebSocketReceipt(closeReceipt)
+	if !cfg.FlightRecorder.RequireReceipts || stats.blocked {
+		emitWebSocketReceipt(closeReceipt)
+	}
 
 	sc.RecordRequest(relay.hostname, int(stats.clientToServer+stats.serverToClient))
 
@@ -974,7 +1000,9 @@ func (r *wsRelay) applyFrameRequestPolicy(log *audit.Logger, msg []byte) bool {
 	in.RequestID = r.requestID
 	in.Agent = r.agent
 	in.AuditCtx = newHTTPAuditContext(log, "WS", r.targetURL, r.clientIP, r.requestID, r.agent)
-	in.Emit = r.proxy.emitReceipt
+	in.Emit = func(opts receipt.EmitOpts) {
+		_ = r.proxy.emitReceipt(opts)
+	}
 	res := r.proxy.applyRequestPolicy(in)
 	if !res.Block {
 		return false
@@ -1073,7 +1101,7 @@ func (r *wsRelay) scanClientCrossMessageText(ctx context.Context, log *audit.Log
 		r.recordSignal(session.SignalBlock, log)
 		log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, scannerLabelRedaction, reason, r.clientIP, r.requestID)
 		r.proxy.metrics.RecordWSScanHit(scannerLabelRedaction)
-		r.proxy.emitReceipt(receipt.EmitOpts{
+		_ = r.proxy.emitReceipt(receipt.EmitOpts{
 			ActionID:         receipt.NewActionID(),
 			Verdict:          config.ActionBlock,
 			Layer:            scannerLabelRedaction,
@@ -1154,7 +1182,7 @@ func (r *wsRelay) handleClientTextFindings(log *audit.Logger, dlpMatches []scann
 			reason := fmt.Sprintf("DLP match: %s", strings.Join(names, ", "))
 			log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, audit.ScannerDLP, reason, r.clientIP, r.requestID)
 			r.proxy.metrics.RecordWSScanHit(audit.ScannerDLP)
-			r.proxy.emitReceipt(receipt.EmitOpts{
+			_ = r.proxy.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
 				Layer:     audit.ScannerDLP,
@@ -1180,7 +1208,7 @@ func (r *wsRelay) handleClientTextFindings(log *audit.Logger, dlpMatches []scann
 			reason := fmt.Sprintf("DLP match: %s (escalated)", strings.Join(names, ", "))
 			log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, audit.ScannerDLP, reason, r.clientIP, r.requestID)
 			r.proxy.metrics.RecordWSScanHit(audit.ScannerDLP)
-			r.proxy.emitReceipt(receipt.EmitOpts{
+			_ = r.proxy.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
 				Layer:     audit.ScannerDLP,
@@ -1241,7 +1269,7 @@ func (r *wsRelay) handleClientTextFindings(log *audit.Logger, dlpMatches []scann
 			}
 			reason := fmt.Sprintf("address poisoning: %s", blockExplanation)
 			log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, scannerLabelAddressProtection, reason, r.clientIP, r.requestID)
-			r.proxy.emitReceipt(receipt.EmitOpts{
+			_ = r.proxy.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
 				Layer:     "address_protection",
@@ -1261,7 +1289,7 @@ func (r *wsRelay) handleClientTextFindings(log *audit.Logger, dlpMatches []scann
 			r.recordSignal(session.SignalBlock, log)
 			reason := fmt.Sprintf("address poisoning: %s (escalated)", names[0])
 			log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, scannerLabelAddressProtection, reason, r.clientIP, r.requestID)
-			r.proxy.emitReceipt(receipt.EmitOpts{
+			_ = r.proxy.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
 				Layer:     "address_protection",
@@ -1452,7 +1480,7 @@ func (r *wsRelay) handleClientMessageBodyResult(log *audit.Logger, bodyBytes []b
 		r.recordSignal(session.SignalBlock, log)
 		log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, scannerLabel, reason, r.clientIP, r.requestID)
 		r.proxy.metrics.RecordWSScanHit(scannerLabel)
-		r.proxy.emitReceipt(receipt.EmitOpts{
+		_ = r.proxy.emitReceipt(receipt.EmitOpts{
 			ActionID:         receipt.NewActionID(),
 			Verdict:          config.ActionBlock,
 			Layer:            receiptLayer,
@@ -1521,7 +1549,7 @@ func (r *wsRelay) handleClientMessageBodyResult(log *audit.Logger, bodyBytes []b
 		}
 		log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, scannerLabel, blockReason, r.clientIP, r.requestID)
 		r.proxy.metrics.RecordWSScanHit(scannerLabel)
-		r.proxy.emitReceipt(receipt.EmitOpts{
+		_ = r.proxy.emitReceipt(receipt.EmitOpts{
 			ActionID:         receipt.NewActionID(),
 			Verdict:          config.ActionBlock,
 			Layer:            receiptLayer,
@@ -1599,7 +1627,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 		// Kill switch: terminate WebSocket relay when activated mid-stream.
 		if r.proxy.ks != nil && r.proxy.ks.IsActive() {
 			r.terminalOnce.Do(func() {
-				r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.proxy.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "kill_switch",
@@ -1630,7 +1658,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 			sessionKey := sessionKeyFor(r.agent, r.clientIP)
 			recordAdaptiveUpgrade(log, r.proxy.metrics, adaptiveUpgrade{SessionKey: sessionKey, Level: session.EscalationLabel(r.escalationLevel()), FromAction: "", ToAction: config.ActionBlock, Scanner: "session_deny", ClientIP: r.clientIP, RequestID: r.requestID})
 			r.terminalOnce.Do(func() {
-				r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.proxy.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "session_deny",
@@ -1720,7 +1748,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 			if !r.allowBinary {
 				log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, "ws_protocol", "binary frames not allowed", r.clientIP, r.requestID)
 				r.proxy.metrics.RecordWSScanHit("ws_protocol")
-				r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.proxy.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "ws_protocol",
@@ -1742,7 +1770,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 			reason := string(redact.ReasonWebSocketFragmented)
 			log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, scannerLabelRedaction, reason, r.clientIP, r.requestID)
 			r.proxy.metrics.RecordWSScanHit(scannerLabelRedaction)
-			r.proxy.emitReceipt(receipt.EmitOpts{
+			_ = r.proxy.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
 				Layer:     scannerLabelRedaction,
@@ -1763,7 +1791,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 		complete, msg, closeCode, closeReason := frag.Process(hdr, payload)
 		if closeCode != 0 {
 			log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, "ws_protocol", closeReason, r.clientIP, r.requestID)
-			r.proxy.emitReceipt(receipt.EmitOpts{
+			_ = r.proxy.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
 				Layer:     "ws_protocol",
@@ -1878,7 +1906,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 			if ceeRes.Blocked {
 				log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, "cross_request", ceeRes.Reason, r.clientIP, r.requestID)
 				r.proxy.metrics.RecordWSScanHit("cross_request")
-				r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.proxy.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "cross_request",
@@ -1902,7 +1930,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 				level := recEscalationLevel(ceeRec)
 				recordAdaptiveUpgrade(log, r.proxy.metrics, adaptiveUpgrade{SessionKey: sessionKey, Level: session.EscalationLabel(level), FromAction: "", ToAction: config.ActionBlock, Scanner: "session_deny", ClientIP: r.clientIP, RequestID: r.requestID})
 				r.terminalOnce.Do(func() {
-					r.proxy.emitReceipt(receipt.EmitOpts{
+					_ = r.proxy.emitReceipt(receipt.EmitOpts{
 						ActionID:  receipt.NewActionID(),
 						Verdict:   config.ActionBlock,
 						Layer:     "session_deny",
@@ -1958,7 +1986,7 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 		// Kill switch: terminate WebSocket relay when activated mid-stream.
 		if r.proxy.ks != nil && r.proxy.ks.IsActive() {
 			r.terminalOnce.Do(func() {
-				r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.proxy.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "kill_switch",
@@ -1988,7 +2016,7 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 			sessionKey := sessionKeyFor(r.agent, r.clientIP)
 			recordAdaptiveUpgrade(log, r.proxy.metrics, adaptiveUpgrade{SessionKey: sessionKey, Level: session.EscalationLabel(r.escalationLevel()), FromAction: "", ToAction: config.ActionBlock, Scanner: "session_deny", ClientIP: r.clientIP, RequestID: r.requestID})
 			r.terminalOnce.Do(func() {
-				r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.proxy.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "session_deny",
@@ -2077,7 +2105,7 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 			if !r.allowBinary {
 				log.LogWSBlocked(r.targetURL, audit.DirectionServerToClient, "ws_protocol", "binary frames not allowed", r.clientIP, r.requestID)
 				r.proxy.metrics.RecordWSScanHit("ws_protocol")
-				r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.proxy.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "ws_protocol",
@@ -2099,7 +2127,7 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 		complete, msg, closeCode, closeReason := frag.Process(hdr, payload)
 		if closeCode != 0 {
 			log.LogWSBlocked(r.targetURL, audit.DirectionServerToClient, "ws_protocol", closeReason, r.clientIP, r.requestID)
-			r.proxy.emitReceipt(receipt.EmitOpts{
+			_ = r.proxy.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
 				Layer:     "ws_protocol",
@@ -2135,7 +2163,7 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 			if mediaVerdict.Blocked {
 				log.LogWSBlocked(r.targetURL, audit.DirectionServerToClient, "media_policy", mediaVerdict.BlockReason, r.clientIP, r.requestID)
 				r.proxy.metrics.RecordWSScanHit("media_policy")
-				r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.proxy.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "media_policy",
@@ -2203,7 +2231,7 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 					case config.ActionBlock:
 						reason := fmt.Sprintf("injection detected: %s", strings.Join(patternNames, ", "))
 						log.LogWSBlocked(r.targetURL, audit.DirectionServerToClient, "response_scan", reason, r.clientIP, r.requestID)
-						r.proxy.emitReceipt(receipt.EmitOpts{
+						_ = r.proxy.emitReceipt(receipt.EmitOpts{
 							ActionID:  receipt.NewActionID(),
 							Verdict:   config.ActionBlock,
 							Layer:     "response_scan",

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -90,6 +90,10 @@ func (r *wsRelay) escalationLevel() int {
 	return r.rec.EscalationLevel()
 }
 
+func (r *wsRelay) emitReceipt(opts receipt.EmitOpts) error {
+	return r.proxy.emitReceipt(withReceiptPolicyHash(opts, r.cfg.CanonicalPolicyHash()))
+}
+
 // recordSignal records an adaptive enforcement signal on the relay's session
 // recorder. No-op when the recorder is nil or adaptive enforcement is disabled.
 func (r *wsRelay) recordSignal(sig session.SignalType, log *audit.Logger) {
@@ -559,17 +563,6 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	if wsGate.HasContractContext() {
 		admissionReceipt = withContractReceipt(wsGate, admissionReceipt)
 	}
-	if cfg.FlightRecorder.RequireReceipts {
-		if err := p.emitRequiredReceipt(withReceiptPolicyHash(admissionReceipt, cfg.CanonicalPolicyHash())); err != nil {
-			blockedErr := newReceiptEmissionBlockedRequest(err)
-			log.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
-			p.metrics.RecordWSBlocked()
-			writeBlockedError(w,
-				blockInfoFor(blockreason.ReceiptEmissionFailed, blockedErr.layer),
-				"WebSocket blocked: "+blockedErr.reason, http.StatusForbidden)
-			return
-		}
-	}
 
 	// Upgrade the client connection.
 	upgrader := ws.HTTPUpgrader{
@@ -701,6 +694,17 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if cfg.FlightRecorder.RequireReceipts {
+		if err := p.emitRequiredReceipt(withReceiptPolicyHash(admissionReceipt, cfg.CanonicalPolicyHash())); err != nil {
+			blockedErr := newReceiptEmissionBlockedRequest(err)
+			log.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
+			p.metrics.RecordWSBlocked()
+			plwsutil.WriteCloseFrame(clientConn, ws.StatusPolicyViolation,
+				blockInfoFor(blockreason.ReceiptEmissionFailed, blockedErr.layer).CloseFramePayload())
+			return
+		}
+	}
+
 	// Dial upstream via SSRF-safe dialer.
 	upstreamConn, dialErr := p.wsDialUpstream(r.Context(), targetURL, fwdHeaders, cfg)
 	if dialErr != nil {
@@ -802,7 +806,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	if wsGate.HasContractContext() {
 		closeReceipt = withContractReceipt(wsGate, closeReceipt)
 	}
-	if !cfg.FlightRecorder.RequireReceipts || stats.blocked {
+	if !cfg.FlightRecorder.RequireReceipts || stats.blocked || relay.redactionLog != nil {
 		emitWebSocketReceipt(closeReceipt)
 	}
 
@@ -1001,7 +1005,7 @@ func (r *wsRelay) applyFrameRequestPolicy(log *audit.Logger, msg []byte) bool {
 	in.Agent = r.agent
 	in.AuditCtx = newHTTPAuditContext(log, "WS", r.targetURL, r.clientIP, r.requestID, r.agent)
 	in.Emit = func(opts receipt.EmitOpts) {
-		_ = r.proxy.emitReceipt(opts)
+		_ = r.emitReceipt(opts)
 	}
 	res := r.proxy.applyRequestPolicy(in)
 	if !res.Block {
@@ -1101,7 +1105,7 @@ func (r *wsRelay) scanClientCrossMessageText(ctx context.Context, log *audit.Log
 		r.recordSignal(session.SignalBlock, log)
 		log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, scannerLabelRedaction, reason, r.clientIP, r.requestID)
 		r.proxy.metrics.RecordWSScanHit(scannerLabelRedaction)
-		_ = r.proxy.emitReceipt(receipt.EmitOpts{
+		_ = r.emitReceipt(receipt.EmitOpts{
 			ActionID:         receipt.NewActionID(),
 			Verdict:          config.ActionBlock,
 			Layer:            scannerLabelRedaction,
@@ -1182,7 +1186,7 @@ func (r *wsRelay) handleClientTextFindings(log *audit.Logger, dlpMatches []scann
 			reason := fmt.Sprintf("DLP match: %s", strings.Join(names, ", "))
 			log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, audit.ScannerDLP, reason, r.clientIP, r.requestID)
 			r.proxy.metrics.RecordWSScanHit(audit.ScannerDLP)
-			_ = r.proxy.emitReceipt(receipt.EmitOpts{
+			_ = r.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
 				Layer:     audit.ScannerDLP,
@@ -1208,7 +1212,7 @@ func (r *wsRelay) handleClientTextFindings(log *audit.Logger, dlpMatches []scann
 			reason := fmt.Sprintf("DLP match: %s (escalated)", strings.Join(names, ", "))
 			log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, audit.ScannerDLP, reason, r.clientIP, r.requestID)
 			r.proxy.metrics.RecordWSScanHit(audit.ScannerDLP)
-			_ = r.proxy.emitReceipt(receipt.EmitOpts{
+			_ = r.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
 				Layer:     audit.ScannerDLP,
@@ -1269,7 +1273,7 @@ func (r *wsRelay) handleClientTextFindings(log *audit.Logger, dlpMatches []scann
 			}
 			reason := fmt.Sprintf("address poisoning: %s", blockExplanation)
 			log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, scannerLabelAddressProtection, reason, r.clientIP, r.requestID)
-			_ = r.proxy.emitReceipt(receipt.EmitOpts{
+			_ = r.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
 				Layer:     "address_protection",
@@ -1289,7 +1293,7 @@ func (r *wsRelay) handleClientTextFindings(log *audit.Logger, dlpMatches []scann
 			r.recordSignal(session.SignalBlock, log)
 			reason := fmt.Sprintf("address poisoning: %s (escalated)", names[0])
 			log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, scannerLabelAddressProtection, reason, r.clientIP, r.requestID)
-			_ = r.proxy.emitReceipt(receipt.EmitOpts{
+			_ = r.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
 				Layer:     "address_protection",
@@ -1480,7 +1484,7 @@ func (r *wsRelay) handleClientMessageBodyResult(log *audit.Logger, bodyBytes []b
 		r.recordSignal(session.SignalBlock, log)
 		log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, scannerLabel, reason, r.clientIP, r.requestID)
 		r.proxy.metrics.RecordWSScanHit(scannerLabel)
-		_ = r.proxy.emitReceipt(receipt.EmitOpts{
+		_ = r.emitReceipt(receipt.EmitOpts{
 			ActionID:         receipt.NewActionID(),
 			Verdict:          config.ActionBlock,
 			Layer:            receiptLayer,
@@ -1549,7 +1553,7 @@ func (r *wsRelay) handleClientMessageBodyResult(log *audit.Logger, bodyBytes []b
 		}
 		log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, scannerLabel, blockReason, r.clientIP, r.requestID)
 		r.proxy.metrics.RecordWSScanHit(scannerLabel)
-		_ = r.proxy.emitReceipt(receipt.EmitOpts{
+		_ = r.emitReceipt(receipt.EmitOpts{
 			ActionID:         receipt.NewActionID(),
 			Verdict:          config.ActionBlock,
 			Layer:            receiptLayer,
@@ -1627,7 +1631,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 		// Kill switch: terminate WebSocket relay when activated mid-stream.
 		if r.proxy.ks != nil && r.proxy.ks.IsActive() {
 			r.terminalOnce.Do(func() {
-				_ = r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "kill_switch",
@@ -1658,7 +1662,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 			sessionKey := sessionKeyFor(r.agent, r.clientIP)
 			recordAdaptiveUpgrade(log, r.proxy.metrics, adaptiveUpgrade{SessionKey: sessionKey, Level: session.EscalationLabel(r.escalationLevel()), FromAction: "", ToAction: config.ActionBlock, Scanner: "session_deny", ClientIP: r.clientIP, RequestID: r.requestID})
 			r.terminalOnce.Do(func() {
-				_ = r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "session_deny",
@@ -1748,7 +1752,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 			if !r.allowBinary {
 				log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, "ws_protocol", "binary frames not allowed", r.clientIP, r.requestID)
 				r.proxy.metrics.RecordWSScanHit("ws_protocol")
-				_ = r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "ws_protocol",
@@ -1770,7 +1774,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 			reason := string(redact.ReasonWebSocketFragmented)
 			log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, scannerLabelRedaction, reason, r.clientIP, r.requestID)
 			r.proxy.metrics.RecordWSScanHit(scannerLabelRedaction)
-			_ = r.proxy.emitReceipt(receipt.EmitOpts{
+			_ = r.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
 				Layer:     scannerLabelRedaction,
@@ -1791,7 +1795,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 		complete, msg, closeCode, closeReason := frag.Process(hdr, payload)
 		if closeCode != 0 {
 			log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, "ws_protocol", closeReason, r.clientIP, r.requestID)
-			_ = r.proxy.emitReceipt(receipt.EmitOpts{
+			_ = r.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
 				Layer:     "ws_protocol",
@@ -1906,7 +1910,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 			if ceeRes.Blocked {
 				log.LogWSBlocked(r.targetURL, audit.DirectionClientToServer, "cross_request", ceeRes.Reason, r.clientIP, r.requestID)
 				r.proxy.metrics.RecordWSScanHit("cross_request")
-				_ = r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "cross_request",
@@ -1930,7 +1934,7 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 				level := recEscalationLevel(ceeRec)
 				recordAdaptiveUpgrade(log, r.proxy.metrics, adaptiveUpgrade{SessionKey: sessionKey, Level: session.EscalationLabel(level), FromAction: "", ToAction: config.ActionBlock, Scanner: "session_deny", ClientIP: r.clientIP, RequestID: r.requestID})
 				r.terminalOnce.Do(func() {
-					_ = r.proxy.emitReceipt(receipt.EmitOpts{
+					_ = r.emitReceipt(receipt.EmitOpts{
 						ActionID:  receipt.NewActionID(),
 						Verdict:   config.ActionBlock,
 						Layer:     "session_deny",
@@ -1986,7 +1990,7 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 		// Kill switch: terminate WebSocket relay when activated mid-stream.
 		if r.proxy.ks != nil && r.proxy.ks.IsActive() {
 			r.terminalOnce.Do(func() {
-				_ = r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "kill_switch",
@@ -2016,7 +2020,7 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 			sessionKey := sessionKeyFor(r.agent, r.clientIP)
 			recordAdaptiveUpgrade(log, r.proxy.metrics, adaptiveUpgrade{SessionKey: sessionKey, Level: session.EscalationLabel(r.escalationLevel()), FromAction: "", ToAction: config.ActionBlock, Scanner: "session_deny", ClientIP: r.clientIP, RequestID: r.requestID})
 			r.terminalOnce.Do(func() {
-				_ = r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "session_deny",
@@ -2105,7 +2109,7 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 			if !r.allowBinary {
 				log.LogWSBlocked(r.targetURL, audit.DirectionServerToClient, "ws_protocol", "binary frames not allowed", r.clientIP, r.requestID)
 				r.proxy.metrics.RecordWSScanHit("ws_protocol")
-				_ = r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "ws_protocol",
@@ -2127,7 +2131,7 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 		complete, msg, closeCode, closeReason := frag.Process(hdr, payload)
 		if closeCode != 0 {
 			log.LogWSBlocked(r.targetURL, audit.DirectionServerToClient, "ws_protocol", closeReason, r.clientIP, r.requestID)
-			_ = r.proxy.emitReceipt(receipt.EmitOpts{
+			_ = r.emitReceipt(receipt.EmitOpts{
 				ActionID:  receipt.NewActionID(),
 				Verdict:   config.ActionBlock,
 				Layer:     "ws_protocol",
@@ -2163,7 +2167,7 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 			if mediaVerdict.Blocked {
 				log.LogWSBlocked(r.targetURL, audit.DirectionServerToClient, "media_policy", mediaVerdict.BlockReason, r.clientIP, r.requestID)
 				r.proxy.metrics.RecordWSScanHit("media_policy")
-				_ = r.proxy.emitReceipt(receipt.EmitOpts{
+				_ = r.emitReceipt(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,
 					Layer:     "media_policy",
@@ -2231,7 +2235,7 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 					case config.ActionBlock:
 						reason := fmt.Sprintf("injection detected: %s", strings.Join(patternNames, ", "))
 						log.LogWSBlocked(r.targetURL, audit.DirectionServerToClient, "response_scan", reason, r.clientIP, r.requestID)
-						_ = r.proxy.emitReceipt(receipt.EmitOpts{
+						_ = r.emitReceipt(receipt.EmitOpts{
 							ActionID:  receipt.NewActionID(),
 							Verdict:   config.ActionBlock,
 							Layer:     "response_scan",

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -549,6 +549,67 @@ func TestWSProxyRedaction_RewritesJSONMessage(t *testing.T) {
 	}
 }
 
+func TestWSProxyRequireReceipts_RedactedSuccessEmitsCloseSummary(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+
+	rph := newReceiptProxyHelper(t)
+	proxyAddr, p, proxyCleanup := setupWSProxyDefaultWithProxy(t, func(cfg *config.Config) {
+		cfg.Enforce = ptrBool(false)
+		cfg.FlightRecorder.RequireReceipts = true
+		applyRedactionTestProfile(cfg)
+	})
+	defer proxyCleanup()
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	conn := dialWS(t, proxyAddr, backendAddr)
+	secret := redactionE2ESecret()
+	msg := []byte(`{"prompt":"use ` + secret + ` to deploy"}`)
+	if err := wsutil.WriteClientMessage(conn, ws.OpText, msg); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	reply, op, err := wsutil.ReadServerData(conn)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if op != ws.OpText {
+		t.Fatalf("opcode = %v, want OpText", op)
+	}
+	if strings.Contains(string(reply), secret) {
+		t.Fatalf("echoed reply leaked secret: %q", reply)
+	}
+	plwsutil.WriteClientCloseFrame(conn, ws.StatusNormalClosure, "done")
+	if err := conn.Close(); err != nil {
+		t.Fatalf("conn.Close: %v", err)
+	}
+
+	testwait.For(t, 2*time.Second, func() bool {
+		for _, rcpt := range extractReceiptsFromDir(t, rph.dir) {
+			if rcpt.ActionRecord.Layer == "session_close" && rcpt.ActionRecord.Redaction != nil {
+				return true
+			}
+		}
+		return false
+	}, "websocket redaction close receipt")
+
+	receipts := rph.findReceipts(t)
+	var allowCount, redactionCloseCount int
+	for _, rcpt := range receipts {
+		if rcpt.ActionRecord.Verdict == config.ActionAllow && rcpt.ActionRecord.Layer == "" {
+			allowCount++
+		}
+		if rcpt.ActionRecord.Layer == "session_close" && rcpt.ActionRecord.Redaction != nil {
+			redactionCloseCount++
+		}
+	}
+	if allowCount != 1 {
+		t.Fatalf("allow receipt count = %d, want one admission receipt", allowCount)
+	}
+	if redactionCloseCount != 1 {
+		t.Fatalf("redaction close receipt count = %d, want one signed close summary", redactionCloseCount)
+	}
+}
+
 func TestWSProxyRedaction_BinaryNonJSONBlocked(t *testing.T) {
 	backendAddr, backendCleanup := wsEchoServer(t)
 	defer backendCleanup()


### PR DESCRIPTION
## Summary
- add `flight_recorder.require_receipts` as a default-off fail-closed mode for signed action receipts
- enforce required receipt emission across forward proxy, CONNECT, WebSocket, fetch, MCP stdio, and MCP HTTP paths
- refuse startup when required receipts are configured without a healthy signed receipt emitter
- preserve reload safety by warning when `require_receipts` is enabled without a live emitter
- add `receipt_emission_failed` block reason coverage and transport-parity tests
- stabilize MCP capture subprocess tests by removing the hard run deadline and using the existing hang backstop pattern

## Notes
`require_receipts` remains opt-in. When enabled, allowed egress must have a signed receipt before the request leaves the proxy; receipt emission failure blocks before egress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `require_receipts` option to the flight recorder to optionally enforce successful receipt emission for allowed requests; when enabled, forwarding is blocked if a required receipt cannot be emitted.
  * Added new block reason code `receipt_emission_failed` to identify receipt-emission failures.

* **Bug Fixes**
  * Startup/reload now validates receipt-emitter availability and surfaces errors when enforcement is enabled but no emitter is present.

* **Documentation**
  * Updated configuration guides and transport docs to explain receipt-enforcement semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->