### PR TITLE
feat(license): add 'license crl inspect' and 'license crl verify'

### DIFF
--- a/docs/cli/license.md
+++ b/docs/cli/license.md
@@ -123,6 +123,45 @@ ledger. The `--features` you sign decide what the token unlocks: `agents` for
 Pro, `fleet` for the Enterprise fleet control plane (see the
 [tier-gating audit matrix](../security/tier-gating-audit-matrix.md)).
 
+## `pipelock license crl`
+
+Inspect and verify signed **certificate/license revocation lists** (CRLs). A CRL
+lets the runtime reject licenses (and revoked intermediate signing certificates)
+that have been pulled before their natural expiry.
+
+CRLs are **issued (signed) by the cluster license-service**, which owns the
+canonical revocation list. The CLI deliberately does **not** sign CRLs: a CRL is
+a whole-list snapshot with no monotonic generation number, so an offline signer
+that could mint a smaller list would be a revocation-rollback footgun. The CLI
+provides only the read side.
+
+### `pipelock license crl inspect FILE`
+
+Decode a CRL and show what it revokes. Does **not** verify the signature.
+
+```bash
+pipelock license crl inspect crl.json
+pipelock license crl inspect crl.json --json
+```
+
+### `pipelock license crl verify FILE`
+
+Verify a CRL's Ed25519 signature and check it has not expired. Exit code `0` on
+a valid, unexpired CRL; `1` otherwise.
+
+```bash
+pipelock license crl verify crl.json --public-key /path/to/license.pub
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--public-key` | embedded key, then configured key | Public key as a file path or raw hex. |
+| `--config` / `-c` | discovered config | Config file used to resolve the license public key when `--public-key` is omitted. |
+
+The public key is resolved in order: `--public-key`, then the embedded build key
+(if the binary was built with one), then the configured license public key
+(config file or `PIPELOCK_LICENSE_PUBLIC_KEY`).
+
 ## Enterprise Eval
 
 The time-boxed **Enterprise Eval** tier grants the full Enterprise feature set

--- a/enterprise/cli/license.go
+++ b/enterprise/cli/license.go
@@ -46,6 +46,7 @@ func LicenseCmd() *cobra.Command {
 		licenseInspectCmd(),
 		licenseInstallCmd(),
 		licenseStatusCmd(),
+		licenseCRLCmd(),
 	)
 	return cmd
 }

