### PR TITLE
feat(contain): install/UX hardening for first-run and older hosts

### DIFF
--- a/docs/contain-cli.md
+++ b/docs/contain-cli.md
@@ -70,6 +70,18 @@ Exit codes:
 - **1** — a step failed; earlier applied steps were rolled back.
 - **2** — precondition error: not root, missing executable, bad `--config`.
 
+### Post-install output
+
+On success, `install` prints a **Next steps** block with:
+
+- **sudo secure_path check** -- if `/usr/local/bin` is not in sudo's `secure_path`, a warning explains how to add it. Without this, `sudo pipelock ...` reports "command not found" even though the binary is installed. Install emits guidance rather than silently editing sudoers.
+- **Agent registration** -- the exact command to register the first agent tool (`sudo pipelock contain add-tool <name> --target /path/to/<tool>`) and how to invoke it (`plk-<name> [args...]`).
+- **Evidence paths** -- where audit logs and signed receipts are written (`/var/lib/pipelock/logs` and `/var/lib/pipelock/recorder`).
+
+### nftables version compatibility
+
+The nftables step checks the installed `nft` version before generating rules. The containment ruleset requires nftables >= 0.6 (for `meta skuid` and inline `counter log prefix ... drop` syntax). On hosts with an older `nft` (seen on some older enterprise Linux images), install fails with a clear error naming the minimum version and the distro-appropriate upgrade command, rather than a cryptic parse error at load time.
+
 ## `pipelock contain verify`
 
 Verify is read-only. It walks 12 probes in order and prints pass / fail / skip per probe. It does not require root.
@@ -169,6 +181,14 @@ Flags:
 | `--url` | `https://example.com/` | Allowed canary URL the agent should be able to reach. |
 
 Exit code is 0 if every check passed, 1 if any check failed, and 2 if the diagnosis was incomplete because a check skipped (for example, not run as root, or a tool isn't installed). Checks that can't proceed skip with remediation rather than failing.
+
+After the result summary, `doctor` prints the resolved evidence paths so operators know where to find audit logs and signed receipts:
+
+```text
+Evidence paths:
+  logs:     /var/lib/pipelock/logs
+  receipts: /var/lib/pipelock/recorder
+```
 
 ## `pipelock contain explain`
 

--- a/internal/cli/contain/doctor.go
+++ b/internal/cli/contain/doctor.go
@@ -545,6 +545,7 @@ func runDoctor(cmd *cobra.Command, env *doctorEnv, opts doctorOpts) error {
 		}
 	} else {
 		_, _ = fmt.Fprintf(w, "Result: %d PASS / %d FAIL / %d SKIP — exit %d\n", passN, failN, skipN, exitCode)
+		printEvidencePaths(w)
 	}
 
 	if exitCode == cliutil.ExitOK {
@@ -578,4 +579,15 @@ func writeDoctorLine(w io.Writer, c doctorCheck, res doctorResult) {
 			_, _ = fmt.Fprintf(w, "          ↳ %s\n", res.remediation)
 		}
 	}
+}
+
+// printEvidencePaths emits the resolved evidence/receipts paths after the
+// doctor result summary. Operators running doctor are typically debugging
+// containment and need to know where to find audit logs and receipts.
+func printEvidencePaths(w io.Writer) {
+	// Use the same default paths from the install env so there is a single
+	// source of truth for the filesystem layout.
+	_, _ = fmt.Fprintln(w, "Evidence paths:")
+	_, _ = fmt.Fprintf(w, "  logs:     %s\n", filepath.Join(defaultDataDir, "logs"))
+	_, _ = fmt.Fprintf(w, "  receipts: %s\n", filepath.Join(defaultDataDir, "recorder"))
 }

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -173,7 +173,79 @@ func runInstall(ctx context.Context, env *installEnv, opts installOpts) error {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, err)
 	}
 	_, _ = fmt.Fprintln(env.out, "install complete — run `pipelock contain verify` to confirm.")
+	printPostInstallNextActions(env)
 	return nil
