### PR TITLE
Fix Conductor rollback reconcile upgrade crashloop, restore coverage

### DIFF
--- a/enterprise/cli/conductor/enroll_keyload_test.go
+++ b/enterprise/cli/conductor/enroll_keyload_test.go
@@ -1,0 +1,166 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestLoadEnrollmentToken(t *testing.T) {
+	t.Run("empty path", func(t *testing.T) {
+		if _, err := loadEnrollmentToken("  "); err == nil || !strings.Contains(err.Error(), "is required") {
+			t.Fatalf("loadEnrollmentToken(empty path) error = %v, want required", err)
+		}
+	})
+
+	t.Run("unreadable path", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "does-not-exist")
+		if _, err := loadEnrollmentToken(missing); err == nil || !strings.Contains(err.Error(), "read --enrollment-token-file") {
+			t.Fatalf("loadEnrollmentToken(missing) error = %v, want read error", err)
+		}
+	})
+
+	t.Run("empty contents", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "blank")
+		if err := os.WriteFile(path, []byte("   \n\t "), 0o600); err != nil {
+			t.Fatalf("write blank token: %v", err)
+		}
+		if _, err := loadEnrollmentToken(path); err == nil || !strings.Contains(err.Error(), "is empty") {
+			t.Fatalf("loadEnrollmentToken(blank) error = %v, want empty", err)
+		}
+	})
+
+	t.Run("trims and returns", func(t *testing.T) {
+		token := "pl_" + "enroll_token"
+		path := writeEnrollmentTokenFile(t, token)
+		got, err := loadEnrollmentToken(path)
+		if err != nil {
+			t.Fatalf("loadEnrollmentToken() error = %v", err)
+		}
+		if got != token {
+			t.Fatalf("loadEnrollmentToken() = %q, want %q", got, token)
+		}
+	})
+}
+
+func TestValidateAuditKeyID(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		if err := validateAuditKeyID("   "); err == nil || !strings.Contains(err.Error(), "audit key id is required") {
+			t.Fatalf("validateAuditKeyID(empty) error = %v, want required", err)
+		}
+	})
+
+	t.Run("invalid identifier", func(t *testing.T) {
+		if err := validateAuditKeyID("bad key!"); err == nil {
+			t.Fatal("validateAuditKeyID(invalid) error = nil, want identifier rejection")
+		}
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		if err := validateAuditKeyID("audit-key-1"); err != nil {
+			t.Fatalf("validateAuditKeyID(valid) error = %v", err)
+		}
+	})
+}
+
+// writeRawPrivateKeyFile writes an Ed25519 private key in the raw
+// pipelock-ed25519-private-v1 encoding (NOT the JSON keypair envelope) so the
+// raw-key branch of loadEnrollmentAuditKey is exercised.
+func writeRawPrivateKeyFile(t *testing.T) (string, ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "raw-audit-key")
+	if err := os.WriteFile(path, []byte(signing.EncodePrivateKey(priv)), 0o600); err != nil {
+		t.Fatalf("write raw key: %v", err)
+	}
+	return path, pub
+}
+
+func TestLoadEnrollmentAuditKey(t *testing.T) {
+	t.Run("empty path", func(t *testing.T) {
+		if _, _, err := loadEnrollmentAuditKey("  ", ""); err == nil || !strings.Contains(err.Error(), "is required") {
+			t.Fatalf("loadEnrollmentAuditKey(empty) error = %v, want required", err)
+		}
+	})
+
+	t.Run("json keypair derives id", func(t *testing.T) {
+		_, keyFile, pub := writeSigningKeyWithPurpose(t, "audit-key-json", signing.PurposeAuditBatchSigning)
+		gotID, gotPub, err := loadEnrollmentAuditKey(keyFile, "")
+		if err != nil {
+			t.Fatalf("loadEnrollmentAuditKey() error = %v", err)
+		}
+		if gotID != "audit-key-json" {
+			t.Fatalf("loadEnrollmentAuditKey() id=%q, want audit-key-json", gotID)
+		}
+		if !pub.Equal(gotPub) {
+			t.Fatal("loadEnrollmentAuditKey() returned mismatched public key")
+		}
+	})
+
+	t.Run("json keypair override id wins", func(t *testing.T) {
+		_, keyFile, _ := writeSigningKeyWithPurpose(t, "audit-key-json2", signing.PurposeAuditBatchSigning)
+		gotID, _, err := loadEnrollmentAuditKey(keyFile, "audit-override")
+		if err != nil {
+			t.Fatalf("loadEnrollmentAuditKey(override) error = %v", err)
+		}
+		if gotID != "audit-override" {
+			t.Fatalf("loadEnrollmentAuditKey(override) id=%q, want audit-override", gotID)
+		}
+	})
+
+	t.Run("json keypair invalid override id rejected", func(t *testing.T) {
+		_, keyFile, _ := writeSigningKeyWithPurpose(t, "audit-key-json3", signing.PurposeAuditBatchSigning)
+		if _, _, err := loadEnrollmentAuditKey(keyFile, "bad id!"); err == nil {
+			t.Fatal("loadEnrollmentAuditKey(bad override) error = nil, want identifier rejection")
+		}
+	})
+
+	t.Run("raw private key requires audit key id", func(t *testing.T) {
+		rawFile, _ := writeRawPrivateKeyFile(t)
+		if _, _, err := loadEnrollmentAuditKey(rawFile, ""); err == nil ||
+			!strings.Contains(err.Error(), "--audit-key-id is required") {
+			t.Fatalf("loadEnrollmentAuditKey(raw, no id) error = %v, want id required", err)
+		}
+	})
+
+	t.Run("raw private key with override id", func(t *testing.T) {
+		rawFile, pub := writeRawPrivateKeyFile(t)
+		gotID, gotPub, err := loadEnrollmentAuditKey(rawFile, "audit-raw-1")
+		if err != nil {
+			t.Fatalf("loadEnrollmentAuditKey(raw) error = %v", err)
+		}
+		if gotID != "audit-raw-1" {
+			t.Fatalf("loadEnrollmentAuditKey(raw) id=%q, want audit-raw-1", gotID)
+		}
+		if !pub.Equal(gotPub) {
+			t.Fatal("loadEnrollmentAuditKey(raw) returned mismatched public key")
+		}
+	})
+
+	t.Run("raw private key invalid override id rejected", func(t *testing.T) {
+		rawFile, _ := writeRawPrivateKeyFile(t)
+		if _, _, err := loadEnrollmentAuditKey(rawFile, "bad id!"); err == nil {
+			t.Fatal("loadEnrollmentAuditKey(raw, bad id) error = nil, want identifier rejection")
+		}
+	})
+
+	t.Run("unreadable file errors", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "absent-key")
+		if _, _, err := loadEnrollmentAuditKey(missing, "audit-key-1"); err == nil ||
+			!strings.Contains(err.Error(), "load audit key file as JSON keypair or raw private key") {
+			t.Fatalf("loadEnrollmentAuditKey(missing) error = %v, want combined load error", err)
+		}
+	})
+}

--- a/enterprise/conductor/applycache/cache_integrity_test.go
+++ b/enterprise/conductor/applycache/cache_integrity_test.go
@@ -253,10 +253,9 @@ func TestActivateRejectsNonHexHash(t *testing.T) {
 	}
 }
 
-// TestRollbackAuthorizationMismatches drives every post-signature rejection
-// branch in authorizeVersionTransition: a validly signed authorization is
-// still refused when its window, rollback scope, or bundle targeting does not match
-// the local state.
+// TestRollbackAuthorizationMismatches drives post-signature rejection branches
+// in authorizeVersionTransition: a validly signed authorization is still
+// refused when its window or bundle targeting does not match the local state.
 func TestRollbackAuthorizationMismatches(t *testing.T) {
 	policyKey := newTestKey(t)
 	rk1 := newPurposeKey(t, "rollback-1", signing.PurposePolicyBundleRollback)
@@ -271,13 +270,6 @@ func TestRollbackAuthorizationMismatches(t *testing.T) {
 			name:   "expired",
 			mutate: func(a *conductor.RollbackAuthorization) { a.ExpiresAt = testNow.Add(-time.Hour) },
 			want:   nil, // ValidateAtTime returns a window error; assert non-nil + not activated
-		},
-		{
-			name: "scoped_rollback_audience",
-			mutate: func(a *conductor.RollbackAuthorization) {
-				a.Audience = conductor.Audience{InstanceIDs: []string{"other"}}
-			},
-			want: conductor.ErrInvalidRollback,
 		},
 		{
 			name: "wrong_current_target",
@@ -326,6 +318,42 @@ func TestRollbackAuthorizationMismatches(t *testing.T) {
 				t.Fatalf("active version = %d, want 2 (rejected rollback must not activate)", active.Bundle.Version)
 			}
 		})
