### PR TITLE
fix(conductor): de-conflate misleading publish conflict error

### DIFF
--- a/docs/guides/conductor-operator-runbook.md
+++ b/docs/guides/conductor-operator-runbook.md
@@ -248,6 +248,18 @@ The server authorizes the request with the publisher token file configured on `c
 
 This runbook does not include a one-line policy signing helper because none exists in the verified CLI help. Use the signed bundle producer in your operator workflow, then publish through the API above.
 
+### Publish conflicts (HTTP 409)
+
+A forward publish can be rejected with `409 Conflict` for three operationally distinct reasons. The control plane carries a machine-readable `code` in the JSON error body so the publisher can tell them apart instead of treating every conflict as a stale version:
+
+| `code` | Meaning | What to do |
+| --- | --- | --- |
+| `rollback_attempt` | The supplied `version` is below the current (rolled-back) stream head. A publish cannot roll back. | Use the rollback authorization flow, not a publish. |
+| `version_below_stream_max` | The `version` is not greater than the stream's **highest-ever** published version. After a rollback the head sits at `vN` while `vN+1..vM` still exist, so a forward publish needs a version greater than `M`, not merely greater than the current head `N`. | Publish a `version` above the stream **max**. Query the stream head/max version through your Conductor status workflow before retrying. |
+| `previous_hash_mismatch` | `previous_bundle_hash` does not match the current stream head hash (typically a stale or copy-pasted hash). | Set `previous_bundle_hash` to the hash printed by the most recent successful publish for this stream. |
+
+The `pipelock conductor publish` CLI maps each `code` to a distinct, errors-comparable error with an actionable message, so an operator recovering from a rollback is told to publish above the stream max rather than seeing a misleading "version is stale".
+
 ## Signed Audit Batch And Offline Verification
 
 Bootstrap proves the signed audit path end to end unless `--skip-proof` is set:

--- a/enterprise/cli/conductor/publish.go
+++ b/enterprise/cli/conductor/publish.go
@@ -53,11 +53,41 @@ const (
 	keyFileSchemaVersion = 1
 )
 
-// ErrStalePolicyVersion is returned when the Conductor rejects a publish because
-// the supplied --version is not strictly greater than the version already
-// published for this org/fleet/environment stream. Monotonic versions are how a
-// follower distinguishes a newer policy from a replay of an older one.
-var ErrStalePolicyVersion = errors.New("policy bundle version is stale (not greater than the currently published version for this stream)")
+// A publish can be rejected by the Conductor with HTTP 409 Conflict for several
+// operationally distinct reasons. The control plane reports which one in the
+// "code" field of the JSON error body (see controlplane.PublishConflict*); the
+// CLI maps each to a distinct sentinel below so an operator gets an accurate,
+// actionable message instead of one collapsed "version is stale". Every sentinel
+// is errors.Is-testable. Conflating them once cost a real operator a failed
+// publish during a live recovery (the head was rolled back to vN while vN+1..vM
+// still existed, so the forward publish needed a version above the stream MAX,
+// not merely above the head — but the message only said "stale").
+var (
+	// ErrPolicyVersionBelowStreamMax: the supplied --version is not strictly
+	// greater than the stream's HIGHEST-ever published version. After a rollback
+	// the head sits at vN while vN+1..vM already exist, so a forward publish must
+	// use a version greater than M, not merely greater than the current head N.
+	// Query the stream's head/max version through the operator's Conductor status
+	// surface and re-publish with --version greater than the max.
+	ErrPolicyVersionBelowStreamMax = errors.New("policy bundle version must exceed the stream's highest published version (after a rollback, newer versions still exist above the current head; publish a version above the stream max, not just above the head)")
+
+	// ErrPolicyRollbackViaPublish: the supplied --version is below the current
+	// (rolled-back) stream head. A forward publish cannot perform a rollback; use
+	// the rollback authorization flow (`pipelock conductor rollback`) instead.
+	ErrPolicyRollbackViaPublish = errors.New("policy bundle version is below the current (rolled-back) stream head; a publish cannot roll back — use the rollback authorization flow instead")
+
+	// ErrPolicyPreviousHashMismatch: --previous-bundle-hash does not match the
+	// current stream head hash. The version is fine; the chain pointer is wrong
+	// (typically a stale or copy-pasted hash). Use the hash printed by the most
+	// recent successful publish for this stream (also reported by the stream
+	// head/status query) as --previous-bundle-hash.
+	ErrPolicyPreviousHashMismatch = errors.New("policy bundle --previous-bundle-hash does not match the current stream head hash; use the hash printed by the most recent successful publish for this stream")
+
+	// ErrPolicyPublishConflict: a 409 Conflict that is none of the more specific
+	// cases above (e.g. a bundle_id/version already published with a different
+	// hash, or a first-in-stream bundle that carries a --previous-bundle-hash).
+	ErrPolicyPublishConflict = errors.New("policy bundle conflicts with the active stream")
+)
 
 // publishOptions collects every operator-supplied input for `conductor publish`.
 // Grouped into a struct (rather than a long parameter list) per the project
@@ -110,9 +140,13 @@ rule-bundle references), signs it with a policy-bundle-signing key, and POSTs it
 to a running Conductor's policy-bundle endpoint over mutual TLS using a publisher
 bearer token. Followers then pull and apply it on their next poll.
 
-The --version must be strictly greater than the version already published for the
-same org/fleet/environment stream; the Conductor rejects a stale or duplicate
-version and this command reports it as such.
+The --version must be strictly greater than the stream's highest published
+version. After a rollback the stream head sits below the highest version that was
+ever published, so a forward publish must use a version above the stream MAX, not
+merely above the current head. The Conductor distinguishes a rollback attempt, a
+below-stream-max version, and a previous_bundle_hash mismatch, and this command
+reports each as a distinct, actionable error (query the stream head/max version
+through your Conductor status workflow).
 
 The signing key is a file produced by:
   pipelock signing key generate --purpose policy-bundle-signing --out <abs>
@@ -567,8 +601,10 @@ func isLoopbackHost(host string) bool {
 }
 
 // postBundle marshals the bundle into the publish request envelope and POSTs it.
-// It translates the Conductor's status codes into clear operator errors, in
-// particular surfacing a 409 (stale/duplicate version) as ErrStalePolicyVersion.
+// It translates the Conductor's status codes into clear operator errors. A 409
+// Conflict is de-conflated via conflictSentinel into one of the distinct publish
+// conflict sentinels (rollback attempt, version-below-stream-max, or
+// previous-hash mismatch) so the operator gets an accurate, actionable message.
 func postBundle(ctx context.Context, client *http.Client, baseURL, token string, bundle conductorcore.PolicyBundle) (publishResult, error) {
 	envelope := struct {
 		Bundle conductorcore.PolicyBundle `json:"bundle"`
@@ -599,7 +635,7 @@ func postBundle(ctx context.Context, client *http.Client, baseURL, token string,
 		}
 		return result, nil
 	case http.StatusConflict:
-		return publishResult{}, fmt.Errorf("%w: %s", ErrStalePolicyVersion, serverErrorDetail(respBody, token))
+		return publishResult{}, fmt.Errorf("%w: %s", conflictSentinel(respBody), serverErrorDetail(respBody, token))
 	case http.StatusForbidden, http.StatusUnauthorized:
 		return publishResult{}, fmt.Errorf("publisher not authorized (HTTP %d): %s", resp.StatusCode, serverErrorDetail(respBody, token))
 	default:
@@ -613,6 +649,34 @@ type publishResult struct {
 	Version     uint64    `json:"version"`
 	PublishedAt time.Time `json:"published_at"`
 	Created     bool      `json:"created"`
+}
+
+// conflictSentinel selects the distinct CLI sentinel for an HTTP 409 publish
+// rejection by reading the machine-readable "code" field the control plane
+// attaches to the JSON error body (controlplane.PublishConflict*). This is the
+// de-conflation: the three operationally distinct conflicts map to three
+// distinct, errors.Is-testable sentinels rather than one "version is stale".
+//
+// An older control plane that does not emit a code (or a malformed body) yields
+// the generic ErrPolicyPublishConflict, so the CLI still reports a correct
+// (if less specific) conflict rather than mis-attributing the cause.
+func conflictSentinel(body []byte) error {
+	var payload struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return ErrPolicyPublishConflict
+	}
+	switch payload.Code {
+	case controlplane.PublishConflictRollbackAttempt:
+		return ErrPolicyRollbackViaPublish
+	case controlplane.PublishConflictVersionBelowStreamMax:
+		return ErrPolicyVersionBelowStreamMax
+	case controlplane.PublishConflictPreviousHashMismatch:
+		return ErrPolicyPreviousHashMismatch
+	default:
+		return ErrPolicyPublishConflict
+	}
 }
 
 // serverErrorMaxRunes bounds the sanitized server-error detail we surface in an

--- a/enterprise/cli/conductor/publish_test.go
+++ b/enterprise/cli/conductor/publish_test.go
@@ -213,7 +213,9 @@ func TestPublish_HappyPathAcceptedByRealHandler(t *testing.T) {
 
 // TestPublish_ForwardWithoutChainHashRejected proves a forward publish that
 // omits --previous-bundle-hash is rejected by the stream chain check (409), so
-// an operator cannot accidentally fork the stream.
+// an operator cannot accidentally fork the stream. The version is fine (v2 > max
+// v1); only the chain pointer is wrong, so the operator must get the
+// previous-hash-mismatch error, NOT a misleading "version is stale".
 func TestPublish_ForwardWithoutChainHashRejected(t *testing.T) {
 	dir := t.TempDir()
 	url := newPublishServer(t)
@@ -230,8 +232,12 @@ func TestPublish_ForwardWithoutChainHashRejected(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected chain-conflict error, got nil")
 	}
-	if !errors.Is(err, ErrStalePolicyVersion) {
-		t.Fatalf("want ErrStalePolicyVersion (409), got %v", err)
+	if !errors.Is(err, ErrPolicyPreviousHashMismatch) {
+		t.Fatalf("want ErrPolicyPreviousHashMismatch (409), got %v", err)
+	}
+	// De-conflation guard: this must NOT be reported as any other conflict class.
+	if errors.Is(err, ErrPolicyRollbackViaPublish) || errors.Is(err, ErrPolicyVersionBelowStreamMax) {
+		t.Fatalf("prev-hash mismatch conflated with another conflict class: %v", err)
 	}
 }
 
@@ -245,8 +251,10 @@ func TestPublish_FirstBundleWithPreviousHashRejected(t *testing.T) {
 	opts := baseOpts(t, dir, url)
 	opts.previousHash = strings.Repeat("ab", 32) // valid-shape hash, but no stream head exists
 	err := runPublish(context.Background(), &strings.Builder{}, opts)
-	if err == nil || !errors.Is(err, ErrStalePolicyVersion) {
-		t.Fatalf("want rejection for first bundle with previous hash, got %v", err)
+	// No stream head exists yet, so this is the generic conflict class (the store
+	// reports "initial bundle has previous_bundle_hash" without a specific code).
+	if err == nil || !errors.Is(err, ErrPolicyPublishConflict) {
+		t.Fatalf("want ErrPolicyPublishConflict for first bundle with previous hash, got %v", err)
 	}
 }
 
@@ -266,9 +274,11 @@ func extractHash(t *testing.T, out string) string {
 	return strings.TrimSpace(rest[:end])
 }
 
-// TestPublish_StaleVersionRejectedClean drives the 409 path explicitly with
-// captured output so the assertion is deterministic.
-func TestPublish_StaleVersionRejectedClean(t *testing.T) {
+// TestPublish_LowerVersionReportedAsRollbackAttempt drives the 409 path with a
+// version BELOW the current head: that is a rollback attempt via publish, and
+// the operator must get the rollback-attempt error (pointing at the rollback
+// flow), NOT a generic "version is stale".
+func TestPublish_LowerVersionReportedAsRollbackAttempt(t *testing.T) {
 	dir := t.TempDir()
 	url := newPublishServer(t)
 	opts := baseOpts(t, dir, url)
@@ -278,15 +288,19 @@ func TestPublish_StaleVersionRejectedClean(t *testing.T) {
 	if err := runPublish(context.Background(), &out, opts); err != nil {
 		t.Fatalf("publish v5: %v", err)
 	}
-	// Now publish a lower version: server returns 409, surfaced as ErrStalePolicyVersion.
+	// Now publish a lower version (4 < head 5): server returns 409 with the
+	// rollback-attempt code.
 	opts.version = 4
 	out.Reset()
 	err := runPublish(context.Background(), &out, opts)
 	if err == nil {
-		t.Fatalf("expected stale-version error, got nil")
+		t.Fatalf("expected rollback-attempt error, got nil")
 	}
-	if !errors.Is(err, ErrStalePolicyVersion) {
-		t.Fatalf("want ErrStalePolicyVersion, got %v", err)
+	if !errors.Is(err, ErrPolicyRollbackViaPublish) {
+		t.Fatalf("want ErrPolicyRollbackViaPublish, got %v", err)
+	}
+	if errors.Is(err, ErrPolicyVersionBelowStreamMax) || errors.Is(err, ErrPolicyPreviousHashMismatch) {
+		t.Fatalf("rollback attempt conflated with another conflict class: %v", err)
 	}
 }
 
@@ -945,6 +959,93 @@ func TestPostBundle_401Rejected(t *testing.T) {
 	_, err := postBundle(context.Background(), &http.Client{Timeout: time.Second}, url, "tok", minimalBundle(t))
 	if err == nil || !strings.Contains(err.Error(), "not authorized") {
 		t.Fatalf("want auth error, got %v", err)
+	}
+}
+
+// TestPostBundle_409ConflictCodesDeConflated is the core regression for gap A3:
+// the SAME HTTP 409 that used to collapse into one "version is stale" must now
+// map to a DISTINCT, accurate sentinel per the control plane's "code" field.
+// The prev-hash case in particular must surface a previous-hash-specific message
+// instead of "version is stale".
+func TestPostBundle_409ConflictCodesDeConflated(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		code        string
+		want        error
+		notWant     []error
+		wantMessage string // a substring proving the message is specific to the case
+	}{
+		{
+			name:        "rollback-attempt",
+			code:        controlplane.PublishConflictRollbackAttempt,
+			want:        ErrPolicyRollbackViaPublish,
+			notWant:     []error{ErrPolicyVersionBelowStreamMax, ErrPolicyPreviousHashMismatch},
+			wantMessage: "rolled-back",
+		},
+		{
+			name:        "below-stream-max",
+			code:        controlplane.PublishConflictVersionBelowStreamMax,
+			want:        ErrPolicyVersionBelowStreamMax,
+			notWant:     []error{ErrPolicyRollbackViaPublish, ErrPolicyPreviousHashMismatch},
+			wantMessage: "highest published version",
+		},
+		{
+			name:        "previous-hash-mismatch",
+			code:        controlplane.PublishConflictPreviousHashMismatch,
+			want:        ErrPolicyPreviousHashMismatch,
+			notWant:     []error{ErrPolicyRollbackViaPublish, ErrPolicyVersionBelowStreamMax},
+			wantMessage: "previous-bundle-hash",
+		},
+		{
+			name:        "unknown-code-falls-back",
+			code:        "some_future_code",
+			want:        ErrPolicyPublishConflict,
+			notWant:     []error{ErrPolicyRollbackViaPublish, ErrPolicyVersionBelowStreamMax, ErrPolicyPreviousHashMismatch},
+			wantMessage: "conflicts with the active stream",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"error":"server detail here","code":"` + tc.code + `"}`
+			url := newStubStatusServer(t, http.StatusConflict, body)
+			_, err := postBundle(context.Background(), &http.Client{Timeout: time.Second}, url, "tok", minimalBundle(t))
+			if err == nil {
+				t.Fatalf("want conflict error, got nil")
+			}
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("want %v, got %v", tc.want, err)
+			}
+			for _, nw := range tc.notWant {
+				if errors.Is(err, nw) {
+					t.Fatalf("conflict conflated: %v also matches %v", err, nw)
+				}
+			}
+			if !strings.Contains(err.Error(), tc.wantMessage) {
+				t.Fatalf("message %q does not contain case-specific %q", err.Error(), tc.wantMessage)
+			}
+		})
+	}
+}
+
+// TestPostBundle_409PrevHashNotReportedAsStale is the explicit before/after of
+// the conflated case: a previous_bundle_hash mismatch (which the old code
+// reported as "version is stale") must now produce a previous-hash-specific
+// message and MUST NOT mention version staleness.
+func TestPostBundle_409PrevHashNotReportedAsStale(t *testing.T) {
+	body := `{"error":"previous_bundle_hash does not match stream head","code":"` + controlplane.PublishConflictPreviousHashMismatch + `"}`
+	url := newStubStatusServer(t, http.StatusConflict, body)
+	_, err := postBundle(context.Background(), &http.Client{Timeout: time.Second}, url, "tok", minimalBundle(t))
+	if err == nil {
+		t.Fatalf("want conflict error, got nil")
+	}
+	if !errors.Is(err, ErrPolicyPreviousHashMismatch) {
+		t.Fatalf("want ErrPolicyPreviousHashMismatch, got %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "previous-bundle-hash") {
+		t.Fatalf("message not prev-hash-specific: %q", msg)
+	}
+	if strings.Contains(msg, "stale") {
+		t.Fatalf("message still says 'stale' for a prev-hash mismatch: %q", msg)
 	}
 }
 

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -43,6 +43,30 @@ const (
 	DefaultRollbackMaxValidity   = 24 * time.Hour
 )
 
+// Publish-conflict codes. A policy-bundle publish can be rejected with HTTP 409
+// for three operationally distinct reasons; the control plane carries one of
+// these machine-readable codes in the JSON error body's "code" field so the
+// publishing CLI can render an accurate, actionable message instead of a single
+// misleading "version is stale". The codes are part of the publish API contract
+// and MUST stay in sync with the CLI's mapping (enterprise/cli/conductor).
+const (
+	// PublishConflictRollbackAttempt: the supplied version is below the current
+	// (rolled-back) stream head. A forward publish cannot perform a rollback;
+	// the operator must use the rollback authorization flow instead.
+	PublishConflictRollbackAttempt = "rollback_attempt"
+	// PublishConflictVersionBelowStreamMax: the version is not strictly greater
+	// than the highest version EVER published in the stream (vN+1..vM exist after
+	// a rollback, so a forward publish needs a version greater than M, not N).
+	PublishConflictVersionBelowStreamMax = "version_below_stream_max"
+	// PublishConflictPreviousHashMismatch: previous_bundle_hash does not match
+	// the current stream head hash (a stale or copy-pasted chain pointer).
+	PublishConflictPreviousHashMismatch = "previous_hash_mismatch"
+	// PublishConflictOther: a 409 conflict that is none of the above (e.g. a
+	// bundle_id/version already published with a different hash, or an initial
+	// bundle that carries a previous_bundle_hash).
+	PublishConflictOther = "conflict"
+)
+
 // FollowerIdentityResolver returns the [FollowerIdentity] for an incoming
 // request. Production implementations MUST derive identity from authenticated
 // transport metadata (mTLS peer certificate subject, SAN, or extensions). A
@@ -620,7 +644,7 @@ func (h *Handler) handlePublishPolicyBundle(w http.ResponseWriter, r *http.Reque
 	}
 	record, created, err := h.store.Publish(r.Context(), req.Bundle, PublishOptions{Now: h.now()})
 	if err != nil {
-		writeStoreError(w, err)
+		writePublishStoreError(w, err)
 		return
 	}
 	status := http.StatusOK
@@ -967,6 +991,47 @@ func decodeStrictJSON(w http.ResponseWriter, r *http.Request, maxBytes int64, de
 		return errors.New("trailing JSON document")
 	}
 	return nil
+}
+
+// writePublishStoreError maps a policy-bundle Publish error to an HTTP response.
+// It preserves the exact status semantics of writeStoreError (publish conflicts
+// remain HTTP 409 Conflict) but DE-CONFLATES the 409 body: it attaches a
+// machine-readable "code" so the publishing CLI can distinguish a rollback
+// attempt, a below-stream-max version, and a previous_bundle_hash mismatch
+// instead of collapsing all three into one misleading "version is stale".
+// Non-conflict errors fall through to writeStoreError unchanged.
+func writePublishStoreError(w http.ResponseWriter, err error) {
+	if !errors.Is(err, ErrBundleConflict) {
+		writeStoreError(w, err)
+		return
+	}
+	writeCodedError(w, http.StatusConflict, publishConflictCode(err), err)
+}
+
+// publishConflictCode classifies an ErrBundleConflict from the forward-publish
+// authorization path into one of the operator-facing PublishConflict* codes.
+// Order matters: the rollback-attempt case wraps ErrUnsupportedRollback in
+// addition to ErrBundleConflict, so it must be checked before the umbrella
+// fallthrough. The codes mirror the distinct wrapped sentinels set by
+// authorizeForwardLocked in store.go.
+func publishConflictCode(err error) string {
+	switch {
+	case errors.Is(err, ErrUnsupportedRollback):
+		return PublishConflictRollbackAttempt
+	case errors.Is(err, ErrVersionBelowStreamMax):
+		return PublishConflictVersionBelowStreamMax
+	case errors.Is(err, ErrPreviousHashMismatch):
+		return PublishConflictPreviousHashMismatch
+	default:
+		return PublishConflictOther
+	}
+}
+
+// writeCodedError writes a JSON error body carrying both the human-readable
+// message and a stable machine-readable code. Mirrors writeError's shape with
+// the extra "code" field so existing {"error":"..."} parsers keep working.
+func writeCodedError(w http.ResponseWriter, status int, code string, err error) {
+	writeJSON(w, status, map[string]string{"error": err.Error(), "code": code})
 }
 
 func writeStoreError(w http.ResponseWriter, err error) {

--- a/enterprise/conductor/controlplane/handler_errors_test.go
+++ b/enterprise/conductor/controlplane/handler_errors_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -141,6 +142,63 @@ func TestHandlerMapsStoreErrors(t *testing.T) {
 			}
 			if strings.Contains(w.Body.String(), internalErr.Error()) {
 				t.Fatalf("body leaked internal error: %s", w.Body.String())
+			}
+		})
+	}
+}
+
+// TestHandlerPublishConflictCarriesDistinctCode proves the publish endpoint
+// keeps every conflict at HTTP 409 (status semantics unchanged) but attaches a
+// DISTINCT machine-readable "code" so the CLI can de-conflate the three cases.
+// The store error shapes here mirror exactly what authorizeForwardLocked wraps.
+func TestHandlerPublishConflictCarriesDistinctCode(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		storeErr error
+		wantCode string
+	}{
+		{
+			name:     "rollback-attempt",
+			storeErr: fmt.Errorf("%w: %w", ErrBundleConflict, ErrUnsupportedRollback),
+			wantCode: PublishConflictRollbackAttempt,
+		},
+		{
+			name:     "below-stream-max",
+			storeErr: fmt.Errorf("%w: %w (stream max version is 2)", ErrBundleConflict, ErrVersionBelowStreamMax),
+			wantCode: PublishConflictVersionBelowStreamMax,
+		},
+		{
+			name:     "previous-hash-mismatch",
+			storeErr: fmt.Errorf("%w: %w (current stream head hash is abc)", ErrBundleConflict, ErrPreviousHashMismatch),
+			wantCode: PublishConflictPreviousHashMismatch,
+		},
+		{
+			name:     "generic-conflict",
+			storeErr: fmt.Errorf("%w: bundle_id/version already published as deadbeef", ErrBundleConflict),
+			wantCode: PublishConflictOther,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := newTestHandler(t, fakeStore{publishErr: tc.storeErr}, nil)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, PublishPolicyBundlePath, strings.NewReader(`{"bundle":{}}`))
+			req.Header.Set("X-Pipelock-Publisher", "ok")
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code != http.StatusConflict {
+				t.Fatalf("status = %d body=%s, want 409", w.Code, w.Body.String())
+			}
+			var payload struct {
+				Error string `json:"error"`
+				Code  string `json:"code"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("decode body %s: %v", w.Body.String(), err)
+			}
+			if payload.Code != tc.wantCode {
+				t.Fatalf("code = %q, want %q (body=%s)", payload.Code, tc.wantCode, w.Body.String())
+			}
+			if payload.Error == "" {
+				t.Fatalf("error message empty (body=%s)", w.Body.String())
 			}
 		})
 	}

--- a/enterprise/conductor/controlplane/store.go
+++ b/enterprise/conductor/controlplane/store.go
@@ -74,7 +74,20 @@ var (
 	ErrAuditBatchConflict    = errors.New("conductor audit batch conflicts with accepted batch")
 	ErrAuditForkDetected     = errors.New("conductor audit sequence fork detected")
 	ErrUnsupportedRollback   = errors.New("conductor control plane rollback publication not implemented")
-	ErrEmergencyKeyRequired  = errors.New("conductor emergency control key resolver required")
+	// ErrVersionBelowStreamMax is returned by a forward publish whose version is
+	// not strictly greater than the highest version EVER published in the stream,
+	// yet is not below the current (possibly rolled-back) head. After a rollback
+	// the head sits at vN while vN+1..vM already exist, so a forward publish needs
+	// a version greater than M, not merely greater than N. This is a distinct case
+	// from a genuine rollback attempt (ErrUnsupportedRollback) and from a stream
+	// head-hash mismatch (ErrPreviousHashMismatch); conflating the three is what
+	// produced the misleading "version is stale" message during a live recovery.
+	ErrVersionBelowStreamMax = errors.New("conductor policy bundle version must exceed the stream's highest published version")
+	// ErrPreviousHashMismatch is returned by a forward publish whose
+	// previous_bundle_hash does not equal the current stream head hash. The version
+	// is fine; the chain pointer is wrong (typically a stale or copy-pasted hash).
+	ErrPreviousHashMismatch = errors.New("conductor policy bundle previous_bundle_hash does not match the current stream head hash")
+	ErrEmergencyKeyRequired = errors.New("conductor emergency control key resolver required")
 	// ErrAuditEvidenceTruncated is returned by ListAuditBatchEvidence when the
 	// window matches more accepted audit batches than the effective limit. Report
 	// minting must fail closed rather than sign a report over a silently truncated
@@ -597,9 +610,9 @@ func (s *FileBundleStore) authorizeForwardLocked(record PublishedBundle) error {
 		if record.Bundle.Version < current.Bundle.Version {
 			return fmt.Errorf("%w: %w", ErrBundleConflict, ErrUnsupportedRollback)
 		}
-		return fmt.Errorf("%w: version must exceed stream max version", ErrBundleConflict)
+		return fmt.Errorf("%w: %w (stream max version is %d)", ErrBundleConflict, ErrVersionBelowStreamMax, maxVersion)
 	case record.Bundle.PreviousBundleHash != current.BundleHash:
-		return fmt.Errorf("%w: previous_bundle_hash does not match stream head", ErrBundleConflict)
+		return fmt.Errorf("%w: %w (current stream head hash is %s)", ErrBundleConflict, ErrPreviousHashMismatch, current.BundleHash)
 	default:
 		return nil
 	}

--- a/enterprise/conductor/controlplane/store_test.go
+++ b/enterprise/conductor/controlplane/store_test.go
@@ -525,6 +525,115 @@ func TestFileBundleStoreRejectsStreamConflicts(t *testing.T) {
 	}
 }
 
+// TestFileBundleStoreForwardPublishConflictsAreDistinct proves the store
+// returns three operationally DISTINCT, errors.Is-testable sentinels for the
+// three forward-publish conflict cases, so the publish error can no longer be
+// conflated into a single misleading "version is stale". The third case (the
+// below-stream-max trap) is the one that cost a real operator a failed publish
+// during a live recovery: after a rollback the head sits at vN while vN+1..vM
+// still exist, so a naive forward publish of vN+1 is below the stream MAX.
+func TestFileBundleStoreForwardPublishConflictsAreDistinct(t *testing.T) {
+	store, err := OpenFileBundleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore() error = %v", err)
+	}
+	signer := newTestSigner(t)
+	aud := conductor.Audience{InstanceIDs: []string{"*"}}
+
+	v1 := signedControlBundle(t, signer, bundleSpec{id: "distinct-v1", version: 1, audience: aud})
+	r1, _, err := store.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id: "distinct-v2", version: 2, previousHash: r1.BundleHash, audience: aud,
+		configYAML: "mode: strict\napi_allowlist:\n  - api2.example.com\n",
+	})
+	if _, _, err := store.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+
+	// Case 3: previous_bundle_hash mismatch. Version (3) is above the stream max
+	// (2), so the only fault is the chain pointer.
+	prevHashMismatch := signedControlBundle(t, signer, bundleSpec{
+		id: "distinct-v3-badprev", version: 3, previousHash: stringsOf("a", 64), audience: aud,
+		configYAML: "mode: strict\napi_allowlist:\n  - api3-badprev.example.com\n",
+	})
+	err = publishErr(t, store, prevHashMismatch, testNow.Add(2*time.Minute))
+	if !errors.Is(err, ErrPreviousHashMismatch) {
+		t.Fatalf("prev-hash case err=%v, want ErrPreviousHashMismatch", err)
+	}
+	assertConflictExclusive(t, err, ErrPreviousHashMismatch)
+
+	// Roll the head back to v1 so the head (1) is now BELOW the stream max (2).
+	auth := signedRollbackAuthorizationForBundles(t, "distinct-rollback", v2, v1, testNow)
+	if err := store.ApplyRollbackHead(t.Context(), auth, testNow.Add(3*time.Minute)); err != nil {
+		t.Fatalf("ApplyRollbackHead() error = %v", err)
+	}
+
+	// Case 1: rollback attempt. Version (1) is below the current head... but the
+	// head was rolled back to v1, so use version below the rolled-back head is
+	// impossible at v>=1; instead drive it with a version strictly below head via
+	// a fresh stream-internal lower version is not available. The rollback-attempt
+	// branch fires when version < current head; after the rollback head is v1, so
+	// we re-publish v1's content under a new id at version... not possible (<1).
+	// The rollback-attempt branch is covered by the v1-after-v2 adversarial test;
+	// here we focus on the below-stream-max trap, the case the old message hid.
+
+	// Case 2 (THE key fix): below-stream-max trap. Head is v1 after rollback, but
+	// max is still 2. A naive operator publishes version 2 (head+1) chained to the
+	// current head v1 — that is <= max(2) and >= head(1), so it must be reported
+	// as below-stream-max, NOT as a stale/rollback error.
+	belowMax := signedControlBundle(t, signer, bundleSpec{
+		id: "distinct-v2-trap", version: 2, previousHash: r1.BundleHash, audience: aud,
+		configYAML: "mode: strict\napi_allowlist:\n  - api2-trap.example.com\n",
+	})
+	err = publishErr(t, store, belowMax, testNow.Add(4*time.Minute))
+	if !errors.Is(err, ErrVersionBelowStreamMax) {
+		t.Fatalf("below-stream-max case err=%v, want ErrVersionBelowStreamMax", err)
+	}
+	assertConflictExclusive(t, err, ErrVersionBelowStreamMax)
+
+	// A correct forward publish above the stream max (3) chained to the head still
+	// succeeds: detection is preserved, only the message is de-conflated.
+	ok := signedControlBundle(t, signer, bundleSpec{
+		id: "distinct-v3-good", version: 3, previousHash: r1.BundleHash, audience: aud,
+		configYAML: "mode: strict\napi_allowlist:\n  - api3-good.example.com\n",
+	})
+	if _, _, err := store.Publish(t.Context(), ok, PublishOptions{Now: testNow.Add(5 * time.Minute)}); err != nil {
+		t.Fatalf("Publish(v3 above max) error = %v, want success", err)
+	}
+}
+
+// publishErr publishes a bundle and returns only the error (helper to keep the
+// distinctness assertions terse).
+func publishErr(t *testing.T, store *FileBundleStore, bundle conductor.PolicyBundle, now time.Time) error {
+	t.Helper()
+	_, _, err := store.Publish(t.Context(), bundle, PublishOptions{Now: now})
+	return err
+}
+
+// assertConflictExclusive asserts err is the umbrella ErrBundleConflict and the
+// expected specific sentinel, and is NOT any of the OTHER specific conflict
+// sentinels — i.e. the three cases never alias each other.
+func assertConflictExclusive(t *testing.T, err, want error) {
+	t.Helper()
+	if !errors.Is(err, ErrBundleConflict) {
+		t.Fatalf("conflict err=%v does not wrap umbrella ErrBundleConflict", err)
+	}
+	if !errors.Is(err, want) {
+		t.Fatalf("conflict err=%v does not match expected sentinel %v", err, want)
+	}
+	for _, other := range []error{ErrUnsupportedRollback, ErrVersionBelowStreamMax, ErrPreviousHashMismatch} {
+		if errors.Is(other, want) {
+			continue
+		}
+		if errors.Is(err, other) {
+			t.Fatalf("conflict err=%v conflated: also matches %v", err, other)
+		}
+	}
+}
+
 func TestFileBundleStoreLatestSelectsMatchingValidBundle(t *testing.T) {
 	store, err := OpenFileBundleStore(t.TempDir())
 	if err != nil {


### PR DESCRIPTION
## Problem

A forward policy-bundle publish after a rollback can fail for three distinct reasons, but `pipelock conductor publish` reported all three as a single misleading "policy bundle version is stale". During a live recovery this cost a failed publish: the head had been rolled back to `vN` while `vN+1..vM` still existed, so the forward publish needed a version above the stream max `M`, not merely above the current head `N`, but the error said only "stale", and a `previous_bundle_hash` mismatch reported the same way.

## Change

The control plane now emits a machine-readable `code` in the `409 Conflict` body, and the CLI maps each to a distinct, actionable error:

- rollback attempt: the version is at or below the rolled-back head, and a publish cannot roll back (use the rollback authorization flow).
- version below stream max: publish a version above the stream's highest-ever version, not merely above the current head.
- previous_bundle_hash mismatch: the supplied hash does not match the current stream head hash.

An older control plane that emits no `code` falls back to a generic conflict, so the change is backward and forward compatible. HTTP status semantics are unchanged (still 409); only the error classification and message are clarified. There is no change to which publishes succeed or fail.

Free-tier operability.

## Changelog (for the pre-tag sweep, not added to CHANGELOG.md here)

Conductor: de-conflated the policy-bundle publish `409 Conflict` error. A forward publish that fails after a rollback now reports the specific cause (a rollback attempt, a version at or below the stream's highest-ever version, or a `previous_bundle_hash` mismatch) instead of collapsing all three into a misleading "version is stale".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added operator runbook guidance for policy bundle publication conflicts, including three distinct conflict scenarios and recovery steps.

* **New Features**
  * Policy bundle publication now returns machine-readable conflict codes in error responses for improved error identification and automated handling.

* **Bug Fixes**
  * Enhanced error messages for policy publication failures to distinguish between rollback attempts, version constraints, and hash mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->