### PR TITLE
Clarify Conductor key purposes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2880,7 +2880,7 @@ The old string form, `learn_lock.environment: production`, is not accepted by th
 
 Two commands compose the trust topology:
 
-- `pipelock signing key generate --purpose <purpose> --out <path>` writes a new Ed25519 keypair to a 0o600 JSON file with explicit purpose binding. Used for deployment-level keys (root, activation, recovery).
+- `pipelock signing key generate --purpose <purpose> --out <path>` writes a new Ed25519 keypair to a 0o600 JSON file with explicit purpose binding. Purposes cover deployment-level trust (root, activation, recovery, receipt, rules) and Conductor control-plane purpose strings; run `pipelock signing key generate --help` for the authoritative list and reserved-purpose notes. Conductor rollback, remote-kill, and trust-root-rotation are threshold key types — generate one key per approver and never deploy a single-signer authority.
 - `pipelock signing roster build --root <root.json> --include id=,key=,purpose=,...` composes a signed `RosterEnvelope` from the root key plus a list of public-key includes. The output JSON is what `learn_lock.roster_path` consumes and what `pipelock signing roster verify` accepts.
 
 End-to-end example:

--- a/internal/cli/signing/key_generate.go
+++ b/internal/cli/signing/key_generate.go
@@ -46,6 +46,24 @@ const fingerprintPrefix = "sha256:"
 
 var errKeyFileTooLarge = errors.New("key file exceeds size cap")
 
+func keyPurposeUsage() string {
+	purposes := domsigning.KnownPurposes()
+	labels := make([]string, 0, len(purposes))
+	for _, purpose := range purposes {
+		labels = append(labels, purpose.String())
+	}
+	return strings.Join(labels, ", ")
+}
+
+func isReservedConductorKeyPurpose(purpose domsigning.KeyPurpose) bool {
+	switch purpose {
+	case domsigning.PurposeTrustRootRotation, domsigning.PurposeEnrollmentTokenSigning:
+		return true
+	default:
+		return false
+	}
+}
+
 // keyFile is the on-disk JSON shape produced by "pipelock signing key generate".
 // Both private and public keys are stored hex-encoded; the file is written
 // 0o600 because the private key is sensitive.
@@ -94,6 +112,18 @@ The --purpose flag binds the key to one of the recognised wire purposes:
   recovery-root                  break-glass root for recovery operations
   receipt-signing                runtime receipt signing
   rules-official-signing         official rules package signing
+  policy-bundle-signing          Conductor policy bundle signing
+  policy-bundle-rollback         Conductor rollback authorization signing
+  remote-kill-signing            Conductor remote kill-switch signing
+  trust-root-rotation            reserved Conductor trust-root rotation signing
+  audit-batch-signing            Conductor follower audit batch signing
+  enrollment-token-signing       reserved Conductor enrollment-token signing
+
+Conductor rollback, remote-kill, and trust-root-rotation keys are threshold
+keys: generate independent keys for separate approvers and configure the
+Conductor roster/control plane to require the fleet threshold. Reserved
+purposes are wire-stable purpose bindings, but no shipped operator workflow
+consumes them yet.
 
 Writes a 0o600 JSON file containing schema_version, purpose, key_id, public
 (hex), private (hex), and created_at. The canonical sha256 fingerprint is
@@ -165,13 +195,19 @@ Examples:
 			_, _ = fmt.Fprintf(out, "Generated %s keypair\n", purpose)
 			_, _ = fmt.Fprintf(out, "  key_id:      %s\n", resolvedID)
 			_, _ = fmt.Fprintf(out, "  fingerprint: %s\n", fp)
+			if isReservedConductorKeyPurpose(kp) {
+				_, _ = fmt.Fprintf(out, "  status:      reserved purpose; no shipped operator workflow consumes this key yet\n")
+			}
+			if kp.RequiresConductorThreshold() {
+				_, _ = fmt.Fprintf(out, "  threshold:   required for this Conductor purpose; do not deploy as a single-signer authority\n")
+			}
 			_, _ = fmt.Fprintf(out, "  out:         %s\n", cleanOut)
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVar(&purpose, "purpose", "",
-		"key purpose (one of: roster-root, contract-activation-signing, contract-compile-signing, recovery-root, receipt-signing, rules-official-signing)")
+		"key purpose (one of: "+keyPurposeUsage()+")")
 	cmd.Flags().StringVar(&outPath, "out", "", "absolute output path for the keypair JSON file")
 	cmd.Flags().StringVar(&keyID, "id", "", "operator-chosen key ID (default: <purpose>-<short-fingerprint>)")
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite an existing output file")

