### PR TITLE
Add Fleet Receipt Report verifier foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Pipelock will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### New Features
+
+- **Fleet Receipt Report verification foundation.** Adds the Apache/free verifier path for Fleet Receipt Report DSSE envelopes through `pipelock verify-receipt --fleet-report --key <fleet-report.pub>`, the `fleet-report-signing` key purpose, and the `fleet-receipt/v1` schema/spec foundation. Report creation remains Enterprise-gated and lands separately.
+
 ## [2.7.0] - 2026-06-10
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ Details, config examples, and gap analysis: [docs/owasp-mapping.md](docs/owasp-m
 | [Policy Spec v0.1](docs/policy-spec-v0.1.md) | Portable agent firewall policy format |
 | [Mediation Envelope](docs/guides/mediation-envelope.md) | Sideband metadata headers, config, interaction with receipts |
 | [Media Policy](docs/guides/media-policy.md) | Stego stripping, SVG hardening, allowed types, size limits |
-| [Receipt Verification](docs/guides/receipt-verification.md) | `pipelock verify-receipt`, standalone `pipelock-verifier`, conformance suite, chain integrity |
+| [Receipt Verification](docs/guides/receipt-verification.md) | `pipelock verify-receipt`, Fleet Receipt Report verification, standalone `pipelock-verifier`, conformance suite, chain integrity |
 | [Receipt Spec Profiles](docs/specs/in-toto-agent-action-receipt-v0.1.md) | in-toto attestation predicate for action receipts, with companion SCITT and AARP profiles and prior-art mapping |
 | [Audit Packet Threat Model](docs/security/audit-packet-threat-model.md) | What verified Audit Packets prove, what they do not prove, and the trust assumptions relying parties must pin |
 | [Receipt Transport Coverage](docs/guides/receipt-transports.md) | Receipt emission matrix across fetch, forward, CONNECT/TLS, WebSocket, MCP, and A2A paths |

--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -74,6 +74,41 @@ pipelock verify-receipt receipt.json --allow-unpinned
 Exit code 0 means valid (and signer-pinned, unless you passed `--allow-unpinned`);
 exit code 1 means invalid, malformed, or unpinned without `--allow-unpinned`.
 
+## Verifying a Fleet Receipt Report
+
+Fleet Receipt Reports are DSSE envelopes wrapping an in-toto Statement v1
+payload with the `fleet-receipt/v1` predicate. They summarize a fleet's
+included signed audit batches and carry the mediated-fraction completeness
+metric. They do not claim non-bypass; they prove the signed report's source set
+and arithmetic for mediated actions inside that source set.
+
+Pin the fleet-report public key:
+
+```bash
+pipelock verify-receipt fleet-receipt.dsse.json --fleet-report --key fleet-report.pub
+```
+
+Output on success:
+
+```text
+FLEET RECEIPT OK: fleet-receipt.dsse.json
+  Signer:           70b991eb...
+  Payload SHA-256:  9c46a3...
+  Org/Fleet:        pipelab/dogfood
+  Report ID:        019...
+  Level:            L1
+  Source batches:   12
+  Total actions:    481
+  Mediated fraction: 1
+```
+
+Without `--key`, the verifier can check structure and self-consistency only. It
+prints `FLEET RECEIPT UNPINNED` and exits non-zero unless `--allow-unpinned` is
+passed.
+
+See [Fleet Receipt Report v1](../specs/fleet-receipt-v1.md) for the wire
+format.
+
 ## Verifying a receipt chain
 
 Pass a flight recorder JSONL file (or `--chain DIR` for a multi-file chain that

--- a/docs/specs/fleet-receipt-v1.md
+++ b/docs/specs/fleet-receipt-v1.md
@@ -1,0 +1,118 @@
+# Fleet Receipt Report v1
+
+Fleet Receipt Report v1 is a signed, offline-verifiable rollup of accepted
+Conductor audit batches for one fleet and one report window.
+
+The report is an evidence artifact for mediated actions. It does not claim that
+unmediated actions were impossible or absent. The completeness fields say what
+fraction of the observed action records inside the included signed audit batches
+were mediated by Pipelock.
+
+## Envelope
+
+A Fleet Receipt Report is a DSSE v1 envelope:
+
+```json
+{
+  "payloadType": "application/vnd.in-toto+json",
+  "payload": "<base64 JCS-canonical in-toto Statement v1 JSON>",
+  "signatures": [
+    {
+      "keyid": "<hex Ed25519 public key>",
+      "key_purpose": "fleet-report-signing",
+      "algorithm": "ed25519",
+      "sig": "ed25519:<base64 signature>"
+    }
+  ]
+}
+```
+
+The signature is Ed25519 over DSSE PAE for the payload type and canonical
+payload bytes. The profile requires one signature and the
+`fleet-report-signing` key purpose.
+
+## Statement
+
+The payload is an in-toto Statement v1:
+
+```json
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "conductor-audit-batch:pipelab/dogfood/pl-1/audit-1",
+      "digest": {
+        "sha256": "<sourceBatches[].envelopeHash>"
+      }
+    }
+  ],
+  "predicateType": "https://pipelab.org/attestation/fleet-receipt/v1",
+  "predicate": {}
+}
+```
+
+Subjects anchor the report to the immutable source set. Producers MUST include
+exactly one subject per included audit batch. The subject name is
+`conductor-audit-batch:<orgId>/<fleetId>/<instanceId>/<batchId>`, and
+`digest.sha256` MUST equal that batch's `sourceBatches[].envelopeHash`.
+
+## Predicate
+
+Required fields:
+
+| Field | Meaning |
+|---|---|
+| `schemaVersion` | Must be `1`. |
+| `reportId` | Unique report identifier. |
+| `generatedAt` | RFC3339 UTC timestamp. |
+| `orgId` / `fleetId` | Fleet namespace. |
+| `reportWindow` | Inclusive source window selected by the producer. |
+| `verificationLevel` | `L1` for this verifier profile. |
+| `conductor` | Conductor identity and optional version. |
+| `sourceBatches` | Ordered accepted audit-batch references. |
+| `summary` | Action counts by follower, transport, action type, verdict, layer, severity. |
+| `completeness` | Signed mediated-fraction fields. |
+
+`sourceBatches` are ordered per follower. A verifier rejects duplicates,
+overlaps, and reordered sequence ranges for the same `(orgId, fleetId,
+instanceId)`.
+
+## Verification Levels
+
+L1 verifies the report envelope, schema, source-batch subject/digest set,
+summary arithmetic, completeness arithmetic, duplicate detection, and sequence
+ordering.
+It is the default procurement artifact.
+
+`L2` is reserved for a future forensic profile. A future `L2` verifier must
+replay operator-supplied raw audit batch envelopes and payloads, verify follower
+audit-batch signatures, and recompute the report summary from recorder entries.
+This v1 verifier rejects `L2` rather than accepting a stronger claim it did not
+perform.
+
+## Completeness Semantics
+
+`completeness.mediatedFraction` is a decimal string between `0` and `1`.
+
+The value means:
+
+> fraction of observed fleet action records in included signed audit batches
+> that were mediated by Pipelock
+
+It does not mean:
+
+> no bypass occurred
+
+Traffic outside Pipelock, outside enrolled followers, outside the report window,
+or omitted from unavailable audit batches is outside the claim.
+
+## Verification
+
+Use the free Apache binary:
+
+```bash
+pipelock verify-receipt fleet-receipt.dsse.json --fleet-report --key fleet-report.pub
+```
+
+Without `--key`, verification is structural-only and exits non-zero unless
+`--allow-unpinned` is passed.

--- a/internal/cli/signing/receipt.go
+++ b/internal/cli/signing/receipt.go
@@ -4,6 +4,7 @@
 package signing
 
 import (
+	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/luckyPipewrench/pipelock/internal/fleetreceipt"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	sigutil "github.com/luckyPipewrench/pipelock/internal/signing"
 )
@@ -26,16 +28,18 @@ func VerifyReceiptCmd() *cobra.Command {
 	var chainDir string
 	var sessionID string
 	var allowUnpinned bool
+	var fleetReport bool
 
 	cmd := &cobra.Command{
 		Use:   "verify-receipt [file]",
 		Short: "Verify a signed action receipt or receipt chain",
-		Long: `Verifies Ed25519 signatures on action receipts.
+		Long: `Verifies Ed25519 signatures on action receipts and Fleet Receipt Reports.
 
 For a single receipt JSON file: verifies the signature and prints details.
 For a flight recorder JSONL file: extracts all receipts and verifies the
 full hash chain (prev_hash linkage, seq continuity, signatures). For a
 multi-file chain spanning restarts or rotations, pass --chain DIR.
+For a Fleet Receipt Report DSSE envelope, pass --fleet-report.
 
 Signing-key rotation: a chain that rotated its signing key splits into
 segments. Each segment's key must be trusted. Pass --key once per trusted
@@ -53,6 +57,7 @@ Examples:
   pipelock verify-receipt --chain /var/lib/pipelock/evidence
   pipelock verify-receipt receipt.json --key 70b991eb...
   pipelock verify-receipt --chain DIR --key old.key --key new.key
+  pipelock verify-receipt fleet-receipt.dsse.json --fleet-report --key fleet-report.pub
   pipelock verify-receipt receipt.json --allow-unpinned`,
 		Args: func(_ *cobra.Command, args []string) error {
 			return validateReceiptSourceArgs(args, chainDir)
@@ -65,6 +70,12 @@ Examples:
 			}
 			if len(expectedKeys) > 0 && len(trustedKeys) == 0 {
 				return fmt.Errorf("--key was provided but no valid signer keys were resolved")
+			}
+			if fleetReport {
+				if chainDir != "" {
+					return fmt.Errorf("--fleet-report cannot be combined with --chain")
+				}
+				return verifyFleetReportWithOptions(out, args[0], trustedKeys, allowUnpinned)
 			}
 			if chainDir != "" {
 				return verifyChainFromSessionDirWithOptions(out, chainDir, sessionID, trustedKeys, allowUnpinned)
@@ -87,6 +98,7 @@ Examples:
 	cmd.Flags().StringVar(&chainDir, "chain", "", "verify the full receipt chain from an evidence directory")
 	cmd.Flags().StringVar(&sessionID, "session", "proxy", "receipt chain session ID inside the evidence directory")
 	cmd.Flags().BoolVar(&allowUnpinned, "allow-unpinned", false, "allow structural-only verification without a trusted signer key")
+	cmd.Flags().BoolVar(&fleetReport, "fleet-report", false, "verify a Fleet Receipt Report DSSE envelope")
 	return cmd
 }
 
@@ -125,6 +137,58 @@ func verifySingleReceiptWithOptions(out io.Writer, path, expectedKey string, all
 	}
 	printReceiptDetails(out, r)
 	return nil
+}
+
+func verifyFleetReportWithOptions(out io.Writer, path string, trustedKeys []string, allowUnpinned bool) error {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("reading fleet receipt: %w", err)
+	}
+	keyMap, err := fleetTrustedKeyMap(trustedKeys)
+	if err != nil {
+		return err
+	}
+	result, err := fleetreceipt.Verify(data, keyMap)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "FAILED: %s: %v\n", path, err)
+		return fmt.Errorf("fleet receipt verification failed: %w", err)
+	}
+	if result.Unpinned {
+		_, _ = fmt.Fprintf(out, "FLEET RECEIPT UNPINNED: %s\n", path)
+		_, _ = fmt.Fprintln(out, unpinnedReceiptBanner)
+	} else {
+		_, _ = fmt.Fprintf(out, "FLEET RECEIPT OK: %s\n", path)
+	}
+	_, _ = fmt.Fprintf(out, "  Signer:           %s\n", result.SignerKeyID)
+	_, _ = fmt.Fprintf(out, "  Payload SHA-256:  %s\n", result.PayloadSHA256)
+	_, _ = fmt.Fprintf(out, "  Org/Fleet:        %s/%s\n", result.Statement.Predicate.OrgID, result.Statement.Predicate.FleetID)
+	_, _ = fmt.Fprintf(out, "  Report ID:        %s\n", result.Statement.Predicate.ReportID)
+	_, _ = fmt.Fprintf(out, "  Level:            %s\n", result.Statement.Predicate.VerificationLevel)
+	_, _ = fmt.Fprintf(out, "  Source batches:   %d\n", result.SourceBatches)
+	_, _ = fmt.Fprintf(out, "  Total actions:    %d\n", result.TotalActions)
+	_, _ = fmt.Fprintf(out, "  Mediated fraction: %s\n", result.MediatedFraction)
+	if result.Unpinned && !allowUnpinned {
+		return fmt.Errorf("fleet receipt verification unpinned: pass --key for provenance or --allow-unpinned for structural-only verification")
+	}
+	return nil
+}
+
+func fleetTrustedKeyMap(keys []string) (map[string]ed25519.PublicKey, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]ed25519.PublicKey, len(keys))
+	for _, key := range keys {
+		raw, err := hex.DecodeString(key)
+		if err != nil {
+			return nil, fmt.Errorf("decode trusted fleet report key: %w", err)
+		}
+		if len(raw) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("trusted fleet report key length=%d want %d", len(raw), ed25519.PublicKeySize)
+		}
+		out[key] = ed25519.PublicKey(raw)
+	}
+	return out, nil
 }
 
 func verifyChainFromFile(out io.Writer, path string, trustedKeys []string) error {

--- a/internal/cli/signing/receipt.go
+++ b/internal/cli/signing/receipt.go
@@ -75,6 +75,9 @@ Examples:
 				if chainDir != "" {
 					return fmt.Errorf("--fleet-report cannot be combined with --chain")
 				}
+				if cmd.Flags().Changed("session") {
+					return fmt.Errorf("--fleet-report cannot be combined with --session")
+				}
 				return verifyFleetReportWithOptions(out, args[0], trustedKeys, allowUnpinned)
 			}
 			if chainDir != "" {

--- a/internal/cli/signing/receipt_test.go
+++ b/internal/cli/signing/receipt_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/fleetreceipt"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	sigutil "github.com/luckyPipewrench/pipelock/internal/signing"
@@ -166,6 +168,48 @@ func TestVerifyReceiptCmd_WithExpectedKey(t *testing.T) {
 
 	if !strings.Contains(buf.String(), "OK:") {
 		t.Errorf("expected OK in output, got: %s", buf.String())
+	}
+}
+
+func TestVerifyReceiptCmd_FleetReportWithExpectedKey(t *testing.T) {
+	t.Parallel()
+
+	pub, path := writeFleetReportFixture(t)
+	cmd := VerifyReceiptCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{path, "--fleet-report", "--key", hex.EncodeToString(pub)})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"FLEET RECEIPT OK:",
+		"Org/Fleet:        pipelab/dogfood",
+		"Source batches:   1",
+		"Total actions:    2",
+		"Mediated fraction: 1",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestVerifyReceiptCmd_FleetReportRequiresPinByDefault(t *testing.T) {
+	t.Parallel()
+
+	_, path := writeFleetReportFixture(t)
+	cmd := VerifyReceiptCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{path, "--fleet-report"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected unpinned fleet report verification to exit non-zero")
+	}
+	if !strings.Contains(buf.String(), "FLEET RECEIPT UNPINNED:") {
+		t.Fatalf("output missing unpinned warning:\n%s", buf.String())
 	}
 }
 
@@ -851,4 +895,79 @@ func TestResolveExpectedKeyHexesWrapsFailedKey(t *testing.T) {
 	if !strings.Contains(err.Error(), `resolving --key "not-a-key"`) {
 		t.Fatalf("expected failing key in error, got %v", err)
 	}
+}
+
+func writeFleetReportFixture(t *testing.T) (ed25519.PublicKey, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	keyID := hex.EncodeToString(pub)
+	statement := fleetreceipt.Statement{
+		Type: fleetreceipt.StatementType,
+		Subject: []fleetreceipt.Subject{{
+			Name:   "conductor-audit-batch:pipelab/dogfood/pl-1/audit-1",
+			Digest: fleetreceipt.Digest{SHA256: testHexSHA256("envelope")},
+		}},
+		PredicateType: fleetreceipt.PredicateType,
+		Predicate: fleetreceipt.Predicate{
+			SchemaVersion:     1,
+			ReportID:          "01934e1c-cd60-7abc-823a-d6f5e6f7a8b9",
+			GeneratedAt:       "2026-06-13T12:00:00Z",
+			OrgID:             "pipelab",
+			FleetID:           "dogfood",
+			ReportWindow:      fleetreceipt.TimeWindow{Start: "2026-06-13T11:00:00Z", End: "2026-06-13T12:00:00Z"},
+			VerificationLevel: fleetreceipt.VerificationLevelL1,
+			Conductor:         fleetreceipt.Conductor{ID: "conductor"},
+			SourceBatches: []fleetreceipt.SourceBatch{{
+				OrgID:           "pipelab",
+				FleetID:         "dogfood",
+				InstanceID:      "pl-1",
+				BatchID:         "audit-1",
+				SeqStart:        1,
+				SeqEnd:          2,
+				EventCount:      2,
+				PayloadSHA256:   testHexSHA256("payload"),
+				PayloadBytes:    512,
+				EnvelopeHash:    testHexSHA256("envelope"),
+				SegmentTailHash: testHexSHA256("tail"),
+				EmittedAt:       "2026-06-13T12:00:00Z",
+				ReceivedAt:      "2026-06-13T12:00:00Z",
+				SignatureKeyIDs: []string{"audit-key"},
+			}},
+			Summary: fleetreceipt.Summary{
+				TotalActions: 2,
+				ByFollower:   map[string]uint64{"pl-1": 2},
+				ByVerdict:    map[string]uint64{"allow": 1, "block": 1},
+			},
+			Completeness: fleetreceipt.Completeness{
+				ObservedActions:        2,
+				DroppedObservedActions: 0,
+				MediatedActions:        2,
+				MediatedFraction:       "1",
+				Basis:                  "included_signed_audit_batches",
+				Claim:                  "fraction of observed fleet action records in included signed audit batches that were mediated by Pipelock",
+				NonClaim:               "does not prove no bypass occurred outside Pipelock, outside enrolled followers, or outside the report window",
+			},
+		},
+	}
+	env, err := fleetreceipt.SignStatement(statement, keyID, priv)
+	if err != nil {
+		t.Fatalf("SignStatement: %v", err)
+	}
+	data, err := fleetreceipt.MarshalEnvelope(env)
+	if err != nil {
+		t.Fatalf("MarshalEnvelope: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "fleet-receipt.dsse.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return pub, path
+}
+
+func testHexSHA256(seed string) string {
+	sum := sha256.Sum256([]byte(seed))
+	return hex.EncodeToString(sum[:])
 }

--- a/internal/cli/signing/receipt_test.go
+++ b/internal/cli/signing/receipt_test.go
@@ -213,6 +213,23 @@ func TestVerifyReceiptCmd_FleetReportRequiresPinByDefault(t *testing.T) {
 	}
 }
 
+func TestVerifyReceiptCmd_FleetReportRejectsSessionSelector(t *testing.T) {
+	t.Parallel()
+
+	_, path := writeFleetReportFixture(t)
+	cmd := VerifyReceiptCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{path, "--fleet-report", "--session", "operator"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected --fleet-report with --session to fail")
+	}
+	if !strings.Contains(err.Error(), "--fleet-report cannot be combined with --session") {
+		t.Fatalf("Execute error = %v, want --session conflict", err)
+	}
+}
+
 func TestVerifyReceiptCmd_WithExpectedKeyFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/fleetreceipt/fleetreceipt.go
+++ b/internal/fleetreceipt/fleetreceipt.go
@@ -407,7 +407,7 @@ func validateSubjects(subjects []Subject, batches []SourceBatch) error {
 		if name == "" {
 			return fmt.Errorf("%w: subject.name required", ErrInvalidStatement)
 		}
-		if err := validateHexSHA256("subject.digest.sha256", subject.Digest.SHA256); err != nil {
+		if err := validateHexSHA256(ErrInvalidStatement, "subject.digest.sha256", subject.Digest.SHA256); err != nil {
 			return err
 		}
 		if _, ok := seen[name]; ok {
@@ -460,7 +460,7 @@ func validateSourceBatches(orgID, fleetID string, batches []SourceBatch) error {
 			"envelopeHash":    b.EnvelopeHash,
 			"segmentTailHash": b.SegmentTailHash,
 		} {
-			if err := validateHexSHA256(name, value); err != nil {
+			if err := validateHexSHA256(ErrInvalidPredicate, name, value); err != nil {
 				return err
 			}
 		}
@@ -507,20 +507,23 @@ func addUint64(a, b uint64) (uint64, bool) {
 	return a + b, true
 }
 
-func validateHexSHA256(name, value string) error {
+func validateHexSHA256(baseErr error, name, value string) error {
 	if len(value) != sha256.Size*2 {
-		return fmt.Errorf("%w: %s must be 64 hex chars", ErrInvalidPredicate, name)
+		return fmt.Errorf("%w: %s must be 64 hex chars", baseErr, name)
 	}
 	if _, err := hex.DecodeString(value); err != nil {
-		return fmt.Errorf("%w: %s must be hex", ErrInvalidPredicate, name)
+		return fmt.Errorf("%w: %s must be hex", baseErr, name)
 	}
 	if value != strings.ToLower(value) {
-		return fmt.Errorf("%w: %s must be lowercase hex", ErrInvalidPredicate, name)
+		return fmt.Errorf("%w: %s must be lowercase hex", baseErr, name)
 	}
 	return nil
 }
 
 func parseTime(name, value string) (time.Time, error) {
+	if !strings.HasSuffix(value, "Z") {
+		return time.Time{}, fmt.Errorf("%w: %s must be an RFC3339 UTC timestamp ending in Z", ErrInvalidPredicate, name)
+	}
 	parsed, err := time.Parse(time.RFC3339, value)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("%w: %s: %w", ErrInvalidPredicate, name, err)

--- a/internal/fleetreceipt/fleetreceipt.go
+++ b/internal/fleetreceipt/fleetreceipt.go
@@ -1,0 +1,644 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package fleetreceipt verifies Fleet Receipt Reports: DSSE envelopes wrapping
+// in-toto Statement v1 payloads with Pipelock's fleet-receipt/v1 predicate.
+package fleetreceipt
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const (
+	StatementType   = "https://in-toto.io/Statement/v1"
+	PredicateType   = "https://pipelab.org/attestation/fleet-receipt/v1"
+	DssePayloadType = "application/vnd.in-toto+json"
+
+	VerificationLevelL1 = "L1"
+
+	signatureAlgEd25519 = "ed25519"
+	signaturePrefix     = "ed25519:"
+)
+
+var (
+	ErrInvalidEnvelope  = errors.New("invalid fleet receipt envelope")
+	ErrInvalidStatement = errors.New("invalid fleet receipt statement")
+	ErrInvalidPredicate = errors.New("invalid fleet receipt predicate")
+	ErrUntrustedKey     = errors.New("fleet receipt signer key is not trusted")
+)
+
+type Envelope struct {
+	PayloadType string      `json:"payloadType"`
+	Payload     string      `json:"payload"`
+	Signatures  []Signature `json:"signatures"`
+}
+
+type Signature struct {
+	KeyID      string `json:"keyid"`
+	KeyPurpose string `json:"key_purpose"`
+	Algorithm  string `json:"algorithm"`
+	Sig        string `json:"sig"`
+}
+
+type Statement struct {
+	Type          string    `json:"_type"`
+	Subject       []Subject `json:"subject"`
+	PredicateType string    `json:"predicateType"`
+	Predicate     Predicate `json:"predicate"`
+}
+
+type Subject struct {
+	Name   string `json:"name"`
+	Digest Digest `json:"digest"`
+}
+
+type Digest struct {
+	SHA256 string `json:"sha256"`
+}
+
+type Predicate struct {
+	SchemaVersion        int                   `json:"schemaVersion"`
+	ReportID             string                `json:"reportId"`
+	GeneratedAt          string                `json:"generatedAt"`
+	OrgID                string                `json:"orgId"`
+	FleetID              string                `json:"fleetId"`
+	ReportWindow         TimeWindow            `json:"reportWindow"`
+	VerificationLevel    string                `json:"verificationLevel"`
+	Conductor            Conductor             `json:"conductor"`
+	SourceBatches        []SourceBatch         `json:"sourceBatches"`
+	Summary              Summary               `json:"summary"`
+	Completeness         Completeness          `json:"completeness"`
+	Limits               []string              `json:"limits,omitempty"`
+	ExternalCorrelations []ExternalCorrelation `json:"externalCorrelations,omitempty"`
+}
+
+type TimeWindow struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+type Conductor struct {
+	ID      string `json:"id"`
+	Version string `json:"version,omitempty"`
+}
+
+type SourceBatch struct {
+	OrgID           string   `json:"orgId"`
+	FleetID         string   `json:"fleetId"`
+	InstanceID      string   `json:"instanceId"`
+	BatchID         string   `json:"batchId"`
+	SeqStart        uint64   `json:"seqStart"`
+	SeqEnd          uint64   `json:"seqEnd"`
+	EventCount      uint64   `json:"eventCount"`
+	PayloadSHA256   string   `json:"payloadSha256"`
+	PayloadBytes    uint64   `json:"payloadBytes"`
+	EnvelopeHash    string   `json:"envelopeHash"`
+	SegmentTailHash string   `json:"segmentTailHash"`
+	DroppedCount    uint64   `json:"droppedCount"`
+	EmittedAt       string   `json:"emittedAt"`
+	ReceivedAt      string   `json:"receivedAt"`
+	SignatureKeyIDs []string `json:"signatureKeyIds"`
+}
+
+type Summary struct {
+	TotalActions uint64            `json:"totalActions"`
+	ByFollower   map[string]uint64 `json:"byFollower,omitempty"`
+	ByTransport  map[string]uint64 `json:"byTransport,omitempty"`
+	ByActionType map[string]uint64 `json:"byActionType,omitempty"`
+	ByVerdict    map[string]uint64 `json:"byVerdict,omitempty"`
+	ByLayer      map[string]uint64 `json:"byLayer,omitempty"`
+	BySeverity   map[string]uint64 `json:"bySeverity,omitempty"`
+}
+
+type Completeness struct {
+	ObservedActions        uint64 `json:"observedActions"`
+	DroppedObservedActions uint64 `json:"droppedObservedActions"`
+	MediatedActions        uint64 `json:"mediatedActions"`
+	MediatedFraction       string `json:"mediatedFraction"`
+	Basis                  string `json:"basis"`
+	Claim                  string `json:"claim"`
+	NonClaim               string `json:"nonClaim"`
+}
+
+type ExternalCorrelation struct {
+	System string `json:"system"`
+	Ref    string `json:"ref"`
+	Digest Digest `json:"digest,omitempty"`
+}
+
+type Verification struct {
+	Statement        Statement
+	SignerKeyID      string
+	Trusted          bool
+	Unpinned         bool
+	PayloadSHA256    string
+	SourceBatches    int
+	TotalActions     uint64
+	MediatedFraction string
+}
+
+func SignStatement(statement Statement, signerKeyID string, priv ed25519.PrivateKey) (Envelope, error) {
+	if len(priv) != ed25519.PrivateKeySize {
+		return Envelope{}, fmt.Errorf("%w: private key length=%d", ErrInvalidEnvelope, len(priv))
+	}
+	if err := statement.Validate(); err != nil {
+		return Envelope{}, err
+	}
+	payload, err := CanonicalStatement(statement)
+	if err != nil {
+		return Envelope{}, err
+	}
+	if strings.TrimSpace(signerKeyID) == "" {
+		signerKeyID = hex.EncodeToString(priv.Public().(ed25519.PublicKey))
+	}
+	sig := ed25519.Sign(priv, pae(DssePayloadType, payload))
+	return Envelope{
+		PayloadType: DssePayloadType,
+		Payload:     base64.StdEncoding.EncodeToString(payload),
+		Signatures: []Signature{{
+			KeyID:      signerKeyID,
+			KeyPurpose: signing.PurposeFleetReportSigning.String(),
+			Algorithm:  signatureAlgEd25519,
+			Sig:        signaturePrefix + base64.StdEncoding.EncodeToString(sig),
+		}},
+	}, nil
+}
+
+func Verify(data []byte, trustedKeys map[string]ed25519.PublicKey) (Verification, error) {
+	env, err := UnmarshalEnvelope(data)
+	if err != nil {
+		return Verification{}, err
+	}
+	return VerifyEnvelope(env, trustedKeys)
+}
+
+func UnmarshalEnvelope(data []byte) (Envelope, error) {
+	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
+		return Envelope{}, fmt.Errorf("%w: %w", ErrInvalidEnvelope, err)
+	}
+	var env Envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return Envelope{}, fmt.Errorf("%w: %w", ErrInvalidEnvelope, err)
+	}
+	return env, nil
+}
+
+func VerifyEnvelope(env Envelope, trustedKeys map[string]ed25519.PublicKey) (Verification, error) {
+	if env.PayloadType != DssePayloadType {
+		return Verification{}, fmt.Errorf("%w: payloadType=%q", ErrInvalidEnvelope, env.PayloadType)
+	}
+	if len(env.Signatures) != 1 {
+		return Verification{}, fmt.Errorf("%w: signatures=%d want 1", ErrInvalidEnvelope, len(env.Signatures))
+	}
+	payload, err := base64.StdEncoding.DecodeString(env.Payload)
+	if err != nil {
+		return Verification{}, fmt.Errorf("%w: decode payload: %w", ErrInvalidEnvelope, err)
+	}
+	statement, err := ParseStatement(payload)
+	if err != nil {
+		return Verification{}, err
+	}
+	if err := statement.Validate(); err != nil {
+		return Verification{}, err
+	}
+	canonical, err := CanonicalStatement(statement)
+	if err != nil {
+		return Verification{}, err
+	}
+	if !bytes.Equal(payload, canonical) {
+		return Verification{}, fmt.Errorf("%w: payload is not canonical JCS", ErrInvalidEnvelope)
+	}
+	sig := env.Signatures[0]
+	if sig.KeyPurpose != signing.PurposeFleetReportSigning.String() {
+		return Verification{}, fmt.Errorf("%w: key_purpose=%q", ErrInvalidEnvelope, sig.KeyPurpose)
+	}
+	if sig.Algorithm != signatureAlgEd25519 {
+		return Verification{}, fmt.Errorf("%w: algorithm=%q", ErrInvalidEnvelope, sig.Algorithm)
+	}
+	rawSig, err := decodeSignature(sig.Sig)
+	if err != nil {
+		return Verification{}, err
+	}
+	pub, trusted, err := resolveVerifierKey(sig.KeyID, trustedKeys)
+	if err != nil {
+		return Verification{}, err
+	}
+	if !ed25519.Verify(pub, pae(env.PayloadType, payload), rawSig) {
+		return Verification{}, fmt.Errorf("%w: signature verification failed", ErrInvalidEnvelope)
+	}
+	sum := sha256.Sum256(payload)
+	return Verification{
+		Statement:        statement,
+		SignerKeyID:      sig.KeyID,
+		Trusted:          trusted,
+		Unpinned:         !trusted,
+		PayloadSHA256:    hex.EncodeToString(sum[:]),
+		SourceBatches:    len(statement.Predicate.SourceBatches),
+		TotalActions:     statement.Predicate.Summary.TotalActions,
+		MediatedFraction: statement.Predicate.Completeness.MediatedFraction,
+	}, nil
+}
+
+func ParseStatement(payload []byte) (Statement, error) {
+	if _, err := contract.ParseJSONStrict(payload); err != nil {
+		return Statement{}, fmt.Errorf("%w: %w", ErrInvalidStatement, err)
+	}
+	var statement Statement
+	if err := json.Unmarshal(payload, &statement); err != nil {
+		return Statement{}, fmt.Errorf("%w: %w", ErrInvalidStatement, err)
+	}
+	return statement, nil
+}
+
+func CanonicalStatement(statement Statement) ([]byte, error) {
+	raw, err := json.Marshal(statement)
+	if err != nil {
+		return nil, fmt.Errorf("%w: marshal statement: %w", ErrInvalidStatement, err)
+	}
+	tree, err := contract.ParseJSONStrict(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: parse statement: %w", ErrInvalidStatement, err)
+	}
+	return contract.Canonicalize(tree)
+}
+
+func (s Statement) Validate() error {
+	if s.Type != StatementType {
+		return fmt.Errorf("%w: _type=%q", ErrInvalidStatement, s.Type)
+	}
+	if s.PredicateType != PredicateType {
+		return fmt.Errorf("%w: predicateType=%q", ErrInvalidStatement, s.PredicateType)
+	}
+	if len(s.Subject) == 0 {
+		return fmt.Errorf("%w: subject required", ErrInvalidStatement)
+	}
+	if err := s.Predicate.Validate(); err != nil {
+		return err
+	}
+	return validateSubjects(s.Subject, s.Predicate.SourceBatches)
+}
+
+func (p Predicate) Validate() error {
+	if p.SchemaVersion != 1 {
+		return fmt.Errorf("%w: schemaVersion=%d", ErrInvalidPredicate, p.SchemaVersion)
+	}
+	for _, item := range []struct {
+		name, value string
+	}{
+		{"reportId", p.ReportID},
+		{"generatedAt", p.GeneratedAt},
+		{"orgId", p.OrgID},
+		{"fleetId", p.FleetID},
+		{"reportWindow.start", p.ReportWindow.Start},
+		{"reportWindow.end", p.ReportWindow.End},
+		{"conductor.id", p.Conductor.ID},
+		{"completeness.basis", p.Completeness.Basis},
+		{"completeness.claim", p.Completeness.Claim},
+		{"completeness.nonClaim", p.Completeness.NonClaim},
+	} {
+		if strings.TrimSpace(item.value) == "" {
+			return fmt.Errorf("%w: %s required", ErrInvalidPredicate, item.name)
+		}
+	}
+	if _, err := parseTime("generatedAt", p.GeneratedAt); err != nil {
+		return err
+	}
+	start, err := parseTime("reportWindow.start", p.ReportWindow.Start)
+	if err != nil {
+		return err
+	}
+	end, err := parseTime("reportWindow.end", p.ReportWindow.End)
+	if err != nil {
+		return err
+	}
+	if !end.After(start) {
+		return fmt.Errorf("%w: reportWindow.end must be after start", ErrInvalidPredicate)
+	}
+	if p.VerificationLevel != VerificationLevelL1 {
+		return fmt.Errorf("%w: verificationLevel=%q", ErrInvalidPredicate, p.VerificationLevel)
+	}
+	if len(p.SourceBatches) == 0 {
+		return fmt.Errorf("%w: sourceBatches required", ErrInvalidPredicate)
+	}
+	if err := validateSourceBatches(p.OrgID, p.FleetID, p.SourceBatches); err != nil {
+		return err
+	}
+	if err := p.validateSummary(); err != nil {
+		return err
+	}
+	return p.validateCompleteness()
+}
+
+func (p Predicate) validateSummary() error {
+	if p.Summary.TotalActions == 0 {
+		return fmt.Errorf("%w: summary.totalActions required", ErrInvalidPredicate)
+	}
+	for _, item := range []struct {
+		name   string
+		counts map[string]uint64
+	}{
+		{"byFollower", p.Summary.ByFollower},
+		{"byTransport", p.Summary.ByTransport},
+		{"byActionType", p.Summary.ByActionType},
+		{"byVerdict", p.Summary.ByVerdict},
+		{"byLayer", p.Summary.ByLayer},
+		{"bySeverity", p.Summary.BySeverity},
+	} {
+		sum, err := validateCountMap(item.name, item.counts)
+		if err != nil {
+			return err
+		}
+		if len(item.counts) > 0 && sum != p.Summary.TotalActions {
+			return fmt.Errorf("%w: summary.%s totals %d, want %d", ErrInvalidPredicate, item.name, sum, p.Summary.TotalActions)
+		}
+	}
+	return nil
+}
+
+func (p Predicate) validateCompleteness() error {
+	c := p.Completeness
+	if c.ObservedActions != p.Summary.TotalActions {
+		return fmt.Errorf("%w: completeness.observedActions=%d totalActions=%d", ErrInvalidPredicate, c.ObservedActions, p.Summary.TotalActions)
+	}
+	if c.MediatedActions > c.ObservedActions {
+		return fmt.Errorf("%w: mediatedActions exceeds observedActions", ErrInvalidPredicate)
+	}
+	fraction, err := parseUnitDecimal("completeness.mediatedFraction", c.MediatedFraction)
+	if err != nil {
+		return err
+	}
+	want := new(big.Rat).SetFrac(
+		new(big.Int).SetUint64(c.MediatedActions),
+		new(big.Int).SetUint64(c.ObservedActions),
+	)
+	if fraction.Cmp(want) != 0 {
+		return fmt.Errorf("%w: completeness.mediatedFraction=%s want %s/%s", ErrInvalidPredicate, c.MediatedFraction, want.Num(), want.Denom())
+	}
+	return nil
+}
+
+func validateSubjects(subjects []Subject, batches []SourceBatch) error {
+	expected := make(map[string]string, len(batches))
+	for _, batch := range batches {
+		expected[sourceBatchSubjectName(batch)] = batch.EnvelopeHash
+	}
+	if len(subjects) != len(expected) {
+		return fmt.Errorf("%w: subject count=%d want %d source batches", ErrInvalidStatement, len(subjects), len(expected))
+	}
+	seen := make(map[string]struct{}, len(subjects))
+	for _, subject := range subjects {
+		name := strings.TrimSpace(subject.Name)
+		if name == "" {
+			return fmt.Errorf("%w: subject.name required", ErrInvalidStatement)
+		}
+		if err := validateHexSHA256("subject.digest.sha256", subject.Digest.SHA256); err != nil {
+			return err
+		}
+		if _, ok := seen[name]; ok {
+			return fmt.Errorf("%w: duplicate subject %s", ErrInvalidStatement, name)
+		}
+		seen[name] = struct{}{}
+		want, ok := expected[name]
+		if !ok {
+			return fmt.Errorf("%w: subject %s does not match a source batch", ErrInvalidStatement, name)
+		}
+		if subject.Digest.SHA256 != want {
+			return fmt.Errorf("%w: subject %s digest %s, want source batch envelopeHash %s", ErrInvalidStatement, name, subject.Digest.SHA256, want)
+		}
+	}
+	return nil
+}
+
+func sourceBatchSubjectName(b SourceBatch) string {
+	return fmt.Sprintf("conductor-audit-batch:%s/%s/%s/%s", b.OrgID, b.FleetID, b.InstanceID, b.BatchID)
+}
+
+func validateSourceBatches(orgID, fleetID string, batches []SourceBatch) error {
+	seen := map[string]struct{}{}
+	lastSeq := map[string]uint64{}
+	for _, b := range batches {
+		key := strings.Join([]string{b.OrgID, b.FleetID, b.InstanceID, b.BatchID}, "\x00")
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("%w: duplicate source batch %s", ErrInvalidPredicate, b.BatchID)
+		}
+		seen[key] = struct{}{}
+		if b.OrgID == "" || b.FleetID == "" || b.InstanceID == "" || b.BatchID == "" {
+			return fmt.Errorf("%w: source batch identity required", ErrInvalidPredicate)
+		}
+		if b.OrgID != orgID || b.FleetID != fleetID {
+			return fmt.Errorf("%w: source batch %s belongs to %s/%s, want %s/%s", ErrInvalidPredicate, b.BatchID, b.OrgID, b.FleetID, orgID, fleetID)
+		}
+		if b.SeqEnd < b.SeqStart {
+			return fmt.Errorf("%w: invalid source batch sequence range", ErrInvalidPredicate)
+		}
+		followerKey := strings.Join([]string{b.OrgID, b.FleetID, b.InstanceID}, "\x00")
+		if previous, ok := lastSeq[followerKey]; ok && b.SeqStart <= previous {
+			return fmt.Errorf("%w: source batches overlap or are reordered for %s", ErrInvalidPredicate, b.InstanceID)
+		}
+		lastSeq[followerKey] = b.SeqEnd
+		if b.EventCount == 0 || b.PayloadBytes == 0 {
+			return fmt.Errorf("%w: source batch eventCount and payloadBytes required", ErrInvalidPredicate)
+		}
+		for name, value := range map[string]string{
+			"payloadSha256":   b.PayloadSHA256,
+			"envelopeHash":    b.EnvelopeHash,
+			"segmentTailHash": b.SegmentTailHash,
+		} {
+			if err := validateHexSHA256(name, value); err != nil {
+				return err
+			}
+		}
+		if _, err := parseTime("emittedAt", b.EmittedAt); err != nil {
+			return err
+		}
+		if _, err := parseTime("receivedAt", b.ReceivedAt); err != nil {
+			return err
+		}
+		if len(b.SignatureKeyIDs) == 0 {
+			return fmt.Errorf("%w: source batch signatureKeyIds required", ErrInvalidPredicate)
+		}
+		for _, keyID := range b.SignatureKeyIDs {
+			if strings.TrimSpace(keyID) == "" {
+				return fmt.Errorf("%w: source batch signatureKeyIds contains blank key", ErrInvalidPredicate)
+			}
+		}
+	}
+	return nil
+}
+
+func validateCountMap(name string, counts map[string]uint64) (uint64, error) {
+	sum := uint64(0)
+	for key, count := range counts {
+		if strings.TrimSpace(key) == "" {
+			return 0, fmt.Errorf("%w: %s has empty key", ErrInvalidPredicate, name)
+		}
+		if count == 0 {
+			return 0, fmt.Errorf("%w: %s[%q] is zero", ErrInvalidPredicate, name, key)
+		}
+		next, ok := addUint64(sum, count)
+		if !ok {
+			return 0, fmt.Errorf("%w: %s totals overflow uint64", ErrInvalidPredicate, name)
+		}
+		sum = next
+	}
+	return sum, nil
+}
+
+func addUint64(a, b uint64) (uint64, bool) {
+	if b > ^uint64(0)-a {
+		return 0, false
+	}
+	return a + b, true
+}
+
+func validateHexSHA256(name, value string) error {
+	if len(value) != sha256.Size*2 {
+		return fmt.Errorf("%w: %s must be 64 hex chars", ErrInvalidPredicate, name)
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return fmt.Errorf("%w: %s must be hex", ErrInvalidPredicate, name)
+	}
+	if value != strings.ToLower(value) {
+		return fmt.Errorf("%w: %s must be lowercase hex", ErrInvalidPredicate, name)
+	}
+	return nil
+}
+
+func parseTime(name, value string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%w: %s: %w", ErrInvalidPredicate, name, err)
+	}
+	return parsed, nil
+}
+
+func parseUnitDecimal(name, value string) (*big.Rat, error) {
+	if strings.TrimSpace(value) == "" || strings.ContainsAny(value, "eE/") {
+		return nil, fmt.Errorf("%w: %s must be a decimal string", ErrInvalidPredicate, name)
+	}
+	rat, ok := new(big.Rat).SetString(value)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s must be a decimal string", ErrInvalidPredicate, name)
+	}
+	if rat.Sign() < 0 || rat.Cmp(big.NewRat(1, 1)) > 0 {
+		return nil, fmt.Errorf("%w: %s must be between 0 and 1", ErrInvalidPredicate, name)
+	}
+	if !isUnitDecimalString(value) {
+		return nil, fmt.Errorf("%w: %s must be a decimal string", ErrInvalidPredicate, name)
+	}
+	return rat, nil
+}
+
+func isUnitDecimalString(value string) bool {
+	if value == "0" || value == "1" {
+		return true
+	}
+	if strings.HasPrefix(value, "0.") && len(value) > len("0.") {
+		for _, r := range value[len("0."):] {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+		return true
+	}
+	if strings.HasPrefix(value, "1.") && len(value) > len("1.") {
+		for _, r := range value[len("1."):] {
+			if r != '0' {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func resolveVerifierKey(keyID string, trustedKeys map[string]ed25519.PublicKey) (ed25519.PublicKey, bool, error) {
+	if strings.TrimSpace(keyID) == "" {
+		return nil, false, fmt.Errorf("%w: signature keyid required", ErrInvalidEnvelope)
+	}
+	if len(trustedKeys) > 0 {
+		pub, ok := trustedKeys[keyID]
+		if !ok {
+			return nil, false, fmt.Errorf("%w: %s", ErrUntrustedKey, keyID)
+		}
+		if len(pub) != ed25519.PublicKeySize {
+			return nil, false, fmt.Errorf("%w: trusted key %s length=%d", ErrInvalidEnvelope, keyID, len(pub))
+		}
+		return pub, true, nil
+	}
+	raw, err := hex.DecodeString(keyID)
+	if err != nil || len(raw) != ed25519.PublicKeySize {
+		return nil, false, fmt.Errorf("%w: unpinned keyid must be hex Ed25519 public key", ErrInvalidEnvelope)
+	}
+	return ed25519.PublicKey(raw), false, nil
+}
+
+func decodeSignature(value string) ([]byte, error) {
+	raw := strings.TrimPrefix(value, signaturePrefix)
+	if raw == value {
+		return nil, fmt.Errorf("%w: signature missing %s prefix", ErrInvalidEnvelope, signaturePrefix)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: decode signature: %w", ErrInvalidEnvelope, err)
+	}
+	if len(decoded) != ed25519.SignatureSize {
+		return nil, fmt.Errorf("%w: signature length=%d", ErrInvalidEnvelope, len(decoded))
+	}
+	return decoded, nil
+}
+
+func pae(payloadType string, payload []byte) []byte {
+	pieces := [][]byte{
+		[]byte("DSSEv1"),
+		[]byte(strconv.Itoa(len(payloadType))),
+		[]byte(payloadType),
+		[]byte(strconv.Itoa(len(payload))),
+		payload,
+	}
+	return bytes.Join(pieces, []byte(" "))
+}
+
+func MarshalEnvelope(env Envelope) ([]byte, error) {
+	raw, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("%w: marshal envelope: %w", ErrInvalidEnvelope, err)
+	}
+	return raw, nil
+}
+
+func TrustedKeyMap(keys map[string]string) (map[string]ed25519.PublicKey, error) {
+	out := make(map[string]ed25519.PublicKey, len(keys))
+	ids := make([]string, 0, len(keys))
+	for id := range keys {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		raw, err := hex.DecodeString(keys[id])
+		if err != nil {
+			return nil, fmt.Errorf("decode trusted key %s: %w", id, err)
+		}
+		if len(raw) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("trusted key %s length=%d want %d", id, len(raw), ed25519.PublicKeySize)
+		}
+		out[id] = ed25519.PublicKey(raw)
+	}
+	return out, nil
+}

--- a/internal/fleetreceipt/fleetreceipt_test.go
+++ b/internal/fleetreceipt/fleetreceipt_test.go
@@ -1,0 +1,312 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package fleetreceipt
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const (
+	testReportID  = "01934e1c-cd60-7abc-823a-d6f5e6f7a8b9"
+	testTimestamp = "2026-06-13T12:00:00Z"
+)
+
+func TestSignAndVerifyFleetReceipt(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	keyID := hex.EncodeToString(pub)
+	env, err := SignStatement(testStatement(), keyID, priv)
+	if err != nil {
+		t.Fatalf("SignStatement: %v", err)
+	}
+	raw, err := MarshalEnvelope(env)
+	if err != nil {
+		t.Fatalf("MarshalEnvelope: %v", err)
+	}
+	got, err := Verify(raw, map[string]ed25519.PublicKey{keyID: pub})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !got.Trusted || got.Unpinned {
+		t.Fatalf("trusted/unpinned = %v/%v, want true/false", got.Trusted, got.Unpinned)
+	}
+	if got.SignerKeyID != keyID {
+		t.Fatalf("SignerKeyID = %q, want %q", got.SignerKeyID, keyID)
+	}
+	if got.SourceBatches != 2 || got.TotalActions != 3 || got.MediatedFraction != "1" {
+		t.Fatalf("summary = batches %d actions %d fraction %q", got.SourceBatches, got.TotalActions, got.MediatedFraction)
+	}
+}
+
+func TestVerifyFleetReceipt_UnpinnedUsesKeyIDButReportsIt(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	env, err := SignStatement(testStatement(), hex.EncodeToString(pub), priv)
+	if err != nil {
+		t.Fatalf("SignStatement: %v", err)
+	}
+	raw, err := MarshalEnvelope(env)
+	if err != nil {
+		t.Fatalf("MarshalEnvelope: %v", err)
+	}
+	got, err := Verify(raw, nil)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got.Trusted || !got.Unpinned {
+		t.Fatalf("trusted/unpinned = %v/%v, want false/true", got.Trusted, got.Unpinned)
+	}
+}
+
+func TestVerifyFleetReceiptRejectsWrongTrustedKey(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	otherPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey other: %v", err)
+	}
+	keyID := hex.EncodeToString(pub)
+	env, err := SignStatement(testStatement(), keyID, priv)
+	if err != nil {
+		t.Fatalf("SignStatement: %v", err)
+	}
+	raw, err := MarshalEnvelope(env)
+	if err != nil {
+		t.Fatalf("MarshalEnvelope: %v", err)
+	}
+	_, err = Verify(raw, map[string]ed25519.PublicKey{keyID: otherPub})
+	if err == nil || !strings.Contains(err.Error(), "signature verification failed") {
+		t.Fatalf("Verify error = %v, want signature failure", err)
+	}
+}
+
+func TestVerifyFleetReceiptRejectsWrongKeyPurpose(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	keyID := hex.EncodeToString(pub)
+	env, err := SignStatement(testStatement(), keyID, priv)
+	if err != nil {
+		t.Fatalf("SignStatement: %v", err)
+	}
+	env.Signatures[0].KeyPurpose = signing.PurposeAuditBatchSigning.String()
+	raw, err := MarshalEnvelope(env)
+	if err != nil {
+		t.Fatalf("MarshalEnvelope: %v", err)
+	}
+	_, err = Verify(raw, map[string]ed25519.PublicKey{keyID: pub})
+	if err == nil || !strings.Contains(err.Error(), "key_purpose") {
+		t.Fatalf("Verify error = %v, want key_purpose failure", err)
+	}
+}
+
+func TestVerifyFleetReceiptRejectsTamperedPayload(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	keyID := hex.EncodeToString(pub)
+	env, err := SignStatement(testStatement(), keyID, priv)
+	if err != nil {
+		t.Fatalf("SignStatement: %v", err)
+	}
+	payload, err := base64.StdEncoding.DecodeString(env.Payload)
+	if err != nil {
+		t.Fatalf("DecodeString: %v", err)
+	}
+	payload = []byte(strings.Replace(string(payload), `"totalActions":3`, `"totalActions":4`, 1))
+	env.Payload = base64.StdEncoding.EncodeToString(payload)
+	raw, err := MarshalEnvelope(env)
+	if err != nil {
+		t.Fatalf("MarshalEnvelope: %v", err)
+	}
+	_, err = Verify(raw, map[string]ed25519.PublicKey{keyID: pub})
+	if err == nil || !strings.Contains(err.Error(), "summary.") {
+		t.Fatalf("Verify error = %v, want predicate arithmetic failure", err)
+	}
+}
+
+func TestStatementValidateRejectsDuplicateAndReorderedBatches(t *testing.T) {
+	base := testStatement()
+	tests := []struct {
+		name string
+		edit func(*Statement)
+		want string
+	}{
+		{
+			name: "duplicate",
+			edit: func(s *Statement) {
+				s.Predicate.SourceBatches = append(s.Predicate.SourceBatches, s.Predicate.SourceBatches[0])
+			},
+			want: "duplicate source batch",
+		},
+		{
+			name: "reordered",
+			edit: func(s *Statement) {
+				s.Predicate.SourceBatches[1].SeqStart = 1
+			},
+			want: "overlap or are reordered",
+		},
+		{
+			name: "fraction_not_decimal",
+			edit: func(s *Statement) {
+				s.Predicate.Completeness.MediatedFraction = "1/2"
+			},
+			want: "decimal string",
+		},
+		{
+			name: "fraction_above_one",
+			edit: func(s *Statement) {
+				s.Predicate.Completeness.MediatedFraction = "1.2"
+			},
+			want: "between 0 and 1",
+		},
+		{
+			name: "fraction_arithmetic_mismatch",
+			edit: func(s *Statement) {
+				s.Predicate.Completeness.MediatedActions = 1
+				s.Predicate.Completeness.MediatedFraction = "1"
+			},
+			want: "completeness.mediatedFraction",
+		},
+		{
+			name: "summary_dimension_total_mismatch",
+			edit: func(s *Statement) {
+				s.Predicate.Summary.ByTransport = map[string]uint64{"fetch": 2}
+			},
+			want: "summary.byTransport totals",
+		},
+		{
+			name: "source_batch_wrong_fleet",
+			edit: func(s *Statement) {
+				s.Predicate.SourceBatches[0].FleetID = "other-fleet"
+			},
+			want: "belongs to",
+		},
+		{
+			name: "l2_reserved_until_replay_verifier",
+			edit: func(s *Statement) {
+				s.Predicate.VerificationLevel = "L2"
+			},
+			want: "verificationLevel",
+		},
+		{
+			name: "subject_digest_mismatch",
+			edit: func(s *Statement) {
+				s.Subject[0].Digest.SHA256 = hex64("not-the-envelope")
+			},
+			want: "digest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := base
+			stmt.Predicate.SourceBatches = append([]SourceBatch(nil), base.Predicate.SourceBatches...)
+			stmt.Subject = append([]Subject(nil), base.Subject...)
+			tt.edit(&stmt)
+			err := stmt.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnmarshalEnvelopeRejectsDuplicateKeys(t *testing.T) {
+	raw := []byte(`{"payloadType":"a","payloadType":"b","payload":"","signatures":[]}`)
+	_, err := UnmarshalEnvelope(raw)
+	if err == nil || !errors.Is(err, ErrInvalidEnvelope) {
+		t.Fatalf("UnmarshalEnvelope error = %v, want ErrInvalidEnvelope", err)
+	}
+}
+
+func testStatement() Statement {
+	start := time.Date(2026, 6, 13, 11, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	end := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	return Statement{
+		Type: StatementType,
+		Subject: []Subject{
+			{Name: "conductor-audit-batch:pipelab/dogfood/pl-1/audit-1", Digest: Digest{SHA256: hex64("envelope-audit-1")}},
+			{Name: "conductor-audit-batch:pipelab/dogfood/pl-1/audit-2", Digest: Digest{SHA256: hex64("envelope-audit-2")}},
+		},
+		PredicateType: PredicateType,
+		Predicate: Predicate{
+			SchemaVersion:     1,
+			ReportID:          testReportID,
+			GeneratedAt:       testTimestamp,
+			OrgID:             "pipelab",
+			FleetID:           "dogfood",
+			ReportWindow:      TimeWindow{Start: start, End: end},
+			VerificationLevel: VerificationLevelL1,
+			Conductor:         Conductor{ID: "conductor", Version: "v2.8.0-test"},
+			SourceBatches: []SourceBatch{
+				testBatch("audit-1", 1, 2, 2),
+				testBatch("audit-2", 3, 3, 1),
+			},
+			Summary: Summary{
+				TotalActions: 3,
+				ByFollower:   map[string]uint64{"pl-1": 3},
+				ByTransport:  map[string]uint64{"mcp": 1, "fetch": 2},
+				ByActionType: map[string]uint64{"read": 2, "write": 1},
+				ByVerdict:    map[string]uint64{"allow": 2, "block": 1},
+				ByLayer:      map[string]uint64{"dlp": 1, "scheme": 2},
+			},
+			Completeness: Completeness{
+				ObservedActions:        3,
+				DroppedObservedActions: 0,
+				MediatedActions:        3,
+				MediatedFraction:       "1",
+				Basis:                  "included_signed_audit_batches",
+				Claim:                  "fraction of observed fleet action records in included signed audit batches that were mediated by Pipelock",
+				NonClaim:               "does not prove no bypass occurred outside Pipelock, outside enrolled followers, or outside the report window",
+			},
+			Limits: []string{"mediated traffic only"},
+		},
+	}
+}
+
+func testBatch(id string, start, end, events uint64) SourceBatch {
+	return SourceBatch{
+		OrgID:           "pipelab",
+		FleetID:         "dogfood",
+		InstanceID:      "pl-1",
+		BatchID:         id,
+		SeqStart:        start,
+		SeqEnd:          end,
+		EventCount:      events,
+		PayloadSHA256:   hex64("payload-" + id),
+		PayloadBytes:    1024,
+		EnvelopeHash:    hex64("envelope-" + id),
+		SegmentTailHash: hex64("tail-" + id),
+		EmittedAt:       testTimestamp,
+		ReceivedAt:      testTimestamp,
+		SignatureKeyIDs: []string{"audit-key-1"},
+	}
+}
+
+func hex64(seed string) string {
+	sum := sha256String(seed)
+	return hex.EncodeToString(sum[:])
+}
+
+func sha256String(seed string) [32]byte {
+	return sha256.Sum256([]byte(seed))
+}

--- a/internal/fleetreceipt/fleetreceipt_test.go
+++ b/internal/fleetreceipt/fleetreceipt_test.go
@@ -215,6 +215,13 @@ func TestStatementValidateRejectsDuplicateAndReorderedBatches(t *testing.T) {
 			},
 			want: "digest",
 		},
+		{
+			name: "generated_at_must_be_utc",
+			edit: func(s *Statement) {
+				s.Predicate.GeneratedAt = "2026-06-13T07:00:00-05:00"
+			},
+			want: "ending in Z",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -228,6 +235,37 @@ func TestStatementValidateRejectsDuplicateAndReorderedBatches(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStatementValidateErrorClasses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("subject digest is statement error", func(t *testing.T) {
+		stmt := testStatement()
+		stmt.Subject[0].Digest.SHA256 = strings.ToUpper(stmt.Subject[0].Digest.SHA256)
+		err := stmt.Validate()
+		if err == nil {
+			t.Fatal("expected uppercase subject digest to fail")
+		}
+		if !errors.Is(err, ErrInvalidStatement) {
+			t.Fatalf("Validate error = %v, want ErrInvalidStatement", err)
+		}
+		if errors.Is(err, ErrInvalidPredicate) {
+			t.Fatalf("Validate error = %v, must not wrap ErrInvalidPredicate", err)
+		}
+	})
+
+	t.Run("source batch digest is predicate error", func(t *testing.T) {
+		stmt := testStatement()
+		stmt.Predicate.SourceBatches[0].PayloadSHA256 = strings.ToUpper(stmt.Predicate.SourceBatches[0].PayloadSHA256)
+		err := stmt.Validate()
+		if err == nil {
+			t.Fatal("expected uppercase source batch digest to fail")
+		}
+		if !errors.Is(err, ErrInvalidPredicate) {
+			t.Fatalf("Validate error = %v, want ErrInvalidPredicate", err)
+		}
+	})
 }
 
 func TestUnmarshalEnvelopeRejectsDuplicateKeys(t *testing.T) {

--- a/internal/fleetreceipt/fleetreceipt_test.go
+++ b/internal/fleetreceipt/fleetreceipt_test.go
@@ -4,11 +4,13 @@
 package fleetreceipt
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -144,6 +146,158 @@ func TestVerifyFleetReceiptRejectsTamperedPayload(t *testing.T) {
 	}
 }
 
+func TestVerifyEnvelopeRejectsMalformedEnvelope(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	keyID := hex.EncodeToString(pub)
+	env, err := SignStatement(testStatement(), keyID, priv)
+	if err != nil {
+		t.Fatalf("SignStatement: %v", err)
+	}
+	payload, err := base64.StdEncoding.DecodeString(env.Payload)
+	if err != nil {
+		t.Fatalf("DecodeString: %v", err)
+	}
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, payload, "", "  "); err != nil {
+		t.Fatalf("Indent: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		edit        func(*Envelope)
+		trustedKeys map[string]ed25519.PublicKey
+		want        string
+	}{
+		{
+			name: "wrong_payload_type",
+			edit: func(e *Envelope) {
+				e.PayloadType = "application/json"
+			},
+			trustedKeys: map[string]ed25519.PublicKey{keyID: pub},
+			want:        "payloadType",
+		},
+		{
+			name: "signature_count",
+			edit: func(e *Envelope) {
+				e.Signatures = append(e.Signatures, e.Signatures[0])
+			},
+			trustedKeys: map[string]ed25519.PublicKey{keyID: pub},
+			want:        "signatures=2",
+		},
+		{
+			name: "bad_payload_base64",
+			edit: func(e *Envelope) {
+				e.Payload = "not base64"
+			},
+			trustedKeys: map[string]ed25519.PublicKey{keyID: pub},
+			want:        "decode payload",
+		},
+		{
+			name: "noncanonical_payload",
+			edit: func(e *Envelope) {
+				e.Payload = base64.StdEncoding.EncodeToString(pretty.Bytes())
+			},
+			trustedKeys: map[string]ed25519.PublicKey{keyID: pub},
+			want:        "not canonical",
+		},
+		{
+			name: "wrong_key_purpose",
+			edit: func(e *Envelope) {
+				e.Signatures[0].KeyPurpose = signing.PurposeAuditBatchSigning.String()
+			},
+			trustedKeys: map[string]ed25519.PublicKey{keyID: pub},
+			want:        "key_purpose",
+		},
+		{
+			name: "wrong_algorithm",
+			edit: func(e *Envelope) {
+				e.Signatures[0].Algorithm = "rsa"
+			},
+			trustedKeys: map[string]ed25519.PublicKey{keyID: pub},
+			want:        "algorithm",
+		},
+		{
+			name: "missing_signature_prefix",
+			edit: func(e *Envelope) {
+				e.Signatures[0].Sig = strings.TrimPrefix(e.Signatures[0].Sig, signaturePrefix)
+			},
+			trustedKeys: map[string]ed25519.PublicKey{keyID: pub},
+			want:        "signature missing",
+		},
+		{
+			name: "bad_signature_base64",
+			edit: func(e *Envelope) {
+				e.Signatures[0].Sig = signaturePrefix + "not base64"
+			},
+			trustedKeys: map[string]ed25519.PublicKey{keyID: pub},
+			want:        "decode signature",
+		},
+		{
+			name: "bad_signature_length",
+			edit: func(e *Envelope) {
+				e.Signatures[0].Sig = signaturePrefix + base64.StdEncoding.EncodeToString([]byte("short"))
+			},
+			trustedKeys: map[string]ed25519.PublicKey{keyID: pub},
+			want:        "signature length",
+		},
+		{
+			name: "missing_keyid",
+			edit: func(e *Envelope) {
+				e.Signatures[0].KeyID = ""
+			},
+			trustedKeys: nil,
+			want:        "keyid required",
+		},
+		{
+			name: "untrusted_key",
+			edit: func(*Envelope) {
+			},
+			trustedKeys: map[string]ed25519.PublicKey{"other": pub},
+			want:        ErrUntrustedKey.Error(),
+		},
+		{
+			name: "bad_trusted_key_length",
+			edit: func(*Envelope) {
+			},
+			trustedKeys: map[string]ed25519.PublicKey{keyID: ed25519.PublicKey("short")},
+			want:        "trusted key",
+		},
+		{
+			name: "bad_unpinned_keyid",
+			edit: func(e *Envelope) {
+				e.Signatures[0].KeyID = "not-hex"
+			},
+			trustedKeys: nil,
+			want:        "unpinned keyid",
+		},
+		{
+			name: "signature_mismatch",
+			edit: func(e *Envelope) {
+				e.Signatures[0].KeyID = hex.EncodeToString(mustOtherPublicKey(t))
+			},
+			trustedKeys: nil,
+			want:        "signature verification failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := env
+			candidate.Signatures = append([]Signature(nil), env.Signatures...)
+			tt.edit(&candidate)
+			_, err := VerifyEnvelope(candidate, tt.trustedKeys)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("VerifyEnvelope error = %v, want %q", err, tt.want)
+			}
+			if !errors.Is(err, ErrInvalidEnvelope) && !errors.Is(err, ErrUntrustedKey) {
+				t.Fatalf("VerifyEnvelope error = %v, want envelope or trust error", err)
+			}
+		})
+	}
+}
+
 func TestStatementValidateRejectsDuplicateAndReorderedBatches(t *testing.T) {
 	base := testStatement()
 	tests := []struct {
@@ -268,6 +422,247 @@ func TestStatementValidateErrorClasses(t *testing.T) {
 	})
 }
 
+func TestStatementValidateRejectsInvalidStatementHeaders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		edit func(*Statement)
+		want string
+	}{
+		{
+			name: "wrong_type",
+			edit: func(s *Statement) {
+				s.Type = "https://example.com/wrong"
+			},
+			want: "_type",
+		},
+		{
+			name: "wrong_predicate_type",
+			edit: func(s *Statement) {
+				s.PredicateType = "https://example.com/wrong"
+			},
+			want: "predicateType",
+		},
+		{
+			name: "missing_subjects",
+			edit: func(s *Statement) {
+				s.Subject = nil
+			},
+			want: "subject required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := testStatement()
+			tt.edit(&stmt)
+			err := stmt.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate error = %v, want %q", err, tt.want)
+			}
+			if !errors.Is(err, ErrInvalidStatement) {
+				t.Fatalf("Validate error = %v, want ErrInvalidStatement", err)
+			}
+		})
+	}
+}
+
+func TestPredicateValidateRejectsEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		edit func(*Predicate)
+		want string
+	}{
+		{
+			name: "schema_version",
+			edit: func(p *Predicate) {
+				p.SchemaVersion = 2
+			},
+			want: "schemaVersion",
+		},
+		{
+			name: "required_string",
+			edit: func(p *Predicate) {
+				p.ReportID = " "
+			},
+			want: "reportId required",
+		},
+		{
+			name: "bad_rfc3339",
+			edit: func(p *Predicate) {
+				p.GeneratedAt = "2026-13-99T99:99:99Z"
+			},
+			want: "generatedAt",
+		},
+		{
+			name: "window_end_not_after_start",
+			edit: func(p *Predicate) {
+				p.ReportWindow.End = p.ReportWindow.Start
+			},
+			want: "reportWindow.end",
+		},
+		{
+			name: "source_batches_required",
+			edit: func(p *Predicate) {
+				p.SourceBatches = nil
+			},
+			want: "sourceBatches required",
+		},
+		{
+			name: "source_batch_identity_required",
+			edit: func(p *Predicate) {
+				p.SourceBatches[0].BatchID = ""
+			},
+			want: "source batch identity required",
+		},
+		{
+			name: "source_batch_invalid_range",
+			edit: func(p *Predicate) {
+				p.SourceBatches[0].SeqEnd = p.SourceBatches[0].SeqStart - 1
+			},
+			want: "invalid source batch sequence range",
+		},
+		{
+			name: "source_batch_empty_size",
+			edit: func(p *Predicate) {
+				p.SourceBatches[0].PayloadBytes = 0
+			},
+			want: "eventCount and payloadBytes",
+		},
+		{
+			name: "source_batch_bad_hex_length",
+			edit: func(p *Predicate) {
+				p.SourceBatches[0].PayloadSHA256 = "abc"
+			},
+			want: "64 hex chars",
+		},
+		{
+			name: "source_batch_bad_hex_char",
+			edit: func(p *Predicate) {
+				p.SourceBatches[0].PayloadSHA256 = strings.Repeat("g", 64)
+			},
+			want: "must be hex",
+		},
+		{
+			name: "source_batch_bad_timestamp",
+			edit: func(p *Predicate) {
+				p.SourceBatches[0].EmittedAt = "2026-06-13T12:00:00"
+			},
+			want: "ending in Z",
+		},
+		{
+			name: "source_batch_signature_keys_required",
+			edit: func(p *Predicate) {
+				p.SourceBatches[0].SignatureKeyIDs = nil
+			},
+			want: "signatureKeyIds required",
+		},
+		{
+			name: "source_batch_signature_blank",
+			edit: func(p *Predicate) {
+				p.SourceBatches[0].SignatureKeyIDs = []string{" "}
+			},
+			want: "blank key",
+		},
+		{
+			name: "summary_total_required",
+			edit: func(p *Predicate) {
+				p.Summary.TotalActions = 0
+			},
+			want: "summary.totalActions",
+		},
+		{
+			name: "summary_empty_key",
+			edit: func(p *Predicate) {
+				p.Summary.ByFollower = map[string]uint64{"": 3}
+			},
+			want: "empty key",
+		},
+		{
+			name: "summary_zero_count",
+			edit: func(p *Predicate) {
+				p.Summary.ByFollower = map[string]uint64{"pl-1": 0}
+			},
+			want: "is zero",
+		},
+		{
+			name: "summary_overflow",
+			edit: func(p *Predicate) {
+				p.Summary.TotalActions = ^uint64(0)
+				p.Summary.ByFollower = map[string]uint64{"a": ^uint64(0), "b": 1}
+			},
+			want: "overflow",
+		},
+		{
+			name: "mediated_exceeds_observed",
+			edit: func(p *Predicate) {
+				p.Completeness.MediatedActions = p.Completeness.ObservedActions + 1
+			},
+			want: "mediatedActions exceeds",
+		},
+		{
+			name: "bad_decimal_text",
+			edit: func(p *Predicate) {
+				p.Completeness.MediatedFraction = "0.x"
+			},
+			want: "decimal string",
+		},
+		{
+			name: "bad_decimal_shape",
+			edit: func(p *Predicate) {
+				p.Completeness.MediatedFraction = "1.1"
+			},
+			want: "between 0 and 1",
+		},
+		{
+			name: "bad_decimal_trailing_nonzero",
+			edit: func(p *Predicate) {
+				p.Completeness.MediatedFraction = "1.01"
+			},
+			want: "between 0 and 1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predicate := testStatement().Predicate
+			tt.edit(&predicate)
+			err := predicate.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate error = %v, want %q", err, tt.want)
+			}
+			if !errors.Is(err, ErrInvalidPredicate) {
+				t.Fatalf("Validate error = %v, want ErrInvalidPredicate", err)
+			}
+		})
+	}
+}
+
+func TestTrustedKeyMap(t *testing.T) {
+	t.Parallel()
+
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	keyID := "fleet"
+	got, err := TrustedKeyMap(map[string]string{keyID: hex.EncodeToString(pub)})
+	if err != nil {
+		t.Fatalf("TrustedKeyMap: %v", err)
+	}
+	if !bytes.Equal(got[keyID], pub) {
+		t.Fatalf("TrustedKeyMap[%q] = %x, want %x", keyID, got[keyID], pub)
+	}
+
+	if _, err := TrustedKeyMap(map[string]string{"bad": "not-hex"}); err == nil {
+		t.Fatal("expected bad hex trusted key to fail")
+	}
+	if _, err := TrustedKeyMap(map[string]string{"short": hex.EncodeToString([]byte("short"))}); err == nil {
+		t.Fatal("expected short trusted key to fail")
+	}
+}
+
 func TestUnmarshalEnvelopeRejectsDuplicateKeys(t *testing.T) {
 	raw := []byte(`{"payloadType":"a","payloadType":"b","payload":"","signatures":[]}`)
 	_, err := UnmarshalEnvelope(raw)
@@ -343,6 +738,15 @@ func testBatch(id string, start, end, events uint64) SourceBatch {
 func hex64(seed string) string {
 	sum := sha256String(seed)
 	return hex.EncodeToString(sum[:])
+}
+
+func mustOtherPublicKey(t *testing.T) ed25519.PublicKey {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey other: %v", err)
+	}
+	return pub
 }
 
 func sha256String(seed string) [32]byte {

--- a/internal/signing/key_purpose.go
+++ b/internal/signing/key_purpose.go
@@ -14,7 +14,7 @@ import (
 // every signed-artifact key entry. The wire form is the lowercase hyphenated
 // string representation; this typed wrapper centralises validation and helpers.
 //
-// Twelve values are defined, drawn from the design doc Key Management section
+// Thirteen values are defined, drawn from the design doc Key Management section
 // (lines 758-870) and the Conductor control-plane spec:
 //
 //   - PurposeReceiptSigning:            runtime receipt keys (hot-loadable)
@@ -29,6 +29,7 @@ import (
 //   - PurposeTrustRootRotation:         Conductor trust-root rotation keys
 //   - PurposeAuditBatchSigning:         follower audit batch signing keys
 //   - PurposeEnrollmentTokenSigning:    Conductor enrollment-token signing keys
+//   - PurposeFleetReportSigning:        Fleet Receipt Report signing keys
 //
 // Wire stability: these strings are part of the signed-artifact wire format
 // and will not change without a schema_version bump.
@@ -86,6 +87,10 @@ const (
 	// PurposeEnrollmentTokenSigning identifies Conductor keys used to sign narrow,
 	// one-shot enrollment tokens.
 	PurposeEnrollmentTokenSigning KeyPurpose = "enrollment-token-signing"
+
+	// PurposeFleetReportSigning identifies keys used to sign Fleet Receipt
+	// Reports. Verification is Apache/free; minting is Enterprise-gated.
+	PurposeFleetReportSigning KeyPurpose = "fleet-report-signing"
 )
 
 // ErrUnknownKeyPurpose indicates a key_purpose value is not one of the
@@ -106,6 +111,7 @@ var knownPurposes = [...]KeyPurpose{
 	PurposeTrustRootRotation,
 	PurposeAuditBatchSigning,
 	PurposeEnrollmentTokenSigning,
+	PurposeFleetReportSigning,
 }
 
 // knownSet provides O(1) validation lookup.
@@ -165,7 +171,8 @@ func (p KeyPurpose) IsConductorPurpose() bool {
 		PurposeRemoteKillSigning,
 		PurposeTrustRootRotation,
 		PurposeAuditBatchSigning,
-		PurposeEnrollmentTokenSigning:
+		PurposeEnrollmentTokenSigning,
+		PurposeFleetReportSigning:
 		return true
 	default:
 		return false
@@ -198,6 +205,7 @@ func (p KeyPurpose) RequiresConductorThreshold() bool {
 //  10. PurposeTrustRootRotation
 //  11. PurposeAuditBatchSigning
 //  12. PurposeEnrollmentTokenSigning
+//  13. PurposeFleetReportSigning
 //
 // Tests rely on this order; it will not change without a major version bump.
 func KnownPurposes() []KeyPurpose {

--- a/internal/signing/key_purpose_test.go
+++ b/internal/signing/key_purpose_test.go
@@ -28,6 +28,7 @@ func TestKeyPurpose_String(t *testing.T) {
 		{"trust-root-rotation", PurposeTrustRootRotation, "trust-root-rotation"},
 		{"audit-batch-signing", PurposeAuditBatchSigning, "audit-batch-signing"},
 		{"enrollment-token-signing", PurposeEnrollmentTokenSigning, "enrollment-token-signing"},
+		{"fleet-report-signing", PurposeFleetReportSigning, "fleet-report-signing"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -166,8 +167,8 @@ func TestKnownPurposes(t *testing.T) {
 	purposes := KnownPurposes()
 
 	t.Run("length", func(t *testing.T) {
-		if len(purposes) != 12 {
-			t.Fatalf("KnownPurposes() returned %d elements, want 12", len(purposes))
+		if len(purposes) != 13 {
+			t.Fatalf("KnownPurposes() returned %d elements, want 13", len(purposes))
 		}
 	})
 
@@ -185,6 +186,7 @@ func TestKnownPurposes(t *testing.T) {
 			PurposeTrustRootRotation,
 			PurposeAuditBatchSigning,
 			PurposeEnrollmentTokenSigning,
+			PurposeFleetReportSigning,
 		}
 		for i, p := range purposes {
 			if p != expected[i] {
@@ -221,6 +223,7 @@ func TestKeyPurpose_IsConductorPurpose(t *testing.T) {
 		{PurposeTrustRootRotation, true},
 		{PurposeAuditBatchSigning, true},
 		{PurposeEnrollmentTokenSigning, true},
+		{PurposeFleetReportSigning, true},
 		{KeyPurpose("unknown"), false},
 	}
 	for _, tt := range tests {
@@ -243,6 +246,7 @@ func TestKeyPurpose_RequiresConductorThreshold(t *testing.T) {
 		{PurposeTrustRootRotation, true},
 		{PurposeAuditBatchSigning, false},
 		{PurposeEnrollmentTokenSigning, false},
+		{PurposeFleetReportSigning, false},
 		{PurposeReceiptSigning, false},
 		{KeyPurpose("unknown"), false},
 	}

--- a/schemas/fleet-receipt-v1.schema.json
+++ b/schemas/fleet-receipt-v1.schema.json
@@ -41,7 +41,8 @@
     },
     "rfc3339": {
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
     },
     "countMap": {
       "type": "object",

--- a/schemas/fleet-receipt-v1.schema.json
+++ b/schemas/fleet-receipt-v1.schema.json
@@ -1,0 +1,328 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pipelab.org/attestation/fleet-receipt/v1.schema.json",
+  "title": "Pipelock Fleet Receipt Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["_type", "subject", "predicateType", "predicate"],
+  "properties": {
+    "_type": {
+      "const": "https://in-toto.io/Statement/v1"
+    },
+    "subject": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "digest"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "digest": {
+            "$ref": "#/$defs/digest"
+          }
+        }
+      }
+    },
+    "predicateType": {
+      "const": "https://pipelab.org/attestation/fleet-receipt/v1"
+    },
+    "predicate": {
+      "$ref": "#/$defs/predicate"
+    }
+  },
+  "$defs": {
+    "hexSha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "rfc3339": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "countMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 1
+      }
+    },
+    "digest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sha256"],
+      "properties": {
+        "sha256": {
+          "$ref": "#/$defs/hexSha256"
+        }
+      }
+    },
+    "predicate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "reportId",
+        "generatedAt",
+        "orgId",
+        "fleetId",
+        "reportWindow",
+        "verificationLevel",
+        "conductor",
+        "sourceBatches",
+        "summary",
+        "completeness"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": 1
+        },
+        "reportId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "generatedAt": {
+          "$ref": "#/$defs/rfc3339"
+        },
+        "orgId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fleetId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reportWindow": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["start", "end"],
+          "properties": {
+            "start": {
+              "$ref": "#/$defs/rfc3339"
+            },
+            "end": {
+              "$ref": "#/$defs/rfc3339"
+            }
+          }
+        },
+        "verificationLevel": {
+          "enum": ["L1"]
+        },
+        "conductor": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "version": {
+              "type": "string"
+            }
+          }
+        },
+        "sourceBatches": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/sourceBatch"
+          }
+        },
+        "summary": {
+          "$ref": "#/$defs/summary"
+        },
+        "completeness": {
+          "$ref": "#/$defs/completeness"
+        },
+        "limits": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "externalCorrelations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/externalCorrelation"
+          }
+        }
+      }
+    },
+    "sourceBatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "orgId",
+        "fleetId",
+        "instanceId",
+        "batchId",
+        "seqStart",
+        "seqEnd",
+        "eventCount",
+        "payloadSha256",
+        "payloadBytes",
+        "envelopeHash",
+        "segmentTailHash",
+        "droppedCount",
+        "emittedAt",
+        "receivedAt",
+        "signatureKeyIds"
+      ],
+      "properties": {
+        "orgId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fleetId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "instanceId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "batchId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "seqStart": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "seqEnd": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "eventCount": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "payloadSha256": {
+          "$ref": "#/$defs/hexSha256"
+        },
+        "payloadBytes": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "envelopeHash": {
+          "$ref": "#/$defs/hexSha256"
+        },
+        "segmentTailHash": {
+          "$ref": "#/$defs/hexSha256"
+        },
+        "droppedCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "emittedAt": {
+          "$ref": "#/$defs/rfc3339"
+        },
+        "receivedAt": {
+          "$ref": "#/$defs/rfc3339"
+        },
+        "signatureKeyIds": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["totalActions"],
+      "properties": {
+        "totalActions": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "byFollower": {
+          "$ref": "#/$defs/countMap"
+        },
+        "byTransport": {
+          "$ref": "#/$defs/countMap"
+        },
+        "byActionType": {
+          "$ref": "#/$defs/countMap"
+        },
+        "byVerdict": {
+          "$ref": "#/$defs/countMap"
+        },
+        "byLayer": {
+          "$ref": "#/$defs/countMap"
+        },
+        "bySeverity": {
+          "$ref": "#/$defs/countMap"
+        }
+      }
+    },
+    "completeness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "observedActions",
+        "droppedObservedActions",
+        "mediatedActions",
+        "mediatedFraction",
+        "basis",
+        "claim",
+        "nonClaim"
+      ],
+      "properties": {
+        "observedActions": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "droppedObservedActions": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "mediatedActions": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "mediatedFraction": {
+          "type": "string",
+          "pattern": "^(0(\\.[0-9]+)?|1(\\.0+)?)$"
+        },
+        "basis": {
+          "type": "string",
+          "minLength": 1
+        },
+        "claim": {
+          "type": "string",
+          "minLength": 1
+        },
+        "nonClaim": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "externalCorrelation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["system", "ref"],
+      "properties": {
+        "system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "digest": {
+          "$ref": "#/$defs/digest"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the free verifier foundation for Fleet Receipt Reports.

This introduces the `fleet-report-signing` key purpose, a Fleet Receipt Report verifier for DSSE-wrapped in-toto Statement v1 artifacts, and `pipelock verify-receipt --fleet-report` for offline verification with a pinned report key.

The verifier accepts the L1 profile only. It checks the DSSE signature, key purpose, canonical payload, source-batch subject anchors, source-batch ordering, summary arithmetic, and mediated-fraction arithmetic. L2 is reserved until raw audit-batch replay verification exists.

Docs and schema are included with the feature:
- `docs/specs/fleet-receipt-v1.md`
- `schemas/fleet-receipt-v1.schema.json`
- receipt verification guide update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Fleet Receipt Report verification to the CLI: pipelock verify-receipt --fleet-report --key with pinned/unpinned behavior and clear success/warning outputs.

* **Documentation**
  * New "Verifying a Fleet Receipt Report" guide, updated Docs index, and a Fleet Receipt Report v1 specification describing format, validation rules, and CLI semantics.
  
* **Chores**
  * CHANGELOG updated with Unreleased → New Features entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->