+}
+
+// printPostInstallNextActions emits a next-actions block after a successful
+// install. The block tells the operator how to register their first agent
+// tool, where to find evidence/receipts, and warns about sudo secure_path
+// if /usr/local/bin is not included.
+func printPostInstallNextActions(env *installEnv) {
+	_, _ = fmt.Fprintln(env.out, "")
+	_, _ = fmt.Fprintln(env.out, "Next steps:")
+
+	// 1. sudo secure_path check: if /usr/local/bin is not in sudo's
+	// secure_path the operator gets "command not found" when running
+	// `sudo pipelock ...`. Emit guidance rather than silently editing sudoers.
+	if warning := checkSudoSecurePath(env); warning != "" {
+		_, _ = fmt.Fprintln(env.out, warning)
+	}
+
+	// 2. Agent tool registration guidance.
+	_, _ = fmt.Fprintf(env.out, "  - Register your first agent tool:\n")
+	_, _ = fmt.Fprintf(env.out, "      sudo pipelock contain add-tool <name> --target /path/to/<tool>\n")
+	_, _ = fmt.Fprintf(env.out, "    Then wrap the agent with:\n")
+	_, _ = fmt.Fprintf(env.out, "      plk-<name> [args...]\n")
+
+	// 3. Evidence / receipts location.
+	_, _ = fmt.Fprintf(env.out, "  - Evidence and receipts are written to:\n")
+	_, _ = fmt.Fprintf(env.out, "      logs:     %s\n", env.logsDir())
+	_, _ = fmt.Fprintf(env.out, "      receipts: %s\n", env.recorderDir())
+}
+
+// checkSudoSecurePath runs `sudo -V` and checks whether /usr/local/bin is in
+// the effective secure_path. Returns a warning string if missing, or "" if
+// present or undetectable. Never errors fatally -- this is advisory guidance,
+// not a gate.
+func checkSudoSecurePath(env *installEnv) string {
+	// Try `sudo -V 2>&1` and look for "Value to override ... secure_path"
+	// or the "Default value for ... secure_path" line.
+	out, code, err := env.runCmd(context.Background(), "sudo", "-V")
+	if err != nil || code != 0 {
+		return ""
+	}
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.Contains(trimmed, "secure_path") {
+			continue
+		}
+		// The line looks like:
+		//   Value to override user supplied: secure_path = /sbin:/bin:/usr/sbin:/usr/bin
+		if idx := strings.Index(trimmed, "="); idx >= 0 {
+			pathVal := strings.TrimSpace(trimmed[idx+1:])
+			if containsPathEntry(pathVal, "/usr/local/bin") {
+				return ""
+			}
+			return fmt.Sprintf("  - WARNING: sudo secure_path does not include /usr/local/bin.\n"+
+				"    `sudo pipelock ...` may report 'command not found'.\n"+
+				"    Fix: add /usr/local/bin to secure_path in /etc/sudoers, or create\n"+
+				"    /etc/sudoers.d/99-local-bin with:\n"+
+				"      Defaults secure_path=\"%s:/usr/local/bin\"", pathVal)
+		}
+	}
+	return ""
+}
+
+// containsPathEntry checks whether a colon-separated PATH string contains
+// the given directory entry.
+func containsPathEntry(pathList, entry string) bool {
+	for _, p := range filepath.SplitList(pathList) {
+		if p == entry {
+			return true
+		}
+	}
+	return false
 }
 
 func validateContainUsername(label, name string) error {
@@ -1189,6 +1261,15 @@ func stepInstallNFTRules() step {
 		name: "install-nft-rules",
 		desc: "write + load /etc/nftables.d/50-pipelock-containment.nft + persist via nftables.service",
 		apply: func(ctx context.Context, env *installEnv) (bool, error) {
+			// Check nft version before generating rules. The containment
+			// ruleset requires "meta skuid" (available since nftables 0.4)
+			// and "counter log prefix ... drop" inline syntax (0.6+). Hosts
+			// with nft < 0.5 (rare but seen on AL2-era images) fail at load
+			// time with a cryptic parse error. Detect early and fail with a
+			// clear minimum-version message.
+			if err := checkNFTVersion(ctx, env); err != nil {
+				return false, err
+			}
 			operatorUID, err := operatorUIDFromEnv(env)
 			if err != nil {
 				return false, err
@@ -1419,6 +1500,75 @@ func (e *installEnv) nftTableOrDefault() string {
 
 func (e *installEnv) nftChainOrDefault() string {
 	return defaultNFTChain
+}
+
+// minNFTMajor and minNFTMinor define the minimum nftables version that
+// supports all syntax used by the containment ruleset: "meta skuid" (0.4+),
+// "counter log prefix ... drop" inline (0.6+), and "table inet" (0.2+).
+// We require 0.6.0 as the floor.
+const (
+	minNFTMajor = 0
+	minNFTMinor = 6
+)
+
+// checkNFTVersion runs `nft -v` and parses the version. Returns nil when the
+// version is sufficient, or a clear error naming the minimum when it is not.
+// Unparseable output is treated as a warning-only pass (the subsequent
+// `nft -c -f` validation will catch truly incompatible syntax at load time).
+func checkNFTVersion(ctx context.Context, env *installEnv) error {
+	out, code, err := env.runCmd(ctx, "nft", "-v")
+	if err != nil || code != 0 {
+		// nft exists (passed preflight) but -v failed -- unusual. Let the
+		// later nft -c -f validation catch real issues.
+		return nil
+	}
+	major, minor, ok := parseNFTVersion(out)
+	if !ok {
+		// Unparseable version string. Don't block -- the syntax-check step
+		// (`nft -c -f`) will catch incompatible syntax at load time.
+		return nil
+	}
+	if major > minNFTMajor || (major == minNFTMajor && minor >= minNFTMinor) {
+		return nil
+	}
+	return fmt.Errorf(
+		"nft version %d.%d is too old; the containment ruleset requires nftables >= %d.%d "+
+			"(meta skuid + inline counter/log/drop). "+
+			"Upgrade nftables: on RHEL/AL2 `yum install nftables`, on Debian/Ubuntu `apt install nftables`",
+		major, minor, minNFTMajor, minNFTMinor)
+}
+
+// parseNFTVersion extracts the major.minor version from the output of
+// `nft -v`. The output format is typically:
+//
+//	nftables v0.9.3 (Topsy)
+//	nftables v1.0.6 (Lester Gooch #5)
+//
+// Returns (major, minor, true) on success.
+func parseNFTVersion(output string) (major, minor int, ok bool) {
+	// Look for the "v" prefix followed by digits.
+	idx := strings.Index(output, "v")
+	if idx < 0 || idx+1 >= len(output) {
+		return 0, 0, false
+	}
+	rest := output[idx+1:]
+	// Trim at the first space or paren.
+	for i, c := range rest {
+		if c == ' ' || c == '(' || c == '\n' {
+			rest = rest[:i]
+			break
+		}
+	}
+	parts := strings.SplitN(rest, ".", 3)
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+	maj, err1 := strconv.Atoi(parts[0])
+	mino, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return maj, mino, true
 }
 
 // operatorUIDFromEnv returns the numeric UID for the operator-side user.

--- a/internal/cli/contain/install_ux_test.go
+++ b/internal/cli/contain/install_ux_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Item 3: sudo secure_path check
+// ---------------------------------------------------------------------------
+
+func TestCheckSudoSecurePath_IncludesLocalBin(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor("sudo", "-V"),
+		"Sudo version 1.9.5p2\n"+
+			"Configure options: ...\n"+
+			"Value to override user supplied: secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin\n",
+		0, nil)
+
+	warning := checkSudoSecurePath(env)
+	if warning != "" {
+		t.Fatalf("expected no warning when /usr/local/bin is in secure_path, got: %s", warning)
+	}
+}
+
+func TestCheckSudoSecurePath_MissingLocalBin(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor("sudo", "-V"),
+		"Value to override user supplied: secure_path = /sbin:/bin:/usr/sbin:/usr/bin\n",
+		0, nil)
+
+	warning := checkSudoSecurePath(env)
+	if warning == "" {
+		t.Fatal("expected warning when /usr/local/bin is missing from secure_path")
+	}
+	if !strings.Contains(warning, "/usr/local/bin") {
+		t.Errorf("warning should mention /usr/local/bin: %s", warning)
+	}
+	if !strings.Contains(warning, "sudoers") {
+		t.Errorf("warning should mention sudoers: %s", warning)
+	}
+}
+
+func TestCheckSudoSecurePath_SudoFails(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor("sudo", "-V"), "", 1, nil)
+
+	warning := checkSudoSecurePath(env)
+	if warning != "" {
+		t.Fatalf("expected empty warning when sudo -V fails, got: %s", warning)
+	}
+}
+
+func TestCheckSudoSecurePath_NoSecurePathLine(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor("sudo", "-V"),
+		"Sudo version 1.9.5p2\nConfigure options: ...\n", 0, nil)
+
+	warning := checkSudoSecurePath(env)
+	if warning != "" {
+		t.Fatalf("expected empty warning when no secure_path in output, got: %s", warning)
+	}
+}
+
+func TestContainsPathEntry(t *testing.T) {
+	tests := []struct {
+		name     string
+		pathList string
+		entry    string
+		want     bool
+	}{
+		{"present at start", "/usr/local/bin:/usr/bin:/bin", "/usr/local/bin", true},
+		{"present at end", "/usr/bin:/bin:/usr/local/bin", "/usr/local/bin", true},
+		{"present in middle", "/usr/bin:/usr/local/bin:/bin", "/usr/local/bin", true},
+		{"absent", "/usr/bin:/bin:/sbin", "/usr/local/bin", false},
+		{"empty path", "", "/usr/local/bin", false},
+		{"single entry match", "/usr/local/bin", "/usr/local/bin", true},
+		{"prefix mismatch", "/usr/local/bin2:/usr/bin", "/usr/local/bin", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := containsPathEntry(tt.pathList, tt.entry)
+			if got != tt.want {
+				t.Errorf("containsPathEntry(%q, %q) = %v, want %v", tt.pathList, tt.entry, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Item 4: post-install next-actions
+// ---------------------------------------------------------------------------
+
+func TestPrintPostInstallNextActions_ContainsAgentRegistration(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.out = &bytes.Buffer{}
+
+	// Mock sudo -V to return a clean secure_path.
+	runner := newFakeRunner()
+	runner.on(argvFor("sudo", "-V"),
+		"Value to override user supplied: secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin\n",
+		0, nil)
+	env.runCmd = runner.run
+
+	printPostInstallNextActions(env)
+	output := env.out.(*bytes.Buffer).String()
+
+	if !strings.Contains(output, "Next steps:") {
+		t.Error("missing 'Next steps:' header")
+	}
+	if !strings.Contains(output, "add-tool") {
+		t.Error("missing add-tool guidance")
+	}
+	if !strings.Contains(output, "plk-") {
+		t.Error("missing plk- wrapper guidance")
+	}
+	if !strings.Contains(output, "receipts") {
+		t.Error("missing receipts path")
+	}
+	if !strings.Contains(output, "logs") {
+		t.Error("missing logs path")
+	}
+}
+
+func TestPrintPostInstallNextActions_IncludesSecurePathWarning(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.out = &bytes.Buffer{}
+
+	runner := newFakeRunner()
+	runner.on(argvFor("sudo", "-V"),
+		"Value to override user supplied: secure_path = /sbin:/bin:/usr/sbin:/usr/bin\n",
+		0, nil)
+	env.runCmd = runner.run
+
+	printPostInstallNextActions(env)
+	output := env.out.(*bytes.Buffer).String()
+
+	if !strings.Contains(output, "WARNING") {
+		t.Error("missing secure_path WARNING")
+	}
+	if !strings.Contains(output, "/usr/local/bin") {
+		t.Error("warning should mention /usr/local/bin")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Item 5: evidence paths in doctor output
+// ---------------------------------------------------------------------------
+
+func TestPrintEvidencePaths(t *testing.T) {
+	var buf bytes.Buffer
+	printEvidencePaths(&buf)
+	output := buf.String()
+
+	if !strings.Contains(output, "Evidence paths:") {
+		t.Error("missing 'Evidence paths:' header")
+	}
+	if !strings.Contains(output, "/var/lib/pipelock/logs") {
+		t.Errorf("missing logs path, got: %s", output)
+	}
+	if !strings.Contains(output, "/var/lib/pipelock/recorder") {
+		t.Errorf("missing receipts path, got: %s", output)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Item 6: nft version parsing and checking
+// ---------------------------------------------------------------------------
+
+func TestParseNFTVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		output    string
+		wantMajor int
+		wantMinor int
+		wantOK    bool
+	}{
+		{
+			name:      "standard format",
+			output:    "nftables v0.9.3 (Topsy)",
+			wantMajor: 0, wantMinor: 9, wantOK: true,
+		},
+		{
+			name:      "v1 format",
+			output:    "nftables v1.0.6 (Lester Gooch #5)",
+			wantMajor: 1, wantMinor: 0, wantOK: true,
+		},
+		{
+			name:      "old format",
+			output:    "nftables v0.4 (Dingbat)",
+			wantMajor: 0, wantMinor: 4, wantOK: true,
+		},
+		{
+			name:      "newline terminated",
+			output:    "nftables v0.9.0\n",
+			wantMajor: 0, wantMinor: 9, wantOK: true,
+		},
+		{
+			name:   "no version",
+			output: "something else entirely",
+			wantOK: false,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			wantOK: false,
+		},
+		{
+			name:   "just v",
+			output: "v",
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			major, minor, ok := parseNFTVersion(tt.output)
+			if ok != tt.wantOK {
+				t.Fatalf("parseNFTVersion(%q) ok=%v, want %v", tt.output, ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if major != tt.wantMajor || minor != tt.wantMinor {
+				t.Fatalf("parseNFTVersion(%q) = (%d, %d), want (%d, %d)",
+					tt.output, major, minor, tt.wantMajor, tt.wantMinor)
+			}
+		})
+	}
+}
+
+func TestCheckNFTVersion_Sufficient(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor("nft", "-v"), "nftables v0.9.3 (Topsy)", 0, nil)
+
+	err := checkNFTVersion(context.Background(), env)
+	if err != nil {
+		t.Fatalf("expected nil error for sufficient version, got: %v", err)
+	}
+}
+
+func TestCheckNFTVersion_TooOld(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor("nft", "-v"), "nftables v0.4 (Dingbat)", 0, nil)
+
+	err := checkNFTVersion(context.Background(), env)
+	if err == nil {
+		t.Fatal("expected error for version too old")
+	}
+	if !strings.Contains(err.Error(), "too old") {
+		t.Errorf("error should mention 'too old': %v", err)
+	}
+	if !strings.Contains(err.Error(), "0.6") {
+		t.Errorf("error should mention minimum version 0.6: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Upgrade nftables") {
+		t.Errorf("error should include upgrade guidance: %v", err)
+	}
+}
+
+func TestCheckNFTVersion_V1Passes(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor("nft", "-v"), "nftables v1.0.6 (Lester Gooch #5)", 0, nil)
+
+	err := checkNFTVersion(context.Background(), env)
+	if err != nil {
+		t.Fatalf("expected nil error for v1.0.6, got: %v", err)
+	}
+}
+
+func TestCheckNFTVersion_ExactMinimum(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor("nft", "-v"), "nftables v0.6.0 (Flux)", 0, nil)
+
+	err := checkNFTVersion(context.Background(), env)
+	if err != nil {
+		t.Fatalf("expected nil error at exact minimum version 0.6, got: %v", err)
+	}
+}
+
+func TestCheckNFTVersion_UnparseablePassesThrough(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor("nft", "-v"), "something unexpected", 0, nil)
+
+	err := checkNFTVersion(context.Background(), env)
+	if err != nil {
+		t.Fatalf("expected nil error for unparseable version (fail-open to nft -c -f), got: %v", err)
+	}
+}
+
+func TestCheckNFTVersion_NftCmdFails(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor("nft", "-v"), "", 1, nil)
+
+	err := checkNFTVersion(context.Background(), env)
+	if err != nil {
+		t.Fatalf("expected nil error when nft -v fails (preflight passed), got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes the first-run friction operators hit right after `contain install`, and stops the installer from emitting nftables rules an older host can't apply.

## What changed
- Post-install next-action block: when no agent is registered yet, print the exact wrapper-registration command and the evidence (logs + receipts) paths.
- Detect when sudo's `secure_path` omits `/usr/local/bin` and print the exact `sudoers.d` remediation. Advisory only; never edits global sudoers.
- Surface the resolved receipts/evidence directories in `contain doctor`.
- Check the host `nft` version before generating rules and fail with an actionable minimum-version error on known-old parsers. Unparseable or failing `nft -v` still falls through to `nft -c -f` validation by design.

`--operator-user` for root installs and redirect-following downloads were already present; no change needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `pipelock contain install` and `pipelock contain doctor` command documentation with guidance on next steps, evidence paths, and system compatibility requirements.

* **New Features**
  * Added post-installation guidance including agent registration instructions and secure_path validation warnings.
  * Added nftables version compatibility check; installation now fails with a clear error if nftables is below the required minimum version (0.6).
  * Doctor command now displays evidence and log file paths after diagnostic results.

* **Tests**
  * Added comprehensive test coverage for installation UX features and version checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->