+	}
+}
+
+func TestRollbackAuthorizationLegacyAudienceAccepted(t *testing.T) {
+	policyKey := newTestKey(t)
+	rk1 := newPurposeKey(t, "rollback-1", signing.PurposePolicyBundleRollback)
+	rk2 := newPurposeKey(t, "rollback-2", signing.PurposePolicyBundleRollback)
+	cache := openTestCache(t)
+	v1 := signedTestBundle(t, policyKey, "bundle-1", 1, "")
+	if _, err := cache.storeVerified(v1, testVerifyOptions(policyKey, rk1, rk2)); err != nil {
+		t.Fatalf("storeVerified(v1): %v", err)
+	}
+	v1Hash, err := v1.CanonicalHash()
+	if err != nil {
+		t.Fatalf("CanonicalHash(v1): %v", err)
+	}
+	v2 := signedTestBundle(t, policyKey, "bundle-2", 2, v1Hash)
+	if _, err := cache.storeVerified(v2, testVerifyOptions(policyKey, rk1, rk2)); err != nil {
+		t.Fatalf("storeVerified(v2): %v", err)
+	}
+
+	auth := mutatedRollbackAuth(t, rk1, rk2, v2, v1, func(a *conductor.RollbackAuthorization) {
+		a.Audience = conductor.Audience{InstanceIDs: []string{"other"}}
+	})
+	opts := testVerifyOptions(policyKey, rk1, rk2)
+	opts.AllowRollback = true
+	opts.Rollback = &auth
+	if _, err := cache.storeVerified(v1, opts); err != nil {
+		t.Fatalf("storeVerified(scoped legacy rollback audience) error = %v, want nil", err)
+	}
+	active, err := cache.Active()
+	if err != nil {
+		t.Fatalf("Active(): %v", err)
+	}
+	if active.Bundle.Version != 1 {
+		t.Fatalf("active version = %d, want 1 (legacy audience ignored for stream-wide rollback)", active.Bundle.Version)
 	}
 }
 

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -129,7 +129,7 @@ type rollbackAuthorizationEnumerator interface {
 }
 
 type rollbackHeadReconciler interface {
-	ReconcileRollbackHeads(context.Context, []StoredRollbackAuthorization, time.Time) error
+	ReconcileRollbackHeads(context.Context, []StoredRollbackAuthorization, time.Time) ([]RollbackReconcileSkip, error)
 }
 
 type publishPolicyBundleRequest struct {
@@ -284,7 +284,7 @@ func NewHandler(opts HandlerOptions) (*Handler, error) {
 		}
 	}
 	auditQuerier, _ := opts.AuditSink.(AuditBatchQuerier)