--- a/internal/cli/signing/key_generate_test.go
+++ b/internal/cli/signing/key_generate_test.go
@@ -183,6 +183,83 @@ func TestKeyGenerate_HonoursExplicitID(t *testing.T) {
 	}
 }
 
+func TestKeyGenerate_AcceptsConductorPurposes(t *testing.T) {
+	dir := t.TempDir()
+	for _, purpose := range []domsigning.KeyPurpose{
+		domsigning.PurposePolicyBundleSigning,
+		domsigning.PurposePolicyBundleRollback,
+		domsigning.PurposeRemoteKillSigning,
+		domsigning.PurposeTrustRootRotation,
+		domsigning.PurposeAuditBatchSigning,
+		domsigning.PurposeEnrollmentTokenSigning,
+	} {
+		t.Run(purpose.String(), func(t *testing.T) {
+			out := filepath.Join(dir, purpose.String()+".json")
+			var stdout bytes.Buffer
+			cmd := keyGenerateCmd()
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs([]string{"--purpose", purpose.String(), "--out", out})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+
+			raw, err := os.ReadFile(filepath.Clean(out))
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			var kf keyFile
+			if err := json.Unmarshal(raw, &kf); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if kf.Purpose != purpose.String() {
+				t.Errorf("purpose = %q, want %q", kf.Purpose, purpose)
+			}
+			gotWarning := strings.Contains(stdout.String(), "threshold:")
+			if gotWarning != purpose.RequiresConductorThreshold() {
+				t.Errorf("threshold warning present = %v, want %v; output:\n%s",
+					gotWarning, purpose.RequiresConductorThreshold(), stdout.String())
+			}
+			gotReserved := strings.Contains(stdout.String(), "reserved purpose")
+			if gotReserved != isReservedConductorKeyPurpose(purpose) {
+				t.Errorf("reserved warning present = %v, want %v; output:\n%s",
+					gotReserved, isReservedConductorKeyPurpose(purpose), stdout.String())
+			}
+		})
+	}
+}
+
+func TestKeyGenerate_HelpListsConductorPurposes(t *testing.T) {
+	cmd := keyGenerateCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("help: %v", err)
+	}
+
+	help := stdout.String()
+	for _, purpose := range []domsigning.KeyPurpose{
+		domsigning.PurposePolicyBundleSigning,
+		domsigning.PurposePolicyBundleRollback,
+		domsigning.PurposeRemoteKillSigning,
+		domsigning.PurposeTrustRootRotation,
+		domsigning.PurposeAuditBatchSigning,
+		domsigning.PurposeEnrollmentTokenSigning,
+	} {
+		if !strings.Contains(help, purpose.String()) {
+			t.Errorf("help missing %q:\n%s", purpose, help)
+		}
+	}
+	if !strings.Contains(help, "threshold") {
+		t.Errorf("help missing threshold guidance:\n%s", help)
+	}
+	if !strings.Contains(help, "reserved") {
+		t.Errorf("help missing reserved-purpose guidance:\n%s", help)
+	}
+}
+
 func TestLoadKeyFile_DetectsPurposeMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "k.json")


### PR DESCRIPTION
## Summary

- Advertise Conductor key purposes in `pipelock signing key generate --help`
- Mark reserved Conductor purpose strings as reserved until shipped workflows consume them
- Add keygen tests for Conductor purposes, threshold warnings, and reserved-purpose warnings
- Update configuration docs to point at keygen help for the authoritative purpose list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for Conductor-related purposes in key generation with enhanced status output including reserved purpose and threshold requirement indicators.

* **Documentation**
  * Expanded signing key generation documentation with additional guidance on supported purposes and Conductor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->