--- a/enterprise/cli/license_crl.go
+++ b/enterprise/cli/license_crl.go
@@ -1,0 +1,229 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package entcli
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+	"github.com/spf13/cobra"
+)
+
+// maxInspectCRLSize bounds the file read for `crl inspect` so a malformed or
+// hostile file cannot exhaust memory. Matches the loader's own ceiling.
+const maxInspectCRLSize = 256 * 1024
+
+// licenseCRLCmd returns the "license crl" subcommand group for inspecting and
+// verifying signed license revocation lists (CRLs).
+//
+// CRL *issuance* (signing) is deliberately NOT a CLI capability: a CRL is a
+// whole-list snapshot with no monotonic generation number, so an offline signer
+// that can mint subsets is a revocation-rollback footgun. Revocation issuance
+// stays in the cluster license-service, which owns the canonical list. The CLI
+// provides only the read-side operations operators need in the field: decode a
+// CRL and verify its signature/expiry.
+func licenseCRLCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "crl",
+		Short: "Inspect and verify signed license revocation lists (CRLs)",
+		Long: `Inspect and verify signed license revocation lists (CRLs).
+
+CRLs are ISSUED (signed) by the cluster license-service, which owns the
+canonical revocation list. These commands are the read side: decode a CRL to
+see what it revokes, and verify its signature and expiry against a public key.`,
+	}
+	cmd.AddCommand(
+		licenseCRLInspectCmd(),
+		licenseCRLVerifyCmd(),
+	)
+	return cmd
+}
+
+// crlInspectReport is the JSON shape for `crl inspect --json`. It carries the
+// decoded payload plus the computed digest; it never asserts the signature is
+// valid (inspect does not verify).
+type crlInspectReport struct {
+	SignatureVerified    bool                          `json:"signature_verified"`
+	Version              int                           `json:"version"`
+	IssuedAt             string                        `json:"issued_at"`
+	ExpiresAt            string                        `json:"expires_at"`
+	Expired              bool                          `json:"expired"`
+	SHA256               string                        `json:"sha256"`
+	Revoked              []license.RevokedLicense      `json:"revoked,omitempty"`
+	RevokedIntermediates []license.RevokedIntermediate `json:"revoked_intermediates,omitempty"`
+}
+
+func readCRLFile(path string) ([]byte, error) {
+	clean := filepath.Clean(path)
+	info, err := os.Stat(clean)
+	if err != nil {
+		return nil, fmt.Errorf("stat CRL file: %w", err)
+	}
+	if info.Size() > maxInspectCRLSize {
+		return nil, fmt.Errorf("CRL file too large: %d bytes (max %d)", info.Size(), maxInspectCRLSize)
+	}
+	data, err := os.ReadFile(clean)
+	if err != nil {
+		return nil, fmt.Errorf("read CRL file: %w", err)
+	}
+	return data, nil
+}
+
+func licenseCRLInspectCmd() *cobra.Command {
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "inspect FILE",
+		Short: "Decode and display a CRL without verifying the signature",
+		Long: `Decode a signed CRL file and display the revoked license IDs and
+intermediate serials it carries. The signature is NOT verified -- use
+'license crl verify' for that. Inspect is for seeing what a CRL claims.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := readCRLFile(args[0])
+			if err != nil {
+				return cliutil.ExitCodeError(1, err)
+			}
+			var crl license.CRL
+			if err := json.Unmarshal(data, &crl); err != nil {
+				return cliutil.ExitCodeError(1, fmt.Errorf("decode CRL: %w", err))
+			}
+
+			now := time.Now()
+			expired := crl.Payload.ExpiresAt > 0 && now.Unix() > crl.Payload.ExpiresAt
+
+			if jsonOutput {
+				report := crlInspectReport{
+					SignatureVerified:    false,
+					Version:              crl.Payload.Version,
+					IssuedAt:             time.Unix(crl.Payload.IssuedAt, 0).UTC().Format(time.RFC3339),
+					ExpiresAt:            time.Unix(crl.Payload.ExpiresAt, 0).UTC().Format(time.RFC3339),
+					Expired:              expired,
+					SHA256:               crl.SHA256,
+					Revoked:              crl.Payload.Revoked,
+					RevokedIntermediates: crl.Payload.RevokedIntermediates,
+				}
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				if err := enc.Encode(report); err != nil {
+					return cliutil.ExitCodeError(1, fmt.Errorf("encode CRL JSON: %w", err))
+				}
+				return nil
+			}
+
+			out := cmd.OutOrStdout()
+			_, _ = fmt.Fprintf(out, "CRL contents (signature NOT verified):\n")
+			_, _ = fmt.Fprintf(out, "  Version:  %d\n", crl.Payload.Version)
+			_, _ = fmt.Fprintf(out, "  Issued:   %s\n", time.Unix(crl.Payload.IssuedAt, 0).UTC().Format(time.RFC3339))
+			_, _ = fmt.Fprintf(out, "  Expires:  %s\n", time.Unix(crl.Payload.ExpiresAt, 0).UTC().Format(time.RFC3339))
+			if expired {
+				_, _ = fmt.Fprintf(out, "  Status:   EXPIRED (signature not checked)\n")
+			} else {
+				_, _ = fmt.Fprintf(out, "  Status:   not expired (signature not checked)\n")
+			}
+			_, _ = fmt.Fprintf(out, "  SHA256:   %s\n", crl.SHA256)
+			_, _ = fmt.Fprintf(out, "  Revoked licenses (%d):\n", len(crl.Payload.Revoked))
+			for _, r := range crl.Payload.Revoked {
+				_, _ = fmt.Fprintf(out, "    - %s", r.ID)
+				if r.Reason != "" {
+					_, _ = fmt.Fprintf(out, " (%s)", r.Reason)
+				}
+				_, _ = fmt.Fprintf(out, "\n")
+			}
+			if len(crl.Payload.RevokedIntermediates) > 0 {
+				_, _ = fmt.Fprintf(out, "  Revoked intermediates (%d):\n", len(crl.Payload.RevokedIntermediates))
+				for _, r := range crl.Payload.RevokedIntermediates {
+					_, _ = fmt.Fprintf(out, "    - %s", r.Serial)
+					if r.Reason != "" {
+						_, _ = fmt.Fprintf(out, " (%s)", r.Reason)
+					}
+					_, _ = fmt.Fprintf(out, "\n")
+				}
+			}
+			_, _ = fmt.Fprintf(out, "\n  WARNING: inspect does not verify the signature.\n"+
+				"  Run 'pipelock license crl verify %s' to check it cryptographically.\n", args[0])
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output as JSON")
+	return cmd
+}
+
+func licenseCRLVerifyCmd() *cobra.Command {
+	var (
+		publicKey  string
+		configFile string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "verify FILE",
+		Short: "Verify the signature and expiry of a CRL file",
+		Long: `Load a CRL file, verify its Ed25519 signature, and check that it has
+not expired. The public key is resolved in this order:
+
+  1. --public-key (a key file path or a raw hex value)
+  2. the embedded build key, if the binary was built with one
+  3. the configured license public key (config file or PIPELOCK_LICENSE_PUBLIC_KEY)
+
+Exit code 0: valid signature and not expired.
+Exit code 1: invalid signature, expired, malformed, or no public key available.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pubKey, err := resolveCRLVerifyKey(publicKey, configFile)
+			if err != nil {
+				return cliutil.ExitCodeError(1, err)
+			}
+
+			crl, err := license.LoadAndVerifyCRL(args[0], pubKey, time.Now())
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "CRL verification FAILED: %v\n", err)
+				return cliutil.ExitCodeError(1, err)
+			}
+
+			out := cmd.OutOrStdout()
+			_, _ = fmt.Fprintf(out, "CRL verification OK\n")
+			_, _ = fmt.Fprintf(out, "  Expires:  %s\n", time.Unix(crl.Payload.ExpiresAt, 0).UTC().Format(time.RFC3339))
+			_, _ = fmt.Fprintf(out, "  SHA256:   %s\n", crl.SHA256)
+			_, _ = fmt.Fprintf(out, "  Revoked licenses: %d\n", len(crl.Payload.Revoked))
+			_, _ = fmt.Fprintf(out, "  Revoked intermediates: %d\n", len(crl.Payload.RevokedIntermediates))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&publicKey, "public-key", "", "public key file path or hex value (default: embedded key, then configured key)")
+	cmd.Flags().StringVarP(&configFile, "config", "c", "", "config file used to resolve the license public key")
+	return cmd
+}
+
+// resolveCRLVerifyKey picks the public key to verify a CRL against. An explicit
+// --public-key wins; otherwise it falls back to the same embedded-then-config
+// resolution the rest of the license CLI uses.
+func resolveCRLVerifyKey(publicKey, configFile string) (ed25519.PublicKey, error) {
+	if publicKey != "" {
+		key, err := signing.LoadPublicKey(publicKey)
+		if err != nil {
+			return nil, fmt.Errorf("load --public-key: %w", err)
+		}
+		return key, nil
+	}
+	cfg, err := loadLicenseStatusConfig(configFile)
+	if err != nil {
+		return nil, err
+	}
+	key, err := licenseStatusPublicKey(cfg)
+	if err != nil {
+		return nil, errors.New("no license public key available: pass --public-key, build with an embedded key, or set PIPELOCK_LICENSE_PUBLIC_KEY")
+	}
+	return key, nil
+}