-	if err := reconcileRollbackHeads(opts.Store, opts.EmergencyControls, now()); err != nil {
+	if err := reconcileRollbackHeads(opts.Store, opts.EmergencyControls, now(), opts.Logger); err != nil {
 		return nil, err
 	}
 	return &Handler{
@@ -312,7 +312,13 @@ func NewHandler(opts HandlerOptions) (*Handler, error) {
 	}, nil
 }
 
-func reconcileRollbackHeads(store BundleStore, emergencyControls EmergencyStore, now time.Time) error {
+// reconcileRollbackHeads re-applies persisted rollback authorizations to the
+// stream heads at startup. It is best-effort: a failure to enumerate or a single
+// unapplyable authorization is logged and tolerated, never fatal, so the control
+// plane still starts (the durable head markers loaded by the store hold the
+// effective head regardless). Only a programming error from the store (nil
+// receiver) is propagated.
+func reconcileRollbackHeads(store BundleStore, emergencyControls EmergencyStore, now time.Time, logger *slog.Logger) error {
 	if emergencyControls == nil {
 		return nil
 	}
@@ -326,9 +332,26 @@ func reconcileRollbackHeads(store BundleStore, emergencyControls EmergencyStore,
 	}
 	records, err := lister.RollbackAuthorizations(context.Background())
 	if err != nil {
+		// A control plane must still start even if the persisted rollback
+		// authorizations cannot be listed; the durable head markers remain the
+		// source of truth for the effective policy head.
+		if logger != nil {
+			logger.Warn("conductor_rollback_reconcile_list_failed", "error", err.Error())
+		}
+		return nil
+	}
+	skipped, err := reconciler.ReconcileRollbackHeads(context.Background(), records, now)
+	if err != nil {
 		return err
 	}
-	return reconciler.ReconcileRollbackHeads(context.Background(), records, now)
+	for _, skip := range skipped {
+		if logger != nil {
+			logger.Warn("conductor_rollback_reconcile_skipped",
+				"authorization_id", skip.AuthorizationID,
+				"error", skip.Err.Error())
+		}
+	}
+	return nil
 }
 
 func DefaultCapabilities(conductorID string) conductor.CapabilitiesResponse {

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -823,6 +823,10 @@ func (h *Handler) handlePublishRollbackAuthorization(w http.ResponseWriter, r *h
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
+	if len(req.Authorization.Audience.InstanceIDs) != 0 || len(req.Authorization.Audience.Labels) != 0 {
+		writeStoreError(w, fmt.Errorf("%w: rollback audience must be empty", conductor.ErrInvalidRollback))
+		return
+	}
 	now := h.now()
 	if err := validateMaxValidity(req.Authorization.CreatedAt, req.Authorization.ExpiresAt, h.rollbackMaxTTL); err != nil {
 		writeStoreError(w, err)

--- a/enterprise/conductor/controlplane/handler_test.go
+++ b/enterprise/conductor/controlplane/handler_test.go
@@ -295,6 +295,59 @@ func TestHandlerPublishRollbackAuthorizationMissingTargetDoesNotRecord(t *testin
 	}
 }
 
+func TestHandlerPublishRollbackAuthorizationRejectsAudience(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		audience conductor.Audience
+	}{
+		{name: "instance_ids", audience: conductor.Audience{InstanceIDs: []string{"edge-01"}}},
+		{name: "labels", audience: conductor.Audience{Labels: map[string]string{"tier": "prod"}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			store := mustStore(t)
+			signer := newTestSigner(t)
+			v1 := signedControlBundle(t, signer, bundleSpec{
+				id:       "bundle-handler-audience-v1-" + tt.name,
+				version:  1,
+				audience: conductor.Audience{InstanceIDs: []string{"*"}},
+			})
+			r1, _, err := store.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+			if err != nil {
+				t.Fatalf("Publish(v1) error = %v", err)
+			}
+			v2 := signedControlBundle(t, signer, bundleSpec{
+				id:           "bundle-handler-audience-v2-" + tt.name,
+				version:      2,
+				previousHash: r1.BundleHash,
+				audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+				configYAML:   "mode: strict\napi_allowlist:\n  - audience2.example.com\n",
+			})
+			if _, _, err := store.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+				t.Fatalf("Publish(v2) error = %v", err)
+			}
+			auth := signedRollbackAuthorizationForBundles(t, "rollback-handler-audience-"+tt.name, v2, v1, testNow)
+			auth.Audience = tt.audience
+			signatures, resolver := signConductorPreimage(t, auth.SignablePreimage, signing.PurposePolicyBundleRollback, "rollback-signer-1", "rollback-signer-2")
+			auth.Signatures = signatures
+			if err := auth.Validate(); err != nil {
+				t.Fatalf("Validate(legacy audience) error = %v, want nil", err)
+			}
+			handler := newTestHandlerWithOptions(t, store, nil, resolver)
+			body, err := json.Marshal(publishRollbackAuthorizationRequest{Authorization: auth})
+			if err != nil {
+				t.Fatalf("Marshal(rollback): %v", err)
+			}
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, RollbackAuthorizationsPath, strings.NewReader(string(body)))
+			req.Header.Set("X-Pipelock-Admin", "ok")
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code != http.StatusUnprocessableEntity || !strings.Contains(w.Body.String(), "rollback audience must be empty") {
+				t.Fatalf("rollback audience status=%d body=%s, want 422 audience error", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 func TestHandlerPublishesAndServesEmergencyControls(t *testing.T) {
 	msg, killResolver := signedRemoteKillMessageWithResolver(t, "kill-handler", 3, conductor.KillSwitchActive, testNow)
 	auth, rollbackResolver := signedRollbackAuthorizationWithResolver(t, "rollback-handler", 4, testNow)

--- a/enterprise/conductor/controlplane/rollback_coverage_test.go
+++ b/enterprise/conductor/controlplane/rollback_coverage_test.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -287,25 +288,36 @@ func TestReconcileRollbackHeadsBranches(t *testing.T) {
 
 // TestReconcileRollbackHeadsToleratesLegacyAudience is the regression for the
 // startup-bricking migration bug: a rollback authorization persisted by an
-// earlier release carried a non-empty audience, which the current validator
-// rejects. Reconciliation must SKIP it (collected with the audience error) and
-// return no fatal error, so a control plane with such legacy state still starts.
+// earlier release carried a non-empty audience. Reconciliation must ignore that
+// legacy audience and apply the stream-wide rollback when the bundles are
+// present.
 func TestReconcileRollbackHeadsToleratesLegacyAudience(t *testing.T) {
 	store, err := OpenFileBundleStore(t.TempDir())
 	if err != nil {
 		t.Fatalf("OpenFileBundleStore() error = %v", err)
 	}
-	legacy := conductor.RollbackAuthorization{
-		SchemaVersion:   conductor.SchemaVersion,
-		AuthorizationID: "rollback-legacy-audience",
-		OrgID:           "org-local",
-		FleetID:         "prod",
-		Audience:        conductor.Audience{InstanceIDs: []string{"edge-01"}},
-		CurrentBundleID: "bundle-current",
-		CurrentVersion:  2,
-		TargetBundleID:  "bundle-target",
-		TargetVersion:   1,
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-legacy-audience-v1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	r1, _, err := store.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
 	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-legacy-audience-v2",
+		version:      2,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - legacy2.example.com\n",
+	})
+	if _, _, err := store.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+	legacy := signedRollbackAuthorizationForBundles(t, "rollback-legacy-audience", v2, v1, testNow)
+	legacy.Audience = conductor.Audience{InstanceIDs: []string{"edge-01"}}
 	skips, err := store.ReconcileRollbackHeads(
 		t.Context(),
 		[]StoredRollbackAuthorization{{Authorization: legacy, PublishedAt: testNow}},
@@ -314,9 +326,59 @@ func TestReconcileRollbackHeadsToleratesLegacyAudience(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReconcileRollbackHeads(legacy audience) err=%v, want nil (tolerated)", err)
 	}
-	if len(skips) != 1 || skips[0].AuthorizationID != "rollback-legacy-audience" ||
-		!strings.Contains(skips[0].Err.Error(), "audience must be empty") {
-		t.Fatalf("ReconcileRollbackHeads(legacy audience) skips=%+v, want one audience-rejected skip", skips)
+	if len(skips) != 0 {
+		t.Fatalf("ReconcileRollbackHeads(legacy audience) skips=%+v, want none", skips)
+	}
+	latest, err := store.Latest(t.Context(), defaultFollowerIdentity(), testNow.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("Latest(after legacy audience reconcile) error = %v", err)
+	}
+	if latest.Bundle.BundleID != "bundle-legacy-audience-v1" {
+		t.Fatalf("Latest(after legacy audience reconcile) bundle=%q, want bundle-legacy-audience-v1", latest.Bundle.BundleID)
+	}
+}
+
+func TestReconcileRollbackHeadsFatalOnStreamHeadWriteFailure(t *testing.T) {
+	store, err := OpenFileBundleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore() error = %v", err)
+	}
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-reconcile-fatal-v1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	r1, _, err := store.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-reconcile-fatal-v2",
+		version:      2,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - fatal2.example.com\n",
+	})
+	if _, _, err := store.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+	auth := signedRollbackAuthorizationForBundles(t, "rollback-reconcile-fatal", v2, v1, testNow)
+	store.streamHeadsDir = filepath.Join(store.dir, "missing-stream-heads")
+
+	skips, err := store.ReconcileRollbackHeads(
+		t.Context(),
+		[]StoredRollbackAuthorization{{Authorization: auth, PublishedAt: testNow}},
+		testNow.Add(time.Minute),
+	)
+	if err == nil {
+		t.Fatal("ReconcileRollbackHeads(write failure) error = nil, want fatal error")
+	}
+	if len(skips) != 0 {
+		t.Fatalf("ReconcileRollbackHeads(write failure) skips=%+v, want none", skips)
+	}
+	if errors.Is(err, conductor.ErrInvalidRollback) || errors.Is(err, ErrBundleNotFound) {
+		t.Fatalf("ReconcileRollbackHeads(write failure) err=%v, want non-logical fatal error", err)
 	}
 }
 

--- a/enterprise/conductor/controlplane/rollback_coverage_test.go
+++ b/enterprise/conductor/controlplane/rollback_coverage_test.go
@@ -1,0 +1,572 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package controlplane
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
+)
+
+// TestApplyRollbackHeadGuards exercises the nil-receiver, structurally invalid
+// authorization, and current<=target rejection branches that the durable/forward
+// tests do not reach.
+func TestApplyRollbackHeadGuards(t *testing.T) {
+	var nilStore *FileBundleStore
+	if err := nilStore.ApplyRollbackHead(t.Context(), conductor.RollbackAuthorization{}, testNow); !errors.Is(err, ErrStoreRequired) {
+		t.Fatalf("ApplyRollbackHead(nil store) err=%v, want ErrStoreRequired", err)
+	}
+
+	store, err := OpenFileBundleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore() error = %v", err)
+	}
+	// Empty authorization fails RollbackAuthorization.Validate() before any
+	// store lookup.
+	if err := store.ApplyRollbackHead(t.Context(), conductor.RollbackAuthorization{}, testNow); err == nil {
+		t.Fatal("ApplyRollbackHead(empty auth) error = nil, want validation error")
+	}
+
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-guard-v1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	r1, _, err := store.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-guard-v2",
+		version:      2,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - guard2.example.com\n",
+	})
+	if _, _, err := store.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+
+	// Zero now defaults to time.Now().UTC() inside ApplyRollbackHead. A valid
+	// v2->v1 rollback applied with a zero now must still succeed.
+	auth := signedRollbackAuthorizationForBundles(t, "rollback-zero-now", v2, v1, testNow)
+	if err := store.ApplyRollbackHead(t.Context(), auth, time.Time{}); err != nil {
+		t.Fatalf("ApplyRollbackHead(zero now) error = %v", err)
+	}
+}
+
+// TestApplyRollbackHeadSupersededHeadNoOp covers the branch where a later forward
+// publish has already moved the head past the rollback's current version, so a
+// stale operator retry must be a no-op (nil) rather than moving the head
+// backward again.
+func TestApplyRollbackHeadSupersededHeadNoOp(t *testing.T) {
+	store, err := OpenFileBundleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore() error = %v", err)
+	}
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-superseded-v1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	r1, _, err := store.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-superseded-v2",
+		version:      2,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - superseded2.example.com\n",
+	})
+	if _, _, err := store.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+	// Roll back v2 -> v1, then publish v3 forward from the rollback target.
+	auth := signedRollbackAuthorizationForBundles(t, "rollback-superseded", v2, v1, testNow)
+	if err := store.ApplyRollbackHead(t.Context(), auth, testNow); err != nil {
+		t.Fatalf("ApplyRollbackHead() error = %v", err)
+	}
+	v3 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-superseded-v3",
+		version:      3,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - superseded3.example.com\n",
+	})
+	if _, _, err := store.Publish(t.Context(), v3, PublishOptions{Now: testNow.Add(2 * time.Minute)}); err != nil {
+		t.Fatalf("Publish(v3) error = %v", err)
+	}
+	// Head is now v3 (version 3) > auth.CurrentVersion (2): a stale retry of the
+	// v2->v1 rollback must be a no-op and leave the head at v3.
+	if err := store.ApplyRollbackHead(t.Context(), auth, testNow.Add(3*time.Minute)); err != nil {
+		t.Fatalf("ApplyRollbackHead(stale retry) error = %v", err)
+	}
+	latest, err := store.Latest(t.Context(), defaultFollowerIdentity(), testNow.Add(4*time.Minute))
+	if err != nil {
+		t.Fatalf("Latest() error = %v", err)
+	}
+	if latest.Bundle.BundleID != "bundle-superseded-v3" {
+		t.Fatalf("Latest() bundle=%q, want bundle-superseded-v3 (stale rollback must not move head back)", latest.Bundle.BundleID)
+	}
+}
+
+// TestApplyRollbackHeadCurrentInDifferentStream covers the branch where the
+// rollback's current bundle exists but lives in a different stream than the
+// target, which is rejected as ErrInvalidRollback.
+func TestApplyRollbackHeadCurrentInDifferentStream(t *testing.T) {
+	store, err := OpenFileBundleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore() error = %v", err)
+	}
+	signer := newTestSigner(t)
+	// Target stream (wildcard audience).
+	targetV1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-xstream-target",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	if _, _, err := store.Publish(t.Context(), targetV1, PublishOptions{Now: testNow}); err != nil {
+		t.Fatalf("Publish(target) error = %v", err)
+	}
+	// A separate canary stream holds the "current" bundle at a higher version.
+	currentV2 := signedControlBundle(t, signer, bundleSpec{
+		id:         "bundle-xstream-current",
+		version:    2,
+		audience:   conductor.Audience{Labels: map[string]string{"ring": "canary"}},
+		configYAML: "mode: strict\napi_allowlist:\n  - xstream-current.example.com\n",
+	})
+	if _, _, err := store.Publish(t.Context(), currentV2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+		t.Fatalf("Publish(current) error = %v", err)
+	}
+	// current (canary stream) and target (wildcard stream) are in different
+	// streams; the rollback must be rejected.
+	auth := signedRollbackAuthorizationForBundles(t, "rollback-xstream", currentV2, targetV1, testNow)
+	if err := store.ApplyRollbackHead(t.Context(), auth, testNow); !errors.Is(err, conductor.ErrInvalidRollback) {
+		t.Fatalf("ApplyRollbackHead(cross-stream current) err=%v, want ErrInvalidRollback", err)
+	}
+}
+
+// TestBundleByIDVersionGuards covers the nil-store, invalid-identifier, and
+// zero-version rejection paths plus the defensive duplicate-match error in
+// bundleByIDVersionLocked.
+func TestBundleByIDVersionGuards(t *testing.T) {
+	var nilStore *FileBundleStore
+	if _, err := nilStore.BundleByIDVersion(t.Context(), "bundle-x", 1); !errors.Is(err, ErrStoreRequired) {
+		t.Fatalf("BundleByIDVersion(nil store) err=%v, want ErrStoreRequired", err)
+	}
+
+	store, err := OpenFileBundleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore() error = %v", err)
+	}
+	if _, err := store.BundleByIDVersion(t.Context(), "bad id!", 1); err == nil {
+		t.Fatal("BundleByIDVersion(invalid id) error = nil, want identifier error")
+	}
+	if _, err := store.BundleByIDVersion(t.Context(), "bundle-x", 0); !errors.Is(err, conductor.ErrMissingField) {
+		t.Fatalf("BundleByIDVersion(zero version) err=%v, want ErrMissingField", err)
+	}
+
+	// Defensive duplicate guard: two in-memory records share the same
+	// bundle_id/version. Publish enforces uniqueness, so inject records
+	// directly to reach the locked-lookup branch.
+	signer := newTestSigner(t)
+	dupA := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-dup-lookup",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	dupB := signedControlBundle(t, signer, bundleSpec{
+		id:         "bundle-dup-lookup",
+		version:    1,
+		audience:   conductor.Audience{Labels: map[string]string{"ring": "canary"}},
+		configYAML: "mode: strict\napi_allowlist:\n  - dup-b.example.com\n",
+	})
+	store.records = map[string]PublishedBundle{
+		"hash-a": {Bundle: dupA, BundleHash: "hash-a", StreamKey: "stream-a"},
+		"hash-b": {Bundle: dupB, BundleHash: "hash-b", StreamKey: "stream-b"},
+	}
+	if _, err := store.BundleByIDVersion(t.Context(), "bundle-dup-lookup", 1); !errors.Is(err, ErrInvalidStoreRecord) {
+		t.Fatalf("BundleByIDVersion(duplicate match) err=%v, want ErrInvalidStoreRecord", err)
+	}
+}
+
+// TestReconcileRollbackHeadsBranches covers nil-store, empty-list no-op,
+// newest-first ordering across multiple records, and the wrapped apply error.
+func TestReconcileRollbackHeadsBranches(t *testing.T) {
+	var nilStore *FileBundleStore
+	if _, err := nilStore.ReconcileRollbackHeads(t.Context(), nil, testNow); !errors.Is(err, ErrStoreRequired) {
+		t.Fatalf("ReconcileRollbackHeads(nil store) err=%v, want ErrStoreRequired", err)
+	}
+
+	store, err := OpenFileBundleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore() error = %v", err)
+	}
+	if skips, err := store.ReconcileRollbackHeads(t.Context(), nil, testNow); err != nil || len(skips) != 0 {
+		t.Fatalf("ReconcileRollbackHeads(empty) skips=%v err=%v, want nil no-op", skips, err)
+	}
+
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-reconcile-multi-v1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	r1, _, err := store.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-reconcile-multi-v2",
+		version:      2,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - reconcile-multi2.example.com\n",
+	})
+	if _, _, err := store.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+
+	// Two records both roll v2->v1. Sorting newest-first applies the newer
+	// record first (head -> v1); the older record then converges idempotently
+	// because the head already equals the target. The list-supplied (unsorted)
+	// order is intentionally older-then-newer to exercise the sort.
+	older := signedRollbackAuthorizationForBundles(t, "rollback-reconcile-older", v2, v1, testNow)
+	newer := signedRollbackAuthorizationForBundles(t, "rollback-reconcile-newer", v2, v1, testNow.Add(time.Minute))
+	// newer-first then older exercises the descending comparator's negative
+	// branch (a newer than b => -1); the trailing older record then converges
+	// idempotently.
+	records := []StoredRollbackAuthorization{
+		{Authorization: newer, PublishedAt: testNow.Add(time.Minute)},
+		{Authorization: older, PublishedAt: testNow},
+	}
+	if skips, err := store.ReconcileRollbackHeads(t.Context(), records, testNow.Add(3*time.Minute)); err != nil || len(skips) != 0 {
+		t.Fatalf("ReconcileRollbackHeads(multi) skips=%v err=%v", skips, err)
+	}
+	latest, err := store.Latest(t.Context(), defaultFollowerIdentity(), testNow.Add(4*time.Minute))
+	if err != nil {
+		t.Fatalf("Latest() error = %v", err)
+	}
+	if latest.Bundle.BundleID != "bundle-reconcile-multi-v1" {
+		t.Fatalf("Latest() bundle=%q, want bundle-reconcile-multi-v1", latest.Bundle.BundleID)
+	}
+
+	// An unapplyable record is TOLERATED, not fatal: a record whose target bundle
+	// is absent fails ApplyRollbackHead with ErrBundleNotFound, is collected as a
+	// skip carrying the authorization ID, and reconciliation returns no error so
+	// one stale authorization never bricks startup.
+	missingTarget := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-reconcile-absent",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	badAuth := signedRollbackAuthorizationForBundles(t, "rollback-reconcile-bad", v2, missingTarget, testNow)
+	badRecords := []StoredRollbackAuthorization{{Authorization: badAuth, PublishedAt: testNow}}
+	skips, err := store.ReconcileRollbackHeads(t.Context(), badRecords, testNow.Add(5*time.Minute))
+	if err != nil {
+		t.Fatalf("ReconcileRollbackHeads(bad target) err=%v, want nil (tolerated)", err)
+	}
+	if len(skips) != 1 || skips[0].AuthorizationID != "rollback-reconcile-bad" || !errors.Is(skips[0].Err, ErrBundleNotFound) {
+		t.Fatalf("ReconcileRollbackHeads(bad target) skips=%+v, want one ErrBundleNotFound skip for rollback-reconcile-bad", skips)
+	}
+}
+
+// TestReconcileRollbackHeadsToleratesLegacyAudience is the regression for the
+// startup-bricking migration bug: a rollback authorization persisted by an
+// earlier release carried a non-empty audience, which the current validator
+// rejects. Reconciliation must SKIP it (collected with the audience error) and
+// return no fatal error, so a control plane with such legacy state still starts.
+func TestReconcileRollbackHeadsToleratesLegacyAudience(t *testing.T) {
+	store, err := OpenFileBundleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore() error = %v", err)
+	}
+	legacy := conductor.RollbackAuthorization{
+		SchemaVersion:   conductor.SchemaVersion,
+		AuthorizationID: "rollback-legacy-audience",
+		OrgID:           "org-local",
+		FleetID:         "prod",
+		Audience:        conductor.Audience{InstanceIDs: []string{"edge-01"}},
+		CurrentBundleID: "bundle-current",
+		CurrentVersion:  2,
+		TargetBundleID:  "bundle-target",
+		TargetVersion:   1,
+	}
+	skips, err := store.ReconcileRollbackHeads(
+		t.Context(),
+		[]StoredRollbackAuthorization{{Authorization: legacy, PublishedAt: testNow}},
+		testNow,
+	)
+	if err != nil {
+		t.Fatalf("ReconcileRollbackHeads(legacy audience) err=%v, want nil (tolerated)", err)
+	}
+	if len(skips) != 1 || skips[0].AuthorizationID != "rollback-legacy-audience" ||
+		!strings.Contains(skips[0].Err.Error(), "audience must be empty") {
+		t.Fatalf("ReconcileRollbackHeads(legacy audience) skips=%+v, want one audience-rejected skip", skips)
+	}
+}
+
+// stubEnumerator implements EmergencyStore + the optional enumerator interface
+// so reconcileRollbackHeads can reach the list/skip branches without a full
+// emergency store.
+type stubEnumerator struct {
+	EmergencyStore
+	records []StoredRollbackAuthorization
+	err     error
+}
+
+func (s stubEnumerator) RollbackAuthorizations(context.Context) ([]StoredRollbackAuthorization, error) {
+	return s.records, s.err
+}
+
+// TestReconcileRollbackHeadsHelperBranches covers the package-level
+// reconcileRollbackHeads helper: nil emergency controls, stores/controls that do
+// not implement the optional interfaces, and an enumerator that returns an error.
+func TestReconcileRollbackHeadsHelperBranches(t *testing.T) {
+	store, err := OpenFileBundleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore() error = %v", err)
+	}
+
+	// nil emergency controls: no-op.
+	if err := reconcileRollbackHeads(store, nil, testNow, nil); err != nil {
+		t.Fatalf("reconcileRollbackHeads(nil emergency) error = %v", err)
+	}
+
+	// Emergency controls that do not implement rollbackAuthorizationEnumerator:
+	// no-op. failingEmergencyStore has no RollbackAuthorizations method.
+	if err := reconcileRollbackHeads(store, failingEmergencyStore{}, testNow, nil); err != nil {
+		t.Fatalf("reconcileRollbackHeads(non-enumerator emergency) error = %v", err)
+	}
+
+	// Emergency controls enumerate but the store is not a rollbackHeadReconciler:
+	// no-op. stubBundleStore does not implement ReconcileRollbackHeads.
+	enumerator := stubEnumerator{EmergencyStore: failingEmergencyStore{}}
+	if err := reconcileRollbackHeads(stubBundleStore{}, enumerator, testNow, nil); err != nil {
+		t.Fatalf("reconcileRollbackHeads(non-reconciler store) error = %v", err)
+	}
+
+	// Enumerator returns an error: TOLERATED (logged, not surfaced) so the
+	// control plane still starts even if persisted authorizations cannot be read.
+	var logbuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logbuf, nil))
+	failing := stubEnumerator{EmergencyStore: failingEmergencyStore{}, err: errors.New("enumerate failed")}
+	if err := reconcileRollbackHeads(store, failing, testNow, logger); err != nil {
+		t.Fatalf("reconcileRollbackHeads(enumerate error) err=%v, want nil (tolerated)", err)
+	}
+	if !strings.Contains(logbuf.String(), "conductor_rollback_reconcile_list_failed") {
+		t.Fatalf("reconcileRollbackHeads(enumerate error) log=%q, want list-failed warning", logbuf.String())
+	}
+}
+
+// stubBundleStore implements BundleStore but NOT rollbackHeadReconciler, so the
+// reconcile helper takes the no-op type-assertion branch.
+type stubBundleStore struct{}
+
+func (stubBundleStore) Publish(context.Context, conductor.PolicyBundle, PublishOptions) (PublishedBundle, bool, error) {
+	return PublishedBundle{}, false, nil
+}
+
+func (stubBundleStore) Latest(context.Context, FollowerIdentity, time.Time) (PublishedBundle, error) {
+	return PublishedBundle{}, ErrBundleNotFound
+}
+
+func (stubBundleStore) BundleByIDVersion(context.Context, string, uint64) (PublishedBundle, error) {
+	return PublishedBundle{}, ErrBundleNotFound
+}
+
+func (stubBundleStore) ApplyRollbackHead(context.Context, conductor.RollbackAuthorization, time.Time) error {
+	return nil
+}
+
+// TestApplyRollbackCeilingUnavailableBundles drives the leader-side ceiling
+// helper through the current-unavailable, target-unavailable, and cross-stream
+// branches by serving GET latest with a published rollback authorization whose
+// referenced bundles are missing or live in a different stream.
+func TestApplyRollbackCeilingUnavailableBundles(t *testing.T) {
+	// current unavailable: rollback references a current bundle that was never
+	// published, while the target IS present. The ceiling returns a 404-mapped
+	// error rather than serving any bundle.
+	t.Run("current unavailable", func(t *testing.T) {
+		store := mustStore(t)
+		handler := newTestHandler(t, store, nil)
+		signer := newTestSigner(t)
+		audience := conductor.Audience{InstanceIDs: []string{"*"}}
+		target := signedControlBundle(t, signer, bundleSpec{
+			id:       "bundle-ceiling-cur-target",
+			version:  1,
+			audience: audience,
+		})
+		if _, _, err := store.Publish(t.Context(), target, PublishOptions{Now: testNow}); err != nil {
+			t.Fatalf("Publish(target) error = %v", err)
+		}
+		// current (version 2) is referenced by the auth but never published.
+		missingCurrent := signedControlBundle(t, signer, bundleSpec{
+			id:         "bundle-ceiling-cur-current",
+			version:    2,
+			audience:   audience,
+			configYAML: "mode: strict\napi_allowlist:\n  - cur-current.example.com\n",
+		})
+		auth := signedRollbackAuthorizationForBundles(t, "rollback-ceiling-cur", missingCurrent, target, testNow)
+		if _, created, err := handler.emergencyControls.PublishRollbackAuthorization(t.Context(), auth, testNow); err != nil || !created {
+			t.Fatalf("PublishRollbackAuthorization() created=%v err=%v, want created", created, err)
+		}
+		w := latestPolicyBundle(t, handler, nil)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("current-unavailable status=%d body=%s, want 404", w.Code, w.Body.String())
+		}
+	})
+
+	// target unavailable: rollback references a current bundle that IS present
+	// but a target bundle that was never published. The ceiling returns a
+	// 404-mapped error.
+	t.Run("target unavailable", func(t *testing.T) {
+		store := mustStore(t)
+		handler := newTestHandler(t, store, nil)
+		signer := newTestSigner(t)
+		audience := conductor.Audience{InstanceIDs: []string{"*"}}
+		current := signedControlBundle(t, signer, bundleSpec{
+			id:       "bundle-ceiling-tgt-current",
+			version:  2,
+			audience: audience,
+		})
+		if _, _, err := store.Publish(t.Context(), current, PublishOptions{Now: testNow}); err != nil {
+			t.Fatalf("Publish(current) error = %v", err)
+		}
+		// target (version 1) is referenced by the auth but never published.
+		missingTarget := signedControlBundle(t, signer, bundleSpec{
+			id:         "bundle-ceiling-tgt-target",
+			version:    1,
+			audience:   audience,
+			configYAML: "mode: strict\napi_allowlist:\n  - tgt-target.example.com\n",
+		})
+		auth := signedRollbackAuthorizationForBundles(t, "rollback-ceiling-tgt", current, missingTarget, testNow)
+		if _, created, err := handler.emergencyControls.PublishRollbackAuthorization(t.Context(), auth, testNow); err != nil || !created {
+			t.Fatalf("PublishRollbackAuthorization() created=%v err=%v, want created", created, err)
+		}
+		w := latestPolicyBundle(t, handler, nil)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("target-unavailable status=%d body=%s, want 404", w.Code, w.Body.String())
+		}
+	})
+
+	// cross-stream: current and target live in a different stream than the
+	// follower's latest bundle, so the ceiling leaves the latest unchanged.
+	t.Run("cross stream returns latest unchanged", func(t *testing.T) {
+		store := mustStore(t)
+		handler := newTestHandler(t, store, nil)
+		signer := newTestSigner(t)
+
+		// Follower's matching stream: a wildcard-audience bundle (the latest the
+		// default follower identity resolves to).
+		wildcard := signedControlBundle(t, signer, bundleSpec{
+			id:       "bundle-ceiling-cross-wild",
+			version:  1,
+			audience: conductor.Audience{InstanceIDs: []string{"*"}},
+		})
+		if _, _, err := store.Publish(t.Context(), wildcard, PublishOptions{Now: testNow}); err != nil {
+			t.Fatalf("Publish(wildcard) error = %v", err)
+		}
+
+		// A separate canary stream holds the rollback's current/target bundles.
+		canary := conductor.Audience{Labels: map[string]string{"ring": "canary"}}
+		canaryV1 := signedControlBundle(t, signer, bundleSpec{
+			id:         "bundle-ceiling-cross-canary-v1",
+			version:    1,
+			audience:   canary,
+			configYAML: "mode: strict\napi_allowlist:\n  - cross-canary1.example.com\n",
+		})
+		cr1, _, err := store.Publish(t.Context(), canaryV1, PublishOptions{Now: testNow})
+		if err != nil {
+			t.Fatalf("Publish(canary v1) error = %v", err)
+		}
+		canaryV2 := signedControlBundle(t, signer, bundleSpec{
+			id:           "bundle-ceiling-cross-canary-v2",
+			version:      2,
+			previousHash: cr1.BundleHash,
+			audience:     canary,
+			configYAML:   "mode: strict\napi_allowlist:\n  - cross-canary2.example.com\n",
+		})
+		if _, _, err := store.Publish(t.Context(), canaryV2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+			t.Fatalf("Publish(canary v2) error = %v", err)
+		}
+		auth := signedRollbackAuthorizationForBundles(t, "rollback-ceiling-cross", canaryV2, canaryV1, testNow)
+		if _, created, err := handler.emergencyControls.PublishRollbackAuthorization(t.Context(), auth, testNow); err != nil || !created {
+			t.Fatalf("PublishRollbackAuthorization() created=%v err=%v, want created", created, err)
+		}
+		// The default follower resolves to the wildcard stream; the canary
+		// rollback is cross-stream so the wildcard latest is served unchanged.
+		w := latestPolicyBundle(t, handler, nil)
+		assertLatestBundleID(t, w, "bundle-ceiling-cross-wild")
+	})
+}
+
+// TestApplyRollbackCeilingNilEmergencyControls covers the early return when the
+// handler has no emergency controls configured.
+func TestApplyRollbackCeilingNilEmergencyControls(t *testing.T) {
+	store := mustStore(t)
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-ceiling-noemerg",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	if _, _, err := store.Publish(t.Context(), v1, PublishOptions{Now: testNow}); err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	handler := newTestHandler(t, store, nil)
+	handler.emergencyControls = nil
+	got, err := handler.applyRollbackCeiling(
+		httptest.NewRequestWithContext(context.Background(), http.MethodGet, LatestPolicyBundlePath, nil),
+		defaultFollowerIdentity(),
+		PublishedBundle{Bundle: v1},
+		testNow,
+	)
+	if err != nil {
+		t.Fatalf("applyRollbackCeiling(nil emergency) error = %v", err)
+	}
+	if got.Bundle.BundleID != "bundle-ceiling-noemerg" {
+		t.Fatalf("applyRollbackCeiling(nil emergency) bundle=%q, want latest unchanged", got.Bundle.BundleID)
+	}
+}
+
+// TestApplyRollbackCeilingActiveLookupError covers the branch where
+// ActiveRollbackForFollower returns an error: the ceiling propagates it rather
+// than serving a possibly-stale bundle.
+func TestApplyRollbackCeilingActiveLookupError(t *testing.T) {
+	store := mustStore(t)
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-ceiling-activeerr",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	if _, _, err := store.Publish(t.Context(), v1, PublishOptions{Now: testNow}); err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	handler := newTestHandler(t, store, nil)
+	handler.emergencyControls = failingEmergencyStore{}
+	_, err := handler.applyRollbackCeiling(
+		httptest.NewRequestWithContext(context.Background(), http.MethodGet, LatestPolicyBundlePath, nil),
+		defaultFollowerIdentity(),
+		PublishedBundle{Bundle: v1},
+		testNow,
+	)
+	if err == nil || !strings.Contains(err.Error(), "emergency store failed") {
+		t.Fatalf("applyRollbackCeiling(active lookup error) err=%v, want propagated error", err)
+	}
+}

