### PR TITLE
fix(mcp): protect concurrent stdio subprocesses during teardown

### DIFF
--- a/internal/cli/runtime/mcp_capture_test.go
+++ b/internal/cli/runtime/mcp_capture_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/config"
-	"github.com/luckyPipewrench/pipelock/internal/mcp"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
@@ -147,10 +146,9 @@ func collectCaptureSurfaces(t *testing.T, baseDir string) (map[string]int, int) 
 // the fix, MCP evidence flowed only through the (key-gated) receipt emitter, so
 // this directory stayed empty on every OS.
 func TestMcpProxyCmd_KeyFreeCapture_WritesEvidence(t *testing.T) {
-	// Intentionally NOT parallel: this spawns a wrapped go-test helper
-	// subprocess, and stacking it in the parallel batch alongside the other
-	// subprocess proxy tests adds CI-load contention to a known-flaky family
-	// (the stdio receipt/recorder tests race their subprocess teardown).
+	// Intentionally not parallel: this test exercises subprocess lifecycle plus
+	// evidence capture, and it does not need package-level scheduling pressure to
+	// prove the capture invariant.
 	captureDir := filepath.Join(t.TempDir(), "evidence")
 	configPath := writeMCPCaptureProbeConfig(t)
 
@@ -172,10 +170,7 @@ func TestMcpProxyCmd_KeyFreeCapture_WritesEvidence(t *testing.T) {
 		os.Args[0],
 		"-test.run=TestMCPRuntimeHelperProcess$",
 	})
-	// ErrSubprocessExit is expected when the wrapped Go-test helper exits
-	// non-zero (see TestMcpProxyCmd_EmitsSignedReceipts_StdioSubprocess for the
-	// race rationale). The assertion is about evidence written before exit.
-	if err != nil && !errors.Is(err, mcp.ErrSubprocessExit) {
+	if err != nil {
 		t.Fatalf("run mcp proxy --capture-output: %v\nstderr:\n%s", err, stderr)
 	}
 

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -292,15 +292,7 @@ func TestMcpProxyCmd_EmitsSignedReceipts_StdioSubprocess(t *testing.T) {
 	configPath := writeMCPProxyConfig(t, evidenceDir, keyPath, true)
 
 	stdout, stderr, err := runMCPProxyCommand(t, configPath)
-	// ErrSubprocessExit is an expected outcome when the wrapped Go-test
-	// helper exits non-zero. Under CI load the helper's testing.M
-	// cleanup (which prints "PASS\nok <pkg>" to stdout after the
-	// JSON-RPC scanner loop exits) can race with pipelock's pgid
-	// teardown and surface as "signal: killed". The test assertion is
-	// about receipts being emitted before the child exited, not about
-	// the child's own exit status, so only fail for non-subprocess
-	// errors.
-	if err != nil && !errors.Is(err, mcp.ErrSubprocessExit) {
+	if err != nil {
 		t.Fatalf("run mcp proxy command: %v\nstderr:\n%s", err, stderr)
 	}
 
@@ -343,7 +335,7 @@ func TestMcpProxyCmd_FlightRecorderDisabled_NoReceipts(t *testing.T) {
 	configPath := writeMCPProxyConfig(t, evidenceDir, keyPath, false)
 
 	stdout, stderr, err := runMCPProxyCommand(t, configPath)
-	if err != nil && !errors.Is(err, mcp.ErrSubprocessExit) {
+	if err != nil {
 		t.Fatalf("run mcp proxy command: %v\nstderr:\n%s", err, stderr)
 	}
 

--- a/internal/mcp/subtree_linux.go
+++ b/internal/mcp/subtree_linux.go
@@ -45,13 +45,16 @@ func enableSubreaper() error {
 	return unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0)
 }
 
-// killAdoptedDescendants SIGKILLs every process whose parent PID matches
-// our own. Call after the direct MCP child has been waited on and the
-// pgid kill has drained; anything still around at that point was either
-// a double-forked orphan (reparented to us by the subreaper bit) or a
-// grandchild that set its own session via setsid. Either way, it is not
-// a child of the original process group and the earlier -pid SIGKILL
-// would not have reached it.
+// killAdoptedDescendants SIGKILLs orphaned descendants whose parent PID
+// matches our own. Call after the direct MCP child has been waited on and the
+// pgid kill has drained; anything still around at that point was either a
+// double-forked orphan (reparented to us by the subreaper bit) or a grandchild
+// that set its own session via setsid. Either way, it is not a child of the
+// original process group and the earlier -pid SIGKILL would not have reached it.
+//
+// Concurrent RunProxy calls in the same process also have direct children whose
+// PPID is our PID. Those are active MCP servers, not adopted descendants, and
+// must not be killed by another proxy's teardown sweep.
 //
 // We don't return errors - best-effort. A process we can't signal
 // (ESRCH because it already died, EPERM because of a namespace boundary)
@@ -71,7 +74,7 @@ func killAdoptedDescendants() {
 		if convErr != nil {
 			continue
 		}
-		if childPID == pid {
+		if childPID == pid || isProtectedDirectPID(childPID) {
 			continue
 		}
 		statPath := filepath.Clean("/proc/" + name + "/stat")

--- a/internal/mcp/subtree_linux_test.go
+++ b/internal/mcp/subtree_linux_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestKillAdoptedDescendants_PreservesProtectedDirectChild(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting protected child: %v", err)
+	}
+
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- cmd.Wait() }()
+
+	unregister := registerProtectedDirectPID(cmd.Process.Pid)
+	defer unregister()
+
+	killAdoptedDescendants()
+
+	select {
+	case err := <-waitDone:
+		if err == nil {
+			t.Fatal("protected direct child exited during adopted-descendant cleanup")
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ProcessState.Sys().(syscall.WaitStatus).Signaled() {
+			t.Fatalf("protected direct child was signaled during adopted-descendant cleanup: %v", err)
+		}
+		t.Fatalf("protected direct child exited during adopted-descendant cleanup: %v", err)
+	default:
+	}
+
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("signaling protected child after cleanup: %v", err)
+	}
+	select {
+	case <-waitDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("protected child did not exit after test cleanup SIGTERM")
+	}
+}


### PR DESCRIPTION
## Summary

- Skip protected direct child PIDs during the Linux adopted-descendant cleanup sweep.
- Add regression coverage proving cleanup does not signal another live proxy subprocess.
- Remove stale subprocess-exit tolerances from MCP stdio runtime tests so killed helpers fail hard again.

## Details

The Linux subtree cleanup is meant to remove orphaned descendants after a wrapped MCP subprocess exits. In package-level concurrent runs, another live proxy subprocess can also have Pipelock as its parent, so the cleanup sweep must distinguish active direct children from adopted descendants.

This change reuses the existing protected direct PID registry that the live reaper already uses, and applies the same guard to the final adopted-descendant sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced subprocess error handling for MCP proxy commands; tests now consistently fail on any error from proxy operations.
- Improved Linux process teardown to differentiate between adopted processes requiring termination and active MCP server processes that must be preserved.

## Tests
- Added test coverage verifying protected child processes are preserved during cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->