### PR TITLE
fix(release): build with patched Go 1.25.11

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,14 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
+          check-latest: true
+
+      - name: Verify Go version
+        run: |
+          got="$(go env GOVERSION)"
+          echo "GOVERSION=$got"
+          test "$got" = "go1.25.11"
 
       - name: Verify dependencies
         run: go mod verify


### PR DESCRIPTION
Moves v-tag release builds from Go 1.25.10 to Go 1.25.11.

Go 1.25.11 is the Go 1.25 patch that includes stdlib security fixes for crypto/x509 and net/textproto.

The workflow also sets check-latest and checks GOVERSION before later release steps run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to use Go 1.25.11 with latest version checking enabled.
  * Added verification step to ensure release process uses the correct Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->