--- a/enterprise/conductor/controlplane/store.go
+++ b/enterprise/conductor/controlplane/store.go
@@ -341,14 +341,11 @@ type RollbackReconcileSkip struct {
 
 // ReconcileRollbackHeads re-applies persisted rollback authorizations to the
 // stream heads at startup, healing a head whose marker write failed after the
-// authorization was accepted. It is best-effort and TOLERANT: an authorization
-// that no longer applies (e.g. one persisted by an earlier release whose
-// audience the current validator rejects, one already superseded by a forward
-// publish, or one whose bundles are no longer present) is collected as a skip
-// and reconciliation continues. The durable per-stream head markers loaded by
-// the store remain the source of truth for the effective head, so skipping a
-// stale authorization is safe; failing the whole startup on one bad record would
-// take the fleet's coordination down. Only a nil store is fatal.
+// authorization was accepted. It is tolerant only for logical/stale
+// authorizations that no longer apply, such as one already superseded by a
+// forward publish or one whose bundles are no longer present. Persistence and
+// other non-logical errors are fatal so startup cannot serve an un-rolled-back
+// forward head after recovery fails to durably apply the rollback marker.
 func (s *FileBundleStore) ReconcileRollbackHeads(ctx context.Context, records []StoredRollbackAuthorization, now time.Time) ([]RollbackReconcileSkip, error) {
 	if s == nil {
 		return nil, ErrStoreRequired
@@ -370,10 +367,14 @@ func (s *FileBundleStore) ReconcileRollbackHeads(ctx context.Context, records []
 	var skipped []RollbackReconcileSkip
 	for _, record := range sorted {
 		if err := s.ApplyRollbackHead(ctx, record.Authorization, now); err != nil {
-			skipped = append(skipped, RollbackReconcileSkip{
-				AuthorizationID: record.Authorization.AuthorizationID,
-				Err:             err,
-			})
+			if errors.Is(err, conductor.ErrInvalidRollback) || errors.Is(err, ErrBundleNotFound) {
+				skipped = append(skipped, RollbackReconcileSkip{
+					AuthorizationID: record.Authorization.AuthorizationID,
+					Err:             err,
+				})
+				continue
+			}
+			return skipped, err
 		}
 	}
 	return skipped, nil

--- a/enterprise/conductor/controlplane/store.go
+++ b/enterprise/conductor/controlplane/store.go
@@ -330,12 +330,31 @@ func (s *FileBundleStore) BundleByIDVersion(_ context.Context, bundleID string, 
 	return s.bundleByIDVersionLocked(bundleID, version)
 }
 
-func (s *FileBundleStore) ReconcileRollbackHeads(ctx context.Context, records []StoredRollbackAuthorization, now time.Time) error {
+// RollbackReconcileSkip records a persisted rollback authorization that startup
+// reconciliation could not re-apply. It is informational, not fatal: the caller
+// logs it and continues so one stale authorization never bricks the control
+// plane (see ReconcileRollbackHeads).
+type RollbackReconcileSkip struct {
+	AuthorizationID string
+	Err             error
+}
+
+// ReconcileRollbackHeads re-applies persisted rollback authorizations to the
+// stream heads at startup, healing a head whose marker write failed after the
+// authorization was accepted. It is best-effort and TOLERANT: an authorization
+// that no longer applies (e.g. one persisted by an earlier release whose
+// audience the current validator rejects, one already superseded by a forward
+// publish, or one whose bundles are no longer present) is collected as a skip
+// and reconciliation continues. The durable per-stream head markers loaded by
+// the store remain the source of truth for the effective head, so skipping a
+// stale authorization is safe; failing the whole startup on one bad record would
+// take the fleet's coordination down. Only a nil store is fatal.
+func (s *FileBundleStore) ReconcileRollbackHeads(ctx context.Context, records []StoredRollbackAuthorization, now time.Time) ([]RollbackReconcileSkip, error) {
 	if s == nil {
-		return ErrStoreRequired
+		return nil, ErrStoreRequired
 	}
 	if len(records) == 0 {
-		return nil
+		return nil, nil
 	}
 	sorted := slices.Clone(records)
 	slices.SortFunc(sorted, func(a, b StoredRollbackAuthorization) int {
@@ -348,12 +367,16 @@ func (s *FileBundleStore) ReconcileRollbackHeads(ctx context.Context, records []
 			return 0
 		}
 	})
+	var skipped []RollbackReconcileSkip
 	for _, record := range sorted {
 		if err := s.ApplyRollbackHead(ctx, record.Authorization, now); err != nil {
-			return fmt.Errorf("reconcile rollback authorization %q: %w", record.Authorization.AuthorizationID, err)
+			skipped = append(skipped, RollbackReconcileSkip{
+				AuthorizationID: record.Authorization.AuthorizationID,
+				Err:             err,
+			})
 		}
 	}
-	return nil
+	return skipped, nil
 }
 
 func (s *FileBundleStore) bundleByIDVersionLocked(bundleID string, version uint64) (PublishedBundle, error) {

--- a/enterprise/conductor/controlplane/store_test.go
+++ b/enterprise/conductor/controlplane/store_test.go
@@ -273,7 +273,7 @@ func TestRollbackHeadReconciliationRecoversAfterTTL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenFileEmergencyStore(reopen) error = %v", err)
 	}
-	if err := reconcileRollbackHeads(reopenedStore, reopenedEmergency, testNow.Add(2*time.Hour)); err != nil {
+	if err := reconcileRollbackHeads(reopenedStore, reopenedEmergency, testNow.Add(2*time.Hour), nil); err != nil {
 		t.Fatalf("reconcileRollbackHeads(after TTL) error = %v", err)
 	}
 	latest, err = reopenedStore.Latest(t.Context(), defaultFollowerIdentity(), testNow.Add(2*time.Hour))

--- a/enterprise/conductor/controlplane/store_test.go
+++ b/enterprise/conductor/controlplane/store_test.go
@@ -285,6 +285,77 @@ func TestRollbackHeadReconciliationRecoversAfterTTL(t *testing.T) {
 	}
 }
 
+func TestRollbackHeadReconciliationLoadsLegacyAudienceEmergencyState(t *testing.T) {
+	store, err := OpenFileBundleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore() error = %v", err)
+	}
+	emergencyDir := t.TempDir()
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-reconcile-legacy-v1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	r1, _, err := store.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-reconcile-legacy-v2",
+		version:      2,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - legacy-reconcile2.example.com\n",
+	})
+	if _, _, err := store.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+	auth := conductor.RollbackAuthorization{
+		SchemaVersion:   conductor.SchemaVersion,
+		AuthorizationID: "rollback-reconcile-legacy-audience",
+		OrgID:           v2.OrgID,
+		FleetID:         v2.FleetID,
+		Audience:        conductor.Audience{Labels: map[string]string{"tier": "legacy"}},
+		CurrentBundleID: v2.BundleID,
+		CurrentVersion:  v2.Version,
+		TargetBundleID:  v1.BundleID,
+		TargetVersion:   v1.Version,
+		Counter:         1,
+		Reason:          "operator rollback",
+		CreatedAt:       testNow,
+		ExpiresAt:       testNow.Add(time.Hour),
+	}
+	auth.Signatures, _ = signConductorPreimage(t, auth.SignablePreimage, signing.PurposePolicyBundleRollback, "rollback-signer-1", "rollback-signer-2")
+	authHash, err := auth.CanonicalHash()
+	if err != nil {
+		t.Fatalf("CanonicalHash(rollback): %v", err)
+	}
+	record := StoredRollbackAuthorization{
+		Authorization:     auth,
+		AuthorizationHash: authHash,
+		PublishedAt:       testNow,
+	}
+	if err := writeEmergencyState(filepath.Join(emergencyDir, emergencyStateFileName), emergencyStateRecord{Rollbacks: []StoredRollbackAuthorization{record}}); err != nil {
+		t.Fatalf("writeEmergencyState(legacy rollback): %v", err)
+	}
+
+	reopenedEmergency, err := OpenFileEmergencyStore(emergencyDir)
+	if err != nil {
+		t.Fatalf("OpenFileEmergencyStore(legacy rollback) error = %v", err)
+	}
+	if err := reconcileRollbackHeads(store, reopenedEmergency, testNow.Add(2*time.Minute), nil); err != nil {
+		t.Fatalf("reconcileRollbackHeads(legacy rollback) error = %v", err)
+	}
+	latest, err := store.Latest(t.Context(), defaultFollowerIdentity(), testNow.Add(3*time.Minute))
+	if err != nil {
+		t.Fatalf("Latest(after legacy reconcile) error = %v", err)
+	}
+	if latest.Bundle.BundleID != "bundle-reconcile-legacy-v1" {
+		t.Fatalf("Latest(after legacy reconcile) bundle=%q, want bundle-reconcile-legacy-v1", latest.Bundle.BundleID)
+	}
+}
+
 func TestFileBundleStoreApplyRollbackHeadForwardProgress(t *testing.T) {
 	store, err := OpenFileBundleStore(t.TempDir())
 	if err != nil {

--- a/enterprise/conductor/enrollmentclient/client_test.go
+++ b/enterprise/conductor/enrollmentclient/client_test.go
@@ -6,6 +6,7 @@ package enrollmentclient
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -110,4 +111,172 @@ func TestEnrollHappyPathUsesEnrollEndpoint(t *testing.T) {
 	if doer.req == nil || doer.req.URL.Scheme != "https" || doer.req.URL.Path != "/api/v1/conductor/enroll" {
 		t.Fatalf("request URL = %v, want https enroll endpoint", doer.req.URL)
 	}
+}
+
+// TestValidateResponseMissingFields covers each per-field guard in
+// validateResponse so a malformed conductor response fails closed with a
+// specific diagnostic instead of accepting a partial enrollment.
+func TestValidateResponseMissingFields(t *testing.T) {
+	const enrolledAt = `"enrolled_at":"2026-06-11T12:00:00Z"`
+	full := map[string]string{
+		"org_id":       `"org_id":"org-main"`,
+		"fleet_id":     `"fleet_id":"prod"`,
+		"instance_id":  `"instance_id":"edge-01"`,
+		"environment":  `"environment":"prod"`,
+		"audit_key_id": `"audit_key_id":"audit-key-1"`,
+	}
+	order := []string{"org_id", "fleet_id", "instance_id", "environment", "audit_key_id"}
+	wantByMissing := map[string]string{
+		"org_id":       "missing org_id",
+		"fleet_id":     "missing fleet_id",
+		"instance_id":  "missing instance_id",
+		"environment":  "missing environment",
+		"audit_key_id": "missing audit_key_id",
+	}
+	for _, missing := range order {
+		t.Run("missing "+missing, func(t *testing.T) {
+			fields := []string{}
+			for _, key := range order {
+				if key == missing {
+					continue
+				}
+				fields = append(fields, full[key])
+			}
+			fields = append(fields, enrolledAt)
+			body := "{" + strings.Join(fields, ",") + "}"
+			c, err := New(Config{BaseURL: "https://conductor.example:8895", Client: &stubDoer{body: body}})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			_, err = c.Enroll(context.Background(), Request{
+				Token:          "pl_" + "enroll_test",
+				AuditKeyID:     "audit-key-1",
+				AuditPublicKey: strings.Repeat("a", 64),
+			})
+			if err == nil || !strings.Contains(err.Error(), wantByMissing[missing]) {
+				t.Fatalf("Enroll(missing %s) error = %v, want %q", missing, err, wantByMissing[missing])
+			}
+		})
+	}
+}
+
+// errDoer simulates a transport-level failure (DNS/TCP/TLS) from the HTTP client.
+type errDoer struct{}
+
+func (errDoer) Do(*http.Request) (*http.Response, error) {
+	return nil, errors.New("dial tcp: connection refused")
+}
+
+// readErrDoer returns a response body that errors mid-read so the io.ReadAll
+// path is exercised.
+type readErrDoer struct{}
+
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) { return 0, errors.New("body read failed") }
+func (errReadCloser) Close() error             { return nil }
+
+func (readErrDoer) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusCreated,
+		Body:       errReadCloser{},
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestEnrollTransportAndDecodeErrors(t *testing.T) {
+	const token = "pl_" + "enroll_test"
+	t.Run("transport error", func(t *testing.T) {
+		c, err := New(Config{BaseURL: "https://conductor.example:8895", Client: errDoer{}})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		if _, err := c.Enroll(context.Background(), Request{Token: token, AuditKeyID: "audit-key-1"}); err == nil ||
+			!strings.Contains(err.Error(), "enroll request") {
+			t.Fatalf("Enroll(transport error) error = %v, want enroll request wrapped", err)
+		}
+	})
+
+	t.Run("body read error", func(t *testing.T) {
+		c, err := New(Config{BaseURL: "https://conductor.example:8895", Client: readErrDoer{}})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		if _, err := c.Enroll(context.Background(), Request{Token: token, AuditKeyID: "audit-key-1"}); err == nil ||
+			!strings.Contains(err.Error(), "read enroll response") {
+			t.Fatalf("Enroll(body read error) error = %v, want read enroll response wrapped", err)
+		}
+	})
+
+	t.Run("non-2xx status redacts token in snippet", func(t *testing.T) {
+		// The error body echoes the token; the snippet must redact it so the
+		// secret never lands in logs.
+		doer := &stubDoer{status: http.StatusForbidden, body: "denied for token " + token}
+		c, err := New(Config{BaseURL: "https://conductor.example:8895", Client: doer})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		_, err = c.Enroll(context.Background(), Request{Token: token, AuditKeyID: "audit-key-1"})
+		if err == nil || !strings.Contains(err.Error(), "status=403") {
+			t.Fatalf("Enroll(403) error = %v, want status=403", err)
+		}
+		if strings.Contains(err.Error(), token) {
+			t.Fatalf("Enroll(403) error leaked token: %v", err)
+		}
+		if !strings.Contains(err.Error(), "[redacted]") {
+			t.Fatalf("Enroll(403) error = %v, want [redacted] token", err)
+		}
+	})
+
+	t.Run("invalid json decode error", func(t *testing.T) {
+		doer := &stubDoer{body: "{not json"}
+		c, err := New(Config{BaseURL: "https://conductor.example:8895", Client: doer})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		if _, err := c.Enroll(context.Background(), Request{Token: token, AuditKeyID: "audit-key-1"}); err == nil ||
+			!strings.Contains(err.Error(), "decode enroll response") {
+			t.Fatalf("Enroll(bad json) error = %v, want decode enroll response wrapped", err)
+		}
+	})
+}
+
+func TestEnrollNilClient(t *testing.T) {
+	var c *Client
+	if _, err := c.Enroll(context.Background(), Request{}); err == nil || !strings.Contains(err.Error(), "nil client") {
+		t.Fatalf("Enroll(nil client) error = %v, want nil client", err)
+	}
+}
+
+func TestSnippetRedactsAndSanitizes(t *testing.T) {
+	t.Run("redacts secrets and strips control chars", func(t *testing.T) {
+		secret := "pl_" + "snippet_secret"
+		raw := "  error with \x00\x07control " + secret + " and \x7f trailing  "
+		got := snippet([]byte(raw), secret, "", "   ")
+		if strings.Contains(got, secret) {
+			t.Fatalf("snippet leaked secret: %q", got)
+		}
+		if !strings.Contains(got, "[redacted]") {
+			t.Fatalf("snippet missing [redacted]: %q", got)
+		}
+		if strings.ContainsRune(got, 0x00) || strings.ContainsRune(got, 0x07) || strings.ContainsRune(got, 0x7f) {
+			t.Fatalf("snippet retained control chars: %q", got)
+		}
+		// Leading/trailing whitespace is trimmed before mapping.
+		if strings.HasPrefix(got, " ") || strings.HasSuffix(got, " ") {
+			t.Fatalf("snippet not trimmed: %q", got)
+		}
+	})
+
+	t.Run("truncates beyond 512 bytes", func(t *testing.T) {
+		raw := strings.Repeat("a", 600)
+		got := snippet([]byte(raw))
+		if !strings.HasSuffix(got, "...") {
+			t.Fatalf("snippet(>512) missing ellipsis suffix: len=%d", len(got))
+		}
+		if len(got) != 512+len("...") {
+			t.Fatalf("snippet(>512) len=%d, want %d", len(got), 512+len("..."))
+		}
+	})
 }

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -714,9 +714,6 @@ func (r RollbackAuthorization) Validate() error {
 	if err := validateOrgFleet(r.OrgID, r.FleetID); err != nil {
 		return err
 	}
-	if len(r.Audience.InstanceIDs) != 0 || len(r.Audience.Labels) != 0 {
-		return fmt.Errorf("%w: rollback audience must be empty", ErrInvalidRollback)
-	}
 	if err := validateIdentifier("current_bundle_id", r.CurrentBundleID); err != nil {
 		return err
 	}

--- a/enterprise/conductor/messages_test.go
+++ b/enterprise/conductor/messages_test.go
@@ -1028,8 +1028,6 @@ func TestRollbackAuthorization_ValidateErrors(t *testing.T) {
 		{"unsupported_schema", func(r *RollbackAuthorization) { r.SchemaVersion = 99 }, ErrUnsupportedSchemaVersion},
 		{"missing_authorization_id", func(r *RollbackAuthorization) { r.AuthorizationID = "" }, ErrMissingField},
 		{"missing_fleet", func(r *RollbackAuthorization) { r.FleetID = "" }, ErrMissingField},
-		{"instance_scoped_audience", func(r *RollbackAuthorization) { r.Audience = Audience{InstanceIDs: []string{"instance-1"}} }, ErrInvalidRollback},
-		{"label_scoped_audience", func(r *RollbackAuthorization) { r.Audience = Audience{Labels: map[string]string{"tier": "prod"}} }, ErrInvalidRollback},
 		{"missing_current_bundle", func(r *RollbackAuthorization) { r.CurrentBundleID = "" }, ErrMissingField},
 		{"missing_target_bundle", func(r *RollbackAuthorization) { r.TargetBundleID = "" }, ErrMissingField},
 		{"missing_counter", func(r *RollbackAuthorization) { r.Counter = 0 }, ErrMissingField},
@@ -1044,6 +1042,19 @@ func TestRollbackAuthorization_ValidateErrors(t *testing.T) {
 				t.Fatalf("Validate() = %v, want %v", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestRollbackAuthorization_ValidateToleratesLegacyAudience(t *testing.T) {
+	for _, audience := range []Audience{
+		{InstanceIDs: []string{"instance-1"}},
+		{Labels: map[string]string{"tier": "prod"}},
+	} {
+		auth := testRollbackAuthorization()
+		auth.Audience = audience
+		if err := auth.Validate(); err != nil {
+			t.Fatalf("Validate() with audience %+v error = %v, want nil", audience, err)
+		}
 	}
 }
 

--- a/internal/cli/runtime/conductor_enrollment_test.go
+++ b/internal/cli/runtime/conductor_enrollment_test.go
@@ -184,6 +184,101 @@ func TestInitConductorEnrollmentFailureDoesNotBlockStartup(t *testing.T) {
 	}
 }
 
+func TestRunConductorAutoEnrollNilRecorderKeyErrors(t *testing.T) {
+	cfg := conductorEnrollmentTestConfig(t)
+	client := &conductorEnrollmentStubClient{}
+	// A nil recorder/flight-recorder key fails closed before any enroll POST:
+	// the follower has no audit public key to register.
+	_, err := runConductorAutoEnroll(t.Context(), cfg, nil, client)
+	if err == nil || !strings.Contains(err.Error(), "flight recorder signing key") {
+		t.Fatalf("runConductorAutoEnroll(nil key) error = %v, want recorder key required", err)
+	}
+	if client.count() != 0 {
+		t.Fatalf("request count = %d, want 0 (no POST before key check)", client.count())
+	}
+}
+
+func TestRunConductorAutoEnrollTokenReadError(t *testing.T) {
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	cfg := conductorEnrollmentTestConfig(t)
+	// Point at a token path that does not exist so the read fails.
+	cfg.Conductor.EnrollmentTokenPath = filepath.Join(t.TempDir(), "absent-token")
+	client := &conductorEnrollmentStubClient{}
+	_, err = runConductorAutoEnroll(t.Context(), cfg, priv, client)
+	if err == nil || !strings.Contains(err.Error(), "read conductor enrollment token") {
+		t.Fatalf("runConductorAutoEnroll(token read error) error = %v, want read error", err)
+	}
+	if client.count() != 0 {
+		t.Fatalf("request count = %d, want 0", client.count())
+	}
+}
+
+func TestRunConductorAutoEnrollBuildsClientWhenNil(t *testing.T) {
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	cfg := conductorEnrollmentTestConfig(t)
+	client := &conductorEnrollmentStubClient{}
+	// When the caller passes a nil HTTPDoer, runConductorAutoEnroll builds one
+	// via newConductorEnrollmentHTTPClient. Stub that constructor.
+	old := newConductorEnrollmentHTTPClient
+	newConductorEnrollmentHTTPClient = func(config.Conductor) (enrollmentclient.HTTPDoer, error) {
+		return client, nil
+	}
+	t.Cleanup(func() { newConductorEnrollmentHTTPClient = old })
+
+	enrolled, err := runConductorAutoEnroll(t.Context(), cfg, priv, nil)
+	if err != nil {
+		t.Fatalf("runConductorAutoEnroll(nil client) error = %v", err)
+	}
+	if !enrolled {
+		t.Fatal("runConductorAutoEnroll(nil client) enrolled=false, want true")
+	}
+	if client.count() != 1 {
+		t.Fatalf("request count = %d, want 1", client.count())
+	}
+}
+
+func TestReadConductorEnrollmentToken(t *testing.T) {
+	t.Run("unreadable path", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "no-such-token")
+		if _, err := readConductorEnrollmentToken(missing); err == nil ||
+			!strings.Contains(err.Error(), "read conductor enrollment token") {
+			t.Fatalf("readConductorEnrollmentToken(missing) error = %v, want read error", err)
+		}
+	})
+
+	t.Run("empty contents", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "blank-token")
+		if err := os.WriteFile(path, []byte("  \n"), 0o600); err != nil {
+			t.Fatalf("write blank token: %v", err)
+		}
+		if _, err := readConductorEnrollmentToken(path); err == nil ||
+			!strings.Contains(err.Error(), "token file is empty") {
+			t.Fatalf("readConductorEnrollmentToken(blank) error = %v, want empty", err)
+		}
+	})
+
+	t.Run("trims and returns", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "token")
+		token := "pl_" + "enroll_runtime"
+		if err := os.WriteFile(path, []byte("  "+token+"\n"), 0o600); err != nil {
+			t.Fatalf("write token: %v", err)
+		}
+		got, err := readConductorEnrollmentToken(path)
+		if err != nil {
+			t.Fatalf("readConductorEnrollmentToken() error = %v", err)
+		}
+		if got != token {
+			t.Fatalf("readConductorEnrollmentToken() = %q, want %q", got, token)
+		}
+	})
+}
+
 func conductorEnrollmentTestConfig(t *testing.T) *config.Config {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/cli/runtime/conductor_targetbundle_test.go
+++ b/internal/cli/runtime/conductor_targetbundle_test.go
@@ -1,0 +1,70 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package runtime
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/applycache"
+)
+
+// TestTargetBundleActiveError covers the branch where cache.Active() fails (no
+// bundle has ever been applied): targetBundle fails closed rather than rolling
+// back to nothing.
+func TestTargetBundleActiveError(t *testing.T) {
+	cache, err := applycache.Open(applycache.Config{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Open(cache): %v", err)
+	}
+	applier := conductorRollbackApplier{cache: cache}
+	if _, err := applier.targetBundle(); !errors.Is(err, applycache.ErrNoValidBundle) {
+		t.Fatalf("targetBundle(empty cache) err=%v, want ErrNoValidBundle", err)
+	}
+}
+
+// TestTargetBundleEmptyBaseHash covers the predecessor-missing branch: a single
+// applied bundle has no BaseHash, so there is nothing to roll back to.
+func TestTargetBundleEmptyBaseHash(t *testing.T) {
+	s, policy := newConductorApplyTestServer(t)
+	b1 := signedRuntimePolicyBundle(t, policy, "bundle-target-1", 1, "", rollbackTestBundle1YAML)
+	if _, err := s.ApplyConductorPolicyBundle(b1, ConductorApplyOptions{Resolver: policy.resolver()}); err != nil {
+		t.Fatalf("apply bundle-1: %v", err)
+	}
+	cache, _ := s.conductorApply.(*applycache.Cache)
+	applier := conductorRollbackApplier{server: s, cache: cache, resolver: policy.resolver()}
+	if _, err := applier.targetBundle(); !errors.Is(err, applycache.ErrNoValidBundle) {
+		t.Fatalf("targetBundle(no predecessor) err=%v, want ErrNoValidBundle", err)
+	}
+}
+
+// TestTargetBundleUnreadableTargetRecord covers the branch where the active
+// bundle's predecessor record (reached via BaseHash) cannot be read. After two
+// bundles are applied, corrupting bundle-1's on-disk record makes the BaseHash
+// lookup fail so targetBundle returns the read error rather than a stale target.
+func TestTargetBundleUnreadableTargetRecord(t *testing.T) {
+	s, policy := newConductorApplyTestServer(t)
+	cache, b1, _ := applyTwoBundles(t, s, policy)
+
+	b1Hash, err := b1.CanonicalHash()
+	if err != nil {
+		t.Fatalf("CanonicalHash(bundle-1): %v", err)
+	}
+	// Predecessor record lives at <bundle_cache_dir>/bundles/<b1Hash>.json.
+	recordPath := filepath.Join(s.cfg.Conductor.BundleCacheDir, "bundles", b1Hash+".json")
+	if _, statErr := os.Stat(recordPath); statErr != nil {
+		t.Fatalf("predecessor record missing before corruption: %v", statErr)
+	}
+	if err := os.WriteFile(recordPath, []byte("{ not valid json"), 0o600); err != nil {
+		t.Fatalf("corrupt predecessor record: %v", err)
+	}
+
+	applier := conductorRollbackApplier{server: s, cache: cache, resolver: policy.resolver()}
+	if _, err := applier.targetBundle(); err == nil {
+		t.Fatal("targetBundle(corrupt predecessor) error = nil, want read failure")
+	}
+}


### PR DESCRIPTION
Follow-up to #743. Two fixes plus restored patch coverage.

**Upgrade crashloop fix (found and fixed on the live fleet).** A conductor leader that had persisted a rollback authorization under an earlier release (which permitted instance/label audiences) crashed on startup after #743 made rollback stream-wide: the audience-empty rule lived in the shared `RollbackAuthorization.Validate()`, so the emergency-store load re-validated every persisted record and the rejection bricked the control plane before it could serve. The rule now lives at the publish ingress (`handlePublishRollbackAuthorization`), not in `Validate()`, so already-persisted records load and the leader starts; integrity checks (schema, ids, hash, signature, validity) stay fatal on load. Rollback is stream-wide, so a legacy audience is ignored at apply.

**Reconcile no longer fails open.** Startup `ReconcileRollbackHeads` skips only logical/stale failures (`ErrInvalidRollback`, `ErrBundleNotFound`); any other error (for example a head-marker write I/O failure) is fatal, so a recovery that cannot persist the head never starts the leader serving the un-rolled-back bundle.

**Patch coverage** restored on the v2.7 follower enrollment and rollback code (enrollment client, rollback store/handler, enroll CLI, runtime auto-enroll), which #743 merged below target.

Regression tests: emergency-store load plus reconcile of a legacy audience-scoped record starts clean, the publish handler rejects a non-empty audience, and a non-logical reconcile error is fatal. Enterprise-gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging for conductor rollback reconciliation at startup, with tolerance for non-fatal failures.
  * Enhanced enrollment client error handling with better diagnostics and token redaction in error messages.

* **Tests**
  * Expanded test coverage for conductor enrollment, rollback authorization validation, bundle management, and emergency controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->