--- a/enterprise/cli/license_crl.go
+++ b/enterprise/cli/license_crl.go
@@ -69,6 +69,9 @@ func readCRLFile(path string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("stat CRL file: %w", err)
 	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("CRL must be a regular file")
+	}
 	if info.Size() > maxInspectCRLSize {
 		return nil, fmt.Errorf("CRL file too large: %d bytes (max %d)", info.Size(), maxInspectCRLSize)
 	}

--- a/enterprise/cli/license_crl_test.go
+++ b/enterprise/cli/license_crl_test.go
@@ -1,0 +1,281 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package entcli
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+const (
+	testRevokedID    = "lic_test_revoked"
+	testRevokeReason = "compromised"
+)
+
+// writeSignedCRL signs a CRL over the given revoked IDs and writes the wire
+// format to a temp file. Uses time.Now()-relative offsets, never a frozen date,
+// so the test cannot become a time-bomb.
+func writeSignedCRL(t *testing.T, priv ed25519.PrivateKey, ids ...string) string {
+	t.Helper()
+	now := time.Now()
+	revoked := make([]license.RevokedLicense, 0, len(ids))
+	for _, id := range ids {
+		revoked = append(revoked, license.RevokedLicense{ID: id, Reason: testRevokeReason, RevokedAt: now.Unix()})
+	}
+	crl, err := license.SignCRL(license.CRLPayload{
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(720 * time.Hour).Unix(),
+		Revoked:   revoked,
+	}, priv)
+	if err != nil {
+		t.Fatalf("SignCRL: %v", err)
+	}
+	data, err := json.Marshal(crl)
+	if err != nil {
+		t.Fatalf("marshal CRL: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "crl.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write CRL: %v", err)
+	}
+	return path
+}
+
+// writeUnsignedExpiredCRL hand-builds a CRL wire file with a past expiry and a
+// junk signature. Inspect must decode it (it does not verify); verify must
+// reject it. SignCRL refuses past expiry, so the wire format is built directly.
+func writeUnsignedExpiredCRL(t *testing.T) string {
+	t.Helper()
+	now := time.Now()
+	payload := license.CRLPayload{
+		Version:   license.CRLVersion,
+		IssuedAt:  now.Add(-1440 * time.Hour).Unix(),
+		ExpiresAt: now.Add(-720 * time.Hour).Unix(),
+		Revoked:   []license.RevokedLicense{{ID: testRevokedID, RevokedAt: now.Add(-1440 * time.Hour).Unix()}},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	wire := struct {
+		Payload   string `json:"payload"`
+		Signature string `json:"signature"`
+	}{
+		Payload:   base64.RawURLEncoding.EncodeToString(raw),
+		Signature: base64.RawURLEncoding.EncodeToString([]byte("not-a-real-signature")),
+	}
+	data, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatalf("marshal wire: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "expired-crl.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write CRL: %v", err)
+	}
+	return path
+}
+
+func runCRLCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := licenseCRLCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+func exitCode(t *testing.T, err error) int {
+	t.Helper()
+	if err == nil {
+		return 0
+	}
+	var ee *cliutil.ExitError
+	if errors.As(err, &ee) {
+		return ee.Code
+	}
+	return -1
+}
+
+func TestLicenseCRLInspect(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	path := writeSignedCRL(t, priv, testRevokedID)
+
+	t.Run("text shows revoked id and unverified warning", func(t *testing.T) {
+		out, err := runCRLCmd(t, "inspect", path)
+		if err != nil {
+			t.Fatalf("inspect: %v", err)
+		}
+		if !strings.Contains(out, testRevokedID) {
+			t.Errorf("output missing revoked id: %s", out)
+		}
+		if !strings.Contains(out, "NOT verified") {
+			t.Errorf("output missing unverified warning: %s", out)
+		}
+	})
+
+	t.Run("json mode reports signature_verified false", func(t *testing.T) {
+		out, err := runCRLCmd(t, "inspect", path, "--json")
+		if err != nil {
+			t.Fatalf("inspect --json: %v", err)
+		}
+		var report crlInspectReport
+		if err := json.Unmarshal([]byte(out), &report); err != nil {
+			t.Fatalf("decode json: %v (out=%s)", err, out)
+		}
+		if report.SignatureVerified {
+			t.Error("signature_verified must be false for inspect")
+		}
+		if len(report.Revoked) != 1 || report.Revoked[0].ID != testRevokedID {
+			t.Errorf("unexpected revoked list: %+v", report.Revoked)
+		}
+	})
+
+	t.Run("expired crl shows expired status", func(t *testing.T) {
+		out, err := runCRLCmd(t, "inspect", writeUnsignedExpiredCRL(t))
+		if err != nil {
+			t.Fatalf("inspect expired: %v", err)
+		}
+		if !strings.Contains(out, "EXPIRED") {
+			t.Errorf("expected EXPIRED status: %s", out)
+		}
+	})
+
+	t.Run("nonexistent file fails closed", func(t *testing.T) {
+		_, err := runCRLCmd(t, "inspect", filepath.Join(t.TempDir(), "nope.json"))
+		if exitCode(t, err) != 1 {
+			t.Errorf("want exit 1, got err=%v", err)
+		}
+	})
+
+	t.Run("oversized file rejected", func(t *testing.T) {
+		big := filepath.Join(t.TempDir(), "big.json")
+		if err := os.WriteFile(big, bytes.Repeat([]byte("a"), maxInspectCRLSize+1), 0o600); err != nil {
+			t.Fatalf("write big: %v", err)
+		}
+		_, err := runCRLCmd(t, "inspect", big)
+		if exitCode(t, err) != 1 {
+			t.Errorf("want exit 1 for oversized, got err=%v", err)
+		}
+	})
+
+	t.Run("malformed json fails closed", func(t *testing.T) {
+		bad := filepath.Join(t.TempDir(), "bad.json")
+		if err := os.WriteFile(bad, []byte("{not json"), 0o600); err != nil {
+			t.Fatalf("write bad: %v", err)
+		}
+		_, err := runCRLCmd(t, "inspect", bad)
+		if exitCode(t, err) != 1 {
+			t.Errorf("want exit 1 for malformed, got err=%v", err)
+		}
+	})
+}
+
+func TestLicenseCRLVerify(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	path := writeSignedCRL(t, priv, testRevokedID)
+	pubHex := hex.EncodeToString(pub)
+
+	t.Run("correct key verifies", func(t *testing.T) {
+		out, err := runCRLCmd(t, "verify", path, "--public-key", pubHex)
+		if err != nil {
+			t.Fatalf("verify: %v (out=%s)", err, out)
+		}
+		if !strings.Contains(out, "OK") {
+			t.Errorf("expected OK: %s", out)
+		}
+	})
+
+	t.Run("wrong key fails closed", func(t *testing.T) {
+		otherPub, _, err := ed25519.GenerateKey(nil)
+		if err != nil {
+			t.Fatalf("GenerateKey: %v", err)
+		}
+		out, err := runCRLCmd(t, "verify", path, "--public-key", hex.EncodeToString(otherPub))
+		if exitCode(t, err) != 1 {
+			t.Errorf("want exit 1 for wrong key, got err=%v out=%s", err, out)
+		}
+	})
+
+	t.Run("expired but validly-signed crl fails closed", func(t *testing.T) {
+		expiredPath := writeValidlySignedExpiredCRL(t, priv)
+		out, err := runCRLCmd(t, "verify", expiredPath, "--public-key", pubHex)
+		if exitCode(t, err) != 1 {
+			t.Errorf("want exit 1 for expired, got err=%v out=%s", err, out)
+		}
+	})
+
+	t.Run("missing public key fails closed", func(t *testing.T) {
+		// No --public-key, no config, no embedded key in a test build.
+		if license.EmbeddedPublicKey() != nil {
+			t.Skip("embedded key present in this build")
+		}
+		_, err := runCRLCmd(t, "verify", path)
+		if exitCode(t, err) != 1 {
+			t.Errorf("want exit 1 when no key available, got err=%v", err)
+		}
+	})
+
+	t.Run("nonexistent file fails closed", func(t *testing.T) {
+		_, err := runCRLCmd(t, "verify", filepath.Join(t.TempDir(), "nope.json"), "--public-key", pubHex)
+		if exitCode(t, err) != 1 {
+			t.Errorf("want exit 1, got err=%v", err)
+		}
+	})
+}
+
+// writeValidlySignedExpiredCRL builds a CRL with a VALID signature over a
+// past-expiry payload, bypassing SignCRL's expiry guard, so verify's expiry
+// rejection (not just signature) is exercised end-to-end.
+func writeValidlySignedExpiredCRL(t *testing.T, priv ed25519.PrivateKey) string {
+	t.Helper()
+	now := time.Now()
+	payload := license.CRLPayload{
+		Version:   license.CRLVersion,
+		IssuedAt:  now.Add(-1440 * time.Hour).Unix(),
+		ExpiresAt: now.Add(-720 * time.Hour).Unix(),
+		Revoked:   []license.RevokedLicense{{ID: testRevokedID, RevokedAt: now.Add(-1440 * time.Hour).Unix()}},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	sig := ed25519.Sign(priv, raw)
+	wire := struct {
+		Payload   string `json:"payload"`
+		Signature string `json:"signature"`
+	}{
+		Payload:   base64.RawURLEncoding.EncodeToString(raw),
+		Signature: base64.RawURLEncoding.EncodeToString(sig),
+	}
+	data, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatalf("marshal wire: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "signed-expired-crl.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write CRL: %v", err)
+	}
+	return path
+}

--- a/enterprise/cli/license_crl_test.go
+++ b/enterprise/cli/license_crl_test.go
@@ -55,10 +55,10 @@ func writeSignedCRL(t *testing.T, priv ed25519.PrivateKey, ids ...string) string
 	return path
 }
 
-// writeUnsignedExpiredCRL hand-builds a CRL wire file with a past expiry and a
-// junk signature. Inspect must decode it (it does not verify); verify must
-// reject it. SignCRL refuses past expiry, so the wire format is built directly.
-func writeUnsignedExpiredCRL(t *testing.T) string {
+// writeExpiredCRLWire hand-builds a past-expiry CRL wire file, signing the
+// payload bytes with sign. SignCRL refuses past expiry, so expired fixtures are
+// built directly. Callers vary only the signature (junk vs valid) and filename.
+func writeExpiredCRLWire(t *testing.T, name string, sign func(payload []byte) string) string {
 	t.Helper()
 	now := time.Now()
 	payload := license.CRLPayload{
@@ -76,17 +76,26 @@ func writeUnsignedExpiredCRL(t *testing.T) string {
 		Signature string `json:"signature"`
 	}{
 		Payload:   base64.RawURLEncoding.EncodeToString(raw),
-		Signature: base64.RawURLEncoding.EncodeToString([]byte("not-a-real-signature")),
+		Signature: sign(raw),
 	}
 	data, err := json.Marshal(wire)
 	if err != nil {
 		t.Fatalf("marshal wire: %v", err)
 	}
-	path := filepath.Join(t.TempDir(), "expired-crl.json")
+	path := filepath.Join(t.TempDir(), name)
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatalf("write CRL: %v", err)
 	}
 	return path
+}
+
+// writeUnsignedExpiredCRL builds an expired CRL with a junk signature. Inspect
+// must decode it (it does not verify); verify must reject it.
+func writeUnsignedExpiredCRL(t *testing.T) string {
+	t.Helper()
+	return writeExpiredCRLWire(t, "expired-crl.json", func([]byte) string {
+		return base64.RawURLEncoding.EncodeToString([]byte("not-a-real-signature"))
+	})
 }
 
 func runCRLCmd(t *testing.T, args ...string) (string, error) {
@@ -187,6 +196,15 @@ func TestLicenseCRLInspect(t *testing.T) {
 			t.Errorf("want exit 1 for malformed, got err=%v", err)
 		}
 	})
+
+	t.Run("non-regular file rejected", func(t *testing.T) {
+		// A directory is a portable non-regular file; the size guard alone
+		// would not catch a device/FIFO, so IsRegular must reject it.
+		_, err := runCRLCmd(t, "inspect", t.TempDir())
+		if exitCode(t, err) != 1 {
+			t.Errorf("want exit 1 for non-regular file, got err=%v", err)
+		}
+	})
 }
 
 func TestLicenseCRLVerify(t *testing.T) {
@@ -250,32 +268,7 @@ func TestLicenseCRLVerify(t *testing.T) {
 // rejection (not just signature) is exercised end-to-end.
 func writeValidlySignedExpiredCRL(t *testing.T, priv ed25519.PrivateKey) string {
 	t.Helper()
-	now := time.Now()
-	payload := license.CRLPayload{
-		Version:   license.CRLVersion,
-		IssuedAt:  now.Add(-1440 * time.Hour).Unix(),
-		ExpiresAt: now.Add(-720 * time.Hour).Unix(),
-		Revoked:   []license.RevokedLicense{{ID: testRevokedID, RevokedAt: now.Add(-1440 * time.Hour).Unix()}},
-	}
-	raw, err := json.Marshal(payload)
-	if err != nil {
-		t.Fatalf("marshal payload: %v", err)
-	}
-	sig := ed25519.Sign(priv, raw)
-	wire := struct {
-		Payload   string `json:"payload"`
-		Signature string `json:"signature"`
-	}{
-		Payload:   base64.RawURLEncoding.EncodeToString(raw),
-		Signature: base64.RawURLEncoding.EncodeToString(sig),
-	}
-	data, err := json.Marshal(wire)
-	if err != nil {
-		t.Fatalf("marshal wire: %v", err)
-	}
-	path := filepath.Join(t.TempDir(), "signed-expired-crl.json")
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		t.Fatalf("write CRL: %v", err)
-	}
-	return path
+	return writeExpiredCRLWire(t, "signed-expired-crl.json", func(raw []byte) string {
+		return base64.RawURLEncoding.EncodeToString(ed25519.Sign(priv, raw))
+	})
 }


### PR DESCRIPTION
Read-side CLI for signed license revocation lists (CRLs).

## What changed
- `license crl inspect FILE` decodes a CRL and shows the revoked license IDs and intermediate serials it carries. Does not verify the signature. `--json` for machine output.
- `license crl verify FILE` verifies the Ed25519 signature and expiry; exit 0 on a valid, unexpired CRL, 1 otherwise. Public key resolves from `--public-key` (file path or hex), the embedded build key, then the configured license public key.

CRL issuance (signing) stays in the cluster license-service by design. A CRL is a whole-list snapshot with no monotonic generation number, so an offline signer able to mint a subset would be a revocation-rollback footgun. The CLI ships the read side only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `license crl inspect` to read CRLs and display revoked license IDs and intermediate certificate serials without signature verification.
  * Added `license crl verify` to verify Ed25519 signatures, check CRL expiration, and return non-zero exit codes on failure.
* **Documentation**
  * Added documentation for `pipelock license crl`, including command details and public-key resolution precedence.
* **Tests**
  * Added coverage for CRL inspect/verify success cases, failure modes, JSON/text output, and exit code behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->